### PR TITLE
[Hotfix] Fix crash pertaining to new PVPEnableGuardFactionAssist code

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -383,7 +383,7 @@ bool Mob::DoCastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 			Chat::SpellFailure,
 			(IsClient() ? FilterPCSpells : FilterNPCSpells),
 			(fizzle_msg == MISS_NOTE ? MISSED_NOTE_OTHER : SPELL_FIZZLE_OTHER),
-			/* 
+			/*
 				MessageFormat: You miss a note, bringing your song to a close! (if missed note)
 				MessageFormat: A missed note brings %1's song to a close!
 				MessageFormat: %1's spell fizzles!
@@ -1235,7 +1235,7 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 				else {
 					if (!RuleB(Character, PetsUseReagents) && (IsEffectInSpell(spell_id, SE_SummonPet) || IsEffectInSpell(spell_id, SE_NecPet))) {
 						//bypass reagent cost
-					} 
+					}
 					else if(c->GetInv().HasItem(component, component_count, invWhereWorn|invWherePersonal) == -1) // item not found
 					{
 						if (!missingreags)
@@ -1421,7 +1421,7 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 			Client *c = CastToClient();
 			if((IsFromItem  && RuleB(Character, SkillUpFromItems)) || !IsFromItem) {
 				c->CheckSongSkillIncrease(spell_id);
-			} 
+			}
 			if (spells[spell_id].EndurTimerIndex > 0 && slot < CastingSlot::MaxGems)
 				c->SetLinkedSpellReuseTimer(spells[spell_id].EndurTimerIndex, spells[spell_id].recast_time / 1000);
 			c->MemorizeSpell(static_cast<uint32>(slot), spell_id, memSpellSpellbar);
@@ -2049,14 +2049,14 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, CastingSlot slot, ui
 	//Death Touch targets the pet owner instead of the pet when said pet is tanking.
 	if ((RuleB(Spells, CazicTouchTargetsPetOwner) && spell_target && spell_target->HasOwner()) && spell_id == DB_SPELL_CAZIC_TOUCH || spell_id == DB_SPELL_TOUCH_OF_VINITRAS) {
 		Mob* owner =  spell_target->GetOwner();
-		
+
 		if (owner) {
 			spell_target = owner;
 		}
 	}
-  
+
   //Guard Assist Code
-	if (RuleB(Character, PVPEnableGuardFactionAssist) && IsDetrimentalSpell(spell_id) && spell_target != this) {
+	if (RuleB(Character, PVPEnableGuardFactionAssist) && spell_target && IsDetrimentalSpell(spell_id) && spell_target != this) {
 		if (IsClient() || (HasOwner() && GetOwner()->IsClient())) {
 			auto& mob_list = entity_list.GetCloseMobList(spell_target);
 			for (auto& e : mob_list) {
@@ -3430,7 +3430,7 @@ int Mob::CanBuffStack(uint16 spellid, uint8 caster_level, bool iFailIfOverwrite)
 				firstfree = i;
 		}
 		if(ret == -1) {
-			
+
 			LogAI("Buff [{}] would conflict with [{}] in slot [{}], reporting stack failure", spellid, curbuf.spellid, i);
 			return -1;	// stop the spell, can't stack it
 		}
@@ -3565,7 +3565,7 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, bool reflect, bool use_r
 		spelltar, /* Sender */
 		action_packet, /* Packet */
 		true, /* Ignore Sender */
-		RuleI(Range, SpellMessages), 
+		RuleI(Range, SpellMessages),
 		this, /* Skip this Mob */
 		true, /* Packet ACK */
 		(spelltar->IsClient() ? FilterPCSpells : FilterNPCSpells) /* EQ Filter Type: (8 or 9) */
@@ -3908,7 +3908,7 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, bool reflect, bool use_r
 					spelltar->CastToClient()->BreakSneakWhenCastOn(this, true);
 					spelltar->CastToClient()->BreakFeignDeathWhenCastOn(true);
 				}
-				
+
 				spelltar->CheckNumHitsRemaining(NumHit::IncomingSpells);
 				CheckNumHitsRemaining(NumHit::OutgoingSpells);
 
@@ -4024,7 +4024,7 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, bool reflect, bool use_r
 			spelltar, /* Sender */
 			message_packet, /* Packet */
 			false, /* Ignore Sender */
-			RuleI(Range, SpellMessages), 
+			RuleI(Range, SpellMessages),
 			0, /* Skip this mob */
 			true, /* Packet ACK */
 			(spelltar->IsClient() ? FilterPCSpells : FilterNPCSpells) /* Message Filter Type: (8 or 9) */
@@ -4098,17 +4098,17 @@ bool Mob::FindBuff(uint16 spellid)
 uint16 Mob::FindBuffBySlot(int slot) {
 	if (buffs[slot].spellid != SPELL_UNKNOWN)
 		return buffs[slot].spellid;
-	
+
 	return 0;
 }
 
 uint32 Mob::BuffCount() {
 	uint32 active_buff_count = 0;
 	int buff_count = GetMaxTotalSlots();
-	for (int i = 0; i < buff_count; i++) 
+	for (int i = 0; i < buff_count; i++)
 		if (buffs[i].spellid != SPELL_UNKNOWN)
 			active_buff_count++;
-	
+
 	return active_buff_count;
 }
 
@@ -5023,7 +5023,7 @@ void Mob::Mesmerize()
 
 	if (spell_id)
 		InterruptSpell(spell_id);
-	
+
 	StopNavigation();
 }
 
@@ -5141,7 +5141,7 @@ uint32 Client::GetSpellIDByBookSlot(int book_slot) {
 uint16 Client::FindMemmedSpellBySlot(int slot) {
 	if (m_pp.mem_spells[slot] != 0xFFFFFFFF)
 		return m_pp.mem_spells[slot];
-	
+
 	return 0;
 }
 
@@ -5150,7 +5150,7 @@ int Client::MemmedCount() {
 	for (int i = 0; i < EQ::spells::SPELL_GEM_COUNT; i++)
 		if (m_pp.mem_spells[i] != 0xFFFFFFFF)
 			memmed_count++;
-		
+
 	return memmed_count;
 }
 
@@ -5328,7 +5328,7 @@ bool Client::SpellBucketCheck(uint16 spell_id, uint32 char_id) {
 
 	if (results.RowCount() != 1)
 		return true;
-	
+
 	auto row = results.begin();
 	spell_bucket_name = row[0];
 	spell_bucket_value = atoi(row[1]);


### PR DESCRIPTION
Stack Trace

```
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
0x00007f04bc75a0ca in __waitpid (pid=14948, stat_loc=stat_loc@entry=0x0, options=options@entry=0) at ../sysdeps/unix/sysv/linux/waitpid.c:30
[Current thread is 1 (Thread 0x7f04bba80140 (LWP 12099))]
#0  0x00007f04bc75a0ca in __waitpid (pid=14948, stat_loc=stat_loc@entry=0x0, options=options@entry=0) at ../sysdeps/unix/sysv/linux/waitpid.c:30
#1  0x000055e6afebfcae in print_trace () at /home/eqemu/code/common/crash.cpp:154
#2  <signal handler called>
#3  std::_Hashtable<unsigned short, std::pair<unsigned short const, Mob*>, std::allocator<std::pair<unsigned short const, Mob*> >, std::__detail::_Select1st, std::equal_to<unsigned short>, std::hash<unsigned short>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::begin (this=0x18) at /usr/include/c++/8/bits/hashtable.h:503
#4  std::unordered_map<unsigned short, Mob*, std::hash<unsigned short>, std::equal_to<unsigned short>, std::allocator<std::pair<unsigned short const, Mob*> > >::begin (this=0x18) at /usr/include/c++/8/bits/unordered_map.h:325
#5  Mob::SpellFinished (this=0x55e6b2862c80, spell_id=<optimized out>, spell_target=<optimized out>, slot=EQ::spells::CastingSlot::Gem1, mana_used=<optimized out>, inventory_slot=4294967295, resist_adjust=0, isproc=false, level_override=-1) at /home/eqemu/code/zone/spells.cpp:2062
#6  0x000055e6afe2e01d in Mob::CastedSpellFinished (this=<optimized out>, spell_id=<optimized out>, target_id=<optimized out>, slot=<optimized out>, mana_used=<optimized out>, inventory_slot=<optimized out>, resist_adjust=<optimized out>) at /home/eqemu/code/zone/spells.cpp:1382
#7  0x000055e6afe2ff0e in Mob::SpellProcess (this=0x55e6b2862c80) at /home/eqemu/code/zone/spells.cpp:130
#8  Mob::SpellProcess (this=0x55e6b2862c80) at /home/eqemu/code/zone/spells.cpp:115
#9  0x000055e6af93e801 in Client::Process (this=0x55e6b2862c80) at /home/eqemu/code/zone/client_process.cpp:491
#10 0x000055e6afa7a6cc in EntityList::MobProcess (this=this@entry=0x55e6b034cc40 <entity_list>) at /home/eqemu/code/zone/entity.cpp:529
#11 0x000055e6afc9c8c0 in <lambda(EQ::Timer*)>::operator()(EQ::Timer *) const (__closure=0x55e6b1814400, t=<optimized out>) at /home/eqemu/code/zone/main.cpp:550
#12 0x000055e6afc9cc8f in std::function<void (EQ::Timer*)>::operator()(EQ::Timer*) const (__args#0=<optimized out>, this=<optimized out>) at /usr/include/c++/8/bits/std_function.h:682
#13 EQ::Timer::Execute (this=<optimized out>) at /home/eqemu/code/zone/../common/net/../event/timer.h:61
#14 EQ::Timer::Start(unsigned long, bool)::{lambda(uv_timer_s*)#1}::operator()(uv_timer_s*) const (handle=<optimized out>, __closure=0x0) at /home/eqemu/code/zone/../common/net/../event/timer.h:38
#15 EQ::Timer::Start(unsigned long, bool)::{lambda(uv_timer_s*)#1}::_FUN(uv_timer_s*) () at /home/eqemu/code/zone/../common/net/../event/timer.h:39
#16 0x000055e6b00407f5 in uv__run_timers (loop=loop@entry=0x7f04bba7fdf0) at /home/eqemu/code/submodules/libuv/src/timer.c:174
#17 0x000055e6b0044585 in uv_run (loop=0x7f04bba7fdf0, mode=mode@entry=UV_RUN_DEFAULT) at /home/eqemu/code/submodules/libuv/src/unix/core.c:352
#18 0x000055e6af867792 in EQ::EventLoop::Run (this=<optimized out>) at /home/eqemu/code/zone/../common/net/../event/event_loop.h:25
#19 main (argc=<optimized out>, argv=<optimized out>) at /home/eqemu/code/zone/main.cpp:579
[Inferior 1 (process 12099) detached]
```