### PR TITLE
[Quest API] Add corpse->GetLootList() and npc->GetLootList() to Perl and Lua.

### DIFF
--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -1462,12 +1462,12 @@ bool Corpse::HasItem(uint32 item_id) {
 	for (auto current_item  = itemlist.begin(); current_item != itemlist.end(); ++current_item) {
 		ServerLootItem_Struct* loot_item = *current_item;
 		if (!loot_item) {
-			LogError("NPC::CountItem() - ItemList error, null item");
+			LogError("Corpse::HasItem() - ItemList error, null item");
 			continue;
 		}
 
 		if (!loot_item->item_id || !database.GetItem(loot_item->item_id)) {
-			LogError("NPC::CountItem() - Database error, invalid item");
+			LogError("Corpse::HasItem() - Database error, invalid item");
 			continue;
 		}
 
@@ -1487,12 +1487,12 @@ uint16 Corpse::CountItem(uint32 item_id) {
 	for (auto current_item  = itemlist.begin(); current_item != itemlist.end(); ++current_item) {
 		ServerLootItem_Struct* loot_item = *current_item;
 		if (!loot_item) {
-			LogError("NPC::CountItem() - ItemList error, null item");
+			LogError("Corpse::CountItem() - ItemList error, null item");
 			continue;
 		}
 
 		if (!loot_item->item_id || !database.GetItem(loot_item->item_id)) {
-			LogError("NPC::CountItem() - Database error, invalid item");
+			LogError("Corpse::CountItem() - Database error, invalid item");
 			continue;
 		}
 
@@ -1746,4 +1746,22 @@ bool Corpse::MovePlayerCorpseToNonInstance()
 	}
 
 	return false;
+}
+
+std::vector<int> Corpse::GetLootList() {
+	std::vector<int> corpse_items;
+	for (auto current_item  = itemlist.begin(); current_item != itemlist.end(); ++current_item) {
+		ServerLootItem_Struct* loot_item = *current_item;
+		if (!loot_item) {
+			LogError("Corpse::GetLootList() - ItemList error, null item");
+			continue;
+		}
+
+		if (std::find(corpse_items.begin(), corpse_items.end(), loot_item->item_id) != corpse_items.end()) {
+			continue;
+		}
+		
+		corpse_items.push_back(loot_item->item_id);
+	}
+	return corpse_items;
 }

--- a/zone/corpse.h
+++ b/zone/corpse.h
@@ -117,6 +117,7 @@ class Corpse : public Mob {
 	uint16	CountItem(uint32 item_id);
 	uint32	GetItemIDBySlot(uint16 loot_slot);
 	uint16	GetFirstSlotByItemID(uint32 item_id);
+	std::vector<int> GetLootList();
 	void	LootItem(Client* client, const EQApplicationPacket* app);
 	void	EndLoot(Client* client, const EQApplicationPacket* app);
 	void	MakeLootRequestPackets(Client* client, const EQApplicationPacket* app);

--- a/zone/lua_corpse.cpp
+++ b/zone/lua_corpse.cpp
@@ -172,6 +172,20 @@ uint16 Lua_Corpse::GetFirstSlotByItemID(uint32 item_id) {
 	return self->GetFirstSlotByItemID(item_id);
 }
 
+luabind::object Lua_Corpse::GetLootList(lua_State* L) {
+	auto lua_table = luabind::newtable(L);
+	if (d_) {
+		auto self = reinterpret_cast<NativeType*>(d_);
+		auto corpse_items = self->GetLootList();
+		int index = 0;
+		for (auto item_id : corpse_items) {
+			lua_table[index] = item_id;
+			index++;
+		}
+	}
+	return lua_table;
+}
+
 luabind::scope lua_register_corpse() {
 	return luabind::class_<Lua_Corpse, Lua_Mob>("Corpse")
 		.def(luabind::constructor<>())
@@ -209,7 +223,8 @@ luabind::scope lua_register_corpse() {
 		.def("HasItem", (bool(Lua_Corpse::*)(uint32))&Lua_Corpse::HasItem)
 		.def("CountItem", (uint16(Lua_Corpse::*)(uint32))&Lua_Corpse::CountItem)
 		.def("GetItemIDBySlot", (uint32(Lua_Corpse::*)(uint16))&Lua_Corpse::GetItemIDBySlot)
-		.def("GetFirstSlotByItemID", (uint16(Lua_Corpse::*)(uint32))&Lua_Corpse::GetFirstSlotByItemID);
+		.def("GetFirstSlotByItemID", (uint16(Lua_Corpse::*)(uint32))&Lua_Corpse::GetFirstSlotByItemID)
+		.def("GetLootList", (luabind::object(Lua_Corpse::*)(lua_State* L))&Lua_Corpse::GetLootList);
 }
 
 #endif

--- a/zone/lua_corpse.h
+++ b/zone/lua_corpse.h
@@ -6,12 +6,14 @@
 
 class Corpse;
 class Lua_Client;
+struct Lua_Corpse_Loot_List;
 
 namespace luabind {
 	struct scope;
 }
 
 luabind::scope lua_register_corpse();
+luabind::scope lua_register_corpse_loot_list();
 
 class Lua_Corpse : public Lua_Mob
 {
@@ -58,7 +60,7 @@ public:
 	uint16 CountItem(uint32 item_id);
 	uint32 GetItemIDBySlot(uint16 loot_slot);
 	uint16 GetFirstSlotByItemID(uint32 item_id);
-	luabind::object GetLootList(lua_State* L);
+	Lua_Corpse_Loot_List GetLootList(lua_State* L);
 };
 
 #endif

--- a/zone/lua_corpse.h
+++ b/zone/lua_corpse.h
@@ -58,6 +58,7 @@ public:
 	uint16 CountItem(uint32 item_id);
 	uint32 GetItemIDBySlot(uint16 loot_slot);
 	uint16 GetFirstSlotByItemID(uint32 item_id);
+	luabind::object GetLootList(lua_State* L);
 };
 
 #endif

--- a/zone/lua_npc.cpp
+++ b/zone/lua_npc.cpp
@@ -618,6 +618,20 @@ float Lua_NPC::GetSpellScale()
 	return self->GetSpellScale();
 }
 
+luabind::object Lua_NPC::GetLootList(lua_State* L) {
+	auto lua_table = luabind::newtable(L);
+	if (d_) {
+		auto self = reinterpret_cast<NativeType*>(d_);
+		auto npc_items = self->GetLootList();
+		int index = 0;
+		for (auto item_id : npc_items) {
+			lua_table[index] = item_id;
+			index++;
+		}
+	}
+	return lua_table;
+}
+
 luabind::scope lua_register_npc() {
 	return luabind::class_<Lua_NPC, Lua_Mob>("NPC")
 		.def(luabind::constructor<>())
@@ -740,7 +754,8 @@ luabind::scope lua_register_npc() {
 		.def("GetItemIDBySlot", (uint32(Lua_NPC::*)(uint16))&Lua_NPC::GetItemIDBySlot)
 		.def("GetFirstSlotByItemID", (uint16(Lua_NPC::*)(uint32))&Lua_NPC::GetFirstSlotByItemID)
 		.def("GetHealScale", (float(Lua_NPC::*)(void))&Lua_NPC::GetHealScale)
-		.def("GetSpellScale", (float(Lua_NPC::*)(void))&Lua_NPC::GetSpellScale);
+		.def("GetSpellScale", (float(Lua_NPC::*)(void))&Lua_NPC::GetSpellScale)
+		.def("GetLootList", (luabind::object(Lua_NPC::*)(lua_State* L))&Lua_NPC::GetLootList);
 }
 
 #endif

--- a/zone/lua_npc.h
+++ b/zone/lua_npc.h
@@ -8,12 +8,14 @@ class NPC;
 class Lua_Mob;
 class Lua_NPC;
 class Lua_Client;
+struct Lua_NPC_Loot_List;
 
 namespace luabind {
 	struct scope;
 }
 
 luabind::scope lua_register_npc();
+luabind::scope lua_register_npc_loot_list();
 
 class Lua_NPC : public Lua_Mob
 {
@@ -146,7 +148,7 @@ public:
 	uint16 GetFirstSlotByItemID(uint32 item_id);
 	float GetHealScale();
 	float GetSpellScale();
-	luabind::object GetLootList(lua_State* L);
+	Lua_NPC_Loot_List GetLootList(lua_State* L);
 };
 
 #endif

--- a/zone/lua_npc.h
+++ b/zone/lua_npc.h
@@ -146,6 +146,7 @@ public:
 	uint16 GetFirstSlotByItemID(uint32 item_id);
 	float GetHealScale();
 	float GetSpellScale();
+	luabind::object GetLootList(lua_State* L);
 };
 
 #endif

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -1121,6 +1121,8 @@ void LuaParser::MapFunctions(lua_State *L) {
 			lua_register_object_list(),
 			lua_register_door_list(),
 			lua_register_spawn_list(),
+			lua_register_corpse_loot_list(),
+			lua_register_npc_loot_list(),
 			lua_register_group(),
 			lua_register_raid(),
 			lua_register_corpse(),

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -682,12 +682,12 @@ bool NPC::HasItem(uint32 item_id) {
 	for (auto current_item  = itemlist.begin(); current_item != itemlist.end(); ++current_item) {
 		ServerLootItem_Struct* loot_item = *current_item;
 		if (!loot_item) {
-			LogError("NPC::CountItem() - ItemList error, null item");
+			LogError("NPC::HasItem() - ItemList error, null item");
 			continue;
 		}
 
 		if (!loot_item->item_id || !database.GetItem(loot_item->item_id)) {
-			LogError("NPC::CountItem() - Database error, invalid item");
+			LogError("NPC::HasItem() - Database error, invalid item");
 			continue;
 		}
 
@@ -3466,4 +3466,22 @@ bool NPC::IsGuard()
 		return true;
 	}
 	return false;
+}
+
+std::vector<int> NPC::GetLootList() {
+	std::vector<int> npc_items;
+	for (auto current_item  = itemlist.begin(); current_item != itemlist.end(); ++current_item) {
+		ServerLootItem_Struct* loot_item = *current_item;
+		if (!loot_item) {
+			LogError("NPC::GetLootList() - ItemList error, null item");
+			continue;
+		}
+
+		if (std::find(npc_items.begin(), npc_items.end(), loot_item->item_id) != npc_items.end()) {
+			continue;
+		}
+		
+		npc_items.push_back(loot_item->item_id);
+	}
+	return npc_items;
 }

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -208,6 +208,7 @@ public:
 	uint16	CountItem(uint32 item_id);
 	uint32	GetItemIDBySlot(uint16 loot_slot);
 	uint16	GetFirstSlotByItemID(uint32 item_id);
+	std::vector<int> GetLootList();
 	uint32	CountLoot();
 	inline uint32	GetLoottableID()	const { return loottable_id; }
 	virtual void UpdateEquipmentLight();

--- a/zone/perl_npc.cpp
+++ b/zone/perl_npc.cpp
@@ -1850,7 +1850,7 @@ XS(XS_NPC_GetLootList);
 XS(XS_NPC_GetLootList) {
 	dXSARGS;
 	if (items != 1)
-		Perl_croak(aTHX_ "Usage: NPC::GetLootList(THIS)");
+		Perl_croak(aTHX_ "Usage: NPC::GetLootList(THIS)"); // @categories Script Utility
 	{
 		NPC *THIS;
 		VALIDATE_THIS_IS_NPC;

--- a/zone/perl_npc.cpp
+++ b/zone/perl_npc.cpp
@@ -1846,6 +1846,29 @@ XS(XS_NPC_GetSpellScale) {
 	XSRETURN(1);
 }
 
+XS(XS_NPC_GetLootList);
+XS(XS_NPC_GetLootList) {
+	dXSARGS;
+	if (items != 1)
+		Perl_croak(aTHX_ "Usage: NPC::GetLootList(THIS)");
+	{
+		NPC *THIS;
+		VALIDATE_THIS_IS_NPC;
+		auto npc_items = THIS->GetLootList();
+		auto item_count = npc_items.size();
+		if (item_count > 0) {
+			EXTEND(sp, item_count);
+			for (int index = 0; index < item_count; ++index) {
+				ST(index) = sv_2mortal(newSVuv(npc_items[index]));
+			}
+			XSRETURN(item_count);
+		}
+		SV* return_value = &PL_sv_undef;
+		ST(0) = return_value;
+		XSRETURN(1);
+	}
+}
+
 #ifdef __cplusplus
 extern "C"
 #endif
@@ -1970,6 +1993,7 @@ XS(boot_NPC) {
 	newXSproto(strcpy(buf, "GetFirstSlotByItemID"), XS_NPC_GetFirstSlotByItemID, file, "$$");
 	newXSproto(strcpy(buf, "GetHealScale"), XS_NPC_GetHealScale, file, "$");
 	newXSproto(strcpy(buf, "GetSpellScale"), XS_NPC_GetSpellScale, file, "$");
+	newXSproto(strcpy(buf, "GetLootList"), XS_NPC_GetLootList, file, "$");
 	XSRETURN_YES;
 }
 

--- a/zone/perl_player_corpse.cpp
+++ b/zone/perl_player_corpse.cpp
@@ -599,6 +599,29 @@ XS(XS_Corpse_GetFirstSlotByItemID) {
 	XSRETURN(1);
 }
 
+XS(XS_Corpse_GetLootList);
+XS(XS_Corpse_GetLootList) {
+	dXSARGS;
+	if (items != 1)
+		Perl_croak(aTHX_ "Usage: Corpse::GetLootList(THIS)");
+	{
+		Corpse *THIS;
+		VALIDATE_THIS_IS_CORPSE;
+		auto corpse_items = THIS->GetLootList();
+		auto item_count = corpse_items.size();
+		if (item_count > 0) {
+			EXTEND(sp, item_count);
+			for (int index = 0; index < item_count; ++index) {
+				ST(index) = sv_2mortal(newSVuv(corpse_items[index]));
+			}
+			XSRETURN(item_count);
+		}
+		SV* return_value = &PL_sv_undef;
+		ST(0) = return_value;
+		XSRETURN(1);
+	}
+}
+
 #ifdef __cplusplus
 extern "C"
 #endif
@@ -649,6 +672,7 @@ XS(boot_Corpse) {
 	newXSproto(strcpy(buf, "CountItem"), XS_Corpse_CountItem, file, "$$");
 	newXSproto(strcpy(buf, "GetItemIDBySlot"), XS_Corpse_GetItemIDBySlot, file, "$$");
 	newXSproto(strcpy(buf, "GetFirstSlotByItemID"), XS_Corpse_GetFirstSlotByItemID, file, "$$");
+	newXSproto(strcpy(buf, "GetLootList"), XS_Corpse_GetLootList, file, "$");
 	XSRETURN_YES;
 }
 

--- a/zone/perl_player_corpse.cpp
+++ b/zone/perl_player_corpse.cpp
@@ -603,7 +603,7 @@ XS(XS_Corpse_GetLootList);
 XS(XS_Corpse_GetLootList) {
 	dXSARGS;
 	if (items != 1)
-		Perl_croak(aTHX_ "Usage: Corpse::GetLootList(THIS)");
+		Perl_croak(aTHX_ "Usage: Corpse::GetLootList(THIS)"); // @categories Script Utility
 	{
 		Corpse *THIS;
 		VALIDATE_THIS_IS_CORPSE;


### PR DESCRIPTION
- Add $corpse->GetLootList() to Perl.
- Add $npc->GetLootList() to Perl.
- Add corpse:GetLootList() to Lua.
- Add npc:GetLootList() to Lua.

Returns an array of item IDs for use with corpse and NPC methods such as HasItem(item_id), CountItem(item_id), and GetFirstSlotByItemID(item_id).