### PR TITLE
Fix for a stacking issue with SE_StackingCommand_Block for druid skins

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ EQEMu Changelog (Started on Sept 24, 2003 15:50)
 -------------------------------------------------------
 == 11/15/2013 ==
 demonstar55: Fixed Mob::CalcFocusEffect()'s SE_LimitEffect
+Leere: Fixed a stacking issue for SE_StackingCommand_Block
 
 == 11/13/2013 ==
 demonstar55: Implemented bard song effect cap. You can set the base cap with the rule Character:BaseInstrumentSoftCap, defaults to 36 or "3.6" as it is sometimes referred to.


### PR DESCRIPTION
This should fix the issue where druid skin line spells were unable to overwrite each other.

Single version can be overriden by the group version. Group cannot be overriden by single. The next tier up single can override both the lower group and single version. They will block the Virtue line from overriding them. Virtue will block them in turn due to being better on HP.

The actual blocking values for SE_StackingCommand_Block still seem to be a bit off, but applying an adjustment of -1000 to the max value produced inconclusive results and so was left out.
