### PR TITLE
Windows #hotfix Fix

### DIFF
--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -917,6 +917,7 @@ bool SharedDatabase::LoadItems(const std::string &prefix) {
 		EQ::IPCMutex mutex("items");
 		mutex.Lock();
 		std::string file_name = Config->SharedMemDir + prefix + std::string("items");
+		LogInfo("[Shared Memory] Attempting to load file [{}]", file_name);
 		items_mmf = std::unique_ptr<EQ::MemoryMappedFile>(new EQ::MemoryMappedFile(file_name));
 		items_hash = std::unique_ptr<EQ::FixedMemoryHashSet<EQ::ItemData>>(new EQ::FixedMemoryHashSet<EQ::ItemData>(reinterpret_cast<uint8*>(items_mmf->Get()), items_mmf->Size()));
 		mutex.Unlock();
@@ -1341,6 +1342,7 @@ bool SharedDatabase::LoadNPCFactionLists(const std::string &prefix) {
 		EQ::IPCMutex mutex("faction");
 		mutex.Lock();
 		std::string file_name = Config->SharedMemDir + prefix + std::string("faction");
+		LogInfo("[Shared Memory] Attempting to load file [{}]", file_name);
 		faction_mmf = std::unique_ptr<EQ::MemoryMappedFile>(new EQ::MemoryMappedFile(file_name));
 		faction_hash = std::unique_ptr<EQ::FixedMemoryHashSet<NPCFactionList>>(new EQ::FixedMemoryHashSet<NPCFactionList>(reinterpret_cast<uint8*>(faction_mmf->Get()), faction_mmf->Size()));
 		mutex.Unlock();
@@ -1542,6 +1544,7 @@ bool SharedDatabase::LoadSkillCaps(const std::string &prefix) {
 		EQ::IPCMutex mutex("skill_caps");
 		mutex.Lock();
 		std::string file_name = Config->SharedMemDir + prefix + std::string("skill_caps");
+		LogInfo("[Shared Memory] Attempting to load file [{}]", file_name);
 		skill_caps_mmf = std::unique_ptr<EQ::MemoryMappedFile>(new EQ::MemoryMappedFile(file_name));
 		mutex.Unlock();
 	} catch(std::exception &ex) {
@@ -1700,6 +1703,7 @@ bool SharedDatabase::LoadSpells(const std::string &prefix, int32 *records, const
 	
 		std::string file_name = Config->SharedMemDir + prefix + std::string("spells");
 		spells_mmf = std::unique_ptr<EQ::MemoryMappedFile>(new EQ::MemoryMappedFile(file_name));
+		LogInfo("[Shared Memory] Attempting to load file [{}]", file_name);
 		*records = *reinterpret_cast<uint32*>(spells_mmf->Get());
 		*sp = reinterpret_cast<const SPDat_Spell_Struct*>((char*)spells_mmf->Get() + 4);
 		mutex.Unlock();

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -12832,10 +12832,10 @@ void command_hotfix(Client *c, const Seperator *sep)
 			}
 
 			if (hotfix_name.length() > 0) {
-				if (system(StringFormat("%s -hotfix=%s", shared_memory_path.c_str(), hotfix_name.c_str()).c_str())) {}
+				if (system(StringFormat("\"%s\" -hotfix=%s", shared_memory_path.c_str(), hotfix_name.c_str()).c_str())) {}
 			}
 			else {
-				if (system(StringFormat("%s", shared_memory_path.c_str()).c_str())) {}
+				if (system(StringFormat("\"%s\"", shared_memory_path.c_str()).c_str())) {}
 			}
 #else
 			shared_memory_path = "./shared_memory";

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -12827,7 +12827,7 @@ void command_hotfix(Client *c, const Seperator *sep)
 
 #ifdef WIN32
 			shared_memory_path = "shared_memory";
-			if (file_exists("bin/shared_memory")) {
+			if (file_exists("bin/shared_memory.exe")) {
 				shared_memory_path = "bin/shared_memory";
 			}
 

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -12828,15 +12828,19 @@ void command_hotfix(Client *c, const Seperator *sep)
 #ifdef WIN32
 			shared_memory_path = "shared_memory";
 			if (file_exists("bin/shared_memory.exe")) {
-				shared_memory_path = "bin/shared_memory";
+				shared_memory_path = "bin\\shared_memory.exe";
 			}
 
+			std::string hotfix_command;
 			if (hotfix_name.length() > 0) {
-				if (system(StringFormat("\"%s\" -hotfix=%s", shared_memory_path.c_str(), hotfix_name.c_str()).c_str())) {}
+				hotfix_command = fmt::format("\"{}\" -hotfix={}", shared_memory_path, hotfix_name);
 			}
 			else {
-				if (system(StringFormat("\"%s\"", shared_memory_path.c_str()).c_str())) {}
+				hotfix_command = fmt::format("\"{}\"", shared_memory_path, hotfix_name);
 			}
+
+			LogInfo("Running hotfix command [{}]", hotfix_command);
+			if (system(hotfix_command.c_str())) {}
 #else
 			shared_memory_path = "./shared_memory";
 			if (file_exists("./bin/shared_memory")) {


### PR DESCRIPTION
Fixes #hotfix command execution when trying to access the shared_memory binary in the `bin` folder