### PR TITLE
[Bugfix] Don't respawn doors while clients are zoning

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -2511,7 +2511,7 @@ void EntityList::DespawnAllDoors()
 	auto outapp = new EQApplicationPacket(OP_RemoveAllDoors, 0);
 	for (auto it = client_list.begin(); it != client_list.end(); ++it) {
 		if (it->second) {
-			it->second->QueuePacket(outapp);
+			it->second->QueuePacket(outapp, true, Client::CLIENT_CONNECTED);
 		}
 	}
 	safe_delete(outapp);
@@ -2524,7 +2524,7 @@ void EntityList::RespawnAllDoors()
 		if (it->second) {
 			auto outapp = new EQApplicationPacket();
 			MakeDoorSpawnPacket(outapp, it->second);
-			it->second->FastQueuePacket(&outapp);
+			it->second->FastQueuePacket(&outapp, true, Client::CLIENT_CONNECTED);
 		}
 		++it;
 	}


### PR DESCRIPTION
Fixes regression from b08dc02a (PR #1051)

The normal door list sent on zone entry caused unopenable double doors on clients if an api respawned them while the client was zoning. This waits until the client finishes zoning and has received the initial door list before sending any despawn/respawn packets.

Example packet order for one of the door APIs if called while a client is zoning:
```cpp
void Doors::SetOpenType(uint8 in) {
  entity_list.DespawnAllDoors();
  open_type = in;
  entity_list.RespawnAllDoors();
}
```
before patch b08dc02a:
```
OP_SpawnDoor      -- part 2 (RespawnAllDoors) of api call (CLIENT_CONNECTINGALL)
OP_SpawnDoor      -- normal zone entry door list packet
OP_RemoveAllDoors -- part 1 (DespawnAllDoors) of api call, deferred until now (CLIENT_CONNECTED)

*all doors missing*
```

current behavior (with b08dc02a):
```
OP_RemoveAllDoors -- part 1 (DespawnAllDoors) of api call (CLIENT_CONNECTINGALL)
OP_SpawnDoor      -- part 2 (RespawnAllDoors) of api call (CLIENT_CONNECTINGALL)
OP_SpawnDoor      -- normal zone entry door list packet

*all doors visually doubled, client can't open one of them*
```

after this patch:
```
OP_SpawnDoor      -- normal zone entry door list packet
OP_RemoveAllDoors -- part 1 (DespawnAllDoors) of api call, deferred until now (CLIENT_CONNECTED)
OP_SpawnDoor      -- part 2 (RespawnAllDoors) of api call, deferred until now (CLIENT_CONNECTED)
```