### PR TITLE
Fishing update to match live 2018 patch

### DIFF
--- a/common/item_instance.h
+++ b/common/item_instance.h
@@ -103,7 +103,7 @@ namespace EQEmu
 		bool IsAugmentSlotAvailable(int32 augtype, uint8 slot) const;
 		inline int32 GetAugmentType() const { return ((m_item) ? m_item->AugType : 0); }
 
-		inline bool IsExpendable() const { return ((m_item) ? ((m_item->Click.Type == item::ItemEffectExpendable) || (m_item->ItemType == item::ItemTypePotion) || (m_item->ExpendableArrow == 1)) : false); }
+		inline bool IsExpendable() const { return ((m_item) ? ((m_item->Click.Type == item::ItemEffectExpendable) || (m_item->ItemType == item::ItemTypePotion)) : false); }
 
 		//
 		// Contents

--- a/common/item_instance.h
+++ b/common/item_instance.h
@@ -103,7 +103,7 @@ namespace EQEmu
 		bool IsAugmentSlotAvailable(int32 augtype, uint8 slot) const;
 		inline int32 GetAugmentType() const { return ((m_item) ? m_item->AugType : 0); }
 
-		inline bool IsExpendable() const { return ((m_item) ? ((m_item->Click.Type == item::ItemEffectExpendable) || (m_item->ItemType == item::ItemTypePotion)) : false); }
+		inline bool IsExpendable() const { return ((m_item) ? ((m_item->Click.Type == item::ItemEffectExpendable) || (m_item->ItemType == item::ItemTypePotion) || (m_item->ExpendableArrow == 1)) : false); }
 
 		//
 		// Contents

--- a/common/version.h
+++ b/common/version.h
@@ -34,7 +34,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9152
+#define CURRENT_BINARY_DATABASE_VERSION 9153
 
 #ifdef BOTS
 	#define CURRENT_BINARY_BOTS_DATABASE_VERSION 9027

--- a/utils/sql/db_update_manifest.txt
+++ b/utils/sql/db_update_manifest.txt
@@ -406,6 +406,7 @@
 9150|2020_02_06_aa_reset_on_death.sql|SHOW COLUMNS FROM `aa_ability` LIKE 'reset_on_death'|empty|
 9151|2020_03_05_npc_always_aggro.sql|SHOW COLUMNS FROM `npc_types` LIKE 'always_aggro'|empty|
 9152|2020_03_09_convert_myisam_to_innodb.sql|SELECT * FROM db_version WHERE version >= 9152|empty|
+9152|2020_04_30_fishing_2018.sql|SELECT name FROM items WHERE expendablearrow = 1 and name like "%fishing pole%"|empty|
 
 # Upgrade conditions:
 # 	This won't be needed after this system is implemented, but it is used database that are not

--- a/utils/sql/db_update_manifest.txt
+++ b/utils/sql/db_update_manifest.txt
@@ -406,7 +406,7 @@
 9150|2020_02_06_aa_reset_on_death.sql|SHOW COLUMNS FROM `aa_ability` LIKE 'reset_on_death'|empty|
 9151|2020_03_05_npc_always_aggro.sql|SHOW COLUMNS FROM `npc_types` LIKE 'always_aggro'|empty|
 9152|2020_03_09_convert_myisam_to_innodb.sql|SELECT * FROM db_version WHERE version >= 9152|empty|
-9153|2020_04_30_fishing_2018.sql|SELECT name FROM items WHERE expendablearrow = 1 and name like "%fishing pole%"|empty|
+9153|2020_04_30_fishing_2018.sql|SHOW columns FROM `items` like 'sub_type'|empty|
 
 # Upgrade conditions:
 # 	This won't be needed after this system is implemented, but it is used database that are not

--- a/utils/sql/db_update_manifest.txt
+++ b/utils/sql/db_update_manifest.txt
@@ -406,7 +406,7 @@
 9150|2020_02_06_aa_reset_on_death.sql|SHOW COLUMNS FROM `aa_ability` LIKE 'reset_on_death'|empty|
 9151|2020_03_05_npc_always_aggro.sql|SHOW COLUMNS FROM `npc_types` LIKE 'always_aggro'|empty|
 9152|2020_03_09_convert_myisam_to_innodb.sql|SELECT * FROM db_version WHERE version >= 9152|empty|
-9152|2020_04_30_fishing_2018.sql|SELECT name FROM items WHERE expendablearrow = 1 and name like "%fishing pole%"|empty|
+9153|2020_04_30_fishing_2018.sql|SELECT name FROM items WHERE expendablearrow = 1 and name like "%fishing pole%"|empty|
 
 # Upgrade conditions:
 # 	This won't be needed after this system is implemented, but it is used database that are not

--- a/utils/sql/git/required/2020_04_30_fishing_2018.sql
+++ b/utils/sql/git/required/2020_04_30_fishing_2018.sql
@@ -1,3 +1,4 @@
 /* Update all non-magical fishing poles to expendable per 2018 patch */
 
-UPDATE items SET expendablearrow = 1 where id in (9969, 9666, 16863, 13100, 84004, 25154, 22857, 46996);
+ALTER TABLE items RENAME COLUMN unk219 TO sub_type;
+UPDATE items SET unk219 = !magic WHERE itemtype = 36;

--- a/utils/sql/git/required/2020_04_30_fishing_2018.sql
+++ b/utils/sql/git/required/2020_04_30_fishing_2018.sql
@@ -1,0 +1,3 @@
+/* Update all non-magical fishing poles to expendable per 2018 patch */
+
+UPDATE items SET expendablearrow = 1 where id in (9969, 9666, 16863, 13100, 84004, 25154, 22857, 46996);

--- a/utils/sql/git/required/2020_04_30_fishing_2018.sql
+++ b/utils/sql/git/required/2020_04_30_fishing_2018.sql
@@ -1,4 +1,4 @@
 /* Update all non-magical fishing poles to expendable per 2018 patch */
 
 ALTER TABLE items RENAME COLUMN unk219 TO sub_type;
-UPDATE items SET unk219 = !magic WHERE itemtype = 36;
+UPDATE items SET sub_type = !magic WHERE itemtype = 36;

--- a/zone/forage.cpp
+++ b/zone/forage.cpp
@@ -369,7 +369,7 @@ void Client::GoFish()
 	//this is potentially exploitable in that they can fish
 	//and then swap out items in primary slot... too lazy to fix right now
 	const EQEmu::ItemInstance* Pole = m_inv[EQEmu::invslot::slotPrimary];
-	if (Pole && Pole->IsExpendable() && zone->random.Int(0, 49) == 1) {
+	if (Pole && Pole->IsExpendablePole() && zone->random.Int(0, 49) == 1) {
 		MessageString(Chat::Skills, FISHING_POLE_BROKE);	//Your fishing pole broke!
 		DeleteItemInInventory(EQEmu::invslot::slotPrimary, 0, true);
 	}

--- a/zone/forage.cpp
+++ b/zone/forage.cpp
@@ -368,7 +368,8 @@ void Client::GoFish()
 	//chance to break fishing pole...
 	//this is potentially exploitable in that they can fish
 	//and then swap out items in primary slot... too lazy to fix right now
-	if (zone->random.Int(0, 49) == 1) {
+	const EQEmu::ItemInstance* Pole = m_inv[EQEmu::invslot::slotPrimary];
+	if (Pole && Pole->IsExpendable() && zone->random.Int(0, 49) == 1) {
 		MessageString(Chat::Skills, FISHING_POLE_BROKE);	//Your fishing pole broke!
 		DeleteItemInInventory(EQEmu::invslot::slotPrimary, 0, true);
 	}


### PR DESCRIPTION
From July 28th, 2018 patch:

**- Changed a number of fishing pole items to be unbreakable. Fishing poles that have a chance to break while fishing now display the Expendable flag when inspected.**

From EQTrader's research:

http://mboards.eqtraders.com/eq/forum/tradeskills/fishing/368408-unbreakable-fishing-poles

My own research.  I was able to learn that only poles tagged as magic were unbreakable.

I could have coded this, using the magic flag, but that would not have resulted in the "Expendable" tag on the item.  This is a capture from live this week on a breakable pole:

![image](https://user-images.githubusercontent.com/8644833/80725792-8e64f380-8ad1-11ea-96e1-d2633f613ac4.png)

As such, I found the only way I could get this tag, in lower case, like live. was to set the expendablearrow field in items.  Perhaps the field should get a name change, but I didn't want to break anything else.

This is working and tested on my server. 

Re: the sql, I played with updates using item type and item name instead of using specific ids.  However too many exceptions existed, like a pail that is tagged as 36 and poles not called poles, etc.

This sql should keep all standard poles breakable.