### PR TITLE
/assist exploit fix

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -2950,7 +2950,11 @@ void Client::Handle_OP_Assist(const EQApplicationPacket *app)
 				Distance(m_Position, assistee->GetPosition()) <= TARGETING_RANGE)) {
 				SetAssistExemption(true);
 				eid->entity_id = new_target->GetID();
+			} else {
+				eid->entity_id = 0;
 			}
+		} else {
+			eid->entity_id = 0;
 		}
 	}
 


### PR DESCRIPTION
Prevents players from /assist to see if a mob is up due to error or no error messages.