### PR TITLE
[Bug Fix] Bards casting from items with cast times with melody wasn't displaying timer.

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -6497,7 +6497,6 @@ void Mob::DoBardCastingFromItemClick(bool is_casting_bard_song, uint32 cast_time
 			CastToClient()->QueuePacket(outapp);
 			safe_delete(outapp);
 
-			SendSpellBarDisable();
 			ZeroCastingVars();
 			ZeroBardPulseVars();
 		}


### PR DESCRIPTION
Bards casting from items with cast times with melody wasn't displaying timer. Looks like I didn't need to be locking the spell bar for the casting to work. Everything seems fine for melody while clicking and regular song casting while clicking.
From https://github.com/EQEmu/Server/pull/1954)