### PR TITLE
Add Necromancer pet spell effect id to pet spell reagent check

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -1263,7 +1263,7 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 					return;
 				}
 			}
-			else if (!RuleB(Character, PetsUseReagents) && IsEffectInSpell(spell_id, SE_SummonPet)) {
+			else if (!RuleB(Character, PetsUseReagents) && (IsEffectInSpell(spell_id, SE_SummonPet) || IsEffectInSpell(spell_id, SE_NecPet))) {
 				//bypass reagent cost
 			}
 			else if (!bard_song_mode)

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -1230,7 +1230,7 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 
 				// handle the components for traditional casters
 				else {
-					if (!RuleB(Character, PetsUseReagents) && IsEffectInSpell(spell_id, SE_SummonPet)) {
+					if (!RuleB(Character, PetsUseReagents) && (IsEffectInSpell(spell_id, SE_SummonPet) || IsEffectInSpell(spell_id, SE_NecPet))) {
 						//bypass reagent cost
 					} 
 					else if(c->GetInv().HasItem(component, component_count, invWhereWorn|invWherePersonal) == -1) // item not found


### PR DESCRIPTION
The rule that was created does not include create undead pet spell effects, which have a different id than standard pets (magician, enchanter, shaman...) and therefore still require bone chips for Necromancers and Shadowknights. This will fix that functionality.