### PR TITLE
[Quest API] Export killed XYZH to EVENT_DEATH_ZONE in Perl.

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2285,8 +2285,14 @@ bool NPC::Death(Mob* killer_mob, int32 damage, uint16 spell, EQ::skills::SkillTy
 	Mob *oos = nullptr;
 	if (killer_mob) {
 		oos = killer_mob->GetOwnerOrSelf();
-		std::string buffer = fmt::format("{} {} {} {}", killer_mob->GetID(), damage, spell, static_cast<int>(attack_skill));
-		if (parse->EventNPC(EVENT_DEATH, this, oos, buffer.c_str(), 0) != 0) {
+		std::string export_string = fmt::format(
+			"{} {} {} {}",
+			killer_mob->GetID(),
+			damage,
+			spell,
+			static_cast<int>(attack_skill)
+		);
+		if (parse->EventNPC(EVENT_DEATH, this, oos, export_string, 0) != 0) {
 			if (GetHP() < 0) {
 				SetHP(0);
 			}
@@ -2309,8 +2315,14 @@ bool NPC::Death(Mob* killer_mob, int32 damage, uint16 spell, EQ::skills::SkillTy
 		}
 	}
 	else {
-		std::string buffer = fmt::format("{} {} {} {}", 0, damage, spell, static_cast<int>(attack_skill));
-		if (parse->EventNPC(EVENT_DEATH, this, nullptr, buffer.c_str(), 0) != 0) {
+		std::string export_string = fmt::format(
+			"{} {} {} {}",
+			0,
+			damage,
+			spell,
+			static_cast<int>(attack_skill)
+		);
+		if (parse->EventNPC(EVENT_DEATH, this, nullptr, export_string, 0) != 0) {
 			if (GetHP() < 0) {
 				SetHP(0);
 			}
@@ -2704,15 +2716,32 @@ bool NPC::Death(Mob* killer_mob, int32 damage, uint16 spell, EQ::skills::SkillTy
 
 	entity_list.UpdateFindableNPCState(this, true);
 
-	std::string buffer = fmt::format("{} {} {} {}", killer_mob ? killer_mob->GetID() : 0, damage, spell, static_cast<int>(attack_skill));
-	parse->EventNPC(EVENT_DEATH_COMPLETE, this, oos, buffer.c_str(), 0);
+	std::string export_string = fmt::format(
+		"{} {} {} {}",
+		killer_mob ? killer_mob->GetID() : 0,
+		damage,
+		spell,
+		static_cast<int>(attack_skill)
+	);
+	parse->EventNPC(EVENT_DEATH_COMPLETE, this, oos, export_string, 0);
 
 	/* Zone controller process EVENT_DEATH_ZONE (Death events) */
 	if (RuleB(Zone, UseZoneController)) {
 		auto controller = entity_list.GetNPCByNPCTypeID(ZONE_CONTROLLER_NPC_ID);
 		if (controller && GetNPCTypeID() != ZONE_CONTROLLER_NPC_ID) {
-			std::string data_pass = fmt::format("{} {} {} {} {}", killer_mob ? killer_mob->GetID() : 0, damage, spell, static_cast<int>(attack_skill), GetNPCTypeID());
-			parse->EventNPC(EVENT_DEATH_ZONE, controller, nullptr, data_pass.c_str(), 0);
+			export_string = fmt::format(
+				"{} {} {} {} {} {:.2f} {:.2f} {:.2f} {:.2f}",
+				killer_mob ? killer_mob->GetID() : 0,
+				damage,
+				spell,
+				static_cast<int>(attack_skill),
+				GetNPCTypeID(),
+				GetX(),
+				GetY(),
+				GetZ(),
+				GetHeading()
+			);
+			parse->EventNPC(EVENT_DEATH_ZONE, controller, nullptr, export_string, 0);
 		}
 	}
 

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -1636,6 +1636,10 @@ void PerlembParser::ExportEventVariables(
 			ExportVar(package_name.c_str(), "killer_spell", sep.arg[2]);
 			ExportVar(package_name.c_str(), "killer_skill", sep.arg[3]);
 			ExportVar(package_name.c_str(), "killed_npc_id", sep.arg[4]);
+			ExportVar(package_name.c_str(), "killed_x", sep.arg[5]);
+			ExportVar(package_name.c_str(), "killed_y", sep.arg[6]);
+			ExportVar(package_name.c_str(), "killed_z", sep.arg[7]);
+			ExportVar(package_name.c_str(), "killed_h", sep.arg[8]);
 			break;
 		}
 		case EVENT_USE_SKILL: {

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -733,8 +733,12 @@ void EntityList::AddNPC(NPC *npc, bool SendSpawnPacket, bool dontqueue)
 	if (RuleB(Zone, UseZoneController)) {
 		auto controller = entity_list.GetNPCByNPCTypeID(ZONE_CONTROLLER_NPC_ID);
 		if (controller && npc->GetNPCTypeID() != ZONE_CONTROLLER_NPC_ID){
-			std::string data_pass = fmt::format("{} {}", npc->GetID(), npc->GetNPCTypeID());
-			parse->EventNPC(EVENT_SPAWN_ZONE, controller, nullptr, data_pass.c_str(), 0);
+			std::string export_string = fmt::format(
+				"{} {}",
+				npc->GetID(),
+				npc->GetNPCTypeID()
+			);
+			parse->EventNPC(EVENT_SPAWN_ZONE, controller, nullptr, export_string, 0);
 		}
 	}
 

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1426,9 +1426,9 @@ void Mob::CreateHPPacket(EQApplicationPacket* app)
 	{
 		if (ds->hp < GetNextHPEvent())
 		{
-			std::string buf = fmt::format("{}", GetNextHPEvent());
+			std::string export_string = fmt::format("{}", GetNextHPEvent());
 			SetNextHPEvent(-1);
-			parse->EventNPC(EVENT_HP, CastToNPC(), nullptr, buf.c_str(), 0);
+			parse->EventNPC(EVENT_HP, CastToNPC(), nullptr, export_string, 0);
 		}
 	}
 
@@ -1436,9 +1436,9 @@ void Mob::CreateHPPacket(EQApplicationPacket* app)
 	{
 		if (ds->hp > GetNextIncHPEvent())
 		{
-			std::string buf = fmt::format("{}", GetNextIncHPEvent());
+			std::string export_string = fmt::format("{}", GetNextIncHPEvent());
 			SetNextIncHPEvent(-1);
-			parse->EventNPC(EVENT_HP, CastToNPC(), nullptr, buf.c_str(), 1);
+			parse->EventNPC(EVENT_HP, CastToNPC(), nullptr, export_string, 1);
 		}
 	}
 }

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -1782,8 +1782,8 @@ void NPC::AI_DoMovement() {
 					}
 
 					//kick off event_waypoint arrive
-					std::string buf = fmt::format("{}", cur_wp);
-					parse->EventNPC(EVENT_WAYPOINT_ARRIVE, CastToNPC(), nullptr, buf.c_str(), 0);
+					std::string export_string = fmt::format("{}", cur_wp);
+					parse->EventNPC(EVENT_WAYPOINT_ARRIVE, CastToNPC(), nullptr, export_string, 0);
 					// No need to move as we are there.  Next loop will
 					// take care of normal grids, even at pause 0.
 					// We do need to call and setup a wp if we're cur_wp=-2
@@ -1900,8 +1900,8 @@ void NPC::AI_SetupNextWaypoint() {
 
 		if (!DistractedFromGrid) {
 			//kick off event_waypoint depart
-			std::string buf = fmt::format("{}", cur_wp);
-			parse->EventNPC(EVENT_WAYPOINT_DEPART, CastToNPC(), nullptr, buf.c_str(), 0);
+			std::string export_string = fmt::format("{}", cur_wp);
+			parse->EventNPC(EVENT_WAYPOINT_DEPART, CastToNPC(), nullptr, export_string, 0);
 
 			//setup our next waypoint, if we are still on our normal grid
 			//remember that the quest event above could have done anything it wanted with our grid
@@ -2484,8 +2484,8 @@ void NPC::CheckSignal() {
 	if (!signal_q.empty()) {
 		int signal_id = signal_q.front();
 		signal_q.pop_front();
-		std::string buf = fmt::format("{}", signal_id);
-		parse->EventNPC(EVENT_SIGNAL, this, nullptr, buf.c_str(), 0);
+		std::string export_string = fmt::format("{}", signal_id);
+		parse->EventNPC(EVENT_SIGNAL, this, nullptr, export_string, 0);
 	}
 }
 

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -161,7 +161,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 		}
 	}
 
-	std::string buf = fmt::format(
+	std::string export_string = fmt::format(
 		"{} {} {} {}",
 		caster ? caster->GetID() : 0,
 		buffslot >= 0 ? buffs[buffslot].ticsremaining : 0,
@@ -170,12 +170,12 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 	);
 
 	if (IsClient()) {
-		if (parse->EventSpell(EVENT_SPELL_EFFECT_CLIENT, nullptr, CastToClient(), spell_id, buf, 0) != 0) {
+		if (parse->EventSpell(EVENT_SPELL_EFFECT_CLIENT, nullptr, CastToClient(), spell_id, export_string, 0) != 0) {
 			CalcBonuses();
 			return true;
 		}
 	} else if (IsNPC()) {
-		if (parse->EventSpell(EVENT_SPELL_EFFECT_NPC, CastToNPC(), nullptr, spell_id, buf, 0) != 0) {
+		if (parse->EventSpell(EVENT_SPELL_EFFECT_NPC, CastToNPC(), nullptr, spell_id, export_string, 0) != 0) {
 			CalcBonuses();
 			return true;
 		}
@@ -3759,7 +3759,7 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 
 	const SPDat_Spell_Struct &spell = spells[buff.spellid];
 
-	std::string buf = fmt::format(
+	std::string export_string = fmt::format(
 		"{} {} {} {}",
 		caster ? caster->GetID() : 0,
 		buffs[slot].ticsremaining,
@@ -3768,11 +3768,11 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 	);
 
 	if (IsClient()) {
-		if (parse->EventSpell(EVENT_SPELL_EFFECT_BUFF_TIC_CLIENT, nullptr, CastToClient(), buff.spellid, buf, 0) != 0) {
+		if (parse->EventSpell(EVENT_SPELL_EFFECT_BUFF_TIC_CLIENT, nullptr, CastToClient(), buff.spellid, export_string, 0) != 0) {
 			return;
 		}
 	} else if (IsNPC()) {
-		if (parse->EventSpell(EVENT_SPELL_EFFECT_BUFF_TIC_NPC, CastToNPC(), nullptr, buff.spellid, buf, 0) != 0) {
+		if (parse->EventSpell(EVENT_SPELL_EFFECT_BUFF_TIC_NPC, CastToNPC(), nullptr, buff.spellid, export_string, 0) != 0) {
 			return;
 		}
 	}
@@ -4106,7 +4106,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 
 	LogSpells("Fading buff [{}] from slot [{}]", buffs[slot].spellid, slot);
 
-	std::string buf = fmt::format(
+	std::string export_string = fmt::format(
 		"{} {} {} {}",
 		buffs[slot].casterid,
 		buffs[slot].ticsremaining,
@@ -4115,11 +4115,11 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 	);
 
 	if (IsClient()) {
-		if (parse->EventSpell(EVENT_SPELL_FADE, nullptr, CastToClient(), buffs[slot].spellid, buf, 0) != 0) {
+		if (parse->EventSpell(EVENT_SPELL_FADE, nullptr, CastToClient(), buffs[slot].spellid, export_string, 0) != 0) {
 			return;
 		}
 	} else if (IsNPC()) {
-		if (parse->EventSpell(EVENT_SPELL_FADE, CastToNPC(), nullptr, buffs[slot].spellid, buf, 0) != 0) {
+		if (parse->EventSpell(EVENT_SPELL_FADE, CastToNPC(), nullptr, buffs[slot].spellid, export_string, 0) != 0) {
 			return;
 		}
 	}

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -2439,11 +2439,11 @@ void ClientTaskState::AcceptNewTask(
 	client->MessageString(Chat::White, YOU_ASSIGNED_TASK, task->title.c_str());
 
 	task_manager->SaveClientState(client, this);
-	std::string buf = std::to_string(task_id);
+	std::string export_string = std::to_string(task_id);
 
 	NPC *npc = entity_list.GetID(npc_type_id)->CastToNPC();
 	if (npc) {
-		parse->EventNPC(EVENT_TASK_ACCEPTED, npc, client, buf.c_str(), 0);
+		parse->EventNPC(EVENT_TASK_ACCEPTED, npc, client, export_string, 0);
 	}
 }
 

--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -417,7 +417,8 @@ void Object::HandleCombine(Client* user, const NewCombine_Struct* in_combine, Ob
 	}
 
 	// final check for any additional quest requirements .. "check_zone" in this case - exported as variable [validate_type]
-	if (parse->EventPlayer(EVENT_COMBINE_VALIDATE, user, fmt::format("check_zone {}", zone->GetZoneID()), spec.recipe_id) != 0) {
+	std::string export_string = fmt::format("check_zone {}", zone->GetZoneID());
+	if (parse->EventPlayer(EVENT_COMBINE_VALIDATE, user, export_string, spec.recipe_id) != 0) {
 		user->Message(Chat::Emote, "You cannot make this combine because the location requirement has not been met.");
 		auto outapp = new EQApplicationPacket(OP_TradeSkillCombine, 0);
 		user->QueuePacket(outapp);

--- a/zone/waypoints.cpp
+++ b/zone/waypoints.cpp
@@ -165,10 +165,10 @@ void NPC::ResumeWandering()
 
 		if (m_CurrentWayPoint.x == GetX() && m_CurrentWayPoint.y == GetY())
 		{	// are we we at a waypoint? if so, trigger event and start to next
-			std::string buf = fmt::format("{}", cur_wp);
+			std::string export_string = fmt::format("{}", cur_wp);
 			CalculateNewWaypoint();
 			SetAppearance(eaStanding, false);
-			parse->EventNPC(EVENT_WAYPOINT_DEPART, this, nullptr, buf.c_str(), 0);
+			parse->EventNPC(EVENT_WAYPOINT_DEPART, this, nullptr, export_string, 0);
 		}	// if not currently at a waypoint, we continue on to the one we were headed to before the stop
 	}
 	else


### PR DESCRIPTION
- Export $killed_x, $killed_y, $killed_z, and $killed_h to EVENT_DEATH_ZONE in Perl.
- Cleanup export strings and unnecessary .c_str() calls on event exports.