### PR TITLE
[Spells] Fix for Spell Buff Max Hits not displaying when initially cast

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3401,7 +3401,7 @@ int Mob::AddBuff(Mob *caster, uint16 spell_id, int duration, int32 level_overrid
 	buffs[emptyslot].focusproclimit_procamt = 0;
 	buffs[emptyslot].instrument_mod = caster ? caster->GetInstrumentMod(spell_id) : 10;
 
-	if (level_override > 0) {
+	if (level_override > 0 || buffs[emptyslot].numhits > 0) {
 		buffs[emptyslot].UpdateClient = true;
 	} else {
 		if (buffs[emptyslot].ticsremaining > (1 + CalcBuffDuration_formula(caster_level, spells[spell_id].buffdurationformula, spells[spell_id].buffduration)))


### PR DESCRIPTION
Fix for Spell Buff Max Hits not displaying when initially cast. This the little number in the left bottom corner of buffs that can be counted down if conditions are met. Example spell Mana Flare 8032.

Not entirely sure why this broke, but noticed it.

The update that sends the packet needs to occur at the first buff tick so it may be slightly delayed, not ideal but best I could do to make it work again.