### PR TITLE
[Bug Fix] Fix issue with mobs summoning PCs into ceilings

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -3594,7 +3594,10 @@ bool Mob::HateSummon() {
 		if(summon_level == 1) {
 			entity_list.MessageClose(this, true, 500, Chat::Say, "%s says 'You will not evade me, %s!' ", GetCleanName(), target->GetCleanName() );
 
+			float summoner_zoff = this->GetZOffset();
+			float summoned_zoff = target->GetZOffset();
 			auto new_pos = m_Position;
+			new_pos.z -= (summoner_zoff - summoned_zoff);
 			float angle = new_pos.w - target->GetHeading();
 			new_pos.w = target->GetHeading();
 

--- a/zone/waypoints.cpp
+++ b/zone/waypoints.cpp
@@ -958,6 +958,7 @@ void Mob::TryMoveAlong(float distance, float angle, bool send)
 	}
 
 	new_pos.z = GetFixedZ(new_pos);
+
 	Teleport(new_pos);
 }
 
@@ -971,7 +972,6 @@ glm::vec4 Mob::TryMoveAlong(const glm::vec4 &start, float distance, float angle)
 	glm::vec3 new_pos = start;
 	new_pos.x += distance * g_Math.FastSin(angle);
 	new_pos.y += distance * g_Math.FastCos(angle);
-	new_pos.z += GetZOffset();
 
 	if (zone->HasMap()) {
 		if (zone->zonemap->LineIntersectsZone(start, new_pos, 0.0f, &tmp_pos))


### PR DESCRIPTION
This has been in production for a few weeks on my server now and has completely eliminated the summon issue that cropped up when the summon code was changed a couple of months ago.

Talking with @mackal I believe he feels we need something more comprehensive than this, ala checking ceiling or something similar.

However, I believe this correct the issue for all cases I have seen.  I can't say if it will solve everyone's issue, but the change is small and makes sense.