### PR TITLE
[Commands] Add #petitems Command.

### DIFF
--- a/zone/CMakeLists.txt
+++ b/zone/CMakeLists.txt
@@ -440,6 +440,7 @@ SET(gm_commands
     gm_commands/permaclass.cpp
     gm_commands/permagender.cpp
     gm_commands/permarace.cpp
+    gm_commands/petitems.cpp
     gm_commands/petitioninfo.cpp
     gm_commands/petname.cpp
     gm_commands/pf.cpp

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -277,6 +277,7 @@ int command_init(void)
 		command_add("permaclass", "[Class ID] - Change your or your player target's class, changed client is disconnected", AccountStatus::QuestTroupe, command_permaclass) ||
 		command_add("permagender", "[Gender ID] - Change your or your player target's gender", AccountStatus::QuestTroupe, command_permagender) ||
 		command_add("permarace", "[Race ID] - Change your or your player target's race", AccountStatus::QuestTroupe, command_permarace) ||
+		command_add("petitems", "- View your pet's items if you have one", AccountStatus::ApprenticeGuide, command_petitems) ||
 		command_add("petitioninfo", "[petition number] - Get info about a petition", AccountStatus::ApprenticeGuide, command_petitioninfo) ||
 		command_add("pf", "- Display additional mob coordinate and wandering data", AccountStatus::Player, command_pf) ||
 		command_add("picklock",  "Analog for ldon pick lock for the newer clients since we still don't have it working.", AccountStatus::Player, command_picklock) ||

--- a/zone/command.h
+++ b/zone/command.h
@@ -193,6 +193,7 @@ void command_peqzone(Client *c, const Seperator *sep);
 void command_permaclass(Client *c, const Seperator *sep);
 void command_permagender(Client *c, const Seperator *sep);
 void command_permarace(Client *c, const Seperator *sep);
+void command_petitems(Client *c, const Seperator *sep);
 void command_petitioninfo(Client *c, const Seperator *sep);
 void command_picklock(Client *c, const Seperator *sep);
 void command_profanity(Client *c, const Seperator *sep);

--- a/zone/gm_commands/npcstats.cpp
+++ b/zone/gm_commands/npcstats.cpp
@@ -9,9 +9,7 @@ void command_npcstats(Client *c, const Seperator *sep)
 		target->ShowStats(c);
 
 		// Loot Data
-		if (target->GetLoottableID()) {
-			target->QueryLoot(c);
-		}
+		target->QueryLoot(c);
 	}
 	else {
 		c->Message(Chat::White, "You must target an NPC to use this command.");

--- a/zone/gm_commands/petitems.cpp
+++ b/zone/gm_commands/petitems.cpp
@@ -1,0 +1,25 @@
+#include "../client.h"
+
+void command_petitems(Client *c, const Seperator *sep)
+{
+	if (!c->GetPet()) {
+		c->Message(Chat::White, "You must have a pet to use this command.");
+		return;
+	}
+	
+	auto pet = c->GetPet()->CastToNPC();
+	auto loot_list = pet->GetLootList();
+	if (!loot_list.empty()) {
+		pet->QueryLoot(c, true);
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"Your pet has {} item{}.",
+				loot_list.size(),
+				loot_list.size() != 1 ? "s" : ""
+			).c_str()
+		);
+	} else {
+		c->Message(Chat::White, "Your pet has no items.");
+	}
+}

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -641,18 +641,21 @@ void NPC::ClearItemList() {
 		SendAppearancePacket(AT_Light, GetActiveLightType());
 }
 
-void NPC::QueryLoot(Client* to)
+void NPC::QueryLoot(Client* to, bool is_pet_query)
 {
-	if (itemlist.size() > 0) {
-		to->Message(
-			Chat::White,
-			fmt::format(
-				"Loot | Name: {} ID: {} Loottable ID: {}",
-				GetName(),
-				GetNPCTypeID(),
-				GetLoottableID()
-			).c_str()
-		);
+	if (!itemlist.empty()) {
+		if (!is_pet_query) {
+			to->Message(
+				Chat::White,
+				fmt::format(
+					"Loot | {} ({}) ID: {} Loottable ID: {}",
+					GetName(),
+					GetID(),
+					GetNPCTypeID(),
+					GetLoottableID()
+				).c_str()
+			);
+		}
 
 		int item_count = 0;
 		for (auto current_item : itemlist) {
@@ -674,7 +677,7 @@ void NPC::QueryLoot(Client* to)
 			to->Message(
 				Chat::White,
 				fmt::format(
-					"Item {} | Name: {} ({}){}",
+					"Item {} | {} ({}){}",
 					item_number,
 					linker.GenerateLink().c_str(),
 					current_item->item_id,
@@ -692,25 +695,27 @@ void NPC::QueryLoot(Client* to)
 		}
 	}
 
-	bool has_money = (
-		platinum > 0 ||
-		gold > 0 ||
-		silver > 0 ||
-		copper > 0
-	);
-	if (has_money) {
-		to->Message(
-			Chat::White,
-			fmt::format(
-				"Money | {}",
-				ConvertMoneyToString(
-					platinum,
-					gold,
-					silver,
-					copper
-				)
-			).c_str()
+	if (!is_pet_query) {
+		bool has_money = (
+			platinum > 0 ||
+			gold > 0 ||
+			silver > 0 ||
+			copper > 0
 		);
+		if (has_money) {
+			to->Message(
+				Chat::White,
+				fmt::format(
+					"Money | {}",
+					ConvertMoneyToString(
+						platinum,
+						gold,
+						silver,
+						copper
+					)
+				).c_str()
+			);
+		}
 	}
 }
 

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -203,7 +203,7 @@ public:
 	void	AddCash(uint16 in_copper, uint16 in_silver, uint16 in_gold, uint16 in_platinum);
 	void	AddCash();
 	void	RemoveCash();
-	void	QueryLoot(Client* to);
+	void	QueryLoot(Client* to, bool is_pet_query = false);
 	bool	HasItem(uint32 item_id);
 	uint16	CountItem(uint32 item_id);
 	uint32	GetItemIDBySlot(uint16 loot_slot);


### PR DESCRIPTION
- Add #petitems command to show a person's pet items if they have access to the command.
- Adds a default false parameter to QueryLoot for NPCs that keeps messages and logic from being ran on pets for no reason.
- Cleaned up message a bit for loot and stuff.
- Remove check for loottable ID when using #npcstats for NPCs that get items from a script or otherwise.