### PR TITLE
[Spells] Invisibility updates and rework

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -404,7 +404,7 @@ RULE_BOOL(Spells, July242002PetResists, true, "Enable Pets using PCs resist chan
 RULE_INT(Spells, AOEMaxTargets, 0, "Max number of targets a Targeted AOE spell can cast on. Set to 0 for no limit.")
 RULE_BOOL(Spells, CazicTouchTargetsPetOwner, true, "If True, causes Cazic Touch to swap targets from pet to pet owner if a pet is tanking.")
 RULE_BOOL(Spells, PreventFactionWarOnCharmBreak, false, "Enable spell interupts and dot removal on charm break to prevent faction wars.")
-RULE_BOOL(Spells, AllowDoubleInvis, false, "Allows you to cast invisibility spells on a player that is already invisible")
+RULE_BOOL(Spells, AllowDoubleInvis, true, "Allows you to cast invisibility spells on a player that is already invisible, live like behavior.")
 RULE_BOOL(Spells, AllowSpellMemorizeFromItem, false, "Allows players to memorize spells by right-clicking spell scrolls")
 RULE_BOOL(Spells, InvisRequiresGroup, false, "Invis requires the the target to be in group.")
 RULE_INT(Spells, ClericInnateHealFocus, 5, "Clerics on live get a 5 pct innate heal focus")

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -191,6 +191,8 @@
 #define MAX_APPEARANCE_EFFECTS 20 //Up to 20 Appearance Effects can be saved to a mobs appearance effect array, these will be sent to other clients when they enter a zone (This is arbitrary)
 #define MAX_CAST_ON_SKILL_USE 36 //Actual amount is MAX/3
 
+#define MAX_INVISIBILTY_LEVEL 254
+
 //instrument item id's used as song components
 #define INSTRUMENT_HAND_DRUM 13000
 #define INSTRUMENT_WOODEN_FLUTE 13001

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -541,10 +541,10 @@ enum ReflectSpellType
 	REFLECT_ALL_SPELLS                = 4,
 };
 
-enum InvisibilityType {
-	TYPE_INVISIBLE					= 0,
-	TYPE_INVISIBLE_VERSE_UNDEAD		= 1,
-	TYPE_INVISIBLE_VERSE_ANIMAL		= 2,
+enum InvisType {
+	T_INVISIBLE						= 0,
+	T_INVISIBLE_VERSE_UNDEAD		= 1,
+	T_INVISIBLE_VERSE_ANIMAL		= 2,
 };
 
 //For better organizing in proc effects, not used in spells.

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -540,6 +540,14 @@ enum ReflectSpellType
 	RELFECT_ALL_SINGLE_TARGET_SPELLS  = 3,
 	REFLECT_ALL_SPELLS                = 4,
 };
+
+enum InvisibilityType {
+	TYPE_INVISIBLE					= 0,
+	TYPE_INVISIBLE_VERSE_UNDAEAD	= 1,
+	TYPE_INVISIBLE_VERSE_ANIMAL		= 3,
+	TYPE_HIDDEN						= 4,
+};
+
 //For better organizing in proc effects, not used in spells.
 enum ProcType
 {

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1047,7 +1047,7 @@ typedef enum {
 #define SE_ForageAdditionalItems		313	// implemented[AA] - chance to forage additional items
 #define SE_Invisibility2				314 // implemented - fixed duration invisible
 #define SE_InvisVsUndead2				315 // implemented - fixed duration ITU
-//#define SE_ImprovedInvisAnimals		316	// not used
+#define SE_ImprovedInvisAnimals			316	// implemented
 #define SE_ItemHPRegenCapIncrease		317	// implemented[AA] - increases amount of health regen gained via items
 #define SE_ItemManaRegenCapIncrease		318 // implemented - increases amount of mana regen you can gain via items
 #define SE_CriticalHealOverTime			319 // implemented

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -543,9 +543,8 @@ enum ReflectSpellType
 
 enum InvisibilityType {
 	TYPE_INVISIBLE					= 0,
-	TYPE_INVISIBLE_VERSE_UNDAEAD	= 1,
-	TYPE_INVISIBLE_VERSE_ANIMAL		= 3,
-	TYPE_HIDDEN						= 4,
+	TYPE_INVISIBLE_VERSE_UNDEAD		= 1,
+	TYPE_INVISIBLE_VERSE_ANIMAL		= 2,
 };
 
 //For better organizing in proc effects, not used in spells.

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -5631,19 +5631,19 @@ void Mob::CommonBreakInvisibleFromCombat()
 		LogCombat("Removing invisibility due to melee attack");
 		BuffFadeByEffect(SE_Invisibility);
 		BuffFadeByEffect(SE_Invisibility2);
-		RemoveInvisible(InvisibilityType::TYPE_INVISIBLE);
+		ZeroInvisibleVars(InvisibilityType::TYPE_INVISIBLE);
 	}
 	if (invisible_undead) {
 		LogCombat("Removing invisibility vs. undead due to melee attack");
 		BuffFadeByEffect(SE_InvisVsUndead);
 		BuffFadeByEffect(SE_InvisVsUndead2);
-		RemoveInvisible(InvisibilityType::TYPE_INVISIBLE_VERSE_UNDEAD);
+		ZeroInvisibleVars(InvisibilityType::TYPE_INVISIBLE_VERSE_UNDEAD);
 	}
 	if (invisible_animals) {
 		LogCombat("Removing invisibility vs. animals due to melee attack");
 		BuffFadeByEffect(SE_ImprovedInvisAnimals);
 		BuffFadeByEffect(SE_InvisVsAnimals);
-		RemoveInvisible(InvisibilityType::TYPE_INVISIBLE_VERSE_ANIMAL);
+		ZeroInvisibleVars(InvisibilityType::TYPE_INVISIBLE_VERSE_ANIMAL);
 	}
 
 	CancelSneakHide();

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -5631,19 +5631,19 @@ void Mob::CommonBreakInvisibleFromCombat()
 		LogCombat("Removing invisibility due to melee attack");
 		BuffFadeByEffect(SE_Invisibility);
 		BuffFadeByEffect(SE_Invisibility2);
-		ZeroInvisibleVars(InvisibilityType::TYPE_INVISIBLE);
+		ZeroInvisibleVars(InvisType::T_INVISIBLE);
 	}
 	if (invisible_undead) {
 		LogCombat("Removing invisibility vs. undead due to melee attack");
 		BuffFadeByEffect(SE_InvisVsUndead);
 		BuffFadeByEffect(SE_InvisVsUndead2);
-		ZeroInvisibleVars(InvisibilityType::TYPE_INVISIBLE_VERSE_UNDEAD);
+		ZeroInvisibleVars(InvisType::T_INVISIBLE_VERSE_UNDEAD);
 	}
 	if (invisible_animals) {
 		LogCombat("Removing invisibility vs. animals due to melee attack");
 		BuffFadeByEffect(SE_ImprovedInvisAnimals);
 		BuffFadeByEffect(SE_InvisVsAnimals);
-		ZeroInvisibleVars(InvisibilityType::TYPE_INVISIBLE_VERSE_ANIMAL);
+		ZeroInvisibleVars(InvisType::T_INVISIBLE_VERSE_ANIMAL);
 	}
 
 	CancelSneakHide();

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -5631,18 +5631,19 @@ void Mob::CommonBreakInvisibleFromCombat()
 		LogCombat("Removing invisibility due to melee attack");
 		BuffFadeByEffect(SE_Invisibility);
 		BuffFadeByEffect(SE_Invisibility2);
-		invisible = false;
+		RemoveInvisible(InvisibilityType::TYPE_INVISIBLE);
 	}
 	if (invisible_undead) {
 		LogCombat("Removing invisibility vs. undead due to melee attack");
 		BuffFadeByEffect(SE_InvisVsUndead);
 		BuffFadeByEffect(SE_InvisVsUndead2);
-		invisible_undead = false;
+		RemoveInvisible(InvisibilityType::TYPE_INVISIBLE_VERSE_UNDAEAD);
 	}
 	if (invisible_animals) {
 		LogCombat("Removing invisibility vs. animals due to melee attack");
+		BuffFadeByEffect(SE_ImprovedInvisAnimals);
 		BuffFadeByEffect(SE_InvisVsAnimals);
-		invisible_animals = false;
+		RemoveInvisible(InvisibilityType::TYPE_INVISIBLE_VERSE_ANIMAL);
 	}
 
 	CancelSneakHide();

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -5637,7 +5637,7 @@ void Mob::CommonBreakInvisibleFromCombat()
 		LogCombat("Removing invisibility vs. undead due to melee attack");
 		BuffFadeByEffect(SE_InvisVsUndead);
 		BuffFadeByEffect(SE_InvisVsUndead2);
-		RemoveInvisible(InvisibilityType::TYPE_INVISIBLE_VERSE_UNDAEAD);
+		RemoveInvisible(InvisibilityType::TYPE_INVISIBLE_VERSE_UNDEAD);
 	}
 	if (invisible_animals) {
 		LogCombat("Removing invisibility vs. animals due to melee attack");

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -5625,7 +5625,6 @@ void Mob::DoShieldDamageOnShielder(Mob *shield_target, int hit_damage_done, EQ::
 
 void Mob::CommonBreakInvisibleFromCombat()
 {
-	Shout("CommonBreakInvisibleFromCombat()");
 	//break invis when you attack
 	BreakInvisibleSpells();
 	CancelSneakHide();

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -5627,29 +5627,12 @@ void Mob::CommonBreakInvisibleFromCombat()
 {
 	Shout("CommonBreakInvisibleFromCombat()");
 	//break invis when you attack
-	if (invisible) {
-		LogCombat("Removing invisibility due to melee attack");
-		BuffFadeByEffect(SE_Invisibility);
-		BuffFadeByEffect(SE_Invisibility2);
-		ZeroInvisibleVars(InvisType::T_INVISIBLE);
-	}
-	if (invisible_undead) {
-		LogCombat("Removing invisibility vs. undead due to melee attack");
-		BuffFadeByEffect(SE_InvisVsUndead);
-		BuffFadeByEffect(SE_InvisVsUndead2);
-		ZeroInvisibleVars(InvisType::T_INVISIBLE_VERSE_UNDEAD);
-	}
-	if (invisible_animals) {
-		LogCombat("Removing invisibility vs. animals due to melee attack");
-		BuffFadeByEffect(SE_ImprovedInvisAnimals);
-		BuffFadeByEffect(SE_InvisVsAnimals);
-		ZeroInvisibleVars(InvisType::T_INVISIBLE_VERSE_ANIMAL);
-	}
-
+	BreakInvisibleSpells();
 	CancelSneakHide();
 
-	if (spellbonuses.NegateIfCombat)
+	if (spellbonuses.NegateIfCombat) {
 		BuffFadeByEffect(SE_NegateIfCombat);
+	}
 
 	hidden = false;
 	improved_hidden = false;

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -5625,6 +5625,7 @@ void Mob::DoShieldDamageOnShielder(Mob *shield_target, int hit_damage_done, EQ::
 
 void Mob::CommonBreakInvisibleFromCombat()
 {
+	Shout("CommonBreakInvisibleFromCombat()");
 	//break invis when you attack
 	if (invisible) {
 		LogCombat("Removing invisibility due to melee attack");

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -48,6 +48,7 @@ void Mob::CalcBonuses()
 	SetAttackTimer();
 	CalcAC();
 	CalcSeeInvisibleLevel();
+	CalcInvisibleLevel();
 
 	/* Fast walking NPC's are prone to disappear into walls/hills
 		We set this here because NPC's can cast spells to change walkspeed/runspeed
@@ -81,6 +82,9 @@ void Client::CalcBonuses()
 	CalcEdibleBonuses(&itembonuses);
 	CalcSpellBonuses(&spellbonuses);
 	CalcAABonuses(&aabonuses);
+
+	CalcSeeInvisibleLevel();
+	CalcInvisibleLevel();
 
 	ProcessItemCaps(); // caps that depend on spell/aa bonuses
 

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -872,6 +872,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			newbon->MaxBindWound += base_value;
 			break;
 		case SE_SeeInvis:
+			base_value = std::min({ base_value, MAX_INVISIBILTY_LEVEL });
 			if (newbon->SeeInvis < base_value) {
 				newbon->SeeInvis = base_value;
 			}
@@ -3833,6 +3834,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 
 			case SE_Invisibility:
 			case SE_Invisibility2:
+				effect_value = std::min({ effect_value, MAX_INVISIBILTY_LEVEL });
 				if (new_bonus->invisibility < effect_value)
 					new_bonus->invisibility = effect_value;
 				break;
@@ -3844,11 +3846,13 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 
 			case SE_InvisVsAnimals:
+				effect_value = std::min({ effect_value, MAX_INVISIBILTY_LEVEL });
 				if (new_bonus->invisibility_verse_animal < effect_value)
 					new_bonus->invisibility_verse_animal = effect_value;
 				break;
 
 			case SE_SeeInvis:
+				effect_value = std::min({ effect_value, MAX_INVISIBILTY_LEVEL });
 				if (new_bonus->SeeInvis < effect_value) {
 					new_bonus->SeeInvis = effect_value;
 				}

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -871,7 +871,6 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 				newbon->SeeInvis = base_value;
 			}
 			SetSeeInvisibleLevel();
-			SetSeeInvisible(std::max({ spellbonuses.SeeInvis, itembonuses.SeeInvis, aabonuses.SeeInvis }));
 			break;
 		case SE_BaseMovementSpeed:
 			newbon->BaseMovementSpeed += base_value;

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -867,7 +867,8 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			newbon->MaxBindWound += base_value;
 			break;
 		case SE_SeeInvis:
-			newbon->SeeInvis = base_value;
+			if (newbon->SeeInvis < base_value)
+				newbon->SeeInvis = base_value;
 			break;
 		case SE_BaseMovementSpeed:
 			newbon->BaseMovementSpeed += base_value;
@@ -3839,6 +3840,11 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 			case SE_InvisVsAnimals:
 				if (new_bonus->invisibility_verse_animal < effect_value)
 					new_bonus->invisibility_verse_animal = effect_value;
+				break;
+
+			case SE_SeeInvis:
+				if (new_bonus->SeeInvis < effect_value)
+					new_bonus->SeeInvis = effect_value;
 				break;
 
 			case SE_ZoneSuspendMinion:

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -867,8 +867,11 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			newbon->MaxBindWound += base_value;
 			break;
 		case SE_SeeInvis:
-			if (newbon->SeeInvis < base_value)
+			if (newbon->SeeInvis < base_value) {
 				newbon->SeeInvis = base_value;
+			}
+			SetSeeInvisibleLevel();
+			SetSeeInvisible(std::max({ spellbonuses.SeeInvis, itembonuses.SeeInvis, aabonuses.SeeInvis }));
 			break;
 		case SE_BaseMovementSpeed:
 			newbon->BaseMovementSpeed += base_value;
@@ -3843,8 +3846,10 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 
 			case SE_SeeInvis:
-				if (new_bonus->SeeInvis < effect_value)
+				if (new_bonus->SeeInvis < effect_value) {
 					new_bonus->SeeInvis = effect_value;
+				}
+				SetSeeInvisibleLevel();
 				break;
 
 			case SE_ZoneSuspendMinion:

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -3824,6 +3824,23 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
+			case SE_Invisibility:
+			case SE_Invisibility2:
+				if (new_bonus->invisibility < effect_value)
+					new_bonus->invisibility = effect_value;
+				break;
+
+			case SE_InvisVsUndead:
+			case SE_InvisVsUndead2:
+				if (new_bonus->invisibility_verse_undead < effect_value)
+					new_bonus->invisibility_verse_undead = effect_value;
+				break;
+
+			case SE_InvisVsAnimals:
+				if (new_bonus->invisibility_verse_animal < effect_value)
+					new_bonus->invisibility_verse_animal = effect_value;
+				break;
+
 			case SE_ZoneSuspendMinion:
 				new_bonus->ZoneSuspendMinion = effect_value;
 				break;

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -47,6 +47,7 @@ void Mob::CalcBonuses()
 	CalcMaxMana();
 	SetAttackTimer();
 	CalcAC();
+	CalcSeeInvisibleLevel();
 
 	/* Fast walking NPC's are prone to disappear into walls/hills
 		We set this here because NPC's can cast spells to change walkspeed/runspeed
@@ -870,7 +871,6 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			if (newbon->SeeInvis < base_value) {
 				newbon->SeeInvis = base_value;
 			}
-			SetSeeInvisibleLevel();
 			break;
 		case SE_BaseMovementSpeed:
 			newbon->BaseMovementSpeed += base_value;
@@ -3848,7 +3848,6 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				if (new_bonus->SeeInvis < effect_value) {
 					new_bonus->SeeInvis = effect_value;
 				}
-				SetSeeInvisibleLevel();
 				break;
 
 			case SE_ZoneSuspendMinion:

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -7437,6 +7437,8 @@ void Bot::CalcBonuses() {
 	CalcSpellBonuses(&spellbonuses);
 	CalcAABonuses(&aabonuses);
 	SetAttackTimer();
+	CalcSeeInvisibleLevel();
+	CalcInvisibleLevel();
 	CalcATK();
 	CalcSTR();
 	CalcSTA();

--- a/zone/bot_command.h
+++ b/zone/bot_command.h
@@ -109,7 +109,7 @@ public:
 	} AType;
 	static const int AilmentTypeCount = 5;
 
-	typedef enum InvisibilityType {
+	typedef enum InvisType {
 		IT_None = 0,
 		IT_Animal,
 		IT_Undead,

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -3453,7 +3453,7 @@ uint8 Client::SlotConvert2(uint8 slot){
 void Client::Escape()
 {
 	entity_list.RemoveFromTargets(this, true);
-	SetInvisibleAppearance(Invisibility::Invisible);
+	SetInvisible(Invisibility::Invisible);
 	MessageString(Chat::Skills, ESCAPE);
 }
 

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -3453,7 +3453,7 @@ uint8 Client::SlotConvert2(uint8 slot){
 void Client::Escape()
 {
 	entity_list.RemoveFromTargets(this, true);
-	SetInvisible(Invisibility::Invisible);
+	SetInvisibleAppearance(Invisibility::Invisible);
 
 	MessageString(Chat::Skills, ESCAPE);
 }

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -3454,7 +3454,6 @@ void Client::Escape()
 {
 	entity_list.RemoveFromTargets(this, true);
 	SetInvisibleAppearance(Invisibility::Invisible);
-
 	MessageString(Chat::Skills, ESCAPE);
 }
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -682,8 +682,7 @@ void Client::CompleteConnect()
 			case SE_Invisibility2:
 			case SE_Invisibility:
 			{
-				invisible = true;
-				SendAppearancePacket(AT_Invis, 1);
+				SendAppearancePacket(AT_Invis, Invisibility::Invisible);
 				break;
 			}
 			case SE_Levitate:
@@ -705,18 +704,6 @@ void Client::CompleteConnect()
 						SendAppearancePacket(AT_Levitate, EQ::constants::GravityBehavior::Levitating, true, true);
 					}
 				}
-				break;
-			}
-			case SE_InvisVsUndead2:
-			case SE_InvisVsUndead:
-			{
-				invisible_undead = true;
-				break;
-			}
-			case SE_ImprovedInvisAnimals:
-			case SE_InvisVsAnimals:
-			{
-				invisible_animals = true;
 				break;
 			}
 			case SE_AddMeleeProc:

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4839,7 +4839,7 @@ void Client::Handle_OP_Consider(const EQApplicationPacket *app)
 
 	// this could be done better, but this is only called when you con so w/e
 	// Shroud of Stealth has a special message
-	if (improved_hidden && (!tmob->see_improved_hide && (tmob->see_invis || tmob->see_hide)))
+	if (improved_hidden && (!tmob->see_improved_hide && (tmob->SeeInvisible() || tmob->see_hide)))
 		MessageString(Chat::NPCQuestSay, SOS_KEEPS_HIDDEN);
 	// we are trying to hide but they can see us
 	else if ((invisible || invisible_undead || hidden || invisible_animals) && !IsInvisible(tmob))

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -13553,7 +13553,7 @@ void Client::Handle_OP_SpawnAppearance(const EQApplicationPacket *app)
 			}
 			return;
 		}
-		RemoveInvisible(InvisibilityType::TYPE_INVISIBLE);
+		ZeroInvisibleVars(InvisibilityType::TYPE_INVISIBLE);
 		hidden = false;
 		improved_hidden = false;
 		entity_list.QueueClients(this, app, true);

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -13553,7 +13553,7 @@ void Client::Handle_OP_SpawnAppearance(const EQApplicationPacket *app)
 			}
 			return;
 		}
-		invisible = false;
+		RemoveInvisible(InvisibilityType::TYPE_INVISIBLE);
 		hidden = false;
 		improved_hidden = false;
 		entity_list.QueueClients(this, app, true);

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -3986,18 +3986,22 @@ void Client::Handle_OP_CastSpell(const EQApplicationPacket *app)
 	}
 
 	Shout("Bonuses %i", spellbonuses.invisibility);
-	if (spellbonuses.invisibility) {
+	if (invisible) {
+		Shout("nuke ALL invs");
+		ZeroInvisibleVars(InvisType::T_INVISIBLE);
 		BuffFadeByEffect(SE_Invisibility);
 		BuffFadeByEffect(SE_Invisibility2);
 	}
 
 	Shout("Casting %i %i %i", invisible_undead, invisible_animals, invisible);
 	// Hack for broken RoF2 which allows casting after a zoned IVU/IVA
-	if (invisible_undead || invisible_animals) {
-		BuffFadeByEffect(SE_InvisVsAnimals);
-		BuffFadeByEffect(SE_ImprovedInvisAnimals);
+	if (invisible_undead) {
 		BuffFadeByEffect(SE_InvisVsUndead);
 		BuffFadeByEffect(SE_InvisVsUndead2);
+	}
+	if (invisible_animals) {
+		BuffFadeByEffect(SE_InvisVsAnimals);
+		BuffFadeByEffect(SE_ImprovedInvisAnimals);
 	}
 	Shout("Casting DROP %i %i %i", invisible_undead, invisible_animals, invisible);
 	CastSpell_Struct* castspell = (CastSpell_Struct*)app->pBuffer;

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -713,6 +713,7 @@ void Client::CompleteConnect()
 				invisible_undead = true;
 				break;
 			}
+			case SE_ImprovedInvisAnimals:
 			case SE_InvisVsAnimals:
 			{
 				invisible_animals = true;
@@ -4007,6 +4008,7 @@ void Client::Handle_OP_CastSpell(const EQApplicationPacket *app)
 	// Hack for broken RoF2 which allows casting after a zoned IVU/IVA
 	if (invisible_undead || invisible_animals) {
 		BuffFadeByEffect(SE_InvisVsAnimals);
+		BuffFadeByEffect(SE_ImprovedInvisAnimals);
 		BuffFadeByEffect(SE_InvisVsUndead);
 		BuffFadeByEffect(SE_InvisVsUndead2);
 	}

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -3985,15 +3985,12 @@ void Client::Handle_OP_CastSpell(const EQApplicationPacket *app)
 		return;
 	}
 
-	Shout("Bonuses %i", spellbonuses.invisibility);
 	if (invisible) {
-		Shout("nuke ALL invs");
 		ZeroInvisibleVars(InvisType::T_INVISIBLE);
 		BuffFadeByEffect(SE_Invisibility);
 		BuffFadeByEffect(SE_Invisibility2);
 	}
 
-	Shout("Casting %i %i %i", invisible_undead, invisible_animals, invisible);
 	// Hack for broken RoF2 which allows casting after a zoned IVU/IVA
 	if (invisible_undead) {
 		BuffFadeByEffect(SE_InvisVsUndead);
@@ -4003,7 +4000,7 @@ void Client::Handle_OP_CastSpell(const EQApplicationPacket *app)
 		BuffFadeByEffect(SE_InvisVsAnimals);
 		BuffFadeByEffect(SE_ImprovedInvisAnimals);
 	}
-	Shout("Casting DROP %i %i %i", invisible_undead, invisible_animals, invisible);
+
 	CastSpell_Struct* castspell = (CastSpell_Struct*)app->pBuffer;
 
 	m_TargetRing = glm::vec3(castspell->x_pos, castspell->y_pos, castspell->z_pos);

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -3828,8 +3828,6 @@ void Client::Handle_OP_Buff(const EQApplicationPacket *app)
 		QueuePacket(app);
 	}
 	else {
-		Shout("Bonuses %i", spellbonuses.invisibility);
-		Shout("Handle_OP_Buff Fade buff %i", spid);
 		BuffFadeBySpellID(spid);
 	}
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -13553,7 +13553,7 @@ void Client::Handle_OP_SpawnAppearance(const EQApplicationPacket *app)
 			}
 			return;
 		}
-		ZeroInvisibleVars(InvisibilityType::TYPE_INVISIBLE);
+		ZeroInvisibleVars(InvisType::T_INVISIBLE);
 		hidden = false;
 		improved_hidden = false;
 		entity_list.QueueClients(this, app, true);

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -1163,9 +1163,9 @@ void Client::BreakInvis()
 		sa_out->parameter = 0;
 		entity_list.QueueClients(this, outapp, true);
 		safe_delete(outapp);
-		RemoveInvisible(InvisibilityType::TYPE_INVISIBLE);
-		RemoveInvisible(InvisibilityType::TYPE_INVISIBLE_VERSE_UNDEAD);
-		RemoveInvisible(InvisibilityType::TYPE_INVISIBLE_VERSE_ANIMAL);
+		ZeroInvisibleVars(InvisibilityType::TYPE_INVISIBLE);
+		ZeroInvisibleVars(InvisibilityType::TYPE_INVISIBLE_VERSE_UNDEAD);
+		ZeroInvisibleVars(InvisibilityType::TYPE_INVISIBLE_VERSE_ANIMAL);
 		hidden = false;
 		improved_hidden = false;
 	}

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -1163,9 +1163,9 @@ void Client::BreakInvis()
 		sa_out->parameter = 0;
 		entity_list.QueueClients(this, outapp, true);
 		safe_delete(outapp);
-		invisible = false;
-		invisible_undead = false;
-		invisible_animals = false;
+		RemoveInvisible(InvisibilityType::TYPE_INVISIBLE);
+		RemoveInvisible(InvisibilityType::TYPE_INVISIBLE_VERSE_UNDEAD);
+		RemoveInvisible(InvisibilityType::TYPE_INVISIBLE_VERSE_ANIMAL);
 		hidden = false;
 		improved_hidden = false;
 	}

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -1163,9 +1163,9 @@ void Client::BreakInvis()
 		sa_out->parameter = 0;
 		entity_list.QueueClients(this, outapp, true);
 		safe_delete(outapp);
-		ZeroInvisibleVars(InvisibilityType::TYPE_INVISIBLE);
-		ZeroInvisibleVars(InvisibilityType::TYPE_INVISIBLE_VERSE_UNDEAD);
-		ZeroInvisibleVars(InvisibilityType::TYPE_INVISIBLE_VERSE_ANIMAL);
+		ZeroInvisibleVars(InvisType::T_INVISIBLE);
+		ZeroInvisibleVars(InvisType::T_INVISIBLE_VERSE_UNDEAD);
+		ZeroInvisibleVars(InvisType::T_INVISIBLE_VERSE_ANIMAL);
 		hidden = false;
 		improved_hidden = false;
 	}

--- a/zone/common.h
+++ b/zone/common.h
@@ -561,9 +561,9 @@ struct StatBonuses {
 	bool	ZoneSuspendMinion;					// base 1 allows suspended minions to zone
 	bool	CompleteHealBuffBlocker;			// Use in SPA 101 to prevent recast of complete heal from this effect till blocker buff is removed.
 	int32	Illusion;							// illusion spell id
-	int16	invisibility;						// invisibility level
-	int16	invisibility_verse_undead;			// IVU level
-	int16	invisibility_verse_animal;			// IVA level
+	uint8	invisibility;						// invisibility level
+	uint8	invisibility_verse_undead;			// IVU level
+	uint8	invisibility_verse_animal;			// IVA level
 
 	// AAs
 	int32	TrapCircumvention;					// reduce chance to trigger a trap.
@@ -583,7 +583,7 @@ struct StatBonuses {
 	int32	MaxBindWound;						// Increase max amount of HP you can bind wound.
 	int32	ChannelChanceSpells;				// Modify chance to channel a spell.
 	int32	ChannelChanceItems;					// Modify chance to channel a items.
-	int16	SeeInvis;							// See Invs.
+	uint8	SeeInvis;							// See Invs.
 	uint8	TripleBackstab;						// Chance to triple backstab
 	bool	FrontalBackstabMinDmg;				// Allow frontal backstabs for min damage
 	uint8	FrontalBackstabChance;				// Chance to backstab from the front for full damage

--- a/zone/common.h
+++ b/zone/common.h
@@ -560,6 +560,9 @@ struct StatBonuses {
 	bool	ZoneSuspendMinion;					// base 1 allows suspended minions to zone
 	bool	CompleteHealBuffBlocker;			// Use in SPA 101 to prevent recast of complete heal from this effect till blocker buff is removed.
 	int32	Illusion;							// illusion spell id
+	uint8	invisibility;						// invisibility level
+	uint8	invisibility_verse_undead;			// IVU level
+	uint8	invisibility_verse_animal;			// IVA level
 
 	// AAs
 	int32	TrapCircumvention;					// reduce chance to trigger a trap.

--- a/zone/common.h
+++ b/zone/common.h
@@ -561,9 +561,9 @@ struct StatBonuses {
 	bool	ZoneSuspendMinion;					// base 1 allows suspended minions to zone
 	bool	CompleteHealBuffBlocker;			// Use in SPA 101 to prevent recast of complete heal from this effect till blocker buff is removed.
 	int32	Illusion;							// illusion spell id
-	uint8	invisibility;						// invisibility level
-	uint8	invisibility_verse_undead;			// IVU level
-	uint8	invisibility_verse_animal;			// IVA level
+	int16	invisibility;						// invisibility level
+	int16	invisibility_verse_undead;			// IVU level
+	int16	invisibility_verse_animal;			// IVA level
 
 	// AAs
 	int32	TrapCircumvention;					// reduce chance to trigger a trap.

--- a/zone/common.h
+++ b/zone/common.h
@@ -583,7 +583,7 @@ struct StatBonuses {
 	int32	MaxBindWound;						// Increase max amount of HP you can bind wound.
 	int32	ChannelChanceSpells;				// Modify chance to channel a spell.
 	int32	ChannelChanceItems;					// Modify chance to channel a items.
-	uint8	SeeInvis;							// See Invs.
+	int16	SeeInvis;							// See Invs.
 	uint8	TripleBackstab;						// Chance to triple backstab
 	bool	FrontalBackstabMinDmg;				// Allow frontal backstabs for min damage
 	uint8	FrontalBackstabChance;				// Chance to backstab from the front for full damage

--- a/zone/gm_commands/tune.cpp
+++ b/zone/gm_commands/tune.cpp
@@ -3,9 +3,6 @@
 void command_tune(Client *c, const Seperator *sep)
 {
 	//Work in progress - Kayen
-	Mob* mytarget = c->GetTarget();
-	mytarget->Shout("See Invis Level %i", mytarget->SeeInvisible());
-	mytarget->Shout("Invisible %i", mytarget->GetInvisibleLevel());
 
 	if (sep->arg[1][0] == '\0' || !strcasecmp(sep->arg[1], "help")) {
 		c->Message(Chat::White, "Syntax: #tune [subcommand].");

--- a/zone/gm_commands/tune.cpp
+++ b/zone/gm_commands/tune.cpp
@@ -3,6 +3,11 @@
 void command_tune(Client *c, const Seperator *sep)
 {
 	//Work in progress - Kayen
+	Mob* mytarget = c->GetTarget();
+	mytarget->Shout("See Invis Level %i", mytarget->SeeInvisible());
+	mytarget->Shout("Invisible %i", mytarget->GetInvisibleLevel());
+
+
 
 	if (sep->arg[1][0] == '\0' || !strcasecmp(sep->arg[1], "help")) {
 		c->Message(Chat::White, "Syntax: #tune [subcommand].");

--- a/zone/gm_commands/tune.cpp
+++ b/zone/gm_commands/tune.cpp
@@ -7,8 +7,6 @@ void command_tune(Client *c, const Seperator *sep)
 	mytarget->Shout("See Invis Level %i", mytarget->SeeInvisible());
 	mytarget->Shout("Invisible %i", mytarget->GetInvisibleLevel());
 
-
-
 	if (sep->arg[1][0] == '\0' || !strcasecmp(sep->arg[1], "help")) {
 		c->Message(Chat::White, "Syntax: #tune [subcommand].");
 		c->Message(Chat::White, "-- Tune System Commands --");

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -319,7 +319,7 @@ bool Lua_Mob::IsInvisible(Lua_Mob other) {
 
 void Lua_Mob::SetInvisible(int state) {
 	Lua_Safe_Call_Void();
-	self->SetInvisible(state);
+	self->SetInvisibleAppearance(state);
 }
 
 bool Lua_Mob::FindBuff(int spell_id) {

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -319,7 +319,7 @@ bool Lua_Mob::IsInvisible(Lua_Mob other) {
 
 void Lua_Mob::SetInvisible(int state) {
 	Lua_Safe_Call_Void();
-	self->SetInvisibleAppearance(state);
+	self->SetInvisible(state);
 }
 
 bool Lua_Mob::FindBuff(int spell_id) {

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -2118,7 +2118,7 @@ uint8 Lua_Mob::SeeInvisible() {
 	return self->SeeInvisible();
 }
 
-bool Lua_Mob::SeeInvisibleUndead() {
+uint8 Lua_Mob::SeeInvisibleUndead() {
 	Lua_Safe_Call_Bool();
 	return self->SeeInvisibleUndead();
 }
@@ -2423,6 +2423,31 @@ Lua_NPC Lua_Mob::GetHateRandomNPC() {
 	return Lua_NPC(self->GetHateRandomNPC());
 }
 
+uint8 Lua_Mob::GetInvisibleLevel()
+{
+	Lua_Safe_Call_Int();
+	return self->GetInvisibleLevel();
+}
+
+uint8 Lua_Mob::GetInvisibleUndeadLevel()
+{
+	Lua_Safe_Call_Int();
+	return self->GetInvisibleUndeadLevel();
+}
+
+void Lua_Mob::SetSeeInvisibleLevel(uint8 invisible_level)
+{
+	Lua_Safe_Call_Void();
+	self->SetInnateSeeInvisible(invisible_level);
+	self->CalcSeeInvisibleLevel();
+}
+
+void Lua_Mob::SetSeeInvisibleUndeadLevel(uint8 invisible_level)
+{
+	Lua_Safe_Call_Void();
+	self->SetSeeInvisibleUndead(invisible_level);
+}
+
 luabind::scope lua_register_mob() {
 	return luabind::class_<Lua_Mob, Lua_Entity>("Mob")
 	.def(luabind::constructor<>())
@@ -2618,6 +2643,8 @@ luabind::scope lua_register_mob() {
 	.def("GetHelmTexture", &Lua_Mob::GetHelmTexture)
 	.def("GetHerosForgeModel", (int32(Lua_Mob::*)(uint8))&Lua_Mob::GetHerosForgeModel)
 	.def("GetINT", &Lua_Mob::GetINT)
+	.def("GetInvisibleLevel", (uint8(Lua_Mob::*)(void))&Lua_Mob::GetInvisibleLevel)
+	.def("GetInvisibleUndeadLevel", (uint8(Lua_Mob::*)(void))&Lua_Mob::GetInvisibleUndeadLevel)
 	.def("GetInvul", (bool(Lua_Mob::*)(void))&Lua_Mob::GetInvul)
 	.def("GetItemBonuses", &Lua_Mob::GetItemBonuses)
 	.def("GetItemHPBonuses", &Lua_Mob::GetItemHPBonuses)
@@ -2763,7 +2790,9 @@ luabind::scope lua_register_mob() {
 	.def("SeeHide", (bool(Lua_Mob::*)(void))&Lua_Mob::SeeHide)
 	.def("SeeImprovedHide", (bool(Lua_Mob::*)(bool))&Lua_Mob::SeeImprovedHide)
 	.def("SeeInvisible", (uint8(Lua_Mob::*)(void))&Lua_Mob::SeeInvisible)
-	.def("SeeInvisibleUndead", (bool(Lua_Mob::*)(void))&Lua_Mob::SeeInvisibleUndead)
+	.def("SeeInvisibleUndead", (uint8(Lua_Mob::*)(void))&Lua_Mob::SeeInvisibleUndead)
+	.def("SetSeeInvisibleLevel", (void(Lua_Mob::*)(uint8))&Lua_Mob::SetSeeInvisibleLevel)
+	.def("SetSeeInvisibleUndeadLevel", (void(Lua_Mob::*)(uint8))&Lua_Mob::SetSeeInvisibleUndeadLevel)
 	.def("SendAppearanceEffect", (void(Lua_Mob::*)(uint32,uint32,uint32,uint32,uint32))&Lua_Mob::SendAppearanceEffect)
 	.def("SendAppearanceEffect", (void(Lua_Mob::*)(uint32,uint32,uint32,uint32,uint32,Lua_Client))&Lua_Mob::SendAppearanceEffect)
 	.def("SendBeginCast", &Lua_Mob::SendBeginCast)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -410,7 +410,7 @@ public:
 	int CanBuffStack(int spell_id, int caster_level, bool fail_if_overwrite);
 	void SetPseudoRoot(bool in);
 	uint8 SeeInvisible();
-	bool SeeInvisibleUndead();
+	uint8 SeeInvisibleUndead();
 	bool SeeHide();
 	bool SeeImprovedHide();
 	uint8 GetNimbusEffect1();

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -86,6 +86,10 @@ public:
 	bool IsInvisible();
 	bool IsInvisible(Lua_Mob other);
     void SetInvisible(int state);
+	uint8 GetInvisibleLevel();
+	uint8 GetInvisibleUndeadLevel();
+	void SetSeeInvisibleLevel(uint8 invisible_level);
+	void SetSeeInvisibleUndeadLevel(uint8 invisible_level);
 	bool FindBuff(int spell_id);
 	uint16 FindBuffBySlot(int slot);
 	uint32 BuffCount();

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -679,20 +679,22 @@ bool Mob::IsInvisible(Mob* other)
 	}
 	//Shout("Invisible %i and See invisible %i", other->SeeInvisible());
 	//check regular invisibility
-	if (invisible && invisible > (other->SeeInvisible())) {
+	if (invisible && (invisible > other->SeeInvisible())) {
 		return true;
 	}
 
 	//check invis vs. undead
 	if (other->GetBodyType() == BT_Undead || other->GetBodyType() == BT_SummonedUndead) {
-		if(invisible_undead && !other->SeeInvisibleUndead())
+		if (invisible_undead && (invisible_undead > other->SeeInvisibleUndead())) {
 			return true;
+		}
 	}
 
-	//check invis vs. animals...
+	//check invis vs. animals. //TODO: should we have a specific see invisible animal stat or this how live does it?
 	if (other->GetBodyType() == BT_Animal){
-		if(invisible_animals && !other->SeeInvisible())
+		if (invisible_animals && (invisible_animals > other->SeeInvisible())) {
 			return true;
+		}
 	}
 
 	if(hidden){
@@ -709,8 +711,9 @@ bool Mob::IsInvisible(Mob* other)
 
 	//handle sneaking
 	if(sneaking) {
-		if(BehindMob(other, GetX(), GetY()) )
+		if (BehindMob(other, GetX(), GetY())) {
 			return true;
+		}
 	}
 
 	return(false);
@@ -6495,7 +6498,7 @@ void Mob::CancelSneakHide()
 
 void Mob::CommonBreakInvisible()
 {
-	Shout("Break ALL INVS");
+	Shout("CommonBreakInvisible() Break ALL INVS");
 	BreakInvisibleSpells();
 	CancelSneakHide();
 }

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -440,10 +440,10 @@ Mob::Mob(
 	pStandingPetOrder = SPO_Follow;
 	pseudo_rooted     = false;
 
-	innate_see_invis  = GetSeeInvisible(in_see_invis);
-	see_invis_undead  = GetSeeInvisible(in_see_invis_undead);
-	see_hide          = GetSeeInvisible(in_see_hide);
-	see_improved_hide = GetSeeInvisible(in_see_improved_hide);
+	innate_see_invis  = GetInnateSeeInvisible(in_see_invis);
+	see_invis_undead  = GetInnateSeeInvisible(in_see_invis_undead);
+	see_hide          = GetInnateSeeInvisible(in_see_hide);
+	see_improved_hide = GetInnateSeeInvisible(in_see_improved_hide);
 
 	qglobal = in_qglobal != 0;
 
@@ -584,10 +584,13 @@ uint32 Mob::GetAppearanceValue(EmuAppearance iAppearance) {
 	return(ANIM_STAND);
 }
 
-void Mob::SetInvisible(uint8 state)
+void Mob::SetInvisibleAppearance(uint8 state, int16 invisible_level)
 {
 	if (state != Invisibility::Special) {
-		invisible = state;
+		if (!escape_invisible) {
+			escape_invisible = 1;
+		}
+		Shout("SetInvisibleAppearance");
 		SendAppearancePacket(AT_Invis, invisible);
 	}
 
@@ -599,6 +602,23 @@ void Mob::SetInvisible(uint8 state)
 		}
 
 		LogRules("Pets:LivelikeBreakCharmOnInvis for [{}] | Invis [{}] - Hidden [{}] - Shroud of Stealth [{}] - IVA [{}] - IVU [{}]", GetCleanName(), invisible, hidden, improved_hidden, invisible_animals, invisible_undead);
+	}
+}
+
+void Mob::RemoveInvisible(uint8 invisible_type) {
+
+	if (InvisibilityType::TYPE_INVISIBLE) {
+		invisible = 0;
+		escape_invisible = 0;
+	}
+
+	if (InvisibilityType::TYPE_INVISIBLE_VERSE_UNDAEAD) {
+		invisible_undead = 0;
+		
+	}
+
+	if (InvisibilityType::TYPE_INVISIBLE_VERSE_ANIMAL) {
+		invisible_animals = 0;
 	}
 }
 
@@ -6109,7 +6129,7 @@ float Mob::HeadingAngleToMob(float other_x, float other_y)
 	return CalculateHeadingAngleBetweenPositions(this_x, this_y, other_x, other_y);
 }
 
-int16 Mob::GetSeeInvisible(int16 see_invis)
+int16 Mob::GetInnateSeeInvisible(int16 see_invis)
 {
 	/*
 		Returns the NPC's see invisible level based on 'see_invs' value in npc_types.
@@ -6578,6 +6598,12 @@ void Mob::CalcSeeInvisibleLevel()
 {
 	see_invis = std::max({ spellbonuses.SeeInvis, itembonuses.SeeInvis, aabonuses.SeeInvis, innate_see_invis});
 	Shout("CalcSeeInvisibleLevel() %i", see_invis);
+}
+
+void Mob::CalcInvisibleLevel()
+{
+	invisible = std::max({ spellbonuses.invisibility, escape_invisible });
+	Shout("CalcInvisibleLevel() %i", invisible);
 }
 
 #ifdef BOTS

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -618,26 +618,23 @@ void Mob::CalcInvisibleLevel()
 	}
 }
 
-void Mob::SetInvisible(uint8 state, bool from_spell_effect)
+void Mob::SetInvisible(uint8 state, bool set_on_bonus_calc)
 {
 	Shout("Mob::SetInvisible :: invisible %i state %i", invisible, state);
 
-	if (state != Invisibility::Special) {
-
-		if (state == Invisibility::Visible) {
-			SendAppearancePacket(AT_Invis, Invisibility::Visible);
-			ZeroInvisibleVars(InvisType::T_INVISIBLE);
+	if (state == Invisibility::Visible) {
+		SendAppearancePacket(AT_Invis, Invisibility::Visible);
+		ZeroInvisibleVars(InvisType::T_INVISIBLE);
+	}
+	else {
+		/*
+			if your setting invisible from a script, or escape/fading memories effect then 
+			we use the internal invis variable which allows invisible without a buff on mob.
+		*/
+		if (!set_on_bonus_calc) {
+			nobuff_invisible = state;
 		}
-		else {
-			/*
-				if your setting invisible from a script, or escape/fading memories effect then 
-				we use the internal invis variable which allows invisible without a buff on mob.
-			*/
-			if (!from_spell_effect) {
-				nobuff_invisible = state;
-			}
-			SendAppearancePacket(AT_Invis, Invisibility::Invisible);
-		}
+		SendAppearancePacket(AT_Invis, Invisibility::Invisible);
 	}
 
 	// Invis and hide breaks charms
@@ -646,7 +643,6 @@ void Mob::SetInvisible(uint8 state, bool from_spell_effect)
 		if (RuleB(Pets, LivelikeBreakCharmOnInvis) || IsInvisible(pet)) {
 			pet->BuffFadeByEffect(SE_Charm);
 		}
-
 		LogRules("Pets:LivelikeBreakCharmOnInvis for [{}] | Invis [{}] - Hidden [{}] - Shroud of Stealth [{}] - IVA [{}] - IVU [{}]", GetCleanName(), invisible, hidden, improved_hidden, invisible_animals, invisible_undead);
 	}
 }

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -611,7 +611,7 @@ void Mob::SetInvisible(uint8 state, bool from_spell_effect)
 
 		if (state == Invisibility::Visible) {
 			SendAppearancePacket(AT_Invis, Invisibility::Visible);
-			RemoveInvisible(InvisibilityType::TYPE_INVISIBLE);
+			ZeroInvisibleVars(InvisibilityType::TYPE_INVISIBLE);
 		}
 		else {
 			/*
@@ -636,9 +636,8 @@ void Mob::SetInvisible(uint8 state, bool from_spell_effect)
 	}
 }
 
-void Mob::RemoveInvisible(uint8 invisible_type) 
+void Mob::ZeroInvisibleVars(uint8 invisible_type) 
 {
-
 	switch (invisible_type) {
 		
 		case InvisibilityType::TYPE_INVISIBLE:

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -591,14 +591,14 @@ uint32 Mob::GetAppearanceValue(EmuAppearance iAppearance) {
 void Mob::CalcSeeInvisibleLevel()
 {
 	see_invis = std::max({ spellbonuses.SeeInvis, itembonuses.SeeInvis, aabonuses.SeeInvis, innate_see_invis });
-	Shout("CalcSeeInvisibleLevel() %i", see_invis);
+	Shout("CalcSeeInvisibleLevel() %i [INNATE %i Spell %i]", see_invis, innate_see_invis, spellbonuses.SeeInvis);
 }
 
 void Mob::CalcInvisibleLevel()
 {
 	Shout("CalcInvisibleLevel() %i", invisible);
 	invisible = std::max({ spellbonuses.invisibility, nobuff_invisible });
-	Shout("CalcInvisibleLevel() %i", invisible);
+	Shout("CalcInvisibleLevel() %i [NON BUFF %i]", invisible, nobuff_invisible);
 }
 
 void Mob::SetInvisibleAppearance(uint8 state, bool from_spell_effect)

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -440,7 +440,7 @@ Mob::Mob(
 	pStandingPetOrder = SPO_Follow;
 	pseudo_rooted     = false;
 
-	see_invis         = GetSeeInvisible(in_see_invis);
+	innate_see_invis  = GetSeeInvisible(in_see_invis);
 	see_invis_undead  = GetSeeInvisible(in_see_invis_undead);
 	see_hide          = GetSeeInvisible(in_see_hide);
 	see_improved_hide = GetSeeInvisible(in_see_improved_hide);
@@ -6544,9 +6544,9 @@ void Mob::SetFeigned(bool in_feigned) {
 	feigned = in_feigned;
 }
 
-void Mob::SetSeeInvisibleLevel() {
-
-	see_invis = std::max({ spellbonuses.SeeInvis, itembonuses.SeeInvis, aabonuses.SeeInvis });
+void Mob::SetSeeInvisibleLevel() 
+{
+	see_invis = std::max({ spellbonuses.SeeInvis, itembonuses.SeeInvis, aabonuses.SeeInvis, innate_see_invis});
 }
 
 #ifdef BOTS

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -598,21 +598,16 @@ void Mob::CalcInvisibleLevel()
 {
 	bool is_invisible = invisible;
 
-	Shout("CalcInvisibleLevel() %i", invisible);
 	invisible = std::max({ spellbonuses.invisibility, nobuff_invisible });
 	invisible_undead = spellbonuses.invisibility_verse_undead;
 	invisible_animals = spellbonuses.invisibility_verse_animal;
-	Shout("CalcInvisibleLevel() %i [NON BUFF %i]", invisible, nobuff_invisible);
-
 
 	if (!is_invisible && invisible) {
-		Shout("<<<<<<<<<<<<<<<<<< Set INVIS from bonus");
 		SetInvisible(Invisibility::Invisible, true);
 		return;
 	}
 	
 	if (is_invisible && !invisible) {
-		Shout("<<<<<<<<<<<<<<<<<<<<< REMOVE INVIS from bonus");
 		SetInvisible(Invisibility::Visible, true);
 		return;
 	}
@@ -620,8 +615,6 @@ void Mob::CalcInvisibleLevel()
 
 void Mob::SetInvisible(uint8 state, bool set_on_bonus_calc)
 {
-	Shout("Mob::SetInvisible :: invisible %i state %i", invisible, state);
-
 	if (state == Invisibility::Visible) {
 		SendAppearancePacket(AT_Invis, Invisibility::Visible);
 		ZeroInvisibleVars(InvisType::T_INVISIBLE);
@@ -667,13 +660,12 @@ void Mob::ZeroInvisibleVars(uint8 invisible_type)
 }
 
 //check to see if `this` is invisible to `other`
-//bool Mob::IsInvisible(Mob* other) const
-bool Mob::IsInvisible(Mob* other)
+bool Mob::IsInvisible(Mob* other) const
 {
 	if (!other) {
 		return(false);
 	}
-	//Shout("Invisible %i and See invisible %i", other->SeeInvisible());
+
 	//check regular invisibility
 	if (invisible && (invisible > other->SeeInvisible())) {
 		return true;

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -443,10 +443,10 @@ Mob::Mob(
 	nobuff_invisible = 0;
 	see_invis = 0;
 
-	innate_see_invis  = GetInnateSeeInvisible(in_see_invis);
-	see_invis_undead  = GetInnateSeeInvisible(in_see_invis_undead);
-	see_hide          = GetInnateSeeInvisible(in_see_hide);
-	see_improved_hide = GetInnateSeeInvisible(in_see_improved_hide);
+	innate_see_invis  = GetInnateSeeInvisibleLevel(in_see_invis);
+	see_invis_undead  = GetInnateSeeInvisibleLevel(in_see_invis_undead);
+	see_hide          = GetInnateSeeInvisibleLevel(in_see_hide);
+	see_improved_hide = GetInnateSeeInvisibleLevel(in_see_improved_hide);
 
 	qglobal = in_qglobal != 0;
 
@@ -6168,7 +6168,7 @@ float Mob::HeadingAngleToMob(float other_x, float other_y)
 	return CalculateHeadingAngleBetweenPositions(this_x, this_y, other_x, other_y);
 }
 
-uint8 Mob::GetInnateSeeInvisible(uint16 in_see_invis)
+uint8 Mob::GetInnateSeeInvisibleLevel(uint16 in_see_invis)
 {
 	/*
 		Returns the NPC's see invisible level based on 'see_invs' value in npc_types.
@@ -6486,7 +6486,6 @@ void Mob::CancelSneakHide()
 
 void Mob::CommonBreakInvisible()
 {
-	Shout("CommonBreakInvisible() Break ALL INVS");
 	BreakInvisibleSpells();
 	CancelSneakHide();
 }

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -6401,6 +6401,7 @@ void Mob::CancelSneakHide()
 
 void Mob::CommonBreakInvisible()
 {
+	Shout("Break ALL INVS");
 	BreakInvisibleSpells();
 	CancelSneakHide();
 }

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -603,9 +603,9 @@ void Mob::CalcInvisibleLevel()
 	Shout("CalcInvisibleLevel() %i [NON BUFF %i]", invisible, nobuff_invisible);
 }
 
-void Mob::SetInvisibleAppearance(uint8 state, bool from_spell_effect)
+void Mob::SetInvisible(uint8 state, bool from_spell_effect)
 {
-	Shout("SetInvisibleAppearance %i", invisible);
+	Shout("SetInvisible %i", invisible);
 
 	if (state != Invisibility::Special) {
 
@@ -646,7 +646,7 @@ void Mob::RemoveInvisible(uint8 invisible_type)
 			nobuff_invisible = 0;
 			break;
 
-		case InvisibilityType::TYPE_INVISIBLE_VERSE_UNDAEAD:
+		case InvisibilityType::TYPE_INVISIBLE_VERSE_UNDEAD:
 			invisible_undead = 0;
 			break;
 

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -81,7 +81,7 @@ Mob::Mob(
 	uint32 in_drakkin_details,
 	EQ::TintProfile in_armor_tint,
 	uint8 in_aa_title,
-	uint8 in_see_invis, // see through invis/ivu
+	int16 in_see_invis, // see through invis/ivu
 	uint8 in_see_invis_undead,
 	uint8 in_see_hide,
 	uint8 in_see_improved_hide,
@@ -609,7 +609,7 @@ bool Mob::IsInvisible(Mob* other)
 	if (!other) {
 		return(false);
 	}
-	Shout("Invisible %i and See invisible %i", other->SeeInvisible());
+	//Shout("Invisible %i and See invisible %i", other->SeeInvisible());
 	//check regular invisibility
 	if (invisible && invisible > (other->SeeInvisible())) {
 		return true;
@@ -6118,13 +6118,15 @@ int16 Mob::GetSeeInvisible(int16 see_invis)
 		ect... for higher levels, 200,300 ect.
 	*/
 	
-	//covers npcs with no see invs or standard level 1 see invs.
+	//npc does not have see invis
 	if (!see_invis) {
 		return 0;
 	}
-	else if (see_invis == 1) {
+	//npc has basic see invis
+	if (see_invis == 1) {
 		return 1;
 	}
+	
 	//random chance to apply standard level 1 see invs
 	if (see_invis > 1 && see_invis < 100) {
 		if (zone->random.Int(0, 99) < see_invis) {
@@ -6132,13 +6134,24 @@ int16 Mob::GetSeeInvisible(int16 see_invis)
 		}
 	}
 	//covers npcs with see invis levels beyond level 1
-	int16 see_invis_level = see_invis / 100;;
+	int16 see_invis_level = 1;
+	see_invis_level += (see_invis / 100);
 
-	int random_remainder = see_invis % 100;
-	if (zone->random.Int(0, 99) < random_remainder) {
+	Shout("see level %i", see_invis_level);
+
+	int see_invis_chance = see_invis % 100;
+
+	Shout("see chance %i", see_invis_chance);
+
+	//has enhanced see invis level
+	if (see_invis_chance == 0) {
 		return see_invis_level;
 	}
-
+	//has chance for enhanced see invis level
+	if (zone->random.Int(0, 99) < see_invis_chance) {
+		return see_invis_level;
+	}
+	//failed chance at attempted enhanced see invs level, use previous level.
 	return (see_invis_level - 1);
 }
 
@@ -6561,10 +6574,10 @@ void Mob::SetFeigned(bool in_feigned) {
 	feigned = in_feigned;
 }
 
-void Mob::SetSeeInvisibleLevel() 
+void Mob::CalcSeeInvisibleLevel() 
 {
 	see_invis = std::max({ spellbonuses.SeeInvis, itembonuses.SeeInvis, aabonuses.SeeInvis, innate_see_invis});
-	Shout("SetSeeInvisibleLevel() %i", see_invis);
+	Shout("CalcSeeInvisibleLevel() %i", see_invis);
 }
 
 #ifdef BOTS

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -6544,6 +6544,11 @@ void Mob::SetFeigned(bool in_feigned) {
 	feigned = in_feigned;
 }
 
+void Mob::SetSeeInvisibleLevel() {
+
+	see_invis = std::max({ spellbonuses.SeeInvis, itembonuses.SeeInvis, aabonuses.SeeInvis });
+}
+
 #ifdef BOTS
 bool Mob::JoinHealRotationTargetPool(std::shared_ptr<HealRotation>* heal_rotation)
 {

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -82,7 +82,7 @@ Mob::Mob(
 	EQ::TintProfile in_armor_tint,
 	uint8 in_aa_title,
 	uint16 in_see_invis, // see through invis/ivu
-	uint8 in_see_invis_undead,
+	uint16 in_see_invis_undead,
 	uint8 in_see_hide,
 	uint8 in_see_improved_hide,
 	int32 in_hp_regen,
@@ -269,8 +269,8 @@ Mob::Mob(
 	maxlevel          = in_maxlevel;
 	scalerate         = in_scalerate;
 	invisible         = 0;
-	invisible_undead  = false;
-	invisible_animals = false;
+	invisible_undead  = 0;
+	invisible_animals = 0;
 	sneaking          = false;
 	hidden            = false;
 	improved_hidden   = false;
@@ -598,6 +598,8 @@ void Mob::CalcInvisibleLevel()
 {
 	Shout("CalcInvisibleLevel() %i", invisible);
 	invisible = std::max({ spellbonuses.invisibility, nobuff_invisible });
+	invisible_undead = spellbonuses.invisibility_verse_undead;
+	invisible_animals = spellbonuses.invisibility_verse_animal;
 	Shout("CalcInvisibleLevel() %i [NON BUFF %i]", invisible, nobuff_invisible);
 }
 
@@ -634,20 +636,23 @@ void Mob::SetInvisibleAppearance(uint8 state, bool from_spell_effect)
 	}
 }
 
-void Mob::RemoveInvisible(uint8 invisible_type) {
+void Mob::RemoveInvisible(uint8 invisible_type) 
+{
 
-	if (InvisibilityType::TYPE_INVISIBLE) {
-		invisible = 0;
-		nobuff_invisible = 0;
-	}
-
-	if (InvisibilityType::TYPE_INVISIBLE_VERSE_UNDAEAD) {
-		invisible_undead = 0;
+	switch (invisible_type) {
 		
-	}
+		case InvisibilityType::TYPE_INVISIBLE:
+			invisible = 0;
+			nobuff_invisible = 0;
+			break;
 
-	if (InvisibilityType::TYPE_INVISIBLE_VERSE_ANIMAL) {
-		invisible_animals = 0;
+		case InvisibilityType::TYPE_INVISIBLE_VERSE_UNDAEAD:
+			invisible_undead = 0;
+			break;
+
+		case InvisibilityType::TYPE_INVISIBLE_VERSE_ANIMAL:
+			invisible_animals = 0;
+			break;
 	}
 }
 

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -596,22 +596,37 @@ void Mob::CalcSeeInvisibleLevel()
 
 void Mob::CalcInvisibleLevel()
 {
+	bool is_invisible = invisible;
+
 	Shout("CalcInvisibleLevel() %i", invisible);
 	invisible = std::max({ spellbonuses.invisibility, nobuff_invisible });
 	invisible_undead = spellbonuses.invisibility_verse_undead;
 	invisible_animals = spellbonuses.invisibility_verse_animal;
 	Shout("CalcInvisibleLevel() %i [NON BUFF %i]", invisible, nobuff_invisible);
+
+
+	if (!is_invisible && invisible) {
+		Shout("<<<<<<<<<<<<<<<<<< Set INVIS from bonus");
+		SetInvisible(Invisibility::Invisible, true);
+		return;
+	}
+	
+	if (is_invisible && !invisible) {
+		Shout("<<<<<<<<<<<<<<<<<<<<< REMOVE INVIS from bonus");
+		SetInvisible(Invisibility::Visible, true);
+		return;
+	}
 }
 
 void Mob::SetInvisible(uint8 state, bool from_spell_effect)
 {
-	Shout("SetInvisible %i", invisible);
+	Shout("Mob::SetInvisible :: invisible %i state %i", invisible, state);
 
 	if (state != Invisibility::Special) {
 
 		if (state == Invisibility::Visible) {
 			SendAppearancePacket(AT_Invis, Invisibility::Visible);
-			ZeroInvisibleVars(InvisibilityType::TYPE_INVISIBLE);
+			ZeroInvisibleVars(InvisType::T_INVISIBLE);
 		}
 		else {
 			/*
@@ -640,16 +655,16 @@ void Mob::ZeroInvisibleVars(uint8 invisible_type)
 {
 	switch (invisible_type) {
 		
-		case InvisibilityType::TYPE_INVISIBLE:
+		case T_INVISIBLE:
 			invisible = 0;
 			nobuff_invisible = 0;
 			break;
 
-		case InvisibilityType::TYPE_INVISIBLE_VERSE_UNDEAD:
+		case T_INVISIBLE_VERSE_UNDEAD:
 			invisible_undead = 0;
 			break;
 
-		case InvisibilityType::TYPE_INVISIBLE_VERSE_ANIMAL:
+		case T_INVISIBLE_VERSE_ANIMAL:
 			invisible_animals = 0;
 			break;
 	}

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -584,14 +584,36 @@ uint32 Mob::GetAppearanceValue(EmuAppearance iAppearance) {
 	return(ANIM_STAND);
 }
 
-void Mob::SetInvisibleAppearance(uint8 state, int16 invisible_level)
+
+void Mob::CalcSeeInvisibleLevel()
 {
+	see_invis = std::max({ spellbonuses.SeeInvis, itembonuses.SeeInvis, aabonuses.SeeInvis, innate_see_invis });
+	Shout("CalcSeeInvisibleLevel() %i", see_invis);
+}
+
+void Mob::CalcInvisibleLevel()
+{
+	invisible = std::max({ spellbonuses.invisibility, escape_invisible });
+	Shout("CalcInvisibleLevel() %i", invisible);
+}
+
+void Mob::SetInvisibleAppearance(uint8 state, bool from_spell_effect)
+{
+	Shout("SetInvisibleAppearance");
+
 	if (state != Invisibility::Special) {
-		if (!escape_invisible) {
-			escape_invisible = 1;
+
+		if (state == Invisibility::Visible) {
+			SendAppearancePacket(AT_Invis, Invisibility::Visible);
+			SetInvisibleLevel(0);
 		}
-		Shout("SetInvisibleAppearance");
-		SendAppearancePacket(AT_Invis, invisible);
+		else {
+			//if your setting invisible from a script then we use the internal invis variable
+			if (!from_spell_effect) {
+				escape_invisible = state;
+			}
+			SendAppearancePacket(AT_Invis, Invisibility::Invisible);
+		}
 	}
 
 	// Invis and hide breaks charms
@@ -6592,18 +6614,6 @@ void Mob::SetFeigned(bool in_feigned) {
 		forget_timer.Disable();
 	}
 	feigned = in_feigned;
-}
-
-void Mob::CalcSeeInvisibleLevel() 
-{
-	see_invis = std::max({ spellbonuses.SeeInvis, itembonuses.SeeInvis, aabonuses.SeeInvis, innate_see_invis});
-	Shout("CalcSeeInvisibleLevel() %i", see_invis);
-}
-
-void Mob::CalcInvisibleLevel()
-{
-	invisible = std::max({ spellbonuses.invisibility, escape_invisible });
-	Shout("CalcInvisibleLevel() %i", invisible);
 }
 
 #ifdef BOTS

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -250,7 +250,7 @@ public:
 	void CalcInvisibleLevel();
 	void ZeroInvisibleVars(uint8 invisible_type);
 	
-	inline uint8 GetInnateSeeInvisible(uint16 in_see_invis);
+	inline uint8 GetInnateSeeInvisibleLevel(uint16 in_see_invis);
 
 	void BreakInvisibleSpells();
 	virtual void CancelSneakHide();
@@ -258,6 +258,8 @@ public:
 	void CommonBreakInvisibleFromCombat();
 
 	inline uint8 GetInvisibleLevel() const { return invisible; }
+	inline uint8 GetInvisibleUndeadLevel() const { return invisible_undead; }
+
 	inline bool SeeHide() const { return see_hide; }
 	inline bool SeeImprovedHide() const { return see_improved_hide; }
 	inline uint8 SeeInvisibleUndead() const { return see_invis_undead; }

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -263,8 +263,8 @@ public:
 	inline uint8 SeeInvisibleUndead() const { return see_invis_undead; }
 	inline uint8 SeeInvisible() const { return see_invis; }
 
-	inline void SetInnateSeeInvisible(bool val) { innate_see_invis = val; }
-	inline void SetSeeInvisibleUndead(bool val) { see_invis_undead = val; }
+	inline void SetInnateSeeInvisible(uint8 val) { innate_see_invis = val; }
+	inline void SetSeeInvisibleUndead(uint8 val) { see_invis_undead = val; }
 
 	uint32 tmHidden; // timestamp of hide, only valid while hidden == true
 	uint8 invisible, nobuff_invisible, invisible_undead, invisible_animals; 

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -250,7 +250,7 @@ public:
 	void CalcInvisibleLevel();
 	void ZeroInvisibleVars(uint8 invisible_type);
 	
-	inline uint8 GetInnateSeeInvisibleLevel(uint16 in_see_invis);
+	inline uint8 GetSeeInvisibleLevelFromNPCStat(uint16 in_see_invis);
 
 	void BreakInvisibleSpells();
 	virtual void CancelSneakHide();

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -226,10 +226,6 @@ public:
 	virtual inline bool IsBerserk() { return false; } // only clients
 	void RogueEvade(Mob *other);
 	void CommonOutgoingHitSuccess(Mob *defender, DamageHitInfo &hit, ExtraAttackOptions *opts = nullptr);
-	void BreakInvisibleSpells();
-	virtual void CancelSneakHide();
-	void CommonBreakInvisible();
-	void CommonBreakInvisibleFromCombat();
 	bool HasDied();
 	virtual bool CheckDualWield();
 	void DoMainHandAttackRounds(Mob *target, ExtraAttackOptions *opts = nullptr);
@@ -246,6 +242,21 @@ public:
 		return;
 	}
 
+	//invisible
+	bool IsInvisible(Mob* other = 0) const;
+	void SetInvisible(uint8 state);
+
+	void BreakInvisibleSpells();
+	virtual void CancelSneakHide();
+	void CommonBreakInvisible();
+	void CommonBreakInvisibleFromCombat();
+
+	inline bool GetSeeInvisible(uint8 see_invis);
+	inline bool SeeHide() const { return see_hide; }
+	inline bool SeeImprovedHide() const { return see_improved_hide; }
+	inline bool SeeInvisibleUndead() const { return see_invis_undead; }
+	inline uint8 SeeInvisible() const { return see_invis; }
+
 	/**
 	 ************************************************
 	 * Appearance
@@ -254,16 +265,7 @@ public:
 
 	EQ::InternalTextureProfile mob_texture_profile = {};
 
-	bool IsInvisible(Mob* other = 0) const;
-	void SetInvisible(uint8 state);
-
 	EQ::skills::SkillType AttackAnimation(int Hand, const EQ::ItemInstance* weapon, EQ::skills::SkillType skillinuse = EQ::skills::Skill1HBlunt);
-
-	inline bool GetSeeInvisible(uint8 see_invis);
-	inline bool SeeHide() const { return see_hide; }
-	inline bool SeeImprovedHide() const { return see_improved_hide; }
-	inline bool SeeInvisibleUndead() const { return see_invis_undead; }
-	inline uint8 SeeInvisible() const { return see_invis; }
 
 	int32 GetTextureProfileMaterial(uint8 material_slot) const;
 	int32 GetTextureProfileColor(uint8 material_slot) const;

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -265,10 +265,15 @@ public:
 	inline bool SeeImprovedHide() const { return see_improved_hide; }
 	inline uint8 SeeInvisibleUndead() const { return see_invis_undead; }
 	inline uint8 SeeInvisible() const { return see_invis; }
+	inline uint8 SeeInvisibleAnimal() const { return see_invis_animal; }
+
+	inline void SetInnateSeeInvisible(bool val) { innate_see_invis = val; }
+	inline void SetSeeInvisibleUndead(bool val) { see_invis_undead = val; }
+	inline void SetSeeInvisibleAnimal(bool val) { see_invis_animal = val; }
 
 	uint32 tmHidden; // timestamp of hide, only valid while hidden == true
 	uint8 invisible, nobuff_invisible, invisible_undead, invisible_animals; 
-	uint8 see_invis, innate_see_invis, see_invis_undead; //TODO: see_invis_animal added to npc_types
+	uint8 see_invis, innate_see_invis, see_invis_undead, see_invis_animal; //TODO: see_invis_animal added to npc_types
 
 	bool sneaking, hidden, improved_hidden;
 	bool see_hide, see_improved_hide;

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -147,7 +147,7 @@ public:
 		uint32 in_drakkin_details,
 		EQ::TintProfile in_armor_tint,
 		uint8 in_aa_title,
-		int16 in_see_invis, // see through invis
+		uint16 in_see_invis, // see through invis
 		uint8 in_see_invis_undead, // see through invis vs. undead
 		uint8 in_see_hide,
 		uint8 in_see_improved_hide,
@@ -251,9 +251,9 @@ public:
 	void CalcInvisibleLevel();
 	void RemoveInvisible(uint8 invisible_type);
 	
-	inline int16 GetInnateSeeInvisible(int16 see_invis);
+	inline uint8 GetInnateSeeInvisible(uint16 in_see_invis);
 
-	inline int16 GetInvisibleLevel() const { return invisible; }
+	inline uint8 GetInvisibleLevel() const { return invisible; }
 	inline void SetInvisibleLevel(int16 val) { invisible = val; }
 
 	void BreakInvisibleSpells();
@@ -265,7 +265,14 @@ public:
 	inline bool SeeHide() const { return see_hide; }
 	inline bool SeeImprovedHide() const { return see_improved_hide; }
 	inline bool SeeInvisibleUndead() const { return see_invis_undead; }
-	inline int16 SeeInvisible() const { return see_invis; }
+	inline uint8 SeeInvisible() const { return see_invis; }
+
+	uint32 tmHidden; // timestamp of hide, only valid while hidden == true
+	uint8 invisible, nobuff_invisible;
+	uint8 see_invis, innate_see_invis;
+
+	bool invisible_undead, invisible_animals, sneaking, hidden, improved_hidden;
+	bool see_invis_undead, see_hide, see_improved_hide;
 
 
 	/**
@@ -986,11 +993,7 @@ public:
 	inline const bodyType GetOrigBodyType() const { return orig_bodytype; }
 	void SetBodyType(bodyType new_body, bool overwrite_orig);
 
-	uint32 tmHidden; // timestamp of hide, only valid while hidden == true
-	int16 invisible, escape_invisible;
-	int16 see_invis, innate_see_invis;
-	bool invulnerable, invisible_undead, invisible_animals, sneaking, hidden, improved_hidden;
-	bool see_invis_undead, see_hide, see_improved_hide;
+	bool invulnerable;
 	bool qglobal;
 
 	virtual void SetAttackTimer();

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -147,7 +147,7 @@ public:
 		uint32 in_drakkin_details,
 		EQ::TintProfile in_armor_tint,
 		uint8 in_aa_title,
-		uint8 in_see_invis, // see through invis
+		int16 in_see_invis, // see through invis
 		uint8 in_see_invis_undead, // see through invis vs. undead
 		uint8 in_see_hide,
 		uint8 in_see_improved_hide,
@@ -247,7 +247,7 @@ public:
 	bool IsInvisible(Mob* other = 0);
 	void SetInvisible(uint8 state);
 	
-	void SetSeeInvisibleLevel();
+	void CalcSeeInvisibleLevel();
 	inline int16 GetSeeInvisible(int16 see_invis);
 
 	inline uint8 GetInvisibleLevel() const { return invisible; }
@@ -267,7 +267,7 @@ public:
 
 	//uint8 GetSeeInvisibleLevel();
 	
-	//void SetSeeInvisibleLevel2() { see_invis = std::max({ spellbonuses.SeeInvis, itembonuses.SeeInvis, aabonuses.SeeInvis, innate_see_invis }); }
+	//void CalcSeeInvisibleLevel2() { see_invis = std::max({ spellbonuses.SeeInvis, itembonuses.SeeInvis, aabonuses.SeeInvis, innate_see_invis }); }
 
 	/**
 	 ************************************************
@@ -988,7 +988,8 @@ public:
 	void SetBodyType(bodyType new_body, bool overwrite_orig);
 
 	uint32 tmHidden; // timestamp of hide, only valid while hidden == true
-	uint8 invisible, see_invis, innate_see_invis;
+	uint8 invisible;
+	int16 see_invis, innate_see_invis;
 	bool invulnerable, invisible_undead, invisible_animals, sneaking, hidden, improved_hidden;
 	bool see_invis_undead, see_hide, see_improved_hide;
 	bool qglobal;

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -249,7 +249,7 @@ public:
 	
 	void CalcSeeInvisibleLevel();
 	void CalcInvisibleLevel();
-	void RemoveInvisible(uint8 invisible_type);
+	void ZeroInvisibleVars(uint8 invisible_type);
 	
 	inline uint8 GetInnateSeeInvisible(uint16 in_see_invis);
 

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -245,7 +245,7 @@ public:
 	//invisible
 	//bool IsInvisible(Mob* other = 0) const;
 	bool IsInvisible(Mob* other = 0);
-	void SetInvisibleAppearance(uint8 state, bool from_spell_effect = false);
+	void SetInvisible(uint8 state, bool from_spell_effect = false);
 	
 	void CalcSeeInvisibleLevel();
 	void CalcInvisibleLevel();
@@ -254,7 +254,6 @@ public:
 	inline uint8 GetInnateSeeInvisible(uint16 in_see_invis);
 
 	inline uint8 GetInvisibleLevel() const { return invisible; }
-	inline void SetInvisibleLevel(int16 val) { invisible = val; }
 
 	void BreakInvisibleSpells();
 	virtual void CancelSneakHide();
@@ -264,12 +263,12 @@ public:
 	
 	inline bool SeeHide() const { return see_hide; }
 	inline bool SeeImprovedHide() const { return see_improved_hide; }
-	inline bool SeeInvisibleUndead() const { return see_invis_undead; }
+	inline uint8 SeeInvisibleUndead() const { return see_invis_undead; }
 	inline uint8 SeeInvisible() const { return see_invis; }
 
 	uint32 tmHidden; // timestamp of hide, only valid while hidden == true
-	uint8 invisible, nobuff_invisible, invisible_undead, invisible_animals; //NOTE: NO see invis for animals.
-	uint8 see_invis, innate_see_invis, see_invis_undead;
+	uint8 invisible, nobuff_invisible, invisible_undead, invisible_animals; 
+	uint8 see_invis, innate_see_invis, see_invis_undead; //TODO: see_invis_animal added to npc_types
 
 	bool sneaking, hidden, improved_hidden;
 	bool see_hide, see_improved_hide;

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -257,6 +257,12 @@ public:
 	inline bool SeeInvisibleUndead() const { return see_invis_undead; }
 	inline uint8 SeeInvisible() const { return see_invis; }
 
+	void SetSeeInvisible(uint8 val) { see_invis = val; }
+
+	uint8 GetSeeInvisibleLevel();
+	void SetSeeInvisibleLevel();
+	uint8 Mob::SetSeeInvisibleLevel2() { see_invis = std::max({ spellbonuses.SeeInvis, itembonuses.SeeInvis, aabonuses.SeeInvis }); }
+
 	/**
 	 ************************************************
 	 * Appearance

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -245,7 +245,7 @@ public:
 	//invisible
 	//bool IsInvisible(Mob* other = 0) const;
 	bool IsInvisible(Mob* other = 0);
-	void SetInvisibleAppearance(uint8 state, int16 invisible_level = 0);
+	void SetInvisibleAppearance(uint8 state, bool from_spell_effect = false);
 	
 	void CalcSeeInvisibleLevel();
 	void CalcInvisibleLevel();
@@ -254,6 +254,7 @@ public:
 	inline int16 GetInnateSeeInvisible(int16 see_invis);
 
 	inline int16 GetInvisibleLevel() const { return invisible; }
+	inline void SetInvisibleLevel(int16 val) { invisible = val; }
 
 	void BreakInvisibleSpells();
 	virtual void CancelSneakHide();

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -255,6 +255,7 @@ public:
 	EQ::InternalTextureProfile mob_texture_profile = {};
 
 	bool IsInvisible(Mob* other = 0) const;
+	void SetInvisible(uint8 state);
 
 	EQ::skills::SkillType AttackAnimation(int Hand, const EQ::ItemInstance* weapon, EQ::skills::SkillType skillinuse = EQ::skills::Skill1HBlunt);
 
@@ -282,7 +283,6 @@ public:
 	void SendLevelAppearance();
 	void SendStunAppearance();
 	void SendTargetable(bool on, Client *specific_target = nullptr);
-	void SetInvisible(uint8 state);
 	void SetMobTextureProfile(uint8 material_slot, uint16 texture, uint32 color = 0, uint32 hero_forge_model = 0);
 
 	//Spell

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -148,7 +148,7 @@ public:
 		EQ::TintProfile in_armor_tint,
 		uint8 in_aa_title,
 		uint16 in_see_invis, // see through invis
-		uint8 in_see_invis_undead, // see through invis vs. undead
+		uint16 in_see_invis_undead, // see through invis vs. undead
 		uint8 in_see_hide,
 		uint8 in_see_improved_hide,
 		int32 in_hp_regen,
@@ -268,11 +268,11 @@ public:
 	inline uint8 SeeInvisible() const { return see_invis; }
 
 	uint32 tmHidden; // timestamp of hide, only valid while hidden == true
-	uint8 invisible, nobuff_invisible;
-	uint8 see_invis, innate_see_invis;
+	uint8 invisible, nobuff_invisible, invisible_undead, invisible_animals; //NOTE: NO see invis for animals.
+	uint8 see_invis, innate_see_invis, see_invis_undead;
 
-	bool invisible_undead, invisible_animals, sneaking, hidden, improved_hidden;
-	bool see_invis_undead, see_hide, see_improved_hide;
+	bool sneaking, hidden, improved_hidden;
+	bool see_hide, see_improved_hide;
 
 
 	/**

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -243,24 +243,30 @@ public:
 	}
 
 	//invisible
-	bool IsInvisible(Mob* other = 0) const;
+	//bool IsInvisible(Mob* other = 0) const;
+	bool IsInvisible(Mob* other = 0);
 	void SetInvisible(uint8 state);
+	
+	void SetSeeInvisibleLevel();
+	inline int16 GetSeeInvisible(int16 see_invis);
+
+	inline uint8 GetInvisibleLevel() const { return invisible; }
 
 	void BreakInvisibleSpells();
 	virtual void CancelSneakHide();
 	void CommonBreakInvisible();
 	void CommonBreakInvisibleFromCombat();
 
-	inline bool GetSeeInvisible(uint8 see_invis);
+	
 	inline bool SeeHide() const { return see_hide; }
 	inline bool SeeImprovedHide() const { return see_improved_hide; }
 	inline bool SeeInvisibleUndead() const { return see_invis_undead; }
 	inline uint8 SeeInvisible() const { return see_invis; }
 
-	void SetSeeInvisible(uint8 val) { see_invis = val; }
+	//void SetSeeInvisible(uint8 val) { see_invis = val; }
 
-	uint8 GetSeeInvisibleLevel();
-	void SetSeeInvisibleLevel();
+	//uint8 GetSeeInvisibleLevel();
+	
 	//void SetSeeInvisibleLevel2() { see_invis = std::max({ spellbonuses.SeeInvis, itembonuses.SeeInvis, aabonuses.SeeInvis, innate_see_invis }); }
 
 	/**

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -245,7 +245,7 @@ public:
 	//invisible
 	//bool IsInvisible(Mob* other = 0) const;
 	bool IsInvisible(Mob* other = 0);
-	void SetInvisible(uint8 state, bool from_spell_effect = false);
+	void SetInvisible(uint8 state, bool set_on_bonus_calc = false);
 	
 	void CalcSeeInvisibleLevel();
 	void CalcInvisibleLevel();

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -245,12 +245,15 @@ public:
 	//invisible
 	//bool IsInvisible(Mob* other = 0) const;
 	bool IsInvisible(Mob* other = 0);
-	void SetInvisible(uint8 state);
+	void SetInvisibleAppearance(uint8 state, int16 invisible_level = 0);
 	
 	void CalcSeeInvisibleLevel();
-	inline int16 GetSeeInvisible(int16 see_invis);
+	void CalcInvisibleLevel();
+	void RemoveInvisible(uint8 invisible_type);
+	
+	inline int16 GetInnateSeeInvisible(int16 see_invis);
 
-	inline uint8 GetInvisibleLevel() const { return invisible; }
+	inline int16 GetInvisibleLevel() const { return invisible; }
 
 	void BreakInvisibleSpells();
 	virtual void CancelSneakHide();
@@ -261,13 +264,8 @@ public:
 	inline bool SeeHide() const { return see_hide; }
 	inline bool SeeImprovedHide() const { return see_improved_hide; }
 	inline bool SeeInvisibleUndead() const { return see_invis_undead; }
-	inline uint8 SeeInvisible() const { return see_invis; }
+	inline int16 SeeInvisible() const { return see_invis; }
 
-	//void SetSeeInvisible(uint8 val) { see_invis = val; }
-
-	//uint8 GetSeeInvisibleLevel();
-	
-	//void CalcSeeInvisibleLevel2() { see_invis = std::max({ spellbonuses.SeeInvis, itembonuses.SeeInvis, aabonuses.SeeInvis, innate_see_invis }); }
 
 	/**
 	 ************************************************
@@ -988,7 +986,7 @@ public:
 	void SetBodyType(bodyType new_body, bool overwrite_orig);
 
 	uint32 tmHidden; // timestamp of hide, only valid while hidden == true
-	uint8 invisible;
+	int16 invisible, escape_invisible;
 	int16 see_invis, innate_see_invis;
 	bool invulnerable, invisible_undead, invisible_animals, sneaking, hidden, improved_hidden;
 	bool see_invis_undead, see_hide, see_improved_hide;

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -242,9 +242,8 @@ public:
 		return;
 	}
 
-	//invisible
-	//bool IsInvisible(Mob* other = 0) const;
-	bool IsInvisible(Mob* other = 0);
+	//Invisible
+	bool IsInvisible(Mob* other = 0) const;
 	void SetInvisible(uint8 state, bool set_on_bonus_calc = false);
 	
 	void CalcSeeInvisibleLevel();
@@ -253,31 +252,26 @@ public:
 	
 	inline uint8 GetInnateSeeInvisible(uint16 in_see_invis);
 
-	inline uint8 GetInvisibleLevel() const { return invisible; }
-
 	void BreakInvisibleSpells();
 	virtual void CancelSneakHide();
 	void CommonBreakInvisible();
 	void CommonBreakInvisibleFromCombat();
 
-	
+	inline uint8 GetInvisibleLevel() const { return invisible; }
 	inline bool SeeHide() const { return see_hide; }
 	inline bool SeeImprovedHide() const { return see_improved_hide; }
 	inline uint8 SeeInvisibleUndead() const { return see_invis_undead; }
 	inline uint8 SeeInvisible() const { return see_invis; }
-	inline uint8 SeeInvisibleAnimal() const { return see_invis_animal; }
 
 	inline void SetInnateSeeInvisible(bool val) { innate_see_invis = val; }
 	inline void SetSeeInvisibleUndead(bool val) { see_invis_undead = val; }
-	inline void SetSeeInvisibleAnimal(bool val) { see_invis_animal = val; }
 
 	uint32 tmHidden; // timestamp of hide, only valid while hidden == true
 	uint8 invisible, nobuff_invisible, invisible_undead, invisible_animals; 
-	uint8 see_invis, innate_see_invis, see_invis_undead, see_invis_animal; //TODO: see_invis_animal added to npc_types
+	uint8 see_invis, innate_see_invis, see_invis_undead; //TODO: do we need a see_invis_animal ?
 
 	bool sneaking, hidden, improved_hidden;
 	bool see_hide, see_improved_hide;
-
 
 	/**
 	 ************************************************

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -261,7 +261,7 @@ public:
 
 	uint8 GetSeeInvisibleLevel();
 	void SetSeeInvisibleLevel();
-	uint8 Mob::SetSeeInvisibleLevel2() { see_invis = std::max({ spellbonuses.SeeInvis, itembonuses.SeeInvis, aabonuses.SeeInvis }); }
+	//void SetSeeInvisibleLevel2() { see_invis = std::max({ spellbonuses.SeeInvis, itembonuses.SeeInvis, aabonuses.SeeInvis, innate_see_invis }); }
 
 	/**
 	 ************************************************
@@ -982,7 +982,7 @@ public:
 	void SetBodyType(bodyType new_body, bool overwrite_orig);
 
 	uint32 tmHidden; // timestamp of hide, only valid while hidden == true
-	uint8 invisible, see_invis;
+	uint8 invisible, see_invis, innate_see_invis;
 	bool invulnerable, invisible_undead, invisible_animals, sneaking, hidden, improved_hidden;
 	bool see_invis_undead, see_hide, see_improved_hide;
 	bool qglobal;

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -926,6 +926,7 @@ XS(XS_Mob_SetSeeInvisibleLevel) {
 		uint8 see_invis_level = (uint8)SvUV(ST(1));
 		VALIDATE_THIS_IS_MOB;
 		THIS->SetInnateSeeInvisible(see_invis_level);
+		THIS->CalcSeeInvisibleLevel();
 	}
 	XSRETURN_EMPTY;
 }
@@ -5805,6 +5806,41 @@ XS(XS_Mob_IsBlind) {
 	XSRETURN(1);
 }
 
+XS(XS_Mob_GetInvisibleLevel);
+XS(XS_Mob_GetInvisibleLevel) {
+	dXSARGS;
+	if (items != 1)
+		Perl_croak(aTHX_ "Usage: Mob::GetInvisibleLevel(THIS)"); // @categories Stats and Attributes
+	{
+		Mob *THIS;
+		uint8 RETVAL;
+		dXSTARG;
+		VALIDATE_THIS_IS_MOB;
+		RETVAL = THIS->GetInvisibleLevel();
+		XSprePUSH;
+		PUSHu((UV)RETVAL);
+	}
+	XSRETURN(1);
+}
+
+XS(XS_Mob_GetInvisibleUndeadLevel);
+XS(XS_Mob_GetInvisibleUndeadLevel) {
+	dXSARGS;
+	if (items != 1)
+		Perl_croak(aTHX_ "Usage: Mob::GetInvisibleUndeadLevel(THIS)"); // @categories Stats and Attributes
+	{
+		Mob *THIS;
+		uint8 RETVAL;
+		dXSTARG;
+		VALIDATE_THIS_IS_MOB;
+		RETVAL = THIS->GetInvisibleUndeadLevel();
+		XSprePUSH;
+		PUSHu((UV)RETVAL);
+	}
+	XSRETURN(1);
+}
+
+
 XS(XS_Mob_SeeInvisible);
 XS(XS_Mob_SeeInvisible) {
 	dXSARGS;
@@ -6727,6 +6763,8 @@ XS(boot_Mob) {
 	newXSproto(strcpy(buf, "GetHerosForgeModel"), XS_Mob_GetHerosForgeModel, file, "$$");
 	newXSproto(strcpy(buf, "GetID"), XS_Mob_GetID, file, "$");
 	newXSproto(strcpy(buf, "GetINT"), XS_Mob_GetINT, file, "$");
+	newXSproto(strcpy(buf, "GetInvisibleLevel"), XS_Mob_GetInvisibleLevel, file, "$");
+	newXSproto(strcpy(buf, "GetInvisibleUndeadLevel"), XS_Mob_GetInvisibleUndeadLevel, file, "$");
 	newXSproto(strcpy(buf, "GetInvul"), XS_Mob_GetInvul, file, "$");
 	newXSproto(strcpy(buf, "GetItemHPBonuses"), XS_Mob_GetItemHPBonuses, file, "$");
 	newXSproto(strcpy(buf, "GetItemStat"), XS_Mob_GetItemStat, file, "$$$");

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -939,7 +939,7 @@ XS(XS_Mob_SetSeeInvisibleUndeadLevel) {
 		Mob *THIS;
 		uint8 see_invis_undead_level = (uint8)SvUV(ST(1));
 		VALIDATE_THIS_IS_MOB;
-		THIS->SetInnateSeeInvisible(see_invis_undead_level);
+		THIS->SetSeeInvisibleUndead(see_invis_undead_level);
 	}
 	XSRETURN_EMPTY;
 }
@@ -5829,11 +5829,12 @@ XS(XS_Mob_SeeInvisibleUndead) {
 		Perl_croak(aTHX_ "Usage: Mob::SeeInvisibleUndead(THIS)"); // @categories Stats and Attributes
 	{
 		Mob *THIS;
-		bool RETVAL;
+		uint8 RETVAL;
+		dXSTARG;
 		VALIDATE_THIS_IS_MOB;
 		RETVAL = THIS->SeeInvisibleUndead();
-		ST(0) = boolSV(RETVAL);
-		sv_2mortal(ST(0));
+		XSprePUSH;
+		PUSHu((UV)RETVAL);
 	}
 	XSRETURN(1);
 }

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -916,6 +916,34 @@ XS(XS_Mob_SetInvisible) {
 	XSRETURN_EMPTY;
 }
 
+XS(XS_Mob_SetSeeInvisibleLevel); /* prototype to pass -Wmissing-prototypes */
+XS(XS_Mob_SetSeeInvisibleLevel) {
+	dXSARGS;
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: Mob::SetSeeInvisibleLevel(THIS, uint8 see_invis_level)"); // @categories Script Utility
+	{
+		Mob *THIS;
+		uint8 see_invis_level = (uint8)SvUV(ST(1));
+		VALIDATE_THIS_IS_MOB;
+		THIS->SetInnateSeeInvisible(see_invis_level);
+	}
+	XSRETURN_EMPTY;
+}
+
+XS(XS_Mob_SetSeeInvisibleUndeadLevel); /* prototype to pass -Wmissing-prototypes */
+XS(XS_Mob_SetSeeInvisibleUndeadLevel) {
+	dXSARGS;
+	if (items != 2)
+		Perl_croak(aTHX_ "Usage: Mob::SetSeeInvisibleLevel(THIS, uint8 see_invis_undead_level)"); // @categories Script Utility
+	{
+		Mob *THIS;
+		uint8 see_invis_undead_level = (uint8)SvUV(ST(1));
+		VALIDATE_THIS_IS_MOB;
+		THIS->SetInnateSeeInvisible(see_invis_undead_level);
+	}
+	XSRETURN_EMPTY;
+}
+
 XS(XS_Mob_FindBuff); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Mob_FindBuff) {
 	dXSARGS;
@@ -6877,6 +6905,8 @@ XS(boot_Mob) {
 	newXSproto(strcpy(buf, "SetRace"), XS_Mob_SetRace, file, "$$");
 	newXSproto(strcpy(buf, "SetRunAnimSpeed"), XS_Mob_SetRunAnimSpeed, file, "$$");
 	newXSproto(strcpy(buf, "SetRunning"), XS_Mob_SetRunning, file, "$$");
+	newXSproto(strcpy(buf, "SetSeeInvisibleLevel"), XS_Mob_SetSeeInvisibleLevel, file, "$$");
+	newXSproto(strcpy(buf, "SetSeeInvisibleUndeadLevel"), XS_Mob_SetSeeInvisibleUndeadLevel, file, "$$");
 	newXSproto(strcpy(buf, "SetSlotTint"), XS_Mob_SetSlotTint, file, "$$$$$");
 	newXSproto(strcpy(buf, "SetSpecialAbility"), XS_Mob_SetSpecialAbility, file, "$$$");
 	newXSproto(strcpy(buf, "SetSpecialAbilityParam"), XS_Mob_SetSpecialAbilityParam, file, "$$$$");

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -911,7 +911,7 @@ XS(XS_Mob_SetInvisible) {
 		Mob *THIS;
 		uint8 state = (uint8) SvUV(ST(1));
 		VALIDATE_THIS_IS_MOB;
-		THIS->SetInvisibleAppearance(state);
+		THIS->SetInvisible(state);
 	}
 	XSRETURN_EMPTY;
 }

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -911,7 +911,7 @@ XS(XS_Mob_SetInvisible) {
 		Mob *THIS;
 		uint8 state = (uint8) SvUV(ST(1));
 		VALIDATE_THIS_IS_MOB;
-		THIS->SetInvisible(state);
+		THIS->SetInvisibleAppearance(state);
 	}
 	XSRETURN_EMPTY;
 }

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -935,7 +935,7 @@ XS(XS_Mob_SetSeeInvisibleUndeadLevel); /* prototype to pass -Wmissing-prototypes
 XS(XS_Mob_SetSeeInvisibleUndeadLevel) {
 	dXSARGS;
 	if (items != 2)
-		Perl_croak(aTHX_ "Usage: Mob::SetSeeInvisibleLevel(THIS, uint8 see_invis_undead_level)"); // @categories Script Utility
+		Perl_croak(aTHX_ "Usage: Mob::SetSeeInvisibleUndeadLevel(THIS, uint8 see_invis_undead_level)"); // @categories Script Utility
 	{
 		Mob *THIS;
 		uint8 see_invis_undead_level = (uint8)SvUV(ST(1));

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -9560,17 +9560,17 @@ void Mob::BreakInvisibleSpells()
 	if(invisible) {
 		BuffFadeByEffect(SE_Invisibility);
 		BuffFadeByEffect(SE_Invisibility2);
-		RemoveInvisible(InvisibilityType::TYPE_INVISIBLE);
+		ZeroInvisibleVars(InvisibilityType::TYPE_INVISIBLE);
 	}
 	if(invisible_undead) {
 		BuffFadeByEffect(SE_InvisVsUndead);
 		BuffFadeByEffect(SE_InvisVsUndead2);
-		RemoveInvisible(InvisibilityType::TYPE_INVISIBLE_VERSE_UNDEAD);
+		ZeroInvisibleVars(InvisibilityType::TYPE_INVISIBLE_VERSE_UNDEAD);
 	}
 	if(invisible_animals){
 		BuffFadeByEffect(SE_ImprovedInvisAnimals);
 		BuffFadeByEffect(SE_InvisVsAnimals);
-		RemoveInvisible(InvisibilityType::TYPE_INVISIBLE_VERSE_ANIMAL);
+		ZeroInvisibleVars(InvisibilityType::TYPE_INVISIBLE_VERSE_ANIMAL);
 	}
 }
 

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -589,7 +589,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Invisibility");
 #endif
-				SetInvisibleAppearance(Invisibility::Invisible, true);
+				SetInvisible(Invisibility::Invisible, true);
 				break;
 			}
 
@@ -599,7 +599,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Invisibility to Animals");
 #endif
-				SetInvisibleAppearance(Invisibility::Special, true);
+				SetInvisible(Invisibility::Special, true);
 				break;
 			}
 
@@ -609,7 +609,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Invisibility to Undead");
 #endif
-				SetInvisibleAppearance(Invisibility::Special, true);
+				SetInvisible(Invisibility::Special, true);
 				break;
 			}
 
@@ -2221,7 +2221,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					if (IsClient()) {
 						int pre_aggro_count = CastToClient()->GetAggroCount();
 						entity_list.RemoveFromTargetsFadingMemories(this, true, max_level);
-						SetInvisibleAppearance(Invisibility::Invisible);
+						SetInvisible(Invisibility::Invisible);
 						int post_aggro_count = CastToClient()->GetAggroCount();
 						if (RuleB(Spells, UseFadingMemoriesMaxLevel)) {
 							if (pre_aggro_count == post_aggro_count) {
@@ -2237,7 +2237,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					}
 					else{
 						entity_list.RemoveFromTargets(caster);
-						SetInvisibleAppearance(Invisibility::Invisible);
+						SetInvisible(Invisibility::Invisible);
 					}
 				}
 				break;
@@ -4185,7 +4185,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 			case SE_Invisibility:
 			{
 				Shout("Mob::BuffFadeBySlot INVIS %i", buffs[slot].spellid);
-				SetInvisibleAppearance(Invisibility::Visible);
+				SetInvisible(Invisibility::Visible);
 				break;
 			}
 
@@ -9565,7 +9565,7 @@ void Mob::BreakInvisibleSpells()
 	if(invisible_undead) {
 		BuffFadeByEffect(SE_InvisVsUndead);
 		BuffFadeByEffect(SE_InvisVsUndead2);
-		RemoveInvisible(InvisibilityType::TYPE_INVISIBLE_VERSE_UNDAEAD);
+		RemoveInvisible(InvisibilityType::TYPE_INVISIBLE_VERSE_UNDEAD);
 	}
 	if(invisible_animals){
 		BuffFadeByEffect(SE_ImprovedInvisAnimals);

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -589,8 +589,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Invisibility");
 #endif
-				Shout("ADD INVS %i", spell_id);
-				SetInvisibleAppearance(spell.base_value[i]);
+				SetInvisibleAppearance(Invisibility::Invisible, true);
 				break;
 			}
 
@@ -600,7 +599,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				snprintf(effect_desc, _EDLEN, "Invisibility to Animals");
 #endif
 				invisible_animals = true;
-				SetInvisibleAppearance(Invisibility::Special);
+				SetInvisibleAppearance(Invisibility::Special, true);
 				break;
 			}
 
@@ -611,7 +610,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				snprintf(effect_desc, _EDLEN, "Invisibility to Undead");
 #endif
 				invisible_undead = true;
-				SetInvisibleAppearance(Invisibility::Special);
+				SetInvisibleAppearance(Invisibility::Special, true);
 				break;
 			}
 
@@ -3270,6 +3269,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 			case SE_Proc_Timer_Modifier:
 			case SE_FFItemClass:
 			case SE_SpellEffectResistChance:
+			case SE_SeeInvis:
 			{
 				break;
 			}

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -614,14 +614,6 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				SetInvisible(Invisibility::Special);
 				break;
 			}
-			case SE_SeeInvis:
-			{
-#ifdef SPELL_EFFECT_SPAM
-				snprintf(effect_desc, _EDLEN, "See Invisible");
-#endif
-				see_invis = spell.base_value[i];
-				break;
-			}
 
 			case SE_FleshToBone:
 			{

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -3949,9 +3949,10 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 		}
 		case SE_Invisibility2:
 		case SE_InvisVsUndead2: {
-			Shout("TEST FIXED INVS");
-			if (buff.ticsremaining <= 3 && buff.ticsremaining > 1) {
-				MessageString(Chat::Spells, INVIS_BEGIN_BREAK);
+			if (!IsBardSong(buff.spellid)) {
+				if (buff.ticsremaining <= 3 && buff.ticsremaining > 1) {
+					MessageString(Chat::Spells, INVIS_BEGIN_BREAK);
+				}
 			}
 			break;
 		}

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -3949,6 +3949,7 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 		}
 		case SE_Invisibility2:
 		case SE_InvisVsUndead2: {
+			Shout("TEST FIXED INVS");
 			if (buff.ticsremaining <= 3 && buff.ticsremaining > 1) {
 				MessageString(Chat::Spells, INVIS_BEGIN_BREAK);
 			}

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -593,6 +593,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
+			case SE_ImprovedInvisAnimals:
 			case SE_InvisVsAnimals:
 			{
 #ifdef SPELL_EFFECT_SPAM
@@ -3939,6 +3940,7 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 				}
 			}
 		}
+		case SE_ImprovedInvisAnimals:
 		case SE_Invisibility2:
 		case SE_InvisVsUndead2: {
 			if (!IsBardSong(buff.spellid)) {
@@ -4184,7 +4186,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 			case SE_Invisibility2:
 			case SE_Invisibility:
 			{
-				Shout("Drop INVS %i", buffs[slot].spellid);
+				Shout("Mob::BuffFadeBySlot INVIS %i", buffs[slot].spellid);
 				SetInvisibleAppearance(Invisibility::Visible);
 				break;
 			}
@@ -4196,15 +4198,10 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 				break;
 			}
 
+			case SE_ImprovedInvisAnimals:
 			case SE_InvisVsAnimals:
 			{
 				invisible_animals = false;
-				break;
-			}
-
-			case SE_SeeInvis:
-			{
-				see_invis = innate_see_invis;
 				break;
 			}
 
@@ -9587,6 +9584,7 @@ void Mob::BreakInvisibleSpells()
 		invisible_undead = false;
 	}
 	if(invisible_animals){
+		BuffFadeByEffect(SE_ImprovedInvisAnimals);
 		BuffFadeByEffect(SE_InvisVsAnimals);
 		invisible_animals = false;
 	}

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -583,36 +583,6 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Invisibility:
-			case SE_Invisibility2:
-			{
-#ifdef SPELL_EFFECT_SPAM
-				snprintf(effect_desc, _EDLEN, "Invisibility");
-#endif
-				SetInvisible(Invisibility::Invisible, true);
-				break;
-			}
-
-			case SE_ImprovedInvisAnimals:
-			case SE_InvisVsAnimals:
-			{
-#ifdef SPELL_EFFECT_SPAM
-				snprintf(effect_desc, _EDLEN, "Invisibility to Animals");
-#endif
-				SetInvisible(Invisibility::Special, true);
-				break;
-			}
-
-			case SE_InvisVsUndead2:
-			case SE_InvisVsUndead:
-			{
-#ifdef SPELL_EFFECT_SPAM
-				snprintf(effect_desc, _EDLEN, "Invisibility to Undead");
-#endif
-				SetInvisible(Invisibility::Special, true);
-				break;
-			}
-
 			case SE_FleshToBone:
 			{
 #ifdef SPELL_EFFECT_SPAM
@@ -4185,7 +4155,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 			case SE_Invisibility:
 			{
 				Shout("Mob::BuffFadeBySlot INVIS %i", buffs[slot].spellid);
-				SetInvisible(Invisibility::Visible);
+				//SetInvisible(Invisibility::Visible);
 				break;
 			}
 
@@ -9560,17 +9530,17 @@ void Mob::BreakInvisibleSpells()
 	if(invisible) {
 		BuffFadeByEffect(SE_Invisibility);
 		BuffFadeByEffect(SE_Invisibility2);
-		ZeroInvisibleVars(InvisibilityType::TYPE_INVISIBLE);
+		ZeroInvisibleVars(InvisType::T_INVISIBLE);
 	}
 	if(invisible_undead) {
 		BuffFadeByEffect(SE_InvisVsUndead);
 		BuffFadeByEffect(SE_InvisVsUndead2);
-		ZeroInvisibleVars(InvisibilityType::TYPE_INVISIBLE_VERSE_UNDEAD);
+		ZeroInvisibleVars(InvisType::T_INVISIBLE_VERSE_UNDEAD);
 	}
 	if(invisible_animals){
 		BuffFadeByEffect(SE_ImprovedInvisAnimals);
 		BuffFadeByEffect(SE_InvisVsAnimals);
-		ZeroInvisibleVars(InvisibilityType::TYPE_INVISIBLE_VERSE_ANIMAL);
+		ZeroInvisibleVars(InvisType::T_INVISIBLE_VERSE_ANIMAL);
 	}
 }
 

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -4151,14 +4151,6 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 				break;
 			}
 
-			case SE_Invisibility2:
-			case SE_Invisibility:
-			{
-				Shout("Mob::BuffFadeBySlot INVIS %i", buffs[slot].spellid);
-				//SetInvisible(Invisibility::Visible);
-				break;
-			}
-
 			case SE_Silence:
 			{
 				Silence(false);

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -589,6 +589,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Invisibility");
 #endif
+				Shout("ADD INVS %i", spell_id);
 				SetInvisible(spell.base_value[i]);
 				break;
 			}
@@ -4157,6 +4158,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 			case SE_Invisibility2:
 			case SE_Invisibility:
 			{
+				Shout("Drop INVS %i", buffs[slot].spellid);
 				SetInvisible(Invisibility::Visible);
 				break;
 			}
@@ -9547,6 +9549,7 @@ void Mob::CalcSpellPowerDistanceMod(uint16 spell_id, float range, Mob* caster)
 
 void Mob::BreakInvisibleSpells()
 {
+	Shout("BreakInvisibleSpells()");
 	if(invisible) {
 		BuffFadeByEffect(SE_Invisibility);
 		BuffFadeByEffect(SE_Invisibility2);

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -9520,19 +9520,19 @@ void Mob::BreakInvisibleSpells()
 {
 	Shout("BreakInvisibleSpells()");
 	if(invisible) {
+		ZeroInvisibleVars(InvisType::T_INVISIBLE);
 		BuffFadeByEffect(SE_Invisibility);
 		BuffFadeByEffect(SE_Invisibility2);
-		ZeroInvisibleVars(InvisType::T_INVISIBLE);
 	}
 	if(invisible_undead) {
+		ZeroInvisibleVars(InvisType::T_INVISIBLE_VERSE_UNDEAD);
 		BuffFadeByEffect(SE_InvisVsUndead);
 		BuffFadeByEffect(SE_InvisVsUndead2);
-		ZeroInvisibleVars(InvisType::T_INVISIBLE_VERSE_UNDEAD);
 	}
 	if(invisible_animals){
+		ZeroInvisibleVars(InvisType::T_INVISIBLE_VERSE_ANIMAL);
 		BuffFadeByEffect(SE_ImprovedInvisAnimals);
 		BuffFadeByEffect(SE_InvisVsAnimals);
-		ZeroInvisibleVars(InvisType::T_INVISIBLE_VERSE_ANIMAL);
 	}
 }
 

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -9518,7 +9518,6 @@ void Mob::CalcSpellPowerDistanceMod(uint16 spell_id, float range, Mob* caster)
 
 void Mob::BreakInvisibleSpells()
 {
-	Shout("BreakInvisibleSpells()");
 	if(invisible) {
 		ZeroInvisibleVars(InvisType::T_INVISIBLE);
 		BuffFadeByEffect(SE_Invisibility);

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -590,7 +590,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				snprintf(effect_desc, _EDLEN, "Invisibility");
 #endif
 				Shout("ADD INVS %i", spell_id);
-				SetInvisible(spell.base_value[i]);
+				SetInvisibleAppearance(spell.base_value[i]);
 				break;
 			}
 
@@ -600,7 +600,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				snprintf(effect_desc, _EDLEN, "Invisibility to Animals");
 #endif
 				invisible_animals = true;
-				SetInvisible(Invisibility::Special);
+				SetInvisibleAppearance(Invisibility::Special);
 				break;
 			}
 
@@ -611,7 +611,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				snprintf(effect_desc, _EDLEN, "Invisibility to Undead");
 #endif
 				invisible_undead = true;
-				SetInvisible(Invisibility::Special);
+				SetInvisibleAppearance(Invisibility::Special);
 				break;
 			}
 
@@ -2223,7 +2223,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					if (IsClient()) {
 						int pre_aggro_count = CastToClient()->GetAggroCount();
 						entity_list.RemoveFromTargetsFadingMemories(this, true, max_level);
-						SetInvisible(Invisibility::Invisible);
+						SetInvisibleAppearance(Invisibility::Invisible);
 						int post_aggro_count = CastToClient()->GetAggroCount();
 						if (RuleB(Spells, UseFadingMemoriesMaxLevel)) {
 							if (pre_aggro_count == post_aggro_count) {
@@ -2239,7 +2239,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					}
 					else{
 						entity_list.RemoveFromTargets(caster);
-						SetInvisible(Invisibility::Invisible);
+						SetInvisibleAppearance(Invisibility::Invisible);
 					}
 				}
 				break;
@@ -4185,7 +4185,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 			case SE_Invisibility:
 			{
 				Shout("Drop INVS %i", buffs[slot].spellid);
-				SetInvisible(Invisibility::Visible);
+				SetInvisibleAppearance(Invisibility::Visible);
 				break;
 			}
 

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -4204,7 +4204,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 
 			case SE_SeeInvis:
 			{
-				see_invis = 0;
+				see_invis = innate_see_invis;
 				break;
 			}
 

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3637,7 +3637,7 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 
 	// Prevent double invising, which made you uninvised
 	// Not sure if all 3 should be stacking
-	/*
+	//This is not live like behavior (~Kayen confirmed 2/2/22)
 	if (!RuleB(Spells, AllowDoubleInvis)) {
 		if (IsEffectInSpell(spell_id, SE_Invisibility))
 		{
@@ -3669,7 +3669,6 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 			}
 		}
 	}
-	*/
 
 	if(!(IsClient() && CastToClient()->GetGM()) && !IsHarmonySpell(spell_id))	// GMs can cast on anything
 	{

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3722,7 +3722,7 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 
 	// Prevent double invising, which made you uninvised
 	// Not sure if all 3 should be stacking
-
+	/*
 	if (!RuleB(Spells, AllowDoubleInvis)) {
 		if (IsEffectInSpell(spell_id, SE_Invisibility))
 		{
@@ -3754,6 +3754,7 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 			}
 		}
 	}
+	*/
 
 	if(!(IsClient() && CastToClient()->GetGM()) && !IsHarmonySpell(spell_id))	// GMs can cast on anything
 	{

--- a/zone/zonedump.h
+++ b/zone/zonedump.h
@@ -108,7 +108,7 @@ struct NPCType
 	int32	mana_regen;
 	int32	aggroradius; // added for AI improvement - neotokyo
 	int32	assistradius; // assist radius, defaults to aggroradis if not set
-	uint8	see_invis;			// See Invis flag added
+	int16	see_invis;			// See Invis flag added
 	bool	see_invis_undead;	// See Invis vs. Undead flag added
 	bool	see_hide;
 	bool	see_improved_hide;

--- a/zone/zonedump.h
+++ b/zone/zonedump.h
@@ -108,7 +108,7 @@ struct NPCType
 	int32	mana_regen;
 	int32	aggroradius; // added for AI improvement - neotokyo
 	int32	assistradius; // assist radius, defaults to aggroradis if not set
-	int16	see_invis;			// See Invis flag added
+	uint16	see_invis;			// See Invis flag added
 	bool	see_invis_undead;	// See Invis vs. Undead flag added
 	bool	see_hide;
 	bool	see_improved_hide;

--- a/zone/zonedump.h
+++ b/zone/zonedump.h
@@ -109,7 +109,7 @@ struct NPCType
 	int32	aggroradius; // added for AI improvement - neotokyo
 	int32	assistradius; // assist radius, defaults to aggroradis if not set
 	uint16	see_invis;			// See Invis flag added
-	bool	see_invis_undead;	// See Invis vs. Undead flag added
+	uint16	see_invis_undead;	// See Invis vs. Undead flag added
 	bool	see_hide;
 	bool	see_improved_hide;
 	bool	qglobal;


### PR DESCRIPTION
This update improves the way we handle invisibility related spells to allow better implementation of invisibility levels and support for live like having multiple different invisibility buffs on a character at same time.

Live invisible mechanic allows for multiple different invisibles spells to applied to same client. For example you can have self only Improved Invisible, have bard invisible and have a regular targeted invisible cast on you. Thus giving you all 3 buffs at same time. If you cast or attack all three will fade. Therefore the below rule, should be true by default. This update provides full support for multiple invisible spells.

`RULE_BOOL(Spells, AllowDoubleInvis, true, "Allows you to cast invisibility spells on a player that is already invisible, live like behavior.")`

Invisible spells base value defines the spells 'invisibility level' while a see invisible spells base value defines its 'see invisible level', these two levels are checked against each other to determine if you can be seen by see invisible or if you can see and invisible target. If the invisible level is higher than the see invisible level then you will not be detected. If you have multiple different invisible spells on you that have different invisibility levels then the highest level will be used for detection.

If a client uses an invisible spell then in order for an NPC to detect them they must have an npc see invisible stat (set in npc types table) that is greater than or equal to the client's invisible level. For basic invisible spells that have a base value of 1, an npc invisible stat of 1 will detect it. If you want to set on your NPC a random chance for them to see invisible then set the value between 2 and 99, which will determine percent chance to be granted see invisible. This system then goes on to allow setting invisible levels all the way up to 254. See mechanic description below.

```
		1 = See Invis Level 1, 2-99 will gives a random roll to apply see invis level 1
		100 = See Invis Level 2, where 101-199 gives a random roll to apply see invis 2, if fails get see invs 1
		ect... for higher levels, 200,300 ect.
		MAX 25499, which can give you level 254.
```

Note, this innate see invisible that NPC's get from the see invisible stat can not be debuffed. However, an NPC can have spell buff version of see invisible be applied to them, in that case whatever value is higher will be used. If the spell buffed version is removed, then the innate see invis will remain and be used.

If an NPC is made invisible using quest function $npc->SetInvisible(state) where state is the invisibility level (max 254), then in order for the client to see it then the see invisible spell must be greater than or equal to the state value. For example, if you set $npc->SetInvisible(30), then you must have a see invisible spell on your client with a base value greater than  or equal to 30. Note, for custom spells, the client must have a spell file with the changes to the see invis value or it will not work to display the invisible NPC.

For invisibility vs undead, the mechanics as above apply, using npc stat 'see invis undead'

For invisibility vs animal, the mechanics as above apply, except detection is done using 'see invisible' (there is no see invis verse animal stat, I do not know if this was intentional or live mechanic, leaving it as is for now).

Implemented SPA SE_ImprovedInvisAnimals	316, fixed duration invisible verse animals. ( no live spells exist with this)

Bards will no longer get spammed with 'invisible about to fade' message from songs

The following new perl functions have been added to allow for more flexibility in using invisible mechanics on client's and NPCs. Note there exists many other invisible related quest functions.

```
$mob->SetSeeInvisibleLevel(uint8 see_invis_level) //this is the actual level used by the npc as the innate see invis
$mob->SetSeeInvisibleUndeadLevel(uint8 see invis undead level) //this is the actual level used by the npc as the innate see invis
$mob->GetInvisibleLevel()
$mob->GetInvisibleUndeadLevel()
```

There are a lot of interesting scenarios that can be invented using these invisible mechanics...