### PR TITLE
[Spells] Allow SE_SecondaryForte 248 to be calculated as a bonus instead of hardcoded AA

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -1,4 +1,4 @@
-/*	EQEMu: Everquest Server Emulator
+/*	EQEMuSE_SecondaryForteSE_SecondaryForte: Everquest Server Emulator
 	Copyright (C) 2001-2004 EQEMu Development Team (http://eqemu.org)
 
 	This program is free software; you can redistribute it and/or modify
@@ -1662,8 +1662,8 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 		case SE_SecondaryForte:
 			if (newbon->SecondaryForte < base1) {
 				newbon->SecondaryForte = base1;
-      }
-      break;
+			}
+			break;
         
 		case SE_ZoneSuspendMinion:
 			newbon->ZoneSuspendMinion = base1;

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -1658,14 +1658,17 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			newbon->ItemEnduranceRegenCap += base1;
 			break;
 
+		case SE_SecondaryForte:
+			if (newbon->SecondaryForte < base1)
+				newbon->SecondaryForte = base1;
+			break;
+
 		// to do
 		case SE_PetDiscipline:
 			break;
 		case SE_PotionBeltSlots:
 			break;
 		case SE_BandolierSlots:
-			break;
-		case SE_SecondaryForte:
 			break;
 		case SE_ReduceApplyPoisonTime:
 			break;

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -1,4 +1,4 @@
-/*	EQEMuSE_SecondaryForteSE_SecondaryForte: Everquest Server Emulator
+/*	EQEMu: Everquest Server Emulator
 	Copyright (C) 2001-2004 EQEMu Development Team (http://eqemu.org)
 
 	This program is free software; you can redistribute it and/or modify

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -2580,7 +2580,7 @@ uint16 Client::GetMaxSkillAfterSpecializationRules(EQ::skills::SkillType skillid
 
 		}
 	}
-
+	Shout("Result %i Max skill %i [%i]", Result, maxSkill, skillid);
 	Result += spellbonuses.RaiseSkillCap[skillid] + itembonuses.RaiseSkillCap[skillid] + aabonuses.RaiseSkillCap[skillid];
 
 	if (skillid == EQ::skills::SkillType::SkillForage)

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -2552,7 +2552,6 @@ uint16 Client::GetMaxSkillAfterSpecializationRules(EQ::skills::SkillType skillid
 				}
 				else
 				{
-					Shout("Skill id %i PrimarySpec %i SecondaryForte skillid %i [aa bonus %i]", skillid, PrimarySpecialization, SecondaryForte, aabonuses.SecondaryForte);
 					if((skillid != PrimarySpecialization) && ((skillid == SecondaryForte) || (SecondaryForte == 0)))
 					{
 						if((PrimarySkillValue > 100) || (!SecondaryForte))
@@ -2580,7 +2579,7 @@ uint16 Client::GetMaxSkillAfterSpecializationRules(EQ::skills::SkillType skillid
 
 		}
 	}
-	Shout("Result %i Max skill %i [%i]", Result, maxSkill, skillid);
+
 	Result += spellbonuses.RaiseSkillCap[skillid] + itembonuses.RaiseSkillCap[skillid] + aabonuses.RaiseSkillCap[skillid];
 
 	if (skillid == EQ::skills::SkillType::SkillForage)

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -2502,8 +2502,8 @@ uint16 Client::GetMaxSkillAfterSpecializationRules(EQ::skills::SkillType skillid
 	uint16 PrimarySpecialization = 0, SecondaryForte = 0;
 
 	uint16 PrimarySkillValue = 0, SecondarySkillValue = 0;
-
-	uint16 MaxSpecializations = GetAA(aaSecondaryForte) ? 2 : 1;
+	
+	uint16 MaxSpecializations = aabonuses.SecondaryForte ? 2 : 1;
 
 	if (skillid >= EQ::skills::SkillSpecializeAbjure && skillid <= EQ::skills::SkillSpecializeEvocation)
 	{
@@ -2552,6 +2552,7 @@ uint16 Client::GetMaxSkillAfterSpecializationRules(EQ::skills::SkillType skillid
 				}
 				else
 				{
+					Shout("Skill id %i PrimarySpec %i SecondaryForte skillid %i [aa bonus %i]", skillid, PrimarySpecialization, SecondaryForte, aabonuses.SecondaryForte);
 					if((skillid != PrimarySpecialization) && ((skillid == SecondaryForte) || (SecondaryForte == 0)))
 					{
 						if((PrimarySkillValue > 100) || (!SecondaryForte))

--- a/zone/common.h
+++ b/zone/common.h
@@ -556,6 +556,7 @@ struct StatBonuses {
 
 
 	// AAs
+	uint16  SecondaryForte;						// allow a second skill to be specialized with a cap of this value.
 	int32	ShieldDuration;						// extends duration of /shield ability
 	int32	ExtendedShielding;					// extends range of /shield ability
 	int8	Packrat;							// weight reduction for items, 1 point = 10%


### PR DESCRIPTION
Allow SE_SecondaryForte 248 to be calculated as a bonus instead of hardcoded AA

This affect allows you to have a secondary specialization that goes above the cap.

No change in functionality.