### PR TITLE
 [Bug Fix] EntityList::AESpell fix for Pacify / Mez

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -369,7 +369,7 @@ RULE_BOOL(Spells, NPCInnateProcOverride, true, "NPC innate procs override the ta
 RULE_BOOL(Spells, OldRainTargets, false, "Use old incorrectly implemented maximum targets for rains")
 RULE_BOOL(Spells, NPCSpellPush, false, "Enable spell push on NPCs")
 RULE_BOOL(Spells, July242002PetResists, true, "Enable Pets using PCs resist change from July 24 2002")
-RULE_INT(Spells, AOEMaxTargets, 0, "Max number of targets a Targeted AOE spell can cast on")
+RULE_INT(Spells, AOEMaxTargets, 0, "Max number of targets a Targeted AOE spell can cast on. Set to 0 for no limit.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Combat)

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -369,6 +369,7 @@ RULE_BOOL(Spells, NPCInnateProcOverride, true, "NPC innate procs override the ta
 RULE_BOOL(Spells, OldRainTargets, false, "Use old incorrectly implemented maximum targets for rains")
 RULE_BOOL(Spells, NPCSpellPush, false, "Enable spell push on NPCs")
 RULE_BOOL(Spells, July242002PetResists, true, "Enable Pets using PCs resist change from July 24 2002")
+RULE_INT(Spells, AOEMaxTargets, 0, "Max number of targets a Targeted AOE spell can cast on")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Combat)

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -793,6 +793,8 @@ void EntityList::AESpell(
 	}
 	else if (IsTargetableAESpell(spell_id) && is_detrimental_spell && !is_npc) {
 		max_targets_allowed = 4;
+		if (spells[spell_id].effectid[2] == 18 || spells[spell_id].effectid[0] == 31) // pacify and mez
+			max_targets_allowed = 99;												  // this is suppose to be unlimited cap
 	}
 
 	int   target_hit_counter = 0;

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -784,7 +784,7 @@ void EntityList::AESpell(
 	/**
 	 * Max AOE targets
 	 */
-	int max_targets_allowed = 0; // unlimited
+	int max_targets_allowed = RuleI(Range, AOEMaxTargets); // unlimited
 	if (max_targets) { // rains pass this in since they need to preserve the count through waves
 		max_targets_allowed = *max_targets;
 	}

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -793,7 +793,7 @@ void EntityList::AESpell(
 	}
 	else if (IsTargetableAESpell(spell_id) && is_detrimental_spell && !is_npc) {
 		max_targets_allowed = 4;
-		if (spells[spell_id].effectid[2] == 18 || spells[spell_id].effectid[0] == 31) // pacify and mez
+		if (spells[spell_id].effectid[2] == SE_Lull || spells[spell_id].effectid[0] == SE_Mez) // pacify and mez
 			max_targets_allowed = 99;												  // this is suppose to be unlimited cap
 	}
 

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -793,8 +793,8 @@ void EntityList::AESpell(
 	}
 	else if (IsTargetableAESpell(spell_id) && is_detrimental_spell && !is_npc) {
 		max_targets_allowed = 4;
-		if (spells[spell_id].effectid[2] == SE_Lull || spells[spell_id].effectid[0] == SE_Mez) // pacify and mez
-			max_targets_allowed = 99;												  // this is suppose to be unlimited cap
+		if (IsEffectInSpell(spell_id, SE_Lull) || IsEffectInSpell(spell_id, SE_Mez))
+			max_targets_allowed = 99;
 	}
 
 	int   target_hit_counter = 0;

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -791,10 +791,8 @@ void EntityList::AESpell(
 	else if (spells[spell_id].aemaxtargets) {
 		max_targets_allowed = spells[spell_id].aemaxtargets;
 	}
-	else if (IsTargetableAESpell(spell_id) && is_detrimental_spell && !is_npc) {
+	else if (IsTargetableAESpell(spell_id) && is_detrimental_spell && !is_npc && !IsEffectInSpell(spell_id, SE_Lull) && !IsEffectInSpell(spell_id, SE_Mez)) {
 		max_targets_allowed = 4;
-		if (IsEffectInSpell(spell_id, SE_Lull) || IsEffectInSpell(spell_id, SE_Mez))
-			max_targets_allowed = 99;
 	}
 
 	int   target_hit_counter = 0;


### PR DESCRIPTION
this fixes AE pacify / Mez spells only landing on 4 when it shouldn't have a cap