### PR TITLE
[Shared Tasks] Enforce task reqs on player removal

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -555,6 +555,7 @@ RULE_BOOL(TaskSystem, RecordCompletedOptionalActivities, false, "Record complete
 RULE_BOOL(TaskSystem, KeepOneRecordPerCompletedTask, true, "Keep only one record per completed task")
 RULE_BOOL(TaskSystem, EnableTaskProximity, true, "Enable task proximity system")
 RULE_INT(TaskSystem, RequestCooldownTimerSeconds, 15, "Seconds between allowing characters to request tasks (live-like default: 15 seconds)")
+RULE_INT(TaskSystem, SharedTasksWorldProcessRate, 6000, "Timer interval (milliseconds) that shared tasks are processed in world")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Range)

--- a/common/shared_tasks.h
+++ b/common/shared_tasks.h
@@ -2,6 +2,7 @@
 #define EQEMU_SHARED_TASKS_H
 
 #include "database.h"
+#include "timer.h"
 #include "types.h"
 #include "repositories/character_data_repository.h"
 #include "repositories/tasks_repository.h"
@@ -202,6 +203,8 @@ public:
 	std::vector<SharedTaskMember>             m_members;
 	std::vector<uint32_t>                     member_id_history; // past and present members for replay timers
 	std::vector<uint32_t>                     dynamic_zone_ids;
+
+	Timer terminate_timer;
 
 protected:
 	SharedTasksRepository::SharedTasks m_db_shared_task;

--- a/common/tasks.h
+++ b/common/tasks.h
@@ -389,7 +389,7 @@ namespace TaskStr {
 	constexpr uint16 NO_LONGER_MEMBER                                  = 8942; // You are no longer a member of the shared task.
 	constexpr uint16 YOU_MAY_NOT_REQUEST_EXPANSION                     = 8943; // You may not request this shared task because you do not have the required expansion.
 	constexpr uint16 PLAYER_MAY_NOT_REQUEST_EXPANSION                  = 8944; // You may not request this shared task because %1 does not have the required expansion.
-	constexpr uint16 TWO_MIN_REQ_TASK_TERMINATED                       = 8945; // If your party does not meet the requirements in two minutes, the shared task will be terminated.
+	constexpr uint16 REQS_TWO_MIN                                      = 8945; // If your party does not meet the requirements in two minutes, the shared task will be terminated.
 	constexpr uint16 YOU_REPLAY_TIMER                                  = 8946; // You may not request this shared task because you must wait %1d:%2h:%3m before you can do another task of this type.
 	constexpr uint16 PLAYER_REPLAY_TIMER                               = 8947; // You may not request this shared task because %1 must wait %2d:%3h:%4m before they can do another task of this type.
 	constexpr uint16 PLAYER_NOW_LEADER                                 = 8948; // %1 is now the leader of your shared task, '%2'.

--- a/world/main.cpp
+++ b/world/main.cpp
@@ -427,6 +427,7 @@ int main(int argc, char **argv)
 		launcher_list.Process();
 		LFPGroupList.Process();
 		adventure_manager.Process();
+		shared_task_manager.Process();
 		dynamic_zone_manager.Process();
 
 		if (InterserverTimer.Check()) {

--- a/world/shared_task_manager.h
+++ b/world/shared_task_manager.h
@@ -3,6 +3,7 @@
 
 #include "../common/database.h"
 #include "../common/shared_tasks.h"
+#include "../common/timer.h"
 #include "../common/repositories/character_task_timers_repository.h"
 
 class DynamicZone;
@@ -20,6 +21,8 @@ struct SharedTaskActiveInvitation {
 
 class SharedTaskManager {
 public:
+	SharedTaskManager();
+
 	SharedTaskManager *SetDatabase(Database *db);
 	SharedTaskManager *SetContentDatabase(Database *db);
 
@@ -65,6 +68,7 @@ public:
 	);
 	void RemovePlayerFromSharedTask(SharedTask *s, uint32 character_id);
 	void PrintSharedTaskState();
+	void Process();
 	void RemoveMember(SharedTask* s, const SharedTaskMember& member, bool remove_from_db);
 	void RemoveEveryoneFromSharedTask(SharedTask *s, uint32 requested_character_id);
 
@@ -108,6 +112,8 @@ protected:
 	// store a reference of active invitations that have been sent to players
 	std::vector<SharedTaskActiveInvitation> m_active_invitations{};
 
+	Timer m_process_timer;
+
 	std::vector<CharacterTaskTimersRepository::CharacterTaskTimers> GetCharacterTimers(
 		const std::vector<uint32_t>& character_ids, const TasksRepository::Tasks& task);
 
@@ -124,6 +130,8 @@ protected:
 	void SendSharedTaskInvitePacket(SharedTask *s, int64 invited_character_id);
 	void RecordSharedTaskCompletion(SharedTask *s);
 	void RemoveAllMembersFromDynamicZones(SharedTask *s);
+	void StartTerminateTimer(SharedTask* s);
+	void Terminate(SharedTask* s);
 
 	// memory search
 	std::vector<SharedTaskMember> FindCharactersInSharedTasks(const std::vector<uint32_t> &find_characters);


### PR DESCRIPTION
This verifies a shared task's minimum players requirement is still met
when a member is removed and schedules it for termination if not