### PR TITLE
[API] GetNPCStat can now return default stat values.

### DIFF
--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -2784,9 +2784,6 @@ float NPC::GetNPCStat(const char *identifier)
 	else if (id == "default_attack_delay") {
 		return default_attack_delay;
 	}
-	else if (id == "default_attack_delay") {
-		return default_attack_delay;
-	}
 	else if (id == "default_accuracy_rating") {
 		return default_accuracy_rating;
 	}

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -2771,6 +2771,31 @@ float NPC::GetNPCStat(const char *identifier)
 	else if (id == "npc_spells_effects_id") {
 		return npc_spells_effects_id;
 	}
+	//default values
+	else if (id == "default_ac") {
+		return default_ac;
+	}
+	else if (id == "default_min_dmg") {
+		return default_min_dmg;
+	}
+	else if (id == "default_max_dmg") {
+		return default_max_dmg;
+	}
+	else if (id == "default_attack_delay") {
+		return default_attack_delay;
+	}
+	else if (id == "default_attack_delay") {
+		return default_attack_delay;
+	}
+	else if (id == "default_accuracy_rating") {
+		return default_accuracy_rating;
+	}
+	else if (id == "default_avoidance_rating") {
+		return default_avoidance_rating;
+	}
+	else if (id == "default_atk") {
+		return default_atk;
+	}
 }
 
 void NPC::LevelScale() {


### PR DESCRIPTION
For $npc->GetNPCStat(identified)
Useful for scripts that use scaling.
```
	"default_ac"
	"default_min_dmg"
	"default_max_dmg"
	"default_attack_delay"
	"default_accuracy_rating"
	"default_avoidance_rating"
	"default_atk"
```