### PR TITLE
Use languages when reading books that are in a language other than common.

### DIFF
--- a/common/eq_packet_structs.h
+++ b/common/eq_packet_structs.h
@@ -2495,6 +2495,7 @@ struct BookRequest_Struct {
 	uint8 window;	// where to display the text (0xFF means new window)
 	uint8 type;		//type: 0=scroll, 1=book, 2=item info.. prolly others.
 	uint32 invslot;	// Only used in Sof and later clients;
+	int16 subslot; // The subslot inside of a bag if it is inside one.
 	char txtfile[20];
 };
 

--- a/common/patches/rof2.cpp
+++ b/common/patches/rof2.cpp
@@ -5154,6 +5154,7 @@ namespace RoF2
 
 		IN(type);
 		IN(invslot);
+		IN(subslot);
 		emu->window = (uint8)eq->window;
 		strn0cpy(emu->txtfile, eq->txtfile, sizeof(emu->txtfile));
 

--- a/common/patches/rof2_structs.h
+++ b/common/patches/rof2_structs.h
@@ -2826,7 +2826,8 @@ struct BookText_Struct {
 struct BookRequest_Struct {
 /*0000*/	uint32 window;		// where to display the text (0xFFFFFFFF means new window).
 /*0004*/	uint16 invslot;		// Is the slot, but the RoF2 conversion causes it to fail.  Turned to 0 since it isnt required anyway.
-/*0008*/	uint32 unknown006;	// Seen FFFFFFFF
+/*0006*/	int16 subslot;		// Inventory sub-slot (0-x)
+/*0008*/	uint16 unknown006;	// Seen FFFF
 /*0010*/	uint16 unknown008;	// seen 0000
 /*0012*/	uint32 type;		// 0 = Scroll, 1 = Book, 2 = Item Info. Possibly others
 /*0016*/	uint32 unknown0012;

--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -1136,13 +1136,13 @@ const EQEmu::ItemData* SharedDatabase::IterateItems(uint32* id) {
 	return nullptr;
 }
 
-std::string SharedDatabase::GetBook(const char *txtfile)
+std::string SharedDatabase::GetBook(const char *txtfile, int16 *language)
 {
 	char txtfile2[20];
 	std::string txtout;
 	strcpy(txtfile2, txtfile);
 
-	std::string query = StringFormat("SELECT txtfile FROM books WHERE name = '%s'", txtfile2);
+	std::string query = StringFormat("SELECT txtfile, language FROM books WHERE name = '%s'", txtfile2);
 	auto results = QueryDatabase(query);
 	if (!results.Success()) {
 		txtout.assign(" ",1);
@@ -1157,6 +1157,7 @@ std::string SharedDatabase::GetBook(const char *txtfile)
 
     auto row = results.begin();
     txtout.assign(row[0],strlen(row[0]));
+    *language = static_cast<int16>(atoi(row[1]));
 
     return txtout;
 }

--- a/common/shareddb.h
+++ b/common/shareddb.h
@@ -94,7 +94,7 @@ class SharedDatabase : public Database
 		bool	SetStartingItems(PlayerProfile_Struct* pp, EQEmu::InventoryProfile* inv, uint32 si_race, uint32 si_class, uint32 si_deity, uint32 si_current_zone, char* si_name, int admin);
 
 
-		std::string	GetBook(const char *txtfile);
+		std::string	GetBook(const char *txtfile, int16 *language);
 
 		/*
 		    Item Methods

--- a/common/version.h
+++ b/common/version.h
@@ -30,7 +30,7 @@
 	Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
 */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9101
+#define CURRENT_BINARY_DATABASE_VERSION 9102
 #ifdef BOTS
 	#define CURRENT_BINARY_BOTS_DATABASE_VERSION 9008
 #else

--- a/utils/sql/db_update_manifest.txt
+++ b/utils/sql/db_update_manifest.txt
@@ -355,6 +355,7 @@
 9099|2016_08_27_ip_exemptions.sql|SHOW TABLES LIKE 'ip_exemptions'|empty|
 9100|2016_08_27_object_display_name.sql|SHOW COLUMNS FROM `object` LIKE 'display_name'|empty|
 9101|2016_12_01_pcnpc_only.sql|SHOW COLUMNS FROM `spells_new` LIKE 'pcnpc_only_flag'|empty|
+9102|2017_01_10_book_languages.sql|SHOW COLUMNS FROM `books` LIKE 'language'|empty|
 
 # Upgrade conditions:
 # 	This won't be needed after this system is implemented, but it is used database that are not

--- a/utils/sql/git/required/2017_01_10_book_languages.sql
+++ b/utils/sql/git/required/2017_01_10_book_languages.sql
@@ -1,0 +1,15 @@
+alter table books add language int default 0;
+
+drop table reading_is_fundamental;
+
+create table reading_is_fundamental
+(
+filename varchar(32),
+language int
+);
+
+insert into reading_is_fundamental (select items.filename, items.booktype from items where items.filename  != "" group by filename);
+
+update books set books.language = (select language from reading_is_fundamental r where r.filename = books.name);
+
+drop table reading_is_fundamental;


### PR DESCRIPTION
booktype in the items database contains language.  book contains type (scroll or book).  The OP to ReadBook did not contain enough information to implement the language for all clients in a common way.

Titanium only sends up book type (the 0, 1 and 2 field - relating to book in item) and the filename for the text. To get language we would have to do an item query and then pick one of multiple hits.  It made more sense to me to store language in the book table.

With newer clients that send slot, I could have used that to get the item id (in fact I did this until I saw what titanium was doing).  But to make one simple solution, I went with a new column in books.

On a separate issue that I discovered while in the code:

Newer clients send over slot (but this OP did not have all the new slot data decoded).  My changes to this stuff are solely for the newer clients that require book type to be sent back to the client.  The old code was retrieving the incorrect item always (was 1 off) and did not work at all for books inside bags.  The new subslot field was added (decoded from part of the old unknown006) and now all personal inventory slots work correctly as far as book type.