### PR TITLE
Nimbus Updates / Other fixes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 EQEMu Changelog (Started on Sept 24, 2003 15:50)
 -------------------------------------------------------
+== 09/15/2014 ==
+Kayen: Nimbus effects will now be reapplied after zoning and will be removed when associated buff fades.
+
 == 09/13/2014 ==
 demonstar55: Fix rogues not having Thieves' Cant
 

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -3516,7 +3516,7 @@ void Mob::CommonDamage(Mob* attacker, int32 &damage, const uint16 spell_id, cons
 		if(spell_id == SPELL_UNKNOWN) {
 			damage = ReduceDamage(damage);
 			mlog(COMBAT__HITS, "Melee Damage reduced to %d", damage);
-			ReduceAllDamage(damage);
+			damage = ReduceAllDamage(damage);
 			TryTriggerThreshHold(damage, SE_TriggerMeleeThreshold, attacker);
 		} else {
 			int32 origdmg = damage;
@@ -3529,7 +3529,7 @@ void Mob::CommonDamage(Mob* attacker, int32 &damage, const uint16 spell_id, cons
 				//Kayen: Probably need to add a filter for this - Not sure if this msg is correct but there should be a message for spell negate/runes.
 				Message(263, "%s tries to cast on YOU, but YOUR magical skin absorbs the spell.",attacker->GetCleanName());
 			}
-			ReduceAllDamage(damage);
+			damage = ReduceAllDamage(damage);
 			TryTriggerThreshHold(damage, SE_TriggerSpellThreshold, attacker);
 		}
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -9574,10 +9574,16 @@ void Client::CompleteConnect() {
 	//reapply some buffs
 	uint32 buff_count = GetMaxTotalSlots();
 	for (uint32 j1 = 0; j1 < buff_count; j1++) {
-		if (buffs[j1].spellid >(uint32)SPDAT_RECORDS)
+		if (!IsValidSpell(buffs[j1].spellid))
 			continue;
 
 		const SPDat_Spell_Struct &spell = spells[buffs[j1].spellid];
+
+		int NimbusEffect = GetNimbusEffect(buffs[j1].spellid);
+		if(NimbusEffect) {
+			if(!IsNimbusEffectActive(NimbusEffect))
+				SendSpellEffect(NimbusEffect, 500, 0, 1, 3000, true);
+		}
 
 		for (int x1 = 0; x1 < EFFECT_COUNT; x1++) {
 			switch (spell.effectid[x1]) {

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -4375,6 +4375,15 @@ void Mob::SpreadVirus(uint16 spell_id, uint16 casterID)
 
 void Mob::RemoveNimbusEffect(int effectid)
 {
+	if (effectid == nimbus_effect1)
+		nimbus_effect1 = 0;
+
+	else if (effectid == nimbus_effect2)
+		nimbus_effect2 = 0;
+
+	else if (effectid == nimbus_effect3)
+		nimbus_effect3 = 0;
+
 	EQApplicationPacket* outapp = new EQApplicationPacket(OP_RemoveNimbusEffect, sizeof(RemoveNimbusEffect_Struct));
 	RemoveNimbusEffect_Struct* rne = (RemoveNimbusEffect_Struct*)outapp->pBuffer;
 	rne->spawnid = GetID();

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -4016,6 +4016,9 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 		if (!found_numhits)
 			Numhits(false);
 	}
+	
+	if (spells[buffs[slot].spellid].NimbusEffect > 0)
+		RemoveNimbusEffect(spells[buffs[slot].spellid].NimbusEffect);
 
 	buffs[slot].spellid = SPELL_UNKNOWN;
 	if(IsPet() && GetOwner() && GetOwner()->IsClient()) {


### PR DESCRIPTION
Nimbus effects will now be reapplied after zoning.
Nimbus effects will now fade when associated buff is removed.
Fix for ReduceAllDamage function.
