### PR TITLE
Allow boats flymode to be overridden by local db

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1197,10 +1197,6 @@ void Mob::FillSpawnStruct(NewSpawn_Struct* ns, Mob* ForWho)
 	else
 		ns->spawn.flymode = flymode;
 
-	if(IsBoat()) {
-		ns->spawn.flymode = GravityBehavior::Floating;
-	}
-
 	ns->spawn.lastName[0] = '\0';
 
 	strn0cpy(ns->spawn.lastName, lastname, sizeof(ns->spawn.lastName));

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -230,8 +230,13 @@ NPC::NPC(const NPCType *npc_type_data, Spawn2 *in_respawn, const glm::vec4 &posi
 	adventure_template_id = npc_type_data->adventure_template;
 	flymode               = iflymode;
 
+	// If server has set a flymode in db honor it over all else.
+	// If server has not set a flymde in db, and this is a boat - force floating.
 	if (npc_type_data->flymode >= 0) {
 		flymode = static_cast<GravityBehavior>(npc_type_data->flymode);
+	}
+	else if (IsBoat()) {
+		flymode = GravityBehavior::Floating;
 	}
 
 	guard_anim            = eaStanding;


### PR DESCRIPTION
Some boats (like race 533) line up better with some docs when they are not "levitating".

Before this patch, the flymode from the db could not override the code, because the check for IsBoat() in Mob::FillSpawnStruct happens after npc/mob creation has already been forced to turn the db field into the GravityBehavior enum which means it can no longer tell what to do.  I moved the check to inside the npc constructor, where this check against -1 can be made.

I also think that the old boat override only addressed the levitation mode in the packet being sent, and not in the mob itself.  I think this is what may be leading to some people seeing a floating boat and others seeing it underwater.  @thalix1337  and this may fix that.