### PR TITLE
[Bug Fix] Delete NpcType Struct returned by Bot::CreateDefaultNPCTypeStructForB…

### DIFF
--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -434,6 +434,8 @@ bool BotDatabase::LoadBot(const uint32 bot_id, Bot*& loaded_bot)
 		defaultNPCTypeStruct->ATK
 	);
 
+	safe_delete(defaultNPCTypeStruct);
+
 	loaded_bot = new Bot(bot_id, atoi(row[0]), atoi(row[1]), atof(row[14]), atoi(row[6]), tempNPCStruct);
 	if (loaded_bot) {
 		loaded_bot->SetShowHelm((atoi(row[43]) > 0 ? true : false));


### PR DESCRIPTION
…ot() when unused