### PR TITLE
[Fix] Fix Spell Cast Time reduction issues

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -326,7 +326,6 @@ RULE_INT(Spells, CharismaEffectivenessCap, 255, "Determines how much resist modi
 RULE_BOOL(Spells, CharismaCharmDuration, false, "Allow CHA resist mod to extend charm duration")
 RULE_INT(Spells, CharmBreakCheckChance, 25, "Determines chance for a charm break check to occur each buff tick")
 RULE_BOOL(Spells, CharmDisablesSpecialAbilities, false, "When charm is cast on an NPC, strip their special abilities")
-RULE_INT(Spells, MaxCastTimeReduction, 50, "Maximum percent your spell cast time can be reduced by spell haste")
 RULE_INT(Spells, RootBreakFromSpells, 55, "Chance for root to break when cast on")
 RULE_INT(Spells, DeathSaveCharismaMod, 3, "Determines how much charisma effects chance of death save firing")
 RULE_INT(Spells, DivineInterventionHeal, 8000, "Divine intervention heal amount")

--- a/zone/client.h
+++ b/zone/client.h
@@ -550,7 +550,6 @@ public:
 	inline virtual int32 GetDelayDeath() const { return aabonuses.DelayDeath + spellbonuses.DelayDeath + itembonuses.DelayDeath + 11; }
 
 	int32 GetActSpellCost(uint16 spell_id, int32);
-	int32 GetActSpellCasttime(uint16 spell_id, int32);
 	virtual bool CheckFizzle(uint16 spell_id);
 	virtual bool CheckSpellLevelRestriction(uint16 spell_id);
 	virtual int GetCurrentBuffSlots() const;

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -407,29 +407,6 @@ int32 Mob::GetActSpellDuration(uint16 spell_id, int32 duration)
 		return ifocused + 1;
 }
 
-int32 Client::GetActSpellCasttime(uint16 spell_id, int32 casttime)
-{
-	int32 cast_reducer = 0;
-	cast_reducer += GetFocusEffect(focusSpellHaste, spell_id);
-
-	//this function loops through the effects of spell_id many times
-	//could easily be consolidated.
-
-	if (GetLevel() >= 51 && casttime >= 3000 && !BeneficialSpell(spell_id)
-		&& (GetClass() == SHADOWKNIGHT || GetClass() == RANGER
-			|| GetClass() == PALADIN || GetClass() == BEASTLORD ))
-		cast_reducer += (GetLevel()-50)*3;
-
-	//LIVE AA SpellCastingDeftness, QuickBuff, QuickSummoning, QuickEvacuation, QuickDamage
-
-	if (cast_reducer > RuleI(Spells, MaxCastTimeReduction))
-		cast_reducer = RuleI(Spells, MaxCastTimeReduction);
-
-	casttime = (casttime*(100 - cast_reducer)/100);
-
-	return casttime;
-}
-
 bool Client::TrainDiscipline(uint32 itemid) {
 
 	//get the item info

--- a/zone/merc.cpp
+++ b/zone/merc.cpp
@@ -2756,19 +2756,6 @@ int32 Merc::GetActSpellCost(uint16 spell_id, int32 cost)
 	return cost;
 }
 
-int32 Merc::GetActSpellCasttime(uint16 spell_id, int32 casttime)
-{
-	int32 cast_reducer = 0;
-	cast_reducer += GetFocusEffect(focusSpellHaste, spell_id);
-
-	if (cast_reducer > RuleI(Spells, MaxCastTimeReduction))
-		cast_reducer = RuleI(Spells, MaxCastTimeReduction);
-
-	casttime = (casttime*(100 - cast_reducer)/100);
-
-	return casttime;
-}
-
 int8 Merc::GetChanceToCastBySpellType(uint32 spellType) {
 	int mercStance = (int)GetStance();
 	int8 mercClass = GetClass();

--- a/zone/merc.h
+++ b/zone/merc.h
@@ -83,7 +83,6 @@ public:
 	Corpse* GetGroupMemberCorpse();
 
 	// Merc Spell Casting Methods
-	virtual int32 GetActSpellCasttime(uint16 spell_id, int32 casttime);
 	virtual int32 GetActSpellCost(uint16 spell_id, int32 cost);
 	int8 GetChanceToCastBySpellType(uint32 spellType);
 	void SetSpellRecastTimer(uint16 timer_id, uint16 spellid, uint32 recast_delay);

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -3112,26 +3112,18 @@ uint32 Mob::GetLevelHP(uint8 tlevel)
 	return multiplier;
 }
 
-int32 Mob::GetActSpellCasttime(uint16 spell_id, int32 casttime) {
+int32 Mob::GetActSpellCasttime(uint16 spell_id, int32 casttime)
+{
+	int32 cast_reducer = GetFocusEffect(focusSpellHaste, spell_id);
 
-	int32 cast_reducer = 0;
-	cast_reducer += GetFocusEffect(focusSpellHaste, spell_id);
-
-	if (level >= 60 && casttime > 1000)
-	{
-		casttime = casttime / 2;
-		if (casttime < 1000)
-			casttime = 1000;
-	} else if (level >= 50 && casttime > 1000) {
-		int32 cast_deduction = (casttime*(level - 49))/5;
-		if (cast_deduction > casttime/2)
-			casttime /= 2;
-		else
-			casttime -= cast_deduction;
+	if (level > 50 && casttime >= 3000 && !spells[spell_id].goodEffect &&
+	    (GetClass() == RANGER || GetClass() == SHADOWKNIGHT || GetClass() == PALADIN || GetClass() == BEASTLORD)) {
+		int level_mod = std::min(15, GetLevel() - 50);
+		cast_reducer += level_mod * 3;
 	}
 
-	casttime = (casttime*(100 - cast_reducer)/100);
-	return casttime;
+	casttime = casttime * (100 - cast_reducer) / 100;
+	return std::max(casttime, casttime / 2);
 }
 
 void Mob::ExecWeaponProc(const EQ::ItemInstance *inst, uint16 spell_id, Mob *on, int level_override) {


### PR DESCRIPTION
Remove the overloads that don't make sense (bots probably doesn't make
sense either, but too lazy)

Fix the formulas

Removed the Spells:MaxCastTimeReduction rule since this is HARDCODED in
the client so it doesn't really make sense to have it as a customization
point. If you want to hack the client, change the hardcode as well I
guess.