### PR TITLE
[Bug Fix] Fix Raid Groups Auto Split.

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -13706,35 +13706,33 @@ void Client::Handle_OP_Split(const EQApplicationPacket *app)
 	//Per the note above, Im not exactly sure what to do on error
 	//to notify the client of the error...
 
-	Group *group = nullptr;
-	Raid *raid = nullptr;
+	Group *group = GetGroup();
+	Raid *raid = GetRaid();
 
-	if (IsRaidGrouped())
-		raid = GetRaid();
-	else if (IsGrouped())
-		group = GetGroup();
-
-	// is there an actual error message for this?
-	if (raid == nullptr && group == nullptr) {
+	if (!raid && !group) {
 		Message(Chat::Red, "You can not split money if you're not in a group.");
 		return;
 	}
 
-	if (!TakeMoneyFromPP(static_cast<uint64>(split->copper) +
-		10 * static_cast<uint64>(split->silver) +
-		100 * static_cast<uint64>(split->gold) +
-		1000 * static_cast<uint64>(split->platinum))) {
+	if (
+		!TakeMoneyFromPP(
+			static_cast<uint64>(split->copper) +
+			10 * static_cast<uint64>(split->silver) +
+			100 * static_cast<uint64>(split->gold) +
+			1000 * static_cast<uint64>(split->platinum)
+		)
+	) {
 		Message(Chat::Red, "You do not have enough money to do that split.");
 		return;
 	}
 
-	if (raid)
-		raid->SplitMoney(raid->GetGroup(this), split->copper, split->silver, split->gold, split->platinum);
-	else if (group)
+	if (raid) {
+		raid->SplitMoney(split->copper, split->silver, split->gold, split->platinum);
+	} else if (group) {
 		group->SplitMoney(split->copper, split->silver, split->gold, split->platinum);
+	}
 
 	return;
-
 }
 
 void Client::Handle_OP_Surname(const EQApplicationPacket *app)

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -1083,7 +1083,6 @@ void Corpse::MakeLootRequestPackets(Client* client, const EQApplicationPacket* a
 			d->gold = 0;
 			d->platinum = 0;
 			client_raid->SplitMoney(
-				client_raid->GetGroup(client),
 				GetCopper(),
 				GetSilver(),
 				GetGold(),

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -937,8 +937,9 @@ void Corpse::AllowPlayerLoot(Mob *them, uint8 slot) {
 }
 
 void Corpse::MakeLootRequestPackets(Client* client, const EQApplicationPacket* app) {
-	if (!client)
+	if (!client) {
 		return;
+	}
 
 	// Added 12/08. Started compressing loot struct on live.
 	if(player_corpse_depop) {
@@ -959,8 +960,9 @@ void Corpse::MakeLootRequestPackets(Client* client, const EQApplicationPacket* a
 		return;
 	}
 
-	if(!being_looted_by || (being_looted_by != 0xFFFFFFFF && !entity_list.GetID(being_looted_by)))
+	if(!being_looted_by || (being_looted_by != 0xFFFFFFFF && !entity_list.GetID(being_looted_by))) {
 		being_looted_by = 0xFFFFFFFF;
+	}
 
 	if (DistanceSquaredNoZ(client->GetPosition(), m_Position) > 625) {
 		SendLootReqErrorPacket(client, LootResponse::TooFar);
@@ -977,26 +979,32 @@ void Corpse::MakeLootRequestPackets(Client* client, const EQApplicationPacket* a
 
 	// loot_request_type is scoped to class Corpse and reset on a per-loot session basis
 	if (client->GetGM()) {
-		if (client->Admin() >= AccountStatus::GMAdmin)
-			loot_request_type = LootRequestType::GMAllowed;
-		else
-			loot_request_type = LootRequestType::GMPeek;
-	}
-	else {
+		loot_request_type = (
+			client->Admin() >= AccountStatus::GMAdmin ?
+			LootRequestType::GMAllowed :
+			LootRequestType::GMPeek
+		);
+	} else {
 		if (IsPlayerCorpse()) {
 			if (char_id == client->CharacterID()) {
 				loot_request_type = LootRequestType::Self;
-			}
-			else if (CanPlayerLoot(client->CharacterID())) {
-				if (GetPlayerKillItem() == -1)
+			} else if (CanPlayerLoot(client->CharacterID())) {
+				auto player_kill_item = GetPlayerKillItem();
+				if (player_kill_item == -1) {
 					loot_request_type = LootRequestType::AllowedPVPAll;
-				else if (GetPlayerKillItem() == 1)
+				} else if (player_kill_item == 1) {
 					loot_request_type = LootRequestType::AllowedPVPSingle;
-				else if (GetPlayerKillItem() > 1)
+				} else if (player_kill_item > 1) {
 					loot_request_type = LootRequestType::AllowedPVPDefined;
+				}
 			}
-		}
-		else if ((IsNPCCorpse() || become_npc) && CanPlayerLoot(client->CharacterID())) {
+		} else if (
+			CanPlayerLoot(client->CharacterID()) &&
+			(
+				IsNPCCorpse() ||
+				become_npc
+			)
+		) {
 			loot_request_type = LootRequestType::AllowedPVE;
 		}
 
@@ -1010,71 +1018,105 @@ void Corpse::MakeLootRequestPackets(Client* client, const EQApplicationPacket* a
 	}
 
 	being_looted_by = client->GetID();
-	client->CommonBreakInvisible(); // we should be "all good" so lets break invis now instead of earlier before all error checking is done
+	client->CommonBreakInvisible();
 
-	// process coin
 	bool loot_coin = false;
 	std::string tmp;
-	if (database.GetVariable("LootCoin", tmp))
+	if (database.GetVariable("LootCoin", tmp)) {
 		loot_coin = (tmp[0] == 1 && tmp[1] == '\0');
-
-	if (loot_request_type == LootRequestType::GMPeek || loot_request_type == LootRequestType::GMAllowed) {
-		client->Message(Chat::Yellow, "This corpse contains %u platinum, %u gold, %u silver and %u copper.",
-			GetPlatinum(), GetGold(), GetSilver(), GetCopper());
-
-		auto outapp = new EQApplicationPacket(OP_MoneyOnCorpse, sizeof(moneyOnCorpseStruct));
-		moneyOnCorpseStruct* d = (moneyOnCorpseStruct*)outapp->pBuffer;
-
-		d->response = static_cast<uint8>(LootResponse::Normal);
-		d->unknown1 = 0x42;
-		d->unknown2 = 0xef;
-
-		d->copper = 0;
-		d->silver = 0;
-		d->gold = 0;
-		d->platinum = 0;
-
-		outapp->priority = 6;
-		client->QueuePacket(outapp);
-
-		safe_delete(outapp);
 	}
-	else {
-		auto outapp = new EQApplicationPacket(OP_MoneyOnCorpse, sizeof(moneyOnCorpseStruct));
-		moneyOnCorpseStruct* d = (moneyOnCorpseStruct*)outapp->pBuffer;
 
-		d->response = static_cast<uint8>(LootResponse::Normal);
-		d->unknown1 = 0x42;
-		d->unknown2 = 0xef;
+	if (
+		loot_request_type == LootRequestType::GMPeek ||
+		loot_request_type == LootRequestType::GMAllowed
+	) {
+		if (
+			GetPlatinum() ||
+			GetGold() ||
+			GetSilver() ||
+			GetCopper()
+		) {
+			client->Message(
+				Chat::White,
+				fmt::format(
+					"This corpse contains {}.",
+					ConvertMoneyToString(
+						GetPlatinum(),
+						GetGold(),
+						GetSilver(),
+						GetCopper()
+					)
+				).c_str()
+			);
+		}
+	}
 
-		Group* cgroup = client->GetGroup();
+	auto outapp = new EQApplicationPacket(OP_MoneyOnCorpse, sizeof(moneyOnCorpseStruct));
+	moneyOnCorpseStruct* d = (moneyOnCorpseStruct*) outapp->pBuffer;
 
-		// this can be reworked into a switch and/or massaged to include specialized pve loot rules based on 'LootRequestType'
-		if (!IsPlayerCorpse() && client->IsGrouped() && client->AutoSplitEnabled() && cgroup) {
+	d->response = static_cast<uint8>(LootResponse::Normal);
+	d->unknown1 = 0x42;
+	d->unknown2 = 0xef;
+
+	if (
+		loot_request_type != LootRequestType::GMPeek &&
+		loot_request_type != LootRequestType::GMAllowed
+		) {
+		Group* client_group = client->GetGroup();
+		Raid* client_raid = client->GetRaid();
+
+		if (!IsPlayerCorpse() && client->IsGrouped() && client->AutoSplitEnabled() && client_group) {
 			d->copper = 0;
 			d->silver = 0;
 			d->gold = 0;
 			d->platinum = 0;
-			cgroup->SplitMoney(GetCopper(), GetSilver(), GetGold(), GetPlatinum(), client);
-		}
-		else {
+			client_group->SplitMoney(
+				GetCopper(),
+				GetSilver(),
+				GetGold(),
+				GetPlatinum(),
+				client
+			);
+		} else if (!IsPlayerCorpse() && client->IsRaidGrouped() && client->AutoSplitEnabled() && client_raid) {
+			d->copper = 0;
+			d->silver = 0;
+			d->gold = 0;
+			d->platinum = 0;
+			client_raid->SplitMoney(
+				client_raid->GetGroup(client),
+				GetCopper(),
+				GetSilver(),
+				GetGold(),
+				GetPlatinum(),
+				client
+			);			
+		} else {
 			d->copper = GetCopper();
 			d->silver = GetSilver();
 			d->gold = GetGold();
 			d->platinum = GetPlatinum();
-			client->AddMoneyToPP(GetCopper(), GetSilver(), GetGold(), GetPlatinum(), false);
+			client->AddMoneyToPP(
+				GetCopper(),
+				GetSilver(),
+				GetGold(),
+				GetPlatinum(),
+				false
+			);
 		}
 
 		RemoveCash();
 		Save();
-
-		outapp->priority = 6;
-		client->QueuePacket(outapp);
-
-		safe_delete(outapp);
+	} else {
+		d->copper = 0;
+		d->silver = 0;
+		d->gold = 0;
+		d->platinum = 0;
 	}
 
-	// process items
+	outapp->priority = 6;
+	client->QueuePacket(outapp);
+	safe_delete(outapp);
+
 	auto timestamps = database.GetItemRecastTimestamps(client->CharacterID());
 
 	if (loot_request_type == LootRequestType::AllowedPVPDefined) {
@@ -1083,17 +1125,18 @@ void Corpse::MakeLootRequestPackets(Client* client, const EQApplicationPacket* a
 		auto pkinst = database.CreateItem(pkitem, pkitem->MaxCharges);
 
 		if (pkinst) {
-			if (pkitem->RecastDelay)
-				pkinst->SetRecastTimestamp(timestamps.count(pkitem->RecastType) ? timestamps.at(pkitem->RecastType) : 0);
-
+			if (pkitem->RecastDelay) {
+				pkinst->SetRecastTimestamp(
+					timestamps.count(pkitem->RecastType) ?
+					timestamps.at(pkitem->RecastType) :
+					0
+				);
+			}
 			LogInventory("MakeLootRequestPackets() Slot [{}], Item [{}]", EQ::invslot::CORPSE_BEGIN, pkitem->Name);
-
 			client->SendItemPacket(EQ::invslot::CORPSE_BEGIN, pkinst, ItemPacketLoot);
 			safe_delete(pkinst);
-		}
-		else {
+		} else {
 			LogInventory("MakeLootRequestPackets() PlayerKillItem [{}] not found", pkitemid);
-
 			client->Message(Chat::Red, "PlayerKillItem (id: %i) could not be found!", pkitemid);
 		}
 
@@ -1110,17 +1153,28 @@ void Corpse::MakeLootRequestPackets(Client* client, const EQApplicationPacket* a
 		item_data->lootslot = 0xFFFF;
 
 		// align server and client corpse slot mappings so translators can function properly
-		while (loot_slot <= EQ::invslot::CORPSE_END && (((uint64)1 << loot_slot) & corpse_mask) == 0)
+		while (loot_slot <= EQ::invslot::CORPSE_END && (((uint64)1 << loot_slot) & corpse_mask) == 0) {
 			++loot_slot;
-		if (loot_slot > EQ::invslot::CORPSE_END)
+		}
+
+		if (loot_slot > EQ::invslot::CORPSE_END) {
 			continue;
+		}
 
 		if (IsPlayerCorpse()) {
-			if (loot_request_type == LootRequestType::AllowedPVPSingle && loot_slot != EQ::invslot::CORPSE_BEGIN)
+			if (
+				loot_request_type == LootRequestType::AllowedPVPSingle &&
+				loot_slot != EQ::invslot::CORPSE_BEGIN
+			) {
 				continue;
+			}
 
-			if (item_data->equip_slot < EQ::invslot::POSSESSIONS_BEGIN || item_data->equip_slot > EQ::invslot::POSSESSIONS_END)
+			if (
+				item_data->equip_slot < EQ::invslot::POSSESSIONS_BEGIN ||
+				item_data->equip_slot > EQ::invslot::POSSESSIONS_END
+			) {
 				continue;
+			}
 		}
 
 		const auto *item = database.GetItem(item_data->item_id);
@@ -1135,27 +1189,30 @@ void Corpse::MakeLootRequestPackets(Client* client, const EQApplicationPacket* a
 			item_data->aug_6,
 			item_data->attuned
 		);
-		if (!inst)
+		if (!inst) {
 			continue;
+		}
 
-		if (item->RecastDelay)
-			inst->SetRecastTimestamp(timestamps.count(item->RecastType) ? timestamps.at(item->RecastType) : 0);
+		if (item->RecastDelay) {
+			inst->SetRecastTimestamp(
+				timestamps.count(item->RecastType) ?
+				timestamps.at(item->RecastType) :
+				0
+			);
+		}
 
 		LogInventory("MakeLootRequestPackets() Slot [{}], Item [{}]", loot_slot, item->Name);
-
 		client->SendItemPacket(loot_slot, inst, ItemPacketLoot);
 		safe_delete(inst);
-
 		item_data->lootslot = loot_slot++;
 	}
 
-	// Disgrace: Client seems to require that we send the packet back...
 	client->QueuePacket(app);
-
-	// This is required for the 'Loot All' feature to work for SoD clients. I expect it is to tell the client that the
-	// server has now sent all the items on the corpse.
-	if (client->ClientVersion() >= EQ::versions::ClientVersion::SoD)
+	if (client->ClientVersion() >= EQ::versions::ClientVersion::SoD) {
+		// This is required for the 'Loot All' feature to work for SoD clients. I expect it is to tell the client that the
+		// server has now sent all the items on the corpse.
 		SendLootReqErrorPacket(client, LootResponse::LootAll);
+	}
 }
 
 void Corpse::LootItem(Client *client, const EQApplicationPacket *app)

--- a/zone/lua_raid.cpp
+++ b/zone/lua_raid.cpp
@@ -51,14 +51,14 @@ uint32 Lua_Raid::GetTotalRaidDamage(Lua_Mob other) {
 	return self->GetTotalRaidDamage(other);
 }
 
-void Lua_Raid::SplitMoney(uint32 gid, uint32 copper, uint32 silver, uint32 gold, uint32 platinum) {
+void Lua_Raid::SplitMoney(uint32 copper, uint32 silver, uint32 gold, uint32 platinum) {
 	Lua_Safe_Call_Void();
-	self->SplitMoney(gid, copper, silver, gold, platinum);
+	self->SplitMoney(copper, silver, gold, platinum);
 }
 
-void Lua_Raid::SplitMoney(uint32 gid, uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Lua_Client splitter) {
+void Lua_Raid::SplitMoney(uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Lua_Client splitter) {
 	Lua_Safe_Call_Void();
-	self->SplitMoney(gid, copper, silver, gold, platinum, splitter);
+	self->SplitMoney(copper, silver, gold, platinum, splitter);
 }
 
 void Lua_Raid::BalanceHP(int penalty, uint32 group_id) {
@@ -167,8 +167,8 @@ luabind::scope lua_register_raid() {
 	.def("IsRaidMember", (bool(Lua_Raid::*)(const char*))&Lua_Raid::IsRaidMember)
 	.def("RaidCount", (int(Lua_Raid::*)(void))&Lua_Raid::RaidCount)
 	.def("SplitExp", (void(Lua_Raid::*)(uint32,Lua_Mob))&Lua_Raid::SplitExp)
-	.def("SplitMoney", (void(Lua_Raid::*)(uint32,uint32,uint32,uint32,uint32))&Lua_Raid::SplitMoney)
-	.def("SplitMoney", (void(Lua_Raid::*)(uint32,uint32,uint32,uint32,uint32,Lua_Client))&Lua_Raid::SplitMoney)
+	.def("SplitMoney", (void(Lua_Raid::*)(uint32,uint32,uint32,uint32))&Lua_Raid::SplitMoney)
+	.def("SplitMoney", (void(Lua_Raid::*)(uint32,uint32,uint32,uint32,Lua_Client))&Lua_Raid::SplitMoney)
 	.def("TeleportGroup", (int(Lua_Raid::*)(Lua_Mob,uint32,uint32,float,float,float,float,uint32))&Lua_Raid::TeleportGroup)
 	.def("TeleportRaid", (int(Lua_Raid::*)(Lua_Mob,uint32,uint32,float,float,float,float))&Lua_Raid::TeleportRaid);
 }

--- a/zone/lua_raid.h
+++ b/zone/lua_raid.h
@@ -34,8 +34,8 @@ public:
 	int GetGroup(Lua_Client c);
 	void SplitExp(uint32 exp, Lua_Mob other);
 	uint32 GetTotalRaidDamage(Lua_Mob other);
-	void SplitMoney(uint32 gid, uint32 copper, uint32 silver, uint32 gold, uint32 platinum);
-	void SplitMoney(uint32 gid, uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Lua_Client splitter);
+	void SplitMoney(uint32 copper, uint32 silver, uint32 gold, uint32 platinum);
+	void SplitMoney(uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Lua_Client splitter);
 	void BalanceHP(int penalty, uint32 group_id);
 	bool IsLeader(const char *c);
 	bool IsLeader(Lua_Client c);

--- a/zone/perl_raids.cpp
+++ b/zone/perl_raids.cpp
@@ -176,16 +176,15 @@ XS(XS_Raid_SplitMoney); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Raid_SplitMoney) {
 	dXSARGS;
 	if (items != 5)
-		Perl_croak(aTHX_ "Usage: Raid::SplitMoney(THIS, uint32 gid, uint32 copper, uint32 silver, uint32 gold, uint32 platinum)"); // @categories Currency and Points, Raid
+		Perl_croak(aTHX_ "Usage: Raid::SplitMoney(THIS, uint32 copper, uint32 silver, uint32 gold, uint32 platinum)"); // @categories Currency and Points, Raid
 	{
 		Raid   *THIS;
-		uint32 gid      = (uint32) SvUV(ST(1));
-		uint32 copper   = (uint32) SvUV(ST(2));
-		uint32 silver   = (uint32) SvUV(ST(3));
-		uint32 gold     = (uint32) SvUV(ST(4));
-		uint32 platinum = (uint32) SvUV(ST(5));
+		uint32 copper   = (uint32) SvUV(ST(1));
+		uint32 silver   = (uint32) SvUV(ST(2));
+		uint32 gold     = (uint32) SvUV(ST(3));
+		uint32 platinum = (uint32) SvUV(ST(4));
 		VALIDATE_THIS_IS_RAID;
-		THIS->SplitMoney(gid, copper, silver, gold, platinum);
+		THIS->SplitMoney(copper, silver, gold, platinum);
 	}
 	XSRETURN_EMPTY;
 }
@@ -437,7 +436,7 @@ XS(boot_Raid) {
 	newXSproto(strcpy(buf, "IsRaidMember"), XS_Raid_IsRaidMember, file, "$$");
 	newXSproto(strcpy(buf, "RaidCount"), XS_Raid_RaidCount, file, "$");
 	newXSproto(strcpy(buf, "SplitExp"), XS_Raid_SplitExp, file, "$$$");
-	newXSproto(strcpy(buf, "SplitMoney"), XS_Raid_SplitMoney, file, "$$$$$$");
+	newXSproto(strcpy(buf, "SplitMoney"), XS_Raid_SplitMoney, file, "$$$$$");
 	newXSproto(strcpy(buf, "TeleportGroup"), XS_Raid_TeleportGroup, file, "$$$$$$$$");
 	newXSproto(strcpy(buf, "TeleportRaid"), XS_Raid_TeleportRaid, file, "$$$$$$$");
 	XSRETURN_YES;

--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -733,96 +733,85 @@ void Raid::BalanceMana(int32 penalty, uint32 gid, float range, Mob* caster, int3
 
 //basically the same as Group's version just with more people like a lot of non group specific raid stuff
 //this only functions if the member has a group in the raid. This does not support /autosplit?
-void Raid::SplitMoney(uint32 gid, uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Client *splitter)
+void Raid::SplitMoney(uint32 group_id, uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Client *splitter)
 {
-	//avoid unneeded work
-	if (gid == RAID_GROUPLESS)
+	if (group_id == RAID_GROUPLESS) {
 		return;
+	}
 
-	if(copper == 0 && silver == 0 && gold == 0 && platinum == 0)
+	if (
+		!platinum &&
+		!gold &&
+		!silver &&
+		!copper
+	) {
 		return;
+	}
 
-	uint32 i;
-	uint8 membercount = 0;
-	for (i = 0; i < MAX_RAID_MEMBERS; i++) {
-		if (members[i].member != nullptr && members[i].GroupNumber == gid) {
-			membercount++;
+	uint32 member_index;
+	uint8 split_count = 0;
+	for (member_index = 0; member_index < MAX_RAID_MEMBERS; member_index++) {
+		if (
+			members[member_index].member &&
+			members[member_index].GroupNumber == group_id
+		) {
+			split_count++;
 		}
 	}
 
-	if (membercount == 0)
+	if (!split_count) {
 		return;
+	}
 
-	uint32 mod;
-	//try to handle round off error a little better
-	if(membercount > 1) {
-		mod = platinum % membercount;
-		if((mod) > 0) {
-			platinum -= mod;
-			gold += 10 * mod;
+	uint32 split_modifier;
+	if(split_count > 1) {
+		split_modifier = platinum % split_count;
+		if (split_modifier) {
+			platinum -= split_modifier;
+			gold += (10 * split_modifier);
 		}
-		mod = gold % membercount;
-		if((mod) > 0) {
-			gold -= mod;
-			silver += 10 * mod;
+
+		split_modifier = gold % split_count;
+		if (split_modifier) {
+			gold -= split_modifier;
+			silver += (10 * split_modifier);
 		}
-		mod = silver % membercount;
-		if((mod) > 0) {
-			silver -= mod;
-			copper += 10 * mod;
+
+		split_modifier = silver % split_count;
+		if (split_modifier) {
+			silver -= split_modifier;
+			copper += (10 * split_modifier);
 		}
 	}
 
-	//calculate the splits
-	//We can still round off copper pieces, but I dont care
-	uint32 sc;
-	uint32 cpsplit = copper / membercount;
-	sc = copper % membercount;
-	uint32 spsplit = silver / membercount;
-	uint32 gpsplit = gold / membercount;
-	uint32 ppsplit = platinum / membercount;
+	uint32 copper_split = copper / split_count;
+	uint32 silver_split = silver / split_count;
+	uint32 gold_split = gold / split_count;
+	uint32 platinum_split = platinum / split_count;
 
-	char buf[128];
-	buf[63] = '\0';
-	std::string msg = "You receive";
-	bool one = false;
-
-	if(ppsplit > 0) {
-		snprintf(buf, 63, " %u platinum", ppsplit);
-		msg += buf;
-		one = true;
-	}
-	if(gpsplit > 0) {
-		if(one)
-			msg += ",";
-		snprintf(buf, 63, " %u gold", gpsplit);
-		msg += buf;
-		one = true;
-	}
-	if(spsplit > 0) {
-		if(one)
-			msg += ",";
-		snprintf(buf, 63, " %u silver", spsplit);
-		msg += buf;
-		one = true;
-	}
-	if(cpsplit > 0) {
-		if(one)
-			msg += ",";
-		//this message is not 100% accurate for the splitter
-		//if they are receiving any roundoff
-		snprintf(buf, 63, " %u copper", cpsplit);
-		msg += buf;
-		one = true;
-	}
-	msg += " as your split";
-
-	for (i = 0; i < MAX_RAID_MEMBERS; i++) {
-		if (members[i].member != nullptr && members[i].GroupNumber == gid) { // If Group Member is Client
-			//I could not get MoneyOnCorpse to work, so we use this
-			members[i].member->AddMoneyToPP(cpsplit, spsplit, gpsplit, ppsplit, true);
-
-			members[i].member->Message(Chat::Green, msg.c_str());
+	
+	for (member_index = 0; member_index < MAX_RAID_MEMBERS; member_index++) {
+		if (members[member_index].member) {
+			Client *c = members[member_index].member;
+			c->AddMoneyToPP(
+				copper_split,
+				silver_split,
+				gold_split,
+				platinum_split,
+				true
+			);
+			c->Message(
+				Chat::Green,
+				fmt::format(
+					"You receieve {} as your split.",
+					ConvertMoneyToString(
+						platinum_split,
+						gold_split,
+						silver_split,
+						copper_split
+					)
+				).c_str()
+			);
 		}
 	}
 }

--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -733,12 +733,8 @@ void Raid::BalanceMana(int32 penalty, uint32 gid, float range, Mob* caster, int3
 
 //basically the same as Group's version just with more people like a lot of non group specific raid stuff
 //this only functions if the member has a group in the raid. This does not support /autosplit?
-void Raid::SplitMoney(uint32 group_id, uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Client *splitter)
+void Raid::SplitMoney(uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Client *splitter)
 {
-	if (group_id == RAID_GROUPLESS) {
-		return;
-	}
-
 	if (
 		!platinum &&
 		!gold &&
@@ -751,10 +747,7 @@ void Raid::SplitMoney(uint32 group_id, uint32 copper, uint32 silver, uint32 gold
 	uint32 member_index;
 	uint8 split_count = 0;
 	for (member_index = 0; member_index < MAX_RAID_MEMBERS; member_index++) {
-		if (
-			members[member_index].member &&
-			members[member_index].GroupNumber == group_id
-		) {
+		if (members[member_index].member) {
 			split_count++;
 		}
 	}
@@ -764,7 +757,7 @@ void Raid::SplitMoney(uint32 group_id, uint32 copper, uint32 silver, uint32 gold
 	}
 
 	uint32 split_modifier;
-	if(split_count > 1) {
+	if (split_count > 1) {
 		split_modifier = platinum % split_count;
 		if (split_modifier) {
 			platinum -= split_modifier;

--- a/zone/raids.h
+++ b/zone/raids.h
@@ -159,7 +159,7 @@ public:
 	void	BalanceHP(int32 penalty, uint32 gid, float range = 0, Mob* caster = nullptr, int32 limit = 0);
 	void	BalanceMana(int32 penalty, uint32 gid,  float range = 0, Mob* caster = nullptr, int32 limit = 0);
 	void	HealGroup(uint32 heal_amt, Mob* caster, uint32 gid, float range = 0);
-	void	SplitMoney(uint32 group_id, uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Client *splitter = nullptr);
+	void	SplitMoney(uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Client *splitter = nullptr);
 	void	GroupBardPulse(Mob* caster, uint16 spellid, uint32 gid);
 
 	void	TeleportGroup(Mob* sender, uint32 zoneID, uint16 instance_id, float x, float y, float z, float heading, uint32 gid);

--- a/zone/raids.h
+++ b/zone/raids.h
@@ -159,7 +159,7 @@ public:
 	void	BalanceHP(int32 penalty, uint32 gid, float range = 0, Mob* caster = nullptr, int32 limit = 0);
 	void	BalanceMana(int32 penalty, uint32 gid,  float range = 0, Mob* caster = nullptr, int32 limit = 0);
 	void	HealGroup(uint32 heal_amt, Mob* caster, uint32 gid, float range = 0);
-	void	SplitMoney(uint32 gid, uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Client *splitter = nullptr);
+	void	SplitMoney(uint32 group_id, uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Client *splitter = nullptr);
 	void	GroupBardPulse(Mob* caster, uint16 spellid, uint32 gid);
 
 	void	TeleportGroup(Mob* sender, uint32 zoneID, uint16 instance_id, float x, float y, float z, float heading, uint32 gid);


### PR DESCRIPTION
- Fix auto split not working in Raids.
- Cleanup split logic and messages.
- Cleanup corpse logic and messages for splitting/viewing money.
![image](https://user-images.githubusercontent.com/89047260/143475510-b71dbd39-1264-4ce2-b84c-60c249478934.png)
![image](https://user-images.githubusercontent.com/89047260/143475557-038b5fcc-4659-4f8f-9358-05a9ae5c27c0.png)
![image](https://user-images.githubusercontent.com/89047260/143475656-75bc3061-c1de-4258-ad2e-35bb6fc379e0.png)