### PR TITLE
Beginnings of fix to SendBuffDuration.

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -5259,8 +5259,31 @@ void Client::SendBuffDurationPacket(Buffs_Struct &buff)
 	sbf->slot = 2;
 	sbf->spellid = buff.spellid;
 	sbf->slotid = 0;
-	sbf->effect = 255;
 	sbf->level = buff.casterlevel > 0 ? buff.casterlevel : GetLevel();
+
+	if (IsEffectInSpell(buff.spellid, SE_TotalHP))
+	{
+		// If any of the lower 6 bits are set, the GUI changes MAX_HP AGAIN.
+		// If its set to 0 the effect is cancelled.  
+		// 128 seems to work (ie: change only duration).
+		sbf->effect = 128;
+	}
+	else if (IsEffectInSpell(buff.spellid, SE_CurrentHP))
+	{
+		// This is mostly a problem when we try and update duration on a
+		// dot or a hp->mana conversion.  Zero cancels the effect, any
+		// other value has the GUI doing that value at the same time server
+		// is doing theirs.  This makes the two match.
+		int index = GetSpellEffectIndex(buff.spellid, SE_CurrentHP);
+		sbf->effect = abs(spells[buff.spellid].base[index]);
+	}
+	else
+	{
+		// Default to what old code did until we find a better fix for
+		// other spell lines.
+		sbf->effect=sbf->level;
+	}
+
 	sbf->bufffade = 0;
 	sbf->duration = buff.ticsremaining;
 	sbf->num_hits = buff.numhits;


### PR DESCRIPTION
When we update the duration on a spell (because of focus or AA, etc) we send a packet to the client with the intent of only changing the duration.

One of the fields, effect, is not completely understood.  Older code tried using caster_level, but that hosed up max HP on spells that had a max_hp effect.  I made changes to try other values.  255 seemed to be ok, so I used that for a time.  However, 255 does not work on some DOTS, in fact it makes them very erratic.

My testing has yielded this code, which starts to specifically address values for effect that work for various spell types.  I've tested this and it seems much better for the two types I listed in the routine.  I'll make a note to start looking for other problems this routine causes and map out what needs to be done.

This patch makes the code better for the most obvious two issues.