### PR TITLE
[Bug Fix] Bind Sight will now function properly 

### DIFF
--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -242,7 +242,7 @@ bool IsBeneficialSpell(uint16 spell_id)
 				    (sai == SAI_Calm || sai == SAI_Dispell_Sight || sai == SAI_Memory_Blur ||
 				     sai == SAI_Calm_Song))
 					return false;
-			} else {
+			} else {//KAYENFIX
 				// If the resisttype is not magic and spell is Bind Sight or Cast Sight
 				// It's not beneficial
 				if ((sai == SAI_Calm && IsEffectInSpell(spell_id, SE_Harmony)) || (sai == SAI_Calm_Song && IsEffectInSpell(spell_id, SE_BindSight)) || (sai == SAI_Dispell_Sight && spells[spell_id].skill == 18 && !IsEffectInSpell(spell_id, SE_VoiceGraft)))

--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -242,7 +242,7 @@ bool IsBeneficialSpell(uint16 spell_id)
 				    (sai == SAI_Calm || sai == SAI_Dispell_Sight || sai == SAI_Memory_Blur ||
 				     sai == SAI_Calm_Song))
 					return false;
-			} else {//KAYENFIX
+			} else {
 				// If the resisttype is not magic and spell is Bind Sight or Cast Sight
 				// It's not beneficial
 				if ((sai == SAI_Calm && IsEffectInSpell(spell_id, SE_Harmony)) || (sai == SAI_Calm_Song && IsEffectInSpell(spell_id, SE_BindSight)) || (sai == SAI_Dispell_Sight && spells[spell_id].skill == 18 && !IsEffectInSpell(spell_id, SE_VoiceGraft)))

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -775,7 +775,7 @@ typedef enum {
 //#define SE_CorpseBomb					70	// not used
 #define SE_NecPet						71	// implemented
 //#define SE_PreserveCorpse				72	// not used
-#define SE_BindSight					73	// implemented
+#define SE_BindSight					73	// implemented, @Vision, see through the eyes of your target, click off buff to end effect, base: 1, limit: none, max: none
 #define SE_FeignDeath					74	// implemented
 #define SE_VoiceGraft					75	// implemented
 #define SE_Sentinel						76	// *not implemented?(just seems to send a message)

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -3986,8 +3986,9 @@ void Client::Handle_OP_BuffRemoveRequest(const EQApplicationPacket *app)
 
 	uint16 SpellID = m->GetSpellIDFromSlot(brrs->SlotID);
 
-	if (SpellID && IsBeneficialSpell(SpellID) && !spells[SpellID].no_remove)
+	if (SpellID && (IsBeneficialSpell(SpellID) || IsEffectInSpell(SpellID, SE_BindSight)) && !spells[SpellID].no_remove) {
 		m->BuffFadeBySlot(brrs->SlotID, true);
+	}
 }
 
 void Client::Handle_OP_Bug(const EQApplicationPacket *app)

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3644,13 +3644,11 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 		}
 	}
 
+	//KAYENFIX
 	// select target
-	if	// Bind Sight line of spells
-	(
-		spell_id == 500 ||	// bind sight
-		spell_id == 407		// cast sight
-	)
+	if (IsEffectInSpell(spell_id, SE_BindSight))
 	{
+		Shout("DEBUG 1: Bind Sight Cast");
 		action->target = GetID();
 	}
 	else

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -1462,7 +1462,7 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 		for (int i = 0; i < GetMaxTotalSlots(); i++) {
 			if (buffs[i].spellid == spell_id) {
 				CastToClient()->SendBuffNumHitPacket(buffs[i], i);//its hack, it works.
-				continue;
+				break;
 			}
 		}
 	}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -1458,6 +1458,15 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 	if(DeleteChargeFromSlot >= 0)
 		CastToClient()->DeleteItemInInventory(DeleteChargeFromSlot, 1, true);
 
+	if (IsClient() && IsEffectInSpell(spell_id, SE_BindSight)) {
+		for (int i = 0; i < GetMaxTotalSlots(); i++) {
+			if (buffs[i].spellid == spell_id) {
+				CastToClient()->SendBuffNumHitPacket(buffs[i], i);//its hack, it works.
+				continue;
+			}
+		}
+	}
+
 	//
 	// at this point the spell has successfully been cast
 	//
@@ -3644,11 +3653,9 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 		}
 	}
 
-	//KAYENFIX
 	// select target
 	if (IsEffectInSpell(spell_id, SE_BindSight))
 	{
-		Shout("DEBUG 1: Bind Sight Cast");
 		action->target = GetID();
 	}
 	else


### PR DESCRIPTION
Fixed issue where Bind Sight effects would not display the buff on your character when initially cast
Fixed issue where you could not click off the buff on your character (preventing you from restoring your own vision)
Fixed issue where the effect was hard coded to only two spells

SE_BindSight	73 see through the eyes of your target, click off buff to end effect, base: 1, limit: none, max: none