### PR TITLE
[Doors] Improvements to door manipulation

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -1111,8 +1111,8 @@ void Client::ChannelMessageReceived(uint8 chan_num, uint8 language, uint8 lang_s
 		break;
 	}
 	case ChatChannel_Say: { /* Say */
-		if(message[0] == COMMAND_CHAR) {
-			if(command_dispatch(this, message) == -2) {
+		if (message[0] == COMMAND_CHAR) {
+			if (command_dispatch(this, message) == -2) {
 				if (parse->PlayerHasQuestSub(EVENT_COMMAND)) {
 					int i = parse->EventPlayer(EVENT_COMMAND, this, message, 0);
 					if (i == 0 && !RuleB(Chat, SuppressCommandErrors)) {

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4265,7 +4265,7 @@ void Client::Handle_OP_ClickDoor(const EQApplicationPacket *app)
 			fmt::format(
 				"Door ({}) [{}]",
 				currentdoor->GetEntityID(),
-				Saylink::Create("#door edit", false, "#door edit")
+				Saylink::Create("#door edit", true, "#door edit")
 			).c_str()
 		);
 	}
@@ -8523,7 +8523,7 @@ void Client::Handle_OP_ItemLinkClick(const EQApplicationPacket *app)
 			response = row[0];
 		}
 
-		if ((response).size() > 0) {
+		if (!response.empty()) {
 			if (!mod_saylink(response, silentsaylink)) {
 				return;
 			}
@@ -8531,43 +8531,21 @@ void Client::Handle_OP_ItemLinkClick(const EQApplicationPacket *app)
 			if (GetTarget() && GetTarget()->IsNPC()) {
 				if (silentsaylink) {
 					parse->EventNPC(EVENT_SAY, GetTarget()->CastToNPC(), this, response, 0);
-
-					if (response[0] == '#' && parse->PlayerHasQuestSub(EVENT_COMMAND)) {
-						parse->EventPlayer(EVENT_COMMAND, this, response, 0);
-					}
-#ifdef BOTS
-					else if (response[0] == '^' && parse->PlayerHasQuestSub(EVENT_BOT_COMMAND)) {
-						parse->EventPlayer(EVENT_BOT_COMMAND, this, response, 0);
-					}
-#endif
-					else {
-						parse->EventPlayer(EVENT_SAY, this, response, 0);
-					}
 				}
 				else {
 					Message(Chat::LightGray, "You say, '%s'", response.c_str());
-					ChannelMessageReceived(8, 0, 100, response.c_str());
 				}
+
+				ChannelMessageReceived(ChatChannel_Say, 0, 100, response.c_str());
+
 				return;
 			}
 			else {
-				if (silentsaylink) {
-					if (response[0] == '#' && parse->PlayerHasQuestSub(EVENT_COMMAND)) {
-						parse->EventPlayer(EVENT_COMMAND, this, response, 0);
-					}
-#ifdef BOTS
-					else if (response[0] == '^' && parse->PlayerHasQuestSub(EVENT_BOT_COMMAND)) {
-						parse->EventPlayer(EVENT_BOT_COMMAND, this, response, 0);
-					}
-#endif
-					else {
-						parse->EventPlayer(EVENT_SAY, this, response, 0);
-					}
-				}
-				else {
+				ChannelMessageReceived(ChatChannel_Say, 0, 100, response.c_str());
+				if (!silentsaylink) {
 					Message(Chat::LightGray, "You say, '%s'", response.c_str());
-					ChannelMessageReceived(8, 0, 100, response.c_str());
 				}
+
 				return;
 			}
 		}
@@ -8584,7 +8562,6 @@ void Client::Handle_OP_ItemLinkClick(const EQApplicationPacket *app)
 		SendItemPacket(0, inst, ItemPacketViewLink);
 		safe_delete(inst);
 	}
-	return;
 }
 
 void Client::Handle_OP_ItemLinkResponse(const EQApplicationPacket *app)

--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -39,75 +39,76 @@
 #define OPEN_INVDOOR 0x03
 #define CLOSE_INVDOOR 0x02
 
-extern EntityList entity_list;
+extern EntityList  entity_list;
 extern WorldServer worldserver;
 
-Doors::Doors(const DoorsRepository::Doors& door) :
-		close_timer(5000),
-		m_Position(door.pos_x, door.pos_y, door.pos_z, door.heading),
-		m_Destination(door.dest_x, door.dest_y, door.dest_z, door.dest_heading)
+Doors::Doors(const DoorsRepository::Doors &door) :
+	m_close_timer(5000),
+	m_position(door.pos_x, door.pos_y, door.pos_z, door.heading),
+	m_destination(door.dest_x, door.dest_y, door.dest_z, door.dest_heading)
 {
-	strn0cpy(zone_name, door.zone.c_str(), sizeof(zone_name));
-	strn0cpy(door_name, door.name.c_str(), sizeof(door_name));
-	strn0cpy(destination_zone_name, door.dest_zone.c_str(), sizeof(destination_zone_name));
+	strn0cpy(m_zone_name, door.zone.c_str(), sizeof(m_zone_name));
+	strn0cpy(m_door_name, door.name.c_str(), sizeof(m_door_name));
+	strn0cpy(m_destination_zone_name, door.dest_zone.c_str(), sizeof(m_destination_zone_name));
 
-	database_id             = door.id;
-	door_id                 = door.doorid;
-	incline                 = door.incline;
-	open_type               = door.opentype;
-	guild_id                = door.guild;
-	lockpick                = door.lockpick;
-	key_item_id             = door.keyitem;
-	no_key_ring             = door.nokeyring;
-	trigger_door            = door.triggerdoor;
-	trigger_type            = door.triggertype;
-	triggered               = false;
-	door_param              = door.door_param;
-	size                    = door.size;
-	invert_state            = door.invert_state;
-	destination_instance_id = door.dest_instance;
-	is_ldon_door            = door.is_ldon_door;
-	m_dz_switch_id          = door.dz_switch_id;
-	client_version_mask     = door.client_version_mask;
+	m_database_id             = door.id;
+	m_door_id                 = door.doorid;
+	m_incline                 = door.incline;
+	m_open_type               = door.opentype;
+	m_guild_id                = door.guild;
+	m_lockpick                = door.lockpick;
+	m_key_item_id             = door.keyitem;
+	m_no_key_ring             = door.nokeyring;
+	m_trigger_door            = door.triggerdoor;
+	m_trigger_type            = door.triggertype;
+	triggered                 = false;
+	m_door_param              = door.door_param;
+	m_size                    = door.size;
+	m_invert_state            = door.invert_state;
+	m_destination_instance_id = door.dest_instance;
+	m_is_ldon_door            = door.is_ldon_door;
+	m_dz_switch_id            = door.dz_switch_id;
+	m_client_version_mask     = door.client_version_mask;
 
 	SetOpenState(false);
 
-	close_timer.Disable();
+	m_close_timer.Disable();
 
-	disable_timer = (door.disable_timer == 1 ? true : false);
+	m_disable_timer = (door.disable_timer == 1 ? true : false);
 }
 
 Doors::Doors(const char *model, const glm::vec4 &position, uint8 open_type, uint16 size) :
-		close_timer(5000),
-		m_Position(position),
-		m_Destination(glm::vec4()){
+	m_close_timer(5000),
+	m_position(position),
+	m_destination(glm::vec4())
+{
 
-	strn0cpy(zone_name, zone->GetShortName(), 32);
-	strn0cpy(door_name, model, 32);
-	strn0cpy(destination_zone_name, "NONE", 32);
+	strn0cpy(m_zone_name, zone->GetShortName(), 32);
+	strn0cpy(m_door_name, model, 32);
+	strn0cpy(m_destination_zone_name, "NONE", 32);
 
-	database_id = (uint32) content_db.GetDoorsCountPlusOne(zone->GetShortName(), zone->GetInstanceVersion());
-	door_id     = (uint8) content_db.GetDoorsDBCountPlusOne(zone->GetShortName(), zone->GetInstanceVersion());
+	m_database_id = (uint32) content_db.GetDoorsCountPlusOne(zone->GetShortName(), zone->GetInstanceVersion());
+	m_door_id     = (uint8) content_db.GetDoorsDBCountPlusOne(zone->GetShortName(), zone->GetInstanceVersion());
 
-	open_type               = open_type;
-	size                    = size;
-	incline                 = 0;
-	guild_id                = 0;
-	lockpick                = 0;
-	key_item_id             = 0;
-	no_key_ring             = 0;
-	trigger_door            = 0;
-	trigger_type            = 0;
-	triggered               = false;
-	door_param              = 0;
-	invert_state            = 0;
-	is_ldon_door            = 0;
-	client_version_mask     = 4294967295u;
-	disable_timer           = 0;
-	destination_instance_id = 0;
+	m_open_type               = open_type;
+	m_size                    = size;
+	m_incline                 = 0;
+	m_guild_id                = 0;
+	m_lockpick                = 0;
+	m_key_item_id             = 0;
+	m_no_key_ring             = 0;
+	m_trigger_door            = 0;
+	m_trigger_type            = 0;
+	triggered                 = false;
+	m_door_param              = 0;
+	m_invert_state            = 0;
+	m_is_ldon_door            = 0;
+	m_client_version_mask     = 4294967295u;
+	m_disable_timer           = 0;
+	m_destination_instance_id = 0;
 
 	SetOpenState(false);
-	close_timer.Disable();
+	m_close_timer.Disable();
 }
 
 
@@ -117,57 +118,58 @@ Doors::~Doors()
 
 bool Doors::Process()
 {
-	if (close_timer.Enabled() && close_timer.Check() && IsDoorOpen()) {
-		if (open_type == 40 || GetTriggerType() == 1) {
-			auto outapp = new EQApplicationPacket(OP_MoveDoor, sizeof(MoveDoor_Struct));
-			MoveDoor_Struct *md = (MoveDoor_Struct *) outapp->pBuffer;
-			md->doorid = door_id;
-			md->action = invert_state == 0 ? CLOSE_DOOR : CLOSE_INVDOOR;
+	if (m_close_timer.Enabled() && m_close_timer.Check() && IsDoorOpen()) {
+		if (m_open_type == 40 || GetTriggerType() == 1) {
+			auto            outapp = new EQApplicationPacket(OP_MoveDoor, sizeof(MoveDoor_Struct));
+			MoveDoor_Struct *md    = (MoveDoor_Struct *) outapp->pBuffer;
+			md->doorid = m_door_id;
+			md->action = m_invert_state == 0 ? CLOSE_DOOR : CLOSE_INVDOOR;
 			entity_list.QueueClients(0, outapp);
 			safe_delete(outapp);
 		}
 
 		triggered = false;
-		close_timer.Disable();
+		m_close_timer.Disable();
 		SetOpenState(false);
 	}
 	return true;
 }
 
-void Doors::HandleClick(Client* sender, uint8 trigger) {
+void Doors::HandleClick(Client *sender, uint8 trigger)
+{
 	Log(Logs::Detail, Logs::Doors,
-	    "%s clicked door %s (dbid %d, eqid %d) at %s",
-	    sender->GetName(),
-	    door_name,
-	    database_id,
-	    door_id,
-	    to_string(m_Position).c_str()
+		"%s clicked door %s (dbid %d, eqid %d) at %s",
+		sender->GetName(),
+		m_door_name,
+		m_database_id,
+		m_door_id,
+		to_string(m_position).c_str()
 	);
 
 	Log(Logs::Detail, Logs::Doors,
-	    "incline %d, open_type %d, lockpick %d, key %d, nokeyring %d, trigger %d type %d, param %d",
-	    incline,
-	    open_type,
-	    lockpick,
-	    key_item_id,
-	    no_key_ring,
-	    trigger_door,
-	    trigger_type,
-	    door_param
+		"incline %d, open_type %d, lockpick %d, key %d, nokeyring %d, trigger %d type %d, param %d",
+		m_incline,
+		m_open_type,
+		m_lockpick,
+		m_key_item_id,
+		m_no_key_ring,
+		m_trigger_door,
+		m_trigger_type,
+		m_door_param
 	);
 
 	Log(Logs::Detail, Logs::Doors,
-	    "disable_timer '%s',size %d, invert %d, dest: %s %s",
-	    (disable_timer ? "true" : "false"),
-	    size,
-	    invert_state,
-	    destination_zone_name,
-	    to_string(m_Destination).c_str()
+		"disable_timer '%s',size %d, invert %d, dest: %s %s",
+		(m_disable_timer ? "true" : "false"),
+		m_size,
+		m_invert_state,
+		m_destination_zone_name,
+		to_string(m_destination).c_str()
 	);
 
-	auto outapp = new EQApplicationPacket(OP_MoveDoor, sizeof(MoveDoor_Struct));
+	auto outapp            = new EQApplicationPacket(OP_MoveDoor, sizeof(MoveDoor_Struct));
 	auto *move_door_packet = (MoveDoor_Struct *) outapp->pBuffer;
-	move_door_packet->doorid = door_id;
+	move_door_packet->doorid = m_door_id;
 
 	if (IsLDoNDoor()) {
 		if (sender) {
@@ -177,7 +179,8 @@ void Doors::HandleClick(Client* sender, uint8 trigger) {
 						sender->MessageString(Chat::Red, DUNGEON_SEALED);
 						safe_delete(outapp);
 						return;
-					} else {
+					}
+					else {
 						sender->KeyRingAdd(RuleI(Adventure, ItemIDToEnablePorts));
 					}
 				}
@@ -186,8 +189,8 @@ void Doors::HandleClick(Client* sender, uint8 trigger) {
 			if (!sender->GetPendingAdventureDoorClick()) {
 				sender->PendingAdventureDoorClick();
 				auto pack = new ServerPacket(
-						ServerOP_AdventureClickDoor,
-						sizeof(ServerPlayerClickedAdventureDoor_Struct)
+					ServerOP_AdventureClickDoor,
+					sizeof(ServerPlayerClickedAdventureDoor_Struct)
 				);
 
 				/**
@@ -208,11 +211,9 @@ void Doors::HandleClick(Client* sender, uint8 trigger) {
 		}
 	}
 
-	if (m_dz_switch_id != 0)
-	{
+	if (m_dz_switch_id != 0) {
 		sender->UpdateTasksOnTouchSwitch(m_dz_switch_id);
-		if (sender->TryMovePCDynamicZoneSwitch(m_dz_switch_id))
-		{
+		if (sender->TryMovePCDynamicZoneSwitch(m_dz_switch_id)) {
 			safe_delete(outapp);
 			return;
 		}
@@ -220,7 +221,7 @@ void Doors::HandleClick(Client* sender, uint8 trigger) {
 
 	uint32 required_key_item       = GetKeyItem();
 	uint8  disable_add_to_key_ring = GetNoKeyring();
-	bool player_has_key            = false;
+	bool   player_has_key          = false;
 	uint32 player_key              = 0;
 
 	const EQ::ItemInstance *lock_pick_item = sender->GetInv().GetItem(EQ::invslot::slotCursor);
@@ -249,12 +250,14 @@ void Doors::HandleClick(Client* sender, uint8 trigger) {
 		 * Door is only triggered by an object
 		 */
 		if (trigger == 1) {
-			if (!IsDoorOpen() || (open_type == 58)) {
-				move_door_packet->action = static_cast<uint8>(invert_state == 0 ? OPEN_DOOR : OPEN_INVDOOR);
-			} else {
-				move_door_packet->action = static_cast<uint8>(invert_state == 0 ? CLOSE_DOOR : CLOSE_INVDOOR);
+			if (!IsDoorOpen() || (m_open_type == 58)) {
+				move_door_packet->action = static_cast<uint8>(m_invert_state == 0 ? OPEN_DOOR : OPEN_INVDOOR);
 			}
-		} else {
+			else {
+				move_door_packet->action = static_cast<uint8>(m_invert_state == 0 ? CLOSE_DOOR : CLOSE_INVDOOR);
+			}
+		}
+		else {
 			safe_delete(outapp);
 			return;
 		}
@@ -265,17 +268,19 @@ void Doors::HandleClick(Client* sender, uint8 trigger) {
 	 *
 	 * Door is not locked
 	 */
-	bool is_guild_door = (GetGuildID() > 0) && (GetGuildID() == sender->GuildID());
-	bool is_door_not_locked = ((required_key_item == 0) && (GetLockpick() == 0) && (GetGuildID() == 0));
-	bool is_door_open_and_open_able = (IsDoorOpen() && (open_type == 58));
+	bool is_guild_door              = (GetGuildID() > 0) && (GetGuildID() == sender->GuildID());
+	bool is_door_not_locked         = ((required_key_item == 0) && (GetLockpick() == 0) && (GetGuildID() == 0));
+	bool is_door_open_and_open_able = (IsDoorOpen() && (m_open_type == 58));
 
 	if (is_door_not_locked || is_door_open_and_open_able || is_guild_door) {
 		if (!IsDoorOpen() || (GetOpenType() == 58)) {
-			move_door_packet->action = static_cast<uint8>(invert_state == 0 ? OPEN_DOOR : OPEN_INVDOOR);
-		} else {
-			move_door_packet->action = static_cast<uint8>(invert_state == 0 ? CLOSE_DOOR : CLOSE_INVDOOR);
+			move_door_packet->action = static_cast<uint8>(m_invert_state == 0 ? OPEN_DOOR : OPEN_INVDOOR);
 		}
-	} else {
+		else {
+			move_door_packet->action = static_cast<uint8>(m_invert_state == 0 ? CLOSE_DOOR : CLOSE_INVDOOR);
+		}
+	}
+	else {
 
 		/**
 		 * Guild Doors
@@ -284,9 +289,10 @@ void Doors::HandleClick(Client* sender, uint8 trigger) {
 			std::string guild_name;
 			char        door_message[240];
 
-			if (guild_mgr.GetGuildNameByID(guild_id, guild_name)) {
+			if (guild_mgr.GetGuildNameByID(m_guild_id, guild_name)) {
 				sprintf(door_message, "Only members of the <%s> guild may enter here", guild_name.c_str());
-			} else {
+			}
+			else {
 				strcpy(door_message, "Door is locked by an unknown guild");
 			}
 
@@ -309,24 +315,25 @@ void Doors::HandleClick(Client* sender, uint8 trigger) {
 		if (sender->GetGM()) {
 			sender->MessageString(Chat::LightBlue, DOORS_GM);
 
-			if (!IsDoorOpen() || (open_type == 58)) {
-				move_door_packet->action = static_cast<uint8>(invert_state == 0 ? OPEN_DOOR : OPEN_INVDOOR);
-			} else {
-				move_door_packet->action = static_cast<uint8>(invert_state == 0 ? CLOSE_DOOR : CLOSE_INVDOOR);
+			if (!IsDoorOpen() || (m_open_type == 58)) {
+				move_door_packet->action = static_cast<uint8>(m_invert_state == 0 ? OPEN_DOOR : OPEN_INVDOOR);
+			}
+			else {
+				move_door_packet->action = static_cast<uint8>(m_invert_state == 0 ? CLOSE_DOOR : CLOSE_INVDOOR);
 			}
 
 		}
 
-		/**
-		 * Player has something they are trying to open it with
-		 */
+			/**
+			 * Player has something they are trying to open it with
+			 */
 		else if (player_key) {
 
 			/**
 			 * Key required and client is using the right key
 			 */
 			if (required_key_item &&
-			    (required_key_item == player_key)) {
+				(required_key_item == player_key)) {
 
 				if (!disable_add_to_key_ring) {
 					sender->KeyRingAdd(player_key);
@@ -334,20 +341,21 @@ void Doors::HandleClick(Client* sender, uint8 trigger) {
 
 				sender->Message(Chat::LightBlue, "You got it open!");
 
-				if (!IsDoorOpen() || (open_type == 58)) {
-					move_door_packet->action = static_cast<uint8>(invert_state == 0 ? OPEN_DOOR : OPEN_INVDOOR);
-				} else {
-					move_door_packet->action = static_cast<uint8>(invert_state == 0 ? CLOSE_DOOR : CLOSE_INVDOOR);
+				if (!IsDoorOpen() || (m_open_type == 58)) {
+					move_door_packet->action = static_cast<uint8>(m_invert_state == 0 ? OPEN_DOOR : OPEN_INVDOOR);
+				}
+				else {
+					move_door_packet->action = static_cast<uint8>(m_invert_state == 0 ? CLOSE_DOOR : CLOSE_INVDOOR);
 				}
 			}
 		}
 
-		/**
-		 * Try Lock pick
-		 */
+			/**
+			 * Try Lock pick
+			 */
 		else if (lock_pick_item != nullptr) {
 			if (sender->GetSkill(EQ::skills::SkillPickLock)) {
-				Timer* pick_lock_timer = sender->GetPickLockTimer();
+				Timer *pick_lock_timer = sender->GetPickLockTimer();
 				if (lock_pick_item->GetItem()->ItemType == EQ::item::ItemTypeLockPick) {
 					if (!pick_lock_timer->Check()) {
 						// Stop full scale mad spamming
@@ -366,31 +374,37 @@ void Doors::HandleClick(Client* sender, uint8 trigger) {
 
 						if (!IsDoorOpen()) {
 							sender->CheckIncreaseSkill(EQ::skills::SkillPickLock, nullptr, 1);
-							move_door_packet->action = static_cast<uint8>(invert_state == 0 ? OPEN_DOOR : OPEN_INVDOOR);
+							move_door_packet->action = static_cast<uint8>(m_invert_state == 0 ? OPEN_DOOR
+								: OPEN_INVDOOR);
 							sender->MessageString(Chat::LightBlue, DOORS_SUCCESSFUL_PICK);
-						} else {
-							move_door_packet->action = static_cast<uint8>(invert_state == 0 ? CLOSE_DOOR : CLOSE_INVDOOR);
 						}
-					} else {
+						else {
+							move_door_packet->action = static_cast<uint8>(m_invert_state == 0 ? CLOSE_DOOR
+								: CLOSE_INVDOOR);
+						}
+					}
+					else {
 						sender->MessageString(Chat::LightBlue, DOORS_INSUFFICIENT_SKILL);
 						safe_delete(outapp);
 						return;
 					}
-				} else {
+				}
+				else {
 					sender->MessageString(Chat::LightBlue, DOORS_NO_PICK);
 					safe_delete(outapp);
 					return;
 				}
-			} else {
+			}
+			else {
 				sender->MessageString(Chat::LightBlue, DOORS_CANT_PICK);
 				safe_delete(outapp);
 				return;
 			}
 		}
 
-		/**
-		 * Locked door and nothing to open it with
-		 */
+			/**
+			 * Locked door and nothing to open it with
+			 */
 		else {
 
 			/**
@@ -399,12 +413,14 @@ void Doors::HandleClick(Client* sender, uint8 trigger) {
 			if (sender->KeyRingCheck(required_key_item)) {
 				player_key = required_key_item;
 				sender->Message(Chat::LightBlue, "You got it open!"); // more debug spam
-				if (!IsDoorOpen() || (open_type == 58)) {
-					move_door_packet->action = static_cast<uint8>(invert_state == 0 ? OPEN_DOOR : OPEN_INVDOOR);
-				} else {
-					move_door_packet->action = static_cast<uint8>(invert_state == 0 ? CLOSE_DOOR : CLOSE_INVDOOR);
+				if (!IsDoorOpen() || (m_open_type == 58)) {
+					move_door_packet->action = static_cast<uint8>(m_invert_state == 0 ? OPEN_DOOR : OPEN_INVDOOR);
 				}
-			} else {
+				else {
+					move_door_packet->action = static_cast<uint8>(m_invert_state == 0 ? CLOSE_DOOR : CLOSE_INVDOOR);
+				}
+			}
+			else {
 				sender->MessageString(Chat::LightBlue, DOORS_LOCKED);
 				safe_delete(outapp);
 				return;
@@ -413,16 +429,20 @@ void Doors::HandleClick(Client* sender, uint8 trigger) {
 	}
 
 	entity_list.QueueClients(sender, outapp, false);
-	if (!IsDoorOpen() || (open_type == 58)) {
-		if (!disable_timer)
-			close_timer.Start();
+	if (!IsDoorOpen() || (m_open_type == 58)) {
+		if (!m_disable_timer) {
+			m_close_timer.Start();
+		}
 
-		if(strncmp(destination_zone_name, "NONE", strlen("NONE")) == 0)
+		if (strncmp(m_destination_zone_name, "NONE", strlen("NONE")) == 0) {
 			SetOpenState(true);
-	} else {
-		close_timer.Disable();
-		if (!disable_timer)
+		}
+	}
+	else {
+		m_close_timer.Disable();
+		if (!m_disable_timer) {
 			SetOpenState(false);
+		}
 	}
 
 	/*
@@ -432,7 +452,8 @@ void Doors::HandleClick(Client* sender, uint8 trigger) {
 	 *  we return because we don't want people using teleports on an unlocked door (exploit!)
 	 */
 
-	if ((move_door_packet->action == CLOSE_DOOR && invert_state == 0) || (move_door_packet->action == CLOSE_INVDOOR && invert_state == 1)) {
+	if ((move_door_packet->action == CLOSE_DOOR && m_invert_state == 0) ||
+		(move_door_packet->action == CLOSE_INVDOOR && m_invert_state == 1)) {
 		safe_delete(outapp);
 		return;
 	}
@@ -444,15 +465,18 @@ void Doors::HandleClick(Client* sender, uint8 trigger) {
 		if (trigger_door_entity && !trigger_door_entity->triggered) {
 			triggered = true;
 			trigger_door_entity->HandleClick(sender, 1);
-		} else {
+		}
+		else {
 			triggered = false;
 		}
-	} else if ((GetTriggerDoorID() != 0) && (GetTriggerType() != 1)) {
+	}
+	else if ((GetTriggerDoorID() != 0) && (GetTriggerType() != 1)) {
 		Doors *trigger_door_entity = entity_list.FindDoor(GetTriggerDoorID());
 		if (trigger_door_entity && !trigger_door_entity->triggered) {
 			triggered = true;
 			trigger_door_entity->HandleClick(sender, 0);
-		} else {
+		}
+		else {
 			triggered = false;
 		}
 	}
@@ -460,270 +484,302 @@ void Doors::HandleClick(Client* sender, uint8 trigger) {
 	/**
 	 * Teleport door
 	 */
-	if (((open_type == 57) || (open_type == 58)) &&
-	    (strncmp(destination_zone_name, "NONE", strlen("NONE")) != 0)) {
+	if (((m_open_type == 57) || (m_open_type == 58)) &&
+		(strncmp(m_destination_zone_name, "NONE", strlen("NONE")) != 0)) {
 
 		/**
 		 * If click destination is same zone and doesn't require a key
 		 */
-		if ((strncmp(destination_zone_name, zone_name, strlen(zone_name)) == 0) && (!required_key_item)) {
+		if ((strncmp(m_destination_zone_name, m_zone_name, strlen(m_zone_name)) == 0) && (!required_key_item)) {
 			if (!disable_add_to_key_ring) {
 				sender->KeyRingAdd(player_key);
 			}
 			sender->MovePC(
-					zone->GetZoneID(),
-					zone->GetInstanceID(),
-					m_Destination.x,
-					m_Destination.y,
-					m_Destination.z,
-					m_Destination.w
+				zone->GetZoneID(),
+				zone->GetInstanceID(),
+				m_destination.x,
+				m_destination.y,
+				m_destination.z,
+				m_destination.w
 			);
 		}
-		/**
-		 * If requires a key
-		 */
+			/**
+			 * If requires a key
+			 */
 		else if (
-				(!IsDoorOpen() || open_type == 58) &&
-				(required_key_item && ((required_key_item == player_key) || sender->GetGM()))
-		) {
+			(!IsDoorOpen() || m_open_type == 58) &&
+			(required_key_item && ((required_key_item == player_key) || sender->GetGM()))
+			) {
 
 			if (!disable_add_to_key_ring) {
 				sender->KeyRingAdd(player_key);
 			}
-			if (ZoneID(destination_zone_name) == zone->GetZoneID()) {
+			if (ZoneID(m_destination_zone_name) == zone->GetZoneID()) {
 				sender->MovePC(
-						zone->GetZoneID(),
-						zone->GetInstanceID(),
-						m_Destination.x,
-						m_Destination.y,
-						m_Destination.z,
-						m_Destination.w
+					zone->GetZoneID(),
+					zone->GetInstanceID(),
+					m_destination.x,
+					m_destination.y,
+					m_destination.z,
+					m_destination.w
 				);
-			} else {
+			}
+			else {
 				sender->MovePC(
-						ZoneID(destination_zone_name),
-						static_cast<uint32>(destination_instance_id),
-						m_Destination.x,
-						m_Destination.y,
-						m_Destination.z,
-						m_Destination.w
+					ZoneID(m_destination_zone_name),
+					static_cast<uint32>(m_destination_instance_id),
+					m_destination.x,
+					m_destination.y,
+					m_destination.z,
+					m_destination.w
 				);
 			}
 		}
 
-		if ((!IsDoorOpen() || open_type == 58) && (!required_key_item)) {
-			if (ZoneID(destination_zone_name) == zone->GetZoneID()) {
+		if ((!IsDoorOpen() || m_open_type == 58) && (!required_key_item)) {
+			if (ZoneID(m_destination_zone_name) == zone->GetZoneID()) {
 				sender->MovePC(
-						zone->GetZoneID(),
-						zone->GetInstanceID(),
-						m_Destination.x,
-						m_Destination.y,
-						m_Destination.z,
-						m_Destination.w
+					zone->GetZoneID(),
+					zone->GetInstanceID(),
+					m_destination.x,
+					m_destination.y,
+					m_destination.z,
+					m_destination.w
 				);
-			} else {
+			}
+			else {
 				sender->MovePC(
-					ZoneID(destination_zone_name),
-						static_cast<uint32>(destination_instance_id),
-						m_Destination.x,
-						m_Destination.y,
-						m_Destination.z,
-						m_Destination.w
+					ZoneID(m_destination_zone_name),
+					static_cast<uint32>(m_destination_instance_id),
+					m_destination.x,
+					m_destination.y,
+					m_destination.z,
+					m_destination.w
 				);
 			}
 		}
 	}
 }
 
-void Doors::Open(Mob* sender, bool alt_mode)
+void Doors::Open(Mob *sender, bool alt_mode)
 {
 	if (sender) {
-		if (GetTriggerType() == 255 || GetTriggerDoorID() > 0 || GetLockpick() != 0 || GetKeyItem() != 0 || open_type == 59 || open_type == 58 || !sender->IsNPC()) { // this object isnt triggered or door is locked - NPCs should not open locked doors!
+		if (GetTriggerType() == 255 || GetTriggerDoorID() > 0 || GetLockpick() != 0 || GetKeyItem() != 0 ||
+			m_open_type == 59 || m_open_type == 58 ||
+			!sender->IsNPC()) { // this object isnt triggered or door is locked - NPCs should not open locked doors!
 			return;
 		}
 
-		auto outapp = new EQApplicationPacket(OP_MoveDoor, sizeof(MoveDoor_Struct));
-		MoveDoor_Struct* md = (MoveDoor_Struct*)outapp->pBuffer;
-		md->doorid = door_id;
-		md->action = invert_state == 0 ? OPEN_DOOR : OPEN_INVDOOR;
+		auto            outapp = new EQApplicationPacket(OP_MoveDoor, sizeof(MoveDoor_Struct));
+		MoveDoor_Struct *md    = (MoveDoor_Struct *) outapp->pBuffer;
+		md->doorid = m_door_id;
+		md->action = m_invert_state == 0 ? OPEN_DOOR : OPEN_INVDOOR;
 		entity_list.QueueCloseClients(sender, outapp, false, 200);
 		safe_delete(outapp);
 
 		if (!alt_mode) { // original function
-			if (!is_open) {
-				if (!disable_timer)
-					close_timer.Start();
-				is_open = true;
+			if (!m_is_open) {
+				if (!m_disable_timer) {
+					m_close_timer.Start();
+				}
+				m_is_open = true;
 			}
 			else {
-				close_timer.Disable();
-				if (!disable_timer)
-					is_open = false;
+				m_close_timer.Disable();
+				if (!m_disable_timer) {
+					m_is_open = false;
+				}
 			}
 		}
 		else { // alternative function
-			if (!disable_timer)
-				close_timer.Start();
-			is_open = true;
+			if (!m_disable_timer) {
+				m_close_timer.Start();
+			}
+			m_is_open = true;
 		}
 	}
 }
 
 void Doors::ForceOpen(Mob *sender, bool alt_mode)
 {
-	auto outapp = new EQApplicationPacket(OP_MoveDoor, sizeof(MoveDoor_Struct));
-	MoveDoor_Struct* md = (MoveDoor_Struct*)outapp->pBuffer;
-	md->doorid = door_id;
-	md->action = invert_state == 0 ? OPEN_DOOR : OPEN_INVDOOR;
+	auto            outapp = new EQApplicationPacket(OP_MoveDoor, sizeof(MoveDoor_Struct));
+	MoveDoor_Struct *md    = (MoveDoor_Struct *) outapp->pBuffer;
+	md->doorid = m_door_id;
+	md->action = m_invert_state == 0 ? OPEN_DOOR : OPEN_INVDOOR;
 	entity_list.QueueClients(sender, outapp, false);
 	safe_delete(outapp);
 
 	if (!alt_mode) { // original function
-		if (!is_open) {
-			if (!disable_timer)
-				close_timer.Start();
-			is_open = true;
+		if (!m_is_open) {
+			if (!m_disable_timer) {
+				m_close_timer.Start();
+			}
+			m_is_open = true;
 		}
 		else {
-			close_timer.Disable();
-			if (!disable_timer)
-				is_open = false;
+			m_close_timer.Disable();
+			if (!m_disable_timer) {
+				m_is_open = false;
+			}
 		}
 	}
 	else { // alternative function
-		if (!disable_timer)
-			close_timer.Start();
-		is_open = true;
+		if (!m_disable_timer) {
+			m_close_timer.Start();
+		}
+		m_is_open = true;
 	}
 }
 
-void Doors::ForceClose(Mob *sender, bool alt_mode) {
-	auto outapp = new EQApplicationPacket(OP_MoveDoor, sizeof(MoveDoor_Struct));
+void Doors::ForceClose(Mob *sender, bool alt_mode)
+{
+	auto            outapp = new EQApplicationPacket(OP_MoveDoor, sizeof(MoveDoor_Struct));
 	MoveDoor_Struct *move_door_packet;
 	move_door_packet = (MoveDoor_Struct *) outapp->pBuffer;
-	move_door_packet->doorid = door_id;
-	move_door_packet->action = invert_state == 0 ? CLOSE_DOOR : CLOSE_INVDOOR; // change from original (open to close)
+	move_door_packet->doorid = m_door_id;
+	move_door_packet->action = m_invert_state == 0 ? CLOSE_DOOR : CLOSE_INVDOOR; // change from original (open to close)
 	entity_list.QueueClients(sender, outapp, false);
 	safe_delete(outapp);
 
 	if (!alt_mode) { // original function
-		if (!is_open) {
-			if (!disable_timer)
-				close_timer.Start();
-			is_open = true;
-		} else {
-			close_timer.Disable();
-			is_open = false;
+		if (!m_is_open) {
+			if (!m_disable_timer) {
+				m_close_timer.Start();
+			}
+			m_is_open = true;
 		}
-	} else { // alternative function
-		if (is_open)
-			close_timer.Trigger();
+		else {
+			m_close_timer.Disable();
+			m_is_open = false;
+		}
+	}
+	else { // alternative function
+		if (m_is_open) {
+			m_close_timer.Trigger();
+		}
 	}
 }
 
 void Doors::ToggleState(Mob *sender)
 {
-	if(GetTriggerDoorID() > 0 || GetLockpick() != 0 || GetKeyItem() != 0 || open_type == 58 || open_type == 40) { // borrowed some NPCOpen criteria
+	if (GetTriggerDoorID() > 0 || GetLockpick() != 0 || GetKeyItem() != 0 || m_open_type == 58 ||
+		m_open_type == 40) { // borrowed some NPCOpen criteria
 		return;
 	}
 
-	auto outapp = new EQApplicationPacket(OP_MoveDoor, sizeof(MoveDoor_Struct));
-	MoveDoor_Struct* move_door_packet;
-	move_door_packet = (MoveDoor_Struct*)outapp->pBuffer;
-	move_door_packet->doorid = door_id;
+	auto            outapp = new EQApplicationPacket(OP_MoveDoor, sizeof(MoveDoor_Struct));
+	MoveDoor_Struct *move_door_packet;
+	move_door_packet = (MoveDoor_Struct *) outapp->pBuffer;
+	move_door_packet->doorid = m_door_id;
 
-	if(!is_open) {
-		move_door_packet->action = static_cast<uint8>(invert_state == 0 ? OPEN_DOOR : OPEN_INVDOOR);
-		is_open=true;
+	if (!m_is_open) {
+		move_door_packet->action = static_cast<uint8>(m_invert_state == 0 ? OPEN_DOOR : OPEN_INVDOOR);
+		m_is_open = true;
 	}
 	else {
-		move_door_packet->action = static_cast<uint8>(invert_state == 0 ? CLOSE_DOOR : CLOSE_INVDOOR);
-		is_open=false;
+		move_door_packet->action = static_cast<uint8>(m_invert_state == 0 ? CLOSE_DOOR : CLOSE_INVDOOR);
+		m_is_open = false;
 	}
 
-	entity_list.QueueClients(sender,outapp,false);
+	entity_list.QueueClients(sender, outapp, false);
 	safe_delete(outapp);
 }
 
-int32 ZoneDatabase::GetDoorsCount(uint32* oMaxID, const char *zone_name, int16 version) {
+int32 ZoneDatabase::GetDoorsCount(uint32 *oMaxID, const char *zone_name, int16 version)
+{
 
-	std::string query = StringFormat("SELECT MAX(id), count(*) FROM doors "
-                                    "WHERE zone = '%s' AND (version = %u OR version = -1)",
-                                    zone_name, version);
-    auto results = QueryDatabase(query);
-    if (!results.Success()) {
-		return -1;
-    }
-
-    if (results.RowCount() != 1)
-        return -1;
-
-    auto row = results.begin();
-
-    if (!oMaxID)
-        return atoi(row[1]);
-
-    if (row[0])
-        *oMaxID = atoi(row[0]);
-    else
-        *oMaxID = 0;
-
-    return atoi(row[1]);
-
-}
-
-int32 ZoneDatabase::GetDoorsCountPlusOne(const char *zone_name, int16 version) {
-    std::string query = StringFormat(
-    		"SELECT MAX(id) FROM doors WHERE zone = '%s' AND version = %u",
-		    zone_name,
-		    version
-    );
-    auto results = QueryDatabase(query);
-    if (!results.Success()) {
-		return -1;
-    }
-
-	if (results.RowCount() != 1)
-        return -1;
-
-    auto row = results.begin();
-
-    if (!row[0])
-        return 0;
-
-    return atoi(row[0]) + 1;
-}
-
-int32 ZoneDatabase::GetDoorsDBCountPlusOne(const char *zone_name, int16 version) {
-
-	uint32 oMaxID = 0;
-
-    std::string query = StringFormat("SELECT MAX(doorid) FROM doors "
-                                    "WHERE zone = '%s' AND (version = %u OR version = -1)",
-                                    zone_name, version);
-	auto results = QueryDatabase(query);
+	std::string query   = StringFormat(
+		"SELECT MAX(id), count(*) FROM doors "
+		"WHERE zone = '%s' AND (version = %u OR version = -1)",
+		zone_name, version
+	);
+	auto        results = QueryDatabase(query);
 	if (!results.Success()) {
 		return -1;
 	}
 
-    if (results.RowCount() != 1)
-        return -1;
+	if (results.RowCount() != 1) {
+		return -1;
+	}
 
-    auto row = results.begin();
+	auto row = results.begin();
 
-    if (!row[0])
-        return 0;
+	if (!oMaxID) {
+		return atoi(row[1]);
+	}
 
-    return atoi(row[0]) + 1;
+	if (row[0]) {
+		*oMaxID = atoi(row[0]);
+	}
+	else {
+		*oMaxID = 0;
+	}
+
+	return atoi(row[1]);
+
 }
 
-std::vector<DoorsRepository::Doors> ZoneDatabase::LoadDoors(const std::string& zone_name, int16 version)
+int32 ZoneDatabase::GetDoorsCountPlusOne(const char *zone_name, int16 version)
+{
+	std::string query   = StringFormat(
+		"SELECT MAX(id) FROM doors WHERE zone = '%s' AND version = %u",
+		zone_name,
+		version
+	);
+	auto        results = QueryDatabase(query);
+	if (!results.Success()) {
+		return -1;
+	}
+
+	if (results.RowCount() != 1) {
+		return -1;
+	}
+
+	auto row = results.begin();
+
+	if (!row[0]) {
+		return 0;
+	}
+
+	return atoi(row[0]) + 1;
+}
+
+int32 ZoneDatabase::GetDoorsDBCountPlusOne(const char *zone_name, int16 version)
+{
+
+	uint32 oMaxID = 0;
+
+	std::string query   = StringFormat(
+		"SELECT MAX(doorid) FROM doors "
+		"WHERE zone = '%s' AND (version = %u OR version = -1)",
+		zone_name, version
+	);
+	auto        results = QueryDatabase(query);
+	if (!results.Success()) {
+		return -1;
+	}
+
+	if (results.RowCount() != 1) {
+		return -1;
+	}
+
+	auto row = results.begin();
+
+	if (!row[0]) {
+		return 0;
+	}
+
+	return atoi(row[0]) + 1;
+}
+
+std::vector<DoorsRepository::Doors> ZoneDatabase::LoadDoors(const std::string &zone_name, int16 version)
 {
 	LogInfo("Loading Doors from database");
 
-	auto door_entries = DoorsRepository::GetWhere(*this, fmt::format(
-		"zone = '{}' AND (version = {} OR version = -1) {} ORDER BY doorid ASC",
-		zone_name, version, ContentFilterCriteria::apply()));
+	auto door_entries = DoorsRepository::GetWhere(
+		*this, fmt::format(
+			"zone = '{}' AND (version = {} OR version = -1) {} ORDER BY doorid ASC",
+			zone_name, version, ContentFilterCriteria::apply()));
 
 	LogDoors("Loaded [{}] doors for [{}] version [{}]", door_entries.size(), zone_name, version);
 
@@ -733,49 +789,56 @@ std::vector<DoorsRepository::Doors> ZoneDatabase::LoadDoors(const std::string& z
 void Doors::SetLocation(float x, float y, float z)
 {
 	entity_list.DespawnAllDoors();
-    m_Position = glm::vec4(x, y, z, m_Position.w);
+	m_position = glm::vec4(x, y, z, m_position.w);
 	entity_list.RespawnAllDoors();
 }
 
-void Doors::SetPosition(const glm::vec4& position) {
+void Doors::SetPosition(const glm::vec4 &position)
+{
 	entity_list.DespawnAllDoors();
-	m_Position = position;
+	m_position = position;
 	entity_list.RespawnAllDoors();
 }
 
-void Doors::SetIncline(int in) {
+void Doors::SetIncline(int in)
+{
 	entity_list.DespawnAllDoors();
-	incline = in;
+	m_incline = in;
 	entity_list.RespawnAllDoors();
 }
 
-void Doors::SetInvertState(int in) {
+void Doors::SetInvertState(int in)
+{
 	entity_list.DespawnAllDoors();
-	invert_state = in;
+	m_invert_state = in;
 	entity_list.RespawnAllDoors();
 }
 
-void Doors::SetOpenType(uint8 in) {
+void Doors::SetOpenType(uint8 in)
+{
 	entity_list.DespawnAllDoors();
-	open_type = in;
+	m_open_type = in;
 	entity_list.RespawnAllDoors();
 }
 
-void Doors::SetDoorName(const char* name) {
+void Doors::SetDoorName(const char *name)
+{
 	entity_list.DespawnAllDoors();
-	memset(door_name, 0, sizeof(door_name));
-	strncpy(door_name, name, sizeof(door_name));
+	memset(m_door_name, 0, sizeof(m_door_name));
+	strncpy(m_door_name, name, sizeof(m_door_name));
 	entity_list.RespawnAllDoors();
 }
 
-void Doors::SetSize(uint16 in) {
+void Doors::SetSize(uint16 in)
+{
 	entity_list.DespawnAllDoors();
-	size = in;
+	m_size = in;
 	entity_list.RespawnAllDoors();
 }
 
-void Doors::SetDisableTimer(bool flag) {
-	disable_timer = flag;
+void Doors::SetDisableTimer(bool flag)
+{
+	m_disable_timer = flag;
 }
 
 void Doors::CreateDatabaseEntry()
@@ -791,7 +854,7 @@ void Doors::CreateDatabaseEntry()
 		GetDoorDBID(),
 		GetDoorID(),
 		GetDoorName(),
-		m_Position,
+		m_position,
 		GetOpenType(),
 		static_cast<uint16>(GetGuildID()),
 		GetLockpick(),
@@ -805,15 +868,15 @@ void Doors::CreateDatabaseEntry()
 
 float Doors::GetX()
 {
-	return m_Position.x;
+	return m_position.x;
 }
 
 float Doors::GetY()
 {
-	return m_Position.y;
+	return m_position.y;
 }
 
 float Doors::GetZ()
 {
-	return m_Position.z;
+	return m_position.z;
 }

--- a/zone/doors.h
+++ b/zone/doors.h
@@ -17,31 +17,31 @@ public:
 	Doors(const char *model, const glm::vec4& position, uint8 open_type = 58, uint16 size = 100);
 	Doors(const DoorsRepository::Doors& door);
 
-	bool GetDisableTimer() { return disable_timer; }
+	bool GetDisableTimer() { return m_disable_timer; }
 	bool IsDoor() const { return true; }
-	bool IsDoorOpen() { return is_open; }
+	bool IsDoorOpen() { return m_is_open; }
 	bool Process();
 	bool triggered;
-	char *GetDoorName() { return door_name; }
-	const glm::vec4 GetDestination() const { return m_Destination; }
-	const glm::vec4 &GetPosition() const { return m_Position; }
+	char *GetDoorName() { return m_door_name; }
+	const glm::vec4 GetDestination() const { return m_destination; }
+	const glm::vec4 &GetPosition() const { return m_position; }
 	int GetDzSwitchID() const { return m_dz_switch_id; }
-	int GetIncline() { return incline; }
-	int GetInvertState() { return invert_state; }
-	uint8 GetDoorID() { return door_id; }
-	uint8 GetNoKeyring() { return no_key_ring; }
-	uint8 GetOpenType() { return open_type; }
-	uint8 GetTriggerDoorID() { return trigger_door; }
-	uint8 GetTriggerType() { return trigger_type; }
-	uint8 IsLDoNDoor() { return is_ldon_door; }
-	uint16 GetLockpick() { return lockpick; }
-	uint16 GetSize() { return size; }
-	uint32 GetClientVersionMask() { return client_version_mask; }
-	uint32 GetDoorDBID() { return database_id; }
-	uint32 GetDoorParam() { return door_param; }
-	uint32 GetEntityID() { return entity_id; }
-	uint32 GetGuildID() { return guild_id; }
-	uint32 GetKeyItem() { return key_item_id; }
+	int GetIncline() { return m_incline; }
+	int GetInvertState() { return m_invert_state; }
+	uint8 GetDoorID() { return m_door_id; }
+	uint8 GetNoKeyring() { return m_no_key_ring; }
+	uint8 GetOpenType() { return m_open_type; }
+	uint8 GetTriggerDoorID() { return m_trigger_door; }
+	uint8 GetTriggerType() { return m_trigger_type; }
+	uint8 IsLDoNDoor() { return m_is_ldon_door; }
+	uint16 GetLockpick() { return m_lockpick; }
+	uint16 GetSize() { return m_size; }
+	uint32 GetClientVersionMask() { return m_client_version_mask; }
+	uint32 GetDoorDBID() { return m_database_id; }
+	uint32 GetDoorParam() { return m_door_param; }
+	uint32 GetEntityID() { return m_entity_id; }
+	uint32 GetGuildID() { return m_guild_id; }
+	uint32 GetKeyItem() { return m_key_item_id; }
 	void CreateDatabaseEntry();
 	void ForceClose(Mob *sender, bool alt_mode = false);
 	void ForceOpen(Mob *sender, bool alt_mode = false);
@@ -49,14 +49,14 @@ public:
 	void Open(Mob *sender, bool alt_mode = false);
 	void SetDisableTimer(bool flag);
 	void SetDoorName(const char *name);
-	void SetEntityID(uint32 entity) { entity_id = entity; }
+	void SetEntityID(uint32 entity) { m_entity_id = entity; }
 	void SetIncline(int in);
 	void SetInvertState(int in);
-	void SetKeyItem(uint32 in) { key_item_id = in; }
+	void SetKeyItem(uint32 in) { m_key_item_id = in; }
 	void SetLocation(float x, float y, float z);
-	void SetLockpick(uint16 in) { lockpick = in; }
-	void SetNoKeyring(uint8 in) { no_key_ring = in; }
-	void SetOpenState(bool st) { is_open = st; }
+	void SetLockpick(uint16 in) { m_lockpick = in; }
+	void SetNoKeyring(uint8 in) { m_no_key_ring = in; }
+	void SetOpenState(bool st) { m_is_open = st; }
 	void SetOpenType(uint8 in);
 	void SetPosition(const glm::vec4 &position);
 	void SetSize(uint16 size);
@@ -68,31 +68,31 @@ public:
 
 private:
 
-	uint32    database_id;
-	uint8     door_id;
-	char      zone_name[32];
-	char      door_name[32];
-	glm::vec4 m_Position;
-	int       incline;
-	uint8     open_type;
-	uint32    guild_id;
-	uint16    lockpick;
-	uint32    key_item_id;
-	uint8     no_key_ring;
-	uint8     trigger_door;
-	uint8     trigger_type;
-	uint32    door_param;
-	uint16    size;
-	int       invert_state;
-	uint32    entity_id;
-	bool      disable_timer;
-	bool      is_open;
-	Timer     close_timer;
-	char      destination_zone_name[16];
-	int       destination_instance_id;
-	glm::vec4 m_Destination;
-	uint8     is_ldon_door;
+	uint32    m_database_id;
+	uint8     m_door_id;
+	char      m_zone_name[32];
+	char      m_door_name[32];
+	glm::vec4 m_position;
+	int       m_incline;
+	uint8     m_open_type;
+	uint32    m_guild_id;
+	uint16    m_lockpick;
+	uint32    m_key_item_id;
+	uint8     m_no_key_ring;
+	uint8     m_trigger_door;
+	uint8     m_trigger_type;
+	uint32    m_door_param;
+	uint16    m_size;
+	int       m_invert_state;
+	uint32    m_entity_id;
+	bool      m_disable_timer;
+	bool      m_is_open;
+	Timer     m_close_timer;
+	char      m_destination_zone_name[16];
+	int       m_destination_instance_id;
+	glm::vec4 m_destination;
+	uint8     m_is_ldon_door;
 	int       m_dz_switch_id = 0;
-	uint32    client_version_mask;
+	uint32    m_client_version_mask;
 };
 #endif

--- a/zone/gm_commands/door_manipulation.cpp
+++ b/zone/gm_commands/door_manipulation.cpp
@@ -34,269 +34,16 @@ void DoorManipulation::CommandHandler(Client *c, const Seperator *sep)
 		);
 	}
 
-	// option
-	if (arg1.empty()) {
-		DoorManipulation::CommandHeader(c);
-		c->Message(
-			Chat::White,
-			"#door create <modelname> | Creates a door from a model. (Example IT78 creates a campfire)"
-		);
-		c->Message(Chat::White, "#door setinvertstate [0|1] | Sets selected door invert state");
-		c->Message(Chat::White, "#door setincline <incline> | Sets selected door incline");
-		c->Message(Chat::White, "#door opentype <opentype> | Sets selected door opentype");
-		c->Message(
-			Chat::White,
-			fmt::format(
-				"#door model <modelname> | Changes door model for selected door or select from [{}] or [{}]",
-				Saylink::Create("#door showmodelszone", false, "local zone"),
-				Saylink::Create("#door showmodelsglobal", false, "global")
-			).c_str()
-		);
-		c->Message(
-			Chat::White,
-			"#door showmodelsfromfile <file.eqg|file.s3d> | Shows models from s3d or eqg file. Example tssequip.eqg or wallet01.eqg"
-		);
-
-		c->Message(
-			Chat::White,
-			fmt::format(
-				"{} | Shows available models in the current zone that you are in",
-				Saylink::Create("#door showmodelszone", false, "#door showmodelszone")
-			).c_str()
-		);
-
-		c->Message(
-			Chat::White,
-			fmt::format(
-				"{} | Shows available models globally by first listing all global model files",
-				Saylink::Create("#door showmodelsglobal", false, "#door showmodelsglobal")
-			).c_str()
-		);
-
-		c->Message(Chat::White, "#door save | Creates database entry for selected door");
-		c->Message(
-			Chat::White,
-			fmt::format(
-				"{} - Brings up editing interface for selected door",
-				Saylink::Create("#door edit", false, "#door edit")
-			).c_str()
-		);
-		c->Message(
-			Chat::White,
-			fmt::format(
-				"{} - lists doors in zone",
-				Saylink::Create("#list doors", false, "#list doors")
-			).c_str()
-		);
-
-		return;
-	}
-
 	// edit menu
 	if (arg1 == "edit") {
 		Doors *door = entity_list.GetDoorsByID(c->GetDoorToolEntityId());
 		if (door) {
-			c->Message(
-				Chat::White,
-				fmt::format(
-					"Door Selected ID [{}] Name [{}] OpenType [{}] Invertstate [{} | {}/{}] ",
-					c->GetDoorToolEntityId(),
-					door->GetDoorName(),
-					door->GetOpenType(),
-					door->GetInvertState(),
-					Saylink::Create("#door setinvertstate 0", false, "0"),
-					Saylink::Create("#door setinvertstate 1", false, "1")
-				).c_str()
-			);
 
 			const std::string move_x_action   = "move_x";
 			const std::string move_y_action   = "move_y";
 			const std::string move_z_action   = "move_z";
 			const std::string move_h_action   = "move_h";
 			const std::string set_size_action = "set_size";
-
-			std::vector<std::string> move_options = {
-				move_x_action,
-				move_y_action,
-				move_z_action,
-				move_h_action,
-				set_size_action
-			};
-			std::vector<std::string> move_x_options_positive;
-			std::vector<std::string> move_x_options_negative;
-			std::vector<std::string> move_y_options_positive;
-			std::vector<std::string> move_y_options_negative;
-			std::vector<std::string> move_z_options_positive;
-			std::vector<std::string> move_z_options_negative;
-			std::vector<std::string> move_h_options_positive;
-			std::vector<std::string> move_h_options_negative;
-			std::vector<std::string> set_size_options_positive;
-			std::vector<std::string> set_size_options_negative;
-			for (const auto          &move_option : move_options) {
-				if (move_option == move_x_action) {
-					move_x_options_positive.emplace_back(
-						Saylink::Create(
-							fmt::format("#door edit {} .25", move_option),
-							false,
-							".25"
-						)
-					);
-
-					for (int move_index = 0; move_index <= 15; move_index += 5) {
-						int value = (move_index == 0 ? 1 : move_index);
-						move_x_options_positive.emplace_back(
-							Saylink::Create(
-								fmt::format("#door edit {} {}", move_option, value),
-								false,
-								fmt::format("{}", std::abs(value))
-							)
-						);
-					}
-
-					for (int move_index = -15; move_index <= 0; move_index += 5) {
-						int value = (move_index == 0 ? 1 : move_index);
-						move_x_options_negative.emplace_back(
-							Saylink::Create(
-								fmt::format("#door edit {} {}", move_option, value),
-								false,
-								fmt::format("{}", std::abs(value))
-							)
-						);
-					}
-
-					move_x_options_negative.emplace_back(
-						Saylink::Create(
-							fmt::format("#door edit {} -.25", move_option),
-							false,
-							".25"
-						)
-					);
-				}
-				else if (move_option == move_y_action) {
-					move_y_options_positive.emplace_back(
-						Saylink::Create(
-							fmt::format("#door edit {} .25", move_option),
-							false,
-							".25"
-						)
-					);
-
-					for (int move_index = 0; move_index <= 15; move_index += 5) {
-						int value = (move_index == 0 ? 1 : move_index);
-						move_y_options_positive.emplace_back(
-							Saylink::Create(
-								fmt::format("#door edit {} {}", move_option, value),
-								false,
-								fmt::format("{}", std::abs(value))
-							)
-						);
-					}
-
-					for (int move_index = -15; move_index <= 0; move_index += 5) {
-						int value = (move_index == 0 ? -1 : move_index);
-						move_y_options_negative.emplace_back(
-							Saylink::Create(
-								fmt::format("#door edit {} {}", move_option, value),
-								false,
-								fmt::format("{}", std::abs(value))
-							)
-						);
-					}
-
-					move_y_options_negative.emplace_back(
-						Saylink::Create(
-							fmt::format("#door edit {} -.25", move_option),
-							false,
-							".25"
-						)
-					);
-				}
-				else if (move_option == move_z_action) {
-					move_z_options_positive.emplace_back(
-						Saylink::Create(
-							fmt::format("#door edit {} .25", move_option),
-							false,
-							".25"
-						)
-					);
-
-					for (int move_index = 0; move_index <= 15; move_index += 5) {
-						int value = (move_index == 0 ? 1 : move_index);
-						move_z_options_positive.emplace_back(
-							Saylink::Create(
-								fmt::format("#door edit {} {}", move_option, value),
-								false,
-								fmt::format("{}", std::abs(value))
-							)
-						);
-					}
-
-					for (int move_index = -15; move_index <= 0; move_index += 5) {
-						int value = (move_index == 0 ? -1 : move_index);
-						move_z_options_negative.emplace_back(
-							Saylink::Create(
-								fmt::format("#door edit {} {}", move_option, value),
-								false,
-								fmt::format("{}", std::abs(value))
-							)
-						);
-					}
-
-					move_z_options_negative.emplace_back(
-						Saylink::Create(
-							fmt::format("#door edit {} -.25", move_option),
-							false,
-							".25"
-						)
-					);
-				}
-				else if (move_option == move_h_action) {
-					for (int move_index = 0; move_index <= 50; move_index += 5) {
-						int value = (move_index == 0 ? 1 : move_index);
-						move_h_options_positive.emplace_back(
-							Saylink::Create(
-								fmt::format("#door edit {} {}", move_option, value),
-								false,
-								fmt::format("{}", std::abs(value))
-							)
-						);
-					}
-
-					for (int move_index = -50; move_index <= 0; move_index += 5) {
-						int value = (move_index == 0 ? -1 : move_index);
-						move_h_options_negative.emplace_back(
-							Saylink::Create(
-								fmt::format("#door edit {} {}", move_option, value),
-								false,
-								fmt::format("{}", std::abs(value))
-							)
-						);
-					}
-				}
-				else if (move_option == set_size_action) {
-					for (int move_index = 0; move_index <= 100; move_index += 10) {
-						int value = (move_index == 0 ? 1 : move_index);
-						set_size_options_positive.emplace_back(
-							Saylink::Create(
-								fmt::format("#door edit {} {}", move_option, value),
-								false,
-								fmt::format("{}", std::abs(value))
-							)
-						);
-					}
-
-					for (int move_index = -100; move_index <= 0; move_index += 10) {
-						int value = (move_index == 0 ? -1 : move_index);
-						set_size_options_negative.emplace_back(
-							Saylink::Create(
-								fmt::format("#door edit {} {}", move_option, value),
-								false,
-								fmt::format("{}", std::abs(value))
-							)
-						);
-					}
-				}
-			}
 
 			// we're passing a move action here
 			if (!arg3.empty() && Strings::IsNumber(arg3)) {
@@ -336,73 +83,192 @@ void DoorManipulation::CommandHandler(Client *c, const Seperator *sep)
 				door_position.w = door_position.w + h_move;
 				door->SetPosition(door_position);
 				door->SetSize(door->GetSize() + set_size);
-			}
 
-			// spawn and move helpers
-			uint16 helper_mob_x_negative = 0;
-			uint16 helper_mob_x_positive = 0;
-			uint16 helper_mob_y_positive = 0;
-			uint16 helper_mob_y_negative = 0;
+				// spawn and move helpers
+				uint16 helper_mob_x_negative = 0;
+				uint16 helper_mob_x_positive = 0;
+				uint16 helper_mob_y_positive = 0;
+				uint16 helper_mob_y_negative = 0;
 
-			for (auto &n: entity_list.GetNPCList()) {
-				NPC         *npc     = n.second;
-				std::string npc_name = npc->GetName();
-				if (npc_name.find("-X") != std::string::npos) {
-					helper_mob_x_negative = npc->GetID();
+				for (auto &n: entity_list.GetNPCList()) {
+					NPC         *npc     = n.second;
+					std::string npc_name = npc->GetName();
+					if (npc_name.find("-X") != std::string::npos) {
+						helper_mob_x_negative = npc->GetID();
+					}
+					if (npc_name.find("-Y") != std::string::npos) {
+						helper_mob_y_negative = npc->GetID();
+					}
+					if (npc_name.find("+X") != std::string::npos) {
+						helper_mob_x_positive = npc->GetID();
+					}
+					if (npc_name.find("+Y") != std::string::npos) {
+						helper_mob_y_positive = npc->GetID();
+					}
 				}
-				if (npc_name.find("-Y") != std::string::npos) {
-					helper_mob_y_negative = npc->GetID();
+
+				// -X
+				door_position = door->GetPosition();
+				if (helper_mob_x_negative == 0) {
+					door_position.x = door_position.x - 15;
+					helper_mob_x_negative = NPC::SpawnNodeNPC("-X", "", door_position)->GetID();
 				}
-				if (npc_name.find("+X") != std::string::npos) {
-					helper_mob_x_positive = npc->GetID();
+				else {
+					auto n = entity_list.GetNPCByID(helper_mob_x_negative);
+					n->GMMove(door->GetX() - 15, door->GetY(), door->GetZ(), n->GetHeading());
 				}
-				if (npc_name.find("+Y") != std::string::npos) {
-					helper_mob_y_positive = npc->GetID();
+
+				// +X
+				door_position = door->GetPosition();
+				if (helper_mob_x_positive == 0) {
+					door_position.x = door_position.x + 15;
+					helper_mob_x_positive = NPC::SpawnNodeNPC("+X", "", door_position)->GetID();
+				}
+				else {
+					auto n = entity_list.GetNPCByID(helper_mob_x_positive);
+					n->GMMove(door->GetX() + 15, door->GetY(), door->GetZ(), n->GetHeading());
+				}
+
+				// -Y
+				door_position = door->GetPosition();
+				if (helper_mob_y_negative == 0) {
+					door_position.y = door_position.y - 15;
+					helper_mob_y_negative = NPC::SpawnNodeNPC("-Y", "", door_position)->GetID();
+				}
+				else {
+					auto n = entity_list.GetNPCByID(helper_mob_y_negative);
+					n->GMMove(door->GetX(), door->GetY() - 15, door->GetZ(), n->GetHeading());
+				}
+
+				// +Y
+				door_position = door->GetPosition();
+				if (helper_mob_y_positive == 0) {
+					door_position.y = door_position.y + 15;
+					helper_mob_y_positive = NPC::SpawnNodeNPC("+Y", "", door_position)->GetID();
+				}
+				else {
+					auto n = entity_list.GetNPCByID(helper_mob_y_positive);
+					n->GMMove(door->GetX(), door->GetY() + 15, door->GetZ(), n->GetHeading());
+				}
+
+				return;
+			}
+
+			c->Message(
+				Chat::White,
+				fmt::format(
+					"Door Selected ID [{}] Name [{}] OpenType [{}] Invertstate [{} | {}/{}] ",
+					c->GetDoorToolEntityId(),
+					door->GetDoorName(),
+					door->GetOpenType(),
+					door->GetInvertState(),
+					Saylink::Create("#door setinvertstate 0", true, "0"),
+					Saylink::Create("#door setinvertstate 1", true, "1")
+				).c_str()
+			);
+
+
+			std::vector<std::string> move_options = {
+				move_x_action,
+				move_y_action,
+				move_z_action,
+				move_h_action,
+				set_size_action
+			};
+			std::vector<std::string> move_x_options_positive;
+			std::vector<std::string> move_x_options_negative;
+			std::vector<std::string> move_y_options_positive;
+			std::vector<std::string> move_y_options_negative;
+			std::vector<std::string> move_z_options_positive;
+			std::vector<std::string> move_z_options_negative;
+			std::vector<std::string> move_h_options_positive;
+			std::vector<std::string> move_h_options_negative;
+			std::vector<std::string> set_size_options_positive;
+			std::vector<std::string> set_size_options_negative;
+
+			std::vector<std::string> xyz_values = {
+				".1", "1", "5", "10", "25", "50", "100"
+			};
+
+			// build positive options x/y/z
+			for (const auto &v: xyz_values) {
+				for (const auto &o: move_options) {
+					if (o == move_x_action) {
+						move_x_options_positive.emplace_back(
+							Saylink::Create(fmt::format("#door edit {} {}", o, v), true, v)
+						);
+					}
+					else if (o == move_y_action) {
+						move_y_options_positive.emplace_back(
+							Saylink::Create(fmt::format("#door edit {} {}", o, v), true, v)
+						);
+					}
+					else if (o == move_z_action) {
+						move_z_options_positive.emplace_back(
+							Saylink::Create(fmt::format("#door edit {} {}", o, v), true, v)
+						);
+					}
 				}
 			}
 
-			// -X
-			glm::vec4 door_position = door->GetPosition();
-			if (helper_mob_x_negative == 0) {
-				door_position.x = door_position.x - 15;
-				helper_mob_x_negative = NPC::SpawnNodeNPC("-X", "", door_position)->GetID();
-			}
-			else {
-				auto n = entity_list.GetNPCByID(helper_mob_x_negative);
-				n->GMMove(door->GetX() - 15, door->GetY(), door->GetZ(), n->GetHeading());
-			}
-
-			// +X
-			door_position = door->GetPosition();
-			if (helper_mob_x_positive == 0) {
-				door_position.x = door_position.x + 15;
-				helper_mob_x_positive = NPC::SpawnNodeNPC("+X", "", door_position)->GetID();
-			}
-			else {
-				auto n = entity_list.GetNPCByID(helper_mob_x_positive);
-				n->GMMove(door->GetX() + 15, door->GetY(), door->GetZ(), n->GetHeading());
-			}
-
-			// -Y
-			door_position = door->GetPosition();
-			if (helper_mob_y_negative == 0) {
-				door_position.y = door_position.y - 15;
-				helper_mob_y_negative = NPC::SpawnNodeNPC("-Y", "", door_position)->GetID();
-			}
-			else {
-				auto n = entity_list.GetNPCByID(helper_mob_y_negative);
-				n->GMMove(door->GetX(), door->GetY() - 15, door->GetZ(), n->GetHeading());
+			// loop through vector in reverse order
+			// build negative options x/y/z
+			for (auto v = xyz_values.rbegin(); v != xyz_values.rend(); ++v) {
+				for (const auto &o: move_options) {
+					if (o == move_x_action) {
+						move_x_options_negative.emplace_back(
+							Saylink::Create(fmt::format("#door edit {} -{}", o, *v), true, *v)
+						);
+					}
+					else if (o == move_y_action) {
+						move_y_options_negative.emplace_back(
+							Saylink::Create(fmt::format("#door edit {} -{}", o, *v), true, *v)
+						);
+					}
+					else if (o == move_z_action) {
+						move_z_options_negative.emplace_back(
+							Saylink::Create(fmt::format("#door edit {} -{}", o, *v), true, *v)
+						);
+					}
+				}
 			}
 
-			// +Y
-			door_position = door->GetPosition();
-			if (helper_mob_y_positive == 0) {
-				door_position.y = door_position.y + 15;
-				helper_mob_y_positive = NPC::SpawnNodeNPC("+Y", "", door_position)->GetID();
+			std::vector<std::string> heading_values = {
+				"1", "5", "32.5", "63.75", "130",
+			};
+
+			// build positive options h
+			for (const auto &v: heading_values) {
+				move_h_options_positive.emplace_back(
+					Saylink::Create(fmt::format("#door edit {} {}", move_h_action, v), true, v)
+				);
 			}
-			else {
-				auto n = entity_list.GetNPCByID(helper_mob_y_positive);
-				n->GMMove(door->GetX(), door->GetY() + 15, door->GetZ(), n->GetHeading());
+
+			// loop through vector in reverse order
+			// build negative options h
+			for (auto v = heading_values.rbegin(); v != heading_values.rend(); ++v) {
+				move_h_options_negative.emplace_back(
+					Saylink::Create(fmt::format("#door edit {} -{}", move_h_action, *v), true, *v)
+				);
+			}
+
+			std::vector<std::string> size_values = {
+				"1", "5", "10", "25", "50", "100", "1000"
+			};
+
+			// build positive options size
+			for (const auto &v: size_values) {
+				set_size_options_positive.emplace_back(
+					Saylink::Create(fmt::format("#door edit {} {}", set_size_action, v), true, v)
+				);
+			}
+
+			// loop through vector in reverse order
+			// build negative options size
+			for (auto v = size_values.rbegin(); v != size_values.rend(); ++v) {
+				set_size_options_negative.emplace_back(
+					Saylink::Create(fmt::format("#door edit {} -{}", set_size_action, *v), true, *v)
+				);
 			}
 
 			c->Message(
@@ -412,17 +278,17 @@ void DoorManipulation::CommandHandler(Client *c, const Seperator *sep)
 					door->GetDoorName(),
 					Saylink::Create(
 						"#door save",
-						false,
+						true,
 						"Save"
 					),
 					Saylink::Create(
 						"#door changemodelqueue",
-						false,
+						true,
 						"Change Model"
 					),
 					Saylink::Create(
 						"#door setinclineinc",
-						false,
+						true,
 						"Incline"
 					)
 				).c_str()
@@ -505,8 +371,8 @@ void DoorManipulation::CommandHandler(Client *c, const Seperator *sep)
 			Chat::White,
 			fmt::format(
 				"#door model <modelname> | Changes door model for selected door or select from [{}] or [{}]",
-				Saylink::Create("#door showmodelszone", false, "local zone"),
-				Saylink::Create("#door showmodelsglobal", false, "global")
+				Saylink::Create("#door showmodelszone", true, "local zone"),
+				Saylink::Create("#door showmodelsglobal", true, "global")
 			).c_str()
 		);
 	}
@@ -527,7 +393,7 @@ void DoorManipulation::CommandHandler(Client *c, const Seperator *sep)
 		}
 	}
 
-	// incline
+	// invertstate
 	if (arg1 == "setinvertstate" && !arg2.empty() && Strings::IsNumber(arg2)) {
 		Doors *door = entity_list.GetDoorsByID(c->GetDoorToolEntityId());
 		if (door) {
@@ -551,6 +417,7 @@ void DoorManipulation::CommandHandler(Client *c, const Seperator *sep)
 			door->SetIncline(door->GetIncline() + std::atoi(arg2.c_str()));
 		}
 	}
+
 	if (arg1 == "setinclineinc") {
 		std::map<float, std::string> incline_values = {
 			{.01,    "Upright"},
@@ -567,14 +434,14 @@ void DoorManipulation::CommandHandler(Client *c, const Seperator *sep)
 		std::vector<std::string> incline_normal_options;
 		std::vector<std::string> incline_positive_options;
 		std::vector<std::string> incline_negative_options;
-		for (auto                incline_value : incline_values) {
+		for (auto                incline_value: incline_values) {
 			incline_normal_options.emplace_back(
 				Saylink::Create(
 					fmt::format(
 						"#door setincline {}",
 						incline_value.first
 					),
-					false,
+					true,
 					incline_value.second
 				)
 			);
@@ -588,7 +455,7 @@ void DoorManipulation::CommandHandler(Client *c, const Seperator *sep)
 						"#door setinclineinc {}",
 						incline_value
 					),
-					false,
+					true,
 					itoa(std::abs(incline_value))
 				)
 			);
@@ -602,7 +469,7 @@ void DoorManipulation::CommandHandler(Client *c, const Seperator *sep)
 						"#door setinclineinc {}",
 						incline_value
 					),
-					false,
+					true,
 					itoa(std::abs(incline_value))
 				)
 			);
@@ -680,6 +547,64 @@ void DoorManipulation::CommandHandler(Client *c, const Seperator *sep)
 
 		DisplayObjectResultToClient(c, game_objects);
 	}
+
+	// help menu
+	if (arg1.empty()) {
+		DoorManipulation::CommandHeader(c);
+		c->Message(
+			Chat::White,
+			"#door create <modelname> | Creates a door from a model. (Example IT78 creates a campfire)"
+		);
+		c->Message(Chat::White, "#door setinvertstate [0|1] | Sets selected door invert state");
+		c->Message(Chat::White, "#door setincline <incline> | Sets selected door incline");
+		c->Message(Chat::White, "#door opentype <opentype> | Sets selected door opentype");
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"#door model <modelname> | Changes door model for selected door or select from [{}] or [{}]",
+				Saylink::Create("#door showmodelszone", true, "local zone"),
+				Saylink::Create("#door showmodelsglobal", true, "global")
+			).c_str()
+		);
+		c->Message(
+			Chat::White,
+			"#door showmodelsfromfile <file.eqg|file.s3d> | Shows models from s3d or eqg file. Example tssequip.eqg or wallet01.eqg"
+		);
+
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"{} | Shows available models in the current zone that you are in",
+				Saylink::Create("#door showmodelszone", true, "#door showmodelszone")
+			).c_str()
+		);
+
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"{} | Shows available models globally by first listing all global model files",
+				Saylink::Create("#door showmodelsglobal", true, "#door showmodelsglobal")
+			).c_str()
+		);
+
+		c->Message(Chat::White, "#door save | Creates database entry for selected door");
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"{} - Brings up editing interface for selected door",
+				Saylink::Create("#door edit", true, "#door edit")
+			).c_str()
+		);
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"{} - lists doors in zone",
+				Saylink::Create("#list doors", true, "#list doors")
+			).c_str()
+		);
+
+		return;
+	}
 }
 
 void DoorManipulation::CommandHeader(Client *c)
@@ -702,7 +627,7 @@ void DoorManipulation::DisplayObjectResultToClient(
 				"[{}] ",
 				Saylink::Create(
 					fmt::format("#door model {}", g.object_name),
-					false,
+					true,
 					g.object_name
 				)
 			)
@@ -750,7 +675,7 @@ void DoorManipulation::DisplayModelsFromFileResults(
 				"[{}] ",
 				Saylink::Create(
 					fmt::format("#door showmodelsfromfile {}", g.file_from),
-					false,
+					true,
 					g.file_from
 				)
 			)

--- a/zone/npc_scale_manager.cpp
+++ b/zone/npc_scale_manager.cpp
@@ -28,7 +28,7 @@
  */
 void NpcScaleManager::ScaleNPC(NPC *npc)
 {
-	if (npc->IsSkipAutoScale()) {
+	if (npc->IsSkipAutoScale() || npc->GetNPCTypeID() == 0) {
 		return;
 	}
 


### PR DESCRIPTION
This PR is in response to https://github.com/EQEmu/Server/issues/2367

**Changes**

* Simplified the saylink menu building
* Fixed a bug where `Doors` scoped variables were the same as variables being passed in so member variables were not being set and creating uninitialized behavior - resulting in created objects being incredibly small or large
* Refactored private member variables to be `m_` prefixed for readability and addressing / preventing the above issue from happening again
* Silent saylinks now pipe to commands (So when a saylink is clicked it doesn't result in. "You say, "message"")
* NPC Scale Manager now skips the door helpers because they have no NPC type ID assigned
* The door menu no longer prints every time a command is clicked (because silent saylinks now work)
* All door edit commands were converted to silent saylinks
* Door target saylink was converted to be silent

PR needs additional testers to make sure nothing was broken around EVENT_SAY, EVENT_COMMAND and any other say behaviors because of code consolidation, cleanup

![image](https://user-images.githubusercontent.com/3319450/184509660-e97c139f-f25b-42b1-88b3-69f5efd223e9.png)
