### PR TITLE
VS2015: Fix compile errors after EQDictionary rework

### DIFF
--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -1084,7 +1084,11 @@ void SharedDatabase::LoadItems(void *data, uint32 size, int32 items, uint32 max_
 	}
 }
 
+#if (defined(_MSC_VER) && (_MSC_VER > 1899))
+Item_Struct* SharedDatabase::GetItem(uint32 id) {
+#else
 const Item_Struct* SharedDatabase::GetItem(uint32 id) {
+#endif
 	if (id == 0)
 	{
 		return nullptr;

--- a/common/shareddb.h
+++ b/common/shareddb.h
@@ -111,7 +111,11 @@ class SharedDatabase : public Database
 		void LoadItems(void *data, uint32 size, int32 items, uint32 max_item_id);
 		bool LoadItems(const std::string &prefix);
 		const Item_Struct* IterateItems(uint32* id);
+#if (defined(_MSC_VER) && (_MSC_VER > 1899))
+		Item_Struct* GetItem(uint32 id);
+#else
 		const Item_Struct* GetItem(uint32 id);
+#endif
 		const EvolveInfo* GetEvolveInfo(uint32 loregroup);
 
 		//faction lists


### PR DESCRIPTION
VS2015: In zone\client.cpp, fix call(s) to SharedDatabase::GetItem fails if SharedDatabase::GetItem is declared as const.  (This must not be an issue for non-MS compilers? #defined fix for only if MSVC 2015.)  Error appeared after Uleat's "Reworked EQDictionary into namespace EQEmu" commit. 
This doesn't _appear_ to break anything else; then again I am not analytical enough to resolve this other than by brute force.