### PR TITLE
[XTarget] Disallow Corpses in XTarget Auto Slots

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2573,7 +2573,7 @@ bool NPC::Death(Mob* killer_mob, int32 damage, uint16 spell, EQ::skills::SkillTy
 
 		entity_list.RemoveFromAutoXTargets(this);
 
-		if (killer->GetUltimateOwner()->IsClient()) {
+		if (killer->GetUltimateOwner() && killer->GetUltimateOwner()->IsClient()) {
 			killer->GetUltimateOwner()->CastToClient()->ProcessXTargetAutoHaters();
 		}
 		uint16 emoteid = this->GetEmoteID();

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1801,6 +1801,7 @@ bool Client::Death(Mob* killerMob, int32 damage, uint16 spell, EQ::skills::Skill
 	entity_list.RemoveFromTargets(this, true);
 	hate_list.RemoveEntFromHateList(this);
 	RemoveAutoXTargets();
+	ProcessXTargetAutoHaters();
 
 	//remove ourself from all proximities
 	ClearAllProximities();
@@ -2571,6 +2572,10 @@ bool NPC::Death(Mob* killer_mob, int32 damage, uint16 spell, EQ::skills::SkillTy
 		}
 
 		entity_list.RemoveFromAutoXTargets(this);
+
+		if (killer->GetUltimateOwner()->IsClient()) {
+			killer->GetUltimateOwner()->CastToClient()->ProcessXTargetAutoHaters();
+		}
 		uint16 emoteid = this->GetEmoteID();
 		auto corpse = new Corpse(this, &itemlist, GetNPCTypeID(), &NPCTypedata,
 			level > 54 ? RuleI(NPC, MajorNPCCorpseDecayTimeMS)

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -7197,7 +7197,7 @@ void Client::OpenLFGuildWindow()
 
 bool Client::IsXTarget(const Mob *m) const
 {
-	if(!XTargettingAvailable() || !m || (m->GetID() == 0))
+	if(!XTargettingAvailable() || !m || (m->GetID() == 0) || m->IsCorpse())
 		return false;
 
 	for(int i = 0; i < GetMaxXTargets(); ++i)
@@ -7455,6 +7455,13 @@ void Client::ProcessXTargetAutoHaters()
 
 		if (XTargets[i].ID != 0 && !GetXTargetAutoMgr()->contains_mob(XTargets[i].ID)) {
 			XTargets[i].ID = 0;
+			XTargets[i].Name[0] = 0;
+			XTargets[i].dirty = true;
+		}
+
+		if (XTargets[i].ID != 0 && entity_list.GetMob(XTargets[i].ID) && entity_list.GetMob(XTargets[i].ID)->IsCorpse()) {
+			XTargets[i].ID = 0;
+			XTargets[i].Name[0] = 0;
 			XTargets[i].dirty = true;
 		}
 

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -7453,13 +7453,15 @@ void Client::ProcessXTargetAutoHaters()
 		if (XTargets[i].Type != Auto)
 			continue;
 
+		auto *mob = entity_list.GetMob(XTargets[i].ID);
+
 		if (XTargets[i].ID != 0 && !GetXTargetAutoMgr()->contains_mob(XTargets[i].ID)) {
 			XTargets[i].ID = 0;
 			XTargets[i].Name[0] = 0;
 			XTargets[i].dirty = true;
 		}
 
-		if (XTargets[i].ID != 0 && entity_list.GetMob(XTargets[i].ID) && !entity_list.GetMob(XTargets[i].ID)->IsValidXTarget()) {
+		if (XTargets[i].ID != 0 && mob && !mob->IsValidXTarget()) {
 			XTargets[i].ID = 0;
 			XTargets[i].Name[0] = 0;
 			XTargets[i].dirty = true;

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -7197,7 +7197,7 @@ void Client::OpenLFGuildWindow()
 
 bool Client::IsXTarget(const Mob *m) const
 {
-	if(!XTargettingAvailable() || !m || (m->GetID() == 0) || m->IsCorpse())
+	if(!XTargettingAvailable() || !m || !m->IsValidXTarget())
 		return false;
 
 	for(int i = 0; i < GetMaxXTargets(); ++i)
@@ -7240,10 +7240,10 @@ void Client::UpdateClientXTarget(Client *c)
 // IT IS NOT SAFE TO CALL THIS IF IT'S NOT INITIAL AGGRO
 void Client::AddAutoXTarget(Mob *m, bool send)
 {
-	m_activeautohatermgr->increment_count(m);
-
 	if (!XTargettingAvailable() || !XTargetAutoAddHaters || IsXTarget(m))
 		return;
+	
+	m_activeautohatermgr->increment_count(m);
 
 	for(int i = 0; i < GetMaxXTargets(); ++i)
 	{
@@ -7411,7 +7411,7 @@ void Client::RemoveAutoXTargets()
 	for(int i = 0; i < GetMaxXTargets(); ++i)
 	{
 		if(XTargets[i].Type == Auto)
-		{
+		{			
 			XTargets[i].ID = 0;
 			XTargets[i].Name[0] = 0;
 			SendXTargetPacket(i, nullptr);
@@ -7459,7 +7459,7 @@ void Client::ProcessXTargetAutoHaters()
 			XTargets[i].dirty = true;
 		}
 
-		if (XTargets[i].ID != 0 && entity_list.GetMob(XTargets[i].ID) && entity_list.GetMob(XTargets[i].ID)->IsCorpse()) {
+		if (XTargets[i].ID != 0 && entity_list.GetMob(XTargets[i].ID) && !entity_list.GetMob(XTargets[i].ID)->IsValidXTarget()) {
 			XTargets[i].ID = 0;
 			XTargets[i].Name[0] = 0;
 			XTargets[i].dirty = true;
@@ -7497,6 +7497,7 @@ void Client::ProcessXTargetAutoHaters()
 				break;
 		}
 	}
+	
 	m_dirtyautohaters = false;
 	SendXTargetUpdates();
 }

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -7411,7 +7411,7 @@ void Client::RemoveAutoXTargets()
 	for(int i = 0; i < GetMaxXTargets(); ++i)
 	{
 		if(XTargets[i].Type == Auto)
-		{			
+		{
 			XTargets[i].ID = 0;
 			XTargets[i].Name[0] = 0;
 			SendXTargetPacket(i, nullptr);

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -6610,5 +6610,5 @@ void Mob::SetBucket(std::string bucket_name, std::string bucket_value, std::stri
 }
 
 bool Mob::IsValidXTarget() const {
-	return (!GetID() == 0 || !IsCorpse());
+	return (GetID() > 0 || !IsCorpse());
 }

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -6608,3 +6608,7 @@ void Mob::SetBucket(std::string bucket_name, std::string bucket_value, std::stri
 	std::string full_bucket_name = fmt::format("{}-{}", GetBucketKey(), bucket_name);
 	DataBucket::SetData(full_bucket_name, bucket_value, expiration);
 }
+
+bool Mob::IsValidXTarget() const {
+	return (!GetID() == 0 || !IsCorpse());
+}

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1299,6 +1299,8 @@ public:
 	std::string GetBucketRemaining(std::string bucket_name);
 	void SetBucket(std::string bucket_name, std::string bucket_value, std::string expiration = "");
 
+	bool IsValidXTarget() const;
+
 #ifdef BOTS
 	// Bots HealRotation methods
 	bool IsHealRotationTarget() { return (m_target_of_heal_rotation.use_count() && m_target_of_heal_rotation.get()); }


### PR DESCRIPTION
The problem:
There existed a state where a mob's corpse would remain indefinitely in an auto XTarget slot if Auto Haters was on.
In order to get to this state, a combination of pet attacks and a timely feign death without feign memory was required.

My fix:
Added an IsValidXTarget method to the Mob class. which includes filtering out corpses.  Just in case this logic needs referenced elsewhere, at some other point in the future.
Call IsValidXTarget from the IsXTarget method in client class.
Added call to ProcessXTargetAutoHaters() inside Death methods for both NPC and Client
Inside AddAutoXTarget, moved autohate increment call to after the IsXTarget check.
