### PR TITLE
[Bug Fix] Urgent - Previous fix for TimeSync on static zones broke dynamic zones.

### DIFF
--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -158,7 +158,7 @@ bool Zone::Bootup(uint32 iZoneID, uint32 iInstanceID, bool iStaticZone) {
 	// Dynamic zones need to Sync here.
 	// Static zones sync when they connect in worldserver.cpp.
 	// Static zones cannot sync here as request is ignored by worldserver.
-	if (zone->IsStaticZone() == false)
+	if (!iStaticZone)
 	{
 		zone->GetTimeSync();
 	}


### PR DESCRIPTION
My fix in PR [1561](https://github.com/EQEmu/Server/pull/1561) fixed a problem where static zones no longer time synced with world.

In my fix, I removed a line in zone.cpp that was sending a sync message to world that was getting ignored by world, as it was out-of-sequence.

That turns out to only be true for static zones.  Dynamic zones still need this line, and this works for them, as the boot sequence is different.

I added extra data to logging on zone bootup, and restored the call, but only for Dynamic zones.

Urgent PR for anyone current with the code up to PR 1561.

THANK YOU to Dhaymion for finding and getting this to me so quickly.

I apologize to anyone inconvenienced by this.  I only run static zones and didn't see this issue.  Only that static zones were broken.
