### PR TITLE
Fix for command '#editmassrespawn'

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -6879,7 +6879,7 @@ void command_editmassrespawn(Client* c, const Seperator* sep)
 
 	int results_count = 0;
 
-	auto results = database.QueryDatabase(query);
+	auto results = content_db.QueryDatabase(query);
 	if (results.Success() && results.RowCount()) {
 
 		results_count = results.RowCount();
@@ -6906,7 +6906,7 @@ void command_editmassrespawn(Client* c, const Seperator* sep)
 
 			if (change_apply) {
 
-				results = database.QueryDatabase(
+				results = content_db.QueryDatabase(
 					fmt::format(
 						SQL(
 							UPDATE spawn2


### PR DESCRIPTION
Fixes an issue with command query not using content database connecter.