### PR TITLE
Add cross-zone player move utilities to Perl/Lua.

### DIFF
--- a/common/servertalk.h
+++ b/common/servertalk.h
@@ -211,6 +211,10 @@
 #define ServerOP_CZTaskAssignGroup 0x4026
 #define ServerOP_CZTaskAssignRaid 0x4027
 #define ServerOP_CZTaskAssignGuild 0x4028
+#define ServerOP_CZMovePlayer 0x4029
+#define ServerOP_CZMoveGroup 0x4030
+#define ServerOP_CZMoveRaid 0x4031
+#define ServerOP_CZMoveGuild 0x4032
 
 /**
  * QueryServer
@@ -1406,6 +1410,26 @@ struct CZMessageGuild_Struct {
 	uint32 Type;
 	int GuildID;
 	char Message[512];
+};
+
+struct CZMovePlayer_Struct {
+	int character_id;
+	char zone_short_name[32];
+};
+
+struct CZMoveGroup_Struct {
+	int group_id;
+	char zone_short_name[32];
+};
+
+struct CZMoveRaid_Struct {
+	int raid_id;
+	char zone_short_name[32];
+};
+
+struct CZMoveGuild_Struct {
+	int guild_id;
+	char zone_short_name[32];
 };
 
 struct WWMarquee_Struct {

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -1255,6 +1255,10 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 	case ServerOP_CZTaskAssignGroup:
 	case ServerOP_CZTaskAssignRaid:
 	case ServerOP_CZTaskAssignGuild:
+	case ServerOP_CZMovePlayer:
+	case ServerOP_CZMoveGroup:
+	case ServerOP_CZMoveRaid:
+	case ServerOP_CZMoveGuild:
 	case ServerOP_WWMarquee:
 	case ServerOP_DepopAllPlayersCorpses:
 	case ServerOP_DepopPlayerCorpse:

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -3976,6 +3976,70 @@ XS(XS__crosszonemessageplayerbyguildid) {
 	XSRETURN_EMPTY;
 }
 
+XS(XS__crosszonemoveplayerbycharid);
+XS(XS__crosszonemoveplayerbycharid) {
+	dXSARGS;
+
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: quest::crosszonemoveplayerbycharid(int character_id, string zone_short_name)");
+
+	if (items == 2) {
+		int character_id = (int) SvIV(ST(0));
+		char *zone_short_name = (char *) SvPV_nolen(ST(1));
+		quest_manager.CrossZoneMovePlayerByCharID(character_id, zone_short_name);
+	}
+
+	XSRETURN_EMPTY;
+}
+
+XS(XS__crosszonemoveplayerbygroupid);
+XS(XS__crosszonemoveplayerbygroupid) {
+	dXSARGS;
+
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: quest::crosszonemoveplayerbygroupid(int group_id, string zone_short_name)");
+
+	if (items == 2) {
+		int group_id = (int) SvIV(ST(0));
+		char *zone_short_name = (char *) SvPV_nolen(ST(1));
+		quest_manager.CrossZoneMovePlayerByGroupID(group_id, zone_short_name);
+	}
+
+	XSRETURN_EMPTY;
+}
+
+XS(XS__crosszonemoveplayerbyraidid);
+XS(XS__crosszonemoveplayerbyraidid) {
+	dXSARGS;
+
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: quest::crosszonemoveplayerbyraidid(int raid_id, string zone_short_name)");
+
+	if (items == 2) {
+		int raid_id = (int) SvIV(ST(0));
+		char *zone_short_name = (char *) SvPV_nolen(ST(1));
+		quest_manager.CrossZoneMovePlayerByRaidID(raid_id, zone_short_name);
+	}
+
+	XSRETURN_EMPTY;
+}
+
+XS(XS__crosszonemoveplayerbyguildid);
+XS(XS__crosszonemoveplayerbyguildid) {
+	dXSARGS;
+
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: quest::crosszonemoveplayerbyguildid(int guild_id, string zone_short_name)");
+
+	if (items == 2) {
+		int guild_id = (int) SvIV(ST(0));
+		char *zone_short_name = (char *) SvPV_nolen(ST(1));
+		quest_manager.CrossZoneMovePlayerByGuildID(guild_id, zone_short_name);
+	}
+
+	XSRETURN_EMPTY;
+}
+
 XS(XS__enablerecipe);
 XS(XS__enablerecipe) {
 	dXSARGS;
@@ -4450,6 +4514,10 @@ EXTERN_C XS(boot_quest) {
 	newXS(strcpy(buf, "crosszonemessageplayerbygroupid"), XS__crosszonemessageplayerbygroupid, file);
 	newXS(strcpy(buf, "crosszonemessageplayerbyraidid"), XS__crosszonemessageplayerbyraidid, file);
 	newXS(strcpy(buf, "crosszonemessageplayerbyguildid"), XS__crosszonemessageplayerbyguildid, file);
+	newXS(strcpy(buf, "crosszonemoveplayerbycharid"), XS__crosszonemoveplayerbycharid, file);
+	newXS(strcpy(buf, "crosszonemoveplayerbygroupid"), XS__crosszonemoveplayerbygroupid, file);
+	newXS(strcpy(buf, "crosszonemoveplayerbyraidid"), XS__crosszonemoveplayerbyraidid, file);
+	newXS(strcpy(buf, "crosszonemoveplayerbyguildid"), XS__crosszonemoveplayerbyguildid, file);
 	newXS(strcpy(buf, "crosszonesetentityvariablebynpctypeid"), XS__crosszonesetentityvariablebynpctypeid, file);
 	newXS(strcpy(buf, "crosszonesetentityvariablebyclientname"), XS__crosszonesetentityvariablebyclientname, file);
 	newXS(strcpy(buf, "crosszonesetentityvariablebygroupid"), XS__crosszonesetentityvariablebygroupid, file);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -1090,6 +1090,22 @@ void lua_cross_zone_message_player_by_guild_id(uint32 type, int guild_id, const 
 	quest_manager.CrossZoneMessagePlayerByGuildID(type, guild_id, message);
 }
 
+void lua_cross_zone_move_player_by_char_id(int character_id, const char *zone_short_name) {
+	quest_manager.CrossZoneMovePlayerByCharID(character_id, zone_short_name);
+}
+
+void lua_cross_zone_move_player_by_group_id(int group_id, const char *zone_short_name) {
+	quest_manager.CrossZoneMovePlayerByGroupID(group_id, zone_short_name);
+}
+
+void lua_cross_zone_move_player_by_raid_id(int raid_id, const char *zone_short_name) {
+	quest_manager.CrossZoneMovePlayerByRaidID(raid_id, zone_short_name);
+}
+
+void lua_cross_zone_move_player_by_guild_id(int guild_id, const char *zone_short_name) {
+	quest_manager.CrossZoneMovePlayerByGuildID(guild_id, zone_short_name);
+}
+
 void lua_cross_zone_set_entity_variable_by_client_name(const char *player, const char *id, const char *m_var) {
 	quest_manager.CrossZoneSetEntityVariableByClientName(player, id, m_var);
 }
@@ -1935,6 +1951,10 @@ luabind::scope lua_register_general() {
 		luabind::def("cross_zone_message_player_by_group_id", &lua_cross_zone_message_player_by_group_id),
 		luabind::def("cross_zone_message_player_by_raid_id", &lua_cross_zone_message_player_by_raid_id),
 		luabind::def("cross_zone_message_player_by_guild_id", &lua_cross_zone_message_player_by_guild_id),
+		luabind::def("cross_zone_move_player_by_char_id", &lua_cross_zone_move_player_by_char_id),
+		luabind::def("cross_zone_move_player_by_group_id", &lua_cross_zone_move_player_by_group_id),
+		luabind::def("cross_zone_move_player_by_raid_id", &lua_cross_zone_move_player_by_raid_id),
+		luabind::def("cross_zone_move_player_by_guild_id", &lua_cross_zone_move_player_by_guild_id),
 		luabind::def("cross_zone_set_entity_variable_by_client_name", &lua_cross_zone_set_entity_variable_by_client_name),
 		luabind::def("cross_zone_set_entity_variable_by_group_id", &lua_cross_zone_set_entity_variable_by_group_id),
 		luabind::def("cross_zone_set_entity_variable_by_raid_id", &lua_cross_zone_set_entity_variable_by_raid_id),

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -3428,6 +3428,46 @@ void QuestManager::CrossZoneMessagePlayerByGuildID(uint32 Type, int GuildID, con
 	safe_delete(pack);
 }
 
+void QuestManager::CrossZoneMovePlayerByCharID(int character_id, const char *zone_short_name){
+	uint32 message_len = strlen(zone_short_name) + 1;
+	auto pack = new ServerPacket(ServerOP_CZMovePlayer, sizeof(CZMovePlayer_Struct) + message_len);
+	CZMovePlayer_Struct* CZGM = (CZMovePlayer_Struct*) pack->pBuffer;
+	CZGM->character_id = character_id;
+	strn0cpy(CZGM->zone_short_name, zone_short_name, 32);
+	worldserver.SendPacket(pack);
+	safe_delete(pack);
+}
+
+void QuestManager::CrossZoneMovePlayerByGroupID(int group_id, const char *zone_short_name){
+	uint32 message_len = strlen(zone_short_name) + 1;
+	auto pack = new ServerPacket(ServerOP_CZMoveGroup, sizeof(CZMoveGroup_Struct) + message_len);
+	CZMoveGroup_Struct* CZGM = (CZMoveGroup_Struct*) pack->pBuffer;
+	CZGM->group_id = group_id;
+	strn0cpy(CZGM->zone_short_name, zone_short_name, 32);
+	worldserver.SendPacket(pack);
+	safe_delete(pack);
+}
+
+void QuestManager::CrossZoneMovePlayerByRaidID(int raid_id, const char *zone_short_name){
+	uint32 message_len = strlen(zone_short_name) + 1;
+	auto pack = new ServerPacket(ServerOP_CZMoveRaid, sizeof(CZMoveRaid_Struct) + message_len);
+	CZMoveRaid_Struct* CZRM = (CZMoveRaid_Struct*) pack->pBuffer;
+	CZRM->raid_id = raid_id;
+	strn0cpy(CZRM->zone_short_name, zone_short_name, 32);
+	worldserver.SendPacket(pack);
+	safe_delete(pack);
+}
+
+void QuestManager::CrossZoneMovePlayerByGuildID(int guild_id, const char *zone_short_name){
+	uint32 message_len = strlen(zone_short_name) + 1;
+	auto pack = new ServerPacket(ServerOP_CZMoveGuild, sizeof(CZMoveGuild_Struct) + message_len);
+	CZMoveGuild_Struct* CZGM = (CZMoveGuild_Struct*) pack->pBuffer;
+	CZGM->guild_id = guild_id;
+	strn0cpy(CZGM->zone_short_name, zone_short_name, 32);
+	worldserver.SendPacket(pack);
+	safe_delete(pack);
+}
+
 void QuestManager::CrossZoneSetEntityVariableByClientName(const char *CharName, const char *id, const char *m_var){
 	uint32 message_len = strlen(id) + 1;
 	uint32 message_len2 = strlen(m_var) + 1;

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -299,6 +299,10 @@ public:
 	void CrossZoneMessagePlayerByGroupID(uint32 Type, int GroupID, const char *Message);
 	void CrossZoneMessagePlayerByRaidID(uint32 Type, int RaidID, const char *Message);
 	void CrossZoneMessagePlayerByGuildID(uint32 Type, int GuildID, const char *Message);
+	void CrossZoneMovePlayerByCharID(int character_id, const char *zone_short_name);
+	void CrossZoneMovePlayerByGroupID(int group_id, const char *zone_short_name);
+	void CrossZoneMovePlayerByRaidID(int raid_id, const char *zone_short_name);
+	void CrossZoneMovePlayerByGuildID(int guild_id, const char *zone_short_name);
 	void WorldWideMarquee(uint32 Type, uint32 Priority, uint32 FadeIn, uint32 FadeOut, uint32 Duration, const char *Message);
 	bool EnableRecipe(uint32 recipe_id);
 	bool DisableRecipe(uint32 recipe_id);

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -2044,7 +2044,6 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 	case ServerOP_CZTaskAssign:
 	{
 		CZTaskAssign_Struct* CZTA = (CZTaskAssign_Struct*)pack->pBuffer;
-		auto client_list = entity_list.GetClientList();
 		Client* client = entity_list.GetClientByCharID(CZTA->character_id);
 		if (client != 0) {
 			client->AssignTask(CZTA->task_id, CZTA->npc_entity_id, CZTA->enforce_level_requirement);
@@ -2080,6 +2079,48 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 		for (auto client : client_list) {
 			if (client.second->GuildID() > 0 && client.second->GuildID() == CZTA->guild_id) {
 				client.second->AssignTask(CZTA->task_id, CZTA->npc_entity_id, CZTA->enforce_level_requirement);
+			}
+		}
+		break;
+	}
+	case ServerOP_CZMovePlayer:
+	{
+		CZMovePlayer_Struct* CZMP = (CZMovePlayer_Struct*)pack->pBuffer;
+		Client* client = entity_list.GetClientByCharID(CZMP->character_id);
+		if (client != 0) {
+			client->MoveZone(CZMP->zone_short_name);
+		}
+		break;
+	}
+	case ServerOP_CZMoveGroup:
+	{
+		CZMoveGroup_Struct* CZMG = (CZMoveGroup_Struct*)pack->pBuffer;
+		auto client_list = entity_list.GetClientList();
+		for (auto client : client_list) {
+			if (client.second->GetGroup() && client.second->GetGroup()->GetID() == CZMG->group_id) {
+				client.second->MoveZone(CZMG->zone_short_name);
+			}
+		}
+		break;
+	}
+	case ServerOP_CZMoveRaid:
+	{
+		CZMoveRaid_Struct* CZMR = (CZMoveRaid_Struct*)pack->pBuffer;
+		auto client_list = entity_list.GetClientList();
+		for (auto client : client_list) {
+			if (client.second->GetRaid() && client.second->GetRaid()->GetID() == CZMR->raid_id) {
+				client.second->MoveZone(CZMR->zone_short_name);
+			}
+		}
+		break;
+	}
+	case ServerOP_CZMoveGuild:
+	{
+		CZMoveGuild_Struct* CZMG = (CZMoveGuild_Struct*)pack->pBuffer;
+		auto client_list = entity_list.GetClientList();
+		for (auto client : client_list) {
+			if (client.second->GuildID() > 0 && client.second->GuildID() == CZMG->guild_id) {
+				client.second->MoveZone(CZMG->zone_short_name);
 			}
 		}
 		break;


### PR DESCRIPTION
- Add quest::crosszonemoveplayerbycharid(character_id, zone_short_name) to Perl.
- Add eq.cross_zone_move_player_by_char_id(character_id, zone_short_name) to Lua.
- Add quest::crosszonemoveplayerbygroupid(group_id, zone_short_name) to Perl.
- Add eq.cross_zone_move_player_by_group_id(group_id, zone_short_name) to Lua.
- Add quest::crosszonemoveplayerbyraidid(raid_id, zone_short_name) to Perl.
- Add eq.cross_zone_move_player_by_raid_id(raid_id, zone_short_name) to Lua.
- Add quest::crosszonemoveplayerbyguildid(guild_id, zone_short_name) to Perl.
- Add eq.cross_zone_move_player_by_guild_id(guild_id, zone_short_name) to Lua.