### PR TITLE
[API] GetNPCStat default better naming

### DIFF
--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -2775,19 +2775,19 @@ float NPC::GetNPCStat(const char *identifier)
 	else if (id == "default_ac") {
 		return default_ac;
 	}
-	else if (id == "default_min_dmg") {
+	else if (id == "default_min_hit") {
 		return default_min_dmg;
 	}
-	else if (id == "default_max_dmg") {
+	else if (id == "default_max_hit") {
 		return default_max_dmg;
 	}
 	else if (id == "default_attack_delay") {
 		return default_attack_delay;
 	}
-	else if (id == "default_accuracy_rating") {
+	else if (id == "default_accuracy") {
 		return default_accuracy_rating;
 	}
-	else if (id == "default_avoidance_rating") {
+	else if (id == "default_avoidance") {
 		return default_avoidance_rating;
 	}
 	else if (id == "default_atk") {


### PR DESCRIPTION
Update to this recent PR: https://github.com/EQEmu/Server/pull/2048

Realized the names should match the regular version names.

	"default_ac"
	"default_min_hit"
	"default_max_hit"
	"default_attack_delay"
	"default_accuracy"
	"default_avoidance"
	"default_atk"