### PR TITLE
[Quest API] Add EVENT_CONSIDER_CORPSE to Perl and Lua.

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4962,6 +4962,7 @@ void Client::Handle_OP_ConsiderCorpse(const EQApplicationPacket *app)
 	Consider_Struct* conin = (Consider_Struct*)app->pBuffer;
 	Corpse* tcorpse = entity_list.GetCorpseByID(conin->targetid);
 	if (tcorpse && tcorpse->IsNPCCorpse()) {
+		parse->EventPlayer(EVENT_CONSIDER_CORPSE, this, fmt::format("{}", conin->targetid), 0);
 		uint32 min; uint32 sec; uint32 ttime;
 		if ((ttime = tcorpse->GetDecayTime()) != 0) {
 			sec = (ttime / 1000) % 60; // Total seconds
@@ -4975,6 +4976,7 @@ void Client::Handle_OP_ConsiderCorpse(const EQApplicationPacket *app)
 		}
 	}
 	else if (tcorpse && tcorpse->IsPlayerCorpse()) {
+		parse->EventPlayer(EVENT_CONSIDER_CORPSE, this, fmt::format("{}", conin->targetid), 0);
 		uint32 day, hour, min, sec, ttime;
 		if ((ttime = tcorpse->GetDecayTime()) != 0) {
 			sec = (ttime / 1000) % 60; // Total seconds
@@ -4989,22 +4991,6 @@ void Client::Handle_OP_ConsiderCorpse(const EQApplicationPacket *app)
 				Message(0, "This corpse will decay in %i minutes and %i seconds.", min, sec);
 
 			Message(0, "This corpse %s be resurrected.", tcorpse->IsRezzed() ? "cannot" : "can");
-			/*
-			hour = 0;
-
-			if((ttime = tcorpse->GetResTime()) != 0) {
-			sec = (ttime/1000)%60; // Total seconds
-			min = (ttime/60000)%60; // Total seconds
-			hour = (ttime/3600000)%24; // Total hours
-			if(hour)
-			Message(0, "This corpse can be resurrected for %i hours, %i minutes and %i seconds.", hour, min, sec);
-			else
-			Message(0, "This corpse can be resurrected for %i minutes and %i seconds.", min, sec);
-			}
-			else {
-			MessageString(Chat::White, CORPSE_TOO_OLD);
-			}
-			*/
 		}
 		else {
 			MessageString(Chat::NPCQuestSay, CORPSE_DECAY_NOW);

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -121,7 +121,8 @@ const char *QuestEventSubroutines[_LargestEventID] = {
 	"EVENT_COMBINE_VALIDATE",
 	"EVENT_BOT_COMMAND",
 	"EVENT_WARP",
-	"EVENT_TEST_BUFF"
+	"EVENT_TEST_BUFF",
+	"EVENT_CONSIDER_CORPSE"
 };
 
 PerlembParser::PerlembParser() : perl(nullptr)
@@ -1642,6 +1643,10 @@ void PerlembParser::ExportEventVariables(
 			ExportVar(package_name.c_str(), "from_x", sep.arg[0]);
 			ExportVar(package_name.c_str(), "from_y", sep.arg[1]);
 			ExportVar(package_name.c_str(), "from_z", sep.arg[2]);
+			break;
+		}
+		case EVENT_CONSIDER_CORPSE: {
+			ExportVar(package_name.c_str(), "corpse_entity_id", std::stoi(data));
 			break;
 		}
 

--- a/zone/event_codes.h
+++ b/zone/event_codes.h
@@ -90,6 +90,7 @@ typedef enum {
 	EVENT_BOT_COMMAND,
 	EVENT_WARP,
 	EVENT_TEST_BUFF,
+	EVENT_CONSIDER_CORPSE,
 	_LargestEventID
 } QuestEventID;
 

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -3241,7 +3241,8 @@ luabind::scope lua_register_events() {
 			luabind::value("death_zone", static_cast<int>(EVENT_DEATH_ZONE)),
 			luabind::value("use_skill", static_cast<int>(EVENT_USE_SKILL)),
 			luabind::value("warp", static_cast<int>(EVENT_WARP)),
-			luabind::value("test_buff", static_cast<int>(EVENT_TEST_BUFF))
+			luabind::value("test_buff", static_cast<int>(EVENT_TEST_BUFF)),
+			luabind::value("consider_corpse", static_cast<int>(EVENT_CONSIDER_CORPSE))
 		];
 }
 

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -132,7 +132,8 @@ const char *LuaEvents[_LargestEventID] = {
 	"event_combine_validate",
 	"event_bot_command",
 	"event_warp",
-	"event_test_buff"
+	"event_test_buff",
+	"event_consider_corpse"
 };
 
 extern Zone *zone;
@@ -220,6 +221,7 @@ LuaParser::LuaParser() {
 	PlayerArgumentDispatch[EVENT_COMBINE_VALIDATE] = handle_player_combine_validate;
 	PlayerArgumentDispatch[EVENT_BOT_COMMAND] = handle_player_bot_command;
 	PlayerArgumentDispatch[EVENT_WARP] = handle_player_warp;
+	PlayerArgumentDispatch[EVENT_CONSIDER_CORPSE] = handle_player_consider_corpse;
 
 	ItemArgumentDispatch[EVENT_ITEM_CLICK] = handle_item_click;
 	ItemArgumentDispatch[EVENT_ITEM_CLICK_CAST] = handle_item_click;

--- a/zone/lua_parser_events.cpp
+++ b/zone/lua_parser_events.cpp
@@ -573,6 +573,11 @@ void handle_player_warp(QuestInterface* parse, lua_State* L, Client* client, std
 	lua_setfield(L, -2, "from_z");
 }
 
+void handle_player_consider_corpse(QuestInterface* parse, lua_State* L, Client* client, std::string data, uint32 extra_data, std::vector<EQ::Any>* extra_pointers) {
+	lua_pushinteger(L, std::stoi(data));
+	lua_setfield(L, -2, "corpse_entity_id");
+}
+
 //Item
 void handle_item_click(QuestInterface *parse, lua_State* L, Client* client, EQ::ItemInstance* item, Mob *mob, std::string data, uint32 extra_data,
 					   std::vector<EQ::Any> *extra_pointers) {

--- a/zone/lua_parser_events.h
+++ b/zone/lua_parser_events.h
@@ -105,6 +105,8 @@ void handle_player_bot_command(QuestInterface *parse, lua_State* L, Client* clie
 		std::vector<EQ::Any> *extra_pointers);
 void handle_player_warp(QuestInterface* parse, lua_State* L, Client* client, std::string data, uint32 extra_data,
 	std::vector<EQ::Any>* extra_pointers);
+void handle_player_consider_corpse(QuestInterface* parse, lua_State* L, Client* client, std::string data, uint32 extra_data,
+	std::vector<EQ::Any>* extra_pointers);
 
 //Item
 void handle_item_click(QuestInterface *parse, lua_State* L, Client* client, EQ::ItemInstance* item, Mob *mob, std::string data, uint32 extra_data,


### PR DESCRIPTION
- Exports $corpse_entity_id in Perl.
- Exports e.corpse_entity_id in Lua.

Allows you to perform events on corpse consider for server operators.