### PR TITLE
[Quest API] Add quest::get_spell_level(uint16 spell_id, uint8 class_id)

### DIFF
--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -899,6 +899,27 @@ XS(XS__getspellname) {
 	XSRETURN(1);
 }
 
+XS(XS__get_spell_level);
+XS(XS__get_spell_level) {
+	dXSARGS;
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: quest::get_spell_level(uint16 spell_id, uint8 class_id)");
+
+	dXSTARG;
+	uint16 spell_id = (int)SvIV(ST(0));
+	uint8 class_id = (int)SvIV(ST(1));
+	uint8 spell_level = IsValidSpell(spell_id) ? GetSpellLevel(spell_id, class_id) : 0;
+	uint8 server_max_level = RuleI(Character, MaxLevel);
+
+	if (spell_level && spell_level > server_max_level) 
+		spell_level = 0;
+	
+	XSprePUSH;
+	PUSHu((UV)spell_level);
+
+	XSRETURN(1);
+}
+
 XS(XS__getskillname);
 XS(XS__getskillname) {
 	dXSARGS;
@@ -6647,6 +6668,7 @@ EXTERN_C XS(boot_quest) {
 	newXS(strcpy(buf, "getraididbycharid"), XS__getraididbycharid, file);
 	newXS(strcpy(buf, "getracename"), XS__getracename, file);
 	newXS(strcpy(buf, "getspellname"), XS__getspellname, file);
+	newXS(strcpy(buf, "get_spell_level"), XS__get_spell_level, file);
 	newXS(strcpy(buf, "getskillname"), XS__getskillname, file);
 	newXS(strcpy(buf, "getlevel"), XS__getlevel, file);
 	newXS(strcpy(buf, "getplayerburiedcorpsecount"), XS__getplayerburiedcorpsecount, file);


### PR DESCRIPTION
I needed this for a spell scriber I am making.. Figured I'd put it here in case someone else finds it useful in the future. I searched for something that does this already but couldn't find anything.

This uses the already existing GetSpellLevel from spdat.cpp. Generally I would copy the naming scheme of similar methods (getspellname, getskillname) but the triple L made it quite ugly.

If the class provided cannot use the spell, the spell level is greater than the max level of the server, or an invalid spell is provided it will return 0.