### PR TITLE
Fix errant merchant full messages and add logging for later use

### DIFF
--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -2913,23 +2913,33 @@ void Client::SendItemPacket(int16 slot_id, const EQEmu::ItemInstance* inst, Item
 	if (!inst)
 		return;
 
-	if (slot_id <= EQEmu::invslot::POSSESSIONS_END && slot_id >= EQEmu::invslot::POSSESSIONS_BEGIN) {
-		if ((((uint64)1 << slot_id) & GetInv().GetLookup()->PossessionsBitmask) == 0)
-			return;
-	}
-	else if (slot_id <= EQEmu::invbag::GENERAL_BAGS_END && slot_id >= EQEmu::invbag::GENERAL_BAGS_BEGIN) {
-		auto temp_slot = EQEmu::invslot::GENERAL_BEGIN + ((slot_id - EQEmu::invbag::GENERAL_BAGS_BEGIN) / EQEmu::invbag::SLOT_COUNT);
-		if ((((uint64)1 << temp_slot) & GetInv().GetLookup()->PossessionsBitmask) == 0)
-			return;
-	}
-	else if (slot_id <= EQEmu::invslot::BANK_END && slot_id >= EQEmu::invslot::BANK_BEGIN) {
-		if ((slot_id - EQEmu::invslot::BANK_BEGIN) >= GetInv().GetLookup()->InventoryTypeSize.Bank)
-			return;
-	}
-	else if (slot_id <= EQEmu::invbag::BANK_BAGS_END && slot_id >= EQEmu::invbag::BANK_BAGS_BEGIN) {
-		auto temp_slot = (slot_id - EQEmu::invbag::BANK_BAGS_BEGIN) / EQEmu::invbag::SLOT_COUNT;
-		if (temp_slot >= GetInv().GetLookup()->InventoryTypeSize.Bank)
-			return;
+	if (packet_type != ItemPacketMerchant) {
+		if (slot_id <= EQEmu::invslot::POSSESSIONS_END && slot_id >= EQEmu::invslot::POSSESSIONS_BEGIN) {
+			if ((((uint64)1 << slot_id) & GetInv().GetLookup()->PossessionsBitmask) == 0) {
+				LogError("Item not sent to merchant : slot [{}]", slot_id);
+				return;
+			}
+		}
+		else if (slot_id <= EQEmu::invbag::GENERAL_BAGS_END && slot_id >= EQEmu::invbag::GENERAL_BAGS_BEGIN) {
+			auto temp_slot = EQEmu::invslot::GENERAL_BEGIN + ((slot_id - EQEmu::invbag::GENERAL_BAGS_BEGIN) / EQEmu::invbag::SLOT_COUNT);
+			if ((((uint64)1 << temp_slot) & GetInv().GetLookup()->PossessionsBitmask) == 0) {
+				LogError("Item not sent to merchant2 : slot [{}]", slot_id);
+				return;
+			}
+		}
+		else if (slot_id <= EQEmu::invslot::BANK_END && slot_id >= EQEmu::invslot::BANK_BEGIN) {
+			if ((slot_id - EQEmu::invslot::BANK_BEGIN) >= GetInv().GetLookup()->InventoryTypeSize.Bank) {
+				LogError("Item not sent to merchant3 : slot [{}]", slot_id);
+				return;
+			}
+		}
+		else if (slot_id <= EQEmu::invbag::BANK_BAGS_END && slot_id >= EQEmu::invbag::BANK_BAGS_BEGIN) {
+			auto temp_slot = (slot_id - EQEmu::invbag::BANK_BAGS_BEGIN) / EQEmu::invbag::SLOT_COUNT;
+			if (temp_slot >= GetInv().GetLookup()->InventoryTypeSize.Bank) {
+				LogError("Item not sent to merchant4 : slot [{}]", slot_id);
+				return;
+			}
+		}
 	}
 
 	// Serialize item into |-delimited string (Titanium- uses '|' delimiter .. newer clients use pure data serialization)

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -330,81 +330,154 @@ bool Zone::LoadGroundSpawns() {
 	return(true);
 }
 
-int Zone::SaveTempItem(uint32 merchantid, uint32 npcid, uint32 item, int32 charges, bool sold) {
-	int freeslot = 0;
-	std::list<MerchantList> merlist = merchanttable[merchantid];
-	std::list<MerchantList>::const_iterator itr;
-	uint32 i = 1;
-	for (itr = merlist.begin(); itr != merlist.end(); ++itr) {
-		MerchantList ml = *itr;
-		if (ml.item == item)
-			return 0;
-
-		// Account for merchant lists with gaps in them.
-		if (ml.slot >= i)
-			i = ml.slot + 1;
-	}
+void Zone::DumpIt(uint32 npcid) {
 	std::list<TempMerchantList> tmp_merlist = tmpmerchanttable[npcid];
 	std::list<TempMerchantList>::const_iterator tmp_itr;
-	bool update_charges = false;
 	TempMerchantList ml;
-	while (freeslot == 0 && !update_charges) {
-		freeslot = i;
-		for (tmp_itr = tmp_merlist.begin(); tmp_itr != tmp_merlist.end(); ++tmp_itr) {
-			ml = *tmp_itr;
-			if (ml.item == item) {
-				update_charges = true;
-				freeslot = 0;
-				break;
-			}
-			if ((ml.slot == i) || (ml.origslot == i)) {
-				freeslot = 0;
-			}
-		}
-		i++;
+
+	for (tmp_itr = tmp_merlist.begin(); tmp_itr != tmp_merlist.end(); ++tmp_itr) {
+		ml = *tmp_itr;
+		
+		LogInventory("slot[{}] Orig[{}] Item[{}] Charges[{}]", ml.slot, ml.origslot, ml.item, ml.charges);
 	}
-	if (update_charges) {
+}
+
+int Zone::SaveTempItem(uint32 merchantid, uint32 npcid, uint32 item, int32 charges, bool sold) {
+
+	LogInventory("Transaction of [{}] [{}]", charges, item);
+	//DumpIt(npcid);
+	// Iterate past main items.
+	// If the item being transacted is in this list, return 0;
+	std::list<MerchantList> merlist = merchanttable[merchantid];
+	std::list<MerchantList>::const_iterator itr;
+	uint32 temp_slot_index = 1;
+	for (itr = merlist.begin(); itr != merlist.end(); ++itr) {
+		MerchantList ml = *itr;
+		if (ml.item == item) {
+			return 0;
+		}
+
+		// Account for merchant lists with gaps in them.
+		if (ml.slot >= temp_slot_index) {
+			temp_slot_index = ml.slot + 1;
+		}
+	}
+
+	LogInventory("Searching Temporary List.  Main list ended at [{}]", temp_slot_index-1);
+
+	// Now search the temporary list.
+	std::list<TempMerchantList> tmp_merlist = tmpmerchanttable[npcid];
+	std::list<TempMerchantList>::const_iterator tmp_itr;
+	TempMerchantList ml;
+	uint32 first_empty_slot=0; // Save 1st vacant slot while searching..
+	bool found = false;
+
+	for (tmp_itr = tmp_merlist.begin(); tmp_itr != tmp_merlist.end(); ++tmp_itr) {
+		ml = *tmp_itr;
+		
+		if (ml.item == item) {
+			found = true;
+			LogInventory("Item found in temp list at [{}] with [{}] charges", ml.origslot, ml.charges);
+			break;
+		}
+	}
+
+	if (found) {
 		tmp_merlist.clear();
 		std::list<TempMerchantList> oldtmp_merlist = tmpmerchanttable[npcid];
 		for (tmp_itr = oldtmp_merlist.begin(); tmp_itr != oldtmp_merlist.end(); ++tmp_itr) {
 			TempMerchantList ml2 = *tmp_itr;
 			if(ml2.item != item)
 				tmp_merlist.push_back(ml2);
+			else {
+				if (sold) {
+					LogInventory("Total charges is [{}] + [{}] charges", ml.charges, charges);
+					ml.charges = ml.charges + charges;
+				}
+				else {
+					ml.charges = charges;
+					LogInventory("new charges is [{}] charges", ml.charges);
+				}
+				if (!ml.origslot) {
+					ml.origslot = ml.slot;
+				}
+				if (charges > 0) {
+					database.SaveMerchantTemp(npcid, ml.origslot, item, ml.charges);
+					tmp_merlist.push_back(ml);
+				}
+				else {
+					database.DeleteMerchantTemp(npcid, ml.origslot);
+				}
+			}
 		}
-		if (sold)
-			ml.charges = ml.charges + charges;
-		else
-			ml.charges = charges;
-		if (!ml.origslot)
-			ml.origslot = ml.slot;
-		if (charges > 0) {
-			database.SaveMerchantTemp(npcid, ml.origslot, item, ml.charges);
-			tmp_merlist.push_back(ml);
-		}
-		else {
-			database.DeleteMerchantTemp(npcid, ml.origslot);
-		}
+
 		tmpmerchanttable[npcid] = tmp_merlist;
-
-		if (sold)
-			return ml.slot;
-
+		//DumpIt(npcid);
+		return ml.slot;
 	}
-	if (freeslot) {
-		if (charges < 0) //sanity check only, shouldnt happen
+	else {
+		if (charges < 0) { //sanity check only, shouldnt happen
 			charges = 0x7FFF;
-		database.SaveMerchantTemp(npcid, freeslot, item, charges);
+		}
+
+		// Find an ununsed db slot #
+		std::list<int> slots;
+		TempMerchantList ml3;
+		for (tmp_itr = tmp_merlist.begin(); tmp_itr != tmp_merlist.end(); ++tmp_itr) {
+			ml3 = *tmp_itr;
+			slots.push_back(ml3.origslot);
+		}			
+		slots.sort();
+		std::list<int>::const_iterator slots_itr;
+		uint32 first_empty_slot=0;
+		uint32 idx = temp_slot_index;
+		for (slots_itr = slots.begin(); slots_itr != slots.end(); ++slots_itr) {
+			if (!first_empty_slot && *slots_itr > idx) {
+				LogInventory("Popped [{}]", *slots_itr);
+				LogInventory("First Gap Found at [{}]", idx);
+				break;
+			}
+
+			++idx;
+		}			
+
+		first_empty_slot = idx;
+
+		// Find an ununsed mslot
+		slots.clear();
+		for (tmp_itr = tmp_merlist.begin(); tmp_itr != tmp_merlist.end(); ++tmp_itr) {
+			ml3 = *tmp_itr;
+			slots.push_back(ml3.slot);
+		}			
+		slots.sort();
+		uint32 first_empty_mslot=0;
+		idx = temp_slot_index;
+		for (slots_itr = slots.begin(); slots_itr != slots.end(); ++slots_itr) {
+			if (!first_empty_mslot && *slots_itr > idx) {
+				LogInventory("Popped [{}]", *slots_itr);
+				LogInventory("First Gap Found at [{}]", idx);
+				break;
+			}
+
+			++idx;
+		}			
+
+		first_empty_mslot = idx;
+
+		database.SaveMerchantTemp(npcid, first_empty_slot, item, charges);
 		tmp_merlist = tmpmerchanttable[npcid];
 		TempMerchantList ml2;
 		ml2.charges = charges;
+		LogInventory("Adding slot [{}] with [{}] charges.", first_empty_mslot, charges);
 		ml2.item = item;
 		ml2.npcid = npcid;
-		ml2.slot = freeslot;
-		ml2.origslot = ml2.slot;
+		ml2.slot = first_empty_mslot;
+		ml2.origslot = first_empty_slot;
 		tmp_merlist.push_back(ml2);
 		tmpmerchanttable[npcid] = tmp_merlist;
+		//DumpIt(npcid);
+		return ml2.slot;
 	}
-	return freeslot;
 }
 
 uint32 Zone::GetTempMerchantQuantity(uint32 NPCID, uint32 Slot) {
@@ -413,8 +486,10 @@ uint32 Zone::GetTempMerchantQuantity(uint32 NPCID, uint32 Slot) {
 	std::list<TempMerchantList>::const_iterator Iterator;
 
 	for (Iterator = TmpMerchantList.begin(); Iterator != TmpMerchantList.end(); ++Iterator)
-		if ((*Iterator).slot == Slot)
+		if ((*Iterator).slot == Slot) {
+			LogInventory("Slot [{}] has [{}] charges.", Slot, (*Iterator).charges);
 			return (*Iterator).charges;
+		}
 
 	return 0;
 }

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -398,9 +398,11 @@ int Zone::SaveTempItem(uint32 merchantid, uint32 npcid, uint32 item, int32 charg
 					ml.charges = charges;
 					LogInventory("new charges is [{}] charges", ml.charges);
 				}
+				
 				if (!ml.origslot) {
 					ml.origslot = ml.slot;
 				}
+				
 				if (charges > 0) {
 					database.SaveMerchantTemp(npcid, ml.origslot, item, ml.charges);
 					tmp_merlist.push_back(ml);

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -330,7 +330,7 @@ bool Zone::LoadGroundSpawns() {
 	return(true);
 }
 
-void Zone::DumpIt(uint32 npcid) {
+void Zone::DumpMerchantList(uint32 npcid) {
 	std::list<TempMerchantList> tmp_merlist = tmpmerchanttable[npcid];
 	std::list<TempMerchantList>::const_iterator tmp_itr;
 	TempMerchantList ml;
@@ -345,7 +345,7 @@ void Zone::DumpIt(uint32 npcid) {
 int Zone::SaveTempItem(uint32 merchantid, uint32 npcid, uint32 item, int32 charges, bool sold) {
 
 	LogInventory("Transaction of [{}] [{}]", charges, item);
-	//DumpIt(npcid);
+	//DumpMerchantList(npcid);
 	// Iterate past main items.
 	// If the item being transacted is in this list, return 0;
 	std::list<MerchantList> merlist = merchanttable[merchantid];
@@ -412,7 +412,7 @@ int Zone::SaveTempItem(uint32 merchantid, uint32 npcid, uint32 item, int32 charg
 		}
 
 		tmpmerchanttable[npcid] = tmp_merlist;
-		//DumpIt(npcid);
+		//DumpMerchantList(npcid);
 		return ml.slot;
 	}
 	else {
@@ -475,7 +475,7 @@ int Zone::SaveTempItem(uint32 merchantid, uint32 npcid, uint32 item, int32 charg
 		ml2.origslot = first_empty_slot;
 		tmp_merlist.push_back(ml2);
 		tmpmerchanttable[npcid] = tmp_merlist;
-		//DumpIt(npcid);
+		//DumpMerchantList(npcid);
 		return ml2.slot;
 	}
 }

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -369,7 +369,7 @@ int Zone::SaveTempItem(uint32 merchantid, uint32 npcid, uint32 item, int32 charg
 	std::list<TempMerchantList> tmp_merlist = tmpmerchanttable[npcid];
 	std::list<TempMerchantList>::const_iterator tmp_itr;
 	TempMerchantList ml;
-	uint32 first_empty_slot=0; // Save 1st vacant slot while searching..
+	uint32 first_empty_slot = 0; // Save 1st vacant slot while searching..
 	bool found = false;
 
 	for (tmp_itr = tmp_merlist.begin(); tmp_itr != tmp_merlist.end(); ++tmp_itr) {
@@ -429,7 +429,7 @@ int Zone::SaveTempItem(uint32 merchantid, uint32 npcid, uint32 item, int32 charg
 		}			
 		slots.sort();
 		std::list<int>::const_iterator slots_itr;
-		uint32 first_empty_slot=0;
+		uint32 first_empty_slot = 0;
 		uint32 idx = temp_slot_index;
 		for (slots_itr = slots.begin(); slots_itr != slots.end(); ++slots_itr) {
 			if (!first_empty_slot && *slots_itr > idx) {

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -163,7 +163,7 @@ public:
 	inline void ShowNPCGlobalLoot(Client *to, NPC *who) { m_global_loot.ShowNPCGlobalLoot(to, who); }
 	inline void ShowZoneGlobalLoot(Client *to) { m_global_loot.ShowZoneGlobalLoot(to); }
 	int GetZoneTotalBlockedSpells() { return zone_total_blocked_spells; }
-	void DumpIt(uint32 npcid);
+	void DumpMerchantList(uint32 npcid);
 	int SaveTempItem(uint32 merchantid, uint32 npcid, uint32 item, int32 charges, bool sold = false);
 	int32 MobsAggroCount() { return aggroedmobs; }
 

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -163,6 +163,7 @@ public:
 	inline void ShowNPCGlobalLoot(Client *to, NPC *who) { m_global_loot.ShowNPCGlobalLoot(to, who); }
 	inline void ShowZoneGlobalLoot(Client *to) { m_global_loot.ShowZoneGlobalLoot(to); }
 	int GetZoneTotalBlockedSpells() { return zone_total_blocked_spells; }
+	void DumpIt(uint32 npcid);
 	int SaveTempItem(uint32 merchantid, uint32 npcid, uint32 item, int32 charges, bool sold = false);
 	int32 MobsAggroCount() { return aggroedmobs; }
 


### PR DESCRIPTION
This change fixes cases where a merchant has at one point used slot 255 and slot 255 is still full but there are plenty of other slots open for use due to player buyback.  Without this fix, the code will throw an error saying the merchant is full.

This fix:

- Utilizes empty merchantlist_temp slots when available, regardless of where they are in the list
- Added LogInventory() statements throughout to aid in any later debugging that might be needed (though this has been running on my server for months)
- Added a DumpIt function which will dump the entire merchant inventory (currently unused) for later debugging if neeeded.
- Fixed a handful of if statements that were missing braces.

Obviously this fix is mainly for those that have rule:  World:ClearTempMerchantlist set to false.