### PR TITLE
[Bug Fix] Fix #guild rename, #killallnpcs, and #worldwide message errors.

### DIFF
--- a/zone/gm_commands/guild.cpp
+++ b/zone/gm_commands/guild.cpp
@@ -225,10 +225,7 @@ void command_guild(Client *c, const Seperator *sep)
 
 		guild_mgr.ListGuilds(c);
 	} else if (is_rename) {
-		if (
-			arguments != 3 ||
-			!sep->IsNumber(2)
-		) {
+		if (!sep->IsNumber(2)) {
 			c->Message(Chat::White, "Usage: #guild rename [Guild ID] [New Guild Name]");
 		} else {
 			auto guild_id = std::stoul(sep->arg[2]);

--- a/zone/gm_commands/killallnpcs.cpp
+++ b/zone/gm_commands/killallnpcs.cpp
@@ -10,6 +10,10 @@ void command_killallnpcs(Client *c, const Seperator *sep)
 	int killed_count = 0;
 	for (auto& npc_entity : entity_list.GetNPCList()) {
 		auto entity_id = npc_entity.first;
+		if (!entity_id) {
+			continue;
+		}
+
 		auto npc = npc_entity.second;
 		if (!npc) {
 			continue;

--- a/zone/gm_commands/worldwide.cpp
+++ b/zone/gm_commands/worldwide.cpp
@@ -62,7 +62,7 @@ void command_worldwide(Client *c, const Seperator *sep)
 	}
 	else if (sub_command == "message") {
 		if (sep->arg[2]) {
-			std::string message = sep->arg[2];
+			std::string message = sep->argplus[2];
 			quest_manager.WorldWideMessage(
 				Chat::White,
 				fmt::format(


### PR DESCRIPTION
- #guild rename was checking argument count and not allowing you to rename guilds to names that had spaces.
- #killallnpcs was crashing zones when used sometimes due to getting a nullptr somewhere in the loop.
- #worldwide message was using just the first word of the message sent using the command, not all of them.