### PR TITLE
[Bug Fix] Allow invisibility to be cast on Raid Group members.

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -432,22 +432,37 @@ bool Mob::DoCastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 	casting_spell_targetid = target_id;
 
 	if (RuleB(Spells, InvisRequiresGroup) && IsInvisSpell(spell_id)) {
-		if (GetTarget() && GetTarget()->IsClient()) {
-			Client *spell_target = entity_list.GetClientByID(target_id);
+		if (IsClient() && GetTarget() && GetTarget()->IsClient()) {
+			Client* spell_caster = this->CastToClient();
+			Client* spell_target = entity_list.GetClientByID(target_id);
 			if (spell_target && spell_target->GetID() != GetID()) {
-				if (!spell_target->IsGrouped()) {
-					InterruptSpell(spell_id);
-					Message(Chat::Red, "You cannot invis someone who is not in your group.");
-					return false;
-				}
-				else if (spell_target->IsGrouped()) {
+				bool cast_failed = true;
+				if (spell_target->IsGrouped()) {
 					Group *target_group = spell_target->GetGroup();
-					Group *my_group     = GetGroup();
-					if (target_group && my_group && (target_group->GetID() != my_group->GetID())) {
-						InterruptSpell(spell_id);
-						Message(Chat::Red, "You cannot invis someone who is not in your group.");
-						return false;
+					Group *my_group = GetGroup();
+					if (
+						target_group &&
+						my_group &&
+						(target_group->GetID() == my_group->GetID())
+					) {
+						cast_failed = false;
 					}
+				} else if (spell_target->IsRaidGrouped()) {					
+					Raid *target_raid = spell_target->GetRaid();
+					Raid *my_raid = GetRaid();
+					if (
+						target_raid &&
+						my_raid &&
+						(target_raid->GetGroup(spell_target) == my_raid->GetGroup(spell_caster))
+					) {
+						cast_failed = false;
+					}
+				}
+
+				if (cast_failed) {
+					InterruptSpell(spell_id);
+					MessageString(Chat::Red, TARGET_GROUP_MEMBER);
+					return false;
 				}
 			}
 		}


### PR DESCRIPTION
When `Spells:InvisRequiresGroup` was true, you could only cast on Group members, intended functionality is to cast on Group members and/or people in your Raid Group.