### PR TITLE
Notify new titles

### DIFF
--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -1210,6 +1210,11 @@ void Lua_Client::OpenLFGuildWindow() {
 	self->OpenLFGuildWindow();
 }
 
+void Lua_Client::NotifyNewTitlesAvailable() {
+	Lua_Safe_Call_Void();
+	self->NotifyNewTitlesAvailable();
+}
+
 void Lua_Client::Signal(uint32 id) {
 	Lua_Safe_Call_Void();
 	self->Signal(id);
@@ -1820,6 +1825,7 @@ luabind::scope lua_register_client() {
 		.def("GetAllMoney", (uint64(Lua_Client::*)(void))&Lua_Client::GetAllMoney)
 		.def("GetMoney", (uint32(Lua_Client::*)(uint8, uint8))&Lua_Client::GetMoney)
 		.def("OpenLFGuildWindow", (void(Lua_Client::*)(void))&Lua_Client::OpenLFGuildWindow)
+		.def("NotifyNewTitlesAvailable", (void(Lua_Client::*)(void))&Lua_Client::NotifyNewTitlesAvailable)
 		.def("Signal", (void(Lua_Client::*)(uint32))&Lua_Client::Signal)
 		.def("AddAlternateCurrencyValue", (void(Lua_Client::*)(uint32,int))&Lua_Client::AddAlternateCurrencyValue)
 		.def("SetAlternateCurrencyValue", (void(Lua_Client::*)(uint32,int))&Lua_Client::SetAlternateCurrencyValue)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -269,6 +269,7 @@ public:
 	uint64 GetAllMoney();
 	uint32 GetMoney(uint8 type, uint8 subtype);
 	void OpenLFGuildWindow();
+	void NotifyNewTitlesAvailable();
 	void Signal(uint32 id);
 	void AddAlternateCurrencyValue(uint32 currency, int amount);
 	void SetAlternateCurrencyValue(uint32 currency, int amount);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -5522,7 +5522,7 @@ XS(XS_Client_OpenLFGuildWindow) {
 	XSRETURN_EMPTY;
 }
 
-XS(XS_NotifyNewTitlesAvailable); /* prototype to pass -Wmissing-prototypes */
+XS(XS_Client_NotifyNewTitlesAvailable); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Client_NotifyNewTitlesAvailable) {
 	dXSARGS;
 	if (items != 1)

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -5522,6 +5522,27 @@ XS(XS_Client_OpenLFGuildWindow) {
 	XSRETURN_EMPTY;
 }
 
+XS(XS_NotifyNewTitlesAvailable); /* prototype to pass -Wmissing-prototypes */
+XS(XS_Client_NotifyNewTitlesAvailable) {
+	dXSARGS;
+	if (items != 1)
+		Perl_croak(aTHX_ "Usage: Client::NotifyNewTitlesAvailable(THIS)");
+	{
+		Client *THIS;
+
+		if (sv_derived_from(ST(0), "Client")) {
+			IV tmp = SvIV((SV *) SvRV(ST(0)));
+			THIS = INT2PTR(Client *, tmp);
+		} else
+			Perl_croak(aTHX_ "THIS is not of type Client");
+		if (THIS == nullptr)
+			Perl_croak(aTHX_ "THIS is nullptr, avoiding crash.");
+
+		THIS->NotifyNewTitlesAvailable();
+	}
+	XSRETURN_EMPTY;
+}
+
 XS(XS_Client_SignalClient); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Client_SignalClient) {
 	dXSARGS;
@@ -6568,6 +6589,7 @@ XS(boot_Client) {
 	newXSproto(strcpy(buf, "NPCSpawn"), XS_Client_NPCSpawn, file, "$$$;$");
 	newXSproto(strcpy(buf, "NukeItem"), XS_Client_NukeItem, file, "$$;$");
 	newXSproto(strcpy(buf, "OpenLFGuildWindow"), XS_Client_OpenLFGuildWindow, file, "$");
+	newXSproto(strcpy(buf, "NotifyNewTitlesAvailable"), XS_Client_NotifyNewTitlesAvailable, file, "$");
 	newXSproto(strcpy(buf, "PlayMP3"), XS_Client_PlayMP3, file, "$;$");
 	newXSproto(strcpy(buf, "Popup2"), XS_Client_Popup2, file, "$$$;$$$$$$$");
 	newXSproto(strcpy(buf, "QuestReward"), XS_Client_QuestReward, file, "$$;$$$$$$$");


### PR DESCRIPTION
This exposes the client method NotifyNewTitlesAvailable for both perl and lua.

For what it's worth, I am exposing this to extend @KinglyKrab perl code that implements artisan titles, but it can be used anywhere you grant a title and want the popup.

His code was posted on this thread back in 2015.  In combination with quest::checktitle() quests can not use the TitlesAvailable popup at will.



