### PR TITLE
Add fix for GetGroundZ and fix some constant references.

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -7257,7 +7257,7 @@ void command_bestz(Client *c, const Seperator *sep) {
 
 		float best_z = zone->zonemap->FindBestZ(me, &hit);
 
-		if (best_z != -999999)
+		if (best_z != BEST_Z_INVALID)
 		{
 			c->Message(0, "Z is %.3f at (%.3f, %.3f).",  best_z, me.x, me.y);
 		}

--- a/zone/fearpath.cpp
+++ b/zone/fearpath.cpp
@@ -163,7 +163,7 @@ void Mob::CalculateNewFearpoint()
 		ranx = GetX()+zone->random.Int(0, ran-1)-zone->random.Int(0, ran-1);
 		rany = GetY()+zone->random.Int(0, ran-1)-zone->random.Int(0, ran-1);
 		ranz = FindGroundZ(ranx,rany);
-		if (ranz == -999999)
+		if (ranz == BEST_Z_INVALID)
 			continue;
 		float fdist = ranz - GetZ();
 		if (fdist >= -12 && fdist <= 12 && CheckCoordLosNoZLeaps(GetX(),GetY(),GetZ(),ranx,rany,ranz))

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -3441,7 +3441,7 @@ void Mob::SetTarget(Mob* mob) {
 
 float Mob::FindGroundZ(float new_x, float new_y, float z_offset)
 {
-	float ret = -999999;
+	float ret = BEST_Z_INVALID;
 	if (zone->zonemap != nullptr)
 	{
 		glm::vec3 me;
@@ -3450,7 +3450,7 @@ float Mob::FindGroundZ(float new_x, float new_y, float z_offset)
 		me.z = m_Position.z + z_offset;
 		glm::vec3 hit;
 		float best_z = zone->zonemap->FindBestZ(me, &hit);
-		if (best_z != -999999)
+		if (best_z != BEST_Z_INVALID)
 		{
 			ret = best_z;
 		}
@@ -3461,7 +3461,7 @@ float Mob::FindGroundZ(float new_x, float new_y, float z_offset)
 // Copy of above function that isn't protected to be exported to Perl::Mob
 float Mob::GetGroundZ(float new_x, float new_y, float z_offset)
 {
-	float ret = -999999;
+	float ret = BEST_Z_INVALID;
 	if (zone->zonemap != 0)
 	{
 		glm::vec3 me;
@@ -3470,7 +3470,7 @@ float Mob::GetGroundZ(float new_x, float new_y, float z_offset)
 		me.z = m_Position.z+z_offset;
 		glm::vec3 hit;
 		float best_z = zone->zonemap->FindBestZ(me, &hit);
-		if (best_z != -999999)
+		if (best_z != BEST_Z_INVALID)
 		{
 			ret = best_z;
 		}

--- a/zone/waypoints.cpp
+++ b/zone/waypoints.cpp
@@ -867,7 +867,7 @@ void Mob::FixZ(int32 z_find_offset /*= 5*/)
 				duration
 			);
 
-			if ((new_z > -2000) && new_z != -999999) {
+			if ((new_z > -2000) && new_z != BEST_Z_INVALID) {
 				if (RuleB(Map, MobZVisualDebug))
 					this->SendAppearanceEffect(78, 0, 0, 0, 0);
 				


### PR DESCRIPTION
When GetGroundZ used GetBestZ, I have logs where 1028 turned into -489...
All the way down to the map grid.

Using ClosestZ grabs the more sane value.