### PR TITLE
Fixed and cleaned up Client::Escape()

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,11 @@
 EQEMu Changelog (Started on Sept 24, 2003 15:50)
 -------------------------------------------------------
 
+== 03/23/2013 ==
+demonstar55: Fix issues with escape not always working and fixed SE_FadingMemories to have the message since the message isn't part of the spell data.
+    Escape now uses just the spell and not the AA Actoin
+    Fading Memories now only uses the AA Action to eat mana
+
 == 03/21/2013 ==
 Bad_Captain: Fixed merc buffing bugs.
 Bad_Captain: Added checks before dismissing merc to prevent possible bugged mercs.

--- a/utils/sql/git/required/2013_03_23_Escape_FadingMemories.sql
+++ b/utils/sql/git/required/2013_03_23_Escape_FadingMemories.sql
@@ -1,0 +1,2 @@
+UPDATE `aa_actions` SET `spell_id` = '5244', `nonspell_action` = '0' WHERE `aaid` = '243';
+UDPATE `altadv_vars` SET `spell_id` = '5244' WHERE `skill_id` = '243';

--- a/zone/AA.cpp
+++ b/zone/AA.cpp
@@ -480,8 +480,7 @@ void Client::HandleAAAction(aaID activate) {
 			break;
 
 		case aaActionFadingMemories:
-			entity_list.RemoveFromTargets(this, true);
-			SetInvisible(1);
+            // Do nothing since spell effect works correctly, but mana isn't used.
 			break;
 
 		default:

--- a/zone/StringIDs.h
+++ b/zone/StringIDs.h
@@ -10,6 +10,7 @@
 #define SPELL_DOES_NOT_WORK_PLANE	107		//This spell does not work on this plane.
 #define CANT_SEE_TARGET				108		//You cannot see your target.
 #define MGB_STRING					113		//The next group buff you cast will hit all targets in range.
+#define ESCAPE                      114     //You escape from combat, hiding yourself from view.
 #define TARGET_TOO_FAR				124		//Your target is too far away, get closer!
 #define PROC_TOOLOW					126		//Your will is not sufficient to command this weapon.
 #define PROC_PETTOOLOW				127		//Your pet's will is not sufficient to command its weapon.

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -3128,22 +3128,10 @@ uint8 Client::SlotConvert2(uint8 slot){
 
 void Client::Escape()
 {
-	hidden = true;
-	entity_list.ClearFeignAggro(this);
+    entity_list.RemoveFromTargets(this, true);
+    SetInvisible(1);
 
-	EQApplicationPacket *outapp = new EQApplicationPacket(OP_SimpleMessage,12);
-	SimpleMessage_Struct *msg=(SimpleMessage_Struct *)outapp->pBuffer;
-	msg->color=0x010E;
-	msg->string_id=114;
-	FastQueuePacket(&outapp);
-
-	outapp = new EQApplicationPacket(OP_SpawnAppearance, sizeof(SpawnAppearance_Struct));
-	SpawnAppearance_Struct* sa_out = (SpawnAppearance_Struct*)outapp->pBuffer;
-	sa_out->spawn_id = GetID();
-	sa_out->type = 0x03;
-	sa_out->parameter = 1;
-	entity_list.QueueClients(this, outapp);
-	safe_delete(outapp);
+    Message_StringID(MT_Skills, ESCAPE);
 }
 
 float Client::CalcPriceMod(Mob* other, bool reverse)

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -2039,8 +2039,13 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial)
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Fading Memories");
 #endif
-				entity_list.RemoveFromTargets(caster);
-				SetInvisible(1);
+                if(caster && caster->IsClient())
+                    caster->CastToClient()->Escape();
+                else
+                {
+                    entity_list.RemoveFromTargets(caster);
+                    SetInvisible(1);
+                }
 				break;
 			}
 


### PR DESCRIPTION
Fixed SE_FadingMemories to use Client::Escape()
Rogue AA Escape now uses a spell instead of AA Action
Bard AA Fading Memories now only uses the AA Action to eat mana
