### PR TITLE
[Spells] Implemented SPA 281 SE_PetFeignMinion

### DIFF
--- a/common/spdat.h
+++ b/common/spdat.h
@@ -26,6 +26,7 @@
 #define SPELLBOOK_UNKNOWN 0xFFFFFFFF		//player profile spells are 32 bit
 
 //some spell IDs which will prolly change, but are needed
+#define SPELL_LIFEBURN 2755
 #define SPELL_LEECH_TOUCH 2766
 #define SPELL_LAY_ON_HANDS 87
 #define SPELL_HARM_TOUCH 88

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -998,7 +998,7 @@ typedef enum {
 #define	SE_FinishingBlow				278 // implemented[AA] - chance to do massive damage under 10% HP (base1 = chance, base2 = damage)
 #define SE_Flurry						279	// implemented
 #define SE_PetFlurry					280 // implemented[AA]
-#define SE_FeignedMinion				281	// *not implemented[AA] ability allows you to instruct your pet to feign death via the '/pet feign' command. value = succeed chance
+#define SE_FeignedMinion				281	// implemented, ability allows you to instruct your pet to feign death via the '/pet feign' command, base: succeed chance, limit: none, max: none, Note: Only implemented as an AA.
 #define SE_ImprovedBindWound			282	// implemented[AA] - increase bind wound amount by percent.
 #define SE_DoubleSpecialAttack			283	// implemented[AA] - Chance to perform second special attack as monk
 //#define SE_LoHSetHeal					284	// not used

--- a/zone/aggro.cpp
+++ b/zone/aggro.cpp
@@ -1406,7 +1406,7 @@ void Mob::AddFeignMemory(Mob* attacker) {
 	if (feign_memory_list.empty() && AI_feign_remember_timer != nullptr) {
 		AI_feign_remember_timer->Start(AIfeignremember_delay);
 	}
-	Shout("Mob::AddFeignMemory INSERT INTO ARRAY: %i", attacker->GetID());
+
 	if (attacker) {
 		feign_memory_list.insert(attacker->GetID());
 	}
@@ -1417,8 +1417,6 @@ void Mob::RemoveFromFeignMemory(Mob* attacker) {
 	if (!attacker) {
 		return;
 	}
-
-	Shout("Mob::RemoveFromFeignMemory Remove from ARRAY: %i", attacker->GetID());
 
 	feign_memory_list.erase(attacker->GetID());
 	if (feign_memory_list.empty() && AI_feign_remember_timer != nullptr) {
@@ -1435,25 +1433,14 @@ void Mob::RemoveFromFeignMemory(Mob* attacker) {
 }
 
 void Mob::ClearFeignMemory() {
-	auto RememberedCharID = feign_memory_list.begin();
-	while (RememberedCharID != feign_memory_list.end())
+	auto remembered_feigned_mobid = feign_memory_list.begin();
+	while (remembered_feigned_mobid != feign_memory_list.end())
 	{
-		
-		Mob* remember_client = entity_list.GetMob(*RememberedCharID);
-		Shout("Mob::ClearFeignMemory TRy ID %i [%i]", RememberedCharID, remember_client->GetID());
-		if (remember_client) {
-			remember_client->Shout("ClearFeignMemory:: REMEMBER_CLIENT FOUND");
+		Mob* remembered_mob = entity_list.GetMob(*remembered_feigned_mobid);
+		if (remembered_mob->IsClient() && remembered_mob != nullptr) { //Still in zone
+			remembered_mob->CastToClient()->RemoveXTarget(this, false);
 		}
-		else {
-			Shout("ClearFeignMemory :: REMEMBER_CLIENT FAILED");
-		}
-
-
-		if (remember_client->IsClient() && remember_client != nullptr) { //Still in zone
-			Shout("Mob::ClearFeignMemory FIOUND ID %i REmove from X target", RememberedCharID);
-			remember_client->CastToClient()->RemoveXTarget(this, false);
-		}
-		++RememberedCharID;
+		++remembered_feigned_mobid;
 	}
 
 	feign_memory_list.clear();

--- a/zone/aggro.cpp
+++ b/zone/aggro.cpp
@@ -1406,10 +1406,20 @@ void Mob::AddFeignMemory(Mob* attacker) {
 	if (feign_memory_list.empty() && AI_feign_remember_timer != nullptr) {
 		AI_feign_remember_timer->Start(AIfeignremember_delay);
 	}
-	feign_memory_list.insert(attacker->GetID());
+	Shout("Mob::AddFeignMemory INSERT INTO ARRAY: %i", attacker->GetID());
+	if (attacker) {
+		feign_memory_list.insert(attacker->GetID());
+	}
 }
 
 void Mob::RemoveFromFeignMemory(Mob* attacker) {
+
+	if (!attacker) {
+		return;
+	}
+
+	Shout("Mob::RemoveFromFeignMemory Remove from ARRAY: %i", attacker->GetID());
+
 	feign_memory_list.erase(attacker->GetID());
 	if (feign_memory_list.empty() && AI_feign_remember_timer != nullptr) {
 		AI_feign_remember_timer->Disable();
@@ -1428,8 +1438,10 @@ void Mob::ClearFeignMemory() {
 	auto RememberedCharID = feign_memory_list.begin();
 	while (RememberedCharID != feign_memory_list.end())
 	{
+		Shout("Mob::ClearFeignMemory TRy ID %i", RememberedCharID);
 		Mob* remember_client = entity_list.GetMob(*RememberedCharID);
 		if (remember_client->IsClient() && remember_client != nullptr) { //Still in zone
+			Shout("Mob::ClearFeignMemory FIOUND ID %i REmove from X target", RememberedCharID);
 			remember_client->CastToClient()->RemoveXTarget(this, false);
 		}
 		++RememberedCharID;
@@ -1445,6 +1457,10 @@ void Mob::ClearFeignMemory() {
 
 bool Mob::IsOnFeignMemory(Mob *attacker) const
 {
+	if (!attacker) {
+		return 0;
+	}
+
 	return feign_memory_list.find(attacker->GetID()) != feign_memory_list.end();
 }
 

--- a/zone/aggro.cpp
+++ b/zone/aggro.cpp
@@ -1438,8 +1438,17 @@ void Mob::ClearFeignMemory() {
 	auto RememberedCharID = feign_memory_list.begin();
 	while (RememberedCharID != feign_memory_list.end())
 	{
-		Shout("Mob::ClearFeignMemory TRy ID %i", RememberedCharID);
+		
 		Mob* remember_client = entity_list.GetMob(*RememberedCharID);
+		Shout("Mob::ClearFeignMemory TRy ID %i [%i]", RememberedCharID, remember_client->GetID());
+		if (remember_client) {
+			remember_client->Shout("ClearFeignMemory:: REMEMBER_CLIENT FOUND");
+		}
+		else {
+			Shout("ClearFeignMemory :: REMEMBER_CLIENT FAILED");
+		}
+
+
 		if (remember_client->IsClient() && remember_client != nullptr) { //Still in zone
 			Shout("Mob::ClearFeignMemory FIOUND ID %i REmove from X target", RememberedCharID);
 			remember_client->CastToClient()->RemoveXTarget(this, false);

--- a/zone/aggro.cpp
+++ b/zone/aggro.cpp
@@ -1402,22 +1402,25 @@ int32 Mob::CheckHealAggroAmount(uint16 spell_id, Mob *target, uint32 heal_possib
 	return std::max(0, AggroAmount);
 }
 
-void Mob::AddFeignMemory(Client* attacker) {
-	if(feign_memory_list.empty() && AI_feign_remember_timer != nullptr)
+void Mob::AddFeignMemory(Mob* attacker) {
+	if (feign_memory_list.empty() && AI_feign_remember_timer != nullptr) {
 		AI_feign_remember_timer->Start(AIfeignremember_delay);
-	feign_memory_list.insert(attacker->CharacterID());
+	}
+	feign_memory_list.insert(attacker->GetID());
 }
 
-void Mob::RemoveFromFeignMemory(Client* attacker) {
-	feign_memory_list.erase(attacker->CharacterID());
-	if(feign_memory_list.empty() && AI_feign_remember_timer != nullptr)
+void Mob::RemoveFromFeignMemory(Mob* attacker) {
+	feign_memory_list.erase(attacker->GetID());
+	if (feign_memory_list.empty() && AI_feign_remember_timer != nullptr) {
 		AI_feign_remember_timer->Disable();
+	}
 	if(feign_memory_list.empty())
 	{
 		minLastFightingDelayMoving = RuleI(NPC, LastFightingDelayMovingMin);
 		maxLastFightingDelayMoving = RuleI(NPC, LastFightingDelayMovingMax);
-		if(AI_feign_remember_timer != nullptr)
+		if (AI_feign_remember_timer != nullptr) {
 			AI_feign_remember_timer->Disable();
+		}
 	}
 }
 
@@ -1425,22 +1428,24 @@ void Mob::ClearFeignMemory() {
 	auto RememberedCharID = feign_memory_list.begin();
 	while (RememberedCharID != feign_memory_list.end())
 	{
-		Client* remember_client = entity_list.GetClientByCharID(*RememberedCharID);
-		if(remember_client != nullptr) //Still in zone
-			remember_client->RemoveXTarget(this, false);
+		Mob* remember_client = entity_list.GetMob(*RememberedCharID);
+		if (remember_client->IsClient() && remember_client != nullptr) { //Still in zone
+			remember_client->CastToClient()->RemoveXTarget(this, false);
+		}
 		++RememberedCharID;
 	}
 
 	feign_memory_list.clear();
 	minLastFightingDelayMoving = RuleI(NPC, LastFightingDelayMovingMin);
 	maxLastFightingDelayMoving = RuleI(NPC, LastFightingDelayMovingMax);
-	if(AI_feign_remember_timer != nullptr)
+	if (AI_feign_remember_timer != nullptr) {
 		AI_feign_remember_timer->Disable();
+	}
 }
 
-bool Mob::IsOnFeignMemory(Client *attacker) const
+bool Mob::IsOnFeignMemory(Mob *attacker) const
 {
-	return feign_memory_list.find(attacker->CharacterID()) != feign_memory_list.end();
+	return feign_memory_list.find(attacker->GetID()) != feign_memory_list.end();
 }
 
 bool Mob::PassCharismaCheck(Mob* caster, uint16 spell_id) {

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2812,7 +2812,7 @@ void Mob::AddToHateList(Mob* other, uint32 hate /*= 0*/, int32 damage /*= 0*/, b
 
 	hate_list.AddEntToHateList(other, hate, damage, bFrenzy, !iBuffTic);
 
-	if (other->IsClient() && !on_hatelist && !IsOnFeignMemory(other->CastToClient()))
+	if (other->IsClient() && !on_hatelist && !IsOnFeignMemory(other))
 		other->CastToClient()->AddAutoXTarget(this);
 
 #ifdef BOTS

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -1564,8 +1564,10 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 
 		case SE_FeignedMinion:
-			if (newbon->FeignedMinionChance < base_value)
+			if (newbon->FeignedMinionChance < base_value) {
 				newbon->FeignedMinionChance = base_value;
+			}
+			newbon->PetCommands[PET_FEIGN] = true;
 			break;
 
 		case SE_AdditionalAura:

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -145,7 +145,6 @@ Client::Client(EQStreamInterface* ieqs)
   global_channel_timer(1000),
   fishing_timer(8000),
   endupkeep_timer(1000),
-  forget_timer(0),
   autosave_timer(RuleI(Character, AutosaveIntervalS) * 1000),
   client_scan_npc_aggro_timer(RuleI(Aggro, ClientAggroCheckIdleInterval)),
   client_zone_wide_full_position_update_timer(5 * 60 * 1000),
@@ -185,7 +184,6 @@ Client::Client(EQStreamInterface* ieqs)
 	character_id = 0;
 	conn_state = NoPacketsReceived;
 	client_data_loaded = false;
-	feigned = false;
 	berserk = false;
 	dead = false;
 	eqs = ieqs;
@@ -2675,22 +2673,6 @@ void Client::MemorizeSpell(uint32 slot,uint32 spellid,uint32 scribing, uint32 re
 	QueuePacket(outapp);
 	safe_delete(outapp);
 }
-
-void Client::SetFeigned(bool in_feigned) {
-	if (in_feigned)
-	{
-		if(RuleB(Character, FeignKillsPet))
-		{
-			SetPet(0);
-		}
-		SetHorseId(0);
-		entity_list.ClearFeignAggro(this);
-		forget_timer.Start(FeignMemoryDuration);
-	} else {
-		forget_timer.Disable();
-	}
-	feigned=in_feigned;
- }
 
 void Client::LogMerchant(Client* player, Mob* merchant, uint32 quantity, uint32 price, const EQ::ItemData* item, bool buying)
 {

--- a/zone/client.h
+++ b/zone/client.h
@@ -830,9 +830,6 @@ public:
 	inline uint8 GetBecomeNPCLevel() const { return npclevel; }
 	inline void SetBecomeNPC(bool flag) { npcflag = flag; }
 	inline void SetBecomeNPCLevel(uint8 level) { npclevel = level; }
-	void SetFeigned(bool in_feigned);
-	/// this cures timing issues cuz dead animation isn't done but server side feigning is?
-	inline bool GetFeigned() const { return(feigned); }
 	EQStreamInterface* Connection() { return eqs; }
 #ifdef PACKET_PROFILER
 	void DumpPacketProfile() { if(eqs) eqs->DumpPacketProfile(); }
@@ -1844,7 +1841,6 @@ private:
 	Timer global_channel_timer;
 	Timer fishing_timer;
 	Timer endupkeep_timer;
-	Timer forget_timer; // our 2 min everybody forgets you timer
 	Timer autosave_timer;
 	Timer client_scan_npc_aggro_timer;
 	Timer client_zone_wide_full_position_update_timer;
@@ -1883,7 +1879,6 @@ private:
 
 	bool npcflag;
 	uint8 npclevel;
-	bool feigned;
 	bool bZoning;
 	bool tgb;
 	bool instalog;

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -10695,22 +10695,20 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 	}
 
 	case PET_FEIGN: {
-		Shout("Found FD command do I have command %i", aabonuses.PetCommands[PetCommand]);
 		if (aabonuses.PetCommands[PetCommand] && mypet->IsNPC()) {
 			if (mypet->IsFeared())
 				break;
 
 			int pet_fd_chance = aabonuses.FeignedMinionChance;
-			Shout("Get Chance %i", pet_fd_chance);
-			pet_fd_chance = 100;
 			if (zone->random.Int(0, 99) > pet_fd_chance) {
 				mypet->SetFeigned(false);
 				entity_list.MessageCloseString(this, false, 200, 10, STRING_FEIGNFAILED, mypet->GetCleanName());
 			}
 			else {
+				bool immune_aggro = GetSpecialAbility(IMMUNE_AGGRO);
 				mypet->SetSpecialAbility(IMMUNE_AGGRO, 1);
 				mypet->WipeHateList();
-				mypet->SetPetOrder(SPO_Sit);
+				mypet->SetPetOrder(SPO_FeignDeath);
 				mypet->SetRunAnimSpeed(0);
 				mypet->StopNavigation();
 				mypet->SendAppearancePacket(AT_Anim, ANIM_DEATH);
@@ -10719,9 +10717,11 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 				if (!mypet->UseBardSpellLogic()) {
 					mypet->InterruptSpell();
 				}
-				mypet->SetSpecialAbility(IMMUNE_AGGRO, 0);
+
+				if (!immune_aggro) {
+					mypet->SetSpecialAbility(IMMUNE_AGGRO, 0);
+				}
 			}
-			mypet->Shout("Try FD comlpeted");
 		}
 		break;
 	}

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -10695,23 +10695,22 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			Shout("Get Chance %i", pet_fd_chance);
 			pet_fd_chance = 100;
 			if (zone->random.Int(0, 99) > pet_fd_chance) {
-				SetFeigned(false);
+				mypet->SetFeigned(false);
 				entity_list.MessageCloseString(this, false, 200, 10, STRING_FEIGNFAILED, mypet->GetCleanName());
 			}
 			else {
-				SetSpecialAbility(IMMUNE_AGGRO, 1);
+				mypet->SetSpecialAbility(IMMUNE_AGGRO, 1);
 				mypet->WipeHateList();
 				mypet->SetPetOrder(SPO_Sit);
 				mypet->SetRunAnimSpeed(0);
-				//mypet->CastToNPC()->SaveGuardSpot(mypet->GetPosition());
 				mypet->StopNavigation();
 				mypet->SendAppearancePacket(AT_Anim, ANIM_DEATH);
-				SetFeigned(true);
+				mypet->SetFeigned(true);
 				mypet->SetTarget(nullptr);
 				if (!mypet->UseBardSpellLogic()) {
 					mypet->InterruptSpell();
 				}
-				SetSpecialAbility(IMMUNE_AGGRO, 0);
+				mypet->SetSpecialAbility(IMMUNE_AGGRO, 0);
 			}
 			mypet->Shout("Try FD comlpeted");
 		}

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -10187,8 +10187,6 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 	Mob* mypet = this->GetPet();
 	Mob *target = entity_list.GetMob(pet->target);
 
-	Shout("Pet Commands %i", pet->command);
-
 	if (!mypet || pet->command == PET_LEADER) {
 		if (pet->command == PET_LEADER) {
 			// we either send the ID of an NPC we're interested in or no ID for our own pet

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -10252,6 +10252,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 
 		if ((mypet->GetPetType() == petAnimation && aabonuses.PetCommands[PetCommand]) || mypet->GetPetType() != petAnimation) {
 			if (target != this && DistanceSquaredNoZ(mypet->GetPosition(), target->GetPosition()) <= (RuleR(Pets, AttackCommandRange)*RuleR(Pets, AttackCommandRange))) {
+				mypet->SetFeigned(false);
 				if (mypet->IsPetStop()) {
 					mypet->SetPetStop(false);
 					SetPetCommandState(PET_BUTTON_STOP, 0);
@@ -10298,6 +10299,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 
 		if ((mypet->GetPetType() == petAnimation && aabonuses.PetCommands[PetCommand]) || mypet->GetPetType() != petAnimation) {
 			if (GetTarget() != this && DistanceSquaredNoZ(mypet->GetPosition(), GetTarget()->GetPosition()) <= (RuleR(Pets, AttackCommandRange)*RuleR(Pets, AttackCommandRange))) {
+				mypet->SetFeigned(false);
 				if (mypet->IsPetStop()) {
 					mypet->SetPetStop(false);
 					SetPetCommandState(PET_BUTTON_STOP, 0);
@@ -10373,6 +10375,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			if (mypet->IsNPC()) {
 
 				// Set Sit button to unpressed - send stand anim/end hpregen
+				mypet->SetFeigned(false);
 				SetPetCommandState(PET_BUTTON_SIT, 0);
 				mypet->SendAppearancePacket(AT_Anim, ANIM_STAND);
 
@@ -10393,6 +10396,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 		if (mypet->IsFeared()) break; //could be exploited like PET_BACKOFF
 
 		if ((mypet->GetPetType() == petAnimation && aabonuses.PetCommands[PetCommand]) || mypet->GetPetType() != petAnimation) {
+			mypet->SetFeigned(false);
 			mypet->SayString(this, Chat::PetResponse, PET_FOLLOWING);
 			mypet->SetPetOrder(SPO_Follow);
 
@@ -10440,6 +10444,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 		if (mypet->IsFeared()) break; //could be exploited like PET_BACKOFF
 
 		if ((mypet->GetPetType() == petAnimation && aabonuses.PetCommands[PetCommand]) || mypet->GetPetType() != petAnimation) {
+			mypet->SetFeigned(false);
 			mypet->SayString(this, Chat::PetResponse, PET_GUARDME_STRING);
 			mypet->SetPetOrder(SPO_Follow);
 
@@ -10460,12 +10465,14 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 		if ((mypet->GetPetType() == petAnimation && aabonuses.PetCommands[PetCommand]) || mypet->GetPetType() != petAnimation) {
 			if (mypet->GetPetOrder() == SPO_Sit)
 			{
+				mypet->SetFeigned(false);
 				mypet->SayString(this, Chat::PetResponse, PET_SIT_STRING);
 				mypet->SetPetOrder(SPO_Follow);
 				mypet->SendAppearancePacket(AT_Anim, ANIM_STAND);
 			}
 			else
 			{
+				mypet->SetFeigned(false);
 				mypet->SayString(this, Chat::PetResponse, PET_SIT_STRING);
 				mypet->SetPetOrder(SPO_Sit);
 				mypet->SetRunAnimSpeed(0);
@@ -10480,6 +10487,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 		if (mypet->IsFeared()) break; //could be exploited like PET_BACKOFF
 
 		if ((mypet->GetPetType() == petAnimation && aabonuses.PetCommands[PetCommand]) || mypet->GetPetType() != petAnimation) {
+			mypet->SetFeigned(false);
 			mypet->SayString(this, Chat::PetResponse, PET_SIT_STRING);
 			SetPetCommandState(PET_BUTTON_SIT, 0);
 			mypet->SetPetOrder(SPO_Follow);
@@ -10491,6 +10499,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 		if (mypet->IsFeared()) break; //could be exploited like PET_BACKOFF
 
 		if ((mypet->GetPetType() == petAnimation && aabonuses.PetCommands[PetCommand]) || mypet->GetPetType() != petAnimation) {
+			mypet->SetFeigned(false);
 			mypet->SayString(this, Chat::PetResponse, PET_SIT_STRING);
 			SetPetCommandState(PET_BUTTON_SIT, 1);
 			mypet->SetPetOrder(SPO_Sit);

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -3515,12 +3515,18 @@ void EntityList::ClearFeignAggro(Mob *targ)
 			it->second->RemoveFromHateList(targ);
 			if (targ->IsClient()) {
 				if (it->second->GetLevel() >= 35 && zone->random.Roll(60)) {
-					it->second->AddFeignMemory(targ->CastToClient());
+					it->second->AddFeignMemory(targ);
 					targ->Shout("EntityList::ClearFeignAggro ADD TO FD ROLL FAIllED");
 				}
 				else {
 					targ->CastToClient()->RemoveXTarget(it->second, false);
 					targ->Shout("EntityList::ClearFeignAggro Remove me from Xtarget");
+				}
+			}
+			else if (targ->IsPet()){
+				if (it->second->GetLevel() >= 35 && zone->random.Roll(60)) {
+					it->second->AddFeignMemory(targ);
+					targ->Shout("EntityList::ClearFeignAggro PET ADD TO FD ROLL FAIllED");
 				}
 			}
 		}

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -3516,17 +3516,14 @@ void EntityList::ClearFeignAggro(Mob *targ)
 			if (targ->IsClient()) {
 				if (it->second->GetLevel() >= 35 && zone->random.Roll(60)) {
 					it->second->AddFeignMemory(targ);
-					targ->Shout("EntityList::ClearFeignAggro ADD TO FD ROLL FAIllED");
 				}
 				else {
 					targ->CastToClient()->RemoveXTarget(it->second, false);
-					targ->Shout("EntityList::ClearFeignAggro Remove me from Xtarget");
 				}
 			}
 			else if (targ->IsPet()){
 				if (it->second->GetLevel() >= 35 && zone->random.Roll(60)) {
 					it->second->AddFeignMemory(targ);
-					targ->Shout("EntityList::ClearFeignAggro PET ADD TO FD ROLL FAIllED");
 				}
 			}
 		}

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -1515,10 +1515,10 @@ void EntityList::RemoveFromTargets(Mob *mob, bool RemoveFromXTargets)
 			continue;
 
 		if (RemoveFromXTargets) {
-			if (m->IsClient() && (mob->CheckAggro(m) || mob->IsOnFeignMemory(m->CastToClient())))
+			if (m->IsClient() && (mob->CheckAggro(m) || mob->IsOnFeignMemory(m)))
 				m->CastToClient()->RemoveXTarget(mob, false);
 			// FadingMemories calls this function passing the client.
-			else if (mob->IsClient() && (m->CheckAggro(mob) || m->IsOnFeignMemory(mob->CastToClient())))
+			else if (mob->IsClient() && (m->CheckAggro(mob) || m->IsOnFeignMemory(mob)))
 				mob->CastToClient()->RemoveXTarget(m, false);
 		}
 
@@ -3488,7 +3488,7 @@ void EntityList::ClearFeignAggro(Mob *targ)
 	auto it = npc_list.begin();
 	while (it != npc_list.end()) {
 		// add Feign Memory check because sometimes weird stuff happens
-		if (it->second->CheckAggro(targ) || (targ->IsClient() && it->second->IsOnFeignMemory(targ->CastToClient()))) {
+		if (it->second->CheckAggro(targ) || (targ->IsClient() && it->second->IsOnFeignMemory(targ))) {
 			if (it->second->GetSpecialAbility(IMMUNE_FEIGN_DEATH)) {
 				++it;
 				continue;

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -3531,12 +3531,14 @@ void EntityList::ClearFeignAggro(Mob *targ)
 	}
 }
 
-void EntityList::ClearZoneFeignAggro(Client *targ)
+void EntityList::ClearZoneFeignAggro(Mob *targ)
 {
 	auto it = npc_list.begin();
 	while (it != npc_list.end()) {
 		it->second->RemoveFromFeignMemory(targ);
-		targ->CastToClient()->RemoveXTarget(it->second, false);
+		if (targ && targ->IsClient()) {
+			targ->CastToClient()->RemoveXTarget(it->second, false);
+		}
 		++it;
 	}
 }

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -3514,10 +3514,14 @@ void EntityList::ClearFeignAggro(Mob *targ)
 
 			it->second->RemoveFromHateList(targ);
 			if (targ->IsClient()) {
-				if (it->second->GetLevel() >= 35 && zone->random.Roll(60))
+				if (it->second->GetLevel() >= 35 && zone->random.Roll(60)) {
 					it->second->AddFeignMemory(targ->CastToClient());
-				else
+					targ->Shout("EntityList::ClearFeignAggro ADD TO FD ROLL FAIllED");
+				}
+				else {
 					targ->CastToClient()->RemoveXTarget(it->second, false);
+					targ->Shout("EntityList::ClearFeignAggro Remove me from Xtarget");
+				}
 			}
 		}
 		++it;

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -455,7 +455,7 @@ public:
 	void	ClearAggro(Mob* targ);
 	void    ClearWaterAggro(Mob* targ);
 	void	ClearFeignAggro(Mob* targ);
-	void	ClearZoneFeignAggro(Client* targ);
+	void	ClearZoneFeignAggro(Mob* targ);
 	void	AggroZone(Mob* who, uint32 hate = 0);
 
 	bool	Fighting(Mob* targ);

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -6509,7 +6509,6 @@ void Mob::ShieldAbilityClearVariables()
 void Mob::SetFeigned(bool in_feigned) {
 	
 	if (in_feigned)	{
-
 		if (IsClient()) {
 			if (RuleB(Character, FeignKillsPet)){
 				SetPet(0);

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -109,6 +109,7 @@ Mob::Mob(
 	stunned_timer(0),
 	spun_timer(0),
 	bardsong_timer(6000),
+	forget_timer(0),
 	gravity_timer(1000),
 	viral_timer(0),
 	m_FearWalkTarget(-999999.0f, -999999.0f, -999999.0f),
@@ -281,6 +282,8 @@ Mob::Mob(
 	always_aggro      = in_always_aggro;
 
 	InitializeBuffSlots();
+
+	feigned = false;
 
 	// clear the proc arrays
 	for (int j = 0; j < MAX_PROCS; j++) {
@@ -6501,6 +6504,25 @@ void Mob::ShieldAbilityClearVariables()
 		SetShielderMaxDistance(0);
 		shield_timer.Disable();
 	}
+}
+
+void Mob::SetFeigned(bool in_feigned) {
+	if (in_feigned)
+	{
+		if (IsClient()) {
+			if (RuleB(Character, FeignKillsPet))
+			{
+				SetPet(0);
+			}
+			CastToClient()->SetHorseId(0);
+		}
+		entity_list.ClearFeignAggro(this);
+		forget_timer.Start(FeignMemoryDuration);
+	}
+	else {
+		forget_timer.Disable();
+	}
+	feigned = in_feigned;
 }
 
 #ifdef BOTS

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -6507,11 +6507,11 @@ void Mob::ShieldAbilityClearVariables()
 }
 
 void Mob::SetFeigned(bool in_feigned) {
-	if (in_feigned)
-	{
+	
+	if (in_feigned)	{
+
 		if (IsClient()) {
-			if (RuleB(Character, FeignKillsPet))
-			{
+			if (RuleB(Character, FeignKillsPet)){
 				SetPet(0);
 			}
 			CastToClient()->SetHorseId(0);

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -670,10 +670,10 @@ public:
 	bool HateSummon();
 	void FaceTarget(Mob* mob_to_face = 0);
 	void WipeHateList();
-	void AddFeignMemory(Client* attacker);
-	void RemoveFromFeignMemory(Client* attacker);
+	void AddFeignMemory(Mob* attacker);
+	void RemoveFromFeignMemory(Mob* attacker);
 	void ClearFeignMemory();
-	bool IsOnFeignMemory(Client *attacker) const;
+	bool IsOnFeignMemory(Mob *attacker) const;
 	void PrintHateListToClient(Client *who) { hate_list.PrintHateListToClient(who); }
 	std::list<struct_HateList*>& GetHateList() { return hate_list.GetHateList(); }
 	std::list<struct_HateList*> GetHateListByDistance(int distance = 0) { return hate_list.GetHateListByDistance(distance); }

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -71,7 +71,7 @@ class Mob : public Entity {
 public:
 	enum CLIENT_CONN_STATUS { CLIENT_CONNECTING, CLIENT_CONNECTED, CLIENT_LINKDEAD,
 						CLIENT_KICKED, DISCONNECTED, CLIENT_ERROR, CLIENT_CONNECTINGALL };
-	enum eStandingPetOrder { SPO_Follow, SPO_Sit, SPO_Guard };
+	enum eStandingPetOrder { SPO_Follow, SPO_Sit, SPO_Guard, SPO_FeignDeath };
 
 	struct SpecialAbility {
 		SpecialAbility() {

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1296,6 +1296,10 @@ public:
 	bool CanOpenDoors() const;
 	void SetCanOpenDoors(bool can_open);
 
+	void SetFeigned(bool in_feigned);
+	/// this cures timing issues cuz dead animation isn't done but server side feigning is?
+	inline bool GetFeigned() const { return(feigned); }
+
 	void DeleteBucket(std::string bucket_name);
 	std::string GetBucket(std::string bucket_name);
 	std::string GetBucketExpires(std::string bucket_name);
@@ -1719,6 +1723,9 @@ protected:
 	AuraMgr aura_mgr;
 	AuraMgr trap_mgr;
 
+	bool feigned;
+	Timer forget_timer; // our 2 min everybody forgets you timer
+
 	bool m_can_open_doors;
 
 	MobMovementManager *mMovementManager;
@@ -1726,7 +1733,7 @@ protected:
 private:
 	void _StopSong(); //this is not what you think it is
 	Mob* target;
-
+	
 
 #ifdef BOTS
 	std::shared_ptr<HealRotation> m_target_of_heal_rotation;

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -1554,6 +1554,11 @@ void Mob::AI_Process() {
 		}
 	}
 
+	if (forget_timer.Check()) {
+		forget_timer.Disable();
+		entity_list.ClearZoneFeignAggro(this);
+	}
+
 	//Do Ranged attack here
 	if (doranged) {
 		RangedAttack(target);

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -840,15 +840,17 @@ void Client::AI_Process()
 		if(AI_feign_remember_timer->Check()) {
 			std::set<uint32>::iterator RememberedCharID;
 			RememberedCharID = feign_memory_list.begin();
+			Shout("timer check %i", RememberedCharID);
 			while (RememberedCharID != feign_memory_list.end()) {
-				Shout("Check FD List: %i", RememberedCharID);
+				
 				Mob* remember_client = entity_list.GetMob(*RememberedCharID);
+				Shout("AI_feign_remember_timer->Check() :: Check FD List: %i", RememberedCharID, remember_client->GetFeigned());
 				if (remember_client == nullptr || remember_client->IsCorpse()) {
 					//they are gone now...
 					RememberedCharID = feign_memory_list.erase(RememberedCharID);
-					Shout("Erase FD ID %i", RememberedCharID);
+					Shout("AI_feign_remember_timer->Check() :: Erase FD ID %i", RememberedCharID);
 				} else if (!remember_client->GetFeigned()) {
-					Shout("Now standing %i ADD TO HATE LIST %i", RememberedCharID);
+					Shout("AI_feign_remember_timer->Check() :: Now standing %i ADD TO HATE LIST %i", RememberedCharID);
 					AddToHateList(remember_client,1);
 					RememberedCharID = feign_memory_list.erase(RememberedCharID);
 					break;
@@ -1370,7 +1372,7 @@ void Mob::AI_Process() {
 			// check to see if any of our previous feigned targets have gotten up.
 			std::set<uint32>::iterator RememberedCharID;
 			RememberedCharID = feign_memory_list.begin();
-			Shout("PASS2 :: Check FD List: %i", RememberedCharID);
+			//Shout("PASS2 :: Check FD List: %i", RememberedCharID);
 			while (RememberedCharID != feign_memory_list.end()) {
 				Mob *remember_client = entity_list.GetMob(*RememberedCharID);
 				if (remember_client == nullptr) {
@@ -1481,6 +1483,10 @@ void Mob::AI_Process() {
 						if (IsNPC()) {
 							CastToNPC()->NextGuardPosition();
 						}
+						break;
+					}
+					case SPO_FeignDeath: {
+						SetAppearance(eaDead, false);
 						break;
 					}
 				}

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -1370,7 +1370,7 @@ void Mob::AI_Process() {
 			remembered_feigned_mobid = feign_memory_list.begin();
 			while (remembered_feigned_mobid != feign_memory_list.end()) {
 				Mob *remembered_mob = entity_list.GetMob(*remembered_feigned_mobid);
-				if (remembered_mob == nullptr) {
+				if (remembered_mob == nullptr || remembered_mob->IsCorpse()) {
 					//they are gone now...
 					remembered_feigned_mobid = feign_memory_list.erase(remembered_feigned_mobid);
 				}

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -838,25 +838,21 @@ void Client::AI_Process()
 	else
 	{
 		if(AI_feign_remember_timer->Check()) {
-			std::set<uint32>::iterator RememberedCharID;
-			RememberedCharID = feign_memory_list.begin();
-			Shout("timer check %i", RememberedCharID);
-			while (RememberedCharID != feign_memory_list.end()) {
+			std::set<uint32>::iterator remembered_feigned_mobid;
+			remembered_feigned_mobid = feign_memory_list.begin();
+			while (remembered_feigned_mobid != feign_memory_list.end()) {
 				
-				Mob* remember_client = entity_list.GetMob(*RememberedCharID);
-				Shout("AI_feign_remember_timer->Check() :: Check FD List: %i", RememberedCharID, remember_client->GetFeigned());
-				if (remember_client == nullptr || remember_client->IsCorpse()) {
+				Mob* remembered_mob = entity_list.GetMob(*remembered_feigned_mobid);
+				if (remembered_mob == nullptr || remembered_mob->IsCorpse()) {
 					//they are gone now...
-					RememberedCharID = feign_memory_list.erase(RememberedCharID);
-					Shout("AI_feign_remember_timer->Check() :: Erase FD ID %i", RememberedCharID);
-				} else if (!remember_client->GetFeigned()) {
-					Shout("AI_feign_remember_timer->Check() :: Now standing %i ADD TO HATE LIST %i", RememberedCharID);
-					AddToHateList(remember_client,1);
-					RememberedCharID = feign_memory_list.erase(RememberedCharID);
+					remembered_feigned_mobid = feign_memory_list.erase(remembered_feigned_mobid);
+				} else if (!remembered_mob->GetFeigned()) {
+					AddToHateList(remembered_mob,1);
+					remembered_feigned_mobid = feign_memory_list.erase(remembered_feigned_mobid);
 					break;
 				} else {
 					//they are still feigned, carry on...
-					++RememberedCharID;
+					++remembered_feigned_mobid;
 				}
 			}
 		}
@@ -1370,25 +1366,22 @@ void Mob::AI_Process() {
 			// 6/14/06
 			// Improved Feign Death Memory
 			// check to see if any of our previous feigned targets have gotten up.
-			std::set<uint32>::iterator RememberedCharID;
-			RememberedCharID = feign_memory_list.begin();
-			//Shout("PASS2 :: Check FD List: %i", RememberedCharID);
-			while (RememberedCharID != feign_memory_list.end()) {
-				Mob *remember_client = entity_list.GetMob(*RememberedCharID);
-				if (remember_client == nullptr) {
+			std::set<uint32>::iterator remembered_feigned_mobid;
+			remembered_feigned_mobid = feign_memory_list.begin();
+			while (remembered_feigned_mobid != feign_memory_list.end()) {
+				Mob *remembered_mob = entity_list.GetMob(*remembered_feigned_mobid);
+				if (remembered_mob == nullptr) {
 					//they are gone now...
-					Shout("PASS2 ::  Erase FD ID %i", RememberedCharID);
-					RememberedCharID = feign_memory_list.erase(RememberedCharID);
+					remembered_feigned_mobid = feign_memory_list.erase(remembered_feigned_mobid);
 				}
-				else if (!remember_client->GetFeigned()) {
-					Shout("PASS :: 2 Now standing %i ADD TO HATE LIST %i", RememberedCharID);
-					AddToHateList(remember_client, 1);
-					RememberedCharID = feign_memory_list.erase(RememberedCharID);
+				else if (!remembered_mob->GetFeigned()) {
+					AddToHateList(remembered_mob, 1);
+					remembered_feigned_mobid = feign_memory_list.erase(remembered_feigned_mobid);
 					break;
 				}
 				else {
 					//they are still feigned, carry on...
-					++RememberedCharID;
+					++remembered_feigned_mobid;
 				}
 			}
 		}

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -841,12 +841,15 @@ void Client::AI_Process()
 			std::set<uint32>::iterator RememberedCharID;
 			RememberedCharID = feign_memory_list.begin();
 			while (RememberedCharID != feign_memory_list.end()) {
-				Client* remember_client = entity_list.GetClientByCharID(*RememberedCharID);
-				if (remember_client == nullptr) {
+				Shout("Check FD List: %i", RememberedCharID);
+				Mob* remember_client = entity_list.GetMob(*RememberedCharID);
+				if (remember_client == nullptr || remember_client->IsCorpse()) {
 					//they are gone now...
 					RememberedCharID = feign_memory_list.erase(RememberedCharID);
+					Shout("Erase FD ID %i", RememberedCharID);
 				} else if (!remember_client->GetFeigned()) {
-					AddToHateList(remember_client->CastToMob(),1);
+					Shout("Now standing %i ADD TO HATE LIST %i", RememberedCharID);
+					AddToHateList(remember_client,1);
 					RememberedCharID = feign_memory_list.erase(RememberedCharID);
 					break;
 				} else {
@@ -1367,14 +1370,17 @@ void Mob::AI_Process() {
 			// check to see if any of our previous feigned targets have gotten up.
 			std::set<uint32>::iterator RememberedCharID;
 			RememberedCharID = feign_memory_list.begin();
+			Shout("PASS2 :: Check FD List: %i", RememberedCharID);
 			while (RememberedCharID != feign_memory_list.end()) {
-				Client *remember_client = entity_list.GetClientByCharID(*RememberedCharID);
+				Mob *remember_client = entity_list.GetMob(*RememberedCharID);
 				if (remember_client == nullptr) {
 					//they are gone now...
+					Shout("PASS2 ::  Erase FD ID %i", RememberedCharID);
 					RememberedCharID = feign_memory_list.erase(RememberedCharID);
 				}
 				else if (!remember_client->GetFeigned()) {
-					AddToHateList(remember_client->CastToMob(), 1);
+					Shout("PASS :: 2 Now standing %i ADD TO HATE LIST %i", RememberedCharID);
+					AddToHateList(remember_client, 1);
 					RememberedCharID = feign_memory_list.erase(RememberedCharID);
 					break;
 				}

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -1557,18 +1557,17 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Feign Death");
 #endif
-				//todo, look up spell ID in DB
-				if(spell_id == 2488) //Dook- Lifeburn fix
+				if(spell_id == SPELL_LIFEBURN) //Dook- Lifeburn fix
 					break;
 
 				if(IsClient()) {
 					CastToClient()->SetHorseId(0); // dismount if have horse
 
 					if (zone->random.Int(0, 99) > spells[spell_id].base_value[i]) {
-						CastToClient()->SetFeigned(false);
+						SetFeigned(false);
 						entity_list.MessageCloseString(this, false, 200, 10, STRING_FEIGNFAILED, GetName());
 					} else {
-						CastToClient()->SetFeigned(true);
+						SetFeigned(true);
 					}
 				}
 				break;


### PR DESCRIPTION
Implemented SPA 281 SE_PetFeignMinion which will allow you to command your pet to FD using /pet feign
Requires purchasing the the AA ability for it to work.

`#define SE_FeignedMinion				281	// implemented, ability allows you to instruct your pet to feign death via the '/pet feign' command, base: succeed chance, limit: none, max: none, Note: Only implemented as an AA.`

Note: This required a little bit of changes to the feign death code in general to let it support non clients. I don't think there should be any unintended changes to regular FD.