### PR TITLE
Add missing break for OP_AppCombined switch statement

### DIFF
--- a/common/net/daybreak_connection.cpp
+++ b/common/net/daybreak_connection.cpp
@@ -605,6 +605,8 @@ void EQ::Net::DaybreakConnection::ProcessDecodedPacket(const Packet &p)
 					ProcessDecodedPacket(StaticPacket(current, subpacket_length));
 					current += subpacket_length;
 				}
+
+				break;
 			}
 
 			case OP_SessionRequest:


### PR DESCRIPTION
This randomly popped into my head that I meant to mention a while back when I was trying to fix the network issue on Windows server. When I was looking at the network code I noticed this switch statement missing a break for OP_AppCombined so some of those packets were spilling over into session request. I remember getting excited because I thought maybe that had something to do with the issue at the time, but it wasn't the case in the end. The missing break doesn't seem to have any major adverse affects but thought I'd quickly point it out with this pull request while I remember.