### PR TITLE
[Dialogue Window / Saylinks] Missing Changes

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -601,6 +601,8 @@ RULE_INT(Chat, KarmaGlobalChatLimit, 72, "Amount of karma you need to be able to
 RULE_INT(Chat, GlobalChatLevelLimit, 8, "Level limit you need to of reached to talk in ooc/auction/chat if your karma is too low")
 RULE_BOOL(Chat, AutoInjectSaylinksToSay, true, "Automatically injects saylinks into dialogue that has [brackets in them]")
 RULE_BOOL(Chat, AutoInjectSaylinksToClientMessage, true, "Automatically injects saylinks into dialogue that has [brackets in them]")
+RULE_BOOL(Chat, QuestDialogueUsesDialogueWindow, false, "Pipes all quest dialogue to dialogue window")
+RULE_BOOL(Chat, DialogueWindowAnimatesNPCsIfNoneSet, true, "If there is no animation specified in the dialogue window markdown then it will choose a random greet animation such as wave or salute")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Merchant)

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -5001,7 +5001,7 @@ void Client::Handle_OP_ConsiderCorpse(const EQApplicationPacket *app)
 		if (parse->EventPlayer(EVENT_CONSIDER_CORPSE, this, fmt::format("{}", conin->targetid), 0) == 1) {
 			return;
 		}
-		
+
 		uint32 day, hour, min, sec, ttime;
 		if ((ttime = tcorpse->GetDecayTime()) != 0) {
 			sec = (ttime / 1000) % 60; // Total seconds

--- a/zone/dialogue_window.cpp
+++ b/zone/dialogue_window.cpp
@@ -4,6 +4,10 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 {
 	std::string output = markdown;
 
+	if (!c->ClientDataLoaded()) {
+		return;
+	}
+
 	// this is the NPC that the client is interacting with if there is dialogue going on
 	Mob *target;
 	if (c->GetTarget()) {
@@ -79,6 +83,21 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 				}
 			}
 		}
+	}
+
+	if (animation.empty() && RuleB(Chat, DialogueWindowAnimatesNPCsIfNoneSet)) {
+		std::vector<int> greet_animations = {
+			29, // wave
+			48, // nodyes
+			64, // point
+			67, // salute
+			69, // tapfoot
+			70, // bowto
+		};
+
+		int random_animation = rand() % (greet_animations.size() - 1) + 0;
+
+		target->DoAnim(greet_animations[random_animation]);
 	}
 
 	// window expire time
@@ -234,7 +253,7 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 				button_one_name = button_one.c_str();
 			}
 		}
-		
+
 		LogDiaWind("Client [{}] Rendering button_two option.", c->GetCleanName());
 
 		auto two_first_split = split_string(output, "button_two:");
@@ -266,6 +285,33 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 	std::vector<std::string> responses;
 	std::vector<std::string> bracket_responses;
 	if (markdown.find('[') != std::string::npos && markdown.find(']') != std::string::npos) {
+
+		// record any saylinks that may be in saylink form
+		std::string                        strip_saylinks = output;
+		std::map<std::string, std::string> replacements   = {};
+		while (strip_saylinks.find('[') != std::string::npos && strip_saylinks.find(']') != std::string::npos) {
+			std::string bracket_message = get_between(strip_saylinks, "[", "]");
+
+			// strip saylinks and normalize to [regular message]
+			size_t link_open  = bracket_message.find('\x12');
+			size_t link_close = bracket_message.find_last_of('\x12');
+			if (link_open != link_close && (bracket_message.length() - link_open) > EQ::constants::SAY_LINK_BODY_SIZE) {
+				replacements.insert(
+					std::pair<std::string, std::string>(
+						bracket_message,
+						bracket_message.substr(EQ::constants::SAY_LINK_BODY_SIZE + 1)
+					)
+				);
+			}
+
+			find_replace(strip_saylinks, fmt::format("[{}]", bracket_message), "");
+		}
+
+		// write replacement strips
+		for (auto &replacement: replacements) {
+			find_replace(output, replacement.first, replacement.second.substr(0, replacement.second.size() - 1));
+		}
+
 		// copy
 		std::string content = output;
 
@@ -412,8 +458,8 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 				color_tag
 			);
 
-			std::string html_tag;
-			for (const auto& color : html_colors) {
+			std::string     html_tag;
+			for (const auto &color : html_colors) {
 				if (color_tag.find(color.first) != std::string::npos) {
 					// build html tag
 					html_tag = fmt::format("<c \"{}\">", color.second);
@@ -425,7 +471,6 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 			tag_index++;
 		}
 	}
-
 
 	// build the final output string
 	std::string final_output;

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -43,6 +43,7 @@
 #include "water_map.h"
 #include "npc_scale_manager.h"
 #include "../common/say_link.h"
+#include "dialogue_window.h"
 
 #ifdef _WINDOWS
 	#define snprintf	_snprintf
@@ -4202,8 +4203,25 @@ void EntityList::QuestJournalledSayClose(
 	buf.WriteInt32(0);
 	buf.WriteInt32(0);
 
-	// auto inject saylinks (say)
-	if (RuleB(Chat, AutoInjectSaylinksToSay)) {
+	if (RuleB(Chat, QuestDialogueUsesDialogueWindow)) {
+		for (auto &e : GetCloseMobList(sender, (dist * dist))) {
+			Mob *mob = e.second;
+
+			if (!mob->IsClient()) {
+				continue;
+			}
+
+			Client *client = mob->CastToClient();
+
+			if (client->GetTarget() && client->GetTarget()->IsMob() && client->GetTarget()->CastToMob() == sender) {
+				std::string window_markdown = message;
+				DialogueWindow::Render(client, window_markdown);
+			}
+		}
+
+		return;
+	}
+	else if (RuleB(Chat, AutoInjectSaylinksToSay)) {
 		std::string new_message = EQ::SayLinkEngine::InjectSaylinksIfNotExist(message);
 		buf.WriteString(new_message);
 	}

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -4205,7 +4205,7 @@ void EntityList::QuestJournalledSayClose(
 	// auto inject saylinks (say)
 	if (RuleB(Chat, AutoInjectSaylinksToSay)) {
 		std::string new_message = EQ::SayLinkEngine::InjectSaylinksIfNotExist(message);
-		buf.WriteString(new_message.c_str());
+		buf.WriteString(new_message);
 	}
 	else {
 		buf.WriteString(message);

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -4205,7 +4205,7 @@ void EntityList::QuestJournalledSayClose(
 	// auto inject saylinks (say)
 	if (RuleB(Chat, AutoInjectSaylinksToSay)) {
 		std::string new_message = EQ::SayLinkEngine::InjectSaylinksIfNotExist(message);
-		buf.WriteString(new_message);
+		buf.WriteString(new_message.c_str());
 	}
 	else {
 		buf.WriteString(message);

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -11,6 +11,7 @@
 #include "lua_hate_list.h"
 #include "lua_client.h"
 #include "lua_stat_bonuses.h"
+#include "dialogue_window.h"
 
 struct SpecialAbilities { };
 
@@ -757,7 +758,11 @@ void Lua_Mob::Message(int type, const char *message) {
 	Lua_Safe_Call_Void();
 
 	// auto inject saylinks
-	if (RuleB(Chat, AutoInjectSaylinksToClientMessage)) {
+	if (RuleB(Chat, QuestDialogueUsesDialogueWindow) && self->IsClient()) {
+		std::string window_markdown = message;
+		DialogueWindow::Render(self->CastToClient(), window_markdown);
+	}
+	else if (RuleB(Chat, AutoInjectSaylinksToClientMessage)) {
 		std::string new_message = EQ::SayLinkEngine::InjectSaylinksIfNotExist(message);
 		self->Message(type, new_message.c_str());
 	}

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -26,6 +26,7 @@
 #include "worldserver.h"
 #include "mob_movement_manager.h"
 #include "water_map.h"
+#include "dialogue_window.h"
 
 #include <limits.h>
 #include <math.h>
@@ -2974,16 +2975,35 @@ void Mob::Say(const char *format, ...)
 		talker = this;
 	}
 
-	if (RuleB(Chat, AutoInjectSaylinksToSay)) {
+	int16 distance = 200;
+
+	if (RuleB(Chat, QuestDialogueUsesDialogueWindow)) {
+		for (auto &e : entity_list.GetCloseMobList(talker, (distance * distance))) {
+			Mob *mob = e.second;
+
+			if (!mob->IsClient()) {
+				continue;
+			}
+
+			Client *client = mob->CastToClient();
+			if (client->GetTarget() && client->GetTarget()->IsMob() && client->GetTarget()->CastToMob() == talker) {
+				std::string window_markdown = buf;
+				DialogueWindow::Render(client, window_markdown);
+			}
+		}
+
+		return;
+	}
+	else if (RuleB(Chat, AutoInjectSaylinksToSay)) {
 		std::string new_message = EQ::SayLinkEngine::InjectSaylinksIfNotExist(buf);
 		entity_list.MessageCloseString(
-			talker, false, 200, 10,
+			talker, false, distance, Chat::NPCQuestSay,
 			GENERIC_SAY, GetCleanName(), new_message.c_str()
 		);
 	}
 	else {
 		entity_list.MessageCloseString(
-			talker, false, 200, 10,
+			talker, false, distance, Chat::NPCQuestSay,
 			GENERIC_SAY, GetCleanName(), buf
 		);
 	}

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -41,6 +41,7 @@ typedef const char Const_char;
 #include "mob.h"
 #include "client.h"
 #include "../common/spdat.h"
+#include "dialogue_window.h"
 
 #ifdef BOTS
 #include "bot.h"
@@ -2621,8 +2622,11 @@ XS(XS_Mob_Message) {
 		char *message = (char *) SvPV_nolen(ST(2));
 		VALIDATE_THIS_IS_MOB;
 
-		// auto inject saylinks
-		if (RuleB(Chat, AutoInjectSaylinksToClientMessage)) {
+		if (RuleB(Chat, QuestDialogueUsesDialogueWindow) && THIS->IsClient()) {
+			std::string window_markdown = message;
+			DialogueWindow::Render(THIS->CastToClient(), window_markdown);
+		}
+		else if (RuleB(Chat, AutoInjectSaylinksToClientMessage)) {
 			std::string new_message = EQ::SayLinkEngine::InjectSaylinksIfNotExist(message);
 			THIS->Message(type, new_message.c_str());
 		}


### PR DESCRIPTION
For some reason there were some changes that got merged into this branch that didn't make it into master. Creating this PR to reconcile

Originally parts from #1526 that only got merged into another branch

This PR is a completely optional feature that server operators may like to use for a richer dialogue experience

It utilizes the Dialogue Window from https://docs.eqemu.io/quest-api/perl/plugins/diawind

It intercepts the default behavior for `quest::say` and pipes it to a popup dialogue window for richer interaction if server operators choose to do so

**Rules**

```
RULE_BOOL(Chat, QuestDialogueUsesDialogueWindow, false, "Pipes all quest dialogue to dialogue window")
RULE_BOOL(Chat, DialogueWindowAnimatesNPCsIfNoneSet, true, "If there is no animation specified in the dialogue window markdown then it will choose a random greet animation such as wave or salute")
```

* If there are quest saylinks in the quest::say code, the dialogue window render will strip them out so they display normally in the window. 
* If there are multiple saylink responses, they are rendered in the chat window per normal window implementation. Single responses are at the click of a button
* If there is no animation code set in the dialogue window the NPC will animate socially with a handful of different "greet" animations. This can also be shut off behind rule mentioned above

![dialogue](https://user-images.githubusercontent.com/3319450/132463174-b1156824-b5c1-4acb-8d75-7061d5cc334d.gif)
