### PR TITLE
[Quest API] Add several methods to Perl/Lua API for LDoN stuff.

### DIFF
--- a/common/servertalk.h
+++ b/common/servertalk.h
@@ -287,6 +287,7 @@
 #define ServerOP_CZTaskRemoveRaid 0x4561
 #define ServerOP_CZTaskRemoveGuild 0x4562
 #define ServerOP_CZClientMessageString 0x4563
+#define ServerOP_CZLDoNUpdate 0x4564
 
 #define ServerOP_WWAssignTask 0x4750
 #define ServerOP_WWCastSpell 0x4751
@@ -318,6 +319,20 @@
 #define ServerOP_QSPlayerLogMerchantTransactions 0x5005
 #define ServerOP_QSSendQuery 0x5006
 #define ServerOP_QSPlayerDropItem 0x5007
+
+enum {
+	CZLDoNUpdateType_Character = 0,
+	CZLDoNUpdateType_Group,
+	CZLDoNUpdateType_Raid,
+	CZLDoNUpdateType_Guild,
+	CZLDoNUpdateType_Expedition
+};
+
+enum {
+	CZLDoNUpdateSubtype_Win = 0,
+	CZLDoNUpdateSubtype_Loss,
+	CZLDoNUpdateSubtype_Points
+};
 
 /* Query Serv Generic Packet Flag/Type Enumeration */
 enum { QSG_LFGuild = 0 };
@@ -1860,6 +1875,14 @@ struct CZTaskRemoveGuild_Struct {
 	uint16 npc_entity_id;
 	int guild_id;
 	uint32 task_id;
+};
+
+struct CZLDoNUpdate_Struct {
+	uint8 update_type; // 0 - Character, 1 - Group, 2 - Raid, 3 - Guild, 4 - Expedition
+	uint8 update_subtype; // 0 - Win, 1 - Loss, 2 - Points
+	int update_identifier; // Character ID, Group ID, Raid ID, Guild ID, or Expedition ID based on update type
+	uint32 theme_id;
+	int points; // Always 1, except for when Points are used
 };
 
 struct WWAssignTask_Struct {

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -1302,6 +1302,7 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 	case ServerOP_CZTaskRemoveGroup:
 	case ServerOP_CZTaskRemoveRaid:
 	case ServerOP_CZTaskRemoveGuild:
+	case ServerOP_CZLDoNUpdate:
 	case ServerOP_WWAssignTask:
 	case ServerOP_WWCastSpell:
 	case ServerOP_WWDisableTask:

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -1374,8 +1374,7 @@ void Client::SetMaxHP() {
 	Save();
 }
 
-bool Client::UpdateLDoNPoints(int32 points, uint32 theme)
-{
+bool Client::UpdateLDoNPoints(uint32 theme_id, int points) {
 
 /* make sure total stays in sync with individual buckets
 	m_pp.ldon_points_available = m_pp.ldon_points_guk
@@ -1384,113 +1383,97 @@ bool Client::UpdateLDoNPoints(int32 points, uint32 theme)
 		+m_pp.ldon_points_ruj
 		+m_pp.ldon_points_tak; */
 
-	if(points < 0)
-	{
-		if(m_pp.ldon_points_available < (0-points))
+	if(points < 0) {
+		if(m_pp.ldon_points_available < (0 - points))
 			return false;
 	}
-	switch(theme)
+
+	switch (theme_id)
 	{
-	// handle generic points (theme=0)
-	case 0:
-		{	// no theme, so distribute evenly across all
-			int splitpts=points/5;
-			int gukpts=splitpts+(points%5);
-			int mirpts=splitpts;
-			int mmcpts=splitpts;
-			int rujpts=splitpts;
-			int takpts=splitpts;
-
-			splitpts=0;
-
-			if(points < 0)
-			{
-				if(m_pp.ldon_points_available < (0-points))
-				{
+		case 0: { // No theme, so distribute evenly across all
+			int split_points = (points / 5);
+			int guk_points = (split_points + (points % 5));
+			int mir_points = split_points;
+			int mmc_points = split_points;
+			int ruj_points = split_points;
+			int tak_points = split_points;
+			split_points = 0;
+			if(points < 0) {
+				if(m_pp.ldon_points_available < (0 - points)) {
 					return false;
 				}
-				if(m_pp.ldon_points_guk < (0-gukpts))
-				{
-					mirpts+=gukpts+m_pp.ldon_points_guk;
-					gukpts=0-m_pp.ldon_points_guk;
+
+				if(m_pp.ldon_points_guk < (0 - guk_points)) {
+					mir_points += (guk_points + m_pp.ldon_points_guk);
+					guk_points = (0 - m_pp.ldon_points_guk);
 				}
-				if(m_pp.ldon_points_mir < (0-mirpts))
-				{
-					mmcpts+=mirpts+m_pp.ldon_points_mir;
-					mirpts=0-m_pp.ldon_points_mir;
+
+				if(m_pp.ldon_points_mir < (0 - mir_points)) {
+					mmc_points += (mir_points + m_pp.ldon_points_mir);
+					mir_points = (0 - m_pp.ldon_points_mir);
 				}
-				if(m_pp.ldon_points_mmc < (0-mmcpts))
-				{
-					rujpts+=mmcpts+m_pp.ldon_points_mmc;
-					mmcpts=0-m_pp.ldon_points_mmc;
+				
+				if(m_pp.ldon_points_mmc < (0 - mmc_points)) {
+					ruj_points += (mmc_points + m_pp.ldon_points_mmc);
+					mmc_points = (0 - m_pp.ldon_points_mmc);
 				}
-				if(m_pp.ldon_points_ruj < (0-rujpts))
-				{
-					takpts+=rujpts+m_pp.ldon_points_ruj;
-					rujpts=0-m_pp.ldon_points_ruj;
+
+				if(m_pp.ldon_points_ruj < (0 - ruj_points)) {
+					tak_points += (ruj_points + m_pp.ldon_points_ruj);
+					ruj_points = (0 - m_pp.ldon_points_ruj);
 				}
-				if(m_pp.ldon_points_tak < (0-takpts))
-				{
-					splitpts=takpts+m_pp.ldon_points_tak;
-					takpts=0-m_pp.ldon_points_tak;
+
+				if(m_pp.ldon_points_tak < (0 - tak_points)) {
+					split_points = (tak_points + m_pp.ldon_points_tak);
+					tak_points = (0 - m_pp.ldon_points_tak);
 				}
 			}
-			m_pp.ldon_points_guk += gukpts;
-			m_pp.ldon_points_mir+=mirpts;
-			m_pp.ldon_points_mmc += mmcpts;
-			m_pp.ldon_points_ruj += rujpts;
-			m_pp.ldon_points_tak += takpts;
-			points-=splitpts;
-			// if anything left, recursively loop thru again
-			if (splitpts !=0)
-				UpdateLDoNPoints(splitpts,0);
+			m_pp.ldon_points_guk += guk_points;
+			m_pp.ldon_points_mir += mir_points;
+			m_pp.ldon_points_mmc += mmc_points;
+			m_pp.ldon_points_ruj += ruj_points;
+			m_pp.ldon_points_tak += tak_points;
+			points -= split_points;
+			if (split_points != 0) // if anything left, recursively loop thru again
+				UpdateLDoNPoints(0, split_points);
+
 			break;
 		}
-	case 1:
-		{
-			if(points < 0)
-			{
-				if(m_pp.ldon_points_guk < (0-points))
+		case 1:	{
+			if(points < 0) {
+				if(m_pp.ldon_points_guk < (0 - points))
 					return false;
 			}
 			m_pp.ldon_points_guk += points;
 			break;
 		}
-	case 2:
-		{
-			if(points < 0)
-			{
-				if(m_pp.ldon_points_mir < (0-points))
+		case 2: {
+			if(points < 0) {
+				if(m_pp.ldon_points_mir < (0 - points))
 					return false;
 			}
 			m_pp.ldon_points_mir += points;
 			break;
 		}
-	case 3:
-		{
-			if(points < 0)
-			{
-				if(m_pp.ldon_points_mmc < (0-points))
+		case 3: {
+			if(points < 0) {
+				if(m_pp.ldon_points_mmc < (0 - points))
 					return false;
 			}
 			m_pp.ldon_points_mmc += points;
 			break;
 		}
-	case 4:
-		{
-			if(points < 0)
-			{
-				if(m_pp.ldon_points_ruj < (0-points))
+		case 4: {
+			if(points < 0) {
+				if(m_pp.ldon_points_ruj < (0 - points))
 					return false;
 			}
 			m_pp.ldon_points_ruj += points;
 			break;
 		}
-	case 5:
-		{
-			if(points < 0)
-			{
-				if(m_pp.ldon_points_tak < (0-points))
+		case 5: {
+			if(points < 0) {
+				if(m_pp.ldon_points_tak < (0 - points))
 					return false;
 			}
 			m_pp.ldon_points_tak += points;
@@ -1498,7 +1481,6 @@ bool Client::UpdateLDoNPoints(int32 points, uint32 theme)
 		}
 	}
 	m_pp.ldon_points_available += points;
-
 	auto outapp = new EQApplicationPacket(OP_AdventurePointsUpdate, sizeof(AdventurePoints_Update_Struct));
 	AdventurePoints_Update_Struct* apus = (AdventurePoints_Update_Struct*)outapp->pBuffer;
 	apus->ldon_available_points = m_pp.ldon_points_available;
@@ -1511,8 +1493,6 @@ bool Client::UpdateLDoNPoints(int32 points, uint32 theme)
 	QueuePacket(outapp);
 	safe_delete(outapp);
 	return true;
-
-	return(false);
 }
 
 void Client::SetSkill(EQ::skills::SkillType skillid, uint16 value) {
@@ -5566,51 +5546,61 @@ uint32 Client::GetLDoNLossesTheme(uint32 t)
 	}
 }
 
-void Client::UpdateLDoNWins(uint32 t, int32 n)
+void Client::AddLDoNLoss(uint32 theme_id)
 {
-	switch(t)
+	switch (theme_id)
 	{
-	case 1:
-		m_pp.ldon_wins_guk = n;
-		break;
-	case 2:
-		m_pp.ldon_wins_mir = n;
-		break;
-	case 3:
-		m_pp.ldon_wins_mmc = n;
-		break;
-	case 4:
-		m_pp.ldon_wins_ruj = n;
-		break;
-	case 5:
-		m_pp.ldon_wins_tak = n;
-		break;
-	default:
-		return;
+		case 1:
+			m_pp.ldon_losses_guk += 1;
+			database.UpdateAdventureStatsEntry(CharacterID(), theme_id, false);
+			break;
+		case 2:
+			m_pp.ldon_losses_mir += 1;
+			database.UpdateAdventureStatsEntry(CharacterID(), theme_id, false);
+			break;
+		case 3:
+			m_pp.ldon_losses_mmc += 1;
+			database.UpdateAdventureStatsEntry(CharacterID(), theme_id, false);
+			break;
+		case 4:
+			m_pp.ldon_losses_ruj += 1;
+			database.UpdateAdventureStatsEntry(CharacterID(), theme_id, false);
+			break;
+		case 5:
+			m_pp.ldon_losses_tak += 1;
+			database.UpdateAdventureStatsEntry(CharacterID(), theme_id, false);
+			break;
+		default:
+			return;
 	}
 }
 
-void Client::UpdateLDoNLosses(uint32 t, int32 n)
+void Client::AddLDoNWin(uint32 theme_id)
 {
-	switch(t)
+	switch (theme_id)
 	{
-	case 1:
-		m_pp.ldon_losses_guk = n;
-		break;
-	case 2:
-		m_pp.ldon_losses_mir = n;
-		break;
-	case 3:
-		m_pp.ldon_losses_mmc = n;
-		break;
-	case 4:
-		m_pp.ldon_losses_ruj = n;
-		break;
-	case 5:
-		m_pp.ldon_losses_tak = n;
-		break;
-	default:
-		return;
+		case 1:
+			m_pp.ldon_wins_guk += 1;
+			database.UpdateAdventureStatsEntry(CharacterID(), theme_id, true);
+			break;
+		case 2:
+			m_pp.ldon_wins_mir += 1;
+			database.UpdateAdventureStatsEntry(CharacterID(), theme_id, true);
+			break;
+		case 3:
+			m_pp.ldon_wins_mmc += 1;
+			database.UpdateAdventureStatsEntry(CharacterID(), theme_id, true);
+			break;
+		case 4:
+			m_pp.ldon_wins_ruj += 1;
+			database.UpdateAdventureStatsEntry(CharacterID(), theme_id, true);
+			break;
+		case 5:
+			m_pp.ldon_wins_tak += 1;
+			database.UpdateAdventureStatsEntry(CharacterID(), theme_id, true);
+			break;
+		default:
+			return;
 	}
 }
 
@@ -6043,7 +6033,7 @@ void Client::ClearCurrentAdventure()
 
 void Client::AdventureFinish(bool win, int theme, int points)
 {
-	UpdateLDoNPoints(points, theme);
+	UpdateLDoNPoints(theme, points);
 	auto outapp = new EQApplicationPacket(OP_AdventureFinish, sizeof(AdventureFinish_Struct));
 	AdventureFinish_Struct *af = (AdventureFinish_Struct*)outapp->pBuffer;
 	af->win_lose = win ? 1 : 0;

--- a/zone/client.h
+++ b/zone/client.h
@@ -605,7 +605,7 @@ public:
 	inline void SetAAEXPModifier(uint32 zone_id, double aa_modifier) { database.SetAAEXPModifier(CharacterID(), zone_id, aa_modifier); };
 	inline void SetEXPModifier(uint32 zone_id, double exp_modifier) { database.SetEXPModifier(CharacterID(), zone_id, exp_modifier); };
 	
-	bool UpdateLDoNPoints(int32 points, uint32 theme);
+	bool UpdateLDoNPoints(uint32 theme_id, int points);
 	void SetPVPPoints(uint32 Points) { m_pp.PVPCurrentPoints = Points; }
 	uint32 GetPVPPoints() { return m_pp.PVPCurrentPoints; }
 	void AddPVPPoints(uint32 Points);
@@ -1309,8 +1309,8 @@ public:
 	uint32 GetLDoNWinsTheme(uint32 t);
 	uint32 GetLDoNLossesTheme(uint32 t);
 	uint32 GetLDoNPointsTheme(uint32 t);
-	void UpdateLDoNWins(uint32 t, int32 n);
-	void UpdateLDoNLosses(uint32 t, int32 n);
+	void AddLDoNWin(uint32 theme_id);
+	void AddLDoNLoss(uint32 theme_id);
 	void CheckLDoNHail(Mob *target);
 	void CheckEmoteHail(Mob *target, const char* message);
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -2032,7 +2032,7 @@ void Client::Handle_OP_AdventureMerchantPurchase(const EQApplicationPacket *app)
 	{
 		int32 requiredpts = (int32)item->LDoNPrice*-1;
 
-		if (!UpdateLDoNPoints(requiredpts, 6))
+		if (!UpdateLDoNPoints(6, requiredpts))
 			return;
 	}
 	else if (aps->Type == DiscordMerchant)
@@ -2260,7 +2260,7 @@ void Client::Handle_OP_AdventureMerchantSell(const EQApplicationPacket *app)
 	{
 	case ADVENTUREMERCHANT:
 	{
-		UpdateLDoNPoints(price, 6);
+		UpdateLDoNPoints(6, price);
 		break;
 	}
 	case NORRATHS_KEEPERS_MERCHANT:

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -8432,13 +8432,13 @@ void command_set_adventure_points(Client *c, const Seperator *sep)
 
 	if(!sep->arg[1][0])
 	{
-		c->Message(Chat::White, "Usage: #setadventurepoints [points] [theme]");
+		c->Message(Chat::White, "Usage: #setadventurepoints [theme] [points]");
 		return;
 	}
 
 	if(!sep->IsNumber(1) || !sep->IsNumber(2))
 	{
-		c->Message(Chat::White, "Usage: #setadventurepoints [points] [theme]");
+		c->Message(Chat::White, "Usage: #setadventurepoints [theme] [points]");
 		return;
 	}
 

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -1592,27 +1592,22 @@ XS(XS__addldonpoints);
 XS(XS__addldonpoints) {
 	dXSARGS;
 	if (items != 2)
-		Perl_croak(aTHX_ "Usage: quest::addldonpoints(int points, int theme_id)");
-
-long          points = (long)SvIV(ST(0));
-unsigned long theme_id = (unsigned long)SvUV(ST(1));
-
-quest_manager.addldonpoints(points, theme_id);
-
-XSRETURN_EMPTY;
+		Perl_croak(aTHX_ "Usage: quest::addldonpoints(uint32 theme_id, int points)");
+	
+	uint32 theme_id = (uint32) SvUV(ST(0));
+	int points = (int) SvIV(ST(1));
+	quest_manager.addldonpoints(theme_id, points);
+	XSRETURN_EMPTY;
 }
 
 XS(XS__addldonwin);
 XS(XS__addldonwin) {
 	dXSARGS;
-	if (items != 2)
-		Perl_croak(aTHX_ "Usage: quest::addldonwin(int wins, int theme_id)");
+	if (items != 1)
+		Perl_croak(aTHX_ "Usage: quest::addldonwin(uint32 theme_id)");
 
-	long          wins = (long)SvIV(ST(0));
-	unsigned long theme_id = (unsigned long)SvUV(ST(1));
-
-	quest_manager.addldonwin(wins, theme_id);
-
+	uint32 theme_id = (uint32) SvUV(ST(0));
+	quest_manager.addldonwin(theme_id);
 	XSRETURN_EMPTY;
 }
 
@@ -1620,13 +1615,10 @@ XS(XS__addldonloss);
 XS(XS__addldonloss) {
 	dXSARGS;
 	if (items != 2)
-		Perl_croak(aTHX_ "Usage: quest::addldonloss(int losses, int theme_id)");
+		Perl_croak(aTHX_ "Usage: quest::addldonloss(uint32 theme_id)");
 
-	long          losses = (long)SvIV(ST(0));
-	unsigned long theme_id = (unsigned long)SvUV(ST(1));
-
-	quest_manager.addldonloss(losses, theme_id);
-
+	uint32 theme_id = (uint32) SvUV(ST(0));
+	quest_manager.addldonloss(theme_id);
 	XSRETURN_EMPTY;
 }
 
@@ -6553,6 +6545,221 @@ XS(XS__setexpmodifierbycharid) {
 	XSRETURN_EMPTY;
 }
 
+XS(XS__crosszoneaddldonlossbycharid);
+XS(XS__crosszoneaddldonlossbycharid) {
+	dXSARGS;
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: quest::crosszoneaddldonlossbycharid(int character_id, uint32 theme_id)");
+
+	uint8 update_type = CZLDoNUpdateType_Character;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Loss;
+	int character_id = (int) SvIV(ST(0));
+	uint32 theme_id = (uint32) SvUV(ST(1));
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, character_id, theme_id);
+	XSRETURN_EMPTY;
+}
+
+XS(XS__crosszoneaddldonpointsbycharid);
+XS(XS__crosszoneaddldonpointsbycharid) {
+	dXSARGS;
+	if (items != 3)
+		Perl_croak(aTHX_ "Usage: quest::crosszoneaddldonpointsbycharid(int character_id, uint32 theme_id, int points)");
+
+	uint8 update_type = CZLDoNUpdateType_Character;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Points;
+	int character_id = (int) SvIV(ST(0));
+	uint32 theme_id = (uint32) SvUV(ST(1));
+	int points = (int) SvIV(ST(2));
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, character_id, theme_id, points);
+	XSRETURN_EMPTY;
+}
+
+XS(XS__crosszoneaddldonwinbycharid);
+XS(XS__crosszoneaddldonwinbycharid) {
+	dXSARGS;
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: quest::crosszoneaddldonwinbycharid(int character_id, uint32 theme_id)");
+
+	uint8 update_type = CZLDoNUpdateType_Character;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Win;
+	int character_id = (int) SvIV(ST(0));
+	uint32 theme_id = (uint32) SvUV(ST(1));
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, character_id, theme_id);
+	XSRETURN_EMPTY;
+}
+
+XS(XS__crosszoneaddldonlossbygroupid);
+XS(XS__crosszoneaddldonlossbygroupid) {
+	dXSARGS;
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: quest::crosszoneaddldonlossbygroupid(int group_id, uint32 theme_id)");
+
+	uint8 update_type = CZLDoNUpdateType_Group;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Loss;
+	int group_id = (int) SvIV(ST(0));
+	uint32 theme_id = (uint32) SvUV(ST(1));
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, group_id, theme_id);
+	XSRETURN_EMPTY;
+}
+
+XS(XS__crosszoneaddldonpointsbygroupid);
+XS(XS__crosszoneaddldonpointsbygroupid) {
+	dXSARGS;
+	if (items != 3)
+		Perl_croak(aTHX_ "Usage: quest::crosszoneaddldonpointsbygroupid(int group_id, uint32 theme_id, int points)");
+
+	uint8 update_type = CZLDoNUpdateType_Group;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Points;
+	int group_id = (int) SvIV(ST(0));
+	uint32 theme_id = (uint32) SvUV(ST(1));
+	int points = (int) SvIV(ST(2));
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, group_id, theme_id, points);
+	XSRETURN_EMPTY;
+}
+
+XS(XS__crosszoneaddldonwinbygroupid);
+XS(XS__crosszoneaddldonwinbygroupid) {
+	dXSARGS;
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: quest::crosszoneaddldonwinbygroupid(int group_id, uint32 theme_id)");
+
+	uint8 update_type = CZLDoNUpdateType_Group;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Win;
+	int group_id = (int) SvIV(ST(0));
+	uint32 theme_id = (uint32) SvUV(ST(1));
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, group_id, theme_id);
+	XSRETURN_EMPTY;
+}
+
+XS(XS__crosszoneaddldonlossbyraidid);
+XS(XS__crosszoneaddldonlossbyraidid) {
+	dXSARGS;
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: quest::crosszoneaddldonlossbyraidid(int raid_id, uint32 theme_id)");
+
+	uint8 update_type = CZLDoNUpdateType_Raid;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Loss;
+	int raid_id = (int) SvIV(ST(0));
+	uint32 theme_id = (uint32) SvUV(ST(1));
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, raid_id, theme_id);
+	XSRETURN_EMPTY;
+}
+
+XS(XS__crosszoneaddldonpointsbyraidid);
+XS(XS__crosszoneaddldonpointsbyraidid) {
+	dXSARGS;
+	if (items != 3)
+		Perl_croak(aTHX_ "Usage: quest::crosszoneaddldonpointsbyraidid(int raid_id, uint32 theme_id, int points)");
+
+	uint8 update_type = CZLDoNUpdateType_Raid;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Points;
+	int raid_id = (int) SvIV(ST(0));
+	uint32 theme_id = (uint32) SvUV(ST(1));
+	int points = (int) SvIV(ST(2));
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, raid_id, theme_id, points);
+	XSRETURN_EMPTY;
+}
+
+XS(XS__crosszoneaddldonwinbyraidid);
+XS(XS__crosszoneaddldonwinbyraidid) {
+	dXSARGS;
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: quest::crosszoneaddldonwinbyraidid(int raid_id, uint32 theme_id)");
+
+	uint8 update_type = CZLDoNUpdateType_Raid;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Win;
+	int raid_id = (int) SvIV(ST(0));
+	uint32 theme_id = (uint32) SvUV(ST(1));
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, raid_id, theme_id);
+	XSRETURN_EMPTY;
+}
+
+XS(XS__crosszoneaddldonlossbyguildid);
+XS(XS__crosszoneaddldonlossbyguildid) {
+	dXSARGS;
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: quest::crosszoneaddldonlossbyguildid(int guild_id, uint32 theme_id)");
+
+	uint8 update_type = CZLDoNUpdateType_Guild;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Loss;
+	int guild_id = (int) SvIV(ST(0));
+	uint32 theme_id = (uint32) SvUV(ST(1));
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, guild_id, theme_id);
+	XSRETURN_EMPTY;
+}
+
+XS(XS__crosszoneaddldonpointsbyguildid);
+XS(XS__crosszoneaddldonpointsbyguildid) {
+	dXSARGS;
+	if (items != 3)
+		Perl_croak(aTHX_ "Usage: quest::crosszoneaddldonpointsbyguildid(int guild_id, uint32 theme_id, int points)");
+
+	uint8 update_type = CZLDoNUpdateType_Guild;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Points;
+	int guild_id = (int) SvIV(ST(0));
+	uint32 theme_id = (uint32) SvUV(ST(1));
+	int points = (int) SvIV(ST(2));
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, guild_id, theme_id, points);
+	XSRETURN_EMPTY;
+}
+
+XS(XS__crosszoneaddldonwinbyguildid);
+XS(XS__crosszoneaddldonwinbyguildid) {
+	dXSARGS;
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: quest::crosszoneaddldonwinbyguildid(int guild_id, uint32 theme_id)");
+
+	uint8 update_type = CZLDoNUpdateType_Guild;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Win;
+	int guild_id = (int) SvIV(ST(0));
+	uint32 theme_id = (uint32) SvUV(ST(1));
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, guild_id, theme_id);
+	XSRETURN_EMPTY;
+}
+
+XS(XS__crosszoneaddldonlossbyexpeditionid);
+XS(XS__crosszoneaddldonlossbyexpeditionid) {
+	dXSARGS;
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: quest::crosszoneaddldonlossbyexpeditionid(uint32 expedition_id, uint32 theme_id)");
+
+	uint8 update_type = CZLDoNUpdateType_Expedition;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Loss;
+	uint32 expedition_id = (uint32) SvUV(ST(0));
+	uint32 theme_id = (uint32) SvUV(ST(1));
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, expedition_id, theme_id);
+	XSRETURN_EMPTY;
+}
+
+XS(XS__crosszoneaddldonpointsbyexpeditionid);
+XS(XS__crosszoneaddldonpointsbyexpeditionid) {
+	dXSARGS;
+	if (items != 3)
+		Perl_croak(aTHX_ "Usage: quest::crosszoneaddldonpointsbyexpeditionid(uint32 expedition_id, uint32 theme_id, int points)");
+
+	uint8 update_type = CZLDoNUpdateType_Expedition;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Points;
+	uint32 expedition_id = (uint32) SvUV(ST(0));
+	uint32 theme_id = (uint32) SvUV(ST(1));
+	int points = (int) SvIV(ST(2));
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, expedition_id, theme_id, points);
+	XSRETURN_EMPTY;
+}
+
+XS(XS__crosszoneaddldonwinbyexpeditionid);
+XS(XS__crosszoneaddldonwinbyexpeditionid) {
+	dXSARGS;
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: quest::crosszoneaddldonwinbyexpeditionid(uint32 expedition_id, uint32 theme_id)");
+
+	uint8 update_type = CZLDoNUpdateType_Expedition;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Win;
+	uint32 expedition_id = (uint32) SvUV(ST(0));
+	uint32 theme_id = (uint32) SvUV(ST(1));
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, expedition_id, theme_id);
+	XSRETURN_EMPTY;
+}
+
 /*
 This is the callback perl will look for to setup the
 quest package's XSUBs
@@ -6627,9 +6834,9 @@ EXTERN_C XS(boot_quest) {
 	newXS(strcpy(buf, "activetasksinset"), XS__activetasksinset, file);
 	newXS(strcpy(buf, "add_expedition_lockout_all_clients"), XS__add_expedition_lockout_all_clients, file);
 	newXS(strcpy(buf, "add_expedition_lockout_by_char_id"), XS__add_expedition_lockout_by_char_id, file);
-	newXS(strcpy(buf, "addldonloss"), XS__addldonpoints, file);
+	newXS(strcpy(buf, "addldonloss"), XS__addldonloss, file);
 	newXS(strcpy(buf, "addldonpoints"), XS__addldonpoints, file);
-	newXS(strcpy(buf, "addldonwin"), XS__addldonpoints, file);
+	newXS(strcpy(buf, "addldonwin"), XS__addldonwin, file);
 	newXS(strcpy(buf, "addloot"), XS__addloot, file);
 	newXS(strcpy(buf, "addskill"), XS__addskill, file);
 	newXS(strcpy(buf, "assigntask"), XS__assigntask, file);
@@ -6652,6 +6859,21 @@ EXTERN_C XS(boot_quest) {
 	newXS(strcpy(buf, "creategroundobjectfrommodel"), XS__CreateGroundObjectFromModel, file);
 	newXS(strcpy(buf, "createguild"), XS__createguild, file);
 	newXS(strcpy(buf, "createitem"), XS__createitem, file);
+	newXS(strcpy(buf, "crosszoneaddldonlossbycharid"), XS__crosszoneaddldonlossbycharid, file);
+	newXS(strcpy(buf, "crosszoneaddldonlossbygroupid"), XS__crosszoneaddldonlossbygroupid, file);
+	newXS(strcpy(buf, "crosszoneaddldonlossbyraidid"), XS__crosszoneaddldonlossbyraidid, file);
+	newXS(strcpy(buf, "crosszoneaddldonlossbyguildid"), XS__crosszoneaddldonlossbyguildid, file);
+	newXS(strcpy(buf, "crosszoneaddldonlossbyexpeditionid"), XS__crosszoneaddldonlossbyexpeditionid, file);
+	newXS(strcpy(buf, "crosszoneaddldonpointsbycharid"), XS__crosszoneaddldonpointsbycharid, file);
+	newXS(strcpy(buf, "crosszoneaddldonpointsbygroupid"), XS__crosszoneaddldonpointsbygroupid, file);
+	newXS(strcpy(buf, "crosszoneaddldonpointsbyraidid"), XS__crosszoneaddldonpointsbyraidid, file);
+	newXS(strcpy(buf, "crosszoneaddldonpointsbyguildid"), XS__crosszoneaddldonpointsbyguildid, file);
+	newXS(strcpy(buf, "crosszoneaddldonpointsbyexpeditionid"), XS__crosszoneaddldonpointsbyexpeditionid, file);
+	newXS(strcpy(buf, "crosszoneaddldonwinbycharid"), XS__crosszoneaddldonwinbycharid, file);
+	newXS(strcpy(buf, "crosszoneaddldonwinbygroupid"), XS__crosszoneaddldonwinbygroupid, file);
+	newXS(strcpy(buf, "crosszoneaddldonwinbyraidid"), XS__crosszoneaddldonwinbyraidid, file);
+	newXS(strcpy(buf, "crosszoneaddldonwinbyguildid"), XS__crosszoneaddldonwinbyguildid, file);
+	newXS(strcpy(buf, "crosszoneaddldonwinbyexpeditionid"), XS__crosszoneaddldonwinbyexpeditionid, file);
 	newXS(strcpy(buf, "crosszoneassigntaskbycharid"), XS__crosszoneassigntaskbycharid, file);
 	newXS(strcpy(buf, "crosszoneassigntaskbygroupid"), XS__crosszoneassigntaskbygroupid, file);
 	newXS(strcpy(buf, "crosszoneassigntaskbyraidid"), XS__crosszoneassigntaskbyraidid, file);

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -234,9 +234,9 @@ uint32 Lua_Client::GetTotalSecondsPlayed() {
 	return self->GetTotalSecondsPlayed();
 }
 
-void Lua_Client::UpdateLDoNPoints(int points, uint32 theme) {
+void Lua_Client::UpdateLDoNPoints(uint32 theme_id, int points) {
 	Lua_Safe_Call_Void();
-	self->UpdateLDoNPoints(points, theme);
+	self->UpdateLDoNPoints(theme_id, points);
 }
 
 void Lua_Client::SetDeity(int v) {
@@ -2083,6 +2083,16 @@ void Lua_Client::SetEXPModifier(uint32 zone_id, double exp_modifier) {
 	self->SetEXPModifier(zone_id, exp_modifier);	
 }
 
+void Lua_Client::AddLDoNLoss(uint32 theme_id) {
+	Lua_Safe_Call_Void();
+	self->AddLDoNLoss(theme_id);
+}
+
+void Lua_Client::AddLDoNWin(uint32 theme_id) {
+	Lua_Safe_Call_Void();
+	self->AddLDoNWin(theme_id);
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 		.def(luabind::constructor<>())
@@ -2129,7 +2139,7 @@ luabind::scope lua_register_client() {
 		.def("GetAAExp", (uint32(Lua_Client::*)(void))&Lua_Client::GetAAExp)
 		.def("GetAAPercent", (uint32(Lua_Client::*)(void))&Lua_Client::GetAAPercent)
 		.def("GetTotalSecondsPlayed", (uint32(Lua_Client::*)(void))&Lua_Client::GetTotalSecondsPlayed)
-		.def("UpdateLDoNPoints", (void(Lua_Client::*)(int,uint32))&Lua_Client::UpdateLDoNPoints)
+		.def("UpdateLDoNPoints", (void(Lua_Client::*)(uint32,int))&Lua_Client::UpdateLDoNPoints)
 		.def("SetDeity", (void(Lua_Client::*)(int))&Lua_Client::SetDeity)
 		.def("AddEXP", (void(Lua_Client::*)(uint32))&Lua_Client::AddEXP)
 		.def("AddEXP", (void(Lua_Client::*)(uint32,int))&Lua_Client::AddEXP)
@@ -2435,7 +2445,9 @@ luabind::scope lua_register_client() {
 		.def("GetAAEXPModifier", (double(Lua_Client::*)(uint32))&Lua_Client::GetAAEXPModifier)
 		.def("GetEXPModifier", (double(Lua_Client::*)(uint32))&Lua_Client::GetEXPModifier)
 		.def("SetAAEXPModifier", (void(Lua_Client::*)(uint32,double))&Lua_Client::SetAAEXPModifier)
-		.def("SetEXPModifier", (void(Lua_Client::*)(uint32,double))&Lua_Client::SetEXPModifier);
+		.def("SetEXPModifier", (void(Lua_Client::*)(uint32,double))&Lua_Client::SetEXPModifier)
+		.def("AddLDoNLoss", (void(Lua_Client::*)(uint32))&Lua_Client::AddLDoNLoss)
+		.def("AddLDoNWin", (void(Lua_Client::*)(uint32))&Lua_Client::AddLDoNWin);
 }
 
 luabind::scope lua_register_inventory_where() {

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -77,7 +77,9 @@ public:
 	uint32 GetAAExp();
 	uint32 GetAAPercent();
 	uint32 GetTotalSecondsPlayed();
-	void UpdateLDoNPoints(int points, uint32 theme);
+	void AddLDoNLoss(uint32 theme_id);
+	void AddLDoNWin(uint32 theme_id);
+	void UpdateLDoNPoints(uint32 theme_id, int points);
 	void SetDeity(int v);
 	void AddEXP(uint32 add_exp);
 	void AddEXP(uint32 add_exp, int conlevel);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -2353,6 +2353,108 @@ void lua_set_exp_modifier_by_char_id(uint32 character_id, uint32 zone_id, double
 	database.SetEXPModifier(character_id, zone_id, exp_modifier);
 }
 
+void lua_add_ldon_loss(uint32 theme_id) {
+	quest_manager.addldonloss(theme_id);
+}
+
+void lua_add_ldon_points(uint32 theme_id, int points) {
+	quest_manager.addldonpoints(theme_id, points);
+}
+
+void lua_add_ldon_win(uint32 theme_id) {
+	quest_manager.addldonwin(theme_id);
+}
+
+void lua_cross_zone_add_ldon_loss_by_char_id(int character_id, uint32 theme_id) {
+	uint8 update_type = CZLDoNUpdateType_Character;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Loss;
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, character_id, theme_id);
+}
+
+void lua_cross_zone_add_ldon_points_by_char_id(int character_id, uint32 theme_id, int points) {
+	uint8 update_type = CZLDoNUpdateType_Character;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Points;
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, character_id, theme_id, points);
+}
+
+void lua_cross_zone_add_ldon_win_by_char_id(int character_id, uint32 theme_id) {
+	uint8 update_type = CZLDoNUpdateType_Character;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Win;
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, character_id, theme_id);
+}
+
+void lua_cross_zone_add_ldon_loss_by_group_id(int group_id, uint32 theme_id) {
+	uint8 update_type = CZLDoNUpdateType_Group;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Loss;
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, group_id, theme_id);
+}
+
+void lua_cross_zone_add_ldon_points_by_group_id(int group_id, uint32 theme_id, int points) {
+	uint8 update_type = CZLDoNUpdateType_Group;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Points;
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, group_id, theme_id, points);
+}
+
+void lua_cross_zone_add_ldon_win_by_group_id(int group_id, uint32 theme_id) {
+	uint8 update_type = CZLDoNUpdateType_Group;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Win;
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, group_id, theme_id);
+}
+
+void lua_cross_zone_add_ldon_loss_by_raid_id(int raid_id, uint32 theme_id) {
+	uint8 update_type = CZLDoNUpdateType_Raid;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Loss;
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, raid_id, theme_id);
+}
+
+void lua_cross_zone_add_ldon_points_by_raid_id(int raid_id, uint32 theme_id, int points) {
+	uint8 update_type = CZLDoNUpdateType_Raid;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Points;
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, raid_id, theme_id, points);
+}
+
+void lua_cross_zone_add_ldon_win_by_raid_id(int raid_id, uint32 theme_id) {
+	uint8 update_type = CZLDoNUpdateType_Raid;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Win;
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, raid_id, theme_id);
+}
+
+void lua_cross_zone_add_ldon_loss_by_guild_id(int guild_id, uint32 theme_id) {
+	uint8 update_type = CZLDoNUpdateType_Guild;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Loss;
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, guild_id, theme_id);
+}
+
+void lua_cross_zone_add_ldon_points_by_guild_id(int guild_id, uint32 theme_id, int points) {
+	uint8 update_type = CZLDoNUpdateType_Guild;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Points;
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, guild_id, theme_id, points);
+}
+
+void lua_cross_zone_add_ldon_win_by_guild_id(int guild_id, uint32 theme_id) {
+	uint8 update_type = CZLDoNUpdateType_Guild;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Win;
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, guild_id, theme_id);
+}
+
+void lua_cross_zone_add_ldon_loss_by_expedition_id(uint32 expedition_id, uint32 theme_id) {
+	uint8 update_type = CZLDoNUpdateType_Expedition;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Loss;
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, expedition_id, theme_id);
+}
+
+void lua_cross_zone_add_ldon_points_by_expedition_id(uint32 expedition_id, uint32 theme_id, int points) {
+	uint8 update_type = CZLDoNUpdateType_Expedition;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Points;
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, expedition_id, theme_id, points);
+}
+
+void lua_cross_zone_add_ldon_win_by_expedition_id(uint32 expedition_id, uint32 theme_id) {
+	uint8 update_type = CZLDoNUpdateType_Expedition;
+	uint8 update_subtype = CZLDoNUpdateSubtype_Win;
+	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, expedition_id, theme_id);
+}
+
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
 	cur = table[#name]; \
 	if(luabind::type(cur) != LUA_TNIL) { \
@@ -2899,7 +3001,24 @@ luabind::scope lua_register_general() {
 		luabind::def("get_exp_modifier_by_char_id", &lua_get_exp_modifier_by_char_id),
 		luabind::def("set_aa_exp_modifier_by_char_id", &lua_set_aa_exp_modifier_by_char_id),
 		luabind::def("set_exp_modifier_by_char_id", &lua_set_exp_modifier_by_char_id),
-    
+		luabind::def("add_ldon_loss", &lua_add_ldon_loss),
+		luabind::def("add_ldon_points", &lua_add_ldon_points),
+		luabind::def("add_ldon_win", &lua_add_ldon_win),
+		luabind::def("cross_zone_add_ldon_loss_by_char_id", &lua_cross_zone_add_ldon_loss_by_char_id),
+		luabind::def("cross_zone_add_ldon_points_by_char_id", &lua_cross_zone_add_ldon_points_by_char_id),
+		luabind::def("cross_zone_add_ldon_win_by_char_id", &lua_cross_zone_add_ldon_win_by_char_id),
+		luabind::def("cross_zone_add_ldon_loss_by_group_id", &lua_cross_zone_add_ldon_loss_by_group_id),
+		luabind::def("cross_zone_add_ldon_points_by_group_id", &lua_cross_zone_add_ldon_points_by_group_id),
+		luabind::def("cross_zone_add_ldon_win_by_group_id", &lua_cross_zone_add_ldon_win_by_group_id),
+		luabind::def("cross_zone_add_ldon_loss_by_raid_id", &lua_cross_zone_add_ldon_loss_by_raid_id),
+		luabind::def("cross_zone_add_ldon_points_by_raid_id", &lua_cross_zone_add_ldon_points_by_raid_id),
+		luabind::def("cross_zone_add_ldon_win_by_raid_id", &lua_cross_zone_add_ldon_win_by_raid_id),
+		luabind::def("cross_zone_add_ldon_loss_by_guild_id", &lua_cross_zone_add_ldon_loss_by_guild_id),
+		luabind::def("cross_zone_add_ldon_points_by_guild_id", &lua_cross_zone_add_ldon_points_by_guild_id),
+		luabind::def("cross_zone_add_ldon_win_by_guild_id", &lua_cross_zone_add_ldon_win_by_guild_id),
+		luabind::def("cross_zone_add_ldon_loss_by_expedition_id", &lua_cross_zone_add_ldon_loss_by_expedition_id),
+		luabind::def("cross_zone_add_ldon_points_by_expedition_id", &lua_cross_zone_add_ldon_points_by_expedition_id),
+		luabind::def("cross_zone_add_ldon_win_by_expedition_id", &lua_cross_zone_add_ldon_win_by_expedition_id),
 		/**
 		 * Expansions
 		 */

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -672,15 +672,15 @@ XS(XS_Client_UpdateLDoNPoints); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Client_UpdateLDoNPoints) {
 	dXSARGS;
 	if (items != 3)
-		Perl_croak(aTHX_ "Usage: Client::UpdateLDoNPoints(THIS, int32 points, uint32 theme)"); // @categories Currency and Points
+		Perl_croak(aTHX_ "Usage: Client::UpdateLDoNPoints(THIS, uint32 theme_id, int points)"); // @categories Currency and Points
 	{
 		Client *THIS;
-		bool   RETVAL;
-		int32  points = (int32) SvIV(ST(1));
-		uint32 theme  = (uint32) SvUV(ST(2));
+		bool RETVAL;
+		uint32 theme_id = (uint32) SvUV(ST(1));
+		int points = (int) SvIV(ST(2));
 		VALIDATE_THIS_IS_CLIENT;
-		RETVAL = THIS->UpdateLDoNPoints(points, theme);
-		ST(0)         = boolSV(RETVAL);
+		RETVAL = THIS->UpdateLDoNPoints(theme_id, points);
+		ST(0) = boolSV(RETVAL);
 		sv_2mortal(ST(0));
 	}
 	XSRETURN(1);
@@ -5272,7 +5272,7 @@ XS(XS_Client_SetAAEXPModifier) {
 		VALIDATE_THIS_IS_CLIENT;
 		THIS->SetAAEXPModifier(zone_id, aa_modifier);
 	}
-	XSRETURN_EMPTY;	
+	XSRETURN_EMPTY;
 }
 
 XS(XS_Client_SetEXPModifier);
@@ -5287,7 +5287,35 @@ XS(XS_Client_SetEXPModifier) {
 		VALIDATE_THIS_IS_CLIENT;
 		THIS->SetEXPModifier(zone_id, exp_modifier);
 	}
-	XSRETURN_EMPTY;		
+	XSRETURN_EMPTY;
+}
+
+XS(XS_Client_AddLDoNLoss);
+XS(XS_Client_AddLDoNLoss) {
+	dXSARGS;
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: Client::AddLDoNLoss(THIS, uint32 theme_id)");
+	{
+		Client* THIS;
+		uint32 theme_id = (uint32) SvUV(ST(1));
+		VALIDATE_THIS_IS_CLIENT;
+		THIS->AddLDoNLoss(theme_id);
+	}
+	XSRETURN_EMPTY;
+}
+
+XS(XS_Client_AddLDoNWin);
+XS(XS_Client_AddLDoNWin) {
+	dXSARGS;
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: Client::AddLDoNWin(THIS, uint32 theme_id)");
+	{
+		Client* THIS;
+		uint32 theme_id = (uint32) SvUV(ST(1));
+		VALIDATE_THIS_IS_CLIENT;
+		THIS->AddLDoNWin(theme_id);
+	}
+	XSRETURN_EMPTY;
 }
 
 #ifdef __cplusplus
@@ -5318,6 +5346,8 @@ XS(boot_Client) {
 	newXSproto(strcpy(buf, "AddEXP"), XS_Client_AddEXP, file, "$$;$$");
 	newXSproto(strcpy(buf, "AddExpeditionLockout"), XS_Client_AddExpeditionLockout, file, "$$$$;$");
 	newXSproto(strcpy(buf, "AddExpeditionLockoutDuration"), XS_Client_AddExpeditionLockoutDuration, file, "$$$$;$");
+	newXSproto(strcpy(buf, "AddLDoNLoss"), XS_Client_AddLDoNLoss, file, "$$");
+	newXSproto(strcpy(buf, "AddLDoNWin"), XS_Client_AddLDoNWin, file, "$$");
 	newXSproto(strcpy(buf, "AddLevelBasedExp"), XS_Client_AddLevelBasedExp, file, "$$;$$");
 	newXSproto(strcpy(buf, "AddMoneyToPP"), XS_Client_AddMoneyToPP, file, "$$$$$$");
 	newXSproto(strcpy(buf, "AddPVPPoints"), XS_Client_AddPVPPoints, file, "$$");

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -1727,22 +1727,22 @@ void QuestManager::resume() {
 	owner->CastToNPC()->ResumeWandering();
 }
 
-void QuestManager::addldonpoints(int32 points, uint32 theme) {
+void QuestManager::addldonpoints(uint32 theme_id, int points) {
 	QuestManagerCurrentQuestVars();
 	if(initiator)
-		initiator->UpdateLDoNPoints(points, theme);
+		initiator->UpdateLDoNPoints(theme_id, points);
 }
 
-void QuestManager::addldonwin(int32 wins, uint32 theme) {
+void QuestManager::addldonloss(uint32 theme_id) {
 	QuestManagerCurrentQuestVars();
 	if(initiator)
-		initiator->UpdateLDoNWins(theme, wins);
+		initiator->AddLDoNLoss(theme_id);
 }
 
-void QuestManager::addldonloss(int32 losses, uint32 theme) {
+void QuestManager::addldonwin(uint32 theme_id) {
 	QuestManagerCurrentQuestVars();
 	if(initiator)
-		initiator->UpdateLDoNLosses(theme, losses);
+		initiator->AddLDoNWin(theme_id);
 }
 
 void QuestManager::setnexthpevent(int at) {
@@ -4631,4 +4631,16 @@ void QuestManager::SetAAEXPModifierByCharID(uint32 character_id, uint32 zone_id,
 
 void QuestManager::SetEXPModifierByCharID(uint32 character_id, uint32 zone_id, double exp_modifier) {
 	database.SetEXPModifier(character_id, zone_id, exp_modifier);
+}
+
+void QuestManager::CrossZoneLDoNUpdate(uint8 type, uint8 subtype, int identifier, uint32 theme_id, int points) {
+	auto pack = new ServerPacket(ServerOP_CZLDoNUpdate, sizeof(CZLDoNUpdate_Struct));
+	CZLDoNUpdate_Struct* CZLU = (CZLDoNUpdate_Struct*)pack->pBuffer;
+	CZLU->update_type = type;
+	CZLU->update_subtype = subtype;
+	CZLU->update_identifier = identifier;
+	CZLU->theme_id = theme_id;
+	CZLU->points = points;
+	worldserver.SendPacket(pack);
+	safe_delete(pack);
 }

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -158,9 +158,9 @@ public:
 	void pause(int duration);
 	void moveto(const glm::vec4& position, bool saveguardspot);
 	void resume();
-	void addldonpoints(int32 points, uint32 theme);
-	void addldonwin(int32 wins, uint32 theme);
-	void addldonloss(int32 losses, uint32 theme);
+	void addldonpoints(uint32 theme_id, int points);
+	void addldonloss(uint32 theme_id);
+	void addldonwin(uint32 theme_id);
 	void setnexthpevent(int at);
 	void setnextinchpevent(int at);
 	void respawn(int npc_type, int grid);
@@ -308,6 +308,7 @@ public:
 	void CrossZoneFailTaskByGroupID(int group_id, uint32 task_id);
 	void CrossZoneFailTaskByRaidID(int raid_id, uint32 task_id);
 	void CrossZoneFailTaskByGuildID(int guild_id, uint32 task_id);
+	void CrossZoneLDoNUpdate(uint8 type, uint8 subtype, int identifier, uint32 theme_id, int points = 1);
 	void CrossZoneMarqueeByCharID(int character_id, uint32 type, uint32 priority, uint32 fade_in, uint32 fade_out, uint32 duration, const char *message);
 	void CrossZoneMarqueeByGroupID(int group_id, uint32 type, uint32 priority, uint32 fade_in, uint32 fade_out, uint32 duration, const char *message);
 	void CrossZoneMarqueeByRaidID(int raid_id, uint32 type, uint32 priority, uint32 fade_in, uint32 fade_out, uint32 duration, const char *message);

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -1932,6 +1932,115 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 		}
 		break;
 	}
+	case ServerOP_CZLDoNUpdate:
+	{
+		CZLDoNUpdate_Struct* CZLU = (CZLDoNUpdate_Struct*) pack->pBuffer;
+		uint8 update_type = CZLU->update_type;
+		uint8 update_subtype = CZLU->update_subtype;
+		int update_identifier = CZLU->update_identifier;
+		uint32 theme_id = CZLU->theme_id;
+		int points = CZLU->points;
+		if (update_type == CZLDoNUpdateType_Character) {
+			auto client = entity_list.GetClientByCharID(update_identifier);
+			if (client) {
+				switch (update_subtype) {
+					case CZLDoNUpdateSubtype_Loss:
+						client->AddLDoNLoss(theme_id);
+						break;
+					case CZLDoNUpdateSubtype_Points:
+						client->UpdateLDoNPoints(theme_id, points);
+						break;
+					case CZLDoNUpdateSubtype_Win:
+						client->AddLDoNWin(theme_id);
+						break;
+					default:
+						break;
+				}
+			}
+			break;
+		} else if (update_type == CZLDoNUpdateType_Group) {
+			auto client_group = entity_list.GetGroupByID(update_identifier);
+			if (client_group) {
+				for (int member_index = 0; member_index < MAX_GROUP_MEMBERS; member_index++) {
+					if (client_group->members[member_index] && client_group->members[member_index]->IsClient()) {
+						auto client_group_member = client_group->members[member_index]->CastToClient();
+						switch (update_subtype) {
+							case CZLDoNUpdateSubtype_Loss:
+								client_group_member->AddLDoNLoss(theme_id);
+								break;
+							case CZLDoNUpdateSubtype_Points:
+								client_group_member->UpdateLDoNPoints(theme_id, points);
+								break;
+							case CZLDoNUpdateSubtype_Win:
+								client_group_member->AddLDoNWin(theme_id);
+								break;
+							default:
+								break;
+						}
+					}
+				}
+			}
+		} else if (update_type == CZLDoNUpdateType_Raid) {
+			auto client_raid = entity_list.GetRaidByID(update_identifier);
+			if (client_raid) {
+				for (int member_index = 0; member_index < MAX_RAID_MEMBERS; member_index++) {
+					auto client_raid_member = client_raid->members[member_index].member;
+					if (client_raid_member && client_raid_member->IsClient()) {
+						switch (update_subtype) {
+							case CZLDoNUpdateSubtype_Loss:
+								client_raid_member->AddLDoNLoss(theme_id);
+								break;
+							case CZLDoNUpdateSubtype_Points:
+								client_raid_member->UpdateLDoNPoints(theme_id, points);
+								break;
+							case CZLDoNUpdateSubtype_Win:
+								client_raid_member->AddLDoNWin(theme_id);
+								break;
+							default:
+								break;
+						}
+					}
+				}
+			}
+		} else if (update_type == CZLDoNUpdateType_Guild) {
+			for (auto &client : entity_list.GetClientList()) {
+				if (client.second->GuildID() > 0 && client.second->GuildID() == update_identifier) {
+					switch (update_subtype) {
+						case CZLDoNUpdateSubtype_Loss:
+							client.second->AddLDoNLoss(theme_id);
+							break;
+						case CZLDoNUpdateSubtype_Points:
+							client.second->UpdateLDoNPoints(theme_id, points);
+							break;
+						case CZLDoNUpdateSubtype_Win:
+							client.second->AddLDoNWin(theme_id);
+							break;
+						default:
+							break;
+					}
+				}
+			}
+		} else if (update_type == CZLDoNUpdateType_Expedition) {
+			for (auto &client : entity_list.GetClientList()) {
+				if (client.second->GetExpedition() && client.second->GetExpedition()->GetID() == update_identifier) {
+					switch (update_subtype) {
+						case CZLDoNUpdateSubtype_Loss:
+							client.second->AddLDoNLoss(theme_id);
+							break;
+						case CZLDoNUpdateSubtype_Points:
+							client.second->UpdateLDoNPoints(theme_id, points);
+							break;
+						case CZLDoNUpdateSubtype_Win:
+							client.second->AddLDoNWin(theme_id);
+							break;
+						default:
+							break;
+					}
+				}
+			}
+		}
+		break;
+	}
 	case ServerOP_CZMarqueePlayer:
 	{
 		CZMarqueePlayer_Struct* CZMS = (CZMarqueePlayer_Struct*) pack->pBuffer;


### PR DESCRIPTION
- Swapped parameters in mostly unused functions to be theme_id first and points second. (No examples in PEQ quests.)
- Removed UpdateLDoNLosses/UpdateLDonWins source methods in favor of AddLDoNLoss/AddLDoNWin as you can only add 1 at a time.
- Add $client->AddLDoNLoss(theme_id) to Perl.
- Add $client->AddLDoNWin(theme_id) to Perl.
- Add quest::crosszoneaddldonlossbycharid(character_id, theme_id) to Perl.
- Add quest::crosszoneaddldonlossbygroupid(group_id, theme_id) to Perl.
- Add quest::crosszoneaddldonlossbyraidid(raid_id, theme_id) to Perl.
- Add quest::crosszoneaddldonlossbyguildid(guild_id, theme_id) to Perl.
- Add quest::crosszoneaddldonlossbyexpeditionid(expedition_id, theme_id) to Perl.
- Add quest::crosszoneaddldonpointsbycharid(character_id, theme_id, points) to Perl.
- Add quest::crosszoneaddldonpointsbygroupid(group_id, theme_id, points) to Perl.
- Add quest::crosszoneaddldonpointsbyraidid(raid_id, theme_id, points) to Perl.
- Add quest::crosszoneaddldonpointsbyguildid(guild_id, theme_id, points) to Perl.
- Add quest::crosszoneaddldonpointsbyexpeditionid(expedition_id, theme_id, points) to Perl.
- Add quest::crosszoneaddldonwinbycharid(character_id, theme_id) to Perl.
- Add quest::crosszoneaddldonwinbygroupid(group_id, theme_id) to Perl.
- Add quest::crosszoneaddldonwinbyraidid(raid_id, theme_id) to Perl.
- Add quest::crosszoneaddldonwinbyguildid(guild_id, theme_id) to Perl.
- Add quest::crosszoneaddldonwinbyexpeditionid(expedition_id, theme_id) to Perl.
- Fix quest::addldonloss(theme_id) in Perl.
- Fix quest::addldonwin(theme_id) in Perl.
- Add client:AddLDoNLoss(theme_id) to Lua.
- Add client:AddLDoNWin(theme_id) to Lua.
- Add eq.add_ldon_loss(theme_id) to Lua.
- Add eq.add_ldon_points(theme_id, points) to Lua.
- Add eq.add_ldon_win(theme_id) to Lua.
- Add eq.cross_zone_add_ldon_loss_by_char_id(character_id, theme_id) to Lua.
- Add eq.cross_zone_add_ldon_loss_by_group_id(group_id, theme_id) to Lua.
- Add eq.cross_zone_add_ldon_loss_by_raid_id(raid_id, theme_id) to Lua.
- Add eq.cross_zone_add_ldon_loss_by_guild_id(guild_id, theme_id) to Lua.
- Add eq.cross_zone_add_ldon_loss_by_expedition_id(expedition_id, theme_id) to Lua.
- Add eq.cross_zone_add_ldon_points_by_char_id(character_id, theme_id, points) to Lua.
- Add eq.cross_zone_add_ldon_points_by_group_id(group_id, theme_id, points) to Lua.
- Add eq.cross_zone_add_ldon_points_by_raid_id(raid_id, theme_id, points) to Lua.
- Add eq.cross_zone_add_ldon_points_by_guild_id(guild_id, theme_id, points) to Lua.
- Add eq.cross_zone_add_ldon_points_by_expedition_id(expedition_id, theme_id, points) to Lua.
- Add eq.cross_zone_add_ldon_win_by_char_id(character_id, theme_id) to Lua.
- Add eq.cross_zone_add_ldon_win_by_group_id(group_id, theme_id) to Lua.
- Add eq.cross_zone_add_ldon_win_by_raid_id(raid_id, theme_id) to Lua.
- Add eq.cross_zone_add_ldon_win_by_guild_id(guild_id, theme_id) to Lua.
- Add eq.cross_zone_add_ldon_win_by_expedition_id(expedition_id, theme_id) to Lua.