### PR TITLE
Fix edge case with door packets that can cause missing doors on clients

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -2506,7 +2506,11 @@ void EntityList::RemoveAllDoors()
 void EntityList::DespawnAllDoors()
 {
 	auto outapp = new EQApplicationPacket(OP_RemoveAllDoors, 0);
-	this->QueueClients(0,outapp);
+	for (auto it = client_list.begin(); it != client_list.end(); ++it) {
+		if (it->second) {
+			it->second->QueuePacket(outapp);
+		}
+	}
 	safe_delete(outapp);
 }
 


### PR DESCRIPTION
This is a bit of an edge case which causes anguish doors on peq to sometimes be missing on clients

QueueClients in DespawnAllDoors() uses the CLIENT_CONNECTED flag but RespawnAllDoors()
uses default CLIENT_CONNECTINGALL

If a quest script calls a door function that calls these (amv 'close_door' timer calls SetOpenType()) while a character is zoning in the client receives the OP_SpawnDoor packets immediately but doesn't receive any of the OP_RemoveAllDoors packets until after zoning is complete

I don't know if using CLIENT_CONNECTED for RespawnAllDoors() instead is a better approach