### PR TITLE
[Aggro] PercentalHeal should be included in aggro generation

### DIFF
--- a/zone/aggro.cpp
+++ b/zone/aggro.cpp
@@ -1144,7 +1144,9 @@ int32 Mob::CheckHealAggroAmount(uint16 spell_id, Mob *target, uint32 heal_possib
 
 	for (int o = 0; o < EFFECT_COUNT; o++) {
 		switch (spells[spell_id].effectid[o]) {
-		case SE_CurrentHP: {
+			case SE_CurrentHP:
+			case SE_PercentalHeal:
+			{
 			if (heal_possible == 0) {
 				AggroAmount += 1;
 				break;


### PR DESCRIPTION
Per January 15th 2003 Patch Notes:
"NPCs will now notice Druid and Shaman Percentage Heal spells in a manner similar to traditional healing spells."

Added SE_PercetalHeal to the same CheckHealAggroAmount as SE_CurrentHP to be similar to traditional healing spells.