### PR TITLE
[Merchants] Add Merchant databucket functionality.

### DIFF
--- a/common/eq_packet_structs.h
+++ b/common/eq_packet_structs.h
@@ -3618,14 +3618,17 @@ struct LevelAppearance_Struct { //Sends a little graphic on level up
 };
 
 struct MerchantList {
-	uint32	id;
-	uint32	slot;
-	uint32	item;
-	int16	faction_required;
-	int8	level_required;
-	uint16	alt_currency_cost;
-	uint32	classes_required;
-	uint8	probability;
+	uint32 id;
+	uint32 slot;
+	uint32 item;
+	int16 faction_required;
+	int8 level_required;
+	uint16 alt_currency_cost;
+	uint32 classes_required;
+	uint8 probability;
+	std::string bucket_name;
+	std::string bucket_value;
+	uint8 bucket_comparison; 
 };
 
 struct TempMerchantList {

--- a/common/version.h
+++ b/common/version.h
@@ -34,7 +34,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9167
+#define CURRENT_BINARY_DATABASE_VERSION 9168
 
 #ifdef BOTS
 	#define CURRENT_BINARY_BOTS_DATABASE_VERSION 9028

--- a/utils/sql/db_update_manifest.txt
+++ b/utils/sql/db_update_manifest.txt
@@ -421,6 +421,7 @@
 9165|2021_04_28_idle_pathing.sql|SHOW COLUMNS FROM `spawn2` LIKE 'path_when_zone_idle'|empty|
 9166|2021_02_12_dynamic_zone_members.sql|SHOW TABLES LIKE 'dynamic_zone_members'|empty|
 9167|2021_06_06_beastlord_pets.sql|SHOW TABLES LIKE 'pets_beastlord_data'|empty|
+9168|2021_06_14_merchant_data_buckets.sql|SHOW COLUMNS FROM `merchantlist` LIKE 'bucket_name'|empty|
 
 # Upgrade conditions:
 # 	This won't be needed after this system is implemented, but it is used database that are not

--- a/utils/sql/git/required/2021_06_14_merchant_data_buckets.sql
+++ b/utils/sql/git/required/2021_06_14_merchant_data_buckets.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `merchantlist` 
+ADD COLUMN `bucket_name` varchar(100) NOT NULL DEFAULT '' AFTER `probability`,
+ADD COLUMN `bucket_value` varchar(100) NOT NULL DEFAULT '' AFTER `bucket_name`,
+ADD COLUMN `bucket_comparison` tinyint UNSIGNED NULL DEFAULT 0 AFTER `bucket_value`;

--- a/zone/client.h
+++ b/zone/client.h
@@ -212,6 +212,15 @@ enum eInnateSkill {
 	InnateDisabled = 255
 };
 
+enum MerchantBucketComparison {
+	BucketEqualTo = 0,
+	BucketNotEqualTo,
+	BucketGreaterThanOrEqualTo,
+	BucketLesserThanOrEqualTo,
+	BucketGreaterThan,
+	BucketLesserThan
+};
+
 const uint32 POPUPID_UPDATE_SHOWSTATSWINDOW = 1000000;
 
 struct ClientReward

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -968,11 +968,10 @@ void Client::BulkSendMerchantInventory(int merchant_id, int npcid) {
 				handy_chance--;
 			}
 
-			int charges = item->MaxCharges;
-			EQ::ItemInstance* item_instance = database.CreateItem(item, charges);
+			auto item_charges = (item->MaxCharges > 0 ? item->MaxCharges : 1);
+			EQ::ItemInstance* item_instance = database.CreateItem(item, item_charges);
 			if (item_instance) {
 				auto item_price = (item->Price * (RuleR(Merchant, SellCostMod)) * item->SellRate);
-				auto item_charges = (charges > 0 ? item->MaxCharges : 1);
 				if (RuleB(Merchant, UsePriceMod)) {
 					item_price *= Client::CalcPriceMod(merchant, false);
 				}

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -601,7 +601,10 @@ void Zone::LoadNewMerchantData(uint32 merchantid) {
 			  level_required,
 			  alt_currency_cost,
 			  classes_required,
-			  probability
+			  probability,
+			  bucket_name,
+			  bucket_value,
+			  bucket_comparison
 			FROM
 			  merchantlist
 			WHERE
@@ -621,14 +624,17 @@ void Zone::LoadNewMerchantData(uint32 merchantid) {
 
 	for (auto row = results.begin(); row != results.end(); ++row) {
 		MerchantList ml;
-		ml.id                = merchantid;
-		ml.item              = atoul(row[0]);
-		ml.slot              = atoul(row[1]);
-		ml.faction_required  = atoul(row[2]);
-		ml.level_required    = atoul(row[3]);
+		ml.id = merchantid;
+		ml.item = atoul(row[0]);
+		ml.slot = atoul(row[1]);
+		ml.faction_required = atoul(row[2]);
+		ml.level_required = atoul(row[3]);
 		ml.alt_currency_cost = atoul(row[4]);
-		ml.classes_required  = atoul(row[5]);
-		ml.probability       = atoul(row[6]);
+		ml.classes_required = atoul(row[5]);
+		ml.probability = atoul(row[6]);
+		ml.bucket_name = row[7];
+		ml.bucket_value = row[8];
+		ml.bucket_comparison = atoul(row[9]);
 		merlist.push_back(ml);
 	}
 
@@ -647,7 +653,10 @@ void Zone::GetMerchantDataForZoneLoad() {
 			  merchantlist.level_required,
 			  merchantlist.alt_currency_cost,
 			  merchantlist.classes_required,
-			  merchantlist.probability
+			  merchantlist.probability,
+			  merchantlist.bucket_name,
+			  merchantlist.bucket_value,
+			  merchantlist.bucket_comparison
 			FROM
 			  merchantlist,
 			  npc_types,
@@ -677,7 +686,7 @@ void Zone::GetMerchantDataForZoneLoad() {
 		LogDebug("No Merchant Data found for [{}]", GetShortName());
 		return;
 	}
-	for (auto row = results.begin(); row != results.end(); ++row) {
+	for (auto row : results) {
 		MerchantList merchant_list_entry{};
 		merchant_list_entry.id = atoul(row[0]);
 		if (npc_id != merchant_list_entry.id) {
@@ -691,31 +700,30 @@ void Zone::GetMerchantDataForZoneLoad() {
 			npc_id = merchant_list_entry.id;
 		}
 
-		auto iter  = merchant_list->second.begin();
 		bool found = false;
-		while (iter != merchant_list->second.end()) {
-			if ((*iter).item == merchant_list_entry.id) {
+		for (auto current_item : merchant_list->second) {
+			if (current_item.item == merchant_list_entry.id) {
 				found = true;
 				break;
 			}
-			++iter;
 		}
 
 		if (found) {
 			continue;
 		}
 
-		merchant_list_entry.slot              = atoul(row[1]);
-		merchant_list_entry.item              = atoul(row[2]);
-		merchant_list_entry.faction_required  = atoul(row[3]);
-		merchant_list_entry.level_required    = atoul(row[4]);
+		merchant_list_entry.slot = atoul(row[1]);
+		merchant_list_entry.item = atoul(row[2]);
+		merchant_list_entry.faction_required = atoul(row[3]);
+		merchant_list_entry.level_required = atoul(row[4]);
 		merchant_list_entry.alt_currency_cost = atoul(row[5]);
-		merchant_list_entry.classes_required  = atoul(row[6]);
-		merchant_list_entry.probability       = atoul(row[7]);
-
+		merchant_list_entry.classes_required = atoul(row[6]);
+		merchant_list_entry.probability = atoul(row[7]);
+		merchant_list_entry.bucket_name = row[8];
+		merchant_list_entry.bucket_value = row[9];
+		merchant_list_entry.bucket_comparison = atoul(row[10]);
 		merchant_list->second.push_back(merchant_list_entry);
 	}
-
 }
 
 void Zone::LoadMercTemplates(){


### PR DESCRIPTION
- Allows server operators to limit merchant items based on data bucket values and comparisons.
- Adds 3 columns, `bucket_name`, `bucket_value`, and `bucket_comparison` to `merchantlist` table.
- Bucket is checked based on `character_id-bucket_name`.
- `bucket_comparison` Values are as follows:
  - `bucket_comparison` 0: `bucket_name` == `bucket_value`.
  - `bucket_comparison` 1: `bucket_name` != `bucket_value`.
  - `bucket_comparison` 2: `bucket_name` >= `bucket_value`.
  - `bucket_comparison` 3: `bucket_name` <= `bucket_value`.
  - `bucket_comparison` 4: `bucket_name` > `bucket_value`.
  - `bucket_comparison` 5: `bucket_name` < `bucket_value`.