### PR TITLE
Implemented SPA 482 SE_Skill_Base_Damage_Mod

### DIFF
--- a/common/spdat.h
+++ b/common/spdat.h
@@ -825,7 +825,7 @@ typedef enum {
 //#define SE_Ff_Value_Min				479 //
 //#define SE_Ff_Value_Max				480 //
 #define SE_Fc_Cast_Spell_On_Land		481 // Implemented - [FOCUS] Spells cast on target with this Focus Effect will have chance to cause a Spell to be cast if limits met.
-//#define SE_Skill_Base_Damage_Mod		482 //
+#define SE_Skill_Base_Damage_Mod		482 // implemented, @OffBonus, modify base melee damage by percent, base: pct, limit: skill(-1=ALL), max: none
 #define SE_Fc_Spell_Damage_Pct_IncomingPC	483 // Implemented - [FOCUS] modifies incoming spell damage by percent
 #define SE_Fc_Spell_Damage_Amt_IncomingPC	484 // Implemented - [FOCUS] modifies incoming spell damage by flat amount. Typically adds damage to incoming spells.
 #define SE_Ff_CasterClass				485 // Implemented - [FOCUS LIMIT] Caster of spell on target with a focus effect that is checked by incoming spells must be specified class.

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -1177,6 +1177,17 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
+		case SE_Skill_Base_Damage_Mod: {
+			// Bad data or unsupported new skill
+			if (base2 > EQ::skills::HIGHEST_SKILL)
+				break;
+			if (base2 == ALL_SKILLS)
+				newbon->DamageModifier3[EQ::skills::HIGHEST_SKILL + 1] += base1;
+			else
+				newbon->DamageModifier3[base2] += base1;
+			break;
+		}
+
 		case SE_SlayUndead: {
 			if (newbon->SlayUndead[1] < base1)
 				newbon->SlayUndead[0] = base1; // Rate
@@ -2320,6 +2331,19 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 					new_bonus->DamageModifier2[skill] = effect_value;
 				else if (effect_value > 0 && new_bonus->DamageModifier2[skill] < effect_value)
 					new_bonus->DamageModifier2[skill] = effect_value;
+				break;
+			}
+
+			case SE_Skill_Base_Damage_Mod:
+			{
+				// Bad data or unsupported new skill
+				if (base2 > EQ::skills::HIGHEST_SKILL)
+					break;
+				int skill = base2 == ALL_SKILLS ? EQ::skills::HIGHEST_SKILL + 1 : base2;
+				if (effect_value < 0 && new_bonus->DamageModifier3[skill] > effect_value)
+					new_bonus->DamageModifier3[skill] = effect_value;
+				else if (effect_value > 0 && new_bonus->DamageModifier3[skill] < effect_value)
+					new_bonus->DamageModifier3[skill] = effect_value;
 				break;
 			}
 
@@ -4241,6 +4265,18 @@ void Mob::NegateSpellsBonuses(uint16 spell_id)
 					}
 					break;
 				}
+
+				case SE_Skill_Base_Damage_Mod:
+				{
+					for (int e = 0; e < EQ::skills::HIGHEST_SKILL + 1; e++)
+					{
+						spellbonuses.DamageModifier3[e] = effect_value;
+						aabonuses.DamageModifier3[e] = effect_value;
+						itembonuses.DamageModifier3[e] = effect_value;
+					}
+					break;
+				}
+
 
 				case SE_MinDamageModifier:
 				{

--- a/zone/common.h
+++ b/zone/common.h
@@ -442,6 +442,7 @@ struct StatBonuses {
 	int32	HitChanceEffect[EQ::skills::HIGHEST_SKILL + 2];	//Spell effect Chance to Hit, straight percent increase
 	int32	DamageModifier[EQ::skills::HIGHEST_SKILL + 2];	//i
 	int32	DamageModifier2[EQ::skills::HIGHEST_SKILL + 2];	//i
+	int32	DamageModifier3[EQ::skills::HIGHEST_SKILL + 2];	//i
 	int32	MinDamageModifier[EQ::skills::HIGHEST_SKILL + 2]; //i
 	int32	ProcChance;							// ProcChance/10 == % increase i = CombatEffects
 	int32	ProcChanceSPA;						// ProcChance from spell effects

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -4856,6 +4856,9 @@ int16 Mob::GetMeleeDamageMod_SE(uint16 skill)
 	dmg_mod += itembonuses.DamageModifier2[EQ::skills::HIGHEST_SKILL + 1] + spellbonuses.DamageModifier2[EQ::skills::HIGHEST_SKILL + 1] + aabonuses.DamageModifier2[EQ::skills::HIGHEST_SKILL + 1] +
 				itembonuses.DamageModifier2[skill] + spellbonuses.DamageModifier2[skill] + aabonuses.DamageModifier2[skill];
 
+	dmg_mod += itembonuses.DamageModifier3[EQ::skills::HIGHEST_SKILL + 1] + spellbonuses.DamageModifier3[EQ::skills::HIGHEST_SKILL + 1] + aabonuses.DamageModifier3[EQ::skills::HIGHEST_SKILL + 1] +
+		itembonuses.DamageModifier3[skill] + spellbonuses.DamageModifier3[skill] + aabonuses.DamageModifier3[skill];
+
 	if(dmg_mod < -100)
 		dmg_mod = -100;
 

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -3214,6 +3214,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 			case SE_Fc_Cast_Spell_On_Land:
 			case SE_Ff_CasterClass:
 			case SE_Ff_Same_Caster:
+			case SE_Skill_Base_Damage_Mod:
 			{
 				break;
 			}


### PR DESCRIPTION
Implemented new spell affect

SPA 482 SE_Skill_Base_Damage_Mod

Modifies base melee damage by skill 
Base: pct Limit: skill(-1=ALL), max: none

Stacks with SPA 189 and 482