### PR TITLE
FlatItemExtraSpellAmt Custom Rule Addition

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 EQEMu Changelog (Started on Sept 24, 2003 15:50)
 -------------------------------------------------------
+== 02/10/2016 ==
+Hateborne: Added FlatItemExtraSpellAmt rule (boolean) to allow SpellDmg on items to be added as raw damage versus scaled.
+
 == 01/26/2016 ==
 Uleat: Fix for Berserker 'Piercing' skill issues. Server Admins: If you run custom skill sets, this patch touches the code segments that you will need to modify if you have changed the default berserker 1H-/2H-piercing skill values.
 Uleat (Daerath): Fix for precision-loss item weight conversions in older clients.

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -361,6 +361,7 @@ RULE_BOOL(Spells, NPC_UseFocusFromSpells, true) // Allow npcs to use most spell 
 RULE_BOOL(Spells, NPC_UseFocusFromItems, false) // Allow npcs to use most item derived focus effects.
 RULE_BOOL(Spells, UseAdditiveFocusFromWornSlot, false) // Allows an additive focus effect to be calculated from worn slot.
 RULE_BOOL(Spells, AlwaysSendTargetsBuffs, false) // ignore LAA level if true
+RULE_BOOL(Spells, FlatItemExtraSpellAmt, false) // allow SpellDmg stat to affect all spells, regardless of cast time/cooldown/etc
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Combat)

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -225,6 +225,9 @@ int32 Mob::GetActDoTDamage(uint16 spell_id, int32 value, Mob* target) {
 
 int32 Mob::GetExtraSpellAmt(uint16 spell_id, int32 extra_spell_amt, int32 base_spell_dmg)
 {
+	if (RuleB(Spells, FlatItemExtraSpellAmt))
+		return extra_spell_amt;
+
 	int total_cast_time = 0;
 
 	if (spells[spell_id].recast_time >= spells[spell_id].recovery_time)


### PR DESCRIPTION
Added FlatItemExtraSpellAmt rule (boolean) to allow SpellDmg on items to
be added as raw damage versus scaled.