### PR TITLE
[Bug Fix] Fix stack leaks in Lua events

### DIFF
--- a/zone/lua_mod.cpp
+++ b/zone/lua_mod.cpp
@@ -206,7 +206,7 @@ void LuaMod::MeleeMitigation(Mob *self, Mob *attacker, DamageHitInfo &hit, Extra
 		if (lua_pcall(L, 1, 1, 0)) {
 			std::string error = lua_tostring(L, -1);
 			parser_->AddError(error);
-			lua_pop(L, 1);
+			lua_pop(L, 2);
 			return;
 		}
 
@@ -253,7 +253,7 @@ void LuaMod::ApplyDamageTable(Mob *self, DamageHitInfo &hit, bool &ignoreDefault
 		if (lua_pcall(L, 1, 1, 0)) {
 			std::string error = lua_tostring(L, -1);
 			parser_->AddError(error);
-			lua_pop(L, 1);
+			lua_pop(L, 2);
 			return;
 		}
 
@@ -301,7 +301,7 @@ void LuaMod::AvoidDamage(Mob *self, Mob *other, DamageHitInfo &hit, bool &return
 		if (lua_pcall(L, 1, 1, 0)) {
 			std::string error = lua_tostring(L, -1);
 			parser_->AddError(error);
-			lua_pop(L, 1);
+			lua_pop(L, 2);
 			return;
 		}
 
@@ -354,7 +354,7 @@ void LuaMod::CheckHitChance(Mob *self, Mob* other, DamageHitInfo &hit, bool &ret
 		if (lua_pcall(L, 1, 1, 0)) {
 			std::string error = lua_tostring(L, -1);
 			parser_->AddError(error);
-			lua_pop(L, 1);
+			lua_pop(L, 2);
 			return;
 		}
 
@@ -409,7 +409,7 @@ void LuaMod::CommonOutgoingHitSuccess(Mob *self, Mob *other, DamageHitInfo &hit,
 		if (lua_pcall(L, 1, 1, 0)) {
 			std::string error = lua_tostring(L, -1);
 			parser_->AddError(error);
-			lua_pop(L, 1);
+			lua_pop(L, 2);
 			return;
 		}
 
@@ -459,7 +459,7 @@ void LuaMod::TryCriticalHit(Mob *self, Mob *defender, DamageHitInfo &hit, ExtraA
 		if (lua_pcall(L, 1, 1, 0)) {
 			std::string error = lua_tostring(L, -1);
 			parser_->AddError(error);
-			lua_pop(L, 1);
+			lua_pop(L, 2);
 			return;
 		}
 
@@ -505,7 +505,7 @@ void LuaMod::GetRequiredAAExperience(Client *self, uint32 &returnValue, bool &ig
 		if (lua_pcall(L, 1, 1, 0)) {
 			std::string error = lua_tostring(L, -1);
 			parser_->AddError(error);
-			lua_pop(L, 1);
+			lua_pop(L, 2);
 			return;
 		}
 
@@ -553,7 +553,7 @@ void LuaMod::GetEXPForLevel(Client *self, uint16 level, uint32 &returnValue, boo
 		if (lua_pcall(L, 1, 1, 0)) {
 			std::string error = lua_tostring(L, -1);
 			parser_->AddError(error);
-			lua_pop(L, 1);
+			lua_pop(L, 2);
 			return;
 		}
 
@@ -604,7 +604,7 @@ void LuaMod::GetExperienceForKill(Client *self, Mob *against, uint32 &returnValu
 		if (lua_pcall(L, 1, 1, 0)) {
 			std::string error = lua_tostring(L, -1);
 			parser_->AddError(error);
-			lua_pop(L, 1);
+			lua_pop(L, 2);
 			return;
 		}
 

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -340,6 +340,7 @@ int LuaParser::_EventNPC(std::string package_name, QuestEventID evt, NPC* npc, M
 			std::string error = lua_tostring(L, -1);
 			AddError(error);
 			quest_manager.EndQuest();
+			lua_pop(L, npop);
 			return 0;
 		}
 		quest_manager.EndQuest();
@@ -433,6 +434,7 @@ int LuaParser::_EventPlayer(std::string package_name, QuestEventID evt, Client *
 			std::string error = lua_tostring(L, -1);
 			AddError(error);
 			quest_manager.EndQuest();
+			lua_pop(L, npop);
 			return 0;
 		}
 		quest_manager.EndQuest();
@@ -493,6 +495,7 @@ int LuaParser::_EventItem(std::string package_name, QuestEventID evt, Client *cl
 		} else {
 			lua_getfield(L, LUA_REGISTRYINDEX, package_name.c_str());
 			lua_getfield(L, -1, sub_name);
+			npop = 2;
 		}
 
 		lua_createtable(L, 0, 0);
@@ -516,6 +519,7 @@ int LuaParser::_EventItem(std::string package_name, QuestEventID evt, Client *cl
 			std::string error = lua_tostring(L, -1);
 			AddError(error);
 			quest_manager.EndQuest();
+			lua_pop(L, npop);
 			return 0;
 		}
 		quest_manager.EndQuest();
@@ -597,6 +601,7 @@ int LuaParser::_EventSpell(std::string package_name, QuestEventID evt, NPC* npc,
 			std::string error = lua_tostring(L, -1);
 			AddError(error);
 			quest_manager.EndQuest();
+			lua_pop(L, npop);
 			return 0;
 		}
 		quest_manager.EndQuest();
@@ -663,6 +668,7 @@ int LuaParser::_EventEncounter(std::string package_name, QuestEventID evt, std::
 			std::string error = lua_tostring(L, -1);
 			AddError(error);
 			quest_manager.EndQuest();
+			lua_pop(L, 2);
 			return 0;
 		}
 		quest_manager.EndQuest();


### PR DESCRIPTION
EventItem was leaving the package table on the stack in successful
(non-encounter) calls and only popping the return. All events were
also leaking the full stack on lua_pcall errors. Lua mod callbacks
were popping error returns but leaking the table.