### PR TITLE
[Combat] Legacy Combat Middleware Affected by PR #1858

### DIFF
--- a/utils/mods/legacy_combat.lua
+++ b/utils/mods/legacy_combat.lua
@@ -962,15 +962,14 @@ function CommonOutgoingHitSuccess(e)
 			)
 	);
 
-	e.hit.damage_done = e.hit.damage_done + (e.hit.damage_done * e.other:GetSkillDmgTaken(e.hit.skill) / 100) + (e.self:GetSkillDmgAmt(e.hit.skill) + e.other:GetFcDamageAmtIncoming(e.self, 0, true, e.hit.skill));
+	e.hit.damage_done = e.hit.damage_done + (e.hit.damage_done * e.other:GetSkillDmgTaken(e.hit.skill) / 100) + e.self:GetSkillDmgAmt(e.hit.skill);
 
 	eq.log_combat(
-			string.format("[%s] [Mob::CommonOutgoingHitSuccess] Dmg [%i] SkillDmgTaken [%i] SkillDmgtAmt [%i] FcDmgAmtIncoming [%i] Post DmgCalcs",
+			string.format("[%s] [Mob::CommonOutgoingHitSuccess] Dmg [%i] SkillDmgTaken [%i] SkillDmgtAmt [%i] Post DmgCalcs",
 					e.self:GetCleanName(),
 					e.hit.damage_done,
 					e.other:GetSkillDmgTaken(e.hit.skill),
-					e.self:GetSkillDmgAmt(e.hit.skill),
-					e.other:GetFcDamageAmtIncoming(e.self, 0, true, e.hit.skill)
+					e.self:GetSkillDmgAmt(e.hit.skill)
 			)
 	);
 


### PR DESCRIPTION
After a few hours of chasing our tails (Kayen, Drac and I) during upgrading EZ's code; NPC scaling was heavily out of whack. After digging through tons of logs and narrowing things down it looks like it is related to a function being bound to Lua that now has a signature change. Because this signature has changed the middleware needs to change. Since the function really isn't needed to begin with it has been removed entirely.

Affected by PR #1858 

![image](https://user-images.githubusercontent.com/3319450/150288049-cd66fe76-e6df-483e-a438-d92ac9c69613.png)
