### PR TITLE
Repair so that mobs that are fleeing or feared use FixZ.

### DIFF
--- a/zone/fearpath.cpp
+++ b/zone/fearpath.cpp
@@ -154,7 +154,8 @@ void Mob::CalculateNewFearpoint()
 
 	int loop = 0;
 	float ranx, rany, ranz;
-	currently_fleeing = false;
+
+	currently_fleeing = true;
 	while (loop < 100) //Max 100 tries
 	{
 		int ran = 250 - (loop*2);
@@ -167,11 +168,13 @@ void Mob::CalculateNewFearpoint()
 		float fdist = ranz - GetZ();
 		if (fdist >= -12 && fdist <= 12 && CheckCoordLosNoZLeaps(GetX(),GetY(),GetZ(),ranx,rany,ranz))
 		{
-			currently_fleeing = true;
 			break;
 		}
 	}
-	if (currently_fleeing)
-        m_FearWalkTarget = glm::vec3(ranx, rany, ranz);
+
+	if (loop <= 100)
+	{
+		m_FearWalkTarget = glm::vec3(ranx, rany, ranz);
+	}
 }
 

--- a/zone/waypoints.cpp
+++ b/zone/waypoints.cpp
@@ -495,7 +495,8 @@ bool Mob::MakeNewPositionAndSendUpdate(float x, float y, float z, int speed, boo
 		m_Position.y = new_y;
 		m_Position.z = new_z;
 
-		if(fix_z_timer.Check() && !this->IsEngaged())
+		if(fix_z_timer.Check() && 
+			(!this->IsEngaged() || flee_mode || currently_fleeing))
 			this->FixZ();
 
 		tar_ndx++;


### PR DESCRIPTION
Ok this time the fix seems to work better.  Needed to fix common functions in waypoints to use FixZ when mobs are fleeing or feared.  Also, the original function needs to set currently_fleeing all the time.

If we want to set that to false and/or remove the fear spell again to avoid exploits, then I'm gonna need help fixing that function to find proper points, as now, without the help of fixz, it was always killing my fear spell on IceGiants - immediately at cast,.