### PR TITLE
UCS / Raid / Zone Fixes

### DIFF
--- a/ucs/chatchannel.cpp
+++ b/ucs/chatchannel.cpp
@@ -47,8 +47,13 @@ ChatChannel::ChatChannel(std::string inName, std::string inOwner, std::string in
 
 	Moderated = false;
 
-	LogInfo("New ChatChannel created: Name: [[{}]], Owner: [[{}]], Password: [[{}]], MinStatus: [{}]",
-		Name.c_str(), Owner.c_str(), Password.c_str(), MinimumStatus);
+	LogDebug(
+		"New ChatChannel created: Name: [[{}]], Owner: [[{}]], Password: [[{}]], MinStatus: [{}]",
+		Name.c_str(),
+		Owner.c_str(),
+		Password.c_str(),
+		MinimumStatus
+	);
 
 }
 
@@ -154,7 +159,7 @@ void ChatChannelList::SendAllChannels(Client *c) {
 
 void ChatChannelList::RemoveChannel(ChatChannel *Channel) {
 
-	LogInfo("RemoveChannel([{}])", Channel->GetName().c_str());
+	LogDebug("RemoveChannel ([{}])", Channel->GetName().c_str());
 
 	LinkedListIterator<ChatChannel*> iterator(ChatChannels);
 
@@ -175,7 +180,7 @@ void ChatChannelList::RemoveChannel(ChatChannel *Channel) {
 
 void ChatChannelList::RemoveAllChannels() {
 
-	LogInfo("RemoveAllChannels");
+	LogDebug("RemoveAllChannels");
 
 	LinkedListIterator<ChatChannel*> iterator(ChatChannels);
 
@@ -242,7 +247,7 @@ void ChatChannel::AddClient(Client *c) {
 
 	int AccountStatus = c->GetAccountStatus();
 
-	LogInfo("Adding [{}] to channel [{}]", c->GetName().c_str(), Name.c_str());
+	LogDebug("Adding [{}] to channel [{}]", c->GetName().c_str(), Name.c_str());
 
 	LinkedListIterator<Client*> iterator(ClientsInChannel);
 
@@ -267,7 +272,7 @@ bool ChatChannel::RemoveClient(Client *c) {
 
 	if(!c) return false;
 
-	LogInfo("RemoveClient [{}] from channel [{}]", c->GetName().c_str(), GetName().c_str());
+	LogDebug("RemoveClient [{}] from channel [{}]", c->GetName().c_str(), GetName().c_str());
 
 	bool HideMe = c->GetHideMe();
 
@@ -304,7 +309,7 @@ bool ChatChannel::RemoveClient(Client *c) {
 		if((Password.length() == 0) || (RuleI(Channels, DeleteTimer) == 0))
 			return false;
 
-		LogInfo("Starting delete timer for empty password protected channel [{}]", Name.c_str());
+		LogDebug("Starting delete timer for empty password protected channel [{}]", Name.c_str());
 
 		DeleteTimer.Start(RuleI(Channels, DeleteTimer) * 60000);
 	}
@@ -402,7 +407,7 @@ void ChatChannel::SendMessageToChannel(std::string Message, Client* Sender) {
 
 		if(ChannelClient)
 		{
-			LogInfo("Sending message to [{}] from [{}]",
+			LogDebug("Sending message to [{}] from [{}]",
 				ChannelClient->GetName().c_str(), Sender->GetName().c_str());
 
 			if (cv_messages[static_cast<uint32>(ChannelClient->GetClientVersion())].length() == 0) {
@@ -505,7 +510,7 @@ ChatChannel *ChatChannelList::AddClientToChannel(std::string ChannelName, Client
 		return nullptr;
 	}
 
-	LogInfo("AddClient to channel [[{}]] with password [[{}]]", NormalisedName.c_str(), Password.c_str());
+	LogDebug("AddClient to channel [[{}]] with password [[{}]]", NormalisedName.c_str(), Password.c_str());
 
 	ChatChannel *RequiredChannel = FindChannel(NormalisedName);
 
@@ -581,7 +586,7 @@ void ChatChannelList::Process() {
 
 		if(CurrentChannel && CurrentChannel->ReadyToDelete()) {
 
-			LogInfo("Empty temporary password protected channel [{}] being destroyed",
+			LogDebug("Empty temporary password protected channel [{}] being destroyed",
 				CurrentChannel->GetName().c_str());
 
 			RemoveChannel(CurrentChannel);
@@ -597,7 +602,7 @@ void ChatChannel::AddInvitee(const std::string &Invitee)
 	if (!IsInvitee(Invitee)) {
 		Invitees.push_back(Invitee);
 
-		LogInfo("Added [{}] as invitee to channel [{}]", Invitee.c_str(), Name.c_str());
+		LogDebug("Added [{}] as invitee to channel [{}]", Invitee.c_str(), Name.c_str());
 	}
 
 }
@@ -608,7 +613,7 @@ void ChatChannel::RemoveInvitee(std::string Invitee)
 
 	if(it != std::end(Invitees)) {
 		Invitees.erase(it);
-		LogInfo("Removed [{}] as invitee to channel [{}]", Invitee.c_str(), Name.c_str());
+		LogDebug("Removed [{}] as invitee to channel [{}]", Invitee.c_str(), Name.c_str());
 	}
 }
 

--- a/ucs/clientlist.h
+++ b/ucs/clientlist.h
@@ -143,7 +143,7 @@ public:
 	void SetConnectionType(char c);
 	ConnectionType GetConnectionType() { return TypeOfConnection; }
 	EQEmu::versions::ClientVersion GetClientVersion() { return ClientVersion_; }
-	
+
 	inline bool IsMailConnection() { return (TypeOfConnection == ConnectionTypeMail) || (TypeOfConnection == ConnectionTypeCombined); }
 	void SendNotification(int MailBoxNumber, std::string From, std::string Subject, int MessageID);
 	void ChangeMailBox(int NewMailBox);
@@ -151,6 +151,7 @@ public:
 	void SendFriends();
 	int GetCharID();
 	void SendUptime();
+	void SendKeepAlive();
 
 private:
 	unsigned int CurrentMailBox;
@@ -183,6 +184,7 @@ public:
 	void	Process();
 	void	CloseAllConnections();
 	Client *FindCharacter(std::string CharacterName);
+	void	CheckForStaleConnectionsAll();
 	void	CheckForStaleConnections(Client *c);
 	Client *IsCharacterOnline(std::string CharacterName);
 	void ProcessOPMailCommand(Client *c, std::string CommandString);

--- a/ucs/database.cpp
+++ b/ucs/database.cpp
@@ -320,7 +320,7 @@ void Database::SendHeaders(Client *client)
 	int unknownField3 = 1;
 	int characterID   = FindCharacter(client->MailBoxName().c_str());
 
-	LogInfo("Sendheaders for [{}], CharID is [{}]", client->MailBoxName().c_str(), characterID);
+	LogDebug("Sendheaders for [{}], CharID is [{}]", client->MailBoxName().c_str(), characterID);
 
 	if (characterID <= 0) {
 		return;

--- a/ucs/database.cpp
+++ b/ucs/database.cpp
@@ -108,7 +108,7 @@ void Database::GetAccountStatus(Client *client)
 {
 
 	std::string query = StringFormat(
-		"SELECT `status`, `hideme`, `karma`, `revoked` FROM `account` WHERE `id` = '%i' LIMIT 1",
+		"SELECT `status`, `hideme`, `karma`, `revoked` FROM `account` WHERE `id` = %i LIMIT 1",
 		client->GetAccountID()
 	);
 
@@ -173,7 +173,7 @@ int Database::FindAccount(const char *characterName, Client *client)
 
 	query = StringFormat(
 		"SELECT `id`, `name`, `level` FROM `character_data` "
-		"WHERE `account_id` = %i AND `name` != '%s'",
+		"WHERE `account_id` = %i AND `name` != '%s' AND deleted_at is NULL",
 		accountID, characterName
 	);
 

--- a/ucs/ucs.cpp
+++ b/ucs/ucs.cpp
@@ -70,7 +70,7 @@ int main() {
 	// Check every minute for unused channels we can delete
 	//
 	Timer ChannelListProcessTimer(60000);
-	Timer ClientConnectionPruneTimer(1000);
+	Timer ClientConnectionPruneTimer(60000);
 
 	Timer InterserverTimer(INTERSERVER_TIMER); // does auto-reconnect
 

--- a/ucs/ucs.cpp
+++ b/ucs/ucs.cpp
@@ -70,17 +70,18 @@ int main() {
 	// Check every minute for unused channels we can delete
 	//
 	Timer ChannelListProcessTimer(60000);
+	Timer ClientConnectionPruneTimer(1000);
 
 	Timer InterserverTimer(INTERSERVER_TIMER); // does auto-reconnect
 
 	LogInfo("Starting EQEmu Universal Chat Server");
 
-	if (!ucsconfig::LoadConfig()) { 
-		LogInfo("Loading server configuration failed"); 
+	if (!ucsconfig::LoadConfig()) {
+		LogInfo("Loading server configuration failed");
 		return 1;
 	}
 
-	Config = ucsconfig::get(); 
+	Config = ucsconfig::get();
 
 	WorldShortName = Config->ShortName;
 
@@ -144,19 +145,26 @@ int main() {
 
 	worldserver = new WorldServer;
 
-	while(RunLoops) {
+	auto loop_fn = [&](EQ::Timer* t) {
 
 		Timer::SetCurrentTime();
 
 		g_Clientlist->Process();
 
-		if(ChannelListProcessTimer.Check())
+		if (ChannelListProcessTimer.Check()) {
 			ChannelList->Process();
+		}
 
-		EQ::EventLoop::Get().Process();
+		if (ClientConnectionPruneTimer.Check()) {
+			g_Clientlist->CheckForStaleConnectionsAll();
+		}
 
-		Sleep(5);
-	}
+	};
+
+	EQ::Timer process_timer(loop_fn);
+	process_timer.Start(32, true);
+
+	EQ::EventLoop::Get().Run();
 
 	ChannelList->RemoveAllChannels();
 

--- a/ucs/worldserver.cpp
+++ b/ucs/worldserver.cpp
@@ -61,7 +61,7 @@ void WorldServer::ProcessMessage(uint16 opcode, EQ::Net::Packet &p)
 	ServerPacket tpack(opcode, p);
 	ServerPacket *pack = &tpack;
 
-	LogInfo("Received Opcode: {:#04x}", opcode);
+	LogNetcode("Received Opcode: {:#04x}", opcode);
 
 	switch (opcode)
 	{

--- a/world/ucs.h
+++ b/world/ucs.h
@@ -4,6 +4,7 @@
 #include "../common/types.h"
 #include "../common/net/servertalk_server_connection.h"
 #include "../common/servertalk.h"
+#include "../common/event/timer.h"
 #include <memory>
 
 class UCSConnection
@@ -13,11 +14,17 @@ public:
 	void SetConnection(std::shared_ptr<EQ::Net::ServertalkServerConnection> connection);
 	void ProcessPacket(uint16 opcode, EQ::Net::Packet &p);
 	void SendPacket(ServerPacket* pack);
-	void Disconnect() { if(Stream && Stream->Handle()) Stream->Handle()->Disconnect(); }
+	void Disconnect() { if(connection && connection->Handle()) connection->Handle()->Disconnect(); }
 	void SendMessage(const char *From, const char *Message);
 private:
-	inline std::string GetIP() const { return (Stream && Stream->Handle()) ? Stream->Handle()->RemoteIP() : 0; }
-	std::shared_ptr<EQ::Net::ServertalkServerConnection> Stream;
+	inline std::string GetIP() const { return (connection && connection->Handle()) ? connection->Handle()->RemoteIP() : 0; }
+	std::shared_ptr<EQ::Net::ServertalkServerConnection> connection;
+
+	/**
+	 * Keepalive
+	 */
+	std::unique_ptr<EQ::Timer> m_keepalive;
+	void OnKeepAlive(EQ::Timer *t);
 };
 
 #endif /*UCS_H_*/

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -256,6 +256,7 @@ Client::Client(EQStreamInterface* ieqs)
 	TotalSecondsPlayed = 0;
 	keyring.clear();
 	bind_sight_target = nullptr;
+	p_raid_instance = nullptr;
 	mercid = 0;
 	mercSlot = 0;
 	InitializeMercInfo();

--- a/zone/client.h
+++ b/zone/client.h
@@ -1304,6 +1304,8 @@ public:
 	void SetLastPositionBeforeBulkUpdate(glm::vec4 in_last_position_before_bulk_update);
 	glm::vec4 &GetLastPositionBeforeBulkUpdate();
 
+	Raid *p_raid_instance;
+
 protected:
 	friend class Mob;
 	void CalcItemBonuses(StatBonuses* newbon);
@@ -1343,6 +1345,7 @@ protected:
 	char *adv_data;
 
 private:
+
 	eqFilterMode ClientFilters[_FilterCount];
 	int32 HandlePacket(const EQApplicationPacket *app);
 	void OPTGB(const EQApplicationPacket *app);

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -2011,7 +2011,7 @@ Raid *EntityList::GetRaidByClient(Client* client)
 		++iterator;
 	}
 
-	return nullptr;
+	return client->p_raid_instance;
 }
 
 Raid *EntityList::GetRaidByMob(Mob *mob)

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -1985,8 +1985,11 @@ Raid *EntityList::GetRaidByID(uint32 id)
 Raid *EntityList::GetRaidByClient(Client* client)
 {
 	if (client->p_raid_instance) {
+		LogInfo("returning cached raid instance pointer");
 		return client->p_raid_instance;
 	}
+
+	LogInfo("fetching raid instance pointer");
 
 	std::list<Raid *>::iterator iterator;
 

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -498,7 +498,7 @@ void EntityList::MobProcess()
 		size_t sz = mob_list.size();
 
 #ifdef IDLE_WHEN_EMPTY
-		if (numclients > 0 || 
+		if (numclients > 0 ||
 			mob->GetWanderType() == 4 || mob->GetWanderType() == 6) {
 			// Normal processing, or assuring that spawns that should
 			// path and depop do that.  Otherwise all of these type mobs
@@ -931,12 +931,12 @@ bool EntityList::MakeDoorSpawnPacket(EQApplicationPacket *app, Client *client)
 			memcpy(new_door.name, door->GetDoorName(), 32);
 
 			auto position = door->GetPosition();
-			
+
 			new_door.xPos = position.x;
 			new_door.yPos = position.y;
 			new_door.zPos = position.z;
 			new_door.heading = position.w;
-			
+
 			new_door.incline = door->GetIncline();
 			new_door.size = door->GetSize();
 			new_door.doorId = door->GetDoorID();
@@ -1984,17 +1984,33 @@ Raid *EntityList::GetRaidByID(uint32 id)
 
 Raid *EntityList::GetRaidByClient(Client* client)
 {
+	if (client->p_raid_instance) {
+		return client->p_raid_instance;
+	}
+
 	std::list<Raid *>::iterator iterator;
 
 	iterator = raid_list.begin();
 
+	bool found_raid = false;
 	while (iterator != raid_list.end()) {
-		for (int x = 0; x < MAX_RAID_MEMBERS; x++)
-			if ((*iterator)->members[x].member)
-				if((*iterator)->members[x].member == client)
-					return *iterator;
+		if (found_raid) {
+			break;
+		}
+
+		for (auto & member : (*iterator)->members) {
+			if (member.member) {
+				if (member.member == client) {
+					client->p_raid_instance = *iterator;
+					found_raid = true;
+					break;
+				}
+			}
+		}
+
 		++iterator;
 	}
+
 	return nullptr;
 }
 

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -1995,7 +1995,7 @@ Raid *EntityList::GetRaidByClient(Client* client)
 	bool found_raid = false;
 	while (iterator != raid_list.end()) {
 		if (found_raid) {
-			break;
+			return client->p_raid_instance;
 		}
 
 		for (auto & member : (*iterator)->members) {
@@ -2011,7 +2011,7 @@ Raid *EntityList::GetRaidByClient(Client* client)
 		++iterator;
 	}
 
-	return client->p_raid_instance;
+	return nullptr;
 }
 
 Raid *EntityList::GetRaidByMob(Mob *mob)

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -1992,18 +1992,12 @@ Raid *EntityList::GetRaidByClient(Client* client)
 
 	iterator = raid_list.begin();
 
-	bool found_raid = false;
 	while (iterator != raid_list.end()) {
-		if (found_raid) {
-			return client->p_raid_instance;
-		}
-
 		for (auto & member : (*iterator)->members) {
 			if (member.member) {
 				if (member.member == client) {
 					client->p_raid_instance = *iterator;
-					found_raid = true;
-					break;
+					return *iterator;
 				}
 			}
 		}

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -1985,18 +1985,14 @@ Raid *EntityList::GetRaidByID(uint32 id)
 Raid *EntityList::GetRaidByClient(Client* client)
 {
 	if (client->p_raid_instance) {
-		LogInfo("returning cached raid instance pointer");
 		return client->p_raid_instance;
 	}
 
-	LogInfo("fetching raid instance pointer");
-
 	std::list<Raid *>::iterator iterator;
-
 	iterator = raid_list.begin();
 
 	while (iterator != raid_list.end()) {
-		for (auto & member : (*iterator)->members) {
+		for (auto &member : (*iterator)->members) {
 			if (member.member) {
 				if (member.member == client) {
 					client->p_raid_instance = *iterator;

--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -177,6 +177,7 @@ void Raid::RemoveMember(const char *characterName)
 	if(client) {
 		client->SetRaidGrouped(false);
 		client->LeaveRaidXTargets(this);
+		client->p_raid_instance = nullptr;
 	}
 
 	auto pack = new ServerPacket(ServerOP_RaidRemove, sizeof(ServerRaidGeneralAction_Struct));
@@ -1614,7 +1615,7 @@ void Raid::SendHPManaEndPacketsFrom(Mob *mob)
 		return;
 
 	uint32 group_id = 0;
-	
+
 	if(mob->IsClient())
 		group_id = this->GetGroup(mob->CastToClient());
 
@@ -1622,7 +1623,7 @@ void Raid::SendHPManaEndPacketsFrom(Mob *mob)
 	EQApplicationPacket outapp(OP_MobManaUpdate, sizeof(MobManaUpdate_Struct));
 
 	mob->CreateHPPacket(&hpapp);
-	
+
 	for(int x = 0; x < MAX_RAID_MEMBERS; x++) {
 		if(members[x].member) {
 			if(!mob->IsClient() || ((members[x].member != mob->CastToClient()) && (members[x].GroupNumber == group_id))) {
@@ -1633,7 +1634,7 @@ void Raid::SendHPManaEndPacketsFrom(Mob *mob)
 					mana_update->spawn_id = mob->GetID();
 					mana_update->mana = mob->GetManaPercent();
 					members[x].member->QueuePacket(&outapp, false);
-					
+
 					outapp.SetOpcode(OP_MobEnduranceUpdate);
 					MobEnduranceUpdate_Struct *endurance_update = (MobEnduranceUpdate_Struct *)outapp.pBuffer;
 					endurance_update->endurance = mob->GetEndurancePercent();

--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -1045,6 +1045,8 @@ void Raid::SendRaidRemove(const char *who, Client *to)
 	{
 		if(strcmp(members[x].membername, who) == 0)
 		{
+			members[x].member->p_raid_instance = nullptr;
+
 			auto outapp = new EQApplicationPacket(OP_RaidUpdate, sizeof(RaidGeneral_Struct));
 			RaidGeneral_Struct *rg = (RaidGeneral_Struct*)outapp->pBuffer;
 			rg->action = raidRemove2;
@@ -1064,6 +1066,8 @@ void Raid::SendRaidRemoveAll(const char *who)
 	{
 		if(strcmp(members[x].membername, who) == 0)
 		{
+			members[x].member->p_raid_instance = nullptr;
+
 			auto outapp = new EQApplicationPacket(OP_RaidUpdate, sizeof(RaidGeneral_Struct));
 			RaidGeneral_Struct *rg = (RaidGeneral_Struct*)outapp->pBuffer;
 			rg->action = raidRemove2;
@@ -1079,8 +1083,9 @@ void Raid::SendRaidRemoveAll(const char *who)
 
 void Raid::SendRaidDisband(Client *to)
 {
-	if(!to)
+	if (!to) {
 		return;
+	}
 
 	auto outapp = new EQApplicationPacket(OP_RaidUpdate, sizeof(RaidGeneral_Struct));
 	RaidGeneral_Struct *rg = (RaidGeneral_Struct*)outapp->pBuffer;

--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -1045,8 +1045,6 @@ void Raid::SendRaidRemove(const char *who, Client *to)
 	{
 		if(strcmp(members[x].membername, who) == 0)
 		{
-			members[x].member->p_raid_instance = nullptr;
-
 			auto outapp = new EQApplicationPacket(OP_RaidUpdate, sizeof(RaidGeneral_Struct));
 			RaidGeneral_Struct *rg = (RaidGeneral_Struct*)outapp->pBuffer;
 			rg->action = raidRemove2;
@@ -1066,8 +1064,6 @@ void Raid::SendRaidRemoveAll(const char *who)
 	{
 		if(strcmp(members[x].membername, who) == 0)
 		{
-			members[x].member->p_raid_instance = nullptr;
-
 			auto outapp = new EQApplicationPacket(OP_RaidUpdate, sizeof(RaidGeneral_Struct));
 			RaidGeneral_Struct *rg = (RaidGeneral_Struct*)outapp->pBuffer;
 			rg->action = raidRemove2;

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -1881,9 +1881,11 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 	}
 	case ServerOP_UCSServerStatusReply:
 	{
-		auto ucsss = (UCSServerStatus_Struct*)pack->pBuffer;
-		if (zone)
+		auto ucsss = (UCSServerStatus_Struct *) pack->pBuffer;
+		if (zone) {
 			zone->SetUCSServerAvailable((ucsss->available != 0), ucsss->timestamp);
+			LogInfo("UCS Server is now [{}]", (ucsss->available == 1 ? "online" : "offline"));
+		}
 		break;
 	}
 	case ServerOP_CZSetEntityVariableByNPCTypeID:

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -734,7 +734,7 @@ void Zone::Shutdown(bool quiet)
 
 	if (RuleB(Zone, KillProcessOnDynamicShutdown)) {
 		LogInfo("[KillProcessOnDynamicShutdown] Shutting down");
-		std::exit(EXIT_SUCCESS);
+		EQ::EventLoop::Get().Shutdown();
 	}
 }
 


### PR DESCRIPTION
This PR addresses many things

**Raid::GetRaidByClient**

On PEQ we noticed via zone with high CPU footprint spending tons of time in in function `Raid::GetRaidByClient` where we excessively loop through all raids in zone, all members in the raid to return back a simple raid pointer. Now, we cache the pointer lookup instead of running the entire loop constantly. For perspective, with 100 toons in a zone all in a raid, you will easily see 4k/s calls to this function which adds up on a CPU profile (nuts)

**CPU Profile** https://gist.github.com/Akkadius/a5c55654d4b729697964f938c824030f
**Call Measurement Example**

```
eqemu@ce0931611614:~$ tail -f ~/server/logs/**/*.log | grep "returning cached raid" | pv -lr 2>&1 >/dev/null
[4.04k/s]
```

**UCS**

We also noticed UCS sucking up a lot of CPU with 1,500 players online

**CPU Profile** https://gist.github.com/Akkadius/14efe565caf468cc892293fd95cc0377

* Converted to a less aggressive loop frequency 31.25 FPS and converted to using UV library
* No longer load characters into UCS context that are soft deleted
* Fixed UCS bug where it would not reconnect properly after a crash / improper shutdown
* Fixed UCS bug where it was not registering a new connection properly, and sending a "Not Available" to all zones right after it is in fact "Available"
* Added Logging in zone that clearly says whether or not UCS is online or not
* Properly removing UCS connected clients even if the /q /ex connections resolving by sending keepalive packets https://github.com/EQEmu/Server/issues/735 this prevents UCS from looping over ghosted clients making unnecessary database calls and sending improper connected client counts
* Removed tons of verbose LogInfo logging and replaced the calls for LogDebug as it was writing to disk excessively for mostly debugging related information

**Zone**

* We are now properly shutting down zone processes by killing the UV loop instead of doing a hard process exit, allowing the zone to shut everything else down gracefully