### PR TITLE
SlowMItigation sql fix

### DIFF
--- a/utils/sql/git/required/2014_04_12_SlowMitigation.sql
+++ b/utils/sql/git/required/2014_04_12_SlowMitigation.sql
@@ -2,6 +2,6 @@
 UPDATE npc_types SET slow_mitigation = slow_mitigation * 100;
 
 -- Change variable type from FLOAT TO INT
-ALTER TABLE npc_types MODIFY slow_mitigation smallint(4);
+ALTER TABLE npc_types MODIFY slow_mitigation smallint(4) NOT NULL DEFAULT  '0'; 
 
 

--- a/utils/sql/git/required/2014_05_4_SlowMitigationFix.sql
+++ b/utils/sql/git/required/2014_05_4_SlowMitigationFix.sql
@@ -1,0 +1,3 @@
+ALTER TABLE npc_types MODIFY slow_mitigation smallint(4) NOT NULL DEFAULT  '0'; 
+
+


### PR DESCRIPTION
Fix for npc_types table error setting SlowMitigation to null by default.

If you already ran the 4-12 update DO NOT run it again.
