### PR TITLE
Optional rule to grant HoTT to newly created characters

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -638,6 +638,13 @@ bool Database::SaveCharacterCreate(uint32 character_id, uint32 account_id, Playe
 		character_id, pp->binds[4].zoneId, 0, pp->binds[4].x, pp->binds[4].y, pp->binds[4].z, pp->binds[4].heading, 4
 	); results = QueryDatabase(query);
 
+        /* HoTT Ability */
+        if(RuleB(Character, GrantHoTTOnCreate))
+        {
+                query = StringFormat("INSERT INTO `character_leadership_abilities` (id, slot, rank) VALUES (%u, %i, %i)", character_id, 14, 1);
+                results = QueryDatabase(query);
+        }
+
 	/* Save Skills */
 	int firstquery = 0;
 	for (int i = 0; i < MAX_PP_SKILL; i++){

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -147,7 +147,7 @@ RULE_BOOL(Character, EnableAvoidanceCap, false)
 RULE_INT(Character, AvoidanceCap, 750) // 750 Is a pretty good value, seen people dodge all attacks beyond 1,000 Avoidance
 RULE_BOOL(Character, AllowMQTarget, false) // Disables putting players in the 'hackers' list for targeting beyond the clip plane or attempting to target something untargetable
 RULE_BOOL(Character, UseOldBindWound, false) // Uses the original bind wound behavior
-
+RULE_BOOL(Character, GrantHoTTOnCreate, false) // Grant Health of Target's Target leadership AA on character creation
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Mercs)

--- a/utils/sql/git/optional/2016_10_17_GrantHoTTOnCharacterCreate.sql
+++ b/utils/sql/git/optional/2016_10_17_GrantHoTTOnCharacterCreate.sql
@@ -1,0 +1,1 @@
+INSERT INTO `rule_values` (`ruleset_id`, `rule_name`, `rule_value`, `notes`) VALUES (1, 'Character:GrantHoTTOnCreate', 'false', 'Grant Health of Target\'s Target leadership AA on character creation');


### PR DESCRIPTION
This adds a rule - Character:GrantHoTTOnCreate - that if turned on will give all newly created characters the group leadership ability Health of Target's Target without the need to spend group ability points.
