### PR TITLE
[Bug Fix] Illusions will now properly display armor to other clients when they zone in.

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -1460,6 +1460,10 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
+		case SE_Illusion:
+			newbon->Illusion = true;
+			break;
+
 		case SE_IllusionPersistence:
 			newbon->IllusionPersistence = base_value;
 			break;
@@ -3540,6 +3544,10 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 					new_bonus->FactionModPct = effect_value;
 				break;
 			}
+
+			case SE_Illusion:
+				new_bonus->Illusion = true;
+				break;
 
 			case SE_IllusionPersistence:
 				new_bonus->IllusionPersistence = effect_value;

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -747,6 +747,8 @@ void Client::CompleteConnect()
 
 	entity_list.SendAppearanceEffects(this);
 
+	entity_list.SendIllusionWearChange(this);
+
 	entity_list.SendTraders(this);
 
 	Mob *pet = GetPet();

--- a/zone/common.h
+++ b/zone/common.h
@@ -559,6 +559,7 @@ struct StatBonuses {
 	int32   WeaponStance[WEAPON_STANCE_TYPE_MAX +1];// base = trigger spell id, base2 = 0 is 2h, 1 is shield, 2 is dual wield, [0]spid 2h, [1]spid shield, [2]spid DW
 	bool	ZoneSuspendMinion;					// base 1 allows suspended minions to zone
 	bool	CompleteHealBuffBlocker;			// Use in SPA 101 to prevent recast of complete heal from this effect till blocker buff is removed.
+	bool	Illusion;							// check if illusion is present.
 
 	// AAs
 	int32	TrapCircumvention;					// reduce chance to trigger a trap.

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -4657,6 +4657,29 @@ void EntityList::SendAppearanceEffects(Client *c)
 	}
 }
 
+void EntityList::SendIllusionWearChange(Client *c)
+{
+
+	if (!c) {
+		return;
+	}
+
+	auto it = mob_list.begin();
+	while (it != mob_list.end()) {
+		Mob *cur = it->second;
+
+		if (cur) {
+			if (cur == c) {
+				++it;
+				continue;
+			}
+
+			cur->SendIllusionWearChange(c);
+		}
+		++it;
+	}
+}
+
 void EntityList::ZoneWho(Client *c, Who_All_Struct *Who)
 {
 	// This is only called for SoF clients, as regular /who is now handled server-side for that client.

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -4659,24 +4659,20 @@ void EntityList::SendAppearanceEffects(Client *c)
 
 void EntityList::SendIllusionWearChange(Client *c)
 {
-
 	if (!c) {
 		return;
 	}
 
-	auto it = mob_list.begin();
-	while (it != mob_list.end()) {
-		Mob *cur = it->second;
+	for (auto &e : mob_list) {
+		auto &mob = e.second;
 
-		if (cur) {
-			if (cur == c) {
-				++it;
+		if (mob) {
+			if (mob == c) {
 				continue;
 			}
 
-			cur->SendIllusionWearChange(c);
+			mob->SendIllusionWearChange(c);
 		}
-		++it;
 	}
 }
 

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -381,6 +381,7 @@ public:
 	void	SendNimbusEffects(Client *c);
 	void	SendUntargetable(Client *c);
 	void	SendAppearanceEffects(Client *c);
+	void    SendIllusionWearChange(Client *c);
 	void	DuelMessage(Mob* winner, Mob* loser, bool flee);
 	void	QuestJournalledSayClose(Mob *sender, float dist, const char* mobname, const char* message, Journal::Options &opts);
 	void	GroupMessage(uint32 gid, const char *from, const char *message);

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -357,6 +357,7 @@ public:
 	void ConeDirectional(uint16 spell_id, int16 resist_adjust);
 	void TryOnSpellFinished(Mob *caster, Mob *target, uint16 spell_id);
 	void ApplySpellEffectIllusion(int32 spell_id, Mob* caster, int buffslot, int base, int limit, int max);
+	void SendIllusionWearChange(Client* c);
 
 	//Buff
 	void BuffProcess();

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -8963,6 +8963,26 @@ void Mob::SetProcLimitTimer(int32 base_spell_id, uint32 proc_reuse_time, int pro
 	}
 }
 
+void Mob::SendIllusionWearChange(Client* c) {
+
+	/*
+		We send this to client on Client::CompleteConnect() to properly update textures of
+		other mobs in zone with illusions on them.
+	*/
+	if (!c) {
+		return;
+	}
+
+	if (!spellbonuses.Illusion && !itembonuses.Illusion && !aabonuses.Illusion) {
+		return;
+	}
+
+	for (int x = EQ::textures::textureBegin; x <= EQ::textures::LastTintableTexture; x++) {
+		SendWearChange(x, c);
+	}
+}
+
+
 void Mob::ApplySpellEffectIllusion(int32 spell_id, Mob *caster, int buffslot, int base, int limit, int max)
 {
 	// Gender Illusions


### PR DESCRIPTION
This update resolves an issue where if a mob already has an illusion on them, when a new client zones in, the armor would not display properly on the mob with the illusion to that client who just zoned in.
