### PR TITLE
[Logging] Implement World GMSay Logging

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -727,6 +727,7 @@ RULE_CATEGORY_END()
 
 RULE_CATEGORY(Logging)
 RULE_BOOL(Logging, PrintFileFunctionAndLine, false, "Ex: [World Server] [net.cpp::main:309] Loading variables...")
+RULE_BOOL(Logging, WorldGMSayLogging, true, "Relay worldserver logging to zone processes via GM say output")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(HotReload)

--- a/world/main.cpp
+++ b/world/main.cpp
@@ -229,6 +229,44 @@ void RegisterLoginservers()
 	}
 }
 
+static void GMSayHookCallBackProcessWorld(uint16 log_category, std::string message)
+{
+	// Cut messages down to 4000 max to prevent client crash
+	if (!message.empty()) {
+		message = message.substr(0, 4000);
+	}
+
+	// Replace Occurrences of % or MessageStatus will crash
+	find_replace(message, std::string("%"), std::string("."));
+
+	if (message.find('\n') != std::string::npos) {
+		auto message_split = SplitString(message, '\n');
+
+		for (size_t iter = 0; iter < message_split.size(); ++iter) {
+			zoneserver_list.SendEmoteMessage(
+				nullptr,
+				0,
+				0,
+				LogSys.GetGMSayColorFromCategory(log_category),
+				" %s%s",
+				(iter == 0 ? " ---" : ""),
+				message_split[iter].c_str()
+			);
+		}
+
+		return;
+	}
+
+	zoneserver_list.SendEmoteMessage(
+		nullptr,
+		0,
+		0,
+		LogSys.GetGMSayColorFromCategory(log_category),
+		"%s",
+		message.c_str()
+	);
+}
+
 /**
  * World process entrypoint
  *

--- a/world/main.cpp
+++ b/world/main.cpp
@@ -297,9 +297,15 @@ int main(int argc, char** argv) {
 
 	guild_mgr.SetDatabase(&database);
 
-	LogSys.SetDatabase(&database)
-		->LoadLogDatabaseSettings()
-		->StartFileLogs();
+	// logging system init
+	auto logging = LogSys.SetDatabase(&database)
+		->LoadLogDatabaseSettings();
+
+	if (RuleB(Logging, WorldGMSayLogging)) {
+		logging->SetGMSayHandler(&GMSayHookCallBackProcessWorld);
+	}
+
+	logging->StartFileLogs();
 
 	/**
 	 * Parse simple CLI passes

--- a/world/main.cpp
+++ b/world/main.cpp
@@ -246,7 +246,7 @@ static void GMSayHookCallBackProcessWorld(uint16 log_category, std::string messa
 			zoneserver_list.SendEmoteMessage(
 				nullptr,
 				0,
-				0,
+				80,
 				LogSys.GetGMSayColorFromCategory(log_category),
 				" %s%s",
 				(iter == 0 ? " ---" : ""),
@@ -260,7 +260,7 @@ static void GMSayHookCallBackProcessWorld(uint16 log_category, std::string messa
 	zoneserver_list.SendEmoteMessage(
 		nullptr,
 		0,
-		0,
+		80,
 		LogSys.GetGMSayColorFromCategory(log_category),
 		"%s",
 		message.c_str()


### PR DESCRIPTION
Also work peeled from #1451 

This enables world GM say logging and relays all messages to all zoneservers.

This was especially helpful during Shared Tasks work where we need / want to see real live communication of packets being sent back and forth between world and zone

**Example**

![image](https://user-images.githubusercontent.com/3319450/130721233-a63c792b-accc-4a32-ad8b-b1ba3aa4dfa7.png)

This also adds the following rule which is enabled by default

```
RULE_BOOL(Logging, WorldGMSayLogging, true, "Relay worldserver logging to zone processes via GM say output")
```

Of course operators will need to be mindful of not turning on excessive logging but should be fine performance wise under normal conditions
