### PR TITLE
Hack to fix melee chasing fleeing mobs "too far" issues.

### DIFF
--- a/zone/aggro.cpp
+++ b/zone/aggro.cpp
@@ -851,6 +851,17 @@ bool Mob::CombatRange(Mob* other, float fixed_size_mod, bool aeRampage)
 	size_mod *= RuleR(Combat,HitBoxMod);		// used for testing sizemods on different races.
 	size_mod *= fixed_size_mod;					// used to extend the size_mod
 
+	// Melee chasing fleeing mobs is borked.  The client updates don't
+	// come to the server quickly enough, especially when mob is running
+	// and/or PC has good run speed.  This change is a hack, but it greatly
+	// improved playability and "you are too far away" while chasing
+	// a fleeing mob.  The Blind check is to make sure that this does not
+	// apply to disoriented fleeing mobs who need proximity to turn and fight.
+	if  (other->currently_fleeing && !other->IsBlind())
+	{
+		size_mod *= 3;
+	}
+
 	// prevention of ridiculously sized hit boxes
 	if (size_mod > 10000)
 		size_mod = size_mod / 7;
@@ -901,6 +912,7 @@ bool Mob::CombatRange(Mob* other, float fixed_size_mod, bool aeRampage)
 		}
 		return true;
 	}
+
 	return false;
 }
 


### PR DESCRIPTION
Just about everyone has seen the "mob is too far away" while chasing fleeing mobs.  Perhaps more so on servers that use a higher percentage for flee ratio.  Upon looking at this, the client updates for client position come in too slowly to accurately compare against a mobs location when fleeing, the earlier a mob flees (and thus the faster the mob is running).

This has been a gripe of melee players for years on my server, and myself.

This patch is a hack, but I don't see a reasonable, or realistic way to fix it any better.  This come from trial and error and looking at the difference in distances that the math is showing, vs. what I see on the screen while chasing.

It dramatically reduces the frustration and looks far more realistic.  Far fewer "you are too far away" despite being right on the target's ass on screen.

The IsBlind() caveat is so that we don't create an exploit where we can hit blinded mobs that don't think they are close enough to turn and engage.