### PR TITLE
[Commands] Cleanup #reloadworld and #repop Command.

### DIFF
--- a/common/emu_constants.h
+++ b/common/emu_constants.h
@@ -416,4 +416,10 @@ enum ConsiderLevel : uint8 {
 	Scowls
 };
 
+enum ReloadWorld : uint8 {
+	NoRepop = 0,
+	Repop,
+	ForceRepop
+};
+
 #endif /*COMMON_EMU_CONSTANTS_H*/

--- a/common/servertalk.h
+++ b/common/servertalk.h
@@ -1600,7 +1600,7 @@ struct WWTaskUpdate_Struct {
 };
 
 struct ReloadWorld_Struct {
-	uint32 Option;
+	uint8 global_repop;
 };
 
 struct HotReloadQuestsStruct {

--- a/world/console.cpp
+++ b/world/console.cpp
@@ -889,7 +889,7 @@ void ConsoleReloadWorld(
 	connection->SendLine("Reloading World...");
 	auto               pack = new ServerPacket(ServerOP_ReloadWorld, sizeof(ReloadWorld_Struct));
 	ReloadWorld_Struct *RW  = (ReloadWorld_Struct *) pack->pBuffer;
-	RW->Option = 1;
+	RW->global_repop = ReloadWorld::Repop;
 	zoneserver_list.SendPacket(pack);
 	safe_delete(pack);
 }

--- a/world/console.old.cpp
+++ b/world/console.old.cpp
@@ -875,7 +875,7 @@ void Console::ProcessCommand(const char* command) {
 				SendEmoteMessage(0,0,0,15,"Reloading World...");
 				auto pack = new ServerPacket(ServerOP_ReloadWorld, sizeof(ReloadWorld_Struct));
 				ReloadWorld_Struct* RW = (ReloadWorld_Struct*) pack->pBuffer;
-				RW->Option = 1;
+				RW->global_repop = ReloadWorld::Repop;
 				zoneserver_list.SendPacket(pack);
 				safe_delete(pack);
 			}

--- a/world/world_event_scheduler.cpp
+++ b/world/world_event_scheduler.cpp
@@ -59,7 +59,7 @@ void WorldEventScheduler::Process(ZSList *zs_list)
 
 					auto pack = new ServerPacket(ServerOP_ReloadWorld, sizeof(ReloadWorld_Struct));
 					auto *reload_world = (ReloadWorld_Struct *) pack->pBuffer;
-					reload_world->Option = 1;
+					reload_world->global_repop = ReloadWorld::Repop;
 					zs_list->SendPacket(pack);
 					safe_delete(pack);
 				}

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -306,10 +306,10 @@ int command_init(void)
 		command_add("reloadstatic", "- Reload Static Zone Data", AccountStatus::GMLeadAdmin, command_reloadstatic) ||
 		command_add("reloadtraps", "- Repops all traps in the current zone.", AccountStatus::QuestTroupe, command_reloadtraps) ||
 		command_add("reloadtitles", "- Reload player titles from the database", AccountStatus::GMLeadAdmin, command_reloadtitles) ||
-		command_add("reloadworld", "[0|1] - Clear quest cache (0 - no repop, 1 - repop)", AccountStatus::Max, command_reloadworld) ||
+		command_add("reloadworld", "[0|1|2] - Reload quests global and repop NPCs if specified (0 = No Repop, 1 = Repop, 2 = Force Repop)", AccountStatus::Max, command_reloadworld) ||
 		command_add("reloadzps", "- Reload zone points from database", AccountStatus::GMLeadAdmin, command_reloadzps) ||
 		command_add("removeitem", "[Item ID] [Amount] - Removes the specified Item ID by Amount from you or your player target's inventory (Amount defaults to 1 if not used)", AccountStatus::GMAdmin, command_removeitem) ||
-		command_add("repop", "[delay] - Repop the zone with optional delay", AccountStatus::GMAdmin, command_repop) ||
+		command_add("repop", "[Force] - Repop the zone with optional force repop", AccountStatus::GMAdmin, command_repop) ||
 		command_add("resetaa", "- Resets a Player's AA in their profile and refunds spent AA's to unspent, may disconnect player.", AccountStatus::GMMgmt, command_resetaa) ||
 		command_add("resetaa_timer", "Command to reset AA cooldown timers.", AccountStatus::GMMgmt, command_resetaa_timer) ||
 		command_add("resetdisc_timer", "Command to reset all discipline cooldown timers.", AccountStatus::GMMgmt, command_resetdisc_timer) ||

--- a/zone/gm_commands/reloadworld.cpp
+++ b/zone/gm_commands/reloadworld.cpp
@@ -5,15 +5,21 @@ extern WorldServer worldserver;
 
 void command_reloadworld(Client *c, const Seperator *sep)
 {
-	int world_repop = atoi(sep->arg[1]);
-	if (world_repop == 0) {
-		c->Message(Chat::White, "Reloading quest cache worldwide.");
-	}
-	else {
-		c->Message(Chat::White, "Reloading quest cache and repopping zones worldwide.");
+	uint32 world_repop = 0;
+
+	if (sep->IsNumber(1)) {
+		world_repop = std::stoul(sep->arg[1]);
 	}
 
-	auto               pack = new ServerPacket(ServerOP_ReloadWorld, sizeof(ReloadWorld_Struct));
+	c->Message(
+		Chat::White,
+		fmt::format(
+			"Attempting to reload quests {}worldwide.",
+			world_repop ? "and repop NPCs " : ""
+		).c_str()
+	);
+
+	auto pack = new ServerPacket(ServerOP_ReloadWorld, sizeof(ReloadWorld_Struct));
 	ReloadWorld_Struct *RW  = (ReloadWorld_Struct *) pack->pBuffer;
 	RW->Option = world_repop;
 	worldserver.SendPacket(pack);

--- a/zone/gm_commands/reloadworld.cpp
+++ b/zone/gm_commands/reloadworld.cpp
@@ -5,23 +5,35 @@ extern WorldServer worldserver;
 
 void command_reloadworld(Client *c, const Seperator *sep)
 {
-	uint32 world_repop = 0;
+	uint8 global_repop = ReloadWorld::NoRepop;
 
 	if (sep->IsNumber(1)) {
-		world_repop = std::stoul(sep->arg[1]);
+		global_repop = static_cast<uint8>(std::stoul(sep->arg[1]));
+
+		if (global_repop > ReloadWorld::ForceRepop) {
+			global_repop = ReloadWorld::ForceRepop;
+		}
 	}
 
 	c->Message(
 		Chat::White,
 		fmt::format(
 			"Attempting to reload quests {}worldwide.",
-			world_repop ? "and repop NPCs " : ""
+			(
+				global_repop ?
+				(
+					global_repop == ReloadWorld::Repop ?
+					"and repop NPCs " :
+					"and forcefully repop NPCs "
+				) :
+				""
+			)
 		).c_str()
 	);
 
 	auto pack = new ServerPacket(ServerOP_ReloadWorld, sizeof(ReloadWorld_Struct));
 	ReloadWorld_Struct *RW  = (ReloadWorld_Struct *) pack->pBuffer;
-	RW->Option = world_repop;
+	RW->global_repop = global_repop;
 	worldserver.SendPacket(pack);
 	safe_delete(pack);
 }

--- a/zone/gm_commands/repop.cpp
+++ b/zone/gm_commands/repop.cpp
@@ -2,39 +2,22 @@
 
 void command_repop(Client *c, const Seperator *sep)
 {
-	int timearg = 1;
-	int delay   = 0;
-
-	if (sep->arg[1] && strcasecmp(sep->arg[1], "force") == 0) {
-		timearg++;
-
-		LinkedListIterator<Spawn2 *> iterator(zone->spawn2_list);
-		iterator.Reset();
-		while (iterator.MoreElements()) {
-			std::string query   = StringFormat(
-				"DELETE FROM respawn_times WHERE id = %lu AND instance_id = %lu",
-				(unsigned long) iterator.GetData()->GetID(),
-				(unsigned long) zone->GetInstanceID()
-			);
-			auto        results = database.QueryDatabase(query);
-			iterator.Advance();
-		}
-		c->Message(Chat::White, "Zone depop: Force resetting spawn timers.");
-	}
-
-	if (!sep->IsNumber(timearg)) {
-		c->Message(Chat::White, "Zone depopped - repopping now.");
-
-		zone->Repop();
-
-		/* Force a spawn2 timer trigger so we don't delay actually spawning the NPC's */
-		zone->spawn2_timer.Trigger();
+	int arguments = sep->argnum;
+	if (!arguments) {
+		c->Message(Chat::White, "Zone depopped, repopping now.");
 		return;
 	}
 
-	c->Message(Chat::White, "Zone depoped. Repop in %i seconds", atoi(sep->arg[timearg]));
-	zone->Repop(atoi(sep->arg[timearg]) * 1000);
+	bool is_force = !strcasecmp(sep->arg[1], "force");
 
+	if (is_force) {
+		zone->ClearSpawnTimers();
+		c->Message(Chat::White, "Zone depopped, forcefully repopping now.");
+	} else {		
+		c->Message(Chat::White, "Zone depopped, repopping now.");
+	}
+
+	zone->Repop();
 	zone->spawn2_timer.Trigger();
 }
 

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -2520,20 +2520,11 @@ std::string QuestManager::gettaskname(uint32 task_id) {
 }
 
 void QuestManager::clearspawntimers() {
-	if(!zone)
+	if (!zone) {
         return;
-
-	//TODO: Dec 19, 2008, replace with code updated for current spawn timers.
-    LinkedListIterator<Spawn2*> iterator(zone->spawn2_list);
-	iterator.Reset();
-	while (iterator.MoreElements()) {
-		std::string query = StringFormat("DELETE FROM respawn_times "
-                                        "WHERE id = %lu AND instance_id = %lu",
-                                        (unsigned long)iterator.GetData()->GetID(),
-                                        (unsigned long)zone->GetInstanceID());
-        auto results = database.QueryDatabase(query);
-		iterator.Advance();
 	}
+
+	zone->ClearSpawnTimers();
 }
 
 void QuestManager::ze(int type, const char *str) {

--- a/zone/spawn2.cpp
+++ b/zone/spawn2.cpp
@@ -535,7 +535,7 @@ bool ZoneDatabase::PopulateZoneSpawnListClose(uint32 zoneid, LinkedList<Spawn2*>
 	return true;
 }
 
-bool ZoneDatabase::PopulateZoneSpawnList(uint32 zoneid, LinkedList<Spawn2*> &spawn2_list, int16 version, uint32 repopdelay) {
+bool ZoneDatabase::PopulateZoneSpawnList(uint32 zoneid, LinkedList<Spawn2*> &spawn2_list, int16 version) {
 
 	std::unordered_map<uint32, uint32> spawn_times;
 

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -3094,7 +3094,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 	{
 		auto* reload_world = (ReloadWorld_Struct*)pack->pBuffer;
 		if (zone) {
-			zone->ReloadWorld(reload_world->Option);
+			zone->ReloadWorld(reload_world->global_repop);
 		}
 		break;
 	}

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -2558,11 +2558,35 @@ void Zone::ReloadWorld(uint32 Option){
 	if (Option == 0) {
 		entity_list.ClearAreas();
 		parse->ReloadQuests();
-	} else if(Option == 1) {
+	} else if (Option == 1) {
 		entity_list.ClearAreas();
 		parse->ReloadQuests();
 		zone->Repop(0);
 	}
+
+	worldserver.SendEmoteMessage(
+		0,
+		0,
+		AccountStatus::GMAdmin,
+		Chat::Yellow,
+		fmt::format(
+			"Quests reloaded {}for {}.",
+			Option ? "and NPCs repopped " : "",
+			fmt::format(
+				"{} ({})",
+				GetLongName(),
+				GetZoneID()
+			),
+			(
+				GetInstanceID() ?
+				fmt::format(
+					"Instance ID: {}",
+					GetInstanceID()
+				) :
+				""
+			)
+		).c_str()
+	);
 }
 
 void Zone::LoadTickItems()

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -2564,7 +2564,7 @@ void Zone::ReloadWorld(uint8 global_repop)
 			zone->ClearSpawnTimers();
 		}
 
-		zone->Repop(0);
+		zone->Repop();
 	}
 
 	worldserver.SendEmoteMessage(

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -1773,7 +1773,7 @@ void Zone::ClearNPCTypeCache(int id) {
 	}
 }
 
-void Zone::Repop(uint32 delay)
+void Zone::Repop()
 {
 	if (!Depop()) {
 		return;
@@ -1802,7 +1802,7 @@ void Zone::Repop(uint32 delay)
 		LogError("Loading spawn conditions failed, continuing without them");
 	}
 
-	if (!content_db.PopulateZoneSpawnList(zoneid, spawn2_list, GetInstanceVersion(), delay)) {
+	if (!content_db.PopulateZoneSpawnList(zoneid, spawn2_list, GetInstanceVersion())) {
 		LogDebug("Error in Zone::Repop: database.PopulateZoneSpawnList failed");
 	}
 
@@ -2554,13 +2554,16 @@ void Zone::LoadNPCEmotes(LinkedList<NPC_Emote_Struct*>* NPCEmoteList)
 
 }
 
-void Zone::ReloadWorld(uint32 Option){
-	if (Option == 0) {
-		entity_list.ClearAreas();
-		parse->ReloadQuests();
-	} else if (Option == 1) {
-		entity_list.ClearAreas();
-		parse->ReloadQuests();
+void Zone::ReloadWorld(uint8 global_repop)
+{
+	entity_list.ClearAreas();
+	parse->ReloadQuests();
+
+	if (global_repop) {
+		if (global_repop == ReloadWorld::ForceRepop) {
+			zone->ClearSpawnTimers();
+		}
+
 		zone->Repop(0);
 	}
 
@@ -2570,8 +2573,16 @@ void Zone::ReloadWorld(uint32 Option){
 		AccountStatus::GMAdmin,
 		Chat::Yellow,
 		fmt::format(
-			"Quests reloaded {}for {}.",
-			Option ? "and NPCs repopped " : "",
+			"Quests reloaded {}for {}{}.",
+			(
+				global_repop ?
+				(
+					global_repop == ReloadWorld::Repop ?
+					"and repopped NPCs " :
+					"and forcefully repopped NPCs "
+				) :
+				""
+			),
 			fmt::format(
 				"{} ({})",
 				GetLongName(),
@@ -2580,13 +2591,29 @@ void Zone::ReloadWorld(uint32 Option){
 			(
 				GetInstanceID() ?
 				fmt::format(
-					"Instance ID: {}",
+					" (Instance ID {})",
 					GetInstanceID()
 				) :
 				""
 			)
 		).c_str()
 	);
+}
+
+void Zone::ClearSpawnTimers()
+{
+	LinkedListIterator<Spawn2 *> iterator(spawn2_list);
+	iterator.Reset();
+	while (iterator.MoreElements()) {
+		auto query = fmt::format(
+			"DELETE FROM respawn_times WHERE id = {} AND instance_id = {}",
+			iterator.GetData()->GetID(),
+			GetInstanceID()
+		);
+		auto results = database.QueryDatabase(query);
+
+		iterator.Advance();
+	}
 }
 
 void Zone::LoadTickItems()

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -275,7 +275,7 @@ public:
 	void LoadVeteranRewards();
 	void LoadZoneDoors(const char *zone, int16 version);
 	void ReloadStaticData();
-	void ReloadWorld(uint32 Option);
+	void ReloadWorld(uint8 global_repop);
 	void RemoveAuth(const char *iCharName, const char *iLSKey);
 	void RemoveAuth(uint32 lsid);
 	void Repop(uint32 delay = 0);
@@ -295,6 +295,7 @@ public:
 	void StartShutdownTimer(uint32 set_time = (RuleI(Zone, AutoShutdownDelay)));
 	void UpdateQGlobal(uint32 qid, QGlobal newGlobal);
 	void weatherSend(Client *client = nullptr);
+	void ClearSpawnTimers();
 
 	bool IsQuestHotReloadQueued() const;
 	void SetQuestHotReloadQueued(bool in_quest_hot_reload_queued);

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -278,7 +278,7 @@ public:
 	void ReloadWorld(uint8 global_repop);
 	void RemoveAuth(const char *iCharName, const char *iLSKey);
 	void RemoveAuth(uint32 lsid);
-	void Repop(uint32 delay = 0);
+	void Repop();
 	void RequestUCSServerStatus();
 	void ResetAuth();
 	void SetDate(uint16 year, uint8 month, uint8 day, uint8 hour, uint8 minute);

--- a/zone/zone_reload.cpp
+++ b/zone/zone_reload.cpp
@@ -30,7 +30,7 @@ void ZoneReload::HotReloadQuests()
 	parse->ReloadQuests(RuleB(HotReload, QuestsResetTimersWithReload));
 
 	if (RuleB(HotReload, QuestsRepopWithReload)) {
-		zone->Repop(0);
+		zone->Repop();
 	}
 	
 	zone->SetQuestHotReloadQueued(false);

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -460,7 +460,7 @@ public:
 	/* Spawns and Spawn Points  */
 	bool		LoadSpawnGroups(const char* zone_name, uint16 version, SpawnGroupList* spawn_group_list);
 	bool		LoadSpawnGroupsByID(int spawn_group_id, SpawnGroupList* spawn_group_list);
-	bool		PopulateZoneSpawnList(uint32 zoneid, LinkedList<Spawn2*> &spawn2_list, int16 version, uint32 repopdelay = 0);
+	bool		PopulateZoneSpawnList(uint32 zoneid, LinkedList<Spawn2*> &spawn2_list, int16 version);
 	bool		PopulateZoneSpawnListClose(uint32 zoneid, LinkedList<Spawn2*> &spawn2_list, int16 version, const glm::vec4& client_position, uint32 repop_distance);
 	Spawn2*		LoadSpawn2(LinkedList<Spawn2*> &spawn2_list, uint32 spawn2id, uint32 timeleft);
 	bool		CreateSpawn2(Client *c, uint32 spawngroup, const char* zone, const glm::vec4& position, uint32 respawn, uint32 variance, uint16 condition, int16 cond_value);


### PR DESCRIPTION
- Cleanup messages and logic.
- Add #reloadworld 2 option to forcefully repop all mobs globally as well as reset quest timers and reload quests.
- Add zone->ClearSpawnTimers() for a shorthand to clear all spawn timers instead of it being stuck in the quest method.
- Add enum for reloadworld types to avoid magic numbers.