### PR TITLE
Fix /split while in a raid

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -13327,13 +13327,17 @@ void Client::Handle_OP_Split(const EQApplicationPacket *app)
 	Split_Struct *split = (Split_Struct *)app->pBuffer;
 	//Per the note above, Im not exactly sure what to do on error
 	//to notify the client of the error...
-	if (!isgrouped) {
-		Message(Chat::Red, "You can not split money if you're not in a group.");
-		return;
-	}
-	Group *cgroup = GetGroup();
-	if (cgroup == nullptr) {
-		//invalid group, not sure if we should say more...
+
+	Group *group = nullptr;
+	Raid *raid = nullptr;
+
+	if (IsRaidGrouped())
+		raid = GetRaid();
+	else if (IsGrouped())
+		group = GetGroup();
+
+	// is there an actual error message for this?
+	if (raid == nullptr && group == nullptr) {
 		Message(Chat::Red, "You can not split money if you're not in a group.");
 		return;
 	}
@@ -13345,7 +13349,11 @@ void Client::Handle_OP_Split(const EQApplicationPacket *app)
 		Message(Chat::Red, "You do not have enough money to do that split.");
 		return;
 	}
-	cgroup->SplitMoney(split->copper, split->silver, split->gold, split->platinum);
+
+	if (raid)
+		raid->SplitMoney(raid->GetGroup(this), split->copper, split->silver, split->gold, split->platinum);
+	else if (group)
+		group->SplitMoney(split->copper, split->silver, split->gold, split->platinum);
 
 	return;
 

--- a/zone/lua_raid.cpp
+++ b/zone/lua_raid.cpp
@@ -52,14 +52,14 @@ uint32 Lua_Raid::GetTotalRaidDamage(Lua_Mob other) {
 	return self->GetTotalRaidDamage(other);
 }
 
-void Lua_Raid::SplitMoney(uint32 copper, uint32 silver, uint32 gold, uint32 platinum) {
+void Lua_Raid::SplitMoney(uint32 gid, uint32 copper, uint32 silver, uint32 gold, uint32 platinum) {
 	Lua_Safe_Call_Void();
-	self->SplitMoney(copper, silver, gold, platinum);
+	self->SplitMoney(gid, copper, silver, gold, platinum);
 }
 
-void Lua_Raid::SplitMoney(uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Lua_Client splitter) {
+void Lua_Raid::SplitMoney(uint32 gid, uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Lua_Client splitter) {
 	Lua_Safe_Call_Void();
-	self->SplitMoney(copper, silver, gold, platinum, splitter);
+	self->SplitMoney(gid, copper, silver, gold, platinum, splitter);
 }
 
 void Lua_Raid::BalanceHP(int penalty, uint32 group_id) {
@@ -146,8 +146,8 @@ luabind::scope lua_register_raid() {
 		.def("GetGroup", (int(Lua_Raid::*)(Lua_Client))&Lua_Raid::GetGroup)
 		.def("SplitExp", (void(Lua_Raid::*)(uint32,Lua_Mob))&Lua_Raid::SplitExp)
 		.def("GetTotalRaidDamage", (uint32(Lua_Raid::*)(Lua_Mob))&Lua_Raid::GetTotalRaidDamage)
-		.def("SplitMoney", (void(Lua_Raid::*)(uint32,uint32,uint32,uint32))&Lua_Raid::SplitMoney)
-		.def("SplitMoney", (void(Lua_Raid::*)(uint32,uint32,uint32,uint32,Lua_Client))&Lua_Raid::SplitMoney)
+		.def("SplitMoney", (void(Lua_Raid::*)(uint32,uint32,uint32,uint32,uint32))&Lua_Raid::SplitMoney)
+		.def("SplitMoney", (void(Lua_Raid::*)(uint32,uint32,uint32,uint32,uint32,Lua_Client))&Lua_Raid::SplitMoney)
 		.def("BalanceHP", (void(Lua_Raid::*)(int,uint32))&Lua_Raid::BalanceHP)
 		.def("IsLeader", (bool(Lua_Raid::*)(const char*))&Lua_Raid::IsLeader)
 		.def("IsGroupLeader", (bool(Lua_Raid::*)(const char*))&Lua_Raid::IsGroupLeader)

--- a/zone/lua_raid.h
+++ b/zone/lua_raid.h
@@ -34,8 +34,8 @@ public:
 	int GetGroup(Lua_Client c);
 	void SplitExp(uint32 exp, Lua_Mob other);
 	uint32 GetTotalRaidDamage(Lua_Mob other);
-	void SplitMoney(uint32 copper, uint32 silver, uint32 gold, uint32 platinum);
-	void SplitMoney(uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Lua_Client splitter);
+	void SplitMoney(uint32 gid, uint32 copper, uint32 silver, uint32 gold, uint32 platinum);
+	void SplitMoney(uint32 gid, uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Lua_Client splitter);
 	void BalanceHP(int penalty, uint32 group_id);
 	bool IsLeader(const char *c);
 	bool IsLeader(Lua_Client c);

--- a/zone/perl_raids.cpp
+++ b/zone/perl_raids.cpp
@@ -247,13 +247,14 @@ XS(XS_Raid_SplitMoney); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Raid_SplitMoney) {
 	dXSARGS;
 	if (items != 5)
-		Perl_croak(aTHX_ "Usage: Raid::SplitMoney(THIS, uint32 copper, uint32 silver, uint32 gold, uint32 platinum)");
+		Perl_croak(aTHX_ "Usage: Raid::SplitMoney(THIS, uint32 gid, uint32 copper, uint32 silver, uint32 gold, uint32 platinum)");
 	{
 		Raid   *THIS;
-		uint32 copper   = (uint32) SvUV(ST(1));
-		uint32 silver   = (uint32) SvUV(ST(2));
-		uint32 gold     = (uint32) SvUV(ST(3));
-		uint32 platinum = (uint32) SvUV(ST(4));
+		uint32 gid      = (uint32) SvUV(ST(1));
+		uint32 copper   = (uint32) SvUV(ST(2));
+		uint32 silver   = (uint32) SvUV(ST(3));
+		uint32 gold     = (uint32) SvUV(ST(4));
+		uint32 platinum = (uint32) SvUV(ST(5));
 
 		if (sv_derived_from(ST(0), "Raid")) {
 			IV tmp = SvIV((SV *) SvRV(ST(0)));
@@ -263,7 +264,7 @@ XS(XS_Raid_SplitMoney) {
 		if (THIS == nullptr)
 			Perl_croak(aTHX_ "THIS is nullptr, avoiding crash.");
 
-		THIS->SplitMoney(copper, silver, gold, platinum);
+		THIS->SplitMoney(gid, copper, silver, gold, platinum);
 	}
 	XSRETURN_EMPTY;
 }
@@ -569,7 +570,7 @@ XS(boot_Raid) {
 	newXSproto(strcpy(buf, "GetGroup"), XS_Raid_GetGroup, file, "$$");
 	newXSproto(strcpy(buf, "SplitExp"), XS_Raid_SplitExp, file, "$$$");
 	newXSproto(strcpy(buf, "GetTotalRaidDamage"), XS_Raid_GetTotalRaidDamage, file, "$$");
-	newXSproto(strcpy(buf, "SplitMoney"), XS_Raid_SplitMoney, file, "$$$$$");
+	newXSproto(strcpy(buf, "SplitMoney"), XS_Raid_SplitMoney, file, "$$$$$$");
 	newXSproto(strcpy(buf, "BalanceHP"), XS_Raid_BalanceHP, file, "$$$");
 	newXSproto(strcpy(buf, "IsLeader"), XS_Raid_IsLeader, file, "$$");
 	newXSproto(strcpy(buf, "IsGroupLeader"), XS_Raid_IsGroupLeader, file, "$$");

--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -728,15 +728,20 @@ void Raid::BalanceMana(int32 penalty, uint32 gid, float range, Mob* caster, int3
 }
 
 //basically the same as Group's version just with more people like a lot of non group specific raid stuff
-void Raid::SplitMoney(uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Client *splitter){
+//this only functions if the member has a group in the raid. This does not support /autosplit?
+void Raid::SplitMoney(uint32 gid, uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Client *splitter)
+{
 	//avoid unneeded work
+	if (gid == RAID_GROUPLESS)
+		return;
+
 	if(copper == 0 && silver == 0 && gold == 0 && platinum == 0)
 		return;
 
 	uint32 i;
 	uint8 membercount = 0;
 	for (i = 0; i < MAX_RAID_MEMBERS; i++) {
-		if (members[i].member != nullptr) {
+		if (members[i].member != nullptr && members[i].GroupNumber == gid) {
 			membercount++;
 		}
 	}
@@ -809,11 +814,11 @@ void Raid::SplitMoney(uint32 copper, uint32 silver, uint32 gold, uint32 platinum
 	msg += " as your split";
 
 	for (i = 0; i < MAX_RAID_MEMBERS; i++) {
-		if (members[i].member != nullptr) { // If Group Member is Client
-		//I could not get MoneyOnCorpse to work, so we use this
-		members[i].member->AddMoneyToPP(cpsplit, spsplit, gpsplit, ppsplit, true);
+		if (members[i].member != nullptr && members[i].GroupNumber == gid) { // If Group Member is Client
+			//I could not get MoneyOnCorpse to work, so we use this
+			members[i].member->AddMoneyToPP(cpsplit, spsplit, gpsplit, ppsplit, true);
 
-		members[i].member->Message(Chat::Green, msg.c_str());
+			members[i].member->Message(Chat::Green, msg.c_str());
 		}
 	}
 }

--- a/zone/raids.h
+++ b/zone/raids.h
@@ -159,7 +159,7 @@ public:
 	void	BalanceHP(int32 penalty, uint32 gid, float range = 0, Mob* caster = nullptr, int32 limit = 0);
 	void	BalanceMana(int32 penalty, uint32 gid,  float range = 0, Mob* caster = nullptr, int32 limit = 0);
 	void	HealGroup(uint32 heal_amt, Mob* caster, uint32 gid, float range = 0);
-	void	SplitMoney(uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Client *splitter = nullptr);
+	void	SplitMoney(uint32 gid, uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Client *splitter = nullptr);
 	void	GroupBardPulse(Mob* caster, uint16 spellid, uint32 gid);
 
 	void	TeleportGroup(Mob* sender, uint32 zoneID, uint16 instance_id, float x, float y, float z, float heading, uint32 gid);


### PR DESCRIPTION
This still doesn't add support for /autosplit in a raid, how should that
work?

This changes the Raid::SplitMoney to take a group ID and fails when
provided with RAID_GROUPLESS. This does change behavior, but I'm not
sure if it was ever used so ...

Reported here: http://www.projecteq.net/forums/index.php?threads/cant-split-when-raiding.16514/#post-78810