### PR TITLE
[Spells] Update to SPA 130 and SPA 131 focus calculation, focus code improvements

### DIFF
--- a/zone/mob.h
+++ b/zone/mob.h
@@ -838,6 +838,8 @@ public:
 	inline void SetSpellPowerDistanceMod(int16 value) { SpellPowerDistanceMod = value; };
 	int32 GetSpellStat(uint32 spell_id, const char *identifier, uint8 slot = 0);
 	bool HarmonySpellLevelCheck(int32 spell_id, Mob* target = nullptr);
+	bool CanFocusUseRandomEffectivenessByType(focusType type);
+	int GetFocusRandomEffectivenessValue(int focus_base, int focus_base2, bool best_focus = 0);
 	
 	void CastSpellOnLand(Mob* caster, uint32 spell_id);
 	void FocusProcLimitProcess();

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -5640,7 +5640,7 @@ int16 Client::GetFocusEffect(focusType type, uint16 spell_id)
 
 	//Improved Healing, Damage & Mana Reduction are handled differently in that some are random percentages
 	//In these cases we need to find the most powerful effect, so that each piece of gear wont get its own chance
-	if(RuleB(Spells, LiveLikeFocusEffects) && (type == focusManaCost || type == focusImprovedHeal || type == focusImprovedDamage || type == focusImprovedDamage2 || type == focusResistRate))
+	if(RuleB(Spells, LiveLikeFocusEffects) && CanFocusUseRandomEffectivenessByType(type))
 		rand_effectiveness = true;
 
 	//Check if item focus effect exists for the client.
@@ -7458,4 +7458,47 @@ bool Mob::HarmonySpellLevelCheck(int32 spell_id, Mob *target)
 		}
 	}
 	return true;
+}
+
+
+bool Mob::CanFocusUseRandomEffectivenessByType(focusType type)
+{
+	switch (type)
+	{
+	case focusImprovedDamage:
+	case focusImprovedDamage2:
+	case focusImprovedHeal:
+	case focusManaCost:
+	case focusResistRate:
+	case focusFcDamagePctCrit:
+	case focusReagentCost:
+	case focusSpellHateMod:
+		return 1;
+	}
+	return 0;
+}
+
+int Mob::GetFocusRandomEffectivenessValue(int focus_base, int focus_base2, bool best_focus)
+{
+	int value = 0;
+	// This is used to determine which focus should be used for the random calculation
+	if (best_focus) {
+		// If the spell contains a value in the base2 field then that is the max value
+		if (focus_base2 != 0) {
+			value = focus_base2;
+		}
+		// If the spell does not contain a base2 value, then its a straight non random
+		else {
+			value = focus_base;
+		}
+	}
+	// Actual focus calculation starts here
+	else if (focus_base2 == 0 || focus_base == focus_base2) {
+		value = focus_base;
+	}
+	else {
+		value = zone->random.Int(focus_base, focus_base2);
+	}
+
+	return value;
 }

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -5186,76 +5186,23 @@ int16 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 
 		// handle effects
 		case SE_ImprovedDamage:
-			if (type == focusImprovedDamage) {
-				// This is used to determine which focus should be used for the random calculation
-				if (best_focus) {
-					// If the spell contains a value in the base2 field then that is the max value
-					if (focus_spell.base2[i] != 0) {
-						value = focus_spell.base2[i];
-					}
-					// If the spell does not contain a base2 value, then its a straight non random
-					// value
-					else {
-						value = focus_spell.base[i];
-					}
-				}
-				// Actual focus calculation starts here
-				else if (focus_spell.base2[i] == 0 || focus_spell.base[i] == focus_spell.base2[i]) {
-					value = focus_spell.base[i];
-				} else {
-					value = zone->random.Int(focus_spell.base[i], focus_spell.base2[i]);
-				}
-			}
+			if (type == focusImprovedDamage)
+				value = GetFocusRandomEffectivenessValue(focus_spell.base[i], focus_spell.base2[i], best_focus);
 			break;
 
 		case SE_ImprovedDamage2:
-			if (type == focusImprovedDamage2) {
-				if (best_focus) {
-					if (focus_spell.base2[i] != 0) {
-						value = focus_spell.base2[i];
-					}
-					else {
-						value = focus_spell.base[i];
-					}
-				}
-				else if (focus_spell.base2[i] == 0 || focus_spell.base[i] == focus_spell.base2[i]) {
-					value = focus_spell.base[i];
-				} else {
-					value = zone->random.Int(focus_spell.base[i], focus_spell.base2[i]);
-				}
-			}
+			if (type == focusImprovedDamage2)
+				value = GetFocusRandomEffectivenessValue(focus_spell.base[i], focus_spell.base2[i], best_focus);
 			break;
 
 		case SE_ImprovedHeal:
-			if (type == focusImprovedHeal) {
-				if (best_focus) {
-					if (focus_spell.base2[i] != 0) {
-						value = focus_spell.base2[i];
-					} else {
-						value = focus_spell.base[i];
-					}
-				} else if (focus_spell.base2[i] == 0 || focus_spell.base[i] == focus_spell.base2[i]) {
-					value = focus_spell.base[i];
-				} else {
-					value = zone->random.Int(focus_spell.base[i], focus_spell.base2[i]);
-				}
-			}
+			if (type == focusImprovedHeal)
+				value = GetFocusRandomEffectivenessValue(focus_spell.base[i], focus_spell.base2[i], best_focus);
 			break;
 
 		case SE_ReduceManaCost:
-			if (type == focusManaCost) {
-				if (best_focus) {
-					if (focus_spell.base2[i] != 0) {
-						value = focus_spell.base2[i];
-					} else {
-						value = focus_spell.base[i];
-					}
-				} else if (focus_spell.base2[i] == 0 || focus_spell.base[i] == focus_spell.base2[i]) {
-					value = focus_spell.base[i];
-				} else {
-					value = zone->random.Int(focus_spell.base[i], focus_spell.base2[i]);
-				}
-			}
+			if (type == focusManaCost)
+				value = GetFocusRandomEffectivenessValue(focus_spell.base[i], focus_spell.base2[i], best_focus);
 			break;
 
 		case SE_IncreaseSpellHaste:
@@ -5284,8 +5231,8 @@ int16 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 			break;
 
 		case SE_ReduceReagentCost:
-			if (type == focusReagentCost && focus_spell.base[i] > value)
-				value = focus_spell.base[i];
+			if (type == focusReagentCost)
+				value = GetFocusRandomEffectivenessValue(focus_spell.base[i], focus_spell.base2[i], best_focus);
 			break;
 
 		case SE_PetPowerIncrease:
@@ -5294,34 +5241,13 @@ int16 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 			break;
 
 		case SE_SpellResistReduction:
-			if (type == focusResistRate) {
-				if (best_focus) {
-					if (focus_spell.base2[i] != 0) {
-						value = focus_spell.base2[i];
-					} else {
-						value = focus_spell.base[i];
-					}
-				} else if (focus_spell.base2[i] == 0 || focus_spell.base[i] == focus_spell.base2[i]) {
-					value = focus_spell.base[i];
-				} else {
-					value = zone->random.Int(focus_spell.base[i], focus_spell.base2[i]);
-				}
-			}
+			if (type == focusResistRate)
+				value = GetFocusRandomEffectivenessValue(focus_spell.base[i], focus_spell.base2[i], best_focus);
 			break;
 
 		case SE_SpellHateMod:
-			if (type == focusSpellHateMod) {
-				if (value != 0) {
-					if (value > 0) {
-						if (focus_spell.base[i] > value)
-							value = focus_spell.base[i];
-					} else {
-						if (focus_spell.base[i] < value)
-							value = focus_spell.base[i];
-					}
-				} else
-					value = focus_spell.base[i];
-			}
+			if (type == focusSpellHateMod)
+				value = GetFocusRandomEffectivenessValue(focus_spell.base[i], focus_spell.base2[i], best_focus);
 			break;
 
 		case SE_ReduceReuseTimer:
@@ -5353,33 +5279,13 @@ int16 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 
 		case SE_FcSpellVulnerability:
 			if (type == focusSpellVulnerability) {
-				if (best_focus) {
-					if (focus_spell.base2[i] != 0)
-						value = focus_spell.base2[i]; //max damage
-					else
-						value = focus_spell.base[i]; //min damage
-				} else if (focus_spell.base2[i] == 0 || focus_spell.base[i] == focus_spell.base2[i]) {
-					value = focus_spell.base[i]; //If no max damage set, then default to min damage
-				} else {
-					value = zone->random.Int(focus_spell.base[i], focus_spell.base2[i]); //else random for value
-				}
+				value = GetFocusRandomEffectivenessValue(focus_spell.base[i], focus_spell.base2[i], best_focus);
 			}
 			break;
 
 		case SE_Fc_Spell_Damage_Pct_IncomingPC:
 			if (type == focusFcSpellDamagePctIncomingPC) {
-				if (best_focus) {
-					if (focus_spell.base2[i] != 0)
-						value = focus_spell.base2[i]; //max damage
-					else
-						value = focus_spell.base[i]; //min damage
-				}
-				else if (focus_spell.base2[i] == 0 || focus_spell.base[i] == focus_spell.base2[i]) {
-					value = focus_spell.base[i]; //If no max damage set, then default to min damage
-				}
-				else {
-					value = zone->random.Int(focus_spell.base[i], focus_spell.base2[i]); //else random for value
-				}
+				value = GetFocusRandomEffectivenessValue(focus_spell.base[i], focus_spell.base2[i], best_focus);
 			}
 			break;
 
@@ -7473,7 +7379,9 @@ bool Mob::CanFocusUseRandomEffectivenessByType(focusType type)
 	case focusFcDamagePctCrit:
 	case focusReagentCost:
 	case focusSpellHateMod:
-		return 1;
+	case focusSpellVulnerability:
+	case focusFcSpellDamagePctIncomingPC:
+	return 1;
 	}
 	return 0;
 }
@@ -7499,6 +7407,5 @@ int Mob::GetFocusRandomEffectivenessValue(int focus_base, int focus_base2, bool 
 	else {
 		value = zone->random.Int(focus_base, focus_base2);
 	}
-
 	return value;
 }

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -7380,9 +7380,10 @@ bool Mob::CanFocusUseRandomEffectivenessByType(focusType type)
 		case focusSpellHateMod:
 		case focusSpellVulnerability:
 		case focusFcSpellDamagePctIncomingPC:
-			return 1;
+			return true;
 	}
-	return 0;
+	
+	return false;
 }
 
 int Mob::GetFocusRandomEffectivenessValue(int focus_base, int focus_base2, bool best_focus)

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -2903,10 +2903,10 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 
 				if (zone->random.Roll(spells[spell_id].base[i]) && IsValidSpell(spells[spell_id].base2[i]))
 						caster->SpellFinished(spells[spell_id].base2[i], this, EQ::spells::CastingSlot::Item, 0, -1, spells[spells[spell_id].base2[i]].ResistDiff);
-				
+
 				break;
 			}
-					
+
 			case SE_Hatelist_To_Tail_Index: {
 				if (caster && zone->random.Roll(spells[spell_id].base[i]))
 					caster->SetBottomRampageList();
@@ -2940,7 +2940,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					else
 						Stun(spells[spell_id].base[i]);
 				}
-				else 
+				else
 					caster->MessageString(Chat::SpellFailure, FEAR_TOO_HIGH);
 				break;
 			}
@@ -2949,7 +2949,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				buffs[buffslot].focusproclimit_procamt = spells[spell_id].base[i]; //Set max amount of procs before lockout timer
 				break;
 			}
-	
+
 			case SE_PersistentEffect:
 				MakeAura(spell_id);
 				break;
@@ -3928,11 +3928,11 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 			int32 amt = abs(GetMaxHP() * effect_value / 100);
 			if (spells[buff.spellid].max[i] && amt > spells[buff.spellid].max[i])
 				amt = spells[buff.spellid].max[i];
-			
-			if (effect_value < 0) { 
+
+			if (effect_value < 0) {
 				Damage(this, amt, 0, EQ::skills::SkillEvocation, false);
 			}
-			else { 
+			else {
 				HealDamage(amt);
 			}
 			break;
@@ -3945,7 +3945,7 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 				amt = spells[buff.spellid].max[i];
 
 			if (effect_value < 0) {
-				
+
 				SetMana(GetMana() - amt);
 			}
 			else {
@@ -7093,7 +7093,7 @@ void Mob::CastSpellOnLand(Mob* caster, uint32 spell_id)
 	the CalcFocusEffect function if not 100pct.
 	ApplyFocusProcLimiter() function checks for SE_Proc_Timer_Modifier which allows for limiting how often a spell from effect can be triggered
 	for example, if set to base=1 and base2= 1500, then for everyone 1 successful trigger, you will be unable to trigger again for 1.5 seconds.
-	
+
 	Live only has this focus in buffs/debuffs that can be placed on a target. TODO: Will consider adding support for it as AA and Item.
 	*/
 	if (!caster)
@@ -7127,7 +7127,7 @@ void Mob::CastSpellOnLand(Mob* caster, uint32 spell_id)
 								SpellFinished(trigger_spell_id, current_target, EQ::spells::CastingSlot::Item, 0, -1, spells[trigger_spell_id].ResistDiff);
 						}
 					}
-				
+
 					if (i >= 0)
 						CheckNumHitsRemaining(NumHit::MatchingSpells, i);
 				}
@@ -7143,13 +7143,13 @@ bool Mob::ApplyFocusProcLimiter(uint32 spell_id, int buffslot)
 
 	//Do not allow spell cast if timer is active.
 	if (buffs[buffslot].focusproclimit_time > 0)
-		return false; 
+		return false;
 
 	/*
-	SE_Proc_Timer_Modifier 
+	SE_Proc_Timer_Modifier
 	base1= amount of total procs allowed until lock out timer is triggered, should be set to at least 1 in any spell for the effect to function.
 	base2= lock out timer, which prevents any more procs set in ms 1500 = 1.5 seconds
-	This system allows easy scaling for multiple different buffs with same effects each having seperate active individual timer checks. Ie. 
+	This system allows easy scaling for multiple different buffs with same effects each having seperate active individual timer checks. Ie.
 	*/
 
 	if (IsValidSpell(spell_id)) {
@@ -7176,7 +7176,7 @@ bool Mob::ApplyFocusProcLimiter(uint32 spell_id, int buffslot)
 						if (!focus_proc_limit_timer.Enabled()) {
 							focus_proc_limit_timer.Start(250);
 						}
-				
+
 						return true;
 					}
 				}
@@ -7369,19 +7369,18 @@ bool Mob::HarmonySpellLevelCheck(int32 spell_id, Mob *target)
 
 bool Mob::CanFocusUseRandomEffectivenessByType(focusType type)
 {
-	switch (type)
-	{
-	case focusImprovedDamage:
-	case focusImprovedDamage2:
-	case focusImprovedHeal:
-	case focusManaCost:
-	case focusResistRate:
-	case focusFcDamagePctCrit:
-	case focusReagentCost:
-	case focusSpellHateMod:
-	case focusSpellVulnerability:
-	case focusFcSpellDamagePctIncomingPC:
-	return 1;
+	switch (type) {
+		case focusImprovedDamage:
+		case focusImprovedDamage2:
+		case focusImprovedHeal:
+		case focusManaCost:
+		case focusResistRate:
+		case focusFcDamagePctCrit:
+		case focusReagentCost:
+		case focusSpellHateMod:
+		case focusSpellVulnerability:
+		case focusFcSpellDamagePctIncomingPC:
+			return 1;
 	}
 	return 0;
 }
@@ -7391,21 +7390,17 @@ int Mob::GetFocusRandomEffectivenessValue(int focus_base, int focus_base2, bool 
 	int value = 0;
 	// This is used to determine which focus should be used for the random calculation
 	if (best_focus) {
+		// If the spell does not contain a base2 value, then its a straight non random
+		value = focus_base;
 		// If the spell contains a value in the base2 field then that is the max value
 		if (focus_base2 != 0) {
 			value = focus_base2;
 		}
-		// If the spell does not contain a base2 value, then its a straight non random
-		else {
-			value = focus_base;
-		}
+		return value
 	}
-	// Actual focus calculation starts here
-	else if (focus_base2 == 0 || focus_base == focus_base2) {
-		value = focus_base;
+	else if (focus_base2 == 0 || focus_base == focus_base2) { // Actual focus calculation starts here
+		return focus_base;
 	}
-	else {
-		value = zone->random.Int(focus_base, focus_base2);
-	}
-	return value;
+
+	return zone->random.Int(focus_base, focus_base2);
 }


### PR DESCRIPTION
Live like updates.
Update to SPA 130 SE_SpellHateMod: To allow focus calculation to check a random range if indicated by spell file data.
Reminder, focus allows to increase or decrease hatred generated from spell damage.

Update to SPA 131 SE_ReduceReagentCost: To allow focus calculation to check a random range if indicated by spell file data.
Reminder, focus gives a chance not to consume a reagent.

For both, and any focus that uses random effectiveness formula.
If Base and Limit values both are defined. Then Base = min value Limit = max value
If you don't want random range, then Base = value Limit = 0, or set Limit to same as Base value

Added a standard function to do all the random effectiveness calculations in source.