### PR TITLE
[Tasks] Add Task Reward Points Field

### DIFF
--- a/common/repositories/base/base_tasks_repository.h
+++ b/common/repositories/base/base_tasks_repository.h
@@ -30,8 +30,8 @@ public:
 		int         cashreward;
 		int         xpreward;
 		int         rewardmethod;
-		int         reward_radiant_crystals;
-		int         reward_ebon_crystals;
+		int         reward_points;
+		int         reward_point_type;
 		int         minlevel;
 		int         maxlevel;
 		int         level_spread;
@@ -63,8 +63,8 @@ public:
 			"cashreward",
 			"xpreward",
 			"rewardmethod",
-			"reward_radiant_crystals",
-			"reward_ebon_crystals",
+			"reward_points",
+			"reward_point_type",
 			"minlevel",
 			"maxlevel",
 			"level_spread",
@@ -92,8 +92,8 @@ public:
 			"cashreward",
 			"xpreward",
 			"rewardmethod",
-			"reward_radiant_crystals",
-			"reward_ebon_crystals",
+			"reward_points",
+			"reward_point_type",
 			"minlevel",
 			"maxlevel",
 			"level_spread",
@@ -144,29 +144,29 @@ public:
 	{
 		Tasks entry{};
 
-		entry.id                      = 0;
-		entry.type                    = 0;
-		entry.duration                = 0;
-		entry.duration_code           = 0;
-		entry.title                   = "";
-		entry.description             = "";
-		entry.reward                  = "";
-		entry.rewardid                = 0;
-		entry.cashreward              = 0;
-		entry.xpreward                = 0;
-		entry.rewardmethod            = 2;
-		entry.reward_radiant_crystals = 0;
-		entry.reward_ebon_crystals    = 0;
-		entry.minlevel                = 0;
-		entry.maxlevel                = 0;
-		entry.level_spread            = 0;
-		entry.min_players             = 0;
-		entry.max_players             = 0;
-		entry.repeatable              = 1;
-		entry.faction_reward          = 0;
-		entry.completion_emote        = "";
-		entry.replay_timer_seconds    = 0;
-		entry.request_timer_seconds   = 0;
+		entry.id                    = 0;
+		entry.type                  = 0;
+		entry.duration              = 0;
+		entry.duration_code         = 0;
+		entry.title                 = "";
+		entry.description           = "";
+		entry.reward                = "";
+		entry.rewardid              = 0;
+		entry.cashreward            = 0;
+		entry.xpreward              = 0;
+		entry.rewardmethod          = 2;
+		entry.reward_points         = 0;
+		entry.reward_point_type     = 0;
+		entry.minlevel              = 0;
+		entry.maxlevel              = 0;
+		entry.level_spread          = 0;
+		entry.min_players           = 0;
+		entry.max_players           = 0;
+		entry.repeatable            = 1;
+		entry.faction_reward        = 0;
+		entry.completion_emote      = "";
+		entry.replay_timer_seconds  = 0;
+		entry.request_timer_seconds = 0;
 
 		return entry;
 	}
@@ -202,29 +202,29 @@ public:
 		if (results.RowCount() == 1) {
 			Tasks entry{};
 
-			entry.id                      = atoi(row[0]);
-			entry.type                    = atoi(row[1]);
-			entry.duration                = atoi(row[2]);
-			entry.duration_code           = atoi(row[3]);
-			entry.title                   = row[4] ? row[4] : "";
-			entry.description             = row[5] ? row[5] : "";
-			entry.reward                  = row[6] ? row[6] : "";
-			entry.rewardid                = atoi(row[7]);
-			entry.cashreward              = atoi(row[8]);
-			entry.xpreward                = atoi(row[9]);
-			entry.rewardmethod            = atoi(row[10]);
-			entry.reward_radiant_crystals = atoi(row[11]);
-			entry.reward_ebon_crystals    = atoi(row[12]);
-			entry.minlevel                = atoi(row[13]);
-			entry.maxlevel                = atoi(row[14]);
-			entry.level_spread            = atoi(row[15]);
-			entry.min_players             = atoi(row[16]);
-			entry.max_players             = atoi(row[17]);
-			entry.repeatable              = atoi(row[18]);
-			entry.faction_reward          = atoi(row[19]);
-			entry.completion_emote        = row[20] ? row[20] : "";
-			entry.replay_timer_seconds    = atoi(row[21]);
-			entry.request_timer_seconds   = atoi(row[22]);
+			entry.id                    = atoi(row[0]);
+			entry.type                  = atoi(row[1]);
+			entry.duration              = atoi(row[2]);
+			entry.duration_code         = atoi(row[3]);
+			entry.title                 = row[4] ? row[4] : "";
+			entry.description           = row[5] ? row[5] : "";
+			entry.reward                = row[6] ? row[6] : "";
+			entry.rewardid              = atoi(row[7]);
+			entry.cashreward            = atoi(row[8]);
+			entry.xpreward              = atoi(row[9]);
+			entry.rewardmethod          = atoi(row[10]);
+			entry.reward_points         = atoi(row[11]);
+			entry.reward_point_type     = atoi(row[12]);
+			entry.minlevel              = atoi(row[13]);
+			entry.maxlevel              = atoi(row[14]);
+			entry.level_spread          = atoi(row[15]);
+			entry.min_players           = atoi(row[16]);
+			entry.max_players           = atoi(row[17]);
+			entry.repeatable            = atoi(row[18]);
+			entry.faction_reward        = atoi(row[19]);
+			entry.completion_emote      = row[20] ? row[20] : "";
+			entry.replay_timer_seconds  = atoi(row[21]);
+			entry.request_timer_seconds = atoi(row[22]);
 
 			return entry;
 		}
@@ -269,8 +269,8 @@ public:
 		update_values.push_back(columns[8] + " = " + std::to_string(tasks_entry.cashreward));
 		update_values.push_back(columns[9] + " = " + std::to_string(tasks_entry.xpreward));
 		update_values.push_back(columns[10] + " = " + std::to_string(tasks_entry.rewardmethod));
-		update_values.push_back(columns[11] + " = " + std::to_string(tasks_entry.reward_radiant_crystals));
-		update_values.push_back(columns[12] + " = " + std::to_string(tasks_entry.reward_ebon_crystals));
+		update_values.push_back(columns[11] + " = " + std::to_string(tasks_entry.reward_points));
+		update_values.push_back(columns[12] + " = " + std::to_string(tasks_entry.reward_point_type));
 		update_values.push_back(columns[13] + " = " + std::to_string(tasks_entry.minlevel));
 		update_values.push_back(columns[14] + " = " + std::to_string(tasks_entry.maxlevel));
 		update_values.push_back(columns[15] + " = " + std::to_string(tasks_entry.level_spread));
@@ -313,8 +313,8 @@ public:
 		insert_values.push_back(std::to_string(tasks_entry.cashreward));
 		insert_values.push_back(std::to_string(tasks_entry.xpreward));
 		insert_values.push_back(std::to_string(tasks_entry.rewardmethod));
-		insert_values.push_back(std::to_string(tasks_entry.reward_radiant_crystals));
-		insert_values.push_back(std::to_string(tasks_entry.reward_ebon_crystals));
+		insert_values.push_back(std::to_string(tasks_entry.reward_points));
+		insert_values.push_back(std::to_string(tasks_entry.reward_point_type));
 		insert_values.push_back(std::to_string(tasks_entry.minlevel));
 		insert_values.push_back(std::to_string(tasks_entry.maxlevel));
 		insert_values.push_back(std::to_string(tasks_entry.level_spread));
@@ -365,8 +365,8 @@ public:
 			insert_values.push_back(std::to_string(tasks_entry.cashreward));
 			insert_values.push_back(std::to_string(tasks_entry.xpreward));
 			insert_values.push_back(std::to_string(tasks_entry.rewardmethod));
-			insert_values.push_back(std::to_string(tasks_entry.reward_radiant_crystals));
-			insert_values.push_back(std::to_string(tasks_entry.reward_ebon_crystals));
+			insert_values.push_back(std::to_string(tasks_entry.reward_points));
+			insert_values.push_back(std::to_string(tasks_entry.reward_point_type));
 			insert_values.push_back(std::to_string(tasks_entry.minlevel));
 			insert_values.push_back(std::to_string(tasks_entry.maxlevel));
 			insert_values.push_back(std::to_string(tasks_entry.level_spread));
@@ -410,29 +410,29 @@ public:
 		for (auto row = results.begin(); row != results.end(); ++row) {
 			Tasks entry{};
 
-			entry.id                      = atoi(row[0]);
-			entry.type                    = atoi(row[1]);
-			entry.duration                = atoi(row[2]);
-			entry.duration_code           = atoi(row[3]);
-			entry.title                   = row[4] ? row[4] : "";
-			entry.description             = row[5] ? row[5] : "";
-			entry.reward                  = row[6] ? row[6] : "";
-			entry.rewardid                = atoi(row[7]);
-			entry.cashreward              = atoi(row[8]);
-			entry.xpreward                = atoi(row[9]);
-			entry.rewardmethod            = atoi(row[10]);
-			entry.reward_radiant_crystals = atoi(row[11]);
-			entry.reward_ebon_crystals    = atoi(row[12]);
-			entry.minlevel                = atoi(row[13]);
-			entry.maxlevel                = atoi(row[14]);
-			entry.level_spread            = atoi(row[15]);
-			entry.min_players             = atoi(row[16]);
-			entry.max_players             = atoi(row[17]);
-			entry.repeatable              = atoi(row[18]);
-			entry.faction_reward          = atoi(row[19]);
-			entry.completion_emote        = row[20] ? row[20] : "";
-			entry.replay_timer_seconds    = atoi(row[21]);
-			entry.request_timer_seconds   = atoi(row[22]);
+			entry.id                    = atoi(row[0]);
+			entry.type                  = atoi(row[1]);
+			entry.duration              = atoi(row[2]);
+			entry.duration_code         = atoi(row[3]);
+			entry.title                 = row[4] ? row[4] : "";
+			entry.description           = row[5] ? row[5] : "";
+			entry.reward                = row[6] ? row[6] : "";
+			entry.rewardid              = atoi(row[7]);
+			entry.cashreward            = atoi(row[8]);
+			entry.xpreward              = atoi(row[9]);
+			entry.rewardmethod          = atoi(row[10]);
+			entry.reward_points         = atoi(row[11]);
+			entry.reward_point_type     = atoi(row[12]);
+			entry.minlevel              = atoi(row[13]);
+			entry.maxlevel              = atoi(row[14]);
+			entry.level_spread          = atoi(row[15]);
+			entry.min_players           = atoi(row[16]);
+			entry.max_players           = atoi(row[17]);
+			entry.repeatable            = atoi(row[18]);
+			entry.faction_reward        = atoi(row[19]);
+			entry.completion_emote      = row[20] ? row[20] : "";
+			entry.replay_timer_seconds  = atoi(row[21]);
+			entry.request_timer_seconds = atoi(row[22]);
 
 			all_entries.push_back(entry);
 		}
@@ -457,29 +457,29 @@ public:
 		for (auto row = results.begin(); row != results.end(); ++row) {
 			Tasks entry{};
 
-			entry.id                      = atoi(row[0]);
-			entry.type                    = atoi(row[1]);
-			entry.duration                = atoi(row[2]);
-			entry.duration_code           = atoi(row[3]);
-			entry.title                   = row[4] ? row[4] : "";
-			entry.description             = row[5] ? row[5] : "";
-			entry.reward                  = row[6] ? row[6] : "";
-			entry.rewardid                = atoi(row[7]);
-			entry.cashreward              = atoi(row[8]);
-			entry.xpreward                = atoi(row[9]);
-			entry.rewardmethod            = atoi(row[10]);
-			entry.reward_radiant_crystals = atoi(row[11]);
-			entry.reward_ebon_crystals    = atoi(row[12]);
-			entry.minlevel                = atoi(row[13]);
-			entry.maxlevel                = atoi(row[14]);
-			entry.level_spread            = atoi(row[15]);
-			entry.min_players             = atoi(row[16]);
-			entry.max_players             = atoi(row[17]);
-			entry.repeatable              = atoi(row[18]);
-			entry.faction_reward          = atoi(row[19]);
-			entry.completion_emote        = row[20] ? row[20] : "";
-			entry.replay_timer_seconds    = atoi(row[21]);
-			entry.request_timer_seconds   = atoi(row[22]);
+			entry.id                    = atoi(row[0]);
+			entry.type                  = atoi(row[1]);
+			entry.duration              = atoi(row[2]);
+			entry.duration_code         = atoi(row[3]);
+			entry.title                 = row[4] ? row[4] : "";
+			entry.description           = row[5] ? row[5] : "";
+			entry.reward                = row[6] ? row[6] : "";
+			entry.rewardid              = atoi(row[7]);
+			entry.cashreward            = atoi(row[8]);
+			entry.xpreward              = atoi(row[9]);
+			entry.rewardmethod          = atoi(row[10]);
+			entry.reward_points         = atoi(row[11]);
+			entry.reward_point_type     = atoi(row[12]);
+			entry.minlevel              = atoi(row[13]);
+			entry.maxlevel              = atoi(row[14]);
+			entry.level_spread          = atoi(row[15]);
+			entry.min_players           = atoi(row[16]);
+			entry.max_players           = atoi(row[17]);
+			entry.repeatable            = atoi(row[18]);
+			entry.faction_reward        = atoi(row[19]);
+			entry.completion_emote      = row[20] ? row[20] : "";
+			entry.replay_timer_seconds  = atoi(row[21]);
+			entry.request_timer_seconds = atoi(row[22]);
 
 			all_entries.push_back(entry);
 		}

--- a/common/tasks.h
+++ b/common/tasks.h
@@ -50,6 +50,20 @@ enum class TaskTimerType
 	Request
 };
 
+// live alt currency types, may not match current server alternate currency ids
+enum class AltCurrencyType
+{
+	RadiantCrystal       = 4,
+	EbonCrystal          = 5,
+	MarkOfValor          = 31,
+	CommemorativeCoin    = 33,
+	PieceOfEight         = 37,
+	RemnantOfTranquility = 38,
+	SathirTradeGem       = 41,
+	BathezidTradeGem     = 43,
+	FroststoneDucat      = 48,
+};
+
 struct ActivityInformation {
 	int              step_number;
 	TaskActivityType activity_type;
@@ -198,8 +212,8 @@ struct TaskInformation {
 	int                 experience_reward{};
 	int                 faction_reward{};   // just a npc_faction_id
 	TaskMethodType      reward_method;
-	int                 reward_radiant_crystals;
-	int                 reward_ebon_crystals;
+	int                 reward_points;
+	AltCurrencyType     reward_point_type;
 	int                 activity_count{};
 	SequenceType        sequence_mode;
 	int                 last_step{};

--- a/common/version.h
+++ b/common/version.h
@@ -34,7 +34,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9189
+#define CURRENT_BINARY_DATABASE_VERSION 9190
 
 #ifdef BOTS
 	#define CURRENT_BINARY_BOTS_DATABASE_VERSION 9029

--- a/utils/sql/db_update_manifest.txt
+++ b/utils/sql/db_update_manifest.txt
@@ -443,7 +443,7 @@
 9187|2022_07_09_task_zone_version_matching.sql|SHOW COLUMNS FROM `task_activities` LIKE 'zone_version'|empty|
 9188|2022_07_14_zone_expansion_revert.sql|SHOW COLUMNS FROM `zone` LIKE 'expansion'|empty|
 9189|2022_07_10_character_task_rewarded.sql|SHOW COLUMNS FROM `character_tasks` LIKE 'was_rewarded'|empty|
-9190|2022_07_13_task_reward_points.sql|SHOW COLUMNS FROM `tasks` LIKE `reward_points`|empty|
+9190|2022_07_13_task_reward_points.sql|SHOW COLUMNS FROM `tasks` LIKE 'reward_points'|empty|
 
 # Upgrade conditions:
 # 	This won't be needed after this system is implemented, but it is used database that are not

--- a/utils/sql/db_update_manifest.txt
+++ b/utils/sql/db_update_manifest.txt
@@ -443,6 +443,7 @@
 9187|2022_07_09_task_zone_version_matching.sql|SHOW COLUMNS FROM `task_activities` LIKE 'zone_version'|empty|
 9188|2022_07_14_zone_expansion_revert.sql|SHOW COLUMNS FROM `zone` LIKE 'expansion'|empty|
 9189|2022_07_10_character_task_rewarded.sql|SHOW COLUMNS FROM `character_tasks` LIKE 'was_rewarded'|empty|
+9190|2022_07_13_task_reward_points.sql|SHOW COLUMNS FROM `tasks` LIKE `reward_points`|empty|
 
 # Upgrade conditions:
 # 	This won't be needed after this system is implemented, but it is used database that are not

--- a/utils/sql/git/required/2022_07_13_task_reward_points.sql
+++ b/utils/sql/git/required/2022_07_13_task_reward_points.sql
@@ -1,0 +1,13 @@
+ALTER TABLE `tasks`
+	ADD COLUMN `reward_points` INT NOT NULL DEFAULT '0' AFTER `rewardmethod`,
+	ADD COLUMN `reward_point_type` INT NOT NULL DEFAULT '0' AFTER `reward_points`;
+
+-- convert don crystal points to new fields
+UPDATE tasks SET reward_point_type = 4 WHERE reward_radiant_crystals > 0;
+UPDATE tasks SET reward_point_type = 5 WHERE reward_ebon_crystals > 0;
+UPDATE tasks SET reward_points = reward_radiant_crystals WHERE reward_radiant_crystals > 0;
+UPDATE tasks SET reward_points = reward_ebon_crystals WHERE reward_ebon_crystals > 0;
+
+ALTER TABLE `tasks`
+	DROP COLUMN `reward_radiant_crystals`,
+	DROP COLUMN `reward_ebon_crystals`;

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -1381,9 +1381,16 @@ void ClientTaskState::RewardTask(Client *client, TaskInformation *task_informati
 		}
 	}
 
-	if (task_information->reward_radiant_crystals > 0 || task_information->reward_ebon_crystals > 0)
+	if (task_information->reward_points > 0)
 	{
-		client->AddCrystals(task_information->reward_radiant_crystals, task_information->reward_ebon_crystals);
+		if (task_information->reward_point_type == AltCurrencyType::RadiantCrystal)
+		{
+			client->AddCrystals(task_information->reward_points, 0);
+		}
+		else if (task_information->reward_point_type == AltCurrencyType::EbonCrystal)
+		{
+			client->AddCrystals(0, task_information->reward_points);
+		}
 	}
 
 	client->SendSound();

--- a/zone/task_manager.cpp
+++ b/zone/task_manager.cpp
@@ -105,8 +105,8 @@ bool TaskManager::LoadTasks(int single_task)
 		m_task_data[task_id]->cash_reward             = task.cashreward;
 		m_task_data[task_id]->experience_reward       = task.xpreward;
 		m_task_data[task_id]->reward_method           = (TaskMethodType) task.rewardmethod;
-		m_task_data[task_id]->reward_radiant_crystals = task.reward_radiant_crystals;
-		m_task_data[task_id]->reward_ebon_crystals    = task.reward_ebon_crystals;
+		m_task_data[task_id]->reward_points           = task.reward_points;
+		m_task_data[task_id]->reward_point_type       = static_cast<AltCurrencyType>(task.reward_point_type);
 		m_task_data[task_id]->faction_reward          = task.faction_reward;
 		m_task_data[task_id]->min_level               = task.minlevel;
 		m_task_data[task_id]->max_level               = task.maxlevel;
@@ -1213,8 +1213,7 @@ void TaskManager::SendActiveTaskDescription(
 	task_description_header->open_window    = bring_up_task_journal;
 	task_description_header->task_type      = static_cast<uint32>(m_task_data[task_id]->type);
 
-	constexpr uint32_t reward_radiant_type = 4; // Radiant Crystals, anything else is Ebon for shared tasks
-	task_description_header->reward_type = m_task_data[task_id]->reward_radiant_crystals > 0 ? reward_radiant_type : 0;
+	task_description_header->reward_type = static_cast<int>(m_task_data[task_id]->reward_point_type);
 
 	Ptr = (char *) task_description_header + sizeof(TaskDescriptionHeader_Struct);
 
@@ -1257,10 +1256,8 @@ void TaskManager::SendActiveTaskDescription(
 
 	tdt = (TaskDescriptionTrailer_Struct *) Ptr;
 	// shared tasks show radiant/ebon crystal reward, non-shared tasks show generic points
-	tdt->Points               = m_task_data[task_id]->reward_ebon_crystals;
-	if (m_task_data[task_id]->reward_radiant_crystals > 0) {
-		tdt->Points = m_task_data[task_id]->reward_radiant_crystals;
-	}
+	tdt->Points = m_task_data[task_id]->reward_points;
+
 	tdt->has_reward_selection = 0; // TODO: new rewards window
 
 	client->QueuePacket(outapp);


### PR DESCRIPTION
This replaces the separate DoN crystal reward fields with points and
point_type fields. This will make it easier to import data from
packet/client captures and possibly better support any future clients
or tasks that don't reward through the newer reward window.