### PR TITLE
[Bug Fix] Bard Instrument Mods should not affect spells that change model size.

### DIFF
--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -1474,6 +1474,8 @@ bool IsInstrumentModAppliedToSpellEffect(int32 spell_id, int effect)
 		case SE_SeeInvis:
 		case SE_Levitate:
 		case SE_WaterBreathing:
+		case SE_ModelSize:
+		case SE_ChangeHeight:
 			return false;
 		default:
 			return true;


### PR DESCRIPTION
Bard Instrument Mods should not affect spells that change model size. SPA 89 and SPA 298