### PR TITLE
Fix calls to GetSafePoints to not pass null_ptr as zonename

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -971,7 +971,11 @@ bool Database::SetVariable(const std::string varname, const std::string &varvalu
 }
 
 // Get zone starting points from DB
-bool Database::GetSafePoints(const char* zone_short_name, uint32 instance_version, float* safe_x, float* safe_y, float* safe_z, float* safe_heading, int16* min_status, uint8* min_level, char *flag_needed) {
+bool Database::GetSafePoints(const char* zone_short_name, uint32 instance_version, float* safe_x, float* safe_y, float* safe_z, float* safe_heading, int16* min_status, uint8* min_level, char *flag_needed){
+
+	if (zone_short_name == nullptr)
+		return false;
+
 	std::string query = fmt::format(
 		SQL(
 			SELECT

--- a/common/database.cpp
+++ b/common/database.cpp
@@ -971,7 +971,7 @@ bool Database::SetVariable(const std::string varname, const std::string &varvalu
 }
 
 // Get zone starting points from DB
-bool Database::GetSafePoints(const char* zone_short_name, uint32 instance_version, float* safe_x, float* safe_y, float* safe_z, float* safe_heading, int16* min_status, uint8* min_level, char *flag_needed){
+bool Database::GetSafePoints(const char* zone_short_name, uint32 instance_version, float* safe_x, float* safe_y, float* safe_z, float* safe_heading, int16* min_status, uint8* min_level, char *flag_needed) {
 
 	if (zone_short_name == nullptr)
 		return false;

--- a/world/worlddb.cpp
+++ b/world/worlddb.cpp
@@ -235,7 +235,7 @@ void WorldDatabase::GetCharSelectInfo(uint32 account_id, EQApplicationPacket **o
 				if (atoi(row_d[1]) != 0) {
 					player_profile_struct.binds[4].zone_id = (uint32) atoi(row_d[1]);
 					content_db.GetSafePoints(
-						ZoneName(player_profile_struct.binds[4].zone_id),
+						ZoneName(player_profile_struct.binds[4].zone_id, true),
 						0,
 						&player_profile_struct.binds[4].x,
 						&player_profile_struct.binds[4].y,
@@ -252,7 +252,7 @@ void WorldDatabase::GetCharSelectInfo(uint32 account_id, EQApplicationPacket **o
 					float heading = atof(row_d[5]);
 					if (x == 0 && y == 0 && z == 0 && heading == 0) {
 						content_db.GetSafePoints(
-							ZoneName(player_profile_struct.binds[4].zone_id),
+							ZoneName(player_profile_struct.binds[4].zone_id, true),
 							0,
 							&x,
 							&y,
@@ -567,7 +567,7 @@ bool WorldDatabase::GetStartZone(
 		p_player_profile_struct->heading == 0
 	) {
 		content_db.GetSafePoints(
-			ZoneName(p_player_profile_struct->zone_id),
+			ZoneName(p_player_profile_struct->zone_id, true),
 			0,
 			&p_player_profile_struct->x,
 			&p_player_profile_struct->y,
@@ -583,7 +583,7 @@ bool WorldDatabase::GetStartZone(
 		p_player_profile_struct->binds[0].heading == 0
 	) {
 		content_db.GetSafePoints(
-			ZoneName(p_player_profile_struct->binds[0].zone_id),
+			ZoneName(p_player_profile_struct->binds[0].zone_id, true),
 			0,
 			&p_player_profile_struct->binds[0].x,
 			&p_player_profile_struct->binds[0].y,

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -230,9 +230,9 @@ void Client::Handle_OP_ZoneChange(const EQApplicationPacket *app) {
 		break;
 	case GateToBindPoint:
 		target_x = m_pp.binds[0].x;
-		target_x = m_pp.binds[0].y;
-		target_x = m_pp.binds[0].z;
-		target_x = m_pp.binds[0].heading;
+		target_y = m_pp.binds[0].y;
+		target_z = m_pp.binds[0].z;
+		target_heading = m_pp.binds[0].heading;
 		break;
 	case ZoneToBindPoint:
 		target_x = m_pp.binds[0].x;


### PR DESCRIPTION
GetSafePoints  was causing a crash on character creation on Ubuntu due to a null_ptr being sent to GetSafePoints when bindid was 0 in start_zones.

I can't identify why this has cropped up in the last few weeks of changes, but it is 100% repeatable now.  Maybe changes to string utils?

Regardless, passing null_ptr to GetSafePoints isn't good, and this change will simple end up passing "UNKNOWN" which fixes the crash.

I changed all (4) spots for safety, but only in the case of bindid=0 do I expect ZoneName() to be returning a 0.

This was the dump created by the unsafe calls:

terminate called after throwing an instance of 'fmt::v5::format_error'
  what():  string pointer is null
[sudo] password for drool:
29      ../sysdeps/unix/sysv/linux/waitpid.c: No such file or directory.
[World] [Crash] [New LWP 26252]
[World] [Crash] [New LWP 26253]
[World] [Crash] [New LWP 26254]
[World] [Crash] [New LWP 26255]
[World] [Crash] [Thread debugging using libthread_db enabled]
[World] [Crash] Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
[World] [Crash] 0x00007f0fc8444f7b in __waitpid (pid=26336, stat_loc=stat_loc@entry=0x0, options=options@entry=0) at ../sysdeps/unix/sysv/linux/waitpid.c:29
[World] [Crash] [Current thread is 1 (Thread 0x7f0fc906fac0 (LWP 26249))]
[World] [Crash] #0  0x00007f0fc8444f7b in __waitpid (pid=26336, stat_loc=stat_loc@entry=0x0, options=options@entry=0) at ../sysdeps/unix/sysv/linux/waitpid.c:29
[World] [Crash] #1  0x000000000055776f in print_trace () at /home/felinicity/server-042621/Server/common/crash.cpp:154
[World] [Crash] #2  <signal handler called>
[World] [Crash] #3  0x00007f0fc73f1438 in __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:54
[World] [Crash] #4  0x00007f0fc73f303a in __GI_abort () at abort.c:89
[World] [Crash] #5  0x00007f0fc7d3484d in __gnu_cxx::__verbose_terminate_handler() () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
[World] [Crash] #6  0x00007f0fc7d326b6 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
[World] [Crash] #7  0x00007f0fc7d32701 in std::terminate() () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
[World] [Crash] #8  0x00007f0fc7d32919 in __cxa_throw () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
[World] [Crash] #9  0x00000000004e4d17 in fmt::v5::internal::arg_formatter_base<fmt::v5::back_insert_range<fmt::v5::internal::basic_buffer<char> > >::write (this=<optimized out>, value=<optimized out>) at /home/felinicity/server-042621/Server/submodules/fmt/include/fmt/format.h:1352
[World] [Crash] #10 0x00000000004ede1a in fmt::v5::internal::arg_formatter_base<fmt::v5::back_insert_range<fmt::v5::internal::basic_buffer<char> > >::operator() (value=<optimized out>, this=0x7ffd63956cb0) at /home/felinicity/server-042621/Server/submodules/fmt/include/fmt/format.h:1421
[World] [Crash] #11 fmt::v5::visit_format_arg<fmt::v5::arg_formatter<fmt::v5::back_insert_range<fmt::v5::internal::basic_buffer<char> > >, fmt::v5::basic_format_context<std::back_insert_iterator<fmt::v5::internal::basic_buffer<char> >, char> >(fmt::v5::arg_formatter<fmt::v5::back_insert_range<fmt::v5::internal::basic_buffer<char> > >&&, fmt::v5::basic_format_arg<fmt::v5::basic_format_context<std::back_insert_iterator<fmt::v5::internal::basic_buffer<char> >, char> > const&) (vis=<unknown type in /home/felinicity/server-042621/Server/bin/world, CU 0x8fcc3, DIE 0xe538d>, arg=...) at /home/felinicity/server-042621/Server/submodules/fmt/include/fmt/core.h:856
[World] [Crash] #12 0x00000000004ef488 in fmt::v5::format_handler<fmt::v5::arg_formatter<fmt::v5::back_insert_range<fmt::v5::internal::basic_buffer<char> > >, char, fmt::v5::basic_format_context<std::back_insert_iterator<fmt::v5::internal::basic_buffer<char> >, char> >::on_replacement_field (p=0x70e647 "}' AND (`version` = {} OR `version` = 0) ORDER BY `version` DESC", this=0x7ffd63956d60) at /home/felinicity/server-042621/Server/submodules/fmt/include/fmt/format.h:3097
[World] [Crash] #13 fmt::v5::internal::parse_format_string<false, char, fmt::v5::format_handler<fmt::v5::arg_formatter<fmt::v5::back_insert_range<fmt::v5::internal::basic_buffer<char> > >, char, fmt::v5::basic_format_context<std::back_insert_iterator<fmt::v5::internal::basic_buffer<char> >, char> >&> (format_str=..., handler=...) at /home/felinicity/server-042621/Server/submodules/fmt/include/fmt/format.h:2031
[World] [Crash] #14 0x00000000004f0a0a in fmt::v5::vformat_to<fmt::v5::arg_formatter<fmt::v5::back_insert_range<fmt::v5::internal::basic_buffer<char> > >, char, fmt::v5::basic_format_context<std::back_insert_iterator<fmt::v5::internal::basic_buffer<char> >, char> > (loc=..., args=..., format_str=..., out=...) at /home/felinicity/server-042621/Server/submodules/fmt/include/fmt/format.h:3130
[World] [Crash] #15 fmt::v5::internal::vformat_to<char> (args=..., format_str=..., buf=...) at /home/felinicity/server-042621/Server/submodules/fmt/include/fmt/format.h:3238
[World] [Crash] #16 fmt::v5::internal::vformat<char> (format_str=..., args=...) at /home/felinicity/server-042621/Server/submodules/fmt/include/fmt/format.h:3414
[World] [Crash] #17 0x000000000056a47c in fmt::v5::format<char [192], char const*, unsigned int> (format_str=...) at /home/felinicity/server-042621/Server/submodules/fmt/include/fmt/core.h:1458
[World] [Crash] #18 Database::GetSafePoints (this=this@entry=0x9c71a8 <content_db+8>, zone_short_name=<optimized out>, instance_version=instance_version@entry=0, safe_x=safe_x@entry=0x7ffd63957848, safe_y=safe_y@entry=0x7ffd6395784c, safe_z=safe_z@entry=0x7ffd63957850, safe_heading=0x7ffd63957854, min_status=0x0, min_level=0x0, flag_needed=0x0) at /home/felinicity/server-042621/Server/common/database.cpp:987
[World] [Crash] #19 0x00000000005419d0 in WorldDatabase::GetStartZone (this=<optimized out>, p_player_profile_struct=p_player_profile_struct@entry=0x7ffd639577d0, p_char_create_struct=p_char_create_struct@entry=0x14eb5d0, is_titanium=<optimized out>) at /home/felinicity/server-042621/Server/world/worlddb.cpp:592
[World] [Crash] #20 0x00000000004e1eca in Client::OPCharCreate (this=this@entry=0x15b3790, name=name@entry=0x15b379c "Thorin", cc=0x14eb5d0) at /home/felinicity/server-042621/Server/world/client.cpp:1559
[World] [Crash] #21 0x00000000004e2f93 in Client::HandleCharacterCreatePacket (this=this@entry=0x15b3790, app=app@entry=0x15b55a0) at /home/felinicity/server-042621/Server/world/client.cpp:705
[World] [Crash] #22 0x00000000004e36d1 in Client::HandlePacket (this=this@entry=0x15b3790, app=app@entry=0x15b55a0) at /home/felinicity/server-042621/Server/world/client.cpp:1052
[World] [Crash] #23 0x00000000004e3849 in Client::Process (this=0x15b3790) at /home/felinicity/server-042621/Server/world/client.cpp:1127
[World] [Crash] #24 0x00000000004fa739 in ClientList::Process (this=this@entry=0x9c63e0 <client_list>) at /home/felinicity/server-042621/Server/world/clientlist.cpp:64
[World] [Crash] #25 0x00000000004bb9d1 in main (argc=<optimized out>, argv=<optimized out>) at /home/felinicity/server-042621/Server/world/main.cpp:612
[World] [Client Login] ClientListEntry::SetOnline for [OdusPaul3] (99) = [Online] (1)
