### PR TITLE
Fully implemented QuestReward.  (credit to Cavedude on EQMacEmu)

### DIFF
--- a/common/eq_packet_structs.h
+++ b/common/eq_packet_structs.h
@@ -2154,24 +2154,24 @@ struct Illusion_Struct_Old {
 // OP_Sound - Size: 68
 struct QuestReward_Struct
 {
-/*000*/ uint32	from_mob;	// ID of mob awarding the client
-/*004*/ uint32	unknown004;
-/*008*/ uint32	unknown008;
-/*012*/ uint32	unknown012;
-/*016*/ uint32	unknown016;
-/*020*/ uint32	unknown020;
-/*024*/ uint32	silver;		// Gives silver to the client
-/*028*/ uint32	gold;		// Gives gold to the client
-/*032*/ uint32	platinum;	// Gives platinum to the client
-/*036*/ uint32	unknown036;
-/*040*/ uint32	unknown040;
-/*044*/ uint32	unknown044;
-/*048*/ uint32	unknown048;
-/*052*/ uint32	unknown052;
-/*056*/ uint32	unknown056;
-/*060*/ uint32	unknown060;
-/*064*/ uint32	unknown064;
-/*068*/
+	/*000*/ uint32	mob_id;	// ID of mob awarding the client
+	/*004*/ uint32	target_id;
+	/*008*/ uint32	exp_reward;
+	/*012*/ uint32	faction;
+	/*016*/ int32	faction_mod;
+	/*020*/ uint32	copper;		// Gives copper to the client
+	/*024*/ uint32	silver;		// Gives silver to the client
+	/*028*/ uint32	gold;		// Gives gold to the client
+	/*032*/ uint32	platinum;	// Gives platinum to the client
+	/*036*/ uint32	item_id;
+	/*040*/ uint32	unknown040;
+	/*044*/ uint32	unknown044;
+	/*048*/ uint32	unknown048;
+	/*052*/ uint32	unknown052;
+	/*056*/ uint32	unknown056;
+	/*060*/ uint32	unknown060;
+	/*064*/ uint32	unknown064;
+	/*068*/
 };
 
 // Size: 8

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -8584,3 +8584,36 @@ bool Client::TextLink::GenerateLinkBody(std::string& textLinkBody, const TextLin
 	if (textLinkBody.length() != EmuConstants::TEXT_LINK_BODY_LENGTH) { return false; }
 	return true;
 }
+
+void Client::QuestReward(Mob* target, uint32 copper, uint32 silver, uint32 gold, uint32 platinum, uint32 itemid, uint32 exp, uint32 factionid, int32 faction) {
+
+	EQApplicationPacket* outapp = new EQApplicationPacket(OP_Sound, sizeof(QuestReward_Struct));
+	memset(outapp->pBuffer, 0, sizeof(outapp->pBuffer));
+	QuestReward_Struct* qr = (QuestReward_Struct*)outapp->pBuffer;
+
+	qr->mob_id = target->GetID();		// Entity ID for the from mob name
+	qr->target_id = GetID();			// The Client ID (this)
+	qr->copper = copper;
+	qr->silver = silver;
+	qr->gold = gold;
+	qr->platinum = platinum;
+	qr->item_id = itemid;
+	qr->exp_reward = exp;
+	qr->faction = factionid;
+	qr->faction_mod = faction;
+
+	if (copper > 0 || silver > 0 || gold > 0 || platinum > 0)
+		AddMoneyToPP(copper, silver, gold, platinum, false);
+
+	if (itemid > 0)
+		SummonItem(itemid, 0, 0, 0, 0, 0, 0, false, MainPowerSource);
+
+	if (exp > 0)
+		AddEXP(exp);
+
+	if (factionid > 0)
+		SetFactionLevel2(CharacterID(), factionid, GetClass(), GetBaseRace(), GetDeity(), faction, 0);
+
+	QueuePacket(outapp, false, Client::CLIENT_CONNECTED);
+	safe_delete(outapp);
+}

--- a/zone/client.h
+++ b/zone/client.h
@@ -1254,6 +1254,7 @@ public:
 	virtual int32 Tune_GetMeleeMitDmg(Mob* GM, Mob *attacker, int32 damage, int32 minhit, float mit_rating, float atk_rating);
 	int32 GetMeleeDamage(Mob* other, bool GetMinDamage = false);
 
+	void QuestReward(Mob* target, uint32 copper = 0, uint32 silver = 0, uint32 gold = 0, uint32 platinum = 0, uint32 itemid = 0, uint32 exp = 0, uint32 factionid = 0, int32 faction = 0);
 protected:
 	friend class Mob;
 	void CalcItemBonuses(StatBonuses* newbon);

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -1255,6 +1255,46 @@ void Lua_Client::PlayMP3(std::string file)
 	self->PlayMP3(file.c_str());
 }
 
+void Lua_Client::QuestReward(Lua_Mob target) {
+	Lua_Safe_Call_Void();
+	self->QuestReward(target);
+}
+
+void Lua_Client::QuestReward(Lua_Mob target, uint32 copper) {
+	Lua_Safe_Call_Void();
+	self->QuestReward(target, copper);
+}
+
+void Lua_Client::QuestReward(Lua_Mob target, uint32 copper, uint32 silver) {
+	Lua_Safe_Call_Void();
+	self->QuestReward(target, copper, silver);
+}
+
+void Lua_Client::QuestReward(Lua_Mob target, uint32 copper, uint32 silver, uint32 gold) {
+	Lua_Safe_Call_Void();
+	self->QuestReward(target, copper, silver, gold);
+}
+
+void Lua_Client::QuestReward(Lua_Mob target, uint32 copper, uint32 silver, uint32 gold, uint32 platinum) {
+	Lua_Safe_Call_Void();
+	self->QuestReward(target, copper, silver, gold, platinum);
+}
+
+void Lua_Client::QuestReward(Lua_Mob target, uint32 copper, uint32 silver, uint32 gold, uint32 platinum, uint32 itemid) {
+	Lua_Safe_Call_Void();
+	self->QuestReward(target, copper, silver, gold, platinum, itemid);
+}
+
+void Lua_Client::QuestReward(Lua_Mob target, uint32 copper, uint32 silver, uint32 gold, uint32 platinum, uint32 itemid, uint32 exp) {
+	Lua_Safe_Call_Void();
+	self->QuestReward(target, copper, silver, gold, platinum, itemid, exp);
+}
+
+void Lua_Client::QuestReward(Lua_Mob target, uint32 copper, uint32 silver, uint32 gold, uint32 platinum, uint32 itemid, uint32 exp, uint32 factionid, int32 faction) {
+	Lua_Safe_Call_Void();
+	self->QuestReward(target, copper, silver, gold, platinum, itemid, exp, factionid, faction);
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 		.def(luabind::constructor<>())
@@ -1504,7 +1544,15 @@ luabind::scope lua_register_client() {
 		.def("SetConsumption", (void(Lua_Client::*)(int, int))&Lua_Client::SetConsumption)
 		.def("SendMarqueeMessage", (void(Lua_Client::*)(uint32, uint32, uint32, uint32, uint32, std::string))&Lua_Client::SendMarqueeMessage)
 		.def("SendColoredText", (void(Lua_Client::*)(uint32, std::string))&Lua_Client::SendColoredText)
-		.def("PlayMP3", (void(Lua_Client::*)(std::string))&Lua_Client::PlayMP3);
+		.def("PlayMP3", (void(Lua_Client::*)(std::string))&Lua_Client::PlayMP3)
+		.def("QuestReward", (void(Lua_Client::*)(Lua_Mob))&Lua_Client::QuestReward)
+		.def("QuestReward", (void(Lua_Client::*)(Lua_Mob, uint32))&Lua_Client::QuestReward)
+		.def("QuestReward", (void(Lua_Client::*)(Lua_Mob, uint32, uint32))&Lua_Client::QuestReward)
+		.def("QuestReward", (void(Lua_Client::*)(Lua_Mob, uint32, uint32, uint32))&Lua_Client::QuestReward)
+		.def("QuestReward", (void(Lua_Client::*)(Lua_Mob, uint32, uint32, uint32, uint32))&Lua_Client::QuestReward)
+		.def("QuestReward", (void(Lua_Client::*)(Lua_Mob, uint32, uint32, uint32, uint32, uint32))&Lua_Client::QuestReward)
+		.def("QuestReward", (void(Lua_Client::*)(Lua_Mob, uint32, uint32, uint32, uint32, uint32, uint32))&Lua_Client::QuestReward)
+		.def("QuestReward", (void(Lua_Client::*)(Lua_Mob, uint32, uint32, uint32, uint32, uint32, uint32, uint32, int32))&Lua_Client::QuestReward);
 }
 
 luabind::scope lua_register_inventory_where() {

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -278,6 +278,14 @@ public:
 	void SendMarqueeMessage(uint32 type, uint32 priority, uint32 fade_in, uint32 fade_out, uint32 duration, std::string msg);
 	void SendColoredText(uint32 type, std::string msg);
 	void PlayMP3(std::string file);
+	void QuestReward(Lua_Mob target);
+	void QuestReward(Lua_Mob target, uint32 copper);
+	void QuestReward(Lua_Mob target, uint32 copper, uint32 silver);
+	void QuestReward(Lua_Mob target, uint32 copper, uint32 silver, uint32 gold);
+	void QuestReward(Lua_Mob target, uint32 copper, uint32 silver, uint32 gold, uint32 platinum);
+	void QuestReward(Lua_Mob target, uint32 copper, uint32 silver, uint32 gold, uint32 platinum, uint32 itemid);
+	void QuestReward(Lua_Mob target, uint32 copper, uint32 silver, uint32 gold, uint32 platinum, uint32 itemid, uint32 exp);
+	void QuestReward(Lua_Mob target, uint32 copper, uint32 silver, uint32 gold, uint32 platinum, uint32 itemid, uint32 exp, uint32 factionid, int32 faction);
 };
 
 #endif

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -1590,26 +1590,6 @@ void Lua_Mob::SendIllusionPacket(luabind::adl::object illusion) {
 		beard, aa_title, drakkin_heritage, drakkin_tattoo, drakkin_details, size);
 }
 
-void Lua_Mob::QuestReward(Lua_Client c) {
-	Lua_Safe_Call_Void();
-	self->QuestReward(c);
-}
-
-void Lua_Mob::QuestReward(Lua_Client c, uint32 silver) {
-	Lua_Safe_Call_Void();
-	self->QuestReward(c, silver);
-}
-
-void Lua_Mob::QuestReward(Lua_Client c, uint32 silver, uint32 gold) {
-	Lua_Safe_Call_Void();
-	self->QuestReward(c, silver, gold);
-}
-
-void Lua_Mob::QuestReward(Lua_Client c, uint32 silver, uint32 gold, uint32 platinum) {
-	Lua_Safe_Call_Void();
-	self->QuestReward(c, silver, gold, platinum);
-}
-
 void Lua_Mob::CameraEffect(uint32 duration, uint32 intensity) {
 	Lua_Safe_Call_Void();
 	self->CameraEffect(duration, intensity);
@@ -2132,10 +2112,6 @@ luabind::scope lua_register_mob() {
 		.def("SetRace", (void(Lua_Mob::*)(int))&Lua_Mob::SetRace)
 		.def("SetGender", (void(Lua_Mob::*)(int))&Lua_Mob::SetGender)
 		.def("SendIllusionPacket", (void(Lua_Mob::*)(luabind::adl::object))&Lua_Mob::SendIllusionPacket)
-		.def("QuestReward", (void(Lua_Mob::*)(Lua_Client))&Lua_Mob::QuestReward)
-		.def("QuestReward", (void(Lua_Mob::*)(Lua_Client,uint32))&Lua_Mob::QuestReward)
-		.def("QuestReward", (void(Lua_Mob::*)(Lua_Client,uint32,uint32))&Lua_Mob::QuestReward)
-		.def("QuestReward", (void(Lua_Mob::*)(Lua_Client,uint32,uint32,uint32))&Lua_Mob::QuestReward)
 		.def("CameraEffect", (void(Lua_Mob::*)(uint32,uint32))&Lua_Mob::CameraEffect)
 		.def("CameraEffect", (void(Lua_Mob::*)(uint32,uint32,Lua_Client))&Lua_Mob::CameraEffect)
 		.def("CameraEffect", (void(Lua_Mob::*)(uint32,uint32,Lua_Client,bool))&Lua_Mob::CameraEffect)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -296,10 +296,6 @@ public:
 	void SetRace(int in);
 	void SetGender(int in);
 	void SendIllusionPacket(luabind::adl::object illusion);
-	void QuestReward(Lua_Client c);
-	void QuestReward(Lua_Client c, uint32 silver);
-	void QuestReward(Lua_Client c, uint32 silver, uint32 gold);
-	void QuestReward(Lua_Client c, uint32 silver, uint32 gold, uint32 platinum);
 	void CameraEffect(uint32 duration, uint32 intensity);
 	void CameraEffect(uint32 duration, uint32 intensity, Lua_Client c);
 	void CameraEffect(uint32 duration, uint32 intensity, Lua_Client c, bool global);

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1910,22 +1910,6 @@ void Mob::SendTargetable(bool on, Client *specific_target) {
 	safe_delete(outapp);
 }
 
-void Mob::QuestReward(Client *c, uint32 silver, uint32 gold, uint32 platinum) {
-
-	EQApplicationPacket* outapp = new EQApplicationPacket(OP_Sound, sizeof(QuestReward_Struct));
-	QuestReward_Struct* qr = (QuestReward_Struct*) outapp->pBuffer;
-
-	qr->from_mob = GetID();		// Entity ID for the from mob name
-	qr->silver = silver;
-	qr->gold = gold;
-	qr->platinum = platinum;
-
-	if(c)
-		c->QueuePacket(outapp, false, Client::CLIENT_CONNECTED);
-
-	safe_delete(outapp);
-}
-
 void Mob::CameraEffect(uint32 duration, uint32 intensity, Client *c, bool global) {
 
 

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -493,7 +493,6 @@ public:
 	inline bool CheckLastLosState() const { return last_los_check; }
 
 	//Quest
-	void QuestReward(Client *c = nullptr, uint32 silver = 0, uint32 gold = 0, uint32 platinum = 0);
 	void CameraEffect(uint32 duration, uint32 intensity, Client *c = nullptr, bool global = false);
 	inline bool GetQglobal() const { return qglobal; }
 

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -6188,6 +6188,57 @@ XS(XS_Client_GetTargetRingZ)
    XSRETURN(1);
 }
 
+XS(XS_Client_QuestReward); /* prototype to pass -Wmissing-prototypes */
+XS(XS_Client_QuestReward)
+{
+	dXSARGS;
+	if (items < 1 || items > 9)
+		Perl_croak(aTHX_ "Usage: Client::QuestReward(THIS, mob, copper, silver, gold, platinum, itemid, exp, factionid, faction)");
+	{
+		Client*		THIS;
+		Mob *		mob = nullptr;
+		int32		copper = 0;
+		int32		silver = 0;
+		int32		gold = 0;
+		int32		platinum = 0;
+		int32		itemid = 0;
+		int32		exp = 0;
+		int32		factionid = 0;
+		int32		faction = 0;
+
+		if (sv_derived_from(ST(0), "THIS")) {
+			IV tmp = SvIV((SV*)SvRV(ST(0)));
+			THIS = INT2PTR(Client *, tmp);
+		}
+		else
+			Perl_croak(aTHX_ "THIS is not of type client");
+		if (THIS == nullptr)
+			Perl_croak(aTHX_ "THIS is nullptr, avoiding crash.");
+
+		if (items > 1)	{
+			if (sv_derived_from(ST(1), "mob")) {
+				IV tmp = SvIV((SV*)SvRV(ST(1)));
+				mob = INT2PTR(Mob *, tmp);
+			}
+			else
+				Perl_croak(aTHX_ "mob is not of type Mob");
+			if (mob == nullptr)
+				Perl_croak(aTHX_ "mob is nullptr, avoiding crash.");
+		}
+		if (items > 2)	{ copper = (int32)SvIV(ST(2)); }
+		if (items > 3)	{ silver = (int32)SvIV(ST(3)); }
+		if (items > 4)	{ gold = (int32)SvIV(ST(4)); }
+		if (items > 5)	{ platinum = (int32)SvIV(ST(5)); }
+		if (items > 6)	{ itemid = (int32)SvIV(ST(6)); }
+		if (items > 7)	{ exp = (int32)SvIV(ST(7)); }
+		if (items > 8)	{ factionid = (int32)SvIV(ST(8)); }
+		if (items > 9)	{ faction = (int32)SvIV(ST(9)); }
+
+		THIS->QuestReward(mob, copper, silver, gold, platinum, itemid, exp, factionid, faction);
+	}
+	XSRETURN_EMPTY;
+}
+
 #ifdef __cplusplus
 extern "C"
 #endif
@@ -6432,7 +6483,7 @@ XS(boot_Client)
 		newXSproto(strcpy(buf, "GetTargetRingX"), XS_Client_GetTargetRingX, file, "$$");
 		newXSproto(strcpy(buf, "GetTargetRingY"), XS_Client_GetTargetRingY, file, "$$");
 		newXSproto(strcpy(buf, "GetTargetRingZ"), XS_Client_GetTargetRingZ, file, "$$");
-
+		newXSproto(strcpy(buf, "QuestReward"), XS_Client_QuestReward, file, "$$;$$$$$$$$");
 		XSRETURN_YES;
 }
 

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -7027,47 +7027,6 @@ XS(XS_Mob_SendAppearanceEffect)
 	XSRETURN_EMPTY;
 }
 
-XS(XS_Mob_QuestReward); /* prototype to pass -Wmissing-prototypes */
-XS(XS_Mob_QuestReward)
-{
-	dXSARGS;
-	if (items < 1 || items > 5)
-		Perl_croak(aTHX_ "Usage: Mob::QuestReward(THIS, client, silver, gold, platinum)");
-	{
-		Mob *		THIS;
-		Client*		client = nullptr;
-		int32		silver = 0;
-		int32		gold = 0;
-		int32		platinum = 0;
-
-		if (sv_derived_from(ST(0), "Mob")) {
-			IV tmp = SvIV((SV*)SvRV(ST(0)));
-			THIS = INT2PTR(Mob *,tmp);
-		}
-		else
-			Perl_croak(aTHX_ "THIS is not of type Mob");
-		if(THIS == nullptr)
-			Perl_croak(aTHX_ "THIS is nullptr, avoiding crash.");
-
-		if (items > 1)	{
-			if (sv_derived_from(ST(1), "Client")) {
-				IV tmp = SvIV((SV*)SvRV(ST(1)));
-				client = INT2PTR(Client *,tmp);
-			}
-			else
-				Perl_croak(aTHX_ "client is not of type Client");
-			if(client == nullptr)
-				Perl_croak(aTHX_ "client is nullptr, avoiding crash.");
-		}
-		if (items > 2)	{	silver = (int32)SvIV(ST(2));	}
-		if (items > 3)	{	gold = (int32)SvIV(ST(3));		}
-		if (items > 4)	{	platinum = (int32)SvIV(ST(4));	}
-
-		THIS->QuestReward(client, silver, gold, platinum);
-	}
-	XSRETURN_EMPTY;
-}
-
 XS(XS_Mob_SetFlyMode); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Mob_SetFlyMode)
 {
@@ -8660,7 +8619,6 @@ XS(boot_Mob)
 		newXSproto(strcpy(buf, "SendIllusion"), XS_Mob_SendIllusion, file, "$$;$$$$$$$$$$$$");
 		newXSproto(strcpy(buf, "MakeTempPet"), XS_Mob_MakeTempPet, file, "$$;$$$$");
 		newXSproto(strcpy(buf, "TypesTempPet"), XS_Mob_TypesTempPet, file, "$$;$$$$$");
-		newXSproto(strcpy(buf, "QuestReward"), XS_Mob_QuestReward, file, "$$;$$$");
 		newXSproto(strcpy(buf, "CameraEffect"), XS_Mob_CameraEffect, file, "$$;$$$");
 		newXSproto(strcpy(buf, "SpellEffect"), XS_Mob_SpellEffect, file, "$$;$$$$$$");
 		newXSproto(strcpy(buf, "TempName"), XS_Mob_TempName, file, "$:$");


### PR DESCRIPTION
Syntax on NPC is:
e.other:QuestReward(e.self,copper,silver,gold,platinum,item,experience,factionid,factionvalue);

This will give you any or all of the rewards and their messages with one call, including the quest ding sound. Any item is sent to your inventory, like SummonItem does now. The coin message is generated by the client, and will give you a message for each coin type (You recieve 5 copper...). No way around that, but it's still useful if the reward only calls for a single type.

Tested this on RoF2 and confirmed it worked on that client.