### PR TITLE
Fix rogue merchant usage under sneak.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 EQEMu Changelog (Started on Sept 24, 2003 15:50)
 -------------------------------------------------------
+== 10/09/2016 ==
+Noudess: Rogue usage of merchants while utilizing sneak was limited to
+temporary items, as the code that checked faction per item sold did not
+take into account that rogue was sneaking.  Now sneaking rogues can see full
+inventory on merchants (well, unless an item requires a + faction value).
 == 09/12/2016 ==
 Akkadius: Massive overhaul of the update system and EQEmu Server management utility framework 
 	(known as eqemu_update.pl) now known as eqemu_server.pl

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -12134,11 +12134,6 @@ void Client::Handle_OP_ShopPlayerBuy(const EQApplicationPacket *app)
 			continue;
 		}
 
-		int32 fac = tmp->GetPrimaryFaction();
-		if (fac != 0 && GetModCharacterFactionLevel(fac) < ml.faction_required) {
-			continue;
-		}
-
 		if (mp->itemslot == ml.slot){
 			item_id = ml.item;
 			break;

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -857,7 +857,17 @@ void Client::BulkSendMerchantInventory(int merchant_id, int npcid) {
 			continue;
 
 		int32 fac = merch ? merch->GetPrimaryFaction() : 0;
-		if (fac != 0 && GetModCharacterFactionLevel(fac) < ml.faction_required)
+		int32 cur_fac_level;
+		if (fac == 0 || sneaking)
+			{
+			cur_fac_level = 0;
+			}
+		else
+			{
+			cur_fac_level = GetModCharacterFactionLevel(fac);
+			}
+			
+		if (cur_fac_level < ml.faction_required)
 			continue;
 
 		handychance = zone->random.Int(0, merlist.size() + tmp_merlist.size() - 1);

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -858,14 +858,12 @@ void Client::BulkSendMerchantInventory(int merchant_id, int npcid) {
 
 		int32 fac = merch ? merch->GetPrimaryFaction() : 0;
 		int32 cur_fac_level;
-		if (fac == 0 || sneaking)
-			{
+		if (fac == 0 || sneaking) {
 			cur_fac_level = 0;
-			}
-		else
-			{
+		}
+		else {
 			cur_fac_level = GetModCharacterFactionLevel(fac);
-			}
+		}
 			
 		if (cur_fac_level < ml.faction_required)
 			continue;


### PR DESCRIPTION
Rogue sneak was not taken into account while checking each of the merchants items against faction requirements, resulting in rogues only seeing temporary items on merchants when using sneak/buy.