### PR TITLE
[Bug Fix] always_aggro flag needed to be checked on assist

### DIFF
--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -3379,7 +3379,7 @@ void NPC::AIYellForHelp(Mob *sender, Mob *attacker)
 			 * if they are in range, make sure we are not green...
 			 * then jump in if they are our friend
 			 */
-			if (mob->GetLevel() >= 50 || attacker->GetLevelCon(mob->GetLevel()) != CON_GRAY) {
+			if (mob->GetLevel() >= 50 || mob->AlwaysAggro() || attacker->GetLevelCon(mob->GetLevel()) != CON_GRAY) {
 				if (mob->GetPrimaryFaction() == sender->CastToNPC()->GetPrimaryFaction()) {
 					const NPCFactionList *cf = content_db.GetNPCFactionEntry(mob->CastToNPC()->GetNPCFactionID());
 					if (cf) {


### PR DESCRIPTION
Awhile back I added the always_aggro field to npc_types to allow creation/modification of npcs to always attack their ememies (much like undead and mobs over 50).  I failed to take into account the logic in Yell For Help.  This PR fixes this.

If always_aggro is set for a mob, that it will listen to calls for help, even if the opponent is red.

This PR has no impact on any server other than those who have changed or added npcs to use the newish always_aggro field.