### PR TITLE
[BugFix] Charm Targeting and other issues.

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -1514,7 +1514,9 @@ void EntityList::RemoveFromTargets(Mob *mob, bool RemoveFromXTargets)
 				mob->CastToClient()->RemoveXTarget(m, false);
 		}
 
-		m->RemoveFromHateList(mob);
+		if (m->IsAIControlled()) {
+			m->RemoveFromHateList(mob);
+		}
 	}
 }
 

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -2875,7 +2875,7 @@ bool Mob::RemoveFromHateList(Mob* mob)
 				ResetAssistCap();
 		}
 	}
-	if(GetTarget() == mob)
+	if(IsAIControlled() && GetTarget() == mob)
 	{
 		SetTarget(hate_list.GetEntWithMostHateOnList(this));
 	}

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -731,6 +731,27 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				if (!caster)	// can't be someone's pet unless we know who that someone is
 					break;
 
+				if (IsClient() && caster->IsClient()) {
+					caster->Message(Chat::White, "Unable to cast charm on a fellow player.");
+					BuffFadeByEffect(SE_Charm);
+					break;
+				}
+				else if (IsCorpse()) {
+					caster->Message(Chat::White, "Unable to cast charm on a corpse.");
+					BuffFadeByEffect(SE_Charm);
+					break;
+				}
+				else if (caster->GetPet() != nullptr && caster->IsClient()) {
+					caster->Message(Chat::White, "You cannot charm something when you already have a pet.");
+					BuffFadeByEffect(SE_Charm);
+					break;
+				}
+				else if (GetOwner()) {
+					caster->Message(Chat::White, "You cannot charm someone else's pet!");
+					BuffFadeByEffect(SE_Charm);
+					break;
+				}
+
 				if(IsNPC())
 				{
 					CastToNPC()->SaveGuardSpotCharm();
@@ -739,25 +760,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				entity_list.RemoveDebuffs(this);
 				entity_list.RemoveFromTargets(this);
 				WipeHateList();
-
-				if (IsClient() && caster->IsClient()) {
-					caster->Message(Chat::White, "Unable to cast charm on a fellow player.");
-					BuffFadeByEffect(SE_Charm);
-					break;
-				} else if(IsCorpse()) {
-					caster->Message(Chat::White, "Unable to cast charm on a corpse.");
-					BuffFadeByEffect(SE_Charm);
-					break;
-				} else if(caster->GetPet() != nullptr && caster->IsClient()) {
-					caster->Message(Chat::White, "You cannot charm something when you already have a pet.");
-					BuffFadeByEffect(SE_Charm);
-					break;
-				} else if(GetOwner()) {
-					caster->Message(Chat::White, "You cannot charm someone else's pet!");
-					BuffFadeByEffect(SE_Charm);
-					break;
-				}
-
+							   
 				Mob *my_pet = GetPet();
 				if(my_pet)
 				{


### PR DESCRIPTION
Bug fix for clients losing target server side when charming
Reported: https://github.com/EQEmu/Server/issues/1652

Bug fix for failed charms due to things like already having a pet causing NPC to have hate list wiped and lose aggro.
Likely need to be checking fail check else where, but for now just moved the check to avoid this issue.