### PR TITLE
Calc focus effects from worn slots, for an additive foci bonus [NOT LIVE LIKE]

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -329,6 +329,7 @@ RULE_BOOL ( Spells, Jun182014HundredHandsRevamp, false) // this should be true f
 RULE_BOOL ( Spells, SwarmPetTargetLock, false) // Use old method of swarm pets target locking till target dies then despawning.
 RULE_BOOL ( Spells, NPC_UseFocusFromSpells, true) // Allow npcs to use most spell derived focus effects.
 RULE_BOOL ( Spells, NPC_UseFocusFromItems, false) // Allow npcs to use most item derived focus effects.
+RULE_BOOL ( Spells, UseAdditiveFocusFromWornSlot, false) // Allows an additive focus effect to be calculated from worn slot.
 RULE_CATEGORY_END()
 
 RULE_CATEGORY( Combat )

--- a/utils/sql/git/optional/2015_2_5_UseAdditiveFocusFromWornSlot.sql
+++ b/utils/sql/git/optional/2015_2_5_UseAdditiveFocusFromWornSlot.sql
@@ -1,0 +1,1 @@
+INSERT INTO `rule_values` (`ruleset_id`, `rule_name`, `rule_value`, `notes`) VALUES (1, 'Spells:UseAdditiveFocusFromWornSlot', 'false', '[Not live like] If a focus effect is placed in a worn slot the base value will calculated as an additive bonus to regular focus effects.');

--- a/zone/common.h
+++ b/zone/common.h
@@ -350,7 +350,8 @@ struct StatBonuses {
 	int32	CharmBreakChance;					// chance to break charm
 	int32	SongRange;							// increases range of beneficial bard songs
 	uint32	HPToManaConvert;					// Uses HP to cast spells at specific conversion
-	uint32	FocusEffects[HIGHEST_FOCUS+1];		// Stores the focus effectid for each focustype you have.
+	uint8	FocusEffects[HIGHEST_FOCUS+1];		// Stores the focus effectid for each focustype you have.
+	int16	FocusEffectsWorn[HIGHEST_FOCUS+1];	// Optional to allow focus effects to be applied additively from worn slot
 	bool	NegateEffects;						// Check if you contain a buff with negate effect. (only spellbonuses)
 	int32	SkillDamageAmount2[HIGHEST_SKILL+2];	// Adds skill specific damage
 	uint32	NegateAttacks[3];					// 0 = bool HasEffect 1 = Buff Slot 2 = Max damage absorbed per hit

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -194,7 +194,7 @@ public:
 	bool IsBeneficialAllowed(Mob *target);
 	virtual int GetCasterLevel(uint16 spell_id);
 	void ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses* newbon, uint16 casterID = 0,
-		bool item_bonus = false, uint32 ticsremaining = 0, int buffslot = -1,
+		bool item_bonus = false, bool IsWornEffect = false, uint32 ticsremaining = 0, int buffslot = -1,
 		bool IsAISpellEffect = false, uint16 effect_id = 0, int32 se_base = 0, int32 se_limit = 0, int32 se_max = 0);
 	void NegateSpellsBonuses(uint16 spell_id);
 	virtual float GetActSpellRange(uint16 spell_id, float range, bool IsBard = false);

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -5527,7 +5527,12 @@ int16 Client::GetFocusEffect(focusType type, uint16 spell_id) {
 	//Summon Spells that require reagents are typically imbue type spells, enchant metal, sacrifice and shouldn't be affected
 	//by reagent conservation for obvious reasons.
 
-	return realTotal + realTotal2 + realTotal3;
+	//Non-Live like feature to allow for an additive focus bonus to be applied from foci that are placed in worn slot. (No limit checks)
+	int16 worneffect_bonus = 0;
+	if (RuleB(Spells, UseAdditiveFocusFromWornSlot))
+		worneffect_bonus = itembonuses.FocusEffectsWorn[type];
+
+	return realTotal + realTotal2 + realTotal3 + worneffect_bonus;
 }
 
 int16 NPC::GetFocusEffect(focusType type, uint16 spell_id) {


### PR DESCRIPTION
Implemented non-live like feature to allow focus effects to be placed in worn slot
to provide an additive focus bonus that stacks with regular focus effects.
This is opposed to how regular focus effects work in which the highest
value is always taken. Please note, focus calculated from worn slot
will only use only the focuses base value (ie ignores all limit checks).

Example (Hypothetical).
Improved Heal I (10 pct focus) in Helm Worn Slot
Improved Heal I (10 pct focus) in Glove Worn Slot
Improved Heal V (50 pct focus) in Glove Focus Slot
Total Heal Focus would be 50 + 10 + 10

Added optional rule which is OFF by default.
UseAdditiveFocusFromWornSlot