### PR TITLE
[Regen] Implement Per Second HP Regen for NPCs

### DIFF
--- a/common/version.h
+++ b/common/version.h
@@ -34,7 +34,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9178
+#define CURRENT_BINARY_DATABASE_VERSION 9179
 
 #ifdef BOTS
 	#define CURRENT_BINARY_BOTS_DATABASE_VERSION 9028

--- a/utils/sql/db_update_manifest.txt
+++ b/utils/sql/db_update_manifest.txt
@@ -432,6 +432,7 @@
 9176|2022_01_10_checksum_verification.sql|SHOW COLUMNS FROM `account` LIKE 'crc_eqgame'|empty|
 9177|2022_03_06_table_structure_changes.sql|SHOW COLUMNS FROM `pets` LIKE 'id'|empty|
 9178|2022_03_07_saylink_collation.sql|SELECT * FROM db_version WHERE version >= 9178|empty|
+9179|2022_04_30_hp_regen_per_second.sql|SHOW COLUMNS FROM `npc_types` LIKE 'hp_regen_per_second'|empty|
 
 # Upgrade conditions:
 # 	This won't be needed after this system is implemented, but it is used database that are not

--- a/utils/sql/git/required/2022_04_30_hp_regen_per_second.sql
+++ b/utils/sql/git/required/2022_04_30_hp_regen_per_second.sql
@@ -1,0 +1,1 @@
+ALTER TABLE npc_types ADD COLUMN hp_regen_per_second bigint(11) DEFAULT 0 AFTER hp_regen_rate;

--- a/zone/gm_commands/npcedit.cpp
+++ b/zone/gm_commands/npcedit.cpp
@@ -28,6 +28,7 @@ void command_npcedit(Client *c, const Seperator *sep)
 		c->Message(Chat::White, "#npcedit herosforgemodel - Sets an NPC's Hero's Forge Model");
 		c->Message(Chat::White, "#npcedit size - Sets an NPC's Size");
 		c->Message(Chat::White, "#npcedit hpregen - Sets an NPC's Hitpoints Regeneration Rate Per Tick");
+		c->Message(Chat::White, "#npcedit hp_regen_per_second - Sets an NPC's HP regeneration per second");
 		c->Message(Chat::White, "#npcedit manaregen - Sets an NPC's Mana Regeneration Rate Per Tick");
 		c->Message(Chat::White, "#npcedit loottable - Sets an NPC's Loottable ID");
 		c->Message(Chat::White, "#npcedit merchantid - Sets an NPC's Merchant ID");
@@ -301,6 +302,23 @@ void command_npcedit(Client *c, const Seperator *sep)
 			fmt::format("NPC ID {} now regenerates {} Health per Tick.", npc_id, atoi(sep->arg[2])).c_str());
 		std::string query = fmt::format(
 			"UPDATE npc_types SET hp_regen_rate = {} WHERE id = {}",
+			atoi(sep->arg[2]),
+			npc_id
+		);
+		content_db.QueryDatabase(query);
+		return;
+	}
+
+	if (strcasecmp(sep->arg[1], "hp_regen_per_second") == 0) {
+		c->Message(
+			Chat::Yellow,
+			fmt::format(
+				"NPC ID {} now regenerates {} HP per second.",
+				npc_id,
+				atoi(sep->arg[2])).c_str()
+		);
+		std::string query = fmt::format(
+			"UPDATE npc_types SET hp_regen_per_second = {} WHERE id = {}",
 			atoi(sep->arg[2]),
 			npc_id
 		);

--- a/zone/merc.cpp
+++ b/zone/merc.cpp
@@ -4880,6 +4880,7 @@ void Merc::UpdateMercStats(Client *c, bool setmax)
 			max_end = npc_type->max_hp;  // Hack since Endurance does not exist for NPCType yet
 			base_end = npc_type->max_hp; // Hack since Endurance does not exist for NPCType yet
 			hp_regen = npc_type->hp_regen;
+			hp_regen_per_second = npc_type->hp_regen_per_second;
 			mana_regen = npc_type->mana_regen;
 			max_dmg = npc_type->max_dmg;
 			min_dmg = npc_type->min_dmg;

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -101,6 +101,7 @@ Mob::Mob(
 	attack_timer(2000),
 	attack_dw_timer(2000),
 	ranged_timer(2000),
+	hp_regen_per_second_timer(1000),
 	tic_timer(6000),
 	mana_timer(2000),
 	spellend_timer(0),
@@ -603,7 +604,7 @@ void Mob::CalcInvisibleLevel()
 		SetInvisible(Invisibility::Invisible, true);
 		return;
 	}
-	
+
 	if (is_invisible && !invisible) {
 		SetInvisible(invisible, true);
 		return;
@@ -624,7 +625,7 @@ void Mob::SetInvisible(uint8 state, bool set_on_bonus_calc)
 	}
 	else {
 		/*
-			if your setting invisible from a script, or escape/fading memories effect then 
+			if your setting invisible from a script, or escape/fading memories effect then
 			we use the internal invis variable which allows invisible without a buff on mob.
 		*/
 		if (!set_on_bonus_calc) {
@@ -644,10 +645,10 @@ void Mob::SetInvisible(uint8 state, bool set_on_bonus_calc)
 	}
 }
 
-void Mob::ZeroInvisibleVars(uint8 invisible_type) 
+void Mob::ZeroInvisibleVars(uint8 invisible_type)
 {
 	switch (invisible_type) {
-		
+
 		case T_INVISIBLE:
 			invisible = 0;
 			nobuff_invisible = 0;
@@ -1791,13 +1792,13 @@ void Mob::ShowStats(Client* client)
 				target_name,
 				(
 					!target_last_name.empty() ?
-					fmt::format(" ({})", target_last_name) : 
+					fmt::format(" ({})", target_last_name) :
 					""
 				),
 				target->GetLevel()
 			).c_str()
 		);
-		
+
 		// Race / Class / Gender
 		client->Message(
 			Chat::White,
@@ -1879,7 +1880,7 @@ void Mob::ShowStats(Client* client)
 				target->GetHairColor()
 			).c_str()
 		);
-		
+
 		// Beard
 		client->Message(
 			Chat::White,
@@ -1912,7 +1913,7 @@ void Mob::ShowStats(Client* client)
 				target->GetHelmTexture()
 			).c_str()
 		);
-		
+
 		if (
 			target->GetArmTexture() ||
 			target->GetBracerTexture() ||
@@ -1928,7 +1929,7 @@ void Mob::ShowStats(Client* client)
 				).c_str()
 			);
 		}
-		
+
 		if (
 			target->GetFeetTexture() ||
 			target->GetLegTexture()
@@ -2152,7 +2153,7 @@ void Mob::ShowStats(Client* client)
 				target->GetINT()
 			).c_str()
 		);
-		
+
 		client->Message(
 			Chat::White,
 			fmt::format(
@@ -2182,7 +2183,7 @@ void Mob::ShowStats(Client* client)
 					target->GetCharmedAvoidance()
 				).c_str()
 			);
-			
+
 			client->Message(
 				Chat::White,
 				fmt::format(
@@ -2324,7 +2325,7 @@ void Mob::ShowStats(Client* client)
 					(target->GetProximityMaxX() - target->GetProximityMinX())
 				).c_str()
 			);
-			
+
 			client->Message(
 				Chat::White,
 				fmt::format(
@@ -2334,7 +2335,7 @@ void Mob::ShowStats(Client* client)
 					(target->GetProximityMaxY() - target->GetProximityMinY())
 				).c_str()
 			);
-			
+
 			client->Message(
 				Chat::White,
 				fmt::format(
@@ -2932,11 +2933,11 @@ void Mob::SendStunAppearance()
 	safe_delete(outapp);
 }
 
-void Mob::SendAppearanceEffect(uint32 parm1, uint32 parm2, uint32 parm3, uint32 parm4, uint32 parm5, Client *specific_target, 
-	uint32 value1slot, uint32 value1ground, uint32 value2slot, uint32 value2ground, uint32 value3slot, uint32 value3ground, 
+void Mob::SendAppearanceEffect(uint32 parm1, uint32 parm2, uint32 parm3, uint32 parm4, uint32 parm5, Client *specific_target,
+	uint32 value1slot, uint32 value1ground, uint32 value2slot, uint32 value2ground, uint32 value3slot, uint32 value3ground,
 	uint32 value4slot, uint32 value4ground, uint32 value5slot, uint32 value5ground){
 	auto outapp = new EQApplicationPacket(OP_LevelAppearance, sizeof(LevelAppearance_Struct));
-	
+
 	/* Location of the effect from value#slot, this is removed upon mob death/despawn.
 		0 = pelvis1
 		1 = pelvis2
@@ -3014,7 +3015,7 @@ void Mob::SendAppearanceEffect(uint32 parm1, uint32 parm2, uint32 parm3, uint32 
 	safe_delete(outapp);
 }
 
-void Mob::SetAppearenceEffects(int32 slot, int32 value) 
+void Mob::SetAppearenceEffects(int32 slot, int32 value)
 {
 	for (int i = 0; i < MAX_APPEARANCE_EFFECTS; i++) {
 		if (!appearance_effects_id[i]) {
@@ -3032,7 +3033,7 @@ void Mob::GetAppearenceEffects()
 		Message(Chat::Red, "No Appearance Effects exist on this mob");
 		return;
 	}
-	
+
 	for (int i = 0; i < MAX_APPEARANCE_EFFECTS; i++) {
 		Message(Chat::Red, "ID: %i :: App Effect ID %i :: Slot %i", i, appearance_effects_id[i], appearance_effects_slot[i]);
 	}
@@ -4593,7 +4594,7 @@ int32 Mob::GetVulnerability(Mob *caster, uint32 spell_id, uint32 ticsremaining, 
 
 	fc_spell_vulnerability_mod = GetFocusEffect(focusSpellVulnerability, spell_id, caster, from_buff_tic);
 	fc_spell_damage_pct_incomingPC_mod = GetFocusEffect(focusFcSpellDamagePctIncomingPC, spell_id, caster, from_buff_tic);
-	
+
 	total_mod = fc_spell_vulnerability_mod + fc_spell_damage_pct_incomingPC_mod;
 
 	//Don't let focus derived mods reduce past 99% mitigation. Quest related can, and for custom functionality if negative will give a healing affect instead of damage.
@@ -6190,7 +6191,7 @@ uint8 Mob::GetSeeInvisibleLevelFromNPCStat(uint16 in_see_invis)
 	if (in_see_invis == 1) {
 		return 1;
 	}
-	
+
 	//random chance to apply standard level 1 see invs
 	if (in_see_invis > 1 && in_see_invis < 100) {
 		if (zone->random.Int(0, 99) < in_see_invis) {
@@ -6550,7 +6551,7 @@ bool Mob::ShieldAbility(uint32 target_id, int shielder_max_distance, int shield_
 
 	if (shield_target->CalculateDistance(GetX(), GetY(), GetZ()) > static_cast<float>(shielder_max_distance)) {
 		MessageString(Chat::Blue, TARGET_TOO_FAR);
-		return false; 
+		return false;
 	}
 
 	entity_list.MessageCloseString(this, false, 100, 0, START_SHIELDING, GetCleanName(), shield_target->GetCleanName());
@@ -6617,7 +6618,7 @@ void Mob::ShieldAbilityClearVariables()
 }
 
 void Mob::SetFeigned(bool in_feigned) {
-	
+
 	if (in_feigned)	{
 		if (IsClient()) {
 			if (RuleB(Character, FeignKillsPet)){

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -96,7 +96,8 @@ Mob::Mob(
 	uint8 in_legtexture,
 	uint8 in_feettexture,
 	uint16 in_usemodel,
-	bool in_always_aggro
+	bool in_always_aggro,
+	int64 in_hp_regen_per_second
 ) :
 	attack_timer(2000),
 	attack_dw_timer(2000),
@@ -250,37 +251,38 @@ Mob::Mob(
 		aa_title = 0xFF;
 	}
 
-	AC                = in_ac;
-	ATK               = in_atk;
-	STR               = in_str;
-	STA               = in_sta;
-	DEX               = in_dex;
-	AGI               = in_agi;
-	INT               = in_int;
-	WIS               = in_wis;
-	CHA               = in_cha;
-	MR                = CR = FR = DR = PR = Corrup = PhR = 0;
-	ExtraHaste        = 0;
-	bEnraged          = false;
-	current_mana      = 0;
-	max_mana          = 0;
-	hp_regen          = in_hp_regen;
-	mana_regen        = in_mana_regen;
-	ooc_regen         = RuleI(NPC, OOCRegen); //default Out of Combat Regen
-	maxlevel          = in_maxlevel;
-	scalerate         = in_scalerate;
-	invisible         = 0;
-	invisible_undead  = 0;
-	invisible_animals = 0;
-	sneaking          = false;
-	hidden            = false;
-	improved_hidden   = false;
-	invulnerable      = false;
-	IsFullHP          = (current_hp == max_hp);
-	qglobal           = 0;
-	spawned           = false;
-	rare_spawn        = false;
-	always_aggro      = in_always_aggro;
+	AC                  = in_ac;
+	ATK                 = in_atk;
+	STR                 = in_str;
+	STA                 = in_sta;
+	DEX                 = in_dex;
+	AGI                 = in_agi;
+	INT                 = in_int;
+	WIS                 = in_wis;
+	CHA                 = in_cha;
+	MR                  = CR = FR = DR = PR = Corrup = PhR = 0;
+	ExtraHaste          = 0;
+	bEnraged            = false;
+	current_mana        = 0;
+	max_mana            = 0;
+	hp_regen            = in_hp_regen;
+	hp_regen_per_second = in_hp_regen_per_second;
+	mana_regen          = in_mana_regen;
+	ooc_regen           = RuleI(NPC, OOCRegen); //default Out of Combat Regen
+	maxlevel            = in_maxlevel;
+	scalerate           = in_scalerate;
+	invisible           = 0;
+	invisible_undead    = 0;
+	invisible_animals   = 0;
+	sneaking            = false;
+	hidden              = false;
+	improved_hidden     = false;
+	invulnerable        = false;
+	IsFullHP            = (current_hp == max_hp);
+	qglobal             = 0;
+	spawned             = false;
+	rare_spawn          = false;
+	always_aggro        = in_always_aggro;
 
 	InitializeBuffSlots();
 

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -162,7 +162,8 @@ public:
 		uint8 in_legtexture,
 		uint8 in_feettexture,
 		uint16 in_usemodel,
-		bool in_always_aggros_foes
+		bool in_always_aggros_foes,
+		int64 in_hp_regen_per_second = 0
 	);
 	virtual ~Mob();
 

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -245,11 +245,11 @@ public:
 	//Invisible
 	bool IsInvisible(Mob* other = 0) const;
 	void SetInvisible(uint8 state, bool set_on_bonus_calc = false);
-	
+
 	void CalcSeeInvisibleLevel();
 	void CalcInvisibleLevel();
 	void ZeroInvisibleVars(uint8 invisible_type);
-	
+
 	inline uint8 GetSeeInvisibleLevelFromNPCStat(uint16 in_see_invis);
 
 	void BreakInvisibleSpells();
@@ -269,7 +269,7 @@ public:
 	inline void SetSeeInvisibleUndead(uint8 val) { see_invis_undead = val; }
 
 	uint32 tmHidden; // timestamp of hide, only valid while hidden == true
-	uint8 invisible, nobuff_invisible, invisible_undead, invisible_animals; 
+	uint8 invisible, nobuff_invisible, invisible_undead, invisible_animals;
 	uint8 see_invis, innate_see_invis, see_invis_undead; //TODO: do we need a see_invis_animal ?
 
 	bool sneaking, hidden, improved_hidden;
@@ -298,7 +298,7 @@ public:
 	void ChangeSize(float in_size, bool bNoRestriction = false);
 	void DoAnim(const int animnum, int type=0, bool ackreq = true, eqFilterType filter = FilterNone);
 	void ProjectileAnimation(Mob* to, int item_id, bool IsArrow = false, float speed = 0, float angle = 0, float tilt = 0, float arc = 0, const char *IDFile = nullptr, EQ::skills::SkillType skillInUse = EQ::skills::SkillArchery);
-	void SendAppearanceEffect(uint32 parm1, uint32 parm2, uint32 parm3, uint32 parm4, uint32 parm5, Client *specific_target=nullptr, uint32 value1slot = 1, uint32 value1ground = 1, uint32 value2slot = 1, uint32 value2ground = 1, 
+	void SendAppearanceEffect(uint32 parm1, uint32 parm2, uint32 parm3, uint32 parm4, uint32 parm5, Client *specific_target=nullptr, uint32 value1slot = 1, uint32 value1ground = 1, uint32 value2slot = 1, uint32 value2ground = 1,
 		uint32 value3slot = 1, uint32 value3ground = 1, uint32 value4slot = 1, uint32 value4ground = 1, uint32 value5slot = 1, uint32 value5ground = 1);
 	void SendLevelAppearance();
 	void SendStunAppearance();
@@ -380,13 +380,13 @@ public:
 	int16 GetItemSlotToConsumeCharge(int32 spell_id, uint32 inventory_slot);
 	bool CheckItemRaceClassDietyRestrictionsOnCast(uint32 inventory_slot);
 	bool IsFromTriggeredSpell(EQ::spells::CastingSlot slot, uint32 item_slot = 0xFFFFFFFF);
-	
-	//Bard 
+
+	//Bard
 	bool ApplyBardPulse(int32 spell_id, Mob *spell_target, EQ::spells::CastingSlot slot);
 	bool IsActiveBardSong(int32 spell_id);
 	bool HasActiveSong() const { return(bardsong != 0); }
 	void ZeroBardPulseVars();
-	void DoBardCastingFromItemClick(bool is_casting_bard_song, uint32 cast_time, int32 spell_id, uint16 target_id, EQ::spells::CastingSlot slot, uint32 item_slot, 
+	void DoBardCastingFromItemClick(bool is_casting_bard_song, uint32 cast_time, int32 spell_id, uint16 target_id, EQ::spells::CastingSlot slot, uint32 item_slot,
 		uint32 recast_type , uint32 recast_delay);
 	bool UseBardSpellLogic(uint16 spell_id = 0xffff, int slot = -1);
 
@@ -1424,6 +1424,7 @@ protected:
 	int32 current_mana;
 	int32 max_mana;
 	int32 hp_regen;
+	int64 hp_regen_per_second;
 	int32 mana_regen;
 	int32 ooc_regen;
 	uint8 maxlevel;
@@ -1542,6 +1543,7 @@ protected:
 	int attack_delay; //delay between attacks in 10ths of seconds
 	bool always_aggro;
 	int16 slow_mitigation; // Allows for a slow mitigation (100 = 100%, 50% = 50%)
+	Timer hp_regen_per_second_timer;
 	Timer tic_timer;
 	Timer mana_timer;
 	int32 dw_same_delay;
@@ -1558,7 +1560,7 @@ protected:
 
 	int32 appearance_effects_id[MAX_APPEARANCE_EFFECTS];
 	int32 appearance_effects_slot[MAX_APPEARANCE_EFFECTS];
-	
+
 	int queue_wearchange_slot;
 
 	Timer shield_timer;
@@ -1766,7 +1768,7 @@ protected:
 
 private:
 	Mob* target;
-	
+
 
 #ifdef BOTS
 	std::shared_ptr<HealRotation> m_target_of_heal_rotation;

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -870,6 +870,12 @@ bool NPC::Process()
 		}
 	}
 
+	if (hp_regen_per_second > 0 && hp_regen_per_second_timer.Check()) {
+		if (GetHP() < GetMaxHP()) {
+			SetHP(GetHP() + hp_regen_per_second);
+		}
+	}
+
 	if (tic_timer.Check()) {
 		parse->EventNPC(EVENT_TICK, this, nullptr, "", 0);
 		BuffProcess();
@@ -2392,9 +2398,9 @@ void NPC::PetOnSpawn(NewSpawn_Struct* ns)
 				if (tmp_lastname.size() < sizeof(ns->spawn.lastName))
 					strn0cpy(ns->spawn.lastName, tmp_lastname.c_str(), sizeof(ns->spawn.lastName));
 			}
-			else 
+			else
 			{
-				if (entity_list.GetNPCByID(GetOwnerID())) 
+				if (entity_list.GetNPCByID(GetOwnerID()))
 				{
 					SetPetOwnerNPC(true);
 				}
@@ -3666,7 +3672,7 @@ std::vector<int> NPC::GetLootList() {
 		if (std::find(npc_items.begin(), npc_items.end(), loot_item->item_id) != npc_items.end()) {
 			continue;
 		}
-		
+
 		npc_items.push_back(loot_item->item_id);
 	}
 	return npc_items;

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -2600,6 +2600,10 @@ void NPC::ModifyNPCStat(const char *identifier, const char *new_value)
 		hp_regen = atoi(val.c_str());
 		return;
 	}
+	else if (id == "hp_regen_per_second") {
+		hp_regen_per_second = strtoll(val.c_str(), nullptr, 10);
+		return;
+	}
 	else if (id == "mana_regen") {
 		mana_regen = atoi(val.c_str());
 		return;
@@ -2746,6 +2750,9 @@ float NPC::GetNPCStat(const char *identifier)
 	}
 	else if (id == "hp_regen") {
 		return hp_regen;
+	}
+	else if (id == "hp_regen_per_second") {
+		return hp_regen_per_second;
 	}
 	else if (id == "mana_regen") {
 		return mana_regen;

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -114,7 +114,8 @@ NPC::NPC(const NPCType *npc_type_data, Spawn2 *in_respawn, const glm::vec4 &posi
 	npc_type_data->legtexture,
 	npc_type_data->feettexture,
 	npc_type_data->use_model,
-	npc_type_data->always_aggro
+	npc_type_data->always_aggro,
+	npc_type_data->hp_regen_per_second
 ),
 	  attacked_timer(CombatEventTimer_expire),
 	  swarm_timer(100),

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -2476,7 +2476,7 @@ const NPCType *ZoneDatabase::LoadNPCTypesData(uint32 npc_type_id, bool bulk_load
 		"npc_types.model, "
 		"npc_types.flymode, "
 		"npc_types.always_aggro, "
-		"npc_types.exp_mod, ",
+		"npc_types.exp_mod, "
 		"npc_types.hp_regen_per_second "
 
 		"FROM npc_types %s",
@@ -2551,7 +2551,6 @@ const NPCType *ZoneDatabase::LoadNPCTypesData(uint32 npc_type_id, bool bulk_load
 		temp_npctype_data->findable            = atoi(row[45]) == 0 ? false : true;
 		temp_npctype_data->trackable           = atoi(row[46]) == 0 ? false : true;
 		temp_npctype_data->hp_regen            = atoi(row[47]);
-		temp_npctype_data->hp_regen_per_second = atoi(row[114]);
 		temp_npctype_data->mana_regen          = atoi(row[48]);
 
 		// set default value for aggroradius
@@ -2676,14 +2675,14 @@ const NPCType *ZoneDatabase::LoadNPCTypesData(uint32 npc_type_id, bool bulk_load
 		temp_npctype_data->charm_avoidance_rating = atoi(row[105]);
 		temp_npctype_data->charm_atk              = atoi(row[106]);
 
-		temp_npctype_data->skip_global_loot 	= atoi(row[107]) != 0;
-		temp_npctype_data->rare_spawn       	= atoi(row[108]) != 0;
-		temp_npctype_data->stuck_behavior   	= atoi(row[109]);
-		temp_npctype_data->use_model        	= atoi(row[110]);
-		temp_npctype_data->flymode          	= atoi(row[111]);
-		temp_npctype_data->always_aggro	        = atoi(row[112]);
-		temp_npctype_data->exp_mod              = atoi(row[113]);
-		// 114 is used by hp_regen_per_second
+		temp_npctype_data->skip_global_loot    = atoi(row[107]) != 0;
+		temp_npctype_data->rare_spawn          = atoi(row[108]) != 0;
+		temp_npctype_data->stuck_behavior      = atoi(row[109]);
+		temp_npctype_data->use_model           = atoi(row[110]);
+		temp_npctype_data->flymode             = atoi(row[111]);
+		temp_npctype_data->always_aggro        = atoi(row[112]);
+		temp_npctype_data->exp_mod             = atoi(row[113]);
+		temp_npctype_data->hp_regen_per_second = strtoll(row[114], nullptr, 10);
 
 		temp_npctype_data->skip_auto_scale = false; // hardcoded here for now
 

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -2476,7 +2476,9 @@ const NPCType *ZoneDatabase::LoadNPCTypesData(uint32 npc_type_id, bool bulk_load
 		"npc_types.model, "
 		"npc_types.flymode, "
 		"npc_types.always_aggro, "
-		"npc_types.exp_mod "
+		"npc_types.exp_mod, ",
+		"npc_types.hp_regen_per_second "
+
 		"FROM npc_types %s",
 		where_condition.c_str()
 	);
@@ -2542,14 +2544,15 @@ const NPCType *ZoneDatabase::LoadNPCTypesData(uint32 npc_type_id, bool bulk_load
 		temp_npctype_data->d_melee_texture1      = atoi(row[38]);
 		temp_npctype_data->d_melee_texture2      = atoi(row[39]);
 		strn0cpy(temp_npctype_data->ammo_idfile, row[40], 30);
-		temp_npctype_data->prim_melee_type = atoi(row[41]);
-		temp_npctype_data->sec_melee_type  = atoi(row[42]);
-		temp_npctype_data->ranged_type     = atoi(row[43]);
-		temp_npctype_data->runspeed        = atof(row[44]);
-		temp_npctype_data->findable        = atoi(row[45]) == 0 ? false : true;
-		temp_npctype_data->trackable       = atoi(row[46]) == 0 ? false : true;
-		temp_npctype_data->hp_regen        = atoi(row[47]);
-		temp_npctype_data->mana_regen      = atoi(row[48]);
+		temp_npctype_data->prim_melee_type     = atoi(row[41]);
+		temp_npctype_data->sec_melee_type      = atoi(row[42]);
+		temp_npctype_data->ranged_type         = atoi(row[43]);
+		temp_npctype_data->runspeed            = atof(row[44]);
+		temp_npctype_data->findable            = atoi(row[45]) == 0 ? false : true;
+		temp_npctype_data->trackable           = atoi(row[46]) == 0 ? false : true;
+		temp_npctype_data->hp_regen            = atoi(row[47]);
+		temp_npctype_data->hp_regen_per_second = atoi(row[114]);
+		temp_npctype_data->mana_regen          = atoi(row[48]);
 
 		// set default value for aggroradius
 		temp_npctype_data->aggroradius = (int32) atoi(row[49]);
@@ -2680,6 +2683,7 @@ const NPCType *ZoneDatabase::LoadNPCTypesData(uint32 npc_type_id, bool bulk_load
 		temp_npctype_data->flymode          	= atoi(row[111]);
 		temp_npctype_data->always_aggro	        = atoi(row[112]);
 		temp_npctype_data->exp_mod              = atoi(row[113]);
+		// 114 is used by hp_regen_per_second
 
 		temp_npctype_data->skip_auto_scale = false; // hardcoded here for now
 
@@ -3588,7 +3592,7 @@ void ZoneDatabase::ListAllInstances(Client* client, uint32 character_id)
 				remaining_time_string = "Already Expired";
 			}
 		}
-		
+
 		client->Message(
 			Chat::White,
 			fmt::format("Instance {} | Zone: {} ({}){}",
@@ -3860,7 +3864,7 @@ void ZoneDatabase::SavePetInfo(Client *client)
 				"ON DUPLICATE KEY UPDATE `petname` = '%s', `petpower` = %i, `spell_id` = %u, "
 				"`hp` = %u, `mana` = %u, `size` = %f, `taunting` = %u",
 				client->CharacterID(), pet, petinfo->Name, petinfo->petpower, petinfo->SpellID,
-				petinfo->HP, petinfo->Mana, petinfo->size, (petinfo->taunting) ? 1 : 0, 
+				petinfo->HP, petinfo->Mana, petinfo->size, (petinfo->taunting) ? 1 : 0,
 				// and now the ON DUPLICATE ENTRIES
 				petinfo->Name, petinfo->petpower, petinfo->SpellID, petinfo->HP, petinfo->Mana, petinfo->size, (petinfo->taunting) ? 1 : 0);
 		results = database.QueryDatabase(query);

--- a/zone/zonedump.h
+++ b/zone/zonedump.h
@@ -35,9 +35,9 @@ spawn2 mediumblob, npcs mediumblob, npc_loot mediumblob, gmspawntype mediumblob,
 struct NPCType
 {
 	char	name[64];
-	char	lastname[70]; 
+	char	lastname[70];
 	int32	current_hp;
-	int32	max_hp; 
+	int32	max_hp;
 	float	size;
 	float	runspeed;
 	uint8	gender;
@@ -105,6 +105,7 @@ struct NPCType
 	uint8	sec_melee_type;
 	uint8	ranged_type;
 	int32	hp_regen;
+	int64	hp_regen_per_second;
 	int32	mana_regen;
 	int32	aggroradius; // added for AI improvement - neotokyo
 	int32	assistradius; // assist radius, defaults to aggroradis if not set
@@ -122,7 +123,7 @@ struct NPCType
 	int		avoidance_rating;	// flat bonus before mods
 	bool	findable;		//can be found with find command
 	bool	trackable;
-	int16	slow_mitigation;	
+	int16	slow_mitigation;
 	uint8	maxlevel;
 	uint32	scalerate;
 	bool	private_corpse;
@@ -164,8 +165,8 @@ namespace player_lootitem {
 		uint32	aug_5;
 		uint32	aug_6;
 		int8	attuned;
-		uint8	min_level;		  // 
-		uint8	max_level;		  // 
+		uint8	min_level;		  //
+		uint8	max_level;		  //
 	};
 }
 


### PR DESCRIPTION
This PR implements an additional and optional per second HP regen to offset DPS. (HPRS vs DPS) 

Per second HP regen makes it easier for operators to build content against projected DPS rates and makes it easier to tune encounters based on baseline DPS rates for a given content tier.

* Implemented new field `hp_regen_per_second` at the `npc_types` table level
* Implemented #npcedit hp_regen_per_second
* Implemented modifier to ModifyNPCStat / GetNPCStat `hp_regen_per_second`

This does not change in anyway the existing `hp_regen_rate` functionality or intended Live functionality is completely optional. Default value is 0