### PR TITLE
[Dynamic Zones] Store min and max players on dz

### DIFF
--- a/common/dynamic_zone_base.h
+++ b/common/dynamic_zone_base.h
@@ -61,6 +61,8 @@ public:
 	uint64_t GetExpireTime() const { return std::chrono::system_clock::to_time_t(m_expire_time); }
 	uint32_t GetID() const { return m_id; }
 	uint16_t GetInstanceID() const { return static_cast<uint16_t>(m_instance_id); }
+	uint32_t GetMaxPlayers() const { return m_max_players; }
+	uint32_t GetMinPlayers() const { return m_min_players; }
 	uint32_t GetSecondsRemaining() const;
 	uint16_t GetZoneID() const { return static_cast<uint16_t>(m_zone_id); }
 	uint32_t GetZoneIndex() const { return (m_instance_id << 16) | (m_zone_id & 0xffff); }
@@ -86,6 +88,8 @@ public:
 	void SetCompass(const DynamicZoneLocation& location, bool update_db = false);
 	void SetCompass(uint32_t zone_id, float x, float y, float z, bool update_db = false);
 	void SetLeaderName(const std::string& leader_name) { m_leader_name = leader_name; }
+	void SetMaxPlayers(uint32_t max_players) { m_max_players = max_players; }
+	void SetMinPlayers(uint32_t min_players) { m_min_players = min_players; }
 	void SetName(const std::string& name) { m_name = name; }
 	void SetSafeReturn(const DynamicZoneLocation& location, bool update_db = false);
 	void SetSafeReturn(uint32_t zone_id, float x, float y, float z, float heading, bool update_db = false);
@@ -113,6 +117,8 @@ protected:
 	uint32_t m_zone_id = 0;
 	uint32_t m_instance_id = 0;
 	uint32_t m_zone_version = 0;
+	uint32_t m_min_players = 0;
+	uint32_t m_max_players = 0;
 	bool m_never_expires = false;
 	bool m_has_zonein = false;
 	std::string m_name;

--- a/common/expedition_base.cpp
+++ b/common/expedition_base.cpp
@@ -3,15 +3,12 @@
 #include "rulesys.h"
 
 ExpeditionBase::ExpeditionBase(uint32_t id, const std::string& uuid,
-	const std::string& expedition_name, const DynamicZoneMember& leader,
-	uint32_t min_players, uint32_t max_players
+	const std::string& expedition_name, const DynamicZoneMember& leader
 ) :
 	m_id(id),
 	m_uuid(uuid),
 	m_expedition_name(expedition_name),
-	m_leader(leader),
-	m_min_players(min_players),
-	m_max_players(max_players)
+	m_leader(leader)
 {
 }
 
@@ -20,8 +17,6 @@ void ExpeditionBase::LoadRepositoryResult(ExpeditionsRepository::ExpeditionWithL
 	m_id                 = entry.id;
 	m_uuid               = std::move(entry.uuid);
 	m_expedition_name    = std::move(entry.expedition_name);
-	m_min_players        = entry.min_players;
-	m_max_players        = entry.max_players;
 	m_add_replay_on_join = entry.add_replay_on_join;
 	m_is_locked          = entry.is_locked;
 	m_leader.id          = entry.leader_id;

--- a/common/expedition_base.h
+++ b/common/expedition_base.h
@@ -19,8 +19,6 @@ public:
 
 	uint32_t GetID() const { return m_id; }
 	uint32_t GetLeaderID() const { return m_leader.id; }
-	uint32_t GetMinPlayers() const { return m_min_players; }
-	uint32_t GetMaxPlayers() const { return m_max_players; }
 	uint32_t GetMemberCount() const { return static_cast<uint32_t>(m_members.size()); }
 	const std::string& GetName() const { return m_expedition_name; }
 	const std::string& GetLeaderName() const { return m_leader.name; }
@@ -41,14 +39,12 @@ public:
 protected:
 	ExpeditionBase() = default;
 	ExpeditionBase(uint32_t id, const std::string& uuid, const std::string& expedition_name,
-		const DynamicZoneMember& leader, uint32_t min_players, uint32_t max_players);
+		const DynamicZoneMember& leader);
 
 	DynamicZoneMember GetMemberData(uint32_t character_id);
 	DynamicZoneMember GetMemberData(const std::string& character_name);
 
 	uint32_t m_id = 0;
-	uint32_t m_min_players = 0;
-	uint32_t m_max_players = 0;
 	bool m_is_locked = false;
 	bool m_add_replay_on_join = true;
 	std::string m_uuid;

--- a/world/expedition_state.cpp
+++ b/world/expedition_state.cpp
@@ -110,6 +110,10 @@ void ExpeditionState::CacheExpeditions(
 			}
 		}
 
+		// stored on expedition in db but on dz in memory cache
+		expedition->GetDynamicZone().SetMinPlayers(entry.min_players);
+		expedition->GetDynamicZone().SetMaxPlayers(entry.max_players);
+
 		expedition->CacheMemberStatuses();
 
 		m_expeditions.emplace_back(std::move(expedition));

--- a/zone/expedition.h
+++ b/zone/expedition.h
@@ -52,7 +52,7 @@ class Expedition : public ExpeditionBase
 public:
 	Expedition() = default;
 	Expedition(uint32_t id, const std::string& uuid, DynamicZone&& dz, const std::string& expedition_name,
-		const DynamicZoneMember& leader, uint32_t min_players, uint32_t max_players);
+		const DynamicZoneMember& leader);
 
 	static Expedition* TryCreate(Client* requester, DynamicZone& dynamiczone, ExpeditionRequest& request);
 


### PR DESCRIPTION
This starts some changes that move storage of things from expeditions to
dynamic zone class so other systems can possibly use them. This will also
make it easier to move window packet creation methods to DynamicZone.

For now these will remain on the expeditions table in the database. This
can be re-evaluated once other components are moved and seeing how other
systems may want to handle their player requirements.