### PR TITLE
Add safeguard for issue with mobs pathing to 0,0,0 on teleport nodes with values 0,0,0

### DIFF
--- a/zone/mob_movement_manager.cpp
+++ b/zone/mob_movement_manager.cpp
@@ -1225,7 +1225,7 @@ void MobMovementManager::UpdatePathGround(Mob *who, float x, float y, float z, M
 				)
 			);
 		}
-		else {
+		else if(!next_node.teleport) {
 			if (zone->watermap->InLiquid(previous_pos)) {
 				PushSwimTo(ent.second, next_node.pos.x, next_node.pos.y, next_node.pos.z, mode);
 			}
@@ -1345,7 +1345,7 @@ void MobMovementManager::UpdatePathUnderwater(Mob *who, float x, float y, float 
 					next_node.pos.y
 				));
 		}
-		else {
+		else if(!next_node.teleport) {
 			PushSwimTo(ent.second, next_node.pos.x, next_node.pos.y, next_node.pos.z, movement_mode);
 		}
 	}


### PR DESCRIPTION
Under any teleport node with 0.0f for x/y, mobs will end up at 0,0,0 due to a bug that does not check teleport nodes in the else statement that prevents the mob from having that route added.

Ignore the Jan 13, 2019 commit, it's reverted in the merge commit. Only the two changes are in question here.