### PR TITLE
[Commands] Add #setendurance Command.

### DIFF
--- a/zone/CMakeLists.txt
+++ b/zone/CMakeLists.txt
@@ -488,6 +488,7 @@ SET(gm_commands
     gm_commands/setaaxp.cpp
     gm_commands/setanim.cpp
     gm_commands/setcrystals.cpp
+    gm_commands/setendurance.cpp
     gm_commands/setfaction.cpp
     gm_commands/setgraveyard.cpp
     gm_commands/setlanguage.cpp

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -324,6 +324,7 @@ int command_init(void)
 		command_add("setadventurepoints", "- Set your or your player target's available adventure points", AccountStatus::GMLeadAdmin, command_set_adventure_points) ||
 		command_add("setanim", "[Animation ID (IDs are 0 to 4)] - Set target's appearance to Animation ID", AccountStatus::GMMgmt, command_setanim) ||
 		command_add("setcrystals", "[value] - Set your or your player target's available radiant or ebon crystals", AccountStatus::GMAdmin, command_setcrystals) ||
+		command_add("setendurance", "[Endurance] - Set your or your target's Endurance", AccountStatus::GMAdmin, command_setendurance) ||
 		command_add("setfaction", "[Faction ID] - Sets targeted NPC's faction in the database", AccountStatus::GMAreas, command_setfaction) ||
 		command_add("setgraveyard", "[zone name] - Creates a graveyard for the specified zone based on your target's LOC.", AccountStatus::GMMgmt, command_setgraveyard) ||
 		command_add("setlanguage", "[language ID] [value] - Set your target's language skillnum to value", AccountStatus::Guide, command_setlanguage) ||

--- a/zone/command.h
+++ b/zone/command.h
@@ -245,6 +245,7 @@ void command_setaapts(Client *c, const Seperator *sep);
 void command_setaaxp(Client *c, const Seperator *sep);
 void command_setanim(Client *c, const Seperator *sep);
 void command_setcrystals(Client *c, const Seperator *sep);
+void command_setendurance(Client *c, const Seperator *sep);
 void command_setfaction(Client *c, const Seperator *sep);
 void command_setgraveyard(Client *c, const Seperator *sep);
 void command_setlanguage(Client *c, const Seperator *sep);

--- a/zone/gm_commands/endurance.cpp
+++ b/zone/gm_commands/endurance.cpp
@@ -2,26 +2,35 @@
 
 void command_endurance(Client *c, const Seperator *sep)
 {
-	auto target = c->GetTarget() ? c->GetTarget() : c;
-	if (target->IsClient()) {
-		target->CastToClient()->SetEndurance(target->CastToClient()->GetMaxEndurance());
-	}
-	else {
-		target->SetEndurance(target->GetMaxEndurance());
+	Mob* target = c;
+	if (c->GetTarget()) {
+		target = c->GetTarget();
 	}
 
-	if (c != target) {
-		c->Message(
-			Chat::White,
-			fmt::format(
-				"Set {} ({}) to full Endurance.",
-				target->GetCleanName(),
-				target->GetID()
-			).c_str()
-		);
+	int endurance = 0;
+	if (target->IsClient()) {
+		endurance = target->CastToClient()->GetMaxEndurance();
+		target->CastToClient()->SetEndurance(endurance);
+	} else {
+		endurance = target->GetMaxEndurance();
+		target->SetEndurance(endurance);
 	}
-	else {
-		c->Message(Chat::White, "Restored your Endurance to full.");
-	}
+
+	c->Message(
+		Chat::White,
+		fmt::format(
+			"Set {} to full Endurance ({}).",
+			(
+				c == target ?
+				"yourself" :
+				fmt::format(
+					"{} ({})",
+					target->GetCleanName(),
+					target->GetID()
+				)
+			),
+			endurance
+		).c_str()
+	);
 }
 

--- a/zone/gm_commands/setendurance.cpp
+++ b/zone/gm_commands/setendurance.cpp
@@ -1,0 +1,62 @@
+#include "../client.h"
+
+void command_setendurance(Client *c, const Seperator *sep)
+{
+	int arguments = sep->argnum;
+	if (!arguments || !sep->IsNumber(1)) {
+		c->Message(Chat::White, "Usage: #setendurance [Endurance]");
+		return;
+	}
+
+	auto endurance = static_cast<int>(std::min(std::stoll(sep->arg[1]), (long long) 2000000000));
+	bool set_to_max = false;
+	Mob* target = c;
+	if (c->GetTarget()) {
+		target = c->GetTarget();
+	}
+	
+	if (target->IsClient()) {
+		if (endurance >= target->CastToClient()->GetMaxEndurance()) {
+			endurance = target->CastToClient()->GetMaxEndurance();
+			set_to_max = true;
+		}
+
+		target->CastToClient()->SetEndurance(endurance);
+	} else {
+		if (endurance >= target->GetMaxEndurance()) {
+			endurance = target->GetMaxEndurance();
+			set_to_max = true;
+		}
+
+		target->SetEndurance(endurance);
+	}
+
+	c->Message(
+		Chat::White,
+		fmt::format(
+			"Set {} to {} Endurance{}.",
+			(
+				c == target ?
+				"yourself" :
+				fmt::format(
+					"{} ({})",
+					target->GetCleanName(),
+					target->GetID()
+				)
+			),
+			(
+				set_to_max ?
+				"full" :
+				std::to_string(endurance)
+			),
+			(
+				set_to_max ?
+				fmt::format(
+					" ({})",
+					endurance
+				) :
+				""
+			)
+		).c_str()
+	);
+}


### PR DESCRIPTION
- Add #setendurance [Endurance] command to set an NPC or player's endurance to a specified amount, or to max if the amount is greater than their max.
- Cleanup #endurance command message and logic.