### PR TITLE
[Spells] Update SPA158 Reflect

### DIFF
--- a/common/spdat.h
+++ b/common/spdat.h
@@ -511,6 +511,15 @@ enum NegateSpellEffectType
 	NEGATE_SPA_SPELLBONUS_AND_AABONUS     = 5,
 	NEGATE_SPA_ITEMBONUS_AND_AABONUS      = 6,
 };
+//Used for rule RuleI(Spells, ReflectType))
+enum ReflectSpellType
+{
+	REFLECT_DISABLED                  = 0,
+	REFLECT_SINGLE_TARGET_SPELLS_ONLY = 1,
+	REFLECT_ALL_PLAYER_SPELLS         = 2,
+	RELFECT_ALL_SINGLE_TARGET_SPELLS  = 3,
+	REFLECT_ALL_SPELLS                = 4,
+};
 
 enum SpellTypes : uint32
 {

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -852,7 +852,7 @@ typedef enum {
 #define SE_SpellCritDmgIncrease			155 // implemented - no known live spells use this currently
 #define SE_IllusionCopy					156	// implemented - Deception
 #define SE_SpellDamageShield			157	// implemented - Petrad's Protection
-#define SE_Reflect						158 // implemented
+#define SE_Reflect						158 // implemented, @SpellMisc, reflect casted detrimental spell back at caster, base: chance pct, limit: resist modifier (positive value reduces resists), max: pct of base dmg mod (50=50pct of base)
 #define SE_AllStats						159	// implemented
 //#define SE_MakeDrunk					160 // *not implemented - Effect works entirely client side (Should check against tolerance)
 #define SE_MitigateSpellDamage			161	// implemented - rune with max value

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -1674,11 +1674,11 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 
 		case SE_Reflect:
 
-			if (newbon->reflect_chance[0] < base1) {
-				newbon->reflect_chance[0] = base1;
+			if (newbon->reflect[SBIndex::REFLECT_CHANCE] < base1) {
+				newbon->reflect[SBIndex::REFLECT_CHANCE] = base1;
 			}
-			if (newbon->reflect_chance[1] < base2) {
-				newbon->reflect_chance[1] = base2;
+			if (newbon->reflect[SBIndex::REFLECT_RESISTANCE_MOD] < base2) {
+				newbon->reflect[SBIndex::REFLECT_RESISTANCE_MOD] = base2;
 			}
 			break;
 
@@ -2160,13 +2160,13 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 			case SE_Reflect:
 
 				if (AdditiveWornBonus) {
-					new_bonus->reflect_chance[0] += effect_value;
+					new_bonus->reflect[SBIndex::REFLECT_CHANCE] += effect_value;
 				}
 
-				else if (new_bonus->reflect_chance[0] < effect_value) {
-					new_bonus->reflect_chance[0] = effect_value;
-					new_bonus->reflect_chance[1] = base2;
-					new_bonus->reflect_chance[2] = max;
+				else if (new_bonus->reflect[SBIndex::REFLECT_CHANCE] < effect_value) {
+					new_bonus->reflect[SBIndex::REFLECT_CHANCE] = effect_value;
+					new_bonus->reflect[SBIndex::REFLECT_RESISTANCE_MOD] = base2;
+					new_bonus->reflect[SBIndex::REFLECT_DMG_EFFECTIVENESS] = max;
 				}
 				break;
 
@@ -4396,9 +4396,9 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 					break;
 
 				case SE_Reflect:
-					if (negate_spellbonus) { spellbonuses.reflect_chance[0] = effect_value; }
-					if (negate_aabonus) { aabonuses.reflect_chance[0] = effect_value; }
-					if (negate_itembonus) { itembonuses.reflect_chance[0] = effect_value; }
+					if (negate_spellbonus) { spellbonuses.reflect[SBIndex::REFLECT_CHANCE] = effect_value; }
+					if (negate_aabonus) { aabonuses.reflect[SBIndex::REFLECT_CHANCE] = effect_value; }
+					if (negate_itembonus) { itembonuses.reflect[SBIndex::REFLECT_CHANCE] = effect_value; }
 					break;
 
 				case SE_Amplification:

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -1672,6 +1672,16 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			newbon->ZoneSuspendMinion = base1;
 			break;
 
+		case SE_Reflect:
+
+			if (newbon->reflect_chance[0] < base1) {
+				newbon->reflect_chance[0] = base1;
+			}
+			if (newbon->reflect_chance[1] < base2) {
+				newbon->reflect_chance[1] = base2;
+			}
+			break;
+
 		// to do
 		case SE_PetDiscipline:
 			break;
@@ -2148,7 +2158,16 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 			}
 
 			case SE_Reflect:
-				new_bonus->reflect_chance += effect_value;
+
+				if (AdditiveWornBonus) {
+					new_bonus->reflect_chance[0] += effect_value;
+				}
+
+				else if (new_bonus->reflect_chance[0] < effect_value) {
+					new_bonus->reflect_chance[0] = effect_value;
+					new_bonus->reflect_chance[1] = base2;
+					new_bonus->reflect_chance[2] = max;
+				}
 				break;
 
 			case SE_Amplification:
@@ -4377,9 +4396,9 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 					break;
 
 				case SE_Reflect:
-					if (negate_spellbonus) { spellbonuses.reflect_chance = effect_value; }
-					if (negate_aabonus) { aabonuses.reflect_chance = effect_value; }
-					if (negate_itembonus) { itembonuses.reflect_chance = effect_value; }
+					if (negate_spellbonus) { spellbonuses.reflect_chance[0] = effect_value; }
+					if (negate_aabonus) { aabonuses.reflect_chance[0] = effect_value; }
+					if (negate_itembonus) { itembonuses.reflect_chance[0] = effect_value; }
 					break;
 
 				case SE_Amplification:

--- a/zone/common.h
+++ b/zone/common.h
@@ -404,7 +404,7 @@ struct StatBonuses {
 	int32	skillmodmax[EQ::skills::HIGHEST_SKILL + 1];
 	int		effective_casting_level;
 	int		adjusted_casting_skill;				// SPA 112 for fizzles
-	int		reflect_chance;						// chance to reflect incoming spell
+	int		reflect_chance[3];					// chance to reflect incoming spell [0]=Chance [1]=Resist Mod [2]= % of Base Dmg
 	uint32	singingMod;
 	uint32	Amplification;						// stacks with singingMod
 	uint32	brassMod;

--- a/zone/common.h
+++ b/zone/common.h
@@ -404,7 +404,7 @@ struct StatBonuses {
 	int32	skillmodmax[EQ::skills::HIGHEST_SKILL + 1];
 	int		effective_casting_level;
 	int		adjusted_casting_skill;				// SPA 112 for fizzles
-	int		reflect_chance[3];					// chance to reflect incoming spell [0]=Chance [1]=Resist Mod [2]= % of Base Dmg
+	int		reflect[3];					// chance to reflect incoming spell [0]=Chance [1]=Resist Mod [2]= % of Base Dmg
 	uint32	singingMod;
 	uint32	Amplification;						// stacks with singingMod
 	uint32	brassMod;
@@ -680,6 +680,9 @@ namespace SBIndex {
 	constexpr uint16 FINISHING_EFFECT_LEVEL_CHANCE_BONUS    = 1; // SPA 440, 345, 346
 	constexpr uint16 DOUBLE_MELEE_ROUND_CHANCE              = 0; // SPA 471
 	constexpr uint16 DOUBLE_MELEE_ROUND_DMG_BONUS			= 1; // SPA 471
+	constexpr uint16 REFLECT_CHANCE                         = 0; // SPA 158
+	constexpr uint16 REFLECT_RESISTANCE_MOD                 = 1; // SPA 158
+	constexpr uint16 REFLECT_DMG_EFFECTIVENESS              = 2; // SPA 158
 };
 
 

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -168,7 +168,7 @@ int32 Mob::GetActSpellDamage(uint16 spell_id, int32 value, Mob* target) {
 }
 
 int32 Mob::GetActReflectedSpellDamage(int32 value, int effectiveness) {
-	/* NOTES: !reflect, get rid of bool and change it to effectiveness, pass it into spell effect.
+	/*
 		Reflected spells use the spells base damage before any modifiers or formulas applied.
 		That value can then be modifier by the reflect spells 'max' value, defined here as effectiveness
 		Default effectiveness is set at 100.
@@ -1038,7 +1038,7 @@ void EntityList::AESpell(
 		}
 
 		current_mob->CalcSpellPowerDistanceMod(spell_id, distance_to_target);
-		caster_mob->SpellOnTarget(spell_id, current_mob, false, true, resist_adjust);
+		caster_mob->SpellOnTarget(spell_id, current_mob, 0, true, resist_adjust);
 
 		/**
 		 * Increment hit count if max targets

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -167,6 +167,25 @@ int32 Mob::GetActSpellDamage(uint16 spell_id, int32 value, Mob* target) {
 	return value;
 }
 
+int32 Mob::GetActReflectedSpellDamage(int32 value, int effectiveness) {
+	/* NOTES: !reflect, get rid of bool and change it to effectiveness, pass it into spell effect.
+		Reflected spells use the spells base damage before any modifiers or formulas applied.
+		That value can then be modifier by the reflect spells 'max' value, defined here as effectiveness
+		Default effectiveness is set at 100.
+	*/
+	if (IsNPC()) {
+		value += value * CastToNPC()->GetSpellFocusDMG() / 100;
+
+		if (CastToNPC()->GetSpellScale()) {
+			value = int(static_cast<float>(value) * CastToNPC()->GetSpellScale() / 100.0f);
+		}
+	}
+	
+	value = value * effectiveness / 100;
+	
+	return value;
+}
+
 int32 Mob::GetActDoTDamage(uint16 spell_id, int32 value, Mob* target) {
 
 	if (target == nullptr)

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -173,7 +173,6 @@ int32 Mob::GetActReflectedSpellDamage(int32 value, int effectiveness) {
 		That value can then be modifier by the reflect spells 'max' value, defined here as effectiveness
 		Default effectiveness is set at 100.
 	*/
-	Shout("1 Reflected DMG [%i] MOD %i", value, effectiveness);
 	if (IsNPC()) {
 		value += value * CastToNPC()->GetSpellFocusDMG() / 100;
 
@@ -183,7 +182,6 @@ int32 Mob::GetActReflectedSpellDamage(int32 value, int effectiveness) {
 	}
 	
 	value = value * effectiveness / 100;
-	Shout("2 Reflected DMG [%i] MOD %i", value, effectiveness);
 	return value;
 }
 

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -173,6 +173,7 @@ int32 Mob::GetActReflectedSpellDamage(int32 value, int effectiveness) {
 		That value can then be modifier by the reflect spells 'max' value, defined here as effectiveness
 		Default effectiveness is set at 100.
 	*/
+	Shout("1 Reflected DMG [%i] MOD %i", value, effectiveness);
 	if (IsNPC()) {
 		value += value * CastToNPC()->GetSpellFocusDMG() / 100;
 
@@ -182,7 +183,7 @@ int32 Mob::GetActReflectedSpellDamage(int32 value, int effectiveness) {
 	}
 	
 	value = value * effectiveness / 100;
-	
+	Shout("2 Reflected DMG [%i] MOD %i", value, effectiveness);
 	return value;
 }
 

--- a/zone/lua_stat_bonuses.cpp
+++ b/zone/lua_stat_bonuses.cpp
@@ -342,7 +342,7 @@ int Lua_StatBonuses::Getadjusted_casting_skill() const {
 
 int Lua_StatBonuses::Getreflect_chance() const {
 	Lua_Safe_Call_Int();
-	return self->reflect_chance;
+	return self->reflect_chance[0];
 }
 
 uint32 Lua_StatBonuses::GetsingingMod() const {

--- a/zone/lua_stat_bonuses.cpp
+++ b/zone/lua_stat_bonuses.cpp
@@ -342,7 +342,7 @@ int Lua_StatBonuses::Getadjusted_casting_skill() const {
 
 int Lua_StatBonuses::Getreflect_chance() const {
 	Lua_Safe_Call_Int();
-	return self->reflect_chance[0];
+	return self->reflect[SBIndex::REFLECT_CHANCE];
 }
 
 uint32 Lua_StatBonuses::GetsingingMod() const {

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -473,7 +473,6 @@ Mob::Mob(
 	npc_assist_cap = 0;
 
 	use_double_melee_round_dmg_bonus = false;
-	reflected_spell_power_mod = 0;
 
 #ifdef BOTS
 	m_manual_follow = false;
@@ -3245,12 +3244,12 @@ void Mob::ExecWeaponProc(const EQ::ItemInstance *inst, uint16 spell_id, Mob *on,
 	if (IsBeneficialSpell(spell_id) && (!IsNPC() || (IsNPC() && CastToNPC()->GetInnateProcSpellID() != spell_id))) { // NPC innate procs don't take this path ever
 		SpellFinished(spell_id, this, EQ::spells::CastingSlot::Item, 0, -1, spells[spell_id].ResistDiff, true, level_override);
 		if(twinproc)
-			SpellOnTarget(spell_id, this, false, false, 0, true, level_override);
+			SpellOnTarget(spell_id, this, 0, false, 0, true, level_override);
 	}
 	else if(!(on->IsClient() && on->CastToClient()->dead)) { //dont proc on dead clients
 		SpellFinished(spell_id, on, EQ::spells::CastingSlot::Item, 0, -1, spells[spell_id].ResistDiff, true, level_override);
 		if(twinproc)
-			SpellOnTarget(spell_id, on, false, false, 0, true, level_override);
+			SpellOnTarget(spell_id, on, 0, false, 0, true, level_override);
 	}
 	return;
 }
@@ -4624,28 +4623,6 @@ bool Mob::TryDoubleMeleeRoundEffect() {
 	}
 
 	SetUseDoubleMeleeRoundDmgBonus(false);
-	return false;
-}
-
-bool Mob::TryReflectSpell(uint32 spell_id)
-{
-	if (!spells[spell_id].reflectable)
- 		return false;
-
-	if (spellbonuses.reflect_chance[0] && zone->random.Roll(spellbonuses.reflect_chance[0])) {
-		return true;
-	}
-	
-	
-	int chance = itembonuses.reflect_chance[0] + spellbonuses.reflect_chance[0] + aabonuses.reflect_chance[0];
-
-	
-	
-	
-	if (chance && zone->random.Roll(chance)) {
-		return true;
-	}
-
 	return false;
 }
 

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -473,6 +473,7 @@ Mob::Mob(
 	npc_assist_cap = 0;
 
 	use_double_melee_round_dmg_bonus = false;
+	reflected_spell_power_mod = 0;
 
 #ifdef BOTS
 	m_manual_follow = false;
@@ -4631,10 +4632,19 @@ bool Mob::TryReflectSpell(uint32 spell_id)
 	if (!spells[spell_id].reflectable)
  		return false;
 
-	int chance = itembonuses.reflect_chance + spellbonuses.reflect_chance + aabonuses.reflect_chance;
-
-	if(chance && zone->random.Roll(chance))
+	if (spellbonuses.reflect_chance[0] && zone->random.Roll(spellbonuses.reflect_chance[0])) {
 		return true;
+	}
+	
+	
+	int chance = itembonuses.reflect_chance[0] + spellbonuses.reflect_chance[0] + aabonuses.reflect_chance[0];
+
+	
+	
+	
+	if (chance && zone->random.Roll(chance)) {
+		return true;
+	}
 
 	return false;
 }

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -332,9 +332,9 @@ public:
 	bool SpellFinished(uint16 spell_id, Mob *target, EQ::spells::CastingSlot slot = EQ::spells::CastingSlot::Item, uint16 mana_used = 0,
 		uint32 inventory_slot = 0xFFFFFFFF, int16 resist_adjust = 0, bool isproc = false, int level_override = -1);
 	void SendBeginCast(uint16 spell_id, uint32 casttime);
-	virtual bool SpellOnTarget(uint16 spell_id, Mob* spelltar, bool reflect = false,
+	virtual bool SpellOnTarget(uint16 spell_id, Mob* spelltar, int reflect_effectiveness = 0,
 		bool use_resist_adjust = false, int16 resist_adjust = 0, bool isproc = false, int level_override = -1);
-	virtual bool SpellEffect(Mob* caster, uint16 spell_id, float partial = 100, int level_override = -1);
+	virtual bool SpellEffect(Mob* caster, uint16 spell_id, float partial = 100, int level_override = -1, int reflect_effectiveness = 0);
 	virtual bool DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_center,
 		CastAction_type &CastAction, EQ::spells::CastingSlot slot, bool isproc = false);
 	virtual bool CheckFizzle(uint16 spell_id);
@@ -828,7 +828,6 @@ public:
 	int GetCriticalChanceBonus(uint16 skill);
 	int16 GetSkillDmgAmt(uint16 skill);
 	int16 GetPositionalDmgAmt(Mob* defender);
-	bool TryReflectSpell(uint32 spell_id);
 	inline bool CanBlockSpell() const { return(spellbonuses.FocusEffects[focusBlockNextSpell]); }
 	bool DoHPToManaCovert(uint16 mana_cost = 0);
 	int32 ApplySpellEffectiveness(int16 spell_id, int32 value, bool IsBard = false, uint16 caster_id=0);
@@ -848,9 +847,6 @@ public:
 	int GetFocusRandomEffectivenessValue(int focus_base, int focus_base2, bool best_focus = 0);
 	int GetHealRate() const { return itembonuses.HealRate + spellbonuses.HealRate + aabonuses.HealRate; }
 	int GetMemoryBlurChance(int base_chance);
-	inline int GetReflectedSpellPowerMod() const { return reflected_spell_power_mod; }
-	inline void SetReflectedSpellPowerMod(int val) { reflected_spell_power_mod = val; }
-
 
 	bool TryDoubleMeleeRoundEffect();
 	bool GetUseDoubleMeleeRoundDmgBonus() const { return use_double_melee_round_dmg_bonus; }
@@ -1534,7 +1530,6 @@ protected:
 	bool has_MGB;
 	bool has_ProjectIllusion;
 	int16 SpellPowerDistanceMod;
-	int reflected_spell_power_mod;
 	bool last_los_check;
 	bool pseudo_rooted;
 	bool endur_upkeep;

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -306,6 +306,7 @@ public:
 	virtual int32 GetActSpellCost(uint16 spell_id, int32 cost){ return cost;}
 	virtual int32 GetActSpellDuration(uint16 spell_id, int32 duration);
 	virtual int32 GetActSpellCasttime(uint16 spell_id, int32 casttime);
+	virtual int32 GetActReflectedSpellDamage(int32 value, int effectiveness);
 	float ResistSpell(uint8 resist_type, uint16 spell_id, Mob *caster, bool use_resist_override = false,
 		int resist_override = 0, bool CharismaCheck = false, bool CharmTick = false, bool IsRoot = false,
 		int level_override = -1);
@@ -847,6 +848,8 @@ public:
 	int GetFocusRandomEffectivenessValue(int focus_base, int focus_base2, bool best_focus = 0);
 	int GetHealRate() const { return itembonuses.HealRate + spellbonuses.HealRate + aabonuses.HealRate; }
 	int GetMemoryBlurChance(int base_chance);
+	inline int GetReflectedSpellPowerMod() const { return reflected_spell_power_mod; }
+	inline void SetReflectedSpellPowerMod(int val) { reflected_spell_power_mod = val; }
 
 
 	bool TryDoubleMeleeRoundEffect();
@@ -1531,6 +1534,7 @@ protected:
 	bool has_MGB;
 	bool has_ProjectIllusion;
 	int16 SpellPowerDistanceMod;
+	int reflected_spell_power_mod;
 	bool last_los_check;
 	bool pseudo_rooted;
 	bool endur_upkeep;

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -2043,7 +2043,7 @@ void Mob::InstillDoubt(Mob *who) {
 		//temporary hack...
 		//cast fear on them... should prolly be a different spell
 		//and should be un-resistable.
-		SpellOnTarget(229, who, false, true, -2000);
+		SpellOnTarget(229, who, 0, true, -2000);
 		//is there a success message?
 	} else {
 		MessageString(Chat::LightBlue,NOT_SCARING);

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -46,7 +46,7 @@ extern WorldServer worldserver;
 
 // the spell can still fail here, if the buff can't stack
 // in this case false will be returned, true otherwise
-bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_override)
+bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_override, int reflect_effectiveness)
 {
 	int caster_level, buffslot, effect, effect_value, i;
 	EQ::ItemInstance *SummonedItem=nullptr;
@@ -259,8 +259,8 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 
 					//handles AAs and what not...
 					if(caster) {
-						if (caster->GetReflectedSpellPowerMod()) {
-							dmg = caster->GetActReflectedSpellDamage((int32)(spells[spell_id].base[i] * partial / 100), caster->GetReflectedSpellPowerMod());
+						if (reflect_effectiveness) {
+							dmg = caster->GetActReflectedSpellDamage((int32)(spells[spell_id].base[i] * partial / 100), reflect_effectiveness);
 						}
 						else {
 							dmg = caster->GetActSpellDamage(spell_id, dmg, this);

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -259,7 +259,12 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 
 					//handles AAs and what not...
 					if(caster) {
-						dmg = caster->GetActSpellDamage(spell_id, dmg, this);
+						if (caster->GetReflectedSpellPowerMod()) {
+							dmg = caster->GetActReflectedSpellDamage((int32)(spells[spell_id].base[i] * partial / 100), caster->GetReflectedSpellPowerMod());
+						}
+						else {
+							dmg = caster->GetActSpellDamage(spell_id, dmg, this);
+						}
 						caster->ResourceTap(-dmg, spell_id);
 					}
 

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3873,7 +3873,8 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 		
 		There are a few spells in database that are not detrimental that have Reflectable field set, however from testing, they do not actually reflect.
 	*/
-	if(spells[spell_id].reflectable && !reflect_effectiveness && spelltar && this != spelltar && IsDetrimentalSpell(spell_id)) {
+	if(spells[spell_id].reflectable && !reflect_effectiveness && spelltar && this != spelltar && IsDetrimentalSpell(spell_id) &&
+		(spelltar->spellbonuses.reflect[SBIndex::REFLECT_CHANCE] || spelltar->aabonuses.reflect[SBIndex::REFLECT_CHANCE] || spelltar->itembonuses.reflect[SBIndex::REFLECT_CHANCE])) {
 		bool can_spell_reflect = false;
 		switch(RuleI(Spells, ReflectType))
 		{

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3869,7 +3869,7 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 		reflect_effectiveness is applied to damage spells, a value of 100 is no change to base damage. Other values change by percent. (50=50% of damage)
 		we this variable to both check if a spell being applied is from a reflection and for the damage modifier.
 		
-		There are spells in database that are not detrimental that have Reflectable field set, however from testing, they do not actually reflect.
+		There are a few spells in database that are not detrimental that have Reflectable field set, however from testing, they do not actually reflect.
 	*/
 	if(spells[spell_id].reflectable && !reflect_effectiveness && spelltar && this != spelltar && IsDetrimentalSpell(spell_id)) {
 		bool can_spell_reflect = false;
@@ -3915,20 +3915,20 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 
 			int reflect_resist_adjust = 0;
 			int reflect_effectiveness_mod = 0; //Need value of 100 to do baseline unmodified damage.
-
-			if (spelltar->spellbonuses.reflect_chance[0] && zone->random.Roll(spelltar->spellbonuses.reflect_chance[0])) {
-				reflect_resist_adjust = spelltar->spellbonuses.reflect_chance[1];
-				reflect_effectiveness_mod = spelltar->spellbonuses.reflect_chance[2] ? spelltar->spellbonuses.reflect_chance[2] : 100;
+			Shout("Chances SP[%i] AA[%i] Item [%i]", spelltar->spellbonuses.reflect[SBIndex::REFLECT_CHANCE], spelltar->aabonuses.reflect[SBIndex::REFLECT_CHANCE], spelltar->itembonuses.reflect[SBIndex::REFLECT_CHANCE]);
+			if (spelltar->spellbonuses.reflect[SBIndex::REFLECT_CHANCE] && zone->random.Roll(spelltar->spellbonuses.reflect[SBIndex::REFLECT_CHANCE])) {
+				reflect_resist_adjust = spelltar->spellbonuses.reflect[SBIndex::REFLECT_RESISTANCE_MOD];
+				reflect_effectiveness_mod = spelltar->spellbonuses.reflect[SBIndex::REFLECT_DMG_EFFECTIVENESS] ? spelltar->spellbonuses.reflect[SBIndex::REFLECT_DMG_EFFECTIVENESS] : 100;
 			}
-			else if (spelltar->aabonuses.reflect_chance[0] && zone->random.Roll(spelltar->aabonuses.reflect_chance[0])) {
+			else if (spelltar->aabonuses.reflect[SBIndex::REFLECT_CHANCE] && zone->random.Roll(spelltar->aabonuses.reflect[SBIndex::REFLECT_CHANCE])) {
 				reflect_effectiveness_mod = 100;
-				reflect_resist_adjust = spelltar->aabonuses.reflect_chance[1];
+				reflect_resist_adjust = spelltar->aabonuses.reflect[SBIndex::REFLECT_RESISTANCE_MOD];
 			}
-			else if (spelltar->itembonuses.reflect_chance[0] && zone->random.Roll(spelltar->itembonuses.reflect_chance[0])) {
-				reflect_resist_adjust = spelltar->itembonuses.reflect_chance[1];
-				reflect_effectiveness_mod = spelltar->itembonuses.reflect_chance[2] ? spelltar->itembonuses.reflect_chance[2] : 100;
+			else if (spelltar->itembonuses.reflect[SBIndex::REFLECT_CHANCE] && zone->random.Roll(spelltar->itembonuses.reflect[SBIndex::REFLECT_CHANCE])) {
+				reflect_resist_adjust = spelltar->itembonuses.reflect[SBIndex::REFLECT_RESISTANCE_MOD];
+				reflect_effectiveness_mod = spelltar->itembonuses.reflect[SBIndex::REFLECT_DMG_EFFECTIVENESS] ? spelltar->itembonuses.reflect[SBIndex::REFLECT_DMG_EFFECTIVENESS] : 100;
 			}
-
+			Shout("Resist %i Effective %i", reflect_resist_adjust, reflect_effectiveness_mod);
 			if (reflect_effectiveness_mod) {
 
 				if (RuleB(Spells, ReflectMessagesClose)) {

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3862,7 +3862,9 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 	}
 	/*
 		Reflect
-		Effect has three components, base=% Chance to Reflect Limit=Resist Modifier Max=% of base spell damage (this is the base before any formula is applied)
+		base= % Chance to Reflect 
+		Limit= Resist Modifier (+Value for decrease chance to resist) 
+		Max= % of base spell damage (this is the base before any formula or focus is applied)
 		On live any type of detrimental spell can be reflected as long as the Reflectable spell field is set, this includes AOE.
 		The 'caster' of the reflected spell is owner of the reflect effect. Caster's focus effects are NOT applied to reflected spell.
 		
@@ -3915,7 +3917,7 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 
 			int reflect_resist_adjust = 0;
 			int reflect_effectiveness_mod = 0; //Need value of 100 to do baseline unmodified damage.
-			Shout("Chances SP[%i] AA[%i] Item [%i]", spelltar->spellbonuses.reflect[SBIndex::REFLECT_CHANCE], spelltar->aabonuses.reflect[SBIndex::REFLECT_CHANCE], spelltar->itembonuses.reflect[SBIndex::REFLECT_CHANCE]);
+
 			if (spelltar->spellbonuses.reflect[SBIndex::REFLECT_CHANCE] && zone->random.Roll(spelltar->spellbonuses.reflect[SBIndex::REFLECT_CHANCE])) {
 				reflect_resist_adjust = spelltar->spellbonuses.reflect[SBIndex::REFLECT_RESISTANCE_MOD];
 				reflect_effectiveness_mod = spelltar->spellbonuses.reflect[SBIndex::REFLECT_DMG_EFFECTIVENESS] ? spelltar->spellbonuses.reflect[SBIndex::REFLECT_DMG_EFFECTIVENESS] : 100;
@@ -3928,7 +3930,7 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 				reflect_resist_adjust = spelltar->itembonuses.reflect[SBIndex::REFLECT_RESISTANCE_MOD];
 				reflect_effectiveness_mod = spelltar->itembonuses.reflect[SBIndex::REFLECT_DMG_EFFECTIVENESS] ? spelltar->itembonuses.reflect[SBIndex::REFLECT_DMG_EFFECTIVENESS] : 100;
 			}
-			Shout("Resist %i Effective %i", reflect_resist_adjust, reflect_effectiveness_mod);
+
 			if (reflect_effectiveness_mod) {
 
 				if (RuleB(Spells, ReflectMessagesClose)) {
@@ -3947,6 +3949,7 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 				}
 
 				CheckNumHitsRemaining(NumHit::ReflectSpell);
+
 				spelltar->SpellOnTarget(spell_id, this, reflect_effectiveness_mod, use_resist_adjust, (resist_adjust - reflect_resist_adjust));
 				safe_delete(action_packet);
 				return false;


### PR DESCRIPTION
Updated 'Reflect' spell effect to use current spell files additional modifiers.

**Limit** value is a resist modifier, where positive values works to decrease resist chance (further decreases any resist modifiers, ie value of 100 on a spell with a -50 resist modifier, will make it a -150 resist modifer)

**Max** value is the percent of base damage that is reflected back at caster (50 = 50pct of damage), if set to 0 will do full damage.

Note: Spell table as a field called 'Reflectable' this must be true for a spell to reflect.

**Mechanics** updated, when reflecting back damage spells the actual damage reflected is BASE damage of the spell, this is
the lowest possible value before any formula or focus effects are applied. No focus at all are applied to damage spells. Also note we have am old RULE that regulate what type of targets/spells reflect can be applied to do.

Spells:ReflectType Reflect type. 0=disabled, 1=single target player spells only, 2=all player spells, 3=all single target spells, 4=all spells. [DEFAULT IS 3]

Based on live testing, AOE spells that have the spell file field 'Reflectable' as true, are able to be reflected. Thus if you want a live like reflect mechanic change the the rule to 4.

Support now for live like Reflect AA's

When a spell is a cast on a player with multiple reflect abilities. It will check spells buffs first, and choose one with highest chance. If that fails will check AA's and then for items effects.


```
	/*
		Reflect
		base= % Chance to Reflect 
		Limit= Resist Modifier (+Value for decrease chance to resist) 
		Max= % of base spell damage (this is the base before any formula or focus is applied)
		On live any type of detrimental spell can be reflected as long as the Reflectable spell field is set, this includes AOE.
		The 'caster' of the reflected spell is owner of the reflect effect. Caster's focus effects are NOT applied to reflected spell.
		
		reflect_effectiveness is applied to damage spells, a value of 100 is no change to base damage. Other values change by percent. (50=50% of damage)
		we this variable to both check if a spell being applied is from a reflection and for the damage modifier.
		
		There are a few spells in database that are not detrimental that have Reflectable field set, however from testing, they do not actually reflect.
	*/
```

SE_Reflect 158 reflect casted detrimental spell back at caster, base: chance pct, limit: resist modifier (positive value reduces resists), max: pct of base dmg mod (50=50pct of base)