### PR TITLE
New Perl/Lua buff functionality.

### DIFF
--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -322,6 +322,16 @@ bool Lua_Mob::FindBuff(int spell_id) {
 	return self->FindBuff(spell_id);
 }
 
+uint16 Lua_Mob::FindBuffBySlot(int slot) {
+	Lua_Safe_Call_Int();
+	return self->FindBuffBySlot(slot);
+}
+
+uint32 Lua_Mob::BuffCount() {
+	Lua_Safe_Call_Int();
+	return self->BuffCount();
+}
+
 bool Lua_Mob::FindType(int type) {
 	Lua_Safe_Call_Bool();
 	return self->FindType(type);
@@ -2218,6 +2228,8 @@ luabind::scope lua_register_mob() {
 		.def("IsInvisible", (bool(Lua_Mob::*)(Lua_Mob))&Lua_Mob::IsInvisible)
 		.def("SetInvisible", &Lua_Mob::SetInvisible)
 		.def("FindBuff", &Lua_Mob::FindBuff)
+		.def("FindBuffBySlot", (uint16(Lua_Mob::*)(int))&Lua_Mob::FindBuffBySlot)
+		.def("BuffCount", &Lua_Mob::BuffCount)
 		.def("FindType", (bool(Lua_Mob::*)(int))&Lua_Mob::FindType)
 		.def("FindType", (bool(Lua_Mob::*)(int,bool))&Lua_Mob::FindType)
 		.def("FindType", (bool(Lua_Mob::*)(int,bool,int))&Lua_Mob::FindType)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -82,6 +82,8 @@ public:
 	bool IsInvisible(Lua_Mob other);
     void SetInvisible(int state);
 	bool FindBuff(int spell_id);
+	uint16 FindBuffBySlot(int slot);
+	uint32 BuffCount();
     bool FindType(int type);
 	bool FindType(int type, bool offensive);
 	bool FindType(int type, bool offensive, int threshold);

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -385,6 +385,8 @@ public:
 	void DamageShield(Mob* other, bool spell_ds = false);
 	int32 RuneAbsorb(int32 damage, uint16 type);
 	bool FindBuff(uint16 spellid);
+	uint16 FindBuffBySlot(int slot);
+	uint32 BuffCount();
 	bool FindType(uint16 type, bool bOffensive = false, uint16 threshold = 100);
 	int16 GetBuffSlotFromType(uint16 type);
 	uint16 GetSpellIDFromSlot(uint8 slot);

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -1297,6 +1297,57 @@ XS(XS_Mob_FindBuff) {
 	XSRETURN(1);
 }
 
+XS(XS_Mob_FindBuffBySlot); /* prototype to pass -Wmissing-prototypes */
+XS(XS_Mob_FindBuffBySlot) {
+	dXSARGS;
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: Mob::FindBuffBySlot(THIS, int slot)");
+	{
+		Mob *THIS;
+		uint16 RETVAL;
+		dXSTARG;
+		int slot = SvIV(ST(1));
+
+		if (sv_derived_from(ST(0), "Mob")) {
+			IV tmp = SvIV((SV *) SvRV(ST(0)));
+			THIS = INT2PTR(Mob *, tmp);
+		} else
+			Perl_croak(aTHX_ "THIS is not of type Mob");
+		if (THIS == nullptr)
+			Perl_croak(aTHX_ "THIS is nullptr, avoiding crash.");
+
+		RETVAL = THIS->FindBuffBySlot(slot);
+		XSprePUSH;
+		PUSHu((UV) RETVAL);
+	}
+	XSRETURN(1);
+}
+
+XS(XS_Mob_BuffCount); /* prototype to pass -Wmissing-prototypes */
+XS(XS_Mob_BuffCount) {
+	dXSARGS;
+	if (items != 1)
+		Perl_croak(aTHX_ "Usage: Mob::BuffCount(THIS)");
+	{
+		Mob *THIS;
+		uint32  RETVAL;
+		dXSTARG;
+
+		if (sv_derived_from(ST(0), "Mob")) {
+			IV tmp = SvIV((SV *) SvRV(ST(0)));
+			THIS = INT2PTR(Mob *, tmp);
+		} else
+			Perl_croak(aTHX_ "THIS is not of type Mob");
+		if (THIS == nullptr)
+			Perl_croak(aTHX_ "THIS is nullptr, avoiding crash.");
+
+		RETVAL = THIS->BuffCount();
+		XSprePUSH;
+		PUSHu((UV) RETVAL);		
+	}
+	XSRETURN(1);
+}
+
 XS(XS_Mob_FindType); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Mob_FindType) {
 	dXSARGS;
@@ -8581,6 +8632,8 @@ XS(boot_Mob) {
 	newXSproto(strcpy(buf, "IsInvisible"), XS_Mob_IsInvisible, file, "$;$");
 	newXSproto(strcpy(buf, "SetInvisible"), XS_Mob_SetInvisible, file, "$$");
 	newXSproto(strcpy(buf, "FindBuff"), XS_Mob_FindBuff, file, "$$");
+	newXSproto(strcpy(buf, "FindBuffBySlot"), XS_Mob_FindBuffBySlot, file, "$$");
+	newXSproto(strcpy(buf, "BuffCount"), XS_Mob_BuffCount, file, "$");
 	newXSproto(strcpy(buf, "FindType"), XS_Mob_FindType, file, "$$;$$");
 	newXSproto(strcpy(buf, "GetBuffSlotFromType"), XS_Mob_GetBuffSlotFromType, file, "$$");
 	newXSproto(strcpy(buf, "MakePet"), XS_Mob_MakePet, file, "$$$;$");

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4032,6 +4032,23 @@ bool Mob::FindBuff(uint16 spellid)
 	return false;
 }
 
+uint16 Mob::FindBuffBySlot(int slot) {
+	if (buffs[slot].spellid != SPELL_UNKNOWN)
+		return buffs[slot].spellid;
+	
+	return 0;
+}
+
+uint32 Mob::BuffCount() {
+	uint32 active_buff_count = 0;
+	int buff_count = GetMaxTotalSlots();
+	for (int i = 0; i < buff_count; i++) 
+		if (buffs[i].spellid != SPELL_UNKNOWN)
+			active_buff_count++;
+	
+	return active_buff_count;
+}
+
 // removes all buffs
 void Mob::BuffFadeAll()
 {


### PR DESCRIPTION
- Mob::FindBuffBySlot(slot)
	This allows you to find buffs by a specific slot.
	Example: https://i.imgur.com/VG68cxs.png
	Perl Example: https://pastebin.com/8HvMAC4h

- Mob::BuffCount()
	This will find the active number of buffs an NPC/client has.
	Example: https://i.imgur.com/jrLRBwV.png
	Perl Example: https://pastebin.com/Wmg16wwp