### PR TITLE
[Bug Fix] Prevent critical DOTs from affecting beneficial damage over time

### DIFF
--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -212,6 +212,10 @@ int32 Mob::GetActDoTDamage(uint16 spell_id, int32 value, Mob* target) {
 	if (spells[spell_id].override_crit_chance > 0 && chance > spells[spell_id].override_crit_chance)
 		chance = spells[spell_id].override_crit_chance;
 
+	if (spells[spell_id].good_effect == 0) {
+		chance = 0; //Beneficial damage over time, such as necro Lich line should not critical.
+	}
+
 	if (chance > 0 && (zone->random.Roll(chance))) {
 		int32 ratio = 200;
 		ratio += itembonuses.DotCritDmgIncrease + spellbonuses.DotCritDmgIncrease + aabonuses.DotCritDmgIncrease;

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -212,11 +212,7 @@ int32 Mob::GetActDoTDamage(uint16 spell_id, int32 value, Mob* target) {
 	if (spells[spell_id].override_crit_chance > 0 && chance > spells[spell_id].override_crit_chance)
 		chance = spells[spell_id].override_crit_chance;
 
-	if (spells[spell_id].good_effect == 0) {
-		chance = 0; //Beneficial damage over time, such as necro Lich line should not critical.
-	}
-
-	if (chance > 0 && (zone->random.Roll(chance))) {
+	if (!spells[spell_id].good_effect && chance > 0 && (zone->random.Roll(chance))) {
 		int32 ratio = 200;
 		ratio += itembonuses.DotCritDmgIncrease + spellbonuses.DotCritDmgIncrease + aabonuses.DotCritDmgIncrease;
 		value = base_value*ratio/100;


### PR DESCRIPTION
As far as I can tell on live, damage over time critical hits do not apply to beneficial DOT effects like necromancer Lich spell line.