### PR TITLE
[Hotfix] Illusion Revert

### DIFF
--- a/common/eq_packet_structs.h
+++ b/common/eq_packet_structs.h
@@ -2131,31 +2131,31 @@ struct AdventureLeaderboard_Struct
 };*/
 
 struct Illusion_Struct { //size: 256 - SoF
-/*000*/	uint32	spawnid;
-/*004*/	char charname[64];		//
-/*068*/	uint16	race;			//
-/*070*/	char	unknown006[2];
-/*072*/	uint8	gender;
-/*073*/	uint8	texture;
-/*074*/	uint8	unknown008;		//
-/*075*/	uint8	unknown009;		//
-/*076*/	uint8	helmtexture;	//
-/*077*/	uint8	unknown010;		//
-/*078*/	uint8	unknown011;		//
-/*079*/	uint8	unknown012;		//
-/*080*/	uint32	face;			//
-/*084*/	uint8	hairstyle;		//
-/*085*/	uint8	haircolor;		//
-/*086*/	uint8	beard;			//
-/*087*/	uint8	beardcolor;		//
-/*088*/	float	size;			//
-/*092*/	uint32	drakkin_heritage;	//
-/*096*/	uint32	drakkin_tattoo;		//
-/*100*/	uint32	drakkin_details;	//
-/*104*/	EQ::TintProfile	armor_tint;	//
-/*140*/	uint8	eyecolor1;		// Field Not Identified in any Illusion Struct
-/*141*/	uint8	eyecolor2;		// Field Not Identified in any Illusion Struct
-/*142*/	uint8	unknown138[114];	//
+/*000*/    uint32          spawnid;
+/*004*/    char            charname[64];        //
+/*068*/    uint16          race;            //
+/*070*/    char            unknown006[2];
+/*072*/    uint8           gender;
+/*073*/    uint8           texture;
+/*074*/    uint8           unknown008;        //
+/*075*/    uint8           unknown009;        //
+/*076*/    uint8           helmtexture;    //
+/*077*/    uint8           unknown010;        //
+/*078*/    uint8           unknown011;        //
+/*079*/    uint8           unknown012;        //
+/*080*/    uint32          face;            //
+/*084*/    uint8           hairstyle;        //
+/*085*/    uint8           haircolor;        //
+/*086*/    uint8           beard;            //
+/*087*/    uint8           beardcolor;        //
+/*088*/    float           size;            //
+/*092*/    uint32          drakkin_heritage;    //
+/*096*/    uint32          drakkin_tattoo;        //
+/*100*/    uint32          drakkin_details;    //
+/*104*/    EQ::TintProfile armor_tint;    //
+/*140*/    uint8           eyecolor1;        // Field Not Identified in any Illusion Struct
+/*141*/    uint8           eyecolor2;        // Field Not Identified in any Illusion Struct
+/*142*/    uint8           unknown138[114];    //
 /*256*/
 };
 

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1810,7 +1810,7 @@ void Mob::SendIllusionPacket(
 	new_drakkin_tattoo   = (in_drakkin_tattoo == 0xFFFFFFFF) ? GetDrakkinTattoo() : in_drakkin_tattoo;
 	new_drakkin_details  = (in_drakkin_details == 0xFFFFFFFF) ? GetDrakkinDetails() : in_drakkin_details;
 	new_aa_title         = in_aa_title;
-	
+
 	bool  reset_features_to_player_profile = IsClient() && in_race == 0;
 	if (reset_features_to_player_profile) {
 		auto c = CastToClient();
@@ -1861,7 +1861,7 @@ void Mob::SendIllusionPacket(
 	}
 
 	// update internal values for mob from illusion
-	size             = (in_size <= 0.0f) ? GetSize() : in_size;
+	size             = (in_size <= 0.0f) ? GetRaceGenderDefaultHeight(race, gender) : in_size;
 	texture          = new_texture;
 	helmtexture      = new_helmtexture;
 	haircolor        = new_haircolor;

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1810,24 +1810,26 @@ void Mob::SendIllusionPacket(
 	new_drakkin_tattoo   = (in_drakkin_tattoo == 0xFFFFFFFF) ? GetDrakkinTattoo() : in_drakkin_tattoo;
 	new_drakkin_details  = (in_drakkin_details == 0xFFFFFFFF) ? GetDrakkinDetails() : in_drakkin_details;
 	new_aa_title         = in_aa_title;
-
-	// Reset features to Base from the Player Profile
-	if (IsClient() && in_race == 0) {
-		race                 = CastToClient()->GetBaseRace();
-		gender               = CastToClient()->GetBaseGender();
+	
+	bool  reset_features_to_player_profile = IsClient() && in_race == 0;
+	if (reset_features_to_player_profile) {
+		auto c = CastToClient();
+		race                 = c->GetBaseRace();
+		gender               = c->GetBaseGender();
 		new_texture          = texture          = 0xFF;
 		new_helmtexture      = helmtexture      = 0xFF;
-		new_haircolor        = haircolor        = CastToClient()->GetBaseHairColor();
-		new_beardcolor       = beardcolor       = CastToClient()->GetBaseBeardColor();
-		new_eyecolor1        = eyecolor1        = CastToClient()->GetBaseEyeColor();
-		new_eyecolor2        = eyecolor2        = CastToClient()->GetBaseEyeColor();
-		new_hairstyle        = hairstyle        = CastToClient()->GetBaseHairStyle();
-		new_luclinface       = luclinface       = CastToClient()->GetBaseFace();
-		new_beard            = beard            = CastToClient()->GetBaseBeard();
+		new_haircolor        = haircolor        = c->GetBaseHairColor();
+		new_beardcolor       = beardcolor       = c->GetBaseBeardColor();
+		new_eyecolor1        = eyecolor1        = c->GetBaseEyeColor();
+		new_eyecolor2        = eyecolor2        = c->GetBaseEyeColor();
+		new_hairstyle        = hairstyle        = c->GetBaseHairStyle();
+		new_luclinface       = luclinface       = c->GetBaseFace();
+		new_beard            = beard            = c->GetBaseBeard();
 		new_aa_title         = aa_title         = 0xFF;
-		new_drakkin_heritage = drakkin_heritage = CastToClient()->GetBaseHeritage();
-		new_drakkin_tattoo   = drakkin_tattoo   = CastToClient()->GetBaseTattoo();
-		new_drakkin_details  = drakkin_details  = CastToClient()->GetBaseDetails();
+		new_drakkin_heritage = drakkin_heritage = c->GetBaseHeritage();
+		new_drakkin_tattoo   = drakkin_tattoo   = c->GetBaseTattoo();
+		new_drakkin_details  = drakkin_details  = c->GetBaseDetails();
+
 		switch (race) {
 			case OGRE:
 				size = 9;
@@ -1858,50 +1860,52 @@ void Mob::SendIllusionPacket(
 		}
 	}
 
-	// update internal values for mob
-	// TODO: Move this to its own SetIllusion function later
-	//	size             = (in_size <= 0.0f) ? GetSize() : in_size;
-	//	texture          = new_texture;
-	//	helmtexture      = new_helmtexture;
-	//	haircolor        = new_haircolor;
-	//	beardcolor       = new_beardcolor;
-	//	eyecolor1        = new_eyecolor1;
-	//	eyecolor2        = new_eyecolor2;
-	//	hairstyle        = new_hairstyle;
-	//	luclinface       = new_luclinface;
-	//	beard            = new_beard;
-	//	drakkin_heritage = new_drakkin_heritage;
-	//	drakkin_tattoo   = new_drakkin_tattoo;
-	//	drakkin_details  = new_drakkin_details;
+	// update internal values for mob from illusion
+	size             = (in_size <= 0.0f) ? GetSize() : in_size;
+	texture          = new_texture;
+	helmtexture      = new_helmtexture;
+	haircolor        = new_haircolor;
+	beardcolor       = new_beardcolor;
+	eyecolor1        = new_eyecolor1;
+	eyecolor2        = new_eyecolor2;
+	hairstyle        = new_hairstyle;
+	luclinface       = new_luclinface;
+	beard            = new_beard;
+	drakkin_heritage = new_drakkin_heritage;
+	drakkin_tattoo   = new_drakkin_tattoo;
+	drakkin_details  = new_drakkin_details;
 
-	auto            outapp = new EQApplicationPacket(OP_Illusion, sizeof(Illusion_Struct));
-	Illusion_Struct *is    = (Illusion_Struct *) outapp->pBuffer;
-	is->spawnid = GetID();
-	strcpy(is->charname, GetCleanName());
-	is->race             = race;
-	is->gender           = gender;
-	is->texture          = new_texture;
-	is->helmtexture      = new_helmtexture;
-	is->haircolor        = new_haircolor;
-	is->beardcolor       = new_beardcolor;
-	is->beard            = new_beard;
-	is->eyecolor1        = new_eyecolor1;
-	is->eyecolor2        = new_eyecolor2;
-	is->hairstyle        = new_hairstyle;
-	is->face             = new_luclinface;
-	is->drakkin_heritage = new_drakkin_heritage;
-	is->drakkin_tattoo   = new_drakkin_tattoo;
-	is->drakkin_details  = new_drakkin_details;
-	is->size             = size;
+	// send packet
+	auto outapp = new EQApplicationPacket(OP_Illusion, sizeof(Illusion_Struct));
+	auto *i     = (Illusion_Struct *) outapp->pBuffer;
+	i->spawnid = GetID();
+	strcpy(i->charname, GetCleanName());
+	i->race             = race;
+	i->gender           = gender;
+	i->texture          = new_texture;
+	i->helmtexture      = new_helmtexture;
+	i->haircolor        = new_haircolor;
+	i->beardcolor       = new_beardcolor;
+	i->beard            = new_beard;
+	i->eyecolor1        = new_eyecolor1;
+	i->eyecolor2        = new_eyecolor2;
+	i->hairstyle        = new_hairstyle;
+	i->face             = new_luclinface;
+	i->drakkin_heritage = new_drakkin_heritage;
+	i->drakkin_tattoo   = new_drakkin_tattoo;
+	i->drakkin_details  = new_drakkin_details;
+	i->size             = size;
 
 	entity_list.QueueClients(this, outapp);
 	safe_delete(outapp);
 
-	/* Refresh armor and tints after send illusion packet */
+	// Refresh armor and tints after send illusion packet
 	SendArmorAppearance();
 
-	LogSpells(
-		"Illusion: Race [{}] Gender [{}] Texture [{}] HelmTexture [{}] HairColor [{}] BeardColor [{}] EyeColor1 [{}] EyeColor2 [{}] HairStyle [{}] Face [{}] DrakkinHeritage [{}] DrakkinTattoo [{}] DrakkinDetails [{}] Size [{}]",
+	LogMobAppearance(
+		"[SendIllusionPacket] race [{}] gender [{}] new_texture [{}] new_helmtexture [{}] new_haircolor [{}] new_beardcolor [{}] "
+		"new_eyecolor1 [{}] new_eyecolor2 [{}] new_hairstyle [{}] new_luclinface [{}] new_drakkin_heritage [{}] "
+		"new_drakkin_tattoo [{}] new_drakkin_details [{}] size [{}]",
 		race,
 		gender,
 		new_texture,

--- a/zone/mob_appearance.cpp
+++ b/zone/mob_appearance.cpp
@@ -378,9 +378,7 @@ void Mob::SendArmorAppearance(Client *one_client)
 	 * The other packets work for primary/secondary.
 	 */
 
-	Log(Logs::Detail, Logs::MobAppearance, "Mob::SendArmorAppearance [%s]",
-		this->GetCleanName()
-	);
+	LogMobAppearance("[SendArmorAppearance] [{}]", GetCleanName());
 
 	if (IsPlayerRace(race)) {
 		if (!IsClient()) {

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -1319,7 +1319,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 #endif
 				if (caster)
 					effect_value = caster->ApplySpellEffectiveness(spell_id, effect_value);
-				
+
 				buffs[buffslot].melee_rune = effect_value;
 				break;
 			}
@@ -1476,8 +1476,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					}
 				}
 
-				for (int x = EQ::textures::textureBegin; x <= EQ::textures::LastTintableTexture; x++)
-					SendWearChange(x);
+				SendArmorAppearance();
 
 				if (caster == this && spell.id != 287 && spell.id != 601 &&
 				    (spellbonuses.IllusionPersistence || aabonuses.IllusionPersistence ||
@@ -1841,7 +1840,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 						Group* group = client_target->GetGroup();
 						if (!group->IsGroupMember(caster)) {
 							if (caster != this) {
-								caster->MessageString(Chat::Red, SUMMON_ONLY_GROUP_CORPSE);	
+								caster->MessageString(Chat::Red, SUMMON_ONLY_GROUP_CORPSE);
 								break;
 							}
 						}
@@ -1862,7 +1861,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 							}
 						}
 					}
-					
+
 					if (client_target) {
 						if (database.CountCharacterCorpses(client_target->CharacterID()) == 0) {
 							if (caster == this) {
@@ -2305,7 +2304,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 			}
 
 			case SE_AETaunt:
-			{			
+			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "AE Taunt");
 #endif
@@ -3878,30 +3877,30 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 			case SE_Illusion:
 			{
 				SendIllusionPacket(0, GetBaseGender());
-				if(GetRace() == OGRE){
+				if (GetRace() == OGRE) {
 					SendAppearancePacket(AT_Size, 9);
 				}
-				else if(GetRace() == TROLL){
+				else if (GetRace() == TROLL) {
 					SendAppearancePacket(AT_Size, 8);
 				}
-				else if(GetRace() == VAHSHIR || GetRace() == FROGLOK || GetRace() == BARBARIAN){
+				else if (GetRace() == VAHSHIR || GetRace() == FROGLOK || GetRace() == BARBARIAN) {
 					SendAppearancePacket(AT_Size, 7);
 				}
-				else if(GetRace() == HALF_ELF || GetRace() == WOOD_ELF || GetRace() == DARK_ELF){
+				else if (GetRace() == HALF_ELF || GetRace() == WOOD_ELF || GetRace() == DARK_ELF) {
 					SendAppearancePacket(AT_Size, 5);
 				}
-				else if(GetRace() == DWARF){
+				else if (GetRace() == DWARF) {
 					SendAppearancePacket(AT_Size, 4);
 				}
-				else if(GetRace() == HALFLING || GetRace() == GNOME){
+				else if (GetRace() == HALFLING || GetRace() == GNOME) {
 					SendAppearancePacket(AT_Size, 3);
 				}
-				else{
+				else {
 					SendAppearancePacket(AT_Size, 6);
 				}
-				for (int x = EQ::textures::textureBegin; x <= EQ::textures::LastTintableTexture; x++){
-					SendWearChange(x);
-				}
+
+				SendArmorAppearance();
+
 				break;
 			}
 
@@ -4144,7 +4143,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 					CastToClient()->SetControlledMobId(0);
 					}
 			}
-					
+
 		}
 	}
 
@@ -6788,24 +6787,24 @@ void Mob::ResourceTap(int32 damage, uint16 spellid)
 	for (int i = 0; i < EFFECT_COUNT; i++) {
 		if (spells[spellid].effectid[i] == SE_ResourceTap) {
 			damage = (damage * spells[spellid].base[i]) / 1000;
-			
+
 			if (damage) {
 				if (spells[spellid].max[i] && (damage > spells[spellid].max[i]))
 					damage = spells[spellid].max[i];
-	
+
 				if (spells[spellid].base2[i] == 0) { // HP Tap
 					if (damage > 0)
 						HealDamage(damage);
 					else
 						Damage(this, -damage, 0, EQ::skills::SkillEvocation, false);
 				}
-	
+
 				if (spells[spellid].base2[i] == 1) // Mana Tap
 					SetMana(GetMana() + damage);
-	
+
 				if (spells[spellid].base2[i] == 2 && IsClient()) // Endurance Tap
 					CastToClient()->SetEndurance(CastToClient()->GetEndurance() + damage);
-			
+
 			}
 		}
 	}
@@ -6982,7 +6981,7 @@ void Client::BreakFeignDeathWhenCastOn(bool IsResisted)
 			MessageString(Chat::SpellFailure,FD_CAST_ON_NO_BREAK);
 			return;
 		}
-	
+
 		SetFeigned(false);
 		MessageString(Chat::SpellFailure,FD_CAST_ON);
 	}


### PR DESCRIPTION
Reverts a revert https://github.com/EQEmu/Server/pull/1389

Tested this and this is working fine. The previous revert was hurting more than it was helping so it makes sense to keep what I had patched in from last October for now unless there is something that warrants taking a closer look

Time boxing investing time in this but for the most part we should be good and should get this merged back in to fix previous regressions on master

* #size (Camped character, re-zone etc.)
* Illusion (Camp other player, re-zone back in)
* Click off Illusion, returns to normal (Camp other player and re-zone back-in)

This also fixes an issue where Illusions were improperly setting size for a specific Illusion. The Illusion would update properly for one client but would not set the size properly. We're not calculating the proper size for the Race / Gender combination and size shows up correctly for new clients also entering the zone