### PR TITLE
[Commands] Cleanup #flagedit Command.

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -183,7 +183,7 @@ int command_init(void)
 		command_add("findzone", "[search criteria] - Search database zones", AccountStatus::GMAdmin, command_findzone) ||
 		command_add("fixmob", "[race|gender|texture|helm|face|hair|haircolor|beard|beardcolor|heritage|tattoo|detail] [next|prev] - Manipulate appearance of your target", AccountStatus::QuestTroupe, command_fixmob) ||
 		command_add("flag", "[status] [acctname] - Refresh your admin status, or set an account's admin status if arguments provided", AccountStatus::Player, command_flag) ||
-		command_add("flagedit", "- Edit zone flags on your target", AccountStatus::GMAdmin, command_flagedit) ||
+		command_add("flagedit", "- Edit zone flags on your target. Use #flagedit help for more info.", AccountStatus::GMAdmin, command_flagedit) ||
 		command_add("flags", "- displays the flags of you or your target", AccountStatus::Player, command_flags) ||
 		command_add("flymode", "[0/1/2/3/4/5] - Set your or your player target's flymode to ground/flying/levitate/water/floating/levitate_running", AccountStatus::Guide, command_flymode) ||
 		command_add("fov", "- Check wether you're behind or in your target's field of view", AccountStatus::QuestTroupe, command_fov) ||

--- a/zone/gm_commands/flagedit.cpp
+++ b/zone/gm_commands/flagedit.cpp
@@ -2,156 +2,289 @@
 
 void command_flagedit(Client *c, const Seperator *sep)
 {
-	//super-command for editing zone flags
-	if (sep->arg[1][0] == '\0' || !strcasecmp(sep->arg[1], "help")) {
-		c->Message(Chat::White, "Syntax: #flagedit [lockzone|unlockzone|listzones|give|take].");
+	int arguments = sep->argnum;
+	if (!arguments) {
+		auto flags_link = EQ::SayLinkEngine::GenerateQuestSaylink("#flags", false, "#flags");
 		c->Message(
 			Chat::White,
-			"...lockzone [zone id/short] [flag name] - Set the specified flag name on the zone, locking the zone"
+			"Usage: #flagedit lock [Zone ID|Zone Short Name] [Flag Name] - Set the specified flag name on the zone, locking the zone"
 		);
-		c->Message(Chat::White, "...unlockzone [zone id/short] - Removes the flag requirement from the specified zone");
-		c->Message(Chat::White, "...listzones - List all zones which require a flag, and their flag's name");
-		c->Message(Chat::White, "...give [zone id/short] - Give your target the zone flag for the specified zone.");
 		c->Message(
 			Chat::White,
-			"...take [zone id/short] - Take the zone flag for the specified zone away from your target"
+			"Usage: #flagedit unlock [Zone ID|Zone Short Name] - Removes the flag requirement from the specified zone"
 		);
-		c->Message(Chat::White, "...Note: use #flags to view flags on a person");
+		c->Message(
+			Chat::White,
+			"Usage: #flagedit list - List all zones which require a flag, and their flag's name"
+		);
+		c->Message(
+			Chat::White,
+			"Usage: #flagedit give [Zone ID|Zone Short Name] - Give your target the zone flag for the specified zone."
+		);
+		c->Message(
+			Chat::White,
+			"Usage: #flagedit take [Zone ID|Zone Short Name] - Take the zone flag for the specified zone away from your target"
+		);
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"Note: Use {} to view the flags a player has.",
+				flags_link
+			).c_str()
+		);
 		return;
 	}
 
-	if (!strcasecmp(sep->arg[1], "lockzone")) {
-		uint32 zoneid = 0;
-		if (sep->arg[2][0] != '\0') {
-			zoneid = atoi(sep->arg[2]);
-			if (zoneid < 1) {
-				zoneid = ZoneID(sep->arg[2]);
+	bool is_give = !strcasecmp(sep->arg[1], "give");
+	bool is_list = !strcasecmp(sep->arg[1], "list");
+	bool is_lock = !strcasecmp(sep->arg[1], "lock");
+	bool is_take = !strcasecmp(sep->arg[1], "take");
+	bool is_unlock = !strcasecmp(sep->arg[1], "unlock");
+
+	if (
+		!is_give &&
+		!is_list &&
+		!is_lock &&
+		!is_take &&
+		!is_unlock
+	) {
+		auto flags_link = EQ::SayLinkEngine::GenerateQuestSaylink("#flags", false, "#flags");
+		c->Message(
+			Chat::White,
+			"Usage: #flagedit lock [Zone ID|Zone Short Name] [Flag Name] - Set the specified flag name on the zone, locking the zone"
+		);
+		c->Message(
+			Chat::White,
+			"Usage: #flagedit unlock [Zone ID|Zone Short Name] - Removes the flag requirement from the specified zone"
+		);
+		c->Message(
+			Chat::White,
+			"Usage: #flagedit list - List all zones which require a flag, and their flag's name"
+		);
+		c->Message(
+			Chat::White,
+			"Usage: #flagedit give [Zone ID|Zone Short Name] - Give your target the zone flag for the specified zone."
+		);
+		c->Message(
+			Chat::White,
+			"Usage: #flagedit take [Zone ID|Zone Short Name] - Take the zone flag for the specified zone away from your target"
+		);
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"Note: Use {} to view the flags a player has.",
+				flags_link
+			).c_str()
+		);
+		return;
+	}
+
+	if (is_give) {
+		uint32 zone_id = (
+			sep->IsNumber(2) ?
+			std::stoul(sep->arg[2]) :
+			ZoneID(sep->arg[2])
+		);
+		std::string zone_short_name = str_tolower(ZoneName(zone_id, true));
+		bool is_unknown_zone = zone_short_name.find("unknown") != std::string::npos;
+		if (zone_id && !is_unknown_zone) {
+			std::string zone_long_name = ZoneLongName(zone_id);
+			auto target = c;
+			if (c->GetTarget() && c->GetTarget()->IsClient()) {
+				target = c->GetTarget()->CastToClient();
 			}
-		}
-		if (zoneid < 1) {
-			c->Message(Chat::Red, "zone required. see help.");
-			return;
-		}
 
-		char flag_name[128];
-		if (sep->argplus[3][0] == '\0') {
-			c->Message(Chat::Red, "flag name required. see help.");
-			return;
-		}
-		database.DoEscapeString(flag_name, sep->argplus[3], 64);
-		flag_name[127] = '\0';
-
-		std::string query   = StringFormat(
-			"UPDATE zone SET flag_needed = '%s' "
-			"WHERE zoneidnumber = %d AND version = %d",
-			flag_name, zoneid, zone->GetInstanceVersion());
-		auto        results = content_db.QueryDatabase(query);
-		if (!results.Success()) {
-			c->Message(Chat::Red, "Error updating zone: %s", results.ErrorMessage().c_str());
-			return;
-		}
-
-		c->Message(Chat::Yellow, "Success! Zone %s now requires a flag, named %s", ZoneName(zoneid), flag_name);
-		return;
-	}
-
-	if (!strcasecmp(sep->arg[1], "unlockzone")) {
-		uint32 zoneid = 0;
-		if (sep->arg[2][0] != '\0') {
-			zoneid = atoi(sep->arg[2]);
-			if (zoneid < 1) {
-				zoneid = ZoneID(sep->arg[2]);
-			}
-		}
-
-		if (zoneid < 1) {
-			c->Message(Chat::Red, "zone required. see help.");
-			return;
-		}
-
-		std::string query   = StringFormat(
-			"UPDATE zone SET flag_needed = '' "
-			"WHERE zoneidnumber = %d AND version = %d",
-			zoneid, zone->GetInstanceVersion());
-		auto        results = content_db.QueryDatabase(query);
-		if (!results.Success()) {
-			c->Message(Chat::Yellow, "Error updating zone: %s", results.ErrorMessage().c_str());
-			return;
-		}
-
-		c->Message(Chat::Yellow, "Success! Zone %s no longer requires a flag.", ZoneName(zoneid));
-		return;
-	}
-
-	if (!strcasecmp(sep->arg[1], "listzones")) {
-		std::string query   = "SELECT zoneidnumber, short_name, long_name, version, flag_needed "
-							  "FROM zone WHERE flag_needed != ''";
-		auto        results = content_db.QueryDatabase(query);
-		if (!results.Success()) {
-			return;
-		}
-
-		c->Message(Chat::White, "Zones which require flags:");
-		for (auto row = results.begin(); row != results.end(); ++row)
+			target->SetZoneFlag(zone_id);
 			c->Message(
 				Chat::White,
-				"Zone %s (%s,%s) version %s requires key %s",
-				row[2],
+				fmt::format(
+					"{} now {} the flag for {} ({}).",
+					c == target ?
+					"You" :
+					fmt::format(
+						"{} ({})",
+						target->GetCleanName(),
+						target->GetID()
+					),
+					c == target ? "have" : "has",
+					zone_long_name,
+					zone_id
+				).c_str()
+			);
+			return;
+		}
+	} else if (is_list) {
+		std::string query = SQL(
+			SELECT long_name, zoneidnumber, version, flag_needed
+			FROM zone
+			WHERE flag_needed != ''
+			ORDER BY long_name ASC
+		);
+		auto results = content_db.QueryDatabase(query);
+		if (!results.Success()) {
+			return;
+		}
+
+		std::string popup_text = "<table>";
+		
+		popup_text += "<tr><td>Zone</td><td>Flag Required</td></tr>";
+
+		for (auto row : results) {
+			popup_text += fmt::format(
+				"<tr><td>{} ({}){}</td><td>{}</td></tr>",
 				row[0],
 				row[1],
-				row[3],
-				row[4]
+				(
+					std::stoi(row[2]) != 0 ?
+					fmt::format(
+						"[Version {}]",
+						row[2]
+					) :
+					""
+				),
+				row[3]
+			);
+		}
+
+		popup_text += "</table>";
+
+		c->SendPopupToClient(
+			"Zone Flags",
+			popup_text.c_str()
+		);
+
+		return;
+	} else if (is_lock) {
+		uint32 zone_id = (
+			sep->IsNumber(2) ?
+			std::stoul(sep->arg[2]) :
+			ZoneID(sep->arg[2])
+		);
+		std::string zone_short_name = str_tolower(ZoneName(zone_id, true));
+		bool is_unknown_zone = zone_short_name.find("unknown") != std::string::npos;
+		if (zone_id && !is_unknown_zone) {
+			if (arguments < 3) {
+				c->Message(
+					Chat::White,
+					"Usage: #flagedit lock [Zone ID|Zone Short Name] [Flag Name] - Set the specified flag name on the zone, locking the zone"
+				);
+				return;
+			}
+			
+			std::string flag_name = EscapeString(sep->argplus[3]);
+			std::string zone_long_name = ZoneLongName(zone_id);
+
+			auto query = fmt::format(
+				SQL(
+					UPDATE zone
+					SET flag_needed = '{}'
+					WHERE zoneidnumber = {} AND version = {}
+				),
+				flag_name,
+				zone_id,
+				zone->GetInstanceVersion()
 			);
 
-		return;
-	}
-
-	if (!strcasecmp(sep->arg[1], "give")) {
-		uint32 zoneid = 0;
-		if (sep->arg[2][0] != '\0') {
-			zoneid = atoi(sep->arg[2]);
-			if (zoneid < 1) {
-				zoneid = ZoneID(sep->arg[2]);
+			auto results = content_db.QueryDatabase(query);
+			if (!results.Success()) {
+				c->Message(
+					Chat::White,
+					fmt::format(
+						"Error updating zone flag for {} ({}).",
+						zone_long_name,
+						zone_id
+					).c_str()
+				);
+				return;
 			}
-		}
-		if (zoneid < 1) {
-			c->Message(Chat::Red, "zone required. see help.");
+
+			c->Message(
+				Chat::White,
+				fmt::format(
+					"{} ({}) now requires a flag, named {}.",
+					zone_long_name,
+					zone_id,
+					flag_name
+				).c_str()
+			);
 			return;
 		}
-
-		Mob *t = c->GetTarget();
-		if (t == nullptr || !t->IsClient()) {
-			c->Message(Chat::Red, "client target required");
-			return;
-		}
-
-		t->CastToClient()->SetZoneFlag(zoneid);
-		return;
-	}
-
-	if (!strcasecmp(sep->arg[1], "give")) {
-		uint32 zoneid = 0;
-		if (sep->arg[2][0] != '\0') {
-			zoneid = atoi(sep->arg[2]);
-			if (zoneid < 1) {
-				zoneid = ZoneID(sep->arg[2]);
+	} else if (is_take) {
+		uint32 zone_id = (
+			sep->IsNumber(2) ?
+			std::stoul(sep->arg[2]) :
+			ZoneID(sep->arg[2])
+		);
+		std::string zone_short_name = str_tolower(ZoneName(zone_id, true));
+		bool is_unknown_zone = zone_short_name.find("unknown") != std::string::npos;
+		if (zone_id && !is_unknown_zone) {
+			std::string zone_long_name = ZoneLongName(zone_id);
+			auto target = c;
+			if (c->GetTarget() && c->GetTarget()->IsClient()) {
+				target = c->GetTarget()->CastToClient();
 			}
-		}
-		if (zoneid < 1) {
-			c->Message(Chat::Red, "zone required. see help.");
+
+			target->ClearZoneFlag(zone_id);
+			c->Message(
+				Chat::White,
+				fmt::format(
+					"{} no longer {} the flag for {} ({}).",
+					c == target ?
+					"You" :
+					fmt::format(
+						"{} ({})",
+						target->GetCleanName(),
+						target->GetID()
+					),
+					c == target ? "have" : "has",
+					zone_long_name,
+					zone_id
+				).c_str()
+			);
 			return;
 		}
+	} else if (is_unlock) {
+		uint32 zone_id = (
+			sep->IsNumber(2) ?
+			std::stoul(sep->arg[2]) :
+			ZoneID(sep->arg[2])
+		);
+		std::string zone_short_name = str_tolower(ZoneName(zone_id, true));
+		bool is_unknown_zone = zone_short_name.find("unknown") != std::string::npos;
+		if (zone_id && !is_unknown_zone) {
+			std::string zone_long_name = ZoneLongName(zone_id);
+			auto query = fmt::format(
+				SQL(
+					UPDATE zone
+					SET flag_needed = ''
+					WHERE zoneidnumber = {} AND version = {}
+				),
+				zone_id,
+				zone->GetInstanceVersion()
+			);
+			auto results = content_db.QueryDatabase(query);
+			if (!results.Success()) {
+				c->Message(
+					Chat::White,
+					fmt::format(
+						"Error updating zone flag for {} ({}).",
+						zone_long_name,
+						zone_id
+					).c_str()
+				);
+				return;
+			}
 
-		Mob *t = c->GetTarget();
-		if (t == nullptr || !t->IsClient()) {
-			c->Message(Chat::Red, "client target required");
+			c->Message(
+				Chat::White,
+				fmt::format(
+					"{} ({}) no longer requires a flag.",
+					zone_long_name,
+					zone_id
+				).c_str()
+			);
 			return;
 		}
-
-		t->CastToClient()->ClearZoneFlag(zoneid);
-		return;
 	}
-
-	c->Message(Chat::Yellow, "Invalid action specified. use '#flagedit help' for help");
 }
 


### PR DESCRIPTION
- Cleanup and fix messages and logic.
- Utilized popup for listing zones that have required flags.
![image](https://user-images.githubusercontent.com/89047260/152706633-57353930-d1f6-41d8-b667-317d0b6f92eb.png)