### PR TITLE
Removed pets from Witness Heal Aggro.

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -3257,7 +3257,7 @@ void EntityList::AddHealAggro(Mob *target, Mob *caster, uint16 hate)
 
 	for (auto &e : npc_list) {
 		auto &npc = e.second;
-		if (!npc->CheckAggro(target) || npc->IsFeared())
+		if (!npc->CheckAggro(target) || npc->IsFeared() || npc->IsPet())
 			continue;
 
 		if (zone->random.Roll(50)) // witness check -- place holder


### PR DESCRIPTION
To solve issue where a mob that is not engaged heals and pets witness and run off.

Discussed in discord with @mackal.