### PR TITLE
[Feature] Add humanoid and non-wielded restrictions to pick pocket

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -11059,14 +11059,6 @@ void Client::Handle_OP_PickPocket(const EQApplicationPacket *app)
 		return;
 
 	p_timers.Start(pTimerBeggingPickPocket, 8);
-	auto outapp = new EQApplicationPacket(OP_PickPocket, sizeof(sPickPocket_Struct));
-	sPickPocket_Struct* pick_out = (sPickPocket_Struct*)outapp->pBuffer;
-	pick_out->coin = 0;
-	pick_out->from = victim->GetID();
-	pick_out->to = GetID();
-	pick_out->myskill = GetSkill(EQ::skills::SkillPickPockets);
-	pick_out->type = 0;
-	//if we do not send this packet the client will lock up and require the player to relog.
 
 	if (victim == this) {
 		Message(Chat::White, "You catch yourself red-handed.");
@@ -11085,14 +11077,12 @@ void Client::Handle_OP_PickPocket(const EQApplicationPacket *app)
 		auto body = victim->GetBodyType();
 		if (body == BT_Humanoid || body == BT_Monster || body == BT_Giant ||
 			body == BT_Lycanthrope) {
-			safe_delete(outapp);
 			victim->CastToNPC()->PickPocket(this);
 			return;
 		}
 	}
 
-	QueuePacket(outapp);
-	safe_delete(outapp);
+	SendPickPocketResponse(victim, 0, PickPocketFailed);
 }
 
 void Client::Handle_OP_PopupResponse(const EQApplicationPacket *app)

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -11089,9 +11089,9 @@ void Client::Handle_OP_PickPocket(const EQApplicationPacket *app)
 			victim->CastToNPC()->PickPocket(this);
 			return;
 		}
-		else {
-			MessageString(Chat::White, STEAL_UNSUCCESSFUL);
-		}
+	}
+	else {
+		MessageString(Chat::White, STEAL_UNSUCCESSFUL);
 	}
 
 	QueuePacket(outapp);

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -11090,9 +11090,6 @@ void Client::Handle_OP_PickPocket(const EQApplicationPacket *app)
 			return;
 		}
 	}
-	else {
-		MessageString(Chat::White, STEAL_UNSUCCESSFUL);
-	}
 
 	QueuePacket(outapp);
 	safe_delete(outapp);

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -11081,13 +11081,17 @@ void Client::Handle_OP_PickPocket(const EQApplicationPacket *app)
 		Message(Chat::Red, "Attempt to pickpocket out of range detected.");
 		database.SetMQDetectionFlag(AccountName(), GetName(), "OP_PickPocket was sent from outside combat range.", zone->GetShortName());
 	}
-	else if (victim->IsNPC() && victim->GetBodyType() == BT_Humanoid) {
-		safe_delete(outapp);
-		victim->CastToNPC()->PickPocket(this);
-		return;
-	}
-	else {
-		MessageString(Chat::White, STEAL_UNSUCCESSFUL);
+	else if (victim->IsNPC()) {
+		auto body = victim->GetBodyType();
+		if (body == BT_Humanoid || body == BT_Monster || body == BT_Giant ||
+			body == BT_Lycanthrope) {
+			safe_delete(outapp);
+			victim->CastToNPC()->PickPocket(this);
+			return;
+		}
+		else {
+			MessageString(Chat::White, STEAL_UNSUCCESSFUL);
+		}
 	}
 
 	QueuePacket(outapp);

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -11069,13 +11069,13 @@ void Client::Handle_OP_PickPocket(const EQApplicationPacket *app)
 	//if we do not send this packet the client will lock up and require the player to relog.
 
 	if (victim == this) {
-		Message(0, "You catch yourself red-handed.");
+		Message(Chat::White, "You catch yourself red-handed.");
 	}
 	else if (victim->GetOwnerID()) {
-		Message(0, "You cannot steal from pets!");
+		Message(Chat::White, "You cannot steal from pets!");
 	}
 	else if (victim->IsClient()) {
-		Message(0, "Stealing from clients not yet supported.");
+		Message(Chat::White, "Stealing from clients not yet supported.");
 	}
 	else if (Distance(GetPosition(), victim->GetPosition()) > 20) {
 		Message(Chat::Red, "Attempt to pickpocket out of range detected.");

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -11074,18 +11074,22 @@ void Client::Handle_OP_PickPocket(const EQApplicationPacket *app)
 	else if (victim->GetOwnerID()) {
 		Message(0, "You cannot steal from pets!");
 	}
+	else if (victim->IsClient()) {
+		Message(0, "Stealing from clients not yet supported.");
+	}
 	else if (Distance(GetPosition(), victim->GetPosition()) > 20) {
 		Message(Chat::Red, "Attempt to pickpocket out of range detected.");
 		database.SetMQDetectionFlag(AccountName(), GetName(), "OP_PickPocket was sent from outside combat range.", zone->GetShortName());
 	}
-	else if (victim->IsNPC()) {
+	else if (victim->IsNPC() && victim->GetBodyType() == BT_Humanoid) {
 		safe_delete(outapp);
 		victim->CastToNPC()->PickPocket(this);
 		return;
 	}
 	else {
-		Message(0, "Stealing from clients not yet supported.");
+		Message(0, "Your attempt at stealing was unsuccessful.");
 	}
+
 	QueuePacket(outapp);
 	safe_delete(outapp);
 }

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -11087,7 +11087,7 @@ void Client::Handle_OP_PickPocket(const EQApplicationPacket *app)
 		return;
 	}
 	else {
-		Message(0, "Your attempt at stealing was unsuccessful.");
+		MessageString(Chat::White, STEAL_UNSUCCESSFUL);
 	}
 
 	QueuePacket(outapp);

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -1867,7 +1867,7 @@ void NPC::PickPocket(Client* thief)
 				continue;
 
 			auto item_test = database.GetItem(item_iter->item_id);
-			if (item_test->Magic || !item_test->NoDrop || item_test->IsClassBag() || thief->CheckLoreConflict(item_test))
+			if (item_test->Magic || !item_test->NoDrop || item_test->IsClassBag() || thief->CheckLoreConflict(item_test) || item_iter->equip_slot != EQ::invslot::SLOT_INVALID)
 				continue;
 
 			loot_selection.push_back(std::make_pair(item_test, ((item_test->Stackable) ? (1) : (item_iter->charges))));

--- a/zone/string_ids.h
+++ b/zone/string_ids.h
@@ -507,6 +507,7 @@
 #define TRY_ATTACKING_SOMEONE		12696	//Try attacking someone other than yourself, it's more productive
 #define RANGED_TOO_CLOSE			12698	//Your target is too close to use a ranged weapon!
 #define BACKSTAB_WEAPON				12874	//You need a piercing weapon as your primary weapon in order to backstab
+#define STEAL_UNSUCCESSFUL			12898	//Your attempt at stealing was unsuccessful
 #define DISARMED                    12889   //You have been disarmed!
 #define DISARM_SUCCESS              12890   //You disarmed %1!
 #define DISARM_FAILED               12891   //Your attempt to disarm failed.

--- a/zone/string_ids.h
+++ b/zone/string_ids.h
@@ -507,7 +507,6 @@
 #define TRY_ATTACKING_SOMEONE		12696	//Try attacking someone other than yourself, it's more productive
 #define RANGED_TOO_CLOSE			12698	//Your target is too close to use a ranged weapon!
 #define BACKSTAB_WEAPON				12874	//You need a piercing weapon as your primary weapon in order to backstab
-#define STEAL_UNSUCCESSFUL			12898	//Your attempt at stealing was unsuccessful
 #define DISARMED                    12889   //You have been disarmed!
 #define DISARM_SUCCESS              12890   //You disarmed %1!
 #define DISARM_FAILED               12891   //Your attempt to disarm failed.


### PR DESCRIPTION
The pick pocket skill should only work on certain body types.

The pick pocket skill should not allow picking items that are wielded.

Verified on live (though some mobs are marked as humanoid on live that are questionable - this will be a db issue).