### PR TITLE
Convert constant check in level_command() to a Rule

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -205,6 +205,7 @@ RULE_CATEGORY_END()
 RULE_CATEGORY(GM)
 RULE_INT(GM, MinStatusToSummonItem, 250)
 RULE_INT(GM, MinStatusToZoneAnywhere, 250)
+RULE_INT(GM, MinStatusToLevelTarget, 100)
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(World)

--- a/utils/sql/git/optional/2019_06_21_new_rule_gm_level_target.sql
+++ b/utils/sql/git/optional/2019_06_21_new_rule_gm_level_target.sql
@@ -1,0 +1,2 @@
+INSERT INTO `rule_values` (`ruleset_id`, `rule_name`, `rule_value`, `notes`)
+VALUES (1, 'GM:MinStatusToLevelTarget', '100', 'GM status needed to use #level on your target');

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -2784,7 +2784,7 @@ void command_level(Client *c, const Seperator *sep)
 	if ((level <= 0) || ((level > RuleI(Character, MaxLevel)) && (c->Admin() < commandLevelAboveCap))) {
 		c->Message(0, "Error: #Level: Invalid Level");
 	}
-	else if (c->Admin() < 100) {
+	else if (c->Admin() < RuleI(GM, MinStatusToLevelTarget)) {
 		c->SetLevel(level, true);
 #ifdef BOTS
 		if(RuleB(Bots, BotLevelsWithOwner))


### PR DESCRIPTION
Add GM:MinStatusToLevelTarget rule, which determines the GM status needed to use the #level command on your target.