### PR TITLE
Swarm pet critical/flurry bonuses

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 EQEMu Changelog (Started on Sept 24, 2003 15:50)
 -------------------------------------------------------
+== 05/07/2014 ==
+Kayen: AA/Item/Spells that allow pets to critical and flurry will now work on the owners swarm pets consistent with live.
+
 == 05/05/2014 ==
 Uleat: Oops! Wrong state check (conn_state != client_state)
 Uleat: Test fix to eliminate seemingly random crashes when an AE spell is being used. (Possible access to uninstantiated pointers during client connection process when someone casts a beneficial AE spell within range of a connecting client.)

--- a/zone/MobAI.cpp
+++ b/zone/MobAI.cpp
@@ -1213,11 +1213,18 @@ void Mob::AI_Process() {
 						}
 					}
 
-					if (IsPet()) {
-						Mob *owner = GetOwner();
+					if (IsPet() || (IsNPC() && CastToNPC()->GetSwarmOwner())) {
+						Mob *owner = nullptr;
+		
+						if (IsPet())
+							owner = GetOwner();
+						else 
+							owner = entity_list.GetMobID(CastToNPC()->GetSwarmOwner());
+							
 						if (owner) {
 						int16 flurry_chance = owner->aabonuses.PetFlurry +
 							owner->spellbonuses.PetFlurry + owner->itembonuses.PetFlurry;
+						
 							if (flurry_chance && (MakeRandomInt(0, 99) < flurry_chance))
 								Flurry(nullptr);
 						}

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -4226,10 +4226,12 @@ void Mob::TryPetCriticalHit(Mob *defender, uint16 skill, int32 &damage)
 	if (damage < 1) //We can't critical hit if we don't hit.
 		return;
 
-	if (!IsPet())
+	if (IsPet())
+		owner = GetOwner();
+	else if ((IsNPC() && CastToNPC()->GetSwarmOwner()))
+		owner = entity_list.GetMobID(CastToNPC()->GetSwarmOwner());
+	else
 		return;
-
-	owner = GetOwner();
 
 	if (!owner)
 		return;
@@ -4267,7 +4269,7 @@ void Mob::TryCriticalHit(Mob *defender, uint16 skill, int32 &damage, ExtraAttack
 
 	// decided to branch this into it's own function since it's going to be duplicating a lot of the
 	// code in here, but could lead to some confusion otherwise
-	if (IsPet() && GetOwner()->IsClient()) {
+	if (IsPet() && GetOwner()->IsClient() || (IsNPC() && CastToNPC()->GetSwarmOwner())) {
 		TryPetCriticalHit(defender,skill,damage);
 		return;
 	}
@@ -4456,6 +4458,7 @@ void Mob::DoRiposte(Mob* defender) {
 
 	//Double Riposte effect, allows for a chance to do RIPOSTE with a skill specfic special attack (ie Return Kick).
 	//Coded narrowly: Limit to one per client. Limit AA only. [1 = Skill Attack Chance, 2 = Skill]
+
 	DoubleRipChance = defender->aabonuses.GiveDoubleRiposte[1];
 
 	if(DoubleRipChance && (DoubleRipChance >= MakeRandomInt(0, 100))) {


### PR DESCRIPTION
AA/Item/Spell that allow owner's pets to flurry and critical will now also apply to owner's swarm pets consistent with live.
