### PR TITLE
[Bugfix] Fix MySQL Dump Buffer Allocation

### DIFF
--- a/common/database/database_dump_service.cpp
+++ b/common/database/database_dump_service.cpp
@@ -300,8 +300,7 @@ void DatabaseDumpService::Dump()
 		config->DatabaseUsername
 	);
 
-	std::string options = "--allow-keywords --extended-insert";
-
+	std::string options = "--allow-keywords --extended-insert --max-allowed-packet=1G --net-buffer-length=32704";
 	if (IsDumpWithNoData()) {
 		options += " --no-data";
 	}


### PR DESCRIPTION
Fix issue where sometimes under certain circumstances when issuing a database dump with large data over a network with extended inserts we hit a buffer threshold that kills a MySQL dump with Error 2013

This occurs when using world cli command `database:dump`

This is seen specifically during http://db.projecteq.net/ 's dump operation when sourcing data both from the content database and local database simultaneously. This resulted in fragmented dumps on a very intermittent occasion

Tested fix 30x manually on PEQ

```
mysqldump: Error 2013: Lost connection to MySQL server during query when dumping table `items` at row: 82810
```