### PR TITLE
Update zone.cpp to fix bug in loading merchantlist_temp

### DIFF
--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -433,8 +433,8 @@ void Zone::LoadTempMerchantData(){
 			npcid = ml.npcid;
 		}
 		ml.slot = atoul(row[1]);
-		ml.item = atoul(row[2]);
-		ml.charges = atoul(row[3]);
+		ml.charges = atoul(row[2]);
+		ml.item = atoul(row[3]);
 		ml.origslot = ml.slot;
 		cur->second.push_back(ml);
 	}


### PR DESCRIPTION
The order of rows in the query did not match the order of the variables.

Merchants were ending up with quantity=itemid and itemid=quantity,

Only shows up if clearing the temp list is disabled in rules.
