### PR TITLE
Fix Get Corpse to fetch the corpse indicated.

### DIFF
--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -4356,15 +4356,15 @@ uint32 ZoneDatabase::GetCharacterCorpseCount(uint32 char_id) {
 }
 
 uint32 ZoneDatabase::GetCharacterCorpseID(uint32 char_id, uint8 corpse) {
-	std::string query = StringFormat("SELECT `id` FROM `character_corpses` WHERE `charid` = '%u'", char_id);
-	auto results = QueryDatabase(query);
+	std::string query = StringFormat("SELECT `id` FROM `character_corpses` WHERE `charid` = '%u' limit %d, 1", char_id, corpse);
 
-	for (auto row = results.begin(); row != results.end(); ++row) {
-		for (int i = 0; i < corpse; i++) {
-			return atoul(row[0]);
-		}
-	}
-	return 0;
+	auto results = QueryDatabase(query);
+	auto row = results.begin();
+
+	if (row != results.end())
+		return atoul(row[0]);
+	else
+		return 0;
 }
 
 uint32 ZoneDatabase::GetCharacterCorpseItemCount(uint32 corpse_id){


### PR DESCRIPTION
ZoneDatabase::GetCharacterCorpseID was always returning the 1st corpse, not the n-th corpse as requested.