### PR TITLE
[Bug Fix] Tradeskill Item 0 Error

### DIFF
--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -1051,9 +1051,9 @@ bool Client::TradeskillExecute(DBTradeskillRecipe_Struct *spec) {
 		itr = spec->onsuccess.begin();
 		while(itr != spec->onsuccess.end() && !spec->quest) {
 
-			SummonItem(itr->first, itr->second);
 			item = database.GetItem(itr->first);
 			if (item) {
+				SummonItem(itr->first, itr->second);
 				if (GetGroup()) {
 					entity_list.MessageGroup(this, true, Chat::Skills, "%s has successfully fashioned %s!", GetName(), item->Name);
 				}


### PR DESCRIPTION
When trying to fully script a combine so the tradeskill itself does not return an item (Item 0) and handling all items through quests, the source will provide an error regardless that "Item 0 does not exist". This change will move the item summon after the validity check thus preventing the error to the client.