### PR TITLE
MSVC 2015 wants <algorithm> #included for std::min.  If any other com…

### DIFF
--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -1,6 +1,10 @@
 #include <iostream>
 #include <cstring>
 
+#if defined(_MSC_VER) && _MSC_VER >= 1900
+	#include <algorithm>
+#endif
+
 #include "classes.h"
 #include "eq_packet_structs.h"
 #include "eqemu_exception.h"


### PR DESCRIPTION
MSVC 2015 wants <algorithm> #included for std::min.  If any other compilers require the same, feel free to alter the #if test.