### PR TITLE
[Commands] Cleanup #zonelock Command.

### DIFF
--- a/common/emu_constants.h
+++ b/common/emu_constants.h
@@ -254,7 +254,7 @@ namespace EQ
 			GMMgmt = 200,
 			GMImpossible = 250
 			Max = 255
-		}
+		};
 	} /*constants*/
 
 	namespace profile {

--- a/common/emu_constants.h
+++ b/common/emu_constants.h
@@ -252,7 +252,7 @@ namespace EQ
 			GMAreas = 170,
 			GMCoder = 180,
 			GMMgmt = 200,
-			GMImpossible = 250
+			GMImpossible = 250,
 			Max = 255
 		};
 	} /*constants*/

--- a/common/emu_constants.h
+++ b/common/emu_constants.h
@@ -230,6 +230,11 @@ namespace EQ
 		const int STANCE_TYPE_LAST = stanceBurnAE;
 		const int STANCE_TYPE_COUNT = stanceBurnAE;
 
+		enum ServerLockType : int {
+			List,
+			Lock,
+			Unlock
+		};
 	} /*constants*/
 
 	namespace profile {

--- a/common/emu_constants.h
+++ b/common/emu_constants.h
@@ -235,6 +235,26 @@ namespace EQ
 			Lock,
 			Unlock
 		};
+
+		enum AccountStatus : uint8 {
+			Player = 0,
+			Steward = 10,
+			ApprenticeGuide = 20,
+			Guide = 50,
+			QuestTroupe = 80,
+			SeniorGuide = 81,
+			GMTester = 85,
+			EQSupport = 90,
+			GMStaff = 95,
+			GMAdmin = 100,
+			GMLeadAdmin = 150,
+			QuestMaster = 160,
+			GMAreas = 170,
+			GMCoder = 180,
+			GMMgmt = 200,
+			GMImpossible = 250
+			Max = 255
+		}
 	} /*constants*/
 
 	namespace profile {

--- a/world/world_store.cpp
+++ b/world/world_store.cpp
@@ -87,6 +87,26 @@ std::string WorldStore::GetZoneName(uint32 zone_id)
 
 /**
  * @param zone_id
+ * @param error_unknown
+ * @return
+ */
+const char *WorldStore::GetZoneLongName(uint32 zone_id, bool error_unknown)
+{
+	for (auto &z: zones) {
+		if (z.zoneidnumber == zone_id) {
+			return z.long_name.c_str();
+		}
+	}
+
+	if (error_unknown) {
+		return "UNKNOWN";
+	}
+
+	return nullptr;
+}
+
+/**
+ * @param zone_id
  * @return
  */
 std::string WorldStore::GetZoneLongName(uint32 zone_id)

--- a/world/world_store.h
+++ b/world/world_store.h
@@ -40,7 +40,7 @@ public:
 	std::string GetZoneName(uint32 zone_id);
 	std::string GetZoneLongName(uint32 zone_id);
 	const char *GetZoneName(uint32 zone_id, bool error_unknown = false);
-
+	const char *GetZoneLongName(uint32 zone_id, bool error_unknown = false);
 };
 
 extern WorldStore world_store;
@@ -57,7 +57,13 @@ inline const char *ZoneName(uint32 zone_id, bool error_unknown = false)
 		error_unknown
 	);
 }
-inline const char *ZoneLongName(uint32 zone_id) { return world_store.GetZoneLongName(zone_id).c_str(); }
+inline const char *ZoneLongName(uint32 zone_id, bool error_unknown = false)
+{
+	return world_store.GetZoneLongName(
+		zone_id,
+		error_unknown
+	);
+}
 inline ZoneRepository::Zone GetZone(uint32 zone_id, int version = 0) { return world_store.GetZone(zone_id, version); };
 inline ZoneRepository::Zone GetZone(const char *in_zone_name) { return world_store.GetZone(in_zone_name); };
 

--- a/world/zonelist.cpp
+++ b/world/zonelist.cpp
@@ -277,7 +277,7 @@ void ZSList::ListLockedZones(const char* to, WorldTCPConnection* connection) {
 			connection->SendEmoteMessageRaw(
 				to,
 				0,
-				0,
+				EQ::constants::AccountStatus::Player,
 				Chat::White,
 				fmt::format(
 					"Zone {} | Name: {} ({}) ID: {}",
@@ -299,7 +299,7 @@ void ZSList::ListLockedZones(const char* to, WorldTCPConnection* connection) {
 	connection->SendEmoteMessage(
 		to,
 		0,
-		0,
+		EQ::constants::AccountStatus::Player,
 		Chat::White,
 		zone_message.c_str()
 	);

--- a/world/zonelist.cpp
+++ b/world/zonelist.cpp
@@ -270,14 +270,39 @@ bool ZSList::IsZoneLocked(uint16 iZoneID) {
 }
 
 void ZSList::ListLockedZones(const char* to, WorldTCPConnection* connection) {
-	int x = 0;
-	for (auto &zone : pLockedZones) {
-		if (zone) {
-			connection->SendEmoteMessageRaw(to, 0, 0, 0, ZoneName(zone, true));
-			x++;
+	int zone_count = 0;
+	for (const auto& zone_id : pLockedZones) {
+		if (zone_id) {
+			int zone_number = (zone_count + 1);
+			connection->SendEmoteMessageRaw(
+				to,
+				0,
+				0,
+				Chat::White,
+				fmt::format(
+					"Zone {} | Name: {} ({}) ID: {}",
+					zone_number,
+					ZoneLongName(zone_id),
+					ZoneName(zone_id),
+					zone_id
+				).c_str()
+			);
+			zone_count++;
 		}
 	}
-	connection->SendEmoteMessage(to, 0, 0, 0, "%i zones locked.", x);
+
+	std::string zone_message = (
+		zone_count ?
+		fmt::format("{} Zones are locked.", zone_count) :
+		"There are no zones locked."
+	);
+	connection->SendEmoteMessage(
+		to,
+		0,
+		0,
+		Chat::White,
+		zone_message.c_str()
+	);
 }
 
 void ZSList::SendZoneStatus(const char* to, int16 admin, WorldTCPConnection* connection) {

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -1035,7 +1035,7 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 				zoneserver_list.SendEmoteMessage(
 					0,
 					0,
-					80,
+					EQ::constants::AccountStatus::QuestTroupe,
 					Chat::White,
 					fmt::format(
 						"Zone {} | Name: {} ({}) ID: {}",
@@ -1049,7 +1049,7 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 				SendEmoteMessageRaw(
 					lock_zone->adminname,
 					0,
-					0,
+					EQ::constants::AccountStatus::Player,
 					Chat::White,
 					fmt::format(
 						"Zone Failed to {} | Name: {} ({}) ID: {}",

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -1022,22 +1022,44 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 			LogInfo("Wrong size on ServerOP_LockZone. Got: [{}], Expected: [{}]", pack->size, sizeof(ServerLockZone_Struct));
 			break;
 		}
-		ServerLockZone_Struct* s = (ServerLockZone_Struct*)pack->pBuffer;
-		switch (s->op) {
-		case 0:
-			zoneserver_list.ListLockedZones(s->adminname, this);
+
+		ServerLockZone_Struct* lock_zone = (ServerLockZone_Struct*) pack->pBuffer;
+		if (lock_zone->op == EQ::constants::ServerLockType::List) {
+			zoneserver_list.ListLockedZones(lock_zone->adminname, this);
 			break;
-		case 1:
-			if (zoneserver_list.SetLockedZone(s->zoneID, true))
-				zoneserver_list.SendEmoteMessage(0, 0, 80, 15, "Zone locked: %s", ZoneName(s->zoneID));
-			else
-				this->SendEmoteMessageRaw(s->adminname, 0, 0, 0, "Failed to change lock");
-			break;
-		case 2:
-			if (zoneserver_list.SetLockedZone(s->zoneID, false))
-				zoneserver_list.SendEmoteMessage(0, 0, 80, 15, "Zone unlocked: %s", ZoneName(s->zoneID));
-			else
-				this->SendEmoteMessageRaw(s->adminname, 0, 0, 0, "Failed to change lock");
+		} else if (
+			lock_zone->op == EQ::constants::ServerLockType::Lock ||
+			lock_zone->op == EQ::constants::ServerLockType::Unlock
+		) {
+			if (zoneserver_list.SetLockedZone(lock_zone->zoneID, lock_zone->op == EQ::constants::ServerLockType::Lock)) {
+				zoneserver_list.SendEmoteMessage(
+					0,
+					0,
+					80,
+					Chat::White,
+					fmt::format(
+						"Zone {} | Name: {} ({}) ID: {}",
+						lock_zone->op == EQ::constants::ServerLockType::Lock ? "Locked" : "Unlocked",
+						ZoneLongName(lock_zone->zoneID),
+						ZoneName(lock_zone->zoneID),
+						lock_zone->zoneID
+					).c_str()
+				);
+			} else {
+				SendEmoteMessageRaw(
+					lock_zone->adminname,
+					0,
+					0,
+					Chat::White,
+					fmt::format(
+						"Zone Failed to {} | Name: {} ({}) ID: {}",
+						lock_zone->op == EQ::constants::ServerLockType::Lock ? "Lock" : "Unlock",
+						ZoneLongName(lock_zone->zoneID),
+						ZoneName(lock_zone->zoneID),
+						lock_zone->zoneID
+					).c_str()
+				);
+			}
 			break;
 		}
 		break;

--- a/world/zoneserver.h
+++ b/world/zoneserver.h
@@ -22,13 +22,13 @@
 #include "../common/net/servertalk_server.h"
 #include "../common/event/timer.h"
 #include "../common/timer.h"
+#include "../common/emu_constants.h"
 #include "console.h"
 #include <string.h>
 #include <string>
 
 class Client;
 class ServerPacket;
-
 
 class ZoneServer : public WorldTCPConnection {
 public:

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -5658,11 +5658,11 @@ void command_zonelock(Client *c, const Seperator *sep)
 	}
 	
 	auto pack = new ServerPacket(ServerOP_LockZone, sizeof(ServerLockZone_Struct));
-	ServerLockZone_Struct* s = (ServerLockZone_Struct*) pack->pBuffer;
-	strn0cpy(s->adminname, c->GetName(), sizeof(s->adminname));
+	ServerLockZone_Struct* lock_zone = (ServerLockZone_Struct*) pack->pBuffer;
+	strn0cpy(lock_zone->adminname, c->GetName(), sizeof(lock_zone->adminname));
 	
 	if (is_list) {
-		s->op = EQ::constants::ServerLockType::List;
+		lock_zone->op = EQ::constants::ServerLockType::List;
 		worldserver.SendPacket(pack);
 	} else if (!is_list && c->Admin() >= commandLockZones) {		
 		auto zone_id = (
@@ -5673,8 +5673,8 @@ void command_zonelock(Client *c, const Seperator *sep)
 		std::string zone_short_name = str_tolower(ZoneName(zone_id, true));
 		bool is_unknown_zone = zone_short_name.find("unknown") != std::string::npos;
 		if (zone_id && !is_unknown_zone) {
-			s->op = is_lock ? EQ::constants::ServerLockType::Lock : EQ::constants::ServerLockType::Unlock;
-			s->zoneID = zone_id;
+			lock_zone->op = is_lock ? EQ::constants::ServerLockType::Lock : EQ::constants::ServerLockType::Unlock;
+			lock_zone->zoneID = zone_id;
 			worldserver.SendPacket(pack);
 		} else {
 			c->Message(

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -5667,7 +5667,7 @@ void command_zonelock(Client *c, const Seperator *sep)
 	} else if (!is_list && c->Admin() >= commandLockZones) {		
 		auto zone_id = (
 			sep->IsNumber(2) ?
-			static_cast<uint16>(sep->arg[2]) :
+			static_cast<uint16>(std::stoul(sep->arg[2])) :
 			static_cast<uint16>(ZoneID(sep->arg[2]))
 		);
 		std::string zone_short_name = str_tolower(ZoneName(zone_id, true));


### PR DESCRIPTION
- Add support for Zone IDs.
- Cleanup messages and display.
- Fix dangling pointer in ZoneLongName() helper method so name is displayed properly.
![image](https://user-images.githubusercontent.com/89047260/141384654-2a92f745-a79b-4056-8dbb-31e192263c45.png)
![image](https://user-images.githubusercontent.com/89047260/141384658-824b0a95-54e6-4894-9e99-84ce62114d99.png)