### PR TITLE
[Fix] Boats should never get FixZ'd

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -512,6 +512,18 @@ Mob::Mob(
 	mob_close_scan_timer.Trigger();
 
 	SetCanOpenDoors(true);
+
+	is_boat = (
+        race == RACE_SHIP_72 ||
+        race == RACE_LAUNCH_73 ||
+        race == RACE_GHOST_SHIP_114 ||
+        race == RACE_SHIP_404 ||
+        race == RACE_MERCHANT_SHIP_550 ||
+        race == RACE_PIRATE_SHIP_551 ||
+        race == RACE_GHOST_SHIP_552 ||
+        race == RACE_BOAT_533
+    );
+
 }
 
 Mob::~Mob()
@@ -5658,20 +5670,6 @@ void Mob::RemoveAllNimbusEffects()
 	nimbus_effect1 = 0;
 	nimbus_effect2 = 0;
 	nimbus_effect3 = 0;
-}
-
-bool Mob::IsBoat() const {
-
-	return (
-		race == RACE_SHIP_72 ||
-		race == RACE_LAUNCH_73 ||
-		race == RACE_GHOST_SHIP_114 ||
-		race == RACE_SHIP_404 ||
-		race == RACE_MERCHANT_SHIP_550 ||
-		race == RACE_PIRATE_SHIP_551 ||
-		race == RACE_GHOST_SHIP_552 ||
-		race == RACE_BOAT_533
-	);
 }
 
 bool Mob::IsControllableBoat() const {

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -512,18 +512,8 @@ Mob::Mob(
 	mob_close_scan_timer.Trigger();
 
 	SetCanOpenDoors(true);
-
-	is_boat = (
-        race == RACE_SHIP_72 ||
-        race == RACE_LAUNCH_73 ||
-        race == RACE_GHOST_SHIP_114 ||
-        race == RACE_SHIP_404 ||
-        race == RACE_MERCHANT_SHIP_550 ||
-        race == RACE_PIRATE_SHIP_551 ||
-        race == RACE_GHOST_SHIP_552 ||
-        race == RACE_BOAT_533
-    );
-
+	
+	is_boat = IsBoat();
 }
 
 Mob::~Mob()
@@ -3736,7 +3726,7 @@ bool Mob::HateSummon() {
 
 void Mob::FaceTarget(Mob* mob_to_face /*= 0*/) {
 
-	if (IsBoat()) {
+	if (GetIsBoat()) {
 		return;
 	}
 
@@ -5670,6 +5660,20 @@ void Mob::RemoveAllNimbusEffects()
 	nimbus_effect1 = 0;
 	nimbus_effect2 = 0;
 	nimbus_effect3 = 0;
+}
+
+bool Mob::IsBoat() const {
+
+	return (
+		race == RACE_SHIP_72 ||
+		race == RACE_LAUNCH_73 ||
+		race == RACE_GHOST_SHIP_114 ||
+		race == RACE_SHIP_404 ||
+		race == RACE_MERCHANT_SHIP_550 ||
+		race == RACE_PIRATE_SHIP_551 ||
+		race == RACE_GHOST_SHIP_552 ||
+		race == RACE_BOAT_533
+	);
 }
 
 bool Mob::IsControllableBoat() const {

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -630,7 +630,9 @@ public:
 	inline const float GetSize() const { return size; }
 	inline const float GetBaseSize() const { return base_size; }
 	inline const GravityBehavior GetFlyMode() const { return flymode; }
-	bool IsBoat() const { return is_boat; }
+	bool IsBoat() const; // Checks races - used on mob instantiation
+	bool GetIsBoat() const { return is_boat; } // Set on instantiation for speed
+	bool SetIsBoat(bool boat) { is_boat = boat; };
 	bool IsControllableBoat() const;
 	inline const bool AlwaysAggro() const { return always_aggro; }
 

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -630,7 +630,7 @@ public:
 	inline const float GetSize() const { return size; }
 	inline const float GetBaseSize() const { return base_size; }
 	inline const GravityBehavior GetFlyMode() const { return flymode; }
-	bool IsBoat() const;
+	bool IsBoat() const { return is_boat; }
 	bool IsControllableBoat() const;
 	inline const bool AlwaysAggro() const { return always_aggro; }
 
@@ -1664,6 +1664,7 @@ protected:
 	bool endur_upkeep;
 	bool degenerating_effects; // true if we have a buff that needs to be recalced every tick
 	bool spawned_in_water;
+	bool is_boat;
 
 	CombatRecord combat_record{};
 

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -632,7 +632,7 @@ public:
 	inline const GravityBehavior GetFlyMode() const { return flymode; }
 	bool IsBoat() const; // Checks races - used on mob instantiation
 	bool GetIsBoat() const { return is_boat; } // Set on instantiation for speed
-	bool SetIsBoat(bool boat) { is_boat = boat; };
+	void SetIsBoat(bool boat) { is_boat = boat; }
 	bool IsControllableBoat() const;
 	inline const bool AlwaysAggro() const { return always_aggro; }
 

--- a/zone/mob_movement_manager.cpp
+++ b/zone/mob_movement_manager.cpp
@@ -1075,7 +1075,7 @@ void MobMovementManager::UpdatePath(Mob *who, float x, float y, float z, MobMove
 		return;
 	}
 
-	if (who->IsBoat()) {
+	if (who->GetIsBoat()) {
 		UpdatePathBoat(who, x, y, z, mob_movement_mode);
 	}
 	else if (who->IsUnderwaterOnly()) {

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -236,7 +236,7 @@ NPC::NPC(const NPCType *npc_type_data, Spawn2 *in_respawn, const glm::vec4 &posi
 	if (npc_type_data->flymode >= 0) {
 		flymode = static_cast<GravityBehavior>(npc_type_data->flymode);
 	}
-	else if (IsBoat()) {
+	else if (GetIsBoat()) {
 		flymode = GravityBehavior::Floating;
 	}
 

--- a/zone/waypoints.cpp
+++ b/zone/waypoints.cpp
@@ -795,6 +795,10 @@ void Mob::FixZ(int32 z_find_offset /*= 5*/, bool fix_client_z /*= false*/) {
 		return;
 	}
 
+	if (IsBoat()) {
+		return;
+	}
+
 	if (flymode == GravityBehavior::Flying) {
 		return;
 	}

--- a/zone/waypoints.cpp
+++ b/zone/waypoints.cpp
@@ -795,7 +795,7 @@ void Mob::FixZ(int32 z_find_offset /*= 5*/, bool fix_client_z /*= false*/) {
 		return;
 	}
 
-	if (IsBoat()) {
+	if (GetIsBoat()) {
 		return;
 	}
 


### PR DESCRIPTION
If a boat spawn point or waypoint had a Z value that caused the code to no longer see the boat in water, even though a great deal of the boat was below water. FixZ would kick in.  This can cause massive issues to clients viewpoints of the boat (other than the client riding the boat) - causing some people that zone in after the FixZ to see the boat and rider underwater.

This is a tiny patch to avoid the issue in general - but I'll be looking to touch up my Boat navigation in movement_manager to be more in sync with how the client deals with Z for boats.