### PR TITLE
Fix SE_TwinCastBlocker SPA 399 to also block twinproc

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -3702,9 +3702,6 @@ void Mob::TryTwincast(Mob *caster, Mob *target, uint32 spell_id)
 	if(!IsValidSpell(spell_id))
 		return;
 
-	if (IsEffectInSpell(spell_id, SE_TwinCastBlocker))
-		return;
-
 	if(IsClient())
 	{
 		int32 focus = CastToClient()->GetFocusEffect(focusTwincast, spell_id);

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -4811,7 +4811,7 @@ int16 Client::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 			break;
 
 		case SE_FcTwincast:
-			if (type == focusTwincast)
+			if (type == focusTwincast && !IsEffectInSpell(spell_id, SE_TwinCastBlocker))
 				value = base1;
 			break;
 
@@ -5381,7 +5381,7 @@ int16 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 			break;
 
 		case SE_FcTwincast:
-			if (type == focusTwincast)
+			if (type == focusTwincast && !IsEffectInSpell(spell_id, SE_TwinCastBlocker))
 				value = focus_spell.base[i];
 			break;
 


### PR DESCRIPTION
Improvement to SE_TwinCastBlocker SPA 399 implementation to catch all cases where twincast is used. 

Will now ensure both spell casted and weapon proced twincasts can be effectively blocked.