### PR TITLE
[Spells] Update to SPA 442 and 443 (SE_TriggerOnReqTarget, SE_TriggerOnReqCaster)

### DIFF
--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1125,8 +1125,8 @@ typedef enum {
 #define SE_Assassinate					439 // implemented[AA] - Assassinate damage
 #define SE_FinishingBlowLvl				440 // implemented[AA] - Sets the level Finishing blow can be triggered on an NPC
 #define SE_DistanceRemoval				441 // implemented - Buff is removed from target when target moves X amount of distance away from where initially hit.
-#define SE_TriggerOnReqTarget			442 // implemented - triggers a spell which a certain criteria are met (below X amount of hp,mana,end, number of pets on hatelist)
-#define SE_TriggerOnReqCaster			443 // implemented - triggers a spell which a certain criteria are met (below X amount of hp,mana,end, number of pets on hatelist)
+#define SE_TriggerOnReqTarget			442 // implemented, @SpellTrigger, triggers a spell when Target Requirement conditions are met (see enum SpellRestriction for IDs), base: spellid, limit: SpellRestriction ID, max: none, Note: Usually cast on a target
+#define SE_TriggerOnReqCaster			443 // implemented, @SpellTrigger, triggers a spell when Caster Requirement conditions are met (see enum SpellRestriction for IDs), base: spellid, limit: SpellRestriction ID, max: none, Note: Usually self only
 #define SE_ImprovedTaunt				444 // implemented - Locks Aggro On Caster and Decrease other Players Aggro by X% on NPC targets below level Y
 //#define SE_AddMercSlot				445 // *not implemented[AA] - [Hero's Barracks] Allows you to conscript additional mercs.
 #define SE_AStacker						446 // implementet - bufff stacking blocker (26219 | Qirik's Watch)

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2701,8 +2701,9 @@ void Mob::AddToHateList(Mob* other, uint32 hate /*= 0*/, int32 damage /*= 0*/, b
 		}
 	}
 
-	if (other->IsNPC() && (other->IsPet() || other->CastToNPC()->GetSwarmOwner() > 0))
-		TryTriggerOnValueAmount(false, false, false, true);
+	if (other->IsNPC() && (other->IsPet() || other->CastToNPC()->GetSwarmOwner() > 0)) {
+		TryTriggerOnCastRequirement();
+	}
 
 	if (IsClient() && !IsAIControlled())
 		return;
@@ -3343,7 +3344,7 @@ int32 Mob::ReduceAllDamage(int32 damage)
 		if (GetMana() >= mana_reduced) {
 			damage -= mana_reduced;
 			SetMana(GetMana() - mana_reduced);
-			TryTriggerOnValueAmount(false, true);
+			TryTriggerOnCastRequirement();
 		}
 	}
 
@@ -3356,7 +3357,7 @@ int32 Mob::ReduceAllDamage(int32 damage)
 		if (IsClient() && CastToClient()->GetEndurance() >= endurance_drain) {
 			damage -= damage_reduced;
 			CastToClient()->SetEndurance(CastToClient()->GetEndurance() - endurance_drain);
-			TryTriggerOnValueAmount(false, false, true);
+			TryTriggerOnCastRequirement();
 		}
 	}
 
@@ -3646,7 +3647,7 @@ void Mob::CommonDamage(Mob* attacker, int &damage, const uint16 spell_id, const 
 				TryDeathSave();
 		}
 
-		TryTriggerOnValueAmount(true);
+		TryTriggerOnCastRequirement();
 
 		//fade mez if we are mezzed
 		if (IsMezzed() && attacker) {

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -3198,7 +3198,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 
 			case SE_TriggerOnReqTarget:
 			case SE_TriggerOnReqCaster:
-				new_bonus->TriggerOnValueAmount = true;
+				new_bonus->TriggerOnCastRequirement = true;
 				break;
 
 			case SE_DivineAura:

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -1864,7 +1864,7 @@ void Client::DoEnduranceUpkeep() {
 
 	if(upkeep_sum != 0){
 		SetEndurance(GetEndurance() - upkeep_sum);
-		TryTriggerOnValueAmount(false, false, true);
+		TryTriggerOnCastRequirement();
 	}
 
 	if (!has_effect)

--- a/zone/common.h
+++ b/zone/common.h
@@ -602,7 +602,7 @@ struct StatBonuses {
 	int32	FinishingBlow[2];					// Chance to do a finishing blow for specified damage amount.
 	uint32	FinishingBlowLvl[2];				// Sets max level an NPC can be affected by FB. (base1 = lv, base2= ???)
 	int32	ShieldEquipDmgMod;					// Increases weapon's base damage by base1 % when shield is equipped (indirectly increasing hate)
-	bool	TriggerOnValueAmount;				// Triggers off various different conditions, bool to check if client has effect.
+	bool	TriggerOnCastRequirement;			// Triggers off various different conditions defined as emum SpellRestrictions
 	int8	StunBashChance;						// chance to stun with bash.
 	int8	IncreaseChanceMemwipe;				// increases chance to memory wipe
 	int8	CriticalMend;						// chance critical monk mend

--- a/zone/lua_stat_bonuses.cpp
+++ b/zone/lua_stat_bonuses.cpp
@@ -987,7 +987,7 @@ int32 Lua_StatBonuses::GetShieldEquipDmgMod() const {
 
 bool Lua_StatBonuses::GetTriggerOnValueAmount() const {
 	Lua_Safe_Call_Bool();
-	return self->TriggerOnValueAmount;
+	return self->TriggerOnCastRequirement;
 }
 
 int8 Lua_StatBonuses::GetStunBashChance() const {

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -3605,22 +3605,14 @@ bool Mob::TrySpellTrigger(Mob *target, uint32 spell_id, int effect)
 void Mob::TryTriggerOnCastRequirement()
 {
 	if (spellbonuses.TriggerOnCastRequirement) {
-
 		int buff_count = GetMaxTotalSlots();
-
 		for (int e = 0; e < buff_count; e++) {
-
-			uint32 spell_id = buffs[e].spellid;
-
+			int spell_id = buffs[e].spellid;
 			if (IsValidSpell(spell_id)) {
-
 				for (int i = 0; i < EFFECT_COUNT; i++) {
-
 					if ((spells[spell_id].effectid[i] == SE_TriggerOnReqTarget) || (spells[spell_id].effectid[i] == SE_TriggerOnReqCaster)) {
-						Shout("ID: %i", spells[spell_id].base2[i]);
 						if (PassCastRestriction(spells[spell_id].base2[i])) {
 							SpellFinished(spells[spell_id].base[i], this, EQ::spells::CastingSlot::Item, 0, -1, spells[spell_id].ResistDiff);
-							Shout("Success");
 							if (!TryFadeEffect(e)) {
 								BuffFadeBySlot(e);
 							}

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -796,7 +796,7 @@ public:
 	void TryTriggerOnCastFocusEffect(focusType type, uint16 spell_id);
 	bool TryTriggerOnCastProc(uint16 focusspellid, uint16 spell_id, uint16 proc_spellid);
 	bool TrySpellTrigger(Mob *target, uint32 spell_id, int effect);
-	void TryTriggerOnValueAmount(bool IsHP = false, bool IsMana = false, bool IsEndur = false, bool IsPet = false);
+	void TryTriggerOnCastRequirement();
 	void TryTwincast(Mob *caster, Mob *target, uint32 spell_id);
 	void TrySympatheticProc(Mob *target, uint32 spell_id);
 	bool TryFadeEffect(int slot);

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -387,7 +387,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 							caster->SetMana(caster->GetMana() + std::abs(effect_value));
 
 						if (effect_value < 0)
-							TryTriggerOnValueAmount(false, true);
+							TryTriggerOnCastRequirement();
 #ifdef SPELL_EFFECT_SPAM
 						if (caster)
 							caster->Message(Chat::White, "You have gained %+i mana!", effect_value);
@@ -403,7 +403,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 
 				SetMana(GetMana() + effect_value);
 				if (effect_value < 0)
-					TryTriggerOnValueAmount(false, true);
+					TryTriggerOnCastRequirement();
 				}
 
 				break;
@@ -2458,8 +2458,9 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 #endif
 				if(IsClient()) {
 					CastToClient()->SetEndurance(CastToClient()->GetEndurance() + effect_value);
-					if (effect_value < 0)
-						TryTriggerOnValueAmount(false, false, true);
+					if (effect_value < 0) {
+						TryTriggerOnCastRequirement();
+					}
 				}
 				break;
 			}
@@ -2470,10 +2471,11 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				snprintf(effect_desc, _EDLEN, "Current Endurance Once: %+i", effect_value);
 #endif
 
-				if(IsClient()) {
+				if (IsClient()) {
 					CastToClient()->SetEndurance(CastToClient()->GetEndurance() + effect_value);
-					if (effect_value < 0)
-						TryTriggerOnValueAmount(false, false, true);
+					if (effect_value < 0) {
+						TryTriggerOnCastRequirement();
+					}
 				}
 				break;
 			}
@@ -2652,7 +2654,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				int32 mana_to_use = GetMana() - spell.base[i];
 				if(mana_to_use > -1) {
 					SetMana(GetMana() - spell.base[i]);
-					TryTriggerOnValueAmount(false, true);
+					TryTriggerOnCastRequirement();
 					// we take full dmg(-10 to make the damage the right sign)
 					mana_damage = spell.base[i] / -10 * spell.base2[i];
 					Damage(caster, mana_damage, spell_id, spell.skill, false, i, true);
@@ -2672,7 +2674,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					int32 end_to_use = CastToClient()->GetEndurance() - spell.base[i];
 					if(end_to_use > -1) {
 						CastToClient()->SetEndurance(CastToClient()->GetEndurance() - spell.base[i]);
-						TryTriggerOnValueAmount(false, false, true);
+						TryTriggerOnCastRequirement();
 						// we take full dmg(-10 to make the damage the right sign)
 						end_damage = spell.base[i] / -10 * spell.base2[i];
 						Damage(caster, end_damage, spell_id, spell.skill, false, i, true);
@@ -2754,7 +2756,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					else {
 						dmg = ratio*max_mana/10;
 						caster->SetMana(caster->GetMana() - max_mana);
-						TryTriggerOnValueAmount(false, true);
+						TryTriggerOnCastRequirement();
 					}
 
 					if(IsDetrimentalSpell(spell_id)) {

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -383,7 +383,7 @@ bool Mob::DoCastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 			GetName()
 		);
 
-		TryTriggerOnValueAmount(false, true);
+		TryTriggerOnCastRequirement();
 		return(false);
 	}
 
@@ -2467,7 +2467,7 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, CastingSlot slot, ui
 		LogSpells("Spell [{}]: consuming [{}] mana", spell_id, mana_used);
 		if (!DoHPToManaCovert(mana_used)) {
 			SetMana(GetMana() - mana_used);
-			TryTriggerOnValueAmount(false, true);
+			TryTriggerOnCastRequirement();
 		}
 	}
 	// one may want to check if this is a disc or not, but we actually don't, there are non disc stuff that have end cost
@@ -2478,7 +2478,7 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, CastingSlot slot, ui
 		if (mgb)
 			end_cost *= 2;
 		SetEndurance(GetEndurance() - EQ::ClampUpper(end_cost, GetEndurance()));
-		TryTriggerOnValueAmount(false, false, true);
+		TryTriggerOnCastRequirement();
 	}
 	if (mgb)
 		SetMGB(false);


### PR DESCRIPTION
These effects trigger a spell when specific requirement is met, these requirements mimic values used the Caster and Target requirement  field from spell table. Updated these effects to utilize all the same code pathways. Overall this just now allows you to use all the possible options in the SpellRestriction enum from spdat.h. 

Note, to trigger this effect you need to use SpellRestrictions that affect HP, Mana, Endurance or Pet count. 
Ie. Trigger Completel heal if HP < 50% ... Where your base would be spell ID 13 and limit value would be 510 (SpellRestriction ID)
```
#define SE_TriggerOnReqTarget			442 // implemented, @SpellTrigger, triggers a spell when Target Requirement conditions are met (see enum SpellRestriction for IDs), base: spellid, limit: SpellRestriction ID, max: none, Note: Usually cast on a target
#define SE_TriggerOnReqCaster			443 // implemented, @SpellTrigger, triggers a spell when Caster Requirement conditions are met (see enum SpellRestriction for IDs), base: spellid, limit: SpellRestriction ID, max: none, Note: Usually self only
```