### PR TITLE
[Leak] Port SpawnGroup stuff to unique_ptr to fix leak

### DIFF
--- a/zone/spawngroup.h
+++ b/zone/spawngroup.h
@@ -22,6 +22,7 @@
 
 #include <map>
 #include <list>
+#include <memory>
 
 class SpawnEntry {
 public:
@@ -55,7 +56,7 @@ public:
 
 	~SpawnGroup();
 	uint32 GetNPCType(uint16 condition_value_filter=1);
-	void AddSpawnEntry(SpawnEntry *newEntry);
+	void AddSpawnEntry(std::unique_ptr<SpawnEntry> &newEntry);
 	uint32 id;
 	bool wp_spawns;			// if true, spawn NPCs at a random waypoint location (if spawnpoint has a grid) instead of the spawnpoint's loc
 	float  roamdist;
@@ -66,7 +67,7 @@ public:
 	uint32 despawn_timer;
 private:
 	char name_[120];
-	std::list<SpawnEntry *> list_;
+	std::list<std::unique_ptr<SpawnEntry>> list_;
 	uint8 group_spawn_limit; //max # of this entry which can be spawned by this group
 };
 
@@ -75,14 +76,13 @@ public:
 	SpawnGroupList() {}
 	~SpawnGroupList();
 
-	void AddSpawnGroup(SpawnGroup *new_group);
+	void AddSpawnGroup(std::unique_ptr<SpawnGroup> &new_group);
 	SpawnGroup *GetSpawnGroup(uint32 id);
 	bool RemoveSpawnGroup(uint32 in_id);
 	void ClearSpawnGroups();
 	void ReloadSpawnGroups();
 private:
-	//LinkedList<SpawnGroup*> list_;
-	std::map<uint32, SpawnGroup *> m_spawn_groups;
+	std::map<uint32, std::unique_ptr<SpawnGroup>> m_spawn_groups;
 };
 
 #endif


### PR DESCRIPTION
This was leaking on #repop, unsure of other cases, smart pointers should
cover us though.

```
Direct leak of 3600 byte(s) in 18 object(s) allocated from:
    #0 0x7f2b3dbe0d30 in operator new(unsigned long) (/lib/x86_64-linux-gnu/libasan.so.5+0xead30)
    #1 0x5645dc7c9dff in ZoneDatabase::LoadSpawnGroups(char const*, unsigned short, SpawnGroupList*) ../zone/spawngroup.cpp:241
    #2 0x5645dc9db3f5 in Zone::Depop(bool) ../zone/zone.cpp:1746
    #3 0x5645dca1ba6b in Zone::Repop(unsigned int) ../zone/zone.cpp:1777
    #4 0x5645db4624b7 in command_repop(Client*, Seperator const*) ../zone/command.cpp:5683
```

```
Indirect leak of 6552 byte(s) in 273 object(s) allocated from:
    #0 0x7f26f2ff8d30 in operator new(unsigned long) (/lib/x86_64-linux-gnu/libasan.so.5+0xead30)
    #1 0x558d00490bc6 in __gnu_cxx::new_allocator<std::_List_node<SpawnEntry*> >::allocate(unsigned long, void const*) /usr/include/c++/8/ext/new_allocator.h:111
    #2 0x558d00490bc6 in std::allocator_traits<std::allocator<std::_List_node<SpawnEntry*> > >::allocate(std::allocator<std::_List_node<SpawnEntry*> >&, unsigned long) /usr/include/c++/8/bits/alloc_traits.h:436
    #3 0x558d00490bc6 in std::__cxx11::_List_base<SpawnEntry*, std::allocator<SpawnEntry*> >::_M_get_node() /usr/include/c++/8/bits/stl_list.h:450
    #4 0x558d00490bc6 in std::_List_node<SpawnEntry*>* std::__cxx11::list<SpawnEntry*, std::allocator<SpawnEntry*> >::_M_create_node<SpawnEntry* const&>(SpawnEntry* const&) /usr/include/c++/8/bits/stl_list.h:642
    #5 0x558d00490bc6 in void std::__cxx11::list<SpawnEntry*, std::allocator<SpawnEntry*> >::_M_insert<SpawnEntry* const&>(std::_List_iterator<SpawnEntry*>, SpawnEntry* const&) /usr/include/c++/8/bits/stl_list.h:1903
    #6 0x558d00490bc6 in std::__cxx11::list<SpawnEntry*, std::allocator<SpawnEntry*> >::push_back(SpawnEntry* const&) /usr/include/c++/8/bits/stl_list.h:1220
    #7 0x558d00490bc6 in SpawnGroup::AddSpawnEntry(SpawnEntry*) ../zone/spawngroup.cpp:122
    #8 0x558d00490bc6 in ZoneDatabase::LoadSpawnGroups(char const*, unsigned short, SpawnGroupList*) ../zone/spawngroup.cpp:291
    #9 0x558d006a1465 in Zone::Depop(bool) ../zone/zone.cpp:1746
    #10 0x558d006e1adb in Zone::Repop(unsigned int) ../zone/zone.cpp:1777
```