### PR TITLE
Item weights being downcast to uint8

### DIFF
--- a/common/item_struct.h
+++ b/common/item_struct.h
@@ -83,7 +83,7 @@ struct Item_Struct {
 	char	Lore[80];		// Lore Name: *=lore, &=summoned, #=artifact, ~=pending lore
 	char	IDFile[30];		// Visible model
 	uint32	ID;				// Unique ID (also PK for DB)
-	uint8	Weight;			// Item weight * 10
+	int32	Weight;			// Item weight * 10
 	uint8	NoRent;			// No Rent: 0=norent, 255=not norent
 	uint8	NoDrop;			// No Drop: 0=nodrop, 255=not nodrop
 	uint8	Size;			// Size: 0=tiny, 1=small, 2=medium, 3=large, 4=giant

--- a/common/patches/sod.cpp
+++ b/common/patches/sod.cpp
@@ -3623,7 +3623,8 @@ namespace SoD
 		memset(&ibs, 0, sizeof(SoD::structs::ItemBodyStruct));
 
 		ibs.id = item->ID;
-		ibs.weight = item->Weight;
+		// weight is uint8 in the struct, and some weights exceed that, so capping at 255.
+		ibs.weight = (item->Weight > 255) ? 255 : item->Weight;
 		ibs.norent = item->NoRent;
 		ibs.nodrop = item->NoDrop;
 		ibs.attune = item->Attuneable;

--- a/common/patches/sof.cpp
+++ b/common/patches/sof.cpp
@@ -2945,7 +2945,8 @@ namespace SoF
 		memset(&ibs, 0, sizeof(SoF::structs::ItemBodyStruct));
 
 		ibs.id = item->ID;
-		ibs.weight = item->Weight;
+		// weight is uint8 in the struct, and some weights exceed that, so capping at 255.
+		ibs.weight = (item->Weight > 255) ? 255 : item->Weight;
 		ibs.norent = item->NoRent;
 		ibs.nodrop = item->NoDrop;
 		ibs.attune = item->Attuneable;

--- a/common/patches/uf.cpp
+++ b/common/patches/uf.cpp
@@ -3924,7 +3924,8 @@ namespace UF
 		memset(&ibs, 0, sizeof(UF::structs::ItemBodyStruct));
 
 		ibs.id = item->ID;
-		ibs.weight = item->Weight;
+		// weight is uint8 in the struct, and some weights exceed that, so capping at 255.
+		ibs.weight = (item->Weight > 255) ? 255 : item->Weight;
 		ibs.norent = item->NoRent;
 		ibs.nodrop = item->NoDrop;
 		ibs.attune = item->Attuneable;

--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -857,7 +857,7 @@ void SharedDatabase::LoadItems(void *data, uint32 size, int32 items, uint32 max_
 		strcpy(item.IDFile, row[ItemField::idfile]);
 
 		item.ID = (uint32)atoul(row[ItemField::id]);
-		item.Weight = (uint8)atoi(row[ItemField::weight]);
+		item.Weight = (int32)atoi(row[ItemField::weight]);
 		item.NoRent = disableNoRent ? (uint8)atoi("255") : (uint8)atoi(row[ItemField::norent]);
 		item.NoDrop = disableNoDrop ? (uint8)atoi("255") : (uint8)atoi(row[ItemField::nodrop]);
 		item.Size = (uint8)atoi(row[ItemField::size]);


### PR DESCRIPTION
Item weight was being downcast to uint8 which impacted any item with weight over 255.  For SoD, SoF, and UF, prior to sending item info to the client we now cap weight at 255 to ensure the item remains heavy instead of being made (in most cases), super light.