### PR TITLE
[Spells] Update to mod incoming Spell Damage amount focus, SPA 297 and 484 to support focus from  AA and items.

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -5458,7 +5458,7 @@ void Mob::CommonOutgoingHitSuccess(Mob* defender, DamageHitInfo &hit, ExtraAttac
 
 	int pct_damage_reduction = defender->GetSkillDmgTaken(hit.skill, opts) + defender->GetPositionalDmgTaken(this);
 
-	hit.damage_done += (hit.damage_done * pct_damage_reduction / 100) + (defender->GetFcDamageAmtIncoming(this, 0, true, hit.skill)) + defender->GetPositionalDmgTakenAmt(this);
+	hit.damage_done += (hit.damage_done * pct_damage_reduction / 100) + defender->GetPositionalDmgTakenAmt(this);
 
 	if (defender->GetShielderID()) {
 		DoShieldDamageOnShielder(defender, hit.damage_done, hit.skill);

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -1941,10 +1941,10 @@ int Lua_Mob::GetSkillDmgTaken(int skill) {
 	return self->GetSkillDmgTaken(static_cast<EQ::skills::SkillType>(skill));
 }
 
-int Lua_Mob::GetFcDamageAmtIncoming(Lua_Mob caster, uint32 spell_id, bool use_skill, uint16 skill)
+int Lua_Mob::GetFcDamageAmtIncoming(Lua_Mob caster, int32 spell_id)
 {
 	Lua_Safe_Call_Int();
-	return self->GetFcDamageAmtIncoming(caster, spell_id, use_skill, skill);
+	return self->GetFcDamageAmtIncoming(caster, spell_id);
 }
 
 int Lua_Mob::GetSkillDmgAmt(uint16 skill)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -373,7 +373,7 @@ public:
 	void ModSkillDmgTaken(int skill, int value);
 	int GetModSkillDmgTaken(int skill);
 	int GetSkillDmgTaken(int skill);
-	int GetFcDamageAmtIncoming(Lua_Mob caster, uint32 spell_id, bool use_skill, uint16 skill);
+	int GetFcDamageAmtIncoming(Lua_Mob caster, int32 spell_id);
 	int GetSkillDmgAmt(uint16 skill);
 	void SetAllowBeneficial(bool value);
 	bool GetAllowBeneficial();

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -811,7 +811,7 @@ public:
 	bool TryFadeEffect(int slot);
 	uint16 GetSpellEffectResistChance(uint16 spell_id);
 	int32 GetVulnerability(Mob* caster, uint32 spell_id, uint32 ticsremaining);
-	int32 GetFcDamageAmtIncoming(Mob *caster, uint32 spell_id, bool use_skill = false, uint16 skill=0);
+	int32 GetFcDamageAmtIncoming(Mob *caster, int32 spell_id);
 	int32 GetFocusIncoming(focusType type, int effect, Mob *caster, uint32 spell_id); //**** This can be removed when bot healing focus code is updated ****
 	int32 GetSkillDmgTaken(const EQ::skills::SkillType skill_used, ExtraAttackOptions *opts = nullptr);
 	int32 GetPositionalDmgTaken(Mob *attacker);

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -7100,72 +7100,12 @@ bool Mob::DoHPToManaCovert(uint16 mana_cost)
 	return false;
 }
 
-int32 Mob::GetFcDamageAmtIncoming(Mob *caster, uint32 spell_id, bool use_skill, uint16 skill )
+int32 Mob::GetFcDamageAmtIncoming(Mob *caster, int32 spell_id)
 {
-	//Used to check focus derived from SE_FcDamageAmtIncoming which adds direct damage to Spells or Skill based attacks.
-	//Used to check focus derived from SE_Fc_Spell_Damage_Amt_IncomingPC which adds direct damage to Spells.
+	//THIS is target of spell cast
 	int32 dmg = 0;
-	bool limit_exists = false;
-	bool skill_found = false;
-
-	if (!caster)
-		return 0;
-
-	if (spellbonuses.FocusEffects[focusFcDamageAmtIncoming]){
-		int buff_count = GetMaxTotalSlots();
-		for(int i = 0; i < buff_count; i++){
-
-			if( (IsValidSpell(buffs[i].spellid) && (IsEffectInSpell(buffs[i].spellid, SE_FcDamageAmtIncoming))) ){
-
-				if (use_skill){
-					int32 temp_dmg = 0;
-					for (int e = 0; e < EFFECT_COUNT; e++) {
-
-						if (spells[buffs[i].spellid].effect_id[e] == SE_FcDamageAmtIncoming){
-							temp_dmg += spells[buffs[i].spellid].base_value[e];
-							continue;
-						}
-
-						if (!skill_found){
-							if ((spells[buffs[i].spellid].effect_id[e] == SE_LimitToSkill) ||
-								(spells[buffs[i].spellid].effect_id[e] == SE_LimitCastingSkill)){
-								limit_exists = true;
-
-								if (spells[buffs[i].spellid].base_value[e] == skill)
-									skill_found = true;
-							}
-						}
-					}
-					if ((!limit_exists) || (limit_exists && skill_found)){
-						dmg += temp_dmg;
-						CheckNumHitsRemaining(NumHit::MatchingSpells, i);
-					}
-				}
-
-				else{
-					int32 focus = caster->CalcFocusEffect(focusFcDamageAmtIncoming, buffs[i].spellid, spell_id);
-					if(focus){
-						dmg += focus;
-						CheckNumHitsRemaining(NumHit::MatchingSpells, i);
-					}
-				}
-			}
-		}
-	}
-	if (spellbonuses.FocusEffects[focusFcSpellDamageAmtIncomingPC]) {
-		int buff_count = GetMaxTotalSlots();
-		for (int i = 0; i < buff_count; i++) {
-
-			if ((IsValidSpell(buffs[i].spellid) && (IsEffectInSpell(buffs[i].spellid, SE_FcDamageAmtIncoming)))) {
-
-				int32 focus = caster->CalcFocusEffect(focusFcSpellDamageAmtIncomingPC, buffs[i].spellid, spell_id);
-				if (focus) {
-					dmg += focus;
-					CheckNumHitsRemaining(NumHit::MatchingSpells, i);
-				}
-			}
-		}
-	}
+	dmg += GetFocusEffect(focusFcDamageAmtIncoming, spell_id); //SPA 297 SE_FcDamageAmtIncoming
+	dmg += GetFocusEffect(focusFcSpellDamageAmtIncomingPC, spell_id); //SPA 484 SE_Fc_Spell_Damage_Amt_IncomingPC
 	return dmg;
 }
 


### PR DESCRIPTION
Added support for modify incoming spell damage amount focus effects, SPA 296 and 483 to work on items and AA's.
These effects can be used to modify incoming spell damage by flat on a target with the buff containing the focus.
If you put it on an AA or an item you can cause your client to have an innate increase or decrease in spell damage taken by amount.
Example, your client gains an AA that makes them take 100 less damage from Fire Spells.
Positive value increases damage taken, negative value reduces damage taken by amount
These two foci do same thing and will stack with each other.

Also, removed some out dated uses of the spell that are no longer applicable.

SE_FcDamageAmtIncoming			297, Focus Effect,, On Target, damage taken flat amt, base: amt
SE_Fc_Spell_Damage_Amt_IncomingPC	484, Focus Effect, On Target, damage taken flat amt, base: amt
