### PR TITLE
[Commands] Cleanup #summon Command.

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4367,7 +4367,7 @@ void Client::Handle_OP_ClientUpdate(const EQApplicationPacket *app) {
 			safe_delete(outapp);
 
 			/* Update the boat's position on the server, without sending an update */
-			cmob->GMMove(ppu->x_pos, ppu->y_pos, ppu->z_pos, EQ12toFloat(ppu->heading), false);
+			cmob->GMMove(ppu->x_pos, ppu->y_pos, ppu->z_pos, EQ12toFloat(ppu->heading));
 			return;
 		}
 		else {

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -361,7 +361,7 @@ int command_init(void)
 		command_add("spawnstatus", "- Show respawn timer status", AccountStatus::GMAdmin, command_spawnstatus) ||
 		command_add("spellinfo", "[spellid] - Get detailed info about a spell", AccountStatus::Steward, command_spellinfo) ||
 		command_add("stun", "[duration] - Stuns you or your target for duration", AccountStatus::GMAdmin, command_stun) ||
-		command_add("summon", "[charname] - Summons your player/npc/corpse target, or charname if specified", AccountStatus::QuestTroupe, command_summon) ||
+		command_add("summon", "[Character Name] - Summons your corpse, NPC, or player target, or by character name if specified", AccountStatus::QuestTroupe, command_summon) ||
 		command_add("summonburiedplayercorpse", "- Summons the target's oldest buried corpse, if any exist.", AccountStatus::GMAdmin, command_summonburiedplayercorpse) ||
 		command_add("summonitem", "[itemid] [charges] - Summon an item onto your cursor. Charges are optional.", AccountStatus::GMMgmt, command_summonitem) ||
 		command_add("suspend", "[name] [days] [reason] - Suspend by character name and for specificed number of days", AccountStatus::GMLeadAdmin, command_suspend) ||

--- a/zone/gm_commands/summon.cpp
+++ b/zone/gm_commands/summon.cpp
@@ -58,55 +58,27 @@ void command_summon(Client *c, const Seperator *sep)
 	} else if (c->GetTarget()) {
 		target = c->GetTarget();
 	}
+	
+	if (c == target) {
+		c->Message(Chat::White, "You cannot summon yourself.");
+		return;
+	}
+	
+	c->Message(
+		Chat::White,
+		fmt::format(
+			"Summoning {} ({}) to {:.2f}, {:.2f}, {:.2f} in {} ({}).",
+			target->GetCleanName(),
+			target->GetID(),
+			c->GetX(),
+			c->GetY(),
+			c->GetZ(),
+			zone->GetLongName(),
+			zone->GetZoneID()
+		).c_str()
+	);
 
-	if (target->IsNPC()) {
-		c->Message(
-			Chat::White,
-			fmt::format(
-				"Summoning NPC {} ({}) to {:.2f}, {:.2f}, {:.2f} in {} ({}).",
-				target->GetCleanName(),
-				target->GetID(),
-				c->GetX(),
-				c->GetY(),
-				c->GetZ(),
-				zone->GetLongName(),
-				zone->GetZoneID()
-			).c_str()
-		);
-
-		target->GMMove(c->GetPosition());
-		target->CastToNPC()->SaveGuardSpot(glm::vec4(0.0f));
-	} else if (target->IsCorpse()) {
-		c->Message(
-			Chat::White,
-			fmt::format(
-				"Summoning Corpse {} ({}) to {:.2f}, {:.2f}, {:.2f} in {} ({}).",
-				target->GetCleanName(),
-				target->GetID(),
-				c->GetX(),
-				c->GetY(),
-				c->GetZ(),
-				zone->GetLongName(),
-				zone->GetZoneID()
-			).c_str()
-		);
-
-		target->GMMove(c->GetPosition());
-	} else if (target->IsClient()) {
-		c->Message(
-			Chat::White,
-			fmt::format(
-				"Summoning {} ({}) to {:.2f}, {:.2f}, {:.2f} in {} ({}).",
-				target->GetCleanName(),
-				target->GetID(),
-				c->GetX(),
-				c->GetY(),
-				c->GetZ(),
-				zone->GetLongName(),
-				zone->GetZoneID()
-			).c_str()
-		);
-
+	if (target->IsClient()) {
 		target->CastToClient()->MovePC(
 			zone->GetZoneID(),
 			zone->GetInstanceID(),
@@ -117,6 +89,12 @@ void command_summon(Client *c, const Seperator *sep)
 			2,
 			GMSummon
 		);
+	} else {
+		target->GMMove(c->GetPosition());
+
+		if (target->IsNPC()) {
+			target->CastToNPC()->SaveGuardSpot(glm::vec4(0.0f));
+		}
 	}
 }
 

--- a/zone/gm_commands/summon.cpp
+++ b/zone/gm_commands/summon.cpp
@@ -41,7 +41,7 @@ void command_summon(Client *c, const Seperator *sep)
 			}
 
 			auto pack = new ServerPacket(ServerOP_ZonePlayer, sizeof(ServerZonePlayer_Struct));
-			ServerZonePlayer_Struct *szp = (ServerZonePlayer_Struct *) pack->pBuffer;
+			auto szp = (ServerZonePlayer_Struct *) pack->pBuffer;
 			strn0cpy(szp->adminname, c->GetName(), sizeof(szp->adminname));
 			szp->adminrank = c->Admin();
 			szp->ignorerestrictions = 2;
@@ -89,12 +89,13 @@ void command_summon(Client *c, const Seperator *sep)
 			2,
 			GMSummon
 		);
-	} else {
-		target->GMMove(c->GetPosition());
+		return;
+	}
 
-		if (target->IsNPC()) {
-			target->CastToNPC()->SaveGuardSpot(glm::vec4(0.0f));
-		}
+	target->GMMove(c->GetPosition());
+
+	if (target->IsNPC()) {
+		target->CastToNPC()->SaveGuardSpot(glm::vec4(0.0f));
 	}
 }
 

--- a/zone/gm_commands/summon.cpp
+++ b/zone/gm_commands/summon.cpp
@@ -7,82 +7,107 @@ extern WorldServer worldserver;
 
 void command_summon(Client *c, const Seperator *sep)
 {
-	Mob *t;
+	int arguments = sep->argnum;
+	if (!arguments && !c->GetTarget()) {
+		c->Message(Chat::White, "Usage: #summon - Summon your target, if you have one, to your position");
+		c->Message(Chat::White, "Usage: #summon [Character Name] - Summon a character by name to your position");
+		c->Message(Chat::White, "Note: You may also summon your target if you have one.");
+		return;
+	}
 
-	if (sep->arg[1][0] != 0)        // arg specified
-	{
-		Client *client = entity_list.GetClientByName(sep->arg[1]);
-		if (client != 0) {    // found player in zone
-			t = client->CastToMob();
-		}
-		else {
-			if (!worldserver.Connected()) {
-				c->Message(Chat::White, "Error: World server disconnected.");
-			}
-			else { // player is in another zone
-				//Taking this command out until we test the factor of 8 in ServerOP_ZonePlayer
-				//c->Message(Chat::White, "Summoning player from another zone not yet implemented.");
-				//return;
+	Mob* target;
 
-				auto                    pack = new ServerPacket(ServerOP_ZonePlayer, sizeof(ServerZonePlayer_Struct));
-				ServerZonePlayer_Struct *szp = (ServerZonePlayer_Struct *) pack->pBuffer;
-				strcpy(szp->adminname, c->GetName());
-				szp->adminrank          = c->Admin();
-				szp->ignorerestrictions = 2;
-				strcpy(szp->name, sep->arg[1]);
-				strcpy(szp->zone, zone->GetShortName());
-				szp->x_pos       = c->GetX(); // May need to add a factor of 8 in here..
-				szp->y_pos       = c->GetY();
-				szp->z_pos       = c->GetZ();
-				szp->instance_id = zone->GetInstanceID();
-				worldserver.SendPacket(pack);
-				safe_delete(pack);
-			}
+	if (arguments == 1) {
+		std::string character_name = sep->arg[1];
+		auto character_id = database.GetCharacterID(character_name.c_str());
+		if (!character_id) {
+			c->Message(
+				Chat::White,
+				fmt::format(
+					"Character '{}' does not exist.",
+					character_name
+				).c_str()
+			);
 			return;
 		}
-	}
-	else if (c->GetTarget()) {        // have target
-		t = c->GetTarget();
-	}
-	else {
-		c->Message(Chat::White, "Usage: #summon [charname] Either target or charname is required");
-		return;
+
+		auto search_client = entity_list.GetClientByName(character_name.c_str());
+		if (search_client) {
+			target = search_client->CastToMob();
+		} else {
+			if (!worldserver.Connected()) {
+				c->Message(Chat::White, "World server is currently disconnected.");
+				return;
+			}
+
+			auto pack = new ServerPacket(ServerOP_ZonePlayer, sizeof(ServerZonePlayer_Struct));
+			ServerZonePlayer_Struct *szp = (ServerZonePlayer_Struct *) pack->pBuffer;
+			strn0cpy(szp->adminname, c->GetName(), sizeof(szp->adminname));
+			szp->adminrank = c->Admin();
+			szp->ignorerestrictions = 2;
+			strn0cpy(szp->name, character_name.c_str(), sizeof(szp->name));
+			strn0cpy(szp->zone, zone->GetShortName(), sizeof(szp->zone));
+			szp->x_pos = c->GetX();
+			szp->y_pos = c->GetY();
+			szp->z_pos = c->GetZ();
+			szp->instance_id = zone->GetInstanceID();
+			worldserver.SendPacket(pack);
+			safe_delete(pack);
+			return;
+		}
+	} else if (c->GetTarget()) {
+		target = c->GetTarget();
 	}
 
-	if (!t) {
-		return;
-	}
+	if (target->IsNPC()) {
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"Summoning NPC {} ({}) to {:.2f}, {:.2f}, {:.2f} in {} ({}).",
+				target->GetCleanName(),
+				target->GetID(),
+				c->GetX(),
+				c->GetY(),
+				c->GetZ(),
+				zone->GetLongName(),
+				zone->GetZoneID()
+			).c_str()
+		);
 
-	if (t->IsNPC()) { // npc target
+		target->GMMove(c->GetPosition());
+		target->CastToNPC()->SaveGuardSpot(glm::vec4(0.0f));
+	} else if (target->IsCorpse()) {
 		c->Message(
 			Chat::White,
-			"Summoning NPC %s to %1.1f, %1.1f, %1.1f",
-			t->GetName(),
-			c->GetX(),
-			c->GetY(),
-			c->GetZ());
-		t->CastToNPC()->GMMove(c->GetX(), c->GetY(), c->GetZ(), c->GetHeading());
-		t->CastToNPC()->SaveGuardSpot(glm::vec4(0.0f));
-	}
-	else if (t->IsCorpse()) { // corpse target
+			fmt::format(
+				"Summoning Corpse {} ({}) to {:.2f}, {:.2f}, {:.2f} in {} ({}).",
+				target->GetCleanName(),
+				target->GetID(),
+				c->GetX(),
+				c->GetY(),
+				c->GetZ(),
+				zone->GetLongName(),
+				zone->GetZoneID()
+			).c_str()
+		);
+
+		target->GMMove(c->GetPosition());
+	} else if (target->IsClient()) {
 		c->Message(
 			Chat::White,
-			"Summoning corpse %s to %1.1f, %1.1f, %1.1f",
-			t->GetName(),
-			c->GetX(),
-			c->GetY(),
-			c->GetZ());
-		t->CastToCorpse()->GMMove(c->GetX(), c->GetY(), c->GetZ(), c->GetHeading());
-	}
-	else if (t->IsClient()) {
-		c->Message(
-			Chat::White,
-			"Summoning player %s to %1.1f, %1.1f, %1.1f",
-			t->GetName(),
-			c->GetX(),
-			c->GetY(),
-			c->GetZ());
-		t->CastToClient()->MovePC(
+			fmt::format(
+				"Summoning {} ({}) to {:.2f}, {:.2f}, {:.2f} in {} ({}).",
+				target->GetCleanName(),
+				target->GetID(),
+				c->GetX(),
+				c->GetY(),
+				c->GetZ(),
+				zone->GetLongName(),
+				zone->GetZoneID()
+			).c_str()
+		);
+
+		target->CastToClient()->MovePC(
 			zone->GetZoneID(),
 			zone->GetInstanceID(),
 			c->GetX(),

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -287,11 +287,6 @@ void Lua_Mob::GMMove(double x, double y, double z, double heading) {
 	self->GMMove(static_cast<float>(x), static_cast<float>(y), static_cast<float>(z), static_cast<float>(heading));
 }
 
-void Lua_Mob::GMMove(double x, double y, double z, double heading, bool send_update) {
-	Lua_Safe_Call_Void();
-	self->GMMove(static_cast<float>(x), static_cast<float>(y), static_cast<float>(z), static_cast<float>(heading), send_update);
-}
-
 void Lua_Mob::TryMoveAlong(float distance, float angle) {
 	Lua_Safe_Call_Void();
 	self->TryMoveAlong(distance, angle);
@@ -2605,7 +2600,6 @@ luabind::scope lua_register_mob() {
 	.def("FindType", (bool(Lua_Mob::*)(int,bool,int))&Lua_Mob::FindType)
 	.def("GMMove", (void(Lua_Mob::*)(double,double,double))&Lua_Mob::GMMove)
 	.def("GMMove", (void(Lua_Mob::*)(double,double,double,double))&Lua_Mob::GMMove)
-	.def("GMMove", (void(Lua_Mob::*)(double,double,double,double,bool))&Lua_Mob::GMMove)
 	.def("GetAA", (int(Lua_Mob::*)(int))&Lua_Mob::GetAA)
 	.def("GetAABonuses", &Lua_Mob::GetAABonuses)
 	.def("GetAAByAAID", (int(Lua_Mob::*)(int))&Lua_Mob::GetAAByAAID)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -79,7 +79,6 @@ public:
 	void RandomizeFeatures(bool send_illusion, bool save_variables);
 	void GMMove(double x, double y, double z);
 	void GMMove(double x, double y, double z, double heading);
-	void GMMove(double x, double y, double z, double heading, bool send_update);
 	void TryMoveAlong(float distance, float heading);
 	void TryMoveAlong(float distance, float heading, bool send);
 	bool HasProcs();

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -2433,7 +2433,7 @@ void Mob::ShowBuffList(Client* client) {
 	}
 }
 
-void Mob::GMMove(float x, float y, float z, float heading, bool SendUpdate) {
+void Mob::GMMove(float x, float y, float z, float heading) {
 	m_Position.x = x;
 	m_Position.y = y;
 	m_Position.z = z;
@@ -2442,6 +2442,18 @@ void Mob::GMMove(float x, float y, float z, float heading, bool SendUpdate) {
 
 	if (IsNPC()) {
 		CastToNPC()->SaveGuardSpot(glm::vec4(x, y, z, heading));
+	}
+}
+
+void Mob::GMMove(const glm::vec4 &position) {
+	m_Position.x = position.x;
+	m_Position.y = position.y;
+	m_Position.z = position.z;
+	SetHeading(position.w);
+	mMovementManager->SendCommandToClients(this, 0.0, 0.0, 0.0, 0.0, 0, ClientRangeAny);
+
+	if (IsNPC()) {
+		CastToNPC()->SaveGuardSpot(position);
 	}
 }
 

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -655,7 +655,8 @@ public:
 	float GetMovespeed() const { return IsRunning() ? GetRunspeed() : GetWalkspeed(); }
 	bool IsRunning() const { return m_is_running; }
 	void SetRunning(bool val) { m_is_running = val; }
-	virtual void GMMove(float x, float y, float z, float heading = 0.01, bool SendUpdate = true);
+	virtual void GMMove(float x, float y, float z, float heading = 0.01);
+	virtual void GMMove(const glm::vec4 &position);
 	void SetDelta(const glm::vec4& delta);
 	void MakeSpawnUpdateNoDelta(PlayerPositionUpdateServer_Struct* spu);
 	void MakeSpawnUpdate(PlayerPositionUpdateServer_Struct* spu);


### PR DESCRIPTION
- Cleanup messages and logic.
- Command will now tell you if the specified character name does not exist instead of incorrectly telling you it's summoning a non-existent character.
- Add glm::vec4 overload for GMMove.
- Remove unused parameter from GMMove.
- Remove unnecessary Lua GMMove now that parameter is gone.