### PR TITLE
Pets always try and update owner, if hp changed

### DIFF
--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -747,8 +747,10 @@ bool NPC::Process()
 
 	/**
 	 * Send HP updates when engaged
+	 * Pets always - master wants to see the healing
 	 */
-	if (send_hp_update_timer.Check(false) && this->IsEngaged()) {
+	if (send_hp_update_timer.Check(false) && 
+		(this->IsEngaged() || (GetOwner() && GetOwner()->IsClient()))) {
 		SendHPUpdate();
 	}
 


### PR DESCRIPTION
SendHPUpdate never got called for non-engaged pets.  This could lead to issues between mobs and when resting.