### PR TITLE
[Spells] Update SPA 238 SE_IllusionPersistence allow illusions to persist through deaths at higher AA ranks.

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -1454,7 +1454,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 		}
 
 		case SE_IllusionPersistence:
-			newbon->IllusionPersistence = true;
+			newbon->IllusionPersistence = base_value;
 			break;
 
 		case SE_LimitToSkill: {
@@ -3529,7 +3529,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 			}
 
 			case SE_IllusionPersistence:
-				new_bonus->IllusionPersistence = true;
+				new_bonus->IllusionPersistence = effect_value;
 				break;
 
 			case SE_LimitToSkill:{
@@ -5410,9 +5410,9 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 					break;
 
 				case SE_IllusionPersistence:
-					if (negate_spellbonus) { spellbonuses.IllusionPersistence = false; }
-					if (negate_itembonus) { itembonuses.IllusionPersistence = false; }
-					if (negate_aabonus) { aabonuses.IllusionPersistence = false; }
+					if (negate_spellbonus) { spellbonuses.IllusionPersistence = effect_value; }
+					if (negate_itembonus) { itembonuses.IllusionPersistence = effect_value; }
+					if (negate_aabonus) { aabonuses.IllusionPersistence = effect_value; }
 					break;
 
 				case SE_Attack_Accuracy_Max_Percent:

--- a/zone/common.h
+++ b/zone/common.h
@@ -617,7 +617,7 @@ struct StatBonuses {
 	uint32	Assassinate[2];						// Assassinate AA (Massive dmg vs humaniod w/ assassinate) 0= ? 1= Dmg
 	uint8	AssassinateLevel[2];				// Max Level Assassinate will be effective at.
 	int32	PetMeleeMitigation;					// Add AC to owner's pet.
-	bool	IllusionPersistence;				// Causes illusions not to fade.
+	int		IllusionPersistence;				// 1=Causes illusions not to fade when zoning 2=Allow to persist after death.
 	uint16	extra_xtargets;						// extra xtarget entries
 	bool	ShroudofStealth;					// rogue improved invisiblity
 	uint16  ReduceFallDamage;					// reduce fall damage by percent

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -861,6 +861,7 @@ public:
 	inline bool HasBaseEffectFocus() const { return (spellbonuses.FocusEffects[focusFcBaseEffects] || aabonuses.FocusEffects[focusFcBaseEffects] || itembonuses.FocusEffects[focusFcBaseEffects]); }
 	int32 GetDualWieldingSameDelayWeapons() const { return dw_same_delay; }
 	inline void SetDualWieldingSameDelayWeapons(int32 val) { dw_same_delay = val; }
+	bool HasPersistDeathIllusion(int32 spell_id);
 
 	bool TryDoubleMeleeRoundEffect();
 	bool GetUseDoubleMeleeRoundDmgBonus() const { return use_double_melee_round_dmg_bonus; }

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -8938,3 +8938,13 @@ void Mob::ApplySpellEffectIllusion(int32 spell_id, Mob *caster, int buffslot, in
 		buffs[buffslot].persistant_buff = 0;
 	}
 }
+
+bool Mob::HasPersistDeathIllusion(int32 spell_id) {
+
+	if (spellbonuses.IllusionPersistence > 1 || aabonuses.IllusionPersistence > 1  || itembonuses.IllusionPersistence > 1) {
+		if (spell_id != SPELL_MINOR_ILLUSION && spell_id != SPELL_ILLUSION_TREE && IsEffectInSpell(spell_id, SE_Illusion) && IsBeneficialSpell(spell_id)) {
+			return true;
+		}
+	}
+	return false;
+}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -2929,9 +2929,10 @@ int Mob::CalcBuffDuration(Mob *caster, Mob *target, uint16 spell_id, int32 caste
 
 	int res = CalcBuffDuration_formula(castlevel, formula, duration);
 	if (caster == target && (target->aabonuses.IllusionPersistence || target->spellbonuses.IllusionPersistence ||
-				 target->itembonuses.IllusionPersistence) &&
-	    spell_id != SPELL_MINOR_ILLUSION && spell_id != SPELL_ILLUSION_TREE && IsEffectInSpell(spell_id, SE_Illusion))
+		target->itembonuses.IllusionPersistence) &&
+		spell_id != SPELL_MINOR_ILLUSION && spell_id != SPELL_ILLUSION_TREE && IsEffectInSpell(spell_id, SE_Illusion)) {
 		res = 10000; // ~16h override
+	}
 
 
 	res = mod_buff_duration(res, caster, target, spell_id);
@@ -4373,7 +4374,8 @@ void Mob::BuffFadeNonPersistDeath()
 		auto current_spell_id = buffs[buff_slot].spellid;
 		if (
 			IsValidSpell(current_spell_id) &&
-			!IsPersistDeathSpell(current_spell_id)
+			!IsPersistDeathSpell(current_spell_id) &&
+			!HasPersistDeathIllusion(current_spell_id)
 		) {
 			BuffFadeBySlot(buff_slot, false);
 			recalc_bonus = true;


### PR DESCRIPTION
Update to SPA 238 SE_IllusionPersistence to allow at higher rank to persist through death. Newer AA's on live have this feature.

Baseline AA ability allows illusions to persist through zones. Set base value to 2 to gain persist through death attribute.