### PR TITLE
[Bug Fix] Lua GetBlockNextSpell() no return.

### DIFF
--- a/zone/lua_stat_bonuses.cpp
+++ b/zone/lua_stat_bonuses.cpp
@@ -677,7 +677,7 @@ int Lua_StatBonuses::GetXPRateMod() const {
 
 bool Lua_StatBonuses::GetBlockNextSpell() const {
 	Lua_Safe_Call_Bool();
-	//return self->BlockNextSpell; bonus no longer used due to effect being a focus
+	return false; // Bonus no longer used due to effect being a focus
 }
 
 bool Lua_StatBonuses::GetImmuneToFlee() const {


### PR DESCRIPTION
```
/drone/src/zone/lua_stat_bonuses.cpp: In member function 'bool Lua_StatBonuses::GetBlockNextSpell() const':
/drone/src/zone/lua_stat_bonuses.cpp:681:1: warning: control reaches end of non-void function [-Wreturn-type]
```