### PR TITLE
[Bug Fix] Any use of TempName left old clean_name.

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -3094,6 +3094,7 @@ void Mob::TempName(const char *newname)
 	char temp_name[64];
 	char old_name[64];
 	strn0cpy(old_name, GetName(), 64);
+	*clean_name = (char) NULL;
 
 	if(newname)
 		strn0cpy(temp_name, newname, 64);
@@ -3102,7 +3103,6 @@ void Mob::TempName(const char *newname)
 	if(!newname) {
 		strn0cpy(temp_name, GetOrigName(), 64);
 		SetName(temp_name);
-		//CleanMobName(GetName(), temp_name);
 		strn0cpy(temp_name, GetCleanName(), 64);
 	}
 

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -3094,7 +3094,7 @@ void Mob::TempName(const char *newname)
 	char temp_name[64];
 	char old_name[64];
 	strn0cpy(old_name, GetName(), 64);
-	*clean_name = (char) NULL;
+	clean_name[0] = 0;
 
 	if(newname)
 		strn0cpy(temp_name, newname, 64);


### PR DESCRIPTION
clean_name is cached by the 1st use of GetCleanName().  Any use of TempName() did not cause that cache to be invalidated.

One resulting bug is that #petname would change the pets name, but would not alter some messages that used GetCleanName() until a zone or a camp.

Simply setting *clean_name to NULL forces a recache on the next call to GetCleanName().