### PR TITLE
[Dialogue] Add support for Dialogue Window titles.

### DIFF
--- a/zone/dialogue_window.cpp
+++ b/zone/dialogue_window.cpp
@@ -104,7 +104,7 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 
 	// window type
 	std::string wintype;
-	if (markdown.find("wintype") != std::string::npos) {
+	if (markdown.find("wintype:") != std::string::npos) {
 		LogDiaWind("Client [{}] Rendering wintype option", c->GetCleanName());
 
 		auto first_split = split_string(output, "wintype:");
@@ -135,7 +135,7 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 
 	// popupid
 	std::string popupid;
-	if (markdown.find("popupid") != std::string::npos) {
+	if (markdown.find("popupid:") != std::string::npos) {
 		LogDiaWind("Client [{}] Rendering popupid option", c->GetCleanName());
 
 		auto first_split = split_string(output, "popupid:");
@@ -171,7 +171,7 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 
 	// secondresponseid
 	std::string secondresponseid;
-	if (markdown.find("secondresponseid") != std::string::npos) {
+	if (markdown.find("secondresponseid:") != std::string::npos) {
 		LogDiaWind("Client [{}] Rendering secondresponseid option", c->GetCleanName());
 
 		auto first_split = split_string(output, "secondresponseid:");
@@ -203,8 +203,8 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 	std::string button_one;
 	std::string button_two;
 	if (
-		markdown.find("button_one") != std::string::npos &&
-		markdown.find("button_two") != std::string::npos
+		markdown.find("button_one:") != std::string::npos &&
+		markdown.find("button_two:") != std::string::npos
 	) {
 		LogDiaWind("Client [{}] Rendering button_one option.", c->GetCleanName());
 
@@ -350,7 +350,7 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 
 	// title
 	std::string popup_title;
-	if (markdown.find("title") != std::string::npos) {
+	if (markdown.find("title:") != std::string::npos) {
 		LogDiaWind("Client [{}] Rendering title option", c->GetCleanName());
 
 		auto first_split = split_string(output, "title:");

--- a/zone/dialogue_window.cpp
+++ b/zone/dialogue_window.cpp
@@ -5,10 +5,7 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 	std::string output = markdown;
 
 	// this is the NPC that the client is interacting with if there is dialogue going on
-	Mob *target;
-	if (c->GetTarget()) {
-		target = c->GetTarget();
-	}
+	Mob* target = c->GetTarget() ? c->GetTarget() : c;
 
 	// zero this out
 	c->SetEntityVariable(DIAWIND_RESPONSE_ONE_KEY.c_str(), "");
@@ -351,7 +348,39 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 		speaking = "A Mysterious Voice says";
 	}
 
-	title = fmt::format("Dialogue [{}]", speaking);
+	// title
+	std::string popup_title;
+	if (markdown.find("title") != std::string::npos) {
+		LogDiaWind("Client [{}] Rendering title option", c->GetCleanName());
+
+		auto first_split = split_string(output, "title:");
+		if (!first_split.empty()) {
+			auto second_split = split_string(first_split[1], " ");
+			if (!second_split.empty()) {
+				popup_title = second_split[0];
+				LogDiaWindDetail("Client [{}] Rendering title option title [{}]", c->GetCleanName(), popup_title);
+			}
+
+			if (first_split[1].length() == 1) {
+				popup_title = first_split[1];
+				LogDiaWindDetail(
+					"Client [{}] Rendering title (end) option title [{}]",
+					c->GetCleanName(),
+					popup_title
+				);
+			}
+
+			find_replace(output, fmt::format("title:{}", popup_title), "");
+
+			if (!popup_title.empty()) {
+				title = popup_title;
+			}
+		}
+	}
+
+	if (title.empty()) {
+		title = fmt::format("Dialogue [{}]", speaking);
+	}
 
 	// render quotes
 	std::string quote_string = "'";


### PR DESCRIPTION
- Syntax is `title:popup_title`
- Custom title allows defaults to be overridden where necessary, like a leaderboard or something.
- Default target to client in case people want to send Dialogue Windows from current client.
- Fix possible issue with markdown.
- Example: Using the word "title" or using any identifier and forgetting the colon.