### PR TITLE
[INT64] Further int64 cleanup in Perl SetHP() and GetSpellHPBonuses() in Perl/Lua.

### DIFF
--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -497,7 +497,7 @@ int64 Lua_Mob::GetItemHPBonuses() {
 	return self->GetItemHPBonuses();
 }
 
-int Lua_Mob::GetSpellHPBonuses() {
+int64 Lua_Mob::GetSpellHPBonuses() {
 	Lua_Safe_Call_Int();
 	return self->GetSpellHPBonuses();
 }

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -126,7 +126,7 @@ public:
 	int64 GetHP();
 	int64 GetMaxHP();
 	int64 GetItemHPBonuses();
-	int GetSpellHPBonuses();
+	int64 GetSpellHPBonuses();
 	double GetWalkspeed();
 	double GetRunspeed();
 	int GetCasterLevel(int spell_id);

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -981,8 +981,8 @@ int64 Mob::GetItemHPBonuses() {
 	return item_hp;
 }
 
-int32 Mob::GetSpellHPBonuses() {
-	int32 spell_hp = 0;
+int64 Mob::GetSpellHPBonuses() {
+	int64 spell_hp = 0;
 	spell_hp = spellbonuses.HP;
 	spell_hp += spell_hp * spellbonuses.MaxHPChange / 10000;
 	return spell_hp;

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -608,7 +608,7 @@ public:
 	virtual int64 GetMaxEndurance() const { return 0; }
 	virtual void SetEndurance(int32 newEnd) { return; }
 	int64 GetItemHPBonuses();
-	int32 GetSpellHPBonuses();
+	int64 GetSpellHPBonuses();
 	virtual const int64& SetMana(int64 amount);
 	inline float GetManaRatio() const { return max_mana == 0 ? 100 :
 		((static_cast<float>(current_mana) / max_mana) * 100); }

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -770,7 +770,7 @@ XS(XS_Mob_SetHP) {
 		Perl_croak(aTHX_ "Usage: Mob::SetHP(THIS, int64 hp)"); // @categories Stats and Attributes
 	{
 		Mob *THIS;
-		int64 hp = (int32) SvIV(ST(1));
+		int64 hp = (int64) SvIV(ST(1));
 		VALIDATE_THIS_IS_MOB;
 		THIS->SetHP(hp);
 	}
@@ -1630,7 +1630,7 @@ XS(XS_Mob_GetSpellHPBonuses) {
 		Perl_croak(aTHX_ "Usage: Mob::GetSpellHPBonuses(THIS)"); // @categories Spells and Disciplines
 	{
 		Mob *THIS;
-		int32 RETVAL;
+		int64 RETVAL;
 		dXSTARG;
 		VALIDATE_THIS_IS_MOB;
 		RETVAL = THIS->GetSpellHPBonuses();


### PR DESCRIPTION
- Setter was using int, causing any value over 2 billion to overflow.
- Stat bonuses HP is int64, so getter for Spell HP Bonuses should be, too.