### PR TITLE
Fix some bugs with the use of the model field in npc_types

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -3061,6 +3061,7 @@ void command_texture(Client *c, const Seperator *sep)
 {
 
 	uint16 texture;
+
 	if (sep->IsNumber(1) && atoi(sep->arg[1]) >= 0 && atoi(sep->arg[1]) <= 255) {
 		texture = atoi(sep->arg[1]);
 		uint8 helm = 0xFF;
@@ -3072,9 +3073,9 @@ void command_texture(Client *c, const Seperator *sep)
 			{
 				c->SendTextureWC(i, texture);
 			}
-		else if ((c->GetTarget()->GetRace() > 0 && c->GetTarget()->GetRace() <= 12) ||
-			c->GetTarget()->GetRace() == 128 || c->GetTarget()->GetRace() == 130 ||
-			c->GetTarget()->GetRace() == 330 || c->GetTarget()->GetRace() == 522) {
+		else if ((c->GetTarget()->GetModel() > 0 && c->GetTarget()->GetModel() <= 12) ||
+			c->GetTarget()->GetModel() == 128 || c->GetTarget()->GetModel() == 130 ||
+			c->GetTarget()->GetModel() == 330 || c->GetTarget()->GetModel() == 522) {
 			for (i = EQEmu::textures::textureBegin; i <= EQEmu::textures::LastTintableTexture; i++)
 			{
 				c->GetTarget()->SendTextureWC(i, texture);
@@ -3093,7 +3094,7 @@ void command_texture(Client *c, const Seperator *sep)
 			}
 
 			if ((c->GetTarget()) && (c->Admin() >= commandTextureOthers))
-				c->GetTarget()->SendIllusionPacket(c->GetTarget()->GetRace(), 0xFF, texture, helm);
+				c->GetTarget()->SendIllusionPacket(c->GetTarget()->GetModel(), 0xFF, texture, helm);
 			else
 				c->SendIllusionPacket(c->GetRace(), 0xFF, texture, helm);
 		}

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1736,7 +1736,11 @@ void Mob::SendIllusionPacket(
 	uint32 new_drakkin_tattoo;
 	uint32 new_drakkin_details;
 
-	race = (in_race) ? in_race : GetBaseRace();
+	race = in_race;
+	if (race == 0)
+		{
+		race = (use_model) ? use_model : GetBaseRace();
+		}
 
 	if (in_gender != 0xFF)
 		{

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -449,6 +449,7 @@ public:
 	virtual inline uint16 GetDeity() const { return deity; }
 	virtual EQEmu::deity::DeityTypeBit GetDeityBit() { return EQEmu::deity::ConvertDeityTypeToDeityTypeBit((EQEmu::deity::DeityType)deity); }
 	inline uint16 GetRace() const { return race; }
+	inline uint16 GetModel() const { return (use_model == 0) ? race : use_model; }
 	inline uint8 GetGender() const { return gender; }
 	inline uint8 GetTexture() const { return texture; }
 	inline uint8 GetHelmTexture() const { return helmtexture; }


### PR DESCRIPTION
Earlier this year I added a model field to npc_types.  The use of this field is to allow servers to specify the actual race of all mobs in the race field, and the graphical model to be used in the model field.  This has the advantage that things like gnollbane can work on all gnolls, regardless of model. 

This PR fixes two bugs uncovered when this field (model) is used.

1) #texture command was not working, as it expected the model being used was in GetRace().  I added a new call GetModel() which returns race unless model is defined, in which case it uses model.

2) Illusiions fading would default back to race, rather than model in the cases where model was used.  This now fades back to model (if used) or GetBaseRace() as before.
