### PR TITLE
[Spells] Minor update to SPA 502 Fearstuns max calculation.

### DIFF
--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -2883,8 +2883,15 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					caster->MessageString(Chat::SpellFailure, IMMUNE_FEAR);
 					break;
 				}
+				int max_level = 0;
+				if (spells[spell_id].max_value[i] >= 1000) {
+					max_level = spells[spell_id].max_value[i] - 1000;
+				}
+				else {
+					max_level = caster->GetLevel() + spells[spell_id].max_value[i];
+				}
 
-				if (spells[spell_id].max_value[i] == 0 || GetLevel() <= spells[spell_id].max_value[i]) {
+				if (spells[spell_id].max_value[i] == 0 || GetLevel() <= max_level) {
 					if (IsClient() && spells[spell_id].limit_value[i])
 						Stun(spells[spell_id].limit_value[i]);
 					else


### PR DESCRIPTION
Max level calculation updated to match lives.
max_value determines max level of target to be affected.
If max_value > 1000, formula is value - 1000 = max level. Example 1080 = max level of 80
If max_value < 1000 formula is value = casters level + value = max level of target, if 3, then target must be no more than 3 levels higher.