### PR TITLE
FD break from spells

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,12 @@
 EQEMu Changelog (Started on Sept 24, 2003 15:50)
 -------------------------------------------------------
+
 == 10/12/2015 ==
 Uleat: Implemented 'bots' database versioning
 Note: See thread for more information: http://www.eqemulator.org/forums/showthread.php?t=40091
+
+Kayen: Feign death will now break when hit by casted spells, consisted with live.
+Implemented suport for AA/spell effect which provides a chance to avoid FD breaking from spells.
 
 == 10/10/2015 ==
 Kayen: Updated mechanics to be consistent with live regarding how invisible breaks when the client is the target of a spell.

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -392,7 +392,7 @@ typedef enum {
 //#define SE_FreePet					236	// not used
 #define SE_GivePetGroupTarget			237 // implemented[AA] - (Pet Affinity)
 #define SE_IllusionPersistence			238	// implemented - lends persistence to your illusionary disguises, causing them to last until you die or the illusion is forcibly removed.
-#define SE_FeignedCastOnChance			239	// *not implemented as bonus - ability gives you an increasing chance for your feigned deaths to not be revealed by spells cast upon you.
+#define SE_FeignedCastOnChance			239	// implemented - ability gives you an increasing chance for your feigned deaths to not be revealed by spells cast upon you.
 //#define SE_StringUnbreakable			240	// not used [Likely related to above - you become immune to feign breaking on a resisted spell and have a good chance of feigning through a spell that successfully lands upon you.]
 #define SE_ImprovedReclaimEnergy		241	// implemented - increase the amount of mana returned to you when reclaiming your pet.
 #define SE_IncreaseChanceMemwipe		242	// implemented - increases the chance to wipe hate with memory blurr

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -1457,6 +1457,11 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 				newbon->NoBreakAESneak = base1;
 			break;
 
+		case SE_FeignedCastOnChance:
+			if (newbon->FeignedCastOnChance < base1)
+				newbon->FeignedCastOnChance = base1;
+			break;
+
 		// to do
 		case SE_PetDiscipline:
 			break;
@@ -1469,8 +1474,6 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 		case SE_ForageSkill:
 			break;
 		case SE_SecondaryForte:
-			break;
-		case SE_FeignedCastOnChance:
 			break;
 		case SE_ExtendedShielding:
 			break;
@@ -3197,6 +3200,11 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 			case SE_NoBreakAESneak:
 				if (new_bonus->NoBreakAESneak < effect_value)
 					new_bonus->NoBreakAESneak = effect_value;
+				break;
+
+			case SE_FeignedCastOnChance:
+				if (new_bonus->FeignedCastOnChance < effect_value)
+					new_bonus->FeignedCastOnChance = effect_value;
 				break;
 		
 			//Special custom cases for loading effects on to NPC from 'npc_spels_effects' table

--- a/zone/client.h
+++ b/zone/client.h
@@ -879,6 +879,7 @@ public:
 
 	void BreakInvis();
 	void BreakSneakWhenCastOn(Mob* caster, bool IsResisted);
+	void BreakFeignDeathWhenCastOn(bool IsResisted);
 	void LeaveGroup();
 
 	bool Hungry() const {if (GetGM()) return false; return m_pp.hunger_level <= 3000;}

--- a/zone/common.h
+++ b/zone/common.h
@@ -472,6 +472,7 @@ struct StatBonuses {
 	int32	ReduceTradeskillFail[HIGHEST_SKILL+1]; // Reduces chance for trade skills to fail by percent.
 	uint8	TradeSkillMastery;					// Allow number of tradeskills to exceed 200 skill.
 	int16	NoBreakAESneak;						// Percent value
+	int16	FeignedCastOnChance;				// Percent Value
 };
 
 typedef struct

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -6771,3 +6771,22 @@ void Client::BreakSneakWhenCastOn(Mob* caster, bool IsResisted)
 		}
 	}
 }
+
+void Client::BreakFeignDeathWhenCastOn(bool IsResisted)
+{
+	if(GetFeigned()){
+
+		int chance = spellbonuses.FeignedCastOnChance + itembonuses.FeignedCastOnChance + aabonuses.FeignedCastOnChance;
+
+		if (IsResisted)
+			chance *= 2;
+
+		if(chance && (zone->random.Roll(chance))){
+			Message_StringID(MT_SpellFailure,FD_CAST_ON_NO_BREAK);
+			return;
+		}
+	
+		SetFeigned(false);
+		Message_StringID(MT_SpellFailure,FD_CAST_ON);
+	}
+}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3714,8 +3714,10 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, bool reflect, bool use_r
 					}
 				}
 
-				if (spelltar->IsClient())
+				if (spelltar->IsClient()){
 					spelltar->CastToClient()->BreakSneakWhenCastOn(this, true);
+					spelltar->CastToClient()->BreakFeignDeathWhenCastOn(true);
+				}
 				
 				spelltar->CheckNumHitsRemaining(NumHit::IncomingSpells);
 				CheckNumHitsRemaining(NumHit::OutgoingSpells);
@@ -3724,8 +3726,10 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, bool reflect, bool use_r
 				return false;
 			}
 		}
+
 		if (spelltar->IsClient()){
 			spelltar->CastToClient()->BreakSneakWhenCastOn(this, false);
+			spelltar->CastToClient()->BreakFeignDeathWhenCastOn(false);
 		}
 	}
 	else

--- a/zone/string_ids.h
+++ b/zone/string_ids.h
@@ -78,6 +78,7 @@
 #define ONLY_ONE_PET				246		//You cannot have more than one pet at a time.
 #define CANNOT_CHARM_YET			248		//Your target is too high of a level for your charm spell.
 #define CANNOT_AFFECT_NPC			251		//That spell can not affect this target NPC.
+#define FD_CAST_ON					254		//You are no longer feigning death, because a spell hit you.
 #define SUSPEND_MINION_HAS_AGGRO	256		//Your pet is the focus of something's attention.
 #define NO_PET						255		//You do not have a pet.
 #define GATE_FAIL					260		//Your gate is too unstable, and collapses.
@@ -356,6 +357,7 @@
 #define STRIKETHROUGH_STRING		9078	//You strike through your opponent's defenses!
 #define SPELL_REFLECT				9082	//%1's spell has been reflected by %2.
 #define NEW_SPELLS_AVAIL			9149	//You have new spells available to you. Check the merchants near your guild master.
+#define FD_CAST_ON_NO_BREAK			9174	//The strength of your will allows you to resume feigning death.
 #define SNEAK_RESTRICT				9240	//You can not use this ability because you have not been hidden for long enough.
 #define PET_NOW_FOCUSING			9254	//Focusing on one target, Master.
 #define PET_NOT_FOCUSING			9263	//No longer focusing on one target, Master.


### PR DESCRIPTION
Feign death will now break when hit by casted spells, consisted with live.
Implemented support for AA/spell effect which provides a chance to avoid FD breaking from spells.