### PR TITLE
Update to give client access to the proper AAs for the expansions all…

### DIFF
--- a/zone/aa.cpp
+++ b/zone/aa.cpp
@@ -1419,11 +1419,11 @@ bool Mob::CanUseAlternateAdvancementRank(AA::Rank *rank) {
 	}
 
 	if(IsClient()) {
-		if(!(CastToClient()->GetPP().expansions & (1 << rank->expansion))) {
+		if(!(CastToClient()->GetPP().expansions & (1 << (rank->expansion - 1)))) {
 			return false;
 		}
 	} else {
-		if(!(RuleI(World, ExpansionSettings) & (1 << rank->expansion))) {
+		if(!(RuleI(World, ExpansionSettings) & (1 << (rank->expansion - 1)))) {
 			return false;
 		}
 	}


### PR DESCRIPTION
…owed

Bit shifting by expansion value minus 1, rather than expansion value