### PR TITLE
[Feature] Send message when trying to invite player already in group.

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -192,6 +192,7 @@ RULE_INT(Character, MagicianTrackingDistanceMultiplier, 0, "If you want magician
 RULE_INT(Character, EnchanterTrackingDistanceMultiplier, 0, "If you want enchanters to be able to track, increase this above 0.  0 disables tracking packets.")
 RULE_INT(Character, BeastlordTrackingDistanceMultiplier, 0, "If you want beastlords to be able to track, increase this above 0.  0 disables tracking packets.")
 RULE_INT(Character, BerserkerTrackingDistanceMultiplier, 0, "If you want berserkers to be able to track, increase this above 0.  0 disables tracking packets.")
+RULE_BOOL(Character, OnInviteReceiveAlreadyinGroupMessage, true, "If you want clients to receive a message when trying to invite a player into a group that is currently in another group.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Mercs)

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -6960,6 +6960,13 @@ void Client::Handle_OP_GroupInvite2(const EQApplicationPacket *app)
 					Invitee->CastToClient()->QueuePacket(app);
 				}
 			}
+			else {
+				if (RuleB(Character, OnInviteReceiveAlreadyinGroupMessage)) {
+					if (!Invitee->CastToClient()->MercOnlyOrNoGroup()) {
+						Message(Chat::LightGray, "%s is already in another group.", Invitee->GetCleanName());
+					}
+				}
+			}
 		}
 #ifdef BOTS
 		else if (Invitee->IsBot()) {

--- a/zone/string_ids.h
+++ b/zone/string_ids.h
@@ -469,6 +469,7 @@
 #define LEADER_OF_X_GUILD			12258
 #define NOT_IN_A_GUILD				12259
 #define TARGET_PLAYER_FOR_GUILD_STATUS		12260
+#define TARGET_ALREADY_IN_GROUP		12265	//% 1 is already in another group.
 #define GROUP_INVITEE_NOT_FOUND		12268	//You must target a player or use /invite <name> to invite someone to your group.
 #define GROUP_INVITEE_SELF			12270	//12270 You cannot invite yourself.
 #define ALREADY_IN_PARTY			12272	//That person is already in your party.


### PR DESCRIPTION
When trying to invite a client into your group who is already in a group, if you have the rule enabled you will receive a message informing you that the player is already in a group.

RULE_BOOL(Character, OnInviteReceiveAlreadyinGroupMessage)

*Note string id was not displaying properly so didn't use it.