### PR TITLE
[Saylinks] Multiple saylinks in brackets

### DIFF
--- a/common/say_link.cpp
+++ b/common/say_link.cpp
@@ -350,7 +350,7 @@ std::string EQ::SayLinkEngine::InjectSaylinksIfNotExist(const char *message)
 	std::vector<std::string> saylinks          = {};
 	int                      saylink_length    = 50;
 	std::string              saylink_separator = "\u0012";
-	std::string              saylink_partial   = "000";
+	std::string              saylink_partial   = "00000";
 
 	LogSaylinkDetail("new_message pre pass 1 [{}]", new_message);
 
@@ -374,6 +374,8 @@ std::string EQ::SayLinkEngine::InjectSaylinksIfNotExist(const char *message)
 	}
 
 	LogSaylinkDetail("new_message post pass 1 [{}]", new_message);
+
+	LogSaylinkDetail("saylink separator count [{}]", std::count(new_message.begin(), new_message.end(), '\u0012'));
 
 	// loop through brackets until none exist
 	if (new_message.find('[') != std::string::npos) {


### PR DESCRIPTION
Fix an edge case where multiple saylinks may exist between brackets. Injection code will ignore cases like these and not assume only one saylink will show up between brackets

Issue reported by Natedog because he is an issue magnet

**Example Natedog code**

```perl
sub EVENT_TARGET_CHANGE {
    $CT = $client->GetTarget();
    if ($CT->IsNPC()) {
        my $featsave = quest::saylink("#npcedit featuresave", 0, "Feature Save");
        $client->Message(335,
            "Name:" . $CT->GetCleanName() . " [" . quest::saylink("#randomfeatures", 1, "Random Features") .
                " - $featsave]");
        $client->Message(335,

            "Level: " . $CT->GetLevel() .
                " HP: " . plugin::commify($CT->GetMaxHP()) .
                " NPCID: " . $CT->GetNPCTypeID() .
                " Loottable: " . $CT->CastToNPC()->GetLoottableID() .
                " [" . quest::saylink("#npcstats", 0, "Check Stats-Loot") . "]");
    }
}
```

**Result**
![image](https://user-images.githubusercontent.com/3319450/138637239-b4161959-4f9c-4bf3-85ff-157cabced2ff.png)
