### PR TITLE
#petsetname newname command

### DIFF
--- a/utils/sql/db_update_manifest.txt
+++ b/utils/sql/db_update_manifest.txt
@@ -406,6 +406,7 @@
 9150|2020_02_06_aa_reset_on_death.sql|SHOW COLUMNS FROM `aa_ability` LIKE 'reset_on_death'|empty|
 9151|2020_03_05_npc_always_aggro.sql|SHOW COLUMNS FROM `npc_types` LIKE 'always_aggro'|empty|
 9152|2020_03_09_convert_myisam_to_innodb.sql|SELECT * FROM db_version WHERE version >= 9152|empty|
+9153|2020_03_12_custom_pet_name.sql|SHOW COLUMNS FROM `character_pet_info` LIKE 'custompetname'|empty|
 
 # Upgrade conditions:
 # 	This won't be needed after this system is implemented, but it is used database that are not

--- a/utils/sql/git/required/2020_03_12_custom_pet_name.sql
+++ b/utils/sql/git/required/2020_03_12_custom_pet_name.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `character_pet_info` ADD COLUMN `custompetname` VARCHAR(64) NOT NULL DEFAULT '' AFTER `size`;

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -5663,7 +5663,7 @@ void Client::SuspendMinion()
 	else
 	{
 		uint16 SpellID = CurrentPet->GetPetSpellID();
-		std::string OrigName = database.GetOriginalPetName(0, this->character_id);
+		std::string original_name = database.GetOriginalPetName(0, this->character_id);
 		if (SpellID)
 		{
 			if (m_suspendedminion.SpellID > 0)
@@ -5694,7 +5694,7 @@ void Client::SuspendMinion()
 					CurrentPet->GetPetState(m_suspendedminion.Buffs, m_suspendedminion.Items, m_suspendedminion.Name);
 				}
 
-				strn0cpy(m_suspendedminion.Name, OrigName.c_str(), 64);
+				strn0cpy(m_suspendedminion.Name, original_name.c_str(), 64);
 				MessageString(Chat::Magenta, SUSPEND_MINION_SUSPEND, CurrentPet->GetCleanName());
 
 				CurrentPet->Depop(false);

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -5599,15 +5599,15 @@ void Client::SuspendMinion()
 
 	int AALevel = GetAA(aaSuspendedMinion);
 
-	if(AALevel == 0)
+	if (AALevel == 0)
 		return;
 
-	if(GetLevel() < 62)
+	if (GetLevel() < 62)
 		return;
 
-	if(!CurrentPet)
+	if (!CurrentPet)
 	{
-		if(m_suspendedminion.SpellID > 0)
+		if (m_suspendedminion.SpellID > 0)
 		{
 			if (m_suspendedminion.SpellID >= SPDAT_RECORDS) {
 				Message(Chat::Red, "Invalid suspended minion spell id (%u).", m_suspendedminion.SpellID);
@@ -5620,13 +5620,13 @@ void Client::SuspendMinion()
 
 			CurrentPet = GetPet()->CastToNPC();
 
-			if(!CurrentPet)
+			if (!CurrentPet)
 			{
 				Message(Chat::Red, "Failed to recall suspended minion.");
 				return;
 			}
 
-			if(AALevel >= 2)
+			if (AALevel >= 2)
 			{
 				CurrentPet->SetPetState(m_suspendedminion.Buffs, m_suspendedminion.Items);
 
@@ -5664,23 +5664,23 @@ void Client::SuspendMinion()
 	{
 		uint16 SpellID = CurrentPet->GetPetSpellID();
 		std::string OrigName = database.GetOriginalPetName(0, this->character_id);
-		if(SpellID)
+		if (SpellID)
 		{
-			if(m_suspendedminion.SpellID > 0)
+			if (m_suspendedminion.SpellID > 0)
 			{
-				MessageString(Chat::Red,ONLY_ONE_PET);
+				MessageString(Chat::Red, ONLY_ONE_PET);
 
 				return;
 			}
-			else if(CurrentPet->IsEngaged())
+			else if (CurrentPet->IsEngaged())
 			{
-				MessageString(Chat::Red,SUSPEND_MINION_FIGHTING);
+				MessageString(Chat::Red, SUSPEND_MINION_FIGHTING);
 
 				return;
 			}
-			else if(entity_list.Fighting(CurrentPet))
+			else if (entity_list.Fighting(CurrentPet))
 			{
-				MessageString(Chat::Blue,SUSPEND_MINION_HAS_AGGRO);
+				MessageString(Chat::Blue, SUSPEND_MINION_HAS_AGGRO);
 			}
 			else
 			{
@@ -5693,7 +5693,7 @@ void Client::SuspendMinion()
 				if (AALevel >= 2) {
 					CurrentPet->GetPetState(m_suspendedminion.Buffs, m_suspendedminion.Items, m_suspendedminion.Name);
 				}
-				
+
 				strn0cpy(m_suspendedminion.Name, OrigName.c_str(), 64);
 				MessageString(Chat::Magenta, SUSPEND_MINION_SUSPEND, CurrentPet->GetCleanName());
 
@@ -5709,8 +5709,8 @@ void Client::SuspendMinion()
 			return;
 		}
 	}
-		//get db and struct in sync.
-		if (GetPet() && GetPet()->CastToNPC()->GetPetSpellID() && !dead) {
+	//get db and struct in sync.
+	if (GetPet() && GetPet()->CastToNPC()->GetPetSpellID() && !dead) {
 		NPC * pet = GetPet()->CastToNPC();
 		m_petinfo.SpellID = pet->CastToNPC()->GetPetSpellID();
 		m_petinfo.HP = pet->GetHP();

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -5663,7 +5663,7 @@ void Client::SuspendMinion()
 	else
 	{
 		uint16 SpellID = CurrentPet->GetPetSpellID();
-
+		std::string OrigName = database.GetOriginalPetName(0, this->character_id);
 		if(SpellID)
 		{
 			if(m_suspendedminion.SpellID > 0)
@@ -5685,18 +5685,16 @@ void Client::SuspendMinion()
 			else
 			{
 				m_suspendedminion.SpellID = SpellID;
-
 				m_suspendedminion.HP = CurrentPet->GetHP();;
-
 				m_suspendedminion.Mana = CurrentPet->GetMana();
 				m_suspendedminion.petpower = CurrentPet->GetPetPower();
 				m_suspendedminion.size = CurrentPet->GetSize();
 
-				if(AALevel >= 2)
+				if (AALevel >= 2) {
 					CurrentPet->GetPetState(m_suspendedminion.Buffs, m_suspendedminion.Items, m_suspendedminion.Name);
-				else
-					strn0cpy(m_suspendedminion.Name, CurrentPet->GetName(), 64); // Name stays even at rank 1
-
+				}
+				
+				strn0cpy(m_suspendedminion.Name, OrigName.c_str(), 64);
 				MessageString(Chat::Magenta, SUSPEND_MINION_SUSPEND, CurrentPet->GetCleanName());
 
 				CurrentPet->Depop(false);
@@ -5711,6 +5709,20 @@ void Client::SuspendMinion()
 			return;
 		}
 	}
+		//get db and struct in sync.
+		if (GetPet() && GetPet()->CastToNPC()->GetPetSpellID() && !dead) {
+		NPC * pet = GetPet()->CastToNPC();
+		m_petinfo.SpellID = pet->CastToNPC()->GetPetSpellID();
+		m_petinfo.HP = pet->GetHP();
+		m_petinfo.Mana = pet->GetMana();
+		pet->GetPetState(m_petinfo.Buffs, m_petinfo.Items, m_petinfo.Name);
+		m_petinfo.petpower = pet->GetPetPower();
+		m_petinfo.size = pet->GetSize();
+	}
+	else {
+		memset(&m_petinfo, 0, sizeof(struct PetInfo));
+	}
+	database.SavePetInfo(this);
 }
 
 void Client::AddPVPPoints(uint32 Points)

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -10127,8 +10127,10 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 
 		mypet->SayString(this, Chat::PetResponse, PET_GETLOST_STRING);
 		mypet->CastToNPC()->Depop();
+		this->Save(1);
 
 		//Oddly, the client (Titanium) will still allow "/pet get lost" command despite me adding the code below. If someone can figure that out, you can uncomment this code and use it.
+		// on live since aa merging to companions discipline /pet get lost is available without any aa requirement.
 		/*
 		if((mypet->GetPetType() == petAnimation && GetAA(aaAnimationEmpathy) >= 2) || mypet->GetPetType() != petAnimation) {
 		mypet->SayString(PET_GETLOST_STRING);

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -309,7 +309,7 @@ int command_init(void)
 		command_add("path", "- view and edit pathing", 200, command_path) ||
 		command_add("peekinv", "[equip/gen/cursor/poss/limbo/curlim/trib/bank/shbank/allbank/trade/world/all] - Print out contents of your player target's inventory", 100, command_peekinv) ||
 		command_add("petname", "[newname] - Temporarily renames your pet. Leave name blank to restore the original name.", 100, command_petname) ||
-		command_add("petsetname", "[newname] - Sets a persistent name for your pet. Leave name portion blank to restore the original generated names.", 0, command_petsetname) ||
+		command_add("petsetname", "[newname] - Sets a persistent name for your pet. Leave name portion blank to restore the original generated names.", 100, command_petsetname) ||
 		command_add("peqzone", "[zonename] - Go to specified zone, if you have > 75% health", 0, command_peqzone) ||
 		command_add("permaclass", "[classnum] - Change your or your player target's class (target is disconnected)", 80, command_permaclass) ||
 		command_add("permagender", "[gendernum] - Change your or your player target's gender (zone to take effect)", 80, command_permagender) ||

--- a/zone/command.h
+++ b/zone/command.h
@@ -306,6 +306,7 @@ void command_task(Client *c, const Seperator *sep);
 void command_tattoo(Client *c, const Seperator *sep);
 void command_tempname(Client *c, const Seperator *sep);
 void command_petname(Client *c, const Seperator *sep);
+void command_petsetname(Client *c, const Seperator *sep);
 void command_test(Client *c, const Seperator *sep);
 void command_testspawn(Client *c, const Seperator *sep);
 void command_testspawnkill(Client *c, const Seperator *sep);

--- a/zone/pets.cpp
+++ b/zone/pets.cpp
@@ -186,9 +186,9 @@ void Mob::MakePet(uint16 spell_id, const char* pettype, const char *petname) {
 // stay equipped when the character zones. petpower of -1 means that the currently equipped petfocus
 // of a client is searched for and used instead.
 void Mob::MakePoweredPet(uint16 spell_id, const char* pettype, int16 petpower,
-		const char *petname, float in_size) {
+	const char *petname, float in_size) {
 	// Sanity and early out checking first.
-	if(HasPet() || pettype == nullptr)
+	if (HasPet() || pettype == nullptr)
 		return;
 
 	int16 act_power = 0; // The actual pet power we'll use.
@@ -211,7 +211,7 @@ void Mob::MakePoweredPet(uint16 spell_id, const char* pettype, int16 petpower,
 
 	//lookup our pets table record for this type
 	PetRecord record;
-	if(!database.GetPoweredPetEntry(pettype, act_power, &record)) {
+	if (!database.GetPoweredPetEntry(pettype, act_power, &record)) {
 		Message(Chat::Red, "Unable to find data for pet %s", pettype);
 		LogError("Unable to find data for pet [{}], check pets table", pettype);
 		return;
@@ -219,7 +219,7 @@ void Mob::MakePoweredPet(uint16 spell_id, const char* pettype, int16 petpower,
 
 	//find the NPC data for the specified NPC type
 	const NPCType *base = database.LoadNPCTypesData(record.npc_type);
-	if(base == nullptr) {
+	if (base == nullptr) {
 		Message(Chat::Red, "Unable to load NPC data for pet %s", pettype);
 		LogError("Unable to load NPC data for pet [{}] (NPC ID [{}]), check pets and npc_types tables", pettype, record.npc_type);
 		return;
@@ -230,14 +230,14 @@ void Mob::MakePoweredPet(uint16 spell_id, const char* pettype, int16 petpower,
 	memcpy(npc_type, base, sizeof(NPCType));
 
 	// If pet power is set to -1 in the DB, use stat scaling
-	if ((this->IsClient() 
+	if ((this->IsClient()
 #ifdef BOTS
 		|| this->IsBot()
 #endif
 		) && record.petpower == -1)
 	{
 		float scale_power = (float)act_power / 100.0f;
-		if(scale_power > 0)
+		if (scale_power > 0)
 		{
 			npc_type->max_hp *= (1 + scale_power);
 			npc_type->current_hp = npc_type->max_hp;
@@ -245,7 +245,7 @@ void Mob::MakePoweredPet(uint16 spell_id, const char* pettype, int16 petpower,
 			npc_type->level += 1 + ((int)act_power / 25) > npc_type->level + RuleR(Pets, PetPowerLevelCap) ? RuleR(Pets, PetPowerLevelCap) : 1 + ((int)act_power / 25); // gains an additional level for every 25 pet power
 			npc_type->min_dmg = (npc_type->min_dmg * (1 + (scale_power / 2)));
 			npc_type->max_dmg = (npc_type->max_dmg * (1 + (scale_power / 2)));
-			npc_type->size = npc_type->size * (1 + (scale_power / 2)) > npc_type->size * 3 ? npc_type->size * 3 : npc_type-> size * (1 + (scale_power / 2));
+			npc_type->size = npc_type->size * (1 + (scale_power / 2)) > npc_type->size * 3 ? npc_type->size * 3 : npc_type->size * (1 + (scale_power / 2));
 		}
 		record.petpower = act_power;
 	}
@@ -253,8 +253,8 @@ void Mob::MakePoweredPet(uint16 spell_id, const char* pettype, int16 petpower,
 	//Live AA - Elemental Durability
 	int16 MaxHP = aabonuses.PetMaxHP + itembonuses.PetMaxHP + spellbonuses.PetMaxHP;
 
-	if (MaxHP){
-		npc_type->max_hp += (npc_type->max_hp*MaxHP)/100;
+	if (MaxHP) {
+		npc_type->max_hp += (npc_type->max_hp*MaxHP) / 100;
 		npc_type->current_hp = npc_type->max_hp;
 	}
 
@@ -272,36 +272,43 @@ void Mob::MakePoweredPet(uint16 spell_id, const char* pettype, int16 petpower,
 	if (petname != nullptr) {
 		// Name was provided, use it.
 		strn0cpy(npc_type->name, petname, 64);
-	} else if (record.petnaming == 0) {
+	}
+	else if (record.petnaming == 0) {
 		strcpy(npc_type->name, this->GetCleanName());
 		npc_type->name[25] = '\0';
 		strcat(npc_type->name, "`s_pet");
-	} else if (record.petnaming == 1) {
+	}
+	else if (record.petnaming == 1) {
 		strcpy(npc_type->name, this->GetName());
 		npc_type->name[19] = '\0';
 		strcat(npc_type->name, "`s_familiar");
-	} else if (record.petnaming == 2) {
+	}
+	else if (record.petnaming == 2) {
 		strcpy(npc_type->name, this->GetName());
 		npc_type->name[21] = 0;
 		strcat(npc_type->name, "`s_Warder");
-	} else if (record.petnaming == 4) {
+	}
+	else if (record.petnaming == 4) {
 		// Keep the DB name
-	} else if (record.petnaming == 3 && IsClient()) {
+	}
+	else if (record.petnaming == 3 && IsClient()) {
 		GetRandPetName(npc_type->name);
-	} else if (record.petnaming == 5 && IsClient()) {
+	}
+	else if (record.petnaming == 5 && IsClient()) {
 		strcpy(npc_type->name, this->GetName());
 		npc_type->name[24] = '\0';
 		strcat(npc_type->name, "`s_ward");
-	} else {
+	}
+	else {
 		strcpy(npc_type->name, this->GetCleanName());
 		npc_type->name[25] = '\0';
 		strcat(npc_type->name, "`s_pet");
 	}
 
 	//handle beastlord pet appearance
-	if(record.petnaming == 2)
+	if (record.petnaming == 2)
 	{
-		switch(GetBaseRace())
+		switch (GetBaseRace())
 		{
 		case VAHSHIR:
 			npc_type->race = TIGER;
@@ -334,20 +341,20 @@ void Mob::MakePoweredPet(uint16 spell_id, const char* pettype, int16 petpower,
 	}
 
 	// handle monster summoning pet appearance
-	if(record.monsterflag) {
+	if (record.monsterflag) {
 
 		uint32 monsterid = 0;
 
 		// get a random npc id from the spawngroups assigned to this zone
 		auto query = StringFormat("SELECT npcID "
-									"FROM (spawnentry INNER JOIN spawn2 ON spawn2.spawngroupID = spawnentry.spawngroupID) "
-									"INNER JOIN npc_types ON npc_types.id = spawnentry.npcID "
-									"WHERE spawn2.zone = '%s' AND npc_types.bodytype NOT IN (11, 33, 66, 67) "
-									"AND npc_types.race NOT IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 44, "
-									"55, 67, 71, 72, 73, 77, 78, 81, 90, 92, 93, 94, 106, 112, 114, 127, 128, "
-									"130, 139, 141, 183, 236, 237, 238, 239, 254, 266, 329, 330, 378, 379, "
-									"380, 381, 382, 383, 404, 522) "
-									"ORDER BY RAND() LIMIT 1", zone->GetShortName());
+			"FROM (spawnentry INNER JOIN spawn2 ON spawn2.spawngroupID = spawnentry.spawngroupID) "
+			"INNER JOIN npc_types ON npc_types.id = spawnentry.npcID "
+			"WHERE spawn2.zone = '%s' AND npc_types.bodytype NOT IN (11, 33, 66, 67) "
+			"AND npc_types.race NOT IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 44, "
+			"55, 67, 71, 72, 73, 77, 78, 81, 90, 92, 93, 94, 106, 112, 114, 127, 128, "
+			"130, 139, 141, 183, 236, 237, 238, 239, 254, 266, 329, 330, 378, 379, "
+			"380, 381, 382, 383, 404, 522) "
+			"ORDER BY RAND() LIMIT 1", zone->GetShortName());
 		auto results = database.QueryDatabase(query);
 		if (!results.Success()) {
 			safe_delete(npc_type);
@@ -365,7 +372,7 @@ void Mob::MakePoweredPet(uint16 spell_id, const char* pettype, int16 petpower,
 
 		// give the summoned pet the attributes of the monster we found
 		const NPCType* monster = database.LoadNPCTypesData(monsterid);
-		if(monster) {
+		if (monster) {
 			npc_type->race = monster->race;
 			npc_type->size = monster->size;
 			npc_type->texture = monster->texture;
@@ -373,7 +380,8 @@ void Mob::MakePoweredPet(uint16 spell_id, const char* pettype, int16 petpower,
 			npc_type->luclinface = monster->luclinface;
 			npc_type->helmtexture = monster->helmtexture;
 			npc_type->herosforgemodel = monster->herosforgemodel;
-		} else
+		}
+		else
 			LogError("Error loading NPC data for monster summoning pet (NPC ID [{}])", monsterid);
 
 	}
@@ -405,8 +413,8 @@ void Mob::MakePoweredPet(uint16 spell_id, const char* pettype, int16 petpower,
 
 	entity_list.AddNPC(npc, true, true);
 	SetPetID(npc->GetID());
-	
-	
+
+
 	if (this->IsClient()) {
 		// save updated clients petinfo
 		this->CastToClient()->Save(1);
@@ -418,22 +426,23 @@ void Mob::MakePoweredPet(uint16 spell_id, const char* pettype, int16 petpower,
 		{
 			npc->TempName(customName.c_str());
 		}
-
-		// We need to handle PetType 5 (petHatelist), add the current target to the hatelist of the pet
-
-		if (record.petcontrol == petTargetLock)
-		{
-			Mob* target = GetTarget();
-
-			if (target) {
-				npc->AddToHateList(target, 1);
-				npc->SetPetTargetLockID(target->GetID());
-				npc->SetSpecialAbility(IMMUNE_AGGRO, 1);
-			}
-			else
-				npc->Kill(); //On live casts spell 892 Unsummon (Kayen - Too limiting to use that for emu since pet can have more than 20k HP)
-		}
 	}
+	// We need to handle PetType 5 (petHatelist), add the current target to the hatelist of the pet
+
+	if (record.petcontrol == petTargetLock)
+	{
+		Mob* target = GetTarget();
+
+		if (target) {
+			npc->AddToHateList(target, 1);
+			npc->SetPetTargetLockID(target->GetID());
+			npc->SetSpecialAbility(IMMUNE_AGGRO, 1);
+		}
+		else
+			npc->Kill(); //On live casts spell 892 Unsummon (Kayen - Too limiting to use that for emu since pet can have more than 20k HP)
+	}
+}
+
 /* This is why the pets ghost - pets were being spawned too far away from its npc owner and some
 into walls or objects (+10), this sometimes creates the "ghost" effect. I changed to +2 (as close as I
 could get while it still looked good). I also noticed this can happen if an NPC is spawned on the same spot of another or in a related bad spot.*/

--- a/zone/pets.cpp
+++ b/zone/pets.cpp
@@ -405,6 +405,19 @@ void Mob::MakePoweredPet(uint16 spell_id, const char* pettype, int16 petpower,
 
 	entity_list.AddNPC(npc, true, true);
 	SetPetID(npc->GetID());
+	// save updated clients petinfo
+	this->CastToClient()->Save(1);
+	//to then update name if custom is set
+	if (this->IsClient()) {
+		uint32 charid = this->CastToClient()->CharacterID();
+		std::string customName = charid == 0 ? "" : database.GetCustomPetName(charid);
+		if (customName.length() > 3)
+		{
+			npc->TempName(customName.c_str());
+		}
+	}
+
+
 	// We need to handle PetType 5 (petHatelist), add the current target to the hatelist of the pet
 
 

--- a/zone/pets.cpp
+++ b/zone/pets.cpp
@@ -405,35 +405,35 @@ void Mob::MakePoweredPet(uint16 spell_id, const char* pettype, int16 petpower,
 
 	entity_list.AddNPC(npc, true, true);
 	SetPetID(npc->GetID());
-	// save updated clients petinfo
-	this->CastToClient()->Save(1);
-	//to then update name if custom is set
+	
+	
 	if (this->IsClient()) {
+		// save updated clients petinfo
+		this->CastToClient()->Save(1);
+
+		//to then update name if custom is set
 		uint32 charid = this->CastToClient()->CharacterID();
 		std::string customName = charid == 0 ? "" : database.GetCustomPetName(charid);
 		if (customName.length() > 3)
 		{
 			npc->TempName(customName.c_str());
 		}
-	}
 
+		// We need to handle PetType 5 (petHatelist), add the current target to the hatelist of the pet
 
-	// We need to handle PetType 5 (petHatelist), add the current target to the hatelist of the pet
+		if (record.petcontrol == petTargetLock)
+		{
+			Mob* target = GetTarget();
 
-
-	if (record.petcontrol == petTargetLock)
-	{
-		Mob* target = GetTarget();
-
-		if (target){
-			npc->AddToHateList(target, 1);
-			npc->SetPetTargetLockID(target->GetID());
-			npc->SetSpecialAbility(IMMUNE_AGGRO, 1);
+			if (target) {
+				npc->AddToHateList(target, 1);
+				npc->SetPetTargetLockID(target->GetID());
+				npc->SetSpecialAbility(IMMUNE_AGGRO, 1);
+			}
+			else
+				npc->Kill(); //On live casts spell 892 Unsummon (Kayen - Too limiting to use that for emu since pet can have more than 20k HP)
 		}
-		else
-			npc->Kill(); //On live casts spell 892 Unsummon (Kayen - Too limiting to use that for emu since pet can have more than 20k HP)
 	}
-}
 /* This is why the pets ghost - pets were being spawned too far away from its npc owner and some
 into walls or objects (+10), this sometimes creates the "ghost" effect. I changed to +2 (as close as I
 could get while it still looked good). I also noticed this can happen if an NPC is spawned on the same spot of another or in a related bad spot.*/

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -3771,14 +3771,14 @@ void ZoneDatabase::SavePetInfo(Client *client)
 		if (!petinfo)
 			continue;
 		
-		std::string Orig = GetOriginalPetName(pet,client->CharacterID());
-		if (Orig == "") 
+		std::string original_name = GetOriginalPetName(pet,client->CharacterID());
+		if (original_name.empty())
 		{
-			Orig = petinfo->Name; 
+			original_name = petinfo->Name;
 		}
 
 		if (petinfo->SpellID == 0) { //got here from  /pet getlost
-			Orig = "";
+			original_name = "";
 		}
 
 		query = StringFormat("INSERT INTO `character_pet_info` "
@@ -3786,9 +3786,9 @@ void ZoneDatabase::SavePetInfo(Client *client)
 				"VALUES (%u, %u, '%s', %i, %u, %u, %u, %f) "
 				"ON DUPLICATE KEY UPDATE `petname` = '%s', `petpower` = %i, `spell_id` = %u, "
 				"`hp` = %u, `mana` = %u, `size` = %f",
-				client->CharacterID(), pet, Orig.c_str(), petinfo->petpower, petinfo->SpellID,
+				client->CharacterID(), pet, original_name.c_str(), petinfo->petpower, petinfo->SpellID,
 				petinfo->HP, petinfo->Mana, petinfo->size, // and now the ON DUPLICATE ENTRIES
-			Orig.c_str(), petinfo->petpower, petinfo->SpellID, petinfo->HP, petinfo->Mana, petinfo->size);
+			original_name.c_str(), petinfo->petpower, petinfo->SpellID, petinfo->HP, petinfo->Mana, petinfo->size);
 		results = database.QueryDatabase(query);
 		if (!results.Success())
 			return;

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -451,6 +451,8 @@ public:
 	bool		SetSpecialAttkFlag(uint8 id, const char* flag);
 	bool		GetPetEntry(const char *pet_type, PetRecord *into);
 	bool		GetPoweredPetEntry(const char *pet_type, int16 petpower, PetRecord *into);
+	std::string GetCustomPetName(uint32 char_id);
+	std::string GetOriginalPetName(int petid, uint32 char_id);
 	bool		GetBasePetItems(int32 equipmentset, uint32 *items);
 	void		AddLootTableToNPC(NPC* npc, uint32 loottable_id, ItemList* itemlist, uint32* copper, uint32* silver, uint32* gold, uint32* plat);
 	void		AddLootDropToNPC(NPC* npc, uint32 lootdrop_id, ItemList* itemlist, uint8 droplimit, uint8 mindrop);


### PR DESCRIPTION
#petsetname [newname] to set a persistent name , or command by itself to revert to generated name.

zoning/camping/death/new pet etc retain custom name until its cleared.
Suspended pets get custom name upon unsuspending. 
When pet is initially created the original generated name stays in place, with new name being stored in a separate field on pet[0]

left temp version #petname in place for now.