### PR TITLE
[Spells] Update to SPA 58 SE_Levitate to support limit value

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -743,7 +743,12 @@ void Client::CompleteConnect()
 					}
 				}
 				else {
-					SendAppearancePacket(AT_Levitate, 2);
+					if (spell.limit_value[x1] == 1) {
+						SendAppearancePacket(AT_Levitate, EQ::constants::GravityBehavior::LevitateWhileRunning, true, true);
+					}
+					else {
+						SendAppearancePacket(AT_Levitate, EQ::constants::GravityBehavior::Levitating, true, true);
+					}
 				}
 				break;
 			}

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -1369,7 +1369,12 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 #endif
 				//this sends the levitate packet to everybody else
 				//who does not otherwise receive the buff packet.
-				SendAppearancePacket(AT_Levitate, 2, true, true);
+				if (spells[spell_id].limit_value[i] == 1) {
+					SendAppearancePacket(AT_Levitate, EQ::constants::GravityBehavior::LevitateWhileRunning, true, true);
+				}
+				else {
+					SendAppearancePacket(AT_Levitate, EQ::constants::GravityBehavior::Levitating, true, true);
+				}
 				break;
 			}
 


### PR DESCRIPTION
Levitate spells that have a limit value are used for Flying mounts. If set it seems like it should be using Flymode 5 LevitateWhileRunning. Add support for that.