### PR TITLE
[Bug Fix] Hack to fix repulsable bard charms

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -2645,6 +2645,12 @@ bool Mob::ApplyNextBardPulse(uint16 spell_id, Mob *spell_target, CastingSlot slo
 }
 
 void Mob::BardPulse(uint16 spell_id, Mob *caster) {
+	// so for Solon's Song of the Sirens (725) if we're repulsing, we need to skip
+	// other charms have mana and don't repulse
+	// This is probably not the ideal place for this, but it will work
+	if (IsCharmed() && GetOwner() == caster && IsEffectInSpell(spell_id, SE_Charm)) {
+		return;
+	}
 	int buffs_i;
 	int buff_count = GetMaxTotalSlots();
 	for (buffs_i = 0; buffs_i < buff_count; buffs_i++) {


### PR DESCRIPTION
This isn't the exactly the right way, but it's behavior is much closer
to live than current for Solon's Song of the Sirens (725), the other
bard charms don't repulse due to mana cost