### PR TITLE
[Enhancement] Remove hard coded 200 limit for RoF+ clients merchantlist_temp

### DIFF
--- a/common/version.h
+++ b/common/version.h
@@ -34,7 +34,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9172
+#define CURRENT_BINARY_DATABASE_VERSION 9173
 
 #ifdef BOTS
 	#define CURRENT_BINARY_BOTS_DATABASE_VERSION 9028

--- a/utils/sql/db_update_manifest.txt
+++ b/utils/sql/db_update_manifest.txt
@@ -426,6 +426,7 @@
 9170|2021_03_03_instance_safereturns.sql|SHOW TABLES LIKE 'character_instance_safereturns'|empty|
 9171|2021_03_30_remove_dz_is_current_member.sql|SHOW COLUMNS FROM `dynamic_zone_members` LIKE 'is_current_member'|not_empty|
 9172|2021_05_21_shared_tasks.sql|SHOW TABLES LIKE 'shared_tasks'|empty|
+9173|2021_09_12_more_merchant_slots.sql|SELECT data_type FROM information_schema.columns WHERE table_schema = database() AND table_name = 'merchantlist_temp' AND column_name = 'slot'|match|tinyint|
 
 # Upgrade conditions:
 # 	This won't be needed after this system is implemented, but it is used database that are not

--- a/utils/sql/git/required/2021_09_12_more_merchant_slots.sql
+++ b/utils/sql/git/required/2021_09_12_more_merchant_slots.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `merchantlist_temp` MODIFY `slot` INT(11);


### PR DESCRIPTION
Temporary merchant lists are limited to 80 pre RoF (per comment in the code).  As of RoF, the client was allowing 200.  I have tested and have found no reasonable boundary to the # of entries.

This code removes the length limitation of what is sent to the client.  The server was already tracking an unlimited list.

The only real limitation is the tinyint(3) type of the field 'slot' in merchantlist_temp.  The same field in merchantlist is int(11).

This PR:

- Removed the 200 limitation of what we can send clients (RoF+)  Pre RoF remains unchanged.
- Raises the datatype for slot in templist to an int(11) to allow for #s greater than 255 (current db storage limit)