### PR TITLE
[Bug Fix] Buff hit counter will now display instantly on cast.

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -1458,6 +1458,16 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 	if(DeleteChargeFromSlot >= 0)
 		CastToClient()->DeleteItemInInventory(DeleteChargeFromSlot, 1, true);
 
+	//Check if buffs has numhits, then resend packet so it displays the hit count.
+	if (IsClient() && (spells[spell_id].buff_duration > 0 || spells[spell_id].short_buff_box)) {
+		for (int i = 0; i < GetMaxTotalSlots(); i++) {
+			if (buffs[i].spellid == spell_id && buffs[i].hit_number > 0) {
+				CastToClient()->SendBuffNumHitPacket(buffs[i], i);
+				break;
+			}
+		}
+	}
+
 	//
 	// at this point the spell has successfully been cast
 	//


### PR DESCRIPTION
Resolves the issue with buff hit counters not displaying the counters instantly when buff is applied to client.

Hit counters are that little number on the buffs that tells you how many times something can happen till it fades.