### PR TITLE
[Bugfix] Fix zone crash on spawn condition change

### DIFF
--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -968,9 +968,12 @@ void NPC::Depop(bool StartSpawnTimer) {
 	if(emoteid != 0)
 		this->DoNPCEmote(ONDESPAWN,emoteid);
 	p_depop = true;
-	if (StartSpawnTimer) {
-		if (respawn2 != 0) {
+	if (respawn2)
+	{
+		if (StartSpawnTimer) {
 			respawn2->DeathReset();
+		} else {
+			respawn2->Depop();
 		}
 	}
 }


### PR DESCRIPTION
The NPC (npcthis) pointer held by Spawn2 wasn't reset if the npc was depopped without a respawn timer by #depop commands or depop(false) quest apis. If the NPC was part of a spawn condition then the condition would try to dereference that pointer (which gets deleted) on condition change.

STR with current peq db/quests:
- #zone fearplane
- #depopzone or #depop some trash mobs that exist on condition 1
- #dbspawn 72003 to repop Cazic_Thule (he toggles condition 1 5s after spawn and should crash zone)
- crash in Spawn2::SpawnConditionChanged
