### PR TITLE
#summon will now work when you are in an instance.

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -2148,3 +2148,15 @@ int Database::GetIPExemption(std::string account_ip) {
 	
 	return RuleI(World, MaxClientsPerIP);
 }
+
+int Database::GetInstanceID(uint32 char_id, uint32 zone_id) {
+	std::string query = StringFormat("SELECT instance_list.id FROM instance_list INNER JOIN instance_list_player ON instance_list.id = instance_list_player.id WHERE instance_list.zone = '%i' AND instance_list_player.charid = '%i'", zone_id, char_id);
+	auto results = QueryDatabase(query);
+
+	if (results.Success() && results.RowCount() > 0) {
+		auto row = results.begin();
+		return atoi(row[0]);;
+	}
+
+	return 0;
+}

--- a/common/database.h
+++ b/common/database.h
@@ -189,6 +189,8 @@ public:
 	
 	int		GetIPExemption(std::string account_ip);
 
+	int		GetInstanceID(uint32 char_id, uint32 zone_id);
+
 
 	/* Groups */
 	

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -1007,6 +1007,7 @@ void command_summon(Client *c, const Seperator *sep)
 				szp->x_pos = c->GetX(); // May need to add a factor of 8 in here..
 				szp->y_pos = c->GetY();
 				szp->z_pos = c->GetZ();
+				szp->instance_id = zone->GetInstanceID();
 				worldserver.SendPacket(pack);
 				safe_delete(pack);
 			}

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -543,7 +543,18 @@ void WorldServer::Process() {
 				else {
 					SendEmoteMessage(szp->adminname, 0, 0, "Summoning %s to %s %1.1f, %1.1f, %1.1f", szp->name, szp->zone, szp->x_pos, szp->y_pos, szp->z_pos);
 				}
-				client->MovePC(database.GetZoneID(szp->zone), szp->instance_id, szp->x_pos, szp->y_pos, szp->z_pos, client->GetHeading(), szp->ignorerestrictions, GMSummon);
+				if (!szp->instance_id) {
+					client->MovePC(database.GetZoneID(szp->zone), szp->instance_id, szp->x_pos, szp->y_pos, szp->z_pos, client->GetHeading(), szp->ignorerestrictions, GMSummon);
+				} else {
+					if (database.GetInstanceID(client->CharacterID(), database.GetZoneID(szp->zone)) == 0) {
+						client->AssignToInstance(szp->instance_id);
+						client->MovePC(database.GetZoneID(szp->zone), szp->instance_id, szp->x_pos, szp->y_pos, szp->z_pos, client->GetHeading(), szp->ignorerestrictions, GMSummon);
+					} else {
+						client->RemoveFromInstance(database.GetInstanceID(client->CharacterID(), database.GetZoneID(szp->zone)));
+						client->AssignToInstance(szp->instance_id);
+						client->MovePC(database.GetZoneID(szp->zone), szp->instance_id, szp->x_pos, szp->y_pos, szp->z_pos, client->GetHeading(), szp->ignorerestrictions, GMSummon);
+					}
+				}
 			}
 			break;
 		}


### PR DESCRIPTION
Before #summon summoned the player to your zone, but if you were in an instance it would not account for that, so they would go to the non-instanced zone at your XYZ.