### PR TITLE
Repair #grid show command

### DIFF
--- a/common/string_util.cpp
+++ b/common/string_util.cpp
@@ -527,3 +527,51 @@ bool isAlphaNumeric(const char *text)
 
 	return true;
 }
+
+// Function to convert single digit or two digit number into words
+std::string convert2digit(int n, std::string suffix)
+{
+	// if n is zero
+	if (n == 0) {
+		return "";
+	}
+
+	// split n if it is more than 19
+	if (n > 19) {
+		return NUM_TO_ENGLISH_Y[n / 10] + NUM_TO_ENGLISH_X[n % 10] + suffix;
+	}
+	else {
+		return NUM_TO_ENGLISH_X[n] + suffix;
+	}
+}
+
+// Function to convert a given number (max 9-digits) into words
+std::string numberToWords(unsigned long long int n)
+{
+	// string to store word representation of given number
+	std::string res;
+
+	// this handles digits at ones & tens place
+	res = convert2digit((n % 100), "");
+
+	if (n > 100 && n % 100) {
+		res = "and " + res;
+	}
+
+	// this handles digit at hundreds place
+	res = convert2digit(((n / 100) % 10), "Hundred ") + res;
+
+	// this handles digits at thousands & tens thousands place
+	res = convert2digit(((n / 1000) % 100), "Thousand ") + res;
+
+	// this handles digits at hundred thousands & one millions place
+	res = convert2digit(((n / 100000) % 100), "Lakh, ") + res;
+
+	// this handles digits at ten millions & hundred millions place
+	res = convert2digit((n / 10000000) % 100, "Crore, ") + res;
+
+	// this handles digits at ten millions & hundred millions place
+	res = convert2digit((n / 1000000000) % 100, "Billion, ") + res;
+
+	return res;
+}

--- a/common/string_util.h
+++ b/common/string_util.h
@@ -43,6 +43,20 @@ std::vector<std::string> split(std::string str_to_split, char delimiter);
 const std::string StringFormat(const char* format, ...);
 const std::string vStringFormat(const char* format, va_list args);
 std::string implode(std::string glue, std::vector<std::string> src);
+std::string convert2digit(int n, std::string suffix);
+std::string numberToWords(unsigned long long int n);
+
+// For converstion of numerics into English
+// Used for grid nodes, as NPC names remove numerals.
+// But general purpose
+
+const std::string NUM_TO_ENGLISH_X[] = { "", "One ", "Two ", "Three ", "Four ",
+				"Five ", "Six ", "Seven ", "Eight ", "Nine ", "Ten ", "Eleven ",
+				"Twelve ", "Thirteen ", "Fourteen ", "Fifteen ",
+				"Sixteen ", "Seventeen ", "Eighteen ", "Nineteen " };
+
+const std::string NUM_TO_ENGLISH_Y[] = { "", "", "Twenty ", "Thirty ", "Forty ",
+				"Fifty ", "Sixty ", "Seventy ", "Eighty ", "Ninety " };
 
 /**
  * @param str
@@ -189,5 +203,8 @@ uint32 hextoi(const char* num);
 uint64 hextoi64(const char* num);
 void MakeLowerString(const char *source, char *target);
 void RemoveApostrophes(std::string &s);
+std::string convert2digit(int n, std::string suffix);
+std::string numberToWords(unsigned long long int n);
+
 
 #endif

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -2477,7 +2477,9 @@ void command_grid(Client *c, const Seperator *sep)
 			glm::vec4 node_position = glm::vec4(atof(row[0]), atof(row[1]), atof(row[2]), atof(row[3]));
 
 			std::vector<float> node_loc {
-					node_position.x, node_position.y, node_position.z
+					node_position.x, 
+					node_position.y, 
+					node_position.z
 			};
 
 			// If we already have a node at this location, set the z offset

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -2438,10 +2438,10 @@ void command_grid(Client *c, const Seperator *sep)
 		}
 
 		std::string query = StringFormat(
-			"SELECT `x`, `y`, `z`, `heading`, `number`, `pause` "
+			"SELECT `x`, `y`, `z`, `heading`, `number` "
 			"FROM `grid_entries` "
 			"WHERE `zoneid` = %u and `gridid` = %i "
-			"ORDER BY `number` ",
+			"ORDER BY `number`",
 			zone->GetZoneID(),
 			target->CastToNPC()->GetGrid()
 		);
@@ -2471,18 +2471,29 @@ void command_grid(Client *c, const Seperator *sep)
 		/**
 		 * Spawn grid nodes
 		 */
-		for (auto row = results.begin(); row != results.end(); ++row) {
-			auto node_position = glm::vec4(atof(row[0]), atof(row[1]), atof(row[2]), atof(row[3]));
+		std::map<std::vector<float>, int32> zoffset;
 
-			NPC *npc = NPC::SpawnGridNodeNPC(
-				target->GetCleanName(),
-				node_position,
-				static_cast<uint32>(target->CastToNPC()->GetGrid()),
-				static_cast<uint32>(atoi(row[4])),
-				static_cast<uint32>(atoi(row[5]))
-			);
-			npc->SetFlyMode(GravityBehavior::Flying);
-			npc->GMMove(node_position.x, node_position.y, node_position.z, node_position.w);
+		for (auto row = results.begin(); row != results.end(); ++row) {
+			glm::vec4 node_position = glm::vec4(atof(row[0]), atof(row[1]), atof(row[2]), atof(row[3]));
+
+			std::vector<float> node_loc {
+					node_position.x, node_position.y, node_position.z
+			};
+
+			// If we already have a node at this location, set the z offset
+			// higher from the existing one so we can see it.  Adjust so if
+			// there is another at the same spot we adjust again.
+			auto search = zoffset.find(node_loc);
+			if (search != zoffset.end()) {
+				search->second = search->second + 3;
+			}
+			else {
+				zoffset[node_loc] = 0.0;
+			}
+
+			node_position.z += zoffset[node_loc];
+
+			NPC::SpawnGridNodeNPC(node_position,atoi(row[4]),zoffset[node_loc]);
 		}
 	}
 	else if (strcasecmp("delete", sep->arg[1]) == 0) {

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -1074,11 +1074,11 @@ void NPC::SpawnGridNodeNPC(const glm::vec4 &position, int32 grid_number, int32 z
 	memset(npc_type, 0, sizeof(NPCType));
 
 	std::string str_zoffset = numberToWords(zoffset);
-	std::string str_number= numberToWords(grid_number);
+	std::string str_number = numberToWords(grid_number);
 
 	strcpy(npc_type->name, str_number.c_str());
 	if (zoffset != 0) {
-		strcat(npc_type->name, "(Zoffset)");
+		strcat(npc_type->name, "(Stacked)");
 	}
 
 	npc_type->current_hp       = 4000000;

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -1068,14 +1068,20 @@ bool NPC::SpawnZoneController()
 	return true;
 }
 
-NPC * NPC::SpawnGridNodeNPC(std::string name, const glm::vec4 &position, uint32 grid_id, uint32 grid_number, uint32 pause) {
+void NPC::SpawnGridNodeNPC(const glm::vec4 &position, int32 grid_number, int32 zoffset) {
+
 	auto npc_type = new NPCType;
 	memset(npc_type, 0, sizeof(NPCType));
 
-	sprintf(npc_type->name, "%u_%u", grid_id, grid_number);
-	sprintf(npc_type->lastname, "Number: %u Grid: %u Pause: %u", grid_number, grid_id, pause);
+	std::string str_zoffset = numberToWords(zoffset);
+	std::string str_number= numberToWords(grid_number);
 
-	npc_type->current_hp           = 4000000;
+	strcpy(npc_type->name, str_number.c_str());
+	if (zoffset != 0) {
+		strcat(npc_type->name, "(Zoffset)");
+	}
+
+	npc_type->current_hp       = 4000000;
 	npc_type->max_hp           = 4000000;
 	npc_type->race             = 2254;
 	npc_type->gender           = 2;
@@ -1095,11 +1101,12 @@ NPC * NPC::SpawnGridNodeNPC(std::string name, const glm::vec4 &position, uint32 
 
 	auto node_position = glm::vec4(position.x, position.y, position.z, position.w);
 	auto npc           = new NPC(npc_type, nullptr, node_position, GravityBehavior::Flying);
+
+	npc->name[strlen(npc->name)-3] = (char) NULL;
+
 	npc->GiveNPCTypeData(npc_type);
 
-	entity_list.AddNPC(npc, true, true);
-
-	return npc;
+	entity_list.AddNPC(npc);
 }
 
 NPC * NPC::SpawnNodeNPC(std::string name, std::string last_name, const glm::vec4 &position) {

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -112,7 +112,7 @@ public:
 	virtual ~NPC();
 
 	static NPC *SpawnNodeNPC(std::string name, std::string last_name, const glm::vec4 &position);
-	static NPC *SpawnGridNodeNPC(std::string name, const glm::vec4 &position, uint32 grid_id, uint32 grid_number, uint32 pause);
+	static void SpawnGridNodeNPC(const glm::vec4 &position, int32 grid_number, int32 zoffset);
 
 	//abstract virtual function implementations requird by base abstract class
 	virtual bool Death(Mob* killerMob, int32 damage, uint16 spell_id, EQ::skills::SkillType attack_skill);


### PR DESCRIPTION

I had been trying to use #grid show in game to help debug some pathing issues.  I quickly noticed that in many cases, the node names did not match, or even come close to the grid nodes.

After investigation, the code was trying to spawn nodes named aaa_bbb where aaa is the grid # and bbb is the node number.  This was failing in a number of ways.  The creating of the NPC was stripping all numbers, leaving the node named '_'.  Then, the entity list code was making it unique, adding 000, 001, 002 on the end.  The resulting nodes were all _000, _001, _002 where the values were not guaranteed to match the node numbers, and in faction, when used in repetition, sometimes node 0 ended up being some arbitrary available number.  This is due to timing and the cleaning up of used values.

Also, if a grid reuses the same location, the values are impossible to read as the nodes stack  onto each other.

This PR replaces the names with text.  It also staggers the nodes that are literally on top of each other so they are readable.  For those nodes, Z is altered for readability.

This video shows how the nodes look now.   Clicking the link fails (I don't know why),  Cut-n-paste it into a browser and it works fine.

[http://norrath.no-ip.org/gridshow.mp4](url)