### PR TITLE
[Quest API] Add new zone name methods to Perl and Lua.

### DIFF
--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -3821,6 +3821,36 @@ XS(XS__GetZoneLongName) {
 	XSRETURN(1);
 }
 
+XS(XS__GetZoneLongNameByID);
+XS(XS__GetZoneLongNameByID) {
+	dXSARGS;
+	if (items != 1)
+		Perl_croak(aTHX_ "Usage: quest::GetZoneLongNameByID(uint32 zone_id)");
+
+	dXSTARG;
+	uint32 zone_id = (uint32) SvUV(ST(0));
+	std::string zone_long_name = quest_manager.GetZoneLongNameByID(zone_id);
+	sv_setpv(TARG, zone_long_name.c_str());
+	XSprePUSH;
+	PUSHTARG;
+	XSRETURN(1);
+}
+
+XS(XS__GetZoneShortName);
+XS(XS__GetZoneShortName) {
+	dXSARGS;
+	if (items != 1)
+		Perl_croak(aTHX_ "Usage: quest::GetZoneShortName(uint32 zone_id)");
+
+	dXSTARG;
+	uint32 zone_id = (uint32) SvUV(ST(0));
+	std::string zone_short_name = quest_manager.GetZoneShortName(zone_id);
+	sv_setpv(TARG, zone_short_name.c_str());
+	XSprePUSH;
+	PUSHTARG;
+	XSRETURN(1);
+}
+
 XS(XS__GetTimeSeconds);
 XS(XS__GetTimeSeconds) {
 	dXSARGS;
@@ -6490,6 +6520,8 @@ EXTERN_C XS(boot_quest) {
 	newXS(strcpy(buf, "GetTimeSeconds"), XS__GetTimeSeconds, file);
 	newXS(strcpy(buf, "GetZoneID"), XS__GetZoneID, file);
 	newXS(strcpy(buf, "GetZoneLongName"), XS__GetZoneLongName, file);
+	newXS(strcpy(buf, "GetZoneLongNameByID"), XS__GetZoneLongNameByID, file);
+	newXS(strcpy(buf, "GetZoneShortName"), XS__GetZoneShortName, file);
 	newXS(strcpy(buf, "set_rule"), XS__set_rule, file);
 	newXS(strcpy(buf, "get_rule"), XS__get_rule, file);
 	newXS(strcpy(buf, "get_data"), XS__get_data, file);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -1608,6 +1608,10 @@ int lua_get_zone_id() {
 	return zone->GetZoneID();
 }
 
+int lua_get_zone_id_by_name(const char* zone_name) {
+	return ZoneID(zone_name);
+}
+
 const char *lua_get_zone_long_name() {
 	if(!zone)
 		return "";
@@ -1615,11 +1619,25 @@ const char *lua_get_zone_long_name() {
 	return zone->GetLongName();
 }
 
+const char *lua_get_zone_long_name_by_name(const char* zone_name) {
+	return ZoneLongName(
+		ZoneID(zone_name)
+	);
+}
+
+const char *lua_get_zone_long_name_by_id(uint32 zone_id) {
+	return ZoneLongName(zone_id);
+}
+
 const char *lua_get_zone_short_name() {
 	if(!zone)
 		return "";
 
 	return zone->GetShortName();
+}
+
+const char *lua_get_zone_short_name_by_id(uint32 zone_id) {
+	return ZoneName(zone_id);
 }
 
 int lua_get_zone_instance_id() {
@@ -2806,8 +2824,12 @@ luabind::scope lua_register_general() {
 		luabind::def("zone_group", &lua_zone_group),
 		luabind::def("zone_raid", &lua_zone_raid),
 		luabind::def("get_zone_id", &lua_get_zone_id),
+		luabind::def("get_zone_id_by_name", &lua_get_zone_id_by_name),
 		luabind::def("get_zone_long_name", &lua_get_zone_long_name),
+		luabind::def("get_zone_long_name_by_name", &lua_get_zone_long_name_by_name),
+		luabind::def("get_zone_long_name_by_id", &lua_get_zone_long_name_by_id),
 		luabind::def("get_zone_short_name", &lua_get_zone_short_name),
+		luabind::def("get_zone_short_name_by_id", &lua_get_zone_short_name_by_id),
 		luabind::def("get_zone_instance_id", &lua_get_zone_instance_id),
 		luabind::def("get_zone_instance_version", &lua_get_zone_instance_version),
 		luabind::def("get_zone_weather", &lua_get_zone_weather),

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -3219,9 +3219,15 @@ int32 QuestManager::GetZoneID(const char *zone) {
 
 std::string QuestManager::GetZoneLongName(std::string zone_short_name)
 {
-	return zone_store.GetZoneLongName(
-		zone_store.GetZoneID(zone_short_name)
-	);
+	return ZoneLongName(ZoneID(zone_short_name));
+}
+
+std::string QuestManager::GetZoneLongNameByID(uint32 zone_id) {
+	return ZoneLongName(zone_id);
+}
+
+std::string QuestManager::GetZoneShortName(uint32 zone_id) {
+	return ZoneName(zone_id);
 }
 
 void QuestManager::CrossZoneAssignTaskByCharID(int character_id, uint32 task_id, bool enforce_level_requirement) {

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -285,6 +285,8 @@ public:
 	uint16 CreateDoor( const char* model, float x, float y, float z, float heading, uint8 opentype, uint16 size);
     int32 GetZoneID(const char *zone);
     static std::string GetZoneLongName(std::string zone_short_name);
+    static std::string GetZoneLongNameByID(uint32 zone_id);
+	static std::string GetZoneShortName(uint32 zone_id);
 	void CrossZoneAssignTaskByCharID(int character_id, uint32 task_id, bool enforce_level_requirement = false);
 	void CrossZoneAssignTaskByGroupID(int group_id, uint32 task_id, bool enforce_level_requirement = false);
 	void CrossZoneAssignTaskByRaidID(int raid_id, uint32 task_id, bool enforce_level_requirement = false);


### PR DESCRIPTION
- Add quest::GetZoneLongNameByID(zone_id) to Perl.
- Add quest::GetZoneShortName(zone_id) to Perl.
- Add eq.get_zone_id_by_name(zone_name) to Lua.
- Add eq.get_zone_long_name_by_id(zone_id) to Lua.
- Add eq.get_zone_long_name_by_name(zone_name) to Lua.
- Add eq.get_zone_short_name_by_id(zone_id) to Lua.