### PR TITLE
Fix for spawn2.version

### DIFF
--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -899,6 +899,27 @@ XS(XS__getspellname) {
 	XSRETURN(1);
 }
 
+XS(XS__get_spell_level);
+XS(XS__get_spell_level) {
+	dXSARGS;
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: quest::get_spell_level(uint16 spell_id, uint8 class_id)");
+
+	dXSTARG;
+	uint16 spell_id = (int)SvIV(ST(0));
+	uint8 class_id = (int)SvIV(ST(1));
+	uint8 spell_level = IsValidSpell(spell_id) ? GetSpellLevel(spell_id, class_id) : 0;
+	uint8 server_max_level = RuleI(Character, MaxLevel);
+
+	if (spell_level && spell_level > server_max_level) 
+		spell_level = 0;
+	
+	XSprePUSH;
+	PUSHu((UV)spell_level);
+
+	XSRETURN(1);
+}
+
 XS(XS__getskillname);
 XS(XS__getskillname) {
 	dXSARGS;
@@ -6647,6 +6668,7 @@ EXTERN_C XS(boot_quest) {
 	newXS(strcpy(buf, "getraididbycharid"), XS__getraididbycharid, file);
 	newXS(strcpy(buf, "getracename"), XS__getracename, file);
 	newXS(strcpy(buf, "getspellname"), XS__getspellname, file);
+	newXS(strcpy(buf, "get_spell_level"), XS__get_spell_level, file);
 	newXS(strcpy(buf, "getskillname"), XS__getskillname, file);
 	newXS(strcpy(buf, "getlevel"), XS__getlevel, file);
 	newXS(strcpy(buf, "getplayerburiedcorpsecount"), XS__getplayerburiedcorpsecount, file);

--- a/zone/spawngroup.cpp
+++ b/zone/spawngroup.cpp
@@ -191,7 +191,8 @@ bool ZoneDatabase::LoadSpawnGroups(const char *zone_name, uint16 version, SpawnG
 				WHERE
 				spawn2.spawngroupID = spawngroup.ID
 				AND
-				spawn2.version = {} and zone = '{}'
+				(spawn2.version = {} OR version = -1)
+				AND zone = '{}'
 				{}
 		),
 		version,


### PR DESCRIPTION
setting spawn2.version to -1 will now properly spawn mobs in all zone versions.