### PR TITLE
[GM Command] Fix Crash Issue and Validation with #zclip

### DIFF
--- a/zone/gm_commands/zclip.cpp
+++ b/zone/gm_commands/zclip.cpp
@@ -4,37 +4,42 @@ void command_zclip(Client *c, const Seperator *sep)
 {
 	int arguments = sep->argnum;
 	if (
-		!arguments ||
-		!sep->IsNumber(1) ||
-		!sep->IsNumber(2)
-	) {		
-		c->Message(Chat::White, "Usage: #zclip [Minimum Clip] [Maximum Clip] [Fog Minimum Clip] [Fog Maximum Clip] [Permanent (0 = False, 1 = True)]");
+		arguments <= 3
+		) {
+		c->Message(
+			Chat::White,
+			"Usage: #zclip [Minimum Clip] [Maximum Clip] [Fog Minimum Clip] [Fog Maximum Clip] [Permanent (0 = False, 1 = True)]"
+		);
+		return;
 	}
 
-	auto minimum_clip = std::stof(sep->arg[1]);
-	auto maximum_clip = std::stof(sep->arg[2]);
+	auto minimum_clip     = sep->arg[1] ? std::stof(sep->arg[1]) : 0;
+	auto maximum_clip     = sep->arg[2] ? std::stof(sep->arg[2]) : 0;
 	auto minimum_fog_clip = sep->arg[3] ? std::stof(sep->arg[3]) : 0;
 	auto maximum_fog_clip = sep->arg[4] ? std::stof(sep->arg[4]) : 0;
+
 	auto permanent = sep->arg[5] ? atobool(sep->arg[5]) : false;
 	if (minimum_clip <= 0 || maximum_clip <= 0) {
 		c->Message(Chat::White, "Minimum Clip and Maximum Clip must be greater than 0.");
 		return;
-	} else if (minimum_clip > maximum_clip) {
+	}
+	else if (minimum_clip > maximum_clip) {
 		c->Message(Chat::White, "Minimum Clip must be less than or equal to Maximum Clip!");
 		return;
-	} else {
+	}
+	else {
 		zone->newzone_data.minclip = minimum_clip;
 		zone->newzone_data.maxclip = maximum_clip;
 
 		if (minimum_fog_clip) {
-			for (int fog_index = 0; fog_index < 4; fog_index++) {
-				zone->newzone_data.fog_minclip[fog_index] = minimum_fog_clip;
+			for (float &fog_index: zone->newzone_data.fog_minclip) {
+				fog_index = minimum_fog_clip;
 			}
 		}
 
 		if (maximum_fog_clip) {
-			for (int fog_index = 0; fog_index < 4; fog_index++) {
-				zone->newzone_data.fog_maxclip[fog_index] = maximum_fog_clip;
+			for (float &fog_index: zone->newzone_data.fog_maxclip) {
+				fog_index = maximum_fog_clip;
 			}
 		}
 

--- a/zone/gm_commands/zclip.cpp
+++ b/zone/gm_commands/zclip.cpp
@@ -3,9 +3,7 @@
 void command_zclip(Client *c, const Seperator *sep)
 {
 	int arguments = sep->argnum;
-	if (
-		arguments <= 3
-		) {
+	if (arguments <= 3) {
 		c->Message(
 			Chat::White,
 			"Usage: #zclip [Minimum Clip] [Maximum Clip] [Fog Minimum Clip] [Fog Maximum Clip] [Permanent (0 = False, 1 = True)]"


### PR DESCRIPTION
This fixes an issue where `#zclip` crashes when ran with 0 or 2 args.

Help command should return otherwise execution falls through other logic and crashes. This also adds requirements for 4 args