### PR TITLE
[Rules] Add Rule to Enable Tells with #hideme

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -809,6 +809,7 @@ RULE_CATEGORY_END()
 
 RULE_CATEGORY(Command)
 RULE_BOOL(Command, DyeCommandRequiresDyes, false, "Enable this to require a Prismatic Dye (32557) each time someone uses #dye.")
+RULE_BOOL(Command, HideMeCommandDisablesTells, true, "Disable this to allow tells to be received when using #hideme.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Doors)

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -3388,9 +3388,10 @@ void Client::SetHideMe(bool gm_hide_me)
 		CreateDespawnPacket(&app, false);
 		entity_list.RemoveFromTargets(this);
 		trackable = false;
-		tellsoff  = true;
-	}
-	else {
+		if (RuleB(Command, HideMeCommandDisablesTells)) {
+			tellsoff  = true;
+		}
+	} else {
 		database.SetHideMe(AccountID(), false);
 		CreateSpawnPacket(&app);
 		trackable = true;


### PR DESCRIPTION
With the recent changes to #hideme as of #2328, tells are disabled to hidden GMs, meaning a GM must show themselves in order to receive tells.