### PR TITLE
[Bug Fix] Make columns in doors table not nullable

### DIFF
--- a/common/version.h
+++ b/common/version.h
@@ -34,7 +34,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9173
+#define CURRENT_BINARY_DATABASE_VERSION 9174
 
 #ifdef BOTS
 	#define CURRENT_BINARY_BOTS_DATABASE_VERSION 9028

--- a/utils/sql/db_update_manifest.txt
+++ b/utils/sql/db_update_manifest.txt
@@ -427,6 +427,7 @@
 9171|2021_03_30_remove_dz_is_current_member.sql|SHOW COLUMNS FROM `dynamic_zone_members` LIKE 'is_current_member'|not_empty|
 9172|2021_05_21_shared_tasks.sql|SHOW TABLES LIKE 'shared_tasks'|empty|
 9173|2021_09_14_zone_lava_damage.sql|SHOW COLUMNS FROM `zone` LIKE 'lava_damage'|empty|
+9174|2021_10_09_not_null_door_columns.sql|SELECT * FROM db_version WHERE version >= 9174|empty|
 
 # Upgrade conditions:
 # 	This won't be needed after this system is implemented, but it is used database that are not

--- a/utils/sql/git/required/2021_10_09_not_null_door_columns.sql
+++ b/utils/sql/git/required/2021_10_09_not_null_door_columns.sql
@@ -1,0 +1,18 @@
+-- update any null columns to non-null value first to avoid data truncation errors
+-- this will likely only affect the buffer column
+update `doors` set `doors`.`dest_x` = 0 where `doors`.`dest_x` is null;
+update `doors` set `doors`.`dest_y` = 0 where `doors`.`dest_y` is null;
+update `doors` set `doors`.`dest_z` = 0 where `doors`.`dest_z` is null;
+update `doors` set `doors`.`dest_heading` = 0 where `doors`.`dest_heading` is null;
+update `doors` set `doors`.`invert_state` = 0 where `doors`.`invert_state` is null;
+update `doors` set `doors`.`incline` = 0 where `doors`.`incline` is null;
+update `doors` set `doors`.`buffer` = 0 where `doors`.`buffer` is null;
+
+ALTER TABLE `doors`
+	CHANGE COLUMN `dest_x` `dest_x` FLOAT NOT NULL DEFAULT '0' AFTER `dest_instance`,
+	CHANGE COLUMN `dest_y` `dest_y` FLOAT NOT NULL DEFAULT '0' AFTER `dest_x`,
+	CHANGE COLUMN `dest_z` `dest_z` FLOAT NOT NULL DEFAULT '0' AFTER `dest_y`,
+	CHANGE COLUMN `dest_heading` `dest_heading` FLOAT NOT NULL DEFAULT '0' AFTER `dest_z`,
+	CHANGE COLUMN `invert_state` `invert_state` INT(11) NOT NULL DEFAULT '0' AFTER `dest_heading`,
+	CHANGE COLUMN `incline` `incline` INT(11) NOT NULL DEFAULT '0' AFTER `invert_state`,
+	CHANGE COLUMN `buffer` `buffer` FLOAT NOT NULL DEFAULT '0' AFTER `size`;


### PR DESCRIPTION
This makes the float and integer fields in the doors table not nullable.
The only column this should affect is the buffer column which wasn't
being loaded in the old doors loading query. The other columns weren't
validated but they should still be made not nullable to avoid issues.

This will fix a crash in potimeb which is the only zone that had NULL
values in the buffer column with the current peq database. This column
can be removed in a future followup since it isn't being used anyway.

The repository generator should also probably be changed to handle nullable columns better to fix any future issues like this