### PR TITLE
Fix for stackable items being unmoveable when charges=0

### DIFF
--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -565,7 +565,9 @@ bool SharedDatabase::GetInventory(uint32 char_id, Inventory* inv) {
 
         if(charges==0x7FFF)
             inst->SetCharges(-1);
-        else
+		else if (charges == 0 && inst->IsStackable()) // Stackable items need a minimum charge of 1 remain moveable.
+			inst->SetCharges(1);
+		else
             inst->SetCharges(charges);
 
         if (item->ItemClass == ItemClassCommon)
@@ -1233,6 +1235,9 @@ ItemInst* SharedDatabase::CreateBaseItem(const Item_Struct* item, int16 charges)
 		// if maxcharges is -1 that means it is an unlimited use item.
 		// set it to 1 charge so that it is usable on creation
 		if (charges == 0 && item->MaxCharges == -1)
+			charges = 1;
+		// Stackable items need a minimum charge of 1 to remain moveable.
+		if(charges <= 0 && item->Stackable)
 			charges = 1;
 
 		inst = new ItemInst(item, charges);


### PR DESCRIPTION
Stackable items will become unmoveable for the client (with the exception of clicking on their slot with another item already on your cursor) when they have charges set to 0. This mainly seems to happen for stackable ground spawns where you only picked up one and then zoned.

Fix this by having the CreateBaseItem check for charges == 0 with stackable items.
Also perform a check for this case during character inventory load.

In both cases, and only in the case of charges being 0 for a stackable item, charges for the ItemInst are set to 1.
