### PR TITLE
[Spells] SPA 311 SE_LimitCombatSkills should prevent focusing of procs even if proc is a 'casted' spell.

### DIFF
--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1030,7 +1030,7 @@ typedef enum {
 #define SE_ZoneSuspendMinion			308 // implemented, @Pet, allow suspended pets to be resummoned upon zoning, base: 1, limit: none, max: none, Calc: Bool
 #define SE_GateCastersBindpoint			309 // implemented - Gate to casters bind point
 #define SE_ReduceReuseTimer				310 // implemented, @Fc, On Caster, spell and disc reuse time mod by amount, base: milliseconds
-#define SE_LimitCombatSkills			311 // implemented, @Ff, Include or exclude combat skills or procs from being focused, base1: 0=Exclude if proc 1=Allow only if proc
+#define SE_LimitCombatSkills			311 // implemented, @Ff, Include or exclude combat skills or procs from being focused, base1: 0=Exclude if proc 1=Allow only if proc.
 #define SE_Sanctuary					312 // implemented - Places caster at bottom hate list, effect fades if cast cast spell on targets other than self.
 #define SE_ForageAdditionalItems		313	// implemented[AA] - chance to forage additional items
 #define SE_Invisibility2				314 // implemented - fixed duration invisible

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1030,7 +1030,7 @@ typedef enum {
 #define SE_ZoneSuspendMinion			308 // implemented, @Pet, allow suspended pets to be resummoned upon zoning, base: 1, limit: none, max: none, Calc: Bool
 #define SE_GateCastersBindpoint			309 // implemented - Gate to casters bind point
 #define SE_ReduceReuseTimer				310 // implemented, @Fc, On Caster, spell and disc reuse time mod by amount, base: milliseconds
-#define SE_LimitCombatSkills			311 // implemented, @Ff, Include or exclude combat skills or procs (non-memorizable spells) from being focused, base1: 0=Exclude if proc 1=Allow only if proc
+#define SE_LimitCombatSkills			311 // implemented, @Ff, Include or exclude combat skills or procs from being focused, base1: 0=Exclude if proc 1=Allow only if proc
 #define SE_Sanctuary					312 // implemented - Places caster at bottom hate list, effect fades if cast cast spell on targets other than self.
 #define SE_ForageAdditionalItems		313	// implemented[AA] - chance to forage additional items
 #define SE_Invisibility2				314 // implemented - fixed duration invisible

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -5836,31 +5836,27 @@ bool Mob::IsCombatProc(uint16 spell_id) {
 	if (spell_id == SPELL_UNKNOWN) {
 		return(false);
 	}
-
-	if ((spells[spell_id].cast_time == 0) && (spells[spell_id].recast_time == 0) && (spells[spell_id].recovery_time == 0))
-	{
-
-		for (int i = 0; i < MAX_PROCS; i++){
-			if (PermaProcs[i].spellID == spell_id || 
-				SpellProcs[i].spellID == spell_id ||
-				RangedProcs[i].spellID == spell_id || 
-				DefensiveProcs[i].spellID == spell_id){
-				return true;
-			}
-		}
-
-		if (IsClient()) {
-			for (int i = 0; i < MAX_AA_PROCS; i += 4) {
-
-				if (aabonuses.SpellProc[i + 1] == spell_id ||
-					aabonuses.RangedProc[i + 1] == spell_id ||
-					aabonuses.DefensiveProc[i + 1] == spell_id) {
-					return true;
-				}
-			}
+	/*
+		Procs that originate from casted spells are still limited by SPA 311 (~Kayen confirmed on live 2/4/22)
+	*/
+	for (int i = 0; i < MAX_PROCS; i++) {
+		if (PermaProcs[i].spellID == spell_id ||
+			SpellProcs[i].spellID == spell_id ||
+			RangedProcs[i].spellID == spell_id ||
+			DefensiveProcs[i].spellID == spell_id) {
+			return true;
 		}
 	}
 
+	if (IsClient()) {
+		for (int i = 0; i < MAX_AA_PROCS; i += 4) {
+			if (aabonuses.SpellProc[i + 1] == spell_id ||
+				aabonuses.RangedProc[i + 1] == spell_id ||
+				aabonuses.DefensiveProc[i + 1] == spell_id) {
+				return true;
+			}
+		}
+	}
 	return false;
 }
 


### PR DESCRIPTION
Update affects SPA 311 SE_LimitCombatSkills which prevents procs from being focused. The way it was coded was incorrectly excluding 'casted' spells that were put as procs.  Where casted spells refers to a spell that can be memorized and casted by a class. Confirmed on live 'casted' spells that are on proc weapons do not receive any focusing.