### PR TITLE
Prevent mob from moving from point of aggro until after calls for help are issued.

### DIFF
--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -1319,7 +1319,7 @@ void Mob::AI_Process() {
 						FaceTarget();
 					}
 				}
-				else if (AI_movement_timer->Check() && target) {
+				else if (AI_movement_timer->Check() && target && CastToNPC()->GetCombatEvent()) {
 					if (!IsRooted()) {
 						LogAI("Pursuing [{}] while engaged", target->GetName());
 						RunTo(target->GetX(), target->GetY(), target->GetZ());

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -1321,7 +1321,7 @@ void Mob::AI_Process() {
 				}
 				// mob/npc waits until call for help complete, others can move
 				else if (AI_movement_timer->Check() && target &&
-						(IsPet() || IsMerc() || IsBot() ||
+						(GetOwnerID() || IsBot() ||
 						CastToNPC()->GetCombatEvent())) {
 					if (!IsRooted()) {
 						LogAI("Pursuing [{}] while engaged", target->GetName());

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -1319,7 +1319,9 @@ void Mob::AI_Process() {
 						FaceTarget();
 					}
 				}
-				else if (AI_movement_timer->Check() && target && CastToNPC()->GetCombatEvent()) {
+				else if (AI_movement_timer->Check() &&
+						(IsPet() || IsMerc() || IsBot() ||
+						(target && CastToNPC()->GetCombatEvent()))) {
 					if (!IsRooted()) {
 						LogAI("Pursuing [{}] while engaged", target->GetName());
 						RunTo(target->GetX(), target->GetY(), target->GetZ());

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -1319,9 +1319,10 @@ void Mob::AI_Process() {
 						FaceTarget();
 					}
 				}
-				else if (AI_movement_timer->Check() &&
+				// mob/npc waits until call for help complete, others can move
+				else if (AI_movement_timer->Check() && target &&
 						(IsPet() || IsMerc() || IsBot() ||
-						(target && CastToNPC()->GetCombatEvent()))) {
+						CastToNPC()->GetCombatEvent())) {
 					if (!IsRooted()) {
 						LogAI("Pursuing [{}] while engaged", target->GetName());
 						RunTo(target->GetX(), target->GetY(), target->GetZ());

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -192,7 +192,7 @@ void Mob::DoSpecialAttackDamage(Mob *who, EQ::skills::SkillType skill, int32 bas
 
 	DoAttack(who, my_hit);
 
-	who->AddToHateList(this, hate, 0, false);
+	who->AddToHateList(this, hate, 0);
 	if (my_hit.damage_done > 0 && aabonuses.SkillAttackProc[0] && aabonuses.SkillAttackProc[1] == skill &&
 	    IsValidSpell(aabonuses.SkillAttackProc[2])) {
 		float chance = aabonuses.SkillAttackProc[0] / 1000.0f;
@@ -870,7 +870,7 @@ void Mob::DoArcheryAttackDmg(Mob *other, const EQ::ItemInstance *RangeWeapon, co
 	}
 
 	if (IsClient() && !CastToClient()->GetFeigned())
-		other->AddToHateList(this, hate, 0, false);
+		other->AddToHateList(this, hate, 0);
 
 	other->Damage(this, TotalDmg, SPELL_UNKNOWN, EQ::skills::SkillArchery);
 
@@ -1200,9 +1200,9 @@ void NPC::DoRangedAttackDmg(Mob* other, bool Launch, int16 damage_mod, int16 cha
 
 	if (TotalDmg > 0) {
 		TotalDmg += TotalDmg * damage_mod / 100;
-		other->AddToHateList(this, TotalDmg, 0, false);
+		other->AddToHateList(this, TotalDmg, 0);
 	} else {
-		other->AddToHateList(this, 0, 0, false);
+		other->AddToHateList(this, 0, 0);
 	}
 
 	other->Damage(this, TotalDmg, SPELL_UNKNOWN, skillInUse);
@@ -1384,7 +1384,7 @@ void Mob::DoThrowingAttackDmg(Mob *other, const EQ::ItemInstance *RangeWeapon, c
 	}
 
 	if (IsClient() && !CastToClient()->GetFeigned())
-		other->AddToHateList(this, WDmg, 0, false);
+		other->AddToHateList(this, WDmg, 0);
 
 	other->Damage(this, TotalDmg, SPELL_UNKNOWN, EQ::skills::SkillThrowing);
 
@@ -2158,7 +2158,7 @@ void Mob::DoMeleeSkillAttackDmg(Mob *other, uint16 weapon_damage, EQ::skills::Sk
 		CanSkillProc = false;			    // Disable skill procs
 	}
 
-	other->AddToHateList(this, hate, 0, false);
+	other->AddToHateList(this, hate, 0);
 	if (damage > 0 && aabonuses.SkillAttackProc[0] && aabonuses.SkillAttackProc[1] == skillinuse &&
 	    IsValidSpell(aabonuses.SkillAttackProc[2])) {
 		float chance = aabonuses.SkillAttackProc[0] / 1000.0f;


### PR DESCRIPTION
Mob_ai was using the engaged flag to decide when to start navigating toward a target.  This flag is a reflection of the hatelist being non-empty.  As is stood, the hatelist is added to early in the process, and calls for help have not yet been processed.  This resulted in the mob moving, sometimes a significant distance, before calls for help were sent out.

I changed mob_ai to only start moving toward the target after the CombatEvent has been set (which is done by all calls to AI_Event_Engaged).

This wasn't enough, as all special attacks were using callforhelp=false, which resulted in AI_Event_Engaged not calling for help, but setting the flag.

I changes all special attacks to use callforhelp=true and this seems to work.

Pulling via throwing or arrows now properly calls for help BEFORE mob_ai code starts moving the pulled mob toward the target.  Seems good, but seek advice.  

I will be testing this starting now on my server with a player load.

