### PR TITLE
Melee tomes named "Skill: ..." can be handed to guildmasters and memoriz...

### DIFF
--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -467,6 +467,14 @@ bool Client::TrainDiscipline(uint32 itemid) {
 		item->Name[2] == 'm' &&
 		item->Name[3] == 'e' &&
 		item->Name[4] == ' '
+		) && !(
+		item->Name[0] == 'S' &&
+		item->Name[1] == 'k' &&
+		item->Name[2] == 'i' &&
+		item->Name[3] == 'l' &&
+		item->Name[4] == 'l' &&
+		item->Name[5] == ':' &&
+		item->Name[6] == ' '
 		)) {
 		Message(13, "This item is not a tome.");
 		//summon them the item back...

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -668,6 +668,14 @@ bool QuestManager::isdisctome(int item_id) {
 		item->Name[2] == 'm' &&
 		item->Name[3] == 'e' &&
 		item->Name[4] == ' '
+		) && !(
+		item->Name[0] == 'S' &&
+		item->Name[1] == 'k' &&
+		item->Name[2] == 'i' &&
+		item->Name[3] == 'l' &&
+		item->Name[4] == 'l' &&
+		item->Name[5] == ':' &&
+		item->Name[6] == ' '
 		)) {
 		return(false);
 	}


### PR DESCRIPTION
Some melee tomes have names that begin "Skill:" instead of "Tome."  Since the name test is hard-coded in two places, update the test to allow either to be recognized.
