### PR TITLE
Fix issue with perl script not updating itself correctly

### DIFF
--- a/utils/scripts/eqemu_server.pl
+++ b/utils/scripts/eqemu_server.pl
@@ -637,7 +637,7 @@ sub do_self_update_check_routine {
                     if ($OS eq "Linux") {
                         system("chmod 755 eqemu_server.pl");
                     }
-                    system("perl eqemu_server.pl start_from_world");
+                    exec("perl eqemu_server.pl ran_from_world");
                 }
             }
             print "[Install] Done\n";


### PR DESCRIPTION
I believe the argument passed was wrong.  Am I correct?

I think exec is better here that system.  Exec will start over again with the new downloaded script and the current execution will terminate.

I believe this fixes the problem with quests updating automatically.  I tested as best I could with an alternate git fetch path for the script, but that of course updates the script!  Will retest immediately on main line if this is merged.