### PR TITLE
Bot bugs - targeting after zoning and zone.exe crash

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -2841,6 +2841,8 @@ void Bot::Spawn(Client* botCharacterOwner) {
 		FaceTarget(botCharacterOwner);
 		UpdateEquipmentLight();
 		UpdateActiveLight();
+
+		this->m_targetable = true;
 		entity_list.AddBot(this, true, true);
 		// Load pet
 		LoadPet();

--- a/zone/groups.cpp
+++ b/zone/groups.cpp
@@ -2471,6 +2471,9 @@ void Group::QueueClients(Mob *sender, const EQApplicationPacket *app, bool ack_r
 			if (!members[i])
 				continue;
 
+			if (!members[i]->IsClient())
+				continue;
+
 			if (ignore_sender && members[i] == sender)
 				continue;
 


### PR DESCRIPTION
Sorry if this isn't in the right format.  This is my first time opening a pr.  

The first commit addresses issue #657 by setting bots to be target-able in Bot::Spawn.  The second commit addresses a zone.exe crash when a client gets too far away from bots in their group. 