### PR TITLE
Added a #petname command for renaming only pets

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -375,6 +375,7 @@ int command_init(void)
 		command_add("task", "(subcommand) - Task system commands",  150, command_task) ||
 		command_add("tattoo", "- Change the tattoo of your target (Drakkin Only)", 80, command_tattoo) ||
 		command_add("tempname", "[newname] - Temporarily renames your target. Leave name blank to restore the original name.", 100, command_tempname) ||
+		command_add("petname", "[newname] - Temporarily renames your pet. Leave name blank to restore the original name.", 100, command_petname) ||
 		command_add("texture", "[texture] [helmtexture] - Change your or your target's appearance, use 255 to show equipment", 10, command_texture) ||
 		command_add("time", "[HH] [MM] - Set EQ time", 90, command_time) ||
 		command_add("timers", "- Display persistent timers for target", 200, command_timers) ||
@@ -4145,6 +4146,26 @@ void command_tempname(Client *c, const Seperator *sep)
 	if(!target)
 		c->Message(0, "Usage: #tempname newname (requires a target)");
 	else if(strlen(sep->arg[1]) > 0)
+	{
+		char *oldname = strdup(target->GetName());
+		target->TempName(sep->arg[1]);
+		c->Message(0, "Renamed %s to %s",  oldname, sep->arg[1]);
+		free(oldname);
+	}
+	else {
+		target->TempName();
+		c->Message(0, "Restored the original name");
+	}
+}
+
+void command_petname(Client *c, const Seperator *sep)
+{
+	Mob *target;
+	target = c->GetTarget();
+
+	if(!target)
+		c->Message(0, "Usage: #petname newname (requires a target)");
+	else if(target->IsPet() && (target->GetOwnerID() == c->GetID()) && strlen(sep->arg[1]) > 0)
 	{
 		char *oldname = strdup(target->GetName());
 		target->TempName(sep->arg[1]);

--- a/zone/command.h
+++ b/zone/command.h
@@ -286,6 +286,7 @@ void command_synctod(Client *c, const Seperator *sep);
 void command_task(Client *c, const Seperator *sep);
 void command_tattoo(Client *c, const Seperator *sep);
 void command_tempname(Client *c, const Seperator *sep);
+void command_petname(Client *c, const Seperator *sep);
 void command_testspawn(Client *c, const Seperator *sep);
 void command_testspawnkill(Client *c, const Seperator *sep);
 void command_texture(Client *c, const Seperator *sep);


### PR DESCRIPTION
For GMs that want to give players the ability to name only their own pets.