### PR TITLE
[Server] Configuration Issues Checker (LAN Detection)

### DIFF
--- a/common/eqemu_config.cpp
+++ b/common/eqemu_config.cpp
@@ -100,6 +100,10 @@ void EQEmuConfig::parse_config()
 		WorldHTTPEnabled = true;
 	}
 
+	if (_root["server"].get("disable_config_checks", "false").asString() == "true") {
+		DisableConfigChecks = true;
+	}
+
 	/**
 	 * UCS
 	 */

--- a/common/eqemu_config.h
+++ b/common/eqemu_config.h
@@ -58,6 +58,7 @@ class EQEmuConfig
 		uint16 WorldHTTPPort;
 		std::string WorldHTTPMimeFile;
 		std::string SharedKey;
+		bool DisableConfigChecks;
 
 		// From <chatserver/>
 		std::string ChatHost;
@@ -130,7 +131,7 @@ class EQEmuConfig
 		void parse_config();
 
 		EQEmuConfig()
-		{			
+		{
 
 		}
 		virtual ~EQEmuConfig() {}
@@ -174,7 +175,7 @@ class EQEmuConfig
 			}
 			catch (std::exception &) {
 				return false;
-			}			
+			}
 			return true;
 		}
 

--- a/common/ip_util.cpp
+++ b/common/ip_util.cpp
@@ -217,7 +217,10 @@ std::string IpUtil::DNSLookupSync(const std::string &addr, int port)
 		}
 	);
 
-	return res.get();
+	std::string result = res.get();
+	safe_delete(task_runner);
+
+	return result;
 }
 
 bool IpUtil::IsIPAddress(const std::string &ip_address)

--- a/common/ip_util.cpp
+++ b/common/ip_util.cpp
@@ -18,7 +18,19 @@
  *
  */
 
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <fmt/format.h>
+#include <csignal>
+#include <vector>
 #include "ip_util.h"
+#include "http/httplib.h"
+#include "http/uri.h"
 
 /**
  * @param ip
@@ -70,3 +82,91 @@ bool IpUtil::IsIpInPrivateRfc1918(const std::string &ip)
 		IpUtil::IsIpInRange(ip, "192.168.0.0", "255.255.0.0")
 	);
 }
+
+/**
+ * Gets local address - pings google to inspect what interface was used locally
+ * @return
+ */
+std::string IpUtil::GetLocalIPAddress()
+{
+	char               my_ip_address[16];
+	unsigned int       my_port;
+	struct sockaddr_in server_address{};
+	struct sockaddr_in my_address{};
+	int                sockfd;
+
+	// Connect to server
+	if ((sockfd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+		return "";
+	}
+
+	// Set server_addr
+	bzero(&server_address, sizeof(server_address));
+	server_address.sin_family      = AF_INET;
+	server_address.sin_addr.s_addr = inet_addr("172.217.160.99");
+	server_address.sin_port        = htons(80);
+
+	// Connect to server
+	if (connect(sockfd, (struct sockaddr *) &server_address, sizeof(server_address)) < 0) {
+		close(sockfd);
+		return "";
+	}
+
+	// Get my ip address and port
+	bzero(&my_address, sizeof(my_address));
+	socklen_t len = sizeof(my_address);
+	getsockname(sockfd, (struct sockaddr *) &my_address, &len);
+	inet_ntop(AF_INET, &my_address.sin_addr, my_ip_address, sizeof(my_ip_address));
+	my_port = ntohs(my_address.sin_port);
+
+	return fmt::format("{}", my_ip_address);
+}
+
+/**
+ * Gets public address
+ * Uses various websites as options to return raw public IP back to the client
+ * @return
+ */
+std::string IpUtil::GetPublicIPAddress()
+{
+	std::vector<std::string> endpoints = {
+		"http://ifconfig.me",
+		"http://api.ipify.org",
+		"http://ipinfo.io/ip",
+		"http://ipecho.net/plain",
+	};
+
+	for (auto &s: endpoints) {
+		// http get request
+		uri u(s);
+
+		httplib::Client r(
+			fmt::format(
+				"{}://{}",
+				u.get_scheme(),
+				u.get_host()
+			).c_str()
+		);
+
+		httplib::Headers headers = {
+			{"Content-type", "text/plain; charset=utf-8"},
+			{"User-Agent",   "curl/7.81.0"}
+		};
+
+		r.set_connection_timeout(1, 0);
+		r.set_read_timeout(1, 0);
+		r.set_write_timeout(1, 0);
+
+		if (auto res = r.Get(fmt::format("/{}", u.get_path()).c_str(), headers)) {
+			if (res->status == 200) {
+				if (res->body.find('.') != std::string::npos) {
+					return res->body;
+				}
+			}
+		}
+	}
+
+	return {};
+}
+
+

--- a/common/ip_util.h
+++ b/common/ip_util.h
@@ -32,6 +32,11 @@ public:
 	static bool IsIpInPrivateRfc1918(const std::string &ip);
 	static std::string GetLocalIPAddress();
 	static std::string GetPublicIPAddress();
+	static std::string DNSLookupSync(
+		const std::string &addr,
+		int port
+	);
+	static bool IsIPAddress(const std::string &ip_address);
 
 };
 

--- a/common/ip_util.h
+++ b/common/ip_util.h
@@ -30,6 +30,8 @@ public:
 	static uint32_t IPToUInt(const std::string &ip);
 	static bool IsIpInRange(const std::string &ip, const std::string &network, const std::string &mask);
 	static bool IsIpInPrivateRfc1918(const std::string &ip);
+	static std::string GetLocalIPAddress();
+	static std::string GetPublicIPAddress();
 
 };
 

--- a/world/main.cpp
+++ b/world/main.cpp
@@ -635,22 +635,7 @@ int main(int argc, char **argv)
 		}
 	);
 
-	/**
-	 * LAN checks
-	 */
-	const std::string local_address  = IpUtil::GetLocalIPAddress();
-	const std::string public_address = IpUtil::GetPublicIPAddress();
-	if (local_address != public_address && IpUtil::IsIpInPrivateRfc1918(local_address) &&
-		local_address != Config->LocalAddress) {
-		LogWarning("====================================================================");
-		LogWarning("You appear to be on a LAN and your localaddress may not be properly set!");
-		LogWarning("This will keep clients from properly connecting to your server");
-		LogWarning("https://docs.eqemu.io/server/installation/configure-your-eqemu_config/#world");
-		LogWarning("====================================================================");
-		LogWarning("Local address (eqemu_config) [{}]", Config->LocalAddress);
-		LogWarning("Local address (auto-detect) [{}]", local_address);
-		LogWarning("====================================================================");
-	}
+	WorldConfig::CheckForPossibleConfigurationIssues();
 
 	EQStreamManagerInterfaceOptions opts(9000, false, false);
 	opts.daybreak_options.resend_delay_ms     = RuleI(Network, ResendDelayBaseMS);

--- a/world/main.cpp
+++ b/world/main.cpp
@@ -104,6 +104,7 @@ union semun {
 #include "world_store.h"
 #include "world_event_scheduler.h"
 #include "shared_task_manager.h"
+#include "../common/ip_util.h"
 
 WorldStore          world_store;
 ClientList          client_list;
@@ -633,6 +634,23 @@ int main(int argc, char **argv)
 			web_interface.RemoveConnection(connection);
 		}
 	);
+
+	/**
+	 * LAN checks
+	 */
+	const std::string local_address  = IpUtil::GetLocalIPAddress();
+	const std::string public_address = IpUtil::GetPublicIPAddress();
+	if (local_address != public_address && IpUtil::IsIpInPrivateRfc1918(local_address) &&
+		local_address != Config->LocalAddress) {
+		LogWarning("====================================================================");
+		LogWarning("You appear to be on a LAN and your localaddress may not be properly set!");
+		LogWarning("This will keep clients from properly connecting to your server");
+		LogWarning("https://docs.eqemu.io/server/installation/configure-your-eqemu_config/#world");
+		LogWarning("====================================================================");
+		LogWarning("Local address (eqemu_config) [{}]", Config->LocalAddress);
+		LogWarning("Local address (auto-detect) [{}]", local_address);
+		LogWarning("====================================================================");
+	}
 
 	EQStreamManagerInterfaceOptions opts(9000, false, false);
 	opts.daybreak_options.resend_delay_ms     = RuleI(Network, ResendDelayBaseMS);

--- a/world/world_config.cpp
+++ b/world/world_config.cpp
@@ -70,7 +70,13 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 	}
 
 	// docker configuration
-	if ((_config->LocalAddress.empty() && _config->WorldAddress.empty()) && is_in_docker) {
+	if (
+		(
+			(_config->LocalAddress.empty() && _config->WorldAddress.empty()) ||
+			(_config->WorldAddress != public_address)
+		)
+		&& is_in_docker
+		) {
 		LogWarning("# Docker Configuration (Configuration)");
 		LogWarning("");
 		LogWarning("You appear to running EQEmu in a docker container");
@@ -97,7 +103,7 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 	if (!_config->WorldAddress.empty() && public_address != _config->WorldAddress) {
 		LogWarning("# Public address (Configuration)");
 		LogWarning("");
-		LogWarning("Your configured public address appears to be different from your configuration!");
+		LogWarning("Your configured public address appears to be different from what's detected!");
 		LogWarning("");
 		LogWarning("Docs [https://docs.eqemu.io/server/installation/configure-your-eqemu_config/#world]");
 		LogWarning("");

--- a/world/world_config.cpp
+++ b/world/world_config.cpp
@@ -118,8 +118,7 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 		LogWarning("# Public meta-address (Configuration)");
 		LogWarning("");
 		LogWarning("Your configured public address is set to a meta-address (0.0.0.0) (all-interfaces)");
-		LogWarning(
-			"The meta-address may not work properly and it is recommended you configure your public address explicitly");
+		LogWarning("The meta-address may not work properly and it is recommended you configure your public address explicitly");
 		LogWarning("");
 		LogWarning("Docs [https://docs.eqemu.io/server/installation/configure-your-eqemu_config/#world]");
 		LogWarning("");

--- a/world/world_config.cpp
+++ b/world/world_config.cpp
@@ -82,11 +82,13 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 		LogWarning("You appear to running EQEmu in a docker container");
 		LogWarning("In order for networking to work properly you will need to properly configure your server");
 		LogWarning("");
-		LogWarning("If your Docker host is on a [LAN], your [localaddress] variable under [server->world] will need to");
-		LogWarning("be set to your LAN address on the host, not the container address. [address] will need to be your ");
-		LogWarning("public address");
+		LogWarning("If your Docker host is on a [LAN] or behind a NAT / Firewall, your [localaddress] variable under [server->world] will need to");
+		LogWarning(
+			"be set to your LAN address on the host, not the container address. [address] will need to be your public address");
 		LogWarning("");
-		LogWarning("If your Docker host is on the [public internet], your [localaddress] variable under [server->world] can be empty or set to [127.0.0.1]. ");
+		LogWarning(
+			"If your Docker host is directly on the [public internet], your [localaddress] variable under [server->world] can be set to [127.0.0.1]."
+		);
 		LogWarning("");
 		LogWarning("[address] will need to be your public address");
 		LogWarning("");
@@ -95,7 +97,41 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 		LogWarning("Config file [{}] path [server->world] variable(s) [localaddress] [address]", config_file);
 		LogWarning("");
 		LogWarning("Local address (eqemu_config) value [{}] detected value [{}]", _config->LocalAddress, local_address);
-		LogWarning("Public address (eqemu_config) value [{}] detected value [{}]", _config->WorldAddress, public_address);
+		LogWarning(
+			"Public address (eqemu_config) value [{}] detected value [{}]",
+			_config->WorldAddress,
+			public_address
+		);
+		std::cout << std::endl;
+	}
+
+	// docker LAN not set
+	if (_config->LocalAddress.empty() && is_in_docker) {
+		LogWarning("# Docker LAN (Configuration)");
+		LogWarning("");
+		LogWarning("You appear to running EQEmu in a docker container");
+		LogWarning("Your local address does not appear to be set, this may not be an issue if your deployment is not on a LAN");
+		LogWarning("");
+		LogWarning("If your Docker host is on a [LAN] or behind a NAT / Firewall, your [localaddress] variable under [server->world] will need to");
+		LogWarning(
+			"be set to your LAN address on the host, not the container address. [address] will need to be your public address");
+		LogWarning("");
+		LogWarning(
+			"If your Docker host is directly on the [public internet], your [localaddress] variable under [server->world] can be set to [127.0.0.1]."
+		);
+		LogWarning("");
+		LogWarning("[address] will need to be your public address");
+		LogWarning("");
+		LogWarning("Docs [https://docs.eqemu.io/server/installation/configure-your-eqemu_config/#world]");
+		LogWarning("");
+		LogWarning("Config file [{}] path [server->world] variable(s) [localaddress] [address]", config_file);
+		LogWarning("");
+		LogWarning("Local address (eqemu_config) value [{}] detected value [{}]", _config->LocalAddress, local_address);
+		LogWarning(
+			"Public address (eqemu_config) value [{}] detected value [{}]",
+			_config->WorldAddress,
+			public_address
+		);
 		std::cout << std::endl;
 	}
 
@@ -109,7 +145,11 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 		LogWarning("");
 		LogWarning("Config file [{}] path [server->world] variable [address]", config_file);
 		LogWarning("");
-		LogWarning("Public address (eqemu_config) value [{}] detected value [{}]", _config->WorldAddress, public_address);
+		LogWarning(
+			"Public address (eqemu_config) value [{}] detected value [{}]",
+			_config->WorldAddress,
+			public_address
+		);
 		std::cout << std::endl;
 	}
 
@@ -118,13 +158,18 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 		LogWarning("# Public meta-address (Configuration)");
 		LogWarning("");
 		LogWarning("Your configured public address is set to a meta-address (0.0.0.0) (all-interfaces)");
-		LogWarning("The meta-address may not work properly and it is recommended you configure your public address explicitly");
+		LogWarning(
+			"The meta-address may not work properly and it is recommended you configure your public address explicitly");
 		LogWarning("");
 		LogWarning("Docs [https://docs.eqemu.io/server/installation/configure-your-eqemu_config/#world]");
 		LogWarning("");
 		LogWarning("Config file [{}] path [server->world] variable [address]", config_file);
 		LogWarning("");
-		LogWarning("Public address (eqemu_config) value [{}] detected value [{}]", _config->WorldAddress, public_address);
+		LogWarning(
+			"Public address (eqemu_config) value [{}] detected value [{}]",
+			_config->WorldAddress,
+			public_address
+		);
 		std::cout << std::endl;
 	}
 
@@ -141,6 +186,33 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 		LogWarning("Config file [{}] path [server->world] variable [localaddress]", config_file);
 		LogWarning("");
 		LogWarning("Local address (eqemu_config) value [{}] detected value [{}]", _config->LocalAddress, local_address);
+		std::cout << std::endl;
+	}
+
+	// ucs (public)
+	if (
+		(!_config->WorldAddress.empty() && _config->MailHost != _config->WorldAddress) ||
+		(!_config->WorldAddress.empty() && _config->ChatHost != _config->WorldAddress)
+		) {
+		LogWarning("# UCS Address Mailhost (Configuration)");
+		LogWarning("");
+		LogWarning(
+			"UCS (Universal Chat Service) mail or chat appears to use a different address from your main world address"
+		);
+		LogWarning("This can result in a chat service that doesn't network properly");
+		LogWarning("");
+		LogWarning("Docs [https://docs.eqemu.io/server/installation/configure-your-eqemu_config/#mailserver]");
+		LogWarning("");
+		LogWarning(
+			"[server->world->address] value [{}] [server->chatserver->host] [{}]",
+			_config->WorldAddress,
+			_config->ChatHost
+		);
+		LogWarning(
+			"[server->world->address] value [{}] [server->mailserver->host] [{}]",
+			_config->WorldAddress,
+			_config->MailHost
+		);
 		std::cout << std::endl;
 	}
 }

--- a/world/world_config.cpp
+++ b/world/world_config.cpp
@@ -16,17 +16,102 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 #include "../common/global_define.h"
+#include "../common/eqemu_logsys.h"
 #include "world_config.h"
+#include "../common/ip_util.h"
 
 WorldConfig *WorldConfig::_world_config = nullptr;
 
+std::string WorldConfig::GetByName(const std::string &var_name) const
+{
+	if (var_name == "UpdateStats") {
+		return (UpdateStats ? "true" : "false");
+	}
+	if (var_name == "LoginDisabled") {
+		return (LoginDisabled ? "true" : "false");
+	}
+	return (EQEmuConfig::GetByName(var_name));
+}
 
-std::string WorldConfig::GetByName(const std::string &var_name) const {
-	if(var_name == "UpdateStats")
-		return(UpdateStats?"true":"false");
-	if(var_name == "LoginDisabled")
-		return(LoginDisabled?"true":"false");
-	return(EQEmuConfig::GetByName(var_name));
+void WorldConfig::CheckForPossibleConfigurationIssues()
+{
+	if (_config->DisableConfigChecks) {
+		LogInfo("Configuration checking [disabled]");
+		return;
+	}
+
+	const std::string local_address  = IpUtil::GetLocalIPAddress();
+	const std::string public_address = IpUtil::GetPublicIPAddress();
+	const std::string config_file    = "eqemu_config.json";
+
+	LogInfo("Checking for possible configuration issues");
+	LogInfo("To disable configuration checks, set [server->disable_config_checks] to [true] in [{}]", config_file);
+
+	std::cout << std::endl;
+
+	// lan detection
+	if (local_address != public_address
+		&& IpUtil::IsIpInPrivateRfc1918(local_address) && local_address != _config->LocalAddress) {
+		LogWarning("# LAN detection (Configuration)");
+		LogWarning("");
+		LogWarning("You appear to be on a LAN and your localaddress may not be properly set!");
+		LogWarning("This can prevent local clients from properly connecting to your server");
+		LogWarning("");
+		LogWarning("Docs [https://docs.eqemu.io/server/installation/configure-your-eqemu_config/#world]");
+		LogWarning("");
+		LogWarning("Config file [{}] path [server->world] variable [localaddress]", config_file);
+		LogWarning("");
+		LogWarning("Local address (eqemu_config) value [{}]", _config->LocalAddress);
+		LogWarning("Local address (auto-detect) value [{}]", local_address);
+		std::cout << std::endl;
+	}
+
+	// public address different from configuration
+	if (!_config->WorldAddress.empty() && public_address != _config->WorldAddress) {
+		LogWarning("# Public address (Configuration)");
+		LogWarning("");
+		LogWarning("Your configured public address appears to be different from your configuration!");
+		LogWarning("");
+		LogWarning("Docs [https://docs.eqemu.io/server/installation/configure-your-eqemu_config/#world]");
+		LogWarning("");
+		LogWarning("Config file [{}] path [server->world] variable [address]", config_file);
+		LogWarning("");
+		LogWarning("Public address (eqemu_config) value [{}]", _config->WorldAddress);
+		LogWarning("Public address (auto-detect) value [{}]", public_address);
+		std::cout << std::endl;
+	}
+
+	// public address set to meta-address
+	if (_config->WorldAddress == "0.0.0.0") {
+		LogWarning("# Public meta-address (Configuration)");
+		LogWarning("");
+		LogWarning("Your configured public address is set to a meta-address (0.0.0.0) (all-interfaces)");
+		LogWarning("The meta-address may not work properly and it is recommended you configure your public address explicitly");
+		LogWarning("");
+		LogWarning("Docs [https://docs.eqemu.io/server/installation/configure-your-eqemu_config/#world]");
+		LogWarning("");
+		LogWarning("Config file [{}] path [server->world] variable [address]", config_file);
+		LogWarning("");
+		LogWarning("Public address (eqemu_config) value [{}]", _config->WorldAddress);
+		LogWarning("Public address (auto-detect) value [{}]", public_address);
+		std::cout << std::endl;
+	}
+
+	// local address set to meta-address
+	if (_config->LocalAddress == "0.0.0.0") {
+		LogWarning("# Local meta-address (Configuration)");
+		LogWarning("");
+		LogWarning("Your configured local address is set to a meta-address (0.0.0.0) (all-interfaces)");
+		LogWarning("The meta-address may not work properly and it is recommended you configure your local address explicitly");
+		LogWarning("");
+		LogWarning("Docs [https://docs.eqemu.io/server/installation/configure-your-eqemu_config/#world]");
+		LogWarning("");
+		LogWarning("Config file [{}] path [server->world] variable [localaddress]", config_file);
+		LogWarning("");
+		LogWarning("Local address (eqemu_config) value [{}]", _config->LocalAddress);
+		LogWarning("Local address (auto-detect) value [{}]", local_address);
+		std::cout << std::endl;
+	}
 }
 
 

--- a/world/world_config.cpp
+++ b/world/world_config.cpp
@@ -45,8 +45,23 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 	const std::string   config_file    = "eqemu_config.json";
 	const std::ifstream is_in_docker("/.dockerenv");
 
+	if (local_address.empty() && public_address.empty()) {
+		LogInfo("Configuration check, probes failed for local and public address, returning");
+		return;
+	}
+
 	LogInfo("Checking for possible configuration issues");
 	LogInfo("To disable configuration checks, set [server->disable_config_checks] to [true] in [{}]", config_file);
+
+	std::string config_address = _config->WorldAddress;
+	if (!IpUtil::IsIPAddress(config_address)) {
+		config_address = IpUtil::DNSLookupSync(_config->WorldAddress, 9000);
+		LogInfo(
+			"World config address using DNS [{}] resolves to [{}]",
+			_config->WorldAddress,
+			config_address
+		);
+	}
 
 	std::cout << std::endl;
 
@@ -72,8 +87,8 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 	// docker configuration
 	if (
 		(
-			(_config->LocalAddress.empty() && _config->WorldAddress.empty()) ||
-			(_config->WorldAddress != public_address)
+			(_config->LocalAddress.empty() && config_address.empty()) ||
+			(config_address != public_address)
 		)
 		&& is_in_docker
 		) {
@@ -82,7 +97,8 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 		LogWarning("You appear to running EQEmu in a docker container");
 		LogWarning("In order for networking to work properly you will need to properly configure your server");
 		LogWarning("");
-		LogWarning("If your Docker host is on a [LAN] or behind a NAT / Firewall, your [localaddress] variable under [server->world] will need to");
+		LogWarning(
+			"If your Docker host is on a [LAN] or behind a NAT / Firewall, your [localaddress] variable under [server->world] will need to");
 		LogWarning(
 			"be set to your LAN address on the host, not the container address. [address] will need to be your public address");
 		LogWarning("");
@@ -99,7 +115,7 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 		LogWarning("Local address (eqemu_config) value [{}] detected value [{}]", _config->LocalAddress, local_address);
 		LogWarning(
 			"Public address (eqemu_config) value [{}] detected value [{}]",
-			_config->WorldAddress,
+			config_address,
 			public_address
 		);
 		std::cout << std::endl;
@@ -110,9 +126,12 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 		LogWarning("# Docker LAN (Configuration)");
 		LogWarning("");
 		LogWarning("You appear to running EQEmu in a docker container");
-		LogWarning("Your local address does not appear to be set, this may not be an issue if your deployment is not on a LAN");
+		LogWarning(
+			"Your local address does not appear to be set, this may not be an issue if your deployment is not on a LAN"
+		);
 		LogWarning("");
-		LogWarning("If your Docker host is on a [LAN] or behind a NAT / Firewall, your [localaddress] variable under [server->world] will need to");
+		LogWarning(
+			"If your Docker host is on a [LAN] or behind a NAT / Firewall, your [localaddress] variable under [server->world] will need to");
 		LogWarning(
 			"be set to your LAN address on the host, not the container address. [address] will need to be your public address");
 		LogWarning("");
@@ -129,14 +148,14 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 		LogWarning("Local address (eqemu_config) value [{}] detected value [{}]", _config->LocalAddress, local_address);
 		LogWarning(
 			"Public address (eqemu_config) value [{}] detected value [{}]",
-			_config->WorldAddress,
+			config_address,
 			public_address
 		);
 		std::cout << std::endl;
 	}
 
 	// public address different from configuration
-	if (!_config->WorldAddress.empty() && public_address != _config->WorldAddress) {
+	if (!config_address.empty() && public_address != config_address) {
 		LogWarning("# Public address (Configuration)");
 		LogWarning("");
 		LogWarning("Your configured public address appears to be different from what's detected!");
@@ -147,14 +166,14 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 		LogWarning("");
 		LogWarning(
 			"Public address (eqemu_config) value [{}] detected value [{}]",
-			_config->WorldAddress,
+			config_address,
 			public_address
 		);
 		std::cout << std::endl;
 	}
 
 	// public address set to meta-address
-	if (_config->WorldAddress == "0.0.0.0") {
+	if (config_address == "0.0.0.0") {
 		LogWarning("# Public meta-address (Configuration)");
 		LogWarning("");
 		LogWarning("Your configured public address is set to a meta-address (0.0.0.0) (all-interfaces)");
@@ -167,7 +186,7 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 		LogWarning("");
 		LogWarning(
 			"Public address (eqemu_config) value [{}] detected value [{}]",
-			_config->WorldAddress,
+			config_address,
 			public_address
 		);
 		std::cout << std::endl;
@@ -179,7 +198,8 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 		LogWarning("");
 		LogWarning("Your configured local address is set to a meta-address (0.0.0.0) (all-interfaces)");
 		LogWarning(
-			"The meta-address may not work properly and it is recommended you configure your local address explicitly");
+			"The meta-address may not work properly and it is recommended you configure your local address explicitly"
+		);
 		LogWarning("");
 		LogWarning("Docs [https://docs.eqemu.io/server/installation/configure-your-eqemu_config/#world]");
 		LogWarning("");
@@ -191,8 +211,8 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 
 	// ucs (public)
 	if (
-		(!_config->WorldAddress.empty() && _config->MailHost != _config->WorldAddress) ||
-		(!_config->WorldAddress.empty() && _config->ChatHost != _config->WorldAddress)
+		(!config_address.empty() && _config->MailHost != config_address) ||
+		(!config_address.empty() && _config->ChatHost != config_address)
 		) {
 		LogWarning("# UCS Address Mailhost (Configuration)");
 		LogWarning("");
@@ -205,12 +225,12 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 		LogWarning("");
 		LogWarning(
 			"[server->world->address] value [{}] [server->chatserver->host] [{}]",
-			_config->WorldAddress,
+			config_address,
 			_config->ChatHost
 		);
 		LogWarning(
 			"[server->world->address] value [{}] [server->mailserver->host] [{}]",
-			_config->WorldAddress,
+			config_address,
 			_config->MailHost
 		);
 		std::cout << std::endl;

--- a/world/world_config.cpp
+++ b/world/world_config.cpp
@@ -40,9 +40,10 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 		return;
 	}
 
-	const std::string local_address  = IpUtil::GetLocalIPAddress();
-	const std::string public_address = IpUtil::GetPublicIPAddress();
-	const std::string config_file    = "eqemu_config.json";
+	const std::string   local_address  = IpUtil::GetLocalIPAddress();
+	const std::string   public_address = IpUtil::GetPublicIPAddress();
+	const std::string   config_file    = "eqemu_config.json";
+	const std::ifstream is_in_docker("/.dockerenv");
 
 	LogInfo("Checking for possible configuration issues");
 	LogInfo("To disable configuration checks, set [server->disable_config_checks] to [true] in [{}]", config_file);
@@ -51,7 +52,10 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 
 	// lan detection
 	if (local_address != public_address
-		&& IpUtil::IsIpInPrivateRfc1918(local_address) && local_address != _config->LocalAddress) {
+		&& IpUtil::IsIpInPrivateRfc1918(local_address)
+		&& local_address != _config->LocalAddress
+		&& !is_in_docker
+		) {
 		LogWarning("# LAN detection (Configuration)");
 		LogWarning("");
 		LogWarning("You appear to be on a LAN and your localaddress may not be properly set!");
@@ -61,8 +65,31 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 		LogWarning("");
 		LogWarning("Config file [{}] path [server->world] variable [localaddress]", config_file);
 		LogWarning("");
-		LogWarning("Local address (eqemu_config) value [{}]", _config->LocalAddress);
-		LogWarning("Local address (auto-detect) value [{}]", local_address);
+		LogWarning("Local address (eqemu_config) value [{}] detected value [{}]", _config->LocalAddress, local_address);
+		std::cout << std::endl;
+	}
+
+	// docker configuration
+	if ((_config->LocalAddress.empty() && _config->WorldAddress.empty()) && is_in_docker) {
+		LogWarning("# Docker Configuration (Configuration)");
+		LogWarning("");
+		LogWarning("You appear to running EQEmu in a docker container");
+		LogWarning("In order for networking to work properly you will need to properly configure your server");
+		LogWarning("");
+		LogWarning("If your Docker host is on a [LAN], your [localaddress] variable under [server->world] will need to");
+		LogWarning("be set to your LAN address on the host, not the container address. [address] will need to be your ");
+		LogWarning("public address");
+		LogWarning("");
+		LogWarning("If your Docker host is on the [public internet], your [localaddress] variable under [server->world] can be empty or set to [127.0.0.1]. ");
+		LogWarning("");
+		LogWarning("[address] will need to be your public address");
+		LogWarning("");
+		LogWarning("Docs [https://docs.eqemu.io/server/installation/configure-your-eqemu_config/#world]");
+		LogWarning("");
+		LogWarning("Config file [{}] path [server->world] variable(s) [localaddress] [address]", config_file);
+		LogWarning("");
+		LogWarning("Local address (eqemu_config) value [{}] detected value [{}]", _config->LocalAddress, local_address);
+		LogWarning("Public address (eqemu_config) value [{}] detected value [{}]", _config->WorldAddress, public_address);
 		std::cout << std::endl;
 	}
 
@@ -76,8 +103,7 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 		LogWarning("");
 		LogWarning("Config file [{}] path [server->world] variable [address]", config_file);
 		LogWarning("");
-		LogWarning("Public address (eqemu_config) value [{}]", _config->WorldAddress);
-		LogWarning("Public address (auto-detect) value [{}]", public_address);
+		LogWarning("Public address (eqemu_config) value [{}] detected value [{}]", _config->WorldAddress, public_address);
 		std::cout << std::endl;
 	}
 
@@ -86,14 +112,14 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 		LogWarning("# Public meta-address (Configuration)");
 		LogWarning("");
 		LogWarning("Your configured public address is set to a meta-address (0.0.0.0) (all-interfaces)");
-		LogWarning("The meta-address may not work properly and it is recommended you configure your public address explicitly");
+		LogWarning(
+			"The meta-address may not work properly and it is recommended you configure your public address explicitly");
 		LogWarning("");
 		LogWarning("Docs [https://docs.eqemu.io/server/installation/configure-your-eqemu_config/#world]");
 		LogWarning("");
 		LogWarning("Config file [{}] path [server->world] variable [address]", config_file);
 		LogWarning("");
-		LogWarning("Public address (eqemu_config) value [{}]", _config->WorldAddress);
-		LogWarning("Public address (auto-detect) value [{}]", public_address);
+		LogWarning("Public address (eqemu_config) value [{}] detected value [{}]", _config->WorldAddress, public_address);
 		std::cout << std::endl;
 	}
 
@@ -102,14 +128,14 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 		LogWarning("# Local meta-address (Configuration)");
 		LogWarning("");
 		LogWarning("Your configured local address is set to a meta-address (0.0.0.0) (all-interfaces)");
-		LogWarning("The meta-address may not work properly and it is recommended you configure your local address explicitly");
+		LogWarning(
+			"The meta-address may not work properly and it is recommended you configure your local address explicitly");
 		LogWarning("");
 		LogWarning("Docs [https://docs.eqemu.io/server/installation/configure-your-eqemu_config/#world]");
 		LogWarning("");
 		LogWarning("Config file [{}] path [server->world] variable [localaddress]", config_file);
 		LogWarning("");
-		LogWarning("Local address (eqemu_config) value [{}]", _config->LocalAddress);
-		LogWarning("Local address (auto-detect) value [{}]", local_address);
+		LogWarning("Local address (eqemu_config) value [{}] detected value [{}]", _config->LocalAddress, local_address);
 		std::cout << std::endl;
 	}
 }

--- a/world/world_config.cpp
+++ b/world/world_config.cpp
@@ -51,7 +51,7 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 	}
 
 	LogInfo("Checking for possible configuration issues");
-	LogInfo("To disable configuration checks, set [server->disable_config_checks] to [true] in [{}]", config_file);
+	LogInfo("To disable configuration checks, set [server.disable_config_checks] to [true] in [{}]", config_file);
 
 	std::string config_address = _config->WorldAddress;
 	if (!IpUtil::IsIPAddress(config_address)) {
@@ -78,7 +78,7 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 		LogWarning("");
 		LogWarning("Docs [https://docs.eqemu.io/server/installation/configure-your-eqemu_config/#world]");
 		LogWarning("");
-		LogWarning("Config file [{}] path [server->world] variable [localaddress]", config_file);
+		LogWarning("Config file [{}] path [server.world] variable [localaddress]", config_file);
 		LogWarning("");
 		LogWarning("Local address (eqemu_config) value [{}] detected value [{}]", _config->LocalAddress, local_address);
 		std::cout << std::endl;
@@ -98,19 +98,19 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 		LogWarning("In order for networking to work properly you will need to properly configure your server");
 		LogWarning("");
 		LogWarning(
-			"If your Docker host is on a [LAN] or behind a NAT / Firewall, your [localaddress] variable under [server->world] will need to");
+			"If your Docker host is on a [LAN] or behind a NAT / Firewall, your [localaddress] variable under [server.world] will need to");
 		LogWarning(
 			"be set to your LAN address on the host, not the container address. [address] will need to be your public address");
 		LogWarning("");
 		LogWarning(
-			"If your Docker host is directly on the [public internet], your [localaddress] variable under [server->world] can be set to [127.0.0.1]."
+			"If your Docker host is directly on the [public internet], your [localaddress] variable under [server.world] can be set to [127.0.0.1]."
 		);
 		LogWarning("");
 		LogWarning("[address] will need to be your public address");
 		LogWarning("");
 		LogWarning("Docs [https://docs.eqemu.io/server/installation/configure-your-eqemu_config/#world]");
 		LogWarning("");
-		LogWarning("Config file [{}] path [server->world] variable(s) [localaddress] [address]", config_file);
+		LogWarning("Config file [{}] path [server.world] variable(s) [localaddress] [address]", config_file);
 		LogWarning("");
 		LogWarning("Local address (eqemu_config) value [{}] detected value [{}]", _config->LocalAddress, local_address);
 		LogWarning(
@@ -131,19 +131,19 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 		);
 		LogWarning("");
 		LogWarning(
-			"If your Docker host is on a [LAN] or behind a NAT / Firewall, your [localaddress] variable under [server->world] will need to");
+			"If your Docker host is on a [LAN] or behind a NAT / Firewall, your [localaddress] variable under [server.world] will need to");
 		LogWarning(
 			"be set to your LAN address on the host, not the container address. [address] will need to be your public address");
 		LogWarning("");
 		LogWarning(
-			"If your Docker host is directly on the [public internet], your [localaddress] variable under [server->world] can be set to [127.0.0.1]."
+			"If your Docker host is directly on the [public internet], your [localaddress] variable under [server.world] can be set to [127.0.0.1]."
 		);
 		LogWarning("");
 		LogWarning("[address] will need to be your public address");
 		LogWarning("");
 		LogWarning("Docs [https://docs.eqemu.io/server/installation/configure-your-eqemu_config/#world]");
 		LogWarning("");
-		LogWarning("Config file [{}] path [server->world] variable(s) [localaddress] [address]", config_file);
+		LogWarning("Config file [{}] path [server.world] variable(s) [localaddress] [address]", config_file);
 		LogWarning("");
 		LogWarning("Local address (eqemu_config) value [{}] detected value [{}]", _config->LocalAddress, local_address);
 		LogWarning(
@@ -162,7 +162,7 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 		LogWarning("");
 		LogWarning("Docs [https://docs.eqemu.io/server/installation/configure-your-eqemu_config/#world]");
 		LogWarning("");
-		LogWarning("Config file [{}] path [server->world] variable [address]", config_file);
+		LogWarning("Config file [{}] path [server.world] variable [address]", config_file);
 		LogWarning("");
 		LogWarning(
 			"Public address (eqemu_config) value [{}] detected value [{}]",
@@ -182,7 +182,7 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 		LogWarning("");
 		LogWarning("Docs [https://docs.eqemu.io/server/installation/configure-your-eqemu_config/#world]");
 		LogWarning("");
-		LogWarning("Config file [{}] path [server->world] variable [address]", config_file);
+		LogWarning("Config file [{}] path [server.world] variable [address]", config_file);
 		LogWarning("");
 		LogWarning(
 			"Public address (eqemu_config) value [{}] detected value [{}]",
@@ -203,7 +203,7 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 		LogWarning("");
 		LogWarning("Docs [https://docs.eqemu.io/server/installation/configure-your-eqemu_config/#world]");
 		LogWarning("");
-		LogWarning("Config file [{}] path [server->world] variable [localaddress]", config_file);
+		LogWarning("Config file [{}] path [server.world] variable [localaddress]", config_file);
 		LogWarning("");
 		LogWarning("Local address (eqemu_config) value [{}] detected value [{}]", _config->LocalAddress, local_address);
 		std::cout << std::endl;
@@ -224,12 +224,12 @@ void WorldConfig::CheckForPossibleConfigurationIssues()
 		LogWarning("Docs [https://docs.eqemu.io/server/installation/configure-your-eqemu_config/#mailserver]");
 		LogWarning("");
 		LogWarning(
-			"[server->world->address] value [{}] [server->chatserver->host] [{}]",
+			"[server.world.address] value [{}] [server.chatserver.host] [{}]",
 			config_address,
 			_config->ChatHost
 		);
 		LogWarning(
-			"[server->world->address] value [{}] [server->mailserver->host] [{}]",
+			"[server.world.address] value [{}] [server.mailserver.host] [{}]",
 			config_address,
 			_config->MailHost
 		);

--- a/world/world_config.h
+++ b/world/world_config.h
@@ -68,6 +68,8 @@ public:
 	static void SetWorldAddress(std::string addr) { if (_world_config) _world_config->WorldAddress=addr; }
 	static void SetLocalAddress(std::string addr) { if (_world_config) _world_config->LocalAddress=addr; }
 
+	static void CheckForPossibleConfigurationIssues();
+
 	void Dump() const;
 };
 


### PR DESCRIPTION
**What**

This PR implements a mechanism in which informs new server operators that they may have a misconfiguration in their server config.

This is by far one of the most common issues of setting up a new server that are not immediately obvious to new operators and this is a way to help them before they reach support channels

* Resolves world `address` DNS when DNS record present to prevent from creating warnings from mismatch
* Detects when using meta-address `0.0.0.0` for `address`
* Detects when using meta-address `0.0.0.0` for `localaddress`
* Detects when in a Docker environment and configuration for `localaddress` or `address` is not correct
* Detects when UCS `host` addresses are different from `address`
* Detects when World `address` differs from publicly auto-detected address
* Detects when World is running within a LAN
* Implemented `IpUtil::GetLocalIPAddress()` Gets local address - pings google to inspect what interface was used locally
* Implemented `IpUtil::GetPublicIPAddress()` Uses various websites as options to return raw public IP back to the client

These methods fail transparently when no internet connection is present

### LAN Detection

![image](https://user-images.githubusercontent.com/3319450/177206432-8df12153-406f-40b0-92a0-6b6932ad50eb.png)

### Meta Address Detection

**Public**

```
[World] [Warning] # Public meta-address (Configuration)
[World] [Warning] 
[World] [Warning] Your configured public address is set to a meta-address (0.0.0.0) (all-interfaces)
[World] [Warning] The meta-address may not work properly and it is recommended you configure your public address explicitly
[World] [Warning] 
[World] [Warning] Docs [https://docs.eqemu.io/server/installation/configure-your-eqemu_config/#world]
[World] [Warning] 
[World] [Warning] Config file [eqemu_config.json] path [server->world] variable [address]
[World] [Warning] 
[World] [Warning] Public address (eqemu_config) value [0.0.0.0]
[World] [Warning] Public address (auto-detect) value [64.90.x.x]
```

**Private**

```
[World] [Warning] # Local meta-address (Configuration)
[World] [Warning] 
[World] [Warning] Your configured local address is set to a meta-address (0.0.0.0) (all-interfaces)
[World] [Warning] The meta-address may not work properly and it is recommended you configure your local address explicitly
[World] [Warning] 
[World] [Warning] Docs [https://docs.eqemu.io/server/installation/configure-your-eqemu_config/#world]
[World] [Warning] 
[World] [Warning] Config file [eqemu_config.json] path [server->world] variable [localaddress]
[World] [Warning] 
[World] [Warning] Local address (eqemu_config) value [0.0.0.0]
[World] [Warning] Local address (auto-detect) value [172.27.0.3]
```

### Docker Detections

![image](https://user-images.githubusercontent.com/3319450/177210332-bd1854e9-821b-463a-9dc7-74a77a8a4dd2.png)


### Public Address

When a public address is set in the configuration and its different from what is being automatically detected, a warning will be thrown.

```
[World] [Warning] # Public address (Configuration)
[World] [Warning] 
[World] [Warning] Your configured public address appears to be different from your configuration!
[World] [Warning] 
[World] [Warning] Docs [https://docs.eqemu.io/server/installation/configure-your-eqemu_config/#world]
[World] [Warning] 
[World] [Warning] Config file [eqemu_config.json] path [server->world] variable [address]
[World] [Warning] 
[World] [Warning] Public address (eqemu_config) value [0.0.0.0]
[World] [Warning] Public address (auto-detect) value [64.90.x.x]

```

### UCS

```
[World] [Warning] # UCS Address Mailhost (Configuration)
[World] [Warning] 
[World] [Warning] UCS (Universal Chat Service) mail or chat appears to use a different address from your main world address
[World] [Warning] This can result in a chat service that doesn't network properly
[World] [Warning] 
[World] [Warning] Docs [https://docs.eqemu.io/server/installation/configure-your-eqemu_config/#mailserver]
[World] [Warning] 
[World] [Warning] [server->world->address] value [64.90.x.x] [server->chatserver->host] [192.168.65.161]
[World] [Warning] [server->world->address] value [64.90.x.x] [server->mailserver->host] [192.168.65.161]
```

### Disabling Config Checks

If you are an expert and you never want to see warnings, you can optionally disable the checks by setting **server->disable_config_checks** to **true**

```
[World] [Info] Checking for possible configuration issues
[World] [Info] To disable configuration checks, set [server->disable_config_checks] to [true] in [eqemu_config.json]
```

**Result**

```
[World] [Info] Configuration checking [disabled]
```