### PR TITLE
[Shared Tasks] Cleanup shared task request and remove

### DIFF
--- a/common/shared_tasks.cpp
+++ b/common/shared_tasks.cpp
@@ -52,21 +52,22 @@ void SharedTask::SetDbSharedTask(const SharedTasksRepository::SharedTasks &m_db_
 	SharedTask::m_db_shared_task = m_db_shared_task;
 }
 
-SharedTaskRequestCharacters SharedTask::GetRequestCharacters(Database &db, uint32_t requested_character_id)
+SharedTaskRequest SharedTask::GetRequestCharacters(Database &db, uint32_t requested_character_id)
 {
-	SharedTaskRequestCharacters request{};
+	// todo: group/raid refactors to check online members without querying
+	SharedTaskRequest request{};
 
 	request.group_type = SharedTaskRequestGroupType::Group;
-	request.characters = CharacterDataRepository::GetWhere(
+	auto characters = CharacterDataRepository::GetWhere(
 		db, fmt::format(
 			"id IN (select charid from group_id where groupid = (select groupid from group_id where charid = {}))",
 			requested_character_id
 		)
 	);
 
-	if (request.characters.empty()) {
+	if (characters.empty()) {
 		request.group_type = SharedTaskRequestGroupType::Raid;
-		request.characters = CharacterDataRepository::GetWhere(
+		characters = CharacterDataRepository::GetWhere(
 			db, fmt::format(
 				"id IN (select charid from raid_members where raidid = (select raidid from raid_members where charid = {}))",
 				requested_character_id
@@ -74,10 +75,10 @@ SharedTaskRequestCharacters SharedTask::GetRequestCharacters(Database &db, uint3
 		);
 	}
 
-	if (request.characters.empty()) // solo request
+	if (characters.empty()) // solo request
 	{
 		request.group_type = SharedTaskRequestGroupType::Solo;
-		request.characters = CharacterDataRepository::GetWhere(
+		characters = CharacterDataRepository::GetWhere(
 			db, fmt::format(
 				"id = {} LIMIT 1",
 				requested_character_id
@@ -85,12 +86,24 @@ SharedTaskRequestCharacters SharedTask::GetRequestCharacters(Database &db, uint3
 		);
 	}
 
+	request.leader_id     = requested_character_id;
 	request.lowest_level  = std::numeric_limits<uint8_t>::max();
 	request.highest_level = 0;
-	for (const auto &character: request.characters) {
+	request.members.reserve(characters.size());
+	for (const auto& character: characters)
+	{
 		request.lowest_level  = std::min(request.lowest_level, character.level);
 		request.highest_level = std::max(request.highest_level, character.level);
 		request.character_ids.emplace_back(character.id); // convenience
+
+		SharedTaskMember member = {};
+		member.character_id   = character.id;
+		member.character_name = character.name;
+		if (character.id == requested_character_id)
+		{
+			member.is_leader = true;
+		}
+		request.members.emplace_back(member);
 	}
 
 	return request;

--- a/common/shared_tasks.h
+++ b/common/shared_tasks.h
@@ -16,7 +16,7 @@
 #define ServerOP_SharedTaskAddPlayer                0x0301 // bidirectional. /taskaddplayer request zone -> world. success world -> zone
 #define ServerOP_SharedTaskMakeLeader               0x0302 // zone -> world -> zone
 #define ServerOP_SharedTaskRemovePlayer             0x0303 // zone -> world -> zone
-#define ServerOP_SharedTaskAttemptRemove            0x0304 // zone -> world. Player trying to delete task
+#define ServerOP_SharedTaskQuit                     0x0304 // zone -> world. Player trying to delete task
 #define ServerOP_SharedTaskUpdate                   0x0305 // zone -> world. Client sending task update to world. Relayed world -> zone on confirmation
 #define ServerOP_SharedTaskMemberlist               0x0306 // world -> zone. Send shared task memberlist
 #define ServerOP_SharedTaskRequestMemberlist        0x0307 // zone -> world. Send shared task memberlist (zone in initial for now, could change)
@@ -55,11 +55,11 @@ struct ServerSharedTaskInvitePlayer_Struct {
 	char   inviter_name[64];
 };
 
-// ServerOP_SharedTaskAttemptRemove
+// ServerOP_SharedTaskQuit
 // gets re-used when sent back to clients
-struct ServerSharedTaskAttemptRemove_Struct {
+struct ServerSharedTaskQuit_Struct {
 	uint32 requested_character_id;
-	uint32 requested_task_id;
+	uint32 task_id;
 	bool   remove_from_db;
 };
 
@@ -77,12 +77,13 @@ struct SharedTaskMember {
 };
 
 // used in shared task requests to validate group/raid members
-struct SharedTaskRequestCharacters {
+struct SharedTaskRequest {
 	int  lowest_level;
 	int  highest_level;
+	uint32_t leader_id;
 	SharedTaskRequestGroupType group_type;
 	std::vector<uint32_t> character_ids;
-	std::vector<CharacterDataRepository::CharacterData> characters;
+	std::vector<SharedTaskMember> members;
 };
 
 // ServerOP_SharedTaskMemberlist
@@ -174,7 +175,7 @@ struct ServerSharedTaskLock_Struct {
 class SharedTask {
 public:
 	// used in both zone and world validation
-	static SharedTaskRequestCharacters GetRequestCharacters(Database& db, uint32_t requested_character_id);
+	static SharedTaskRequest GetRequestCharacters(Database& db, uint32_t requested_character_id);
 
 	void AddCharacterToMemberHistory(uint32_t character_id);
 	SharedTaskMember FindMemberFromCharacterID(uint32_t character_id) const;

--- a/common/tasks.h
+++ b/common/tasks.h
@@ -344,15 +344,15 @@ namespace Tasks {
 	}
 }
 
-namespace SharedTaskMessage {
-	constexpr uint16 TASK_ASSIGN_WAIT_REPLAY_TIMER                     = 8017; // This task can not be assigned to you because you must wait %1d:%2h:%3m before you can do another task of this type.
+namespace TaskStr {
+	constexpr uint16 ASSIGN_REPLAY_TIMER                               = 8017; // This task can not be assigned to you because you must wait %1d:%2h:%3m before you can do another task of this type.
 	constexpr uint16 COULD_NOT_USE_COMMAND                             = 8272; // You could not use this command because you are not currently assigned to a shared task.
-	constexpr uint16 AVG_LVL_LOW                                       = 8553; // You can not be assigned this shared task because your party's average level is too low.
-	constexpr uint16 AVG_LVL_HIGH                                      = 8889; // You can not be assigned this shared task because your party's average level is too high.
+	constexpr uint16 LVL_TOO_LOW                                       = 8553; // You can not be assigned this shared task because your party's average level is too low.
+	constexpr uint16 LVL_TOO_HIGH                                      = 8889; // You can not be assigned this shared task because your party's average level is too high.
 	constexpr uint16 LVL_SPREAD_HIGH                                   = 8890; // You can not be assigned this shared task because your party's level spread is too high.
-	constexpr uint16 PARTY_EXCEED_MAX_PLAYER                           = 8891; // You can not be assigned this shared task because your party exceeds the maximum allowed number of players.
+	constexpr uint16 MAX_PLAYERS                                       = 8891; // You can not be assigned this shared task because your party exceeds the maximum allowed number of players.
 	constexpr uint16 LEADER_NOT_MEET_REQUIREMENTS                      = 8892; // You can not be assigned this shared task because the leader does not meet the shared task requirements.
-	constexpr uint16 SHARED_TASK_NOT_MEET_MIN_NUM_PLAYER               = 8895; // You can not be assigned this shared task because your party does not contain the minimum required number of players.
+	constexpr uint16 MIN_PLAYERS                                       = 8895; // You can not be assigned this shared task because your party does not contain the minimum required number of players.
 	constexpr uint16 WILL_REMOVE_ZONE_TWO_MIN_RAID_NOT_MIN_NUM_PLAYER  = 8908; // %1 will be removed from their zone in two minutes because your raid does not meet the minimum requirement of qualified players.
 	constexpr uint16 WILL_REMOVE_ZONE_TWO_MIN_GROUP_NOT_MIN_NUM_PLAYER = 8909; // %1 will be removed from their zone in two minutes because your group does not meet the minimum requirement of qualified players.
 	constexpr uint16 WILL_REMOVE_AREA_TWO_MIN_RAID_NOT_MIN_NUM_PLAYER  = 8910; // %1 will be removed from their area in two minutes because your raid does not meet the minimum requirement of qualified players.
@@ -363,12 +363,12 @@ namespace SharedTaskMessage {
 	constexpr uint16 HAS_REMOVED_AREA_TWO_MIN_GROUP_NOT_MIN_NUM_PLAYER = 8915; // %1 has been removed from their area because your group does not meet the minimum requirement of qualified players.
 	constexpr uint16 SEND_INVITE_TO                                    = 8916; // Sending a shared task invitation to %1.
 	constexpr uint16 COULD_NOT_BE_INVITED                              = 8917; // %1 could not be invited to join you.
-	constexpr uint16 YOU_ARE_NOT_LEADER_COMMAND_ISSUE                  = 8919; // You are not the shared task leader.  Only %1 can issue this command.
+	constexpr uint16 NOT_LEADER                                        = 8919; // You are not the shared task leader.  Only %1 can issue this command.
 	constexpr uint16 SWAP_SENDING_INVITATION_TO                        = 8920; // Sending an invitation to: %1.  They must accept in order to swap party members.
 	constexpr uint16 SWAP_ACCEPTED_OFFER                               = 8921; // %1 has accepted your offer to join your shared task.  Swapping %1 for %2.
 	constexpr uint16 IS_NOT_MEMBER                                     = 8922; // %1 is not a member of this shared task.
 	constexpr uint16 NOT_ALLOW_PLAYER_REMOVE                           = 8923; // The shared task is not allowing players to be removed from it at this time.
-	constexpr uint16 PLAYER_HAS_BEEN_REMOVED                           = 8924; // %1 has been removed from your shared task, '%2'.
+	constexpr uint16 PLAYER_REMOVED                                    = 8924; // %1 has been removed from your shared task, '%2'.
 	constexpr uint16 TRANSFER_LEADERSHIP_NOT_ONLINE                    = 8925; // %1 is not currently online.  You can only transfer leadership to an online member of the shared task.
 	constexpr uint16 MADE_LEADER                                       = 8926; // %1 has been made the leader for this shared task.
 	constexpr uint16 YOU_MADE_LEADER                                   = 8927; // You have been made the leader of this shared task.
@@ -376,43 +376,43 @@ namespace SharedTaskMessage {
 	constexpr uint16 MEMBERS_PRINT                                     = 8929; // Shared Task Members: %1
 	constexpr uint16 PLAYER_ACCEPTED_OFFER_JOIN                        = 8930; // %1 has accepted your offer to join your shared task.
 	constexpr uint16 PLAYER_HAS_BEEN_ADDED                             = 8931; // %1 has been added to your shared task, '%2'.
-	constexpr uint16 ACCEPTED_OFFER_TO_JOIN_BUT_COULD_NOT              = 8932; // %1 accepted your offer to join your shared task but could not.
+	constexpr uint16 COULD_NOT_JOIN                                    = 8932; // %1 accepted your offer to join your shared task but could not.
 	constexpr uint16 PLAYER_DECLINED_OFFER                             = 8933; // %1 has declined your offer to join your shared task.
 	constexpr uint16 PLAYER_HAS_ASKED_YOU_TO_JOIN                      = 8934; // %1 has asked you to join the shared task '%2'.        Would you like to join?
-	constexpr uint16 NO_REQUEST_BECAUSE_HAVE_ONE                       = 8935; // You may not request a shared task because you already have one.
-	constexpr uint16 NO_REQUEST_BECAUSE_RAID_HAS_ONE                   = 8936; // You may not request a shared task because someone in your raid, %1, already has one.
-	constexpr uint16 NO_REQUEST_BECAUSE_GROUP_HAS_ONE                  = 8937; // You may not request a shared task because someone in your group, %1, already has one.
-	constexpr uint16 YOU_DO_NOT_MEET_REQ_AVAILABLE                     = 8938; // You do not meet the requirements for any available shared tasks.
+	constexpr uint16 REQUEST_HAVE                                      = 8935; // You may not request a shared task because you already have one.
+	constexpr uint16 REQUEST_RAID_HAS                                  = 8936; // You may not request a shared task because someone in your raid, %1, already has one.
+	constexpr uint16 REQUEST_GROUP_HAS                                 = 8937; // You may not request a shared task because someone in your group, %1, already has one.
+	constexpr uint16 NOT_MEET_REQ                                      = 8938; // You do not meet the requirements for any available shared tasks.
 	constexpr uint16 YOUR_RAID_DOES_NOT_MEET_REQ                       = 8939; // Your raid does not meet the requirements for any available shared tasks.
 	constexpr uint16 YOUR_GROUP_DOES_NOT_MEET_REQ                      = 8940; // Your group does not meet the requirements for any available shared tasks.
 	constexpr uint16 YOUR_GROUP__RAID_DOES_NOT_MEET_REQ                = 8941; // You can not be assigned this shared task because the raid or group does not meet the shared task requirements.
-	constexpr uint16 YOU_NO_LONGER_MEMBER                              = 8942; // You are no longer a member of the shared task.
+	constexpr uint16 NO_LONGER_MEMBER                                  = 8942; // You are no longer a member of the shared task.
 	constexpr uint16 YOU_MAY_NOT_REQUEST_EXPANSION                     = 8943; // You may not request this shared task because you do not have the required expansion.
 	constexpr uint16 PLAYER_MAY_NOT_REQUEST_EXPANSION                  = 8944; // You may not request this shared task because %1 does not have the required expansion.
 	constexpr uint16 TWO_MIN_REQ_TASK_TERMINATED                       = 8945; // If your party does not meet the requirements in two minutes, the shared task will be terminated.
-	constexpr uint16 YOU_MUST_WAIT_REPLAY_TIMER                        = 8946; // You may not request this shared task because you must wait %1d:%2h:%3m before you can do another task of this type.
-	constexpr uint16 PLAYER_MUST_WAIT_REPLAY_TIMER                     = 8947; // You may not request this shared task because %1 must wait %2d:%3h:%4m before they can do another task of this type.
+	constexpr uint16 YOU_REPLAY_TIMER                                  = 8946; // You may not request this shared task because you must wait %1d:%2h:%3m before you can do another task of this type.
+	constexpr uint16 PLAYER_REPLAY_TIMER                               = 8947; // You may not request this shared task because %1 must wait %2d:%3h:%4m before they can do another task of this type.
 	constexpr uint16 PLAYER_NOW_LEADER                                 = 8948; // %1 is now the leader of your shared task, '%2'.
 	constexpr uint16 HAS_ENDED                                         = 8951; // Your shared task, '%1', has ended.
 	constexpr uint16 YOU_ALREADY_LEADER                                = 8952; // You are already the leader of the shared task.
 	constexpr uint16 TASK_NO_LONGER_ACTIVE                             = 8953; // Your shared task, '%1', is no longer active.
 	constexpr uint16 YOU_HAVE_BEEN_ADDED_TO_TASK                       = 8954; // You have been added to the shared task '%1'.
 	constexpr uint16 YOU_ARE_NOW_LEADER                                = 8955; // You are now the leader of your shared task, '%1'.
-	constexpr uint16 YOU_HAVE_BEEN_REMOVED                             = 8956; // You have been removed from the shared task '%1'.
-	constexpr uint16 YOU_ARE_NO_LONGER_A_MEMBER                        = 8960; // You are no longer a member of the shared task, '%1'.
-	constexpr uint16 YOUR_TASK_NOW_LOCKED                              = 8961; // Your shared task is now locked.  You may no longer add or remove players.
-	constexpr uint16 TASK_NOT_ALLOWING_PLAYERS_AT_TIME                 = 8962; // The shared task is not allowing players to be added at this time.
-	constexpr uint16 PLAYER_NOT_ONLINE_TO_ADD                          = 8963; // %1 is not currently online.  A player needs to be online to be added to a shared task.
-	constexpr uint16 CANT_ADD_PLAYER_ALREADY_MEMBER                    = 8964; // You can not add %1 because they are already a member of this shared task.
-	constexpr uint16 CANT_ADD_PLAYER_ALREADY_ASSIGNED                  = 8965; // You can not add %1 because they are already assigned to another shared task.
-	constexpr uint16 PLAYER_ALREADY_OUTSTANDING_INVITATION_THIS        = 8966; // %1 already has an outstanding invitation to join this shared task.
-	constexpr uint16 PLAYER_ALREADY_OUTSTANDING_ANOTHER                = 8967; // %1 already has an outstanding invitation to join another shared task.  Players may only have one invitation outstanding.
-	constexpr uint16 CANT_ADD_PLAYER_MAX_PLAYERS                       = 8968; // You can not add another player since you currently have the maximum number of players allowed (%1) in this shared task.
-	constexpr uint16 CANT_ADD_PLAYER_MAX_LEVEL_SPREAD                  = 8969; // You can not add this player because you would exceed the maximum level spread (%1) for this shared task.
-	constexpr uint16 CANT_ADD_PLAYER_MAX_AVERAGE_LEVEL                 = 8970; // You can not add this player because you would exceed the maximum average level for this shared task.
-	constexpr uint16 CANT_ADD_PLAYER_FALL_MIN_AVG_LEVEL                = 8971; // You can not add this player because you would fall below the minimum average level for this shared task.
+	constexpr uint16 YOU_REMOVED                                       = 8956; // You have been removed from the shared task '%1'.
+	constexpr uint16 NO_LONGER_MEMBER_TITLE                            = 8960; // You are no longer a member of the shared task, '%1'.
+	constexpr uint16 TASK_LOCKED                                       = 8961; // Your shared task is now locked.  You may no longer add or remove players.
+	constexpr uint16 NOT_ALLOWING_PLAYERS                              = 8962; // The shared task is not allowing players to be added at this time.
+	constexpr uint16 PLAYER_NOT_ONLINE                                 = 8963; // %1 is not currently online.  A player needs to be online to be added to a shared task.
+	constexpr uint16 PLAYER_ALREADY_MEMBER                             = 8964; // You can not add %1 because they are already a member of this shared task.
+	constexpr uint16 PLAYER_ALREADY_ASSIGNED                           = 8965; // You can not add %1 because they are already assigned to another shared task.
+	constexpr uint16 PLAYER_INVITED                                    = 8966; // %1 already has an outstanding invitation to join this shared task.
+	constexpr uint16 PLAYER_INVITED_OTHER                              = 8967; // %1 already has an outstanding invitation to join another shared task.  Players may only have one invitation outstanding.
+	constexpr uint16 CANT_ADD_MAX_PLAYERS                              = 8968; // You can not add another player since you currently have the maximum number of players allowed (%1) in this shared task.
+	constexpr uint16 CANT_ADD_LVL_SPREAD                               = 8969; // You can not add this player because you would exceed the maximum level spread (%1) for this shared task.
+	constexpr uint16 CANT_ADD_MAX_LEVEL                                = 8970; // You can not add this player because you would exceed the maximum average level for this shared task.
+	constexpr uint16 CANT_ADD_MIN_LEVEL                                = 8971; // You can not add this player because you would fall below the minimum average level for this shared task.
 	constexpr uint16 PLAYER_DOES_NOT_OWN_EXPANSION                     = 8972; // %1 does not own the expansion needed for this shared task.
-	constexpr uint16 CANT_ADD_PLAYER_PARTY_FILTER_REQ_FOR_TASK         = 8973; // You can not add this player because your party would no longer meet the filter requirements for this shared task.
+	constexpr uint16 CANT_ADD_FILTER_REQS                              = 8973; // You can not add this player because your party would no longer meet the filter requirements for this shared task.
 	constexpr uint16 CANT_ADD_PLAYER_ONE_OF_GROUP_RAID_HAS_TASK        = 8977; // You can not add %1 because they or one of their group or raid members is in another shared task.
 	constexpr uint16 CANT_JOIN_GROUP_ACTIVE_TASK                       = 8978; // You can not join that group because you have an active shared task.
 	constexpr uint16 CANT_ADD_PLAYER_REPLAY_TIMER                      = 8979; // You may not add %1 because they must wait %2d:%3h:%4m before they can do another task of this type.
@@ -423,40 +423,48 @@ namespace SharedTaskMessage {
 	constexpr uint16 PLAYER_CANT_ADD_RAID_BECAUSE_DIFF_TASK            = 8984; // %1 can not be added to the raid because they are in a different shared task.
 	constexpr uint16 YOU_CANT_ADD_RAID_BECAUSE_DIFF_TASK               = 8985; // You can not be added to the raid because you are in a different shared task.
 	constexpr uint16 REPLAY_TIMER_REMAINING                            = 8987; // '%1' replay timer:  %2d:%3h:%4m remaining.
-	constexpr uint16 YOU_NO_CURRENT_REPLAY_TIMERS                      = 8989; // You do not currently have any task replay timers.
+	constexpr uint16 NO_REPLAY_TIMERS                                  = 8989; // You do not currently have any task replay timers.
 	constexpr uint16 SURE_QUIT_TASK                                    = 8995; // Are you sure you want to quit the task '%1'?
 	constexpr uint16 SURE_REMOVE_SELF_FROM_TASK                        = 8996; // Are you sure you want to remove yourself from the shared task '%1'
-	constexpr uint16 TASK_ASSIGN_WAIT_REQUEST_TIMER                    = 14506; // This task can not be assigned to you because you must wait %1d:%2h:%3m before you can request another task of this type.
+	constexpr uint16 ASSIGN_REQUEST_TIMER                              = 14506; // This task can not be assigned to you because you must wait %1d:%2h:%3m before you can request another task of this type.
 	constexpr uint16 REQUEST_TIMER_REMAINING                           = 14507; // '%1' request timer:  %2d:%3h:%4m remaining.
-	constexpr uint16 YOU_MUST_WAIT_REQUEST_TIMER                       = 14508; // You may not request this shared task because you must wait %1d:%2h:%3m before you can request another task of this type.
+	constexpr uint16 YOU_REQUEST_TIMER                                 = 14508; // You may not request this shared task because you must wait %1d:%2h:%3m before you can request another task of this type.
 	constexpr uint16 RECEIVED_REQUEST_TIMER                            = 14509; // You have received a request timer for '%1': %2d:%3h:%4m remaining.
 	constexpr uint16 RECEIVED_REPLAY_TIMER                             = 14510; // You have received a replay timer for '%1': %2d:%3h:%4m remaining.
-	constexpr uint16 PLAYER_MUST_WAIT_REQUEST_TIMER                    = 14511; // You may not request this shared task because %1 must wait %2d:%3h:%4m before they can request another task of this type.
+	constexpr uint16 PLAYER_REQUEST_TIMER                              = 14511; // You may not request this shared task because %1 must wait %2d:%3h:%4m before they can request another task of this type.
 	constexpr uint16 CANT_ADD_PLAYER_REQUEST_TIMER                     = 14512; // You may not add %1 because they must wait %2d:%3h:%4m before they can request another task of this type.
 
 	// for eqstrs not in current emu clients (some are also used by non-shared tasks)
-	constexpr auto GetEQStr(uint16 eqstr_id)
+	constexpr auto Get(uint16 eqstr_id)
 	{
 		switch (eqstr_id)
 		{
-		case SharedTaskMessage::COULD_NOT_USE_COMMAND:
+		case TaskStr::LVL_TOO_LOW:
+			return "You can not be assigned this shared task because your party's minimum level is too low.";
+		case TaskStr::LVL_TOO_HIGH:
+			return "You can not be assigned this shared task because your party's maximum level is too high.";
+		case TaskStr::COULD_NOT_USE_COMMAND:
 			return "You could not use this command because you are not currently assigned to a shared task.";
-		case SharedTaskMessage::TASK_ASSIGN_WAIT_REQUEST_TIMER:
+		case TaskStr::CANT_ADD_MAX_LEVEL:
+			return "You can not add this player because their level exceeds the maximum level limit for this shared task.";
+		case TaskStr::CANT_ADD_MIN_LEVEL:
+			return "You can not add this player because their level is below the minimum required level for this shared task.";
+		case TaskStr::ASSIGN_REQUEST_TIMER:
 			return "This task can not be assigned to you because you must wait {}d:{}h:{}m before you can request another task of this type.";
-		case SharedTaskMessage::REQUEST_TIMER_REMAINING:
+		case TaskStr::REQUEST_TIMER_REMAINING:
 			return "'{}' request timer:  {}d:{}h:{}m remaining.";
-		case SharedTaskMessage::YOU_MUST_WAIT_REQUEST_TIMER:
+		case TaskStr::YOU_REQUEST_TIMER:
 			return "You may not request this shared task because you must wait {}d:{}h:{}m before you can request another task of this type.";
-		case SharedTaskMessage::RECEIVED_REQUEST_TIMER:
+		case TaskStr::RECEIVED_REQUEST_TIMER:
 			return "You have received a request timer for '{}': {}d:{}h:{}m remaining.";
-		case SharedTaskMessage::RECEIVED_REPLAY_TIMER:
+		case TaskStr::RECEIVED_REPLAY_TIMER:
 			return "You have received a replay timer for '{}': {}d:{}h:{}m remaining.";
-		case SharedTaskMessage::PLAYER_MUST_WAIT_REQUEST_TIMER:
+		case TaskStr::PLAYER_REQUEST_TIMER:
 			return "You may not request this shared task because {} must wait {}d:{}h:{}m before they can request another task of this type.";
-		case SharedTaskMessage::CANT_ADD_PLAYER_REQUEST_TIMER:
+		case TaskStr::CANT_ADD_PLAYER_REQUEST_TIMER:
 			return "You may not add {} because they must wait {}d:{}h:{}m before they can request another task of this type.";
 		default:
-			LogTasks("[GetEQStr] Unhandled eqstr id [{}]", eqstr_id);
+			LogTasks("[TaskStr::Get] Unhandled eqstr id [{}]", eqstr_id);
 			break;
 		}
 		return "Unknown EQStr";

--- a/world/shared_task_manager.h
+++ b/world/shared_task_manager.h
@@ -33,15 +33,8 @@ public:
 	TasksRepository::Tasks GetSharedTaskDataByTaskId(uint32 task_id);
 	std::vector<TaskActivitiesRepository::TaskActivities> GetSharedTaskActivityDataByTaskId(uint32 task_id);
 
-	// gets group / raid members belonging to requested character
-	std::vector<SharedTaskMember> GetRequestMembers(
-		uint32 requestor_character_id,
-		const std::vector<CharacterDataRepository::CharacterData> &characters
-	);
-
 	// client attempting to create a shared task
 	void AttemptSharedTaskCreation(uint32 requested_task_id, uint32 requested_character_id, uint32 npc_type_id);
-	void AttemptSharedTaskRemoval(uint32 requested_task_id, uint32 requested_character_id, bool remove_from_db);
 
 	// shared task activity update middleware
 	void SharedTaskActivityUpdate(
@@ -72,7 +65,7 @@ public:
 	);
 	void RemovePlayerFromSharedTask(SharedTask *s, uint32 character_id);
 	void PrintSharedTaskState();
-	void RemovePlayerFromSharedTaskByPlayerName(SharedTask *s, const std::string &character_name);
+	void RemoveMember(SharedTask* s, const SharedTaskMember& member, bool remove_from_db);
 	void RemoveEveryoneFromSharedTask(SharedTask *s, uint32 requested_character_id);
 
 	void MakeLeaderByPlayerName(SharedTask *s, const std::string &character_name);
@@ -120,7 +113,7 @@ protected:
 
 	void AddReplayTimers(SharedTask *s);
 	bool CanAddPlayer(SharedTask *s, uint32_t character_id, std::string player_name, bool accepted);
-	bool CanRequestSharedTask(uint32_t task_id, uint32_t character_id, const SharedTaskRequestCharacters &request);
+	bool CanRequestSharedTask(uint32_t task_id, const SharedTaskRequest& request);
 	void ChooseNewLeader(SharedTask *s);
 	bool HandleCompletedActivities(SharedTask* s);
 	void HandleCompletedTask(SharedTask* s);
@@ -133,7 +126,7 @@ protected:
 	void RemoveAllMembersFromDynamicZones(SharedTask *s);
 
 	// memory search
-	std::vector<uint32_t> FindCharactersInSharedTasks(const std::vector<uint32_t> &find_characters);
+	std::vector<SharedTaskMember> FindCharactersInSharedTasks(const std::vector<uint32_t> &find_characters);
 };
 
 #endif //EQEMU_SHARED_TASK_MANAGER_H

--- a/world/shared_task_world_messaging.cpp
+++ b/world/shared_task_world_messaging.cpp
@@ -38,21 +38,22 @@ void SharedTaskWorldMessaging::HandleZoneMessage(ServerPacket *pack)
 
 			break;
 		}
-		case ServerOP_SharedTaskAttemptRemove: {
-			auto *r = (ServerSharedTaskAttemptRemove_Struct *) pack->pBuffer;
+		case ServerOP_SharedTaskQuit: {
+			auto *r = (ServerSharedTaskQuit_Struct *) pack->pBuffer;
 			LogTasksDetail(
-				"[ServerOP_SharedTaskAttemptRemove] Received request from character [{}] task_id [{}] remove_from_db [{}]",
+				"[ServerOP_SharedTaskQuit] Received request from character [{}] task_id [{}] remove_from_db [{}]",
 				r->requested_character_id,
-				r->requested_task_id,
+				r->task_id,
 				r->remove_from_db
 			);
 
-			shared_task_manager.AttemptSharedTaskRemoval(
-				r->requested_task_id,
-				r->requested_character_id,
-				r->remove_from_db
-			);
-
+			auto s = shared_task_manager.FindSharedTaskByTaskIdAndCharacterId(r->task_id, r->requested_character_id);
+			if (s) {
+				auto member = s->FindMemberFromCharacterID(r->requested_character_id);
+				if (member.character_id != 0) {
+					shared_task_manager.RemoveMember(s, member, r->remove_from_db);
+				}
+			}
 			break;
 		}
 		case ServerOP_SharedTaskKickPlayers: {
@@ -67,10 +68,7 @@ void SharedTaskWorldMessaging::HandleZoneMessage(ServerPacket *pack)
 			if (t) {
 				auto leader = t->GetLeader();
 				if (leader.character_id != r->source_character_id) {
-					client_list.SendCharacterMessageID(
-						r->source_character_id, Chat::Red,
-						SharedTaskMessage::YOU_ARE_NOT_LEADER_COMMAND_ISSUE, {leader.character_name}
-					);
+					client_list.SendCharacterMessageID(r->source_character_id, Chat::Red, TaskStr::NOT_LEADER, {leader.character_name});
 				}
 				else {
 					shared_task_manager.RemoveEveryoneFromSharedTask(t, r->source_character_id);
@@ -146,10 +144,7 @@ void SharedTaskWorldMessaging::HandleZoneMessage(ServerPacket *pack)
 
 				auto leader = t->GetLeader();
 				if (leader.character_id != r->source_character_id) {
-					client_list.SendCharacterMessageID(
-						r->source_character_id, Chat::Red,
-						SharedTaskMessage::YOU_ARE_NOT_LEADER_COMMAND_ISSUE, {leader.character_name}
-					);
+					client_list.SendCharacterMessageID(r->source_character_id, Chat::Red, TaskStr::NOT_LEADER, {leader.character_name});
 				}
 				else {
 					LogTasksDetail(
@@ -158,8 +153,14 @@ void SharedTaskWorldMessaging::HandleZoneMessage(ServerPacket *pack)
 						t->GetDbSharedTask().id
 					);
 
-					std::string character_name = r->player_name;
-					shared_task_manager.RemovePlayerFromSharedTaskByPlayerName(t, character_name);
+					auto member = t->FindMemberFromCharacterName(r->player_name);
+					if (member.character_id == 0) {
+						shared_task_manager.SendLeaderMessageID(t, Chat::Red, TaskStr::IS_NOT_MEMBER, {r->player_name});
+					}
+					else {
+						shared_task_manager.RemoveMember(t, member, true);
+						shared_task_manager.SendLeaderMessageID(t, Chat::Yellow, TaskStr::PLAYER_REMOVED, {member.character_name, t->GetTaskData().title});
+					}
 				}
 			}
 
@@ -185,17 +186,10 @@ void SharedTaskWorldMessaging::HandleZoneMessage(ServerPacket *pack)
 
 				auto leader = t->GetLeader();
 				if (leader.character_id != r->source_character_id) {
-					client_list.SendCharacterMessageID(
-						r->source_character_id, Chat::Red,
-						SharedTaskMessage::YOU_ARE_NOT_LEADER_COMMAND_ISSUE, {leader.character_name}
-					);
+					client_list.SendCharacterMessageID(r->source_character_id, Chat::Red, TaskStr::NOT_LEADER, {leader.character_name});
 				}
 				else if (strcasecmp(leader.character_name.c_str(), r->player_name) == 0) {
-					client_list.SendCharacterMessageID(
-						r->source_character_id,
-						Chat::Red,
-						SharedTaskMessage::YOU_ALREADY_LEADER
-					);
+					client_list.SendCharacterMessageID(r->source_character_id, Chat::Red, TaskStr::YOU_ALREADY_LEADER);
 				}
 				else {
 					LogTasksDetail(
@@ -232,10 +226,7 @@ void SharedTaskWorldMessaging::HandleZoneMessage(ServerPacket *pack)
 				auto leader = t->GetLeader();
 				if (leader.character_id != r->source_character_id) {
 					// taskadd is client sided with System color in newer clients, server side might still be red
-					client_list.SendCharacterMessageID(
-						r->source_character_id, Chat::Red,
-						SharedTaskMessage::YOU_ARE_NOT_LEADER_COMMAND_ISSUE, {leader.character_name}
-					);
+					client_list.SendCharacterMessageID(r->source_character_id, Chat::Red, TaskStr::NOT_LEADER, {leader.character_name});
 				}
 				else {
 					LogTasksDetail(
@@ -275,12 +266,7 @@ void SharedTaskWorldMessaging::HandleZoneMessage(ServerPacket *pack)
 					shared_task_manager.AddPlayerByCharacterIdAndName(t, r->source_character_id, r->player_name);
 				}
 				else {
-					shared_task_manager.SendLeaderMessageID(
-						t,
-						Chat::Red,
-						SharedTaskMessage::PLAYER_DECLINED_OFFER,
-						{r->player_name}
-					);
+					shared_task_manager.SendLeaderMessageID(t, Chat::Red, TaskStr::PLAYER_DECLINED_OFFER, {r->player_name});
 				}
 			}
 			break;
@@ -333,18 +319,12 @@ void SharedTaskWorldMessaging::HandleZoneMessage(ServerPacket *pack)
 					player_names.emplace_back(member.character_name);
 
 					if (member.is_leader) {
-						client_list.SendCharacterMessageID(
-							buf->source_character_id, Chat::Yellow,
-							SharedTaskMessage::LEADER_PRINT, {member.character_name}
-						);
+						client_list.SendCharacterMessageID(buf->source_character_id, Chat::Yellow, TaskStr::LEADER_PRINT, {member.character_name});
 					}
 				}
 
 				std::string player_list = fmt::format("{}", fmt::join(player_names, ", "));
-				client_list.SendCharacterMessageID(
-					buf->source_character_id, Chat::Yellow,
-					SharedTaskMessage::MEMBERS_PRINT, {player_list}
-				);
+				client_list.SendCharacterMessageID(buf->source_character_id, Chat::Yellow, TaskStr::MEMBERS_PRINT, {player_list});
 			}
 
 			break;

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -1385,7 +1385,7 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 		}
 		case ServerOP_SharedTaskRequest:
 		case ServerOP_SharedTaskAddPlayer:
-		case ServerOP_SharedTaskAttemptRemove:
+		case ServerOP_SharedTaskQuit:
 		case ServerOP_SharedTaskUpdate:
 		case ServerOP_SharedTaskRequestMemberlist:
 		case ServerOP_SharedTaskRemovePlayer:

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -15420,7 +15420,7 @@ void Client::Handle_OP_SharedTaskAddPlayer(const EQApplicationPacket *app)
 
 	if (!GetTaskState()->HasActiveSharedTask()) {
 		// this message is generated client-side in newer clients
-		Message(Chat::System, SharedTaskMessage::GetEQStr(SharedTaskMessage::COULD_NOT_USE_COMMAND));
+		Message(Chat::System, TaskStr::Get(TaskStr::COULD_NOT_USE_COMMAND));
 	}
 	else {
 		// struct

--- a/zone/shared_task_zone_messaging.cpp
+++ b/zone/shared_task_zone_messaging.cpp
@@ -53,11 +53,11 @@ void SharedTaskZoneMessaging::HandleWorldMessage(ServerPacket *pack)
 
 			break;
 		}
-		case ServerOP_SharedTaskAttemptRemove: {
-			auto p = reinterpret_cast<ServerSharedTaskAttemptRemove_Struct *>(pack->pBuffer);
+		case ServerOP_SharedTaskQuit: {
+			auto p = reinterpret_cast<ServerSharedTaskQuit_Struct *>(pack->pBuffer);
 			auto c = entity_list.GetClientByCharID(p->requested_character_id);
 			if (c) {
-				LogTasks("[ServerOP_SharedTaskAttemptRemove] We're back in zone and I found [{}]", c->GetCleanName());
+				LogTasks("[ServerOP_SharedTaskQuit] We're back in zone and I found [{}]", c->GetCleanName());
 
 				c->m_requested_shared_task_removal = true;
 				c->GetTaskState()->CancelTask(

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -3236,7 +3236,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 	}
 	case ServerOP_SharedTaskAcceptNewTask:
 	case ServerOP_SharedTaskUpdate:
-	case ServerOP_SharedTaskAttemptRemove:
+	case ServerOP_SharedTaskQuit:
 	case ServerOP_SharedTaskMemberlist:
 	case ServerOP_SharedTaskMemberChange:
 	case ServerOP_SharedTaskInvitePlayer:


### PR DESCRIPTION
Functionally nothing should change in this patch. This refactors a lot
of formatting and code duplication in requests and member removals.

The long SharedTaskMessage namespace and its constants were contributing
to a lot of formatting that was difficult to read. These were shortened
since they're not all shared task specific anyway (though they should
probably just be moved to string_ids.h with other eqstrs now)

Shared task requests were refactored a little to remove an unnecessary
function that filled potential members. The separate functions used for
/taskquit and /taskremove were also combined into a single function to
remove a member while preserving live message differences.