### PR TITLE
[Hotfix] Gate some new shared task logic behind task rule

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -959,7 +959,7 @@ void Client::CompleteConnect()
 	}
 
 	// shared tasks memberlist
-	if (GetTaskState()->HasActiveSharedTask()) {
+	if (RuleB(TaskSystem, EnableTaskSystem) && GetTaskState()->HasActiveSharedTask()) {
 
 		// struct
 		auto p = new ServerPacket(


### PR DESCRIPTION
This logic should be gated behind a rule for servers who have task system disabled