### PR TITLE
[Bug Fix] Bandolier didn't recognize source weapon on cursor

### DIFF
--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -3332,8 +3332,7 @@ void Client::SetBandolier(const EQApplicationPacket *app)
 			// removed 'invWhereCursor' argument from above and implemented slots 30, 331-340 checks here
 			if (slot == INVALID_INDEX) {
 				if (m_inv.GetItem(EQ::invslot::slotCursor)) {
-					if (m_inv.GetItem(EQ::invslot::slotCursor)->GetItem()->ID == m_pp.bandoliers[bss->Number].Items[BandolierSlot].ID &&
-						m_inv.GetItem(EQ::invslot::slotCursor)->GetCharges() >= 1) { // '> 0' the same, but this matches Inventory::_HasItem conditional check
+					if (m_inv.GetItem(EQ::invslot::slotCursor)->GetItem()->ID == m_pp.bandoliers[bss->Number].Items[BandolierSlot].ID) {
 						slot = EQ::invslot::slotCursor;
 					}
 					else if (m_inv.GetItem(EQ::invslot::slotCursor)->GetItem()->ItemClass == 1) {

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -3332,6 +3332,10 @@ void Client::SetBandolier(const EQApplicationPacket *app)
 			// removed 'invWhereCursor' argument from above and implemented slots 30, 331-340 checks here
 			if (slot == INVALID_INDEX) {
 				if (m_inv.GetItem(EQ::invslot::slotCursor)) {
+					// Below used to check charges but for some reason
+					// m_inv.GetItem(EQ::invslot::slotCursor)->GetCharges()
+					// is returning 0.  We know it exists, so removed check.
+					// TODO: Why is 0 being returned for slotCursor.
 					if (m_inv.GetItem(EQ::invslot::slotCursor)->GetItem()->ID == m_pp.bandoliers[bss->Number].Items[BandolierSlot].ID) {
 						slot = EQ::invslot::slotCursor;
 					}


### PR DESCRIPTION
If you activated a bandolier set and one of the source weapons was on your cursor, the code didn't see it.

For whatever reason, m_inv.GetItem(EQ::invslot::slotCursor)->GetCharges() was returning 0 when the source weapon was on the cursor, bypassing the code that was written to handle this case.