### PR TITLE
Update Fedora package install method

### DIFF
--- a/utils/scripts/linux_installer/install.sh
+++ b/utils/scripts/linux_installer/install.sh
@@ -150,8 +150,32 @@ EOF
 
 elif [[ "$OS" == "fedora_core" ]]; then
 	# Do Fedora stuff
-	dnf -y install open-vm-tools vim cmake boost-devel zlib-devel mariadb-server mariadb-devel mariadb-libs perl perl-DBD-MySQL perl-IO-stringy perl-devel lua-devel lua-sql-mysql dos2unix php-mysql proftpd wget compat-lua-libs compat-lua-devel compat-lua perl-Time-HiRes
-	dnf -y groupinstall "Development Tools" "Basic Web Server" "C Development Tools and Libraries"
+	dnf -y install open-vm-tools
+	dnf -y install vim
+	dnf -y install cmake
+	dnf -y install boost-devel
+	dnf -y install zlib-devel
+	dnf -y install mariadb-server
+	dnf -y install mariadb-devel
+	dnf -y install mariadb-libs
+	dnf -y install perl
+	dnf -y install perl-DBD-MySQL
+	dnf -y install perl-IO-stringy
+	dnf -y install perl-devel
+	dnf -y install lua-devel
+	dnf -y install lua-sql-mysql
+	dnf -y install dos2unix
+	dnf -y install php-mysql
+	dnf -y install php-mysqlnd
+	dnf -y install proftpd
+	dnf -y install wget
+	dnf -y install compat-lua-libs
+	dnf -y install compat-lua-devel
+	dnf -y install compat-lua
+	dnf -y install perl-Time-HiRes
+	dnf -y groupinstall "Development Tools"
+	dnf -y groupinstall "Basic Web Server"
+	dnf -y groupinstall "C Development Tools and Libraries"
 fi
 
 if [[ "$OS" == "fedora_core" ]] || [[ "$OS" == "red_hat" ]]; then

--- a/utils/scripts/linux_installer/install.sh
+++ b/utils/scripts/linux_installer/install.sh
@@ -173,6 +173,7 @@ elif [[ "$OS" == "fedora_core" ]]; then
 	dnf -y install compat-lua-devel
 	dnf -y install compat-lua
 	dnf -y install perl-Time-HiRes
+	dnf -y install libuuid-devel
 	dnf -y groupinstall "Development Tools"
 	dnf -y groupinstall "Basic Web Server"
 	dnf -y groupinstall "C Development Tools and Libraries"

--- a/utils/scripts/linux_installer/install.sh
+++ b/utils/scripts/linux_installer/install.sh
@@ -117,6 +117,8 @@ if [[ "$OS" == "Debian" ]]; then
 	apt-get $apt_options install wget
 	apt-get $apt_options install zlib-bin
 	apt-get $apt_options install zlibc
+	apt-get $apt_options install libsodium-dev
+	apt-get $apt_options install libsodium18
 
 	#::: Install FTP for remote FTP access
 	echo "proftpd-basic shared/proftpd/inetd_or_standalone select standalone" | debconf-set-selections

--- a/utils/scripts/linux_installer/install.sh
+++ b/utils/scripts/linux_installer/install.sh
@@ -174,6 +174,8 @@ elif [[ "$OS" == "fedora_core" ]]; then
 	dnf -y install compat-lua
 	dnf -y install perl-Time-HiRes
 	dnf -y install libuuid-devel
+	dnf -y install libsodium
+	dnf -y install libsodium-devel
 	dnf -y groupinstall "Development Tools"
 	dnf -y groupinstall "Basic Web Server"
 	dnf -y groupinstall "C Development Tools and Libraries"


### PR DESCRIPTION
Split each package install out to its own line. This will cause the install to iterate though the package manager for each package installation. This will take a bit longer but will be less stringent. A package can be missing and not cause the others to fail.