### PR TITLE
[Typo Fix] Wizard evac saying the wrong zone

### DIFF
--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -495,7 +495,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 						LogDebug("Succor/Evacuation Spell In Same Zone");
 #endif
 							if(IsClient())
-								CastToClient()->MovePC(zone->GetZoneID(), zone->GetInstanceID(), x, y, z, heading, 0, EvacToSafeCoords);
+								CastToClient()->MovePC(zone->GetZoneID(), zone->GetInstanceID(), x, y, z, heading, 0, ZoneToSafeCoords);
 							else
 								GMMove(x, y, z, heading);
 					}


### PR DESCRIPTION
fix for issue brought up by @thalix1337 in issue #1442 this should solve the incorrect succor zone message being shown on the client