### PR TITLE
[Bug Fix] Fix illusions

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1859,19 +1859,20 @@ void Mob::SendIllusionPacket(
 	}
 
 	// update internal values for mob
-	size             = (in_size <= 0.0f) ? GetSize() : in_size;
-	texture          = new_texture;
-	helmtexture      = new_helmtexture;
-	haircolor        = new_haircolor;
-	beardcolor       = new_beardcolor;
-	eyecolor1        = new_eyecolor1;
-	eyecolor2        = new_eyecolor2;
-	hairstyle        = new_hairstyle;
-	luclinface       = new_luclinface;
-	beard            = new_beard;
-	drakkin_heritage = new_drakkin_heritage;
-	drakkin_tattoo   = new_drakkin_tattoo;
-	drakkin_details  = new_drakkin_details;
+	// TODO: Move this to its own SetIllusion function later
+	//	size             = (in_size <= 0.0f) ? GetSize() : in_size;
+	//	texture          = new_texture;
+	//	helmtexture      = new_helmtexture;
+	//	haircolor        = new_haircolor;
+	//	beardcolor       = new_beardcolor;
+	//	eyecolor1        = new_eyecolor1;
+	//	eyecolor2        = new_eyecolor2;
+	//	hairstyle        = new_hairstyle;
+	//	luclinface       = new_luclinface;
+	//	beard            = new_beard;
+	//	drakkin_heritage = new_drakkin_heritage;
+	//	drakkin_tattoo   = new_drakkin_tattoo;
+	//	drakkin_details  = new_drakkin_details;
 
 	auto            outapp = new EQApplicationPacket(OP_Illusion, sizeof(Illusion_Struct));
 	Illusion_Struct *is    = (Illusion_Struct *) outapp->pBuffer;


### PR DESCRIPTION
Fix an issue originally reported by @RoT-PvP  where armor appearance does not look correct after an illusion fades

**Before Illusion**

![image](https://user-images.githubusercontent.com/3319450/121765077-0b083500-cb0e-11eb-95f9-1c72647f6105.png)

**Illusion**

![image](https://user-images.githubusercontent.com/3319450/121765083-10657f80-cb0e-11eb-8c35-9a895d36343a.png)

**After Illusion**

![image](https://user-images.githubusercontent.com/3319450/121765092-1bb8ab00-cb0e-11eb-8b23-4cf4a4367d0d.png)

Issue caused by my PR back in Oct 2020 https://github.com/EQEmu/Server/pull/1130

The original PR will have to have functionality split into a separate function