### PR TITLE
Compile errors with VS2015 Community RC/RTM v2.0

### DIFF
--- a/common/tcp_connection.h
+++ b/common/tcp_connection.h
@@ -23,7 +23,9 @@
 */
 
 #ifdef _WINDOWS
-	#define snprintf	_snprintf
+	#if (!defined(_MSC_VER) || (defined(_MSC_VER) && _MSC_VER < 1900))
+		#define snprintf	_snprintf
+	#endif
 	#define strncasecmp	_strnicmp
 	#define strcasecmp	_stricmp
 

--- a/common/types.h
+++ b/common/types.h
@@ -43,7 +43,9 @@ typedef unsigned char		uchar;
 typedef const char Const_char;	//for perl XS
 
 #ifdef _WINDOWS
-	#define snprintf	_snprintf
+	#if (!defined(_MSC_VER) || (defined(_MSC_VER) && _MSC_VER < 1900))
+		#define snprintf	_snprintf
+	#endif
 	#define strncasecmp	_strnicmp
 	#define strcasecmp	_stricmp
 	typedef void ThreadReturnType;

--- a/zone/aggro.cpp
+++ b/zone/aggro.cpp
@@ -1117,6 +1117,9 @@ int32 Mob::CheckAggroAmount(uint16 spell_id, Mob *target, bool isproc)
 		int HateMod = RuleI(Aggro, SpellAggroMod);
 		HateMod += GetFocusEffect(focusSpellHateMod, spell_id);
 
+		//Live AA - Spell casting subtlety
+		HateMod += aabonuses.hatemod + spellbonuses.hatemod + itembonuses.hatemod;
+
 		AggroAmount = (AggroAmount * HateMod) / 100;
 	}
 

--- a/zone/aggro.cpp
+++ b/zone/aggro.cpp
@@ -1134,7 +1134,7 @@ int32 Mob::CheckAggroAmount(uint16 spell_id, Mob *target, bool isproc)
 int32 Mob::CheckHealAggroAmount(uint16 spell_id, Mob *target, uint32 heal_possible)
 {
 	int32 AggroAmount = 0;
-	auto target_level = target ? target->GetLevel() : GetLevel();
+	auto target_level = target ? target->GetLevel() : 1;
 	bool ignore_default_buff = false; // rune/hot don't use the default 9, HP buffs that heal (virtue) do use the default
 
 	for (int o = 0; o < EFFECT_COUNT; o++) {
@@ -1177,7 +1177,7 @@ int32 Mob::CheckHealAggroAmount(uint16 spell_id, Mob *target, uint32 heal_possib
 		AggroAmount = AggroAmount * RuleI(Aggro, PetSpellAggroMod) / 100;
 
 	if (!ignore_default_buff && IsBuffSpell(spell_id) && IsBeneficialSpell(spell_id))
-		AggroAmount = 9;
+		AggroAmount = IsBardSong(spell_id) ? 2 : 9;
 
 	if (AggroAmount > 0) {
 		int HateMod = RuleI(Aggro, SpellAggroMod);

--- a/zone/beacon.cpp
+++ b/zone/beacon.cpp
@@ -26,8 +26,10 @@ target to center around.
 class Zone;
 
 #ifdef _WINDOWS
-    #define snprintf	_snprintf
-    #define vsnprintf	_vsnprintf
+	#if (!defined(_MSC_VER) || (defined(_MSC_VER) && _MSC_VER < 1900))
+		#define snprintf	_snprintf
+		#define vsnprintf	_vsnprintf
+	#endif
     #define strncasecmp	_strnicmp
     #define strcasecmp	_stricmp
 #endif

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -38,7 +38,6 @@
 #include "../common/unix.h"
 #endif
 
-
 void Mob::CalcBonuses()
 {
 	CalcSpellBonuses(&spellbonuses);
@@ -3493,6 +3492,17 @@ uint8 Mob::IsFocusEffect(uint16 spell_id,int effect_index, bool AA,uint32 aa_eff
 	return 0;
 }
 
+// Avoid an internal compiler error in VS 2015 
+// Community RC (free) with the /O2 compiler
+// option enabled on x64 build; definite fail on
+// building Release-X64.  Disabling optimizations
+// for the entire file might be overkill and/or
+// inapplicable to other builds, more testing needed.
+// Bug has been reported to MS, fix ETA unknown.
+#if (defined(_MSC_VER) && defined(_WIN64)&& _MSC_VER==1900)
+#pragma optimize( "", off )
+#endif
+
 void Mob::NegateSpellsBonuses(uint16 spell_id)
 {
 	if(!IsValidSpell(spell_id))
@@ -4654,6 +4664,7 @@ void Mob::NegateSpellsBonuses(uint16 spell_id)
 						itembonuses.SkillProcSuccess[e] = effect_value;
 						aabonuses.SkillProcSuccess[e] = effect_value;
 					}
+					break;
 				 }
 
 				case SE_SkillProc:{
@@ -4663,9 +4674,14 @@ void Mob::NegateSpellsBonuses(uint16 spell_id)
 						itembonuses.SkillProc[e] = effect_value;
 						aabonuses.SkillProc[e] = effect_value;
 					}
+					break;
 				 }
 			}
 		}
 	}
 }
 
+// See line 3495 above, more or less
+#if (defined(_MSC_VER) && defined(_WIN64)&& _MSC_VER==1900)
+	#pragma optimize( "", on )
+#endif

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -22,8 +22,10 @@ Child of the Mob class.
 */
 
 #ifdef _WINDOWS
-    #define snprintf	_snprintf
-	#define vsnprintf	_vsnprintf
+	#if (!defined(_MSC_VER) || (defined(_MSC_VER) && _MSC_VER < 1900))
+		#define snprintf	_snprintf
+		#define vsnprintf	_vsnprintf
+	#endif
     #define strncasecmp	_strnicmp
     #define strcasecmp	_stricmp
 #endif

--- a/zone/encounter.cpp
+++ b/zone/encounter.cpp
@@ -17,10 +17,12 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
 #ifdef _WINDOWS
-#define snprintf	_snprintf
-#define vsnprintf	_vsnprintf
-#define strncasecmp	_strnicmp
-#define strcasecmp	_stricmp
+	#if (!defined(_MSC_VER) || (defined(_MSC_VER) && _MSC_VER < 1900))
+		#define snprintf	_snprintf
+		#define vsnprintf	_vsnprintf
+	#endif
+	#define strncasecmp	_strnicmp
+	#define strcasecmp	_stricmp
 #endif
 
 #include "../common/races.h"


### PR DESCRIPTION
Very preliminary work with Visual Studio 2015 Community RC/RTM, resolve some version-specific build errors:
-- Standard library functions snprintf & vsnprintf are available thusly named (without the prepended underscores). Someone may want to check my conditionals against non-MSVC compilers, though
-- zone/bonuses.cpp throws an internal compiler error with optimize enabled; #pragma disable optimization on VS2015 only for the function Mob:NegateSpellBonuses only is enough to work around the internal error.
PS sorry for the multiple commits ...