### PR TITLE
Bards can now use instant cast AAs while singing (Fading Memories, Boast...

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,10 @@
 EQEMu Changelog (Started on Sept 24, 2003 15:50)
 -------------------------------------------------------
 
+== 04/01/2013 ==
+demonstar55: AA reuse timers now start when you hit the button and are reset upon failure
+demonstar55: Instant Cast bard AAs can now be used while singing a song
+
 == 03/30/2013 ==
 demonstar55: Fixed most of the pet talking, all use StringIDs now. Pet now informs you when it taunts.
 

--- a/zone/StringIDs.h
+++ b/zone/StringIDs.h
@@ -10,6 +10,7 @@
 #define SPELL_DOES_NOT_WORK_PLANE	107		//This spell does not work on this plane.
 #define CANT_SEE_TARGET				108		//You cannot see your target.
 #define MGB_STRING					113		//The next group buff you cast will hit all targets in range.
+#define ABILITY_FAILED              116     //Your ability failed. Timer has been reset.
 #define ESCAPE                      114     //You escape from combat, hiding yourself from view.
 #define TARGET_TOO_FAR				124		//Your target is too far away, get closer!
 #define PROC_TOOLOW					126		//Your will is not sufficient to command this weapon.

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -707,23 +707,26 @@ void Mob::InterruptSpell(uint16 message, uint16 color, uint16 spellid)
 		CastToNPC()->AI_Event_SpellCastFinished(false, casting_spell_slot);
 	}
     
-	if(casting_spell_type == 1 && IsClient()) //Rest AA Timer on failed cast
-		CastToClient()->GetPTimers().Clear(&database, casting_spell_timer);
-	
+    if(casting_spell_type == 1 && IsClient()) { //Rest AA Timer on failed cast
+        CastToClient()->SendAATimer(casting_spell_timer - pTimerAAStart, 0, 0xFFFFFF);
+        CastToClient()->Message_StringID(15,ABILITY_FAILED);
+        CastToClient()->GetPTimers().Clear(&database, casting_spell_timer);
+    }
+
 	ZeroCastingVars();	// resets all the state keeping stuff
-	
+
 	mlog(SPELLS__CASTING, "Spell %d has been interrupted.", spellid);
-	
+
 	if(!spellid)
 		return;
-	
+
 	if (bardsong || IsBardSong(casting_spell_id))
 		_StopSong();
 
     if(bard_song_mode) {
         return;
     }
-	
+
 	if(!message)
 		message = IsBardSong(spellid) ? SONG_ENDS_ABRUPTLY : INTERRUPT_SPELL;
 
@@ -1971,11 +1974,6 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, uint16 slot, uint16 
 		{
 			CastToClient()->GetPTimers().Start(casting_spell_timer, casting_spell_timer_duration);
 			mlog(SPELLS__CASTING, "Spell %d: Setting custom reuse timer %d to %d", spell_id, casting_spell_timer, casting_spell_timer_duration);
-			if(casting_spell_type == 1) //AA
-			{
-				time_t timestamp = time(NULL);
-				CastToClient()->SendAATimer((casting_spell_timer - pTimerAAStart), timestamp, timestamp);
-			}
 		}
 		else if(spells[spell_id].recast_time > 1000) {
 			int recast = spells[spell_id].recast_time/1000;


### PR DESCRIPTION
...ful Bellow)

AA reuse timers now start before the spell is cast and reset upon failure or canceling

More info on the bug: http://www.peqtgc.com/phpBB3/viewtopic.php?f=17&t=13937

Confirmed both of theses changes on live.

Note: I used SendAATimer to reset the AAs, sending anything above the reuse time will make it appear ready again. I also changed all the others to use SendAATimer(AATimerID, 0, 0) since that works instead of doing a pointless time stamp. Also, some reason 0xFFFFFFFF (UINT32_MAX) wasn't working for some reason, so I used 0xFFFFFF instead.
