### PR TITLE
[Bug Fix] NPC::CountItem and Corpse::CountItem 0 Charge Item Fix.

### DIFF
--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -1570,7 +1570,7 @@ uint16 Corpse::CountItem(uint32 item_id) {
 		}
 
 		if (loot_item->item_id == item_id) {
-			item_count += loot_item->charges;
+			item_count += loot_item->charges > 0 ? loot_item->charges : 1;
 		}
 	}
 	return item_count;

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -758,7 +758,7 @@ uint16 NPC::CountItem(uint32 item_id) {
 		}
 
 		if (loot_item->item_id == item_id) {
-			item_count += loot_item->charges;
+			item_count += loot_item->charges > 0 ? loot_item->charges : 1;
 		}
 	}
 	return item_count;


### PR DESCRIPTION
- Fixes an issue where 0 charged or out of charge items do not count towards the return value.