### PR TITLE
Add string util search_deliminated_string

### DIFF
--- a/common/string_util.cpp
+++ b/common/string_util.cpp
@@ -125,6 +125,19 @@ std::vector<std::string> SplitString(const std::string &str, char delim) {
 	return ret;
 }
 
+std::string::size_type search_deliminated_string(const std::string &haystack, const std::string &needle, const char deliminator)
+{
+	// this shouldn't go out of bounds, even without obvious bounds checks
+	auto pos = haystack.find(needle);
+	while (pos != std::string::npos) {
+		auto c = haystack[pos + needle.length()];
+		if ((c == '\0' || c == deliminator) && (pos == 0 || haystack[pos - 1] == deliminator))
+			return pos;
+		pos = haystack.find(needle, pos + needle.length());
+	}
+	return std::string::npos;
+}
+
 std::string implode(std::string glue, std::vector<std::string> src)
 {
 	if (src.empty()) {

--- a/common/string_util.h
+++ b/common/string_util.h
@@ -178,6 +178,7 @@ std::vector<std::string> join_tuple(const std::string &glue, const std::pair<cha
 }
 
 std::vector<std::string> SplitString(const std::string &s, char delim);
+std::string::size_type search_deliminated_string(const std::string &haystack, const std::string &needle, const char deliminator = ',');
 std::string EscapeString(const char *src, size_t sz);
 std::string EscapeString(const std::string &s);
 bool StringIsNumber(const std::string &s);

--- a/tests/string_util_test.h
+++ b/tests/string_util_test.h
@@ -29,6 +29,7 @@ public:
 		TEST_ADD(StringUtilTest::StringFormatTest);
 		TEST_ADD(StringUtilTest::EscapeStringTest);
 		TEST_ADD(StringUtilTest::EscapeStringMemoryTest);
+		TEST_ADD(StringUtilTest::SearchDeliminatedStringTest);
 	}
 
 	~StringUtilTest() {
@@ -79,6 +80,33 @@ public:
 
 		auto s = EscapeString(t, 10);
 		TEST_ASSERT(s.compare("abc\\x00\\n\\r\\\\\\'\\\"\\x1a") == 0);
+	}
+
+	void SearchDeliminatedStringTest() {
+		std::string h =
+		    "befallen,charasis,dalnir,frontiermtns,gukbottom,iceclad,lakeofillomen,northkarana,qey2hh1,soldunga,southro,wakening,podisease,velketor,akheva,riwwi,bothunder,poair";
+		TEST_ASSERT(search_deliminated_string(h, "befallen") == 0);
+		TEST_ASSERT(search_deliminated_string(h, "charasis") == 9);
+		TEST_ASSERT(search_deliminated_string(h, "dalnir") == 18);
+		TEST_ASSERT(search_deliminated_string(h, "frontiermtns") == 25);
+		TEST_ASSERT(search_deliminated_string(h, "gukbottom") == 38);
+		TEST_ASSERT(search_deliminated_string(h, "iceclad") == 48);
+		TEST_ASSERT(search_deliminated_string(h, "lakeofillomen") == 56);
+		TEST_ASSERT(search_deliminated_string(h, "northkarana") == 70);
+		TEST_ASSERT(search_deliminated_string(h, "qey2hh1") == 82);
+		TEST_ASSERT(search_deliminated_string(h, "soldunga") == 90);
+		TEST_ASSERT(search_deliminated_string(h, "southro") == 99);
+		TEST_ASSERT(search_deliminated_string(h, "wakening") == 107);
+		TEST_ASSERT(search_deliminated_string(h, "podisease") == 116);
+		TEST_ASSERT(search_deliminated_string(h, "velketor") == 126);
+		TEST_ASSERT(search_deliminated_string(h, "akheva") == 135);
+		TEST_ASSERT(search_deliminated_string(h, "riwwi") == 142);
+		TEST_ASSERT(search_deliminated_string(h, "bothunder") == 148);
+		TEST_ASSERT(search_deliminated_string(h, "poair") == 158);
+		TEST_ASSERT(search_deliminated_string(h, "pod") == std::string::npos);
+		TEST_ASSERT(search_deliminated_string(h, "air") == std::string::npos);
+		TEST_ASSERT(search_deliminated_string(h, "bef") == std::string::npos);
+		TEST_ASSERT(search_deliminated_string(h, "wwi") == std::string::npos);
 	}
 };
 


### PR DESCRIPTION
This function takes a string of deliminated an see if another string is
one of those

This function also verifies it's not finding a substring

The motivational example for this function is the hotzone checking in PR #1257 

Currently our easiest way of doing this task is to split the string, this is rather needlessly expensive, so I wrote this.


Benchmarks: (on 8700k, stock, governor set to performance, optimization level 2 an march not set)

```----------------------------------------------------
Benchmark             Time           CPU Iterations
----------------------------------------------------
bench_split         871 ns        871 ns     796901
bench_search         38 ns         38 ns   18419186
```
