### PR TITLE
[Doors] Ignore Doors that Have Non-Zero Trigger or Door Param

### DIFF
--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -1000,6 +1000,14 @@ void Mob::AI_Process() {
 					continue;
 				}
 
+				if (door->GetTriggerDoorID() > 0) {
+					continue;
+				}
+
+				if (door->GetDoorParam() > 0) {
+					continue;
+				}
+
 				float distance                = DistanceSquared(m_Position, door->GetPosition());
 				float distance_scan_door_open = 20;
 


### PR DESCRIPTION
For @noudess 

Additional context for readers.

When NPC's in Faydark are walking by the platform and platform triggers both the trigger and the platform would get triggered.

This would ignore cases mentioned above as NPC's should not be manipulating these types of doors on an automatic basis.

If NPC's need to manipulate these types of doors in pathing they can be handled via script.