### PR TITLE
Alliance spell line for chanters was not working.

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3631,7 +3631,7 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, bool reflect, bool use_r
 
 				}
 
-				if(!IsBeneficialAllowed(spelltar) ||
+				if((!IsAllianceSpellLine(spell_id) && !IsBeneficialAllowed(spelltar)) ||
 					(IsGroupOnlySpell(spell_id) &&
 						!(
 							(pBasicGroup && ((pBasicGroup == pBasicGroupTarget) || (pBasicGroup == pBasicGroupTargetPet))) || //Basic Group


### PR DESCRIPTION
I'm looking for help here to determine if I need more code for this fix.

Currently, chanters could not cast spells like Benevolence as a check was invalidating all PC->NPC benevolent spells.

I used an existing function (IsAllianceSpellLine()) to fix this.  I'm a little worried about other spells that increases faction ending up in something we don't want.  Any advice from  you guys on if this needs more bolting down, or if this is good enough?

Obviously this worked at some point, but seems broken in the current baseline, unless I am missing some setting.