### PR TITLE
Feature/save bulk transactions

### DIFF
--- a/common/dbcore.h
+++ b/common/dbcore.h
@@ -22,11 +22,13 @@ public:
 	eStatus	GetStatus() { return pStatus; }
 	MySQLRequestResult	QueryDatabase(const char* query, uint32 querylen, bool retryOnFailureOnce = true);
 	MySQLRequestResult	QueryDatabase(std::string query, bool retryOnFailureOnce = true);
+	bool QueryDatabaseMulti(const char * query, uint32 querylen, bool retryOnFailureOnce);
 	void TransactionBegin();
 	void TransactionCommit();
 	void TransactionRollback();
 	uint32	DoEscapeString(char* tobuf, const char* frombuf, uint32 fromlen);
 	void	ping();
+	bool QueryDatabaseMulti(std::string query, bool retryOnFailureOnce);
 	MYSQL*	getMySQL(){ return &mysql; }
 
 protected:

--- a/common/ptimer.cpp
+++ b/common/ptimer.cpp
@@ -150,11 +150,11 @@ bool PersistentTimer::Load(Database *db) {
     return true;
 }
 
-std::string PersistentTimer::StoreQuery(Database *db) {
+void PersistentTimer::StoreQuery(Database *db, std::string& query) {
 	if (Expired(db, false))	//dont need to store expired timers.
-		return "";
+		return;
 
-	std::string query = StringFormat("REPLACE INTO timers "
+	query += StringFormat("REPLACE INTO timers "
 		" (char_id, type, start, duration, enable) "
 		" VALUES (%lu, %u, %lu, %lu, %d);",
 		(unsigned long)_char_id, _type, (unsigned long)start_time,
@@ -164,14 +164,14 @@ std::string PersistentTimer::StoreQuery(Database *db) {
 #ifdef DEBUG_PTIMERS
 	printf("Storing timer: char %lu of type %u: '%s'\n", (unsigned long)_char_id, _type, query.c_str());
 #endif
-	return query;
-
+	
 }
 bool PersistentTimer::Store(Database *db) {
 	if(Expired(db, false))	//dont need to store expired timers.
 		return true;
 
-	std::string query = StoreQuery(db);
+	std::string query = "";
+	StoreQuery(db,query);
 
 #ifdef DEBUG_PTIMERS
 	printf("Storing timer: char %lu of type %u: '%s'\n", (unsigned long)_char_id, _type, query.c_str());
@@ -331,11 +331,11 @@ bool PTimerList::Load(Database *db) {
 	return true;
 }
 
-std::string PTimerList::StoreListQuery(Database *db) {
+void PTimerList::StoreListQuery(Database *db, std::string& query) {
 #ifdef DEBUG_PTIMERS
 	printf("Storing all timers for char %lu\n", (unsigned long)_char_id);
 #endif
-	std::string query = "";
+	
 	std::map<pTimerType, PersistentTimer *>::iterator s;
 	s = _list.begin();
 	bool res = true;
@@ -345,11 +345,11 @@ std::string PTimerList::StoreListQuery(Database *db) {
 			printf("Storing timer %u for char %lu\n", s->first, (unsigned long)_char_id);
 #endif
 	
-			query += s->second->StoreQuery(db);
+			s->second->StoreQuery(db,query);
 		}
 		++s;
 	}
-	return query;
+	
 }
 
 bool PTimerList::Store(Database *db) {

--- a/common/ptimer.cpp
+++ b/common/ptimer.cpp
@@ -150,15 +150,28 @@ bool PersistentTimer::Load(Database *db) {
     return true;
 }
 
+std::string PersistentTimer::StoreQuery(Database *db) {
+	if (Expired(db, false))	//dont need to store expired timers.
+		return "";
+
+	std::string query = StringFormat("REPLACE INTO timers "
+		" (char_id, type, start, duration, enable) "
+		" VALUES (%lu, %u, %lu, %lu, %d);",
+		(unsigned long)_char_id, _type, (unsigned long)start_time,
+		(unsigned long)timer_time, enabled ? 1 : 0);
+
+
+#ifdef DEBUG_PTIMERS
+	printf("Storing timer: char %lu of type %u: '%s'\n", (unsigned long)_char_id, _type, query.c_str());
+#endif
+	return query;
+
+}
 bool PersistentTimer::Store(Database *db) {
 	if(Expired(db, false))	//dont need to store expired timers.
 		return true;
 
-	std::string query = StringFormat("REPLACE INTO timers "
-                                    " (char_id, type, start, duration, enable) "
-                                    " VALUES (%lu, %u, %lu, %lu, %d)",
-                                    (unsigned long)_char_id, _type, (unsigned long)start_time,
-                                    (unsigned long)timer_time, enabled ? 1: 0);
+	std::string query = StoreQuery(db);
 
 #ifdef DEBUG_PTIMERS
 	printf("Storing timer: char %lu of type %u: '%s'\n", (unsigned long)_char_id, _type, query.c_str());
@@ -316,6 +329,27 @@ bool PTimerList::Load(Database *db) {
 	}
 
 	return true;
+}
+
+std::string PTimerList::StoreListQuery(Database *db) {
+#ifdef DEBUG_PTIMERS
+	printf("Storing all timers for char %lu\n", (unsigned long)_char_id);
+#endif
+	std::string query = "";
+	std::map<pTimerType, PersistentTimer *>::iterator s;
+	s = _list.begin();
+	bool res = true;
+	while (s != _list.end()) {
+		if (s->second != nullptr) {
+#ifdef DEBUG_PTIMERS
+			printf("Storing timer %u for char %lu\n", s->first, (unsigned long)_char_id);
+#endif
+	
+			query += s->second->StoreQuery(db);
+		}
+		++s;
+	}
+	return query;
 }
 
 bool PTimerList::Store(Database *db) {

--- a/common/ptimer.h
+++ b/common/ptimer.h
@@ -88,6 +88,7 @@ public:
 	inline bool Enabled() { return enabled; }
 
 	bool Load(Database *db);
+	std::string StoreQuery(Database * db);
 	bool Store(Database *db);
 	bool Clear(Database *db);
 
@@ -110,6 +111,7 @@ public:
 	~PTimerList();
 
 	bool Load(Database *db);
+	std::string StoreListQuery(Database * db);
 	bool Store(Database *db);
 	bool Clear(Database *db);
 

--- a/common/ptimer.h
+++ b/common/ptimer.h
@@ -88,7 +88,7 @@ public:
 	inline bool Enabled() { return enabled; }
 
 	bool Load(Database *db);
-	std::string StoreQuery(Database * db);
+	void StoreQuery(Database * db, std::string& query);
 	bool Store(Database *db);
 	bool Clear(Database *db);
 
@@ -111,7 +111,7 @@ public:
 	~PTimerList();
 
 	bool Load(Database *db);
-	std::string StoreListQuery(Database * db);
+	void StoreListQuery(Database * db, std::string& query);
 	bool Store(Database *db);
 	bool Clear(Database *db);
 

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -607,109 +607,6 @@ void Client::RemoveExpendedAA(int aa_id)
 	database.QueryDatabase(StringFormat("DELETE from `character_alternate_abilities` WHERE `id` = %d and `aa_id` = %d", character_id, aa_id));
 }
 
-//bool Client::Save(uint8 iCommitNow) {
-//	if (!ClientDataLoaded())
-//		return false;
-//	clock_t t = std::clock(); /* Function timer start */
-//	/* Wrote current basics to PP for saves */
-//	m_pp.x = m_Position.x;
-//	m_pp.y = m_Position.y;
-//	m_pp.z = m_Position.z;
-//	m_pp.guildrank = guildrank;
-//	m_pp.heading = m_Position.w;
-//
-//	/* Mana and HP */
-//	if (GetHP() <= 0) {
-//		m_pp.cur_hp = GetMaxHP();
-//	}
-//	else {
-//		m_pp.cur_hp = GetHP();
-//	}
-//
-//	m_pp.mana = current_mana;
-//	m_pp.endurance = current_endurance;
-//
-//	/* Save Character Currency */
-//	database.SaveCharacterCurrency(CharacterID(), &m_pp);
-//
-//	/* Save Current Bind Points */
-//	for (int i = 0; i < 5; i++)
-//		if (m_pp.binds[i].zoneId)
-//			database.SaveCharacterBindPoint(CharacterID(), m_pp.binds[i], i);
-//
-//	/* Save Character Buffs */
-//	database.SaveBuffs(this);
-//
-//	/* Total Time Played */
-//	TotalSecondsPlayed += (time(nullptr) - m_pp.lastlogin);
-//	m_pp.timePlayedMin = (TotalSecondsPlayed / 60);
-//	m_pp.RestTimer = GetRestTimer();
-//
-//	/* Save Mercs */
-//	if (GetMercInfo().MercTimerRemaining > RuleI(Mercs, UpkeepIntervalMS)) {
-//		GetMercInfo().MercTimerRemaining = RuleI(Mercs, UpkeepIntervalMS);
-//	}
-//
-//	if (GetMercTimer()->Enabled()) {
-//		GetMercInfo().MercTimerRemaining = GetMercTimer()->GetRemainingTime();
-//	}
-//
-//	if (dead || (!GetMerc() && !GetMercInfo().IsSuspended)) {
-//		memset(&m_mercinfo, 0, sizeof(struct MercInfo));
-//	}
-//
-//	m_pp.lastlogin = time(nullptr);
-//
-//	if (GetPet() && GetPet()->CastToNPC()->GetPetSpellID() && !dead) {
-//		NPC *pet = GetPet()->CastToNPC();
-//		m_petinfo.SpellID = pet->CastToNPC()->GetPetSpellID();
-//		m_petinfo.HP = pet->GetHP();
-//		m_petinfo.Mana = pet->GetMana();
-//		pet->GetPetState(m_petinfo.Buffs, m_petinfo.Items, m_petinfo.Name);
-//		m_petinfo.petpower = pet->GetPetPower();
-//		m_petinfo.size = pet->GetSize();
-//	}
-//	else {
-//		memset(&m_petinfo, 0, sizeof(struct PetInfo));
-//	}
-//	database.SavePetInfo(this);
-//
-//	if (tribute_timer.Enabled()) {
-//		m_pp.tribute_time_remaining = tribute_timer.GetRemainingTime();
-//	}
-//	else {
-//		m_pp.tribute_time_remaining = 0xFFFFFFFF; m_pp.tribute_active = 0;
-//	}
-//
-//	if (m_pp.hunger_level < 0)
-//		m_pp.hunger_level = 0;
-//
-//	if (m_pp.thirst_level < 0)
-//		m_pp.thirst_level = 0;
-//
-//	p_timers.Store(&database);
-//
-//	database.SaveCharacterTribute(this->CharacterID(), &m_pp);
-//	SaveTaskState(); /* Save Character Task */
-//
-//	Log(Logs::General, Logs::Food, "Client::Save - hunger_level: %i thirst_level: %i", m_pp.hunger_level, m_pp.thirst_level);
-//
-//	// perform snapshot before SaveCharacterData() so that m_epp will contain the updated time
-//	if (RuleB(Character, ActiveInvSnapshots) && time(nullptr) >= GetNextInvSnapshotTime()) {
-//		if (database.SaveCharacterInvSnapshot(CharacterID())) {
-//			SetNextInvSnapshot(RuleI(Character, InvSnapshotMinIntervalM));
-//		}
-//		else {
-//			SetNextInvSnapshot(RuleI(Character, InvSnapshotMinRetryM));
-//		}
-//	}
-//
-//	database.SaveCharacterData(this->CharacterID(), this->AccountID(), &m_pp, &m_epp); /* Save Character Data */
-//	float totalTime = ((float)(std::clock() - t));
-//	Log(Logs::General, Logs::Zone_Server, "ZoneDatabase::SaveCharacterData_OldWay %i, done... Took %f seconds", character_id, ((float)(std::clock() - t)) / CLOCKS_PER_SEC);
-//	return true;
-//}
-
 bool Client::Save(uint8 iCommitNow) {
 	if(!ClientDataLoaded())
 		return false;
@@ -738,18 +635,18 @@ bool Client::Save(uint8 iCommitNow) {
 	m_pp.endurance = current_endurance;
 
 	/* Save Character Currency */
-	combinedQueries+=database.SaveCharacterCurrencyQuery(CharacterID(), &m_pp);
+	database.SaveCharacterCurrencyQuery(CharacterID(), &m_pp, combinedQueries);
 
 	/* Save Current Bind Points */
 	for (int i = 0; i < 5; i++)
 	{
 		if (m_pp.binds[i].zoneId)
 		{
-			combinedQueries += database.SaveCharacterBindPointQuery(CharacterID(), m_pp.binds[i], i);
+			 database.SaveCharacterBindPointQuery(CharacterID(), m_pp.binds[i], i, combinedQueries);
 		}
 	}
 	/* Save Character Buffs */
-	combinedQueries+=database.SaveBuffsQuery(this);
+	database.SaveBuffsQuery(this,combinedQueries);
 	
 	/* Total Time Played */
 	TotalSecondsPlayed += (time(nullptr) - m_pp.lastlogin);
@@ -782,7 +679,7 @@ bool Client::Save(uint8 iCommitNow) {
 	} else {
 		memset(&m_petinfo, 0, sizeof(struct PetInfo));
 	}
-	combinedQueries+=database.SavePetInfoQuery(this);
+	database.SavePetInfoQuery(this, combinedQueries);
 
 	if(tribute_timer.Enabled()) {
 		m_pp.tribute_time_remaining = tribute_timer.GetRemainingTime();
@@ -797,14 +694,14 @@ bool Client::Save(uint8 iCommitNow) {
 	if (m_pp.thirst_level < 0)
 		m_pp.thirst_level = 0;
 
-	combinedQueries+=p_timers.StoreListQuery(&database);
+	p_timers.StoreListQuery(&database, combinedQueries);
 
-	combinedQueries+=database.SaveCharacterTributeQuery(this->CharacterID(), &m_pp);
+	database.SaveCharacterTributeQuery(this->CharacterID(), &m_pp, combinedQueries);
 	
 	if (taskmanager)
 	{ 
 		/* Save Character Task */
-		combinedQueries+=taskmanager->SaveClientStateQuery(this, taskstate);
+		taskmanager->SaveClientStateQuery(this, taskstate, combinedQueries);
 	}
 	
 	Log(Logs::General, Logs::Food, "Client::Save - hunger_level: %i thirst_level: %i", m_pp.hunger_level, m_pp.thirst_level);
@@ -820,13 +717,19 @@ bool Client::Save(uint8 iCommitNow) {
 		}
 	}
 
-	combinedQueries+=database.SaveCharacterDataQuery(this->CharacterID(), this->AccountID(), &m_pp, &m_epp); /* Save Character Data */
+	database.SaveCharacterDataQuery(this->CharacterID(), this->AccountID(), &m_pp, &m_epp, combinedQueries); /* Save Character Data */
 	combinedQueries+="COMMIT;";
 
 	bool savedCharacter = database.QueryDatabaseMulti(combinedQueries, false);
 	float totalTime = ((float)(std::clock() - t));
-	Log(Logs::General, Logs::Zone_Server, "ZoneDatabase::SaveCharacterData_NewWay %i, done... Took %f seconds", character_id, ((float)(std::clock() - t)) / CLOCKS_PER_SEC);
-
+	if (savedCharacter)
+	{
+		Log(Logs::General, Logs::Zone_Server, "ZoneDatabase::SaveCharacterData_NewWay %i, done... Took %f seconds", character_id, ((float)(std::clock() - t)) / CLOCKS_PER_SEC);
+	}
+	else
+	{
+		Log(Logs::General, Logs::Error, "ZoneDatabase::Failed to save character %i, done... Took %f seconds", character_id, ((float)(std::clock() - t)) / CLOCKS_PER_SEC);
+	}
 	return savedCharacter;
 }
 

--- a/zone/mob_movement_manager.cpp
+++ b/zone/mob_movement_manager.cpp
@@ -810,10 +810,54 @@ void MobMovementManager::UpdatePathGround(Mob * who, float x, float y, float z, 
 	}
 
 	AdjustRoute(route, who);
+	   
+	
+	
+	//avoid doing any processing if the mob is stuck to allow normal stuck code to work.
+	if (!stuck)
+	{
 
+		//there are times when the routes returned are no differen than where the mob is currently standing. What basically happens
+		//is a mob will get 'stuck' in such a way that it should be moving but the 'moving' place is the exact same spot it is at. 
+		//this is a problem and creates an area of ground that if a mob gets to, will stay there forever. If socal this creates a 
+		//"Ball of Death" (tm). This code tries to prevent this by simply warping the mob to the requested x/y. Better to have a warp than 
+		//have stuck mobs.
+
+		auto routeNode = route.begin();
+		bool noValidPath = true;
+		while (routeNode != route.end() && noValidPath == true) {
+			auto &currentNode = (*routeNode);
+
+			if (routeNode == route.end())
+			{
+				continue;
+			}
+
+			if (!(currentNode.pos.x == who->GetX() && currentNode.pos.y == who->GetY()))
+			{
+				//if one of the nodes to move to, is not our current node, pass it.
+				noValidPath = false;
+				break;
+			}
+			//move to the next node
+			routeNode++;
+
+		}
+
+		if (noValidPath)
+		{
+			//we are 'stuck' in a path, lets just get out of this by 'teleporting' to the next position.
+			PushTeleportTo(ent.second, x, y, z,
+				CalculateHeadingAngleBetweenPositions(who->GetX(), who->GetY(), x, y));
+			return;
+		}
+
+	}
+	
 	auto iter = route.begin();
 	glm::vec3 previous_pos(who->GetX(), who->GetY(), who->GetZ());
 	bool first_node = true;
+
 
 	while (iter != route.end()) {
 		auto &current_node = (*iter);

--- a/zone/tasks.cpp
+++ b/zone/tasks.cpp
@@ -280,14 +280,14 @@ bool TaskManager::LoadTasks(int singleTask)
 
 	return true;
 }
-std::string TaskManager::SaveClientStateQuery(Client *c, ClientTaskState *state)
+void TaskManager::SaveClientStateQuery(Client *c, ClientTaskState *state, std::string& query)
 {
 	// I am saving the slot in the ActiveTasks table, because unless a Task is cancelled/completed, the client
 	// doesn't seem to like tasks moving slots between zoning and you can end up with 'bogus' activities if the task
 	// previously in that slot had more activities than the one now occupying it. Hopefully retaining the slot
 	// number for the duration of a session will overcome this.
 	if (!c || !state)
-		return false;
+		return;
 
 	const char *ERR_MYSQLERROR = "[TASKS]Error in TaskManager::SaveClientState %s";
 
@@ -295,7 +295,7 @@ std::string TaskManager::SaveClientStateQuery(Client *c, ClientTaskState *state)
 
 	Log(Logs::Detail, Logs::Tasks, "TaskManager::SaveClientState for character ID %d", characterID);
 
-	std::string query = "";
+	
 	if (state->ActiveTaskCount > 0 || state->ActiveTask.TaskID != TASKSLOTEMPTY) { // TODO: tasks
 		for (int task = 0; task < MAXACTIVEQUESTS + 1; task++) {
 			int taskID = state->ActiveTasks[task].TaskID;
@@ -371,7 +371,7 @@ std::string TaskManager::SaveClientStateQuery(Client *c, ClientTaskState *state)
 	if (!RuleB(TaskSystem, RecordCompletedTasks) ||
 		(state->CompletedTasks.size() <= (unsigned int)state->LastCompletedTaskLoaded)) {
 		state->LastCompletedTaskLoaded = state->CompletedTasks.size();
-		return query;
+		return;
 	}
 
 	const char *completedTaskQuery = "REPLACE INTO completed_tasks (charid, completedtime, taskid, activityid) "
@@ -408,7 +408,6 @@ std::string TaskManager::SaveClientStateQuery(Client *c, ClientTaskState *state)
 		}
 	}
 
-	return query;
 }
 //if you make modifications to SaveClientSate, be sure to update SaveClientStateQuery as well.Overall this method is a tangle of logic
 //so was hard to seperate the queries from the actual code base. 

--- a/zone/tasks.h
+++ b/zone/tasks.h
@@ -289,6 +289,7 @@ public:
 	int GetActivityCount(int TaskID);
 	bool LoadSingleTask(int TaskID);
 	bool LoadTasks(int SingleTask=0);
+	std::string SaveClientStateQuery(Client * c, ClientTaskState * state);
 	void ReloadGoalLists();
 	inline void LoadProximities(int ZoneID) { ProximityManager.LoadProximities(ZoneID); }
 	bool LoadTaskSets();

--- a/zone/tasks.h
+++ b/zone/tasks.h
@@ -289,7 +289,7 @@ public:
 	int GetActivityCount(int TaskID);
 	bool LoadSingleTask(int TaskID);
 	bool LoadTasks(int SingleTask=0);
-	std::string SaveClientStateQuery(Client * c, ClientTaskState * state);
+	void SaveClientStateQuery(Client * c, ClientTaskState * state, std::string& query);
 	void ReloadGoalLists();
 	inline void LoadProximities(int ZoneID) { ProximityManager.LoadProximities(ZoneID); }
 	bool LoadTaskSets();

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -1498,11 +1498,10 @@ bool ZoneDatabase::SaveCharacterLanguage(uint32 character_id, uint32 lang_id, ui
 	return true;
 }
 
-std::string ZoneDatabase::SaveCharacterBindPointQuery(uint32 character_id, const BindStruct &bind, uint32 bind_num)
+void ZoneDatabase::SaveCharacterBindPointQuery(uint32 character_id, const BindStruct &bind, uint32 bind_num, std::string& query)
 {
 	/* Save Home Bind Point */
-	std::string query =
-		StringFormat("REPLACE INTO `character_bind` (id, zone_id, instance_id, x, y, z, heading, slot) VALUES (%u, "
+	query +=StringFormat("REPLACE INTO `character_bind` (id, zone_id, instance_id, x, y, z, heading, slot) VALUES (%u, "
 			"%u, %u, %f, %f, %f, %f, %i);",
 			character_id, bind.zoneId, bind.instance_id, bind.x, bind.y, bind.z, bind.heading, bind_num);
 
@@ -1512,12 +1511,13 @@ std::string ZoneDatabase::SaveCharacterBindPointQuery(uint32 character_id, const
 
 	
 
-	return query;
 }
 bool ZoneDatabase::SaveCharacterBindPoint(uint32 character_id, const BindStruct &bind, uint32 bind_num)
 {
 	/* Save Home Bind Point */
-	std::string query = SaveCharacterBindPointQuery(character_id, bind, bind_num);
+	std::string query = "";
+
+	SaveCharacterBindPointQuery(character_id, bind, bind_num, query);
 
 	auto results = QueryDatabase(query);
 	if (!results.RowsAffected())
@@ -1550,8 +1550,8 @@ bool ZoneDatabase::SaveCharacterDisc(uint32 character_id, uint32 slot_id, uint32
 	return true;
 }
 
-std::string ZoneDatabase::SaveCharacterTributeQuery(uint32 character_id, PlayerProfile_Struct* pp) {
-	std::string query = StringFormat("DELETE FROM `character_tribute` WHERE `id` = %u;", character_id);
+void ZoneDatabase::SaveCharacterTributeQuery(uint32 character_id, PlayerProfile_Struct* pp, std::string& query) {
+	 query += StringFormat("DELETE FROM `character_tribute` WHERE `id` = %u;", character_id);
 
 	/* Save Tributes only if we have values... */
 	for (int i = 0; i < EQEmu::invtype::TRIBUTE_SIZE; i++) {
@@ -1561,7 +1561,6 @@ std::string ZoneDatabase::SaveCharacterTributeQuery(uint32 character_id, PlayerP
 			Log(Logs::General, Logs::None, "ZoneDatabase::SaveCharacterTribute for character ID: %i, tier:%u tribute:%u done", character_id, pp->tributes[i].tier, pp->tributes[i].tribute);
 		}
 	}
-	return query;
 }
 
 bool ZoneDatabase::SaveCharacterTribute(uint32 character_id, PlayerProfile_Struct* pp){
@@ -1610,19 +1609,19 @@ bool ZoneDatabase::SaveCharacterLeadershipAA(uint32 character_id, PlayerProfile_
 	return true;
 }
 
-std::string ZoneDatabase::SaveCharacterDataQuery(uint32 character_id, uint32 account_id, PlayerProfile_Struct* pp, ExtendedProfile_Struct* m_epp) 
+void ZoneDatabase::SaveCharacterDataQuery(uint32 character_id, uint32 account_id, PlayerProfile_Struct* pp, ExtendedProfile_Struct* m_epp, std::string& query) 
 {
 
 	/* If this is ever zero - the client hasn't fully loaded and potentially crashed during zone */
 	if (account_id <= 0)
 	{
-		return "";
+		return;
 	}
 
 	std::string mail_key = database.GetMailKey(character_id);
 
 	
-	std::string query = StringFormat(
+	 query += StringFormat(
 		"REPLACE INTO `character_data` ("
 		" id,                        "
 		" account_id,                "
@@ -1913,7 +1912,7 @@ std::string ZoneDatabase::SaveCharacterDataQuery(uint32 character_id, uint32 acc
 		m_epp->last_invsnapshot_time,
 		mail_key.c_str()
 			);
-	return query;
+	
 }
 
 bool ZoneDatabase::SaveCharacterData(uint32 character_id, uint32 account_id, PlayerProfile_Struct* pp, ExtendedProfile_Struct* m_epp){
@@ -1922,12 +1921,13 @@ bool ZoneDatabase::SaveCharacterData(uint32 character_id, uint32 account_id, Pla
 	if (account_id <= 0)
 		return false;
 	clock_t t = std::clock(); /* Function timer start */
-	std::string query = SaveCharacterDataQuery(character_id, account_id, pp, m_epp);
+	std::string query = "";
+	SaveCharacterDataQuery(character_id, account_id, pp, m_epp, query);
 	auto results = database.QueryDatabase(query);
 	Log(Logs::General, Logs::None, "ZoneDatabase::SaveCharacterData %i, done... Took %f seconds", character_id, ((float)(std::clock() - t)) / CLOCKS_PER_SEC);
 	return true;
 }
-std::string ZoneDatabase::SaveCharacterCurrencyQuery(uint32 character_id, PlayerProfile_Struct* pp) {
+void ZoneDatabase::SaveCharacterCurrencyQuery(uint32 character_id, PlayerProfile_Struct* pp, std::string& query) {
 	if (pp->copper < 0) { pp->copper = 0; }
 	if (pp->silver < 0) { pp->silver = 0; }
 	if (pp->gold < 0) { pp->gold = 0; }
@@ -1940,7 +1940,7 @@ std::string ZoneDatabase::SaveCharacterCurrencyQuery(uint32 character_id, Player
 	if (pp->gold_cursor < 0) { pp->gold_cursor = 0; }
 	if (pp->silver_cursor < 0) { pp->silver_cursor = 0; }
 	if (pp->copper_cursor < 0) { pp->copper_cursor = 0; }
-	std::string query = StringFormat(
+	query += StringFormat(
 		"REPLACE INTO `character_currency` (id, platinum, gold, silver, copper,"
 		"platinum_bank, gold_bank, silver_bank, copper_bank,"
 		"platinum_cursor, gold_cursor, silver_cursor, copper_cursor, "
@@ -1963,11 +1963,12 @@ std::string ZoneDatabase::SaveCharacterCurrencyQuery(uint32 character_id, Player
 		pp->careerRadCrystals,
 		pp->currentEbonCrystals,
 		pp->careerEbonCrystals);
-	return query;
+	
 }
 bool ZoneDatabase::SaveCharacterCurrency(uint32 character_id, PlayerProfile_Struct* pp){
 	
-	std::string query= SaveCharacterCurrencyQuery(character_id, pp);
+	std::string query = "";
+	SaveCharacterCurrencyQuery(character_id, pp,query);
 	auto results = database.QueryDatabase(query);
 	Log(Logs::General, Logs::None, "Saving Currency for character ID: %i, done", character_id);
 	return true;
@@ -3602,17 +3603,10 @@ void ZoneDatabase::UpdateAltCurrencyValue(uint32 char_id, uint32 currency_id, ui
 }
 
 
+void ZoneDatabase::SaveBuffsQuery(Client *client, std::string& query) {
 
-std::string ZoneDatabase::SaveBuffsDeleteQuery(Client *client) {
+	query += StringFormat("DELETE FROM `character_buffs` WHERE `character_id` = '%u';", client->CharacterID());
 
-	std::string query = StringFormat("DELETE FROM `character_buffs` WHERE `character_id` = '%u';", client->CharacterID());
-	
-	return query;
-	
-}
-std::string ZoneDatabase::SaveBuffsInsertQuery(Client *client) {
-
-	std::string query ="";
 
 	uint32 buff_count = client->GetMaxBuffSlots();
 	Buffs_Struct *buffs = client->GetBuffs();
@@ -3632,16 +3626,9 @@ std::string ZoneDatabase::SaveBuffsInsertQuery(Client *client) {
 			buffs[index].magic_rune, buffs[index].persistant_buff, buffs[index].dot_rune,
 			buffs[index].caston_x, buffs[index].caston_y, buffs[index].caston_z,
 			buffs[index].ExtraDIChance, buffs[index].instrument_mod);
-		
+
 	}
-	return query;
-}
-std::string ZoneDatabase::SaveBuffsQuery(Client *client) {
-
-	std::string query = SaveBuffsDeleteQuery(client);
-	query += SaveBuffsInsertQuery(client);
-	return query;
-
+	
 }
 void ZoneDatabase::SaveBuffs(Client *client) {
 
@@ -3797,11 +3784,11 @@ void ZoneDatabase::LoadAuras(Client *c)
 		c->MakeAura(atoi(row[0]));
 }
 
-std::string ZoneDatabase::SavePetInfoQuery(Client *client)
+void ZoneDatabase::SavePetInfoQuery(Client *client, std::string& query)
 {
 	PetInfo *petinfo = nullptr;
 
-	std::string query = StringFormat("DELETE FROM `character_pet_buffs` WHERE `char_id` = %u;", client->CharacterID());
+	query += StringFormat("DELETE FROM `character_pet_buffs` WHERE `char_id` = %u;", client->CharacterID());
 	
 	query += StringFormat("DELETE FROM `character_pet_inventory` WHERE `char_id` = %u;", client->CharacterID());
 	
@@ -3864,7 +3851,7 @@ std::string ZoneDatabase::SavePetInfoQuery(Client *client)
 			query += ";";
 
 		}
-		return query;
+		
 	}
 }
 

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -284,6 +284,7 @@ public:
 	void LoadBuffs(Client *c);
 	void SaveAuras(Client *c);
 	void LoadAuras(Client *c);
+	std::string SavePetInfoQuery(Client * client);
 	void LoadPetInfo(Client *c);
 	void SavePetInfo(Client *c);
 	void RemoveTempFactions(Client *c);
@@ -314,12 +315,16 @@ public:
 
 	bool SaveCharacterAA(uint32 character_id, uint32 aa_id, uint32 current_level, uint32 charges);
 	bool SaveCharacterBandolier(uint32 character_id, uint8 bandolier_id, uint8 bandolier_slot, uint32 item_id, uint32 icon, const char* bandolier_name);
+	std::string SaveCharacterBindPointQuery(uint32 character_id, const BindStruct & bind, uint32 bind_num);
 	bool SaveCharacterBindPoint(uint32 character_id, const BindStruct &bind, uint32 bind_num);
 	bool SaveCharacterCurrency(uint32 character_id, PlayerProfile_Struct* pp);
 	bool SaveCharacterData(uint32 character_id, uint32 account_id, PlayerProfile_Struct* pp, ExtendedProfile_Struct* m_epp);
+	std::string SaveCharacterCurrencyQuery(uint32 character_id, PlayerProfile_Struct * pp);
 	bool SaveCharacterDisc(uint32 character_id, uint32 slot_id, uint32 disc_id);
+	std::string SaveCharacterTributeQuery(uint32 character_id, PlayerProfile_Struct * pp);
 	bool SaveCharacterLanguage(uint32 character_id, uint32 lang_id, uint32 value);
 	bool SaveCharacterLeadershipAA(uint32 character_id, PlayerProfile_Struct* pp);
+	std::string SaveCharacterDataQuery(uint32 character_id, uint32 account_id, PlayerProfile_Struct * pp, ExtendedProfile_Struct * m_epp);
 	bool SaveCharacterMaterialColor(uint32 character_id, uint32 slot_id, uint32 color);
 	bool SaveCharacterMemorizedSpell(uint32 character_id, uint32 spell_id, uint32 slot_id);
 	bool SaveCharacterPotionBelt(uint32 character_id, uint8 potion_id, uint32 item_id, uint32 icon);
@@ -329,6 +334,7 @@ public:
 
 	/* Character Inventory  */
 	bool	NoRentExpired(const char* name);
+	std::string SaveCharacterInvSnapshotQuery(uint32 character_id);
 	bool	SaveCharacterInvSnapshot(uint32 character_id);
 	int		CountCharacterInvSnapshots(uint32 character_id);
 	void	ClearCharacterInvSnapshots(uint32 character_id, bool from_now = false);
@@ -517,6 +523,12 @@ public:
 	/* Alternate Currency   */
 	void LoadAltCurrencyValues(uint32 char_id, std::map<uint32, uint32> &currency);
 	void UpdateAltCurrencyValue(uint32 char_id, uint32 currency_id, uint32 value);
+
+	std::string SaveBuffsDeleteQuery(Client * client);
+
+	std::string SaveBuffsInsertQuery(Client * client);
+
+	std::string SaveBuffsQuery(Client * client);
 
 	/* Saylinks   */
 	uint32 LoadSaylinkID(const char* saylink_text, bool auto_insert = true);

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -284,7 +284,7 @@ public:
 	void LoadBuffs(Client *c);
 	void SaveAuras(Client *c);
 	void LoadAuras(Client *c);
-	std::string SavePetInfoQuery(Client * client);
+	void SavePetInfoQuery(Client * client, std::string& query);
 	void LoadPetInfo(Client *c);
 	void SavePetInfo(Client *c);
 	void RemoveTempFactions(Client *c);
@@ -315,16 +315,16 @@ public:
 
 	bool SaveCharacterAA(uint32 character_id, uint32 aa_id, uint32 current_level, uint32 charges);
 	bool SaveCharacterBandolier(uint32 character_id, uint8 bandolier_id, uint8 bandolier_slot, uint32 item_id, uint32 icon, const char* bandolier_name);
-	std::string SaveCharacterBindPointQuery(uint32 character_id, const BindStruct & bind, uint32 bind_num);
+	void SaveCharacterBindPointQuery(uint32 character_id, const BindStruct & bind, uint32 bind_num, std::string& query);
 	bool SaveCharacterBindPoint(uint32 character_id, const BindStruct &bind, uint32 bind_num);
 	bool SaveCharacterCurrency(uint32 character_id, PlayerProfile_Struct* pp);
 	bool SaveCharacterData(uint32 character_id, uint32 account_id, PlayerProfile_Struct* pp, ExtendedProfile_Struct* m_epp);
-	std::string SaveCharacterCurrencyQuery(uint32 character_id, PlayerProfile_Struct * pp);
+	void SaveCharacterCurrencyQuery(uint32 character_id, PlayerProfile_Struct * pp,std::string& query);
 	bool SaveCharacterDisc(uint32 character_id, uint32 slot_id, uint32 disc_id);
-	std::string SaveCharacterTributeQuery(uint32 character_id, PlayerProfile_Struct * pp);
+	void SaveCharacterTributeQuery(uint32 character_id, PlayerProfile_Struct * pp, std::string& query);
 	bool SaveCharacterLanguage(uint32 character_id, uint32 lang_id, uint32 value);
 	bool SaveCharacterLeadershipAA(uint32 character_id, PlayerProfile_Struct* pp);
-	std::string SaveCharacterDataQuery(uint32 character_id, uint32 account_id, PlayerProfile_Struct * pp, ExtendedProfile_Struct * m_epp);
+	void SaveCharacterDataQuery(uint32 character_id, uint32 account_id, PlayerProfile_Struct * pp, ExtendedProfile_Struct * m_epp, std::string& query);
 	bool SaveCharacterMaterialColor(uint32 character_id, uint32 slot_id, uint32 color);
 	bool SaveCharacterMemorizedSpell(uint32 character_id, uint32 spell_id, uint32 slot_id);
 	bool SaveCharacterPotionBelt(uint32 character_id, uint8 potion_id, uint32 item_id, uint32 icon);
@@ -524,11 +524,7 @@ public:
 	void LoadAltCurrencyValues(uint32 char_id, std::map<uint32, uint32> &currency);
 	void UpdateAltCurrencyValue(uint32 char_id, uint32 currency_id, uint32 value);
 
-	std::string SaveBuffsDeleteQuery(Client * client);
-
-	std::string SaveBuffsInsertQuery(Client * client);
-
-	std::string SaveBuffsQuery(Client * client);
+	void SaveBuffsQuery(Client * client, std::string& query);
 
 	/* Saylinks   */
 	uint32 LoadSaylinkID(const char* saylink_text, bool auto_insert = true);


### PR DESCRIPTION
Note, I am sorry about this also including the 'stuck' characters but I forgot to make a branch before the pull request and the PR is on master and didn't want to mess it up. Can strip that feature out if need be. 

For this feature however: I have enabled multi results in mysql connection and  changed the Save method in client.cpp to bulk up all operations into one query.

In very small benchmarks this is over 2x faster and I believe under load it will be much higher. Right now my testing is on a zero load and its already 2x faster.
Example:
ZoneDatabase::SaveCharacterData_OldWay 685273, done... Took 0.013000 seconds
ZoneDatabase::SaveCharacterData_NewWay 685273, done... Took 0.005000 seconds

Note, two indexes need to be added to the pet tables, as part of the update hits these columns and they are doing full table scans.

ALTER TABLE `character_pet_inventory`
	ADD INDEX `char_idIndex` (`char_id`);

ALTER TABLE `character_pet_info`
	ADD INDEX `char_idIndex` (`char_id`);

Note, this only a stop gap measure, and while it limits "fsyncs" during transactions, this may have to be rethought out. IMO a distruptor ring buffer, and a 1 sec heartbeat is a better way to handle this. Publish all bulk events to the ring buffer which are serialized and appened to queue per character. either the 1 sec event or the size of the buffer will 'flush' the data to mysql. If multiple saves happen (For whatever reason simply camping a character causes 3x saves!) during that period, last character save wins.  So instead of 3x hitting the database only 1x does.