### PR TITLE
Fix bug where stacks of non-stackable items are removed when you buy 1.

### DIFF
--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -361,7 +361,8 @@ void Zone::DumpMerchantList(uint32 npcid) {
 
 int Zone::SaveTempItem(uint32 merchantid, uint32 npcid, uint32 item, int32 charges, bool sold) {
 
-	LogInventory("Transaction of [{}] [{}]", charges, item);
+	LogInventory("[{}] [{}] charges of [{}]", ((sold) ? "Sold" : "Bought"),
+		charges, item);
 	//DumpMerchantList(npcid);
 	// Iterate past main items.
 	// If the item being transacted is in this list, return 0;
@@ -419,8 +420,7 @@ int Zone::SaveTempItem(uint32 merchantid, uint32 npcid, uint32 item, int32 charg
 				if (!ml.origslot) {
 					ml.origslot = ml.slot;
 				}
-				bool is_stackable = database.GetItem(item)->Stackable;
-				if ((is_stackable && charges > 0) || (!is_stackable && sold)) {
+				if (ml.charges > 0) {
 					database.SaveMerchantTemp(npcid, ml.origslot, item, ml.charges);
 					tmp_merlist.push_back(ml);
 				} else {


### PR DESCRIPTION
There is currently a bug when you buy (1) item like a_giant_snake_fang from a vendor that has say, 10 of these.  The 1st one you buy works.  But when you go to buy a second, the server spits a "display purposes only" message and you end up having to log off.

Test case.  Find a vendor with more than 1 of a non-stackable item.  Buy one.  Attempt to buy another one.  This crashes if you are more recent than about 4 months ago.

This is because the code changed in the PR does not retain the item in the merchant list.

I talked this over with @dencelle.  These changes were made as part of a scheme to preserve item charges, not # of items on the merchants.  He has told me he plans to revisit that and make it more comprehensive.

That said, the below only has to do with the merchantlist_temp and the internal cache of same, which has nothing to do with an item's charge, just the # of the item on the merchant.

My only change to the logic if you break it down, is that non-stackable items that are BOUGHT where the merchant still has more than 1 left, are not deleted from the db and cache of the merchantlist_temp.  No changes are made to an item's charges.

I also made a LogInventory more helpful with added information.