### PR TITLE
[INT64] Fix int64 for OOC Regen and GetHP(), GetMaxHP(), GetItemHPBonuses() in Perl/Lua.

### DIFF
--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -482,17 +482,17 @@ bool Lua_Mob::IsWarriorClass() {
 	return self->IsWarriorClass();
 }
 
-int Lua_Mob::GetHP() {
+int64 Lua_Mob::GetHP() {
 	Lua_Safe_Call_Int();
 	return self->GetHP();
 }
 
-int Lua_Mob::GetMaxHP() {
+int64 Lua_Mob::GetMaxHP() {
 	Lua_Safe_Call_Int();
 	return self->GetMaxHP();
 }
 
-int Lua_Mob::GetItemHPBonuses() {
+int64 Lua_Mob::GetItemHPBonuses() {
 	Lua_Safe_Call_Int();
 	return self->GetItemHPBonuses();
 }
@@ -1356,9 +1356,9 @@ bool Lua_Mob::DivineAura() {
 	return self->DivineAura();
 }
 
-void Lua_Mob::SetOOCRegen(int regen) {
+void Lua_Mob::SetOOCRegen(int64 new_ooc_regen) {
 	Lua_Safe_Call_Void();
-	self->SetOOCRegen(regen);
+	self->SetOOCRegen(new_ooc_regen);
 }
 
 const char* Lua_Mob::GetEntityVariable(const char *name) {
@@ -2860,7 +2860,7 @@ luabind::scope lua_register_mob() {
 	.def("SetLevel", (void(Lua_Mob::*)(int))&Lua_Mob::SetLevel)
 	.def("SetLevel", (void(Lua_Mob::*)(int,bool))&Lua_Mob::SetLevel)
 	.def("SetMana", &Lua_Mob::SetMana)
-	.def("SetOOCRegen", (void(Lua_Mob::*)(int))&Lua_Mob::SetOOCRegen)
+	.def("SetOOCRegen", (void(Lua_Mob::*)(int64))&Lua_Mob::SetOOCRegen)
 	.def("SetPet", &Lua_Mob::SetPet)
 	.def("SetPetOrder", (void(Lua_Mob::*)(int))&Lua_Mob::SetPetOrder)
 	.def("SetPseudoRoot", (void(Lua_Mob::*)(bool))&Lua_Mob::SetPseudoRoot)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -123,9 +123,9 @@ public:
 	void SetTarget(Lua_Mob t);
 	double GetHPRatio();
 	bool IsWarriorClass();
-	int GetHP();
-	int GetMaxHP();
-	int GetItemHPBonuses();
+	int64 GetHP();
+	int64 GetMaxHP();
+	int64 GetItemHPBonuses();
 	int GetSpellHPBonuses();
 	double GetWalkspeed();
 	double GetRunspeed();
@@ -288,7 +288,7 @@ public:
 	bool SetAA(int rank_id, int new_value);
 	bool SetAA(int rank_id, int new_value, int charges);
 	bool DivineAura();
-	void SetOOCRegen(int regen);
+	void SetOOCRegen(int64 new_ooc_regen);
 	const char* GetEntityVariable(const char *name);
 	void SetEntityVariable(const char *name, const char *value);
 	bool EntityVariableExists(const char *name);

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -497,7 +497,7 @@ public:
 		bool avoidable = true, int8 buffslot = -1, bool iBuffTic = false, eSpecialAttacks special = eSpecialAttacks::None) = 0;
 	virtual void SetHP(int64 hp);
 	bool ChangeHP(Mob* other, int32 amount, uint16 spell_id = 0, int8 buffslot = -1, bool iBuffTic = false);
-	inline void SetOOCRegen(int32 newoocregen) {ooc_regen = newoocregen;}
+	inline void SetOOCRegen(int64 new_ooc_regen) { ooc_regen = new_ooc_regen; }
 	virtual void Heal();
 	virtual void HealDamage(uint64 ammount, Mob* caster = nullptr, uint16 spell_id = SPELL_UNKNOWN);
 	virtual void SetMaxHP() { current_hp = max_hp; }
@@ -1448,7 +1448,7 @@ protected:
 	int64 hp_regen;
 	int64 hp_regen_per_second;
 	int64 mana_regen;
-	int32 ooc_regen;
+	int64 ooc_regen;
 	uint8 maxlevel;
 	uint32 scalerate;
 	Buffs_Struct *buffs;

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -886,9 +886,9 @@ bool NPC::Process()
 		}
 
 		int64 npc_sitting_regen_bonus = 0;
-		int64 pet_regen_bonus         = 0;
-		int64 npc_regen               = 0;
-		int64  npc_hp_regen            = GetNPCHPRegen();
+		int64 pet_regen_bonus = 0;
+		int64 npc_regen = 0;
+		int64 npc_hp_regen = GetNPCHPRegen();
 
 		if (GetAppearance() == eaSitting) {
 			npc_sitting_regen_bonus += 3;

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -885,9 +885,9 @@ bool NPC::Process()
 			ProcessFlee();
 		}
 
-		uint32 npc_sitting_regen_bonus = 0;
-		uint32 pet_regen_bonus         = 0;
-		uint64 npc_regen               = 0;
+		int64 npc_sitting_regen_bonus = 0;
+		int64 pet_regen_bonus         = 0;
+		int64 npc_regen               = 0;
 		int64  npc_hp_regen            = GetNPCHPRegen();
 
 		if (GetAppearance() == eaSitting) {

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -1579,7 +1579,7 @@ XS(XS_Mob_GetHP) {
 		Perl_croak(aTHX_ "Usage: Mob::GetHP(THIS)"); // @categories Stats and Attributes
 	{
 		Mob *THIS;
-		int32 RETVAL;
+		int64 RETVAL;
 		dXSTARG;
 		VALIDATE_THIS_IS_MOB;
 		RETVAL = THIS->GetHP();
@@ -1596,7 +1596,7 @@ XS(XS_Mob_GetMaxHP) {
 		Perl_croak(aTHX_ "Usage: Mob::GetMaxHP(THIS)"); // @categories Stats and Attributes
 	{
 		Mob *THIS;
-		int32 RETVAL;
+		int64 RETVAL;
 		dXSTARG;
 		VALIDATE_THIS_IS_MOB;
 		RETVAL = THIS->GetMaxHP();
@@ -1613,7 +1613,7 @@ XS(XS_Mob_GetItemHPBonuses) {
 		Perl_croak(aTHX_ "Usage: Mob::GetItemHPBonuses(THIS)"); // @categories Inventory and Items, Stats and Attributes
 	{
 		Mob *THIS;
-		int32 RETVAL;
+		int64 RETVAL;
 		dXSTARG;
 		VALIDATE_THIS_IS_MOB;
 		RETVAL = THIS->GetItemHPBonuses();
@@ -4417,12 +4417,12 @@ XS(XS_Mob_SetOOCRegen); /* prototype to pass -Wmissing-prototypes */
 XS(XS_Mob_SetOOCRegen) {
 	dXSARGS;
 	if (items != 2)
-		Perl_croak(aTHX_ "Usage: Mob::SetOOCRegen(THIS, int32 new_ooc_regen)"); // @categories Stats and Attributes
+		Perl_croak(aTHX_ "Usage: Mob::SetOOCRegen(THIS, int64 new_ooc_regen)"); // @categories Stats and Attributes
 	{
 		Mob *THIS;
-		int32 newoocregen = (int32) SvIV(ST(1));
+		int64 new_ooc_regen = (int64) SvIV(ST(1));
 		VALIDATE_THIS_IS_MOB;
-		THIS->SetOOCRegen(newoocregen);
+		THIS->SetOOCRegen(new_ooc_regen);
 	}
 	XSRETURN_EMPTY;
 }


### PR DESCRIPTION
- These all had int64 values and were overflowing, returning garbage data.