### PR TITLE
[Quest API] Perl Money Fixes.

### DIFF
--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -4079,12 +4079,12 @@ XS(XS_Client_GetCarriedMoney) {
 		Perl_croak(aTHX_ "Usage: Client::GetCarriedMoney(THIS)"); // @categories Currency and Points
 	{
 		Client *THIS;
-		int RETVAL;
+		uint64 RETVAL;
 		dXSTARG;
 		VALIDATE_THIS_IS_CLIENT;
 		RETVAL = THIS->GetCarriedMoney();
 		XSprePUSH;
-		PUSHi((IV) RETVAL);
+		PUSHu((UV) RETVAL);
 	}
 	XSRETURN(1);
 }
@@ -4097,12 +4097,12 @@ XS(XS_Client_GetAllMoney) {
 		Perl_croak(aTHX_ "Usage: Client::GetAllMoney(THIS)"); // @categories Currency and Points
 	{
 		Client *THIS;
-		int RETVAL;
+		uint64 RETVAL;
 		dXSTARG;
 		VALIDATE_THIS_IS_CLIENT;
 		RETVAL = THIS->GetAllMoney();
 		XSprePUSH;
-		PUSHi((IV) RETVAL);
+		PUSHu((UV) RETVAL);
 	}
 	XSRETURN(1);
 }


### PR DESCRIPTION
- Fixes `$client->GetAllMoney()` to use `uint64` and not overflow int value.
- Fixes `$client->GetCarriedMoney()` to use `uint64` and not overflow int value.