### PR TITLE
[Spells] Bug fix for AOE Harmony/Lull

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -1715,7 +1715,9 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 
 			case SE_ChangeFrenzyRad:
 			{
-				// redundant to have level check here
+				if (max != 0 && GetLevel() > max)
+					break;
+
 				if(new_bonus->AggroRange == -1 || effect_value < new_bonus->AggroRange)
 				{
 					new_bonus->AggroRange = static_cast<float>(effect_value);
@@ -1725,6 +1727,8 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 
 			case SE_Harmony:
 			{
+				if (max != 0 && GetLevel() > max)
+					break;
 				// Harmony effect as buff - kinda tricky
 				// harmony could stack with a lull spell, which has better aggro range
 				// take the one with less range in any case

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -837,7 +837,7 @@ public:
 	inline int16 GetSpellPowerDistanceMod() const { return SpellPowerDistanceMod; };
 	inline void SetSpellPowerDistanceMod(int16 value) { SpellPowerDistanceMod = value; };
 	int32 GetSpellStat(uint32 spell_id, const char *identifier, uint8 slot = 0);
-	bool HarmonySpellLevelCheck(int32 spell_id, int target_id, Mob* target = nullptr);
+	bool HarmonySpellLevelCheck(int32 spell_id, Mob* target = nullptr);
 	
 	void CastSpellOnLand(Mob* caster, uint32 spell_id);
 	void FocusProcLimitProcess();

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -837,7 +837,7 @@ public:
 	inline int16 GetSpellPowerDistanceMod() const { return SpellPowerDistanceMod; };
 	inline void SetSpellPowerDistanceMod(int16 value) { SpellPowerDistanceMod = value; };
 	int32 GetSpellStat(uint32 spell_id, const char *identifier, uint8 slot = 0);
-	bool HarmonySpellLevelCheck(int32 spell_id, int target_id);
+	bool HarmonySpellLevelCheck(int32 spell_id, int target_id, Mob* target = nullptr);
 	
 	void CastSpellOnLand(Mob* caster, uint32 spell_id);
 	void FocusProcLimitProcess();

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -837,6 +837,7 @@ public:
 	inline int16 GetSpellPowerDistanceMod() const { return SpellPowerDistanceMod; };
 	inline void SetSpellPowerDistanceMod(int16 value) { SpellPowerDistanceMod = value; };
 	int32 GetSpellStat(uint32 spell_id, const char *identifier, uint8 slot = 0);
+	bool HarmonySpellLevelCheck(int32 spell_id, int target_id);
 	
 	void CastSpellOnLand(Mob* caster, uint32 spell_id);
 	void FocusProcLimitProcess();

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -7416,27 +7416,18 @@ void Client::BreakFeignDeathWhenCastOn(bool IsResisted)
 	}
 }
 
-bool Mob::HarmonySpellLevelCheck(int32 spell_id, int target_id, Mob *target)
+bool Mob::HarmonySpellLevelCheck(int32 spell_id, Mob *target)
 {
 	//'this' = caster of spell
-	if (IsClient() && IsHarmonySpell(spell_id))
-	{
-		Mob *spell_target = nullptr;
+	if (!target) {
+		return false;
+	}
 
-		if (target_id)
-			spell_target = entity_list.GetMobID(target_id);
-		else
-			spell_target = target;
-
-		if (!spell_target)
-			return false;
-
-		for (int i = 0; i < EFFECT_COUNT; i++) {
-			// not important to check limit on SE_Lull as it doesnt have one and if the other components won't land, then SE_Lull wont either
-			if (spells[spell_id].effectid[i] == SE_ChangeFrenzyRad || spells[spell_id].effectid[i] == SE_Harmony) {
-				if ((spells[spell_id].max[i] != 0 && spell_target->GetLevel() > spells[spell_id].max[i]) || spell_target->GetSpecialAbility(IMMUNE_PACIFY)) {
-					return false;
-				}
+	for (int i = 0; i < EFFECT_COUNT; i++) {
+		// not important to check limit on SE_Lull as it doesnt have one and if the other components won't land, then SE_Lull wont either
+		if (spells[spell_id].effectid[i] == SE_ChangeFrenzyRad || spells[spell_id].effectid[i] == SE_Harmony) {
+			if ((spells[spell_id].max[i] != 0 && target->GetLevel() > spells[spell_id].max[i]) || target->GetSpecialAbility(IMMUNE_PACIFY)) {
+				return false;
 			}
 		}
 	}

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -7415,3 +7415,25 @@ void Client::BreakFeignDeathWhenCastOn(bool IsResisted)
 		MessageString(Chat::SpellFailure,FD_CAST_ON);
 	}
 }
+
+bool Mob::HarmonySpellLevelCheck(int32 spell_id, int target_id)
+{
+	//'this' = caster of spell
+	if (IsClient() && IsHarmonySpell(spell_id))
+	{
+		Mob *target = entity_list.GetMobID(target_id);
+
+		if (!target)
+			return false;
+
+		for (int i = 0; i < EFFECT_COUNT; i++) {
+			// not important to check limit on SE_Lull as it doesnt have one and if the other components won't land, then SE_Lull wont either
+			if (spells[spell_id].effectid[i] == SE_ChangeFrenzyRad || spells[spell_id].effectid[i] == SE_Harmony) {
+				if ((spells[spell_id].max[i] != 0 && target->GetLevel() > spells[spell_id].max[i]) || target->GetSpecialAbility(IMMUNE_PACIFY)) {
+					return false;
+				}
+			}
+		}
+	}
+	return true;
+}

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -7416,20 +7416,25 @@ void Client::BreakFeignDeathWhenCastOn(bool IsResisted)
 	}
 }
 
-bool Mob::HarmonySpellLevelCheck(int32 spell_id, int target_id)
+bool Mob::HarmonySpellLevelCheck(int32 spell_id, int target_id, Mob *target)
 {
 	//'this' = caster of spell
 	if (IsClient() && IsHarmonySpell(spell_id))
 	{
-		Mob *target = entity_list.GetMobID(target_id);
+		Mob *spell_target = nullptr;
 
-		if (!target)
+		if (target_id)
+			spell_target = entity_list.GetMobID(target_id);
+		else
+			spell_target = target;
+
+		if (!spell_target)
 			return false;
 
 		for (int i = 0; i < EFFECT_COUNT; i++) {
 			// not important to check limit on SE_Lull as it doesnt have one and if the other components won't land, then SE_Lull wont either
 			if (spells[spell_id].effectid[i] == SE_ChangeFrenzyRad || spells[spell_id].effectid[i] == SE_Harmony) {
-				if ((spells[spell_id].max[i] != 0 && target->GetLevel() > spells[spell_id].max[i]) || target->GetSpecialAbility(IMMUNE_PACIFY)) {
+				if ((spells[spell_id].max[i] != 0 && spell_target->GetLevel() > spells[spell_id].max[i]) || spell_target->GetSpecialAbility(IMMUNE_PACIFY)) {
 					return false;
 				}
 			}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -224,6 +224,11 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 	if (spellbonuses.NegateIfCombat)
 		BuffFadeByEffect(SE_NegateIfCombat);
 
+	if (!HarmonySpellLevelCheck(spell_id, target_id)) {
+		InterruptSpell(SPELL_NO_EFFECT, 0x121, spell_id);
+		return false;
+	}
+
 	if(IsClient() && GetTarget() && IsHarmonySpell(spell_id))
 	{
 		for(int i = 0; i < EFFECT_COUNT; i++) {

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -224,7 +224,7 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 	if (spellbonuses.NegateIfCombat)
 		BuffFadeByEffect(SE_NegateIfCombat);
 
-	if (!HarmonySpellLevelCheck(spell_id, target_id)) {
+	if (IsClient() && IsHarmonySpell(spell_id) && !HarmonySpellLevelCheck(spell_id, entity_list.GetMobID(target_id))) {
 		InterruptSpell(SPELL_NO_EFFECT, 0x121, spell_id);
 		return false;
 	}
@@ -3782,7 +3782,7 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, bool reflect, bool use_r
 		}
 	}
 	//Need this to account for special AOE cases.
-	if (!HarmonySpellLevelCheck(spell_id, 0, spelltar)) {
+	if (IsClient() && IsHarmonySpell(spell_id) && !HarmonySpellLevelCheck(spell_id, spelltar)) {
 		MessageString(Chat::SpellFailure, SPELL_NO_EFFECT);
 		return false;
 	}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -229,19 +229,6 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 		return false;
 	}
 
-	if(IsClient() && GetTarget() && IsHarmonySpell(spell_id))
-	{
-		for(int i = 0; i < EFFECT_COUNT; i++) {
-			// not important to check limit on SE_Lull as it doesnt have one and if the other components won't land, then SE_Lull wont either
-			if (spells[spell_id].effectid[i] == SE_ChangeFrenzyRad || spells[spell_id].effectid[i] == SE_Harmony) {
-				if((spells[spell_id].max[i] != 0 && GetTarget()->GetLevel() > spells[spell_id].max[i]) || GetTarget()->GetSpecialAbility(IMMUNE_PACIFY)) {
-					InterruptSpell(CANNOT_AFFECT_NPC, 0x121, spell_id);
-					return(false);
-				}
-			}
-		}
-	}
-
 	if (HasActiveSong() && IsBardSong(spell_id)) {
 		LogSpells("Casting a new song while singing a song. Killing old song [{}]", bardsong);
 		//Note: this does NOT tell the client
@@ -3794,6 +3781,12 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, bool reflect, bool use_r
 			return false;
 		}
 	}
+	//Need this to account for special AOE cases.
+	if (!HarmonySpellLevelCheck(spell_id, 0, spelltar)) {
+		MessageString(Chat::SpellFailure, SPELL_NO_EFFECT);
+		return false;
+	}
+			
 	// Block next spell effect should be used up first(since its blocking the next spell)
 	if(CanBlockSpell()) {
 		int buff_count = GetMaxTotalSlots();


### PR DESCRIPTION
Fixed bug with SPA 30 SE_SE_ChangeFrenzyRad and SPA 86 SE_Harmony allowing those spells to affect NPC's above their level restrictions when cast as a 'Targeted AE' spell (ie. Harmony, Wake of Tranquility) when the targeted NPC was bellow level restricted range, but the NPC's next to them were above it.

Implemented the live like behavior, if this case occurs on live, the buff is not applied to the targets over the level limit and "Your target looks unaffected" message is given. 

Also added additional layer of protection, even if somehow the buff does get on the target, the actual effect will not be applied to an NPC over the level limit.

This bug was originally reported by: Isaaru (7/26/21)