### PR TITLE
[Repository] Cast floats to avoid grid repository warnings

### DIFF
--- a/common/repositories/grid_entries_repository.h
+++ b/common/repositories/grid_entries_repository.h
@@ -109,10 +109,10 @@ public:
 			entry.gridid      = atoi(row[0]);
 			entry.zoneid      = atoi(row[1]);
 			entry.number      = atoi(row[2]);
-			entry.x           = atof(row[3]);
-			entry.y           = atof(row[4]);
-			entry.z           = atof(row[5]);
-			entry.heading     = atof(row[6]);
+			entry.x           = static_cast<float>(atof(row[3]));
+			entry.y           = static_cast<float>(atof(row[4]));
+			entry.z           = static_cast<float>(atof(row[5]));
+			entry.heading     = static_cast<float>(atof(row[6]));
 			entry.pause       = atoi(row[7]);
 			entry.centerpoint = atoi(row[8]);
 


### PR DESCRIPTION
This is in the custom repository method file so the generator doesn't
need modified for it