### PR TITLE
[Commands] Cleanup #wpinfo Command.

### DIFF
--- a/zone/gm_commands/wpinfo.cpp
+++ b/zone/gm_commands/wpinfo.cpp
@@ -2,14 +2,25 @@
 
 void command_wpinfo(Client *c, const Seperator *sep)
 {
-	Mob *t = c->GetTarget();
-
-	if (t == nullptr || !t->IsNPC()) {
-		c->Message(Chat::White, "You must target an NPC to use this.");
+	if (!c->GetTarget() || !c->GetTarget()->IsNPC()) {
+		c->Message(Chat::White, "You must target an NPC to use this command.");
 		return;
 	}
 
-	NPC *n = t->CastToNPC();
-	n->DisplayWaypointInfo(c);
+	auto target = c->GetTarget()->CastToNPC();
+
+	if (!target->GetGrid()) {
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"{} ({}) is not a part of any grid.",
+				target->GetCleanName(),
+				target->GetID()
+			).c_str()
+		);
+		return;
+	}
+
+	target->DisplayWaypointInfo(c);
 }
 

--- a/zone/lua_npc.cpp
+++ b/zone/lua_npc.cpp
@@ -267,9 +267,9 @@ int Lua_NPC::GetMaxWp() {
 	return self->GetMaxWp();
 }
 
-void Lua_NPC::DisplayWaypointInfo(Lua_Client to) {
+void Lua_NPC::DisplayWaypointInfo(Lua_Client client) {
 	Lua_Safe_Call_Void();
-	self->DisplayWaypointInfo(to);
+	self->DisplayWaypointInfo(client);
 }
 
 void Lua_NPC::CalculateNewWaypoint() {

--- a/zone/lua_npc.h
+++ b/zone/lua_npc.h
@@ -80,7 +80,7 @@ public:
 	void StartSwarmTimer(uint32 duration);
 	void DoClassAttacks(Lua_Mob target);
 	int GetMaxWp();
-	void DisplayWaypointInfo(Lua_Client to);
+	void DisplayWaypointInfo(Lua_Client client);
 	void CalculateNewWaypoint();
 	void AssignWaypoints(int grid);
 	void SetWaypointPause();

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -327,7 +327,7 @@ public:
 
 	//waypoint crap
 	int					GetMaxWp() const { return max_wp; }
-	void				DisplayWaypointInfo(Client *to);
+	void				DisplayWaypointInfo(Client *client);
 	void				CalculateNewWaypoint();
 	void				AssignWaypoints(int32 grid_id, int start_wp = 0);
 	void				SetWaypointPause();

--- a/zone/perl_npc.cpp
+++ b/zone/perl_npc.cpp
@@ -775,20 +775,23 @@ XS(XS_NPC_DisplayWaypointInfo); /* prototype to pass -Wmissing-prototypes */
 XS(XS_NPC_DisplayWaypointInfo) {
 	dXSARGS;
 	if (items != 2)
-		Perl_croak(aTHX_ "Usage: NPC::DisplayWaypointInfo(THIS, Client* target)"); // @categories Script Utility
+		Perl_croak(aTHX_ "Usage: NPC::DisplayWaypointInfo(THIS, Client* client)"); // @categories Script Utility
 	{
-		NPC    *THIS;
-		Client *to;
+		NPC *THIS;
+		Client *client;
 		VALIDATE_THIS_IS_NPC;
 		if (sv_derived_from(ST(1), "Client")) {
 			IV tmp = SvIV((SV *) SvRV(ST(1)));
-			to = INT2PTR(Client *, tmp);
-		} else
-			Perl_croak(aTHX_ "to is not of type Client");
-		if (to == nullptr)
-			Perl_croak(aTHX_ "to is nullptr, avoiding crash.");
+			client = INT2PTR(Client *, tmp);
+		} else {
+			Perl_croak(aTHX_ "client is not of type Client");
+		}
 
-		THIS->DisplayWaypointInfo(to);
+		if (!client) {
+			Perl_croak(aTHX_ "client is nullptr, avoiding crash.");
+		}
+
+		THIS->DisplayWaypointInfo(client);
 	}
 	XSRETURN_EMPTY;
 }

--- a/zone/waypoints.cpp
+++ b/zone/waypoints.cpp
@@ -76,26 +76,53 @@ void NPC::AI_SetRoambox(
 	roambox_min_delay     = min_delay;
 }
 
-void NPC::DisplayWaypointInfo(Client *c) {
+void NPC::DisplayWaypointInfo(Client *client) {
+	client->Message(
+		Chat::White,
+		fmt::format(
+			"Waypoint Info for {} ({}) | Grid: {} Waypoint: {} of {}",
+			GetCleanName(),
+			GetID(),
+			GetGrid(),
+			GetCurWp(),
+			GetMaxWp()
+		).c_str()
+	);
 
-	c->Message(Chat::White, "Mob is on grid %d, in spawn group %d, on waypoint %d/%d",
-			   GetGrid(),
-			   GetSpawnGroupId(),
-			   GetCurWp(),
-			   GetMaxWp());
+	client->Message(
+		Chat::White,
+		fmt::format(
+			"Waypoint Info for {} ({}) | Spawn Group: {} Spawn Point: {}",
+			GetCleanName(),
+			GetID(),
+			GetSpawnGroupId(),
+			GetSpawnPointID()
+		).c_str()		
+	);
 
-
-	std::vector<wplist>::iterator cur, end;
-	cur = Waypoints.begin();
-	end = Waypoints.end();
-	for (; cur != end; ++cur) {
-		c->Message(Chat::White, "Waypoint %d: (%.2f,%.2f,%.2f,%.2f) pause %d",
-			cur->index,
-			cur->x,
-			cur->y,
-			cur->z,
-			cur->heading,
-			cur->pause);
+	
+	for (const auto& current_waypoint : Waypoints) {
+		client->Message(
+			Chat::White,
+			fmt::format(
+				"Waypoint {}{} | XYZ: {:.2f}, {:.2f}, {:.2f} Heading: {:.2f}{}",
+				current_waypoint.index,
+				current_waypoint.centerpoint ? " (Center)" : "",
+				current_waypoint.x,
+				current_waypoint.y,
+				current_waypoint.z,
+				current_waypoint.heading,
+				(
+					current_waypoint.pause ?
+					fmt::format(
+						"{} ({})",
+						ConvertSecondsToTime(current_waypoint.pause),
+						current_waypoint.pause
+					) : 
+					""
+				)
+			).c_str()
+		);
 	}
 }
 


### PR DESCRIPTION
- Cleanup message and logic.
- Only display grid/waypoints if NPC has a grid.