### PR TITLE
Added new rule to make the UnmemSpellAll on death optional.

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -102,6 +102,7 @@ RULE_INT ( Character, BaseInstrumentSoftCap, 36) // Softcap for instrument mods,
 RULE_INT ( Character, BaseRunSpeedCap, 158) // Base Run Speed Cap, on live it's 158% which will give you a runspeed of 1.580 hard capped to 225.
 RULE_INT ( Character, OrnamentationAugmentType, 20) //Ornamentation Augment Type
 RULE_REAL(Character, EnvironmentDamageMulipliter, 1)
+RULE_BOOL(Character, UnmemSpellsOnDeath, true)
 RULE_CATEGORY_END()
 
 RULE_CATEGORY( Mercs )

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1584,10 +1584,12 @@ bool Client::Death(Mob* killerMob, int32 damage, uint16 spell, SkillUseTypes att
 
 		//this generates a lot of 'updates' to the client that the client does not need
 		BuffFadeNonPersistDeath();
-		if((GetClientVersionBit() & BIT_SoFAndLater) && RuleB(Character, RespawnFromHover))
-			UnmemSpellAll(true);
-		else
-			UnmemSpellAll(false);
+		if (RuleB(Character, UnmemSpellsOnDeath)) {
+			if((GetClientVersionBit() & BIT_SoFAndLater) && RuleB(Character, RespawnFromHover))
+				UnmemSpellAll(true);
+			else
+				UnmemSpellAll(false);
+		}
 
 		if((RuleB(Character, LeaveCorpses) && GetLevel() >= RuleI(Character, DeathItemLossLevel)) || RuleB(Character, LeaveNakedCorpses))
 		{


### PR DESCRIPTION
 - New Rule: Character:UnmemSpellsOnDeath (default true)