### PR TITLE
Changed personal faction earned min/max values to -2000/2000.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 EQEMu Changelog (Started on Sept 24, 2003 15:50)
 -------------------------------------------------------
+== 06/13/2016 ==
+Noudess: Changes personal faction earned min/max to -2000/2000 from -3000/1200
+
 == 06/06/2016 ==
 Uleat: Reworked EQEmuDictionary to use class LookupEntry
 

--- a/common/features.h
+++ b/common/features.h
@@ -213,8 +213,8 @@ enum {	//some random constants
 #define MAX_NPC_FACTIONS 20
 
 //individual faction pool
-#define MAX_PERSONAL_FACTION 1200
-#define MIN_PERSONAL_FACTION -3000
+#define MAX_PERSONAL_FACTION 2000
+#define MIN_PERSONAL_FACTION -2000
 
 //The Level Cap:
 //#define LEVEL_CAP RuleI(Character, MaxLevel)	//hard cap is 127


### PR DESCRIPTION
As per some consensus, changing the min/max personal earned faction constants to -2000/2000.

There will be some autocorrection for people that are currently bottomed out.  Their new personal faction will end up being -2000 if they were already below that (as -2000 is the new low not counting modifiers).

See threads and issues:

[https://github.com/EQEmu/Server/issues/513](url)

[http://www.eqemulator.org/forums/showthread.php?p=249403&posted=1#post249403](url)

[http://www.peqtgc.com/phpBB3/viewtopic.php?f=17&t=15758&p=75196#p75196](url)