### PR TITLE
[Spells] Illusions will now persist onto the corpse when mob is killed.

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1891,6 +1891,8 @@ bool Client::Death(Mob* killerMob, int32 damage, uint16 spell, EQ::skills::Skill
 			//m_epp.perAA = 0;	//reset to no AA exp on death.
 		}
 
+		int32 illusion_spell_id = spellbonuses.Illusion;
+
 		//this generates a lot of 'updates' to the client that the client does not need
 		BuffFadeNonPersistDeath();
 		if (RuleB(Character, UnmemSpellsOnDeath)) {
@@ -1936,13 +1938,12 @@ bool Client::Death(Mob* killerMob, int32 damage, uint16 spell, EQ::skills::Skill
 					}
 				}
 			}
-
 			entity_list.AddCorpse(new_corpse, GetID());
 			SetID(0);
 
 			//send the become corpse packet to everybody else in the zone.
 			entity_list.QueueClients(this, &app2, true);
-
+			ApplyIllusionToCorpse(illusion_spell_id, new_corpse);
 			LeftCorpse = true;
 		}
 	}
@@ -2340,6 +2341,8 @@ bool NPC::Death(Mob* killer_mob, int32 damage, uint16 spell, EQ::skills::SkillTy
 	if (p_depop == true)
 		return false;
 
+	int32 illusion_spell_id = spellbonuses.Illusion;
+
 	HasAISpellEffects = false;
 	BuffFadeAll();
 	uint8 killed_level = GetLevel();
@@ -2595,8 +2598,8 @@ bool NPC::Death(Mob* killer_mob, int32 damage, uint16 spell, EQ::skills::SkillTy
 
 		// entity_list.RemoveMobFromCloseLists(this);
 		close_mobs.clear();
-
 		this->SetID(0);
+		ApplyIllusionToCorpse(illusion_spell_id, corpse);
 
 		if (killer != 0 && emoteid != 0)
 			corpse->CastToNPC()->DoNPCEmote(AFTERDEATH, emoteid);

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -3546,7 +3546,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 			}
 
 			case SE_Illusion:
-				new_bonus->Illusion = true;
+				new_bonus->Illusion = spell_id;
 				break;
 
 			case SE_IllusionPersistence:

--- a/zone/common.h
+++ b/zone/common.h
@@ -559,7 +559,7 @@ struct StatBonuses {
 	int32   WeaponStance[WEAPON_STANCE_TYPE_MAX +1];// base = trigger spell id, base2 = 0 is 2h, 1 is shield, 2 is dual wield, [0]spid 2h, [1]spid shield, [2]spid DW
 	bool	ZoneSuspendMinion;					// base 1 allows suspended minions to zone
 	bool	CompleteHealBuffBlocker;			// Use in SPA 101 to prevent recast of complete heal from this effect till blocker buff is removed.
-	bool	Illusion;							// check if illusion is present.
+	int32	Illusion;							// illusion spell id
 
 	// AAs
 	int32	TrapCircumvention;					// reduce chance to trigger a trap.

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -357,6 +357,7 @@ public:
 	void ConeDirectional(uint16 spell_id, int16 resist_adjust);
 	void TryOnSpellFinished(Mob *caster, Mob *target, uint16 spell_id);
 	void ApplySpellEffectIllusion(int32 spell_id, Mob* caster, int buffslot, int base, int limit, int max);
+	void ApplyIllusionToCorpse(int32 spell_id, Corpse* new_corpse);
 	void SendIllusionWearChange(Client* c);
 
 	//Buff

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -8982,6 +8982,29 @@ void Mob::SendIllusionWearChange(Client* c) {
 	}
 }
 
+void Mob::ApplyIllusionToCorpse(int32 spell_id, Corpse* new_corpse) {
+
+	//Transfers most illusions over to the corpse.
+
+	if (!IsValidSpell(spell_id)) {
+		return;
+	}
+
+	//Corpse *new_corpse = entity_list.GetCorpseByID(corpse_id);
+
+	if (!new_corpse) {
+		return;
+	}
+
+	for (int i = 0; i < EFFECT_COUNT; i++)
+	{
+		if (spells[spell_id].effect_id[i] == SE_Illusion) {
+			new_corpse->ApplySpellEffectIllusion(spell_id, nullptr, -1, spells[spell_id].base_value[i], spells[spell_id].limit_value[i], spells[spell_id].max_value[i]);
+		}
+	}
+
+}
+
 
 void Mob::ApplySpellEffectIllusion(int32 spell_id, Mob *caster, int buffslot, int base, int limit, int max)
 {
@@ -9091,12 +9114,15 @@ void Mob::ApplySpellEffectIllusion(int32 spell_id, Mob *caster, int buffslot, in
 		SendWearChange(x);
 	}
 
-	if (caster == this && spell_id != SPELL_MINOR_ILLUSION && spell_id != SPELL_ILLUSION_TREE &&
-		(spellbonuses.IllusionPersistence || aabonuses.IllusionPersistence || itembonuses.IllusionPersistence)) {
-		buffs[buffslot].persistant_buff = 1;
-	}
-	else {
-		buffs[buffslot].persistant_buff = 0;
+	if (buffslot != -1) {
+
+		if (caster == this && spell_id != SPELL_MINOR_ILLUSION && spell_id != SPELL_ILLUSION_TREE &&
+			(spellbonuses.IllusionPersistence || aabonuses.IllusionPersistence || itembonuses.IllusionPersistence)) {
+			buffs[buffslot].persistant_buff = 1;
+		}
+		else {
+			buffs[buffslot].persistant_buff = 0;
+		}
 	}
 }
 

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -8984,13 +8984,10 @@ void Mob::SendIllusionWearChange(Client* c) {
 
 void Mob::ApplyIllusionToCorpse(int32 spell_id, Corpse* new_corpse) {
 
-	//Transfers most illusions over to the corpse.
-
+	//Transfers most illusions over to the corpse upon death
 	if (!IsValidSpell(spell_id)) {
 		return;
 	}
-
-	//Corpse *new_corpse = entity_list.GetCorpseByID(corpse_id);
 
 	if (!new_corpse) {
 		return;
@@ -9000,9 +8997,9 @@ void Mob::ApplyIllusionToCorpse(int32 spell_id, Corpse* new_corpse) {
 	{
 		if (spells[spell_id].effect_id[i] == SE_Illusion) {
 			new_corpse->ApplySpellEffectIllusion(spell_id, nullptr, -1, spells[spell_id].base_value[i], spells[spell_id].limit_value[i], spells[spell_id].max_value[i]);
+			return;
 		}
 	}
-
 }
 
 

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -8993,15 +8993,13 @@ void Mob::ApplyIllusionToCorpse(int32 spell_id, Corpse* new_corpse) {
 		return;
 	}
 
-	for (int i = 0; i < EFFECT_COUNT; i++)
-	{
+	for (int i = 0; i < EFFECT_COUNT; i++){
 		if (spells[spell_id].effect_id[i] == SE_Illusion) {
 			new_corpse->ApplySpellEffectIllusion(spell_id, nullptr, -1, spells[spell_id].base_value[i], spells[spell_id].limit_value[i], spells[spell_id].max_value[i]);
 			return;
 		}
 	}
 }
-
 
 void Mob::ApplySpellEffectIllusion(int32 spell_id, Mob *caster, int buffslot, int base, int limit, int max)
 {
@@ -9112,7 +9110,6 @@ void Mob::ApplySpellEffectIllusion(int32 spell_id, Mob *caster, int buffslot, in
 	}
 
 	if (buffslot != -1) {
-
 		if (caster == this && spell_id != SPELL_MINOR_ILLUSION && spell_id != SPELL_ILLUSION_TREE &&
 			(spellbonuses.IllusionPersistence || aabonuses.IllusionPersistence || itembonuses.IllusionPersistence)) {
 			buffs[buffslot].persistant_buff = 1;


### PR DESCRIPTION
Implemented live like mechanic of when a mob dies while having an illusion on them, the corpse will retain that illusion. 