### PR TITLE
[Spells] Swarm pet aggro logic fix

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -3696,6 +3696,10 @@ void Mob::CommonDamage(Mob* attacker, int &damage, const uint16 spell_id, const 
 				MessageString(Chat::NPCQuestSay, PET_ATTACKING, pet->GetCleanName(), attacker->GetCleanName());
 			}
 		}
+		Shout("Attack :: Pet count %i", GetTempPetCount());
+		if (GetTempPetCount()) {
+			//entity_list.AddTempPetsToHateListOnOwnerDamage(this, attacker, spell_id);
+		}
 
 		//see if any runes want to reduce this damage
 		if (spell_id == SPELL_UNKNOWN) {

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2869,7 +2869,7 @@ void Mob::AddToHateList(Mob* other, uint32 hate /*= 0*/, int32 damage /*= 0*/, b
 		}
 	} //MERC
 
-	  // then add pet owner if there's one
+	//if I am a pet, then add pet owner if there's one
 	if (owner) { // Other is a pet, add him and it
 				 // EverHood 6/12/06
 				 // Can't add a feigned owner to hate list
@@ -2884,8 +2884,9 @@ void Mob::AddToHateList(Mob* other, uint32 hate /*= 0*/, int32 damage /*= 0*/, b
 				!(this->GetSpecialAbility(IMMUNE_AGGRO_CLIENT) && owner->IsClient()) &&
 				!(this->GetSpecialAbility(IMMUNE_AGGRO_NPC) && owner->IsNPC())
 			) {
-				if (owner->IsClient() && !CheckAggro(owner))
+				if (owner->IsClient() && !CheckAggro(owner)) {
 					owner->CastToClient()->AddAutoXTarget(this);
+				}
 				hate_list.AddEntToHateList(owner, 0, 0, false, !iBuffTic);
 			}
 		}
@@ -2912,8 +2913,9 @@ void Mob::AddToHateList(Mob* other, uint32 hate /*= 0*/, int32 damage /*= 0*/, b
 		}
 	}
 
-	if (other->GetTempPetCount()) {
-		entity_list.AddTempPetsToHateList(other, this, bFrenzy);
+	//I have a swarm pet, add other to it.
+	if (GetTempPetCount()) {
+		entity_list.AddTempPetsToHateList(this, other, bFrenzy);
 	}
 
 	if (!wasengaged) {
@@ -3696,9 +3698,9 @@ void Mob::CommonDamage(Mob* attacker, int &damage, const uint16 spell_id, const 
 				MessageString(Chat::NPCQuestSay, PET_ATTACKING, pet->GetCleanName(), attacker->GetCleanName());
 			}
 		}
-		Shout("Attack :: Pet count %i", GetTempPetCount());
+
 		if (GetTempPetCount()) {
-			//entity_list.AddTempPetsToHateListOnOwnerDamage(this, attacker, spell_id);
+			entity_list.AddTempPetsToHateListOnOwnerDamage(this, attacker, spell_id);
 		}
 
 		//see if any runes want to reduce this damage

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -4233,7 +4233,6 @@ void EntityList::AddTempPetsToHateListOnOwnerDamage(Mob *owner, Mob* attacker, i
 		NPC* n = it->second;
 		if (n && n->GetSwarmInfo()) {
 			if (n->GetSwarmInfo()->owner_id == owner->GetID()) {
-				n->Shout("Found %i Engaged %i", n->GetID(), n->IsEngaged());
 				if (
 					attacker &&
 					attacker != n &&
@@ -4244,7 +4243,6 @@ void EntityList::AddTempPetsToHateListOnOwnerDamage(Mob *owner, Mob* attacker, i
 					!attacker->IsTrap() &&
 					!attacker->IsCorpse()
 					) {
-					n->Shout("new function CHECK");
 					n->AddToHateList(attacker, 1, 0, true, false, false, spell_id);
 					n->SetTarget(attacker);
 				}

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -4237,7 +4237,7 @@ void EntityList::AddTempPetsToHateListOnOwnerDamage(Mob *owner, Mob* attacker, i
 				if (
 					attacker &&
 					attacker != n &&
-					//!n->IsEngaged() &&
+					!n->IsEngaged() &&
 					!n->GetSpecialAbility(IMMUNE_AGGRO) &&
 					!(n->GetSpecialAbility(IMMUNE_AGGRO_CLIENT) && attacker->IsClient()) &&
 					!(n->GetSpecialAbility(IMMUNE_AGGRO_NPC) && attacker->IsNPC()) &&

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -4208,7 +4208,7 @@ void EntityList::AddTempPetsToHateList(Mob *owner, Mob* other, bool bFrenzy)
 	auto it = npc_list.begin();
 	while (it != npc_list.end()) {
 		NPC* n = it->second;
-		if (n->GetSwarmInfo()) {
+		if (n && n->GetSwarmInfo()) {
 			if (n->GetSwarmInfo()->owner_id == owner->GetID()) {
 				if (
 					!n->GetSpecialAbility(IMMUNE_AGGRO) &&
@@ -4216,6 +4216,37 @@ void EntityList::AddTempPetsToHateList(Mob *owner, Mob* other, bool bFrenzy)
 					!(n->GetSpecialAbility(IMMUNE_AGGRO_NPC) && other->IsNPC())
 				) {
 					n->hate_list.AddEntToHateList(other, 0, 0, bFrenzy);
+				}
+			}
+		}
+		++it;
+	}
+}
+
+void EntityList::AddTempPetsToHateListOnOwnerDamage(Mob *owner, Mob* attacker, int32 spell_id)
+{
+	if (!attacker || !owner)
+		return;
+
+	auto it = npc_list.begin();
+	while (it != npc_list.end()) {
+		NPC* n = it->second;
+		if (n && n->GetSwarmInfo()) {
+			if (n->GetSwarmInfo()->owner_id == owner->GetID()) {
+				n->Shout("Found %i Engaged %i", n->GetID(), n->IsEngaged());
+				if (
+					attacker &&
+					attacker != n &&
+					//!n->IsEngaged() &&
+					!n->GetSpecialAbility(IMMUNE_AGGRO) &&
+					!(n->GetSpecialAbility(IMMUNE_AGGRO_CLIENT) && attacker->IsClient()) &&
+					!(n->GetSpecialAbility(IMMUNE_AGGRO_NPC) && attacker->IsNPC()) &&
+					!attacker->IsTrap() &&
+					!attacker->IsCorpse()
+					) {
+					n->Shout("new function CHECK");
+					n->AddToHateList(attacker, 1, 0, true, false, false, spell_id);
+					n->SetTarget(attacker);
 				}
 			}
 		}

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -315,6 +315,7 @@ public:
 	void	DestroyTempPets(Mob *owner);
 	int16	CountTempPets(Mob *owner);
 	void	AddTempPetsToHateList(Mob *owner, Mob* other, bool bFrenzy = false);
+	void	AddTempPetsToHateListOnOwnerDamage(Mob *owner, Mob* attacker, int32 spell_id);
 	Entity *GetEntityMob(uint16 id);
 	Entity *GetEntityMerc(uint16 id);
 	Entity *GetEntityDoor(uint16 id);

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -1068,7 +1068,6 @@ void Mob::AI_Process() {
 	}
 
 	if (engaged) {
-
 		if (!(m_PlayerState & static_cast<uint32>(PlayerState::Aggressive)))
 			SendAddPlayerState(PlayerState::Aggressive);
 
@@ -1333,6 +1332,7 @@ void Mob::AI_Process() {
 
 		}    //end is within combat rangepet
 		else {
+
 			// See if we can summon the mob to us
 			if (!HateSummon()) {
 				//could not summon them, check ranged...
@@ -1348,31 +1348,16 @@ void Mob::AI_Process() {
 					}
 				}
 				// mob/npc waits until call for help complete, others can move
-				else if (AI_movement_timer->Check()){
-					if (IsTempPet()) {
-						Shout("AI PASS TIMER CHECK");
-					}
-					if (target && (GetOwnerID() || IsTempPet() || IsBot() || CastToNPC()->GetCombatEvent())) {
+				else if (AI_movement_timer->Check() && target &&
+						(GetOwnerID() || IsBot() || IsTempPet() ||
+						CastToNPC()->GetCombatEvent())) {
+					if (!IsRooted()) {
+						LogAI("Pursuing [{}] while engaged", target->GetName());
+						RunTo(target->GetX(), target->GetY(), target->GetZ());
 
-						if (!IsRooted()) {
-							if (IsTempPet()) {
-								Shout("Run to target");
-							}
-							LogAI("Pursuing [{}] while engaged", target->GetName());
-							RunTo(target->GetX(), target->GetY(), target->GetZ());
-
-						}
-						else {
-							if (IsTempPet()) {
-								Shout("Face Target");
-							}
-							FaceTarget();
-						}
 					}
 					else {
-						if (IsTempPet()) {
-							Shout("SUPER FAILURE");
-						}
+						FaceTarget();
 					}
 				}
 			}

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -1068,6 +1068,7 @@ void Mob::AI_Process() {
 	}
 
 	if (engaged) {
+
 		if (!(m_PlayerState & static_cast<uint32>(PlayerState::Aggressive)))
 			SendAddPlayerState(PlayerState::Aggressive);
 
@@ -1332,7 +1333,6 @@ void Mob::AI_Process() {
 
 		}    //end is within combat rangepet
 		else {
-
 			// See if we can summon the mob to us
 			if (!HateSummon()) {
 				//could not summon them, check ranged...
@@ -1348,16 +1348,31 @@ void Mob::AI_Process() {
 					}
 				}
 				// mob/npc waits until call for help complete, others can move
-				else if (AI_movement_timer->Check() && target &&
-						(GetOwnerID() || IsBot() ||
-						CastToNPC()->GetCombatEvent())) {
-					if (!IsRooted()) {
-						LogAI("Pursuing [{}] while engaged", target->GetName());
-						RunTo(target->GetX(), target->GetY(), target->GetZ());
+				else if (AI_movement_timer->Check()){
+					if (IsTempPet()) {
+						Shout("AI PASS TIMER CHECK");
+					}
+					if (target && (GetOwnerID() || IsTempPet() || IsBot() || CastToNPC()->GetCombatEvent())) {
 
+						if (!IsRooted()) {
+							if (IsTempPet()) {
+								Shout("Run to target");
+							}
+							LogAI("Pursuing [{}] while engaged", target->GetName());
+							RunTo(target->GetX(), target->GetY(), target->GetZ());
+
+						}
+						else {
+							if (IsTempPet()) {
+								Shout("Face Target");
+							}
+							FaceTarget();
+						}
 					}
 					else {
-						FaceTarget();
+						if (IsTempPet()) {
+							Shout("SUPER FAILURE");
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Swarm pet aggro after initial target died was broken in various ways.

Correct behavior is once the initial swarm pets target dies, the swarm pet until it despawns will follow you and if you take damage/detrimental spell cast on you from an npc, the pet will attack that NPC. Similar to an enchanter animations AI.

This update will make the pets function like they do on live.