### PR TITLE
[World] Add More Descriptive LS Auth Error Message

### DIFF
--- a/world/login_server.cpp
+++ b/world/login_server.cpp
@@ -294,10 +294,27 @@ void LoginServer::ProcessLSFatalError(uint16_t opcode, EQ::Net::Packet &p)
 	const WorldConfig *Config = WorldConfig::get();
 	LogNetcode("Received ServerPacket from LS OpCode {:#04x}", opcode);
 
-	LogInfo("Login server responded with FatalError");
+	std::string error;
+	std::string reason;
+
 	if (p.Length() > 1) {
-		LogError("Error [{}]", (const char *) p.Data());
+		error = fmt::format("{}", (const char *) p.Data());
 	}
+
+	if (error.find("Worldserver Account / Password INVALID") != std::string::npos) {
+		reason = "Usually this indicates you do not have a valid [account] and [password] (worldserver) account associated with your loginserver configuration. ";
+		if (fmt::format("{}", m_loginserver_address).find("login.eqemulator.net") != std::string::npos) {
+			reason += "For Legacy EQEmulator connections, you need to register your server @ http://www.eqemulator.org/account/?LS";
+		}
+	}
+
+	LogInfo(
+		"Login server [{}:{}] responded with fatal error [{}] {}\n",
+		m_loginserver_address,
+		m_loginserver_port,
+		error,
+		reason
+	);
 }
 
 void LoginServer::ProcessSystemwideMessage(uint16_t opcode, EQ::Net::Packet &p)


### PR DESCRIPTION
Today we have terrible, vague messages for when a new operator installs a new server and tries to connect it to the Legacy EQEmulator Loginserver. Users simply get the error message

This error comes from the loginserver itself, it's not super descriptive and doesn't tell the user hardly anything and usually it is ambiguous until someone on Discord informs a user what the cause of the error is.

This PR adds more descriptive erroring so its more clear to users what action should be taken to remediate. Including the source loginserver address and reason for the error with a link to where to remediate


**Before**

```
[World] [Error] Error [Worldserver Account / Password INVALID.]
```

**After**

![image](https://user-images.githubusercontent.com/3319450/178118813-f9d6fff2-82e7-4760-9bc2-4515de3a5dce.png)

```
[World] [Info] Login server [login.eqemulator.net:5998] responded with fatal error [Worldserver Account / Password INVALID.net:5998]] Usually this indicates you do not have a valid [account] and [password] (worldserver) account associated with your loginserver configuration.For Legacy EQEmulator connections, you need to register your server @ http://www.eqemulator.org/account/?LS
```