### PR TITLE
[Quest API] Allow EVENT_ZONE to be parsed as non-zero to prevent zoning.

### DIFF
--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -1443,7 +1443,9 @@ void PerlembParser::ExportEventVariables(
 		}
 
 		case EVENT_ZONE: {
-			ExportVar(package_name.c_str(), "target_zone_id", data);
+			Seperator sep(data);
+			ExportVar(package_name.c_str(), "from_zone_id", sep.arg[0]);
+			ExportVar(package_name.c_str(), "target_zone_id", sep.arg[1]);
 			break;
 		}
 

--- a/zone/lua_parser_events.cpp
+++ b/zone/lua_parser_events.cpp
@@ -406,7 +406,12 @@ void handle_player_task_fail(QuestInterface *parse, lua_State* L, Client* client
 
 void handle_player_zone(QuestInterface *parse, lua_State* L, Client* client, std::string data, uint32 extra_data,
 						std::vector<EQ::Any> *extra_pointers) {
-	lua_pushinteger(L, std::stoi(data));
+	Seperator sep(data.c_str());
+
+	lua_pushinteger(L, std::stoi(sep.arg[0]));
+	lua_setfield(L, -2, "from_zone_id");
+
+	lua_pushinteger(L, std::stoi(sep.arg[1]));
 	lua_setfield(L, -2, "zone_id");
 }
 

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -202,8 +202,15 @@ void Client::Handle_OP_ZoneChange(const EQApplicationPacket *app) {
 		return;
 	}
 
-	std::string export_string = fmt::format("{}", target_zone_id);
-	parse->EventPlayer(EVENT_ZONE, this, export_string, 0);
+	std::string export_string = fmt::format(
+		"{} {}",
+		zone->GetZoneID(),
+		target_zone_id
+	);
+	if (parse->EventPlayer(EVENT_ZONE, this, export_string, 0) != 0) {
+		SendZoneCancel(zc);
+		return;
+	}
 
 	//handle circumvention of zone restrictions
 	//we need the value when creating the outgoing packet as well.


### PR DESCRIPTION
- This will allow server operators to prevent zoning to or from a specific zone based on whatever criteria they want.