### PR TITLE
Rule to apply Spell Dmg and Heal Amount stats as a percentage instead of flat value.

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -396,7 +396,7 @@ RULE_BOOL(Spells, UseAdditiveFocusFromWornSlot, false, "Allows an additive focus
 RULE_BOOL(Spells, AlwaysSendTargetsBuffs, false, "Ignore Leadership Alternate Abilities level if true")
 RULE_BOOL(Spells, FlatItemExtraSpellAmt, false, "Allow SpellDmg stat to affect all spells, regardless of cast time/cooldown/etc")
 RULE_BOOL(Spells, IgnoreSpellDmgLvlRestriction, false, "Ignore the 5 level spread on applying SpellDmg")
-RULE_BOOL(Spells, PctSpellMod, false, "Apply Spell Dmg and Heal Amount as Percentage-based modifiers flat additions")
+RULE_BOOL(Spells, ItemExtraSpellAmtCalcAsPercent, false, "Apply the Item stats Spell Dmg and Heal Amount as Percentage-based modifiers instead of flat additions")
 RULE_BOOL(Spells, AllowItemTGB, false, "Target group buff (/tgb) doesn't work with items on live, custom servers want it though")
 RULE_BOOL(Spells, NPCInnateProcOverride, true, "NPC innate procs override the target type to single target")
 RULE_BOOL(Spells, OldRainTargets, false, "Use old incorrectly implemented maximum targets for rains")

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -396,6 +396,7 @@ RULE_BOOL(Spells, UseAdditiveFocusFromWornSlot, false, "Allows an additive focus
 RULE_BOOL(Spells, AlwaysSendTargetsBuffs, false, "Ignore Leadership Alternate Abilities level if true")
 RULE_BOOL(Spells, FlatItemExtraSpellAmt, false, "Allow SpellDmg stat to affect all spells, regardless of cast time/cooldown/etc")
 RULE_BOOL(Spells, IgnoreSpellDmgLvlRestriction, false, "Ignore the 5 level spread on applying SpellDmg")
+RULE_BOOL(Spells, PctSpellMod, false, "Apply Spell Dmg and Heal Amount as Percentage-based modifiers flat additions")
 RULE_BOOL(Spells, AllowItemTGB, false, "Target group buff (/tgb) doesn't work with items on live, custom servers want it though")
 RULE_BOOL(Spells, NPCInnateProcOverride, true, "NPC innate procs override the target type to single target")
 RULE_BOOL(Spells, OldRainTargets, false, "Use old incorrectly implemented maximum targets for rains")

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -284,8 +284,12 @@ int32 Mob::GetActDoTDamage(uint16 spell_id, int32 value, Mob* target) {
 
 int32 Mob::GetExtraSpellAmt(uint16 spell_id, int32 extra_spell_amt, int32 base_spell_dmg)
 {
-	if (RuleB(Spells, FlatItemExtraSpellAmt))
-		return extra_spell_amt;
+	if (RuleB(Spells, FlatItemExtraSpellAmt)) {
+		if (RuleB(Spells, PctSpellMod))
+			return abs(base_spell_dmg)*extra_spell_amt/100;
+		else
+			return extra_spell_amt;
+	}
 
 	int total_cast_time = 0;
 

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -285,7 +285,7 @@ int32 Mob::GetActDoTDamage(uint16 spell_id, int32 value, Mob* target) {
 int32 Mob::GetExtraSpellAmt(uint16 spell_id, int32 extra_spell_amt, int32 base_spell_dmg)
 {
 	if (RuleB(Spells, FlatItemExtraSpellAmt)) {
-		if (RuleB(Spells, PctSpellMod))
+		if (RuleB(Spells, ItemExtraSpellAmtCalcAsPercent))
 			return abs(base_spell_dmg)*extra_spell_amt/100;
 		else
 			return extra_spell_amt;
@@ -310,7 +310,7 @@ int32 Mob::GetExtraSpellAmt(uint16 spell_id, int32 extra_spell_amt, int32 base_s
 		extra_spell_amt = abs(base_spell_dmg) / 2;
 	}
 
-	if (RuleB(Spells, PctSpellMod))
+	if (RuleB(Spells, ItemExtraSpellAmtCalcAsPercent))
                 return abs(base_spell_dmg)*extra_spell_amt/100;
 
 	return extra_spell_amt;

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -306,6 +306,9 @@ int32 Mob::GetExtraSpellAmt(uint16 spell_id, int32 extra_spell_amt, int32 base_s
 		extra_spell_amt = abs(base_spell_dmg) / 2;
 	}
 
+	if (RuleB(Spells, PctSpellMod))
+                return abs(base_spell_dmg)*extra_spell_amt/100;
+
 	return extra_spell_amt;
 }
 


### PR DESCRIPTION
Rule to apply Spell Dmg and Heal Amount stats as a percentage instead of flat value.

This was useful for my server. Each point of these stats is reflected as a 1% increase in spell effectiveness, subject to the 5-level spread and recalculation around casting time, etc (unless the rules to disable those are in effect).