### PR TITLE
The mob AT_Anim (as set in spawn2) was not working in some cases.

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -619,6 +619,7 @@ void EntityList::AddNPC(NPC *npc, bool SendSpawnPacket, bool dontqueue)
 			npc->CreateSpawnPacket(app, npc);
 			QueueClients(npc, app);
 			npc->SendArmorAppearance();
+			npc->SetAppearance(npc->GetGuardPointAnim(),false);
 			safe_delete(app);
 		} else {
 			NewSpawn_Struct *ns = new NewSpawn_Struct;
@@ -737,6 +738,7 @@ void EntityList::CheckSpawnQueue()
 			auto it = npc_list.find(ns->spawn.spawnId);
 			NPC *pnpc = it->second;
 			pnpc->SendArmorAppearance();
+			pnpc->SetAppearance(pnpc->GetGuardPointAnim(),false);
 			safe_delete(outapp);
 			iterator.RemoveCurrent();
 		}

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -2040,12 +2040,10 @@ const int32& Mob::SetMana(int32 amount)
 
 
 void Mob::SetAppearance(EmuAppearance app, bool iIgnoreSelf) {
-	if (_appearance != app) {
-		_appearance = app;
-		SendAppearancePacket(AT_Anim, GetAppearanceValue(app), true, iIgnoreSelf);
-		if (this->IsClient() && this->IsAIControlled())
-			SendAppearancePacket(AT_Anim, ANIM_FREEZE, false, false);
-	}
+	_appearance = app;
+	SendAppearancePacket(AT_Anim, GetAppearanceValue(app), true, iIgnoreSelf);
+	if (this->IsClient() && this->IsAIControlled())
+		SendAppearancePacket(AT_Anim, ANIM_FREEZE, false, false);
 }
 
 bool Mob::UpdateActiveLight()


### PR DESCRIPTION
First, the set function for mob _appearance optimized by not sending a message
if the new appearance was equal to the old.  This can't be done, as
the 1st time the zone runs there is no client when the set function is
called.  If we're combining set/send, as we are, better to always do both.  This fixes several of the cases.

Repop also did not work, as no code was being called reliably to set
appearance and update the client based on code path and various flags.  This is also fixed.