### PR TITLE
Avoid expedition leader change if only member

### DIFF
--- a/world/expedition.cpp
+++ b/world/expedition.cpp
@@ -182,7 +182,7 @@ void Expedition::UpdateMemberStatus(uint32_t character_id, DynamicZoneMemberStat
 	}
 
 	// any member status update will trigger a leader fix if leader was offline
-	if (m_leader.status == DynamicZoneMemberStatus::Offline)
+	if (m_leader.status == DynamicZoneMemberStatus::Offline && GetDynamicZone().GetMemberCount() > 1)
 	{
 		ChooseNewLeader();
 	}


### PR DESCRIPTION
This fixes an edge case where a player could be made leader when added
to an expedition that only had a single member previously.

If a leader in a two-member expedition quit (forcing a leader change)
and the new leader went offline while throttled, a leader change flag
would be set until a non-leader was available. The first added member
would then be made the new leader.

This could also potentially occur on world startup due to the initial
throttle timer state but member statuses aren't processed there yet