### PR TITLE
Roam Box code was changing z every loop through.

### DIFF
--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -1535,15 +1535,17 @@ void NPC::AI_DoMovement() {
 				roambox_movingto_x = zone->random.Real(roambox_min_x+1,roambox_max_x-1);
 			if (roambox_movingto_y > roambox_max_y || roambox_movingto_y < roambox_min_y)
 				roambox_movingto_y = zone->random.Real(roambox_min_y+1,roambox_max_y-1);
+			Log(Logs::Detail, Logs::AI, 
+				"Roam Box: d=%.3f (%.3f->%.3f,%.3f->%.3f): Go To (%.3f,%.3f)",
+				roambox_distance, roambox_min_x, roambox_max_x, roambox_min_y, 
+				roambox_max_y, roambox_movingto_x, roambox_movingto_y);
 		}
 
-		Log(Logs::Detail, Logs::AI, "Roam Box: d=%.3f (%.3f->%.3f,%.3f->%.3f): Go To (%.3f,%.3f)",
-			roambox_distance, roambox_min_x, roambox_max_x, roambox_min_y, roambox_max_y, roambox_movingto_x, roambox_movingto_y);
-
-		float new_z = this->FindGroundZ(m_Position.x, m_Position.y, 5) + this->GetZOffset();
-
-		if (!CalculateNewPosition2(roambox_movingto_x, roambox_movingto_y, new_z, walksp, true))
+		// Keep calling with updates, using wherever we are in Z.
+		if (!MakeNewPositionAndSendUpdate(roambox_movingto_x, 
+				roambox_movingto_y, m_Position.z, walksp))
 		{
+			this->FixZ(); // FixZ on final arrival point.
 			roambox_movingto_x = roambox_max_x + 1; // force update
 			pLastFightingDelayMoving = Timer::GetCurrentTime() + RandomTimer(roambox_min_delay, roambox_delay);
 			SetMoving(false);


### PR DESCRIPTION
The roam box code basically comes up with a new position to move to, and then keeps getting called until the mobs position is in the x/y location we aimed for.  The way it was however, it was possible to get into an endless cycle, as CalculateNewPosition2 could change out current location and the client could change it back due to Z issues... resulting in the roam box stalling.

In this patch I did two things:

1) Make debugging easier by spitting out the debugging once per new coordinate instead of smamming the same data.

2) Called MakeNewPositionAndSendUpdate directly, since thats what CalculateNewPosition2 did anyway.

3) Most importantly, every call to MakeNewPositionAndSendUpdate  uses the z for the mobs current progress so that we will get a result of false when the x and y match, resulting in a successful move to the new position.  Then, we fix Z, and update and wait for the next move,

This seems to work very well now.  The stalling issue is gone.