### PR TITLE
[Commands] Cleanup #task Command.

### DIFF
--- a/zone/gm_commands/task.cpp
+++ b/zone/gm_commands/task.cpp
@@ -4,11 +4,12 @@
 extern WorldServer worldserver;
 
 #include "../../common/shared_tasks.h"
+#include "../../common/repositories/completed_tasks_repository.h"
 
 void command_task(Client *c, const Seperator *sep)
 {
-	//super-command for managing tasks
-	if (sep->arg[1][0] == '\0' || !strcasecmp(sep->arg[1], "help")) {
+	int arguments = sep->argnum;
+	if (!arguments) {
 		c->Message(Chat::White, "Syntax: #task [subcommand]");
 		c->Message(Chat::White, "------------------------------------------------");
 		c->Message(Chat::White, "# Task System Commands");
@@ -22,6 +23,7 @@ void command_task(Client *c, const Seperator *sep)
 		);
 		c->Message(Chat::White, "--- update <task_id> <activity_id> [count] | Updates task");
 		c->Message(Chat::White, "--- assign <task_id> | Assigns task to client");
+		c->Message(Chat::White, "--- uncomplete <task_id> | Uncompletes a task if a client has completed it");
 		c->Message(
 			Chat::White,
 			fmt::format(
@@ -75,7 +77,6 @@ void command_task(Client *c, const Seperator *sep)
 				EQ::SayLinkEngine::GenerateQuestSaylink("#task sharedpurge", false, "sharedpurge")
 			).c_str()
 		);
-
 		return;
 	}
 
@@ -84,53 +85,190 @@ void command_task(Client *c, const Seperator *sep)
 		client_target = c->GetTarget()->CastToClient();
 	}
 
-	if (!strcasecmp(sep->arg[1], "show")) {
-		c->ShowClientTasks(client_target);
+	bool is_assign = !strcasecmp(sep->arg[1], "assign");
+	bool is_purgetimers = !strcasecmp(sep->arg[1], "purgetimers");
+	bool is_reload = !strcasecmp(sep->arg[1], "reload");
+	bool is_reloadall = !strcasecmp(sep->arg[1], "reloadall");
+	bool is_sharedpurge = !strcasecmp(sep->arg[1], "sharedpurge");
+	bool is_show = !strcasecmp(sep->arg[1], "show");
+	bool is_uncomplete = !strcasecmp(sep->arg[1], "uncomplete");
+	bool is_update = !strcasecmp(sep->arg[1], "update");
+
+	if (
+		!is_assign &&
+		!is_purgetimers &&
+		!is_reload &&
+		!is_reloadall &&
+		!is_sharedpurge &&
+		!is_show &&
+		!is_uncomplete &&
+		!is_update
+	) {
+		c->Message(Chat::White, "Syntax: #task [subcommand]");
+		c->Message(Chat::White, "------------------------------------------------");
+		c->Message(Chat::White, "# Task System Commands");
+		c->Message(Chat::White, "------------------------------------------------");
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"--- [{}] List active tasks for a client",
+				EQ::SayLinkEngine::GenerateQuestSaylink("#task show", false, "show")
+			).c_str()
+		);
+		c->Message(Chat::White, "--- update <task_id> <activity_id> [count] | Updates task");
+		c->Message(Chat::White, "--- assign <task_id> | Assigns task to client");
+		c->Message(Chat::White, "--- uncomplete <task_id> | Uncompletes a task if a client has completed it");
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"--- [{}] Reload all Task information from the database",
+				EQ::SayLinkEngine::GenerateQuestSaylink("#task reloadall", false, "reloadall")
+			).c_str()
+		);
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"--- [{}] <task_id> Reload Task and Activity information for a single task",
+				EQ::SayLinkEngine::GenerateQuestSaylink("#task reload task", false, "reload task")
+			).c_str()
+		);
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"--- [{}] Reload goal/reward list information",
+				EQ::SayLinkEngine::GenerateQuestSaylink("#task reload lists", false, "reload lists")
+			).c_str()
+		);
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"--- [{}] Reload proximity information",
+				EQ::SayLinkEngine::GenerateQuestSaylink("#task reload prox", false, "reload prox")
+			).c_str()
+		);
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"--- [{}] Reload task set information",
+				EQ::SayLinkEngine::GenerateQuestSaylink("#task reload sets", false, "reload sets")
+			).c_str()
+		);
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"--- [{}] Purges targeted characters task timers",
+				EQ::SayLinkEngine::GenerateQuestSaylink("#task purgetimers", false, "purgetimers")
+			).c_str()
+		);
+
+		c->Message(Chat::White, "------------------------------------------------");
+		c->Message(Chat::White, "# Shared Task System Commands");
+		c->Message(Chat::White, "------------------------------------------------");
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"--- [{}] Purges all active Shared Tasks in memory and database ",
+				EQ::SayLinkEngine::GenerateQuestSaylink("#task sharedpurge", false, "sharedpurge")
+			).c_str()
+		);
 		return;
 	}
 
-	if (!strcasecmp(sep->arg[1], "purgetimers")) {
-		c->Message(15, fmt::format("{}'s task timers have been purged", client_target->GetCleanName()).c_str());
-		if (client_target != c) {
-			client_target->Message(15, "[GM] Your task timers have been purged by a GM");
-		}
-		client_target->PurgeTaskTimers();
-		return;
-	}
-
-	if (!strcasecmp(sep->arg[1], "update")) {
-		if (sep->argnum >= 3) {
-			int task_id     = atoi(sep->arg[2]);
-			int activity_id = atoi(sep->arg[3]);
-			int count       = 1;
-
-			if (sep->argnum >= 4) {
-				count = atoi(sep->arg[4]);
-				if (count <= 0) {
-					count = 1;
-				}
-			}
+	if (is_assign) {
+		auto task_id = std::stoul(sep->arg[2]);
+		if (task_id && task_id < MAXTASKS) {
+			client_target->AssignTask(task_id, 0, false);
 			c->Message(
 				Chat::Yellow,
-				"Updating Task [%i] Activity [%i] Count [%i] for client [%s]",
-				task_id,
-				activity_id,
-				count,
-				client_target->GetCleanName()
+				fmt::format(
+					"Assigned task ID {} to {}.",
+					task_id,
+					(
+						client_target == c ?
+						"yourself" :
+						fmt::format(
+							"{} ({})",
+							client_target->GetCleanName(),
+							client_target->GetID()
+						)
+					)
+				).c_str()
 			);
-			client_target->UpdateTaskActivity(task_id, activity_id, count);
-			c->ShowClientTasks(client_target);
 		}
 		return;
-	}
+	} else if (is_purgetimers) {
+		c->Message(
+			Chat::Yellow,
+			fmt::format(
+				"Task timers have been purged for {}.",
+				(
+					client_target == c ?
+					"yourself" :
+					fmt::format(
+						"{} ({})",
+						client_target->GetCleanName(),
+						client_target->GetID()
+					)
+				)
+			).c_str()
+		);
 
-	if (!strcasecmp(sep->arg[1], "sharedpurge")) {
+		if (client_target != c) {
+			client_target->Message(Chat::Yellow, "Your task timers have been purged by a GM.");
+		}
+
+		client_target->PurgeTaskTimers();
+		return;
+	} else if (is_reload) {
+		if (arguments >= 2) {
+			if (!strcasecmp(sep->arg[2], "lists")) {
+				c->Message(Chat::Yellow, "Attempting to reload goal lists.");
+				worldserver.SendReloadTasks(RELOADTASKGOALLISTS);
+				c->Message(Chat::Yellow, "Successfully reloaded goal lists.");
+				return;
+			} else if (!strcasecmp(sep->arg[2], "prox")) {
+				c->Message(Chat::Yellow, "Attempting to reload task proximites.");
+				worldserver.SendReloadTasks(RELOADTASKPROXIMITIES);
+				c->Message(Chat::Yellow, "Successfully reloaded task proximites.");
+				return;
+			} else if (!strcasecmp(sep->arg[2], "sets")) {
+				c->Message(Chat::Yellow, "Attempting to reload task sets.");
+				worldserver.SendReloadTasks(RELOADTASKSETS);
+				c->Message(Chat::Yellow, "Successfully reloaded task sets.");
+				return;
+			} else if (!strcasecmp(sep->arg[2], "task") && arguments == 3) {
+				int task_id = std::stoul(sep->arg[3]);
+				if (task_id && task_id < MAXTASKS) {
+					c->Message(
+						Chat::Yellow,
+						fmt::format(
+							"Attempted to reload task ID {}.",
+							task_id
+						).c_str()
+					);
+					worldserver.SendReloadTasks(RELOADTASKS, task_id);
+					c->Message(
+						Chat::Yellow,
+						fmt::format(
+							"Successfully reloaded task ID {}.",
+							task_id
+						).c_str()
+					);
+					return;
+				}
+			}
+		}
+	} else if (is_reloadall) {
+		c->Message(Chat::Yellow, "Attempting to reload tasks.");
+		worldserver.SendReloadTasks(RELOADTASKS);
+		c->Message(Chat::Yellow, "Successfully reloaded tasks.");
+		return;
+	} else if (is_sharedpurge) {
 		if (!strcasecmp(sep->arg[2], "confirm")) {
 			LogTasksDetail("Sending purge request");
 			auto pack = new ServerPacket(ServerOP_SharedTaskPurgeAllCommand, 0);
 			worldserver.SendPacket(pack);
 			safe_delete(pack);
-
 			return;
 		}
 
@@ -143,56 +281,99 @@ void command_task(Client *c, const Seperator *sep)
 		);
 
 		return;
-	}
-
-	if (!strcasecmp(sep->arg[1], "assign")) {
-		int task_id = atoi(sep->arg[2]);
-		if ((task_id > 0) && (task_id < MAXTASKS)) {
-			client_target->AssignTask(task_id, 0, false);
-			c->Message(Chat::Yellow, "Assigned task [%i] to [%s]", task_id, client_target->GetCleanName());
-		}
+	} else if (is_show) {
+		c->ShowClientTasks(client_target);
 		return;
-	}
-
-	if (!strcasecmp(sep->arg[1], "reloadall")) {
-		c->Message(Chat::Yellow, "Sending reloadtasks to world");
-		worldserver.SendReloadTasks(RELOADTASKS);
-		c->Message(Chat::Yellow, "Back again");
-		return;
-	}
-
-	if (!strcasecmp(sep->arg[1], "reload")) {
-		if (sep->arg[2][0] != '\0') {
-			if (!strcasecmp(sep->arg[2], "lists")) {
-				c->Message(Chat::Yellow, "Sending reload lists to world");
-				worldserver.SendReloadTasks(RELOADTASKGOALLISTS);
-				c->Message(Chat::Yellow, "Reloaded");
-				return;
-			}
-			if (!strcasecmp(sep->arg[2], "prox")) {
-				c->Message(Chat::Yellow, "Sending reload proximities to world");
-				worldserver.SendReloadTasks(RELOADTASKPROXIMITIES);
-				c->Message(Chat::Yellow, "Reloaded");
-				return;
-			}
-			if (!strcasecmp(sep->arg[2], "sets")) {
-				c->Message(Chat::Yellow, "Sending reload task sets to world");
-				worldserver.SendReloadTasks(RELOADTASKSETS);
-				c->Message(Chat::Yellow, "Reloaded");
-				return;
-			}
-			if (!strcasecmp(sep->arg[2], "task") && (sep->arg[3][0] != '\0')) {
-				int task_id = atoi(sep->arg[3]);
-				if ((task_id > 0) && (task_id < MAXTASKS)) {
-					c->Message(Chat::Yellow, "Sending reload task %i to world", task_id);
-					worldserver.SendReloadTasks(RELOADTASKS, task_id);
-					c->Message(Chat::Yellow, "Reloaded");
+	} else if (is_uncomplete) {
+		if (sep->IsNumber(2)) {
+			auto task_id = std::stoul(sep->arg[2]);
+			if (task_id && task_id < MAXTASKS) {
+				if (
+					CompletedTasksRepository::DeleteWhere(
+						database,					
+						fmt::format(
+							"charid = {} AND taskid = {}",
+							client_target->CharacterID(),
+							task_id
+						)
+					)
+				) {
+					c->Message(
+						Chat::Yellow,
+						fmt::format(
+							"Successfully uncompleted task ID {} for {}.",
+							task_id,
+							(
+								client_target == c ?
+								"yourself" :
+								fmt::format(
+									"{} ({})",
+									client_target->GetCleanName(),
+									client_target->GetID()
+								)
+							)
+						).c_str()
+					);
+					return;
+				} else {
+					c->Message(
+						Chat::Yellow,
+						fmt::format(
+							"{} not completed task ID {}.",
+							(
+								client_target == c ?
+								"You have" :
+								fmt::format(
+									"{} ({}) has",
+									client_target->GetCleanName(),
+									client_target->GetID()
+								)
+							),
+							task_id
+						).c_str()
+					);
 					return;
 				}
+			} else {
+				c->Message(Chat::White, "Invalid task ID specified.");
+				return;
 			}
 		}
+	} else if (is_update) {
+		if (arguments >= 3) {
+			auto task_id = std::stoul(sep->arg[2]);
+			auto activity_id = std::stoul(sep->arg[3]);
+			int count = 1;
 
+			if (arguments >= 4) {
+				count = std::stoi(sep->arg[4]);
+				if (count <= 0) {
+					count = 1;
+				}
+			}
+
+			c->Message(
+				Chat::Yellow,
+				fmt::format(
+					"Updating task ID {}, activity {} with a count of {} for {}.",
+					task_id,
+					activity_id,
+					count,
+					(
+						client_target == c ?
+						"yourself" :
+						fmt::format(
+							"{} ({})",
+							client_target->GetCleanName(),
+							client_target->GetID()
+						)
+					)
+				).c_str()
+			);
+
+			client_target->UpdateTaskActivity(task_id, activity_id, count);
+			c->ShowClientTasks(client_target);
+		}
+		return;
 	}
-	c->Message(Chat::White, "Unable to interpret command. Type #task help");
-
 }

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -1682,22 +1682,27 @@ void ClientTaskState::ShowClientTaskInfoMessage(ClientTaskInformation *task, Cli
 
 	c->Message(Chat::White, "------------------------------------------------");
 	c->Message(
-		Chat::White, "# [%s] | task_id [%i] title [%s] slot (%i)",
-		Tasks::GetTaskTypeDescription(task_data->type).c_str(),
-		task->task_id,
-		task_data->title.c_str(),
-		task->slot
+		Chat::White,
+		fmt::format(
+			"Task {} | Title: {} ID: {} Type: {}",
+			task->slot,
+			task_data->title,
+			task->task_id,
+			Tasks::GetTaskTypeDescription(task_data->type)
+		).c_str()
 	);
 	c->Message(Chat::White, "------------------------------------------------");
 	c->Message(
 		Chat::White,
-		" -- Description [%s]\n",
-		task_data->description.c_str()
+		fmt::format(
+			"Description | {}",
+			task_data->description
+		).c_str()
 	);
 
 	for (int activity_id = 0; activity_id < task_manager->GetActivityCount(task->task_id); activity_id++) {
-		std::vector<std::string> update_increments = {"1", "5", "50"};
-		std::string              update_saylinks;
+		std::vector<std::string> update_increments = { "1", "5", "10", "20", "50" };
+		std::vector<std::string> update_saylinks;
 
 		for (auto &increment: update_increments) {
 			auto task_update_saylink = EQ::SayLinkEngine::GenerateQuestSaylink(
@@ -1711,17 +1716,19 @@ void ClientTaskState::ShowClientTaskInfoMessage(ClientTaskInformation *task, Cli
 				increment
 			);
 
-			update_saylinks += "[" + task_update_saylink + "] ";
+			update_saylinks.push_back(task_update_saylink);
 		}
 
 		c->Message(
 			Chat::White,
-			" --- Update %s activity_id [%i] done_count [%i] state [%d] (%s)",
-			update_saylinks.c_str(),
-			task->activity[activity_id].activity_id,
-			task->activity[activity_id].done_count,
-			task->activity[activity_id].activity_state,
-			Tasks::GetActivityStateDescription(task->activity[activity_id].activity_state).c_str()
+			fmt::format(
+				"Activity {} | Count: {} State: {} ({}) [{}]",
+				task->activity[activity_id].activity_id,
+				task->activity[activity_id].done_count,
+				task->activity[activity_id].activity_state,
+				Tasks::GetActivityStateDescription(task->activity[activity_id].activity_state),
+				implode(" | ", update_saylinks)
+			).c_str()
 		);
 	}
 }
@@ -1729,8 +1736,15 @@ void ClientTaskState::ShowClientTaskInfoMessage(ClientTaskInformation *task, Cli
 void ClientTaskState::ShowClientTasks(Client *client)
 {
 	client->Message(Chat::White, "------------------------------------------------");
-	client->Message(Chat::White, "# Task Information | Client [%s]", client->GetCleanName());
-//	client->Message(Chat::White, "------------------------------------------------");
+	client->Message(
+		Chat::White,
+		fmt::format(
+			"Task Information for {} ({})",
+			client->GetCleanName(),
+			client->GetID()
+		).c_str()
+	);
+
 	if (m_active_task.task_id != TASKSLOTEMPTY) {
 		ShowClientTaskInfoMessage(&m_active_task, client);
 	}


### PR DESCRIPTION
- Cleanup messages.
- Add #task uncomplete [Task ID] to uncomplete a completed task without having to go in the database manually.