### PR TITLE
[Bug Fix] Blocked spells max spell id increased

### DIFF
--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1239,8 +1239,8 @@ public:
 	inline uint8 GetManaPercent() { return (uint8)((float)current_mana / (float)max_mana * 100.0f); }
 	virtual uint8 GetEndurancePercent() { return 0; }
 
-	inline virtual bool IsBlockedBuff(int16 SpellID) { return false; }
-	inline virtual bool IsBlockedPetBuff(int16 SpellID) { return false; }
+	inline virtual bool IsBlockedBuff(int32 SpellID) { return false; }
+	inline virtual bool IsBlockedPetBuff(int32 SpellID) { return false; }
 
 	std::string GetGlobal(const char *varname);
 	void SetGlobal(const char *varname, const char *newvalue, int options, const char *duration, Mob *other = nullptr);


### PR DESCRIPTION
https://github.com/EQEmu/Server/pull/2073 broke blocking spells. There is another location in mob.h that needs to be updated to int32. Tested as fixed on my server.