### PR TITLE
[Bug Fix] Hero Forge armor graphics not displaying properly to other clients in zone.

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -270,7 +270,7 @@ Client::Client(EQStreamInterface* ieqs)
 	if (RuleI(World, PVPMinLevel) > 0 && level >= RuleI(World, PVPMinLevel) && m_pp.pvp == 0) SetPVP(true, false);
 	dynamiczone_removal_timer.Disable();
 
-	connect_delay_timer.Disable();
+	on_connect_complete_delay_timer.Disable();
 
 	//for good measure:
 	memset(&m_pp, 0, sizeof(m_pp));

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -270,7 +270,7 @@ Client::Client(EQStreamInterface* ieqs)
 	if (RuleI(World, PVPMinLevel) > 0 && level >= RuleI(World, PVPMinLevel) && m_pp.pvp == 0) SetPVP(true, false);
 	dynamiczone_removal_timer.Disable();
 
-	on_connect_complete_delay_timer.Disable();
+	heroforge_wearchange_timer.Disable();
 
 	//for good measure:
 	memset(&m_pp, 0, sizeof(m_pp));

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -270,6 +270,8 @@ Client::Client(EQStreamInterface* ieqs)
 	if (RuleI(World, PVPMinLevel) > 0 && level >= RuleI(World, PVPMinLevel) && m_pp.pvp == 0) SetPVP(true, false);
 	dynamiczone_removal_timer.Disable();
 
+	connect_delay_timer.Disable();
+
 	//for good measure:
 	memset(&m_pp, 0, sizeof(m_pp));
 	memset(&m_epp, 0, sizeof(m_epp));

--- a/zone/client.h
+++ b/zone/client.h
@@ -1870,7 +1870,7 @@ private:
 	Timer dynamiczone_removal_timer;
 	Timer task_request_timer;
 
-	Timer connect_delay_timer;
+	Timer on_connect_complete_delay_timer;
 
 	glm::vec3 m_Proximity;
 	glm::vec4 last_position_before_bulk_update;

--- a/zone/client.h
+++ b/zone/client.h
@@ -1870,7 +1870,7 @@ private:
 	Timer dynamiczone_removal_timer;
 	Timer task_request_timer;
 
-	Timer on_connect_complete_delay_timer;
+	Timer heroforge_wearchange_timer;
 	
 	glm::vec3 m_Proximity;
 	glm::vec4 last_position_before_bulk_update;

--- a/zone/client.h
+++ b/zone/client.h
@@ -1871,7 +1871,7 @@ private:
 	Timer task_request_timer;
 
 	Timer on_connect_complete_delay_timer;
-
+	
 	glm::vec3 m_Proximity;
 	glm::vec4 last_position_before_bulk_update;
 

--- a/zone/client.h
+++ b/zone/client.h
@@ -1870,6 +1870,8 @@ private:
 	Timer dynamiczone_removal_timer;
 	Timer task_request_timer;
 
+	Timer connect_delay_timer;
+
 	glm::vec3 m_Proximity;
 	glm::vec4 last_position_before_bulk_update;
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -902,7 +902,7 @@ void Client::CompleteConnect()
 		safe_delete(p);
 	}
 
-	connect_delay_timer.Start(250);
+	on_connect_complete_delay_timer.Start(250);
 }
 
 // connecting opcode handlers

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -747,28 +747,11 @@ void Client::CompleteConnect()
 
 	entity_list.SendAppearanceEffects(this);
 
-	int x;
-	for (x = EQ::textures::textureBegin; x <= EQ::textures::LastTexture; x++) {
-		SendWearChange(x);
-	}
-	// added due to wear change above
-	UpdateActiveLight();
-	SendAppearancePacket(AT_Light, GetActiveLightType());
-
-	Mob *pet = GetPet();
-	if (pet != nullptr) {
-		for (x = EQ::textures::textureBegin; x <= EQ::textures::LastTexture; x++) {
-			pet->SendWearChange(x);
-		}
-		// added due to wear change above
-		pet->UpdateActiveLight();
-		pet->SendAppearancePacket(AT_Light, pet->GetActiveLightType());
-	}
-
 	entity_list.SendTraders(this);
 
-	if (GetPet()) {
-		GetPet()->SendPetBuffsToClient();
+	Mob *pet = GetPet();
+	if (pet) {
+		pet->SendPetBuffsToClient();
 	}
 
 	if (GetGroup())
@@ -918,6 +901,8 @@ void Client::CompleteConnect()
 		worldserver.SendPacket(p);
 		safe_delete(p);
 	}
+
+	connect_delay_timer.Start(250);
 }
 
 // connecting opcode handlers

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -902,7 +902,7 @@ void Client::CompleteConnect()
 		safe_delete(p);
 	}
 
-	on_connect_complete_delay_timer.Start(250);
+	heroforge_wearchange_timer.Start(250);
 }
 
 // connecting opcode handlers

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -199,14 +199,18 @@ bool Client::Process() {
 			instalog = true;
 		}
 
-		if (connect_delay_timer.Check()) {
-			Shout("Connect Delay Timer check");
+		if (on_connect_complete_delay_timer.Check()) {
+			/*
+				This addresses bug where on zone in heroforge models would not be sent to other clients when this was
+				in Client::CompleteConnect(). Sending after a small 250 ms delay after that function resolves the issue. 
+				Unclear the underlying reason for this, if a better solution can be found then can move this back. 
+			*/
 			SendWearChangeAndLighting(EQ::textures::LastTexture);
 			Mob *pet = GetPet();
 			if (pet) {
 				pet->SendWearChangeAndLighting(EQ::textures::LastTexture);
 			}
-			connect_delay_timer.Disable();
+			on_connect_complete_delay_timer.Disable();
 		}
 
 		if (IsStunned() && stunned_timer.Check())

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -199,6 +199,16 @@ bool Client::Process() {
 			instalog = true;
 		}
 
+		if (connect_delay_timer.Check()) {
+			Shout("Connect Delay Timer check");
+			SendWearChangeAndLighting(EQ::textures::LastTexture);
+			Mob *pet = GetPet();
+			if (pet) {
+				pet->SendWearChangeAndLighting(EQ::textures::LastTexture);
+			}
+			connect_delay_timer.Disable();
+		}
+
 		if (IsStunned() && stunned_timer.Check())
 			Mob::UnStun();
 

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -199,24 +199,23 @@ bool Client::Process() {
 			instalog = true;
 		}
 
-		if (on_connect_complete_delay_timer.Check()) {
+		if (heroforge_wearchange_timer.Check()) {
 			/*
 				This addresses bug where on zone in heroforge models would not be sent to other clients when this was
 				in Client::CompleteConnect(). Sending after a small 250 ms delay after that function resolves the issue. 
-				Unclear the underlying reason for this, if a better solution can be found then can move this back. 
+				Unclear the underlying reason for this, if a better solution can be found then can move this back.
 			*/
-			Shout("Timer Check QUE %i", que_wearchange_slot);
-			if (que_wearchange_slot == -1) {
+			if (queue_wearchange_slot >= 0) { //Resend slot from Client::SwapItem if heroforge item is swapped.
+				SendWearChange(static_cast<uint8>(queue_wearchange_slot));
+			}
+			else { //Send from Client::CompleteConnect()
 				SendWearChangeAndLighting(EQ::textures::LastTexture);
 				Mob *pet = GetPet();
 				if (pet) {
 					pet->SendWearChangeAndLighting(EQ::textures::LastTexture);
 				}
 			}
-			else if (que_wearchange_slot >= 0) {
-				SendWearChange(static_cast<uint8>(que_wearchange_slot));
-			}
-			on_connect_complete_delay_timer.Disable();
+			heroforge_wearchange_timer.Disable();
 		}
 
 		if (IsStunned() && stunned_timer.Check())

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -205,10 +205,16 @@ bool Client::Process() {
 				in Client::CompleteConnect(). Sending after a small 250 ms delay after that function resolves the issue. 
 				Unclear the underlying reason for this, if a better solution can be found then can move this back. 
 			*/
-			SendWearChangeAndLighting(EQ::textures::LastTexture);
-			Mob *pet = GetPet();
-			if (pet) {
-				pet->SendWearChangeAndLighting(EQ::textures::LastTexture);
+			Shout("Timer Check QUE %i", que_wearchange_slot);
+			if (que_wearchange_slot == -1) {
+				SendWearChangeAndLighting(EQ::textures::LastTexture);
+				Mob *pet = GetPet();
+				if (pet) {
+					pet->SendWearChangeAndLighting(EQ::textures::LastTexture);
+				}
+			}
+			else if (que_wearchange_slot >= 0) {
+				SendWearChange(static_cast<uint8>(que_wearchange_slot));
 			}
 			on_connect_complete_delay_timer.Disable();
 		}

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -2227,6 +2227,9 @@ bool Client::SwapItem(MoveItem_Struct* move_in) {
 	if (dst_slot_id <= EQ::invslot::EQUIPMENT_END) {// on Titanium and ROF2 /showhelm works even if sending helm slot
 		SendWearChange(matslot);
 	}
+	if (matslot == 0) {
+		on_connect_complete_delay_timer.Start(250);//TOO HACKY BUT WORKS
+	}
 
 	// Step 7: Save change to the database
 	if (src_slot_id == EQ::invslot::slotCursor) {

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -2228,8 +2228,8 @@ bool Client::SwapItem(MoveItem_Struct* move_in) {
 		SendWearChange(matslot);
 	}
 	// This is part of a bug fix to ensure heroforge graphics display to other clients in zone.
-	if (que_wearchange_slot >= 0) {
-		on_connect_complete_delay_timer.Start(100);//TOO HACKY BUT WORKS
+	if (queue_wearchange_slot >= 0) {
+		heroforge_wearchange_timer.Start(100);//TOO HACKY BUT WORKS
 	}
 
 	// Step 7: Save change to the database

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -2224,7 +2224,7 @@ bool Client::SwapItem(MoveItem_Struct* move_in) {
 	}
 
 	int matslot = SlotConvert2(dst_slot_id);
-	if (dst_slot_id <= EQ::invslot::EQUIPMENT_END) {
+	if (dst_slot_id <= EQ::invslot::EQUIPMENT_END) {// on Titanium and ROF2 /showhelm works even if sending helm slot
 		SendWearChange(matslot);
 	}
 

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -2224,7 +2224,7 @@ bool Client::SwapItem(MoveItem_Struct* move_in) {
 	}
 
 	int matslot = SlotConvert2(dst_slot_id);
-	if (dst_slot_id <= EQ::invslot::EQUIPMENT_END && matslot != EQ::textures::armorHead) { // think this is to allow the client to update with /showhelm
+	if (dst_slot_id <= EQ::invslot::EQUIPMENT_END) {
 		SendWearChange(matslot);
 	}
 

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -2229,7 +2229,7 @@ bool Client::SwapItem(MoveItem_Struct* move_in) {
 	}
 	// This is part of a bug fix to ensure heroforge graphics display to other clients in zone.
 	if (queue_wearchange_slot >= 0) {
-		heroforge_wearchange_timer.Start(100);//TOO HACKY BUT WORKS
+		heroforge_wearchange_timer.Start(100);
 	}
 
 	// Step 7: Save change to the database

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -2227,7 +2227,7 @@ bool Client::SwapItem(MoveItem_Struct* move_in) {
 	if (dst_slot_id <= EQ::invslot::EQUIPMENT_END) {// on Titanium and ROF2 /showhelm works even if sending helm slot
 		SendWearChange(matslot);
 	}
-	if (matslot == 0) {
+	if (que_wearchange_slot >= 0) {
 		on_connect_complete_delay_timer.Start(250);//TOO HACKY BUT WORKS
 	}
 

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -2227,8 +2227,9 @@ bool Client::SwapItem(MoveItem_Struct* move_in) {
 	if (dst_slot_id <= EQ::invslot::EQUIPMENT_END) {// on Titanium and ROF2 /showhelm works even if sending helm slot
 		SendWearChange(matslot);
 	}
+	// This is part of a bug fix to ensure heroforge graphics display to other clients in zone.
 	if (que_wearchange_slot >= 0) {
-		on_connect_complete_delay_timer.Start(250);//TOO HACKY BUT WORKS
+		on_connect_complete_delay_timer.Start(100);//TOO HACKY BUT WORKS
 	}
 
 	// Step 7: Save change to the database

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -495,6 +495,8 @@ Mob::Mob(
 	use_double_melee_round_dmg_bonus = false;
 	dw_same_delay = 0;
 
+	que_wearchange_slot = -1;
+
 #ifdef BOTS
 	m_manual_follow = false;
 #endif

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -3168,6 +3168,16 @@ bool Mob::UpdateActiveLight()
 	return (m_Light.Level[EQ::lightsource::LightActive] != old_light_level);
 }
 
+void Mob::SendWearChangeAndLighting(int8 last_texture) {
+
+	for (int i = EQ::textures::textureBegin; i <= last_texture; i++) {
+		SendWearChange(i);
+	}
+	UpdateActiveLight();
+	SendAppearancePacket(AT_Light, GetActiveLightType());
+
+}
+
 void Mob::ChangeSize(float in_size = 0, bool bNoRestriction) {
 	// Size Code
 	if (!bNoRestriction)

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -495,7 +495,7 @@ Mob::Mob(
 	use_double_melee_round_dmg_bonus = false;
 	dw_same_delay = 0;
 
-	que_wearchange_slot = -1;
+	queue_wearchange_slot = -1;
 
 #ifdef BOTS
 	m_manual_follow = false;

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1515,6 +1515,8 @@ protected:
 
 	int32 appearance_effects_id[MAX_APPEARANCE_EFFECTS];
 	int32 appearance_effects_slot[MAX_APPEARANCE_EFFECTS];
+	
+	int que_wearchange_slot;
 
 	Timer shield_timer;
 	uint32 m_shield_target_id;

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -910,6 +910,7 @@ public:
 	virtual void UpdateEquipmentLight() { m_Light.Type[EQ::lightsource::LightEquipment] = 0; m_Light.Level[EQ::lightsource::LightEquipment] = 0; }
 	inline void SetSpellLightType(uint8 light_type) { m_Light.Type[EQ::lightsource::LightSpell] = (light_type & 0x0F); m_Light.Level[EQ::lightsource::LightSpell] = EQ::lightsource::TypeToLevel(m_Light.Type[EQ::lightsource::LightSpell]); }
 
+	void SendWearChangeAndLighting(int8 last_texture);
 	inline uint8 GetActiveLightType() { return m_Light.Type[EQ::lightsource::LightActive]; }
 	bool UpdateActiveLight(); // returns true if change, false if no change
 

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1516,7 +1516,7 @@ protected:
 	int32 appearance_effects_id[MAX_APPEARANCE_EFFECTS];
 	int32 appearance_effects_slot[MAX_APPEARANCE_EFFECTS];
 	
-	int que_wearchange_slot;
+	int queue_wearchange_slot;
 
 	Timer shield_timer;
 	uint32 m_shield_target_id;

--- a/zone/mob_appearance.cpp
+++ b/zone/mob_appearance.cpp
@@ -433,13 +433,8 @@ void Mob::SendWearChange(uint8 material_slot, Client *one_client)
 
 	wear_change->wear_slot_id = material_slot;
 
-	if (wear_change->hero_forge_model) {
-		que_wearchange_slot = material_slot;
-	}
-	else {
-		que_wearchange_slot = - 1;
-	}
-	Shout("que wearchange slot %i HF %i", que_wearchange_slot, wear_change->hero_forge_model);
+	// Part of a bug fix to ensure heroforge models send to other clients in zone.
+	queue_wearchange_slot = wear_change->hero_forge_model ? material_slot : -1;
 
 	if (!one_client) {
 		entity_list.QueueClients(this, packet);

--- a/zone/mob_appearance.cpp
+++ b/zone/mob_appearance.cpp
@@ -433,6 +433,14 @@ void Mob::SendWearChange(uint8 material_slot, Client *one_client)
 
 	wear_change->wear_slot_id = material_slot;
 
+	if (wear_change->hero_forge_model) {
+		que_wearchange_slot = material_slot;
+	}
+	else {
+		que_wearchange_slot = - 1;
+	}
+	Shout("que wearchange slot %i HF %i", que_wearchange_slot, wear_change->hero_forge_model);
+
 	if (!one_client) {
 		entity_list.QueueClients(this, packet);
 	}


### PR DESCRIPTION
This update provides fixes to a couple of issues regarding Hero Forge Armor not displaying to other clients in zone under certain conditions. 

1- Resolved Issue: When a client wearing the hero forge armor zones into a new zone, other clients in that zone could not see hero forge armor on that client.

2- Resolved Issue: When a client wearing hero forge armor in the helmet removed the helmet, the hero forge graphic would not be reapplied if the item was equipped, until the client zoned. (For some reason we were excluding helmets from wear change, I can see no real reason why, I verified on both titanium AND ROF2 that it has no impact on clients show helm option.)

3- Resolved Issue: When a client wearing hero forge armor removes the item and then re-equipped it in zone, for helmet slot it would not show the hero forge graphic to other clients consistently (even after fixing issue 2), also have reports of other slots having same problem.

For issues 1 and 3, I am not completely certain why the packet is not being received by other clients in zone. I tried many different ways to fix it without luck. But what did work is sending it on slight delay which resolves the problem completely. Might not be the ideal fix, but it is a fix.
