### PR TITLE
[GM Command] Door Manipulation Command Port

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -526,6 +526,7 @@ SET(common_headers
 	guild_base.h
 	guilds.h
 	http/httplib.h
+	http/uri.h
 	inventory_profile.h
 	inventory_slot.h
 	ipc_mutex.h
@@ -638,7 +639,8 @@ SET(common_headers
 	StackWalker/StackWalker.h
 	util/memory_stream.h
 	util/directory.h
-	util/uuid.h)
+	util/uuid.h
+)
 
 SOURCE_GROUP(Event FILES
 	event/event_loop.h

--- a/common/database.cpp
+++ b/common/database.cpp
@@ -39,7 +39,6 @@
 #include "unix.h"
 #include <netinet/in.h>
 #include <sys/time.h>
-#include <codecvt>
 
 #endif
 
@@ -2424,58 +2423,65 @@ bool Database::CopyCharacter(
 
 void Database::SourceDatabaseTableFromUrl(std::string table_name, std::string url)
 {
-	std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-	std::wstring wurl = converter.from_bytes(url);
-	Uri result = Uri::Parse(wurl);
+	try {
+		uri request_uri(url);
 
-//	std::cout << "Path " << converter.to_bytes(result.Path) << std::endl;
-//	std::cout << "Host " << converter.to_bytes(result.Host) << std::endl;
-//	std::cout << "QueryString " << converter.to_bytes(result.QueryString) << std::endl;
-//	std::cout << "Protocol " << converter.to_bytes(result.Protocol) << std::endl;
-//	std::cout << "Port " << converter.to_bytes(result.Port) << std::endl;
-
-	if (!DoesTableExist(table_name)) {
-		LogMySQLQuery("Table [{}] does not exist. Downloading from Github and installing...", table_name);
-
-		// http get request
-		httplib::Client cli(
-			fmt::format(
-				"{}://{}",
-				converter.to_bytes(result.Protocol),
-				converter.to_bytes(result.Host)
-			).c_str()
+		LogHTTP(
+			"[SourceDatabaseTableFromUrl] parsing url [{}] path [{}] host [{}] query_string [{}] protocol [{}] port [{}]",
+			url,
+			request_uri.get_path(),
+			request_uri.get_host(),
+			request_uri.get_query(),
+			request_uri.get_scheme(),
+			request_uri.get_port()
 		);
 
-		cli.set_connection_timeout(0, 60000000); // 60 sec
-		cli.set_read_timeout(60, 0); // 60 seconds
-		cli.set_write_timeout(60, 0); // 60 seconds
+		if (!DoesTableExist(table_name)) {
+			LogMySQLQuery("Table [{}] does not exist. Downloading from Github and installing...", table_name);
 
-		int sourced_queries     = 0;
-		std::string request_url = converter.to_bytes(result.Path);
+			// http get request
+			httplib::Client cli(
+				fmt::format(
+					"{}://{}",
+					request_uri.get_scheme(),
+					request_uri.get_host()
+				).c_str()
+			);
 
-		if (auto res = cli.Get(request_url.c_str())) {
-			if (res->status == 200) {
-				for (auto &s: SplitString(res->body, ';')) {
-					if (!trim(s).empty()) {
-						auto results = QueryDatabase(s);
-						if (!results.ErrorMessage().empty()) {
-							LogError("Error sourcing SQL [{}]", results.ErrorMessage());
-							return;
+			cli.set_connection_timeout(0, 60000000); // 60 sec
+			cli.set_read_timeout(60, 0); // 60 seconds
+			cli.set_write_timeout(60, 0); // 60 seconds
+
+			int sourced_queries = 0;
+
+			if (auto res = cli.Get(request_uri.get_path().c_str())) {
+				if (res->status == 200) {
+					for (auto &s: SplitString(res->body, ';')) {
+						if (!trim(s).empty()) {
+							auto results = QueryDatabase(s);
+							if (!results.ErrorMessage().empty()) {
+								LogError("Error sourcing SQL [{}]", results.ErrorMessage());
+								return;
+							}
+							sourced_queries++;
 						}
-						sourced_queries++;
 					}
 				}
 			}
-		}
-		else {
-			LogError("Error retrieving URL [{}]", url);
+			else {
+				LogError("Error retrieving URL [{}]", url);
+			}
+
+			LogMySQLQuery(
+				"Table [{}] installed. Sourced [{}] queries",
+				table_name,
+				sourced_queries
+			);
 		}
 
-		LogMySQLQuery(
-			"Table [{}] installed. Sourced [{}] queries",
-			table_name,
-			sourced_queries
-		);
+	}
+	catch (std::invalid_argument iae) {
+		LogError("[SourceDatabaseTableFromUrl] URI parser error [{}]", iae.what());
 	}
 }
 

--- a/common/database.h
+++ b/common/database.h
@@ -269,6 +269,8 @@ public:
 	int		CountInvSnapshots();
 	void	ClearInvSnapshots(bool from_now = false);
 
+	void SourceDatabaseTableFromUrl(std::string table_name, std::string url);
+
 
 private:
 

--- a/common/eqemu_logsys.cpp
+++ b/common/eqemu_logsys.cpp
@@ -130,6 +130,8 @@ EQEmuLogSys *EQEmuLogSys::LoadLogSettingsDefaults()
 	log_settings[Logs::Loot].log_to_gmsay             = static_cast<uint8>(Logs::General);
 	log_settings[Logs::Scheduler].log_to_console      = static_cast<uint8>(Logs::General);
 	log_settings[Logs::Cheat].log_to_console          = static_cast<uint8>(Logs::General);
+	log_settings[Logs::HTTP].log_to_console           = static_cast<uint8>(Logs::General);
+	log_settings[Logs::HTTP].log_to_gmsay             = static_cast<uint8>(Logs::General);
 
 	/**
 	 * RFC 5424

--- a/common/eqemu_logsys.h
+++ b/common/eqemu_logsys.h
@@ -125,6 +125,7 @@ namespace Logs {
 		Cheat,
 		ClientList,
 		DiaWind,
+		HTTP,
 		MaxCategoryID /* Don't Remove this */
 	};
 
@@ -208,6 +209,7 @@ namespace Logs {
 		"Cheat",
 		"ClientList",
 		"DialogueWindow",
+		"HTTP",
 	};
 }
 

--- a/common/eqemu_logsys_log_aliases.h
+++ b/common/eqemu_logsys_log_aliases.h
@@ -676,6 +676,16 @@
         OutF(LogSys, Logs::Detail, Logs::DiaWind, __FILE__, __func__, __LINE__, message, ##__VA_ARGS__);\
 } while (0)
 
+#define LogHTTP(message, ...) do {\
+    if (LogSys.log_settings[Logs::HTTP].is_category_enabled == 1)\
+        OutF(LogSys, Logs::General, Logs::HTTP, __FILE__, __func__, __LINE__, message, ##__VA_ARGS__);\
+} while (0)
+
+#define LogHTTPDetail(message, ...) do {\
+    if (LogSys.log_settings[Logs::HTTP].is_category_enabled == 1)\
+        OutF(LogSys, Logs::Detail, Logs::HTTP, __FILE__, __func__, __LINE__, message, ##__VA_ARGS__);\
+} while (0)
+
 #define Log(debug_level, log_category, message, ...) do {\
     if (LogSys.log_settings[log_category].is_category_enabled == 1)\
         LogSys.Out(debug_level, log_category, __FILE__, __func__, __LINE__, message, ##__VA_ARGS__);\
@@ -1064,6 +1074,12 @@
 } while (0)
 
 #define LogDiaWindDetail(message, ...) do {\
+} while (0)
+
+#define LogHTTP(message, ...) do {\
+} while (0)
+
+#define LogHTTPDetail(message, ...) do {\
 } while (0)
 
 #define Log(debug_level, log_category, message, ...) do {\

--- a/common/http/uri.h
+++ b/common/http/uri.h
@@ -1,79 +1,633 @@
-#ifndef EQEMU_URI_H
-#define EQEMU_URI_H
+// Copyright (C) 2015 Ben Lewis <benjf5+github@gmail.com>
+// Licensed under the MIT license.
+// https://github.com/ben-zen/uri-library
 
+#pragma once
+
+#include <cctype>
+#include <map>
 #include <string>
-#include <algorithm>    // find
+#include <stdexcept>
+#include <utility>
 
-struct Uri {
+class uri {
+	/* URIs are broadly divided into two categories: hierarchical and
+	 * non-hierarchical. Both hierarchical URIs and non-hierarchical URIs have a
+	 * few elements in common; all URIs have a scheme of one or more alphanumeric
+	 * characters followed by a colon, and they all may optionally have a query
+	 * component preceded by a question mark, and a fragment component preceded by
+	 * an octothorpe (hash mark: '#'). The query consists of stanzas separated by
+	 * either ampersands ('&') or semicolons (';') (but only one or the other),
+	 * and each stanza consists of a key and an optional value; if the value
+	 * exists, the key and value must be divided by an equals sign.
+	 *
+	 * The following is an example from Wikipedia of a hierarchical URI:
+	 * scheme:[//[user:password@]domain[:port]][/]path[?query][#fragment]
+	 */
+
 public:
-	std::wstring QueryString, Path, Protocol, Host, Port;
 
-	static Uri Parse(const std::wstring &uri)
+	enum class scheme_category {
+		Hierarchical,
+		NonHierarchical
+	};
+
+	enum class component {
+		Scheme,
+		Content,
+		Username,
+		Password,
+		Host,
+		Port,
+		Path,
+		Query,
+		Fragment
+	};
+
+	enum class query_argument_separator {
+		ampersand,
+		semicolon
+	};
+
+	uri(
+		char const *uri_text, scheme_category category = scheme_category::Hierarchical,
+		query_argument_separator separator = query_argument_separator::ampersand
+	) :
+		m_category(category),
+		m_path_is_rooted(false),
+		m_port(0),
+		m_separator(separator)
 	{
-		Uri result;
+		setup(std::string(uri_text), category);
+	};
 
-		typedef std::wstring::const_iterator iterator_t;
+	uri(
+		std::string const &uri_text, scheme_category category = scheme_category::Hierarchical,
+		query_argument_separator separator = query_argument_separator::ampersand
+	) :
+		m_category(category),
+		m_path_is_rooted(false),
+		m_port(0),
+		m_separator(separator)
+	{
+		setup(uri_text, category);
+	};
 
-		if (uri.length() == 0) {
-			return result;
-		}
-
-		iterator_t uriEnd = uri.end();
-
-		// get query start
-		iterator_t queryStart = std::find(uri.begin(), uriEnd, L'?');
-
-		// protocol
-		iterator_t protocolStart = uri.begin();
-		iterator_t protocolEnd   = std::find(protocolStart, uriEnd, L':');            //"://");
-
-		if (protocolEnd != uriEnd) {
-			std::wstring prot = &*(protocolEnd);
-			if ((prot.length() > 3) && (prot.substr(0, 3) == L"://")) {
-				result.Protocol = std::wstring(protocolStart, protocolEnd);
-				protocolEnd += 3;   //      ://
+	uri(
+		std::map<component, std::string> const &components,
+		scheme_category category,
+		bool rooted_path,
+		query_argument_separator separator = query_argument_separator::ampersand
+	) :
+		m_category(category),
+		m_path_is_rooted(rooted_path),
+		m_separator(separator)
+	{
+		if (components.count(component::Scheme)) {
+			if (components.at(component::Scheme).length() == 0) {
+				throw std::invalid_argument("Scheme cannot be empty.");
 			}
-			else {
-				protocolEnd = uri.begin();
-			}  // no protocol
+			m_scheme = components.at(component::Scheme);
 		}
 		else {
-			protocolEnd = uri.begin();
-		}  // no protocol
-
-		// host
-		iterator_t hostStart = protocolEnd;
-		iterator_t pathStart = std::find(hostStart, uriEnd, L'/');  // get pathStart
-
-		iterator_t hostEnd = std::find(
-			protocolEnd,
-			(pathStart != uriEnd) ? pathStart : queryStart,
-			L':'
-		);  // check for port
-
-		result.Host = std::wstring(hostStart, hostEnd);
-
-		// port
-		if ((hostEnd != uriEnd) && ((&*(hostEnd))[0] == L':'))  // we have a port
-		{
-			hostEnd++;
-			iterator_t portEnd = (pathStart != uriEnd) ? pathStart : queryStart;
-			result.Port = std::wstring(hostEnd, portEnd);
+			throw std::invalid_argument("A URI must have a scheme.");
 		}
 
-		// path
-		if (pathStart != uriEnd) {
-			result.Path = std::wstring(pathStart, queryStart);
+		if (category == scheme_category::Hierarchical) {
+			if (components.count(component::Content)) {
+				throw std::invalid_argument("The content component is only for use in non-hierarchical URIs.");
+			}
+
+			bool has_username = components.count(component::Username);
+			bool has_password = components.count(component::Password);
+			if (has_username && has_password) {
+				m_username = components.at(component::Username);
+				m_password = components.at(component::Password);
+			}
+			else if ((has_username && !has_password) || (!has_username && has_password)) {
+				throw std::invalid_argument("If a username or password is supplied, both must be provided.");
+			}
+
+			if (components.count(component::Host)) {
+				m_host = components.at(component::Host);
+			}
+
+			if (components.count(component::Port)) {
+				m_port = std::stoul(components.at(component::Port));
+			}
+
+			if (components.count(component::Path)) {
+				m_path = components.at(component::Path);
+			}
+			else {
+				throw std::invalid_argument("A path is required on a hierarchical URI, even an empty path.");
+			}
+		}
+		else {
+			if (components.count(component::Username)
+				|| components.count(component::Password)
+				|| components.count(component::Host)
+				|| components.count(component::Port)
+				|| components.count(component::Path)) {
+				throw std::invalid_argument("None of the hierarchical components are allowed in a non-hierarchical URI.");
+			}
+
+			if (components.count(component::Content)) {
+				m_content = components.at(component::Content);
+			}
+			else {
+				throw std::invalid_argument(
+					"Content is a required component for a non-hierarchical URI, even an empty string."
+				);
+			}
 		}
 
-		// query
-		if (queryStart != uriEnd) {
-			result.QueryString = std::wstring(queryStart, uri.end());
+		if (components.count(component::Query)) {
+			m_query = components.at(component::Query);
 		}
 
-		return result;
+		if (components.count(component::Fragment)) {
+			m_fragment = components.at(component::Fragment);
+		}
+	}
 
-	}   // Parse
-};  // uri
+	uri(uri const &other, std::map<component, std::string> const &replacements) :
+		m_category(other.m_category),
+		m_path_is_rooted(other.m_path_is_rooted),
+		m_separator(other.m_separator)
+	{
+		m_scheme = (replacements.count(component::Scheme))
+			? replacements.at(component::Scheme) : other.m_scheme;
 
-#endif //EQEMU_URI_H
+		if (m_category == scheme_category::Hierarchical) {
+			m_username = (replacements.count(component::Username))
+				? replacements.at(component::Username) : other.m_username;
+
+			m_password = (replacements.count(component::Password))
+				? replacements.at(component::Password) : other.m_password;
+
+			m_host = (replacements.count(component::Host))
+				? replacements.at(component::Host) : other.m_host;
+
+			m_port = (replacements.count(component::Port))
+				? std::stoul(replacements.at(component::Port)) : other.m_port;
+
+			m_path = (replacements.count(component::Path))
+				? replacements.at(component::Path) : other.m_path;
+		}
+		else {
+			m_content = (replacements.count(component::Content))
+				? replacements.at(component::Content) : other.m_content;
+		}
+
+		m_query = (replacements.count(component::Query))
+			? replacements.at(component::Query) : other.m_query;
+
+		m_fragment = (replacements.count(component::Fragment))
+			? replacements.at(component::Fragment) : other.m_fragment;
+	}
+
+	// Copy constructor; just use the copy assignment operator internally.
+	uri(uri const &other)
+	{
+		*this = other;
+	};
+
+	// Copy assignment operator
+	uri &operator=(uri const &other)
+	{
+		if (this != &other) {
+			m_scheme         = other.m_scheme;
+			m_content        = other.m_content;
+			m_username       = other.m_username;
+			m_password       = other.m_password;
+			m_host           = other.m_host;
+			m_path           = other.m_path;
+			m_query          = other.m_query;
+			m_fragment       = other.m_fragment;
+			m_query_dict     = other.m_query_dict;
+			m_category       = other.m_category;
+			m_port           = other.m_port;
+			m_path_is_rooted = other.m_path_is_rooted;
+			m_separator      = other.m_separator;
+		}
+		return *this;
+	}
+
+	~uri() {};
+
+	std::string const &get_scheme() const
+	{
+		return m_scheme;
+	};
+
+	scheme_category get_scheme_category() const
+	{
+		return m_category;
+	};
+
+	std::string const &get_content() const
+	{
+		if (m_category != scheme_category::NonHierarchical) {
+			throw std::domain_error("The content component is only valid for non-hierarchical URIs.");
+		}
+		return m_content;
+	};
+
+	std::string const &get_username() const
+	{
+		if (m_category != scheme_category::Hierarchical) {
+			throw std::domain_error("The username component is only valid for hierarchical URIs.");
+		}
+		return m_username;
+	};
+
+	std::string const &get_password() const
+	{
+		if (m_category != scheme_category::Hierarchical) {
+			throw std::domain_error("The password component is only valid for hierarchical URIs.");
+		}
+		return m_password;
+	};
+
+	std::string const &get_host() const
+	{
+		if (m_category != scheme_category::Hierarchical) {
+			throw std::domain_error("The host component is only valid for hierarchical URIs.");
+		}
+		return m_host;
+	};
+
+	unsigned long get_port() const
+	{
+		if (m_category != scheme_category::Hierarchical) {
+			throw std::domain_error("The port component is only valid for hierarchical URIs.");
+		}
+		return m_port;
+	};
+
+	std::string const &get_path() const
+	{
+		if (m_category != scheme_category::Hierarchical) {
+			throw std::domain_error("The path component is only valid for hierarchical URIs.");
+		}
+		return m_path;
+	};
+
+	std::string const &get_query() const
+	{
+		return m_query;
+	};
+
+	std::map<std::string, std::string> const &get_query_dictionary() const
+	{
+		return m_query_dict;
+	};
+
+	std::string const &get_fragment() const
+	{
+		return m_fragment;
+	};
+
+	std::string to_string() const
+	{
+		std::string full_uri;
+		full_uri.append(m_scheme);
+		full_uri.append(":");
+
+		if (m_content.length() > m_path.length()) {
+			full_uri.append("//");
+			if (!(m_username.empty() || m_password.empty())) {
+				full_uri.append(m_username);
+				full_uri.append(":");
+				full_uri.append(m_password);
+				full_uri.append("@");
+			}
+
+			full_uri.append(m_host);
+
+			if (m_port != 0) {
+				full_uri.append(":");
+				full_uri.append(std::to_string(m_port));
+			}
+		}
+
+		if (m_path_is_rooted) {
+			full_uri.append("/");
+		}
+		full_uri.append(m_path);
+
+		if (!m_query.empty()) {
+			full_uri.append("?");
+			full_uri.append(m_query);
+		}
+
+		if (!m_fragment.empty()) {
+			full_uri.append("#");
+			full_uri.append(m_fragment);
+		}
+
+		return full_uri;
+	};
+
+private:
+
+	void setup(std::string const &uri_text, scheme_category category)
+	{
+		size_t const uri_length = uri_text.length();
+
+		if (uri_length == 0) {
+			throw std::invalid_argument("URIs cannot be of zero length.");
+		}
+
+		std::string::const_iterator cursor = parse_scheme(
+			uri_text,
+			uri_text.begin());
+		// After calling parse_scheme, *cursor == ':'; none of the following parsers
+		// expect a separator character, so we advance the cursor upon calling them.
+		cursor = parse_content(uri_text, (cursor + 1));
+
+		if ((cursor != uri_text.end()) && (*cursor == '?')) {
+			cursor = parse_query(uri_text, (cursor + 1));
+		}
+
+		if ((cursor != uri_text.end()) && (*cursor == '#')) {
+			cursor = parse_fragment(uri_text, (cursor + 1));
+		}
+
+		init_query_dictionary(); // If the query string is empty, this will be empty too.
+
+	};
+
+	std::string::const_iterator parse_scheme(
+		std::string const &uri_text,
+		std::string::const_iterator scheme_start
+	)
+	{
+		std::string::const_iterator scheme_end = scheme_start;
+		while ((scheme_end != uri_text.end()) && (*scheme_end != ':')) {
+			if (!(std::isalnum(*scheme_end) || (*scheme_end == '-')
+				  || (*scheme_end == '+') || (*scheme_end == '.'))) {
+				throw std::invalid_argument(
+					"Invalid character found in the scheme component. Supplied URI was: \""
+					+ uri_text + "\"."
+				);
+			}
+			++scheme_end;
+		}
+
+		if (scheme_end == uri_text.end()) {
+			throw std::invalid_argument(
+				"End of URI found while parsing the scheme. Supplied URI was: \""
+				+ uri_text + "\"."
+			);
+		}
+
+		if (scheme_start == scheme_end) {
+			throw std::invalid_argument(
+				"Scheme component cannot be zero-length. Supplied URI was: \""
+				+ uri_text + "\"."
+			);
+		}
+
+		m_scheme = std::move(std::string(scheme_start, scheme_end));
+		return scheme_end;
+	};
+
+	std::string::const_iterator parse_content(
+		std::string const &uri_text,
+		std::string::const_iterator content_start
+	)
+	{
+		std::string::const_iterator content_end = content_start;
+		while ((content_end != uri_text.end()) && (*content_end != '?') && (*content_end != '#')) {
+			++content_end;
+		}
+
+		m_content = std::move(std::string(content_start, content_end));
+
+		if ((m_category == scheme_category::Hierarchical) && (m_content.length() > 0)) {
+			// If it's a hierarchical URI, the content should be parsed for the hierarchical components.
+			std::string::const_iterator path_start = m_content.begin();
+			std::string::const_iterator path_end   = m_content.end();
+			if (!m_content.compare(0, 2, "//")) {
+				// In this case an authority component is present.
+				std::string::const_iterator authority_cursor = (m_content.begin() + 2);
+				if (m_content.find_first_of('@') != std::string::npos) {
+					std::string::const_iterator userpass_divider = parse_username(
+						uri_text,
+						m_content,
+						authority_cursor
+					);
+					authority_cursor = parse_password(uri_text, m_content, (userpass_divider + 1));
+					// After this call, *authority_cursor == '@', so we skip over it.
+					++authority_cursor;
+				}
+
+				authority_cursor = parse_host(uri_text, m_content, authority_cursor);
+
+				if ((authority_cursor != m_content.end()) && (*authority_cursor == ':')) {
+					authority_cursor = parse_port(uri_text, m_content, (authority_cursor + 1));
+				}
+
+				if ((authority_cursor != m_content.end()) && (*authority_cursor == '/')) {
+					// Then the path is rooted, and we should note this.
+					m_path_is_rooted = true;
+					path_start       = authority_cursor + 1;
+				}
+
+				// If we've reached the end and no path is present then set path_start
+				// to the end.
+				if (authority_cursor == m_content.end()) {
+					path_start = m_content.end();
+				}
+			}
+			else if (!m_content.compare(0, 1, "/")) {
+				m_path_is_rooted = true;
+				++path_start;
+			}
+
+			// We can now build the path based on what remains in the content string,
+			// since that's all that exists after the host and optional port component.
+			m_path = std::move(std::string(path_start, path_end));
+		}
+		return content_end;
+	};
+
+	std::string::const_iterator parse_username(
+		std::string const &uri_text,
+		std::string const &content,
+		std::string::const_iterator username_start
+	)
+	{
+		std::string::const_iterator username_end = username_start;
+		// Since this is only reachable when '@' was in the content string, we can
+		// ignore the end-of-string case.
+		while (*username_end != ':') {
+			if (*username_end == '@') {
+				throw std::invalid_argument(
+					"Username must be followed by a password. Supplied URI was: \""
+					+ uri_text + "\"."
+				);
+			}
+			++username_end;
+		}
+		m_username = std::move(std::string(username_start, username_end));
+		return username_end;
+	};
+
+	std::string::const_iterator parse_password(
+		std::string const &uri_text,
+		std::string const &content,
+		std::string::const_iterator password_start
+	)
+	{
+		std::string::const_iterator password_end = password_start;
+		while (*password_end != '@') {
+			++password_end;
+		}
+
+		m_password = std::move(std::string(password_start, password_end));
+		return password_end;
+	};
+
+	std::string::const_iterator parse_host(
+		std::string const &uri_text,
+		std::string const &content,
+		std::string::const_iterator host_start
+	)
+	{
+		std::string::const_iterator host_end = host_start;
+		// So, the host can contain a few things. It can be a domain, it can be an
+		// IPv4 address, it can be an IPv6 address, or an IPvFuture literal. In the
+		// case of those last two, it's of the form [...] where what's between the
+		// brackets is a matter of which IPv?? version it is.
+		while (host_end != content.end()) {
+			if (*host_end == '[') {
+				// We're parsing an IPv6 or IPvFuture address, so we should handle that
+				// instead of the normal procedure.
+				while ((host_end != content.end()) && (*host_end != ']')) {
+					++host_end;
+				}
+
+				if (host_end == content.end()) {
+					throw std::invalid_argument(
+						"End of content component encountered "
+						"while parsing the host component. "
+						"Supplied URI was: \""
+						+ uri_text + "\"."
+					);
+				}
+
+				++host_end;
+				break;
+				// We can stop looping, we found the end of the IP literal, which is the
+				// whole of the host component when one's in use.
+			}
+			else if ((*host_end == ':') || (*host_end == '/')) {
+				break;
+			}
+			else {
+				++host_end;
+			}
+		}
+
+		m_host = std::move(std::string(host_start, host_end));
+		return host_end;
+	};
+
+	std::string::const_iterator parse_port(
+		std::string const &uri_text,
+		std::string const &content,
+		std::string::const_iterator port_start
+	)
+	{
+		std::string::const_iterator port_end = port_start;
+		while ((port_end != content.end()) && (*port_end != '/')) {
+			if (!std::isdigit(*port_end)) {
+				throw std::invalid_argument(
+					"Invalid character while parsing the port. "
+					"Supplied URI was: \"" + uri_text + "\"."
+				);
+			}
+
+			++port_end;
+		}
+
+		m_port = std::stoul(std::string(port_start, port_end));
+		return port_end;
+	};
+
+	std::string::const_iterator parse_query(
+		std::string const &uri_text,
+		std::string::const_iterator query_start
+	)
+	{
+		std::string::const_iterator query_end = query_start;
+		while ((query_end != uri_text.end()) && (*query_end != '#')) {
+			// Queries can contain almost any character except hash, which is reserved
+			// for the start of the fragment.
+			++query_end;
+		}
+		m_query = std::move(std::string(query_start, query_end));
+		return query_end;
+	};
+
+	std::string::const_iterator parse_fragment(
+		std::string const &uri_text,
+		std::string::const_iterator fragment_start
+	)
+	{
+		m_fragment = std::move(std::string(fragment_start, uri_text.end()));
+		return uri_text.end();
+	};
+
+	void init_query_dictionary()
+	{
+		if (!m_query.empty()) {
+			// Loop over the query string looking for '&'s, then check each one for
+			// an '=' to find keys and values; if there's not an '=' then the key
+			// will have an empty value in the map.
+			char   separator  = (m_separator == query_argument_separator::ampersand) ? '&' : ';';
+			size_t carat      = 0;
+			size_t stanza_end = m_query.find_first_of(separator);
+			do {
+				std::string stanza            = m_query.substr(
+					carat,
+					((stanza_end != std::string::npos) ? (stanza_end - carat) : std::string::npos));
+				size_t      key_value_divider = stanza.find_first_of('=');
+				std::string key               = stanza.substr(0, key_value_divider);
+				std::string value;
+				if (key_value_divider != std::string::npos) {
+					value = stanza.substr((key_value_divider + 1));
+				}
+
+				if (m_query_dict.count(key) != 0) {
+					throw std::invalid_argument("Bad key in the query string!");
+				}
+
+				m_query_dict.emplace(key, value);
+				carat      = ((stanza_end != std::string::npos) ? (stanza_end + 1)
+					: std::string::npos);
+				stanza_end = m_query.find_first_of(separator, carat);
+			} while ((stanza_end != std::string::npos)
+					 || (carat != std::string::npos));
+		}
+	}
+
+	std::string m_scheme;
+	std::string m_content;
+	std::string m_username;
+	std::string m_password;
+	std::string m_host;
+	std::string m_path;
+	std::string m_query;
+	std::string m_fragment;
+
+	std::map<std::string, std::string> m_query_dict;
+
+	scheme_category          m_category;
+	unsigned long            m_port;
+	bool                     m_path_is_rooted;
+	query_argument_separator m_separator;
+};

--- a/common/http/uri.h
+++ b/common/http/uri.h
@@ -1,0 +1,79 @@
+#ifndef EQEMU_URI_H
+#define EQEMU_URI_H
+
+#include <string>
+#include <algorithm>    // find
+
+struct Uri {
+public:
+	std::wstring QueryString, Path, Protocol, Host, Port;
+
+	static Uri Parse(const std::wstring &uri)
+	{
+		Uri result;
+
+		typedef std::wstring::const_iterator iterator_t;
+
+		if (uri.length() == 0) {
+			return result;
+		}
+
+		iterator_t uriEnd = uri.end();
+
+		// get query start
+		iterator_t queryStart = std::find(uri.begin(), uriEnd, L'?');
+
+		// protocol
+		iterator_t protocolStart = uri.begin();
+		iterator_t protocolEnd   = std::find(protocolStart, uriEnd, L':');            //"://");
+
+		if (protocolEnd != uriEnd) {
+			std::wstring prot = &*(protocolEnd);
+			if ((prot.length() > 3) && (prot.substr(0, 3) == L"://")) {
+				result.Protocol = std::wstring(protocolStart, protocolEnd);
+				protocolEnd += 3;   //      ://
+			}
+			else {
+				protocolEnd = uri.begin();
+			}  // no protocol
+		}
+		else {
+			protocolEnd = uri.begin();
+		}  // no protocol
+
+		// host
+		iterator_t hostStart = protocolEnd;
+		iterator_t pathStart = std::find(hostStart, uriEnd, L'/');  // get pathStart
+
+		iterator_t hostEnd = std::find(
+			protocolEnd,
+			(pathStart != uriEnd) ? pathStart : queryStart,
+			L':'
+		);  // check for port
+
+		result.Host = std::wstring(hostStart, hostEnd);
+
+		// port
+		if ((hostEnd != uriEnd) && ((&*(hostEnd))[0] == L':'))  // we have a port
+		{
+			hostEnd++;
+			iterator_t portEnd = (pathStart != uriEnd) ? pathStart : queryStart;
+			result.Port = std::wstring(hostEnd, portEnd);
+		}
+
+		// path
+		if (pathStart != uriEnd) {
+			result.Path = std::wstring(pathStart, queryStart);
+		}
+
+		// query
+		if (queryStart != uriEnd) {
+			result.QueryString = std::wstring(queryStart, uri.end());
+		}
+
+		return result;
+
+	}   // Parse
+};  // uri
+
+#endif //EQEMU_URI_H

--- a/common/repositories/base/base_tool_game_objects_repository.h
+++ b/common/repositories/base/base_tool_game_objects_repository.h
@@ -1,0 +1,346 @@
+/**
+ * DO NOT MODIFY THIS FILE
+ *
+ * This repository was automatically generated and is NOT to be modified directly.
+ * Any repository modifications are meant to be made to the repository extending the base.
+ * Any modifications to base repositories are to be made by the generator only
+ *
+ * @generator ./utils/scripts/generators/repository-generator.pl
+ * @docs https://eqemu.gitbook.io/server/in-development/developer-area/repositories
+ */
+
+#ifndef EQEMU_BASE_TOOL_GAME_OBJECTS_REPOSITORY_H
+#define EQEMU_BASE_TOOL_GAME_OBJECTS_REPOSITORY_H
+
+#include "../../database.h"
+#include "../../string_util.h"
+#include <ctime>
+
+class BaseToolGameObjectsRepository {
+public:
+	struct ToolGameObjects {
+		int         id;
+		int         zoneid;
+		std::string zonesn;
+		std::string object_name;
+		std::string file_from;
+		int         is_global;
+	};
+
+	static std::string PrimaryKey()
+	{
+		return std::string("id");
+	}
+
+	static std::vector<std::string> Columns()
+	{
+		return {
+			"id",
+			"zoneid",
+			"zonesn",
+			"object_name",
+			"file_from",
+			"is_global",
+		};
+	}
+
+	static std::vector<std::string> SelectColumns()
+	{
+		return {
+			"id",
+			"zoneid",
+			"zonesn",
+			"object_name",
+			"file_from",
+			"is_global",
+		};
+	}
+
+	static std::string ColumnsRaw()
+	{
+		return std::string(implode(", ", Columns()));
+	}
+
+	static std::string SelectColumnsRaw()
+	{
+		return std::string(implode(", ", SelectColumns()));
+	}
+
+	static std::string TableName()
+	{
+		return std::string("tool_game_objects");
+	}
+
+	static std::string BaseSelect()
+	{
+		return fmt::format(
+			"SELECT {} FROM {}",
+			SelectColumnsRaw(),
+			TableName()
+		);
+	}
+
+	static std::string BaseInsert()
+	{
+		return fmt::format(
+			"INSERT INTO {} ({}) ",
+			TableName(),
+			ColumnsRaw()
+		);
+	}
+
+	static ToolGameObjects NewEntity()
+	{
+		ToolGameObjects entry{};
+
+		entry.id          = 0;
+		entry.zoneid      = 0;
+		entry.zonesn      = "";
+		entry.object_name = "";
+		entry.file_from   = "";
+		entry.is_global   = 0;
+
+		return entry;
+	}
+
+	static ToolGameObjects GetToolGameObjectsEntry(
+		const std::vector<ToolGameObjects> &tool_game_objectss,
+		int tool_game_objects_id
+	)
+	{
+		for (auto &tool_game_objects : tool_game_objectss) {
+			if (tool_game_objects.id == tool_game_objects_id) {
+				return tool_game_objects;
+			}
+		}
+
+		return NewEntity();
+	}
+
+	static ToolGameObjects FindOne(
+		Database& db,
+		int tool_game_objects_id
+	)
+	{
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} WHERE id = {} LIMIT 1",
+				BaseSelect(),
+				tool_game_objects_id
+			)
+		);
+
+		auto row = results.begin();
+		if (results.RowCount() == 1) {
+			ToolGameObjects entry{};
+
+			entry.id          = atoi(row[0]);
+			entry.zoneid      = atoi(row[1]);
+			entry.zonesn      = row[2] ? row[2] : "";
+			entry.object_name = row[3] ? row[3] : "";
+			entry.file_from   = row[4] ? row[4] : "";
+			entry.is_global   = atoi(row[5]);
+
+			return entry;
+		}
+
+		return NewEntity();
+	}
+
+	static int DeleteOne(
+		Database& db,
+		int tool_game_objects_id
+	)
+	{
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"DELETE FROM {} WHERE {} = {}",
+				TableName(),
+				PrimaryKey(),
+				tool_game_objects_id
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
+
+	static int UpdateOne(
+		Database& db,
+		ToolGameObjects tool_game_objects_entry
+	)
+	{
+		std::vector<std::string> update_values;
+
+		auto columns = Columns();
+
+		update_values.push_back(columns[1] + " = " + std::to_string(tool_game_objects_entry.zoneid));
+		update_values.push_back(columns[2] + " = '" + EscapeString(tool_game_objects_entry.zonesn) + "'");
+		update_values.push_back(columns[3] + " = '" + EscapeString(tool_game_objects_entry.object_name) + "'");
+		update_values.push_back(columns[4] + " = '" + EscapeString(tool_game_objects_entry.file_from) + "'");
+		update_values.push_back(columns[5] + " = " + std::to_string(tool_game_objects_entry.is_global));
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"UPDATE {} SET {} WHERE {} = {}",
+				TableName(),
+				implode(", ", update_values),
+				PrimaryKey(),
+				tool_game_objects_entry.id
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
+
+	static ToolGameObjects InsertOne(
+		Database& db,
+		ToolGameObjects tool_game_objects_entry
+	)
+	{
+		std::vector<std::string> insert_values;
+
+		insert_values.push_back(std::to_string(tool_game_objects_entry.id));
+		insert_values.push_back(std::to_string(tool_game_objects_entry.zoneid));
+		insert_values.push_back("'" + EscapeString(tool_game_objects_entry.zonesn) + "'");
+		insert_values.push_back("'" + EscapeString(tool_game_objects_entry.object_name) + "'");
+		insert_values.push_back("'" + EscapeString(tool_game_objects_entry.file_from) + "'");
+		insert_values.push_back(std::to_string(tool_game_objects_entry.is_global));
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} VALUES ({})",
+				BaseInsert(),
+				implode(",", insert_values)
+			)
+		);
+
+		if (results.Success()) {
+			tool_game_objects_entry.id = results.LastInsertedID();
+			return tool_game_objects_entry;
+		}
+
+		tool_game_objects_entry = NewEntity();
+
+		return tool_game_objects_entry;
+	}
+
+	static int InsertMany(
+		Database& db,
+		std::vector<ToolGameObjects> tool_game_objects_entries
+	)
+	{
+		std::vector<std::string> insert_chunks;
+
+		for (auto &tool_game_objects_entry: tool_game_objects_entries) {
+			std::vector<std::string> insert_values;
+
+			insert_values.push_back(std::to_string(tool_game_objects_entry.id));
+			insert_values.push_back(std::to_string(tool_game_objects_entry.zoneid));
+			insert_values.push_back("'" + EscapeString(tool_game_objects_entry.zonesn) + "'");
+			insert_values.push_back("'" + EscapeString(tool_game_objects_entry.object_name) + "'");
+			insert_values.push_back("'" + EscapeString(tool_game_objects_entry.file_from) + "'");
+			insert_values.push_back(std::to_string(tool_game_objects_entry.is_global));
+
+			insert_chunks.push_back("(" + implode(",", insert_values) + ")");
+		}
+
+		std::vector<std::string> insert_values;
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} VALUES {}",
+				BaseInsert(),
+				implode(",", insert_chunks)
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
+
+	static std::vector<ToolGameObjects> All(Database& db)
+	{
+		std::vector<ToolGameObjects> all_entries;
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{}",
+				BaseSelect()
+			)
+		);
+
+		all_entries.reserve(results.RowCount());
+
+		for (auto row = results.begin(); row != results.end(); ++row) {
+			ToolGameObjects entry{};
+
+			entry.id          = atoi(row[0]);
+			entry.zoneid      = atoi(row[1]);
+			entry.zonesn      = row[2] ? row[2] : "";
+			entry.object_name = row[3] ? row[3] : "";
+			entry.file_from   = row[4] ? row[4] : "";
+			entry.is_global   = atoi(row[5]);
+
+			all_entries.push_back(entry);
+		}
+
+		return all_entries;
+	}
+
+	static std::vector<ToolGameObjects> GetWhere(Database& db, std::string where_filter)
+	{
+		std::vector<ToolGameObjects> all_entries;
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} WHERE {}",
+				BaseSelect(),
+				where_filter
+			)
+		);
+
+		all_entries.reserve(results.RowCount());
+
+		for (auto row = results.begin(); row != results.end(); ++row) {
+			ToolGameObjects entry{};
+
+			entry.id          = atoi(row[0]);
+			entry.zoneid      = atoi(row[1]);
+			entry.zonesn      = row[2] ? row[2] : "";
+			entry.object_name = row[3] ? row[3] : "";
+			entry.file_from   = row[4] ? row[4] : "";
+			entry.is_global   = atoi(row[5]);
+
+			all_entries.push_back(entry);
+		}
+
+		return all_entries;
+	}
+
+	static int DeleteWhere(Database& db, std::string where_filter)
+	{
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"DELETE FROM {} WHERE {}",
+				TableName(),
+				where_filter
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
+
+	static int Truncate(Database& db)
+	{
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"TRUNCATE TABLE {}",
+				TableName()
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
+
+};
+
+#endif //EQEMU_BASE_TOOL_GAME_OBJECTS_REPOSITORY_H

--- a/common/repositories/tool_game_objects_repository.h
+++ b/common/repositories/tool_game_objects_repository.h
@@ -1,0 +1,70 @@
+/**
+ * EQEmulator: Everquest Server Emulator
+ * Copyright (C) 2001-2020 EQEmulator Development Team (https://github.com/EQEmu/Server)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY except by those people which sell it, which
+ * are required to give you total support for your newly bought product;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ */
+
+#ifndef EQEMU_TOOL_GAME_OBJECTS_REPOSITORY_H
+#define EQEMU_TOOL_GAME_OBJECTS_REPOSITORY_H
+
+#include "../database.h"
+#include "../string_util.h"
+#include "base/base_tool_game_objects_repository.h"
+
+class ToolGameObjectsRepository: public BaseToolGameObjectsRepository {
+public:
+
+    /**
+     * This file was auto generated and can be modified and extended upon
+     *
+     * Base repository methods are automatically
+     * generated in the "base" version of this repository. The base repository
+     * is immutable and to be left untouched, while methods in this class
+     * are used as extension methods for more specific persistence-layer
+     * accessors or mutators.
+     *
+     * Base Methods (Subject to be expanded upon in time)
+     *
+     * Note: Not all tables are designed appropriately to fit functionality with all base methods
+     *
+     * InsertOne
+     * UpdateOne
+     * DeleteOne
+     * FindOne
+     * GetWhere(std::string where_filter)
+     * DeleteWhere(std::string where_filter)
+     * InsertMany
+     * All
+     *
+     * Example custom methods in a repository
+     *
+     * ToolGameObjectsRepository::GetByZoneAndVersion(int zone_id, int zone_version)
+     * ToolGameObjectsRepository::GetWhereNeverExpires()
+     * ToolGameObjectsRepository::GetWhereXAndY()
+     * ToolGameObjectsRepository::DeleteWhereXAndY()
+     *
+     * Most of the above could be covered by base methods, but if you as a developer
+     * find yourself re-using logic for other parts of the code, its best to just make a
+     * method that can be re-used easily elsewhere especially if it can use a base repository
+     * method and encapsulate filters there
+     */
+
+	// Custom extended repository methods here
+
+};
+
+#endif //EQEMU_TOOL_GAME_OBJECTS_REPOSITORY_H

--- a/utils/scripts/generators/repository-generator.pl
+++ b/utils/scripts/generators/repository-generator.pl
@@ -157,7 +157,7 @@ foreach my $table_to_generate (@tables) {
         $table_found_in_schema = 0;
     }
 
-    if ($table_found_in_schema == 0) {
+    if ($table_found_in_schema == 0 && ($requested_table_to_generate eq "" || $requested_table_to_generate eq "all")) {
         print "Table [$table_to_generate] not found in schema, skipping\n";
         next;
     }

--- a/zone/CMakeLists.txt
+++ b/zone/CMakeLists.txt
@@ -80,6 +80,7 @@ SET(zone_sources
 	fearpath.cpp
 	forage.cpp
 	global_loot_manager.cpp
+	gm_commands/door_manipulation.cpp
 	groups.cpp
 	guild.cpp
 	guild_mgr.cpp
@@ -198,6 +199,7 @@ SET(zone_headers
 	fastmath.h
 	forage.h
 	global_loot_manager.h
+	gm_commands/door_manipulation.h
 	groups.h
 	guild_mgr.h
 	hate_list.h

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10515,3 +10515,13 @@ void Client::ApplyWeaponsStance()
 		weaponstance.spellbonus_enabled = false;
 	}
 }
+
+uint16 Client::GetDoorToolEntityId() const
+{
+	return m_door_tool_entity_id;
+}
+
+void Client::SetDoorToolEntityId(uint16 door_tool_entity_id)
+{
+	Client::m_door_tool_entity_id = door_tool_entity_id;
+}

--- a/zone/client.h
+++ b/zone/client.h
@@ -1764,8 +1764,16 @@ private:
 	int Haste; //precalced value
 	uint32 tmSitting; // time stamp started sitting, used for HP regen bonus added on MAY 5, 2004
 
+
+	// dev tools
 	bool display_mob_info_window;
 	bool dev_tools_enabled;
+
+	uint16 m_door_tool_entity_id;
+public:
+	uint16 GetDoorToolEntityId() const;
+	void SetDoorToolEntityId(uint16 door_tool_entity_id);
+private:
 
 	int32 max_end;
 	int32 current_endurance;

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4359,7 +4359,7 @@ void Client::Handle_OP_ClickDoor(const EQApplicationPacket *app)
 
 	// set door selected
 	if (IsDevToolsEnabled()) {
-		SetDoorToolEntityId(currentdoor->GetID());
+		SetDoorToolEntityId(currentdoor->GetEntityID());
 
 		// $client->Message(15, "Door $doorid [" . quest::saylink("Close Door $doorid", 1, "Close Door") . "][" . quest::saylink("Open Door $doorid", 1, "Open Door") . "] [" . quest::saylink("#door edit", 1, "Edit Door") . "]");
 
@@ -4368,7 +4368,7 @@ void Client::Handle_OP_ClickDoor(const EQApplicationPacket *app)
 			Chat::White,
 			fmt::format(
 				"Door ({}) [{}]",
-				currentdoor->GetID(),
+				currentdoor->GetEntityID(),
 				EQ::SayLinkEngine::GenerateQuestSaylink("#door edit", false, "#door edit")
 			).c_str()
 		);

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4360,9 +4360,6 @@ void Client::Handle_OP_ClickDoor(const EQApplicationPacket *app)
 	// set door selected
 	if (IsDevToolsEnabled()) {
 		SetDoorToolEntityId(currentdoor->GetEntityID());
-
-		// $client->Message(15, "Door $doorid [" . quest::saylink("Close Door $doorid", 1, "Close Door") . "][" . quest::saylink("Open Door $doorid", 1, "Open Door") . "] [" . quest::saylink("#door edit", 1, "Edit Door") . "]");
-
 		DoorManipulation::CommandHeader(this);
 		Message(
 			Chat::White,

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -66,6 +66,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include "../common/repositories/character_instance_safereturns_repository.h"
 #include "../common/repositories/criteria/content_filter_criteria.h"
 #include "../common/shared_tasks.h"
+#include "gm_commands/door_manipulation.h"
 
 #ifdef BOTS
 #include "bot.h"
@@ -4354,6 +4355,23 @@ void Client::Handle_OP_ClickDoor(const EQApplicationPacket *app)
 	{
 		Message(0, "Unable to find door, please notify a GM (DoorID: %i).", cd->doorid);
 		return;
+	}
+
+	// set door selected
+	if (IsDevToolsEnabled()) {
+		SetDoorToolEntityId(currentdoor->GetID());
+
+		// $client->Message(15, "Door $doorid [" . quest::saylink("Close Door $doorid", 1, "Close Door") . "][" . quest::saylink("Open Door $doorid", 1, "Open Door") . "] [" . quest::saylink("#door edit", 1, "Edit Door") . "]");
+
+		DoorManipulation::CommandHeader(this);
+		Message(
+			Chat::White,
+			fmt::format(
+				"Door ({}) [{}]",
+				currentdoor->GetID(),
+				EQ::SayLinkEngine::GenerateQuestSaylink("#door edit", false, "#door edit")
+			).c_str()
+		);
 	}
 
 	char buf[20];

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -78,6 +78,7 @@
 #include "../common/content/world_content_service.h"
 #include "../common/http/httplib.h"
 #include "../common/shared_tasks.h"
+#include "gm_commands/door_manipulation.h"
 
 extern QueryServ* QServ;
 extern WorldServer worldserver;
@@ -202,6 +203,7 @@ int command_init(void)
 		command_add("disablerecipe",  "[recipe_id] - Disables a recipe using the recipe id.",  80, command_disablerecipe) ||
 		command_add("disarmtrap",  "Analog for ldon disarm trap for the newer clients since we still don't have it working.", 80, command_disarmtrap) ||
 		command_add("distance", "- Reports the distance between you and your target.",  80, command_distance) ||
+		command_add("door", "Door editing command", 80, command_door) ||
 		command_add("doanim", "[animnum] [type] - Send an EmoteAnim for you or your target", 50, command_doanim) ||
 		command_add("dz", "Manage expeditions and dynamic zone instances", 80, command_dz) ||
 		command_add("dzkickplayers", "Removes all players from current expedition. (/kickplayers alternative for pre-RoF clients)", 0, command_dzkickplayers) ||
@@ -12938,6 +12940,10 @@ void command_distance(Client *c, const Seperator *sep) {
 
 		c->Message(Chat::White, "Your target, %s, is %1.1f units from you.",  c->GetTarget()->GetName(), Distance(c->GetPosition(), target->GetPosition()));
 	}
+}
+
+void command_door(Client *c, const Seperator *sep) {
+	DoorManipulation::CommandHandler(c, sep);
 }
 
 void command_cvs(Client *c, const Seperator *sep)

--- a/zone/command.h
+++ b/zone/command.h
@@ -90,6 +90,7 @@ void command_devtools(Client *c, const Seperator *sep);
 void command_details(Client *c, const Seperator *sep);
 void command_disablerecipe(Client *c, const Seperator *sep);
 void command_disarmtrap(Client *c, const Seperator *sep);
+void command_door(Client *c, const Seperator *sep);
 void command_distance(Client *c, const Seperator *sep);
 void command_doanim(Client *c, const Seperator *sep);
 void command_dz(Client *c, const Seperator *sep);

--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -801,6 +801,12 @@ void Doors::SetIncline(int in) {
 	entity_list.RespawnAllDoors();
 }
 
+void Doors::SetInvertState(int in) {
+	entity_list.DespawnAllDoors();
+	invert_state = in;
+	entity_list.RespawnAllDoors();
+}
+
 void Doors::SetOpenType(uint8 in) {
 	entity_list.DespawnAllDoors();
 	open_type = in;

--- a/zone/doors.h
+++ b/zone/doors.h
@@ -54,6 +54,7 @@ public:
 	void SetDoorName(const char *name);
 	void SetEntityID(uint32 entity) { entity_id = entity; }
 	void SetIncline(int in);
+	void SetInvertState(int in);
 	void SetKeyItem(uint32 in) { key_item_id = in; }
 	void SetLocation(float x, float y, float z);
 	void SetLockpick(uint16 in) { lockpick = in; }

--- a/zone/gm_commands/door_manipulation.cpp
+++ b/zone/gm_commands/door_manipulation.cpp
@@ -66,10 +66,7 @@ void DoorManipulation::CommandHandler(Client *c, const Seperator *sep)
 
 	if (arg1 == "edit") {
 		Doors       *door = entity_list.GetDoorsByID(c->GetDoorToolEntityId());
-		std::string model = str_toupper(arg2);
 		if (door) {
-			door->SetDoorName(model.c_str());
-
 			c->Message(
 				Chat::White,
 				fmt::format(

--- a/zone/gm_commands/door_manipulation.cpp
+++ b/zone/gm_commands/door_manipulation.cpp
@@ -12,6 +12,7 @@ void DoorManipulation::CommandHandler(Client *c, const Seperator *sep)
 	// args
 	std::string arg1(sep->arg[1]);
 	std::string arg2(sep->arg[2]);
+	std::string arg3(sep->arg[3]);
 
 	// table check
 	std::string table_name = "tool_game_objects";
@@ -65,7 +66,7 @@ void DoorManipulation::CommandHandler(Client *c, const Seperator *sep)
 	}
 
 	if (arg1 == "edit") {
-		Doors       *door = entity_list.GetDoorsByID(c->GetDoorToolEntityId());
+		Doors *door = entity_list.GetDoorsByID(c->GetDoorToolEntityId());
 		if (door) {
 			c->Message(
 				Chat::White,
@@ -78,26 +79,381 @@ void DoorManipulation::CommandHandler(Client *c, const Seperator *sep)
 				).c_str()
 			);
 
+			const std::string move_x_action   = "move_x";
+			const std::string move_y_action   = "move_y";
+			const std::string move_z_action   = "move_z";
+			const std::string move_h_action   = "move_h";
+			const std::string set_size_action = "set_size";
+
+			std::vector<std::string> move_options = {
+				move_x_action,
+				move_y_action,
+				move_z_action,
+				move_h_action,
+				set_size_action
+			};
+			std::vector<std::string> move_x_options_positive;
+			std::vector<std::string> move_x_options_negative;
+			std::vector<std::string> move_y_options_positive;
+			std::vector<std::string> move_y_options_negative;
+			std::vector<std::string> move_z_options_positive;
+			std::vector<std::string> move_z_options_negative;
+			std::vector<std::string> move_h_options_positive;
+			std::vector<std::string> move_h_options_negative;
+			std::vector<std::string> set_size_options_positive;
+			std::vector<std::string> set_size_options_negative;
+			for (const auto          &move_option : move_options) {
+				if (move_option == move_x_action) {
+					move_x_options_positive.emplace_back(
+						EQ::SayLinkEngine::GenerateQuestSaylink(
+							fmt::format("#door edit {} .25", move_option),
+							false,
+							".25"
+						)
+					);
+
+					for (int move_index = 0; move_index <= 15; move_index += 5) {
+						int value = (move_index == 0 ? 1 : move_index);
+						move_x_options_positive.emplace_back(
+							EQ::SayLinkEngine::GenerateQuestSaylink(
+								fmt::format("#door edit {} {}", move_option, value),
+								false,
+								fmt::format("{}", std::abs(value))
+							)
+						);
+					}
+
+					for (int move_index = -15; move_index <= 0; move_index += 5) {
+						int value = (move_index == 0 ? 1 : move_index);
+						move_x_options_negative.emplace_back(
+							EQ::SayLinkEngine::GenerateQuestSaylink(
+								fmt::format("#door edit {} {}", move_option, value),
+								false,
+								fmt::format("{}", std::abs(value))
+							)
+						);
+					}
+
+					move_x_options_negative.emplace_back(
+						EQ::SayLinkEngine::GenerateQuestSaylink(
+							fmt::format("#door edit {} -.25", move_option),
+							false,
+							"-.25"
+						)
+					);
+				}
+				else if (move_option == move_y_action) {
+					move_y_options_positive.emplace_back(
+						EQ::SayLinkEngine::GenerateQuestSaylink(
+							fmt::format("#door edit {} .25", move_option),
+							false,
+							".25"
+						)
+					);
+
+					for (int move_index = 0; move_index <= 15; move_index += 5) {
+						int value = (move_index == 0 ? 1 : move_index);
+						move_y_options_positive.emplace_back(
+							EQ::SayLinkEngine::GenerateQuestSaylink(
+								fmt::format("#door edit {} {}", move_option, value),
+								false,
+								fmt::format("{}", std::abs(value))
+							)
+						);
+					}
+
+					for (int move_index = -15; move_index <= 0; move_index += 5) {
+						int value = (move_index == 0 ? 1 : move_index);
+						move_y_options_negative.emplace_back(
+							EQ::SayLinkEngine::GenerateQuestSaylink(
+								fmt::format("#door edit {} {}", move_option, value),
+								false,
+								fmt::format("{}", std::abs(value))
+							)
+						);
+					}
+
+					move_y_options_negative.emplace_back(
+						EQ::SayLinkEngine::GenerateQuestSaylink(
+							fmt::format("#door edit {} -.25", move_option),
+							false,
+							"-.25"
+						)
+					);
+				}
+				else if (move_option == move_z_action) {
+					move_z_options_positive.emplace_back(
+						EQ::SayLinkEngine::GenerateQuestSaylink(
+							fmt::format("#door edit {} .25", move_option),
+							false,
+							".25"
+						)
+					);
+
+					for (int move_index = 0; move_index <= 15; move_index += 5) {
+						int value = (move_index == 0 ? 1 : move_index);
+						move_z_options_positive.emplace_back(
+							EQ::SayLinkEngine::GenerateQuestSaylink(
+								fmt::format("#door edit {} {}", move_option, value),
+								false,
+								fmt::format("{}", std::abs(value))
+							)
+						);
+					}
+
+					for (int move_index = -15; move_index <= 0; move_index += 5) {
+						int value = (move_index == 0 ? 1 : move_index);
+						move_z_options_negative.emplace_back(
+							EQ::SayLinkEngine::GenerateQuestSaylink(
+								fmt::format("#door edit {} {}", move_option, value),
+								false,
+								fmt::format("{}", std::abs(value))
+							)
+						);
+					}
+
+					move_z_options_negative.emplace_back(
+						EQ::SayLinkEngine::GenerateQuestSaylink(
+							fmt::format("#door edit {} -.25", move_option),
+							false,
+							"-.25"
+						)
+					);
+				}
+				else if (move_option == move_h_action) {
+					for (int move_index = 0; move_index <= 50; move_index += 5) {
+						int value = (move_index == 0 ? 1 : move_index);
+						move_h_options_positive.emplace_back(
+							EQ::SayLinkEngine::GenerateQuestSaylink(
+								fmt::format("#door edit {} {}", move_option, value),
+								false,
+								fmt::format("{}", std::abs(value))
+							)
+						);
+					}
+
+					for (int move_index = -50; move_index <= 0; move_index += 5) {
+						int value = (move_index == 0 ? 1 : move_index);
+						move_h_options_negative.emplace_back(
+							EQ::SayLinkEngine::GenerateQuestSaylink(
+								fmt::format("#door edit {} {}", move_option, value),
+								false,
+								fmt::format("{}", std::abs(value))
+							)
+						);
+					}
+				}
+				else if (move_option == set_size_action) {
+					for (int move_index = 0; move_index <= 100; move_index += 10) {
+						int value = (move_index == 0 ? 1 : move_index);
+						set_size_options_positive.emplace_back(
+							EQ::SayLinkEngine::GenerateQuestSaylink(
+								fmt::format("#door edit {} {}", move_option, value),
+								false,
+								fmt::format("{}", std::abs(value))
+							)
+						);
+					}
+
+					for (int move_index = -100; move_index <= 0; move_index += 10) {
+						int value = (move_index == 0 ? 1 : move_index);
+						set_size_options_negative.emplace_back(
+							EQ::SayLinkEngine::GenerateQuestSaylink(
+								fmt::format("#door edit {} {}", move_option, value),
+								false,
+								fmt::format("{}", std::abs(value))
+							)
+						);
+					}
+				}
+			}
+
+			// we're passing a move action here
+			if (!arg3.empty() && StringIsNumber(arg3)) {
+				int x_move   = 0;
+				int y_move   = 0;
+				int z_move   = 0;
+				int h_move   = 0;
+				int set_size = 0;
+
+				if (arg2 == move_x_action) {
+					x_move = std::atoi(arg3.c_str());
+				}
+				if (arg2 == move_y_action) {
+					y_move = std::atoi(arg3.c_str());
+				}
+				if (arg2 == move_z_action) {
+					z_move = std::atoi(arg3.c_str());
+				}
+				if (arg2 == move_h_action) {
+					h_move = std::atoi(arg3.c_str());
+				}
+				if (arg2 == set_size_action) {
+					set_size = std::atoi(arg3.c_str());
+				}
+
+				door->SetLocation(
+					door->GetX() + x_move,
+					door->GetY() + y_move,
+					door->GetZ() + z_move
+				);
+
+				glm::vec4 door_position = door->GetPosition();
+				door_position.w = door_position.w + h_move;
+				door->SetPosition(door_position);
+				door->SetSize(door->GetSize() + set_size);
+			}
+
+			// spawn and move helpers
+			uint16 helper_mob_x_negative = 0;
+			uint16 helper_mob_x_positive = 0;
+			uint16 helper_mob_y_positive = 0;
+			uint16 helper_mob_y_negative = 0;
+
+			for (auto &n: entity_list.GetNPCList()) {
+				NPC * npc = n.second;
+				std::string npc_name = npc->GetName();
+				if (npc_name.find("-X") != std::string::npos) {
+					helper_mob_x_negative = npc->GetID();
+				}
+				if (npc_name.find("-Y") != std::string::npos) {
+					helper_mob_y_negative = npc->GetID();
+				}
+				if (npc_name.find("+X") != std::string::npos) {
+					helper_mob_x_positive = npc->GetID();
+				}
+				if (npc_name.find("+Y") != std::string::npos) {
+					helper_mob_y_positive = npc->GetID();
+				}
+			}
+
+			// -X
+			glm::vec4 door_position = door->GetPosition();
+			if (helper_mob_x_negative == 0) {
+				door_position.x = door_position.x - 15;
+				auto node = NPC::SpawnNodeNPC("-X", "", door_position);
+				helper_mob_x_negative = node->GetID();
+			} else {
+				auto n = entity_list.GetNPCByID(helper_mob_x_negative);
+				n->GMMove(door->GetX() - 15, door->GetY(), door->GetZ(), n->GetHeading());
+			}
+
+			// +X
+			door_position = door->GetPosition();
+			if (helper_mob_x_positive == 0) {
+				door_position.x = door_position.x + 15;
+				auto node = NPC::SpawnNodeNPC("+X", "", door_position);
+				helper_mob_x_positive = node->GetID();
+			} else {
+				auto n = entity_list.GetNPCByID(helper_mob_x_positive);
+				n->GMMove(door->GetX() + 15, door->GetY(), door->GetZ(), n->GetHeading());
+			}
+
+			// -Y
+			door_position = door->GetPosition();
+			if (helper_mob_y_negative == 0) {
+				door_position.y = door_position.y - 15;
+				auto node = NPC::SpawnNodeNPC("-Y", "", door_position);
+				helper_mob_y_negative = node->GetID();
+			} else {
+				auto n = entity_list.GetNPCByID(helper_mob_y_negative);
+				n->GMMove(door->GetX(), door->GetY() - 15, door->GetZ(), n->GetHeading());
+			}
+
+			// +Y
+			door_position = door->GetPosition();
+			if (helper_mob_y_positive == 0) {
+				door_position.y = door_position.y + 15;
+				auto node = NPC::SpawnNodeNPC("+Y", "", door_position);
+				helper_mob_y_positive = node->GetID();
+			} else {
+				auto n = entity_list.GetNPCByID(helper_mob_y_positive);
+				n->GMMove(door->GetX(), door->GetY() + 15, door->GetZ(), n->GetHeading());
+			}
+
+			c->Message(
+				Chat::White,
+				fmt::format(
+					"Name [{}] [{}] [{}] [{}]",
+					door->GetDoorName(),
+					EQ::SayLinkEngine::GenerateQuestSaylink(
+						"#door save",
+						false,
+						"Save"
+					),
+					EQ::SayLinkEngine::GenerateQuestSaylink(
+						"#door changemodelqueue",
+						false,
+						"Change Model"
+					),
+					EQ::SayLinkEngine::GenerateQuestSaylink(
+						"#door setinclineinc",
+						false,
+						"Incline"
+					)
+				).c_str()
+			);
+			c->Message(
+				Chat::White,
+				fmt::format(
+					"[{}] - [X] + [{}]",
+					implode(" | ", move_x_options_negative),
+					implode(" | ", move_x_options_positive)
+				).c_str()
+			);
+			c->Message(
+				Chat::White,
+				fmt::format(
+					"[{}] - [Y] + [{}]",
+					implode(" | ", move_y_options_negative),
+					implode(" | ", move_y_options_positive)
+				).c_str()
+			);
+			c->Message(
+				Chat::White,
+				fmt::format(
+					"[{}] - [Z] + [{}]",
+					implode(" | ", move_z_options_negative),
+					implode(" | ", move_z_options_positive)
+				).c_str()
+			);
+			c->Message(
+				Chat::White,
+				fmt::format(
+					"[{}] - [H] + [{}]",
+					implode(" | ", move_h_options_negative),
+					implode(" | ", move_h_options_positive)
+				).c_str()
+			);
+			c->Message(
+				Chat::White,
+				fmt::format(
+					"[{}] - [Size] + [{}]",
+					implode(" | ", set_size_options_negative),
+					implode(" | ", set_size_options_positive)
+				).c_str()
+			);
+
 			return;
 		}
 
 		c->Message(Chat::Red, "Door selection invalid...");
 	}
 
-//	if (arg1 == "showmodelszone") {
-//		auto game_objects = ToolGameObjectsRepository::GetWhere(
-//			database,
-//			fmt::format("zoneid = {}", zone->GetZoneID())
-//		);
-//
-//		if (game_objects.empty()) {
-//			c->Message(Chat::White, "There are no models for this zone...");
-//		}
-//
-//		for (auto &g: game_objects) {
-//			c->Message(Chat::White, g.object_name.c_str());
-//		}
-//	}
+	//	if (arg1 == "showmodelszone") {
+	//		auto game_objects = ToolGameObjectsRepository::GetWhere(
+	//			database,
+	//			fmt::format("zoneid = {}", zone->GetZoneID())
+	//		);
+	//
+	//		if (game_objects.empty()) {
+	//			c->Message(Chat::White, "There are no models for this zone...");
+	//		}
+	//
+	//		for (auto &g: game_objects) {
+	//			c->Message(Chat::White, g.object_name.c_str());
+	//		}
+	//	}
 
 	if (arg1 == "create") {
 		std::string model     = str_toupper(arg2);
@@ -108,7 +464,9 @@ void DoorManipulation::CommandHandler(Client *c, const Seperator *sep)
 			100
 		);
 
-		c->Message(Chat::White, fmt::format("Creating door entity_id [{}] with model [{}]", entity_id, model).c_str());
+		c->Message(
+			Chat::White,
+			fmt::format("Creating door entity_id [{}] with model [{}]", entity_id, model).c_str());
 		c->SetDoorToolEntityId(entity_id);
 	}
 
@@ -181,6 +539,7 @@ void DoorManipulation::CommandHandler(Client *c, const Seperator *sep)
 
 
 	}
+
 }
 
 void DoorManipulation::CommandHeader(Client *c)

--- a/zone/gm_commands/door_manipulation.cpp
+++ b/zone/gm_commands/door_manipulation.cpp
@@ -37,6 +37,7 @@ void DoorManipulation::CommandHandler(Client *c, const Seperator *sep)
 	// option
 	if (arg1.empty()) {
 		DoorManipulation::CommandHeader(c);
+		c->Message(Chat::White, "#door create <modelname> | Creates a door from a model. (Example IT78 creates a campfire)");
 		c->Message(Chat::White, "#door setinvertstate [0|1] | Sets selected door invert state");
 		c->Message(Chat::White, "#door setincline <incline> | Sets selected door incline");
 		c->Message(Chat::White, "#door opentype <opentype> | Sets selected door opentype");

--- a/zone/gm_commands/door_manipulation.cpp
+++ b/zone/gm_commands/door_manipulation.cpp
@@ -1,0 +1,175 @@
+#include "door_manipulation.h"
+#include "../doors.h"
+#include "../../common/repositories/tool_game_objects_repository.h"
+
+void DoorManipulation::CommandHandler(Client *c, const Seperator *sep)
+{
+	// this should never happen
+	if (!c) {
+		return;
+	}
+
+	// args
+	std::string arg1(sep->arg[1]);
+	std::string arg2(sep->arg[2]);
+
+	// table check
+	std::string table_name = "tool_game_objects";
+	std::string url        = "https://raw.githubusercontent.com/EQEmu/database-tool-sqls/main/tool_game_objects.sql";
+	if (!database.DoesTableExist(table_name)) {
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"Table [{}] does not exist. Downloading from [{}] and installing locally",
+				table_name,
+				url
+			).c_str()
+		);
+		database.SourceDatabaseTableFromUrl(
+			table_name,
+			url
+		);
+	}
+
+	// option
+	if (arg1.empty()) {
+		DoorManipulation::CommandHeader(c);
+		c->Message(Chat::White, "#door setincline <incline> | Sets selected door incline");
+		c->Message(Chat::White, "#door opentype <opentype> | Sets selected door opentype");
+		c->Message(Chat::White, "#door model <modelname> | Changes door model for selected door");
+		c->Message(Chat::White, "#door save | Creates database entry for highlighted door");
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"{} - lists doors in zone",
+				EQ::SayLinkEngine::GenerateQuestSaylink("#door list", false, "#door list")
+			).c_str()
+		);
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"{} - Brings up editing interface for selected door",
+				EQ::SayLinkEngine::GenerateQuestSaylink("#door edit", false, "#door edit")
+			).c_str()
+		);;
+		c->Message(
+			Chat::White,
+			// "#door model <modelname> or select from " . quest::saylink("#door showmodelszone", 1, "Local Zone") . " " . quest::saylink("#door showmodelsglobal", 1, "Global")
+			fmt::format(
+				"{} - Brings up editing interface for selected door",
+				EQ::SayLinkEngine::GenerateQuestSaylink("#door showmodelszone", false, "#door showmodelszone")
+			).c_str()
+		);
+
+		return;
+	}
+
+	if (arg1 == "edit") {
+
+	}
+
+//	if (arg1 == "showmodelszone") {
+//		auto game_objects = ToolGameObjectsRepository::GetWhere(
+//			database,
+//			fmt::format("zoneid = {}", zone->GetZoneID())
+//		);
+//
+//		if (game_objects.empty()) {
+//			c->Message(Chat::White, "There are no models for this zone...");
+//		}
+//
+//		for (auto &g: game_objects) {
+//			c->Message(Chat::White, g.object_name.c_str());
+//		}
+//	}
+
+	if (arg1 == "create") {
+		std::string model     = str_toupper(arg2);
+		uint16      entity_id = entity_list.CreateDoor(
+			model.c_str(),
+			c->GetPosition(),
+			58,
+			100
+		);
+
+		c->Message(Chat::White, fmt::format("Creating door entity_id [{}] with model [{}]", entity_id, model).c_str());
+		c->SetDoorToolEntityId(entity_id);
+	}
+
+	if (arg1 == "model") {
+		Doors       *door = entity_list.GetDoorsByID(c->GetDoorToolEntityId());
+		std::string model = str_toupper(arg2);
+		if (door) {
+			door->SetDoorName(model.c_str());
+		}
+	}
+
+	if (arg1 == "showmodelszone") {
+		auto game_objects = ToolGameObjectsRepository::GetWhere(
+			database,
+			fmt::format("zoneid = {}", zone->GetZoneID())
+		);
+
+		if (game_objects.empty()) {
+			c->Message(Chat::White, "There are no models for this zone...");
+		}
+
+		c->Message(Chat::White, "------------------------------------------------");
+		c->Message(Chat::White, "# Doors from zone");
+		c->Message(Chat::White, "------------------------------------------------");
+
+		std::vector<std::string> objects;
+		for (auto                &g: game_objects) {
+			objects.emplace_back(g.object_name);
+		}
+
+		int                      character_length = 0;
+		std::vector<std::string> object_names;
+		for (auto                &o: objects) {
+			character_length += o.length();
+			object_names.emplace_back(o);
+
+			if (character_length > 500) {
+				std::string message_buffer;
+				for (auto   &object_name: object_names) {
+					message_buffer += fmt::format(
+						"[{}] ",
+						EQ::SayLinkEngine::GenerateQuestSaylink(
+							fmt::format("#door model {}", object_name),
+							false,
+							object_name
+						)
+					);
+				}
+
+				c->Message(Chat::White, message_buffer.c_str());
+
+				character_length = 0;
+				object_names     = {};
+			}
+		}
+
+		std::string message_buffer;
+		for (auto   &object_name: object_names) {
+			message_buffer += fmt::format(
+				"[{}] ",
+				EQ::SayLinkEngine::GenerateQuestSaylink(
+					fmt::format("#door model {}", object_name),
+					false,
+					object_name
+				)
+			);
+		}
+
+		c->Message(Chat::White, message_buffer.c_str());
+
+
+	}
+}
+
+void DoorManipulation::CommandHeader(Client *c)
+{
+	c->Message(Chat::White, "------------------------------------------------");
+	c->Message(Chat::White, "# Door Commands");
+	c->Message(Chat::White, "------------------------------------------------");
+}

--- a/zone/gm_commands/door_manipulation.cpp
+++ b/zone/gm_commands/door_manipulation.cpp
@@ -65,7 +65,26 @@ void DoorManipulation::CommandHandler(Client *c, const Seperator *sep)
 	}
 
 	if (arg1 == "edit") {
+		Doors       *door = entity_list.GetDoorsByID(c->GetDoorToolEntityId());
+		std::string model = str_toupper(arg2);
+		if (door) {
+			door->SetDoorName(model.c_str());
 
+			c->Message(
+				Chat::White,
+				fmt::format(
+					"Door Selected ID [{}] Name [{}] OpenType [{}] Invertstate [{}]",
+					c->GetDoorToolEntityId(),
+					door->GetDoorName(),
+					door->GetOpenType(),
+					door->GetInvertState()
+				).c_str()
+			);
+
+			return;
+		}
+
+		c->Message(Chat::Red, "Door selection invalid...");
 	}
 
 //	if (arg1 == "showmodelszone") {

--- a/zone/gm_commands/door_manipulation.cpp
+++ b/zone/gm_commands/door_manipulation.cpp
@@ -33,6 +33,12 @@ void DoorManipulation::CommandHandler(Client *c, const Seperator *sep)
 		);
 	}
 
+	// save needs to be implemented
+	// saylinks need to be added to main menu
+	// inverted needs to either be supported or dropped
+	// opentype needs to be handled
+	// any other polish
+
 	// option
 	if (arg1.empty()) {
 		DoorManipulation::CommandHeader(c);

--- a/zone/gm_commands/door_manipulation.h
+++ b/zone/gm_commands/door_manipulation.h
@@ -2,12 +2,21 @@
 #define EQEMU_DOOR_MANIPULATION_H
 
 #include "../client.h"
+#include "../../common/repositories/tool_game_objects_repository.h"
 
 class DoorManipulation {
 
 public:
 	static void CommandHandler(Client *c, const Seperator *sep);
 	static void CommandHeader(Client *c);
+	static void DisplayObjectResultToClient(
+		Client *c,
+		std::vector<ToolGameObjectsRepository::ToolGameObjects> game_objects
+	);
+	static void DisplayModelsFromFileResults(
+		Client *c,
+		std::vector<ToolGameObjectsRepository::ToolGameObjects> game_objects
+	);
 };
 
 

--- a/zone/gm_commands/door_manipulation.h
+++ b/zone/gm_commands/door_manipulation.h
@@ -1,0 +1,14 @@
+#ifndef EQEMU_DOOR_MANIPULATION_H
+#define EQEMU_DOOR_MANIPULATION_H
+
+#include "../client.h"
+
+class DoorManipulation {
+
+public:
+	static void CommandHandler(Client *c, const Seperator *sep);
+	static void CommandHeader(Client *c);
+};
+
+
+#endif //EQEMU_DOOR_MANIPULATION_H

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -284,7 +284,7 @@ NPC::NPC(const NPCType *npc_type_data, Spawn2 *in_respawn, const glm::vec4 &posi
 	entity_list.MakeNameUnique(name);
 
 	npc_aggro = npc_type_data->npc_aggro;
-	
+
 	AISpellVar.fail_recast                     = static_cast<uint32>(RuleI(Spells, AI_SpellCastFinishedFailRecast));
 	AISpellVar.engaged_no_sp_recast_min        = static_cast<uint32>(RuleI(Spells, AI_EngagedNoSpellMinRecast));
 	AISpellVar.engaged_no_sp_recast_max        = static_cast<uint32>(RuleI(Spells, AI_EngagedNoSpellMaxRecast));
@@ -694,7 +694,7 @@ bool NPC::HasItem(uint32 item_id) {
 		if (loot_item->item_id == item_id) {
 			return true;
 		}
-	}	
+	}
 	return false;
 }
 
@@ -1124,7 +1124,7 @@ bool NPC::SpawnZoneController()
 	memset(npc_type, 0, sizeof(NPCType));
 
 	strncpy(npc_type->name, "zone_controller", 60);
-	npc_type->current_hp           = 2000000000;
+	npc_type->current_hp       = 2000000000;
 	npc_type->max_hp           = 2000000000;
 	npc_type->hp_regen         = 100000000;
 	npc_type->race             = 240;
@@ -1207,7 +1207,7 @@ void NPC::SpawnGridNodeNPC(const glm::vec4 &position, int32 grid_id, int32 grid_
 	entity_list.AddNPC(npc);
 }
 
-void NPC::SpawnZonePointNodeNPC(std::string name, const glm::vec4 &position)
+NPC * NPC::SpawnZonePointNodeNPC(std::string name, const glm::vec4 &position)
 {
 	auto npc_type = new NPCType;
 	memset(npc_type, 0, sizeof(NPCType));
@@ -1235,6 +1235,8 @@ void NPC::SpawnZonePointNodeNPC(std::string name, const glm::vec4 &position)
 	npc_type->show_name        = true;
 	npc_type->findable         = true;
 
+	strcpy(npc_type->special_abilities, "12,1^13,1^14,1^15,1^16,1^17,1^19,1^22,1^24,1^25,1^28,1^31,1^35,1^39,1^42,1");
+
 	auto node_position = glm::vec4(position.x, position.y, position.z, position.w);
 	auto npc           = new NPC(npc_type, nullptr, node_position, GravityBehavior::Flying);
 
@@ -1243,14 +1245,15 @@ void NPC::SpawnZonePointNodeNPC(std::string name, const glm::vec4 &position)
 	npc->GiveNPCTypeData(npc_type);
 
 	entity_list.AddNPC(npc);
+
+	return npc;
 }
 
 NPC * NPC::SpawnNodeNPC(std::string name, std::string last_name, const glm::vec4 &position) {
 	auto npc_type = new NPCType;
 	memset(npc_type, 0, sizeof(NPCType));
 
-	sprintf(npc_type->name, "%s", name.c_str());
-	sprintf(npc_type->lastname, "%s", last_name.c_str());
+	strncpy(npc_type->name, name.c_str(), 60);
 
 	npc_type->current_hp       = 4000000;
 	npc_type->max_hp           = 4000000;
@@ -1272,8 +1275,12 @@ NPC * NPC::SpawnNodeNPC(std::string name, std::string last_name, const glm::vec4
 	npc_type->findable         = true;
 	npc_type->runspeed         = 1.25;
 
+	strcpy(npc_type->special_abilities, "12,1^13,1^14,1^15,1^16,1^17,1^19,1^22,1^24,1^25,1^28,1^31,1^35,1^39,1^42,1");
+
 	auto node_position = glm::vec4(position.x, position.y, position.z, position.w);
 	auto npc           = new NPC(npc_type, nullptr, node_position, GravityBehavior::Flying);
+
+	npc->name[strlen(npc->name) - 3] = (char) NULL;
 
 	npc->GiveNPCTypeData(npc_type);
 

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -115,7 +115,7 @@ public:
 
 	static NPC *SpawnNodeNPC(std::string name, std::string last_name, const glm::vec4 &position);
 	static void SpawnGridNodeNPC(const glm::vec4 &position, int32 grid_id, int32 grid_number, int32 zoffset);
-	static void SpawnZonePointNodeNPC(std::string name, const glm::vec4 &position);
+	static NPC * SpawnZonePointNodeNPC(std::string name, const glm::vec4 &position);
 
 	//abstract virtual function implementations requird by base abstract class
 	virtual bool Death(Mob* killerMob, int32 damage, uint16 spell_id, EQ::skills::SkillType attack_skill);


### PR DESCRIPTION
This PR ports Perl plugin from https://docs.eqemu.io/quest-api/perl/plugins/doors-manipluation to native GM command #door 

This plugin has been used widely by lots of folks over the years. Parts of the plugin have gone stale and it has deserved a port into the source with some improvements and zero-touch installation

Props to @Kinglykrab for the coordinate saylink menus as he was backseat driving during the stream porting this plugin over <3 

**Notes**

* Functionality is 1:1 - no net new commands
* Helper NPC's are created "on-the-fly" and no longer require fixed `npc_type` data as did the original plugin
* Uses data from table `tool_game_objects` sourced from https://github.com/EQEmu/database-tool-sqls
* First invocation of the GM command automatically fetches the table data from the internet and installs locally
* Selection of any existing door invokes the developer tools menus highlighted in this tool
* Added a database helper function to install tables from remote web `.sql` files if the table doesn't exist
* Added a URL helper function to help parse and validate a URI and pull pieces out of it as necessary

**Door Top Level Command Menu**

![image](https://user-images.githubusercontent.com/3319450/132435026-41e53d1c-6449-4926-aa6a-9fbb11dbfd9e.png)

**Door Edit Menu**

![image](https://user-images.githubusercontent.com/3319450/132434956-76315ee9-627d-4910-9326-2535f75767f7.png)

**Demos**

**Door Creation and Position Editing**

![door-edit-1](https://user-images.githubusercontent.com/3319450/132434607-f8b452a5-69ba-42fb-a7fb-21d39ed9c3a2.gif)

**Model Selection (Zone)**

![door-edit-2](https://user-images.githubusercontent.com/3319450/132431397-fbd6273e-7e62-4df1-8b89-abd6b31013dc.gif)

**Model Selection (Global)**

![door-edit-3](https://user-images.githubusercontent.com/3319450/132434612-ce54c6fb-6b9a-4dad-a7a7-90350f42aa83.gif)
