### PR TITLE
Added skills rebuild to NPC::SetLevel

### DIFF
--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -2200,7 +2200,13 @@ void NPC::SetLevel(uint8 in_level, bool command)
 	if(in_level > level)
 		SendLevelAppearance();
 	level = in_level;
-	SendAppearancePacket(AT_WhoLevel, in_level);
+	SendAppearancePacket(AT_WhoLevel, in_level);	
+	
+	int r;
+	for (r = 0; r <= EQEmu::skills::HIGHEST_SKILL; r++) {
+		skills[r] = database.GetSkillCap(GetClass(), (EQEmu::skills::SkillType)r, level);
+	}
+
 }
 
 void NPC::ModifyNPCStat(const char *identifier, const char *new_value)

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -2206,6 +2206,22 @@ void NPC::SetLevel(uint8 in_level, bool command)
 	for (r = 0; r <= EQEmu::skills::HIGHEST_SKILL; r++) {
 		skills[r] = database.GetSkillCap(GetClass(), (EQEmu::skills::SkillType)r, level);
 	}
+	// some overrides -- really we need to be able to set skills for mobs in the DB
+	// There are some known low level SHM/BST pets that do not follow this, which supports
+	// the theory of needing to be able to set skills for each mob separately
+	if (!IsBot()) {
+		if (level > 50) {
+			skills[EQEmu::skills::SkillDoubleAttack] = 250;
+			skills[EQEmu::skills::SkillDualWield] = 250;
+		}
+		else if (level > 3) {
+			skills[EQEmu::skills::SkillDoubleAttack] = level * 5;
+			skills[EQEmu::skills::SkillDualWield] = skills[EQEmu::skills::SkillDoubleAttack];
+		}
+		else {
+			skills[EQEmu::skills::SkillDoubleAttack] = level * 5;
+		}
+	}
 
 }
 


### PR DESCRIPTION
Reasoning: 
![image](https://user-images.githubusercontent.com/845670/74527407-715d5300-4eda-11ea-8fb1-ca6ab04e9405.png)
left is a mob scaled from lvl 14 to 70, you can see the calculated stats are off vs the Elite Guardian of Ro on right.

After this fix:
<img width="301" alt="Screen Shot 2020-02-14 at 3 29 34 AM" src="https://user-images.githubusercontent.com/845670/74527449-918d1200-4eda-11ea-96f3-41a41bbddd30.png">

So, now it's possible to "scale" an NPC using my scaling plugin code.
