### PR TITLE
[AI] Spell Type (1024) InCombatBuff were spam casting

### DIFF
--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -195,10 +195,11 @@ bool NPC::AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes, bool bInnates
 					}
 
 					case SpellType_InCombatBuff: {
-						if(bInnates || zone->random.Roll(50))
-						{
-							AIDoSpellCast(i, tar, mana_cost);
-							return true;
+						if(bInnates || zone->random.Roll(50)) {
+							if (tar->CanBuffStack(AIspells[i].spellid, GetLevel(), true) >= 0) {
+								AIDoSpellCast(i, tar, mana_cost);
+								return true;
+							}
 						}
 						break;
 					}


### PR DESCRIPTION
The AI code for spell casting (engaged):

- two forms of innate/priority0 spells
- in combat buffs
- heals/bene
- everything else

The first spell to get a sucess roll wins for that trip through the loop.

InCombatBuffs is 50% per spell to be chosen.  Hopwever, the code did not have a CanStack check.  So mobs with a spell list that included InCombatBuffs is severely compromised due to one spell getting cast over and over, on top if itself, 50% of the loops through if the spell list has no innates/priority0 spells.

Added a simple CanStack check and these mobs behave much better.

(Also changed the brace style to match the surrounding code)