### PR TITLE
[Commands] Cleanup #showskills Command.

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -347,7 +347,7 @@ int command_init(void)
 		command_add("showbuffs", "- List buffs active on your target or you if no target", AccountStatus::Guide, command_showbuffs) ||
 		command_add("shownumhits",  "Shows buffs numhits for yourself.", AccountStatus::Player, command_shownumhits) ||
 		command_add("shownpcgloballoot", "Show GlobalLoot entires on this npc", AccountStatus::Guide, command_shownpcgloballoot) ||
-		command_add("showskills", "[Start Skill ID] [All] - Show the values of your or your player target's skills in a popup 50 at a time, use 'all' as third argument to show non-usable skill's values", AccountStatus::Guide, command_showskills) ||
+		command_add("showskills", "[Start Skill ID] [All] - Show the values of your or your player target's skills in a popup 50 at a time, use 'all' as second argument to show non-usable skill's values", AccountStatus::Guide, command_showskills) ||
 		command_add("showspellslist", "Shows spell list of targeted NPC", AccountStatus::GMAdmin, command_showspellslist) ||
 		command_add("showstats", "- Show details about you or your target", AccountStatus::Guide, command_showstats) ||
 		command_add("showzonegloballoot", "Show GlobalLoot entires on this zone", AccountStatus::Guide, command_showzonegloballoot) ||

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -347,7 +347,7 @@ int command_init(void)
 		command_add("showbuffs", "- List buffs active on your target or you if no target", AccountStatus::Guide, command_showbuffs) ||
 		command_add("shownumhits",  "Shows buffs numhits for yourself.", AccountStatus::Player, command_shownumhits) ||
 		command_add("shownpcgloballoot", "Show GlobalLoot entires on this npc", AccountStatus::Guide, command_shownpcgloballoot) ||
-		command_add("showskills", "- Show the values of your or your player target's skills", AccountStatus::Guide, command_showskills) ||
+		command_add("showskills", "[Start Skill ID] [All] - Show the values of your or your player target's skills in a popup 50 at a time, use 'all' as third argument to show non-usable skill's values", AccountStatus::Guide, command_showskills) ||
 		command_add("showspellslist", "Shows spell list of targeted NPC", AccountStatus::GMAdmin, command_showspellslist) ||
 		command_add("showstats", "- Show details about you or your target", AccountStatus::Guide, command_showstats) ||
 		command_add("showzonegloballoot", "Show GlobalLoot entires on this zone", AccountStatus::Guide, command_showzonegloballoot) ||

--- a/zone/gm_commands/showskills.cpp
+++ b/zone/gm_commands/showskills.cpp
@@ -72,7 +72,7 @@ void command_showskills(Client *c, const Seperator *sep)
 			EQ::skills::GetSkillName((EQ::skills::SkillType) max_skill_id),
 			max_skill_id,
 			c == target ?
-			"Yourself" :
+			"yourself" :
 			fmt::format(
 				"{} ({})",
 				target->GetCleanName(),

--- a/zone/gm_commands/showskills.cpp
+++ b/zone/gm_commands/showskills.cpp
@@ -2,43 +2,117 @@
 
 void command_showskills(Client *c, const Seperator *sep)
 {
-	Client *target = c;
+	auto target = c;
 	if (c->GetTarget() && c->GetTarget()->IsClient()) {
 		target = c->GetTarget()->CastToClient();
 	}
 
-	bool show_all = false;
-
-	if (!strcasecmp("all", sep->arg[1])) {
-		show_all = true;
+	uint32 start_skill_id = 0;
+	if (sep->IsNumber(1)) {
+		start_skill_id = std::stoul(sep->arg[1]);
 	}
+
+	bool show_all = !strcasecmp(sep->arg[2], "all");
+
+	uint32 max_skill_id = (start_skill_id + 49);
+
+	std::string popup_text = "<table>";
+
+	popup_text += "<tr><td>ID</td><td>Name</td><td>Current</td><td>Max</td><td>Raw</td></tr>";
+
+	for (
+		EQ::skills::SkillType skill_id = (EQ::skills::SkillType) start_skill_id;
+		skill_id <= (EQ::skills::SkillType) max_skill_id;
+		skill_id = (EQ::skills::SkillType) (skill_id + 1)
+	) {
+		if ((EQ::skills::SkillType) skill_id >= EQ::skills::SkillCount) {
+			max_skill_id = (EQ::skills::SkillCount - 1);
+			break;
+		}
+
+		if (show_all || (target->CanHaveSkill(skill_id) && target->MaxSkill(skill_id))) {
+			popup_text += fmt::format(
+				"<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>",
+				skill_id,
+				EQ::skills::GetSkillName(skill_id),
+				target->GetSkill(skill_id),
+				target->MaxSkill(skill_id),
+				target->GetRawSkill(skill_id)
+			);
+		}
+	}
+
+	popup_text += "</table>";
+
+	std::string popup_title = fmt::format(
+		"Skills for {} [{} to {}]",
+		c == target ?
+		"Yourself" :
+		fmt::format(
+			"{} ({})",
+			target->GetCleanName(),
+			target->GetID()
+		),
+		start_skill_id,
+		max_skill_id
+	);
+
+	c->SendPopupToClient(
+		popup_title.c_str(),
+		popup_text.c_str()
+	);
+	
 
 	c->Message(
 		Chat::White,
 		fmt::format(
-			"Skills | Name: {}",
-			target->GetCleanName()
+			"Viewing skill levels from {} ({}) to {} ({}) for {}.",
+			EQ::skills::GetSkillName((EQ::skills::SkillType) start_skill_id),
+			start_skill_id,
+			EQ::skills::GetSkillName((EQ::skills::SkillType) max_skill_id),
+			max_skill_id,
+			c == target ?
+			"Yourself" :
+			fmt::format(
+				"{} ({})",
+				target->GetCleanName(),
+				target->GetID()
+			)
 		).c_str()
 	);
 
-	for (
-		EQ::skills::SkillType skill_type = EQ::skills::Skill1HBlunt;
-		skill_type <= EQ::skills::HIGHEST_SKILL;
-		skill_type = (EQ::skills::SkillType) (skill_type + 1)
-		) {
-		if (show_all || (target->CanHaveSkill(skill_type) && target->MaxSkill(skill_type))) {
-			c->Message(
-				Chat::White,
-				fmt::format(
-					"{} ({}) | Current: {} Max: {} Raw: {}",
-					EQ::skills::GetSkillName(skill_type),
-					skill_type,
-					target->GetSkill(skill_type),
-					target->MaxSkill(skill_type),
-					target->GetRawSkill(skill_type)
-				).c_str()
-			);
-		}
+	int next_skill_id = (max_skill_id + 1);
+	if ((EQ::skills::SkillType) next_skill_id < EQ::skills::SkillCount) {
+		auto next_list_string = fmt::format(
+			"#showskills {}",
+			next_skill_id
+		);
+
+		auto next_list_link = EQ::SayLinkEngine::GenerateQuestSaylink(
+			next_list_string,
+			false,
+			next_list_string
+		);
+
+		auto next_list_all_string = fmt::format(
+			"#showskills {} all",
+			next_skill_id
+		);
+
+		auto next_list_all_link = EQ::SayLinkEngine::GenerateQuestSaylink(
+			next_list_all_string,
+			false,
+			next_list_all_string
+		);
+
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"To view the next 50 skill levels, you can use {} or {} to show skills the player cannot normally have.",
+				next_list_link,
+				next_list_all_link
+			).c_str()
+		);
 	}
 }
 


### PR DESCRIPTION
- Utilize popup over messages.
- Usage: #showskills [Start Skill ID] [All] - shows skills starting from skill ID and if "all" is specified it will show skills the player does not have normally (no max/cannot have skill).
![image](https://user-images.githubusercontent.com/89047260/153762896-28e17fe0-478b-4e3b-8411-35d59ecf00e3.png)
![image](https://user-images.githubusercontent.com/89047260/153762929-71de7407-f42e-47c2-ad03-9b722a8b433b.png)
![image](https://user-images.githubusercontent.com/89047260/153762935-ba38e727-2ce9-4ec4-b024-c9e11c800590.png)
![image](https://user-images.githubusercontent.com/89047260/153762948-eb1cd31d-6861-41bb-8fa9-0ca3326b6a6e.png)
