### PR TITLE
[Commands] Cleanup #zheader Command.

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -392,7 +392,7 @@ int command_init(void)
 		command_add("xtargets",  "Show your targets Extended Targets and optionally set how many xtargets they can have.", AccountStatus::GMImpossible, command_xtargets) ||
 		command_add("zclip", "[min] [max] - modifies and resends zhdr packet", AccountStatus::QuestTroupe, command_zclip) ||
 		command_add("zcolor", "[red] [green] [blue] - Change sky color", AccountStatus::QuestTroupe, command_zcolor) ||
-		command_add("zheader", "[zonename] - Load zheader for zonename from the database", AccountStatus::QuestTroupe, command_zheader) ||
+		command_add("zheader", "[Zone ID|Zone Short Name] [Version] - Load a zone header from the database", AccountStatus::QuestTroupe, command_zheader) ||
 		command_add("zone", "[zonename] [x] [y] [z] - Go to specified zone (coords optional)", AccountStatus::Guide, command_zone) ||
 		command_add("zonebootup", "[ZoneServerID] [shortname] - Make a zone server boot a specific zone", AccountStatus::GMLeadAdmin, command_zonebootup) ||
 		command_add("zoneinstance", "[instanceid] [x] [y] [z] - Go to specified instance zone (coords optional)", AccountStatus::Guide, command_zone_instance) ||

--- a/zone/gm_commands/zheader.cpp
+++ b/zone/gm_commands/zheader.cpp
@@ -2,25 +2,60 @@
 
 void command_zheader(Client *c, const Seperator *sep)
 {
-	// sends zhdr packet
-	if (sep->arg[1][0] == 0) {
-		c->Message(Chat::White, "Usage: #zheader <zone name>");
+	int arguments = sep->argnum;
+	if (!arguments) {
+		c->Message(Chat::White, "Usage: #zheader [Zone ID|Zone Short Name] [Version]");
+		return;
 	}
-	else if (ZoneID(sep->argplus[1]) == 0) {
-		c->Message(Chat::White, "Invalid Zone Name: %s", sep->argplus[1]);
-	}
-	else {
 
-		if (zone->LoadZoneCFG(sep->argplus[1], 0)) {
-			c->Message(Chat::White, "Successfully loaded zone header for %s from database.", sep->argplus[1]);
-		}
-		else {
-			c->Message(Chat::White, "Failed to load zone header %s from database", sep->argplus[1]);
-		}
-		auto outapp = new EQApplicationPacket(OP_NewZone, sizeof(NewZone_Struct));
-		memcpy(outapp->pBuffer, &zone->newzone_data, outapp->size);
-		entity_list.QueueClients(c, outapp);
-		safe_delete(outapp);
+	auto zone_id = (
+		sep->IsNumber(1) ?
+		std::stoul(sep->arg[1]) :
+		ZoneID(sep->arg[1])
+	);
+	if (!zone_id) {
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"Zone ID {} could not be found.",
+				zone_id
+			).c_str()
+		);
+		return;
 	}
+
+	auto zone_short_name = ZoneName(zone_id);
+	auto zone_long_name = ZoneLongName(zone_id);
+	auto version = (
+		sep->IsNumber(2) ?
+		std::stoul(sep->arg[2]) :
+		0
+	);
+	
+	auto outapp = new EQApplicationPacket(OP_NewZone, sizeof(NewZone_Struct));
+	memcpy(outapp->pBuffer, &zone->newzone_data, outapp->size);
+	entity_list.QueueClients(c, outapp);
+	safe_delete(outapp);
+
+	c->Message(
+		Chat::White,
+		fmt::format(
+			"Zone Header Load {} | Zone: {} ({}){}",
+			(
+				zone->LoadZoneCFG(zone_short_name, version) ?
+				"Suceeded" :
+				"Failed"
+			),
+			zone_long_name,
+			zone_short_name,
+			(
+				version ?
+				fmt::format(
+					" Version: {}",
+					version
+				) :
+				""
+			)
+		).c_str()
+	);
 }
-

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -1262,7 +1262,7 @@ void Zone::ReloadStaticData() {
 	LogInfo("Zone Static Data Reloaded");
 }
 
-bool Zone::LoadZoneCFG(const char* filename, uint16 instance_id)
+bool Zone::LoadZoneCFG(const char* filename, uint16 instance_version)
 {
 
 	memset(&newzone_data, 0, sizeof(NewZone_Struct));
@@ -1270,7 +1270,7 @@ bool Zone::LoadZoneCFG(const char* filename, uint16 instance_id)
 
 	if (!content_db.GetZoneCFG(
 		ZoneID(filename),
-		instance_id,
+		instance_version,
 		&newzone_data,
 		can_bind,
 		can_combat,
@@ -1285,7 +1285,7 @@ bool Zone::LoadZoneCFG(const char* filename, uint16 instance_id)
 		&map_name
 	)) {
 		// If loading a non-zero instance failed, try loading the default
-		if (instance_id != 0) {
+		if (instance_version != 0) {
 			safe_delete_array(map_name);
 			if (!content_db.GetZoneCFG(
 				ZoneID(filename),
@@ -1319,7 +1319,7 @@ bool Zone::LoadZoneCFG(const char* filename, uint16 instance_id)
 		GetShortName(),
 		GetLongName(),
 		GetInstanceVersion(),
-		instance_id
+		instance_version
 	);
 
 	return true;

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -134,7 +134,7 @@ public:
 	bool IsUCSServerAvailable() { return m_ucss_available; }
 	bool IsZone(uint32 zone_id, uint16 instance_id) const;
 	bool LoadGroundSpawns();
-	bool LoadZoneCFG(const char *filename, uint16 instance_id);
+	bool LoadZoneCFG(const char *filename, uint16 instance_version);
 	bool LoadZoneObjects();
 	bool Process();
 	bool SaveZoneCFG();

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -63,11 +63,11 @@ ZoneDatabase::~ZoneDatabase() {
 
 bool ZoneDatabase::SaveZoneCFG(uint32 zoneid, uint16 instance_version, NewZone_Struct* zd) {
 	std::string query = fmt::format(
-		"UPDATE zone SET underworld = {}, minclip = {}, "
-		"maxclip = {}, fog_minclip = {}, fog_maxclip = {}, "
+		"UPDATE zone SET underworld = {:.2f}, minclip = {:.2f}, "
+		"maxclip = {:.2f}, fog_minclip = {:.2f}, fog_maxclip = {:.2f}, "
 		"fog_blue = {}, fog_red = {}, fog_green = {}, "
-		"sky = {}, ztype = {}, zone_exp_multiplier = {}, "
-		"safe_x = {}, safe_y = {}, safe_z = {} "
+		"sky = {}, ztype = {}, zone_exp_multiplier = {:.2f}, "
+		"safe_x = {:.2f}, safe_y = {:.2f}, safe_z = {:.2f} "
 		"WHERE zoneidnumber = {} AND version = {}",
 		zd->underworld,
 		zd->minclip,

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -61,20 +61,31 @@ ZoneDatabase::~ZoneDatabase() {
 	}
 }
 
-bool ZoneDatabase::SaveZoneCFG(uint32 zoneid, uint16 instance_id, NewZone_Struct* zd) {
-
-	std::string query = StringFormat("UPDATE zone SET underworld = %f, minclip = %f, "
-                                    "maxclip = %f, fog_minclip = %f, fog_maxclip = %f, "
-                                    "fog_blue = %i, fog_red = %i, fog_green = %i, "
-                                    "sky = %i, ztype = %i, zone_exp_multiplier = %f, "
-                                    "safe_x = %f, safe_y = %f, safe_z = %f "
-                                    "WHERE zoneidnumber = %i AND version = %i",
-                                    zd->underworld, zd->minclip,
-                                    zd->maxclip, zd->fog_minclip[0], zd->fog_maxclip[0],
-                                    zd->fog_blue[0], zd->fog_red[0], zd->fog_green[0],
-                                    zd->sky, zd->ztype, zd->zone_exp_multiplier,
-                                    zd->safe_x, zd->safe_y, zd->safe_z,
-                                    zoneid, instance_id);
+bool ZoneDatabase::SaveZoneCFG(uint32 zoneid, uint16 instance_version, NewZone_Struct* zd) {
+	std::string query = fmt::format(
+		"UPDATE zone SET underworld = {}, minclip = {}, "
+		"maxclip = {}, fog_minclip = {}, fog_maxclip = {}, "
+		"fog_blue = {}, fog_red = {}, fog_green = {}, "
+		"sky = {}, ztype = {}, zone_exp_multiplier = {}, "
+		"safe_x = {}, safe_y = {}, safe_z = {} "
+		"WHERE zoneidnumber = {} AND version = {}",
+		zd->underworld,
+		zd->minclip,
+		zd->maxclip,
+		zd->fog_minclip[0],
+		zd->fog_maxclip[0],
+		zd->fog_blue[0],
+		zd->fog_red[0],
+		zd->fog_green[0],
+		zd->sky,
+		zd->ztype,
+		zd->zone_exp_multiplier,
+		zd->safe_x,
+		zd->safe_y,
+		zd->safe_z,
+		zoneid,
+		instance_version
+	);
 	auto results = QueryDatabase(query);
 	if (!results.Success()) {
         return false;
@@ -85,7 +96,7 @@ bool ZoneDatabase::SaveZoneCFG(uint32 zoneid, uint16 instance_id, NewZone_Struct
 
 bool ZoneDatabase::GetZoneCFG(
 	uint32 zoneid,
-	uint16 instance_id,
+	uint16 instance_version,
 	NewZone_Struct *zone_data,
 	bool &can_bind,
 	bool &can_combat,
@@ -102,7 +113,7 @@ bool ZoneDatabase::GetZoneCFG(
 	*map_filename = new char[100];
 	zone_data->zone_id = zoneid;
 
-	std::string query = StringFormat(
+	std::string query = fmt::format(
 		"SELECT "
 		"ztype, "						// 0
 		"fog_red, "						// 1
@@ -169,10 +180,10 @@ bool ZoneDatabase::GetZoneCFG(
 		"underworld_teleport_index, "	// 62
 		"lava_damage, "					// 63
 		"min_lava_damage "				// 64
-		"FROM zone WHERE zoneidnumber = %i AND version = %i %s",
+		"FROM zone WHERE zoneidnumber = {} AND version = {} {}",
 		zoneid,
-		instance_id,
-		ContentFilterCriteria::apply().c_str()
+		instance_version,
+		ContentFilterCriteria::apply()
 	);
 	auto results = QueryDatabase(query);
 	if (!results.Success()) {

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -438,7 +438,7 @@ public:
 	/* Zone related   */
 	bool		GetZoneCFG(
 		uint32 zoneid, 
-		uint16 instance_id, 
+		uint16 instance_version, 
 		NewZone_Struct *data, 
 		bool &can_bind, 
 		bool &can_combat, 
@@ -451,7 +451,7 @@ public:
 		uint8 &zone_type, 
 		int &ruleset, 
 		char **map_filename);
-	bool		SaveZoneCFG(uint32 zoneid, uint16 instance_id, NewZone_Struct* zd);
+	bool		SaveZoneCFG(uint32 zoneid, uint16 instance_version, NewZone_Struct* zd);
 	bool		LoadStaticZonePoints(LinkedList<ZonePoint*>* zone_point_list,const char* zonename, uint32 version);
 	bool		UpdateZoneSafeCoords(const char* zonename, const glm::vec3& location);
 	uint8		GetUseCFGSafeCoords();


### PR DESCRIPTION
- Cleanup message and logic.
- Add parameter to allow versions to be loaded.
- Cleanup parameter name in CFG methods from instance_id to instance_version.