### PR TITLE
Fixes for:

### DIFF
--- a/world/client.cpp
+++ b/world/client.cpp
@@ -92,8 +92,6 @@ Client::Client(EQStreamInterface* ieqs)
 	connect(1000),
 	eqs(ieqs)
 {
-	//mMovementManager->AddClient(this);
-
 	// Live does not send datarate as of 3/11/2005
 	//eqs->SetDataRate(7);
 	ip = eqs->GetRemoteIP();

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -156,6 +156,7 @@ Client::Client(EQStreamInterface* ieqs)
 	m_AutoAttackTargetLocation(0.0f, 0.0f, 0.0f),
 	last_region_type(RegionTypeUnsupported),
 	m_dirtyautohaters(false),
+	npc_close_scan_timer(6000),
 	hp_self_update_throttle_timer(300),
 	hp_other_update_throttle_timer(500),
 	position_update_timer(10000),

--- a/zone/client.h
+++ b/zone/client.h
@@ -1514,6 +1514,7 @@ private:
 	Timer afk_toggle_timer;
 	Timer helm_toggle_timer;
 	Timer aggro_meter_timer;
+	Timer npc_close_scan_timer;
 	Timer hp_self_update_throttle_timer; /* This is to prevent excessive packet sending under trains/fast combat */
 	Timer hp_other_update_throttle_timer; /* This is to keep clients from DOSing the server with macros that change client targets constantly */
 	Timer position_update_timer; /* Timer used when client hasn't updated within a 10 second window */

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -251,6 +251,32 @@ bool Client::Process() {
 			}
 		}
 		
+		
+		/* Build a close range list of NPC's  */
+		if (npc_close_scan_timer.Check()) {
+			close_mobs.clear();
+
+			//Force spawn updates when traveled far 
+			bool force_spawn_updates = false;
+			float client_update_range = (RuleI(Range, ClientForceSpawnUpdateRange) *  RuleI(Range, ClientForceSpawnUpdateRange));
+
+			float scan_range = (RuleI(Range, ClientNPCScan) * RuleI(Range, ClientNPCScan));
+			auto &mob_list = entity_list.GetMobList();
+			for (auto itr = mob_list.begin(); itr != mob_list.end(); ++itr) {
+				Mob* mob = itr->second;
+
+				float distance = DistanceSquared(m_Position, mob->GetPosition());
+				if (mob->IsNPC()) {
+					if (distance <= scan_range) {
+						close_mobs.insert(std::pair<Mob *, float>(mob, distance));
+					}
+					else if ((mob->GetAggroRange() * mob->GetAggroRange()) > scan_range) {
+						close_mobs.insert(std::pair<Mob *, float>(mob, distance));
+					}
+				}
+			}
+		}
+
 		bool may_use_attacks = false;
 		/*
 			Things which prevent us from attacking:

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -41,6 +41,7 @@ Child of the Mob class.
 #include "groups.h"
 #include "mob.h"
 #include "raids.h"
+#include "mob_movement_manager.h"
 
 #ifdef BOTS
 #include "bot.h"
@@ -1427,7 +1428,10 @@ bool Corpse::Summon(Client* client, bool spell, bool CheckDistance) {
 				return false;
 			}
 			if (!CheckDistance || (DistanceSquaredNoZ(m_Position, client->GetPosition()) <= dist2)) {
-				GMMove(client->GetX(), client->GetY(), client->GetZ());
+				m_Position.x = client->GetX();
+				m_Position.y = client->GetY();
+				m_Position.z = client->GetZ();
+				mMovementManager->SendCommandToClients(this, 0.0, 0.0, 0.0, 0.0, 0, ClientRangeAny);
 				is_corpse_changed = true;
 			}
 			else {
@@ -1442,7 +1446,10 @@ bool Corpse::Summon(Client* client, bool spell, bool CheckDistance) {
 			for(itr = client->consent_list.begin(); itr != client->consent_list.end(); ++itr) {
 				if(strcmp(this->GetOwnerName(), itr->c_str()) == 0) {
 					if (!CheckDistance || (DistanceSquaredNoZ(m_Position, client->GetPosition()) <= dist2)) {
-						GMMove(client->GetX(), client->GetY(), client->GetZ());
+						m_Position.x = client->GetX();
+						m_Position.y = client->GetY();
+						m_Position.z = client->GetZ();
+						mMovementManager->SendCommandToClients(this, 0.0, 0.0, 0.0, 0.0, 0, ClientRangeAny);
 						is_corpse_changed = true;
 					}
 					else {

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1658,8 +1658,17 @@ void Mob::ShowBuffList(Client* client) {
 }
 
 void Mob::GMMove(float x, float y, float z, float heading, bool SendUpdate) {
+	if (!IsCorpse())
+	{
 	Teleport(glm::vec4(x, y, z, heading));
-
+	}
+	else
+	{
+		m_Position.x = x;
+		m_Position.y = y;
+		m_Position.z = z;
+		mMovementManager->SendCommandToClients(this, 0.0, 0.0, 0.0, 0.0, 0, ClientRangeAny);
+	}
 	if (IsNPC()) {
 		CastToNPC()->SaveGuardSpot(glm::vec4(x, y, z, heading));
 	}

--- a/zone/mob_movement_manager.cpp
+++ b/zone/mob_movement_manager.cpp
@@ -122,7 +122,12 @@ public:
 		double current_time = static_cast<double>(Timer::GetCurrentTime()) / 1000.0;
 		int current_speed = 0;
 
-		if (m_move_to_mode == MovementRunning) {
+		
+		
+		if (m->IsFeared()) {
+			current_speed = m->GetFearSpeed();
+		}
+		else if (m_move_to_mode == MovementRunning) {
 			current_speed = m->GetRunspeed();
 		}
 		else {
@@ -170,6 +175,9 @@ public:
 		double len = glm::distance(pos, tar);
 		if (len == 0) {
 			return true;
+		}
+		if (current_speed == 0.0f) {
+			return false;
 		}
 
 		m->SetMoved(true);
@@ -378,6 +386,7 @@ public:
 
 		if (m->IsMoving()) {
 			m->SetMoving(false);
+			m->FixZ();
 			mgr->SendCommandToClients(m, 0.0, 0.0, 0.0, 0.0, 0, ClientRangeCloseMedium);
 		}
 		return true;
@@ -579,7 +588,7 @@ void MobMovementManager::NavigateTo(Mob *who, float x, float y, float z, MobMove
 		auto within = IsPositionWithinSimpleCylinder(glm::vec3(x, y, z), glm::vec3(nav.navigate_to_x, nav.navigate_to_y, nav.navigate_to_z), 1.5f, 6.0f);
 		auto heading_match = IsHeadingEqual(0.0, nav.navigate_to_heading);
 
-		if (false == within || false == heading_match) {
+		if(false == within || false == heading_match || ent.second.Commands.size() == 0) {
 			ent.second.Commands.clear();
 
 			//Path is no longer valid, calculate a new path

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3509,7 +3509,7 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, bool reflect, bool use_r
 		RuleI(Range, SpellMessages), 
 		this, /* Skip this Mob */
 		true, /* Packet ACK */
-		(spelltar->IsClient() ? FilterPCSpells : FilterNPCSpells) /* EQ Filter Type: (8 or 9) */
+		IsBardSong(spell_id) ? FilterBardSongs : ((spelltar->IsClient() ? FilterPCSpells : FilterNPCSpells))); /* EQ Filter Type: (8 or 9) */
 	);
 
 	/* Send the EVENT_CAST_ON event */


### PR DESCRIPTION
-Corpse summoning - all cases of corpse summoning should now work (#summon, /corpse, /corpsedrag)
-Re-implement mob aggro radius to check for proximity aggro based on client location, but remove position update code from that logic
-AI fixups for pets and casting NPCs - they should now stop.
-zone map check for roambox - prevents crash
-Use fear speed in cases where we need to slow down movement (ie; snared + feared)
-Fix Z on stopping movement - the final position may not always have the best Z, based on route changes
-Add check to see if we're completely stuck (ie; we have no commands but are moving) and fix that scenario if it happens (this was happening in a live environment)