### PR TITLE
[Spells] Implemented SPA 390 SE_FcTimerLockout

### DIFF
--- a/common/spdat.h
+++ b/common/spdat.h
@@ -752,8 +752,8 @@ typedef enum {
 #define SE_CastOnCurer					386 // implemented - Casts a spell on the person curing
 #define SE_CastOnCure					387 // implemented - Casts a spell on the cured person
 #define SE_SummonCorpseZone				388 // implemented - summons a corpse from any zone(nec AA)
-#define SE_FcTimerRefresh				389 // implemented, @Fc, On Caster, reset all recast timers, base: 1
-//#define SE_FcTimerLockout				390 // *not implemented - Sets recast timers to specific value, focus limited.
+#define SE_FcTimerRefresh				389 // implemented, @Fc, On Caster, reset all recast timers, base: 1, Note: Applied from casted spells only
+#define SE_FcTimerLockout				390 // implemented, @Fc, On Caster, set a spell to be on recast timer, base: recast duration milliseconds, Note: Applied from casted spells only
 #define SE_LimitManaMax					391	// implemented, @Ff, Mininum mana of spell that can be focused, base1: mana amt
 #define SE_FcHealAmt					392 // implemented, @Fc, On Caster, spell healing mod flat amt, base: amt
 #define SE_FcHealPctIncoming			393 // implemented, @Fc, On Target, heal received critical chance mod, base: chance pct

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -3966,6 +3966,8 @@ uint8 Mob::IsFocusEffect(uint16 spell_id,int effect_index, bool AA,uint32 aa_eff
 			return focusFcMute;
 		case SE_FcTimerRefresh:
 			return focusFcTimerRefresh;
+		case SE_FcTimerLockout:
+			return focusFcTimerLockout;
 		case SE_Fc_Cast_Spell_On_Land:
 			return focusFcCastSpellOnLand;
 		case SE_FcStunTimeMod:

--- a/zone/common.h
+++ b/zone/common.h
@@ -143,7 +143,8 @@ typedef enum {	//focus types
 	focusIncreaseNumHits,				//@Fc, SPA: 421, SE_FcIncreaseNumHits,				On Caster, numhits mod flat amt, base: amt
 	focusFcLimitUse,					//@Fc, SPA: 420, SE_FcLimitUse,						On Caster, numhits mod pct, base: pct
 	focusFcMute,						//@Fc, SPA: 357, SE_FcMute,							On Caster, prevents spell casting, base: chance pct
-	focusFcTimerRefresh,				//@Fc, SPA: 389, SE_FcTimerRefresh,					On Caster, reset all recast timers, base: 1
+	focusFcTimerRefresh,				//@Fc, SPA: 389, SE_FcTimerRefresh,					On Caster, reset spell recast timer, base: 1
+	focusFcTimerLockout,				//@Fc, SPA: 390, SE_FcTimerLockout,					On Caster, set a spell to be on recast timer, base: recast duration milliseconds
 	focusFcStunTimeMod,					//@Fc, SPA: 133, SE_FcStunTimeMod,					On Caster, stun time mod pct, base: chance pct
 	focusFcResistIncoming,				//@Fc, SPA: 510, SE_Fc_Resist_Incoming,				On Target, resist modifier, base: amt
 	focusFcAmplifyMod,					//@Fc, SPA: 507, SE_Fc_Amplify_Mod,					On Caster, damage-heal-dot mod pct, base: pct

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -2561,22 +2561,22 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 
 			case SE_FcTimerLockout: {
 				if (IsClient()) {
-					for (unsigned int gem_index = 0; gem_index < EQ::spells::SPELL_GEM_COUNT; ++gem_index) {
-						if (IsValidSpell(CastToClient()->m_pp.mem_spells[gem_index])) {
+					for (unsigned int mem_spell : CastToClient()->m_pp.mem_spells) {
+						if (IsValidSpell(mem_spell)) {
 							int32 new_recast_timer = CalcFocusEffect(
 								focusFcTimerLockout,
 								spell_id,
-								CastToClient()->m_pp.mem_spells[gem_index]
+								mem_spell
 							);
 							if (new_recast_timer) {
 								bool apply_recast_timer = true;
-								if (IsCasting() && casting_spell_id == CastToClient()->m_pp.mem_spells[gem_index]) {
+								if (IsCasting() && casting_spell_id == mem_spell) {
 									apply_recast_timer = false;
 								}
 								if (apply_recast_timer) {
 									new_recast_timer = new_recast_timer / 1000;
 									CastToClient()->GetPTimers().Start(
-										pTimerSpellStart + CastToClient()->m_pp.mem_spells[gem_index],
+										pTimerSpellStart + mem_spell,
 										static_cast<uint32>(new_recast_timer)
 									);
 								}

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -2559,6 +2559,34 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
+			case SE_FcTimerLockout: {
+				if (IsClient()) {
+
+					for (unsigned int i = 0; i < EQ::spells::SPELL_GEM_COUNT; ++i) {
+
+						if (IsValidSpell(CastToClient()->m_pp.mem_spells[i])) {
+
+							int32 new_recast_timer = CalcFocusEffect(focusFcTimerLockout, spell_id, CastToClient()->m_pp.mem_spells[i]);
+							if (new_recast_timer) {
+
+								bool apply_recast_timer = true;
+								if (IsCasting() && casting_spell_id == CastToClient()->m_pp.mem_spells[i]) {
+									
+									apply_recast_timer = false;
+								}
+								if (apply_recast_timer) {
+									
+									new_recast_timer = new_recast_timer / 1000;
+									CastToClient()->GetPTimers().Start(pTimerSpellStart + CastToClient()->m_pp.mem_spells[i], static_cast<uint32>(new_recast_timer));
+								}
+							}
+						}
+					}
+					SetMana(GetMana());
+				}
+				break;
+			}
+
 			case SE_HealGroupFromMana: {
 				if(!caster)
 					break;
@@ -5737,6 +5765,12 @@ int32 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 
 			case SE_FcTimerRefresh:
 				if (type == focusFcTimerRefresh) {
+					value = focus_spell.base[i];
+				}
+				break;
+
+			case SE_FcTimerLockout:
+				if (type == focusFcTimerLockout) {
 					value = focus_spell.base[i];
 				}
 				break;

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -2561,23 +2561,24 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 
 			case SE_FcTimerLockout: {
 				if (IsClient()) {
-
-					for (unsigned int i = 0; i < EQ::spells::SPELL_GEM_COUNT; ++i) {
-
-						if (IsValidSpell(CastToClient()->m_pp.mem_spells[i])) {
-
-							int32 new_recast_timer = CalcFocusEffect(focusFcTimerLockout, spell_id, CastToClient()->m_pp.mem_spells[i]);
+					for (unsigned int gem_index = 0; gem_index < EQ::spells::SPELL_GEM_COUNT; ++gem_index) {
+						if (IsValidSpell(CastToClient()->m_pp.mem_spells[gem_index])) {
+							int32 new_recast_timer = CalcFocusEffect(
+								focusFcTimerLockout,
+								spell_id,
+								CastToClient()->m_pp.mem_spells[gem_index]
+							);
 							if (new_recast_timer) {
-
 								bool apply_recast_timer = true;
-								if (IsCasting() && casting_spell_id == CastToClient()->m_pp.mem_spells[i]) {
-									
+								if (IsCasting() && casting_spell_id == CastToClient()->m_pp.mem_spells[gem_index]) {
 									apply_recast_timer = false;
 								}
 								if (apply_recast_timer) {
-									
 									new_recast_timer = new_recast_timer / 1000;
-									CastToClient()->GetPTimers().Start(pTimerSpellStart + CastToClient()->m_pp.mem_spells[i], static_cast<uint32>(new_recast_timer));
+									CastToClient()->GetPTimers().Start(
+										pTimerSpellStart + CastToClient()->m_pp.mem_spells[gem_index],
+										static_cast<uint32>(new_recast_timer)
+									);
 								}
 							}
 						}


### PR DESCRIPTION
Implemented

SPA 390 SE_FcTimerLockout

This focus limited effect sets any spell in the spell bar that meets the criteria of the of the focus limits to be a on recast timer.
Base value: recast duration in milliseconds.

Example spell: Suppression of Fire ID 16973.
Sets any fire spell in the clients spell bar to a 2 second recast when the client is affect by the spell.

Note: This focus can only be applied from spells (not item or AA)

Note: Although reinforced by the server, to appear visually correct both server side and client side spell values need to match (ie. need to matching database and spells_us.txt values).



