### PR TITLE
[Hot Fix] Fix Linux compile due to missing include.

### DIFF
--- a/zone/groups.cpp
+++ b/zone/groups.cpp
@@ -25,6 +25,7 @@
 #include "../common/packet_dump.h"
 #include "../common/string_util.h"
 #include "worldserver.h"
+#include "string_ids.h"
 
 extern EntityList entity_list;
 extern WorldServer worldserver;

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -37,6 +37,7 @@
 #include "zonedb.h"
 #include "zone_store.h"
 #include "dialogue_window.h"
+#include "string_ids.h"
 
 #include <iostream>
 #include <limits.h>


### PR DESCRIPTION
- Not sure how Windows compiles, but Linux fails.

Not sure if we need this, as AppVeyor build succeeded this time, it had just said YOU_RECEIVE and YOU_RECEIVE_AS_SPLIT were undefined before, so I assumed it was this.