### PR TITLE
Null ptr fixes

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -2476,7 +2476,7 @@ void EntityList::RemoveAllGroups()
 	while (group_list.size()) {
 		auto group = group_list.front();
 		group_list.pop_front();
-		delete group;
+		safe_delete(group);
 	}
 #if EQDEBUG >= 5
 	CheckGroupList (__FILE__, __LINE__);
@@ -2488,7 +2488,7 @@ void EntityList::RemoveAllRaids()
 	while (raid_list.size()) {
 		auto raid = raid_list.front();
 		raid_list.pop_front();
-		delete raid;
+		safe_delete(raid);
 	}
 }
 
@@ -2838,7 +2838,7 @@ bool EntityList::RemoveGroup(uint32 delete_id)
 	}
 	auto group = *it;
 	group_list.erase(it);
-	delete group;
+	safe_delete(group);
 	return true;
 }
 
@@ -2850,7 +2850,7 @@ bool EntityList::RemoveRaid(uint32 delete_id)
 		return false;
 	auto raid = *it;
 	raid_list.erase(it);
-	delete raid;
+	safe_delete(raid);
 	return true;
 }
 

--- a/zone/groups.cpp
+++ b/zone/groups.cpp
@@ -498,6 +498,9 @@ void Group::SendEndurancePacketFrom(Mob* member)
 //if the group was in the zone already
 bool Group::UpdatePlayer(Mob* update){
 
+	if (!update)
+		return false;
+
 	bool updateSuccess = false;
 
 	VerifyGroup();
@@ -1009,6 +1012,7 @@ void Group::DisbandGroup(bool joinraid) {
 		Leader->UpdateLFP();
 	}
 
+	SetLeader(nullptr);
 	safe_delete(outapp);
 }
 

--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -279,6 +279,8 @@ void Raid::SetRaidLeader(const char *wasLead, const char *name)
 	Client *c = entity_list.GetClientByName(name);
 	if(c)
 		SetLeader(c);
+	else
+		SetLeader(nullptr); //sanity check, should never get hit but we want to prefer to NOT crash if we do VerifyRaid and leader never gets set there (raid without a leader?)
 
 	LearnMembers();
 	VerifyRaid();
@@ -1549,6 +1551,11 @@ void Raid::VerifyRaid()
 				SetLeader(members[x].member);
 				strn0cpy(leadername, members[x].membername, 64);
 			}
+			else
+			{
+				//should never happen, but maybe it is?
+				SetLeader(nullptr);
+			}
 		}
 	}
 }
@@ -1557,6 +1564,11 @@ void Raid::MemberZoned(Client *c)
 {
 	if(!c)
 		return;
+
+	if (leader == c)
+	{
+		leader = nullptr;
+	}
 
 	// Raid::GetGroup() goes over the members as well, this way we go over once
 	uint32 gid = RAID_GROUPLESS;

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -773,12 +773,14 @@ void Zone::Shutdown(bool quiet)
 	while (!zone->npctable.empty()) {
 		itr = zone->npctable.begin();
 		delete itr->second;
+		itr->second = nullptr;
 		zone->npctable.erase(itr);
 	}
 
 	while (!zone->merctable.empty()) {
 		itr = zone->merctable.begin();
 		delete itr->second;
+		itr->second = nullptr;
 		zone->merctable.erase(itr);
 	}
 
@@ -788,6 +790,7 @@ void Zone::Shutdown(bool quiet)
 	while (!zone->ldon_trap_list.empty()) {
 		itr4 = zone->ldon_trap_list.begin();
 		delete itr4->second;
+		itr4->second = nullptr;
 		zone->ldon_trap_list.erase(itr4);
 	}
 	zone->ldon_trap_entry_list.clear();
@@ -1583,6 +1586,7 @@ bool Zone::Depop(bool StartSpawnTimer) {
 	while(!npctable.empty()) {
 		itr = npctable.begin();
 		delete itr->second;
+		itr->second = nullptr;
 		npctable.erase(itr);
 	}
 
@@ -1599,6 +1603,7 @@ void Zone::ClearNPCTypeCache(int id) {
 		auto iter = npctable.begin();
 		while (iter != npctable.end()) {
 			delete iter->second;
+			iter->second = nullptr;
 			++iter;
 		}
 		npctable.clear();
@@ -1608,6 +1613,7 @@ void Zone::ClearNPCTypeCache(int id) {
 		while (iter != npctable.end()) {
 			if (iter->first == (uint32)id) {
 				delete iter->second;
+				iter->second = nullptr;
 				npctable.erase(iter);
 				return;
 			}


### PR DESCRIPTION
Few fixes I've never put back upstream from classless involving deleted pointers that are not set to null. The codebase really needs a bigger review of "delete" usage vs "safe_delete" macro usage, but that could have complications that extend beyond just a mass find/replace, so don't do that (also not everything crashes that does that!)

First, fix null pointers in group/raid removal code. This is to avoid an instance where a group or raid is removed in that instance of the zone and then becomes a dangling pointer that could be later used in the same server tick.

Fix issue where npc_types could become null in the cache but remain referenced, causing a crash due to invalid memory accessed later in the code (IE; pets that are spawned by NPC Type ID, and mercenaries/bots are especially bad with this.)

Don't do Group::Update if there is no member in zone to update for. This fixes an issue where the zone would crash upon receiving an update about a member that doesn't exist.

Set the leader to null in various places:
When the group is disbanded, set the leader to null.

When setting a new raid leader, make sure we have a new raid leader. If we don't, avoid a crash and disband the raid. It's better than zones falling apart, and will resolve itself on the next VerifyRaid call.

If a member zones, set the leader pointer to nullptr. This fixes an issue where the leader pointer is freed later (MemberZoned normally cleans up the Client object), but referenced by other entities, allowing the leader to be used in the same server process tick, post-cleanup - as the leader won't exist.