### PR TITLE
[Telnet] Add guildsay to console commands and Guild Channel to QueueMessage.

### DIFF
--- a/common/net/console_server_connection.cpp
+++ b/common/net/console_server_connection.cpp
@@ -116,43 +116,42 @@ bool EQ::Net::ConsoleServerConnection::SendChannelMessage(const ServerChannelMes
 	}
 
 	switch (scm->chan_num) {
-		case 4: {
-			if (RuleB(Chat, ServerWideAuction)) {
-				QueueMessage(fmt::format("{0} auctions, '{1}'", scm->from, scm->message));
-				break;
-			} else { // I think we want default action in this case?
-				return false;
-			}
-		}
-
-		case 5: {
-			if (RuleB(Chat, ServerWideOOC)) {
-				QueueMessage(fmt::format("{0} says ooc, '{1}'", scm->from, scm->message));
-				break;
-			} else { // I think we want default action in this case?
-				return false;
-			}
-		}
-
-		case 6: {
-			QueueMessage(fmt::format("{0} BROADCASTS, '{1}'", scm->from, scm->message));
+		case ChatChannel_Guild: {
+			QueueMessage(fmt::format("{} tells the guild [{}], '{}'", scm->from, scm->guilddbid, scm->message));
 			break;
 		}
-
-		case 7: {
-			QueueMessage(fmt::format("[{0}] tells you, '{1}'", scm->from, scm->message));
+		case ChatChannel_Auction: {
+			if (RuleB(Chat, ServerWideAuction)) {
+				QueueMessage(fmt::format("{} auctions, '{}'", scm->from, scm->message));
+				break;
+			} else { // I think we want default action in this case?
+				return false;
+			}
+		}
+		case ChatChannel_OOC: {
+			if (RuleB(Chat, ServerWideOOC)) {
+				QueueMessage(fmt::format("{} says ooc, '{}'", scm->from, scm->message));
+				break;
+			} else { // I think we want default action in this case?
+				return false;
+			}
+		}
+		case ChatChannel_Broadcast: {
+			QueueMessage(fmt::format("{} BROADCASTS, '{}'", scm->from, scm->message));
+			break;
+		}
+		case ChatChannel_Tell: {
+			QueueMessage(fmt::format("[{}] tells {}, '{}'", scm->from, scm->to, scm->message));
 			if (onTell) {
 				onTell();
 			}
 
 			break;
 		}
-		
-		case 11: {
-			QueueMessage(fmt::format("{0} GMSAYS, '{1}'", scm->from, scm->message));
+		case ChatChannel_GMSAY: {
+			QueueMessage(fmt::format("{} GMSAYS, '{}'", scm->from, scm->message));
 			break;
 		}
-
 		default: {
 			return false;
 		}

--- a/world/console.cpp
+++ b/world/console.cpp
@@ -411,6 +411,40 @@ void ConsoleGMSay(
  * @param command
  * @param args
  */
+void ConsoleGuildSay(
+	EQ::Net::ConsoleServerConnection *connection,
+	const std::string &command,
+	const std::vector<std::string> &args
+)
+{
+	if (args.size() < 1) {
+		return;
+	}
+
+	char tmpname[64];
+	tmpname[0] = '*';
+	strcpy(&tmpname[1], connection->UserName().c_str());
+
+	auto from = args[0];
+	auto guild_id = std::stoul(args[1]);
+
+	auto join_args = args;
+	join_args.erase(join_args.begin(), join_args.begin() + 2);
+
+	auto message = fmt::format(
+		"{} tells the guild, '{}'",
+		from,
+		JoinString(join_args, " ")
+	);
+
+	zoneserver_list.SendEmoteMessage(0, guild_id, AccountStatus::Player, Chat::Guild, message.c_str());
+}
+
+/**
+ * @param connection
+ * @param command
+ * @param args
+ */
 void ConsoleOOC(
 	EQ::Net::ConsoleServerConnection *connection,
 	const std::string &command,
@@ -951,6 +985,7 @@ void RegisterConsoleFunctions(std::unique_ptr<EQ::Net::ConsoleServer>& console)
 	console->RegisterCall("emote", 50, "emote [zonename or charname or world] [type] [message]", std::bind(ConsoleEmote, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 	console->RegisterCall("flag", 200, "flag [status] [accountname]", std::bind(ConsoleFlag, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 	console->RegisterCall("gmsay", 50, "gmsay [message]", std::bind(ConsoleGMSay, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+	console->RegisterCall("guildsay", 50, "guildsay [Character Name] [Guild ID] [Message]", std::bind(ConsoleGuildSay, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 	console->RegisterCall("iplookup", 50, "IPLookup [name]", std::bind(ConsoleIpLookup, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 	console->RegisterCall("kick", 150, "kick [charname]", std::bind(ConsoleKick, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 	console->RegisterCall("lock", 150, "lock", std::bind(ConsoleLock, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));

--- a/world/console.cpp
+++ b/world/console.cpp
@@ -422,7 +422,10 @@ void ConsoleGuildSay(
 	}
 
 	auto from = args[0];
-	auto guild_id = std::stoul(args[1]);
+	auto guild_id = StringIsNumber(args[1]) ? std::stoul(args[1]) : 0;
+	if (!guild_id) {
+		return;
+	}
 
 	auto join_args = args;
 	join_args.erase(join_args.begin(), join_args.begin() + 2);

--- a/world/console.cpp
+++ b/world/console.cpp
@@ -421,10 +421,6 @@ void ConsoleGuildSay(
 		return;
 	}
 
-	char tmpname[64];
-	tmpname[0] = '*';
-	strcpy(&tmpname[1], connection->UserName().c_str());
-
 	auto from = args[0];
 	auto guild_id = std::stoul(args[1]);
 

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -527,6 +527,7 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 				}
 			} else {
 				if (
+					scm->chan_num == ChatChannel_Auction ||
 					scm->chan_num == ChatChannel_OOC ||
 					scm->chan_num == ChatChannel_Broadcast ||
 					scm->chan_num == ChatChannel_GMSAY


### PR DESCRIPTION
- Will allow you to send guild-specific messages from things like Discord EQ.
- Add Guild support in `EQ::Net::ConsoleServerConnection::SendChannelMessage` so guild ID can be parsed out.
- Fix Auction messages not sending to telnet (thanks @xackery).
![image](https://user-images.githubusercontent.com/89047260/173168129-fff486c8-4ddb-4b7c-8b7d-fd9a662a0876.png)
![image](https://user-images.githubusercontent.com/89047260/173168135-019577c2-1f6e-4bda-b627-3bba41539072.png)
