### PR TITLE
[Commands] Add #setaltcurrency Command.

### DIFF
--- a/zone/CMakeLists.txt
+++ b/zone/CMakeLists.txt
@@ -486,6 +486,7 @@ SET(gm_commands
     gm_commands/set_adventure_points.cpp
     gm_commands/setaapts.cpp
     gm_commands/setaaxp.cpp
+    gm_commands/setaltcurrency.cpp
     gm_commands/setanim.cpp
     gm_commands/setcrystals.cpp
     gm_commands/setfaction.cpp

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -7082,23 +7082,16 @@ void Client::SendAltCurrencies() {
 		altc->opcode = ALT_CURRENCY_OP_POPULATE;
 		altc->count = count;
 
-		uint32 i = 0;
-		auto iter = zone->AlternateCurrencies.begin();
-		while(iter != zone->AlternateCurrencies.end()) {
-			const EQ::ItemData* item = database.GetItem((*iter).item_id);
-			altc->entries[i].currency_number = (*iter).id;
-			altc->entries[i].unknown00 = 1;
-			altc->entries[i].currency_number2 = (*iter).id;
-			altc->entries[i].item_id = (*iter).item_id;
-			if(item) {
-				altc->entries[i].item_icon = item->Icon;
-				altc->entries[i].stack_size = item->StackSize;
-			} else {
-				altc->entries[i].item_icon = 1000;
-				altc->entries[i].stack_size = 1000;
-			}
-			i++;
-			++iter;
+		uint32 currency_id = 0;
+		for (const auto& alternate_currency : zone->AlternateCurrencies) {
+			const EQ::ItemData* item = database.GetItem(alternate_currency.item_id);
+			altc->entries[currency_id].currency_number = alternate_currency.id;
+			altc->entries[currency_id].unknown00 = 1;
+			altc->entries[currency_id].currency_number2 = alternate_currency.id;
+			altc->entries[currency_id].item_id = alternate_currency.item_id;
+			altc->entries[currency_id].item_icon = item ? item->Icon : 1000;
+			altc->entries[currency_id].stack_size = item ? item->StackSize : 1000;
+			currency_id++;
 		}
 
 		FastQueuePacket(&outapp);
@@ -7153,10 +7146,8 @@ void Client::AddAlternateCurrencyValue(uint32 currency_id, int32 amount, int8 me
 
 void Client::SendAlternateCurrencyValues()
 {
-	auto iter = zone->AlternateCurrencies.begin();
-	while(iter != zone->AlternateCurrencies.end()) {
-		SendAlternateCurrencyValue((*iter).id, false);
-		++iter;
+	for (const auto& alternate_currency : zone->AlternateCurrencies);
+		SendAlternateCurrencyValue(alternate_currency.id, false);
 	}
 }
 

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -7146,7 +7146,7 @@ void Client::AddAlternateCurrencyValue(uint32 currency_id, int32 amount, int8 me
 
 void Client::SendAlternateCurrencyValues()
 {
-	for (const auto& alternate_currency : zone->AlternateCurrencies);
+	for (const auto& alternate_currency : zone->AlternateCurrencies) {
 		SendAlternateCurrencyValue(alternate_currency.id, false);
 	}
 }

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -2465,39 +2465,31 @@ void Client::Handle_OP_AltCurrencyMerchantRequest(const EQApplicationPacket *app
 {
 	VERIFY_PACKET_LENGTH(OP_AltCurrencyMerchantRequest, app, uint32);
 
-	NPC* tar = entity_list.GetNPCByID(*((uint32*)app->pBuffer));
-	if (tar) {
-		if (DistanceSquared(m_Position, tar->GetPosition())  > USE_NPC_RANGE2)
-			return;
-
-		if (tar->GetClass() != ALT_CURRENCY_MERCHANT) {
+	auto target = entity_list.GetNPCByID(*((uint32*)app->pBuffer));
+	if (target) {
+		if (DistanceSquared(m_Position, target->GetPosition())  > USE_NPC_RANGE2) {
 			return;
 		}
 
-		uint32 alt_cur_id = tar->GetAltCurrencyType();
-		if (alt_cur_id == 0) {
+		if (target->GetClass() != ALT_CURRENCY_MERCHANT) {
 			return;
 		}
 
-		auto altc_iter = zone->AlternateCurrencies.begin();
-		bool found = false;
-		while (altc_iter != zone->AlternateCurrencies.end()) {
-			if ((*altc_iter).id == alt_cur_id) {
-				found = true;
-				break;
-			}
-			++altc_iter;
+		uint32 currency_id = target->GetAltCurrencyType();
+		if (!currency_id) {
+			return;
 		}
 
-		if (!found) {
+		auto currency_item_id = zone->GetCurrencyItemID(currency_id);
+		if (!currency_item_id) {
 			return;
 		}
 
 		std::stringstream ss(std::stringstream::in | std::stringstream::out);
 		std::stringstream item_ss(std::stringstream::in | std::stringstream::out);
-		ss << alt_cur_id << "|1|" << alt_cur_id;
+		ss << currency_id << "|1|" << currency_id;
 		uint32 count = 0;
-		uint32 merchant_id = tar->MerchantType;
+		uint32 merchant_id = target->MerchantType;
 		const EQ::ItemData *item = nullptr;
 
 		std::list<MerchantList> merlist = zone->merchanttable[merchant_id];
@@ -2508,14 +2500,16 @@ void Client::Handle_OP_AltCurrencyMerchantRequest(const EQApplicationPacket *app
 				continue;
 			}
 
-			int32 fac = tar->GetPrimaryFaction();
-			if (fac != 0 && GetModCharacterFactionLevel(fac) < ml.faction_required) {
+			auto faction_id = target->GetPrimaryFaction();
+			if (
+				faction_id &&
+				GetModCharacterFactionLevel(faction_id) < ml.faction_required
+			) {
 				continue;
 			}
 
 			item = database.GetItem(ml.item);
-			if (item)
-			{
+			if (item) {
 				item_ss << "^" << item->Name << "|";
 				item_ss << item->ID << "|";
 				item_ss << ml.alt_currency_cost << "|";
@@ -2529,8 +2523,7 @@ void Client::Handle_OP_AltCurrencyMerchantRequest(const EQApplicationPacket *app
 
 		if (count > 0) {
 			ss << "|" << count << item_ss.str();
-		}
-		else {
+		} else {
 			ss << "|0";
 		}
 
@@ -2628,16 +2621,9 @@ void Client::Handle_OP_AltCurrencyReclaim(const EQApplicationPacket *app)
 {
 	VERIFY_PACKET_LENGTH(OP_AltCurrencyReclaim, app, AltCurrencyReclaim_Struct);
 	AltCurrencyReclaim_Struct *reclaim = (AltCurrencyReclaim_Struct*)app->pBuffer;
-	uint32 item_id = 0;
-	auto iter = zone->AlternateCurrencies.begin();
-	while (iter != zone->AlternateCurrencies.end()) {
-		if ((*iter).id == reclaim->currency_id) {
-			item_id = (*iter).item_id;
-		}
-		++iter;
-	}
+	uint32 item_id = zone->GetCurrencyItemID(reclaim->currency_id);
 
-	if (item_id == 0) {
+	if (!item_id) {
 		return;
 	}
 

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -322,6 +322,7 @@ int command_init(void)
 		command_add("setaapts", "[AA|Group|Raid] [AA Amount] - Set your or your player target's Available AA Points by Type", AccountStatus::GMAdmin, command_setaapts) ||
 		command_add("setaaxp", "[AA|Group|Raid] [AA Experience] - Set your or your player target's AA Experience by Type", AccountStatus::GMAdmin, command_setaaxp) ||
 		command_add("setadventurepoints", "- Set your or your player target's available adventure points", AccountStatus::GMLeadAdmin, command_set_adventure_points) ||
+		command_add("setaltcurrency", "[Currency ID] [Amount] - Set your or your target's available Alternate Currency by Currency ID", AccountStatus::GMAdmin, command_setaltcurrency) ||
 		command_add("setanim", "[Animation ID (IDs are 0 to 4)] - Set target's appearance to Animation ID", AccountStatus::GMMgmt, command_setanim) ||
 		command_add("setcrystals", "[value] - Set your or your player target's available radiant or ebon crystals", AccountStatus::GMAdmin, command_setcrystals) ||
 		command_add("setfaction", "[Faction ID] - Sets targeted NPC's faction in the database", AccountStatus::GMAreas, command_setfaction) ||

--- a/zone/command.h
+++ b/zone/command.h
@@ -243,6 +243,7 @@ void command_serverrules(Client *c, const Seperator *sep);
 void command_set_adventure_points(Client *c, const Seperator *sep);
 void command_setaapts(Client *c, const Seperator *sep);
 void command_setaaxp(Client *c, const Seperator *sep);
+void command_setaltcurrency(Client *c, const Seperator *sep);
 void command_setanim(Client *c, const Seperator *sep);
 void command_setcrystals(Client *c, const Seperator *sep);
 void command_setfaction(Client *c, const Seperator *sep);

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -3483,7 +3483,7 @@ XS(XS__getcurrencyitemid) {
 	dXSTARG;
 
 	int RETVAL;
-	int currency_id = (int) SvUV(ST(0));
+	uint32 currency_id = (uint32) SvUV(ST(0));
 
 	RETVAL = quest_manager.getcurrencyitemid(currency_id);
 
@@ -3499,8 +3499,8 @@ XS(XS__getcurrencyid) {
 		Perl_croak(aTHX_ "Usage: quest::getcurrencyid(uint32 item_id)");
 	dXSTARG;
 
-	int 		RETVAL;
-	uint32      item_id = (int) SvUV(ST(0));
+	uint32 RETVAL;
+	uint32 item_id = (uint32) SvUV(ST(0));
 
 	RETVAL = quest_manager.getcurrencyid(item_id);
 	XSprePUSH;

--- a/zone/gm_commands/setaltcurrency.cpp
+++ b/zone/gm_commands/setaltcurrency.cpp
@@ -1,0 +1,59 @@
+#include "../client.h"
+
+void command_setaltcurrency(Client *c, const Seperator *sep)
+{
+	int arguments = sep->argnum;
+	if (
+		arguments < 2 ||
+		!sep->IsNumber(1) ||
+		!sep->IsNumber(2)
+	) {
+		c->Message(Chat::White, "Command Syntax: #setaltcurrency [Currency ID] [Amount]");
+		return;
+	}
+
+	auto target = c;
+	if (c->GetTarget() && c->GetTarget()->IsClient()) {
+		target = c->GetTarget()->CastToClient();
+	}
+
+	auto currency_id = std::stoul(sep->arg[1]);
+	auto amount = static_cast<int>(std::min(std::stoll(sep->arg[2]), (long long) 2000000000));
+	uint32 currency_item_id = zone->GetCurrencyItemID(currency_id);
+	if (!currency_item_id) {
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"Currency ID {} could not be found.",
+				currency_id
+			).c_str()
+		);
+		return;
+	}
+
+	target->SetAlternateCurrencyValue(currency_id, amount);
+	
+	c->Message(
+		Chat::White,
+		fmt::format(
+			"{} now {} {} {}.",
+			(
+				c == target ?
+				"You" :
+				fmt::format(
+					"{} ({})",
+					target->GetCleanName(),
+					target->GetID()
+				)
+			),
+			c == target ? "have" : "has",
+			(
+				amount ?
+				std::to_string(amount) :
+				"no"
+			),
+			database.CreateItemLink(currency_item_id)
+		).c_str()
+	);
+}
+

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -918,11 +918,11 @@ std::string lua_get_class_name(uint8 class_id, uint8 level) {
 	return quest_manager.getclassname(class_id, level);
 }
 
-int lua_get_currency_id(uint32 item_id) {
+uint32 lua_get_currency_id(uint32 item_id) {
 	return quest_manager.getcurrencyid(item_id);
 }
 
-int lua_get_currency_item_id(int currency_id) {
+uint32 lua_get_currency_item_id(uint32 currency_id) {
 	return quest_manager.getcurrencyitemid(currency_id);
 }
 

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -3009,28 +3009,12 @@ std::string QuestManager::getclassname(uint8 class_id, uint8 level) {
 	return GetClassIDName(class_id, level);
 }
 
-int QuestManager::getcurrencyid(uint32 item_id) {
-	auto iter = zone->AlternateCurrencies.begin();
-	while (iter != zone->AlternateCurrencies.end()) {
-		if (item_id == (*iter).item_id) {
-			return (*iter).id;
-		}
-		++iter;
-	}
-	return 0;
+uint32 QuestManager::getcurrencyid(uint32 item_id) {
+	return zone->GetCurrencyID(item_id);
 }
 
-int QuestManager::getcurrencyitemid(int currency_id) {
-	if (currency_id > 0) {
-		auto iter = zone->AlternateCurrencies.begin();
-		while (iter != zone->AlternateCurrencies.end()) {
-			if (currency_id == (*iter).id) {
-				return (*iter).item_id;
-			}
-			++iter;
-		}
-	}
-	return 0;
+uint32 QuestManager::getcurrencyitemid(uint32 currency_id) {
+	return zone->GetCurrencyItemID(currency_id);
 }
 
 const char* QuestManager::getguildnamebyid(int guild_id) {

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -272,8 +272,8 @@ public:
 	std::string getcharnamebyid(uint32 char_id);
 	uint32 getcharidbyname(const char* name);
 	std::string getclassname(uint8 class_id, uint8 level = 0);
-	int getcurrencyid(uint32 item_id);
-	int getcurrencyitemid(int currency_id);
+	uint32 getcurrencyid(uint32 item_id);
+	uint32 getcurrencyitemid(uint32 currency_id);
 	const char* getguildnamebyid(int guild_id);
 	int getguildidbycharid(uint32 char_id);
 	int getgroupidbycharid(uint32 char_id);

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -2421,10 +2421,9 @@ void Zone::LoadAlternateCurrencies()
 		return;
     }
 
-    for (auto row = results.begin(); row != results.end(); ++row)
-    {
-        current_currency.id = atoi(row[0]);
-        current_currency.item_id = atoi(row[1]);
+    for (auto row : results) {
+        current_currency.id = std::stoul(row[0]);
+        current_currency.item_id = std::stoul(row[1]);
         AlternateCurrencies.push_back(current_currency);
     }
 
@@ -2743,4 +2742,34 @@ DynamicZone* Zone::GetDynamicZone()
 	}
 
 	return nullptr;
+}
+
+uint32 Zone::GetCurrencyID(uint32 item_id)
+{
+	if (!item_id) {
+		return 0;
+	}
+	
+	for (const auto& alternate_currency : AlternateCurrencies) {
+		if (item_id == alternate_currency.item_id) {
+			return alternate_currency.id;
+		}
+	}
+
+	return 0;
+}
+
+uint32 Zone::GetCurrencyItemID(uint32 currency_id)
+{
+	if (!currency_id) {
+		return 0;
+	}
+
+	for (const auto& alternate_currency : AlternateCurrencies) {
+		if (currency_id == alternate_currency.id) {
+			return alternate_currency.item_id;
+		}
+	}
+
+	return 0;
 }

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -241,6 +241,9 @@ public:
 	uint32 GetSpawnKillCount(uint32 in_spawnid);
 	uint32 GetTempMerchantQuantity(uint32 NPCID, uint32 Slot);
 
+	uint32 GetCurrencyID(uint32 item_id);
+	uint32 GetCurrencyItemID(uint32 currency_id);
+
 	void AddAggroMob() { aggroedmobs++; }
 	void AddAuth(ServerZoneIncomingClient_Struct *szic);
 	void ChangeWeather();


### PR DESCRIPTION
- Add #setaltcurrency [Currency ID] [Amount] command to allow you to set a specific alternate currency to a value.
- Add Zone::GetCurrencyID() and Zone::GetCurrencyItemID() helper methods.
- Cleanup loops through zone->AlternateCurrencies.
- Utilize helper methods where necessary.
- Convert old methods parameters and return values from int to uint32 where necessary.