### PR TITLE
[Spells] Update to SPA 205 SE_Rampage

### DIFF
--- a/common/spdat.h
+++ b/common/spdat.h
@@ -912,7 +912,7 @@ typedef enum {
 #define SE_IllusionOther				202	// implemented - Project Illusion
 #define SE_MassGroupBuff				203	// implemented
 #define SE_GroupFearImmunity			204	// implemented - (Does not use bonus)
-#define SE_Rampage						205	// implemented
+#define SE_Rampage						205	// implemented, @Combat Instant, Perform a primary slot combat rounds on all creatures within a 40 foot radius, base: number of attack rounds, limit: max entities hit per round, max: none, Note: AE range is 40 by default. Custom: Set field 'aoe_range' to override default. Adding additional attacks and hit count limit.
 #define SE_AETaunt						206	// implemented
 #define SE_FleshToBone					207	// implemented
 //#define SE_PurgePoison				208	// not used

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -405,7 +405,7 @@ bool Client::Process() {
 				}
 
 				if (CheckAATimer(aaTimerRampage)) {
-					entity_list.AEAttack(this, 30);
+					entity_list.AEAttack(this, 40);
 				}
 			}
 		}

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -1264,7 +1264,8 @@ void EntityList::AEAttack(
 	float distance,
 	int Hand,
 	int count,
-	bool is_from_spell)
+	bool is_from_spell,
+	int attack_rounds)
 {
 	Mob   *current_mob     = nullptr;
 	float distance_squared = distance * distance;
@@ -1276,15 +1277,18 @@ void EntityList::AEAttack(
 		if (current_mob->IsNPC()
 			&& current_mob != attacker //this is not needed unless NPCs can use this
 			&& (attacker->IsAttackAllowed(current_mob))
-			&& current_mob->GetRace() != 216 && current_mob->GetRace() != 472 /* dont attack horses */
+			&& !current_mob->IsHorse() /* dont attack mounts */
 			&& (DistanceSquared(current_mob->GetPosition(), attacker->GetPosition()) <= distance_squared)
 			) {
 
-			if (!attacker->IsClient() || attacker->GetClass() == MONK || attacker->GetClass() == RANGER) {
-				attacker->Attack(current_mob, Hand, false, false, is_from_spell);
-			}
-			else {
-				attacker->CastToClient()->DoAttackRounds(current_mob, Hand, is_from_spell);
+			for (int i = 0; i < attack_rounds; i++) {
+
+				if (!attacker->IsClient() || attacker->GetClass() == MONK || attacker->GetClass() == RANGER) {
+					attacker->Attack(current_mob, Hand, false, false, is_from_spell);
+				}
+				else {
+					attacker->CastToClient()->DoAttackRounds(current_mob, Hand, is_from_spell);
+				}
 			}
 
 			hit_count++;

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -407,7 +407,8 @@ public:
 		float distance,
 		int Hand = EQ::invslot::slotPrimary,
 		int count = 0,
-		bool is_from_spell = false
+		bool is_from_spell = false,
+		int attack_rounds = 1
 	);
 	void AETaunt(Client *caster, float range = 0, int32 bonus_hate = 0);
 	void AESpell(

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -2202,9 +2202,16 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Rampage");
 #endif
-				if(caster)
-					entity_list.AEAttack(caster, 30, EQ::invslot::slotPrimary, 0, true); // on live wars dont get a duration ramp, its a one shot deal
-
+				//defulat live range is 40, with 1 attack per round, no hit count limit
+				float rampage_range = 40;
+				if (spells[spell_id].aoe_range) {
+					rampage_range = spells[spell_id].aoe_range; //added for expanded functionality
+				}
+				int attack_count = spells[spell_id].base_value[i]; //added for expanded functionality
+				int hit_count = spells[spell_id].limit_value[i]; //added for expanded functionality
+				if (caster) {
+					entity_list.AEAttack(caster, rampage_range, EQ::invslot::slotPrimary, hit_count, true, attack_count); // on live wars dont get a duration ramp, its a one shot deal
+				}
 				break;
 			}
 


### PR DESCRIPTION
Updated the hard coded rampage range from 30 to 40 which is how live describes it in every spell.

This effect performs a single primary slot combat rounds on all creatures within a 40 foot radius. On live if you want more than one round of melee you need to use an additional effectid slot.

Added some additional functionality.
**base value** which is normally 1, can be set to do allow for additional combat rounds from same slot (ie set to 15 to do 15 melee swings)
**limit value** can set to limit the number of NPCs that can be hit by the AE (ie set to 5 to make it so no more than 5 different NPC can take damage)
**max value** can be set to override the 40 default range

`#define SE_Rampage						205	// implemented, @Combat Instant, Perform a primary slot combat rounds on all creatures within a 40 foot radius, base: number of attack rounds, limit: max entities hit per round, max: AE range override, Note: AE range is 40 by default. Custom: max ae range, adding additional attacks and hit count limit.`