### PR TITLE
[GM Command] #list npcs Goto option now goes to higher Z if selected NPC is a boat.

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -1610,7 +1610,7 @@ void command_list(Client *c, const Seperator *sep)
 					"#goto %.0f %0.f %.0f",
 					entity->GetX(),
 					entity->GetY(),
-					entity->GetZ() + (entity->IsBoat() * 50));
+					entity->GetZ() + (entity->IsBoat() ? 50 : 0);
 
 				c->Message(
 					0,

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -1610,7 +1610,7 @@ void command_list(Client *c, const Seperator *sep)
 					"#goto %.0f %0.f %.0f",
 					entity->GetX(),
 					entity->GetY(),
-					entity->GetZ());
+					entity->GetZ() + (entity->IsBoat() * 50));
 
 				c->Message(
 					0,

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -1610,7 +1610,7 @@ void command_list(Client *c, const Seperator *sep)
 					"#goto %.0f %0.f %.0f",
 					entity->GetX(),
 					entity->GetY(),
-					entity->GetZ() + (entity->IsBoat() ? 50 : 0);
+					entity->GetZ() + (entity->IsBoat() ? 50 : 0));
 
 				c->Message(
 					0,


### PR DESCRIPTION
Makes using #list npcs and using the goto button more useful when NPC is a boat, as normal Z will put you in the water.