### PR TITLE
[Quest API] Add secondstotime(duration) to Perl and Lua.

### DIFF
--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -6404,17 +6404,17 @@ XS(XS__createitem) {
 	XSRETURN(1);
 }
 
-XS(XS__converttime);
-XS(XS__converttime) {
+XS(XS__secondstotime);
+XS(XS__secondstotime) {
 	dXSARGS;
 	if (items != 1) {
-		Perl_croak(aTHX_ "Usage: quest::converttime(int duration)");
+		Perl_croak(aTHX_ "Usage: quest::secondstotime(int duration)");
 	}
 
 	dXSTARG;
 	std::string time_string;
 	int duration = (int) SvIV(ST(0));
-	time_string = quest_manager.converttime(duration);
+	time_string = quest_manager.secondstotime(duration);
 	sv_setpv(TARG, time_string.c_str());
 	XSprePUSH;
 	PUSHTARG;
@@ -6512,7 +6512,6 @@ EXTERN_C XS(boot_quest) {
 	newXS(strcpy(buf, "clearspawntimers"), XS__clearspawntimers, file);
 	newXS(strcpy(buf, "collectitems"), XS__collectitems, file);
 	newXS(strcpy(buf, "completedtasksinset"), XS__completedtasksinset, file);
-	newXS(strcpy(buf, "converttime"), XS__converttime, file);
 	newXS(strcpy(buf, "countitem"), XS__countitem, file);
 	newXS(strcpy(buf, "createdoor"), XS__CreateDoor, file);
 	newXS(strcpy(buf, "creategroundobject"), XS__CreateGroundObject, file);
@@ -6714,6 +6713,7 @@ EXTERN_C XS(boot_quest) {
 	newXS(strcpy(buf, "say"), XS__say, file);
 	newXS(strcpy(buf, "saylink"), XS__saylink, file);
 	newXS(strcpy(buf, "scribespells"), XS__scribespells, file);
+	newXS(strcpy(buf, "secondstotime"), XS__secondstotime, file);
 	newXS(strcpy(buf, "selfcast"), XS__selfcast, file);
 	newXS(strcpy(buf, "set_proximity"), XS__set_proximity, file);
 	newXS(strcpy(buf, "set_zone_flag"), XS__set_zone_flag, file);

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -6404,6 +6404,23 @@ XS(XS__createitem) {
 	XSRETURN(1);
 }
 
+XS(XS__converttime);
+XS(XS__converttime) {
+	dXSARGS;
+	if (items != 1) {
+		Perl_croak(aTHX_ "Usage: quest::converttime(int duration)");
+	}
+
+	dXSTARG;
+	std::string time_string;
+	int duration = (int) SvIV(ST(0));
+	time_string = quest_manager.converttime(duration);
+	sv_setpv(TARG, time_string.c_str());
+	XSprePUSH;
+	PUSHTARG;
+	XSRETURN(1);	
+}
+
 /*
 This is the callback perl will look for to setup the
 quest package's XSUBs
@@ -6495,6 +6512,7 @@ EXTERN_C XS(boot_quest) {
 	newXS(strcpy(buf, "clearspawntimers"), XS__clearspawntimers, file);
 	newXS(strcpy(buf, "collectitems"), XS__collectitems, file);
 	newXS(strcpy(buf, "completedtasksinset"), XS__completedtasksinset, file);
+	newXS(strcpy(buf, "converttime"), XS__converttime, file);
 	newXS(strcpy(buf, "countitem"), XS__countitem, file);
 	newXS(strcpy(buf, "createdoor"), XS__CreateDoor, file);
 	newXS(strcpy(buf, "creategroundobject"), XS__CreateGroundObject, file);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -2300,6 +2300,10 @@ void lua_remove_all_expedition_lockouts_by_char_id(uint32 char_id, std::string e
 	Expedition::RemoveLockoutsByCharacterID(char_id, expedition_name);
 }
 
+std::string lua_convert_time(int duration) {
+	return quest_manager.converttime(duration);
+}
+
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
 	cur = table[#name]; \
 	if(luabind::type(cur) != LUA_TNIL) { \
@@ -2836,6 +2840,7 @@ luabind::scope lua_register_general() {
 		luabind::def("debug", (void(*)(std::string))&lua_debug),
 		luabind::def("debug", (void(*)(std::string, int))&lua_debug),
 		luabind::def("log_combat", (void(*)(std::string))&lua_log_combat),
+		luabind::def("convert_time", &lua_convert_time),
 
 		/**
 		 * Expansions

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -2300,8 +2300,8 @@ void lua_remove_all_expedition_lockouts_by_char_id(uint32 char_id, std::string e
 	Expedition::RemoveLockoutsByCharacterID(char_id, expedition_name);
 }
 
-std::string lua_convert_time(int duration) {
-	return quest_manager.converttime(duration);
+std::string lua_seconds_to_time(int duration) {
+	return quest_manager.secondstotime(duration);
 }
 
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
@@ -2840,7 +2840,7 @@ luabind::scope lua_register_general() {
 		luabind::def("debug", (void(*)(std::string))&lua_debug),
 		luabind::def("debug", (void(*)(std::string, int))&lua_debug),
 		luabind::def("log_combat", (void(*)(std::string))&lua_log_combat),
-		luabind::def("convert_time", &lua_convert_time),
+		luabind::def("seconds_to_time", &lua_seconds_to_time),
 
 		/**
 		 * Expansions

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -4251,3 +4251,32 @@ EQ::ItemInstance *QuestManager::CreateItem(uint32 item_id, int16 charges, uint32
 	}
 	return nullptr;
 }
+
+std::string QuestManager::converttime(int duration) {
+	int timer_length = duration;
+	int hours = int(timer_length / 3600);
+	timer_length %= 3600;
+	int minutes = int(timer_length / 60);
+	timer_length %= 60;
+	int seconds = timer_length;
+	std::string time_string = "Unknown";
+	std::string hour_string = (hours == 1 ? "Hour" : "Hours");
+	std::string minute_string = (minutes == 1 ? "Minute" : "Minutes");
+	std::string second_string = (seconds == 1 ? "Second" : "Seconds");
+	if (hours > 0 && minutes > 0 && seconds > 0) {
+		time_string = fmt::format("{} {}, {} {}, and {} {}", hours, hour_string, minutes, minute_string, seconds, second_string);
+	} else if (hours > 0 && minutes > 0 && seconds == 0) {
+		time_string = fmt::format("{} {} and {} {}", hours, hour_string, minutes, minute_string);
+	} else if (hours > 0 && minutes == 0 && seconds > 0) {
+		time_string = fmt::format("{} {} and {} {}", hours, hour_string, seconds, second_string);
+	} else if (hours > 0 && minutes == 0 && seconds == 0) {
+		time_string = fmt::format("{} {}", hours, hour_string);
+	} else if (hours == 0 && minutes > 0 && seconds > 0) {
+		time_string = fmt::format("{} {} and {} {}", minutes, minute_string, seconds, second_string);
+	} else if (hours == 0 && minutes > 0 && seconds == 0) {
+		time_string = fmt::format("{} {}", minutes, minute_string);
+	} else if (hours == 0 && minutes == 0 && seconds > 0) {
+		time_string = fmt::format("{} {}", seconds, second_string);
+	}
+	return time_string;
+}

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -4252,7 +4252,7 @@ EQ::ItemInstance *QuestManager::CreateItem(uint32 item_id, int16 charges, uint32
 	return nullptr;
 }
 
-std::string QuestManager::converttime(int duration) {
+std::string QuestManager::secondstotime(int duration) {
 	int timer_length = duration;
 	int hours = int(timer_length / 3600);
 	timer_length %= 3600;

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -369,7 +369,7 @@ public:
 	bool DisableRecipe(uint32 recipe_id);
 	void ClearNPCTypeCache(int npctype_id);
 	void ReloadZoneStaticData();
-	std::string converttime(int duration);
+	std::string secondstotime(int duration);
 
 	Client *GetInitiator() const;
 	NPC *GetNPC() const;

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -369,6 +369,7 @@ public:
 	bool DisableRecipe(uint32 recipe_id);
 	void ClearNPCTypeCache(int npctype_id);
 	void ReloadZoneStaticData();
+	std::string converttime(int duration);
 
 	Client *GetInitiator() const;
 	NPC *GetNPC() const;


### PR DESCRIPTION
Converts time in seconds to human readable string.

- Add quest::secondstotime(duration) to Perl.
- Add eq.seconds_to_time(duration) to Lua.