### PR TITLE
Added sanity check for #hotfix

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -10835,7 +10835,7 @@ void command_hotfix(Client *c, const Seperator *sep) {
 		}
 		worldserver.SendPacket(&pack);
 
-		c->Message(0, "Hotfix applied");
+		if (c) c->Message(0, "Hotfix applied");
 	});
 
 	t1.detach();


### PR DESCRIPTION
If a person is gm, and uses /camp while a #hotfix was invoked, it will crash the zone as the hotfix takes a moment and doesn't verify the client still exists. 