### PR TITLE
Implement DefaultGuild Rule

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -343,15 +343,9 @@ bool Database::ReserveName(uint32 account_id, char* name) {
 	int guild_id = RuleI(Character, DefaultGuild);
 
 	if (guild_id != 0) {
-		int char_id=-1;
-		query = StringFormat("select `id` FROM `character_data` WHERE `name` = '%s'", name);
-		results = QueryDatabase(query);
-		for (auto row = results.begin(); row != results.end(); ++row) {
-			char_id = atoi(row[0]);	
-			}
-
-		if (char_id > -1) {
-			query = StringFormat("INSERT INTO `guild_members` SET `char_id` = %i, `guild_id` = '%i'", char_id, guild_id);
+		int character_id=results.LastInsertedID();
+		if (character_id > -1) {
+			query = StringFormat("INSERT INTO `guild_members` SET `char_id` = %i, `guild_id` = '%i'", character_id, guild_id);
 			results = QueryDatabase(query);
 			if (!results.Success() || results.ErrorMessage() != ""){
 				LogInfo("Could not put character [{}] into default Guild", name);

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -159,6 +159,7 @@ RULE_BOOL(Character, PetsUseReagents, true, "Pets use reagent on spells")
 RULE_BOOL(Character, DismountWater, true, "Dismount horses when entering water")
 RULE_BOOL(Character, UseNoJunkFishing, false, "Disregards junk items when fishing")
 RULE_BOOL(Character, SoftDeletes, true, "When characters are deleted in character select, they are only soft deleted")
+RULE_INT(Character, DefaultGuild, 0, "If not 0, new characters placed into the guild # indicated")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Mercs)


### PR DESCRIPTION
This allows server owners to assign all new characters created to a default guild of their choosing,

Default behavior is that the rule if off - as normal.

I see this good for:

- local servers where everyone is in same guild
- all servers that want new characters to be born into a community.