### PR TITLE
[Bug Fix] Dialogue Window Name replace.

### DIFF
--- a/zone/dialogue_window.cpp
+++ b/zone/dialogue_window.cpp
@@ -26,7 +26,7 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 	find_replace(output, "{gray}", "<c \"#808080\">");
 	find_replace(output, "{tan}", "<c \"#daa520\">");
 	find_replace(output, "{bullet}", "•");
-	find_replace(output, "{name}", "$name");
+	find_replace(output, "{name}", fmt::format("{}", c->GetCleanName()));
 	find_replace(output, "{linebreak}", "--------------------------------------------------------------------");
 	find_replace(output, "{rowpad}", R"(<tr><td>{tdpad}<"td><td>{tdpad}<"td><"tr>)");
 	find_replace(output, "{tdpad}", "----------------------");


### PR DESCRIPTION
{name} was being replaced with the string "$name" because Perl would parse it properly, but when used here it doesn't return the client's name.