### PR TITLE
[Bug] Fix ignore_primary_assist.

### DIFF
--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -3298,7 +3298,7 @@ void NPC::AIYellForHelp(Mob *sender, Mob *attacker)
 					const NPCFactionList *cf = content_db.GetNPCFactionEntry(mob->CastToNPC()->GetNPCFactionID());
 					if (cf) {
 						if (cf->assistprimaryfaction == 0) {
-							return; //Same faction and ignore primary assist
+							continue; //Same faction and ignore primary assist
 						}
 					}
 				}

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -3294,17 +3294,16 @@ void NPC::AIYellForHelp(Mob *sender, Mob *attacker)
 			 * then jump in if they are our friend
 			 */
 			if (mob->GetLevel() >= 50 || attacker->GetLevelCon(mob->GetLevel()) != CON_GRAY) {
-				bool use_primary_faction = false;
 				if (mob->GetPrimaryFaction() == sender->CastToNPC()->GetPrimaryFaction()) {
 					const NPCFactionList *cf = content_db.GetNPCFactionEntry(mob->CastToNPC()->GetNPCFactionID());
 					if (cf) {
-						if (cf->assistprimaryfaction != 0) {
-							use_primary_faction = true;
+						if (cf->assistprimaryfaction == 0) {
+							return; //Same faction and ignore primary assist
 						}
 					}
 				}
 
-				if (use_primary_faction || sender->GetReverseFactionCon(mob) <= FACTION_AMIABLE) {
+				if (sender->GetReverseFactionCon(mob) <= FACTION_AMIABLE) {
 					//attacking someone on same faction, or a friend
 					//Father Nitwit: make sure we can see them.
 					if (mob->CheckLosFN(sender)) {


### PR DESCRIPTION
If you set ignore_primary_assist in npc_faction, then mobs of the same primary faction should not assist each other.  The code to handle this was broken, in that it checked for this, but also always did this check regardless:

sender->GetReverseFactionCon(mob) <= FACTION_AMIABLE

That call always returns AMIABLE if the mob requesting assistance and the mob being checked are on the same primary faction.

So, the ignore_primary_assist  was essentially doing nothing.

The fix is easy, we simply coninue when we find this condition in call for help.  No need to proceed with the mob being checked if they are on the same faction and ignore primary is true.