### PR TITLE
_GetRunSpeed did not correctly report aa mods for Clients.

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -684,7 +684,7 @@ int Mob::_GetRunSpeed() const {
 	int runspeedcap = RuleI(Character,BaseRunSpeedCap);
 	runspeedcap += itembonuses.IncreaseRunSpeedCap + spellbonuses.IncreaseRunSpeedCap + aabonuses.IncreaseRunSpeedCap;
 
-	aa_mod = itembonuses.IncreaseRunSpeedCap + spellbonuses.IncreaseRunSpeedCap + aabonuses.IncreaseRunSpeedCap;
+	aa_mod += aabonuses.BaseMovementSpeed + aabonuses.movementspeed;
 	int spell_mod = spellbonuses.movementspeed + itembonuses.movementspeed;
 	int movemod = 0;
 


### PR DESCRIPTION
I actually believe this was some old cut-n-paste error.  aa_mod was being set to a total of all (3) caps - like the previous line.

#showstats now correctly displays movement rate for people with runspeed AAs.