### PR TITLE
Focus limit changes/additions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,12 @@
 EQEMu Changelog (Started on Sept 24, 2003 15:50)
 -------------------------------------------------------
+== 04/23/2014 ==
+Kayen: Improved SE_LimitCombatSkills will now more accurately determine if a spell is a combat proc.
+Kayen: SE_LimitInstant will now also work when set to include instant spells.
+
+Optional SQL: utils/sql/git/optional/2014_04_23_FocusComabtProcs.sql
+Note: Set to false, if enabled will allow all combat procs to receive spell focuses.
+
 == 04/21/2014 ==
 Secrets: Crash fix for more hatelist crashes.
 Secrets: Hate list fixes, again.

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -309,6 +309,7 @@ RULE_INT ( Spells, FRProjectileItem_Titanium, 1113) // Item id for Titanium clie
 RULE_INT ( Spells, FRProjectileItem_SOF, 80684) // Item id for SOF clients for Fire 'spell projectile'.
 RULE_INT ( Spells, FRProjectileItem_NPC, 80684) // Item id for NPC Fire 'spell projectile'.
 RULE_BOOL ( Spells, UseLiveSpellProjectileGFX, false) // Use spell projectile graphics set in the spells_new table (player_1). Server must be using UF+ spell file.
+RULE_BOOL ( Spells, FocusCombatProcs, false) //Allow all combat procs to receive focus effects.
 RULE_CATEGORY_END()
 
 RULE_CATEGORY( Combat )

--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -677,11 +677,9 @@ bool IsCombatSkill(uint16 spell_id)
 {
 	if (!IsValidSpell(spell_id))
 		return false;
-
-	//Check if Discipline OR melee proc (from non-castable spell)
-	if ((spells[spell_id].mana == 0 &&
-			(spells[spell_id].EndurCost || spells[spell_id].EndurUpkeep)) || 
-			((spells[spell_id].cast_time == 0) && (spells[spell_id].recast_time == 0) && (spells[spell_id].recovery_time == 0)))
+	
+	//Check if Discipline
+	if ((spells[spell_id].mana == 0 &&	(spells[spell_id].EndurCost || spells[spell_id].EndurUpkeep)))			
 		return true;
 
 	return false;

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -500,6 +500,7 @@ public:
 	bool AddProcToWeapon(uint16 spell_id, bool bPerma = false, uint16 iChance = 3, uint16 base_spell_id = SPELL_UNKNOWN);
 	bool RemoveProcFromWeapon(uint16 spell_id, bool bAll = false);
 	bool HasProcs() const;
+	bool IsCombatProc(uint16 spell_id);
 
 	//Logging
 	bool IsLoggingEnabled() const { return(logging_enabled); }

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4966,6 +4966,28 @@ bool Mob::FindType(uint16 type, bool bOffensive, uint16 threshold) {
 	return false;
 }
 
+bool Mob::IsCombatProc(uint16 spell_id) {
+	
+	if (RuleB(Spells, FocusCombatProcs))
+		return false;
+
+	if(spell_id == SPELL_UNKNOWN)
+		return(false);
+
+	if ((spells[spell_id].cast_time == 0) && (spells[spell_id].recast_time == 0) && (spells[spell_id].recovery_time == 0))
+	{
+
+		for (int i = 0; i < MAX_PROCS; i++){
+			if (PermaProcs[i].spellID == spell_id || SpellProcs[i].spellID == spell_id 
+				|| SkillProcs[i].spellID == spell_id || RangedProcs[i].spellID == spell_id){
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
 bool Mob::AddProcToWeapon(uint16 spell_id, bool bPerma, uint16 iChance, uint16 base_spell_id) {
 	if(spell_id == SPELL_UNKNOWN)
 		return(false);


### PR DESCRIPTION
Improved SE_LimitCombatSkills will now more accurately determine if a spell is a combat proc.

SE_LimitInstant will now also work when set to include instant spells.

Optional SQL: utils/sql/git/optional/2014_04_23_FocusComabtProcs.sql
Note: Set to false, if enabled will allow all combat procs to receive spell focuses.
