### PR TITLE
[Expeditions] Throttle auto expedition leader changes

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -796,6 +796,7 @@ RULE_INT(Expedition, WorldExpeditionProcessRateMS, 6000, "Timer interval (ms) th
 RULE_BOOL(Expedition, AlwaysNotifyNewLeaderOnChange, false, "Always notify clients when made expedition leader. If false (live-like) new leaders are only notified when made leader via /dzmakeleader")
 RULE_REAL(Expedition, LockoutDurationMultiplier, 1.0, "Multiplies lockout duration by this value when new lockouts are added")
 RULE_BOOL(Expedition, EnableInDynamicZoneStatus, false, "Enables the 'In Dynamic Zone' member status in expedition window. If false (live-like) players inside the dz will show as 'Online'")
+RULE_INT(Expedition, ChooseLeaderCooldownTime, 2000, "Cooldown time (ms) between choosing a new leader for automatic leader changes")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(DynamicZone)

--- a/world/expedition.h
+++ b/world/expedition.h
@@ -37,6 +37,7 @@ public:
 	void RemoveMember(uint32_t character_id);
 	void RemoveAllMembers() { m_member_ids.clear(); }
 	void CheckExpireWarning();
+	void CheckLeader();
 	void ChooseNewLeader();
 	uint32_t GetID() const { return m_expedition_id; }
 	uint16_t GetInstanceID() const { return static_cast<uint16_t>(m_dz_instance_id); }
@@ -62,8 +63,10 @@ private:
 	uint32_t m_dz_instance_id = 0;
 	uint32_t m_dz_zone_id     = 0;
 	uint32_t m_leader_id      = 0;
-	bool     m_pending_delete = false;
-	Timer    m_warning_cooldown_timer;
+	bool m_pending_delete = false;
+	bool m_choose_leader_needed = false;
+	Timer m_choose_leader_cooldown_timer;
+	Timer m_warning_cooldown_timer;
 	std::vector<uint32_t> m_member_ids;
 	std::chrono::seconds m_duration;
 	std::chrono::time_point<std::chrono::system_clock> m_start_time;

--- a/world/expedition_state.cpp
+++ b/world/expedition_state.cpp
@@ -145,6 +145,7 @@ void ExpeditionState::Process()
 		else
 		{
 			it->CheckExpireWarning();
+			it->CheckLeader();
 		}
 
 		it = is_deleted ? m_expeditions.erase(it) : it + 1;


### PR DESCRIPTION
This fixes unnecessary leader processing on mass dzquits

Also marks leader dirty for empty expeditions in case something goes
wrong (shouldn't be possible after 62e480fe)