### PR TITLE
[Bug Fix] NPCs were getting weapon proc added twice

### DIFF
--- a/zone/loottables.cpp
+++ b/zone/loottables.cpp
@@ -473,8 +473,6 @@ void NPC::AddLootDrop(
 		}
 
 		if (foundslot == EQ::invslot::slotPrimary) {
-			if (item2->Proc.Effect != 0)
-				CastToMob()->AddProcToWeapon(item2->Proc.Effect, true);
 
 			eslot = EQ::textures::weaponPrimary;
 			if (item2->Damage > 0) {
@@ -489,8 +487,6 @@ void NPC::AddLootDrop(
 			&& (GetOwner() != nullptr || (CanThisClassDualWield() && zone->random.Roll(NPC_DW_CHANCE)) || (item2->Damage==0)) &&
 			(item2->IsType1HWeapon() || item2->ItemType == EQ::item::ItemTypeShield || item2->ItemType ==  EQ::item::ItemTypeLight))
 		{
-			if (item2->Proc.Effect!=0)
-				CastToMob()->AddProcToWeapon(item2->Proc.Effect, true);
 
 			eslot = EQ::textures::weaponSecondary;
 			if (item2->Damage > 0)


### PR DESCRIPTION
NPCs and pets that wield a weapon with a proc were getting the proc added twice to the in memory tables.  

This also caused pets to sometimes proc weapons that should not proc for their level, while sometimes yielding the "not able to command this weapon" other times.

Tested thoroughly with the fix.