### PR TITLE
suspend/ban kick fix

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -6364,7 +6364,7 @@ void command_ban(Client *c, const Seperator *sep)
 			client = entity_list.GetClientByName(sep->arg[1]);
 			if(client)
 			{
-				client->Kick();
+				client->WorldKick();
 			}
 			else
 			{
@@ -6426,7 +6426,7 @@ void command_suspend(Client *c, const Seperator *sep)
 			Client *BannedClient = entity_list.GetClientByName(sep->arg[1]);
 
 			if(BannedClient)
-				BannedClient->Kick();
+				BannedClient->WorldKick();
 			else
 			{
 				ServerPacket* pack = new ServerPacket(ServerOP_KickPlayer, sizeof(ServerKickPlayer_Struct));


### PR DESCRIPTION
Currently #suspend and #ban kick the client back to character select, and they are able to log right back in (until they camp out to login or desktop). This kicks the client straight to login. I have only tested this with UF clients.
