### PR TITLE
[Shared Tasks] Always update group members for task kill updates

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2350,18 +2350,6 @@ bool NPC::Death(Mob* killer_mob, int32 damage, uint16 spell, EQ::skills::SkillTy
 		int32 finalxp = give_exp_client->GetExperienceForKill(this);
 		finalxp = give_exp_client->mod_client_xp(finalxp, this);
 
-		// handle task credit on behalf of the killer
-		if (RuleB(TaskSystem, EnableTaskSystem)) {
-			LogTasksDetail(
-				"[NPC::Death] Triggering HandleUpdateTasksOnKill for [{}] npc [{}]",
-				give_exp_client->GetCleanName(),
-				GetNPCTypeID()
-			);
-			give_exp_client
-				->GetTaskState()
-				->HandleUpdateTasksOnKill(give_exp_client, GetNPCTypeID());
-		}
-
 		if (kr) {
 			if (!IsLdonTreasure && MerchantType == 0) {
 				kr->SplitExp((finalxp), this);
@@ -2379,6 +2367,11 @@ bool NPC::Death(Mob* killer_mob, int32 damage, uint16 spell, EQ::skills::SkillTy
 						c->SetFactionLevel(c->CharacterID(), GetNPCFactionID(), c->GetBaseClass(), c->GetBaseRace(), c->GetDeity());
 
 					mod_npc_killed_merit(kr->members[i].member);
+
+					if (RuleB(TaskSystem, EnableTaskSystem)) {
+						bool update_shared_task = (c == give_exp_client);
+						c->UpdateTasksOnKill(GetNPCTypeID(), update_shared_task);
+					}
 
 					PlayerCount++;
 				}
@@ -2427,6 +2420,11 @@ bool NPC::Death(Mob* killer_mob, int32 damage, uint16 spell, EQ::skills::SkillTy
 
 					mod_npc_killed_merit(c);
 
+					if (RuleB(TaskSystem, EnableTaskSystem)) {
+						bool update_shared_task = (c == give_exp_client);
+						c->UpdateTasksOnKill(GetNPCTypeID(), update_shared_task);
+					}
+
 					PlayerCount++;
 				}
 			}
@@ -2474,6 +2472,10 @@ bool NPC::Death(Mob* killer_mob, int32 damage, uint16 spell, EQ::skills::SkillTy
 					give_exp_client->GetBaseRace(), give_exp_client->GetDeity());
 
 			mod_npc_killed_merit(give_exp_client);
+
+			if (RuleB(TaskSystem, EnableTaskSystem)) {
+				give_exp_client->UpdateTasksOnKill(GetNPCTypeID(), true);
+			}
 
 			// QueryServ Logging - Solo
 			if (RuleB(QueryServ, PlayerLogNPCKills)) {

--- a/zone/client.h
+++ b/zone/client.h
@@ -1093,13 +1093,10 @@ public:
 			);
 		}
 	}
-	inline void UpdateTasksOnKill(int npc_type_id)
+	inline void UpdateTasksOnKill(int npc_type_id, bool update_shared_tasks)
 	{
 		if (task_state) {
-			task_state->UpdateTasksOnKill(
-				this,
-				npc_type_id
-			);
+			task_state->UpdateTasksOnKill(this, npc_type_id, update_shared_tasks);
 		}
 	}
 	inline void UpdateTasksForItem(

--- a/zone/task_client_state.h
+++ b/zone/task_client_state.h
@@ -33,8 +33,8 @@ public:
 	void CancelAllTasks(Client *client);
 	void RemoveTask(Client *client, int sequence_number, TaskType task_type);
 	void RemoveTaskByTaskID(Client *client, uint32 task_id);
-	bool UpdateTasksByNPC(Client *client, TaskActivityType activity_type, int npc_type_id);
-	void UpdateTasksOnKill(Client *client, int npc_type_id);
+	bool UpdateTasksByNPC(Client *client, TaskActivityType activity_type, int npc_type_id, bool update_shared_tasks);
+	void UpdateTasksOnKill(Client *client, int npc_type_id, bool update_shared_tasks);
 	void UpdateTasksForItem(Client *client, TaskActivityType activity_type, int item_id, int count = 1);
 	void UpdateTasksOnExplore(Client *client, int explore_id);
 	bool UpdateTasksOnSpeakWith(Client *client, int npc_type_id);
@@ -74,8 +74,6 @@ public:
 	const ClientTaskInformation &GetActiveSharedTask() const;
 	bool HasActiveSharedTask();
 
-
-	void HandleUpdateTasksOnKill(Client *client, uint32 npc_type_id);
 private:
 	void AddReplayTimer(Client *client, ClientTaskInformation& client_task, TaskInformation& task);
 


### PR DESCRIPTION
This reverts the commit that added HandleUpdateTasksOnKill

Solo task updates for group members were being ignored if the client
that killed the npc did not have the same task or had already finished
the kill objective. This was a regression caused by changes to prevent
shared tasks from updating multiple times for every party member.

This changes it so solo task updates for party members are no longer
dependent on the task state of the client that killed the npc. Shared
tasks will still only be explicitly updated once for the client that
kills the npc.