### PR TITLE
[Database] Mark titles as a server table so it at least shows up in dumps

### DIFF
--- a/common/database_schema.h
+++ b/common/database_schema.h
@@ -82,7 +82,6 @@ namespace DatabaseSchema {
 			{"player_titlesets",               "char_id"},
 			{"quest_globals",                  "charid"},
 			{"timers",                         "char_id"},
-			{"titles",                         "char_id"},
 			{"trader",                         "char_id"},
 			{"zone_flags",                     "charID"}
 		};
@@ -158,7 +157,6 @@ namespace DatabaseSchema {
 			"spell_buckets",
 			"spell_globals",
 			"timers",
-			"titles",
 			"trader",
 			"trader_audit",
 			"zone_flags"
@@ -270,6 +268,7 @@ namespace DatabaseSchema {
 			"perl_event_export_settings",
 			"profanity_list",
 			"rule_sets",
+			"titles",
 			"rule_values",
 			"variables",
 		};


### PR DESCRIPTION
Titles is a hybrid table which needs to be split up. It stores both record of content and character level persistence data. Until these are split out I am going to reclassify this table until we have split titles out