### PR TITLE
[Rules] Add rule 'GM:MinStatusToBypassLockedServer'

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -209,6 +209,7 @@ RULE_CATEGORY(GM)
 RULE_INT(GM, MinStatusToSummonItem, 250, "Minimum required status to summon items")
 RULE_INT(GM, MinStatusToZoneAnywhere, 250, "Minimum required status to zone anywhere")
 RULE_INT(GM, MinStatusToLevelTarget, 100, "Minimum required status to set the level of a player")
+RULE_INT(GM, MinStatusToBypassLockedServer, 100, "Players >= this status can log in to the server even when it is locked")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(World)

--- a/world/login_server.cpp
+++ b/world/login_server.cpp
@@ -92,7 +92,7 @@ void LoginServer::ProcessUsertoWorldReqLeg(uint16_t opcode, EQ::Net::Packet &p)
 	utwrs->response    = UserToWorldStatusSuccess;
 
 	if (Config->Locked) {
-		if (status < 100) {
+		if (status < (RuleI(GM, MinStatusToBypassLockedServer))) {
 			LogDebug("[ProcessUsertoWorldReqLeg] Server locked and status is not high enough for account_id [{0}]", utwr->lsaccountid);
 			utwrs->response = UserToWorldStatusWorldUnavail;
 			SendPacket(&outpack);
@@ -170,7 +170,7 @@ void LoginServer::ProcessUsertoWorldReq(uint16_t opcode, EQ::Net::Packet &p)
 	utwrs->response = UserToWorldStatusSuccess;
 
 	if (Config->Locked == true) {
-		if (status < 100) {
+		if (status < (RuleI(GM, MinStatusToBypassLockedServer))) {
 			LogDebug("[ProcessUsertoWorldReq] Server locked and status is not high enough for account_id [{0}]", utwr->lsaccountid);
 			utwrs->response = UserToWorldStatusWorldUnavail;
 			SendPacket(&outpack);
@@ -179,7 +179,7 @@ void LoginServer::ProcessUsertoWorldReq(uint16_t opcode, EQ::Net::Packet &p)
 	}
 
 	int32 x = Config->MaxClients;
-	if ((int32) numplayers >= x && x != -1 && x != 255 && status < 80) {
+	if ((int32) numplayers >= x && x != -1 && x != 255 && status < (RuleI(GM, MinStatusToBypassLockedServer))) {
 		LogDebug("[ProcessUsertoWorldReq] World at capacity account_id [{0}]", utwr->lsaccountid);
 		utwrs->response = UserToWorldStatusWorldAtCapacity;
 		SendPacket(&outpack);


### PR DESCRIPTION
Rule Name: GM:MinStatusToBypassLockedServer
Default Status: 100
Description: Players >= this status can log in to the server even when it is locked

Believe you used to be able to change this via the old config? Either way should be very useful as the current requirement is 101 to get through a Locked server. Since our default is 100 now you will be able to get in at status 100 but nothing below that obviously.

The plan for me specifically is to create a new field in the accounts table and disconnect this whole thing from GM status entirely (field would be named ignoreLockedServer or bypassLockedServer or something). Don't know if that's too custom for Master source but will provide that as well when I am done with it if anyone wants it.