### PR TITLE
[Bug Fix] Charm Break Invisibility Fix.

### DIFF
--- a/common/emu_constants.h
+++ b/common/emu_constants.h
@@ -371,4 +371,10 @@ enum AccountStatus : uint8 {
 	Max = 255
 };
 
+enum Invisibility : uint8 {
+	Visible,
+	Invisible,
+	Special = 255
+};
+
 #endif /*COMMON_EMU_CONSTANTS_H*/

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -3465,7 +3465,7 @@ uint8 Client::SlotConvert2(uint8 slot){
 void Client::Escape()
 {
 	entity_list.RemoveFromTargets(this, true);
-	SetInvisible(1);
+	SetInvisible(Invisibility::Invisible);
 
 	MessageString(Chat::Skills, ESCAPE);
 }

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -574,13 +574,16 @@ uint32 Mob::GetAppearanceValue(EmuAppearance iAppearance) {
 
 void Mob::SetInvisible(uint8 state)
 {
-	invisible = state;
-	SendAppearancePacket(AT_Invis, invisible);
+	if (state != Invisibility::Special) {
+		invisible = state;
+		SendAppearancePacket(AT_Invis, invisible);
+	}
+
 	// Invis and hide breaks charms
-	auto formerpet = GetPet();
-	if (formerpet && formerpet->GetPetType() == petCharmed && (invisible || hidden || improved_hidden || invisible_animals || invisible_undead)) {
-		if (RuleB(Pets, LivelikeBreakCharmOnInvis) || IsInvisible(formerpet)) {
-			formerpet->BuffFadeByEffect(SE_Charm);
+	auto pet = GetPet();
+	if (pet && pet->GetPetType() == petCharmed && (invisible || hidden || improved_hidden || invisible_animals || invisible_undead)) {
+		if (RuleB(Pets, LivelikeBreakCharmOnInvis) || IsInvisible(pet)) {
+			pet->BuffFadeByEffect(SE_Charm);
 		}
 
 		LogRules("Pets:LivelikeBreakCharmOnInvis for [{}] | Invis [{}] - Hidden [{}] - Shroud of Stealth [{}] - IVA [{}] - IVU [{}]", GetCleanName(), invisible, hidden, improved_hidden, invisible_animals, invisible_undead);

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -593,6 +593,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				snprintf(effect_desc, _EDLEN, "Invisibility to Animals");
 #endif
 				invisible_animals = true;
+				SetInvisible(Invisibility::Special);
 				break;
 			}
 
@@ -603,6 +604,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				snprintf(effect_desc, _EDLEN, "Invisibility to Undead");
 #endif
 				invisible_undead = true;
+				SetInvisible(Invisibility::Special);
 				break;
 			}
 			case SE_SeeInvis:
@@ -2291,7 +2293,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					else
 					{
 						entity_list.RemoveFromTargets(caster);
-						SetInvisible(1);
+						SetInvisible(Invisibility::Invisible);
 					}
 				}
 				break;
@@ -4187,7 +4189,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 			case SE_Invisibility2:
 			case SE_Invisibility:
 			{
-				SetInvisible(0);
+				SetInvisible(Invisibility::Visible);
 				break;
 			}
 


### PR DESCRIPTION
- Invisibility vs. Undead and Invisibility vs. Animals were not breaking charm.
- Add Invisibility enumerator.
- Add special identifier for Invisibility vs. Undead and Invisibility vs. Animals.