### PR TITLE
[Bug Fix] Melee Life tap overflowing and causing damage

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -5199,18 +5199,20 @@ int16 Mob::GetPositionalDmgAmt(Mob* defender)
 void Mob::MeleeLifeTap(int32 damage) {
 
 	int32 lifetap_amt = 0;
-	lifetap_amt = spellbonuses.MeleeLifetap + itembonuses.MeleeLifetap + aabonuses.MeleeLifetap
-				+ spellbonuses.Vampirism + itembonuses.Vampirism + aabonuses.Vampirism;
+	int32 melee_lifetap_mod = spellbonuses.MeleeLifetap + itembonuses.MeleeLifetap + aabonuses.MeleeLifetap
+					+ spellbonuses.Vampirism + itembonuses.Vampirism + aabonuses.Vampirism;
 
-	if(lifetap_amt && damage > 0){
+	if(melee_lifetap_mod && damage > 0){
 
-		lifetap_amt = damage * lifetap_amt / 100;
-		LogCombat("Melee lifetap healing for [{}] damage", damage);
+		lifetap_amt = damage * (static_cast<float>(melee_lifetap_mod) / 100.0f);
+		LogCombat("Melee lifetap healing [{}] points of damage wiht modifier of [{}] ", lifetap_amt, melee_lifetap_mod);
 
-		if (lifetap_amt > 0)
+		if (lifetap_amt >= 0) {
 			HealDamage(lifetap_amt); //Heal self for modified damage amount.
-		else
+		}
+		else {
 			Damage(this, -lifetap_amt, 0, EQ::skills::SkillEvocation, false); //Dmg self for modified damage amount.
+		}
 	}
 }
 

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -5205,7 +5205,7 @@ void Mob::MeleeLifeTap(int32 damage) {
 	if(melee_lifetap_mod && damage > 0){
 
 		lifetap_amt = damage * (static_cast<float>(melee_lifetap_mod) / 100.0f);
-		LogCombat("Melee lifetap healing [{}] points of damage wiht modifier of [{}] ", lifetap_amt, melee_lifetap_mod);
+		LogCombat("Melee lifetap healing [{}] points of damage with modifier of [{}] ", lifetap_amt, melee_lifetap_mod);
 
 		if (lifetap_amt >= 0) {
 			HealDamage(lifetap_amt); //Heal self for modified damage amount.


### PR DESCRIPTION
Adjusted calculation in MeleeLifeTap function to prevent the multiplier from overflowing and causing damage instead of healing when numbers go to high.