### PR TITLE
Identify SubType in Item structs in some clients

### DIFF
--- a/common/patches/rof2_structs.h
+++ b/common/patches/rof2_structs.h
@@ -4804,8 +4804,8 @@ struct ItemQuaternaryBodyStruct
 	int32 HealAmt;
 	int32 SpellDmg;
 	int32 Clairvoyance;
-	uint8 unknown18;	//Power Source Capacity or evolve filename?
-	uint32 evolve_string; // Some String, but being evolution related is just a guess
+	int32 SubType;
+	uint8 evolve_string; // Some String, but being evolution related is just a guess
 	uint8 unknown19;
 	uint16 unknown20;
 	uint8 unknown21;

--- a/common/patches/rof_structs.h
+++ b/common/patches/rof_structs.h
@@ -4744,8 +4744,8 @@ struct ItemQuaternaryBodyStruct
 	int32 HealAmt;
 	int32 SpellDmg;
 	int32 Clairvoyance;
-	uint8 unknown18;	//Power Source Capacity or evolve filename?
-	uint32 evolve_string; // Some String, but being evolution related is just a guess
+	int32 SubType;
+	uint8 evolve_string; // Some String, but being evolution related is just a guess
 	uint8 unknown19;
 	uint32 unknown20;	// Bard Stuff?
 	//uint32 unknown21;

--- a/common/patches/uf_structs.h
+++ b/common/patches/uf_structs.h
@@ -4215,8 +4215,8 @@ struct ItemQuaternaryBodyStruct
 	int32 HealAmt;
 	int32 SpellDmg;
 	int32 Clairvoyance;
-	uint8 unknown18;	//Power Source Capacity or evolve filename?
-	uint32 evolve_string; // Some String, but being evolution related is just a guess
+	int32 SubType;
+	uint8 evolve_string; // Some String, but being evolution related is just a guess
 	uint8 unknown19;
 	uint32 unknown20;	// Bard Stuff?
 	uint32 unknown21;


### PR DESCRIPTION
This maybe in older clients as well, but I couldn't verify it and those
clients never did anything with this field so it doesn't matter.

MQ2 calls this SubClass, but we call the field it's a "sub" of Type so I
figured we'd call it SubType.

We still need to rename the DB field and handle it server side etc