### PR TITLE
[Commands] Cleanup #npcstats Command.

### DIFF
--- a/common/skills.cpp
+++ b/common/skills.cpp
@@ -177,8 +177,7 @@ bool EQ::skills::IsMeleeDmg(SkillType skill)
 
 const std::map<EQ::skills::SkillType, std::string>& EQ::skills::GetSkillTypeMap()
 {
-	/* VS2013 code
-	static const std::map<SkillUseTypes, std::string> skill_use_types_map = {
+	static const std::map<SkillType, std::string> skill_type_map = {
 		{ Skill1HBlunt, "1H Blunt" },
 		{ Skill1HSlashing, "1H Slashing" },
 		{ Skill2HBlunt, "2H Blunt" },
@@ -258,101 +257,20 @@ const std::map<EQ::skills::SkillType, std::string>& EQ::skills::GetSkillTypeMap(
 		{ SkillTripleAttack, "Triple Attack" },
 		{ Skill2HPiercing, "2H Piercing" }
 	};
-	*/
-
-	/* VS2012 code - begin */
-
-	static const char* skill_use_names[SkillCount] = {
-		"1H Blunt",
-		"1H Slashing",
-		"2H Blunt",
-		"2H Slashing",
-		"Abjuration",
-		"Alteration",
-		"Apply Poison",
-		"Archery",
-		"Backstab",
-		"Bind Wound",
-		"Bash",
-		"Block",
-		"Brass Instruments",
-		"Channeling",
-		"Conjuration",
-		"Defense",
-		"Disarm",
-		"Disarm Traps",
-		"Divination",
-		"Dodge",
-		"Double Attack",
-		"Dragon Punch",
-		"Dual Wield",
-		"Eagle Strike",
-		"Evocation",
-		"Feign Death",
-		"Flying Kick",
-		"Forage",
-		"Hand to Hand",
-		"Hide",
-		"Kick",
-		"Meditate",
-		"Mend",
-		"Offense",
-		"Parry",
-		"Pick Lock",
-		"1H Piercing",
-		"Riposte",
-		"Round Kick",
-		"Safe Fall",
-		"Sense Heading",
-		"Singing",
-		"Sneak",
-		"Specialize Abjuration",
-		"Specialize Alteration",
-		"Specialize Conjuration",
-		"Specialize Divination",
-		"Specialize Evocation",
-		"Pick Pockets",
-		"Stringed Instruments",
-		"Swimming",
-		"Throwing",
-		"Tiger Claw",
-		"Tracking",
-		"Wind Instruments",
-		"Fishing",
-		"Make Poison",
-		"Tinkering",
-		"Research",
-		"Alchemy",
-		"Baking",
-		"Tailoring",
-		"Sense Traps",
-		"Blacksmithing",
-		"Fletching",
-		"Brewing",
-		"Alcohol Tolerance",
-		"Begging",
-		"Jewelry Making",
-		"Pottery",
-		"Percussion Instruments",
-		"Intimidation",
-		"Berserking",
-		"Taunt",
-		"Frenzy",
-		"Remove Traps",
-		"Triple Attack",
-		"2H Piercing"
-	};
-
-	static std::map<SkillType, std::string> skill_type_map;
-
-	skill_type_map.clear();
-
-	for (int i = Skill1HBlunt; i < SkillCount; ++i)
-		skill_type_map[(SkillType)i] = skill_use_names[i];
-
-	/* VS2012 code - end */
-
 	return skill_type_map;
+}
+
+std::string EQ::skills::GetSkillName(SkillType skill)
+{
+	if (skill >= Skill1HBlunt && skill <= Skill2HPiercing) {
+		std::map<SkillType, std::string> skills = GetSkillTypeMap();
+		for (auto current_skill : skills) {
+			if (skill == current_skill.first) {
+				return current_skill.second;
+			}
+		}
+	}
+	return std::string();
 }
 
 EQ::SkillProfile::SkillProfile()

--- a/common/skills.h
+++ b/common/skills.h
@@ -171,6 +171,7 @@ namespace EQ
 
 		extern const std::map<SkillType, std::string>& GetSkillTypeMap();
 
+		std::string GetSkillName(SkillType skill);
 	} /*skills*/
 
 	struct SkillProfile { // prototype - not implemented

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -497,6 +497,25 @@ public:
 	uint32 GetRoamboxDelay() const;
 	uint32 GetRoamboxMinDelay() const;
 
+	inline uint8 GetArmTexture() { return armtexture; }
+	inline uint8 GetBracerTexture() { return bracertexture; }
+	inline uint8 GetHandTexture() { return handtexture; }
+	inline uint8 GetFeetTexture() { return feettexture; }
+	inline uint8 GetLegTexture() { return legtexture; }
+
+	inline int GetCharmedAccuracy() { return charm_accuracy_rating; }
+	inline int GetCharmedArmorClass() { return charm_ac; }
+	inline int GetCharmedAttack() { return charm_atk; }
+	inline int GetCharmedAttackDelay() { return charm_attack_delay; }
+	inline int GetCharmedAvoidance() { return charm_avoidance_rating; }
+	inline int GetCharmedMaxDamage() { return charm_max_dmg; }
+	inline int GetCharmedMinDamage() { return charm_min_dmg; }
+
+	inline bool GetAlwaysAggro() { return always_aggro; }
+	inline bool GetNPCAggro() { return npc_aggro; }
+	inline bool GetIgnoreDespawn() { return ignore_despawn; }
+	inline bool GetSkipGlobalLoot() { return skip_global_loot; }
+
 	std::unique_ptr<Timer> AIautocastspell_timer;
 
 	virtual int GetStuckBehavior() const { return NPCTypedata_ours ? NPCTypedata_ours->stuck_behavior : NPCTypedata->stuck_behavior; }

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -1012,15 +1012,7 @@ std::string QuestManager::getspellname(uint32 spell_id) {
 }
 
 std::string QuestManager::getskillname(int skill_id) {
-	if (skill_id >= 0 && skill_id < EQ::skills::SkillCount) {
-		std::map<EQ::skills::SkillType, std::string> Skills = EQ::skills::GetSkillTypeMap();
-		for (auto skills_iter : Skills) {
-			if (skill_id == skills_iter.first) {
-				return skills_iter.second;
-			}
-		}
-	}
-	return std::string();
+	return EQ::skills::GetSkillName(static_cast<EQ::skills::SkillType>(skill_id));
 }
 
 void QuestManager::safemove() {

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -3981,6 +3981,22 @@ bool ZoneDatabase::GetFactionName(int32 faction_id, char* name, uint32 buflen) {
 
 }
 
+std::string ZoneDatabase::GetFactionName(int32 faction_id)
+{
+	std::string faction_name;
+	if (
+		faction_id <= 0 ||
+		 faction_id > static_cast<int>(max_faction) ||
+		 !faction_array[faction_id]
+	) {
+		return faction_name;
+	}
+
+	faction_name = faction_array[faction_id]->name;
+
+	return faction_name;
+}
+
 //o--------------------------------------------------------------
 //| Name: GetNPCFactionList; Dec. 16, 2001
 //o--------------------------------------------------------------

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -403,6 +403,7 @@ public:
 	bool		GetNPCFactionList(uint32 npcfaction_id, int32* faction_id, int32* value, uint8* temp, int32* primary_faction = 0);
 	bool		GetFactionData(FactionMods* fd, uint32 class_mod, uint32 race_mod, uint32 deity_mod, int32 faction_id); //needed for factions Dec, 16 2001
 	bool		GetFactionName(int32 faction_id, char* name, uint32 buflen); // needed for factions Dec, 16 2001
+	std::string GetFactionName(int32 faction_id);
 	bool		GetFactionIdsForNPC(uint32 nfl_id, std::list<struct NPCFaction*> *faction_list, int32* primary_faction = 0); // improve faction handling
 	bool		SetCharacterFactionLevel(uint32 char_id, int32 faction_id, int32 value, uint8 temp, faction_map &val_list); // needed for factions Dec, 16 2001
 	bool		LoadFactionData();


### PR DESCRIPTION
- Cleanup menu and add stats that were not there before.
- Only display some data if necessary (i.e only show loot/money if they have loot/money)
- Add skill name helper method.
- Add faction name helper method.
- Add Charmed stats and other getter methods.
- Cleanup npc->QueryLoot() method.
![image](https://user-images.githubusercontent.com/89047260/140658151-9106d7d4-a8e0-4975-9557-4ee968be84e8.png)