### PR TITLE
[Bug Fix] Allow GMs to chat when AIControlled (feared, mezzed?)

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4214,7 +4214,7 @@ void Client::Handle_OP_ChannelMessage(const EQApplicationPacket *app)
 		std::cout << "Wrong size " << app->size << ", should be " << sizeof(ChannelMessage_Struct) << "+ on 0x" << std::hex << std::setfill('0') << std::setw(4) << app->GetOpcode() << std::dec << std::endl;
 		return;
 	}
-	if (IsAIControlled()) {
+	if (IsAIControlled() && !GetGM()) {
 		Message(Chat::Red, "You try to speak but cant move your mouth!");
 		return;
 	}


### PR DESCRIPTION
When using aggrozone to test certain things if you have any mobs that cast fear in the zone you get stunlocked without being able to use any GM commands.

Tied to green name, not status.