### PR TITLE
[Bug Fix] Update to target types Beam and Cone to ignore invalid targets.

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -5457,6 +5457,15 @@ void EntityList::GetTargetsForConeArea(Mob *start, float min_radius, float radiu
 			++it;
 			continue;
 		}
+		if (ptr->IsClient() && !ptr->CastToClient()->ClientFinishedLoading()) {
+			++it;
+			continue;
+		}
+		if (ptr->IsAura() || ptr->IsTrap()) {
+			++it;
+			continue;
+		}
+
 		float x_diff = ptr->GetX() - start->GetX();
 		float y_diff = ptr->GetY() - start->GetY();
 		float z_diff = ptr->GetZ() - start->GetZ();

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -6372,6 +6372,23 @@ void Mob::BeamDirectional(uint16 spell_id, int16 resist_adjust)
 			}
 		}
 
+		if (!beneficial_targets) {
+			if (!IsAttackAllowed((*iter), true)) {
+				++iter;
+				continue;
+			}
+		}
+		else {
+			if (IsAttackAllowed((*iter), true)) {
+				++iter;
+				continue;
+			}
+			if (CheckAggro((*iter))) {
+				++iter;
+				continue;
+			}
+		}
+
 		//# shortest distance from line to target point
 		float d = std::abs((*iter)->GetY() - m * (*iter)->GetX() - b) / sqrt(m * m + 1);
 
@@ -6444,6 +6461,23 @@ void Mob::ConeDirectional(uint16 spell_id, int16 resist_adjust)
 					++iter;
 					continue;
 				}
+			}
+		}
+
+		if (!beneficial_targets) {
+			if (!IsAttackAllowed((*iter), true)) {
+				++iter;
+				continue;
+			}
+		}
+		else {
+			if (IsAttackAllowed((*iter), true)) {
+				++iter;
+				continue;
+			}
+			if (CheckAggro((*iter))) {
+				++iter;
+				continue;
 			}
 		}
 


### PR DESCRIPTION
AOE target types for Beam and Cone type spells were attempting to hit targets incorrectly like pets and aura's.