### PR TITLE
[Spells] SPA 310 SE_ReduceReuseTimer	will now work on spell recast time

### DIFF
--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1013,7 +1013,7 @@ typedef enum {
 //#define SE_Appraisal					307 // *not implemented Rogue AA - This ability allows you to estimate the selling price of an item you are holding on your cursor.
 #define SE_ZoneSuspendMinion			308 // implemented, @Pet, allow suspended pets to be resummoned upon zoning, base: 1, limit: none, max: none, Calc: Bool
 #define SE_GateCastersBindpoint			309 // implemented - Gate to casters bind point
-#define SE_ReduceReuseTimer				310 // implemented, @Fc, On Caster, disc reuse time mod, base: milliseconds
+#define SE_ReduceReuseTimer				310 // implemented, @Fc, On Caster, spell and disc reuse time mod by amount, base: milliseconds
 #define SE_LimitCombatSkills			311 // implemented, @Ff, Include or exclude combat skills or procs (non-memorizable spells) from being focused, base1: 0=Exclude if proc 1=Allow only if proc
 #define SE_Sanctuary					312 // implemented - Places caster at bottom hate list, effect fades if cast cast spell on targets other than self.
 #define SE_ForageAdditionalItems		313	// implemented[AA] - chance to forage additional items

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -2658,17 +2658,17 @@ bool Client::CheckAccess(int16 iDBLevel, int16 iDefaultLevel) {
 		return false;
 }
 
-void Client::MemorizeSpell(uint32 slot,uint32 spellid,uint32 scribing){
+void Client::MemorizeSpell(uint32 slot,uint32 spellid,uint32 scribing, uint32 reduction){
 	if (slot < 0 || slot >= EQ::spells::DynamicLookup(ClientVersion(), GetGM())->SpellbookSize)
 		return;
 	if ((spellid < 3 || spellid > EQ::spells::DynamicLookup(ClientVersion(), GetGM())->SpellIdMax) && spellid != 0xFFFFFFFF)
 		return;
-
 	auto outapp = new EQApplicationPacket(OP_MemorizeSpell, sizeof(MemorizeSpell_Struct));
 	MemorizeSpell_Struct* mss=(MemorizeSpell_Struct*)outapp->pBuffer;
 	mss->scribing=scribing;
 	mss->slot=slot;
 	mss->spell_id=spellid;
+	mss->reduction = reduction;
 	outapp->priority = 5;
 	QueuePacket(outapp);
 	safe_delete(outapp);

--- a/zone/client.h
+++ b/zone/client.h
@@ -906,7 +906,7 @@ public:
 	int32 CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id);
 	void SetAATitle(const char *Title);
 	void SetTitleSuffix(const char *txt);
-	void MemorizeSpell(uint32 slot, uint32 spellid, uint32 scribing);
+	void MemorizeSpell(uint32 slot, uint32 spellid, uint32 scribing, uint32 reduction = 0);
 
 	// Item methods
 	void EVENT_ITEM_ScriptStopReturn();

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -333,6 +333,7 @@ Mob::Mob(
 	casting_spell_timer_duration = 0;
 	casting_spell_inventory_slot = 0;
 	casting_spell_aa_id          = 0;
+	casting_spell_recast_adjust  = 0;
 	target                       = 0;
 
 	ActiveProjectileATK = false;

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1529,6 +1529,7 @@ protected:
 	uint32 casting_spell_type;
 	int16 casting_spell_resist_adjust;
 	uint32 casting_spell_aa_id;
+	uint32 casting_spell_recast_adjust;
 	bool casting_spell_checks;
 	uint16 bardsong;
 	EQ::spells::CastingSlot bardsong_slot;

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -2546,6 +2546,9 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 							if (CalcFocusEffect(focusFcTimerRefresh, spell_id, CastToClient()->m_pp.mem_spells[i])){
 								CastToClient()->m_pp.spellSlotRefresh[i] = 1;
 								CastToClient()->GetPTimers().Clear(&database, (pTimerSpellStart + CastToClient()->m_pp.mem_spells[i]));
+								if (!CastToClient()->IsLinkedSpellReuseTimerReady(spells[CastToClient()->m_pp.mem_spells[i]].timer_id)) {
+									CastToClient()->GetPTimers().Clear(&database, (pTimerLinkedSpellReuseStart + spells[CastToClient()->m_pp.mem_spells[i]].timer_id));
+								}
 							}
 						}
 					}
@@ -6323,7 +6326,7 @@ uint16 Client::GetSympatheticFocusEffect(focusType type, uint16 spell_id) {
 
 int32 Client::GetFocusEffect(focusType type, uint16 spell_id)
 {
-	if (IsBardSong(spell_id) && type != focusFcBaseEffects && type != focusSpellDuration)
+	if (IsBardSong(spell_id) && type != focusFcBaseEffects && type != focusSpellDuration && type != focusReduceRecastTime)
 		return 0;
 
 	int32 realTotal = 0;


### PR DESCRIPTION
Special credit and thanks to Natedog for helping figure out how to reduce recast reduction with memorizespell_struct!

SPA 310 can now be used to reduced the recast timers on spells (previously only worked on discipline timers).

SE_ReduceReuseTimer	310 Focus Effect, On Caster, spell and disc reuse time mod by amount, base: milliseconds
Note: Use positive values for amount of reduction, IE. 10000 = 10 second reduction.
If you try and reduce lower than the spells recast timer, it will set the spell to be instant refresh.

Also, fixed a bug with Forceful Rejuvenation (resets recast timers) where spells with linked timers were not getting there recast timers reset server side.