### PR TITLE
[Quest API] Add TaskSelector to Perl/Lua.

### DIFF
--- a/zone/client.h
+++ b/zone/client.h
@@ -1236,7 +1236,7 @@ public:
 	}
 	inline void AssignTask(
 		int task_id,
-		int npc_id,
+		int npc_id = 0,
 		bool enforce_level_requirement = false
 	) {
 		if (task_state) {

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -5700,7 +5700,7 @@ XS(XS__crosszoneassigntaskbyraidid);
 XS(XS__crosszoneassigntaskbyraidid) {
 	dXSARGS;
 	if (items < 2 || items > 3)
-		Perl_croak(aTHX_ "Usage: quest::crosszoneassigntaskbyraidid(int raid_id, uint32 task_identifier, [bool enforce_level_requirement = false])");\
+		Perl_croak(aTHX_ "Usage: quest::crosszoneassigntaskbyraidid(int raid_id, uint32 task_identifier, [bool enforce_level_requirement = false])");
 	{
 		uint8 update_type = CZUpdateType_Raid;
 		uint8 update_subtype = CZTaskUpdateSubtype_AssignTask;

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -1385,14 +1385,19 @@ void Lua_Client::UpdateTaskActivity(int task, int activity, int count) {
 	self->UpdateTaskActivity(task, activity, count);
 }
 
-void Lua_Client::AssignTask(int task, int npc_id) {
+void Lua_Client::AssignTask(int task_id) {
 	Lua_Safe_Call_Void();
-	self->AssignTask(task, npc_id);
+	self->AssignTask(task_id);
 }
 
-void Lua_Client::AssignTask(int task, int npc_id, bool enforce_level_requirement) {
+void Lua_Client::AssignTask(int task_id, int npc_id) {
 	Lua_Safe_Call_Void();
-	self->AssignTask(task, npc_id, enforce_level_requirement);
+	self->AssignTask(task_id, npc_id);
+}
+
+void Lua_Client::AssignTask(int task_id, int npc_id, bool enforce_level_requirement) {
+	Lua_Safe_Call_Void();
+	self->AssignTask(task_id, npc_id, enforce_level_requirement);
 }
 
 void Lua_Client::FailTask(int task) {
@@ -2486,6 +2491,35 @@ int Lua_Client::GetSpellDamage() {
 	return self->GetSpellDmg();
 }
 
+void Lua_Client::TaskSelector(luabind::adl::object table) {
+	Lua_Safe_Call_Void();
+
+	if(luabind::type(table) != LUA_TTABLE) {
+		return;
+	}
+
+	int tasks[MAXCHOOSERENTRIES] = { 0 };
+	int task_count = 0;
+
+	for(int i = 1; i <= MAXCHOOSERENTRIES; ++i) {
+		auto cur = table[i];
+		int cur_value = 0;
+		if(luabind::type(cur) != LUA_TNIL) {
+			try {
+				cur_value = luabind::object_cast<int>(cur);
+			} catch(luabind::cast_failed &) {
+			}
+		} else {
+			task_count = i - 1;
+			break;
+		}
+
+		tasks[i - 1] = cur_value;
+	}
+
+	self->TaskQuestSetSelector(self, task_count, tasks);
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 	.def(luabind::constructor<>())
@@ -2514,6 +2548,7 @@ luabind::scope lua_register_client() {
 	.def("AddPVPPoints", (void(Lua_Client::*)(uint32))&Lua_Client::AddPVPPoints)
 	.def("AddSkill", (void(Lua_Client::*)(int,int))&Lua_Client::AddSkill)
 	.def("Admin", (int(Lua_Client::*)(void))&Lua_Client::Admin)
+	.def("AssignTask", (void(Lua_Client::*)(int))&Lua_Client::AssignTask)
 	.def("AssignTask", (void(Lua_Client::*)(int,int))&Lua_Client::AssignTask)
 	.def("AssignTask", (void(Lua_Client::*)(int,int,bool))&Lua_Client::AssignTask)
 	.def("AssignToInstance", (void(Lua_Client::*)(int))&Lua_Client::AssignToInstance)
@@ -2876,6 +2911,7 @@ luabind::scope lua_register_client() {
 	.def("TakeMoneyFromPP", (bool(Lua_Client::*)(uint64,bool))&Lua_Client::TakeMoneyFromPP)
 	.def("TakePlatinum", (bool(Lua_Client::*)(uint32))&Lua_Client::TakePlatinum)
 	.def("TakePlatinum", (bool(Lua_Client::*)(uint32,bool))&Lua_Client::TakePlatinum)
+	.def("TaskSelector", (void(Lua_Client::*)(luabind::adl::object))&Lua_Client::TaskSelector)
 	.def("Thirsty", (bool(Lua_Client::*)(void))&Lua_Client::Thirsty)
 	.def("TrainDisc", (void(Lua_Client::*)(int))&Lua_Client::TrainDisc)
 	.def("TrainDiscBySpellID", (void(Lua_Client::*)(int32))&Lua_Client::TrainDiscBySpellID)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -325,8 +325,9 @@ public:
 	uint32 GetSpellIDByBookSlot(int book_slot);
 	int FindSpellBookSlotBySpellID(int spell_id);
 	void UpdateTaskActivity(int task, int activity, int count);
-	void AssignTask(int task, int npc_id);
-	void AssignTask(int task, int npc_id, bool enforce_level_requirement);
+	void AssignTask(int task_id);
+	void AssignTask(int task_id, int npc_id);
+	void AssignTask(int task_id, int npc_id, bool enforce_level_requirement);
 	void FailTask(int task);
 	bool IsTaskCompleted(int task);
 	bool IsTaskActive(int task);
@@ -419,6 +420,7 @@ public:
 
 	void SetPrimaryWeaponOrnamentation(uint32 model_id);
 	void SetSecondaryWeaponOrnamentation(uint32 model_id);
+	void TaskSelector(luabind::adl::object table);
 
 	void SetClientMaxLevel(int value);
 	int GetClientMaxLevel();

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -3861,20 +3861,24 @@ XS(XS_Client_GetTaskActivityDoneCount) {
 XS(XS_Client_AssignTask); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Client_AssignTask) {
 	dXSARGS;
-	if (items != 3 && items != 4)
-		Perl_croak(aTHX_ "Usage: Client::AssignTask(THIS, int task_id, int npc_id, [bool enforce_level_requirement = false])"); // @categories Tasks and Activities
+	if (items < 2 || items > 4)
+		Perl_croak(aTHX_ "Usage: Client::AssignTask(THIS, int task_id, [int npc_id = 0, bool enforce_level_requirement = false])"); // @categories Tasks and Activities
 	{
 		Client *THIS;
-		int  TaskID                    = (int) SvIV(ST(1));
-		int  NPCID                     = (int) SvIV(ST(2));
+		int task_id = (int) SvIV(ST(1));
+		int npc_id = 0;
 		bool enforce_level_requirement = false;
-		if (items == 4) {
-			if ((int) SvIV(ST(3)) == 1) {
-				enforce_level_requirement = true;
-			}
-		}
 		VALIDATE_THIS_IS_CLIENT;
-		THIS->AssignTask(TaskID, NPCID, enforce_level_requirement);
+
+		if (items > 2) {
+			npc_id = (int) SvIV(ST(2));
+		}
+
+		if (items > 3) {
+			enforce_level_requirement = SvTRUE(ST(3));
+		}
+
+		THIS->AssignTask(task_id, npc_id, enforce_level_requirement);
 	}
 	XSRETURN_EMPTY;
 }
@@ -6366,6 +6370,26 @@ XS(XS_Client_GetSpellDamage) {
 	XSRETURN(1);
 }
 
+XS(XS_Client_TaskSelector); /* prototype to pass -Wmissing-prototypes */
+XS(XS_Client_TaskSelector) {
+	dXSARGS;
+	if (items < 2 || items > 41) {
+		Perl_croak(aTHX_ "Usage: Client::TaskSelector(THIS, int task_id, 2, 3, 4, 5 [up to 40])");
+	}
+
+	Client *THIS;
+	VALIDATE_THIS_IS_CLIENT;
+
+	int tasks[MAXCHOOSERENTRIES];
+	int task_count = (items - 1);
+	for (int i = 1; i <= task_count; i++) {
+		tasks[i] = (int) SvIV(ST(i));
+	}
+
+	THIS->TaskQuestSetSelector(THIS, task_count, tasks);
+	XSRETURN_EMPTY;
+}
+
 #ifdef __cplusplus
 extern "C"
 #endif
@@ -6400,7 +6424,7 @@ XS(boot_Client) {
 	newXSproto(strcpy(buf, "AddPVPPoints"), XS_Client_AddPVPPoints, file, "$$");
 	newXSproto(strcpy(buf, "AddSkill"), XS_Client_AddSkill, file, "$$$");
 	newXSproto(strcpy(buf, "Admin"), XS_Client_Admin, file, "$");
-	newXSproto(strcpy(buf, "AssignTask"), XS_Client_AssignTask, file, "$$$;$");
+	newXSproto(strcpy(buf, "AssignTask"), XS_Client_AssignTask, file, "$$;$$");
 	newXSproto(strcpy(buf, "AssignToInstance"), XS_Client_AssignToInstance, file, "$$");
 	newXSproto(strcpy(buf, "AutoSplitEnabled"), XS_Client_AutoSplitEnabled, file, "$");
 	newXSproto(strcpy(buf, "BreakInvis"), XS_Client_BreakInvis, file, "$");
@@ -6692,6 +6716,7 @@ XS(boot_Client) {
 	newXSproto(strcpy(buf, "TGB"), XS_Client_TGB, file, "$");
 	newXSproto(strcpy(buf, "TakeMoneyFromPP"), XS_Client_TakeMoneyFromPP, file, "$$;$");
 	newXSproto(strcpy(buf, "TakePlatinum"), XS_Client_TakePlatinum, file, "$$;$");
+	newXSproto(strcpy(buf, "TaskSelector"), XS_Client_TaskSelector, file, "$$;$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$");
 	newXSproto(strcpy(buf, "Thirsty"), XS_Client_Thirsty, file, "$");
 	newXSproto(strcpy(buf, "TrainDiscBySpellID"), XS_Client_TrainDiscBySpellID, file, "$$");
 	newXSproto(strcpy(buf, "UnFreeze"), XS_Client_UnFreeze, file, "$");


### PR DESCRIPTION
- Add $client->TaskSelector(task_list) to Perl.
- Add client:TaskSelector({task_list}) to Lua.
- Allow $client->AssignTask(task_id) in Perl.
- Allow client:AssignTask(task_id) in Lua.
- Can now assign tasks in scripts without the NPC ID parameter.