### PR TITLE
[Tasks] Use dz switch id for task touch events

### DIFF
--- a/common/tasks.h
+++ b/common/tasks.h
@@ -163,7 +163,7 @@ struct ActivityInformation {
 			out.WriteInt32(zone_ids.empty() ? 0 : zone_ids.front());
 		}
 
-		out.WriteInt32(0); // unknown id
+		out.WriteInt32(activity_type == TaskActivityType::Touch ? goal_id : 0); // dz_switch_id (maybe add separate field)
 		out.WriteString(description_override);
 		out.WriteInt32(done_count);
 		out.WriteInt8(1); // unknown

--- a/zone/client.h
+++ b/zone/client.h
@@ -1178,6 +1178,10 @@ public:
 		}
 		else { return false; }
 	}
+	void UpdateTasksOnTouchSwitch(int dz_switch_id)
+	{
+		if (task_state) { task_state->UpdateTasksOnTouch(this, dz_switch_id); }
+	}
 	inline void TaskSetSelector(Mob *mob, int task_set_id)
 	{
 		if (task_manager) {

--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -210,7 +210,7 @@ void Doors::HandleClick(Client* sender, uint8 trigger) {
 
 	if (m_dz_switch_id != 0)
 	{
-		// todo: update task touch task events with matching dz switch id
+		sender->UpdateTasksOnTouchSwitch(m_dz_switch_id);
 		if (sender->TryMovePCDynamicZoneSwitch(m_dz_switch_id))
 		{
 			safe_delete(outapp);

--- a/zone/task_client_state.h
+++ b/zone/task_client_state.h
@@ -38,7 +38,7 @@ public:
 	void UpdateTasksOnExplore(Client *client, int explore_id);
 	bool UpdateTasksOnSpeakWith(Client *client, int npc_type_id);
 	bool UpdateTasksOnDeliver(Client *client, std::list<EQ::ItemInstance *> &items, int cash, int npc_type_id);
-	void UpdateTasksOnTouch(Client *client, int zone_id, uint16 version);
+	void UpdateTasksOnTouch(Client *client, int dz_switch_id);
 	void ProcessTaskProximities(Client *client, float x, float y, float z);
 	bool TaskOutOfTime(TaskType task_type, int index);
 	void TaskPeriodicChecks(Client *client);
@@ -130,7 +130,6 @@ private:
 	std::vector<int>                      m_enabled_tasks;
 	std::vector<CompletedTaskInformation> m_completed_tasks;
 	int                                   m_last_completed_task_loaded;
-	bool                                  m_checked_touch_activities;
 
 	static void ShowClientTaskInfoMessage(ClientTaskInformation *task, Client *c);
 


### PR DESCRIPTION
This changes task touch elements to use the dz_switch_id as the goal id
instead of checking if a player zoned. It will remove the need to script
door clicks or modify task element zone field since task packet data can
just be imported.