### PR TITLE
[Items] Allow any bag type 51 to be used for Trader

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -3382,10 +3382,10 @@ bool Client::CalcItemScale(uint32 slot_x, uint32 slot_y) {
 		if (Trader)
 			if (i >= EQ::invbag::GENERAL_BAGS_BEGIN && i <= EQ::invbag::GENERAL_BAGS_END) {
 				EQ::ItemInstance* parent_item = m_inv.GetItem(EQ::InventoryProfile::CalcSlotId(i));
-				if (parent_item && parent_item->GetItem()->ID == 17899) // trader satchel
+				if (parent_item && parent_item->GetItem()->BagType == EQ::item::BagTypeTradersSatchel)
 					continue;
 			}
-
+		
 		bool update_slot = false;
 		if(inst->IsScaling())
 		{
@@ -3468,7 +3468,7 @@ bool Client::DoItemEnterZone(uint32 slot_x, uint32 slot_y) {
 		if (Trader)
 			if (i >= EQ::invbag::GENERAL_BAGS_BEGIN && i <= EQ::invbag::GENERAL_BAGS_END) {
 				EQ::ItemInstance* parent_item = m_inv.GetItem(EQ::InventoryProfile::CalcSlotId(i));
-				if (parent_item && parent_item->GetItem()->ID == 17899) // trader satchel
+				if (parent_item && parent_item->GetItem()->BagType == EQ::item::BagTypeTradersSatchel)
 					continue;
 			}
 

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -1266,7 +1266,7 @@ uint32 Client::FindTraderItemSerialNumber(int32 ItemID) {
 	uint16 SlotID = 0;
 	for (int i = EQ::invslot::GENERAL_BEGIN; i <= EQ::invslot::GENERAL_END; i++){
 		item = this->GetInv().GetItem(i);
-		if (item && item->IsClassBag() && item->GetItem()->BagType == 51){ //Trader's Satchel or any bag marked type 51
+		if (item && item->GetItem()->BagType == EQ::item::BagTypeTradersSatchel){
 			for (int x = EQ::invbag::SLOT_BEGIN; x <= EQ::invbag::SLOT_END; x++) {
 				// we already have the parent bag and a contents iterator..why not just iterate the bag!??
 				SlotID = EQ::InventoryProfile::CalcSlotId(i, x);
@@ -1289,7 +1289,7 @@ EQ::ItemInstance* Client::FindTraderItemBySerialNumber(int32 SerialNumber){
 	uint16 SlotID = 0;
 	for (int i = EQ::invslot::GENERAL_BEGIN; i <= EQ::invslot::GENERAL_END; i++){
 		item = this->GetInv().GetItem(i);
-		if (item && item->IsClassBag() && item->GetItem()->BagType == 51){ //Trader's Satchel or any bag marked type 51
+		if (item && item->GetItem()->BagType == EQ::item::BagTypeTradersSatchel){
 			for (int x = EQ::invbag::SLOT_BEGIN; x <= EQ::invbag::SLOT_END; x++) {
 				// we already have the parent bag and a contents iterator..why not just iterate the bag!??
 				SlotID = EQ::InventoryProfile::CalcSlotId(i, x);
@@ -1322,7 +1322,7 @@ GetItems_Struct* Client::GetTraderItems(){
 		if (ndx >= 80)
 			break;
 		item = this->GetInv().GetItem(i);
-		if(item && item->GetItem()->ID == 17899){ //Traders Satchel
+		if (item && item->GetItem()->BagType == EQ::item::BagTypeTradersSatchel){
 			for (int x = EQ::invbag::SLOT_BEGIN; x <= EQ::invbag::SLOT_END; x++) {
 				if (ndx >= 80)
 					break;
@@ -1349,7 +1349,7 @@ uint16 Client::FindTraderItem(int32 SerialNumber, uint16 Quantity){
 	uint16 SlotID = 0;
 	for (int i = EQ::invslot::GENERAL_BEGIN; i <= EQ::invslot::GENERAL_END; i++) {
 		item = this->GetInv().GetItem(i);
-		if(item && item->GetItem()->ID == 17899){ //Traders Satchel
+		if (item && item->GetItem()->BagType == EQ::item::BagTypeTradersSatchel){
 			for (int x = EQ::invbag::SLOT_BEGIN; x <= EQ::invbag::SLOT_END; x++){
 				SlotID = EQ::InventoryProfile::CalcSlotId(i, x);
 

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -1266,7 +1266,7 @@ uint32 Client::FindTraderItemSerialNumber(int32 ItemID) {
 	uint16 SlotID = 0;
 	for (int i = EQ::invslot::GENERAL_BEGIN; i <= EQ::invslot::GENERAL_END; i++){
 		item = this->GetInv().GetItem(i);
-		if (item && item->GetItem()->ID == 17899){ //Traders Satchel
+		if (item && item->IsClassBag() && item->GetItem()->BagType == 51){ //Trader's Satchel or any bag marked type 51
 			for (int x = EQ::invbag::SLOT_BEGIN; x <= EQ::invbag::SLOT_END; x++) {
 				// we already have the parent bag and a contents iterator..why not just iterate the bag!??
 				SlotID = EQ::InventoryProfile::CalcSlotId(i, x);
@@ -1289,7 +1289,7 @@ EQ::ItemInstance* Client::FindTraderItemBySerialNumber(int32 SerialNumber){
 	uint16 SlotID = 0;
 	for (int i = EQ::invslot::GENERAL_BEGIN; i <= EQ::invslot::GENERAL_END; i++){
 		item = this->GetInv().GetItem(i);
-		if(item && item->GetItem()->ID == 17899){ //Traders Satchel
+		if (item && item->IsClassBag() && item->GetItem()->BagType == 51){ //Trader's Satchel or any bag marked type 51
 			for (int x = EQ::invbag::SLOT_BEGIN; x <= EQ::invbag::SLOT_END; x++) {
 				// we already have the parent bag and a contents iterator..why not just iterate the bag!??
 				SlotID = EQ::InventoryProfile::CalcSlotId(i, x);


### PR DESCRIPTION
Most commonly this would allow the different color satchels to be used in Trader mode.
PEQ database has 1 item (Yellow Trader's Satchel Token - 35037) marked as type 51, but otherwise only the proper bags are already set in that DB.
Bonus of removing the hard-coded ID from source.