### PR TITLE
Propose change in location of Stun check as possible resolution to crash

### DIFF
--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -694,11 +694,6 @@ void NPC::RemoveCash() {
 
 bool NPC::Process()
 {
-	if (IsStunned() && stunned_timer.Check()) {
-		Mob::UnStun();
-		this->spun_timer.Disable();
-	}
-
 	if (p_depop)
 	{
 		Mob* owner = entity_list.GetMob(this->ownerid);
@@ -710,6 +705,11 @@ bool NPC::Process()
 			this->petid = 0;
 		}
 		return false;
+	}
+	
+	if (IsStunned() && stunned_timer.Check()) {
+		Mob::UnStun();
+		this->spun_timer.Disable();
 	}
 
 	SpellProcess();


### PR DESCRIPTION
@KinglyKrab was telling me about a very sporadic crash he is seeing.  He dropped me this stack trace:

[04-03-2020 :: 23:15:28] [Crash] #4  0x00005583db08437f in Mob::AI_Process (this=0x5583ddcdbd00) at /home/eqemu/code/zone/mob_ai.cpp:1083
[04-03-2020 :: 23:15:28] [Crash] #5  0x00005583db0a1bb4 in NPC::Process (this=0x5583ddcdbd00) at /home/eqemu/code/zone/npc.cpp:908
[04-05-2020 :: 19:41:40] [Crash] #6  0x0000560d7e41d014 in EntityList::MobProcess (this=this@entry=0x560d7ebb83e0 <entity_list>) at /home/eqemu/code/zone/entity.cpp:506
[04-05-2020 :: 19:41:40] [Crash] #7  0x0000560d7e5d5d78 in <lambda(EQ::Timer*)>::operator()(EQ::Timer *) const (__closure=0x560d80866fb0, t=<optimized out>) at /home/eqemu/code/zone/main.cpp:526

My best guess is a mob that has p_depop set to true is trying to process a timer at the top of NPC::Process().  I don't fully understand the depop mechanism across all the code, but I don't see any harm in moving this timer check under the check for depop, and if there was something already freed up based on depop, this might fix the issue.

Up to you guys, just trying to help him figure out this crash and this change seemed in the right ballpark given the stack trace, and seems correct anyway.,