### PR TITLE
fixed opcode for deleteing a item out of a player's inventory slot

### DIFF
--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -972,8 +972,8 @@ void Client::DeleteItemInInventory(int16 slot_id, int8 quantity, bool client_upd
 			safe_delete(outapp);
 		}
 		else {
-			outapp = new EQApplicationPacket(OP_MoveItem, sizeof(MoveItem_Struct));
-			MoveItem_Struct* delitem	= (MoveItem_Struct*)outapp->pBuffer;
+			outapp = new EQApplicationPacket(OP_DeleteItem, sizeof(DeleteItem_Struct));
+			DeleteItem_Struct* delitem	= (DeleteItem_Struct*)outapp->pBuffer;
 			delitem->from_slot			= slot_id;
 			delitem->to_slot			= 0xFFFFFFFF;
 			delitem->number_in_stack	= 0xFFFFFFFF;


### PR DESCRIPTION
OP_MoveItem causes a dysec if you try to move to -1 slot on client side, need to use OP_DeleteItem