### PR TITLE
Fixed stacking issues with SE_Limit* (ex. Unholy Aura Discipline and Aur...

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,9 @@
 EQEMu Changelog (Started on Sept 24, 2003 15:50)
 -------------------------------------------------------
 
+== 03/20/2013 ==
+demonstar55: Fixed stacking issues with SE_Limit* (ex. Unholy Aura Discipline and Aura of Reverence)
+
 == 03/18/2013 ==
 Bad_Captain: Fixed zone crash due to merc focus effects & tribute.
 Bad_Captain: Fixed merc aggro issues when client in melee range & spell recast timers. 

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -2564,6 +2564,22 @@ int Mob::CheckStackConflict(uint16 spellid1, int caster_level1, uint16 spellid2,
 		if(effect1 != effect2)
 			continue;
 
+        /*
+        Skip check if effect is SE_Limit*
+        skip checking effect2 since we know they are equal
+        */
+        if(effect1 == SE_LimitMaxLevel ||
+            effect1 == SE_LimitResist ||
+            effect1 == SE_LimitTarget ||
+            effect1 == SE_LimitEffect ||
+            effect1 == SE_LimitSpellType ||
+            effect1 == SE_LimitSpell ||
+            effect1 == SE_LimitMinDur ||
+            effect1 == SE_LimitInstant ||
+            effect1 == SE_LimitMinLevel ||
+            effect1 == SE_LimitCastTime)
+            continue;
+
 		/*
 		If target is a npc and caster1 and caster2 exist
 		If Caster1 isn't the same as Caster2 and the effect is a DoT then ignore it.


### PR DESCRIPTION
...a of Reverence)

It doesn't make sense these effects should prevent spells from stacking with each other and from those I asked who played on live, the two specific example spells had no problems on live. I didn't notice any anomalies on my server while testing.
