### PR TITLE
[Bug Fix] Stop skill ups on Charmed NPCs.

### DIFF
--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -330,7 +330,7 @@ bool Client::Process() {
 			{
 				if (ranged->GetItem() && ranged->GetItem()->ItemType == EQ::item::ItemTypeBow) {
 					if (ranged_timer.Check(false)) {
-						if (GetTarget() && (GetTarget()->IsNPC() || GetTarget()->IsClient())) {
+						if (GetTarget() && (GetTarget()->IsNPC() || GetTarget()->IsClient()) && IsAttackAllowed(GetTarget())) {
 							if (GetTarget()->InFrontMob(this, GetTarget()->GetX(), GetTarget()->GetY())) {
 								if (CheckLosFN(GetTarget())) {
 									//client has built in los check, but auto fire does not.. done last.
@@ -350,7 +350,7 @@ bool Client::Process() {
 				}
 				else if (ranged->GetItem() && (ranged->GetItem()->ItemType == EQ::item::ItemTypeLargeThrowing || ranged->GetItem()->ItemType == EQ::item::ItemTypeSmallThrowing)) {
 					if (ranged_timer.Check(false)) {
-						if (GetTarget() && (GetTarget()->IsNPC() || GetTarget()->IsClient())) {
+						if (GetTarget() && (GetTarget()->IsNPC() || GetTarget()->IsClient()) && IsAttackAllowed(GetTarget())) {
 							if (GetTarget()->InFrontMob(this, GetTarget()->GetX(), GetTarget()->GetY())) {
 								if (CheckLosFN(GetTarget())) {
 									//client has built in los check, but auto fire does not.. done last.
@@ -411,7 +411,7 @@ bool Client::Process() {
 			else if (!los_status || !los_status_facing) {
 				//you can't see your target
 			}
-			else if (auto_attack_target->GetHP() > -10) // -10 so we can watch people bleed in PvP
+			else if (auto_attack_target->GetHP() > -10 && IsAttackAllowed(auto_attack_target)) // -10 so we can watch people bleed in PvP
 			{
 				EQ::ItemInstance *wpn = GetInv().GetItem(EQ::invslot::slotPrimary);
 				TryCombatProcs(wpn, auto_attack_target, EQ::invslot::slotPrimary);
@@ -456,7 +456,7 @@ bool Client::Process() {
 			{
 				//you can't see your target
 			}
-			else if (auto_attack_target->GetHP() > -10) {
+			else if (auto_attack_target->GetHP() > -10 && IsAttackAllowed(auto_attack_target)) {
 				CheckIncreaseSkill(EQ::skills::SkillDualWield, auto_attack_target, -10);
 				if (CheckDualWield()) {
 					EQ::ItemInstance *wpn = GetInv().GetItem(EQ::invslot::slotSecondary);

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -1236,11 +1236,9 @@ void EntityList::AEAttack(
 			) {
 
 			for (int i = 0; i < attack_rounds; i++) {
-
 				if (!attacker->IsClient() || attacker->GetClass() == MONK || attacker->GetClass() == RANGER) {
 					attacker->Attack(current_mob, Hand, false, false, is_from_spell);
-				}
-				else {
+				} else {
 					attacker->CastToClient()->DoAttackRounds(current_mob, Hand, is_from_spell);
 				}
 			}

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -806,14 +806,14 @@ void Client::AI_Process()
 					FaceTarget();
 				}
 			}
-			if (GetTarget() && !IsStunned() && !IsMezzed() && !GetFeigned()) {
+			if (GetTarget() && !IsStunned() && !IsMezzed() && !GetFeigned() && IsAttackAllowed(GetTarget())) {
 				if (attack_timer.Check()) {
 					// Should charmed clients not be procing?
 					DoAttackRounds(GetTarget(), EQ::invslot::slotPrimary);
 				}
 			}
 
-			if (CanThisClassDualWield() && GetTarget() && !IsStunned() && !IsMezzed() && !GetFeigned()) {
+			if (CanThisClassDualWield() && GetTarget() && !IsStunned() && !IsMezzed() && !GetFeigned() && IsAttackAllowed(GetTarget())) {
 				if (attack_dw_timer.Check()) {
 					if (CheckDualWield()) {
 						// Should charmed clients not be procing?


### PR DESCRIPTION
- Clients were capable of leveling up their melee skills on Charmed Mobs according to: https://github.com/EQEmu/Server/issues/2182
- Based on testing and comments by @Isaaru.