### PR TITLE
Revised how dispel works.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 EQEMu Changelog (Started on Sept 24, 2003 15:50)
 -------------------------------------------------------
+== 01/26/2014 ==
+Kayen: Revised 'dispel' type spell effects (ie cancel magic) to be consistent with live
+
 == 01/23/2014 ==
 Kayen: Implemented SE_FfLimitUseType (focus limit to numhits type)
 

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -206,6 +206,7 @@ public:
 	inline bool IsCasting() const { return((casting_spell_id != 0)); }
 	uint16 CastingSpellID() const { return casting_spell_id; }
 	bool DoCastingChecks();
+	bool TryDispel(uint8 caster_level, uint8 buff_level, int level_modifier);
 
 	//Buff
 	void BuffProcess();


### PR DESCRIPTION
Revision to how 'dispel' type spell effects function.
Previous they were 100% success rate and did not incorporate the effect values.
All dispels now have an appropriate chance to fail consistent with my observations on live and other data sources.
Be warned this will be considered a 'nerf' by players.
