### PR TITLE
[Spells] Allow damage spells to heal if quest based spell mitigation is over 100 pct.

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -4530,7 +4530,6 @@ int32 Mob::GetVulnerability(Mob *caster, uint32 spell_id, uint32 ticsremaining)
 	}
 
 	total_mod += innate_mod;
-	Shout("total mod %i", total_mod);
 	return total_mod;
 }
 

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -4530,6 +4530,7 @@ int32 Mob::GetVulnerability(Mob *caster, uint32 spell_id, uint32 ticsremaining)
 	}
 
 	total_mod += innate_mod;
+	Shout("total mod %i", total_mod);
 	return total_mod;
 }
 

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -260,8 +260,14 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 						caster->ResourceTap(-dmg, spell_id);
 					}
 
-					dmg = -dmg;
-					Damage(caster, dmg, spell_id, spell.skill, false, buffslot, false);
+					if (dmg <= 0) {
+						dmg = -dmg;
+						Damage(caster, dmg, spell_id, spell.skill, false, buffslot, false);
+					}
+					//handles custom situation where quest function mitigation put high enough to allow damage to heal.
+					else {
+						HealDamage(dmg, caster);
+					}
 				}
 				else if(dmg > 0) {
 					//healing spell...


### PR DESCRIPTION
This restores functionality I must have accidently removed at some point. With quest added spell mitigation, if you set the mitigation to lower than -100, it would allow your damage spells to heal,  thus providing lots of fun options for developers. This only applies to quest derived spell mitigation using $npc->ModVulnerability(resist type, mitigation amount).

Example add these to an npc and all fire nukes will heal the npc for 1000% of damage done.
```
$npc->SetAllowBeneficial(1);
$npc->ModVulnerability(2, -1000);
```