### PR TITLE
Add safeguard for issue with mobs pathing to 0,0,0 on teleport nodes …

### DIFF
--- a/zone/mob_movement_manager.cpp
+++ b/zone/mob_movement_manager.cpp
@@ -1225,7 +1225,7 @@ void MobMovementManager::UpdatePathGround(Mob *who, float x, float y, float z, M
 				)
 			);
 		}
-		else {
+		else if(!next_node.teleport) {
 			if (zone->watermap->InLiquid(previous_pos)) {
 				PushSwimTo(ent.second, next_node.pos.x, next_node.pos.y, next_node.pos.z, mode);
 			}
@@ -1345,7 +1345,7 @@ void MobMovementManager::UpdatePathUnderwater(Mob *who, float x, float y, float 
 					next_node.pos.y
 				));
 		}
-		else {
+		else if(!next_node.teleport) {
 			PushSwimTo(ent.second, next_node.pos.x, next_node.pos.y, next_node.pos.z, movement_mode);
 		}
 	}


### PR DESCRIPTION
…with values 0,0,0 (#1140)

* IP limit and account session limit refactor - uses responses built into loginserver

* Fix an issue where teleport nodes with 0.0f as a value were added to routes when pathing.