### PR TITLE
Added GetGlobal() support for all Mobs.

### DIFF
--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -1631,6 +1631,11 @@ void Lua_Mob::TempName(const char *newname) {
 	self->TempName(newname);
 }
 
+std::string Lua_Mob::GetGlobal(const char *varname) {
+	Lua_Safe_Call_String();
+	return self->GetGlobal(varname);
+}
+
 void Lua_Mob::SetGlobal(const char *varname, const char *newvalue, int options, const char *duration) {
 	Lua_Safe_Call_Void();
 	self->SetGlobal(varname, newvalue, options, duration);
@@ -2120,6 +2125,7 @@ luabind::scope lua_register_mob() {
 		.def("SendSpellEffect", (void(Lua_Mob::*)(uint32,uint32,uint32,bool,uint32,bool,Lua_Client))&Lua_Mob::SendSpellEffect)
 		.def("TempName", (void(Lua_Mob::*)(void))&Lua_Mob::TempName)
 		.def("TempName", (void(Lua_Mob::*)(const char*))&Lua_Mob::TempName)
+		.def("GetGlobal", (std::string(Lua_Mob::*)(const char*))&Lua_Mob::GetGlobal)
 		.def("SetGlobal", (void(Lua_Mob::*)(const char*,const char*,int,const char*))&Lua_Mob::SetGlobal)
 		.def("SetGlobal", (void(Lua_Mob::*)(const char*,const char*,int,const char*,Lua_Mob))&Lua_Mob::SetGlobal)
 		.def("TarGlobal", (void(Lua_Mob::*)(const char*,const char*,const char*,int,int,int))&Lua_Mob::TarGlobal)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -307,6 +307,7 @@ public:
 		uint32 unk020, bool perm_effect, Lua_Client c);
 	void TempName();
 	void TempName(const char *newname);
+	std::string GetGlobal(const char *varname);
 	void SetGlobal(const char *varname, const char *newvalue, int options, const char *duration);
 	void SetGlobal(const char *varname, const char *newvalue, int options, const char *duration, Lua_Mob other);
 	void TarGlobal(const char *varname, const char *value, const char *duration, int npc_id, int char_id, int zone_id);

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -4202,6 +4202,39 @@ int32 Mob::GetItemStat(uint32 itemid, const char *identifier)
 	return stat;
 }
 
+std::string Mob::GetGlobal(const char *varname) {
+	int qgCharid = 0;
+	int qgNpcid = 0;
+	
+	if (this->IsNPC())
+		qgNpcid = this->GetNPCTypeID();
+	
+	if (this->IsClient())
+		qgCharid = this->CastToClient()->CharacterID();
+	
+	QGlobalCache *qglobals = nullptr;
+	std::list<QGlobal> globalMap;
+	
+	if (this->IsClient())
+		qglobals = this->CastToClient()->GetQGlobals();
+	
+	if (this->IsNPC())
+		qglobals = this->CastToNPC()->GetQGlobals();
+
+	if(qglobals)
+		QGlobalCache::Combine(globalMap, qglobals->GetBucket(), qgNpcid, qgCharid, zone->GetZoneID());
+	
+	std::list<QGlobal>::iterator iter = globalMap.begin();
+	while(iter != globalMap.end()) {
+		if ((*iter).name.compare(varname) == 0)
+			return (*iter).value;
+
+		++iter;
+	}
+	
+	return "Undefined";
+}
+
 void Mob::SetGlobal(const char *varname, const char *newvalue, int options, const char *duration, Mob *other) {
 
 	int qgZoneid = zone->GetZoneID();

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -911,6 +911,7 @@ public:
 	inline virtual bool IsBlockedBuff(int16 SpellID) { return false; }
 	inline virtual bool IsBlockedPetBuff(int16 SpellID) { return false; }
 
+	std::string GetGlobal(const char *varname);
 	void SetGlobal(const char *varname, const char *newvalue, int options, const char *duration, Mob *other = nullptr);
 	void TarGlobal(const char *varname, const char *value, const char *duration, int npcid, int charid, int zoneid);
 	void DelGlobal(const char *varname);

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -7321,6 +7321,37 @@ XS(XS_Mob_GetItemStat)
 	XSRETURN(1);
 }
 
+XS(XS_Mob_GetGlobal);
+XS(XS_Mob_GetGlobal)
+{
+	dXSARGS;
+	if (items < 2)
+		Perl_croak(aTHX_ "Usage: GetGlobal(THIS, varname)");
+	{
+		Mob* THIS;
+		Const_char* varname = (Const_char*)SvPV_nolen(ST(1));
+		std::string ret_val = "Undefined";
+		Const_char* RETVAL;
+		dXSTARG;
+
+		if (sv_derived_from(ST(0), "Mob")) {
+			IV tmp = SvIV((SV*)SvRV(ST(0)));
+			THIS = INT2PTR(Mob *, tmp);
+		}
+		else
+			Perl_croak(aTHX_ "THIS is not of type Mob");
+		if (THIS == nullptr)
+			Perl_croak(aTHX_ "THIS is nullptr, avoiding crash.");
+
+		if (THIS->GetGlobal(varname) != "Undefined")
+			ret_val = THIS->GetGlobal(varname);
+
+		RETVAL = ret_val.c_str();
+		sv_setpv(TARG, RETVAL); XSprePUSH; PUSHTARG;
+	}
+	XSRETURN(1);		
+}
+
 XS(XS_Mob_SetGlobal);
 XS(XS_Mob_SetGlobal)
 {
@@ -8623,6 +8654,7 @@ XS(boot_Mob)
 		newXSproto(strcpy(buf, "SpellEffect"), XS_Mob_SpellEffect, file, "$$;$$$$$$");
 		newXSproto(strcpy(buf, "TempName"), XS_Mob_TempName, file, "$:$");
 		newXSproto(strcpy(buf, "GetItemStat"), XS_Mob_GetItemStat, file, "$$$");
+		newXSproto(strcpy(buf, "GetGlobal"), XS_Mob_GetGlobal, file, "$$");
 		newXSproto(strcpy(buf, "SetGlobal"), XS_Mob_SetGlobal, file, "$$$$$;$");
 		newXSproto(strcpy(buf, "TarGlobal"), XS_Mob_TarGlobal, file, "$$$$$$$");
 		newXSproto(strcpy(buf, "DelGlobal"), XS_Mob_DelGlobal, file, "$$");


### PR DESCRIPTION
- Uses memory (no database hits)
- Allows entity-based quest global checks