### PR TITLE
[Spells] Support for SPA 161 and 450 to give  percent spell or dot mitigation from Items or AA's.

### DIFF
--- a/common/spdat.h
+++ b/common/spdat.h
@@ -863,7 +863,7 @@ typedef enum {
 #define SE_Reflect						158 // implemented, @SpellMisc, reflect casted detrimental spell back at caster, base: chance pct, limit: resist modifier (positive value reduces resists), max: pct of base dmg mod (50=50pct of base)
 #define SE_AllStats						159	// implemented
 //#define SE_MakeDrunk					160 // *not implemented - Effect works entirely client side (Should check against tolerance)
-#define SE_MitigateSpellDamage			161	// implemented - rune with max value
+#define SE_MitigateSpellDamage			161	// implemented, @Runes, mitigate incoming spell damage by percentage until rune fades, base: percent mitigation, limit: max dmg absorbed per hit, max: rune amt, Note: If placed on item or AA, will provide stackable percent mitigation.
 #define SE_MitigateMeleeDamage			162	// implemented - rune with max value
 #define SE_NegateAttacks				163	// implemented
 #define SE_AppraiseLDonChest			164	// implemented
@@ -1152,7 +1152,7 @@ typedef enum {
 #define SE_BStacker						447 // implemented
 #define SE_CStacker						448 // implemented
 #define SE_DStacker						449 // implemented
-#define SE_MitigateDotDamage			450 // implemented  DOT spell mitigation rune with max value
+#define SE_MitigateDotDamage			450 // implemented, @Runes, mitigate incoming dot damage by percentage until rune fades, base: percent mitigation, limit: max dmg absorbed per hit, max: rune amt, Note: If placed on item or AA, will provide stackable percent mitigation.
 #define SE_MeleeThresholdGuard			451 // implemented  Partial Melee Rune that only is lowered if melee hits are over X amount of damage
 #define SE_SpellThresholdGuard			452 // implemented  Partial Spell Rune that only is lowered if spell hits are over X amount of damage
 #define SE_TriggerMeleeThreshold		453 // implemented  Trigger effect on X amount of melee damage taken in a single hit

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -3298,7 +3298,8 @@ int32 Mob::AffectMagicalDamage(int32 damage, uint16 spell_id, const bool iBuffTi
 
 	// If this is a DoT, use DoT Shielding...
 	if (iBuffTic) {
-		damage -= (damage * itembonuses.DoTShielding / 100);
+		int total_dotshielding = itembonuses.DoTShielding + itembonuses.MitigateDotRune[SBIndex::MITIGATION_RUNE_PERCENT] + aabonuses.MitigateDotRune[SBIndex::MITIGATION_RUNE_PERCENT];
+		damage -= (damage * total_dotshielding / 100);
 
 		if (spellbonuses.MitigateDotRune[SBIndex::MITIGATION_RUNE_PERCENT]) {
 			slot = spellbonuses.MitigateDotRune[SBIndex::MITIGATION_RUNE_BUFFSLOT];
@@ -3330,7 +3331,11 @@ int32 Mob::AffectMagicalDamage(int32 damage, uint16 spell_id, const bool iBuffTi
 	else
 	{
 		// Reduce damage by the Spell Shielding first so that the runes don't take the raw damage.
-		damage -= (damage * itembonuses.SpellShield / 100);
+		int total_spellshielding = itembonuses.SpellShield + itembonuses.MitigateSpellRune[SBIndex::MITIGATION_RUNE_PERCENT] + aabonuses.MitigateSpellRune[SBIndex::MITIGATION_RUNE_PERCENT];
+		Shout("SPELL SHIELD %i %i", itembonuses.MitigateSpellRune[SBIndex::MITIGATION_RUNE_PERCENT], aabonuses.MitigateSpellRune[SBIndex::MITIGATION_RUNE_PERCENT]);
+		Shout("DAMGE1 %i", damage);
+		damage -= (damage * total_spellshielding / 100);
+		Shout("DAMGE2 %i", damage);
 
 		//Only mitigate if damage is above the minimium specified.
 		if (spellbonuses.SpellThresholdGuard[SBIndex::THRESHOLDGUARD_MITIGATION_PERCENT]) {

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -3332,11 +3332,8 @@ int32 Mob::AffectMagicalDamage(int32 damage, uint16 spell_id, const bool iBuffTi
 	{
 		// Reduce damage by the Spell Shielding first so that the runes don't take the raw damage.
 		int total_spellshielding = itembonuses.SpellShield + itembonuses.MitigateSpellRune[SBIndex::MITIGATION_RUNE_PERCENT] + aabonuses.MitigateSpellRune[SBIndex::MITIGATION_RUNE_PERCENT];
-		Shout("SPELL SHIELD %i %i", itembonuses.MitigateSpellRune[SBIndex::MITIGATION_RUNE_PERCENT], aabonuses.MitigateSpellRune[SBIndex::MITIGATION_RUNE_PERCENT]);
-		Shout("DAMGE1 %i", damage);
 		damage -= (damage * total_spellshielding / 100);
-		Shout("DAMGE2 %i", damage);
-
+		
 		//Only mitigate if damage is above the minimium specified.
 		if (spellbonuses.SpellThresholdGuard[SBIndex::THRESHOLDGUARD_MITIGATION_PERCENT]) {
 			slot = spellbonuses.SpellThresholdGuard[SBIndex::THRESHOLDGUARD_BUFFSLOT];

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -1761,6 +1761,18 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			newbon->Amplification += base_value;
 			break;
 
+		case SE_MitigateSpellDamage:
+		{
+			newbon->MitigateSpellRune[SBIndex::MITIGATION_RUNE_PERCENT] += base_value;
+			break;
+		}
+
+		case SE_MitigateDotDamage:
+		{
+			newbon->MitigateDotRune[SBIndex::MITIGATION_RUNE_PERCENT] += base_value;
+			break;
+		}
+
 		// to do
 		case SE_PetDiscipline:
 			break;
@@ -3019,6 +3031,10 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 
 			case SE_MitigateSpellDamage:
 			{
+				if (WornType) {
+					new_bonus->MitigateSpellRune[SBIndex::MITIGATION_RUNE_PERCENT] += effect_value;
+				}
+
 				if (new_bonus->MitigateSpellRune[SBIndex::MITIGATION_RUNE_PERCENT] < effect_value){
 					new_bonus->MitigateSpellRune[SBIndex::MITIGATION_RUNE_PERCENT]                = effect_value;
 					new_bonus->MitigateSpellRune[SBIndex::MITIGATION_RUNE_BUFFSLOT]               = buffslot;
@@ -3030,6 +3046,10 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 
 			case SE_MitigateDotDamage:
 			{
+				if (WornType) {
+					new_bonus->MitigateDotRune[SBIndex::MITIGATION_RUNE_PERCENT] += effect_value;
+				}
+
 				if (new_bonus->MitigateDotRune[SBIndex::MITIGATION_RUNE_PERCENT] < effect_value){
 					new_bonus->MitigateDotRune[SBIndex::MITIGATION_RUNE_PERCENT]                = effect_value;
 					new_bonus->MitigateDotRune[SBIndex::MITIGATION_RUNE_BUFFSLOT]               = buffslot;


### PR DESCRIPTION
Added support to SPA 161 and SPA 450 to provide spell or dot shielding respectively, when put on as an Item worn effect or as AA's. There was no easy way to provide percentage spell or dot mitigation via AA's so this solves that problem in a straightforward way. This will stack with item mod2 spellshielding or dotshielding.

SE_MitigateSpellDamage 161	// implemented, Runes, mitigate incoming spell damage by percentage until rune fades, base: percent mitigation, limit: max dmg absorbed per hit, max: rune amt, Note: If placed on item or AA, will provide stackable percent mitigation.

SE_MitigateDotDamage	450 // implemented, Runes, mitigate incoming dot damage by percentage until rune fades, base: percent mitigation, limit: max dmg absorbed per hit, max: rune amt, Note: If placed on item or AA, will provide stackable percent mitigation.