### PR TITLE
[Quest API] Add caster_id and caster_level export to EVENT_CAST_ON in Perl/Lua.

### DIFF
--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -1450,7 +1450,10 @@ void PerlembParser::ExportEventVariables(
 		case EVENT_CAST_ON:
 		case EVENT_CAST:
 		case EVENT_CAST_BEGIN: {
-			ExportVar(package_name.c_str(), "spell_id", data);
+			Seperator sep(data);
+			ExportVar(package_name.c_str(), "spell_id", sep.arg[0]);
+			ExportVar(package_name.c_str(), "caster_id", sep.arg[1]);
+			ExportVar(package_name.c_str(), "caster_level", sep.arg[2]);
 			break;
 		}
 

--- a/zone/lua_parser_events.cpp
+++ b/zone/lua_parser_events.cpp
@@ -376,7 +376,9 @@ void handle_player_pick_up(QuestInterface *parse, lua_State* L, Client* client, 
 
 void handle_player_cast(QuestInterface *parse, lua_State* L, Client* client, std::string data, uint32 extra_data,
 						std::vector<EQ::Any> *extra_pointers) {
-	int spell_id = std::stoi(data);
+	Seperator sep(data.c_str());
+
+	int spell_id = std::stoi(sep.arg[0]);
 	if(IsValidSpell(spell_id)) {
 		Lua_Spell l_spell(&spells[spell_id]);
 		luabind::adl::object l_spell_o = luabind::adl::object(L, l_spell);
@@ -388,6 +390,12 @@ void handle_player_cast(QuestInterface *parse, lua_State* L, Client* client, std
 	}
 
 	lua_setfield(L, -2, "spell");
+	
+	lua_pushinteger(L, std::stoi(sep.arg[1]));
+	lua_setfield(L, -2, "caster_id");
+	
+	lua_pushinteger(L, std::stoi(sep.arg[2]));
+	lua_setfield(L, -2, "caster_level");
 }
 
 void handle_player_task_fail(QuestInterface *parse, lua_State* L, Client* client, std::string data, uint32 extra_data,

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3589,8 +3589,13 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 	);
 
 	/* Send the EVENT_CAST_ON event */
-	std::string export_string = fmt::format("{}", spell_id);
-	if(spelltar->IsNPC()) {
+	std::string export_string = fmt::format(
+		"{} {} {}",
+		spell_id,
+		GetID(),
+		caster_level
+	);
+	if (spelltar->IsNPC()) {
 		parse->EventNPC(EVENT_CAST_ON, spelltar->CastToNPC(), this, export_string, 0);
 	} else if (spelltar->IsClient()) {
 		parse->EventPlayer(EVENT_CAST_ON, spelltar->CastToClient(), export_string, 0);


### PR DESCRIPTION
- Add $caster_id and $caster_level to EVENT_CAST_ON in Perl.
- Add e.caster_id and e.caster_level to EVENT_CAST_ON in Lua.