### PR TITLE
Add support for virtual zonepoints

### DIFF
--- a/common/repositories/base/base_zone_points_repository.h
+++ b/common/repositories/base/base_zone_points_repository.h
@@ -56,6 +56,9 @@ public:
 		int         max_expansion;
 		std::string content_flags;
 		std::string content_flags_disabled;
+		int         is_virtual;
+		int         height;
+		int         width;
 	};
 
 	static std::string PrimaryKey()
@@ -87,6 +90,9 @@ public:
 			"max_expansion",
 			"content_flags",
 			"content_flags_disabled",
+			"is_virtual",
+			"height",
+			"width",
 		};
 	}
 
@@ -158,6 +164,9 @@ public:
 		entry.max_expansion          = 0;
 		entry.content_flags          = "";
 		entry.content_flags_disabled = "";
+		entry.is_virtual             = 0;
+		entry.height                 = 0;
+		entry.width                  = 0;
 
 		return entry;
 	}
@@ -213,6 +222,9 @@ public:
 			entry.max_expansion          = atoi(row[18]);
 			entry.content_flags          = row[19] ? row[19] : "";
 			entry.content_flags_disabled = row[20] ? row[20] : "";
+			entry.is_virtual             = atoi(row[21]);
+			entry.height                 = atoi(row[22]);
+			entry.width                  = atoi(row[23]);
 
 			return entry;
 		}
@@ -264,6 +276,9 @@ public:
 		update_values.push_back(columns[18] + " = " + std::to_string(zone_points_entry.max_expansion));
 		update_values.push_back(columns[19] + " = '" + EscapeString(zone_points_entry.content_flags) + "'");
 		update_values.push_back(columns[20] + " = '" + EscapeString(zone_points_entry.content_flags_disabled) + "'");
+		update_values.push_back(columns[21] + " = " + std::to_string(zone_points_entry.is_virtual));
+		update_values.push_back(columns[22] + " = " + std::to_string(zone_points_entry.height));
+		update_values.push_back(columns[23] + " = " + std::to_string(zone_points_entry.width));
 
 		auto results = content_db.QueryDatabase(
 			fmt::format(
@@ -304,6 +319,9 @@ public:
 		insert_values.push_back(std::to_string(zone_points_entry.max_expansion));
 		insert_values.push_back("'" + EscapeString(zone_points_entry.content_flags) + "'");
 		insert_values.push_back("'" + EscapeString(zone_points_entry.content_flags_disabled) + "'");
+		insert_values.push_back(std::to_string(zone_points_entry.is_virtual));
+		insert_values.push_back(std::to_string(zone_points_entry.height));
+		insert_values.push_back(std::to_string(zone_points_entry.width));
 
 		auto results = content_db.QueryDatabase(
 			fmt::format(
@@ -352,6 +370,9 @@ public:
 			insert_values.push_back(std::to_string(zone_points_entry.max_expansion));
 			insert_values.push_back("'" + EscapeString(zone_points_entry.content_flags) + "'");
 			insert_values.push_back("'" + EscapeString(zone_points_entry.content_flags_disabled) + "'");
+			insert_values.push_back(std::to_string(zone_points_entry.is_virtual));
+			insert_values.push_back(std::to_string(zone_points_entry.height));
+			insert_values.push_back(std::to_string(zone_points_entry.width));
 
 			insert_chunks.push_back("(" + implode(",", insert_values) + ")");
 		}
@@ -406,6 +427,9 @@ public:
 			entry.max_expansion          = atoi(row[18]);
 			entry.content_flags          = row[19] ? row[19] : "";
 			entry.content_flags_disabled = row[20] ? row[20] : "";
+			entry.is_virtual             = atoi(row[21]);
+			entry.height                 = atoi(row[22]);
+			entry.width                  = atoi(row[23]);
 
 			all_entries.push_back(entry);
 		}
@@ -451,6 +475,9 @@ public:
 			entry.max_expansion          = atoi(row[18]);
 			entry.content_flags          = row[19] ? row[19] : "";
 			entry.content_flags_disabled = row[20] ? row[20] : "";
+			entry.is_virtual             = atoi(row[21]);
+			entry.height                 = atoi(row[22]);
+			entry.width                  = atoi(row[23]);
 
 			all_entries.push_back(entry);
 		}

--- a/common/version.h
+++ b/common/version.h
@@ -34,7 +34,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9155
+#define CURRENT_BINARY_DATABASE_VERSION 9156
 
 #ifdef BOTS
 	#define CURRENT_BINARY_BOTS_DATABASE_VERSION 9027

--- a/utils/sql/db_update_manifest.txt
+++ b/utils/sql/db_update_manifest.txt
@@ -409,6 +409,7 @@
 9153|2020_05_09_items_subtype.sql|SHOW COLUMNS from `items` LIKE 'UNK219'|not_empty|
 9154|2020_04_11_expansions_content_filters.sql|SHOW COLUMNS from `zone` LIKE 'min_expansion'|empty|
 9155|2020_08_15_lootdrop_level_filtering.sql|SHOW COLUMNS from `lootdrop_entries` LIKE 'trivial_min_level'|empty|
+9156|2020_08_16_virtual_zonepoints.sql|SHOW COLUMNS from `zonepoints` LIKE 'is_virtual'|empty|
 
 # Upgrade conditions:
 # 	This won't be needed after this system is implemented, but it is used database that are not

--- a/utils/sql/db_update_manifest.txt
+++ b/utils/sql/db_update_manifest.txt
@@ -409,7 +409,7 @@
 9153|2020_05_09_items_subtype.sql|SHOW COLUMNS from `items` LIKE 'UNK219'|not_empty|
 9154|2020_04_11_expansions_content_filters.sql|SHOW COLUMNS from `zone` LIKE 'min_expansion'|empty|
 9155|2020_08_15_lootdrop_level_filtering.sql|SHOW COLUMNS from `lootdrop_entries` LIKE 'trivial_min_level'|empty|
-9156|2020_08_16_virtual_zonepoints.sql|SHOW COLUMNS from `zonepoints` LIKE 'is_virtual'|empty|
+9156|2020_08_16_virtual_zonepoints.sql|SHOW COLUMNS from `zone_points` LIKE 'is_virtual'|empty|
 
 # Upgrade conditions:
 # 	This won't be needed after this system is implemented, but it is used database that are not

--- a/utils/sql/git/required/2020_08_16_virtual_zonepoints.sql
+++ b/utils/sql/git/required/2020_08_16_virtual_zonepoints.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `zone_points` ADD COLUMN `is_virtual` tinyint NOT NULL DEFAULT '0' COMMENT '' AFTER `content_flags_disabled`;
+ALTER TABLE `zone_points` ADD COLUMN `height` int NOT NULL DEFAULT '0' COMMENT '';
+ALTER TABLE `zone_points` ADD COLUMN `width` int NOT NULL DEFAULT '0' COMMENT '';

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -56,6 +56,7 @@ extern volatile bool RunLoops;
 #include "quest_parser_collection.h"
 #include "queryserv.h"
 #include "mob_movement_manager.h"
+#include "../common/content/world_content_service.h"
 
 extern QueryServ* QServ;
 extern EntityList entity_list;
@@ -9427,7 +9428,12 @@ void Client::ShowDevToolsMenu()
 	 * Print menu
 	 */
 	SendChatLineBreak();
-	Message(Chat::White, "| [Devtools] Window %s Show this menu with %s", window_toggle_command.c_str(), EQ::SayLinkEngine::GenerateQuestSaylink("#dev", false, "#dev").c_str());
+	Message(
+		Chat::White, "| [Devtools] Window %s Show this menu with %s | Current expansion [%s]",
+		window_toggle_command.c_str(),
+		EQ::SayLinkEngine::GenerateQuestSaylink("#dev", false, "#dev").c_str(),
+		content_service.GetCurrentExpansionName().c_str()
+	);
 	Message(Chat::White, "| [Devtools] Search %s", menu_commands_search.c_str());
 	Message(Chat::White, "| [Devtools] Show %s", menu_commands_show.c_str());
 	Message(Chat::White, "| [Devtools] Reload %s", reload_commands_show.c_str());

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -9345,3 +9345,96 @@ void Client::SendToGuildHall()
 	AssignToInstance(instance_id);
 	MovePC(345, instance_id, -1.00, -1.00, 3.34, 0, 1);
 }
+
+void Client::CheckVirtualZoneLines()
+{
+	for (auto &virtual_zone_point : zone->virtual_zone_point_list) {
+		float half_width = ((float) virtual_zone_point.width / 2);
+
+		if (
+			GetX() > (virtual_zone_point.x - half_width) &&
+			GetX() < (virtual_zone_point.x + half_width) &&
+			GetY() > (virtual_zone_point.y - half_width) &&
+			GetY() < (virtual_zone_point.y + half_width) &&
+			GetZ() >= (virtual_zone_point.z - 10) &&
+			GetZ() < (virtual_zone_point.z + (float) virtual_zone_point.height)
+			) {
+
+			MovePC(
+				virtual_zone_point.target_zone_id,
+				virtual_zone_point.target_instance,
+				virtual_zone_point.target_x,
+				virtual_zone_point.target_y,
+				virtual_zone_point.target_z,
+				virtual_zone_point.target_heading
+			);
+
+			LogZonePoints(
+				"Virtual Zone Box Sending player [{}] to [{}]",
+				GetCleanName(),
+				zone_store.GetZoneLongName(virtual_zone_point.target_zone_id)
+			);
+		}
+	}
+}
+
+void Client::ShowDevToolsMenu()
+{
+	std::string menu_commands_search;
+	std::string menu_commands_show;
+	std::string reload_commands_show;
+	std::string window_toggle_command;
+
+	/**
+	 * Search entity commands
+	 */
+	menu_commands_search += "[" + EQ::SayLinkEngine::GenerateQuestSaylink("#list npcs", false, "NPC") + "] ";
+	menu_commands_search += "[" + EQ::SayLinkEngine::GenerateQuestSaylink("#list players", false, "Players") + "] ";
+	menu_commands_search += "[" + EQ::SayLinkEngine::GenerateQuestSaylink("#list corpses", false, "Corpses") + "] ";
+	menu_commands_search += "[" + EQ::SayLinkEngine::GenerateQuestSaylink("#list doors", false, "Doors") + "] ";
+	menu_commands_search += "[" + EQ::SayLinkEngine::GenerateQuestSaylink("#list objects", false, "Objects") + "] ";
+	menu_commands_search += "[" + EQ::SayLinkEngine::GenerateQuestSaylink("#fz", false, "Zones") + "] ";
+	menu_commands_search += "[" + EQ::SayLinkEngine::GenerateQuestSaylink("#fi", false, "Items") + "] ";
+
+	/**
+	 * Show
+	 */
+	menu_commands_show += "[" + EQ::SayLinkEngine::GenerateQuestSaylink("#showzonepoints", false, "Zone Points") + "] ";
+	menu_commands_show += "[" + EQ::SayLinkEngine::GenerateQuestSaylink("#showzonegloballoot", false, "Zone Global Loot") + "] ";
+
+	/**
+	 * Reload
+	 */
+	reload_commands_show += "[" + EQ::SayLinkEngine::GenerateQuestSaylink("#rq", false, "Quests") + "] ";
+	reload_commands_show += "[" + EQ::SayLinkEngine::GenerateQuestSaylink("#reloadmerchants", false, "Merchants") + "] ";
+	reload_commands_show += "[" + EQ::SayLinkEngine::GenerateQuestSaylink("#reloadallrules", false, "Rules Globally") + "] ";
+	reload_commands_show += "[" + EQ::SayLinkEngine::GenerateQuestSaylink("#reloadstatic", false, "Ground Spawns") + "] ";
+	reload_commands_show += "[" + EQ::SayLinkEngine::GenerateQuestSaylink("#reloadstatic", false, "Alternate Currencies") + "] ";
+	reload_commands_show += "[" + EQ::SayLinkEngine::GenerateQuestSaylink("#reloadstatic", false, "DB Emotes") + "] ";
+	reload_commands_show += "[" + EQ::SayLinkEngine::GenerateQuestSaylink("#reloadstatic", false, "Doors") + "] ";
+	reload_commands_show += "[" + EQ::SayLinkEngine::GenerateQuestSaylink("#reloadtraps", false, "Traps") + "] ";
+	reload_commands_show += "[" + EQ::SayLinkEngine::GenerateQuestSaylink("#reloadzps", false, "Zone Points") + "] ";
+
+	/**
+	 * Show window status
+	 */
+	window_toggle_command = "Disabled [" + EQ::SayLinkEngine::GenerateQuestSaylink("#devtools enable_window", false, "Enable") + "] ";
+	if (IsDevToolsWindowEnabled()) {
+		window_toggle_command = "Enabled [" + EQ::SayLinkEngine::GenerateQuestSaylink("#devtools disable_window", false, "Disable") + "] ";
+	}
+
+	/**
+	 * Print menu
+	 */
+	SendChatLineBreak();
+	Message(Chat::White, "| [Devtools] Window %s Show this menu with %s", window_toggle_command.c_str(), EQ::SayLinkEngine::GenerateQuestSaylink("#dev", false, "#dev").c_str());
+	Message(Chat::White, "| [Devtools] Search %s", menu_commands_search.c_str());
+	Message(Chat::White, "| [Devtools] Show %s", menu_commands_show.c_str());
+	Message(Chat::White, "| [Devtools] Reload %s", reload_commands_show.c_str());
+	Message(Chat::White, "| [Devtools] Search commands with #help <search>");
+	SendChatLineBreak();
+}
+
+void Client::SendChatLineBreak(uint16 color) {
+	Message(color, "------------------------------------------------");
+}

--- a/zone/client.h
+++ b/zone/client.h
@@ -238,6 +238,8 @@ public:
 	void SetPrimaryWeaponOrnamentation(uint32 model_id);
 	void SetSecondaryWeaponOrnamentation(uint32 model_id);
 
+	void SendChatLineBreak(uint16 color = Chat::White);
+
 	bool GotoPlayer(std::string player_name);
 
 	//abstract virtual function implementations required by base abstract class
@@ -445,6 +447,8 @@ public:
 	inline float ProximityY() const { return m_Proximity.y; }
 	inline float ProximityZ() const { return m_Proximity.z; }
 	inline void ClearAllProximities() { entity_list.ProcessMove(this, glm::vec3(FLT_MAX, FLT_MAX, FLT_MAX)); m_Proximity = glm::vec3(FLT_MAX,FLT_MAX,FLT_MAX); }
+
+	void CheckVirtualZoneLines();
 
 	/*
 			Begin client modifiers
@@ -1316,6 +1320,8 @@ public:
 	glm::vec4 &GetLastPositionBeforeBulkUpdate();
 
 	Raid *p_raid_instance;
+
+	void ShowDevToolsMenu();
 
 protected:
 	friend class Mob;

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -918,6 +918,11 @@ void Client::CompleteConnect()
 	worldserver.RequestTellQueue(GetName());
 
 	entity_list.ScanCloseMobs(close_mobs, this, true);
+
+	if (GetGM()) {
+		ShowDevToolsMenu();
+	}
+
 }
 
 // connecting opcode handlers
@@ -4640,6 +4645,9 @@ void Client::Handle_OP_ClientUpdate(const EQApplicationPacket *app) {
 		}
 		CheckRegionTypeChanges();
 	}
+
+	CheckVirtualZoneLines();
+
 }
 
 void Client::Handle_OP_CombatAbility(const EQApplicationPacket *app)

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -387,6 +387,7 @@ int command_init(void)
 		command_add("showspellslist", "Shows spell list of targeted NPC", 100, command_showspellslist) ||
 		command_add("showstats", "- Show details about you or your target", 50, command_showstats) ||
 		command_add("showzonegloballoot", "Show GlobalLoot entires on this zone", 50, command_showzonegloballoot) ||
+		command_add("showzonepoints", "Show zone points for current zone", 50, command_showzonepoints) ||
 		command_add("shutdown", "- Shut this zone process down", 150, command_shutdown) ||
 		command_add("size", "[size] - Change size of you or your target", 50, command_size) ||
 		command_add("spawn", "[name] [race] [level] [material] [hp] [gender] [class] [priweapon] [secweapon] [merchantid] - Spawn an NPC", 10, command_spawn) ||
@@ -5364,7 +5365,6 @@ void command_memspell(Client *c, const Seperator *sep)
 		}
 	}
 }
-
 void command_save(Client *c, const Seperator *sep)
 {
 	if (c->GetTarget() == 0)
@@ -5397,6 +5397,152 @@ void command_showzonegloballoot(Client *c, const Seperator *sep)
 {
 	c->Message(Chat::White, "GlobalLoot for %s (%d:%d)", zone->GetShortName(), zone->GetZoneID(), zone->GetInstanceVersion());
 	zone->ShowZoneGlobalLoot(c);
+}
+
+void command_showzonepoints(Client *c, const Seperator *sep)
+{
+	auto      &mob_list = entity_list.GetMobList();
+	for (auto itr : mob_list) {
+		Mob *mob = itr.second;
+		if (mob->IsNPC() && mob->GetRace() == 2254) {
+			mob->Depop();
+		}
+	}
+
+	int found_zone_points = 0;
+
+	c->Message(Chat::White, "Listing zone points...");
+	c->SendChatLineBreak();
+
+	for (auto &virtual_zone_point : zone->virtual_zone_point_list) {
+		std::string zone_long_name = zone_store.GetZoneLongName(virtual_zone_point.target_zone_id);
+
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"Virtual Zone Point x [{}] y [{}] z [{}] h [{}] width [{}] height [{}] | To [{}] ({}) x [{}] y [{}] z [{}] h [{}]",
+				virtual_zone_point.x,
+				virtual_zone_point.y,
+				virtual_zone_point.z,
+				virtual_zone_point.width,
+				virtual_zone_point.height,
+				zone_long_name.c_str(),
+				virtual_zone_point.target_zone_id,
+				virtual_zone_point.target_x,
+				virtual_zone_point.target_y,
+				virtual_zone_point.target_z,
+				virtual_zone_point.target_heading
+			).c_str()
+		);
+
+		std::string node_name = fmt::format("ZonePoint To [{}]", zone_long_name);
+
+		float half_width = ((float) virtual_zone_point.width / 2);
+
+		NPC::SpawnZonePointNodeNPC(node_name, glm::vec4(
+			(float) virtual_zone_point.x + half_width,
+			(float) virtual_zone_point.y + half_width,
+			virtual_zone_point.z,
+			virtual_zone_point.heading
+		));
+
+		NPC::SpawnZonePointNodeNPC(node_name, glm::vec4(
+			(float) virtual_zone_point.x + half_width,
+			(float) virtual_zone_point.y - half_width,
+			virtual_zone_point.z,
+			virtual_zone_point.heading
+		));
+
+		NPC::SpawnZonePointNodeNPC(node_name, glm::vec4(
+			(float) virtual_zone_point.x - half_width,
+			(float) virtual_zone_point.y - half_width,
+			virtual_zone_point.z,
+			virtual_zone_point.heading
+		));
+
+		NPC::SpawnZonePointNodeNPC(node_name, glm::vec4(
+			(float) virtual_zone_point.x - half_width,
+			(float) virtual_zone_point.y + half_width,
+			virtual_zone_point.z,
+			virtual_zone_point.heading
+		));
+
+		NPC::SpawnZonePointNodeNPC(node_name, glm::vec4(
+			(float) virtual_zone_point.x + half_width,
+			(float) virtual_zone_point.y + half_width,
+			(float) virtual_zone_point.z + (float) virtual_zone_point.height,
+			virtual_zone_point.heading
+		));
+
+		NPC::SpawnZonePointNodeNPC(node_name, glm::vec4(
+			(float) virtual_zone_point.x + half_width,
+			(float) virtual_zone_point.y - half_width,
+			(float) virtual_zone_point.z + (float) virtual_zone_point.height,
+			virtual_zone_point.heading
+		));
+
+		NPC::SpawnZonePointNodeNPC(node_name, glm::vec4(
+			(float) virtual_zone_point.x - half_width,
+			(float) virtual_zone_point.y - half_width,
+			(float) virtual_zone_point.z + (float) virtual_zone_point.height,
+			virtual_zone_point.heading
+		));
+
+		NPC::SpawnZonePointNodeNPC(node_name, glm::vec4(
+			(float) virtual_zone_point.x - half_width,
+			(float) virtual_zone_point.y + half_width,
+			(float) virtual_zone_point.z + (float) virtual_zone_point.height,
+			virtual_zone_point.heading
+		));
+
+		found_zone_points++;
+	}
+
+	LinkedListIterator<ZonePoint *> iterator(zone->zone_point_list);
+	iterator.Reset();
+	while (iterator.MoreElements()) {
+		ZonePoint   *zone_point    = iterator.GetData();
+		std::string zone_long_name = zone_store.GetZoneLongName(zone_point->target_zone_id);
+		std::string node_name      = fmt::format("ZonePoint To [{}]", zone_long_name);
+
+		NPC::SpawnZonePointNodeNPC(
+			node_name, glm::vec4(
+				zone_point->x,
+				zone_point->y,
+				zone_point->z,
+				zone_point->heading
+			)
+		);
+
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"Client Side Zone Point x [{}] y [{}] z [{}] h [{}] number [{}] | To [{}] ({}) x [{}] y [{}] z [{}] h [{}]",
+				zone_point->x,
+				zone_point->y,
+				zone_point->z,
+				zone_point->heading,
+				zone_point->number,
+				zone_long_name.c_str(),
+				zone_point->target_zone_id,
+				zone_point->target_x,
+				zone_point->target_y,
+				zone_point->target_z,
+				zone_point->target_heading
+			).c_str()
+		);
+
+		iterator.Advance();
+
+		found_zone_points++;
+	}
+
+	if (found_zone_points == 0) {
+		c->Message(Chat::White, "There were no zone points found...");
+	}
+
+	c->SendChatLineBreak();
+
 }
 
 void command_mystats(Client *c, const Seperator *sep)
@@ -5445,18 +5591,6 @@ void command_depopzone(Client *c, const Seperator *sep)
 
 void command_devtools(Client *c, const Seperator *sep)
 {
-	std::string menu_commands_search;
-	std::string window_toggle_command;
-
-	/**
-	 * Search entity commands
-	 */
-	menu_commands_search += "[" + EQ::SayLinkEngine::GenerateQuestSaylink("#list npcs", false, "NPC") + "] ";
-	menu_commands_search += "[" + EQ::SayLinkEngine::GenerateQuestSaylink("#list players", false, "Players") + "] ";
-	menu_commands_search += "[" + EQ::SayLinkEngine::GenerateQuestSaylink("#list corpses", false, "Corpses") + "] ";
-	menu_commands_search += "[" + EQ::SayLinkEngine::GenerateQuestSaylink("#list doors", false, "Doors") + "] ";
-	menu_commands_search += "[" + EQ::SayLinkEngine::GenerateQuestSaylink("#list objects", false, "Objects") + "] ";
-
 	std::string dev_tools_window_key = StringFormat("%i-dev-tools-window-disabled", c->AccountID());
 
 	/**
@@ -5471,19 +5605,7 @@ void command_devtools(Client *c, const Seperator *sep)
 		c->SetDevToolsWindowEnabled(true);
 	}
 
-	/**
-	 * Show window status
-	 */
-	window_toggle_command = "Disabled [" + EQ::SayLinkEngine::GenerateQuestSaylink("#devtools enable_window", false, "Enable") + "] ";
-	if (c->IsDevToolsWindowEnabled()) {
-		window_toggle_command = "Enabled [" + EQ::SayLinkEngine::GenerateQuestSaylink("#devtools disable_window", false, "Disable") + "] ";
-	}
-
-	/**
-	 * Print menu
-	 */
-	c->Message(Chat::White, "| [Devtools] Window %s", window_toggle_command.c_str());
-	c->Message(Chat::White, "| [Devtools] Search %s", menu_commands_search.c_str());
+	c->ShowDevToolsMenu();
 }
 
 void command_repop(Client *c, const Seperator *sep)

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -5424,6 +5424,7 @@ void command_showzonepoints(Client *c, const Seperator *sep)
 				virtual_zone_point.x,
 				virtual_zone_point.y,
 				virtual_zone_point.z,
+				virtual_zone_point.heading,
 				virtual_zone_point.width,
 				virtual_zone_point.height,
 				zone_long_name.c_str(),

--- a/zone/command.h
+++ b/zone/command.h
@@ -290,6 +290,7 @@ void command_showskills(Client *c, const Seperator *sep);
 void command_showspellslist(Client *c, const Seperator *sep);
 void command_showstats(Client *c, const Seperator *sep);
 void command_showzonegloballoot(Client *c, const Seperator *sep);
+void command_showzonepoints(Client *c, const Seperator *sep);
 void command_shutdown(Client *c, const Seperator *sep);
 void command_size(Client *c, const Seperator *sep);
 void command_spawn(Client *c, const Seperator *sep);

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -1118,6 +1118,44 @@ void NPC::SpawnGridNodeNPC(const glm::vec4 &position, int32 grid_number, int32 z
 	entity_list.AddNPC(npc);
 }
 
+void NPC::SpawnZonePointNodeNPC(std::string name, const glm::vec4 &position)
+{
+	auto npc_type = new NPCType;
+	memset(npc_type, 0, sizeof(NPCType));
+
+	char node_name[64];
+	strn0cpy(node_name, name.c_str(), 64);
+
+	strcpy(npc_type->name, entity_list.MakeNameUnique(node_name));
+
+	npc_type->current_hp       = 4000000;
+	npc_type->max_hp           = 4000000;
+	npc_type->race             = 2254;
+	npc_type->gender           = 2;
+	npc_type->class_           = 9;
+	npc_type->deity            = 1;
+	npc_type->level            = 200;
+	npc_type->npc_id           = 0;
+	npc_type->loottable_id     = 0;
+	npc_type->texture          = 1;
+	npc_type->light            = 1;
+	npc_type->size             = 5;
+	npc_type->runspeed         = 0;
+	npc_type->merchanttype     = 1;
+	npc_type->bodytype         = 1;
+	npc_type->show_name        = true;
+	npc_type->findable         = true;
+
+	auto node_position = glm::vec4(position.x, position.y, position.z, position.w);
+	auto npc           = new NPC(npc_type, nullptr, node_position, GravityBehavior::Flying);
+
+	npc->name[strlen(npc->name)-3] = (char) NULL;
+
+	npc->GiveNPCTypeData(npc_type);
+
+	entity_list.AddNPC(npc);
+}
+
 NPC * NPC::SpawnNodeNPC(std::string name, std::string last_name, const glm::vec4 &position) {
 	auto npc_type = new NPCType;
 	memset(npc_type, 0, sizeof(NPCType));

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -115,6 +115,7 @@ public:
 
 	static NPC *SpawnNodeNPC(std::string name, std::string last_name, const glm::vec4 &position);
 	static void SpawnGridNodeNPC(const glm::vec4 &position, int32 grid_number, int32 zoffset);
+	static void SpawnZonePointNodeNPC(std::string name, const glm::vec4 &position);
 
 	//abstract virtual function implementations requird by base abstract class
 	virtual bool Death(Mob* killerMob, int32 damage, uint16 spell_id, EQ::skills::SkillType attack_skill);

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -101,6 +101,7 @@ Copyright (C) 2001-2002 EQEMu Development Team (http://eqemu.org)
 #endif
 
 #include "mob_movement_manager.h"
+#include "client.h"
 
 
 extern Zone* zone;
@@ -6003,4 +6004,5 @@ bool Client::IsLinkedSpellReuseTimerReady(uint32 timer_id)
 		return true;
 	return GetPTimers().Expired(&database, pTimerLinkedSpellReuseStart + timer_id, false);
 }
+
 

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -28,6 +28,7 @@
 #include "zone_store.h"
 #include "../common/repositories/grid_repository.h"
 #include "../common/repositories/grid_entries_repository.h"
+#include "../common/repositories/zone_points_repository.h"
 #include "qglobals.h"
 #include "spawn2.h"
 #include "spawngroup.h"
@@ -48,6 +49,9 @@ struct ZonePoint {
 	uint16 target_zone_id;
 	int32  target_zone_instance;
 	uint32 client_version_mask;
+	bool   is_virtual;
+	int    height;
+	int    width;
 };
 
 struct ZoneClientAuth_Struct {
@@ -171,10 +175,12 @@ public:
 	int SaveTempItem(uint32 merchantid, uint32 npcid, uint32 item, int32 charges, bool sold = false);
 	int32 MobsAggroCount() { return aggroedmobs; }
 
-	IPathfinder                    *pathing;
-	LinkedList<NPC_Emote_Struct *> NPCEmoteList;
-	LinkedList<Spawn2 *>           spawn2_list;
-	LinkedList<ZonePoint *>        zone_point_list;
+	IPathfinder                                   *pathing;
+	LinkedList<NPC_Emote_Struct *>                NPCEmoteList;
+	LinkedList<Spawn2 *>                          spawn2_list;
+	LinkedList<ZonePoint *>                       zone_point_list;
+	std::vector<ZonePointsRepository::ZonePoints> virtual_zone_point_list;
+
 	Map                            *zonemap;
 	MercTemplate *GetMercTemplate(uint32 template_id);
 	NewZone_Struct                 newzone_data;

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -336,6 +336,10 @@ void Client::Handle_OP_ZoneChange(const EQApplicationPacket *app) {
 		}
 	}
 
+	if (content_service.GetCurrentExpansion() >= Expansion::Classic && GetGM()) {
+		LogInfo("[{}] Bypassing Expansion zone checks because GM status is set", GetCleanName());
+	}
+
 	if(myerror == 1) {
 		//we have successfully zoned
 		DoZoneSuccess(zc, target_zone_id, target_instance_id, dest_x, dest_y, dest_z, dest_h, ignorerestrictions);


### PR DESCRIPTION
This PR adds support for virtual zonepoints

Because the zone points that are sent to the client use an internal index lookup, it does not really give us power over determining or creating zone points in some cases. While this works in most of the data we've collected, there are scenarios where we'd like to create zone points entirely server side

![image](https://user-images.githubusercontent.com/3319450/90326965-7e740100-df54-11ea-86b8-213d6b7d227d.png)

![image](https://user-images.githubusercontent.com/3319450/90327109-d9f2be80-df55-11ea-8bc6-45b4f7d1193a.png)

We've added 3 new fields to the `zone_points` table `is_virtual` `width` `height`

When a zone point is virtual it follows different rules, a box is created using the x, y, z with the width and the height into consideration

New command **#showzonepoints** will list all of the zone points in a zone whether they are client side driven or virtual. It will also show a physical representation of the zone points in game

![image](https://user-images.githubusercontent.com/3319450/90327052-56d16880-df55-11ea-821d-ae2d67b98244.png)



## Enhanced DevTools Menu

DevTools menu now displays whenever a GM enters a zone, it also has many more tools available

![image](https://user-images.githubusercontent.com/3319450/90327069-7799be00-df55-11ea-8f8a-a048d9a36d1c.png)
