### PR TITLE
[Rules] Add Rules to disable various item functionalities and cleanup data types.

### DIFF
--- a/common/item_data.h
+++ b/common/item_data.h
@@ -370,7 +370,7 @@ namespace EQ
 		uint32	Slots;			// Bitfield for which slots this item can be used in
 		uint32	Price;			// Item cost (?)
 		uint32	Icon;			// Icon Number
-		uint32	LoreGroup;		// Later items use LoreGroup instead of LoreFlag. we might want to see about changing this to int32 since it is commonly -1 and is constantly being cast from signed (-1) to unsigned (4294967295)
+		int32	LoreGroup;		// Later items use LoreGroup instead of LoreFlag. we might want to see about changing this to int32 since it is commonly -1 and is constantly being cast from signed (-1) to unsigned (4294967295)
 		bool	LoreFlag;		// This will be true if LoreGroup is non-zero
 		bool	PendingLoreFlag;
 		bool	ArtifactFlag;
@@ -473,14 +473,14 @@ namespace EQ
 		uint32	LDoNSold;
 		uint32	BaneDmgRaceAmt;
 		uint32	AugRestrict;
-		uint32	Endur;
-		uint32	DotShielding;
-		uint32	Attack;
-		uint32	Regen;
-		uint32	ManaRegen;
-		uint32	EnduranceRegen;
-		uint32	Haste;
-		uint32	DamageShield;
+		int32	Endur;
+		int32	DotShielding;
+		int32	Attack;
+		int32	Regen;
+		int32	ManaRegen;
+		int32	EnduranceRegen;
+		int32	Haste;
+		int32	DamageShield;
 		uint32	RecastDelay;
 		int	RecastType;
 		uint32	AugDistiller;

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -800,6 +800,18 @@ RULE_CATEGORY(Doors)
 RULE_BOOL(Doors, RequireKeyOnCursor, false, "Enable this to require pre-keyring keys to be on player cursor to open doors.")
 RULE_CATEGORY_END()
 
+RULE_CATEGORY(Items)
+RULE_BOOL(Items, DisableAttuneable, false, "Enable this to disable Attuneable Items")
+RULE_BOOL(Items, DisableBardFocusEffects, false, "Enable this to disable Bard Focus Effects on Items")
+RULE_BOOL(Items, DisableLore, false, "Enable this to disable Lore Items")
+RULE_BOOL(Items, DisableNoDrop, false, "Enable this to disable No Drop Items")
+RULE_BOOL(Items, DisableNoPet, false, "Enable this to disable No Pet Items")
+RULE_BOOL(Items, DisableNoRent, false, "Enable this to disable No Rent Items")
+RULE_BOOL(Items, DisableNoTransfer, false, "Enable this to disable No Transfer Items")
+RULE_BOOL(Items, DisablePotionBelt, false, "Enable this to disable Potion Belt Items")
+RULE_BOOL(Items, DisableSpellFocusEffects, false, "Enable this to disable Spell Focus Effects on Items")
+RULE_CATEGORY_END()
+
 #undef RULE_CATEGORY
 #undef RULE_INT
 #undef RULE_REAL

--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -38,6 +38,7 @@
 #include "shareddb.h"
 #include "string_util.h"
 #include "eqemu_config.h"
+#include "data_verification.h"
 #include "repositories/criteria/content_filter_criteria.h"
 
 namespace ItemField
@@ -634,18 +635,18 @@ bool SharedDatabase::GetInventory(uint32 char_id, EQ::InventoryProfile *inv)
 
 		uint32 aug[EQ::invaug::SOCKET_COUNT];
 
-		aug[0] = (uint32)atoul(row[4]);
-		aug[1] = (uint32)atoul(row[5]);
-		aug[2] = (uint32)atoul(row[6]);
-		aug[3] = (uint32)atoul(row[7]);
-		aug[4] = (uint32)atoul(row[8]);
-		aug[5] = (uint32)atoul(row[9]);
+		aug[0] = std::stoul(row[4]);
+		aug[1] = std::stoul(row[5]);
+		aug[2] = std::stoul(row[6]);
+		aug[3] = std::stoul(row[7]);
+		aug[4] = std::stoul(row[8]);
+		aug[5] = std::stoul(row[9]);
 
 		bool instnodrop = (row[10] && (uint16)atoi(row[10])) ? true : false;
 
-		uint32 ornament_icon = (uint32)atoul(row[12]);
-		uint32 ornament_idfile = (uint32)atoul(row[13]);
-		uint32 ornament_hero_model = (uint32)atoul(row[14]);
+		uint32 ornament_icon = std::stoul(row[12]);
+		uint32 ornament_idfile = std::stoul(row[13]);
+		uint32 ornament_hero_model = std::stoul(row[14]);
 
 		const EQ::ItemData *item = GetItem(item_id);
 
@@ -788,9 +789,9 @@ bool SharedDatabase::GetInventory(uint32 account_id, char *name, EQ::InventoryPr
 		aug[5] = (uint32)atoi(row[9]);
 
 		bool instnodrop = (row[10] && (uint16)atoi(row[10])) ? true : false;
-		uint32 ornament_icon = (uint32)atoul(row[12]);
-		uint32 ornament_idfile = (uint32)atoul(row[13]);
-		uint32 ornament_hero_model = (uint32)atoul(row[14]);
+		uint32 ornament_icon = std::stoul(row[12]);
+		uint32 ornament_idfile = std::stoul(row[13]);
+		uint32 ornament_hero_model = std::stoul(row[14]);
 
 		const EQ::ItemData *item = GetItem(item_id);
 		int16 put_slot_id = INVALID_INDEX;
@@ -943,29 +944,41 @@ void SharedDatabase::LoadItems(void *data, uint32 size, int32 items, uint32 max_
 {
 	EQ::FixedMemoryHashSet<EQ::ItemData> hash(reinterpret_cast<uint8 *>(data), size, items, max_item_id);
 
-	std::string ndbuffer;
-	bool disableNoRent = false;
-	if (GetVariable("disablenorent", ndbuffer)) {
-		if (ndbuffer[0] == '1' && ndbuffer[1] == '\0') {
-			disableNoRent = true;
+	std::string variable_buffer;
+
+	bool disable_attuneable = RuleB(Items, DisableAttuneable);
+	bool disable_bard_focus_effects = RuleB(Items, DisableBardFocusEffects);
+	bool disable_lore = RuleB(Items, DisableLore);
+	bool disable_no_drop = RuleB(Items, DisableNoDrop);
+	bool disable_no_pet = RuleB(Items, DisableNoPet);
+	bool disable_no_rent = RuleB(Items, DisableNoRent);
+	bool disable_no_transfer = RuleB(Items, DisableNoTransfer);
+	bool disable_potion_belt = RuleB(Items, DisablePotionBelt);
+	bool disable_spell_focus_effects = RuleB(Items, DisableSpellFocusEffects);
+
+	// Old Variable Code
+	if (GetVariable("disablelore", variable_buffer)) {
+		if (variable_buffer == "1") {
+			disable_lore = true;
 		}
 	}
-	bool disableNoDrop = false;
-	if (GetVariable("disablenodrop", ndbuffer)) {
-		if (ndbuffer[0] == '1' && ndbuffer[1] == '\0') {
-			disableNoDrop = true;
+
+	if (GetVariable("disablenodrop", variable_buffer)) {
+		if (variable_buffer == "1") {
+			disable_no_drop = true;
 		}
 	}
-	bool disableLoreGroup = false;
-	if (GetVariable("disablelore", ndbuffer)) {
-		if (ndbuffer[0] == '1' && ndbuffer[1] == '\0') {
-			disableLoreGroup = true;
+
+	if (GetVariable("disablenorent", variable_buffer)) {
+		if (variable_buffer == "1") {
+			disable_no_rent = true;
 		}
 	}
-	bool disableNoTransfer = false;
-	if (GetVariable("disablenotransfer", ndbuffer)) {
-		if (ndbuffer[0] == '1' && ndbuffer[1] == '\0') {
-			disableNoTransfer = true;
+
+	
+	if (GetVariable("disablenotransfer", variable_buffer)) {
+		if (variable_buffer == "1") {
+			disable_no_transfer = true;
 		}
 	}
 
@@ -984,212 +997,269 @@ void SharedDatabase::LoadItems(void *data, uint32 size, int32 items, uint32 max_
 	for (auto row = results.begin(); row != results.end(); ++row) {
 		memset(&item, 0, sizeof(EQ::ItemData));
 
-		item.ItemClass = (uint8)atoi(row[ItemField::itemclass]);
-		strcpy(item.Name, row[ItemField::name]);
-		strcpy(item.Lore, row[ItemField::lore]);
-		strcpy(item.IDFile, row[ItemField::idfile]);
+		// Unique Identifier
+		item.ID = std::stoul(row[ItemField::id]);
 
-		item.ID = (uint32)atoul(row[ItemField::id]);
-		item.Weight = (int32)atoi(row[ItemField::weight]);
-		item.NoRent = disableNoRent ? (uint8)atoi("255") : (uint8)atoi(row[ItemField::norent]);
-		item.NoDrop = disableNoDrop ? (uint8)atoi("255") : (uint8)atoi(row[ItemField::nodrop]);
-		item.Size = (uint8)atoi(row[ItemField::size]);
-		item.Slots = (uint32)atoul(row[ItemField::slots]);
-		item.Price = (uint32)atoul(row[ItemField::price]);
-		item.Icon = (uint32)atoul(row[ItemField::icon]);
-		item.BenefitFlag = (atoul(row[ItemField::benefitflag]) != 0);
-		item.Tradeskills = (atoi(row[ItemField::tradeskills]) == 0) ? false : true;
-		item.CR = (int8)atoi(row[ItemField::cr]);
-		item.DR = (int8)atoi(row[ItemField::dr]);
-		item.PR = (int8)atoi(row[ItemField::pr]);
-		item.MR = (int8)atoi(row[ItemField::mr]);
-		item.FR = (int8)atoi(row[ItemField::fr]);
-		item.AStr = (int8)atoi(row[ItemField::astr]);
-		item.ASta = (int8)atoi(row[ItemField::asta]);
-		item.AAgi = (int8)atoi(row[ItemField::aagi]);
-		item.ADex = (int8)atoi(row[ItemField::adex]);
-		item.ACha = (int8)atoi(row[ItemField::acha]);
-		item.AInt = (int8)atoi(row[ItemField::aint]);
-		item.AWis = (int8)atoi(row[ItemField::awis]);
-		item.HP = (int32)atoul(row[ItemField::hp]);
-		item.Mana = (int32)atoul(row[ItemField::mana]);
-		item.AC = (int32)atoul(row[ItemField::ac]);
-		item.Deity = (uint32)atoul(row[ItemField::deity]);
-		item.SkillModValue = (int32)atoul(row[ItemField::skillmodvalue]);
-		item.SkillModMax = (int32)atoul(row[ItemField::skillmodmax]);
-		item.SkillModType = (uint32)atoul(row[ItemField::skillmodtype]);
-		item.BaneDmgRace = (uint32)atoul(row[ItemField::banedmgrace]);
-		item.BaneDmgAmt = (int32)atoul(row[ItemField::banedmgamt]);
-		item.BaneDmgBody = (uint32)atoul(row[ItemField::banedmgbody]);
-		item.Magic = (atoi(row[ItemField::magic]) == 0) ? false : true;
-		item.CastTime_ = (int32)atoul(row[ItemField::casttime_]);
-		item.ReqLevel = (uint8)atoi(row[ItemField::reqlevel]);
-		item.BardType = (uint32)atoul(row[ItemField::bardtype]);
-		item.BardValue = (int32)atoul(row[ItemField::bardvalue]);
-		item.Light = (int8)atoi(row[ItemField::light]);
-		item.Delay = (uint8)atoi(row[ItemField::delay]);
-		item.RecLevel = (uint8)atoi(row[ItemField::reclevel]);
-		item.RecSkill = (uint8)atoi(row[ItemField::recskill]);
-		item.ElemDmgType = (uint8)atoi(row[ItemField::elemdmgtype]);
-		item.ElemDmgAmt = (uint8)atoi(row[ItemField::elemdmgamt]);
-		item.Range = (uint8)atoi(row[ItemField::range]);
-		item.Damage = (uint32)atoi(row[ItemField::damage]);
-		item.Color = (uint32)atoul(row[ItemField::color]);
-		item.Classes = (uint32)atoul(row[ItemField::classes]);
-		item.Races = (uint32)atoul(row[ItemField::races]);
+		// Name and Lore
+		strn0cpy(item.Name, row[ItemField::name], sizeof(item.Name));
+		strn0cpy(item.Lore, row[ItemField::lore], sizeof(item.Lore));
 
-		item.MaxCharges = (int16)atoi(row[ItemField::maxcharges]);
-		item.ItemType = (uint8)atoi(row[ItemField::itemtype]);
-		item.SubType = atoi(row[ItemField::subtype]);
-		item.Material = (uint8)atoi(row[ItemField::material]);
-		item.HerosForgeModel = (uint32)atoi(row[ItemField::herosforgemodel]);
-		item.SellRate = (float)atof(row[ItemField::sellrate]);
-		item.CastTime = (uint32)atoul(row[ItemField::casttime]);
-		item.EliteMaterial = (uint32)atoul(row[ItemField::elitematerial]);
-		item.ProcRate = (int32)atoi(row[ItemField::procrate]);
-		item.CombatEffects = (int8)atoi(row[ItemField::combateffects]);
-		item.Shielding = (int8)atoi(row[ItemField::shielding]);
-		item.StunResist = (int8)atoi(row[ItemField::stunresist]);
-		item.StrikeThrough = (int8)atoi(row[ItemField::strikethrough]);
-		item.ExtraDmgSkill = (uint32)atoul(row[ItemField::extradmgskill]);
-		item.ExtraDmgAmt = (uint32)atoul(row[ItemField::extradmgamt]);
-		item.SpellShield = (int8)atoi(row[ItemField::spellshield]);
-		item.Avoidance = (int8)atoi(row[ItemField::avoidance]);
-		item.Accuracy = (int8)atoi(row[ItemField::accuracy]);
-		item.CharmFileID = (uint32)atoul(row[ItemField::charmfileid]);
-		item.FactionMod1 = (int32)atoul(row[ItemField::factionmod1]);
-		item.FactionMod2 = (int32)atoul(row[ItemField::factionmod2]);
-		item.FactionMod3 = (int32)atoul(row[ItemField::factionmod3]);
-		item.FactionMod4 = (int32)atoul(row[ItemField::factionmod4]);
-		item.FactionAmt1 = (int32)atoul(row[ItemField::factionamt1]);
-		item.FactionAmt2 = (int32)atoul(row[ItemField::factionamt2]);
-		item.FactionAmt3 = (int32)atoul(row[ItemField::factionamt3]);
-		item.FactionAmt4 = (int32)atoul(row[ItemField::factionamt4]);
+		// Flags
+		item.ArtifactFlag = std::stoi(row[ItemField::artifactflag]) ? true : false;
+		item.Attuneable = disable_attuneable ? false : std::stoi(row[ItemField::attuneable]) ? true : false;
+		item.BenefitFlag = std::stoi(row[ItemField::benefitflag]) ? true : false;
+		item.FVNoDrop = std::stoi(row[ItemField::fvnodrop]) ? true : false;
+		item.Magic = std::stoi(row[ItemField::magic]) ? true : false;
+		item.NoDrop = disable_no_drop ? static_cast<uint8>(255) : static_cast<uint8>(std::stoul(row[ItemField::nodrop]));
+		item.NoPet = disable_no_pet ? false : std::stoi(row[ItemField::nopet]) ? true : false;
+		item.NoRent = disable_no_rent ? static_cast<uint8>(255) : static_cast<uint8>(std::stoul(row[ItemField::norent]));
+		item.NoTransfer = disable_no_transfer ? false : std::stoi(row[ItemField::notransfer]) ? true : false;
+		item.PendingLoreFlag = std::stoi(row[ItemField::pendingloreflag]) ? true : false;
+		item.QuestItemFlag = std::stoi(row[ItemField::questitemflag]) ? true : false;
+		item.Stackable = std::stoi(row[ItemField::stackable]) ? true : false;
+		item.Tradeskills = std::stoi(row[ItemField::tradeskills]) ? true : false;
+		item.SummonedFlag = std::stoi(row[ItemField::summonedflag]) ? true : false;
 
-		strcpy(item.CharmFile, row[ItemField::charmfile]);
+		// Lore
+		item.LoreGroup = disable_lore ? 0 : std::stoi(row[ItemField::loregroup]);
+		item.LoreFlag = disable_lore ? false : item.LoreGroup != 0;
 
-		item.AugType = (uint32)atoul(row[ItemField::augtype]);
-		item.AugSlotType[0] = (uint8)atoi(row[ItemField::augslot1type]);
-		item.AugSlotVisible[0] = (uint8)atoi(row[ItemField::augslot1visible]);
-		item.AugSlotUnk2[0] = 0;
-		item.AugSlotType[1] = (uint8)atoi(row[ItemField::augslot2type]);
-		item.AugSlotVisible[1] = (uint8)atoi(row[ItemField::augslot2visible]);
-		item.AugSlotUnk2[1] = 0;
-		item.AugSlotType[2] = (uint8)atoi(row[ItemField::augslot3type]);
-		item.AugSlotVisible[2] = (uint8)atoi(row[ItemField::augslot3visible]);
-		item.AugSlotUnk2[2] = 0;
-		item.AugSlotType[3] = (uint8)atoi(row[ItemField::augslot4type]);
-		item.AugSlotVisible[3] = (uint8)atoi(row[ItemField::augslot4visible]);
-		item.AugSlotUnk2[3] = 0;
-		item.AugSlotType[4] = (uint8)atoi(row[ItemField::augslot5type]);
-		item.AugSlotVisible[4] = (uint8)atoi(row[ItemField::augslot5visible]);
-		item.AugSlotUnk2[4] = 0;
-		item.AugSlotType[5] = (uint8)atoi(row[ItemField::augslot6type]);
-		item.AugSlotVisible[5] = (uint8)atoi(row[ItemField::augslot6visible]);
-		item.AugSlotUnk2[5] = 0;
+		// Type
+		item.AugType = std::stoul(row[ItemField::augtype]);
+		item.ItemType = static_cast<uint8>(std::stoul(row[ItemField::itemtype]));
+		item.SubType = std::stoi(row[ItemField::subtype]);
 
-		item.LDoNTheme = (uint32)atoul(row[ItemField::ldontheme]);
-		item.LDoNPrice = (uint32)atoul(row[ItemField::ldonprice]);
-		item.LDoNSold = (uint32)atoul(row[ItemField::ldonsold]);
-		item.BagType = (uint8)atoi(row[ItemField::bagtype]);
-		item.BagSlots = (uint8)std::min(atoi(row[ItemField::bagslots]), 10); // FIXME: remove when big bags supported
-		item.BagSize = (uint8)atoi(row[ItemField::bagsize]);
-		item.BagWR = (uint8)atoi(row[ItemField::bagwr]);
-		item.Book = (uint8)atoi(row[ItemField::book]);
-		item.BookType = (uint32)atoul(row[ItemField::booktype]);
+		// Miscellaneous
+		item.ExpendableArrow = static_cast<uint16>(std::stoul(row[ItemField::expendablearrow]));
+		item.Light = static_cast<int8>(std::stoi(row[ItemField::light]));
+		item.MaxCharges = static_cast<int16>(std::stoi(row[ItemField::maxcharges]));
+		item.Size = static_cast<uint8>(std::stoul(row[ItemField::size]));
+		item.StackSize = static_cast<int16>(std::stoi(row[ItemField::stacksize]));
+		item.Weight = std::stoi(row[ItemField::weight]);
 
-		strcpy(item.Filename, row[ItemField::filename]);
+		// Potion Belt
+		item.PotionBelt = disable_potion_belt ? false : std::stoi(row[ItemField::potionbelt]) ? true : false;
+		item.PotionBeltSlots = disable_potion_belt ? 0 : static_cast<uint8>(std::stoul(row[ItemField::potionbeltslots]));
 
-		item.BaneDmgRaceAmt = (uint32)atoul(row[ItemField::banedmgraceamt]);
-		item.AugRestrict = (uint32)atoul(row[ItemField::augrestrict]);
-		item.LoreGroup = disableLoreGroup ? (uint8)atoi("0") : atoi(row[ItemField::loregroup]);
-		item.LoreFlag = item.LoreGroup != 0;
-		item.PendingLoreFlag = (atoi(row[ItemField::pendingloreflag]) == 0) ? false : true;
-		item.ArtifactFlag = (atoi(row[ItemField::artifactflag]) == 0) ? false : true;
-		item.SummonedFlag = (atoi(row[ItemField::summonedflag]) == 0) ? false : true;
-		item.Favor = (uint32)atoul(row[ItemField::favor]);
-		item.FVNoDrop = (atoi(row[ItemField::fvnodrop]) == 0) ? false : true;
-		item.Endur = (uint32)atoul(row[ItemField::endur]);
-		item.DotShielding = (uint32)atoul(row[ItemField::dotshielding]);
-		item.Attack = (uint32)atoul(row[ItemField::attack]);
-		item.Regen = (uint32)atoul(row[ItemField::regen]);
-		item.ManaRegen = (uint32)atoul(row[ItemField::manaregen]);
-		item.EnduranceRegen = (uint32)atoul(row[ItemField::enduranceregen]);
-		item.Haste = (uint32)atoul(row[ItemField::haste]);
-		item.DamageShield = (uint32)atoul(row[ItemField::damageshield]);
-		item.RecastDelay = (uint32)atoul(row[ItemField::recastdelay]);
-		item.RecastType = (int)atoi(row[ItemField::recasttype]);
-		item.GuildFavor = (uint32)atoul(row[ItemField::guildfavor]);
-		item.AugDistiller = (uint32)atoul(row[ItemField::augdistiller]);
-		item.Attuneable = (atoi(row[ItemField::attuneable]) == 0) ? false : true;
-		item.NoPet = (atoi(row[ItemField::nopet]) == 0) ? false : true;
-		item.PointType = (uint32)atoul(row[ItemField::pointtype]);
-		item.PotionBelt = (atoi(row[ItemField::potionbelt]) == 0) ? false : true;
-		item.PotionBeltSlots = (atoi(row[ItemField::potionbeltslots]) == 0) ? false : true;
-		item.StackSize = (uint16)atoi(row[ItemField::stacksize]);
-		item.NoTransfer = disableNoTransfer ? false : (atoi(row[ItemField::notransfer]) == 0) ? false : true;
-		item.Stackable = (atoi(row[ItemField::stackable]) == 0) ? false : true;
-		item.Click.Effect = (uint32)atoul(row[ItemField::clickeffect]);
-		item.Click.Type = (uint8)atoul(row[ItemField::clicktype]);
-		item.Click.Level = (uint8)atoul(row[ItemField::clicklevel]);
-		item.Click.Level2 = (uint8)atoul(row[ItemField::clicklevel2]);
+		// Merchant
+		item.Favor = std::stoul(row[ItemField::favor]);
+		item.GuildFavor = std::stoul(row[ItemField::guildfavor]);
+		item.Price = std::stoul(row[ItemField::price]);
+		item.SellRate = std::stof(row[ItemField::sellrate]);
+		
+		// Display
+		item.Color = std::stoul(row[ItemField::color]);
+		item.EliteMaterial = std::stoul(row[ItemField::elitematerial]);
+		item.HerosForgeModel = std::stoul(row[ItemField::herosforgemodel]);
+		item.Icon = std::stoul(row[ItemField::icon]);
+		strn0cpy(item.IDFile, row[ItemField::idfile], sizeof(item.IDFile));
+		item.Material = static_cast<uint8>(std::stoul(row[ItemField::material]));
 
-		strcpy(item.CharmFile, row[ItemField::charmfile]);
+		// Resists
+		item.CR = static_cast<int8>(EQ::Clamp(std::stoi(row[ItemField::cr]), -128, 127));
+		item.DR = static_cast<int8>(EQ::Clamp(std::stoi(row[ItemField::dr]), -128, 127));
+		item.FR = static_cast<int8>(EQ::Clamp(std::stoi(row[ItemField::fr]), -128, 127));
+		item.MR = static_cast<int8>(EQ::Clamp(std::stoi(row[ItemField::mr]), -128, 127));
+		item.PR = static_cast<int8>(EQ::Clamp(std::stoi(row[ItemField::pr]), -128, 127));
+		item.SVCorruption = static_cast<int8>(EQ::Clamp(std::stoi(row[ItemField::svcorruption]), -128, 127));
 
-		item.Proc.Effect = (int32)atoul(row[ItemField::proceffect]);
-		item.Proc.Type = (uint8)atoul(row[ItemField::proctype]);
-		item.Proc.Level = (uint8)atoul(row[ItemField::proclevel]);
-		item.Proc.Level2 = (uint8)atoul(row[ItemField::proclevel2]);
-		item.Worn.Effect = (int32)atoul(row[ItemField::worneffect]);
-		item.Worn.Type = (uint8)atoul(row[ItemField::worntype]);
-		item.Worn.Level = (uint8)atoul(row[ItemField::wornlevel]);
-		item.Worn.Level2 = (uint8)atoul(row[ItemField::wornlevel2]);
-		item.Focus.Effect = (int32)atoul(row[ItemField::focuseffect]);
-		item.Focus.Type = (uint8)atoul(row[ItemField::focustype]);
-		item.Focus.Level = (uint8)atoul(row[ItemField::focuslevel]);
-		item.Focus.Level2 = (uint8)atoul(row[ItemField::focuslevel2]);
-		item.Scroll.Effect = (int32)atoul(row[ItemField::scrolleffect]);
-		item.Scroll.Type = (uint8)atoul(row[ItemField::scrolltype]);
-		item.Scroll.Level = (uint8)atoul(row[ItemField::scrolllevel]);
-		item.Scroll.Level2 = (uint8)atoul(row[ItemField::scrolllevel2]);
-		item.Bard.Effect = (int32)atoul(row[ItemField::bardeffect]);
-		item.Bard.Type = (uint8)atoul(row[ItemField::bardtype]);
-		item.Bard.Level = (uint8)atoul(row[ItemField::bardlevel]);
-		item.Bard.Level2 = (uint8)atoul(row[ItemField::bardlevel2]);
-		item.QuestItemFlag = (atoi(row[ItemField::questitemflag]) == 0) ? false : true;
-		item.SVCorruption = (int32)atoi(row[ItemField::svcorruption]);
-		item.Purity = (uint32)atoul(row[ItemField::purity]);
-		item.EvolvingItem = (uint8)atoul(row[ItemField::evoitem]);
-		item.EvolvingID = (uint8)atoul(row[ItemField::evoid]);
-		item.EvolvingLevel = (uint8)atoul(row[ItemField::evolvinglevel]);
-		item.EvolvingMax = (uint8)atoul(row[ItemField::evomax]);
-		item.BackstabDmg = (uint32)atoul(row[ItemField::backstabdmg]);
-		item.DSMitigation = (uint32)atoul(row[ItemField::dsmitigation]);
-		item.HeroicStr = (int32)atoi(row[ItemField::heroic_str]);
-		item.HeroicInt = (int32)atoi(row[ItemField::heroic_int]);
-		item.HeroicWis = (int32)atoi(row[ItemField::heroic_wis]);
-		item.HeroicAgi = (int32)atoi(row[ItemField::heroic_agi]);
-		item.HeroicDex = (int32)atoi(row[ItemField::heroic_dex]);
-		item.HeroicSta = (int32)atoi(row[ItemField::heroic_sta]);
-		item.HeroicCha = (int32)atoi(row[ItemField::heroic_cha]);
-		item.HeroicMR = (int32)atoi(row[ItemField::heroic_mr]);
-		item.HeroicFR = (int32)atoi(row[ItemField::heroic_fr]);
-		item.HeroicCR = (int32)atoi(row[ItemField::heroic_cr]);
-		item.HeroicDR = (int32)atoi(row[ItemField::heroic_dr]);
-		item.HeroicPR = (int32)atoi(row[ItemField::heroic_pr]);
-		item.HeroicSVCorrup = (int32)atoi(row[ItemField::heroic_svcorrup]);
-		item.HealAmt = (int32)atoi(row[ItemField::healamt]);
-		item.SpellDmg = (int32)atoi(row[ItemField::spelldmg]);
-		item.LDoNSellBackRate = (uint32)atoul(row[ItemField::ldonsellbackrate]);
-		item.ScriptFileID = (uint32)atoul(row[ItemField::scriptfileid]);
-		item.ExpendableArrow = (uint16)atoul(row[ItemField::expendablearrow]);
-		item.Clairvoyance = (uint32)atoul(row[ItemField::clairvoyance]);
+		// Heroic Resists
+		item.HeroicCR = std::stoi(row[ItemField::heroic_cr]);
+		item.HeroicDR = std::stoi(row[ItemField::heroic_dr]);
+		item.HeroicFR = std::stoi(row[ItemField::heroic_fr]);
+		item.HeroicMR = std::stoi(row[ItemField::heroic_mr]);
+		item.HeroicPR = std::stoi(row[ItemField::heroic_pr]);
+		item.HeroicSVCorrup = std::stoi(row[ItemField::heroic_svcorrup]);
 
-		strcpy(item.ClickName, row[ItemField::clickname]);
-		strcpy(item.ProcName, row[ItemField::procname]);
-		strcpy(item.WornName, row[ItemField::wornname]);
-		strcpy(item.FocusName, row[ItemField::focusname]);
-		strcpy(item.ScrollName, row[ItemField::scrollname]);
+		// Stats
+		item.AAgi = static_cast<int8>(EQ::Clamp(std::stoi(row[ItemField::aagi]), -128, 127));
+		item.ACha = static_cast<int8>(EQ::Clamp(std::stoi(row[ItemField::acha]), -128, 127));
+		item.ADex = static_cast<int8>(EQ::Clamp(std::stoi(row[ItemField::adex]), -128, 127));
+		item.AInt = static_cast<int8>(EQ::Clamp(std::stoi(row[ItemField::aint]), -128, 127));
+		item.ASta = static_cast<int8>(EQ::Clamp(std::stoi(row[ItemField::asta]), -128, 127));
+		item.AStr = static_cast<int8>(EQ::Clamp(std::stoi(row[ItemField::astr]), -128, 127));
+		item.AWis = static_cast<int8>(EQ::Clamp(std::stoi(row[ItemField::awis]), -128, 127));
+
+		// Heroic Stats
+		item.HeroicAgi = std::stoi(row[ItemField::heroic_agi]);
+		item.HeroicCha = std::stoi(row[ItemField::heroic_cha]);
+		item.HeroicDex = std::stoi(row[ItemField::heroic_dex]);
+		item.HeroicInt = std::stoi(row[ItemField::heroic_int]);
+		item.HeroicSta = std::stoi(row[ItemField::heroic_sta]);
+		item.HeroicStr = std::stoi(row[ItemField::heroic_str]);
+		item.HeroicWis = std::stoi(row[ItemField::heroic_wis]);
+
+		// Health, Mana, and Endurance
+		item.HP = std::stoi(row[ItemField::hp]);
+		item.Regen = std::stoul(row[ItemField::regen]);
+		item.Mana = std::stoi(row[ItemField::mana]);
+		item.ManaRegen = std::stoul(row[ItemField::manaregen]);
+		item.Endur = std::stoul(row[ItemField::endur]);
+		item.EnduranceRegen = std::stoul(row[ItemField::enduranceregen]);
+
+		// Bane Damage
+		item.BaneDmgAmt = std::stoi(row[ItemField::banedmgamt]);
+		item.BaneDmgBody = std::stoul(row[ItemField::banedmgbody]);
+		item.BaneDmgRace = std::stoul(row[ItemField::banedmgrace]);
+		item.BaneDmgRaceAmt = std::stoul(row[ItemField::banedmgraceamt]);
+
+		// Elemental Damage
+		item.ElemDmgType = static_cast<uint8>(std::stoul(row[ItemField::elemdmgtype]));
+		item.ElemDmgAmt = static_cast<uint8>(std::stoul(row[ItemField::elemdmgamt]));
+
+		// Combat
+		item.BackstabDmg = std::stoul(row[ItemField::backstabdmg]);
+		item.Damage = std::stoul(row[ItemField::damage]);
+		item.Delay = static_cast<uint8>(std::stoul(row[ItemField::delay]));
+		item.Range = static_cast<uint8>(std::stoul(row[ItemField::range]));
+
+		// Combat Stats
+		item.AC = std::stoi(row[ItemField::ac]);
+		item.Accuracy = static_cast<int8>(EQ::Clamp(std::stoi(row[ItemField::accuracy]), -128, 127));
+		item.Attack = std::stoi(row[ItemField::attack]);
+		item.Avoidance = static_cast<int8>(EQ::Clamp(std::stoi(row[ItemField::avoidance]), -128, 127));
+		item.Clairvoyance = std::stoul(row[ItemField::clairvoyance]);
+		item.CombatEffects = static_cast<int8>(EQ::Clamp(std::stoi(row[ItemField::combateffects]), -128, 127));
+		item.DamageShield = std::stoi(row[ItemField::damageshield]);
+		item.DotShielding = std::stoi(row[ItemField::dotshielding]);
+		item.DSMitigation = std::stoul(row[ItemField::dsmitigation]);
+		item.Haste = std::stoi(row[ItemField::haste]);
+		item.HealAmt = std::stoi(row[ItemField::healamt]);
+		item.Purity = std::stoul(row[ItemField::purity]);
+		item.Shielding = static_cast<int8>(EQ::Clamp(std::stoi(row[ItemField::shielding]), -128, 127));
+		item.SpellDmg = std::stoi(row[ItemField::spelldmg]);
+		item.SpellShield = static_cast<int8>(EQ::Clamp(std::stoi(row[ItemField::spellshield]), -128, 127));
+		item.StrikeThrough = static_cast<int8>(EQ::Clamp(std::stoi(row[ItemField::strikethrough]), -128, 127));
+		item.StunResist = static_cast<int8>(EQ::Clamp(std::stoi(row[ItemField::stunresist]), -128, 127));
+
+		// Restrictions
+		item.AugRestrict = std::stoul(row[ItemField::augrestrict]);
+		item.Classes = std::stoul(row[ItemField::classes]);
+		item.Deity = std::stoul(row[ItemField::deity]);
+		item.ItemClass = static_cast<uint8>(std::stoul(row[ItemField::itemclass]));
+		item.Races = std::stoul(row[ItemField::races]);
+		item.RecLevel = static_cast<uint8>(std::stoul(row[ItemField::reclevel]));
+		item.RecSkill = static_cast<uint8>(std::stoul(row[ItemField::recskill]));
+		item.ReqLevel = static_cast<uint8>(std::stoul(row[ItemField::reqlevel]));
+		item.Slots = std::stoul(row[ItemField::slots]);
+
+		// Skill Modifier
+		item.SkillModValue = std::stoi(row[ItemField::skillmodvalue]);
+		item.SkillModMax = std::stoi(row[ItemField::skillmodmax]);
+		item.SkillModType = std::stoul(row[ItemField::skillmodtype]);
+
+		// Extra Damage Skill
+		item.ExtraDmgSkill = std::stoul(row[ItemField::extradmgskill]);
+		item.ExtraDmgAmt = std::stoul(row[ItemField::extradmgamt]);
+
+		// Bard
+		item.BardType = std::stoul(row[ItemField::bardtype]);
+		item.BardValue = std::stoi(row[ItemField::bardvalue]);
+
+		// Faction
+		item.FactionAmt1 = std::stoi(row[ItemField::factionamt1]);
+		item.FactionMod1 = std::stoi(row[ItemField::factionmod1]);
+		item.FactionAmt2 = std::stoi(row[ItemField::factionamt2]);
+		item.FactionMod2 = std::stoi(row[ItemField::factionmod2]);
+		item.FactionAmt3 = std::stoi(row[ItemField::factionamt3]);
+		item.FactionMod3 = std::stoi(row[ItemField::factionmod3]);
+		item.FactionAmt4 = std::stoi(row[ItemField::factionamt4]);
+		item.FactionMod4 = std::stoi(row[ItemField::factionmod4]);
+
+		// Augment
+		item.AugDistiller = std::stoul(row[ItemField::augdistiller]);
+		item.AugSlotType[0] = static_cast<uint8>(std::stoul(row[ItemField::augslot1type]));
+		item.AugSlotVisible[0] = static_cast<uint8>(std::stoul(row[ItemField::augslot1visible]));
+		item.AugSlotType[1] = static_cast<uint8>(std::stoul(row[ItemField::augslot2type]));
+		item.AugSlotVisible[1] = static_cast<uint8>(std::stoul(row[ItemField::augslot2visible]));
+		item.AugSlotType[2] = static_cast<uint8>(std::stoul(row[ItemField::augslot3type]));
+		item.AugSlotVisible[2] = static_cast<uint8>(std::stoul(row[ItemField::augslot3visible]));
+		item.AugSlotType[3] = static_cast<uint8>(std::stoul(row[ItemField::augslot4type]));
+		item.AugSlotVisible[3] = static_cast<uint8>(std::stoul(row[ItemField::augslot4visible]));
+		item.AugSlotType[4] = static_cast<uint8>(std::stoul(row[ItemField::augslot5type]));
+		item.AugSlotVisible[4] = static_cast<uint8>(std::stoul(row[ItemField::augslot5visible]));
+		item.AugSlotType[5] = static_cast<uint8>(std::stoul(row[ItemField::augslot6type]));
+		item.AugSlotVisible[5] = static_cast<uint8>(std::stoul(row[ItemField::augslot6visible]));
+
+		// Augment Unknowns
+		for (uint8 i = EQ::invaug::SOCKET_BEGIN; i <= EQ::invaug::SOCKET_END; i++) {
+			item.AugSlotUnk2[i] = 0;
+		}
+
+		// LDoN
+		item.LDoNTheme = std::stoul(row[ItemField::ldontheme]);
+		item.LDoNPrice = std::stoul(row[ItemField::ldonprice]);
+		item.LDoNSellBackRate = std::stoul(row[ItemField::ldonsellbackrate]);
+		item.LDoNSold = std::stoul(row[ItemField::ldonsold]);
+		item.PointType = std::stoul(row[ItemField::pointtype]);
+		
+		// Bag
+		item.BagSize = static_cast<uint8>(std::stoul(row[ItemField::bagsize]));
+		item.BagSlots = static_cast<uint8>(EQ::Clamp(std::stoi(row[ItemField::bagslots]), 0, 10)); // Will need to be changed from std::min to just use database value when bag slots are increased
+		item.BagType = static_cast<uint8>(std::stoul(row[ItemField::bagtype]));
+		item.BagWR = static_cast<uint8>(EQ::Clamp(std::stoi(row[ItemField::bagwr]), 0, 100));
+
+		// Bard Effect
+		item.Bard.Effect = disable_bard_focus_effects ? 0 : std::stoi(row[ItemField::bardeffect]);
+		item.Bard.Type = disable_bard_focus_effects ? 0 : static_cast<uint8>(std::stoul(row[ItemField::bardtype]));
+		item.Bard.Level = disable_bard_focus_effects ? 0 : static_cast<uint8>(std::stoul(row[ItemField::bardlevel]));
+		item.Bard.Level2 = disable_bard_focus_effects ? 0 : static_cast<uint8>(std::stoul(row[ItemField::bardlevel2]));
+
+		// Book
+		item.Book = static_cast<uint8>(std::stoul(row[ItemField::book]));
+		item.BookType = std::stoul(row[ItemField::booktype]);
+
+		// Click Effect
+		item.CastTime = std::stoul(row[ItemField::casttime]);
+		item.CastTime_ = std::stoi(row[ItemField::casttime_]);
+		item.Click.Effect = std::stoul(row[ItemField::clickeffect]);
+		item.Click.Type = static_cast<uint8>(std::stoul(row[ItemField::clicktype]));
+		item.Click.Level = static_cast<uint8>(std::stoul(row[ItemField::clicklevel]));
+		item.Click.Level2 = static_cast<uint8>(std::stoul(row[ItemField::clicklevel2]));
+		strn0cpy(item.ClickName, row[ItemField::clickname], sizeof(item.ClickName));
+		item.RecastDelay = std::stoul(row[ItemField::recastdelay]);
+		item.RecastType = std::stoi(row[ItemField::recasttype]);
+
+		// Focus Effect
+		item.Focus.Effect = disable_spell_focus_effects ? 0 : std::stoi(row[ItemField::focuseffect]);
+		item.Focus.Type = disable_spell_focus_effects ? 0 : static_cast<uint8>(std::stoul(row[ItemField::focustype]));
+		item.Focus.Level = disable_spell_focus_effects ? 0 : static_cast<uint8>(std::stoul(row[ItemField::focuslevel]));
+		item.Focus.Level2 = disable_spell_focus_effects ? 0 : static_cast<uint8>(std::stoul(row[ItemField::focuslevel2]));
+		strn0cpy(item.FocusName, disable_spell_focus_effects ? "" : row[ItemField::focusname], sizeof(item.FocusName));
+
+		// Proc Effect
+		item.Proc.Effect = std::stoi(row[ItemField::proceffect]);
+		item.Proc.Type = static_cast<uint8>(std::stoul(row[ItemField::proctype]));
+		item.Proc.Level = static_cast<uint8>(std::stoul(row[ItemField::proclevel]));
+		item.Proc.Level2 = static_cast<uint8>(std::stoul(row[ItemField::proclevel2]));
+		strn0cpy(item.ProcName, row[ItemField::procname], sizeof(item.ProcName));
+		item.ProcRate = std::stoi(row[ItemField::procrate]);
+
+		// Scroll Effect
+		item.Scroll.Effect = std::stoi(row[ItemField::scrolleffect]);
+		item.Scroll.Type = static_cast<uint8>(std::stoul(row[ItemField::scrolltype]));
+		item.Scroll.Level = static_cast<uint8>(std::stoul(row[ItemField::scrolllevel]));
+		item.Scroll.Level2 = static_cast<uint8>(std::stoul(row[ItemField::scrolllevel2]));
+		strn0cpy(item.ScrollName, row[ItemField::scrollname], sizeof(item.ScrollName));
+
+		// Worn Effect		
+		item.Worn.Effect = std::stoi(row[ItemField::worneffect]);
+		item.Worn.Type = static_cast<uint8>(std::stoul(row[ItemField::worntype]));
+		item.Worn.Level = static_cast<uint8>(std::stoul(row[ItemField::wornlevel]));
+		item.Worn.Level2 = static_cast<uint8>(std::stoul(row[ItemField::wornlevel2]));
+		strn0cpy(item.WornName, row[ItemField::wornname], sizeof(item.WornName));
+
+		// Evolving Item
+		item.EvolvingID = std::stoul(row[ItemField::evoid]);
+		item.EvolvingItem = static_cast<uint8>(std::stoul(row[ItemField::evoitem]));
+		item.EvolvingLevel = static_cast<uint8>(std::stoul(row[ItemField::evolvinglevel]));
+		item.EvolvingMax = static_cast<uint8>(std::stoul(row[ItemField::evomax]));
+
+		// Scripting
+		item.CharmFileID = std::stoul(row[ItemField::charmfileid]);
+		strn0cpy(item.CharmFile, row[ItemField::charmfile], sizeof(item.CharmFile));
+		strn0cpy(item.Filename, row[ItemField::filename], sizeof(item.Filename));
+		item.ScriptFileID = std::stoul(row[ItemField::scriptfileid]);
 
 		try {
 			hash.insert(item.ID, item);

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -170,7 +170,7 @@ bool Client::CheckLoreConflict(const EQ::ItemData* item)
 	if (!item->LoreFlag) { return false; }
 	if (item->LoreGroup == 0) { return false; }
 
-	if (item->LoreGroup == 0xFFFFFFFF) // Standard lore items; look everywhere except the shared bank, return the result
+	if (item->LoreGroup == -1) // Standard lore items; look everywhere except the shared bank, return the result
 		return (m_inv.HasItem(item->ID, 0, ~invWhereSharedBank) != INVALID_INDEX);
 
 	// If the item has a lore group, we check for other items with the same group and return the result
@@ -1072,7 +1072,7 @@ void Client::SendCursorBuffer()
 	if (test_item == nullptr) { return; }
 
 	bool lore_pass = true;
-	if (test_item->LoreGroup == 0xFFFFFFFF) {
+	if (test_item->LoreGroup == -1) {
 		lore_pass = (m_inv.HasItem(test_item->ID, 0, ~(invWhereSharedBank | invWhereCursor)) == INVALID_INDEX);
 	}
 	else if (test_item->LoreGroup != 0) {
@@ -1799,7 +1799,7 @@ bool Client::SwapItem(MoveItem_Struct* move_in) {
 			if (!test_item->LoreFlag) { return true; }
 
 			bool lore_pass = true;
-			if (test_item->LoreGroup == 0xFFFFFFFF) {
+			if (test_item->LoreGroup == -1) {
 				lore_pass = (m_inv.HasItem(test_item->ID, 0, ~(invWhereSharedBank | invWhereCursor)) == INVALID_INDEX);
 			}
 			else if (test_item->LoreGroup != 0) {


### PR DESCRIPTION
- Noticed some data types were `uint32` when they should be `int32` based on Live items having these stats as negatives.
- Loregroup was `uint32` and should be `int32` for Loregroup -1, fixed any references to -1 as 0xFFFFFFFF.
- Attack was `uint32` and should be `int32`.
- DamageShield was `uint32` and should be `int32`.
- DotShielding was `uint32` and should be `int32`.
- Endurance was `uint32` and should be `int32`.
- EnduranceRegen was `uint32` and should be `int32`.
- Haste was `uint32` and should be `int32`.
- ManaRegen was `uint32` and should be `int32`.
- Regen was `uint32` and should be `int32`.
```cpp
RULE_BOOL(Items, DisableAttuneable, false, "Enable this to disable Attuneable Items")
RULE_BOOL(Items, DisableBardFocusEffects, false, "Enable this to disable Bard Focus Effects on Items")
RULE_BOOL(Items, DisableLore, false, "Enable this to disable Lore Items")
RULE_BOOL(Items, DisableNoDrop, false, "Enable this to disable No Drop Items")
RULE_BOOL(Items, DisableNoPet, false, "Enable this to disable No Pet Items")
RULE_BOOL(Items, DisableNoRent, false, "Enable this to disable No Rent Items")
RULE_BOOL(Items, DisableNoTransfer, false, "Enable this to disable No Transfer Items")
RULE_BOOL(Items, DisablePotionBelt, false, "Enable this to disable Potion Belt Items")
RULE_BOOL(Items, DisableSpellFocusEffects, false, "Enable this to disable Spell Focus Effects on Items")
```