### PR TITLE
Fix HT and LOH to retry after failure to cast

### DIFF
--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -1540,16 +1540,19 @@ void NPC::DoClassAttacks(Mob *target) {
 
 	if(ka_time){
 		int knightreuse = 1000; //lets give it a small cooldown actually.
+
 		switch(GetClass()){
 			case SHADOWKNIGHT: case SHADOWKNIGHTGM:{
-				CastSpell(SPELL_NPC_HARM_TOUCH, target->GetID());
-				knightreuse = HarmTouchReuseTime * 1000;
+				if (CastSpell(SPELL_NPC_HARM_TOUCH, target->GetID())) {
+					knightreuse = HarmTouchReuseTime * 1000;
+					}
 				break;
 			}
 			case PALADIN: case PALADINGM:{
 				if(GetHPRatio() < 20) {
-					CastSpell(SPELL_LAY_ON_HANDS, GetID());
-					knightreuse = LayOnHandsReuseTime * 1000;
+					if (CastSpell(SPELL_LAY_ON_HANDS, GetID())) {
+						knightreuse = LayOnHandsReuseTime * 1000;
+					}
 				} else {
 					knightreuse = 2000; //Check again in two seconds.
 				}


### PR DESCRIPTION
So if Harm Touch fails (line of sight issue for one) the old code still sets the reuse timer as if it was used.

Now, the mob will retry since it never actually fired.