### PR TITLE
[Spells] Update to SPA 335 SE_BlockNextSpellFocus

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -2750,10 +2750,6 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_BlockNextSpellFocus:
-				new_bonus->BlockNextSpell = true;
-				break;
-
 			case SE_NegateSpellEffect:
 				new_bonus->NegateEffects = true;
 				break;
@@ -3827,8 +3823,7 @@ uint8 Mob::IsFocusEffect(uint16 spell_id,int effect_index, bool AA,uint32 aa_eff
 		case SE_Fc_Spell_Damage_Pct_IncomingPC:
 			return focusFcSpellDamagePctIncomingPC;
 		case SE_BlockNextSpellFocus:
-			//return focusBlockNextSpell;
-			return 0; //This is calculated as an actual bonus
+			return focusBlockNextSpell;
 		case SE_FcTwincast:
 			return focusTwincast;
 		case SE_SympatheticProc:

--- a/zone/common.h
+++ b/zone/common.h
@@ -483,8 +483,6 @@ struct StatBonuses {
 	int		HPPercCap[2];						//Spell effect that limits you to being healed/regening beyond a % of your max
 	int		ManaPercCap[2];						// ^^ 0 = % Cap 1 = Flat Amount Cap
 	int		EndPercCap[2];						// ^^
-	bool	BlockNextSpell;						// Indicates whether the client can block a spell or not
-	//uint16	BlockSpellEffect[EFFECT_COUNT];		// Prevents spells with certain effects from landing on you *no longer used
 	bool	ImmuneToFlee;						// Bypass the fleeing flag
 	uint32	VoiceGraft;							// Stores the ID of the mob with which to talk through
 	int32	SpellProcChance;					// chance to proc from sympathetic spell effects

--- a/zone/lua_stat_bonuses.cpp
+++ b/zone/lua_stat_bonuses.cpp
@@ -677,7 +677,7 @@ int Lua_StatBonuses::GetXPRateMod() const {
 
 bool Lua_StatBonuses::GetBlockNextSpell() const {
 	Lua_Safe_Call_Bool();
-	return self->BlockNextSpell;
+	//return self->BlockNextSpell; bonus no longer used due to effect being a focus
 }
 
 bool Lua_StatBonuses::GetImmuneToFlee() const {

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -823,7 +823,7 @@ public:
 	int GetCriticalChanceBonus(uint16 skill);
 	int16 GetSkillDmgAmt(uint16 skill);
 	bool TryReflectSpell(uint32 spell_id);
-	bool CanBlockSpell() const { return(spellbonuses.BlockNextSpell); }
+	inline bool CanBlockSpell() const { return(spellbonuses.FocusEffects[focusBlockNextSpell]); }
 	bool DoHPToManaCovert(uint16 mana_cost = 0);
 	int32 ApplySpellEffectiveness(int16 spell_id, int32 value, bool IsBard = false, uint16 caster_id=0);
 	int8 GetDecayEffectValue(uint16 spell_id, uint16 spelleffect);


### PR DESCRIPTION
Update to SPA 335 SE_BlockNextSpellFocus code.

Minor code changes to make the focus be checked consistent with how all other focuses are checked. No change in functionality.

Reminder functionality, Focus checks on caste for a chance to block next incoming spell if conditions are met. 
base: chance limit: none max: none
You specify which spells are to be blocked using focus limiters.