### PR TITLE
[Cleanup] Add Validation to varchar number item fields.

### DIFF
--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -1119,7 +1119,7 @@ void SharedDatabase::LoadItems(void *data, uint32 size, int32 items, uint32 max_
 		item.Attack = std::stoi(row[ItemField::attack]);
 		item.Avoidance = static_cast<int8>(EQ::Clamp(std::stoi(row[ItemField::avoidance]), -128, 127));
 		item.Clairvoyance = std::stoul(row[ItemField::clairvoyance]);
-		item.CombatEffects = static_cast<int8>(EQ::Clamp(std::stoi(row[ItemField::combateffects]), -128, 127));
+		item.CombatEffects = StringIsNumber(row[ItemField::combateffects]) ? static_cast<int8>(EQ::Clamp(std::stoi(row[ItemField::combateffects]), -128, 127)) : 0;
 		item.DamageShield = std::stoi(row[ItemField::damageshield]);
 		item.DotShielding = std::stoi(row[ItemField::dotshielding]);
 		item.DSMitigation = std::stoul(row[ItemField::dsmitigation]);
@@ -1256,7 +1256,7 @@ void SharedDatabase::LoadItems(void *data, uint32 size, int32 items, uint32 max_
 		item.EvolvingMax = static_cast<uint8>(std::stoul(row[ItemField::evomax]));
 
 		// Scripting
-		item.CharmFileID = std::stoul(row[ItemField::charmfileid]);
+		item.CharmFileID = StringIsNumber(row[ItemField::charmfileid]) ? std::stoul(row[ItemField::charmfileid]) : 0;
 		strn0cpy(item.CharmFile, row[ItemField::charmfile], sizeof(item.CharmFile));
 		strn0cpy(item.Filename, row[ItemField::filename], sizeof(item.Filename));
 		item.ScriptFileID = std::stoul(row[ItemField::scriptfileid]);


### PR DESCRIPTION
- `combateffects` and `charmfileid` were varchar and have no default value, so if you passed '' shared memory would fail, default these to 0 to prevent this.