### PR TITLE
[Bots] Apply Spells:IgnoreSpellDmgLvlRestriction to bots

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -6735,9 +6735,7 @@ int32 Bot::GetActSpellDamage(uint16 spell_id, int32 value, Mob* target) {
 			value -= GetBotFocusEffect(focusFcDamageAmt, spell_id);
 			value -= GetBotFocusEffect(focusFcDamageAmt2, spell_id);
 			
-			if (RuleB(Spells, IgnoreSpellDmgLvlRestriction) && itembonuses.SpellDmg)
-				value += (GetExtraSpellAmt(spell_id, itembonuses.SpellDmg, value) * ratio / 100);
-			else if (itembonuses.SpellDmg && spells[spell_id].classes[(GetClass() % 17) - 1] >= GetLevel() - 5)
+			if ((RuleB(Spells, IgnoreSpellDmgLvlRestriction) || spells[spell_id].classes[(GetClass() % 17) - 1] >= GetLevel() - 5) && itembonuses.SpellDmg)
 				value += (GetExtraSpellAmt(spell_id, itembonuses.SpellDmg, value) * ratio / 100);
 
 			entity_list.MessageClose(this, false, 100, Chat::SpellCrit, "%s delivers a critical blast! (%d)", GetName(), -value);
@@ -6759,9 +6757,7 @@ int32 Bot::GetActSpellDamage(uint16 spell_id, int32 value, Mob* target) {
 	value -= GetBotFocusEffect(focusFcDamageAmt, spell_id);
 	value -= GetBotFocusEffect(focusFcDamageAmt2, spell_id);
 	
-	if (RuleB(Spells, IgnoreSpellDmgLvlRestriction)&& itembonuses.SpellDmg)
-		value += GetExtraSpellAmt(spell_id, itembonuses.SpellDmg, value);
-	else if(itembonuses.SpellDmg && spells[spell_id].classes[(GetClass() % 17) - 1] >= GetLevel() - 5)
+	if ((RuleB(Spells, IgnoreSpellDmgLvlRestriction) || spells[spell_id].classes[(GetClass() % 17) - 1] >= GetLevel() - 5) && itembonuses.SpellDmg)
 		value += GetExtraSpellAmt(spell_id, itembonuses.SpellDmg, value);
 
 	return value;
@@ -6795,13 +6791,8 @@ int32 Bot::GetActSpellHealing(uint16 spell_id, int32 value, Mob* target) {
 		value += target->GetFocusIncoming(focusFcHealAmtIncoming, SE_FcHealAmtIncoming, this, spell_id);
 		
 		//Using IgnoreSpellDmgLvlRestriction
-		if (RuleB(Spells, IgnoreSpellDmgLvlRestriction) && itembonuses.HealAmt) {
+		if ((RuleB(Spells, IgnoreSpellDmgLvlRestriction) || spells[spell_id].classes[(GetClass() % 17) - 1] >= GetLevel() - 5) && itembonuses.HealAmt)
 			value += (GetExtraSpellAmt(spell_id, itembonuses.HealAmt, value) * modifier);
-		}
-		else if (itembonuses.HealAmt && spells[spell_id].classes[(GetClass() % 17) - 1] >= GetLevel() - 5) {
-			value += (GetExtraSpellAmt(spell_id, itembonuses.HealAmt, value) * modifier);
-		}
-
 		value += (value * target->GetHealRate() / 100);
 		if (Critical)
 			entity_list.MessageClose(this, false, 100, Chat::SpellCrit, "%s performs an exceptional heal! (%d)", GetName(), value);
@@ -6811,12 +6802,8 @@ int32 Bot::GetActSpellHealing(uint16 spell_id, int32 value, Mob* target) {
 		int32 extra_heal = 0;
 		//Using IgnoreSpellDmgLvlRestriction to also allow healing to scale
 		if (RuleB(Spells, HOTsScaleWithHealAmt)) {
-			if (RuleB(Spells, IgnoreSpellDmgLvlRestriction) && !spells[spell_id].no_heal_damage_item_mod && itembonuses.HealAmt) {
-				extra_heal += GetExtraSpellAmt(spell_id, itembonuses.HealAmt, value);
-			}
-			else if(!spells[spell_id].no_heal_damage_item_mod && itembonuses.HealAmt && spells[spell_id].classes[(GetClass() % 17) - 1] >= GetLevel() - 5) {
-				extra_heal += GetExtraSpellAmt(spell_id, itembonuses.HealAmt, value);
-			}
+			if ((RuleB(Spells, IgnoreSpellDmgLvlRestriction) || spells[spell_id].classes[(GetClass() % 17) - 1] >= GetLevel() - 5) && itembonuses.HealAmt)
+				extra_heal += GetExtraSpellAmt(spell_id, itembonuses.HealAmt, value);			
 		}
 		
 		if (extra_heal) {

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -6734,8 +6734,10 @@ int32 Bot::GetActSpellDamage(uint16 spell_id, int32 value, Mob* target) {
 
 			value -= GetBotFocusEffect(focusFcDamageAmt, spell_id);
 			value -= GetBotFocusEffect(focusFcDamageAmt2, spell_id);
-
-			if(itembonuses.SpellDmg && spells[spell_id].classes[(GetClass() % 17) - 1] >= GetLevel() - 5)
+			
+			if (RuleB(Spells, IgnoreSpellDmgLvlRestriction) && itembonuses.SpellDmg)
+				value += (GetExtraSpellAmt(spell_id, itembonuses.SpellDmg, value) * ratio / 100);
+			else if (itembonuses.SpellDmg && spells[spell_id].classes[(GetClass() % 17) - 1] >= GetLevel() - 5)
 				value += (GetExtraSpellAmt(spell_id, itembonuses.SpellDmg, value) * ratio / 100);
 
 			entity_list.MessageClose(this, false, 100, Chat::SpellCrit, "%s delivers a critical blast! (%d)", GetName(), -value);
@@ -6756,7 +6758,10 @@ int32 Bot::GetActSpellDamage(uint16 spell_id, int32 value, Mob* target) {
 	value -= GetBotFocusEffect(focusFcDamageAmtCrit, spell_id);
 	value -= GetBotFocusEffect(focusFcDamageAmt, spell_id);
 	value -= GetBotFocusEffect(focusFcDamageAmt2, spell_id);
-	if(itembonuses.SpellDmg && spells[spell_id].classes[(GetClass() % 17) - 1] >= GetLevel() - 5)
+	
+	if (RuleB(Spells, IgnoreSpellDmgLvlRestriction)&& itembonuses.SpellDmg)
+		value += GetExtraSpellAmt(spell_id, itembonuses.SpellDmg, value);
+	else if(itembonuses.SpellDmg && spells[spell_id].classes[(GetClass() % 17) - 1] >= GetLevel() - 5)
 		value += GetExtraSpellAmt(spell_id, itembonuses.SpellDmg, value);
 
 	return value;
@@ -6788,16 +6793,40 @@ int32 Bot::GetActSpellHealing(uint16 spell_id, int32 value, Mob* target) {
 		value += (GetBotFocusEffect(focusFcHealAmtCrit, spell_id) * modifier);
 		value += GetBotFocusEffect(focusFcHealAmt, spell_id);
 		value += target->GetFocusIncoming(focusFcHealAmtIncoming, SE_FcHealAmtIncoming, this, spell_id);
-
-		if(itembonuses.HealAmt && spells[spell_id].classes[(GetClass() % 17) - 1] >= GetLevel() - 5)
+		
+		//Using IgnoreSpellDmgLvlRestriction
+		if (RuleB(Spells, IgnoreSpellDmgLvlRestriction) && itembonuses.HealAmt) {
 			value += (GetExtraSpellAmt(spell_id, itembonuses.HealAmt, value) * modifier);
+		}
+		else if (itembonuses.HealAmt && spells[spell_id].classes[(GetClass() % 17) - 1] >= GetLevel() - 5) {
+			value += (GetExtraSpellAmt(spell_id, itembonuses.HealAmt, value) * modifier);
+		}
 
 		value += (value * target->GetHealRate() / 100);
 		if (Critical)
 			entity_list.MessageClose(this, false, 100, Chat::SpellCrit, "%s performs an exceptional heal! (%d)", GetName(), value);
 
 		return value;
-	} else {
+	} else {		
+		int32 extra_heal = 0;
+		//Using IgnoreSpellDmgLvlRestriction to also allow healing to scale
+		if (RuleB(Spells, HOTsScaleWithHealAmt)) {
+			if (RuleB(Spells, IgnoreSpellDmgLvlRestriction) && !spells[spell_id].no_heal_damage_item_mod && itembonuses.HealAmt) {
+				extra_heal += GetExtraSpellAmt(spell_id, itembonuses.HealAmt, value);
+			}
+			else if(!spells[spell_id].no_heal_damage_item_mod && itembonuses.HealAmt && spells[spell_id].classes[(GetClass() % 17) - 1] >= GetLevel() - 5) {
+				extra_heal += GetExtraSpellAmt(spell_id, itembonuses.HealAmt, value);
+			}
+		}
+		
+		if (extra_heal) {
+			int duration = CalcBuffDuration(this, target, spell_id);
+			if (duration > 0) {
+				extra_heal /= duration;
+				value += extra_heal;
+			}
+		}
+		
 		chance = (itembonuses.CriticalHealOverTime + spellbonuses.CriticalHealOverTime + aabonuses.CriticalHealOverTime);
 		chance += target->GetFocusIncoming(focusFcHealPctCritIncoming, SE_FcHealPctCritIncoming, this, spell_id);
 		if (spellbonuses.CriticalRegenDecay)


### PR DESCRIPTION
Bots use a different method to calculate final spell damage and healing amounts, for which the version for players and bots are out of sync in several ways. This corrects one difference.