### PR TITLE
Rule to dictate if you can teach yourself lang.

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -186,6 +186,7 @@ RULE_INT(Skills, MaxTrainSpecializations, 50)	// Max level a GM trainer will tra
 RULE_INT(Skills, SwimmingStartValue, 100)
 RULE_BOOL(Skills, TrainSenseHeading, false)
 RULE_INT(Skills, SenseHeadingStartValue, 200)
+RULE_BOOL(Skills, SelfLanguageLearning, true)
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Pets)

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -1225,9 +1225,14 @@ void Client::ChannelMessageSend(const char* from, const char* to, uint8 chan_num
 	strcpy(&cm->message[0], buffer);
 	QueuePacket(&app);
 
-	if ((chan_num == 2) && (ListenerSkill < 100)) {	// group message in unmastered language, check for skill up
-		if (m_pp.languages[language] <= lang_skill)
-			CheckLanguageSkillIncrease(language, lang_skill);
+	bool senderCanTrainSelf = RuleB(Client, SelfLanguageLearning);
+	bool weAreNotSender = strcmp(this->GetCleanName(), cm->sender);
+
+	if (senderCanTrainSelf || weAreNotSender) {
+		if ((chan_num == 2) && (ListenerSkill < 100)) {	// group message in unmastered language, check for skill up
+			if (m_pp.languages[language] <= lang_skill)
+				CheckLanguageSkillIncrease(language, lang_skill);
+		}
 	}
 }
 


### PR DESCRIPTION
The current code allows teaching yourself languages that are at least a 1 skill.

Some of us believe that in the past, you needed someone higher than you to teach.

This new rule defaults to current behaviour.

Set to false, it requires someone else to teach.

+RULE_BOOL(Skills, SelfLanguageLearning, true)