### PR TITLE
[Bug Fix] Fix recipient sound (vtell) on non-player races

### DIFF
--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -3369,7 +3369,7 @@ bool WorldServer::SendVoiceMacro(Client* From, uint32 Type, char* Target, uint32
 	uint16 player_race = GetPlayerRaceValue(From->GetRace());
 
 	if (player_race == PLAYER_RACE_UNKNOWN) {
-		player_race = From->GetRace();
+		player_race = From->GetBaseRace();
 	}
 
 	svm->Voice = (player_race * 2) + From->GetGender();

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -3366,7 +3366,13 @@ bool WorldServer::SendVoiceMacro(Client* From, uint32 Type, char* Target, uint32
 
 	svm->Type = Type;
 
-	svm->Voice = (GetPlayerRaceValue(From->GetRace()) * 2) + From->GetGender();
+	uint16 player_race = GetPlayerRaceValue(From->GetRace());
+
+	if (player_race == PLAYER_RACE_UNKNOWN) {
+		player_race = From->GetRace();
+	}
+
+	svm->Voice = (player_race * 2) + From->GetGender();
 
 	svm->MacroNumber = MacroNumber;
 


### PR DESCRIPTION
Voice tells for non-player races (like skeleton illusions, etc.) are incorrectly playing human sounds on recipient clients.

This is because the code isn't checking the return value for GetPlayerRaceValue().  

This patch makes recipient play BaseRace in these cases, to match what sending client plays.