### PR TITLE
quest::npcfeature() could not set all features

### DIFF
--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -1981,8 +1981,8 @@ void QuestManager::npcfeature(char *feature, int setting)
 	QuestManagerCurrentQuestVars();
 	uint16 Race = owner->GetRace();
 	uint8 Gender = owner->GetGender();
-	uint8 Texture = 0xFF;
-	uint8 HelmTexture = 0xFF;
+	uint8 Texture = owner->GetTexture();
+	uint8 HelmTexture = owner->GetHelmTexture();
 	uint8 HairColor = owner->GetHairColor();
 	uint8 BeardColor = owner->GetBeardColor();
 	uint8 EyeColor1 = owner->GetEyeColor1();


### PR DESCRIPTION
The existing npcfeature() gets called per feature.  So you can:

npcfeature("face", 1);
npcfeature("gender", 2);
etc..

and all these would accumulate..

except for texture and helm.

These could be set:

npcfeature("texture", 2);

but a subsequent call to:

npcfeature("face", 1); 

would wipe it out.  

I am not sure why these two are singled out.  At first, I just said ok, always change texture last.  But then I saw the same issue with helm.  

This seems ok to me as a fix?