### PR TITLE
[Bug Fix] Restore missing messages for lifetap and dmg spells.

### DIFF
--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -139,11 +139,13 @@ bool IsEvacSpell(uint16 spellid)
 
 bool IsDamageSpell(uint16 spellid)
 {
+	if (spells[spellid].target_type == ST_Tap)
+		return false;
+
 	for (int o = 0; o < EFFECT_COUNT; o++) {
 		uint32 tid = spells[spellid].effect_id[o];
-		if ((tid == SE_CurrentHPOnce || tid == SE_CurrentHP) &&
-				spells[spellid].target_type != ST_Tap && spells[spellid].buff_duration < 1 &&
-				spells[spellid].base_value[o] < 0)
+		if (spells[spellid].base_value[o] < 0 &&
+			((tid == SE_CurrentHPOnce) || (tid == SE_CurrentHP && spells[spellid].buff_duration < 1)))
 			return true;
 	}
 

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4137,7 +4137,7 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 				Mob::CLIENT_CONNECTINGALL, FilterPCSpells);
 		}
 		// Show the "you feel your life force drain away" on target client...
-		if (spelltar->IsClient()) {
+		if (IsLifetapSpell(spell_id) && spelltar->IsClient()) {
 			spelltar->CastToClient()->QueuePacket(message_packet, true,
 				Mob::CLIENT_CONNECTINGALL,
 				(spellOwner->IsClient() ? FilterPCSpells : FilterNPCSpells));


### PR DESCRIPTION
I noticed that when an npc (spectre) cast lifetap on a PC that the "feel your life drain away" message was missing.

This PR fixes this, and some other missing messages.  It also uses the proper message Filters.  This function had conflicting filters.

Been tested on Rolath for about a week.  Have not seen any extra messages and missing messages are restored.