### PR TITLE
[Server] Tweak inter-process keepalive timers

### DIFF
--- a/loginserver/world_server.cpp
+++ b/loginserver/world_server.cpp
@@ -72,7 +72,7 @@ WorldServer::WorldServer(std::shared_ptr<EQ::Net::ServertalkServerConnection> wo
 		std::bind(&WorldServer::ProcessLSAccountUpdate, this, std::placeholders::_1, std::placeholders::_2)
 	);
 
-	m_keepalive = std::make_unique<EQ::Timer>(5000, true, std::bind(&WorldServer::OnKeepAlive, this, std::placeholders::_1));
+	m_keepalive = std::make_unique<EQ::Timer>(1000, true, std::bind(&WorldServer::OnKeepAlive, this, std::placeholders::_1));
 }
 
 WorldServer::~WorldServer() = default;

--- a/world/login_server.cpp
+++ b/world/login_server.cpp
@@ -552,7 +552,7 @@ bool LoginServer::Connect()
 		);
 	}
 
-	m_keepalive = std::make_unique<EQ::Timer>(5000, true, std::bind(&LoginServer::OnKeepAlive, this, std::placeholders::_1));
+	m_keepalive = std::make_unique<EQ::Timer>(1000, true, std::bind(&LoginServer::OnKeepAlive, this, std::placeholders::_1));
 
 	return true;
 }

--- a/world/zonelist.cpp
+++ b/world/zonelist.cpp
@@ -43,7 +43,7 @@ ZSList::ZSList()
 	memset(pLockedZones, 0, sizeof(pLockedZones));
 
 	m_tick = std::make_unique<EQ::Timer>(5000, true, std::bind(&ZSList::OnTick, this, std::placeholders::_1));
-	m_keepalive = std::make_unique<EQ::Timer>(2500, true, std::bind(&ZSList::OnKeepAlive, this, std::placeholders::_1));
+	m_keepalive = std::make_unique<EQ::Timer>(1500, true, std::bind(&ZSList::OnKeepAlive, this, std::placeholders::_1));
 }
 
 ZSList::~ZSList() {

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -86,7 +86,7 @@ void WorldServer::Connect()
 
 	m_connection->OnMessage(std::bind(&WorldServer::HandleMessage, this, std::placeholders::_1, std::placeholders::_2));
 
-	m_keepalive = std::make_unique<EQ::Timer>(2500, true, std::bind(&WorldServer::OnKeepAlive, this, std::placeholders::_1));
+	m_keepalive = std::make_unique<EQ::Timer>(1000, true, std::bind(&WorldServer::OnKeepAlive, this, std::placeholders::_1));
 }
 
 bool WorldServer::SendPacket(ServerPacket *pack)


### PR DESCRIPTION
This is carry over from Shared Tasks work in #1451 

This brings down inter-process keep alive pings to 1 second (1000ms); this results in faster disconnects and reconnects and the overhead is very minimal