### PR TITLE
Add CrossZoneSetEntityVariableByClientName

### DIFF
--- a/common/servertalk.h
+++ b/common/servertalk.h
@@ -189,6 +189,7 @@
 #define ServerOP_ReloadWorld 0x4009
 #define ServerOP_ReloadLogs 0x4010
 #define ServerOP_ReloadPerlExportSettings	0x4011
+#define ServerOP_CZSetEntityVariableByClientName 0x4012
 /* Query Server OP Codes */
 #define ServerOP_QSPlayerLogTrades					0x5010
 #define ServerOP_QSPlayerLogHandins					0x5011
@@ -1259,6 +1260,12 @@ struct WWMarquee_Struct {
 
 struct CZSetEntVarByNPCTypeID_Struct {
 	uint32 npctype_id;
+	char id[256];
+	char m_var[256];
+};
+
+struct CZSetEntVarByClientName_Struct {
+	char CharName[64];
 	char id[256];
 	char m_var[256];
 };

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -1248,6 +1248,7 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 	case ServerOP_CZSignalNPC:
 	case ServerOP_CZSetEntityVariableByNPCTypeID:
 	case ServerOP_CZSignalClient:
+	case ServerOP_CZSetEntityVariableByClientName:
 	case ServerOP_WWMarquee:
 	case ServerOP_DepopAllPlayersCorpses:
 	case ServerOP_DepopPlayerCorpse:

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -3599,6 +3599,24 @@ XS(XS__crosszonesetentityvariablebynpctypeid)
 	XSRETURN_EMPTY;
 }
 
+XS(XS__crosszonesetentityvariablebyclientname);
+XS(XS__crosszonesetentityvariablebyclientname)
+{
+	dXSARGS;
+
+	if (items != 3)
+		Perl_croak(aTHX_ "Usage: crosszonesetentityvariablebyclientname(clientname, id, m_var)");
+
+	if (items == 3) {
+		const char *clientname = (const char *)SvPV_nolen(ST(0));
+		const char *id = (const char *)SvPV_nolen(ST(1));
+		const char *m_var = (const char *)SvPV_nolen(ST(2));
+		quest_manager.CrossZoneSetEntityVariableByClientName(clientname, id, m_var);
+	}
+
+	XSRETURN_EMPTY;
+}
+
 XS(XS__crosszonesignalnpcbynpctypeid);
 XS(XS__crosszonesignalnpcbynpctypeid)
 {
@@ -3766,6 +3784,7 @@ EXTERN_C XS(boot_quest)
 		newXS(strcpy(buf, "createguild"), XS__createguild, file);
 		newXS(strcpy(buf, "crosszonemessageplayerbyname"), XS__crosszonemessageplayerbyname, file);
 		newXS(strcpy(buf, "crosszonesetentityvariablebynpctypeid"), XS__crosszonesetentityvariablebynpctypeid, file);
+		newXS(strcpy(buf, "crosszonesetentityvariablebyclientname"), XS__crosszonesetentityvariablebyclientname, file);
 		newXS(strcpy(buf, "crosszonesignalclientbycharid"), XS__crosszonesignalclientbycharid, file);
 		newXS(strcpy(buf, "crosszonesignalclientbyname"), XS__crosszonesignalclientbyname, file);
 		newXS(strcpy(buf, "crosszonesignalnpcbynpctypeid"), XS__crosszonesignalnpcbynpctypeid, file);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -892,6 +892,10 @@ void lua_cross_zone_message_player_by_name(uint32 type, const char *player, cons
 	quest_manager.CrossZoneMessagePlayerByName(type, player, message);
 }
 
+void lua_cross_zone_set_entity_variable_by_client_name(const char *player, const char *id, const char *m_var) {
+	quest_manager.CrossZoneSetEntityVariableByClientName(player, id, m_var);
+}
+
 void lua_world_wide_marquee(uint32 type, uint32 priority, uint32 fadein, uint32 fadeout, uint32 duration, const char *message) {
 	quest_manager.WorldWideMarquee(type, priority, fadein, fadeout, duration, message);
 }
@@ -1617,6 +1621,7 @@ luabind::scope lua_register_general() {
 		luabind::def("cross_zone_signal_client_by_char_id", &lua_cross_zone_signal_client_by_char_id),
 		luabind::def("cross_zone_signal_client_by_name", &lua_cross_zone_signal_client_by_name),
 		luabind::def("cross_zone_message_player_by_name", &lua_cross_zone_message_player_by_name),
+		luabind::def("cross_zone_set_entity_variable_by_client_name", &lua_cross_zone_set_entity_variable_by_client_name),
 		luabind::def("world_wide_marquee", &lua_world_wide_marquee),
 		luabind::def("get_qglobals", (luabind::adl::object(*)(lua_State*,Lua_NPC,Lua_Client))&lua_get_qglobals),
 		luabind::def("get_qglobals", (luabind::adl::object(*)(lua_State*,Lua_Client))&lua_get_qglobals),

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -3004,6 +3004,20 @@ void QuestManager::CrossZoneMessagePlayerByName(uint32 Type, const char *CharNam
 	safe_delete(pack);
 }
 
+void QuestManager::CrossZoneSetEntityVariableByClientName(const char *CharName, const char *id, const char *m_var){
+	uint32 message_len = strlen(id) + 1;
+	uint32 message_len2 = strlen(m_var) + 1;
+	uint32 message_len3 = strlen(CharName) + 1;
+	auto pack = new ServerPacket(ServerOP_CZSetEntityVariableByClientName,
+				     sizeof(CZSetEntVarByClientName_Struct) + message_len + message_len2 + message_len3);
+	CZSetEntVarByClientName_Struct* CZ = (CZSetEntVarByClientName_Struct*)pack->pBuffer;
+	strn0cpy(CZ->CharName, CharName, 64);
+	strn0cpy(CZ->id, id, 256);
+	strn0cpy(CZ->m_var, m_var, 256);
+	worldserver.SendPacket(pack);
+	safe_delete(pack);
+}
+
 void QuestManager::CrossZoneSetEntityVariableByNPCTypeID(uint32 npctype_id, const char *id, const char *m_var){
 	uint32 message_len = strlen(id) + 1;
 	uint32 message_len2 = strlen(m_var) + 1;

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -255,6 +255,7 @@ public:
 	void CrossZoneSignalNPCByNPCTypeID(uint32 npctype_id, uint32 data);
 	void CrossZoneSignalPlayerByName(const char *CharName, uint32 data);
 	void CrossZoneSetEntityVariableByNPCTypeID(uint32 npctype_id, const char *id, const char *m_var);
+	void CrossZoneSetEntityVariableByClientName(const char *CharName, const char *id, const char *m_var);
 	void CrossZoneMessagePlayerByName(uint32 Type, const char *CharName, const char *Message);
 	void WorldWideMarquee(uint32 Type, uint32 Priority, uint32 FadeIn, uint32 FadeOut, uint32 Duration, const char *Message);
 	bool EnableRecipe(uint32 recipe_id);

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -1857,6 +1857,15 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 		}
 		break;
 	}
+	case ServerOP_CZSetEntityVariableByClientName:
+	{
+		CZSetEntVarByClientName_Struct* CZCS = (CZSetEntVarByClientName_Struct*)pack->pBuffer;
+		Client* client = entity_list.GetClientByName(CZCS->CharName);
+		if (client != 0) {
+			client->SetEntityVariable(CZCS->id, CZCS->m_var);
+		}
+		break;
+	}
 	case ServerOP_WWMarquee:
 	{
 		WWMarquee_Struct* WWMS = (WWMarquee_Struct*)pack->pBuffer;


### PR DESCRIPTION
Allow entity variables to be sent across zones to other clients.