### PR TITLE
[ASan] Fix strcpy-param-overlap with GetGroupLeadershipInfo calls

### DIFF
--- a/common/database_instances.cpp
+++ b/common/database_instances.cpp
@@ -507,7 +507,7 @@ void Database::FlagInstanceByGroupLeader(uint32 zone, int16 version, uint32 char
 
 	char ln[128];
 	memset(ln, 0, 128);
-	strcpy(ln, GetGroupLeadershipInfo(gid, ln));
+	GetGroupLeadershipInfo(gid, ln);
 	uint32 l_charid = GetCharacterID((const char*)ln);
 	uint16 l_id = GetInstanceID(zone, l_charid, version);
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1532,7 +1532,7 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 			int mentor_percent;
 			GroupLeadershipAA_Struct GLAA;
 			memset(ln, 0, 64);
-			strcpy(ln, database.GetGroupLeadershipInfo(group->GetID(), ln, MainTankName, AssistName, PullerName, NPCMarkerName, mentoree_name, &mentor_percent, &GLAA));
+			database.GetGroupLeadershipInfo(group->GetID(), ln, MainTankName, AssistName, PullerName, NPCMarkerName, mentoree_name, &mentor_percent, &GLAA);
 			Client *c = entity_list.GetClientByName(ln);
 			if (c)
 				group->SetLeader(c);

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -1052,7 +1052,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 				int mentor_percent;
 				GroupLeadershipAA_Struct GLAA;
 				memset(ln, 0, 64);
-				strcpy(ln, database.GetGroupLeadershipInfo(group->GetID(), ln, MainTankName, AssistName, PullerName, NPCMarkerName, mentoree_name, &mentor_percent, &GLAA));
+				database.GetGroupLeadershipInfo(group->GetID(), ln, MainTankName, AssistName, PullerName, NPCMarkerName, mentoree_name, &mentor_percent, &GLAA);
 				Client *lc = entity_list.GetClientByName(ln);
 				if (lc)
 					group->SetLeader(lc);


### PR DESCRIPTION
```
==1810==ERROR: AddressSanitizer: strcpy-param-overlap: memory ranges [0x7ffef04baf90,0x7ffef04baf98) and [0x7ffef04baf90, 0x7ffef04baf98) overlap
    #0 0x7f163bb9509e  (/lib/x86_64-linux-gnu/libasan.so.5+0x4f09e)
    #1 0x5652caed27b3 in Client::Handle_Connect_OP_ZoneEntry(EQApplicationPacket const*) ../zone/client_packet.cpp:1535
```

```
==1918==ERROR: AddressSanitizer: strcpy-param-overlap: memory ranges [0x7ffddc8057c0,0x7ffddc8057c8) and [0x7ffddc8057c0, 0x7ffddc8057c8) overlap
    #0 0x7fc61ee0e09e  (/lib/x86_64-linux-gnu/libasan.so.5+0x4f09e)
    #1 0x56023c149698 in WorldServer::HandleMessage(unsigned short, EQ::Net::Packet const&) ../zone/worldserver.cpp:1055
```