### PR TITLE
[Spells] Update to Charm target restriction code

### DIFF
--- a/zone/mob.h
+++ b/zone/mob.h
@@ -846,6 +846,7 @@ public:
 	inline void SetSpellPowerDistanceMod(int16 value) { SpellPowerDistanceMod = value; };
 	int32 GetSpellStat(uint32 spell_id, const char *identifier, uint8 slot = 0);
 	bool HarmonySpellLevelCheck(int32 spell_id, Mob* target = nullptr);
+	bool PassCharmTargetRestriction(Mob *target);
 	bool CanFocusUseRandomEffectivenessByType(focusType type);
 	int GetFocusRandomEffectivenessValue(int focus_base, int focus_base2, bool best_focus = 0);
 	int GetHealRate() const { return itembonuses.HealRate + spellbonuses.HealRate + aabonuses.HealRate; }

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -8428,17 +8428,21 @@ bool Mob::PassCharmTargetRestriction(Mob *target) {
 	
 	if (target->IsClient() && IsClient()) {
 		MessageString(Chat::Red, CANNOT_AFFECT_PC);
+		LogSpells("Spell casting canceled: Can not cast charm on a client.");
 		return false;
 	}
 	else if (target->IsCorpse()) {
+		LogSpells("Spell casting canceled: Can not cast charm on a corpse.");
 		return false;
 	}
 	else if (GetPet() && IsClient()) {
 		MessageString(Chat::Red, ONLY_ONE_PET);
+		LogSpells("Spell casting canceled: Can not cast charm if you have a pet.");
 		return false;
 	}
 	else if (target->GetOwner()) {
 		MessageString(Chat::Red, CANNOT_CHARM);
+		LogSpells("Spell casting canceled: Can not cast charm on a pet.");
 		return false;
 	}
 	return true;

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -8419,6 +8419,31 @@ bool Mob::HarmonySpellLevelCheck(int32 spell_id, Mob *target)
 	return true;
 }
 
+bool Mob::PassCharmTargetRestriction(Mob *target) {
+	
+	//Level restriction check should not go here.
+	if (!target) {
+		return false;
+	}
+	
+	if (target->IsClient() && IsClient()) {
+		MessageString(Chat::Red, CANNOT_AFFECT_PC);
+		return false;
+	}
+	else if (target->IsCorpse()) {
+		return false;
+	}
+	else if (GetPet() && IsClient()) {
+		MessageString(Chat::Red, ONLY_ONE_PET);
+		return false;
+	}
+	else if (target->GetOwner()) {
+		MessageString(Chat::Red, CANNOT_CHARM);
+		return false;
+	}
+	return true;
+}
+
 bool Mob::CanFocusUseRandomEffectivenessByType(focusType type)
 {
 	switch (type) {

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -732,27 +732,6 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					break;
 				}
 
-				if (IsClient() && caster->IsClient()) {
-					caster->Message(Chat::White, "Unable to cast charm on a fellow player.");
-					BuffFadeByEffect(SE_Charm);
-					break;
-				}
-				else if (IsCorpse()) {
-					caster->Message(Chat::White, "Unable to cast charm on a corpse.");
-					BuffFadeByEffect(SE_Charm);
-					break;
-				}
-				else if (caster->GetPet() != nullptr && caster->IsClient()) {
-					caster->Message(Chat::White, "You cannot charm something when you already have a pet.");
-					BuffFadeByEffect(SE_Charm);
-					break;
-				}
-				else if (GetOwner()) {
-					caster->Message(Chat::White, "You cannot charm someone else's pet!");
-					BuffFadeByEffect(SE_Charm);
-					break;
-				}
-
 				if (IsNPC()) {
 					CastToNPC()->SaveGuardSpotCharm();
 				}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -229,6 +229,26 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 		return false;
 	}
 
+	if (IsEffectInSpell(spell_id, SE_Charm)) {
+		Mob* charm_target = entity_list.GetMobID(target_id);
+		if (charm_target->IsClient() && IsClient()) {
+			InterruptSpell(CANNOT_AFFECT_PC, 0x121, spell_id);
+			return false;
+		}
+		else if (charm_target->IsCorpse()) {
+			InterruptSpell(SPELL_NO_EFFECT, 0x121, spell_id);
+			return false;
+		}
+		else if (GetPet() && IsClient()) {
+			InterruptSpell(ONLY_ONE_PET, 0x121, spell_id);
+			return false;
+		}
+		else if (charm_target->GetOwner()) {
+			InterruptSpell(CANNOT_CHARM, 0x121, spell_id);
+			return false;
+		}
+	}
+
 	if (HasActiveSong() && IsBardSong(spell_id)) {
 		LogSpells("Casting a new song while singing a song. Killing old song [{}]", bardsong);
 		//Note: this does NOT tell the client

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -230,8 +230,9 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 	}
 
 	if (IsEffectInSpell(spell_id, SE_Charm) && !PassCharmTargetRestriction(entity_list.GetMobID(target_id))) {
-		if (IsClient()) {
-			CastToClient()->SendSpellBarEnable(spell_id);
+		if ((item_slot != -1 && cast_time > 0) || !aa_id) {
+			Shout("Pass");
+			SendSpellBarEnable(spell_id);
 		}
 		if (casting_spell_id && IsNPC()) {
 			CastToNPC()->AI_Event_SpellCastFinished(false, static_cast<uint16>(casting_spell_slot));
@@ -4530,6 +4531,11 @@ bool Mob::IsImmuneToSpell(uint16 spell_id, Mob *caster)
 			} else {
 				AddToHateList(caster, 1,0,true,false,false,spell_id);
 			}
+			return true;
+		}
+
+		//Item and AA charms are checked here due to potential issue with GCD.
+		if (!caster->PassCharmTargetRestriction(this)) {
 			return true;
 		}
 

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -230,8 +230,12 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 	}
 
 	if (IsEffectInSpell(spell_id, SE_Charm) && !PassCharmTargetRestriction(entity_list.GetMobID(target_id))) {
-		if ((item_slot != -1 && cast_time > 0) || !aa_id) {
-			Shout("Pass");
+		bool can_send_spellbar_enable = true;
+		if ((item_slot != -1 && cast_time == 0) || aa_id) {
+			can_send_spellbar_enable = false;
+		}
+
+		if (can_send_spellbar_enable) {
 			SendSpellBarEnable(spell_id);
 		}
 		if (casting_spell_id && IsNPC()) {
@@ -4531,11 +4535,6 @@ bool Mob::IsImmuneToSpell(uint16 spell_id, Mob *caster)
 			} else {
 				AddToHateList(caster, 1,0,true,false,false,spell_id);
 			}
-			return true;
-		}
-
-		//Item and AA charms are checked here due to potential issue with GCD.
-		if (!caster->PassCharmTargetRestriction(this)) {
 			return true;
 		}
 

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -229,24 +229,12 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 		return false;
 	}
 
-	if (IsEffectInSpell(spell_id, SE_Charm)) {
-		Mob* charm_target = entity_list.GetMobID(target_id);
-		if (charm_target->IsClient() && IsClient()) {
-			InterruptSpell(CANNOT_AFFECT_PC, 0x121, spell_id);
-			return false;
-		}
-		else if (charm_target->IsCorpse()) {
-			InterruptSpell(SPELL_NO_EFFECT, 0x121, spell_id);
-			return false;
-		}
-		else if (GetPet() && IsClient()) {
-			InterruptSpell(ONLY_ONE_PET, 0x121, spell_id);
-			return false;
-		}
-		else if (charm_target->GetOwner()) {
-			InterruptSpell(CANNOT_CHARM, 0x121, spell_id);
-			return false;
-		}
+	if (IsEffectInSpell(spell_id, SE_Charm) && !PassCharmTargetRestriction(entity_list.GetMobID(target_id))) {
+		if (IsClient())
+			CastToClient()->SendSpellBarEnable(spell_id);
+		if (casting_spell_id && IsNPC())
+			CastToNPC()->AI_Event_SpellCastFinished(false, static_cast<uint16>(casting_spell_slot));
+		return false;
 	}
 
 	if (HasActiveSong() && IsBardSong(spell_id)) {

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -230,10 +230,12 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 	}
 
 	if (IsEffectInSpell(spell_id, SE_Charm) && !PassCharmTargetRestriction(entity_list.GetMobID(target_id))) {
-		if (IsClient())
+		if (IsClient()) {
 			CastToClient()->SendSpellBarEnable(spell_id);
-		if (casting_spell_id && IsNPC())
+		}
+		if (casting_spell_id && IsNPC()) {
 			CastToNPC()->AI_Event_SpellCastFinished(false, static_cast<uint16>(casting_spell_slot));
+		}
 		return false;
 	}
 


### PR DESCRIPTION
When casting charm the check for if charm could be applied for specific target restriction was not being done at the correct location in the code. This was causing issues due to having to remove the buff after it was applied if target checks failed.

As verified on live,  it should be checking restrictions as soon as you start casting and then it quickly cancels the cast.

Also, updated the fail messages to reflect live messages.

*This does not solve the other charm bug involving targeting.