### PR TITLE
Added individual tradeskill skillup settings rules

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -103,6 +103,16 @@ RULE_INT ( Character, BaseRunSpeedCap, 158) // Base Run Speed Cap, on live it's 
 RULE_INT ( Character, OrnamentationAugmentType, 20) //Ornamentation Augment Type
 RULE_REAL(Character, EnvironmentDamageMulipliter, 1)
 RULE_BOOL(Character, UnmemSpellsOnDeath, true)
+RULE_INT ( Character, TradeskillUpAlchemy, 2 ) // Alchemy skillup rate adjust. Lower is faster.
+RULE_INT ( Character, TradeskillUpBaking, 2 ) // Baking skillup rate adjust. Lower is faster.
+RULE_INT ( Character, TradeskillUpBlacksmithing, 2 ) // Blacksmithing skillup rate adjust. Lower is faster.
+RULE_INT ( Character, TradeskillUpBrewing, 3 ) // Brewing skillup rate adjust. Lower is faster.
+RULE_INT ( Character, TradeskillUpFletching, 2 ) // Fletching skillup rate adjust. Lower is faster.
+RULE_INT ( Character, TradeskillUpJewelcrafting, 2 ) // Jewelcrafting skillup rate adjust. Lower is faster.
+RULE_INT ( Character, TradeskillUpMakePoison, 2 ) // Make Poison skillup rate adjust. Lower is faster.
+RULE_INT ( Character, TradeskillUpPottery, 4 ) // Pottery skillup rate adjust. Lower is faster.
+RULE_INT ( Character, TradeskillUpResearch, 1 ) // Research skillup rate adjust. Lower is faster.
+RULE_INT ( Character, TradeskillUpTinkering, 2 ) // Tinkering skillup rate adjust. Lower is faster.
 RULE_CATEGORY_END()
 
 RULE_CATEGORY( Mercs )

--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -848,24 +848,41 @@ bool Client::TradeskillExecute(DBTradeskillRecipe_Struct *spec) {
 	// Some tradeskills are more eqal then others. ;-)
 	// If you want to customize the stage1 success rate do it here.
 	// Remember: skillup_modifier is (float). Lower is better
-	switch(spec->tradeskill) {
-	case SkillFletching:
-	case SkillAlchemy:
-	case SkillJewelryMaking:
-	case SkillPottery:
-		skillup_modifier = 4;
-		break;
-	case SkillBaking:
-	case SkillBrewing:
-		skillup_modifier = 3;
-		break;
-	case SkillResearch:
-		skillup_modifier = 1;
-		break;
-	default:
-		skillup_modifier = 2;
-		break;
-	}
+        switch(spec->tradeskill) {
+        case SkillFletching:
+                skillup_modifier = RuleI(Character, TradeskillUpFletching);
+                break;
+        case SkillAlchemy:
+                skillup_modifier = RuleI(Character, TradeskillUpAlchemy);
+                break;
+        case SkillJewelryMaking:
+                skillup_modifier = RuleI(Character, TradeskillUpJewelcrafting);
+                break;
+        case SkillPottery:
+                skillup_modifier = RuleI(Character, TradeskillUpPottery);
+                break;
+        case SkillBaking:
+                skillup_modifier = RuleI(Character, TradeskillUpBaking);
+                break;
+        case SkillBrewing:
+                skillup_modifier = RuleI(Character, TradeskillUpBrewing);
+                break;
+        case SkillBlacksmithing:
+                skillup_modifier = RuleI(Character, TradeskillUpBlacksmithing);
+                break;
+        case SkillResearch:
+                skillup_modifier = RuleI(Character, TradeskillUpResearch);
+                break;
+        case SkillMakePoison:
+                skillup_modifier = RuleI(Character, TradeskillUpMakePoison);
+                break;
+        case SkillTinkering:
+                skillup_modifier = RuleI(Character, TradeskillUpTinkering);
+                break;
+        default:
+                skillup_modifier = 2;
+                break;
+        }
 
 	// Some tradeskills take the higher of one additional stat beside INT and WIS
 	// to determine the skillup rate. Additionally these tradeskills do not have an


### PR DESCRIPTION
This allows for adjusting each individual skillup rate for a tradeskill without needing to recompile. Database rules added:

Character:TradeskillUpAlchemy
Character:TradeskillUpBaking
Character:TradeskillUpBlacksmithing
Character:TradeskillUpBrewing
Character:TradeskillUpFletching
Character:TradeskillUpJewelcrafting
Character:TradeskillUpMakePoison
Character:TradeskillUpPottery
Character:TradeskillUpResearch
Character:TradeskillUpTinkering