### PR TITLE
[Bug Fix] Healing pets not correctly dropping out of combat status

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4048,11 +4048,9 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 			}
 		}
 		
-		if (spelltar->IsEngaged()) {
-			entity_list.AddHealAggro(
-				spelltar, this,
-				CheckHealAggroAmount(spell_id, spelltar, (spelltar->GetMaxHP() - spelltar->GetHP())));
-		}
+		entity_list.AddHealAggro(
+			spelltar, this,
+			CheckHealAggroAmount(spell_id, spelltar, (spelltar->GetMaxHP() - spelltar->GetHP())));
 	}
 
 	// make sure spelltar is high enough level for the buff


### PR DESCRIPTION
Addresses issue: https://github.com/EQEmu/Server/issues/1560

Credit to Mackal for helping solve this.

Healing a pet or charmed pet will now apply the owners reset timer. 

Be aware that there is an innate 50 pct chance witness check for a heal/buff not to cause you to be added to an NPC's hate list. So if you are not always seeing your healer enter into an In Combat state immediately from healing that can be the reason. Often you may need to heal your target several times before your actually on the hatelist.
