### PR TITLE
[Commands] Remove #shownumhits Command.

### DIFF
--- a/zone/CMakeLists.txt
+++ b/zone/CMakeLists.txt
@@ -507,7 +507,6 @@ SET(gm_commands
     gm_commands/showbonusstats.cpp
     gm_commands/showbuffs.cpp
     gm_commands/shownpcgloballoot.cpp
-    gm_commands/shownumhits.cpp
     gm_commands/showskills.cpp
     gm_commands/showspellslist.cpp
     gm_commands/showstats.cpp

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -8647,17 +8647,6 @@ void Client::ExpeditionSay(const char *str, int ExpID) {
 
 }
 
-void Client::ShowNumHits()
-{
-	uint32 buffcount = GetMaxTotalSlots();
-	for (uint32 buffslot = 0; buffslot < buffcount; buffslot++) {
-		const Buffs_Struct &curbuff = buffs[buffslot];
-		if (curbuff.spellid != SPELL_UNKNOWN && curbuff.hit_number)
-			Message(0, "You have %d hits left on %s", curbuff.hit_number, GetSpellName(curbuff.spellid));
-	}
-	return;
-}
-
 int Client::GetQuiverHaste(int delay)
 {
 	const EQ::ItemInstance *pi = nullptr;

--- a/zone/client.h
+++ b/zone/client.h
@@ -1577,8 +1577,6 @@ public:
 	int mod_food_value(const EQ::ItemData *item, int change);
 	int mod_drink_value(const EQ::ItemData *item, int change);
 
-	void ShowNumHits(); // work around function for numhits not showing on buffs
-
 	void ApplyWeaponsStance();
 	void TogglePassiveAlternativeAdvancement(const AA::Rank &rank, uint32 ability_id);
 	bool UseTogglePassiveHotkey(const AA::Rank &rank);

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -342,7 +342,6 @@ int command_init(void)
 		command_add("setxp", "[value] - Set your or your player target's experience", AccountStatus::GMAdmin, command_setxp) ||
 		command_add("showbonusstats", "[item|spell|all] Shows bonus stats for target from items or spells. Shows both by default.", AccountStatus::Guide, command_showbonusstats) ||
 		command_add("showbuffs", "- List buffs active on your target or you if no target", AccountStatus::Guide, command_showbuffs) ||
-		command_add("shownumhits",  "Shows buffs numhits for yourself.", AccountStatus::Player, command_shownumhits) ||
 		command_add("shownpcgloballoot", "Show GlobalLoot entires on this npc", AccountStatus::Guide, command_shownpcgloballoot) ||
 		command_add("showskills", "- Show the values of your or your player target's skills", AccountStatus::Guide, command_showskills) ||
 		command_add("showspellslist", "Shows spell list of targeted NPC", AccountStatus::GMAdmin, command_showspellslist) ||

--- a/zone/command.h
+++ b/zone/command.h
@@ -263,7 +263,6 @@ void command_setstat(Client *c, const Seperator *sep);
 void command_setxp(Client *c, const Seperator *sep);
 void command_showbonusstats(Client *c, const Seperator *sep);
 void command_showbuffs(Client *c, const Seperator *sep);
-void command_shownumhits(Client *c, const Seperator *sep);
 void command_shownpcgloballoot(Client *c, const Seperator *sep);
 void command_showpetspell(Client *c, const Seperator *sep);
 void command_showskills(Client *c, const Seperator *sep);

--- a/zone/gm_commands/shownumhits.cpp
+++ b/zone/gm_commands/shownumhits.cpp
@@ -1,8 +1,0 @@
-#include "../client.h"
-
-void command_shownumhits(Client *c, const Seperator *sep)
-{
-	c->ShowNumHits();
-	return;
-}
-


### PR DESCRIPTION
- Remove unused and/or unnecessary command, buff hit number packets are now properly sent.