### PR TITLE
[Spells]  Implemented SPA 415 SE_FFItemClass

### DIFF
--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -1230,7 +1230,7 @@ bool IsEffectIgnoredInStacking(int spa)
 	case SE_LimitClass:
 	case SE_LimitRace:
 	case SE_FcBaseEffects:
-	case 415:
+	case SE_FFItemClass:
 	case SE_SkillDamageAmount2:
 	case SE_FcLimitUse:
 	case SE_FcIncreaseNumHits:
@@ -1298,6 +1298,7 @@ bool IsFocusLimit(int spa)
 	case SE_Ff_Value_Min:
 	case SE_Ff_Value_Max:
 	case SE_Ff_FocusTimerMin:
+	case SE_FFItemClass:
 		return true;
 	default:
 		return false;

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1115,7 +1115,7 @@ typedef enum {
 #define SE_LimitRace					412 // implemented, @Ff, Race that can use the spell focus, base1: race, Note: not used in any known live spells. Use only single race at a time.
 #define SE_FcBaseEffects				413 // implemented, @Fc, On Caster, base spell effectiveness mod pct, base: pct
 #define SE_LimitCastingSkill			414 // implemented, @Ff, Spell and singing skills(s) that a spell focus can require or exclude, base1: skill id, Include: Positive Exclude: Negative
-#define SE_FFItemClass					415 // implemented, @Ff, Limits focuses to be applied only from item click. base1: item ItemType (-1 for all ItemTypes), limit: item SubType, max: item Slots (bitmask of valid slots), Note: not used on live [-1 is an exclude]...
+#define SE_FFItemClass					415 // implemented, @Ff, Limits focuses to be applied only from item click. base1: item ItemType (-1 for all ItemTypes,-2 to exclude clicks from getting the focus, or exclude specific SubTypes or Sltos if set), limit: item SubType (-1 for all SubTypes), max: item Slots (bitmask of valid slots, -1 ALL slots), Note: not used on live
 #define SE_ACv2							416 // implemented - New AC spell effect
 #define SE_ManaRegen_v2					417 // implemented - New mana regen effect
 #define SE_SkillDamageAmount2			418 // implemented - adds skill damage directly to certain attacks

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1115,7 +1115,7 @@ typedef enum {
 #define SE_LimitRace					412 // implemented, @Ff, Race that can use the spell focus, base1: race, Note: not used in any known live spells. Use only single race at a time.
 #define SE_FcBaseEffects				413 // implemented, @Fc, On Caster, base spell effectiveness mod pct, base: pct
 #define SE_LimitCastingSkill			414 // implemented, @Ff, Spell and singing skills(s) that a spell focus can require or exclude, base1: skill id, Include: Positive Exclude: Negative
-//#define SE_FFItemClass				415 // not used - base1 matches ItemType, base2 matches SubType, -1 ignored, max is bitmask of valid slots
+#define SE_FFItemClass					415 // not used - base1 matches ItemType, base2 matches SubType, -1 ignored, max is bitmask of valid slots
 #define SE_ACv2							416 // implemented - New AC spell effect
 #define SE_ManaRegen_v2					417 // implemented - New mana regen effect
 #define SE_SkillDamageAmount2			418 // implemented - adds skill damage directly to certain attacks

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1117,7 +1117,7 @@ typedef enum {
 #define SE_LimitRace					412 // implemented, @Ff, Race that can use the spell focus, base1: race, Note: not used in any known live spells. Use only single race at a time.
 #define SE_FcBaseEffects				413 // implemented, @Fc, On Caster, base spell effectiveness mod pct, base: pct
 #define SE_LimitCastingSkill			414 // implemented, @Ff, Spell and singing skills(s) that a spell focus can require or exclude, base1: skill id, Include: Positive Exclude: Negative
-#define SE_FFItemClass					415 // implemented, @Ff, Limits focuses to be applied only from item click. base1: item ItemType (-1 for all ItemTypes,-2 to exclude clicks from getting the focus, or exclude specific SubTypes or Sltos if set), limit: item SubType (-1 for all SubTypes), max: item Slots (bitmask of valid slots, -1 ALL slots), Note: not used on live
+#define SE_FFItemClass					415 // implemented, @Ff, Limits focuses to be applied only from item click. base1: item ItemType (-1 to include for all ItemTypes,-1000 to exclude clicks from getting the focus, or exclude specific SubTypes or Slots if set), limit: item SubType (-1 for all SubTypes), max: item Slots (bitmask of valid slots, -1 ALL slots), Note: not used on live. See comments in Mob::CalcFocusEffect for more details.
 #define SE_ACv2							416 // implemented - New AC spell effect
 #define SE_ManaRegen_v2					417 // implemented - New mana regen effect
 #define SE_SkillDamageAmount2			418 // implemented - adds skill damage directly to certain attacks

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -177,7 +177,7 @@
 #define EFFECT_COUNT 12
 #define MAX_SPELL_TRIGGER 12	// One for each slot(only 6 for AA since AA use 2)
 #define MAX_RESISTABLE_EFFECTS 12	// Number of effects that are typcially checked agianst resists.
-#define MaxLimitInclude 16 //Number(x 0.5) of focus Limiters that have inclusive checks used when calcing focus effects
+#define MaxLimitInclude 18 //Number(x 0.5) of focus Limiters that have inclusive checks used when calcing focus effects
 #define MAX_SKILL_PROCS 4 //Number of spells to check skill procs from. (This is arbitrary) [Single spell can have multiple proc checks]
 #define MAX_AA_PROCS 16 //(Actual Proc Amount is MAX_AA_PROCS/4) Number of spells to check AA procs from. (This is arbitrary)
 #define MAX_SYMPATHETIC_PROCS 10 // Number of sympathetic procs a client can have (This is arbitrary)
@@ -206,7 +206,9 @@ enum FocusLimitIncludes {
 	IncludeExistsSELimitSpellClass    = 12,
 	IncludeFoundSELimitSpellClass     = 13,
 	IncludeExistsSELimitSpellSubclass = 14,
-	IncludeFoundSELimitSpellSubclass  = 15
+	IncludeFoundSELimitSpellSubclass  = 15,
+	IncludeExistsSEFFItemClass        = 16,
+	IncludeFoundSEFFItemClass         = 17
 };
 /*
 	The id's correspond to 'type' 39 in live(2021) dbstr_us gives the message for target and caster restricted effects. These are not present in the ROF2 dbstr_us.

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1115,7 +1115,7 @@ typedef enum {
 #define SE_LimitRace					412 // implemented, @Ff, Race that can use the spell focus, base1: race, Note: not used in any known live spells. Use only single race at a time.
 #define SE_FcBaseEffects				413 // implemented, @Fc, On Caster, base spell effectiveness mod pct, base: pct
 #define SE_LimitCastingSkill			414 // implemented, @Ff, Spell and singing skills(s) that a spell focus can require or exclude, base1: skill id, Include: Positive Exclude: Negative
-#define SE_FFItemClass					415 // implemented, @Ff, Limits focuses to be applied only from item click. base1: item ItemType (-1 for all ItemTypes), limit: item SubType, max: item Slots (bitmask of valid slots), Note: not used on live
+#define SE_FFItemClass					415 // implemented, @Ff, Limits focuses to be applied only from item click. base1: item ItemType (-1 for all ItemTypes), limit: item SubType, max: item Slots (bitmask of valid slots), Note: not used on live [-1 is an exclude]...
 #define SE_ACv2							416 // implemented - New AC spell effect
 #define SE_ManaRegen_v2					417 // implemented - New mana regen effect
 #define SE_SkillDamageAmount2			418 // implemented - adds skill damage directly to certain attacks

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1115,7 +1115,7 @@ typedef enum {
 #define SE_LimitRace					412 // implemented, @Ff, Race that can use the spell focus, base1: race, Note: not used in any known live spells. Use only single race at a time.
 #define SE_FcBaseEffects				413 // implemented, @Fc, On Caster, base spell effectiveness mod pct, base: pct
 #define SE_LimitCastingSkill			414 // implemented, @Ff, Spell and singing skills(s) that a spell focus can require or exclude, base1: skill id, Include: Positive Exclude: Negative
-#define SE_FFItemClass					415 // not used - base1 matches ItemType, base2 matches SubType, -1 ignored, max is bitmask of valid slots
+#define SE_FFItemClass					415 // implemented, @Ff, Limits focuses to be applied only from item click. base1: item ItemType (-1 for all ItemTypes), limit: item SubType, max: item Slots (bitmask of valid slots), Note: not used on live
 #define SE_ACv2							416 // implemented - New AC spell effect
 #define SE_ManaRegen_v2					417 // implemented - New mana regen effect
 #define SE_SkillDamageAmount2			418 // implemented - adds skill damage directly to certain attacks

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -5270,8 +5270,10 @@ int32 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 
 	for (int i = 0; i < EFFECT_COUNT; i++) {
 
-		switch (focus_spell.effect_id[i]) {
+		Shout("Check SPA %i", focus_spell.effect_id[i]);
 
+		switch (focus_spell.effect_id[i]) {
+			
 			case SE_Blank:
 				break;
 
@@ -5594,11 +5596,13 @@ int32 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				break;
 
 			case SE_FFItemClass:
+				Shout("1 Limit Check ItemClass");
 				if (casting_spell_inventory_slot && casting_spell_inventory_slot != -1) {
 					if (IsClient() && casting_spell_slot == EQ::spells::CastingSlot::Item && casting_spell_inventory_slot != 0xFFFFFFFF) {
 						auto item = CastToClient()->GetInv().GetItem(casting_spell_inventory_slot);
 						if (item && item->GetItem()) {
-							
+							Shout("2 Limit Check ItemClass FROM ITEM %i %i %i", focus_spell.base_value[i], focus_spell.limit_value[i], focus_spell.max_value[i]);
+							Shout("2 Limit Check ItemClass FROM FOCUS %i %i %i", item->GetItem()->ItemType, item->GetItem()->SubType, item->GetItem()->Slots);
 							//If ItemType set to -2, then we will exclude either all items, or specific items by SubType or Slot.
 							if (focus_spell.base_value[i] == -2) { //Excludes
 								bool exclude_this_item = true;
@@ -5614,8 +5618,8 @@ int32 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 										exclude_this_item = false;
 									}
 								}
-								
 								if (exclude_this_item) {
+									Shout("Excluded Fail");
 									return 0;
 								}
 							}
@@ -5629,7 +5633,7 @@ int32 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 									}
 								}
 								//SubType (if set to -1, ignore and include any SubType)
-								if (focus_spell.limit_value[i] >= 0) { //this should not be zero
+								if (focus_spell.limit_value[i] >= 0) {
 									if (focus_spell.limit_value[i] != item->GetItem()->SubType) {
 										include_this_item = false;
 									}
@@ -5641,11 +5645,9 @@ int32 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 									}
 								}
 
-								if (!include_this_item) {
-									return 0;
-								}
-								else {
+								if (include_this_item) {
 									LimitInclude[IncludeFoundSEFFItemClass] = true;
+									Shout("Found and Included");
 								}
 							}
 						}
@@ -5959,7 +5961,7 @@ int32 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 	if (focus_reuse_time) {
 		SetFocusProcLimitTimer(focus_spell.id, focus_reuse_time);
 	}
-
+	Shout("[Focus Spell ID %i] Focus Passed value %i", focus_spell.id, value);
 	return (value * lvlModifier / 100);
 }
 

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -4892,6 +4892,29 @@ int32 Client::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 				}
 				break;
 
+			case SE_FFItemClass:
+				if (casting_spell_inventory_slot && casting_spell_inventory_slot != -1) {
+					if (IsClient() && casting_spell_slot == EQ::spells::CastingSlot::Item && casting_spell_inventory_slot != 0xFFFFFFFF) {
+						auto item = CastToClient()->GetInv().GetItem(casting_spell_inventory_slot);
+						//ItemType
+						if (item && item->GetItem()) {
+							if (base_value >= 0) {//if this is set to a negative value (ie -1) allow any ItemType
+								if (base_value != item->GetItem()->ItemType) {//this can be zero
+									LimitFailure = true;
+								}
+							}
+							//SubType
+							if (limit_value) { //this should not be zero
+								if (limit_value != item->GetItem()->SubType) {
+									LimitFailure = true;
+								}
+							}
+						}
+					}
+				}
+				break;
+
+
 
 				/* These are not applicable to AA's because there is never a 'caster' of the 'buff' with the focus effect.
 				case SE_Ff_Same_Caster:

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -5598,41 +5598,55 @@ int32 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 					if (IsClient() && casting_spell_slot == EQ::spells::CastingSlot::Item && casting_spell_inventory_slot != 0xFFFFFFFF) {
 						auto item = CastToClient()->GetInv().GetItem(casting_spell_inventory_slot);
 						if (item && item->GetItem()) {
-							//ItemType (if set to -1, ignore and allow any ItemType)
-							if (focus_spell.base_value[i] >= 0) {//if this is set to a negative value (ie -1) allow any ItemType
-								if (focus_spell.base_value[i] != item->GetItem()->ItemType) {//this can be zero
-									return 0;
-								}
-							}
-							//SubType (if set to -1, ignore and allow any SubType)
-							if (focus_spell.limit_value[i] >= 0) { //this should not be zero
-								if (focus_spell.limit_value[i] != item->GetItem()->SubType) {
-									return 0;
-								}
-							}
-							//item slot bitmask (if set to -1, ignore and allow any slot)
-							if (focus_spell.max_value[i] >= 0) {
-								if (focus_spell.limit_value[i] != item->GetItem()->Slots) {
-									return 0;
-								}
-							}
-
+							
 							//If ItemType set to -2, then we will exclude either all items, or specific items by SubType or Slot.
-							if (focus_spell.base_value[i] == -2) {
-								
+							if (focus_spell.base_value[i] == -2) { //Excludes
+								bool exclude_this_item = true;
 								//SubType (if set to -1, ignore and exclude all SubTypes)
 								if (focus_spell.limit_value[i] >= 0) { //this should not be zero
-									if (focus_spell.limit_value[i] == item->GetItem()->SubType) {
-										return 0;
+									if (focus_spell.limit_value[i] != item->GetItem()->SubType) {
+										exclude_this_item = false;
 									}
 								}
 								//item slot bitmask (if set to -1, ignore and exclude all SubTypes)
 								if (focus_spell.max_value[i] >= 0) {
-									if (focus_spell.limit_value[i] == item->GetItem()->Slots) {
-										return 0;
+									if (focus_spell.max_value[i] != item->GetItem()->Slots) {
+										exclude_this_item = false;
 									}
 								}
-								return 0;
+								
+								if (exclude_this_item) {
+									return 0;
+								}
+							}
+							else {//Includes
+								LimitInclude[IncludeExistsSEFFItemClass] = true;
+								bool include_this_item = true;
+								//ItemType (if set to -1, ignore and include any ItemType)
+								if (focus_spell.base_value[i] >= 0) {//if this is set to a negative value (ie -1) allow any ItemType
+									if (focus_spell.base_value[i] != item->GetItem()->ItemType) {//this can be zero
+										include_this_item = false;
+									}
+								}
+								//SubType (if set to -1, ignore and include any SubType)
+								if (focus_spell.limit_value[i] >= 0) { //this should not be zero
+									if (focus_spell.limit_value[i] != item->GetItem()->SubType) {
+										include_this_item = false;
+									}
+								}
+								//item slot bitmask (if set to -1, ignore and include any slot)
+								if (focus_spell.max_value[i] >= 0) {
+									if (focus_spell.max_value[i] != item->GetItem()->Slots) {
+										include_this_item = false;
+									}
+								}
+
+								if (!include_this_item) {
+									return 0;
+								}
+								else {
+									LimitInclude[IncludeFoundSEFFItemClass] = true;
+								}
 							}
 						}
 					}

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -4940,9 +4940,11 @@ int32 Client::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 						}
 					}
 				}
-				else {
+				//If this is checking that focus can only be cast from an item, then if its not cast from item fail.
+				else if (base_value >= -1) {
 					LimitFailure = true;
 				}
+				//If we are checking to exclude items from a focus then do not fail unless the above check fails.
 				break;
 
 				/* These are not applicable to AA's because there is never a 'caster' of the 'buff' with the focus effect.
@@ -5644,7 +5646,7 @@ int32 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 					Note: You can apply multiple includes or excludes to a single focus spell,  using multiple SPA 415 limits in the spell. Ie. Check for clicks from ItemType 10 or 11.
 				
 				*/
-							
+		
 				if (casting_spell_inventory_slot && casting_spell_inventory_slot != -1) {
 					if (IsClient() && casting_spell_slot == EQ::spells::CastingSlot::Item && casting_spell_inventory_slot != 0xFFFFFFFF) {
 						auto item = CastToClient()->GetInv().GetItem(casting_spell_inventory_slot);
@@ -5704,9 +5706,11 @@ int32 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 						}
 					}
 				}
-				else {
+				//If this is checking that focus can only be cast from an item, then if its not cast from item fail.
+				else if (focus_spell.base_value[i] >= -1) {
 					return 0;
 				}
+				//If we are checking to exclude items from a focus then do not fail unless the above check fails.
 				break;
 
 			// handle effects

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -4939,6 +4939,9 @@ int32 Client::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 							}
 						}
 					}
+					else {
+						LimitFailure = true;
+					}
 				}
 				break;
 
@@ -5699,6 +5702,9 @@ int32 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 								}
 							}
 						}
+					}
+					else {
+						return 0;
 					}
 				}
 				break;

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -5634,11 +5634,11 @@ int32 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 					To exclude a specific ItemType we have to do some math. The exclude value will be the negative value of (ItemType + 100).
 					If ItemType = 10, then SET ItemType= -110 to exclude. If its ItemType 0, then SET ItemType= -100 to exclude ect. Not ideal but it works.
 					
-					Usage example: Only focus spell if from click cast and is a 'defense armor' item type=10 [base= 10, limit= -1, max= -1]
-					Usage example: Only focus spell if from click cast and is from helmet slot' slots= 4     [base= -1, limit= -1, max= 4]
-					Usage example: Do not focus spell if it is from an item click. [base= -1000, limit= -1, max= -1]
-					Usage example: Do not focus spell if it is from an item click from a helmet slot. [base= -1000, limit= -1, max= 4]
-					Usage example: Do not focus spell if it is from an item click and is a 'defense armor' item type=10. [base= -110, limit= -1, max= -1]
+					Usage example: [INCLUDE] Only focus spell if from click cast and is a 'defense armor' item type=10 [base= 10, limit= -1, max= -1]
+					Usage example: [INCLUDE] Only focus spell if from click cast and is from helmet slot' slots= 4     [base= -1, limit= -1, max= 4]
+					Usage example: [EXCLUDE] Do not focus spell if it is from an item click. [base= -1000, limit= -1, max= -1]
+					Usage example: [EXCLUDE] Do not focus spell if it is from an item click from a helmet slot. [base= -1000, limit= -1, max= 4]
+					Usage example: [EXCLUDE] Do not focus spell if it is from an item click and is a 'defense armor' item type=10. [base= -110, limit= -1, max= -1]
 
 					Note: You can apply multiple includes or excludes to a single focus spell,  using multiple SPA 415 limits in the spell. Ie. Check for clicks from ItemType 10 or 11.
 				

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -5609,7 +5609,7 @@ int32 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 					For SubType and Slots set using same rules above as for includes. Ie. -1 for all, positive for specifics
 					To exclude a specific ItemType we have to do some math. The exclude value will be the negative value of (ItemType + 100).
 					If ItemType = 10, then SET ItemType= -110 to exclude. If its ItemType 0, then SET ItemType= -100 to exclude ect. Not ideal but it works.
-
+					
 					Usage example: Only focus spell if from click cast and is a 'defense armor' item type=10 [base= 10, limit= -1, max= -1]
 					Usage example: Only focus spell if from click cast and is from helmet slot' slots= 4     [base= -1, limit= -1, max= 4]
 					Usage example: Do not focus spell if it is from an item click. [base= -1000, limit= -1, max= -1]
@@ -5624,32 +5624,36 @@ int32 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 					if (IsClient() && casting_spell_slot == EQ::spells::CastingSlot::Item && casting_spell_inventory_slot != 0xFFFFFFFF) {
 						auto item = CastToClient()->GetInv().GetItem(casting_spell_inventory_slot);
 						if (item && item->GetItem()) {
-							Shout("DEBUG Limit Check ItemClass FROM ITEM %i %i %i", focus_spell.base_value[i], focus_spell.limit_value[i], focus_spell.max_value[i]);
-							Shout("DEBUG  Limit Check ItemClass FROM FOCUS %i %i %i", item->GetItem()->ItemType, item->GetItem()->SubType, item->GetItem()->Slots);
+							Shout("DEBUG Limit Check ItemClass FROM FOCUS %i %i %i", focus_spell.base_value[i], focus_spell.limit_value[i], focus_spell.max_value[i]);
+							Shout("DEBUG  Limit Check ItemClass FROM item %i %i %i", item->GetItem()->ItemType, item->GetItem()->SubType, item->GetItem()->Slots);
 							//If ItemType set to < -1, then we will exclude either all Subtypes (-1000), or specific items by ItemType, SubType or Slot. See above for rules.
 							if (focus_spell.base_value[i] < -1) { //Excludes
 								bool exclude_this_item = true;
 								int tmp_itemtype = (item->GetItem()->ItemType + 100) * -1;
+								Shout("tmp item type = %i", tmp_itemtype);
 								//ItemType (if set to -1000, ignore and exclude any ItemType)
-								if (focus_spell.base_value[i] >= 0) {
+								if (focus_spell.base_value[i] < -1 && focus_spell.base_value[i] != -1000) {
 									if (focus_spell.base_value[i] != tmp_itemtype) {
 										exclude_this_item = false;
+										Shout("fail 1");
 									}
 								}
 								//SubType (if set to -1, ignore and exclude all SubTypes)
 								if (focus_spell.limit_value[i] >= 0) { //this should not be zero
 									if (focus_spell.limit_value[i] != item->GetItem()->SubType) {
 										exclude_this_item = false;
+										Shout("fail 2");
 									}
 								}
 								//item slot bitmask (if set to -1, ignore and exclude all SubTypes)
 								if (focus_spell.max_value[i] >= 0) {
 									if (focus_spell.max_value[i] != item->GetItem()->Slots) {
 										exclude_this_item = false;
+										Shout("fail 3  don't exclude because item is not one we are matching to");
 									}
 								}
 								if (exclude_this_item) {
-									Shout("Excluded Fail");
+									Shout("Excluded Fail DO NOT USE THIS");
 									return 0;
 								}
 							}

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -4939,9 +4939,9 @@ int32 Client::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 							}
 						}
 					}
-					else {
-						LimitFailure = true;
-					}
+				}
+				else {
+					LimitFailure = true;
 				}
 				break;
 
@@ -5703,9 +5703,9 @@ int32 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 							}
 						}
 					}
-					else {
-						return 0;
-					}
+				}
+				else {
+					return 0;
 				}
 				break;
 

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -5295,8 +5295,6 @@ int32 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 
 	for (int i = 0; i < EFFECT_COUNT; i++) {
 
-		Shout("Check SPA %i", focus_spell.effect_id[i]);
-
 		switch (focus_spell.effect_id[i]) {
 			
 			case SE_Blank:

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -3266,6 +3266,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 			case SE_Buy_AA_Rank:
 			case SE_Ff_FocusTimerMin:
 			case SE_Proc_Timer_Modifier:
+			case SE_FFItemClass:
 			{
 				break;
 			}
@@ -5564,6 +5565,45 @@ int32 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				}
 				else {
 					focus_reuse_time = focus_spell.limit_value[i];
+				}
+				break;
+
+			case SE_FFItemClass: 
+				Shout("Check ITEM slot %i", casting_spell_inventory_slot);
+				if (casting_spell_inventory_slot && casting_spell_inventory_slot != -1){
+					Shout("Check ITEM slot %i ivnentory slot %i", casting_spell_inventory_slot, casting_spell_inventory_slot);
+					if (IsClient() && casting_spell_slot == EQ::spells::CastingSlot::Item && casting_spell_inventory_slot != 0xFFFFFFFF) {
+						auto item = CastToClient()->GetInv().GetItem(casting_spell_inventory_slot);
+											   
+						if (item && item->GetItem()) {
+							Shout("FOUND ITEM TYPE %i SUB %i SLOTS %i", item->GetItem()->ItemType, item->GetItem()->SubType, item->GetItem()->Slots);
+							Shout("Focus TYPE %i SUB %i SLOTS %i", focus_spell.base_value[i], focus_spell.limit_value[i], focus_spell.max_value[i]);
+							
+							if (focus_spell.base_value[i] >= 0) {//if this is set to a negative value (ie -1) allow any ItemType
+								if (focus_spell.base_value[i] != item->GetItem()->ItemType) {//this can be zero
+									Shout("Fail base");
+									return 0;
+								}
+							}
+							if (focus_spell.limit_value[i]) { //this should not be zero
+								if (focus_spell.limit_value[i] != item->GetItem()->SubType) {
+									Shout("Fail limit");
+									return 0;
+								}
+							}
+							//item slot bitmask
+							if (focus_spell.max_value[i]) {
+								if (focus_spell.limit_value[i] != item->GetItem()->Slots) {
+									Shout("Fail Max");
+									return 0;
+								}
+							}
+							Shout("Item Passes");
+						}
+						else {
+							Shout("FAIL to find item.");
+						}
+					}
 				}
 				break;
 

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -5569,39 +5569,28 @@ int32 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				break;
 
 			case SE_FFItemClass: 
-				Shout("Check ITEM slot %i", casting_spell_inventory_slot);
 				if (casting_spell_inventory_slot && casting_spell_inventory_slot != -1){
-					Shout("Check ITEM slot %i ivnentory slot %i", casting_spell_inventory_slot, casting_spell_inventory_slot);
 					if (IsClient() && casting_spell_slot == EQ::spells::CastingSlot::Item && casting_spell_inventory_slot != 0xFFFFFFFF) {
 						auto item = CastToClient()->GetInv().GetItem(casting_spell_inventory_slot);
-											   
+						//ItemType
 						if (item && item->GetItem()) {
-							Shout("FOUND ITEM TYPE %i SUB %i SLOTS %i", item->GetItem()->ItemType, item->GetItem()->SubType, item->GetItem()->Slots);
-							Shout("Focus TYPE %i SUB %i SLOTS %i", focus_spell.base_value[i], focus_spell.limit_value[i], focus_spell.max_value[i]);
-							
 							if (focus_spell.base_value[i] >= 0) {//if this is set to a negative value (ie -1) allow any ItemType
 								if (focus_spell.base_value[i] != item->GetItem()->ItemType) {//this can be zero
-									Shout("Fail base");
 									return 0;
 								}
 							}
+							//SubType
 							if (focus_spell.limit_value[i]) { //this should not be zero
 								if (focus_spell.limit_value[i] != item->GetItem()->SubType) {
-									Shout("Fail limit");
 									return 0;
 								}
 							}
 							//item slot bitmask
 							if (focus_spell.max_value[i]) {
 								if (focus_spell.limit_value[i] != item->GetItem()->Slots) {
-									Shout("Fail Max");
 									return 0;
 								}
 							}
-							Shout("Item Passes");
-						}
-						else {
-							Shout("FAIL to find item.");
 						}
 					}
 				}

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -4928,7 +4928,7 @@ int32 Client::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 									}
 								}
 								//SubType (if set to -1, ignore and include any SubType)
-								if (base_value >= 0) {
+								if (limit_value >= 0) {
 									if (limit_value != item->GetItem()->SubType) {
 										include_this_item = false;
 									}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -425,16 +425,6 @@ bool Mob::DoCastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 			cast_time = GetActSpellCasttime(spell_id, cast_time);
 		}
 	}
-	else if (cast_time && IsClient() && slot == CastingSlot::Item && item_slot != 0xFFFFFFFF) {
-		Shout("From Items %i", cast_time);
-		orgcasttime = cast_time;
-		Shout("Cast time %i", cast_time);
-		// if there's a cast time, check if they have a modifier for it
-		if (cast_time) {
-			cast_time = GetActSpellCasttime(spell_id, cast_time);
-		}
-		Shout("Cast time %i", cast_time);
-	}
 	else
 		orgcasttime = cast_time;
 

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -425,6 +425,16 @@ bool Mob::DoCastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 			cast_time = GetActSpellCasttime(spell_id, cast_time);
 		}
 	}
+	else if (cast_time && IsClient() && slot == CastingSlot::Item && item_slot != 0xFFFFFFFF) {
+		Shout("From Items %i", cast_time);
+		orgcasttime = cast_time;
+		Shout("Cast time %i", cast_time);
+		// if there's a cast time, check if they have a modifier for it
+		if (cast_time) {
+			cast_time = GetActSpellCasttime(spell_id, cast_time);
+		}
+		Shout("Cast time %i", cast_time);
+	}
 	else
 		orgcasttime = cast_time;
 


### PR DESCRIPTION
Implemented SPA 415 SE_FFItemClass **Limits focuses to check if cast from item clicks. Can be used to INCLUDE or EXCLUDE items by ItemType and/or SubType and/or Slots**

This is a very powerful effect that can have a lot of creative uses. Most simply, if you don't want a specific focus effect being applied to items you can add this to it. But, interestingly if you want a focus effect that say ONLY applies to Shield slot click effect, or weapon slot click effects. For example you have a Custom warrior Breastplate with a click effect that gives 90 pct damage mitigation for 3 tics. You can make a custom focus on another item that extends ONLY that breastplates click focus to last 6 tics, by setting the SubType on your item to say the Item ID, and then setting focus limit to that same Item ID so the match. Now the focus will only effect the click on that specific breastplate.

Full description and examples
```
Limits focuses to check if cast from item clicks. Can be used to INCLUDE or EXCLUDE items by ItemType and/or SubType and/or Slots
	
Not used on live, going on information we have plus implemented as broadly as possible to allow all possible options.

base = item table field 'ItemType' Limit = item table field 'SubType' Max = item table field 'Slots' (this is slot bitmask)
					
When including: Setting base, limit, max respectively to -1 will cause it to ignore that check, letting any type or slot ect be used.
					
Special rules for excluding. base value needs to be negative < -1, if excluding all ItemTypes set to -1000. 
For SubType and Slots set using same rules above as for includes. Ie. -1 for all, positive for specifics
To exclude a specific ItemType we have to do some math. The exclude value will be the negative value of (ItemType + 100).
If ItemType = 10, then SET ItemType= -110 to exclude. If its ItemType 0, then SET ItemType= -100 to exclude ect. Not ideal but it works.
					
Usage example: [INCLUDE] Only focus spell if from click cast and is a 'defense armor' item type=10 [base= 10, limit= -1, max= -1]
Usage example: [INCLUDE] Only focus spell if from click cast and is from helmet slot' slots= 4     [base= -1, limit= -1, max= 4]
Usage example: [EXCLUDE] Do not focus spell if it is from an item click. [base= -1000, limit= -1, max= -1]
Usage example: [EXCLUDE] Do not focus spell if it is from an item click from a helmet slot. [base= -1000, limit= -1, max= 4]
Usage example: [EXCLUDE] Do not focus spell if it is from an item click and is a 'defense armor' item type=10. [base= -110, limit= -1, max= -1]

Note: You can apply multiple includes or excludes to a single focus spell,  using multiple SPA 415 limits in the spell. Ie. Check for clicks from ItemType 10 or 11.
```
			

```