### PR TITLE
[Pets] Unhardcode Beastlord pet values.

### DIFF
--- a/common/database_schema.h
+++ b/common/database_schema.h
@@ -217,6 +217,7 @@ namespace DatabaseSchema {
 			"npc_types_tint",
 			"object",
 			"pets",
+			"pets_beastlord_data",
 			"pets_equipmentset",
 			"pets_equipmentset_entries",
 			"proximities",

--- a/common/version.h
+++ b/common/version.h
@@ -34,7 +34,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9166
+#define CURRENT_BINARY_DATABASE_VERSION 9167
 
 #ifdef BOTS
 	#define CURRENT_BINARY_BOTS_DATABASE_VERSION 9027

--- a/utils/sql/db_update_manifest.txt
+++ b/utils/sql/db_update_manifest.txt
@@ -420,6 +420,7 @@
 9164|2021_04_23_character_exp_modifiers.sql|SHOW TABLES LIKE 'character_exp_modifiers'|empty|
 9165|2021_04_28_idle_pathing.sql|SHOW COLUMNS FROM `spawn2` LIKE 'path_when_zone_idle'|empty|
 9166|2021_02_12_dynamic_zone_members.sql|SHOW TABLES LIKE 'dynamic_zone_members'|empty|
+9167|2021_06_06_beastlord_pets.sql|SHOW TABLES LIKE 'pets_beastlord_data'|empty|
 
 # Upgrade conditions:
 # 	This won't be needed after this system is implemented, but it is used database that are not

--- a/utils/sql/git/required/2021_06_06_beastlord_pets.sql
+++ b/utils/sql/git/required/2021_06_06_beastlord_pets.sql
@@ -1,0 +1,28 @@
+SET NAMES utf8mb4;
+SET FOREIGN_KEY_CHECKS = 0;
+
+-- ----------------------------
+-- Table structure for pets_beastlord_data
+-- ----------------------------
+DROP TABLE IF EXISTS `pets_beastlord_data`;
+CREATE TABLE `pets_beastlord_data`  (
+  `player_race` int UNSIGNED NOT NULL DEFAULT 1,
+  `pet_race` int UNSIGNED NOT NULL DEFAULT 42,
+  `texture` tinyint UNSIGNED NOT NULL DEFAULT 0,
+  `helm_texture` tinyint UNSIGNED NOT NULL DEFAULT 0,
+  `gender` tinyint UNSIGNED NOT NULL DEFAULT 2,
+  `size_modifier` float UNSIGNED NULL DEFAULT 1,
+  `face` tinyint UNSIGNED NOT NULL DEFAULT 0,
+  PRIMARY KEY (`player_race`) USING BTREE
+) ENGINE = InnoDB CHARACTER SET = latin1 COLLATE = latin1_swedish_ci ROW_FORMAT = Compact;
+
+-- ----------------------------
+-- Records of pets_beastlord_data
+-- ----------------------------
+INSERT INTO `pets_beastlord_data` VALUES (2, 42, 2, 0, 2, 1, 0); -- Barbarian
+INSERT INTO `pets_beastlord_data` VALUES (9, 91, 0, 0, 2, 2.5, 0); -- Troll
+INSERT INTO `pets_beastlord_data` VALUES (10, 43, 3, 0, 2, 1, 0); -- Ogre
+INSERT INTO `pets_beastlord_data` VALUES (128, 42, 0, 0, 1, 2, 0); -- Iksar
+INSERT INTO `pets_beastlord_data` VALUES (130, 63, 0, 0, 2, 0.8, 0); -- Vah Shir
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -15,6 +15,8 @@
 #include "bot_database.h"
 #endif
 
+#define WOLF 42
+
 class Client;
 class Corpse;
 class Merc;
@@ -243,6 +245,17 @@ struct ClientMercEntry {
 	uint32 npcid;
 };
 
+namespace BeastlordPetData {	
+	struct PetStruct {
+		uint16 race_id = WOLF;
+		uint8 texture = 0;
+		uint8 helm_texture = 0;
+		uint8 gender = 2;
+		float size_modifier = 1.0f;
+		uint8 face = 0;
+	};
+}
+
 class ZoneDatabase : public SharedDatabase {
 	typedef std::list<ServerLootItem_Struct*> ItemList;
 public:
@@ -458,6 +471,7 @@ public:
 	bool		GetPetEntry(const char *pet_type, PetRecord *into);
 	bool		GetPoweredPetEntry(const char *pet_type, int16 petpower, PetRecord *into);
 	bool		GetBasePetItems(int32 equipmentset, uint32 *items);
+	BeastlordPetData::PetStruct GetBeastlordPetData(uint16 race_id);
 	void		AddLootTableToNPC(NPC* npc, uint32 loottable_id, ItemList* itemlist, uint32* copper, uint32* silver, uint32* gold, uint32* plat);
 	void		AddLootDropToNPC(NPC* npc, uint32 lootdrop_id, ItemList* item_list, uint8 droplimit, uint8 mindrop);
 	uint32		GetMaxNPCSpellsID();


### PR DESCRIPTION
- Create a Beastlord pets table to allow server operators to easily customize Beastlord pets without a source modification.
- Defaults to similar values as the original switch inside the struct and database table.