### PR TITLE
[API] mob->SpellEffect small perl fix

### DIFF
--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -4877,6 +4877,7 @@ XS(XS_Mob_SpellEffect) {
 		Client *client = nullptr;
 		uint32 caster_id = 0;
 		uint32 target_id = 0;
+		bool nullclient = false;
 		VALIDATE_THIS_IS_MOB;
 		if (items > 2) { duration = (uint32) SvUV(ST(2)); }
 		if (items > 3) { finish_delay = (uint32) SvUV(ST(3)); }
@@ -4884,19 +4885,27 @@ XS(XS_Mob_SpellEffect) {
 		if (items > 5) { unk20 = (uint32) SvUV(ST(5)); }
 		if (items > 6) { perm_effect = (bool) SvTRUE(ST(6)); }
 		if (items > 7) {
-			if (sv_derived_from(ST(7), "Client")) {
-				IV tmp = SvIV((SV *) SvRV(ST(7)));
+			if (sv_derived_from(ST(3), "Client")) {
+				IV tmp = SvIV((SV *)SvRV(ST(7)));
 				client = INT2PTR(Client *, tmp);
-			} else
-				Perl_croak(aTHX_ "client is not of type Client");
-			if (client == nullptr)
-				Perl_croak(aTHX_ "client is nullptr, avoiding crash.");
+			}
+			else {
+				nullclient = true;
+			}
+			if (client == nullptr) {
+				nullclient = true;
+			}
 		}
 		if (items > 8) { caster_id = (uint32)SvUV(ST(8)); }
 		if (items > 9) { target_id = (uint32)SvUV(ST(9)); }
+		
+		if (nullclient) {
+			THIS->SendSpellEffect(effect, duration, finish_delay, zone_wide, unk20, perm_effect, 0, caster_id, target_id);
+		}
+		else {
+			THIS->SendSpellEffect(effect, duration, finish_delay, zone_wide, unk20, perm_effect, client, caster_id, target_id);
+		}
 
-
-		THIS->SendSpellEffect(effect, duration, finish_delay, zone_wide, unk20, perm_effect, client, caster_id, target_id);
 	}
 	XSRETURN_EMPTY;
 }

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -4885,7 +4885,7 @@ XS(XS_Mob_SpellEffect) {
 		if (items > 5) { unk20 = (uint32) SvUV(ST(5)); }
 		if (items > 6) { perm_effect = (bool) SvTRUE(ST(6)); }
 		if (items > 7) {
-			if (sv_derived_from(ST(3), "Client")) {
+			if (sv_derived_from(ST(7), "Client")) {
 				IV tmp = SvIV((SV *)SvRV(ST(7)));
 				client = INT2PTR(Client *, tmp);
 			}


### PR DESCRIPTION
Update to recent PR https://github.com/EQEmu/Server/pull/1785

Usage: Mob::SpellEffect(THIS, uint32 effect, [uint32 duration = 5000], [uint32 finish_delay = 0], [bool zone_wide = false], [uint32 unk20 = 3000], [bool perm_effect = false], [Client* single_client]), [caster_id = 0], [target_id = 0]"); 

Needed to now allow perl to pass nullptr or 0 for [Client* single_client] parameter otherwise wouldn't work unless you set $client
to send to only a single client.
