### PR TITLE
Work-around for "strange ADL issues" not needed if using Boost 1.57.0

### DIFF
--- a/luabind/luabind/object.hpp
+++ b/luabind/luabind/object.hpp
@@ -537,6 +537,7 @@ namespace detail
   };
 
 // Needed because of some strange ADL issues.
+#if BOOST_VERSION < 105700
 
 #define LUABIND_OPERATOR_ADL_WKND(op) \
   inline bool operator op( \
@@ -557,7 +558,8 @@ namespace detail
   LUABIND_OPERATOR_ADL_WKND(!=)
 
 #undef LUABIND_OPERATOR_ADL_WKND
- 
+#endif
+
 } // namespace detail
 
 namespace adl


### PR DESCRIPTION
Work-around for "strange ADL issues" not needed if using Boost 1.57.0 (was required through 1.56.0, thus test for less than 1.57.0).  Tested on VS2013 x64 and in-game appears to be working correctly; someone might want to check this on other compilers and/or OS.