### PR TITLE
[Bug Fix] Fix possible crash with zone name methods.

### DIFF
--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -1146,12 +1146,13 @@ const char *lua_get_zone_long_name() {
 
 const char *lua_get_zone_long_name_by_name(const char* zone_name) {
 	return ZoneLongName(
-		ZoneID(zone_name)
+		ZoneID(zone_name),
+		true
 	);
 }
 
 const char *lua_get_zone_long_name_by_id(uint32 zone_id) {
-	return ZoneLongName(zone_id);
+	return ZoneLongName(zone_id, true);
 }
 
 const char *lua_get_zone_short_name() {
@@ -1162,7 +1163,7 @@ const char *lua_get_zone_short_name() {
 }
 
 const char *lua_get_zone_short_name_by_id(uint32 zone_id) {
-	return ZoneName(zone_id);
+	return ZoneName(zone_id, true);
 }
 
 int lua_get_zone_instance_id() {

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -3234,15 +3234,15 @@ int32 QuestManager::GetZoneID(const char *zone) {
 
 std::string QuestManager::GetZoneLongName(std::string zone_short_name)
 {
-	return ZoneLongName(ZoneID(zone_short_name));
+	return ZoneLongName(ZoneID(zone_short_name), true);
 }
 
 std::string QuestManager::GetZoneLongNameByID(uint32 zone_id) {
-	return ZoneLongName(zone_id);
+	return ZoneLongName(zone_id, true);
 }
 
 std::string QuestManager::GetZoneShortName(uint32 zone_id) {
-	return ZoneName(zone_id);
+	return ZoneName(zone_id, true);
 }
 
 bool QuestManager::EnableRecipe(uint32 recipe_id)


### PR DESCRIPTION
- ZoneLongName and ZoneName were returning nullptr in places when given invalid data that were then attempting to use that nullptr value, causing zone crashes.