### PR TITLE
[Commands] Cleanup #reloadstatic Command.

### DIFF
--- a/common/servertalk.h
+++ b/common/servertalk.h
@@ -228,6 +228,7 @@
 #define ServerOP_UpdateSchedulerEvents 0x4012
 #define ServerOP_ReloadContentFlags 0x4013
 #define ServerOP_ReloadVariablesWorld 0x4014
+#define ServerOP_ReloadStaticZoneData 0x4020
 
 #define ServerOP_CZDialogueWindow 0x4500
 #define ServerOP_CZLDoNUpdate 0x4501

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -889,6 +889,11 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 		zoneserver_list.SendPacket(pack);
 		break;
 	}
+	case ServerOP_ReloadStaticZoneData:
+	{
+		zoneserver_list.SendPacket(pack);
+		break;
+	}
 	case ServerOP_CameraShake:
 	{
 		zoneserver_list.SendPacket(pack);

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -303,7 +303,7 @@ int command_init(void)
 		command_add("reloadperlexportsettings", nullptr, AccountStatus::Max, command_reloadperlexportsettings) ||
 		command_add("reloadqst", " - Clear quest cache (any argument causes it to also stop all timers)", AccountStatus::GMLeadAdmin, command_reloadqst) ||
 		command_add("reloadrulesworld", "Executes a reload of all rules in world specifically.", AccountStatus::QuestTroupe, command_reloadworldrules) ||
-		command_add("reloadstatic", "- Reload Static Zone Data", AccountStatus::GMLeadAdmin, command_reloadstatic) ||
+		command_add("reloadstatic", "- Reload Static Zone Data globally", AccountStatus::GMLeadAdmin, command_reloadstatic) ||
 		command_add("reloadtraps", "- Repops all traps in the current zone.", AccountStatus::QuestTroupe, command_reloadtraps) ||
 		command_add("reloadtitles", "- Reload player titles from the database", AccountStatus::GMLeadAdmin, command_reloadtitles) ||
 		command_add("reloadworld", "[0|1] - Clear quest cache (0 - no repop, 1 - repop)", AccountStatus::Max, command_reloadworld) ||

--- a/zone/gm_commands/reloadstatic.cpp
+++ b/zone/gm_commands/reloadstatic.cpp
@@ -2,7 +2,9 @@
 
 void command_reloadstatic(Client *c, const Seperator *sep)
 {
-	c->Message(Chat::White, "Reloading zone static data...");
-	zone->ReloadStaticData();
+	c->Message(Chat::White, "Attempting to reload static zone data globally.");
+	auto pack = new ServerPacket(ServerOP_ReloadStaticZoneData, 0);
+	worldserver.SendPacket(pack);
+	safe_delete(pack);
 }
 

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -2013,6 +2013,34 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 		parse->LoadPerlEventExportSettings(parse->perl_event_export_settings);
 		break;
 	}
+	case ServerOP_ReloadStaticZoneData: {
+		if (zone) {
+			worldserver.SendEmoteMessage(
+				0,
+				0,
+				AccountStatus::GMAdmin,
+				Chat::Yellow,
+				fmt::format(
+					"Static zone data reloaded for {}{}.",
+					fmt::format(
+						"{} ({})",
+						zone->GetLongName(),
+						zone->GetZoneID()
+					),
+					(
+						zone->GetInstanceID() ?
+						fmt::format(
+							" (Instance ID {})",
+							zone->GetInstanceID()
+						) :
+						""
+					)
+				).c_str()
+			);
+			zone->ReloadStaticData();
+		}
+		break;
+	}
 	case ServerOP_CameraShake:
 	{
 		if (zone)


### PR DESCRIPTION
- Cleanup messages and logic.
- Make reloading of static zone data global instead of zone specific.