### PR TITLE
[Expeditions] Track DZ member status in world

### DIFF
--- a/common/dynamic_zone_base.h
+++ b/common/dynamic_zone_base.h
@@ -25,6 +25,8 @@ struct DynamicZoneMember
 	DynamicZoneMember(uint32_t id, std::string name_, DynamicZoneMemberStatus status_)
 		: id(id), name{std::move(name_)}, status(status_) {}
 
+	bool IsOnline() const { return status == DynamicZoneMemberStatus::Online ||
+	                               status == DynamicZoneMemberStatus::InDynamicZone; }
 	bool IsValid() const { return id != 0 && !name.empty(); }
 };
 

--- a/common/expedition_base.cpp
+++ b/common/expedition_base.cpp
@@ -1,5 +1,6 @@
 #include "expedition_base.h"
 #include "repositories/expeditions_repository.h"
+#include "rulesys.h"
 
 ExpeditionBase::ExpeditionBase(uint32_t id, const std::string& uuid,
 	const std::string& expedition_name, const DynamicZoneMember& leader,
@@ -90,4 +91,28 @@ DynamicZoneMember ExpeditionBase::GetMemberData(const std::string& character_nam
 		member_data = *it;
 	}
 	return member_data;
+}
+
+bool ExpeditionBase::SetInternalMemberStatus(uint32_t character_id, DynamicZoneMemberStatus status)
+{
+	if (status == DynamicZoneMemberStatus::InDynamicZone && !RuleB(Expedition, EnableInDynamicZoneStatus))
+	{
+		status = DynamicZoneMemberStatus::Online;
+	}
+
+	if (character_id == m_leader.id)
+	{
+		m_leader.status = status;
+	}
+
+	auto it = std::find_if(m_members.begin(), m_members.end(),
+		[&](const DynamicZoneMember& member) { return member.id == character_id; });
+
+	if (it != m_members.end() && it->status != status)
+	{
+		it->status = status;
+		return true;
+	}
+
+	return false;
 }

--- a/common/expedition_base.h
+++ b/common/expedition_base.h
@@ -33,6 +33,7 @@ public:
 	bool HasMember(uint32_t character_id);
 	bool IsEmpty() const { return m_members.empty(); }
 	void RemoveInternalMember(uint32_t character_id);
+	bool SetInternalMemberStatus(uint32_t character_id, DynamicZoneMemberStatus status);
 
 	void LoadRepositoryResult(ExpeditionsRepository::ExpeditionWithLeader&& entry);
 	void AddMemberFromRepositoryResult(ExpeditionMembersRepository::MemberWithName&& entry);

--- a/common/servertalk.h
+++ b/common/servertalk.h
@@ -148,7 +148,7 @@
 #define ServerOP_ExpeditionMemberChange       0x0404
 #define ServerOP_ExpeditionMemberSwap         0x0405
 #define ServerOP_ExpeditionMemberStatus       0x0406
-#define ServerOP_ExpeditionGetOnlineMembers   0x0407
+#define ServerOP_ExpeditionGetMemberStatuses  0x0407
 #define ServerOP_ExpeditionDzAddPlayer        0x0408
 #define ServerOP_ExpeditionDzMakeLeader       0x0409
 #define ServerOP_ExpeditionCharacterLockout   0x040d
@@ -159,7 +159,6 @@
 #define ServerOP_ExpeditionMembersRemoved     0x0412
 #define ServerOP_ExpeditionLockoutDuration    0x0414
 #define ServerOP_ExpeditionExpireWarning      0x0416
-#define ServerOP_ExpeditionChooseNewLeader    0x0417
 
 #define ServerOP_DzAddRemoveCharacter         0x0450
 #define ServerOP_DzRemoveAllCharacters        0x0451
@@ -2035,19 +2034,15 @@ struct ServerExpeditionMemberStatus_Struct {
 	uint32 character_id;
 };
 
-struct ServerExpeditionCharacterEntry_Struct {
-	uint32 expedition_id;
+struct ServerExpeditionMemberStatusEntry_Struct {
 	uint32 character_id;
-	uint32 character_zone_id;
-	uint16 character_instance_id;
-	uint8  character_online; // 0: offline 1: online
+	uint8  online_status; // 0: unknown 1: Online 2: Offline 3: In Dynamic Zone 4: Link Dead
 };
 
-struct ServerExpeditionCharacters_Struct {
-	uint32 sender_zone_id;
-	uint16 sender_instance_id;
+struct ServerExpeditionMemberStatuses_Struct {
+	uint32 expedition_id;
 	uint32 count;
-	ServerExpeditionCharacterEntry_Struct entries[0];
+	ServerExpeditionMemberStatusEntry_Struct entries[0];
 };
 
 struct ServerExpeditionLockout_Struct {

--- a/world/expedition.h
+++ b/world/expedition.h
@@ -32,16 +32,18 @@ public:
 	Expedition();
 
 	void RemoveMember(uint32_t character_id);
+	void CacheMemberStatuses();
 	void CheckExpireWarning();
 	void CheckLeader();
 	void ChooseNewLeader();
 	DynamicZone& GetDynamicZone() { return m_dynamic_zone; }
 	bool Process();
-
+	void SendZoneMemberStatuses(uint16_t zone_id, uint16_t instance_id);
 	void SendZonesExpeditionDeleted();
 	void SendZonesExpireWarning(uint32_t minutes_remaining);
 	void SetDynamicZone(DynamicZone&& dz);
 	bool SetNewLeader(const DynamicZoneMember& member);
+	void UpdateMemberStatus(uint32_t character_id, DynamicZoneMemberStatus status);
 
 private:
 	void SendZonesLeaderChanged();

--- a/world/expedition_message.h
+++ b/world/expedition_message.h
@@ -26,8 +26,7 @@ class ServerPacket;
 namespace ExpeditionMessage
 {
 	void AddPlayer(ServerPacket* pack);
-	void ChooseNewLeader(ServerPacket* pack);
-	void GetOnlineMembers(ServerPacket* pack);
+	void GetMemberStatuses(ServerPacket* pack);
 	void HandleZoneMessage(ServerPacket* pack);
 	void MakeLeader(ServerPacket* pack);
 	void RequestInvite(ServerPacket* pack);

--- a/world/expedition_state.cpp
+++ b/world/expedition_state.cpp
@@ -110,6 +110,8 @@ void ExpeditionState::CacheExpeditions(
 			}
 		}
 
+		expedition->CacheMemberStatuses();
+
 		m_expeditions.emplace_back(std::move(expedition));
 	}
 }

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -1366,17 +1366,16 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 	case ServerOP_ExpeditionLockout:
 	case ServerOP_ExpeditionLockoutDuration:
 	case ServerOP_ExpeditionLockState:
-	case ServerOP_ExpeditionMemberStatus:
 	case ServerOP_ExpeditionReplayOnJoin:
 	case ServerOP_ExpeditionExpireWarning:
 	{
 		zoneserver_list.SendPacket(pack);
 		break;
 	}
-	case ServerOP_ExpeditionChooseNewLeader:
 	case ServerOP_ExpeditionCreate:
-	case ServerOP_ExpeditionGetOnlineMembers:
+	case ServerOP_ExpeditionGetMemberStatuses:
 	case ServerOP_ExpeditionMemberChange:
+	case ServerOP_ExpeditionMemberStatus:
 	case ServerOP_ExpeditionMemberSwap:
 	case ServerOP_ExpeditionMembersRemoved:
 	case ServerOP_ExpeditionDzAddPlayer:

--- a/zone/expedition.h
+++ b/zone/expedition.h
@@ -128,7 +128,6 @@ public:
 
 private:
 	static void CacheExpeditions(std::vector<ExpeditionsRepository::ExpeditionWithLeader>&& expeditions);
-	static void SendWorldGetOnlineMembers(const std::vector<std::pair<uint32_t, uint32_t>>& expedition_character_ids);
 	static void SendWorldCharacterLockout(uint32_t character_id, const ExpeditionLockoutTimer& lockout, bool remove);
 
 	void AddLockout(const ExpeditionLockoutTimer& lockout, bool members_only = false);
@@ -148,8 +147,9 @@ private:
 		Client* client, const std::string& inviter_name, const std::string& swap_remove_name);
 	void SendLeaderMessage(Client* leader_client, uint16_t chat_type, uint32_t string_id,
 		const std::initializer_list<std::string>& args = {});
+	void SendMemberListToZoneMembers();
+	void SendMemberStatusToZoneMembers(uint32_t update_character_id, DynamicZoneMemberStatus status);
 	void SendMembersExpireWarning(uint32_t minutes);
-	void SendNewMemberAddedToZoneMembers(const std::string& added_name);
 	void SendUpdatesToZoneMembers(bool clear = false, bool message_on_clear = true);
 	void SendCompassUpdateToZoneMembers();
 	void SendWorldExpeditionUpdate(uint16_t server_opcode);
@@ -167,7 +167,6 @@ private:
 	void SetDynamicZone(DynamicZone&& dz);
 	void TryAddClient(Client* add_client, const std::string& inviter_name,
 		const std::string& swap_remove_name, Client* leader_client = nullptr);
-	void UpdateMemberStatus(uint32_t update_character_id, DynamicZoneMemberStatus status);
 
 	std::unique_ptr<EQApplicationPacket> CreateExpireWarningPacket(uint32_t minutes_remaining);
 	std::unique_ptr<EQApplicationPacket> CreateInfoPacket(bool clear = false);

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -2905,7 +2905,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 	case ServerOP_ExpeditionMemberStatus:
 	case ServerOP_ExpeditionMembersRemoved:
 	case ServerOP_ExpeditionReplayOnJoin:
-	case ServerOP_ExpeditionGetOnlineMembers:
+	case ServerOP_ExpeditionGetMemberStatuses:
 	case ServerOP_ExpeditionDzAddPlayer:
 	case ServerOP_ExpeditionDzMakeLeader:
 	case ServerOP_ExpeditionCharacterLockout:


### PR DESCRIPTION
World now caches and tracks member statuses so it can send them to zones
that request them on startup. Prior to this the cle would be searched in
world for every zone startup caching request, now it's only searched once
when a new expedition is created.

Bulk loading statuses removed since it would only be needed on world
startup now and likely have no clients in the client list anyway.

This also lets world choose non-linkdead members on expedition leader
changes and better detect when a leader change needs to occur