### PR TITLE
Fix FixZ regarding the use of model in npc_types

### DIFF
--- a/zone/waypoints.cpp
+++ b/zone/waypoints.cpp
@@ -771,7 +771,7 @@ void Mob::FixZ(int32 z_find_offset /*= 5*/, bool fix_client_z /*= false*/) {
 float Mob::GetZOffset() const {
 	float offset = 3.125f;
 
-	switch (race) {
+	switch (GetModel()) {
 		case RACE_BASILISK_436:
 			offset = 0.577f;
 			break;


### PR DESCRIPTION
This fix only impacts those that use the model field in npc_types to override race on the client.

GetModel() returns model if set, otherwise race.

As a refresher, the model field is there so the server can still see a mob as its base race for things like bane, while the client can use a new model.

FixZ needs to know about this.