### PR TITLE
Mobs will now be removed from XTarget when they clear their feign memory

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 EQEMu Changelog (Started on Sept 24, 2003 15:50)
 -------------------------------------------------------
+== 02/22/2013 ==
+demonstar55: Mobs will now be removed from XTargets when they get back to their way point, should be last instance of XTarget mobs not clearing when they are not aggroed anymore
+
 == 02/19/2013 ==
 Derision: World should no longer crash if the start_zone query fails at character creation.
 

--- a/zone/aggro.cpp
+++ b/zone/aggro.cpp
@@ -1422,6 +1422,17 @@ void Mob::RemoveFromFeignMemory(Client* attacker) {
 }
 
 void Mob::ClearFeignMemory() {
+    std::set<uint32>::iterator RememberedCharID;
+    RememberedCharID = feign_memory_list.begin();
+
+    while (RememberedCharID != feign_memory_list.end()) 
+    {
+        Client* remember_client = entity_list.GetClientByCharID(*RememberedCharID);
+        if(remember_client != NULL) //Still in zone
+            remember_client->RemoveXTarget(this, false);
+        RememberedCharID++;
+    }
+
 	feign_memory_list.clear();
 	minLastFightingDelayMoving = RuleI(NPC, LastFightingDelayMovingMin);
 	maxLastFightingDelayMoving = RuleI(NPC, LastFightingDelayMovingMax);


### PR DESCRIPTION
This should be the last instance of mobs being on the XTargets post-deaggroing
