### PR TITLE
Fix Random Ground Spawn Z

### DIFF
--- a/utils/sql/git/optional/2016_09_29_GroundSpawnsMaxZ.sql
+++ b/utils/sql/git/optional/2016_09_29_GroundSpawnsMaxZ.sql
@@ -1,0 +1,1 @@
+UPDATE ground_spawns SET max_z = -99999 WHERE max_x != min_x OR max_y != min_y

--- a/zone/object.cpp
+++ b/zone/object.cpp
@@ -451,6 +451,21 @@ void Object::RandomSpawn(bool send_packet) {
 
 	m_data.x = zone->random.Real(m_min_x, m_max_x);
 	m_data.y = zone->random.Real(m_min_y, m_max_y);
+	
+	if(m_data.z == BEST_Z_INVALID) {
+		glm::vec3 me;
+		me.x = m_data.x;
+		me.y = m_data.y;
+		me.z = 0;
+		glm::vec3 hit;
+		float best_z = zone->zonemap->FindClosestZ(me, &hit);
+		if (best_z != BEST_Z_INVALID) {
+			m_data.z = best_z;
+		} 
+	}
+
+	Log.Out(Logs::Detail, Logs::Zone_Server, "Object::RandomSpawn(%s): %d (%.2f, %.2f, %.2f)", m_data.object_name, m_inst->GetID(), m_data.x, m_data.y, m_data.z);
+	
 	respawn_timer.Disable();
 
 	if(send_packet) {

--- a/zone/object.cpp
+++ b/zone/object.cpp
@@ -460,7 +460,7 @@ void Object::RandomSpawn(bool send_packet) {
 		glm::vec3 hit;
 		float best_z = zone->zonemap->FindClosestZ(me, &hit);
 		if (best_z != BEST_Z_INVALID) {
-			m_data.z = best_z;
+			m_data.z = best_z + 0.1f;
 		} 
 	}
 


### PR DESCRIPTION
This fixes the random ground spawn z location on RoF2 clients, notably the Eastern Wastes skinning rocks, but also other occurrences. Titanium did not have an issue with this, and it is tested to still be functional.

I changed the max_z in the database to be equal to BEST_Z_INVALID (-99,999) to activate this code, and when ground spawns are generated, the Z value is set to the closest Z per the map file. To affect all ground spawns with variance in the X/Y location, use this query: `UPDATE ground_spawns SET max_z = -99999 WHERE max_x != min_x OR max_y != min_y`.

I also had to reorder the zone initialization code for this to work, as the zonemap is loaded after groundspawns, which prevented calculating the closestZ.