### PR TITLE
Fixes normal tasks to work properly, shared tasks may need logic change.

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2357,9 +2357,27 @@ bool NPC::Death(Mob* killer_mob, int32 damage, uint16 spell, EQ::skills::SkillTy
 				give_exp_client->GetCleanName(),
 				GetNPCTypeID()
 			);
-			give_exp_client
-				->GetTaskState()
-				->HandleUpdateTasksOnKill(give_exp_client, GetNPCTypeID());
+			if (kr) {
+				for (int i = 0; i < MAX_RAID_MEMBERS; i++) {
+					if (kr->members[i].member != nullptr && kr->members[i].member->IsClient()) { // If Group Member is Client
+						Client *c = kr->members[i].member;
+						c->GetTaskState()->HandleUpdateTasksOnKill(c, GetNPCTypeID());
+					}
+				}
+			}
+			else if (give_exp_client->IsGrouped() && kg != nullptr) {
+				for (int i = 0; i < MAX_GROUP_MEMBERS; i++) {
+					if (kg->members[i] != nullptr && kg->members[i]->IsClient()) { // If Group Member is Client
+						Client *c = kg->members[i]->CastToClient();
+						c->GetTaskState()->HandleUpdateTasksOnKill(c, GetNPCTypeID());
+					}
+				}
+			}
+			else {
+				give_exp_client
+					->GetTaskState()
+					->HandleUpdateTasksOnKill(give_exp_client, GetNPCTypeID());
+			}
 		}
 
 		if (kr) {

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -2813,33 +2813,15 @@ void ClientTaskState::HandleUpdateTasksOnKill(Client *client, uint32 npc_type_id
 			if (p_task_data->type != TaskType::Shared) {
 				LogTasksDetail("[HandleUpdateTasksOnKill] Non-Shared Update");
 
-				Raid *raid = entity_list.GetRaidByClient(client);
-				if (raid) {
-					for (auto &e : raid->members) {
-						if (e.member && e.member->IsClient()) {
-							Client *c = e.member->CastToClient();
-							c->UpdateTasksOnKill(npc_type_id);
-						}
-					}
-					return;
-				}
-
-				Group *group = entity_list.GetGroupByClient(client);
-				if (group) {
-					for (auto &m : group->members) {
-						if (m && m->IsClient()) {
-							Client *c = m->CastToClient();
-							c->UpdateTasksOnKill(npc_type_id);
-						}
-					}
-					return;
-				}
+				client->UpdateTasksOnKill(npc_type_id);
 			}
 
 			LogTasksDetail("[HandleUpdateTasksOnKill] Shared update");
-
-			// shared tasks only require one client to receive an update to propagate
-			client->UpdateTasksOnKill(npc_type_id);
+			
+			if (p_task_data->type == TaskType::Shared) {
+				// shared tasks only require one client to receive an update to propagate
+				client->UpdateTasksOnKill(npc_type_id);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Shared task logic broke old tasks.. example...

Player 1 is top damage and doesn't have tasks.. everyone in party will not get OnKill task updates.
Player 1 is top damage and has task, but this stage is completed .. everyone else in party will not get OnKill task updates.

This fixes current tasks to work properly again, however looking to find something that won't cause duplicate updates for ShareTask updates.