### PR TITLE
[XTarget] Add Character:XTargetAllowCorpses Rule

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -174,6 +174,7 @@ RULE_INT(Character, ResurrectionSicknessSpellID, 756, "756 is Default Resurrecti
 RULE_BOOL(Character, EnableBardMelody, true, "Enable Bard /melody by default, to disable change to false for a classic experience.")
 RULE_BOOL(Character, EnableRangerAutoFire, true, "Enable Ranger /autofire by default, to disable change to false for a classic experience.")
 RULE_BOOL(Character, EnableTGB, true, "Enable /tgb (Target Group Buff) by default, to disable change to false for a classic experience.")
+RULE_BOOL(Character, XTargetAllowCorpses, true, "Allow Extended Target Window to display corpses.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Mercs)

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -7206,7 +7206,7 @@ void Client::OpenLFGuildWindow()
 
 bool Client::IsXTarget(const Mob *m) const
 {
-	if(!XTargettingAvailable() || !m || (m->GetID() == 0))
+	if(!XTargettingAvailable() || !m || (m->GetID() == 0) || (!RuleB(Character, XTargetAllowCorpses) && m->IsCorpse()))
 		return false;
 
 	for(int i = 0; i < GetMaxXTargets(); ++i)


### PR DESCRIPTION
Why:

A condition could occur where a member of a group or raid could FD and still
have mobs on his/her hate list due to feign memory.  If during this state a
mob in this client's XTarget window dies, the corpse of that mob would take
its place in the XTarget window.  This would not clear until the corpse rots.
This feels undesired.

What:

Added a rule (Character:XTargetAllowCorpses) to toggle the behavior of
allowing corpses to appear in the XTarget window.  I implemented this as a
condition within the IsXTarget method, as this seemed the cleanest way of
implementing this behavior across the board.  I defaulted the rule to true,
so server owners need to opt in to this rule by setting it to false.