### PR TITLE
[API] Apply spells with custom buff durations and adjust existing spell buff durations.

### DIFF
--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1257,7 +1257,7 @@ typedef enum {
 
 #define DF_Permanent				50
 #define DF_Aura						51
-#define PERMENANT_BUFF_DURATION 	-1000 //this is arbitrary used when overriding spells regular buff duration.
+#define PERMENANT_BUFF_DURATION 	-1000 //this is arbitrary used when overriding spells regular buff duration to set it as permenant
 
 // note this struct is historical, we don't actually need it to be
 // aligned to anything, but for maintaining it it is kept in the order that

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1255,8 +1255,9 @@ typedef enum {
 // LAST
 
 
-#define DF_Permanent			50
-#define DF_Aura					51
+#define DF_Permanent				50
+#define DF_Aura						51
+#define PERMENANT_BUFF_DURATION 	-1000 //this is arbitrary used when overriding spells regular buff duration.
 
 // note this struct is historical, we don't actually need it to be
 // aligned to anything, but for maintaining it it is kept in the order that

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -441,7 +441,7 @@ public:
 	void ClearAppearenceEffects();
 	void SendSavedAppearenceEffects(Client *receiver);
 	void SetBuffDuration(int32 spell_id, int32 duration);
-	void AddBuffToTarget(Mob *spell_target, int32 spell_id, int32 duration);
+	void ApplySpellBuff(int32 spell_id, int32 duration);
 
 	//Basic Stats/Inventory
 	virtual void SetLevel(uint8 in_level, bool command = false) { level = in_level; }

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -442,6 +442,8 @@ public:
 	void SendSavedAppearenceEffects(Client *receiver);
 	void SetBuffDuration(int32 spell_id, int32 duration);
 	void ApplySpellBuff(int32 spell_id, int32 duration);
+	int GetBuffStatValueBySpell(int32 spell_id, const char* stat_identifier);
+	int GetBuffStatValueBySlot(uint8 slot, const char* stat_identifier);
 
 	//Basic Stats/Inventory
 	virtual void SetLevel(uint8 in_level, bool command = false) { level = in_level; }

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -438,7 +438,7 @@ public:
 	void GetAppearenceEffects();
 	void ClearAppearenceEffects();
 	void SendSavedAppearenceEffects(Client *receiver);
-	void SetBuffDuration(Mob *spell_target, int32 spell_id, int32 duration);
+	void SetBuffDuration(int32 spell_id, int32 duration);
 	void AddBuffToTarget(Mob *spell_target, int32 spell_id, int32 duration);
 
 	//Basic Stats/Inventory

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -438,6 +438,7 @@ public:
 	void GetAppearenceEffects();
 	void ClearAppearenceEffects();
 	void SendSavedAppearenceEffects(Client *receiver);
+	void SetBuffDuration(int32 spell_id, int32 duration);
 
 	//Basic Stats/Inventory
 	virtual void SetLevel(uint8 in_level, bool command = false) { level = in_level; }

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -329,8 +329,8 @@ public:
 		uint32 inventory_slot = 0xFFFFFFFF, int16 resist_adjust = 0, bool isproc = false, int level_override = -1, bool from_casted_spell = false, uint32 aa_id = 0);
 	void SendBeginCast(uint16 spell_id, uint32 casttime);
 	virtual bool SpellOnTarget(uint16 spell_id, Mob* spelltar, int reflect_effectiveness = 0,
-		bool use_resist_adjust = false, int16 resist_adjust = 0, bool isproc = false, int level_override = -1, int32 duration_override = 0);
-	virtual bool SpellEffect(Mob* caster, uint16 spell_id, float partial = 100, int level_override = -1, int reflect_effectiveness = 0, int32 duration_override = 0);
+		bool use_resist_adjust = false, int16 resist_adjust = 0, bool isproc = false, int level_override = -1, int32 duration_override = 0, bool disable_buff_overrwrite = false);
+	virtual bool SpellEffect(Mob* caster, uint16 spell_id, float partial = 100, int level_override = -1, int reflect_effectiveness = 0, int32 duration_override = 0, bool disable_buff_overrwrite = false);
 	virtual bool DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_center,
 		CastAction_type &CastAction, EQ::spells::CastingSlot slot, bool isproc = false);
 	bool DoCastingChecksOnCaster(int32 spell_id);
@@ -383,7 +383,7 @@ public:
 	bool IsAffectedByBuff(uint16 spell_id);
 	bool IsAffectedByBuffByGlobalGroup(GlobalGroup group);
 	void BuffModifyDurationBySpellID(uint16 spell_id, int32 newDuration);
-	int AddBuff(Mob *caster, const uint16 spell_id, int duration = 0, int32 level_override = -1);
+	int AddBuff(Mob *caster, const uint16 spell_id, int duration = 0, int32 level_override = -1, bool disable_buff_overrwrite = false);
 	int CanBuffStack(uint16 spellid, uint8 caster_level, bool iFailIfOverwrite = false);
 	int CalcBuffDuration(Mob *caster, Mob *target, uint16 spell_id, int32 caster_level_override = -1);
 	void SendPetBuffsToClient();

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -438,7 +438,8 @@ public:
 	void GetAppearenceEffects();
 	void ClearAppearenceEffects();
 	void SendSavedAppearenceEffects(Client *receiver);
-	void SetBuffDuration(int32 spell_id, int32 duration);
+	void SetBuffDuration(Mob *spell_target, int32 spell_id, int32 duration);
+	void AddBuffToTarget(Mob *spell_target, int32 spell_id, int32 duration);
 
 	//Basic Stats/Inventory
 	virtual void SetLevel(uint8 in_level, bool command = false) { level = in_level; }

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -6502,6 +6502,21 @@ XS(XS_Mob_GetHateRandomNPC) {
 	XSRETURN(1);
 }
 
+XS(XS_Mob_SetBuffDuration); /* prototype to pass -Wmissing-prototypes */
+XS(XS_Mob_SetBuffDuration) {
+	dXSARGS;
+	if (items != 3)
+		Perl_croak(aTHX_ "Usage: Mob::SetBuffDuration(THIS, spell_id, duration)"); // @categories Script Utility
+	{
+		Mob *THIS;
+		int spell_id = (int)SvIV(ST(1));
+		int duration = (int)SvIV(ST(2));
+		VALIDATE_THIS_IS_MOB;
+		THIS->SetBuffDuration(spell_id, duration);
+	}
+	XSRETURN_EMPTY;
+}
+
 #ifdef BOTS
 XS(XS_Mob_CastToBot); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Mob_CastToBot)
@@ -6850,6 +6865,7 @@ XS(boot_Mob) {
 	newXSproto(strcpy(buf, "SetAppearance"), XS_Mob_SetAppearance, file, "$$;$");
 	newXSproto(strcpy(buf, "SetBodyType"), XS_Mob_SetBodyType, file, "$$;$");
 	newXSproto(strcpy(buf, "SetBucket"), XS_Mob_SetBucket, file, "$$$;$");
+	newXSproto(strcpy(buf, "SetBuffDuration"), XS_Mob_SetBuffDuration, file, "$$$");
 	newXSproto(strcpy(buf, "SetCurrentWP"), XS_Mob_SetCurrentWP, file, "$$");
 	newXSproto(strcpy(buf, "SetDeltas"), XS_Mob_SetDeltas, file, "$$$$$");
 	newXSproto(strcpy(buf, "SetDisableMelee"), XS_Mob_SetDisableMelee, file, "$$");

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -6505,24 +6505,14 @@ XS(XS_Mob_GetHateRandomNPC) {
 XS(XS_Mob_SetBuffDuration); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Mob_SetBuffDuration) {
 	dXSARGS;
-	if (items != 4)
-		Perl_croak(aTHX_ "Usage: Mob::SetBuffDuration(THIS, target, spell_id, duration)"); // @categories Spells and Disciplines
+	if (items != 3)
+		Perl_croak(aTHX_ "Usage: Mob::SetBuffDuration(THIS, spell_id, duration)"); // // @categories Script Utility
 	{
 		Mob *THIS;
-		Mob* other;
-		int spell_id = (int)SvIV(ST(2));
-		int duration = (int)SvIV(ST(3));
+		int spell_id = (int)SvIV(ST(1));
+		int duration = (int)SvIV(ST(2));
 		VALIDATE_THIS_IS_MOB;
-		if (sv_derived_from(ST(1), "Mob")) {
-			IV tmp = SvIV((SV *)SvRV(ST(1)));
-			other = INT2PTR(Mob *, tmp);
-		}
-		else
-			Perl_croak(aTHX_ "other is not of type Mob");
-		if (other == nullptr)
-			Perl_croak(aTHX_ "other is nullptr, avoiding crash.");
-
-		THIS->SetBuffDuration(other, spell_id, duration);
+		THIS->SetBuffDuration(spell_id, duration);
 	}
 	XSRETURN_EMPTY;
 }
@@ -6875,7 +6865,7 @@ XS(boot_Mob) {
 	newXSproto(strcpy(buf, "SetAppearance"), XS_Mob_SetAppearance, file, "$$;$");
 	newXSproto(strcpy(buf, "SetBodyType"), XS_Mob_SetBodyType, file, "$$;$");
 	newXSproto(strcpy(buf, "SetBucket"), XS_Mob_SetBucket, file, "$$$;$");
-	newXSproto(strcpy(buf, "SetBuffDuration"), XS_Mob_SetBuffDuration, file, "$$$$");
+	newXSproto(strcpy(buf, "SetBuffDuration"), XS_Mob_SetBuffDuration, file, "$$$");
 	newXSproto(strcpy(buf, "SetCurrentWP"), XS_Mob_SetCurrentWP, file, "$$");
 	newXSproto(strcpy(buf, "SetDeltas"), XS_Mob_SetDeltas, file, "$$$$$");
 	newXSproto(strcpy(buf, "SetDisableMelee"), XS_Mob_SetDisableMelee, file, "$$");

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -6505,14 +6505,39 @@ XS(XS_Mob_GetHateRandomNPC) {
 XS(XS_Mob_SetBuffDuration); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Mob_SetBuffDuration) {
 	dXSARGS;
-	if (items != 3)
-		Perl_croak(aTHX_ "Usage: Mob::SetBuffDuration(THIS, spell_id, duration)"); // // @categories Script Utility
+	if (items < 2 || items > 3)
+		Perl_croak(aTHX_ "Usage: Mob::SetBuffDuration(THIS, spell_id, [int duration = 0])"); // // @categories Script Utility
 	{
 		Mob *THIS;
 		int spell_id = (int)SvIV(ST(1));
 		int duration = (int)SvIV(ST(2));
 		VALIDATE_THIS_IS_MOB;
+
+		if (items < 3) {
+			duration = 0;
+		}
+
 		THIS->SetBuffDuration(spell_id, duration);
+	}
+	XSRETURN_EMPTY;
+}
+
+XS(XS_Mob_ApplySpellBuff); /* prototype to pass -Wmissing-prototypes */
+XS(XS_Mob_ApplySpellBuff) {
+	dXSARGS;
+	if (items < 2 || items > 3)
+		Perl_croak(aTHX_ "Usage: Mob::ApplySpellBuff(THIS, spell_id, [int duration = 0])"); // // @categories Script Utility
+	{
+		Mob *THIS;
+		int spell_id = (int)SvIV(ST(1));
+		int duration = (int)SvIV(ST(2));
+		VALIDATE_THIS_IS_MOB;
+
+		if (items < 3) {
+			duration = 0;
+		}
+
+		THIS->ApplySpellBuff(spell_id, duration);
 	}
 	XSRETURN_EMPTY;
 }
@@ -6572,6 +6597,7 @@ XS(boot_Mob) {
 	newXSproto(strcpy(buf, "AddFeignMemory"), XS_Mob_AddFeignMemory, file, "$$");
 	newXSproto(strcpy(buf, "AddNimbusEffect"), XS_Mob_AddNimbusEffect, file, "$$");
 	newXSproto(strcpy(buf, "AddToHateList"), XS_Mob_AddToHateList, file, "$$;$$$$$");
+	newXSproto(strcpy(buf, "ApplySpellBuff"), XS_Mob_ApplySpellBuff, file, "$$$");
 	newXSproto(strcpy(buf, "Attack"), XS_Mob_Attack, file, "$$;$$");
 	newXSproto(strcpy(buf, "BehindMob"), XS_Mob_BehindMob, file, "$;$$$");
 	newXSproto(strcpy(buf, "BuffCount"), XS_Mob_BuffCount, file, "$");

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -5633,6 +5633,46 @@ XS(XS_Mob_GetSpellStat) {
 	XSRETURN(1);
 }
 
+XS(XS_Mob_GetBuffStatValueBySpell); /* prototype to pass -Wmissing-prototypes */
+XS(XS_Mob_GetBuffStatValueBySpell) {
+	dXSARGS;
+	if (items != 3)
+		Perl_croak(aTHX_ "Usage: Mob::GetBuffStatValueBySpell(THIS, int32 spell_id, string stat)"); // @categories Spells and Disciplines
+	{
+		Mob *THIS;
+		int32  RETVAL;
+		int32  spellid = (int32)SvIV(ST(1));
+		Const_char *stat = (Const_char *)SvPV_nolen(ST(2));
+		dXSTARG;
+		VALIDATE_THIS_IS_MOB;
+	
+		RETVAL = THIS->GetBuffStatValueBySpell(spellid, stat);
+		XSprePUSH;
+		PUSHi((IV)RETVAL);
+	}
+	XSRETURN(1);
+}
+
+XS(XS_Mob_GetBuffStatValueBySlot); /* prototype to pass -Wmissing-prototypes */
+XS(XS_Mob_GetBuffStatValueBySlot) {
+	dXSARGS;
+	if (items != 3)
+		Perl_croak(aTHX_ "Usage: Mob::GetBuffStatValueBySpell(THIS, uint8 slot, string stat)"); // @categories Spells and Disciplines
+	{
+		Mob *THIS;
+		int32  RETVAL;
+		uint8 slot = (uint8)SvUV(ST(1));
+		Const_char *stat = (Const_char *)SvPV_nolen(ST(2));
+		dXSTARG;
+		VALIDATE_THIS_IS_MOB;
+
+		RETVAL = THIS->GetBuffStatValueBySlot(slot, stat);
+		XSprePUSH;
+		PUSHi((IV)RETVAL);
+	}
+	XSRETURN(1);
+}
+
 XS(XS_Mob_GetSpecialAbility); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Mob_GetSpecialAbility) {
 	dXSARGS;
@@ -6688,6 +6728,8 @@ XS(boot_Mob) {
 	newXSproto(strcpy(buf, "GetBucketKey"), XS_Mob_GetBucketKey, file, "$");
 	newXSproto(strcpy(buf, "GetBucketRemaining"), XS_Mob_GetBucketRemaining, file, "$$");
 	newXSproto(strcpy(buf, "GetBuffSlotFromType"), XS_Mob_GetBuffSlotFromType, file, "$$");
+	newXSproto(strcpy(buf, "GetBuffStatValueBySpell"), XS_Mob_GetBuffStatValueBySpell, file, "$$$");
+	newXSproto(strcpy(buf, "GetBuffStatValueBySlot"), XS_Mob_GetBuffStatValueBySlot, file, "$$$");
 	newXSproto(strcpy(buf, "GetCHA"), XS_Mob_GetCHA, file, "$");
 	newXSproto(strcpy(buf, "GetCR"), XS_Mob_GetCR, file, "$");
 	newXSproto(strcpy(buf, "GetCasterLevel"), XS_Mob_GetCasterLevel, file, "$$");

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -6505,14 +6505,24 @@ XS(XS_Mob_GetHateRandomNPC) {
 XS(XS_Mob_SetBuffDuration); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Mob_SetBuffDuration) {
 	dXSARGS;
-	if (items != 3)
-		Perl_croak(aTHX_ "Usage: Mob::SetBuffDuration(THIS, spell_id, duration)"); // @categories Script Utility
+	if (items != 4)
+		Perl_croak(aTHX_ "Usage: Mob::SetBuffDuration(THIS, target, spell_id, duration)"); // @categories Spells and Disciplines
 	{
 		Mob *THIS;
-		int spell_id = (int)SvIV(ST(1));
-		int duration = (int)SvIV(ST(2));
+		Mob* other;
+		int spell_id = (int)SvIV(ST(2));
+		int duration = (int)SvIV(ST(3));
 		VALIDATE_THIS_IS_MOB;
-		THIS->SetBuffDuration(spell_id, duration);
+		if (sv_derived_from(ST(1), "Mob")) {
+			IV tmp = SvIV((SV *)SvRV(ST(1)));
+			other = INT2PTR(Mob *, tmp);
+		}
+		else
+			Perl_croak(aTHX_ "other is not of type Mob");
+		if (other == nullptr)
+			Perl_croak(aTHX_ "other is nullptr, avoiding crash.");
+
+		THIS->SetBuffDuration(other, spell_id, duration);
 	}
 	XSRETURN_EMPTY;
 }
@@ -6865,7 +6875,7 @@ XS(boot_Mob) {
 	newXSproto(strcpy(buf, "SetAppearance"), XS_Mob_SetAppearance, file, "$$;$");
 	newXSproto(strcpy(buf, "SetBodyType"), XS_Mob_SetBodyType, file, "$$;$");
 	newXSproto(strcpy(buf, "SetBucket"), XS_Mob_SetBucket, file, "$$$;$");
-	newXSproto(strcpy(buf, "SetBuffDuration"), XS_Mob_SetBuffDuration, file, "$$$");
+	newXSproto(strcpy(buf, "SetBuffDuration"), XS_Mob_SetBuffDuration, file, "$$$$");
 	newXSproto(strcpy(buf, "SetCurrentWP"), XS_Mob_SetCurrentWP, file, "$$");
 	newXSproto(strcpy(buf, "SetDeltas"), XS_Mob_SetDeltas, file, "$$$$$");
 	newXSproto(strcpy(buf, "SetDisableMelee"), XS_Mob_SetDisableMelee, file, "$$");

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -5657,7 +5657,7 @@ XS(XS_Mob_GetBuffStatValueBySlot); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Mob_GetBuffStatValueBySlot) {
 	dXSARGS;
 	if (items != 3)
-		Perl_croak(aTHX_ "Usage: Mob::GetBuffStatValueBySpell(THIS, uint8 slot, string stat)"); // @categories Spells and Disciplines
+		Perl_croak(aTHX_ "Usage: Mob::GetBuffStatValueBySpell(THIS, uint8 slot, string stat)"); // @categories Script Utility, Spells and Disciplines
 	{
 		Mob *THIS;
 		int32  RETVAL;
@@ -6546,7 +6546,7 @@ XS(XS_Mob_SetBuffDuration); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Mob_SetBuffDuration) {
 	dXSARGS;
 	if (items < 2 || items > 3)
-		Perl_croak(aTHX_ "Usage: Mob::SetBuffDuration(THIS, spell_id, [int duration = 0])"); // // @categories Script Utility
+		Perl_croak(aTHX_ "Usage: Mob::SetBuffDuration(THIS, spell_id, [int duration = 0])"); // @categories Script Utility, Spells and Disciplines
 	{
 		Mob *THIS;
 		int spell_id = (int)SvIV(ST(1));
@@ -6566,7 +6566,7 @@ XS(XS_Mob_ApplySpellBuff); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Mob_ApplySpellBuff) {
 	dXSARGS;
 	if (items < 2 || items > 3)
-		Perl_croak(aTHX_ "Usage: Mob::ApplySpellBuff(THIS, spell_id, [int duration = 0])"); // // @categories Script Utility
+		Perl_croak(aTHX_ "Usage: Mob::ApplySpellBuff(THIS, spell_id, [int duration = 0])"); // @categories Script Utility, Spells and Disciplines
 	{
 		Mob *THIS;
 		int spell_id = (int)SvIV(ST(1));

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -10234,3 +10234,42 @@ bool Mob::HasPersistDeathIllusion(int32 spell_id) {
 	}
 	return false;
 }
+
+void Mob::SetBuffDuration(int32 spell_id, int32 duration) {
+	Shout("Test %i %i", spell_id, duration);
+
+	bool adjust_all_buffs = false;
+
+	if (spell_id == -1) {
+		adjust_all_buffs = true;
+	}
+
+	if (!adjust_all_buffs && !IsValidSpell(spell_id)) {
+		return;
+	}
+
+	if (duration == 0) {
+		duration = CalcBuffDuration(this, this, spell_id);
+
+		if (duration > 0){
+			duration = GetActSpellDuration(spell_id, duration);
+		}
+	}
+
+	int buff_count = GetMaxBuffSlots();
+	for (int slot = 0; slot < buff_count; slot++) {
+		
+		if (!adjust_all_buffs) {
+			if (buffs[slot].spellid != SPELL_UNKNOWN && buffs[slot].spellid == spell_id) {
+				SpellOnTarget(spell_id, this, 0, false, 0, false, -1, duration);
+				return;
+			}
+		}
+		else {
+			if (buffs[slot].spellid != SPELL_UNKNOWN) {
+				SpellOnTarget(spell_id, this, 0, false, 0, false, -1, duration);
+				return;
+			}
+		}
+	}
+}

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -10248,27 +10248,32 @@ void Mob::SetBuffDuration(int32 spell_id, int32 duration) {
 		return;
 	}
 
-	if (duration == 0) {
-		duration = CalcBuffDuration(this, this, spell_id);
-
-		if (duration > 0){
-			duration = GetActSpellDuration(spell_id, duration);
-		}
-	}
-
 	int buff_count = GetMaxBuffSlots();
 	for (int slot = 0; slot < buff_count; slot++) {
 		
 		if (!adjust_all_buffs) {
 			if (buffs[slot].spellid != SPELL_UNKNOWN && buffs[slot].spellid == spell_id) {
+				if (duration == 0) {
+					duration = CalcBuffDuration(this, this, spell_id);
+
+					if (duration > 0) {
+						duration = GetActSpellDuration(spell_id, duration);
+					}
+				}
 				SpellOnTarget(spell_id, this, 0, false, 0, false, -1, duration);
 				return;
 			}
 		}
 		else {
 			if (buffs[slot].spellid != SPELL_UNKNOWN) {
-				SpellOnTarget(spell_id, this, 0, false, 0, false, -1, duration);
-				return;
+				if (duration == 0) {
+					duration = CalcBuffDuration(this, this, spell_id);
+
+					if (duration > 0) {
+						duration = GetActSpellDuration(spell_id, duration);
+					}
+				}
+				SpellOnTarget(buffs[slot].spellid, this, 0, false, 0, false, -1, duration);
 			}
 		}
 	}

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -10235,7 +10235,7 @@ bool Mob::HasPersistDeathIllusion(int32 spell_id) {
 	return false;
 }
 
-void Mob::SetBuffDuration(int32 spell_id, int32 duration) {
+void Mob::SetBuffDuration(Mob *spell_target, int32 spell_id, int32 duration) {
 	Shout("Test %i %i", spell_id, duration);
 
 	bool adjust_all_buffs = false;
@@ -10244,7 +10244,9 @@ void Mob::SetBuffDuration(int32 spell_id, int32 duration) {
 		adjust_all_buffs = true;
 	}
 
-	if (!adjust_all_buffs && !IsValidSpell(spell_id)) {
+	if (!adjust_all_buffs && !IsValidSpell(spell_id) ||
+		duration < 0 ||
+		!spell_target) {
 		return;
 	}
 
@@ -10273,8 +10275,20 @@ void Mob::SetBuffDuration(int32 spell_id, int32 duration) {
 						duration = GetActSpellDuration(spell_id, duration);
 					}
 				}
-				SpellOnTarget(buffs[slot].spellid, this, 0, false, 0, false, -1, duration);
+				SpellOnTarget(buffs[slot].spellid, spell_target, 0, false, 0, false, -1, duration);
 			}
 		}
 	}
+}
+
+void Mob::AddBuffToTarget(Mob *spell_target, int32 spell_id, int32 duration)
+{
+	if (!spell_target ||
+		!IsValidSpell(spell_id) ||
+		duration < 0 ||
+		!spells[spell_id].buff_duration) {
+		return;
+	}
+
+	SpellOnTarget(spell_id, spell_target, 0, false, 0, false, -1, duration);
 }

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -3700,7 +3700,8 @@ void Mob::BuffProcess()
 
 			// DF_Permanent uses -1 DF_Aura uses -4 but we need to check negatives for some spells for some reason?
 			if (spells[buffs[buffs_i].spellid].buff_duration_formula != DF_Permanent &&
-			    spells[buffs[buffs_i].spellid].buff_duration_formula != DF_Aura) {
+			    spells[buffs[buffs_i].spellid].buff_duration_formula != DF_Aura &&
+				buffs[buffs_i].ticsremaining != PERMENANT_BUFF_DURATION) {
 				if(!zone->BuffTimersSuspended() || !IsSuspendableSpell(buffs[buffs_i].spellid))
 				{
 					--buffs[buffs_i].ticsremaining;
@@ -10281,9 +10282,12 @@ void Mob::SetBuffDuration(int32 spell_id, int32 duration) {
 		adjust_all_buffs = true;
 	}
 
-	if (!adjust_all_buffs && !IsValidSpell(spell_id) ||
-		duration < 0) {
+	if (!adjust_all_buffs && !IsValidSpell(spell_id)){
 		return;
+	}
+
+	if (duration < -1) {
+		duration = -1;
 	}
 
 	int buff_count = GetMaxBuffSlots();

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -10326,3 +10326,63 @@ void Mob::ApplySpellBuff(int32 spell_id, int32 duration)
 
 	SpellOnTarget(spell_id, this, 0, false, 0, false, -1, duration);
 }
+
+int Mob::GetBuffStatValueBySpell(int32 spell_id, const char* stat_identifier)
+{
+	if (!IsValidSpell(spell_id)) {
+		return 0;
+	}
+
+	if (!stat_identifier) {
+		return 0;
+	}
+
+	std::string id = stat_identifier;
+	for (uint32 i = 0; i < id.length(); ++i) {
+		id[i] = tolower(id[i]);
+	}
+
+	int buff_count = GetMaxBuffSlots();
+	for (int slot = 0; slot < buff_count; slot++) {
+		if (buffs[slot].spellid != SPELL_UNKNOWN && buffs[slot].spellid == spell_id) {
+			return GetBuffStatValueBySlot(slot, stat_identifier);
+		}
+	}
+	return 0;
+}
+
+int Mob::GetBuffStatValueBySlot(uint8 slot, const char* stat_identifier) 
+{
+	if (slot > GetMaxBuffSlots()) {
+		return 0;
+	}
+
+	if (!stat_identifier) {
+		return 0;
+	}
+
+	std::string id = stat_identifier;
+	for (uint32 i = 0; i < id.length(); ++i) {
+		id[i] = tolower(id[i]);
+	}
+
+	if (id == "caster_level") { return buffs[slot].casterlevel; }
+	else if (id == "spell_id") { return buffs[slot].spellid; }
+	else if (id == "caster_id") { return buffs[slot].spellid;; }
+	else if (id == "ticsremaining") { return buffs[slot].ticsremaining; }
+	else if (id == "counters") { return buffs[slot].counters; }
+	else if (id == "hit_number") { return  buffs[slot].hit_number; }
+	else if (id == "melee_rune") { return  buffs[slot].melee_rune; }
+	else if (id == "magic_rune") { return  buffs[slot].magic_rune; }
+	else if (id == "dot_rune") { return  buffs[slot].dot_rune; }
+	else if (id == "caston_x") { return  buffs[slot].caston_x; }
+	else if (id == "caston_y") { return buffs[slot].caston_y; }
+	else if (id == "caston_z") { return  buffs[slot].caston_z; }
+	else if (id == "instrument_mod") { return  buffs[slot].instrument_mod; }
+	else if (id == "persistant_buff") { return  buffs[slot].persistant_buff; }
+	else if (id == "client") { return  buffs[slot].client; }
+	else if (id == "extra_di_chance") { return  buffs[slot].ExtraDIChance; }
+	else if (id == "root_break_chance") { return  buffs[slot].RootBreakChance; }
+	else if (id == "virus_spread_time") { return  buffs[slot].virus_spread_time; }
+	return 0;
+}

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -10235,7 +10235,7 @@ bool Mob::HasPersistDeathIllusion(int32 spell_id) {
 	return false;
 }
 
-void Mob::SetBuffDuration(Mob *spell_target, int32 spell_id, int32 duration) {
+void Mob::SetBuffDuration(int32 spell_id, int32 duration) {
 	Shout("Test %i %i", spell_id, duration);
 
 	bool adjust_all_buffs = false;
@@ -10245,8 +10245,7 @@ void Mob::SetBuffDuration(Mob *spell_target, int32 spell_id, int32 duration) {
 	}
 
 	if (!adjust_all_buffs && !IsValidSpell(spell_id) ||
-		duration < 0 ||
-		!spell_target) {
+		duration < 0) {
 		return;
 	}
 
@@ -10262,7 +10261,8 @@ void Mob::SetBuffDuration(Mob *spell_target, int32 spell_id, int32 duration) {
 						duration = GetActSpellDuration(spell_id, duration);
 					}
 				}
-				SpellOnTarget(spell_id, this, 0, false, 0, false, -1, duration);
+				Shout("Cast spell %i", buffs[slot].spellid);
+				SpellOnTarget(buffs[slot].spellid, this, 0, false, 0, false, -1, duration, true);
 				return;
 			}
 		}
@@ -10275,7 +10275,7 @@ void Mob::SetBuffDuration(Mob *spell_target, int32 spell_id, int32 duration) {
 						duration = GetActSpellDuration(spell_id, duration);
 					}
 				}
-				SpellOnTarget(buffs[slot].spellid, spell_target, 0, false, 0, false, -1, duration);
+				SpellOnTarget(buffs[slot].spellid, this, 0, false, 0, false, -1, duration, true);
 			}
 		}
 	}

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -46,7 +46,7 @@ extern WorldServer worldserver;
 
 // the spell can still fail here, if the buff can't stack
 // in this case false will be returned, true otherwise
-bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_override, int reflect_effectiveness, int32 duration_override)
+bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_override, int reflect_effectiveness, int32 duration_override, bool disable_buff_overrwrite)
 {
 	int caster_level, buffslot, effect, effect_value, i;
 	EQ::ItemInstance *SummonedItem=nullptr;
@@ -119,7 +119,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 			}
 			else
 			{
-				buffslot = AddBuff(caster, spell_id, duration_override);
+				buffslot = AddBuff(caster, spell_id, duration_override, disable_buff_overrwrite);
 			}
 			if(buffslot == -1)	// stacking failure
 				return false;

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -119,7 +119,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 			}
 			else
 			{
-				buffslot = AddBuff(caster, spell_id, duration_override, disable_buff_overrwrite);
+				buffslot = AddBuff(caster, spell_id, duration_override, -1, disable_buff_overrwrite);
 			}
 			if(buffslot == -1)	// stacking failure
 				return false;
@@ -10286,41 +10286,28 @@ void Mob::SetBuffDuration(int32 spell_id, int32 duration) {
 		
 		if (!adjust_all_buffs) {
 			if (buffs[slot].spellid != SPELL_UNKNOWN && buffs[slot].spellid == spell_id) {
-				if (duration == 0) {
-					duration = CalcBuffDuration(this, this, spell_id);
-
-					if (duration > 0) {
-						duration = GetActSpellDuration(spell_id, duration);
-					}
-				}
-				Shout("Cast spell %i", buffs[slot].spellid);
+				Shout("Cast spell %i duration %i", buffs[slot].spellid, duration);
 				SpellOnTarget(buffs[slot].spellid, this, 0, false, 0, false, -1, duration, true);
 				return;
 			}
 		}
 		else {
 			if (buffs[slot].spellid != SPELL_UNKNOWN) {
-				if (duration == 0) {
-					duration = CalcBuffDuration(this, this, spell_id);
-
-					if (duration > 0) {
-						duration = GetActSpellDuration(spell_id, duration);
-					}
-				}
 				SpellOnTarget(buffs[slot].spellid, this, 0, false, 0, false, -1, duration, true);
 			}
 		}
 	}
 }
 
-void Mob::AddBuffToTarget(Mob *spell_target, int32 spell_id, int32 duration)
+void Mob::ApplySpellBuff(int32 spell_id, int32 duration)
 {
-	if (!spell_target ||
-		!IsValidSpell(spell_id) ||
-		duration < 0 ||
-		!spells[spell_id].buff_duration) {
+	//used for quest command to apply a new buff with custom duration.
+	if (!IsValidSpell(spell_id)) {
 		return;
 	}
-
-	SpellOnTarget(spell_id, spell_target, 0, false, 0, false, -1, duration);
+	if (!spells[spell_id].buff_duration) {
+		return;
+	}
+	
+	SpellOnTarget(spell_id, this, 0, false, 0, false, -1, duration);
 }

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -10287,7 +10287,7 @@ void Mob::SetBuffDuration(int32 spell_id, int32 duration) {
 	}
 
 	if (duration < -1) {
-		duration = -1;
+		duration = PERMENANT_BUFF_DURATION;
 	}
 
 	int buff_count = GetMaxBuffSlots();
@@ -10319,5 +10319,10 @@ void Mob::ApplySpellBuff(int32 spell_id, int32 duration)
 	if (!spells[spell_id].buff_duration) {
 		return;
 	}
+	
+	if (duration < -1) {
+		duration = PERMENANT_BUFF_DURATION;
+	}
+
 	SpellOnTarget(spell_id, this, 0, false, 0, false, -1, duration);
 }

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -10268,7 +10268,12 @@ bool Mob::HasPersistDeathIllusion(int32 spell_id) {
 }
 
 void Mob::SetBuffDuration(int32 spell_id, int32 duration) {
-	Shout("Test %i %i", spell_id, duration);
+
+	/*
+		Will refresh the buff with specified spell_id to the specified duration
+		If spell is -1, then all spells will be set to the specified duration
+		If duration 0, then will set duration to buffs normal max duration.
+	*/
 
 	bool adjust_all_buffs = false;
 
@@ -10286,7 +10291,6 @@ void Mob::SetBuffDuration(int32 spell_id, int32 duration) {
 		
 		if (!adjust_all_buffs) {
 			if (buffs[slot].spellid != SPELL_UNKNOWN && buffs[slot].spellid == spell_id) {
-				Shout("Cast spell %i duration %i", buffs[slot].spellid, duration);
 				SpellOnTarget(buffs[slot].spellid, this, 0, false, 0, false, -1, duration, true);
 				return;
 			}
@@ -10301,13 +10305,15 @@ void Mob::SetBuffDuration(int32 spell_id, int32 duration) {
 
 void Mob::ApplySpellBuff(int32 spell_id, int32 duration)
 {
-	//used for quest command to apply a new buff with custom duration.
+	/*
+		Used for quest command to apply a new buff with custom duration.
+		Duration set to 0 will apply with normal duration.
+	*/
 	if (!IsValidSpell(spell_id)) {
 		return;
 	}
 	if (!spells[spell_id].buff_duration) {
 		return;
 	}
-	
 	SpellOnTarget(spell_id, this, 0, false, 0, false, -1, duration);
 }

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3301,7 +3301,7 @@ bool Mob::HasDiscBuff()
 // stacking problems, and -2 if this is not a buff
 // if caster is null, the buff will be added with the caster level being
 // the level of the mob
-int Mob::AddBuff(Mob *caster, uint16 spell_id, int duration, int32 level_override)
+int Mob::AddBuff(Mob *caster, uint16 spell_id, int duration, int32 level_override, bool disable_buff_overrwrite)
 {
 
 	int buffslot, ret, caster_level, emptyslot = -1;
@@ -3398,7 +3398,7 @@ int Mob::AddBuff(Mob *caster, uint16 spell_id, int duration, int32 level_overrid
 
 	// at this point we know that this buff will stick, but we have
 	// to remove some other buffs already worn if will_overwrite is true
-	if (will_overwrite) {
+	if (will_overwrite && !disable_buff_overrwrite) {
 		std::vector<int>::iterator cur, end;
 		cur = overwrite_slots.begin();
 		end = overwrite_slots.end();
@@ -3547,7 +3547,7 @@ int Mob::CanBuffStack(uint16 spellid, uint8 caster_level, bool iFailIfOverwrite)
 // break stuff
 //
 bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectiveness, bool use_resist_adjust, int16 resist_adjust,
-			bool isproc, int level_override, int32 duration_override)
+			bool isproc, int level_override, int32 duration_override, bool disable_buff_overrwrite)
 {
 	// well we can't cast a spell on target without a target
 	if(!spelltar)
@@ -4094,7 +4094,7 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 	}
 
 	// cause the effects to the target
-	if(!spelltar->SpellEffect(this, spell_id, spell_effectiveness, level_override, reflect_effectiveness, duration_override))
+	if(!spelltar->SpellEffect(this, spell_id, spell_effectiveness, level_override, reflect_effectiveness, duration_override, disable_buff_overrwrite))
 	{
 		// if SpellEffect returned false there's a problem applying the
 		// spell. It's most likely a buff that can't stack.

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3398,6 +3398,7 @@ int Mob::AddBuff(Mob *caster, uint16 spell_id, int duration, int32 level_overrid
 
 	// at this point we know that this buff will stick, but we have
 	// to remove some other buffs already worn if will_overwrite is true
+	Shout("willoverride %i disable override %i emptyslot %i duration %i", will_overwrite, disable_buff_overrwrite, emptyslot, duration);
 	if (will_overwrite && !disable_buff_overrwrite) {
 		std::vector<int>::iterator cur, end;
 		cur = overwrite_slots.begin();

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3209,7 +3209,6 @@ bool Mob::HasDiscBuff()
 // the level of the mob
 int Mob::AddBuff(Mob *caster, uint16 spell_id, int duration, int32 level_override, bool disable_buff_overrwrite)
 {
-	Shout("Buff duration %i", duration);
 	int buffslot, ret, caster_level, emptyslot = -1;
 	bool will_overwrite = false;
 	std::vector<int> overwrite_slots;
@@ -3304,7 +3303,6 @@ int Mob::AddBuff(Mob *caster, uint16 spell_id, int duration, int32 level_overrid
 
 	// at this point we know that this buff will stick, but we have
 	// to remove some other buffs already worn if will_overwrite is true
-	Shout("[%s] willoverride %i disable override %i emptyslot %i duration %i", spells[spell_id].name, will_overwrite, disable_buff_overrwrite, emptyslot, duration);
 	if (will_overwrite && !disable_buff_overrwrite) {
 		std::vector<int>::iterator cur, end;
 		cur = overwrite_slots.begin();

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3229,10 +3229,6 @@ int Mob::AddBuff(Mob *caster, uint16 spell_id, int duration, int32 level_overrid
 	else
 		caster_level = caster ? caster->GetCasterLevel(spell_id) : GetCasterLevel(spell_id);
 
-	if (duration < 0) {
-		duration = PERMENANT_BUFF_DURATION;
-	}
-	
 	if (duration == 0) {
 		duration = CalcBuffDuration(caster, this, spell_id);
 

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3219,7 +3219,7 @@ bool Mob::HasDiscBuff()
 // the level of the mob
 int Mob::AddBuff(Mob *caster, uint16 spell_id, int duration, int32 level_override, bool disable_buff_overrwrite)
 {
-
+	Shout("Buff duration %i", duration);
 	int buffslot, ret, caster_level, emptyslot = -1;
 	bool will_overwrite = false;
 	std::vector<int> overwrite_slots;
@@ -3229,6 +3229,10 @@ int Mob::AddBuff(Mob *caster, uint16 spell_id, int duration, int32 level_overrid
 	else
 		caster_level = caster ? caster->GetCasterLevel(spell_id) : GetCasterLevel(spell_id);
 
+	if (duration < 0) {
+		duration = PERMENANT_BUFF_DURATION;
+	}
+	
 	if (duration == 0) {
 		duration = CalcBuffDuration(caster, this, spell_id);
 
@@ -3240,7 +3244,7 @@ int Mob::AddBuff(Mob *caster, uint16 spell_id, int duration, int32 level_overrid
 		LogSpells("Buff [{}] failed to add because its duration came back as 0", spell_id);
 		return -2;	// no duration? this isn't a buff
 	}
-
+	
 	LogSpells("Trying to add buff [{}] cast by [{}] (cast level [{}]) with duration [{}]",
 		spell_id, caster?caster->GetName():"UNKNOWN", caster_level, duration);
 
@@ -3314,7 +3318,7 @@ int Mob::AddBuff(Mob *caster, uint16 spell_id, int duration, int32 level_overrid
 
 	// at this point we know that this buff will stick, but we have
 	// to remove some other buffs already worn if will_overwrite is true
-	Shout("willoverride %i disable override %i emptyslot %i duration %i", will_overwrite, disable_buff_overrwrite, emptyslot, duration);
+	Shout("[%s] willoverride %i disable override %i emptyslot %i duration %i", spells[spell_id].name, will_overwrite, disable_buff_overrwrite, emptyslot, duration);
 	if (will_overwrite && !disable_buff_overrwrite) {
 		std::vector<int>::iterator cur, end;
 		cur = overwrite_slots.begin();

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3332,9 +3332,6 @@ int Mob::AddBuff(Mob *caster, uint16 spell_id, int duration, int32 level_overrid
 		}
 	}
 
-	// now add buff at emptyslot
-	assert(buffs[emptyslot].spellid == SPELL_UNKNOWN);	// sanity check
-
 	buffs[emptyslot].spellid = spell_id;
 	buffs[emptyslot].casterlevel = caster_level;
 	if (caster && !caster->IsAura()) // maybe some other things we don't want to ...


### PR DESCRIPTION
Added quest function that allow you to alter existing buffs durations and a function that allows you to apply new buffs with custom durations. As well, new functions to obtain buff information, such as duration, from spell id or buff slot.

`$mob->SetBuffDuration(spell_id, duration)`
This function will adjust an existing buff with the defined spell id to a new buff duration.
Setting spell_id to -1 will adjust ALL buffs to that duration
Setting duration to 0, will adjust the buff to its normal max duration.
Setting duration to -1, will set the buff to be permanent duration.

` $mob->ApplySpellBuff(spell_id, duration)`
This function will add a new spell buff to the mob with a custom duration.
Setting duration to 0 or not defined, will  set the buff to its normal max duration.
Setting duration to -1, will set the buff to be permanent duration.

	
```
GetBuffStatValueBySpell(spell_id, stat_identifier)
GetBuffStatValueBySlot(slot, stat_identifier)
```
Obtain information about a buff from our internal buff struct, such as duration ("ticsremaining'), can be obtained by finding the buff by a spell id, or by finding the buff by buff slot (0=1st slot).

```
	 "caster_level"
	 "spell_id"
	 "caster_id"
	"ticsremaining" // duration
	 "counters" //cure counters
	"hit_number" //hit counter, that little box on spell buffs that tics down
	"melee_rune"
	"magic_rune"
	"dot_rune"
	"caston_x"
	"caston_y"
	"caston_z"
	"instrument_mod" //bard and base effects modifier
	"persistant_buff" // buff exists after zoning
	"client" //is on a client
	 "extra_di_chance"
	 "root_break_chance"
	 "virus_spread_time"
```