### PR TITLE
[Commands] Cleanup #undye and #undyeme Commands.

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -378,6 +378,7 @@ int command_init(void)
 		command_add("trapinfo", "- Gets infomation about the traps currently spawned in the zone.", AccountStatus::QuestTroupe, command_trapinfo) ||
 		command_add("tune",  "Calculate statistical values related to combat.", AccountStatus::GMAdmin, command_tune) ||
 		command_add("ucs", "- Attempts to reconnect to the UCS server", AccountStatus::Player, command_ucs) ||
+		command_add("undye", "- Remove dye from all of your or your target's armor slots", AccountStatus::GMAdmin, command_undye) ||
 		command_add("undyeme", "- Remove dye from all of your armor slots", AccountStatus::Player, command_undyeme) ||
 		command_add("unfreeze", "- Unfreeze your target", AccountStatus::QuestTroupe, command_unfreeze) ||
 		command_add("unlock", "- Unlock the worldserver", AccountStatus::GMLeadAdmin, command_unlock) ||

--- a/zone/gm_commands/undye.cpp
+++ b/zone/gm_commands/undye.cpp
@@ -2,11 +2,23 @@
 
 void command_undye(Client *c, const Seperator *sep)
 {
+	auto target = c;
 	if (c->GetTarget() && c->GetTarget()->IsClient()) {
-		c->GetTarget()->CastToClient()->Undye();
+		target = c->GetTarget()->CastToClient();
 	}
-	else {
-		c->Message(Chat::White, "ERROR: Client target required");
-	}
-}
 
+	target->Undye();
+	c->Message(
+		Chat::White,
+		fmt::format(
+			"Undyed armor for {}.",
+			c == target ?
+			"yourself" :
+			fmt::format(
+				"{} ({})",
+				target->GetCleanName(),
+				target->GetID()
+			)
+		).c_str()
+	);
+}

--- a/zone/gm_commands/undyeme.cpp
+++ b/zone/gm_commands/undyeme.cpp
@@ -2,9 +2,6 @@
 
 void command_undyeme(Client *c, const Seperator *sep)
 {
-	if (c) {
-		c->Undye();
-		c->Message(Chat::Red, "Dye removed from all slots. Please zone for the process to complete.");
-	}
+	c->Undye();
+	c->Message(Chat::White, "Undyed armor for yourself.");
 }
-


### PR DESCRIPTION
- Fix #undye command as its method was not being used in command.cpp.
- Cleanup messages and logic for both #undye and #undyeme.