### PR TITLE
Max Range attack calculation fix.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 EQEMu Changelog (Started on Sept 24, 2003 15:50)
 -------------------------------------------------------
+== 12/04/2014 ==
+Kayen: Ranged attacks will now more accurately check MAX firing range, fixing the issue where you would
+hit ranged attack and nothing would happpen due to incorrect server side range checks.
+
 == 12/01/2014 ==
 Trevius: Mercenaries now spawn as the same Gender and Size of the Merchant they are purchased from.
 Trevius: Mercenaries now spawn with randomized facial features when purchased.

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -737,6 +737,7 @@ public:
 	void ProjectileAttack();
 	inline bool HasProjectileAttack() const { return ActiveProjectileATK; }
 	inline void SetProjectileAttack(bool value) { ActiveProjectileATK = value; }
+	float GetRangeDistTargetSizeMod(Mob* other);
 	bool CanDoSpecialAttack(Mob *other);
 	bool Flurry(ExtraAttackOptions *opts);
 	bool Rampage(ExtraAttackOptions *opts);

--- a/zone/string_ids.h
+++ b/zone/string_ids.h
@@ -396,7 +396,8 @@
 #define SONG_ENDS_OTHER				12688	//%1's song ends.
 #define SONG_ENDS_ABRUPTLY_OTHER	12689	//%1's song ends abruptly.
 #define DIVINE_AURA_NO_ATK			12695	//You can't attack while invulnerable!
-#define TRY_ATTACKING_SOMEONE		12696	//Try attacking someone other than yourself, it's more productive.
+#define TRY_ATTACKING_SOMEONE		12696	//Try attacking someone other than yourself, it's more productive
+#define RANGED_TOO_CLOSE			12698	//Your target is too close to use a ranged weapon!
 #define BACKSTAB_WEAPON				12874	//You need a piercing weapon as your primary weapon in order to backstab
 #define MORE_SKILLED_THAN_I			12931	//%1 tells you, 'You are more skilled than I! What could I possibly teach you?'
 #define SURNAME_EXISTS				12939	//You already have a surname. Operation failed.


### PR DESCRIPTION
Ranged attacks will now much more accurately calculate max distance server side
via accounting for differences in attacker/target size. This
fixes a very common issue of player hitting range attack and
nothing happening due to server improperly calculating
max range.
