### PR TITLE
[Cleanup] Quest API push methods using invalid types.

### DIFF
--- a/common/content/world_content_service.h
+++ b/common/content/world_content_service.h
@@ -54,7 +54,7 @@ namespace Expansion {
 		VeilOfAlaris,
 		RainOfFear,
 		CallOfTheForsaken,
-		TheDarkendSea,
+		TheDarkenedSea,
 		TheBrokenMirror,
 		EmpiresOfKunark,
 		RingOfScale,
@@ -127,7 +127,7 @@ public:
 	bool IsVeilOfAlarisEnabled() { return GetCurrentExpansion() >= Expansion::ExpansionNumber::VeilOfAlaris || GetCurrentExpansion() == Expansion::EXPANSION_ALL; }
 	bool IsRainOfFearEnabled() { return GetCurrentExpansion() >= Expansion::ExpansionNumber::RainOfFear || GetCurrentExpansion() == Expansion::EXPANSION_ALL; }
 	bool IsCallOfTheForsakenEnabled() { return GetCurrentExpansion() >= Expansion::ExpansionNumber::CallOfTheForsaken || GetCurrentExpansion() == Expansion::EXPANSION_ALL; }
-	bool IsTheDarkendSeaEnabled() { return GetCurrentExpansion() >= Expansion::ExpansionNumber::TheDarkendSea || GetCurrentExpansion() == Expansion::EXPANSION_ALL; }
+	bool IsTheDarkenedSeaEnabled() { return GetCurrentExpansion() >= Expansion::ExpansionNumber::TheDarkenedSea || GetCurrentExpansion() == Expansion::EXPANSION_ALL; }
 	bool IsTheBrokenMirrorEnabled() { return GetCurrentExpansion() >= Expansion::ExpansionNumber::TheBrokenMirror || GetCurrentExpansion() == Expansion::EXPANSION_ALL; }
 	bool IsEmpiresOfKunarkEnabled() { return GetCurrentExpansion() >= Expansion::ExpansionNumber::EmpiresOfKunark || GetCurrentExpansion() == Expansion::EXPANSION_ALL; }
 	bool IsRingOfScaleEnabled() { return GetCurrentExpansion() >= Expansion::ExpansionNumber::RingOfScale || GetCurrentExpansion() == Expansion::EXPANSION_ALL; }
@@ -155,7 +155,7 @@ public:
 	bool IsCurrentExpansionVeilOfAlaris() { return current_expansion == Expansion::ExpansionNumber::VeilOfAlaris; }
 	bool IsCurrentExpansionRainOfFear() { return current_expansion == Expansion::ExpansionNumber::RainOfFear; }
 	bool IsCurrentExpansionCallOfTheForsaken() { return current_expansion == Expansion::ExpansionNumber::CallOfTheForsaken; }
-	bool IsCurrentExpansionTheDarkendSea() { return current_expansion == Expansion::ExpansionNumber::TheDarkendSea; }
+	bool IsCurrentExpansionTheDarkenedSea() { return current_expansion == Expansion::ExpansionNumber::TheDarkenedSea; }
 	bool IsCurrentExpansionTheBrokenMirror() { return current_expansion == Expansion::ExpansionNumber::TheBrokenMirror; }
 	bool IsCurrentExpansionEmpiresOfKunark() { return current_expansion == Expansion::ExpansionNumber::EmpiresOfKunark; }
 	bool IsCurrentExpansionRingOfScale() { return current_expansion == Expansion::ExpansionNumber::RingOfScale; }

--- a/common/perl_eqdb.cpp
+++ b/common/perl_eqdb.cpp
@@ -58,7 +58,8 @@ XS(XS_EQDB_field_count)
 			Perl_croak(aTHX_ "THIS is nullptr, avoiding crash.");
 
 		RETVAL = THIS->field_count();
-		XSprePUSH; PUSHu((UV)RETVAL);
+		XSprePUSH;
+		PUSHu((UV) RETVAL);
 	}
 	XSRETURN(1);
 }
@@ -84,7 +85,8 @@ XS(XS_EQDB_affected_rows)
 			Perl_croak(aTHX_ "THIS is nullptr, avoiding crash.");
 
 		RETVAL = THIS->affected_rows();
-		XSprePUSH; PUSHu((UV)RETVAL);
+		XSprePUSH;
+		PUSHu((UV) RETVAL);
 	}
 	XSRETURN(1);
 }
@@ -110,7 +112,8 @@ XS(XS_EQDB_insert_id)
 			Perl_croak(aTHX_ "THIS is nullptr, avoiding crash.");
 
 		RETVAL = THIS->insert_id();
-		XSprePUSH; PUSHu((UV)RETVAL);
+		XSprePUSH;
+		PUSHu((UV) RETVAL);
 	}
 	XSRETURN(1);
 }
@@ -136,7 +139,8 @@ XS(XS_EQDB_get_errno)
 			Perl_croak(aTHX_ "THIS is nullptr, avoiding crash.");
 
 		RETVAL = THIS->get_errno();
-		XSprePUSH; PUSHu((UV)RETVAL);
+		XSprePUSH;
+		PUSHu((UV) RETVAL);
 	}
 	XSRETURN(1);
 }

--- a/common/perl_eqdb_res.cpp
+++ b/common/perl_eqdb_res.cpp
@@ -54,7 +54,8 @@ XS(XS_EQDBRes_num_rows)
 			Perl_croak(aTHX_ "THIS is nullptr, avoiding crash.");
 
 		RETVAL = THIS->num_rows();
-		XSprePUSH; PUSHu((UV)RETVAL);
+		XSprePUSH;
+		PUSHu((UV) RETVAL);
 	}
 	XSRETURN(1);
 }
@@ -80,7 +81,8 @@ XS(XS_EQDBRes_num_fields)
 			Perl_croak(aTHX_ "THIS is nullptr, avoiding crash.");
 
 		RETVAL = THIS->num_fields();
-		XSprePUSH; PUSHu((UV)RETVAL);
+		XSprePUSH;
+		PUSHu((UV) RETVAL);
 	}
 	XSRETURN(1);
 }

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -499,8 +499,8 @@ XS(XS__getinventoryslotid) {
 		else if (identifier == "augsocket.end")         RETVAL = EQ::invaug::SOCKET_END;
 	}
 
-	XSprePUSH; PUSHu((IV)RETVAL);
-
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
 	XSRETURN(1);
 }
 
@@ -600,7 +600,6 @@ XS(XS__hastimer) {
 	char *timer_name = (char *)SvPV_nolen(ST(0));
 
 	RETVAL = quest_manager.hastimer(timer_name);
-
 	ST(0) = boolSV(RETVAL);
 	sv_2mortal(ST(0));
 	XSRETURN(1);
@@ -619,7 +618,7 @@ XS(XS__getremainingtimeMS) {
 	RETVAL = quest_manager.getremainingtimeMS(timer_name);
 
 	XSprePUSH;
-	PUSHu((IV)RETVAL);
+	PUSHu((UV) RETVAL);
 	XSRETURN(1);
 }
 
@@ -636,7 +635,7 @@ XS(XS__gettimerdurationMS) {
 	RETVAL = quest_manager.gettimerdurationMS(timer_name);
 
 	XSprePUSH;
-	PUSHu((IV)RETVAL);
+	PUSHu((UV) RETVAL);
 	XSRETURN(1);
 }
 
@@ -926,8 +925,7 @@ XS(XS__isdisctome) {
 	int  item_id = (int) SvIV(ST(0));
 
 	RETVAL = quest_manager.isdisctome(item_id);
-
-	ST(0)        = boolSV(RETVAL);
+	ST(0) = boolSV(RETVAL);
 	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
@@ -1109,7 +1107,7 @@ XS(XS__scribespells) {
 		RETVAL = quest_manager.scribespells(max_level);
 
 	XSprePUSH;
-	PUSHu((IV) RETVAL);
+	PUSHu((UV) RETVAL);
 	XSRETURN(1);
 }
 
@@ -1131,7 +1129,7 @@ XS(XS__traindiscs) {
 		RETVAL = quest_manager.traindiscs(max_level);
 
 	XSprePUSH;
-	PUSHu((IV) RETVAL);
+	PUSHu((UV) RETVAL);
 	XSRETURN(1);
 }
 
@@ -1886,7 +1884,7 @@ XS(XS__get_spawn_condition) {
 
 		RETVAL = quest_manager.get_spawn_condition(zone_short, zone->GetInstanceID(), cond_id);
 		XSprePUSH;
-		PUSHu((IV) RETVAL);
+		PUSHi((IV) RETVAL);
 
 		XSRETURN(1);
 	} else {
@@ -1899,7 +1897,7 @@ XS(XS__get_spawn_condition) {
 
 		RETVAL = quest_manager.get_spawn_condition(zone_short, instance_id, cond_id);
 		XSprePUSH;
-		PUSHu((IV) RETVAL);
+		PUSHi((IV) RETVAL);
 
 		XSRETURN(1);
 	}
@@ -1934,7 +1932,7 @@ XS(XS__has_zone_flag) {
 
 	RETVAL = quest_manager.has_zone_flag(zone_id);
 	XSprePUSH;
-	PUSHu((IV) RETVAL);
+	PUSHi((IV) RETVAL);
 
 	XSRETURN(1);
 
@@ -1977,8 +1975,7 @@ XS(XS__summonburiedplayercorpse) {
 	auto   position = glm::vec4((float) SvIV(ST(1)), (float) SvIV(ST(2)), (float) SvIV(ST(3)), (float) SvIV(ST(4)));
 
 	RETVAL = quest_manager.summonburiedplayercorpse(char_id, position);
-
-	ST(0)           = boolSV(RETVAL);
+	ST(0) = boolSV(RETVAL);
 	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
@@ -1994,8 +1991,7 @@ XS(XS__summonallplayercorpses) {
 	auto   position = glm::vec4((float) SvIV(ST(1)), (float) SvIV(ST(2)), (float) SvIV(ST(3)), (float) SvIV(ST(4)));
 
 	RETVAL = quest_manager.summonallplayercorpses(char_id, position);
-
-	ST(0)           = boolSV(RETVAL);
+	ST(0) = boolSV(RETVAL);
 	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
@@ -2013,7 +2009,7 @@ XS(XS__getplayercorpsecount) {
 
 	RETVAL = quest_manager.getplayercorpsecount(char_id);
 	XSprePUSH;
-	PUSHu((IV) RETVAL);
+	PUSHu((UV) RETVAL);
 
 	XSRETURN(1);
 }
@@ -2032,7 +2028,7 @@ XS(XS__getplayercorpsecountbyzoneid) {
 
 	RETVAL = quest_manager.getplayercorpsecountbyzoneid(char_id, zone_id);
 	XSprePUSH;
-	PUSHu((IV) RETVAL);
+	PUSHu((UV) RETVAL);
 
 	XSRETURN(1);
 }
@@ -2050,7 +2046,7 @@ XS(XS__getplayerburiedcorpsecount) {
 
 	RETVAL = quest_manager.getplayerburiedcorpsecount(char_id);
 	XSprePUSH;
-	PUSHu((IV) RETVAL);
+	PUSHu((UV) RETVAL);
 
 	XSRETURN(1);
 }
@@ -2068,7 +2064,7 @@ XS(XS__buryplayercorpse) {
 
 	RETVAL = quest_manager.buryplayercorpse(char_id);
 	XSprePUSH;
-	PUSHu((IV) RETVAL);
+	PUSHu((UV) RETVAL);
 
 	XSRETURN(1);
 }
@@ -2142,9 +2138,8 @@ XS(XS__isdooropen) {
 	uint32 door_id = (int) SvIV(ST(0));
 
 	RETVAL = quest_manager.isdooropen(door_id);
-	XSprePUSH;
-	PUSHu((IV) RETVAL);
-
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -2327,7 +2322,8 @@ XS(XS__createbotcount)
 	dXSTARG;
 
 	RETVAL = quest_manager.createbotcount();
-	XSprePUSH; PUSHi((IV)RETVAL);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
 
 	XSRETURN(1);
 }
@@ -2340,7 +2336,8 @@ XS(XS__spawnbotcount)
 	dXSTARG;
 
 	RETVAL = quest_manager.spawnbotcount();
-	XSprePUSH; PUSHi((IV)RETVAL);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
 
 	XSRETURN(1);
 }
@@ -2353,8 +2350,8 @@ XS(XS__botquest)
 	dXSTARG;
 
 	RETVAL = quest_manager.botquest();
-	XSprePUSH; PUSHu((IV)RETVAL);
-
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
 	XSRETURN(1);
 }
 
@@ -2378,7 +2375,8 @@ XS(XS__createBot)
 	int gender_id = (int) SvIV(ST(5));
 
 	RETVAL = quest_manager.createBot(firstname, lastname, level, race_id, class_id, gender_id);
-	XSprePUSH; PUSHu((IV)RETVAL);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
 	XSRETURN(1);
 }
 
@@ -2454,12 +2452,12 @@ XS(XS__istaskenabled) {
 	} else {
 		Perl_croak(aTHX_ "Usage: quest::istaskenabled(int task_id)");
 	}
-
-	XSprePUSH;
-	PUSHu((IV) RETVAL);
-
+	
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
+
 XS(XS__istaskactive);
 XS(XS__istaskactive) {
 	dXSARGS;
@@ -2472,12 +2470,12 @@ XS(XS__istaskactive) {
 	} else {
 		Perl_croak(aTHX_ "Usage: quest::istaskactive(int task_id)");
 	}
-
-	XSprePUSH;
-	PUSHu((IV) RETVAL);
-
+	
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
+
 XS(XS__istaskactivityactive);
 XS(XS__istaskactivityactive) {
 	dXSARGS;
@@ -2491,12 +2489,12 @@ XS(XS__istaskactivityactive) {
 	} else {
 		Perl_croak(aTHX_ "Usage: quest::istaskactivityactive(int task_id, int activity_id)");
 	}
-
-	XSprePUSH;
-	PUSHu((IV) RETVAL);
-
+	
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
+
 XS(XS__gettaskactivitydonecount);
 XS(XS__gettaskactivitydonecount) {
 	dXSARGS;
@@ -2515,6 +2513,7 @@ XS(XS__gettaskactivitydonecount) {
 
 	XSRETURN(1);
 }
+
 XS(XS__updatetaskactivity);
 XS(XS__updatetaskactivity) {
 	dXSARGS;
@@ -2806,10 +2805,9 @@ XS(XS__istaskappropriate) {
 	} else {
 		Perl_croak(aTHX_ "Usage: quest::istaskaappropriate(int task_id)");
 	}
-
-	XSprePUSH;
-	PUSHu((IV) RETVAL);
-
+	
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -2933,7 +2931,7 @@ XS(XS__getlevel) {
 
 	RETVAL = quest_manager.getlevel(type);
 	XSprePUSH;
-	PUSHu((IV) RETVAL);
+	PUSHi((IV) RETVAL);
 
 	XSRETURN(1);
 }
@@ -3375,10 +3373,9 @@ XS(XS__CheckInstanceByCharID) {
 
 	uint16 instance_id = (int) SvUV(ST(0));
 	uint32 char_id = (int) SvUV(ST(1));
-	RETVAL = quest_manager.CheckInstanceByCharID(instance_id, char_id);
-	XSprePUSH;
-	PUSHu((IV) RETVAL);
-
+	RETVAL = quest_manager.CheckInstanceByCharID(instance_id, char_id);	
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -3500,7 +3497,7 @@ XS(XS__getcharidbyname) {
 
 	RETVAL = quest_manager.getcharidbyname(name);
 	XSprePUSH;
-	PUSHu((UV)RETVAL);
+	PUSHu((UV) RETVAL);
 
 	XSRETURN(1);
 }
@@ -3538,7 +3535,7 @@ XS(XS__getcurrencyitemid) {
 	RETVAL = quest_manager.getcurrencyitemid(currency_id);
 
 	XSprePUSH;
-	PUSHi((IV)RETVAL);
+	PUSHi((IV) RETVAL);
   	XSRETURN(1);
 }
 
@@ -3554,7 +3551,7 @@ XS(XS__getcurrencyid) {
 
 	RETVAL = quest_manager.getcurrencyid(item_id);
 	XSprePUSH;
-	PUSHi((IV)RETVAL);
+	PUSHi((IV) RETVAL);
 	XSRETURN(1);
 }
 
@@ -3589,7 +3586,7 @@ XS(XS__getguildidbycharid) {
 	RETVAL = quest_manager.getguildidbycharid(char_id);
 
 	XSprePUSH;
-	PUSHi((IV)RETVAL);
+	PUSHi((IV) RETVAL);
 
 	XSRETURN(1);
 }
@@ -3606,7 +3603,7 @@ XS(XS__getgroupidbycharid) {
 
 	RETVAL = quest_manager.getgroupidbycharid(char_id);
 	XSprePUSH;
-	PUSHi((IV)RETVAL);
+	PUSHi((IV) RETVAL);
 
 	XSRETURN(1);
 }
@@ -3623,7 +3620,7 @@ XS(XS__getraididbycharid) {
 
 	RETVAL = quest_manager.getraididbycharid(char_id);
 	XSprePUSH;
-	PUSHi((IV)RETVAL);
+	PUSHi((IV) RETVAL);
 
 	XSRETURN(1);
 }
@@ -3650,11 +3647,9 @@ XS(XS__IsRunning) {
 	bool RETVAL;
 	dXSTARG;
 
-
-	RETVAL = quest_manager.IsRunning();
-	XSprePUSH;
-	PUSHu((IV) RETVAL);
-
+	RETVAL = quest_manager.IsRunning();	
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -3669,11 +3664,9 @@ XS(XS__IsEffectInSpell) {
 	bool   RETVAL;
 	dXSTARG;
 
-
 	RETVAL = IsEffectInSpell(spell_id, effect_id);
-	XSprePUSH;
-	PUSHu((IV) RETVAL);
-
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -3687,11 +3680,9 @@ XS(XS__IsBeneficialSpell) {
 	bool   RETVAL;
 	dXSTARG;
 
-
 	RETVAL = BeneficialSpell(spell_id);
-	XSprePUSH;
-	PUSHu((IV) RETVAL);
-
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4174,7 +4165,7 @@ XS(XS__delete_data) {
 	std::string key = (std::string) SvPV_nolen(ST(0));
 
 	XSprePUSH;
-	PUSHu((IV) DataBucket::DeleteData(key));
+	PUSHi((IV) DataBucket::DeleteData(key));
 
 	XSRETURN(1);
 }
@@ -4187,9 +4178,12 @@ XS(XS__IsClassicEnabled) {
 		Perl_croak(aTHX_ "Usage: quest::is_classic_enabled()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsClassicEnabled();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsTheRuinsOfKunarkEnabled);
@@ -4199,9 +4193,12 @@ XS(XS__IsTheRuinsOfKunarkEnabled) {
 		Perl_croak(aTHX_ "Usage: quest::is_the_ruins_of_kunark_enabled()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsTheRuinsOfKunarkEnabled();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsTheScarsOfVeliousEnabled);
@@ -4211,9 +4208,12 @@ XS(XS__IsTheScarsOfVeliousEnabled) {
 		Perl_croak(aTHX_ "Usage: quest::is_the_scars_of_velious_enabled()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsTheScarsOfVeliousEnabled();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsTheShadowsOfLuclinEnabled);
@@ -4223,9 +4223,12 @@ XS(XS__IsTheShadowsOfLuclinEnabled) {
 		Perl_croak(aTHX_ "Usage: quest::is_the_shadows_of_luclin_enabled()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsTheShadowsOfLuclinEnabled();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsThePlanesOfPowerEnabled);
@@ -4235,9 +4238,12 @@ XS(XS__IsThePlanesOfPowerEnabled) {
 		Perl_croak(aTHX_ "Usage: quest::is_the_planes_of_power_enabled()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsThePlanesOfPowerEnabled();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsTheLegacyOfYkeshaEnabled);
@@ -4247,9 +4253,12 @@ XS(XS__IsTheLegacyOfYkeshaEnabled) {
 		Perl_croak(aTHX_ "Usage: quest::is_the_legacy_of_ykesha_enabled()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsTheLegacyOfYkeshaEnabled();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsLostDungeonsOfNorrathEnabled);
@@ -4259,9 +4268,12 @@ XS(XS__IsLostDungeonsOfNorrathEnabled) {
 		Perl_croak(aTHX_ "Usage: quest::is_lost_dungeons_of_norrath_enabled()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsLostDungeonsOfNorrathEnabled();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsGatesOfDiscordEnabled);
@@ -4271,9 +4283,12 @@ XS(XS__IsGatesOfDiscordEnabled) {
 		Perl_croak(aTHX_ "Usage: quest::is_gates_of_discord_enabled()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsGatesOfDiscordEnabled();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsOmensOfWarEnabled);
@@ -4283,9 +4298,12 @@ XS(XS__IsOmensOfWarEnabled) {
 		Perl_croak(aTHX_ "Usage: quest::is_omens_of_war_enabled()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsOmensOfWarEnabled();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsDragonsOfNorrathEnabled);
@@ -4295,9 +4313,12 @@ XS(XS__IsDragonsOfNorrathEnabled) {
 		Perl_croak(aTHX_ "Usage: quest::is_dragons_of_norrath_enabled()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsDragonsOfNorrathEnabled();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsDepthsOfDarkhollowEnabled);
@@ -4307,9 +4328,12 @@ XS(XS__IsDepthsOfDarkhollowEnabled) {
 		Perl_croak(aTHX_ "Usage: quest::is_depths_of_darkhollow_enabled()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsDepthsOfDarkhollowEnabled();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsProphecyOfRoEnabled);
@@ -4319,9 +4343,12 @@ XS(XS__IsProphecyOfRoEnabled) {
 		Perl_croak(aTHX_ "Usage: quest::is_prophecy_of_ro_enabled()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsProphecyOfRoEnabled();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsTheSerpentsSpineEnabled);
@@ -4331,9 +4358,12 @@ XS(XS__IsTheSerpentsSpineEnabled) {
 		Perl_croak(aTHX_ "Usage: quest::is_the_serpents_spine_enabled()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsTheSerpentsSpineEnabled();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsTheBuriedSeaEnabled);
@@ -4343,9 +4373,12 @@ XS(XS__IsTheBuriedSeaEnabled) {
 		Perl_croak(aTHX_ "Usage: quest::is_the_buried_sea_enabled()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsTheBuriedSeaEnabled();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsSecretsOfFaydwerEnabled);
@@ -4355,9 +4388,12 @@ XS(XS__IsSecretsOfFaydwerEnabled) {
 		Perl_croak(aTHX_ "Usage: quest::is_secrets_of_faydwer_enabled()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsSecretsOfFaydwerEnabled();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsSeedsOfDestructionEnabled);
@@ -4367,9 +4403,12 @@ XS(XS__IsSeedsOfDestructionEnabled) {
 		Perl_croak(aTHX_ "Usage: quest::is_seeds_of_destruction_enabled()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsSeedsOfDestructionEnabled();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsUnderfootEnabled);
@@ -4379,9 +4418,12 @@ XS(XS__IsUnderfootEnabled) {
 		Perl_croak(aTHX_ "Usage: quest::is_underfoot_enabled()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsUnderfootEnabled();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsHouseOfThuleEnabled);
@@ -4391,9 +4433,12 @@ XS(XS__IsHouseOfThuleEnabled) {
 		Perl_croak(aTHX_ "Usage: quest::is_house_of_thule_enabled()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsHouseOfThuleEnabled();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsVeilOfAlarisEnabled);
@@ -4403,9 +4448,12 @@ XS(XS__IsVeilOfAlarisEnabled) {
 		Perl_croak(aTHX_ "Usage: quest::is_veil_of_alaris_enabled()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsVeilOfAlarisEnabled();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsRainOfFearEnabled);
@@ -4415,9 +4463,12 @@ XS(XS__IsRainOfFearEnabled) {
 		Perl_croak(aTHX_ "Usage: quest::is_rain_of_fear_enabled()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsRainOfFearEnabled();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCallOfTheForsakenEnabled);
@@ -4427,9 +4478,12 @@ XS(XS__IsCallOfTheForsakenEnabled) {
 		Perl_croak(aTHX_ "Usage: quest::is_call_of_the_forsaken_enabled()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCallOfTheForsakenEnabled();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsTheDarkendSeaEnabled);
@@ -4439,9 +4493,12 @@ XS(XS__IsTheDarkendSeaEnabled) {
 		Perl_croak(aTHX_ "Usage: quest::is_the_darkend_sea_enabled()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsTheDarkendSeaEnabled();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsTheBrokenMirrorEnabled);
@@ -4451,9 +4508,12 @@ XS(XS__IsTheBrokenMirrorEnabled) {
 		Perl_croak(aTHX_ "Usage: quest::is_the_broken_mirror_enabled()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsTheBrokenMirrorEnabled();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsEmpiresOfKunarkEnabled);
@@ -4463,9 +4523,12 @@ XS(XS__IsEmpiresOfKunarkEnabled) {
 		Perl_croak(aTHX_ "Usage: quest::is_empires_of_kunark_enabled()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsEmpiresOfKunarkEnabled();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsRingOfScaleEnabled);
@@ -4475,9 +4538,12 @@ XS(XS__IsRingOfScaleEnabled) {
 		Perl_croak(aTHX_ "Usage: quest::is_ring_of_scale_enabled()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsRingOfScaleEnabled();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsTheBurningLandsEnabled);
@@ -4487,9 +4553,12 @@ XS(XS__IsTheBurningLandsEnabled) {
 		Perl_croak(aTHX_ "Usage: quest::is_the_burning_lands_enabled()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsTheBurningLandsEnabled();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsTormentOfVeliousEnabled);
@@ -4499,9 +4568,12 @@ XS(XS__IsTormentOfVeliousEnabled) {
 		Perl_croak(aTHX_ "Usage: quest::is_torment_of_velious_enabled()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsTormentOfVeliousEnabled();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCurrentExpansionClassic);
@@ -4511,9 +4583,12 @@ XS(XS__IsCurrentExpansionClassic) {
 		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_classic()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionClassic();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCurrentExpansionTheRuinsOfKunark);
@@ -4523,9 +4598,12 @@ XS(XS__IsCurrentExpansionTheRuinsOfKunark) {
 		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_the_ruins_of_kunark()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionTheRuinsOfKunark();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCurrentExpansionTheScarsOfVelious);
@@ -4535,9 +4613,12 @@ XS(XS__IsCurrentExpansionTheScarsOfVelious) {
 		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_the_scars_of_velious()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionTheScarsOfVelious();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCurrentExpansionTheShadowsOfLuclin);
@@ -4547,9 +4628,12 @@ XS(XS__IsCurrentExpansionTheShadowsOfLuclin) {
 		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_the_shadows_of_luclin()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionTheShadowsOfLuclin();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCurrentExpansionThePlanesOfPower);
@@ -4559,9 +4643,12 @@ XS(XS__IsCurrentExpansionThePlanesOfPower) {
 		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_the_planes_of_power()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionThePlanesOfPower();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCurrentExpansionTheLegacyOfYkesha);
@@ -4571,9 +4658,12 @@ XS(XS__IsCurrentExpansionTheLegacyOfYkesha) {
 		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_the_legacy_of_ykesha()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionTheLegacyOfYkesha();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCurrentExpansionLostDungeonsOfNorrath);
@@ -4583,9 +4673,12 @@ XS(XS__IsCurrentExpansionLostDungeonsOfNorrath) {
 		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_lost_dungeons_of_norrath()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionLostDungeonsOfNorrath();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCurrentExpansionGatesOfDiscord);
@@ -4595,9 +4688,12 @@ XS(XS__IsCurrentExpansionGatesOfDiscord) {
 		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_gates_of_discord()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionGatesOfDiscord();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCurrentExpansionOmensOfWar);
@@ -4607,9 +4703,12 @@ XS(XS__IsCurrentExpansionOmensOfWar) {
 		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_omens_of_war()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionOmensOfWar();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCurrentExpansionDragonsOfNorrath);
@@ -4619,9 +4718,12 @@ XS(XS__IsCurrentExpansionDragonsOfNorrath) {
 		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_dragons_of_norrath()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionDragonsOfNorrath();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCurrentExpansionDepthsOfDarkhollow);
@@ -4631,9 +4733,12 @@ XS(XS__IsCurrentExpansionDepthsOfDarkhollow) {
 		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_depths_of_darkhollow()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionDepthsOfDarkhollow();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCurrentExpansionProphecyOfRo);
@@ -4643,9 +4748,12 @@ XS(XS__IsCurrentExpansionProphecyOfRo) {
 		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_prophecy_of_ro()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionProphecyOfRo();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCurrentExpansionTheSerpentsSpine);
@@ -4655,9 +4763,12 @@ XS(XS__IsCurrentExpansionTheSerpentsSpine) {
 		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_the_serpents_spine()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionTheSerpentsSpine();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCurrentExpansionTheBuriedSea);
@@ -4667,9 +4778,12 @@ XS(XS__IsCurrentExpansionTheBuriedSea) {
 		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_the_buried_sea()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionTheBuriedSea();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCurrentExpansionSecretsOfFaydwer);
@@ -4679,9 +4793,12 @@ XS(XS__IsCurrentExpansionSecretsOfFaydwer) {
 		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_secrets_of_faydwer()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionSecretsOfFaydwer();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCurrentExpansionSeedsOfDestruction);
@@ -4691,9 +4808,12 @@ XS(XS__IsCurrentExpansionSeedsOfDestruction) {
 		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_seeds_of_destruction()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionSeedsOfDestruction();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCurrentExpansionUnderfoot);
@@ -4703,9 +4823,12 @@ XS(XS__IsCurrentExpansionUnderfoot) {
 		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_underfoot()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionUnderfoot();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCurrentExpansionHouseOfThule);
@@ -4715,9 +4838,12 @@ XS(XS__IsCurrentExpansionHouseOfThule) {
 		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_house_of_thule()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionHouseOfThule();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCurrentExpansionVeilOfAlaris);
@@ -4727,9 +4853,12 @@ XS(XS__IsCurrentExpansionVeilOfAlaris) {
 		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_veil_of_alaris()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionVeilOfAlaris();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCurrentExpansionRainOfFear);
@@ -4739,9 +4868,12 @@ XS(XS__IsCurrentExpansionRainOfFear) {
 		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_rain_of_fear()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionRainOfFear();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCurrentExpansionCallOfTheForsaken);
@@ -4751,9 +4883,12 @@ XS(XS__IsCurrentExpansionCallOfTheForsaken) {
 		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_call_of_the_forsaken()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionCallOfTheForsaken();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCurrentExpansionTheDarkendSea);
@@ -4763,9 +4898,12 @@ XS(XS__IsCurrentExpansionTheDarkendSea) {
 		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_the_darkend_sea()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionTheDarkendSea();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCurrentExpansionTheBrokenMirror);
@@ -4775,9 +4913,12 @@ XS(XS__IsCurrentExpansionTheBrokenMirror) {
 		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_the_broken_mirror()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionTheBrokenMirror();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCurrentExpansionEmpiresOfKunark);
@@ -4787,9 +4928,12 @@ XS(XS__IsCurrentExpansionEmpiresOfKunark) {
 		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_empires_of_kunark()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionEmpiresOfKunark();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCurrentExpansionRingOfScale);
@@ -4799,9 +4943,12 @@ XS(XS__IsCurrentExpansionRingOfScale) {
 		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_ring_of_scale()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionRingOfScale();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCurrentExpansionTheBurningLands);
@@ -4811,9 +4958,12 @@ XS(XS__IsCurrentExpansionTheBurningLands) {
 		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_the_burning_lands()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionTheBurningLands();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsCurrentExpansionTormentOfVelious);
@@ -4823,9 +4973,12 @@ XS(XS__IsCurrentExpansionTormentOfVelious) {
 		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_torment_of_velious()");
 	}
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionTormentOfVelious();
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__IsContentFlagEnabled);
@@ -4837,9 +4990,12 @@ XS(XS__IsContentFlagEnabled) {
 
 	std::string flag_name = (std::string) SvPV_nolen(ST(0));
 
-	bool RETVAL; dXSTARG;
+	bool RETVAL;
+	dXSTARG;
 	RETVAL = content_service.IsContentFlagEnabled(flag_name);
-	XSprePUSH; PUSHu((IV) RETVAL); XSRETURN(1);
+	XSprePUSH;
+	PUSHi((IV) RETVAL);
+	XSRETURN(1);
 }
 
 XS(XS__SetContentFlag);
@@ -5346,7 +5502,7 @@ XS(XS__getitemstat) {
 	stat_value = quest_manager.getitemstat(item_id, stat_identifier);
 
 	XSprePUSH;
-	PUSHi((IV)stat_value);
+	PUSHi((IV) stat_value);
 
 	XSRETURN(1);
 }
@@ -5368,7 +5524,7 @@ XS(XS__getspellstat) {
 	stat_value = quest_manager.getspellstat(spell_id, stat_identifier, slot);
 
 	XSprePUSH;
-	PUSHi((IV)stat_value);
+	PUSHi((IV) stat_value);
 
 	XSRETURN(1);
 }
@@ -8054,7 +8210,7 @@ XS(XS__countspawnednpcs) {
 		}
 		npc_count = entity_list.CountSpawnedNPCs(npc_ids);
 		XSprePUSH;
-		PUSHu((UV)npc_count);
+		PUSHu((UV) npc_count);
 		XSRETURN(1);
 	}
 }

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -4181,8 +4181,8 @@ XS(XS__IsClassicEnabled) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsClassicEnabled();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4196,8 +4196,8 @@ XS(XS__IsTheRuinsOfKunarkEnabled) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsTheRuinsOfKunarkEnabled();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4211,8 +4211,8 @@ XS(XS__IsTheScarsOfVeliousEnabled) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsTheScarsOfVeliousEnabled();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4226,8 +4226,8 @@ XS(XS__IsTheShadowsOfLuclinEnabled) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsTheShadowsOfLuclinEnabled();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4241,8 +4241,8 @@ XS(XS__IsThePlanesOfPowerEnabled) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsThePlanesOfPowerEnabled();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4256,8 +4256,8 @@ XS(XS__IsTheLegacyOfYkeshaEnabled) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsTheLegacyOfYkeshaEnabled();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4271,8 +4271,8 @@ XS(XS__IsLostDungeonsOfNorrathEnabled) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsLostDungeonsOfNorrathEnabled();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4286,8 +4286,8 @@ XS(XS__IsGatesOfDiscordEnabled) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsGatesOfDiscordEnabled();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4301,8 +4301,8 @@ XS(XS__IsOmensOfWarEnabled) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsOmensOfWarEnabled();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4316,8 +4316,8 @@ XS(XS__IsDragonsOfNorrathEnabled) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsDragonsOfNorrathEnabled();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4331,8 +4331,8 @@ XS(XS__IsDepthsOfDarkhollowEnabled) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsDepthsOfDarkhollowEnabled();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4346,8 +4346,8 @@ XS(XS__IsProphecyOfRoEnabled) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsProphecyOfRoEnabled();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4361,8 +4361,8 @@ XS(XS__IsTheSerpentsSpineEnabled) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsTheSerpentsSpineEnabled();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4376,8 +4376,8 @@ XS(XS__IsTheBuriedSeaEnabled) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsTheBuriedSeaEnabled();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4391,8 +4391,8 @@ XS(XS__IsSecretsOfFaydwerEnabled) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsSecretsOfFaydwerEnabled();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4406,8 +4406,8 @@ XS(XS__IsSeedsOfDestructionEnabled) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsSeedsOfDestructionEnabled();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4421,8 +4421,8 @@ XS(XS__IsUnderfootEnabled) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsUnderfootEnabled();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4436,8 +4436,8 @@ XS(XS__IsHouseOfThuleEnabled) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsHouseOfThuleEnabled();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4451,8 +4451,8 @@ XS(XS__IsVeilOfAlarisEnabled) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsVeilOfAlarisEnabled();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4466,8 +4466,8 @@ XS(XS__IsRainOfFearEnabled) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsRainOfFearEnabled();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4481,23 +4481,23 @@ XS(XS__IsCallOfTheForsakenEnabled) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsCallOfTheForsakenEnabled();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
-XS(XS__IsTheDarkendSeaEnabled);
-XS(XS__IsTheDarkendSeaEnabled) {
+XS(XS__IsTheDarkenedSeaEnabled);
+XS(XS__IsTheDarkenedSeaEnabled) {
 	dXSARGS;
 	if (items >= 1) {
-		Perl_croak(aTHX_ "Usage: quest::is_the_darkend_sea_enabled()");
+		Perl_croak(aTHX_ "Usage: quest::is_the_darkened_sea_enabled()");
 	}
 
 	bool RETVAL;
 	dXSTARG;
-	RETVAL = content_service.IsTheDarkendSeaEnabled();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	RETVAL = content_service.IsTheDarkenedSeaEnabled();
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4511,8 +4511,8 @@ XS(XS__IsTheBrokenMirrorEnabled) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsTheBrokenMirrorEnabled();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4526,8 +4526,8 @@ XS(XS__IsEmpiresOfKunarkEnabled) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsEmpiresOfKunarkEnabled();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4541,8 +4541,8 @@ XS(XS__IsRingOfScaleEnabled) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsRingOfScaleEnabled();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4556,8 +4556,8 @@ XS(XS__IsTheBurningLandsEnabled) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsTheBurningLandsEnabled();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4571,8 +4571,8 @@ XS(XS__IsTormentOfVeliousEnabled) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsTormentOfVeliousEnabled();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4586,8 +4586,8 @@ XS(XS__IsCurrentExpansionClassic) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionClassic();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4601,8 +4601,8 @@ XS(XS__IsCurrentExpansionTheRuinsOfKunark) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionTheRuinsOfKunark();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4616,8 +4616,8 @@ XS(XS__IsCurrentExpansionTheScarsOfVelious) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionTheScarsOfVelious();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4631,8 +4631,8 @@ XS(XS__IsCurrentExpansionTheShadowsOfLuclin) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionTheShadowsOfLuclin();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4646,8 +4646,8 @@ XS(XS__IsCurrentExpansionThePlanesOfPower) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionThePlanesOfPower();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4661,8 +4661,8 @@ XS(XS__IsCurrentExpansionTheLegacyOfYkesha) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionTheLegacyOfYkesha();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4676,8 +4676,8 @@ XS(XS__IsCurrentExpansionLostDungeonsOfNorrath) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionLostDungeonsOfNorrath();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4691,8 +4691,8 @@ XS(XS__IsCurrentExpansionGatesOfDiscord) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionGatesOfDiscord();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4706,8 +4706,8 @@ XS(XS__IsCurrentExpansionOmensOfWar) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionOmensOfWar();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4721,8 +4721,8 @@ XS(XS__IsCurrentExpansionDragonsOfNorrath) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionDragonsOfNorrath();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4736,8 +4736,8 @@ XS(XS__IsCurrentExpansionDepthsOfDarkhollow) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionDepthsOfDarkhollow();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4751,8 +4751,8 @@ XS(XS__IsCurrentExpansionProphecyOfRo) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionProphecyOfRo();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4766,8 +4766,8 @@ XS(XS__IsCurrentExpansionTheSerpentsSpine) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionTheSerpentsSpine();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4781,8 +4781,8 @@ XS(XS__IsCurrentExpansionTheBuriedSea) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionTheBuriedSea();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4796,8 +4796,8 @@ XS(XS__IsCurrentExpansionSecretsOfFaydwer) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionSecretsOfFaydwer();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4811,8 +4811,8 @@ XS(XS__IsCurrentExpansionSeedsOfDestruction) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionSeedsOfDestruction();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4826,8 +4826,8 @@ XS(XS__IsCurrentExpansionUnderfoot) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionUnderfoot();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4841,8 +4841,8 @@ XS(XS__IsCurrentExpansionHouseOfThule) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionHouseOfThule();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4856,8 +4856,8 @@ XS(XS__IsCurrentExpansionVeilOfAlaris) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionVeilOfAlaris();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4871,8 +4871,8 @@ XS(XS__IsCurrentExpansionRainOfFear) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionRainOfFear();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4886,23 +4886,23 @@ XS(XS__IsCurrentExpansionCallOfTheForsaken) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionCallOfTheForsaken();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
-XS(XS__IsCurrentExpansionTheDarkendSea);
-XS(XS__IsCurrentExpansionTheDarkendSea) {
+XS(XS__IsCurrentExpansionTheDarkenedSea);
+XS(XS__IsCurrentExpansionTheDarkenedSea) {
 	dXSARGS;
 	if (items >= 1) {
-		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_the_darkend_sea()");
+		Perl_croak(aTHX_ "Usage: quest::is_current_expansion_the_darkened_sea()");
 	}
 
 	bool RETVAL;
 	dXSTARG;
-	RETVAL = content_service.IsCurrentExpansionTheDarkendSea();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	RETVAL = content_service.IsCurrentExpansionTheDarkenedSea();
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4916,8 +4916,8 @@ XS(XS__IsCurrentExpansionTheBrokenMirror) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionTheBrokenMirror();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4931,8 +4931,8 @@ XS(XS__IsCurrentExpansionEmpiresOfKunark) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionEmpiresOfKunark();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4946,8 +4946,8 @@ XS(XS__IsCurrentExpansionRingOfScale) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionRingOfScale();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4961,8 +4961,8 @@ XS(XS__IsCurrentExpansionTheBurningLands) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionTheBurningLands();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4976,8 +4976,8 @@ XS(XS__IsCurrentExpansionTormentOfVelious) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsCurrentExpansionTormentOfVelious();
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -4993,8 +4993,8 @@ XS(XS__IsContentFlagEnabled) {
 	bool RETVAL;
 	dXSTARG;
 	RETVAL = content_service.IsContentFlagEnabled(flag_name);
-	XSprePUSH;
-	PUSHi((IV) RETVAL);
+	ST(0) = boolSV(RETVAL);
+	sv_2mortal(ST(0));
 	XSRETURN(1);
 }
 
@@ -5338,7 +5338,7 @@ XS(XS__gethexcolorcode);
 XS(XS__gethexcolorcode) {
 	dXSARGS;
 	if (items != 1) {
-		Perl_croak(aTHX_ "Usage: quest::gethexcolorcode(std::string color_name)");
+		Perl_croak(aTHX_ "Usage: quest::gethexcolorcode(string color_name)");
 	}
 
 	dXSTARG;
@@ -8335,7 +8335,7 @@ XS(XS__commify);
 XS(XS__commify) {
 	dXSARGS;
 	if (items != 1)
-		Perl_croak(aTHX_ "Usage: quest::commify(std::string number)");
+		Perl_croak(aTHX_ "Usage: quest::commify(string number)");
 
 	dXSTARG;
 	std::string number = (std::string) SvPV_nolen(ST(0));
@@ -8827,7 +8827,7 @@ EXTERN_C XS(boot_quest) {
 	newXS(strcpy(buf, "is_veil_of_alaris_enabled"), XS__IsVeilOfAlarisEnabled, file);
 	newXS(strcpy(buf, "is_rain_of_fear_enabled"), XS__IsRainOfFearEnabled, file);
 	newXS(strcpy(buf, "is_call_of_the_forsaken_enabled"), XS__IsCallOfTheForsakenEnabled, file);
-	newXS(strcpy(buf, "is_the_darkend_sea_enabled"), XS__IsTheDarkendSeaEnabled, file);
+	newXS(strcpy(buf, "is_the_darkened_sea_enabled"), XS__IsTheDarkenedSeaEnabled, file);
 	newXS(strcpy(buf, "is_the_broken_mirror_enabled"), XS__IsTheBrokenMirrorEnabled, file);
 	newXS(strcpy(buf, "is_empires_of_kunark_enabled"), XS__IsEmpiresOfKunarkEnabled, file);
 	newXS(strcpy(buf, "is_ring_of_scale_enabled"), XS__IsRingOfScaleEnabled, file);
@@ -8854,7 +8854,7 @@ EXTERN_C XS(boot_quest) {
 	newXS(strcpy(buf, "is_current_expansion_veil_of_alaris"), XS__IsCurrentExpansionVeilOfAlaris, file);
 	newXS(strcpy(buf, "is_current_expansion_rain_of_fear"), XS__IsCurrentExpansionRainOfFear, file);
 	newXS(strcpy(buf, "is_current_expansion_call_of_the_forsaken"), XS__IsCurrentExpansionCallOfTheForsaken, file);
-	newXS(strcpy(buf, "is_current_expansion_the_darkend_sea"), XS__IsCurrentExpansionTheDarkendSea, file);
+	newXS(strcpy(buf, "is_current_expansion_the_darkened_sea"), XS__IsCurrentExpansionTheDarkenedSea, file);
 	newXS(strcpy(buf, "is_current_expansion_the_broken_mirror"), XS__IsCurrentExpansionTheBrokenMirror, file);
 	newXS(strcpy(buf, "is_current_expansion_empires_of_kunark"), XS__IsCurrentExpansionEmpiresOfKunark, file);
 	newXS(strcpy(buf, "is_current_expansion_ring_of_scale"), XS__IsCurrentExpansionRingOfScale, file);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -1619,8 +1619,8 @@ bool lua_is_call_of_the_forsaken_enabled() {
 	return content_service.IsCallOfTheForsakenEnabled();
 }
 
-bool lua_is_the_darkend_sea_enabled() {
-	return content_service.IsTheDarkendSeaEnabled();
+bool lua_is_the_darkened_sea_enabled() {
+	return content_service.IsTheDarkenedSeaEnabled();
 }
 
 bool lua_is_the_broken_mirror_enabled() {
@@ -1727,8 +1727,8 @@ bool lua_is_current_expansion_call_of_the_forsaken() {
 	return content_service.IsCurrentExpansionCallOfTheForsaken();
 }
 
-bool lua_is_current_expansion_the_darkend_sea() {
-	return content_service.IsCurrentExpansionTheDarkendSea();
+bool lua_is_current_expansion_the_darkened_sea() {
+	return content_service.IsCurrentExpansionTheDarkenedSea();
 }
 
 bool lua_is_current_expansion_the_broken_mirror() {
@@ -4078,7 +4078,7 @@ luabind::scope lua_register_general() {
 		luabind::def("is_veil_of_alaris_enabled", &lua_is_veil_of_alaris_enabled),
 		luabind::def("is_rain_of_fear_enabled", &lua_is_rain_of_fear_enabled),
 		luabind::def("is_call_of_the_forsaken_enabled", &lua_is_call_of_the_forsaken_enabled),
-		luabind::def("is_the_darkend_sea_enabled", &lua_is_the_darkend_sea_enabled),
+		luabind::def("is_the_darkened_sea_enabled", &lua_is_the_darkened_sea_enabled),
 		luabind::def("is_the_broken_mirror_enabled", &lua_is_the_broken_mirror_enabled),
 		luabind::def("is_empires_of_kunark_enabled", &lua_is_empires_of_kunark_enabled),
 		luabind::def("is_ring_of_scale_enabled", &lua_is_ring_of_scale_enabled),
@@ -4105,7 +4105,7 @@ luabind::scope lua_register_general() {
 		luabind::def("is_current_expansion_veil_of_alaris", &lua_is_current_expansion_veil_of_alaris),
 		luabind::def("is_current_expansion_rain_of_fear", &lua_is_current_expansion_rain_of_fear),
 		luabind::def("is_current_expansion_call_of_the_forsaken", &lua_is_current_expansion_call_of_the_forsaken),
-		luabind::def("is_current_expansion_the_darkend_sea", &lua_is_current_expansion_the_darkend_sea),
+		luabind::def("is_current_expansion_the_darkened_sea", &lua_is_current_expansion_the_darkened_sea),
 		luabind::def("is_current_expansion_the_broken_mirror", &lua_is_current_expansion_the_broken_mirror),
 		luabind::def("is_current_expansion_empires_of_kunark", &lua_is_current_expansion_empires_of_kunark),
 		luabind::def("is_current_expansion_ring_of_scale", &lua_is_current_expansion_ring_of_scale),

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -55,7 +55,7 @@ XS(XS_Client_Save) {
 		uint8 iCommitNow = (uint8) SvUV(ST(1));
 		VALIDATE_THIS_IS_CLIENT;
 		RETVAL = THIS->Save(iCommitNow);
-		ST(0)            = boolSV(RETVAL);
+		ST(0) = boolSV(RETVAL);
 		sv_2mortal(ST(0));
 	}
 	XSRETURN(1);
@@ -2688,7 +2688,7 @@ XS(XS_Client_DecreaseByID) {
 		int16  quantity  = (int16) SvIV(ST(2));
 		VALIDATE_THIS_IS_CLIENT;
 		RETVAL = THIS->DecreaseByID(type, quantity);
-		ST(0)       = boolSV(RETVAL);
+		ST(0) = boolSV(RETVAL);
 		sv_2mortal(ST(0));
 	}
 	XSRETURN(1);
@@ -2826,7 +2826,7 @@ XS(XS_Client_UseDiscipline) {
 		uint32 target   = (uint32) SvUV(ST(2));
 		VALIDATE_THIS_IS_CLIENT;
 		RETVAL = THIS->UseDiscipline(spell_id, target);
-		ST(0)           = boolSV(RETVAL);
+		ST(0) = boolSV(RETVAL);
 		sv_2mortal(ST(0));
 	}
 	XSRETURN(1);
@@ -2921,7 +2921,7 @@ XS(XS_Client_HasZoneFlag) {
 		uint32 zone_id = (uint32) SvUV(ST(1));
 		VALIDATE_THIS_IS_CLIENT;
 		RETVAL = THIS->HasZoneFlag(zone_id);
-		ST(0)          = boolSV(RETVAL);
+		ST(0) = boolSV(RETVAL);
 		sv_2mortal(ST(0));
 	}
 	XSRETURN(1);
@@ -3313,7 +3313,7 @@ XS(XS_Client_KeyRingCheck) {
 		uint32 item_id = (uint32) SvUV(ST(1));
 		VALIDATE_THIS_IS_CLIENT;
 		RETVAL = THIS->KeyRingCheck(item_id);;
-		ST(0)          = boolSV(RETVAL);
+		ST(0) = boolSV(RETVAL);
 		sv_2mortal(ST(0));
 	}
 	XSRETURN(1);
@@ -3705,7 +3705,7 @@ XS(XS_Client_GrantAlternateAdvancementAbility) {
 		}
 
 		RETVAL = THIS->GrantAlternateAdvancementAbility(aa_id, points, ignore_cost);
-		ST(0)            = boolSV(RETVAL);
+		ST(0) = boolSV(RETVAL);
 		sv_2mortal(ST(0));
 	}
 	XSRETURN(1);
@@ -3810,7 +3810,7 @@ XS(XS_Client_GetSpellIDByBookSlot) {
 		VALIDATE_THIS_IS_CLIENT;
 		RETVAL = THIS->GetSpellIDByBookSlot(slot_id);
 		XSprePUSH;
-		PUSHi((IV)RETVAL);
+		PUSHi((IV) RETVAL);
 	}
 	XSRETURN(1);
 }
@@ -3904,7 +3904,7 @@ XS(XS_Client_IsTaskCompleted) {
 		int TaskID = (int) SvIV(ST(1));
 		VALIDATE_THIS_IS_CLIENT;
 		RETVAL = THIS->IsTaskCompleted(TaskID);
-		ST(0)      = boolSV(RETVAL);
+		ST(0) = boolSV(RETVAL);
 		sv_2mortal(ST(0));
 	}
 	XSRETURN(1);
@@ -3921,7 +3921,7 @@ XS(XS_Client_IsTaskActive) {
 		int  TaskID = (int) SvIV(ST(1));
 		VALIDATE_THIS_IS_CLIENT;
 		RETVAL = THIS->IsTaskActive(TaskID);
-		ST(0)       = boolSV(RETVAL);
+		ST(0) = boolSV(RETVAL);
 		sv_2mortal(ST(0));
 	}
 	XSRETURN(1);
@@ -3939,7 +3939,7 @@ XS(XS_Client_IsTaskActivityActive) {
 		int  ActivityID = (int) SvIV(ST(2));
 		VALIDATE_THIS_IS_CLIENT;
 		RETVAL = THIS->IsTaskActivityActive(TaskID, ActivityID);
-		ST(0)           = boolSV(RETVAL);
+		ST(0) = boolSV(RETVAL);
 		sv_2mortal(ST(0));
 	}
 	XSRETURN(1);
@@ -4280,7 +4280,7 @@ XS(XS_Client_HasSpellScribed) {
 		int  spell_id = (int) SvUV(ST(1));
 		VALIDATE_THIS_IS_CLIENT;
 		RETVAL = THIS->HasSpellScribed(spell_id);
-		ST(0)         = boolSV(RETVAL);
+		ST(0) = boolSV(RETVAL);
 		sv_2mortal(ST(0));
 	}
 	XSRETURN(1);
@@ -4657,7 +4657,7 @@ XS(XS_Client_GetMoney) {
 		VALIDATE_THIS_IS_CLIENT;
 		RETVAL = THIS->GetMoney(type, subtype);
 		XSprePUSH;
-		PUSHn((uint32) RETVAL);
+		PUSHu((UV) RETVAL);
 	}
 	XSRETURN(1);
 }
@@ -4674,7 +4674,7 @@ XS(XS_Client_GetAccountAge) {
 		VALIDATE_THIS_IS_CLIENT;
 		RETVAL = THIS->GetAccountAge();
 		XSprePUSH;
-		PUSHn((int) RETVAL);
+		PUSHi((IV) RETVAL);
 	}
 	XSRETURN(1);
 }
@@ -4769,7 +4769,7 @@ XS(XS_Client_GetClientMaxLevel) {
 		VALIDATE_THIS_IS_CLIENT;
 		RETVAL = THIS->GetClientMaxLevel();
 		XSprePUSH;
-		PUSHu((UV)RETVAL);
+		PUSHu((UV) RETVAL);
 	}
 	XSRETURN(1);
 }
@@ -6015,7 +6015,7 @@ XS(XS_Client_GetEnvironmentDamageModifier) {
 		VALIDATE_THIS_IS_CLIENT;
 		RETVAL = THIS->GetEnvironmentDamageModifier();
 		XSprePUSH;
-		PUSHi((IV)RETVAL);
+		PUSHi((IV) RETVAL);
 	}
 	XSRETURN(1);
 }
@@ -6152,7 +6152,7 @@ XS(XS_Client_CountAugmentEquippedByID) {
 		VALIDATE_THIS_IS_CLIENT;
 		quantity = THIS->GetInv().CountAugmentEquippedByID(item_id);
 		XSprePUSH;
-		PUSHi((IV)quantity);
+		PUSHi((IV) quantity);
 	}
 	XSRETURN(1);
 }
@@ -6224,7 +6224,7 @@ XS(XS_Client_CountItemEquippedByID) {
 		VALIDATE_THIS_IS_CLIENT;
 		quantity = THIS->GetInv().CountItemEquippedByID(item_id);
 		XSprePUSH;
-		PUSHi((IV)quantity);
+		PUSHi((IV) quantity);
 	}
 	XSRETURN(1);
 }

--- a/zone/perl_entity.cpp
+++ b/zone/perl_entity.cpp
@@ -40,7 +40,7 @@ XS(XS_EntityList_GetMobID) {
 		uint16     id = (uint16) SvUV(ST(1));
 		VALIDATE_THIS_IS_ENTITY;
 		RETVAL = THIS->GetMobID(id);
-		ST(0)         = sv_newmortal();
+		ST(0) = sv_newmortal();
 		sv_setref_pv(ST(0), "Mob", (void *) RETVAL);
 	}
 	XSRETURN(1);
@@ -57,7 +57,7 @@ XS(XS_EntityList_GetMob) {
 		char       *name = (char *) SvPV_nolen(ST(1));
 		VALIDATE_THIS_IS_ENTITY;
 		RETVAL = THIS->GetMob(name);
-		ST(0)            = sv_newmortal();
+		ST(0) = sv_newmortal();
 		sv_setref_pv(ST(0), "Mob", (void *) RETVAL);
 	}
 	XSRETURN(1);
@@ -74,7 +74,7 @@ XS(XS_EntityList_GetMobByID) {
 		uint16     id = (uint16) SvUV(ST(1));
 		VALIDATE_THIS_IS_ENTITY;
 		RETVAL = THIS->GetMob(id);
-		ST(0)         = sv_newmortal();
+		ST(0) = sv_newmortal();
 		sv_setref_pv(ST(0), "Mob", (void *) RETVAL);
 	}
 	XSRETURN(1);
@@ -91,7 +91,7 @@ XS(XS_EntityList_GetMobByNpcTypeID) {
 		uint32     get_id = (uint32) SvUV(ST(1));
 		VALIDATE_THIS_IS_ENTITY;
 		RETVAL = THIS->GetMobByNpcTypeID(get_id);
-		ST(0)             = sv_newmortal();
+		ST(0) = sv_newmortal();
 		sv_setref_pv(ST(0), "Mob", (void *) RETVAL);
 	}
 	XSRETURN(1);
@@ -108,7 +108,7 @@ XS(XS_EntityList_IsMobSpawnedByNpcTypeID) {
 		uint32     get_id = (uint32) SvUV(ST(1));
 		VALIDATE_THIS_IS_ENTITY;
 		RETVAL = THIS->IsMobSpawnedByNpcTypeID(get_id);
-		ST(0)             = boolSV(RETVAL);
+		ST(0) = boolSV(RETVAL);
 		sv_2mortal(ST(0));
 	}
 	XSRETURN(1);
@@ -125,7 +125,7 @@ XS(XS_EntityList_GetNPCByID) {
 		uint16     id = (uint16) SvUV(ST(1));
 		VALIDATE_THIS_IS_ENTITY;
 		RETVAL = THIS->GetNPCByID(id);
-		ST(0)         = sv_newmortal();
+		ST(0) = sv_newmortal();
 		sv_setref_pv(ST(0), "NPC", (void *) RETVAL);
 	}
 	XSRETURN(1);
@@ -142,7 +142,7 @@ XS(XS_EntityList_GetNPCByNPCTypeID) {
 		uint32     npc_id = (uint32) SvUV(ST(1));
 		VALIDATE_THIS_IS_ENTITY;
 		RETVAL = THIS->GetNPCByNPCTypeID(npc_id);
-		ST(0)             = sv_newmortal();
+		ST(0) = sv_newmortal();
 		sv_setref_pv(ST(0), "NPC", (void *) RETVAL);
 	}
 	XSRETURN(1);
@@ -176,7 +176,7 @@ XS(XS_EntityList_GetClientByName) {
 		char       *name = (char *) SvPV_nolen(ST(1));
 		VALIDATE_THIS_IS_ENTITY;
 		RETVAL = THIS->GetClientByName(name);
-		ST(0)            = sv_newmortal();
+		ST(0) = sv_newmortal();
 		sv_setref_pv(ST(0), "Client", (void *) RETVAL);
 	}
 	XSRETURN(1);
@@ -193,7 +193,7 @@ XS(XS_EntityList_GetClientByAccID) {
 		uint32     accid = (uint32) SvUV(ST(1));
 		VALIDATE_THIS_IS_ENTITY;
 		RETVAL = THIS->GetClientByAccID(accid);
-		ST(0)            = sv_newmortal();
+		ST(0) = sv_newmortal();
 		sv_setref_pv(ST(0), "Client", (void *) RETVAL);
 	}
 	XSRETURN(1);
@@ -210,7 +210,7 @@ XS(XS_EntityList_GetClientByID) {
 		uint16     id = (uint16) SvUV(ST(1));
 		VALIDATE_THIS_IS_ENTITY;
 		RETVAL = THIS->GetClientByID(id);
-		ST(0)         = sv_newmortal();
+		ST(0) = sv_newmortal();
 		sv_setref_pv(ST(0), "Client", (void *) RETVAL);
 	}
 	XSRETURN(1);
@@ -227,7 +227,7 @@ XS(XS_EntityList_GetClientByCharID) {
 		uint32     iCharID = (uint32) SvUV(ST(1));
 		VALIDATE_THIS_IS_ENTITY;
 		RETVAL = THIS->GetClientByCharID(iCharID);
-		ST(0)              = sv_newmortal();
+		ST(0) = sv_newmortal();
 		sv_setref_pv(ST(0), "Client", (void *) RETVAL);
 	}
 	XSRETURN(1);
@@ -244,7 +244,7 @@ XS(XS_EntityList_GetClientByWID) {
 		uint32     iWID = (uint32) SvUV(ST(1));
 		VALIDATE_THIS_IS_ENTITY;
 		RETVAL = THIS->GetClientByWID(iWID);
-		ST(0)           = sv_newmortal();
+		ST(0) = sv_newmortal();
 		sv_setref_pv(ST(0), "Client", (void *) RETVAL);
 	}
 	XSRETURN(1);
@@ -261,7 +261,7 @@ XS(XS_EntityList_GetObjectByDBID) {
 		uint32     id = (uint32) SvUV(ST(1));
 		VALIDATE_THIS_IS_ENTITY;
 		RETVAL = THIS->GetObjectByDBID(id);
-		ST(0)         = sv_newmortal();
+		ST(0) = sv_newmortal();
 		sv_setref_pv(ST(0), "Object", (void *) RETVAL);
 	}
 	XSRETURN(1);
@@ -278,7 +278,7 @@ XS(XS_EntityList_GetObjectByID) {
 		uint32     id = (uint32) SvUV(ST(1));
 		VALIDATE_THIS_IS_ENTITY;
 		RETVAL = THIS->GetObjectByID(id);
-		ST(0)         = sv_newmortal();
+		ST(0) = sv_newmortal();
 		sv_setref_pv(ST(0), "Object", (void *) RETVAL);
 	}
 	XSRETURN(1);
@@ -295,7 +295,7 @@ XS(XS_EntityList_GetDoorsByDBID) {
 		uint32     id = (uint32) SvUV(ST(1));
 		VALIDATE_THIS_IS_ENTITY;
 		RETVAL = THIS->GetDoorsByDBID(id);
-		ST(0)         = sv_newmortal();
+		ST(0) = sv_newmortal();
 		sv_setref_pv(ST(0), "Doors", (void *) RETVAL);
 	}
 	XSRETURN(1);
@@ -312,7 +312,7 @@ XS(XS_EntityList_GetDoorsByDoorID) {
 		uint32     id = (uint32) SvUV(ST(1));
 		VALIDATE_THIS_IS_ENTITY;
 		RETVAL = THIS->GetDoorsByDoorID(id);
-		ST(0)         = sv_newmortal();
+		ST(0) = sv_newmortal();
 		sv_setref_pv(ST(0), "Doors", (void *) RETVAL);
 	}
 	XSRETURN(1);
@@ -329,7 +329,7 @@ XS(XS_EntityList_GetDoorsByID) {
 		uint32     id = (uint32) SvUV(ST(1));
 		VALIDATE_THIS_IS_ENTITY;
 		RETVAL = THIS->GetDoorsByID(id);
-		ST(0)         = sv_newmortal();
+		ST(0) = sv_newmortal();
 		sv_setref_pv(ST(0), "Doors", (void *) RETVAL);
 	}
 	XSRETURN(1);
@@ -346,7 +346,7 @@ XS(XS_EntityList_FindDoor) {
 		uint32     id = (uint32) SvUV(ST(1));
 		VALIDATE_THIS_IS_ENTITY;
 		RETVAL = THIS->FindDoor(id);
-		ST(0)         = sv_newmortal();
+		ST(0) = sv_newmortal();
 		sv_setref_pv(ST(0), "Doors", (void *) RETVAL);
 	}
 	XSRETURN(1);
@@ -413,7 +413,7 @@ XS(XS_EntityList_GetGroupByID) {
 		uint32     id = (uint32) SvUV(ST(1));
 		VALIDATE_THIS_IS_ENTITY;
 		RETVAL = THIS->GetGroupByID(id);
-		ST(0)         = sv_newmortal();
+		ST(0) = sv_newmortal();
 		sv_setref_pv(ST(0), "Group", (void *) RETVAL);
 	}
 	XSRETURN(1);
@@ -430,7 +430,7 @@ XS(XS_EntityList_GetGroupByLeaderName) {
 		char       *leader = (char *) SvPV_nolen(ST(1));
 		VALIDATE_THIS_IS_ENTITY;
 		RETVAL = THIS->GetGroupByLeaderName(leader);
-		ST(0)              = sv_newmortal();
+		ST(0) = sv_newmortal();
 		sv_setref_pv(ST(0), "Group", (void *) RETVAL);
 	}
 	XSRETURN(1);
@@ -447,7 +447,7 @@ XS(XS_EntityList_GetRaidByID) {
 		uint32     id = (uint32) SvUV(ST(1));
 		VALIDATE_THIS_IS_ENTITY;
 		RETVAL = THIS->GetRaidByID(id);
-		ST(0)         = sv_newmortal();
+		ST(0) = sv_newmortal();
 		sv_setref_pv(ST(0), "Raid", (void *) RETVAL);
 	}
 	XSRETURN(1);
@@ -514,7 +514,7 @@ XS(XS_EntityList_GetCorpseByID) {
 		uint16     id = (uint16) SvUV(ST(1));
 		VALIDATE_THIS_IS_ENTITY;
 		RETVAL = THIS->GetCorpseByID(id);
-		ST(0)         = sv_newmortal();
+		ST(0) = sv_newmortal();
 		sv_setref_pv(ST(0), "Corpse", (void *) RETVAL);
 	}
 	XSRETURN(1);
@@ -531,7 +531,7 @@ XS(XS_EntityList_GetCorpseByName) {
 		char       *name = (char *) SvPV_nolen(ST(1));
 		VALIDATE_THIS_IS_ENTITY;
 		RETVAL = THIS->GetCorpseByName(name);
-		ST(0)            = sv_newmortal();
+		ST(0) = sv_newmortal();
 		sv_setref_pv(ST(0), "Corpse", (void *) RETVAL);
 	}
 	XSRETURN(1);

--- a/zone/perl_groups.cpp
+++ b/zone/perl_groups.cpp
@@ -411,7 +411,7 @@ XS(XS_Group_GetMember) {
 				RETVAL = member->CastToClient();
 		}
 
-		ST(0)          = sv_newmortal();
+		ST(0) = sv_newmortal();
 		sv_setref_pv(ST(0), "Client", (void *) RETVAL);
 	}
 	XSRETURN(1);

--- a/zone/perl_inventory.cpp
+++ b/zone/perl_inventory.cpp
@@ -126,7 +126,7 @@ XS(XS_Inventory_GetBagIndex) {
 		VALIDATE_THIS_IS_INVENTORY;
 		bag_index = THIS->CalcBagIdx(slot_id);
 		XSprePUSH;
-		PUSHu((UV)bag_index);
+		PUSHu((UV) bag_index);
 	}
 	XSRETURN(1);
 }
@@ -162,7 +162,7 @@ XS(XS_Inventory_GetMaterialFromSlot) {
 		VALIDATE_THIS_IS_INVENTORY;
 		material = THIS->CalcMaterialFromSlot(slot_id);
 		XSprePUSH;
-		PUSHu((UV)material);
+		PUSHu((UV) material);
 	}
 	XSRETURN(1);
 }
@@ -180,7 +180,7 @@ XS(XS_Inventory_GetSlotByItemInst) {
 		VALIDATE_THIS_IS_INVENTORY;
 		slot_id = THIS->GetSlotByItemInst(item);
 		XSprePUSH;
-		PUSHi((IV)slot_id);
+		PUSHi((IV) slot_id);
 	}
 	XSRETURN(1);
 }
@@ -198,7 +198,7 @@ XS(XS_Inventory_GetSlotFromMaterial) {
 		VALIDATE_THIS_IS_INVENTORY;
 		slot_id = THIS->CalcSlotFromMaterial(material);
 		XSprePUSH;
-		PUSHi((IV)slot_id);
+		PUSHi((IV) slot_id);
 	}
 	XSRETURN(1);
 }
@@ -222,7 +222,7 @@ XS(XS_Inventory_GetSlotID) {
 		}
 
 		XSprePUSH;
-		PUSHi((IV)slot_id);
+		PUSHi((IV) slot_id);
 	}
 	XSRETURN(1);
 }
@@ -247,7 +247,7 @@ XS(XS_Inventory_HasItem) {
 
 		slot_id = THIS->HasItem(item_id, quantity, where_to_look);
 		XSprePUSH;
-		PUSHi((IV)slot_id);
+		PUSHi((IV) slot_id);
 	}
 	XSRETURN(1);
 }
@@ -269,7 +269,7 @@ XS(XS_Inventory_HasItemByLoreGroup) {
 
 		slot_id = THIS->HasItemByLoreGroup(loregroup, where_to_look);
 		XSprePUSH;
-		PUSHi((IV)slot_id);
+		PUSHi((IV) slot_id);
 	}
 	XSRETURN(1);
 }
@@ -292,7 +292,7 @@ XS(XS_Inventory_HasItemByUse) {
 
 		slot_id = THIS->HasItemByUse(item_use, quantity, where_to_look);
 		XSprePUSH;
-		PUSHi((IV)slot_id);
+		PUSHi((IV) slot_id);
 	}
 	XSRETURN(1);
 }
@@ -387,7 +387,7 @@ XS(XS_Inventory_PushCursor) {
 			slot_id = 0;
 
 		XSprePUSH;
-		PUSHi((IV)slot_id);
+		PUSHi((IV) slot_id);
 	}
 	XSRETURN(1);
 }
@@ -409,7 +409,7 @@ XS(XS_Inventory_PutItem) {
 			slot_id = 0;
 			
 		XSprePUSH;
-		PUSHi((IV)slot_id);
+		PUSHi((IV) slot_id);
 	}
 	XSRETURN(1);
 }
@@ -444,7 +444,7 @@ XS(XS_Inventory_CountAugmentEquippedByID) {
 		VALIDATE_THIS_IS_INVENTORY;
 		quantity = THIS->CountAugmentEquippedByID(item_id);
 		XSprePUSH;
-		PUSHi((IV)quantity);
+		PUSHi((IV) quantity);
 	}
 	XSRETURN(1);
 }
@@ -479,7 +479,7 @@ XS(XS_Inventory_CountItemEquippedByID) {
 		VALIDATE_THIS_IS_INVENTORY;
 		quantity = THIS->CountItemEquippedByID(item_id);
 		XSprePUSH;
-		PUSHi((IV)quantity);
+		PUSHi((IV) quantity);
 	}
 	XSRETURN(1);
 }

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -956,7 +956,7 @@ XS(XS_Mob_FindBuff) {
 		uint16 spellid = (uint16) SvUV(ST(1));
 		VALIDATE_THIS_IS_MOB;
 		RETVAL = THIS->FindBuff(spellid);
-		ST(0)          = boolSV(RETVAL);
+		ST(0) = boolSV(RETVAL);
 		sv_2mortal(ST(0));
 	}
 	XSRETURN(1);
@@ -1022,7 +1022,7 @@ XS(XS_Mob_FindType) {
 		}
 
 		RETVAL = THIS->FindType(type, bOffensive, threshold);
-		ST(0)       = boolSV(RETVAL);
+		ST(0) = boolSV(RETVAL);
 		sv_2mortal(ST(0));
 	}
 	XSRETURN(1);
@@ -2830,7 +2830,7 @@ XS(XS_Mob_IsImmuneToSpell) {
 			Perl_croak(aTHX_ "caster is nullptr, avoiding crash.");
 
 		RETVAL = THIS->IsImmuneToSpell(spell_id, caster);
-		ST(0)           = boolSV(RETVAL);
+		ST(0) = boolSV(RETVAL);
 		sv_2mortal(ST(0));
 	}
 	XSRETURN(1);
@@ -4334,7 +4334,7 @@ XS(XS_Mob_SetAA) {
 		int  charges = (items == 4) ? (int) SvIV(ST(3)) : 0;
 		VALIDATE_THIS_IS_MOB;
 		RETVAL = THIS->SetAA(aa_id, points, charges);
-		ST(0)        = boolSV(RETVAL);
+		ST(0) = boolSV(RETVAL);
 		sv_2mortal(ST(0));
 	}
 	XSRETURN(1);
@@ -4457,7 +4457,7 @@ XS(XS_Mob_EntityVariableExists) {
 		bool RETVAL;
 		VALIDATE_THIS_IS_MOB;
 		RETVAL = THIS->EntityVariableExists(id);
-		ST(0)          = boolSV(RETVAL);
+		ST(0) = boolSV(RETVAL);
 		sv_2mortal(ST(0));
 	}
 	XSRETURN(1);
@@ -4544,7 +4544,7 @@ XS(XS_Mob_CombatRange) {
 			Perl_croak(aTHX_ "target is nullptr, avoiding crash.");
 
 		RETVAL = THIS->CombatRange(target);
-		ST(0)       = boolSV(RETVAL);
+		ST(0) = boolSV(RETVAL);
 		sv_2mortal(ST(0));
 	}
 	XSRETURN(1);
@@ -4721,7 +4721,7 @@ XS(XS_Mob_HasNPCSpecialAtk) {
 		bool RETVAL;
 		VALIDATE_THIS_IS_MOB;
 		RETVAL = THIS->HasNPCSpecialAtk(parse);
-		ST(0)       = boolSV(RETVAL);
+		ST(0) = boolSV(RETVAL);
 		sv_2mortal(ST(0));
 	}
 	XSRETURN(1);
@@ -5677,7 +5677,7 @@ XS(XS_Mob_GetBuffStatValueBySpell) {
 
 		RETVAL = THIS->GetBuffStatValueBySpell(spellid, stat);
 		XSprePUSH;
-		PUSHi((IV)RETVAL);
+		PUSHi((IV) RETVAL);
 	}
 	XSRETURN(1);
 }
@@ -5697,7 +5697,7 @@ XS(XS_Mob_GetBuffStatValueBySlot) {
 
 		RETVAL = THIS->GetBuffStatValueBySlot(slot, stat);
 		XSprePUSH;
-		PUSHi((IV)RETVAL);
+		PUSHi((IV) RETVAL);
 	}
 	XSRETURN(1);
 }
@@ -5858,7 +5858,7 @@ XS(XS_Mob_GetInvisibleLevel) {
 		VALIDATE_THIS_IS_MOB;
 		RETVAL = THIS->GetInvisibleLevel();
 		XSprePUSH;
-		PUSHu((UV)RETVAL);
+		PUSHu((UV) RETVAL);
 	}
 	XSRETURN(1);
 }
@@ -5875,7 +5875,7 @@ XS(XS_Mob_GetInvisibleUndeadLevel) {
 		VALIDATE_THIS_IS_MOB;
 		RETVAL = THIS->GetInvisibleUndeadLevel();
 		XSprePUSH;
-		PUSHu((UV)RETVAL);
+		PUSHu((UV) RETVAL);
 	}
 	XSRETURN(1);
 }
@@ -5910,7 +5910,7 @@ XS(XS_Mob_SeeInvisibleUndead) {
 		VALIDATE_THIS_IS_MOB;
 		RETVAL = THIS->SeeInvisibleUndead();
 		XSprePUSH;
-		PUSHu((UV)RETVAL);
+		PUSHu((UV) RETVAL);
 	}
 	XSRETURN(1);
 }

--- a/zone/perl_npc.cpp
+++ b/zone/perl_npc.cpp
@@ -1282,7 +1282,7 @@ XS(XS_NPC_GetNPCStat) {
 
 		RETVAL = THIS->GetNPCStat(identifier);
 		XSprePUSH;
-		PUSHn((double)RETVAL);
+		PUSHn((double) RETVAL);
 	}
 	XSRETURN(1);
 }
@@ -1496,7 +1496,7 @@ XS(XS_NPC_GetScore) {
 		VALIDATE_THIS_IS_NPC;
 		RETVAL = THIS->GetScore();
 		XSprePUSH;
-		PUSHi((UV) RETVAL);
+		PUSHi((IV) RETVAL);
 	}
 	XSRETURN(1);
 }

--- a/zone/perl_object.cpp
+++ b/zone/perl_object.cpp
@@ -549,7 +549,7 @@ XS(XS_Object_EntityVariableExists) {
 		bool       RETVAL;
 		VALIDATE_THIS_IS_OBJECT;
 		RETVAL = THIS->EntityVariableExists(id);
-		ST(0)          = boolSV(RETVAL);
+		ST(0) = boolSV(RETVAL);
 		sv_2mortal(ST(0));
 	}
 	XSRETURN(1);

--- a/zone/perl_perlpacket.cpp
+++ b/zone/perl_perlpacket.cpp
@@ -317,7 +317,8 @@ XS(XS_PerlPacket_GetByte)
 		uint32		pos = (uint32)SvUV(ST(1));
 		VALIDATE_THIS_IS_PACKET;
 		RETVAL = THIS->GetByte(pos);
-		XSprePUSH; PUSHu((UV)RETVAL);
+		XSprePUSH;
+		PUSHu((UV) RETVAL);
 	}
 	XSRETURN(1);
 }
@@ -335,7 +336,8 @@ XS(XS_PerlPacket_GetShort)
 		uint32		pos = (uint32)SvUV(ST(1));
 		VALIDATE_THIS_IS_PACKET;
 		RETVAL = THIS->GetShort(pos);
-		XSprePUSH; PUSHu((UV)RETVAL);
+		XSprePUSH;
+		PUSHu((UV) RETVAL);
 	}
 	XSRETURN(1);
 }
@@ -353,7 +355,8 @@ XS(XS_PerlPacket_GetLong)
 		uint32		pos = (uint32)SvUV(ST(1));
 		VALIDATE_THIS_IS_PACKET;
 		RETVAL = THIS->GetLong(pos);
-		XSprePUSH; PUSHu((UV)RETVAL);
+		XSprePUSH;
+		PUSHu((UV) RETVAL);
 	}
 	XSRETURN(1);
 }
@@ -371,7 +374,8 @@ XS(XS_PerlPacket_GetFloat)
 		uint32		pos = (uint32)SvUV(ST(1));
 		VALIDATE_THIS_IS_PACKET;
 		RETVAL = THIS->GetFloat(pos);
-		XSprePUSH; PUSHn((double)RETVAL);
+		XSprePUSH;
+		PUSHn((double) RETVAL);
 	}
 	XSRETURN(1);
 }

--- a/zone/perl_player_corpse.cpp
+++ b/zone/perl_player_corpse.cpp
@@ -434,7 +434,7 @@ XS(XS_Corpse_CanMobLoot) {
 		int  charid = (int) SvIV(ST(1));
 		VALIDATE_THIS_IS_CORPSE;
 		RETVAL = THIS->CanPlayerLoot(charid);
-		ST(0)       = boolSV(RETVAL);
+		ST(0) = boolSV(RETVAL);
 		sv_2mortal(ST(0));
 	}
 	XSRETURN(1);

--- a/zone/perl_questitem.cpp
+++ b/zone/perl_questitem.cpp
@@ -95,7 +95,7 @@ XS(XS_QuestItem_IsType) {
 		uint32 type = (int32) SvIV(ST(1));
 		VALIDATE_THIS_IS_ITEM;
 		RETVAL = THIS->IsType((EQ::item::ItemClass) type);
-		ST(0)       = boolSV(RETVAL);
+		ST(0) = boolSV(RETVAL);
 		sv_2mortal(ST(0));
 	}
 	XSRETURN(1);

--- a/zone/perl_raids.cpp
+++ b/zone/perl_raids.cpp
@@ -40,7 +40,7 @@ XS(XS_Raid_IsRaidMember) {
 		const char *name = (char *) SvPV_nolen(ST(1));
 		VALIDATE_THIS_IS_RAID;
 		RETVAL = THIS->IsRaidMember(name);
-		ST(0)            = boolSV(RETVAL);
+		ST(0) = boolSV(RETVAL);
 		sv_2mortal(ST(0));
 	}
 	XSRETURN(1);
@@ -216,7 +216,7 @@ XS(XS_Raid_IsLeader) {
 		const char *name = (char *) SvPV_nolen(ST(1));
 		VALIDATE_THIS_IS_RAID;
 		RETVAL = THIS->IsLeader(name);
-		ST(0)            = boolSV(RETVAL);
+		ST(0) = boolSV(RETVAL);
 		sv_2mortal(ST(0));
 	}
 	XSRETURN(1);
@@ -233,7 +233,7 @@ XS(XS_Raid_IsGroupLeader) {
 		const char *who = (char *) SvPV_nolen(ST(1));
 		VALIDATE_THIS_IS_RAID;
 		RETVAL = THIS->IsGroupLeader(who);
-		ST(0)           = boolSV(RETVAL);
+		ST(0) = boolSV(RETVAL);
 		sv_2mortal(ST(0));
 	}
 	XSRETURN(1);
@@ -284,7 +284,7 @@ XS(XS_Raid_GetClientByIndex) {
 		uint16 index = (uint16) SvUV(ST(1));
 		VALIDATE_THIS_IS_RAID;
 		RETVAL = THIS->GetClientByIndex(index);
-		ST(0)        = sv_newmortal();
+		ST(0) = sv_newmortal();
 		sv_setref_pv(ST(0), "Client", (void *) RETVAL);
 	}
 	XSRETURN(1);
@@ -380,7 +380,7 @@ XS(XS_Raid_GetMember) {
 				RETVAL = THIS->members[index].member->CastToClient();
 		}
 
-		ST(0)          = sv_newmortal();
+		ST(0) = sv_newmortal();
 		sv_setref_pv(ST(0), "Client", (void *) RETVAL);
 	}
 	XSRETURN(1);


### PR DESCRIPTION
- Some push methods were pushing integers as unsigned integers or unsigned integer as integers, this fixes all of that.
- Some methods were using integer returns instead of bool returns.
- Also cleans up some lines that had multiple function calls on them.