### PR TITLE
Expose RandomizeFeatures which supercedes plugin::RandomFeatures in functionality

### DIFF
--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -267,6 +267,11 @@ void Lua_Mob::ChangeSize(double in_size, bool no_restriction) {
 	self->ChangeSize(static_cast<float>(in_size), no_restriction);
 }
 
+void Lua_Mob::RandomizeFeatures(bool send_illusion, bool save_variables) {
+       Lua_Safe_Call_Void();
+       self->RandomizeFeatures(send_illusion, save_variables);
+}
+
 void Lua_Mob::GMMove(double x, double y, double z) {
 	Lua_Safe_Call_Void();
 	self->GMMove(static_cast<float>(x), static_cast<float>(y), static_cast<float>(z));
@@ -2202,6 +2207,7 @@ luabind::scope lua_register_mob() {
 		.def("DoAnim", (void(Lua_Mob::*)(int,int,bool,int))&Lua_Mob::DoAnim)
 		.def("ChangeSize", (void(Lua_Mob::*)(double))&Lua_Mob::ChangeSize)
 		.def("ChangeSize", (void(Lua_Mob::*)(double,bool))&Lua_Mob::ChangeSize)
+		.def("RandomizeFeatures", (void(Lua_Mob::*)(bool,bool))&Lua_Mob::RandomizeFeatures)
 		.def("GMMove", (void(Lua_Mob::*)(double,double,double))&Lua_Mob::GMMove)
 		.def("GMMove", (void(Lua_Mob::*)(double,double,double,double))&Lua_Mob::GMMove)
 		.def("GMMove", (void(Lua_Mob::*)(double,double,double,double,bool))&Lua_Mob::GMMove)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -71,6 +71,7 @@ public:
 	void DoAnim(int anim_num, int type, bool ackreq, int filter);
 	void ChangeSize(double in_size);
 	void ChangeSize(double in_size, bool no_restriction);
+	void RandomizeFeatures(bool send_illusion, bool save_variables);
 	void GMMove(double x, double y, double z);
 	void GMMove(double x, double y, double z, double heading);
 	void GMMove(double x, double y, double z, double heading, bool send_update);

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -1135,6 +1135,29 @@ XS(XS_Mob_ChangeSize) {
 	XSRETURN_EMPTY;
 }
 
++XS(XS_Mob_RandomizeFeatures); /* prototype to pass -Wmissing-prototypes */
++XS(XS_Mob_RandomizeFeatures) {
++       dXSARGS;
++       if (items < 2 || items > 3)
++               Perl_croak(aTHX_ "Usage: Mob::RandomizeFeatures(THIS, bool send_illusion, set_variables)");
++       {
++               Mob *THIS;
++               bool send_illusion = (bool) SvNV(ST(1));
++               bool set_variables = (bool) SvNV(ST(2));
++
++               if (sv_derived_from(ST(0), "Mob")) {
++                       IV tmp = SvIV((SV *) SvRV(ST(0)));
++                       THIS = INT2PTR(Mob *, tmp);
++               } else
++                       Perl_croak(aTHX_ "THIS is not of type Mob");
++               if (THIS == nullptr)
++                       Perl_croak(aTHX_ "THIS is nullptr, avoiding crash.");
++
++               THIS->RandomizeFeatures(send_illusion, set_variables);
++       }
++       XSRETURN_EMPTY;
++}
+
 XS(XS_Mob_GMMove); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Mob_GMMove) {
 	dXSARGS;
@@ -6760,7 +6783,7 @@ XS(XS_Mob_SendIllusion) {
 	dXSARGS;
 	if (items < 2 || items > 14)
 		Perl_croak(aTHX_
-		           "Usage: Mob::SendIllusion(THIS, uint16 race, [uint8 gender = 0xFF], [uint8 texture = 0xFF], [unit8 helmtexture = 0xFF], [unit8 face = 0xFF], [unit8 hairstyle = 0xFF], [uint8 hair_color = 0xFF], [uint8 beard = 0xFF], [uint8 beard_color = 0xFF], [uint32 drakkin_heritage = 0xFFFFFFFF], [uint32 drakkin_tattoo = 0xFFFFFFFF], [uint32 drakkin_details = 0xFFFFFFFF], [float size = -1])");
+		           "Usage: Mob::SendIllusion(THIS, uint16 race, [uint8 gender = 0xFF], [uint8 texture  face = 0xFF], [uint8 hairstyle = 0xFF], [uint8 hair_color = 0xFF], [uint8 beard = 0xFF], [uint8 beard_color =FF], [uint32 drakkin_tattoo = 0xFFFFFFFF], [uint32 drakkin_details = 0xFFFFFFFF], [float size = -1])");
 	{
 		Mob *THIS;
 		uint16 race             = (uint16) SvIV(ST(1));
@@ -8552,6 +8575,7 @@ XS(boot_Mob) {
 	newXSproto(strcpy(buf, "SetHP"), XS_Mob_SetHP, file, "$$");
 	newXSproto(strcpy(buf, "DoAnim"), XS_Mob_DoAnim, file, "$$;$");
 	newXSproto(strcpy(buf, "ChangeSize"), XS_Mob_ChangeSize, file, "$$;$");
+	newXSproto(strcpy(buf, "RandomizeFeatures"), XS_Mob_RandomizeFeatures, file, "$$;$");
 	newXSproto(strcpy(buf, "GMMove"), XS_Mob_GMMove, file, "$$$$;$");
 	newXSproto(strcpy(buf, "HasProcs"), XS_Mob_HasProcs, file, "$");
 	newXSproto(strcpy(buf, "IsInvisible"), XS_Mob_IsInvisible, file, "$;$");

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -1135,28 +1135,28 @@ XS(XS_Mob_ChangeSize) {
 	XSRETURN_EMPTY;
 }
 
-+XS(XS_Mob_RandomizeFeatures); /* prototype to pass -Wmissing-prototypes */
-+XS(XS_Mob_RandomizeFeatures) {
-+       dXSARGS;
-+       if (items < 2 || items > 3)
-+               Perl_croak(aTHX_ "Usage: Mob::RandomizeFeatures(THIS, bool send_illusion, set_variables)");
-+       {
-+               Mob *THIS;
-+               bool send_illusion = (bool) SvNV(ST(1));
-+               bool set_variables = (bool) SvNV(ST(2));
-+
-+               if (sv_derived_from(ST(0), "Mob")) {
-+                       IV tmp = SvIV((SV *) SvRV(ST(0)));
-+                       THIS = INT2PTR(Mob *, tmp);
-+               } else
-+                       Perl_croak(aTHX_ "THIS is not of type Mob");
-+               if (THIS == nullptr)
-+                       Perl_croak(aTHX_ "THIS is nullptr, avoiding crash.");
-+
-+               THIS->RandomizeFeatures(send_illusion, set_variables);
-+       }
-+       XSRETURN_EMPTY;
-+}
+XS(XS_Mob_RandomizeFeatures); /* prototype to pass -Wmissing-prototypes */
+XS(XS_Mob_RandomizeFeatures) {
+       dXSARGS;
+       if (items < 2 || items > 3)
+               Perl_croak(aTHX_ "Usage: Mob::RandomizeFeatures(THIS, bool send_illusion, set_variables)");
+       {
+               Mob *THIS;
+               bool send_illusion = (bool) SvNV(ST(1));
+               bool set_variables = (bool) SvNV(ST(2));
+
+               if (sv_derived_from(ST(0), "Mob")) {
+                       IV tmp = SvIV((SV *) SvRV(ST(0)));
+                       THIS = INT2PTR(Mob *, tmp);
+               } else
+                       Perl_croak(aTHX_ "THIS is not of type Mob");
+               if (THIS == nullptr)
+                       Perl_croak(aTHX_ "THIS is nullptr, avoiding crash.");
+
+               THIS->RandomizeFeatures(send_illusion, set_variables);
+       }
+       XSRETURN_EMPTY;
+}
 
 XS(XS_Mob_GMMove); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Mob_GMMove) {


### PR DESCRIPTION
By exposing RandomizeFeatures, the plugin::RandomFeatures is no longer needed.

Additionally, RandomizeFeatures has arguments for sending illusion and updating the mob instance.  This lets the quest caller decide if he wants an illusion (only visible to people in zone at the time) or if he wants this instance to retain the features even if a player zones out and back in, or new players zone in.

Also,this new exposed function works at EVENT_SPAWN, whereas the plugin::RandomFatures would not work until at least a second after spawn.

I also fixed a typo in a comment.