### PR TITLE
* LightProfile_Struct::TypeToLevel.  Incorrect comparision in case statement.

### DIFF
--- a/common/item.cpp
+++ b/common/item.cpp
@@ -2416,7 +2416,7 @@ uint8 LightProfile_Struct::TypeToLevel(uint8 lightType)
 		return lightLevelSmallMagic;	// 3
 	case lightTypeTorch:
 		return lightLevelTorch;			// 2
-	case lightLevelCandle:
+	case lightTypeCandle:
 		return lightLevelCandle;		// 1
 	default:
 		return lightLevelUnlit;			// 0


### PR DESCRIPTION
The case statement for lightLevelCandle should be comparing against lightTypeCandle as the check is on light types, not light levels.  Light levels are used for the return value.

The numerical value for lightLevelCandle and lightTypeCandle are the same (1) which is why this never broke anything, but it was still an incorrect comparision.