### PR TITLE
[Bug Fix] Add debugging and fix edge case where no target for aggro mob

### DIFF
--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -916,6 +916,10 @@ bool NPC::Process()
 
 	if (assist_timer.Check() && IsEngaged() && !Charmed() && !HasAssistAggro() &&
 	    NPCAssistCap() < RuleI(Combat, NPCAssistCap)) {
+		// Some cases like flash of light used for aggro haven't set target
+		if (!GetTarget()) {
+			SetTarget(hate_list.GetEntWithMostHateOnList(this));
+		}
 		AIYellForHelp(this, GetTarget());
 		if (NPCAssistCap() > 0 && !assist_cap_timer.Enabled())
 			assist_cap_timer.Start(RuleI(Combat, NPCAssistCapTimer));
@@ -3217,6 +3221,11 @@ bool NPC::AICheckCloseBeneficialSpells(
  */
 void NPC::AIYellForHelp(Mob *sender, Mob *attacker)
 {
+	LogAIYellForHelp("Mob[{}] Target[{}]",
+		(sender == nullptr ? "NULL MOB" : GetCleanName()),
+		(attacker == nullptr ? "NULL TARGET" : attacker->GetCleanName())
+		);
+
 	if (!sender || !attacker) {
 		return;
 	}
@@ -3225,11 +3234,14 @@ void NPC::AIYellForHelp(Mob *sender, Mob *attacker)
 	 * If we dont have a faction set, we're gonna be indiff to everybody
 	 */
 	if (sender->GetPrimaryFaction() == 0) {
+		LogAIYellForHelp("No Primary Faction");
 		return;
 	}
 
-	if (sender->HasAssistAggro())
+	if (sender->HasAssistAggro()) {
+		LogAIYellForHelp("I have assist aggro");
 		return;
+	}
 
 	LogAIYellForHelp(
 		"NPC [{}] ID [{}] is starting to scan",


### PR DESCRIPTION
If a mob is pulled with a spell like flash of light, the mob_ai never sets a target until the flee portion of the spell wears off.

On live, these fleeing mobs still cause other mobs to help, even while the mob keeps fleeing.

This PR assigns a target in these cases to YellForHelp functions properly.

It also adds additional logging for YellForHelp debugging.