### PR TITLE
* CheckNameFilter minimum surname check incorrect

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -1183,21 +1183,16 @@ bool Database::CheckNameFilter(const char* name, bool surname)
 {
 	std::string str_name = name;
 
-	if(surname)
+	// the minimum 4 is enforced by the client too
+	if (!name || strlen(name) < 4)
 	{
-		// the minimum 4 is enforced by the client too
-		if(!name || strlen(name) < 3)
-		{
-			return false;
-		}
+		return false;
 	}
-	else
+
+	// Given name length is enforced by the client too
+	if (!surname && strlen(name) > 15)
 	{
-		// the minimum 4 is enforced by the client too
-		if(!name || strlen(name) < 4 || strlen(name) > 15)
-		{
-			return false;
-		}
+		return false;
 	}
 
 	for (size_t i = 0; i < str_name.size(); i++)


### PR DESCRIPTION
CheckNameFilter was enforcing given name as minimum length 4, but surnames were being limited to minimum length of 3.  Confirmed in the client that minimum length is 4.

Minor refactoring of CheckNameFilter to eliminate redundant code.  The check for null name and name min length 4 was duplicated (which is probably where the typo came from) so I eliminated the duplicate.