### PR TITLE
[Commands] Cleanup #guild Command.

### DIFF
--- a/common/guild_base.cpp
+++ b/common/guild_base.cpp
@@ -1225,6 +1225,66 @@ uint32 BaseGuildManager::DoesAccountContainAGuildLeader(uint32 AccountID)
 	return results.RowCount();
 }
 
+std::string BaseGuildManager::GetGuildNameByID(uint32 guild_id) const {
+	if(guild_id == GUILD_NONE) {
+		return std::string();
+	}
 
+	std::map<uint32, GuildInfo *>::const_iterator res;
+	res = m_guilds.find(guild_id);
+	if(res == m_guilds.end()) {
+		return "Invalid Guild";
+	}
 
+	return res->second->name;
+}
 
+std::string BaseGuildManager::GetGuildRankName(uint32 guild_id, uint8 rank) const
+{
+	if(rank > GUILD_MAX_RANK) {
+		return "Invalid Rank";
+	}
+
+	std::map<uint32, GuildInfo *>::const_iterator res;
+	res = m_guilds.find(guild_id);
+	if(res == m_guilds.end()) {
+		return "Invalid Guild Rank";
+	}
+
+	return res->second->ranks[rank].name;
+}
+
+uint32 BaseGuildManager::GetGuildIDByCharacterID(uint32 character_id)
+{
+    if(!m_db) {
+		return GUILD_NONE;
+	}
+
+    std::string query = fmt::format(
+		"SELECT `guild_id` FROM `guild_members` WHERE char_id = {} LIMIT 1",
+		character_id
+	);
+    auto results = m_db->QueryDatabase(query);
+	if(!results.Success() || !results.RowCount()) {
+		return GUILD_NONE;
+	}
+
+	auto row = results.begin();
+	auto guild_id = std::stoul(row[0]);
+	return guild_id;
+}
+
+bool BaseGuildManager::IsCharacterInGuild(uint32 character_id, uint32 guild_id)
+{
+	auto current_guild_id = GetGuildIDByCharacterID(character_id);
+
+	if (current_guild_id == GUILD_NONE) {
+		return false;
+	}
+	
+	if (guild_id && current_guild_id != guild_id) {
+		return false;
+	}
+
+	return true;
+}

--- a/common/guild_base.h
+++ b/common/guild_base.h
@@ -76,8 +76,12 @@ class BaseGuildManager
 		bool	GetGuildChannel(uint32 GuildID, char *ChannelBuffer) const;
 		const char *GetRankName(uint32 guild_id, uint8 rank) const;
 		const char *GetGuildName(uint32 guild_id) const;
+		std::string GetGuildNameByID(uint32 guild_id) const;
+		std::string GetGuildRankName(uint32 guild_id, uint8 rank) const;
+		bool IsCharacterInGuild(uint32 character_id, uint32 guild_id = 0);
 		bool	GetGuildNameByID(uint32 guild_id, std::string &into) const;
 		uint32	GetGuildIDByName(const char *GuildName);
+		uint32 GetGuildIDByCharacterID(uint32 character_id);
 		bool	IsGuildLeader(uint32 guild_id, uint32 char_id) const;
 		uint8	GetDisplayedRank(uint32 guild_id, uint8 rank, uint32 char_id) const;
 		bool	CheckGMStatus(uint32 guild_id, uint8 status) const;

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -5369,25 +5369,15 @@ void Client::ShowSkillsWindow()
 
 		// Current Skill Level out of Max Skill Level or a Check Mark for Maxed
 		popup_text += fmt::format(
-			"<td>{}{}{}</td>",
+			"<td>{}</td>",
 			(
 				skill_maxed ?
-				"<c \"#00FF00\">" :
-				""
-			),
-			(
-				skill_maxed ?				
-				"✔" :
+				"<c \"#00FF00\">✔</c>" :
 				fmt::format(
 					"{}/{}",
 					current_skill,
 					max_skill
 				)
-			),
-			(
-				skill_maxed ?
-				"</c>" :
-				""
 			)
 		);
 


### PR DESCRIPTION
- Cleanup messages and logic.
- Adds GetGuildNameByID, GetGuildRankName, GetGuildIDByCharacterID, and IsCharacterInGuild helper methods for guild stuff.
- Convert #guild info message to a popup display to tidy it up and make it more legible.

Before:
![image](https://user-images.githubusercontent.com/89047260/145719139-134f53fc-d848-4c72-b618-a81d295aa567.png)

After:
![image](https://user-images.githubusercontent.com/89047260/145719128-2d0fd710-f5cc-4c12-b408-876de6f7a4f6.png)
