### PR TITLE
[Spells] Bard AA clicks should not receive song modifiers.

### DIFF
--- a/zone/client_mods.cpp
+++ b/zone/client_mods.cpp
@@ -1517,6 +1517,11 @@ uint32 Mob::GetInstrumentMod(uint16 spell_id)
 		}
 		return 10;
 	}
+
+	//AA's click effects that use instrument/singing skills don't apply modifiers (Confirmed on live 11/24/21 ~Kayen)
+	if (casting_spell_aa_id) {
+		return 10;
+	}
 		
 	uint32 effectmod = 10;
 	int effectmodcap = 0;


### PR DESCRIPTION
Confirmed on live that AA clicks that use song skills do not benefit from bard song modifiers.

Evident by using Quick Time and Fierce Eye AA, neither benefit from having a song modifier. While similar effects in regular songs do.