### PR TITLE
[Door Opening] Rule to let configure Animal Door Opening

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -531,6 +531,7 @@ RULE_INT(NPC, NPCGateDistanceBind, 75, "Distance from bind before NPC will attem
 RULE_BOOL(NPC, NPCHealOnGate, true, "Will the NPC Heal on Gate")
 RULE_BOOL(NPC, UseMeditateBasedManaRegen, false, "Based NPC ooc regen on Meditate skill")
 RULE_REAL(NPC, NPCHealOnGateAmount, 25, "How much the NPC will heal on gate if enabled")
+RULE_BOOL(NPC, AnimalsOpenDoors, true, "Determines or not whether animals open doors or not when they approach them")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Aggro)

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -3604,18 +3604,21 @@ void EntityList::AddHealAggro(Mob *target, Mob *caster, uint16 hate)
 
 void EntityList::OpenDoorsNear(Mob *who)
 {
-
-	for (auto it = door_list.begin();it != door_list.end(); ++it) {
-		Doors *cdoor = it->second;
-		if (!cdoor || cdoor->IsDoorOpen())
+	for (auto &it : door_list) {
+		Doors *door = it.second;
+		if (!door || door->IsDoorOpen()) {
 			continue;
+		}
 
-		auto diff = who->GetPosition() - cdoor->GetPosition();
+		if (who->GetBodyType() == BT_Animal && !RuleB(NPC, AnimalsOpenDoors)) {
+			continue;
+		}
 
-		float curdist = diff.x * diff.x + diff.y * diff.y;
-
-		if (diff.z * diff.z < 10 && curdist <= 100)
-			cdoor->Open(who);
+		auto  diff     = who->GetPosition() - door->GetPosition();
+		float distance = diff.x * diff.x + diff.y * diff.y;
+		if (diff.z * diff.z < 10 && distance <= 100) {
+			door->Open(who);
+		}
 	}
 }
 

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -3604,13 +3604,13 @@ void EntityList::AddHealAggro(Mob *target, Mob *caster, uint16 hate)
 
 void EntityList::OpenDoorsNear(Mob *who)
 {
+	if (!who->CanOpenDoors()) {
+		return;
+	}
+
 	for (auto &it : door_list) {
 		Doors *door = it.second;
 		if (!door || door->IsDoorOpen()) {
-			continue;
-		}
-
-		if (who->GetBodyType() == BT_Animal && !RuleB(NPC, AnimalsOpenDoors)) {
 			continue;
 		}
 

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -464,6 +464,8 @@ Mob::Mob(
 #endif
 
 	mob_close_scan_timer.Trigger();
+
+	SetCanOpenDoors(true);
 }
 
 Mob::~Mob()
@@ -509,8 +511,6 @@ Mob::~Mob()
 	entity_list.RemoveAuraFromMobs(this);
 
 	close_mobs.clear();
-
-	SetCanOpenDoors(true);
 
 #ifdef BOTS
 	LeaveHealRotationTargetPool();

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -510,6 +510,8 @@ Mob::~Mob()
 
 	close_mobs.clear();
 
+	SetCanOpenDoors(true);
+
 #ifdef BOTS
 	LeaveHealRotationTargetPool();
 #endif
@@ -5960,3 +5962,13 @@ float Mob::HealRotationExtendedHealFrequency()
 	return m_target_of_heal_rotation->ExtendedHealFrequency(this);
 }
 #endif
+
+bool Mob::CanOpenDoors() const
+{
+	return m_can_open_doors;
+}
+
+void Mob::SetCanOpenDoors(bool can_open)
+{
+	m_can_open_doors = can_open;
+}

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1194,6 +1194,9 @@ public:
 	int32 GetHPRegen() const;
 	int32 GetManaRegen() const;
 
+	bool CanOpenDoors() const;
+	void SetCanOpenDoors(bool can_open);
+
 
 #ifdef BOTS
 	// Bots HealRotation methods
@@ -1587,11 +1590,14 @@ protected:
 	AuraMgr aura_mgr;
 	AuraMgr trap_mgr;
 
+	bool m_can_open_doors;
+
 	MobMovementManager *mMovementManager;
 
 private:
 	void _StopSong(); //this is not what you think it is
 	Mob* target;
+
 
 #ifdef BOTS
 	std::shared_ptr<HealRotation> m_target_of_heal_rotation;

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -450,7 +450,7 @@ void Mob::AI_Start(uint32 iMoveDelay) {
 
 	if (CastToNPC()->WillAggroNPCs())
 		AI_scan_area_timer = std::unique_ptr<Timer>(new Timer(RandomTimer(RuleI(NPC, NPCToNPCAggroTimerMin), RuleI(NPC, NPCToNPCAggroTimerMax))));
-	
+
 	AI_check_signal_timer = std::unique_ptr<Timer>(new Timer(AI_check_signal_timer_delay));
 
 
@@ -884,49 +884,49 @@ void Mob::ProcessForcedMovement()
 	if (AI_movement_timer->Check()) {
 		bool bPassed = true;
 		glm::vec3 normal;
-	
+
 		// no zone map = fucked
 		if (zone->HasMap()) {
 			// in front
 			m_CollisionBox[0].x = m_Position.x + 3.0f * g_Math.FastSin(0.0f);
 			m_CollisionBox[0].y = m_Position.y + 3.0f * g_Math.FastCos(0.0f);
 			m_CollisionBox[0].z = m_Position.z;
-	
+
 			// 45 right front
 			m_CollisionBox[1].x = m_Position.x + 3.0f * g_Math.FastSin(64.0f);
 			m_CollisionBox[1].y = m_Position.y + 3.0f * g_Math.FastCos(64.0f);
 			m_CollisionBox[1].z = m_Position.z;
-	
+
 			// to right
 			m_CollisionBox[2].x = m_Position.x + 3.0f * g_Math.FastSin(128.0f);
 			m_CollisionBox[2].y = m_Position.y + 3.0f * g_Math.FastCos(128.0f);
 			m_CollisionBox[2].z = m_Position.z;
-	
+
 			// 45 right back
 			m_CollisionBox[3].x = m_Position.x + 3.0f * g_Math.FastSin(192.0f);
 			m_CollisionBox[3].y = m_Position.y + 3.0f * g_Math.FastCos(192.0f);
 			m_CollisionBox[3].z = m_Position.z;
-	
+
 			// behind
 			m_CollisionBox[4].x = m_Position.x + 3.0f * g_Math.FastSin(256.0f);
 			m_CollisionBox[4].y = m_Position.y + 3.0f * g_Math.FastCos(256.0f);
 			m_CollisionBox[4].z = m_Position.z;
-	
+
 			// 45 left back
 			m_CollisionBox[5].x = m_Position.x + 3.0f * g_Math.FastSin(320.0f);
 			m_CollisionBox[5].y = m_Position.y + 3.0f * g_Math.FastCos(320.0f);
 			m_CollisionBox[5].z = m_Position.z;
-	
+
 			// to left
 			m_CollisionBox[6].x = m_Position.x + 3.0f * g_Math.FastSin(384.0f);
 			m_CollisionBox[6].y = m_Position.y + 3.0f * g_Math.FastCos(384.0f);
 			m_CollisionBox[6].z = m_Position.z;
-	
+
 			// 45 left front
 			m_CollisionBox[7].x = m_Position.x + 3.0f * g_Math.FastSin(448.0f);
 			m_CollisionBox[7].y = m_Position.y + 3.0f * g_Math.FastCos(448.0f);
 			m_CollisionBox[7].z = m_Position.z;
-	
+
 			// collision happened, need to move along the wall
 			float distance = 0.0f, shortest = std::numeric_limits<float>::infinity();
 			glm::vec3 tmp_nrm;
@@ -940,7 +940,7 @@ void Mob::ProcessForcedMovement()
 				}
 			}
 		}
-	
+
 		if (bPassed) {
 			ForcedMovement = 0;
 			Teleport(m_Position + m_Delta);
@@ -1003,8 +1003,13 @@ void Mob::AI_Process() {
 					 * Make sure we're opening a door within height relevance and not platforms
 					 * above or below
 					 */
-					if (std::abs(this->m_Position.z - door->GetPosition().z) > 10)
+					if (std::abs(this->m_Position.z - door->GetPosition().z) > 10) {
 						continue;
+					}
+
+					if (GetBodyType() == BT_Animal && !RuleB(NPC, AnimalsOpenDoors)) {
+						continue;
+					}
 
 					door->ForceOpen(this);
 				}
@@ -1743,7 +1748,7 @@ void NPC::AI_DoMovement() {
 					if (cur_wp_pause > 0 && m_CurrentWayPoint.w >= 0.0) {
 						RotateTo(m_CurrentWayPoint.w);
 					}
-							
+
 					//kick off event_waypoint arrive
 					char temp[16];
 					sprintf(temp, "%d", cur_wp);
@@ -1757,7 +1762,7 @@ void NPC::AI_DoMovement() {
 					if (cur_wp == EQ::WaypointStatus::QuestControlNoGrid) {
 						AI_SetupNextWaypoint();
 					}
-		
+
 					// wipe feign memory since we reached our first waypoint
 					if (cur_wp == 1)
 						ClearFeignMemory();
@@ -1775,7 +1780,7 @@ void NPC::AI_DoMovement() {
 						m_CurrentWayPoint.y,
 						m_CurrentWayPoint.z
 					);
-		
+
 				}
 			}
 		}        // endif (gridno > 0)
@@ -1784,15 +1789,15 @@ void NPC::AI_DoMovement() {
 			if (pause_timer_complete == true) { // time to pause has ended
 				SetGrid(0 - GetGrid()); // revert to AI control
 				LogPathing("Quest pathing is finished. Resuming on grid [{}]", GetGrid());
-		
+
 				SetAppearance(eaStanding, false);
-		
+
 				CalculateNewWaypoint();
 			}
 		}
 
 	}
-	else if (IsGuarding()) {	
+	else if (IsGuarding()) {
 		bool at_gp = IsPositionEqualWithinCertainZ(m_Position, m_GuardPoint, 15.0f);
 
 		if (at_gp) {
@@ -1857,17 +1862,17 @@ void NPC::AI_SetupNextWaypoint() {
 			roamer = false;
 			cur_wp = 0;
 		}
-		
+
 		SetAppearance(eaStanding, false);
-		
+
 		entity_list.OpenDoorsNear(this);
-		
+
 		if (!DistractedFromGrid) {
 			//kick off event_waypoint depart
 			char temp[16];
 			sprintf(temp, "%d", cur_wp);
 			parse->EventNPC(EVENT_WAYPOINT_DEPART, CastToNPC(), nullptr, temp, 0);
-		
+
 			//setup our next waypoint, if we are still on our normal grid
 			//remember that the quest event above could have done anything it wanted with our grid
 			if (GetGrid() > 0) {
@@ -1937,7 +1942,7 @@ void Mob::AI_Event_NoLongerEngaged() {
 		time_until_can_move += minLastFightingDelayMoving;
 	else
 		time_until_can_move += zone->random.Int(minLastFightingDelayMoving, maxLastFightingDelayMoving);
-	
+
 	StopNavigation();
 	ClearRampage();
 

--- a/zone/mob_info.cpp
+++ b/zone/mob_info.cpp
@@ -225,6 +225,10 @@ inline std::string GetMobAttributeByString(Mob *mob, const std::string &attribut
 		return std::to_string(mob->GetMaxBuffSlots());
 	}
 
+	if (attribute == "can_open_doors") {
+		return std::to_string(mob->CanOpenDoors());
+	}
+
 	if (attribute == "curbuffslots") {
 		return std::to_string(mob->GetCurrentBuffSlots());
 	}
@@ -770,6 +774,7 @@ void Mob::DisplayInfo(Mob *mob)
 				"spells_id",
 				"curbuffslots",
 				"maxbuffslots",
+				"can_open_doors",
 			};
 
 			window_text += WriteDisplayInfoSection(mob, "NPC Attributes", npc_attributes, 1, true);

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -409,6 +409,11 @@ NPC::NPC(const NPCType *npc_type_data, Spawn2 *in_respawn, const glm::vec4 &posi
 	AISpellVar.idle_no_sp_recast_min           = static_cast<uint32>(RuleI(Spells, AI_IdleNoSpellMinRecast));
 	AISpellVar.idle_no_sp_recast_max           = static_cast<uint32>(RuleI(Spells, AI_IdleNoSpellMaxRecast));
 	AISpellVar.idle_beneficial_chance          = static_cast<uint8> (RuleI(Spells, AI_IdleBeneficialChance));
+
+	if (GetBodyType() == BT_Animal && !RuleB(NPC, AnimalsOpenDoors)) {
+		m_can_open_doors = false;
+	}
+
 }
 
 float NPC::GetRoamboxMaxX() const

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -639,11 +639,10 @@ protected:
 
 
 private:
-	uint32	loottable_id;
-	bool	skip_global_loot;
-	bool	skip_auto_scale;
-	bool	p_depop;
-
+	uint32 loottable_id;
+	bool   skip_global_loot;
+	bool   skip_auto_scale;
+	bool   p_depop;
 };
 
 #endif


### PR DESCRIPTION
This PR allows a server operator to turn off animals opening doors if they want

Default live behavior is for animals to open doors when in proximity

```
RULE_BOOL(NPC, AnimalsOpenDoors, true, "Determines or not whether animals open doors or not when they approach them")
```

**Show your Work**

**Default Value** (Animals can open doors)

![image](https://user-images.githubusercontent.com/3319450/107166499-d3308b80-697b-11eb-8e6a-d44a604f3d8e.png)
![image](https://user-images.githubusercontent.com/3319450/107166471-bf852500-697b-11eb-9f44-51e8bd6eb0b2.png)

Rodent opened door

**Rule Disabled** (Animals can't open doors)

![image](https://user-images.githubusercontent.com/3319450/107166463-b6945380-697b-11eb-8013-8865fc5e0e10.png)

Rodent warped through door
