### PR TITLE
Changed Item_Struct's CastTime member to uint32 (was uint16)

### DIFF
--- a/common/item_struct.h
+++ b/common/item_struct.h
@@ -160,7 +160,7 @@ struct Item_Struct {
 	//uint32	Unk059;
 	union {
 		uint32 Fulfilment;	// Food fulfilment (How long it lasts)
-		int16 CastTime;		// Cast Time for clicky effects, in milliseconds
+		uint32 CastTime;		// Cast Time for clicky effects, in milliseconds
 	};
 	uint32 EliteMaterial;
 	int32	ProcRate;


### PR DESCRIPTION
Casttime was too small for the possible data values.  The Potion of Serious Healing has a cast time of 90.0 sec (90000) which exceeds the max value of uint16.  Updated Casttime from uint16 to uint32.  This change also makes CastTime have the same data type as Fulfilment which is notable as they are in a struct union and should have the same type.