### PR TITLE
Prevent Gate if near bind location (Rule) and Heal on Gate (Rule)

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -532,6 +532,11 @@ RULE_INT(NPC, NPCToNPCAggroTimerMin, 500)
 RULE_INT(NPC, NPCToNPCAggroTimerMax, 6000)
 RULE_BOOL(NPC, UseClassAsLastName, true) // Uses class archetype as LastName for npcs with none
 RULE_BOOL(NPC, NewLevelScaling, true) // Better level scaling, use old if new formulas would break your server
+RULE_INT(NPC, NPCGatePercent, 5) // % at which the NPC Will attempt to gate at.
+RULE_BOOL(NPC, NPCGateNearBind, false) // Will NPC attempt to gate when near bind location?
+RULE_INT(NPC, NPCGateDistanceBind, 75) // Distance from bind before NPC will attempt to gate
+RULE_BOOL(NPC, NPCHealOnGate, true) // Will the NPC Heal on Gate.
+RULE_REAL(NPC, NPCHealOnGateAmount, 25) // How much the npc will heal on gate if enabled.
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Aggro)

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -201,10 +201,14 @@ bool NPC::AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes, bool bInnates
 						// If min_hp !=0 then the spell list has specified
 						// custom range and we're inside that range if we
 						// made it here.  The hard coded <=5 is for unspecified.
-						if (AIspells[i].min_hp != 0 || GetHPRatio() <= 5)
-						{
-							AIDoSpellCast(i, tar, mana_cost);
-							return true;
+						if (GetHPRatio() <= (RuleI(NPC, NPCGatePercent))) {
+							auto npcSpawnPoint = CastToNPC()->GetSpawnPoint();
+							if (!RuleB(NPC, NPCGateNearBind) && DistanceNoZ(m_Position, npcSpawnPoint) < RuleI(NPC, NPCGateDistanceBind)) {
+								break;
+							} else {
+								AIDoSpellCast(i, tar, mana_cost);
+								return true;
+							}
 						}
 						break;
 					}

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -200,8 +200,8 @@ bool NPC::AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes, bool bInnates
 					case SpellType_Escape: {
 						// If min_hp !=0 then the spell list has specified
 						// custom range and we're inside that range if we
-						// made it here.  The hard coded <=5 is for unspecified.
-						if (GetHPRatio() <= (RuleI(NPC, NPCGatePercent))) {
+						// made it here.
+						if (AIspells[i].min_hp != 0 || GetHPRatio() <= (RuleI(NPC, NPCGatePercent))) {
 							auto npcSpawnPoint = CastToNPC()->GetSpawnPoint();
 							if (!RuleB(NPC, NPCGateNearBind) && DistanceNoZ(m_Position, npcSpawnPoint) < RuleI(NPC, NPCGateDistanceBind)) {
 								break;

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -717,6 +717,10 @@ void Client::GoToSafeCoords(uint16 zone_id, uint16 instance_id) {
 
 void Mob::Gate(uint8 bindnum) {
 	GoToBind(bindnum);
+	if (RuleB(NPC, NPCHealOnGate) && this->IsNPC() && this->GetHPRatio() <= RuleR(NPC, NPCHealOnGateAmount)) {
+		auto HealAmount = (RuleR(NPC, NPCHealOnGateAmount) / 100);
+		SetHP(int(this->GetMaxHP() * HealAmount));
+	}
 }
 
 void Client::Gate(uint8 bindnum) {


### PR DESCRIPTION
RULE_INT(NPC, NPCGatePercent, 5) // % at which the NPC Will attempt to gate at.
RULE_BOOL(NPC, NPCGateNearBind, false) // Will NPC attempt to gate when near bind location?
RULE_INT(NPC, NPCGateDistanceBind, 75) // Distance from bind before NPC will attempt to gate
RULE_BOOL(NPC, NPCHealOnGate, true) // Will the NPC Heal on Gate.
RULE_REAL(NPC, NPCHealOnGateAmount, 25) // How much the npc will heal on gate if enabled.