### PR TITLE
[Quest API] Add GetBotListByClientName(client_name) to Perl/Lua.

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -5057,9 +5057,26 @@ void EntityList::GetClientList(std::list<Client *> &c_list)
 void EntityList::GetBotList(std::list<Bot *> &b_list)
 {
 	b_list.clear();
-	for (auto bot_iterator : bot_list) {
-		b_list.push_back(bot_iterator);
+	for (auto bot : bot_list) {
+		b_list.push_back(bot);
 	}
+}
+
+std::vector<Bot *> EntityList::GetBotListByClientName(std::string client_name)
+{
+	std::vector<Bot *> client_bot_list;
+
+	if (client_name.empty()) {
+		return client_bot_list;
+	}
+
+	for (auto bot : bot_list) {
+		if (bot->GetOwner() && str_tolower(bot->GetOwner()->GetCleanName()) == str_tolower(client_name)) {
+			client_bot_list.push_back(bot);
+		}
+	}
+
+	return client_bot_list;
 }
 #endif
 

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -526,6 +526,7 @@ public:
 	inline const std::unordered_map<uint16, Client *> &GetClientList() { return client_list; }
 #ifdef BOTS
 	inline const std::list<Bot *> &GetBotList() { return bot_list; }
+	std::vector<Bot *> GetBotListByClientName(std::string client_name);
 #endif
 	inline const std::unordered_map<uint16, Corpse *> &GetCorpseList() { return corpse_list; }
 	inline const std::unordered_map<uint16, Object *> &GetObjectList() { return object_list; }

--- a/zone/lua_entity_list.cpp
+++ b/zone/lua_entity_list.cpp
@@ -375,8 +375,19 @@ Lua_Bot_List Lua_EntityList::GetBotList() {
 	Lua_Safe_Call_Class(Lua_Bot_List);
 	Lua_Bot_List ret;
 	auto &bot_list = self->GetBotList();
-	for (auto bot_iterator : bot_list) {
-		ret.entries.push_back(Lua_Bot(bot_iterator));
+	for (auto bot : bot_list) {
+		ret.entries.push_back(Lua_Bot(bot));
+	}
+
+	return ret;
+}
+
+Lua_Bot_List Lua_EntityList::GetBotListByClientName(std::string client_name) {
+	Lua_Safe_Call_Class(Lua_Bot_List);
+	Lua_Bot_List ret;
+	auto &bot_list = self->GetBotListByClientName(client_name);
+	for (auto bot : bot_list) {
+		ret.entries.push_back(Lua_Bot(bot));
 	}
 
 	return ret;
@@ -519,6 +530,7 @@ luabind::scope lua_register_entity_list() {
 	.def("GetBotByID", (Lua_Bot(Lua_EntityList::*)(uint32))&Lua_EntityList::GetBotByID)
 	.def("GetBotByName", (Lua_Bot(Lua_EntityList::*)(std::string))&Lua_EntityList::GetBotByName)
 	.def("GetBotList", (Lua_Bot_List(Lua_EntityList::*)(void))&Lua_EntityList::GetBotList)
+	.def("GetBotListByClientName", (Lua_Bot_List(Lua_EntityList::*)(std::string))&Lua_EntityList::GetBotListByClientName)
 #endif
 	.def("GetClientByAccID", (Lua_Client(Lua_EntityList::*)(uint32))&Lua_EntityList::GetClientByAccID)
 	.def("GetClientByCharID", (Lua_Client(Lua_EntityList::*)(uint32))&Lua_EntityList::GetClientByCharID)

--- a/zone/lua_entity_list.cpp
+++ b/zone/lua_entity_list.cpp
@@ -385,7 +385,7 @@ Lua_Bot_List Lua_EntityList::GetBotList() {
 Lua_Bot_List Lua_EntityList::GetBotListByClientName(std::string client_name) {
 	Lua_Safe_Call_Class(Lua_Bot_List);
 	Lua_Bot_List ret;
-	auto &bot_list = self->GetBotListByClientName(client_name);
+	auto bot_list = self->GetBotListByClientName(client_name);
 	for (auto bot : bot_list) {
 		ret.entries.push_back(Lua_Bot(bot));
 	}

--- a/zone/lua_entity_list.h
+++ b/zone/lua_entity_list.h
@@ -128,6 +128,7 @@ public:
 	Lua_Bot GetBotByID(uint32 bot_id);
 	Lua_Bot GetBotByName(std::string bot_name);
 	Lua_Bot_List GetBotList();
+	Lua_Bot_List GetBotListByClientName(std::string client_name);
 #endif
 };
 

--- a/zone/perl_entity.cpp
+++ b/zone/perl_entity.cpp
@@ -1346,6 +1346,34 @@ XS(XS_EntityList_GetBotList) {
 	}
 	XSRETURN(bot_count);
 }
+
+XS(XS_EntityList_GetBotListByClientName);
+XS(XS_EntityList_GetBotListByClientName) {
+	dXSARGS;
+	if (items != 2) {
+		Perl_croak(aTHX_ "Usage: EntityList::GetBotListByClientName(THIS, string client_name)"); // @categories Script Utility, Bot
+	}
+
+	EntityList *THIS;
+	std::string client_name = (std::string) SvPV_nolen(ST(1));
+	VALIDATE_THIS_IS_ENTITY;
+
+	auto current_bot_list = THIS->GetBotListByClientName(client_name);
+	auto bot_count = current_bot_list.size();
+
+    if (bot_count > 0) {
+        EXTEND(sp, bot_count);
+        for (int index = 0; index < bot_count; ++index) {
+            ST(index) = sv_newmortal();
+			sv_setref_pv(ST(index), "Bot", (void *) current_bot_list[index]);
+			XPUSHs(ST(index));
+        }
+        XSRETURN(bot_count);
+    }
+    SV* return_value = &PL_sv_undef;
+    ST(0) = return_value;
+    XSRETURN(1);
+}
 #endif
 
 XS(XS_EntityList_GetNPCList); /* prototype to pass -Wmissing-prototypes */
@@ -1548,6 +1576,7 @@ XS(boot_EntityList) {
 	newXSproto(strcpy(buf, "GetBotByID"), XS_EntityList_GetBotByID, file, "$$");
 	newXSproto(strcpy(buf, "GetBotByName"), XS_EntityList_GetBotByName, file, "$$");
 	newXSproto(strcpy(buf, "GetBotList"), XS_EntityList_GetBotList, file, "$");
+	newXSproto(strcpy(buf, "GetBotListByClientName"), XS_EntityList_GetBotListByClientName, file, "$$");
 #endif
 	newXSproto(strcpy(buf, "GetClientByAccID"), XS_EntityList_GetClientByAccID, file, "$$");
 	newXSproto(strcpy(buf, "GetClientByCharID"), XS_EntityList_GetClientByCharID, file, "$$");


### PR DESCRIPTION
- Add $entity_list->GetBotListByClientName(client_name) to Perl.
- Add eq.get_entity_list():GetBotListByClientName(client_name) to Lua.
- Allows you to get a bot list comprised solely of a specific character's bots.