### PR TITLE
[Quest API] Add GetSkillDmgAmt() to Perl.

### DIFF
--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -2447,6 +2447,11 @@ void Perl_Mob_ApplySpellBuff(Mob* self, int spell_id, int duration) // @categori
 	self->ApplySpellBuff(spell_id, duration);
 }
 
+int Perl_Mob_GetSkillDmgAmt(Mob* self, uint16 skill_id)
+{
+	return self->GetSkillDmgAmt(skill_id);
+}
+
 #ifdef BOTS
 Bot* Perl_Mob_CastToBot(Mob* self)
 {
@@ -2695,6 +2700,7 @@ void perl_register_mob()
 	package.add("GetSTR", &Perl_Mob_GetSTR);
 	package.add("GetSize", &Perl_Mob_GetSize);
 	package.add("GetSkill", &Perl_Mob_GetSkill);
+	package.add("GetSkillDmgAmt", &Perl_Mob_GetSkillDmgAmt);
 	package.add("GetSkillDmgTaken", &Perl_Mob_GetSkillDmgTaken);
 	package.add("GetSpecialAbility", &Perl_Mob_GetSpecialAbility);
 	package.add("GetSpecialAbilityParam", &Perl_Mob_GetSpecialAbilityParam);


### PR DESCRIPTION
- Add $mob->GetSkillDmgAmt(skill_id) to Perl.
- This already exists in Lua, but not Perl.
- Perl Test Script:
```perl
sub EVENT_SAY {
	if ($text=~/#b/i) {
		foreach my $skill_id (0..77) {
			my $extra_skill_damage = $client->GetSkillDmgAmt($skill_id);
			if ($extra_skill_damage > 0) {
				my $skill_name = quest::getskillname($skill_id);
				quest::message(315, "$skill_name: $extra_skill_damage");
			}
		}
	}
}
```
![image](https://user-images.githubusercontent.com/89047260/183792059-2d693c4f-5143-4afa-8ede-f57a481eae29.png)