### PR TITLE
Fix to allow for PBAE/Targeted AE spells to check the 'npc_no_los' field...

### DIFF
--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -749,9 +749,9 @@ void EntityList::AESpell(Mob *caster, Mob *center, uint16 spell_id, bool affect_
 		if (bad) {
 			if (!caster->IsAttackAllowed(curmob, true))
 				continue;
-			if (center && !center->CheckLosFN(curmob))
+			if (center &&  !spells[spell_id].npc_no_los && !center->CheckLosFN(curmob))
 				continue;
-			if (!center && !caster->CheckLosFN(caster->GetTargetRingX(), caster->GetTargetRingY(), caster->GetTargetRingZ(), curmob->GetSize()))
+			if (!center && !spells[spell_id].npc_no_los && !caster->CheckLosFN(caster->GetTargetRingX(), caster->GetTargetRingY(), caster->GetTargetRingZ(), curmob->GetSize()))
 				continue;
 		} else { // check to stop casting beneficial ae buffs (to wit: bard songs) on enemies...
 			// This does not check faction for beneficial AE buffs..only agro and attackable.


### PR DESCRIPTION
... in spell file

to disable LOS checks.