### PR TITLE
[Bug Fix] Fix underscores in Loginserver Error String Identifiers.

### DIFF
--- a/loginserver/login_types.h
+++ b/loginserver/login_types.h
@@ -128,14 +128,14 @@ namespace LS {
 		Legends   = 1,
 	};
 
-	namespace ErrStr {
-		constexpr static int NO_ERROR                    = 101; // No Error
-		constexpr static int SERVER_UNAVAILABLE          = 326; // That server is currently unavailable.  Please check the EverQuest webpage for current server status and try again later.
-		constexpr static int ACCOUNT_SUSPENDED           = 337; // This account is currently suspended.  Please contact customer service for more information.
-		constexpr static int ACCOUNT_BANNED              = 338; // This account is currently banned.  Please contact customer service for more information.
-		constexpr static int WORLD_MAX_CAPACITY          = 339; // The world server is currently at maximum capacity and not allowing further logins until the number of players online decreases.  Please try again later.
-		constexpr static int ERROR_1018_ACTIVE_CHARACTER = 111; // Error 1018: You currently have an active character on that EverQuest Server, please allow a minute for synchronization and try again.
-		constexpr static int UNKNOWN_ERROR               = 102; // Error - Unknown Error Occurred
+	enum ErrorString {
+		NoError = 101, // No Error
+		UnknownError = 102, // Error - Unknown Error Occurred
+		CharacterAlreadyOnline = 111, // Error 1018: You currently have an active character on that EverQuest Server, please allow a minute for synchronization and try again.
+		WorldUnavailabe = 326, // That server is currently unavailable.  Please check the EverQuest webpage for current server status and try again later.
+		StatusSuspended = 337, // This account is currently suspended.  Please contact customer service for more information.
+		StatusBanned = 338, // This account is currently banned.  Please contact customer service for more information.
+		WorldMaxCapacity = 339 // The world server is currently at maximum capacity and not allowing further logins until the number of players online decreases.  Please try again later.
 	};
 }
 

--- a/loginserver/world_server.cpp
+++ b/loginserver/world_server.cpp
@@ -232,25 +232,26 @@ void WorldServer::ProcessUserToWorldResponseLegacy(uint16_t opcode, const EQ::Ne
 
 		switch (r->response) {
 			case UserToWorldStatusSuccess:
-				per->base_reply.error_str_id = LS::ErrStr::NO_ERROR;
+				per->base_reply.error_str_id = LS::ErrorString::NoError;
 				break;
 			case UserToWorldStatusWorldUnavail:
-				per->base_reply.error_str_id = LS::ErrStr::SERVER_UNAVAILABLE;
+				per->base_reply.error_str_id = LS::ErrorString::WorldUnavailabe;
 				break;
 			case UserToWorldStatusSuspended:
-				per->base_reply.error_str_id = LS::ErrStr::ACCOUNT_SUSPENDED;
+				per->base_reply.error_str_id = LS::ErrorString::StatusSuspended;
 				break;
 			case UserToWorldStatusBanned:
-				per->base_reply.error_str_id = LS::ErrStr::ACCOUNT_BANNED;
+				per->base_reply.error_str_id = LS::ErrorString::StatusBanned;
 				break;
 			case UserToWorldStatusWorldAtCapacity:
-				per->base_reply.error_str_id = LS::ErrStr::WORLD_MAX_CAPACITY;
+				per->base_reply.error_str_id = LS::ErrorString::WorldMaxCapacity;
 				break;
 			case UserToWorldStatusAlreadyOnline:
-				per->base_reply.error_str_id = LS::ErrStr::ERROR_1018_ACTIVE_CHARACTER;
+				per->base_reply.error_str_id = LS::ErrorString::CharacterAlreadyOnline;
 				break;
 			default:
-				per->base_reply.error_str_id = LS::ErrStr::UNKNOWN_ERROR;
+				per->base_reply.error_str_id = LS::ErrorString::UnknownError;
+				break;
 		}
 
 		if (server.options.IsWorldTraceOn()) {
@@ -358,25 +359,26 @@ void WorldServer::ProcessUserToWorldResponse(uint16_t opcode, const EQ::Net::Pac
 
 		switch (user_to_world_response->response) {
 			case UserToWorldStatusSuccess:
-				per->base_reply.error_str_id = LS::ErrStr::NO_ERROR;
+				per->base_reply.error_str_id = LS::ErrorString::NoError;
 				break;
 			case UserToWorldStatusWorldUnavail:
-				per->base_reply.error_str_id = LS::ErrStr::SERVER_UNAVAILABLE;
+				per->base_reply.error_str_id = LS::ErrorString::WorldUnavailabe;
 				break;
 			case UserToWorldStatusSuspended:
-				per->base_reply.error_str_id = LS::ErrStr::ACCOUNT_SUSPENDED;
+				per->base_reply.error_str_id = LS::ErrorString::StatusSuspended;
 				break;
 			case UserToWorldStatusBanned:
-				per->base_reply.error_str_id = LS::ErrStr::ACCOUNT_BANNED;
+				per->base_reply.error_str_id = LS::ErrorString::StatusBanned;
 				break;
 			case UserToWorldStatusWorldAtCapacity:
-				per->base_reply.error_str_id = LS::ErrStr::WORLD_MAX_CAPACITY;
+				per->base_reply.error_str_id = LS::ErrorString::WorldMaxCapacity;
 				break;
 			case UserToWorldStatusAlreadyOnline:
-				per->base_reply.error_str_id = LS::ErrStr::ERROR_1018_ACTIVE_CHARACTER;
+				per->base_reply.error_str_id = LS::ErrorString::CharacterAlreadyOnline;
 				break;
 			default:
-				per->base_reply.error_str_id = LS::ErrStr::UNKNOWN_ERROR;
+				per->base_reply.error_str_id = LS::ErrorString::UnknownError;
+				break;
 		}
 
 		if (server.options.IsTraceOn()) {


### PR DESCRIPTION
- Caused Windows compile to fail.
- Add break to default cases in switch.