### PR TITLE
[Spells] Fix for  SE_CompleteHeal SPA 101 buff blocker

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -3661,6 +3661,10 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				new_bonus->ZoneSuspendMinion = effect_value;
 				break;
 
+			case SE_CompleteHeal:
+				new_bonus->CompleteHealBuffBlocker = true;
+				break;
+
 			//Special custom cases for loading effects on to NPC from 'npc_spels_effects' table
 			if (IsAISpellEffect) {
 

--- a/zone/common.h
+++ b/zone/common.h
@@ -554,6 +554,7 @@ struct StatBonuses {
 	int32	ItemEnduranceRegenCap;				// modify endurance regen cap
 	int32   WeaponStance[WEAPON_STANCE_TYPE_MAX +1];// base = trigger spell id, base2 = 0 is 2h, 1 is shield, 2 is dual wield, [0]spid 2h, [1]spid shield, [2]spid DW
 	bool	ZoneSuspendMinion;					// base 1 allows suspended minions to zone
+	bool	CompleteHealBuffBlocker;			// Use in SPA 101 to prevent recast of complete heal from this effect till blocker buff is removed.
 
 	// AAs
 	uint16  SecondaryForte;						// allow a second skill to be specialized with a cap of this value.

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -343,31 +343,13 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Complete Heal");
 #endif
-				//make sure they are not allready affected by this...
-				//I think that is the point of making this a buff.
-				//this is in the wrong spot, it should be in the immune
-				//section so the buff timer does not get refreshed!
-
-				int i;
-				bool inuse = false;
-				int buff_count = GetMaxTotalSlots();
-				for(i = 0; i < buff_count; i++) {
-					if(buffs[i].spellid == spell_id && i != buffslot) {
-						Message(0, "You must wait before you can be affected by this spell again.");
-						inuse = true;
-						break;
-					}
-				}
-				if(inuse)
-					break;
-
-				int32 val = 0;
-				val = 7500 * effect_value;
-				if (caster)
+				int val = 7500 * effect_value;
+				if (caster) {
 					val = caster->GetActSpellHealing(spell_id, val, this);
-
-				if (val > 0)
+				}
+				if (val > 0) {
 					HealDamage(val, caster);
+				}
 
 				break;
 			}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -2931,6 +2931,11 @@ int Mob::CheckStackConflict(uint16 spellid1, int caster_level1, uint16 spellid2,
 
 	LogSpells("Check Stacking on old [{}] ([{}]) @ lvl [{}] (by [{}]) vs. new [{}] ([{}]) @ lvl [{}] (by [{}])", sp1.name, spellid1, caster_level1, (caster1==nullptr)?"Nobody":caster1->GetName(), sp2.name, spellid2, caster_level2, (caster2==nullptr)?"Nobody":caster2->GetName());
 
+	if (spellbonuses.CompleteHealBuffBlocker && IsEffectInSpell(spellid2, SE_CompleteHeal)) {
+		Message(0, "You must wait before you can be affected by this spell again.");
+		return -1;
+	}
+
 	if (spellid1 == spellid2 ) {
 		if (!IsStackableDot(spellid1) && !IsEffectInSpell(spellid1, SE_ManaBurn)) { // mana burn spells we need to use the stacking command blocks live actually checks those first, we should probably rework to that too
 			if (caster_level1 > caster_level2) { // cur buff higher level than new


### PR DESCRIPTION
This is the effect on the Kunark Cleric Breastplates that had a clicky complete heal.
Once the CH is applied it also applied a buff that prevented any additional clicky CH from a BP from healing that target again
until the buffed faded.

From my testing it didn't even seem like the buff was blocking anything, further even if it was working the way it was coded caused the buff duration to be refreshed if it would block it. Regardless, this fixes the issue completely and now if you have the CH blocking buff on you, it just blocks any new incoming CH's correctly