### PR TITLE
Fix omission for Perl/Lua binds for get_data_expires()

### DIFF
--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -3692,6 +3692,7 @@ EXTERN_C XS(boot_quest) {
 	newXS(strcpy(buf, "GetZoneID"), XS__GetZoneID, file);
 	newXS(strcpy(buf, "GetZoneLongName"), XS__GetZoneLongName, file);
 	newXS(strcpy(buf, "get_data"), XS__get_data, file);
+	newXS(strcpy(buf, "get_data_expires"), XS__get_data_expires, file);
 	newXS(strcpy(buf, "set_data"), XS__set_data, file);
 	newXS(strcpy(buf, "delete_data"), XS__delete_data, file);
 	newXS(strcpy(buf, "IsBeneficialSpell"), XS__IsBeneficialSpell, file);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -1680,6 +1680,7 @@ luabind::scope lua_register_general() {
 		luabind::def("say_link", (std::string(*)(const char*,bool))&lua_say_link),
 		luabind::def("say_link", (std::string(*)(const char*))&lua_say_link),
 		luabind::def("get_data", (std::string(*)(std::string))&lua_get_data),
+		luabind::def("get_data_expires", (std::string(*)(std::string))&lua_get_data_expires),
 		luabind::def("set_data", (void(*)(std::string, std::string))&lua_set_data),
 		luabind::def("set_data", (void(*)(std::string, std::string, std::string))&lua_set_data),
 		luabind::def("delete_data", (bool(*)(std::string))&lua_delete_data),


### PR DESCRIPTION
Last commit when I added this function I omitted these lines.