### PR TITLE
[Spells] Updated Memory Blur SPA 63 - Implemented Live Mechanics

### DIFF
--- a/common/spdat.h
+++ b/common/spdat.h
@@ -748,7 +748,7 @@ typedef enum {
 //#define SE_TransferItem				60	// not used
 #define SE_Identify						61	// implemented
 //#define SE_ItemID						62	// not used
-#define SE_WipeHateList					63	// implemented
+#define SE_WipeHateList					63	// implemented, @Memblur, chance to wipe hate list of target, base: pct chance, limit: none, max: ? (not implemented), Note: caster level and CHA add to pct chance
 #define SE_SpinTarget					64	// implemented - TO DO: Not sure stun portion is working correctly
 #define SE_InfraVision					65	// implemented
 #define SE_UltraVision					66	// implemented
@@ -927,7 +927,7 @@ typedef enum {
 #define SE_FeignedCastOnChance			239	// implemented - ability gives you an increasing chance for your feigned deaths to not be revealed by spells cast upon you.
 //#define SE_StringUnbreakable			240	// not used [Likely related to above - you become immune to feign breaking on a resisted spell and have a good chance of feigning through a spell that successfully lands upon you.]
 #define SE_ImprovedReclaimEnergy		241	// implemented - increase the amount of mana returned to you when reclaiming your pet.
-#define SE_IncreaseChanceMemwipe		242	// implemented - increases the chance to wipe hate with memory blurr
+#define SE_IncreaseChanceMemwipe		242	// implemented - @Memblur, increases the chance to wipe hate with memory blurr, base: chance pct, limit: none, max: none, Note: Mods final blur chance after other bonuses added.
 #define SE_CharmBreakChance				243	// implemented - Total Domination
 #define	SE_RootBreakChance				244	// implemented[AA] reduce the chance that your root will break.
 #define SE_TrapCircumvention			245	// *not implemented[AA] - decreases the chance that you will set off a trap when opening a chest

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -845,6 +845,7 @@ public:
 	bool HarmonySpellLevelCheck(int32 spell_id, Mob* target = nullptr);
 	bool CanFocusUseRandomEffectivenessByType(focusType type);
 	int GetFocusRandomEffectivenessValue(int focus_base, int focus_base2, bool best_focus = 0);
+	int GetMemoryBlurChance(int base_chance);
 
 	bool TryDoubleMeleeRoundEffect();
 	bool GetUseDoubleMeleeRoundDmgBonus() const { return use_double_melee_round_dmg_bonus; }
@@ -1533,6 +1534,7 @@ protected:
 	bool endur_upkeep;
 	bool degenerating_effects; // true if we have a buff that needs to be recalced every tick
 	bool spawned_in_water;
+
 public:
 	bool GetWasSpawnedInWater() const;
 


### PR DESCRIPTION
Memory blur spell effect should be calculated as below. I personally checked on live to confirm this is accurate. These changes will allow memory blur chances to be significantly higher than how we have them now, which for most effects makes almost useless at 1% to 10% chances.


	        Memory Blur mechanic for SPA 62
		Chance formula is effect chance + charisma modifier + caster level modifier
		Effect chance is base value of spell
		Charisma modifier is CHA/10 = %, with MAX of 15% (thus 150 cha gives you max bonus)
		Caster level modifier. +100% if caster < level 17 which scales down to 25% at > 53. **
		(Yes the above gets worse as you level. Behavior was confirmed on live.)
		Memory blur is applied to mez on initial cast using same formula. However, recasting on a target that
		is already mezed will not give a chance to memory blur. The blur is not checked on buff ticks.

		SPA 242 SE_IncreaseChanceMemwipe modifies the final chance after all bonuses are applied.
		This is also applied to memory blur from mez spells.

Example: Using Memory blur with a 10pct chance, at lv 60 with cha of 150... 
10+25+15 = 50 pct chance  .... Add in SPA 242 with value of 100 ... 50 + (50*100/100) = 100% chance

Example: Using Memory blur with a 10pct chance, at lv 10 with cha of 100... 
10+10+100 = 120 pct chance (I know it sounds crazy but you can log onto live and see for yourself!)

SE_WipeHateList	63, Memblur, chance to wipe hate list of target, base: pct chance, limit: none, max: ? (not implemented), Note: caster level and CHA add to pct chance
SE_IncreaseChanceMemwipe	242	- increases the chance to wipe hate with memory blurr, base: chance pct, limit: none, max: none, Note: Mods final blur chance after other bonuses added.

