### PR TITLE
Made familiars persistent.

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -549,7 +549,7 @@ bool Client::Save(uint8 iCommitNow) {
 
 	m_pp.lastlogin = time(nullptr);
 
-	if (GetPet() && !GetPet()->IsFamiliar() && GetPet()->CastToNPC()->GetPetSpellID() && !dead) {
+	if (GetPet() && GetPet()->CastToNPC()->GetPetSpellID() && !dead) {
 		NPC *pet = GetPet()->CastToNPC();
 		m_petinfo.SpellID = pet->CastToNPC()->GetPetSpellID();
 		m_petinfo.HP = pet->GetHP();


### PR DESCRIPTION
I'd like input on this change.

Wizard familiars were not persistent on zoning.  I checked live, and they are.  This one line change fixes that, but I am concerned as to why it is there to begin with.  My server doesn't support many new zones/expansions, so is the old code there to make something else work?

This does, in fact, fix the wizard familiars, so accept it if you think that's good.  If there are issues you need me to look into, let me know.