### PR TITLE
[BugFix] Charm Targeting Fix

### DIFF
--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -758,7 +758,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				}
 				InterruptSpell();
 				entity_list.RemoveDebuffs(this);
-				entity_list.RemoveFromTargets(this);
+				entity_list.RemoveFromHateLists(this);
 				WipeHateList();
 
 				Mob *my_pet = GetPet();


### PR DESCRIPTION
Bug fix for clients losing target server side when charming
Reported: #1652

Original fix last week was causing a ton of crashes and had to be reverted. Targeting issue arises from function  entity_list.RemoveFromTargets(this) which we were calling to remove the charmed NPC from other npc hatelists, which also had side effect messing with client targeting. While I did make a safe fix for that. Ultimately, I realized it was irrelevant because what we should be using is the function entity_list.RemoveFromHateLists(this). Achieves the goal without the targeting side effects.