### PR TITLE
[Quest API] Add GetEnvironmentalDamageName() to Perl/Lua.

### DIFF
--- a/common/emu_constants.cpp
+++ b/common/emu_constants.cpp
@@ -226,12 +226,12 @@ std::string EQ::constants::GetLDoNThemeName(uint32 theme_id)
 const std::map<uint8, std::string>& EQ::constants::GetFlyModeMap()
 {
 	static const std::map<uint8, std::string> flymode_map = {
-		{ EQ::constants::GravityBehavior::Ground, "Ground" },
-		{ EQ::constants::GravityBehavior::Flying, "Flying" },
-		{ EQ::constants::GravityBehavior::Levitating, "Levitating" },
-		{ EQ::constants::GravityBehavior::Water, "Water" },
-		{ EQ::constants::GravityBehavior::Floating, "Floating" },
-		{ EQ::constants::GravityBehavior::LevitateWhileRunning, "Levitating While Running" },
+		{ GravityBehavior::Ground, "Ground" },
+		{ GravityBehavior::Flying, "Flying" },
+		{ GravityBehavior::Levitating, "Levitating" },
+		{ GravityBehavior::Water, "Water" },
+		{ GravityBehavior::Floating, "Floating" },
+		{ GravityBehavior::LevitateWhileRunning, "Levitating While Running" },
 	};
 	return flymode_map;
 }
@@ -336,4 +336,24 @@ std::string EQ::constants::GetAccountStatusName(uint8 account_status)
 	}
 
 	return status_name;
+}
+
+const std::map<uint8, std::string>& EQ::constants::GetEnvironmentalDamageMap()
+{
+	static const std::map<uint8, std::string> damage_type_map = {
+		{ EnvironmentalDamage::Lava, "Lava" },
+		{ EnvironmentalDamage::Drowning, "Drowning" },
+		{ EnvironmentalDamage::Falling, "Falling" },
+		{ EnvironmentalDamage::Trap, "Trap" }
+	};
+	return damage_type_map;
+}
+
+std::string EQ::constants::GetEnvironmentalDamageName(uint8 damage_type)
+{
+	if (EQ::ValueWithin(damage_type, EnvironmentalDamage::Lava, EnvironmentalDamage::Trap)) {
+		auto damage_types = EQ::constants::GetEnvironmentalDamageMap();
+		return damage_types[damage_type];
+	}
+	return std::string();
 }

--- a/common/emu_constants.h
+++ b/common/emu_constants.h
@@ -230,6 +230,13 @@ namespace EQ
 			LevitateWhileRunning
 		};
 
+		enum EnvironmentalDamage : uint8 {
+			Lava = 250,
+			Drowning,
+			Falling,
+			Trap
+		};
+
 		const char *GetStanceName(StanceType stance_type);
 		int ConvertStanceTypeToIndex(StanceType stance_type);
 
@@ -247,6 +254,9 @@ namespace EQ
 
 		extern const std::map<uint8, std::string>& GetAccountStatusMap();
 		std::string GetAccountStatusName(uint8 account_status);
+
+		extern const std::map<uint8, std::string>& GetEnvironmentalDamageMap();
+		std::string GetEnvironmentalDamageName(uint8 damage_type);
 
 		const int STANCE_TYPE_FIRST = stancePassive;
 		const int STANCE_TYPE_LAST = stanceBurnAE;

--- a/common/eq_packet_structs.h
+++ b/common/eq_packet_structs.h
@@ -2762,7 +2762,7 @@ struct EnvDamage2_Struct {
 /*0004*/	uint16 unknown4;
 /*0006*/	uint32 damage;
 /*0010*/	uint8 unknown10[12];
-/*0022*/	uint8 dmgtype; //FA = Lava; FC = Falling
+/*0022*/	uint8 dmgtype; // FA = Lava, FB = Drowning, FC = Falling, FD = Trap
 /*0023*/	uint8 unknown2[4];
 /*0027*/	uint16 constant; //Always FFFF
 /*0029*/	uint16 unknown29;

--- a/common/patches/rof2_structs.h
+++ b/common/patches/rof2_structs.h
@@ -3061,7 +3061,7 @@ struct EnvDamage2_Struct {
 /*0006*/	uint32 damage;
 /*0010*/	float unknown10;	// New to Underfoot - Seen 1
 /*0014*/	uint8 unknown14[12];
-/*0026*/	uint8 dmgtype;		// FA = Lava; FC = Falling
+/*0026*/	uint8 dmgtype; // FA = Lava, FB = Drowning, FC = Falling, FD = Trap
 /*0027*/	uint8 unknown27[4];
 /*0031*/	uint16 unknown31;	// New to Underfoot - Seen 66
 /*0033*/	uint16 constant;		// Always FFFF

--- a/common/patches/rof_structs.h
+++ b/common/patches/rof_structs.h
@@ -3032,7 +3032,7 @@ struct EnvDamage2_Struct {
 /*0006*/	uint32 damage;
 /*0010*/	float unknown10;	// New to Underfoot - Seen 1
 /*0014*/	uint8 unknown14[12];
-/*0026*/	uint8 dmgtype;		// FA = Lava; FC = Falling
+/*0026*/	uint8 dmgtype; // FA = Lava, FB = Drowning, FC = Falling, FD = Trap
 /*0027*/	uint8 unknown27[4];
 /*0031*/	uint16 unknown31;	// New to Underfoot - Seen 66
 /*0033*/	uint16 constant;		// Always FFFF

--- a/common/patches/sod_structs.h
+++ b/common/patches/sod_structs.h
@@ -2539,7 +2539,7 @@ struct EnvDamage2_Struct {
 /*0004*/	uint16 unknown4;
 /*0006*/	uint32 damage;
 /*0010*/	uint8 unknown10[12];
-/*0022*/	uint8 dmgtype; //FA = Lava; FC = Falling
+/*0022*/	uint8 dmgtype; // FA = Lava, FB = Drowning, FC = Falling, FD = Trap
 /*0023*/	uint8 unknown2[4];
 /*0027*/	uint16 constant; //Always FFFF
 /*0029*/	uint16 unknown29;

--- a/common/patches/sof_structs.h
+++ b/common/patches/sof_structs.h
@@ -2509,7 +2509,7 @@ struct EnvDamage2_Struct {
 /*0004*/	uint16 unknown4;
 /*0006*/	uint32 damage;
 /*0010*/	uint8 unknown10[12];
-/*0022*/	uint8 dmgtype; //FA = Lava; FC = Falling
+/*0022*/	uint8 dmgtype; // FA = Lava, FB = Drowning, FC = Falling, FD = Trap
 /*0023*/	uint8 unknown2[4];
 /*0027*/	uint16 constant; //Always FFFF
 /*0029*/	uint16 unknown29;

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -5785,8 +5785,7 @@ void Client::Handle_OP_EndLootRequest(const EQApplicationPacket *app)
 
 void Client::Handle_OP_EnvDamage(const EQApplicationPacket *app)
 {
-	if (!ClientFinishedLoading())
-	{
+	if (!ClientFinishedLoading()) {
 		SetHP(GetHP() - 1);
 		return;
 	}
@@ -5796,38 +5795,46 @@ void Client::Handle_OP_EnvDamage(const EQApplicationPacket *app)
 		DumpPacket(app);
 		return;
 	}
+
 	EnvDamage2_Struct* ed = (EnvDamage2_Struct*)app->pBuffer;
-
-	int damage = ed->damage;
-
-	if (ed->dmgtype == 252) {
-
-		int mod = spellbonuses.ReduceFallDamage + itembonuses.ReduceFallDamage + aabonuses.ReduceFallDamage;
-
+	auto damage = ed->damage;
+	if (ed->dmgtype == EQ::constants::EnvironmentalDamage::Falling) {
+		uint32 mod = spellbonuses.ReduceFallDamage + itembonuses.ReduceFallDamage + aabonuses.ReduceFallDamage;
 		damage -= damage * mod / 100;
 	}
 
-	if (damage < 0)
+	if (damage < 0) {
 		damage = 31337;
+	}
 
 	if (admin >= minStatusToAvoidFalling && GetGM()) {
-		Message(Chat::Red, "Your GM status protects you from %i points of type %i environmental damage.", ed->damage, ed->dmgtype);
+		Message(
+			Chat::Red,
+			fmt::format(
+				"Your GM status protects you from {} points of {} (Type {}) damage.",
+				ed->damage,
+				EQ::constants::GetEnvironmentalDamageName(ed->dmgtype),
+				ed->dmgtype
+			).c_str()
+		);
 		SetHP(GetHP() - 1);//needed or else the client wont acknowledge
 		return;
-	}
-	else if (GetInvul()) {
-		Message(Chat::Red, "Your invuln status protects you from %i points of type %i environmental damage.", ed->damage, ed->dmgtype);
+	} else if (GetInvul()) {
+		Message(
+			Chat::Red,
+			fmt::format(
+				"Your invulnerability protects you from {} points of {} (Type {}) damage.",
+				ed->damage,
+				EQ::constants::GetEnvironmentalDamageName(ed->dmgtype),
+				ed->dmgtype
+			).c_str()
+		);
 		SetHP(GetHP() - 1);//needed or else the client wont acknowledge
 		return;
-	}
-	else if (zone->GetZoneID() == 183 || zone->GetZoneID() == 184) {
-		// Hard coded tutorial and load zones for no fall damage
+	} else if (zone->GetZoneID() == Zones::TUTORIAL || zone->GetZoneID() == Zones::LOAD) { // Hard coded tutorial and load zones for no fall damage
 		return;
-	}
-	else {
+	} else {
 		SetHP(GetHP() - (damage * RuleR(Character, EnvironmentDamageMulipliter)));
-
-		/* EVENT_ENVIRONMENTAL_DAMAGE */
 		int final_damage = (damage * RuleR(Character, EnvironmentDamageMulipliter));
 		std::string export_string = fmt::format(
 			"{} {} {}",

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -8092,6 +8092,22 @@ XS(XS__getbodytypename) {
 	}
 }
 
+XS(XS__getenvironmentaldamagename);
+XS(XS__getenvironmentaldamagename) {
+	dXSARGS;
+	if (items != 1)
+		Perl_croak(aTHX_ "Usage: quest::getenvironmentaldamagename(uint8 damage_type)");
+
+	dXSTARG;
+	uint8 damage_type = (uint8) SvIV(ST(0));
+	std::string environmental_damage_name = quest_manager.getenvironmentaldamagename(damage_type);
+
+	sv_setpv(TARG, environmental_damage_name.c_str());
+	XSprePUSH;
+	PUSHTARG;
+	XSRETURN(1);
+}
+
 /*
 This is the callback perl will look for to setup the
 quest package's XSUBs
@@ -8398,6 +8414,7 @@ EXTERN_C XS(boot_quest) {
 	newXS(strcpy(buf, "getcurrencyitemid"), XS__getcurrencyitemid, file);
 	newXS(strcpy(buf, "getgendername"), XS__getgendername, file);
 	newXS(strcpy(buf, "getdeityname"), XS__getdeityname, file);
+	newXS(strcpy(buf, "getenvironmentaldamagename"), XS__getenvironmentaldamagename, file);
 	newXS(strcpy(buf, "getguildnamebyid"), XS__getguildnamebyid, file);
 	newXS(strcpy(buf, "getguildidbycharid"), XS__getguildidbycharid, file);
 	newXS(strcpy(buf, "getgroupidbycharid"), XS__getgroupidbycharid, file);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -3367,6 +3367,10 @@ std::string lua_get_body_type_name(uint32 bodytype_id) {
 	return quest_manager.getbodytypename(bodytype_id);
 }
 
+std::string lua_get_environmental_damage_name(uint8 damage_type) {
+	return quest_manager.getenvironmentaldamagename(damage_type);
+}
+
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
 	cur = table[#name]; \
 	if(luabind::type(cur) != LUA_TNIL) { \
@@ -3814,6 +3818,7 @@ luabind::scope lua_register_general() {
 		luabind::def("get_faction_name", &lua_get_faction_name),
 		luabind::def("get_language_name", &lua_get_language_name),
 		luabind::def("get_body_type_name", &lua_get_body_type_name),
+		luabind::def("get_environmental_damage_name", &lua_get_environmental_damage_name),
 
 		/*
 			Cross Zone

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -3698,3 +3698,8 @@ const SPDat_Spell_Struct* QuestManager::getspell(uint32 spell_id) {
     }
     return nullptr;
 }
+
+std::string QuestManager::getenvironmentaldamagename(uint8 damage_type) {
+	std::string environmental_damage_name = EQ::constants::GetEnvironmentalDamageName(damage_type);
+	return environmental_damage_name;
+}

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -330,7 +330,8 @@ public:
 	std::string getinventoryslotname(int16 slot_id);
 	int getitemstat(uint32 item_id, std::string stat_identifier);
 	int getspellstat(uint32 spell_id, std::string stat_identifier, uint8 slot = 0);
-	const SPDat_Spell_Struct *getspell(uint32 spell_id);	
+	const SPDat_Spell_Struct *getspell(uint32 spell_id);
+	std::string getenvironmentaldamagename(uint8 damage_type);
 
 	Client *GetInitiator() const;
 	NPC *GetNPC() const;


### PR DESCRIPTION
- Add EQ::constants::GetEnvironmentalDamageMap() and EQ::constants::GetEnvironmentalDamageName().
- Add quest::getenvironmentaldamagename(damage_type) to Perl.
- Add eq.get_environmental_damage_name(damage_type) to Lua.
- Cleanup GM messages for avoiding environmental damage.
![image](https://user-images.githubusercontent.com/89047260/152694442-69062bdb-ae40-4a60-b2f3-b7e3f6f167b8.png)
![image](https://user-images.githubusercontent.com/89047260/152694417-a14d3707-e831-431a-99c3-1c9600339c68.png)

```perl
sub EVENT_ENVIRONMENTAL_DAMAGE {
	my $damage_type_name = quest::getenvironmentaldamagename($env_damage_type);
	quest::message(315, "$env_damage $env_damage_type $damage_type_name $final_damage");
}
```

```lua
function event_environmental_damage(e)
	local damage_type_name = eq.get_environmental_damage_name(e.env_damage_type);
	eq.message(315, string.format("%s %s %s %s", e.env_damage, e.env_damage_type, damage_type_name, e.env_final_damage));
end
```