### PR TITLE
Idle NPC mana regen

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -526,6 +526,7 @@ RULE_INT(NPC, NPCGatePercent, 20, "% at which the NPC Will attempt to gate at")
 RULE_BOOL(NPC, NPCGateNearBind, false, "Will NPC attempt to gate when near bind location?")
 RULE_INT(NPC, NPCGateDistanceBind, 75, "Distance from bind before NPC will attempt to gate")
 RULE_BOOL(NPC, NPCHealOnGate, true, "Will the NPC Heal on Gate")
+RULE_BOOL(NPC, UseMeditateBasedManaRegen, false, "Based NPC ooc regen on Meditate skill")
 RULE_REAL(NPC, NPCHealOnGateAmount, 25, "How much the npc will heal on gate if enabled")
 RULE_CATEGORY_END()
 

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -793,7 +793,7 @@ bool NPC::Process()
 				SetMana(GetMana() + mana_regen + npc_sitting_regen_bonus);
 			}
 		}
-		
+
 		SendHPUpdate();
 
 		if (zone->adv_data && !p_depop) {

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -778,17 +778,22 @@ bool NPC::Process()
 		}
 
 		if (GetMana() < GetMaxMana()) {
-			int32 npc_idle_mana_regen_bonus = 2;
-			uint16 meditate_skill = GetSkill(EQEmu::skills::SkillMeditate);
-			if (!IsEngaged() && meditate_skill > 0) {
-				uint8 clevel = GetLevel();
-				npc_idle_mana_regen_bonus =
-					(((meditate_skill / 10) +
-					(clevel - (clevel / 4))) / 4) + 4;
+			if (RuleB(NPC, UseMeditateBasedManaRegen)) {
+				int32 npc_idle_mana_regen_bonus = 2;
+				uint16 meditate_skill = GetSkill(EQEmu::skills::SkillMeditate);
+				if (!IsEngaged() && meditate_skill > 0) {
+					uint8 clevel = GetLevel();
+					npc_idle_mana_regen_bonus =
+						(((meditate_skill / 10) +
+						(clevel - (clevel / 4))) / 4) + 4;
+				}
+				SetMana(GetMana() + mana_regen + npc_idle_mana_regen_bonus);
 			}
-			SetMana(GetMana() + mana_regen + npc_idle_mana_regen_bonus);
+			else {
+				SetMana(GetMana() + mana_regen + npc_sitting_regen_bonus);
+			}
 		}
-
+		
 		SendHPUpdate();
 
 		if (zone->adv_data && !p_depop) {

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -778,7 +778,15 @@ bool NPC::Process()
 		}
 
 		if (GetMana() < GetMaxMana()) {
-			SetMana(GetMana() + mana_regen + npc_sitting_regen_bonus);
+			int32 npc_idle_mana_regen_bonus = 2;
+			uint16 meditate_skill = GetSkill(EQEmu::skills::SkillMeditate);
+			if (!IsEngaged() && meditate_skill > 0) {
+				uint8 clevel = GetLevel();
+				npc_idle_mana_regen_bonus =
+					(((meditate_skill / 10) +
+					(clevel - (clevel / 4))) / 4) + 4;
+			}
+			SetMana(GetMana() + mana_regen + npc_idle_mana_regen_bonus);
 		}
 
 		SendHPUpdate();


### PR DESCRIPTION
Without this change, Idle NPC casters get mana_regen from database which  happens all the time (non-idle) + the npc_sitting_regen_bonus variable (which was set for HP and only set when the NPC anim is actually sittting).

This current (existing) behavior means that if an NPC caster like a priest or shaman buffs his camp - he will eventually run out of mana and never have any again (depending on the db mana_regen).  It also means it gets no bonuses for being idle.

I don't think we want code to make our NPCs actually sit when out of battle.  I do think, a slow recovery rate when they are out of combat is reasonable, so that when A PC engages them after the zone has been up for hours, they have a chance of having mana and/or buffs.

Tested on my server before the changes, priests/shamans buff themselves n-times, as buffs drop until they have no mana, then they run around buffless/manaless.

This code was based on mercs code and works very well on my server (been using it for about 8 weeks).  I watched their mana pools throughout the process.

I can isolate this with an optional rule if you like. I feel this makes NPCs more realistic and should be standard.  Makes no sense to me that they would just run out of mana forever, and tweaking the mana_regen in the db just gives them higher regen even while in combat - which isnt good.