### PR TITLE
Destination check needed to be actual ground z at loc.  -15 wasnt enough

### DIFF
--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -1610,7 +1610,7 @@ void NPC::AI_DoMovement() {
 					auto position = glm::vec3(
 						roambox_destination_x,
 						roambox_destination_y,
-						(m_Position.z - 15)
+						roambox_destination_z
 					);
 
 					/**


### PR DESCRIPTION
On islands, the -15 to z for checks to see if destination was in water was not enough, resulting in destinations in water for land creatures to look like land.

@KimLS 