### PR TITLE
Refactor saylink injection

### DIFF
--- a/common/say_link.cpp
+++ b/common/say_link.cpp
@@ -322,145 +322,54 @@ std::string EQ::SayLinkEngine::GenerateQuestSaylink(std::string saylink_text, bo
 
 std::string EQ::SayLinkEngine::InjectSaylinksIfNotExist(const char *message)
 {
-	std::string              new_message       = message;
-	int                      link_index        = 0;
-	int                      saylink_index     = 0;
-	std::vector<std::string> links             = {};
-	std::vector<std::string> saylinks          = {};
-	int                      saylink_length    = 50;
-	std::string              saylink_separator = "\u0012";
-	std::string              saylink_partial   = "00000";
+	LogSaylinkDetail("message [{}]", message);
 
-	LogSaylinkDetail("new_message pre pass 1 [{}]", new_message);
+	std::string new_message;
+	new_message.reserve(strlen(message));
 
-	// first pass - strip existing saylinks by putting placeholder anchors on them
-	for (auto &saylink: Strings::Split(new_message, saylink_separator)) {
-		if (!saylink.empty() && saylink.length() > saylink_length &&
-			saylink.find(saylink_partial) != std::string::npos) {
-			saylinks.emplace_back(saylink);
+	bool in_bracket_state = false;
+	bool in_link_state = false;
 
-			LogSaylinkDetail("Found saylink [{}]", saylink);
+	const char* ch = message;
+	const char* startpos = message;
+	for (; *ch != '\0'; ++ch)
+	{
+		// saylinks not added if spaces touch brackets
+		bool abort_space = in_bracket_state && *ch == ' ' && (*(ch-1) == '[' || *(ch+1) == ']');
 
-			// replace with anchor
-			Strings::FindReplace(
-				new_message,
-				fmt::format("{}", saylink),
-				fmt::format("<saylink:{}>", saylink_index)
-			);
-
-			saylink_index++;
+		if (in_bracket_state && (*ch == '[' || *ch == '\x12' || abort_space))
+		{
+			// abort due to nested bracket (which starts another) or existing saylink
+			new_message.append(startpos, ch - startpos);
+			in_bracket_state = false;
 		}
-	}
-
-	LogSaylinkDetail("new_message post pass 1 [{}]", new_message);
-
-	LogSaylinkDetail("saylink separator count [{}]", std::count(new_message.begin(), new_message.end(), '\u0012'));
-
-	// loop through brackets until none exist
-	if (new_message.find('[') != std::string::npos) {
-		for (auto &b: Strings::Split(new_message, "[")) {
-			if (!b.empty() && b.find(']') != std::string::npos) {
-				std::vector<std::string> right_split = Strings::Split(b, "]");
-				if (!right_split.empty()) {
-					std::string bracket_message = Strings::Trim(right_split[0]);
-
-					// we shouldn't see a saylink fragment here, ignore this bracket
-					if (bracket_message.find(saylink_partial) != std::string::npos) {
-						continue;
-					}
-
-					// skip where multiple saylinks are within brackets
-					if (bracket_message.find(saylink_separator) != std::string::npos &&
-						std::count(bracket_message.begin(), bracket_message.end(), '\u0012') > 1) {
-						continue;
-					}
-
-					// if non empty bracket contents
-					if (!bracket_message.empty()) {
-						LogSaylinkDetail("Found bracket_message [{}]", bracket_message);
-
-						// already a saylink
-						// todo: improve this later
-						if (!bracket_message.empty() &&
-							(bracket_message.length() > saylink_length ||
-							 bracket_message.find(saylink_separator) != std::string::npos)) {
-							links.emplace_back(bracket_message);
-						}
-						else {
-							links.emplace_back(
-								EQ::SayLinkEngine::GenerateQuestSaylink(
-									bracket_message,
-									false,
-									bracket_message
-								)
-							);
-						}
-
-						// replace with anchor
-						Strings::FindReplace(
-							new_message,
-							fmt::format("[{}]", bracket_message),
-							fmt::format("<prelink:{}>", link_index)
-						);
-
-						link_index++;
-					}
-				}
+		else if (in_bracket_state && *ch == ']')
+		{
+			if (ch != startpos)
+			{
+				std::string str(startpos, ch - startpos);
+				new_message += EQ::SayLinkEngine::GenerateQuestSaylink(str, false, str);
 			}
+			in_bracket_state = false;
+		}
+
+		if (!in_bracket_state)
+		{
+			new_message.push_back(*ch);
+		}
+
+		if (*ch == '[' && !in_link_state)
+		{
+			startpos = ch + 1;
+			in_bracket_state = true;
+		}
+		else if (*ch == '\x12')
+		{
+			in_link_state = !in_link_state;
 		}
 	}
 
-	LogSaylinkDetail("new_message post pass 2 (post brackets) [{}]", new_message);
-
-	// strip any current delimiters of saylinks
-	Strings::FindReplace(new_message, saylink_separator, "");
-
-	// pop links onto anchors
-	link_index = 0;
-	for (auto &link: links) {
-
-		// strip any current delimiters of saylinks
-		Strings::FindReplace(link, saylink_separator, "");
-
-		Strings::FindReplace(
-			new_message,
-			fmt::format("<prelink:{}>", link_index),
-			fmt::format("[\u0012{}\u0012]", link)
-		);
-		link_index++;
-	}
-
-	LogSaylinkDetail("new_message post pass 3 (post prelink anchor pop) [{}]", new_message);
-
-	// pop links onto anchors
-	saylink_index = 0;
-	for (auto &link: saylinks) {
-		// strip any current delimiters of saylinks
-		Strings::FindReplace(link, saylink_separator, "");
-
-		// check to see if we did a double anchor pass (existing saylink that was also inside brackets)
-		// this means we found a saylink and we're checking to see if we're already encoded before double encoding
-		if (new_message.find(fmt::format("\u0012<saylink:{}>\u0012", saylink_index)) != std::string::npos) {
-			LogSaylinkDetail("Found encoded saylink at index [{}]", saylink_index);
-
-			Strings::FindReplace(
-				new_message,
-				fmt::format("\u0012<saylink:{}>\u0012", saylink_index),
-				fmt::format("\u0012{}\u0012", link)
-			);
-			saylink_index++;
-			continue;
-		}
-
-		Strings::FindReplace(
-			new_message,
-			fmt::format("<saylink:{}>", saylink_index),
-			fmt::format("\u0012{}\u0012", link)
-		);
-		saylink_index++;
-	}
-
-	LogSaylinkDetail("new_message post pass 4 (post saylink anchor pop) [{}]", new_message);
+	LogSaylinkDetail("new_message [{}]", new_message);
 
 	return new_message;
 }


### PR DESCRIPTION
If a message was longer than 50 characters with "00000" somewhere in the
message (such as messages with hex numbers) then the saylink injection
method was sending a blank message to the chat window.

This refactors the saylink injection method using a crude state machine
to build the output. It should function the same:

  - Inner-most brackets generate saylinks when nested
  - Saylinks are not generated in brackets that already have a saylink
  - Existing saylinks are preserved
  - Existing saylinks that contain text with brackets do not attempt to
    generate saylinks
  - Saylinks are not generated if brackets contains leading or trailing
    spaces (e.g. [ spaces ])

---

Original bug:
```lua
e.other:Message(MT.White, "following message broken:")
e.other:Message(MT.White, "This message is over 50 characters with 5 consecutive 0s: 0xb0000000")
e.other:Message(MT.White, "This message is over 50 characters with 5 consecutive Xs: 0xbXXXXXXX")
```
![image](https://user-images.githubusercontent.com/4683435/179366867-c9e5b489-2c6c-4cdc-8ae6-ae12606957db.png)

after this patch:

![image](https://user-images.githubusercontent.com/4683435/179366888-faad5891-aa57-4641-b3f3-18c74a90dff4.png)

---

Comparisons with current injector:
```lua
local existing2 = eq.say_link("existing2", false, "[existing2 with inner brackets]")
e.other:Message(MT.White, "gen saylink 1: [gen1] [" .. eq.say_link("existing1") .. "] [] [ ] [ spaces ] [ lspace] [rspace ]")
e.other:Message(MT.White, "gen saylink 2: [[gen2]] [foo[foo[gen3] bar] bar] [a[b[" .. existing2 .. " gen4]]]")
```

before:
![image](https://user-images.githubusercontent.com/4683435/179367343-f72c5d7b-8afa-4806-ab34-23738b7c4d2b.png)

after:
![image](https://user-images.githubusercontent.com/4683435/179367006-22eaabdb-4fe4-4222-b2b6-f35959fc8e7f.png)

---

Example from #1525:
before:
![image](https://user-images.githubusercontent.com/4683435/179367032-46c6f42d-fc3e-4ae3-8c96-7edf5cf7c39c.png)

after:
![image](https://user-images.githubusercontent.com/4683435/179367038-26ecddf9-b248-4250-84b3-98b58f673f05.png)

---

Example from #1620:
before:
![image](https://user-images.githubusercontent.com/4683435/179367746-91d2c578-1f8e-4847-b6cf-e646a30b2c6c.png)

after:
![image](https://user-images.githubusercontent.com/4683435/179367085-a7fbf42a-a438-45ac-a56a-0afa805f733c.png)

Note that new behavior preserves the 3rd closing bracket in `my $d = quest::saylink("a", 1, "[[A]]]");` here as part of the saylink text which should be expected. Though the current injector does include the third bracket if the first argument is something other than `"a"`, so possibly there was another bug here.

---

Example from #1643:
before:
![image](https://user-images.githubusercontent.com/4683435/179367380-738888c0-4241-4d65-9901-a6a3b883064e.png)

after:
![image](https://user-images.githubusercontent.com/4683435/179367109-a220dbc3-c74b-48e8-8d9f-e544e3017150.png)



