### PR TITLE
[Bug Fix] Fix for dual wield animation when same delay weapons.

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -138,17 +138,23 @@ EQ::skills::SkillType Mob::AttackAnimation(int Hand, const EQ::ItemInstance* wea
 		skillinuse = EQ::skills::SkillHandtoHand;
 		type = animHand2Hand;
 	}
-
+	Shout("PRE Hand %i Type %i", Hand, type);
 	// If we're attacking with the secondary hand, play the dual wield anim
 	if (Hand == EQ::invslot::slotSecondary) {// DW anim
 		type = animDualWield;
+
+		//allow animation chance to fire to be similar to your dw chance
+		if (GetDualWieldingSameDelayWeapons() == 2) {
+			SetDualWieldingSameDelayWeapons(3);
+		}
 	}
 	
 	//If both weapons have same delay this allows a chance for DW animation
 	if (GetDualWieldingSameDelayWeapons() && Hand == EQ::invslot::slotPrimary) {
-		
-		if (GetDualWieldingSameDelayWeapons() == 2 && zone->random.Roll(50)) {
+
+		if (GetDualWieldingSameDelayWeapons() == 3 && zone->random.Roll(50)) {
 			type = animDualWield;
+			SetDualWieldingSameDelayWeapons(2);//Don't roll again till you do another dw attack.
 		}
 		SetDualWieldingSameDelayWeapons(2);//Ensures first attack is always primary.
 	}

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -145,12 +145,12 @@ EQ::skills::SkillType Mob::AttackAnimation(int Hand, const EQ::ItemInstance* wea
 	}
 	
 	//If both weapons have same delay this allows a chance for DW animation
-	if (GetDualWeildingSameDelayWeapons() && Hand == EQ::invslot::slotPrimary) {
+	if (GetDualWieldingSameDelayWeapons() && Hand == EQ::invslot::slotPrimary) {
 		
-		if (GetDualWeildingSameDelayWeapons() == 2 && zone->random.Roll(50)) {
+		if (GetDualWieldingSameDelayWeapons() == 2 && zone->random.Roll(50)) {
 			type = animDualWield;
 		}
-		SetDualWeildingSameDelayWeapons(2);//Ensures first attack is always primary.
+		SetDualWieldingSameDelayWeapons(2);//Ensures first attack is always primary.
 	}
 
 	DoAnim(type, 0, false);
@@ -5500,10 +5500,10 @@ void Client::SetAttackTimer()
 
 	//To allow for duel wield animation to display correctly if both weapons have same delay
 	if (primary_speed == secondary_speed) {
-		SetDualWeildingSameDelayWeapons(1);
+		SetDualWieldingSameDelayWeapons(1);
 	}
 	else {
-		SetDualWeildingSameDelayWeapons(0);
+		SetDualWieldingSameDelayWeapons(0);
 	}
 }
 

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -140,8 +140,18 @@ EQ::skills::SkillType Mob::AttackAnimation(int Hand, const EQ::ItemInstance* wea
 	}
 
 	// If we're attacking with the secondary hand, play the dual wield anim
-	if (Hand == EQ::invslot::slotSecondary)	// DW anim
+	if (Hand == EQ::invslot::slotSecondary) {// DW anim
 		type = animDualWield;
+	}
+	
+	//If both weapons have same delay this allows a chance for DW animation
+	if (GetDualWeildingSameDelayWeapons() && Hand == EQ::invslot::slotPrimary) {
+		
+		if (GetDualWeildingSameDelayWeapons() == 2 && zone->random.Roll(50)) {
+			type = animDualWield;
+		}
+		SetDualWeildingSameDelayWeapons(2);//Ensures first attack is always primary.
+	}
 
 	DoAnim(type, 0, false);
 
@@ -5400,6 +5410,8 @@ void Mob::SetAttackTimer()
 void Client::SetAttackTimer()
 {
 	float haste_mod = GetHaste() * 0.01f;
+	int primary_speed = 0;
+	int secondary_speed = 0;
 
 	//default value for attack timer in case they have
 	//an invalid weapon equipped:
@@ -5477,6 +5489,21 @@ void Client::SetAttackTimer()
 				speed = static_cast<int>(speed + ((hhe / 100.0f) * delay));
 		}
 		TimerToUse->SetAtTrigger(std::max(RuleI(Combat, MinHastedDelay), speed), true, true);
+
+		if (i == EQ::invslot::slotPrimary) {
+			primary_speed = speed;
+		}
+		else if (i == EQ::invslot::slotSecondary) {
+			secondary_speed = speed;
+		}
+	}
+
+	//To allow for duel wield animation to display correctly if both weapons have same delay
+	if (primary_speed == secondary_speed) {
+		SetDualWeildingSameDelayWeapons(1);
+	}
+	else {
+		SetDualWeildingSameDelayWeapons(0);
 	}
 }
 

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -138,7 +138,7 @@ EQ::skills::SkillType Mob::AttackAnimation(int Hand, const EQ::ItemInstance* wea
 		skillinuse = EQ::skills::SkillHandtoHand;
 		type = animHand2Hand;
 	}
-	Shout("PRE Hand %i Type %i", Hand, type);
+
 	// If we're attacking with the secondary hand, play the dual wield anim
 	if (Hand == EQ::invslot::slotSecondary) {// DW anim
 		type = animDualWield;

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -474,6 +474,7 @@ Mob::Mob(
 	npc_assist_cap = 0;
 
 	use_double_melee_round_dmg_bonus = false;
+	dw_same_delay = 0;
 
 #ifdef BOTS
 	m_manual_follow = false;

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -851,6 +851,8 @@ public:
 	int GetHealRate() const { return itembonuses.HealRate + spellbonuses.HealRate + aabonuses.HealRate; }
 	int GetMemoryBlurChance(int base_chance);
 	inline bool HasBaseEffectFocus() const { return (spellbonuses.FocusEffects[focusFcBaseEffects] || aabonuses.FocusEffects[focusFcBaseEffects] || itembonuses.FocusEffects[focusFcBaseEffects]); }
+	int32 GetDualWeildingSameDelayWeapons() const { return dw_same_delay; }
+	inline void SetDualWeildingSameDelayWeapons(int32 val) { dw_same_delay = val; }
 
 	bool TryDoubleMeleeRoundEffect();
 	bool GetUseDoubleMeleeRoundDmgBonus() const { return use_double_melee_round_dmg_bonus; }
@@ -1464,6 +1466,7 @@ protected:
 	int16 slow_mitigation; // Allows for a slow mitigation (100 = 100%, 50% = 50%)
 	Timer tic_timer;
 	Timer mana_timer;
+	int32 dw_same_delay;
 
 	Timer focusproclimit_timer[MAX_FOCUS_PROC_LIMIT_TIMERS];	//SPA 511
 	int32 focusproclimit_spellid[MAX_FOCUS_PROC_LIMIT_TIMERS];	//SPA 511

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -851,8 +851,8 @@ public:
 	int GetHealRate() const { return itembonuses.HealRate + spellbonuses.HealRate + aabonuses.HealRate; }
 	int GetMemoryBlurChance(int base_chance);
 	inline bool HasBaseEffectFocus() const { return (spellbonuses.FocusEffects[focusFcBaseEffects] || aabonuses.FocusEffects[focusFcBaseEffects] || itembonuses.FocusEffects[focusFcBaseEffects]); }
-	int32 GetDualWeildingSameDelayWeapons() const { return dw_same_delay; }
-	inline void SetDualWeildingSameDelayWeapons(int32 val) { dw_same_delay = val; }
+	int32 GetDualWieldingSameDelayWeapons() const { return dw_same_delay; }
+	inline void SetDualWieldingSameDelayWeapons(int32 val) { dw_same_delay = val; }
 
 	bool TryDoubleMeleeRoundEffect();
 	bool GetUseDoubleMeleeRoundDmgBonus() const { return use_double_melee_round_dmg_bonus; }


### PR DESCRIPTION
Resolves an issue where if you start auto attacking with two weapons with the same delay the offhand animation will never fire due to the throttle timer, the primary would always go first. This solution checks when the timers are set if both attack and dw timers are the same, if so it will ensure an equal chance of primary and secondary animations.