### PR TITLE
Removed unneeded calcs from FixZ if Client()

### DIFF
--- a/zone/waypoints.cpp
+++ b/zone/waypoints.cpp
@@ -794,24 +794,27 @@ float Mob::GetFixedZ(glm::vec3 destination, int32 z_find_offset) {
 }
 
 void Mob::FixZ(int32 z_find_offset /*= 5*/) {
-	glm::vec3 current_loc(m_Position);
-	float     new_z = GetFixedZ(current_loc, z_find_offset);
 
-	if (!IsClient() && new_z != m_Position.z) {
-		if ((new_z > -2000) && new_z != BEST_Z_INVALID) {
-			if (RuleB(Map, MobZVisualDebug)) {
-				this->SendAppearanceEffect(78, 0, 0, 0, 0);
+	if (!IsClient()) {
+		glm::vec3 current_loc(m_Position);
+		float     new_z = GetFixedZ(current_loc, z_find_offset);
+
+		if (new_z != m_Position.z) {
+			if ((new_z > -2000) && new_z != BEST_Z_INVALID) {
+				if (RuleB(Map, MobZVisualDebug)) {
+					this->SendAppearanceEffect(78, 0, 0, 0, 0);
+				}
+
+				m_Position.z = new_z;
 			}
+			else {
+				if (RuleB(Map, MobZVisualDebug)) {
+					this->SendAppearanceEffect(103, 0, 0, 0, 0);
+				}
 
-			m_Position.z = new_z;
-		}
-		else {
-			if (RuleB(Map, MobZVisualDebug)) {
-				this->SendAppearanceEffect(103, 0, 0, 0, 0);
+				Log(Logs::General, Logs::FixZ, "%s is failing to find Z %f",
+					this->GetCleanName(), std::abs(m_Position.z - new_z));
 			}
-
-			Log(Logs::General, Logs::FixZ, "%s is failing to find Z %f",
-				this->GetCleanName(), std::abs(m_Position.z - new_z));
 		}
 	}
 }


### PR DESCRIPTION
Just pushed the variables and the call to GetFixedZ() inside the conditional so we only do it when needed.