### PR TITLE
Update questmgr.cpp

### DIFF
--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -167,6 +167,10 @@ void QuestManager::say(const char *str, Journal::Options &opts) {
 			opts.target_spawn_id = initiator->GetID();
 			owner->QuestJournalledSay(initiator, str, opts);
 		}
+		else {
+			// Non initiated Say() like from a quest waypoint.
+			owner->Say(str);
+		}
 	}
 }
 


### PR DESCRIPTION
Put back Say() for non initiated quest::say() calls like those in an EVENT_WAYPOINT_ARRIVE sub.