### PR TITLE
Build on all cores

### DIFF
--- a/utils/scripts/eqemu_server.pl
+++ b/utils/scripts/eqemu_server.pl
@@ -414,7 +414,7 @@ sub build_linux_source {
     print "Building EQEmu Server code. This will take a while.";
 
     #::: Build
-    print `make`;
+    print `make -j\$(nproc)`
 
     chdir($current_directory);
 


### PR DESCRIPTION
nproc is part of the coreutils so no further yum/apt package needed.
One could argue to build on nproc-1 or even nproc/2 for SMT systems, but that would need handling for nproc=1)
Building the latest source on an 8 core CentOS7 qemu VM (E5-2690 v2) takes 2m12s on all cores.