### PR TITLE
[Bug Fix] Fix #repop Command.

### DIFF
--- a/zone/gm_commands/repop.cpp
+++ b/zone/gm_commands/repop.cpp
@@ -5,6 +5,8 @@ void command_repop(Client *c, const Seperator *sep)
 	int arguments = sep->argnum;
 	if (!arguments) {
 		c->Message(Chat::White, "Zone depopped, repopping now.");
+		zone->Repop();
+		zone->spawn2_timer.Trigger();
 		return;
 	}
 


### PR DESCRIPTION
If you use no arguments, the command does not repop.