### PR TITLE
Add DB support for the AA Seq numbers

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 EQEMu Changelog (Started on Sept 24, 2003 15:50)
 -------------------------------------------------------
+== 11/24/2013 ==
+Leere: Added the seq number for AAs as something loaded from the DB. Only those AAs that should not have their seq number (which the client uses for /alt act and hotkeys) change when new AAs are added need to have it set. The server will still generate numbers for those that have seq set to the default of 0.
+- There is a required SQL file: 2013-11-24_AA_Seq_Support.sql
+
 == 11/23/2013 ==
 Secrets: Fixed an issue related to a zone crash where the count of the abilities in an AA was 0, leading to a size 0 buffer issue.
 

--- a/utils/sql/git/required/2013-11-24_AA_Seq_Support.sql
+++ b/utils/sql/git/required/2013-11-24_AA_Seq_Support.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `altadv_vars` ADD `seq` INT(11) NOT NULL DEFAULT '0';


### PR DESCRIPTION
The seq numbers can now be loaded from the DB with this change. The client uses them for /alt act # and direct AA hotkeys, so creating them based on a sort by AAID lead to changes each time an AA was added, requiring the client to recreate the hotkeys.

There is no need to set all seq numbers, the server will still generate a number for those that have it set to 0. Only the activated AAs should have it set so that they no longer change when new AAs are added.
