### PR TITLE
[Rules] Add Spells:IllusionsAlwaysPersist.

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -417,6 +417,7 @@ RULE_BOOL(Spells, CompoundLifetapHeals, true, "True: Lifetap heals calculate dam
 RULE_BOOL(Spells, UseFadingMemoriesMaxLevel, false, "Enables to limit field in spell data to set the max level that over which an NPC will ignore fading memories effect and not lose aggro.")
 RULE_BOOL(Spells, FixBeaconHeading, false, "Beacon spells use casters heading to fix live bug.  False: Live like heading always 0.")
 RULE_BOOL(Spells, UseSpellImpliedTargeting, false, "Replicates EQ2-style targeting behavior for spells. Spells will 'pass through' inappropriate targets to target's target if it is appropriate.")
+RULE_BOOL(Spells, IllusionsAlwaysPersist, false, "Allows Illusions to persist beyond death and zoning always.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Combat)

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -10214,8 +10214,17 @@ void Mob::ApplySpellEffectIllusion(int32 spell_id, Mob *caster, int buffslot, in
 	}
 
 	if (buffslot != -1) {
-		if (caster == this && spell_id != SPELL_MINOR_ILLUSION && spell_id != SPELL_ILLUSION_TREE &&
-			(spellbonuses.IllusionPersistence || aabonuses.IllusionPersistence || itembonuses.IllusionPersistence)) {
+		if (
+			caster == this &&
+			spell_id != SPELL_MINOR_ILLUSION &&
+			spell_id != SPELL_ILLUSION_TREE &&
+			(
+				spellbonuses.IllusionPersistence ||
+				aabonuses.IllusionPersistence ||
+				itembonuses.IllusionPersistence ||
+				RuleB(Spells, IllusionsAlwaysPersist)
+			)
+		) {
 			buffs[buffslot].persistant_buff = 1;
 		}
 		else {
@@ -10225,9 +10234,18 @@ void Mob::ApplySpellEffectIllusion(int32 spell_id, Mob *caster, int buffslot, in
 }
 
 bool Mob::HasPersistDeathIllusion(int32 spell_id) {
-
-	if (spellbonuses.IllusionPersistence > 1 || aabonuses.IllusionPersistence > 1  || itembonuses.IllusionPersistence > 1) {
-		if (spell_id != SPELL_MINOR_ILLUSION && spell_id != SPELL_ILLUSION_TREE && IsEffectInSpell(spell_id, SE_Illusion) && IsBeneficialSpell(spell_id)) {
+	if (
+		spellbonuses.IllusionPersistence > 1 ||
+		aabonuses.IllusionPersistence > 1  ||
+		itembonuses.IllusionPersistence > 1 ||
+		RuleB(Spells, IllusionsAlwaysPersist)
+	) {
+		if (
+			spell_id != SPELL_MINOR_ILLUSION &&
+			spell_id != SPELL_ILLUSION_TREE &&
+			IsEffectInSpell(spell_id, SE_Illusion) &&
+			IsBeneficialSpell(spell_id)
+		) {
 			return true;
 		}
 	}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -2800,9 +2800,18 @@ int Mob::CalcBuffDuration(Mob *caster, Mob *target, uint16 spell_id, int32 caste
 		castlevel = caster_level_override;
 
 	int res = CalcBuffDuration_formula(castlevel, formula, duration);
-	if (caster == target && (target->aabonuses.IllusionPersistence || target->spellbonuses.IllusionPersistence ||
-		target->itembonuses.IllusionPersistence) &&
-		spell_id != SPELL_MINOR_ILLUSION && spell_id != SPELL_ILLUSION_TREE && IsEffectInSpell(spell_id, SE_Illusion)) {
+	if (
+		caster == target &&
+		(
+			target->aabonuses.IllusionPersistence ||
+			target->spellbonuses.IllusionPersistence ||
+			target->itembonuses.IllusionPersistence ||
+			RuleB(Spells, IllusionsAlwaysPersist)
+		) &&
+		spell_id != SPELL_MINOR_ILLUSION &&
+		spell_id != SPELL_ILLUSION_TREE &&
+		IsEffectInSpell(spell_id, SE_Illusion)
+	) {
 		res = 10000; // ~16h override
 	}
 


### PR DESCRIPTION
- Allows illusions to always persist beyond death or zoning.