### PR TITLE
[Feature] GM State Change Persistance

### DIFF
--- a/common/repositories/base/base_account_repository.h
+++ b/common/repositories/base/base_account_repository.h
@@ -28,6 +28,9 @@ public:
 		std::string ls_id;
 		int         lsaccount_id;
 		int         gmspeed;
+		int         invulnerable;
+		int         flymode;
+		int         ignore_tells;
 		int         revoked;
 		int         karma;
 		std::string minilogin_ip;
@@ -60,6 +63,9 @@ public:
 			"ls_id",
 			"lsaccount_id",
 			"gmspeed",
+			"invulnerable",
+			"flymode",
+			"ignore_tells",
 			"revoked",
 			"karma",
 			"minilogin_ip",
@@ -88,6 +94,9 @@ public:
 			"ls_id",
 			"lsaccount_id",
 			"gmspeed",
+			"invulnerable",
+			"flymode",
+			"ignore_tells",
 			"revoked",
 			"karma",
 			"minilogin_ip",
@@ -150,6 +159,9 @@ public:
 		entry.ls_id          = "eqemu";
 		entry.lsaccount_id   = 0;
 		entry.gmspeed        = 0;
+		entry.invulnerable   = 0;
+		entry.flymode        = 0;
+		entry.ignore_tells   = 0;
 		entry.revoked        = 0;
 		entry.karma          = 0;
 		entry.minilogin_ip   = "";
@@ -207,19 +219,22 @@ public:
 			entry.ls_id          = row[6] ? row[6] : "";
 			entry.lsaccount_id   = atoi(row[7]);
 			entry.gmspeed        = atoi(row[8]);
-			entry.revoked        = atoi(row[9]);
-			entry.karma          = atoi(row[10]);
-			entry.minilogin_ip   = row[11] ? row[11] : "";
-			entry.hideme         = atoi(row[12]);
-			entry.rulesflag      = atoi(row[13]);
-			entry.suspendeduntil = strtoll(row[14] ? row[14] : "-1", nullptr, 10);
-			entry.time_creation  = atoi(row[15]);
-			entry.expansion      = atoi(row[16]);
-			entry.ban_reason     = row[17] ? row[17] : "";
-			entry.suspend_reason = row[18] ? row[18] : "";
-			entry.crc_eqgame     = row[19] ? row[19] : "";
-			entry.crc_skillcaps  = row[20] ? row[20] : "";
-			entry.crc_basedata   = row[21] ? row[21] : "";
+			entry.invulnerable   = atoi(row[9]);
+			entry.flymode        = atoi(row[10]);
+			entry.ignore_tells   = atoi(row[11]);
+			entry.revoked        = atoi(row[12]);
+			entry.karma          = atoi(row[13]);
+			entry.minilogin_ip   = row[14] ? row[14] : "";
+			entry.hideme         = atoi(row[15]);
+			entry.rulesflag      = atoi(row[16]);
+			entry.suspendeduntil = strtoll(row[17] ? row[17] : "-1", nullptr, 10);
+			entry.time_creation  = atoi(row[18]);
+			entry.expansion      = atoi(row[19]);
+			entry.ban_reason     = row[20] ? row[20] : "";
+			entry.suspend_reason = row[21] ? row[21] : "";
+			entry.crc_eqgame     = row[22] ? row[22] : "";
+			entry.crc_skillcaps  = row[23] ? row[23] : "";
+			entry.crc_basedata   = row[24] ? row[24] : "";
 
 			return entry;
 		}
@@ -261,19 +276,22 @@ public:
 		update_values.push_back(columns[6] + " = '" + Strings::Escape(account_entry.ls_id) + "'");
 		update_values.push_back(columns[7] + " = " + std::to_string(account_entry.lsaccount_id));
 		update_values.push_back(columns[8] + " = " + std::to_string(account_entry.gmspeed));
-		update_values.push_back(columns[9] + " = " + std::to_string(account_entry.revoked));
-		update_values.push_back(columns[10] + " = " + std::to_string(account_entry.karma));
-		update_values.push_back(columns[11] + " = '" + Strings::Escape(account_entry.minilogin_ip) + "'");
-		update_values.push_back(columns[12] + " = " + std::to_string(account_entry.hideme));
-		update_values.push_back(columns[13] + " = " + std::to_string(account_entry.rulesflag));
-		update_values.push_back(columns[14] + " = FROM_UNIXTIME(" + (account_entry.suspendeduntil > 0 ? std::to_string(account_entry.suspendeduntil) : "null") + ")");
-		update_values.push_back(columns[15] + " = " + std::to_string(account_entry.time_creation));
-		update_values.push_back(columns[16] + " = " + std::to_string(account_entry.expansion));
-		update_values.push_back(columns[17] + " = '" + Strings::Escape(account_entry.ban_reason) + "'");
-		update_values.push_back(columns[18] + " = '" + Strings::Escape(account_entry.suspend_reason) + "'");
-		update_values.push_back(columns[19] + " = '" + Strings::Escape(account_entry.crc_eqgame) + "'");
-		update_values.push_back(columns[20] + " = '" + Strings::Escape(account_entry.crc_skillcaps) + "'");
-		update_values.push_back(columns[21] + " = '" + Strings::Escape(account_entry.crc_basedata) + "'");
+		update_values.push_back(columns[9] + " = " + std::to_string(account_entry.invulnerable));
+		update_values.push_back(columns[10] + " = " + std::to_string(account_entry.flymode));
+		update_values.push_back(columns[11] + " = " + std::to_string(account_entry.ignore_tells));
+		update_values.push_back(columns[12] + " = " + std::to_string(account_entry.revoked));
+		update_values.push_back(columns[13] + " = " + std::to_string(account_entry.karma));
+		update_values.push_back(columns[14] + " = '" + Strings::Escape(account_entry.minilogin_ip) + "'");
+		update_values.push_back(columns[15] + " = " + std::to_string(account_entry.hideme));
+		update_values.push_back(columns[16] + " = " + std::to_string(account_entry.rulesflag));
+		update_values.push_back(columns[17] + " = FROM_UNIXTIME(" + (account_entry.suspendeduntil > 0 ? std::to_string(account_entry.suspendeduntil) : "null") + ")");
+		update_values.push_back(columns[18] + " = " + std::to_string(account_entry.time_creation));
+		update_values.push_back(columns[19] + " = " + std::to_string(account_entry.expansion));
+		update_values.push_back(columns[20] + " = '" + Strings::Escape(account_entry.ban_reason) + "'");
+		update_values.push_back(columns[21] + " = '" + Strings::Escape(account_entry.suspend_reason) + "'");
+		update_values.push_back(columns[22] + " = '" + Strings::Escape(account_entry.crc_eqgame) + "'");
+		update_values.push_back(columns[23] + " = '" + Strings::Escape(account_entry.crc_skillcaps) + "'");
+		update_values.push_back(columns[24] + " = '" + Strings::Escape(account_entry.crc_basedata) + "'");
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -304,6 +322,9 @@ public:
 		insert_values.push_back("'" + Strings::Escape(account_entry.ls_id) + "'");
 		insert_values.push_back(std::to_string(account_entry.lsaccount_id));
 		insert_values.push_back(std::to_string(account_entry.gmspeed));
+		insert_values.push_back(std::to_string(account_entry.invulnerable));
+		insert_values.push_back(std::to_string(account_entry.flymode));
+		insert_values.push_back(std::to_string(account_entry.ignore_tells));
 		insert_values.push_back(std::to_string(account_entry.revoked));
 		insert_values.push_back(std::to_string(account_entry.karma));
 		insert_values.push_back("'" + Strings::Escape(account_entry.minilogin_ip) + "'");
@@ -355,6 +376,9 @@ public:
 			insert_values.push_back("'" + Strings::Escape(account_entry.ls_id) + "'");
 			insert_values.push_back(std::to_string(account_entry.lsaccount_id));
 			insert_values.push_back(std::to_string(account_entry.gmspeed));
+			insert_values.push_back(std::to_string(account_entry.invulnerable));
+			insert_values.push_back(std::to_string(account_entry.flymode));
+			insert_values.push_back(std::to_string(account_entry.ignore_tells));
 			insert_values.push_back(std::to_string(account_entry.revoked));
 			insert_values.push_back(std::to_string(account_entry.karma));
 			insert_values.push_back("'" + Strings::Escape(account_entry.minilogin_ip) + "'");
@@ -410,19 +434,22 @@ public:
 			entry.ls_id          = row[6] ? row[6] : "";
 			entry.lsaccount_id   = atoi(row[7]);
 			entry.gmspeed        = atoi(row[8]);
-			entry.revoked        = atoi(row[9]);
-			entry.karma          = atoi(row[10]);
-			entry.minilogin_ip   = row[11] ? row[11] : "";
-			entry.hideme         = atoi(row[12]);
-			entry.rulesflag      = atoi(row[13]);
-			entry.suspendeduntil = strtoll(row[14] ? row[14] : "-1", nullptr, 10);
-			entry.time_creation  = atoi(row[15]);
-			entry.expansion      = atoi(row[16]);
-			entry.ban_reason     = row[17] ? row[17] : "";
-			entry.suspend_reason = row[18] ? row[18] : "";
-			entry.crc_eqgame     = row[19] ? row[19] : "";
-			entry.crc_skillcaps  = row[20] ? row[20] : "";
-			entry.crc_basedata   = row[21] ? row[21] : "";
+			entry.invulnerable   = atoi(row[9]);
+			entry.flymode        = atoi(row[10]);
+			entry.ignore_tells   = atoi(row[11]);
+			entry.revoked        = atoi(row[12]);
+			entry.karma          = atoi(row[13]);
+			entry.minilogin_ip   = row[14] ? row[14] : "";
+			entry.hideme         = atoi(row[15]);
+			entry.rulesflag      = atoi(row[16]);
+			entry.suspendeduntil = strtoll(row[17] ? row[17] : "-1", nullptr, 10);
+			entry.time_creation  = atoi(row[18]);
+			entry.expansion      = atoi(row[19]);
+			entry.ban_reason     = row[20] ? row[20] : "";
+			entry.suspend_reason = row[21] ? row[21] : "";
+			entry.crc_eqgame     = row[22] ? row[22] : "";
+			entry.crc_skillcaps  = row[23] ? row[23] : "";
+			entry.crc_basedata   = row[24] ? row[24] : "";
 
 			all_entries.push_back(entry);
 		}
@@ -456,19 +483,22 @@ public:
 			entry.ls_id          = row[6] ? row[6] : "";
 			entry.lsaccount_id   = atoi(row[7]);
 			entry.gmspeed        = atoi(row[8]);
-			entry.revoked        = atoi(row[9]);
-			entry.karma          = atoi(row[10]);
-			entry.minilogin_ip   = row[11] ? row[11] : "";
-			entry.hideme         = atoi(row[12]);
-			entry.rulesflag      = atoi(row[13]);
-			entry.suspendeduntil = strtoll(row[14] ? row[14] : "-1", nullptr, 10);
-			entry.time_creation  = atoi(row[15]);
-			entry.expansion      = atoi(row[16]);
-			entry.ban_reason     = row[17] ? row[17] : "";
-			entry.suspend_reason = row[18] ? row[18] : "";
-			entry.crc_eqgame     = row[19] ? row[19] : "";
-			entry.crc_skillcaps  = row[20] ? row[20] : "";
-			entry.crc_basedata   = row[21] ? row[21] : "";
+			entry.invulnerable   = atoi(row[9]);
+			entry.flymode        = atoi(row[10]);
+			entry.ignore_tells   = atoi(row[11]);
+			entry.revoked        = atoi(row[12]);
+			entry.karma          = atoi(row[13]);
+			entry.minilogin_ip   = row[14] ? row[14] : "";
+			entry.hideme         = atoi(row[15]);
+			entry.rulesflag      = atoi(row[16]);
+			entry.suspendeduntil = strtoll(row[17] ? row[17] : "-1", nullptr, 10);
+			entry.time_creation  = atoi(row[18]);
+			entry.expansion      = atoi(row[19]);
+			entry.ban_reason     = row[20] ? row[20] : "";
+			entry.suspend_reason = row[21] ? row[21] : "";
+			entry.crc_eqgame     = row[22] ? row[22] : "";
+			entry.crc_skillcaps  = row[23] ? row[23] : "";
+			entry.crc_basedata   = row[24] ? row[24] : "";
 
 			all_entries.push_back(entry);
 		}

--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -39,6 +39,7 @@
 #include "eqemu_config.h"
 #include "data_verification.h"
 #include "repositories/criteria/content_filter_criteria.h"
+#include "repositories/account_repository.h"
 
 namespace ItemField
 {
@@ -65,62 +66,56 @@ SharedDatabase::~SharedDatabase() = default;
 
 bool SharedDatabase::SetHideMe(uint32 account_id, uint8 hideme)
 {
-	const std::string query = StringFormat("UPDATE account SET hideme = %i WHERE id = %i", hideme, account_id);
-	const auto results = QueryDatabase(query);
-	if (!results.Success()) {
-		return false;
+	auto a = AccountRepository::FindOne(*this, account_id);
+	if (a.id > 0) {
+		a.hideme = hideme ? 1 : 0;
+		AccountRepository::UpdateOne(*this, a);
 	}
 
-	return true;
+	return a.id > 0;
 }
 
 uint8 SharedDatabase::GetGMSpeed(uint32 account_id)
 {
-	const std::string query = StringFormat("SELECT gmspeed FROM account WHERE id = '%i'", account_id);
-	auto results = QueryDatabase(query);
-	if (!results.Success()) {
-		return 0;
+	auto a = AccountRepository::FindOne(*this, account_id);
+	if (a.id > 0) {
+		return a.gmspeed;
 	}
 
-    if (results.RowCount() != 1)
-        return 0;
-
-    auto& row = results.begin();
-
-	return atoi(row[0]);
+	return 0;
 }
 
 bool SharedDatabase::SetGMSpeed(uint32 account_id, uint8 gmspeed)
 {
-	const std::string query = StringFormat("UPDATE account SET gmspeed = %i WHERE id = %i", gmspeed, account_id);
-	const auto results = QueryDatabase(query);
-	if (!results.Success()) {
-		return false;
+	auto a = AccountRepository::FindOne(*this, account_id);
+	if (a.id > 0) {
+		a.gmspeed = gmspeed ? 1 : 0;
+		AccountRepository::UpdateOne(*this, a);
 	}
 
-	return true;
+	return a.id > 0;
 }
 
 bool SharedDatabase::SetGMInvul(uint32 account_id, bool gminvul)
 {
-	std::string query = StringFormat("UPDATE account SET gminvul = %i WHERE id = %i", gminvul, account_id);
-	auto results = QueryDatabase(query);
-	if (!results.Success()) {
-		return false;
+	auto a = AccountRepository::FindOne(*this, account_id);
+	if (a.id > 0) {
+		a.invulnerable = gminvul ? 1 : 0;
+		AccountRepository::UpdateOne(*this, a);
 	}
 
-	return true;
+	return a.id > 0;
 }
 
 bool SharedDatabase::SetGMFlymode(uint32 account_id, uint8 flymode)
 {
-	std::string query = StringFormat("UPDATE account SET flymode = %i WHERE id = %i", flymode, account_id);
-	auto results = QueryDatabase(query);
-	if (!results.Success()) {
-		return false;
+	auto a = AccountRepository::FindOne(*this, account_id);
+	if (a.id > 0) {
+		a.flymode = flymode ? 1 : 0;
+		AccountRepository::UpdateOne(*this, a);
 	}
 
-	return true;
+	return a.id > 0;
 }
 
 uint32 SharedDatabase::GetTotalTimeEntitledOnAccount(uint32 AccountID) {

--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -101,6 +101,28 @@ bool SharedDatabase::SetGMSpeed(uint32 account_id, uint8 gmspeed)
 	return true;
 }
 
+bool SharedDatabase::SetGMInvul(uint32 account_id, bool gminvul)
+{
+	std::string query = StringFormat("UPDATE account SET gminvul = %i WHERE id = %i", gminvul, account_id);
+	auto results = QueryDatabase(query);
+	if (!results.Success()) {
+		return false;
+	}
+
+	return true;
+}
+
+bool SharedDatabase::SetGMFlymode(uint32 account_id, uint8 flymode)
+{
+	std::string query = StringFormat("UPDATE account SET flymode = %i WHERE id = %i", flymode, account_id);
+	auto results = QueryDatabase(query);
+	if (!results.Success()) {
+		return false;
+	}
+
+	return true;
+}
+
 uint32 SharedDatabase::GetTotalTimeEntitledOnAccount(uint32 AccountID) {
 	uint32 EntitledTime = 0;
 	const std::string query = StringFormat("SELECT `time_played` FROM `character_data` WHERE `account_id` = %u", AccountID);

--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -111,7 +111,7 @@ bool SharedDatabase::SetGMFlymode(uint32 account_id, uint8 flymode)
 {
 	auto a = AccountRepository::FindOne(*this, account_id);
 	if (a.id > 0) {
-		a.flymode = flymode ? 1 : 0;
+		a.flymode = flymode;
 		AccountRepository::UpdateOne(*this, a);
 	}
 

--- a/common/shareddb.h
+++ b/common/shareddb.h
@@ -79,6 +79,8 @@ public:
 	bool UpdateInjectedCommandSettings(const std::vector<std::pair<std::string, uint8>> &injected);
 	bool UpdateOrphanedCommandSettings(const std::vector<std::string> &orphaned);
 	uint32 GetTotalTimeEntitledOnAccount(uint32 AccountID);
+	bool SetGMInvul(uint32 account_id, bool gminvul);
+	bool SetGMFlymode(uint32 account_id, uint8 flymode);
 	void SetMailKey(int CharID, int IPAddress, int MailKey);
 	std::string GetMailKey(int CharID, bool key_only = false);
 	bool SaveCursor(

--- a/utils/sql/db_update_manifest.txt
+++ b/utils/sql/db_update_manifest.txt
@@ -444,7 +444,7 @@
 9188|2022_07_14_zone_expansion_revert.sql|SHOW COLUMNS FROM `zone` LIKE 'expansion'|empty|
 9189|2022_07_10_character_task_rewarded.sql|SHOW COLUMNS FROM `character_tasks` LIKE 'was_rewarded'|empty|
 9190|2022_07_13_task_reward_points.sql|SHOW COLUMNS FROM `tasks` LIKE 'reward_points'|empty|
-9191|2022_07_28_gm_state_changes.sql|SHOW COLUMNS FROM `account` LIKE `invulnerable`|empty|
+9191|2022_07_28_gm_state_changes.sql|SHOW COLUMNS FROM `account` LIKE 'invulnerable'|empty|
 
 # Upgrade conditions:
 # 	This won't be needed after this system is implemented, but it is used database that are not

--- a/utils/sql/db_update_manifest.txt
+++ b/utils/sql/db_update_manifest.txt
@@ -444,6 +444,7 @@
 9188|2022_07_14_zone_expansion_revert.sql|SHOW COLUMNS FROM `zone` LIKE 'expansion'|empty|
 9189|2022_07_10_character_task_rewarded.sql|SHOW COLUMNS FROM `character_tasks` LIKE 'was_rewarded'|empty|
 9190|2022_07_13_task_reward_points.sql|SHOW COLUMNS FROM `tasks` LIKE 'reward_points'|empty|
+9191|2022_07_28_gm_state_changes.sql|SHOW COLUMNS FROM `account` LIKE `invulnerable`|empty|
 
 # Upgrade conditions:
 # 	This won't be needed after this system is implemented, but it is used database that are not

--- a/utils/sql/git/required/2022_07_28_gm_state_changes.sql
+++ b/utils/sql/git/required/2022_07_28_gm_state_changes.sql
@@ -1,4 +1,4 @@
 ALTER TABLE `account`
     ADD COLUMN `invulnerable` TINYINT(4) NULL DEFAULT '0' AFTER `gmspeed`,
-	ADD COLUMN `flymode` TINYINT(4) NULL DEFAULT '0' AFTER `invulnerable`,
-	ADD COLUMN `ignore_tells` TINYINT(4) NULL DEFAULT '0' AFTER `flymode`;
+    ADD COLUMN `flymode` TINYINT(4) NULL DEFAULT '0' AFTER `invulnerable`,
+    ADD COLUMN `ignore_tells` TINYINT(4) NULL DEFAULT '0' AFTER `flymode`;

--- a/utils/sql/git/required/2022_07_28_gm_state_changes.sql
+++ b/utils/sql/git/required/2022_07_28_gm_state_changes.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `account`
+	ADD COLUMN `gminvul` TINYINT(4) NULL DEFAULT '0' AFTER `ip_exemption_multiplier`,
+	ADD COLUMN `flymode` TINYINT(4) NULL DEFAULT '0' AFTER `gminvul`,
+	ADD COLUMN `ignore_tells` TINYINT(4) NULL DEFAULT '0' AFTER `flymode`;

--- a/utils/sql/git/required/2022_07_28_gm_state_changes.sql
+++ b/utils/sql/git/required/2022_07_28_gm_state_changes.sql
@@ -1,4 +1,4 @@
 ALTER TABLE `account`
-	ADD COLUMN `gminvul` TINYINT(4) NULL DEFAULT '0' AFTER `ip_exemption_multiplier`,
-	ADD COLUMN `flymode` TINYINT(4) NULL DEFAULT '0' AFTER `gminvul`,
+    ADD COLUMN `invulnerable` TINYINT(4) NULL DEFAULT '0' AFTER `gmspeed`,
+	ADD COLUMN `flymode` TINYINT(4) NULL DEFAULT '0' AFTER `invulnerable`,
 	ADD COLUMN `ignore_tells` TINYINT(4) NULL DEFAULT '0' AFTER `flymode`;

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -455,13 +455,10 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 					!cle ||
 					cle->Online() < CLE_Status::Zoning ||
 					(
-						cle->TellsOff() &&
+						cle->TellsOff() && 
 						(
-							(
-								cle->Anon() == 1 &&
-								scm->fromadmin < cle->Admin()
-							) ||
-							scm->fromadmin < AccountStatus::QuestTroupe
+							scm->fromadmin < cle->Admin() 
+							|| scm->fromadmin < AccountStatus::QuestTroupe
 						)
 					)
 				) {

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -455,26 +455,27 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 					!cle ||
 					cle->Online() < CLE_Status::Zoning ||
 					(
-						cle->TellsOff() && 
+						cle->TellsOff() &&
 						(
-							scm->fromadmin < cle->Admin() 
+							scm->fromadmin < cle->Admin()
 							|| scm->fromadmin < AccountStatus::QuestTroupe
 						)
 					)
-				) {
+					) {
 					if (!scm->noreply) {
 						auto sender = client_list.FindCharacter(scm->from);
 						if (!sender || !sender->Server()) {
 							break;
 						}
 
-						scm->noreply = true;
-						scm->queued = 3; // offline
+						scm->noreply  = true;
+						scm->queued   = 3; // offline
 						scm->chan_num = ChatChannel_TellEcho;
 						strcpy(scm->deliverto, scm->from);
 						sender->Server()->SendPacket(pack);
 					}
-				} else if (cle->Online() == CLE_Status::Zoning) {
+				}
+				else if (cle->Online() == CLE_Status::Zoning) {
 					if (!scm->noreply) {
 						auto sender = client_list.FindCharacter(scm->from);
 						if (cle->TellQueueFull()) {

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -3383,20 +3383,21 @@ void Client::SetHideMe(bool gm_hide_me)
 {
 	EQApplicationPacket app;
 
-	if(gm_hide_me) {
-		database.SetHideMe(AccountID(),true);
+	if (gm_hide_me) {
+		database.SetHideMe(AccountID(), true);
 		CreateDespawnPacket(&app, false);
 		entity_list.RemoveFromTargets(this);
 		trackable = false;
-		tellsoff = true;
-	} else {
-		database.SetHideMe(AccountID(),false);
+		tellsoff  = true;
+	}
+	else {
+		database.SetHideMe(AccountID(), false);
 		CreateSpawnPacket(&app);
 		trackable = true;
-		tellsoff = false;
+		tellsoff  = false;
 	}
 
-	entity_list.QueueClientsStatus(this, &app, true, 0, Admin()-1);
+	entity_list.QueueClientsStatus(this, &app, true, 0, Admin() - 1);
 	UpdateWho();
 }
 

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -3398,7 +3398,7 @@ void Client::SetHideMe(bool flag)
 		database.SetHideMe(AccountID(),false);
 		CreateSpawnPacket(&app);
 		trackable = true;
-		tellsoff = true;
+		tellsoff = false;
 	}
 
 	entity_list.QueueClientsStatus(this, &app, true, 0, Admin()-1);

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -3379,22 +3379,17 @@ void Client::SetTint(int16 in_slot, EQ::textures::Tint_Struct& color) {
 
 }
 
-void Client::SetHideMe(bool flag)
+void Client::SetHideMe(bool gm_hide_me)
 {
 	EQApplicationPacket app;
 
-	gm_hide_me = flag;
-
-	if(gm_hide_me)
-	{
+	if(gm_hide_me) {
 		database.SetHideMe(AccountID(),true);
 		CreateDespawnPacket(&app, false);
 		entity_list.RemoveFromTargets(this);
 		trackable = false;
 		tellsoff = true;
-	}
-	else
-	{
+	} else {
 		database.SetHideMe(AccountID(),false);
 		CreateSpawnPacket(&app);
 		trackable = true;

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -220,6 +220,7 @@ Client::Client(EQStreamInterface* ieqs)
 	LFGComments[0] = '\0';
 	LFP = false;
 	gmspeed = 0;
+	gminvul = false;
 	playeraction = 0;
 	SetTarget(0);
 	auto_attack = false;
@@ -3390,15 +3391,18 @@ void Client::SetHideMe(bool flag)
 		CreateDespawnPacket(&app, false);
 		entity_list.RemoveFromTargets(this);
 		trackable = false;
+		tellsoff = true;
 	}
 	else
 	{
 		database.SetHideMe(AccountID(),false);
 		CreateSpawnPacket(&app);
 		trackable = true;
+		tellsoff = true;
 	}
 
 	entity_list.QueueClientsStatus(this, &app, true, 0, Admin()-1);
+	UpdateWho();
 }
 
 void Client::SetLanguageSkill(int langid, int value)
@@ -7092,6 +7096,7 @@ void Client::SendStatsWindow(Client* client, bool use_window)
 	client->Message(Chat::White, " compute_tohit: %i TotalToHit: %i", compute_tohit(skill), GetTotalToHit(skill, 0));
 	client->Message(Chat::White, " compute_defense: %i TotalDefense: %i", compute_defense(), GetTotalDefense());
 	client->Message(Chat::White, " offense: %i mitigation ac: %i", offense(skill), GetMitigationAC());
+	client->Message(Chat::White, " AFK: %i LFG: %i Anon: %i PVP: %i GM: %i Flymode: %i GMSpeed: %i Hideme: %i GMInvul: %d LD: %i ClientVersion: %i TellsOff: %i", AFK, LFG, GetAnon(), GetPVP(), GetGM(), flymode, GetGMSpeed(), GetHideMe(), GetGMInvul(), IsLD(), ClientVersionBit(), tellsoff);
 	if(CalcMaxMana() > 0)
 		client->Message(Chat::White, " Mana: %i/%i  Mana Regen: %i/%i", GetMana(), GetMaxMana(), CalcManaRegen(), CalcManaRegenCap());
 	client->Message(Chat::White, " End.: %i/%i  End. Regen: %i/%i",GetEndurance(), GetMaxEndurance(), CalcEnduranceRegen(), CalcEnduranceRegenCap());

--- a/zone/client.h
+++ b/zone/client.h
@@ -1040,6 +1040,7 @@ public:
 	void SendRules();
 
 	const bool GetGMSpeed() const { return (gmspeed > 0); }
+	const bool GetGMInvul() const { return gminvul; }
 	bool CanUseReport;
 
 	//This is used to later set the buff duration of the spell, in slot to duration.
@@ -1786,6 +1787,7 @@ private:
 	bool auto_fire;
 	bool runmode;
 	uint8 gmspeed;
+	bool gminvul;
 	bool medding;
 	uint16 horseId;
 	bool revoked;

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -571,7 +571,7 @@ void Client::CompleteConnect()
 	//SendAATable();
 
 	if (GetGM() && (GetHideMe() || GetGMSpeed() || GetGMInvul() || flymode != 0 || tellsoff)) {
-		std::vector<std::string> state = {"currently"};
+		std::vector<std::string> state;
 		if (GetHideMe()) {
 			state.emplace_back("hidden to all clients");
 		}
@@ -592,7 +592,7 @@ void Client::CompleteConnect()
 		}
 
 		if (!state.empty()) {
-			Message(Chat::Red, "[GM] You are %s.", Strings::Join(state, ", ").c_str());
+			Message(Chat::Red, "[GM] You are currently %s.", Strings::Join(state, ", ").c_str());
 		}
 	}
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -571,19 +571,28 @@ void Client::CompleteConnect()
 	//SendAATable();
 
 	if (GetGM() && (GetHideMe() || GetGMSpeed() || GetGMInvul() || flymode != 0 || tellsoff)) {
-		std::string state = "currently ";
+		std::vector<std::string> state = {"currently"};
+		if (GetHideMe()) {
+			state.emplace_back("hidden to all clients");
+		}
+		if (GetGMSpeed()) {
+			state.emplace_back("running at GM speed");
+		}
+		if (GetGMInvul()) {
+			state.emplace_back("invulnerable to all damage");
+		}
+		if (flymode == 1) {
+			state.emplace_back("flying");
+		}
+		else if (flymode == 2) {
+			state.emplace_back("levitating");
+		}
+		if (tellsoff) {
+			state.emplace_back("ignoring tells");
+		}
 
-		if (GetHideMe()) state += "hidden to all clients, ";
-		if (GetGMSpeed()) state += "running at GM speed, ";
-		if (GetGMInvul()) state += "invulnerable to all damage, ";
-		if (flymode == 1) state += "flying, ";
-		else if (flymode == 2) state += "levitating, ";
-		if (tellsoff) state += "ignoring tells, ";
-
-		if (state.size () > 0) {
-			//Remove last two characters from the string
-			state.resize (state.size () - 2);
-			Message(Chat::Red, "[GM] You are %s.", state.c_str());
+		if (!state.empty()) {
+			Message(Chat::Red, "[GM] You are %s.", Strings::Join(state, ", ").c_str());
 		}
 	}
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -581,10 +581,10 @@ void Client::CompleteConnect()
 		if (GetGMInvul()) {
 			state.emplace_back("invulnerable to all damage");
 		}
-		if (flymode == 1) {
+		if (flymode == GravityBehavior::Flying) {
 			state.emplace_back("flying");
 		}
-		else if (flymode == 2) {
+		else if (flymode == GravityBehavior::Levitating) {
 			state.emplace_back("levitating");
 		}
 		if (tellsoff) {

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1200,7 +1200,7 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 	database.LoadCharacterFactionValues(cid, factionvalues);
 
 	/* Load Character Account Data: Temp until I move */
-	query = StringFormat("SELECT `status`, `name`, `ls_id`, `lsaccount_id`, `gmspeed`, `revoked`, `hideme`, `time_creation`, `gminvul`, `flymode` FROM `account` WHERE `id` = %u", this->AccountID());
+	query = StringFormat("SELECT `status`, `name`, `ls_id`, `lsaccount_id`, `gmspeed`, `revoked`, `hideme`, `time_creation`, `gminvul`, `flymode` FROM `account` WHERE `id` = %u", AccountID());
 	auto results = database.QueryDatabase(query);
 	for (auto row = results.begin(); row != results.end(); ++row) {
 		admin = atoi(row[0]);

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -166,6 +166,7 @@ int command_init(void)
 		command_add("gm", "[On|Off] - Modify your or your target's GM Flag", AccountStatus::QuestTroupe, command_gm) ||
 		command_add("gmspeed", "[On|Off] - Turn GM Speed On or Off for you or your player target", AccountStatus::GMAdmin, command_gmspeed) ||
 		command_add("gmzone", "[Zone ID|Zone Short Name] [Version] [Instance Identifier] - Zones to a private GM instance (Version defaults to 0 and Instance Identifier defaults to 'gmzone' if not used)", AccountStatus::GMAdmin, command_gmzone) ||
+		command_add("godmode", "[on/off] - Turns on/off hideme, gmspeed, invul, and flymode.", AccountStatus::GMMgmt, command_godmode) ||
 		command_add("goto", "[playername] or [x y z] [h] - Teleport to the provided coordinates or to your target", AccountStatus::Steward, command_goto) ||
 		command_add("grid", "[add/delete] [grid_num] [wandertype] [pausetype] - Create/delete a wandering grid", AccountStatus::GMAreas, command_grid) ||
 		command_add("guild", "Guild manipulation commands. Use argument help for more info.", AccountStatus::Steward, command_guild) ||
@@ -1007,6 +1008,7 @@ void command_bot(Client *c, const Seperator *sep)
 #include "gm_commands/gm.cpp"
 #include "gm_commands/gmspeed.cpp"
 #include "gm_commands/gmzone.cpp"
+#include "gm_commands/godmode.cpp"
 #include "gm_commands/goto.cpp"
 #include "gm_commands/grid.cpp"
 #include "gm_commands/guild.cpp"

--- a/zone/command.h
+++ b/zone/command.h
@@ -105,6 +105,7 @@ void command_globalview(Client *c, const Seperator *sep);
 void command_gm(Client *c, const Seperator *sep);
 void command_gmspeed(Client *c, const Seperator *sep);
 void command_gmzone(Client *c, const Seperator *sep);
+void command_godmode(Client* c, const Seperator *sep);
 void command_goto(Client *c, const Seperator *sep);
 void command_grid(Client *c, const Seperator *sep);
 void command_guild(Client *c, const Seperator *sep);

--- a/zone/gm_commands/flymode.cpp
+++ b/zone/gm_commands/flymode.cpp
@@ -24,6 +24,8 @@ void command_flymode(Client *c, const Seperator *sep)
 
 	target->SetFlyMode(static_cast<GravityBehavior>(flymode_id));
 	target->SendAppearancePacket(AT_Levitate, flymode_id);
+	uint32 account = c->AccountID();
+	database.SetGMFlymode(account, flymode_id);
 	c->Message(
 		Chat::White,
 		fmt::format(

--- a/zone/gm_commands/godmode.cpp
+++ b/zone/gm_commands/godmode.cpp
@@ -1,18 +1,33 @@
 #include "../client.h"
+#include "../../common/repositories/account_repository.h"
 
-void command_godmode(Client *c, const Seperator *sep) {
-	bool state = atobool(sep->arg[1]);
-	uint32 account = c->AccountID();
+void command_godmode(Client *c, const Seperator *sep)
+{
+	bool   state      = atobool(sep->arg[1]);
+	uint32 account_id = c->AccountID();
 
 	if (sep->arg[1][0] != 0) {
+		auto a = AccountRepository::FindOne(database, c->AccountID());
+		if (a.id > 0) {
+			a.flymode      = state ? 1 : 0;
+			a.gmspeed      = state ? 1 : 0;
+			a.invulnerable = state ? 1 : 0;
+			a.hideme       = state ? 1 : 0;
+		}
+
 		c->SetInvul(state);
-		database.SetGMInvul(account, state);
-		database.SetGMSpeed(account, state ? 1 : 0);
 		c->SendAppearancePacket(AT_Levitate, state);
-		database.SetGMFlymode(account, state);
 		c->SetHideMe(state);
-		c->Message(Chat::White, "Turning GodMode %s for %s (zone for gmspeed to take effect)", state ? "On" : "Off", c->GetName());
-	} else {
+		c->Message(
+			Chat::White,
+			"Turning GodMode %s for %s (zone for gmspeed to take effect)",
+			state ? "On" : "Off",
+			c->GetName()
+		);
+
+		AccountRepository::UpdateOne(database, a);
+	}
+	else {
 		c->Message(Chat::White, "Usage: #godmode [on/off]");
 	}
 }

--- a/zone/gm_commands/godmode.cpp
+++ b/zone/gm_commands/godmode.cpp
@@ -1,0 +1,18 @@
+#include "../client.h"
+
+void command_godmode(Client *c, const Seperator *sep) {
+	bool state = atobool(sep->arg[1]);
+	uint32 account = c->AccountID();
+
+	if (sep->arg[1][0] != 0) {
+		c->SetInvul(state);
+		database.SetGMInvul(account, state);
+		database.SetGMSpeed(account, state ? 1 : 0);
+		c->SendAppearancePacket(AT_Levitate, state);
+		database.SetGMFlymode(account, state);
+		c->SetHideMe(state);
+		c->Message(Chat::White, "Turning GodMode %s for %s (zone for gmspeed to take effect)", state ? "On" : "Off", c->GetName());
+	} else {
+		c->Message(Chat::White, "Usage: #godmode [on/off]");
+	}
+}

--- a/zone/gm_commands/invul.cpp
+++ b/zone/gm_commands/invul.cpp
@@ -1,7 +1,6 @@
 #include "../client.h"
 
-void command_invul(Client *c, const Seperator *sep)
-{
+void command_invul(Client *c, const Seperator *sep) {
 	int arguments = sep->argnum;
 	if (!arguments) {
 		c->Message(Chat::White, "Usage: #invul [On|Off]");
@@ -15,6 +14,8 @@ void command_invul(Client *c, const Seperator *sep)
 	}
 
 	target->SetInvul(invul_flag);
+	uint32 account = target->AccountID();
+	database.SetGMInvul(account, invul_flag);
 	c->Message(
 		Chat::White,
 		fmt::format(
@@ -25,4 +26,3 @@ void command_invul(Client *c, const Seperator *sep)
 		).c_str()
 	);
 }
-

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -1959,7 +1959,7 @@ bool Client::SwapItem(MoveItem_Struct* move_in) {
 
 	// Check for No Drop Hacks
 	Mob* with = trade->With();
-	if (((with && with->IsClient() && dst_slot_id >= EQ::invslot::TRADE_BEGIN && dst_slot_id <= EQ::invslot::TRADE_END) ||
+	if (((with && with->IsClient() && !with->CastToClient()->IsBecomeNPC() && dst_slot_id >= EQ::invslot::TRADE_BEGIN && dst_slot_id <= EQ::invslot::TRADE_END) ||
 		(dst_slot_id >= EQ::invslot::SHARED_BANK_BEGIN && dst_slot_id <= EQ::invbag::SHARED_BANK_BAGS_END))
 	&& GetInv().CheckNoDrop(src_slot_id)
 	&& !CanTradeFVNoDropItem()) {


### PR DESCRIPTION
- Flymode and Invulnerable will now persist over zoning.
- Appended GMSpeed, Flymode and Invulnerable to the hideme message GMs see when they first login.
- Added #godmode [on/off] command to turn on or off hideme, flymode, gmspeed and invulnerable all in one shot.
- /becomenpc will now disable tells to the target player. It will also automatically disable GM States that interfere with its functionality.
- GM Command /toggle will not properly turn tells on/off
- GMs will now be notified if they are ignoring tells when they first zone-in, provided their GM flag is up.
- Added TellsOff variable to the output to #showstats