### PR TITLE
Rune revisions and fixes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 EQEMu Changelog (Started on Sept 24, 2003 15:50)
 -------------------------------------------------------
+
+== 03/12/2014 ==
+Kayen: Melee/Magic runes are now calculated as bonuses. Resolved issues with runes not working and not fading properly.
+
 == 03/08/2014 ==
 Kayen: Revision to lull/harmony/pacification code to be consistent with live based on extensive personal parsing.
 *Lulls on initial cast do not check regular resists (MR ect) but only apply a flat ~7.5 % resist chance + level modifier

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -3188,7 +3188,6 @@ int32 Mob::ReduceDamage(int32 damage)
 				damage -= damage_to_reduce;
 				if(!TryFadeEffect(slot))
 					BuffFadeBySlot(slot);
-				//UpdateRuneFlags();
 			}
 			else
 			{
@@ -3213,7 +3212,6 @@ int32 Mob::ReduceDamage(int32 damage)
 				damage -= damage_to_reduce;
 				if(!TryFadeEffect(slot))
 					BuffFadeBySlot(slot);
-				UpdateRuneFlags();
 			}
 			else
 			{
@@ -3221,7 +3219,6 @@ int32 Mob::ReduceDamage(int32 damage)
 					" damage remaining.", damage_to_reduce, buffs[slot].melee_rune);
 				buffs[slot].melee_rune = (buffs[slot].melee_rune - damage_to_reduce);
 				damage -= damage_to_reduce;
-				UpdateRuneFlags();
 			}
 		}
 	}
@@ -3243,7 +3240,7 @@ int32 Mob::ReduceDamage(int32 damage)
 	if(damage < 1)
 		return -6;
 
-	if (HasRune())
+	if (spellbonuses.MeleeRune[0] && spellbonuses.MeleeRune[1] >= 0)
 		damage = RuneAbsorb(damage, SE_Rune);
 
 	if(damage < 1)
@@ -3317,7 +3314,6 @@ int32 Mob::AffectMagicalDamage(int32 damage, uint16 spell_id, const bool iBuffTi
 					damage -= damage_to_reduce;
 					if(!TryFadeEffect(slot))
 						BuffFadeBySlot(slot);
-					//UpdateRuneFlags();
 				}
 				else
 				{
@@ -3341,7 +3337,6 @@ int32 Mob::AffectMagicalDamage(int32 damage, uint16 spell_id, const bool iBuffTi
 					damage -= damage_to_reduce;
 					if(!TryFadeEffect(slot))
 						BuffFadeBySlot(slot);
-					UpdateRuneFlags();
 				}
 				else
 				{
@@ -3349,7 +3344,6 @@ int32 Mob::AffectMagicalDamage(int32 damage, uint16 spell_id, const bool iBuffTi
 						" damage remaining.", damage_to_reduce, buffs[slot].magic_rune);
 					buffs[slot].magic_rune = (buffs[slot].magic_rune - damage_to_reduce);
 					damage -= damage_to_reduce;
-					UpdateRuneFlags();
 				}
 			}
 		}
@@ -3372,7 +3366,7 @@ int32 Mob::AffectMagicalDamage(int32 damage, uint16 spell_id, const bool iBuffTi
 			return 0;
 
 
-		if (HasSpellRune())
+		if (spellbonuses.AbsorbMagicAtt[0] && spellbonuses.AbsorbMagicAtt[1] >= 0)
 			damage = RuneAbsorb(damage, SE_AbsorbMagicAtt);
 
 		if(damage < 1)
@@ -4602,9 +4596,10 @@ int32 Mob::RuneAbsorb(int32 damage, uint16 type)
 	uint32 buff_max = GetMaxTotalSlots();
 	if (type == SE_Rune){
 		for(uint32 slot = 0; slot < buff_max; slot++) {
-			if((buffs[slot].spellid != SPELL_UNKNOWN) && (buffs[slot].melee_rune) && IsEffectInSpell(buffs[slot].spellid, type)){
+			if(slot == spellbonuses.MeleeRune[1] && spellbonuses.MeleeRune[0] && buffs[slot].melee_rune && IsValidSpell(buffs[slot].spellid)){
 				uint32 melee_rune_left = buffs[slot].melee_rune;
-				if(melee_rune_left >= damage)
+				
+				if(melee_rune_left > damage)
 				{
 					melee_rune_left -= damage;
 					buffs[slot].melee_rune = melee_rune_left;
@@ -4615,22 +4610,20 @@ int32 Mob::RuneAbsorb(int32 damage, uint16 type)
 				{
 					if(melee_rune_left > 0)
 						damage -= melee_rune_left;
+						
 					if(!TryFadeEffect(slot))
 						BuffFadeBySlot(slot);
-					UpdateRuneFlags();
-					continue;
 				}
 			}
 		}
-		return damage;
 	}
 
-
+		
 	else{
 		for(uint32 slot = 0; slot < buff_max; slot++) {
-			if((buffs[slot].spellid != SPELL_UNKNOWN) && (buffs[slot].magic_rune) && IsEffectInSpell(buffs[slot].spellid, type)){
+			if(slot == spellbonuses.AbsorbMagicAtt[1] && spellbonuses.AbsorbMagicAtt[0] && buffs[slot].magic_rune && IsValidSpell(buffs[slot].spellid)){
 				uint32 magic_rune_left = buffs[slot].magic_rune;
-				if(magic_rune_left >= damage)
+				if(magic_rune_left > damage)
 				{
 					magic_rune_left -= damage;
 					buffs[slot].magic_rune = magic_rune_left;
@@ -4641,14 +4634,14 @@ int32 Mob::RuneAbsorb(int32 damage, uint16 type)
 				{
 					if(magic_rune_left > 0)
 						damage -= magic_rune_left;
+					
 					if(!TryFadeEffect(slot))
 						BuffFadeBySlot(slot);
-					UpdateRuneFlags();
-					continue;
 				}
 			}
 		}
-		return damage;
 	}
+
+	return damage;
 }
 

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -2538,9 +2538,34 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses* ne
 					newbon->Root[0] = 1;
 					newbon->Root[1] = buffslot;
 				}
-				else {
+				else if (!newbon->Root[0]){
 					newbon->Root[0] = 1;
 					newbon->Root[1] = buffslot;
+				}
+				break;
+
+			case SE_Rune:
+
+				if (newbon->MeleeRune[0] && (newbon->MeleeRune[1] > buffslot)){
+
+					newbon->MeleeRune[0] = effect_value;
+					newbon->MeleeRune[1] = buffslot;
+				}
+				else if (!newbon->MeleeRune[0]){
+					newbon->MeleeRune[0] = effect_value;
+					newbon->MeleeRune[1] = buffslot;
+				}
+
+				break;
+
+			case SE_AbsorbMagicAtt:
+				if (newbon->AbsorbMagicAtt[0] && (newbon->AbsorbMagicAtt[1] > buffslot)){
+					newbon->AbsorbMagicAtt[0] = effect_value;
+					newbon->AbsorbMagicAtt[1] = buffslot;
+				}
+				else if (!newbon->AbsorbMagicAtt[0]){
+					newbon->AbsorbMagicAtt[0] = effect_value;
+					newbon->AbsorbMagicAtt[1] = buffslot;
 				}
 				break;
 		}
@@ -3896,7 +3921,18 @@ void Mob::NegateSpellsBonuses(uint16 spell_id)
 				case SE_Root:
 					spellbonuses.Root[0] = effect_value;
 					spellbonuses.Root[1] = -1;
+					break;
 
+				case SE_Rune:
+					spellbonuses.MeleeRune[0] = effect_value;
+					spellbonuses.MeleeRune[1] = -1;
+					break;
+
+				case SE_AbsorbMagicAtt:
+					spellbonuses.AbsorbMagicAtt[0] = effect_value;
+					spellbonuses.AbsorbMagicAtt[1] = -1;
+					break;
+				
 			}
 		}
 	}

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -6710,9 +6710,9 @@ void Client::SendStatsWindow(Client* client, bool use_window)
 	uint32 buff_count = GetMaxTotalSlots();
 	for (int i=0; i < buff_count; i++) {
 		if (buffs[i].spellid != SPELL_UNKNOWN) {
-			if ((HasRune() || HasPartialMeleeRune()) && buffs[i].melee_rune > 0) { rune_number += buffs[i].melee_rune; }
+			if (buffs[i].melee_rune > 0) { rune_number += buffs[i].melee_rune; }
 
-			if ((HasSpellRune() || HasPartialSpellRune()) && buffs[i].magic_rune > 0) { magic_rune_number += buffs[i].magic_rune; }
+			if (buffs[i].magic_rune > 0) { magic_rune_number += buffs[i].magic_rune; }
 		}
 	}
 

--- a/zone/common.h
+++ b/zone/common.h
@@ -342,8 +342,8 @@ struct StatBonuses {
 	int16	ImprovedTaunt[3];					// 0 = Max Level 1 = Aggro modifier 2 = buffid
 	int8	Root[2];							// The lowest buff slot a root can be found. [0] = Bool if has root [1] = buff slot
 	int16	FrenziedDevastation;				// base1= AArank(used) base2= chance increase spell criticals + all DD spells 2x mana.
-	//bool	AbsorbMagicAtt;						// Magic Rune *Need to be implemented for NegateEffect
-	//bool	MeleeRune;							// Melee Rune *Need to be implemented for NegateEffect
+	uint16	AbsorbMagicAtt[2];					// 0 = magic rune value 1 = buff slot
+	uint16	MeleeRune[2];						// 0 = rune value 1 = buff slot
 
 	// AAs
 	int8	Packrat;							//weight reduction for items, 1 point = 10%

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -349,12 +349,6 @@ Mob::Mob(const char* in_name,
 	nextinchpevent = -1;
 
 	TempPets(false);
-	SetHasRune(false);
-	SetHasSpellRune(false);
-	SetHasPartialMeleeRune(false);
-	SetHasPartialSpellRune(false);
-
-	m_hasDeathSaveChance = false;
 
 	m_is_running = false;
 

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -248,14 +248,6 @@ public:
 	virtual int GetMaxTotalSlots() const { return 0; }
 	virtual void InitializeBuffSlots() { buffs = nullptr; current_buff_count = 0; }
 	virtual void UninitializeBuffSlots() { }
-	inline bool HasRune() const { return m_hasRune; }
-	inline bool HasSpellRune() const { return m_hasSpellRune; }
-	inline bool HasPartialMeleeRune() const { return m_hasPartialMeleeRune; }
-	inline bool HasPartialSpellRune() const { return m_hasPartialSpellRune; }
-	inline void SetHasRune(bool hasRune) { m_hasRune = hasRune; }
-	inline void SetHasSpellRune(bool hasSpellRune) { m_hasSpellRune = hasSpellRune; }
-	inline void SetHasPartialMeleeRune(bool hasPartialMeleeRune) { m_hasPartialMeleeRune = hasPartialMeleeRune; }
-	inline void SetHasPartialSpellRune(bool hasPartialSpellRune) { m_hasPartialSpellRune = hasPartialSpellRune; }
 	EQApplicationPacket *MakeBuffsPacket(bool for_target = true);
 	void SendBuffsToClient(Client *c);
 	inline Buffs_Struct* GetBuffs() { return buffs; }
@@ -993,7 +985,6 @@ protected:
 	float FindGroundZ(float new_x, float new_y, float z_offset=0.0);
 	VERTEX UpdatePath(float ToX, float ToY, float ToZ, float Speed, bool &WaypointChange, bool &NodeReached);
 	void PrintRoute();
-	void UpdateRuneFlags();
 
 	virtual float GetSympatheticProcChances(float &ProcBonus, float &ProcChance, int32 cast_time, int16 ProcRateMod);
 
@@ -1192,11 +1183,6 @@ protected:
 	float tar_vz;
 	float test_vector;
 
-	bool m_hasRune;
-	bool m_hasSpellRune;
-	bool m_hasPartialMeleeRune;
-	bool m_hasPartialSpellRune;
-	bool m_hasDeathSaveChance;
 	uint32 m_spellHitsLeft[38]; // Used to track which spells will have their numhits incremented when spell finishes casting, 38 Buffslots
 	int flymode;
 	bool m_targetable;

--- a/zone/pets.cpp
+++ b/zone/pets.cpp
@@ -627,7 +627,6 @@ void NPC::SetPetState(SpellBuff_Struct *pet_buffs, uint32 *items) {
 			}
 		}
 	}
-	UpdateRuneFlags();
 
 	//restore their equipment...
 	for(i = 0; i < MAX_WORN_INVENTORY; i++) {

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -1242,7 +1242,6 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial)
 #endif
 				effect_value = ApplySpellEffectiveness(caster, spell_id, effect_value);
 				buffs[buffslot].melee_rune = effect_value;
-				SetHasRune(true);
 				break;
 			}
 
@@ -1251,17 +1250,15 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial)
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Spell Absorb Rune: %+i", effect_value);
 #endif
-				if(effect_value > 0) {
-				buffs[buffslot].magic_rune = effect_value;
-					SetHasSpellRune(true);
-				}
+				if(effect_value > 0) 
+					buffs[buffslot].magic_rune = effect_value;
+
 				break;
 			}
 
 			case SE_MitigateMeleeDamage:
 			{
-				buffs[buffslot].melee_rune = GetPartialMeleeRuneAmount(spell_id);
-				SetHasPartialMeleeRune(true);
+				buffs[buffslot].melee_rune = spells[spell_id].max[i];
 				break;
 			}
 
@@ -1279,8 +1276,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial)
 
 			case SE_MitigateSpellDamage:
 			{
-				buffs[buffslot].magic_rune = GetPartialMagicRuneAmount(spell_id);
-				SetHasPartialSpellRune(true);
+				buffs[buffslot].magic_rune = spells[spell_id].max[i];
 				break;
 			}
 

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -5133,51 +5133,6 @@ void Mob::BuffModifyDurationBySpellID(uint16 spell_id, int32 newDuration)
 		}
 	}
 }
-void Mob::UpdateRuneFlags()
-{
-	bool Has_SE_Rune = false, Has_SE_AbsorbMagicAtt = false, Has_SE_MitigateMeleeDamage = false, Has_SE_MitigateSpellDamage = false;
-	uint32 buff_count = GetMaxTotalSlots();
-	for (unsigned int i = 0; i < buff_count; ++i)
-	{
-		if (buffs[i].spellid != SPELL_UNKNOWN)
-		{
-			for (int j = 0; j < EFFECT_COUNT; ++j)
-			{
-				switch(spells[buffs[i].spellid].effectid[j])
-				{
-					case SE_Rune:
-					{
-						Has_SE_Rune = true;
-						break;
-					}
-					case SE_AbsorbMagicAtt:
-					{
-						Has_SE_AbsorbMagicAtt = true;
-						break;
-					}
-					case SE_MitigateMeleeDamage:
-					{
-						Has_SE_MitigateMeleeDamage = true;
-						break;
-					}
-					case SE_MitigateSpellDamage:
-					{
-						Has_SE_MitigateSpellDamage = true;
-						break;
-					}
-
-					default:
-						break;
-				}
-			}
-		}
-	}
-
-	SetHasRune(Has_SE_Rune);
-	SetHasSpellRune(Has_SE_AbsorbMagicAtt);
-	SetHasPartialMeleeRune(Has_SE_MitigateMeleeDamage);
-	SetHasPartialSpellRune(Has_SE_MitigateSpellDamage);
-}
 
 int Client::GetCurrentBuffSlots() const
 {

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -2656,12 +2656,6 @@ void ZoneDatabase::LoadBuffs(Client *c) {
 			buffs[slot_id].ExtraDIChance = ExtraDIChance;
 			buffs[slot_id].RootBreakChance = 0;
 			buffs[slot_id].UpdateClient = false;
-			if(IsRuneSpell(spell_id)) {
-				c->SetHasRune(true);
-			}
-			else if(IsMagicRuneSpell(spell_id)) {
-				c->SetHasSpellRune(true);
-			}
 
 		}
 		mysql_free_result(result);


### PR DESCRIPTION
Converted melee and magic runes to use bonuses.
Removed all the old rune flags now that none of them are used.
Fixed issues where runes would not fade properly if damage = remaining rune amount
Fixed issue where runes would stop absorbing damage if you had multiple runes.
