### PR TITLE
[Bug Fix] Hasten AA will now reduce time properly if multiple Hasten AA's affect same cool down.

### DIFF
--- a/zone/aa.cpp
+++ b/zone/aa.cpp
@@ -1286,6 +1286,7 @@ int Mob::GetAlternateAdvancementCooldownReduction(AA::Rank *rank_in) {
 		return 0;
 	}
 
+	int total_reduction = 0;
 	for(auto &aa : aa_ranks) {
 		auto ability_rank = zone->GetAlternateAdvancementAbilityAndRank(aa.first, aa.second.first);
 		auto ability = ability_rank.first;
@@ -1297,12 +1298,12 @@ int Mob::GetAlternateAdvancementCooldownReduction(AA::Rank *rank_in) {
 
 		for(auto &effect : rank->effects) {
 			if(effect.effect_id == SE_HastenedAASkill && effect.limit_value == ability_in->id) {
-				return effect.base_value;
+				total_reduction += effect.base_value;
 			}
 		}
 	}
 
-	return 0;
+	return total_reduction;
 }
 
 void Mob::ExpendAlternateAdvancementCharge(uint32 aa_id) {


### PR DESCRIPTION
Problem: Hasten AA (spa 246) would not stack with itself if multiple AA are available that hasten the same hotkey cool down.

For example Beastlord 'Bite of the Asp' AA can be reduced by both 'Haste Feral Attacks' and 'Hasten Bite of the Asp', due to how it was coded it could not properly calculate the total cool down reduction if both cool down reduction AA's were purchased. However, client would display it properly.

This now resolved.