### PR TITLE
[Spells] Fixed proc rate for Ranged procs

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -4136,7 +4136,7 @@ void Mob::TryDefensiveProc(Mob *on, uint16 hand) {
 		float ProcChance, ProcBonus;
 		on->GetDefensiveProcChances(ProcBonus, ProcChance, hand, this);
 
-		if (hand != EQ::invslot::slotPrimary) {
+		if (hand == EQ::invslot::slotSecondary) {
 			ProcChance /= 2;
 		}
 
@@ -4238,7 +4238,7 @@ void Mob::TryWeaponProc(const EQ::ItemInstance *inst, const EQ::ItemData *weapon
 	ProcBonus += static_cast<float>(itembonuses.ProcChance) / 10.0f; // Combat Effects
 	float ProcChance = GetProcChances(ProcBonus, hand);
 
-	if (hand != EQ::invslot::slotPrimary) //Is Archery intened to proc at 50% rate?
+	if (hand == EQ::invslot::slotSecondary)
 		ProcChance /= 2;
 
 	// Try innate proc on weapon
@@ -4321,7 +4321,7 @@ void Mob::TrySpellProc(const EQ::ItemInstance *inst, const EQ::ItemData *weapon,
 	float ProcChance = 0.0f;
 	ProcChance = GetProcChances(ProcBonus, hand);
 
-	if (hand != EQ::invslot::slotPrimary) //Is Archery intened to proc at 50% rate?
+	if (hand == EQ::invslot::slotSecondary)
 		ProcChance /= 2;
 
 	bool rangedattk = false;
@@ -5216,7 +5216,7 @@ float Mob::GetSkillProcChances(uint16 ReuseTime, uint16 hand) {
 	if (!ReuseTime && hand) {
 		weapon_speed = GetWeaponSpeedbyHand(hand);
 		ProcChance = static_cast<float>(weapon_speed) * (RuleR(Combat, AvgProcsPerMinute) / 60000.0f);
-		if (hand != EQ::invslot::slotPrimary)
+		if (hand == EQ::invslot::slotSecondary)
 			ProcChance /= 2;
 	}
 


### PR DESCRIPTION
Ranged procs were receiving a 50 pct reduction in proc rate chance due to what I think was an oversite when ranged procs were implemented. It was getting the reduction meant for offhand attacks which checked for anything that wasn't primary slot, which is probably how the code was before the ranged procs went in.

I took the time to parse this on live and found no significant difference between primary hand melee spell proc rate and ranged spell proc rate. Thus confident this is correct.

Conclusion: Ranged Procs should proc 2x as often now.