### PR TITLE
Exported GetSpellIDFromSlot into Perl

### DIFF
--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -2362,6 +2362,37 @@ XS(XS_Mob_GetSpellHPBonuses)
 	XSRETURN(1);
 }
 
+XS(XS_Mob_GetSpellIDFromSlot); /* prototype to pass -Wmissing-prototypes */
+XS(XS_Mob_GetSpellIDFromSlot)
+{
+	dXSARGS;
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: Mob::GetSpellIDFromSlot(THIS, slot)");
+	{
+		Mob *		THIS;
+		int		RETVAL;
+		dXSTARG;
+		uint8		slot = (uint16)SvUV(ST(1));
+
+		if (sv_derived_from(ST(0), "Mob")) {
+			IV tmp = SvIV((SV*)SvRV(ST(0)));
+			THIS = INT2PTR(Mob *, tmp);
+		}
+		else
+			Perl_croak(aTHX_ "THIS is not of type Mob");
+		if (THIS == nullptr)
+			Perl_croak(aTHX_ "THIS is nullptr, avoiding crash.");
+
+		if (slot > THIS->GetMaxBuffSlots())
+			RETVAL = -1;
+		else 
+			RETVAL = THIS->GetSpellIDFromSlot(slot);
+
+		XSprePUSH; PUSHi((IV)RETVAL);
+	}
+	XSRETURN(1);
+}
+
 XS(XS_Mob_GetWalkspeed); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Mob_GetWalkspeed)
 {
@@ -9105,6 +9136,7 @@ XS(boot_Mob)
 		newXSproto(strcpy(buf, "GetMaxHP"), XS_Mob_GetMaxHP, file, "$");
 		newXSproto(strcpy(buf, "GetItemHPBonuses"), XS_Mob_GetItemHPBonuses, file, "$");
 		newXSproto(strcpy(buf, "GetSpellHPBonuses"), XS_Mob_GetSpellHPBonuses, file, "$");
+		newXSproto(strcpy(buf, "GetSpellIDFromSlot"), XS_Mob_GetSpellIDFromSlot, file, "$$");
 		newXSproto(strcpy(buf, "GetWalkspeed"), XS_Mob_GetWalkspeed, file, "$");
 		newXSproto(strcpy(buf, "GetRunspeed"), XS_Mob_GetRunspeed, file, "$");
 		newXSproto(strcpy(buf, "GetCasterLevel"), XS_Mob_GetCasterLevel, file, "$$");


### PR DESCRIPTION
Exported the GetSpellIDFromSlot into Perl. Currently, there are numerous
Perl objections that can accept buff slot info, but nothing that can
return the buffs a mob/client currently has. This lets us iterate over
them with a loop, returning -1 if the slot requested doesn't exist.

Additionally: Tested this with valid buff slots and outrageous ones to ensure it doesn't cause a crash.