### PR TITLE
[API] mob->AppearanceEffects improved functionality.

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -2838,8 +2838,44 @@ void Mob::SendStunAppearance()
 	safe_delete(outapp);
 }
 
-void Mob::SendAppearanceEffect(uint32 parm1, uint32 parm2, uint32 parm3, uint32 parm4, uint32 parm5, Client *specific_target){
+void Mob::SendAppearanceEffect(uint32 parm1, uint32 parm2, uint32 parm3, uint32 parm4, uint32 parm5, Client *specific_target, 
+	uint32 value1slot, uint32 value1ground, uint32 value2slot, uint32 value2ground, uint32 value3slot, uint32 value3ground, 
+	uint32 value4slot, uint32 value4ground, uint32 value5slot, uint32 value5ground){
 	auto outapp = new EQApplicationPacket(OP_LevelAppearance, sizeof(LevelAppearance_Struct));
+	
+	/* Location of the effect from value#slot, this is removed upon mob death/despawn.
+		0 = pelvis1
+		1 = pelvis2
+		2 = helm
+		3 = Offhand
+		4 = Mainhand
+		5 = left foot
+		6 = right foot
+		9 = Face
+
+		value#ground = 1, will place the effect on ground, this is permanent
+	*/
+
+	//higher values can crash client
+	if (value1slot > 9) {
+		value1slot = 1;
+	}
+	else if (value2slot > 9) {
+		value1slot = 1;
+	}
+	else if (value2slot > 9) {
+		value1slot = 1;
+	}
+	else if (value3slot > 9) {
+		value1slot = 1;
+	}
+	else if (value4slot > 9) {
+		value1slot = 1;
+	}
+	else if (value5slot > 9) {
+		value1slot = 1;
+	}
+
 	LevelAppearance_Struct* la = (LevelAppearance_Struct*)outapp->pBuffer;
 	la->spawn_id = GetID();
 	la->parm1 = parm1;
@@ -2849,16 +2885,16 @@ void Mob::SendAppearanceEffect(uint32 parm1, uint32 parm2, uint32 parm3, uint32 
 	la->parm5 = parm5;
 	// Note that setting the b values to 0 will disable the related effect from the corresponding parameter.
 	// Setting the a value appears to have no affect at all.s
-	la->value1a = 1;
-	la->value1b = 1;
-	la->value2a = 1;
-	la->value2b = 1;
-	la->value3a = 1;
-	la->value3b = 1;
-	la->value4a = 1;
-	la->value4b = 1;
-	la->value5a = 1;
-	la->value5b = 1;
+	la->value1a = value1slot;
+	la->value1b = value1ground;
+	la->value2a = value2slot;
+	la->value2b = value2ground;
+	la->value3a = value3slot;
+	la->value3b = value3ground;
+	la->value4a = value4slot;
+	la->value4b = value4ground;
+	la->value5a = value5slot;
+	la->value5b = value5ground;
 	if(specific_target == nullptr) {
 		entity_list.QueueClients(this,outapp);
 	}

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -2853,7 +2853,7 @@ void Mob::SendAppearanceEffect(uint32 parm1, uint32 parm2, uint32 parm3, uint32 
 		6 = right foot
 		9 = Face
 
-		value#ground = 1, will place the effect on ground, this is permanent
+		value#ground = 1, will place the effect on ground, of corresponding slot is set to 0 effect is permanenant, if > 0 will fade if mob death/despawn.
 	*/
 
 	//higher values can crash client

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -2860,20 +2860,20 @@ void Mob::SendAppearanceEffect(uint32 parm1, uint32 parm2, uint32 parm3, uint32 
 	if (value1slot > 9) {
 		value1slot = 1;
 	}
-	else if (value2slot > 9) {
-		value1slot = 1;
+	if (value2slot > 9) {
+		value2slot = 1;
 	}
-	else if (value2slot > 9) {
-		value1slot = 1;
+	if (value2slot > 9) {
+		value2slot = 1;
 	}
-	else if (value3slot > 9) {
-		value1slot = 1;
+	if (value3slot > 9) {
+		value3slot = 1;
 	}
-	else if (value4slot > 9) {
-		value1slot = 1;
+	if (value4slot > 9) {
+		value4slot = 1;
 	}
-	else if (value5slot > 9) {
-		value1slot = 1;
+	if (value5slot > 9) {
+		value5slot = 1;
 	}
 
 	LevelAppearance_Struct* la = (LevelAppearance_Struct*)outapp->pBuffer;

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -277,7 +277,8 @@ public:
 	void ChangeSize(float in_size, bool bNoRestriction = false);
 	void DoAnim(const int animnum, int type=0, bool ackreq = true, eqFilterType filter = FilterNone);
 	void ProjectileAnimation(Mob* to, int item_id, bool IsArrow = false, float speed = 0, float angle = 0, float tilt = 0, float arc = 0, const char *IDFile = nullptr, EQ::skills::SkillType skillInUse = EQ::skills::SkillArchery);
-	void SendAppearanceEffect(uint32 parm1, uint32 parm2, uint32 parm3, uint32 parm4, uint32 parm5, Client *specific_target=nullptr);
+	void SendAppearanceEffect(uint32 parm1, uint32 parm2, uint32 parm3, uint32 parm4, uint32 parm5, Client *specific_target=nullptr, uint32 value1slot = 1, uint32 value1ground = 1, uint32 value2slot = 1, uint32 value2ground = 1, 
+		uint32 value3slot = 1, uint32 value3ground = 1, uint32 value4slot = 1, uint32 value4ground = 1, uint32 value5slot = 1, uint32 value5ground = 1);
 	void SendLevelAppearance();
 	void SendStunAppearance();
 	void SendTargetable(bool on, Client *specific_target = nullptr);

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -4850,6 +4850,19 @@ XS(XS_Mob_SendAppearanceEffectGround) {
 	XSRETURN_EMPTY;
 }
 
+XS(XS_Mob_RemoveAppearanceEffect); /* prototype to pass -Wmissing-prototypes */
+XS(XS_Mob_RemoveAppearanceEffect) {
+	dXSARGS;
+	if (items != 1)
+		Perl_croak(aTHX_ "Usage: Mob::RemoveAppearanceEffect(THIS)"); // @categories Script Utility
+	{
+		Mob *THIS;
+		VALIDATE_THIS_IS_MOB;
+		THIS->SendIllusionPacket(THIS->GetRace());
+	}
+	XSRETURN_EMPTY;
+}
+
 XS(XS_Mob_SetFlyMode); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Mob_SetFlyMode) {
 	dXSARGS;
@@ -6823,6 +6836,7 @@ XS(boot_Mob) {
 	newXSproto(strcpy(buf, "SendAppearanceEffect"), XS_Mob_SendAppearanceEffect, file, "$$;$$$$$$$$$$$$$$");
 	newXSproto(strcpy(buf, "SendAppearanceEffectActor"), XS_Mob_SendAppearanceEffectActor, file, "$$$;$$$$$$$$$");
 	newXSproto(strcpy(buf, "SendAppearanceEffectGround"), XS_Mob_SendAppearanceEffectGround, file, "$$$;$$$$$$$$$");
+	newXSproto(strcpy(buf, "RemoveAppearanceEffect"), XS_Mob_RemoveAppearanceEffect, file, "$");
 	newXSproto(strcpy(buf, "SendIllusion"), XS_Mob_SendIllusion, file, "$$;$$$$$$$$$$$$");
 	newXSproto(strcpy(buf, "SendTo"), XS_Mob_SendTo, file, "$$$$");
 	newXSproto(strcpy(buf, "SendToFixZ"), XS_Mob_SendToFixZ, file, "$$$$");

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -4850,11 +4850,11 @@ XS(XS_Mob_SendAppearanceEffectGround) {
 	XSRETURN_EMPTY;
 }
 
-XS(XS_Mob_RemoveAppearanceEffect); /* prototype to pass -Wmissing-prototypes */
-XS(XS_Mob_RemoveAppearanceEffect) {
+XS(XS_Mob_RemoveAllAppearanceEffects); /* prototype to pass -Wmissing-prototypes */
+XS(XS_Mob_RemoveAllAppearanceEffects) {
 	dXSARGS;
 	if (items != 1)
-		Perl_croak(aTHX_ "Usage: Mob::RemoveAppearanceEffect(THIS)"); // @categories Script Utility
+		Perl_croak(aTHX_ "Usage: Mob::RemoveAllAppearanceEffects(THIS)"); // @categories Script Utility
 	{
 		Mob *THIS;
 		VALIDATE_THIS_IS_MOB;
@@ -6822,6 +6822,7 @@ XS(boot_Mob) {
 	newXSproto(strcpy(buf, "RandomizeFeatures"), XS_Mob_RandomizeFeatures, file, "$$;$");
 	newXSproto(strcpy(buf, "RangedAttack"), XS_Mob_RangedAttack, file, "$$");
 	newXSproto(strcpy(buf, "RemoveAllNimbusEffects"), XS_Mob_RemoveAllNimbusEffects, file, "$");
+	newXSproto(strcpy(buf, "RemoveAllAppearanceEffects"), XS_Mob_RemoveAllAppearanceEffects, file, "$");
 	newXSproto(strcpy(buf, "RemoveFromFeignMemory"), XS_Mob_RemoveFromFeignMemory, file, "$$");
 	newXSproto(strcpy(buf, "RemoveNimbusEffect"), XS_Mob_RemoveNimbusEffect, file, "$$");
 	newXSproto(strcpy(buf, "RemovePet"), XS_Mob_RemovePet, file, "$");
@@ -6836,7 +6837,6 @@ XS(boot_Mob) {
 	newXSproto(strcpy(buf, "SendAppearanceEffect"), XS_Mob_SendAppearanceEffect, file, "$$;$$$$$$$$$$$$$$");
 	newXSproto(strcpy(buf, "SendAppearanceEffectActor"), XS_Mob_SendAppearanceEffectActor, file, "$$$;$$$$$$$$$");
 	newXSproto(strcpy(buf, "SendAppearanceEffectGround"), XS_Mob_SendAppearanceEffectGround, file, "$$$;$$$$$$$$$");
-	newXSproto(strcpy(buf, "RemoveAppearanceEffect"), XS_Mob_RemoveAppearanceEffect, file, "$");
 	newXSproto(strcpy(buf, "SendIllusion"), XS_Mob_SendIllusion, file, "$$;$$$$$$$$$$$$");
 	newXSproto(strcpy(buf, "SendTo"), XS_Mob_SendTo, file, "$$$$");
 	newXSproto(strcpy(buf, "SendToFixZ"), XS_Mob_SendToFixZ, file, "$$$$");

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -4701,8 +4701,8 @@ XS(XS_Mob_HasNPCSpecialAtk) {
 XS(XS_Mob_SendAppearanceEffect); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Mob_SendAppearanceEffect) {
 	dXSARGS;
-	if (items < 2 || items > 7)
-		Perl_croak(aTHX_ "Usage: Mob::SendAppearanceEffect(THIS, int32 param_1, [int32 param_2 = 0], [int32 param_3 = 0], [int32 param_4 = 0], [int32 param_5 = 0], [Client* single_client_to_send_to = null])"); // @categories Script Utility
+	if (items < 2 || items > 17)
+		Perl_croak(aTHX_ "Usage: Mob::SendAppearanceEffect(THIS, int32 param_1, [int32 param_2 = 0], [int32 param_3 = 0], [int32 param_4 = 0], [int32 param_5 = 0], [Client* single_client_to_send_to = null]), [uint32 value1slot = 1], [uint32 value1ground = 1], [uint32 value2slot = 1], [uint32 value2ground = 1], [uint32 value3slot = 1], [uint32 value3ground = 1], [uint32 value4slot = 1], [uint32 value4ground = 1], [uint32 value5slot = 1], [uint32 value5ground = 1]"); // @categories Script Utility
 	{
 		Mob *THIS;
 		int32 parm1 = (int32) SvIV(ST(1));
@@ -4710,6 +4710,16 @@ XS(XS_Mob_SendAppearanceEffect) {
 		int32 parm3 = 0;
 		int32 parm4 = 0;
 		int32 parm5 = 0;
+		uint32 value1slot = 1;
+		uint32 value1ground = 1;
+		uint32 value2slot = 1;
+		uint32 value2ground = 1;
+		uint32 value3slot = 1;
+		uint32 value3ground = 1;
+		uint32 value4slot = 1;
+		uint32 value4ground = 1;
+		uint32 value5slot = 1;
+		uint32 value5ground = 1;
 		Client *client = nullptr;
 		VALIDATE_THIS_IS_MOB;
 		if (items > 2) { parm2 = (int32) SvIV(ST(2)); }
@@ -4725,12 +4735,101 @@ XS(XS_Mob_SendAppearanceEffect) {
 			if (client == nullptr)
 				Perl_croak(aTHX_ "client is nullptr, avoiding crash.");
 		}
+		if (items > 7) { value1slot = (uint32)SvIV(ST(7)); }
+		if (items > 8) { value1ground = (uint32)SvIV(ST(8)); }
+		if (items > 9) { value2slot = (uint32)SvIV(ST(9)); }
+		if (items > 10) { value2ground = (uint32)SvIV(ST(10)); }
+		if (items > 11) { value3slot = (uint32)SvIV(ST(11)); }
+		if (items > 12) { value3ground = (uint32)SvIV(ST(12)); }
+		if (items > 13) { value4slot = (uint32)SvIV(ST(13)); }
+		if (items > 14) { value4ground = (uint32)SvIV(ST(14)); }
+		if (items > 15) { value5slot = (uint32)SvIV(ST(15)); }
+		if (items > 16) { value5ground = (uint32)SvIV(ST(16)); }
 
-		THIS->SendAppearanceEffect(parm1, parm2, parm3, parm4, parm5, client);
+		THIS->SendAppearanceEffect(parm1, parm2, parm3, parm4, parm5, client, value1slot, value1ground, value2slot, value2ground, value3slot, value3ground,
+			value4slot, value4ground, value5slot, value5ground);
 	}
 	XSRETURN_EMPTY;
 }
 
+XS(XS_Mob_SendAppearanceEffectActor); /* prototype to pass -Wmissing-prototypes */
+XS(XS_Mob_SendAppearanceEffectActor) {
+	dXSARGS;
+	if (items < 3 || items > 12)
+		Perl_croak(aTHX_ "Usage: Mob::SendAppearanceEffect(THIS, int32 param_1, uint32 value1slot = 0, [int32 param_2 = 0] [uint32 value2slot = 0], [int32 param_3 = 0] [uint32 value3slot = 0], [int32 param_4 = 0] [uint32 value4slot = 0], [int32 param_5 = 0], [uint32 value5slot = 0], [Client* single_client_to_send_to = null])"); // @categories Script Utility
+	{
+		Mob *THIS;
+		int32 parm1 = (int32)SvIV(ST(1));
+		uint32 value1slot = (uint32)SvIV(ST(2));
+		int32 parm2 = 0;
+		uint32 value2slot = 0;
+		int32 parm3 = 0;
+		uint32 value3slot = 0;
+		int32 parm4 = 0;
+		uint32 value4slot = 0;
+		int32 parm5 = 0;
+		uint32 value5slot = 0;
+		Client *client = nullptr;
+		VALIDATE_THIS_IS_MOB;
+		if (items > 3) { parm2 = (int32)SvIV(ST(3)); }
+		if (items > 4) { value2slot = (uint32)SvIV(ST(7)); }
+		if (items > 5) { parm3 = (int32)SvIV(ST(3)); }
+		if (items > 6) { value3slot = (uint32)SvIV(ST(7)); }
+		if (items > 7) { parm4 = (int32)SvIV(ST(4)); }
+		if (items > 8) { value4slot = (uint32)SvIV(ST(7)); }
+		if (items > 9) { parm5 = (int32)SvIV(ST(5)); }
+		if (items > 10) { value5slot = (uint32)SvIV(ST(7)); }
+		if (items > 11) {
+			if (sv_derived_from(ST(6), "Client")) {
+				IV tmp = SvIV((SV *)SvRV(ST(6)));
+				client = INT2PTR(Client *, tmp);
+			}
+			else
+				Perl_croak(aTHX_ "client is not of type Client");
+			if (client == nullptr)
+				Perl_croak(aTHX_ "client is nullptr, avoiding crash.");
+		}
+
+		THIS->SendAppearanceEffect(parm1, parm2, parm3, parm4, parm5, client, value1slot, 0, value2slot, 0, value3slot, 0,
+			value4slot, 0, value5slot, 0);
+	}
+	XSRETURN_EMPTY;
+}
+
+XS(XS_Mob_SendAppearanceEffectGround); /* prototype to pass -Wmissing-prototypes */
+XS(XS_Mob_SendAppearanceEffectGround) {
+	dXSARGS;
+	if (items < 3 || items > 7)
+		Perl_croak(aTHX_ "Usage: Mob::SendAppearanceEffectGround(THIS, int32 param_1, [int32 param_2 = 0] [int32 param_3 = 0] [int32 param_4 = 0] [int32 param_5 = 0], [Client* single_client_to_send_to = null])"); // @categories Script Utility
+	{
+		Mob *THIS;
+		int32 parm1 = (int32)SvIV(ST(1));
+		int32 parm2 = 0;
+		int32 parm3 = 0;
+		int32 parm4 = 0;
+		int32 parm5 = 0;
+		Client *client = nullptr;
+		VALIDATE_THIS_IS_MOB;
+		if (items > 2) { parm2 = (int32)SvIV(ST(2)); }
+		if (items > 3) { parm3 = (int32)SvIV(ST(3)); }
+		if (items > 4) { parm4 = (int32)SvIV(ST(4)); }
+		if (items > 5) { parm5 = (int32)SvIV(ST(5)); }
+		if (items > 6) {
+			if (sv_derived_from(ST(6), "Client")) {
+				IV tmp = SvIV((SV *)SvRV(ST(6)));
+				client = INT2PTR(Client *, tmp);
+			}
+			else
+				Perl_croak(aTHX_ "client is not of type Client");
+			if (client == nullptr)
+				Perl_croak(aTHX_ "client is nullptr, avoiding crash.");
+		}
+
+		THIS->SendAppearanceEffect(parm1, parm2, parm3, parm4, parm5, client, 0, 1, 0, 1, 0, 1,
+			0, 1, 0, 1);
+	}
+	XSRETURN_EMPTY;
+}
 XS(XS_Mob_SetFlyMode); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Mob_SetFlyMode) {
 	dXSARGS;
@@ -6701,7 +6800,9 @@ XS(boot_Mob) {
 	newXSproto(strcpy(buf, "SeeImprovedHide"), XS_Mob_SeeImprovedHide, file, "$");
 	newXSproto(strcpy(buf, "SeeInvisible"), XS_Mob_SeeInvisible, file, "$");
 	newXSproto(strcpy(buf, "SeeInvisibleUndead"), XS_Mob_SeeInvisibleUndead, file, "$");
-	newXSproto(strcpy(buf, "SendAppearanceEffect"), XS_Mob_SendAppearanceEffect, file, "$$;$$$$");
+	newXSproto(strcpy(buf, "SendAppearanceEffect"), XS_Mob_SendAppearanceEffect, file, "$$;$$$$$$$$$$$$$$");
+	newXSproto(strcpy(buf, "SendAppearanceEffectActor"), XS_Mob_SendAppearanceEffectActor, file, "$$$;$$$$$$$$$");
+	newXSproto(strcpy(buf, "SendAppearanceEffectGround"), XS_Mob_SendAppearanceEffectGround, file, "$$;$$$$$");
 	newXSproto(strcpy(buf, "SendIllusion"), XS_Mob_SendIllusion, file, "$$;$$$$$$$$$$$$");
 	newXSproto(strcpy(buf, "SendTo"), XS_Mob_SendTo, file, "$$$$");
 	newXSproto(strcpy(buf, "SendToFixZ"), XS_Mob_SendToFixZ, file, "$$$$");

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -6821,8 +6821,8 @@ XS(boot_Mob) {
 	newXSproto(strcpy(buf, "ProjectileAnim"), XS_Mob_ProjectileAnim, file, "$$$;$$$$$$");
 	newXSproto(strcpy(buf, "RandomizeFeatures"), XS_Mob_RandomizeFeatures, file, "$$;$");
 	newXSproto(strcpy(buf, "RangedAttack"), XS_Mob_RangedAttack, file, "$$");
-	newXSproto(strcpy(buf, "RemoveAllNimbusEffects"), XS_Mob_RemoveAllNimbusEffects, file, "$");
 	newXSproto(strcpy(buf, "RemoveAllAppearanceEffects"), XS_Mob_RemoveAllAppearanceEffects, file, "$");
+	newXSproto(strcpy(buf, "RemoveAllNimbusEffects"), XS_Mob_RemoveAllNimbusEffects, file, "$");
 	newXSproto(strcpy(buf, "RemoveFromFeignMemory"), XS_Mob_RemoveFromFeignMemory, file, "$$");
 	newXSproto(strcpy(buf, "RemoveNimbusEffect"), XS_Mob_RemoveNimbusEffect, file, "$$");
 	newXSproto(strcpy(buf, "RemovePet"), XS_Mob_RemovePet, file, "$");

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -4702,7 +4702,7 @@ XS(XS_Mob_SendAppearanceEffect); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Mob_SendAppearanceEffect) {
 	dXSARGS;
 	if (items < 2 || items > 17)
-		Perl_croak(aTHX_ "Usage: Mob::SendAppearanceEffect(THIS, int32 param_1, [int32 param_2 = 0], [int32 param_3 = 0], [int32 param_4 = 0], [int32 param_5 = 0], [Client* single_client_to_send_to = null]), [uint32 value1slot = 1], [uint32 value1ground = 1], [uint32 value2slot = 1], [uint32 value2ground = 1], [uint32 value3slot = 1], [uint32 value3ground = 1], [uint32 value4slot = 1], [uint32 value4ground = 1], [uint32 value5slot = 1], [uint32 value5ground = 1]"); // @categories Script Utility
+		Perl_croak(aTHX_ "Usage: Mob::SendAppearanceEffect(THIS, int32 effect1, [int32 effect2 = 0], [int32 effect3 = 0], [int32 effect4 = 0], [int32 effect5 = 0], [Client* single_client_to_send_to = null]), [uint32 slot1 = 1], [uint32 ground1 = 1], [uint32 slot2 = 1], [uint32 ground2 = 1], [uint32 slot3 = 1], [uint32 ground2 = 1], [uint32 slot4 = 1], [uint32 ground4 = 1], [uint32 slot5 = 1], [uint32 ground5 = 1]"); // @categories Script Utility
 	{
 		Mob *THIS;
 		int32 parm1 = (int32) SvIV(ST(1));
@@ -4766,7 +4766,7 @@ XS(XS_Mob_SendAppearanceEffectActor); /* prototype to pass -Wmissing-prototypes 
 XS(XS_Mob_SendAppearanceEffectActor) {
 	dXSARGS;
 	if (items < 3 || items > 12)
-		Perl_croak(aTHX_ "Usage: Mob::SendAppearanceEffectActor(THIS, int32 param_1, uint32 value1slot = 0, [int32 param_2 = 0] [uint32 value2slot = 0], [int32 param_3 = 0] [uint32 value3slot = 0], [int32 param_4 = 0] [uint32 value4slot = 0], [int32 param_5 = 0], [uint32 value5slot = 0], [Client* single_client_to_send_to = null])"); // @categories Script Utility
+		Perl_croak(aTHX_ "Usage: Mob::SendAppearanceEffectActor(THIS, int32 effect1, uint32 slot1 = 0, [int32 effect2 = 0] [uint32 slot2 = 0], [int32 effect3 = 0] [uint32 slot3 = 0], [int32 effect4 = 0] [uint32 slot4 = 0], [int32 effect5 = 0], [uint32 slot5 = 0], [Client* single_client_to_send_to = null])"); // @categories Script Utility
 	{
 		Mob *THIS;
 		int32 parm1 = (int32)SvIV(ST(1));
@@ -4810,7 +4810,7 @@ XS(XS_Mob_SendAppearanceEffectGround); /* prototype to pass -Wmissing-prototypes
 XS(XS_Mob_SendAppearanceEffectGround) {
 	dXSARGS;
 	if (items < 3 || items > 12)
-		Perl_croak(aTHX_ "Usage: Mob::SendAppearanceEffectGround(THIS, int32 param_1, uint32 value1slot = 1, [int32 param_2 = 0] [uint32 value2slot = 1], [int32 param_3 = 0] [uint32 value3slot = 1], [int32 param_4 = 0] [uint32 value4slot = 1], [int32 param_5 = 0], [uint32 value5slot = 1], [Client* single_client_to_send_to = null])"); // @categories Script Utility
+		Perl_croak(aTHX_ "Usage: Mob::SendAppearanceEffectActor(THIS, int32 effect1, uint32 slot1 = 1, [int32 effect2 = 0] [uint32 slot2 = 1], [int32 effect3 = 0] [uint32 slot3 = 1], [int32 effect4 = 0] [uint32 slot4 = 1], [int32 effect5 = 0], [uint32 slot5 = 1], [Client* single_client_to_send_to = null])"); // @categories Script Utility
 	{
 		Mob *THIS;
 		int32 parm1 = (int32)SvIV(ST(1));

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -4766,7 +4766,7 @@ XS(XS_Mob_SendAppearanceEffectActor); /* prototype to pass -Wmissing-prototypes 
 XS(XS_Mob_SendAppearanceEffectActor) {
 	dXSARGS;
 	if (items < 3 || items > 12)
-		Perl_croak(aTHX_ "Usage: Mob::SendAppearanceEffectActor(THIS, int32 effect1, uint32 slot1 = 0, [int32 effect2 = 0] [uint32 slot2 = 0], [int32 effect3 = 0] [uint32 slot3 = 0], [int32 effect4 = 0] [uint32 slot4 = 0], [int32 effect5 = 0], [uint32 slot5 = 0], [Client* single_client_to_send_to = null])"); // @categories Script Utility
+		Perl_croak(aTHX_ "Usage: Mob::SendAppearanceEffectActor(THIS, int32 effect1, uint32 slot1 = 0, [int32 effect2 = 0], [uint32 slot2 = 0], [int32 effect3 = 0], [uint32 slot3 = 0], [int32 effect4 = 0], [uint32 slot4 = 0], [int32 effect5 = 0], [uint32 slot5 = 0], [Client* single_client_to_send_to = null])"); // @categories Script Utility
 	{
 		Mob *THIS;
 		int32 parm1 = (int32)SvIV(ST(1));
@@ -4810,7 +4810,7 @@ XS(XS_Mob_SendAppearanceEffectGround); /* prototype to pass -Wmissing-prototypes
 XS(XS_Mob_SendAppearanceEffectGround) {
 	dXSARGS;
 	if (items < 3 || items > 12)
-		Perl_croak(aTHX_ "Usage: Mob::SendAppearanceEffectActor(THIS, int32 effect1, uint32 slot1 = 1, [int32 effect2 = 0] [uint32 slot2 = 1], [int32 effect3 = 0] [uint32 slot3 = 1], [int32 effect4 = 0] [uint32 slot4 = 1], [int32 effect5 = 0], [uint32 slot5 = 1], [Client* single_client_to_send_to = null])"); // @categories Script Utility
+		Perl_croak(aTHX_ "Usage: Mob::SendAppearanceEffectGround(THIS, int32 effect1, uint32 slot1 = 1, [int32 effect2 = 0], [uint32 slot2 = 1], [int32 effect3 = 0], [uint32 slot3 = 1], [int32 effect4 = 0], [uint32 slot4 = 1], [int32 effect5 = 0], [uint32 slot5 = 1], [Client* single_client_to_send_to = null])"); // @categories Script Utility
 	{
 		Mob *THIS;
 		int32 parm1 = (int32)SvIV(ST(1));

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -4782,16 +4782,16 @@ XS(XS_Mob_SendAppearanceEffectActor) {
 		Client *client = nullptr;
 		VALIDATE_THIS_IS_MOB;
 		if (items > 3) { parm2 = (int32)SvIV(ST(3)); }
-		if (items > 4) { value2slot = (uint32)SvIV(ST(7)); }
-		if (items > 5) { parm3 = (int32)SvIV(ST(3)); }
-		if (items > 6) { value3slot = (uint32)SvIV(ST(7)); }
-		if (items > 7) { parm4 = (int32)SvIV(ST(4)); }
-		if (items > 8) { value4slot = (uint32)SvIV(ST(7)); }
-		if (items > 9) { parm5 = (int32)SvIV(ST(5)); }
-		if (items > 10) { value5slot = (uint32)SvIV(ST(7)); }
+		if (items > 4) { value2slot = (uint32)SvIV(ST(4)); }
+		if (items > 5) { parm3 = (int32)SvIV(ST(5)); }
+		if (items > 6) { value3slot = (uint32)SvIV(ST(6)); }
+		if (items > 7) { parm4 = (int32)SvIV(ST(7)); }
+		if (items > 8) { value4slot = (uint32)SvIV(ST(8)); }
+		if (items > 9) { parm5 = (int32)SvIV(ST(9)); }
+		if (items > 10) { value5slot = (uint32)SvIV(ST(10)); }
 		if (items > 11) {
-			if (sv_derived_from(ST(6), "Client")) {
-				IV tmp = SvIV((SV *)SvRV(ST(6)));
+			if (sv_derived_from(ST(11), "Client")) {
+				IV tmp = SvIV((SV *)SvRV(ST(11)));
 				client = INT2PTR(Client *, tmp);
 			}
 			else
@@ -4826,16 +4826,16 @@ XS(XS_Mob_SendAppearanceEffectGround) {
 		Client *client = nullptr;
 		VALIDATE_THIS_IS_MOB;
 		if (items > 3) { parm2 = (int32)SvIV(ST(3)); }
-		if (items > 4) { value2slot = (uint32)SvIV(ST(7)); }
-		if (items > 5) { parm3 = (int32)SvIV(ST(3)); }
-		if (items > 6) { value3slot = (uint32)SvIV(ST(7)); }
-		if (items > 7) { parm4 = (int32)SvIV(ST(4)); }
-		if (items > 8) { value4slot = (uint32)SvIV(ST(7)); }
-		if (items > 9) { parm5 = (int32)SvIV(ST(5)); }
-		if (items > 10) { value5slot = (uint32)SvIV(ST(7)); }
+		if (items > 4) { value2slot = (uint32)SvIV(ST(4)); }
+		if (items > 5) { parm3 = (int32)SvIV(ST(5)); }
+		if (items > 6) { value3slot = (uint32)SvIV(ST(6)); }
+		if (items > 7) { parm4 = (int32)SvIV(ST(7)); }
+		if (items > 8) { value4slot = (uint32)SvIV(ST(8)); }
+		if (items > 9) { parm5 = (int32)SvIV(ST(9)); }
+		if (items > 10) { value5slot = (uint32)SvIV(ST(10)); }
 		if (items > 11) {
 			if (sv_derived_from(ST(6), "Client")) {
-				IV tmp = SvIV((SV *)SvRV(ST(6)));
+				IV tmp = SvIV((SV *)SvRV(ST(11)));
 				client = INT2PTR(Client *, tmp);
 			}
 			else

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -4721,6 +4721,7 @@ XS(XS_Mob_SendAppearanceEffect) {
 		uint32 value5slot = 1;
 		uint32 value5ground = 1;
 		Client *client = nullptr;
+		bool nullclient = false;
 		VALIDATE_THIS_IS_MOB;
 		if (items > 2) { parm2 = (int32) SvIV(ST(2)); }
 		if (items > 3) { parm3 = (int32) SvIV(ST(3)); }
@@ -4728,12 +4729,15 @@ XS(XS_Mob_SendAppearanceEffect) {
 		if (items > 5) { parm5 = (int32) SvIV(ST(5)); }
 		if (items > 6) {
 			if (sv_derived_from(ST(6), "Client")) {
-				IV tmp = SvIV((SV *) SvRV(ST(6)));
+				IV tmp = SvIV((SV *)SvRV(ST(6)));
 				client = INT2PTR(Client *, tmp);
-			} else
-				Perl_croak(aTHX_ "client is not of type Client");
-			if (client == nullptr)
-				Perl_croak(aTHX_ "client is nullptr, avoiding crash.");
+			}
+			else {
+				nullclient = true;
+			}
+			if (client == nullptr) {
+				nullclient = true;
+			}
 		}
 		if (items > 7) { value1slot = (uint32)SvIV(ST(7)); }
 		if (items > 8) { value1ground = (uint32)SvIV(ST(8)); }
@@ -4746,8 +4750,14 @@ XS(XS_Mob_SendAppearanceEffect) {
 		if (items > 15) { value5slot = (uint32)SvIV(ST(15)); }
 		if (items > 16) { value5ground = (uint32)SvIV(ST(16)); }
 
-		THIS->SendAppearanceEffect(parm1, parm2, parm3, parm4, parm5, client, value1slot, value1ground, value2slot, value2ground, value3slot, value3ground,
-			value4slot, value4ground, value5slot, value5ground);
+		if (nullclient) {
+			THIS->SendAppearanceEffect(parm1, parm2, parm3, parm4, parm5, 0, value1slot, value1ground, value2slot, value2ground, value3slot, value3ground,
+				value4slot, value4ground, value5slot, value5ground);
+		}
+		else {
+			THIS->SendAppearanceEffect(parm1, parm2, parm3, parm4, parm5, client, value1slot, value1ground, value2slot, value2ground, value3slot, value3ground,
+				value4slot, value4ground, value5slot, value5ground);
+		}
 	}
 	XSRETURN_EMPTY;
 }
@@ -4756,7 +4766,7 @@ XS(XS_Mob_SendAppearanceEffectActor); /* prototype to pass -Wmissing-prototypes 
 XS(XS_Mob_SendAppearanceEffectActor) {
 	dXSARGS;
 	if (items < 3 || items > 12)
-		Perl_croak(aTHX_ "Usage: Mob::SendAppearanceEffect(THIS, int32 param_1, uint32 value1slot = 0, [int32 param_2 = 0] [uint32 value2slot = 0], [int32 param_3 = 0] [uint32 value3slot = 0], [int32 param_4 = 0] [uint32 value4slot = 0], [int32 param_5 = 0], [uint32 value5slot = 0], [Client* single_client_to_send_to = null])"); // @categories Script Utility
+		Perl_croak(aTHX_ "Usage: Mob::SendAppearanceEffectActor(THIS, int32 param_1, uint32 value1slot = 0, [int32 param_2 = 0] [uint32 value2slot = 0], [int32 param_3 = 0] [uint32 value3slot = 0], [int32 param_4 = 0] [uint32 value4slot = 0], [int32 param_5 = 0], [uint32 value5slot = 0], [Client* single_client_to_send_to = null])"); // @categories Script Utility
 	{
 		Mob *THIS;
 		int32 parm1 = (int32)SvIV(ST(1));
@@ -4799,22 +4809,31 @@ XS(XS_Mob_SendAppearanceEffectActor) {
 XS(XS_Mob_SendAppearanceEffectGround); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Mob_SendAppearanceEffectGround) {
 	dXSARGS;
-	if (items < 3 || items > 7)
-		Perl_croak(aTHX_ "Usage: Mob::SendAppearanceEffectGround(THIS, int32 param_1, [int32 param_2 = 0] [int32 param_3 = 0] [int32 param_4 = 0] [int32 param_5 = 0], [Client* single_client_to_send_to = null])"); // @categories Script Utility
+	if (items < 3 || items > 12)
+		Perl_croak(aTHX_ "Usage: Mob::SendAppearanceEffectGround(THIS, int32 param_1, uint32 value1slot = 1, [int32 param_2 = 0] [uint32 value2slot = 1], [int32 param_3 = 0] [uint32 value3slot = 1], [int32 param_4 = 0] [uint32 value4slot = 1], [int32 param_5 = 0], [uint32 value5slot = 1], [Client* single_client_to_send_to = null])"); // @categories Script Utility
 	{
 		Mob *THIS;
 		int32 parm1 = (int32)SvIV(ST(1));
+		uint32 value1slot = (uint32)SvIV(ST(2));
 		int32 parm2 = 0;
+		uint32 value2slot = 1;
 		int32 parm3 = 0;
+		uint32 value3slot = 1;
 		int32 parm4 = 0;
+		uint32 value4slot = 1;
 		int32 parm5 = 0;
+		uint32 value5slot = 1;
 		Client *client = nullptr;
 		VALIDATE_THIS_IS_MOB;
-		if (items > 2) { parm2 = (int32)SvIV(ST(2)); }
-		if (items > 3) { parm3 = (int32)SvIV(ST(3)); }
-		if (items > 4) { parm4 = (int32)SvIV(ST(4)); }
-		if (items > 5) { parm5 = (int32)SvIV(ST(5)); }
-		if (items > 6) {
+		if (items > 3) { parm2 = (int32)SvIV(ST(3)); }
+		if (items > 4) { value2slot = (uint32)SvIV(ST(7)); }
+		if (items > 5) { parm3 = (int32)SvIV(ST(3)); }
+		if (items > 6) { value3slot = (uint32)SvIV(ST(7)); }
+		if (items > 7) { parm4 = (int32)SvIV(ST(4)); }
+		if (items > 8) { value4slot = (uint32)SvIV(ST(7)); }
+		if (items > 9) { parm5 = (int32)SvIV(ST(5)); }
+		if (items > 10) { value5slot = (uint32)SvIV(ST(7)); }
+		if (items > 11) {
 			if (sv_derived_from(ST(6), "Client")) {
 				IV tmp = SvIV((SV *)SvRV(ST(6)));
 				client = INT2PTR(Client *, tmp);
@@ -4825,11 +4844,12 @@ XS(XS_Mob_SendAppearanceEffectGround) {
 				Perl_croak(aTHX_ "client is nullptr, avoiding crash.");
 		}
 
-		THIS->SendAppearanceEffect(parm1, parm2, parm3, parm4, parm5, client, 0, 1, 0, 1, 0, 1,
-			0, 1, 0, 1);
+		THIS->SendAppearanceEffect(parm1, parm2, parm3, parm4, parm5, client, value1slot, 1, value2slot, 1, value3slot, 1,
+			value4slot, 1, value5slot, 1);
 	}
 	XSRETURN_EMPTY;
 }
+
 XS(XS_Mob_SetFlyMode); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Mob_SetFlyMode) {
 	dXSARGS;
@@ -6802,7 +6822,7 @@ XS(boot_Mob) {
 	newXSproto(strcpy(buf, "SeeInvisibleUndead"), XS_Mob_SeeInvisibleUndead, file, "$");
 	newXSproto(strcpy(buf, "SendAppearanceEffect"), XS_Mob_SendAppearanceEffect, file, "$$;$$$$$$$$$$$$$$");
 	newXSproto(strcpy(buf, "SendAppearanceEffectActor"), XS_Mob_SendAppearanceEffectActor, file, "$$$;$$$$$$$$$");
-	newXSproto(strcpy(buf, "SendAppearanceEffectGround"), XS_Mob_SendAppearanceEffectGround, file, "$$;$$$$$");
+	newXSproto(strcpy(buf, "SendAppearanceEffectGround"), XS_Mob_SendAppearanceEffectGround, file, "$$$;$$$$$$$$$");
 	newXSproto(strcpy(buf, "SendIllusion"), XS_Mob_SendIllusion, file, "$$;$$$$$$$$$$$$");
 	newXSproto(strcpy(buf, "SendTo"), XS_Mob_SendTo, file, "$$$$");
 	newXSproto(strcpy(buf, "SendToFixZ"), XS_Mob_SendToFixZ, file, "$$$$");


### PR DESCRIPTION
Credit to Natedog who figured out what extra parameters actually did!

SendAppearanceEffect  packet has 3 different parameters, with up to 5 different effects per packet 
parm1 = graphic animation
parm1slot (formerly parm1a) = location on body of the graphic animation
		0 = pelvis1
		1 = pelvis2
		2 = helm
		3 = Offhand
		4 = Mainhand
		5 = left foot
		6 = right foot
		9 = Face
parm1ground (formerly parm1b) = place graphic on the ground.  If this is set and and slot > 0, it will follow the mob and be removed upon zoning/death, if slot set to zero it will be perma set to be on ground in that location

Original Perl function Mob->SendAppearanceEffect has been expanded to accept slot and ground parameters

`Usage: Mob::SendAppearanceEffect(THIS, int32 param_1, [int32 param_2 = 0], [int32 param_3 = 0], [int32 param_4 = 0], [int32 param_5 = 0], [Client* single_client_to_send_to = null]), [uint32 value1slot = 1], [uint32 value1ground = 1], [uint32 value2slot = 1], [uint32 value2ground = 1], [uint32 value3slot = 1], [uint32 value3ground = 1], [uint32 value4slot = 1], [uint32 value4ground = 1], [uint32 value5slot = 1], [uint32 value5ground = 1]")`

Example: $client->SendAppearanceEffect(8,10,27,28,31,0, 1,0,2,0,3,0,4,0,5,0);

This will send 5 different graphics, with id 8 going to pelvis, id 10 going to helm, id 27 going to off hand, id 28 going to main hand, id 31 going to left foot.

New Perl functions added for simple use cases for just sending effects that go on the mob, and just sending effects that go on the ground.

`Usage: Mob::SendAppearanceEffectActor(THIS, int32 param_1, uint32 value1slot = 0, [int32 param_2 = 0] [uint32 value2slot = 0], [int32 param_3 = 0] [uint32 value3slot = 0], [int32 param_4 = 0] [uint32 value4slot = 0], [int32 param_5 = 0], [uint32 value5slot = 0], [Client* single_client_to_send_to = null])");`

Example $client->SendAppearanceEffectActor(8, 9) ... can add up to 5 effects
Send effect id 8 to helm,

`Usage: Mob::SendAppearanceEffectGround(THIS, int32 param_1, uint32 value1slot = 1, [int32 param_2 = 0] [uint32 value2slot = 1], [int32 param_3 = 0] [uint32 value3slot = 1], [int32 param_4 = 0] [uint32 value4slot = 1], [int32 param_5 = 0], [uint32 value5slot = 1], [Client* single_client_to_send_to = null])`

Example $client->SendAppearanceEffectGround(100, 0) ... can add up to 5 effects
Send effect id 100 to the ground permanently,

Example $client->SendAppearanceEffectGround(100, 1) ... can add up to 5 effects
Send effect id 100 to the ground around the mob, which will be removed when mob zones or dies.

**11/26 Added perl method that can be used to remove the AppearanceEffect from a character without them die/zoning.
"Usage: Mob::RemoveAppearanceEffect(THIS)");
Be aware anything that sends an illusion packet will remove an ApperanceEffect.**

Note: Many appearance effects are only temporary and can't be used as permanent. 
Note: I do not personally intend to add support to lua, anyone who is capable is more than welcome to do so. 