### PR TITLE
[Bug Fix] Free return value of ZoneDatabase::LoadTraderItemWithCharges()

### DIFF
--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -1506,6 +1506,8 @@ void Client::FindAndNukeTraderItem(int32 SerialNumber, int16 Quantity, Client* C
 				Trader_EndTrader();
 			}
 
+			safe_delete(TraderItems);
+
 			return;
 		}
 		else


### PR DESCRIPTION
More leakage fixes. This time return values of ZoneDatabase functions were checked for leaks.