### PR TITLE
[BugFix] Missing safe delete of action packet

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3859,6 +3859,7 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 	//Need this to account for special AOE cases.
 	if (IsClient() && IsHarmonySpell(spell_id) && !HarmonySpellLevelCheck(spell_id, spelltar)) {
 		MessageString(Chat::SpellFailure, SPELL_NO_EFFECT);
+		safe_delete(action_packet);
 		return false;
 	}
 


### PR DESCRIPTION
Quick hot fix for missing packet safe delete I came across from a recent update.