### PR TITLE
[Quest API] Add GetIPExemption(), GetIPString(), and SetIPExemption(exemption_amount) to Perl/Lua.

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -2271,6 +2271,35 @@ int Database::GetIPExemption(std::string account_ip) {
 	return RuleI(World, MaxClientsPerIP);
 }
 
+void Database::SetIPExemption(std::string account_ip, int exemption_amount) {
+	std::string query = fmt::format(
+		"SELECT `exemption_id` FROM `ip_exemptions` WHERE `exemption_ip` = '{}'",
+		account_ip
+	);
+
+	auto results = QueryDatabase(query);
+	uint32 exemption_id = 0;
+	if (results.Success() && results.RowCount() > 0) {
+		auto row = results.begin();
+		exemption_id = atoi(row[0]);
+	}
+
+	if (exemption_id != 0) {
+		query = fmt::format(
+			"UPDATE `ip_exemptions` SET `exemption_amount` = {} WHERE `exemption_ip` = '{}'",
+			exemption_amount,
+			account_ip
+		);
+	} else {
+		query = fmt::format(
+			"INSERT INTO `ip_exemptions` (`exemption_ip`, `exemption_amount`) VALUES ('{}', {})",
+			account_ip,
+			exemption_amount
+		);
+	}
+	QueryDatabase(query);
+}
+
 int Database::GetInstanceID(uint32 char_id, uint32 zone_id) {
 	std::string query = StringFormat("SELECT instance_list.id FROM instance_list INNER JOIN instance_list_player ON instance_list.id = instance_list_player.id WHERE instance_list.zone = '%i' AND instance_list_player.charid = '%i'", zone_id, char_id);
 	auto results = QueryDatabase(query);

--- a/common/database.cpp
+++ b/common/database.cpp
@@ -2283,18 +2283,18 @@ void Database::SetIPExemption(std::string account_ip, int exemption_amount) {
 		auto row = results.begin();
 		exemption_id = atoi(row[0]);
 	}
+	
+	query = fmt::format(
+		"INSERT INTO `ip_exemptions` (`exemption_ip`, `exemption_amount`) VALUES ('{}', {})",
+		account_ip,
+		exemption_amount
+	);
 
 	if (exemption_id != 0) {
 		query = fmt::format(
 			"UPDATE `ip_exemptions` SET `exemption_amount` = {} WHERE `exemption_ip` = '{}'",
 			exemption_amount,
 			account_ip
-		);
-	} else {
-		query = fmt::format(
-			"INSERT INTO `ip_exemptions` (`exemption_ip`, `exemption_amount`) VALUES ('{}', {})",
-			account_ip,
-			exemption_amount
 		);
 	}
 	QueryDatabase(query);

--- a/common/database.h
+++ b/common/database.h
@@ -198,7 +198,8 @@ public:
 	void	GetAccountFromID(uint32 id, char* oAccountName, int16* oStatus);
 	void	SetAgreementFlag(uint32 acctid);
 
-	int		GetIPExemption(std::string account_ip);
+	int  GetIPExemption(std::string account_ip);
+	void SetIPExemption(std::string account_ip, int exemption_amount);
 
 	int		GetInstanceID(uint32 char_id, uint32 zone_id);
 

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10529,3 +10529,20 @@ void Client::SetDoorToolEntityId(uint16 door_tool_entity_id)
 {
 	Client::m_door_tool_entity_id = door_tool_entity_id;
 }
+
+int Client::GetIPExemption()
+{
+	return database.GetIPExemption(GetIPString());
+}
+
+std::string Client::GetIPString()
+{
+	in_addr client_ip{};
+	client_ip.s_addr = GetIP();
+	return inet_ntoa(client_ip);
+}
+
+void Client::SetIPExemption(int exemption_amount)
+{
+	database.SetIPExemption(GetIPString(), exemption_amount);
+}

--- a/zone/client.h
+++ b/zone/client.h
@@ -340,6 +340,9 @@ public:
 	bool GetRevoked() const { return revoked; }
 	void SetRevoked(bool rev) { revoked = rev; }
 	inline uint32 GetIP() const { return ip; }
+	std::string GetIPString();
+	int GetIPExemption();
+	void SetIPExemption(int exemption_amount);
 	inline bool GetHideMe() const { return gm_hide_me; }
 	void SetHideMe(bool hm);
 	inline uint16 GetPort() const { return port; }

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -2649,7 +2649,7 @@ luabind::scope lua_register_client() {
 		.def("RemoveItem", (void(Lua_Client::*)(uint32,uint32))&Lua_Client::RemoveItem)
 		.def("GetIPExemption", (int(Lua_Client::*)(void))&Lua_Client::GetIPExemption)
 		.def("GetIPString", (std::string(Lua_Client::*)(void))&Lua_Client::GetIPString)
-		.def("SetIPExemption", (void(Lua_Client::*)(int))&Lua_Client::SetIPExemption);
+		.def("SetIPExemption", (void(Lua_Client::*)(int))&Lua_Client::SetIPExemption)
 		.def("ReadBookByName", (void(Lua_Client::*)(std::string,uint8))&Lua_Client::ReadBookByName)
 		.def("SetGMStatus", (void(Lua_Client::*)(int32))&Lua_Client::SetGMStatus)
 		.def("UntrainDiscBySpellID", (void(Lua_Client::*)(uint16))&Lua_Client::UntrainDiscBySpellID)

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -2219,6 +2219,21 @@ void Lua_Client::SetGMStatus(uint32 newStatus) {
 	return self->SetGMStatus(newStatus);
 }
 
+int Lua_Client::GetIPExemption() {
+	Lua_Safe_Call_Int();
+	return self->GetIPExemption();
+}
+
+std::string Lua_Client::GetIPString() {
+	Lua_Safe_Call_String();
+	return self->GetIPString();
+}
+
+void Lua_Client::SetIPExemption(int exemption_amount) {
+	Lua_Safe_Call_Void();
+	self->SetIPExemption(exemption_amount);
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 		.def(luabind::constructor<>())
@@ -2592,7 +2607,10 @@ luabind::scope lua_register_client() {
 		.def("CountItem", (int(Lua_Client::*)(uint32))&Lua_Client::CountItem)
 		.def("RemoveItem", (void(Lua_Client::*)(uint32))&Lua_Client::RemoveItem)
 		.def("RemoveItem", (void(Lua_Client::*)(uint32,uint32))&Lua_Client::RemoveItem)
-		.def("SetGMStatus", (void(Lua_Client::*)(int32))& Lua_Client::SetGMStatus);
+		.def("SetGMStatus", (void(Lua_Client::*)(int32))& Lua_Client::SetGMStatus)
+		.def("GetIPExemption", (int(Lua_Client::*)(void))&Lua_Client::GetIPExemption)
+		.def("GetIPString", (std::string(Lua_Client::*)(void))&Lua_Client::GetIPString)
+		.def("SetIPExemption", (void(Lua_Client::*)(int))&Lua_Client::SetIPExemption);
 }
 
 luabind::scope lua_register_inventory_where() {

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -280,6 +280,9 @@ public:
 	void SetEndurance(int endur);
 	void SendOPTranslocateConfirm(Lua_Mob caster, int spell_id);
 	uint32 GetIP();
+	std::string GetIPString();
+	int GetIPExemption();
+	void SetIPExemption(int exemption_amount);
 	void AddLevelBasedExp(int exp_pct);
 	void AddLevelBasedExp(int exp_pct, int max_level);
 	void AddLevelBasedExp(int exp_pct, int max_level, bool ignore_mods);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -5466,6 +5466,55 @@ XS(XS_Client_DiaWind) {
 		XSRETURN_EMPTY;
 }
 
+XS(XS_Client_GetIPExemption);
+XS(XS_Client_GetIPExemption) {
+	dXSARGS;
+	if (items != 1)
+		Perl_croak(aTHX_ "Usage: Client::GetIPExemption(THIS)"); // @categories Account and Character
+	{
+		Client* THIS;
+		int exemption_amount = 0;
+		dXSTARG;
+		VALIDATE_THIS_IS_CLIENT;
+		exemption_amount = THIS->GetIPExemption();
+		XSprePUSH;
+		PUSHi((IV) exemption_amount);
+	}
+	XSRETURN(1);	
+}
+
+XS(XS_Client_GetIPString);
+XS(XS_Client_GetIPString) {
+	dXSARGS;
+	if (items != 1)
+		Perl_croak(aTHX_ "Usage: Client::GetIPString(THIS)"); // @categories Account and Character
+	{
+		Client *THIS;
+		dXSTARG;
+		VALIDATE_THIS_IS_CLIENT;
+		std::string ip_string = THIS->GetIPString();
+		sv_setpv(TARG, ip_string.c_str());
+		XSprePUSH;
+		PUSHTARG;
+	}
+	XSRETURN(1);
+}
+
+XS(XS_Client_SetIPExemption); /* prototype to pass -Wmissing-prototypes */
+XS(XS_Client_SetIPExemption) {
+	dXSARGS;
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: Client::SetIPExemption(THIS, int exemption_amount)"); // @categories Account and Character
+	{
+		Client *THIS;
+		int exemption_amount = (int) SvIV(ST(1));
+		dXSTARG;
+		VALIDATE_THIS_IS_CLIENT;
+		THIS->SetIPExemption(exemption_amount);
+	}
+	XSRETURN_EMPTY;
+}
+
 #ifdef __cplusplus
 extern "C"
 #endif
@@ -5592,6 +5641,8 @@ XS(boot_Client) {
 	newXSproto(strcpy(buf, "GetInstrumentMod"), XS_Client_GetInstrumentMod, file, "$$");
 	newXSproto(strcpy(buf, "GetInventory"), XS_Client_GetInventory, file, "$");
 	newXSproto(strcpy(buf, "GetIP"), XS_Client_GetIP, file, "$");
+	newXSproto(strcpy(buf, "GetIPExemption"), XS_Client_GetIPExemption, file, "$");
+	newXSproto(strcpy(buf, "GetIPString"), XS_Client_GetIPString, file, "$");
 	newXSproto(strcpy(buf, "GetItemAt"), XS_Client_GetItemAt, file, "$$");
 	newXSproto(strcpy(buf, "GetItemIDAt"), XS_Client_GetItemIDAt, file, "$$");
 	newXSproto(strcpy(buf, "GetItemInInventory"), XS_Client_GetItemInInventory, file, "$$");
@@ -5736,6 +5787,7 @@ XS(boot_Client) {
 	newXSproto(strcpy(buf, "SetHideMe"), XS_Client_SetHideMe, file, "$$");
 	newXSproto(strcpy(buf, "SetHorseId"), XS_Client_SetHorseId, file, "$$");
 	newXSproto(strcpy(buf, "SetHunger"), XS_Client_SetHunger, file, "$$");
+	newXSproto(strcpy(buf, "SetIPExemption"), XS_Client_SetIPExemption, file, "$$");
 	newXSproto(strcpy(buf, "SetLanguageSkill"), XS_Client_SetLanguageSkill, file, "$$$");
 	newXSproto(strcpy(buf, "SetMaterial"), XS_Client_SetMaterial, file, "$$$");
 	newXSproto(strcpy(buf, "SetPrimaryWeaponOrnamentation"), XS_Client_SetPrimaryWeaponOrnamentation, file, "$$");


### PR DESCRIPTION
- Add $client->GetIPExemption() to Perl.
- Add $client->GetIPString() to Perl.
- Add $client->SetIPExemption(exemption_amount) to Perl.
- Add client:GetIPExemption() to Lua.
- Add client:GetIPString() to Lua.
- Add client:SetIPExemption(exemption_amount) to Lua.

Will make plugin::IP unnecessary and allow people to get readable IP string easier, as well as set/get IP exemptions from Perl and Lua.