### PR TITLE
[Quest API] Add AddPlatinum(), GetCarriedPlatinum() and TakePlatinum() to Perl/Lua.

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -2170,16 +2170,6 @@ void Client::QuestReadBook(const char* text, uint8 type) {
 	}
 }
 
-void Client::SendClientMoneyUpdate(uint8 type,uint32 amount){
-	auto outapp = new EQApplicationPacket(OP_TradeMoneyUpdate, sizeof(TradeMoneyUpdate_Struct));
-	TradeMoneyUpdate_Struct* mus= (TradeMoneyUpdate_Struct*)outapp->pBuffer;
-	mus->amount=amount;
-	mus->trader=0;
-	mus->type=type;
-	QueuePacket(outapp);
-	safe_delete(outapp);
-}
-
 uint32 Client::GetCarriedPlatinum() {
 	return (
 		GetMoney(3, 0) +
@@ -2218,7 +2208,7 @@ bool Client::TakeMoneyFromPP(uint64 copper, bool update_client) {
 		} else {
 			m_pp.copper = player_copper;
 
-			if(update_client) {
+			if (update_client) {
 				SendMoneyUpdate();
 			}
 
@@ -2231,10 +2221,10 @@ bool Client::TakeMoneyFromPP(uint64 copper, bool update_client) {
 			copper = std::abs(silver);
 			m_pp.silver = 0;
 		} else {
-			m_pp.silver = silver/10;
-			m_pp.copper += (silver-(m_pp.silver*10));
+			m_pp.silver = silver / 10;
+			m_pp.copper += (silver - (m_pp.silver * 10));
 
-			if(update_client) {
+			if (update_client) {
 				SendMoneyUpdate();
 			}
 
@@ -2251,10 +2241,10 @@ bool Client::TakeMoneyFromPP(uint64 copper, bool update_client) {
 			m_pp.gold = gold / 100;
 			uint64 silver_test = (gold - (static_cast<uint64>(m_pp.gold) * 100)) / 10;
 			m_pp.silver += silver_test;
-			uint64 copper_test = (gold-(static_cast<uint64>(m_pp.gold) * 100 + silver_test * 10));
+			uint64 copper_test = (gold - (static_cast<uint64>(m_pp.gold) * 100 + silver_test * 10));
 			m_pp.copper += copper_test;
 
-			if(update_client) {
+			if (update_client) {
 				SendMoneyUpdate();
 			}
 
@@ -2274,7 +2264,7 @@ bool Client::TakeMoneyFromPP(uint64 copper, bool update_client) {
 		uint64 copper_test = (platinum - (static_cast<uint64>(m_pp.platinum) * 1000 + gold_test * 100 + silver_test * 10));
 		m_pp.copper = copper_test;
 
-		if(update_client) {
+		if (update_client) {
 			SendMoneyUpdate();
 		}
 
@@ -2296,9 +2286,9 @@ void Client::AddMoneyToPP(uint64 copper, bool update_client){
 
 	/* Add Amount of Platinum */
 	temporary_copper_two = temporary_copper / 1000;
-	int32 new_val = m_pp.platinum + temporary_copper_two;
+	int32 new_value = m_pp.platinum + temporary_copper_two;
 
-	if (new_val < 0) {
+	if (new_value < 0) {
 		m_pp.platinum = 0;
 	} else {
 		m_pp.platinum = m_pp.platinum + temporary_copper_two;
@@ -2308,9 +2298,9 @@ void Client::AddMoneyToPP(uint64 copper, bool update_client){
 
 	/* Add Amount of Gold */
 	temporary_copper_two = temporary_copper / 100;
-	new_val = m_pp.gold + temporary_copper_two;
+	new_value = m_pp.gold + temporary_copper_two;
 
-	if (new_val < 0) {
+	if (new_value < 0) {
 		m_pp.gold = 0;
 	} else {
 		m_pp.gold = m_pp.gold + temporary_copper_two;
@@ -2320,21 +2310,21 @@ void Client::AddMoneyToPP(uint64 copper, bool update_client){
 
 	/* Add Amount of Silver */
 	temporary_copper_two = temporary_copper / 10;
-	new_val = m_pp.silver + temporary_copper_two;
+	new_value = m_pp.silver + temporary_copper_two;
 
-	if (new_val < 0) {
+	if (new_value < 0) {
 		m_pp.silver = 0;
 	} else {
 		m_pp.silver = m_pp.silver + temporary_copper_two;
 	}
 
-	temporary_copper-=temporary_copper_two*10;
+	temporary_copper -= temporary_copper_two * 10;
 
 	/* Add Amount of Copper */
 	temporary_copper_two = temporary_copper;
-	new_val = m_pp.copper + temporary_copper_two;
+	new_value = m_pp.copper + temporary_copper_two;
 
-	if (new_val < 0) {
+	if (new_value < 0) {
 		m_pp.copper = 0;
 	} else {
 		m_pp.copper = m_pp.copper + temporary_copper_two;

--- a/zone/client.h
+++ b/zone/client.h
@@ -733,7 +733,6 @@ public:
 	void ReadBook(BookRequest_Struct *book);
 	void ReadBookByName(std::string book_name, uint8 book_type);
 	void QuestReadBook(const char* text, uint8 type);
-	void SendClientMoneyUpdate(uint8 type,uint32 amount);
 	void SendMoneyUpdate();
 	bool TakeMoneyFromPP(uint64 copper, bool update_client = false);
 	bool TakePlatinum(uint32 platinum, bool update_client = false);

--- a/zone/client.h
+++ b/zone/client.h
@@ -735,11 +735,14 @@ public:
 	void QuestReadBook(const char* text, uint8 type);
 	void SendClientMoneyUpdate(uint8 type,uint32 amount);
 	void SendMoneyUpdate();
-	bool TakeMoneyFromPP(uint64 copper, bool updateclient=false);
-	void AddMoneyToPP(uint64 copper,bool updateclient);
-	void AddMoneyToPP(uint32 copper, uint32 silver, uint32 gold,uint32 platinum,bool updateclient);
+	bool TakeMoneyFromPP(uint64 copper, bool update_client = false);
+	bool TakePlatinum(uint32 platinum, bool update_client = false);
+	void AddMoneyToPP(uint64 copper, bool update_client = false);
+	void AddMoneyToPP(uint32 copper, uint32 silver, uint32 gold, uint32 platinum, bool update_client = false);
+	void AddPlatinum(uint32 platinu, bool update_client = false);
 	bool HasMoney(uint64 copper);
 	uint64 GetCarriedMoney();
+	uint32 GetCarriedPlatinum();
 	uint64 GetAllMoney();
 	uint32 GetMoney(uint8 type, uint8 subtype);
 	int GetAccountAge();

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -3652,12 +3652,12 @@ void Client::Handle_OP_Begging(const EQApplicationPacket *app)
 		if (CurrentSkill < 50)
 		{
 			brs->Result = 4;	// Copper
-			AddMoneyToPP(brs->Amount, false);
+			AddMoneyToPP(brs->Amount);
 		}
 		else
 		{
 			brs->Result = 3;	// Silver
-			AddMoneyToPP(brs->Amount * 10, false);
+			AddMoneyToPP(brs->Amount * 10);
 		}
 
 	}
@@ -13295,7 +13295,7 @@ void Client::Handle_OP_ShopPlayerSell(const EQApplicationPacket *app)
 		}
 	}
 
-	AddMoneyToPP(price, false);
+	AddMoneyToPP(price);
 
 	if (inst->IsStackable() || inst->IsCharged())
 	{

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -1062,7 +1062,7 @@ void Corpse::MakeLootRequestPackets(Client* client, const EQApplicationPacket* a
 			d->silver = GetSilver();
 			d->gold = GetGold();
 			d->platinum = GetPlatinum();
-			client->AddMoneyToPP(GetCopper(), GetSilver(), GetGold(), GetPlatinum(), false);
+			client->AddMoneyToPP(GetCopper(), GetSilver(), GetGold(), GetPlatinum());
 		}
 
 		RemoveCash();

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -490,6 +490,10 @@ bool Lua_Client::TakeMoneyFromPP(uint64 copper, bool update_client) {
 	return self->TakeMoneyFromPP(copper, update_client);
 }
 
+void Lua_Client::AddMoneyToPP(uint32 copper, uint32 silver, uint32 gold, uint32 platinum) {
+	Lua_Safe_Call_Void();
+	self->AddMoneyToPP(copper, silver, gold, platinum);
+}
 void Lua_Client::AddMoneyToPP(uint32 copper, uint32 silver, uint32 gold, uint32 platinum, bool update_client) {
 	Lua_Safe_Call_Void();
 	self->AddMoneyToPP(copper, silver, gold, platinum, update_client);
@@ -2397,6 +2401,31 @@ void Lua_Client::AddItem(luabind::object item_table) {
 	);
 }
 
+void Lua_Client::AddPlatinum(uint32 platinum) {
+	Lua_Safe_Call_Void();
+	self->AddPlatinum(platinum);
+}
+
+void Lua_Client::AddPlatinum(uint32 platinum, bool update_client) {
+	Lua_Safe_Call_Void();
+	self->AddPlatinum(platinum, update_client);
+}
+
+uint32 Lua_Client::GetCarriedPlatinum() {
+	Lua_Safe_Call_Int();
+	return self->GetCarriedPlatinum();
+}
+
+bool Lua_Client::TakePlatinum(uint32 platinum) {
+	Lua_Safe_Call_Bool();
+	return self->TakePlatinum(platinum);
+}
+
+bool Lua_Client::TakePlatinum(uint32 platinum, bool update_client) {
+	Lua_Safe_Call_Bool();
+	return self->TakePlatinum(platinum, update_client);
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 	.def(luabind::constructor<>())
@@ -2418,7 +2447,10 @@ luabind::scope lua_register_client() {
 	.def("AddLevelBasedExp", (void(Lua_Client::*)(int))&Lua_Client::AddLevelBasedExp)
 	.def("AddLevelBasedExp", (void(Lua_Client::*)(int,int))&Lua_Client::AddLevelBasedExp)
 	.def("AddLevelBasedExp", (void(Lua_Client::*)(int,int,bool))&Lua_Client::AddLevelBasedExp)
+	.def("AddMoneyToPP", (void(Lua_Client::*)(uint32,uint32,uint32,uint32))&Lua_Client::AddMoneyToPP)
 	.def("AddMoneyToPP", (void(Lua_Client::*)(uint32,uint32,uint32,uint32,bool))&Lua_Client::AddMoneyToPP)
+	.def("AddPlatinum", (void(Lua_Client::*)(uint32))&Lua_Client::AddPlatinum)
+	.def("AddPlatinum", (void(Lua_Client::*)(uint32,bool))&Lua_Client::AddPlatinum)
 	.def("AddPVPPoints", (void(Lua_Client::*)(uint32))&Lua_Client::AddPVPPoints)
 	.def("AddSkill", (void(Lua_Client::*)(int,int))&Lua_Client::AddSkill)
 	.def("Admin", (int(Lua_Client::*)(void))&Lua_Client::Admin)
@@ -2506,6 +2538,7 @@ luabind::scope lua_register_client() {
 	.def("GetBindZoneID", (uint32(Lua_Client::*)(int))&Lua_Client::GetBindZoneID)
 	.def("GetBindZoneID", (uint32(Lua_Client::*)(void))&Lua_Client::GetBindZoneID)
 	.def("GetCarriedMoney", (uint64(Lua_Client::*)(void))&Lua_Client::GetCarriedMoney)
+	.def("GetCarriedPlatinum", (uint32(Lua_Client::*)(void))&Lua_Client::GetCarriedPlatinum)
 	.def("GetCharacterFactionLevel", (int(Lua_Client::*)(int))&Lua_Client::GetCharacterFactionLevel)
 	.def("GetClassBitmask", (int(Lua_Client::*)(void))&Lua_Client::GetClassBitmask)
 	.def("GetClientMaxLevel", (int(Lua_Client::*)(void))&Lua_Client::GetClientMaxLevel)
@@ -2769,6 +2802,8 @@ luabind::scope lua_register_client() {
 	.def("TGB", (bool(Lua_Client::*)(void))&Lua_Client::TGB)
 	.def("TakeMoneyFromPP", (bool(Lua_Client::*)(uint64))&Lua_Client::TakeMoneyFromPP)
 	.def("TakeMoneyFromPP", (bool(Lua_Client::*)(uint64,bool))&Lua_Client::TakeMoneyFromPP)
+	.def("TakePlatinum", (bool(Lua_Client::*)(uint32))&Lua_Client::TakePlatinum)
+	.def("TakePlatinum", (bool(Lua_Client::*)(uint32,bool))&Lua_Client::TakePlatinum)
 	.def("Thirsty", (bool(Lua_Client::*)(void))&Lua_Client::Thirsty)
 	.def("TrainDisc", (void(Lua_Client::*)(int))&Lua_Client::TrainDisc)
 	.def("TrainDiscBySpellID", (void(Lua_Client::*)(int32))&Lua_Client::TrainDiscBySpellID)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -130,9 +130,14 @@ public:
 	int GuildRank();
 	uint32 GuildID();
 	int GetFace();
+	void AddMoneyToPP(uint32 copper, uint32 silver, uint32 gold, uint32 platinum);
+	void AddMoneyToPP(uint32 copper, uint32 silver, uint32 gold, uint32 platinum, bool update_client);
+	void AddPlatinum(uint32 platinum);
+	void AddPlatinum(uint32 platinum, bool update_client);
 	bool TakeMoneyFromPP(uint64 copper);
 	bool TakeMoneyFromPP(uint64 copper, bool update_client);
-	void AddMoneyToPP(uint32 copper, uint32 silver, uint32 gold, uint32 platinum, bool update_client);
+	bool TakePlatinum(uint32 platinum);
+	bool TakePlatinum(uint32 platinum, bool update_client);
 	bool TGB();
 	int GetSkillPoints();
 	void SetSkillPoints(int skill);
@@ -328,6 +333,7 @@ public:
 	void UnFreeze();
 	int GetAggroCount();
 	uint64 GetCarriedMoney();
+	uint32 GetCarriedPlatinum();
 	uint64 GetAllMoney();
 	uint32 GetMoney(uint8 type, uint8 subtype);
 	void OpenLFGuildWindow();

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -2800,7 +2800,7 @@ void Client::SellToBuyer(const EQApplicationPacket *app) {
 
 	Buyer->TakeMoneyFromPP(Quantity * Price);
 
-	AddMoneyToPP(Quantity * Price, false);
+	AddMoneyToPP(Quantity * Price);
 
 	if(RuleB(Bazaar, AuditTrail))
 		BazaarAuditTrail(GetName(), Buyer->GetName(), ItemName, Quantity, Quantity * Price, 1);


### PR DESCRIPTION
- Allows for easier NPC interactions.
- GetCarriedPlatinum() adds together all currencies in inventory based on conversion amounts so it works easily with removals/checks.
- Add $client->AddPlatinum(platinum, update_client) to Perl.
- Add $client->GetCarriedPlatinum() to Perl.
- Add $client->TakePlatinum(platinum, update_client) to Perl.
- Add client:AddPlatinum(platinum, update_client) to Lua.
- Add client:GetCarriedPlatinum() to Lua.
- Add client:TakePlatinum(platinum, update_client) to Lua.
- Remove unused Client::SendClientMoneyUpdate.