### PR TITLE
[Rules] Add Resurrection Sickness rules for Characters/Bots.

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -169,6 +169,8 @@ RULE_BOOL(Character, PVPEnableGuardFactionAssist, true, "Enables faction based a
 RULE_BOOL(Character, SkillUpFromItems, true, "Allow Skill ups from clickable items")
 RULE_BOOL(Character, EnableTestBuff, false, "Allow the use of /testbuff")
 RULE_BOOL(Character, UseResurrectionSickness, true, "Use Resurrection Sickness based on Resurrection spell cast, set to false to disable Resurrection Sickness.")
+RULE_INT(Character, OldResurrectionSicknessSpellID, 757, "757 is Default Old Resurrection Sickness Spell ID")
+RULE_INT(Character, ResurrectionSicknessSpellID, 756, "756 is Default Resurrection Sickness Spell ID")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Mercs)
@@ -589,6 +591,8 @@ RULE_BOOL(Bots, AllowApplyPotionCommand, true, "Allows the use of the bot comman
 RULE_BOOL(Bots, RestrictApplyPotionToRogue, true, "Restricts the bot command 'applypotion' to rogue-usable potions (i.e., poisons)")
 RULE_BOOL(Bots, OldRaceRezEffects, false, "Older clients had ID 757 for races with high starting STR, but it doesn't seem used anymore")
 RULE_BOOL(Bots, ResurrectionSickness, true, "Use Resurrection Sickness based on Resurrection spell cast, set to false to disable Resurrection Sickness.")
+RULE_INT(Bots, OldResurrectionSicknessSpell, 757, "757 is Default Old Resurrection Sickness Spell")
+RULE_INT(Bots, ResurrectionSicknessSpell, 756, "756 is Default Resurrection Sickness Spell")
 RULE_CATEGORY_END()
 #endif
 

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -168,6 +168,7 @@ RULE_BOOL(Character, EnableCharacterEXPMods, false, "Enables character zone-base
 RULE_BOOL(Character, PVPEnableGuardFactionAssist, true, "Enables faction based assisting against the aggresor in pvp.")
 RULE_BOOL(Character, SkillUpFromItems, true, "Allow Skill ups from clickable items")
 RULE_BOOL(Character, EnableTestBuff, false, "Allow the use of /testbuff")
+RULE_BOOL(Character, UseResurrectionSickness, true, "Use Resurrection Sickness based on Resurrection spell cast, set to false to disable Resurrection Sickness.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Mercs)
@@ -586,6 +587,8 @@ RULE_REAL(Bots, LeashDistance, 562500.0f, "Distance a bot is allowed to travel f
 RULE_BOOL(Bots, AllowApplyPoisonCommand, true, "Allows the use of the bot command 'applypoison'")
 RULE_BOOL(Bots, AllowApplyPotionCommand, true, "Allows the use of the bot command 'applypotion'")
 RULE_BOOL(Bots, RestrictApplyPotionToRogue, true, "Restricts the bot command 'applypotion' to rogue-usable potions (i.e., poisons)")
+RULE_BOOL(Bots, OldRaceRezEffects, false, "Older clients had ID 757 for races with high starting STR, but it doesn't seem used anymore")
+RULE_BOOL(Bots, ResurrectionSickness, true, "Use Resurrection Sickness based on Resurrection spell cast, set to false to disable Resurrection Sickness.")
 RULE_CATEGORY_END()
 #endif
 

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -406,8 +406,8 @@ Bot::Bot(uint32 botID, uint32 botOwnerCharacterID, uint32 botSpellsID, double to
 				GetRace() == TROLL ||
 				GetRace() == OGRE
 			) ? 
-			SPELL_RESURRECTION_SICKNESS4 :
-			SPELL_RESURRECTION_SICKNESS
+			RuleI(Bots, OldResurrectionSicknessSpell) :
+			RuleI(Bots, ResurrectionSicknessSpell)
 		);
 		SetMana(0);
 		SetHP(max_hp / 5);

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -397,22 +397,27 @@ Bot::Bot(uint32 botID, uint32 botOwnerCharacterID, uint32 botSpellsID, double to
 	if(current_hp > max_hp)
 		current_hp = max_hp;
 
-	if(RuleB(Bots, ResurrectionSickness) && current_hp <= 0) {
-		int resurrection_sickness_spell_id = (
-			RuleB(Bots, OldRaceRezEffects) &&
-		    (
-				GetRace() == BARBARIAN ||
-				GetRace() == DWARF ||
-				GetRace() == TROLL ||
-				GetRace() == OGRE
-			) ? 
-			RuleI(Bots, OldResurrectionSicknessSpell) :
-			RuleI(Bots, ResurrectionSicknessSpell)
-		);
-		SetMana(0);
-		SetHP(max_hp / 5);
+	if(current_hp <= 0) {
 		BuffFadeNonPersistDeath();
-		SpellOnTarget(resurrection_sickness_spell_id, this); // Rezz effects
+		if (RuleB(Bots, ResurrectionSickness)) {
+			int resurrection_sickness_spell_id = (
+				RuleB(Bots, OldRaceRezEffects) &&
+				(
+					GetRace() == BARBARIAN ||
+					GetRace() == DWARF ||
+					GetRace() == TROLL ||
+					GetRace() == OGRE
+				) ? 
+				RuleI(Bots, OldResurrectionSicknessSpell) :
+				RuleI(Bots, ResurrectionSicknessSpell)
+			);
+			SetHP(max_hp / 5);
+			SetMana(0);
+			SpellOnTarget(resurrection_sickness_spell_id, this); // Rezz effects
+		} else {
+			SetHP(GetMaxHP());
+			SetMana(GetMaxMana());
+		}
 	}
 
 	if(current_mana > max_mana)

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -397,11 +397,22 @@ Bot::Bot(uint32 botID, uint32 botOwnerCharacterID, uint32 botSpellsID, double to
 	if(current_hp > max_hp)
 		current_hp = max_hp;
 
-	if(current_hp <= 0) {
-		SetHP(max_hp/5);
+	if(RuleB(Bots, ResurrectionSickness) && current_hp <= 0) {
+		int resurrection_sickness_spell_id = (
+			RuleB(Bots, OldRaceRezEffects) &&
+		    (
+				GetRace() == BARBARIAN ||
+				GetRace() == DWARF ||
+				GetRace() == TROLL ||
+				GetRace() == OGRE
+			) ? 
+			SPELL_RESURRECTION_SICKNESS4 :
+			SPELL_RESURRECTION_SICKNESS
+		);
 		SetMana(0);
-		BuffFadeAll();
-		SpellOnTarget(756, this); // Rezz effects
+		SetHP(max_hp / 5);
+		BuffFadeNonPersistDeath();
+		SpellOnTarget(resurrection_sickness_spell_id, this); // Rezz effects
 	}
 
 	if(current_mana > max_mana)

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -985,8 +985,8 @@ void Client::OPRezzAnswer(uint32 Action, uint32 SpellID, uint16 ZoneID, uint16 I
 		int SpellEffectDescNum = GetSpellEffectDescNum(SpellID);
 		// Rez spells with Rez effects have this DescNum (first is Titanium, second is 6.2 Client)
 		if(RuleB(Character, UseResurrectionSickness) && SpellEffectDescNum == 82 || SpellEffectDescNum == 39067) {
-			SetMana(0);
 			SetHP(GetMaxHP() / 5);
+			SetMana(0);
 			int resurrection_sickness_spell_id = (
 				RuleB(Character, UseOldRaceRezEffects) &&
 			    (
@@ -1001,8 +1001,8 @@ void Client::OPRezzAnswer(uint32 Action, uint32 SpellID, uint16 ZoneID, uint16 I
 			SpellOnTarget(resurrection_sickness_spell_id, this); // Rezz effects
 		}
 		else {
-			SetMana(GetMaxMana());
 			SetHP(GetMaxHP());
+			SetMana(GetMaxMana());
 		}
 		if(spells[SpellID].base_value[0] < 100 && spells[SpellID].base_value[0] > 0 && PendingRezzXP > 0)
 		{

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -995,8 +995,8 @@ void Client::OPRezzAnswer(uint32 Action, uint32 SpellID, uint16 ZoneID, uint16 I
 					GetRace() == TROLL ||
 					GetRace() == OGRE
 				) ? 
-				SPELL_RESURRECTION_SICKNESS4 :
-				SPELL_RESURRECTION_SICKNESS
+				RuleI(Character, OldResurrectionSicknessSpellID) :
+				RuleI(Character, ResurrectionSicknessSpellID)
 			);
 			SpellOnTarget(resurrection_sickness_spell_id, this); // Rezz effects
 		}

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -981,7 +981,7 @@ void Client::OPRezzAnswer(uint32 Action, uint32 SpellID, uint16 ZoneID, uint16 I
 				this->name, (uint16)spells[SpellID].base_value[0],
 				SpellID, ZoneID, InstanceID);
 
-		this->BuffFadeNonPersistDeath();
+		BuffFadeNonPersistDeath();
 		int SpellEffectDescNum = GetSpellEffectDescNum(SpellID);
 		// Rez spells with Rez effects have this DescNum (first is Titanium, second is 6.2 Client)
 		if(RuleB(Character, UseResurrectionSickness) && SpellEffectDescNum == 82 || SpellEffectDescNum == 39067) {

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -984,14 +984,21 @@ void Client::OPRezzAnswer(uint32 Action, uint32 SpellID, uint16 ZoneID, uint16 I
 		this->BuffFadeNonPersistDeath();
 		int SpellEffectDescNum = GetSpellEffectDescNum(SpellID);
 		// Rez spells with Rez effects have this DescNum (first is Titanium, second is 6.2 Client)
-		if((SpellEffectDescNum == 82) || (SpellEffectDescNum == 39067)) {
+		if(RuleB(Character, UseResurrectionSickness) && SpellEffectDescNum == 82 || SpellEffectDescNum == 39067) {
 			SetMana(0);
-			SetHP(GetMaxHP()/5);
-			int rez_eff = 756;
-			if (RuleB(Character, UseOldRaceRezEffects) &&
-			    (GetRace() == BARBARIAN || GetRace() == DWARF || GetRace() == TROLL || GetRace() == OGRE))
-				rez_eff = 757;
-			SpellOnTarget(rez_eff, this); // Rezz effects
+			SetHP(GetMaxHP() / 5);
+			int resurrection_sickness_spell_id = (
+				RuleB(Character, UseOldRaceRezEffects) &&
+			    (
+					GetRace() == BARBARIAN ||
+					GetRace() == DWARF ||
+					GetRace() == TROLL ||
+					GetRace() == OGRE
+				) ? 
+				SPELL_RESURRECTION_SICKNESS4 :
+				SPELL_RESURRECTION_SICKNESS
+			);
+			SpellOnTarget(resurrection_sickness_spell_id, this); // Rezz effects
 		}
 		else {
 			SetMana(GetMaxMana());


### PR DESCRIPTION
- Add RULE_BOOL(Character, UseResurrectionSickness, true, "Use Resurrection Sickness based on Resurrection spell cast, set to false to disable Resurrection Sickness.")
- Add RULE_INT(Character, OldResurrectionSicknessSpellID, 757, "757 is Default Old Resurrection Sickness Spell ID")
- Add RULE_INT(Character, ResurrectionSicknessSpellID, 756, "756 is Default Resurrection Sickness Spell ID")
- Add RULE_BOOL(Bots, OldRaceRezEffects, false, "Older clients had ID 757 for races with high starting STR, but it doesn't seem used anymore")
- Add RULE_BOOL(Bots, ResurrectionSickness, true, "Use Resurrection Sickness based on Resurrection spell cast, set to false to disable Resurrection Sickness.")
- Add RULE_INT(Bots, OldResurrectionSicknessSpell, 757, "757 is Default Old Resurrection Sickness Spell")
- Add RULE_INT(Bots, ResurrectionSicknessSpell, 756, "756 is Default Resurrection Sickness Spell")
- Change BuffFadeAll() on Bot death to BuffFadeNonPersistDeath().