### PR TITLE
Additional LS config parser fixes:

### DIFF
--- a/loginserver/config.cpp
+++ b/loginserver/config.cpp
@@ -144,7 +144,7 @@ void Config::Parse(const char *file_name)
 */
 void Config::Tokenize(FILE *input, std::list<std::string> &tokens)
 {
-	int c = fgetc(input);
+	auto c = fgetc(input);
 	std::string lexeme;
 
 	while(c != EOF)
@@ -162,7 +162,7 @@ void Config::Tokenize(FILE *input, std::list<std::string> &tokens)
 
 		if(isalnum(c))
 		{
-			lexeme.append((const char *)&c, 1);
+			lexeme += c;
 			c = fgetc(input);
 			continue;
 		}
@@ -193,14 +193,14 @@ void Config::Tokenize(FILE *input, std::list<std::string> &tokens)
 					lexeme.clear();
 				}
 
-				lexeme.append((const char *)&c, 1);
+				lexeme += c;
 				tokens.push_back(lexeme);
 				lexeme.clear();
 				break;
 			}
 		default:
 			{
-				lexeme.append((const char *)&c, 1);
+				lexeme += c;
 			}
 		}
 


### PR DESCRIPTION
* use auto
* fix some questionable uses of string.append() that were broken by the use of int/auto (depending on endianness...)

There's no version of string.append() that just takes one character... because string+=(char) exists.