### PR TITLE
[Quest API] Further char array cleanup.

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1631,9 +1631,14 @@ bool Client::Death(Mob* killerMob, int32 damage, uint16 spell, EQ::skills::Skill
 	if (!spell)
 		spell = SPELL_UNKNOWN;
 
-	char buffer[48] = { 0 };
-	snprintf(buffer, 47, "%d %d %d %d", killerMob ? killerMob->GetID() : 0, damage, spell, static_cast<int>(attack_skill));
-	if (parse->EventPlayer(EVENT_DEATH, this, buffer, 0) != 0) {
+	std::string export_string = fmt::format(
+		"{} {} {} {}",
+		killerMob ? killerMob->GetID() : 0,
+		damage,
+		spell,
+		static_cast<int>(attack_skill)
+	);
+	if (parse->EventPlayer(EVENT_DEATH, this, export_string, 0) != 0) {
 		if (GetHP() < 0) {
 			SetHP(0);
 		}
@@ -1935,7 +1940,7 @@ bool Client::Death(Mob* killerMob, int32 damage, uint16 spell, EQ::skills::Skill
 		QServ->PlayerLogEvent(Player_Log_Deaths, this->CharacterID(), event_desc);
 	}
 
-	parse->EventPlayer(EVENT_DEATH_COMPLETE, this, buffer, 0);
+	parse->EventPlayer(EVENT_DEATH_COMPLETE, this, export_string, 0);
 	return true;
 }
 

--- a/zone/cheat_manager.cpp
+++ b/zone/cheat_manager.cpp
@@ -43,7 +43,12 @@ void CheatManager::CheatDetected(CheatTypes type, glm::vec3 position1, glm::vec3
 					zone->GetShortName()
 				);
 				LogCheat(message);
-				std::string export_string = fmt::format("{} {} {}", position1.x, position1.y, position1.z);
+				std::string export_string = fmt::format(
+					"{} {} {}",
+					position1.x,
+					position1.y,
+					position1.z
+				);
 				parse->EventPlayer(EVENT_WARP, m_target, export_string, 0);
 			}
 			break;
@@ -67,7 +72,12 @@ void CheatManager::CheatDetected(CheatTypes type, glm::vec3 position1, glm::vec3
 					zone->GetShortName()
 				);
 				LogCheat(message);
-				std::string export_string = fmt::format("{} {} {}", position1.x, position1.y, position1.z);
+				std::string export_string = fmt::format(
+					"{} {} {}",
+					position1.x,
+					position1.y,
+					position1.z
+				);
 				parse->EventPlayer(EVENT_WARP, m_target, export_string, 0);
 				m_time_since_last_warp_detection.Start(2500);
 			}

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -2415,9 +2415,12 @@ bool Client::CheckIncreaseSkill(EQ::skills::SkillType skillid, Mob *against_who,
 		return false;
 	int skillval = GetRawSkill(skillid);
 	int maxskill = GetMaxSkillAfterSpecializationRules(skillid, MaxSkill(skillid));
-	char buffer[24] = { 0 };
-	snprintf(buffer, 23, "%d %d", skillid, skillval);
-	parse->EventPlayer(EVENT_USE_SKILL, this, buffer, 0);
+	std::string export_string = fmt::format(
+		"{} {}",
+		skillid,
+		skillval
+	);
+	parse->EventPlayer(EVENT_USE_SKILL, this, export_string, 0);
 	if (against_who) {
 		if (
 			against_who->GetSpecialAbility(IMMUNE_AGGRO) ||
@@ -5343,10 +5346,8 @@ void Client::ShowSkillsWindow()
 
 void Client::Signal(uint32 data)
 {
-	char buf[32];
-	snprintf(buf, 31, "%d", data);
-	buf[31] = '\0';
-	parse->EventPlayer(EVENT_SIGNAL, this, buf, 0);
+	std::string export_string = fmt::format("{}", data);
+	parse->EventPlayer(EVENT_SIGNAL, this, export_string, 0);
 }
 
 void Client::SendRewards()

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -2074,7 +2074,8 @@ void Client::HandleRespawnFromHover(uint32 Option)
 		}
 
 		//After they've respawned into the same zone, trigger EVENT_RESPAWN
-		parse->EventPlayer(EVENT_RESPAWN, this, static_cast<std::string>(itoa(Option)), is_rez ? 1 : 0);
+		std::string export_string = fmt::format("{}", Option);
+		parse->EventPlayer(EVENT_RESPAWN, this, export_string, is_rez ? 1 : 0);
 
 		//Pop Rez option from the respawn options list;
 		//easiest way to make sure it stays at the end and

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -1283,9 +1283,13 @@ void Corpse::LootItem(Client *client, const EQApplicationPacket *app)
 			}
 		}
 
-		char q_corpse_name[64];
-		strcpy(q_corpse_name, corpse_name);
-		std::string buf = fmt::format("{} {} {} {}", inst->GetItem()->ID, inst->GetCharges(), EntityList::RemoveNumbers(q_corpse_name), GetID());
+		std::string export_string = fmt::format(
+			"{} {} {} {}",
+			inst->GetItem()->ID,
+			inst->GetCharges(),
+			EntityList::RemoveNumbers(corpse_name),
+			GetID()
+		);
 		std::vector<EQ::Any> args;
 		args.push_back(inst);
 		args.push_back(this);
@@ -1293,13 +1297,13 @@ void Corpse::LootItem(Client *client, const EQApplicationPacket *app)
 		if (RuleB(Zone, UseZoneController)) {
 			auto controller = entity_list.GetNPCByNPCTypeID(ZONE_CONTROLLER_NPC_ID);
 			if (controller){
-				if (parse->EventNPC(EVENT_LOOT_ZONE, controller, client, buf.c_str(), 0, &args) != 0) {
+				if (parse->EventNPC(EVENT_LOOT_ZONE, controller, client, export_string, 0, &args) != 0) {
 					prevent_loot = true;
 				}
 			}
 		}
 		
-		if (parse->EventPlayer(EVENT_LOOT, client, buf.c_str(), 0, &args) != 0) {
+		if (parse->EventPlayer(EVENT_LOOT, client, export_string, 0, &args) != 0) {
 			prevent_loot = true;
 		}
 
@@ -1316,7 +1320,7 @@ void Corpse::LootItem(Client *client, const EQApplicationPacket *app)
 		}
 
 		// do we want this to have a fail option too? Sure?
-		if (parse->EventItem(EVENT_LOOT, client, inst, this, buf.c_str(), 0) != 0) {
+		if (parse->EventItem(EVENT_LOOT, client, inst, this, export_string, 0) != 0) {
 			prevent_loot = true;
 		}
 		

--- a/zone/object.cpp
+++ b/zone/object.cpp
@@ -509,12 +509,10 @@ bool Object::HandleClick(Client* sender, const ClickObject_Struct* click_object)
 				m_inst->SetRecastTimestamp(
 				    database.GetItemRecastTimestamp(sender->CharacterID(), item->RecastType));
 
-			char buf[10];
-			snprintf(buf, 9, "%u", item->ID);
-			buf[9] = '\0';
+			std::string export_string = fmt::format("{}", item->ID);
 			std::vector<EQ::Any> args;
 			args.push_back(m_inst);
-			if(parse->EventPlayer(EVENT_PLAYER_PICKUP, sender, buf, this->GetID(), &args))
+			if(parse->EventPlayer(EVENT_PLAYER_PICKUP, sender, export_string, this->GetID(), &args))
 			{
 				auto outapp = new EQApplicationPacket(OP_ClickObject, sizeof(ClickObject_Struct));
 				memcpy(outapp->pBuffer, click_object, sizeof(ClickObject_Struct));

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -288,13 +288,13 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 		}
 	}
 
+	std::string export_string = fmt::format("{}", spell_id);
 	if(IsClient()) {
-		std::string buf = fmt::format("{}", spell_id);
-		if (parse->EventPlayer(EVENT_CAST_BEGIN, CastToClient(), buf.c_str(), 0) != 0)
+		if (parse->EventPlayer(EVENT_CAST_BEGIN, CastToClient(), export_string, 0) != 0) {
 			return false;
+		}
 	} else if(IsNPC()) {
-		std::string buf = fmt::format("{}", spell_id);
-		parse->EventNPC(EVENT_CAST_BEGIN, CastToNPC(), nullptr, buf.c_str(), 0);
+		parse->EventNPC(EVENT_CAST_BEGIN, CastToNPC(), nullptr, export_string, 0);
 	}
 
 	//To prevent NPC ghosting when spells are cast from scripts
@@ -1437,12 +1437,11 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 	// at this point the spell has successfully been cast
 	//
 
+	std::string export_string = fmt::format("{}", spell_id);
 	if(IsClient()) {
-		std::string buf = fmt::format("{}", spell_id);
-		parse->EventPlayer(EVENT_CAST, CastToClient(), buf.c_str(), 0);
+		parse->EventPlayer(EVENT_CAST, CastToClient(), export_string, 0);
 	} else if(IsNPC()) {
-		std::string buf = fmt::format("{}", spell_id);
-		parse->EventNPC(EVENT_CAST, CastToNPC(), nullptr, buf.c_str(), 0);
+		parse->EventNPC(EVENT_CAST, CastToNPC(), nullptr, export_string, 0);
 	}
 
 	if(bard_song_mode)
@@ -3648,15 +3647,11 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 	);
 
 	/* Send the EVENT_CAST_ON event */
-	if(spelltar->IsNPC())
-	{
-		std::string buf = fmt::format("{}", spell_id);
-		parse->EventNPC(EVENT_CAST_ON, spelltar->CastToNPC(), this, buf.c_str(), 0);
-	}
-	else if (spelltar->IsClient())
-	{
-		std::string buf = fmt::format("{}", spell_id);
-		parse->EventPlayer(EVENT_CAST_ON, spelltar->CastToClient(), buf.c_str(), 0);
+	std::string export_string = fmt::format("{}", spell_id);
+	if(spelltar->IsNPC()) {
+		parse->EventNPC(EVENT_CAST_ON, spelltar->CastToNPC(), this, export_string, 0);
+	} else if (spelltar->IsClient()) {
+		parse->EventPlayer(EVENT_CAST_ON, spelltar->CastToClient(), export_string, 0);
 	}
 
 	mod_spell_cast(spell_id, spelltar, reflect_effectiveness, use_resist_adjust, resist_adjust, isproc);

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -1154,17 +1154,13 @@ void ClientTaskState::IncrementDoneCount(
 	}
 
 	if (!ignore_quest_update) {
-		char buf[24];
-		snprintf(
-			buf,
-			23,
-			"%d %d %d",
+		std::string export_string = fmt::format(
+			"{} {} {}",
 			info->activity[activity_id].done_count,
 			info->activity[activity_id].activity_id,
 			info->task_id
 		);
-		buf[23] = '\0';
-		parse->EventPlayer(EVENT_TASK_UPDATE, client, buf, 0);
+		parse->EventPlayer(EVENT_TASK_UPDATE, client, export_string, 0);
 	}
 
 	info->activity[activity_id].updated = true;
@@ -1189,10 +1185,12 @@ void ClientTaskState::IncrementDoneCount(
 		client->MessageString(Chat::White, TASK_UPDATED, task_information->title.c_str());
 
 		if (!ignore_quest_update) {
-			char buf[24];
-			snprintf(buf, 23, "%d %d", info->task_id, info->activity[activity_id].activity_id);
-			buf[23] = '\0';
-			parse->EventPlayer(EVENT_TASK_STAGE_COMPLETE, client, buf, 0);
+			std::string export_string = fmt::format(
+				"{} {}",
+				info->task_id,
+				info->activity[activity_id].activity_id
+			);
+			parse->EventPlayer(EVENT_TASK_STAGE_COMPLETE, client, export_string, 0);
 		}
 		/* QS: PlayerLogTaskUpdates :: Update */
 		if (RuleB(QueryServ, PlayerLogTaskUpdates)) {
@@ -1210,17 +1208,13 @@ void ClientTaskState::IncrementDoneCount(
 		// updated in UnlockActivities. Send the completed task list to the
 		// client. This is the same sequence the packets are sent on live.
 		if (task_complete) {
-			char buf[24];
-			snprintf(
-				buf,
-				23,
-				"%d %d %d",
+			std::string export_string = fmt::format(
+				"{} {} {}",
 				info->activity[activity_id].done_count,
 				info->activity[activity_id].activity_id,
 				info->task_id
 			);
-			buf[23] = '\0';
-			parse->EventPlayer(EVENT_TASK_COMPLETE, client, buf, 0);
+			parse->EventPlayer(EVENT_TASK_COMPLETE, client, export_string, 0);
 
 			/* QS: PlayerLogTaskUpdates :: Complete */
 			if (RuleB(QueryServ, PlayerLogTaskUpdates)) {

--- a/zone/tasks.cpp
+++ b/zone/tasks.cpp
@@ -97,10 +97,8 @@ void Client::SendTaskActivityComplete(
 void Client::SendTaskFailed(int task_id, int task_index, TaskType task_type)
 {
 	// 0x54eb
-	char buf[24];
-	snprintf(buf, 23, "%d", task_id);
-	buf[23] = '\0';
-	parse->EventPlayer(EVENT_TASK_FAIL, this, buf, 0);
+	std::string export_string = fmt::format("{}", task_id);
+	parse->EventPlayer(EVENT_TASK_FAIL, this, export_string, 0);
 
 	TaskActivityComplete_Struct *task_activity_complete;
 

--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -504,11 +504,11 @@ void Object::HandleCombine(Client* user, const NewCombine_Struct* in_combine, Ob
 			user->DeleteItemInInventory(in_combine->container_slot, 0, true);
 		}
 	}
+
 	if (success) {
-		parse->EventPlayer(EVENT_COMBINE_SUCCESS, user, spec.name.c_str(), spec.recipe_id);
-	}
-	else {
-		parse->EventPlayer(EVENT_COMBINE_FAILURE, user, spec.name.c_str(), spec.recipe_id);
+		parse->EventPlayer(EVENT_COMBINE_SUCCESS, user, spec.name, spec.recipe_id);
+	} else {
+		parse->EventPlayer(EVENT_COMBINE_FAILURE, user, spec.name, spec.recipe_id);
 	}
 }
 
@@ -672,10 +672,12 @@ void Object::HandleAutoCombine(Client* user, const RecipeAutoCombine_Struct* rac
 	if(success && spec.replace_container) {
 //		user->DeleteItemInInventory(in_combine->container_slot, 0, true);
 	}
-	if (success)
-		parse->EventPlayer(EVENT_COMBINE_SUCCESS, user, spec.name.c_str(), spec.recipe_id);
-	else
-		parse->EventPlayer(EVENT_COMBINE_FAILURE, user, spec.name.c_str(), spec.recipe_id);
+
+	if (success) {
+		parse->EventPlayer(EVENT_COMBINE_SUCCESS, user, spec.name, spec.recipe_id);
+	} else {
+		parse->EventPlayer(EVENT_COMBINE_FAILURE, user, spec.name, spec.recipe_id);
+	}
 }
 
 EQ::skills::SkillType Object::TypeToSkill(uint32 type)

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -202,10 +202,8 @@ void Client::Handle_OP_ZoneChange(const EQApplicationPacket *app) {
 		return;
 	}
 
-	char buf[10];
-	snprintf(buf, 9, "%d", target_zone_id);
-	buf[9] = '\0';
-	parse->EventPlayer(EVENT_ZONE, this, buf, 0);
+	std::string export_string = fmt::format("{}", target_zone_id);
+	parse->EventPlayer(EVENT_ZONE, this, export_string, 0);
 
 	//handle circumvention of zone restrictions
 	//we need the value when creating the outgoing packet as well.


### PR DESCRIPTION
- Cleans up the rest of the char arrays used when exporting to events.
- Converts all events to use a similar variable name for export `export_string`.
- Needless calls to .c_str() removed.