### PR TITLE
Res effects now block certain buffs like on live.  Blocked spells generate message like on live.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 EQEMu Changelog (Started on Sept 24, 2003 15:50)
 -------------------------------------------------------
+== 06/28/2016
+Noudess: Resurrection effects now block certain buffs like on live.
+Noudess: Added message about why spells are blocked (rule based)
+Noudess: Added new rule:  Client:UseLiveBlockedMessage
+
 == 06/13/2016 ==
 Noudess: Changes personal faction earned min/max to -2000/2000 from -3000/1200
 

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -665,6 +665,7 @@ RULE_CATEGORY_END()
 
 RULE_CATEGORY(Client)
 RULE_BOOL(Client, UseLiveFactionMessage, false) // Allows players to see faction adjustments like Live
+RULE_BOOL(Client, UseLiveBlockedMessage, false) // Allows players to see faction adjustments like Live
 RULE_CATEGORY_END()
 
 #undef RULE_CATEGORY

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -2775,23 +2775,6 @@ int Mob::CheckStackConflict(uint16 spellid1, int caster_level1, uint16 spellid2,
 	int modval = mod_spell_stack(spellid1, caster_level1, caster1, spellid2, caster_level2, caster2);
 	if(modval < 2) { return(modval); }
 
-	//resurrection effects wont count for overwrite/block stacking
-	switch(spellid1)
-	{
-	case 756:
-	case 757:
-	case 5249:
-		return (0);
-	}
-
-	switch (spellid2)
-	{
-	case 756:
-	case 757:
-	case 5249:
-		return (0);
-	}
-
 	/*
 	One of these is a bard song and one isn't and they're both beneficial so they should stack.
 	*/
@@ -3135,6 +3118,9 @@ int Mob::AddBuff(Mob *caster, uint16 spell_id, int duration, int32 level_overrid
 			if (ret == -1) {	// stop the spell
 				Log.Out(Logs::Detail, Logs::Spells, "Adding buff %d failed: stacking prevented by spell %d in slot %d with caster level %d",
 						spell_id, curbuf.spellid, buffslot, curbuf.casterlevel);
+				if (caster->IsClient()) {
+					caster->Message(13, "Your %s did not take hold on %s. (Blocked by %s.)", spells[spell_id].name, this->GetName(), spells[curbuf.spellid].name);
+				}
 				return -1;
 			}
 			if (ret == 1) {	// set a flag to indicate that there will be overwriting
@@ -3295,6 +3281,7 @@ int Mob::CanBuffStack(uint16 spellid, uint8 caster_level, bool iFailIfOverwrite)
 				firstfree = i;
 		}
 		if(ret == -1) {
+			
 			Log.Out(Logs::Detail, Logs::AI, "Buff %d would conflict with %d in slot %d, reporting stack failure", spellid, curbuf.spellid, i);
 			return -1;	// stop the spell, can't stack it
 		}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3118,7 +3118,7 @@ int Mob::AddBuff(Mob *caster, uint16 spell_id, int duration, int32 level_overrid
 			if (ret == -1) {	// stop the spell
 				Log.Out(Logs::Detail, Logs::Spells, "Adding buff %d failed: stacking prevented by spell %d in slot %d with caster level %d",
 						spell_id, curbuf.spellid, buffslot, curbuf.casterlevel);
-				if (caster->IsClient()) {
+				if (caster->IsClient() && RuleB(Client, UseLiveBlockedMessage)) {
 					caster->Message(13, "Your %s did not take hold on %s. (Blocked by %s.)", spells[spell_id].name, this->GetName(), spells[curbuf.spellid].name);
 				}
 				return -1;


### PR DESCRIPTION
Resurrection effects have always blocked some spells (like strength).  I took out the code that prevented this.

I also added a message to make us look like live as far as when spells are blocked.  Example:

_[Mon Jun 27 09:53:27 2016] Your Flawed Defiant Plate Boots shimmers briefly.
[Mon Jun 27 09:53:27 2016] You begin casting Frenzied Strength.
[Mon Jun 27 09:53:29 2016] Your Frenzied Strength spell did not take hold on Cendabik. (Blocked by Resurrection Sickness.)_

I'm not sure when live started showing this message.  Do you guys want me to add a RULE around this or is it good?