### PR TITLE
Implemented spells_new field 217 override_crit_chance

### DIFF
--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -1671,6 +1671,7 @@ void SharedDatabase::LoadSpells(void *data, int max_spells) {
 		sp[tempid].AllowRest = atoi(row[212]) != 0;
 		sp[tempid].InCombat = atoi(row[213]) != 0;
 		sp[tempid].OutofCombat = atoi(row[214]) != 0;
+		sp[tempid].override_crit_chance = atoi(row[217]);
 		sp[tempid].aemaxtargets = atoi(row[218]);
 		sp[tempid].maxtargets = atoi(row[219]);
 		sp[tempid].persistdeath = atoi(row[224]) != 0;

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -761,7 +761,8 @@ struct SPDat_Spell_Struct
 /* 212 */	bool AllowRest;
 /* 213 */	bool InCombat; //Allow spell if target is in combat
 /* 214 */   bool OutofCombat; //Allow spell if target is out of combat
-/* 215 - 217 */
+/* 215 - 216 */
+/* 217 */   int override_crit_chance; //Places a cap on the max chance to critical
 /* 218 */	int aemaxtargets;  //Is used for various AE effects
 /* 219 */	int maxtargets; //Is used for beam and ring spells for target # limits (not implemented)
 /* 220 - 223 */

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -73,6 +73,9 @@ int32 Mob::GetActSpellDamage(uint16 spell_id, int32 value, Mob* target) {
 		if (spell_id == SPELL_IMP_HARM_TOUCH && IsClient() && (GetAA(aaSpellCastingFury) > 0) && (GetAA(aaUnholyTouch) > 0))
 			 chance = 100;
 
+		if (spells[spell_id].override_crit_chance > 0 && chance > spells[spell_id].override_crit_chance)
+			chance = spells[spell_id].override_crit_chance;
+
 		if (zone->random.Roll(chance)) {
 			Critical = true;
 			ratio += itembonuses.SpellCritDmgIncrease + spellbonuses.SpellCritDmgIncrease + aabonuses.SpellCritDmgIncrease;
@@ -161,7 +164,10 @@ int32 Mob::GetActDoTDamage(uint16 spell_id, int32 value, Mob* target) {
 	chance += itembonuses.CriticalDoTChance + spellbonuses.CriticalDoTChance + aabonuses.CriticalDoTChance;
 
 	if (spellbonuses.CriticalDotDecay)
-			chance += GetDecayEffectValue(spell_id, SE_CriticalDotDecay);
+		chance += GetDecayEffectValue(spell_id, SE_CriticalDotDecay);
+
+	if (spells[spell_id].override_crit_chance > 0 && chance > spells[spell_id].override_crit_chance)
+		chance = spells[spell_id].override_crit_chance;
 
 	value_BaseEffect = value + (value*GetFocusEffect(focusFcBaseEffects, spell_id)/100);
 
@@ -259,6 +265,9 @@ int32 Mob::GetActSpellHealing(uint16 spell_id, int32 value, Mob* target) {
 
 		if (spellbonuses.CriticalHealDecay)
 			chance += GetDecayEffectValue(spell_id, SE_CriticalHealDecay);
+
+		if (spells[spell_id].override_crit_chance > 0 && chance > spells[spell_id].override_crit_chance)
+			chance = spells[spell_id].override_crit_chance;
 
 		if(chance && (zone->random.Roll(chance))) {
 			Critical = true;


### PR DESCRIPTION
Determines the maximum chance this spell has to critical hit.
Ie. If set to 15, the spell will never critical more then 15% of the time
regardless of your characters innate chance to critcal from AAs.