### PR TITLE
Add message(color, message) and whisper(message) to Perl/Lua.

### DIFF
--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -2793,6 +2793,29 @@ XS(XS__we) {
 	XSRETURN_EMPTY;
 }
 
+XS(XS__message);
+XS(XS__message) {
+	dXSARGS;
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: quest::message(int color, string message)");
+
+	int color = (int) SvIV(ST(0));
+	char *message = (char *) SvPV_nolen(ST(1));
+	quest_manager.message(color, message);
+	XSRETURN_EMPTY;
+}
+
+XS(XS__whisper);
+XS(XS__whisper) {
+	dXSARGS;
+	if (items != 1)
+		Perl_croak(aTHX_ "Usage: quest::whisper(string message)");
+
+	char *message = (char *) SvPV_nolen(ST(0));
+	quest_manager.whisper(message);
+	XSRETURN_EMPTY;
+}
+
 XS(XS__getlevel);
 XS(XS__getlevel) {
 	dXSARGS;
@@ -6569,6 +6592,7 @@ EXTERN_C XS(boot_quest) {
 	newXS(strcpy(buf, "log"), XS__log, file);
 	newXS(strcpy(buf, "log_combat"), XS__log_combat, file);
 	newXS(strcpy(buf, "me"), XS__me, file);
+	newXS(strcpy(buf, "message"), XS__message, file);
 	newXS(strcpy(buf, "modifynpcstat"), XS__ModifyNPCStat, file);
 	newXS(strcpy(buf, "movegrp"), XS__movegrp, file);
 	newXS(strcpy(buf, "movepc"), XS__movepc, file);
@@ -6665,6 +6689,7 @@ EXTERN_C XS(boot_quest) {
 	newXS(strcpy(buf, "voicetell"), XS__voicetell, file);
 	newXS(strcpy(buf, "we"), XS__we, file);
 	newXS(strcpy(buf, "wearchange"), XS__wearchange, file);
+	newXS(strcpy(buf, "whisper"), XS__whisper, file);
 	newXS(strcpy(buf, "write"), XS__write, file);
 	newXS(strcpy(buf, "ze"), XS__ze, file);
 	newXS(strcpy(buf, "zone"), XS__zone, file);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -768,6 +768,14 @@ void lua_world_emote(int type, const char *str) {
 	quest_manager.we(type, str);
 }
 
+void lua_message(int color, const char *message) {
+	quest_manager.message(color, message);
+}
+
+void lua_whisper(const char *message) {
+	quest_manager.whisper(message);
+}
+
 int lua_get_level(int type) {
 	return quest_manager.getlevel(type);
 }
@@ -2599,6 +2607,8 @@ luabind::scope lua_register_general() {
 		luabind::def("clear_spawn_timers", &lua_clear_spawn_timers),
 		luabind::def("zone_emote", &lua_zone_emote),
 		luabind::def("world_emote", &lua_world_emote),
+		luabind::def("message", &lua_message),
+		luabind::def("whisper", &lua_whisper),
 		luabind::def("get_level", &lua_get_level),
 		luabind::def("create_ground_object", (void(*)(uint32,float,float,float,float))&lua_create_ground_object),
 		luabind::def("create_ground_object", (void(*)(uint32,float,float,float,float,uint32))&lua_create_ground_object),

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -2580,6 +2580,24 @@ void QuestManager::we(int type, const char *str) {
 	worldserver.SendEmoteMessage(0, 0, type, str);
 }
 
+void QuestManager::message(int color, const char *message) {
+	QuestManagerCurrentQuestVars();
+	if (!initiator)
+		return;
+	
+	initiator->Message(color, message);
+}
+
+void QuestManager::whisper(const char *message) {
+	QuestManagerCurrentQuestVars();
+	if (!initiator || !owner)
+		return;
+
+	std::string mob_name = owner->GetCleanName();
+	std::string new_message = fmt::format("{} whispers, '{}'", mob_name, message);
+	initiator->Message(315, new_message.c_str());
+}
+
 int QuestManager::getlevel(uint8 type)
 {
 	QuestManagerCurrentQuestVars();

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -223,6 +223,8 @@ public:
     void clearspawntimers();
 	void ze(int type, const char *str);
 	void we(int type, const char *str);
+	void message(int color, const char *message);
+	void whisper(const char *message);
     int getlevel(uint8 type);
     int collectitems(uint32 item_id, bool remove);
     int collectitems_processSlot(int16 slot_id, uint32 item_id, bool remove);


### PR DESCRIPTION
- Add quest::message(color, message) to Perl.
- Add eq.message(color, message) to Lua.
- Add quest::whisper(message) to Perl.
- Add eq.whisper(message) to Lua.

These methods allow you to use implied client references.

The whisper method also converts a widely used plugin in Perl to a Perl and Lua method that works on both Clients and NPCs.