### PR TITLE
Zone crash fix

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -1732,7 +1732,10 @@ bool Mob::DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_ce
 						}
 						else if(IsRaidGrouped())
 						{
-							group_id_caster = (GetRaid()->GetGroup(CastToClient()) == 0xFFFF) ? 0 : (GetRaid()->GetGroup(CastToClient()) + 1);
+							if (Raid* raid = GetRaid()) {
+								uint32 group_id = raid->GetGroup(CastToClient());
+                group_id_caster = (group_id == 0xFFFFFFFF) ? 0 : (group_id + 1);
+							}
 						}
 					}
 					else if(IsPet())
@@ -1744,7 +1747,10 @@ bool Mob::DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_ce
 						}
 						else if(owner->IsRaidGrouped())
 						{
-							group_id_caster = (owner->GetRaid()->GetGroup(CastToClient()) == 0xFFFF) ? 0 : (owner->GetRaid()->GetGroup(CastToClient()) + 1);
+							if (Raid* raid = owner->GetRaid()) {
+								uint32 group_id = raid->GetGroup(owner->CastToClient());
+                group_id_caster = (group_id == 0xFFFFFFFF) ? 0 : (group_id + 1);
+							}
 						}
 					}
 #ifdef BOTS
@@ -1770,7 +1776,10 @@ bool Mob::DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_ce
 						}
 						else if(spell_target->IsRaidGrouped())
 						{
-							group_id_target = (spell_target->GetRaid()->GetGroup(CastToClient()) == 0xFFFF) ? 0 : (spell_target->GetRaid()->GetGroup(CastToClient()) + 1);
+							if (Raid* raid = spell_target->GetRaid()) {
+								uint32 group_id = raid->GetGroup(spell_target->CastToClient());
+                group_id_target = (group_id == 0xFFFFFFFF) ? 0 : (group_id + 1);
+							}
 						}
 					}
 					else if(spell_target->IsPet())
@@ -1782,7 +1791,10 @@ bool Mob::DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_ce
 						}
 						else if(owner->IsRaidGrouped())
 						{
-							group_id_target = (owner->GetRaid()->GetGroup(CastToClient()) == 0xFFFF) ? 0 : (owner->GetRaid()->GetGroup(CastToClient()) + 1);
+							if (Raid* raid = owner->GetRaid()) {
+								uint32 group_id = raid->GetGroup(owner->CastToClient());
+                group_id_target = (group_id == 0xFFFFFFFF) ? 0 : (group_id + 1);
+							}
 						}
 					}
 #ifdef BOTS

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -1734,7 +1734,7 @@ bool Mob::DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_ce
 						{
 							if (Raid* raid = GetRaid()) {
 								uint32 group_id = raid->GetGroup(CastToClient());
-                group_id_caster = (group_id == 0xFFFFFFFF) ? 0 : (group_id + 1);
+								group_id_caster = (group_id == 0xFFFFFFFF) ? 0 : (group_id + 1);
 							}
 						}
 					}
@@ -1749,7 +1749,7 @@ bool Mob::DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_ce
 						{
 							if (Raid* raid = owner->GetRaid()) {
 								uint32 group_id = raid->GetGroup(owner->CastToClient());
-                group_id_caster = (group_id == 0xFFFFFFFF) ? 0 : (group_id + 1);
+								group_id_caster = (group_id == 0xFFFFFFFF) ? 0 : (group_id + 1);
 							}
 						}
 					}
@@ -1778,7 +1778,7 @@ bool Mob::DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_ce
 						{
 							if (Raid* raid = spell_target->GetRaid()) {
 								uint32 group_id = raid->GetGroup(spell_target->CastToClient());
-                group_id_target = (group_id == 0xFFFFFFFF) ? 0 : (group_id + 1);
+								group_id_target = (group_id == 0xFFFFFFFF) ? 0 : (group_id + 1);
 							}
 						}
 					}
@@ -1793,7 +1793,7 @@ bool Mob::DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_ce
 						{
 							if (Raid* raid = owner->GetRaid()) {
 								uint32 group_id = raid->GetGroup(owner->CastToClient());
-                group_id_target = (group_id == 0xFFFFFFFF) ? 0 : (group_id + 1);
+								group_id_target = (group_id == 0xFFFFFFFF) ? 0 : (group_id + 1);
 							}
 						}
 					}


### PR DESCRIPTION
This fixes a case where spells with spell target ST_GroupClientAndPet (notably spirit of the panther, etc.. not many spells use this type) crash zone when Mob::IsRaidGrouped() returns true and Mob::GetRaid() returns null. Athrogate has sent me a few PEQ crash reports where this was the cause.

Also fixed a couple spots where the wrong mob was being cast to client when getting the target group id, but I don't think that was causing any real problems.

This doesn't address the underlying mismatch between those functions but that seems to be a pretty deep problem.