### PR TITLE
[Dialogue] Add support for Dialogue Window buttons.

### DIFF
--- a/zone/client.h
+++ b/zone/client.h
@@ -203,8 +203,10 @@ enum eInnateSkill {
 	InnateDisabled = 255
 };
 
-const std::string DIAWIND_RESPONSE_KEY           = "diawind_npcresponse";
-const uint32      POPUPID_DIAWIND                = 999;
+const std::string DIAWIND_RESPONSE_ONE_KEY       = "diawind_npc_response_one";
+const std::string DIAWIND_RESPONSE_TWO_KEY       = "diawind_npc_response_two";
+const uint32      POPUPID_DIAWIND_ONE            = 99999;
+const uint32      POPUPID_DIAWIND_TWO            = 100000;
 const uint32      POPUPID_UPDATE_SHOWSTATSWINDOW = 1000000;
 
 struct ClientReward

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -11155,9 +11155,18 @@ void Client::Handle_OP_PopupResponse(const EQApplicationPacket *app)
 			return;
 			break;
 
-		case POPUPID_DIAWIND:
-			if (EntityVariableExists(DIAWIND_RESPONSE_KEY.c_str())) {
-				response = GetEntityVariable(DIAWIND_RESPONSE_KEY.c_str());
+		case POPUPID_DIAWIND_ONE:
+			if (EntityVariableExists(DIAWIND_RESPONSE_ONE_KEY.c_str())) {
+				response = GetEntityVariable(DIAWIND_RESPONSE_ONE_KEY.c_str());
+				if (!response.empty()) {
+					ChannelMessageReceived(8, 0, 100, response.c_str());
+				}
+			}
+			break;
+
+		case POPUPID_DIAWIND_TWO:
+			if (EntityVariableExists(DIAWIND_RESPONSE_TWO_KEY.c_str())) {
+				response = GetEntityVariable(DIAWIND_RESPONSE_TWO_KEY.c_str());
 				if (!response.empty()) {
 					ChannelMessageReceived(8, 0, 100, response.c_str());
 				}

--- a/zone/dialogue_window.cpp
+++ b/zone/dialogue_window.cpp
@@ -182,7 +182,7 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 			auto second_split = split_string(first_split[1], " ");
 			if (!second_split.empty()) {
 				negativeid = second_split[0];
-				LogDiaWindDetail("Client [{}] Rendering negativeid option popupid [{}]", c->GetCleanName(), negativeid);
+				LogDiaWindDetail("Client [{}] Rendering negativeid option negativeid [{}]", c->GetCleanName(), negativeid);
 			}
 
 			if (first_split[1].length() == 1) {

--- a/zone/dialogue_window.cpp
+++ b/zone/dialogue_window.cpp
@@ -172,6 +172,36 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 		}
 	}
 
+	// negativeid
+	std::string negativeid;
+	if (markdown.find("negativeid") != std::string::npos) {
+		LogDiaWind("Client [{}] Rendering negativeid option", c->GetCleanName());
+
+		auto first_split = split_string(output, "negativeid:");
+		if (!first_split.empty()) {
+			auto second_split = split_string(first_split[1], " ");
+			if (!second_split.empty()) {
+				negativeid = second_split[0];
+				LogDiaWindDetail("Client [{}] Rendering negativeid option popupid [{}]", c->GetCleanName(), negativeid);
+			}
+
+			if (first_split[1].length() == 1) {
+				negativeid = first_split[1];
+				LogDiaWindDetail(
+					"Client [{}] Rendering negativeid (end) option negativeid [{}]",
+					c->GetCleanName(),
+					negativeid
+				);
+			}
+
+			find_replace(output, fmt::format("negativeid:{}", negativeid), "");
+
+			if (!negativeid.empty()) {
+				negative_id = (StringIsNumber(negativeid) ? std::atoi(negativeid.c_str()) : 0);
+			}
+		}
+	}
+
 	// Buttons Text
 	std::string button_one;
 	std::string button_two;

--- a/zone/dialogue_window.cpp
+++ b/zone/dialogue_window.cpp
@@ -270,6 +270,18 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 		}
 	}
 
+	// Placed here to allow silent message or other message to override default for custom values.
+	if (button_one_name != nullptr && button_two_name != nullptr) {
+		c->SetEntityVariable(
+			DIAWIND_RESPONSE_ONE_KEY.c_str(),
+			button_one_name
+		);
+		c->SetEntityVariable(
+			DIAWIND_RESPONSE_TWO_KEY.c_str(),
+			button_two_name
+		);
+	}
+
 	// handle silent prompts from the [> silent syntax
 	std::string silent_message;
 	if (responses.empty() && markdown.find('[') != std::string::npos && markdown.find('>') != std::string::npos) {
@@ -350,14 +362,6 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 			button_one_name,
 			button_one_name,
 			button_two_name,
-			button_two_name
-		);
-		c->SetEntityVariable(
-			DIAWIND_RESPONSE_ONE_KEY.c_str(),
-			button_one_name
-		);
-		c->SetEntityVariable(
-			DIAWIND_RESPONSE_TWO_KEY.c_str(),
 			button_two_name
 		);
 	}

--- a/zone/dialogue_window.cpp
+++ b/zone/dialogue_window.cpp
@@ -11,7 +11,8 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 	}
 
 	// zero this out
-	c->SetEntityVariable(DIAWIND_RESPONSE_KEY.c_str(), "");
+	c->SetEntityVariable(DIAWIND_RESPONSE_ONE_KEY.c_str(), "");
+	c->SetEntityVariable(DIAWIND_RESPONSE_TWO_KEY.c_str(), "");
 
 	// simple find and replace for the markdown
 	find_replace(output, "~", "</c>");
@@ -32,10 +33,10 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 
 	// mysterious voice
 	bool render_mysterious_voice = false;
-	if (markdown.find("mysterious") != std::string::npos) {
+	if (markdown.find("{mysterious}") != std::string::npos) {
 		render_mysterious_voice = true;
 		LogDiaWind("Client [{}] Rendering mysterious voice", c->GetCleanName());
-		find_replace(output, "mysterious", "");
+		find_replace(output, "{mysterious}", "");
 	}
 
 	// noquotes
@@ -98,10 +99,10 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 		}
 	}
 
-	uint32 popup_id       = POPUPID_DIAWIND;
-	uint32 negative_id    = 0;
-	char   *button_name_0 = nullptr;
-	char   *button_name_1 = nullptr;
+	uint32 popup_id = POPUPID_DIAWIND_ONE;
+	uint32 negative_id = POPUPID_DIAWIND_TWO;
+	const char *button_one_name = nullptr;
+	const char *button_two_name = nullptr;
 	uint32 sound_controls = 0;
 
 	// window type
@@ -171,6 +172,66 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 		}
 	}
 
+	// Buttons Text
+	std::string button_one;
+	std::string button_two;
+	if (
+		markdown.find("button_one") != std::string::npos &&
+		markdown.find("button_two") != std::string::npos
+	) {
+		LogDiaWind("Client [{}] Rendering button_one option.", c->GetCleanName());
+
+		auto one_first_split = split_string(output, "button_one:");
+		if (!one_first_split.empty()) {
+			auto one_second_split = split_string(one_first_split[1], " ");
+			if (!one_second_split.empty()) {
+				button_one = one_second_split[0];
+				LogDiaWindDetail("Client [{}] Rendering button_one option button_one [{}]", c->GetCleanName(), button_one);
+			}
+
+			if (one_first_split[1].length() == 1) {
+				button_one = one_first_split[1];
+				LogDiaWindDetail(
+					"Client [{}] Rendering button_one (end) option button_one [{}]",
+					c->GetCleanName(),
+					button_one
+				);
+			}
+
+			find_replace(output, fmt::format("button_one:{}", button_one), "");
+
+			if (!button_one.empty()) {
+				button_one_name = button_one.c_str();
+			}
+		}
+		
+		LogDiaWind("Client [{}] Rendering button_two option.", c->GetCleanName());
+
+		auto two_first_split = split_string(output, "button_two:");
+		if (!two_first_split.empty()) {
+			auto two_second_split = split_string(two_first_split[1], " ");
+			if (!two_second_split.empty()) {
+				button_two = two_second_split[0];
+				LogDiaWindDetail("Client [{}] Rendering button_two option button_two [{}]", c->GetCleanName(), button_two);
+			}
+
+			if (two_first_split[1].length() == 1) {
+				button_two = two_first_split[1];
+				LogDiaWindDetail(
+					"Client [{}] Rendering button_two (end) option button_two [{}]",
+					c->GetCleanName(),
+					button_two
+				);
+			}
+
+			find_replace(output, fmt::format("button_two:{}", button_two), "");
+
+			if (!button_two.empty()) {
+				button_two_name = button_two.c_str();
+			}
+		}
+	}
+
 	// bracket responses
 	std::vector<std::string> responses;
 	std::vector<std::string> bracket_responses;
@@ -215,7 +276,7 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 		silent_message = get_between(output, "[", ">");
 
 		// temporary and used during the response
-		c->SetEntityVariable(DIAWIND_RESPONSE_KEY.c_str(), silent_message.c_str());
+		c->SetEntityVariable(DIAWIND_RESPONSE_ONE_KEY.c_str(), silent_message.c_str());
 
 		// pop the silent message off
 		find_replace(output, fmt::format("[{}>", silent_message), "");
@@ -225,7 +286,7 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 		silent_message = responses[0];
 
 		// temporary and used during the response
-		c->SetEntityVariable(DIAWIND_RESPONSE_KEY.c_str(), silent_message.c_str());
+		c->SetEntityVariable(DIAWIND_RESPONSE_ONE_KEY.c_str(), silent_message.c_str());
 
 		// pop the silent message off
 		find_replace(output, fmt::format("[{}]", silent_message), "");
@@ -282,6 +343,25 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 		);
 	}
 
+	if (button_one_name != nullptr && button_two_name != nullptr) {
+		click_response = fmt::format(
+			"<c \"#F07F00\">Click [{}] to respond with [{}]...<br>"
+			"Click [{}] to respond with [{}]...</c>",
+			button_one_name,
+			button_one_name,
+			button_two_name,
+			button_two_name
+		);
+		c->SetEntityVariable(
+			DIAWIND_RESPONSE_ONE_KEY.c_str(),
+			button_one_name
+		);
+		c->SetEntityVariable(
+			DIAWIND_RESPONSE_TWO_KEY.c_str(),
+			button_two_name
+		);
+	}
+
 	// post processing of color markdowns
 	// {spring_green_1} = <c "#5EFB6E">
 	if (markdown.find('{') != std::string::npos && markdown.find('}') != std::string::npos) {
@@ -325,8 +405,8 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 		negative_id,
 		window_type,
 		window_expire_seconds,
-		button_name_0,
-		button_name_1,
+		button_one_name,
+		button_two_name,
 		sound_controls
 	);
 

--- a/zone/dialogue_window.cpp
+++ b/zone/dialogue_window.cpp
@@ -101,8 +101,8 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 
 	uint32 popup_id = POPUPID_DIAWIND_ONE;
 	uint32 negative_id = POPUPID_DIAWIND_TWO;
-	const char *button_one_name = nullptr;
-	const char *button_two_name = nullptr;
+	std::string button_one_name;
+	std::string button_two_name;
 	uint32 sound_controls = 0;
 
 	// window type
@@ -172,32 +172,32 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 		}
 	}
 
-	// negativeid
-	std::string negativeid;
-	if (markdown.find("negativeid") != std::string::npos) {
-		LogDiaWind("Client [{}] Rendering negativeid option", c->GetCleanName());
+	// secondresponseid
+	std::string secondresponseid;
+	if (markdown.find("secondresponseid") != std::string::npos) {
+		LogDiaWind("Client [{}] Rendering secondresponseid option", c->GetCleanName());
 
-		auto first_split = split_string(output, "negativeid:");
+		auto first_split = split_string(output, "secondresponseid:");
 		if (!first_split.empty()) {
 			auto second_split = split_string(first_split[1], " ");
 			if (!second_split.empty()) {
-				negativeid = second_split[0];
-				LogDiaWindDetail("Client [{}] Rendering negativeid option negativeid [{}]", c->GetCleanName(), negativeid);
+				secondresponseid = second_split[0];
+				LogDiaWindDetail("Client [{}] Rendering secondresponseid option secondresponseid [{}]", c->GetCleanName(), secondresponseid);
 			}
 
 			if (first_split[1].length() == 1) {
-				negativeid = first_split[1];
+				secondresponseid = first_split[1];
 				LogDiaWindDetail(
-					"Client [{}] Rendering negativeid (end) option negativeid [{}]",
+					"Client [{}] Rendering secondresponseid (end) option secondresponseid [{}]",
 					c->GetCleanName(),
-					negativeid
+					secondresponseid
 				);
 			}
 
-			find_replace(output, fmt::format("negativeid:{}", negativeid), "");
+			find_replace(output, fmt::format("secondresponseid:{}", secondresponseid), "");
 
-			if (!negativeid.empty()) {
-				negative_id = (StringIsNumber(negativeid) ? std::atoi(negativeid.c_str()) : 0);
+			if (!secondresponseid.empty()) {
+				negative_id = (StringIsNumber(secondresponseid) ? std::atoi(secondresponseid.c_str()) : 0);
 			}
 		}
 	}
@@ -301,14 +301,14 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 	}
 
 	// Placed here to allow silent message or other message to override default for custom values.
-	if (button_one_name != nullptr && button_two_name != nullptr) {
+	if (!button_one_name.empty() && !button_two_name.empty()) {
 		c->SetEntityVariable(
 			DIAWIND_RESPONSE_ONE_KEY.c_str(),
-			button_one_name
+			button_one_name.c_str()
 		);
 		c->SetEntityVariable(
 			DIAWIND_RESPONSE_TWO_KEY.c_str(),
-			button_two_name
+			button_two_name.c_str()
 		);
 	}
 
@@ -385,7 +385,7 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 		);
 	}
 
-	if (button_one_name != nullptr && button_two_name != nullptr) {
+	if (!button_one_name.empty() && !button_two_name.empty()) {
 		click_response = fmt::format(
 			"<c \"#F07F00\">Click [{}] to respond with [{}]...<br>"
 			"Click [{}] to respond with [{}]...</c>",
@@ -439,8 +439,8 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 		negative_id,
 		window_type,
 		window_expire_seconds,
-		button_one_name,
-		button_two_name,
+		button_one_name.c_str(),
+		button_two_name.c_str(),
 		sound_controls
 	);
 


### PR DESCRIPTION
- Syntax is button_one:button_one_name and button_two:button_two_name, similar to wintype and popupid.
- Add support for negativeid, syntax is negativeid:id. 
- Also changes "mysterious" identifier to "{mysterious}".
- Both button names are required for anything to show up, otherwise it defaults to Yes/No similar to Client::SendFullPopup.

Example:
```pl
sub EVENT_SAY {
    if ($text=~/Hail/i) {
        $client->DialogueWindow("Testing! {mysterious} wintype:1 button_one:Update button_two:Close");
    }
}
```
![image](https://user-images.githubusercontent.com/89047260/133723353-d6389b79-897e-4c41-ad53-baea391876fb.png)
