### PR TITLE
[Spells] SPA 79 SE_CurrentHPOnce now will check for focus, critical and partial resist checks, except for buffs.

### DIFF
--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -347,10 +347,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 						}
 					}
 					else if (dmg > 0) {
-						if (caster) {
-							dmg = caster->GetActSpellHealing(spell_id, dmg, this);
-						}
-
+						//unable to confirm behavior of focus/critical on heals, you can not critical on spells with buffs. (~Kayen 2-22)
 						HealDamage(dmg, caster);
 					}
 				}

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -324,8 +324,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				}
 				//normal effects
 				else {
-					if (dmg < 0)
-					{
+					if (dmg < 0){
 						dmg = (int32)(dmg * partial / 100);
 
 						if (caster) {
@@ -347,7 +346,10 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 						}
 					}
 					else if (dmg > 0) {
-						//unable to confirm behavior of focus/critical on heals, you can not critical on spells with buffs. (~Kayen 2-22)
+						//do not apply focus/critical to buff spells
+						if (caster && !IsEffectInSpell(spell_id, SE_TotalHP)) {
+							dmg = caster->GetActSpellHealing(spell_id, dmg, this);
+						}
 						HealDamage(dmg, caster);
 					}
 				}


### PR DESCRIPTION
Implemented missing mechanic for SPA 79 SE_CurrentHPOnce so it will now appropriately apply focus/critical and partial resists. Currently we do not try to apply any of that.

Was able to confirm on live for healing using SPA 79 as long as it is NOT in a buff spell (defined as using SPA 69), then it can critical and be focused.

Was able to confirm on live for damage using SPA 79 is can critical and can be partially resisted. Was unable to test focus because just about every live focus for damage specifically limits the focus to only apply to SPA 0, however by that logic then if you removed that limitation it should apply to SPA 79, and further it does apply to healing, and it applies all other behaviors of regular damage. So it is reasonable to conclude it can be focused.
