### PR TITLE
Repair unwanted buff side effects from BuffFadeStruct.  Repair buff formula 11.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,24 @@
 EQEMu Changelog (Started on Sept 24, 2003 15:50)
 -------------------------------------------------------
+== 03/10/2015 ==
+Buff Duration Formula 11.  I noticed this was giving incorect results for 
+a bunch of low level spells.  11 was setting the duration to max duration.
+This seemed to match Zam for a bunch of low level spells, but does not match
+what the client thinks.  I asked in channels and demonstar indicated a formula
+of (level +3) * 30 was what the GUI has been using since 2003.  I changes the
+code to match this and all the low level spells I was seeing wrong were all
+fixed.
+
+Changed the code that updates buff duration once after a cast for focus effects
+to send an arbitrary latge value for the effect field.  Previosuly level was
+sent and it caused very odd behaviour on some spells like lesser shielding
+where it would actually adjust max HP when the packet arrived at the GUI.  I
+tried to figure out what the effect field should be by trying various values,
+diff levels to se if it was effective level, effect desc num to see if that
+was expected, etc.  Found no meaningful value that didnt have side effects. By
+sending this large value all my side effects went away, but the diration updated
+correctly.
+
 == 03/04/2015 ==
 Akkadius: Fix Spell Book Deletion
 

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -2672,7 +2672,8 @@ int CalcBuffDuration_formula(int level, int formula, int duration)
 			return i < duration ? (i < 1 ? 1 : i) : duration;
 
 		case 11:
-			return duration;
+			// Change to match client.
+			return std::min((level+3) * 30,duration);
 
 		case 12:
 			return duration;
@@ -5247,6 +5248,7 @@ void Mob::_StopSong()
 void Client::SendBuffDurationPacket(Buffs_Struct &buff)
 {
 	EQApplicationPacket* outapp;
+	
 	outapp = new EQApplicationPacket(OP_Buff, sizeof(SpellBuffFade_Struct));
 	SpellBuffFade_Struct* sbf = (SpellBuffFade_Struct*) outapp->pBuffer;
 
@@ -5254,7 +5256,9 @@ void Client::SendBuffDurationPacket(Buffs_Struct &buff)
 	sbf->slot = 2;
 	sbf->spellid = buff.spellid;
 	sbf->slotid = 0;
-	sbf->effect = buff.casterlevel > 0 ? buff.casterlevel : GetLevel();
+	sbf->effect = 255;
+//	sbf->effect = spells[buff.spellid].effectdescnum;
+//	sbf->effect = buff.casterlevel > 0 ? buff.casterlevel : GetLevel();
 	sbf->level = buff.casterlevel > 0 ? buff.casterlevel : GetLevel();
 	sbf->bufffade = 0;
 	sbf->duration = buff.ticsremaining;


### PR DESCRIPTION
Changelog pretty much says it all.  I can see how these could both have large impacts if I am wrong about these.  They've bene working fine for me for about a week, but I have a tiny player base.

+Buff Duration Formula 11. I noticed this was giving incorect results for
+a bunch of low level spells. 11 was setting the duration to max duration.
+This seemed to match Zam for a bunch of low level spells, but does not match
+what the client thinks. I asked in channels and demonstar indicated a formula
+of (level +3) * 30 was what the GUI has been using since 2003. I change\d the
+code to match this and all the low level spells I was seeing wrong were all
+fixed.
+
+Changed the code that updates buff duration once after a cast for focus effects
+to send an arbitrary latge value for the effect field. Previosuly level was
+sent and it caused very odd behaviour on some spells like lesser shielding
+where it would actually adjust max HP when the packet arrived at the GUI. I
+tried to figure out what the effect field should be by trying various values,
+diff levels to se if it was effective level, effect desc num to see if that
+was expected, etc. Found no meaningful value that didnt have side effects. By
+sending this large value all my side effects went away, but the diration updated
+correctly.