### PR TITLE
[Game Play Mechanic] Very simple implementation of Sneak Pull

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -501,6 +501,7 @@ RULE_INT(Combat, LevelToStopACTwinkControl, 50, "Level to stop armorclass twink 
 RULE_BOOL(Combat, ClassicNPCBackstab, false, "True disables NPC facestab - NPC get normal attack if not behind")
 RULE_BOOL(Combat, UseNPCDamageClassLevelMods, true, "Uses GetClassLevelDamageMod calc in npc_scale_manager")
 RULE_BOOL(Combat, UseExtendedPoisonProcs, false, "Allow old school poisons to last until characrer zones, at a lower proc rate")
+RULE_BOOL(Combat, EnableSneakPull, false, "Enable implementation of Sneak Pull")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(NPC)

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -502,6 +502,7 @@ RULE_BOOL(Combat, ClassicNPCBackstab, false, "True disables NPC facestab - NPC g
 RULE_BOOL(Combat, UseNPCDamageClassLevelMods, true, "Uses GetClassLevelDamageMod calc in npc_scale_manager")
 RULE_BOOL(Combat, UseExtendedPoisonProcs, false, "Allow old school poisons to last until characrer zones, at a lower proc rate")
 RULE_BOOL(Combat, EnableSneakPull, false, "Enable implementation of Sneak Pull")
+RULE_INT(Combat, SneakPullAssistRange, 400, "Modified range of assist for sneak pull")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(NPC)

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -3241,7 +3241,7 @@ void NPC::AIYellForHelp(Mob *sender, Mob *attacker)
 		float assist_range = (mob->GetAssistRange() * mob->GetAssistRange());
 
 		if (RuleB(Combat, EnableSneakPull) && attacker->sneaking) {
-			assist_range=RuleI(SneakPullAssistRange);
+			assist_range=RuleI(Combat, SneakPullAssistRange);
 			if (attacker->IsClient()) {
 				float clientx = attacker->GetX();
 				float clienty = attacker->GetY();

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -3240,6 +3240,7 @@ void NPC::AIYellForHelp(Mob *sender, Mob *attacker)
 
 		float assist_range = (mob->GetAssistRange() * mob->GetAssistRange());
 
+		// Implement optional sneak-pull
 		if (RuleB(Combat, EnableSneakPull) && attacker->sneaking) {
 			assist_range = RuleI(Combat, SneakPullAssistRange);
 			if (attacker->IsClient()) {

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -3241,10 +3241,10 @@ void NPC::AIYellForHelp(Mob *sender, Mob *attacker)
 		float assist_range = (mob->GetAssistRange() * mob->GetAssistRange());
 
 		if (RuleB(Combat, EnableSneakPull) && attacker->sneaking) {
-			assist_range=(20*20);
+			assist_range=RuleI(SneakPullAssistRange);
 			if (attacker->IsClient()) {
-				float clientx=attacker->GetX();
-				float clienty=attacker->GetY();
+				float clientx = attacker->GetX();
+				float clienty = attacker->GetY();
 				if (attacker->CastToClient()->BehindMob(mob, clientx, clienty)) {
 					assist_range = 0;
 				}

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -3239,6 +3239,18 @@ void NPC::AIYellForHelp(Mob *sender, Mob *attacker)
 		}
 
 		float assist_range = (mob->GetAssistRange() * mob->GetAssistRange());
+
+		if (RuleB(Combat, EnableSneakPull) && attacker->sneaking) {
+			assist_range=(20*20);
+			if (attacker->IsClient()) {
+				float clientx=attacker->GetX();
+				float clienty=attacker->GetY();
+				if (attacker->CastToClient()->BehindMob(mob, clientx, clienty)) {
+					assist_range = 0;
+				}
+			}
+		}
+
 		if (distance > assist_range) {
 			continue;
 		}

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -3241,7 +3241,7 @@ void NPC::AIYellForHelp(Mob *sender, Mob *attacker)
 		float assist_range = (mob->GetAssistRange() * mob->GetAssistRange());
 
 		if (RuleB(Combat, EnableSneakPull) && attacker->sneaking) {
-			assist_range=RuleI(Combat, SneakPullAssistRange);
+			assist_range = RuleI(Combat, SneakPullAssistRange);
 			if (attacker->IsClient()) {
 				float clientx = attacker->GetX();
 				float clienty = attacker->GetY();


### PR DESCRIPTION
Sneak pulling is a technique I used for years with my rogue on live, dating way back to 1999.

There are many different interpretations of how this works.  This thread covers alot of the ideas within the thread and with references to Monkly Business and The Safehouse.

https://www.project1999.com/forums/showthread.php?t=260642

For my server and from my memory, this implementation gets me close to my experience from live.

This is behind a rule, so no base behavior will change unless you enable it.

If it is enabled, then  successful sneaking reduces the assist range.  If behind the mob, it negates it - but you must remain sneaking while pulling.  I spent many years hurling throwing weapons while peddling backwards with sneak/hide on with sow. If I peddled back out of aggro range before the missile hit, remaining sneaking, I often got 1 mob if its back was turned.

I like this implementation, and I'll just keep it local if the community doesn't want it.  

I do think it's useful and think some server operators would turn it on.

I know P1999 did alot of work on sneak pull, but I don't know their details.