### PR TITLE
[Bug Fix] Do not allow /open to be used on traps or auras, causes crash

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -9052,7 +9052,7 @@ void Client::Handle_OP_LDoNButton(const EQApplicationPacket *app)
 void Client::Handle_OP_LDoNDisarmTraps(const EQApplicationPacket *app)
 {
 	Mob * target = GetTarget();
-	if (target->IsNPC())
+	if (target && target->IsNPC())
 	{
 		if (HasSkill(EQ::skills::SkillDisarmTraps))
 		{
@@ -9078,7 +9078,7 @@ void Client::Handle_OP_LDoNInspect(const EQApplicationPacket *app)
 void Client::Handle_OP_LDoNOpen(const EQApplicationPacket *app)
 {
 	Mob * target = GetTarget();
-	if (target && target->IsNPC() && !target->IsTrap() && !target->IsAura()) {
+	if (target && target->IsNPC() && !target->IsAura()) {
 		HandleLDoNOpen(target->CastToNPC());
 	}
 }
@@ -9086,7 +9086,7 @@ void Client::Handle_OP_LDoNOpen(const EQApplicationPacket *app)
 void Client::Handle_OP_LDoNPickLock(const EQApplicationPacket *app)
 {
 	Mob * target = GetTarget();
-	if (target->IsNPC())
+	if (target && target->IsNPC())
 	{
 		if (HasSkill(EQ::skills::SkillPickLock))
 		{

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -9078,8 +9078,9 @@ void Client::Handle_OP_LDoNInspect(const EQApplicationPacket *app)
 void Client::Handle_OP_LDoNOpen(const EQApplicationPacket *app)
 {
 	Mob * target = GetTarget();
-	if (target && target->IsNPC())
+	if (target && target->IsNPC() && !target->IsTrap() && !target->IsAura()) {
 		HandleLDoNOpen(target->CastToNPC());
+	}
 }
 
 void Client::Handle_OP_LDoNPickLock(const EQApplicationPacket *app)

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -9052,7 +9052,7 @@ void Client::Handle_OP_LDoNButton(const EQApplicationPacket *app)
 void Client::Handle_OP_LDoNDisarmTraps(const EQApplicationPacket *app)
 {
 	Mob * target = GetTarget();
-	if (target && target->IsNPC())
+	if (target && target->IsNPC() && !target->IsAura())
 	{
 		if (HasSkill(EQ::skills::SkillDisarmTraps))
 		{
@@ -9071,7 +9071,7 @@ void Client::Handle_OP_LDoNDisarmTraps(const EQApplicationPacket *app)
 void Client::Handle_OP_LDoNInspect(const EQApplicationPacket *app)
 {
 	Mob * target = GetTarget();
-	if (target && target->GetClass() == LDON_TREASURE)
+	if (target && target->GetClass() == LDON_TREASURE && !target->IsAura())
 		Message(Chat::Yellow, "%s", target->GetCleanName());
 }
 
@@ -9086,7 +9086,7 @@ void Client::Handle_OP_LDoNOpen(const EQApplicationPacket *app)
 void Client::Handle_OP_LDoNPickLock(const EQApplicationPacket *app)
 {
 	Mob * target = GetTarget();
-	if (target && target->IsNPC())
+	if (target && target->IsNPC() && !target->IsAura())
 	{
 		if (HasSkill(EQ::skills::SkillPickLock))
 		{
@@ -9105,7 +9105,7 @@ void Client::Handle_OP_LDoNPickLock(const EQApplicationPacket *app)
 void Client::Handle_OP_LDoNSenseTraps(const EQApplicationPacket *app)
 {
 	Mob * target = GetTarget();
-	if (target->IsNPC())
+	if (target && target->IsNPC() && !target->IsAura())
 	{
 		if (HasSkill(EQ::skills::SkillSenseTraps))
 		{


### PR DESCRIPTION
Do not allow /open to be used on traps or auras, causes zone crash.