### PR TITLE
Optional additive worn effect bonus rule 

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -300,7 +300,7 @@ RULE_INT ( Spells, MaxCastTimeReduction, 50) //Max percent your spell cast time 
 RULE_INT ( Spells, RootBreakFromSpells, 55) //Chance for root to break when cast on.
 RULE_INT ( Spells, DeathSaveCharismaMod, 3) //Determines how much charisma effects chance of death save firing.
 RULE_INT ( Spells, DivineInterventionHeal, 8000) //Divine intervention heal amount.
-RULE_BOOL ( Spells, AdditiveBonusValues, false) //Allow certain bonuses to be calculated by adding together the value from each item, instead of taking the highest value. (ie Add together all Cleave Effects)
+RULE_INT ( Spells, AdditiveBonusWornType, 0) //Calc worn bonuses to add together (instead of taking highest) if set to THIS worn type. (2=Will covert live items automatically)
 RULE_BOOL ( Spells, UseCHAScribeHack, false) //ScribeSpells and TrainDiscs quest functions will ignore entries where field 12 is CHA.  What's the best way to do this?
 RULE_BOOL ( Spells, BuffLevelRestrictions, true) //Buffs will not land on low level toons like live
 RULE_INT ( Spells, RootBreakCheckChance, 70) //Determines chance for a root break check to occur each buff tick.

--- a/utils/sql/git/optional/2015_2_6_AdditiveBonusWornType.sql
+++ b/utils/sql/git/optional/2015_2_6_AdditiveBonusWornType.sql
@@ -1,0 +1,4 @@
+INSERT INTO `rule_values` (`ruleset_id`, `rule_name`, `rule_value`, `notes`) VALUES (1, 'Spells:AdditiveBonusWornType', '0', 'Calcs worn bonuses to add together (instead of taking highest) if item set to THIS worn type. Will stack with regular worn bonuses. (2=Will cause all live items to use this behavior)');
+
+-- This is no longer used - Set the above value equal to 2 to achieve the same effect.
+DELETE FROM `rule_values` WHERE rule_name LIKE "Spells:AdditiveBonusValues";

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -10959,7 +10959,7 @@ void Bot::CalcItemBonuses()
 						}
 					}
 					if ((itemtmp->Worn.Effect != 0) && (itemtmp->Worn.Type == ET_WornEffect)) { // latent effects
-						ApplySpellsBonuses(itemtmp->Worn.Effect, itemtmp->Worn.Level, &itembonuses);
+						ApplySpellsBonuses(itemtmp->Worn.Effect, itemtmp->Worn.Level, &itembonuses,0,itemtmp->Worn.Type);
 					}
 				}
 			}
@@ -11043,7 +11043,7 @@ void Bot::CalcItemBonuses()
 				}
 			}
 			if ((itemtmp->Worn.Effect != 0) && (itemtmp->Worn.Type == ET_WornEffect)) { // latent effects
-				ApplySpellsBonuses(itemtmp->Worn.Effect, itemtmp->Worn.Level, &itembonuses);
+				ApplySpellsBonuses(itemtmp->Worn.Effect, itemtmp->Worn.Level, &itembonuses,0,itemtmp->Worn.Type);
 			}
 		}
 	}

--- a/zone/client.h
+++ b/zone/client.h
@@ -1257,6 +1257,7 @@ protected:
 	friend class Mob;
 	void CalcItemBonuses(StatBonuses* newbon);
 	void AddItemBonuses(const ItemInst *inst, StatBonuses* newbon, bool isAug = false, bool isTribute = false);
+	void AdditiveWornBonuses(const ItemInst *inst, StatBonuses* newbon, bool isAug = false);
 	int CalcRecommendedLevelBonus(uint8 level, uint8 reclevel, int basestat);
 	void CalcEdibleBonuses(StatBonuses* newbon);
 	void CalcAABonuses(StatBonuses* newbon);

--- a/zone/merc.cpp
+++ b/zone/merc.cpp
@@ -449,11 +449,11 @@ void Merc::AddItemBonuses(const Item_Struct *item, StatBonuses* newbon) {
 			newbon->DSMitigation += item->DSMitigation;
 	}
 	if (item->Worn.Effect>0 && (item->Worn.Type == ET_WornEffect)) { // latent effects
-		ApplySpellsBonuses(item->Worn.Effect, item->Worn.Level, newbon, 0, true);
+		ApplySpellsBonuses(item->Worn.Effect, item->Worn.Level, newbon, 0, item->Worn.Type);
 	}
 
 	if (item->Focus.Effect>0 && (item->Focus.Type == ET_Focus)) { // focus effects
-		ApplySpellsBonuses(item->Focus.Effect, item->Focus.Level, newbon, 0, true);
+		ApplySpellsBonuses(item->Focus.Effect, item->Focus.Level, newbon, 0);
 	}
 
 	switch(item->BardType)

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -194,7 +194,7 @@ public:
 	bool IsBeneficialAllowed(Mob *target);
 	virtual int GetCasterLevel(uint16 spell_id);
 	void ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses* newbon, uint16 casterID = 0,
-		bool item_bonus = false, bool IsWornEffect = false, uint32 ticsremaining = 0, int buffslot = -1,
+		uint8 WornType = 0, uint32 ticsremaining = 0, int buffslot = -1,
 		bool IsAISpellEffect = false, uint16 effect_id = 0, int32 se_base = 0, int32 se_limit = 0, int32 se_max = 0);
 	void NegateSpellsBonuses(uint16 spell_id);
 	virtual float GetActSpellRange(uint16 spell_id, float range, bool IsBard = false);

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -2559,7 +2559,7 @@ void NPC::ApplyAISpellEffects(StatBonuses* newbon)
 
 	for(int i=0; i < AIspellsEffects.size(); i++)
 	{
-		ApplySpellsBonuses(0, 0, newbon, 0, false, 0,-1,
+		ApplySpellsBonuses(0, 0, newbon, 0, 0, 0,-1,
 			true, AIspellsEffects[i].spelleffectid,  AIspellsEffects[i].base, AIspellsEffects[i].limit,AIspellsEffects[i].max);
 	}
 


### PR DESCRIPTION
Implemented a better method for developers who want to have additive
worn bonuses than what was prior implemented.

Removed old rule RuleB(Spells, AdditiveBonusValues) [IF YOU USED SET NEW RULE = 2]

Replaced with new rule RuleI(AdditiveBonusWornType) 

The rule value denotes a specific 'worntype' that is to be
checked on items. If the items 'worntype' matches the rules worntype
then any worn effect on that item will be cacluated additively
instead of taking the highest value. This will also stack with
regular worn effects that take highest value. Unless the value
is set to (2) which is what all live items use. If set to 2 then
all worn effects will be calculated additively (same as what the old
rule did).

In laymans terms. You can take 3 Cleave I items and put them on a character
and they will all add together if you set the worn type = 3 and the rule = 3.
Which would also add to any regular cleave set to worn type = 2.

Hope you enjoyed the novel.