### PR TITLE
[Spells] Minor fix to Item Extra Spell Damage Amt formula

### DIFF
--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -259,10 +259,11 @@ int32 Mob::GetExtraSpellAmt(uint16 spell_id, int32 extra_spell_amt, int32 base_s
 	 else
 		 extra_spell_amt = extra_spell_amt * total_cast_time / 7000;
 
-		if(extra_spell_amt*2 < base_spell_dmg)
-			return 0;
+	if (extra_spell_amt * 2 > abs(base_spell_dmg)) {
+		return 0;
+	}
 
-		return extra_spell_amt;
+	return extra_spell_amt;
 }
 
 int32 Mob::GetActSpellHealing(uint16 spell_id, int32 value, Mob* target) {


### PR DESCRIPTION
Discovered some bad code, which I implemented years ago... 
This portion of formula is suppose to prevent extra damage to applying to spells that are very low damage.
I had a positive value comparing to a negative value, so the compare would never be true.