### PR TITLE
[Spells] Fix for AA and Discipline recast timers being set on spell casting failure.

### DIFF
--- a/zone/aa.cpp
+++ b/zone/aa.cpp
@@ -1227,27 +1227,27 @@ void Client::IncrementAlternateAdvancementRank(int rank_id) {
 void Client::ActivateAlternateAdvancementAbility(int rank_id, int target_id) {
 	AA::Rank *rank = zone->GetAlternateAdvancementRank(rank_id);
 
-	if(!rank) {
+	if (!rank) {
 		return;
 	}
 
 	AA::Ability *ability = rank->base_ability;
-	if(!ability) {
+	if (!ability) {
 		return;
 	}
 
-	if(!IsValidSpell(rank->spell)) {
+	if (!IsValidSpell(rank->spell)) {
 		return;
 	}
 
-	if(!CanUseAlternateAdvancementRank(rank)) {
+	if (!CanUseAlternateAdvancementRank(rank)) {
 		return;
 	}
-	
+
 	bool use_toggle_passive_hotkey = UseTogglePassiveHotkey(*rank);
 
 	//make sure it is not a passive
-	if(!rank->effects.empty() && !use_toggle_passive_hotkey) {
+	if (!rank->effects.empty() && !use_toggle_passive_hotkey) {
 		return;
 	}
 
@@ -1256,32 +1256,26 @@ void Client::ActivateAlternateAdvancementAbility(int rank_id, int target_id) {
 	if (!GetAA(rank_id, &charges))
 		return;
 	//if expendable make sure we have charges
-	if(ability->charges > 0 && charges < 1)
+	if (ability->charges > 0 && charges < 1)
 		return;
 
 	//check cooldown
-	if(!p_timers.Expired(&database, rank->spell_type + pTimerAAStart, false)) {
+	if (!p_timers.Expired(&database, rank->spell_type + pTimerAAStart, false)) {
 		uint32 aaremain = p_timers.GetRemainingTime(rank->spell_type + pTimerAAStart);
 		uint32 aaremain_hr = aaremain / (60 * 60);
 		uint32 aaremain_min = (aaremain / 60) % 60;
 		uint32 aaremain_sec = aaremain % 60;
 
-		if(aaremain_hr >= 1) {
+		if (aaremain_hr >= 1) {
 			Message(Chat::Red, "You can use this ability again in %u hour(s) %u minute(s) %u seconds",
-			aaremain_hr, aaremain_min, aaremain_sec);
+				aaremain_hr, aaremain_min, aaremain_sec);
 		}
 		else {
 			Message(Chat::Red, "You can use this ability again in %u minute(s) %u seconds",
-			aaremain_min, aaremain_sec);
+				aaremain_min, aaremain_sec);
 		}
 
 		return;
-	}
-
-	//calculate cooldown
-	int cooldown = rank->recast_time - GetAlternateAdvancementCooldownReduction(rank);
-	if(cooldown < 0) {
-		cooldown = 0;
 	}
 
 	if (!IsCastWhileInvis(rank->spell))
@@ -1312,24 +1306,17 @@ void Client::ActivateAlternateAdvancementAbility(int rank_id, int target_id) {
 	}
 	else {
 		// Bards can cast instant cast AAs while they are casting or channeling item cast.
-		if (GetClass() == BARD  && IsCasting() && spells[rank->spell].cast_time == 0) {
+		if (GetClass() == BARD && IsCasting() && spells[rank->spell].cast_time == 0) {
 			if (!DoCastingChecksOnCaster(rank->spell)) {
 				return;
 			}
-			if (!SpellFinished(rank->spell, entity_list.GetMob(target_id), EQ::spells::CastingSlot::AltAbility, spells[rank->spell].mana, -1, spells[rank->spell].resist_difficulty, false)) {
-				return;
-			}
-			ExpendAlternateAdvancementCharge(ability->id);
+			SpellFinished(rank->spell, entity_list.GetMob(target_id), EQ::spells::CastingSlot::AltAbility, spells[rank->spell].mana, -1,
+				spells[rank->spell].resist_difficulty, false, -1, 0xFFFFFFFF, 0, false, rank->id);
 		}
 		else {
-			if (!CastSpell(rank->spell, target_id, EQ::spells::CastingSlot::AltAbility, -1, -1, 0, -1, rank->spell_type + pTimerAAStart, cooldown, nullptr, rank->id)) {
-				return;
-			}
+			CastSpell(rank->spell, target_id, EQ::spells::CastingSlot::AltAbility, -1, -1, 0, -1, 0xFFFFFFFF, 0, nullptr, rank->id);
 		}
 	}
-
-	CastToClient()->GetPTimers().Start(rank->spell_type + pTimerAAStart, cooldown);
-	SendAlternateAdvancementTimer(rank->spell_type, 0, 0);
 }
 
 int Mob::GetAlternateAdvancementCooldownReduction(AA::Rank *rank_in) {

--- a/zone/aa.cpp
+++ b/zone/aa.cpp
@@ -1226,7 +1226,7 @@ void Client::IncrementAlternateAdvancementRank(int rank_id) {
 
 void Client::ActivateAlternateAdvancementAbility(int rank_id, int target_id) {
 	AA::Rank *rank = zone->GetAlternateAdvancementRank(rank_id);
-
+	Shout("1 Client::ActivateAlternateAdvancementAbility");
 	if (!rank) {
 		return;
 	}
@@ -1240,7 +1240,7 @@ void Client::ActivateAlternateAdvancementAbility(int rank_id, int target_id) {
 		return;
 	}
 	//do not allow AA to cast if your actively casting another AA.
-	if (rank->spell == casting_spell_id) {
+	if (rank->spell == casting_spell_id && rank->id == casting_spell_aa_id) {
 		return;
 	}
 
@@ -1264,7 +1264,7 @@ void Client::ActivateAlternateAdvancementAbility(int rank_id, int target_id) {
 	if (ability->charges > 0 && charges < 1) {
 		return;
 	}
-
+	Shout("2 Client::ActivateAlternateAdvancementAbility");
 	//check cooldown
 	if (!p_timers.Expired(&database, rank->spell_type + pTimerAAStart, false)) {
 		uint32 aaremain = p_timers.GetRemainingTime(rank->spell_type + pTimerAAStart);
@@ -1293,13 +1293,15 @@ void Client::ActivateAlternateAdvancementAbility(int rank_id, int target_id) {
 	}
 	//
 	// Modern clients don't require pet targeted for AA casts that are ST_Pet
-	if (spells[rank->spell].target_type == ST_Pet || spells[rank->spell].target_type == ST_SummonedPet)
+	if (spells[rank->spell].target_type == ST_Pet || spells[rank->spell].target_type == ST_SummonedPet) {
 		target_id = GetPetID();
+	}
 
 	// extra handling for cast_not_standing spells
 	if (!IgnoreCastingRestriction(rank->spell)) {
-		if (GetAppearance() == eaSitting) // we need to stand!
+		if (GetAppearance() == eaSitting) { // we need to stand!
 			SetAppearance(eaStanding, false);
+		}
 
 		if (GetAppearance() != eaStanding) {
 			MessageString(Chat::SpellFailure, STAND_TO_CAST);
@@ -1327,6 +1329,10 @@ void Client::ActivateAlternateAdvancementAbility(int rank_id, int target_id) {
 
 void Client::SetAARecastTimer(AA::Rank *rank_in, int32 spell_id) {
 	
+	if (!rank_in) {
+		return;
+	}
+
 	//calculate AA cooldown
 	int timer_duration = rank_in->recast_time - GetAlternateAdvancementCooldownReduction(rank_in);
 	
@@ -1370,6 +1376,8 @@ int Mob::GetAlternateAdvancementCooldownReduction(AA::Rank *rank_in) {
 }
 
 void Mob::ExpendAlternateAdvancementCharge(uint32 aa_id) {
+	Shout("Mob::ExpendAlternateAdvancementCharge");
+	return;
 	for (auto &iter : aa_ranks) {
 		AA::Ability *ability = zone->GetAlternateAdvancementAbility(iter.first);
 		if (ability && aa_id == ability->id) {

--- a/zone/aa.cpp
+++ b/zone/aa.cpp
@@ -1226,7 +1226,7 @@ void Client::IncrementAlternateAdvancementRank(int rank_id) {
 
 void Client::ActivateAlternateAdvancementAbility(int rank_id, int target_id) {
 	AA::Rank *rank = zone->GetAlternateAdvancementRank(rank_id);
-	Shout("1 Client::ActivateAlternateAdvancementAbility");
+
 	if (!rank) {
 		return;
 	}
@@ -1264,7 +1264,7 @@ void Client::ActivateAlternateAdvancementAbility(int rank_id, int target_id) {
 	if (ability->charges > 0 && charges < 1) {
 		return;
 	}
-	Shout("2 Client::ActivateAlternateAdvancementAbility");
+
 	//check cooldown
 	if (!p_timers.Expired(&database, rank->spell_type + pTimerAAStart, false)) {
 		uint32 aaremain = p_timers.GetRemainingTime(rank->spell_type + pTimerAAStart);
@@ -1376,8 +1376,7 @@ int Mob::GetAlternateAdvancementCooldownReduction(AA::Rank *rank_in) {
 }
 
 void Mob::ExpendAlternateAdvancementCharge(uint32 aa_id) {
-	Shout("Mob::ExpendAlternateAdvancementCharge");
-	return;
+
 	for (auto &iter : aa_ranks) {
 		AA::Ability *ability = zone->GetAlternateAdvancementAbility(iter.first);
 		if (ability && aa_id == ability->id) {

--- a/zone/aa.cpp
+++ b/zone/aa.cpp
@@ -1239,6 +1239,10 @@ void Client::ActivateAlternateAdvancementAbility(int rank_id, int target_id) {
 	if (!IsValidSpell(rank->spell)) {
 		return;
 	}
+	//do not allow AA to cast if your actively casting another AA.
+	if (rank->spell == casting_spell_id) {
+		return;
+	}
 
 	if (!CanUseAlternateAdvancementRank(rank)) {
 		return;
@@ -1312,9 +1316,9 @@ void Client::ActivateAlternateAdvancementAbility(int rank_id, int target_id) {
 			if (!DoCastingChecksOnCaster(rank->spell)) {
 				return;
 			}
-			SpellFinished(rank->spell, entity_list.GetMob(target_id), EQ::spells::CastingSlot::AltAbility, spells[rank->spell].mana, -1,
-				spells[rank->spell].resist_difficulty, false, -1, 0xFFFFFFFF, 0, false, rank->id);
+			SpellFinished(rank->spell, entity_list.GetMob(target_id), EQ::spells::CastingSlot::AltAbility, spells[rank->spell].mana, -1, spells[rank->spell].resist_difficulty, false, -1, false, rank->id);
 		}
+		//Known issue: If you attempt to give a Bard an AA with a cast time, the cast timer will not display on the client (no live bard AA have cast time).
 		else {
 			CastSpell(rank->spell, target_id, EQ::spells::CastingSlot::AltAbility, -1, -1, 0, -1, 0xFFFFFFFF, 0, nullptr, rank->id);
 		}

--- a/zone/client.h
+++ b/zone/client.h
@@ -1495,6 +1495,8 @@ public:
 	void SendItemRecastTimer(int32 recast_type, uint32 recast_delay = 0);
 	void SetItemRecastTimer(int32 spell_id, uint32 inventory_slot);
 	bool HasItemRecastTimer(int32 spell_id, uint32 inventory_slot);
+	void SetDisciplineRecastTimer(int32 spell_id);
+	void SetAARecastTimer(AA::Rank *rank_in, int32 spell_id);
 
 	inline bool AggroMeterAvailable() const { return ((m_ClientVersionBit & EQ::versions::maskRoF2AndLater)) && RuleB(Character, EnableAggroMeter); } // RoF untested
 	inline void SetAggroMeterLock(int in) { m_aggrometer.set_lock_id(in); }

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -800,51 +800,15 @@ bool Client::UseDiscipline(uint32 spell_id, uint32 target) {
 		return false;
 	}
 
-	bool instant_recast = true;
-
-	if(spell.recast_time > 0) {
-		uint32 reduced_recast = spell.recast_time / 1000;
-		auto focus = GetFocusEffect(focusReduceRecastTime, spell_id);
-		// do stupid stuff because custom servers.
-		// we really should be able to just do the -= focus but since custom servers could have shorter reuse timers
-		// we have to make sure we don't underflow the uint32 ...
-		// and yes, the focus effect can be used to increase the durations (spell 38944)
-		if (focus > reduced_recast) {
-			reduced_recast = 0;
-			if (GetPTimers().Enabled((uint32)DiscTimer))
-				GetPTimers().Clear(&database, (uint32)DiscTimer);
-		} else {
-			reduced_recast -= focus;
-		}
-
-		if (reduced_recast > 0){
-			instant_recast = false;
-			
-			if (GetClass() == BARD && IsCasting() && spells[spell_id].cast_time == 0) {
-				if (DoCastingChecksOnCaster(spell_id)) {
-					if (SpellFinished(spell_id, entity_list.GetMob(target), EQ::spells::CastingSlot::Discipline, 0, -1, spells[spell_id].resist_difficulty, false, -1, (uint32)DiscTimer, reduced_recast, false)) {
-						SendDisciplineTimer(spells[spell_id].timer_id, reduced_recast);
-					}
-				}
-			}
-			else {
-				if (CastSpell(spell_id, target, EQ::spells::CastingSlot::Discipline, -1, -1, 0, -1, (uint32)DiscTimer, reduced_recast)) {
-					SendDisciplineTimer(spells[spell_id].timer_id, reduced_recast);
-				}
-			}
+	if (GetClass() == BARD && IsCasting() && spells[spell_id].cast_time == 0) {
+		if (DoCastingChecksOnCaster(spell_id)) {
+			SpellFinished(spell_id, entity_list.GetMob(target), EQ::spells::CastingSlot::Discipline);
 		}
 	}
-
-	if (instant_recast)	{ 
-		if (GetClass() == BARD && IsCasting() && spells[spell_id].cast_time == 0) {
-			if (DoCastingChecksOnCaster(spell_id)) {
-				SpellFinished(spell_id, entity_list.GetMob(target), EQ::spells::CastingSlot::Discipline, 0, -1, spells[spell_id].resist_difficulty, false, -1, 0xFFFFFFFF, 0, false);
-			}
-		}
-		else {
-			CastSpell(spell_id, target, EQ::spells::CastingSlot::Discipline);
-		}
+	else {
+		CastSpell(spell_id, target, EQ::spells::CastingSlot::Discipline);
 	}
+
 	return(true);
 }
 

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -326,7 +326,7 @@ public:
 	void CastedSpellFinished(uint16 spell_id, uint32 target_id, EQ::spells::CastingSlot slot, uint16 mana_used,
 		uint32 inventory_slot = 0xFFFFFFFF, int16 resist_adjust = 0);
 	bool SpellFinished(uint16 spell_id, Mob *target, EQ::spells::CastingSlot slot = EQ::spells::CastingSlot::Item, uint16 mana_used = 0,
-		uint32 inventory_slot = 0xFFFFFFFF, int16 resist_adjust = 0, bool isproc = false, int level_override = -1, uint32 timer = 0xFFFFFFFF, uint32 timer_duration = 0, bool from_casted_spell = false);
+		uint32 inventory_slot = 0xFFFFFFFF, int16 resist_adjust = 0, bool isproc = false, int level_override = -1, uint32 timer = 0xFFFFFFFF, uint32 timer_duration = 0, bool from_casted_spell = false, uint32 aa_id = 0);
 	void SendBeginCast(uint16 spell_id, uint32 casttime);
 	virtual bool SpellOnTarget(uint16 spell_id, Mob* spelltar, int reflect_effectiveness = 0,
 		bool use_resist_adjust = false, int16 resist_adjust = 0, bool isproc = false, int level_override = -1, int32 duration_override = 0);

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -326,7 +326,7 @@ public:
 	void CastedSpellFinished(uint16 spell_id, uint32 target_id, EQ::spells::CastingSlot slot, uint16 mana_used,
 		uint32 inventory_slot = 0xFFFFFFFF, int16 resist_adjust = 0);
 	bool SpellFinished(uint16 spell_id, Mob *target, EQ::spells::CastingSlot slot = EQ::spells::CastingSlot::Item, uint16 mana_used = 0,
-		uint32 inventory_slot = 0xFFFFFFFF, int16 resist_adjust = 0, bool isproc = false, int level_override = -1, uint32 timer = 0xFFFFFFFF, uint32 timer_duration = 0, bool from_casted_spell = false, uint32 aa_id = 0);
+		uint32 inventory_slot = 0xFFFFFFFF, int16 resist_adjust = 0, bool isproc = false, int level_override = -1, bool from_casted_spell = false, uint32 aa_id = 0);
 	void SendBeginCast(uint16 spell_id, uint32 casttime);
 	virtual bool SpellOnTarget(uint16 spell_id, Mob* spelltar, int reflect_effectiveness = 0,
 		bool use_resist_adjust = false, int16 resist_adjust = 0, bool isproc = false, int level_override = -1, int32 duration_override = 0);

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -2675,7 +2675,13 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, CastingSlot slot, ui
 		SetMGB(false);
 	}
 
-	if (IsClient() && !isproc)
+	//all spell triggers use Item slot, but don't have an item associated. We don't need to check recast timers on these.
+	bool is_triggered_spell = false;
+	if (slot == CastingSlot::Item && inventory_slot == 0xFFFFFFFF) {
+		is_triggered_spell = true;
+	}
+
+	if (IsClient() && !isproc && !is_triggered_spell)
 	{
 		//Set Item or Augment Click Recast Timer
 		if (slot == CastingSlot::Item || slot == CastingSlot::PotionBelt) {

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -2685,30 +2685,23 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, CastingSlot slot, ui
 		else if (slot == CastingSlot::Discipline) {
 			CastToClient()->SetDisciplineRecastTimer(spell_id);
 		}
+		//Set AA Recast Timer.
 		else if (slot == CastingSlot::AltAbility){
-			//Set AA Recast Timer.
-			Shout("casting_spell_aa_id %i || aa_id %i slot %i spell_id %i", casting_spell_aa_id, aa_id, slot, spell_id);
 			uint32 active_aa_id = 0;
 			//aa_id is only passed directly into spellfinished when a bard is using AA while casting, this supports casting an AA while clicking an instant AA.
-			if (GetClass() == BARD && spells[spell_id].cast_time == 0 && casting_spell_aa_id != aa_id) {
+			if (GetClass() == BARD && spells[spell_id].cast_time == 0 && aa_id) {
 				active_aa_id = aa_id;
 			}
 			else {
 				active_aa_id = casting_spell_aa_id;
 			}
-			Shout("Active AA id %i Spell %i", active_aa_id, spell_id);
-
+					   
 			AA::Rank *rank = zone->GetAlternateAdvancementRank(active_aa_id);
 
 			CastToClient()->SetAARecastTimer(rank, spell_id);
-			Shout("try expendtiable");
 
-			//Need to test this for bard casts.
 			if (rank && rank->base_ability) {
 				ExpendAlternateAdvancementCharge(rank->base_ability->id);
-			}
-			else {
-				Shout("try expendtiable FAIL");
 			}
 		}
 		//Set Custom Recast Timer
@@ -2748,7 +2741,6 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, CastingSlot slot, ui
 			}
 		}
 	}
-
 
 	if (IsNPC()) {
 		CastToNPC()->AI_Event_SpellCastFinished(true, static_cast<uint16>(slot));

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -2697,13 +2697,18 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, CastingSlot slot, ui
 				active_aa_id = casting_spell_aa_id;
 			}
 			Shout("Active AA id %i Spell %i", active_aa_id, spell_id);
+
 			AA::Rank *rank = zone->GetAlternateAdvancementRank(active_aa_id);
 
 			CastToClient()->SetAARecastTimer(rank, spell_id);
+			Shout("try expendtiable");
 
 			//Need to test this for bard casts.
 			if (rank && rank->base_ability) {
 				ExpendAlternateAdvancementCharge(rank->base_ability->id);
+			}
+			else {
+				Shout("try expendtiable FAIL");
 			}
 		}
 		//Set Custom Recast Timer
@@ -2804,6 +2809,8 @@ bool Mob::ApplyBardPulse(int32 spell_id, Mob *spell_target, CastingSlot slot) {
 	if (!SpellFinished(spell_id, spell_target, slot, spells[spell_id].mana, 0xFFFFFFFF, spells[spell_id].resist_difficulty)) {
 		return false;
 	}
+
+	return true;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -2683,7 +2683,9 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, CastingSlot slot, ui
 		}
 		//Set Discipline Recast Timer
 		else if (slot == CastingSlot::Discipline) {
-			CastToClient()->SetDisciplineRecastTimer(spell_id);
+			if (spell_id == casting_spell_id || (GetClass() == BARD && spells[spell_id].cast_time == 0 && spell_id != casting_spell_id)) {
+				CastToClient()->SetDisciplineRecastTimer(spell_id);
+			}
 		}
 		//Set AA Recast Timer.
 		else if (slot == CastingSlot::AltAbility){
@@ -6321,11 +6323,9 @@ void Client::SetDisciplineRecastTimer(int32 spell_id) {
 		return;
 	}
 
-	if (spell_id == casting_spell_id || (GetClass() == BARD && spell_id != casting_spell_id && spells[spell_id].cast_time == 0)){
-		CastToClient()->GetPTimers().Start((uint32)DiscTimer, timer_duration);
-		CastToClient()->SendDisciplineTimer(spells[spell_id].timer_id, timer_duration);
-		LogSpells("Spell [{}]: Setting disciple reuse timer [{}] to [{}]", spell_id, spells[spell_id].timer_id, timer_duration);
-	}
+	CastToClient()->GetPTimers().Start((uint32)DiscTimer, timer_duration);
+	CastToClient()->SendDisciplineTimer(spells[spell_id].timer_id, timer_duration);
+	LogSpells("Spell [{}]: Setting disciple reuse timer [{}] to [{}]", spell_id, spells[spell_id].timer_id, timer_duration);
 }
 
 


### PR DESCRIPTION
Recoded how we set AA and Discipline recast timers to finally resolve issues involving recast timers on abilities being set even though the ability failed. As a result, all casting timers (Spell, AA, item, discipline) will now be set at the same location in the code when spell is finished and no further failures can occur, resolving any possibility of the timers not being reset correctly in the event of failure. This also optimizes some of the changes regarding bards casting while using disciplines or AA.