### PR TITLE
[Quest API] Add AI Spell Effect methods to Perl/Lua.

### DIFF
--- a/zone/lua_npc.cpp
+++ b/zone/lua_npc.cpp
@@ -635,6 +635,24 @@ Lua_NPC_Loot_List Lua_NPC::GetLootList(lua_State* L) {
 	return ret;
 }
 
+void Lua_NPC::AddAISpellEffect(int spell_effect_id, int base_value, int limit_value, int max_value)
+{
+	Lua_Safe_Call_Void();
+	self->AddSpellEffectToNPCList(spell_effect_id, base_value, limit_value, max_value, true);
+}
+
+void Lua_NPC::RemoveAISpellEffect(int spell_effect_id)
+{
+	Lua_Safe_Call_Void();
+	self->RemoveSpellEffectFromNPCList(spell_effect_id, true);
+}
+
+bool Lua_NPC::HasAISpellEffect(int spell_effect_id)
+{
+	Lua_Safe_Call_Bool();
+	return self->HasAISpellEffect(spell_effect_id);
+}
+
 luabind::scope lua_register_npc() {
 	return luabind::class_<Lua_NPC, Lua_Mob>("NPC")	
 	.def(luabind::constructor<>())
@@ -642,6 +660,7 @@ luabind::scope lua_register_npc() {
 	.def("AI_SetRoambox", (void(Lua_NPC::*)(float,float,float,float,float,uint32,uint32))&Lua_NPC::AI_SetRoambox)
 	.def("AddAISpell", (void(Lua_NPC::*)(int,int,int,int,int,int))&Lua_NPC::AddAISpell)
 	.def("AddAISpell", (void(Lua_NPC::*)(int,int,int,int,int,int,int,int))&Lua_NPC::AddAISpell)
+	.def("AddAISpellEffect", (void(Lua_NPC::*)(int,int,int,int))&Lua_NPC::AddAISpellEffect)
 	.def("AddCash", (void(Lua_NPC::*)(int,int,int,int))&Lua_NPC::AddCash)
 	.def("AddItem", (void(Lua_NPC::*)(int,int))&Lua_NPC::AddItem)
 	.def("AddItem", (void(Lua_NPC::*)(int,int,bool))&Lua_NPC::AddItem)
@@ -711,6 +730,7 @@ luabind::scope lua_register_npc() {
 	.def("GetSwarmOwner", (int(Lua_NPC::*)(void))&Lua_NPC::GetSwarmOwner)
 	.def("GetSwarmTarget", (int(Lua_NPC::*)(void))&Lua_NPC::GetSwarmTarget)
 	.def("GetWaypointMax", (int(Lua_NPC::*)(void))&Lua_NPC::GetWaypointMax)
+	.def("HasAISpellEffect", (bool(Lua_NPC::*)(int))&Lua_NPC::HasAISpellEffect)
 	.def("HasItem", (bool(Lua_NPC::*)(uint32))&Lua_NPC::HasItem)
 	.def("IsAnimal", (bool(Lua_NPC::*)(void))&Lua_NPC::IsAnimal)
 	.def("IsGuarding", (bool(Lua_NPC::*)(void))&Lua_NPC::IsGuarding)
@@ -726,6 +746,7 @@ luabind::scope lua_register_npc() {
 	.def("PickPocket", (void(Lua_NPC::*)(Lua_Client))&Lua_NPC::PickPocket)
 	.def("RecalculateSkills", (void(Lua_NPC::*)(void))&Lua_NPC::RecalculateSkills)
 	.def("RemoveAISpell", (void(Lua_NPC::*)(int))&Lua_NPC::RemoveAISpell)
+	.def("RemoveAISpellEffect", (void(Lua_NPC::*)(int))&Lua_NPC::RemoveAISpellEffect)
 	.def("RemoveCash", (void(Lua_NPC::*)(void))&Lua_NPC::RemoveCash)
 	.def("RemoveItem", (void(Lua_NPC::*)(int))&Lua_NPC::RemoveItem)
 	.def("RemoveItem", (void(Lua_NPC::*)(int,int))&Lua_NPC::RemoveItem)

--- a/zone/lua_npc.h
+++ b/zone/lua_npc.h
@@ -149,6 +149,9 @@ public:
 	float GetHealScale();
 	float GetSpellScale();
 	Lua_NPC_Loot_List GetLootList(lua_State* L);
+	void AddAISpellEffect(int spell_effect_id, int base_value, int limit_value, int max_value);
+	void RemoveAISpellEffect(int spell_effect_id);
+	bool HasAISpellEffect(int spell_effect_id);
 };
 
 #endif

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -2799,6 +2799,17 @@ void NPC::RemoveSpellEffectFromNPCList(uint16 iSpellEffectID, bool apply_bonus)
 	}
 }
 
+bool NPC::HasAISpellEffect(uint16 spell_effect_id)
+{
+	for (const auto& spell_effect : AIspellsEffects) {
+		if (spell_effect.spelleffectid == spell_effect_id) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 bool IsSpellEffectInList(DBnpcspellseffects_Struct* spelleffect_list, uint16 iSpellEffectID, int32 base_value, int32 limit, int32 max_value) {
 	for (uint32 i=0; i < spelleffect_list->numentries; i++) {
 		if (spelleffect_list->entries[i].spelleffectid == iSpellEffectID &&  spelleffect_list->entries[i].base_value == base_value

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -452,6 +452,7 @@ public:
 	void AddSpellEffectToNPCList(uint16 iSpellEffectID, int32 base_value, int32 limit, int32 max_value, bool apply_bonus = false);
 	void RemoveSpellFromNPCList(uint16 spell_id);
 	void RemoveSpellEffectFromNPCList(uint16 iSpellEffectID, bool apply_bonus = false);
+	bool HasAISpellEffect(uint16 spell_effect_id);
 	Timer *GetRefaceTimer() const { return reface_timer; }
 	const uint32 GetAltCurrencyType() const { return NPCTypedata->alt_currency_type; }
 

--- a/zone/perl_npc.cpp
+++ b/zone/perl_npc.cpp
@@ -1849,14 +1849,14 @@ XS(XS_NPC_AddAISpellEffect); /* prototype to pass -Wmissing-prototypes */
 XS(XS_NPC_AddAISpellEffect) {
 	dXSARGS;
 	if (items != 5)
-		Perl_croak(aTHX_ "Usage: NPC::AddAISpellEffect(THIS, spell_effect id, base_value, limit_value, max_value)"); // @categories Spells and Disciplines
+		Perl_croak(aTHX_ "Usage: NPC::AddAISpellEffect(THIS, int spell_effect_id, int base_value, int limit_value, int max_value)"); // @categories Spells and Disciplines
 	{
 		NPC *THIS;
 
-		int spell_effect_id = (int)SvIV(ST(1));
-		int base_value		= (int)SvIV(ST(2));
-		int limit_value		= (int)SvIV(ST(3));
-		int max_value		= (int)SvIV(ST(4));
+		int spell_effect_id = (int) SvIV(ST(1));
+		int base_value = (int) SvIV(ST(2));
+		int limit_value = (int) SvIV(ST(3));
+		int max_value = (int) SvIV(ST(4));
 
 		VALIDATE_THIS_IS_NPC;
 		THIS->AddSpellEffectToNPCList(spell_effect_id, base_value, limit_value, max_value, true);
@@ -1868,16 +1868,32 @@ XS(XS_NPC_RemoveAISpellEffect); /* prototype to pass -Wmissing-prototypes */
 XS(XS_NPC_RemoveAISpellEffect) {
 	dXSARGS;
 	if (items != 2)
-		Perl_croak(aTHX_ "Usage: NPC::RemoveAISpellEffect(THIS, int spelleffect_id)"); // @categories Spells and Disciplines
+		Perl_croak(aTHX_ "Usage: NPC::RemoveAISpellEffect(THIS, int spell_effect_id)"); // @categories Spells and Disciplines
 	{
 		NPC *THIS;
-		int spell_effect_id = (int)SvIV(ST(1));
+		int spell_effect_id = (int) SvIV(ST(1));
 		VALIDATE_THIS_IS_NPC;
 		THIS->RemoveSpellEffectFromNPCList(spell_effect_id, true);
 	}
 	XSRETURN_EMPTY;
 }
 
+XS(XS_NPC_HasAISpellEffect); /* prototype to pass -Wmissing-prototypes */
+XS(XS_NPC_HasAISpellEffect) {
+	dXSARGS;
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: NPC::HasAISpellEffect(THIS, int spell_effect_id)"); // @categories Spells and Disciplines
+	{
+		NPC *THIS;
+		bool has_spell_effect = false;
+		int spell_effect_id = (int) SvIV(ST(1));
+		VALIDATE_THIS_IS_NPC;
+		has_spell_effect = THIS->HasAISpellEffect(spell_effect_id);
+		ST(0) = boolSV(has_spell_effect);
+		sv_2mortal(ST(0));
+	}
+	XSRETURN(1);
+}
 
 #ifdef __cplusplus
 extern "C"
@@ -1959,6 +1975,7 @@ XS(boot_NPC) {
 	newXSproto(strcpy(buf, "GetSwarmOwner"), XS_NPC_GetSwarmOwner, file, "$");
 	newXSproto(strcpy(buf, "GetSwarmTarget"), XS_NPC_GetSwarmTarget, file, "$");
 	newXSproto(strcpy(buf, "GetWaypointMax"), XS_NPC_GetWaypointMax, file, "$");
+	newXSproto(strcpy(buf, "HasAISpellEffect"), XS_NPC_HasAISpellEffect, file, "$$");
 	newXSproto(strcpy(buf, "HasItem"), XS_NPC_HasItem, file, "$$");
 	newXSproto(strcpy(buf, "IsAnimal"), XS_NPC_IsAnimal, file, "$");
 	newXSproto(strcpy(buf, "IsGuarding"), XS_NPC_IsGuarding, file, "$");


### PR DESCRIPTION
- Add $npc->HasAISpellEffect(spell_effect_id) to Perl.
- Add npc:AddAISpellEffect(spell_effect_id, base_value, limit_value, max_value) to Lua.
- Add npc:HasAISpellEffect(spell_effect_id) to Lua.
- Add npc:RemoveAISpellEffect(spell_effect_id) to Lua.