### PR TITLE
[Roambox] Improve Path Finding

### DIFF
--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -1600,9 +1600,8 @@ void NPC::AI_DoMovement() {
 				move_delay_max
 			);
 
-			Log(
-				Logs::Detail,
-				Logs::NPCRoamBox, "(%s) Timer calc | random_timer [%i] roambox_move_delay [%i] move_min [%i] move_max [%i]",
+			LogNPCRoamBoxDetail(
+				"({}) Timer calc | random_timer [{}] roambox_move_delay [{}] move_min [{}] move_max [{}]",
 				GetCleanName(),
 				random_timer,
 				roambox_move_delay,
@@ -1659,9 +1658,7 @@ void NPC::AI_DoMovement() {
 					}
 
 					if (zone->watermap->InLiquid(position)) {
-						Log(Logs::Detail,
-							Logs::NPCRoamBox, "%s | My destination is in water and I don't belong there!",
-							GetCleanName());
+						LogNPCRoamBoxDetail("[{}] | My destination is in water and I don't belong there!", GetCleanName());
 
 						return;
 					}
@@ -1681,39 +1678,12 @@ void NPC::AI_DoMovement() {
 				}
 			}
 
-			PathfinderOptions opts;
-			opts.smooth_path = true;
-			opts.step_size   = RuleR(Pathing, NavmeshStepSize);
-			opts.offset      = GetZOffset();
-			opts.flags       = PathingNotDisabled ^ PathingZoneLine;
+			LogNPCRoamBox("[{}] | Pathing to [{}] [{}] [{}]", GetCleanName(),
+				roambox_destination_x, roambox_destination_y,
+				roambox_destination_z);
 
-			auto partial = false;
-			auto stuck   = false;
-			auto route   = zone->pathing->FindPath(
-				glm::vec3(GetX(), GetY(), GetZ()),
-				glm::vec3(
-					roambox_destination_x,
-					roambox_destination_y,
-					roambox_destination_z
-				),
-				partial,
-				stuck,
-				opts
-			);
-
-			if (route.empty()) {
-				Log(
-					Logs::Detail,
-					Logs::NPCRoamBox, "(%s) We don't have a path route... exiting...",
-					GetCleanName()
-				);
-				return;
-			}
-
-			Log(
-				Logs::General,
-				Logs::NPCRoamBox,
-				"NPC (%s) distance [%.0f] X (min/max) [%.0f / %.0f] Y (min/max) [%.0f / %.0f] | Dest x/y/z [%.0f / %.0f / %.0f]",
+			LogNPCRoamBox(
+				"NPC ({}) distance [{}] X (min/max) [{} / {}] Y (min/max) [{} / {}] | Dest x/y/z [{} / {} / {}]",
 				GetCleanName(),
 				roambox_distance,
 				roambox_min_x,


### PR DESCRIPTION
While debugging roam boxes under water, I found the log messages were not populating the data fields.  Fixed this.

I also found that the calls to FindPath were very often not finding tiles from start/end when mob started in a water position, causing them to never move and just spew logging errors.

Looking into this, the calls in the mob_ai roambox call to FindPath() are really unneeded and do not take into account terrain.  Simply allowing the Movement Manager code to handle this fixed all my issues, and movement manager has the stuck behavior code as well, which was being bypassed by this pre-emptive check in the roambox code.