### PR TITLE
[Bug Fix] Fix bug where IVU could not be cast on char with Invis

### DIFF
--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -582,7 +582,6 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				snprintf(effect_desc, _EDLEN, "Invisibility to Animals");
 #endif
 				invisible_animals = true;
-				SetInvisible(0);
 				break;
 			}
 
@@ -593,7 +592,6 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				snprintf(effect_desc, _EDLEN, "Invisibility to Undead");
 #endif
 				invisible_undead = true;
-				SetInvisible(0);
 				break;
 			}
 			case SE_SeeInvis:


### PR DESCRIPTION
This issue was introduced by:

[Bug Fix] Fixed Invis vs Undead / Invis Vs Animals not breaking charm + Added rule for custom capabilities #1374

if you look at the code: https://github.com/EQEmu/Server/pull/1374/files I think you'll see that the two lines added to spell_effects.cpp are not needed for this PR and actually break the feature of one char casting invis and IVU *in that order* on a group member.

I don't think SetInvisible(0) is needed in the two spots it was added.

Do you agree @splose?

Tested and fixes my issue, and I don't see how it breaks the original PR intent.

