### PR TITLE
[ASan] Fix heap-use-after-free issue with groups

### DIFF
--- a/zone/groups.cpp
+++ b/zone/groups.cpp
@@ -1006,8 +1006,6 @@ void Group::DisbandGroup(bool joinraid) {
 		database.ClearGroup(GetID());
 	}
 
-	entity_list.RemoveGroup(GetID());
-
 	if(Leader && (Leader->IsLFP()))
 	{
 		Leader->UpdateLFP();
@@ -1015,6 +1013,7 @@ void Group::DisbandGroup(bool joinraid) {
 
 	SetLeader(nullptr);
 	safe_delete(outapp);
+	entity_list.RemoveGroup(GetID());
 }
 
 void Group::GetMemberList(std::list<Mob*>& member_list, bool clear_list)


### PR DESCRIPTION
```
==2317==ERROR: AddressSanitizer: heap-use-after-free on address 0x6170000633c0 at pc 0x55ed1d8e8d8b bp 0x7ffda4bef580 sp 0x7ffda4bef578
WRITE of size 8 at 0x6170000633c0 thread T0
    #0 0x55ed1d8e8d8a in Group::SetLeader(Mob*) ../zone/groups.h:80
    #1 0x55ed1d8e8d8a in Group::DisbandGroup(bool) ../zone/groups.cpp:1016
```
ASan didn't like this