### PR TITLE
[Commands] Remove #testspawn and #testspawnkill Commands.

### DIFF
--- a/zone/command.h
+++ b/zone/command.h
@@ -318,8 +318,6 @@ void command_task(Client *c, const Seperator *sep);
 void command_tattoo(Client *c, const Seperator *sep);
 void command_tempname(Client *c, const Seperator *sep);
 void command_petname(Client *c, const Seperator *sep);
-void command_testspawn(Client *c, const Seperator *sep);
-void command_testspawnkill(Client *c, const Seperator *sep);
 void command_texture(Client *c, const Seperator *sep);
 void command_time(Client *c, const Seperator *sep);
 void command_timers(Client *c, const Seperator *sep);


### PR DESCRIPTION
- Remove unused commands.