### PR TITLE
Bug Fix for WorldServer::HandleMessage, CZUpdateType_NPC

### DIFF
--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -2587,7 +2587,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 			if (client) {
 				client->Signal(signal);
 			}
-		} else if (update_type = CZUpdateType_NPC) {
+		} else if (update_type == CZUpdateType_NPC) {
 			auto npc = entity_list.GetNPCByNPCTypeID(update_identifier);
 			if (npc) {
 				npc->SignalNPC(signal);


### PR DESCRIPTION
WorldServer::HandleMessage wasn't working correctly on else if statement thus preventing cross zone signals from working for quests using lua_cross_zone_signal_npc_by_npctype_id.