### PR TITLE
Fix issue with roambox wait time after switch to new movement code.

### DIFF
--- a/common/emu_constants.h
+++ b/common/emu_constants.h
@@ -307,6 +307,14 @@ namespace EQEmu
 
 	} // namespace bug
 
+	namespace waypoints {
+		enum WaypointStatus : int {
+			wpsRoamBoxPauseInProgress = -3,
+			wpsQuestControlNoGrid = -2,
+			wpsQuestControlGrid = -1
+		};
+	} // waypoint_status behavior
+
 } /*EQEmu*/
 
 #endif /*COMMON_EMU_CONSTANTS_H*/

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -38,8 +38,6 @@
 #include <limits>
 #include <math.h>
 
-#define ROAMBOX_MOVE_IN_PROGESS	(666)
-
 extern EntityList entity_list;
 extern FastMath g_Math;
 
@@ -1574,13 +1572,14 @@ void NPC::AI_DoMovement() {
 	/**
 	 * Roambox logic sets precedence
 	 */
+	using EQEmu::waypoints::WaypointStatus;
 
 	if (roambox_distance > 0) {
 
 		// Check if we're already moving to a WP
 		// If so, if we're not moving we have arrived and need to set delay
 
-		if (GetCWP() == ROAMBOX_MOVE_IN_PROGESS && !IsMoving()) {
+		if (GetCWP() == WaypointStatus::wpsRoamBoxPauseInProgress && !IsMoving()) {
 			// We have arrived
 			time_until_can_move = Timer::GetCurrentTime() + RandomTimer(roambox_min_delay, roambox_delay);
 			SetCurrentWP(0);
@@ -1658,7 +1657,7 @@ void NPC::AI_DoMovement() {
 				roambox_destination_y);
 			Log(Logs::Detail, Logs::NPCRoamBox, "Dest Z is (%f)", roambox_destination_z);
 
-			SetCurrentWP(ROAMBOX_MOVE_IN_PROGESS);
+			SetCurrentWP(WaypointStatus::wpsRoamBoxPauseInProgress);
 			NavigateTo(roambox_destination_x, roambox_destination_y, roambox_destination_z);
 		}
 
@@ -1672,7 +1671,7 @@ void NPC::AI_DoMovement() {
 		
 		int32 gridno = CastToNPC()->GetGrid();
 		
-		if (gridno > 0 || cur_wp == -2) {
+		if (gridno > 0 || cur_wp == WaypointStatus::wpsQuestControlNoGrid) {
 			if (pause_timer_complete == true) { // time to pause at wp is over
 				AI_SetupNextWaypoint();
 			}    // endif (pause_timer_complete==true)
@@ -1704,7 +1703,7 @@ void NPC::AI_DoMovement() {
 					// as that is where roamer is unset and we don't want
 					// the next trip through to move again based on grid stuff.
 					doMove = false;
-					if (cur_wp == -2) {
+					if (cur_wp == WaypointStatus::wpsQuestControlNoGrid) {
 						AI_SetupNextWaypoint();
 					}
 		
@@ -1803,8 +1802,10 @@ void NPC::AI_SetupNextWaypoint() {
 		pause_timer_complete = false;
 		Log(Logs::Detail, Logs::Pathing, "We are departing waypoint %d.", cur_wp);
 		
+		using EQEmu::waypoints::WaypointStatus;
+
 		//if we were under quest control (with no grid), we are done now..
-		if (cur_wp == -2) {
+		if (cur_wp == WaypointStatus::wpsQuestControlNoGrid) {
 			Log(Logs::Detail, Logs::Pathing, "Non-grid quest mob has reached its quest ordered waypoint. Leaving pathing mode.");
 			roamer = false;
 			cur_wp = 0;

--- a/zone/waypoints.cpp
+++ b/zone/waypoints.cpp
@@ -108,7 +108,7 @@ void NPC::ResumeWandering()
 		{	// we were paused by a quest
 			AI_walking_timer->Disable();
 			SetGrid(0 - GetGrid());
-			if (cur_wp == -1)
+			if (cur_wp == EQEmu::waypoints::WaypointStatus::wpsQuestControlGrid)
 			{	// got here by a MoveTo()
 				cur_wp = save_wp;
 				UpdateWaypoint(cur_wp);	// have him head to last destination from here
@@ -166,6 +166,9 @@ void NPC::PauseWandering(int pausetime)
 
 void NPC::MoveTo(const glm::vec4& position, bool saveguardspot)
 {	// makes mob walk to specified location
+
+	using EQEmu::waypoints::WaypointStatus;
+
 	if (IsNPC() && GetGrid() != 0)
 	{	// he is on a grid
 		if (GetGrid() < 0)
@@ -177,7 +180,7 @@ void NPC::MoveTo(const glm::vec4& position, bool saveguardspot)
 		if (cur_wp >= 0)
 		{	// we've not already done a MoveTo()
 			save_wp = cur_wp;	// save the current waypoint
-			cur_wp = -1;		// flag this move as quest controlled
+			cur_wp = WaypointStatus::wpsQuestControlGrid;
 		}
 		Log(Logs::Detail, Logs::AI, "MoveTo %s, pausing regular grid wandering. Grid %d, save_wp %d", to_string(static_cast<glm::vec3>(position)).c_str(), -GetGrid(), save_wp);
 	}
@@ -185,7 +188,7 @@ void NPC::MoveTo(const glm::vec4& position, bool saveguardspot)
 	{	// not on a grid
 		roamer = true;
 		save_wp = 0;
-		cur_wp = -2;		// flag as quest controlled w/no grid
+		cur_wp = WaypointStatus::wpsQuestControlNoGrid;
 		Log(Logs::Detail, Logs::AI, "MoveTo %s without a grid.", to_string(static_cast<glm::vec3>(position)).c_str());
 	}
 


### PR DESCRIPTION
The delay on roamboxes was inadvertently broken when new movement code was added to improve
pathing.  This corrects the delay issue.

I also have code that is a hack to fix underground stuck issues with roamboxes, but have conferred
with @KimLS  that I will hold that back, and wait for a navmesh based next roampoint instead of the 
current random location.