### PR TITLE
[Spells] Target's Target Combat Range Rule

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -417,6 +417,7 @@ RULE_BOOL(Spells, UseSpellImpliedTargeting, false, "Replicates EQ2-style targeti
 RULE_BOOL(Spells, BuffsFadeOnDeath, true, "Disable to keep buffs from fading on death")
 RULE_BOOL(Spells, IllusionsAlwaysPersist, false, "Allows Illusions to persist beyond death and zoning always.")
 RULE_BOOL(Spells, UseItemCastMessage, false, "Enable to use the \"item begins to glow\" messages when casting from an item.")
+RULE_BOOL(Spells, TargetsTargetRequiresCombatRange, true, "Disable to remove combat range requirement from Target's Target Spell Target Type")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Combat)

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -2197,11 +2197,14 @@ bool Mob::DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_ce
 		case ST_TargetsTarget:
 		{
 			Mob *spell_target_tot = spell_target ? spell_target->GetTarget() : nullptr;
-			if(!spell_target_tot)
+			if (!spell_target_tot) {
 				return false;
+			}
+			
 			//Verfied from live - Target's Target needs to be in combat range to recieve the effect
-			if (!CombatRange(spell_target))
+			if (RuleB(Spells, TargetsTargetRequiresCombatRange) && !CombatRange(spell_target)) {
 				return false;
+			}
 
 			spell_target = spell_target_tot;
 			CastAction = SingleTarget;


### PR DESCRIPTION
Adds a rule to disable combat range requirement for spell target type "Target's Target".