### PR TITLE
Properly escape key in SQL queries

### DIFF
--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -1133,7 +1133,7 @@ uint32 Client::GetCharMaxLevelFromQGlobal() {
 
 uint32 Client::GetCharMaxLevelFromBucket() {
 	uint32 char_id = this->CharacterID();
-	std::string query = StringFormat("SELECT value FROM data_buckets WHERE key = '%i-CharMaxLevel'", char_id);
+	std::string query = StringFormat("SELECT value FROM data_buckets WHERE `key` = '%i-CharMaxLevel'", char_id);
 	auto results = database.QueryDatabase(query);
 	if (!results.Success()) {
         Log(Logs::General, Logs::Error, "Data bucket for CharMaxLevel for char ID %i failed.", char_id);

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -5169,7 +5169,7 @@ bool Client::SpellBucketCheck(uint16 spell_id, uint32 char_id) {
 	std::string spell_bucket_name;
 	int spell_bucket_value;
 	int bucket_value;
-	std::string query = StringFormat("SELECT key, value FROM spell_buckets WHERE spellid = %i", spell_id);
+	std::string query = StringFormat("SELECT `key`, value FROM spell_buckets WHERE spellid = %i", spell_id);
 	auto results = database.QueryDatabase(query);
 	if (!results.Success())
 		return false;
@@ -5183,7 +5183,7 @@ bool Client::SpellBucketCheck(uint16 spell_id, uint32 char_id) {
 	if (spell_bucket_name.empty())
 		return true;
 	
-	query = StringFormat("SELECT value FROM data_buckets WHERE key = '%i-%s'", char_id, spell_bucket_name.c_str());
+	query = StringFormat("SELECT value FROM data_buckets WHERE `key` = '%i-%s'", char_id, spell_bucket_name.c_str());
 	results = database.QueryDatabase(query);
 	if (!results.Success()) {
         Log(Logs::General, Logs::Error, "Spell bucket %s for spell ID %i for char ID %i failed.", spell_bucket_name.c_str(), spell_id, char_id);


### PR DESCRIPTION
"key" wasn't being escaped with `s, so the SQL queries were failing. 