### PR TITLE
Implemented Raid OOC Regen

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -76,6 +76,7 @@ RULE_BOOL ( Character, SharedBankPlat, false) //off by default to prevent duping
 RULE_BOOL ( Character, BindAnywhere, false)
 RULE_INT ( Character, RestRegenPercent, 0) // Set to >0 to enable rest state bonus HP and mana regen.
 RULE_INT ( Character, RestRegenTimeToActivate, 30) // Time in seconds for rest state regen to kick in.
+RULE_INT ( Character, RestRegenRaidTimeToActivate, 300) // Time in seconds for rest state regen to kick in with a raid target.
 RULE_BOOL ( Character, RestRegenEndurance, false) // Whether rest regen will work for endurance or not.
 RULE_INT ( Character, KillsPerGroupLeadershipAA, 250) // Number of dark blues or above per Group Leadership AA
 RULE_INT ( Character, KillsPerRaidLeadershipAA, 250) // Number of dark blues or above per Raid Leadership AA

--- a/zone/client.h
+++ b/zone/client.h
@@ -1198,6 +1198,9 @@ public:
     int mod_food_value(const Item_Struct *item, int change);
     int mod_drink_value(const Item_Struct *item, int change);
 
+	void SetEngagedRaidTarget(bool value) { EngagedRaidTarget = value; }
+	bool GetEngagedRaidTarget() const { return EngagedRaidTarget; }
+	
 protected:
 	friend class Mob;
 	void CalcItemBonuses(StatBonuses* newbon);
@@ -1442,6 +1445,9 @@ private:
 	unsigned int	RestRegenHP;
 	unsigned int	RestRegenMana;
 	unsigned int	RestRegenEndurance;
+	
+	bool EngagedRaidTarget;
+	uint32 SavedRaidRestTimer;
 
 	std::set<uint32> zone_flags;
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -9140,7 +9140,8 @@ bool Client::FinishConnState2(DBAsyncWork* dbaw) {
 
 	m_pp.timeentitledonaccount = database.GetTotalTimeEntitledOnAccount(AccountID()) / 1440;
 
-	if(m_pp.RestTimer > RuleI(Character, RestRegenTimeToActivate))
+	// Reset rest timer if the durations have been lowered in the database
+	if ((m_pp.RestTimer > RuleI(Character, RestRegenTimeToActivate)) && (m_pp.RestTimer > RuleI(Character, RestRegenRaidTimeToActivate)))
 		m_pp.RestTimer = 0;
 
 	//This checksum should disappear once dynamic structs are in... each struct strategy will do it

--- a/zone/hate_list.cpp
+++ b/zone/hate_list.cpp
@@ -198,8 +198,11 @@ void HateList::Add(Mob *ent, int32 in_hate, int32 in_dam, bool bFrenzy, bool iAd
 		list.push_back(p);
 		parse->EventNPC(EVENT_HATE_LIST, owner->CastToNPC(), ent, "1", 0);
 
-		if(ent->IsClient())
+		if (ent->IsClient()) {
+			if (owner->CastToNPC()->IsRaidTarget()) 
+				ent->CastToClient()->SetEngagedRaidTarget(true);
 			ent->CastToClient()->IncrementAggroCount();
+		}
 	}
 }
 

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -524,6 +524,7 @@ public:
 
 
 	//More stuff to sort:
+	virtual bool IsRaidTarget() { return false; };
 	virtual bool IsAttackAllowed(Mob *target, bool isSpellAttack = false);
 	bool IsTargeted() const { return (targeted > 0); }
 	inline void IsTargeted(int in_tar) { targeted += in_tar; if(targeted < 0) targeted = 0;}

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -358,6 +358,7 @@ NPC::NPC(const NPCType* d, Spawn2* in_respawn, float x, float y, float z, float 
 	SetEmoteID(d->emoteid);
 	InitializeBuffSlots();
 	CalcBonuses();
+	raid_target = d->raid_target;
 }
 
 NPC::~NPC()

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -395,6 +395,8 @@ public:
 	void	mod_npc_killed_merit(Mob* c);
 	void	mod_npc_killed(Mob* oos);
 	void AISpellsList(Client *c);
+	
+	bool IsRaidTarget() const { return raid_target; };
 
 protected:
 
@@ -500,6 +502,8 @@ protected:
 	//mercenary stuff
 	std::list<MercType> mercTypeList;
 	std::list<MercData> mercDataList;
+	
+	bool raid_target;
 
 private:
 	uint32	loottable_id;

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -1115,7 +1115,8 @@ const NPCType* ZoneDatabase::GetNPCType (uint32 id) {
 			"npc_types.emoteid,"
 			"npc_types.spellscale,"
 			"npc_types.healscale,"
-			"npc_types.no_target_hotkey";
+			"npc_types.no_target_hotkey,"
+			"npc_types.raid_target";
 
 		MakeAnyLenString(&query, "%s FROM npc_types WHERE id=%d", basic_query, id);
 
@@ -1302,6 +1303,7 @@ const NPCType* ZoneDatabase::GetNPCType (uint32 id) {
 				tmpNPCType->spellscale = atoi(row[r++]);
 				tmpNPCType->healscale = atoi(row[r++]);
 				tmpNPCType->no_target_hotkey = atoi(row[r++]) == 1 ? true : false;
+				tmpNPCType->raid_target = atoi(row[r++]) == 0 ? false : true;
 				
 				// If NPC with duplicate NPC id already in table,
 				// free item we attempted to add.

--- a/zone/zonedump.h
+++ b/zone/zonedump.h
@@ -125,6 +125,7 @@ struct NPCType
 	float	spellscale;
 	float	healscale;
 	bool	no_target_hotkey;
+	bool	raid_target;
 };
 
 /*


### PR DESCRIPTION
By request of Bobaski, this implements the raid target out of combat regen timer.

This adds a 'raid_target' column to npc_types, to specify whether a mob should be considered a raid target. 0 = not raid target, 1 = raid target.
If rest regen is enabled, it uses the new Character:RestRegenRaidTimeToActivate rule to set the timer.
The mechanics have been verified on live. If you kill a raid target and then engage a non raid target, the timer pauses for the duration of aggro, then resumes. The default timer is 5 minutes.

This does NOT work for bots/mercs at this time. Their rest timers are implemented very differently, not relying on hatelist interaction. If this feature is desired, someone more familiar with bot/merc code will probably need to do it.

Required SQL:
`ALTER TABLE `npc_types` ADD `raid_target` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0' AFTER `fixed`;`

Not sure if these are required:
`INSERT INTO `rule_values` (`ruleset_id`, `rule_name`, `rule_value`, `notes`) VALUES`
`(1, 'Character:RestRegenRaidTimeToActivate', 300, 'Time in seconds for rest state regen to kick in with a raid target.'),`
`(2, 'Character:RestRegenRaidTimeToActivate', 300, 'Time in seconds for rest state regen to kick in with a raid target.'),`
`(4, 'Character:RestRegenRaidTimeToActivate', 300, 'Time in seconds for rest state regen to kick in with a raid target.'),`
`(10, 'Character:RestRegenRaidTimeToActivate', 300, 'Time in seconds for rest state regen to kick in with a raid target.');`

The raid_target column can also be used for con messages: 'This creature looks like it would take an army to defeat!'. I haven't looked at adding that yet.
