### PR TITLE
reording includes fixes patch file location problem

### DIFF
--- a/common/patches/rof.cpp
+++ b/common/patches/rof.cpp
@@ -18,6 +18,7 @@
 */
 
 #include "../global_define.h"
+#include "../eqemu_config.h"
 #include "../eqemu_logsys.h"
 #include "rof.h"
 #include "../opcodemgr.h"
@@ -31,7 +32,6 @@
 #include "../item.h"
 #include "rof_structs.h"
 #include "../rulesys.h"
-#include "../eqemu_config.h"
 
 #include <iostream>
 #include <sstream>

--- a/common/patches/rof2.cpp
+++ b/common/patches/rof2.cpp
@@ -18,6 +18,7 @@
 */
 
 #include "../global_define.h"
+#include "../eqemu_config.h"
 #include "../eqemu_logsys.h"
 #include "rof2.h"
 #include "../opcodemgr.h"
@@ -31,7 +32,6 @@
 #include "../item.h"
 #include "rof2_structs.h"
 #include "../rulesys.h"
-#include "../eqemu_config.h"
 
 #include <iostream>
 #include <sstream>

--- a/common/patches/sod.cpp
+++ b/common/patches/sod.cpp
@@ -18,6 +18,7 @@
 */
 
 #include "../global_define.h"
+#include "../eqemu_config.h"
 #include "../eqemu_logsys.h"
 #include "sod.h"
 #include "../opcodemgr.h"
@@ -31,7 +32,6 @@
 #include "../item.h"
 #include "sod_structs.h"
 #include "../rulesys.h"
-#include "../eqemu_config.h"
 
 #include <iostream>
 #include <sstream>

--- a/common/patches/sof.cpp
+++ b/common/patches/sof.cpp
@@ -18,6 +18,7 @@
 */
 
 #include "../global_define.h"
+#include "../eqemu_config.h"
 #include "../eqemu_logsys.h"
 #include "sof.h"
 #include "../opcodemgr.h"
@@ -31,7 +32,6 @@
 #include "../item.h"
 #include "sof_structs.h"
 #include "../rulesys.h"
-#include "../eqemu_config.h"
 
 #include <iostream>
 #include <sstream>

--- a/common/patches/titanium.cpp
+++ b/common/patches/titanium.cpp
@@ -18,6 +18,7 @@
 */
 
 #include "../global_define.h"
+#include "../eqemu_config.h"
 #include "../eqemu_logsys.h"
 #include "titanium.h"
 #include "../opcodemgr.h"
@@ -30,7 +31,6 @@
 #include "../misc_functions.h"
 #include "../string_util.h"
 #include "../item.h"
-#include "../eqemu_config.h"
 #include "titanium_structs.h"
 
 #include <sstream>

--- a/common/patches/uf.cpp
+++ b/common/patches/uf.cpp
@@ -18,6 +18,7 @@
 */
 
 #include "../global_define.h"
+#include "../eqemu_config.h"
 #include "../eqemu_logsys.h"
 #include "uf.h"
 #include "../opcodemgr.h"
@@ -31,7 +32,6 @@
 #include "../item.h"
 #include "uf_structs.h"
 #include "../rulesys.h"
-#include "../eqemu_config.h"
 
 #include <iostream>
 #include <sstream>


### PR DESCRIPTION
I get these errors without eqemu_config.h above eqemu_logsys.h
Unable to open opcodes file 'spells_us.txtpatch_SoF.conf'. Thats bad.
Unable to open opcodes file 'spells_us.txtpatch_SoD.conf'. Thats bad.
Unable to open opcodes file 'spells_us.txtpatch_UF.conf'. Thats bad.
Unable to open opcodes file 'spells_us.txtpatch_RoF.conf'. Thats bad.
Unable to open opcodes file 'spells_us.txtpatch_RoF2.conf'. Thats bad.

This fixes that.  I can't explain why this fixes it, so there might be a better solution.