### PR TITLE
[Commands] Cleanup #movechar Command.

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -245,7 +245,7 @@ int command_init(void)
 		command_add("merchant_open_shop",  "Opens a merchants shop", AccountStatus::GMAdmin, command_merchantopenshop) ||
 		command_add("modifynpcstat", "- Modifys a NPC's stats", AccountStatus::GMLeadAdmin, command_modifynpcstat) ||
 		command_add("motd", "[new motd] - Set message of the day", AccountStatus::GMLeadAdmin, command_motd) ||
-		command_add("movechar", "[charname] [zonename] - Move charname to zonename", AccountStatus::Guide, command_movechar) ||
+		command_add("movechar", "[Character ID|Character Name] [Zone ID|Zone Short Name] - Move an offline character to the specified zone", AccountStatus::Guide, command_movechar) ||
 		command_add("movement", "Various movement commands", AccountStatus::GMMgmt, command_movement) ||
 		command_add("myskills", "- Show details about your current skill levels", AccountStatus::Player, command_myskills) ||
 		command_add("mysql", "Mysql CLI, see 'help' for options.", AccountStatus::GMImpossible, command_mysql) ||

--- a/zone/gm_commands/movechar.cpp
+++ b/zone/gm_commands/movechar.cpp
@@ -2,31 +2,101 @@
 
 void command_movechar(Client *c, const Seperator *sep)
 {
-	if (sep->arg[1][0] == 0 || sep->arg[2][0] == 0) {
-		c->Message(Chat::White, "Usage: #movechar [charactername] [zonename]");
+	int arguments = sep->argnum;
+	if (arguments < 2) {
+		c->Message(Chat::White, "Usage: #movechar [Character ID|Character Name] [Zone ID|Zone Short Name]");
+		return;
 	}
-	else if (c->Admin() < commandMovecharToSpecials && strcasecmp(sep->arg[2], "cshome") == 0 ||
-			 strcasecmp(sep->arg[2], "load") == 0 || strcasecmp(sep->arg[2], "load2") == 0) {
-		c->Message(Chat::White, "Invalid zone name");
+	
+	std::string character_name = (
+		sep->IsNumber(1) ?
+		database.GetCharNameByID(std::stoul(sep->arg[1])) :
+		sep->arg[1]
+	);
+	auto character_id = database.GetCharacterID(character_name.c_str());
+	if (!character_id) {
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"Character {} could not be found.",
+				character_name
+			).c_str()
+		);
+		return;
 	}
-	else {
-		uint32 tmp = database.GetAccountIDByChar(sep->arg[1]);
-		if (tmp) {
-			if (c->Admin() >= commandMovecharSelfOnly || tmp == c->AccountID()) {
-				if (!database.MoveCharacterToZone((char *) sep->arg[1], ZoneID(sep->arg[2]))) {
-					c->Message(Chat::White, "Character Move Failed!");
-				}
-				else {
-					c->Message(Chat::White, "Character has been moved.");
-				}
-			}
-			else {
-				c->Message(Chat::Red, "You cannot move characters that are not on your account.");
-			}
-		}
-		else {
-			c->Message(Chat::White, "Character Does Not Exist");
-		}
+
+	auto account_id = database.GetAccountIDByChar(character_name.c_str());
+
+	std::string zone_short_name = str_tolower(
+		sep->IsNumber(2) ?
+		ZoneName(std::stoul(sep->arg[2]), true) :
+		sep->arg[2]
+	);
+
+	bool is_unknown_zone = zone_short_name.find("unknown") != std::string::npos;
+	if (is_unknown_zone) {
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"Zone ID {} could not be found.",
+				std::stoul(sep->arg[2])
+			).c_str()
+		);
+		return;
+	}
+
+	auto zone_id = ZoneID(zone_short_name);
+	std::string zone_long_name = ZoneLongName(zone_id);
+
+	bool is_special_zone = (
+		zone_short_name.find("cshome") != std::string::npos ||
+		zone_short_name.find("load") != std::string::npos ||
+		zone_short_name.find("load2") != std::string::npos
+	);
+
+	if (c->Admin() < commandMovecharToSpecials && is_special_zone) {
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"{} ({}) is a special zone and you cannot move someone there.",
+				zone_long_name,
+				zone_short_name
+			).c_str()
+		);
+		return;
+	}
+
+	if (
+		c->Admin() >= commandMovecharSelfOnly ||
+		account_id == c->AccountID()
+	) {
+		bool moved = database.MoveCharacterToZone(character_name.c_str(), zone_id);
+		std::string moved_string = (
+			moved ?
+			"Succeeded" :
+			"Failed"
+		);
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"Character Move {} | Character: {} ({})",
+				moved_string,
+				character_name,
+				character_id
+			).c_str()
+		);
+
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"Character Move {} | Zone: {} ({}) ID: {}",
+				moved_string,
+				zone_long_name,
+				zone_short_name,
+				zone_id
+			).c_str()
+		);
+	} else {
+		c->Message(Chat::White, "You cannot move characters that are not on your account.");
 	}
 }
-


### PR DESCRIPTION
- Cleanup messages and logic.
- Add support for Zone ID versus Zone Short Name.
- Add support for Character ID versus Character Name.