### PR TITLE
[Bug Fix] NPC::GetNPCStat has no default return.

### DIFF
--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -2807,6 +2807,8 @@ float NPC::GetNPCStat(const char *identifier)
 	else if (id == "default_atk") {
 		return default_atk;
 	}
+
+	return 0.0f;
 }
 
 void NPC::LevelScale() {


### PR DESCRIPTION
```
In member function 'float NPC::GetNPCStat(const char*)': /drone/src/zone/npc.cpp:2810:1: warning: control reaches end of non-void function [-Wreturn-type]```