### PR TITLE
fix potential plat creation exploit

### DIFF
--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -3,7 +3,7 @@
 
 	This program is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
-	the Free Software Foundation; version 2 of the License.
+	the Free Software Foundation; version 2 of the License.f
 
 	This program is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY except by those people which sell it, which
@@ -1194,6 +1194,12 @@ void Client::OPMoveCoin(const EQApplicationPacket* app)
 	int32 *from_bucket = 0, *to_bucket = 0;
 	Mob* trader = trade->With();
 
+	// if amount < 0, client is sending a malicious packet
+	if (mc->amount < 0)
+	{
+		return;
+	}
+	
 	// could just do a range, but this is clearer and explicit
 	if
 	(


### PR DESCRIPTION
The only thing saving the logic of OPMoveCoin from allowing a potential is that most compilers will generate floating point code that do not properly translate to an unsigned 64 bit integer. It is possible for some platforms, and even more likely with software-based floating point assembly logic, for a platinum creation exploit.  

For instance, if you switch OPMoveCoin's uint64 types with uint32, and send a packet moving a negative amount of platinum, the server will subtract a negative amount . Luckily, as stated, when using unsigned 64 bit unsigned integers, most compilers will generate floating point math that will make it 0, however this isn't guaranteed (technically it falls under undefined behavior).

This just automatically stops all packets that come in with a negative amount from being processed further, effectively removing any chance of future vulnerability.