### PR TITLE
Fixed typo in description of #list command. [skip ci]

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -1763,7 +1763,7 @@ void command_list(Client *c, const Seperator *sep)
 	else {
 		c->Message(Chat::White, "Usage of #list");
 		c->Message(Chat::White, "- #list [npcs|players|corpses|doors|objects] [search]");
-		c->Message(Chat::White, "- Example: #list npc (Blank for all)");
+		c->Message(Chat::White, "- Example: #list npcs (Blank for all)");
 	}
 }
 


### PR DESCRIPTION
Fixed typo in the command description.