### PR TITLE
Fix bugged pet sit button and taunt.

### DIFF
--- a/common/version.h
+++ b/common/version.h
@@ -34,7 +34,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9156
+#define CURRENT_BINARY_DATABASE_VERSION 9157
 
 #ifdef BOTS
 	#define CURRENT_BINARY_BOTS_DATABASE_VERSION 9027

--- a/utils/sql/db_update_manifest.txt
+++ b/utils/sql/db_update_manifest.txt
@@ -410,6 +410,7 @@
 9154|2020_04_11_expansions_content_filters.sql|SHOW COLUMNS from `zone` LIKE 'min_expansion'|empty|
 9155|2020_08_15_lootdrop_level_filtering.sql|SHOW COLUMNS from `lootdrop_entries` LIKE 'trivial_min_level'|empty|
 9156|2020_08_16_virtual_zonepoints.sql|SHOW COLUMNS from `zone_points` LIKE 'is_virtual'|empty|
+9157|2020_09_02_pet_taunting.sql|SHOW COLUMNS from `character_pet_info` LIKE 'taunting'|empty|
 
 # Upgrade conditions:
 # 	This won't be needed after this system is implemented, but it is used database that are not

--- a/utils/sql/git/required/2020_09_02_pet_taunting.sql
+++ b/utils/sql/git/required/2020_09_02_pet_taunting.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `character_pet_info` ADD COLUMN `taunting` tinyint(1) NOT NULL DEFAULT '1' COMMENT '';

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -3445,6 +3445,22 @@ void Mob::CommonDamage(Mob* attacker, int &damage, const uint16 spell_id, const 
 				// emote goes with every one ... even npcs
 				entity_list.MessageClose(this, true, RuleI(Range, SpellMessages), Chat::Emote, "%s beams a smile at %s", attacker->GetCleanName(), this->GetCleanName());
 			}
+		
+			// If a client pet is damaged while sitting, stand, fix sit button,
+			// and remove sitting regen.  Removes bug where client clicks sit
+			// during battle and gains pet hp-regen and bugs the sit button.
+			if (IsPet()) {
+				Mob *owner = this->GetOwner();
+				if (owner && owner->IsClient()) {
+					if (GetPetOrder() == SPO_Sit) {
+						SetPetOrder(SPO_Follow);
+					}
+				// fix GUI sit button to be unpressed and stop sitting regen
+				owner->CastToClient()->SetPetCommandState(PET_BUTTON_SIT, 0);
+				SetAppearance(eaStanding);
+				}	
+			}
+
 		}	//end `if there is some damage being done and theres anattacker person involved`
 
 		Mob *pet = GetPet();
@@ -3455,6 +3471,18 @@ void Mob::CommonDamage(Mob* attacker, int &damage, const uint16 spell_id, const 
 		{
 			if (!pet->IsHeld()) {
 				LogAggro("Sending pet [{}] into battle due to attack", pet->GetName());
+				if (IsClient()) {
+					// if pet was sitting his new mode is follow
+					// following after the battle (live verified)
+					if (pet->GetPetOrder() == SPO_Sit) {
+						pet->SetPetOrder(SPO_Follow);
+					}
+
+					// fix GUI sit button to be unpressed and stop sitting regen
+					this->CastToClient()->SetPetCommandState(PET_BUTTON_SIT, 0);
+					pet->SetAppearance(eaStanding);
+				}
+
 				pet->AddToHateList(attacker, 1, 0, true, false, false, spell_id);
 				pet->SetTarget(attacker);
 				MessageString(Chat::NPCQuestSay, PET_ATTACKING, pet->GetCleanName(), attacker->GetCleanName());

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -3455,9 +3455,9 @@ void Mob::CommonDamage(Mob* attacker, int &damage, const uint16 spell_id, const 
 					if (GetPetOrder() == SPO_Sit) {
 						SetPetOrder(SPO_Follow);
 					}
-				// fix GUI sit button to be unpressed and stop sitting regen
-				owner->CastToClient()->SetPetCommandState(PET_BUTTON_SIT, 0);
-				SetAppearance(eaStanding);
+					// fix GUI sit button to be unpressed and stop sitting regen
+					owner->CastToClient()->SetPetCommandState(PET_BUTTON_SIT, 0);
+					SetAppearance(eaStanding);
 				}	
 			}
 

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -687,6 +687,7 @@ bool Client::Save(uint8 iCommitNow) {
 		pet->GetPetState(m_petinfo.Buffs, m_petinfo.Items, m_petinfo.Name);
 		m_petinfo.petpower = pet->GetPetPower();
 		m_petinfo.size = pet->GetSize();
+		m_petinfo.taunting = pet->CastToNPC()->IsTaunting();
 	} else {
 		memset(&m_petinfo, 0, sizeof(struct PetInfo));
 	}
@@ -5642,6 +5643,8 @@ void Client::SuspendMinion()
 
 			CurrentPet->SetMana(m_suspendedminion.Mana);
 
+			CurrentPet->SetTaunting(m_suspendedminion.taunting);
+
 			MessageString(Chat::Magenta, SUSPEND_MINION_UNSUSPEND, CurrentPet->GetCleanName());
 
 			memset(&m_suspendedminion, 0, sizeof(struct PetInfo));
@@ -5653,7 +5656,8 @@ void Client::SuspendMinion()
 				SetPetCommandState(PET_BUTTON_REGROUP, 0);
 				SetPetCommandState(PET_BUTTON_FOLLOW, 1);
 				SetPetCommandState(PET_BUTTON_GUARD, 0);
-				SetPetCommandState(PET_BUTTON_TAUNT, 1);
+				// Taunt saved on client side for logging on with pet
+				// In our db for when we zone.
 				SetPetCommandState(PET_BUTTON_HOLD, 0);
 				SetPetCommandState(PET_BUTTON_GHOLD, 0);
 				SetPetCommandState(PET_BUTTON_FOCUS, 0);

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1632,9 +1632,12 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 			pet->CalcBonuses();
 			pet->SetHP(m_petinfo.HP);
 			pet->SetMana(m_petinfo.Mana);
-			// 1st login, client takes care of this from button status
-			if (!firstlogon) {
-				pet->SetTaunting(m_petinfo.taunting);
+
+			// Taunt persists when zoning on newer clients, overwrite default.
+			if (m_ClientVersionBit & EQ::versions::maskUFAndLater) {
+				if (!firstlogon) {
+					pet->SetTaunting(m_petinfo.taunting);
+				}
 			}
 		}
 		m_petinfo.SpellID = 0;

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -10069,6 +10069,11 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 					mypet->SetPetRegroup(false);
 					SetPetCommandState(PET_BUTTON_REGROUP, 0);
 				}
+
+				// fix GUI sit button to be unpressed and stop sitting regen
+				SetPetCommandState(PET_BUTTON_SIT, 0);
+				mypet->SetAppearance(eaStanding);
+
 				zone->AddAggroMob();
 				// classic acts like qattack
 				int hate = 1;
@@ -10110,6 +10115,11 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 					mypet->SetPetRegroup(false);
 					SetPetCommandState(PET_BUTTON_REGROUP, 0);
 				}
+
+				// fix GUI sit button to be unpressed and stop sitting regen
+				SetPetCommandState(PET_BUTTON_SIT, 0);
+				mypet->SetAppearance(eaStanding);
+
 				zone->AddAggroMob();
 				mypet->AddToHateList(GetTarget(), 1, 0, true, false, false, SPELL_UNKNOWN, true);
 				MessageString(Chat::PetResponse, PET_ATTACKING, mypet->GetCleanName(), GetTarget()->GetCleanName());
@@ -10170,6 +10180,11 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 
 		if ((mypet->GetPetType() == petAnimation && aabonuses.PetCommands[PetCommand]) || mypet->GetPetType() != petAnimation) {
 			if (mypet->IsNPC()) {
+
+				// Set Sit button to unpressed - send stand anim/end hpregen
+				SetPetCommandState(PET_BUTTON_SIT, 0);
+				mypet->SendAppearancePacket(AT_Anim, ANIM_STAND);
+
 				mypet->SayString(this, Chat::PetResponse, PET_GUARDINGLIFE);
 				mypet->SetPetOrder(SPO_Guard);
 				mypet->CastToNPC()->SaveGuardSpot(mypet->GetPosition());
@@ -10189,7 +10204,11 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 		if ((mypet->GetPetType() == petAnimation && aabonuses.PetCommands[PetCommand]) || mypet->GetPetType() != petAnimation) {
 			mypet->SayString(this, Chat::PetResponse, PET_FOLLOWING);
 			mypet->SetPetOrder(SPO_Follow);
+
+			// fix GUI sit button to be unpressed - send stand anim/end hpregen
+			SetPetCommandState(PET_BUTTON_SIT, 0);
 			mypet->SendAppearancePacket(AT_Anim, ANIM_STAND);
+
 			if (mypet->IsPetStop()) {
 				mypet->SetPetStop(false);
 				SetPetCommandState(PET_BUTTON_STOP, 0);
@@ -10232,7 +10251,11 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 		if ((mypet->GetPetType() == petAnimation && aabonuses.PetCommands[PetCommand]) || mypet->GetPetType() != petAnimation) {
 			mypet->SayString(this, Chat::PetResponse, PET_GUARDME_STRING);
 			mypet->SetPetOrder(SPO_Follow);
+
+			// Set Sit button to unpressed - send stand anim/end hpregen
+			SetPetCommandState(PET_BUTTON_SIT, 0);
 			mypet->SendAppearancePacket(AT_Anim, ANIM_STAND);
+
 			if (mypet->IsPetStop()) {
 				mypet->SetPetStop(false);
 				SetPetCommandState(PET_BUTTON_STOP, 0);
@@ -10267,6 +10290,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 
 		if ((mypet->GetPetType() == petAnimation && aabonuses.PetCommands[PetCommand]) || mypet->GetPetType() != petAnimation) {
 			mypet->SayString(this, Chat::PetResponse, PET_SIT_STRING);
+			SetPetCommandState(PET_BUTTON_SIT, 0);
 			mypet->SetPetOrder(SPO_Follow);
 			mypet->SendAppearancePacket(AT_Anim, ANIM_STAND);
 		}
@@ -10277,6 +10301,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 
 		if ((mypet->GetPetType() == petAnimation && aabonuses.PetCommands[PetCommand]) || mypet->GetPetType() != petAnimation) {
 			mypet->SayString(this, Chat::PetResponse, PET_SIT_STRING);
+			SetPetCommandState(PET_BUTTON_SIT, 1);
 			mypet->SetPetOrder(SPO_Sit);
 			mypet->SetRunAnimSpeed(0);
 			if (!mypet->UseBardSpellLogic())	//maybe we can have a bard pet

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -904,7 +904,8 @@ void Client::CompleteConnect()
 		SetPetCommandState(PET_BUTTON_REGROUP, 0);
 		SetPetCommandState(PET_BUTTON_FOLLOW, 1);
 		SetPetCommandState(PET_BUTTON_GUARD, 0);
-		SetPetCommandState(PET_BUTTON_TAUNT, 1);
+		// Taunt saved on client side for logging on with pet
+		// In our db for when we zone.
 		SetPetCommandState(PET_BUTTON_HOLD, 0);
 		SetPetCommandState(PET_BUTTON_GHOLD, 0);
 		SetPetCommandState(PET_BUTTON_FOCUS, 0);
@@ -1631,6 +1632,10 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 			pet->CalcBonuses();
 			pet->SetHP(m_petinfo.HP);
 			pet->SetMana(m_petinfo.Mana);
+			// 1st login, client takes care of this from button status
+			if (!firstlogon) {
+				pet->SetTaunting(m_petinfo.taunting);
+			}
 		}
 		m_petinfo.SpellID = 0;
 	}

--- a/zone/pets.cpp
+++ b/zone/pets.cpp
@@ -434,15 +434,19 @@ Pet::Pet(NPCType *type_data, Mob *owner, PetType type, uint16 spell_id, int16 po
 	SetOwnerID(owner->GetID());
 	SetPetSpellID(spell_id);
 
-	bool non_persistant_pet_states_client = false;
+	// All pets start at false on newer clients. The client
+	// turns it on and tracks the state.
+	taunting=false;
 
-	// Deault to on in older clients, off in new clients that control state.
+	// Older clients didn't track state, and default taunting is on (per @mackal)
+	// Familiar and animation pets don't get taunt until an AA.
 	if (owner && owner->IsClient()) {
 		if (!(owner->CastToClient()->ClientVersionBit() & EQ::versions::maskUFAndLater)) {
-			non_persistant_pet_states_client = true;
+			if ((typeofpet != petFamiliar && typeofpet != petAnimation) || 
+				GetAA(aaAnimationEmpathy) >= 3) {
+				taunting=true;
+			}
 		}
-
-	taunting = non_persistant_pet_states_client;
 	}
 
 	// Class should use npc constructor to set light properties

--- a/zone/pets.cpp
+++ b/zone/pets.cpp
@@ -433,7 +433,7 @@ Pet::Pet(NPCType *type_data, Mob *owner, PetType type, uint16 spell_id, int16 po
 	petpower = power;
 	SetOwnerID(owner->GetID());
 	SetPetSpellID(spell_id);
-	taunting = true;
+	taunting = false;
 
 	// Class should use npc constructor to set light properties
 }

--- a/zone/pets.cpp
+++ b/zone/pets.cpp
@@ -443,7 +443,7 @@ Pet::Pet(NPCType *type_data, Mob *owner, PetType type, uint16 spell_id, int16 po
 	if (owner && owner->IsClient()) {
 		if (!(owner->CastToClient()->ClientVersionBit() & EQ::versions::maskUFAndLater)) {
 			if ((typeofpet != petFamiliar && typeofpet != petAnimation) || 
-				GetAA(aaAnimationEmpathy) >= 3) {
+				aabonuses.PetCommands[PET_TAUNT]) {
 				taunting=true;
 			}
 		}

--- a/zone/pets.cpp
+++ b/zone/pets.cpp
@@ -439,7 +439,6 @@ Pet::Pet(NPCType *type_data, Mob *owner, PetType type, uint16 spell_id, int16 po
 	// Deault to on in older clients, off in new clients that control state.
 	if (owner && owner->IsClient()) {
 		if (!(owner->CastToClient()->ClientVersionBit() & EQ::versions::maskUFAndLater)) {
-			LogError("Titanium");
 			non_persistant_pet_states_client = true;
 		}
 

--- a/zone/pets.cpp
+++ b/zone/pets.cpp
@@ -433,7 +433,18 @@ Pet::Pet(NPCType *type_data, Mob *owner, PetType type, uint16 spell_id, int16 po
 	petpower = power;
 	SetOwnerID(owner->GetID());
 	SetPetSpellID(spell_id);
-	taunting = false;
+
+	bool non_persistant_pet_states_client = false;
+
+	// Deault to on in older clients, off in new clients that control state.
+	if (owner && owner->IsClient()) {
+		if (!(owner->CastToClient()->ClientVersionBit() & EQ::versions::maskUFAndLater)) {
+			LogError("Titanium");
+			non_persistant_pet_states_client = true;
+		}
+
+	taunting = non_persistant_pet_states_client;
+	}
 
 	// Class should use npc constructor to set light properties
 }

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -1245,7 +1245,8 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					MakePet(spell_id, spell.teleport_zone);
 					// TODO: we need to sync the states for these clients ...
 					// Will fix buttons for now
-					if (IsClient()) {
+					Mob *pet=GetPet();
+					if (IsClient() && pet) {
 						auto c = CastToClient();
 						if (c->ClientVersionBit() & EQ::versions::maskUFAndLater) {
 							c->SetPetCommandState(PET_BUTTON_SIT, 0);
@@ -1253,7 +1254,9 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 							c->SetPetCommandState(PET_BUTTON_REGROUP, 0);
 							c->SetPetCommandState(PET_BUTTON_FOLLOW, 1);
 							c->SetPetCommandState(PET_BUTTON_GUARD, 0);
-							c->SetPetCommandState(PET_BUTTON_TAUNT, 1);
+							// Creating pet from spell - taunt always false
+							// If suspended pet - that will be restore there
+							// If logging in, client will send toggle
 							c->SetPetCommandState(PET_BUTTON_HOLD, 0);
 							c->SetPetCommandState(PET_BUTTON_GHOLD, 0);
 							c->SetPetCommandState(PET_BUTTON_FOCUS, 0);

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -3788,13 +3788,14 @@ void ZoneDatabase::SavePetInfo(Client *client)
 			continue;
 
 		query = StringFormat("INSERT INTO `character_pet_info` "
-				"(`char_id`, `pet`, `petname`, `petpower`, `spell_id`, `hp`, `mana`, `size`) "
-				"VALUES (%u, %u, '%s', %i, %u, %u, %u, %f) "
+				"(`char_id`, `pet`, `petname`, `petpower`, `spell_id`, `hp`, `mana`, `size`, `taunting`) "
+				"VALUES (%u, %u, '%s', %i, %u, %u, %u, %f, %u) "
 				"ON DUPLICATE KEY UPDATE `petname` = '%s', `petpower` = %i, `spell_id` = %u, "
-				"`hp` = %u, `mana` = %u, `size` = %f",
+				"`hp` = %u, `mana` = %u, `size` = %f, `taunting` = %u",
 				client->CharacterID(), pet, petinfo->Name, petinfo->petpower, petinfo->SpellID,
-				petinfo->HP, petinfo->Mana, petinfo->size, // and now the ON DUPLICATE ENTRIES
-				petinfo->Name, petinfo->petpower, petinfo->SpellID, petinfo->HP, petinfo->Mana, petinfo->size);
+				petinfo->HP, petinfo->Mana, petinfo->size, (petinfo->taunting) ? 1 : 0, 
+				// and now the ON DUPLICATE ENTRIES
+				petinfo->Name, petinfo->petpower, petinfo->SpellID, petinfo->HP, petinfo->Mana, petinfo->size, (petinfo->taunting) ? 1 : 0);
 		results = database.QueryDatabase(query);
 		if (!results.Success())
 			return;
@@ -3866,7 +3867,7 @@ void ZoneDatabase::LoadPetInfo(Client *client)
 	memset(suspended, 0, sizeof(PetInfo));
 
 	std::string query = StringFormat("SELECT `pet`, `petname`, `petpower`, `spell_id`, "
-					 "`hp`, `mana`, `size` FROM `character_pet_info` "
+					 "`hp`, `mana`, `size` , `taunting` FROM `character_pet_info` "
 					 "WHERE `char_id` = %u",
 					 client->CharacterID());
 	auto results = database.QueryDatabase(query);
@@ -3891,6 +3892,7 @@ void ZoneDatabase::LoadPetInfo(Client *client)
 		pi->HP = atoul(row[4]);
 		pi->Mana = atoul(row[5]);
 		pi->size = atof(row[6]);
+		pi->taunting = (bool) atoi(row[7]);
 	}
 
 	query = StringFormat("SELECT `pet`, `slot`, `spell_id`, `caster_level`, `castername`, "

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -155,6 +155,7 @@ struct PetInfo {
 	SpellBuff_Struct	Buffs[PET_BUFF_COUNT];
 	uint32	Items[EQ::invslot::EQUIPMENT_COUNT];
 	char	Name[64];
+	bool	taunting;
 };
 
 struct ZoneSpellsBlocked {


### PR DESCRIPTION
The pet window sit button is often out of sync.  This PR fixes this issue.  Also pet's were frequently still marked as sitting internal to the server due to the owner being attacked, or other issues.  This is because the anim state was not being correctly updated.

I tested the behavior on live and made it match.  A pet on guard will always return to guard after a battle.  A pet sitting, will switch to follow mode after a battle.  This fix is here as well.

After 2 weeks of testing, I no longer see the pet sit button out of sync, and no longer see (harder to see, but can be done with a char in his teens) pet sitting regen while pet is actually standing.

After hearing from @Trust that the taunt button was also out of sync often, I looked into that as well.

The client stores the status of an active pet's taunt setting.  This is stored across sessions.  The old approach was to try and force taunt on, on pet creation as well as logging on and zoning.   Client messages, sometimes in response to out attempts, would end up toggling our taunt value away from what we just set it to.

Taunt now behaves as follows:

**Clients previous to UF**

Only client on/off clicks change state.  Default is taunt on.  Zoning and logging on both default to true.


UF+ Clients:

**On 1st time pet summoning via spell:**

The pet is created with taunting off.  This matches the client.

**On logging in with an existing pet:**

The client sends a message if the pet was taunting when you logged off, which will turn it on, since pet creation now defaults to  taunting=false in the constructor.

**On zoning:**

The pet's state is set from it's saved value in the database.  The client is not involved, but will match as pet state is preserved by the client across zoning.

**On suspend minion:**

The pet's state is set from it's saved value in the database.  The client is not involved, but will match as pet state is preserved by the client across zoning.

NOTE: After this update, existing pets might be out of sync, because I have no way of knowing if your client has the button depressed or not.  My guess is that they will work.  I do not use the db saved version at all on login from character_select, so the 1st login should sync with the client.

