### PR TITLE
Making $npc->RemoveFromHateList actually work

### DIFF
--- a/zone/perl_npc.cpp
+++ b/zone/perl_npc.cpp
@@ -823,7 +823,7 @@ XS(XS_NPC_RemoveFromHateList)
 		if(ent == nullptr)
 			Perl_croak(aTHX_ "ent  is nullptr, avoiding crash.");
 
-		THIS->RemoveFromHateList(ent);
+		THIS->CastToMob()->RemoveFromHateList(ent);
 
 	}
 	XSRETURN_EMPTY;


### PR DESCRIPTION
$npc->RemoveFromHateList is a mob function, not an NPC function. Castingto Mob to let it work.