### PR TITLE
Old Race/Class Experience Mods

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -85,6 +85,8 @@ RULE_INT(Character, MaxCharmDurationForPlayerCharacter, 15)
 RULE_INT(Character, BaseHPRegenBonusRaces, 4352)	//a bitmask of race(s) that receive the regen bonus. Iksar (4096) & Troll (256) = 4352. see common/races.h for the bitmask values
 RULE_BOOL(Character, SoDClientUseSoDHPManaEnd, false)	// Setting this to true will allow SoD clients to use the SoD HP/Mana/End formulas and previous clients will use the old formulas
 RULE_BOOL(Character, UseRaceClassExpBonuses, true)	// Setting this to true will enable Class and Racial experience rate bonuses
+RULE_BOOL(Character, UseOldRaceExpPenalties, false)	// Setting this to true will enable racial exp penalties for Iksar, Troll, Ogre, and Barbarian, as well as the bonus for Halflings
+RULE_BOOL(Character, UseOldClassExpPenalties, false)	// Setting this to true will enable old class exp penalties for Paladin, SK, Ranger, Bard, Monk, Wizard, Enchanter, Magician, and Necromancer, as well as the bonus for Rogues and Warriors
 RULE_BOOL(Character, RespawnFromHover, false)		// Use Respawn window, or not.
 RULE_INT(Character, RespawnFromHoverTimer, 300)	// Respawn Window countdown timer, in SECONDS
 RULE_BOOL(Character, UseNewStatsWindow, true)		// New stats window shows everything

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -665,6 +665,41 @@ uint32 Client::GetEXPForLevel(uint16 check_level)
 	mod *= 1000;
 
 	uint32 finalxp = uint32(base * mod);
+
+	if(RuleB(Character,UseOldRaceExpPenalties))
+	{
+		float racemod = 1.0;
+		if(GetBaseRace() == TROLL || GetBaseRace() == IKSAR) {
+			racemod = 1.2;
+		} else if(GetBaseRace() == OGRE) {
+			racemod = 1.15;
+		} else if(GetBaseRace() == BARBARIAN) {
+			racemod = 1.05;
+		} else if(GetBaseRace() == HALFLING) {
+			racemod = 0.95;
+		}
+
+		finalxp = uint32(finalxp * racemod);
+	}
+
+	if(RuleB(Character,UseOldClassExpPenalties))
+	{
+		float classmod = 1.0;
+		if(GetClass() == PALADIN || GetClass() == SHADOWKNIGHT || GetClass() == RANGER || GetClass() == BARD) {
+			classmod = 1.4;
+		} else if(GetClass() == MONK) {
+			classmod = 1.2;
+		} else if(GetClass() == WIZARD || GetClass() == ENCHANTER || GetClass() == MAGICIAN || GetClass() == NECROMANCER) {
+			classmod = 1.1;
+		} else if(GetClass() == ROGUE) {
+			classmod = 0.91;
+		} else if(GetClass() == WARRIOR) {
+			classmod = 0.9;
+		}
+
+		finalxp = uint32(finalxp * classmod);
+	}
+
 	finalxp = mod_client_xp_for_level(finalxp, check_level);
 
 	return finalxp;


### PR DESCRIPTION
I wasn't sure if this was something that was wanted in the base code.  This created two rules (false by default) that control the old race and class experience penalties/bonuses, as the class penalties were removed in Velious while the race penalties weren't removed until much later.  The change is put in by increasing the character's required xp to level, as opposed to penalizing xp gains, as this is how it was originally implemented by SOE.  Ideally, they should be used separately from Character:UseRaceClassExpBonuses to avoid doubling up on bonuses.

Let me know if this style change isn't wanted in the base code and I'll refrain from future pull requests of this kind.