### PR TITLE
[Bug fix] Correct type signed/unsigned int when reading item from database in shareddb

### DIFF
--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -1212,7 +1212,7 @@ void SharedDatabase::LoadItems(void *data, uint32 size, int32 items, uint32 max_
 		// Click Effect
 		item.CastTime = std::stoul(row[ItemField::casttime]);
 		item.CastTime_ = std::stoi(row[ItemField::casttime_]);
-		item.Click.Effect = std::stoul(row[ItemField::clickeffect]);
+		item.Click.Effect = std::stoi(row[ItemField::clickeffect]);
 		item.Click.Type = static_cast<uint8>(std::stoul(row[ItemField::clicktype]));
 		item.Click.Level = static_cast<uint8>(std::stoul(row[ItemField::clicklevel]));
 		item.Click.Level2 = static_cast<uint8>(std::stoul(row[ItemField::clicklevel2]));


### PR DESCRIPTION
Corrects the following fields to be read as an int32 instead of uint32 which would have prevented negative values. I verified the database field is a signed integer for these.

Regen
ManaRegen
Endur
EnduranceRegen
Click.Effect