### PR TITLE
[Quest API] Add attuned/augment support to client->SummonBaggedItems() in Perl/Lua.

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10660,7 +10660,17 @@ void Client::SummonBaggedItems(uint32 bag_item_id, const std::vector<ServerLootI
 		}
 		else
 		{
-			EQ::ItemInstance* summoned_bag_item = database.CreateItem(item.item_id, item.charges);
+			EQ::ItemInstance* summoned_bag_item = database.CreateItem(
+				item.item_id,
+				item.charges,
+				item.aug_1,
+				item.aug_2,
+				item.aug_3,
+				item.aug_4,
+				item.aug_5,
+				item.aug_6,
+				item.attuned
+			);
 			if (summoned_bag_item)
 			{
 				summoned_bag->PutItem(open_slot, *summoned_bag_item);

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -2267,6 +2267,34 @@ void Lua_Client::SummonBaggedItems(uint32 bag_item_id, luabind::adl::object bag_
 			ServerLootItem_Struct item{};
 			item.item_id = luabind::object_cast<uint32>((*it)["item_id"]);
 			item.charges = luabind::object_cast<int16>((*it)["charges"]);
+			if (luabind::type((*it)["attuned"]) != LUA_TNIL) {
+				item.attuned = luabind::object_cast<uint8>((*it)["attuned"]);
+			}
+			
+			if (luabind::type((*it)["augment_one"]) != LUA_TNIL) {
+				item.aug_1 = luabind::object_cast<uint32>((*it)["augment_one"]);
+			}
+			
+			if (luabind::type((*it)["augment_two"]) != LUA_TNIL) {
+				item.aug_2 = luabind::object_cast<uint32>((*it)["augment_two"]);
+			}
+
+			if (luabind::type((*it)["augment_three"]) != LUA_TNIL) {
+				item.aug_3 = luabind::object_cast<uint32>((*it)["augment_three"]);
+			}
+
+			if (luabind::type((*it)["augment_four"]) != LUA_TNIL) {
+				item.aug_4 = luabind::object_cast<uint32>((*it)["augment_four"]);
+			}
+
+			if (luabind::type((*it)["augment_five"]) != LUA_TNIL) {
+				item.aug_5 = luabind::object_cast<uint32>((*it)["augment_five"]);
+			}
+
+			if (luabind::type((*it)["augment_six"]) != LUA_TNIL) {
+				item.aug_6 = luabind::object_cast<uint32>((*it)["augment_six"]);
+			}
+
 			bagged_items.emplace_back(item);
 		}
 	}

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -2267,34 +2267,13 @@ void Lua_Client::SummonBaggedItems(uint32 bag_item_id, luabind::adl::object bag_
 			ServerLootItem_Struct item{};
 			item.item_id = luabind::object_cast<uint32>((*it)["item_id"]);
 			item.charges = luabind::object_cast<int16>((*it)["charges"]);
-			if (luabind::type((*it)["attuned"]) != LUA_TNIL) {
-				item.attuned = luabind::object_cast<uint8>((*it)["attuned"]);
-			}
-			
-			if (luabind::type((*it)["augment_one"]) != LUA_TNIL) {
-				item.aug_1 = luabind::object_cast<uint32>((*it)["augment_one"]);
-			}
-			
-			if (luabind::type((*it)["augment_two"]) != LUA_TNIL) {
-				item.aug_2 = luabind::object_cast<uint32>((*it)["augment_two"]);
-			}
-
-			if (luabind::type((*it)["augment_three"]) != LUA_TNIL) {
-				item.aug_3 = luabind::object_cast<uint32>((*it)["augment_three"]);
-			}
-
-			if (luabind::type((*it)["augment_four"]) != LUA_TNIL) {
-				item.aug_4 = luabind::object_cast<uint32>((*it)["augment_four"]);
-			}
-
-			if (luabind::type((*it)["augment_five"]) != LUA_TNIL) {
-				item.aug_5 = luabind::object_cast<uint32>((*it)["augment_five"]);
-			}
-
-			if (luabind::type((*it)["augment_six"]) != LUA_TNIL) {
-				item.aug_6 = luabind::object_cast<uint32>((*it)["augment_six"]);
-			}
-
+			item.attuned = luabind::type((*it)["attuned"]) != LUA_TNIL ? luabind::object_cast<uint8>((*it)["attuned"]) : 0;
+			item.aug_1 = luabind::type((*it)["augment_one"]) != LUA_TNIL ? luabind::object_cast<uint32>((*it)["augment_one"]) : 0;
+			item.aug_2 = luabind::type((*it)["augment_two"]) != LUA_TNIL ? luabind::object_cast<uint32>((*it)["augment_two"]) : 0;
+			item.aug_3 = luabind::type((*it)["augment_three"]) != LUA_TNIL ? luabind::object_cast<uint32>((*it)["augment_three"]) : 0;
+			item.aug_4 = luabind::type((*it)["augment_four"]) != LUA_TNIL ? luabind::object_cast<uint32>((*it)["augment_four"]) : 0;
+			item.aug_5 = luabind::type((*it)["augment_five"]) != LUA_TNIL ? luabind::object_cast<uint32>((*it)["augment_five"]) : 0;
+			item.aug_6 = luabind::type((*it)["augment_six"]) != LUA_TNIL ? luabind::object_cast<uint32>((*it)["augment_six"]) : 0;
 			bagged_items.emplace_back(item);
 		}
 	}

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -5820,35 +5820,13 @@ XS(XS_Client_SummonBaggedItems) {
 				ServerLootItem_Struct item{};
 				item.item_id = static_cast<uint32>(SvUV(*item_id_ptr));
 				item.charges = static_cast<int16>(SvIV(*item_charges_ptr));
-				
-				if (attuned_ptr) {
-					item.attuned = static_cast<uint8>(SvUV(*attuned_ptr));
-				}
-				
-				if (augment_one_ptr) {
-					item.aug_1 = static_cast<uint32>(SvUV(*augment_one_ptr));
-				}
-				
-				if (augment_two_ptr) {
-					item.aug_2 = static_cast<uint32>(SvUV(*augment_two_ptr));
-				}
-				
-				if (augment_three_ptr) {
-					item.aug_3 = static_cast<uint32>(SvUV(*augment_three_ptr));
-				}
-
-				if (augment_four_ptr) {
-					item.aug_4 = static_cast<uint32>(SvUV(*augment_four_ptr));
-				}
-
-				if (augment_five_ptr) {
-					item.aug_5 = static_cast<uint32>(SvUV(*augment_five_ptr));
-				}
-
-				if (augment_six_ptr) {
-					item.aug_6 = static_cast<uint32>(SvUV(*augment_six_ptr));
-				}
-
+				item.attuned = attuned_ptr ? static_cast<uint8>(SvUV(*attuned_ptr)) : 0;
+				item.aug_1 = augment_one_ptr ? static_cast<uint32>(SvUV(*augment_one_ptr)) : 0;
+				item.aug_2 = augment_two_ptr ? static_cast<uint32>(SvUV(*augment_two_ptr)) : 0;
+				item.aug_3 = augment_three_ptr ? static_cast<uint32>(SvUV(*augment_three_ptr)) : 0;
+				item.aug_4 = augment_four_ptr ? static_cast<uint32>(SvUV(*augment_four_ptr)) : 0;
+				item.aug_5 = augment_five_ptr ? static_cast<uint32>(SvUV(*augment_five_ptr)) : 0;
+				item.aug_6 = augment_six_ptr ? static_cast<uint32>(SvUV(*augment_six_ptr)) : 0;
 				bagged_items.emplace_back(item);
 			}
 		}

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -5790,8 +5790,7 @@ XS(XS_Client_SummonBaggedItems) {
 
 	// verify we're receiving a reference to an array type
 	SV* bag_items_avref = ST(2);
-	if (!bag_items_avref || !SvROK(bag_items_avref) || SvTYPE(SvRV(bag_items_avref)) != SVt_PVAV)
-	{
+	if (!bag_items_avref || !SvROK(bag_items_avref) || SvTYPE(SvRV(bag_items_avref)) != SVt_PVAV) {
 		Perl_croak(aTHX_ "Client::SummonBaggedItems second argument is not a reference to an array");
 	}
 
@@ -5801,22 +5800,55 @@ XS(XS_Client_SummonBaggedItems) {
 	std::vector<ServerLootItem_Struct> bagged_items;
 
 	auto count = av_len(bag_items_av) + 1;
-	for (int i = 0; i < count; ++i)
-	{
+	for (int i = 0; i < count; ++i) {
 		SV** element = av_fetch(bag_items_av, i, 0);
 
 		// verify array element is a hash reference containing item details
-		if (element && SvROK(*element) && SvTYPE(SvRV(*element)) == SVt_PVHV)
-		{
+		if (element && SvROK(*element) && SvTYPE(SvRV(*element)) == SVt_PVHV) {
 			HV* hash = (HV*)SvRV(*element); // dereference
 
 			SV** item_id_ptr = hv_fetchs(hash, "item_id", false);
 			SV** item_charges_ptr = hv_fetchs(hash, "charges", false);
-			if (item_id_ptr && item_charges_ptr)
-			{
+			SV** attuned_ptr = hv_fetchs(hash, "attuned", false);
+			SV** augment_one_ptr = hv_fetchs(hash, "augment_one", false);
+			SV** augment_two_ptr = hv_fetchs(hash, "augment_two", false);
+			SV** augment_three_ptr = hv_fetchs(hash, "augment_three", false);
+			SV** augment_four_ptr = hv_fetchs(hash, "augment_four", false);
+			SV** augment_five_ptr = hv_fetchs(hash, "augment_five", false);
+			SV** augment_six_ptr = hv_fetchs(hash, "augment_six", false);			
+			if (item_id_ptr && item_charges_ptr) {
 				ServerLootItem_Struct item{};
 				item.item_id = static_cast<uint32>(SvUV(*item_id_ptr));
 				item.charges = static_cast<int16>(SvIV(*item_charges_ptr));
+				
+				if (attuned_ptr) {
+					item.attuned = static_cast<uint8>(SvUV(*attuned_ptr));
+				}
+				
+				if (augment_one_ptr) {
+					item.aug_1 = static_cast<uint32>(SvUV(*augment_one_ptr));
+				}
+				
+				if (augment_two_ptr) {
+					item.aug_2 = static_cast<uint32>(SvUV(*augment_two_ptr));
+				}
+				
+				if (augment_three_ptr) {
+					item.aug_3 = static_cast<uint32>(SvUV(*augment_three_ptr));
+				}
+
+				if (augment_four_ptr) {
+					item.aug_4 = static_cast<uint32>(SvUV(*augment_four_ptr));
+				}
+
+				if (augment_five_ptr) {
+					item.aug_5 = static_cast<uint32>(SvUV(*augment_five_ptr));
+				}
+
+				if (augment_six_ptr) {
+					item.aug_6 = static_cast<uint32>(SvUV(*augment_six_ptr));
+				}
+
 				bagged_items.emplace_back(item);
 			}
 		}


### PR DESCRIPTION
Allows operators to spawn bagged items that are already attuned and/or have augments in them.
Perl Example:
```pl
my @bag_items = (
	{ item_id => 33649, charges => 1, attuned => 1, augment_one => 32940 },
);
```

Lua Example:
```lua
local bag_items = {
	{ item_id = 33649, charges = 1, attuned = 1, augment_one = 32940 }
}