### PR TITLE
[Loot] Remove unnecessary loot error messages.

### DIFF
--- a/common/eq_packet_structs.h
+++ b/common/eq_packet_structs.h
@@ -4466,6 +4466,10 @@ struct LoadSpellSet_Struct {
 	uint32 unknown;					//there seems to be an extra field in this packet...
 };
 
+struct LootItem_Struct {
+	uint16 entity_id;
+};
+
 // This is the structure for OP_ZonePlayerToBind opcode. Discovered on Feb 9 2007 by FNW from packet logs for titanium client
 // This field "zone_name" is text the Titanium client will display on player death
 // it appears to be a variable length, null-terminated string

--- a/common/eq_packet_structs.h
+++ b/common/eq_packet_structs.h
@@ -4466,7 +4466,6 @@ struct LoadSpellSet_Struct {
 	uint32 unknown;					//there seems to be an extra field in this packet...
 };
 
-
 // This is the structure for OP_ZonePlayerToBind opcode. Discovered on Feb 9 2007 by FNW from packet logs for titanium client
 // This field "zone_name" is text the Titanium client will display on player death
 // it appears to be a variable length, null-terminated string

--- a/common/eq_packet_structs.h
+++ b/common/eq_packet_structs.h
@@ -4466,9 +4466,6 @@ struct LoadSpellSet_Struct {
 	uint32 unknown;					//there seems to be an extra field in this packet...
 };
 
-struct LootItem_Struct {
-	uint16 entity_id;
-};
 
 // This is the structure for OP_ZonePlayerToBind opcode. Discovered on Feb 9 2007 by FNW from packet logs for titanium client
 // This field "zone_name" is text the Titanium client will display on player death

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -9531,8 +9531,8 @@ void Client::Handle_OP_LootItem(const EQApplicationPacket *app)
 		return;
 	}
 
-	auto* l = (LootItem_Struct*) app->pBuffer;
-	auto entity = entity_list.GetID(l->entity_id);
+	auto* l = (LootingItem_Struct*) app->pBuffer;
+	auto entity = entity_list.GetID(static_cast<uint16>(l->lootee));
 	if (!entity) {
 		auto outapp = new EQApplicationPacket(OP_LootComplete, 0);
 		QueuePacket(outapp);

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -9531,26 +9531,21 @@ void Client::Handle_OP_LootItem(const EQApplicationPacket *app)
 		return;
 	}
 
-	EQApplicationPacket* outapp = nullptr;
-	Entity* entity = entity_list.GetID(*((uint16*)app->pBuffer));
-	if (entity == 0) {
-		Message(Chat::Red, "Error: OP_LootItem: Corpse not found (ent = 0)");
-		outapp = new EQApplicationPacket(OP_LootComplete, 0);
+	auto* l = (LootItem_Struct*) app->pBuffer;
+	auto entity = entity_list.GetID(l->entity_id);
+	if (!entity) {
+		auto outapp = new EQApplicationPacket(OP_LootComplete, 0);
 		QueuePacket(outapp);
 		safe_delete(outapp);
 		return;
 	}
 
-	if (entity->IsCorpse()) {
-		entity->CastToCorpse()->LootItem(this, app);
+	if (!entity->IsCorpse()) {
+		Corpse::SendEndLootErrorPacket(this);
 		return;
 	}
-	else {
-		Message(Chat::Red, "Error: Corpse not found! (!ent->IsCorpse())");
-		Corpse::SendEndLootErrorPacket(this);
-	}
-
-	return;
+	
+	entity->CastToCorpse()->LootItem(this, app);
 }
 
 void Client::Handle_OP_LootRequest(const EQApplicationPacket *app)

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -9544,7 +9544,7 @@ void Client::Handle_OP_LootItem(const EQApplicationPacket *app)
 		Corpse::SendEndLootErrorPacket(this);
 		return;
 	}
-	
+
 	entity->CastToCorpse()->LootItem(this, app);
 }
 


### PR DESCRIPTION
- These messages are only sent when you loot a corpse that is mid-decay (i.e. no items and you go to loot it immediately) or if you try to loot a non-corpse entity.
- The ent != 0 shows up a lot if you're trying to loot too quickly and really isn't an error, the server just hasn't caught up to decay the corpse before you try to loot.
- Add LootItem_Struct to give more verbosity to Handle_OP_LootItem.