### PR TITLE
Fix #findzone to allow you to search using part of a zone's short name.

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -4125,7 +4125,8 @@ void command_findzone(Client *c, const Seperator *sep)
 		 */
 		if (id == 0) {
 			query = fmt::format(
-				"SELECT zoneidnumber, short_name, long_name, version FROM zone WHERE long_name LIKE '%{}%'",
+				"SELECT zoneidnumber, short_name, long_name, version FROM zone WHERE long_name LIKE '%{}%' OR `short_name` LIKE '%{}%'",
+				EscapeString(sep->arg[1]),				
 				EscapeString(sep->arg[1])
 			);
 		}


### PR DESCRIPTION
Some zones like 'soldungb' are hard to search for because their long name isn't similar to their short name, this will make life a lot easier for people searching for zones.