### PR TITLE
[Quest API] Add Anon/AFK methods to Perl and Lua.

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10134,3 +10134,27 @@ std::vector<int> Client::GetScribedSpells() {
 	}		
 	return scribed_spells;
 }
+
+void Client::SetAnon(uint8 anon_flag) {
+	m_pp.anon = anon_flag;
+	auto outapp = new EQApplicationPacket(OP_SpawnAppearance, sizeof(SpawnAppearance_Struct));
+	SpawnAppearance_Struct* spawn_appearance = (SpawnAppearance_Struct*)outapp->pBuffer;
+	spawn_appearance->spawn_id = this->GetID();
+	spawn_appearance->type = AT_Anon;
+	spawn_appearance->parameter = anon_flag;
+	entity_list.QueueClients(this, outapp);
+	Save();
+	UpdateWho();
+	safe_delete(outapp);
+}
+
+void Client::SetAFK(uint8 afk_flag) {
+	AFK = afk_flag;
+	auto outapp = new EQApplicationPacket(OP_SpawnAppearance, sizeof(SpawnAppearance_Struct));
+	SpawnAppearance_Struct* spawn_appearance = (SpawnAppearance_Struct*)outapp->pBuffer;
+	spawn_appearance->spawn_id = this->GetID();
+	spawn_appearance->type = AT_AFK;
+	spawn_appearance->parameter = afk_flag;
+	entity_list.QueueClients(this, outapp);
+	safe_delete(outapp);
+}

--- a/zone/client.h
+++ b/zone/client.h
@@ -369,6 +369,9 @@ public:
 	void Kick(const std::string &reason);
 	void WorldKick();
 	inline uint8 GetAnon() const { return m_pp.anon; }
+	inline uint8 GetAFK() const { return AFK; }
+	void SetAnon(uint8 anon_flag);
+	void SetAFK(uint8 afk_flag);
 	inline PlayerProfile_Struct& GetPP() { return m_pp; }
 	inline ExtendedProfile_Struct& GetEPP() { return m_epp; }
 	inline EQ::InventoryProfile& GetInv() { return m_inv; }

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -69,9 +69,24 @@ void Lua_Client::WorldKick() {
 	self->WorldKick();
 }
 
-bool Lua_Client::GetAnon() {
-	Lua_Safe_Call_Bool();
-	return self->GetAnon() != 0;
+int Lua_Client::GetAFK() {
+	Lua_Safe_Call_Int();
+	return self->GetAFK();
+}
+
+void Lua_Client::SetAFK(uint8 afk_flag) {
+	Lua_Safe_Call_Void();
+	self->SetAFK(afk_flag);
+}
+
+int Lua_Client::GetAnon() {
+	Lua_Safe_Call_Int();
+	return self->GetAnon();
+}
+
+void Lua_Client::SetAnon(uint8 anon_flag) {
+	Lua_Safe_Call_Void();
+	self->SetAnon(anon_flag);
 }
 
 void Lua_Client::Duck() {
@@ -2062,7 +2077,10 @@ luabind::scope lua_register_client() {
 		.def("IsLD", (bool(Lua_Client::*)(void))&Lua_Client::IsLD)
 		.def("WorldKick", (void(Lua_Client::*)(void))&Lua_Client::WorldKick)
 		.def("SendToGuildHall", (void(Lua_Client::*)(void))&Lua_Client::SendToGuildHall)
-		.def("GetAnon", (bool(Lua_Client::*)(void))&Lua_Client::GetAnon)
+		.def("GetAFK", (int(Lua_Client::*)(void))&Lua_Client::GetAFK)
+		.def("SetAFK", (void(Lua_Client::*)(uint8))&Lua_Client::SetAFK)
+		.def("GetAnon", (int(Lua_Client::*)(void))&Lua_Client::GetAnon)
+		.def("SetAnon", (void(Lua_Client::*)(uint8))&Lua_Client::SetAnon)
 		.def("Duck", (void(Lua_Client::*)(void))&Lua_Client::Duck)
 		.def("DyeArmorBySlot", (void(Lua_Client::*)(uint8,uint8,uint8,uint8))&Lua_Client::DyeArmorBySlot)
 		.def("DyeArmorBySlot", (void(Lua_Client::*)(uint8,uint8,uint8,uint8,uint8))&Lua_Client::DyeArmorBySlot)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -41,7 +41,10 @@ public:
 	bool IsLD();
 	void WorldKick();
 	void SendToGuildHall();
-	bool GetAnon();
+	int GetAnon();
+	void SetAnon(uint8 anon_flag);
+	int GetAFK();
+	void SetAFK(uint8 afk_flag);
 	void Duck();
 	void DyeArmorBySlot(uint8 slot, uint8 red, uint8 green, uint8 blue);
 	void DyeArmorBySlot(uint8 slot, uint8 red, uint8 green, uint8 blue, uint8 use_tint);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -217,6 +217,51 @@ XS(XS_Client_GetAnon) {
 	XSRETURN(1);
 }
 
+XS(XS_Client_SetAnon); /* prototype to pass -Wmissing-prototypes */
+XS(XS_Client_SetAnon) {
+	dXSARGS;
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: Client::SetAnon(THIS, uint8 anon_flag)");
+	{
+		Client *THIS;
+		uint8 anon_flag = (uint8) SvUV(ST(1));
+		VALIDATE_THIS_IS_CLIENT;
+		THIS->SetAnon(anon_flag);
+	}
+	XSRETURN_EMPTY;
+}
+
+XS(XS_Client_GetAFK); /* prototype to pass -Wmissing-prototypes */
+XS(XS_Client_GetAFK) {
+	dXSARGS;
+	if (items != 1)
+		Perl_croak(aTHX_ "Usage: Client::GetAFK(THIS)");
+	{
+		Client *THIS;
+		uint8 RETVAL;
+		dXSTARG;
+		VALIDATE_THIS_IS_CLIENT;
+		RETVAL = THIS->GetAFK();
+		XSprePUSH;
+		PUSHu((UV) RETVAL);
+	}
+	XSRETURN(1);
+}
+
+XS(XS_Client_SetAFK); /* prototype to pass -Wmissing-prototypes */
+XS(XS_Client_SetAFK) {
+	dXSARGS;
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: Client::SetAFK(THIS, uint8 afk_flag)");
+	{
+		Client *THIS;
+		uint8 afk_flag = (uint8) SvUV(ST(1));
+		VALIDATE_THIS_IS_CLIENT;
+		THIS->SetAFK(afk_flag);
+	}
+	XSRETURN_EMPTY;
+}
+
 XS(XS_Client_Duck); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Client_Duck) {
 	dXSARGS;
@@ -5283,6 +5328,7 @@ XS(boot_Client) {
 	newXSproto(strcpy(buf, "GetAAPoints"), XS_Client_GetAAPoints, file, "$$");
 	newXSproto(strcpy(buf, "GetAccountAge"), XS_Client_GetAccountAge, file, "$");
 	newXSproto(strcpy(buf, "GetAccountFlag"), XS_Client_GetAccountFlag, file, "$$");
+	newXSproto(strcpy(buf, "GetAFK"), XS_Client_GetAFK, file, "$");
 	newXSproto(strcpy(buf, "GetAggroCount"), XS_Client_GetAggroCount, file, "$");
 	newXSproto(strcpy(buf, "GetAllMoney"), XS_Client_GetAllMoney, file, "$");
 	newXSproto(strcpy(buf, "GetAlternateCurrencyValue"), XS_Client_GetAlternateCurrencyValue, file, "$$");
@@ -5450,6 +5496,8 @@ XS(boot_Client) {
 	newXSproto(strcpy(buf, "SetAAPoints"), XS_Client_SetAAPoints, file, "$$");
 	newXSproto(strcpy(buf, "SetAATitle"), XS_Client_SetAATitle, file, "$$;$");
 	newXSproto(strcpy(buf, "SetAccountFlag"), XS_Client_SetAccountFlag, file, "$$");
+	newXSproto(strcpy(buf, "SetAFK"), XS_Client_SetAFK, file, "$$");
+	newXSproto(strcpy(buf, "SetAnon"), XS_Client_SetAnon, file, "$$");
 	newXSproto(strcpy(buf, "SetAlternateCurrencyValue"), XS_Client_SetAlternateCurrencyValue, file, "$$$");
 	newXSproto(strcpy(buf, "SetBaseClass"), XS_Client_SetBaseClass, file, "$$");
 	newXSproto(strcpy(buf, "SetBaseGender"), XS_Client_SetBaseGender, file, "$$");


### PR DESCRIPTION
- Add $client->SetAnon(anon_flag) to Perl.
- Add client:SetAnon(anon_flag) to Lua.
- Add $client->GetAFK() to Perl.
- Add client:GetAFK() to Lua.
- Add $client->SetAFK(afk_flag) to Perl.
- Add client:SetAFK(afk_flag) to Lua.

Converted GetAnon from bool to int for Lua because it can return 0 for Non-Anon, 1 for Anon, and 2 for Roleplaying.

Probably a little hacky, wasn't sure of a better way to get around some of the timer checks and stuff that some of the spawn appearance methods do.