### PR TITLE
[Quest API] Add IsTargetClient() and IsTargetNPC() to Perl/Lua.

### DIFF
--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -2478,6 +2478,17 @@ void Lua_Mob::SetBuffDuration(int spell_id, int duration) {
 	self->SetBuffDuration(spell_id, duration);
 }
 
+
+bool Lua_Mob::IsTargetClient() {
+	Lua_Safe_Call_Bool();
+	return self->IsTargetClient();
+}
+
+bool Lua_Mob::IsTargetNPC() {
+	Lua_Safe_Call_Bool();
+	return self->IsTargetNPC();
+}
+
 luabind::scope lua_register_mob() {
 	return luabind::class_<Lua_Mob, Lua_Entity>("Mob")
 	.def(luabind::constructor<>())
@@ -2788,6 +2799,8 @@ luabind::scope lua_register_mob() {
 	.def("IsStunned", (bool(Lua_Mob::*)(void))&Lua_Mob::IsStunned)
 	.def("IsTargetable", (bool(Lua_Mob::*)(void))&Lua_Mob::IsTargetable)
 	.def("IsTargeted", &Lua_Mob::IsTargeted)
+	.def("IsTargetClient", (bool(Lua_Mob::*)(void))&Lua_Mob::IsTargetClient)
+	.def("IsTargetNPC", (bool(Lua_Mob::*)(void))&Lua_Mob::IsTargetNPC)
 	.def("IsWarriorClass", &Lua_Mob::IsWarriorClass)
 	.def("Kill", (void(Lua_Mob::*)(void))&Lua_Mob::Kill)
 	.def("Mesmerize", (void(Lua_Mob::*)(void))&Lua_Mob::Mesmerize)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -166,6 +166,8 @@ public:
 	int GetSpecializeSkillValue(int spell_id);
 	int GetNPCTypeID();
 	bool IsTargeted();
+	bool IsTargetClient();
+	bool IsTargetNPC();
 	double GetX();
 	double GetY();
 	double GetZ();

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -544,6 +544,8 @@ public:
 	virtual void SetName(const char *new_name = nullptr) { new_name ? strn0cpy(name, new_name, 64) :
 		strn0cpy(name, GetName(), 64); return; };
 	inline Mob* GetTarget() const { return target; }
+	inline bool IsTargetClient() const { return target && target->IsClient(); }
+	inline bool IsTargetNPC() const { return target && target->IsNPC(); }
 	virtual void SetTarget(Mob* mob);
 	inline bool HasTargetReflection() const { return (target && target != this && target->target == this); }
 	virtual inline float GetHPRatio() const { return max_hp == 0 ? 0 : ((float) current_hp / max_hp * 100); }

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -6647,6 +6647,38 @@ XS(XS_Mob_ApplySpellBuff) {
 	XSRETURN_EMPTY;
 }
 
+XS(XS_Mob_IsTargetClient);
+XS(XS_Mob_IsTargetClient) {
+	dXSARGS;
+	if (items != 1)
+		Perl_croak(aTHX_ "Usage: Mob::IsTargetClient(THIS)"); // @categories Script Utility
+	{
+		Mob *THIS;
+		bool RETVAL;
+		VALIDATE_THIS_IS_MOB;
+		RETVAL = THIS->IsTargetClient();
+		ST(0) = boolSV(RETVAL);
+		sv_2mortal(ST(0));
+	}
+	XSRETURN(1);
+}
+
+XS(XS_Mob_IsTargetNPC);
+XS(XS_Mob_IsTargetNPC) {
+	dXSARGS;
+	if (items != 1)
+		Perl_croak(aTHX_ "Usage: Mob::IsTargetNPC(THIS)"); // @categories Script Utility
+	{
+		Mob *THIS;
+		bool RETVAL;
+		VALIDATE_THIS_IS_MOB;
+		RETVAL = THIS->IsTargetNPC();
+		ST(0) = boolSV(RETVAL);
+		sv_2mortal(ST(0));
+	}
+	XSRETURN(1);
+}
+
 #ifdef BOTS
 XS(XS_Mob_CastToBot); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Mob_CastToBot)
@@ -6959,6 +6991,8 @@ XS(boot_Mob) {
 	newXSproto(strcpy(buf, "IsStunned"), XS_Mob_IsStunned, file, "$");
 	newXSproto(strcpy(buf, "IsTargetable"), XS_Mob_IsTargetable, file, "$");
 	newXSproto(strcpy(buf, "IsTargeted"), XS_Mob_IsTargeted, file, "$");
+	newXSproto(strcpy(buf, "IsTargetClient"), XS_Mob_IsTargetClient, file, "$");
+	newXSproto(strcpy(buf, "IsTargetNPC"), XS_Mob_IsTargetNPC, file, "$");
 	newXSproto(strcpy(buf, "IsTrap"), XS_Mob_IsTrap, file, "$");
 	newXSproto(strcpy(buf, "IsWarriorClass"), XS_Mob_IsWarriorClass, file, "$");
 	newXSproto(strcpy(buf, "Kill"), XS_Mob_Kill, file, "$");


### PR DESCRIPTION
- Add $mob->IsTargetClient() to Perl.
- Add $mob->IsTargetNPC() to Perl.
- Add mob:IsTargetClient() to Lua.
- Add mob:IsTargetNPC() to Lua.
- Allows for shorthand checking of if mob's current target is client or NPC.