### PR TITLE
[Commands] Modify #grid and #wp.

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -5314,3 +5314,12 @@ int EntityList::MovePlayerCorpsesToGraveyard(bool force_move_from_instance)
 
 	return moved_count;
 }
+
+void EntityList::DespawnGridNodes(int32 grid_id) {
+	for (auto mob_iterator : mob_list) {
+		Mob *mob = mob_iterator.second;
+		if (mob->IsNPC() && mob->GetRace() == 2254 && mob->EntityVariableExists("grid_id") && atoi(mob->GetEntityVariable("grid_id")) == grid_id) {
+			mob->Depop();
+		}
+	}
+}

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -234,6 +234,7 @@ public:
 	void RemoveAllCorpsesByCharID(uint32 charid);
 	void RemoveCorpseByDBID(uint32 dbid);
 	int RezzAllCorpsesByCharID(uint32 charid);
+	void DespawnGridNodes(int32 grid_id);
 	bool IsMobInZone(Mob *who);
 	void ClearClientPetitionQueue();
 	bool CanAddHateForMob(Mob *p);

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -1099,8 +1099,7 @@ bool NPC::SpawnZoneController()
 	return true;
 }
 
-void NPC::SpawnGridNodeNPC(const glm::vec4 &position, int32 grid_number, int32 zoffset) {
-
+void NPC::SpawnGridNodeNPC(const glm::vec4 &position, int32 grid_id, int32 grid_number, int32 zoffset) {
 	auto npc_type = new NPCType;
 	memset(npc_type, 0, sizeof(NPCType));
 
@@ -1112,31 +1111,30 @@ void NPC::SpawnGridNodeNPC(const glm::vec4 &position, int32 grid_number, int32 z
 		strcat(npc_type->name, "(Stacked)");
 	}
 
-	npc_type->current_hp       = 4000000;
-	npc_type->max_hp           = 4000000;
-	npc_type->race             = 2254;
-	npc_type->gender           = 2;
-	npc_type->class_           = 9;
-	npc_type->deity            = 1;
-	npc_type->level            = 200;
-	npc_type->npc_id           = 0;
-	npc_type->loottable_id     = 0;
-	npc_type->texture          = 1;
-	npc_type->light            = 1;
-	npc_type->size             = 1;
-	npc_type->runspeed         = 0;
-	npc_type->merchanttype     = 1;
-	npc_type->bodytype         = 1;
-	npc_type->show_name        = true;
-	npc_type->findable         = true;
+	npc_type->current_hp = 4000000;
+	npc_type->max_hp = 4000000;
+	npc_type->race = 2254;
+	npc_type->gender = 2;
+	npc_type->class_ = 9;
+	npc_type->deity = 1;
+	npc_type->level = 200;
+	npc_type->npc_id = 0;
+	npc_type->loottable_id = 0;
+	npc_type->texture = 1;
+	npc_type->light = 1;
+	npc_type->size = 1;
+	npc_type->runspeed = 0;
+	npc_type->merchanttype = 1;
+	npc_type->bodytype = 1;
+	npc_type->show_name = true;
+	npc_type->findable = true;
+	strn0cpy(npc_type->special_abilities, "24,1^35,1", 512);
 
 	auto node_position = glm::vec4(position.x, position.y, position.z, position.w);
-	auto npc           = new NPC(npc_type, nullptr, node_position, GravityBehavior::Flying);
-
-	npc->name[strlen(npc->name)-3] = (char) NULL;
-
+	auto npc = new NPC(npc_type, nullptr, node_position, GravityBehavior::Flying);
+	npc->name[strlen(npc->name) - 3] = (char) NULL;
 	npc->GiveNPCTypeData(npc_type);
-
+	npc->SetEntityVariable("grid_id", itoa(grid_id));
 	entity_list.AddNPC(npc);
 }
 

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -114,7 +114,7 @@ public:
 	virtual ~NPC();
 
 	static NPC *SpawnNodeNPC(std::string name, std::string last_name, const glm::vec4 &position);
-	static void SpawnGridNodeNPC(const glm::vec4 &position, int32 grid_number, int32 zoffset);
+	static void SpawnGridNodeNPC(const glm::vec4 &position, int32 grid_id, int32 grid_number, int32 zoffset);
 	static void SpawnZonePointNodeNPC(std::string name, const glm::vec4 &position);
 
 	//abstract virtual function implementations requird by base abstract class

--- a/zone/waypoints.cpp
+++ b/zone/waypoints.cpp
@@ -1036,6 +1036,24 @@ void ZoneDatabase::ModifyGrid(Client *client, bool remove, uint32 id, uint8 type
 	results = QueryDatabase(query);
 }
 
+bool ZoneDatabase::GridExistsInZone(uint32 zone_id, uint32 grid_id) {
+	bool grid_exists = false;
+	std::string query = fmt::format(
+		"SELECT * FROM `grid` WHERE `id` = {} AND `zoneid` = {}",
+		grid_id,
+		zone_id
+	);
+	auto results = QueryDatabase(query);
+	if (!results.Success()) {
+		return grid_exists;
+	}
+
+	if (results.RowCount() == 1) {
+		grid_exists = true;
+	}
+	return grid_exists;
+}
+
 /**************************************
 * AddWP - Adds a new waypoint to a specific grid for a specific zone.
 */

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -448,6 +448,7 @@ public:
 	void		AddWP(Client *c, uint32 gridid, uint32 wpnum, const glm::vec4& position, uint32 pause, uint16 zoneid);
 	uint32		AddWPForSpawn(Client *c, uint32 spawn2id, const glm::vec4& position, uint32 pause, int type1, int type2, uint16 zoneid);
 	void		ModifyGrid(Client *c, bool remove, uint32 id, uint8 type = 0, uint8 type2 = 0, uint16 zoneid = 0);
+	bool		GridExistsInZone(uint32 zone_id, uint32 grid_id);
 	void		ModifyWP(Client *c, uint32 grid_id, uint32 wp_num, const glm::vec3& location, uint32 script = 0, uint16 zoneid = 0);
 	uint8		GetGridType(uint32 grid, uint32 zoneid);
 	uint8		GetGridType2(uint32 grid, uint16 zoneid);


### PR DESCRIPTION
- #grid add will no longer let you put in a duplicate grid.
- Grid nodes now spawn with invul/immune to damage so they cannot be damage accidentally.
- Grid nodes now set an entity variable "grid_id" on spawn.
- This allows grid nodes to be specifically despawned by "grid_id" entity variable, meaning you can view multiple grids at once and not despawn them all accidentally.
- #grid hide will despawn your targeted NPC's Grid nodes.
- #grid add, #grid show, #grid delete, and #grid hide send messages to let GM know what's going on.
- #wp add and #wp delete now send messages to let the GM know what's going on.
- #wpadd now send messages to let the GM know what's going on.