### PR TITLE
[Spells] NPC spell push should work on rooted mobs.

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4234,7 +4234,7 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 				spelltar->CastToClient()->cheat_manager.SetExemptStatus(KnockBack, true);
 			}
 		}
-		else if (RuleB(Spells, NPCSpellPush) && spelltar->ForcedMovement == 0) {
+		else if (RuleB(Spells, NPCSpellPush) && !permarooted && !IsPseudoRooted() && spelltar->ForcedMovement == 0) {
 			spelltar->m_Delta.x += action->force * g_Math.FastSin(action->hit_heading);
 			spelltar->m_Delta.y += action->force * g_Math.FastCos(action->hit_heading);
 			spelltar->m_Delta.z += action->hit_pitch;

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4234,7 +4234,7 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 				spelltar->CastToClient()->cheat_manager.SetExemptStatus(KnockBack, true);
 			}
 		}
-		else if (RuleB(Spells, NPCSpellPush) && !spelltar->IsRooted() && spelltar->ForcedMovement == 0) {
+		else if (RuleB(Spells, NPCSpellPush) && spelltar->ForcedMovement == 0) {
 			spelltar->m_Delta.x += action->force * g_Math.FastSin(action->hit_heading);
 			spelltar->m_Delta.y += action->force * g_Math.FastCos(action->hit_heading);
 			spelltar->m_Delta.z += action->hit_pitch;


### PR DESCRIPTION
On live spells will knock back a rooted NPC. Correct code to allow for that.
Need to have RuleB(Spells, NPCSpellPush) = true.

Will not work on permarooted and pseudorooted mobs, these are typically raid encounters.