### PR TITLE
[Doors] Add new rule enabling classic "key on cursor" for pre keyring keys

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -808,6 +808,10 @@ RULE_CATEGORY(Command)
 RULE_BOOL(Command, DyeCommandRequiresDyes, false, "Enable this to require a Prismatic Dye (32557) each time someone uses #dye.")
 RULE_CATEGORY_END()
 
+RULE_CATEGORY(Doors)
+RULE_BOOL(Doors, RequireKeyOnCursor, false, "Enable this to require pre-keyring keys to be on player cursor to open doors.")
+RULE_CATEGORY_END()
+
 #undef RULE_CATEGORY
 #undef RULE_INT
 #undef RULE_REAL

--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -211,13 +211,23 @@ void Doors::HandleClick(Client* sender, uint8 trigger) {
 
 	uint32 required_key_item       = GetKeyItem();
 	uint8  disable_add_to_key_ring = GetNoKeyring();
-	uint32 player_has_key          = 0;
+	bool player_has_key            = false;
 	uint32 player_key              = 0;
 
 	const EQ::ItemInstance *lock_pick_item = sender->GetInv().GetItem(EQ::invslot::slotCursor);
-	player_has_key = static_cast<uint32>(sender->GetInv().HasItem(required_key_item, 1));
 
-	if (player_has_key != INVALID_INDEX) {
+	// If classic key on cursor rule, check for it, otherwise owning it ok.
+	if (RuleB(Doors, RequireKeyOnCursor)) {
+		if (lock_pick_item != nullptr &&
+			lock_pick_item->GetItem()->ID == required_key_item) {
+			player_has_key = true;
+		}
+	}
+	else if (sender->GetInv().HasItem(required_key_item, 1) != INVALID_INDEX) {
+		player_has_key = true;
+	}
+
+	if (player_has_key) {
 		player_key = required_key_item;
 	}
 


### PR DESCRIPTION
Classic locked doors with keys that do not add to the key ring required the player to have the key on their cursor.

Added a new rule that allows this functionality to work correctly.  The default is the functionality before this patch, which is to just require it to be anywhere in their inventory.