### PR TITLE
spell.max conversion from int16 to int32

### DIFF
--- a/common/spdat.h
+++ b/common/spdat.h
@@ -625,7 +625,7 @@ struct SPDat_Spell_Struct
 /* 019 */	uint16		mana; // Mana Used
 /* 020 */	int			base[EFFECT_COUNT];	//various purposes
 /* 032 */	int			base2[EFFECT_COUNT]; //various purposes
-/* 044 */	int16		max[EFFECT_COUNT];
+/* 044 */	int32		max[EFFECT_COUNT];
 /* 056 */	//uint16 icon; // Spell icon
 /* 057 */	//uint16 memicon; // Icon on membarthing
 /* 058 */	int32		components[4]; // reagents


### PR DESCRIPTION
Converting the spell.max field (spdat.h) to int32 to handle larger numbers in the
PercentalHeal case.

The PercentalHeal case in spell_effects.cpp has "int32 val = spell.max[i]". However, the 'spell.max' field was int16, which in large number cases, resulted in highly unpredictable results. 

I couldn't see any immediate problems as a result of this change.

-Hate

EDIT: Thanks to NatedogEZ for the help testing
