### PR TITLE
Update the SummonItem call to default charges for QuestRewards

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -8617,7 +8617,7 @@ void Client::QuestReward(Mob* target, uint32 copper, uint32 silver, uint32 gold,
 		AddMoneyToPP(copper, silver, gold, platinum, false);
 
 	if (itemid > 0)
-		SummonItem(itemid, 0, 0, 0, 0, 0, 0, false, EQ::invslot::slotCursor);
+		SummonItem(itemid, -1, 0, 0, 0, 0, 0, false, EQ::invslot::slotCursor);
 
 	if (faction)
 	{


### PR DESCRIPTION
This should summon the item at max charges, if it has charges