### PR TITLE
Fix $npc->RecalculateSkills() in Perl.

### DIFF
--- a/zone/perl_npc.cpp
+++ b/zone/perl_npc.cpp
@@ -2479,7 +2479,7 @@ XS(XS_NPC_SetSimpleRoamBox) {
 XS(XS_NPC_RecalculateSkills); /* prototype to pass -Wmissing-prototypes */
 XS(XS_NPC_RecalculateSkills) {
 	dXSARGS;
-	if (items != 2)
+	if (items != 1)
 		Perl_croak(aTHX_ "Usage: NPC::RecalculateSkills(THIS)");
 	{
 		NPC    *THIS;


### PR DESCRIPTION
Currently you have to add an errant parameter (i.e. $npc->RecalculateSkills(1);) to make this function "properly". This fixes that.