### PR TITLE
Fix for detrimental/beneficial spell overwrite and/or block.

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -2984,18 +2984,6 @@ int Mob::CheckStackConflict(uint16 spellid1, int caster_level1, uint16 spellid2,
 		}
 
 		/*
-		If the effects are the same and
-		sp1 = beneficial & sp2 = detrimental or
-		sp1 = detrimental & sp2 = beneficial
-		Then this effect should be ignored for stacking purposes.
-		*/
-		if(sp_det_mismatch)
-		{
-			Log.Out(Logs::Detail, Logs::Spells, "The effects are the same but the spell types are not, passing the effect");
-			continue;
-		}
-
-		/*
 		If the spells aren't the same
 		and the effect is a dot we can go ahead and stack it
 		*/


### PR DESCRIPTION
Spells like listless power and dread touch should be taking down/blocking spells like augmentation and strenthen respectively.  The stacking code was being bypassed when a beneficial spell and a detrimental spell for the same effect were being compared.

With this code removed, the spells are compared and the stronger of the two spells wins and replaces or blocks the other.

Without this change, for example, dread touch takes down strengthen on the
client, but the server still things strength is up, causing a mismatch.

With this change, client/server match.  When a beneficial spell is stronger, it blocks/replaces the detrimental one.  When the beneficial spell is weaker, it is overwritten/blocked by the detrimental.  When they are equal, they can replace one another back and forth.

I am not the expert here, but this change has been working for me for years.  However, my server is a low level server (level 50 max).

I posted this thread about it way back in 2013 when I was not even close to being on the same code base on the main line.  I'm just getting around to pushing this change up.

[(http://www.eqemulator.org/forums/showthread.php?t=36940)]

Do you approve of this change, or should it be done another way.  It seems to work great for me here.