### PR TITLE
[Bug Fix] Fix duplicate and missing messages due to innate in spells

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -4021,6 +4021,24 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 		// we don't send them here.
 		if (!FromDamageShield) {
 
+			int range;
+			if (IsValidSpell(spell_id)) {
+				range = RuleI(Range, SpellMessages);
+			}
+			else {
+				range = RuleI(Range, DamageMessages);
+			}
+
+			entity_list.QueueCloseClients(
+				this, /* Sender */
+				outapp, /* packet */
+				true, /* Skip Sender */
+				range, /* distance packet travels at the speed of sound */
+				(IsValidSpell(spell_id)) ? 0 : skip, /* Skip if not spell */
+				true, /* Packet ACK */
+				filter /* eqFilterType filter */
+				);
+
 			// Send damage to client (including inates skill_id)
 			if (IsClient()) {
 				//I dont think any filters apply to damage affecting us
@@ -4033,16 +4051,6 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 				a->type = DamageTypeSpell;
 				CastToClient()->QueuePacket(outapp);
 			}
-
-			entity_list.QueueCloseClients(
-				this, /* Sender */
-				outapp, /* packet */
-				true, /* Skip Sender */
-				RuleI(Range, SpellMessages),
-				0, /* Skip this mob */
-				true, /* Packet ACK */
-				filter /* eqFilterType filter */
-				);
 		}
 
 		safe_delete(outapp);

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -4034,7 +4034,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 			// produce a spell message.  Send to everyone.
 			// This fixes issues with npc-procs like 1002 and 918 which
 			// need to spit out extra spell color.
-			if (IsValidSpell(spell_id) && skill_used == 52) {
+			if (IsValidSpell(spell_id) && skill_used == EQ::skills::SkillTigerClaw) {
 				a->type = DamageTypeSpell;
 				entity_list.QueueCloseClients(
 					this, /* Sender */
@@ -4058,7 +4058,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 					outapp, /* packet */
 					true, /* Skip Sender */
 					range, /* distance packet travels at the speed of sound */
-					(IsValidSpell(spell_id) && skill_used != 52) ? 0 : skip,
+					(IsValidSpell(spell_id) && skill_used != EQ::skills::SkillTigerClaw) ? 0 : skip,
 					true, /* Packet ACK */
 					filter /* eqFilterType filter */
 					);


### PR DESCRIPTION
The fact that some spells use skill_id 52 (innate) has caused confusion and multiple attempts at understanding why some messages are missing and some are duplicated.

This PR fixes spells that use skill_id 52 to send (2) messages to the person being damaged (attack.cpp)

1) The strike message
2) The actual spell effect (life drains away, you have been poisoned, etc).

Some of the above were being send by spells.cpp because attack.cpp was missing them.

This has been tested using lifetaps, DD, DD+DOT, DOT, root w/damage,etc.

It has been tested in PVP,, and npcs procing as well as casting,

I think more messages come out now (that we were missing) and all duplicates are gone.

Fingers crossed.

@nytmyr This fixes canni also..