### PR TITLE
Support for spells_new field npc_no_los (simply skips the LOS check for ...

### DIFF
--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -1720,6 +1720,7 @@ void SharedDatabase::LoadSpells(void *data, int max_spells) {
 			sp[tempid].descnum = atoi(row[155]);
 			sp[tempid].effectdescnum = atoi(row[157]);
 
+			sp[tempid].npc_no_los = atoi(row[159]) != 0;
 			sp[tempid].reflectable = atoi(row[161]) != 0;
 			sp[tempid].bonushate=atoi(row[162]);
 
@@ -1750,6 +1751,8 @@ void SharedDatabase::LoadSpells(void *data, int max_spells) {
 			sp[tempid].AllowRest = atoi(row[212]) != 0;
 			sp[tempid].NotOutofCombat = atoi(row[213]) != 0;
 			sp[tempid].NotInCombat = atoi(row[214]) != 0;
+			sp[tempid].aemaxtargets = atoi(row[218]);
+			sp[tempid].maxtargets = atoi(row[219]);
 			sp[tempid].persistdeath = atoi(row[224]) != 0;
 			sp[tempid].DamageShieldType = 0;
 		}

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -690,7 +690,7 @@ struct SPDat_Spell_Struct
 /* 156 */	//int typedescnum; // eqstr of type description
 /* 157 */	int effectdescnum; // eqstr of effect description
 /* 158 */   //Category Desc ID 3
-/* 159 */	//bool npc_no_los;
+/* 159 */	bool npc_no_los;
 /* 161 */	bool reflectable;
 /* 162 */	int bonushate;
 /* 163 */
@@ -732,8 +732,9 @@ struct SPDat_Spell_Struct
 /* 212 */	bool AllowRest;
 /* 213 */	bool NotOutofCombat; //Fail if cast out of combat
 /* 214 */   bool NotInCombat; //Fail if cast in combat
-/* 215 - 218 */
-/* 219 */	//int maxtargets; // is used for beam and ring spells for target # limits (not implemented)
+/* 215 - 217 */
+/* 219 */	int aemaxtargets; // 
+/* 219 */	int maxtargets; // is used for beam and ring spells for target # limits (not implemented)
 /* 220 - 223 */
 /* 224 */	bool persistdeath; // buff doesn't get stripped on death
 /* 225 - 236 */ // Not in DB

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -1833,7 +1833,7 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, uint16 slot, uint16 
 	}
 
 	// check line of sight to target if it's a detrimental spell
-	if(spell_target && IsDetrimentalSpell(spell_id) && !CheckLosFN(spell_target) && !IsHarmonySpell(spell_id) && spells[spell_id].targettype != ST_TargetOptional)
+	if(!spells[spell_id].npc_no_los && spell_target && IsDetrimentalSpell(spell_id) && !CheckLosFN(spell_target) && !IsHarmonySpell(spell_id) && spells[spell_id].targettype != ST_TargetOptional)
 	{
 		mlog(SPELLS__CASTING, "Spell %d: cannot see target %s", spell_target->GetName());
 		Message_StringID(13,CANT_SEE_TARGET);


### PR DESCRIPTION
...that spell

despite name, no reason to hard code it only for NPC).
