### PR TITLE
Implement AA timers reset on death

### DIFF
--- a/common/patches/rof2_structs.h
+++ b/common/patches/rof2_structs.h
@@ -4401,7 +4401,7 @@ struct SendAA_Struct {
 /*0104*/	uint32 special_category;
 /*0108*/	uint8 shroud;
 /*0109*/	uint8 unknown109;
-/*0110*/	uint8 layonhands; // 1 for lay on hands -- doesn't seem to matter?
+/*0110*/	uint8 reset_on_death; // timer is reset on death
 /*0111*/	uint8 unknown111;
 /*0112*/	uint32 total_abilities;
 /*0116*/	AA_Ability abilities[0];

--- a/common/patches/rof_structs.h
+++ b/common/patches/rof_structs.h
@@ -4341,7 +4341,7 @@ struct SendAA_Struct {
 /*0104*/	uint32 special_category;
 /*0108*/	uint8 shroud;
 /*0109*/	uint8 unknown109;
-/*0110*/	uint8 layonhands; // 1 for lay on hands -- doesn't seem to matter?
+/*0110*/	uint8 reset_on_death; // timer is reset on death
 /*0111*/	uint8 unknown111;
 /*0112*/	uint32 total_abilities;
 /*0116*/	AA_Ability abilities[0];

--- a/common/patches/sod_structs.h
+++ b/common/patches/sod_structs.h
@@ -3780,7 +3780,7 @@ struct SendAA_Struct {
 /*0092*/	uint32 special_category;
 /*0096*/	uint8 shroud;
 /*0097*/	uint8 unknown97;
-/*0098*/	uint8 layonhands; // 1 for lay on hands -- doesn't seem to matter?
+/*0098*/	uint8 reset_on_death; // timer is reset on death
 /*0099*/	uint8 unknown99;
 /*0100*/	uint32 total_abilities;
 /*0104*/	AA_Ability abilities[0];

--- a/common/patches/sof_structs.h
+++ b/common/patches/sof_structs.h
@@ -3704,7 +3704,7 @@ struct SendAA_Struct {
 /*0088*/	uint32 aa_expansion;
 /*0092*/	uint32 special_category;
 /*0096*/	uint8 shroud;
-/*0097*/	uint8 unknown97;
+/*0097*/	uint8 reset_on_death; // timer is reset on death -- guess
 /*0098*/	uint32 total_abilities;
 /*0102*/	AA_Ability abilities[0];
 };

--- a/common/patches/uf_structs.h
+++ b/common/patches/uf_structs.h
@@ -3835,7 +3835,7 @@ struct SendAA_Struct {
 /*0092*/	uint32 special_category;
 /*0096*/	uint8 shroud;
 /*0097*/	uint8 unknown97;
-/*0098*/	uint8 layonhands; // 1 for lay on hands -- doesn't seem to matter?
+/*0098*/	uint8 reset_on_death; // timer is reset on death
 /*0099*/	uint8 unknown99;
 /*0100*/	uint32 total_abilities;
 /*0104*/	AA_Ability abilities[0];

--- a/common/version.h
+++ b/common/version.h
@@ -34,7 +34,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9149
+#define CURRENT_BINARY_DATABASE_VERSION 9150
 
 #ifdef BOTS
 	#define CURRENT_BINARY_BOTS_DATABASE_VERSION 9026

--- a/utils/sql/db_update_manifest.txt
+++ b/utils/sql/db_update_manifest.txt
@@ -403,6 +403,7 @@
 9147|2020_01_24_grid_centerpoint_wp.sql|SHOW COLUMNS FROM `grid_entries` LIKE 'centerpoint'|empty|
 9148|2020_01_28_corpse_guild_consent_id.sql|SHOW COLUMNS FROM `character_corpses` LIKE 'guild_consent_id'|empty|
 9149|2020_02_06_globalloot.sql|SHOW COLUMNS FROM `global_loot` LIKE 'hot_zone'|empty|
+9150|2020_02_06_aa_reset_on_death.sql|SHOW COLUMNS FROM `aa_ability` LIKE 'reset_on_death'|empty|
 
 # Upgrade conditions:
 # 	This won't be needed after this system is implemented, but it is used database that are not

--- a/utils/sql/git/required/2020_02_06_aa_reset_on_death.sql
+++ b/utils/sql/git/required/2020_02_06_aa_reset_on_death.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `aa_ability` ADD `reset_on_death` TINYINT(4) NOT NULL DEFAULT '0';
+UPDATE `aa_ability` SET `reset_on_death` = '1' WHERE `id` = 6001;

--- a/zone/aa_ability.h
+++ b/zone/aa_ability.h
@@ -50,6 +50,7 @@ public:
 	int drakkin_heritage;
 	int status;
 	bool grant_only;
+	bool reset_on_death;
 	int type;
 	int charges;
 	int first_rank_id;

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1853,6 +1853,11 @@ bool Client::Death(Mob* killerMob, int32 damage, uint16 spell, EQEmu::skills::Sk
 	}
 
 	/*
+	Reset AA reuse timers that need to be, live-like this is only Lay on Hands
+	*/
+	ResetOnDeathAlternateAdvancement();
+
+	/*
 	Finally, send em home
 
 	We change the mob variables, not pp directly, because Save() will copy

--- a/zone/client.h
+++ b/zone/client.h
@@ -838,6 +838,7 @@ public:
 	void SendAlternateAdvancementTimers();
 	void ResetAlternateAdvancementTimer(int ability);
 	void ResetAlternateAdvancementTimers();
+	void ResetOnDeathAlternateAdvancement();
 
 	void SetAAPoints(uint32 points) { m_pp.aapoints = points; SendAlternateAdvancementStats(); }
 	void AddAAPoints(uint32 points) { m_pp.aapoints += points; SendAlternateAdvancementStats(); }


### PR DESCRIPTION
This is a field in the packet, live only uses this for Lay on Hands

Currently I didn't add this to the packet since it has 0 effect on the
client.

We could move this field to aa_ranks which would give more flexibility
for custom servers, but no one said they wanted it there.