### PR TITLE
[Aggro] Rooted mobs will add other hated targets to Hate list

### DIFF
--- a/zone/aggro.cpp
+++ b/zone/aggro.cpp
@@ -456,7 +456,12 @@ bool Mob::CheckWillAggro(Mob *mob) {
 	}
 
 	// Don't aggro new clients if we are already engaged unless PROX_AGGRO is set
-	if (IsEngaged() && (!GetSpecialAbility(PROX_AGGRO) || (GetSpecialAbility(PROX_AGGRO) && !CombatRange(mob)))) {
+
+	// Frustrated mobs (all rooted up with no one to kill)
+	// will engage without PROX_AGGRO ability if someone new is close now.
+	bool is_frustrated = (IsRooted() && !CombatRange(target));
+
+	if (!is_frustrated && IsEngaged() && (!GetSpecialAbility(PROX_AGGRO) || (GetSpecialAbility(PROX_AGGRO) && !CombatRange(mob)))) {
 		LogAggro(
 			"[{}] is in combat, and does not have prox_aggro, or does and is out of combat range with [{}]",
 			GetName(),


### PR DESCRIPTION
So the following scenario seemed wrong to me so I tested on live, and I was correct.

Before this PR:

- Pull a mob and root it next to your group.
-  Back up.
- The mob just stands there.  No one else is added to the hate list.

I tested this on live.  If the current target is out of combat range, it will attack anyone else it hates that is in range.

This is even true of unrooted mobs, but I wasn't sure the community was ready for that big of a change, so I didn't include that.

This PR simply lets other targets to be added to the hatelist if they are close enough and the mob can't reach its currently engaged target due to root.

Feedback appreciated..