### PR TITLE
[ASan] Fix stack-buffer-overflow thanks to StopLFP

### DIFF
--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -3176,8 +3176,8 @@ void WorldServer::UpdateLFP(uint32 LeaderID, GroupLFPMemberEntry *LFPMembers) {
 
 void WorldServer::StopLFP(uint32 LeaderID) {
 
-	GroupLFPMemberEntry LFPMembers;
-	UpdateLFP(LeaderID, LFPOff, 0, 0, 0, 0, "", &LFPMembers);
+	GroupLFPMemberEntry LFPMembers[MAX_GROUP_MEMBERS];
+	UpdateLFP(LeaderID, LFPOff, 0, 0, 0, 0, "", LFPMembers);
 }
 
 void WorldServer::HandleLFGMatches(ServerPacket *pack) {


### PR DESCRIPTION
```
==1674==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fffb47f3068 at pc 0x7f64ee1f531e bp 0x7fffb47f2f50 sp 0x7fffb47f2700
READ of size 432 at 0x7fffb47f3068 thread T0
    #0 0x7f64ee1f531d  (/lib/x86_64-linux-gnu/libasan.so.5+0x3f31d)
    #1 0x55c78e8d002e in WorldServer::UpdateLFP(unsigned int, unsigned char, unsigned char, unsigned int, unsigned int, unsigned int, char const*, GroupLFPMemberEntry*) ../zone/worldserver.cpp:3166
    #2 0x55c78e8d01d9 in WorldServer::StopLFP(unsigned int) ../zone/worldserver.cpp:3180