### PR TITLE
Change EQStream raw pointers to be std::shared_ptr

### DIFF
--- a/common/eq_stream.h
+++ b/common/eq_stream.h
@@ -206,8 +206,14 @@ class EQStream : public EQStreamInterface {
 
 		void init(bool resetSession=true);
 	public:
-		EQStream() { init(); remote_ip = 0; remote_port = 0; State=UNESTABLISHED; StreamType=UnknownStream; compressed=true; encoded=false; app_opcode_size=2; bytes_sent=0; bytes_recv=0; create_time=Timer::GetTimeSeconds(); sessionAttempts = 0; streamactive=false; }
-		EQStream(sockaddr_in addr) { init(); remote_ip=addr.sin_addr.s_addr; remote_port=addr.sin_port; State=UNESTABLISHED; StreamType=UnknownStream; compressed=true; encoded=false; app_opcode_size=2; bytes_sent=0; bytes_recv=0; create_time=Timer::GetTimeSeconds(); }
+		EQStream() { init(); remote_ip = 0; remote_port = 0; State = UNESTABLISHED; 
+			StreamType = UnknownStream; compressed = true; encoded = false; app_opcode_size = 2; 
+			bytes_sent = 0; bytes_recv = 0; create_time = Timer::GetTimeSeconds(); sessionAttempts = 0; 
+			streamactive = false; }
+		EQStream(sockaddr_in addr) { init(); remote_ip = addr.sin_addr.s_addr; 
+			remote_port = addr.sin_port; State = UNESTABLISHED; StreamType = UnknownStream; 
+			compressed = true; encoded = false; app_opcode_size = 2; bytes_sent = 0; bytes_recv = 0; 
+			create_time = Timer::GetTimeSeconds(); }
 		virtual ~EQStream() { RemoveData(); SetState(CLOSED); }
 		void SetMaxLen(uint32 length) { MaxLen=length; }
 

--- a/common/eq_stream_factory.h
+++ b/common/eq_stream_factory.h
@@ -2,6 +2,7 @@
 
 #define _EQSTREAMFACTORY_H
 
+#include <memory>
 #include <queue>
 #include <map>
 
@@ -26,10 +27,10 @@ class EQStreamFactory : private Timeoutable {
 
 		EQStreamType StreamType;
 
-		std::queue<EQStream *> NewStreams;
+		std::queue<std::shared_ptr<EQStream>> NewStreams;
 		Mutex MNewStreams;
 
-		std::map<std::pair<uint32, uint16>,EQStream *> Streams;
+		std::map<std::pair<uint32, uint16>, std::shared_ptr<EQStream>> Streams;
 		Mutex MStreams;
 
 		virtual void CheckTimeout();
@@ -42,8 +43,8 @@ class EQStreamFactory : private Timeoutable {
 		EQStreamFactory(EQStreamType type, uint32 timeout = 135000) : Timeoutable(5000), stream_timeout(timeout) { ReaderRunning=false; WriterRunning=false; StreamType=type; sock=-1; }
 		EQStreamFactory(EQStreamType type, int port, uint32 timeout = 135000);
 
-		EQStream *Pop();
-		void Push(EQStream *s);
+		std::shared_ptr<EQStream> Pop();
+		void Push(std::shared_ptr<EQStream> s);
 
 		bool Open();
 		bool Open(unsigned long port) { Port=port; return Open(); }

--- a/common/eq_stream_ident.h
+++ b/common/eq_stream_ident.h
@@ -5,6 +5,7 @@
 #include "timer.h"
 #include <vector>
 #include <queue>
+#include <memory>
 
 #define STREAM_IDENT_WAIT_MS 10000
 
@@ -21,7 +22,7 @@ public:
 
 	//main processing interface
 	void Process();
-	void AddStream(EQStream *& eqs);
+	void AddStream(std::shared_ptr<EQStream> &eqs);
 	EQStreamInterface *PopIdentified();
 
 protected:
@@ -39,11 +40,11 @@ protected:
 	//pending streams..
 	class Record {
 	public:
-		Record(EQStream *s);
-		EQStream *stream;		//we own this
+		Record(std::shared_ptr<EQStream> s);
+		std::shared_ptr<EQStream> stream;		//we own this
 		Timer expire;
 	};
-	std::vector<Record *> m_streams;	//we own these objects, and the streams contained in them.
+	std::vector<Record> m_streams;	//we own these objects, and the streams contained in them.
 	std::queue<EQStreamInterface *> m_identified;	//we own these objects
 };
 

--- a/common/eq_stream_proxy.cpp
+++ b/common/eq_stream_proxy.cpp
@@ -5,7 +5,7 @@
 #include "struct_strategy.h"
 
 
-EQStreamProxy::EQStreamProxy(EQStream *&stream, const StructStrategy *structs, OpcodeManager **opcodes)
+EQStreamProxy::EQStreamProxy(std::shared_ptr<EQStream> &stream, const StructStrategy *structs, OpcodeManager **opcodes)
 :	m_stream(stream),
 	m_structs(structs),
 	m_opcodes(opcodes)
@@ -15,7 +15,6 @@ EQStreamProxy::EQStreamProxy(EQStream *&stream, const StructStrategy *structs, O
 }
 
 EQStreamProxy::~EQStreamProxy() {
-	//delete m_stream;	//released by the stream factory.
 }
 
 std::string EQStreamProxy::Describe() const {
@@ -85,12 +84,6 @@ const uint32 EQStreamProxy::GetBytesRecvPerSecond() const
 
 void EQStreamProxy::ReleaseFromUse() {
 	m_stream->ReleaseFromUse();
-
-	//this is so ugly, but I cant think of a better way to deal with
-	//it right now...
-	if(!m_stream->IsInUse()) {
-		delete this;
-	}
 }
 
 void EQStreamProxy::RemoveData() {

--- a/common/eq_stream_proxy.h
+++ b/common/eq_stream_proxy.h
@@ -4,8 +4,9 @@
 
 #include "types.h"
 #include "eq_stream_intf.h"
+#include "eq_stream.h"
+#include <memory>
 
-class EQStream;
 class StructStrategy;
 class OpcodeManager;
 class EQApplicationPacket;
@@ -13,7 +14,7 @@ class EQApplicationPacket;
 class EQStreamProxy : public EQStreamInterface {
 public:
 	//takes ownership of the stream.
-	EQStreamProxy(EQStream *&stream, const StructStrategy *structs, OpcodeManager **opcodes);
+	EQStreamProxy(std::shared_ptr<EQStream> &stream, const StructStrategy *structs, OpcodeManager **opcodes);
 	virtual ~EQStreamProxy();
 
 	//EQStreamInterface:
@@ -35,7 +36,7 @@ public:
 	virtual const uint32 GetBytesRecvPerSecond() const;
 
 protected:
-	EQStream *const					m_stream;	//we own this stream object.
+	std::shared_ptr<EQStream> const					m_stream;	//we own this stream object.
 	const StructStrategy *const		m_structs;	//we do not own this object.
 	//this is a pointer to a pointer to make it less likely that a packet will
 	//reference an invalid opcode manager when they are being reloaded.

--- a/common/patches/ss_declare.h
+++ b/common/patches/ss_declare.h
@@ -1,6 +1,6 @@
 
 
-#define E(x) static void Encode_##x(EQApplicationPacket **p, EQStream *dest, bool ack_req);
+#define E(x) static void Encode_##x(EQApplicationPacket **p, std::shared_ptr<EQStream> dest, bool ack_req);
 #define D(x) static void Decode_##x(EQApplicationPacket *p);
 
 

--- a/common/patches/ss_define.h
+++ b/common/patches/ss_define.h
@@ -1,5 +1,5 @@
 
-#define ENCODE(x) void Strategy::Encode_##x(EQApplicationPacket **p, EQStream *dest, bool ack_req)
+#define ENCODE(x) void Strategy::Encode_##x(EQApplicationPacket **p, std::shared_ptr<EQStream> dest, bool ack_req)
 #define DECODE(x) void Strategy::Decode_##x(EQApplicationPacket *__packet)
 
 #define StructDist(in, f1, f2) (uint32(&in->f2)-uint32(&in->f1))

--- a/common/struct_strategy.cpp
+++ b/common/struct_strategy.cpp
@@ -5,6 +5,7 @@
 
 #include "eq_stream.h"
 #include <map>
+#include <memory>
 
 
 //note: all encoders and decoders must be valid functions.
@@ -17,7 +18,7 @@ StructStrategy::StructStrategy() {
 	}
 }
 
-void StructStrategy::Encode(EQApplicationPacket **p, EQStream *dest, bool ack_req) const {
+void StructStrategy::Encode(EQApplicationPacket **p, std::shared_ptr<EQStream> dest, bool ack_req) const {
 	if((*p)->GetOpcodeBypass() != 0) {
 		PassEncoder(p, dest, ack_req);
 		return;
@@ -35,7 +36,7 @@ void StructStrategy::Decode(EQApplicationPacket *p) const {
 }
 
 
-void StructStrategy::ErrorEncoder(EQApplicationPacket **in_p, EQStream *dest, bool ack_req) {
+void StructStrategy::ErrorEncoder(EQApplicationPacket **in_p, std::shared_ptr<EQStream> dest, bool ack_req) {
 	EQApplicationPacket *p = *in_p;
 	*in_p = nullptr;
 
@@ -49,7 +50,7 @@ void StructStrategy::ErrorDecoder(EQApplicationPacket *p) {
 	p->SetOpcode(OP_Unknown);
 }
 
-void StructStrategy::PassEncoder(EQApplicationPacket **p, EQStream *dest, bool ack_req) {
+void StructStrategy::PassEncoder(EQApplicationPacket **p, std::shared_ptr<EQStream> dest, bool ack_req) {
 	dest->FastQueuePacket(p, ack_req);
 }
 

--- a/common/struct_strategy.h
+++ b/common/struct_strategy.h
@@ -7,11 +7,12 @@ class EQStream;
 #include "clientversions.h"
 
 #include <string>
+#include <memory>
 
 class StructStrategy {
 public:
 	//the encoder takes ownership of the supplied packet, and may enqueue multiple resulting packets into the stream
-	typedef void (*Encoder)(EQApplicationPacket **p, EQStream *dest, bool ack_req);
+	typedef void(*Encoder)(EQApplicationPacket **p, std::shared_ptr<EQStream> dest, bool ack_req);
 	//the decoder may only edit the supplied packet, producing a single packet for eqemu to consume.
 	typedef void (*Decoder)(EQApplicationPacket *p);
 
@@ -19,7 +20,7 @@ public:
 	virtual ~StructStrategy() {}
 
 	//this method takes an eqemu struct, and enqueues the produced structs into the stream.
-	void Encode(EQApplicationPacket **p, EQStream *dest, bool ack_req) const;
+	void Encode(EQApplicationPacket **p, std::shared_ptr<EQStream> dest, bool ack_req) const;
 	//this method takes an EQ wire struct, and converts it into an eqemu struct
 	void Decode(EQApplicationPacket *p) const;
 
@@ -29,10 +30,10 @@ public:
 protected:
 	//some common coders:
 	//Print an error saying unknown struct/opcode and drop it
-	static void ErrorEncoder(EQApplicationPacket **p, EQStream *dest, bool ack_req);
+	static void ErrorEncoder(EQApplicationPacket **p, std::shared_ptr<EQStream> dest, bool ack_req);
 	static void ErrorDecoder(EQApplicationPacket *p);
 	//pass the packet through without modification (emu == EQ) (default)
-	static void PassEncoder(EQApplicationPacket **p, EQStream *dest, bool ack_req);
+	static void PassEncoder(EQApplicationPacket **p, std::shared_ptr<EQStream> dest, bool ack_req);
 	static void PassDecoder(EQApplicationPacket *p);
 
 	Encoder encoders[_maxEmuOpcode];

--- a/loginserver/client.cpp
+++ b/loginserver/client.cpp
@@ -24,7 +24,7 @@
 extern ErrorLog *server_log;
 extern LoginServer server;
 
-Client::Client(EQStream *c, LSClientVersion v)
+Client::Client(std::shared_ptr<EQStream> c, LSClientVersion v)
 {
 	connection = c;
 	version = v;

--- a/loginserver/client.h
+++ b/loginserver/client.h
@@ -59,7 +59,7 @@ public:
 	/**
 	* Constructor, sets our connection to c and version to v
 	*/
-	Client(EQStream *c, LSClientVersion v);
+	Client(std::shared_ptr<EQStream> c, LSClientVersion v);
 
 	/**
 	* Destructor.
@@ -129,11 +129,11 @@ public:
 	/**
 	* Gets the connection for this client.
 	*/
-	EQStream *GetConnection() { return connection; }
+	std::shared_ptr<EQStream> GetConnection() { return connection; }
 
 	EQEmu::Random random;
 private:
-	EQStream *connection;
+	std::shared_ptr<EQStream> connection;
 	LSClientVersion version;
 	LSClientStatus status;
 

--- a/loginserver/client_manager.cpp
+++ b/loginserver/client_manager.cpp
@@ -94,7 +94,7 @@ ClientManager::~ClientManager()
 void ClientManager::Process()
 {
 	ProcessDisconnect();
-	EQStream *cur = titanium_stream->Pop();
+	std::shared_ptr<EQStream> cur = titanium_stream->Pop();
 	while(cur)
 	{
 		struct in_addr in;
@@ -141,7 +141,7 @@ void ClientManager::ProcessDisconnect()
 	list<Client*>::iterator iter = clients.begin();
 	while(iter != clients.end())
 	{
-		EQStream *c = (*iter)->GetConnection();
+		std::shared_ptr<EQStream> c = (*iter)->GetConnection();
 		if(c->CheckClosed())
 		{
 			server_log->Log(log_network, "Client disconnected from the server, removing client.");

--- a/ucs/clientlist.cpp
+++ b/ucs/clientlist.cpp
@@ -485,7 +485,7 @@ Clientlist::Clientlist(int ChatPort) {
 	}
 }
 
-Client::Client(EQStream *eqs) {
+Client::Client(std::shared_ptr<EQStream> eqs) {
 
 	ClientStream = eqs;
 
@@ -574,7 +574,7 @@ void Clientlist::CheckForStaleConnections(Client *c) {
 
 void Clientlist::Process() {
 
-	EQStream *eqs;
+	std::shared_ptr<EQStream> eqs;
 
 	while((eqs = chatsf->Pop())) {
 

--- a/ucs/clientlist.h
+++ b/ucs/clientlist.h
@@ -84,10 +84,10 @@ struct CharacterEntry {
 class Client {
 
 public:
-	Client(EQStream* eqs);
+	Client(std::shared_ptr<EQStream> eqs);
 	~Client();
 
-	EQStream *ClientStream;
+	std::shared_ptr<EQStream> ClientStream;
 	void AddCharacter(int CharID, const char *CharacterName, int Level);
 	void ClearCharacters() { Characters.clear(); }
 	void SendMailBoxes();

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -102,6 +102,7 @@ Client::~Client() {
 	//let the stream factory know were done with this stream
 	eqs->Close();
 	eqs->ReleaseFromUse();
+	safe_delete(eqs);
 }
 
 void Client::SendLogServer()

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -1069,6 +1069,10 @@ void Client::EnterWorld(bool TryBootup) {
 	if (zoneID == 0)
 		return;
 
+	if(!cle) {
+		return;
+	}
+
 	ZoneServer* zs = nullptr;
 	if(instanceID > 0)
 	{
@@ -1127,7 +1131,6 @@ void Client::EnterWorld(bool TryBootup) {
 	cle->SetChar(charid, char_name);
 	database.UpdateLiveChar(char_name, GetAccountID());
 	Log.Out(Logs::Detail, Logs::World_Server,"%s %s (%d:%d)",seencharsel ? "Entering zone" : "Zoning to",zone_name,zoneID,instanceID);
-//	database.SetAuthentication(account_id, char_name, zone_name, ip);
 
 	if (seencharsel) {
 		if (GetAdmin() < 80 && zoneserver_list.IsZoneLocked(zoneID)) {

--- a/world/client.h
+++ b/world/client.h
@@ -109,7 +109,7 @@ private:
 	bool HandleDeleteCharacterPacket(const EQApplicationPacket *app);
 	bool HandleZoneChangePacket(const EQApplicationPacket *app);
 
-	EQStreamInterface* const eqs;
+	EQStreamInterface* eqs;
 };
 
 bool CheckCharCreateInfoSoF(CharCreate_Struct *cc);

--- a/world/net.cpp
+++ b/world/net.cpp
@@ -394,7 +394,7 @@ int main(int argc, char** argv) {
 	Timer InterserverTimer(INTERSERVER_TIMER); // does MySQL pings and auto-reconnect
 	InterserverTimer.Trigger();
 	uint8 ReconnectCounter = 100;
-	EQStream* eqs;
+	std::shared_ptr<EQStream> eqs;
 	EmuTCPConnection* tcpc;
 	EQStreamInterface *eqsi;
 
@@ -411,6 +411,8 @@ int main(int argc, char** argv) {
 			Log.Out(Logs::General, Logs::World_Server, "New connection from %s:%d", inet_ntoa(in),ntohs(eqs->GetRemotePort()));
 			stream_identifier.AddStream(eqs);	//takes the stream
 		}
+
+		eqs = nullptr;
 
 		//give the stream identifier a chance to do its work....
 		stream_identifier.Process();

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -402,6 +402,7 @@ Client::~Client() {
 	//let the stream factory know were done with this stream
 	eqs->Close();
 	eqs->ReleaseFromUse();
+	safe_delete(eqs);
 
 	UninitializeBuffSlots();
 }

--- a/zone/client.h
+++ b/zone/client.h
@@ -64,6 +64,7 @@ struct Item_Struct;
 #include <float.h>
 #include <set>
 #include <algorithm>
+#include <memory>
 
 
 #define CLIENT_TIMEOUT 90000
@@ -201,7 +202,7 @@ struct ClientReward
 
 class ClientFactory {
 public:
-	Client *MakeClient(EQStream* ieqs);
+	Client *MakeClient(std::shared_ptr<EQStream> ieqs);
 };
 
 class Client : public Mob

--- a/zone/net.cpp
+++ b/zone/net.cpp
@@ -332,7 +332,7 @@ int main(int argc, char** argv) {
 	Timer quest_timers(100);
 	UpdateWindowTitle();
 	bool worldwasconnected = worldserver.Connected();
-	EQStream* eqss;
+	std::shared_ptr<EQStream> eqss;
 	EQStreamInterface *eqsi;
 	uint8 IDLEZONEUPDATE = 200;
 	uint8 ZONEUPDATE = 10;


### PR DESCRIPTION
Found it addresses many seg faults found with the old eqstream code. PEQ went from 2-5 net related crashes a day to 0.

Still retains the sorta shared ptrish code that it had built into the stream, I plan to remove that in a future experiment but for now it's basically harmless.

Will merge it if I don't find any issue by tomorrow.