### PR TITLE
[Logging] Fix log messages to final damage values

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -5803,7 +5803,7 @@ void Client::Handle_OP_EnvDamage(const EQApplicationPacket *app)
 			Chat::Red,
 			fmt::format(
 				"Your GM status protects you from {} points of {} (Type {}) damage.",
-				ed->damage,
+				damage,
 				EQ::constants::GetEnvironmentalDamageName(ed->dmgtype),
 				ed->dmgtype
 			).c_str()
@@ -5815,7 +5815,7 @@ void Client::Handle_OP_EnvDamage(const EQApplicationPacket *app)
 			Chat::Red,
 			fmt::format(
 				"Your invulnerability protects you from {} points of {} (Type {}) damage.",
-				ed->damage,
+				damage,
 				EQ::constants::GetEnvironmentalDamageName(ed->dmgtype),
 				ed->dmgtype
 			).c_str()


### PR DESCRIPTION
Handle_OP_EnvDamage log messages were logging the input damage base, not the actual adjusted damage that was being mitigated by invulnerability.