### PR TITLE
Roambox patch for navmesh and large roamboxes in hilly zones

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1737,11 +1737,11 @@ void Mob::SendIllusionPacket(
 	new_luclinface = (in_luclinface == 0xFF) ? GetLuclinFace() : in_luclinface;
 	new_beard = (in_beard == 0xFF) ? GetBeard() : in_beard;
 	new_drakkin_heritage = 
-		(in_drakkin_heritage == 0xFF) ? GetDrakkinHeritage() : in_drakkin_heritage;
+		(in_drakkin_heritage == 0xFFFFFFFF) ? GetDrakkinHeritage() : in_drakkin_heritage;
 	new_drakkin_tattoo = 
-		(in_drakkin_tattoo == 0xFF) ? GetDrakkinTattoo() : in_drakkin_tattoo;
+		(in_drakkin_tattoo == 0xFFFFFFFF) ? GetDrakkinTattoo() : in_drakkin_tattoo;
 	new_drakkin_details = 
-		(in_drakkin_details == 0xFF) ? GetDrakkinDetails() : in_drakkin_details;
+		(in_drakkin_details == 0xFFFFFFFF) ? GetDrakkinDetails() : in_drakkin_details;
 	new_aa_title = in_aa_title;
 	size = (in_size <= 0.0f) ? GetSize() : in_size;
 
@@ -1759,12 +1759,9 @@ void Mob::SendIllusionPacket(
 		new_luclinface = luclinface		= CastToClient()->GetBaseFace();
 		new_beard = beard				= CastToClient()->GetBaseBeard();
 		new_aa_title = aa_title			= 0xFF;
-		new_drakkin_heritage 			= drakkin_heritage	
-										= CastToClient()->GetBaseHeritage();
-		new_drakkin_tattoo = 			drakkin_tattoo	
-										= CastToClient()->GetBaseTattoo();
-		new_drakkin_details 			= drakkin_details	
-										= CastToClient()->GetBaseDetails();
+		new_drakkin_heritage = drakkin_heritage	= CastToClient()->GetBaseHeritage();
+		new_drakkin_tattoo = drakkin_tattoo	= CastToClient()->GetBaseTattoo();
+		new_drakkin_details = drakkin_details	= CastToClient()->GetBaseDetails();
 		switch (race) {
 			case OGRE:
 				size = 9;

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -447,7 +447,7 @@ void Mob::AI_Init()
 	maxLastFightingDelayMoving = RuleI(NPC, LastFightingDelayMovingMax);
 
 	pDontHealMeBefore = 0;
-	pDontBuffMeBefore = 0;
+	pDontBuffMeBefore = Timer::GetCurrentTime() + 400;
 	pDontDotMeBefore = 0;
 	pDontRootMeBefore = 0;
 	pDontSnareMeBefore = 0;
@@ -1636,11 +1636,12 @@ void NPC::AI_DoMovement() {
 				}
 			}
 
-			glm::vec3 destination;
-			destination.x = roambox_destination_x;
-			destination.y = roambox_destination_y;
-			destination.z = m_Position.z;
-			roambox_destination_z = zone->zonemap ? zone->zonemap->FindClosestZ(destination, nullptr) + this->GetZOffset() : 0;
+			roambox_destination_z = 0;
+			/*
+			if (zone->zonemap) {
+				roambox_destination_z = FindGroundZ(roambox_destination_x, roambox_destination_y, this->GetZOffset());
+			}
+				*/
 
 			Log(Logs::Detail,
 				Logs::NPCRoamBox,
@@ -1799,7 +1800,6 @@ void NPC::AI_SetupNextWaypoint() {
 	else {
 		pause_timer_complete = false;
 		Log(Logs::Detail, Logs::Pathing, "We are departing waypoint %d.", cur_wp);
-
 		//if we were under quest control (with no grid), we are done now..
 		if (cur_wp == EQEmu::WaypointStatus::QuestControlNoGrid) {
 			Log(Logs::Detail, Logs::Pathing, "Non-grid quest mob has reached its quest ordered waypoint. Leaving pathing mode.");

--- a/zone/pathfinder_nav_mesh.cpp
+++ b/zone/pathfinder_nav_mesh.cpp
@@ -163,7 +163,7 @@ IPathfinder::IPath PathfinderNavmesh::FindPath(const glm::vec3 &start, const glm
 	static const int max_polys = 256;
 	dtPolyRef start_ref;
 	dtPolyRef end_ref;
-	glm::vec3 ext(5.0f, 100.0f, 5.0f);
+	glm::vec3 ext(10.0f, 200.0f, 10.0f);
 
 	m_impl->query->findNearestPoly(&current_location[0], &ext[0], &filter, &start_ref, 0);
 	m_impl->query->findNearestPoly(&dest_location[0], &ext[0], &filter, &end_ref, 0);


### PR DESCRIPTION
These changes result in 0 mobs underground in hilly zones with very large roamboxes,  Without them,
sooner or later the points chosen for next location end up with no route and the default code does a moveto which ends up underground.

KLS and I have discussed,  He has a plan for roamboxes picking destinations in a more correct manner.  This is a patch to get servers with this issue running in the meantime.

The pDontBuffMeBefore fix is a bonus :P  Mobs that could buff self with invis were doing it so early that the buff wasnt sent to the zone in time and they showed visible even though the invis buff was up.