### PR TITLE
[Performance] Switch scheduled hot zone check to search instead of split

### DIFF
--- a/zone/zone_event_scheduler.cpp
+++ b/zone/zone_event_scheduler.cpp
@@ -34,11 +34,8 @@ void ZoneEventScheduler::Process(Zone *zone, WorldContentService *content_servic
 				LogSchedulerDetail("Looping active event validated [{}]", e.event_type);
 				if (e.event_type == ServerEvents::EVENT_TYPE_HOT_ZONE_ACTIVE) {
 					LogScheduler("Deactivating event [{}] disabling hotzone status", e.description);
-					for (auto &short_name: split(e.event_data, ',')) {
-						if (zone->GetShortName() == short_name) {
-							zone->SetIsHotzone(false);
-							break;
-						}
+					if (search_deliminated_string(e.event_data, zone->GetShortName()) != std::string::npos) {
+						zone->SetIsHotzone(false);
 					}
 					RemoveActiveEvent(e);
 				}
@@ -87,12 +84,9 @@ void ZoneEventScheduler::Process(Zone *zone, WorldContentService *content_servic
 			// such as broadcasts, reloads
 			if (ValidateEventReadyToActivate(e) && !IsEventActive(e)) {
 				if (e.event_type == ServerEvents::EVENT_TYPE_HOT_ZONE_ACTIVE) {
-					for (auto &short_name: split(e.event_data, ',')) {
-						if (zone->GetShortName() == short_name) {
-							zone->SetIsHotzone(true);
-							LogScheduler("Activating Event [{}] Enabling zone as hotzone", e.description);
-							break;
-						}
+					if (search_deliminated_string(e.event_data, zone->GetShortName()) != std::string::npos) {
+						zone->SetIsHotzone(true);
+						LogScheduler("Activating Event [{}] Enabling zone as hotzone", e.description);
 					}
 					m_active_events.push_back(e);
 				}


### PR DESCRIPTION
Using search_deliminated_string here is significantly faster than
splitting, most likely because of dynamic memory management

Some tests on my system:

```
----------------------------------------------------
Benchmark             Time           CPU Iterations
----------------------------------------------------
bench_split         864 ns        864 ns     807922
bench_search         35 ns         35 ns   20265205
```

This test was a case where the string was present somewhere in the
middle which gave a ~96% speed up

```
----------------------------------------------------
Benchmark             Time           CPU Iterations
----------------------------------------------------
bench_split         936 ns        936 ns     725518
bench_search         61 ns         61 ns   11156359
```

This test was when the string was not present, which will be the vast
majority of times this is actually checked, was ~93% speed up