### PR TITLE
[Repositories] Explicitly pass database pointers to repository methods

### DIFF
--- a/common/repositories/base/base_aa_ability_repository.h
+++ b/common/repositories/base/base_aa_ability_repository.h
@@ -156,10 +156,11 @@ public:
 	}
 
 	static AaAbility FindOne(
+		Database& db,
 		int aa_ability_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -193,10 +194,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int aa_ability_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -209,6 +211,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		AaAbility aa_ability_entry
 	)
 	{
@@ -231,7 +234,7 @@ public:
 		update_values.push_back(columns[12] + " = " + std::to_string(aa_ability_entry.enabled));
 		update_values.push_back(columns[13] + " = " + std::to_string(aa_ability_entry.reset_on_death));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -245,6 +248,7 @@ public:
 	}
 
 	static AaAbility InsertOne(
+		Database& db,
 		AaAbility aa_ability_entry
 	)
 	{
@@ -284,6 +288,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<AaAbility> aa_ability_entries
 	)
 	{
@@ -312,7 +317,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -323,11 +328,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<AaAbility> All()
+	static std::vector<AaAbility> All(Database& db)
 	{
 		std::vector<AaAbility> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -360,11 +365,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<AaAbility> GetWhere(std::string where_filter)
+	static std::vector<AaAbility> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<AaAbility> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -398,9 +403,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -411,9 +416,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_aa_rank_effects_repository.h
+++ b/common/repositories/base/base_aa_rank_effects_repository.h
@@ -129,10 +129,11 @@ public:
 	}
 
 	static AaRankEffects FindOne(
+		Database& db,
 		int aa_rank_effects_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -157,10 +158,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int aa_rank_effects_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -173,6 +175,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		AaRankEffects aa_rank_effects_entry
 	)
 	{
@@ -186,7 +189,7 @@ public:
 		update_values.push_back(columns[3] + " = " + std::to_string(aa_rank_effects_entry.base1));
 		update_values.push_back(columns[4] + " = " + std::to_string(aa_rank_effects_entry.base2));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -200,6 +203,7 @@ public:
 	}
 
 	static AaRankEffects InsertOne(
+		Database& db,
 		AaRankEffects aa_rank_effects_entry
 	)
 	{
@@ -230,6 +234,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<AaRankEffects> aa_rank_effects_entries
 	)
 	{
@@ -249,7 +254,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -260,11 +265,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<AaRankEffects> All()
+	static std::vector<AaRankEffects> All(Database& db)
 	{
 		std::vector<AaRankEffects> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -288,11 +293,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<AaRankEffects> GetWhere(std::string where_filter)
+	static std::vector<AaRankEffects> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<AaRankEffects> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -317,9 +322,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -330,9 +335,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_aa_rank_prereqs_repository.h
+++ b/common/repositories/base/base_aa_rank_prereqs_repository.h
@@ -123,10 +123,11 @@ public:
 	}
 
 	static AaRankPrereqs FindOne(
+		Database& db,
 		int aa_rank_prereqs_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -149,10 +150,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int aa_rank_prereqs_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -165,6 +167,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		AaRankPrereqs aa_rank_prereqs_entry
 	)
 	{
@@ -176,7 +179,7 @@ public:
 		update_values.push_back(columns[1] + " = " + std::to_string(aa_rank_prereqs_entry.aa_id));
 		update_values.push_back(columns[2] + " = " + std::to_string(aa_rank_prereqs_entry.points));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -190,6 +193,7 @@ public:
 	}
 
 	static AaRankPrereqs InsertOne(
+		Database& db,
 		AaRankPrereqs aa_rank_prereqs_entry
 	)
 	{
@@ -218,6 +222,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<AaRankPrereqs> aa_rank_prereqs_entries
 	)
 	{
@@ -235,7 +240,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -246,11 +251,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<AaRankPrereqs> All()
+	static std::vector<AaRankPrereqs> All(Database& db)
 	{
 		std::vector<AaRankPrereqs> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -272,11 +277,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<AaRankPrereqs> GetWhere(std::string where_filter)
+	static std::vector<AaRankPrereqs> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<AaRankPrereqs> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -299,9 +304,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -312,9 +317,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_aa_ranks_repository.h
+++ b/common/repositories/base/base_aa_ranks_repository.h
@@ -153,10 +153,11 @@ public:
 	}
 
 	static AaRanks FindOne(
+		Database& db,
 		int aa_ranks_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -189,10 +190,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int aa_ranks_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -205,6 +207,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		AaRanks aa_ranks_entry
 	)
 	{
@@ -226,7 +229,7 @@ public:
 		update_values.push_back(columns[11] + " = " + std::to_string(aa_ranks_entry.prev_id));
 		update_values.push_back(columns[12] + " = " + std::to_string(aa_ranks_entry.next_id));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -240,6 +243,7 @@ public:
 	}
 
 	static AaRanks InsertOne(
+		Database& db,
 		AaRanks aa_ranks_entry
 	)
 	{
@@ -278,6 +282,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<AaRanks> aa_ranks_entries
 	)
 	{
@@ -305,7 +310,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -316,11 +321,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<AaRanks> All()
+	static std::vector<AaRanks> All(Database& db)
 	{
 		std::vector<AaRanks> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -352,11 +357,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<AaRanks> GetWhere(std::string where_filter)
+	static std::vector<AaRanks> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<AaRanks> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -389,9 +394,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -402,9 +407,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_account_flags_repository.h
+++ b/common/repositories/base/base_account_flags_repository.h
@@ -123,10 +123,11 @@ public:
 	}
 
 	static AccountFlags FindOne(
+		Database& db,
 		int account_flags_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -149,10 +150,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int account_flags_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -165,6 +167,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		AccountFlags account_flags_entry
 	)
 	{
@@ -176,7 +179,7 @@ public:
 		update_values.push_back(columns[1] + " = '" + EscapeString(account_flags_entry.p_flag) + "'");
 		update_values.push_back(columns[2] + " = '" + EscapeString(account_flags_entry.p_value) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -190,6 +193,7 @@ public:
 	}
 
 	static AccountFlags InsertOne(
+		Database& db,
 		AccountFlags account_flags_entry
 	)
 	{
@@ -218,6 +222,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<AccountFlags> account_flags_entries
 	)
 	{
@@ -235,7 +240,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -246,11 +251,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<AccountFlags> All()
+	static std::vector<AccountFlags> All(Database& db)
 	{
 		std::vector<AccountFlags> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -272,11 +277,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<AccountFlags> GetWhere(std::string where_filter)
+	static std::vector<AccountFlags> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<AccountFlags> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -299,9 +304,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -312,9 +317,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_account_ip_repository.h
+++ b/common/repositories/base/base_account_ip_repository.h
@@ -126,10 +126,11 @@ public:
 	}
 
 	static AccountIp FindOne(
+		Database& db,
 		int account_ip_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -153,10 +154,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int account_ip_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -169,6 +171,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		AccountIp account_ip_entry
 	)
 	{
@@ -181,7 +184,7 @@ public:
 		update_values.push_back(columns[2] + " = " + std::to_string(account_ip_entry.count));
 		update_values.push_back(columns[3] + " = '" + EscapeString(account_ip_entry.lastused) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -195,6 +198,7 @@ public:
 	}
 
 	static AccountIp InsertOne(
+		Database& db,
 		AccountIp account_ip_entry
 	)
 	{
@@ -224,6 +228,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<AccountIp> account_ip_entries
 	)
 	{
@@ -242,7 +247,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -253,11 +258,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<AccountIp> All()
+	static std::vector<AccountIp> All(Database& db)
 	{
 		std::vector<AccountIp> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -280,11 +285,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<AccountIp> GetWhere(std::string where_filter)
+	static std::vector<AccountIp> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<AccountIp> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -308,9 +313,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -321,9 +326,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_account_repository.h
+++ b/common/repositories/base/base_account_repository.h
@@ -171,10 +171,11 @@ public:
 	}
 
 	static Account FindOne(
+		Database& db,
 		int account_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -213,10 +214,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int account_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -229,6 +231,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Account account_entry
 	)
 	{
@@ -255,7 +258,7 @@ public:
 		update_values.push_back(columns[17] + " = '" + EscapeString(account_entry.ban_reason) + "'");
 		update_values.push_back(columns[18] + " = '" + EscapeString(account_entry.suspend_reason) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -269,6 +272,7 @@ public:
 	}
 
 	static Account InsertOne(
+		Database& db,
 		Account account_entry
 	)
 	{
@@ -312,6 +316,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Account> account_entries
 	)
 	{
@@ -344,7 +349,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -355,11 +360,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Account> All()
+	static std::vector<Account> All(Database& db)
 	{
 		std::vector<Account> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -397,11 +402,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Account> GetWhere(std::string where_filter)
+	static std::vector<Account> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Account> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -440,9 +445,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -453,9 +458,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_account_rewards_repository.h
+++ b/common/repositories/base/base_account_rewards_repository.h
@@ -123,10 +123,11 @@ public:
 	}
 
 	static AccountRewards FindOne(
+		Database& db,
 		int account_rewards_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -149,10 +150,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int account_rewards_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -165,6 +167,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		AccountRewards account_rewards_entry
 	)
 	{
@@ -176,7 +179,7 @@ public:
 		update_values.push_back(columns[1] + " = " + std::to_string(account_rewards_entry.reward_id));
 		update_values.push_back(columns[2] + " = " + std::to_string(account_rewards_entry.amount));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -190,6 +193,7 @@ public:
 	}
 
 	static AccountRewards InsertOne(
+		Database& db,
 		AccountRewards account_rewards_entry
 	)
 	{
@@ -218,6 +222,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<AccountRewards> account_rewards_entries
 	)
 	{
@@ -235,7 +240,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -246,11 +251,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<AccountRewards> All()
+	static std::vector<AccountRewards> All(Database& db)
 	{
 		std::vector<AccountRewards> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -272,11 +277,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<AccountRewards> GetWhere(std::string where_filter)
+	static std::vector<AccountRewards> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<AccountRewards> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -299,9 +304,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -312,9 +317,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_adventure_details_repository.h
+++ b/common/repositories/base/base_adventure_details_repository.h
@@ -141,10 +141,11 @@ public:
 	}
 
 	static AdventureDetails FindOne(
+		Database& db,
 		int adventure_details_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -173,10 +174,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int adventure_details_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -189,6 +191,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		AdventureDetails adventure_details_entry
 	)
 	{
@@ -205,7 +208,7 @@ public:
 		update_values.push_back(columns[7] + " = " + std::to_string(adventure_details_entry.time_zoned));
 		update_values.push_back(columns[8] + " = " + std::to_string(adventure_details_entry.time_completed));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -219,6 +222,7 @@ public:
 	}
 
 	static AdventureDetails InsertOne(
+		Database& db,
 		AdventureDetails adventure_details_entry
 	)
 	{
@@ -252,6 +256,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<AdventureDetails> adventure_details_entries
 	)
 	{
@@ -274,7 +279,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -285,11 +290,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<AdventureDetails> All()
+	static std::vector<AdventureDetails> All(Database& db)
 	{
 		std::vector<AdventureDetails> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -317,11 +322,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<AdventureDetails> GetWhere(std::string where_filter)
+	static std::vector<AdventureDetails> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<AdventureDetails> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -350,9 +355,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -363,9 +368,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_adventure_members_repository.h
+++ b/common/repositories/base/base_adventure_members_repository.h
@@ -120,10 +120,11 @@ public:
 	}
 
 	static AdventureMembers FindOne(
+		Database& db,
 		int adventure_members_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -145,10 +146,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int adventure_members_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -161,6 +163,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		AdventureMembers adventure_members_entry
 	)
 	{
@@ -171,7 +174,7 @@ public:
 		update_values.push_back(columns[0] + " = " + std::to_string(adventure_members_entry.id));
 		update_values.push_back(columns[1] + " = " + std::to_string(adventure_members_entry.charid));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -185,6 +188,7 @@ public:
 	}
 
 	static AdventureMembers InsertOne(
+		Database& db,
 		AdventureMembers adventure_members_entry
 	)
 	{
@@ -212,6 +216,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<AdventureMembers> adventure_members_entries
 	)
 	{
@@ -228,7 +233,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -239,11 +244,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<AdventureMembers> All()
+	static std::vector<AdventureMembers> All(Database& db)
 	{
 		std::vector<AdventureMembers> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -264,11 +269,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<AdventureMembers> GetWhere(std::string where_filter)
+	static std::vector<AdventureMembers> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<AdventureMembers> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -290,9 +295,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -303,9 +308,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_adventure_stats_repository.h
+++ b/common/repositories/base/base_adventure_stats_repository.h
@@ -147,10 +147,11 @@ public:
 	}
 
 	static AdventureStats FindOne(
+		Database& db,
 		int adventure_stats_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -181,10 +182,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int adventure_stats_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -197,6 +199,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		AdventureStats adventure_stats_entry
 	)
 	{
@@ -216,7 +219,7 @@ public:
 		update_values.push_back(columns[9] + " = " + std::to_string(adventure_stats_entry.ruj_losses));
 		update_values.push_back(columns[10] + " = " + std::to_string(adventure_stats_entry.tak_losses));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -230,6 +233,7 @@ public:
 	}
 
 	static AdventureStats InsertOne(
+		Database& db,
 		AdventureStats adventure_stats_entry
 	)
 	{
@@ -266,6 +270,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<AdventureStats> adventure_stats_entries
 	)
 	{
@@ -291,7 +296,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -302,11 +307,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<AdventureStats> All()
+	static std::vector<AdventureStats> All(Database& db)
 	{
 		std::vector<AdventureStats> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -336,11 +341,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<AdventureStats> GetWhere(std::string where_filter)
+	static std::vector<AdventureStats> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<AdventureStats> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -371,9 +376,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -384,9 +389,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_adventure_template_entry_flavor_repository.h
+++ b/common/repositories/base/base_adventure_template_entry_flavor_repository.h
@@ -120,10 +120,11 @@ public:
 	}
 
 	static AdventureTemplateEntryFlavor FindOne(
+		Database& db,
 		int adventure_template_entry_flavor_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -145,10 +146,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int adventure_template_entry_flavor_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -161,6 +163,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		AdventureTemplateEntryFlavor adventure_template_entry_flavor_entry
 	)
 	{
@@ -171,7 +174,7 @@ public:
 		update_values.push_back(columns[0] + " = " + std::to_string(adventure_template_entry_flavor_entry.id));
 		update_values.push_back(columns[1] + " = '" + EscapeString(adventure_template_entry_flavor_entry.text) + "'");
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -185,6 +188,7 @@ public:
 	}
 
 	static AdventureTemplateEntryFlavor InsertOne(
+		Database& db,
 		AdventureTemplateEntryFlavor adventure_template_entry_flavor_entry
 	)
 	{
@@ -212,6 +216,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<AdventureTemplateEntryFlavor> adventure_template_entry_flavor_entries
 	)
 	{
@@ -228,7 +233,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -239,11 +244,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<AdventureTemplateEntryFlavor> All()
+	static std::vector<AdventureTemplateEntryFlavor> All(Database& db)
 	{
 		std::vector<AdventureTemplateEntryFlavor> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -264,11 +269,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<AdventureTemplateEntryFlavor> GetWhere(std::string where_filter)
+	static std::vector<AdventureTemplateEntryFlavor> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<AdventureTemplateEntryFlavor> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -290,9 +295,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -303,9 +308,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_adventure_template_entry_repository.h
+++ b/common/repositories/base/base_adventure_template_entry_repository.h
@@ -120,10 +120,11 @@ public:
 	}
 
 	static AdventureTemplateEntry FindOne(
+		Database& db,
 		int adventure_template_entry_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -145,10 +146,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int adventure_template_entry_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -161,6 +163,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		AdventureTemplateEntry adventure_template_entry_entry
 	)
 	{
@@ -171,7 +174,7 @@ public:
 		update_values.push_back(columns[0] + " = " + std::to_string(adventure_template_entry_entry.id));
 		update_values.push_back(columns[1] + " = " + std::to_string(adventure_template_entry_entry.template_id));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -185,6 +188,7 @@ public:
 	}
 
 	static AdventureTemplateEntry InsertOne(
+		Database& db,
 		AdventureTemplateEntry adventure_template_entry_entry
 	)
 	{
@@ -212,6 +216,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<AdventureTemplateEntry> adventure_template_entry_entries
 	)
 	{
@@ -228,7 +233,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -239,11 +244,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<AdventureTemplateEntry> All()
+	static std::vector<AdventureTemplateEntry> All(Database& db)
 	{
 		std::vector<AdventureTemplateEntry> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -264,11 +269,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<AdventureTemplateEntry> GetWhere(std::string where_filter)
+	static std::vector<AdventureTemplateEntry> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<AdventureTemplateEntry> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -290,9 +295,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -303,9 +308,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_adventure_template_repository.h
+++ b/common/repositories/base/base_adventure_template_repository.h
@@ -213,10 +213,11 @@ public:
 	}
 
 	static AdventureTemplate FindOne(
+		Database& db,
 		int adventure_template_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -269,10 +270,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int adventure_template_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -285,6 +287,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		AdventureTemplate adventure_template_entry
 	)
 	{
@@ -326,7 +329,7 @@ public:
 		update_values.push_back(columns[31] + " = " + std::to_string(adventure_template_entry.graveyard_z));
 		update_values.push_back(columns[32] + " = " + std::to_string(adventure_template_entry.graveyard_radius));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -340,6 +343,7 @@ public:
 	}
 
 	static AdventureTemplate InsertOne(
+		Database& db,
 		AdventureTemplate adventure_template_entry
 	)
 	{
@@ -398,6 +402,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<AdventureTemplate> adventure_template_entries
 	)
 	{
@@ -445,7 +450,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -456,11 +461,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<AdventureTemplate> All()
+	static std::vector<AdventureTemplate> All(Database& db)
 	{
 		std::vector<AdventureTemplate> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -512,11 +517,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<AdventureTemplate> GetWhere(std::string where_filter)
+	static std::vector<AdventureTemplate> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<AdventureTemplate> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -569,9 +574,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -582,9 +587,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_alternate_currency_repository.h
+++ b/common/repositories/base/base_alternate_currency_repository.h
@@ -120,10 +120,11 @@ public:
 	}
 
 	static AlternateCurrency FindOne(
+		Database& db,
 		int alternate_currency_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -145,10 +146,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int alternate_currency_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -161,6 +163,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		AlternateCurrency alternate_currency_entry
 	)
 	{
@@ -171,7 +174,7 @@ public:
 		update_values.push_back(columns[0] + " = " + std::to_string(alternate_currency_entry.id));
 		update_values.push_back(columns[1] + " = " + std::to_string(alternate_currency_entry.item_id));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -185,6 +188,7 @@ public:
 	}
 
 	static AlternateCurrency InsertOne(
+		Database& db,
 		AlternateCurrency alternate_currency_entry
 	)
 	{
@@ -212,6 +216,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<AlternateCurrency> alternate_currency_entries
 	)
 	{
@@ -228,7 +233,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -239,11 +244,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<AlternateCurrency> All()
+	static std::vector<AlternateCurrency> All(Database& db)
 	{
 		std::vector<AlternateCurrency> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -264,11 +269,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<AlternateCurrency> GetWhere(std::string where_filter)
+	static std::vector<AlternateCurrency> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<AlternateCurrency> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -290,9 +295,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -303,9 +308,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_auras_repository.h
+++ b/common/repositories/base/base_auras_repository.h
@@ -147,10 +147,11 @@ public:
 	}
 
 	static Auras FindOne(
+		Database& db,
 		int auras_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -181,10 +182,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int auras_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -197,6 +199,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Auras auras_entry
 	)
 	{
@@ -216,7 +219,7 @@ public:
 		update_values.push_back(columns[9] + " = " + std::to_string(auras_entry.icon));
 		update_values.push_back(columns[10] + " = " + std::to_string(auras_entry.cast_time));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -230,6 +233,7 @@ public:
 	}
 
 	static Auras InsertOne(
+		Database& db,
 		Auras auras_entry
 	)
 	{
@@ -266,6 +270,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Auras> auras_entries
 	)
 	{
@@ -291,7 +296,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -302,11 +307,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Auras> All()
+	static std::vector<Auras> All(Database& db)
 	{
 		std::vector<Auras> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -336,11 +341,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Auras> GetWhere(std::string where_filter)
+	static std::vector<Auras> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Auras> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -371,9 +376,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -384,9 +389,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_base_data_repository.h
+++ b/common/repositories/base/base_base_data_repository.h
@@ -144,10 +144,11 @@ public:
 	}
 
 	static BaseData FindOne(
+		Database& db,
 		int base_data_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -177,10 +178,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int base_data_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -193,6 +195,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		BaseData base_data_entry
 	)
 	{
@@ -211,7 +214,7 @@ public:
 		update_values.push_back(columns[8] + " = " + std::to_string(base_data_entry.mana_fac));
 		update_values.push_back(columns[9] + " = " + std::to_string(base_data_entry.end_fac));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -225,6 +228,7 @@ public:
 	}
 
 	static BaseData InsertOne(
+		Database& db,
 		BaseData base_data_entry
 	)
 	{
@@ -260,6 +264,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<BaseData> base_data_entries
 	)
 	{
@@ -284,7 +289,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -295,11 +300,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<BaseData> All()
+	static std::vector<BaseData> All(Database& db)
 	{
 		std::vector<BaseData> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -328,11 +333,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<BaseData> GetWhere(std::string where_filter)
+	static std::vector<BaseData> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<BaseData> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -362,9 +367,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -375,9 +380,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_blocked_spells_repository.h
+++ b/common/repositories/base/base_blocked_spells_repository.h
@@ -150,10 +150,11 @@ public:
 	}
 
 	static BlockedSpells FindOne(
+		Database& db,
 		int blocked_spells_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -185,10 +186,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int blocked_spells_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -201,6 +203,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		BlockedSpells blocked_spells_entry
 	)
 	{
@@ -220,7 +223,7 @@ public:
 		update_values.push_back(columns[10] + " = '" + EscapeString(blocked_spells_entry.message) + "'");
 		update_values.push_back(columns[11] + " = '" + EscapeString(blocked_spells_entry.description) + "'");
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -234,6 +237,7 @@ public:
 	}
 
 	static BlockedSpells InsertOne(
+		Database& db,
 		BlockedSpells blocked_spells_entry
 	)
 	{
@@ -270,6 +274,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<BlockedSpells> blocked_spells_entries
 	)
 	{
@@ -295,7 +300,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -306,11 +311,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<BlockedSpells> All()
+	static std::vector<BlockedSpells> All(Database& db)
 	{
 		std::vector<BlockedSpells> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -341,11 +346,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<BlockedSpells> GetWhere(std::string where_filter)
+	static std::vector<BlockedSpells> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<BlockedSpells> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -377,9 +382,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -390,9 +395,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_bug_reports_repository.h
+++ b/common/repositories/base/base_bug_reports_repository.h
@@ -210,10 +210,11 @@ public:
 	}
 
 	static BugReports FindOne(
+		Database& db,
 		int bug_reports_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -265,10 +266,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int bug_reports_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -281,6 +283,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		BugReports bug_reports_entry
 	)
 	{
@@ -320,7 +323,7 @@ public:
 		update_values.push_back(columns[30] + " = '" + EscapeString(bug_reports_entry.last_reviewer) + "'");
 		update_values.push_back(columns[31] + " = '" + EscapeString(bug_reports_entry.reviewer_notes) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -334,6 +337,7 @@ public:
 	}
 
 	static BugReports InsertOne(
+		Database& db,
 		BugReports bug_reports_entry
 	)
 	{
@@ -390,6 +394,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<BugReports> bug_reports_entries
 	)
 	{
@@ -435,7 +440,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -446,11 +451,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<BugReports> All()
+	static std::vector<BugReports> All(Database& db)
 	{
 		std::vector<BugReports> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -501,11 +506,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<BugReports> GetWhere(std::string where_filter)
+	static std::vector<BugReports> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<BugReports> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -557,9 +562,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -570,9 +575,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_bugs_repository.h
+++ b/common/repositories/base/base_bugs_repository.h
@@ -153,10 +153,11 @@ public:
 	}
 
 	static Bugs FindOne(
+		Database& db,
 		int bugs_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -189,10 +190,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int bugs_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -205,6 +207,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Bugs bugs_entry
 	)
 	{
@@ -225,7 +228,7 @@ public:
 		update_values.push_back(columns[11] + " = '" + EscapeString(bugs_entry.date) + "'");
 		update_values.push_back(columns[12] + " = " + std::to_string(bugs_entry.status));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -239,6 +242,7 @@ public:
 	}
 
 	static Bugs InsertOne(
+		Database& db,
 		Bugs bugs_entry
 	)
 	{
@@ -276,6 +280,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Bugs> bugs_entries
 	)
 	{
@@ -302,7 +307,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -313,11 +318,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Bugs> All()
+	static std::vector<Bugs> All(Database& db)
 	{
 		std::vector<Bugs> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -349,11 +354,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Bugs> GetWhere(std::string where_filter)
+	static std::vector<Bugs> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Bugs> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -386,9 +391,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -399,9 +404,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_buyer_repository.h
+++ b/common/repositories/base/base_buyer_repository.h
@@ -132,10 +132,11 @@ public:
 	}
 
 	static Buyer FindOne(
+		Database& db,
 		int buyer_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -161,10 +162,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int buyer_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -177,6 +179,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Buyer buyer_entry
 	)
 	{
@@ -191,7 +194,7 @@ public:
 		update_values.push_back(columns[4] + " = " + std::to_string(buyer_entry.quantity));
 		update_values.push_back(columns[5] + " = " + std::to_string(buyer_entry.price));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -205,6 +208,7 @@ public:
 	}
 
 	static Buyer InsertOne(
+		Database& db,
 		Buyer buyer_entry
 	)
 	{
@@ -236,6 +240,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Buyer> buyer_entries
 	)
 	{
@@ -256,7 +261,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -267,11 +272,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Buyer> All()
+	static std::vector<Buyer> All(Database& db)
 	{
 		std::vector<Buyer> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -296,11 +301,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Buyer> GetWhere(std::string where_filter)
+	static std::vector<Buyer> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Buyer> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -326,9 +331,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -339,9 +344,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_char_create_combinations_repository.h
+++ b/common/repositories/base/base_char_create_combinations_repository.h
@@ -132,10 +132,11 @@ public:
 	}
 
 	static CharCreateCombinations FindOne(
+		Database& db,
 		int char_create_combinations_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -161,10 +162,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int char_create_combinations_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -177,6 +179,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharCreateCombinations char_create_combinations_entry
 	)
 	{
@@ -191,7 +194,7 @@ public:
 		update_values.push_back(columns[4] + " = " + std::to_string(char_create_combinations_entry.start_zone));
 		update_values.push_back(columns[5] + " = " + std::to_string(char_create_combinations_entry.expansions_req));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -205,6 +208,7 @@ public:
 	}
 
 	static CharCreateCombinations InsertOne(
+		Database& db,
 		CharCreateCombinations char_create_combinations_entry
 	)
 	{
@@ -236,6 +240,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharCreateCombinations> char_create_combinations_entries
 	)
 	{
@@ -256,7 +261,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -267,11 +272,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharCreateCombinations> All()
+	static std::vector<CharCreateCombinations> All(Database& db)
 	{
 		std::vector<CharCreateCombinations> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -296,11 +301,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharCreateCombinations> GetWhere(std::string where_filter)
+	static std::vector<CharCreateCombinations> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharCreateCombinations> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -326,9 +331,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -339,9 +344,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_char_create_point_allocations_repository.h
+++ b/common/repositories/base/base_char_create_point_allocations_repository.h
@@ -159,10 +159,11 @@ public:
 	}
 
 	static CharCreatePointAllocations FindOne(
+		Database& db,
 		int char_create_point_allocations_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -197,10 +198,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int char_create_point_allocations_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -213,6 +215,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharCreatePointAllocations char_create_point_allocations_entry
 	)
 	{
@@ -236,7 +239,7 @@ public:
 		update_values.push_back(columns[13] + " = " + std::to_string(char_create_point_allocations_entry.alloc_wis));
 		update_values.push_back(columns[14] + " = " + std::to_string(char_create_point_allocations_entry.alloc_cha));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -250,6 +253,7 @@ public:
 	}
 
 	static CharCreatePointAllocations InsertOne(
+		Database& db,
 		CharCreatePointAllocations char_create_point_allocations_entry
 	)
 	{
@@ -290,6 +294,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharCreatePointAllocations> char_create_point_allocations_entries
 	)
 	{
@@ -319,7 +324,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -330,11 +335,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharCreatePointAllocations> All()
+	static std::vector<CharCreatePointAllocations> All(Database& db)
 	{
 		std::vector<CharCreatePointAllocations> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -368,11 +373,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharCreatePointAllocations> GetWhere(std::string where_filter)
+	static std::vector<CharCreatePointAllocations> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharCreatePointAllocations> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -407,9 +412,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -420,9 +425,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_char_recipe_list_repository.h
+++ b/common/repositories/base/base_char_recipe_list_repository.h
@@ -123,10 +123,11 @@ public:
 	}
 
 	static CharRecipeList FindOne(
+		Database& db,
 		int char_recipe_list_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -149,10 +150,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int char_recipe_list_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -165,6 +167,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharRecipeList char_recipe_list_entry
 	)
 	{
@@ -176,7 +179,7 @@ public:
 		update_values.push_back(columns[1] + " = " + std::to_string(char_recipe_list_entry.recipe_id));
 		update_values.push_back(columns[2] + " = " + std::to_string(char_recipe_list_entry.madecount));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -190,6 +193,7 @@ public:
 	}
 
 	static CharRecipeList InsertOne(
+		Database& db,
 		CharRecipeList char_recipe_list_entry
 	)
 	{
@@ -218,6 +222,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharRecipeList> char_recipe_list_entries
 	)
 	{
@@ -235,7 +240,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -246,11 +251,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharRecipeList> All()
+	static std::vector<CharRecipeList> All(Database& db)
 	{
 		std::vector<CharRecipeList> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -272,11 +277,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharRecipeList> GetWhere(std::string where_filter)
+	static std::vector<CharRecipeList> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharRecipeList> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -299,9 +304,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -312,9 +317,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_character_activities_repository.h
+++ b/common/repositories/base/base_character_activities_repository.h
@@ -129,10 +129,11 @@ public:
 	}
 
 	static CharacterActivities FindOne(
+		Database& db,
 		int character_activities_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -157,10 +158,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int character_activities_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -173,6 +175,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharacterActivities character_activities_entry
 	)
 	{
@@ -186,7 +189,7 @@ public:
 		update_values.push_back(columns[3] + " = " + std::to_string(character_activities_entry.donecount));
 		update_values.push_back(columns[4] + " = " + std::to_string(character_activities_entry.completed));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -200,6 +203,7 @@ public:
 	}
 
 	static CharacterActivities InsertOne(
+		Database& db,
 		CharacterActivities character_activities_entry
 	)
 	{
@@ -230,6 +234,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharacterActivities> character_activities_entries
 	)
 	{
@@ -249,7 +254,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -260,11 +265,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharacterActivities> All()
+	static std::vector<CharacterActivities> All(Database& db)
 	{
 		std::vector<CharacterActivities> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -288,11 +293,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharacterActivities> GetWhere(std::string where_filter)
+	static std::vector<CharacterActivities> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharacterActivities> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -317,9 +322,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -330,9 +335,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_character_alt_currency_repository.h
+++ b/common/repositories/base/base_character_alt_currency_repository.h
@@ -123,10 +123,11 @@ public:
 	}
 
 	static CharacterAltCurrency FindOne(
+		Database& db,
 		int character_alt_currency_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -149,10 +150,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int character_alt_currency_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -165,6 +167,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharacterAltCurrency character_alt_currency_entry
 	)
 	{
@@ -176,7 +179,7 @@ public:
 		update_values.push_back(columns[1] + " = " + std::to_string(character_alt_currency_entry.currency_id));
 		update_values.push_back(columns[2] + " = " + std::to_string(character_alt_currency_entry.amount));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -190,6 +193,7 @@ public:
 	}
 
 	static CharacterAltCurrency InsertOne(
+		Database& db,
 		CharacterAltCurrency character_alt_currency_entry
 	)
 	{
@@ -218,6 +222,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharacterAltCurrency> character_alt_currency_entries
 	)
 	{
@@ -235,7 +240,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -246,11 +251,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharacterAltCurrency> All()
+	static std::vector<CharacterAltCurrency> All(Database& db)
 	{
 		std::vector<CharacterAltCurrency> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -272,11 +277,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharacterAltCurrency> GetWhere(std::string where_filter)
+	static std::vector<CharacterAltCurrency> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharacterAltCurrency> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -299,9 +304,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -312,9 +317,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_character_alternate_abilities_repository.h
+++ b/common/repositories/base/base_character_alternate_abilities_repository.h
@@ -126,10 +126,11 @@ public:
 	}
 
 	static CharacterAlternateAbilities FindOne(
+		Database& db,
 		int character_alternate_abilities_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -153,10 +154,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int character_alternate_abilities_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -169,6 +171,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharacterAlternateAbilities character_alternate_abilities_entry
 	)
 	{
@@ -181,7 +184,7 @@ public:
 		update_values.push_back(columns[2] + " = " + std::to_string(character_alternate_abilities_entry.aa_value));
 		update_values.push_back(columns[3] + " = " + std::to_string(character_alternate_abilities_entry.charges));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -195,6 +198,7 @@ public:
 	}
 
 	static CharacterAlternateAbilities InsertOne(
+		Database& db,
 		CharacterAlternateAbilities character_alternate_abilities_entry
 	)
 	{
@@ -224,6 +228,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharacterAlternateAbilities> character_alternate_abilities_entries
 	)
 	{
@@ -242,7 +247,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -253,11 +258,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharacterAlternateAbilities> All()
+	static std::vector<CharacterAlternateAbilities> All(Database& db)
 	{
 		std::vector<CharacterAlternateAbilities> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -280,11 +285,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharacterAlternateAbilities> GetWhere(std::string where_filter)
+	static std::vector<CharacterAlternateAbilities> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharacterAlternateAbilities> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -308,9 +313,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -321,9 +326,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_character_auras_repository.h
+++ b/common/repositories/base/base_character_auras_repository.h
@@ -123,10 +123,11 @@ public:
 	}
 
 	static CharacterAuras FindOne(
+		Database& db,
 		int character_auras_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -149,10 +150,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int character_auras_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -165,6 +167,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharacterAuras character_auras_entry
 	)
 	{
@@ -176,7 +179,7 @@ public:
 		update_values.push_back(columns[1] + " = " + std::to_string(character_auras_entry.slot));
 		update_values.push_back(columns[2] + " = " + std::to_string(character_auras_entry.spell_id));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -190,6 +193,7 @@ public:
 	}
 
 	static CharacterAuras InsertOne(
+		Database& db,
 		CharacterAuras character_auras_entry
 	)
 	{
@@ -218,6 +222,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharacterAuras> character_auras_entries
 	)
 	{
@@ -235,7 +240,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -246,11 +251,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharacterAuras> All()
+	static std::vector<CharacterAuras> All(Database& db)
 	{
 		std::vector<CharacterAuras> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -272,11 +277,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharacterAuras> GetWhere(std::string where_filter)
+	static std::vector<CharacterAuras> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharacterAuras> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -299,9 +304,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -312,9 +317,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_character_bandolier_repository.h
+++ b/common/repositories/base/base_character_bandolier_repository.h
@@ -132,10 +132,11 @@ public:
 	}
 
 	static CharacterBandolier FindOne(
+		Database& db,
 		int character_bandolier_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -161,10 +162,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int character_bandolier_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -177,6 +179,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharacterBandolier character_bandolier_entry
 	)
 	{
@@ -191,7 +194,7 @@ public:
 		update_values.push_back(columns[4] + " = " + std::to_string(character_bandolier_entry.icon));
 		update_values.push_back(columns[5] + " = '" + EscapeString(character_bandolier_entry.bandolier_name) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -205,6 +208,7 @@ public:
 	}
 
 	static CharacterBandolier InsertOne(
+		Database& db,
 		CharacterBandolier character_bandolier_entry
 	)
 	{
@@ -236,6 +240,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharacterBandolier> character_bandolier_entries
 	)
 	{
@@ -256,7 +261,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -267,11 +272,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharacterBandolier> All()
+	static std::vector<CharacterBandolier> All(Database& db)
 	{
 		std::vector<CharacterBandolier> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -296,11 +301,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharacterBandolier> GetWhere(std::string where_filter)
+	static std::vector<CharacterBandolier> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharacterBandolier> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -326,9 +331,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -339,9 +344,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_character_bind_repository.h
+++ b/common/repositories/base/base_character_bind_repository.h
@@ -138,10 +138,11 @@ public:
 	}
 
 	static CharacterBind FindOne(
+		Database& db,
 		int character_bind_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -169,10 +170,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int character_bind_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -185,6 +187,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharacterBind character_bind_entry
 	)
 	{
@@ -200,7 +203,7 @@ public:
 		update_values.push_back(columns[6] + " = " + std::to_string(character_bind_entry.z));
 		update_values.push_back(columns[7] + " = " + std::to_string(character_bind_entry.heading));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -214,6 +217,7 @@ public:
 	}
 
 	static CharacterBind InsertOne(
+		Database& db,
 		CharacterBind character_bind_entry
 	)
 	{
@@ -246,6 +250,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharacterBind> character_bind_entries
 	)
 	{
@@ -267,7 +272,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -278,11 +283,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharacterBind> All()
+	static std::vector<CharacterBind> All(Database& db)
 	{
 		std::vector<CharacterBind> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -309,11 +314,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharacterBind> GetWhere(std::string where_filter)
+	static std::vector<CharacterBind> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharacterBind> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -341,9 +346,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -354,9 +359,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_character_buffs_repository.h
+++ b/common/repositories/base/base_character_buffs_repository.h
@@ -165,10 +165,11 @@ public:
 	}
 
 	static CharacterBuffs FindOne(
+		Database& db,
 		int character_buffs_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -205,10 +206,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int character_buffs_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -221,6 +223,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharacterBuffs character_buffs_entry
 	)
 	{
@@ -246,7 +249,7 @@ public:
 		update_values.push_back(columns[15] + " = " + std::to_string(character_buffs_entry.ExtraDIChance));
 		update_values.push_back(columns[16] + " = " + std::to_string(character_buffs_entry.instrument_mod));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -260,6 +263,7 @@ public:
 	}
 
 	static CharacterBuffs InsertOne(
+		Database& db,
 		CharacterBuffs character_buffs_entry
 	)
 	{
@@ -302,6 +306,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharacterBuffs> character_buffs_entries
 	)
 	{
@@ -333,7 +338,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -344,11 +349,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharacterBuffs> All()
+	static std::vector<CharacterBuffs> All(Database& db)
 	{
 		std::vector<CharacterBuffs> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -384,11 +389,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharacterBuffs> GetWhere(std::string where_filter)
+	static std::vector<CharacterBuffs> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharacterBuffs> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -425,9 +430,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -438,9 +443,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_character_corpse_items_repository.h
+++ b/common/repositories/base/base_character_corpse_items_repository.h
@@ -147,10 +147,11 @@ public:
 	}
 
 	static CharacterCorpseItems FindOne(
+		Database& db,
 		int character_corpse_items_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -181,10 +182,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int character_corpse_items_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -197,6 +199,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharacterCorpseItems character_corpse_items_entry
 	)
 	{
@@ -216,7 +219,7 @@ public:
 		update_values.push_back(columns[9] + " = " + std::to_string(character_corpse_items_entry.aug_6));
 		update_values.push_back(columns[10] + " = " + std::to_string(character_corpse_items_entry.attuned));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -230,6 +233,7 @@ public:
 	}
 
 	static CharacterCorpseItems InsertOne(
+		Database& db,
 		CharacterCorpseItems character_corpse_items_entry
 	)
 	{
@@ -266,6 +270,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharacterCorpseItems> character_corpse_items_entries
 	)
 	{
@@ -291,7 +296,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -302,11 +307,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharacterCorpseItems> All()
+	static std::vector<CharacterCorpseItems> All(Database& db)
 	{
 		std::vector<CharacterCorpseItems> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -336,11 +341,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharacterCorpseItems> GetWhere(std::string where_filter)
+	static std::vector<CharacterCorpseItems> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharacterCorpseItems> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -371,9 +376,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -384,9 +389,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_character_corpses_repository.h
+++ b/common/repositories/base/base_character_corpses_repository.h
@@ -255,10 +255,11 @@ public:
 	}
 
 	static CharacterCorpses FindOne(
+		Database& db,
 		int character_corpses_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -325,10 +326,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int character_corpses_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -341,6 +343,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharacterCorpses character_corpses_entry
 	)
 	{
@@ -395,7 +398,7 @@ public:
 		update_values.push_back(columns[45] + " = " + std::to_string(character_corpses_entry.wc_8));
 		update_values.push_back(columns[46] + " = " + std::to_string(character_corpses_entry.wc_9));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -409,6 +412,7 @@ public:
 	}
 
 	static CharacterCorpses InsertOne(
+		Database& db,
 		CharacterCorpses character_corpses_entry
 	)
 	{
@@ -480,6 +484,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharacterCorpses> character_corpses_entries
 	)
 	{
@@ -540,7 +545,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -551,11 +556,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharacterCorpses> All()
+	static std::vector<CharacterCorpses> All(Database& db)
 	{
 		std::vector<CharacterCorpses> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -621,11 +626,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharacterCorpses> GetWhere(std::string where_filter)
+	static std::vector<CharacterCorpses> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharacterCorpses> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -692,9 +697,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -705,9 +710,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_character_currency_repository.h
+++ b/common/repositories/base/base_character_currency_repository.h
@@ -165,10 +165,11 @@ public:
 	}
 
 	static CharacterCurrency FindOne(
+		Database& db,
 		int character_currency_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -205,10 +206,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int character_currency_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -221,6 +223,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharacterCurrency character_currency_entry
 	)
 	{
@@ -246,7 +249,7 @@ public:
 		update_values.push_back(columns[15] + " = " + std::to_string(character_currency_entry.ebon_crystals));
 		update_values.push_back(columns[16] + " = " + std::to_string(character_currency_entry.career_ebon_crystals));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -260,6 +263,7 @@ public:
 	}
 
 	static CharacterCurrency InsertOne(
+		Database& db,
 		CharacterCurrency character_currency_entry
 	)
 	{
@@ -302,6 +306,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharacterCurrency> character_currency_entries
 	)
 	{
@@ -333,7 +338,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -344,11 +349,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharacterCurrency> All()
+	static std::vector<CharacterCurrency> All(Database& db)
 	{
 		std::vector<CharacterCurrency> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -384,11 +389,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharacterCurrency> GetWhere(std::string where_filter)
+	static std::vector<CharacterCurrency> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharacterCurrency> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -425,9 +430,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -438,9 +443,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_character_data_repository.h
+++ b/common/repositories/base/base_character_data_repository.h
@@ -420,10 +420,11 @@ public:
 	}
 
 	static CharacterData FindOne(
+		Database& db,
 		int character_data_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -545,10 +546,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int character_data_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -561,6 +563,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharacterData character_data_entry
 	)
 	{
@@ -670,7 +673,7 @@ public:
 		update_values.push_back(columns[100] + " = " + std::to_string(character_data_entry.e_last_invsnapshot));
 		update_values.push_back(columns[101] + " = '" + EscapeString(character_data_entry.deleted_at) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -684,6 +687,7 @@ public:
 	}
 
 	static CharacterData InsertOne(
+		Database& db,
 		CharacterData character_data_entry
 	)
 	{
@@ -810,6 +814,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharacterData> character_data_entries
 	)
 	{
@@ -925,7 +930,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -936,11 +941,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharacterData> All()
+	static std::vector<CharacterData> All(Database& db)
 	{
 		std::vector<CharacterData> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -1061,11 +1066,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharacterData> GetWhere(std::string where_filter)
+	static std::vector<CharacterData> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharacterData> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -1187,9 +1192,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -1200,9 +1205,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_character_disciplines_repository.h
+++ b/common/repositories/base/base_character_disciplines_repository.h
@@ -123,10 +123,11 @@ public:
 	}
 
 	static CharacterDisciplines FindOne(
+		Database& db,
 		int character_disciplines_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -149,10 +150,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int character_disciplines_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -165,6 +167,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharacterDisciplines character_disciplines_entry
 	)
 	{
@@ -176,7 +179,7 @@ public:
 		update_values.push_back(columns[1] + " = " + std::to_string(character_disciplines_entry.slot_id));
 		update_values.push_back(columns[2] + " = " + std::to_string(character_disciplines_entry.disc_id));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -190,6 +193,7 @@ public:
 	}
 
 	static CharacterDisciplines InsertOne(
+		Database& db,
 		CharacterDisciplines character_disciplines_entry
 	)
 	{
@@ -218,6 +222,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharacterDisciplines> character_disciplines_entries
 	)
 	{
@@ -235,7 +240,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -246,11 +251,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharacterDisciplines> All()
+	static std::vector<CharacterDisciplines> All(Database& db)
 	{
 		std::vector<CharacterDisciplines> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -272,11 +277,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharacterDisciplines> GetWhere(std::string where_filter)
+	static std::vector<CharacterDisciplines> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharacterDisciplines> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -299,9 +304,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -312,9 +317,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_character_expedition_lockouts_repository.h
+++ b/common/repositories/base/base_character_expedition_lockouts_repository.h
@@ -135,10 +135,11 @@ public:
 	}
 
 	static CharacterExpeditionLockouts FindOne(
+		Database& db,
 		int character_expedition_lockouts_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -165,10 +166,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int character_expedition_lockouts_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -181,6 +183,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharacterExpeditionLockouts character_expedition_lockouts_entry
 	)
 	{
@@ -195,7 +198,7 @@ public:
 		update_values.push_back(columns[5] + " = " + std::to_string(character_expedition_lockouts_entry.duration));
 		update_values.push_back(columns[6] + " = '" + EscapeString(character_expedition_lockouts_entry.from_expedition_uuid) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -209,6 +212,7 @@ public:
 	}
 
 	static CharacterExpeditionLockouts InsertOne(
+		Database& db,
 		CharacterExpeditionLockouts character_expedition_lockouts_entry
 	)
 	{
@@ -240,6 +244,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharacterExpeditionLockouts> character_expedition_lockouts_entries
 	)
 	{
@@ -260,7 +265,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -271,11 +276,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharacterExpeditionLockouts> All()
+	static std::vector<CharacterExpeditionLockouts> All(Database& db)
 	{
 		std::vector<CharacterExpeditionLockouts> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -301,11 +306,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharacterExpeditionLockouts> GetWhere(std::string where_filter)
+	static std::vector<CharacterExpeditionLockouts> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharacterExpeditionLockouts> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -332,9 +337,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -345,9 +350,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_character_inspect_messages_repository.h
+++ b/common/repositories/base/base_character_inspect_messages_repository.h
@@ -120,10 +120,11 @@ public:
 	}
 
 	static CharacterInspectMessages FindOne(
+		Database& db,
 		int character_inspect_messages_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -145,10 +146,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int character_inspect_messages_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -161,6 +163,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharacterInspectMessages character_inspect_messages_entry
 	)
 	{
@@ -171,7 +174,7 @@ public:
 		update_values.push_back(columns[0] + " = " + std::to_string(character_inspect_messages_entry.id));
 		update_values.push_back(columns[1] + " = '" + EscapeString(character_inspect_messages_entry.inspect_message) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -185,6 +188,7 @@ public:
 	}
 
 	static CharacterInspectMessages InsertOne(
+		Database& db,
 		CharacterInspectMessages character_inspect_messages_entry
 	)
 	{
@@ -212,6 +216,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharacterInspectMessages> character_inspect_messages_entries
 	)
 	{
@@ -228,7 +233,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -239,11 +244,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharacterInspectMessages> All()
+	static std::vector<CharacterInspectMessages> All(Database& db)
 	{
 		std::vector<CharacterInspectMessages> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -264,11 +269,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharacterInspectMessages> GetWhere(std::string where_filter)
+	static std::vector<CharacterInspectMessages> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharacterInspectMessages> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -290,9 +295,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -303,9 +308,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_character_item_recast_repository.h
+++ b/common/repositories/base/base_character_item_recast_repository.h
@@ -123,10 +123,11 @@ public:
 	}
 
 	static CharacterItemRecast FindOne(
+		Database& db,
 		int character_item_recast_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -149,10 +150,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int character_item_recast_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -165,6 +167,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharacterItemRecast character_item_recast_entry
 	)
 	{
@@ -176,7 +179,7 @@ public:
 		update_values.push_back(columns[1] + " = " + std::to_string(character_item_recast_entry.recast_type));
 		update_values.push_back(columns[2] + " = " + std::to_string(character_item_recast_entry.timestamp));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -190,6 +193,7 @@ public:
 	}
 
 	static CharacterItemRecast InsertOne(
+		Database& db,
 		CharacterItemRecast character_item_recast_entry
 	)
 	{
@@ -218,6 +222,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharacterItemRecast> character_item_recast_entries
 	)
 	{
@@ -235,7 +240,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -246,11 +251,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharacterItemRecast> All()
+	static std::vector<CharacterItemRecast> All(Database& db)
 	{
 		std::vector<CharacterItemRecast> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -272,11 +277,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharacterItemRecast> GetWhere(std::string where_filter)
+	static std::vector<CharacterItemRecast> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharacterItemRecast> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -299,9 +304,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -312,9 +317,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_character_languages_repository.h
+++ b/common/repositories/base/base_character_languages_repository.h
@@ -123,10 +123,11 @@ public:
 	}
 
 	static CharacterLanguages FindOne(
+		Database& db,
 		int character_languages_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -149,10 +150,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int character_languages_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -165,6 +167,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharacterLanguages character_languages_entry
 	)
 	{
@@ -175,7 +178,7 @@ public:
 		update_values.push_back(columns[1] + " = " + std::to_string(character_languages_entry.lang_id));
 		update_values.push_back(columns[2] + " = " + std::to_string(character_languages_entry.value));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -189,6 +192,7 @@ public:
 	}
 
 	static CharacterLanguages InsertOne(
+		Database& db,
 		CharacterLanguages character_languages_entry
 	)
 	{
@@ -216,6 +220,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharacterLanguages> character_languages_entries
 	)
 	{
@@ -232,7 +237,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -243,11 +248,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharacterLanguages> All()
+	static std::vector<CharacterLanguages> All(Database& db)
 	{
 		std::vector<CharacterLanguages> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -269,11 +274,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharacterLanguages> GetWhere(std::string where_filter)
+	static std::vector<CharacterLanguages> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharacterLanguages> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -296,9 +301,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -309,9 +314,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_character_leadership_abilities_repository.h
+++ b/common/repositories/base/base_character_leadership_abilities_repository.h
@@ -123,10 +123,11 @@ public:
 	}
 
 	static CharacterLeadershipAbilities FindOne(
+		Database& db,
 		int character_leadership_abilities_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -149,10 +150,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int character_leadership_abilities_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -165,6 +167,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharacterLeadershipAbilities character_leadership_abilities_entry
 	)
 	{
@@ -176,7 +179,7 @@ public:
 		update_values.push_back(columns[1] + " = " + std::to_string(character_leadership_abilities_entry.slot));
 		update_values.push_back(columns[2] + " = " + std::to_string(character_leadership_abilities_entry.rank));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -190,6 +193,7 @@ public:
 	}
 
 	static CharacterLeadershipAbilities InsertOne(
+		Database& db,
 		CharacterLeadershipAbilities character_leadership_abilities_entry
 	)
 	{
@@ -218,6 +222,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharacterLeadershipAbilities> character_leadership_abilities_entries
 	)
 	{
@@ -235,7 +240,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -246,11 +251,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharacterLeadershipAbilities> All()
+	static std::vector<CharacterLeadershipAbilities> All(Database& db)
 	{
 		std::vector<CharacterLeadershipAbilities> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -272,11 +277,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharacterLeadershipAbilities> GetWhere(std::string where_filter)
+	static std::vector<CharacterLeadershipAbilities> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharacterLeadershipAbilities> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -299,9 +304,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -312,9 +317,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_character_material_repository.h
+++ b/common/repositories/base/base_character_material_repository.h
@@ -135,10 +135,11 @@ public:
 	}
 
 	static CharacterMaterial FindOne(
+		Database& db,
 		int character_material_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -165,10 +166,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int character_material_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -181,6 +183,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharacterMaterial character_material_entry
 	)
 	{
@@ -195,7 +198,7 @@ public:
 		update_values.push_back(columns[5] + " = " + std::to_string(character_material_entry.use_tint));
 		update_values.push_back(columns[6] + " = " + std::to_string(character_material_entry.color));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -209,6 +212,7 @@ public:
 	}
 
 	static CharacterMaterial InsertOne(
+		Database& db,
 		CharacterMaterial character_material_entry
 	)
 	{
@@ -240,6 +244,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharacterMaterial> character_material_entries
 	)
 	{
@@ -260,7 +265,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -271,11 +276,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharacterMaterial> All()
+	static std::vector<CharacterMaterial> All(Database& db)
 	{
 		std::vector<CharacterMaterial> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -301,11 +306,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharacterMaterial> GetWhere(std::string where_filter)
+	static std::vector<CharacterMaterial> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharacterMaterial> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -332,9 +337,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -345,9 +350,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_character_memmed_spells_repository.h
+++ b/common/repositories/base/base_character_memmed_spells_repository.h
@@ -123,10 +123,11 @@ public:
 	}
 
 	static CharacterMemmedSpells FindOne(
+		Database& db,
 		int character_memmed_spells_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -149,10 +150,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int character_memmed_spells_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -165,6 +167,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharacterMemmedSpells character_memmed_spells_entry
 	)
 	{
@@ -176,7 +179,7 @@ public:
 		update_values.push_back(columns[1] + " = " + std::to_string(character_memmed_spells_entry.slot_id));
 		update_values.push_back(columns[2] + " = " + std::to_string(character_memmed_spells_entry.spell_id));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -190,6 +193,7 @@ public:
 	}
 
 	static CharacterMemmedSpells InsertOne(
+		Database& db,
 		CharacterMemmedSpells character_memmed_spells_entry
 	)
 	{
@@ -218,6 +222,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharacterMemmedSpells> character_memmed_spells_entries
 	)
 	{
@@ -235,7 +240,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -246,11 +251,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharacterMemmedSpells> All()
+	static std::vector<CharacterMemmedSpells> All(Database& db)
 	{
 		std::vector<CharacterMemmedSpells> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -272,11 +277,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharacterMemmedSpells> GetWhere(std::string where_filter)
+	static std::vector<CharacterMemmedSpells> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharacterMemmedSpells> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -299,9 +304,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -312,9 +317,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_character_pet_buffs_repository.h
+++ b/common/repositories/base/base_character_pet_buffs_repository.h
@@ -147,10 +147,11 @@ public:
 	}
 
 	static CharacterPetBuffs FindOne(
+		Database& db,
 		int character_pet_buffs_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -181,10 +182,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int character_pet_buffs_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -197,6 +199,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharacterPetBuffs character_pet_buffs_entry
 	)
 	{
@@ -216,7 +219,7 @@ public:
 		update_values.push_back(columns[9] + " = " + std::to_string(character_pet_buffs_entry.rune));
 		update_values.push_back(columns[10] + " = " + std::to_string(character_pet_buffs_entry.instrument_mod));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -230,6 +233,7 @@ public:
 	}
 
 	static CharacterPetBuffs InsertOne(
+		Database& db,
 		CharacterPetBuffs character_pet_buffs_entry
 	)
 	{
@@ -266,6 +270,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharacterPetBuffs> character_pet_buffs_entries
 	)
 	{
@@ -291,7 +296,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -302,11 +307,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharacterPetBuffs> All()
+	static std::vector<CharacterPetBuffs> All(Database& db)
 	{
 		std::vector<CharacterPetBuffs> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -336,11 +341,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharacterPetBuffs> GetWhere(std::string where_filter)
+	static std::vector<CharacterPetBuffs> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharacterPetBuffs> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -371,9 +376,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -384,9 +389,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_character_pet_info_repository.h
+++ b/common/repositories/base/base_character_pet_info_repository.h
@@ -141,10 +141,11 @@ public:
 	}
 
 	static CharacterPetInfo FindOne(
+		Database& db,
 		int character_pet_info_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -173,10 +174,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int character_pet_info_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -189,6 +191,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharacterPetInfo character_pet_info_entry
 	)
 	{
@@ -206,7 +209,7 @@ public:
 		update_values.push_back(columns[7] + " = " + std::to_string(character_pet_info_entry.size));
 		update_values.push_back(columns[8] + " = " + std::to_string(character_pet_info_entry.taunting));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -220,6 +223,7 @@ public:
 	}
 
 	static CharacterPetInfo InsertOne(
+		Database& db,
 		CharacterPetInfo character_pet_info_entry
 	)
 	{
@@ -254,6 +258,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharacterPetInfo> character_pet_info_entries
 	)
 	{
@@ -277,7 +282,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -288,11 +293,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharacterPetInfo> All()
+	static std::vector<CharacterPetInfo> All(Database& db)
 	{
 		std::vector<CharacterPetInfo> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -320,11 +325,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharacterPetInfo> GetWhere(std::string where_filter)
+	static std::vector<CharacterPetInfo> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharacterPetInfo> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -353,9 +358,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -366,9 +371,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_character_pet_inventory_repository.h
+++ b/common/repositories/base/base_character_pet_inventory_repository.h
@@ -126,10 +126,11 @@ public:
 	}
 
 	static CharacterPetInventory FindOne(
+		Database& db,
 		int character_pet_inventory_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -153,10 +154,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int character_pet_inventory_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -169,6 +171,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharacterPetInventory character_pet_inventory_entry
 	)
 	{
@@ -181,7 +184,7 @@ public:
 		update_values.push_back(columns[2] + " = " + std::to_string(character_pet_inventory_entry.slot));
 		update_values.push_back(columns[3] + " = " + std::to_string(character_pet_inventory_entry.item_id));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -195,6 +198,7 @@ public:
 	}
 
 	static CharacterPetInventory InsertOne(
+		Database& db,
 		CharacterPetInventory character_pet_inventory_entry
 	)
 	{
@@ -224,6 +228,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharacterPetInventory> character_pet_inventory_entries
 	)
 	{
@@ -242,7 +247,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -253,11 +258,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharacterPetInventory> All()
+	static std::vector<CharacterPetInventory> All(Database& db)
 	{
 		std::vector<CharacterPetInventory> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -280,11 +285,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharacterPetInventory> GetWhere(std::string where_filter)
+	static std::vector<CharacterPetInventory> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharacterPetInventory> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -308,9 +313,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -321,9 +326,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_character_potionbelt_repository.h
+++ b/common/repositories/base/base_character_potionbelt_repository.h
@@ -126,10 +126,11 @@ public:
 	}
 
 	static CharacterPotionbelt FindOne(
+		Database& db,
 		int character_potionbelt_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -153,10 +154,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int character_potionbelt_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -169,6 +171,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharacterPotionbelt character_potionbelt_entry
 	)
 	{
@@ -181,7 +184,7 @@ public:
 		update_values.push_back(columns[2] + " = " + std::to_string(character_potionbelt_entry.item_id));
 		update_values.push_back(columns[3] + " = " + std::to_string(character_potionbelt_entry.icon));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -195,6 +198,7 @@ public:
 	}
 
 	static CharacterPotionbelt InsertOne(
+		Database& db,
 		CharacterPotionbelt character_potionbelt_entry
 	)
 	{
@@ -224,6 +228,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharacterPotionbelt> character_potionbelt_entries
 	)
 	{
@@ -242,7 +247,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -253,11 +258,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharacterPotionbelt> All()
+	static std::vector<CharacterPotionbelt> All(Database& db)
 	{
 		std::vector<CharacterPotionbelt> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -280,11 +285,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharacterPotionbelt> GetWhere(std::string where_filter)
+	static std::vector<CharacterPotionbelt> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharacterPotionbelt> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -308,9 +313,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -321,9 +326,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_character_skills_repository.h
+++ b/common/repositories/base/base_character_skills_repository.h
@@ -123,10 +123,11 @@ public:
 	}
 
 	static CharacterSkills FindOne(
+		Database& db,
 		int character_skills_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -149,10 +150,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int character_skills_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -165,6 +167,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharacterSkills character_skills_entry
 	)
 	{
@@ -175,7 +178,7 @@ public:
 		update_values.push_back(columns[1] + " = " + std::to_string(character_skills_entry.skill_id));
 		update_values.push_back(columns[2] + " = " + std::to_string(character_skills_entry.value));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -189,6 +192,7 @@ public:
 	}
 
 	static CharacterSkills InsertOne(
+		Database& db,
 		CharacterSkills character_skills_entry
 	)
 	{
@@ -216,6 +220,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharacterSkills> character_skills_entries
 	)
 	{
@@ -232,7 +237,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -243,11 +248,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharacterSkills> All()
+	static std::vector<CharacterSkills> All(Database& db)
 	{
 		std::vector<CharacterSkills> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -269,11 +274,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharacterSkills> GetWhere(std::string where_filter)
+	static std::vector<CharacterSkills> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharacterSkills> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -296,9 +301,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -309,9 +314,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_character_spells_repository.h
+++ b/common/repositories/base/base_character_spells_repository.h
@@ -123,10 +123,11 @@ public:
 	}
 
 	static CharacterSpells FindOne(
+		Database& db,
 		int character_spells_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -149,10 +150,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int character_spells_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -165,6 +167,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharacterSpells character_spells_entry
 	)
 	{
@@ -175,7 +178,7 @@ public:
 		update_values.push_back(columns[1] + " = " + std::to_string(character_spells_entry.slot_id));
 		update_values.push_back(columns[2] + " = " + std::to_string(character_spells_entry.spell_id));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -189,6 +192,7 @@ public:
 	}
 
 	static CharacterSpells InsertOne(
+		Database& db,
 		CharacterSpells character_spells_entry
 	)
 	{
@@ -216,6 +220,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharacterSpells> character_spells_entries
 	)
 	{
@@ -232,7 +237,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -243,11 +248,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharacterSpells> All()
+	static std::vector<CharacterSpells> All(Database& db)
 	{
 		std::vector<CharacterSpells> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -269,11 +274,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharacterSpells> GetWhere(std::string where_filter)
+	static std::vector<CharacterSpells> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharacterSpells> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -296,9 +301,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -309,9 +314,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_character_tasks_repository.h
+++ b/common/repositories/base/base_character_tasks_repository.h
@@ -129,10 +129,11 @@ public:
 	}
 
 	static CharacterTasks FindOne(
+		Database& db,
 		int character_tasks_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -157,10 +158,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int character_tasks_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -173,6 +175,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CharacterTasks character_tasks_entry
 	)
 	{
@@ -186,7 +189,7 @@ public:
 		update_values.push_back(columns[3] + " = " + std::to_string(character_tasks_entry.type));
 		update_values.push_back(columns[4] + " = " + std::to_string(character_tasks_entry.acceptedtime));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -200,6 +203,7 @@ public:
 	}
 
 	static CharacterTasks InsertOne(
+		Database& db,
 		CharacterTasks character_tasks_entry
 	)
 	{
@@ -230,6 +234,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CharacterTasks> character_tasks_entries
 	)
 	{
@@ -249,7 +254,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -260,11 +265,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CharacterTasks> All()
+	static std::vector<CharacterTasks> All(Database& db)
 	{
 		std::vector<CharacterTasks> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -288,11 +293,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CharacterTasks> GetWhere(std::string where_filter)
+	static std::vector<CharacterTasks> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CharacterTasks> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -317,9 +322,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -330,9 +335,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_completed_tasks_repository.h
+++ b/common/repositories/base/base_completed_tasks_repository.h
@@ -126,10 +126,11 @@ public:
 	}
 
 	static CompletedTasks FindOne(
+		Database& db,
 		int completed_tasks_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -153,10 +154,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int completed_tasks_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -169,6 +171,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		CompletedTasks completed_tasks_entry
 	)
 	{
@@ -181,7 +184,7 @@ public:
 		update_values.push_back(columns[2] + " = " + std::to_string(completed_tasks_entry.taskid));
 		update_values.push_back(columns[3] + " = " + std::to_string(completed_tasks_entry.activityid));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -195,6 +198,7 @@ public:
 	}
 
 	static CompletedTasks InsertOne(
+		Database& db,
 		CompletedTasks completed_tasks_entry
 	)
 	{
@@ -224,6 +228,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<CompletedTasks> completed_tasks_entries
 	)
 	{
@@ -242,7 +247,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -253,11 +258,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<CompletedTasks> All()
+	static std::vector<CompletedTasks> All(Database& db)
 	{
 		std::vector<CompletedTasks> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -280,11 +285,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<CompletedTasks> GetWhere(std::string where_filter)
+	static std::vector<CompletedTasks> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<CompletedTasks> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -308,9 +313,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -321,9 +326,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_content_flags_repository.h
+++ b/common/repositories/base/base_content_flags_repository.h
@@ -126,10 +126,11 @@ public:
 	}
 
 	static ContentFlags FindOne(
+		Database& db,
 		int content_flags_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -153,10 +154,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int content_flags_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -169,6 +171,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		ContentFlags content_flags_entry
 	)
 	{
@@ -180,7 +183,7 @@ public:
 		update_values.push_back(columns[2] + " = " + std::to_string(content_flags_entry.enabled));
 		update_values.push_back(columns[3] + " = '" + EscapeString(content_flags_entry.notes) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -194,6 +197,7 @@ public:
 	}
 
 	static ContentFlags InsertOne(
+		Database& db,
 		ContentFlags content_flags_entry
 	)
 	{
@@ -222,6 +226,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<ContentFlags> content_flags_entries
 	)
 	{
@@ -239,7 +244,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -250,11 +255,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<ContentFlags> All()
+	static std::vector<ContentFlags> All(Database& db)
 	{
 		std::vector<ContentFlags> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -277,11 +282,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<ContentFlags> GetWhere(std::string where_filter)
+	static std::vector<ContentFlags> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<ContentFlags> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -305,9 +310,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -318,9 +323,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_damageshieldtypes_repository.h
+++ b/common/repositories/base/base_damageshieldtypes_repository.h
@@ -120,10 +120,11 @@ public:
 	}
 
 	static Damageshieldtypes FindOne(
+		Database& db,
 		int damageshieldtypes_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -145,10 +146,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int damageshieldtypes_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -161,6 +163,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Damageshieldtypes damageshieldtypes_entry
 	)
 	{
@@ -171,7 +174,7 @@ public:
 		update_values.push_back(columns[0] + " = " + std::to_string(damageshieldtypes_entry.spellid));
 		update_values.push_back(columns[1] + " = " + std::to_string(damageshieldtypes_entry.type));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -185,6 +188,7 @@ public:
 	}
 
 	static Damageshieldtypes InsertOne(
+		Database& db,
 		Damageshieldtypes damageshieldtypes_entry
 	)
 	{
@@ -212,6 +216,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Damageshieldtypes> damageshieldtypes_entries
 	)
 	{
@@ -228,7 +233,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -239,11 +244,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Damageshieldtypes> All()
+	static std::vector<Damageshieldtypes> All(Database& db)
 	{
 		std::vector<Damageshieldtypes> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -264,11 +269,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Damageshieldtypes> GetWhere(std::string where_filter)
+	static std::vector<Damageshieldtypes> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Damageshieldtypes> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -290,9 +295,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -303,9 +308,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_data_buckets_repository.h
+++ b/common/repositories/base/base_data_buckets_repository.h
@@ -126,10 +126,11 @@ public:
 	}
 
 	static DataBuckets FindOne(
+		Database& db,
 		int data_buckets_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -153,10 +154,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int data_buckets_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -169,6 +171,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		DataBuckets data_buckets_entry
 	)
 	{
@@ -180,7 +183,7 @@ public:
 		update_values.push_back(columns[2] + " = '" + EscapeString(data_buckets_entry.value) + "'");
 		update_values.push_back(columns[3] + " = " + std::to_string(data_buckets_entry.expires));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -194,6 +197,7 @@ public:
 	}
 
 	static DataBuckets InsertOne(
+		Database& db,
 		DataBuckets data_buckets_entry
 	)
 	{
@@ -222,6 +226,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<DataBuckets> data_buckets_entries
 	)
 	{
@@ -239,7 +244,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -250,11 +255,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<DataBuckets> All()
+	static std::vector<DataBuckets> All(Database& db)
 	{
 		std::vector<DataBuckets> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -277,11 +282,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<DataBuckets> GetWhere(std::string where_filter)
+	static std::vector<DataBuckets> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<DataBuckets> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -305,9 +310,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -318,9 +323,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_db_str_repository.h
+++ b/common/repositories/base/base_db_str_repository.h
@@ -123,10 +123,11 @@ public:
 	}
 
 	static DbStr FindOne(
+		Database& db,
 		int db_str_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -149,10 +150,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int db_str_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -165,6 +167,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		DbStr db_str_entry
 	)
 	{
@@ -176,7 +179,7 @@ public:
 		update_values.push_back(columns[1] + " = " + std::to_string(db_str_entry.type));
 		update_values.push_back(columns[2] + " = '" + EscapeString(db_str_entry.value) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -190,6 +193,7 @@ public:
 	}
 
 	static DbStr InsertOne(
+		Database& db,
 		DbStr db_str_entry
 	)
 	{
@@ -218,6 +222,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<DbStr> db_str_entries
 	)
 	{
@@ -235,7 +240,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -246,11 +251,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<DbStr> All()
+	static std::vector<DbStr> All(Database& db)
 	{
 		std::vector<DbStr> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -272,11 +277,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<DbStr> GetWhere(std::string where_filter)
+	static std::vector<DbStr> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<DbStr> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -299,9 +304,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -312,9 +317,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_discovered_items_repository.h
+++ b/common/repositories/base/base_discovered_items_repository.h
@@ -126,10 +126,11 @@ public:
 	}
 
 	static DiscoveredItems FindOne(
+		Database& db,
 		int discovered_items_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -153,10 +154,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int discovered_items_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -169,6 +171,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		DiscoveredItems discovered_items_entry
 	)
 	{
@@ -181,7 +184,7 @@ public:
 		update_values.push_back(columns[2] + " = " + std::to_string(discovered_items_entry.discovered_date));
 		update_values.push_back(columns[3] + " = " + std::to_string(discovered_items_entry.account_status));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -195,6 +198,7 @@ public:
 	}
 
 	static DiscoveredItems InsertOne(
+		Database& db,
 		DiscoveredItems discovered_items_entry
 	)
 	{
@@ -224,6 +228,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<DiscoveredItems> discovered_items_entries
 	)
 	{
@@ -242,7 +247,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -253,11 +258,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<DiscoveredItems> All()
+	static std::vector<DiscoveredItems> All(Database& db)
 	{
 		std::vector<DiscoveredItems> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -280,11 +285,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<DiscoveredItems> GetWhere(std::string where_filter)
+	static std::vector<DiscoveredItems> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<DiscoveredItems> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -308,9 +313,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -321,9 +326,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_doors_repository.h
+++ b/common/repositories/base/base_doors_repository.h
@@ -219,10 +219,11 @@ public:
 	}
 
 	static Doors FindOne(
+		Database& db,
 		int doors_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -277,10 +278,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int doors_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -293,6 +295,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Doors doors_entry
 	)
 	{
@@ -335,7 +338,7 @@ public:
 		update_values.push_back(columns[33] + " = '" + EscapeString(doors_entry.content_flags) + "'");
 		update_values.push_back(columns[34] + " = '" + EscapeString(doors_entry.content_flags_disabled) + "'");
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -349,6 +352,7 @@ public:
 	}
 
 	static Doors InsertOne(
+		Database& db,
 		Doors doors_entry
 	)
 	{
@@ -408,6 +412,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Doors> doors_entries
 	)
 	{
@@ -456,7 +461,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -467,11 +472,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Doors> All()
+	static std::vector<Doors> All(Database& db)
 	{
 		std::vector<Doors> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -525,11 +530,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Doors> GetWhere(std::string where_filter)
+	static std::vector<Doors> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Doors> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -584,9 +589,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -597,9 +602,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_dynamic_zones_repository.h
+++ b/common/repositories/base/base_dynamic_zones_repository.h
@@ -165,10 +165,11 @@ public:
 	}
 
 	static DynamicZones FindOne(
+		Database& db,
 		int dynamic_zones_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -205,10 +206,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int dynamic_zones_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -221,6 +223,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		DynamicZones dynamic_zones_entry
 	)
 	{
@@ -245,7 +248,7 @@ public:
 		update_values.push_back(columns[15] + " = " + std::to_string(dynamic_zones_entry.zone_in_heading));
 		update_values.push_back(columns[16] + " = " + std::to_string(dynamic_zones_entry.has_zone_in));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -259,6 +262,7 @@ public:
 	}
 
 	static DynamicZones InsertOne(
+		Database& db,
 		DynamicZones dynamic_zones_entry
 	)
 	{
@@ -300,6 +304,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<DynamicZones> dynamic_zones_entries
 	)
 	{
@@ -330,7 +335,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -341,11 +346,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<DynamicZones> All()
+	static std::vector<DynamicZones> All(Database& db)
 	{
 		std::vector<DynamicZones> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -381,11 +386,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<DynamicZones> GetWhere(std::string where_filter)
+	static std::vector<DynamicZones> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<DynamicZones> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -422,9 +427,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -435,9 +440,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_eventlog_repository.h
+++ b/common/repositories/base/base_eventlog_repository.h
@@ -144,10 +144,11 @@ public:
 	}
 
 	static Eventlog FindOne(
+		Database& db,
 		int eventlog_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -177,10 +178,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int eventlog_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -193,6 +195,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Eventlog eventlog_entry
 	)
 	{
@@ -210,7 +213,7 @@ public:
 		update_values.push_back(columns[8] + " = '" + EscapeString(eventlog_entry.description) + "'");
 		update_values.push_back(columns[9] + " = " + std::to_string(eventlog_entry.event_nid));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -224,6 +227,7 @@ public:
 	}
 
 	static Eventlog InsertOne(
+		Database& db,
 		Eventlog eventlog_entry
 	)
 	{
@@ -258,6 +262,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Eventlog> eventlog_entries
 	)
 	{
@@ -281,7 +286,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -292,11 +297,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Eventlog> All()
+	static std::vector<Eventlog> All(Database& db)
 	{
 		std::vector<Eventlog> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -325,11 +330,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Eventlog> GetWhere(std::string where_filter)
+	static std::vector<Eventlog> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Eventlog> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -359,9 +364,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -372,9 +377,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_expedition_lockouts_repository.h
+++ b/common/repositories/base/base_expedition_lockouts_repository.h
@@ -132,10 +132,11 @@ public:
 	}
 
 	static ExpeditionLockouts FindOne(
+		Database& db,
 		int expedition_lockouts_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -161,10 +162,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int expedition_lockouts_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -177,6 +179,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		ExpeditionLockouts expedition_lockouts_entry
 	)
 	{
@@ -190,7 +193,7 @@ public:
 		update_values.push_back(columns[4] + " = " + std::to_string(expedition_lockouts_entry.duration));
 		update_values.push_back(columns[5] + " = '" + EscapeString(expedition_lockouts_entry.from_expedition_uuid) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -204,6 +207,7 @@ public:
 	}
 
 	static ExpeditionLockouts InsertOne(
+		Database& db,
 		ExpeditionLockouts expedition_lockouts_entry
 	)
 	{
@@ -234,6 +238,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<ExpeditionLockouts> expedition_lockouts_entries
 	)
 	{
@@ -253,7 +258,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -264,11 +269,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<ExpeditionLockouts> All()
+	static std::vector<ExpeditionLockouts> All(Database& db)
 	{
 		std::vector<ExpeditionLockouts> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -293,11 +298,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<ExpeditionLockouts> GetWhere(std::string where_filter)
+	static std::vector<ExpeditionLockouts> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<ExpeditionLockouts> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -323,9 +328,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -336,9 +341,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_expedition_members_repository.h
+++ b/common/repositories/base/base_expedition_members_repository.h
@@ -126,10 +126,11 @@ public:
 	}
 
 	static ExpeditionMembers FindOne(
+		Database& db,
 		int expedition_members_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -153,10 +154,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int expedition_members_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -169,6 +171,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		ExpeditionMembers expedition_members_entry
 	)
 	{
@@ -180,7 +183,7 @@ public:
 		update_values.push_back(columns[2] + " = " + std::to_string(expedition_members_entry.character_id));
 		update_values.push_back(columns[3] + " = " + std::to_string(expedition_members_entry.is_current_member));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -194,6 +197,7 @@ public:
 	}
 
 	static ExpeditionMembers InsertOne(
+		Database& db,
 		ExpeditionMembers expedition_members_entry
 	)
 	{
@@ -222,6 +226,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<ExpeditionMembers> expedition_members_entries
 	)
 	{
@@ -239,7 +244,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -250,11 +255,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<ExpeditionMembers> All()
+	static std::vector<ExpeditionMembers> All(Database& db)
 	{
 		std::vector<ExpeditionMembers> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -277,11 +282,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<ExpeditionMembers> GetWhere(std::string where_filter)
+	static std::vector<ExpeditionMembers> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<ExpeditionMembers> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -305,9 +310,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -318,9 +323,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_expeditions_repository.h
+++ b/common/repositories/base/base_expeditions_repository.h
@@ -141,10 +141,11 @@ public:
 	}
 
 	static Expeditions FindOne(
+		Database& db,
 		int expeditions_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -173,10 +174,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int expeditions_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -189,6 +191,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Expeditions expeditions_entry
 	)
 	{
@@ -205,7 +208,7 @@ public:
 		update_values.push_back(columns[7] + " = " + std::to_string(expeditions_entry.add_replay_on_join));
 		update_values.push_back(columns[8] + " = " + std::to_string(expeditions_entry.is_locked));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -219,6 +222,7 @@ public:
 	}
 
 	static Expeditions InsertOne(
+		Database& db,
 		Expeditions expeditions_entry
 	)
 	{
@@ -252,6 +256,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Expeditions> expeditions_entries
 	)
 	{
@@ -274,7 +279,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -285,11 +290,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Expeditions> All()
+	static std::vector<Expeditions> All(Database& db)
 	{
 		std::vector<Expeditions> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -317,11 +322,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Expeditions> GetWhere(std::string where_filter)
+	static std::vector<Expeditions> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Expeditions> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -350,9 +355,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -363,9 +368,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_faction_base_data_repository.h
+++ b/common/repositories/base/base_faction_base_data_repository.h
@@ -132,10 +132,11 @@ public:
 	}
 
 	static FactionBaseData FindOne(
+		Database& db,
 		int faction_base_data_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -161,10 +162,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int faction_base_data_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -177,6 +179,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		FactionBaseData faction_base_data_entry
 	)
 	{
@@ -191,7 +194,7 @@ public:
 		update_values.push_back(columns[4] + " = " + std::to_string(faction_base_data_entry.unk_hero2));
 		update_values.push_back(columns[5] + " = " + std::to_string(faction_base_data_entry.unk_hero3));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -205,6 +208,7 @@ public:
 	}
 
 	static FactionBaseData InsertOne(
+		Database& db,
 		FactionBaseData faction_base_data_entry
 	)
 	{
@@ -236,6 +240,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<FactionBaseData> faction_base_data_entries
 	)
 	{
@@ -256,7 +261,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -267,11 +272,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<FactionBaseData> All()
+	static std::vector<FactionBaseData> All(Database& db)
 	{
 		std::vector<FactionBaseData> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -296,11 +301,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<FactionBaseData> GetWhere(std::string where_filter)
+	static std::vector<FactionBaseData> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<FactionBaseData> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -326,9 +331,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -339,9 +344,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_faction_list_mod_repository.h
+++ b/common/repositories/base/base_faction_list_mod_repository.h
@@ -126,10 +126,11 @@ public:
 	}
 
 	static FactionListMod FindOne(
+		Database& db,
 		int faction_list_mod_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -153,10 +154,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int faction_list_mod_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -169,6 +171,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		FactionListMod faction_list_mod_entry
 	)
 	{
@@ -180,7 +183,7 @@ public:
 		update_values.push_back(columns[2] + " = " + std::to_string(faction_list_mod_entry.mod));
 		update_values.push_back(columns[3] + " = '" + EscapeString(faction_list_mod_entry.mod_name) + "'");
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -194,6 +197,7 @@ public:
 	}
 
 	static FactionListMod InsertOne(
+		Database& db,
 		FactionListMod faction_list_mod_entry
 	)
 	{
@@ -222,6 +226,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<FactionListMod> faction_list_mod_entries
 	)
 	{
@@ -239,7 +244,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -250,11 +255,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<FactionListMod> All()
+	static std::vector<FactionListMod> All(Database& db)
 	{
 		std::vector<FactionListMod> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -277,11 +282,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<FactionListMod> GetWhere(std::string where_filter)
+	static std::vector<FactionListMod> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<FactionListMod> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -305,9 +310,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -318,9 +323,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_faction_list_repository.h
+++ b/common/repositories/base/base_faction_list_repository.h
@@ -123,10 +123,11 @@ public:
 	}
 
 	static FactionList FindOne(
+		Database& db,
 		int faction_list_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -149,10 +150,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int faction_list_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -165,6 +167,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		FactionList faction_list_entry
 	)
 	{
@@ -176,7 +179,7 @@ public:
 		update_values.push_back(columns[1] + " = '" + EscapeString(faction_list_entry.name) + "'");
 		update_values.push_back(columns[2] + " = " + std::to_string(faction_list_entry.base));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -190,6 +193,7 @@ public:
 	}
 
 	static FactionList InsertOne(
+		Database& db,
 		FactionList faction_list_entry
 	)
 	{
@@ -218,6 +222,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<FactionList> faction_list_entries
 	)
 	{
@@ -235,7 +240,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -246,11 +251,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<FactionList> All()
+	static std::vector<FactionList> All(Database& db)
 	{
 		std::vector<FactionList> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -272,11 +277,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<FactionList> GetWhere(std::string where_filter)
+	static std::vector<FactionList> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<FactionList> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -299,9 +304,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -312,9 +317,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_faction_values_repository.h
+++ b/common/repositories/base/base_faction_values_repository.h
@@ -126,10 +126,11 @@ public:
 	}
 
 	static FactionValues FindOne(
+		Database& db,
 		int faction_values_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -153,10 +154,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int faction_values_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -169,6 +171,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		FactionValues faction_values_entry
 	)
 	{
@@ -181,7 +184,7 @@ public:
 		update_values.push_back(columns[2] + " = " + std::to_string(faction_values_entry.current_value));
 		update_values.push_back(columns[3] + " = " + std::to_string(faction_values_entry.temp));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -195,6 +198,7 @@ public:
 	}
 
 	static FactionValues InsertOne(
+		Database& db,
 		FactionValues faction_values_entry
 	)
 	{
@@ -224,6 +228,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<FactionValues> faction_values_entries
 	)
 	{
@@ -242,7 +247,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -253,11 +258,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<FactionValues> All()
+	static std::vector<FactionValues> All(Database& db)
 	{
 		std::vector<FactionValues> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -280,11 +285,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<FactionValues> GetWhere(std::string where_filter)
+	static std::vector<FactionValues> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<FactionValues> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -308,9 +313,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -321,9 +326,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_fishing_repository.h
+++ b/common/repositories/base/base_fishing_repository.h
@@ -147,10 +147,11 @@ public:
 	}
 
 	static Fishing FindOne(
+		Database& db,
 		int fishing_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -181,10 +182,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int fishing_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -197,6 +199,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Fishing fishing_entry
 	)
 	{
@@ -215,7 +218,7 @@ public:
 		update_values.push_back(columns[9] + " = '" + EscapeString(fishing_entry.content_flags) + "'");
 		update_values.push_back(columns[10] + " = '" + EscapeString(fishing_entry.content_flags_disabled) + "'");
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -229,6 +232,7 @@ public:
 	}
 
 	static Fishing InsertOne(
+		Database& db,
 		Fishing fishing_entry
 	)
 	{
@@ -264,6 +268,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Fishing> fishing_entries
 	)
 	{
@@ -288,7 +293,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -299,11 +304,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Fishing> All()
+	static std::vector<Fishing> All(Database& db)
 	{
 		std::vector<Fishing> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -333,11 +338,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Fishing> GetWhere(std::string where_filter)
+	static std::vector<Fishing> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Fishing> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -368,9 +373,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -381,9 +386,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_forage_repository.h
+++ b/common/repositories/base/base_forage_repository.h
@@ -141,10 +141,11 @@ public:
 	}
 
 	static Forage FindOne(
+		Database& db,
 		int forage_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -173,10 +174,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int forage_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -189,6 +191,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Forage forage_entry
 	)
 	{
@@ -205,7 +208,7 @@ public:
 		update_values.push_back(columns[7] + " = '" + EscapeString(forage_entry.content_flags) + "'");
 		update_values.push_back(columns[8] + " = '" + EscapeString(forage_entry.content_flags_disabled) + "'");
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -219,6 +222,7 @@ public:
 	}
 
 	static Forage InsertOne(
+		Database& db,
 		Forage forage_entry
 	)
 	{
@@ -252,6 +256,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Forage> forage_entries
 	)
 	{
@@ -274,7 +279,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -285,11 +290,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Forage> All()
+	static std::vector<Forage> All(Database& db)
 	{
 		std::vector<Forage> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -317,11 +322,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Forage> GetWhere(std::string where_filter)
+	static std::vector<Forage> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Forage> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -350,9 +355,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -363,9 +368,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_friends_repository.h
+++ b/common/repositories/base/base_friends_repository.h
@@ -123,10 +123,11 @@ public:
 	}
 
 	static Friends FindOne(
+		Database& db,
 		int friends_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -149,10 +150,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int friends_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -165,6 +167,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Friends friends_entry
 	)
 	{
@@ -176,7 +179,7 @@ public:
 		update_values.push_back(columns[1] + " = " + std::to_string(friends_entry.type));
 		update_values.push_back(columns[2] + " = '" + EscapeString(friends_entry.name) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -190,6 +193,7 @@ public:
 	}
 
 	static Friends InsertOne(
+		Database& db,
 		Friends friends_entry
 	)
 	{
@@ -218,6 +222,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Friends> friends_entries
 	)
 	{
@@ -235,7 +240,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -246,11 +251,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Friends> All()
+	static std::vector<Friends> All(Database& db)
 	{
 		std::vector<Friends> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -272,11 +277,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Friends> GetWhere(std::string where_filter)
+	static std::vector<Friends> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Friends> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -299,9 +304,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -312,9 +317,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_global_loot_repository.h
+++ b/common/repositories/base/base_global_loot_repository.h
@@ -165,10 +165,11 @@ public:
 	}
 
 	static GlobalLoot FindOne(
+		Database& db,
 		int global_loot_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -205,10 +206,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int global_loot_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -221,6 +223,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		GlobalLoot global_loot_entry
 	)
 	{
@@ -245,7 +248,7 @@ public:
 		update_values.push_back(columns[15] + " = '" + EscapeString(global_loot_entry.content_flags) + "'");
 		update_values.push_back(columns[16] + " = '" + EscapeString(global_loot_entry.content_flags_disabled) + "'");
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -259,6 +262,7 @@ public:
 	}
 
 	static GlobalLoot InsertOne(
+		Database& db,
 		GlobalLoot global_loot_entry
 	)
 	{
@@ -300,6 +304,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<GlobalLoot> global_loot_entries
 	)
 	{
@@ -330,7 +335,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -341,11 +346,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<GlobalLoot> All()
+	static std::vector<GlobalLoot> All(Database& db)
 	{
 		std::vector<GlobalLoot> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -381,11 +386,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<GlobalLoot> GetWhere(std::string where_filter)
+	static std::vector<GlobalLoot> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<GlobalLoot> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -422,9 +427,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -435,9 +440,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_gm_ips_repository.h
+++ b/common/repositories/base/base_gm_ips_repository.h
@@ -123,10 +123,11 @@ public:
 	}
 
 	static GmIps FindOne(
+		Database& db,
 		int gm_ips_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -149,10 +150,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int gm_ips_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -165,6 +167,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		GmIps gm_ips_entry
 	)
 	{
@@ -176,7 +179,7 @@ public:
 		update_values.push_back(columns[1] + " = " + std::to_string(gm_ips_entry.account_id));
 		update_values.push_back(columns[2] + " = '" + EscapeString(gm_ips_entry.ip_address) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -190,6 +193,7 @@ public:
 	}
 
 	static GmIps InsertOne(
+		Database& db,
 		GmIps gm_ips_entry
 	)
 	{
@@ -218,6 +222,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<GmIps> gm_ips_entries
 	)
 	{
@@ -235,7 +240,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -246,11 +251,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<GmIps> All()
+	static std::vector<GmIps> All(Database& db)
 	{
 		std::vector<GmIps> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -272,11 +277,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<GmIps> GetWhere(std::string where_filter)
+	static std::vector<GmIps> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<GmIps> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -299,9 +304,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -312,9 +317,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_goallists_repository.h
+++ b/common/repositories/base/base_goallists_repository.h
@@ -120,10 +120,11 @@ public:
 	}
 
 	static Goallists FindOne(
+		Database& db,
 		int goallists_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -145,10 +146,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int goallists_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -161,6 +163,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Goallists goallists_entry
 	)
 	{
@@ -171,7 +174,7 @@ public:
 		update_values.push_back(columns[0] + " = " + std::to_string(goallists_entry.listid));
 		update_values.push_back(columns[1] + " = " + std::to_string(goallists_entry.entry));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -185,6 +188,7 @@ public:
 	}
 
 	static Goallists InsertOne(
+		Database& db,
 		Goallists goallists_entry
 	)
 	{
@@ -212,6 +216,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Goallists> goallists_entries
 	)
 	{
@@ -228,7 +233,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -239,11 +244,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Goallists> All()
+	static std::vector<Goallists> All(Database& db)
 	{
 		std::vector<Goallists> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -264,11 +269,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Goallists> GetWhere(std::string where_filter)
+	static std::vector<Goallists> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Goallists> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -290,9 +295,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -303,9 +308,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_graveyard_repository.h
+++ b/common/repositories/base/base_graveyard_repository.h
@@ -132,10 +132,11 @@ public:
 	}
 
 	static Graveyard FindOne(
+		Database& db,
 		int graveyard_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -161,10 +162,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int graveyard_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -177,6 +179,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Graveyard graveyard_entry
 	)
 	{
@@ -190,7 +193,7 @@ public:
 		update_values.push_back(columns[4] + " = " + std::to_string(graveyard_entry.z));
 		update_values.push_back(columns[5] + " = " + std::to_string(graveyard_entry.heading));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -204,6 +207,7 @@ public:
 	}
 
 	static Graveyard InsertOne(
+		Database& db,
 		Graveyard graveyard_entry
 	)
 	{
@@ -234,6 +238,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Graveyard> graveyard_entries
 	)
 	{
@@ -253,7 +258,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -264,11 +269,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Graveyard> All()
+	static std::vector<Graveyard> All(Database& db)
 	{
 		std::vector<Graveyard> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -293,11 +298,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Graveyard> GetWhere(std::string where_filter)
+	static std::vector<Graveyard> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Graveyard> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -323,9 +328,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -336,9 +341,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_ground_spawns_repository.h
+++ b/common/repositories/base/base_ground_spawns_repository.h
@@ -168,10 +168,11 @@ public:
 	}
 
 	static GroundSpawns FindOne(
+		Database& db,
 		int ground_spawns_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -209,10 +210,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int ground_spawns_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -225,6 +227,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		GroundSpawns ground_spawns_entry
 	)
 	{
@@ -250,7 +253,7 @@ public:
 		update_values.push_back(columns[16] + " = '" + EscapeString(ground_spawns_entry.content_flags) + "'");
 		update_values.push_back(columns[17] + " = '" + EscapeString(ground_spawns_entry.content_flags_disabled) + "'");
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -264,6 +267,7 @@ public:
 	}
 
 	static GroundSpawns InsertOne(
+		Database& db,
 		GroundSpawns ground_spawns_entry
 	)
 	{
@@ -306,6 +310,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<GroundSpawns> ground_spawns_entries
 	)
 	{
@@ -337,7 +342,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -348,11 +353,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<GroundSpawns> All()
+	static std::vector<GroundSpawns> All(Database& db)
 	{
 		std::vector<GroundSpawns> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -389,11 +394,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<GroundSpawns> GetWhere(std::string where_filter)
+	static std::vector<GroundSpawns> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<GroundSpawns> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -431,9 +436,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -444,9 +449,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_group_id_repository.h
+++ b/common/repositories/base/base_group_id_repository.h
@@ -126,10 +126,11 @@ public:
 	}
 
 	static GroupId FindOne(
+		Database& db,
 		int group_id_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -153,10 +154,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int group_id_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -169,6 +171,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		GroupId group_id_entry
 	)
 	{
@@ -181,7 +184,7 @@ public:
 		update_values.push_back(columns[2] + " = '" + EscapeString(group_id_entry.name) + "'");
 		update_values.push_back(columns[3] + " = " + std::to_string(group_id_entry.ismerc));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -195,6 +198,7 @@ public:
 	}
 
 	static GroupId InsertOne(
+		Database& db,
 		GroupId group_id_entry
 	)
 	{
@@ -224,6 +228,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<GroupId> group_id_entries
 	)
 	{
@@ -242,7 +247,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -253,11 +258,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<GroupId> All()
+	static std::vector<GroupId> All(Database& db)
 	{
 		std::vector<GroupId> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -280,11 +285,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<GroupId> GetWhere(std::string where_filter)
+	static std::vector<GroupId> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<GroupId> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -308,9 +313,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -321,9 +326,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_group_leaders_repository.h
+++ b/common/repositories/base/base_group_leaders_repository.h
@@ -141,10 +141,11 @@ public:
 	}
 
 	static GroupLeaders FindOne(
+		Database& db,
 		int group_leaders_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -173,10 +174,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int group_leaders_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -189,6 +191,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		GroupLeaders group_leaders_entry
 	)
 	{
@@ -206,7 +209,7 @@ public:
 		update_values.push_back(columns[7] + " = '" + EscapeString(group_leaders_entry.mentoree) + "'");
 		update_values.push_back(columns[8] + " = " + std::to_string(group_leaders_entry.mentor_percent));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -220,6 +223,7 @@ public:
 	}
 
 	static GroupLeaders InsertOne(
+		Database& db,
 		GroupLeaders group_leaders_entry
 	)
 	{
@@ -254,6 +258,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<GroupLeaders> group_leaders_entries
 	)
 	{
@@ -277,7 +282,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -288,11 +293,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<GroupLeaders> All()
+	static std::vector<GroupLeaders> All(Database& db)
 	{
 		std::vector<GroupLeaders> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -320,11 +325,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<GroupLeaders> GetWhere(std::string where_filter)
+	static std::vector<GroupLeaders> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<GroupLeaders> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -353,9 +358,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -366,9 +371,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_guild_members_repository.h
+++ b/common/repositories/base/base_guild_members_repository.h
@@ -141,10 +141,11 @@ public:
 	}
 
 	static GuildMembers FindOne(
+		Database& db,
 		int guild_members_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -173,10 +174,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int guild_members_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -189,6 +191,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		GuildMembers guild_members_entry
 	)
 	{
@@ -206,7 +209,7 @@ public:
 		update_values.push_back(columns[7] + " = '" + EscapeString(guild_members_entry.public_note) + "'");
 		update_values.push_back(columns[8] + " = " + std::to_string(guild_members_entry.alt));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -220,6 +223,7 @@ public:
 	}
 
 	static GuildMembers InsertOne(
+		Database& db,
 		GuildMembers guild_members_entry
 	)
 	{
@@ -254,6 +258,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<GuildMembers> guild_members_entries
 	)
 	{
@@ -277,7 +282,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -288,11 +293,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<GuildMembers> All()
+	static std::vector<GuildMembers> All(Database& db)
 	{
 		std::vector<GuildMembers> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -320,11 +325,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<GuildMembers> GetWhere(std::string where_filter)
+	static std::vector<GuildMembers> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<GuildMembers> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -353,9 +358,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -366,9 +371,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_guild_ranks_repository.h
+++ b/common/repositories/base/base_guild_ranks_repository.h
@@ -147,10 +147,11 @@ public:
 	}
 
 	static GuildRanks FindOne(
+		Database& db,
 		int guild_ranks_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -181,10 +182,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int guild_ranks_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -197,6 +199,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		GuildRanks guild_ranks_entry
 	)
 	{
@@ -216,7 +219,7 @@ public:
 		update_values.push_back(columns[9] + " = " + std::to_string(guild_ranks_entry.can_motd));
 		update_values.push_back(columns[10] + " = " + std::to_string(guild_ranks_entry.can_warpeace));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -230,6 +233,7 @@ public:
 	}
 
 	static GuildRanks InsertOne(
+		Database& db,
 		GuildRanks guild_ranks_entry
 	)
 	{
@@ -266,6 +270,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<GuildRanks> guild_ranks_entries
 	)
 	{
@@ -291,7 +296,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -302,11 +307,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<GuildRanks> All()
+	static std::vector<GuildRanks> All(Database& db)
 	{
 		std::vector<GuildRanks> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -336,11 +341,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<GuildRanks> GetWhere(std::string where_filter)
+	static std::vector<GuildRanks> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<GuildRanks> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -371,9 +376,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -384,9 +389,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_guild_relations_repository.h
+++ b/common/repositories/base/base_guild_relations_repository.h
@@ -123,10 +123,11 @@ public:
 	}
 
 	static GuildRelations FindOne(
+		Database& db,
 		int guild_relations_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -149,10 +150,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int guild_relations_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -165,6 +167,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		GuildRelations guild_relations_entry
 	)
 	{
@@ -176,7 +179,7 @@ public:
 		update_values.push_back(columns[1] + " = " + std::to_string(guild_relations_entry.guild2));
 		update_values.push_back(columns[2] + " = " + std::to_string(guild_relations_entry.relation));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -190,6 +193,7 @@ public:
 	}
 
 	static GuildRelations InsertOne(
+		Database& db,
 		GuildRelations guild_relations_entry
 	)
 	{
@@ -218,6 +222,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<GuildRelations> guild_relations_entries
 	)
 	{
@@ -235,7 +240,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -246,11 +251,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<GuildRelations> All()
+	static std::vector<GuildRelations> All(Database& db)
 	{
 		std::vector<GuildRelations> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -272,11 +277,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<GuildRelations> GetWhere(std::string where_filter)
+	static std::vector<GuildRelations> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<GuildRelations> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -299,9 +304,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -312,9 +317,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_guilds_repository.h
+++ b/common/repositories/base/base_guilds_repository.h
@@ -141,10 +141,11 @@ public:
 	}
 
 	static Guilds FindOne(
+		Database& db,
 		int guilds_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -173,10 +174,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int guilds_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -189,6 +191,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Guilds guilds_entry
 	)
 	{
@@ -205,7 +208,7 @@ public:
 		update_values.push_back(columns[7] + " = '" + EscapeString(guilds_entry.channel) + "'");
 		update_values.push_back(columns[8] + " = '" + EscapeString(guilds_entry.url) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -219,6 +222,7 @@ public:
 	}
 
 	static Guilds InsertOne(
+		Database& db,
 		Guilds guilds_entry
 	)
 	{
@@ -252,6 +256,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Guilds> guilds_entries
 	)
 	{
@@ -274,7 +279,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -285,11 +290,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Guilds> All()
+	static std::vector<Guilds> All(Database& db)
 	{
 		std::vector<Guilds> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -317,11 +322,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Guilds> GetWhere(std::string where_filter)
+	static std::vector<Guilds> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Guilds> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -350,9 +355,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -363,9 +368,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_hackers_repository.h
+++ b/common/repositories/base/base_hackers_repository.h
@@ -132,10 +132,11 @@ public:
 	}
 
 	static Hackers FindOne(
+		Database& db,
 		int hackers_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -161,10 +162,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int hackers_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -177,6 +179,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Hackers hackers_entry
 	)
 	{
@@ -190,7 +193,7 @@ public:
 		update_values.push_back(columns[4] + " = '" + EscapeString(hackers_entry.zone) + "'");
 		update_values.push_back(columns[5] + " = '" + EscapeString(hackers_entry.date) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -204,6 +207,7 @@ public:
 	}
 
 	static Hackers InsertOne(
+		Database& db,
 		Hackers hackers_entry
 	)
 	{
@@ -234,6 +238,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Hackers> hackers_entries
 	)
 	{
@@ -253,7 +258,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -264,11 +269,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Hackers> All()
+	static std::vector<Hackers> All(Database& db)
 	{
 		std::vector<Hackers> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -293,11 +298,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Hackers> GetWhere(std::string where_filter)
+	static std::vector<Hackers> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Hackers> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -323,9 +328,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -336,9 +341,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_instance_list_player_repository.h
+++ b/common/repositories/base/base_instance_list_player_repository.h
@@ -120,10 +120,11 @@ public:
 	}
 
 	static InstanceListPlayer FindOne(
+		Database& db,
 		int instance_list_player_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -145,10 +146,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int instance_list_player_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -161,6 +163,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		InstanceListPlayer instance_list_player_entry
 	)
 	{
@@ -171,7 +174,7 @@ public:
 		update_values.push_back(columns[0] + " = " + std::to_string(instance_list_player_entry.id));
 		update_values.push_back(columns[1] + " = " + std::to_string(instance_list_player_entry.charid));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -185,6 +188,7 @@ public:
 	}
 
 	static InstanceListPlayer InsertOne(
+		Database& db,
 		InstanceListPlayer instance_list_player_entry
 	)
 	{
@@ -212,6 +216,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<InstanceListPlayer> instance_list_player_entries
 	)
 	{
@@ -228,7 +233,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -239,11 +244,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<InstanceListPlayer> All()
+	static std::vector<InstanceListPlayer> All(Database& db)
 	{
 		std::vector<InstanceListPlayer> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -264,11 +269,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<InstanceListPlayer> GetWhere(std::string where_filter)
+	static std::vector<InstanceListPlayer> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<InstanceListPlayer> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -290,9 +295,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -303,9 +308,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_instance_list_repository.h
+++ b/common/repositories/base/base_instance_list_repository.h
@@ -135,10 +135,11 @@ public:
 	}
 
 	static InstanceList FindOne(
+		Database& db,
 		int instance_list_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -165,10 +166,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int instance_list_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -181,6 +183,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		InstanceList instance_list_entry
 	)
 	{
@@ -195,7 +198,7 @@ public:
 		update_values.push_back(columns[5] + " = " + std::to_string(instance_list_entry.duration));
 		update_values.push_back(columns[6] + " = " + std::to_string(instance_list_entry.never_expires));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -209,6 +212,7 @@ public:
 	}
 
 	static InstanceList InsertOne(
+		Database& db,
 		InstanceList instance_list_entry
 	)
 	{
@@ -240,6 +244,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<InstanceList> instance_list_entries
 	)
 	{
@@ -260,7 +265,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -271,11 +276,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<InstanceList> All()
+	static std::vector<InstanceList> All(Database& db)
 	{
 		std::vector<InstanceList> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -301,11 +306,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<InstanceList> GetWhere(std::string where_filter)
+	static std::vector<InstanceList> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<InstanceList> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -332,9 +337,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -345,9 +350,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_inventory_repository.h
+++ b/common/repositories/base/base_inventory_repository.h
@@ -162,10 +162,11 @@ public:
 	}
 
 	static Inventory FindOne(
+		Database& db,
 		int inventory_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -201,10 +202,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int inventory_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -217,6 +219,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Inventory inventory_entry
 	)
 	{
@@ -241,7 +244,7 @@ public:
 		update_values.push_back(columns[14] + " = " + std::to_string(inventory_entry.ornamentidfile));
 		update_values.push_back(columns[15] + " = " + std::to_string(inventory_entry.ornament_hero_model));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -255,6 +258,7 @@ public:
 	}
 
 	static Inventory InsertOne(
+		Database& db,
 		Inventory inventory_entry
 	)
 	{
@@ -296,6 +300,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Inventory> inventory_entries
 	)
 	{
@@ -326,7 +331,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -337,11 +342,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Inventory> All()
+	static std::vector<Inventory> All(Database& db)
 	{
 		std::vector<Inventory> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -376,11 +381,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Inventory> GetWhere(std::string where_filter)
+	static std::vector<Inventory> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Inventory> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -416,9 +421,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -429,9 +434,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_inventory_snapshots_repository.h
+++ b/common/repositories/base/base_inventory_snapshots_repository.h
@@ -165,10 +165,11 @@ public:
 	}
 
 	static InventorySnapshots FindOne(
+		Database& db,
 		int inventory_snapshots_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -205,10 +206,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int inventory_snapshots_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -221,6 +223,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		InventorySnapshots inventory_snapshots_entry
 	)
 	{
@@ -246,7 +249,7 @@ public:
 		update_values.push_back(columns[15] + " = " + std::to_string(inventory_snapshots_entry.ornamentidfile));
 		update_values.push_back(columns[16] + " = " + std::to_string(inventory_snapshots_entry.ornament_hero_model));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -260,6 +263,7 @@ public:
 	}
 
 	static InventorySnapshots InsertOne(
+		Database& db,
 		InventorySnapshots inventory_snapshots_entry
 	)
 	{
@@ -302,6 +306,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<InventorySnapshots> inventory_snapshots_entries
 	)
 	{
@@ -333,7 +338,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -344,11 +349,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<InventorySnapshots> All()
+	static std::vector<InventorySnapshots> All(Database& db)
 	{
 		std::vector<InventorySnapshots> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -384,11 +389,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<InventorySnapshots> GetWhere(std::string where_filter)
+	static std::vector<InventorySnapshots> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<InventorySnapshots> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -425,9 +430,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -438,9 +443,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_ip_exemptions_repository.h
+++ b/common/repositories/base/base_ip_exemptions_repository.h
@@ -123,10 +123,11 @@ public:
 	}
 
 	static IpExemptions FindOne(
+		Database& db,
 		int ip_exemptions_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -149,10 +150,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int ip_exemptions_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -165,6 +167,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		IpExemptions ip_exemptions_entry
 	)
 	{
@@ -175,7 +178,7 @@ public:
 		update_values.push_back(columns[1] + " = '" + EscapeString(ip_exemptions_entry.exemption_ip) + "'");
 		update_values.push_back(columns[2] + " = " + std::to_string(ip_exemptions_entry.exemption_amount));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -189,6 +192,7 @@ public:
 	}
 
 	static IpExemptions InsertOne(
+		Database& db,
 		IpExemptions ip_exemptions_entry
 	)
 	{
@@ -216,6 +220,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<IpExemptions> ip_exemptions_entries
 	)
 	{
@@ -232,7 +237,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -243,11 +248,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<IpExemptions> All()
+	static std::vector<IpExemptions> All(Database& db)
 	{
 		std::vector<IpExemptions> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -269,11 +274,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<IpExemptions> GetWhere(std::string where_filter)
+	static std::vector<IpExemptions> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<IpExemptions> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -296,9 +301,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -309,9 +314,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_item_tick_repository.h
+++ b/common/repositories/base/base_item_tick_repository.h
@@ -132,10 +132,11 @@ public:
 	}
 
 	static ItemTick FindOne(
+		Database& db,
 		int item_tick_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -161,10 +162,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int item_tick_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -177,6 +179,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		ItemTick item_tick_entry
 	)
 	{
@@ -190,7 +193,7 @@ public:
 		update_values.push_back(columns[4] + " = '" + EscapeString(item_tick_entry.it_qglobal) + "'");
 		update_values.push_back(columns[5] + " = " + std::to_string(item_tick_entry.it_bagslot));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -204,6 +207,7 @@ public:
 	}
 
 	static ItemTick InsertOne(
+		Database& db,
 		ItemTick item_tick_entry
 	)
 	{
@@ -234,6 +238,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<ItemTick> item_tick_entries
 	)
 	{
@@ -253,7 +258,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -264,11 +269,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<ItemTick> All()
+	static std::vector<ItemTick> All(Database& db)
 	{
 		std::vector<ItemTick> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -293,11 +298,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<ItemTick> GetWhere(std::string where_filter)
+	static std::vector<ItemTick> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<ItemTick> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -323,9 +328,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -336,9 +341,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_items_repository.h
+++ b/common/repositories/base/base_items_repository.h
@@ -969,10 +969,11 @@ public:
 	}
 
 	static Items FindOne(
+		Database& db,
 		int items_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -1277,10 +1278,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int items_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -1293,6 +1295,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Items items_entry
 	)
 	{
@@ -1586,7 +1589,7 @@ public:
 		update_values.push_back(columns[283] + " = " + std::to_string(items_entry.UNK241));
 		update_values.push_back(columns[284] + " = " + std::to_string(items_entry.epicitem));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -1600,6 +1603,7 @@ public:
 	}
 
 	static Items InsertOne(
+		Database& db,
 		Items items_entry
 	)
 	{
@@ -1910,6 +1914,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Items> items_entries
 	)
 	{
@@ -2209,7 +2214,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -2220,11 +2225,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Items> All()
+	static std::vector<Items> All(Database& db)
 	{
 		std::vector<Items> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -2528,11 +2533,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Items> GetWhere(std::string where_filter)
+	static std::vector<Items> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Items> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -2837,9 +2842,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -2850,9 +2855,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_ldon_trap_entries_repository.h
+++ b/common/repositories/base/base_ldon_trap_entries_repository.h
@@ -120,10 +120,11 @@ public:
 	}
 
 	static LdonTrapEntries FindOne(
+		Database& db,
 		int ldon_trap_entries_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -145,10 +146,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int ldon_trap_entries_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -161,6 +163,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		LdonTrapEntries ldon_trap_entries_entry
 	)
 	{
@@ -171,7 +174,7 @@ public:
 		update_values.push_back(columns[0] + " = " + std::to_string(ldon_trap_entries_entry.id));
 		update_values.push_back(columns[1] + " = " + std::to_string(ldon_trap_entries_entry.trap_id));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -185,6 +188,7 @@ public:
 	}
 
 	static LdonTrapEntries InsertOne(
+		Database& db,
 		LdonTrapEntries ldon_trap_entries_entry
 	)
 	{
@@ -212,6 +216,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<LdonTrapEntries> ldon_trap_entries_entries
 	)
 	{
@@ -228,7 +233,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -239,11 +244,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<LdonTrapEntries> All()
+	static std::vector<LdonTrapEntries> All(Database& db)
 	{
 		std::vector<LdonTrapEntries> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -264,11 +269,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<LdonTrapEntries> GetWhere(std::string where_filter)
+	static std::vector<LdonTrapEntries> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<LdonTrapEntries> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -290,9 +295,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -303,9 +308,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_ldon_trap_templates_repository.h
+++ b/common/repositories/base/base_ldon_trap_templates_repository.h
@@ -129,10 +129,11 @@ public:
 	}
 
 	static LdonTrapTemplates FindOne(
+		Database& db,
 		int ldon_trap_templates_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -157,10 +158,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int ldon_trap_templates_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -173,6 +175,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		LdonTrapTemplates ldon_trap_templates_entry
 	)
 	{
@@ -186,7 +189,7 @@ public:
 		update_values.push_back(columns[3] + " = " + std::to_string(ldon_trap_templates_entry.skill));
 		update_values.push_back(columns[4] + " = " + std::to_string(ldon_trap_templates_entry.locked));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -200,6 +203,7 @@ public:
 	}
 
 	static LdonTrapTemplates InsertOne(
+		Database& db,
 		LdonTrapTemplates ldon_trap_templates_entry
 	)
 	{
@@ -230,6 +234,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<LdonTrapTemplates> ldon_trap_templates_entries
 	)
 	{
@@ -249,7 +254,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -260,11 +265,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<LdonTrapTemplates> All()
+	static std::vector<LdonTrapTemplates> All(Database& db)
 	{
 		std::vector<LdonTrapTemplates> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -288,11 +293,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<LdonTrapTemplates> GetWhere(std::string where_filter)
+	static std::vector<LdonTrapTemplates> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<LdonTrapTemplates> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -317,9 +322,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -330,9 +335,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_level_exp_mods_repository.h
+++ b/common/repositories/base/base_level_exp_mods_repository.h
@@ -123,10 +123,11 @@ public:
 	}
 
 	static LevelExpMods FindOne(
+		Database& db,
 		int level_exp_mods_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -149,10 +150,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int level_exp_mods_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -165,6 +167,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		LevelExpMods level_exp_mods_entry
 	)
 	{
@@ -176,7 +179,7 @@ public:
 		update_values.push_back(columns[1] + " = " + std::to_string(level_exp_mods_entry.exp_mod));
 		update_values.push_back(columns[2] + " = " + std::to_string(level_exp_mods_entry.aa_exp_mod));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -190,6 +193,7 @@ public:
 	}
 
 	static LevelExpMods InsertOne(
+		Database& db,
 		LevelExpMods level_exp_mods_entry
 	)
 	{
@@ -218,6 +222,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<LevelExpMods> level_exp_mods_entries
 	)
 	{
@@ -235,7 +240,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -246,11 +251,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<LevelExpMods> All()
+	static std::vector<LevelExpMods> All(Database& db)
 	{
 		std::vector<LevelExpMods> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -272,11 +277,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<LevelExpMods> GetWhere(std::string where_filter)
+	static std::vector<LevelExpMods> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<LevelExpMods> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -299,9 +304,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -312,9 +317,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_lfguild_repository.h
+++ b/common/repositories/base/base_lfguild_repository.h
@@ -141,10 +141,11 @@ public:
 	}
 
 	static Lfguild FindOne(
+		Database& db,
 		int lfguild_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -173,10 +174,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int lfguild_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -189,6 +191,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Lfguild lfguild_entry
 	)
 	{
@@ -206,7 +209,7 @@ public:
 		update_values.push_back(columns[7] + " = " + std::to_string(lfguild_entry.timezone));
 		update_values.push_back(columns[8] + " = " + std::to_string(lfguild_entry.timeposted));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -220,6 +223,7 @@ public:
 	}
 
 	static Lfguild InsertOne(
+		Database& db,
 		Lfguild lfguild_entry
 	)
 	{
@@ -254,6 +258,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Lfguild> lfguild_entries
 	)
 	{
@@ -277,7 +282,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -288,11 +293,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Lfguild> All()
+	static std::vector<Lfguild> All(Database& db)
 	{
 		std::vector<Lfguild> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -320,11 +325,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Lfguild> GetWhere(std::string where_filter)
+	static std::vector<Lfguild> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Lfguild> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -353,9 +358,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -366,9 +371,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_login_accounts_repository.h
+++ b/common/repositories/base/base_login_accounts_repository.h
@@ -141,10 +141,11 @@ public:
 	}
 
 	static LoginAccounts FindOne(
+		Database& db,
 		int login_accounts_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -173,10 +174,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int login_accounts_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -189,6 +191,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		LoginAccounts login_accounts_entry
 	)
 	{
@@ -206,7 +209,7 @@ public:
 		update_values.push_back(columns[7] + " = '" + EscapeString(login_accounts_entry.created_at) + "'");
 		update_values.push_back(columns[8] + " = '" + EscapeString(login_accounts_entry.updated_at) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -220,6 +223,7 @@ public:
 	}
 
 	static LoginAccounts InsertOne(
+		Database& db,
 		LoginAccounts login_accounts_entry
 	)
 	{
@@ -254,6 +258,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<LoginAccounts> login_accounts_entries
 	)
 	{
@@ -277,7 +282,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -288,11 +293,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<LoginAccounts> All()
+	static std::vector<LoginAccounts> All(Database& db)
 	{
 		std::vector<LoginAccounts> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -320,11 +325,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<LoginAccounts> GetWhere(std::string where_filter)
+	static std::vector<LoginAccounts> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<LoginAccounts> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -353,9 +358,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -366,9 +371,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_login_api_tokens_repository.h
+++ b/common/repositories/base/base_login_api_tokens_repository.h
@@ -132,10 +132,11 @@ public:
 	}
 
 	static LoginApiTokens FindOne(
+		Database& db,
 		int login_api_tokens_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -161,10 +162,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int login_api_tokens_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -177,6 +179,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		LoginApiTokens login_api_tokens_entry
 	)
 	{
@@ -190,7 +193,7 @@ public:
 		update_values.push_back(columns[4] + " = '" + EscapeString(login_api_tokens_entry.created_at) + "'");
 		update_values.push_back(columns[5] + " = '" + EscapeString(login_api_tokens_entry.updated_at) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -204,6 +207,7 @@ public:
 	}
 
 	static LoginApiTokens InsertOne(
+		Database& db,
 		LoginApiTokens login_api_tokens_entry
 	)
 	{
@@ -234,6 +238,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<LoginApiTokens> login_api_tokens_entries
 	)
 	{
@@ -253,7 +258,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -264,11 +269,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<LoginApiTokens> All()
+	static std::vector<LoginApiTokens> All(Database& db)
 	{
 		std::vector<LoginApiTokens> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -293,11 +298,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<LoginApiTokens> GetWhere(std::string where_filter)
+	static std::vector<LoginApiTokens> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<LoginApiTokens> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -323,9 +328,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -336,9 +341,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_login_server_admins_repository.h
+++ b/common/repositories/base/base_login_server_admins_repository.h
@@ -138,10 +138,11 @@ public:
 	}
 
 	static LoginServerAdmins FindOne(
+		Database& db,
 		int login_server_admins_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -169,10 +170,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int login_server_admins_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -185,6 +187,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		LoginServerAdmins login_server_admins_entry
 	)
 	{
@@ -200,7 +203,7 @@ public:
 		update_values.push_back(columns[6] + " = '" + EscapeString(login_server_admins_entry.registration_date) + "'");
 		update_values.push_back(columns[7] + " = '" + EscapeString(login_server_admins_entry.registration_ip_address) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -214,6 +217,7 @@ public:
 	}
 
 	static LoginServerAdmins InsertOne(
+		Database& db,
 		LoginServerAdmins login_server_admins_entry
 	)
 	{
@@ -246,6 +250,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<LoginServerAdmins> login_server_admins_entries
 	)
 	{
@@ -267,7 +272,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -278,11 +283,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<LoginServerAdmins> All()
+	static std::vector<LoginServerAdmins> All(Database& db)
 	{
 		std::vector<LoginServerAdmins> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -309,11 +314,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<LoginServerAdmins> GetWhere(std::string where_filter)
+	static std::vector<LoginServerAdmins> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<LoginServerAdmins> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -341,9 +346,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -354,9 +359,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_login_server_list_types_repository.h
+++ b/common/repositories/base/base_login_server_list_types_repository.h
@@ -120,10 +120,11 @@ public:
 	}
 
 	static LoginServerListTypes FindOne(
+		Database& db,
 		int login_server_list_types_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -145,10 +146,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int login_server_list_types_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -161,6 +163,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		LoginServerListTypes login_server_list_types_entry
 	)
 	{
@@ -171,7 +174,7 @@ public:
 		update_values.push_back(columns[0] + " = " + std::to_string(login_server_list_types_entry.id));
 		update_values.push_back(columns[1] + " = '" + EscapeString(login_server_list_types_entry.description) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -185,6 +188,7 @@ public:
 	}
 
 	static LoginServerListTypes InsertOne(
+		Database& db,
 		LoginServerListTypes login_server_list_types_entry
 	)
 	{
@@ -212,6 +216,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<LoginServerListTypes> login_server_list_types_entries
 	)
 	{
@@ -228,7 +233,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -239,11 +244,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<LoginServerListTypes> All()
+	static std::vector<LoginServerListTypes> All(Database& db)
 	{
 		std::vector<LoginServerListTypes> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -264,11 +269,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<LoginServerListTypes> GetWhere(std::string where_filter)
+	static std::vector<LoginServerListTypes> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<LoginServerListTypes> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -290,9 +295,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -303,9 +308,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_login_world_servers_repository.h
+++ b/common/repositories/base/base_login_world_servers_repository.h
@@ -144,10 +144,11 @@ public:
 	}
 
 	static LoginWorldServers FindOne(
+		Database& db,
 		int login_world_servers_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -177,10 +178,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int login_world_servers_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -193,6 +195,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		LoginWorldServers login_world_servers_entry
 	)
 	{
@@ -210,7 +213,7 @@ public:
 		update_values.push_back(columns[8] + " = " + std::to_string(login_world_servers_entry.is_server_trusted));
 		update_values.push_back(columns[9] + " = '" + EscapeString(login_world_servers_entry.note) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -224,6 +227,7 @@ public:
 	}
 
 	static LoginWorldServers InsertOne(
+		Database& db,
 		LoginWorldServers login_world_servers_entry
 	)
 	{
@@ -258,6 +262,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<LoginWorldServers> login_world_servers_entries
 	)
 	{
@@ -281,7 +286,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -292,11 +297,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<LoginWorldServers> All()
+	static std::vector<LoginWorldServers> All(Database& db)
 	{
 		std::vector<LoginWorldServers> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -325,11 +330,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<LoginWorldServers> GetWhere(std::string where_filter)
+	static std::vector<LoginWorldServers> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<LoginWorldServers> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -359,9 +364,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -372,9 +377,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_logsys_categories_repository.h
+++ b/common/repositories/base/base_logsys_categories_repository.h
@@ -129,10 +129,11 @@ public:
 	}
 
 	static LogsysCategories FindOne(
+		Database& db,
 		int logsys_categories_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -157,10 +158,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int logsys_categories_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -173,6 +175,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		LogsysCategories logsys_categories_entry
 	)
 	{
@@ -186,7 +189,7 @@ public:
 		update_values.push_back(columns[3] + " = " + std::to_string(logsys_categories_entry.log_to_file));
 		update_values.push_back(columns[4] + " = " + std::to_string(logsys_categories_entry.log_to_gmsay));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -200,6 +203,7 @@ public:
 	}
 
 	static LogsysCategories InsertOne(
+		Database& db,
 		LogsysCategories logsys_categories_entry
 	)
 	{
@@ -230,6 +234,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<LogsysCategories> logsys_categories_entries
 	)
 	{
@@ -249,7 +254,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -260,11 +265,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<LogsysCategories> All()
+	static std::vector<LogsysCategories> All(Database& db)
 	{
 		std::vector<LogsysCategories> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -288,11 +293,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<LogsysCategories> GetWhere(std::string where_filter)
+	static std::vector<LogsysCategories> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<LogsysCategories> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -317,9 +322,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -330,9 +335,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_lootdrop_entries_repository.h
+++ b/common/repositories/base/base_lootdrop_entries_repository.h
@@ -147,10 +147,11 @@ public:
 	}
 
 	static LootdropEntries FindOne(
+		Database& db,
 		int lootdrop_entries_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -181,10 +182,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int lootdrop_entries_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -197,6 +199,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		LootdropEntries lootdrop_entries_entry
 	)
 	{
@@ -216,7 +219,7 @@ public:
 		update_values.push_back(columns[9] + " = " + std::to_string(lootdrop_entries_entry.npc_min_level));
 		update_values.push_back(columns[10] + " = " + std::to_string(lootdrop_entries_entry.npc_max_level));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -230,6 +233,7 @@ public:
 	}
 
 	static LootdropEntries InsertOne(
+		Database& db,
 		LootdropEntries lootdrop_entries_entry
 	)
 	{
@@ -266,6 +270,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<LootdropEntries> lootdrop_entries_entries
 	)
 	{
@@ -291,7 +296,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -302,11 +307,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<LootdropEntries> All()
+	static std::vector<LootdropEntries> All(Database& db)
 	{
 		std::vector<LootdropEntries> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -336,11 +341,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<LootdropEntries> GetWhere(std::string where_filter)
+	static std::vector<LootdropEntries> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<LootdropEntries> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -371,9 +376,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -384,9 +389,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_lootdrop_repository.h
+++ b/common/repositories/base/base_lootdrop_repository.h
@@ -132,10 +132,11 @@ public:
 	}
 
 	static Lootdrop FindOne(
+		Database& db,
 		int lootdrop_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -161,10 +162,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int lootdrop_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -177,6 +179,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Lootdrop lootdrop_entry
 	)
 	{
@@ -190,7 +193,7 @@ public:
 		update_values.push_back(columns[4] + " = '" + EscapeString(lootdrop_entry.content_flags) + "'");
 		update_values.push_back(columns[5] + " = '" + EscapeString(lootdrop_entry.content_flags_disabled) + "'");
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -204,6 +207,7 @@ public:
 	}
 
 	static Lootdrop InsertOne(
+		Database& db,
 		Lootdrop lootdrop_entry
 	)
 	{
@@ -234,6 +238,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Lootdrop> lootdrop_entries
 	)
 	{
@@ -253,7 +258,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -264,11 +269,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Lootdrop> All()
+	static std::vector<Lootdrop> All(Database& db)
 	{
 		std::vector<Lootdrop> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -293,11 +298,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Lootdrop> GetWhere(std::string where_filter)
+	static std::vector<Lootdrop> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Lootdrop> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -323,9 +328,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -336,9 +341,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_loottable_entries_repository.h
+++ b/common/repositories/base/base_loottable_entries_repository.h
@@ -132,10 +132,11 @@ public:
 	}
 
 	static LoottableEntries FindOne(
+		Database& db,
 		int loottable_entries_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -161,10 +162,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int loottable_entries_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -177,6 +179,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		LoottableEntries loottable_entries_entry
 	)
 	{
@@ -191,7 +194,7 @@ public:
 		update_values.push_back(columns[4] + " = " + std::to_string(loottable_entries_entry.mindrop));
 		update_values.push_back(columns[5] + " = " + std::to_string(loottable_entries_entry.probability));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -205,6 +208,7 @@ public:
 	}
 
 	static LoottableEntries InsertOne(
+		Database& db,
 		LoottableEntries loottable_entries_entry
 	)
 	{
@@ -236,6 +240,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<LoottableEntries> loottable_entries_entries
 	)
 	{
@@ -256,7 +261,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -267,11 +272,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<LoottableEntries> All()
+	static std::vector<LoottableEntries> All(Database& db)
 	{
 		std::vector<LoottableEntries> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -296,11 +301,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<LoottableEntries> GetWhere(std::string where_filter)
+	static std::vector<LoottableEntries> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<LoottableEntries> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -326,9 +331,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -339,9 +344,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_loottable_repository.h
+++ b/common/repositories/base/base_loottable_repository.h
@@ -144,10 +144,11 @@ public:
 	}
 
 	static Loottable FindOne(
+		Database& db,
 		int loottable_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -177,10 +178,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int loottable_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -193,6 +195,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Loottable loottable_entry
 	)
 	{
@@ -210,7 +213,7 @@ public:
 		update_values.push_back(columns[8] + " = '" + EscapeString(loottable_entry.content_flags) + "'");
 		update_values.push_back(columns[9] + " = '" + EscapeString(loottable_entry.content_flags_disabled) + "'");
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -224,6 +227,7 @@ public:
 	}
 
 	static Loottable InsertOne(
+		Database& db,
 		Loottable loottable_entry
 	)
 	{
@@ -258,6 +262,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Loottable> loottable_entries
 	)
 	{
@@ -281,7 +286,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -292,11 +297,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Loottable> All()
+	static std::vector<Loottable> All(Database& db)
 	{
 		std::vector<Loottable> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -325,11 +330,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Loottable> GetWhere(std::string where_filter)
+	static std::vector<Loottable> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Loottable> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -359,9 +364,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -372,9 +377,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_mail_repository.h
+++ b/common/repositories/base/base_mail_repository.h
@@ -138,10 +138,11 @@ public:
 	}
 
 	static Mail FindOne(
+		Database& db,
 		int mail_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -169,10 +170,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int mail_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -185,6 +187,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Mail mail_entry
 	)
 	{
@@ -200,7 +203,7 @@ public:
 		update_values.push_back(columns[6] + " = '" + EscapeString(mail_entry.to) + "'");
 		update_values.push_back(columns[7] + " = " + std::to_string(mail_entry.status));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -214,6 +217,7 @@ public:
 	}
 
 	static Mail InsertOne(
+		Database& db,
 		Mail mail_entry
 	)
 	{
@@ -246,6 +250,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Mail> mail_entries
 	)
 	{
@@ -267,7 +272,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -278,11 +283,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Mail> All()
+	static std::vector<Mail> All(Database& db)
 	{
 		std::vector<Mail> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -309,11 +314,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Mail> GetWhere(std::string where_filter)
+	static std::vector<Mail> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Mail> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -341,9 +346,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -354,9 +359,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_merchantlist_repository.h
+++ b/common/repositories/base/base_merchantlist_repository.h
@@ -150,10 +150,11 @@ public:
 	}
 
 	static Merchantlist FindOne(
+		Database& db,
 		int merchantlist_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -185,10 +186,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int merchantlist_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -201,6 +203,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Merchantlist merchantlist_entry
 	)
 	{
@@ -221,7 +224,7 @@ public:
 		update_values.push_back(columns[10] + " = '" + EscapeString(merchantlist_entry.content_flags) + "'");
 		update_values.push_back(columns[11] + " = '" + EscapeString(merchantlist_entry.content_flags_disabled) + "'");
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -235,6 +238,7 @@ public:
 	}
 
 	static Merchantlist InsertOne(
+		Database& db,
 		Merchantlist merchantlist_entry
 	)
 	{
@@ -272,6 +276,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Merchantlist> merchantlist_entries
 	)
 	{
@@ -298,7 +303,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -309,11 +314,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Merchantlist> All()
+	static std::vector<Merchantlist> All(Database& db)
 	{
 		std::vector<Merchantlist> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -344,11 +349,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Merchantlist> GetWhere(std::string where_filter)
+	static std::vector<Merchantlist> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Merchantlist> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -380,9 +385,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -393,9 +398,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_merchantlist_temp_repository.h
+++ b/common/repositories/base/base_merchantlist_temp_repository.h
@@ -126,10 +126,11 @@ public:
 	}
 
 	static MerchantlistTemp FindOne(
+		Database& db,
 		int merchantlist_temp_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -153,10 +154,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int merchantlist_temp_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -169,6 +171,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		MerchantlistTemp merchantlist_temp_entry
 	)
 	{
@@ -181,7 +184,7 @@ public:
 		update_values.push_back(columns[2] + " = " + std::to_string(merchantlist_temp_entry.itemid));
 		update_values.push_back(columns[3] + " = " + std::to_string(merchantlist_temp_entry.charges));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -195,6 +198,7 @@ public:
 	}
 
 	static MerchantlistTemp InsertOne(
+		Database& db,
 		MerchantlistTemp merchantlist_temp_entry
 	)
 	{
@@ -224,6 +228,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<MerchantlistTemp> merchantlist_temp_entries
 	)
 	{
@@ -242,7 +247,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -253,11 +258,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<MerchantlistTemp> All()
+	static std::vector<MerchantlistTemp> All(Database& db)
 	{
 		std::vector<MerchantlistTemp> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -280,11 +285,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<MerchantlistTemp> GetWhere(std::string where_filter)
+	static std::vector<MerchantlistTemp> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<MerchantlistTemp> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -308,9 +313,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -321,9 +326,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_name_filter_repository.h
+++ b/common/repositories/base/base_name_filter_repository.h
@@ -120,10 +120,11 @@ public:
 	}
 
 	static NameFilter FindOne(
+		Database& db,
 		int name_filter_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -145,10 +146,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int name_filter_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -161,6 +163,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		NameFilter name_filter_entry
 	)
 	{
@@ -170,7 +173,7 @@ public:
 
 		update_values.push_back(columns[1] + " = '" + EscapeString(name_filter_entry.name) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -184,6 +187,7 @@ public:
 	}
 
 	static NameFilter InsertOne(
+		Database& db,
 		NameFilter name_filter_entry
 	)
 	{
@@ -210,6 +214,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<NameFilter> name_filter_entries
 	)
 	{
@@ -225,7 +230,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -236,11 +241,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<NameFilter> All()
+	static std::vector<NameFilter> All(Database& db)
 	{
 		std::vector<NameFilter> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -261,11 +266,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<NameFilter> GetWhere(std::string where_filter)
+	static std::vector<NameFilter> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<NameFilter> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -287,9 +292,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -300,9 +305,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_npc_emotes_repository.h
+++ b/common/repositories/base/base_npc_emotes_repository.h
@@ -129,10 +129,11 @@ public:
 	}
 
 	static NpcEmotes FindOne(
+		Database& db,
 		int npc_emotes_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -157,10 +158,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int npc_emotes_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -173,6 +175,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		NpcEmotes npc_emotes_entry
 	)
 	{
@@ -185,7 +188,7 @@ public:
 		update_values.push_back(columns[3] + " = " + std::to_string(npc_emotes_entry.type));
 		update_values.push_back(columns[4] + " = '" + EscapeString(npc_emotes_entry.text) + "'");
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -199,6 +202,7 @@ public:
 	}
 
 	static NpcEmotes InsertOne(
+		Database& db,
 		NpcEmotes npc_emotes_entry
 	)
 	{
@@ -228,6 +232,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<NpcEmotes> npc_emotes_entries
 	)
 	{
@@ -246,7 +251,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -257,11 +262,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<NpcEmotes> All()
+	static std::vector<NpcEmotes> All(Database& db)
 	{
 		std::vector<NpcEmotes> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -285,11 +290,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<NpcEmotes> GetWhere(std::string where_filter)
+	static std::vector<NpcEmotes> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<NpcEmotes> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -314,9 +319,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -327,9 +332,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_npc_faction_entries_repository.h
+++ b/common/repositories/base/base_npc_faction_entries_repository.h
@@ -129,10 +129,11 @@ public:
 	}
 
 	static NpcFactionEntries FindOne(
+		Database& db,
 		int npc_faction_entries_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -157,10 +158,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int npc_faction_entries_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -173,6 +175,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		NpcFactionEntries npc_faction_entries_entry
 	)
 	{
@@ -186,7 +189,7 @@ public:
 		update_values.push_back(columns[3] + " = " + std::to_string(npc_faction_entries_entry.npc_value));
 		update_values.push_back(columns[4] + " = " + std::to_string(npc_faction_entries_entry.temp));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -200,6 +203,7 @@ public:
 	}
 
 	static NpcFactionEntries InsertOne(
+		Database& db,
 		NpcFactionEntries npc_faction_entries_entry
 	)
 	{
@@ -230,6 +234,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<NpcFactionEntries> npc_faction_entries_entries
 	)
 	{
@@ -249,7 +254,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -260,11 +265,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<NpcFactionEntries> All()
+	static std::vector<NpcFactionEntries> All(Database& db)
 	{
 		std::vector<NpcFactionEntries> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -288,11 +293,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<NpcFactionEntries> GetWhere(std::string where_filter)
+	static std::vector<NpcFactionEntries> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<NpcFactionEntries> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -317,9 +322,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -330,9 +335,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_npc_faction_repository.h
+++ b/common/repositories/base/base_npc_faction_repository.h
@@ -126,10 +126,11 @@ public:
 	}
 
 	static NpcFaction FindOne(
+		Database& db,
 		int npc_faction_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -153,10 +154,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int npc_faction_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -169,6 +171,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		NpcFaction npc_faction_entry
 	)
 	{
@@ -180,7 +183,7 @@ public:
 		update_values.push_back(columns[2] + " = " + std::to_string(npc_faction_entry.primaryfaction));
 		update_values.push_back(columns[3] + " = " + std::to_string(npc_faction_entry.ignore_primary_assist));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -194,6 +197,7 @@ public:
 	}
 
 	static NpcFaction InsertOne(
+		Database& db,
 		NpcFaction npc_faction_entry
 	)
 	{
@@ -222,6 +226,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<NpcFaction> npc_faction_entries
 	)
 	{
@@ -239,7 +244,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -250,11 +255,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<NpcFaction> All()
+	static std::vector<NpcFaction> All(Database& db)
 	{
 		std::vector<NpcFaction> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -277,11 +282,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<NpcFaction> GetWhere(std::string where_filter)
+	static std::vector<NpcFaction> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<NpcFaction> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -305,9 +310,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -318,9 +323,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_npc_scale_global_base_repository.h
+++ b/common/repositories/base/base_npc_scale_global_base_repository.h
@@ -198,10 +198,11 @@ public:
 	}
 
 	static NpcScaleGlobalBase FindOne(
+		Database& db,
 		int npc_scale_global_base_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -249,10 +250,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int npc_scale_global_base_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -265,6 +267,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		NpcScaleGlobalBase npc_scale_global_base_entry
 	)
 	{
@@ -301,7 +304,7 @@ public:
 		update_values.push_back(columns[26] + " = " + std::to_string(npc_scale_global_base_entry.heal_scale));
 		update_values.push_back(columns[27] + " = '" + EscapeString(npc_scale_global_base_entry.special_abilities) + "'");
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -315,6 +318,7 @@ public:
 	}
 
 	static NpcScaleGlobalBase InsertOne(
+		Database& db,
 		NpcScaleGlobalBase npc_scale_global_base_entry
 	)
 	{
@@ -368,6 +372,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<NpcScaleGlobalBase> npc_scale_global_base_entries
 	)
 	{
@@ -410,7 +415,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -421,11 +426,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<NpcScaleGlobalBase> All()
+	static std::vector<NpcScaleGlobalBase> All(Database& db)
 	{
 		std::vector<NpcScaleGlobalBase> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -472,11 +477,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<NpcScaleGlobalBase> GetWhere(std::string where_filter)
+	static std::vector<NpcScaleGlobalBase> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<NpcScaleGlobalBase> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -524,9 +529,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -537,9 +542,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_npc_spells_effects_entries_repository.h
+++ b/common/repositories/base/base_npc_spells_effects_entries_repository.h
@@ -138,10 +138,11 @@ public:
 	}
 
 	static NpcSpellsEffectsEntries FindOne(
+		Database& db,
 		int npc_spells_effects_entries_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -169,10 +170,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int npc_spells_effects_entries_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -185,6 +187,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		NpcSpellsEffectsEntries npc_spells_effects_entries_entry
 	)
 	{
@@ -200,7 +203,7 @@ public:
 		update_values.push_back(columns[6] + " = " + std::to_string(npc_spells_effects_entries_entry.se_limit));
 		update_values.push_back(columns[7] + " = " + std::to_string(npc_spells_effects_entries_entry.se_max));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -214,6 +217,7 @@ public:
 	}
 
 	static NpcSpellsEffectsEntries InsertOne(
+		Database& db,
 		NpcSpellsEffectsEntries npc_spells_effects_entries_entry
 	)
 	{
@@ -246,6 +250,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<NpcSpellsEffectsEntries> npc_spells_effects_entries_entries
 	)
 	{
@@ -267,7 +272,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -278,11 +283,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<NpcSpellsEffectsEntries> All()
+	static std::vector<NpcSpellsEffectsEntries> All(Database& db)
 	{
 		std::vector<NpcSpellsEffectsEntries> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -309,11 +314,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<NpcSpellsEffectsEntries> GetWhere(std::string where_filter)
+	static std::vector<NpcSpellsEffectsEntries> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<NpcSpellsEffectsEntries> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -341,9 +346,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -354,9 +359,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_npc_spells_effects_repository.h
+++ b/common/repositories/base/base_npc_spells_effects_repository.h
@@ -123,10 +123,11 @@ public:
 	}
 
 	static NpcSpellsEffects FindOne(
+		Database& db,
 		int npc_spells_effects_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -149,10 +150,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int npc_spells_effects_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -165,6 +167,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		NpcSpellsEffects npc_spells_effects_entry
 	)
 	{
@@ -175,7 +178,7 @@ public:
 		update_values.push_back(columns[1] + " = '" + EscapeString(npc_spells_effects_entry.name) + "'");
 		update_values.push_back(columns[2] + " = " + std::to_string(npc_spells_effects_entry.parent_list));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -189,6 +192,7 @@ public:
 	}
 
 	static NpcSpellsEffects InsertOne(
+		Database& db,
 		NpcSpellsEffects npc_spells_effects_entry
 	)
 	{
@@ -216,6 +220,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<NpcSpellsEffects> npc_spells_effects_entries
 	)
 	{
@@ -232,7 +237,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -243,11 +248,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<NpcSpellsEffects> All()
+	static std::vector<NpcSpellsEffects> All(Database& db)
 	{
 		std::vector<NpcSpellsEffects> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -269,11 +274,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<NpcSpellsEffects> GetWhere(std::string where_filter)
+	static std::vector<NpcSpellsEffects> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<NpcSpellsEffects> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -296,9 +301,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -309,9 +314,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_npc_spells_entries_repository.h
+++ b/common/repositories/base/base_npc_spells_entries_repository.h
@@ -150,10 +150,11 @@ public:
 	}
 
 	static NpcSpellsEntries FindOne(
+		Database& db,
 		int npc_spells_entries_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -185,10 +186,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int npc_spells_entries_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -201,6 +203,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		NpcSpellsEntries npc_spells_entries_entry
 	)
 	{
@@ -220,7 +223,7 @@ public:
 		update_values.push_back(columns[10] + " = " + std::to_string(npc_spells_entries_entry.min_hp));
 		update_values.push_back(columns[11] + " = " + std::to_string(npc_spells_entries_entry.max_hp));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -234,6 +237,7 @@ public:
 	}
 
 	static NpcSpellsEntries InsertOne(
+		Database& db,
 		NpcSpellsEntries npc_spells_entries_entry
 	)
 	{
@@ -270,6 +274,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<NpcSpellsEntries> npc_spells_entries_entries
 	)
 	{
@@ -295,7 +300,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -306,11 +311,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<NpcSpellsEntries> All()
+	static std::vector<NpcSpellsEntries> All(Database& db)
 	{
 		std::vector<NpcSpellsEntries> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -341,11 +346,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<NpcSpellsEntries> GetWhere(std::string where_filter)
+	static std::vector<NpcSpellsEntries> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<NpcSpellsEntries> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -377,9 +382,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -390,9 +395,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_npc_spells_repository.h
+++ b/common/repositories/base/base_npc_spells_repository.h
@@ -177,10 +177,11 @@ public:
 	}
 
 	static NpcSpells FindOne(
+		Database& db,
 		int npc_spells_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -221,10 +222,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int npc_spells_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -237,6 +239,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		NpcSpells npc_spells_entry
 	)
 	{
@@ -265,7 +268,7 @@ public:
 		update_values.push_back(columns[19] + " = " + std::to_string(npc_spells_entry.idle_no_sp_recast_max));
 		update_values.push_back(columns[20] + " = " + std::to_string(npc_spells_entry.idle_b_chance));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -279,6 +282,7 @@ public:
 	}
 
 	static NpcSpells InsertOne(
+		Database& db,
 		NpcSpells npc_spells_entry
 	)
 	{
@@ -324,6 +328,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<NpcSpells> npc_spells_entries
 	)
 	{
@@ -358,7 +363,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -369,11 +374,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<NpcSpells> All()
+	static std::vector<NpcSpells> All(Database& db)
 	{
 		std::vector<NpcSpells> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -413,11 +418,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<NpcSpells> GetWhere(std::string where_filter)
+	static std::vector<NpcSpells> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<NpcSpells> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -458,9 +463,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -471,9 +476,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_npc_types_repository.h
+++ b/common/repositories/base/base_npc_types_repository.h
@@ -480,10 +480,11 @@ public:
 	}
 
 	static NpcTypes FindOne(
+		Database& db,
 		int npc_types_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -625,10 +626,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int npc_types_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -641,6 +643,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		NpcTypes npc_types_entry
 	)
 	{
@@ -770,7 +773,7 @@ public:
 		update_values.push_back(columns[120] + " = " + std::to_string(npc_types_entry.flymode));
 		update_values.push_back(columns[121] + " = " + std::to_string(npc_types_entry.always_aggro));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -784,6 +787,7 @@ public:
 	}
 
 	static NpcTypes InsertOne(
+		Database& db,
 		NpcTypes npc_types_entry
 	)
 	{
@@ -930,6 +934,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<NpcTypes> npc_types_entries
 	)
 	{
@@ -1065,7 +1070,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -1076,11 +1081,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<NpcTypes> All()
+	static std::vector<NpcTypes> All(Database& db)
 	{
 		std::vector<NpcTypes> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -1221,11 +1226,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<NpcTypes> GetWhere(std::string where_filter)
+	static std::vector<NpcTypes> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<NpcTypes> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -1367,9 +1372,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -1380,9 +1385,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_npc_types_tint_repository.h
+++ b/common/repositories/base/base_npc_types_tint_repository.h
@@ -201,10 +201,11 @@ public:
 	}
 
 	static NpcTypesTint FindOne(
+		Database& db,
 		int npc_types_tint_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -253,10 +254,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int npc_types_tint_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -269,6 +271,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		NpcTypesTint npc_types_tint_entry
 	)
 	{
@@ -306,7 +309,7 @@ public:
 		update_values.push_back(columns[27] + " = " + std::to_string(npc_types_tint_entry.grn9x));
 		update_values.push_back(columns[28] + " = " + std::to_string(npc_types_tint_entry.blu9x));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -320,6 +323,7 @@ public:
 	}
 
 	static NpcTypesTint InsertOne(
+		Database& db,
 		NpcTypesTint npc_types_tint_entry
 	)
 	{
@@ -374,6 +378,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<NpcTypesTint> npc_types_tint_entries
 	)
 	{
@@ -417,7 +422,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -428,11 +433,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<NpcTypesTint> All()
+	static std::vector<NpcTypesTint> All(Database& db)
 	{
 		std::vector<NpcTypesTint> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -480,11 +485,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<NpcTypesTint> GetWhere(std::string where_filter)
+	static std::vector<NpcTypesTint> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<NpcTypesTint> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -533,9 +538,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -546,9 +551,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_object_contents_repository.h
+++ b/common/repositories/base/base_object_contents_repository.h
@@ -150,10 +150,11 @@ public:
 	}
 
 	static ObjectContents FindOne(
+		Database& db,
 		int object_contents_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -185,10 +186,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int object_contents_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -201,6 +203,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		ObjectContents object_contents_entry
 	)
 	{
@@ -221,7 +224,7 @@ public:
 		update_values.push_back(columns[10] + " = " + std::to_string(object_contents_entry.augslot5));
 		update_values.push_back(columns[11] + " = " + std::to_string(object_contents_entry.augslot6));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -235,6 +238,7 @@ public:
 	}
 
 	static ObjectContents InsertOne(
+		Database& db,
 		ObjectContents object_contents_entry
 	)
 	{
@@ -272,6 +276,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<ObjectContents> object_contents_entries
 	)
 	{
@@ -298,7 +303,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -309,11 +314,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<ObjectContents> All()
+	static std::vector<ObjectContents> All(Database& db)
 	{
 		std::vector<ObjectContents> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -344,11 +349,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<ObjectContents> GetWhere(std::string where_filter)
+	static std::vector<ObjectContents> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<ObjectContents> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -380,9 +385,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -393,9 +398,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_object_repository.h
+++ b/common/repositories/base/base_object_repository.h
@@ -204,10 +204,11 @@ public:
 	}
 
 	static Object FindOne(
+		Database& db,
 		int object_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -257,10 +258,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int object_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -273,6 +275,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Object object_entry
 	)
 	{
@@ -310,7 +313,7 @@ public:
 		update_values.push_back(columns[28] + " = '" + EscapeString(object_entry.content_flags) + "'");
 		update_values.push_back(columns[29] + " = '" + EscapeString(object_entry.content_flags_disabled) + "'");
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -324,6 +327,7 @@ public:
 	}
 
 	static Object InsertOne(
+		Database& db,
 		Object object_entry
 	)
 	{
@@ -378,6 +382,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Object> object_entries
 	)
 	{
@@ -421,7 +426,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -432,11 +437,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Object> All()
+	static std::vector<Object> All(Database& db)
 	{
 		std::vector<Object> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -485,11 +490,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Object> GetWhere(std::string where_filter)
+	static std::vector<Object> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Object> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -539,9 +544,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -552,9 +557,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_perl_event_export_settings_repository.h
+++ b/common/repositories/base/base_perl_event_export_settings_repository.h
@@ -135,10 +135,11 @@ public:
 	}
 
 	static PerlEventExportSettings FindOne(
+		Database& db,
 		int perl_event_export_settings_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -165,10 +166,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int perl_event_export_settings_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -181,6 +183,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		PerlEventExportSettings perl_event_export_settings_entry
 	)
 	{
@@ -196,7 +199,7 @@ public:
 		update_values.push_back(columns[5] + " = " + std::to_string(perl_event_export_settings_entry.export_item));
 		update_values.push_back(columns[6] + " = " + std::to_string(perl_event_export_settings_entry.export_event));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -210,6 +213,7 @@ public:
 	}
 
 	static PerlEventExportSettings InsertOne(
+		Database& db,
 		PerlEventExportSettings perl_event_export_settings_entry
 	)
 	{
@@ -242,6 +246,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<PerlEventExportSettings> perl_event_export_settings_entries
 	)
 	{
@@ -263,7 +268,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -274,11 +279,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<PerlEventExportSettings> All()
+	static std::vector<PerlEventExportSettings> All(Database& db)
 	{
 		std::vector<PerlEventExportSettings> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -304,11 +309,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<PerlEventExportSettings> GetWhere(std::string where_filter)
+	static std::vector<PerlEventExportSettings> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<PerlEventExportSettings> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -335,9 +340,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -348,9 +353,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_petitions_repository.h
+++ b/common/repositories/base/base_petitions_repository.h
@@ -162,10 +162,11 @@ public:
 	}
 
 	static Petitions FindOne(
+		Database& db,
 		int petitions_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -201,10 +202,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int petitions_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -217,6 +219,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Petitions petitions_entry
 	)
 	{
@@ -240,7 +243,7 @@ public:
 		update_values.push_back(columns[14] + " = " + std::to_string(petitions_entry.ischeckedout));
 		update_values.push_back(columns[15] + " = " + std::to_string(petitions_entry.senttime));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -254,6 +257,7 @@ public:
 	}
 
 	static Petitions InsertOne(
+		Database& db,
 		Petitions petitions_entry
 	)
 	{
@@ -294,6 +298,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Petitions> petitions_entries
 	)
 	{
@@ -323,7 +328,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -334,11 +339,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Petitions> All()
+	static std::vector<Petitions> All(Database& db)
 	{
 		std::vector<Petitions> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -373,11 +378,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Petitions> GetWhere(std::string where_filter)
+	static std::vector<Petitions> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Petitions> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -413,9 +418,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -426,9 +431,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_pets_equipmentset_entries_repository.h
+++ b/common/repositories/base/base_pets_equipmentset_entries_repository.h
@@ -123,10 +123,11 @@ public:
 	}
 
 	static PetsEquipmentsetEntries FindOne(
+		Database& db,
 		int pets_equipmentset_entries_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -149,10 +150,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int pets_equipmentset_entries_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -165,6 +167,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		PetsEquipmentsetEntries pets_equipmentset_entries_entry
 	)
 	{
@@ -176,7 +179,7 @@ public:
 		update_values.push_back(columns[1] + " = " + std::to_string(pets_equipmentset_entries_entry.slot));
 		update_values.push_back(columns[2] + " = " + std::to_string(pets_equipmentset_entries_entry.item_id));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -190,6 +193,7 @@ public:
 	}
 
 	static PetsEquipmentsetEntries InsertOne(
+		Database& db,
 		PetsEquipmentsetEntries pets_equipmentset_entries_entry
 	)
 	{
@@ -218,6 +222,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<PetsEquipmentsetEntries> pets_equipmentset_entries_entries
 	)
 	{
@@ -235,7 +240,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -246,11 +251,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<PetsEquipmentsetEntries> All()
+	static std::vector<PetsEquipmentsetEntries> All(Database& db)
 	{
 		std::vector<PetsEquipmentsetEntries> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -272,11 +277,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<PetsEquipmentsetEntries> GetWhere(std::string where_filter)
+	static std::vector<PetsEquipmentsetEntries> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<PetsEquipmentsetEntries> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -299,9 +304,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -312,9 +317,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_pets_equipmentset_repository.h
+++ b/common/repositories/base/base_pets_equipmentset_repository.h
@@ -123,10 +123,11 @@ public:
 	}
 
 	static PetsEquipmentset FindOne(
+		Database& db,
 		int pets_equipmentset_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -149,10 +150,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int pets_equipmentset_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -165,6 +167,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		PetsEquipmentset pets_equipmentset_entry
 	)
 	{
@@ -176,7 +179,7 @@ public:
 		update_values.push_back(columns[1] + " = '" + EscapeString(pets_equipmentset_entry.setname) + "'");
 		update_values.push_back(columns[2] + " = " + std::to_string(pets_equipmentset_entry.nested_set));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -190,6 +193,7 @@ public:
 	}
 
 	static PetsEquipmentset InsertOne(
+		Database& db,
 		PetsEquipmentset pets_equipmentset_entry
 	)
 	{
@@ -218,6 +222,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<PetsEquipmentset> pets_equipmentset_entries
 	)
 	{
@@ -235,7 +240,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -246,11 +251,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<PetsEquipmentset> All()
+	static std::vector<PetsEquipmentset> All(Database& db)
 	{
 		std::vector<PetsEquipmentset> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -272,11 +277,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<PetsEquipmentset> GetWhere(std::string where_filter)
+	static std::vector<PetsEquipmentset> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<PetsEquipmentset> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -299,9 +304,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -312,9 +317,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_pets_repository.h
+++ b/common/repositories/base/base_pets_repository.h
@@ -138,10 +138,11 @@ public:
 	}
 
 	static Pets FindOne(
+		Database& db,
 		int pets_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -169,10 +170,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int pets_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -185,6 +187,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Pets pets_entry
 	)
 	{
@@ -201,7 +204,7 @@ public:
 		update_values.push_back(columns[6] + " = " + std::to_string(pets_entry.monsterflag));
 		update_values.push_back(columns[7] + " = " + std::to_string(pets_entry.equipmentset));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -215,6 +218,7 @@ public:
 	}
 
 	static Pets InsertOne(
+		Database& db,
 		Pets pets_entry
 	)
 	{
@@ -248,6 +252,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Pets> pets_entries
 	)
 	{
@@ -270,7 +275,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -281,11 +286,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Pets> All()
+	static std::vector<Pets> All(Database& db)
 	{
 		std::vector<Pets> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -312,11 +317,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Pets> GetWhere(std::string where_filter)
+	static std::vector<Pets> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Pets> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -344,9 +349,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -357,9 +362,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_player_titlesets_repository.h
+++ b/common/repositories/base/base_player_titlesets_repository.h
@@ -123,10 +123,11 @@ public:
 	}
 
 	static PlayerTitlesets FindOne(
+		Database& db,
 		int player_titlesets_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -149,10 +150,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int player_titlesets_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -165,6 +167,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		PlayerTitlesets player_titlesets_entry
 	)
 	{
@@ -175,7 +178,7 @@ public:
 		update_values.push_back(columns[1] + " = " + std::to_string(player_titlesets_entry.char_id));
 		update_values.push_back(columns[2] + " = " + std::to_string(player_titlesets_entry.title_set));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -189,6 +192,7 @@ public:
 	}
 
 	static PlayerTitlesets InsertOne(
+		Database& db,
 		PlayerTitlesets player_titlesets_entry
 	)
 	{
@@ -216,6 +220,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<PlayerTitlesets> player_titlesets_entries
 	)
 	{
@@ -232,7 +237,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -243,11 +248,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<PlayerTitlesets> All()
+	static std::vector<PlayerTitlesets> All(Database& db)
 	{
 		std::vector<PlayerTitlesets> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -269,11 +274,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<PlayerTitlesets> GetWhere(std::string where_filter)
+	static std::vector<PlayerTitlesets> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<PlayerTitlesets> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -296,9 +301,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -309,9 +314,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_proximities_repository.h
+++ b/common/repositories/base/base_proximities_repository.h
@@ -138,10 +138,11 @@ public:
 	}
 
 	static Proximities FindOne(
+		Database& db,
 		int proximities_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -169,10 +170,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int proximities_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -185,6 +187,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Proximities proximities_entry
 	)
 	{
@@ -201,7 +204,7 @@ public:
 		update_values.push_back(columns[6] + " = " + std::to_string(proximities_entry.minz));
 		update_values.push_back(columns[7] + " = " + std::to_string(proximities_entry.maxz));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -215,6 +218,7 @@ public:
 	}
 
 	static Proximities InsertOne(
+		Database& db,
 		Proximities proximities_entry
 	)
 	{
@@ -248,6 +252,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Proximities> proximities_entries
 	)
 	{
@@ -270,7 +275,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -281,11 +286,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Proximities> All()
+	static std::vector<Proximities> All(Database& db)
 	{
 		std::vector<Proximities> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -312,11 +317,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Proximities> GetWhere(std::string where_filter)
+	static std::vector<Proximities> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Proximities> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -344,9 +349,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -357,9 +362,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_quest_globals_repository.h
+++ b/common/repositories/base/base_quest_globals_repository.h
@@ -132,10 +132,11 @@ public:
 	}
 
 	static QuestGlobals FindOne(
+		Database& db,
 		int quest_globals_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -161,10 +162,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int quest_globals_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -177,6 +179,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		QuestGlobals quest_globals_entry
 	)
 	{
@@ -191,7 +194,7 @@ public:
 		update_values.push_back(columns[4] + " = '" + EscapeString(quest_globals_entry.value) + "'");
 		update_values.push_back(columns[5] + " = " + std::to_string(quest_globals_entry.expdate));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -205,6 +208,7 @@ public:
 	}
 
 	static QuestGlobals InsertOne(
+		Database& db,
 		QuestGlobals quest_globals_entry
 	)
 	{
@@ -236,6 +240,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<QuestGlobals> quest_globals_entries
 	)
 	{
@@ -256,7 +261,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -267,11 +272,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<QuestGlobals> All()
+	static std::vector<QuestGlobals> All(Database& db)
 	{
 		std::vector<QuestGlobals> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -296,11 +301,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<QuestGlobals> GetWhere(std::string where_filter)
+	static std::vector<QuestGlobals> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<QuestGlobals> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -326,9 +331,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -339,9 +344,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_raid_details_repository.h
+++ b/common/repositories/base/base_raid_details_repository.h
@@ -126,10 +126,11 @@ public:
 	}
 
 	static RaidDetails FindOne(
+		Database& db,
 		int raid_details_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -153,10 +154,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int raid_details_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -169,6 +171,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		RaidDetails raid_details_entry
 	)
 	{
@@ -181,7 +184,7 @@ public:
 		update_values.push_back(columns[2] + " = " + std::to_string(raid_details_entry.locked));
 		update_values.push_back(columns[3] + " = '" + EscapeString(raid_details_entry.motd) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -195,6 +198,7 @@ public:
 	}
 
 	static RaidDetails InsertOne(
+		Database& db,
 		RaidDetails raid_details_entry
 	)
 	{
@@ -224,6 +228,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<RaidDetails> raid_details_entries
 	)
 	{
@@ -242,7 +247,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -253,11 +258,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<RaidDetails> All()
+	static std::vector<RaidDetails> All(Database& db)
 	{
 		std::vector<RaidDetails> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -280,11 +285,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<RaidDetails> GetWhere(std::string where_filter)
+	static std::vector<RaidDetails> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<RaidDetails> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -308,9 +313,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -321,9 +326,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_raid_members_repository.h
+++ b/common/repositories/base/base_raid_members_repository.h
@@ -141,10 +141,11 @@ public:
 	}
 
 	static RaidMembers FindOne(
+		Database& db,
 		int raid_members_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -173,10 +174,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int raid_members_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -189,6 +191,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		RaidMembers raid_members_entry
 	)
 	{
@@ -206,7 +209,7 @@ public:
 		update_values.push_back(columns[7] + " = " + std::to_string(raid_members_entry.israidleader));
 		update_values.push_back(columns[8] + " = " + std::to_string(raid_members_entry.islooter));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -220,6 +223,7 @@ public:
 	}
 
 	static RaidMembers InsertOne(
+		Database& db,
 		RaidMembers raid_members_entry
 	)
 	{
@@ -254,6 +258,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<RaidMembers> raid_members_entries
 	)
 	{
@@ -277,7 +282,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -288,11 +293,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<RaidMembers> All()
+	static std::vector<RaidMembers> All(Database& db)
 	{
 		std::vector<RaidMembers> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -320,11 +325,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<RaidMembers> GetWhere(std::string where_filter)
+	static std::vector<RaidMembers> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<RaidMembers> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -353,9 +358,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -366,9 +371,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_reports_repository.h
+++ b/common/repositories/base/base_reports_repository.h
@@ -126,10 +126,11 @@ public:
 	}
 
 	static Reports FindOne(
+		Database& db,
 		int reports_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -153,10 +154,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int reports_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -169,6 +171,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Reports reports_entry
 	)
 	{
@@ -180,7 +183,7 @@ public:
 		update_values.push_back(columns[2] + " = '" + EscapeString(reports_entry.reported) + "'");
 		update_values.push_back(columns[3] + " = '" + EscapeString(reports_entry.reported_text) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -194,6 +197,7 @@ public:
 	}
 
 	static Reports InsertOne(
+		Database& db,
 		Reports reports_entry
 	)
 	{
@@ -222,6 +226,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Reports> reports_entries
 	)
 	{
@@ -239,7 +244,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -250,11 +255,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Reports> All()
+	static std::vector<Reports> All(Database& db)
 	{
 		std::vector<Reports> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -277,11 +282,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Reports> GetWhere(std::string where_filter)
+	static std::vector<Reports> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Reports> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -305,9 +310,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -318,9 +323,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_respawn_times_repository.h
+++ b/common/repositories/base/base_respawn_times_repository.h
@@ -126,10 +126,11 @@ public:
 	}
 
 	static RespawnTimes FindOne(
+		Database& db,
 		int respawn_times_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -153,10 +154,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int respawn_times_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -169,6 +171,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		RespawnTimes respawn_times_entry
 	)
 	{
@@ -181,7 +184,7 @@ public:
 		update_values.push_back(columns[2] + " = " + std::to_string(respawn_times_entry.duration));
 		update_values.push_back(columns[3] + " = " + std::to_string(respawn_times_entry.instance_id));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -195,6 +198,7 @@ public:
 	}
 
 	static RespawnTimes InsertOne(
+		Database& db,
 		RespawnTimes respawn_times_entry
 	)
 	{
@@ -224,6 +228,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<RespawnTimes> respawn_times_entries
 	)
 	{
@@ -242,7 +247,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -253,11 +258,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<RespawnTimes> All()
+	static std::vector<RespawnTimes> All(Database& db)
 	{
 		std::vector<RespawnTimes> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -280,11 +285,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<RespawnTimes> GetWhere(std::string where_filter)
+	static std::vector<RespawnTimes> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<RespawnTimes> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -308,9 +313,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -321,9 +326,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_rule_sets_repository.h
+++ b/common/repositories/base/base_rule_sets_repository.h
@@ -120,10 +120,11 @@ public:
 	}
 
 	static RuleSets FindOne(
+		Database& db,
 		int rule_sets_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -145,10 +146,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int rule_sets_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -161,6 +163,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		RuleSets rule_sets_entry
 	)
 	{
@@ -170,7 +173,7 @@ public:
 
 		update_values.push_back(columns[1] + " = '" + EscapeString(rule_sets_entry.name) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -184,6 +187,7 @@ public:
 	}
 
 	static RuleSets InsertOne(
+		Database& db,
 		RuleSets rule_sets_entry
 	)
 	{
@@ -210,6 +214,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<RuleSets> rule_sets_entries
 	)
 	{
@@ -225,7 +230,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -236,11 +241,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<RuleSets> All()
+	static std::vector<RuleSets> All(Database& db)
 	{
 		std::vector<RuleSets> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -261,11 +266,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<RuleSets> GetWhere(std::string where_filter)
+	static std::vector<RuleSets> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<RuleSets> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -287,9 +292,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -300,9 +305,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_rule_values_repository.h
+++ b/common/repositories/base/base_rule_values_repository.h
@@ -126,10 +126,11 @@ public:
 	}
 
 	static RuleValues FindOne(
+		Database& db,
 		int rule_values_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -153,10 +154,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int rule_values_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -169,6 +171,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		RuleValues rule_values_entry
 	)
 	{
@@ -181,7 +184,7 @@ public:
 		update_values.push_back(columns[2] + " = '" + EscapeString(rule_values_entry.rule_value) + "'");
 		update_values.push_back(columns[3] + " = '" + EscapeString(rule_values_entry.notes) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -195,6 +198,7 @@ public:
 	}
 
 	static RuleValues InsertOne(
+		Database& db,
 		RuleValues rule_values_entry
 	)
 	{
@@ -224,6 +228,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<RuleValues> rule_values_entries
 	)
 	{
@@ -242,7 +247,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -253,11 +258,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<RuleValues> All()
+	static std::vector<RuleValues> All(Database& db)
 	{
 		std::vector<RuleValues> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -280,11 +285,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<RuleValues> GetWhere(std::string where_filter)
+	static std::vector<RuleValues> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<RuleValues> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -308,9 +313,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -321,9 +326,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_saylink_repository.h
+++ b/common/repositories/base/base_saylink_repository.h
@@ -120,10 +120,11 @@ public:
 	}
 
 	static Saylink FindOne(
+		Database& db,
 		int saylink_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -145,10 +146,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int saylink_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -161,6 +163,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Saylink saylink_entry
 	)
 	{
@@ -170,7 +173,7 @@ public:
 
 		update_values.push_back(columns[1] + " = '" + EscapeString(saylink_entry.phrase) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -184,6 +187,7 @@ public:
 	}
 
 	static Saylink InsertOne(
+		Database& db,
 		Saylink saylink_entry
 	)
 	{
@@ -210,6 +214,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Saylink> saylink_entries
 	)
 	{
@@ -225,7 +230,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -236,11 +241,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Saylink> All()
+	static std::vector<Saylink> All(Database& db)
 	{
 		std::vector<Saylink> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -261,11 +266,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Saylink> GetWhere(std::string where_filter)
+	static std::vector<Saylink> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Saylink> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -287,9 +292,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -300,9 +305,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_skill_caps_repository.h
+++ b/common/repositories/base/base_skill_caps_repository.h
@@ -129,10 +129,11 @@ public:
 	}
 
 	static SkillCaps FindOne(
+		Database& db,
 		int skill_caps_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -157,10 +158,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int skill_caps_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -173,6 +175,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		SkillCaps skill_caps_entry
 	)
 	{
@@ -186,7 +189,7 @@ public:
 		update_values.push_back(columns[3] + " = " + std::to_string(skill_caps_entry.cap));
 		update_values.push_back(columns[4] + " = " + std::to_string(skill_caps_entry.class_));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -200,6 +203,7 @@ public:
 	}
 
 	static SkillCaps InsertOne(
+		Database& db,
 		SkillCaps skill_caps_entry
 	)
 	{
@@ -230,6 +234,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<SkillCaps> skill_caps_entries
 	)
 	{
@@ -249,7 +254,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -260,11 +265,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<SkillCaps> All()
+	static std::vector<SkillCaps> All(Database& db)
 	{
 		std::vector<SkillCaps> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -288,11 +293,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<SkillCaps> GetWhere(std::string where_filter)
+	static std::vector<SkillCaps> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<SkillCaps> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -317,9 +322,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -330,9 +335,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_spawn2_repository.h
+++ b/common/repositories/base/base_spawn2_repository.h
@@ -171,10 +171,11 @@ public:
 	}
 
 	static Spawn2 FindOne(
+		Database& db,
 		int spawn2_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -213,10 +214,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int spawn2_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -229,6 +231,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Spawn2 spawn2_entry
 	)
 	{
@@ -255,7 +258,7 @@ public:
 		update_values.push_back(columns[17] + " = '" + EscapeString(spawn2_entry.content_flags) + "'");
 		update_values.push_back(columns[18] + " = '" + EscapeString(spawn2_entry.content_flags_disabled) + "'");
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -269,6 +272,7 @@ public:
 	}
 
 	static Spawn2 InsertOne(
+		Database& db,
 		Spawn2 spawn2_entry
 	)
 	{
@@ -312,6 +316,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Spawn2> spawn2_entries
 	)
 	{
@@ -344,7 +349,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -355,11 +360,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Spawn2> All()
+	static std::vector<Spawn2> All(Database& db)
 	{
 		std::vector<Spawn2> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -397,11 +402,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Spawn2> GetWhere(std::string where_filter)
+	static std::vector<Spawn2> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Spawn2> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -440,9 +445,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -453,9 +458,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_spawn_condition_values_repository.h
+++ b/common/repositories/base/base_spawn_condition_values_repository.h
@@ -126,10 +126,11 @@ public:
 	}
 
 	static SpawnConditionValues FindOne(
+		Database& db,
 		int spawn_condition_values_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -153,10 +154,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int spawn_condition_values_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -169,6 +171,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		SpawnConditionValues spawn_condition_values_entry
 	)
 	{
@@ -181,7 +184,7 @@ public:
 		update_values.push_back(columns[2] + " = '" + EscapeString(spawn_condition_values_entry.zone) + "'");
 		update_values.push_back(columns[3] + " = " + std::to_string(spawn_condition_values_entry.instance_id));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -195,6 +198,7 @@ public:
 	}
 
 	static SpawnConditionValues InsertOne(
+		Database& db,
 		SpawnConditionValues spawn_condition_values_entry
 	)
 	{
@@ -224,6 +228,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<SpawnConditionValues> spawn_condition_values_entries
 	)
 	{
@@ -242,7 +247,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -253,11 +258,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<SpawnConditionValues> All()
+	static std::vector<SpawnConditionValues> All(Database& db)
 	{
 		std::vector<SpawnConditionValues> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -280,11 +285,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<SpawnConditionValues> GetWhere(std::string where_filter)
+	static std::vector<SpawnConditionValues> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<SpawnConditionValues> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -308,9 +313,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -321,9 +326,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_spawn_conditions_repository.h
+++ b/common/repositories/base/base_spawn_conditions_repository.h
@@ -129,10 +129,11 @@ public:
 	}
 
 	static SpawnConditions FindOne(
+		Database& db,
 		int spawn_conditions_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -157,10 +158,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int spawn_conditions_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -173,6 +175,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		SpawnConditions spawn_conditions_entry
 	)
 	{
@@ -186,7 +189,7 @@ public:
 		update_values.push_back(columns[3] + " = " + std::to_string(spawn_conditions_entry.onchange));
 		update_values.push_back(columns[4] + " = '" + EscapeString(spawn_conditions_entry.name) + "'");
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -200,6 +203,7 @@ public:
 	}
 
 	static SpawnConditions InsertOne(
+		Database& db,
 		SpawnConditions spawn_conditions_entry
 	)
 	{
@@ -230,6 +234,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<SpawnConditions> spawn_conditions_entries
 	)
 	{
@@ -249,7 +254,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -260,11 +265,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<SpawnConditions> All()
+	static std::vector<SpawnConditions> All(Database& db)
 	{
 		std::vector<SpawnConditions> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -288,11 +293,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<SpawnConditions> GetWhere(std::string where_filter)
+	static std::vector<SpawnConditions> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<SpawnConditions> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -317,9 +322,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -330,9 +335,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_spawn_events_repository.h
+++ b/common/repositories/base/base_spawn_events_repository.h
@@ -156,10 +156,11 @@ public:
 	}
 
 	static SpawnEvents FindOne(
+		Database& db,
 		int spawn_events_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -193,10 +194,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int spawn_events_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -209,6 +211,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		SpawnEvents spawn_events_entry
 	)
 	{
@@ -230,7 +233,7 @@ public:
 		update_values.push_back(columns[12] + " = " + std::to_string(spawn_events_entry.argument));
 		update_values.push_back(columns[13] + " = " + std::to_string(spawn_events_entry.strict));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -244,6 +247,7 @@ public:
 	}
 
 	static SpawnEvents InsertOne(
+		Database& db,
 		SpawnEvents spawn_events_entry
 	)
 	{
@@ -282,6 +286,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<SpawnEvents> spawn_events_entries
 	)
 	{
@@ -309,7 +314,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -320,11 +325,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<SpawnEvents> All()
+	static std::vector<SpawnEvents> All(Database& db)
 	{
 		std::vector<SpawnEvents> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -357,11 +362,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<SpawnEvents> GetWhere(std::string where_filter)
+	static std::vector<SpawnEvents> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<SpawnEvents> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -395,9 +400,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -408,9 +413,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_spawnentry_repository.h
+++ b/common/repositories/base/base_spawnentry_repository.h
@@ -126,10 +126,11 @@ public:
 	}
 
 	static Spawnentry FindOne(
+		Database& db,
 		int spawnentry_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -153,10 +154,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int spawnentry_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -169,6 +171,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Spawnentry spawnentry_entry
 	)
 	{
@@ -181,7 +184,7 @@ public:
 		update_values.push_back(columns[2] + " = " + std::to_string(spawnentry_entry.chance));
 		update_values.push_back(columns[3] + " = " + std::to_string(spawnentry_entry.condition_value_filter));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -195,6 +198,7 @@ public:
 	}
 
 	static Spawnentry InsertOne(
+		Database& db,
 		Spawnentry spawnentry_entry
 	)
 	{
@@ -224,6 +228,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Spawnentry> spawnentry_entries
 	)
 	{
@@ -242,7 +247,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -253,11 +258,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Spawnentry> All()
+	static std::vector<Spawnentry> All(Database& db)
 	{
 		std::vector<Spawnentry> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -280,11 +285,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Spawnentry> GetWhere(std::string where_filter)
+	static std::vector<Spawnentry> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Spawnentry> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -308,9 +313,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -321,9 +326,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_spawngroup_repository.h
+++ b/common/repositories/base/base_spawngroup_repository.h
@@ -153,10 +153,11 @@ public:
 	}
 
 	static Spawngroup FindOne(
+		Database& db,
 		int spawngroup_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -189,10 +190,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int spawngroup_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -205,6 +207,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Spawngroup spawngroup_entry
 	)
 	{
@@ -225,7 +228,7 @@ public:
 		update_values.push_back(columns[11] + " = " + std::to_string(spawngroup_entry.despawn_timer));
 		update_values.push_back(columns[12] + " = " + std::to_string(spawngroup_entry.wp_spawns));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -239,6 +242,7 @@ public:
 	}
 
 	static Spawngroup InsertOne(
+		Database& db,
 		Spawngroup spawngroup_entry
 	)
 	{
@@ -276,6 +280,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Spawngroup> spawngroup_entries
 	)
 	{
@@ -302,7 +307,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -313,11 +318,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Spawngroup> All()
+	static std::vector<Spawngroup> All(Database& db)
 	{
 		std::vector<Spawngroup> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -349,11 +354,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Spawngroup> GetWhere(std::string where_filter)
+	static std::vector<Spawngroup> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Spawngroup> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -386,9 +391,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -399,9 +404,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_spell_buckets_repository.h
+++ b/common/repositories/base/base_spell_buckets_repository.h
@@ -123,10 +123,11 @@ public:
 	}
 
 	static SpellBuckets FindOne(
+		Database& db,
 		int spell_buckets_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -149,10 +150,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int spell_buckets_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -165,6 +167,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		SpellBuckets spell_buckets_entry
 	)
 	{
@@ -176,7 +179,7 @@ public:
 		update_values.push_back(columns[1] + " = '" + EscapeString(spell_buckets_entry.key) + "'");
 		update_values.push_back(columns[2] + " = '" + EscapeString(spell_buckets_entry.value) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -190,6 +193,7 @@ public:
 	}
 
 	static SpellBuckets InsertOne(
+		Database& db,
 		SpellBuckets spell_buckets_entry
 	)
 	{
@@ -218,6 +222,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<SpellBuckets> spell_buckets_entries
 	)
 	{
@@ -235,7 +240,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -246,11 +251,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<SpellBuckets> All()
+	static std::vector<SpellBuckets> All(Database& db)
 	{
 		std::vector<SpellBuckets> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -272,11 +277,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<SpellBuckets> GetWhere(std::string where_filter)
+	static std::vector<SpellBuckets> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<SpellBuckets> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -299,9 +304,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -312,9 +317,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_spell_globals_repository.h
+++ b/common/repositories/base/base_spell_globals_repository.h
@@ -126,10 +126,11 @@ public:
 	}
 
 	static SpellGlobals FindOne(
+		Database& db,
 		int spell_globals_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -153,10 +154,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int spell_globals_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -169,6 +171,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		SpellGlobals spell_globals_entry
 	)
 	{
@@ -181,7 +184,7 @@ public:
 		update_values.push_back(columns[2] + " = '" + EscapeString(spell_globals_entry.qglobal) + "'");
 		update_values.push_back(columns[3] + " = '" + EscapeString(spell_globals_entry.value) + "'");
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -195,6 +198,7 @@ public:
 	}
 
 	static SpellGlobals InsertOne(
+		Database& db,
 		SpellGlobals spell_globals_entry
 	)
 	{
@@ -224,6 +228,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<SpellGlobals> spell_globals_entries
 	)
 	{
@@ -242,7 +247,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -253,11 +258,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<SpellGlobals> All()
+	static std::vector<SpellGlobals> All(Database& db)
 	{
 		std::vector<SpellGlobals> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -280,11 +285,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<SpellGlobals> GetWhere(std::string where_filter)
+	static std::vector<SpellGlobals> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<SpellGlobals> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -308,9 +313,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -321,9 +326,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_spells_new_repository.h
+++ b/common/repositories/base/base_spells_new_repository.h
@@ -825,10 +825,11 @@ public:
 	}
 
 	static SpellsNew FindOne(
+		Database& db,
 		int spells_new_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -1085,10 +1086,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int spells_new_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -1101,6 +1103,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		SpellsNew spells_new_entry
 	)
 	{
@@ -1346,7 +1349,7 @@ public:
 		update_values.push_back(columns[235] + " = " + std::to_string(spells_new_entry.field235));
 		update_values.push_back(columns[236] + " = " + std::to_string(spells_new_entry.field236));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -1360,6 +1363,7 @@ public:
 	}
 
 	static SpellsNew InsertOne(
+		Database& db,
 		SpellsNew spells_new_entry
 	)
 	{
@@ -1622,6 +1626,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<SpellsNew> spells_new_entries
 	)
 	{
@@ -1873,7 +1878,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -1884,11 +1889,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<SpellsNew> All()
+	static std::vector<SpellsNew> All(Database& db)
 	{
 		std::vector<SpellsNew> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -2144,11 +2149,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<SpellsNew> GetWhere(std::string where_filter)
+	static std::vector<SpellsNew> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<SpellsNew> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -2405,9 +2410,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -2418,9 +2423,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_start_zones_repository.h
+++ b/common/repositories/base/base_start_zones_repository.h
@@ -171,10 +171,11 @@ public:
 	}
 
 	static StartZones FindOne(
+		Database& db,
 		int start_zones_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -213,10 +214,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int start_zones_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -229,6 +231,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		StartZones start_zones_entry
 	)
 	{
@@ -256,7 +259,7 @@ public:
 		update_values.push_back(columns[17] + " = '" + EscapeString(start_zones_entry.content_flags) + "'");
 		update_values.push_back(columns[18] + " = '" + EscapeString(start_zones_entry.content_flags_disabled) + "'");
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -270,6 +273,7 @@ public:
 	}
 
 	static StartZones InsertOne(
+		Database& db,
 		StartZones start_zones_entry
 	)
 	{
@@ -314,6 +318,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<StartZones> start_zones_entries
 	)
 	{
@@ -347,7 +352,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -358,11 +363,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<StartZones> All()
+	static std::vector<StartZones> All(Database& db)
 	{
 		std::vector<StartZones> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -400,11 +405,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<StartZones> GetWhere(std::string where_filter)
+	static std::vector<StartZones> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<StartZones> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -443,9 +448,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -456,9 +461,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_starting_items_repository.h
+++ b/common/repositories/base/base_starting_items_repository.h
@@ -153,10 +153,11 @@ public:
 	}
 
 	static StartingItems FindOne(
+		Database& db,
 		int starting_items_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -189,10 +190,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int starting_items_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -205,6 +207,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		StartingItems starting_items_entry
 	)
 	{
@@ -225,7 +228,7 @@ public:
 		update_values.push_back(columns[11] + " = '" + EscapeString(starting_items_entry.content_flags) + "'");
 		update_values.push_back(columns[12] + " = '" + EscapeString(starting_items_entry.content_flags_disabled) + "'");
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -239,6 +242,7 @@ public:
 	}
 
 	static StartingItems InsertOne(
+		Database& db,
 		StartingItems starting_items_entry
 	)
 	{
@@ -276,6 +280,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<StartingItems> starting_items_entries
 	)
 	{
@@ -302,7 +307,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -313,11 +318,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<StartingItems> All()
+	static std::vector<StartingItems> All(Database& db)
 	{
 		std::vector<StartingItems> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -349,11 +354,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<StartingItems> GetWhere(std::string where_filter)
+	static std::vector<StartingItems> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<StartingItems> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -386,9 +391,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -399,9 +404,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_task_activities_repository.h
+++ b/common/repositories/base/base_task_activities_repository.h
@@ -159,10 +159,11 @@ public:
 	}
 
 	static TaskActivities FindOne(
+		Database& db,
 		int task_activities_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -197,10 +198,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int task_activities_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -213,6 +215,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		TaskActivities task_activities_entry
 	)
 	{
@@ -236,7 +239,7 @@ public:
 		update_values.push_back(columns[13] + " = '" + EscapeString(task_activities_entry.zones) + "'");
 		update_values.push_back(columns[14] + " = " + std::to_string(task_activities_entry.optional));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -250,6 +253,7 @@ public:
 	}
 
 	static TaskActivities InsertOne(
+		Database& db,
 		TaskActivities task_activities_entry
 	)
 	{
@@ -290,6 +294,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<TaskActivities> task_activities_entries
 	)
 	{
@@ -319,7 +324,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -330,11 +335,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<TaskActivities> All()
+	static std::vector<TaskActivities> All(Database& db)
 	{
 		std::vector<TaskActivities> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -368,11 +373,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<TaskActivities> GetWhere(std::string where_filter)
+	static std::vector<TaskActivities> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<TaskActivities> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -407,9 +412,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -420,9 +425,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_tasks_repository.h
+++ b/common/repositories/base/base_tasks_repository.h
@@ -162,10 +162,11 @@ public:
 	}
 
 	static Tasks FindOne(
+		Database& db,
 		int tasks_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -201,10 +202,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int tasks_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -217,6 +219,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Tasks tasks_entry
 	)
 	{
@@ -241,7 +244,7 @@ public:
 		update_values.push_back(columns[14] + " = " + std::to_string(tasks_entry.faction_reward));
 		update_values.push_back(columns[15] + " = '" + EscapeString(tasks_entry.completion_emote) + "'");
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -255,6 +258,7 @@ public:
 	}
 
 	static Tasks InsertOne(
+		Database& db,
 		Tasks tasks_entry
 	)
 	{
@@ -296,6 +300,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Tasks> tasks_entries
 	)
 	{
@@ -326,7 +331,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -337,11 +342,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Tasks> All()
+	static std::vector<Tasks> All(Database& db)
 	{
 		std::vector<Tasks> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -376,11 +381,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Tasks> GetWhere(std::string where_filter)
+	static std::vector<Tasks> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Tasks> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -416,9 +421,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -429,9 +434,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_tasksets_repository.h
+++ b/common/repositories/base/base_tasksets_repository.h
@@ -120,10 +120,11 @@ public:
 	}
 
 	static Tasksets FindOne(
+		Database& db,
 		int tasksets_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -145,10 +146,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int tasksets_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -161,6 +163,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Tasksets tasksets_entry
 	)
 	{
@@ -171,7 +174,7 @@ public:
 		update_values.push_back(columns[0] + " = " + std::to_string(tasksets_entry.id));
 		update_values.push_back(columns[1] + " = " + std::to_string(tasksets_entry.taskid));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -185,6 +188,7 @@ public:
 	}
 
 	static Tasksets InsertOne(
+		Database& db,
 		Tasksets tasksets_entry
 	)
 	{
@@ -212,6 +216,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Tasksets> tasksets_entries
 	)
 	{
@@ -228,7 +233,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -239,11 +244,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Tasksets> All()
+	static std::vector<Tasksets> All(Database& db)
 	{
 		std::vector<Tasksets> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -264,11 +269,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Tasksets> GetWhere(std::string where_filter)
+	static std::vector<Tasksets> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Tasksets> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -290,9 +295,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -303,9 +308,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_timers_repository.h
+++ b/common/repositories/base/base_timers_repository.h
@@ -129,10 +129,11 @@ public:
 	}
 
 	static Timers FindOne(
+		Database& db,
 		int timers_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -157,10 +158,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int timers_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -173,6 +175,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Timers timers_entry
 	)
 	{
@@ -186,7 +189,7 @@ public:
 		update_values.push_back(columns[3] + " = " + std::to_string(timers_entry.duration));
 		update_values.push_back(columns[4] + " = " + std::to_string(timers_entry.enable));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -200,6 +203,7 @@ public:
 	}
 
 	static Timers InsertOne(
+		Database& db,
 		Timers timers_entry
 	)
 	{
@@ -230,6 +234,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Timers> timers_entries
 	)
 	{
@@ -249,7 +254,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -260,11 +265,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Timers> All()
+	static std::vector<Timers> All(Database& db)
 	{
 		std::vector<Timers> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -288,11 +293,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Timers> GetWhere(std::string where_filter)
+	static std::vector<Timers> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Timers> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -317,9 +322,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -330,9 +335,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_titles_repository.h
+++ b/common/repositories/base/base_titles_repository.h
@@ -156,10 +156,11 @@ public:
 	}
 
 	static Titles FindOne(
+		Database& db,
 		int titles_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -193,10 +194,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int titles_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -209,6 +211,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Titles titles_entry
 	)
 	{
@@ -230,7 +233,7 @@ public:
 		update_values.push_back(columns[12] + " = '" + EscapeString(titles_entry.suffix) + "'");
 		update_values.push_back(columns[13] + " = " + std::to_string(titles_entry.title_set));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -244,6 +247,7 @@ public:
 	}
 
 	static Titles InsertOne(
+		Database& db,
 		Titles titles_entry
 	)
 	{
@@ -282,6 +286,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Titles> titles_entries
 	)
 	{
@@ -309,7 +314,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -320,11 +325,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Titles> All()
+	static std::vector<Titles> All(Database& db)
 	{
 		std::vector<Titles> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -357,11 +362,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Titles> GetWhere(std::string where_filter)
+	static std::vector<Titles> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Titles> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -395,9 +400,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -408,9 +413,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_trader_repository.h
+++ b/common/repositories/base/base_trader_repository.h
@@ -132,10 +132,11 @@ public:
 	}
 
 	static Trader FindOne(
+		Database& db,
 		int trader_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -161,10 +162,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int trader_id
 	)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -177,6 +179,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Trader trader_entry
 	)
 	{
@@ -191,7 +194,7 @@ public:
 		update_values.push_back(columns[4] + " = " + std::to_string(trader_entry.item_cost));
 		update_values.push_back(columns[5] + " = " + std::to_string(trader_entry.slot_id));
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -205,6 +208,7 @@ public:
 	}
 
 	static Trader InsertOne(
+		Database& db,
 		Trader trader_entry
 	)
 	{
@@ -236,6 +240,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Trader> trader_entries
 	)
 	{
@@ -256,7 +261,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -267,11 +272,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Trader> All()
+	static std::vector<Trader> All(Database& db)
 	{
 		std::vector<Trader> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -296,11 +301,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Trader> GetWhere(std::string where_filter)
+	static std::vector<Trader> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Trader> all_entries;
 
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -326,9 +331,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -339,9 +344,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = database.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_tradeskill_recipe_entries_repository.h
+++ b/common/repositories/base/base_tradeskill_recipe_entries_repository.h
@@ -138,10 +138,11 @@ public:
 	}
 
 	static TradeskillRecipeEntries FindOne(
+		Database& db,
 		int tradeskill_recipe_entries_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -169,10 +170,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int tradeskill_recipe_entries_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -185,6 +187,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		TradeskillRecipeEntries tradeskill_recipe_entries_entry
 	)
 	{
@@ -200,7 +203,7 @@ public:
 		update_values.push_back(columns[6] + " = " + std::to_string(tradeskill_recipe_entries_entry.salvagecount));
 		update_values.push_back(columns[7] + " = " + std::to_string(tradeskill_recipe_entries_entry.iscontainer));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -214,6 +217,7 @@ public:
 	}
 
 	static TradeskillRecipeEntries InsertOne(
+		Database& db,
 		TradeskillRecipeEntries tradeskill_recipe_entries_entry
 	)
 	{
@@ -246,6 +250,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<TradeskillRecipeEntries> tradeskill_recipe_entries_entries
 	)
 	{
@@ -267,7 +272,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -278,11 +283,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<TradeskillRecipeEntries> All()
+	static std::vector<TradeskillRecipeEntries> All(Database& db)
 	{
 		std::vector<TradeskillRecipeEntries> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -309,11 +314,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<TradeskillRecipeEntries> GetWhere(std::string where_filter)
+	static std::vector<TradeskillRecipeEntries> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<TradeskillRecipeEntries> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -341,9 +346,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -354,9 +359,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_tradeskill_recipe_repository.h
+++ b/common/repositories/base/base_tradeskill_recipe_repository.h
@@ -159,10 +159,11 @@ public:
 	}
 
 	static TradeskillRecipe FindOne(
+		Database& db,
 		int tradeskill_recipe_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -197,10 +198,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int tradeskill_recipe_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -213,6 +215,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		TradeskillRecipe tradeskill_recipe_entry
 	)
 	{
@@ -235,7 +238,7 @@ public:
 		update_values.push_back(columns[13] + " = '" + EscapeString(tradeskill_recipe_entry.content_flags) + "'");
 		update_values.push_back(columns[14] + " = '" + EscapeString(tradeskill_recipe_entry.content_flags_disabled) + "'");
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -249,6 +252,7 @@ public:
 	}
 
 	static TradeskillRecipe InsertOne(
+		Database& db,
 		TradeskillRecipe tradeskill_recipe_entry
 	)
 	{
@@ -288,6 +292,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<TradeskillRecipe> tradeskill_recipe_entries
 	)
 	{
@@ -316,7 +321,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -327,11 +332,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<TradeskillRecipe> All()
+	static std::vector<TradeskillRecipe> All(Database& db)
 	{
 		std::vector<TradeskillRecipe> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -365,11 +370,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<TradeskillRecipe> GetWhere(std::string where_filter)
+	static std::vector<TradeskillRecipe> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<TradeskillRecipe> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -404,9 +409,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -417,9 +422,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_traps_repository.h
+++ b/common/repositories/base/base_traps_repository.h
@@ -189,10 +189,11 @@ public:
 	}
 
 	static Traps FindOne(
+		Database& db,
 		int traps_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -237,10 +238,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int traps_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -253,6 +255,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Traps traps_entry
 	)
 	{
@@ -285,7 +288,7 @@ public:
 		update_values.push_back(columns[23] + " = '" + EscapeString(traps_entry.content_flags) + "'");
 		update_values.push_back(columns[24] + " = '" + EscapeString(traps_entry.content_flags_disabled) + "'");
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -299,6 +302,7 @@ public:
 	}
 
 	static Traps InsertOne(
+		Database& db,
 		Traps traps_entry
 	)
 	{
@@ -348,6 +352,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Traps> traps_entries
 	)
 	{
@@ -386,7 +391,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -397,11 +402,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Traps> All()
+	static std::vector<Traps> All(Database& db)
 	{
 		std::vector<Traps> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -445,11 +450,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Traps> GetWhere(std::string where_filter)
+	static std::vector<Traps> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Traps> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -494,9 +499,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -507,9 +512,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_tribute_levels_repository.h
+++ b/common/repositories/base/base_tribute_levels_repository.h
@@ -126,10 +126,11 @@ public:
 	}
 
 	static TributeLevels FindOne(
+		Database& db,
 		int tribute_levels_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -153,10 +154,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int tribute_levels_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -169,6 +171,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		TributeLevels tribute_levels_entry
 	)
 	{
@@ -181,7 +184,7 @@ public:
 		update_values.push_back(columns[2] + " = " + std::to_string(tribute_levels_entry.cost));
 		update_values.push_back(columns[3] + " = " + std::to_string(tribute_levels_entry.item_id));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -195,6 +198,7 @@ public:
 	}
 
 	static TributeLevels InsertOne(
+		Database& db,
 		TributeLevels tribute_levels_entry
 	)
 	{
@@ -224,6 +228,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<TributeLevels> tribute_levels_entries
 	)
 	{
@@ -242,7 +247,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -253,11 +258,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<TributeLevels> All()
+	static std::vector<TributeLevels> All(Database& db)
 	{
 		std::vector<TributeLevels> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -280,11 +285,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<TributeLevels> GetWhere(std::string where_filter)
+	static std::vector<TributeLevels> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<TributeLevels> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -308,9 +313,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -321,9 +326,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_tributes_repository.h
+++ b/common/repositories/base/base_tributes_repository.h
@@ -129,10 +129,11 @@ public:
 	}
 
 	static Tributes FindOne(
+		Database& db,
 		int tributes_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -157,10 +158,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int tributes_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -173,6 +175,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Tributes tributes_entry
 	)
 	{
@@ -186,7 +189,7 @@ public:
 		update_values.push_back(columns[3] + " = '" + EscapeString(tributes_entry.descr) + "'");
 		update_values.push_back(columns[4] + " = " + std::to_string(tributes_entry.isguild));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -200,6 +203,7 @@ public:
 	}
 
 	static Tributes InsertOne(
+		Database& db,
 		Tributes tributes_entry
 	)
 	{
@@ -230,6 +234,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Tributes> tributes_entries
 	)
 	{
@@ -249,7 +254,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -260,11 +265,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Tributes> All()
+	static std::vector<Tributes> All(Database& db)
 	{
 		std::vector<Tributes> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -288,11 +293,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Tributes> GetWhere(std::string where_filter)
+	static std::vector<Tributes> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Tributes> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -317,9 +322,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -330,9 +335,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_veteran_reward_templates_repository.h
+++ b/common/repositories/base/base_veteran_reward_templates_repository.h
@@ -129,10 +129,11 @@ public:
 	}
 
 	static VeteranRewardTemplates FindOne(
+		Database& db,
 		int veteran_reward_templates_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -157,10 +158,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int veteran_reward_templates_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -173,6 +175,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		VeteranRewardTemplates veteran_reward_templates_entry
 	)
 	{
@@ -186,7 +189,7 @@ public:
 		update_values.push_back(columns[3] + " = " + std::to_string(veteran_reward_templates_entry.charges));
 		update_values.push_back(columns[4] + " = " + std::to_string(veteran_reward_templates_entry.reward_slot));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -200,6 +203,7 @@ public:
 	}
 
 	static VeteranRewardTemplates InsertOne(
+		Database& db,
 		VeteranRewardTemplates veteran_reward_templates_entry
 	)
 	{
@@ -230,6 +234,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<VeteranRewardTemplates> veteran_reward_templates_entries
 	)
 	{
@@ -249,7 +254,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -260,11 +265,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<VeteranRewardTemplates> All()
+	static std::vector<VeteranRewardTemplates> All(Database& db)
 	{
 		std::vector<VeteranRewardTemplates> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -288,11 +293,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<VeteranRewardTemplates> GetWhere(std::string where_filter)
+	static std::vector<VeteranRewardTemplates> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<VeteranRewardTemplates> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -317,9 +322,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -330,9 +335,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_zone_points_repository.h
+++ b/common/repositories/base/base_zone_points_repository.h
@@ -186,10 +186,11 @@ public:
 	}
 
 	static ZonePoints FindOne(
+		Database& db,
 		int zone_points_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -233,10 +234,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int zone_points_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -249,6 +251,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		ZonePoints zone_points_entry
 	)
 	{
@@ -280,7 +283,7 @@ public:
 		update_values.push_back(columns[22] + " = " + std::to_string(zone_points_entry.height));
 		update_values.push_back(columns[23] + " = " + std::to_string(zone_points_entry.width));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -294,6 +297,7 @@ public:
 	}
 
 	static ZonePoints InsertOne(
+		Database& db,
 		ZonePoints zone_points_entry
 	)
 	{
@@ -342,6 +346,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<ZonePoints> zone_points_entries
 	)
 	{
@@ -379,7 +384,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -390,11 +395,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<ZonePoints> All()
+	static std::vector<ZonePoints> All(Database& db)
 	{
 		std::vector<ZonePoints> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -437,11 +442,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<ZonePoints> GetWhere(std::string where_filter)
+	static std::vector<ZonePoints> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<ZonePoints> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -485,9 +490,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -498,9 +503,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/base/base_zone_repository.h
+++ b/common/repositories/base/base_zone_repository.h
@@ -387,10 +387,11 @@ public:
 	}
 
 	static Zone FindOne(
+		Database& db,
 		int zone_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -501,10 +502,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int zone_id
 	)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -517,6 +519,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		Zone zone_entry
 	)
 	{
@@ -615,7 +618,7 @@ public:
 		update_values.push_back(columns[89] + " = '" + EscapeString(zone_entry.content_flags_disabled) + "'");
 		update_values.push_back(columns[90] + " = " + std::to_string(zone_entry.underworld_teleport_index));
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -629,6 +632,7 @@ public:
 	}
 
 	static Zone InsertOne(
+		Database& db,
 		Zone zone_entry
 	)
 	{
@@ -744,6 +748,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<Zone> zone_entries
 	)
 	{
@@ -848,7 +853,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -859,11 +864,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<Zone> All()
+	static std::vector<Zone> All(Database& db)
 	{
 		std::vector<Zone> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -973,11 +978,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<Zone> GetWhere(std::string where_filter)
+	static std::vector<Zone> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<Zone> all_entries;
 
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -1088,9 +1093,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -1101,9 +1106,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = content_db.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/common/repositories/template/base_repository.template
+++ b/common/repositories/template/base_repository.template
@@ -117,10 +117,11 @@ public:
 	}
 
 	static {{TABLE_NAME_STRUCT}} FindOne(
+		Database& db,
 		int {{TABLE_NAME_VAR}}_id
 	)
 	{
-		auto results = {{DATABASE_CONNECTION}}.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE id = {} LIMIT 1",
 				BaseSelect(),
@@ -140,10 +141,11 @@ public:
 	}
 
 	static int DeleteOne(
+		Database& db,
 		int {{TABLE_NAME_VAR}}_id
 	)
 	{
-		auto results = {{DATABASE_CONNECTION}}.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {} = {}",
 				TableName(),
@@ -156,6 +158,7 @@ public:
 	}
 
 	static int UpdateOne(
+		Database& db,
 		{{TABLE_NAME_STRUCT}} {{TABLE_NAME_VAR}}_entry
 	)
 	{
@@ -165,7 +168,7 @@ public:
 
 {{UPDATE_ONE_ENTRIES}}
 
-		auto results = {{DATABASE_CONNECTION}}.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"UPDATE {} SET {} WHERE {} = {}",
 				TableName(),
@@ -179,6 +182,7 @@ public:
 	}
 
 	static {{TABLE_NAME_STRUCT}} InsertOne(
+		Database& db,
 		{{TABLE_NAME_STRUCT}} {{TABLE_NAME_VAR}}_entry
 	)
 	{
@@ -205,6 +209,7 @@ public:
 	}
 
 	static int InsertMany(
+		Database& db,
 		std::vector<{{TABLE_NAME_STRUCT}}> {{TABLE_NAME_VAR}}_entries
 	)
 	{
@@ -220,7 +225,7 @@ public:
 
 		std::vector<std::string> insert_values;
 
-		auto results = {{DATABASE_CONNECTION}}.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} VALUES {}",
 				BaseInsert(),
@@ -231,11 +236,11 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static std::vector<{{TABLE_NAME_STRUCT}}> All()
+	static std::vector<{{TABLE_NAME_STRUCT}}> All(Database& db)
 	{
 		std::vector<{{TABLE_NAME_STRUCT}}> all_entries;
 
-		auto results = {{DATABASE_CONNECTION}}.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{}",
 				BaseSelect()
@@ -255,11 +260,11 @@ public:
 		return all_entries;
 	}
 
-	static std::vector<{{TABLE_NAME_STRUCT}}> GetWhere(std::string where_filter)
+	static std::vector<{{TABLE_NAME_STRUCT}}> GetWhere(Database& db, std::string where_filter)
 	{
 		std::vector<{{TABLE_NAME_STRUCT}}> all_entries;
 
-		auto results = {{DATABASE_CONNECTION}}.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"{} WHERE {}",
 				BaseSelect(),
@@ -280,9 +285,9 @@ public:
 		return all_entries;
 	}
 
-	static int DeleteWhere(std::string where_filter)
+	static int DeleteWhere(Database& db, std::string where_filter)
 	{
-		auto results = {{DATABASE_CONNECTION}}.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"DELETE FROM {} WHERE {}",
 				TableName(),
@@ -293,9 +298,9 @@ public:
 		return (results.Success() ? results.RowsAffected() : 0);
 	}
 
-	static int Truncate()
+	static int Truncate(Database& db)
 	{
-		auto results = {{DATABASE_CONNECTION}}.QueryDatabase(
+		auto results = db.QueryDatabase(
 			fmt::format(
 				"TRUNCATE TABLE {}",
 				TableName()

--- a/world/world_server_command_handler.cpp
+++ b/world/world_server_command_handler.cpp
@@ -355,14 +355,14 @@ namespace WorldserverCommandHandler {
 		instance_list_entry.duration      = 0;
 		instance_list_entry.never_expires = 1;
 
-		auto instance_list_inserted = InstanceListRepository::InsertOne(instance_list_entry);
+		auto instance_list_inserted = InstanceListRepository::InsertOne(database, instance_list_entry);
 
 		LogInfo("Inserted ID is [{}] zone [{}]", instance_list_inserted.id, instance_list_inserted.zone);
 
 		/**
 		 * Find one
 		 */
-		auto found_instance_list = InstanceListRepository::FindOne(instance_list_inserted.id);
+		auto found_instance_list = InstanceListRepository::FindOne(database, instance_list_inserted.id);
 
 		LogInfo("Found ID is [{}] zone [{}]", found_instance_list.id, found_instance_list.zone);
 
@@ -371,7 +371,7 @@ namespace WorldserverCommandHandler {
 		 */
 		LogInfo("Updating instance id [{}] zone [{}]", found_instance_list.id, found_instance_list.zone);
 
-		int update_instance_list_count = InstanceListRepository::UpdateOne(found_instance_list);
+		int update_instance_list_count = InstanceListRepository::UpdateOne(database, found_instance_list);
 
 		found_instance_list.zone = 777;
 
@@ -386,7 +386,7 @@ namespace WorldserverCommandHandler {
 		/**
 		 * Delete one
 		 */
-		int deleted = InstanceListRepository::DeleteOne(found_instance_list.id);
+		int deleted = InstanceListRepository::DeleteOne(database, found_instance_list.id);
 
 		LogInfo("Deleting one instance [{}] deleted count [{}]", found_instance_list.id, deleted);
 
@@ -411,18 +411,18 @@ namespace WorldserverCommandHandler {
 		/**
 		 * Fetch all
 		 */
-		int inserted_count = InstanceListRepository::InsertMany(instance_lists);
+		int inserted_count = InstanceListRepository::InsertMany(database, instance_lists);
 
 		LogInfo("Bulk insertion test, inserted [{}]", inserted_count);
 
-		for (auto &entry: InstanceListRepository::GetWhere(fmt::format("zone = {}", 999))) {
+		for (auto &entry: InstanceListRepository::GetWhere(database, fmt::format("zone = {}", 999))) {
 			LogInfo("Iterating through entry id [{}] zone [{}]", entry.id, entry.zone);
 		}
 
 		/**
 		 * Delete where
 		 */
-		int deleted_count = InstanceListRepository::DeleteWhere(fmt::format("zone = {}", 999));
+		int deleted_count = InstanceListRepository::DeleteWhere(database, fmt::format("zone = {}", 999));
 
 		LogInfo("Bulk deletion test, deleted [{}]", deleted_count);
 
@@ -442,7 +442,7 @@ namespace WorldserverCommandHandler {
 			return;
 		}
 
-		auto zones = ZoneRepository::GetWhere("short_name = 'anguish'");
+		auto zones = ZoneRepository::GetWhere(content_db, "short_name = 'anguish'");
 
 		for (auto &zone: zones) {
 			LogInfo(

--- a/world/world_store.cpp
+++ b/world/world_store.cpp
@@ -25,7 +25,7 @@ WorldStore::~WorldStore() = default;
 
 void WorldStore::LoadZones()
 {
-	zones = ZoneRepository::All();
+	zones = ZoneRepository::All(content_db);
 }
 
 uint32 WorldStore::GetZoneID(const char *in_zone_name)

--- a/zone/tasks.cpp
+++ b/zone/tasks.cpp
@@ -3447,7 +3447,7 @@ bool TaskGoalListManager::LoadLists()
 		list_index++;
 	}
 
-	auto goal_lists = GoallistsRepository::GetWhere("TRUE ORDER BY listid, entry ASC");
+	auto goal_lists = GoallistsRepository::GetWhere(content_db, "TRUE ORDER BY listid, entry ASC");
 
 	for (list_index = 0; list_index < NumberOfLists; list_index++) {
 

--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -1582,7 +1582,7 @@ void Client::LearnRecipe(uint32 recipe_id)
 		return;
 	}
 
-	auto tradeskill_recipe = TradeskillRecipeRepository::FindOne(recipe_id);
+	auto tradeskill_recipe = TradeskillRecipeRepository::FindOne(content_db, recipe_id);
 	if (tradeskill_recipe.id == 0) {
 		LogError("Invalid recipe [{}]", recipe_id);
 		return;

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -1979,7 +1979,7 @@ bool ZoneDatabase::LoadStaticZonePoints(LinkedList<ZonePoint *> *zone_point_list
 	zone->numzonepoints = 0;
 	zone->virtual_zone_point_list.clear();
 
-	auto zone_points = ZonePointsRepository::GetWhere(
+	auto zone_points = ZonePointsRepository::GetWhere(content_db,
 		fmt::format(
 			"zone = '{}' AND (version = {} OR version = -1) {} ORDER BY number",
 			zonename,

--- a/zone/zone_store.cpp
+++ b/zone/zone_store.cpp
@@ -27,7 +27,7 @@ ZoneStore::~ZoneStore() = default;
 
 void ZoneStore::LoadZones()
 {
-	zones = ZoneRepository::All();
+	zones = ZoneRepository::All(content_db);
 }
 
 /**
@@ -147,7 +147,7 @@ ZoneRepository::Zone ZoneStore::GetZone(const char *in_zone_name)
 void ZoneStore::LoadContentFlags()
 {
 	std::vector<std::string> set_content_flags;
-	auto                     content_flags = ContentFlagsRepository::GetWhere("enabled = 1");
+	auto                     content_flags = ContentFlagsRepository::GetWhere(database, "enabled = 1");
 
 	set_content_flags.reserve(content_flags.size());
 	for (auto &flags: content_flags) {
@@ -170,7 +170,7 @@ void ZoneStore::LoadContentFlags()
  */
 void ZoneStore::SetContentFlag(const std::string &content_flag_name, bool enabled)
 {
-	auto content_flags = ContentFlagsRepository::GetWhere(
+	auto content_flags = ContentFlagsRepository::GetWhere(database,
 		fmt::format("flag_name = '{}'", content_flag_name)
 	);
 
@@ -183,10 +183,10 @@ void ZoneStore::SetContentFlag(const std::string &content_flag_name, bool enable
 	content_flag.flag_name = content_flag_name;
 
 	if (!content_flags.empty()) {
-		ContentFlagsRepository::UpdateOne(content_flag);
+		ContentFlagsRepository::UpdateOne(database, content_flag);
 	}
 	else {
-		ContentFlagsRepository::InsertOne(content_flag);
+		ContentFlagsRepository::InsertOne(database, content_flag);
 	}
 
 	LoadContentFlags();

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -313,7 +313,7 @@ void Client::Handle_OP_ZoneChange(const EQApplicationPacket *app) {
 		 * In 99% of cases we would never get here and this would be fallback
 		 */
 		if (!found_zone) {
-			auto zones = ZoneRepository::GetWhere(
+			auto zones = ZoneRepository::GetWhere(content_db,
 				fmt::format(
 					"expansion <= {} AND short_name = '{}' and version = 0",
 					(content_service.GetCurrentExpansion() + 1),


### PR DESCRIPTION
This change comes as a result of some user feedback and some of my own experience as I've been using repositories in code

The original intent of a repository method was to make it as intuitive and simple to use as possible so the generation made assumptions about what database pointer it should use under the hood `database` or `content_db`. 

This all works fine and dandy, however this pattern breaks down as soon as we want to use a repository in any shared `./common` logic. The reason for this is our poorly distributed Database logic. For world and zone we have separate classes tied to pointers `database` and `content_db` so we cannot use shared type signatures and make assumptions within the repository methods

For this reason, these assumptions and attempts to simplify usage of repositories are outweighed by the annoyances of not being able to use them in any `./common` shared logic which is a very common use case

This PR implements explicitly passing in database pointers into repository methods and updates all of the referenced places in the code where its used