### PR TITLE
Added Spells:CharmDisablesSpecialAbilities

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -365,6 +365,7 @@ RULE_INT(Spells, CharismaEffectiveness, 10) // Deterimes how much resist modific
 RULE_INT(Spells, CharismaEffectivenessCap, 255) // Deterimes how much resist modification charisma applies to charm/pacify checks. Default 10 CHA = -1 resist mod.
 RULE_BOOL(Spells, CharismaCharmDuration, false) // Allow CHA resist mod to extend charm duration.
 RULE_INT(Spells, CharmBreakCheckChance, 25) //Determines chance for a charm break check to occur each buff tick.
+RULE_BOOL(Spells, CharmDisablesSpecialAbilities, false) //When charm is cast on an NPC, strip their special abilities
 RULE_INT(Spells, MaxCastTimeReduction, 50) //Max percent your spell cast time can be reduced by spell haste
 RULE_INT(Spells, RootBreakFromSpells, 55) //Chance for root to break when cast on.
 RULE_INT(Spells, DeathSaveCharismaMod, 3) //Determines how much charisma effects chance of death save firing.

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -208,6 +208,7 @@ NPC::NPC(const NPCType *npc_type_data, Spawn2 *in_respawn, const glm::vec4 &posi
 	default_accuracy_rating  = npc_type_data->accuracy_rating;
 	default_avoidance_rating = npc_type_data->avoidance_rating;
 	default_atk              = npc_type_data->ATK;
+	strn0cpy(default_special_abilities, npc_type_data->special_abilities, 512);
 
 	// used for when getting charmed, if 0, doesn't swap
 	charm_ac               = npc_type_data->charm_ac;
@@ -2840,6 +2841,8 @@ void NPC::ModifyStatsOnCharm(bool bRemoved)
 			base_damage = round((default_max_dmg - default_min_dmg) / 1.9);
 			min_damage = default_min_dmg - round(base_damage / 10.0);
 		}
+		if (RuleB(Spells, CharmDisablesSpecialAbilities))
+			ProcessSpecialAbilities(default_special_abilities);
 	} else {
 		if (charm_ac)
 			AC = charm_ac;
@@ -2855,6 +2858,8 @@ void NPC::ModifyStatsOnCharm(bool bRemoved)
 			base_damage = round((charm_max_dmg - charm_min_dmg) / 1.9);
 			min_damage = charm_min_dmg - round(base_damage / 10.0);
 		}
+		if (RuleB(Spells, CharmDisablesSpecialAbilities))
+			ClearSpecialAbilities();
 	}
 	// the rest of the stats aren't cached, so lets just do these two instead of full CalcBonuses()
 	SetAttackTimer();

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -538,6 +538,7 @@ protected:
 	int default_accuracy_rating;
 	int default_avoidance_rating;
 	int default_atk;
+	char default_special_abilities[512];
 
 	// when charmed, switch to these
 	int charm_ac;


### PR DESCRIPTION
This PR introduces a new rule, which is disabled by default, named Spells:CharmDisablesSpecialAbilities

I did not test this at all, really, other than ensure it compiles, as I wanted to have others review the implementation first..

When enabled, it will strip the special abilities of an NPC while charm is in effect.

So some debates with this PR:
* Charm even with the scaling features does not disable one of the biggest factors to the benefits of charm: Special abilities of an NPC.
* We could write a dynamic system so charmed NPCs have the special abilities to mirror what a pet gets at a given level?
* Should this be enabled by default?


