### PR TITLE
Adding AutoXTarget for bot owner when hate is added to bot's owner.

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2541,8 +2541,10 @@ void Mob::AddToHateList(Mob* other, uint32 hate /*= 0*/, int32 damage /*= 0*/, b
 			AddFeignMemory(other->CastToBot()->GetBotOwner()->CastToClient());
 		}
 		else {
-			if(!hate_list.IsEntOnHateList(other->CastToBot()->GetBotOwner()))
+			if (!hate_list.IsEntOnHateList(other->CastToBot()->GetBotOwner())) {
 				hate_list.AddEntToHateList(other->CastToBot()->GetBotOwner(), 0, 0, false, true);
+				other->CastToBot()->GetBotOwner()->CastToClient()->AddAutoXTarget(this);
+			}
 		}
 	}
 #endif //BOTS


### PR DESCRIPTION
Bots did not add XTargets, but add hate to client(). This ensures when bots generate hate for client() they also add the mob to the XTarget of the owning Client().
Tested with multi-player groups, with multi-bot owners, with each client initiating with bots, and with client.