### PR TITLE
Added proximity check for feared clients

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -161,6 +161,7 @@ RULE_BOOL(Character, DismountWater, true, "Dismount horses when entering water")
 RULE_BOOL(Character, UseNoJunkFishing, false, "Disregards junk items when fishing")
 RULE_BOOL(Character, SoftDeletes, true, "When characters are deleted in character select, they are only soft deleted")
 RULE_INT(Character, DefaultGuild, 0, "If not 0, new characters placed into the guild # indicated")
+RULE_BOOL(Character, ProcessFearedProximity, true, "Processes proximity checks when feared")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Mercs)

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -747,6 +747,13 @@ void Client::AI_Process()
 						RunTo(m_FearWalkTarget.x, m_FearWalkTarget.y, m_FearWalkTarget.z);
 					}
 				}
+				if (RuleB(Character, ProcessFearedProximity) && proximity_timer.Check()) {
+					entity_list.ProcessMove(this, glm::vec3(GetX(), GetY(), GetZ()));
+					if (RuleB(TaskSystem, EnableTaskSystem) && RuleB(TaskSystem, EnableTaskProximity))
+						ProcessTaskProximities(GetX(), GetY(), GetZ());
+
+					m_Proximity = glm::vec3(GetX(), GetY(), GetZ());
+				}
 				return;
 			}
 


### PR DESCRIPTION
@Uleat made these changes so that a feared entity can still trigger proximity events.  I've tested this since 3/18 and its working great for me.