### PR TITLE
GetAccountAge() for Perl.

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -8667,3 +8667,7 @@ uint32 Client::GetMoney(uint8 type, uint8 subtype) {
 	}
 	return value;
 }
+
+int Client::GetAccountAge() {
+	return (time(nullptr) - GetAccountCreation());
+}

--- a/zone/client.h
+++ b/zone/client.h
@@ -664,6 +664,7 @@ public:
 	uint64 GetCarriedMoney();
 	uint64 GetAllMoney();
 	uint32 GetMoney(uint8 type, uint8 subtype);
+	int GetAccountAge();
 
 	bool IsDiscovered(uint32 itemid);
 	void DiscoverItem(uint32 itemid);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -6309,6 +6309,32 @@ XS(XS_Client_GetMoney)
 	XSRETURN(1);
 }
 
+XS(XS_Client_GetAccountAge);
+XS(XS_Client_GetAccountAge) {
+	dXSARGS;
+	if (items != 1)
+		Perl_croak(aTHX_ "Usage: GetAccountAge(THIS)");
+	{
+		Client* THIS;
+		int RETVAL;
+		dXSTARG;
+
+		if (sv_derived_from(ST(0), "Client")) {
+			IV tmp = SvIV((SV*)SvRV(ST(0)));
+			THIS = INT2PTR(Client *,tmp);
+		}
+		else
+			Perl_croak(aTHX_ "THIS is not of type Client");
+		
+		if(THIS == nullptr)
+			Perl_croak(aTHX_ "THIS is nullptr, avoiding crash.");
+
+		RETVAL = THIS->GetAccountAge();
+		XSprePUSH; PUSHn((int)RETVAL);		
+	}
+	XSRETURN(1);
+}
+
 
 #ifdef __cplusplus
 extern "C"
@@ -6558,6 +6584,7 @@ XS(boot_Client)
 		newXSproto(strcpy(buf, "QuestReward"), XS_Client_QuestReward, file, "$$;$$$$$$$");
 		newXSproto(strcpy(buf, "CalcEXP"), XS_Client_CalcEXP, file, "$");
 		newXSproto(strcpy(buf, "GetMoney"), XS_Client_GetMoney, file, "$$$");
+		newXSproto(strcpy(buf, "GetAccountAge"), XS_Client_GetAccountAge, file, "$");
 		XSRETURN_YES;
 }
 


### PR DESCRIPTION
Added GetAccountAge() functionality to Perl so people can grant veteran AAs based on account age.