### PR TITLE
[Money Messages] Cleanup quest::givecash(), split, and task reward messages.

### DIFF
--- a/common/string_util.cpp
+++ b/common/string_util.cpp
@@ -1192,75 +1192,75 @@ std::string ConvertMoneyToString(uint32 platinum, uint32 gold, uint32 silver, ui
 	if (copper && silver && gold && platinum) { // CSGP
 		money_string = fmt::format(
 			"{} Platinum, {} Gold, {} Silver, and {} Copper",
-			platinum,
-			gold,
-			silver,
-			copper
+			commify(std::to_string(platinum)),
+			commify(std::to_string(gold)),
+			commify(std::to_string(silver)),
+			commify(std::to_string(copper))
 		);
 	} else if (copper && silver && gold && !platinum) { // CSG
 		money_string = fmt::format(
 			"{} Gold, {} Silver, and {} Copper",
-			gold,
-			silver,
-			copper
+			commify(std::to_string(gold)),
+			commify(std::to_string(silver)),
+			commify(std::to_string(copper))
 		);
 	} else if (copper && silver && !gold && !platinum) { // CS
 		money_string = fmt::format(
 			"{} Silver and {} Copper",
-			silver,
-			copper
+			commify(std::to_string(silver)),
+			commify(std::to_string(copper))
 		);
 	} else if (!copper && silver && gold && platinum) { // SGP
 		money_string = fmt::format(
 			"{} Platinum, {} Gold, and {} Silver",
-			platinum,
-			gold,
-			silver
+			commify(std::to_string(platinum)),
+			commify(std::to_string(gold)),
+			commify(std::to_string(silver))
 		);
 	} else if (!copper && silver && gold && !platinum) { // SG
 		money_string = fmt::format(
 			"{} Gold and {} Silver",
-			gold,
-			silver
+			commify(std::to_string(gold)),
+			commify(std::to_string(silver))
 		);
 	} else if (copper && !silver && gold && platinum) { // CGP
 		money_string = fmt::format(
 			"{} Platinum, {} Gold, and {} Copper",
-			platinum,
-			gold,
-			copper
+			commify(std::to_string(platinum)),
+			commify(std::to_string(gold)),
+			commify(std::to_string(copper))
 		);
 	} else if (copper && !silver && gold && !platinum) { // CG
 		money_string = fmt::format(
 			"{} Gold and {} Copper",
-			gold,
-			copper
+			commify(std::to_string(gold)),
+			commify(std::to_string(copper))
 		);
 	} else if (!copper && !silver && gold && platinum) { // GP
 		money_string = fmt::format(
 			"{} Platinum and {} Gold",
-			platinum,
-			gold
+			commify(std::to_string(platinum)),
+			commify(std::to_string(gold))
 		);
 	} else if (!copper && !silver && !gold && platinum) { // P
 		money_string = fmt::format(
 			"{} Platinum",
-			platinum
+			commify(std::to_string(platinum))
 		);
 	} else if (!copper && !silver && gold && !platinum) { // G
 		money_string = fmt::format(
 			"{} Gold",
-			gold
+			commify(std::to_string(gold))
 		);
 	} else if (!copper && silver && !gold && !platinum) { // S
 		money_string = fmt::format(
 			"{} Silver",
-			silver
+			commify(std::to_string(silver))
 		);
 	} else if (copper && !silver && !gold && !platinum) { // C
 		money_string = fmt::format(
 			"{} Copper",
-			copper
+			commify(std::to_string(copper))
 		);
 	}
 	return money_string;

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -1029,7 +1029,12 @@ void Corpse::MakeLootRequestPackets(Client* client, const EQApplicationPacket* a
 				Chat::Yellow,
 				fmt::format(
 					"This corpse contains {}.",
-					ConvertMoneyToString(GetPlatinum(), GetGold(), GetSilver(), GetCopper())
+					ConvertMoneyToString(
+						GetPlatinum(),
+						GetGold(),
+						GetSilver(),
+						GetCopper()
+					)
 				).c_str()
 			);
 		} else {
@@ -1519,13 +1524,12 @@ void Corpse::QueryLoot(Client* to) {
 		}
 	}
 
-	bool has_money = (
-		platinum > 0 ||
-		gold > 0 ||
-		silver > 0 ||
-		copper > 0
-	);
-	if (has_money) {
+	if (
+		platinum ||
+		gold ||
+		silver ||
+		copper
+	) {
 		to->Message(
 			Chat::White,
 			fmt::format(

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -1019,8 +1019,22 @@ void Corpse::MakeLootRequestPackets(Client* client, const EQApplicationPacket* a
 		loot_coin = (tmp[0] == 1 && tmp[1] == '\0');
 
 	if (loot_request_type == LootRequestType::GMPeek || loot_request_type == LootRequestType::GMAllowed) {
-		client->Message(Chat::Yellow, "This corpse contains %u platinum, %u gold, %u silver and %u copper.",
-			GetPlatinum(), GetGold(), GetSilver(), GetCopper());
+		if (
+			GetPlatinum() ||
+			GetGold() ||
+			GetSilver() ||
+			GetCopper()
+		) {
+			client->Message(
+				Chat::Yellow,
+				fmt::format(
+					"This corpse contains {}.",
+					ConvertMoneyToString(GetPlatinum(), GetGold(), GetSilver(), GetCopper())
+				).c_str()
+			);
+		} else {
+			client->Message(Chat::Yellow, "This corpse contains no money.");
+		}
 
 		auto outapp = new EQApplicationPacket(OP_MoneyOnCorpse, sizeof(moneyOnCorpseStruct));
 		moneyOnCorpseStruct* d = (moneyOnCorpseStruct*)outapp->pBuffer;

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -1160,13 +1160,26 @@ XS(XS__untraindiscs) {
 XS(XS__givecash);
 XS(XS__givecash) {
 	dXSARGS;
-	if (items != 4)
-		Perl_croak(aTHX_ "Usage: quest::givecash(int copper, int silver, int gold, int platinum)");
+	if (items < 1 || items > 4) {
+		Perl_croak(aTHX_ "Usage: quest::givecash(uint32 copper, [uint32 silver = 0, uint32 gold = 0, uint32 platinum = 0])");
+	}
 
-	int copper   = (int) SvIV(ST(0));
-	int silver   = (int) SvIV(ST(1));
-	int gold     = (int) SvIV(ST(2));
-	int platinum = (int) SvIV(ST(3));
+	uint32 copper = (uint32) SvUV(ST(0));
+	uint32 silver = 0;
+	uint32 gold = 0;
+	uint32 platinum = 0;
+
+	if (items > 1) {
+		silver = (uint32) SvUV(ST(1));
+	}
+
+	if (items > 2) {
+		gold = (uint32) SvUV(ST(2));
+	}
+
+	if (items > 3) {
+		platinum = (uint32) SvUV(ST(3));
+	}
 
 	quest_manager.givecash(copper, silver, gold, platinum);
 

--- a/zone/gm_commands/givemoney.cpp
+++ b/zone/gm_commands/givemoney.cpp
@@ -35,7 +35,12 @@ void command_givemoney(Client *c, const Seperator *sep)
 		Chat::White,
 		fmt::format(
 			"Added {} to {}.",
-			ConvertMoneyToString(platinum, gold, silver, copper),
+			ConvertMoneyToString(
+				platinum,
+				gold,
+				silver,
+				copper
+			),
 			c->GetTargetDescription(target)
 		).c_str()
 	);

--- a/zone/groups.cpp
+++ b/zone/groups.cpp
@@ -116,91 +116,65 @@ Group::~Group()
 //Split money used in OP_Split (/split and /autosplit).
 void Group::SplitMoney(uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Client *splitter) {
 	//avoid unneeded work
-	if(copper == 0 && silver == 0 && gold == 0 && platinum == 0)
+	if (
+		!copper &&
+		!silver &&
+		!gold &&
+		!platinum
+	) {
 		return;
+	}
 
-	uint32 i;
-	uint8 membercount = 0;
-	for (i = 0; i < MAX_GROUP_MEMBERS; i++) {
+	uint8 member_count = 0;
+	for (uint32 i = 0; i < MAX_GROUP_MEMBERS; i++) {
 		// Don't split with Mercs or Bots
-		if (members[i] != nullptr && members[i]->IsClient()) {
-			membercount++;
+		if (members[i] && members[i]->IsClient()) {
+			member_count++;
 		}
 	}
 
-	if (membercount == 0)
+	if (!member_count) {
 		return;
+	}
 
-	uint32 mod;
-	//try to handle round off error a little better
-	if(membercount > 1) {
-		mod = platinum % membercount;
-		if((mod) > 0) {
-			platinum -= mod;
-			gold += 10 * mod;
+	uint32 modifier;
+	if (member_count > 1) {
+		modifier = platinum % member_count;
+
+		if (modifier) {
+			platinum -= modifier;
+			gold += 10 * modifier;
 		}
-		mod = gold % membercount;
-		if((mod) > 0) {
-			gold -= mod;
-			silver += 10 * mod;
+
+		modifier = gold % member_count;
+
+		if (modifier) {
+			gold -= modifier;
+			silver += 10 * modifier;
 		}
-		mod = silver % membercount;
-		if((mod) > 0) {
-			silver -= mod;
-			copper += 10 * mod;
+
+		modifier = silver % member_count;
+
+		if (modifier) {
+			silver -= modifier;
+			copper += 10 * modifier;
 		}
 	}
 
-	//calculate the splits
-	//We can still round off copper pieces, but I dont care
-	uint32 sc;
-	uint32 cpsplit = copper / membercount;
-	sc = copper % membercount;
-	uint32 spsplit = silver / membercount;
-	uint32 gpsplit = gold / membercount;
-	uint32 ppsplit = platinum / membercount;
+	auto copper_split = copper / member_count;
+	auto silver_split = silver / member_count;
+	auto gold_split = gold / member_count;
+	auto platinum_split = platinum / member_count;
 
-	char buf[128];
-	buf[63] = '\0';
-	std::string msg = "You receive";
-	bool one = false;
+	auto cash_message = fmt::format(
+		"You receive {} as your split.",
+		ConvertMoneyToString(platinum_split, gold_split, silver_split, copper_split)
+	);
 
-	if(ppsplit > 0) {
-		snprintf(buf, 63, " %u platinum", ppsplit);
-		msg += buf;
-		one = true;
-	}
-	if(gpsplit > 0) {
-		if(one)
-			msg += ",";
-		snprintf(buf, 63, " %u gold", gpsplit);
-		msg += buf;
-		one = true;
-	}
-	if(spsplit > 0) {
-		if(one)
-			msg += ",";
-		snprintf(buf, 63, " %u silver", spsplit);
-		msg += buf;
-		one = true;
-	}
-	if(cpsplit > 0) {
-		if(one)
-			msg += ",";
-		//this message is not 100% accurate for the splitter
-		//if they are receiving any roundoff
-		snprintf(buf, 63, " %u copper", cpsplit);
-		msg += buf;
-		one = true;
-	}
-	msg += " as your split";
-
-	for (i = 0; i < MAX_GROUP_MEMBERS; i++) {
-		if (members[i] != nullptr && members[i]->IsClient()) { // If Group Member is Client
-			Client *c = members[i]->CastToClient();
-			//I could not get MoneyOnCorpse to work, so we use this
-			c->AddMoneyToPP(cpsplit, spsplit, gpsplit, ppsplit, true);
-			c->Message(Chat::Green, msg.c_str());
+	for (uint32 i = 0; i < MAX_GROUP_MEMBERS; i++) {
+		if (members[i] && members[i]->IsClient()) { // If Group Member is Client
+			members[i]->CastToClient()->AddMoneyToPP(copper_split, silver_split, gold_split, platinum_split, true);
+			members[i]->CastToClient()->Message(Chat::Green, cash_message.c_str());
 		}
 	}
 }

--- a/zone/groups.cpp
+++ b/zone/groups.cpp
@@ -166,15 +166,26 @@ void Group::SplitMoney(uint32 copper, uint32 silver, uint32 gold, uint32 platinu
 	auto gold_split = gold / member_count;
 	auto platinum_split = platinum / member_count;
 
-	auto cash_message = fmt::format(
-		"You receive {} as your split.",
-		ConvertMoneyToString(platinum_split, gold_split, silver_split, copper_split)
-	);
-
 	for (uint32 i = 0; i < MAX_GROUP_MEMBERS; i++) {
 		if (members[i] && members[i]->IsClient()) { // If Group Member is Client
-			members[i]->CastToClient()->AddMoneyToPP(copper_split, silver_split, gold_split, platinum_split, true);
-			members[i]->CastToClient()->Message(Chat::Green, cash_message.c_str());
+			members[i]->CastToClient()->AddMoneyToPP(
+				copper_split,
+				silver_split,
+				gold_split,
+				platinum_split,
+				true
+			);
+
+			members[i]->CastToClient()->MessageString(
+				Chat::MoneySplit,
+				YOU_RECEIVE_AS_SPLIT,
+				ConvertMoneyToString(
+					platinum_split,
+					gold_split,
+					silver_split,
+					copper_split
+				).c_str()
+			);
 		}
 	}
 }

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -693,13 +693,12 @@ void NPC::QueryLoot(Client* to, bool is_pet_query)
 	}
 
 	if (!is_pet_query) {
-		bool has_money = (
-			platinum > 0 ||
-			gold > 0 ||
-			silver > 0 ||
-			copper > 0
-		);
-		if (has_money) {
+		if (
+			platinum ||
+			gold ||
+			silver ||
+			copper
+		) {
 			to->Message(
 				Chat::White,
 				fmt::format(

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -1170,52 +1170,35 @@ void QuestManager::untraindiscs() {
 	initiator->UntrainDiscAll();
 }
 
-void QuestManager::givecash(int copper, int silver, int gold, int platinum) {
+void QuestManager::givecash(uint32 copper, uint32 silver, uint32 gold, uint32 platinum) {
 	QuestManagerCurrentQuestVars();
-	if (initiator && initiator->IsClient() && ((copper + silver + gold + platinum) > 0))
-	{
+	if (
+		initiator &&
+		initiator->IsClient() &&
+		(
+			copper ||
+			silver ||
+			gold ||
+			platinum
+		)
+	) {
 		initiator->AddMoneyToPP(copper, silver, gold, platinum, true);
 
-		std::string tmp;
-		if (platinum > 0)
-		{
-			tmp = "You receive ";
-			tmp += itoa(platinum);
-			tmp += " platinum";
-		}
-		if (gold > 0)
-		{
-			if (tmp.length() == 0)
-				tmp = "You receive ";
-			else
-				tmp += ",";
+		auto money_string = ConvertMoneyToString(platinum, gold, silver, copper);
 
-			tmp += itoa(gold);
-			tmp += " gold";
+		if (money_string == "Unknown") {
+			return;
 		}
-		if(silver > 0)
-		{
-			if (tmp.length() == 0)
-				tmp = "You receive ";
-			else
-				tmp += ",";
 
-			tmp += itoa(silver);
-			tmp += " silver";
+		if (initiator) {
+			initiator->Message(
+				Chat::Green,
+				fmt::format(
+					"You receive {}.",
+					money_string
+				).c_str()
+			);
 		}
-		if(copper > 0)
-		{
-			if (tmp.length() == 0)
-				tmp = "You receive ";
-			else
-				tmp += ",";
-
-			tmp += itoa(copper);
-			tmp += " copper";
-		}
-		tmp += " pieces.";
-		if (initiator)
-			initiator->Message(Chat::OOC, tmp.c_str());
 	}
 }
 

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -1182,20 +1182,23 @@ void QuestManager::givecash(uint32 copper, uint32 silver, uint32 gold, uint32 pl
 			platinum
 		)
 	) {
-		initiator->AddMoneyToPP(copper, silver, gold, platinum, true);
-
-		auto money_string = ConvertMoneyToString(platinum, gold, silver, copper);
-
-		if (money_string == "Unknown") {
-			return;
-		}
+		initiator->AddMoneyToPP(
+			copper,
+			silver,
+			gold,
+			platinum,
+			true
+		);
 
 		if (initiator) {
-			initiator->Message(
-				Chat::Green,
-				fmt::format(
-					"You receive {}.",
-					money_string
+			initiator->MessageString(
+				Chat::MoneySplit,
+				YOU_RECEIVE,
+				ConvertMoneyToString(
+					platinum,
+					gold,
+					silver,
+					copper
 				).c_str()
 			);
 		}

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -135,7 +135,7 @@ public:
 	uint16 traindiscs(uint8 max_level, uint8 min_level = 1);
 	void unscribespells();
 	void untraindiscs();
-	void givecash(int copper, int silver, int gold, int platinum);
+	void givecash(uint32 copper, uint32 silver = 0, uint32 gold = 0, uint32 platinum = 0);
 	void pvp(const char *mode);
 	void movepc(int zone_id, float x, float y, float z, float heading);
 	void gmmove(float x, float y, float z);

--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -24,6 +24,7 @@
 #include "groups.h"
 #include "mob.h"
 #include "raids.h"
+#include "string_ids.h"
 
 #include "worldserver.h"
 
@@ -789,15 +790,26 @@ void Raid::SplitMoney(uint32 gid, uint32 copper, uint32 silver, uint32 gold, uin
 	auto gold_split = gold / member_count;
 	auto platinum_split = platinum / member_count;
 
-	auto cash_message = fmt::format(
-		"You receive {} as your split.",
-		ConvertMoneyToString(platinum_split, gold_split, silver_split, copper_split)
-	);
-
 	for (uint32 i = 0; i < MAX_RAID_MEMBERS; i++) {
 		if (members[i].member && members[i].GroupNumber == gid) { // If Group Member is Client
-			members[i].member->AddMoneyToPP(copper_split, silver_split, gold_split, platinum_split, true);
-			members[i].member->Message(Chat::Green, cash_message.c_str());
+			members[i].member->AddMoneyToPP(
+				copper_split,
+				silver_split,
+				gold_split,
+				platinum_split,
+				true
+			);
+
+			members[i].member->MessageString(
+				Chat::MoneySplit,
+				YOU_RECEIVE_AS_SPLIT,
+				ConvertMoneyToString(
+					platinum_split,
+					gold_split,
+					silver_split,
+					copper_split
+				).c_str()
+			);
 		}
 	}
 }

--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -736,93 +736,68 @@ void Raid::BalanceMana(int32 penalty, uint32 gid, float range, Mob* caster, int3
 void Raid::SplitMoney(uint32 gid, uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Client *splitter)
 {
 	//avoid unneeded work
-	if (gid == RAID_GROUPLESS)
+	if (gid == RAID_GROUPLESS) {
 		return;
+	}
 
-	if(copper == 0 && silver == 0 && gold == 0 && platinum == 0)
+	if (
+		!copper &&
+		!silver &&
+		!gold &&
+		!platinum
+	) {
 		return;
+	}
 
-	uint32 i;
-	uint8 membercount = 0;
-	for (i = 0; i < MAX_RAID_MEMBERS; i++) {
-		if (members[i].member != nullptr && members[i].GroupNumber == gid) {
-			membercount++;
+	uint8 member_count = 0;
+	for (uint32 i = 0; i < MAX_RAID_MEMBERS; i++) {
+		if (members[i].member && members[i].GroupNumber == gid) {
+			member_count++;
 		}
 	}
 
-	if (membercount == 0)
+	if (!member_count) {
 		return;
+	}
 
-	uint32 mod;
-	//try to handle round off error a little better
-	if(membercount > 1) {
-		mod = platinum % membercount;
-		if((mod) > 0) {
-			platinum -= mod;
-			gold += 10 * mod;
+	uint32 modifier;
+	if (member_count > 1) {
+		modifier = platinum % member_count;
+
+		if (modifier) {
+			platinum -= modifier;
+			gold += 10 * modifier;
 		}
-		mod = gold % membercount;
-		if((mod) > 0) {
-			gold -= mod;
-			silver += 10 * mod;
+
+		modifier = gold % member_count;
+
+		if (modifier) {
+			gold -= modifier;
+			silver += 10 * modifier;
 		}
-		mod = silver % membercount;
-		if((mod) > 0) {
-			silver -= mod;
-			copper += 10 * mod;
+
+		modifier = silver % member_count;
+
+		if (modifier) {
+			silver -= modifier;
+			copper += 10 * modifier;
 		}
 	}
 
-	//calculate the splits
-	//We can still round off copper pieces, but I dont care
-	uint32 sc;
-	uint32 cpsplit = copper / membercount;
-	sc = copper % membercount;
-	uint32 spsplit = silver / membercount;
-	uint32 gpsplit = gold / membercount;
-	uint32 ppsplit = platinum / membercount;
+	auto copper_split = copper / member_count;
+	auto silver_split = silver / member_count;
+	auto gold_split = gold / member_count;
+	auto platinum_split = platinum / member_count;
 
-	char buf[128];
-	buf[63] = '\0';
-	std::string msg = "You receive";
-	bool one = false;
+	auto cash_message = fmt::format(
+		"You receive {} as your split.",
+		ConvertMoneyToString(platinum_split, gold_split, silver_split, copper_split)
+	);
 
-	if(ppsplit > 0) {
-		snprintf(buf, 63, " %u platinum", ppsplit);
-		msg += buf;
-		one = true;
-	}
-	if(gpsplit > 0) {
-		if(one)
-			msg += ",";
-		snprintf(buf, 63, " %u gold", gpsplit);
-		msg += buf;
-		one = true;
-	}
-	if(spsplit > 0) {
-		if(one)
-			msg += ",";
-		snprintf(buf, 63, " %u silver", spsplit);
-		msg += buf;
-		one = true;
-	}
-	if(cpsplit > 0) {
-		if(one)
-			msg += ",";
-		//this message is not 100% accurate for the splitter
-		//if they are receiving any roundoff
-		snprintf(buf, 63, " %u copper", cpsplit);
-		msg += buf;
-		one = true;
-	}
-	msg += " as your split";
-
-	for (i = 0; i < MAX_RAID_MEMBERS; i++) {
-		if (members[i].member != nullptr && members[i].GroupNumber == gid) { // If Group Member is Client
-			//I could not get MoneyOnCorpse to work, so we use this
-			members[i].member->AddMoneyToPP(cpsplit, spsplit, gpsplit, ppsplit, true);
-
-			members[i].member->Message(Chat::Green, msg.c_str());
+	for (uint32 i = 0; i < MAX_RAID_MEMBERS; i++) {
+		if (members[i].member && members[i].GroupNumber == gid) { // If Group Member is Client
+			members[i].member->AddMoneyToPP(copper_split, silver_split, gold_split, platinum_split, true);
+			members[i].member->Message(Chat::Green, cash_message.c_str());
 		}
 	}
 }

--- a/zone/string_ids.h
+++ b/zone/string_ids.h
@@ -455,6 +455,7 @@
 #define AE_RAMPAGE					11015	//%1 goes on a WILD RAMPAGE!
 #define FACE_ACCEPTED				12028	//Facial features accepted.
 #define SPELL_LEVEL_TO_LOW			12048	//You will have to achieve level %1 before you can scribe the %2.
+#define YOU_RECEIVE_AS_SPLIT		12071   //You receive %1 as your split.
 #define ATTACKFAILED				12158	//%1 try to %2 %3, but %4!
 #define HIT_STRING					12183	//hit
 #define CRUSH_STRING				12191	//crush

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -1342,43 +1342,21 @@ void ClientTaskState::RewardTask(Client *client, TaskInformation *task_informati
 
 		std::string cash_message;
 
-		if (platinum > 0) {
-			cash_message = "You receive ";
-			cash_message += itoa(platinum);
-			cash_message += " platinum";
+		if (
+			copper ||
+			silver ||
+			gold ||
+			platinum
+		) {
+			cash_message = fmt::format(
+				"You receive {}.",
+				ConvertMoneyToString(platinum, gold, silver, copper)
+			);
 		}
-		if (gold > 0) {
-			if (cash_message.length() == 0) {
-				cash_message = "You receive ";
-			}
-			else {
-				cash_message += ",";
-			}
-			cash_message += itoa(gold);
-			cash_message += " gold";
+
+		if (!cash_message.empty()) {
+			client->Message(Chat::Yellow, cash_message.c_str());
 		}
-		if (silver > 0) {
-			if (cash_message.length() == 0) {
-				cash_message = "You receive ";
-			}
-			else {
-				cash_message += ",";
-			}
-			cash_message += itoa(silver);
-			cash_message += " silver";
-		}
-		if (copper > 0) {
-			if (cash_message.length() == 0) {
-				cash_message = "You receive ";
-			}
-			else {
-				cash_message += ",";
-			}
-			cash_message += itoa(copper);
-			cash_message += " copper";
-		}
-		cash_message += " pieces.";
-		client->Message(Chat::Yellow, cash_message.c_str());
 	}
 	int32 experience_reward = task_information->experience_reward;
 	if (experience_reward > 0) {

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -1340,22 +1340,22 @@ void ClientTaskState::RewardTask(Client *client, TaskInformation *task_informati
 		silver   = copper / 10;
 		copper   = copper - (silver * 10);
 
-		std::string cash_message;
-
 		if (
 			copper ||
 			silver ||
 			gold ||
 			platinum
 		) {
-			cash_message = fmt::format(
-				"You receive {}.",
-				ConvertMoneyToString(platinum, gold, silver, copper)
+			client->MessageString(
+				Chat::Yellow,
+				YOU_RECEIVE,
+				ConvertMoneyToString(
+					platinum,
+					gold,
+					silver,
+					copper
+				).c_str()
 			);
-		}
-
-		if (!cash_message.empty()) {
-			client->Message(Chat::Yellow, cash_message.c_str());
 		}
 	}
 	int32 experience_reward = task_information->experience_reward;


### PR DESCRIPTION
- Cleans up all the money messages using ConvertMoneyToString().
- Allows quest::givecash() to have optional parameters other than copper.