### PR TITLE
More encounter timers support

### DIFF
--- a/zone/CMakeLists.txt
+++ b/zone/CMakeLists.txt
@@ -20,7 +20,7 @@ SET(zone_sources
 	embparser_api.cpp
 	embperl.cpp
 	embxs.cpp
-  encounter.cpp
+	encounter.cpp
 	entity.cpp
 	exp.cpp
 	fearpath.cpp
@@ -36,6 +36,7 @@ SET(zone_sources
 	lua_corpse.cpp
 	lua_client.cpp
 	lua_door.cpp
+	lua_encounter.cpp
 	lua_entity.cpp
 	lua_entity_list.cpp
 	lua_general.cpp
@@ -138,7 +139,7 @@ SET(zone_headers
 	embparser.h
 	embperl.h
 	embxs.h
-  encounter.h
+	encounter.h
 	entity.h
 	errmsg.h
 	event_codes.h
@@ -150,6 +151,7 @@ SET(zone_headers
 	lua_bit.h
 	lua_client.h
 	lua_corpse.h
+	lua_encounter.h
 	lua_entity.h
 	lua_entity_list.h
 	lua_general.h

--- a/zone/lua_encounter.cpp
+++ b/zone/lua_encounter.cpp
@@ -1,0 +1,14 @@
+#ifdef LUA_EQEMU
+
+#include "lua.hpp"
+#include <luabind/luabind.hpp>
+#include "lua_encounter.h"
+#include "encounter.h"
+
+
+luabind::scope lua_register_encounter() {
+	return luabind::class_<Lua_Encounter>("Encounter")
+		.def(luabind::constructor<>());
+}
+
+#endif

--- a/zone/lua_encounter.cpp
+++ b/zone/lua_encounter.cpp
@@ -7,8 +7,7 @@
 
 
 luabind::scope lua_register_encounter() {
-	return luabind::class_<Lua_Encounter>("Encounter")
-		.def(luabind::constructor<>());
+	return luabind::class_<Lua_Encounter>("Encounter");
 }
 
 #endif

--- a/zone/lua_encounter.h
+++ b/zone/lua_encounter.h
@@ -1,0 +1,30 @@
+#ifndef EQEMU_LUA_ENCOUNTER_H
+#define EQEMU_LUA_ENCOUNTER_H
+#ifdef LUA_EQEMU
+
+#include "lua_ptr.h"
+
+class Encounter;
+
+namespace luabind {
+	struct scope;
+	class object;
+}
+
+luabind::scope lua_register_encounter();
+
+class Lua_Encounter : public Lua_Ptr<Encounter>
+{
+	typedef Encounter NativeType;
+public:
+	Lua_Encounter() { SetLuaPtrData(nullptr); }
+	Lua_Encounter(Encounter *d) { SetLuaPtrData(reinterpret_cast<Encounter*>(d)); }
+	virtual ~Lua_Encounter() { }
+
+	operator Encounter*() {
+		return reinterpret_cast<Encounter*>(GetLuaPtrData());
+	}
+
+};
+#endif
+#endif

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -19,6 +19,7 @@
 #include "../common/timer.h"
 #include "../common/eqemu_logsys.h"
 #include "encounter.h"
+#include "lua_encounter.h"
 
 struct Events { };
 struct Factions { };
@@ -294,6 +295,10 @@ void lua_set_timer(const char *timer, int time_ms, Lua_ItemInst inst) {
 
 void lua_set_timer(const char *timer, int time_ms, Lua_Mob mob) {
 	quest_manager.settimerMS(timer, time_ms, mob);
+}
+
+void lua_set_timer(const char *timer, int time_ms, Lua_Encounter enc) {
+	quest_manager.settimerMS(timer, time_ms, enc);
 }
 
 void lua_stop_timer(const char *timer) {
@@ -1457,6 +1462,7 @@ luabind::scope lua_register_general() {
 		luabind::def("set_timer", (void(*)(const char*, int))&lua_set_timer),
 		luabind::def("set_timer", (void(*)(const char*, int, Lua_ItemInst))&lua_set_timer),
 		luabind::def("set_timer", (void(*)(const char*, int, Lua_Mob))&lua_set_timer),
+		luabind::def("set_timer", (void(*)(const char*, int, Lua_Encounter))&lua_set_timer),
 		luabind::def("stop_timer", (void(*)(const char*))&lua_stop_timer),
 		luabind::def("stop_timer", (void(*)(const char*, Lua_ItemInst))&lua_stop_timer),
 		luabind::def("stop_timer", (void(*)(const char*, Lua_Mob))&lua_stop_timer),

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -313,6 +313,10 @@ void lua_stop_timer(const char *timer, Lua_Mob mob) {
 	quest_manager.stoptimer(timer, mob);
 }
 
+void lua_stop_timer(const char *timer, Lua_Encounter enc) {
+	quest_manager.stoptimer(timer, enc);
+}
+
 void lua_stop_all_timers() {
 	quest_manager.stopalltimers();
 }
@@ -323,6 +327,10 @@ void lua_stop_all_timers(Lua_ItemInst inst) {
 
 void lua_stop_all_timers(Lua_Mob mob) {
 	quest_manager.stopalltimers(mob);
+}
+
+void lua_stop_all_timers(Lua_Encounter enc) {
+	quest_manager.stopalltimers(enc);
 }
 
 void lua_depop() {
@@ -1466,9 +1474,11 @@ luabind::scope lua_register_general() {
 		luabind::def("stop_timer", (void(*)(const char*))&lua_stop_timer),
 		luabind::def("stop_timer", (void(*)(const char*, Lua_ItemInst))&lua_stop_timer),
 		luabind::def("stop_timer", (void(*)(const char*, Lua_Mob))&lua_stop_timer),
+		luabind::def("stop_timer", (void(*)(const char*, Lua_Encounter))&lua_stop_timer),
 		luabind::def("stop_all_timers", (void(*)(void))&lua_stop_all_timers),
 		luabind::def("stop_all_timers", (void(*)(Lua_ItemInst))&lua_stop_all_timers),
 		luabind::def("stop_all_timers", (void(*)(Lua_Mob))&lua_stop_all_timers),
+		luabind::def("stop_all_timers", (void(*)(Lua_Encounter))&lua_stop_all_timers),
 		luabind::def("depop", (void(*)(void))&lua_depop),
 		luabind::def("depop", (void(*)(int))&lua_depop),
 		luabind::def("depop_with_timer", (void(*)(void))&lua_depop_with_timer),

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -34,6 +34,7 @@
 #include "questmgr.h"
 #include "zone.h"
 #include "lua_parser.h"
+#include "lua_encounter.h"
 
 const char *LuaEvents[_LargestEventID] = {
 	"event_say",
@@ -610,10 +611,11 @@ int LuaParser::_EventEncounter(std::string package_name, QuestEventID evt, std::
 		lua_pushstring(L, encounter_name.c_str());
 		lua_setfield(L, -2, "name");
 
-		auto arg_function = EncounterArgumentDispatch[evt];
-		arg_function(this, L, data, extra_data, extra_pointers);
-
 		Encounter *enc = lua_encounters[encounter_name];
+
+		auto arg_function = EncounterArgumentDispatch[evt];
+		arg_function(this, L, enc, data, extra_data, extra_pointers);
+
 		quest_manager.StartQuest(enc, nullptr, nullptr, encounter_name);
 		if(lua_pcall(L, 1, 1, 0)) {
 			std::string error = lua_tostring(L, -1);
@@ -977,6 +979,7 @@ void LuaParser::MapFunctions(lua_State *L) {
 			lua_register_client_version(),
 			lua_register_appearance(),
 			lua_register_entity(),
+			lua_register_encounter(),
 			lua_register_mob(),
 			lua_register_special_abilities(),
 			lua_register_npc(),

--- a/zone/lua_parser_events.cpp
+++ b/zone/lua_parser_events.cpp
@@ -22,6 +22,7 @@
 #include "lua_door.h"
 #include "lua_object.h"
 #include "lua_packet.h"
+#include "lua_encounter.h"
 #include "zone.h"
 #include "lua_parser_events.h"
 
@@ -704,14 +705,20 @@ void handle_spell_null(QuestInterface *parse, lua_State* L, NPC* npc, Client* cl
 					   std::vector<EQEmu::Any> *extra_pointers) {
 }
 
-void handle_encounter_timer(QuestInterface *parse, lua_State* L, std::string data, uint32 extra_data,
+void handle_encounter_timer(QuestInterface *parse, lua_State* L, Encounter* encounter, std::string data, uint32 extra_data,
 							std::vector<EQEmu::Any> *extra_pointers) {
 	lua_pushstring(L, data.c_str());
 	lua_setfield(L, -2, "timer");
 }
 
-void handle_encounter_load(QuestInterface *parse, lua_State* L, std::string data, uint32 extra_data,
+void handle_encounter_load(QuestInterface *parse, lua_State* L, Encounter* encounter, std::string data, uint32 extra_data,
 									 std::vector<EQEmu::Any> *extra_pointers) {
+	if (encounter) {
+		Lua_Encounter l_enc(encounter);
+		luabind::adl::object l_enc_o = luabind::adl::object(L, l_enc);
+		l_enc_o.push(L);
+		lua_setfield(L, -2, "encounter");
+	}
 	if (extra_pointers) {
 		std::string *str = EQEmu::any_cast<std::string*>(extra_pointers->at(0));
 		lua_pushstring(L, str->c_str());
@@ -719,7 +726,7 @@ void handle_encounter_load(QuestInterface *parse, lua_State* L, std::string data
 	}
 }
 
-void handle_encounter_unload(QuestInterface *parse, lua_State* L, std::string data, uint32 extra_data,
+void handle_encounter_unload(QuestInterface *parse, lua_State* L, Encounter* encounter, std::string data, uint32 extra_data,
 	std::vector<EQEmu::Any> *extra_pointers) {
 	if (extra_pointers) {
 		std::string *str = EQEmu::any_cast<std::string*>(extra_pointers->at(0));
@@ -728,7 +735,7 @@ void handle_encounter_unload(QuestInterface *parse, lua_State* L, std::string da
 	}
 }
 
-void handle_encounter_null(QuestInterface *parse, lua_State* L, std::string data, uint32 extra_data,
+void handle_encounter_null(QuestInterface *parse, lua_State* L, Encounter* encounter, std::string data, uint32 extra_data,
 						   std::vector<EQEmu::Any> *extra_pointers) {
 
 }

--- a/zone/lua_parser_events.h
+++ b/zone/lua_parser_events.h
@@ -6,7 +6,7 @@ typedef void(*NPCArgumentHandler)(QuestInterface*, lua_State*, NPC*, Mob*, std::
 typedef void(*PlayerArgumentHandler)(QuestInterface*, lua_State*, Client*, std::string, uint32, std::vector<EQEmu::Any>*);
 typedef void(*ItemArgumentHandler)(QuestInterface*, lua_State*, Client*, ItemInst*, Mob*, std::string, uint32, std::vector<EQEmu::Any>*);
 typedef void(*SpellArgumentHandler)(QuestInterface*, lua_State*, NPC*, Client*, uint32, uint32, std::vector<EQEmu::Any>*);
-typedef void(*EncounterArgumentHandler)(QuestInterface*, lua_State*, std::string, uint32, std::vector<EQEmu::Any>*);
+typedef void(*EncounterArgumentHandler)(QuestInterface*, lua_State*, Encounter* encounter, std::string, uint32, std::vector<EQEmu::Any>*);
 
 //NPC
 void handle_npc_event_say(QuestInterface *parse, lua_State* L, NPC* npc, Mob *init, std::string data, uint32 extra_data,
@@ -130,13 +130,13 @@ void handle_spell_null(QuestInterface *parse, lua_State* L, NPC* npc, Client* cl
 
 
 //Encounter
-void handle_encounter_timer(QuestInterface *parse, lua_State* L, std::string data, uint32 extra_data,
+void handle_encounter_timer(QuestInterface *parse, lua_State* L, Encounter* encounter, std::string data, uint32 extra_data,
 		std::vector<EQEmu::Any> *extra_pointers);
-void handle_encounter_load(QuestInterface *parse, lua_State* L, std::string data, uint32 extra_data,
+void handle_encounter_load(QuestInterface *parse, lua_State* L, Encounter* encounter, std::string data, uint32 extra_data,
 	std::vector<EQEmu::Any> *extra_pointers);
-void handle_encounter_unload(QuestInterface *parse, lua_State* L, std::string data, uint32 extra_data,
+void handle_encounter_unload(QuestInterface *parse, lua_State* L, Encounter* encounter, std::string data, uint32 extra_data,
 	std::vector<EQEmu::Any> *extra_pointers);
-void handle_encounter_null(QuestInterface *parse, lua_State* L, std::string data, uint32 extra_data,
+void handle_encounter_null(QuestInterface *parse, lua_State* L, Encounter* encounter, std::string data, uint32 extra_data,
 		std::vector<EQEmu::Any> *extra_pointers);
 
 #endif


### PR DESCRIPTION
Encounter timers still needed a bit more to work properly.. these changes make it so a hooked function can create timers tied to the encounter even though the function is running in the context of an npc (or whatever you are hooking).

event_encounter_load(e) now passes e.encounter which should be saved and referenced when making/stopping timers.

Sample usage:

```lua
-- Saved encounter reference from event_load_encounter
local encounter;

function event_timer(e)
  eq.zone_emote(15, "Timer: " .. e.timer);
end

function HookedSpawn(e)
  -- create a timer in the encounter context
  eq.set_timer("hooked_timer", 5000, encounter);
end

function HookedDeath(e)
  eq.stop_timer("hooked_timer", encounter);
  -- can also use:
  eq.stop_all_timers(encounter);
end

function event_load_encounter(e)
  encounter = e.encounter;
  eq.register_npc_event("sample_encounter", Event.spawn, 01101001, HookedSpawn);
  eq.register_npc_event("sample_encounter", Event.death_complete, 01101001, HookedDeath);
end
```