### PR TITLE
[Bugfix] Fix for spawn2.version

### DIFF
--- a/zone/spawngroup.cpp
+++ b/zone/spawngroup.cpp
@@ -191,7 +191,8 @@ bool ZoneDatabase::LoadSpawnGroups(const char *zone_name, uint16 version, SpawnG
 				WHERE
 				spawn2.spawngroupID = spawngroup.ID
 				AND
-				spawn2.version = {} and zone = '{}'
+				(spawn2.version = {} OR version = -1)
+				AND zone = '{}'
 				{}
 		),
 		version,


### PR DESCRIPTION
setting spawn2.version to -1 will now properly spawn mobs in all zone versions