### PR TITLE
[Bug Fix] Fixes IMMUNE MELEE NONMAGICAL logic

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -990,32 +990,31 @@ int Mob::GetWeaponDamage(Mob *against, const EQ::ItemData *weapon_item) {
 
 	//check to see if our weapons or fists are magical.
 	if (against->GetSpecialAbility(IMMUNE_MELEE_NONMAGICAL)) {
-		if (weapon_item) {
+		if (GetSpecialAbility(SPECATK_MAGICAL)) {
+			dmg = 1;
+		}
+		//On live this occurs for pets and charmed pet >= level 10
+		else if (GetOwner() && GetLevel() >= RuleI(Combat, PetAttackMagicLevel)) {
+			//pets wouldn't actually use this but...
+			//it gives us an idea if we can hit due to the dual nature of this function
+			dmg = 1;
+		}
+		else if (weapon_item) {
 			if (weapon_item->Magic) {
 				dmg = weapon_item->Damage;
-
 				//this is more for non weapon items, ex: boots for kick
 				//they don't have a dmg but we should be able to hit magical
 				dmg = dmg <= 0 ? 1 : dmg;
 			}
-			else
+			else {
 				return 0;
+			}
+		}
+		else if ((GetClass() == MONK || GetClass() == BEASTLORD) && GetLevel() >= 30) {
+			dmg = GetHandToHandDamage();
 		}
 		else {
-			if ((GetClass() == MONK || GetClass() == BEASTLORD) && GetLevel() >= 30) {
-				dmg = GetHandToHandDamage();
-			}
-			else if (GetOwner() && GetLevel() >= RuleI(Combat, PetAttackMagicLevel)) {
-				//pets wouldn't actually use this but...
-				//it gives us an idea if we can hit due to the dual nature of this function
-				dmg = 1;
-			}
-			else if (GetSpecialAbility(SPECATK_MAGICAL))
-			{
-				dmg = 1;
-			}
-			else
-				return 0;
+			return 0;
 		}
 	}
 	else {

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -156,6 +156,9 @@ void Mob::DoSpecialAttackDamage(Mob *who, EQ::skills::SkillType skill, int32 bas
 	if (my_hit.base_damage == 0)
 		my_hit.base_damage = GetBaseSkillDamage(my_hit.skill);
 
+	if (base_damage = DMG_INVULNERABLE)
+		my_hit.damage_done = DMG_INVULNERABLE;
+
 	if (who->GetInvul() || who->GetSpecialAbility(IMMUNE_MELEE))
 		my_hit.damage_done = DMG_INVULNERABLE;
 
@@ -1649,8 +1652,9 @@ void NPC::DoClassAttacks(Mob *target) {
 					DoAnim(animKick, 0, false);
 					int32 dmg = GetBaseSkillDamage(EQ::skills::SkillKick);
 
-					if (GetWeaponDamage(target, (const EQ::ItemData*)nullptr) <= 0)
+					if (GetWeaponDamage(target, (const EQ::ItemData*)nullptr) <= 0) {
 						dmg = DMG_INVULNERABLE;
+					}
 
 					reuse = (KickReuseTime + 3) * 1000;
 					DoSpecialAttackDamage(target, EQ::skills::SkillKick, dmg, GetMinDamage(), -1, reuse);


### PR DESCRIPTION
Addresses: https://github.com/EQEmu/Server/issues/1461

Fixes issues with pets losing innate ability to hit IMMUNE MELEE NONMAGICAL flagged NPC's when given non magical weapons. (This doesn't happen on live)

Fixed bug where special attacks like BASH or KICK would ignore IMMUNE MELEE NONMAGICAL and other potential immune states.

Updated logic, any NPC flagged with a special attack 'SPECATK_MAGICAL' that allows them to hit IMMUNE MELEE NONMAGICAL will be checked first thus never will fail the check regardless of weapons or any other rules.

Note Live testing showed PETS and Charmed pets gain ability to hit IMMUNE NPC's when the pet level is >= Level 10
RuleI(Combat, PetAttackMagicLevel) this is an OLD rule and its default has been set to 30 (unknown if this used to be lives level).

