### PR TITLE
[Client] Fix IsMoving for Client

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -349,7 +349,8 @@ Client::Client(EQStreamInterface* ieqs)
 		m_pp.InnateSkills[i] = InnateDisabled;
 
 	temp_pvp = false;
-	is_client_moving = false;
+
+	moving = false;
 
 	environment_damage_modifier = 0;
 	invulnerable_environment_damage = false;

--- a/zone/client.h
+++ b/zone/client.h
@@ -229,8 +229,6 @@ public:
 	Client(EQStreamInterface * ieqs);
 	~Client();
 
-	bool is_client_moving;
-
 	void ReconnectUCS();
 
 	void SetDisplayMobInfoWindow(bool display_mob_info_window);
@@ -409,7 +407,7 @@ public:
 	inline void SetBaseRace(uint32 i) { m_pp.race=i; }
 	inline void SetBaseGender(uint32 i) { m_pp.gender=i; }
 	inline void SetDeity(uint32 i) {m_pp.deity=i;deity=i;}
-	
+
 	void SetTrackingID(uint32 entity_id);
 
 	inline uint8 GetLevel2() const { return m_pp.level2; }

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4504,9 +4504,8 @@ void Client::Handle_OP_ClientUpdate(const EQApplicationPacket *app) {
 		}
 		rewind_timer.Start(30000, true);
 	}
-	
-	is_client_moving = !(cy == m_Position.y && cx == m_Position.x);
-	moving = is_client_moving;
+
+	SetMoving(!(cy == m_Position.y && cx == m_Position.x));
 
 	/**
 	 * Client aggro scanning
@@ -4517,11 +4516,11 @@ void Client::Handle_OP_ClientUpdate(const EQApplicationPacket *app) {
 	LogAggroDetail(
 		"ClientUpdate [{}] {}moving, scan timer [{}]",
 		GetCleanName(),
-		is_client_moving ? "" : "NOT ",
+		IsMoving() ? "" : "NOT ",
 		client_scan_npc_aggro_timer.GetRemainingTime()
 	);
 
-	if (is_client_moving) {
+	if (IsMoving()) {
 		if (client_scan_npc_aggro_timer.GetRemainingTime() > client_scan_npc_aggro_timer_moving) {
 			LogAggroDetail("Client [{}] Restarting with moving timer", GetCleanName());
 			client_scan_npc_aggro_timer.Disable();
@@ -4544,11 +4543,11 @@ void Client::Handle_OP_ClientUpdate(const EQApplicationPacket *app) {
 	LogAIScanCloseDetail(
 		"Client [{}] {}moving, scan timer [{}]",
 		GetCleanName(),
-		is_client_moving ? "" : "NOT ",
+		IsMoving() ? "" : "NOT ",
 		mob_close_scan_timer.GetRemainingTime()
 	);
 
-	if (is_client_moving) {
+	if (IsMoving()) {
 		if (mob_close_scan_timer.GetRemainingTime() > client_mob_close_scan_timer_moving) {
 			LogAIScanCloseDetail("Client [{}] Restarting with moving timer", GetCleanName());
 			mob_close_scan_timer.Disable();
@@ -4578,7 +4577,7 @@ void Client::Handle_OP_ClientUpdate(const EQApplicationPacket *app) {
 		client_zone_wide_full_position_update_timer.Check() || moved_far_enough_before_bulk_update
 	);
 
-	if (is_client_moving && is_ready_to_update) {
+	if (IsMoving() && is_ready_to_update) {
 		LogDebug("[[{}]] Client Zone Wide Position Update NPCs", GetCleanName());
 
 		auto &mob_movement_manager = MobMovementManager::Get();
@@ -4621,7 +4620,7 @@ void Client::Handle_OP_ClientUpdate(const EQApplicationPacket *app) {
 	}
 
 	/* Only feed real time updates when client is moving */
-	if (is_client_moving || new_heading != m_Position.w || new_animation != animation) {
+	if (IsMoving() || new_heading != m_Position.w || new_animation != animation) {
 
 		animation = ppu->animation;
 		m_Position.w = new_heading;

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4504,10 +4504,9 @@ void Client::Handle_OP_ClientUpdate(const EQApplicationPacket *app) {
 		}
 		rewind_timer.Start(30000, true);
 	}
-
-
+	
 	is_client_moving = !(cy == m_Position.y && cx == m_Position.x);
-
+	moving = is_client_moving;
 
 	/**
 	 * Client aggro scanning

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -124,7 +124,7 @@ bool Client::Process() {
 		}
 
 		/* I haven't naturally updated my position in 10 seconds, updating manually */
-		if (!is_client_moving && position_update_timer.Check()) {
+		if (!moving && position_update_timer.Check()) {
 			SentPositionPacket(0.0f, 0.0f, 0.0f, 0.0f, 0);
 		}
 
@@ -291,7 +291,7 @@ bool Client::Process() {
 		 * Used in aggro checks
 		 */
 		if (mob_close_scan_timer.Check()) {
-			entity_list.ScanCloseMobs(close_mobs, this, is_client_moving);
+			entity_list.ScanCloseMobs(close_mobs, this, moving);
 		}
 
 		bool may_use_attacks = false;

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -124,7 +124,7 @@ bool Client::Process() {
 		}
 
 		/* I haven't naturally updated my position in 10 seconds, updating manually */
-		if (!moving && position_update_timer.Check()) {
+		if (!IsMoving() && position_update_timer.Check()) {
 			SentPositionPacket(0.0f, 0.0f, 0.0f, 0.0f, 0);
 		}
 
@@ -291,7 +291,7 @@ bool Client::Process() {
 		 * Used in aggro checks
 		 */
 		if (mob_close_scan_timer.Check()) {
-			entity_list.ScanCloseMobs(close_mobs, this, moving);
+			entity_list.ScanCloseMobs(close_mobs, this, IsMoving());
 		}
 
 		bool may_use_attacks = false;


### PR DESCRIPTION
Consolidates "moving" tracker member variables and fixes `IsMoving` Mob export for Client instead of just NPC

**Testing**

![image](https://user-images.githubusercontent.com/3319450/179436196-435db0a6-d5b5-4984-8b3f-f7d5443fe5aa.png)
