### PR TITLE
[Bug Fix] Fixes Enchanter AA Doppleganger crash issue

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -6486,7 +6486,7 @@ void Client::Doppelganger(uint16 spell_id, Mob *target, const char *name_overrid
 		// Give the pets alittle more agro than the caster and then agro them on the target
 		target->AddToHateList(swarm_pet_npc, (target->GetHateAmount(this) + 100), (target->GetDamageAmount(this) + 100));
 		swarm_pet_npc->AddToHateList(target, 1000, 1000);
-		swarm_pet_npc->GetSwarmInfo()->target = target->GetID();
+		swarm_pet_npc->GetSwarmInfo()->target = 0;
 
 		//we allocated a new NPC type object, give the NPC ownership of that memory
 		if(npc_dup != nullptr)

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -6482,6 +6482,7 @@ void Client::Doppelganger(uint16 spell_id, Mob *target, const char *name_overrid
 		swarm_pet_npc->StartSwarmTimer(pet_duration * 1000);
 
 		swarm_pet_npc->GetSwarmInfo()->owner_id = GetID();
+		swarm_pet_npc->SetFollowID(GetID());
 
 		// Give the pets alittle more agro than the caster and then agro them on the target
 		target->AddToHateList(swarm_pet_npc, (target->GetHateAmount(this) + 100), (target->GetDamageAmount(this) + 100));


### PR DESCRIPTION
Fixes Enchanter AA Doppleganger crash issue. 

This will also give like behavior where the Doppleganger will not despawn after its target dies, can continue to fight other targets.