### PR TITLE
[Spells] Implemented SPA 489 SE_Worn_Endurance_Regen_Cap

### DIFF
--- a/common/spdat.h
+++ b/common/spdat.h
@@ -851,7 +851,7 @@ typedef enum {
 #define SE_Ff_Same_Caster				486 // implemented, @Ff, Caster of spell on target with a focus effect that is checked by incoming spells, base1: 0=Must be different caster 1=Must be same caster
 //#define SE_Extend_Tradeskill_Cap		487 //
 //#define SE_Defender_Melee_Force_Pct_PC	488 //
-//#define SE_Worn_Endurance_Regen_Cap	489 //
+#define SE_Worn_Endurance_Regen_Cap		489 // implemented, modify worn regen cap, base: amt, limit: none, max: none
 #define SE_Ff_ReuseTimeMin				490 // implemented, @Ff, Minimum recast time of a spell that can be focused, base: recast time
 #define SE_Ff_ReuseTimeMax				491 // implemented, @Ff, Max recast time of a spell that can be focused, base: recast time 
 #define SE_Ff_Endurance_Min				492 // implemented, @Ff, Minimum endurance cost of a spell that can be focused, base: endurance cost

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -1583,6 +1583,10 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
+		case SE_Worn_Endurance_Regen_Cap:
+			newbon->ItemEnduranceRegenCap += base1;
+			break;
+
 		// to do
 		case SE_PetDiscipline:
 			break;
@@ -3474,6 +3478,14 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				new_bonus->Pet_Add_Atk += effect_value;
 				break;
 
+			case SE_Worn_Endurance_Regen_Cap:
+				new_bonus->ItemEnduranceRegenCap += effect_value;
+				break;
+
+			case SE_ItemManaRegenCapIncrease:
+				new_bonus->ItemManaRegenCap += effect_value;
+				break;
+
 			//Special custom cases for loading effects on to NPC from 'npc_spels_effects' table
 			if (IsAISpellEffect) {
 
@@ -4824,6 +4836,12 @@ void Mob::NegateSpellsBonuses(uint16 spell_id)
 					spellbonuses.ItemHPRegenCap = effect_value;
 					aabonuses.ItemHPRegenCap = effect_value;
 					itembonuses.ItemHPRegenCap = effect_value;
+					break;
+
+				case SE_Worn_Endurance_Regen_Cap:
+					spellbonuses.ItemEnduranceRegenCap = effect_value;
+					aabonuses.ItemEnduranceRegenCap = effect_value;
+					itembonuses.ItemEnduranceRegenCap = effect_value;
 					break;
 
 				case SE_OffhandRiposteFail:

--- a/zone/client_mods.cpp
+++ b/zone/client_mods.cpp
@@ -781,7 +781,7 @@ int32 Client::CalcManaRegen(bool bCombat)
 
 int32 Client::CalcManaRegenCap()
 {
-	int32 cap = RuleI(Character, ItemManaRegenCap) + aabonuses.ItemManaRegenCap;
+	int32 cap = RuleI(Character, ItemManaRegenCap) + aabonuses.ItemManaRegenCap + itembonuses.ItemManaRegenCap + spellbonuses.ItemManaRegenCap;
 	return (cap * RuleI(Character, ManaRegenMultiplier) / 100);
 }
 
@@ -1751,7 +1751,7 @@ int32 Client::CalcEnduranceRegen(bool bCombat)
 
 int32 Client::CalcEnduranceRegenCap()
 {
-	int cap = RuleI(Character, ItemEnduranceRegenCap);
+	int cap = RuleI(Character, ItemEnduranceRegenCap) + aabonuses.ItemEnduranceRegenCap + itembonuses.ItemEnduranceRegenCap + spellbonuses.ItemEnduranceRegenCap;
 	return (cap * RuleI(Character, EnduranceRegenMultiplier) / 100);
 }
 

--- a/zone/common.h
+++ b/zone/common.h
@@ -545,6 +545,7 @@ struct StatBonuses {
 	int32	DS_Mitigation_Percentage;			// base = percent amt of DS mitigation. Negative value to reduce
 	int32   Pet_Crit_Melee_Damage_Pct_Owner;	// base = percent mod for pet critcal damage from owner
 	int32	Pet_Add_Atk;						// base = Pet ATK bonus from owner
+	int32	ItemEnduranceRegenCap;				// modify endurance regen cap
 
 
 	// AAs

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -3229,6 +3229,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 			case SE_AddExtraAttackPct_1h_Primary:
 			case SE_AddExtraAttackPct_1h_Secondary:
 			case SE_Skill_Base_Damage_Mod:
+			case SE_Worn_Endurance_Regen_Cap:
 
 			{
 				break;


### PR DESCRIPTION
Implemented

SE_Worn_Endurance_Regen_Cap	489
modify worn item regen cap
base: amt, limit: none, max: none

Also added support to allow item mana regen cap to check item and spell bonuses.