### PR TITLE
[Installer] $ENV support, formatting, and optimizations

### DIFF
--- a/utils/scripts/eqemu_server.pl
+++ b/utils/scripts/eqemu_server.pl
@@ -436,7 +436,9 @@ sub build_linux_source
         }
     }
     my $eqemu_server_directory = "/home/eqemu";
-    my $source_dir             = $eqemu_server_directory . '/' . $last_directory . '_source' . $source_folder_post_fix;
+    # source between bots and not is the same, just different build results, so use the same source folder, different build folders
+    my $source_dir             = $eqemu_server_directory . '/' . $last_directory . '_source';
+    my $build_dir              = $eqemu_server_directory . '/' . $last_directory . '_build' . $source_folder_post_fix;
 
     $current_directory = trim($current_directory);
 
@@ -448,22 +450,22 @@ sub build_linux_source
 
     chdir($source_dir);
 
-    print `git clone https://github.com/EQEmu/Server.git`;
+    if (!-d "$source_dir/.git") {
+        print `git clone --recurse-submodules https://github.com/EQEmu/Server.git $source_dir`;
+    }
+    else {
+        print `git pull --recurse-submodules`;
+    }
 
-    mkdir($source_dir . "/Server/build") if (!-e $source_dir . "/Server/build");
-    chdir($source_dir . "/Server");
-
-    print `git submodule init`;
-    print `git submodule update`;
-
-    chdir($source_dir . "/Server/build");
+    mkdir($build_dir) if (!-e $build_dir);
+    chdir($build_dir);
 
     print "Generating CMake build files...\n";
     if ($os_flavor eq "fedora_core") {
-        print `cmake $cmake_options -DEQEMU_BUILD_LOGIN=ON -DEQEMU_BUILD_LUA=ON -DLUA_INCLUDE_DIR=/usr/include/lua-5.1/ -G "Unix Makefiles" ..`;
+        print `cmake $cmake_options -DEQEMU_BUILD_LOGIN=ON -DEQEMU_BUILD_LUA=ON -DLUA_INCLUDE_DIR=/usr/include/lua-5.1/ -G "Unix Makefiles" $source_dir`;
     }
     else {
-        print `cmake $cmake_options -DEQEMU_BUILD_LOGIN=ON -DEQEMU_BUILD_LUA=ON -G "Unix Makefiles" ..`;
+        print `cmake $cmake_options -DEQEMU_BUILD_LOGIN=ON -DEQEMU_BUILD_LUA=ON -G "Unix Makefiles" $source_dir`;
     }
     print "Building EQEmu Server code. This will take a while.";
 
@@ -472,17 +474,17 @@ sub build_linux_source
 
     chdir($current_directory);
 
-    print `ln -s -f $source_dir/Server/build/bin/eqlaunch .`;
-    print `ln -s -f $source_dir/Server/build/bin/export_client_files .`;
-    print `ln -s -f $source_dir/Server/build/bin/import_client_files .`;
-    print `ln -s -f $source_dir/Server/build/bin/libcommon.a .`;
-    print `ln -s -f $source_dir/Server/build/bin/libluabind.a .`;
-    print `ln -s -f $source_dir/Server/build/bin/queryserv .`;
-    print `ln -s -f $source_dir/Server/build/bin/shared_memory .`;
-    print `ln -s -f $source_dir/Server/build/bin/ucs .`;
-    print `ln -s -f $source_dir/Server/build/bin/world .`;
-    print `ln -s -f $source_dir/Server/build/bin/zone .`;
-    print `ln -s -f $source_dir/Server/build/bin/loginserver .`;
+    print `ln -s -f $build_dir/bin/eqlaunch .`;
+    print `ln -s -f $build_dir/bin/export_client_files .`;
+    print `ln -s -f $build_dir/bin/import_client_files .`;
+    print `ln -s -f $build_dir/bin/libcommon.a .`;
+    print `ln -s -f $build_dir/bin/libluabind.a .`;
+    print `ln -s -f $build_dir/bin/queryserv .`;
+    print `ln -s -f $build_dir/bin/shared_memory .`;
+    print `ln -s -f $build_dir/bin/ucs .`;
+    print `ln -s -f $build_dir/bin/world .`;
+    print `ln -s -f $build_dir/bin/zone .`;
+    print `ln -s -f $build_dir/bin/loginserver .`;
 }
 
 sub do_installer_routines

--- a/utils/scripts/eqemu_server.pl
+++ b/utils/scripts/eqemu_server.pl
@@ -240,10 +240,11 @@ sub show_install_summary_info
     }
     if ($OS eq "Linux") {
         print "[Install] Linux Utility Scripts:\n";
-        print " - server_start.sh			Starts EQEmu server (Quiet) with 30 dynamic zones, UCS & Queryserv, dynamic zones\n";
-        print " - server_start_dev.sh			Starts EQEmu server with 10 dynamic zones, UCS & Queryserv, dynamic zones all verbose\n";
-        print " - server_stop.sh			Stops EQEmu Server (No warning)\n";
-        print " - server_status.sh			Prints the status of the EQEmu Server processes\n";
+        print " - server_start.sh           	Starts EQEmu server (Quiet) with 30 dynamic zones, UCS & Queryserv, dynamic zones\n";
+        print " - server_start_with_login.sh	Starts EQEmu server (Quiet) with 30 dynamic zones, UCS & Queryserv, dynamic zones\n";
+        print " - server_start_dev.sh       	Starts EQEmu server with 10 dynamic zones, UCS & Queryserv, dynamic zones all verbose\n";
+        print " - server_stop.sh            	Stops EQEmu Server (No warning)\n";
+        print " - server_status.sh          	Prints the status of the EQEmu Server processes\n";
     }
 
     print "[Configure] eqemu_config.json 		Edit to change server settings and name\n";
@@ -417,7 +418,6 @@ sub check_xml_to_json_conversion
 
 sub build_linux_source
 {
-
     $build_options = $_[0];
 
     $cmake_options          = "";
@@ -840,9 +840,9 @@ sub do_install_config_json
 
     my $content;
     open(my $fh, '<', "eqemu_config_template.json") or die "cannot open file $filename"; {
-    local $/;
-    $content = <$fh>;
-}
+        local $/;
+        $content = <$fh>;
+    }
     close($fh);
 
     $config = $json->decode($content);
@@ -895,9 +895,9 @@ sub do_install_config_login_json
 
     my $content;
     open(my $fh, '<', "login_template.json") or die "cannot open file $filename"; {
-    local $/;
-    $content = <$fh>;
-}
+        local $/;
+        $content = <$fh>;
+    }
     close($fh);
 
     $config = $json->decode($content);
@@ -1206,12 +1206,12 @@ sub print_main_menu
     print "\n>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n";
     print ">>> EQEmu Server Main Menu >>>>>>>>>>>>\n";
     print ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n\n";
-    print " [database]				Enter database management menu \n";
-    print " [assets]				Manage server assets \n";
-    print " [new_server]			New folder EQEmu/PEQ install - Assumes MySQL/Perl installed \n";
-    print " [new_server_with_bots]	New folder EQEmu/PEQ install with bots enabled - Assumes MySQL/Perl installed \n";
-    print " [setup_bots]			Enables bots on server - builds code and database requirements \n";
-    print " [conversions]			Routines used for conversion of scripts/data \n";
+    print " [database]              Enter database management menu \n";
+    print " [assets]                Manage server assets \n";
+    print " [new_server]            New folder EQEmu/PEQ install - Assumes MySQL/Perl installed \n";
+    print " [new_server_with_bots]  New folder EQEmu/PEQ install with bots enabled - Assumes MySQL/Perl installed \n";
+    print " [setup_bots]            Enables bots on server - builds code and database requirements \n";
+    print " [conversions]           Routines used for conversion of scripts/data \n";
     print "\n";
     print " exit \n";
     print "\n";
@@ -1351,12 +1351,12 @@ sub script_exit
 sub check_db_version_table
 {
     if (get_mysql_result("SHOW TABLES LIKE 'db_version'") eq "" && $db) {
+        print "[Database] Table 'db_version' does not exist.... Creating...\n\n";
         print get_mysql_result("
 			CREATE TABLE db_version (
 			  version int(11) DEFAULT '0'
 			) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 			INSERT INTO db_version (version) VALUES ('1000');");
-        print "[Database] Table 'db_version' does not exist.... Creating...\n\n";
     }
 }
 
@@ -1505,9 +1505,9 @@ sub read_eqemu_config_json
 
     my $content;
     open(my $fh, '<', "eqemu_config.json") or die "cannot open file $filename"; {
-    local $/;
-    $content = <$fh>;
-}
+        local $/;
+        $content = <$fh>;
+    }
     close($fh);
 
     $config = $json->decode($content);
@@ -2578,7 +2578,6 @@ sub run_database_check
     }
 }
 
-
 sub fetch_missing_db_update
 {
     $db_update   = $_[0];
@@ -2759,7 +2758,6 @@ sub quest_heading_convert
 
     print "Total matches: " . $total_matches . "\n";
 }
-
 
 sub quest_faction_convert
 {


### PR DESCRIPTION
Some improvements to the installer script to help make a streamlined, simplified docker setup that leverages the same installer as suggested on the wiki.  In particular:

- Support for using environment variables for everything in installation_variables.txt (as well as some of the SKIP steps)
- Added support for specifying a db host other than localhost in above
- Added support for specifying the db root password for use when we DROP/CREATE database in new_server
- Added some of the existing additional options to the menus (like the linux start_server_with_login.sh)
- Removed a redundant build step (we were building the source twice in new_server)
- Added an option to deploy a new_server_with_bots, since the processes is all the same, just with different options on build
- Merged the bots/non-bots source directories and split out only the build directories (since the source is the same)
- If the source directory already has a .git folder in it, just do a git pull instead of clone (speeds up the process when re-using a volume for source)
- Cleaned up some formatting