### PR TITLE
[Shared Bank] Shared Bank Disabled Warning Popup

### DIFF
--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -1450,7 +1450,12 @@ void Client::OPMoveCoin(const EQApplicationPacket* app)
 		}
 		else{
 			if (to_bucket == &m_pp.platinum_shared || from_bucket == &m_pp.platinum_shared){
-				this->Message(Chat::Red, "::: WARNING! ::: SHARED BANK IS DISABLED AND YOUR PLATINUM WILL BE DESTROYED IF YOU PUT IT HERE");
+				this->SendPopupToClient(
+					"Shared Bank Warning",
+					"<c \"#F62217\">::: WARNING! :::<br>"
+					"SHARED BANK IS DISABLED AND YOUR PLATINUM WILL BE DESTROYED IF YOU PUT IT HERE!</c>"
+				);
+				this->Message(Chat::Red, "::: WARNING! ::: SHARED BANK IS DISABLED AND YOUR PLATINUM WILL BE DESTROYED IF YOU PUT IT HERE!");
 			}
 		}
 	}


### PR DESCRIPTION
Add additional popup to shared bank warning message, as client-side filters can cause the message to be unseen.
![image](https://user-images.githubusercontent.com/4652173/119280784-da189c80-bc00-11eb-8aef-6cd379e1ebec.png)