### PR TITLE
[Bug Fix] Stop spellbar from locking after looting item with recast timer and clicking it.

### DIFF
--- a/zone/client.h
+++ b/zone/client.h
@@ -1491,6 +1491,7 @@ public:
 	void LeaveRaidXTargets(Raid *r);
 	bool GroupFollow(Client* inviter);
 	inline bool  GetRunMode() const { return runmode; }
+	void SendItemRecastTimer(uint32 recast_type, uint32 recast_delay = 0);
 
 	inline bool AggroMeterAvailable() const { return ((m_ClientVersionBit & EQ::versions::maskRoF2AndLater)) && RuleB(Character, EnableAggroMeter); } // RoF untested
 	inline void SetAggroMeterLock(int in) { m_aggrometer.set_lock_id(in); }

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -8887,6 +8887,9 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 					if (item->RecastDelay > 0)
 					{
 						if (!GetPTimers().Expired(&database, (pTimerItemStart + item->RecastType), false)) {
+							SendItemRecastTimer(item->RecastType); //Problem: When you loot corpse, recast display is not present. This causes it to display again. Could not get to display when sending from looting.
+							MessageString(Chat::Red, SPELL_RECAST);
+							SendSpellBarEnable(item->Click.Effect);
 							LogSpells("Casting of [{}] canceled: item spell reuse timer not expired", spell_id);
 							return;
 						}
@@ -8926,6 +8929,7 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 						if (!GetPTimers().Expired(&database, (pTimerItemStart + augitem->RecastType), false)) {
 							LogSpells("Casting of [{}] canceled: item spell reuse timer from augment not expired", spell_id);
 							MessageString(Chat::Red, SPELL_RECAST);
+							SendSpellBarEnable(augitem->Click.Effect);
 							return;
 						}
 					}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -6283,6 +6283,22 @@ void Client::SendSpellAnim(uint16 targetid, uint16 spell_id)
 	entity_list.QueueCloseClients(this, &app, false, RuleI(Range, SpellParticles));
 }
 
+void Client::SendItemRecastTimer(uint32 recast_type, uint32 recast_delay)
+{
+	if (!recast_delay) {
+		recast_delay = GetPTimers().GetRemainingTime(pTimerItemStart + recast_type);
+	}
+
+	if (recast_delay) {
+		auto outapp = new EQApplicationPacket(OP_ItemRecastDelay, sizeof(ItemRecastDelay_Struct));
+		ItemRecastDelay_Struct *ird = (ItemRecastDelay_Struct *)outapp->pBuffer;
+		ird->recast_delay = recast_delay;
+		ird->recast_type = recast_type;
+		QueuePacket(outapp);
+		safe_delete(outapp);
+	}
+}
+
 void Mob::CalcDestFromHeading(float heading, float distance, float MaxZDiff, float StartX, float StartY, float &dX, float &dY, float &dZ)
 {
 	if (!distance) { return; }


### PR DESCRIPTION
This update resolves the problem on ROF2 where if you died with an item with an active recast timer, then looted that item and clicked it before recast timer was up it would lock the clients spell bar. In addition looted items don't show the graphical cool down timer. I was able to get to redisplay but only when attempting to use the item. So clicking it after you loot it will redisplay the count down timer at its current time remaining.