### PR TITLE
[Bug Fix] Correct (probably) unintended bitwise AND instead of logical AND

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -4598,7 +4598,7 @@ bool Mob::TrySpellTrigger(Mob *target, uint32 spell_id, int effect)
 			SpellFinished(spells[spell_id].limit_value[effect_slot], target, EQ::spells::CastingSlot::Item, 0, -1, spells[spells[spell_id].limit_value[effect_slot]].resist_difficulty);
 			return true;
 		}
-		else if (IsClient() & spells[spell_id].effect_id[effect_slot] == SE_Chance_Best_in_Spell_Grp) {
+		else if (IsClient() && spells[spell_id].effect_id[effect_slot] == SE_Chance_Best_in_Spell_Grp) {
 			uint32 best_spell_id = CastToClient()->GetHighestScribedSpellinSpellGroup(spells[spell_id].limit_value[effect_slot]);
 			if (IsValidSpell(best_spell_id)) {
 				SpellFinished(best_spell_id, target, EQ::spells::CastingSlot::Item, 0, -1, spells[best_spell_id].resist_difficulty);


### PR DESCRIPTION
Original condition `IsClient() & spells[spell_id].effect_id[effect_slot] == SE_Chance_Best_in_Spell_Grp` will evaluate `spells[spell_id].effect_id[effect_slot] == SE_Chance_Best_in_Spell_Grp` first, then `IsClient() & <bool>` will evaluate.

New condition will evaluate in expected left to right order. Results are expected to be the same (`bool & bool` should equal `bool && bool`)