### PR TITLE
Adds dynamic rule capabilities to quests in LUA/Perl.

### DIFF
--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -3622,6 +3622,36 @@ XS(XS__UpdateZoneHeader) {
 	XSRETURN_EMPTY;
 }
 
+XS(XS__set_rule);
+XS(XS__set_rule) {
+	dXSARGS;
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: quest::set_rule(string rule_name, string rule_value)");
+	
+	std::string rule_name = (std::string) SvPV_nolen(ST(0));
+	std::string rule_value = (std::string) SvPV_nolen(ST(1));
+	RuleManager::Instance()->SetRule(rule_name.c_str(), rule_value.c_str());
+	
+	XSRETURN_EMPTY;
+}
+
+XS(XS__get_rule);
+XS(XS__get_rule) {
+	dXSARGS;
+	if (items != 1)
+		Perl_croak(aTHX_ "Usage: quest::get_rule(string rule_name)");
+
+	dXSTARG;
+	std::string rule_name = (std::string) SvPV_nolen(ST(0));
+	std::string rule_value;
+	RuleManager::Instance()->GetRule(rule_name.c_str(), rule_value);
+
+	sv_setpv(TARG, rule_value.c_str());
+	XSprePUSH;
+	PUSHTARG;
+	XSRETURN(1);
+}
+
 XS(XS__get_data);
 XS(XS__get_data) {
 	dXSARGS;
@@ -3734,6 +3764,8 @@ EXTERN_C XS(boot_quest) {
 	newXS(strcpy(buf, "GetTimeSeconds"), XS__GetTimeSeconds, file);
 	newXS(strcpy(buf, "GetZoneID"), XS__GetZoneID, file);
 	newXS(strcpy(buf, "GetZoneLongName"), XS__GetZoneLongName, file);
+	newXS(strcpy(buf, "set_rule"), XS__set_rule, file);
+	newXS(strcpy(buf, "get_rule"), XS__get_rule, file);
 	newXS(strcpy(buf, "get_data"), XS__get_data, file);
 	newXS(strcpy(buf, "get_data_expires"), XS__get_data_expires, file);
 	newXS(strcpy(buf, "set_data"), XS__set_data, file);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -814,6 +814,16 @@ std::string lua_say_link(const char *phrase) {
 	return quest_manager.saylink(text, false, text);
 }
 
+void lua_set_rule(std::string rule_name, std::string rule_value) {
+	RuleManager::Instance()->SetRule(rule_name.c_str(), rule_value.c_str());
+}
+
+std::string lua_get_rule(std::string rule_name) {
+	std::string rule_value;
+	RuleManager::Instance()->GetRule(rule_name.c_str(), rule_value);
+	return rule_value;
+}
+
 std::string lua_get_data(std::string bucket_key) {
 	return DataBucket::GetData(bucket_key);
 }
@@ -1687,6 +1697,8 @@ luabind::scope lua_register_general() {
 		luabind::def("say_link", (std::string(*)(const char*,bool,const char*))&lua_say_link),
 		luabind::def("say_link", (std::string(*)(const char*,bool))&lua_say_link),
 		luabind::def("say_link", (std::string(*)(const char*))&lua_say_link),
+		luabind::def("set_rule", (void(*)(std::string, std::string))&lua_set_rule),
+		luabind::def("get_rule", (std::string(*)(std::string))&lua_get_rule),
 		luabind::def("get_data", (std::string(*)(std::string))&lua_get_data),
 		luabind::def("get_data_expires", (std::string(*)(std::string))&lua_get_data_expires),
 		luabind::def("set_data", (void(*)(std::string, std::string))&lua_set_data),


### PR DESCRIPTION
- quest::set_rule(string rule_name, string rule_value)
	Example: quest::set_rule("Zone:UseZoneController", "false") - Sets the rule "Zone:UseZoneController" to "false" for the current zone.
- quest::get_rule(string rule_name)
	Example: quest::get_rule("Zone:UseZoneController") - Returns true/false depending upon if it's enabled/disabled.
- Example NPC script here: https://pastebin.com/akKKN2NS