### PR TITLE
Fix for auto-consume drinking message

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 EQEMu Changelog (Started on Sept 24, 2003 15:50)
 -------------------------------------------------------
+== 11/16/2013 ==
+Leere: Fixed the drinking message for auto-consume, it will again correctly show up for forced consumption instead.
+
 == 11/15/2013 ==
 demonstar55: Fixed Mob::CalcFocusEffect()'s SE_LimitEffect
 Leere: Fixed a stacking issue for SE_StackingCommand_Block

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -8032,7 +8032,7 @@ void Client::Consume(const Item_Struct *item, uint8 type, int16 slot, bool auto_
         m_pp.thirst_level += tchange;
         DeleteItemInInventory(slot, 1, false);
 
-        if(auto_consume) //no message if the client consumed for us
+        if(!auto_consume) //no message if the client consumed for us
             entity_list.MessageClose_StringID(this, true, 50, 0, DRINKING_MESSAGE, GetName(), item->Name);
 
 #if EQDEBUG >= 1


### PR DESCRIPTION
The message will now again show up for forced consumption instead.
