### PR TITLE
Fix for static zone issue with mobs congregating after last player zones

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -280,6 +280,7 @@ RULE_BOOL(Zone, UseZoneController, true, "Enables the ability to use persistent 
 RULE_BOOL(Zone, EnableZoneControllerGlobals, false, "Enables the ability to use quest globals with the zone controller NPC")
 RULE_INT(Zone, GlobalLootMultiplier, 1, "Sets Global Loot drop multiplier for database based drops, useful for double, triple loot etc")
 RULE_BOOL(Zone, KillProcessOnDynamicShutdown, true, "When process has booted a zone and has hit its zone shut down timer, it will hard kill the process to free memory back to the OS")
+RULE_INT(Zone, SecondsBeforeIdle, 60, "Seconds before IDLE_WHEN_EMPTY define kicks in")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Map)


### PR DESCRIPTION
In static zones, if IDLE_WHILE_EMPTY is used (which is the default), when the last player leaves the zone, mobs cease to path immediately.

This PR adds code to allow these mobs to return to their spawn points before suspending mob::process.  In my testing 60 seconds is a good value for this rule, but servers might want more/less depending on preference.

This resolves issues like trains remaining at zone lines for the next unfortunate PC that zones in, days later.