### PR TITLE
[DevTools] Improve DevTools Toggling Options

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -246,6 +246,7 @@ RULE_BOOL(World, MaxClientsSimplifiedLogic, false, "New logic that only uses Exe
 RULE_INT (World, TellQueueSize, 20, "Maximum tell queue size")
 RULE_BOOL(World, StartZoneSameAsBindOnCreation, true, "Should the start zone always be the same location as your bind?")
 RULE_BOOL(World, EnforceCharacterLimitAtLogin, false, "Enforce the limit for characters that are online at login")
+RULE_BOOL(World, EnableDevTools, true, "Enable or Disable the Developer Tools globally (Most of the time you want this enabled)")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Zone)

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -9387,7 +9387,7 @@ void Client::ShowDevToolsMenu()
 	std::string menu_commands_search;
 	std::string menu_commands_show;
 	std::string reload_commands_show;
-	std::string window_toggle_command;
+	std::string devtools_toggle;
 
 	/**
 	 * Search entity commands
@@ -9422,9 +9422,9 @@ void Client::ShowDevToolsMenu()
 	/**
 	 * Show window status
 	 */
-	window_toggle_command = "Disabled [" + EQ::SayLinkEngine::GenerateQuestSaylink("#devtools enable_window", false, "Enable") + "] ";
+	devtools_toggle = "Disabled [" + EQ::SayLinkEngine::GenerateQuestSaylink("#devtools enable", false, "Enable") + "] ";
 	if (IsDevToolsEnabled()) {
-		window_toggle_command = "Enabled [" + EQ::SayLinkEngine::GenerateQuestSaylink("#devtools disable_window", false, "Disable") + "] ";
+		devtools_toggle = "Enabled [" + EQ::SayLinkEngine::GenerateQuestSaylink("#devtools disable", false, "Disable") + "] ";
 	}
 
 	/**
@@ -9432,8 +9432,8 @@ void Client::ShowDevToolsMenu()
 	 */
 	SendChatLineBreak();
 	Message(
-		Chat::White, "| [Devtools] Window %s Show this menu with %s | Current expansion [%s]",
-		window_toggle_command.c_str(),
+		Chat::White, "| [Devtools] %s Show this menu with %s | Current expansion [%s]",
+		devtools_toggle.c_str(),
 		EQ::SayLinkEngine::GenerateQuestSaylink("#dev", false, "#dev").c_str(),
 		content_service.GetCurrentExpansionName().c_str()
 	);

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -350,8 +350,8 @@ Client::Client(EQStreamInterface* ieqs)
 	/**
 	 * GM
 	 */
-	display_mob_info_window  = true;
-	dev_tools_window_enabled = true;
+	SetDisplayMobInfoWindow(true);
+	SetDevToolsEnabled(true);
 
 #ifdef BOTS
 	bot_owner_options[booDeathMarquee] = false;
@@ -9171,17 +9171,14 @@ void Client::SetDisplayMobInfoWindow(bool display_mob_info_window)
 	Client::display_mob_info_window = display_mob_info_window;
 }
 
-bool Client::IsDevToolsWindowEnabled() const
+bool Client::IsDevToolsEnabled() const
 {
-	return dev_tools_window_enabled;
+	return dev_tools_enabled && RuleB(World, EnableDevTools);
 }
 
-/**
- * @param in_dev_tools_window_enabled
- */
-void Client::SetDevToolsWindowEnabled(bool in_dev_tools_window_enabled)
+void Client::SetDevToolsEnabled(bool in_dev_tools_enabled)
 {
-	Client::dev_tools_window_enabled = in_dev_tools_window_enabled;
+	Client::dev_tools_enabled = in_dev_tools_enabled;
 }
 
 /**
@@ -9426,7 +9423,7 @@ void Client::ShowDevToolsMenu()
 	 * Show window status
 	 */
 	window_toggle_command = "Disabled [" + EQ::SayLinkEngine::GenerateQuestSaylink("#devtools enable_window", false, "Enable") + "] ";
-	if (IsDevToolsWindowEnabled()) {
+	if (IsDevToolsEnabled()) {
 		window_toggle_command = "Enabled [" + EQ::SayLinkEngine::GenerateQuestSaylink("#devtools disable_window", false, "Disable") + "] ";
 	}
 

--- a/zone/client.h
+++ b/zone/client.h
@@ -232,8 +232,8 @@ public:
 	void SetDisplayMobInfoWindow(bool display_mob_info_window);
 	bool GetDisplayMobInfoWindow() const;
 
-	bool IsDevToolsWindowEnabled() const;
-	void SetDevToolsWindowEnabled(bool dev_tools_window_enabled);
+	bool IsDevToolsEnabled() const;
+	void SetDevToolsEnabled(bool in_dev_tools_enabled);
 
 	void SetPrimaryWeaponOrnamentation(uint32 model_id);
 	void SetSecondaryWeaponOrnamentation(uint32 model_id);
@@ -1477,7 +1477,7 @@ private:
 	uint32 tmSitting; // time stamp started sitting, used for HP regen bonus added on MAY 5, 2004
 
 	bool display_mob_info_window;
-	bool dev_tools_window_enabled;
+	bool dev_tools_enabled;
 
 	int32 max_end;
 	int32 current_endurance;

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1705,7 +1705,7 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 	 * DevTools Load Settings
 	 */
 	if (Admin() >= EQ::DevTools::GM_ACCOUNT_STATUS_LEVEL) {
-		std::string dev_tools_window_key = StringFormat("%i-dev-tools-window-disabled", AccountID());
+		std::string dev_tools_window_key = StringFormat("%i-dev-tools-disabled", AccountID());
 		if (DataBucket::GetData(dev_tools_window_key) == "true") {
 			dev_tools_enabled = false;
 		}

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -920,7 +920,7 @@ void Client::CompleteConnect()
 
 	entity_list.ScanCloseMobs(close_mobs, this, true);
 
-	if (GetGM()) {
+	if (GetGM() && IsDevToolsEnabled()) {
 		ShowDevToolsMenu();
 	}
 
@@ -1707,7 +1707,7 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 	if (Admin() >= EQ::DevTools::GM_ACCOUNT_STATUS_LEVEL) {
 		std::string dev_tools_window_key = StringFormat("%i-dev-tools-window-disabled", AccountID());
 		if (DataBucket::GetData(dev_tools_window_key) == "true") {
-			dev_tools_window_enabled = false;
+			dev_tools_enabled = false;
 		}
 	}
 
@@ -10912,8 +10912,8 @@ void Client::Handle_OP_PopupResponse(const EQApplicationPacket *app)
 			break;
 
 		case EQ::popupresponse::MOB_INFO_DISMISS:
-			this->SetDisplayMobInfoWindow(false);
-			this->Message(Chat::Yellow, "[DevTools] Window snoozed in this zone...");
+			SetDisplayMobInfoWindow(false);
+			Message(Chat::Yellow, "[DevTools] Window snoozed in this zone...");
 			break;
 		default:
 			break;

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -5592,17 +5592,17 @@ void command_depopzone(Client *c, const Seperator *sep)
 
 void command_devtools(Client *c, const Seperator *sep)
 {
-	std::string dev_tools_window_key = StringFormat("%i-dev-tools-window-disabled", c->AccountID());
+	std::string dev_tools_key = StringFormat("%i-dev-tools-disabled", c->AccountID());
 
 	/**
 	 * Handle window toggle
 	 */
-	if (strcasecmp(sep->arg[1], "disable_window") == 0) {
-		DataBucket::SetData(dev_tools_window_key, "true");
+	if (strcasecmp(sep->arg[1], "disable") == 0) {
+		DataBucket::SetData(dev_tools_key, "true");
 		c->SetDevToolsEnabled(false);
 	}
-	if (strcasecmp(sep->arg[1], "enable_window") == 0) {
-		DataBucket::DeleteData(dev_tools_window_key);
+	if (strcasecmp(sep->arg[1], "enable") == 0) {
+		DataBucket::DeleteData(dev_tools_key);
 		c->SetDevToolsEnabled(true);
 	}
 

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -5599,11 +5599,11 @@ void command_devtools(Client *c, const Seperator *sep)
 	 */
 	if (strcasecmp(sep->arg[1], "disable_window") == 0) {
 		DataBucket::SetData(dev_tools_window_key, "true");
-		c->SetDevToolsWindowEnabled(false);
+		c->SetDevToolsEnabled(false);
 	}
 	if (strcasecmp(sep->arg[1], "enable_window") == 0) {
 		DataBucket::DeleteData(dev_tools_window_key);
-		c->SetDevToolsWindowEnabled(true);
+		c->SetDevToolsEnabled(true);
 	}
 
 	c->ShowDevToolsMenu();

--- a/zone/mob_info.cpp
+++ b/zone/mob_info.cpp
@@ -640,7 +640,7 @@ void Mob::DisplayInfo(Mob *mob)
 
 		Client *client = this->CastToClient();
 
-		if (!client->IsDevToolsWindowEnabled()) {
+		if (!client->IsDevToolsEnabled()) {
 			return;
 		}
 


### PR DESCRIPTION
This PR improves DevTools toggling options

DevTool Window toggling has been unified into simply "DevTools"

* When DevTools are toggled off at an account level, windows that display on target, messages that display on target and the zone-in menu will no longer show
* DevTools can optionally be shut off globally in rules for all GMs
