### PR TITLE
[Spells] Minor fix SPA 305 SE_MitigateDamageShield

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -1256,8 +1256,11 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 		}
 
 		case SE_MitigateDamageShield: {
-			if (base1 < 0)
+			
+			//AA that increase mitigation are set to negative.
+			if (base1 < 0) {
 				base1 = base1 * (-1);
+			}
 
 			newbon->DSMitigationOffHand += base1;
 			break;
@@ -2663,8 +2666,15 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 
 			case SE_MitigateDamageShield:
 			{
-				if (effect_value < 0)
-					effect_value = effect_value*-1;
+				/*
+				Bard songs have identical negative base value and positive max
+				The effect for the songs should increase mitigation. There are
+				spells that do decrease the mitigation with just negative base values.
+				To be consistent all values that increase mitigation will be set to positives
+				*/
+				if (max > 0 && effect_value < 0) {
+					effect_value = max;
+				}
 
 				new_bonus->DSMitigationOffHand += effect_value;
 				break;


### PR DESCRIPTION
Small fix that will now allow for this spell effect also correctly apply to spells that have a negative effect of Decreasing your Offhand Damage shield mitigation. Ie. causing you to take more damage than normal. (There are a few spells on live that do this).