### PR TITLE
Add rule to use ClassicBackstab (no mob fronttab)

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -198,6 +198,7 @@ RULE_CATEGORY(Pets)
 RULE_REAL(Pets, AttackCommandRange, 150)
 RULE_BOOL(Pets, UnTargetableSwarmPet, false)
 RULE_REAL(Pets, PetPowerLevelCap, 10) // Max number of levels your pet can go up with pet power
+RULE_BOOL(Pets, CanTakeNoDrop, false) // Can everyone trade nodrop gear to pets
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(GM)
@@ -508,6 +509,7 @@ RULE_INT(Combat, NPCAssistCapTimer, 6000) // Time in milliseconds a NPC will tak
 RULE_BOOL(Combat, UseRevampHandToHand, false) // use h2h revamped dmg/delays I believe this was implemented during SoF
 RULE_BOOL(Combat, ClassicMasterWu, false) // classic master wu uses a random special, modern doesn't
 RULE_INT(Combat, LevelToStopDamageCaps, 0) // 1 will effectively disable them, 20 should give basically same results as old incorrect system
+RULE_BOOL(Combat, ClassicNPCBackstab, false) // true disables npc facestab - npcs get normal attack if not behind
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(NPC)

--- a/zone/loottables.cpp
+++ b/zone/loottables.cpp
@@ -336,7 +336,8 @@ void NPC::AddLootDrop(const EQEmu::ItemData *item2, ItemList* itemlist, int16 ch
 			eslot = EQEmu::textures::weaponPrimary;
 			if (item2->Damage > 0) {
 				SendAddPlayerState(PlayerState::PrimaryWeaponEquipped);
-				SetFacestab(true);
+				if (!RuleB(Combat, ClassicNPCBackstab))
+					SetFacestab(true);
 			}
 			if (item2->IsType2HWeapon())
 				SetTwoHanderEquipped(true);


### PR DESCRIPTION
This is the rule we talked about @mackal.  The other rule if for pet trades.  I'll commit that shortly as well.