### PR TITLE
Make SPA 112 affect fizzle rate not effective caster level

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -1217,8 +1217,12 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_CastingLevel2:
 		case SE_CastingLevel: {
+			newbon->adjusted_casting_skill += base1;
+			break;
+		}
+
+		case SE_CastingLevel2: {
 			newbon->effective_casting_level += base1;
 			break;
 		}
@@ -1917,8 +1921,13 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_CastingLevel2:
 			case SE_CastingLevel:	// Brilliance of Ro
+			{
+				new_bonus->adjusted_casting_skill += effect_value;
+				break;
+			}
+
+			case SE_CastingLevel2:
 			{
 				new_bonus->effective_casting_level += effect_value;
 				break;
@@ -3867,8 +3876,13 @@ void Mob::NegateSpellsBonuses(uint16 spell_id)
 					aabonuses.Corrup = effect_value;
 					break;
 
-				case SE_CastingLevel2:
 				case SE_CastingLevel:	// Brilliance of Ro
+					spellbonuses.adjusted_casting_skill = effect_value;
+					aabonuses.adjusted_casting_skill = effect_value;
+					itembonuses.adjusted_casting_skill = effect_value;
+					break;
+
+				case SE_CastingLevel2:
 					spellbonuses.effective_casting_level = effect_value;
 					aabonuses.effective_casting_level = effect_value;
 					itembonuses.effective_casting_level = effect_value;

--- a/zone/common.h
+++ b/zone/common.h
@@ -354,6 +354,7 @@ struct StatBonuses {
 	int32	skillmod[EQEmu::skills::HIGHEST_SKILL + 1];
 	int32	skillmodmax[EQEmu::skills::HIGHEST_SKILL + 1];
 	int		effective_casting_level;
+	int		adjusted_casting_skill;				// SPA 112 for fizzles
 	int		reflect_chance;						// chance to reflect incoming spell
 	uint32	singingMod;
 	uint32	Amplification;						// stacks with singingMod

--- a/zone/lua_stat_bonuses.cpp
+++ b/zone/lua_stat_bonuses.cpp
@@ -333,6 +333,11 @@ int Lua_StatBonuses::Geteffective_casting_level() const {
 	return self->effective_casting_level;
 }
 
+int Lua_StatBonuses::Getadjusted_casting_skill() const {
+	Lua_Safe_Call_Int();
+	return self->adjusted_casting_skill;
+}
+
 int Lua_StatBonuses::Getreflect_chance() const {
 	Lua_Safe_Call_Int();
 	return self->reflect_chance;
@@ -1347,6 +1352,7 @@ luabind::scope lua_register_stat_bonuses() {
 		.def("skillmod", &Lua_StatBonuses::Getskillmod)
 		.def("skillmodmax", &Lua_StatBonuses::Getskillmodmax)
 		.def("effective_casting_level", &Lua_StatBonuses::Geteffective_casting_level)
+		.def("adjusted_casting_skill", &Lua_StatBonuses::Getadjusted_casting_skill)
 		.def("reflect_chance", &Lua_StatBonuses::Getreflect_chance)
 		.def("singingMod", &Lua_StatBonuses::GetsingingMod)
 		.def("Amplification", &Lua_StatBonuses::GetAmplification)

--- a/zone/lua_stat_bonuses.h
+++ b/zone/lua_stat_bonuses.h
@@ -91,6 +91,7 @@ public:
 	int32 Getskillmod(int idx) const;
 	int32 Getskillmodmax(int idx) const;
 	int Geteffective_casting_level() const;
+	int Getadjusted_casting_skill() const;
 	int Getreflect_chance() const;
 	uint32 GetsingingMod() const;
 	uint32 GetAmplification() const;

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -752,6 +752,8 @@ bool Client::CheckFizzle(uint16 spell_id)
 
 	act_skill = GetSkill(spells[spell_id].skill);
 	act_skill += GetLevel(); // maximum of whatever the client can cheat
+	act_skill += itembonuses.adjusted_casting_skill + spellbonuses.adjusted_casting_skill + aabonuses.adjusted_casting_skill;
+	Log(Logs::Detail, Logs::Spells, "Adjusted casting skill: %d+%d+%d+%d+%d=%d", GetSkill(spells[spell_id].skill), GetLevel(), itembonuses.adjusted_casting_skill, spellbonuses.adjusted_casting_skill, aabonuses.adjusted_casting_skill, act_skill);
 
 	//spell specialization
 	float specialize = GetSpecializeSkillValue(spell_id);


### PR DESCRIPTION
Dev quote is here:
https://forums.daybreakgames.com/eq/index.php?threads/enumerated-spa-list.206288/page-4#post-3655856

A couple ways to verify this on live

/testbuff with an Enchanter and self buff Intellectual Superiority. While buffed with Intellectual Superiority, casting a buff like Major Shielding doesn't change caster level that the client sees. Refreshing the existing buff also works after Intellectual Superiority is removed.
On emu, the client sees caster level+6 and the refresh attempt won't take hold. 

Another way to confirm this is via THO's Feeblemind debuff (-200 SPA112 value)
On emu, a shaman with this debuff will only have a ~9s duration on Balance of Discord
on live, the duration of Balance of Discord is the full 1m30s+
