### PR TITLE
[Bug Fix] Fix for issue why some disciplines were randomly failing.

### DIFF
--- a/zone/aa.cpp
+++ b/zone/aa.cpp
@@ -1312,7 +1312,7 @@ void Client::ActivateAlternateAdvancementAbility(int rank_id, int target_id) {
 	else {
 		// Bards can cast instant cast AAs while they are casting or channeling item cast.
 		if (GetClass() == BARD && IsCasting() && spells[rank->spell].cast_time == 0) {
-			if (!DoCastingChecksOnCaster(rank->spell)) {
+			if (!DoCastingChecksOnCaster(rank->spell, EQ::spells::CastingSlot::AltAbility)) {
 				return;
 			}
 

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -822,21 +822,22 @@ bool Client::UseDiscipline(uint32 spell_id, uint32 target) {
 			instant_recast = false;
 
 			if (GetClass() == BARD && IsCasting() && spells[spell_id].cast_time == 0) {
-				if (DoCastingChecksOnCaster(spell_id)) {
+				if (DoCastingChecksOnCaster(spell_id, EQ::spells::CastingSlot::Discipline)) {
 					SpellFinished(spell_id, entity_list.GetMob(target), EQ::spells::CastingSlot::Discipline, 0, -1, spells[spell_id].resist_difficulty, false, -1, (uint32)DiscTimer, reduced_recast, false);
 				}
 			}
 			else {
-				CastSpell(spell_id, target, EQ::spells::CastingSlot::Discipline, -1, -1, 0, -1, (uint32)DiscTimer, reduced_recast);
+				if (!CastSpell(spell_id, target, EQ::spells::CastingSlot::Discipline, -1, -1, 0, -1, (uint32)DiscTimer, reduced_recast)) {
+					return false;
+				}
 			}
-
 			SendDisciplineTimer(spells[spell_id].timer_id, reduced_recast);
 		}
 	}
 
 	if (instant_recast) {
 		if (GetClass() == BARD && IsCasting() && spells[spell_id].cast_time == 0) {
-			if (DoCastingChecksOnCaster(spell_id)) {
+			if (DoCastingChecksOnCaster(spell_id, EQ::spells::CastingSlot::Discipline)) {
 				SpellFinished(spell_id, entity_list.GetMob(target), EQ::spells::CastingSlot::Discipline, 0, -1, spells[spell_id].resist_difficulty, false, -1, 0xFFFFFFFF, 0, false);
 			}
 		}

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -353,7 +353,7 @@ public:
 	virtual bool SpellEffect(Mob* caster, uint16 spell_id, float partial = 100, int level_override = -1, int reflect_effectiveness = 0, int32 duration_override = 0, bool disable_buff_overrwrite = false);
 	virtual bool DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_center,
 		CastAction_type &CastAction, EQ::spells::CastingSlot slot, bool isproc = false);
-	bool DoCastingChecksOnCaster(int32 spell_id);
+	bool DoCastingChecksOnCaster(int32 spell_id, EQ::spells::CastingSlot slot);
 	bool DoCastingChecksZoneRestrictions(bool check_on_casting, int32 spell_id);
 	bool DoCastingChecksOnTarget(bool check_on_casting, int32 spell_id, Mob* spell_target);
 	virtual bool CheckFizzle(uint16 spell_id);

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -179,7 +179,7 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 		return false;
 	}
 
-	if (!DoCastingChecksOnCaster(spell_id) ||
+	if (!DoCastingChecksOnCaster(spell_id, slot) ||
 		!DoCastingChecksZoneRestrictions(true, spell_id) ||
 		!DoCastingChecksOnTarget(true, spell_id, entity_list.GetMobID(target_id))) {
 		StopCastSpell(spell_id, send_spellbar_enable);
@@ -477,7 +477,7 @@ void Mob::SendBeginCast(uint16 spell_id, uint32 casttime)
 	safe_delete(outapp);
 }
 
-bool Mob::DoCastingChecksOnCaster(int32 spell_id) {
+bool Mob::DoCastingChecksOnCaster(int32 spell_id, CastingSlot slot) {
 
 	/*
 		These are casting requirements on the CASTER that will cancel a spell before spell finishes casting or prevent spell from casting.
@@ -531,7 +531,7 @@ bool Mob::DoCastingChecksOnCaster(int32 spell_id) {
 	/*
 		Linked Reused Timers that are not ready
 	*/
-	if (IsClient() && spells[spell_id].timer_id > 0 && casting_spell_slot < CastingSlot::MaxGems) {
+	if (IsClient() && spells[spell_id].timer_id > 0 && slot < CastingSlot::MaxGems) {
 		if (!CastToClient()->IsLinkedSpellReuseTimerReady(spells[spell_id].timer_id)) {
 			LogSpells("Spell casting canceled [{}] : linked reuse timer not ready.", spell_id);
 			return false;
@@ -1602,7 +1602,6 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 	{
 		DeleteChargeFromSlot = GetItemSlotToConsumeCharge(spell_id, inventory_slot);
 	}
-
 	// we're done casting, now try to apply the spell
 	if(!SpellFinished(spell_id, spell_target, slot, mana_used, inventory_slot, resist_adjust, false,-1, 0xFFFFFFFF, 0, true))
 	{
@@ -6532,7 +6531,7 @@ void Mob::DoBardCastingFromItemClick(bool is_casting_bard_song, uint32 cast_time
 		CastSpell(spell_id, target_id, CastingSlot::Item, cast_time, 0, 0, item_slot);
 	}
 	//Instant cast items do not stop bard songs or interrupt casting.
-	else if (CheckItemRaceClassDietyRestrictionsOnCast(item_slot) && DoCastingChecksOnCaster(spell_id)) {
+	else if (CheckItemRaceClassDietyRestrictionsOnCast(item_slot) && DoCastingChecksOnCaster(spell_id, CastingSlot::Item)) {
 		int16 DeleteChargeFromSlot = GetItemSlotToConsumeCharge(spell_id, item_slot);
 		if (SpellFinished(spell_id, entity_list.GetMob(target_id), CastingSlot::Item, 0, item_slot)) {
 			if (IsClient() && DeleteChargeFromSlot >= 0) {


### PR DESCRIPTION
This is from the bard update. Was trying to check casting_spell_slot before it was defined, causing some spells to fail when they shouldn't. Explains the mysterious discipline fail issues that were occurring , likely not related to the recast timer changes that I reverted in hindsight.