### PR TITLE
[Bug Fix] restore some messages lost due to dup fix 2 years ago

### DIFF
--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -139,7 +139,7 @@ bool IsEvacSpell(uint16 spellid)
 
 bool IsDamageSpell(uint16 spellid)
 {
-	if (spells[spellid].target_type == ST_Tap)
+	if (IsLifetapSpell(spellid))
 		return false;
 
 	for (int o = 0; o < EFFECT_COUNT; o++) {
@@ -152,6 +152,27 @@ bool IsDamageSpell(uint16 spellid)
 	return false;
 }
 
+bool IsDOTWithDDSpell(uint16 spellid)
+{
+	bool is_DOT = false;
+	bool is_DD = false;
+
+	for (int o = 0; o < EFFECT_COUNT; o++) {
+		uint32 tid = spells[spellid].effect_id[o];
+		if (spells[spellid].base_value[o] < 0) {
+			if (tid == SE_CurrentHPOnce)
+				is_DD = true;
+
+			if (tid == SE_CurrentHP && spells[spellid].buff_duration > 0)
+				is_DOT = true;
+		}
+
+		if (is_DD && is_DOT)
+			return true;
+	}
+
+	return false;
+}
 
 bool IsFearSpell(uint16 spell_id)
 {

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1483,6 +1483,7 @@ bool IsValidSpell(uint32 spellid);
 bool IsSummonSpell(uint16 spellid);
 bool IsEvacSpell(uint16 spellid);
 bool IsDamageSpell(uint16 spellid);
+bool IsDOTWithDDSpell(uint16 spellid);
 bool IsFearSpell(uint16 spellid);
 bool IsCureSpell(uint16 spellid);
 bool BeneficialSpell(uint16 spell_id);

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4118,18 +4118,17 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 	cd->damage = 0;
 
 	if (!IsEffectInSpell(spell_id, SE_BindAffinity) && !IsAENukeSpell(spell_id)) {
-		// Do not issue the damage message again, if damage spell and client is the target.
-		Mob *ignore_mob = (IsDamageSpell(spell_id) && !IsDOTWithDDSpell(spell_id)) ? spelltar : nullptr;
-
-		entity_list.QueueCloseClients(
-			spelltar, /* Sender */
-			message_packet, /* Packet */
-			false, /* Ignore Sender */
-			RuleI(Range, SpellMessages),
-			ignore_mob, /* Skip this mob */
-			true, /* Packet ACK */
-			(spellOwner->IsClient() ? FilterPCSpells : FilterNPCSpells) /* Message Filter Type: (8 or 9) */
-		);
+		if (!IsDamageSpell(spell_id) || IsDOTWithDDSpell(spell_id)) {
+			entity_list.QueueCloseClients(
+				spelltar, /* Sender */
+				message_packet, /* Packet */
+				false, /* Ignore Sender */
+				RuleI(Range, SpellMessages),
+				0, /* Skip this mob */
+				true, /* Packet ACK */
+				(spellOwner->IsClient() ? FilterPCSpells : FilterNPCSpells) /* Message Filter Type: (8 or 9) */
+			);
+		}
 	}
 
 	safe_delete(action_packet);

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4130,7 +4130,6 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 			);
 		}
 	}
-
 	safe_delete(action_packet);
 	safe_delete(message_packet);
 

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3509,8 +3509,6 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 	if (!IsValidSpell(spell_id))
 		return false;
 
-	bool is_damage_or_lifetap_spell = IsDamageSpell(spell_id) || IsLifetapSpell(spell_id);
-
 	if(IsDetrimentalSpell(spell_id) && !IsAttackAllowed(spelltar, true) && !IsResurrectionEffects(spell_id) && !IsEffectInSpell(spell_id, SE_BindSight)) {
 		if(!IsClient() || !CastToClient()->GetGM()) {
 			MessageString(Chat::SpellFailure, SPELL_NO_HOLD);
@@ -4107,9 +4105,7 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 		if(IsClient())	// send to caster
 			CastToClient()->QueuePacket(action_packet);
 	}
-	// send to people in the area, ignoring caster and target
-	//live dosent send this to anybody but the caster
-	//entity_list.QueueCloseClients(spelltar, action_packet, true, 200, this, true, spelltar->IsClient() ? FILTER_PCSPELLS : FILTER_NPCSPELLS);
+
 	message_packet = new EQApplicationPacket(OP_Damage, sizeof(CombatDamage_Struct));
 	CombatDamage_Struct *cd = (CombatDamage_Struct *)message_packet->pBuffer;
 	cd->target = action->target;
@@ -4121,29 +4117,21 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 	cd->hit_pitch = action->hit_pitch;
 	cd->damage = 0;
 
-	if(!IsEffectInSpell(spell_id, SE_BindAffinity) && !is_damage_or_lifetap_spell){
+	if (!IsEffectInSpell(spell_id, SE_BindAffinity) && !IsAENukeSpell(spell_id)) {
+		// Do not issue the damage message again, if damage spell and client is the target.
+		Mob *ignore_mob = (IsDamageSpell(spell_id) && !IsDOTWithDDSpell(spell_id)) ? spelltar : nullptr;
+
 		entity_list.QueueCloseClients(
 			spelltar, /* Sender */
 			message_packet, /* Packet */
 			false, /* Ignore Sender */
 			RuleI(Range, SpellMessages),
-			0, /* Skip this mob */
+			ignore_mob, /* Skip this mob */
 			true, /* Packet ACK */
 			(spellOwner->IsClient() ? FilterPCSpells : FilterNPCSpells) /* Message Filter Type: (8 or 9) */
 		);
-	} else if (is_damage_or_lifetap_spell) {
-		// Sends the client owner a message like "%T staggers"
-		if (spellOwner->IsClient()) {
-			spellOwner->CastToClient()->QueuePacket(message_packet, true,
-				Mob::CLIENT_CONNECTINGALL, FilterPCSpells);
-		}
-		// Show the "you feel your life force drain away" on target client...
-		if (IsLifetapSpell(spell_id) && spelltar->IsClient()) {
-			spelltar->CastToClient()->QueuePacket(message_packet, true,
-				Mob::CLIENT_CONNECTINGALL,
-				(spellOwner->IsClient() ? FilterPCSpells : FilterNPCSpells));
-		}
 	}
+
 	safe_delete(action_packet);
 	safe_delete(message_packet);
 


### PR DESCRIPTION
Some messages for spells were not getting sent anymore because of a 2 year old fix for duplicate messages.

Old Fix that fixed dups but lost some messages:  https://github.com/EQEmu/Server/commit/60e194e32bb5af2049ff1900c408fa663e60ffef

This is tested but lets get feedback and let me test for another week.