### PR TITLE
Allow scripts to prevent door click

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4238,10 +4238,10 @@ void Client::Handle_OP_ClickDoor(const EQApplicationPacket *app)
 	std::string export_string = fmt::format("{}", cd->doorid);
 	std::vector<EQ::Any> args;
 	args.push_back(currentdoor);
-	parse->EventPlayer(EVENT_CLICK_DOOR, this, export_string, 0, &args);
-
-	currentdoor->HandleClick(this, 0);
-	return;
+	if (parse->EventPlayer(EVENT_CLICK_DOOR, this, export_string, 0, &args) == 0)
+	{
+		currentdoor->HandleClick(this, 0);
+	}
 }
 
 void Client::Handle_OP_ClickObject(const EQApplicationPacket *app)


### PR DESCRIPTION
Returning non-zero from EVENT_CLICK_DOOR will prevent the default
handler.

This should have been implemented when expeditions were put in to
allow scripts to prevent zoning out of vxed and tipt without flags.
Some upcoming changes may need this to allow scripts to prevent
automatic dz entry.