### PR TITLE
[Tasks] Place task item rewards in free slots

### DIFF
--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -1291,7 +1291,8 @@ void ClientTaskState::RewardTask(Client *client, TaskInformation *task_informati
 	switch (task_information->reward_method) {
 		case METHODSINGLEID: {
 			if (task_information->reward_id) {
-				client->SummonItem(task_information->reward_id);
+				int16_t slot = client->GetInv().FindFreeSlot(true, true);
+				client->SummonItem(task_information->reward_id, -1, 0, 0, 0, 0, 0, 0, false, slot);
 				item_data = database.GetItem(task_information->reward_id);
 				if (item_data) {
 					client->MessageString(Chat::Yellow, YOU_HAVE_BEEN_GIVEN, item_data->Name);
@@ -1302,7 +1303,8 @@ void ClientTaskState::RewardTask(Client *client, TaskInformation *task_informati
 		case METHODLIST: {
 			reward_list = task_manager->m_goal_list_manager.GetListContents(task_information->reward_id);
 			for (int item_id : reward_list) {
-				client->SummonItem(item_id);
+				int16_t slot = client->GetInv().FindFreeSlot(true, true);
+				client->SummonItem(item_id, -1, 0, 0, 0, 0, 0, 0, false, slot);
 				item_data = database.GetItem(item_id);
 				if (item_data) {
 					client->MessageString(Chat::Yellow, YOU_HAVE_BEEN_GIVEN, item_data->Name);


### PR DESCRIPTION
Live places item rewards into the first free inventory slot and only
places it on the cursor if inventory is full

This was more of a pet peeve than a critical fix, but it's parity with live