### PR TITLE
Enable ROF2 client with a preprocessor macro #define ENABLE_ROF2 (vs un-...

### DIFF
--- a/common/patches/patches.cpp
+++ b/common/patches/patches.cpp
@@ -17,8 +17,10 @@ void RegisterAllPatches(EQStreamIdentifier &into) {
 	SoD::Register(into);
 	Underfoot::Register(into);
 	RoF::Register(into);
-	// Uncomment the line below to enable RoF2 Client
-	//RoF2::Register(into);
+	// Preprocessor #define ENABLE_ROF2 to enable RoF2 Client
+#ifdef ENABLE_ROF2
+	RoF2::Register(into);
+#endif
 }
 
 void ReloadAllPatches() {
@@ -28,6 +30,8 @@ void ReloadAllPatches() {
 	SoD::Reload();
 	Underfoot::Reload();
 	RoF::Reload();
-	// Uncomment the line below to enable RoF2 Client
-	//RoF2::Reload();
+	// Preprocessor #define ENABLE_ROF2 to enable RoF2 Client
+#ifdef ENABLE_ROF2
+	RoF2::Reload();
+#endif
 }


### PR DESCRIPTION
Enable ROF2 client by a preprocessor #define ENABLE_ROF2 (vs manually un-commenting lines).  Hopefully someone with more CMAKE knowledge could turn this into a full-fledged CMAKE option.
