### PR TITLE
[HP Updates] Fix for Titanium client updating

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1370,20 +1370,18 @@ void Mob::SendHPUpdate(bool force_update_all)
 				last_hp
 			);
 
-			if (CastToClient()->ClientVersion() >= EQ::versions::ClientVersion::SoD) {
-				auto client_packet     = new EQApplicationPacket(OP_HPUpdate, sizeof(SpawnHPUpdate_Struct));
-				auto *hp_packet_client = (SpawnHPUpdate_Struct *) client_packet->pBuffer;
+			auto client_packet     = new EQApplicationPacket(OP_HPUpdate, sizeof(SpawnHPUpdate_Struct));
+			auto *hp_packet_client = (SpawnHPUpdate_Struct *) client_packet->pBuffer;
 
-				hp_packet_client->cur_hp   = static_cast<uint32>(CastToClient()->GetHP() - itembonuses.HP);
-				hp_packet_client->spawn_id = GetID();
-				hp_packet_client->max_hp   = CastToClient()->GetMaxHP() - itembonuses.HP;
+			hp_packet_client->cur_hp   = static_cast<uint32>(CastToClient()->GetHP() - itembonuses.HP);
+			hp_packet_client->spawn_id = GetID();
+			hp_packet_client->max_hp   = CastToClient()->GetMaxHP() - itembonuses.HP;
 
-				CastToClient()->QueuePacket(client_packet);
+			CastToClient()->QueuePacket(client_packet);
 
-				safe_delete(client_packet);
+			safe_delete(client_packet);
 
-				ResetHPUpdateTimer();
-			}
+			ResetHPUpdateTimer();
 
 			// Used to check if HP has changed to update self next round
 			last_hp = current_hp;


### PR DESCRIPTION
Fix for Titanium clients not being updated properly by removing client version check

Tested confirmed working. Does not consider OP_Damage nuances that Titanium has but it at least fixes updates in most scenarios

![image](https://user-images.githubusercontent.com/3319450/136641639-97d77c48-5ca8-4f69-9078-9cbd27e5a742.png)
