### PR TITLE
[Combat] Allow npcs/pets to kick vs opponents requiring magic weapons if wearing magic booties.

### DIFF
--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -1606,6 +1606,8 @@ void NPC::DoClassAttacks(Mob *target) {
 	bool ca_time = classattack_timer.Check(false);
 	bool ka_time = knightattack_timer.Check(false);
 
+	const EQ::ItemData* boots = database.GetItem(equipment[EQ::invslot::slotFeet]);
+
 	//only check attack allowed if we are going to do something
 	if((taunt_time || ca_time || ka_time) && !IsAttackAllowed(target))
 		return;
@@ -1677,7 +1679,7 @@ void NPC::DoClassAttacks(Mob *target) {
 					DoAnim(animKick, 0, false);
 					int32 dmg = GetBaseSkillDamage(EQ::skills::SkillKick);
 
-					if (GetWeaponDamage(target, (const EQ::ItemData*)nullptr) <= 0) {
+					if (GetWeaponDamage(target, boots) <= 0) {
 						dmg = DMG_INVULNERABLE;
 					}
 
@@ -1728,7 +1730,7 @@ void NPC::DoClassAttacks(Mob *target) {
 				DoAnim(animKick, 0, false);
 				int32 dmg = GetBaseSkillDamage(EQ::skills::SkillKick);
 
-				if (GetWeaponDamage(target, (const EQ::ItemData*)nullptr) <= 0)
+				if (GetWeaponDamage(target, boots) <= 0)
 					dmg = DMG_INVULNERABLE;
 
 				reuse = (KickReuseTime + 3) * 1000;
@@ -1744,7 +1746,7 @@ void NPC::DoClassAttacks(Mob *target) {
 				DoAnim(animTailRake, 0, false);
 				int32 dmg = GetBaseSkillDamage(EQ::skills::SkillBash);
 
-				if (GetWeaponDamage(target, (const EQ::ItemData*)nullptr) <= 0)
+				if (GetWeaponDamage(target, boots) <= 0)
 					dmg = DMG_INVULNERABLE;
 
 				reuse = (BashReuseTime + 3) * 1000;

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -1746,7 +1746,7 @@ void NPC::DoClassAttacks(Mob *target) {
 				DoAnim(animTailRake, 0, false);
 				int32 dmg = GetBaseSkillDamage(EQ::skills::SkillBash);
 
-				if (GetWeaponDamage(target, boots) <= 0)
+				if (GetWeaponDamage(target, (const EQ::ItemData*)nullptr) <= 0)
 					dmg = DMG_INVULNERABLE;
 
 				reuse = (BashReuseTime + 3) * 1000;


### PR DESCRIPTION
NPCs and Pets below the rule values allowing damage vs mobs requiring magic weapons can now kick successfully if wearing magical booties.