### PR TITLE
Add a way to bypass locked server without giving client GM status

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -2479,3 +2479,14 @@ bool Database::CopyCharacter(
 	return true;
 }
 
+bool Database::GetBypassFlagByLSAccountID(uint32 lsaccount_id)
+{
+	std::string query = fmt::format("select bypassServerLock from account WHERE lsaccount_id = {}", lsaccount_id);
+	auto results = QueryDatabase(query);
+	auto row = results.begin();
+
+	if (atoi(row[0]))
+		return true;
+
+	return false;
+}

--- a/common/database.h
+++ b/common/database.h
@@ -267,6 +267,9 @@ public:
 	int		CountInvSnapshots();
 	void	ClearInvSnapshots(bool from_now = false);
 
+	/* Bypass Server Lock */
+	bool GetBypassFlagByLSAccountID(uint32 lsaccount_id);
+
 	/* EQEmuLogSys */
 	void	LoadLogSettings(EQEmuLogSys::LogSettings* log_settings);
 

--- a/world/login_server.cpp
+++ b/world/login_server.cpp
@@ -183,7 +183,7 @@ void LoginServer::ProcessUsertoWorldReq(uint16_t opcode, EQ::Net::Packet &p)
 	}
 
 	int32 x = Config->MaxClients;
-	if ((int32)numplayers >= x && x != -1 && x != 255 && status < (RuleI(GM, MinStatusToBypassLockedServer)) && canBypassServerLock == false) {
+	if ((int32)numplayers >= x && x != -1 && x != 255 && canBypassServerLock == false && status < (RuleI(GM, MinStatusToBypassLockedServer))) {
 		LogDebug("[ProcessUsertoWorldReq] World at capacity account_id [{0}]", utwr->lsaccountid);
 		utwrs->response = UserToWorldStatusWorldAtCapacity;
 		SendPacket(&outpack);


### PR DESCRIPTION
Allow certain accounts access to the server when its locked without giving them GM status as mentioned in https://github.com/EQEmu/Server/pull/1330

Not sure how to include the database field.. would I just commit that in the utils folder like anything else? I've included a screenshot of it below. 

I've tested this and it works. Also added it to the debug logging. (screenshots without sensitive information)

![11cc49b6610dcc84c470d26c4c0c5932](https://user-images.githubusercontent.com/4369261/115852801-7844f700-a3f6-11eb-97d4-a93a18809b53.png)
![47052e1d033d49d484e490e6ed9d470f](https://user-images.githubusercontent.com/4369261/115851170-a9242c80-a3f4-11eb-88d0-4c57a5b94a87.png)
