### PR TITLE
Fix potential infinite loop in loginserver's config file reader

### DIFF
--- a/loginserver/config.cpp
+++ b/loginserver/config.cpp
@@ -144,7 +144,7 @@ void Config::Parse(const char *file_name)
 */
 void Config::Tokenize(FILE *input, std::list<std::string> &tokens)
 {
-	char c = fgetc(input);
+	int c = fgetc(input);
 	std::string lexeme;
 
 	while(c != EOF)


### PR DESCRIPTION
Some platforms define char to be unsigned by default (motivating example: Raspberry Pi / ARMv7) while GCC headers always define EOF as -1. This leads to an infinite loop when EOF values from fgetc() are stored as 255 and then checked against -1 as a stopping condition.