### PR TITLE
Fix the LoadGFG function to no longer have the unused parameter.

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -1688,7 +1688,7 @@ void command_zheader(Client *c, const Seperator *sep)
 		c->Message(0, "Invalid Zone Name: %s",  sep->argplus[1]);
 	else {
 
-		if (zone->LoadZoneCFG(sep->argplus[1], true))
+		if (zone->LoadZoneCFG(sep->argplus[1], 0))
 			c->Message(0, "Successfully loaded zone header for %s from database.",  sep->argplus[1]);
 		else
 			c->Message(0, "Failed to load zone header %s from database",  sep->argplus[1]);

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -93,7 +93,7 @@ public:
 	bool is_zone_time_localized;
 
 	bool	Init(bool iStaticZone);
-	bool	LoadZoneCFG(const char* filename, uint16 instance_id, bool DontLoadDefault = false);
+	bool	LoadZoneCFG(const char* filename, uint16 instance_id);
 	bool	SaveZoneCFG();
 	bool	IsLoaded();
 	bool	IsPVPZone() { return pvpzone; }


### PR DESCRIPTION
LoadZoneCFG has a parameter that it never used.
LoadZoneCFG was called from command.cpp with true being passed as the instance id by mistake.
Refactored LoadZoneCFG to make a bit more sense.