### PR TITLE
Updating linux installer script

### DIFF
--- a/utils/scripts/linux_installer/install.sh
+++ b/utils/scripts/linux_installer/install.sh
@@ -146,61 +146,75 @@ if [[ "$OS" == "Debian" ]]; then
 
 elif [[ "$OS" == "red_hat" ]]; then
 	# Do RedHat / CentOS stuff
-	# Add the MariaDB repository to yum
-cat <<EOF > /etc/yum.repos.d/mariadb.repo
-# MariaDB 10.1 CentOS repository list - created 2016-08-20 05:42 UTC
-# http://downloads.mariadb.org/mariadb/repositories/
-[mariadb]
-name = MariaDB
-baseurl = http://yum.mariadb.org/10.1/centos7-amd64
-gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
-enabled=1
-gpgcheck=1
-EOF
 	# Install prereqs
-	yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-	yum -y install deltarpm
-	yum -y install open-vm-tools vim cmake boost-* zlib-devel mariadb-server mariadb-client mariadb-devel mariadb-libs mariadb-compat perl-* lua* dos2unix php-mysql proftpd libuuid-devel
-	yum -y groupinstall "Development Tools" "Basic Web Server" "Compatibility Libraries"
+        yum -y install epel-release deltarpm
+        yum -y update
+	yum -y install \
+                open-vm-tools \
+                vim \
+                cmake \
+                boost-* \
+                zlib-devel \
+		mariadb \
+                mariadb-server \
+                mariadb-devel \
+                mariadb-libs \
+                perl-DBD-MySQL \
+                perl-JSON \
+                perl-IO-stringy \
+                perl-devel \
+                perl-Time-HiRes \
+                lua-devel \
+                dos2unix \
+                php-mysql \
+                proftpd \
+                libuuid-devel \
+                libsodium \
+                libsodium-devel \
+                openssl-devel 
+
+	yum -y groupinstall \
+		"Development Tools" \
+		"Basic Web Server" \
+		"Compatibility Libraries" 
 
 elif [[ "$OS" == "fedora_core" ]]; then
 	# Do Fedora stuff
-	dnf -y install open-vm-tools
-	dnf -y install vim
-	dnf -y install cmake
-	dnf -y install boost-devel
-	dnf -y install zlib-devel
-	dnf -y install mariadb-server
-	dnf -y install mariadb-devel
-	dnf -y install mariadb-libs
-	dnf -y install perl
-	dnf -y install perl-DBD-MySQL
-	dnf -y install perl-IO-stringy
-	dnf -y install perl-devel
-	dnf -y install lua-devel
-	dnf -y install lua-sql-mysql
-	dnf -y install dos2unix
-	dnf -y install php-mysql
-	dnf -y install php-mysqlnd
-	dnf -y install proftpd
-	dnf -y install wget
-	dnf -y install compat-lua-libs
-	dnf -y install compat-lua-devel
-	dnf -y install compat-lua
-	dnf -y install perl-Time-HiRes
-	dnf -y install libuuid-devel
-	dnf -y install libsodium
-	dnf -y install libsodium-devel
-	dnf -y groupinstall "Development Tools"
-	dnf -y groupinstall "Basic Web Server"
-	dnf -y groupinstall "C Development Tools and Libraries"
+	dnf -y install \
+                open-vm-tools \
+                vim \
+                cmake \
+                boost-devel \
+                zlib-devel \
+                mariadb-server \
+                mariadb-devel \
+                perl \
+                perl-DBD-MySQL \
+                perl-IO-stringy \
+                perl-devel \
+                lua-devel \
+                lua-sql-mysql \
+                dos2unix \
+                php-mysqlnd \
+                proftpd \
+                wget \
+                compat-lua-libs \
+                compat-lua-devel \
+                compat-lua \
+                perl-Time-HiRes \
+                perl-JSON \
+                libuuid-devel \
+                libsodium \
+                libsodium-devel \
+                openssl-devel 
+
+        dnf -y group install "Development Tools" "Basic Web Server" "C Development Tools and Libraries"
 fi
 
 if [[ "$OS" == "fedora_core" ]] || [[ "$OS" == "red_hat" ]]; then
 	# Start MariaDB server and set root password
 	echo "Starting MariaDB server..."
-	systemctl enable mariadb.service
-	systemctl start mariadb.service
+	systemctl enable mariadb.service --now
 	sleep 5
 	/usr/bin/mysqladmin -u root password $eqemu_db_root_password
 fi


### PR DESCRIPTION
This brings the installer script up to date and changes a few logical problems. For example running apt 50 times is a ton slower than running it once, same with dnf.

the yum install for RHEL was also installing 1777 undeeded perl and lua modules for no reason. Now it installs 53. 

