### PR TITLE
[Tasks] Reward clients on shared task completion sync

### DIFF
--- a/common/repositories/base/base_character_tasks_repository.h
+++ b/common/repositories/base/base_character_tasks_repository.h
@@ -24,6 +24,7 @@ public:
 		int slot;
 		int type;
 		int acceptedtime;
+		int was_rewarded;
 	};
 
 	static std::string PrimaryKey()
@@ -39,6 +40,7 @@ public:
 			"slot",
 			"type",
 			"acceptedtime",
+			"was_rewarded",
 		};
 	}
 
@@ -50,6 +52,7 @@ public:
 			"slot",
 			"type",
 			"acceptedtime",
+			"was_rewarded",
 		};
 	}
 
@@ -95,6 +98,7 @@ public:
 		entry.slot         = 0;
 		entry.type         = 0;
 		entry.acceptedtime = 0;
+		entry.was_rewarded = 0;
 
 		return entry;
 	}
@@ -135,6 +139,7 @@ public:
 			entry.slot         = atoi(row[2]);
 			entry.type         = atoi(row[3]);
 			entry.acceptedtime = atoi(row[4]);
+			entry.was_rewarded = atoi(row[5]);
 
 			return entry;
 		}
@@ -173,6 +178,7 @@ public:
 		update_values.push_back(columns[2] + " = " + std::to_string(character_tasks_entry.slot));
 		update_values.push_back(columns[3] + " = " + std::to_string(character_tasks_entry.type));
 		update_values.push_back(columns[4] + " = " + std::to_string(character_tasks_entry.acceptedtime));
+		update_values.push_back(columns[5] + " = " + std::to_string(character_tasks_entry.was_rewarded));
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -199,6 +205,7 @@ public:
 		insert_values.push_back(std::to_string(character_tasks_entry.slot));
 		insert_values.push_back(std::to_string(character_tasks_entry.type));
 		insert_values.push_back(std::to_string(character_tasks_entry.acceptedtime));
+		insert_values.push_back(std::to_string(character_tasks_entry.was_rewarded));
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -233,6 +240,7 @@ public:
 			insert_values.push_back(std::to_string(character_tasks_entry.slot));
 			insert_values.push_back(std::to_string(character_tasks_entry.type));
 			insert_values.push_back(std::to_string(character_tasks_entry.acceptedtime));
+			insert_values.push_back(std::to_string(character_tasks_entry.was_rewarded));
 
 			insert_chunks.push_back("(" + Strings::Implode(",", insert_values) + ")");
 		}
@@ -271,6 +279,7 @@ public:
 			entry.slot         = atoi(row[2]);
 			entry.type         = atoi(row[3]);
 			entry.acceptedtime = atoi(row[4]);
+			entry.was_rewarded = atoi(row[5]);
 
 			all_entries.push_back(entry);
 		}
@@ -300,6 +309,7 @@ public:
 			entry.slot         = atoi(row[2]);
 			entry.type         = atoi(row[3]);
 			entry.acceptedtime = atoi(row[4]);
+			entry.was_rewarded = atoi(row[5]);
 
 			all_entries.push_back(entry);
 		}

--- a/common/tasks.h
+++ b/common/tasks.h
@@ -257,6 +257,7 @@ struct ClientTaskInformation {
 	int                       current_step;
 	int                       accepted_time;
 	bool                      updated;
+	bool                      was_rewarded; // character has received reward for this task
 	ClientActivityInformation activity[MAXACTIVITIESPERTASK];
 };
 

--- a/common/version.h
+++ b/common/version.h
@@ -34,7 +34,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9188
+#define CURRENT_BINARY_DATABASE_VERSION 9189
 
 #ifdef BOTS
 	#define CURRENT_BINARY_BOTS_DATABASE_VERSION 9029

--- a/utils/sql/db_update_manifest.txt
+++ b/utils/sql/db_update_manifest.txt
@@ -442,6 +442,7 @@
 9186|2022_07_09_zone_expansion_deprecate.sql|SHOW COLUMNS FROM `zone` LIKE 'expansion'|notempty|
 9187|2022_07_09_task_zone_version_matching.sql|SHOW COLUMNS FROM `task_activities` LIKE 'zone_version'|empty|
 9188|2022_07_14_zone_expansion_revert.sql|SHOW COLUMNS FROM `zone` LIKE 'expansion'|empty|
+9189|2022_07_10_character_task_rewarded.sql|SHOW COLUMNS FROM `character_tasks` LIKE 'was_rewarded'|empty|
 
 # Upgrade conditions:
 # 	This won't be needed after this system is implemented, but it is used database that are not

--- a/utils/sql/git/required/2022_07_10_character_task_rewarded.sql
+++ b/utils/sql/git/required/2022_07_10_character_task_rewarded.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `character_tasks`
+	ADD COLUMN `was_rewarded` TINYINT NOT NULL DEFAULT '0' AFTER `acceptedtime`;

--- a/zone/task_client_state.h
+++ b/zone/task_client_state.h
@@ -43,7 +43,7 @@ public:
 	bool TaskOutOfTime(TaskType task_type, int index);
 	void TaskPeriodicChecks(Client *client);
 	void SendTaskHistory(Client *client, int task_index);
-	void RewardTask(Client *client, TaskInformation *task_information);
+	void RewardTask(Client *client, TaskInformation *task_information, ClientTaskInformation& client_task);
 	void EnableTask(int character_id, int task_count, int *task_list);
 	void DisableTask(int character_id, int task_count, int *task_list);
 	bool IsTaskEnabled(int task_id);
@@ -75,6 +75,7 @@ public:
 
 private:
 	void AddReplayTimer(Client *client, ClientTaskInformation& client_task, TaskInformation& task);
+	void DispatchEventTaskComplete(Client* client, ClientTaskInformation& client_task, int activity_id);
 
 	void IncrementDoneCount(
 		Client *client,

--- a/zone/task_manager.h
+++ b/zone/task_manager.h
@@ -66,6 +66,7 @@ public:
 	int LastTaskInSet(int task_set);
 	int NextTaskInSet(int task_set, int task_id);
 	bool IsTaskRepeatable(int task_id);
+	bool IsActiveTaskComplete(ClientTaskInformation& client_task);
 
 	friend class ClientTaskState;
 


### PR DESCRIPTION
If a member is offline (or possibly during a race while zoning?) when
the shared task is completed they will not receive the reward. On live
the character receives their reward (with an updated replay timer) if
they enter back into game while the shared task is still active. They
keep the original replay timer if the shared task is no longer active
and do not receive a reward.

This makes it so clients are issued rewards (and a task completed
event is dispatch) if the client's task state was out of sync with a
completed shared task. To prevent characters being rewarded more than
once in case of bad sync checks, a 'was_rewarded' field has been added
to the character_tasks table and updated when rewards are assigned.

This fixes a couple bugs so the character_activities table is correctly
updated with shared task states to better detect when out of sync:

- The character_activities table is now flagged to update after syncing
  shared task states. This table was not being updated if a client was
  offline or inaccessible for a shared task element update.

- The character_activities table is now updated when a task element is
  completed. This was only being updated for activity increments and on
  completing the entire task. SaveClientState is now called at the end
  of ClientTaskState::IncrementDoneCount to cover all cases.

This also has a cosmetic change to show replay timers before rewards
like live, though this will not work for shared tasks until refactoring
world code