### PR TITLE
[Feature] Update Sinister Strikes

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -3071,62 +3071,70 @@ uint8 Mob::GetWeaponDamageBonus(const EQ::ItemData *weapon, bool offhand)
 	// We assume that the level check is done before calling this function and sinister strikes is checked before
 	// calling for offhand DB
 	auto level = GetLevel();
-	if (!weapon)
+	if (!weapon) {
 		return 1 + ((level - 28) / 3); // how does weaponless scale?
+	}
 
 	auto delay = weapon->Delay;
 	if (weapon->IsType1HWeapon() || weapon->ItemType == EQ::item::ItemTypeMartial) {
 		// we assume sinister strikes is checked before calling here
 		if (!offhand) {
-			if (delay <= 39)
+			if (delay <= 39) {
 				return 1 + ((level - 28) / 3);
-			else if (delay < 43)
+			} else if (delay < 43) {
 				return 2 + ((level - 28) / 3) + ((delay - 40) / 3);
-			else if (delay < 45)
+			} else if (delay < 45) {
 				return 3 + ((level - 28) / 3) + ((delay - 40) / 3);
-			else if (delay >= 45)
+			} else if (delay >= 45) {
 				return 4 + ((level - 28) / 3) + ((delay - 40) / 3);
+			}
+		} else {
+			if (delay <= 19) {
+				return 5 + ((level - 40) / 3) * (delay / 30);
+			} else if (delay <= 23) {
+				return 6 + ((level - 40) / 3) * (delay / 30);
+			} else if (delay >= 24) {
+				return 7 + ((level - 40) / 3) * (delay / 30);
+			}
 		}
-		else {
-			return 1 + ((level - 40) / 3) * (delay / 30); // YOOO shit's useless waste of AAs
-		}
-	}
-	else {
+	} else {
 		// 2h damage bonus
 		int64 damage_bonus = 1 + (level - 28) / 3;
-		if (delay <= 27)
+		if (delay <= 27) {
 			return damage_bonus + 1;
+		}
 		// Client isn't reflecting what the dev quoted, this matches better
 		if (level > 29) {
 			int level_bonus = (level - 30) / 5 + 1;
 			if (level > 50) {
 				level_bonus++;
 				int level_bonus2 = level - 50;
-				if (level > 67)
+				if (level > 67) {
 					level_bonus2 += 5;
-				else if (level > 59)
+				} else if (level > 59) {
 					level_bonus2 += 4;
-				else if (level > 58)
+				} else if (level > 58) {
 					level_bonus2 += 3;
-				else if (level > 56)
+				} else if (level > 56) {
 					level_bonus2 += 2;
-				else if (level > 54)
+				} else if (level > 54) {
 					level_bonus2++;
+				}
 				level_bonus += level_bonus2 * delay / 40;
 			}
 			damage_bonus += level_bonus;
 		}
 		if (delay >= 40) {
 			int delay_bonus = (delay - 40) / 3 + 1;
-			if (delay >= 45)
+			if (delay >= 45) {
 				delay_bonus += 2;
-			else if (delay >= 43)
+			} else if (delay >= 43) {
 				delay_bonus++;
+			}
 			damage_bonus += delay_bonus;
 		}
 		return damage_bonus;
 	}
-
 	return 0;
 }
 


### PR DESCRIPTION
tapatalk.com/groups/monklybusiness43508/leksikon-s-half-assed-guide-to-monkly-aas-oow-incl-t510-s20.html?sid=a9c7745f287f3e89301c960c20f33248

Sinister Strikes:
19 Delay weapon -- Gives a 5 damage bonus to all hits
20 Delay weapon -- Gives a 6 damage bonus to all hits
24 Delay weapon -- Gives a 7 damage bonus to all hits
Given Quarm hammer with maxed non-GoD AAs:
0.7 HPS offhand = 4.9 DPS increase.