### PR TITLE
Use heading in GMMove and change FaceTarget not to turn boat

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1734,6 +1734,7 @@ void Mob::GMMove(float x, float y, float z, float heading, bool SendUpdate) {
 	m_Position.x = x;
 	m_Position.y = y;
 	m_Position.z = z;
+	SetHeading(heading);
 	mMovementManager->SendCommandToClients(this, 0.0, 0.0, 0.0, 0.0, 0, ClientRangeAny);
 
 	if (IsNPC()) {
@@ -2820,6 +2821,11 @@ bool Mob::HateSummon() {
 }
 
 void Mob::FaceTarget(Mob* mob_to_face /*= 0*/) {
+
+	if (IsBoat()) {
+		return;
+	}
+
 	Mob* faced_mob = mob_to_face;
 	if(!faced_mob) {
 		if(!GetTarget()) {


### PR DESCRIPTION
Mob::GMMove was ignoring heading.  Fixed to set it.

If a server allows boats to be targetted (so you can see boat name), any hail of the boat was turning the boat.  Disabled this for boats.