### PR TITLE
[Spells] Update to SPA 154 and SPA 209 Dispel Bene/Detrimental

### DIFF
--- a/common/spdat.h
+++ b/common/spdat.h
@@ -839,7 +839,7 @@ typedef enum {
 #define SE_SuspendPet					151	// implemented, @Pet, allow caster to have an extra suspended pet, base: 0=no buffs/items 1=buffs+items, limit: none, max: none
 #define SE_TemporaryPets				152	// implemented
 #define SE_BalanceHP					153 // implemented
-#define SE_DispelDetrimental			154 // implemented
+#define SE_DispelDetrimental			154 // implemented, @Dispel only beneficial effects on a target, base: pct chance (950=95%), limit:none, max:none
 #define SE_SpellCritDmgIncrease			155 // implemented - no known live spells use this currently
 #define SE_IllusionCopy					156	// implemented - Deception
 #define SE_SpellDamageShield			157	// implemented - Petrad's Protection
@@ -894,7 +894,7 @@ typedef enum {
 #define SE_AETaunt						206	// implemented
 #define SE_FleshToBone					207	// implemented
 //#define SE_PurgePoison				208	// not used
-#define SE_DispelBeneficial				209 // implemented
+#define SE_DispelBeneficial				209 // implemented, @Dispel only beneficial effects on a target, base: pct chance (950=95%), limit:none, max:none
 #define SE_PetShield					210	// implmented, @ShieldAbility, allows pet to 'shield' owner for 50 pct of damage taken for a duration, base: Time multiplier 1=12 seconds, 2=24 ect, limit: mitigation on pet owner override (not on live), max: mitigation on pet overide (not on live) 
 #define SE_AEMelee						211	// implemented TO DO: Implement to allow NPC use (client only atm).
 #define SE_FrenziedDevastation			212	// implemented - increase spell criticals + all DD spells cast 2x mana.

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -346,6 +346,7 @@ public:
 	uint16 CastingSpellID() const { return casting_spell_id; }
 	bool DoCastingChecks();
 	bool TryDispel(uint8 caster_level, uint8 buff_level, int level_modifier);
+	bool TryDispelBeneficialOrDetrimental(uint8 caster_level, uint8 buff_level, int chance);
 	bool TrySpellProjectile(Mob* spell_target,  uint16 spell_id, float speed = 1.5f);
 	void ResourceTap(int32 damage, uint16 spell_id);
 	void TryTriggerThreshHold(int32 damage, int effect_id, Mob* attacker);

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -1077,7 +1077,12 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 						caster->MessageString(Chat::SpellFailure, SPELL_NO_EFFECT, spells[spell_id].name);
 					break;
 				}
-				int chance = spells[spell_id].base[i] - 20; //Baseline 2% negative modifer derived from parsing.
+				/*
+					TODO: Parsing shows there is no level modifier. However, a consistent -2% modifer was 
+					found on spell with value 950 (95% spells would have 7% failure rates). 
+					Further investigation is needed. ~ Kayen
+				*/
+				int chance = spells[spell_id].base[i];
 				int buff_count = GetMaxTotalSlots();
 				for(int slot = 0; slot < buff_count; slot++) {
 					if (buffs[slot].spellid != SPELL_UNKNOWN &&
@@ -1103,7 +1108,8 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 						caster->MessageString(Chat::SpellFailure, SPELL_NO_EFFECT, spells[spell_id].name);
 					break;
 				}
-				int chance = spells[spell_id].base[i] - 20; //Baseline 2% negative modifer derived from parsing.
+				
+				int chance = spells[spell_id].base[i];
 				int buff_count = GetMaxTotalSlots();
 				for(int slot = 0; slot < buff_count; slot++) {
 					if (buffs[slot].spellid != SPELL_UNKNOWN &&

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -1077,14 +1077,14 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 						caster->MessageString(Chat::SpellFailure, SPELL_NO_EFFECT, spells[spell_id].name);
 					break;
 				}
-
+				int chance = spells[spell_id].base[i] - 20; //Baseline 2% negative modifer derived from parsing.
 				int buff_count = GetMaxTotalSlots();
 				for(int slot = 0; slot < buff_count; slot++) {
 					if (buffs[slot].spellid != SPELL_UNKNOWN &&
 						IsDetrimentalSpell(buffs[slot].spellid) &&
 						spells[buffs[slot].spellid].dispel_flag == 0)
 					{
-						if (caster && TryDispel(caster->GetLevel(),buffs[slot].casterlevel, effect_value)){
+						if (zone->random.Int(1, 1000) <= chance){
 							BuffFadeBySlot(slot);
 							slot = buff_count;
 						}
@@ -1103,14 +1103,14 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 						caster->MessageString(Chat::SpellFailure, SPELL_NO_EFFECT, spells[spell_id].name);
 					break;
 				}
-
+				int chance = spells[spell_id].base[i] - 20; //Baseline 2% negative modifer derived from parsing.
 				int buff_count = GetMaxTotalSlots();
 				for(int slot = 0; slot < buff_count; slot++) {
 					if (buffs[slot].spellid != SPELL_UNKNOWN &&
 						IsBeneficialSpell(buffs[slot].spellid) &&
 						spells[buffs[slot].spellid].dispel_flag == 0)
 					{
-						if (caster && TryDispel(caster->GetLevel(),buffs[slot].casterlevel, effect_value)){
+						if (zone->random.Int(1, 1000) <= chance) {
 							BuffFadeBySlot(slot);
 							slot = buff_count;
 						}
@@ -7082,33 +7082,6 @@ bool Mob::TryDispel(uint8 caster_level, uint8 buff_level, int level_modifier){
 	else
 		return false;
 }
-
-bool Mob::TryDispelBeneficialOrDetrimental(uint8 caster_level, uint8 buff_level, int chance) {
-
-	/*
-		Used in SPA 154 and SPA 209 to specifically dispel only beneficial or only detrimental spells.
-		Formula derived from live parsing.
-		Baseline chance is 'base' / 10, (ie. 950/10 = 95%)
-		Chance receives a penality of 0.5% per level, for each level the 'caster of the buff/debuff' is above the caster of the dispel.
-		There is no bonus percent chance for trying to dispel buff/debuffs cast by mobs lower level than you.
-
-		Ie. Lv 69 Shaman Casts 'Pure Spirit' which has 95% chance to remove deterimental on a debuff cast by a level 85 raid mob. 85-69= 16, 
-		then 16 x 0.5 = 8% penality, thus actual chance to remove is going to be 95-8 = 87%
-	*/
-
-	int dispel_chance = chance;
-	int level_diff = caster_level - buff_level;
-
-	if (level_diff < 0) {
-		dispel_chance += level_diff * 5;
-	}
-
-	if (zone->random.Int(1,1000) <= dispel_chance)
-		return true;
-	else
-		return false;
-}
-
 
 bool Mob::ImprovedTaunt(){
 


### PR DESCRIPTION
Update to the spells mechanics for SPA 154 and 209. They changed how these are calculated a long time ago and our current code was not properly using the values from the spell file. Overall with these changes, these spells should be much more effective in their chance to remove effects.

After extensive parsing I have concluded that unlike regular dispel, there is no level modifier that affects that chance. So essentially should get a flat 95% chance on a 950 base value, regardless of the level of the caster of the buff/debuff. One irregularity I found was a consistent additional 2% chance when parsing, ie 95 would usually end up around 93, I have not yet figured out what is causing this. For now, it will be coded as a just a flat chance based on base value. Will investigate further when I have access to more live spells with this effect.

SE_DispelDetrimental	 removes only detrimental effects on a target, base: pct chance (950=95%), limit: none, max: none
SE_DispelBeneficial		 removes only beneficial effects on a target, base: pct chance (950=95%), limit: none, max: none