### PR TITLE
[Quest API] Add CheckNameFilter to Perl/Lua.

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -1167,90 +1167,66 @@ uint8 Database::GetPEQZone(uint32 zone_id, uint32 version){
 	return static_cast<uint8>(std::stoi(row[0]));
 }
 
-bool Database::CheckNameFilter(const char* name, bool surname)
+bool Database::CheckNameFilter(std::string name, bool surname)
 {
-	std::string str_name = name;
+	name = str_tolower(name);
 
 	// the minimum 4 is enforced by the client too
-	if (!name || strlen(name) < 4)
-	{
+	if (name.empty() || name.size() < 4) {
 		return false;
 	}
 
 	// Given name length is enforced by the client too
-	if (!surname && strlen(name) > 15)
-	{
+	if (!surname && name.size() > 15) {
 		return false;
 	}
 
-	for (size_t i = 0; i < str_name.size(); i++)
-	{
-		if(!isalpha(str_name[i]))
-		{
+	for (size_t i = 0; i < name.size(); i++) {
+		if (!isalpha(name[i])) {
 			return false;
 		}
-	}
-
-	for(size_t x = 0; x < str_name.size(); ++x)
-	{
-		str_name[x] = tolower(str_name[x]);
 	}
 
 	char c = '\0';
 	uint8 num_c = 0;
-	for(size_t x = 0; x < str_name.size(); ++x)
-	{
-		if(str_name[x] == c)
-		{
+	for (size_t x = 0; x < name.size(); ++x) {
+		if (name[x] == c) {
 			num_c++;
-		}
-		else
-		{
+		} else {
 			num_c = 1;
-			c = str_name[x];
+			c = name[x];
 		}
-		if(num_c > 2)
-		{
+
+		if (num_c > 2) {
 			return false;
 		}
 	}
 
-
-	std::string query("SELECT name FROM name_filter");
+	std::string query = "SELECT name FROM name_filter";
 	auto results = QueryDatabase(query);
-
-	if (!results.Success())
-	{
-		// false through to true? shouldn't it be falls through to false?
+	if (!results.Success()) {
 		return true;
 	}
 
-	for (auto row = results.begin();row != results.end();++row)
-	{
-		std::string current_row = row[0];
-
-		for(size_t x = 0; x < current_row.size(); ++x)
-			current_row[x] = tolower(current_row[x]);
-
-		if(str_name.find(current_row) != std::string::npos)
+	for (auto row : results) {
+		std::string current_row = str_tolower(row[0]);
+		if (name.find(current_row) != std::string::npos) {
 			return false;
+		}
 	}
 
 	return true;
 }
 
-bool Database::AddToNameFilter(const char* name) {
-
-	std::string query = StringFormat("INSERT INTO name_filter (name) values ('%s')", name);
+bool Database::AddToNameFilter(std::string name) {
+	auto query = fmt::format(
+		"INSERT INTO name_filter (name) values ('{}')",
+		name
+	);
 	auto results = QueryDatabase(query);
-
-	if (!results.Success())
-	{
+	if (!results.Success() || !results.RowsAffected()) {
 		return false;
 	}
-
-	if (results.RowsAffected() == 0)
-		return false;
 
 	return true;
 }
@@ -1339,15 +1315,15 @@ bool Database::UpdateName(const char* oldname, const char* newname) {
 }
 
 // If the name is used or an error occurs, it returns false, otherwise it returns true
-bool Database::CheckUsedName(const char* name) {
-	std::string query = StringFormat("SELECT `id` FROM `character_data` WHERE `name` = '%s'", name);
+bool Database::CheckUsedName(std::string name) {
+	auto query = fmt::format(
+		"SELECT `id` FROM `character_data` WHERE `name` = '{}'",
+		name
+	);
 	auto results = QueryDatabase(query);
-	if (!results.Success()) {
+	if (!results.Success() || results.RowCount()) {
 		return false;
 	}
-
-	if (results.RowCount() > 0)
-		return false;
 
 	return true;
 }

--- a/common/database.h
+++ b/common/database.h
@@ -88,7 +88,6 @@ public:
 
 	/* Character Creation */
 
-	bool AddToNameFilter(const char *name);
 	bool CreateCharacter(
 		uint32 account_id,
 		char *name,
@@ -122,10 +121,11 @@ public:
 	/* General Information Queries */
 
 	bool	AddBannedIP(std::string banned_ip, std::string notes); //Add IP address to the banned_ips table.
+	bool	AddToNameFilter(std::string name);
 	bool	CheckBannedIPs(std::string login_ip); //Check incoming connection against banned IP table.
 	bool	CheckGMIPs(std::string login_ip, uint32 account_id);
-	bool	CheckNameFilter(const char* name, bool surname = false);
-	bool	CheckUsedName(const char* name);
+	bool	CheckNameFilter(std::string name, bool surname = false);
+	bool	CheckUsedName(std::string name);
 
 	uint32	GetAccountIDByChar(const char* charname, uint32* oCharID = 0);
 	uint32	GetAccountIDByChar(uint32 char_id);

--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -167,15 +167,21 @@ bool BotDatabase::LoadBotSpellCastingChances()
 /* Bot functions   */
 bool BotDatabase::QueryNameAvailablity(const std::string& bot_name, bool& available_flag)
 {
-	if (bot_name.empty() || bot_name.size() > 60 || !database.CheckUsedName(bot_name.c_str()))
+	if (bot_name.empty() || bot_name.size() > 60 || !database.CheckUsedName(bot_name))
 		return false;
 
-	query = StringFormat("SELECT `id` FROM `vw_bot_character_mobs` WHERE `name` LIKE '%s' LIMIT 1", bot_name.c_str());
+	query = fmt::format(
+		"SELECT `id` FROM `vw_bot_character_mobs` WHERE `name` LIKE '{}' LIMIT 1",
+		bot_name
+	);
 	auto results = database.QueryDatabase(query);
-	if (!results.Success())
+	if (!results.Success()) {
 		return false;
-	if (results.RowCount())
+	}
+
+	if (results.RowCount()) {
 		return true;
+	}
 
 	available_flag = true;
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -6375,7 +6375,7 @@ void Client::Handle_OP_GMNameChange(const EQApplicationPacket *app)
 	}
 	Client* client = entity_list.GetClientByName(gmn->oldname);
 	LogInfo("GM([{}]) changeing players name. Old:[{}] New:[{}]", GetName(), gmn->oldname, gmn->newname);
-	bool usedname = database.CheckUsedName((const char*)gmn->newname);
+	bool usedname = database.CheckUsedName(gmn->newname);
 	if (client == 0) {
 		Message(Chat::Red, "%s not found for name change. Operation failed!", gmn->oldname);
 		return;

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -8191,6 +8191,21 @@ XS(XS__commify) {
 	XSRETURN(1);
 }
 
+XS(XS__checknamefilter);
+XS(XS__checknamefilter) {
+	dXSARGS;
+	if (items != 1) {
+		Perl_croak(aTHX_ "Usage: quest::checknamefilter(std::string name)");
+	}
+
+	dXSTARG;
+	std::string name = (std::string) SvPV_nolen(ST(0));
+	bool passes = database.CheckNameFilter(name);
+	ST(0) = boolSV(passes);
+	sv_2mortal(ST(0));
+	XSRETURN(1);
+}
+
 /*
 This is the callback perl will look for to setup the
 quest package's XSUBs
@@ -8278,6 +8293,7 @@ EXTERN_C XS(boot_quest) {
 	newXS(strcpy(buf, "buryplayercorpse"), XS__buryplayercorpse, file);
 	newXS(strcpy(buf, "castspell"), XS__castspell, file);
 	newXS(strcpy(buf, "changedeity"), XS__changedeity, file);
+	newXS(strcpy(buf, "checknamefilter"), XS__checknamefilter, file);
 	newXS(strcpy(buf, "checktitle"), XS__checktitle, file);
 	newXS(strcpy(buf, "clear_npctype_cache"), XS__clear_npctype_cache, file);
 	newXS(strcpy(buf, "clear_proximity"), XS__clear_proximity, file);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -3392,6 +3392,10 @@ std::string lua_commify(std::string number) {
 	return commify(number);
 }
 
+bool lua_check_name_filter(std::string name) {
+	return database.CheckNameFilter(name);
+}
+
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
 	cur = table[#name]; \
 	if(luabind::type(cur) != LUA_TNIL) { \
@@ -3845,6 +3849,7 @@ luabind::scope lua_register_general() {
 		luabind::def("get_consider_level_name", &lua_get_consider_level_name),
 		luabind::def("get_environmental_damage_name", &lua_get_environmental_damage_name),
 		luabind::def("commify", &lua_commify),
+		luabind::def("check_name_filter", &lua_check_name_filter),
 
 		/*
 			Cross Zone


### PR DESCRIPTION
- Add quest::checknamefilter(name) to Perl.
- Add eq.check_name_filter(name) to Lua.
- Allows operators to check strings against the name filter for stuff like setting custom pet names, titles, suffixes, etc in scripts.