### PR TITLE
Allow quests to turn on mob processing in empty zones

### DIFF
--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -2070,6 +2070,19 @@ XS(XS__repopzone) {
 	XSRETURN_EMPTY;
 }
 
+XS(XS__processmobswhilezoneempty);
+XS(XS__processmobswhilezoneempty) {
+	dXSARGS;
+	if (items != 1)
+		Perl_croak(aTHX_ "Usage: quest::processmobswhilezoneempty(bool on)");
+
+	bool ProcessingOn = ((int) SvIV(ST(0))) == 0 ? false : true;
+
+	quest_manager.processmobswhilezoneempty(ProcessingOn);
+
+	XSRETURN_EMPTY;
+}
+
 XS(XS__npcrace);
 XS(XS__npcrace) {
 	dXSARGS;
@@ -5614,6 +5627,7 @@ EXTERN_C XS(boot_quest) {
 	newXS(strcpy(buf, "playersize"), XS__playersize, file);
 	newXS(strcpy(buf, "playertexture"), XS__playertexture, file);
 	newXS(strcpy(buf, "popup"), XS__popup, file);
+	newXS(strcpy(buf, "processmobswhilezoneempty"), XS__processmobswhilezoneempty, file);
 	newXS(strcpy(buf, "pvp"), XS__pvp, file);
 	newXS(strcpy(buf, "qs_player_event"), XS__qs_player_event, file);
 	newXS(strcpy(buf, "qs_send_query"), XS__qs_send_query, file);

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -515,7 +515,7 @@ void EntityList::MobProcess()
 			mob_settle_timer->Disable();
 		}
 
-		if (numclients > 0 ||
+		if (zone->process_mobs_while_empty || numclients > 0 ||
 			mob->GetWanderType() == 4 || mob->GetWanderType() == 6 ||
 			mob_settle_timer->Enabled()) {
 			// Normal processing, or assuring that spawns that should

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -389,6 +389,10 @@ void lua_repop_zone() {
 	quest_manager.repopzone();
 }
 
+void lua_process_mobs_while_zone_empty(bool on) {
+	quest_manager.processmobswhilezoneempty(on);
+}
+
 bool lua_is_disc_tome(int item_id) {
 	return quest_manager.isdisctome(item_id);
 }
@@ -2167,6 +2171,7 @@ luabind::scope lua_register_general() {
 		luabind::def("depop_all", (void(*)(int))&lua_depop_all),
 		luabind::def("depop_zone", &lua_depop_zone),
 		luabind::def("repop_zone", &lua_repop_zone),
+		luabind::def("process_mobs_while_zone_empty", &lua_process_mobs_while_zone_empty),
 		luabind::def("is_disc_tome", &lua_is_disc_tome),
 		luabind::def("get_race_name", (std::string(*)(uint16))&lua_get_race_name),
 		luabind::def("get_spell_name", (std::string(*)(uint32))&lua_get_spell_name),

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -856,6 +856,15 @@ void QuestManager::repopzone() {
 	}
 }
 
+void QuestManager::processmobswhilezoneempty(bool on) {
+	if(zone) {
+		zone->process_mobs_while_empty = on;
+	}
+	else {
+		LogQuests("QuestManager::processmobswhilezoneempty called with nullptr zone. Probably syntax error in quest file");
+	}
+}
+
 void QuestManager::settarget(const char *type, int target_id) {
 	QuestManagerCurrentQuestVars();
 	if (!owner || !owner->IsNPC())

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -101,6 +101,7 @@ public:
 	void depopall(int npc_type = 0);
 	void depopzone(bool StartSpawnTimer = true);
 	void repopzone();
+	void processmobswhilezoneempty(bool on);
 	void settarget(const char *type, int target_id);
 	void follow(int entity_id, int distance);
 	void sfollow();

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -866,6 +866,7 @@ Zone::Zone(uint32 in_zoneid, uint32 in_instanceid, const char* in_short_name)
 	default_ruleset = 0;
 
 	is_zone_time_localized = false;
+	process_mobs_while_empty = false;
 
 	loglevelvar = 0;
 	merchantvar = 0;

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -93,6 +93,7 @@ public:
 	AA::Ability *GetAlternateAdvancementAbilityByRank(int rank_id);
 	AA::Rank *GetAlternateAdvancementRank(int rank_id);
 	bool is_zone_time_localized;
+	bool process_mobs_while_empty;
 	bool AggroLimitReached() { return (aggroedmobs > 10) ? true : false; }
 	bool AllowMercs() const { return (allow_mercs); }
 	bool CanBind() const { return (can_bind); }


### PR DESCRIPTION
This PR allows quest writers to write code that allows activities to take place in zones with no clients.

I'm adding this, so that periodic wars, or movement based on other changes in the world can take place in zones that have no population when the changes or activities are desired.

A quest that wants to make sure that mob movement and processing take place - rergardless of the zone being empty, enable the provessing via quest::processmobswhilezoneempty(1) or the lua counterpart eq.process_mobs_while_zone_empty(true).

Once the quest has completed the quest needs to return the processing to normal state with the same call passing 0 or false.

Or these quest routines could be used by local zone_controller or other spawns to enable processing for a zone permanently.

The default is of course off - so nothing should be impacted if these calls are not used.

I'll add to the docs and the changelog if approved.

These changes allow ownership of territory in game to change - while zones are empty.