### PR TITLE
[Bug Fix] Add Bounds Checking to OP_LFGCommand Comment Processing

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -9190,7 +9190,7 @@ void Client::Handle_OP_LFGCommand(const EQApplicationPacket *app)
 		LFGFromLevel = lfg->FromLevel;
 		LFGToLevel = lfg->ToLevel;
 		LFGMatchFilter = lfg->MatchFilter;
-		strcpy(LFGComments, lfg->Comments);
+		strn0cpy(LFGComments, lfg->Comments, sizeof(LFGComments));
 		break;
 	default:
 		Message(0, "Error: unknown LFG value %i", lfg->value);


### PR DESCRIPTION
Theoretically this could be used to corrupt memory, but they would have
to get extremely lucky to actually execute a successful attack