### PR TITLE
[Spells] Implemented spells_new table 'field220' as 'caster_requirement_id'

### DIFF
--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -1883,6 +1883,7 @@ void SharedDatabase::LoadSpells(void *data, int max_spells) {
 		sp[tempid].override_crit_chance = atoi(row[217]);
 		sp[tempid].aemaxtargets = atoi(row[218]);
 		sp[tempid].no_heal_damage_item_mod = atoi(row[219]);
+		sp[tempid].caster_requirement_id = atoi(row[220]);
 		sp[tempid].spell_class = atoi(row[221]);
 		sp[tempid].spell_subclass = atoi(row[222]);
 		sp[tempid].persistdeath = atoi(row[224]) != 0;

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1037,7 +1037,7 @@ struct SPDat_Spell_Struct
 /* 217 */   int override_crit_chance; //Places a cap on the max chance to critical -- OVERRIDE_CRIT_CHANCE
 /* 218 */	int aemaxtargets;  //Is used for various AE effects -- MAX_TARGETS
 /* 219 */	int no_heal_damage_item_mod; // -- NO_HEAL_DAMAGE_ITEM_MOD
-/* 220 */	//int caster_requirement_id; // -- CASTER_REQUIREMENT_ID
+/* 220 */	int caster_requirement_id; // -- CASTER_REQUIREMENT_ID
 /* 221 */	int spell_class; // -- SPELL_CLASS
 /* 222 */	int spell_subclass; // -- SPELL_SUBCLASS
 /* 223 */	//int ai_valid_targets; // -- AI_VALID_TARGETS

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -5903,6 +5903,7 @@ int32 Mob::GetSpellStat(uint32 spell_id, const char *identifier, uint8 slot)
 	else if (id == "rank") {return spells[spell_id].rank; }
 	else if (id == "no_resist") {return spells[spell_id].no_resist; }
 	else if (id == "CastRestriction") {return spells[spell_id].CastRestriction; }
+	else if (id == "caster_requirement_id") { return spells[spell_id].caster_requirement_id; }
 	else if (id == "AllowRest") {return spells[spell_id].AllowRest; }
 	else if (id == "InCombat") {return spells[spell_id].InCombat; }
 	else if (id == "OutofCombat") {return spells[spell_id].OutofCombat; }

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -833,6 +833,7 @@ public:
 	int32 GetExtraSpellAmt(uint16 spell_id, int32 extra_spell_amt, int32 base_spell_dmg);
 	void MeleeLifeTap(int32 damage);
 	bool PassCastRestriction(bool UseCastRestriction = true, int16 value = 0, bool IsDamage = true);
+	bool PassCasterRestriction(int value);
 	bool ImprovedTaunt();
 	bool TryRootFadeByDamage(int buffslot, Mob* attacker);
 	float GetSlowMitigation() const { return slow_mitigation; }

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -7447,7 +7447,7 @@ bool Mob::PassCasterRestriction(int value)
 		Range -1        : UNKNOWN
 		Range 1         : UNKNOWN
 		Range 3         : UKN 30183 | Mind Spiral
-		Range 5  		: Not on mount
+		Range 5         : Not on mount
 		Range 203       : HP Less Than 20 Percent
 		Range 204       : HP Less Than 50 Percent
 		Range 429       : Mana Above 10 Percent

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -7438,6 +7438,95 @@ bool Mob::PassCastRestriction(bool UseCastRestriction,  int16 value, bool IsDama
 	return false;
 }
 
+bool Mob::PassCasterRestriction(int value)
+{
+	/*
+		If return TRUE if spell has met the restriction (this = caster). 
+		This check is used when the spell_new field caster_requirement_id (field220)
+		The following conditions must be true to allow casting.
+		Range -1        : UNKNOWN
+		Range 1         : UNKNOWN
+		Range 3         : UKN 30183 | Mind Spiral
+		Range 5  		: Not on mount
+		Range 203       : HP Less Than 20 Percent
+		Range 204       : HP Less Than 50 Percent
+		Range 429       : Mana Above 10 Percent
+		Range 518       : HP Below 90 Percent
+		Range 825       : End Below 21 Percent
+		Range 826       : End Below 25 Percent
+		Range 827       : End Below 29 Percent
+		Range 840       : UNKOWN 6883 | Expedient Recovery
+		Range 841       : UNKOWN 32192 | Merciless Blow
+		Range 866       : UNKNOWN 41088 | Defensive Proficiency      *Weaponstance
+		Range 867       : UNKNOWN 41086 | Two-Handed Proficiency     *Weaponstance
+		Range 868       : UNKNOWN 41087 | Dual-Wielding Proficiency  *Weaponstance
+		Range 29556     : UNKNOWN 40372 | Pact of Fate
+		Range 38311     : UNKNOWN 38312 | Mana Reserve
+		Range 38312     : UNKNOWN 38311 | Mana Reserve
+		Range 40297     : UNKNOWN 40297 | Knifeplay Discipline
+		Range 99999     : UNKNOWN 27672 | Strike of Ire
+		THIS IS A WORK IN PROGRESS
+	*/
+
+	switch (value)
+	{
+		case 5:
+			if (IsClient() && !CastToClient()->GetHorseId()) {
+				return true;
+			}
+			break;
+
+		case 203:
+			if (GetHPRatio() < 20) {
+				return true;
+			}
+			break;
+
+		case 204:
+			if (GetHPRatio() < 50) {
+				return true;
+			}
+			break;
+
+		case 429:
+			if (GetManaRatio() > 10) {
+				return true;
+			}
+			break;
+
+		case 518:
+			if (GetHPRatio() < 90) {
+				return true;
+			}
+			break;
+
+		case 825:
+			if (GetEndurancePercent() < 21) {
+				return true;
+			}
+			break;
+
+		case 826:
+			if (GetEndurancePercent() < 25) {
+				return true;
+			}
+			break;
+
+		case 827:
+			if (GetEndurancePercent() < 29) {
+				return true;
+			}
+			break;
+
+		default:
+			return true;//If we don't have a case for this yet, just allow spell to pass.
+			break;
+
+	}
+
+	return false;
+}
+
 bool Mob::TrySpellProjectile(Mob* spell_target, uint16 spell_id, float speed) {
 
 	/*For mage 'Bolt' line and other various spells.

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -1540,6 +1540,11 @@ bool Mob::DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_ce
 		return false;
 	}
 
+	if (spells[spell_id].caster_requirement_id && !PassCasterRestriction(spells[spell_id].caster_requirement_id)) {
+		MessageString(Chat::Red, SPELL_WOULDNT_HOLD);
+		return false;
+	}
+
 	//Must be out of combat. (If Beneficial checks casters combat state, Deterimental checks targets)
 	if (!spells[spell_id].InCombat && spells[spell_id].OutofCombat) {
 		if (IsDetrimentalSpell(spell_id)) {


### PR DESCRIPTION
Implemented spells_new table 'field220' as 'caster_requirement_id'

This field is used to apply requirements on the caster before a spell can be cast.
Example, must be > 10 percent mana to cast the spell. 

The following are the live values that I could figure out definitions for.

```
		Range -1        : UNKNOWN
		Range 1          : UNKNOWN
		Range 3          : UKNOWN 30183 | Mind Spiral
		Range 5          : Not on mount
		Range 203       : HP Less Than 20 Percent
		Range 204       : HP Less Than 50 Percent
		Range 429       : Mana Above 10 Percent
		Range 518       : HP Below 90 Percent
		Range 825       : End Below 21 Percent
		Range 826       : End Below 25 Percent
		Range 827       : End Below 29 Percent
		Range 840       : UNKOWN 6883 | Expedient Recovery
		Range 841       : UNKOWN 32192 | Merciless Blow
		Range 866       : UNKNOWN 41088 | Defensive Proficiency      *Weaponstance
		Range 867       : UNKNOWN 41086 | Two-Handed Proficiency     *Weaponstance
		Range 868       : UNKNOWN 41087 | Dual-Wielding Proficiency  *Weaponstance
		Range 29556     : UNKNOWN 40372 | Pact of Fate
		Range 38311     : UNKNOWN 38312 | Mana Reserve
		Range 38312     : UNKNOWN 38311 | Mana Reserve
		Range 40297     : UNKNOWN 40297 | Knifeplay Discipline
		Range 99999     : UNKNOWN 27672 | Strike of Ire
		THIS IS A WORK IN PROGRESS
```
