### PR TITLE
[Bug Fix] Fixed Invis vs Undead / Invis Vs Animals not breaking charm + Added rule for custom capabilities

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -205,6 +205,7 @@ RULE_REAL(Pets, AttackCommandRange, 150, "Range at which a pet will respond to a
 RULE_BOOL(Pets, UnTargetableSwarmPet, false, "Setting whether swarm pets should be targetable")
 RULE_REAL(Pets, PetPowerLevelCap, 10, "Maximum number of levels a player pet can go up with pet power")
 RULE_BOOL(Pets, CanTakeNoDrop, false, "Setting whether anyone can give no-drop items to pets")
+RULE_BOOL(Pets, LivelikeBreakCharmOnInvis, true, "Default: true will break charm on any type of invis (hide/ivu/iva/etc) false will only break if the pet can not see you (ex. you have an undead pet and cast IVU")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(GM)

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -554,6 +554,7 @@ void Mob::SetInvisible(uint8 state)
 		if (RuleB(Pets, LivelikeBreakCharmOnInvis) || (!RuleB(Pets, LivelikeBreakCharmOnInvis) && IsInvisible(formerpet))) {
 			formerpet->BuffFadeByEffect(SE_Charm);
 		}
+
 		LogRules("Pets:LivelikeBreakCharmOnInvis for [{}] | Invis [{}] - Hidden [{}] - Shroud of Stealth [{}] - IVA [{}] - IVU [{}]", GetCleanName(), invisible, hidden, improved_hidden, invisible_animals, invisible_undead);
 	}
 }

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -551,12 +551,8 @@ void Mob::SetInvisible(uint8 state)
 	// Invis and hide breaks charms
 	auto formerpet = GetPet();
 	if (formerpet && formerpet->GetPetType() == petCharmed && (invisible || hidden || improved_hidden || invisible_animals || invisible_undead)) {
-		if (RuleB(Pets, LivelikeBreakCharmOnInvis)) {	
+		if (RuleB(Pets, LivelikeBreakCharmOnInvis) || (!RuleB(Pets, LivelikeBreakCharmOnInvis) && IsInvisible(formerpet))) {
 			formerpet->BuffFadeByEffect(SE_Charm);
-		}
-		else {	
-			if (IsInvisible(formerpet))
-				formerpet->BuffFadeByEffect(SE_Charm);
 		}
 		LogRules("Pets:LivelikeBreakCharmOnInvis for [{}] | Invis [{}] - Hidden [{}] - Shroud of Stealth [{}] - IVA [{}] - IVU [{}]", GetCleanName(), invisible, hidden, improved_hidden, invisible_animals, invisible_undead);
 	}

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -551,7 +551,7 @@ void Mob::SetInvisible(uint8 state)
 	// Invis and hide breaks charms
 	auto formerpet = GetPet();
 	if (formerpet && formerpet->GetPetType() == petCharmed && (invisible || hidden || improved_hidden || invisible_animals || invisible_undead)) {
-		if (RuleB(Pets, LivelikeBreakCharmOnInvis) || (!RuleB(Pets, LivelikeBreakCharmOnInvis) && IsInvisible(formerpet))) {
+		if (RuleB(Pets, LivelikeBreakCharmOnInvis) || IsInvisible(formerpet))
 			formerpet->BuffFadeByEffect(SE_Charm);
 		}
 

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -549,10 +549,17 @@ void Mob::SetInvisible(uint8 state)
 	invisible = state;
 	SendAppearancePacket(AT_Invis, invisible);
 	// Invis and hide breaks charms
-
 	auto formerpet = GetPet();
-	if (formerpet && formerpet->GetPetType() == petCharmed && (invisible || hidden || improved_hidden))
-		formerpet->BuffFadeByEffect(SE_Charm);
+	if (formerpet && formerpet->GetPetType() == petCharmed && (invisible || hidden || improved_hidden || invisible_animals || invisible_undead)) {
+		if (RuleB(Pets, LivelikeBreakCharmOnInvis)) {	
+			formerpet->BuffFadeByEffect(SE_Charm);
+		}
+		else {	
+			if(IsInvisible(formerpet))
+				formerpet->BuffFadeByEffect(SE_Charm);
+		}
+		LogRules("Pets:LivelikeBreakCharmOnInvis for [{}] | Invis [{}] - Hidden [{}] - Shroud of Stealth [{}] - IVA [{}] - IVU [{}]", GetCleanName(), invisible, hidden, improved_hidden, invisible_animals, invisible_undead);
+	}
 }
 
 //check to see if `this` is invisible to `other`

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -555,7 +555,7 @@ void Mob::SetInvisible(uint8 state)
 			formerpet->BuffFadeByEffect(SE_Charm);
 		}
 		else {	
-			if(IsInvisible(formerpet))
+			if (IsInvisible(formerpet))
 				formerpet->BuffFadeByEffect(SE_Charm);
 		}
 		LogRules("Pets:LivelikeBreakCharmOnInvis for [{}] | Invis [{}] - Hidden [{}] - Shroud of Stealth [{}] - IVA [{}] - IVU [{}]", GetCleanName(), invisible, hidden, improved_hidden, invisible_animals, invisible_undead);

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -600,6 +600,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				snprintf(effect_desc, _EDLEN, "Invisibility to Animals");
 #endif
 				invisible_animals = true;
+				SetInvisible(0);
 				break;
 			}
 
@@ -610,6 +611,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				snprintf(effect_desc, _EDLEN, "Invisibility to Undead");
 #endif
 				invisible_undead = true;
+				SetInvisible(0);
 				break;
 			}
 			case SE_SeeInvis:


### PR DESCRIPTION
This directly addresses https://github.com/EQEmu/Server/issues/904

Apparently the Livelike functionality is ANY invis breaks charm  -- even if you have say a regular mob charmed and you cast IVU. Setting the rule to false will only break charm if your pet cannot see you. (ex. You have a skeleton charmed and cast IVU). Rule description is very clear.

At the current time after the charm breaks the pet starts attacking you which I am told is Livelike behavior. 