### PR TITLE
[Bug Fix] Fixes EVENT_DISCONNECT for /quit and /exit.

### DIFF
--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -183,6 +183,8 @@ bool Client::Process() {
 
 			SetDynamicZoneMemberStatus(DynamicZoneMemberStatus::Offline);
 
+			parse->EventPlayer(EVENT_DISCONNECT, this, "", 0);
+
 			return false; //delete client
 		}
 


### PR DESCRIPTION
/quit and /exit will now properly parse to EVENT_DISCONNECT so operators can do things on disconnect to these players, previously it only functioned for /camp.