### PR TITLE
[Commands] Add #unmemspell and #unmemspells Commands.

### DIFF
--- a/zone/CMakeLists.txt
+++ b/zone/CMakeLists.txt
@@ -541,6 +541,8 @@ SET(gm_commands
     gm_commands/undyeme.cpp
     gm_commands/unfreeze.cpp
     gm_commands/unlock.cpp
+    gm_commands/unmemspell.cpp
+    gm_commands/unmemspells.cpp
     gm_commands/unscribespell.cpp
     gm_commands/unscribespells.cpp
     gm_commands/untraindisc.cpp

--- a/zone/client.h
+++ b/zone/client.h
@@ -792,8 +792,9 @@ public:
 	void UnmemSpell(int slot, bool update_client = true);
 	void UnmemSpellBySpellID(int32 spell_id);
 	void UnmemSpellAll(bool update_client = true);
+	int FindEmptyMemSlot();
 	uint16 FindMemmedSpellBySlot(int slot);
-	int FindMemmedSpellByID(uint16 spell_id);
+	int FindMemmedSpellBySpellID(uint16 spell_id);
 	int MemmedCount();
 	std::vector<int> GetLearnableDisciplines(uint8 min_level = 1, uint8 max_level = 0);
 	std::vector<int> GetLearnedDisciplines();

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -241,7 +241,7 @@ int command_init(void)
 		command_add("makepet", "[level] [class] [race] [texture] - Make a pet", AccountStatus::Guide, command_makepet) ||
 		command_add("mana", "- Fill your or your target's mana", AccountStatus::Guide, command_mana) ||
 		command_add("maxskills", "Maxes skills for you.", AccountStatus::GMMgmt, command_max_all_skills) ||
-		command_add("memspell", "[Slot] [Spell ID] - Memorize a Spell by ID in the specified Slot", AccountStatus::Guide, command_memspell) ||
+		command_add("memspell", "[Spell ID] [Spell Gem] - Memorize a Spell by ID to the specified Spell Gem for you or your target", AccountStatus::Guide, command_memspell) ||
 		command_add("merchant_close_shop",  "Closes a merchant shop", AccountStatus::GMAdmin, command_merchantcloseshop) ||
 		command_add("merchant_open_shop",  "Opens a merchants shop", AccountStatus::GMAdmin, command_merchantopenshop) ||
 		command_add("modifynpcstat", "- Modifys a NPC's stats", AccountStatus::GMLeadAdmin, command_modifynpcstat) ||
@@ -378,6 +378,8 @@ int command_init(void)
 		command_add("undyeme", "- Remove dye from all of your armor slots", AccountStatus::Player, command_undyeme) ||
 		command_add("unfreeze", "- Unfreeze your target", AccountStatus::QuestTroupe, command_unfreeze) ||
 		command_add("unlock", "- Unlock the worldserver", AccountStatus::GMLeadAdmin, command_unlock) ||
+		command_add("unmemspell", "[Spell ID] - Unmemorize a Spell by ID for you or your target", AccountStatus::Guide, command_unmemspell) ||
+		command_add("unmemspells", " - Unmemorize all spells for you or your target", AccountStatus::Guide, command_unmemspells) ||
 		command_add("unscribespell", "[spellid] - Unscribe specified spell from your target's spell book.", AccountStatus::GMCoder, command_unscribespell) ||
 		command_add("unscribespells", "- Clear out your or your player target's spell book.", AccountStatus::GMCoder, command_unscribespells) ||
 		command_add("untraindisc", "[spellid] - Untrain specified discipline from your target.", AccountStatus::GMCoder, command_untraindisc) ||

--- a/zone/command.h
+++ b/zone/command.h
@@ -301,6 +301,8 @@ void command_undye(Client *c, const Seperator *sep);
 void command_undyeme(Client *c, const Seperator *sep);
 void command_unfreeze(Client *c, const Seperator *sep);
 void command_unlock(Client *c, const Seperator *sep);
+void command_unmemspell(Client *c, const Seperator *sep);
+void command_unmemspells(Client *c, const Seperator *sep);
 void command_unscribespell(Client *c, const Seperator *sep);
 void command_unscribespells(Client *c, const Seperator *sep);
 void command_untraindisc(Client *c, const Seperator *sep);

--- a/zone/gm_commands/unmemspell.cpp
+++ b/zone/gm_commands/unmemspell.cpp
@@ -1,13 +1,13 @@
 #include "../client.h"
 
-void command_memspell(Client *c, const Seperator *sep)
+void command_unmemspell(Client *c, const Seperator *sep)
 {
 	int arguments = sep->argnum;
 	if (
 		!arguments ||
 		!sep->IsNumber(1)
 	) {
-		c->Message(Chat::White, "Usage: #memspell [Spell ID] [Spell Gem]");
+		c->Message(Chat::White, "Usage: #unmemspell [Spell ID]");
 		return;
 	}
 
@@ -17,7 +17,7 @@ void command_memspell(Client *c, const Seperator *sep)
 	}
 
 	auto spell_id = static_cast<uint16>(std::stoul(sep->arg[1]));
-	if (!IsValidSpell(spell_id)) {
+	if (!IsValidSpell(spell_id))  {
 		c->Message(
 			Chat::White,
 			fmt::format(
@@ -28,12 +28,12 @@ void command_memspell(Client *c, const Seperator *sep)
 		return;
 	}
 
-	auto empty_slot = target->FindEmptyMemSlot();
-	if (empty_slot == -1) {
+	auto spell_gem = target->FindMemmedSpellBySpellID(spell_id);
+	if (spell_gem == -1) {
 		c->Message(
 			Chat::White,
 			fmt::format(
-				"{} not have a place to memorize {} ({}).",
+				"{} not have {} ({}) memorized.",
 				(
 					c == target ?
 					"You do" :
@@ -50,30 +50,18 @@ void command_memspell(Client *c, const Seperator *sep)
 		return;
 	}
 
-	auto spell_gem = sep->IsNumber(2) ? std::stoul(sep->arg[2]) : empty_slot;
-	if (spell_gem > EQ::spells::SPELL_GEM_COUNT) {
-		c->Message(
-			Chat::White,
-			fmt::format(
-				"Spell Gems range from 0 to {}.",
-				EQ::spells::SPELL_GEM_COUNT
-			).c_str()
-		);
-		return;
-	}
-
-	target->MemSpell(spell_id, spell_gem);
+	target->UnmemSpellBySpellID(spell_id);
 
 	if (c != target) {
 		c->Message(
 			Chat::White,
 			fmt::format(
-				"{} ({}) memorized to spell gem {} for {} ({}).",
+				"{} ({}) unmemorized for {} ({}) from spell gem {}.",
 				GetSpellName(spell_id),
 				spell_id,
-				spell_gem,
 				target->GetCleanName(),
-				target->GetID()
+				target->GetID(),
+				spell_gem
 			).c_str()
 		);
 	}

--- a/zone/gm_commands/unmemspells.cpp
+++ b/zone/gm_commands/unmemspells.cpp
@@ -1,0 +1,43 @@
+#include "../client.h"
+
+void command_unmemspells(Client *c, const Seperator *sep)
+{
+	auto target = c;
+	if (c->GetTarget() && c->GetTarget()->IsClient() && c->GetGM()) {
+		target = c->GetTarget()->CastToClient();
+	}
+
+	auto memmed_count = target->MemmedCount();
+	if (!memmed_count) {
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"{} no spells to unmemorize.",
+				(
+					c == target ?
+					"You have" :
+					fmt::format(
+						"{} ({}) has",
+						target->GetCleanName(),
+						target->GetID()
+					)
+				)
+			).c_str()
+		);
+		return;
+	}
+
+	target->UnmemSpellAll();
+
+	if (c != target) {
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"{} ({}) has had {} spells unmemorized.",
+				target->GetCleanName(),
+				target->GetID(),
+				memmed_count
+			).c_str()
+		);
+	}
+}

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -650,6 +650,16 @@ uint16 Lua_Client::FindMemmedSpellBySlot(int slot) {
 	return self->FindMemmedSpellBySlot(slot);
 }
 
+int Lua_Client::FindMemmedSpellBySpellID(uint16 spell_id) {
+	Lua_Safe_Call_Int();
+	return self->FindMemmedSpellBySpellID(spell_id);
+}
+
+int Lua_Client::FindEmptyMemSlot() {
+	Lua_Safe_Call_Int();
+	return self->FindEmptyMemSlot();
+}
+
 int Lua_Client::MemmedCount() {
 	Lua_Safe_Call_Int();
 	return self->MemmedCount();
@@ -2378,7 +2388,9 @@ luabind::scope lua_register_client() {
 	.def("Escape", (void(Lua_Client::*)(void))&Lua_Client::Escape)
 	.def("FailTask", (void(Lua_Client::*)(int))&Lua_Client::FailTask)
 	.def("FilteredMessage", &Lua_Client::FilteredMessage)
+	.def("FindEmptyMemSlot", (int(Lua_Client::*)(void))&Lua_Client::FindEmptyMemSlot)
 	.def("FindMemmedSpellBySlot", (uint16(Lua_Client::*)(int))&Lua_Client::FindMemmedSpellBySlot)
+	.def("FindMemmedSpellBySpellID", (int(Lua_Client::*)(uint16))&Lua_Client::FindMemmedSpellBySpellID)
 	.def("FindSpellBookSlotBySpellID", (int(Lua_Client::*)(int))&Lua_Client::FindSpellBookSlotBySpellID)
 	.def("Fling", (void(Lua_Client::*)(float,float,float,float))&Lua_Client::Fling)
 	.def("Fling", (void(Lua_Client::*)(float,float,float,float,bool))&Lua_Client::Fling)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -163,7 +163,9 @@ public:
 	void UnmemSpellBySpellID(int32 spell_id);
 	void UnmemSpellAll();
 	void UnmemSpellAll(bool update_client);
+	int FindEmptyMemSlot();
 	uint16 FindMemmedSpellBySlot(int slot);
+	int FindMemmedSpellBySpellID(uint16 spell_id);
 	int MemmedCount();
 	luabind::object GetLearnableDisciplines(lua_State* L);
 	luabind::object GetLearnableDisciplines(lua_State* L, uint8 min_level);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -1897,6 +1897,23 @@ XS(XS_Client_UnmemSpellAll) {
 	XSRETURN_EMPTY;
 }
 
+XS(XS_Client_FindEmptyMemSlot); /* prototype to pass -Wmissing-prototypes */
+XS(XS_Client_FindEmptyMemSlot) {
+	dXSARGS;
+	if (items != 1)
+		Perl_croak(aTHX_ "Usage: Client::FindEmptyMemSlot(THIS)"); // @categories Account and Character, Spells and Disciplines
+	{
+		Client *THIS;
+		int RETVAL;
+		dXSTARG;
+		VALIDATE_THIS_IS_CLIENT;
+		RETVAL = THIS->FindEmptyMemSlot();
+		XSprePUSH;
+		PUSHi((IV) RETVAL);
+	}
+	XSRETURN(1);
+}
+
 XS(XS_Client_FindMemmedSpellBySlot); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Client_FindMemmedSpellBySlot) {
 	dXSARGS;
@@ -1911,6 +1928,24 @@ XS(XS_Client_FindMemmedSpellBySlot) {
 		RETVAL = THIS->FindMemmedSpellBySlot(slot);
 		XSprePUSH;
 		PUSHu((UV) RETVAL);
+	}
+	XSRETURN(1);
+}
+
+XS(XS_Client_FindMemmedSpellBySpellID); /* prototype to pass -Wmissing-prototypes */
+XS(XS_Client_FindMemmedSpellBySpellID) {
+	dXSARGS;
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: Client::FindMemmedSpellBySpellID(THIS, uint16 spell_id)"); // @categories Account and Character, Spells and Disciplines
+	{
+		Client *THIS;
+		int RETVAL;
+		dXSTARG;
+		uint16 spell_id = (uint16) SvUV(ST(1));
+		VALIDATE_THIS_IS_CLIENT;
+		RETVAL = THIS->FindMemmedSpellBySpellID(spell_id);
+		XSprePUSH;
+		PUSHi((IV) RETVAL);
 	}
 	XSRETURN(1);
 }
@@ -5960,7 +5995,9 @@ XS(boot_Client) {
 	newXSproto(strcpy(buf, "Escape"), XS_Client_Escape, file, "$");
 	newXSproto(strcpy(buf, "ExpeditionMessage"), XS_Client_ExpeditionMessage, file, "$$$");
 	newXSproto(strcpy(buf, "FailTask"), XS_Client_FailTask, file, "$$");
+	newXSproto(strcpy(buf, "FindEmptyMemSlot"), XS_Client_FindEmptyMemSlot, file, "$");
 	newXSproto(strcpy(buf, "FindMemmedSpellBySlot"), XS_Client_FindMemmedSpellBySlot, file, "$$");
+	newXSproto(strcpy(buf, "FindMemmedSpellBySpellID"), XS_Client_FindMemmedSpellBySpellID, file, "$$");
 	newXSproto(strcpy(buf, "Fling"), XS_Client_Fling, file, "$$$$$;$$");
 	newXSproto(strcpy(buf, "ForageItem"), XS_Client_ForageItem, file, "$");
 	newXSproto(strcpy(buf, "Freeze"), XS_Client_Freeze, file, "$");


### PR DESCRIPTION
- Add #unmemspell [Spell ID] command to unmemorize a spell by ID from you or your target.
- Add #unmemspells command to unmemorize all spells from you or your target.
- Cleanup #memspell command and change arguments from #memspell [Slot] [Spell ID] to #memspell [Spell ID] [Spell Gem] for easier use.
- Add #memspell [Spell ID] functionality to memorize to first open spell gem if there are any using FindEmptyMemSlot helper method.
- Rename client->FindMemmedSpellByID(spell_id) to FindMemmedSpellBySpellID(spell_id).
- Add client->FindEmptyMemSlot() helper method.
- Add $client->FindEmptyMemSlot() to Perl.
- Add client:FindEmptyMemSlot() to Lua.
- Add $client->FindMemmedSpellBySpellID(spell_id) to Perl.
- Add client:FindMemmedSpellBySpellID(spell_id) to Lua.