### PR TITLE
Loadlootdrops (shareddb.cpp) not exiting on error

### DIFF
--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -1920,6 +1920,7 @@ void SharedDatabase::LoadLootDrops(void *data, uint32 size) {
                             "ON lootdrop.id = lootdrop_entries.lootdrop_id ORDER BY lootdrop_id";
     auto results = QueryDatabase(query);
     if (!results.Success()) {
+		return;
     }
 
     uint32 current_id = 0;


### PR DESCRIPTION
If an error occurs (!results.Success()) in loadlootdrops the method continues processing instead of exiting.