### PR TITLE
[Boats] Fix x/y offsets from client to reflect EQ x/y instead of boat heading…

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4411,27 +4411,27 @@ void Client::Handle_OP_ClientUpdate(const EQApplicationPacket *app) {
 
 	PlayerPositionUpdateClient_Struct *ppu = (PlayerPositionUpdateClient_Struct *) app->pBuffer;
 
-	/* Boat handling */
-	if (ppu->spawn_id != GetID()) {
-		/* If player is controlling boat */
-		if (ppu->spawn_id && ppu->spawn_id == controlling_boat_id) {
-			Mob *boat = entity_list.GetMob(controlling_boat_id);
-			if (boat == 0) {
-				controlling_boat_id = 0;
-				return;
-			}
+	/* Non PC handling like boats and eye of zomm */
+	if (ppu->spawn_id && ppu->spawn_id != GetID()) {
+		Mob *cmob = entity_list.GetMob(ppu->spawn_id);
 
+		if (!cmob) {
+			return;
+		}
+
+		if (cmob->IsControllableBoat()) {
+			// Controllable boats
 			auto boat_delta = glm::vec4(ppu->delta_x, ppu->delta_y, ppu->delta_z, EQ10toFloat(ppu->delta_heading));
-			boat->SetDelta(boat_delta);
+			cmob->SetDelta(boat_delta);
 
 			auto outapp = new EQApplicationPacket(OP_ClientUpdate, sizeof(PlayerPositionUpdateServer_Struct));
 			PlayerPositionUpdateServer_Struct *ppus = (PlayerPositionUpdateServer_Struct *) outapp->pBuffer;
-			boat->MakeSpawnUpdate(ppus);
-			entity_list.QueueCloseClients(boat, outapp, true, 300, this, false);
+			cmob->MakeSpawnUpdate(ppus);
+			entity_list.QueueCloseClients(cmob, outapp, true, 300, this, false);
 			safe_delete(outapp);
 
 			/* Update the boat's position on the server, without sending an update */
-			boat->GMMove(ppu->x_pos, ppu->y_pos, ppu->z_pos, EQ12toFloat(ppu->heading), false);
+			cmob->GMMove(ppu->x_pos, ppu->y_pos, ppu->z_pos, EQ12toFloat(ppu->heading), false);
 			return;
 		}
 		else {
@@ -4439,16 +4439,13 @@ void Client::Handle_OP_ClientUpdate(const EQApplicationPacket *app) {
 			// so that other clients see it.  I could add a check here for eye of zomm
 			// race, to limit this code, but this should handle any client controlled
 			// mob that gets updates from OP_ClientUpdate
-			if (ppu->spawn_id == controlled_mob_id) {
-				Mob *cmob = entity_list.GetMob(ppu->spawn_id);
-				if (cmob != nullptr) {
-					cmob->SetPosition(ppu->x_pos, ppu->y_pos, ppu->z_pos);
-					cmob->SetHeading(EQ12toFloat(ppu->heading));
-					mMovementManager->SendCommandToClients(cmob, 0.0, 0.0, 0.0,
-							0.0, 0, ClientRangeAny, nullptr, this);
-					cmob->CastToNPC()->SaveGuardSpot(glm::vec4(ppu->x_pos,
-							ppu->y_pos, ppu->z_pos, EQ12toFloat(ppu->heading)));
-				}
+			if (!cmob->IsControllableBoat() && ppu->spawn_id == controlled_mob_id) {
+				cmob->SetPosition(ppu->x_pos, ppu->y_pos, ppu->z_pos);
+				cmob->SetHeading(EQ12toFloat(ppu->heading));
+				mMovementManager->SendCommandToClients(cmob, 0.0, 0.0, 0.0,
+						0.0, 0, ClientRangeAny, nullptr, this);
+				cmob->CastToNPC()->SaveGuardSpot(glm::vec4(ppu->x_pos,
+						ppu->y_pos, ppu->z_pos, EQ12toFloat(ppu->heading)));
 			}
 		}
 	return;
@@ -4476,9 +4473,19 @@ void Client::Handle_OP_ClientUpdate(const EQApplicationPacket *app) {
 			LogError("Can't find boat for client position offset.");
 		}
 		else {
-			cx += boat->GetX();
-			cy += boat->GetY();
+			// Calculate angle from boat heading to EQ heading
+			float theta = fmod(((boat->GetHeading() * 360.0) / 512.0),360.0);
+			float thetar = (theta * M_PI) / 180.0;
+
+			// Boat cx is inverted (positive to left)
+			// Boat cy is normal (positive toward heading)
+			float normalizedx, normalizedy;	
+			normalizedx = cx * cos(thetar) - -cy * sin(thetar);
+			normalizedy = -cx * sin(thetar) + cy * cos(thetar);
+			cx = boat->GetX() + normalizedx;
+			cy = boat->GetY() + normalizedy;
 			cz += boat->GetZ();
+
 			new_heading += boat->GetHeading();
 		}
 	}

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4474,14 +4474,20 @@ void Client::Handle_OP_ClientUpdate(const EQApplicationPacket *app) {
 		}
 		else {
 			// Calculate angle from boat heading to EQ heading
-			float theta = fmod(((boat->GetHeading() * 360.0) / 512.0),360.0);
-			float thetar = (theta * M_PI) / 180.0;
+			double theta = std::fmod(((boat->GetHeading() * 360.0) / 512.0),360.0);
+			double thetar = (theta * M_PI) / 180.0;
+
+			if (log) LogError("theta[{}] cx[{}] cy[{}]", theta, cx, cy);
 
 			// Boat cx is inverted (positive to left)
 			// Boat cy is normal (positive toward heading)
-			float normalizedx, normalizedy;	
-			normalizedx = cx * cos(thetar) - -cy * sin(thetar);
-			normalizedy = -cx * sin(thetar) + cy * cos(thetar);
+			double cosine = std::cos(thetar);
+			double sine = std::sin(thetar);
+
+			double normalizedx, normalizedy;	
+			normalizedx = cx * cosine - -cy * sine;
+			normalizedy = -cx * sine + cy * cosine;
+
 			cx = boat->GetX() + normalizedx;
 			cy = boat->GetY() + normalizedy;
 			cz += boat->GetZ();

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4477,8 +4477,6 @@ void Client::Handle_OP_ClientUpdate(const EQApplicationPacket *app) {
 			double theta = std::fmod(((boat->GetHeading() * 360.0) / 512.0),360.0);
 			double thetar = (theta * M_PI) / 180.0;
 
-			if (log) LogError("theta[{}] cx[{}] cy[{}]", theta, cx, cy);
-
 			// Boat cx is inverted (positive to left)
 			// Boat cy is normal (positive toward heading)
 			double cosine = std::cos(thetar);


### PR DESCRIPTION
At the end of  2019 I pushed a [[PR](https://github.com/EQEmu/Server/pull/937)] ( with @Uleat ) which corrected an issue where clients did not properly see other clients that were on a boat.  This was because the x/y sent by the client is an offset from the center of the boat they are on,  when the client is onboard.  We had no code for this, so the moment a client went onto a boat they warped off to close to 0,0 on other client's screens.

I've come to learn, while trying to get cross zone ports from boat to boat working, that the client x,y is also an x,y offset which is based on the boat's heading.  So if the boat has a heading of 0, the x,y offsets are correct in EQ map coordinates, but if the boat is at heading of 128 for example, the x,y sent by the client need to be rotated about the boat's origin to get correct x,y offsets in the EQ map world.

To complicate matters, simple rotation around the boat origin math needed to be altered due to the fact that the EQ X axis is negative to the right, while most axis systems are x positive to the right.

I believe this PR will:

- render clients on the boat in the correct location for other viewing clients
- will not change the view from the rider's perspective as they don't get these updates
- will not fix the drift that we all see.. that is a client issue as best I can tell - where on some angles (mostly non integer) the x,y offsets drift due to rounding (or some other math issue)
- clients actual x and y values will be correct if queried from quests when on a boat (they used to be off by rotation)

The PR also modifies the boat/zomm code slightly to share a variable to clean up that code a little.
