### PR TITLE
Fixed Ubuntu 17.10 compile

### DIFF
--- a/libs/format/fmt/format.h
+++ b/libs/format/fmt/format.h
@@ -1719,6 +1719,8 @@ FMT_DEFINE_INT_FORMATTERS(unsigned long)
 FMT_DEFINE_INT_FORMATTERS(LongLong)
 FMT_DEFINE_INT_FORMATTERS(ULongLong)
 
+#define CHAR_WIDTH 1
+
 /**
   \rst
   Returns a string formatter that pads the formatted argument with the fill
@@ -1823,7 +1825,7 @@ class ArgFormatterBase : public ArgVisitor<Impl, void> {
     typedef typename BasicWriter<Char>::CharPtr CharPtr;
     Char fill = internal::CharTraits<Char>::cast(spec_.fill());
     CharPtr out = CharPtr();
-    const unsigned CHAR_WIDTH = 1;
+
     if (spec_.width_ > CHAR_WIDTH) {
       out = writer_.grow_buffer(spec_.width_);
       if (spec_.align_ == ALIGN_RIGHT) {


### PR DESCRIPTION
This is a compile fix so that fmt can be build on Ubuntu 17.10.

Other notes: uuid-dev is also not included in Ubuntu 17.10 by default. You can apt-get install uuid-dev to get the required libraries.