### PR TITLE
[Spells] Update SPA 339 SE_TriggerOnCast

### DIFF
--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -1282,3 +1282,14 @@ const char* GetSpellName(uint16 spell_id)
     return spells[spell_id].name;
 }
 
+bool SpellRequiresTarget(int spell_id)
+{
+	if (spells[spell_id].targettype == ST_AEClientV1 ||
+		spells[spell_id].targettype == ST_Self ||
+		spells[spell_id].targettype == ST_AECaster ||
+		spells[spell_id].targettype == ST_Ring ||
+		spells[spell_id].targettype == ST_Beam) {
+		return false;
+	}
+	return true;
+}

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1151,6 +1151,7 @@ bool IsStackableDot(uint16 spell_id);
 bool IsBardOnlyStackEffect(int effect);
 bool IsCastWhileInvis(uint16 spell_id);
 bool IsEffectIgnoredInStacking(int spa);
+bool SpellRequiresTarget(int targettype);
 
 int CalcPetHp(int levelb, int classb, int STA = 75);
 int GetSpellEffectDescNum(uint16 spell_id);

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -1065,19 +1065,6 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			}
 			break;
 
-		case SE_TriggerOnCast:
-
-			for (int i = 0; i < MAX_SPELL_TRIGGER; i++) {
-				if (newbon->SpellTriggers[i] == rank.id)
-					break;
-
-				if (!newbon->SpellTriggers[i]) {
-					// Save the 'rank.id' of each triggerable effect to an array
-					newbon->SpellTriggers[i] = rank.id;
-					break;
-				}
-			}
-			break;
 
 		case SE_CriticalHitChance: {
 			// Bad data or unsupported new skill
@@ -2538,19 +2525,6 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_TriggerOnCast:
-			{
-				for(int e = 0; e < MAX_SPELL_TRIGGER; e++)
-				{
-					if(!new_bonus->SpellTriggers[e])
-					{
-						new_bonus->SpellTriggers[e] = spell_id;
-						break;
-					}
-				}
-				break;
-			}
-
 			case SE_SpellCritChance:
 				new_bonus->CriticalSpellChance += effect_value;
 				break;
@@ -3820,8 +3794,7 @@ uint8 Mob::IsFocusEffect(uint16 spell_id,int effect_index, bool AA,uint32 aa_eff
 		case SE_ReduceReuseTimer:
 			return focusReduceRecastTime;
 		case SE_TriggerOnCast:
-			//return focusTriggerOnCast;
-			return 0; //This is calculated as an actual bonus
+			return focusTriggerOnCast;
 		case SE_FcSpellVulnerability:
 			return focusSpellVulnerability;
 		case SE_Fc_Spell_Damage_Pct_IncomingPC:
@@ -4434,17 +4407,6 @@ void Mob::NegateSpellsBonuses(uint16 spell_id)
 						aabonuses.SkillDmgTaken[e] = effect_value;
 						itembonuses.SkillDmgTaken[e] = effect_value;
 
-					}
-					break;
-				}
-
-				case SE_TriggerOnCast:
-				{
-					for(int e = 0; e < MAX_SPELL_TRIGGER; e++)
-					{
-						spellbonuses.SpellTriggers[e] = effect_value;
-						aabonuses.SpellTriggers[e] = effect_value;
-						itembonuses.SpellTriggers[e] = effect_value;
 					}
 					break;
 				}

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -359,6 +359,7 @@ int command_init(void)
 		command_add("repop", "[delay] - Repop the zone with optional delay", 100, command_repop) ||
 		command_add("resetaa", "- Resets a Player's AA in their profile and refunds spent AA's to unspent, may disconnect player.", 200, command_resetaa) ||
 		command_add("resetaa_timer", "Command to reset AA cooldown timers.", 200, command_resetaa_timer) ||
+		command_add("resetdisc_timer", "Command to reset all discipline cooldown timers.", 200, command_resetdisc_timer) ||
 		command_add("revoke", "[charname] [1/0] - Makes charname unable to talk on OOC", 200, command_revoke) ||
 		command_add("roambox", "Manages roambox settings for an NPC", 200, command_roambox) ||
 		command_add("rules", "(subcommand) - Manage server rules", 250, command_rules) ||
@@ -13722,6 +13723,32 @@ void command_resetaa_timer(Client *c, const Seperator *sep) {
 	else
 	{
 		c->Message(Chat::White, "usage: #resetaa_timer [all | timer_id]");
+	}
+}
+
+void command_resetdisc_timer(Client *c, const Seperator *sep) {
+	Client *target = nullptr;
+	if (!c->GetTarget() || !c->GetTarget()->IsClient()) {
+		target = c;
+	}
+	else {
+		target = c->GetTarget()->CastToClient();
+	}
+
+	if (sep->IsNumber(1))
+	{
+		int timer_id = atoi(sep->arg[1]);
+		c->Message(Chat::White, "Reset of disc timer %i for %s", timer_id, c->GetName());
+		c->ResetDisciplineTimer(timer_id);;
+	}
+	else if (!strcasecmp(sep->arg[1], "all"))
+	{
+		c->Message(Chat::White, "Reset all disc timers for %s", c->GetName());
+		c->ResetAllDisciplineTimers();
+	}
+	else
+	{
+		c->Message(Chat::White, "usage: #resetdisc_timer [all | timer_id]");
 	}
 }
 

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -13728,6 +13728,7 @@ void command_resetaa_timer(Client *c, const Seperator *sep) {
 
 void command_resetdisc_timer(Client *c, const Seperator *sep) {
 	Client *target = nullptr;
+
 	if (!c->GetTarget() || !c->GetTarget()->IsClient()) {
 		target = c;
 	}
@@ -13739,7 +13740,7 @@ void command_resetdisc_timer(Client *c, const Seperator *sep) {
 	{
 		int timer_id = atoi(sep->arg[1]);
 		c->Message(Chat::White, "Reset of disc timer %i for %s", timer_id, c->GetName());
-		c->ResetDisciplineTimer(timer_id);;
+		c->ResetDisciplineTimer(timer_id);
 	}
 	else if (!strcasecmp(sep->arg[1], "all"))
 	{

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -8122,31 +8122,31 @@ void command_summonitem(Client *c, const Seperator *sep)
 			).c_str()
 		);
 	}
-	
+
 	if (arguments >= 2 && sep->IsNumber(2)) {
 		charges = atoi(sep->arg[2]);
 	}
-	
+
 	if (arguments >= 3 && sep->IsNumber(3)) {
 		augment_one = atoi(sep->arg[3]);
 	}
-	
+
 	if (arguments >= 4 && sep->IsNumber(4)) {
 		augment_two = atoi(sep->arg[4]);
 	}
-	
+
 	if (arguments >= 5 && sep->IsNumber(5)) {
 		augment_three = atoi(sep->arg[5]);
 	}
-	
+
 	if (arguments >= 6 && sep->IsNumber(6)) {
 		augment_four = atoi(sep->arg[6]);
 	}
-	
+
 	if (arguments >= 7 && sep->IsNumber(7)) {
 		augment_five = atoi(sep->arg[7]);
 	}
-	
+
 	if (arguments == 8 && sep->IsNumber(8)) {
 		augment_six = atoi(sep->arg[8]);
 	}
@@ -8190,7 +8190,7 @@ void command_giveitem(Client *c, const Seperator *sep)
 			c->Message(Chat::Red, "Usage: #giveitem [item id | link] [charges] [augment_one_id] [augment_two_id] [augment_three_id] [augment_four_id] [augment_five_id] [augment_six_id] (Charges are optional.)");
 			return;
 		}
-		
+
 		Client *client_target = c->GetTarget()->CastToClient();
 		uint8 item_status = 0;
 		uint8 current_status = c->Admin();
@@ -8198,7 +8198,7 @@ void command_giveitem(Client *c, const Seperator *sep)
 		if (item) {
 			item_status = item->MinStatus;
 		}
-		
+
 		if (item_status > current_status) {
 			c->Message(
 				Chat::White,
@@ -8210,23 +8210,23 @@ void command_giveitem(Client *c, const Seperator *sep)
 			);
 			return;
 		}
-			
+
 		if (arguments >= 2 && sep->IsNumber(2)) {
 			charges = atoi(sep->arg[2]);
 		}
-		
+
 		if (arguments >= 3 && sep->IsNumber(3)) {
 			augment_one = atoi(sep->arg[3]);
 		}
-		
+
 		if (arguments >= 4 && sep->IsNumber(4)) {
 			augment_two = atoi(sep->arg[4]);
 		}
-		
+
 		if (arguments >= 5 && sep->IsNumber(5)) {
 			augment_three = atoi(sep->arg[5]);
 		}
-		
+
 		if (arguments >= 6 && sep->IsNumber(6)) {
 			augment_four = atoi(sep->arg[6]);
 		}
@@ -13726,29 +13726,23 @@ void command_resetaa_timer(Client *c, const Seperator *sep) {
 	}
 }
 
-void command_resetdisc_timer(Client *c, const Seperator *sep) {
-	Client *target = nullptr;
-
+void command_resetdisc_timer(Client *c, const Seperator *sep)
+{
+	Client *target = c->GetTarget()->CastToClient();
 	if (!c->GetTarget() || !c->GetTarget()->IsClient()) {
 		target = c;
 	}
-	else {
-		target = c->GetTarget()->CastToClient();
-	}
 
-	if (sep->IsNumber(1))
-	{
+	if (sep->IsNumber(1)) {
 		int timer_id = atoi(sep->arg[1]);
 		c->Message(Chat::White, "Reset of disc timer %i for %s", timer_id, c->GetName());
 		c->ResetDisciplineTimer(timer_id);
 	}
-	else if (!strcasecmp(sep->arg[1], "all"))
-	{
+	else if (!strcasecmp(sep->arg[1], "all")) {
 		c->Message(Chat::White, "Reset all disc timers for %s", c->GetName());
 		c->ResetAllDisciplineTimers();
 	}
-	else
-	{
+	else {
 		c->Message(Chat::White, "usage: #resetdisc_timer [all | timer_id]");
 	}
 }

--- a/zone/command.h
+++ b/zone/command.h
@@ -256,6 +256,7 @@ void command_reloadzps(Client *c, const Seperator *sep);
 void command_repop(Client *c, const Seperator *sep);
 void command_resetaa(Client* c,const Seperator *sep);
 void command_resetaa_timer(Client *c, const Seperator *sep);
+void command_resetdisc_timer(Client *c, const Seperator *sep);
 void command_revoke(Client *c, const Seperator *sep);
 void command_roambox(Client *c, const Seperator *sep);
 void command_rules(Client *c, const Seperator *sep);

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -3488,59 +3488,6 @@ void Mob::SetNimbusEffect(uint32 nimbus_effect)
 	}
 }
 
-void Mob::TryTriggerOnCast(uint32 spell_id, bool aa_trigger)
-{
-	if(!IsValidSpell(spell_id))
-			return;
-
-	if (aabonuses.SpellTriggers[0] || spellbonuses.SpellTriggers[0] || itembonuses.SpellTriggers[0]){
-
-		for(int i = 0; i < MAX_SPELL_TRIGGER; i++){
-
-			if(aabonuses.SpellTriggers[i] && IsClient())
-				TriggerOnCast(aabonuses.SpellTriggers[i], spell_id,1);
-
-			if(spellbonuses.SpellTriggers[i])
-				TriggerOnCast(spellbonuses.SpellTriggers[i], spell_id,0);
-
-			if(itembonuses.SpellTriggers[i])
-				TriggerOnCast(spellbonuses.SpellTriggers[i], spell_id,0);
-		}
-	}
-}
-
-void Mob::TriggerOnCast(uint32 focus_spell, uint32 spell_id, bool aa_trigger)
-{
-	if (!IsValidSpell(focus_spell) || !IsValidSpell(spell_id))
-		return;
-
-	uint32 trigger_spell_id = 0;
-
-	if (aa_trigger && IsClient()) {
-		// focus_spell = aaid
-		auto rank = zone->GetAlternateAdvancementRank(focus_spell);
-		if (rank)
-			trigger_spell_id = CastToClient()->CalcAAFocus(focusTriggerOnCast, *rank, spell_id);
-
-		if (IsValidSpell(trigger_spell_id) && GetTarget())
-			SpellFinished(trigger_spell_id, GetTarget(), EQ::spells::CastingSlot::Item, 0, -1,
-				      spells[trigger_spell_id].ResistDiff);
-	}
-
-	else {
-		trigger_spell_id = CalcFocusEffect(focusTriggerOnCast, focus_spell, spell_id);
-
-		if (IsValidSpell(trigger_spell_id) && GetTarget()) {
-			SpellFinished(trigger_spell_id, GetTarget(), EQ::spells::CastingSlot::Item, 0, -1,
-				      spells[trigger_spell_id].ResistDiff);
-			CheckNumHitsRemaining(NumHit::MatchingSpells, -1, focus_spell);
-		}
-	}
-}
-
-
-
-
 bool Mob::TrySpellTrigger(Mob *target, uint32 spell_id, int effect)
 {
 	if (!target || !IsValidSpell(spell_id))

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -791,8 +791,8 @@ public:
 	bool TryDeathSave();
 	bool TryDivineSave();
 	void DoBuffWearOffEffect(uint32 index);
-	void TryTriggerOnCast(uint32 spell_id, bool aa_trigger);
-	void TriggerOnCast(uint32 focus_spell, uint32 spell_id, bool aa_trigger);
+	void TryTriggerOnCastFocusEffect(focusType type, uint16 spell_id);
+	bool TryTriggerOnCastProc(uint16 focusspellid, uint16 spell_id, uint16 proc_spellid);
 	bool TrySpellTrigger(Mob *target, uint32 spell_id, int effect);
 	void TryTriggerOnValueAmount(bool IsHP = false, bool IsMana = false, bool IsEndur = false, bool IsPet = false);
 	void TryTwincast(Mob *caster, Mob *target, uint32 spell_id);

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -5582,9 +5582,8 @@ void Mob::TryTriggerOnCastFocusEffect(focusType type, uint16 spell_id) {
 			proc_spellid = CalcFocusEffect(type, focus_spell_id, spell_id);
 			if (proc_spellid) {
 				TryTriggerOnCastProc(focus_spell_id, spell_id, proc_spellid);
+				CheckNumHitsRemaining(NumHit::MatchingSpells, buff_slot);
 			}
-			
-			CheckNumHitsRemaining(NumHit::MatchingSpells, buff_slot);
 		}
 	}
 	//Only use of this focus per AA effect.
@@ -5613,7 +5612,7 @@ bool Mob::TryTriggerOnCastProc(uint16 focusspellid, uint16 spell_id, uint16 proc
 {
 	//We confirm spell_id and focuspellid are valid before passing into this.
 	if (IsValidSpell(proc_spellid) && spell_id != focusspellid && spell_id != proc_spellid) {
-		Mob* target = target = GetTarget();
+		Mob* target = GetTarget();
 
 		if (target) {
 			SpellFinished(proc_spellid, target, EQ::spells::CastingSlot::Item, 0, -1, spells[proc_spellid].ResistDiff);

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -5544,8 +5544,7 @@ void Mob::TryTriggerOnCastFocusEffect(focusType type, uint16 spell_id) {
 
 			for (int y = EQ::invaug::SOCKET_BEGIN; y <= EQ::invaug::SOCKET_END; ++y)
 			{
-				EQ::ItemInstance *aug = nullptr;
-				aug = ins->GetAugment(y);
+				EQ::ItemInstance *aug = ins->GetAugment(y);
 				if (aug)
 				{
 					const EQ::ItemData* temp_item_aug = aug->GetItem();
@@ -5588,6 +5587,7 @@ void Mob::TryTriggerOnCastFocusEffect(focusType type, uint16 spell_id) {
 	}
 	//Only use of this focus per AA effect.
 	if (IsClient() && aabonuses.FocusEffects[type]) {
+
 		for (const auto &aa : aa_ranks) {
 
 			auto ability_rank = zone->GetAlternateAdvancementAbilityAndRank(aa.first, aa.second.first);

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -5514,8 +5514,8 @@ void Mob::TryTriggerOnCastFocusEffect(focusType type, uint16 spell_id) {
 		return;
 	}
 
-	uint16 focus_spell_id = 0;
-	uint16 proc_spellid = 0;
+	int32 focus_spell_id = 0;
+	int32 proc_spellid = 0;
 	//item focus
 	if  (IsClient() && itembonuses.FocusEffects[type]) {
 
@@ -5616,10 +5616,15 @@ bool Mob::TryTriggerOnCastProc(uint16 focusspellid, uint16 spell_id, uint16 proc
 
 		if (target) {
 			SpellFinished(proc_spellid, target, EQ::spells::CastingSlot::Item, 0, -1, spells[proc_spellid].ResistDiff);
-			return 1;
+			return true;
+		}
+		//Edge cases where proc spell does not require a target such as PBAE, allows proc to still occur even if target potentially dead. Live spells exist with PBAE procs.
+		else if (!SpellRequiresTarget(proc_spellid)) {
+			SpellFinished(proc_spellid, this, EQ::spells::CastingSlot::Item, 0, -1, spells[proc_spellid].ResistDiff);
+			return true;
 		}
 	}
-	return 0;
+	return false;
 }
 
 uint16 Client::GetSympatheticFocusEffect(focusType type, uint16 spell_id) {

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -5569,7 +5569,8 @@ void Mob::TryTriggerOnCastFocusEffect(focusType type, uint16 spell_id) {
 	//Spell Focus
 	if (spellbonuses.FocusEffects[type]) {
 
-		for (int buff_slot = 0; buff_slot < GetMaxTotalSlots(); buff_slot++) {
+		int buff_slot = 0;
+		for (buff_slot = 0; buff_slot < GetMaxTotalSlots(); buff_slot++) {
 
 			focus_spell_id = buffs[buff_slot].spellid;
 			if (!IsValidSpell(focus_spell_id))
@@ -5583,7 +5584,7 @@ void Mob::TryTriggerOnCastFocusEffect(focusType type, uint16 spell_id) {
 				TryTriggerOnCastProc(focus_spell_id, spell_id, proc_spellid);
 			}
 			
-			CheckNumHitsRemaining(NumHit::MatchingSpells, -1, focus_spell_id);
+			CheckNumHitsRemaining(NumHit::MatchingSpells, buff_slot);
 		}
 	}
 	//Only use of this focus per AA effect.

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -2903,10 +2903,10 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 
 				if (zone->random.Roll(spells[spell_id].base[i]) && IsValidSpell(spells[spell_id].base2[i]))
 						caster->SpellFinished(spells[spell_id].base2[i], this, EQ::spells::CastingSlot::Item, 0, -1, spells[spells[spell_id].base2[i]].ResistDiff);
-				
+
 				break;
 			}
-					
+
 			case SE_Hatelist_To_Tail_Index: {
 				if (caster && zone->random.Roll(spells[spell_id].base[i]))
 					caster->SetBottomRampageList();
@@ -2940,7 +2940,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					else
 						Stun(spells[spell_id].base[i]);
 				}
-				else 
+				else
 					caster->MessageString(Chat::SpellFailure, FEAR_TOO_HIGH);
 				break;
 			}
@@ -2949,7 +2949,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				buffs[buffslot].focusproclimit_procamt = spells[spell_id].base[i]; //Set max amount of procs before lockout timer
 				break;
 			}
-	
+
 			case SE_PersistentEffect:
 				MakeAura(spell_id);
 				break;
@@ -3928,11 +3928,11 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 			int32 amt = abs(GetMaxHP() * effect_value / 100);
 			if (spells[buff.spellid].max[i] && amt > spells[buff.spellid].max[i])
 				amt = spells[buff.spellid].max[i];
-			
-			if (effect_value < 0) { 
+
+			if (effect_value < 0) {
 				Damage(this, amt, 0, EQ::skills::SkillEvocation, false);
 			}
-			else { 
+			else {
 				HealDamage(amt);
 			}
 			break;
@@ -3945,7 +3945,7 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 				amt = spells[buff.spellid].max[i];
 
 			if (effect_value < 0) {
-				
+
 				SetMana(GetMana() - amt);
 			}
 			else {
@@ -5504,8 +5504,8 @@ int16 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 	return (value * lvlModifier / 100);
 }
 
-void Mob::TryTriggerOnCastFocusEffect(focusType type, uint16 spell_id) {
-
+void Mob::TryTriggerOnCastFocusEffect(focusType type, uint16 spell_id)
+{
 	if (IsBardSong(spell_id)) {
 		return;
 	}
@@ -5515,22 +5515,20 @@ void Mob::TryTriggerOnCastFocusEffect(focusType type, uint16 spell_id) {
 	}
 
 	int32 focus_spell_id = 0;
-	int32 proc_spellid = 0;
-	//item focus
-	if  (IsClient() && itembonuses.FocusEffects[type]) {
+	int32 proc_spellid   = 0;
 
-		const EQ::ItemData* temp_item = nullptr;
+	// item focus
+	if (IsClient() && itembonuses.FocusEffects[type]) {
+		const EQ::ItemData *temp_item = nullptr;
 
-		for (int x = EQ::invslot::EQUIPMENT_BEGIN; x <= EQ::invslot::EQUIPMENT_END; x++)
-		{
+		for (int x = EQ::invslot::EQUIPMENT_BEGIN; x <= EQ::invslot::EQUIPMENT_END; x++) {
 			temp_item = nullptr;
-			EQ::ItemInstance* ins = CastToClient()->GetInv().GetItem(x);
+			EQ::ItemInstance *ins = CastToClient()->GetInv().GetItem(x);
 			if (!ins) {
 				continue;
 			}
 			temp_item = ins->GetItem();
 			if (temp_item && temp_item->Focus.Effect > 0 && IsValidSpell(temp_item->Focus.Effect)) {
-
 				focus_spell_id = temp_item->Focus.Effect;
 				if (!IsEffectInSpell(focus_spell_id, SE_TriggerOnCast)) {
 					continue;
@@ -5542,14 +5540,11 @@ void Mob::TryTriggerOnCastFocusEffect(focusType type, uint16 spell_id) {
 				}
 			}
 
-			for (int y = EQ::invaug::SOCKET_BEGIN; y <= EQ::invaug::SOCKET_END; ++y)
-			{
+			for (int y = EQ::invaug::SOCKET_BEGIN; y <= EQ::invaug::SOCKET_END; ++y) {
 				EQ::ItemInstance *aug = ins->GetAugment(y);
-				if (aug)
-				{
-					const EQ::ItemData* temp_item_aug = aug->GetItem();
+				if (aug) {
+					const EQ::ItemData *temp_item_aug = aug->GetItem();
 					if (temp_item_aug && temp_item_aug->Focus.Effect > 0 && IsValidSpell(temp_item_aug->Focus.Effect)) {
-
 						focus_spell_id = temp_item_aug->Focus.Effect;
 
 						if (!IsEffectInSpell(focus_spell_id, SE_TriggerOnCast)) {
@@ -5565,18 +5560,19 @@ void Mob::TryTriggerOnCastFocusEffect(focusType type, uint16 spell_id) {
 			}
 		}
 	}
-	//Spell Focus
-	if (spellbonuses.FocusEffects[type]) {
 
+	// Spell Focus
+	if (spellbonuses.FocusEffects[type]) {
 		int buff_slot = 0;
 		for (buff_slot = 0; buff_slot < GetMaxTotalSlots(); buff_slot++) {
-
 			focus_spell_id = buffs[buff_slot].spellid;
-			if (!IsValidSpell(focus_spell_id))
+			if (!IsValidSpell(focus_spell_id)) {
 				continue;
+			}
 
-			if (!IsEffectInSpell(focus_spell_id, SE_TriggerOnCast))
+			if (!IsEffectInSpell(focus_spell_id, SE_TriggerOnCast)) {
 				continue;
+			}
 
 			proc_spellid = CalcFocusEffect(type, focus_spell_id, spell_id);
 			if (proc_spellid) {
@@ -5585,20 +5581,21 @@ void Mob::TryTriggerOnCastFocusEffect(focusType type, uint16 spell_id) {
 			}
 		}
 	}
-	//Only use of this focus per AA effect.
+
+	// Only use of this focus per AA effect.
 	if (IsClient() && aabonuses.FocusEffects[type]) {
-
 		for (const auto &aa : aa_ranks) {
-
 			auto ability_rank = zone->GetAlternateAdvancementAbilityAndRank(aa.first, aa.second.first);
-			auto ability = ability_rank.first;
-			auto rank = ability_rank.second;
+			auto ability      = ability_rank.first;
+			auto rank         = ability_rank.second;
 
-			if (!ability) 
+			if (!ability) {
 				continue;
+			}
 
-			if (rank->effects.empty())
+			if (rank->effects.empty()) {
 				continue;
+			}
 
 			proc_spellid = CastToClient()->CalcAAFocus(type, *rank, spell_id);
 			if (proc_spellid) {
@@ -5610,15 +5607,14 @@ void Mob::TryTriggerOnCastFocusEffect(focusType type, uint16 spell_id) {
 
 bool Mob::TryTriggerOnCastProc(uint16 focusspellid, uint16 spell_id, uint16 proc_spellid)
 {
-	//We confirm spell_id and focuspellid are valid before passing into this.
+	// We confirm spell_id and focuspellid are valid before passing into this.
 	if (IsValidSpell(proc_spellid) && spell_id != focusspellid && spell_id != proc_spellid) {
-		Mob* target = GetTarget();
-
-		if (target) {
-			SpellFinished(proc_spellid, target, EQ::spells::CastingSlot::Item, 0, -1, spells[proc_spellid].ResistDiff);
+		Mob* proc_target = GetTarget();
+		if (proc_target) {
+			SpellFinished(proc_spellid, proc_target, EQ::spells::CastingSlot::Item, 0, -1, spells[proc_spellid].ResistDiff);
 			return true;
 		}
-		//Edge cases where proc spell does not require a target such as PBAE, allows proc to still occur even if target potentially dead. Live spells exist with PBAE procs.
+		// Edge cases where proc spell does not require a target such as PBAE, allows proc to still occur even if target potentially dead. Live spells exist with PBAE procs.
 		else if (!SpellRequiresTarget(proc_spellid)) {
 			SpellFinished(proc_spellid, this, EQ::spells::CastingSlot::Item, 0, -1, spells[proc_spellid].ResistDiff);
 			return true;
@@ -7310,7 +7306,7 @@ void Mob::CastSpellOnLand(Mob* caster, uint32 spell_id)
 	the CalcFocusEffect function if not 100pct.
 	ApplyFocusProcLimiter() function checks for SE_Proc_Timer_Modifier which allows for limiting how often a spell from effect can be triggered
 	for example, if set to base=1 and base2= 1500, then for everyone 1 successful trigger, you will be unable to trigger again for 1.5 seconds.
-	
+
 	Live only has this focus in buffs/debuffs that can be placed on a target. TODO: Will consider adding support for it as AA and Item.
 	*/
 	if (!caster)
@@ -7344,7 +7340,7 @@ void Mob::CastSpellOnLand(Mob* caster, uint32 spell_id)
 								SpellFinished(trigger_spell_id, current_target, EQ::spells::CastingSlot::Item, 0, -1, spells[trigger_spell_id].ResistDiff);
 						}
 					}
-				
+
 					if (i >= 0)
 						CheckNumHitsRemaining(NumHit::MatchingSpells, i);
 				}
@@ -7360,13 +7356,13 @@ bool Mob::ApplyFocusProcLimiter(uint32 spell_id, int buffslot)
 
 	//Do not allow spell cast if timer is active.
 	if (buffs[buffslot].focusproclimit_time > 0)
-		return false; 
+		return false;
 
 	/*
-	SE_Proc_Timer_Modifier 
+	SE_Proc_Timer_Modifier
 	base1= amount of total procs allowed until lock out timer is triggered, should be set to at least 1 in any spell for the effect to function.
 	base2= lock out timer, which prevents any more procs set in ms 1500 = 1.5 seconds
-	This system allows easy scaling for multiple different buffs with same effects each having seperate active individual timer checks. Ie. 
+	This system allows easy scaling for multiple different buffs with same effects each having seperate active individual timer checks. Ie.
 	*/
 
 	if (IsValidSpell(spell_id)) {
@@ -7393,7 +7389,7 @@ bool Mob::ApplyFocusProcLimiter(uint32 spell_id, int buffslot)
 						if (!focus_proc_limit_timer.Enabled()) {
 							focus_proc_limit_timer.Start(250);
 						}
-				
+
 						return true;
 					}
 				}

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -5506,37 +5506,40 @@ int16 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 
 void Mob::TryTriggerOnCastFocusEffect(focusType type, uint16 spell_id) {
 
-	if (IsBardSong(spell_id))
+	if (IsBardSong(spell_id)) {
 		return;
+	}
 
-	if (!IsValidSpell(spell_id))
+	if (!IsValidSpell(spell_id)) {
 		return;
+	}
 
-	uint16 focusspellid = 0;
+	uint16 focus_spell_id = 0;
 	uint16 proc_spellid = 0;
-
 	//item focus
 	if  (IsClient() && itembonuses.FocusEffects[type]) {
 
-		const EQ::ItemData* TempItem = nullptr;
+		const EQ::ItemData* temp_item = nullptr;
 
 		for (int x = EQ::invslot::EQUIPMENT_BEGIN; x <= EQ::invslot::EQUIPMENT_END; x++)
 		{
-
-			TempItem = nullptr;
+			temp_item = nullptr;
 			EQ::ItemInstance* ins = CastToClient()->GetInv().GetItem(x);
-			if (!ins)
+			if (!ins) {
 				continue;
-			TempItem = ins->GetItem();
-			if (TempItem && TempItem->Focus.Effect > 0 && IsValidSpell(TempItem->Focus.Effect)) {
+			}
+			temp_item = ins->GetItem();
+			if (temp_item && temp_item->Focus.Effect > 0 && IsValidSpell(temp_item->Focus.Effect)) {
 
-				focusspellid = TempItem->Focus.Effect;
-				if (!IsEffectInSpell(focusspellid, SE_TriggerOnCast))
+				focus_spell_id = temp_item->Focus.Effect;
+				if (!IsEffectInSpell(focus_spell_id, SE_TriggerOnCast)) {
 					continue;
+				}
 
-				proc_spellid = CalcFocusEffect(type, focusspellid, spell_id);
-				if (proc_spellid)
-					TryTriggerOnCastProc(focusspellid, spell_id, proc_spellid);
+				proc_spellid = CalcFocusEffect(type, focus_spell_id, spell_id);
+				if (proc_spellid) {
+					TryTriggerOnCastProc(focus_spell_id, spell_id, proc_spellid);
+				}
 			}
 
 			for (int y = EQ::invaug::SOCKET_BEGIN; y <= EQ::invaug::SOCKET_END; ++y)
@@ -5545,44 +5548,44 @@ void Mob::TryTriggerOnCastFocusEffect(focusType type, uint16 spell_id) {
 				aug = ins->GetAugment(y);
 				if (aug)
 				{
-					const EQ::ItemData* TempItemAug = aug->GetItem();
-					if (TempItemAug && TempItemAug->Focus.Effect > 0 && IsValidSpell(TempItemAug->Focus.Effect)) {
+					const EQ::ItemData* temp_item_aug = aug->GetItem();
+					if (temp_item_aug && temp_item_aug->Focus.Effect > 0 && IsValidSpell(temp_item_aug->Focus.Effect)) {
 
-						focusspellid = TempItemAug->Focus.Effect;
+						focus_spell_id = temp_item_aug->Focus.Effect;
 
-						if (!IsEffectInSpell(focusspellid, SE_TriggerOnCast))
+						if (!IsEffectInSpell(focus_spell_id, SE_TriggerOnCast)) {
 							continue;
+						}
 
-						proc_spellid = CalcFocusEffect(type, focusspellid, spell_id);
-						if (proc_spellid)
-							TryTriggerOnCastProc(focusspellid, spell_id, proc_spellid);
+						proc_spellid = CalcFocusEffect(type, focus_spell_id, spell_id);
+						if (proc_spellid) {
+							TryTriggerOnCastProc(focus_spell_id, spell_id, proc_spellid);
+						}
 					}
 				}
 			}
 		}
 	}
-
 	//Spell Focus
 	if (spellbonuses.FocusEffects[type]) {
-		int buff_slot = 0;
-		int buff_max = GetMaxTotalSlots();
-		for (buff_slot = 0; buff_slot < buff_max; buff_slot++) {
 
-			focusspellid = buffs[buff_slot].spellid;
-			if (!IsValidSpell(focusspellid))
+		for (int buff_slot = 0; buff_slot < GetMaxTotalSlots(); buff_slot++) {
+
+			focus_spell_id = buffs[buff_slot].spellid;
+			if (!IsValidSpell(focus_spell_id))
 				continue;
 
-			if (!IsEffectInSpell(focusspellid, SE_TriggerOnCast))
+			if (!IsEffectInSpell(focus_spell_id, SE_TriggerOnCast))
 				continue;
 
-			proc_spellid = CalcFocusEffect(type, focusspellid, spell_id);
-			if (proc_spellid)
-				TryTriggerOnCastProc(focusspellid, spell_id, proc_spellid);
+			proc_spellid = CalcFocusEffect(type, focus_spell_id, spell_id);
+			if (proc_spellid) {
+				TryTriggerOnCastProc(focus_spell_id, spell_id, proc_spellid);
+			}
 			
-			CheckNumHitsRemaining(NumHit::MatchingSpells, -1, focusspellid);
+			CheckNumHitsRemaining(NumHit::MatchingSpells, -1, focus_spell_id);
 		}
 	}
-
 	//Only use of this focus per AA effect.
 	if (IsClient() && aabonuses.FocusEffects[type]) {
 		for (const auto &aa : aa_ranks) {
@@ -5598,8 +5601,9 @@ void Mob::TryTriggerOnCastFocusEffect(focusType type, uint16 spell_id) {
 				continue;
 
 			proc_spellid = CastToClient()->CalcAAFocus(type, *rank, spell_id);
-			if (proc_spellid)
+			if (proc_spellid) {
 				TryTriggerOnCastProc(0, spell_id, proc_spellid);
+			}
 		}
 	}
 }
@@ -5608,8 +5612,8 @@ bool Mob::TryTriggerOnCastProc(uint16 focusspellid, uint16 spell_id, uint16 proc
 {
 	//We confirm spell_id and focuspellid are valid before passing into this.
 	if (IsValidSpell(proc_spellid) && spell_id != focusspellid && spell_id != proc_spellid) {
-		Mob* target = nullptr;
-		target = GetTarget();
+		Mob* target = target = GetTarget();
+
 		if (target) {
 			SpellFinished(proc_spellid, target, EQ::spells::CastingSlot::Item, 0, -1, spells[proc_spellid].ResistDiff);
 			return 1;

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -1384,11 +1384,11 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 		TrySympatheticProc(target, spell_id);
 	}
 
-	TryOnSpellFinished(this, target, spell_id);
+	TryOnSpellFinished(this, target, spell_id); //Use for effects that should be checked after SpellFinished is completed.
 
 	TryTwincast(this, target, spell_id);
 
-	TryTriggerOnCast(spell_id, 0);
+	TryTriggerOnCastFocusEffect(focusTriggerOnCast, spell_id);
 
 	if(DeleteChargeFromSlot >= 0)
 		CastToClient()->DeleteItemInInventory(DeleteChargeFromSlot, 1, true);


### PR DESCRIPTION
Rewrote the functions that handle the focus effect SPA 339 SE_TriggerOnCast
As reminder, the effect works as a focus that gives a chance to cast an additional spell whenever a spell is cast is conditions are met. Base1: Chance Base2:  spell_id

This focus was not coded consistently to how other focus effects are checked. There is no longer an arbitrary max number focuses with this effect that a player can have. Overall it works well now, fits with rest of foci code, and is easier to manage.

Also added #command resetdisc_timer
usage: #resetdisc_timer [all | timer_id]