### PR TITLE
Added quest global support for zone_controller.

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -256,6 +256,7 @@ RULE_INT(Zone, WeatherTimer, 600) // Weather timer when no duration is available
 RULE_BOOL(Zone, EnableLoggedOffReplenishments, true)
 RULE_INT(Zone, MinOfflineTimeToReplenishments, 21600) // 21600 seconds is 6 Hours
 RULE_BOOL(Zone, UseZoneController, true) // Enables the ability to use persistent quest based zone controllers (zone_controller.pl/lua)
+RULE_BOOL(Zone, EnableZoneControllerGlobals, false) // Enables the ability to use quest globals with the zone controller NPC
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Map)

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -872,6 +872,10 @@ bool NPC::SpawnZoneController(){
 	npc_type->merchanttype = 0;
 	npc_type->bodytype = 11;
 
+	if (RuleB(Zone, EnableZoneControllerGlobals)) {
+		npc_type->qglobal = true;
+	}
+
 	npc_type->prim_melee_type = 28;
 	npc_type->sec_melee_type = 28;
 


### PR DESCRIPTION
Added optional rule to enable quest globals on the zone controller NPC, as (sort of) requested [here](http://www.eqemulator.org/forums/showpost.php?p=251101&postcount=6),