### PR TITLE
[Bug Fix] Alleviate some lag with crosszone/worldwide spell casting.

### DIFF
--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -2450,7 +2450,7 @@ void Lua_Mob::SetSeeInvisibleUndeadLevel(uint8 invisible_level)
 
 void Lua_Mob::ApplySpellBuff(int spell_id) {
 	Lua_Safe_Call_Void();
-	self->ApplySpellBuff(spell_id, 0);
+	self->ApplySpellBuff(spell_id);
 }
 
 void Lua_Mob::ApplySpellBuff(int spell_id, int duration) {
@@ -2470,7 +2470,7 @@ int Lua_Mob::GetBuffStatValueBySpell(int spell_id, const char* identifier) {
 
 void Lua_Mob::SetBuffDuration(int spell_id) {
 	Lua_Safe_Call_Void();
-	self->SetBuffDuration(spell_id, 0);
+	self->SetBuffDuration(spell_id);
 }
 
 void Lua_Mob::SetBuffDuration(int spell_id, int duration) {

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -461,8 +461,8 @@ public:
 	void GetAppearenceEffects();
 	void ClearAppearenceEffects();
 	void SendSavedAppearenceEffects(Client *receiver);
-	void SetBuffDuration(int32 spell_id, int32 duration);
-	void ApplySpellBuff(int32 spell_id, int32 duration);
+	void SetBuffDuration(int32 spell_id, int32 duration = 0);
+	void ApplySpellBuff(int32 spell_id, int32 duration = 0);
 	int GetBuffStatValueBySpell(int32 spell_id, const char* stat_identifier);
 	int GetBuffStatValueBySlot(uint8 slot, const char* stat_identifier);
 

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -2608,7 +2608,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 			if (client) {
 				switch (update_subtype) {
 					case CZSpellUpdateSubtype_Cast:
-						client->SpellFinished(spell_id, client);
+						client->ApplySpellBuff(spell_id);
 						break;
 					case CZSpellUpdateSubtype_Remove:
 						client->BuffFadeBySpellID(spell_id);
@@ -2623,7 +2623,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 						auto group_member = client_group->members[member_index]->CastToClient();
 						switch (update_subtype) {
 							case CZSpellUpdateSubtype_Cast:
-								group_member->SpellFinished(spell_id, group_member);
+								group_member->ApplySpellBuff(spell_id);
 								break;
 							case CZSpellUpdateSubtype_Remove:
 								group_member->BuffFadeBySpellID(spell_id);
@@ -2640,7 +2640,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 						auto raid_member = client_raid->members[member_index].member->CastToClient();
 						switch (update_subtype) {
 							case CZSpellUpdateSubtype_Cast:
-								raid_member->SpellFinished(spell_id, raid_member);
+								raid_member->ApplySpellBuff(spell_id);
 								break;
 							case CZSpellUpdateSubtype_Remove:
 								raid_member->BuffFadeBySpellID(spell_id);
@@ -2654,7 +2654,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 				if (client.second->GuildID() > 0 && client.second->GuildID() == update_identifier) {
 					switch (update_subtype) {
 						case CZSpellUpdateSubtype_Cast:
-							client.second->SpellFinished(spell_id, client.second);
+							client.second->ApplySpellBuff(spell_id);
 							break;
 						case CZSpellUpdateSubtype_Remove:
 							client.second->BuffFadeBySpellID(spell_id);
@@ -2667,7 +2667,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 				if (client.second->GetExpedition() && client.second->GetExpedition()->GetID() == update_identifier) {
 					switch (update_subtype) {
 						case CZSpellUpdateSubtype_Cast:
-							client.second->SpellFinished(spell_id, client.second);
+							client.second->ApplySpellBuff(spell_id);
 							break;
 						case CZSpellUpdateSubtype_Remove:
 							client.second->BuffFadeBySpellID(spell_id);
@@ -2680,7 +2680,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 			if (client) {
 				switch (update_subtype) {
 					case CZSpellUpdateSubtype_Cast:
-						client->SpellFinished(spell_id, client);
+						client->ApplySpellBuff(spell_id);
 						break;
 					case CZSpellUpdateSubtype_Remove:
 						client->BuffFadeBySpellID(spell_id);
@@ -3038,7 +3038,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 		if (update_type == WWSpellUpdateType_Cast) {
 			for (auto &client : entity_list.GetClientList()) {
 				if (client.second->Admin() >= min_status && (client.second->Admin() <= max_status || max_status == AccountStatus::Player)) {
-					client.second->SpellFinished(spell_id, client.second);
+					client.second->ApplySpellBuff(spell_id);
 				}
 			}
 		} else if (update_type == WWSpellUpdateType_Remove) {


### PR DESCRIPTION
- Spell casting was using SpellFinished which casts the spell, and if the spell was a group spell each member of the group would cast it on all the other members, causing a chain reaction.
- This fix utilizes ApplySpellBuff(spell_id, duration) so that it only casts the spell on the target, as with the crosszone and worldwide methods you will be affecting your target based on identifiers regardless.
- This should alleviate some of the crosszone/worldwide casting crashes on larger servers such as Lazarus.