### PR TITLE
[Networking] Pad Zero Size Server to Server Packets

### DIFF
--- a/common/net/servertalk_client_connection.cpp
+++ b/common/net/servertalk_client_connection.cpp
@@ -21,6 +21,11 @@ EQ::Net::ServertalkClient::~ServertalkClient()
 
 void EQ::Net::ServertalkClient::Send(uint16_t opcode, EQ::Net::Packet &p)
 {
+	// pad zero size packets
+	if (p.Length() == 0) {
+		p.PutUInt8(0, 0);
+	}
+
 	EQ::Net::DynamicPacket out;
 	out.PutUInt32(0, p.Length());
 	out.PutUInt16(4, opcode);

--- a/common/net/servertalk_server_connection.cpp
+++ b/common/net/servertalk_server_connection.cpp
@@ -19,6 +19,11 @@ EQ::Net::ServertalkServerConnection::~ServertalkServerConnection()
 
 void EQ::Net::ServertalkServerConnection::Send(uint16_t opcode, EQ::Net::Packet & p)
 {
+	// pad zero size packets
+	if (p.Length() == 0) {
+		p.PutUInt8(0, 0);
+	}
+
 	EQ::Net::DynamicPacket out;
 	out.PutUInt32(0, p.Length());
 	out.PutUInt16(4, opcode);


### PR DESCRIPTION
We have several packets throughout the code base that are server to server that are zero size to simply send messages which stopped working with #1464 

PR #1464 removed some of this functionality in the sense that encrypted connections padded zero length packets

This restores the padding for unencrypted packets