### PR TITLE
Exp Raw Value / % Gain

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -55,6 +55,7 @@ RULE_REAL(Character, AAExpMultiplier, 0.5)
 RULE_REAL(Character, GroupExpMultiplier, 0.5)
 RULE_REAL(Character, RaidExpMultiplier, 0.2)
 RULE_BOOL(Character, UseXPConScaling, true)
+RULE_INT(Character, ShowExpValues, 0) //0 - normal, 1 - Show raw experience values, 2 - Show raw experience values AND percent.
 RULE_INT(Character, LightBlueModifier, 40)
 RULE_INT(Character, BlueModifier, 90)
 RULE_INT(Character, WhiteModifier, 100)

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -391,8 +391,8 @@ void Client::SetEXP(uint32 set_exp, uint32 set_aaxp, bool isrezzexp) {
 		uint32 exp_lost = m_pp.exp - set_exp;
 		float exp_percent = (float)((float)exp_lost / (float)(GetEXPForLevel(GetLevel() + 1) - GetEXPForLevel(GetLevel())))*(float)100;
 
-		if (RuleI(Character, ShowExpValues) == 1 && exp_lost > 0) Message(13, "You have lost %i experience.", exp_lost);
-		else if (RuleI(Character, ShowExpValues) == 2 && exp_lost > 0) Message(13, "You have lost %i experience. (%.3f%%)", exp_lost, exp_percent);
+		if (RuleI(Character, ShowExpValues) == 1 && exp_lost > 0) Message(15, "You have lost %i experience.", exp_lost);
+		else if (RuleI(Character, ShowExpValues) == 2 && exp_lost > 0) Message(15, "You have lost %i experience. (%.3f%%)", exp_lost, exp_percent);
 		else Message(15, "You have lost experience.");		
 	}
 


### PR DESCRIPTION
![exp](https://cloud.githubusercontent.com/assets/845670/18828968/1f394ed6-838f-11e6-8272-0af5e284ef69.png)

Added new ruleset Character:ShowExpValues
If 0, default behavior will be set. (Default)
If 1, exp raw values will show.
If 2, exp raw values and % gains will show.