### PR TITLE
GM Output for Casting Blocked Spells via Logging System

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -1939,6 +1939,12 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, uint16 slot, uint16 
 		}
 	}
 
+	if (IsClient() && CastToClient()->GetGM()){
+		if (zone->IsSpellBlocked(spell_id, glm::vec3(GetPosition()))){
+			Log.Out(Logs::Detail, Logs::Spells, "GM Cast Blocked Spell: %s (ID %i)", GetSpellName(spell_id), spell_id);
+		}
+	}
+
 	if
 	(
 		this->IsClient() &&


### PR DESCRIPTION
Utilizing the logging system to display an alert when a GM casts a blocked spell, giving some notification instead of silent successes on cast.