### PR TITLE
[Commands] Cleanup #timers Command.

### DIFF
--- a/zone/gm_commands/timers.cpp
+++ b/zone/gm_commands/timers.cpp
@@ -2,21 +2,45 @@
 
 void command_timers(Client *c, const Seperator *sep)
 {
-	if (!c->GetTarget() || !c->GetTarget()->IsClient()) {
-		c->Message(Chat::White, "Need a player target for timers.");
-		return;
+	auto target = c;
+	if (c->GetTarget() && c->GetTarget()->IsClient()) {
+		target = c->GetTarget()->CastToClient();
 	}
-	Client *them = c->GetTarget()->CastToClient();
 
-	std::vector<std::pair<pTimerType, PersistentTimer *> > res;
-	them->GetPTimers().ToVector(res);
+	std::vector<std::pair<pTimerType, PersistentTimer *>> timers;
+	target->GetPTimers().ToVector(timers);
 
-	c->Message(Chat::White, "Timers for target:");
+	std::string popup_title = fmt::format(
+		"Recast Timers for {}",
+		c == target ?
+		"Yourself" :
+		fmt::format(
+			"{} ({})",
+			target->GetCleanName(),
+			target->GetID()
+		)
+	);
 
-	int r;
-	int l        = res.size();
-	for (r = 0; r < l; r++) {
-		c->Message(Chat::White, "Timer %d: %d seconds remain.", res[r].first, res[r].second->GetRemainingTime());
+	std::string popup_text = "<table>";
+
+	popup_text += "<tr><td>Timer ID</td><td>Remaining</td></tr>";
+
+	for (const auto& timer : timers) {
+		auto remaining_time = timer.second->GetRemainingTime();
+		if (remaining_time) {
+			popup_text += fmt::format(
+				"<tr><td>{}</td><td>{}</td></tr>",
+				timer.first,
+				ConvertSecondsToTime(remaining_time)
+			);
+		}
 	}
+
+	popup_text += "</table>";
+
+	c->SendPopupToClient(
+		popup_title.c_str(),
+		popup_text.c_str()
+	);
 }
 


### PR DESCRIPTION
- Cleanup message and logic.
- Utilize popup instead of chat messages.
- Utilize ConvertSecondsToTime() helper method.
![image](https://user-images.githubusercontent.com/89047260/152703761-538f7bf8-530b-4ec8-899d-b1b9ff3b5028.png)
