### PR TITLE
Fix for segfault in Database::CheckStatus() when using MariaDB.

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -304,7 +304,11 @@ int16 Database::CheckStatus(uint32 account_id)
 
 			int16 status = atoi(row[0]);
 
-			int32 suspendeduntil = atoi(row[1]);
+			int32 suspendeduntil = 0;
+			// MariaDB initalizes with NULL if unix_timestamp() is out of range
+			if (row[1] != NULL) {
+				suspendeduntil = atoi(row[1]);
+			}
 
 			int32 current = atoi(row[2]);
 


### PR DESCRIPTION
MariaDB returns NULL instead of 0 when an argument is passed that is out of range
(https://mariadb.com/kb/en/unix_timestamp/)

When the column 'suspendeduntil' of an entry in the 'account' table is out of range (e.g., the default value '0000-00-00 00:00:00'), undefined behavior results in Database::CheckStatus() from common/database.cpp since it essentially calls atoi(NULL), which generally causes a segfault.

On another note, isn't there a safer alternative to atoi() that can be used?
