### PR TITLE
Added new Perl/LUA GetSpellIDByBookSlot

### DIFF
--- a/zone/client.h
+++ b/zone/client.h
@@ -988,6 +988,7 @@ public:
 	void ProcessInspectRequest(Client* requestee, Client* requester);
 	bool ClientFinishedLoading() { return (conn_state == ClientConnectFinished); }
 	int FindSpellBookSlotBySpellID(uint16 spellid);
+	uint32 GetSpellIDByBookSlot(int book_slot);
 	int GetNextAvailableSpellBookSlot(int starting_slot = 0);
 	inline uint32 GetSpellByBookSlot(int book_slot) { return m_pp.spell_book[book_slot]; }
 	inline bool HasSpellScribed(int spellid) { return (FindSpellBookSlotBySpellID(spellid) != -1 ? true : false); }

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -1160,6 +1160,11 @@ int Lua_Client::GetNextAvailableSpellBookSlot() {
 	return self->GetNextAvailableSpellBookSlot();
 }
 
+uint32 Lua_Client::GetSpellIDByBookSlot(int slot_id) {
+	Lua_Safe_Call_Int();
+	return self->GetSpellIDByBookSlot(slot_id);
+}
+
 int Lua_Client::GetNextAvailableSpellBookSlot(int start) {
 	Lua_Safe_Call_Int();
 	return self->GetNextAvailableSpellBookSlot(start);
@@ -1866,6 +1871,7 @@ luabind::scope lua_register_client() {
 		.def("ClearCompassMark",(void(Lua_Client::*)(void))&Lua_Client::ClearCompassMark)
 		.def("GetNextAvailableSpellBookSlot", (int(Lua_Client::*)(void))&Lua_Client::GetNextAvailableSpellBookSlot)
 		.def("GetNextAvailableSpellBookSlot", (int(Lua_Client::*)(int))&Lua_Client::GetNextAvailableSpellBookSlot)
+		.def("GetSpellIDByBookSlot", (uint32(Lua_Client::*)(int))& Lua_Client::GetSpellIDByBookSlot)
 		.def("FindSpellBookSlotBySpellID", (int(Lua_Client::*)(int))&Lua_Client::FindSpellBookSlotBySpellID)
 		.def("UpdateTaskActivity", (void(Lua_Client::*)(int,int,int))&Lua_Client::UpdateTaskActivity)
 		.def("AssignTask", (void(Lua_Client::*)(int,int))&Lua_Client::AssignTask)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -260,6 +260,7 @@ public:
 	void ClearCompassMark();
 	int GetNextAvailableSpellBookSlot();
 	int GetNextAvailableSpellBookSlot(int start);
+	uint32 GetSpellIDByBookSlot(int book_slot);
 	int FindSpellBookSlotBySpellID(int spell_id);
 	void UpdateTaskActivity(int task, int activity, int count);
 	void AssignTask(int task, int npc_id);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -5297,6 +5297,33 @@ XS(XS_Client_GetSpellBookSlotBySpellID) {
 	XSRETURN(1);
 }
 
+XS(XS_Client_GetSpellIDByBookSlot); /* prototype to pass -Wmissing-prototypes */
+XS(XS_Client_GetSpellIDByBookSlot) {
+	dXSARGS;
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: Client::GetSpellIDByBookSlot(THIS, int slot_id)");
+	{
+		Client* THIS;
+		int    RETVAL;
+		int	   slot_id = SvUV(ST(1));
+		dXSTARG;
+
+		if (sv_derived_from(ST(0), "Client")) {
+			IV tmp = SvIV((SV*)SvRV(ST(0)));
+			THIS = INT2PTR(Client*, tmp);
+		}
+		else
+			Perl_croak(aTHX_ "THIS is not of type Client");
+		if (THIS == nullptr)
+			Perl_croak(aTHX_ "THIS is nullptr, avoiding crash.");
+
+		RETVAL = THIS->GetSpellIDByBookSlot(slot_id);
+		XSprePUSH;
+		PUSHi((IV)RETVAL);
+	}
+	XSRETURN(1);
+}
+
 XS(XS_Client_UpdateTaskActivity); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Client_UpdateTaskActivity) {
 	dXSARGS;
@@ -6821,6 +6848,7 @@ XS(boot_Client) {
 	newXSproto(strcpy(buf, "GetRawSkill"), XS_Client_GetRawSkill, file, "$$");
 	newXSproto(strcpy(buf, "GetSkillPoints"), XS_Client_GetSkillPoints, file, "$");
 	newXSproto(strcpy(buf, "GetSpellBookSlotBySpellID"), XS_Client_GetSpellBookSlotBySpellID, file, "$$");
+	newXSproto(strcpy(buf, "GetSpellIDByBookSlot"), XS_Client_GetSpellIDByBookSlot, file, "$$");
 	newXSproto(strcpy(buf, "GetSpentAA"), XS_Client_GetSpentAA, file, "$$");
 	newXSproto(strcpy(buf, "GetStartZone"), XS_Client_GetStartZone, file, "$");
 	newXSproto(strcpy(buf, "GetTargetRingX"), XS_Client_GetTargetRingX, file, "$$");

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -5090,6 +5090,13 @@ void Client::UnmemSpellAll(bool update_client)
 			UnmemSpell(i, update_client);
 }
 
+uint32 Client::GetSpellIDByBookSlot(int book_slot) {
+	if (book_slot <= EQ::spells::SPELLBOOK_SIZE) {
+		return GetSpellByBookSlot(book_slot);
+	}
+	return -1;	//default
+}
+
 uint16 Client::FindMemmedSpellBySlot(int slot) {
 	if (m_pp.mem_spells[slot] != 0xFFFFFFFF)
 		return m_pp.mem_spells[slot];


### PR DESCRIPTION
I wanted to create an quest NPC to allow players to sort their spell book by level. Ended up creating a perl/lua client questAPI called GetSpellIDByBookSlot which uses the existing GetSpellByBookSlot function. This has allowed me to create a perl/lua script to retrieve the spells within the book, sort by various attributes (level, type, etc) and then repopulate the spellbook in whichever sorted order is required. Happy to share the scripts as well. Hope this is useful to others.