### PR TITLE
[Spells] Rework of SPA 288 SE_SkillAttackProc

### DIFF
--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1005,7 +1005,7 @@ typedef enum {
 #define SE_NimbleEvasion				285	// *not implemented - base1 = 100 for max
 #define SE_FcDamageAmt					286	// implemented, @Fc, On Caster, spell damage mod flat amt, base: amt
 #define SE_SpellDurationIncByTic		287 // implemented, @Fc, SPA: 287, SE_SpellDurationIncByTic,			On Caster, spell buff duration mod, base: tics
-#define SE_SkillAttackProc				288	// implemented[AA] - Chance to proc spell on skill attack usage (ex. Dragon Punch)
+#define SE_SkillAttackProc				288	// implemented, @Procs, chance to cast a spell when using a skill, base: chance, limit: skill, max: spellid, note: if used in AA the spell id is set in aa_ranks spell field, chance is calculated as 100% = value 1000.
 #define SE_CastOnFadeEffect				289 // implemented - Triggers only if fades after natural duration.
 #define SE_IncreaseRunSpeedCap			290	// implemented[AA] - increases run speed over the hard cap
 #define SE_Purify						291 // implemented, @Dispel, remove up specified amount of detiremental spells, base: amt removed, limit: none, max: none, Note: excluding charm, fear, resurrection, and revival sickness

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -189,6 +189,7 @@
 #define MAX_FOCUS_PROC_LIMIT_TIMERS 20 //Number of focus recast timers that can be going at same time (This is arbitrary)
 #define MAX_PROC_LIMIT_TIMERS 8 //Number of proc delay timers that can be going at same time, different proc types get their own timer array. (This is arbitrary)
 #define MAX_APPEARANCE_EFFECTS 20 //Up to 20 Appearance Effects can be saved to a mobs appearance effect array, these will be sent to other clients when they enter a zone (This is arbitrary)
+#define MAX_CAST_ON_SKILL_USE 36; //Actual amount is MAX/3
 
 
 const int Z_AGGRO=10;

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -677,7 +677,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			newbon->FocusEffects[focus] = static_cast<uint8>(effect);
 			continue;
 		}
-
+		Shout("Effect %i RANK ID %i", effect, rank.id);
 		switch (effect) {
 		case SE_ACv2:
 		case SE_ArmorClass:
@@ -1070,6 +1070,18 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 				}
 			}
 			break;
+		/*
+		SE_SkillAttackProc: {
+			for (int i = 0; i < MAX_CAST_ON_SKILL_USE; i += 3) {
+				if (!newbon->SkillAttackProc[i]) {
+					newbon->SkillAttackProc[i] = rank.id;   //aa rank id
+					newbon->SpellProc[i + 1] = base_value;	//proc spell id
+					newbon->SpellProc[i + 2] = limit_value; //proc rate modifer
+					break;
+				}
+			}
+		}
+		*/
 
 		case SE_WeaponProc:
 		case SE_AddMeleeProc:

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -677,7 +677,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			newbon->FocusEffects[focus] = effect;
 			continue;
 		}
-		Shout("Effect %i RANK ID %i", effect, rank.id);
+
 		switch (effect) {
 		case SE_ACv2:
 		case SE_ArmorClass:
@@ -1070,18 +1070,6 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 				}
 			}
 			break;
-		/*
-		SE_SkillAttackProc: {
-			for (int i = 0; i < MAX_CAST_ON_SKILL_USE; i += 3) {
-				if (!newbon->SkillAttackProc[i]) {
-					newbon->SkillAttackProc[i] = rank.id;   //aa rank id
-					newbon->SpellProc[i + 1] = base_value;	//proc spell id
-					newbon->SpellProc[i + 2] = limit_value; //proc rate modifer
-					break;
-				}
-			}
-		}
-		*/
 
 		case SE_WeaponProc:
 		case SE_AddMeleeProc:
@@ -1219,11 +1207,18 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 		}
 
 		case SE_SkillAttackProc: {
-			// You can only have one of these per client. [AA Dragon Punch]
-			newbon->SkillAttackProc[SBIndex::SKILLATK_PROC_CHANCE]   = base_value; // Chance base 1000 = 100% proc rate
-			newbon->SkillAttackProc[SBIndex::SKILLATK_PROC_SKILL]    = limit_value; // Skill to Proc Off
-			newbon->SkillAttackProc[SBIndex::SKILLATK_PROC_SPELL_ID] = rank.spell; // spell to proc
-			break;
+			for (int i = 0; i < MAX_CAST_ON_SKILL_USE i += 3) {
+				if (!newbon->SkillAttackProc[i + SBIndex::SKILLATK_PROC_SPELL_ID]) { // spell id
+					newbon->SkillAttackProc[i + SBIndex::SKILLATK_PROC_SPELL_ID] = rank.spell; // spell to proc
+					newbon->SkillAttackProc[i + SBIndex::SKILLATK_PROC_CHANCE] = base_value; // Chance base 1000 = 100% proc rate
+					newbon->SkillAttackProc[i + SBIndex::SKILLATK_PROC_SKILL] = limit_value; // Skill to Proc Offr
+					
+					if (limit_value < EQ::skills::HIGHEST_SKILL) {
+						newbon->HasSkillAttackProc[limit_value] = true; //check first before looking for any effects.
+					}
+					break;
+				}
+			}
 		}
 
 		case SE_DamageModifier: {
@@ -3588,6 +3583,21 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 					}
 				}
 				break;
+			}
+
+			case SE_SkillAttackProc: {
+				for (int i = 0; i < MAX_CAST_ON_SKILL_USE i += 3) { 
+					if (!new_bonus->SkillAttackProc[i + SBIndex::SKILLATK_PROC_SPELL_ID]) { // spell id
+						new_bonus->SkillAttackProc[i + SBIndex::SKILLATK_PROC_SPELL_ID] = max_value; // spell to proc
+						new_bonus->SkillAttackProc[i + SBIndex::SKILLATK_PROC_CHANCE] = effect_value; // Chance base 1000 = 100% proc rate
+						new_bonus->SkillAttackProc[i + SBIndex::SKILLATK_PROC_SKILL] = limit_value; // Skill to Proc Offr
+						
+						if (limit_value < EQ::skills::HIGHEST_SKILL) {
+							new_bonus->HasSkillAttackProc[limit_value] = true; //check first before looking for any effects.
+						}
+						break;
+					}
+				}
 			}
 
 			case SE_PC_Pet_Rampage: {

--- a/zone/common.h
+++ b/zone/common.h
@@ -572,6 +572,7 @@ struct StatBonuses {
 	uint8	IncreaseRunSpeedCap;				// Increase max run speed above cap.
 	int32	DoubleSpecialAttack;				// Chance to to perform a double special attack (ie flying kick 2x)
 	int32	SkillAttackProc[3];					// [0] chance to proc [2] spell on [1] skill usage
+	bool	HasSkillAttackProc[EQ::skills::HIGHEST_SKILL + 1]; //check if any skill proc is present before assessing for all skill procs
 	uint8	FrontalStunResist;					// Chance to resist a frontal stun
 	int32	BindWound;							// Increase amount of HP by percent.
 	int32	MaxBindWound;						// Increase max amount of HP you can bind wound.
@@ -671,9 +672,9 @@ namespace SBIndex {
 	constexpr uint16 POSITION_FRONT							= 1; // SPA 503-506
 	constexpr uint16 PET_RAMPAGE_CHANCE                     = 0; // SPA 464,465
 	constexpr uint16 PET_RAMPAGE_DMG_MOD                    = 1; // SPA 465,465
-	constexpr uint16 SKILLATK_PROC_CHANCE                   = 0; // SPA 427
-	constexpr uint16 SKILLATK_PROC_SKILL                    = 1; // SPA 427
-	constexpr uint16 SKILLATK_PROC_SPELL_ID                 = 2; // SPA 427
+	constexpr uint16 SKILLATK_PROC_SPELL_ID                 = 0; // SPA 288
+	constexpr uint16 SKILLATK_PROC_CHANCE                   = 1; // SPA 288
+	constexpr uint16 SKILLATK_PROC_SKILL                    = 2; // SPA 288
 	constexpr uint16 SLAYUNDEAD_RATE_MOD                    = 0; // SPA 219
 	constexpr uint16 SLAYUNDEAD_DMG_MOD                     = 1; // SPA 219
 	constexpr uint16 DOUBLE_RIPOSTE_CHANCE                  = 0; // SPA 223
@@ -692,7 +693,7 @@ namespace SBIndex {
 	constexpr uint16 COMBAT_PROC_ORIGIN_ID                  = 0; // SPA 
 	constexpr uint16 COMBAT_PROC_SPELL_ID                   = 1; // SPA 
 	constexpr uint16 COMBAT_PROC_RATE_MOD                   = 2; // SPA 
-	constexpr uint16 COMBAT_PROC_REUSE_TIMER              = 3; // SPA 
+	constexpr uint16 COMBAT_PROC_REUSE_TIMER                = 3; // SPA 
 };
 
 

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -4242,6 +4242,8 @@ void Mob::TriggerDefensiveProcs(Mob *on, uint16 hand, bool FromSkillProc, int da
 			break;
 		}
 
+		TryCastOnSkillUse(on, skillinuse);
+
 		if (on->HasSkillProcs()) {
 			on->TrySkillProc(this, skillinuse, 0, false, hand, true);
 		}

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1447,9 +1447,10 @@ protected:
 	bool spawned;
 	void CalcSpellBonuses(StatBonuses* newbon);
 	virtual void CalcBonuses();
-	void TrySkillProc(Mob *on, EQ::skills::SkillType skill, uint16 ReuseTime, bool Success = false, uint16 hand = 0, bool IsDefensive = false); // hand = SlotCharm?
+	void TrySkillProc(Mob *on, EQ::skills::SkillType skill, uint16 ReuseTime, bool Success = false, uint16 hand = 0, bool IsDefensive = false); // hand if 0 means its a skill ability for proc rate checks, otherwise hand is passed.
 	bool PassLimitToSkill(EQ::skills::SkillType skill, int32 spell_id, int proc_type, int aa_id=0);
 	bool PassLimitClass(uint32 Classes_, uint16 Class_);
+	void TryCastOnSkillUse(Mob *on, EQ::skills::SkillType skill);
 	void TryDefensiveProc(Mob *on, uint16 hand = EQ::invslot::slotPrimary);
 	void TryWeaponProc(const EQ::ItemInstance* inst, const EQ::ItemData* weapon, Mob *on, uint16 hand = EQ::invslot::slotPrimary);
 	void TrySpellProc(const EQ::ItemInstance* inst, const EQ::ItemData* weapon, Mob *on, uint16 hand = EQ::invslot::slotPrimary);

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -196,14 +196,6 @@ void Mob::DoSpecialAttackDamage(Mob *who, EQ::skills::SkillType skill, int32 bas
 	DoAttack(who, my_hit);
 
 	who->AddToHateList(this, hate, 0);
-	if (my_hit.damage_done > 0 && aabonuses.SkillAttackProc[SBIndex::SKILLATK_PROC_CHANCE] && aabonuses.SkillAttackProc[SBIndex::SKILLATK_PROC_SKILL] == skill &&
-		IsValidSpell(aabonuses.SkillAttackProc[SBIndex::SKILLATK_PROC_SPELL_ID])) {
-		float chance = aabonuses.SkillAttackProc[SBIndex::SKILLATK_PROC_CHANCE] / 1000.0f;
-		if (zone->random.Roll(chance))
-			SpellFinished(aabonuses.SkillAttackProc[SBIndex::SKILLATK_PROC_SPELL_ID], who, EQ::spells::CastingSlot::Item, 0, -1,
-						  spells[aabonuses.SkillAttackProc[SBIndex::SKILLATK_PROC_SPELL_ID]].resist_difficulty);
-	}
-
 	who->Damage(this, my_hit.damage_done, SPELL_UNKNOWN, skill, false);
 
 	// Make sure 'this' has not killed the target and 'this' is not dead (Damage shield ect).
@@ -211,6 +203,8 @@ void Mob::DoSpecialAttackDamage(Mob *who, EQ::skills::SkillType skill, int32 bas
 		return;
 	if (HasDied())
 		return;
+
+	TryCastOnSkillUse(who, skill);
 
 	if (HasSkillProcs()) {
 		TrySkillProc(who, skill, ReuseTime * 1000);
@@ -916,6 +910,8 @@ void Mob::DoArcheryAttackDmg(Mob *other, const EQ::ItemInstance *RangeWeapon, co
 		TryWeaponProc(Ammo, Ammo->GetItem(), other, EQ::invslot::slotRange);
 	}
 
+	TryCastOnSkillUse(other, EQ::skills::SkillArchery);
+
 	// Skill Proc Attempt
 	if (HasSkillProcs() && other && !other->HasDied()) {
 		if (ReuseTime) {
@@ -1278,6 +1274,8 @@ void NPC::DoRangedAttackDmg(Mob* other, bool Launch, int16 damage_mod, int16 cha
 	if (other && !other->HasDied()) {
 		TrySpellProc(nullptr, (const EQ::ItemData*)nullptr, other, EQ::invslot::slotRange);
 	}
+
+	TryCastOnSkillUse(other, skillInUse);
 
 	if (HasSkillProcs() && other && !other->HasDied()) {
 		TrySkillProc(other, skillInUse, 0, false, EQ::invslot::slotRange);
@@ -2046,6 +2044,8 @@ void Mob::Taunt(NPC *who, bool always_succeed, int chance_bonus, bool FromSpell,
 		MessageString(Chat::SpellFailure, FAILED_TAUNT);
 	}
 
+	TryCastOnSkillUse(who, EQ::skills::SkillTaunt);
+
 	if (HasSkillProcs()) {
 		TrySkillProc(who, EQ::skills::SkillTaunt, TauntReuseTime * 1000);
 	}
@@ -2100,6 +2100,8 @@ void Mob::InstillDoubt(Mob *who) {
 			entity_list.AEAttack(target, 50);
 		}*/
 	}
+
+	TryCastOnSkillUse(who, EQ::skills::SkillIntimidation);
 
 	if (HasSkillProcs()) {
 		TrySkillProc(who, EQ::skills::SkillIntimidation, InstillDoubtReuseTime * 1000);
@@ -2253,18 +2255,12 @@ void Mob::DoMeleeSkillAttackDmg(Mob *other, uint16 weapon_damage, EQ::skills::Sk
 	}
 
 	other->AddToHateList(this, hate, 0);
-	if (damage > 0 && aabonuses.SkillAttackProc[SBIndex::SKILLATK_PROC_CHANCE] && aabonuses.SkillAttackProc[SBIndex::SKILLATK_PROC_SKILL] == skillinuse &&
-		IsValidSpell(aabonuses.SkillAttackProc[SBIndex::SKILLATK_PROC_SPELL_ID])) {
-		float chance = aabonuses.SkillAttackProc[SBIndex::SKILLATK_PROC_CHANCE] / 1000.0f;
-		if (zone->random.Roll(chance))
-			SpellFinished(aabonuses.SkillAttackProc[SBIndex::SKILLATK_PROC_SPELL_ID], other, EQ::spells::CastingSlot::Item, 0, -1,
-						  spells[aabonuses.SkillAttackProc[SBIndex::SKILLATK_PROC_SPELL_ID]].resist_difficulty);
-	}
-
 	other->Damage(this, damage, SPELL_UNKNOWN, skillinuse);
 
 	if (HasDied())
 		return;
+
+	TryCastOnSkillUse(other, skillinuse);
 
 	if (CanSkillProc && HasSkillProcs()) {
 		TrySkillProc(other, skillinuse, ReuseTime);


### PR DESCRIPTION
I originally had this implemented in a much narrower scope where you could have a max of one of this effect as an AA. Current live AA make use of this SPA multiple times in same AA, thus was time to recode this appropriately. Example of an effect that uses this is the monk Dragon Punch AA.

This update, 
-Adds support for up to 12 effects from AA. 
-Adds support also for this effect to place on items and spell buffs, up to 12 each.

SPA 288  SE_SkillAttackProc, chance to cast a spell when using a skill
base: chance (set 1000 for 100% chance)
limit: skill
max: spellid, (custom for emu, no live spells use this effect only AA)
note: if used in AA the spell id is set in aa_ranks table 'spell' field to the spellid (this is how the AA works).

Note, this differs from SPA 427 and 429 SkillProcs, in that the chance of firing is determined by a variable proc rate (based on weapon/skill delay). While this effect SPA 288 does a straight up percent chance roll every time.