### PR TITLE
[Bug Fix] Bard Invisible causing display issues.

### DIFF
--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -1473,6 +1473,7 @@ bool IsInstrumentModAppliedToSpellEffect(int32 spell_id, int effect)
 		case SE_ImprovedInvisAnimals:
 		case SE_SeeInvis:
 		case SE_Levitate:
+		case SE_WaterBreathing:
 			return false;
 		default:
 			return true;

--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -1465,6 +1465,14 @@ bool IsInstrumentModAppliedToSpellEffect(int32 spell_id, int effect)
 		case SE_BardSongRange:
 		case SE_TemporaryPets:
 		case SE_SpellOnDeath:
+		case SE_Invisibility:
+		case SE_Invisibility2:
+		case SE_InvisVsUndead:
+		case SE_InvisVsUndead2:
+		case SE_InvisVsAnimals:
+		case SE_ImprovedInvisAnimals:
+		case SE_SeeInvis:
+		case SE_Levitate:
 			return false;
 		default:
 			return true;

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -3847,6 +3847,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 
 			case SE_InvisVsAnimals:
+			case SE_ImprovedInvisAnimals:
 				effect_value = std::min({ effect_value, MAX_INVISIBILTY_LEVEL });
 				if (new_bonus->invisibility_verse_animal < effect_value)
 					new_bonus->invisibility_verse_animal = effect_value;


### PR DESCRIPTION
Error occurring due to bard modifiers being applied to invisible spell effect value when it should not.