### PR TITLE
Extend spell casting support.

### DIFF
--- a/zone/client.h
+++ b/zone/client.h
@@ -952,6 +952,7 @@ public:
 	void SendDisciplineUpdate();
 	void SendDisciplineTimer(uint32 timer_id, uint32 duration);
 	bool UseDiscipline(uint32 spell_id, uint32 target);
+	void ResetDisciplineTimer(uint32 timer_id);
 
 	void SetLinkedSpellReuseTimer(uint32 timer_id, uint32 duration);
 	bool IsLinkedSpellReuseTimerReady(uint32 timer_id);

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -1505,11 +1505,13 @@ void PerlembParser::ExportEventVariables(
 			break;
 		}
 
+		case EVENT_SPELL_FADE:
 		case EVENT_SPELL_EFFECT_CLIENT:
 		case EVENT_SPELL_EFFECT_NPC:
 		case EVENT_SPELL_BUFF_TIC_CLIENT:
 		case EVENT_SPELL_BUFF_TIC_NPC: {
 			ExportVar(package_name.c_str(), "caster_id", extradata);
+			ExportVar(package_name.c_str(), "spell_id", data);
 			break;
 		}
 

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -850,6 +850,11 @@ bool Lua_Client::UseDiscipline(int spell_id, int target_id) {
 	return self->UseDiscipline(spell_id, target_id);
 }
 
+void Lua_Client::ResetDisciplineTimer(int timer_id) {
+	Lua_Safe_Call_Void();
+	self->ResetDisciplineTimer(timer_id);
+}
+
 int Lua_Client::GetCharacterFactionLevel(int faction_id) {
 	Lua_Safe_Call_Int();
 	return self->GetCharacterFactionLevel(faction_id);
@@ -1753,6 +1758,7 @@ luabind::scope lua_register_client() {
 		.def("CalcPriceMod", (float(Lua_Client::*)(Lua_Mob,bool))&Lua_Client::CalcPriceMod)
 		.def("ResetTrade", (void(Lua_Client::*)(void))&Lua_Client::ResetTrade)
 		.def("UseDiscipline", (bool(Lua_Client::*)(int,int))&Lua_Client::UseDiscipline)
+		.def("ResetDisciplineTimer", (void(Lua_Client::*)(int))&Lua_Client::ResetDisciplineTimer)
 		.def("GetCharacterFactionLevel", (int(Lua_Client::*)(int))&Lua_Client::GetCharacterFactionLevel)
 		.def("SetZoneFlag", (void(Lua_Client::*)(int))&Lua_Client::SetZoneFlag)
 		.def("ClearZoneFlag", (void(Lua_Client::*)(int))&Lua_Client::ClearZoneFlag)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -197,6 +197,7 @@ public:
 	float CalcPriceMod(Lua_Mob other, bool reverse);
 	void ResetTrade();
 	bool UseDiscipline(int spell_id, int target_id);
+	void ResetDisciplineTimer(int timer_id);
 	int GetCharacterFactionLevel(int faction_id);
 	void SetZoneFlag(int zone_id);
 	void ClearZoneFlag(int zone_id);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -3670,6 +3670,30 @@ XS(XS_Client_UseDiscipline) {
 	XSRETURN(1);
 }
 
+XS(XS_Client_ResetDisciplineTimer); /* prototype to pass -Wmissing-prototypes */
+XS(XS_Client_ResetDisciplineTimer)
+{
+	dXSARGS;
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: Client::ResetDisciplineTimer(THIS, timer_id)");
+	{
+		Client*		THIS;
+		uint32		timer_id = (uint32)SvUV(ST(1));
+
+		if (sv_derived_from(ST(0), "Client")) {
+			IV tmp = SvIV((SV*)SvRV(ST(0)));
+			THIS = INT2PTR(Client *,tmp);
+		}
+		else
+			Perl_croak(aTHX_ "THIS is not of type Client");
+		if(THIS == nullptr)
+			Perl_croak(aTHX_ "THIS is nullptr, avoiding crash.");
+
+		THIS->ResetDisciplineTimer(timer_id);
+	}
+	XSRETURN_EMPTY;
+}
+
 XS(XS_Client_GetCharacterFactionLevel); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Client_GetCharacterFactionLevel) {
 	dXSARGS;
@@ -6548,6 +6572,7 @@ XS(boot_Client) {
 	newXSproto(strcpy(buf, "RefundAA"), XS_Client_RefundAA, file, "$$");
 	newXSproto(strcpy(buf, "RemoveNoRent"), XS_Client_RemoveNoRent, file, "$");
 	newXSproto(strcpy(buf, "ResetAA"), XS_Client_ResetAA, file, "$");
+	newXSproto(strcpy(buf, "ResetDisciplineTimer"), XS_Client_ResetDisciplineTimer, file, "$$");
 	newXSproto(strcpy(buf, "ResetTrade"), XS_Client_ResetTrade, file, "$");
 	newXSproto(strcpy(buf, "Save"), XS_Client_Save, file, "$$");
 	newXSproto(strcpy(buf, "SaveBackup"), XS_Client_SaveBackup, file, "$");

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -298,8 +298,16 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 	if(IsClient()) {
 		char temp[64];
 		sprintf(temp, "%d", spell_id);
-		if (parse->EventPlayer(EVENT_CAST_BEGIN, CastToClient(), temp, 0) != 0)
+		if (parse->EventPlayer(EVENT_CAST_BEGIN, CastToClient(), temp, 0) != 0) {
+			if (IsDiscipline(spell_id)) {
+				InterruptSpell(5805, 0x121, spell_id);
+				CastToClient()->SendDisciplineTimer(spells[spell_id].EndurTimerIndex, 1);
+			} else {
+				InterruptSpell(INSUFFICIENT_MANA, 0x121, spell_id);
+				CastToClient()->SendSpellBarEnable(spell_id);
+			}
 			return false;
+		}
 	} else if(IsNPC()) {
 		char temp[64];
 		sprintf(temp, "%d", spell_id);


### PR DESCRIPTION
Add support from Natedog's code.
[Add proper interrupt support.](https://github.com/tiniq007/Server/commit/c461461493fa627f788496a8abd0bada46894e76)
[Export spell ID for buff scripts.](https://github.com/tiniq007/Server/commit/b7bb260bef627e28ba645f386eea5de9559c43aa)
[Set EVENT_SPELL_FADE to follow the same logic as the other quest spell events.](https://github.com/tiniq007/Server/commit/43e0df413c94a72c729fe56cf0bb34a046479836)
[Add ResetDisciplineTimer to Perl/Lua.](https://github.com/tiniq007/Server/commit/a47b16577dcc3b0f0154321772549a7084a422fb)