### PR TITLE
[Logs] #logs list Improvements

### DIFF
--- a/zone/gm_commands/logs.cpp
+++ b/zone/gm_commands/logs.cpp
@@ -3,6 +3,10 @@
 
 extern WorldServer worldserver;
 
+inline void print_legend(Client *c) {
+	c->Message(Chat::White, "[Legend] [G = GM Say] [F = File] [C = Console] [D = Discord]");
+}
+
 void command_logs(Client *c, const Seperator *sep)
 {
 	int arguments = sep->argnum;
@@ -58,15 +62,8 @@ void command_logs(Client *c, const Seperator *sep)
 
 		uint32 max_category_id = (start_category_id + 49);
 
-		std::string popup_text = "<table>";
-
-		popup_text += "<tr>";
-		popup_text += "<td>ID</td>";
-		popup_text += "<td>Name</td>";
-		popup_text += "<td>Console</td>";
-		popup_text += "<td>File</td>";
-		popup_text += "<td>GM Say</td>";
-		popup_text += "</tr>";
+		print_legend(c);
+		c->Message(Chat::White, "------------------------------------------------");
 
 		for (int index = start_category_id; index <= max_category_id; index++) {
 			if (index >= Logs::LogCategory::MaxCategoryID) {
@@ -74,29 +71,100 @@ void command_logs(Client *c, const Seperator *sep)
 				break;
 			}
 
-			popup_text += fmt::format(
-				"<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>",
-				index,
-				Logs::LogCategoryName[index],
-				LogSys.log_settings[index].log_to_console,
-				LogSys.log_settings[index].log_to_file,
-				LogSys.log_settings[index].log_to_gmsay
+			std::vector<std::string> gmsay;
+			for (int i = 0; i <= 3; i++) {
+				if (i == 2) {
+					continue;
+				}
+				if (LogSys.log_settings[index].log_to_gmsay == i) {
+					gmsay.emplace_back(std::to_string(i));
+					continue;
+				}
+
+				gmsay.emplace_back(
+					EQ::SayLinkEngine::GenerateQuestSaylink(
+						fmt::format("#logs set gmsay {} {}", index, i), false, std::to_string(i)
+					)
+				);
+			}
+
+			std::vector<std::string> file;
+			for (int i = 0; i <= 3; i++) {
+				if (i == 2) {
+					continue;
+				}
+				if (LogSys.log_settings[index].log_to_file == i) {
+					file.emplace_back(std::to_string(i));
+					continue;
+				}
+
+				file.emplace_back(
+					EQ::SayLinkEngine::GenerateQuestSaylink(
+						fmt::format("#logs set file {} {}", index, i), false, std::to_string(i)
+					)
+				);
+			}
+
+			std::vector<std::string> console;
+			for (int i = 0; i <= 3; i++) {
+				if (i == 2) {
+					continue;
+				}
+				if (LogSys.log_settings[index].log_to_console == i) {
+					console.emplace_back(std::to_string(i));
+					continue;
+				}
+
+				console.emplace_back(
+					EQ::SayLinkEngine::GenerateQuestSaylink(
+						fmt::format("#logs set console {} {}", index, i), false, std::to_string(i)
+					)
+				);
+			}
+
+			std::vector<std::string> discord;
+			for (int i = 0; i <= 3; i++) {
+				if (i == 2) {
+					continue;
+				}
+				if (LogSys.log_settings[index].log_to_discord == i) {
+					discord.emplace_back(std::to_string(i));
+					continue;
+				}
+
+				discord.emplace_back(
+					EQ::SayLinkEngine::GenerateQuestSaylink(
+						fmt::format("#logs set discord {} {}", index, i), false, std::to_string(i)
+					)
+				);
+			}
+
+			std::string gmsay_string = JoinString(gmsay, "-");
+			std::string console_string = JoinString(console, "-");
+			std::string file_string = JoinString(file, "-");
+			std::string discord_string = JoinString(discord, "-");
+
+			c->Message(
+				0,
+				fmt::format(
+					"G [{}] C [{}] F [{}] D [{}] [{}] [{}] ",
+					rtrim(gmsay_string, "-"),
+					rtrim(console_string, "-"),
+					rtrim(file_string, "-"),
+					rtrim(discord_string, "-"),
+					index,
+					Logs::LogCategoryName[index]
+				).c_str()
 			);
+
+			if (index % 10 == 0) {
+				c->Message(Chat::White, "------------------------------------------------");
+				print_legend(c);
+				c->Message(Chat::White, "------------------------------------------------");
+			}
 		}
 
-		popup_text += "</table>";
-
-		std::string popup_title = fmt::format(
-			"Log Settings [{} to {}]",
-			start_category_id,
-			max_category_id
-		);
-
-		c->SendPopupToClient(
-			popup_title.c_str(),
-			popup_text.c_str()
-		);
-
+		c->Message(Chat::White, "------------------------------------------------");
 		c->Message(
 			Chat::White,
 			fmt::format(
@@ -107,6 +175,7 @@ void command_logs(Client *c, const Seperator *sep)
 				max_category_id
 			).c_str()
 		);
+		c->Message(Chat::White, "------------------------------------------------");
 
 		int next_category_id = (max_category_id + 1);
 		if (next_category_id < Logs::LogCategory::MaxCategoryID) {
@@ -166,7 +235,7 @@ void command_logs(Client *c, const Seperator *sep)
 			c->Message(
 				Chat::White,
 				fmt::format(
-					"{} ({}) is now set to Debug Level {} for {}.",
+					"{} ({}) is now set to Debug Level {} for {}. This is temporary and only in memory for the current zone.",
 					Logs::LogCategoryName[category_id],
 					category_id,
 					setting,


### PR DESCRIPTION
This PR adds improvements to the `#logs list` command that adds clickable saylinks for each log category.

If the logging level is already active, it is shown without a saylink as a white number, otherwise it is printed as a clickable saylink to activate the logging category for that category.

This does remove the popup as your focus will remain in the chat window for listings options. This still keeps paging as it was

**In-Game Example**

![image](https://user-images.githubusercontent.com/3319450/178127555-3c5ec77c-b7d8-442c-835e-2da98468c8af.png)

