### PR TITLE
Added KickLinkDead

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -861,7 +861,7 @@ void Client::ChannelMessageReceived(uint8 chan_num, uint8 language, uint8 lang_s
 				{
 					if(AttemptedMessages > RuleI(Chat, MaxMessagesBeforeKick))
 					{
-						Kick("Sent too many chat messages at once.");
+						KickLinkDead("Sent too many chat messages at once.");
 						return;
 					}
 					if(GlobalChatLimiterTimer)
@@ -2627,6 +2627,19 @@ void Client::Kick(const std::string &reason) {
 	client_state = CLIENT_KICKED;
 
 	LogClientLogin("Client [{}] kicked, reason [{}]", GetCleanName(), reason.c_str());
+}
+
+// KickLinkDead is similar to Kick
+// the difference is that Kick immediately makes a player exit the zone and boots them to character select.
+// While kick linkdead puts them to character select and makes them in a linkdead state
+void Client::KickLinkDead(const std::string& reason) {
+	LogClientLogin("Client [{}] forced linkdead, reason [{}]", GetCleanName(), reason.c_str());
+	LinkDead();
+	auto outapp = new EQApplicationPacket(OP_GMKick, sizeof(GMKick_Struct));
+	GMKick_Struct* gmk = (GMKick_Struct*)outapp->pBuffer;
+	strcpy(gmk->name, GetName());
+	QueuePacket(outapp);
+	safe_delete(outapp);
 }
 
 void Client::WorldKick() {

--- a/zone/client.h
+++ b/zone/client.h
@@ -366,6 +366,7 @@ public:
 	inline void Disconnect() { eqs->Close(); client_state = DISCONNECTED; }
 	inline bool IsLD() const { return (bool) (client_state == CLIENT_LINKDEAD); }
 	void Kick(const std::string &reason);
+	void KickLinkDead(const std::string& reason);
 	void WorldKick();
 	inline uint8 GetAnon() const { return m_pp.anon; }
 	inline uint8 GetAFK() const { return AFK; }

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1239,7 +1239,7 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 		LogClientLogin("[{}] failed zone auth check", cze->char_name);
 		if (nullptr != client) {
 			client->Save();
-			client->Kick("Failed auth check");
+			client->KickLinkDead("Failed auth check");
 		}
 		return;
 	}
@@ -10148,7 +10148,7 @@ void Client::Handle_OP_MoveItem(const EQApplicationPacket *app)
 				itm_to ? itm_to->GetID() : 0,
 				casting_spell_id);
 			database.SetMQDetectionFlag(AccountName(), GetName(), detect, zone->GetShortName());
-			Kick("Inventory desync"); // Kick client to prevent client and server from getting out-of-sync inventory slots
+			KickLinkDead("Inventory desync"); // Kick client to prevent client and server from getting out-of-sync inventory slots
 			return;
 		}
 	}
@@ -10192,7 +10192,7 @@ void Client::Handle_OP_MoveItem(const EQApplicationPacket *app)
 
 void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
 {
-	Kick("Unimplemented move multiple items"); // TODO: lets not desync though
+	KickLinkDead("Unimplemented move multiple items");
 }
 
 void Client::Handle_OP_OpenContainer(const EQApplicationPacket *app)

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -1861,7 +1861,7 @@ bool Client::SwapItem(MoveItem_Struct* move_in) {
 							 "non-existant or too far away ({} units).",
 							 banker ? banker->GetName() : "UNKNOWN NPC", distance);
 			database.SetMQDetectionFlag(AccountName(), GetName(), hacked_string, zone->GetShortName());
-			Kick("Inventory desync");	// Kicking player to avoid item loss do to client and server inventories not being sync'd
+			KickLinkDead("Inventory desync");	// Kicking player to avoid item loss do to client and server inventories not being sync'd
 			return false;
 		}
 	}
@@ -2078,7 +2078,7 @@ bool Client::SwapItem(MoveItem_Struct* move_in) {
 	// Step 4: Check for entity trade
 	if (dst_slot_id >= EQ::invslot::TRADE_BEGIN && dst_slot_id <= EQ::invslot::TRADE_END) {
 		if (src_slot_id != EQ::invslot::slotCursor) {
-			Kick("Trade with non-cursor item");
+			KickLinkDead("Trade with non-cursor item");
 			return false;
 		}
 		if (with) {

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -112,7 +112,7 @@ void Trade::AddEntity(uint16 trade_slot_id, uint32 stack_size) {
 	// (it just didn't handle partial stack move actions)
 	if (stack_size > 0) {
 		if (!inst->IsStackable() || !inst2 || !inst2->GetItem() || (inst->GetID() != inst2->GetID()) || (stack_size > inst->GetCharges())) {
-			client->Kick("Error stacking item in trade");
+			client->KickLinkDead("Error stacking item in trade");
 			return;
 		}
 
@@ -138,7 +138,7 @@ void Trade::AddEntity(uint16 trade_slot_id, uint32 stack_size) {
 	}
 	else {
 		if (inst2 && inst2->GetID()) {
-			client->Kick("Attempting to add null item to trade");
+			client->KickLinkDead("Attempting to add null item to trade");
 			return;
 		}
 


### PR DESCRIPTION
Kick: Character goes to character select, instantly exits zone. (This means you can instant exit with no /camp timer and no LD entity in game)
WorldKick: Character goes to server select, instantly exits zone. (same symptom as above).
KickLinkDead: Character goes to server select, leaves LD character in zone (If World:EnforceCharacterLimitAtLogin is on, a message of a character already logged in will appear for Zone:ClientLinkdeadMS milliseconds)

This PR changes detected hacks or other methods a hacker may use intentionally or unintentionally to not get the advantage of what Kick originally did, by soft punishing them with the login return wait time based on if the server configures rules appropiately.

The only symptom for servers that have World:EnforceCharacterLimitAtLogin  false (the default PEQ setting) is that before you'd get put to character select (via Kick), you'd now get put to server select (via KickLinkDead)


Things needing testing:
- [ ] Ensure all clients honor this packet
- [ ] Verify what happens if the client ignores the GM Kick request. We may need to do a session close as well after other methods, to sever the connection.
- [ ] After about 3 KickLinkDead() packets, a client has a high chance of getting a black screen on RoF2. Perhaps debug the dbg.txt to see why that symptom arises.