### PR TITLE
added CanPvP and PVP mitigation exposure to rules

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -235,6 +235,13 @@ RULE_INT(World, ExpansionSettings, 16383) // Sets the expansion settings for the
 RULE_BOOL(World, UseClientBasedExpansionSettings, true) // if true it will overrule World, ExpansionSettings and set someone's expansion based on the client they're using
 RULE_INT(World, PVPSettings, 0) // Sets the PVP settings for the server, 1 = Rallos Zek RuleSet, 2 = Tallon/Vallon Zek Ruleset, 4 = Sullon Zek Ruleset, 6 = Discord Ruleset, anything above 6 is the Discord Ruleset without the no-drop restrictions removed. TODO: Edit IsAttackAllowed in Zone to accomodate for these rules.
 RULE_INT(World, PVPMinLevel, 0) // minimum level to pvp
+RULE_BOOL(World, PVPUseDeityBasedPVP, false) //In PvP, deity is used to determine if a player can attack another.
+RULE_INT(World, PVPLevelDifference, 0) // In PvP, if value is greater than 0, players with a difference greater than value will not be attackable
+RULE_INT(World, PVPLoseExperienceLevelDifference, 0) // In PvP, if value is greater than 0, players lose experience if killed by a player within level difference
+RULE_INT(World, PVPPetDamageMitigation, 50) // In PvP, pet damage is mitigated by this amount
+RULE_INT(World, PVPMeleeMitigation, 67) // In PvP, melee is mitigated by this amount
+RULE_INT(World, PVPSpellMitigation, 67) // In PvP, spells are mitigated by this amount
+RULE_INT(World, PVPRangedMitigation, 80) // In PvP, ranged attacks (archery/throwing) is mitigated by this amount
 RULE_BOOL (World, IsGMPetitionWindowEnabled, false)
 RULE_INT (World, FVNoDropFlag, 0) // Sets the Firiona Vie settings on the client. If set to 2, the flag will be set for GMs only, allowing trading of no-drop items.
 RULE_BOOL (World, IPLimitDisconnectAll, false)

--- a/zone/aggro.cpp
+++ b/zone/aggro.cpp
@@ -622,22 +622,7 @@ bool Mob::IsAttackAllowed(Mob *target, bool isSpellAttack)
 				c1 = mob1->CastToClient();
 				c2 = mob2->CastToClient();
 
-				if	// if both are pvp they can fight
-				(
-					c1->GetPVP() &&
-					c2->GetPVP()
-				)
-					return true;
-				else if	// if they're dueling they can go at it
-				(
-					c1->IsDueling() &&
-					c2->IsDueling() &&
-					c1->GetDuelTarget() == c2->GetID() &&
-					c2->GetDuelTarget() == c1->GetID()
-				)
-					return true;
-				else
-					return false;
+				return c1->CanPvP(c2);
 			}
 			else if(_NPC(mob2))				// client vs npc
 			{
@@ -792,18 +777,7 @@ bool Mob::IsBeneficialAllowed(Mob *target)
 				c1 = mob1->CastToClient();
 				c2 = mob2->CastToClient();
 
-				if(c1->GetPVP() == c2->GetPVP())
-					return true;
-				else if	// if they're dueling they can heal each other too
-				(
-					c1->IsDueling() &&
-					c2->IsDueling() &&
-					c1->GetDuelTarget() == c2->GetID() &&
-					c2->GetDuelTarget() == c1->GetID()
-				)
-					return true;
-				else
-					return false;
+				return c1->CanPvP(c2);
 			}
 			else if(_NPC(mob2))				// client to npc
 			{

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1560,18 +1560,19 @@ void Client::Damage(Mob* other, int32 damage, uint16 spell_id, EQEmu::skills::Sk
 	if (spell_id == 0)
 		spell_id = SPELL_UNKNOWN;
 
-	// cut all PVP spell damage to 2/3
 	// Blasting ourselfs is considered PvP
 	//Don't do PvP mitigation if the caster is damaging himself
 	//should this be applied to all damage? comments sound like some is for spell DMG
 	//patch notes on PVP reductions only mention archery/throwing ... not normal dmg
 	if (other && other->IsClient() && (other != this) && damage > 0) {
-		int PvPMitigation = 100;
-		if (attack_skill == EQEmu::skills::SkillArchery || attack_skill == EQEmu::skills::SkillThrowing)
-			PvPMitigation = 80;
-		else
-			PvPMitigation = 67;
-		damage = std::max((damage * PvPMitigation) / 100, 1);
+		int PvPMitigation = RuleI(World, PVPMeleeMitigation);
+ 		if (attack_skill == EQEmu::skills::SkillAbjuration ||  //spells
+ 			attack_skill == EQEmu::skills::SkillAlteration ||
+ 			attack_skill == EQEmu::skills::SkillConjuration || 
+ 			attack_skill == EQEmu::skills::SkillDivination ||
+ 			attack_skill == EQEmu::skills::SkillEvocation) PvPMitigation = RuleI(World, PVPSpellMitigation);
+ 		if (attack_skill == EQEmu::skills::SkillArchery ||  //ranged
+ 			attack_skill == EQEmu::skills::SkillThrowing) PvPMitigation = RuleI(World, PVPRangedMitigation);
 	}
 
 	if (!ClientFinishedLoading())
@@ -1746,7 +1747,17 @@ bool Client::Death(Mob* killerMob, int32 damage, uint16 spell, EQEmu::skills::Sk
 	{
 		if (killerMob->IsClient())
 		{
-			exploss = 0;
+			if (RuleI(World, PVPLoseExperienceLevelDifference) > 0) {
+ 				int level_difference = 0;
+ 				if (GetLevel() > killerMob->GetLevel()) level_difference = GetLevel() - killerMob->GetLevel();
+ 				else level_difference = killerMob->GetLevel() - GetLevel();
+ 
+ 				if (level_difference > RuleI(World, PVPLoseExperienceLevelDifference)) exploss = 0;
+ 			}
+ 			else 
+ 			{
+ 				exploss = 0;
+ 			}
 		}
 		else if (killerMob->GetOwner() && killerMob->GetOwner()->IsClient())
 		{
@@ -2049,10 +2060,7 @@ bool NPC::Attack(Mob* other, int Hand, bool bRiposte, bool IsStrikethrough, bool
 		Log(Logs::Detail, Logs::Combat, "Final damage against %s: %d", other->GetName(), my_hit.damage_done);
 
 		if (other->IsClient() && IsPet() && GetOwner()->IsClient()) {
-			//pets do half damage to clients in pvp
-			my_hit.damage_done /= 2;
-			if (my_hit.damage_done < 1)
-				my_hit.damage_done = 1;
+			my_hit.damage_done = std::max(my_hit.damage_done * RuleI(World, PVPPetDamageMitigation) / 100, 1);
 		}
 	}
 	else {

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1747,12 +1747,22 @@ bool Client::Death(Mob* killerMob, int32 damage, uint16 spell, EQEmu::skills::Sk
 	{
 		if (killerMob->IsClient())
 		{
-			if (RuleI(World, PVPLoseExperienceLevelDifference) > 0) {
+			int pvpleveldifference = 0;
+			
+			if (RuleI(World, PVPSettings) == 4) 
+				pvpleveldifference = 5; //Sullon Zek 
+			if (RuleI(World, PVPLoseExperienceLevelDifference) > 0) 
+				pvpleveldifference = RuleI(World, PVPLoseExperienceLevelDifference);
+
+			if (pvpleveldifference > 0) {
  				int level_difference = 0;
- 				if (GetLevel() > killerMob->GetLevel()) level_difference = GetLevel() - killerMob->GetLevel();
- 				else level_difference = killerMob->GetLevel() - GetLevel();
+ 				if (GetLevel() > killerMob->GetLevel()) 
+					level_difference = GetLevel() - killerMob->GetLevel();
+ 				else 
+					level_difference = killerMob->GetLevel() - GetLevel();
  
- 				if (level_difference > RuleI(World, PVPLoseExperienceLevelDifference)) exploss = 0;
+ 				if (level_difference > pvpleveldifference) 
+					exploss = 0;
  			}
  			else 
  			{

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -5652,21 +5652,30 @@ bool Bot::IsBotAttackAllowed(Mob* attacker, Mob* target, bool& hasRuleDefined) {
 	Client *tc = nullptr;
 
 	//Is attacker controlled by a client?
-	if (attacker->IsClient()) ac = attacker->CastToClient();
-	if (attacker->IsBot() && attacker->CastToBot()->GetBotOwner() && attacker->CastToBot()->GetBotOwner()->IsClient()) ac = attacker->CastToBot()->GetBotOwner()->CastToClient();
-	if (attacker->IsPet() && attacker->GetOwner() && attacker->GetOwner()->IsClient()) ac = attacker->GetOwner()->CastToClient();
+	if (attacker->IsClient()) 
+		ac = attacker->CastToClient();
+	if (attacker->IsBot() && attacker->CastToBot()->GetBotOwner() && attacker->CastToBot()->GetBotOwner()->IsClient()) 
+		ac = attacker->CastToBot()->GetBotOwner()->CastToClient();
+	if (attacker->IsPet() && attacker->GetOwner() && attacker->GetOwner()->IsClient()) 
+		ac = attacker->GetOwner()->CastToClient();
 
 	//Is target controlled by a client?
 	if (target->IsClient()) tc = target->CastToClient();
-	if (target->IsBot() && target->CastToBot()->GetBotOwner() && target->CastToBot()->GetBotOwner()->IsClient()) tc = target->CastToBot()->GetBotOwner()->CastToClient();
-	if (target->IsPet() && target->GetOwner() && target->GetOwner()->IsClient()) tc = target->GetOwner()->CastToClient();
+	if (target->IsBot() && target->CastToBot()->GetBotOwner() && target->CastToBot()->GetBotOwner()->IsClient()) 
+		tc = target->CastToBot()->GetBotOwner()->CastToClient();
+	if (target->IsPet() && target->GetOwner() && target->GetOwner()->IsClient()) 
+		tc = target->GetOwner()->CastToClient();
 
 	//Familiars can never attack
-	if (attacker->IsPet() && attacker->IsFamiliar()) return false;
-	if (target->IsPet() && target->IsFamiliar()) return false;
+	if (attacker->IsPet() && attacker->IsFamiliar()) 
+		return false;
+	if (target->IsPet() && target->IsFamiliar()) 
+		return false;
 
-	if (ac && tc) return ac->CanPvP(tc); //Player vs Player check
-	if ((ac && target->IsNPC()) || (tc && ac->IsNPC())) return true; //player vs NPC
+	if (ac && tc) 
+		return ac->CanPvP(tc); //Player vs Player check
+	if ((ac && target->IsNPC()) || (tc && ac->IsNPC())) 
+		return true; //player vs NPC
 
 	hasRuleDefined = false;
 	return false;

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -2177,7 +2177,7 @@ void Bot::AI_Process() {
 	if (!guard_mode && !IsEngaged()) {
 		Mob* lo_target = leash_owner->GetTarget();
 
-		if (lo_target && lo_target->IsNPC() &&
+		if (lo_target &&
 			!lo_target->IsMezzed() &&
 			(lo_target->GetHateAmount(leash_owner) || leash_owner->AutoAttackEnabled()) &&
 			lo_distance <= BOT_LEASH_DISTANCE &&
@@ -2262,7 +2262,6 @@ void Bot::AI_Process() {
 		// If we don't, our hate_list is wiped.
 		// Else, it was causing the bot to aggro behind wall etc... causing massive trains.
 		if (guard_mode ||
-			!tar->IsNPC() ||
 			tar->IsMezzed() ||
 			(!tar->GetHateAmount(this) && !tar->GetHateAmount(leash_owner) && !leash_owner->AutoAttackEnabled()) ||
 			lo_distance > BOT_LEASH_DISTANCE ||
@@ -5660,6 +5659,8 @@ bool Bot::IsBotAttackAllowed(Mob* attacker, Mob* target, bool& hasRuleDefined) {
 		ac = attacker->CastToBot()->GetBotOwner()->CastToClient();
 	if (attacker->IsPet() && attacker->GetOwner() && attacker->GetOwner()->IsClient()) 
 		ac = attacker->GetOwner()->CastToClient();
+	if (attacker->IsPet() && attacker->GetOwner() && attacker->GetOwner()->IsBot() && attacker->GetOwner()->CastToBot()->GetOwner() && attacker->GetOwner()->CastToBot()->GetOwner()->IsClient())
+		ac = attacker->GetOwner()->CastToBot()->GetOwner()->CastToClient();
 
 	//Is target controlled by a client?
 	if (target->IsClient()) 
@@ -5668,6 +5669,8 @@ bool Bot::IsBotAttackAllowed(Mob* attacker, Mob* target, bool& hasRuleDefined) {
 		tc = target->CastToBot()->GetBotOwner()->CastToClient();
 	if (target->IsPet() && target->GetOwner() && target->GetOwner()->IsClient()) 
 		tc = target->GetOwner()->CastToClient();
+	if (target->IsPet() && target->GetOwner() && target->GetOwner()->IsBot() && target->GetOwner()->CastToBot()->GetOwner() && target->GetOwner()->CastToBot()->GetOwner()->IsClient())
+		tc = target->GetOwner()->CastToBot()->GetOwner()->CastToClient();
 
 	//Familiars can never attack
 	if (attacker->IsPet() && attacker->IsFamiliar()) 
@@ -5677,7 +5680,7 @@ bool Bot::IsBotAttackAllowed(Mob* attacker, Mob* target, bool& hasRuleDefined) {
 
 	if (ac && tc) 
 		return ac->CanPvP(tc); //Player vs Player check
-	if ((ac && target->IsNPC()) || (tc && ac->IsNPC())) 
+	if ((ac && target->IsNPC()) || (tc && attacker->IsNPC())) 
 		return true; //player vs NPC
 
 	hasRuleDefined = false;

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -5648,7 +5648,7 @@ bool Bot::IsBotAttackAllowed(Mob* attacker, Mob* target, bool& hasRuleDefined) {
 		if(attacker == target) {
 			hasRuleDefined = true;
 			Result = false;
-		} else if(attacker->IsClient() && target->IsBot() && attacker->CastToClient()->GetPVP() && target->CastToBot()->GetBotOwner()->CastToClient()->GetPVP()) {
+		} else if(attacker->IsClient() && target->IsBot() && attacker->CanPvP(target->CastToBot()->GetBotOwner()->CastToClient())) {
 			hasRuleDefined = true;
 			Result = true;
 		} else if(attacker->IsClient() && target->IsBot()) {
@@ -5663,14 +5663,15 @@ bool Bot::IsBotAttackAllowed(Mob* attacker, Mob* target, bool& hasRuleDefined) {
 		} else if(attacker->IsPet() && attacker->IsFamiliar()) {
 			hasRuleDefined = true;
 			Result = false;
-		} else if(attacker->IsBot() && attacker->CastToBot()->GetBotOwner() && attacker->CastToBot()->GetBotOwner()->CastToClient()->GetPVP()) {
-			if(target->IsBot() && target->GetOwner() && target->GetOwner()->CastToClient()->GetPVP()) {
+		} else if(attacker->IsBot() && attacker->CastToBot()->GetBotOwner() && attacker->CastToBot()->GetBotOwner()->CastToClient()->GetPVP()) { //this needs a cleanup
+ 			if(target->IsBot() && target->GetOwner() && target->GetOwner()->CastToClient()->CanPVP(attacker->CastToBot()->GetBotOwner()->CastToClient())) {
+  		
 				hasRuleDefined = true;
 				if(target->GetOwner() == attacker->GetOwner())
 					Result = false;
 				else
 					Result = true;
-			} else if(target->IsClient() && target->CastToClient()->GetPVP()) {
+			} else if(target->IsClient() && target->CastToClient()->CanPVP(attacker->CastToBot()->GetBotOwner()->CastToClient())) {  			
 				hasRuleDefined = true;
 				if(target == attacker->GetOwner())
 					Result = false;

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -5648,7 +5648,7 @@ bool Bot::IsBotAttackAllowed(Mob* attacker, Mob* target, bool& hasRuleDefined) {
 		if(attacker == target) {
 			hasRuleDefined = true;
 			Result = false;
-		} else if(attacker->IsClient() && target->IsBot() && attacker->CanPvP(target->CastToBot()->GetBotOwner()->CastToClient())) {
+		} else if(attacker->IsClient() && target->IsBot() && attacker->CastToClient()->CanPvP(target->CastToBot()->GetBotOwner()->CastToClient())) {
 			hasRuleDefined = true;
 			Result = true;
 		} else if(attacker->IsClient() && target->IsBot()) {

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -5644,9 +5644,11 @@ Mob* Bot::GetOwner() {
 
 //Is Bot attack allowed between attacker and target
 bool Bot::IsBotAttackAllowed(Mob* attacker, Mob* target, bool& hasRuleDefined) {
-	if (!attacker || !target) return false;	
+	if (!attacker || !target) 
+		return false;	
 	hasRuleDefined = true;
-	if (attacker == target) return false;
+	if (attacker == target) 
+		return false;
 	
 	Client *ac = nullptr;
 	Client *tc = nullptr;
@@ -5660,7 +5662,8 @@ bool Bot::IsBotAttackAllowed(Mob* attacker, Mob* target, bool& hasRuleDefined) {
 		ac = attacker->GetOwner()->CastToClient();
 
 	//Is target controlled by a client?
-	if (target->IsClient()) tc = target->CastToClient();
+	if (target->IsClient()) 
+		tc = target->CastToClient();
 	if (target->IsBot() && target->CastToBot()->GetBotOwner() && target->CastToBot()->GetBotOwner()->IsClient()) 
 		tc = target->CastToBot()->GetBotOwner()->CastToClient();
 	if (target->IsPet() && target->GetOwner() && target->GetOwner()->IsClient()) 

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -9262,25 +9262,43 @@ void Client::InitInnates()
 
 //CanPvP returns true if provided player can attack this player
 bool Client::CanPvP(Client *c) {
-	if (c == nullptr) return false;
+	if (c == nullptr) 
+		return false;
 
 	//Dueling overrides normal PvP logic
-	if (IsDueling() && c->IsDueling() && 
-		GetDuelTarget() == c->GetID() && 
-		c->GetDuelTarget() == GetID()) return true;
+	if (IsDueling() && c->IsDueling() && GetDuelTarget() == c->GetID() && c->GetDuelTarget() == GetID())
+		return true;
 
 	//If PVPLevelDifference is enabled, only allow PVP if players are of proper range
-	if (RuleI(World, PVPLevelDifference) > 0) {
+	int rule_level_diff = 0;
+	if (RuleI(World, PVPSettings) == 4)
+		rule_level_diff = 100; //Sullon Zek rules can attack anyone of opposing deity.
+	if (RuleI(World, PVPLevelDifference) > 0)
+		rule_level_diff = RuleI(World, PVPLevelDifference);
+
+	if (rule_level_diff > 0) {
 		int level_diff = 0;
-		if (c->GetLevel() > GetLevel()) level_diff = c->GetLevel() - GetLevel();
-		else level_diff = GetLevel() - c->GetLevel();
-		if (level_diff > RuleI(World, PVPLevelDifference)) return false;
+		if (c->GetLevel() > GetLevel())
+			level_diff = c->GetLevel() - GetLevel();
+		else 
+			level_diff = GetLevel() - c->GetLevel();
+		if (level_diff > rule_level_diff)
+			return false;
 	}
 
 	//players need to be proper level for pvp
-	if (RuleI(World, PVPMinLevel) > 0 && (GetLevel() < RuleI(World, PVPMinLevel) || c->GetLevel() < RuleI(World, PVPMinLevel))) return false;
+	int rule_min_level = 0;
+	if (RuleI(World, PVPSettings) == 4)
+		rule_min_level = 6;
+	if (RuleI(World, PVPMinLevel) > 0)
+		rule_min_level = RuleI(World, PVPMinLevel);
+
+	if (rule_min_level > 0 && (GetLevel() < RuleI(World, PVPMinLevel) || c->GetLevel() < RuleI(World, PVPMinLevel)))
+		return false;
+
 	//is deity pvp rule enabled? If so, if we're same alignment, don't allow pvp
-	if (RuleB(World, PVPUseDeityBasedPVP) && GetAlignment() == GetAlignment()) return false;
+	if ((RuleI(World, PVPSettings) == 4 || RuleB(World, PVPUseDeityBasedPVP)) && GetAlignment() == GetAlignment())
+		return false;
 	
 	//Check if players are flagged pvp. This may need to be removed later
 	if (!GetPVP() || !c->GetPVP()) return false;

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -9293,11 +9293,11 @@ bool Client::CanPvP(Client *c) {
 	if (RuleI(World, PVPMinLevel) > 0)
 		rule_min_level = RuleI(World, PVPMinLevel);
 
-	if (rule_min_level > 0 && (GetLevel() < RuleI(World, PVPMinLevel) || c->GetLevel() < RuleI(World, PVPMinLevel)))
+	if (rule_min_level > 0 && (GetLevel() < rule_min_level || c->GetLevel() < rule_min_level))
 		return false;
 
 	//is deity pvp rule enabled? If so, if we're same alignment, don't allow pvp
-	if ((RuleI(World, PVPSettings) == 4 || RuleB(World, PVPUseDeityBasedPVP)) && GetAlignment() == GetAlignment())
+	if ((RuleI(World, PVPSettings) == 4 || RuleB(World, PVPUseDeityBasedPVP)) && GetAlignment() == c->GetAlignment())
 		return false;
 	
 	//Check if players are flagged pvp. This may need to be removed later

--- a/zone/client.h
+++ b/zone/client.h
@@ -756,7 +756,8 @@ public:
 	bool TradeskillExecute(DBTradeskillRecipe_Struct *spec);
 	void CheckIncreaseTradeskill(int16 bonusstat, int16 stat_modifier, float skillup_modifier, uint16 success_modifier, EQEmu::skills::SkillType tradeskill);
 	void InitInnates();
-
+	bool CanPvP(Client * c);
+ 	int GetAlignment();
 	void GMKill();
 	inline bool IsMedding() const {return medding;}
 	inline uint16 GetDuelTarget() const { return duel_target; }

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4779,6 +4779,9 @@ void Client::Handle_OP_Consider(const EQApplicationPacket *app)
 		if (!tmob->IsNPC())
 			con->pvpcon = tmob->CastToClient()->GetPVP();
 	}
+	
+	//Disabled until NULL return is figured out
+	//if (tmob->IsClient() && CanPvP(tmob->CastToClient())) con->pvpcon = 1;
 
 	// If we're feigned show NPC as indifferent
 	if (tmob->IsNPC())


### PR DESCRIPTION
This adds new rules:
```RULE_BOOL(World, PVPUseDeityBasedPVP, false) //In PvP, deity is used to determine if a player can attack another.
RULE_INT(World, PVPLevelDifference, 0) // In PvP, if value is greater than 0, players with a difference greater than value will not be attackable
RULE_INT(World, PVPLoseExperienceLevelDifference, 0) // In PvP, if value is greater than 0, players lose experience if killed by a player within level difference
RULE_INT(World, PVPPetDamageMitigation, 50) // In PvP, pet damage is mitigated by this amount
RULE_INT(World, PVPMeleeMitigation, 67) // In PvP, melee is mitigated by this amount
RULE_INT(World, PVPSpellMitigation, 67) // In PvP, spells are mitigated by this amount
RULE_INT(World, PVPRangedMitigation, 80) // In PvP, ranged attacks (archery/throwing) is mitigated by this amount
```

This allows you emulate sullon zek's deity pvp, lets you tweak how impactful spells, melee, ranged and pet damage is in pvp, and allows you to flip exp loss based on a level difference, as well as lock pvp to specific level ranges.

All values by default should be exactly how code was before rules were added.