### PR TITLE
Updated additional support in code for new speed calculations.

### DIFF
--- a/common/opcode_dispatch.h
+++ b/common/opcode_dispatch.h
@@ -146,6 +146,7 @@ INr(OP_GuildDelete);	//?
 IN(OP_GuildPublicNote, GuildUpdate_PublicNote);
 INz(OP_GetGuildsList);	//?
 IN(OP_SetGuildMOTD, GuildMOTD_Struct);
+IN(OP_SetRunMode, SetRunMode_Struct);
 INz(OP_GuildPeace);		//?
 INz(OP_GuildWar);		//?
 IN(OP_GuildLeader, GuildMakeLeader);

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -198,6 +198,7 @@ Client::Client(EQStreamInterface* ieqs)
 	SetTarget(0);
 	auto_attack = false;
 	auto_fire = false;
+	runmode = false;
 	linkdead_timer.Disable();
 	zonesummon_id = 0;
 	zonesummon_ignorerestrictions = 0;

--- a/zone/client.h
+++ b/zone/client.h
@@ -1157,6 +1157,7 @@ public:
 	void RemoveAutoXTargets();
 	void ShowXTargets(Client *c);
 	bool GroupFollow(Client* inviter);
+	inline bool  GetRunMode() const { return runmode; }
 
 	void InitializeMercInfo();
 	bool CheckCanSpawnMerc(uint32 template_id);
@@ -1385,6 +1386,7 @@ private:
 	bool AFK;
 	bool auto_attack;
 	bool auto_fire;
+	bool runmode;
 	uint8 gmspeed;
 	bool medding;
 	uint16 horseId;

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -11836,6 +11836,18 @@ void Client::Handle_OP_SetGuildMOTD(const EQApplicationPacket *app)
 
 void Client::Handle_OP_SetRunMode(const EQApplicationPacket *app)
 {
+	if (app->size < sizeof(SetRunMode_Struct)) {
+		Log.Out(Logs::General, Logs::Error, "Received invalid sized "
+			"OP_SetRunMode: got %d, expected %d", app->size,
+			sizeof(SetRunMode_Struct));
+		DumpPacket(app);
+		return;
+	}
+	SetRunMode_Struct* rms = (SetRunMode_Struct*)app->pBuffer;
+	if (rms->mode)
+		runmode = true;
+	else
+		runmode = false;
 	return;
 }
 

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -522,9 +522,7 @@ bool Client::Process() {
 		if (position_timer.Check()) {
 			if (IsAIControlled())
 			{
-				if(IsMoving())
-					SendPosUpdate(2);
-				else
+				if(!IsMoving())
 				{
 					animation = 0;
 					m_Delta = glm::vec4(0.0f, 0.0f, 0.0f, m_Delta.w);

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -1484,7 +1484,7 @@ void command_npcstats(Client *c, const Seperator *sep)
 		c->Message(0, "Current HP: %i  Max HP: %i",  c->GetTarget()->GetHP(), c->GetTarget()->GetMaxHP());
 		//c->Message(0, "Weapon Item Number: %s", c->GetTarget()->GetWeapNo());
 		c->Message(0, "Gender: %i  Size: %f  Bodytype: %d",  c->GetTarget()->GetGender(), c->GetTarget()->GetSize(), c->GetTarget()->GetBodyType());
-		c->Message(0, "Runspeed: %i  Walkspeed: %i",  c->GetTarget()->GetRunspeed(), c->GetTarget()->GetWalkspeed());
+		c->Message(0, "Runspeed: %.3f  Walkspeed: %.3f",  static_cast<float>(0.025f * c->GetTarget()->GetRunspeed()), static_cast<float>(0.025f * c->GetTarget()->GetWalkspeed()));
 		c->Message(0, "Spawn Group: %i  Grid: %i",  c->GetTarget()->CastToNPC()->GetSp2(), c->GetTarget()->CastToNPC()->GetGrid());
 		c->Message(0, "EmoteID: %i",  c->GetTarget()->CastToNPC()->GetEmoteID());
 		c->GetTarget()->CastToNPC()->QueryLoot(c);

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -725,7 +725,7 @@ int Mob::_GetFearSpeed() const {
 		movemod = -85;
 
 	if (IsClient()) {
-		if (CastToClient()->IsRunning())
+		if (CastToClient()->GetRunMode())
 			speed_mod = GetBaseRunspeed();
 		else
 			speed_mod = GetBaseWalkspeed();
@@ -1085,7 +1085,7 @@ void Mob::FillSpawnStruct(NewSpawn_Struct* ns, Mob* ForWho)
 	ns->spawn.max_hp	= 100;		//this field needs a better name
 	ns->spawn.race		= race;
 	ns->spawn.runspeed	= runspeed;
-	ns->spawn.walkspeed	= runspeed * 0.5f;
+	ns->spawn.walkspeed	= walkspeed;
 	ns->spawn.class_	= class_;
 	ns->spawn.gender	= gender;
 	ns->spawn.level		= level;
@@ -1475,7 +1475,7 @@ void Mob::ShowStats(Client* client)
 			if(n->respawn2 != 0)
 				spawngroupid = n->respawn2->SpawnGroupID();
 			client->Message(0, "  NPCID: %u  SpawnGroupID: %u Grid: %i LootTable: %u FactionID: %i SpellsID: %u ", GetNPCTypeID(),spawngroupid, n->GetGrid(), n->GetLoottableID(), n->GetNPCFactionID(), n->GetNPCSpellsID());
-			client->Message(0, "  Accuracy: %i MerchantID: %i EmoteID: %i Runspeed: %u Walkspeed: %u", n->GetAccuracyRating(), n->MerchantType, n->GetEmoteID(), n->GetRunspeed(), n->GetWalkspeed());
+			client->Message(0, "  Accuracy: %i MerchantID: %i EmoteID: %i Runspeed: %.3f Walkspeed: %.3f", n->GetAccuracyRating(), n->MerchantType, n->GetEmoteID(), static_cast<float>(0.025f * n->GetRunspeed()), static_cast<float>(0.025f * n->GetWalkspeed()));
 			n->QueryLoot(client);
 		}
 		if (IsAIControlled()) {

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -365,7 +365,7 @@ public:
 	inline Mob* GetTarget() const { return target; }
 	virtual void SetTarget(Mob* mob);
 	virtual inline float GetHPRatio() const { return max_hp == 0 ? 0 : ((float)cur_hp/max_hp*100); }
-	virtual inline float GetIntHPRatio() const { return max_hp == 0 ? 0 : (cur_hp/max_hp*100); }
+	virtual inline int GetIntHPRatio() const { return max_hp == 0 ? 0 : static_cast<int>(cur_hp * 100 / max_hp); }
 	inline virtual int32 GetAC() const { return AC + itembonuses.AC + spellbonuses.AC; }
 	inline virtual int32 GetATK() const { return ATK + itembonuses.ATK + spellbonuses.ATK; }
 	inline virtual int32 GetATKBonus() const { return itembonuses.ATK + spellbonuses.ATK; }

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -772,7 +772,10 @@ void Client::AI_Process()
 				engaged = true;
 			} else {
 				if(AImovement_timer->Check()) {
-					//animation = GetFearSpeed() * 21;
+					int speed = GetFearSpeed();
+					animation = speed;
+					speed *= 2;
+					SetCurrentSpeed(speed);
 					// Check if we have reached the last fear point
 					if ((std::abs(GetX() - m_FearWalkTarget.x) < 0.1) &&
 					    (std::abs(GetY() - m_FearWalkTarget.y) < 0.1)) {
@@ -780,18 +783,18 @@ void Client::AI_Process()
 						CalculateNewFearpoint();
 					}
 					if(!RuleB(Pathing, Fear) || !zone->pathing)
-						CalculateNewPosition2(m_FearWalkTarget.x, m_FearWalkTarget.y, m_FearWalkTarget.z, GetFearSpeed(), true);
+						CalculateNewPosition2(m_FearWalkTarget.x, m_FearWalkTarget.y, m_FearWalkTarget.z, speed, true);
 					else
 					{
 						bool WaypointChanged, NodeReached;
 
 						glm::vec3 Goal = UpdatePath(m_FearWalkTarget.x, m_FearWalkTarget.y, m_FearWalkTarget.z,
-									GetFearSpeed(), WaypointChanged, NodeReached);
+									speed, WaypointChanged, NodeReached);
 
 						if(WaypointChanged)
 							tar_ndx = 20;
 
-						CalculateNewPosition2(Goal.x, Goal.y, Goal.z, GetFearSpeed());
+						CalculateNewPosition2(Goal.x, Goal.y, Goal.z, speed);
 					}
 				}
 				return;
@@ -934,8 +937,12 @@ void Client::AI_Process()
 			{
 				if(AImovement_timer->Check())
 				{
+					int newspeed = GetRunspeed();
+					animation = newspeed;
+					newspeed *= 2;
+					SetCurrentSpeed(newspeed);
 					if(!RuleB(Pathing, Aggro) || !zone->pathing)
-						CalculateNewPosition2(GetTarget()->GetX(), GetTarget()->GetY(), GetTarget()->GetZ(), GetRunspeed());
+						CalculateNewPosition2(GetTarget()->GetX(), GetTarget()->GetY(), GetTarget()->GetZ(), newspeed);
 					else
 					{
 						bool WaypointChanged, NodeReached;
@@ -945,7 +952,7 @@ void Client::AI_Process()
 						if(WaypointChanged)
 							tar_ndx = 20;
 
-						CalculateNewPosition2(Goal.x, Goal.y, Goal.z, GetRunspeed());
+						CalculateNewPosition2(Goal.x, Goal.y, Goal.z, newspeed);
 					}
 				}
 			}
@@ -989,11 +996,12 @@ void Client::AI_Process()
 			{
 				if(AImovement_timer->Check())
 				{
-					int speed = GetWalkspeed();
-					if (dist >= 5625)
-						speed = GetRunspeed();
+					int nspeed = (dist >= 5625 ? GetRunspeed() : GetWalkspeed());
+					animation = nspeed;
+					nspeed *= 2;
+					SetCurrentSpeed(nspeed);
 							
-					CalculateNewPosition2(owner->GetX(), owner->GetY(), owner->GetZ(), speed);
+					CalculateNewPosition2(owner->GetX(), owner->GetY(), owner->GetZ(), nspeed);
 				}
 			}
 			else

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -1929,7 +1929,15 @@ void NPC::ModifyNPCStat(const char *identifier, const char *newValue)
 	else if(id == "pr") { PR = atoi(val.c_str()); return; }
 	else if(id == "dr") { DR = atoi(val.c_str()); return; }
 	else if(id == "PhR") { PhR = atoi(val.c_str()); return; }
-	else if(id == "runspeed") { runspeed = (float)atof(val.c_str()); CalcBonuses(); return; }
+	else if(id == "runspeed") { 
+		runspeed = (float)atof(val.c_str());
+		base_runspeed = (int)((float)runspeed * 40.0f);
+		base_walkspeed = base_runspeed * 100 / 265;
+		walkspeed = ((float)base_walkspeed) * 0.025f;
+		base_fearspeed = base_runspeed * 100 / 127;
+		fearspeed = ((float)base_fearspeed) * 0.025f;
+		CalcBonuses(); return; 
+	}
 	else if(id == "special_attacks") { NPCSpecialAttacks(val.c_str(), 0, 1); return; }
 	else if(id == "special_abilities") { ProcessSpecialAbilities(val.c_str()); return; }
 	else if(id == "attack_speed") { attack_speed = (float)atof(val.c_str()); CalcBonuses(); return; }

--- a/zone/waypoints.cpp
+++ b/zone/waypoints.cpp
@@ -597,7 +597,7 @@ bool Mob::MakeNewPositionAndSendUpdate(float x, float y, float z, int speed, boo
 	pRunAnimSpeed = speed;
 	if(IsClient())
 	{
-		animation = speed;
+		animation = speed / 2;
 	}
 	//pRunAnimSpeed = (int8)(speed*NPC_RUNANIM_RATIO);
 	//speed *= NPC_SPEED_MULTIPLIER;
@@ -611,7 +611,7 @@ bool Mob::MakeNewPositionAndSendUpdate(float x, float y, float z, int speed, boo
 	tar_vector = (float)speed / mag;
 
 // mob move fix
-	int numsteps = (int) ( mag * 16.0f / (float)speed);
+	int numsteps = (int) ( mag * 16.0f / (float)speed + 0.5f);
 
 
 // mob move fix


### PR DESCRIPTION
Fixed #modifynpcstat runspeed <value>, to work with new speed calculations.
Updated #showstats and #npcstats for new speed calcs to display speeds again in familiar float format.
Improved client movement while AI Controlled, such as feared and charmed.  Movement will be much smoother from clients perspective.