### PR TITLE
[Bug Fix] SOF+ clients item click recast timer not met check

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -8959,7 +8959,7 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 				}
 				if (GetLevel() >= item->Click.Level2)
 				{
-					if (item && item->RecastDelay > 0)
+					if (item->RecastDelay > 0)
 					{
 						if (!GetPTimers().Expired(&database, (pTimerItemStart + item->RecastType), false)) {
 							LogSpells("Casting of [{}] canceled: item spell reuse timer not expired", spell_id);
@@ -8996,10 +8996,11 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 				}
 				if (GetLevel() >= augitem->Click.Level2)
 				{
-					if (item && item->RecastDelay > 0)
+					if (augitem->RecastDelay > 0)
 					{
-						if (!GetPTimers().Expired(&database, (pTimerItemStart + item->RecastType), false)) {
-							LogSpells("Casting of [{}] canceled: item spell reuse timer not expired", spell_id);
+						if (!GetPTimers().Expired(&database, (pTimerItemStart + augitem->RecastType), false)) {
+							LogSpells("Casting of [{}] canceled: item spell reuse timer from augment not expired", spell_id);
+							MessageString(Chat::Red, SPELL_RECAST);
 							return;
 						}
 					}

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -8959,6 +8959,14 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 				}
 				if (GetLevel() >= item->Click.Level2)
 				{
+					if (item && item->RecastDelay > 0)
+					{
+						if (!GetPTimers().Expired(&database, (pTimerItemStart + item->RecastType), false)) {
+							LogSpells("Casting of [{}] canceled: item spell reuse timer not expired", spell_id);
+							return;
+						}
+					}
+
 					int i = parse->EventItem(EVENT_ITEM_CLICK_CAST, this, p_inst, nullptr, "", slot_id);
 					inst = m_inv[slot_id];
 					if (!inst)
@@ -8988,6 +8996,14 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 				}
 				if (GetLevel() >= augitem->Click.Level2)
 				{
+					if (item && item->RecastDelay > 0)
+					{
+						if (!GetPTimers().Expired(&database, (pTimerItemStart + item->RecastType), false)) {
+							LogSpells("Casting of [{}] canceled: item spell reuse timer not expired", spell_id);
+							return;
+						}
+					}
+
 					int i = parse->EventItem(EVENT_ITEM_CLICK_CAST, this, clickaug, nullptr, "", slot_id);
 					inst = m_inv[slot_id];
 					if (!inst)

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -1020,7 +1020,10 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 			return;
 		}
 	}
-
+	/*
+		Titanium client will prevent item recast on its own. This is only used to enforce. Titanium items are cast from Handle_OP_CastSpell.
+		SOF+ client does not prevent item recast on its own. We enforce this in Handle_OP_ItemVerifyRequest where items are cast from.
+	*/
 	if(IsClient() && (slot == CastingSlot::Item || slot == CastingSlot::PotionBelt))
 	{
 		IsFromItem = true;


### PR DESCRIPTION
SOF+ client's were not checking Item Click Recast timers until after the click spell had completed casting. It should be checked upon initial click and not start casting if the recast timer is active. Titanium does this by default with no code checks needed., though we enforce it server side at end of cast for Titanium. Keeping the end of cast check for both, Titanium doesn't play as nice when I tried to move it up to be done on click.