### PR TITLE
This allows for merchants to drop corpses

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -628,6 +628,7 @@ RULE_INT(Merchant, PricePenaltyPct, 4, "Determines maximum price penalty from ha
 RULE_REAL(Merchant, ChaBonusMod, 3.45, "Determines CHA cap, from 104 CHA. 3.45 is 132 CHA at apprehensive. 0.34 is 400 CHA at apprehensive")
 RULE_REAL(Merchant, ChaPenaltyMod, 1.52, "Determines CHA bottom, up to 102 CHA. 1.52 is 37 CHA at apprehensive. 0.98 is 0 CHA at apprehensive")
 RULE_BOOL(Merchant, EnableAltCurrencySell, true, "Enables the ability to resell items to alternate currency merchants")
+RULE_BOOL(Merchant, AllowCorpse, false, "Can merchants generate a corpse")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Bazaar)

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2438,10 +2438,13 @@ bool NPC::Death(Mob* killer_mob, int32 damage, uint16 spell, EQEmu::skills::Skil
 		}
 	}
 
-	if (!HasOwner() && !IsMerc() && class_ != MERCHANT && class_ != ADVENTUREMERCHANT && !GetSwarmInfo()
-		&& MerchantType == 0 && ((killer && (killer->IsClient() || (killer->HasOwner() && killer->GetUltimateOwner()->IsClient()) ||
-			(killer->IsNPC() && killer->CastToNPC()->GetSwarmInfo() && killer->CastToNPC()->GetSwarmInfo()->GetOwner() && killer->CastToNPC()->GetSwarmInfo()->GetOwner()->IsClient())))
-			|| (killer_mob && IsLdonTreasure)))
+	bool    allow_merchant_corpse = RuleB(Merchant, AllowCorpse);
+	bool    is_merchant = (class_ == MERCHANT || class_ == ADVENTUREMERCHANT || MerchantType != 0);
+	
+	if (!HasOwner() && !IsMerc() && !GetSwarmInfo() && (!is_merchant || allow_merchant_corpse) &&
+		((killer && (killer->IsClient() || (killer->HasOwner() && killer->GetUltimateOwner()->IsClient()) ||
+		(killer->IsNPC() && killer->CastToNPC()->GetSwarmInfo() && killer->CastToNPC()->GetSwarmInfo()->GetOwner() && killer->CastToNPC()->GetSwarmInfo()->GetOwner()->IsClient())))
+		|| (killer_mob && IsLdonTreasure)))
 	{
 		if (killer != 0) {
 			if (killer->GetOwner() != 0 && killer->GetOwner()->IsClient())


### PR DESCRIPTION
The new rule defaults to live behavior of no corpse for merchants.

This is inspired as an option as a newly updated live quest "Noble Hunters" reveals that it was broken because the drops were on merchants before they implemented the no corpse rule.  Live fixed this by making these mobs non-merchants.  

I think this option for servers is a nice one to have .