### PR TITLE
NPC ability to open doors while moving now configuarble in npc_types

### DIFF
--- a/common/version.h
+++ b/common/version.h
@@ -34,7 +34,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9159
+#define CURRENT_BINARY_DATABASE_VERSION 9160
 
 #ifdef BOTS
 	#define CURRENT_BINARY_BOTS_DATABASE_VERSION 9027

--- a/utils/sql/db_update_manifest.txt
+++ b/utils/sql/db_update_manifest.txt
@@ -413,6 +413,7 @@
 9157|2020_09_02_pet_taunting.sql|SHOW COLUMNS from `character_pet_info` LIKE 'taunting'|empty|
 9158|2020_12_09_underworld.sql|SHOW COLUMNS from `zone` LIKE 'underworld_teleport_index'|empty|
 9159|2020_12_22_expedition_system.sql|SELECT * FROM db_version WHERE version >= 9159|empty|
+9160|2021_02_02_npc_can_open_doors.sql|SHOW COLUMNS FROM `npc_types` LIKE 'can_open_doors'|empty|
 
 # Upgrade conditions:
 # 	This won't be needed after this system is implemented, but it is used database that are not

--- a/utils/sql/git/required/2021_02_02_npc_can_open_doors.sql
+++ b/utils/sql/git/required/2021_02_02_npc_can_open_doors.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `npc_types` ADD COLUMN `can_open_doors` tinyint(1) NOT NULL DEFAULT 1;

--- a/zone/beacon.cpp
+++ b/zone/beacon.cpp
@@ -56,7 +56,7 @@ Beacon::Beacon(Mob *at_mob, int lifetime)
 :Mob
 (
 	nullptr, nullptr, 0, 0, 0, INVISIBLE_MAN, 0, BT_NoTarget, 0, 0, 0, 0, 0, at_mob->GetPosition(), 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, EQ::TintProfile(), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, false
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, EQ::TintProfile(), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, false, false
 ),
 		remove_timer(lifetime),
 		spell_timer(0)

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -128,7 +128,8 @@ Client::Client(EQStreamInterface* ieqs)
 	0,
 	0,
 	0,
-	false
+	false,
+	true
 	),
   hpupdate_timer(2000),
   camp_timer(29000),

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -155,7 +155,7 @@ Corpse::Corpse(NPC* in_npc, ItemList* in_itemlist, uint32 in_npctypeid, const NP
 	in_npc->GetPosition(), in_npc->GetInnateLightType(), in_npc->GetTexture(),in_npc->GetHelmTexture(),
 	0,0,0,0,0,0,0,0,0,
 	0,0,0,0,0,0,0,0,0,0,EQ::TintProfile(),0xff,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-	(*in_npctypedata)->use_model, false),
+	(*in_npctypedata)->use_model, false, false),
 	corpse_decay_timer(in_decaytime),
 	corpse_rez_timer(0),
 	corpse_delay_timer(RuleI(NPC, CorpseUnlockTimer)),
@@ -263,7 +263,8 @@ Corpse::Corpse(Client* client, int32 in_rezexp) : Mob (
 	0,								  // uint8		in_legtexture,
 	0,								  // uint8		in_feettexture,
 	0,								  // uint8		in_usemodel,
-	0								  // bool		in_always_aggro
+	0,								  // bool		in_always_aggro
+	0								  // bool		in_can_open_doors
 	),
 	corpse_decay_timer(RuleI(Character, CorpseDecayTimeMS)),
 	corpse_rez_timer(RuleI(Character, CorpseResTimeMS)),
@@ -503,6 +504,7 @@ EQ::TintProfile(),
 0,
 0,
 0,
+false,
 false),
 	corpse_decay_timer(RuleI(Character, CorpseDecayTimeMS)),
 	corpse_rez_timer(RuleI(Character, CorpseResTimeMS)),

--- a/zone/encounter.cpp
+++ b/zone/encounter.cpp
@@ -36,7 +36,7 @@ Encounter::Encounter(const char* enc_name)
 	:Mob
 	(
 	nullptr, nullptr, 0, 0, 0, INVISIBLE_MAN, 0, BT_NoTarget, 0, 0, 0, 0, 0, glm::vec4(0,0,0,0), 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, EQ::TintProfile(), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, false
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, EQ::TintProfile(), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, false, false
 	)
 {
 	encounter_name[0] = 0;

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -94,7 +94,8 @@ Mob::Mob(
 	uint8 in_legtexture,
 	uint8 in_feettexture,
 	uint16 in_usemodel,
-	bool in_always_aggro
+	bool in_always_aggro,
+	bool in_can_open_doors
 ) :
 	attack_timer(2000),
 	attack_dw_timer(2000),
@@ -277,6 +278,7 @@ Mob::Mob(
 	spawned           = false;
 	rare_spawn        = false;
 	always_aggro      = in_always_aggro;
+	can_open_doors	  = in_can_open_doors;
 
 	InitializeBuffSlots();
 

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -162,7 +162,8 @@ public:
 		uint8 in_legtexture,
 		uint8 in_feettexture,
 		uint16 in_usemodel,
-		bool in_always_aggros_foes
+		bool in_always_aggros_foes,
+		bool can_open_doors
 	);
 	virtual ~Mob();
 
@@ -581,6 +582,7 @@ public:
 	bool IsBoat() const;
 	bool IsControllableBoat() const;
 	inline const bool AlwaysAggro() const { return always_aggro; }
+	inline const bool CanOpenDoors() const { return can_open_doors; }
 
 	//Group
 	virtual bool HasRaid() = 0;
@@ -1393,6 +1395,7 @@ protected:
 	float attack_speed; //% increase/decrease in attack speed (not haste)
 	int attack_delay; //delay between attacks in 10ths of seconds
 	bool always_aggro;
+	bool can_open_doors; // Allows mobs to open doors while pathing
 	int16 slow_mitigation; // Allows for a slow mitigation (100 = 100%, 50% = 50%)
 	Timer tic_timer;
 	Timer mana_timer;

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -114,7 +114,8 @@ NPC::NPC(const NPCType *npc_type_data, Spawn2 *in_respawn, const glm::vec4 &posi
 	npc_type_data->legtexture,
 	npc_type_data->feettexture,
 	npc_type_data->use_model,
-	npc_type_data->always_aggro
+	npc_type_data->always_aggro,
+	npc_type_data->can_open_doors
 ),
 	  attacked_timer(CombatEventTimer_expire),
 	  swarm_timer(100),

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -2525,7 +2525,8 @@ const NPCType *ZoneDatabase::LoadNPCTypesData(uint32 npc_type_id, bool bulk_load
 		"npc_types.stuck_behavior, "
 		"npc_types.model, "
 		"npc_types.flymode, "
-		"npc_types.always_aggro "
+		"npc_types.always_aggro, "
+		"npc_types.can_open_doors "
 		"FROM npc_types %s",
 		where_condition.c_str()
 	);
@@ -2728,6 +2729,7 @@ const NPCType *ZoneDatabase::LoadNPCTypesData(uint32 npc_type_id, bool bulk_load
 		temp_npctype_data->use_model        	= atoi(row[110]);
 		temp_npctype_data->flymode          	= atoi(row[111]);
 		temp_npctype_data->always_aggro	        = atoi(row[112]);
+		temp_npctype_data->can_open_doors		= atoi(row[113]);
 
 		temp_npctype_data->skip_auto_scale = false; // hardcoded here for now
 

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -2728,8 +2728,8 @@ const NPCType *ZoneDatabase::LoadNPCTypesData(uint32 npc_type_id, bool bulk_load
 		temp_npctype_data->stuck_behavior   	= atoi(row[109]);
 		temp_npctype_data->use_model        	= atoi(row[110]);
 		temp_npctype_data->flymode          	= atoi(row[111]);
-		temp_npctype_data->always_aggro	        = atoi(row[112]);
-		temp_npctype_data->can_open_doors		= atoi(row[113]);
+		temp_npctype_data->always_aggro	        = atoi(row[112]) != 0;
+		temp_npctype_data->can_open_doors		= atoi(row[113]) != 0;
 
 		temp_npctype_data->skip_auto_scale = false; // hardcoded here for now
 

--- a/zone/zonedump.h
+++ b/zone/zonedump.h
@@ -148,6 +148,7 @@ struct NPCType
 	uint16	use_model;
 	int8	flymode;
 	bool	always_aggro;
+	bool	can_open_doors;
 };
 
 namespace player_lootitem {


### PR DESCRIPTION
This PR allows server operators to change the behavior of some mobs to not open doors.

The PR in itself changes no behavior, unless the operator changes the new field, can_open_doors to 0.  The npc_types is updated so that all npcs  _can_ open doors, which is the behavior before this PR.

My reason for wanting this is to quiet down home cities, where rodents are opening doors like there is no tomorrow, wearing out hinges, and my speakers.