### PR TITLE
Scaled AC and ATK if npc is scaling.

### DIFF
--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -2130,6 +2130,8 @@ void NPC::LevelScale() {
 		if(level > 15 && level <= 25)
 			scale_adjust = 2;
 
+		AC += (int)(AC * scaling);
+		ATK += (int)(ATK * scaling);
 		base_hp += (int)(base_hp * scaling);
 		max_hp += (int)(max_hp * scaling);
 		cur_hp = max_hp;


### PR DESCRIPTION
On mobs where max_level is set,  AC and ATK were not being scaled.  This makes a large difference.  I had mobs that were level 7, max_level 9 and mobs that were just 9.  The level 9 mobs were a challenge for PCs around their level.  PCs could take 3 level 7 mobs scaled to 9 easily.

This makes them all the same based on scaled level.