### PR TITLE
[Expeditions] Refactor expedition requests

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -31,6 +31,7 @@ SET(common_sources
 	eq_stream_proxy.cpp
 	eqtime.cpp
 	event_sub.cpp
+	expedition_lockout_timer.cpp
 	extprofile.cpp
 	faction.cpp
 	file_util.cpp
@@ -488,6 +489,7 @@ SET(common_headers
 	eqtime.h
 	errmsg.h
 	event_sub.h
+	expedition_lockout_timer.h
 	extprofile.h
 	faction.h
 	file_util.h

--- a/common/expedition_lockout_timer.cpp
+++ b/common/expedition_lockout_timer.cpp
@@ -27,16 +27,16 @@
 const char* const DZ_REPLAY_TIMER_NAME = "Replay Timer"; // see December 14, 2016 patch notes
 
 ExpeditionLockoutTimer::ExpeditionLockoutTimer(
-	const std::string& expedition_uuid, const std::string& expedition_name,
-	const std::string& event_name, uint64_t expire_time, uint32_t duration
+	std::string expedition_uuid, std::string expedition_name,
+	std::string event_name, uint64_t expire_time, uint32_t duration
 ) :
-	m_expedition_uuid(expedition_uuid),
-	m_expedition_name(expedition_name),
-	m_event_name(event_name),
+	m_expedition_uuid{std::move(expedition_uuid)},
+	m_expedition_name{std::move(expedition_name)},
+	m_event_name{std::move(event_name)},
 	m_expire_time(std::chrono::system_clock::from_time_t(expire_time)),
 	m_duration(duration)
 {
-	if (event_name == DZ_REPLAY_TIMER_NAME)
+	if (m_event_name == DZ_REPLAY_TIMER_NAME)
 	{
 		m_is_replay_timer = true;
 	}

--- a/common/expedition_lockout_timer.h
+++ b/common/expedition_lockout_timer.h
@@ -31,8 +31,8 @@ class ExpeditionLockoutTimer
 public:
 	ExpeditionLockoutTimer() = default;
 	ExpeditionLockoutTimer(
-		const std::string& expedition_uuid, const std::string& expedition_name,
-		const std::string& event_name, uint64_t expire_time, uint32_t duration);
+		std::string expedition_uuid, std::string expedition_name,
+		std::string event_name, uint64_t expire_time, uint32_t duration);
 
 	static ExpeditionLockoutTimer CreateLockout(
 		const std::string& expedition_name, const std::string& event_name,

--- a/common/repositories/base/base_character_expedition_lockouts_repository.h
+++ b/common/repositories/base/base_character_expedition_lockouts_repository.h
@@ -81,7 +81,7 @@ public:
 		entry.character_id         = 0;
 		entry.expedition_name      = "";
 		entry.event_name           = "";
-		entry.expire_time          = current_timestamp();
+		entry.expire_time          = "";
 		entry.duration             = 0;
 		entry.from_expedition_uuid = "";
 

--- a/common/repositories/character_expedition_lockouts_repository.h
+++ b/common/repositories/character_expedition_lockouts_repository.h
@@ -22,8 +22,10 @@
 #define EQEMU_CHARACTER_EXPEDITION_LOCKOUTS_REPOSITORY_H
 
 #include "../database.h"
+#include "../expedition_lockout_timer.h"
 #include "../string_util.h"
 #include "base/base_character_expedition_lockouts_repository.h"
+#include <unordered_map>
 
 class CharacterExpeditionLockoutsRepository: public BaseCharacterExpeditionLockoutsRepository {
 public:
@@ -65,6 +67,78 @@ public:
 
 	// Custom extended repository methods here
 
+	struct CharacterExpeditionLockoutsTimeStamp {
+		int         id;
+		int         character_id;
+		std::string expedition_name;
+		std::string event_name;
+		time_t      expire_time;
+		int         duration;
+		std::string from_expedition_uuid;
+	};
+
+	static ExpeditionLockoutTimer GetExpeditionLockoutTimerFromEntry(
+		CharacterExpeditionLockoutsTimeStamp&& entry)
+	{
+		ExpeditionLockoutTimer lockout_timer{
+			std::move(entry.from_expedition_uuid),
+			std::move(entry.expedition_name),
+			std::move(entry.event_name),
+			static_cast<uint64_t>(entry.expire_time),
+			static_cast<uint32_t>(entry.duration)
+		};
+
+		return lockout_timer;
+	}
+
+	static std::unordered_map<uint32_t, std::vector<ExpeditionLockoutTimer>> GetManyCharacterLockoutTimers(
+		Database& db, const std::vector<uint32_t>& character_ids,
+		const std::string& expedition_name, const std::string& ordered_event_name)
+	{
+		auto joined_character_ids = fmt::join(character_ids, ",");
+
+		auto results = db.QueryDatabase(fmt::format(SQL(
+			SELECT
+				character_id,
+				UNIX_TIMESTAMP(expire_time),
+				duration,
+				event_name,
+				from_expedition_uuid
+			FROM character_expedition_lockouts
+			WHERE
+				character_id IN ({})
+				AND expire_time > NOW()
+				AND expedition_name = '{}'
+			ORDER BY
+				FIELD(character_id, {}),
+				FIELD(event_name, '{}') DESC
+		),
+			joined_character_ids,
+			EscapeString(expedition_name),
+			joined_character_ids,
+			EscapeString(ordered_event_name)
+		));
+
+		std::unordered_map<uint32_t, std::vector<ExpeditionLockoutTimer>> lockouts;
+
+		for (auto row = results.begin(); row != results.end(); ++row)
+		{
+			CharacterExpeditionLockoutsTimeStamp entry{};
+
+			int col = 0;
+			entry.character_id         = std::strtoul(row[col++], nullptr, 10);
+			entry.expire_time          = std::strtoull(row[col++], nullptr, 10);
+			entry.duration             = std::strtoul(row[col++], nullptr, 10);
+			entry.event_name           = row[col++];
+			entry.expedition_name      = expedition_name;
+			entry.from_expedition_uuid = row[col++];
+
+			auto lockout = GetExpeditionLockoutTimerFromEntry(std::move(entry));
+			lockouts[entry.character_id].emplace_back(std::move(lockout));
+		}
+
+		return lockouts;
+	}
 };
 
 #endif //EQEMU_CHARACTER_EXPEDITION_LOCKOUTS_REPOSITORY_H

--- a/zone/CMakeLists.txt
+++ b/zone/CMakeLists.txt
@@ -33,7 +33,6 @@ SET(zone_sources
 	exp.cpp
 	expedition.cpp
 	expedition_database.cpp
-	expedition_lockout_timer.cpp
 	expedition_request.cpp
 	fastmath.cpp
 	fearpath.cpp
@@ -186,7 +185,6 @@ SET(zone_headers
 	event_codes.h
 	expedition.h
 	expedition_database.h
-	expedition_lockout_timer.h
 	expedition_request.h
 	fastmath.h
 	forage.h

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -42,7 +42,6 @@ extern volatile bool RunLoops;
 #include "data_bucket.h"
 #include "expedition.h"
 #include "expedition_database.h"
-#include "expedition_lockout_timer.h"
 #include "expedition_request.h"
 #include "position.h"
 #include "worldserver.h"
@@ -61,6 +60,7 @@ extern volatile bool RunLoops;
 #include "queryserv.h"
 #include "mob_movement_manager.h"
 #include "../common/content/world_content_service.h"
+#include "../common/expedition_lockout_timer.h"
 
 extern QueryServ* QServ;
 extern EntityList entity_list;

--- a/zone/expedition.cpp
+++ b/zone/expedition.cpp
@@ -20,13 +20,13 @@
 
 #include "expedition.h"
 #include "expedition_database.h"
-#include "expedition_lockout_timer.h"
 #include "expedition_request.h"
 #include "client.h"
 #include "string_ids.h"
 #include "worldserver.h"
 #include "zonedb.h"
 #include "../common/eqemu_logsys.h"
+#include "../common/expedition_lockout_timer.h"
 #include "../common/util/uuid.h"
 
 extern WorldServer worldserver;

--- a/zone/expedition.h
+++ b/zone/expedition.h
@@ -22,8 +22,8 @@
 #define EXPEDITION_H
 
 #include "dynamic_zone.h"
-#include "expedition_lockout_timer.h"
 #include "../common/eq_constants.h"
+#include "../common/expedition_lockout_timer.h"
 #include <cstdint>
 #include <memory>
 #include <string>

--- a/zone/expedition_database.h
+++ b/zone/expedition_database.h
@@ -41,8 +41,6 @@ namespace ExpeditionDatabase
 	std::string LoadExpeditionsSelectQuery();
 	MySQLRequestResult LoadExpedition(uint32_t expedition_id);
 	MySQLRequestResult LoadAllExpeditions();
-	MySQLRequestResult LoadMembersForCreateRequest(
-		const std::vector<std::string>& character_names, const std::string& expedition_name);
 	std::vector<ExpeditionLockoutTimer> LoadCharacterLockouts(uint32_t character_id);
 	std::vector<ExpeditionLockoutTimer> LoadCharacterLockouts(uint32_t character_id,
 		const std::string& expedition_name);
@@ -91,20 +89,6 @@ namespace LoadExpeditionColumns
 		leader_name,
 		member_id,
 		member_name
-	};
-};
-
-namespace LoadMembersForCreateRequestColumns
-{
-	enum eLoadMembersForCreateRequestColumns
-	{
-		character_id = 0,
-		character_name,
-		character_expedition_id,
-		lockout_uuid,
-		lockout_expire_time,
-		lockout_duration,
-		lockout_event_name
 	};
 };
 

--- a/zone/expedition_request.h
+++ b/zone/expedition_request.h
@@ -22,7 +22,7 @@
 #define EXPEDITION_REQUEST_H
 
 #include "expedition.h"
-#include "expedition_lockout_timer.h"
+#include "../common/expedition_lockout_timer.h"
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -30,16 +30,13 @@
 
 class Client;
 class Group;
-class MySQLRequestResult;
 class Raid;
-class ServerPacket;
 
 class ExpeditionRequest
 {
 public:
-	ExpeditionRequest(
-		std::string expedition_name, uint32_t min_players, uint32_t max_players,
-		bool disable_messages = false);
+	ExpeditionRequest(std::string expedition_name, uint32_t min_players,
+		uint32_t max_players, bool disable_messages = false);
 
 	bool Validate(Client* requester);
 
@@ -60,7 +57,7 @@ private:
 	bool CheckMembersForConflicts(const std::vector<std::string>& member_names);
 	std::string GetGroupLeaderName(uint32_t group_id);
 	bool IsPlayerCountValidated();
-	bool LoadLeaderLockouts();
+	bool SaveLeaderLockouts(const std::vector<ExpeditionLockoutTimer>& leader_lockouts);
 	void SendLeaderMemberInExpedition(const std::string& member_name, bool is_solo);
 	void SendLeaderMemberReplayLockout(const std::string& member_name, const ExpeditionLockoutTimer& lockout, bool is_solo);
 	void SendLeaderMemberEventLockout(const std::string& member_name, const ExpeditionLockoutTimer& lockout);
@@ -71,7 +68,6 @@ private:
 	uint32_t m_leader_id            = 0;
 	uint32_t m_min_players          = 0;
 	uint32_t m_max_players          = 0;
-	bool     m_check_event_lockouts = true;
 	bool     m_disable_messages     = false;
 	std::string m_expedition_name;
 	std::string m_leader_name;

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -5,7 +5,6 @@
 
 #include "client.h"
 #include "dynamic_zone.h"
-#include "expedition_lockout_timer.h"
 #include "expedition_request.h"
 #include "lua_client.h"
 #include "lua_expedition.h"
@@ -16,6 +15,7 @@
 #include "lua_group.h"
 #include "lua_raid.h"
 #include "lua_packet.h"
+#include "../common/expedition_lockout_timer.h"
 
 struct InventoryWhere { };
 


### PR DESCRIPTION
Move ExpeditionLockoutTimer to common

This simplifies expedition request conflict checks and uses repository
for the queries instead of processing the query result directly.