### PR TITLE
A non magical weapon with an augment tagged as magic now hits as magic

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -908,6 +908,7 @@ int Mob::GetWeaponDamage(Mob *against, const ItemInst *weapon_item, uint32 *hate
 {
 	int dmg = 0;
 	int banedmg = 0;
+	int x = 0;
 
 	if(!against || against->GetInvul() || against->GetSpecialAbility(IMMUNE_MELEE)){
 		return 0;
@@ -936,10 +937,20 @@ int Mob::GetWeaponDamage(Mob *against, const ItemInst *weapon_item, uint32 *hate
 			bool MagicWeapon = false;
 			if(weapon_item->GetItem() && weapon_item->GetItem()->Magic)
 				MagicWeapon = true;
-			else {
+			else 
 				if(spellbonuses.MagicWeapon || itembonuses.MagicWeapon)
 					MagicWeapon = true;
-			}
+				else 
+					// An augment on the weapon that is marked magic makes
+					// the item magical.
+					for(x = 0; MagicWeapon == false && x < EmuConstants::ITEM_COMMON_SIZE; x++)
+					{
+						if(weapon_item->GetAugment(x) && weapon_item->GetAugment(x)->GetItem())
+						{
+							if (weapon_item->GetAugment(x)->GetItem()->Magic)
+								MagicWeapon = true;
+						}
+					}
 
 			if(MagicWeapon) {
 


### PR DESCRIPTION
When a non magical weapon has an augment placed on it that is tagged as magic, the GUI shows the new adjusted weapon as magical but it still cannot hit a mob that requires a magic weapon.

This change makes the weapon behave as magical after an aug marked as magic is applied in combat.

Ex: It can now hit a willowisp.

I'm not 100% sure of this behavior on live (which augs are marked magical) but this seems quite reasonable.