### PR TITLE
[Quest API] Add getcleannpcnamebyid(npc_id) to Perl/Lua.

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -888,7 +888,7 @@ std::string Database::GetCharNameByID(uint32 char_id) {
 	return res;
 }
 
-std::string Database::GetNPCNameByID(uint32 npc_id, bool clean_name) {
+std::string Database::GetNPCNameByID(uint32 npc_id) {
 	std::string query = fmt::format("SELECT `name` FROM `npc_types` WHERE id = {}", npc_id);
 	auto results = QueryDatabase(query);
 	std::string res;
@@ -903,9 +903,27 @@ std::string Database::GetNPCNameByID(uint32 npc_id, bool clean_name) {
 
 	auto row = results.begin();
 	res = row[0];
-	if (clean_name) {
-		find_replace(res, "_", " ");
+	return res;
+}
+
+std::string Database::GetCleanNPCNameByID(uint32 npc_id) {
+	std::string query = fmt::format("SELECT `name` FROM `npc_types` WHERE id = {}", npc_id);
+	auto results = QueryDatabase(query);
+	std::string res;
+	char mob_name[64];
+
+	if (!results.Success()) {
+		return res;
 	}
+
+	if (results.RowCount() == 0) {
+		return res;
+	}
+
+	auto row = results.begin();
+	res = row[0];
+	CleanMobName(res.c_str(), mob_name);
+	res = mob_name;
 	return res;
 }
 

--- a/common/database.cpp
+++ b/common/database.cpp
@@ -888,7 +888,7 @@ std::string Database::GetCharNameByID(uint32 char_id) {
 	return res;
 }
 
-std::string Database::GetNPCNameByID(uint32 npc_id) {
+std::string Database::GetNPCNameByID(uint32 npc_id, bool clean_name) {
 	std::string query = fmt::format("SELECT `name` FROM `npc_types` WHERE id = {}", npc_id);
 	auto results = QueryDatabase(query);
 	std::string res;
@@ -903,6 +903,9 @@ std::string Database::GetNPCNameByID(uint32 npc_id) {
 
 	auto row = results.begin();
 	res = row[0];
+	if (clean_name) {
+		find_replace(res, "_", " ");
+	}
 	return res;
 }
 

--- a/common/database.cpp
+++ b/common/database.cpp
@@ -910,7 +910,7 @@ std::string Database::GetCleanNPCNameByID(uint32 npc_id) {
 	std::string query = fmt::format("SELECT `name` FROM `npc_types` WHERE id = {}", npc_id);
 	auto results = QueryDatabase(query);
 	std::string res;
-	char mob_name[64];
+	std::string mob_name;
 
 	if (!results.Success()) {
 		return res;
@@ -921,9 +921,8 @@ std::string Database::GetCleanNPCNameByID(uint32 npc_id) {
 	}
 
 	auto row = results.begin();
-	res = row[0];
-	CleanMobName(res.c_str(), mob_name);
-	res = mob_name;
+	mob_name = row[0];
+	CleanMobName(mob_name.begin(), mob_name.end(), std::back_inserter(res));
 	return res;
 }
 

--- a/common/database.h
+++ b/common/database.h
@@ -139,7 +139,8 @@ public:
 	void	GetAccountName(uint32 accountid, char* name, uint32* oLSAccountID = 0);
 	void	GetCharName(uint32 char_id, char* name);
 	std::string GetCharNameByID(uint32 char_id);
-	std::string GetNPCNameByID(uint32 npc_id, bool clean_name = false);
+	std::string GetNPCNameByID(uint32 npc_id);
+	std::string GetCleanNPCNameByID(uint32 npc_id);
 	void	LoginIP(uint32 AccountID, const char* LoginIP);
 
 	/* Instancing */

--- a/common/database.h
+++ b/common/database.h
@@ -139,7 +139,7 @@ public:
 	void	GetAccountName(uint32 accountid, char* name, uint32* oLSAccountID = 0);
 	void	GetCharName(uint32 char_id, char* name);
 	std::string GetCharNameByID(uint32 char_id);
-	std::string GetNPCNameByID(uint32 npc_id);
+	std::string GetNPCNameByID(uint32 npc_id, bool clean_name = false);
 	void	LoginIP(uint32 AccountID, const char* LoginIP);
 
 	/* Instancing */

--- a/common/string_util.h
+++ b/common/string_util.h
@@ -193,7 +193,6 @@ bool atobool(const char* iBool);
 bool isAlphaNumeric(const char *text);
 bool strn0cpyt(char* dest, const char* source, uint32 size);
 char *CleanMobName(const char *in, char *out);
-std::string GetCleanMobName(std::string name);
 char *RemoveApostrophes(const char *s);
 char* strn0cpy(char* dest, const char* source, uint32 size);
 const char *ConvertArray(int input, char *returnchar);
@@ -206,5 +205,18 @@ void RemoveApostrophes(std::string &s);
 std::string convert2digit(int n, std::string suffix);
 std::string numberToWords(unsigned long long int n);
 std::string FormatName(const std::string& char_name);
+
+template<typename InputIterator, typename OutputIterator>
+auto CleanMobName(InputIterator first, InputIterator last, OutputIterator result)
+{
+    for (; first != last; ++first) {
+        if(*first == '_') {
+            *result = ' ';
+        } else if (isalpha(*first) || *first == '`') {
+            *result = *first;
+        }
+    }
+    return result;
+}
 
 #endif

--- a/common/string_util.h
+++ b/common/string_util.h
@@ -193,6 +193,7 @@ bool atobool(const char* iBool);
 bool isAlphaNumeric(const char *text);
 bool strn0cpyt(char* dest, const char* source, uint32 size);
 char *CleanMobName(const char *in, char *out);
+std::string GetCleanMobName(std::string name);
 char *RemoveApostrophes(const char *s);
 char* strn0cpy(char* dest, const char* source, uint32 size);
 const char *ConvertArray(int input, char *returnchar);

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -3020,13 +3020,16 @@ XS(XS__getitemname) {
 XS(XS__getnpcnamebyid);
 XS(XS__getnpcnamebyid) {
 	dXSARGS;
-	if (items != 1)
-		Perl_croak(aTHX_ "Usage: quest::getnpcnamebyid(uint32 npc_id)");
+	if (items != 1 && items != 2)
+		Perl_croak(aTHX_ "Usage: quest::getnpcnamebyid(uint32 npc_id, [bool clean_name = false])");
 
 	dXSTARG;
 	uint32 npc_id = (int) SvIV(ST(0));
-	auto npc_name = quest_manager.getnpcnamebyid(npc_id);
+	bool clean_name = false;
+	if (items == 2)
+		clean_name = (bool) SvTRUE(ST(1));
 
+	auto npc_name = quest_manager.getnpcnamebyid(npc_id, clean_name);
 	sv_setpv(TARG, npc_name.c_str());
 	XSprePUSH;
 	PUSHTARG;

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -6766,7 +6766,7 @@ XS(XS__getcleannpcnamebyid) {
 		Perl_croak(aTHX_ "Usage: quest::getcleannpcnamebyid(uint32 npc_id)");
 
 	dXSTARG;
-	uint32 npc_id = (int) SvIV(ST(0));
+	uint32 npc_id = (uint32) SvUV(ST(0));
 	auto npc_name = quest_manager.getcleannpcnamebyid(npc_id);
 	sv_setpv(TARG, npc_name.c_str());
 	XSprePUSH;

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -3020,16 +3020,12 @@ XS(XS__getitemname) {
 XS(XS__getnpcnamebyid);
 XS(XS__getnpcnamebyid) {
 	dXSARGS;
-	if (items != 1 && items != 2)
-		Perl_croak(aTHX_ "Usage: quest::getnpcnamebyid(uint32 npc_id, [bool clean_name = false])");
+	if (items != 1)
+		Perl_croak(aTHX_ "Usage: quest::getnpcnamebyid(uint32 npc_id)");
 
 	dXSTARG;
 	uint32 npc_id = (int) SvIV(ST(0));
-	bool clean_name = false;
-	if (items == 2)
-		clean_name = (bool) SvTRUE(ST(1));
-
-	auto npc_name = quest_manager.getnpcnamebyid(npc_id, clean_name);
+	auto npc_name = quest_manager.getnpcnamebyid(npc_id);
 	sv_setpv(TARG, npc_name.c_str());
 	XSprePUSH;
 	PUSHTARG;
@@ -6763,6 +6759,21 @@ XS(XS__crosszoneaddldonwinbyexpeditionid) {
 	XSRETURN_EMPTY;
 }
 
+XS(XS__getcleannpcnamebyid);
+XS(XS__getcleannpcnamebyid) {
+	dXSARGS;
+	if (items != 1)
+		Perl_croak(aTHX_ "Usage: quest::getcleannpcnamebyid(uint32 npc_id)");
+
+	dXSTARG;
+	uint32 npc_id = (int) SvIV(ST(0));
+	auto npc_name = quest_manager.getcleannpcnamebyid(npc_id);
+	sv_setpv(TARG, npc_name.c_str());
+	XSprePUSH;
+	PUSHTARG;
+	XSRETURN(1);
+}
+
 /*
 This is the callback perl will look for to setup the
 quest package's XSUBs
@@ -6987,6 +6998,7 @@ EXTERN_C XS(boot_quest) {
 	newXS(strcpy(buf, "getaaexpmodifierbycharid"), XS__getaaexpmodifierbycharid, file);
 	newXS(strcpy(buf, "getcharidbyname"), XS__getcharidbyname, file);
 	newXS(strcpy(buf, "getclassname"), XS__getclassname, file);
+	newXS(strcpy(buf, "getcleannpcnamebyid"), XS__getcleannpcnamebyid, file);
 	newXS(strcpy(buf, "gethexcolorcode"), XS__gethexcolorcode, file);
 	newXS(strcpy(buf, "getcurrencyid"), XS__getcurrencyid, file);
 	newXS(strcpy(buf, "getexpmodifierbycharid"), XS__getexpmodifierbycharid, file);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -941,10 +941,6 @@ std::string lua_get_npc_name_by_id(uint32 npc_id) {
 	return quest_manager.getnpcnamebyid(npc_id);
 }
 
-std::string lua_get_npc_name_by_id(uint32 npc_id, bool clean_name) {
-	return quest_manager.getnpcnamebyid(npc_id, clean_name);
-}
-
 int lua_get_raid_id_by_char_id(uint32 char_id) {
 	return database.GetRaidIDByCharID(char_id);
 }
@@ -2459,6 +2455,10 @@ void lua_cross_zone_add_ldon_win_by_expedition_id(uint32 expedition_id, uint32 t
 	quest_manager.CrossZoneLDoNUpdate(update_type, update_subtype, expedition_id, theme_id);
 }
 
+std::string lua_get_clean_npc_name_by_id(uint32 npc_id) {
+	return quest_manager.getcleannpcnamebyid(npc_id);
+}
+
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
 	cur = table[#name]; \
 	if(luabind::type(cur) != LUA_TNIL) { \
@@ -2800,13 +2800,13 @@ luabind::scope lua_register_general() {
 		luabind::def("get_char_id_by_name", (uint32(*)(const char*))&lua_get_char_id_by_name),
 		luabind::def("get_class_name", (std::string(*)(uint8))&lua_get_class_name),
 		luabind::def("get_class_name", (std::string(*)(uint8,uint8))&lua_get_class_name),
+		luabind::def("get_clean_npc_name_by_id", &lua_get_clean_npc_name_by_id),
 		luabind::def("get_currency_id", &lua_get_currency_id),
 		luabind::def("get_currency_item_id", &lua_get_currency_item_id),
 		luabind::def("get_guild_name_by_id", &lua_get_guild_name_by_id),
 		luabind::def("get_guild_id_by_char_id", &lua_get_guild_id_by_char_id),
 		luabind::def("get_group_id_by_char_id", &lua_get_group_id_by_char_id),
-		luabind::def("get_npc_name_by_id", (std::string(*)(uint32))&lua_get_npc_name_by_id),
-		luabind::def("get_npc_name_by_id", (std::string(*)(uint32,bool))&lua_get_npc_name_by_id),
+		luabind::def("get_npc_name_by_id", &lua_get_npc_name_by_id),
 		luabind::def("get_raid_id_by_char_id", &lua_get_raid_id_by_char_id),
 		luabind::def("create_instance", &lua_create_instance),
 		luabind::def("destroy_instance", &lua_destroy_instance),

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -941,6 +941,10 @@ std::string lua_get_npc_name_by_id(uint32 npc_id) {
 	return quest_manager.getnpcnamebyid(npc_id);
 }
 
+std::string lua_get_npc_name_by_id(uint32 npc_id, bool clean_name) {
+	return quest_manager.getnpcnamebyid(npc_id, clean_name);
+}
+
 int lua_get_raid_id_by_char_id(uint32 char_id) {
 	return database.GetRaidIDByCharID(char_id);
 }
@@ -2801,7 +2805,8 @@ luabind::scope lua_register_general() {
 		luabind::def("get_guild_name_by_id", &lua_get_guild_name_by_id),
 		luabind::def("get_guild_id_by_char_id", &lua_get_guild_id_by_char_id),
 		luabind::def("get_group_id_by_char_id", &lua_get_group_id_by_char_id),
-		luabind::def("get_npc_name_by_id", &lua_get_npc_name_by_id),
+		luabind::def("get_npc_name_by_id", (std::string(*)(uint32))&lua_get_npc_name_by_id),
+		luabind::def("get_npc_name_by_id", (std::string(*)(uint32,bool))&lua_get_npc_name_by_id),
 		luabind::def("get_raid_id_by_char_id", &lua_get_raid_id_by_char_id),
 		luabind::def("create_instance", &lua_create_instance),
 		luabind::def("destroy_instance", &lua_destroy_instance),

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -2781,10 +2781,18 @@ std::string QuestManager::getitemname(uint32 item_id) {
 	return item_name;
 }
 
-std::string QuestManager::getnpcnamebyid(uint32 npc_id, bool clean_name) {
+std::string QuestManager::getnpcnamebyid(uint32 npc_id) {
 	std::string res;
 	if (npc_id > 0) {
-		res = database.GetNPCNameByID(npc_id, clean_name);
+		res = database.GetNPCNameByID(npc_id);
+	}
+	return res;
+}
+
+std::string QuestManager::getcleannpcnamebyid(uint32 npc_id) {
+	std::string res;
+	if (npc_id > 0) {
+		res = database.GetCleanNPCNameByID(npc_id);
 	}
 	return res;
 }

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -2781,10 +2781,10 @@ std::string QuestManager::getitemname(uint32 item_id) {
 	return item_name;
 }
 
-std::string QuestManager::getnpcnamebyid(uint32 npc_id) {
+std::string QuestManager::getnpcnamebyid(uint32 npc_id, bool clean_name) {
 	std::string res;
 	if (npc_id > 0) {
-		res = database.GetNPCNameByID(npc_id);
+		res = database.GetNPCNameByID(npc_id, clean_name);
 	}
 	return res;
 }

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -273,7 +273,7 @@ public:
 	const char* getguildnamebyid(int guild_id);
 	int getguildidbycharid(uint32 char_id);
 	int getgroupidbycharid(uint32 char_id);
-	std::string getnpcnamebyid(uint32 npc_id);
+	std::string getnpcnamebyid(uint32 npc_id, bool clean_name = false);
 	int getraididbycharid(uint32 char_id);
 	void SetRunning(bool val);
 	bool IsRunning();

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -273,7 +273,8 @@ public:
 	const char* getguildnamebyid(int guild_id);
 	int getguildidbycharid(uint32 char_id);
 	int getgroupidbycharid(uint32 char_id);
-	std::string getnpcnamebyid(uint32 npc_id, bool clean_name = false);
+	std::string getnpcnamebyid(uint32 npc_id);
+	std::string getcleannpcnamebyid(uint32 npc_id);
 	int getraididbycharid(uint32 char_id);
 	void SetRunning(bool val);
 	bool IsRunning();


### PR DESCRIPTION
- Allows Server Operators to grab the clean name without having to clean it up in their Perl/Lua.