### PR TITLE
Allow amphibious mobs underwater to follow los and not fall to water bottom when pathing

### DIFF
--- a/zone/mob_movement_manager.cpp
+++ b/zone/mob_movement_manager.cpp
@@ -1088,6 +1088,17 @@ void MobMovementManager::UpdatePath(Mob *who, float x, float y, float z, MobMove
 		PushFlyTo(ent.second, x, y, z, mob_movement_mode);
 		PushStopMoving(ent.second);
 		}
+	// Below for npcs that can traverse land or water so they don't sink
+	else if (who->GetFlyMode() == GravityBehavior::Water &&
+			 zone->watermap->InLiquid(who->GetPosition()) && 
+			 zone->watermap->InLiquid(glm::vec3(x, y, z)) &&
+			 zone->zonemap->CheckLoS(who->GetPosition(), glm::vec3(x, y, z))) {
+		auto iter = _impl->Entries.find(who);
+		auto &ent = (*iter);
+
+		PushSwimTo(ent.second, x, y, z, mob_movement_mode);
+		PushStopMoving(ent.second);
+	}
 	else {
 		UpdatePathGround(who, x, y, z, mob_movement_mode);
 	}


### PR DESCRIPTION
This PR is almost a direct parallel to my PR that was accepted for flying.

Without this PR, only water only mobs swim from path node to path node, or to a target without dropping to
the ground mesh.  Meaning you need to have flymode set to swimming and inwater set in the db.  For some mobs like crocodiles in guk, that start in water, this PR allows then to path between gird nodes that are both underwater, or path to a target that is also out of water without sinking to the bottom.

If LoS fails, the mob reverts to existing pathing hierarchy, just like the flying patch.

I think you'll find that mobs underwater in guk and places like oasis act much better.

If a path grid has a node that has no line of sight to the next path node (or any other path node depending on grid type), the mob will revert to the existing mesh based pathing, again, just like flying.