### PR TITLE
Mobs that were blinded were being included in every use of IsFeared() 

### DIFF
--- a/zone/mob.h
+++ b/zone/mob.h
@@ -803,8 +803,7 @@ public:
 	//old fear function
 	//void SetFeared(Mob *caster, uint32 duration, bool flee = false);
 	float GetFearSpeed();
-	bool IsFeared() { return curfp; } // This returns true if the mob is feared or fleeing due to low HP
-	//old fear: inline void StartFleeing() { SetFeared(GetHateTop(), FLEE_RUN_DURATION, true); }
+	bool IsFeared() { return (spellbonuses.IsFeared || flee_mode); } // This returns true if the mob is feared or fleeing due to low HP
 	inline void StartFleeing() { flee_mode = true; CalculateNewFearpoint(); }
 	void ProcessFlee();
 	void CheckFlee();


### PR DESCRIPTION
Blinded mobs were being rolled into every use of IsFeared.  As I added the blind stuff into fear logic, that was an oversight.  I think this new macro makes more sense.  My testing looks good, but this is wide sweeping so I;d appreciate any feedback on impacts people think is wrong.  It should behave like it did before I added blind, so I feel ok.