### PR TITLE
Client tracks pet sit/stand - force new pets to stand.

### DIFF
--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -774,6 +774,13 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				caster->SetPet(this);
 				SetOwnerID(caster->GetID());
 				SetPetOrder(SPO_Follow);
+				SetAppearance(eaStanding);
+				// Client has saved previous pet sit/stand - make all new pets
+				// stand on charm.
+				if (caster->IsClient()) {
+					caster->CastToClient()->SetPetCommandState(PET_BUTTON_SIT,0);
+				}
+
 				SetPetType(petCharmed);
 
 				if(caster->IsClient()){


### PR DESCRIPTION
I made some earlier fixes to the pet sit/stand window as well as the pet states.  Newly charmed pets need to be set as standing, or the clients old setting (if it was sit) will end up making new charmed pets do the poop-on-my-butt carpet rub when they attack.