### PR TITLE
Rewrite how zone finds ports

### DIFF
--- a/common/event/event_loop.h
+++ b/common/event/event_loop.h
@@ -25,6 +25,10 @@ namespace EQ
 			uv_run(&m_loop, UV_RUN_DEFAULT);
 		}
 
+		void Shutdown() {
+			uv_stop(&m_loop);
+		}
+
 		uv_loop_t* Handle() { return &m_loop; }
 
 	private:

--- a/world/main.cpp
+++ b/world/main.cpp
@@ -415,6 +415,7 @@ int main(int argc, char** argv) {
 		RegisterConsoleFunctions(console);
 	}
 
+	zoneserver_list.Init();
 	std::unique_ptr<EQ::Net::ServertalkServer> server_connection;
 	server_connection.reset(new EQ::Net::ServertalkServer());
 

--- a/world/zonelist.cpp
+++ b/world/zonelist.cpp
@@ -39,7 +39,6 @@ ZSList::ZSList()
 {
 	NextID = 1;
 	CurGroupID = 1;
-	LastAllocatedPort = 0;
 	memset(pLockedZones, 0, sizeof(pLockedZones));
 
 	m_tick.reset(new EQ::Timer(5000, true, std::bind(&ZSList::OnTick, this, std::placeholders::_1)));
@@ -76,7 +75,12 @@ void ZSList::Remove(const std::string &uuid)
 	auto iter = zone_server_list.begin();
 	while (iter != zone_server_list.end()) {
 		if ((*iter)->GetUUID().compare(uuid) == 0) {
+			auto port = (*iter)->GetCPort();
 			zone_server_list.erase(iter);
+
+			if (port != 0) {
+				m_ports_free.push_back(port);
+			}
 			return;
 		}
 		iter++;
@@ -237,6 +241,14 @@ bool ZSList::SetLockedZone(uint16 iZoneID, bool iLock) {
 		}
 	}
 	return false;
+}
+
+void ZSList::Init()
+{
+	const WorldConfig* Config = WorldConfig::get();
+	for (uint16 i = Config->ZonePortLow; i <= Config->ZonePortHigh; ++i) {
+		m_ports_free.push_back(i);
+	}
 }
 
 bool ZSList::IsZoneLocked(uint16 iZoneID) {
@@ -577,30 +589,15 @@ void ZSList::RebootZone(const char* ip1, uint16 port, const char* ip2, uint32 sk
 	safe_delete_array(tmp);
 }
 
-uint16	ZSList::GetAvailableZonePort()
+uint16 ZSList::GetAvailableZonePort()
 {
-	const WorldConfig *Config = WorldConfig::get();
-	int i;
-	uint16 port = 0;
-
-	if (LastAllocatedPort == 0)
-		i = Config->ZonePortLow;
-	else
-		i = LastAllocatedPort + 1;
-
-	while (i != LastAllocatedPort && port == 0) {
-		if (i>Config->ZonePortHigh)
-			i = Config->ZonePortLow;
-
-		if (!FindByPort(i)) {
-			port = i;
-			break;
-		}
-		i++;
+	if (m_ports_free.empty()) {
+		return 0;
 	}
-	LastAllocatedPort = port;
 
-	return port;
+	auto first = m_ports_free.front();
+	m_ports_free.pop_front();
+	return first;
 }
 
 uint32 ZSList::TriggerBootup(uint32 iZoneID, uint32 iInstanceID) {

--- a/world/zonelist.h
+++ b/world/zonelist.h
@@ -7,6 +7,7 @@
 #include "../common/event/timer.h"
 #include <vector>
 #include <memory>
+#include <deque>
 
 class WorldTCPConnection;
 class ServerPacket;
@@ -22,6 +23,7 @@ public:
 	ZSList();
 	~ZSList();
 
+	void Init();
 	bool IsZoneLocked(uint16 iZoneID);
 	bool SendPacket(ServerPacket *pack);
 	bool SendPacket(uint32 zoneid, ServerPacket *pack);
@@ -73,8 +75,7 @@ private:
 	uint32 NextID;
 	uint16	pLockedZones[MaxLockedZones];
 	uint32 CurGroupID;
-	uint16 LastAllocatedPort;
-
+	std::deque<uint16> m_ports_free;
 	std::unique_ptr<EQ::Timer> m_tick;
 	std::unique_ptr<EQ::Timer> m_keepalive;
 

--- a/zone/main.cpp
+++ b/zone/main.cpp
@@ -92,7 +92,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include "../common/unix.h"
 #endif
 
-volatile bool RunLoops = true;
 extern volatile bool is_zone_loaded;
 
 EntityList entity_list;
@@ -577,19 +576,19 @@ int main(int argc, char** argv) {
 	return 0;
 }
 
+void Shutdown()
+{
+	Zone::Shutdown(true);
+	LogInfo("Shutting down...");
+	LogSys.CloseFileLogs();
+	EQ::EventLoop::Get().Shutdown();
+}
+
 void CatchSignal(int sig_num) {
 #ifdef _WINDOWS
 	LogInfo("Recieved signal: [{}]", sig_num);
 #endif
-	RunLoops = false;
-}
-
-void Shutdown()
-{
-	Zone::Shutdown(true);
-	RunLoops = false;
-	LogInfo("Shutting down...");
-	LogSys.CloseFileLogs();
+	Shutdown();
 }
 
 /* Update Window Title with relevant information */


### PR DESCRIPTION
Changes:
-World will no longer loop to find a port which should fix the situation where if you have more zones than your port range can handle your world server gets stuck in an infinite loop.
-Fixes the shutdown command in zone that was broken back when we changed how the zone loop behaves.