### PR TITLE
Remove unneeded calls to DoAnim() for spells/bardsong

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -2389,10 +2389,6 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, CastingSlot slot, ui
 		}
 	}
 
-	if (!spells[spell_id].cast_not_standing) {
-		DoAnim(spells[spell_id].CastingAnim, 0, true, IsClient() ? FilterPCSpells : FilterNPCSpells);
-	}
-
 	// Set and send the nimbus effect if this spell has one
 	int NimbusEffect = GetNimbusEffect(spell_id);
 	if(NimbusEffect) {
@@ -2642,8 +2638,6 @@ bool Mob::ApplyNextBardPulse(uint16 spell_id, Mob *spell_target, CastingSlot slo
 		}
 	}
 
-	//do we need to do this???
-	DoAnim(spells[spell_id].CastingAnim, 0, true, IsClient() ? FilterPCSpells : FilterNPCSpells);
 	if(IsClient())
 		CastToClient()->CheckSongSkillIncrease(spell_id);
 

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -2389,7 +2389,9 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, CastingSlot slot, ui
 		}
 	}
 
-	DoAnim(spells[spell_id].CastingAnim, 0, true, IsClient() ? FilterPCSpells : FilterNPCSpells);
+	if (slot != CastingSlot::Discipline) {
+		DoAnim(spells[spell_id].CastingAnim, 0, true, IsClient() ? FilterPCSpells : FilterNPCSpells);
+	}
 
 	// Set and send the nimbus effect if this spell has one
 	int NimbusEffect = GetNimbusEffect(spell_id);

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -2389,7 +2389,7 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, CastingSlot slot, ui
 		}
 	}
 
-	if (slot != CastingSlot::Discipline) {
+	if (!spells[spell_id].cast_not_standing) {
 		DoAnim(spells[spell_id].CastingAnim, 0, true, IsClient() ? FilterPCSpells : FilterNPCSpells);
 	}
 


### PR DESCRIPTION
I found that disciplines like "Focused Will" were causing our characters to stand up on the client, while on the server their sit/stand status was unchanged.  This got us out of sync with the GUI the next time sit/stand was pressed.

Testing Focused Will on live, it does not require the character to stand up, nor does the character do any animation aside from some glowing.  Testing non spell disciplines, both our server and live stand up first.

The change in this PR makes our server behave live like for Disciplines that cast spells for the disciplines I tested.  We still get the glowing effect, but the character sit/stand does not change.