### PR TITLE
Add hot_zone filtering for global loot

### DIFF
--- a/common/version.h
+++ b/common/version.h
@@ -34,7 +34,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9148
+#define CURRENT_BINARY_DATABASE_VERSION 9149
 
 #ifdef BOTS
 	#define CURRENT_BINARY_BOTS_DATABASE_VERSION 9026

--- a/utils/sql/db_update_manifest.txt
+++ b/utils/sql/db_update_manifest.txt
@@ -402,6 +402,7 @@
 9146|2020_01_10_character_soft_deletes.sql|SHOW COLUMNS FROM `character_data` LIKE 'deleted_at'|empty|
 9147|2020_01_24_grid_centerpoint_wp.sql|SHOW COLUMNS FROM `grid_entries` LIKE 'centerpoint'|empty|
 9148|2020_01_28_corpse_guild_consent_id.sql|SHOW COLUMNS FROM `character_corpses` LIKE 'guild_consent_id'|empty|
+9149|2020_02_06_globalloot.sql|SHOW COLUMNS FROM `global_loot` LIKE 'hot_zone'|empty|
 
 # Upgrade conditions:
 # 	This won't be needed after this system is implemented, but it is used database that are not

--- a/utils/sql/git/required/2020_02_06_globalloot.sql
+++ b/utils/sql/git/required/2020_02_06_globalloot.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `global_loot` ADD `hot_zone` TINYINT NULL;
+

--- a/zone/global_loot_manager.cpp
+++ b/zone/global_loot_manager.cpp
@@ -1,6 +1,9 @@
 #include "global_loot_manager.h"
 #include "npc.h"
 #include "client.h"
+#include "zone.h"
+
+extern Zone *zone;
 
 std::vector<int> GlobalLootManager::GetGlobalLootTables(NPC *mob) const
 {
@@ -77,6 +80,12 @@ bool GlobalLootEntry::PassesRules(NPC *mob) const
 			bBodyType = true; // we must pass BodyType
 			if (mob->GetBodyType() == r.value)
 				bPassesBodyType = true;
+			break;
+		case GlobalLoot::RuleTypes::HotZone: // value == 0 must not be hot_zone, value != must be hot_zone
+			if (zone->IsHotzone() && !r.value)
+				return false;
+			if (!zone->IsHotzone() && r.value)
+				return false;
 			break;
 		default:
 			break;

--- a/zone/global_loot_manager.h
+++ b/zone/global_loot_manager.h
@@ -17,6 +17,7 @@ enum class RuleTypes {
 	BodyType = 4,
 	Rare = 5,
 	Raid = 6,
+	HotZone = 7,
 	Max
 };
 

--- a/zone/loottables.cpp
+++ b/zone/loottables.cpp
@@ -464,7 +464,7 @@ void NPC::CheckGlobalLootTables()
 void ZoneDatabase::LoadGlobalLoot()
 {
 	auto query = StringFormat("SELECT id, loottable_id, description, min_level, max_level, rare, raid, race, "
-				  "class, bodytype, zone FROM global_loot WHERE enabled = 1");
+				  "class, bodytype, zone, hot_zone FROM global_loot WHERE enabled = 1");
 
 	auto results = QueryDatabase(query);
 	if (!results.Success() || results.RowCount() == 0)
@@ -481,6 +481,7 @@ void ZoneDatabase::LoadGlobalLoot()
 			if (it == zones.end())  // not in here, skip
 				continue;
 		}
+
 
 		GlobalLootEntry e(atoi(row[0]), atoi(row[1]), row[2] ? row[2] : "");
 
@@ -520,6 +521,10 @@ void ZoneDatabase::LoadGlobalLoot()
 			for (auto &b : bodytypes)
 				e.AddRule(GlobalLoot::RuleTypes::BodyType, std::stoi(b));
 		}
+
+		// null is not used
+		if (row[11])
+			e.AddRule(GlobalLoot::RuleTypes::HotZone, atoi(row[11]));
 
 		zone->AddGlobalLootEntry(e);
 	}

--- a/zone/loottables.cpp
+++ b/zone/loottables.cpp
@@ -482,7 +482,6 @@ void ZoneDatabase::LoadGlobalLoot()
 				continue;
 		}
 
-
 		GlobalLootEntry e(atoi(row[0]), atoi(row[1]), row[2] ? row[2] : "");
 
 		auto min_level = atoi(row[3]);


### PR DESCRIPTION
We do this in GlobalLootEntry::PassesRules since we want to check if the
hot zone status changes during run time

Value can be null, if null it's not checked. If the value is 0 the zone
must not be a hot zone (I guess one might want that) and if it's not 0,
the zone must be a hot zone