### PR TITLE
[Content Filtering] Updates contents flags to be checked at runtime.

### DIFF
--- a/common/content/world_content_service.cpp
+++ b/common/content/world_content_service.cpp
@@ -157,11 +157,11 @@ bool WorldContentService::IsContentFlagDisabled(const std::string &content_flag)
 
 bool WorldContentService::DoesPassContentFiltering(const ContentFlags &content_flags)
 {
-	if (content_flags.min_expansion >= 0 && current_expansion < content_flags.min_expansion) {
+	if (content_flags.min_expansion > Expansion::EXPANSION_ALL && current_expansion <= content_flags.min_expansion) {
 		return false;
 	}
 
-	if (content_flags.max_expansion >= 0 && current_expansion > content_flags.max_expansion) {
+	if (content_flags.max_expansion > Expansion::EXPANSION_ALL && current_expansion >= content_flags.max_expansion) {
 		return false;
 	}
 

--- a/common/content/world_content_service.cpp
+++ b/common/content/world_content_service.cpp
@@ -155,23 +155,24 @@ bool WorldContentService::IsContentFlagDisabled(const std::string &content_flag)
 	return false;
 }
 
-bool WorldContentService::DoesPassContentFiltering(const ContentFlags_Struct& content_flags) {
-	if(content_flags.min_expansion >= 0 && current_expansion < content_flags.min_expansion) {
+bool WorldContentService::DoesPassContentFiltering(const ContentFlags &content_flags)
+{
+	if (content_flags.min_expansion >= 0 && current_expansion < content_flags.min_expansion) {
 		return false;
 	}
 
-	if(content_flags.max_expansion >= 0 && current_expansion > content_flags.max_expansion) {
+	if (content_flags.max_expansion >= 0 && current_expansion > content_flags.max_expansion) {
 		return false;
 	}
 
-	for(auto content_flag : SplitString(content_flags.content_flags)) {
-		if(!contains(GetContentFlagsEnabled(), content_flag)) {
+	for (const auto& content_flag: SplitString(content_flags.content_flags)) {
+		if (!contains(GetContentFlagsEnabled(), content_flag)) {
 			return false;
 		}
 	}
 
-	for(auto content_flag : SplitString(content_flags.content_flags_disabled)) {
-		if(!contains(GetContentFlagsDisabled(), content_flag)) {
+	for (const auto& content_flag: SplitString(content_flags.content_flags_disabled)) {
+		if (!contains(GetContentFlagsDisabled(), content_flag)) {
 			return false;
 		}
 	}

--- a/common/content/world_content_service.cpp
+++ b/common/content/world_content_service.cpp
@@ -157,11 +157,11 @@ bool WorldContentService::IsContentFlagDisabled(const std::string &content_flag)
 
 bool WorldContentService::DoesPassContentFiltering(const ContentFlags &content_flags)
 {
-	if (content_flags.min_expansion > Expansion::EXPANSION_ALL && current_expansion <= content_flags.min_expansion) {
+	if (content_flags.min_expansion > Expansion::EXPANSION_ALL && current_expansion < content_flags.min_expansion) {
 		return false;
 	}
 
-	if (content_flags.max_expansion > Expansion::EXPANSION_ALL && current_expansion >= content_flags.max_expansion) {
+	if (content_flags.max_expansion > Expansion::EXPANSION_ALL && current_expansion > content_flags.max_expansion) {
 		return false;
 	}
 

--- a/common/content/world_content_service.cpp
+++ b/common/content/world_content_service.cpp
@@ -139,6 +139,47 @@ bool WorldContentService::IsContentFlagEnabled(const std::string &content_flag)
 	return false;
 }
 
+/**
+ * @param content_flag
+ * @return
+ */
+bool WorldContentService::IsContentFlagDisabled(const std::string &content_flag)
+{
+	for (auto &f: GetContentFlags()) {
+		if (f.flag_name == content_flag && f.enabled == false) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool WorldContentService::DoEnabledFlagsPass(const char *content_flags) {
+	if(strlen(content_flags) == 0)
+		return true;
+
+	auto split_content_flags = SplitString(std::string(content_flags));
+
+	for (auto content_flag : split_content_flags)
+		if(this->IsContentFlagEnabled(content_flag))
+			return true;
+
+	return false;
+}
+
+bool WorldContentService::DoDisabledFlagsPass(const char *content_flags) {
+	if(strlen(content_flags) == 0)
+		return true;
+
+	auto split_content_flags = SplitString(std::string(content_flags));
+
+	for (const auto& content_flag : split_content_flags)
+		if(this->IsContentFlagDisabled(content_flag))
+			return true;
+
+	return false;
+}
+
 void WorldContentService::ReloadContentFlags()
 {
 	std::vector<ContentFlagsRepository::ContentFlags> set_content_flags;

--- a/common/content/world_content_service.cpp
+++ b/common/content/world_content_service.cpp
@@ -166,12 +166,14 @@ bool WorldContentService::DoesPassContentFiltering(const ContentFlags &f)
 		return true;
 	}
 
+	// if we have any enabled flag in enabled flags, we pass
 	for (const auto &content_flag: SplitString(f.content_flags)) {
 		if (contains(GetContentFlagsEnabled(), content_flag)) {
 			return true;
 		}
 	}
 
+	// if we have any disabled flag in disabled flags, we pass
 	for (const auto &content_flag: SplitString(f.content_flags_disabled)) {
 		if (contains(GetContentFlagsDisabled(), content_flag)) {
 			return true;

--- a/common/content/world_content_service.cpp
+++ b/common/content/world_content_service.cpp
@@ -157,30 +157,31 @@ bool WorldContentService::IsContentFlagDisabled(const std::string &content_flag)
 
 bool WorldContentService::DoesPassContentFiltering(const ContentFlags &f)
 {
-	// if min or max expansion is -1 we're clear
-	// if both min and max expansion are set, we need to properly filter by both
-	if ((f.min_expansion == Expansion::EXPANSION_ALL && f.max_expansion == Expansion::EXPANSION_ALL) ||
-		(f.min_expansion > Expansion::EXPANSION_ALL && current_expansion >= f.min_expansion &&
-		 f.max_expansion > Expansion::EXPANSION_ALL && current_expansion <= f.max_expansion
-		)) {
-		return true;
+	// if we're not set to (-1 All) then fail when we aren't within minimum expansion
+	if (f.min_expansion > Expansion::EXPANSION_ALL && current_expansion < f.min_expansion) {
+		return false;
 	}
 
-	// if we have any enabled flag in enabled flags, we pass
-	for (const auto &content_flag: SplitString(f.content_flags)) {
-		if (contains(GetContentFlagsEnabled(), content_flag)) {
-			return true;
+	// if we're not set to (-1 All) then fail when we aren't within max expansion
+	if (f.max_expansion > Expansion::EXPANSION_ALL && current_expansion > f.max_expansion) {
+		return false;
+	}
+
+	// if we don't have any enabled flag in enabled flags, we fail
+	for (const auto& flag: SplitString(f.content_flags)) {
+		if (!contains(GetContentFlagsEnabled(), flag)) {
+			return false;
 		}
 	}
 
-	// if we have any disabled flag in disabled flags, we pass
-	for (const auto &content_flag: SplitString(f.content_flags_disabled)) {
-		if (contains(GetContentFlagsDisabled(), content_flag)) {
-			return true;
+	// if we don't have any disabled flag in disabled flags, we fail
+	for (const auto& flag: SplitString(f.content_flags_disabled)) {
+		if (!contains(GetContentFlagsDisabled(), flag)) {
+			return false;
 		}
 	}
 
-	return false;
+	return true;
 }
 
 void WorldContentService::ReloadContentFlags()

--- a/common/content/world_content_service.cpp
+++ b/common/content/world_content_service.cpp
@@ -160,9 +160,11 @@ bool WorldContentService::DoEnabledFlagsPass(const char *content_flags) {
 
 	auto split_content_flags = SplitString(std::string(content_flags));
 
-	for (auto content_flag : split_content_flags)
-		if(this->IsContentFlagEnabled(content_flag))
+	for (auto content_flag : split_content_flags) {
+		if(IsContentFlagEnabled(content_flag)) {
 			return true;
+		}
+	}
 
 	return false;
 }
@@ -173,9 +175,11 @@ bool WorldContentService::DoDisabledFlagsPass(const char *content_flags) {
 
 	auto split_content_flags = SplitString(std::string(content_flags));
 
-	for (const auto& content_flag : split_content_flags)
-		if(this->IsContentFlagDisabled(content_flag))
+	for (const auto& content_flag : split_content_flags) {
+		if(IsContentFlagDisabled(content_flag)) {
 			return true;
+		}
+	}
 
 	return false;
 }

--- a/common/content/world_content_service.h
+++ b/common/content/world_content_service.h
@@ -171,7 +171,7 @@ public:
 	void ReloadContentFlags();
 	WorldContentService * SetExpansionContext();
 
-	bool DoesPassContentFiltering(const ContentFlags& content_flags);
+	bool DoesPassContentFiltering(const ContentFlags& f);
 
 	WorldContentService * SetDatabase(Database *database);
 	Database *GetDatabase() const;

--- a/common/content/world_content_service.h
+++ b/common/content/world_content_service.h
@@ -165,9 +165,13 @@ public:
 	std::vector<std::string> GetContentFlagsEnabled();
 	std::vector<std::string> GetContentFlagsDisabled();
 	bool IsContentFlagEnabled(const std::string& content_flag);
+	bool IsContentFlagDisabled(const std::string& content_flag);
 	void SetContentFlags(std::vector<ContentFlagsRepository::ContentFlags> content_flags);
 	void ReloadContentFlags();
 	WorldContentService * SetExpansionContext();
+
+	bool DoEnabledFlagsPass(const char *content_flags);
+	bool DoDisabledFlagsPass(const char *content_flags);
 
 	WorldContentService * SetDatabase(Database *database);
 	Database *GetDatabase() const;

--- a/common/content/world_content_service.h
+++ b/common/content/world_content_service.h
@@ -23,6 +23,7 @@
 
 #include <string>
 #include <vector>
+#include "../loottable.h"
 #include "../repositories/content_flags_repository.h"
 
 class Database;
@@ -170,8 +171,7 @@ public:
 	void ReloadContentFlags();
 	WorldContentService * SetExpansionContext();
 
-	bool DoEnabledFlagsPass(const char *content_flags);
-	bool DoDisabledFlagsPass(const char *content_flags);
+	bool DoesPassContentFiltering(const ContentFlags_Struct& content_flags);
 
 	WorldContentService * SetDatabase(Database *database);
 	Database *GetDatabase() const;

--- a/common/content/world_content_service.h
+++ b/common/content/world_content_service.h
@@ -171,7 +171,7 @@ public:
 	void ReloadContentFlags();
 	WorldContentService * SetExpansionContext();
 
-	bool DoesPassContentFiltering(const ContentFlags_Struct& content_flags);
+	bool DoesPassContentFiltering(const ContentFlags& content_flags);
 
 	WorldContentService * SetDatabase(Database *database);
 	Database *GetDatabase() const;

--- a/common/loottable.h
+++ b/common/loottable.h
@@ -35,6 +35,8 @@ struct LootTable_Struct {
 	uint32	maxcash;
 	uint32	avgcoin;
 	uint32	NumEntries;
+	char content_flags[100];
+	char content_flags_disabled[100];
 	LootTableEntries_Struct Entries[0];
 };
 
@@ -52,6 +54,8 @@ struct LootDropEntries_Struct {
 
 struct LootDrop_Struct {
 	uint32	NumEntries;
+	char content_flags[100];
+	char content_flags_disabled[100];
 	LootDropEntries_Struct Entries[0];
 };
 #pragma pack()

--- a/common/loottable.h
+++ b/common/loottable.h
@@ -30,19 +30,19 @@ struct LootTableEntries_Struct {
 	float	probability;
 };
 
-struct ContentFlags_Struct {
+struct ContentFlags {
 	int16 min_expansion;
 	int16 max_expansion;
-	char content_flags[100];
-	char content_flags_disabled[100];
+	char  content_flags[100];
+	char  content_flags_disabled[100];
 };
 
 struct LootTable_Struct {
-	uint32	mincash;
-	uint32	maxcash;
-	uint32	avgcoin;
-	uint32	NumEntries;
-	ContentFlags_Struct content_flags;
+	uint32                  mincash;
+	uint32                  maxcash;
+	uint32                  avgcoin;
+	uint32                  NumEntries;
+	ContentFlags            content_flags;
 	LootTableEntries_Struct Entries[0];
 };
 
@@ -59,8 +59,8 @@ struct LootDropEntries_Struct {
 };
 
 struct LootDrop_Struct {
-	uint32	NumEntries;
-	ContentFlags_Struct content_flags;
+	uint32                 NumEntries;
+	ContentFlags           content_flags;
 	LootDropEntries_Struct Entries[0];
 };
 #pragma pack()

--- a/common/loottable.h
+++ b/common/loottable.h
@@ -30,13 +30,19 @@ struct LootTableEntries_Struct {
 	float	probability;
 };
 
+struct ContentFlags_Struct {
+	int16 min_expansion;
+	int16 max_expansion;
+	char content_flags[100];
+	char content_flags_disabled[100];
+};
+
 struct LootTable_Struct {
 	uint32	mincash;
 	uint32	maxcash;
 	uint32	avgcoin;
 	uint32	NumEntries;
-	char content_flags[100];
-	char content_flags_disabled[100];
+	ContentFlags_Struct content_flags;
 	LootTableEntries_Struct Entries[0];
 };
 
@@ -54,8 +60,7 @@ struct LootDropEntries_Struct {
 
 struct LootDrop_Struct {
 	uint32	NumEntries;
-	char content_flags[100];
-	char content_flags_disabled[100];
+	ContentFlags_Struct content_flags;
 	LootDropEntries_Struct Entries[0];
 };
 #pragma pack()

--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -2019,7 +2019,8 @@ void SharedDatabase::GetLootTableInfo(uint32 &loot_table_count, uint32 &max_loot
 	loot_table_entries = 0;
 	const std::string query =
 		fmt::format(
-			"SELECT COUNT(*), MAX(id), (SELECT COUNT(*) FROM loottable_entries) FROM loottable"
+			"SELECT COUNT(*), MAX(id), (SELECT COUNT(*) FROM loottable_entries) FROM loottable WHERE TRUE {}",
+			ContentFilterCriteria::apply()
 		);
     auto results = QueryDatabase(query);
     if (!results.Success()) {
@@ -2042,7 +2043,8 @@ void SharedDatabase::GetLootDropInfo(uint32 &loot_drop_count, uint32 &max_loot_d
 	loot_drop_entries = 0;
 
 	const std::string query = fmt::format(
-		"SELECT COUNT(*), MAX(id), (SELECT COUNT(*) FROM lootdrop_entries) FROM lootdrop"
+		"SELECT COUNT(*), MAX(id), (SELECT COUNT(*) FROM lootdrop_entries) FROM lootdrop WHERE TRUE {}",
+		ContentFilterCriteria::apply()
 	);
 
     auto results = QueryDatabase(query);
@@ -2073,19 +2075,23 @@ void SharedDatabase::LoadLootTables(void *data, uint32 size) {
 			  loottable.mincash,
 			  loottable.maxcash,
 			  loottable.avgcoin,
-			  COALESCE(loottable.content_flags, ''),
-			  COALESCE(loottable.content_flags_disabled, ''),
 			  loottable_entries.lootdrop_id,
 			  loottable_entries.multiplier,
 			  loottable_entries.droplimit,
 			  loottable_entries.mindrop,
-			  loottable_entries.probability
+			  loottable_entries.probability,
+			  loottable.min_expansion,
+			  loottable.max_expansion,
+			  loottable.content_flags,
+			  loottable.content_flags_disabled
 			FROM
 			  loottable
 			  LEFT JOIN loottable_entries ON loottable.id = loottable_entries.loottable_id
+			WHERE TRUE {}
 			ORDER BY
 			  id
-			)
+			),
+			ContentFilterCriteria::apply()
 		);
 
     auto results = QueryDatabase(query);
@@ -2112,24 +2118,27 @@ void SharedDatabase::LoadLootTables(void *data, uint32 size) {
 			lt->mincash = static_cast<uint32>(atoul(row[1]));
 			lt->maxcash = static_cast<uint32>(atoul(row[2]));
 			lt->avgcoin = static_cast<uint32>(atoul(row[3]));
-		}
 
-		strn0cpy(lt->content_flags, row[4], sizeof(lt->content_flags));
-		strn0cpy(lt->content_flags_disabled, row[5], sizeof(lt->content_flags_disabled));
+			lt->content_flags.min_expansion = static_cast<int16>(atoi(row[9]));
+			lt->content_flags.max_expansion = static_cast<int16>(atoi(row[10]));
+
+			strn0cpy(lt->content_flags.content_flags,          row[11], sizeof(lt->content_flags.content_flags));
+			strn0cpy(lt->content_flags.content_flags_disabled, row[12],  sizeof(lt->content_flags.content_flags_disabled));
+		}
 
 		if (current_entry > 128) {
 			continue;
 		}
 
-		if (!row[6]) {
+		if (!row[4]) {
 			continue;
 		}
 
-		lt->Entries[current_entry].lootdrop_id = static_cast<uint32>(atoul(row[6]));
-		lt->Entries[current_entry].multiplier  = static_cast<uint8>(atoi(row[7]));
-		lt->Entries[current_entry].droplimit   = static_cast<uint8>(atoi(row[8]));
-		lt->Entries[current_entry].mindrop     = static_cast<uint8>(atoi(row[9]));
-		lt->Entries[current_entry].probability = static_cast<float>(atof(row[10]));
+		lt->Entries[current_entry].lootdrop_id = static_cast<uint32>(atoul(row[4]));
+		lt->Entries[current_entry].multiplier  = static_cast<uint8>(atoi(row[5]));
+		lt->Entries[current_entry].droplimit   = static_cast<uint8>(atoi(row[6]));
+		lt->Entries[current_entry].mindrop     = static_cast<uint8>(atoi(row[7]));
+		lt->Entries[current_entry].probability = static_cast<float>(atof(row[8]));
 
 		++(lt->NumEntries);
 		++current_entry;
@@ -2155,8 +2164,6 @@ void SharedDatabase::LoadLootDrops(void *data, uint32 size) {
 		SQL(
 			SELECT
 			  lootdrop.id,
-			  COALESCE(lootdrop.content_flags, ''),
-			  COALESCE(lootdrop.content_flags_disabled, ''),
 			  lootdrop_entries.item_id,
 			  lootdrop_entries.item_charges,
 			  lootdrop_entries.equip_item,
@@ -2165,13 +2172,20 @@ void SharedDatabase::LoadLootDrops(void *data, uint32 size) {
 			  lootdrop_entries.trivial_max_level,
 			  lootdrop_entries.npc_min_level,
 			  lootdrop_entries.npc_max_level,
-			  lootdrop_entries.multiplier
+			  lootdrop_entries.multiplier,
+			  lootdrop.min_expansion,
+			  lootdrop.max_expansion,
+			  lootdrop.content_flags,
+			  lootdrop.content_flags_disabled
 			FROM
 			  lootdrop
 			  JOIN lootdrop_entries ON lootdrop.id = lootdrop_entries.lootdrop_id
+			WHERE
+			  TRUE {}
 			ORDER BY
 			  lootdrop_id
-		)
+		),
+		ContentFilterCriteria::apply()
 	);
 
     auto results = QueryDatabase(query);
@@ -2195,24 +2209,27 @@ void SharedDatabase::LoadLootDrops(void *data, uint32 size) {
 			memset(loot_drop, 0, sizeof(LootDrop_Struct) + (sizeof(LootDropEntries_Struct) * 1260));
 			current_entry = 0;
 			current_id    = id;
-		}
 
-		strn0cpy(p_loot_drop_struct->content_flags, row[1], sizeof(p_loot_drop_struct->content_flags));
-		strn0cpy(p_loot_drop_struct->content_flags_disabled, row[2], sizeof(p_loot_drop_struct->content_flags_disabled));
+			p_loot_drop_struct->content_flags.min_expansion = static_cast<int16>(atoi(row[10]));
+			p_loot_drop_struct->content_flags.max_expansion = static_cast<int16>(atoi(row[11]));
+
+			strn0cpy(p_loot_drop_struct->content_flags.content_flags,          row[12], sizeof(p_loot_drop_struct->content_flags.content_flags));
+			strn0cpy(p_loot_drop_struct->content_flags.content_flags_disabled, row[13], sizeof(p_loot_drop_struct->content_flags.content_flags_disabled));
+		}
 
 		if (current_entry >= 1260) {
 			continue;
 		}
 
-		p_loot_drop_struct->Entries[current_entry].item_id           = static_cast<uint32>(atoul(row[3]));
-		p_loot_drop_struct->Entries[current_entry].item_charges      = static_cast<int8>(atoi(row[4]));
-		p_loot_drop_struct->Entries[current_entry].equip_item        = static_cast<uint8>(atoi(row[5]));
-		p_loot_drop_struct->Entries[current_entry].chance            = static_cast<float>(atof(row[6]));
-		p_loot_drop_struct->Entries[current_entry].trivial_min_level = static_cast<uint16>(atoi(row[7]));
-		p_loot_drop_struct->Entries[current_entry].trivial_max_level = static_cast<uint16>(atoi(row[8]));
-		p_loot_drop_struct->Entries[current_entry].npc_min_level     = static_cast<uint16>(atoi(row[9]));
-		p_loot_drop_struct->Entries[current_entry].npc_max_level     = static_cast<uint16>(atoi(row[10]));
-		p_loot_drop_struct->Entries[current_entry].multiplier        = static_cast<uint8>(atoi(row[11]));
+		p_loot_drop_struct->Entries[current_entry].item_id           = static_cast<uint32>(atoul(row[1]));
+		p_loot_drop_struct->Entries[current_entry].item_charges      = static_cast<int8>(atoi(row[2]));
+		p_loot_drop_struct->Entries[current_entry].equip_item        = static_cast<uint8>(atoi(row[3]));
+		p_loot_drop_struct->Entries[current_entry].chance            = static_cast<float>(atof(row[4]));
+		p_loot_drop_struct->Entries[current_entry].trivial_min_level = static_cast<uint16>(atoi(row[5]));
+		p_loot_drop_struct->Entries[current_entry].trivial_max_level = static_cast<uint16>(atoi(row[6]));
+		p_loot_drop_struct->Entries[current_entry].npc_min_level     = static_cast<uint16>(atoi(row[7]));
+		p_loot_drop_struct->Entries[current_entry].npc_max_level     = static_cast<uint16>(atoi(row[8]));
+		p_loot_drop_struct->Entries[current_entry].multiplier        = static_cast<uint8>(atoi(row[9]));
 
 		++(p_loot_drop_struct->NumEntries);
 		++current_entry;

--- a/common/string_util.cpp
+++ b/common/string_util.cpp
@@ -1021,6 +1021,11 @@ std::vector<std::string> GetBadWords()
 	};
 }
 
+bool contains(std::vector<std::string> container, std::string element)
+{
+    return std::find(container.begin(), container.end(), element) != container.end();
+}
+
 std::string ConvertSecondsToTime(int duration, bool is_milliseconds)
 {
 	if (duration <= 0) {

--- a/common/string_util.h
+++ b/common/string_util.h
@@ -218,6 +218,7 @@ void SanitizeWorldServerName(char *name);
 std::string SanitizeWorldServerName(std::string server_long_name);
 std::string repeat(std::string s, int n);
 std::vector<std::string> GetBadWords();
+bool contains(std::vector<std::string> container, std::string element);
 
 template<typename InputIterator, typename OutputIterator>
 auto CleanMobName(InputIterator first, InputIterator last, OutputIterator result)

--- a/shared_memory/main.cpp
+++ b/shared_memory/main.cpp
@@ -167,6 +167,9 @@ int main(int argc, char **argv)
 
 
 	content_service.SetCurrentExpansion(RuleI(Expansion, CurrentExpansion));
+	content_service.SetDatabase(&database)
+		->SetExpansionContext()
+		->ReloadContentFlags();
 
 	LogInfo(
 		"Current expansion is [{}] ({})",

--- a/shared_memory/main.cpp
+++ b/shared_memory/main.cpp
@@ -167,9 +167,6 @@ int main(int argc, char **argv)
 
 
 	content_service.SetCurrentExpansion(RuleI(Expansion, CurrentExpansion));
-	content_service.SetDatabase(&database)
-		->SetExpansionContext()
-		->ReloadContentFlags();
 
 	LogInfo(
 		"Current expansion is [{}] ({})",

--- a/zone/loottables.cpp
+++ b/zone/loottables.cpp
@@ -51,11 +51,13 @@ void ZoneDatabase::AddLootTableToNPC(NPC* npc,uint32 loottable_id, ItemList* ite
 	}
 
 	lts = database.GetLootTable(loottable_id);
-	if (!lts)
+	if (!lts) {
 		return;
+	}
 
-	if(!content_service.DoesPassContentFiltering(lts->content_flags))
+	if (!content_service.DoesPassContentFiltering(lts->content_flags)) {
 		return;
+	}
 
 	uint32 min_cash = lts->mincash;
 	uint32 max_cash = lts->maxcash;
@@ -131,8 +133,9 @@ void ZoneDatabase::AddLootDropToNPC(NPC *npc, uint32 lootdrop_id, ItemList *item
 		return;
 	}
 
-	if(!content_service.DoesPassContentFiltering(loot_drop->content_flags))
+	if (!content_service.DoesPassContentFiltering(loot_drop->content_flags)) {
 		return;
+	}
 
 	// if this lootdrop is droplimit=0 and mindrop 0, scan list once and return
 	if (droplimit == 0 && mindrop == 0) {

--- a/zone/loottables.cpp
+++ b/zone/loottables.cpp
@@ -54,11 +54,7 @@ void ZoneDatabase::AddLootTableToNPC(NPC* npc,uint32 loottable_id, ItemList* ite
 	if (!lts)
 		return;
 
-
-	if(!content_service.DoEnabledFlagsPass(lts->content_flags))
-		return;
-
-	if(!content_service.DoDisabledFlagsPass(lts->content_flags_disabled))
+	if(!content_service.DoesPassContentFiltering(lts->content_flags))
 		return;
 
 	uint32 min_cash = lts->mincash;
@@ -135,10 +131,7 @@ void ZoneDatabase::AddLootDropToNPC(NPC *npc, uint32 lootdrop_id, ItemList *item
 		return;
 	}
 
-	if(!content_service.DoEnabledFlagsPass(loot_drop->content_flags))
-		return;
-
-	if(!content_service.DoDisabledFlagsPass(loot_drop->content_flags_disabled))
+	if(!content_service.DoesPassContentFiltering(loot_drop->content_flags))
 		return;
 
 	// if this lootdrop is droplimit=0 and mindrop 0, scan list once and return

--- a/zone/loottables.cpp
+++ b/zone/loottables.cpp
@@ -54,6 +54,13 @@ void ZoneDatabase::AddLootTableToNPC(NPC* npc,uint32 loottable_id, ItemList* ite
 	if (!lts)
 		return;
 
+
+	if(!content_service.DoEnabledFlagsPass(lts->content_flags))
+		return;
+
+	if(!content_service.DoDisabledFlagsPass(lts->content_flags_disabled))
+		return;
+
 	uint32 min_cash = lts->mincash;
 	uint32 max_cash = lts->maxcash;
 	if(min_cash > max_cash) {
@@ -127,6 +134,12 @@ void ZoneDatabase::AddLootDropToNPC(NPC *npc, uint32 lootdrop_id, ItemList *item
 	if (loot_drop->NumEntries == 0) {
 		return;
 	}
+
+	if(!content_service.DoEnabledFlagsPass(loot_drop->content_flags))
+		return;
+
+	if(!content_service.DoDisabledFlagsPass(loot_drop->content_flags_disabled))
+		return;
 
 	// if this lootdrop is droplimit=0 and mindrop 0, scan list once and return
 	if (droplimit == 0 && mindrop == 0) {
@@ -706,4 +719,3 @@ void ZoneDatabase::LoadGlobalLoot()
 		zone->AddGlobalLootEntry(e);
 	}
 }
-


### PR DESCRIPTION
This helps remove the need to restart server when changing content flags. If you change a flag from enabled to disabled or back, all it requires is a `#reloadcontentflags` and then a `#repop`. If you change the flags on a loottable or lootdrop, then you have to also do a `#hotfix` before `#repop`. 