### PR TITLE
[Quest API] Add AddItem() to Perl/Lua.

### DIFF
--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -2366,6 +2366,37 @@ void Lua_Client::SetInvulnerableEnvironmentDamage(bool value) {
 	self->SetInvulnerableEnvironmentDamage(value);
 }
 
+void Lua_Client::AddItem(luabind::object item_table) {
+	Lua_Safe_Call_Void();
+	if (luabind::type(item_table) != LUA_TTABLE) {
+		return;
+	}
+
+	uint32 item_id = luabind::object_cast<uint32>(item_table["item_id"]);
+	int16 charges = luabind::object_cast<uint32>(item_table["charges"]);
+	uint32 augment_one = luabind::type(item_table["augment_one"]) != LUA_TNIL ? luabind::object_cast<uint32>(item_table["augment_one"]) : 0;
+	uint32 augment_two = luabind::type(item_table["augment_two"]) != LUA_TNIL ? luabind::object_cast<uint32>(item_table["augment_two"]) : 0;
+	uint32 augment_three = luabind::type(item_table["augment_three"]) != LUA_TNIL ? luabind::object_cast<uint32>(item_table["augment_three"]) : 0;
+	uint32 augment_four = luabind::type(item_table["augment_four"]) != LUA_TNIL ? luabind::object_cast<uint32>(item_table["augment_four"]) : 0;
+	uint32 augment_five = luabind::type(item_table["augment_five"]) != LUA_TNIL ? luabind::object_cast<uint32>(item_table["augment_five"]) : 0;
+	uint32 augment_six = luabind::type(item_table["augment_six"]) != LUA_TNIL ? luabind::object_cast<uint32>(item_table["augment_six"]) : 0;
+	bool attuned = luabind::type(item_table["attuned"]) != LUA_TNIL ? luabind::object_cast<bool>(item_table["attuned"]) : false;
+	uint16 slot_id = luabind::type(item_table["slot_id"]) != LUA_TNIL ? luabind::object_cast<uint16>(item_table["slot_id"]) : EQ::invslot::slotCursor;
+
+	self->SummonItem(
+		item_id,
+		charges,
+		augment_one,
+		augment_two,
+		augment_three,
+		augment_four,
+		augment_five,
+		augment_six,
+		attuned,
+		slot_id
+	);
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 	.def(luabind::constructor<>())
@@ -2381,6 +2412,7 @@ luabind::scope lua_register_client() {
 	.def("AddExpeditionLockout", (void(Lua_Client::*)(std::string, std::string, uint32, std::string))&Lua_Client::AddExpeditionLockout)
 	.def("AddExpeditionLockoutDuration", (void(Lua_Client::*)(std::string, std::string, int))&Lua_Client::AddExpeditionLockoutDuration)
 	.def("AddExpeditionLockoutDuration", (void(Lua_Client::*)(std::string, std::string, int, std::string))&Lua_Client::AddExpeditionLockoutDuration)
+	.def("AddItem", (void(Lua_Client::*)(luabind::adl::object))&Lua_Client::AddItem)
 	.def("AddLDoNLoss", (void(Lua_Client::*)(uint32))&Lua_Client::AddLDoNLoss)
 	.def("AddLDoNWin", (void(Lua_Client::*)(uint32))&Lua_Client::AddLDoNWin)
 	.def("AddLevelBasedExp", (void(Lua_Client::*)(int))&Lua_Client::AddLevelBasedExp)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -392,6 +392,7 @@ public:
 	void RemoveItem(uint32 item_id);
 	void RemoveItem(uint32 item_id, uint32 quantity);
 	void SetGMStatus(uint32 newStatus);
+	void AddItem(luabind::object item_table);
 
 	int GetEnvironmentDamageModifier();
 	void SetEnvironmentDamageModifier(int value);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -6057,6 +6057,64 @@ XS(XS_Client_SetInvulnerableEnvironmentDamage) {
 	XSRETURN_EMPTY;
 }
 
+XS(XS_Client_AddItem);
+XS(XS_Client_AddItem) {
+	dXSARGS;
+	if (items != 2) {
+		Perl_croak(aTHX_ "Usage: Client::AddItem(THIS, HASHREF item_table)");
+	}
+
+	Client *THIS;
+	VALIDATE_THIS_IS_CLIENT;
+
+	SV* item_table = ST(1);
+	if (!item_table || !SvROK(item_table)) {
+		Perl_croak(aTHX_ "Client::AddItem argument is not a reference type");
+	}
+
+	HV* item_table_hash = (HV*)SvRV(item_table);
+	if (SvTYPE(item_table_hash) != SVt_PVHV) {
+		Perl_croak(aTHX_ "Client::AddItem reference argument is not to a hash type");
+	}
+
+	SV** item_id_ptr = hv_fetchs(item_table_hash, "item_id", false);
+	SV** item_charges_ptr = hv_fetchs(item_table_hash, "charges", false);
+	SV** augment_one_ptr = hv_fetchs(item_table_hash, "augment_one", false);
+	SV** augment_two_ptr = hv_fetchs(item_table_hash, "augment_two", false);
+	SV** augment_three_ptr = hv_fetchs(item_table_hash, "augment_three", false);
+	SV** augment_four_ptr = hv_fetchs(item_table_hash, "augment_four", false);
+	SV** augment_five_ptr = hv_fetchs(item_table_hash, "augment_five", false);
+	SV** augment_six_ptr = hv_fetchs(item_table_hash, "augment_six", false);
+	SV** attuned_ptr = hv_fetchs(item_table_hash, "attuned", false);
+	SV** slot_id_ptr = hv_fetchs(item_table_hash, "slot_id", false);
+	if (item_id_ptr && item_charges_ptr) {
+		uint32 item_id = static_cast<uint32>(SvUV(*item_id_ptr));
+		int16 charges = static_cast<int16>(SvIV(*item_charges_ptr));
+		uint32 augment_one = augment_one_ptr ? static_cast<uint32>(SvUV(*augment_one_ptr)) : 0;
+		uint32 augment_two = augment_two_ptr ? static_cast<uint32>(SvUV(*augment_two_ptr)) : 0;
+		uint32 augment_three = augment_three_ptr ? static_cast<uint32>(SvUV(*augment_three_ptr)) : 0;
+		uint32 augment_four = augment_four_ptr ? static_cast<uint32>(SvUV(*augment_four_ptr)) : 0;
+		uint32 augment_five = augment_five_ptr ? static_cast<uint32>(SvUV(*augment_five_ptr)) : 0;
+		uint32 augment_six = augment_six_ptr ? static_cast<uint32>(SvUV(*augment_six_ptr)) : 0;
+		bool attuned = attuned_ptr ? static_cast<bool>(SvTRUE(*attuned_ptr)) : false;
+		uint16 slot_id = slot_id_ptr ? static_cast<uint16>(SvUV(*slot_id_ptr)) : EQ::invslot::slotCursor;
+		THIS->SummonItem(
+			item_id,
+			charges,
+			augment_one,
+			augment_two,
+			augment_three,
+			augment_four,
+			augment_five,
+			augment_six,
+			attuned,
+			slot_id
+		);
+	}
+	
+	XSRETURN_EMPTY;
+}
+
 #ifdef __cplusplus
 extern "C"
 #endif
@@ -6082,6 +6140,7 @@ XS(boot_Client) {
 	newXSproto(strcpy(buf, "AddEXP"), XS_Client_AddEXP, file, "$$;$$");
 	newXSproto(strcpy(buf, "AddExpeditionLockout"), XS_Client_AddExpeditionLockout, file, "$$$$;$");
 	newXSproto(strcpy(buf, "AddExpeditionLockoutDuration"), XS_Client_AddExpeditionLockoutDuration, file, "$$$$;$");
+	newXSproto(strcpy(buf, "AddItem"), XS_Client_AddItem, file, "$$");
 	newXSproto(strcpy(buf, "AddLDoNLoss"), XS_Client_AddLDoNLoss, file, "$$");
 	newXSproto(strcpy(buf, "AddLDoNWin"), XS_Client_AddLDoNWin, file, "$$");
 	newXSproto(strcpy(buf, "AddLevelBasedExp"), XS_Client_AddLevelBasedExp, file, "$$;$$");


### PR DESCRIPTION
- Add $client->AddItem(item_data) to Perl.
- Add client:AddItem(item_table) to Lua.
- This will allow server operators to add items without needless parameters.

Perl Example:
```pl
my %item_data = (
	"item_id" => 1200,
	"charges" => 1,
	"augment_one" => 49656,
	"augment_two" => 49656,
	"augment_three" => 49656,
	"augment_four" => 49656,
	"augment_five" => 49656,
	"augment_six" => 49656,
	"attuned" => 1,
	"slot_id" => quest::getinventoryslotid("general1")
);
$client->AddItem(\%item_data);
```
Lua Example:
```lua
local item_data = {
	item_id = 1200,
	charges = 1,
	augment_one = 49656,
	augment_two = 49656,
	augment_three = 49656,
	augment_four = 49656,
	augment_five = 49656,
	augment_six = 49656,
	attuned = true,
	slot_id = Slot.General1
};
e.self:AddItem(item_data);
```