### PR TITLE
[Commands] Cleanup #logs Command.

### DIFF
--- a/zone/gm_commands/logs.cpp
+++ b/zone/gm_commands/logs.cpp
@@ -5,97 +5,198 @@ extern WorldServer worldserver;
 
 void command_logs(Client *c, const Seperator *sep)
 {
-	int logs_set = 0;
-	if (sep->argnum > 0) {
-		/* #logs reload_all */
-		if (strcasecmp(sep->arg[1], "reload_all") == 0) {
-			auto pack = new ServerPacket(ServerOP_ReloadLogs, 0);
-			worldserver.SendPacket(pack);
-			c->Message(
-				Chat::Red,
-				"Successfully sent the packet to world to reload log settings from the database for all zones"
-			);
-			safe_delete(pack);
-		}
-		/* #logs list_settings */
-		if (strcasecmp(sep->arg[1], "list_settings") == 0 ||
-			(strcasecmp(sep->arg[1], "set") == 0 && strcasecmp(sep->arg[3], "") == 0)) {
-			c->Message(Chat::White, "[Category ID | console | file | gmsay | Category Description]");
-			int      redisplay_columns = 0;
-			for (int i                 = 0; i < Logs::LogCategory::MaxCategoryID; i++) {
-				if (redisplay_columns == 10) {
-					c->Message(Chat::White, "[Category ID | console | file | gmsay | Category Description]");
-					redisplay_columns = 0;
-				}
-				c->Message(
-					0,
-					StringFormat(
-						"--- %i | %u | %u | %u | %s",
-						i,
-						LogSys.log_settings[i].log_to_console,
-						LogSys.log_settings[i].log_to_file,
-						LogSys.log_settings[i].log_to_gmsay,
-						Logs::LogCategoryName[i]
-					).c_str());
-				redisplay_columns++;
-			}
-		}
-		/* #logs set */
-		if (strcasecmp(sep->arg[1], "set") == 0) {
-			if (strcasecmp(sep->arg[2], "console") == 0) {
-				LogSys.log_settings[atoi(sep->arg[3])].log_to_console = atoi(sep->arg[4]);
-				logs_set = 1;
-			}
-			else if (strcasecmp(sep->arg[2], "file") == 0) {
-				LogSys.log_settings[atoi(sep->arg[3])].log_to_file = atoi(sep->arg[4]);
-				logs_set = 1;
-			}
-			else if (strcasecmp(sep->arg[2], "gmsay") == 0) {
-				LogSys.log_settings[atoi(sep->arg[3])].log_to_gmsay = atoi(sep->arg[4]);
-				logs_set = 1;
-			}
-			else {
-				c->Message(
-					Chat::White,
-					"--- #logs set [console|file|gmsay] <category_id> <debug_level (1-3)> - Sets log settings during the lifetime of the zone"
-				);
-				c->Message(Chat::White, "--- #logs set gmsay 20 1 - Would output Quest errors to gmsay");
-			}
-			if (logs_set == 1) {
-				c->Message(Chat::Yellow, "Your Log Settings have been applied");
-				c->Message(
-					Chat::Yellow,
-					"Output Method: %s :: Debug Level: %i - Category: %s",
-					sep->arg[2],
-					atoi(sep->arg[4]),
-					Logs::LogCategoryName[atoi(sep->arg[3])]
-				);
-			}
-			/* We use a general 'is_category_enabled' now, let's update when we update any output settings
-				This is used in hot places of code to check if its enabled in any way before triggering logs
-			*/
-			if (atoi(sep->arg[4]) > 0) {
-				LogSys.log_settings[atoi(sep->arg[3])].is_category_enabled = 1;
-			}
-			else {
-				LogSys.log_settings[atoi(sep->arg[3])].is_category_enabled = 0;
-			}
-		}
+	int arguments = sep->argnum;
+	if (!arguments) {
+		c->Message(
+			Chat::White,
+			"#logs list - Shows current log settings and categories loaded into the current process' memory for the first 50 log categories"
+		);
+		c->Message(
+			Chat::White,
+			"#logs list [Start Category ID] - Shows current log settings and categories loaded into the current process' memory, only shows 50 at a time starting at specified Category ID"
+		);
+		c->Message(
+			Chat::White,
+			"#logs reload - Reload all settings in world and all zone processes with what is defined in the database"
+		);
+		c->Message(
+			Chat::White,
+			"#logs set [console|file|gmsay] [Category ID] [Debug Level (1-3)] - Sets log settings during the lifetime of the zone"
+		);
+		return;
 	}
-	else {
-		c->Message(Chat::White, "#logs usage:");
+	
+	bool is_list = !strcasecmp(sep->arg[1], "list");
+	bool is_reload = !strcasecmp(sep->arg[1], "reload");
+	bool is_set = !strcasecmp(sep->arg[1], "set");
+
+	if (!is_list && !is_reload && !is_set) {
 		c->Message(
 			Chat::White,
-			"--- #logs reload_all - Reload all settings in world and all zone processes with what is defined in the database"
+			"#logs list - Shows current log settings and categories loaded into the current process' memory for the first 50 log categories"
 		);
 		c->Message(
 			Chat::White,
-			"--- #logs list_settings - Shows current log settings and categories loaded into the current process' memory"
+			"#logs list [Start Category ID] - Shows current log settings and categories loaded into the current process' memory, only shows 50 at a time starting at specified Category ID"
 		);
 		c->Message(
 			Chat::White,
-			"--- #logs set [console|file|gmsay] <category_id> <debug_level (1-3)> - Sets log settings during the lifetime of the zone"
+			"#logs reload - Reload all settings in world and all zone processes with what is defined in the database"
 		);
+		c->Message(
+			Chat::White,
+			"#logs set [console|file|gmsay] [Category ID] [Debug Level (1-3)] - Sets log settings during the lifetime of the zone"
+		);
+		return;
+	}
+
+	if (is_list) {
+		uint32 start_category_id = 1;
+		if (sep->IsNumber(2)) {
+			start_category_id = std::stoul(sep->arg[2]);
+		}
+
+		uint32 max_category_id = (start_category_id + 49);
+
+		std::string popup_text = "<table>";
+
+		popup_text += "<tr>";
+		popup_text += "<td>ID</td>";
+		popup_text += "<td>Name</td>";
+		popup_text += "<td>Console</td>";
+		popup_text += "<td>File</td>";
+		popup_text += "<td>GM Say</td>";
+		popup_text += "</tr>";
+
+		for (int index = start_category_id; index <= max_category_id; index++) {
+			if (index >= Logs::LogCategory::MaxCategoryID) {
+				max_category_id = (Logs::LogCategory::MaxCategoryID - 1);
+				break;
+			}
+			
+			popup_text += fmt::format(
+				"<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>",
+				index,
+				Logs::LogCategoryName[index],
+				LogSys.log_settings[index].log_to_console,
+				LogSys.log_settings[index].log_to_file,
+				LogSys.log_settings[index].log_to_gmsay
+			);
+		}
+
+		popup_text += "</table>";
+
+		std::string popup_title = fmt::format(
+			"Log Settings [{} to {}]",
+			start_category_id,
+			max_category_id
+		);
+
+		c->SendPopupToClient(
+			popup_title.c_str(),
+			popup_text.c_str()
+		);
+
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"Viewing log category settings from {} ({}) to {} ({}).",
+				Logs::LogCategoryName[start_category_id],
+				start_category_id,
+				Logs::LogCategoryName[max_category_id],
+				max_category_id
+			).c_str()
+		);
+
+		int next_category_id = (max_category_id + 1);
+		if (next_category_id < Logs::LogCategory::MaxCategoryID) {
+			auto next_list_string = fmt::format(
+				"#logs list {}",
+				next_category_id
+			);
+
+			auto next_list_link = EQ::SayLinkEngine::GenerateQuestSaylink(
+				next_list_string,
+				false,
+				next_list_string
+			);
+
+			c->Message(
+				Chat::White,
+				fmt::format(
+					"To view the next 50 log settings, you can use {}.",
+					next_list_link
+				).c_str()
+			);
+		}
+	} else if (is_reload) {
+		auto pack = new ServerPacket(ServerOP_ReloadLogs, 0);
+		worldserver.SendPacket(pack);
+		c->Message(
+			Chat::White,
+			"Reloaded log settings worldwide."
+		);
+		safe_delete(pack);
+	} else if (is_set) {
+		auto logs_set = false;
+		bool is_console = !strcasecmp(sep->arg[2], "console");
+		bool is_file = !strcasecmp(sep->arg[2], "file");
+		bool is_gmsay = !strcasecmp(sep->arg[2], "gmsay");
+
+		if (!is_console && !is_file && !is_gmsay) {
+			c->Message(
+				Chat::White,
+				"#logs set [console|file|gmsay] [Category ID] [Debug Level (1-3)] - Sets log settings during the lifetime of the zone"
+			);
+			c->Message(Chat::White, "Example: #logs set gmsay 20 1 - Would output Quest errors to gmsay");
+			return;
+		}
+
+		logs_set = true;
+
+		auto category_id = std::stoul(sep->arg[3]);
+		auto setting = std::stoul(sep->arg[4]);
+
+		if (is_console) {
+			LogSys.log_settings[category_id].log_to_console = setting;
+		} else if (is_file) {
+			LogSys.log_settings[category_id].log_to_file = setting;
+		} else if (is_gmsay) {
+			LogSys.log_settings[category_id].log_to_gmsay = setting;
+		}
+
+		if (logs_set) {
+			std::string popup_text = "<table>";
+
+			popup_text += fmt::format(
+				"<tr><td>ID</td><td>{}</td><tr>",
+				category_id
+			);
+
+			popup_text += fmt::format(
+				"<tr><td>Category</td><td>{}</td><tr>",
+				Logs::LogCategoryName[category_id]
+			);
+
+			popup_text += fmt::format(
+				"<tr><td>Method</td><td>{}</td></tr>",
+				sep->arg[2]
+			);
+
+			popup_text += fmt::format(
+				"<tr><td>Setting</td><td>{}</td></tr>",
+				setting
+			);
+
+			popup_text += "</table>";
+
+			c->SendPopupToClient(
+				"Log Settings Applied",
+				popup_text.c_str()
+			);
+		}
+
+		LogSys.log_settings[category_id].is_category_enabled = setting ? 1 : 0;
 	}
 }
 


### PR DESCRIPTION
- Cleanup messages and logic.
- Utilize popup for list and applying settings.
- #logs reload_all is now #logs reload
- #logs list_settings is now #logs list
- #logs list has option starting category ID for listing purposes.
![image](https://user-images.githubusercontent.com/89047260/152716709-95fdc6b7-7351-4145-9bf9-d071a39197d2.png)
![image](https://user-images.githubusercontent.com/89047260/152716745-8edb2bf4-8f85-4352-a12f-84a1c231a36e.png)
![image](https://user-images.githubusercontent.com/89047260/152716771-4b146e6b-9183-4697-97e7-02ba2b188711.png)
![image](https://user-images.githubusercontent.com/89047260/152716799-14221e6f-0c03-4635-ab39-4b93f7ef31fd.png)
