### PR TITLE
[Bug Fix] Correct memory leaks from SharedDatabase return values

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -4217,10 +4217,12 @@ void Bot::AddBotItem(
 
 	if (!database.botdb.SaveItemBySlot(this, slot_id, inst)) {
 		LogError("Failed to save item by slot to slot [{}] for [{}].", slot_id, GetCleanName());
+		safe_delete(inst);
 		return;
 	}
 
 	m_inv.PutItem(slot_id, *inst);
+	safe_delete(inst);
 
 	BotAddEquipItem(slot_id, item_id);
 }

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -2039,6 +2039,7 @@ void Client::Handle_OP_AdventureMerchantPurchase(const EQApplicationPacket *app)
 	{
 		PutLootInInventory(EQ::invslot::slotCursor, *inst);
 	}
+	safe_delete(inst);
 	Save(1);
 }
 
@@ -2549,6 +2550,7 @@ void Client::Handle_OP_AltCurrencyPurchase(const EQApplicationPacket *app)
 		{
 			PutLootInInventory(EQ::invslot::slotCursor, *inst);
 		}
+		safe_delete(inst);
 
 		Save(1);
 	}

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -1903,6 +1903,7 @@ void NPC::PickPocket(Client* thief)
 		}
 		RemoveItem(item_inst->GetID());
 		thief->SendPickPocketResponse(this, 0, PickPocketItem, item_inst->GetItem());
+		safe_delete(item_inst);
 
 		return;
 	}

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -675,8 +675,8 @@ void ZoneDatabase::LoadWorldContainer(uint32 parentid, EQ::ItemInstance* contain
                     inst->PutAugment(&database, i, aug[i]);
             // Put item inside world container
             container->PutItem(index, *inst);
-            safe_delete(inst);
         }
+		safe_delete(inst);
     }
 
 }


### PR DESCRIPTION
SharedDatabse::CreateItem() returns an instance that in most cases needs to be deleted after use (Most inventory functions create a Clone before storing it).
I went through all the usages of this function and added any missing deletes.