### PR TITLE
Fix edge case with NPC pet owners charming PCs

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3979,6 +3979,8 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, bool reflect, bool use_r
 	cd->hit_heading = action->hit_heading;
 	cd->hit_pitch = action->hit_pitch;
 	cd->damage = 0;
+
+	auto spellOwner = GetOwnerOrSelf();
 	if(!IsEffectInSpell(spell_id, SE_BindAffinity) && !is_damage_or_lifetap_spell){
 		entity_list.QueueCloseClients(
 			spelltar, /* Sender */
@@ -3989,14 +3991,8 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, bool reflect, bool use_r
 			true, /* Packet ACK */
 			(spelltar->IsClient() ? FilterPCSpells : FilterNPCSpells) /* Message Filter Type: (8 or 9) */
 		);
-	} else if (is_damage_or_lifetap_spell &&
-		(IsClient() ||
-			(HasOwner() &&
-				GetOwner()->IsClient()
-			)
-		)
-	) {
-		(HasOwner() ? GetOwner() : this)->CastToClient()->QueuePacket(
+	} else if (is_damage_or_lifetap_spell && spellOwner->IsClient()) {
+		spellOwner->CastToClient()->QueuePacket(
 			message_packet,
 			true,
 			Mob::CLIENT_CONNECTINGALL,


### PR DESCRIPTION
* Addresses #1036
* Cleaned up if statement formatting
* Using Mob::GetOwnerOrSelf() now, which accounts for the edge case

NB: The Mob::SpellOnTarget() and Mob::CommonDamage() methods really
should be looked at and spell logic combined somehow.  Both have if
statements that dodge around the other's conditions to decide which
method sends the CombatDamage_Struct packet