### PR TITLE
[Bug Fix] Zones no longer syncing time to world

### DIFF
--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -153,7 +153,6 @@ bool Zone::Bootup(uint32 iZoneID, uint32 iInstanceID, bool iStaticZone) {
 	LogInfo("Zone Bootup: [{}] ([{}]: [{}])", zonename, iZoneID, iInstanceID);
 	parse->Init();
 	UpdateWindowTitle(nullptr);
-	zone->GetTimeSync();
 
 	zone->RequestUCSServerStatus();
 
@@ -1818,7 +1817,8 @@ void Zone::Repop(uint32 delay)
 
 void Zone::GetTimeSync()
 {
-	if (worldserver.Connected() && !zone_has_current_time) {
+	if (!zone_has_current_time) {
+		LogInfo("Requesting world time");
 		auto pack = new ServerPacket(ServerOP_GetWorldTime, 1);
 		worldserver.SendPacket(pack);
 		safe_delete(pack);


### PR DESCRIPTION
The changes about a month back to the world/zone connection sequence moved the call from world to OnConnect in the timing sequence. 

https://github.com/EQEmu/Server/commit/1c8231eb9ef2093613ab7791a991e9d0b089ea97

Specifically calling OnConnect before the flag gets cleared.

![image](https://user-images.githubusercontent.com/8644833/134927496-9ca4ade3-2e84-4635-bb81-3c5ff193c54b.png)


Current code:
World calls zone::Bootup()
zone::Bootup calls Zone::GetTimeSync
Zone::GetTimeSync won't request TimeSync unless worldserver.Connected() is true.
World calls zone::OnConnect()
On Connect() calls Zone::GetTimeSync
Zone::GetTimeSync won't request TimeSync unless worldserver.Connected() is true.
World sets m_connecting = false - But now GetTimeSync is no longer called.

After this PR:

- removed call to Zone::GetTimeSync in zone:Bootup as it will fail anyway (worldserver.Connected() is false)
- No longer check worldserver.Connected() in Zone::GetTimeSync because now Zone::GetTimeSync is only called in Zone::OnConnect and we know it is safe to send packets.

Time is now syncing again.

Without this fix - up-to-date servers have all zones are at the default game time.