### PR TITLE
[Lua] Provide more search paths for luajit

### DIFF
--- a/cmake/FindLua51.cmake
+++ b/cmake/FindLua51.cmake
@@ -38,7 +38,7 @@ locations other than lua/
 find_path(LUA_INCLUDE_DIR lua.h
   HINTS
     ENV LUA_DIR
-  PATH_SUFFIXES include/lua51 include/lua5.1 include/lua-5.1 include/lua include/luajit include
+  PATH_SUFFIXES include/lua51 include/lua5.1 include/lua-5.1 include/lua include/luajit include/luajit-2.0 include
   PATHS
   ~/Library/Frameworks
   /Library/Frameworks
@@ -49,7 +49,7 @@ find_path(LUA_INCLUDE_DIR lua.h
 )
 
 find_library(LUA_LIBRARY
-  NAMES lua51 lua5.1 lua-5.1 lua luajit
+  NAMES lua51 lua5.1 lua-5.1 lua luajit51 luajit5.1 luajit-5.1 luajit
   HINTS
     ENV LUA_DIR
   PATH_SUFFIXES lib


### PR DESCRIPTION
The include folder on my system is /usr/include/luajit-2.0, added some
extra library names since mine was /usr/lib64/libluajit-5.1.so