### PR TITLE
[Combat] Fix Frenzy vs opponents immune to non-magic

### DIFF
--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -340,6 +340,11 @@ void Client::OPCombatAbility(const CombatAbility_Struct *ca_atk)
 		ReuseTime = FrenzyReuseTime - 1 - skill_reduction;
 		ReuseTime = (ReuseTime * HasteMod) / 100;
 
+		auto primaryInUse = GetInv().GetItem(EQ::invslot::slotPrimary);
+		if (primaryInUse && GetWeaponDamage(GetTarget(), primaryInUse) <= 0) {
+			max_dmg = DMG_INVULNERABLE;
+		}
+
 		while (AtkRounds > 0) {
 			if (GetTarget())
 				DoSpecialAttackDamage(GetTarget(), EQ::skills::SkillFrenzy, max_dmg, 0, max_dmg, ReuseTime);

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -340,8 +340,8 @@ void Client::OPCombatAbility(const CombatAbility_Struct *ca_atk)
 		ReuseTime = FrenzyReuseTime - 1 - skill_reduction;
 		ReuseTime = (ReuseTime * HasteMod) / 100;
 
-		auto primaryInUse = GetInv().GetItem(EQ::invslot::slotPrimary);
-		if (primaryInUse && GetWeaponDamage(GetTarget(), primaryInUse) <= 0) {
+		auto PrimaryInUse = GetInv().GetItem(EQ::invslot::slotPrimary);
+		if (PrimaryInUse && GetWeaponDamage(GetTarget(), PrimaryInUse) <= 0) {
 			max_dmg = DMG_INVULNERABLE;
 		}
 

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -340,8 +340,8 @@ void Client::OPCombatAbility(const CombatAbility_Struct *ca_atk)
 		ReuseTime = FrenzyReuseTime - 1 - skill_reduction;
 		ReuseTime = (ReuseTime * HasteMod) / 100;
 
-		auto PrimaryInUse = GetInv().GetItem(EQ::invslot::slotPrimary);
-		if (PrimaryInUse && GetWeaponDamage(GetTarget(), PrimaryInUse) <= 0) {
+		auto primary_in_use = GetInv().GetItem(EQ::invslot::slotPrimary);
+		if (primary_in_use && GetWeaponDamage(GetTarget(), primary_in_use) <= 0) {
 			max_dmg = DMG_INVULNERABLE;
 		}
 


### PR DESCRIPTION
I believe that frenzy should fail against opponents that are immune to non-magical weapons, when not wielding one. This PR fixes that.

NOTE: It seems live has removed this invulnerability from wisps and ghouls...  Not sure if it's just gone, or only on selected mobs.

Also note, this fixes the issue for clients.  Very similar code exists in Client::DoClassAttacks for Frenzy.  Does this need to be changed also?  I don't know where that code is called from??  Changing that code had no effect on this bug.  Maybe I need to put the same fix there for cases when client is AI controlled?