### PR TITLE
Fix targeting for summoned pets in Mob::DetermineSpellTargets

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -1313,8 +1313,8 @@ bool Mob::DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_ce
 		case ST_SummonedPet:
 		{
 			uint8 body_type = spell_target ? spell_target->GetBodyType() : 0;
-			if(!spell_target || (spell_target != GetPet()) ||
-			   (body_type != BT_Summoned && body_type != BT_Summoned2 && body_type != BT_Summoned3 && body_type != BT_Animal))
+			if(spell_target && (spell_target == GetPet()) &&
+				(body_type == BT_Summoned || body_type == BT_Summoned2 || body_type == BT_Summoned3 || body_type == BT_Animal))
 			{
 				mlog(SPELLS__CASTING_ERR, "Spell %d canceled: invalid target of body type %d (summoned pet)",
 							  spell_id, body_type);


### PR DESCRIPTION
I _know_ this is fairly trivial and that MAG AA Shared Health doesn't work, but as-is it does not even target the pet ... Expressing the targeting test as "if it IS this" instead of "if it IS NOT that" at least targets the pet, and we can move along to "Unknown spell effect" for the next step to implement the AA.
EDIT: Should label this "Bug" but not getting where I can do so ... probably simpler than I am looking for.
