### PR TITLE
Hot fix for issue with numhits not fading

### DIFF
--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -3908,8 +3908,6 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 			Numhits(false);
 	}
 
-	Numhits(false);
-
 	buffs[slot].spellid = SPELL_UNKNOWN;
 	if(IsPet() && GetOwner() && GetOwner()->IsClient()) {
 		SendPetBuffsToClient();


### PR DESCRIPTION
Fix where in some cases numhits would not count down due to bool being false automatically if a buff faded after you cast a numhits buff on yourself.
