### PR TITLE
Removed redundant check during enter world

### DIFF
--- a/world/client.cpp
+++ b/world/client.cpp
@@ -714,7 +714,7 @@ bool Client::HandleEnterWorldPacket(const EQApplicationPacket *app) {
 	EQApplicationPacket *outapp;
 	uint32 tmpaccid = 0;
 	charid = database.GetCharacterInfo(char_name, &tmpaccid, &zone_id, &instance_id);
-	if (charid == 0 || tmpaccid != GetAccountID()) {
+	if (charid == 0) {
 		LogInfo("Could not get CharInfo for [{}]", char_name);
 		eqs->Close();
 		return true;


### PR DESCRIPTION
The same check is being done right after this.  Having a duplicate check makes debugging harder, as the log message of the first one does not describe failing this check, while the second one does.