### PR TITLE
[Boats] Prevent client update while on boat if boat turning

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4474,6 +4474,8 @@ void Client::Handle_OP_ClientUpdate(const EQApplicationPacket *app) {
 			LogError("Can't find boat for client position offset.");
 		}
 		else {
+			if (boat->turning) return;
+
 			// Calculate angle from boat heading to EQ heading
 			double theta = std::fmod(((boat->GetHeading() * 360.0) / 512.0),360.0);
 			double thetar = (theta * M_PI) / 180.0;

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -131,6 +131,7 @@ Mob::Mob(
 	AI_Init();
 	SetMoving(false);
 	moved            = false;
+	turning = false;
 	m_RewindLocation = glm::vec3();
 	m_RelativePosition = glm::vec4();
 

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1486,6 +1486,7 @@ public:
 	bool GetWasSpawnedInWater() const;
 
 	void SetSpawnedInWater(bool spawned_in_water);
+	bool turning;
 
 protected:
 

--- a/zone/mob_movement_manager.cpp
+++ b/zone/mob_movement_manager.cpp
@@ -63,6 +63,7 @@ public:
 
 		if (!m_started) {
 			m_started = true;
+			mob->turning = true;
 			mob->SetMoving(true);
 
 			if (dist > 15.0f && rotate_to_speed > 0.0 && rotate_to_speed <= 25.0) { //send basic rotation
@@ -84,6 +85,7 @@ public:
 			mob->SetHeading(to);
 			mob->SetMoving(false);
 			mob_movement_manager->SendCommandToClients(mob, 0.0, 0.0, 0.0, 0.0, 0, ClientRangeCloseMedium);
+			mob->turning = false;
 			return true;
 		}
 
@@ -1370,7 +1372,9 @@ void MobMovementManager::UpdatePathBoat(Mob *who, float x, float y, float z, Mob
 {
 	auto eiter = _impl->Entries.find(who);
 	auto &ent  = (*eiter);
+	float to = who->CalculateHeadingToTarget(x, y);
 
+	PushRotateTo(ent.second, who, to, mode);
 	PushSwimTo(ent.second, x, y, z, mode);
 	PushStopMoving(ent.second);
 }


### PR DESCRIPTION
Updates for client positions while a client is on a boat are received as x/y offsets based on the boats current heading.

When the server rotates the boat, it updates Heading in the boat server instance.  This means all future updates from the client will be processed according to that new heading.

Since the server only approximates rotation progress, there will be errors if we use client updates for PCs on boats while the boat is turning.

This patch tosses out the updates for the client while the boat he/she is on is turning, eliminating that error.