### PR TITLE
[Shared Tasks] Avoid erasing shared tasks while iterating

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -556,6 +556,7 @@ RULE_BOOL(TaskSystem, KeepOneRecordPerCompletedTask, true, "Keep only one record
 RULE_BOOL(TaskSystem, EnableTaskProximity, true, "Enable task proximity system")
 RULE_INT(TaskSystem, RequestCooldownTimerSeconds, 15, "Seconds between allowing characters to request tasks (live-like default: 15 seconds)")
 RULE_INT(TaskSystem, SharedTasksWorldProcessRate, 6000, "Timer interval (milliseconds) that shared tasks are processed in world")
+RULE_INT(TaskSystem, SharedTasksTerminateTimerMS, 120000, "Delay (milliseconds) until a shared task is terminated if requirements are no longer met after member removal (default: 2 minutes)")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Range)

--- a/common/shared_tasks.cpp
+++ b/common/shared_tasks.cpp
@@ -7,7 +7,7 @@ std::vector<SharedTaskActivityStateEntry> SharedTask::GetActivityState() const
 	return m_shared_task_activity_state;
 }
 
-std::vector<SharedTaskMember> SharedTask::GetMembers() const
+const std::vector<SharedTaskMember>& SharedTask::GetMembers() const
 {
 	return m_members;
 }

--- a/common/shared_tasks.h
+++ b/common/shared_tasks.h
@@ -183,7 +183,7 @@ public:
 	SharedTaskMember FindMemberFromCharacterName(const std::string& character_name) const;
 	SharedTaskMember GetLeader() const;
 	std::vector<SharedTaskActivityStateEntry> GetActivityState() const;
-	std::vector<SharedTaskMember> GetMembers() const;
+	const std::vector<SharedTaskMember>& GetMembers() const;
 
 	// getters
 	const std::vector<TaskActivitiesRepository::TaskActivities> &GetTaskActivityData() const;

--- a/world/shared_task_manager.h
+++ b/world/shared_task_manager.h
@@ -132,7 +132,6 @@ protected:
 	void RecordSharedTaskCompletion(SharedTask *s);
 	void RemoveAllMembersFromDynamicZones(SharedTask *s);
 	void StartTerminateTimer(SharedTask* s);
-	void Terminate(SharedTask* s);
 
 	// memory search
 	std::vector<SharedTaskMember> FindCharactersInSharedTasks(const std::vector<uint32_t> &find_characters);


### PR DESCRIPTION
This wasn't safe since the erase would invalidate iterators used
internally by the range loops.

Shared tasks with no members are now also cleaned up

Make GetMembers return reference instead of copy (this is used a lot)

Add rule for shared task terminate time for easier debugging