### PR TITLE
[Command] Fix #killallnpcs from crashing

### DIFF
--- a/zone/gm_commands/killallnpcs.cpp
+++ b/zone/gm_commands/killallnpcs.cpp
@@ -8,31 +8,22 @@ void command_killallnpcs(Client *c, const Seperator *sep)
 	}
 
 	int killed_count = 0;
-	for (auto& npc_entity : entity_list.GetNPCList()) {
-		auto entity_id = npc_entity.first;
-		if (!entity_id) {
+
+	for (auto &e: entity_list.GetMobList()) {
+		auto *entity = e.second;
+		if (!entity || !entity->IsNPC()) {
 			continue;
 		}
 
-		auto npc = npc_entity.second;
-		if (!npc) {
-			continue;
-		}
-		
-		std::string entity_name = str_tolower(npc->GetName());
-		if (
-			(
-				!search_string.empty() &&
-				entity_name.find(search_string) == std::string::npos
-			) ||
-			!npc->IsAttackAllowed(c)
-		) {
+		std::string entity_name = str_tolower(entity->GetName());
+		if ((!search_string.empty() && entity_name.find(search_string) == std::string::npos) ||
+			!entity->IsAttackAllowed(c)) {
 			continue;
 		}
 
-		npc->Damage(
+		entity->Damage(
 			c,
-			npc->GetHP(),
+			entity->GetHP() + 1000,
 			SPELL_UNKNOWN,
 			EQ::skills::SkillDragonPunch
 		);
@@ -49,26 +40,27 @@ void command_killallnpcs(Client *c, const Seperator *sep)
 				killed_count != 1 ? "s" : "",
 				(
 					!search_string.empty() ?
-					fmt::format(
-						" that matched '{}'",
-						search_string
-					) :
-					""
+						fmt::format(
+							" that matched '{}'",
+							search_string
+						) :
+						""
 				)
 			).c_str()
 		);
-	} else {
+	}
+	else {
 		c->Message(
 			Chat::White,
 			fmt::format(
 				"There were no NPCs to kill{}.",
 				(
 					!search_string.empty() ?
-					fmt::format(
-						" that matched '{}'",
-						search_string
-					) :
-					""
+						fmt::format(
+							" that matched '{}'",
+							search_string
+						) :
+						""
 				)
 			).c_str()
 		);


### PR DESCRIPTION
This is another command that was crashing from recent cleanups.

Using NPC List is not great for this because it has book keeping issues, I moved it back to using MobList. Using the NPC list was causing crashes in it of itself. It's not a good idea to be iterating over a list that is being manipulated (entries being removed) so in this case using a copy of the mob list works better.

```
[03-06-2022 :: 20:19:43] [Zone] [Crash] Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
[03-06-2022 :: 20:19:43] [Zone] [Crash] 0x00007f472aeae0ca in __waitpid (pid=26569, stat_loc=stat_loc@entry=0x0, options=options@entry=0) at ../sysdeps/unix/sysv/linux/waitpid.c:30
[03-06-2022 :: 20:19:43] [Zone] [Crash] [Current thread is 1 (Thread 0x7f472a1d3140 (LWP 25943))]
[03-06-2022 :: 20:19:43] [Zone] [Crash] #0  0x00007f472aeae0ca in __waitpid (pid=26569, stat_loc=stat_loc@entry=0x0, options=options@entry=0) at ../sysdeps/unix/sysv/linux/waitpid.c:30
[03-06-2022 :: 20:19:43] [Zone] [Crash] #1  0x0000563206c0470e in print_trace () at ../common/crash.cpp:154
[03-06-2022 :: 20:19:43] [Zone] [Crash] #2  <signal handler called>
[03-06-2022 :: 20:19:43] [Zone] [Crash] #3  0x0000563206bb1bcf in command_killallnpcs (c=0x5632093527c0, sep=<optimized out>) at /usr/include/c++/8/bits/hashtable_policy.h:389
```