### PR TITLE
[Quest API] Add client->ReadBookByName(book_name, book_type) to Perl/Lua.

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10537,9 +10537,7 @@ void Client::ReadBookByName(std::string book_name, uint8 book_type)
 	int length = book_text.length();
 
 	if (book_text[0] != '\0') {
-#if EQDEBUG >= 6
-		LogInfo("Client::ReadBookByName() Book Name: [{}] Text: [{}]", book_name, book_text.c_str());
-#endif
+		LogDebug("Client::ReadBookByName() Book Name: [{}] Text: [{}]", book_name, book_text.c_str());
 		auto outapp = new EQApplicationPacket(OP_ReadBook, length + sizeof(BookText_Struct));
 		BookText_Struct *out = (BookText_Struct *) outapp->pBuffer;
 		out->window = 0xFF;

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10529,3 +10529,32 @@ void Client::SetDoorToolEntityId(uint16 door_tool_entity_id)
 {
 	Client::m_door_tool_entity_id = door_tool_entity_id;
 }
+
+void Client::ReadBookByName(std::string book_name, uint8 book_type)
+{
+	int16 book_language = 0;
+	std::string book_text = content_db.GetBook(book_name.c_str(), &book_language);
+	int length = book_text.length();
+
+	if (book_text[0] != '\0') {
+#if EQDEBUG >= 6
+		LogInfo("Client::ReadBookByName() Book Name: [{}] Text: [{}]", book_name, book_text.c_str());
+#endif
+		auto outapp = new EQApplicationPacket(OP_ReadBook, length + sizeof(BookText_Struct));
+		BookText_Struct *out = (BookText_Struct *) outapp->pBuffer;
+		out->window = 0xFF;
+		out->type = book_type;
+		out->invslot = 0;
+		
+		memcpy(out->booktext, book_text.c_str(), length);
+
+		if (book_language > 0 && book_language < MAX_PP_LANGUAGE) {
+			if (m_pp.languages[book_language] < 100) {
+				GarbleMessage(out->booktext, (100 - m_pp.languages[book_language]));
+			}
+		}
+
+		QueuePacket(outapp);
+		safe_delete(outapp);
+	}
+}

--- a/zone/client.h
+++ b/zone/client.h
@@ -728,6 +728,7 @@ public:
 	void Stun(int duration);
 	void UnStun();
 	void ReadBook(BookRequest_Struct *book);
+	void ReadBookByName(std::string book_name, uint8 book_type);
 	void QuestReadBook(const char* text, uint8 type);
 	void SendClientMoneyUpdate(uint8 type,uint32 amount);
 	void SendMoneyUpdate();

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -2219,6 +2219,11 @@ void Lua_Client::SetGMStatus(uint32 newStatus) {
 	return self->SetGMStatus(newStatus);
 }
 
+void Lua_Client::ReadBookByName(std::string book_name, uint8 book_type) {
+	Lua_Safe_Call_Void();
+	self->ReadBookByName(book_name, book_type);
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 		.def(luabind::constructor<>())
@@ -2592,7 +2597,8 @@ luabind::scope lua_register_client() {
 		.def("CountItem", (int(Lua_Client::*)(uint32))&Lua_Client::CountItem)
 		.def("RemoveItem", (void(Lua_Client::*)(uint32))&Lua_Client::RemoveItem)
 		.def("RemoveItem", (void(Lua_Client::*)(uint32,uint32))&Lua_Client::RemoveItem)
-		.def("SetGMStatus", (void(Lua_Client::*)(int32))& Lua_Client::SetGMStatus);
+		.def("SetGMStatus", (void(Lua_Client::*)(int32))& Lua_Client::SetGMStatus)
+		.def("ReadBookByName", (void(Lua_Client::*)(std::string,uint8))&Lua_Client::ReadBookByName);
 }
 
 luabind::scope lua_register_inventory_where() {

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -2632,7 +2632,7 @@ luabind::scope lua_register_client() {
 		.def("CountItem", (int(Lua_Client::*)(uint32))&Lua_Client::CountItem)
 		.def("RemoveItem", (void(Lua_Client::*)(uint32))&Lua_Client::RemoveItem)
 		.def("RemoveItem", (void(Lua_Client::*)(uint32,uint32))&Lua_Client::RemoveItem)
-		.def("ReadBookByName", (void(Lua_Client::*)(std::string,uint8))&Lua_Client::ReadBookByName);
+		.def("ReadBookByName", (void(Lua_Client::*)(std::string,uint8))&Lua_Client::ReadBookByName)
 		.def("SetGMStatus", (void(Lua_Client::*)(int32))&Lua_Client::SetGMStatus)
 		.def("UntrainDiscBySpellID", (void(Lua_Client::*)(uint16))&Lua_Client::UntrainDiscBySpellID)
 		.def("UntrainDiscBySpellID", (void(Lua_Client::*)(uint16,bool))&Lua_Client::UntrainDiscBySpellID)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -270,6 +270,7 @@ public:
 	uint32 GetRadiantCrystals();
 	uint32 GetEbonCrystals();
 	void QuestReadBook(const char *text, int type);
+	void ReadBookByName(std::string book_name, uint8 book_type);
 	void UpdateGroupAAs(int points, uint32 type);
 	uint32 GetGroupPoints();
 	uint32 GetRaidPoints();

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -5466,6 +5466,21 @@ XS(XS_Client_DiaWind) {
 		XSRETURN_EMPTY;
 }
 
+XS(XS_Client_ReadBookByName);
+XS(XS_Client_ReadBookByName) {
+	dXSARGS;
+	if (items != 3)
+		Perl_croak(aTHX_ "Usage: Client::ReadBookByName(THIS, string book_name, uint8 book_type)"); // @categories Script Utility
+	{
+		Client *THIS;
+		std::string book_name(SvPV_nolen(ST(1)));
+		uint8 book_type = (uint8) SvUV(ST(2));
+		VALIDATE_THIS_IS_CLIENT;
+		THIS->ReadBookByName(book_name, book_type);
+	}
+	XSRETURN_EMPTY;
+}
+
 #ifdef __cplusplus
 extern "C"
 #endif
@@ -5778,6 +5793,7 @@ XS(boot_Client) {
 	newXSproto(strcpy(buf, "UpdateWho"), XS_Client_UpdateWho, file, "$;$");
 	newXSproto(strcpy(buf, "UseDiscipline"), XS_Client_UseDiscipline, file, "$$$");
 	newXSproto(strcpy(buf, "WorldKick"), XS_Client_WorldKick, file, "$");
+	newXSproto(strcpy(buf, "ReadBookByName"), XS_Client_ReadBookByName, file, "$$$");
 	XSRETURN_YES;
 }
 


### PR DESCRIPTION
- Add $client->ReadBookByName(book_name, book_type) to Perl.
- Add client:ReadBookByName(book_name, book_type) to Lua.
- Allows server operators to put books in to their database and read from their database instead of storing the values in a script, also allows them to read pre-existing books using a script.