### PR TITLE
[Memory Leak] Fix leak of CommandRecords in commandlist

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -466,6 +466,9 @@ int command_init(void)
  */
 void command_deinit(void)
 {
+	for (auto &c : commandlist)
+		delete c.second;
+
 	commandlist.clear();
 	commandaliases.clear();
 

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -52,6 +52,7 @@ int (*command_dispatch)(Client *,std::string) = command_notavail;
 
 std::map<std::string, CommandRecord *> commandlist;
 std::map<std::string, std::string> commandaliases;
+std::vector<CommandRecord *> command_delete_list;
 
 /*
  * command_notavail
@@ -466,9 +467,9 @@ int command_init(void)
  */
 void command_deinit(void)
 {
-	for (auto &c : commandlist)
-		delete c.second;
-
+	for (auto &c : command_delete_list)
+		delete c;
+	command_delete_list.clear();
 	commandlist.clear();
 	commandaliases.clear();
 
@@ -520,6 +521,7 @@ int command_add(std::string command_name, std::string description, uint8 admin, 
 
 	commandlist[command_name] = c;
 	commandaliases[command_name] = command_name;
+	command_delete_list.push_back(c);
 	command_count++;
 
 	return 0;


### PR DESCRIPTION
Quicker than porting to std::unique_ptr since we do fun stuff with
commandlist ...