### PR TITLE
[Bug Fix] Do not summon pet or set new pet state when PC summoned by a mob

### DIFF
--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -590,10 +590,11 @@ void Client::ProcessMovePC(uint32 zoneID, uint32 instance_id, float x, float y, 
 			return;
 		}
 
-		if(GetPetID() != 0) {
+		if(zm != SummonPC && GetPetID() != 0) {
 			//if they have a pet and they are staying in zone, move with them
 			Mob *p = GetPet();
 			if(p != nullptr){
+				p->SetPetOrder(SPO_Follow);
 				p->GMMove(x+15, y, z);	//so it dosent have to run across the map.
 			}
 		}

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -594,7 +594,6 @@ void Client::ProcessMovePC(uint32 zoneID, uint32 instance_id, float x, float y, 
 			//if they have a pet and they are staying in zone, move with them
 			Mob *p = GetPet();
 			if(p != nullptr){
-				p->SetPetOrder(SPO_Follow);
 				p->GMMove(x+15, y, z);	//so it dosent have to run across the map.
 			}
 		}


### PR DESCRIPTION
This is in response to the discussion in eqemu-coders:

https://discord.com/channels/212663220849213441/557677602706423982/814234259845283870

The "fix" is simple.  From what I read, the pet does not switch from guard to follow on live.  I did not check live myself, I'm relying on the information in the thread.

If the pet should stay on guard, this should fix the issue.

