### PR TITLE
[Bug Fix] Bazaar Search MYSQL Error

### DIFF
--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -1836,13 +1836,13 @@ void Client::SendBazaarResults(
 			search_criteria.append(" AND items.itemclass = 2");
 			break;
 		case 46:
-			search_criteria.append(" AND items.spellid > 0 AND items.spellid < 65000");
+			search_criteria.append(" AND items.scrolleffect > 0 AND items.scrolleffect < 65000");
 			break;
 		case 47:
-			search_criteria.append(" AND items.spellid = 998");
+			search_criteria.append(" AND items.worneffect = 998");
 			break;
 		case 48:
-			search_criteria.append(" AND items.spellid >= 1298 AND items.spellid <= 1307");
+			search_criteria.append(" AND items.worneffect >= 1298 AND items.worneffect <= 1307");
 			break;
 		case 49:
 			search_criteria.append(" AND items.focuseffect > 0");


### PR DESCRIPTION
Corrected fields that the bazaar search function is using to prevent mysql error due to non-existant field items.spellid.