### PR TITLE
Fix buffdurationpacket for seeinvis spells

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -5302,6 +5302,14 @@ void Client::SendBuffDurationPacket(Buffs_Struct &buff)
 		int index = GetSpellEffectIndex(buff.spellid, SE_CurrentHP);
 		sbf->effect = abs(spells[buff.spellid].base[index]);
 	}
+	else if (IsEffectInSpell(buff.spellid, SE_SeeInvis))
+	{
+		// Wish I knew what this sbf->effect field was trying to tell
+		// the client.  10 seems to not break SeeInvis spells.  Level,
+		// which is what the old client sends breaks the client at at 
+		// least level 9, maybe more.
+		sbf->effect = 10;
+	}
 	else
 	{
 		// Default to what old code did until we find a better fix for


### PR DESCRIPTION
In the same line as previous patches, the function to update buff durations has been fixed to not break see invis spells when it updates the duration.  I still don't see a clear explanation for the sbf->effect field, but like with the other spell types, trial and error got me to the value I am sending.  Using level was clearly breaking the buff at some levels.