### PR TITLE
[Bug Fix] Pick Lock was allowing skillups on doors above player skill

### DIFF
--- a/utils/sql/git/optional/2021_11_28_pot_pick_locks_book.sql
+++ b/utils/sql/git/optional/2021_11_28_pot_pick_locks_book.sql
@@ -1,0 +1,1 @@
+UPDATE doors SET lockpick=1 WHERE doorid=46 AND zone="potranquility";

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -154,6 +154,7 @@ Client::Client(EQStreamInterface* ieqs)
   TaskPeriodic_Timer(RuleI(TaskSystem, PeriodicCheckTimer) * 1000),
   charm_update_timer(6000),
   rest_timer(1),
+  pick_lock_timer(1000),
   charm_class_attacks_timer(3000),
   charm_cast_timer(3500),
   qglobal_purge_timer(30000),

--- a/zone/client.h
+++ b/zone/client.h
@@ -1521,6 +1521,7 @@ public:
 	void UpdateMercLevel();
 	void CheckMercSuspendTimer();
 	Timer* GetMercTimer() { return &merc_timer; };
+	Timer* GetPickLockTimer() { return &pick_lock_timer; };
 
 	const char* GetRacePlural(Client* client);
 	const char* GetClassPlural(Client* client);
@@ -1862,6 +1863,7 @@ private:
 	Timer consent_throttle_timer;
 	Timer dynamiczone_removal_timer;
 	Timer task_request_timer;
+	Timer pick_lock_timer;
 
 	glm::vec3 m_Proximity;
 	glm::vec4 last_position_before_bulk_update;

--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -278,8 +278,9 @@ void Doors::HandleClick(Client* sender, uint8 trigger) {
 
 		/**
 		 * Key required
+		 * If using a lock_pick_item leave messaging to that code below
 		 */
-		if (!IsDoorOpen()) {
+		if (lock_pick_item == nullptr && !IsDoorOpen()) {
 			sender->Message(Chat::LightBlue, "This is locked...");
 		}
 

--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -333,7 +333,7 @@ void Doors::HandleClick(Client* sender, uint8 trigger) {
 						// Stop full scale mad spamming
 						safe_delete(outapp);
 						return;
-						}
+					}
 
 					float player_pick_lock_skill = sender->GetSkill(EQ::skills::SkillPickLock);
 

--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -329,11 +329,11 @@ void Doors::HandleClick(Client* sender, uint8 trigger) {
 			if (sender->GetSkill(EQ::skills::SkillPickLock)) {
 				Timer* pick_lock_timer = sender->GetPickLockTimer();
 				if (lock_pick_item->GetItem()->ItemType == EQ::item::ItemTypeLockPick) {
-				if (!pick_lock_timer->Check()) {
-					// Stop full scale mad spamming
-					safe_delete(outapp);
-					return;
-					}
+					if (!pick_lock_timer->Check()) {
+						// Stop full scale mad spamming
+						safe_delete(outapp);
+						return;
+						}
 
 					float player_pick_lock_skill = sender->GetSkill(EQ::skills::SkillPickLock);
 

--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -279,7 +279,9 @@ void Doors::HandleClick(Client* sender, uint8 trigger) {
 		/**
 		 * Key required
 		 */
-		sender->Message(Chat::LightBlue, "This is locked...");
+		if (!IsDoorOpen()) {
+			sender->Message(Chat::LightBlue, "This is locked...");
+		}
 
 		/**
 		 * GM can always open locks
@@ -325,19 +327,30 @@ void Doors::HandleClick(Client* sender, uint8 trigger) {
 		 */
 		else if (lock_pick_item != nullptr) {
 			if (sender->GetSkill(EQ::skills::SkillPickLock)) {
+				Timer* pick_lock_timer = sender->GetPickLockTimer();
 				if (lock_pick_item->GetItem()->ItemType == EQ::item::ItemTypeLockPick) {
+				if (!pick_lock_timer->Check()) {
+					// Stop full scale mad spamming
+					safe_delete(outapp);
+					return;
+					}
+
 					float player_pick_lock_skill = sender->GetSkill(EQ::skills::SkillPickLock);
-					sender->CheckIncreaseSkill(EQ::skills::SkillPickLock, nullptr, 1);
 
 					LogSkills("Client has lockpicks: skill=[{}]", player_pick_lock_skill);
 
 					if (GetLockpick() <= player_pick_lock_skill) {
+
+						// Stop full scale spamming
+						pick_lock_timer->Start(1000, true);
+
 						if (!IsDoorOpen()) {
+							sender->CheckIncreaseSkill(EQ::skills::SkillPickLock, nullptr, 1);
 							move_door_packet->action = static_cast<uint8>(invert_state == 0 ? OPEN_DOOR : OPEN_INVDOOR);
+							sender->MessageString(Chat::LightBlue, DOORS_SUCCESSFUL_PICK);
 						} else {
 							move_door_packet->action = static_cast<uint8>(invert_state == 0 ? CLOSE_DOOR : CLOSE_INVDOOR);
 						}
-						sender->MessageString(Chat::LightBlue, DOORS_SUCCESSFUL_PICK);
 					} else {
 						sender->MessageString(Chat::LightBlue, DOORS_INSUFFICIENT_SKILL);
 						safe_delete(outapp);


### PR DESCRIPTION
This PR fixes picking locks as follows:

- Skilling up class pick lock skill should only happen on a door that can be opened by the PC.  This is now true after this PR.
- Skilling up, as well as messages only happen when you open the door.  Closing the door is quiet.
- A small 1 second spam timer was added to prevent door/sync issues.