### PR TITLE
[Spells] Support for bards using Disciplines while casting or /melody.

### DIFF
--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -814,7 +814,7 @@ bool Client::UseDiscipline(uint32 spell_id, uint32 target) {
 			instant_recast = false;
 			
 			if (GetClass() == BARD && IsCasting() && spells[spell_id].cast_time == 0) {
-				if (DoCastingChecks(spell_id, GetID())) {
+				if (DoCastingChecks(spell_id, target)) {
 					SpellFinished(spell_id, entity_list.GetMob(target), EQ::spells::CastingSlot::Discipline, 0, -1, spells[spell_id].resist_difficulty, false, -1, (uint32)DiscTimer, reduced_recast);
 				}
 			}
@@ -828,7 +828,7 @@ bool Client::UseDiscipline(uint32 spell_id, uint32 target) {
 
 	if (instant_recast)	{ 
 		if (GetClass() == BARD && IsCasting() && spells[spell_id].cast_time == 0) {
-			if (DoCastingChecks(spell_id, GetID())) {
+			if (DoCastingChecks(spell_id, target)) {
 				SpellFinished(spell_id, entity_list.GetMob(target), EQ::spells::CastingSlot::Discipline);
 			}
 		}

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -748,6 +748,10 @@ bool Client::UseDiscipline(uint32 spell_id, uint32 target) {
 		return(false);
 	}
 
+	if (DivineAura() && !spells[spell_id].cast_not_standing) {
+		return false;
+	}
+
 	//can we use the spell?
 	const SPDat_Spell_Struct &spell = spells[spell_id];
 	uint8 level_to_use = spell.classes[GetClass() - 1];

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -725,7 +725,6 @@ void Client::SendDisciplineUpdate() {
 
 bool Client::UseDiscipline(uint32 spell_id, uint32 target) {
 	// Dont let client waste a reuse timer if they can't use the disc
-
 	if (IsStunned() || IsFeared() || IsMezzed() || IsAmnesiad() || IsPet())
 	{
 		if (IsAmnesiad()) {

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -725,6 +725,9 @@ void Client::SendDisciplineUpdate() {
 
 bool Client::UseDiscipline(uint32 spell_id, uint32 target) {
 	// Dont let client waste a reuse timer if they can't use the disc
+
+	Shout("1 Use Disc %i %i", spell_id, target);
+
 	if (IsStunned() || IsFeared() || IsMezzed() || IsAmnesiad() || IsPet())
 	{
 		return(false);
@@ -744,7 +747,7 @@ bool Client::UseDiscipline(uint32 spell_id, uint32 target) {
 		Message(Chat::Red, "This tome contains invalid knowledge.");
 		return(false);
 	}
-
+	Shout("2 Use Disc %i %i", spell_id, target);
 	//can we use the spell?
 	const SPDat_Spell_Struct &spell = spells[spell_id];
 	uint8 level_to_use = spell.classes[GetClass() - 1];
@@ -788,7 +791,7 @@ bool Client::UseDiscipline(uint32 spell_id, uint32 target) {
 		);
 		return false;
 	}
-
+	Shout("3 Use Disc %i %i", spell_id, target);
 	if(spell.recast_time > 0)
 	{
 		uint32 reduced_recast = spell.recast_time / 1000;
@@ -818,6 +821,7 @@ bool Client::UseDiscipline(uint32 spell_id, uint32 target) {
 	{
 		CastSpell(spell_id, target, EQ::spells::CastingSlot::Discipline);
 	}
+	Shout("4 Use Disc %i %i", spell_id, target);
 	return(true);
 }
 

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -726,10 +726,11 @@ void Client::SendDisciplineUpdate() {
 bool Client::UseDiscipline(uint32 spell_id, uint32 target) {
 	// Dont let client waste a reuse timer if they can't use the disc
 
-	Shout("1 Use Disc %i %i", spell_id, target);
-
 	if (IsStunned() || IsFeared() || IsMezzed() || IsAmnesiad() || IsPet())
 	{
+		if (IsAmnesiad()) {
+			MessageString(Chat::Red, MELEE_SILENCE);
+		}
 		return(false);
 	}
 
@@ -747,7 +748,7 @@ bool Client::UseDiscipline(uint32 spell_id, uint32 target) {
 		Message(Chat::Red, "This tome contains invalid knowledge.");
 		return(false);
 	}
-	Shout("2 Use Disc %i %i", spell_id, target);
+
 	//can we use the spell?
 	const SPDat_Spell_Struct &spell = spells[spell_id];
 	uint8 level_to_use = spell.classes[GetClass() - 1];
@@ -791,9 +792,10 @@ bool Client::UseDiscipline(uint32 spell_id, uint32 target) {
 		);
 		return false;
 	}
-	Shout("3 Use Disc %i %i", spell_id, target);
-	if(spell.recast_time > 0)
-	{
+
+	bool instant_recast = true;
+
+	if(spell.recast_time > 0) {
 		uint32 reduced_recast = spell.recast_time / 1000;
 		auto focus = GetFocusEffect(focusReduceRecastTime, spell_id);
 		// do stupid stuff because custom servers.
@@ -808,20 +810,32 @@ bool Client::UseDiscipline(uint32 spell_id, uint32 target) {
 			reduced_recast -= focus;
 		}
 
-		if (reduced_recast > 0)
-			CastSpell(spell_id, target, EQ::spells::CastingSlot::Discipline, -1, -1, 0, -1, (uint32)DiscTimer, reduced_recast);
-		else{
-			CastSpell(spell_id, target, EQ::spells::CastingSlot::Discipline);
-			return true;
+		if (reduced_recast > 0){
+			instant_recast = false;
+			
+			if (GetClass() == BARD && IsCasting() && spells[spell_id].cast_time == 0) {
+				if (DoCastingChecks(spell_id, GetID())) {
+					SpellFinished(spell_id, entity_list.GetMob(target), EQ::spells::CastingSlot::Discipline, 0, -1, spells[spell_id].resist_difficulty, false, -1, (uint32)DiscTimer, reduced_recast);
+				}
+			}
+			else {
+				CastSpell(spell_id, target, EQ::spells::CastingSlot::Discipline, -1, -1, 0, -1, (uint32)DiscTimer, reduced_recast);
+			}
+			
+			SendDisciplineTimer(spells[spell_id].timer_id, reduced_recast);
 		}
+	}
 
-		SendDisciplineTimer(spells[spell_id].timer_id, reduced_recast);
+	if (instant_recast)	{ 
+		if (GetClass() == BARD && IsCasting() && spells[spell_id].cast_time == 0) {
+			if (DoCastingChecks(spell_id, GetID())) {
+				SpellFinished(spell_id, entity_list.GetMob(target), EQ::spells::CastingSlot::Discipline);
+			}
+		}
+		else {
+			CastSpell(spell_id, target, EQ::spells::CastingSlot::Discipline);
+		}
 	}
-	else
-	{
-		CastSpell(spell_id, target, EQ::spells::CastingSlot::Discipline);
-	}
-	Shout("4 Use Disc %i %i", spell_id, target);
 	return(true);
 }
 

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -331,7 +331,7 @@ public:
 	void CastedSpellFinished(uint16 spell_id, uint32 target_id, EQ::spells::CastingSlot slot, uint16 mana_used,
 		uint32 inventory_slot = 0xFFFFFFFF, int16 resist_adjust = 0);
 	bool SpellFinished(uint16 spell_id, Mob *target, EQ::spells::CastingSlot slot = EQ::spells::CastingSlot::Item, uint16 mana_used = 0,
-		uint32 inventory_slot = 0xFFFFFFFF, int16 resist_adjust = 0, bool isproc = false, int level_override = -1);
+		uint32 inventory_slot = 0xFFFFFFFF, int16 resist_adjust = 0, bool isproc = false, int level_override = -1, uint32 timer = 0xFFFFFFFF, uint32 timer_duration = 0);
 	void SendBeginCast(uint16 spell_id, uint32 casttime);
 	virtual bool SpellOnTarget(uint16 spell_id, Mob* spelltar, int reflect_effectiveness = 0,
 		bool use_resist_adjust = false, int16 resist_adjust = 0, bool isproc = false, int level_override = -1, int32 duration_override = 0);
@@ -347,7 +347,7 @@ public:
 	void StopCasting();
 	inline bool IsCasting() const { return((casting_spell_id != 0)); }
 	uint16 CastingSpellID() const { return casting_spell_id; }
-	bool DoCastingChecks();
+	bool DoCastingChecks(int32 spell_id = SPELL_UNKNOWN, uint16 target_id = 0);
 	bool TryDispel(uint8 caster_level, uint8 buff_level, int level_modifier);
 	bool TrySpellProjectile(Mob* spell_target,  uint16 spell_id, float speed = 1.5f);
 	void ResourceTap(int32 damage, uint16 spell_id);

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3791,8 +3791,10 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 		}
 	}
 
-	// invuln mobs can't be affected by any spells, good or bad
-	if(spelltar->GetInvul() || spelltar->DivineAura()) {
+	// invuln mobs can't be affected by any spells, good or bad, except if caster is casting a spell with 'cast_not_standing' on self.
+	if ((spelltar->GetInvul() && !spelltar->DivineAura()) ||
+		(spelltar != this && spelltar->DivineAura()) ||
+		(spelltar == this && spelltar->DivineAura() && !spells[spell_id].cast_not_standing)) {
 		LogSpells("Casting spell [{}] on [{}] aborted: they are invulnerable", spell_id, spelltar->GetName());
 		safe_delete(action_packet);
 		return false;

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -219,8 +219,8 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 		return(false);
 	}
 
-	//cannot cast under divine aura
-	if(DivineAura()) {
+	//cannot cast under divine aura, unless spell has 'cast_not_standing' flag. 
+	if(DivineAura() && !spells[spell_id].cast_not_standing) {
 		LogSpells("Spell casting canceled: cannot cast while Divine Aura is in effect");
 		InterruptSpell(173, 0x121, false);
 		if(IsClient()) {

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -162,6 +162,8 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 	LogSpells("CastSpell called for spell [{}] ([{}]) on entity [{}], slot [{}], time [{}], mana [{}], from item slot [{}]",
 		(IsValidSpell(spell_id))?spells[spell_id].name:"UNKNOWN SPELL", spell_id, target_id, static_cast<int>(slot), cast_time, mana_cost, (item_slot==0xFFFFFFFF)?999:item_slot);
 
+	Shout("[casting_spell_id %i ] Cast spell %i Slot %i [%s]", casting_spell_id, spell_id, slot, spells[spell_id].name);
+
 	if(casting_spell_id == spell_id)
 		ZeroCastingVars();
 
@@ -193,6 +195,8 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 		if (casting_spell_id && IsNPC()) {
 			CastToNPC()->AI_Event_SpellCastFinished(false, static_cast<uint16>(casting_spell_slot));
 		}
+		Shout("Abort");
+		SpellFinished(spell_id, entity_list.GetMob(target_id), CastingSlot::Discipline);
 		return(false);
 	}
 	//It appears that the Sanctuary effect is removed by a check on the client side (keep this however for redundancy)
@@ -2580,6 +2584,7 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, CastingSlot slot, ui
 		else if(spell_id == casting_spell_id && casting_spell_timer != 0xFFFFFFFF)
 		{
 			//aa new todo: aa expendable charges here
+			Shout("SET DISC INTERNAL RECAST HERE");
 			CastToClient()->GetPTimers().Start(casting_spell_timer, casting_spell_timer_duration);
 			LogSpells("Spell [{}]: Setting custom reuse timer [{}] to [{}]", spell_id, casting_spell_timer, casting_spell_timer_duration);
 		}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -162,9 +162,9 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 	LogSpells("CastSpell called for spell [{}] ([{}]) on entity [{}], slot [{}], time [{}], mana [{}], from item slot [{}]",
 		(IsValidSpell(spell_id))?spells[spell_id].name:"UNKNOWN SPELL", spell_id, target_id, static_cast<int>(slot), cast_time, mana_cost, (item_slot==0xFFFFFFFF)?999:item_slot);
 
-	if (casting_spell_id == spell_id)
+	if (casting_spell_id == spell_id) {
 		ZeroCastingVars();
-	
+	}
 	if
 	(
 		!IsValidSpell(spell_id) ||
@@ -193,7 +193,6 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 		if (casting_spell_id && IsNPC()) {
 			CastToNPC()->AI_Event_SpellCastFinished(false, static_cast<uint16>(casting_spell_slot));
 		}
-
 		return(false);
 	}
 	//It appears that the Sanctuary effect is removed by a check on the client side (keep this however for redundancy)
@@ -630,15 +629,20 @@ bool Mob::DoCastingChecks(int32 spell_id, uint16 target_id)
 		return true;
 	}
 
-	bool set_state_variable = false;
+	bool ignore_casting_spell_checks = false;
+	/*
+		If variables are passed into this function it is NOT being called from main spell process
+		thefore we do not want to set the 'casting_spell_checks' state keeping variable.
+	*/
+	if (spell_id != SPELL_UNKNOWN || target_id) {
+		ignore_casting_spell_checks = true;
+	}
 
 	if (spell_id == SPELL_UNKNOWN) {
 		spell_id = casting_spell_id;
-		set_state_variable = true;
 	}
 	if (!target_id) {
 		target_id = casting_spell_targetid;
-		set_state_variable = true;
 	}
 
 	Mob *spell_target = entity_list.GetMob(target_id);
@@ -678,7 +682,7 @@ bool Mob::DoCastingChecks(int32 spell_id, uint16 target_id)
 		if (!CastToClient()->IsLinkedSpellReuseTimerReady(spells[spell_id].timer_id))
 			return false;
 
-	if (set_state_variable) {
+	if (!ignore_casting_spell_checks){
 		casting_spell_checks = true;
 	}
 	return true;


### PR DESCRIPTION
Bards on live can use disciplines while casting a song or using /melody. This update provides support for that.

Also added  live like support for spell field 'cast not standing' to allowing allow when divine aura is present on the character.