### PR TITLE
 [Spells] Update to SPA 130 and SPA 131 focus calculation, focus code improvements (version2)

### DIFF
--- a/zone/mob.h
+++ b/zone/mob.h
@@ -837,6 +837,8 @@ public:
 	inline void SetSpellPowerDistanceMod(int16 value) { SpellPowerDistanceMod = value; };
 	int32 GetSpellStat(uint32 spell_id, const char *identifier, uint8 slot = 0);
 	bool HarmonySpellLevelCheck(int32 spell_id, Mob* target = nullptr);
+	bool CanFocusUseRandomEffectivenessByType(focusType type);
+	int GetFocusRandomEffectivenessValue(int focus_base, int focus_base2, bool best_focus = 0);
 	
 	void CastSpellOnLand(Mob* caster, int32 spell_id);
 	void FocusProcLimitProcess();

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -5462,44 +5462,13 @@ int32 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				// handle effects
 			case SE_ImprovedDamage:
 				if (type == focusImprovedDamage) {
-					// This is used to determine which focus should be used for the random calculation
-					if (best_focus) {
-						// If the spell contains a value in the base2 field then that is the max value
-						if (focus_spell.base2[i] != 0) {
-							value = focus_spell.base2[i];
-						}
-							// If the spell does not contain a base2 value, then its a straight non random
-							// value
-						else {
-							value = focus_spell.base[i];
-						}
-					}
-						// Actual focus calculation starts here
-					else if (focus_spell.base2[i] == 0 || focus_spell.base[i] == focus_spell.base2[i]) {
-						value = focus_spell.base[i];
-					}
-					else {
-						value = zone->random.Int(focus_spell.base[i], focus_spell.base2[i]);
-					}
+					value = GetFocusRandomEffectivenessValue(focus_spell.base[i], focus_spell.base2[i], best_focus);
 				}
 				break;
 
 			case SE_ImprovedDamage2:
 				if (type == focusImprovedDamage2) {
-					if (best_focus) {
-						if (focus_spell.base2[i] != 0) {
-							value = focus_spell.base2[i];
-						}
-						else {
-							value = focus_spell.base[i];
-						}
-					}
-					else if (focus_spell.base2[i] == 0 || focus_spell.base[i] == focus_spell.base2[i]) {
-						value = focus_spell.base[i];
-					}
-					else {
-						value = zone->random.Int(focus_spell.base[i], focus_spell.base2[i]);
-					}
+					value = GetFocusRandomEffectivenessValue(focus_spell.base[i], focus_spell.base2[i], best_focus);
 				}
 				break;
 
@@ -5511,39 +5480,13 @@ int32 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 
 			case SE_ImprovedHeal:
 				if (type == focusImprovedHeal) {
-					if (best_focus) {
-						if (focus_spell.base2[i] != 0) {
-							value = focus_spell.base2[i];
-						}
-						else {
-							value = focus_spell.base[i];
-						}
-					}
-					else if (focus_spell.base2[i] == 0 || focus_spell.base[i] == focus_spell.base2[i]) {
-						value = focus_spell.base[i];
-					}
-					else {
-						value = zone->random.Int(focus_spell.base[i], focus_spell.base2[i]);
-					}
+					value = GetFocusRandomEffectivenessValue(focus_spell.base[i], focus_spell.base2[i], best_focus);
 				}
 				break;
 
 			case SE_ReduceManaCost:
 				if (type == focusManaCost) {
-					if (best_focus) {
-						if (focus_spell.base2[i] != 0) {
-							value = focus_spell.base2[i];
-						}
-						else {
-							value = focus_spell.base[i];
-						}
-					}
-					else if (focus_spell.base2[i] == 0 || focus_spell.base[i] == focus_spell.base2[i]) {
-						value = focus_spell.base[i];
-					}
-					else {
-						value = zone->random.Int(focus_spell.base[i], focus_spell.base2[i]);
-					}
+					value = GetFocusRandomEffectivenessValue(focus_spell.base[i], focus_spell.base2[i], best_focus);
 				}
 				break;
 
@@ -5590,8 +5533,8 @@ int32 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				break;
 
 			case SE_ReduceReagentCost:
-				if (type == focusReagentCost && focus_spell.base[i] > value) {
-					value = focus_spell.base[i];
+				if (type == focusReagentCost) {
+					value = GetFocusRandomEffectivenessValue(focus_spell.base[i], focus_spell.base2[i], best_focus);
 				}
 				break;
 
@@ -5603,20 +5546,7 @@ int32 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 
 			case SE_SpellResistReduction:
 				if (type == focusResistRate) {
-					if (best_focus) {
-						if (focus_spell.base2[i] != 0) {
-							value = focus_spell.base2[i];
-						}
-						else {
-							value = focus_spell.base[i];
-						}
-					}
-					else if (focus_spell.base2[i] == 0 || focus_spell.base[i] == focus_spell.base2[i]) {
-						value = focus_spell.base[i];
-					}
-					else {
-						value = zone->random.Int(focus_spell.base[i], focus_spell.base2[i]);
-					}
+					value = GetFocusRandomEffectivenessValue(focus_spell.base[i], focus_spell.base2[i], best_focus);
 				}
 				break;
 
@@ -5628,21 +5558,7 @@ int32 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 
 			case SE_SpellHateMod:
 				if (type == focusSpellHateMod) {
-					if (value != 0) {
-						if (value > 0) {
-							if (focus_spell.base[i] > value) {
-								value = focus_spell.base[i];
-							}
-						}
-						else {
-							if (focus_spell.base[i] < value) {
-								value = focus_spell.base[i];
-							}
-						}
-					}
-					else {
-						value = focus_spell.base[i];
-					}
+					value = GetFocusRandomEffectivenessValue(focus_spell.base[i], focus_spell.base2[i], best_focus);
 				}
 				break;
 
@@ -5679,39 +5595,13 @@ int32 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 
 			case SE_FcSpellVulnerability:
 				if (type == focusSpellVulnerability) {
-					if (best_focus) {
-						if (focus_spell.base2[i] != 0) {
-							value = focus_spell.base2[i]; //max damage
-						}
-						else {
-							value = focus_spell.base[i];
-						} //min damage
-					}
-					else if (focus_spell.base2[i] == 0 || focus_spell.base[i] == focus_spell.base2[i]) {
-						value = focus_spell.base[i]; //If no max damage set, then default to min damage
-					}
-					else {
-						value = zone->random.Int(focus_spell.base[i], focus_spell.base2[i]); //else random for value
-					}
+					value = GetFocusRandomEffectivenessValue(focus_spell.base[i], focus_spell.base2[i], best_focus);
 				}
 				break;
 
 			case SE_Fc_Spell_Damage_Pct_IncomingPC:
 				if (type == focusFcSpellDamagePctIncomingPC) {
-					if (best_focus) {
-						if (focus_spell.base2[i] != 0) {
-							value = focus_spell.base2[i]; //max damage
-						}
-						else {
-							value = focus_spell.base[i];
-						} //min damage
-					}
-					else if (focus_spell.base2[i] == 0 || focus_spell.base[i] == focus_spell.base2[i]) {
-						value = focus_spell.base[i]; //If no max damage set, then default to min damage
-					}
-					else {
-						value = zone->random.Int(focus_spell.base[i], focus_spell.base2[i]); //else random for value
-					}
+					value = GetFocusRandomEffectivenessValue(focus_spell.base[i], focus_spell.base2[i], best_focus);
 				}
 				break;
 
@@ -6122,7 +6012,7 @@ int32 Client::GetFocusEffect(focusType type, uint16 spell_id)
 
 	//Improved Healing, Damage & Mana Reduction are handled differently in that some are random percentages
 	//In these cases we need to find the most powerful effect, so that each piece of gear wont get its own chance
-	if (RuleB(Spells, LiveLikeFocusEffects) && (type == focusManaCost || type == focusImprovedHeal || type == focusImprovedDamage || type == focusImprovedDamage2 || type == focusResistRate)) {
+	if (RuleB(Spells, LiveLikeFocusEffects) && CanFocusUseRandomEffectivenessByType(type)) {
 		rand_effectiveness = true;
 	}
 
@@ -7888,4 +7778,43 @@ bool Mob::HarmonySpellLevelCheck(int32 spell_id, Mob *target)
 		}
 	}
 	return true;
+}
+
+bool Mob::CanFocusUseRandomEffectivenessByType(focusType type)
+{
+	switch (type) {
+	case focusImprovedDamage:
+	case focusImprovedDamage2:
+	case focusImprovedHeal:
+	case focusManaCost:
+	case focusResistRate:
+	case focusFcDamagePctCrit:
+	case focusReagentCost:
+	case focusSpellHateMod:
+	case focusSpellVulnerability:
+	case focusFcSpellDamagePctIncomingPC:
+		return true;
+	}
+
+	return false;
+}
+
+int Mob::GetFocusRandomEffectivenessValue(int focus_base, int focus_base2, bool best_focus)
+{
+	int value = 0;
+	// This is used to determine which focus should be used for the random calculation
+	if (best_focus) {
+		// If the spell does not contain a base2 value, then its a straight non random
+		value = focus_base;
+		// If the spell contains a value in the base2 field then that is the max value
+		if (focus_base2 != 0) {
+			value = focus_base2;
+		}
+		return value;
+	}
+	else if (focus_base2 == 0 || focus_base == focus_base2) { // Actual focus calculation starts here
+		return focus_base;
+	}
+
+	return zone->random.Int(focus_base, focus_base2);
 }


### PR DESCRIPTION
Live like updates.
Update to SPA 130 SE_SpellHateMod: To allow focus calculation to check a random range if indicated by spell file data.
Reminder, focus allows to increase or decrease hatred generated from spell damage.

Update to SPA 131 SE_ReduceReagentCost: To allow focus calculation to check a random range if indicated by spell file data.
Reminder, focus gives a chance not to consume a reagent.

For both, and any focus that uses random effectiveness formula.
If Base and Limit values both are defined. Then Base = min value Limit = max value
If you don't want random range, then Base = value Limit = 0, or set Limit to same as Base value

Added a standard function to do all the random effectiveness calculations in source.

#USE THIS INSTEAD OF PR 1483