### PR TITLE
[Expeditions] Decouple dz updates from expeditions

### DIFF
--- a/common/eq_constants.h
+++ b/common/eq_constants.h
@@ -464,4 +464,14 @@ namespace ZoneBlockedSpellTypes {
 	const uint8 Region   = 2;
 };
 
+enum class DynamicZoneType
+{
+	None = 0,
+	Expedition,
+	Tutorial,
+	Task,
+	Mission, // Shared Task
+	Quest
+};
+
 #endif /*COMMON_EQ_CONSTANTS_H*/

--- a/common/repositories/instance_list_repository.h
+++ b/common/repositories/instance_list_repository.h
@@ -65,6 +65,15 @@ public:
 
 	// Custom extended repository methods here
 
+	static int UpdateDuration(Database& db, int instance_id, uint32_t new_duration)
+	{
+		auto results = db.QueryDatabase(fmt::format(
+			"UPDATE {} SET duration = {} WHERE {} = {};",
+			TableName(), new_duration, PrimaryKey(), instance_id
+		));
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
 };
 
 #endif //EQEMU_INSTANCE_LIST_REPOSITORY_H

--- a/common/servertalk.h
+++ b/common/servertalk.h
@@ -151,23 +151,23 @@
 #define ServerOP_ExpeditionGetOnlineMembers   0x0407
 #define ServerOP_ExpeditionDzAddPlayer        0x0408
 #define ServerOP_ExpeditionDzMakeLeader       0x0409
-#define ServerOP_ExpeditionDzCompass          0x040a
-#define ServerOP_ExpeditionDzSafeReturn       0x040b
-#define ServerOP_ExpeditionDzZoneIn           0x040c
 #define ServerOP_ExpeditionCharacterLockout   0x040d
 #define ServerOP_ExpeditionSaveInvite         0x040e
 #define ServerOP_ExpeditionRequestInvite      0x040f
 #define ServerOP_ExpeditionReplayOnJoin       0x0410
 #define ServerOP_ExpeditionLockState          0x0411
 #define ServerOP_ExpeditionMembersRemoved     0x0412
-#define ServerOP_ExpeditionDzDuration         0x0413
 #define ServerOP_ExpeditionLockoutDuration    0x0414
-#define ServerOP_ExpeditionSecondsRemaining   0x0415
 #define ServerOP_ExpeditionExpireWarning      0x0416
 #define ServerOP_ExpeditionChooseNewLeader    0x0417
 
 #define ServerOP_DzCharacterChange            0x0450
 #define ServerOP_DzRemoveAllCharacters        0x0451
+#define ServerOP_DzSetSecondsRemaining        0x0452
+#define ServerOP_DzDurationUpdate             0x0453
+#define ServerOP_DzSetCompass                 0x0454
+#define ServerOP_DzSetSafeReturn              0x0455
+#define ServerOP_DzSetZoneIn                  0x0456
 
 #define ServerOP_LSInfo				0x1000
 #define ServerOP_LSStatus			0x1001
@@ -2090,11 +2090,6 @@ struct ServerExpeditionCharacterID_Struct {
 	uint32_t character_id;
 };
 
-struct ServerExpeditionUpdateDuration_Struct {
-	uint32_t expedition_id;
-	uint32_t new_duration_seconds;
-};
-
 struct ServerExpeditionExpireWarning_Struct {
 	uint32_t expedition_id;
 	uint32_t minutes_remaining;
@@ -2117,12 +2112,10 @@ struct ServerDzCommandMakeLeader_Struct {
 };
 
 struct ServerDzLocation_Struct {
-	uint32 owner_id;           // system associated with the dz (expedition, shared task, etc)
-	uint16 dz_zone_id;
-	uint16 dz_instance_id;
+	uint32 dz_id;
 	uint32 sender_zone_id;
 	uint16 sender_instance_id;
-	uint32 zone_id;            // compass or safereturn zone id
+	uint32 zone_id;
 	float  y;
 	float  x;
 	float  z;
@@ -2134,6 +2127,11 @@ struct ServerDzCharacter_Struct {
 	uint16 instance_id;
 	uint8  remove; // 0: added 1: removed
 	uint32 character_id;
+};
+
+struct ServerDzSetDuration_Struct {
+	uint32 dz_id;
+	uint32 seconds;
 };
 
 #pragma pack()

--- a/world/CMakeLists.txt
+++ b/world/CMakeLists.txt
@@ -7,6 +7,7 @@ SET(world_sources
 	cliententry.cpp
 	clientlist.cpp
 	console.cpp
+	dynamic_zone.cpp
 	eql_config.cpp
 	eqemu_api_world_data_service.cpp
 	expedition.cpp
@@ -41,6 +42,7 @@ SET(world_headers
 	cliententry.h
 	clientlist.h
 	console.h
+	dynamic_zone.h
 	eql_config.h
 	eqemu_api_world_data_service.h
 	expedition.h

--- a/world/dynamic_zone.cpp
+++ b/world/dynamic_zone.cpp
@@ -1,0 +1,103 @@
+#include "dynamic_zone.h"
+#include "expedition.h"
+#include "expedition_state.h"
+#include "worlddb.h"
+#include "zonelist.h"
+#include "zoneserver.h"
+#include "../common/eqemu_logsys.h"
+#include "../common/repositories/instance_list_repository.h"
+
+extern ZSList zoneserver_list;
+
+DynamicZone::DynamicZone(
+	uint32_t id, uint32_t zone_id, uint32_t instance_id, uint32_t zone_version,
+	uint32_t start_time, uint32_t duration, DynamicZoneType type
+) :
+	m_id(id),
+	m_instance_id(instance_id),
+	m_zone_id(zone_id),
+	m_zone_version(zone_version),
+	m_start_time(std::chrono::system_clock::from_time_t(start_time)),
+	m_duration(duration),
+	m_type(type),
+	m_expire_time(m_start_time + m_duration)
+{
+}
+
+DynamicZone* DynamicZone::FindDynamicZoneByID(uint32_t dz_id)
+{
+	auto expedition = expedition_state.GetExpeditionByDynamicZoneID(dz_id);
+	if (expedition)
+	{
+		return &expedition->GetDynamicZone();
+	}
+	// todo: other system caches
+	return nullptr;
+}
+
+void DynamicZone::SetSecondsRemaining(uint32_t seconds_remaining)
+{
+	auto now = std::chrono::system_clock::now();
+	auto new_remaining = std::chrono::seconds(seconds_remaining);
+
+	auto current_remaining = m_expire_time - now;
+	if (current_remaining > new_remaining) // reduce only
+	{
+		LogDynamicZonesDetail("Updating dynamic zone [{}] instance [{}] seconds remaining to [{}]s",
+			GetID(), GetInstanceID(), seconds_remaining);
+
+		// preserve original start time and adjust duration instead
+		m_expire_time = now + new_remaining;
+		m_duration = std::chrono::duration_cast<std::chrono::seconds>(m_expire_time - m_start_time);
+
+		InstanceListRepository::UpdateDuration(database,
+			GetInstanceID(), static_cast<uint32_t>(m_duration.count()));
+
+		SendZonesDurationUpdate(); // update zone caches and actual instance's timer
+	}
+}
+
+void DynamicZone::SendZonesDurationUpdate()
+{
+	constexpr uint32_t packsize = sizeof(ServerDzSetDuration_Struct);
+	auto pack = std::make_unique<ServerPacket>(ServerOP_DzDurationUpdate, packsize);
+	auto packbuf = reinterpret_cast<ServerDzSetDuration_Struct*>(pack->pBuffer);
+	packbuf->dz_id = GetID();
+	packbuf->seconds = static_cast<uint32_t>(m_duration.count());
+	zoneserver_list.SendPacket(pack.get());
+}
+
+void DynamicZone::HandleZoneMessage(ServerPacket* pack)
+{
+	switch (pack->opcode)
+	{
+	case ServerOP_DzSetCompass:
+	case ServerOP_DzSetSafeReturn:
+	case ServerOP_DzSetZoneIn:
+	{
+		zoneserver_list.SendPacket(pack);
+		break;
+	}
+	case ServerOP_DzCharacterChange:
+	case ServerOP_DzRemoveAllCharacters:
+	{
+		auto buf = reinterpret_cast<ServerDzCharacter_Struct*>(pack->pBuffer);
+		ZoneServer* instance_zs = zoneserver_list.FindByInstanceID(buf->instance_id);
+		if (instance_zs)
+		{
+			instance_zs->SendPacket(pack);
+		}
+		break;
+	}
+	case ServerOP_DzSetSecondsRemaining:
+	{
+		auto buf = reinterpret_cast<ServerDzSetDuration_Struct*>(pack->pBuffer);
+		auto dz = DynamicZone::FindDynamicZoneByID(buf->dz_id);
+		if (dz)
+		{
+			dz->SetSecondsRemaining(buf->seconds);
+		}
+		break;
+	}
+	};
+}

--- a/world/dynamic_zone.h
+++ b/world/dynamic_zone.h
@@ -1,0 +1,42 @@
+#ifndef WORLD_DYNAMIC_ZONE_H
+#define WORLD_DYNAMIC_ZONE_H
+
+#include "../common/eq_constants.h"
+#include <chrono>
+
+class ServerPacket;
+
+class DynamicZone
+{
+public:
+	DynamicZone() = default;
+	DynamicZone(uint32_t id, uint32_t zone_id, uint32_t instance_id, uint32_t zone_version,
+		uint32_t start_time, uint32_t duration, DynamicZoneType type);
+
+	static DynamicZone* FindDynamicZoneByID(uint32_t dz_id);
+	static void HandleZoneMessage(ServerPacket* pack);
+
+	uint32_t GetID() const { return m_id; }
+	uint16_t GetInstanceID() const { return static_cast<uint16_t>(m_instance_id); }
+	uint16_t GetZoneID() const { return static_cast<uint16_t>(m_zone_id); }
+	uint32_t GetZoneVersion() const { return m_zone_version; }
+	std::chrono::system_clock::duration GetRemainingDuration() const {
+		return m_expire_time - std::chrono::system_clock::now(); }
+
+	bool IsExpired() const { return m_expire_time < std::chrono::system_clock::now(); }
+	void SetSecondsRemaining(uint32_t seconds_remaining);
+
+private:
+	void SendZonesDurationUpdate();
+
+	uint32_t m_id = 0;
+	uint32_t m_instance_id = 0;
+	uint32_t m_zone_id = 0;
+	uint32_t m_zone_version = 0;
+	DynamicZoneType m_type{ DynamicZoneType::None };
+	std::chrono::seconds m_duration;
+	std::chrono::time_point<std::chrono::system_clock> m_start_time;
+	std::chrono::time_point<std::chrono::system_clock> m_expire_time;
+};
+
+#endif

--- a/world/expedition.h
+++ b/world/expedition.h
@@ -21,6 +21,7 @@
 #ifndef WORLD_EXPEDITION_H
 #define WORLD_EXPEDITION_H
 
+#include "dynamic_zone.h"
 #include "../common/timer.h"
 #include <chrono>
 #include <cstdint>
@@ -30,8 +31,7 @@ class Expedition
 {
 public:
 	Expedition() = default;
-	Expedition(uint32_t expedition_id, uint32_t dz_id, uint32_t dz_instance_id,
-		uint32_t dz_zone_id, uint32_t expire_time, uint32_t duration, uint32_t leader_id);
+	Expedition(uint32_t expedition_id, const DynamicZone& dz, uint32_t leader_id);
 
 	void AddMember(uint32_t character_id);
 	void RemoveMember(uint32_t character_id);
@@ -39,38 +39,28 @@ public:
 	void CheckExpireWarning();
 	void CheckLeader();
 	void ChooseNewLeader();
+	DynamicZone& GetDynamicZone() { return m_dynamic_zone; }
 	uint32_t GetID() const { return m_expedition_id; }
-	uint16_t GetInstanceID() const { return static_cast<uint16_t>(m_dz_instance_id); }
-	uint16_t GetZoneID() const { return static_cast<uint16_t>(m_dz_zone_id); }
 	bool HasMember(uint32_t character_id);
 	bool IsEmpty() const { return m_member_ids.empty(); }
-	bool IsExpired() const { return m_expire_time < std::chrono::system_clock::now(); }
 	bool IsPendingDelete() const { return m_pending_delete; }
 	bool IsValid() const { return m_expedition_id != 0; }
-	void SendZonesDurationUpdate();
 	void SendZonesExpeditionDeleted();
 	void SendZonesExpireWarning(uint32_t minutes_remaining);
 	bool SetNewLeader(uint32_t new_leader_id);
 	void SetPendingDelete(bool pending) { m_pending_delete = pending; }
-	void UpdateDzSecondsRemaining(uint32_t seconds_remaining);
-	std::chrono::system_clock::duration GetRemainingDuration() const;
 
 private:
 	void SendZonesLeaderChanged();
 
 	uint32_t m_expedition_id  = 0;
-	uint32_t m_dz_id          = 0;
-	uint32_t m_dz_instance_id = 0;
-	uint32_t m_dz_zone_id     = 0;
 	uint32_t m_leader_id      = 0;
 	bool m_pending_delete = false;
 	bool m_choose_leader_needed = false;
 	Timer m_choose_leader_cooldown_timer;
 	Timer m_warning_cooldown_timer;
+	DynamicZone m_dynamic_zone;
 	std::vector<uint32_t> m_member_ids;
-	std::chrono::seconds m_duration;
-	std::chrono::time_point<std::chrono::system_clock> m_start_time;
-	std::chrono::time_point<std::chrono::system_clock> m_expire_time;
 };
 
 #endif

--- a/world/expedition_database.h
+++ b/world/expedition_database.h
@@ -34,7 +34,6 @@ namespace ExpeditionDatabase
 	void MoveMembersToSafeReturn(const std::vector<uint32_t>& expedition_ids);
 	void PurgeExpiredExpeditions();
 	void PurgeExpiredCharacterLockouts();
-	void UpdateDzDuration(uint16_t instance_id, uint32_t new_duration);
 	void UpdateLeaderID(uint32_t expedition_id, uint32_t leader_id);
 };
 

--- a/world/expedition_message.cpp
+++ b/world/expedition_message.cpp
@@ -104,12 +104,6 @@ void ExpeditionMessage::HandleZoneMessage(ServerPacket* pack)
 		ExpeditionMessage::RequestInvite(pack);
 		break;
 	}
-	case ServerOP_ExpeditionSecondsRemaining:
-	{
-		auto buf = reinterpret_cast<ServerExpeditionUpdateDuration_Struct*>(pack->pBuffer);
-		expedition_state.SetSecondsRemaining(buf->expedition_id, buf->new_duration_seconds);
-		break;
-	}
 	}
 }
 

--- a/world/expedition_state.cpp
+++ b/world/expedition_state.cpp
@@ -38,6 +38,14 @@ Expedition* ExpeditionState::GetExpedition(uint32_t expedition_id)
 	return (it != m_expeditions.end()) ? &(*it) : nullptr;
 }
 
+Expedition* ExpeditionState::GetExpeditionByDynamicZoneID(uint32_t dz_id)
+{
+	auto it = std::find_if(m_expeditions.begin(), m_expeditions.end(),
+		[&](Expedition& expedition) { return expedition.GetDynamicZone().GetID() == dz_id; });
+
+	return (it != m_expeditions.end()) ? &(*it) : nullptr;
+}
+
 void ExpeditionState::LoadActiveExpeditions()
 {
 	BenchTimer benchmark;
@@ -98,15 +106,6 @@ void ExpeditionState::RemoveAllMembers(uint32_t expedition_id)
 	}
 }
 
-void ExpeditionState::SetSecondsRemaining(uint32_t expedition_id, uint32_t seconds_remaining)
-{
-	auto expedition = GetExpedition(expedition_id);
-	if (expedition)
-	{
-		expedition->UpdateDzSecondsRemaining(seconds_remaining);
-	}
-}
-
 void ExpeditionState::Process()
 {
 	if (!m_process_throttle_timer.Check())
@@ -120,13 +119,13 @@ void ExpeditionState::Process()
 	{
 		bool is_deleted = false;
 
-		if (it->IsEmpty() || it->IsExpired())
+		if (it->IsEmpty() || it->GetDynamicZone().IsExpired())
 		{
 			// don't delete expedition until its dz instance is empty. this prevents
 			// an exploit where all members leave expedition and complete an event
 			// before being kicked from removal timer. the lockout could never be
 			// applied because the zone expedition cache was already invalidated.
-			auto dz_zoneserver = zoneserver_list.FindByInstanceID(it->GetInstanceID());
+			auto dz_zoneserver = zoneserver_list.FindByInstanceID(it->GetDynamicZone().GetInstanceID());
 			if (!dz_zoneserver || dz_zoneserver->NumPlayers() == 0)
 			{
 				LogExpeditions("Expedition [{}] expired or empty, notifying zones and deleting", it->GetID());
@@ -137,7 +136,7 @@ void ExpeditionState::Process()
 
 			if (it->IsEmpty() && !it->IsPendingDelete() && RuleB(Expedition, EmptyDzShutdownEnabled))
 			{
-				it->UpdateDzSecondsRemaining(RuleI(Expedition, EmptyDzShutdownDelaySeconds));
+				it->GetDynamicZone().SetSecondsRemaining(RuleI(Expedition, EmptyDzShutdownDelaySeconds));
 			}
 
 			it->SetPendingDelete(true);

--- a/world/expedition_state.h
+++ b/world/expedition_state.h
@@ -35,12 +35,12 @@ class ExpeditionState
 public:
 	void AddExpedition(uint32_t expedition_id);
 	Expedition* GetExpedition(uint32_t expedition_id);
+	Expedition* GetExpeditionByDynamicZoneID(uint32_t dz_id);
 	void LoadActiveExpeditions();
 	void MemberChange(uint32_t expedition_id, uint32_t character_id, bool remove);
 	void Process();
 	void RemoveAllMembers(uint32_t expedition_id);
 	void RemoveExpedition(uint32_t expedition_id);
-	void SetSecondsRemaining(uint32_t expedition_id, uint32_t seconds_remaining);
 
 private:
 	std::vector<Expedition> m_expeditions;

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -36,6 +36,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include "ucs.h"
 #include "queryserv.h"
 #include "world_store.h"
+#include "dynamic_zone.h"
 #include "expedition_message.h"
 
 extern ClientList client_list;
@@ -1367,9 +1368,6 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 	case ServerOP_ExpeditionLockState:
 	case ServerOP_ExpeditionMemberStatus:
 	case ServerOP_ExpeditionReplayOnJoin:
-	case ServerOP_ExpeditionDzCompass:
-	case ServerOP_ExpeditionDzSafeReturn:
-	case ServerOP_ExpeditionDzZoneIn:
 	case ServerOP_ExpeditionExpireWarning:
 	{
 		zoneserver_list.SendPacket(pack);
@@ -1386,20 +1384,18 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 	case ServerOP_ExpeditionCharacterLockout:
 	case ServerOP_ExpeditionSaveInvite:
 	case ServerOP_ExpeditionRequestInvite:
-	case ServerOP_ExpeditionSecondsRemaining:
 	{
 		ExpeditionMessage::HandleZoneMessage(pack);
 		break;
 	}
 	case ServerOP_DzCharacterChange:
 	case ServerOP_DzRemoveAllCharacters:
+	case ServerOP_DzSetSecondsRemaining:
+	case ServerOP_DzSetCompass:
+	case ServerOP_DzSetSafeReturn:
+	case ServerOP_DzSetZoneIn:
 	{
-		auto buf = reinterpret_cast<ServerDzCharacter_Struct*>(pack->pBuffer);
-		ZoneServer* instance_zs = zoneserver_list.FindByInstanceID(buf->instance_id);
-		if (instance_zs)
-		{
-			instance_zs->SendPacket(pack);
-		}
+		DynamicZone::HandleZoneMessage(pack);
 		break;
 	}
 	default:

--- a/zone/expedition.h
+++ b/zone/expedition.h
@@ -161,13 +161,6 @@ public:
 	void DzQuit(Client* requester);
 	void DzKickPlayers(Client* requester);
 
-	void SetDzCompass(uint32_t zone_id, float x, float y, float z, bool update_db = false);
-	void SetDzCompass(const std::string& zone_name, float x, float y, float z, bool update_db = false);
-	void SetDzSafeReturn(uint32_t zone_id, float x, float y, float z, float heading, bool update_db = false);
-	void SetDzSafeReturn(const std::string& zone_name, float x, float y, float z, float heading, bool update_db = false);
-	void SetDzSecondsRemaining(uint32_t seconds_remaining);
-	void SetDzZoneInLocation(float x, float y, float z, float heading, bool update_db = false);
-
 	static const int32_t REPLAY_TIMER_ID;
 	static const int32_t EVENT_TIMER_ID;
 
@@ -197,7 +190,7 @@ private:
 	void SendMembersExpireWarning(uint32_t minutes);
 	void SendNewMemberAddedToZoneMembers(const std::string& added_name);
 	void SendUpdatesToZoneMembers(bool clear = false, bool message_on_clear = true);
-	void SendWorldDzLocationUpdate(uint16_t server_opcode, const DynamicZoneLocation& location);
+	void SendCompassUpdateToZoneMembers();
 	void SendWorldExpeditionUpdate(uint16_t server_opcode);
 	void SendWorldAddPlayerInvite(const std::string& inviter_name, const std::string& swap_remove_name,
 		const std::string& add_name, bool pending = false);
@@ -209,12 +202,10 @@ private:
 	void SendWorldMemberStatus(uint32_t character_id, ExpeditionMemberStatus status);
 	void SendWorldMemberSwapped(const std::string& remove_char_name, uint32_t remove_char_id,
 		const std::string& add_char_name, uint32_t add_char_id);
-	void SendWorldSetSecondsRemaining(uint32_t seconds_remaining);
 	void SendWorldSettingChanged(uint16_t server_opcode, bool setting_value);
 	void SetDynamicZone(DynamicZone&& dz);
 	void TryAddClient(Client* add_client, const std::string& inviter_name,
 		const std::string& swap_remove_name, Client* leader_client = nullptr);
-	void UpdateDzDuration(uint32_t new_duration) { m_dynamiczone.SetUpdatedDuration(new_duration); }
 	void UpdateMemberStatus(uint32_t update_character_id, ExpeditionMemberStatus status);
 
 	ExpeditionMember GetMemberData(uint32_t character_id);

--- a/zone/lua_expedition.cpp
+++ b/zone/lua_expedition.cpp
@@ -168,7 +168,7 @@ bool Lua_Expedition::IsLocked() {
 
 void Lua_Expedition::RemoveCompass() {
 	Lua_Safe_Call_Void();
-	self->SetDzCompass(0, 0, 0, 0, true);
+	self->GetDynamicZone().SetCompass(0, 0, 0, 0, true);
 }
 
 void Lua_Expedition::RemoveLockout(std::string event_name) {
@@ -178,12 +178,12 @@ void Lua_Expedition::RemoveLockout(std::string event_name) {
 
 void Lua_Expedition::SetCompass(uint32_t zone_id, float x, float y, float z) {
 	Lua_Safe_Call_Void();
-	self->SetDzCompass(zone_id, x, y, z, true);
+	self->GetDynamicZone().SetCompass(zone_id, x, y, z, true);
 }
 
 void Lua_Expedition::SetCompass(std::string zone_name, float x, float y, float z) {
 	Lua_Safe_Call_Void();
-	self->SetDzCompass(zone_name, x, y, z, true);
+	self->GetDynamicZone().SetCompass(ZoneID(zone_name), x, y, z, true);
 }
 
 void Lua_Expedition::SetLocked(bool lock_expedition) {
@@ -218,23 +218,23 @@ void Lua_Expedition::SetReplayLockoutOnMemberJoin(bool enable) {
 
 void Lua_Expedition::SetSafeReturn(uint32_t zone_id, float x, float y, float z, float heading) {
 	Lua_Safe_Call_Void();
-	self->SetDzSafeReturn(zone_id, x, y, z, heading, true);
+	self->GetDynamicZone().SetSafeReturn(zone_id, x, y, z, heading, true);
 }
 
 void Lua_Expedition::SetSafeReturn(std::string zone_name, float x, float y, float z, float heading) {
 	Lua_Safe_Call_Void();
-	self->SetDzSafeReturn(zone_name, x, y, z, heading, true);
+	self->GetDynamicZone().SetSafeReturn(ZoneID(zone_name), x, y, z, heading, true);
 }
 
 void Lua_Expedition::SetSecondsRemaining(uint32_t seconds_remaining)
 {
 	Lua_Safe_Call_Void();
-	self->SetDzSecondsRemaining(seconds_remaining);
+	self->GetDynamicZone().SetSecondsRemaining(seconds_remaining);
 }
 
 void Lua_Expedition::SetZoneInLocation(float x, float y, float z, float heading) {
 	Lua_Safe_Call_Void();
-	self->SetDzZoneInLocation(x, y, z, heading, true);
+	self->GetDynamicZone().SetZoneInLocation(x, y, z, heading, true);
 }
 
 void Lua_Expedition::UpdateLockoutDuration(std::string event_name, uint32_t duration) {

--- a/zone/perl_expedition.cpp
+++ b/zone/perl_expedition.cpp
@@ -407,7 +407,7 @@ XS(XS_Expedition_RemoveCompass) {
 	Expedition* THIS = nullptr;
 	VALIDATE_THIS_IS_EXPEDITION;
 
-	THIS->SetDzCompass(0, 0, 0, 0, true);
+	THIS->GetDynamicZone().SetCompass(0, 0, 0, 0, true);
 
 	XSRETURN_EMPTY;
 }
@@ -446,12 +446,12 @@ XS(XS_Expedition_SetCompass) {
 	if (SvTYPE(ST(1)) == SVt_PV)
 	{
 		std::string zone_name(SvPV_nolen(ST(1)));
-		THIS->SetDzCompass(zone_name, x, y, z, true);
+		THIS->GetDynamicZone().SetCompass(ZoneID(zone_name), x, y, z, true);
 	}
 	else if (SvTYPE(ST(1)) == SVt_IV)
 	{
 		uint32_t zone_id = static_cast<uint32_t>(SvUV(ST(1)));
-		THIS->SetDzCompass(zone_id, x, y, z, true);
+		THIS->GetDynamicZone().SetCompass(zone_id, x, y, z, true);
 	}
 	else
 	{
@@ -556,12 +556,12 @@ XS(XS_Expedition_SetSafeReturn) {
 	if (SvTYPE(ST(1)) == SVt_PV)
 	{
 		std::string zone_name(SvPV_nolen(ST(1)));
-		THIS->SetDzSafeReturn(zone_name, x, y, z, heading, true);
+		THIS->GetDynamicZone().SetSafeReturn(ZoneID(zone_name), x, y, z, heading, true);
 	}
 	else if (SvTYPE(ST(1)) == SVt_IV)
 	{
 		uint32_t zone_id = static_cast<uint32_t>(SvUV(ST(1)));
-		THIS->SetDzSafeReturn(zone_id, x, y, z, heading, true);
+		THIS->GetDynamicZone().SetSafeReturn(zone_id, x, y, z, heading, true);
 	}
 	else
 	{
@@ -582,7 +582,7 @@ XS(XS_Expedition_SetSecondsRemaining) {
 	VALIDATE_THIS_IS_EXPEDITION;
 
 	uint32_t seconds_remaining = static_cast<uint32_t>(SvUV(ST(1)));
-	THIS->SetDzSecondsRemaining(seconds_remaining);
+	THIS->GetDynamicZone().SetSecondsRemaining(seconds_remaining);
 
 	XSRETURN_EMPTY;
 }
@@ -602,7 +602,7 @@ XS(XS_Expedition_SetZoneInLocation) {
 	float z = static_cast<float>(SvNV(ST(3)));
 	float heading = static_cast<float>(SvNV(ST(4)));
 
-	THIS->SetDzZoneInLocation(x, y, z, heading, true);
+	THIS->GetDynamicZone().SetZoneInLocation(x, y, z, heading, true);
 
 	XSRETURN_EMPTY;
 }

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -2900,10 +2900,6 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 	case ServerOP_ExpeditionGetOnlineMembers:
 	case ServerOP_ExpeditionDzAddPlayer:
 	case ServerOP_ExpeditionDzMakeLeader:
-	case ServerOP_ExpeditionDzCompass:
-	case ServerOP_ExpeditionDzSafeReturn:
-	case ServerOP_ExpeditionDzZoneIn:
-	case ServerOP_ExpeditionDzDuration:
 	case ServerOP_ExpeditionCharacterLockout:
 	case ServerOP_ExpeditionExpireWarning:
 	{
@@ -2912,6 +2908,10 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 	}
 	case ServerOP_DzCharacterChange:
 	case ServerOP_DzRemoveAllCharacters:
+	case ServerOP_DzDurationUpdate:
+	case ServerOP_DzSetCompass:
+	case ServerOP_DzSetSafeReturn:
+	case ServerOP_DzSetZoneIn:
 	{
 		DynamicZone::HandleWorldMessage(pack);
 		break;


### PR DESCRIPTION
Use internal dz messages to process duration and location changes

Add world DynamicZone class (later this will inherit from a base)

Add FindDynamicZoneByID to get dz from zone and world system caches

This starts the main decoupling process and precedes some more changes that will make dynamic zones more usable by other systems