### PR TITLE
[Exploit] Prevent low level mez testing without aggro.

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4247,6 +4247,7 @@ bool Mob::IsImmuneToSpell(uint16 spell_id, Mob *caster)
 		{
 			Log(Logs::Detail, Logs::Spells, "Our level (%d) is higher than the limit of this Mez spell (%d)", GetLevel(), spells[spell_id].max[effect_index]);
 			caster->Message_StringID(MT_Shout, CANNOT_MEZ_WITH_SPELL);
+			AddToHateList(caster, 1,0,true,false,false,spell_id);
 			return true;
 		}
 	}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4339,6 +4339,7 @@ bool Mob::IsImmuneToSpell(uint16 spell_id, Mob *caster)
 			{
 				Log(Logs::Detail, Logs::Spells, "Our level (%d) is higher than the limit of this Charm spell (%d)", GetLevel(), spells[spell_id].max[effect_index]);
 				caster->Message_StringID(MT_Shout, CANNOT_CHARM_YET);
+                AddToHateList(caster, 1,0,true,false,false,spell_id);
 				return true;
 			}
 		}


### PR DESCRIPTION
Using low level mez to test if a mob is mezzable and NOT get aggro has been squashed. When you cast you will get 1 point of aggro on a Cannot mez with this spell.