### PR TITLE
[Content Flags] Load the content flags before loading shared data.

### DIFF
--- a/shared_memory/main.cpp
+++ b/shared_memory/main.cpp
@@ -167,6 +167,9 @@ int main(int argc, char **argv)
 
 
 	content_service.SetCurrentExpansion(RuleI(Expansion, CurrentExpansion));
+	content_service.SetDatabase(&database)
+		->SetExpansionContext()
+		->ReloadContentFlags();
 
 	LogInfo(
 		"Current expansion is [{}] ({})",


### PR DESCRIPTION
Content flags are not load during the shared memory loading process. This results in any loot with a content flag being omitted from shared memory.