### PR TITLE
[Expeditions] Cleanup client dz safe return methods

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -9901,21 +9901,20 @@ std::unique_ptr<EQApplicationPacket> Client::CreateCompassPacket(
 	return outapp;
 }
 
-void Client::GoToDzSafeReturnOrBind(const DynamicZone& dynamic_zone)
+void Client::GoToDzSafeReturnOrBind(const DynamicZone* dynamic_zone)
 {
-	auto safereturn = dynamic_zone.GetSafeReturnLocation();
-	LogDynamicZonesDetail(
-		"Sending character [{}] to safereturn zone [{}] or bind", CharacterID(), safereturn.zone_id
-	);
+	if (dynamic_zone)
+	{
+		auto safereturn = dynamic_zone->GetSafeReturnLocation();
+		if (safereturn.zone_id != 0)
+		{
+			LogDynamicZonesDetail("Sending [{}] to safereturn zone [{}]", CharacterID(), safereturn.zone_id);
+			MovePC(safereturn.zone_id, 0, safereturn.x, safereturn.y, safereturn.z, safereturn.heading);
+			return;
+		}
+	}
 
-	if (!dynamic_zone.IsValid() || safereturn.zone_id == 0)
-	{
-		GoToBind();
-	}
-	else
-	{
-		MovePC(safereturn.zone_id, 0, safereturn.x, safereturn.y, safereturn.z, safereturn.heading);
-	}
+	GoToBind();
 }
 
 std::vector<DynamicZone*> Client::GetDynamicZones(uint32_t zone_id, int zone_version)

--- a/zone/client.h
+++ b/zone/client.h
@@ -1352,7 +1352,7 @@ public:
 	void DzListTimers();
 	void SetDzRemovalTimer(bool enable_timer);
 	void SendDzCompassUpdate();
-	void GoToDzSafeReturnOrBind(const DynamicZone& dynamic_zone);
+	void GoToDzSafeReturnOrBind(const DynamicZone* dynamic_zone);
 	void MovePCDynamicZone(uint32 zone_id, int zone_version = -1, bool msg_if_invalid = true);
 	void MovePCDynamicZone(const std::string& zone_name, int zone_version = -1, bool msg_if_invalid = true);
 	std::vector<DynamicZone*> GetDynamicZones(uint32_t zone_id = 0, int zone_version = -1);

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -5251,16 +5251,7 @@ std::unordered_map<uint16, Mob *> &EntityList::GetCloseMobList(Mob *mob, float d
 
 void EntityList::GateAllClientsToSafeReturn()
 {
-	DynamicZone dz;
-	if (zone)
-	{
-		dz = zone->GetDynamicZone();
-
-		LogDynamicZones(
-			"Sending all clients in zone: [{}] instance: [{}] to dz safereturn or bind",
-			zone->GetZoneID(), zone->GetInstanceID()
-		);
-	}
+	DynamicZone* dz = zone ? zone->GetDynamicZone() : nullptr;
 
 	for (const auto& client_list_iter : client_list)
 	{

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -2729,20 +2729,20 @@ bool Zone::IsZone(uint32 zone_id, uint16 instance_id) const
 	return (zoneid == zone_id && instanceid == instance_id);
 }
 
-DynamicZone Zone::GetDynamicZone()
+DynamicZone* Zone::GetDynamicZone()
 {
 	if (GetInstanceID() == 0)
 	{
-		return {}; // invalid
+		return nullptr;
 	}
 
 	auto expedition = Expedition::FindCachedExpeditionByZoneInstance(GetZoneID(), GetInstanceID());
 	if (expedition)
 	{
-		return expedition->GetDynamicZone();
+		return &expedition->GetDynamicZone();
 	}
 
 	// todo: tasks, missions, and quests with an associated dz for this instance id
 
-	return {}; // invalid
+	return nullptr;
 }

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -33,9 +33,10 @@
 #include "spawn2.h"
 #include "spawngroup.h"
 #include "aa_ability.h"
-#include "dynamic_zone.h"
 #include "pathfinder_interface.h"
 #include "global_loot_manager.h"
+
+class DynamicZone;
 
 struct ZonePoint {
 	float  x;
@@ -178,7 +179,7 @@ public:
 	void DumpMerchantList(uint32 npcid);
 	int SaveTempItem(uint32 merchantid, uint32 npcid, uint32 item, int32 charges, bool sold = false);
 	int32 MobsAggroCount() { return aggroedmobs; }
-	DynamicZone GetDynamicZone();
+	DynamicZone* GetDynamicZone();
 
 	IPathfinder                                   *pathing;
 	LinkedList<NPC_Emote_Struct *>                NPCEmoteList;


### PR DESCRIPTION
This changes Zone::GetDynamicZone to return a pointer instead of a copy
and also lets DynamicZone be forward declared in zone.h