### PR TITLE
[API] mob->SpellEffect can now properly display spell effect that are used on a target.

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -2910,13 +2910,21 @@ void Mob::CameraEffect(uint32 duration, uint32 intensity, Client *c, bool global
 	safe_delete(outapp);
 }
 
-void Mob::SendSpellEffect(uint32 effect_id, uint32 duration, uint32 finish_delay, bool zone_wide, uint32 unk020, bool perm_effect, Client *c) {
+void Mob::SendSpellEffect(uint32 effect_id, uint32 duration, uint32 finish_delay, bool zone_wide, uint32 unk020, bool perm_effect, Client *c, uint32 caster_id, uint32 target_id) {
+
+	if (!caster_id) {
+		caster_id = GetID();
+	}
+
+	if (!target_id) {
+		target_id = GetID();
+	}
 
 	auto outapp = new EQApplicationPacket(OP_SpellEffect, sizeof(SpellEffect_Struct));
 	SpellEffect_Struct* se = (SpellEffect_Struct*) outapp->pBuffer;
 	se->EffectID = effect_id;	// ID of the Particle Effect
-	se->EntityID = GetID();
-	se->EntityID2 = GetID();	// EntityID again
+	se->EntityID = caster_id; //casting graphic animation
+	se->EntityID2 = target_id;	// //target graphic animation
 	se->Duration = duration;	// In Milliseconds
 	se->FinishDelay = finish_delay;	// Seen 0
 	se->Unknown020 = unk020;	// Seen 3000

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -291,7 +291,7 @@ public:
 
 	//Spell
 	void SendSpellEffect(uint32 effect_id, uint32 duration, uint32 finish_delay, bool zone_wide,
-		uint32 unk020, bool perm_effect = false, Client *c = nullptr);
+		uint32 unk020, bool perm_effect = false, Client *c = nullptr, uint32 caster_id = 0, uint32 target_id = 0);
 	bool IsBeneficialAllowed(Mob *target);
 	virtual int GetCasterLevel(uint16 spell_id);
 	void ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses* newbon, uint16 casterID = 0,

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -4864,8 +4864,8 @@ XS(XS_Mob_CameraEffect) {
 XS(XS_Mob_SpellEffect); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Mob_SpellEffect) {
 	dXSARGS;
-	if (items < 2 || items > 8)
-		Perl_croak(aTHX_ "Usage: Mob::SpellEffect(THIS, uint32 effect, [uint32 duration = 5000], [uint32 finish_delay = 0], [bool zone_wide = false], [uint32 unk20 = 3000], [bool perm_effect = false], [Client* single_client])"); // @categories Spells and Disciplines
+	if (items < 2 || items > 10)
+		Perl_croak(aTHX_ "Usage: Mob::SpellEffect(THIS, uint32 effect, [uint32 duration = 5000], [uint32 finish_delay = 0], [bool zone_wide = false], [uint32 unk20 = 3000], [bool perm_effect = false], [Client* single_client]), [caster_id = 0], [target_id = 0]"); // @categories Spells and Disciplines
 	{
 		Mob *THIS;
 		uint32 effect       = (uint32) SvUV(ST(1));
@@ -4875,6 +4875,8 @@ XS(XS_Mob_SpellEffect) {
 		uint32 unk20        = 3000;
 		bool   perm_effect  = false;
 		Client *client = nullptr;
+		uint32 caster_id = 0;
+		uint32 target_id = 0;
 		VALIDATE_THIS_IS_MOB;
 		if (items > 2) { duration = (uint32) SvUV(ST(2)); }
 		if (items > 3) { finish_delay = (uint32) SvUV(ST(3)); }
@@ -4890,9 +4892,11 @@ XS(XS_Mob_SpellEffect) {
 			if (client == nullptr)
 				Perl_croak(aTHX_ "client is nullptr, avoiding crash.");
 		}
+		if (items > 8) { caster_id = (uint32)SvUV(ST(8)); }
+		if (items > 9) { target_id = (uint32)SvUV(ST(9)); }
 
 
-		THIS->SendSpellEffect(effect, duration, finish_delay, zone_wide, unk20, perm_effect, client);
+		THIS->SendSpellEffect(effect, duration, finish_delay, zone_wide, unk20, perm_effect, client, caster_id, target_id);
 	}
 	XSRETURN_EMPTY;
 }
@@ -6743,7 +6747,7 @@ XS(boot_Mob) {
 	newXSproto(strcpy(buf, "ShieldAbility"), XS_Mob_ShieldAbility, file, "$$$$$$$$");
 	newXSproto(strcpy(buf, "Shout"), XS_Mob_Shout, file, "$$;@");
 	newXSproto(strcpy(buf, "SignalClient"), XS_Mob_SignalClient, file, "$$$");
-	newXSproto(strcpy(buf, "SpellEffect"), XS_Mob_SpellEffect, file, "$$;$$$$$$");
+	newXSproto(strcpy(buf, "SpellEffect"), XS_Mob_SpellEffect, file, "$$;$$$$$$$$");
 	newXSproto(strcpy(buf, "SpellFinished"), XS_Mob_SpellFinished, file, "$$;$$");
 	newXSproto(strcpy(buf, "Spin"), XS_Mob_Spin, file, "$");
 	newXSproto(strcpy(buf, "StartEnrage"), XS_Mob_StartEnrage, file, "$");


### PR DESCRIPTION
Usage: Mob::SpellEffect(THIS, uint32 effect, [uint32 duration = 5000], [uint32 finish_delay = 0], [bool zone_wide = false], [uint32 unk20 = 3000], [bool perm_effect = false], [Client* single_client]), [caster_id = 0], [target_id = 0]")

This function is used for affects like Nimbuses but it also has a large variety of spell casting graphics that are not self only. The way the function was coded it was always setting the target of the effect as the caster. So if you tried to use it to simulate say a "nuke" it would do the casting animation on the target and then spell landing animation. I added a way using optional parameters at the end to set the caster and target.

```
#put on an npc  and hail it
sub EVENT_SAY
{
	$client->SpellEffect(68, 5000,0, 0, 3000, 0, $client, $client->GetID(), $npc->GetID());# Client will cast, NPC will receive the spell
}
```