### PR TITLE
Regen Fix.

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -1831,15 +1831,30 @@ bool Bot::Process() {
 		if(currently_fleeing)
 			ProcessFlee();
 
-		if(GetHP() < GetMaxHP())
-			SetHP(GetHP() + CalcHPRegen() + RestRegenHP);
+		if(GetHP() < GetMaxHP()) {
+			if (static_cast<int64>(GetHP() + CalcHPRegen() + RestRegenHP()) < static_cast<int64>(GetMaxHP())) {
+				SetHP(GetHP() + CalcHPRegen() + RestRegenHP);
+			} else {
+				SetHP(GetMaxHP());
+			}
+		}
 
-		if(GetMana() < GetMaxMana())
-			SetMana(GetMana() + CalcManaRegen() + RestRegenMana);
+		if(GetMana() < GetMaxMana()) {
+			if (static_cast<int64>(GetMana() + CalcManaRegen() + RestRegenMana) < static_cast<int64>(GetMaxMana())) {
+				SetMana(GetMana() + CalcManaRegen() + RestRegenMana);
+			} else {
+				SetMana(GetMaxMana());
+			}
+		}
 
 		CalcATK();
-		if(GetEndurance() < GetMaxEndurance())
-			SetEndurance(GetEndurance() + CalcEnduranceRegen() + RestRegenEndurance);
+		if(GetEndurance() < GetMaxEndurance()) {
+			if (static_cast<int64>(GetEndurance() + CalcEnduranceRegen() + RestRegenEndurance) < static_cast<int64>(GetMaxEndurance())) {
+				SetEndurance(GetEndurance() + CalcEnduranceRegen() + RestRegenEndurance);
+			} else {
+				SetEndurance(GetMaxEndurance());
+			}
+		}
 	}
 
 	if (sendhpupdate_timer.Check(false)) {

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -1776,7 +1776,11 @@ void Client::OPGMSummon(const EQApplicationPacket *app)
 }
 
 void Client::DoHPRegen() {
-	SetHP(GetHP() + CalcHPRegen() + RestRegenHP);
+	if ((GetHP() + CalcHPRegen() + RestRegenHP) < GetMaxHP()) {
+		SetHP(GetHP() + CalcHPRegen() + RestRegenHP);
+	} else {
+		SetHP(GetMaxHP());
+	}
 	SendHPUpdate();
 }
 
@@ -1784,7 +1788,11 @@ void Client::DoManaRegen() {
 	if (GetMana() >= max_mana && spellbonuses.ManaRegen >= 0)
 		return;
 
-	SetMana(GetMana() + CalcManaRegen() + RestRegenMana);
+	if ((GetMana() + CalcManaRegen() + RestRegenMana) < GetMaxMana()) {
+		SetMana(GetMana() + CalcManaRegen() + RestRegenMana);
+	} else {
+		SetMana(GetMaxMana());
+	}
 	SendManaUpdatePacket();
 }
 
@@ -1818,7 +1826,11 @@ void Client::DoEnduranceRegen()
 	if(GetEndurance() >= GetMaxEndurance())
 		return;
 
-	SetEndurance(GetEndurance() + CalcEnduranceRegen() + RestRegenEndurance);
+	if ((GetEndurance() + CalcEnduranceRegen() + RestRegenEndurance) < GetMaxEndurance()) {
+		SetEndurance(GetEndurance() + CalcEnduranceRegen() + RestRegenEndurance);
+	} else {
+		SetEndurance(GetMaxEndurance());
+	}
 }
 
 void Client::DoEnduranceUpkeep() {

--- a/zone/merc.cpp
+++ b/zone/merc.cpp
@@ -1286,14 +1286,29 @@ bool Merc::Process()
 
 		CalcRestState();
 
-		if(GetHP() < GetMaxHP())
-			SetHP(GetHP() + CalcHPRegen() + RestRegenHP);
+		if(GetHP() < GetMaxHP()) {
+			if ((GetHP() + CalcHPRegen() + RestRegenHP) < GetMaxHP()) {
+				SetHP(GetHP() + CalcHPRegen() + RestRegenHP);
+			} else {
+				SetHP(GetMaxHP());
+			}
+		}
 
-		if(GetMana() < GetMaxMana())
-			SetMana(GetMana() + CalcManaRegen() + RestRegenMana);
+		if(GetMana() < GetMaxMana()) {
+			if (static_cast<int64>(GetMana() + CalcManaRegen() + RestRegenMana) < static_cast<int64>(GetMaxMana())) {
+				SetMana(GetMana() + CalcManaRegen() + RestRegenMana);
+			} else {
+				SetMana(GetMaxMana());
+			}
+		}
 
-		if(GetEndurance() < GetMaxEndurance())
-			SetEndurance(GetEndurance() + CalcEnduranceRegen() + RestRegenEndurance);
+		if(GetEndurance() < GetMaxEndurance()) {
+			if (static_cast<int64>(GetEndurance() + CalcEnduranceRegen() + RestRegenEndurance) <static_cast<int64>(GetMaxEndurance())) {
+				SetEndurance(GetEndurance() + CalcEnduranceRegen() + RestRegenEndurance);
+			} else {
+				SetEndurance(GetMaxEndurance());
+			}
+		}
 	}
 
 	if(confidence_timer.Check()) {

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -622,22 +622,56 @@ bool NPC::Process()
 		//Lieka Edit:Fixing NPC regen.NPCs should regen to full during a set duration, not based on their HPs.Increase NPC's HPs by % of total HPs / tick.
 		if((GetHP() < GetMaxHP()) && !IsPet()) {
 			if(!IsEngaged()) {//NPC out of combat
-				if(GetNPCHPRegen() > OOCRegen)
+				if(GetNPCHPRegen() > OOCRegen) {
+					if (static_cast<int64>(GetHP() + GetNPCHPRegen()) < static_cast<int64>(GetMaxHP())) {
+						SetHP(GetHP() + GetNPCHPRegen());
+					} else {
+						SetHP(GetMaxHP());
+					}
+				}
+				else {
+					if (static_cast<int64>(GetHP() + OOCRegen) < static_cast<int64>(GetMaxHP())) {
+						SetHP(GetHP() + OOCRegen);
+					} else {
+						SetHP(GetMaxHP());
+					}
+				}
+			} else {
+				if (static_cast<int64>(GetHP() + GetNPCHPRegen()) < static_cast<int64>(GetMaxHP())) {
 					SetHP(GetHP() + GetNPCHPRegen());
-				else
-					SetHP(GetHP() + OOCRegen);
-			} else
-				SetHP(GetHP()+GetNPCHPRegen());
-		} else if(GetHP() < GetMaxHP() && GetOwnerID() !=0) {
-			if(!IsEngaged()) //pet
-				SetHP(GetHP()+GetNPCHPRegen()+bonus+(GetLevel()/5));
-			else
-				SetHP(GetHP()+GetNPCHPRegen()+bonus);
-		} else
-			SetHP(GetHP()+GetNPCHPRegen());
+				} else {
+					SetHP(GetMaxHP());
+				}
+			}
+		} else if(GetHP() < GetMaxHP() && GetOwnerID() != 0) {
+			if(!IsEngaged()) { //pet
+				if ((GetHP() + GetNPCHPRegen() + bonus + (GetLevel() / 5)) < GetMaxHP()) {
+					SetHP(GetHP() + GetNPCHPRegen() + bonus + (GetLevel() / 5));
+				} else {
+					SetHP(GetMaxHP());
+				}
+			}
+			else {
+				if (static_cast<int64>(GetHP() + GetNPCHPRegen() + bonus) < static_cast<int64>(GetMaxHP())) {
+					SetHP(GetHP() + GetNPCHPRegen() + bonus);
+				} else {
+					SetHP(GetMaxHP());
+				}
+			}
+		} else {
+			if (static_cast<int64>(GetHP() + GetNPCHPRegen()) < static_cast<int64>(GetMaxHP())) {
+				SetHP(GetHP() + GetNPCHPRegen());
+			} else {
+				SetHP(GetMaxHP());
+			}
+		}
 
 		if(GetMana() < GetMaxMana()) {
-			SetMana(GetMana()+mana_regen+bonus);
+			if (static_cast<int64>(GetMana() + mana_regen + bonus) < static_cast<int64>(GetMaxMana())) {
+				SetMana(GetMana() + mana_regen + bonus);
+			} else {
+				SetMana(GetMaxMana());
+			}
 		}
 
 


### PR DESCRIPTION
Fixed regen globally. Regen allowed for health, mana, and endurance t…o go beyond maximum due to the fact we had no safeguard against it. This could cause integer overflow on health in mobs with excessive amounts (2,000,000,000+) health and any regen that would push that beyond the int32 max (2,147,483,647),