### PR TITLE
fix for telnet's lack of language skill

### DIFF
--- a/world/zonelist.cpp
+++ b/world/zonelist.cpp
@@ -432,6 +432,7 @@ void ZSList::SendChannelMessageRaw(const char* from, const char* to, uint8 chan_
 	}
 
 	scm->language = language;
+	scm->lang_skill = 100;
 	scm->chan_num = chan_num;
 	strcpy(&scm->message[0], message);
 


### PR DESCRIPTION
this function is only used when a raw telnet ooc, auction, or tell is used. it needs to have the language skill set though otherwise it just comes out as garbled