### PR TITLE
[Rules] Implement pet tank toggling + Minor bug fix on taunt button

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -232,6 +232,7 @@ RULE_BOOL(Pets, UnTargetableSwarmPet, false, "Setting whether swarm pets should 
 RULE_REAL(Pets, PetPowerLevelCap, 10, "Maximum number of levels a player pet can go up with pet power")
 RULE_BOOL(Pets, CanTakeNoDrop, false, "Setting whether anyone can give no-drop items to pets")
 RULE_BOOL(Pets, LivelikeBreakCharmOnInvis, true, "Default: true will break charm on any type of invis (hide/ivu/iva/etc) false will only break if the pet can not see you (ex. you have an undead pet and cast IVU")
+RULE_BOOL(Pets, TauntTogglesPetTanking, false, "Setting to true allows player to toggle the 'Allow Tank' (41) special attack flag on their pet by using the Taunt button in the pet window.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(GM)

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1612,8 +1612,10 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 
 			// Taunt persists when zoning on newer clients, overwrite default.
 			if (m_ClientVersionBit & EQ::versions::maskUFAndLater) {
-				if (!firstlogon) {
-					pet->SetTaunting(m_petinfo.taunting);
+				pet->SetTaunting(m_petinfo.taunting);
+				SetPetCommandState(PET_BUTTON_TAUNT, m_petinfo.taunting);
+				if (RuleB(Pets, TauntTogglesPetTanking)) {
+					pet->SetSpecialAbility(41, pet->CastToNPC()->IsTaunting());
 				}
 			}
 		}
@@ -10402,15 +10404,12 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 	}
 	case PET_TAUNT: {
 		if ((mypet->GetPetType() == petAnimation && aabonuses.PetCommands[PetCommand]) || mypet->GetPetType() != petAnimation) {
-			if (mypet->CastToNPC()->IsTaunting())
-			{
-				MessageString(Chat::PetResponse, PET_NO_TAUNT);
-				mypet->CastToNPC()->SetTaunting(false);
-			}
-			else
-			{
-				MessageString(Chat::PetResponse, PET_DO_TAUNT);
-				mypet->CastToNPC()->SetTaunting(true);
+			bool tauntStatus = mypet->CastToNPC()->IsTaunting();
+			MessageString(Chat::PetResponse, tauntStatus ? PET_NO_TAUNT : PET_DO_TAUNT);
+			mypet->CastToNPC()->SetTaunting(!tauntStatus);
+			if (RuleB(Pets, TauntTogglesPetTanking)) {
+				mypet->SetSpecialAbility(41, !tauntStatus);
+				LogDebug("Toggle Pet Tanking: [{}] :: Allow Tank (41): [{}]", mypet->CastToNPC()->IsTaunting() ? "ON" : "OFF", mypet->GetSpecialAbility(41) ? "True" : "False");
 			}
 		}
 		break;

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -10405,12 +10405,13 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 	case PET_TAUNT: {
 		if ((mypet->GetPetType() == petAnimation && aabonuses.PetCommands[PetCommand]) || mypet->GetPetType() != petAnimation) {
 			bool tauntStatus = mypet->CastToNPC()->IsTaunting();
-			MessageString(Chat::PetResponse, tauntStatus ? PET_NO_TAUNT : PET_DO_TAUNT);
 			mypet->CastToNPC()->SetTaunting(!tauntStatus);
 			if (RuleB(Pets, TauntTogglesPetTanking)) {
+				Message(Chat::PetResponse, tauntStatus ? "No longer taunting attackers or holding aggro, Master." : "Taunting attackers and holding aggro as normal, Master.");
 				mypet->SetSpecialAbility(41, !tauntStatus);
-				LogDebug("Toggle Pet Tanking: [{}] :: Allow Tank (41): [{}]", mypet->CastToNPC()->IsTaunting() ? "ON" : "OFF", mypet->GetSpecialAbility(41) ? "True" : "False");
 			}
+			else
+				MessageString(Chat::PetResponse, tauntStatus ? PET_NO_TAUNT : PET_DO_TAUNT);
 		}
 		break;
 	}


### PR DESCRIPTION
This rule is **false** by default, so it is completely optional.

Gives client the ability to toggle the 'Allow Tank' special ability on their pet by using the Taunt button in the pet window.

https://i.gyazo.com/f6f340a1f891835f6a97b8e0389a488d.mp4

While testing this change I noticed that when logging in the Taunt button would be depressed but IsTaunting would return false. Clicking the button after that would result in the opposite behavior that the button indicates until the player zones.