### PR TITLE
Added rule to remove pet reagent cost

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -156,6 +156,7 @@ RULE_BOOL(Character, UseOldBindWound, false) // Uses the original bind wound beh
 RULE_BOOL(Character, GrantHoTTOnCreate, false) // Grant Health of Target's Target leadership AA on character creation
 RULE_BOOL(Character, UseOldConSystem, false) // Grant Health of Target's Target leadership AA on character creation
 RULE_BOOL(Character, OPClientUpdateVisualDebug, false) // Shows a pulse and forward directional particle each time the client sends its position to server
+RULE_BOOL(Character, PetsUseReagents, true) //Pets use reagent on spells
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Mercs)

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -1208,7 +1208,10 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 
 				// handle the components for traditional casters
 				else {
-					if(c->GetInv().HasItem(component, component_count, invWhereWorn|invWherePersonal) == -1) // item not found
+					if (!RuleB(Character, PetsUseReagents) && IsEffectInSpell(spell_id, SE_SummonPet)) {
+						//bypass reagent cost
+					} 
+					else if(c->GetInv().HasItem(component, component_count, invWhereWorn|invWherePersonal) == -1) // item not found
 					{
 						if (!missingreags)
 						{
@@ -1237,6 +1240,9 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 					InterruptSpell();
 					return;
 				}
+			}
+			else if (!RuleB(Character, PetsUseReagents) && IsEffectInSpell(spell_id, SE_SummonPet)) {
+				//bypass reagent cost
 			}
 			else if (!bard_song_mode)
 			{


### PR DESCRIPTION
A simple rule, enabled by default, where when disabled reagent costs check if the spell has SE_SummonPet as an effect in it. If it does, it bypasses the normal logic (for malachite, bone chips, tiny daggers, etc)