### PR TITLE
[Bug Fix] Shared Bank Charges Fix

### DIFF
--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -501,7 +501,7 @@ bool SharedDatabase::GetSharedBank(uint32 id, EQ::InventoryProfile *inv, bool is
 	for (auto row = results.begin(); row != results.end(); ++row) {
 		int16 slot_id = (int16)atoi(row[0]);
 		uint32 item_id = (uint32)atoi(row[1]);
-		int8 charges = (int8)atoi(row[2]);
+		int16 charges = (int16)atoi(row[2]);
 
 		uint32 aug[EQ::invaug::SOCKET_COUNT];
 		aug[0] = (uint32)atoi(row[3]);


### PR DESCRIPTION
- Shared bank charges were being set to int8 on select, meaning any item that stacks over 127 would break if put in shared bank, causing loss of items.