### PR TITLE
Allow trading nodrop to pets via new rule.

### DIFF
--- a/zone/pets.cpp
+++ b/zone/pets.cpp
@@ -655,10 +655,15 @@ void NPC::SetPetState(SpellBuff_Struct *pet_buffs, uint32 *items) {
 			continue;
 
 		const EQEmu::ItemData* item2 = database.GetItem(items[i]);
-		if (item2 && item2->NoDrop != 0) {
-			//dont bother saving item charges for now, NPCs never use them
-			//and nobody should be able to get them off the corpse..?
-			AddLootDrop(item2, &itemlist, 0, 1, 255, true, true);
+
+		if (item2) {
+			bool noDrop=(item2->NoDrop == 0); // Field is reverse logic
+			bool petCanHaveNoDrop = (RuleB(Pets, CanTakeNoDrop) && 
+				_CLIENTPET(this) && GetPetType() <= petOther);
+
+			if (!noDrop || petCanHaveNoDrop) {
+				AddLootDrop(item2, &itemlist, 0, 1, 255, true, true);
+			}
 		}
 	}
 }

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -523,7 +523,6 @@ void Client::FinishTrade(Mob* tradingWith, bool finalizer, void* event_entry, st
 									else
 										qs_audit->char1_count += detail->charges;
 
-									//for (uint8 sub_slot = SUB_BEGIN; ((sub_slot < inst->GetItem()->BagSlots) && (sub_slot < EmuConstants::ITEM_CONTAINER_SIZE)); ++sub_slot) {
 									for (uint8 sub_slot = EQEmu::inventory::containerBegin; (sub_slot < EQEmu::inventory::ContainerCount); ++sub_slot) { // this is to catch ALL items
 										const EQEmu::ItemInstance* bag_inst = inst->GetItem(sub_slot);
 
@@ -743,7 +742,6 @@ void Client::FinishTrade(Mob* tradingWith, bool finalizer, void* event_entry, st
 										qs_audit->char1_count += detail->charges;
 
 									// 'step 3' should never really see containers..but, just in case...
-									//for (uint8 sub_slot = SUB_BEGIN; ((sub_slot < inst->GetItem()->BagSlots) && (sub_slot < EmuConstants::ITEM_CONTAINER_SIZE)); ++sub_slot) {
 									for (uint8 sub_slot = EQEmu::inventory::containerBegin; (sub_slot < EQEmu::inventory::ContainerCount); ++sub_slot) { // this is to catch ALL items
 										const EQEmu::ItemInstance* bag_inst = inst->GetItem(sub_slot);
 
@@ -888,8 +886,12 @@ void Client::FinishTrade(Mob* tradingWith, bool finalizer, void* event_entry, st
 
 			const EQEmu::ItemData* item = inst->GetItem();
 			if(item && quest_npc == false) {
+				bool isPetAndCanHaveNoDrop = (RuleB(Pets, CanTakeNoDrop) && 
+					_CLIENTPET(tradingWith) && 
+					tradingWith->GetPetType()<=petOther);
 				// if it was not a NO DROP or Attuned item (or if a GM is trading), let the NPC have it
-				if(GetGM() || (item->NoDrop != 0 && inst->IsAttuned() == false)) {
+				if(GetGM() || (inst->IsAttuned() == false && 
+					(item->NoDrop != 0 || isPetAndCanHaveNoDrop))) {
 					// pets need to look inside bags and try to equip items found there
 					if (item->IsClassBag() && item->BagSlots > 0) {
 						for (int16 bslot = EQEmu::inventory::containerBegin; bslot < item->BagSlots; bslot++) {


### PR DESCRIPTION
This allows pets to take no drop items and use them if the new rule is set.

I believe I have it coded correctly (testing what I know to test) so that only PC summoned pets are eligible and none of the pet corpses that can get the drops will ever be looted.

I also modified the code that loads the pets - since it was subtracting these items.