### PR TITLE
[Hitpoints] Remove HP Update Throttling

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -169,8 +169,6 @@ Client::Client(EQStreamInterface* ieqs)
   last_region_type(RegionTypeUnsupported),
   m_dirtyautohaters(false),
   mob_close_scan_timer(6000),
-  hp_self_update_throttle_timer(300),
-  hp_other_update_throttle_timer(500),
   position_update_timer(10000),
   consent_throttle_timer(2000),
   tmSitting(0)
@@ -2503,7 +2501,7 @@ uint16 Client::GetMaxSkillAfterSpecializationRules(EQ::skills::SkillType skillid
 	uint16 PrimarySpecialization = 0, SecondaryForte = 0;
 
 	uint16 PrimarySkillValue = 0, SecondarySkillValue = 0;
-	
+
 	uint16 MaxSpecializations = aabonuses.SecondaryForte ? 2 : 1;
 
 	if (skillid >= EQ::skills::SkillSpecializeAbjure && skillid <= EQ::skills::SkillSpecializeEvocation)

--- a/zone/client.h
+++ b/zone/client.h
@@ -1818,8 +1818,6 @@ private:
 	Timer helm_toggle_timer;
 	Timer aggro_meter_timer;
 	Timer mob_close_scan_timer;
-	Timer hp_self_update_throttle_timer; /* This is to prevent excessive packet sending under trains/fast combat */
-	Timer hp_other_update_throttle_timer; /* This is to keep clients from DOSing the server with macros that change client targets constantly */
 	Timer position_update_timer; /* Timer used when client hasn't updated within a 10 second window */
 	Timer consent_throttle_timer;
 	Timer dynamiczone_removal_timer;

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -119,8 +119,9 @@ bool Client::Process() {
 
 		// SendHPUpdate calls hpupdate_timer.Start so it can delay this timer, so lets not reset with the check
 		// since the function will anyways
-		if (hpupdate_timer.Check(false))
+		if (hpupdate_timer.Check(false)) {
 			SendHPUpdate();
+		}
 
 		/* I haven't naturally updated my position in 10 seconds, updating manually */
 		if (!is_client_moving && position_update_timer.Check()) {
@@ -466,7 +467,7 @@ bool Client::Process() {
 			if (gravity_timer.Check())
 				DoGravityEffect();
 		}
-		
+
 		if (shield_timer.Check()) {
 			ShieldAbilityFinish();
 		}


### PR DESCRIPTION
Throttling was put in place before we had percentage based HP updates, we're likely missing updates in edge cases because of this so having the throttling removed will increase update precision and accuracy

Folks like splose, chrsschb, symetrix first addressing this in coders