### PR TITLE
[Quest API] Use Floating Point for CameraEffect Intensity

### DIFF
--- a/common/eq_packet_structs.h
+++ b/common/eq_packet_structs.h
@@ -2204,7 +2204,7 @@ struct CashReward_Struct
 struct Camera_Struct
 {
 	uint32	duration;	// Duration in ms
-	uint32	intensity;	// Between 1023410176 and 1090519040
+	float intensity;
 };
 
 struct ZonePoint_Entry {

--- a/common/servertalk.h
+++ b/common/servertalk.h
@@ -1284,7 +1284,7 @@ struct ServerLeaderboardRequest_Struct
 struct ServerCameraShake_Struct
 {
 	uint32 duration; // milliseconds
-	uint32 intensity; // number from 1-10
+	float intensity;
 };
 
 struct ServerMailMessageHeader_Struct {

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -5401,12 +5401,12 @@ void EntityList::AddLootToNPCS(uint32 item_id, uint32 count)
 	safe_delete_array(marked);
 }
 
-void EntityList::CameraEffect(uint32 duration, uint32 intensity)
+void EntityList::CameraEffect(uint32 duration, float intensity)
 {
 	auto outapp = new EQApplicationPacket(OP_CameraEffect, sizeof(Camera_Struct));
 	Camera_Struct* cs = (Camera_Struct*) outapp->pBuffer;
 	cs->duration = duration;	// Duration in milliseconds
-	cs->intensity = ((intensity * 6710886) + 1023410176);	// Intensity ranges from 1023410176 to 1090519040, so simplify it from 0 to 10.
+	cs->intensity = intensity;
 	entity_list.QueueClients(0, outapp);
 	safe_delete(outapp);
 }

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -486,7 +486,7 @@ public:
 	Corpse* GetClosestCorpse(Mob* sender, const char *Name);
 	void	TryWakeTheDead(Mob* sender, Mob* target, int32 spell_id, uint32 max_distance, uint32 duration, uint32 amount_pets);
 	NPC* GetClosestBanker(Mob* sender, uint32 &distance);
-	void	CameraEffect(uint32 duration, uint32 intensity);
+	void	CameraEffect(uint32 duration, float intensity);
 	Mob*	GetClosestMobByBodyType(Mob* sender, bodyType BodyType, bool skip_client_pets=false);
 	void	ForceGroupUpdate(uint32 gid);
 	void	SendGroupLeave(uint32 gid, const char *name);

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -1810,17 +1810,17 @@ void Lua_Mob::ChangeDrakkinDetails(int in) {
 	self->ChangeDrakkinDetails(in);
 }
 
-void Lua_Mob::CameraEffect(uint32 duration, uint32 intensity) {
+void Lua_Mob::CameraEffect(uint32 duration, float intensity) {
 	Lua_Safe_Call_Void();
 	self->CameraEffect(duration, intensity);
 }
 
-void Lua_Mob::CameraEffect(uint32 duration, uint32 intensity, Lua_Client c) {
+void Lua_Mob::CameraEffect(uint32 duration, float intensity, Lua_Client c) {
 	Lua_Safe_Call_Void();
 	self->CameraEffect(duration, intensity, c);
 }
 
-void Lua_Mob::CameraEffect(uint32 duration, uint32 intensity, Lua_Client c, bool global) {
+void Lua_Mob::CameraEffect(uint32 duration, float intensity, Lua_Client c, bool global) {
 	Lua_Safe_Call_Void();
 	self->CameraEffect(duration, intensity, c, global);
 }
@@ -2505,9 +2505,9 @@ luabind::scope lua_register_mob() {
 	.def("BuffFadeBySpellID", (void(Lua_Mob::*)(int))&Lua_Mob::BuffFadeBySpellID)
 	.def("CalculateDistance", (float(Lua_Mob::*)(double,double,double))&Lua_Mob::CalculateDistance)
 	.def("CalculateHeadingToTarget", (double(Lua_Mob::*)(double,double))&Lua_Mob::CalculateHeadingToTarget)
-	.def("CameraEffect", (void(Lua_Mob::*)(uint32,uint32))&Lua_Mob::CameraEffect)
-	.def("CameraEffect", (void(Lua_Mob::*)(uint32,uint32,Lua_Client))&Lua_Mob::CameraEffect)
-	.def("CameraEffect", (void(Lua_Mob::*)(uint32,uint32,Lua_Client,bool))&Lua_Mob::CameraEffect)
+	.def("CameraEffect", (void(Lua_Mob::*)(uint32,float))&Lua_Mob::CameraEffect)
+	.def("CameraEffect", (void(Lua_Mob::*)(uint32,float,Lua_Client))&Lua_Mob::CameraEffect)
+	.def("CameraEffect", (void(Lua_Mob::*)(uint32,float,Lua_Client,bool))&Lua_Mob::CameraEffect)
 	.def("CanBuffStack", (int(Lua_Mob::*)(int,int))&Lua_Mob::CanBuffStack)
 	.def("CanBuffStack", (int(Lua_Mob::*)(int,int,bool))&Lua_Mob::CanBuffStack)
 	.def("CanClassEquipItem", &Lua_Mob::CanClassEquipItem)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -347,9 +347,9 @@ public:
 	void ChangeDrakkinHeritage(int in);
 	void ChangeDrakkinTattoo(int in);
 	void ChangeDrakkinDetails(int in);
-	void CameraEffect(uint32 duration, uint32 intensity);
-	void CameraEffect(uint32 duration, uint32 intensity, Lua_Client c);
-	void CameraEffect(uint32 duration, uint32 intensity, Lua_Client c, bool global);
+	void CameraEffect(uint32 duration, float intensity);
+	void CameraEffect(uint32 duration, float intensity, Lua_Client c);
+	void CameraEffect(uint32 duration, float intensity, Lua_Client c, bool global);
 	void SendSpellEffect(uint32 effect_id, uint32 duration, uint32 finish_delay, bool zone_wide,
 		uint32 unk020);
 	void SendSpellEffect(uint32 effect_id, uint32 duration, uint32 finish_delay, bool zone_wide,

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -3149,7 +3149,7 @@ void Mob::SendTargetable(bool on, Client *specific_target) {
 	safe_delete(outapp);
 }
 
-void Mob::CameraEffect(uint32 duration, uint32 intensity, Client *c, bool global) {
+void Mob::CameraEffect(uint32 duration, float intensity, Client *c, bool global) {
 
 
 	if(global == true)
@@ -3166,7 +3166,7 @@ void Mob::CameraEffect(uint32 duration, uint32 intensity, Client *c, bool global
 	auto outapp = new EQApplicationPacket(OP_CameraEffect, sizeof(Camera_Struct));
 	Camera_Struct* cs = (Camera_Struct*) outapp->pBuffer;
 	cs->duration = duration;	// Duration in milliseconds
-	cs->intensity = ((intensity * 6710886) + 1023410176);	// Intensity ranges from 1023410176 to 1090519040, so simplify it from 0 to 10.
+	cs->intensity = intensity;
 
 	if(c)
 		c->QueuePacket(outapp, false, Client::CLIENT_CONNECTED);

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -732,7 +732,7 @@ public:
 	std::string GetMobDescription();
 
 	//Quest
-	void CameraEffect(uint32 duration, uint32 intensity, Client *c = nullptr, bool global = false);
+	void CameraEffect(uint32 duration, float intensity, Client *c = nullptr, bool global = false);
 	inline bool GetQglobal() const { return qglobal; }
 
 	//Other Packet

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -1851,20 +1851,20 @@ void Perl_Mob_SendIllusion(Mob* self, uint16 race, uint8 gender, uint8 texture, 
 
 void Perl_Mob_CameraEffect(Mob* self, uint32 duration) // @categories Script Utility
 {
-	self->CameraEffect(duration, 0);
+	self->CameraEffect(duration, 0.03125f);
 }
 
-void Perl_Mob_CameraEffect(Mob* self, uint32 duration, uint32 intensity) // @categories Script Utility
+void Perl_Mob_CameraEffect(Mob* self, uint32 duration, float intensity) // @categories Script Utility
 {
 	self->CameraEffect(duration, intensity);
 }
 
-void Perl_Mob_CameraEffect(Mob* self, uint32 duration, uint32 intensity, Client* client) // @categories Script Utility
+void Perl_Mob_CameraEffect(Mob* self, uint32 duration, float intensity, Client* client) // @categories Script Utility
 {
 	self->CameraEffect(duration, intensity, client);
 }
 
-void Perl_Mob_CameraEffect(Mob* self, uint32 duration, uint32 intensity, perl::nullable<Client*> client, bool global) // @categories Script Utility
+void Perl_Mob_CameraEffect(Mob* self, uint32 duration, float intensity, perl::nullable<Client*> client, bool global) // @categories Script Utility
 {
 	self->CameraEffect(duration, intensity, client.get(), global);
 }
@@ -2490,9 +2490,9 @@ void perl_register_mob()
 	package.add("CalculateDistance", &Perl_Mob_CalculateDistance);
 	package.add("CalculateHeadingToTarget", &Perl_Mob_CalculateHeadingToTarget);
 	package.add("CameraEffect", (void(*)(Mob*, uint32))&Perl_Mob_CameraEffect);
-	package.add("CameraEffect", (void(*)(Mob*, uint32, uint32))&Perl_Mob_CameraEffect);
-	package.add("CameraEffect", (void(*)(Mob*, uint32, uint32, Client*))&Perl_Mob_CameraEffect);
-	package.add("CameraEffect", (void(*)(Mob*, uint32, uint32, perl::nullable<Client*>, bool))&Perl_Mob_CameraEffect);
+	package.add("CameraEffect", (void(*)(Mob*, uint32, float))&Perl_Mob_CameraEffect);
+	package.add("CameraEffect", (void(*)(Mob*, uint32, float, Client*))&Perl_Mob_CameraEffect);
+	package.add("CameraEffect", (void(*)(Mob*, uint32, float, perl::nullable<Client*>, bool))&Perl_Mob_CameraEffect);
 	package.add("CanBuffStack", (bool(*)(Mob*, uint16, uint8))&Perl_Mob_CanBuffStack);
 	package.add("CanBuffStack", (bool(*)(Mob*, uint16, uint8, bool))&Perl_Mob_CanBuffStack);
 	package.add("CanClassEquipItem", &Perl_Mob_CanClassEquipItem);


### PR DESCRIPTION
This was implemented in a very odd way. The intensity is just a float.

This is a breaking api change but low-impact (intensity will be
different).

To convert old values to new values with same intensity:

  0: 0.03125
  1: 0.05625
  2: 0.1
  3: 0.175
  4: 0.3
  5: 0.5
  6: 0.9
  7: 1.6
  8: 2.8
  9: 4.8
 10: 8.0