### PR TITLE
Reference the defender melee mitigation, not attacker

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -4514,7 +4514,7 @@ void Mob::ApplyMeleeDamageMods(uint16 skill, int &damage, Mob *defender, ExtraAt
 		if (defender->IsClient() && defender->GetClass() == WARRIOR)
 			dmgbonusmod -= 5;
 		// 168 defensive
-		dmgbonusmod -= (defender->spellbonuses.MeleeMitigationEffect +
+		dmgbonusmod += (defender->spellbonuses.MeleeMitigationEffect +
 		                defender->itembonuses.MeleeMitigationEffect +
 		                defender->aabonuses.MeleeMitigationEffect);
 	}

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -4514,7 +4514,9 @@ void Mob::ApplyMeleeDamageMods(uint16 skill, int &damage, Mob *defender, ExtraAt
 		if (defender->IsClient() && defender->GetClass() == WARRIOR)
 			dmgbonusmod -= 5;
 		// 168 defensive
-		dmgbonusmod += (defender->spellbonuses.MeleeMitigationEffect + itembonuses.MeleeMitigationEffect + aabonuses.MeleeMitigationEffect);
+		dmgbonusmod -= (defender->spellbonuses.MeleeMitigationEffect +
+		                defender->itembonuses.MeleeMitigationEffect +
+		                defender->aabonuses.MeleeMitigationEffect);
 	}
 
 	damage += damage * dmgbonusmod / 100;


### PR DESCRIPTION
This function would cause defender's spell-based MeleeMitigationEffect to increase damage dealt and the attacker's item and aa-based MeleeMitigationEffect to increase damage dealt. New code should cause all three forms of defender MeleeMitigationEffect to reduce damage dealt.