### PR TITLE
[Content Filter] Fix Runtime Filtering When Set to -1 (All)

### DIFF
--- a/common/content/world_content_service.cpp
+++ b/common/content/world_content_service.cpp
@@ -158,12 +158,12 @@ bool WorldContentService::IsContentFlagDisabled(const std::string &content_flag)
 bool WorldContentService::DoesPassContentFiltering(const ContentFlags &f)
 {
 	// if we're not set to (-1 All) then fail when we aren't within minimum expansion
-	if (f.min_expansion > Expansion::EXPANSION_ALL && current_expansion < f.min_expansion) {
+	if (f.min_expansion > Expansion::EXPANSION_ALL && current_expansion < f.min_expansion && current_expansion != -1) {
 		return false;
 	}
 
 	// if we're not set to (-1 All) then fail when we aren't within max expansion
-	if (f.max_expansion > Expansion::EXPANSION_ALL && current_expansion > f.max_expansion) {
+	if (f.max_expansion > Expansion::EXPANSION_ALL && current_expansion > f.max_expansion && current_expansion != -1) {
 		return false;
 	}
 


### PR DESCRIPTION
Fixes regression caused by https://github.com/EQEmu/Server/pull/1940 where when set to expansion `-1` (All) runtime filtering was preventing `min_expansion` 8 in the reported case from dropping

**Example**

Huffin reported from PEQ that Ailing Walrus was not dropping Savage Lord Totem Epic drop https://everquest.allakhazam.com/db/item.html?item=30533

Validated fixed

![image](https://user-images.githubusercontent.com/3319450/179132507-3806b51c-3d9a-468c-b062-8e5c1fc7cfa6.png)
