### PR TITLE
Update to spell timers fix

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -1821,7 +1821,8 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, uint16 slot, uint16 
 				if(!SpellOnTarget(spell_id, spell_target, false, true, resist_adjust, false)) {
 					if(IsBuffSpell(spell_id) && IsBeneficialSpell(spell_id)) {
 						// Prevent mana usage/timers being set for beneficial buffs
-						InterruptSpell();
+            if(casting_spell_type == 1)
+              InterruptSpell();
 						return false;
 					}
 				}


### PR DESCRIPTION
InterruptSpell only needs to be called here if the cast is an AA. If it is a spell, InterruptSpell is currently being called twice (immediately after this block returns false, in Mob::CastedSpellFinished).
