### PR TITLE
[Bug fix] SetPetID after we assign the new NPC an ID

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -689,6 +689,14 @@ void EntityList::AddNPC(NPC *npc, bool SendSpawnPacket, bool dontqueue)
 {
 	npc->SetID(GetFreeID());
 
+	//If this is not set here we will despawn pets from new AC changes
+	auto owner_id = npc->GetOwnerID();
+	if(owner_id) {
+		auto owner = entity_list.GetMob(owner_id);
+		if (owner) {
+			owner->SetPetID(npc->GetID());
+		}
+	}
 	parse->EventNPC(EVENT_SPAWN, npc, nullptr, "", 0);
 
 	uint16 emoteid = npc->GetEmoteID();


### PR DESCRIPTION
Players / npcs need this set otherwise trying to scale NPCs AGI / AC will cause them to depop

Also any NPC pets with items will despawn if this is not set here as well.