### PR TITLE
[XTarget] Performance Improvement After Corpse Change

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1799,7 +1799,6 @@ bool Client::Death(Mob* killerMob, int32 damage, uint16 spell, EQ::skills::Skill
 	entity_list.RemoveFromTargets(this, true);
 	hate_list.RemoveEntFromHateList(this);
 	RemoveAutoXTargets();
-	ProcessXTargetAutoHaters();
 
 	//remove ourself from all proximities
 	ClearAllProximities();

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -7426,17 +7426,9 @@ void Client::ProcessXTargetAutoHaters()
 	std::queue<int> empty_slots;
 	for (int i = 0; i < GetMaxXTargets(); ++i) {
 		if (XTargets[i].Type != Auto)
-			continue;
-
-		auto *mob = entity_list.GetMob(XTargets[i].ID);
+			continue;		
 
 		if (XTargets[i].ID != 0 && !GetXTargetAutoMgr()->contains_mob(XTargets[i].ID)) {
-			XTargets[i].ID = 0;
-			XTargets[i].Name[0] = 0;
-			XTargets[i].dirty = true;
-		}
-
-		if (XTargets[i].ID != 0 && mob && !mob->IsValidXTarget()) {
 			XTargets[i].ID = 0;
 			XTargets[i].Name[0] = 0;
 			XTargets[i].dirty = true;


### PR DESCRIPTION
Removed a conditional that was rendered obsolete by moving the addition of a
mob to the auto haters list to fire after an IsValidXTarget check.  This
made an entity_list call unnecessary.  [zone/client.cpp]

Removed said unnecessary entity_list call.  [zone/client.cpp]

Removed a superfluous call to ProcessXTargetAutoHaters [zone/attack.cpp]

I spent a few hours today, testing to ensure that corpses still won't get stuck in the XTarget window, with these modifications.  I was unable to get a corpse to stay in the XTarget window, which is good.  This is the desired behavior.