### PR TITLE
[Saylinks] Convert all GM Command Saylinks to Silent Saylinks.

### DIFF
--- a/common/say_link.cpp
+++ b/common/say_link.cpp
@@ -420,9 +420,9 @@ SaylinkRepository::Saylink EQ::SayLinkEngine::GetOrSaveSaylink(std::string sayli
 
 std::string Saylink::Create(const std::string &saylink_text, bool silent, const std::string &link_name)
 {
-	return EQ::SayLinkEngine::GenerateQuestSaylink(saylink_text, silent, link_name);
+	return EQ::SayLinkEngine::GenerateQuestSaylink(saylink_text, silent, (link_name.empty() ? saylink_text : link_name));
 }
 
 std::string Saylink::Silent(const std::string &saylink_text, const std::string &link_name) {
-	return EQ::SayLinkEngine::GenerateQuestSaylink(saylink_text, true, link_name);
+	return EQ::SayLinkEngine::GenerateQuestSaylink(saylink_text, true, (link_name.empty() ? saylink_text : link_name));
 }

--- a/common/say_link.h
+++ b/common/say_link.h
@@ -129,8 +129,8 @@ namespace EQ
 
 class Saylink {
 public:
-	static std::string Create(const std::string &saylink_text, bool silent, const std::string &link_name);
-	static std::string Silent(const std::string &saylink_text, const std::string &link_name);
+	static std::string Create(const std::string &saylink_text, bool silent, const std::string &link_name = "");
+	static std::string Silent(const std::string &saylink_text, const std::string &link_name = "");
 };
 
 #endif /*COMMON_SAY_LINK_H*/

--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -5938,9 +5938,8 @@ void bot_subcommand_bot_list(Client *c, const Seperator *sep)
 		}
 
 		auto* bot = entity_list.GetBotByBotName(bots_iter.Name);
-		auto bot_spawn_saylink = Saylink::Create(
+		auto bot_spawn_saylink = Saylink::Silent(
 			fmt::format("^spawn {}", bots_iter.Name),
-			false,
 			bots_iter.Name
 		);
 
@@ -7318,9 +7317,8 @@ void bot_subcommand_botgroup_list(Client *c, const Seperator *sep)
 				botgroups_iter.first,
 				botgroups_iter.second,
 				database.botdb.IsBotGroupAutoSpawn(botgroups_iter.first) ? " (Auto Spawn)" : "",
-				Saylink::Create(
+				Saylink::Silent(
 					fmt::format("^botgroupload {}", botgroups_iter.first),
-					false,
 					"Load"
 				)
 			).c_str()
@@ -8825,9 +8823,8 @@ void bot_subcommand_inventory_list(Client *c, const Seperator *sep)
 				slot_id,
 				EQ::invslot::GetInvPossessionsSlotName(slot_id),
 				linker.GenerateLink(),
-				Saylink::Create(
+				Saylink::Silent(
 					fmt::format("^inventoryremove {}", slot_id),
-					false,
 					"Remove"
 				)
 			).c_str()
@@ -9354,7 +9351,7 @@ uint32 helper_bot_create(Client *bot_owner, std::string bot_name, uint8 bot_clas
 	if (!Bot::IsValidRaceClassCombo(bot_race, bot_class)) {
 		const char* bot_race_name = GetRaceIDName(bot_race);
 		const char* bot_class_name = GetClassIDName(bot_class);
-		std::string view_saylink = Saylink::Create(fmt::format("^viewcombos {}", bot_race), false, "view");
+		std::string view_saylink = Saylink::Silent(fmt::format("^viewcombos {}", bot_race), "view");
 		bot_owner->Message(
 			Chat::White,
 			fmt::format(

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -3903,9 +3903,8 @@ void Client::EnteringMessages(Client* client)
 	if (database.GetVariable("Rules", rules)) {
 		uint8 flag = database.GetAgreementFlag(client->AccountID());
 		if (!flag) {
-			auto rules_link = Saylink::Create(
+			auto rules_link = Saylink::Silent(
 				"#serverrules",
-				false,
 				"rules"
 			);
 
@@ -9539,60 +9538,60 @@ void Client::ShowDevToolsMenu()
 	/**
 	 * Search entity commands
 	 */
-	menu_search += Saylink::Create("#list corpses", false, "Corpses");
-	menu_search += " | " + Saylink::Create("#list doors", false, "Doors");
-	menu_search += " | " + Saylink::Create("#finditem", false, "Items");
-	menu_search += " | " + Saylink::Create("#list npcs", false, "NPC");
-	menu_search += " | " + Saylink::Create("#list objects", false, "Objects");
-	menu_search += " | " + Saylink::Create("#list players", false, "Players");
-	menu_search += " | " + Saylink::Create("#findzone", false, "Zones");
+	menu_search += Saylink::Silent("#list corpses", "Corpses");
+	menu_search += " | " + Saylink::Silent("#list doors", "Doors");
+	menu_search += " | " + Saylink::Silent("#finditem", "Items");
+	menu_search += " | " + Saylink::Silent("#list npcs", "NPC");
+	menu_search += " | " + Saylink::Silent("#list objects", "Objects");
+	menu_search += " | " + Saylink::Silent("#list players", "Players");
+	menu_search += " | " + Saylink::Silent("#findzone", "Zones");
 
 	/**
 	 * Show
 	 */
-	menu_show += Saylink::Create("#showzonepoints", false, "Zone Points");
-	menu_show += " | " + Saylink::Create("#showzonegloballoot", false, "Zone Global Loot");
+	menu_show += Saylink::Silent("#showzonepoints", "Zone Points");
+	menu_show += " | " + Saylink::Silent("#showzonegloballoot", "Zone Global Loot");
 
 	/**
 	 * Reload
 	 */
-	menu_reload_one += Saylink::Create("#reload aa", false, "AAs");
-	menu_reload_one += " | " + Saylink::Create("#reload alternate_currencies", false, "Alternate Currencies");
-	menu_reload_one += " | " + Saylink::Create("#reload blocked_spells", false, "Blocked Spells");
-	menu_reload_one += " | " + Saylink::Create("#reload content_flags", false, "Content Flags");
+	menu_reload_one += Saylink::Silent("#reload aa", "AAs");
+	menu_reload_one += " | " + Saylink::Silent("#reload alternate_currencies", "Alternate Currencies");
+	menu_reload_one += " | " + Saylink::Silent("#reload blocked_spells", "Blocked Spells");
+	menu_reload_one += " | " + Saylink::Silent("#reload content_flags", "Content Flags");
 
-	menu_reload_two += Saylink::Create("#reload doors", false, "Doors");
-	menu_reload_two += " | " + Saylink::Create("#reload ground_spawns", false, "Ground Spawns");
+	menu_reload_two += Saylink::Silent("#reload doors", "Doors");
+	menu_reload_two += " | " + Saylink::Silent("#reload ground_spawns", "Ground Spawns");
 
-	menu_reload_three += Saylink::Create("#reload logs", false, "Level Based Experience Modifiers");
-	menu_reload_three += " | " + Saylink::Create("#reload logs", false, "Log Settings");
+	menu_reload_three += Saylink::Silent("#reload logs", "Level Based Experience Modifiers");
+	menu_reload_three += " | " + Saylink::Silent("#reload logs", "Log Settings");
 
-	menu_reload_four += Saylink::Create("#reload merchants", false, "Merchants");
-	menu_reload_four += " | " + Saylink::Create("#reload npc_emotes", false, "NPC Emotes");
-	menu_reload_four += " | " + Saylink::Create("#reload objects", false, "Objects");
+	menu_reload_four += Saylink::Silent("#reload merchants", "Merchants");
+	menu_reload_four += " | " + Saylink::Silent("#reload npc_emotes", "NPC Emotes");
+	menu_reload_four += " | " + Saylink::Silent("#reload objects", "Objects");
 
-	menu_reload_five += Saylink::Create("#reload perl_export", false, "Perl Event Export Settings");
-	menu_reload_five += " | " + Saylink::Create("#reload quest", false, "Quests");
+	menu_reload_five += Saylink::Silent("#reload perl_export", "Perl Event Export Settings");
+	menu_reload_five += " | " + Saylink::Silent("#reload quest", "Quests");
 
-	menu_reload_six += Saylink::Create("#reload rules", false, "Rules");
-	menu_reload_six += " | " + Saylink::Create("#reload static", false, "Static Zone Data");
-	menu_reload_six += " | " + Saylink::Create("#reload tasks", false, "Tasks");
+	menu_reload_six += Saylink::Silent("#reload rules", "Rules");
+	menu_reload_six += " | " + Saylink::Silent("#reload static", "Static Zone Data");
+	menu_reload_six += " | " + Saylink::Silent("#reload tasks", "Tasks");
 
-	menu_reload_seven += Saylink::Create("#reload titles", false, "Titles");
-	menu_reload_seven += " | " + Saylink::Create("#reload traps 1", false, "Traps");
-	menu_reload_seven += " | " + Saylink::Create("#reload variables", false, "Variables");
-	menu_reload_seven += " | " + Saylink::Create("#reload veteran_rewards", false, "Veteran Rewards");
+	menu_reload_seven += Saylink::Silent("#reload titles", "Titles");
+	menu_reload_seven += " | " + Saylink::Silent("#reload traps 1", "Traps");
+	menu_reload_seven += " | " + Saylink::Silent("#reload variables", "Variables");
+	menu_reload_seven += " | " + Saylink::Silent("#reload veteran_rewards", "Veteran Rewards");
 
-	menu_reload_eight += Saylink::Create("#reload world", false, "World");
-	menu_reload_eight += " | " + Saylink::Create("#reload zone", false, "Zone");
-	menu_reload_eight += " | " + Saylink::Create("#reload zone_points", false, "Zone Points");
+	menu_reload_eight += Saylink::Silent("#reload world", "World");
+	menu_reload_eight += " | " + Saylink::Silent("#reload zone", "Zone");
+	menu_reload_eight += " | " + Saylink::Silent("#reload zone_points", "Zone Points");
 
 	/**
 	 * Show window status
 	 */
-	menu_toggle = Saylink::Create("#devtools enable", false, "Enable");
+	menu_toggle = Saylink::Silent("#devtools enable", "Enable");
 	if (IsDevToolsEnabled()) {
-		menu_toggle = Saylink::Create("#devtools disable", false, "Disable");
+		menu_toggle = Saylink::Silent("#devtools disable", "Disable");
 	}
 
 	/**
@@ -9614,7 +9613,7 @@ void Client::ShowDevToolsMenu()
 		Chat::White,
 		fmt::format(
 			"Show Menu | {}",
-			Saylink::Create("#dev", false, "#dev")
+			Saylink::Silent("#dev", "#dev")
 		).c_str()
 	);
 
@@ -9706,11 +9705,7 @@ void Client::ShowDevToolsMenu()
 		).c_str()
 	);
 
-	auto help_link = Saylink::Create(
-		"#help",
-		false,
-		"#help"
-	);
+	auto help_link = Saylink::Silent("#help", "#help");
 
 	Message(
 		Chat::White,
@@ -11276,11 +11271,7 @@ void Client::ReconnectUCS()
 void Client::SendReloadCommandMessages() {
 	SendChatLineBreak();
 
-	auto aa_link = Saylink::Create(
-		"#reload aa",
-		false,
-		"#reload aa"
-	);
+	auto aa_link = Saylink::Silent("#reload aa");
 
 	Message(
 		Chat::White,
@@ -11290,11 +11281,7 @@ void Client::SendReloadCommandMessages() {
 		).c_str()
 	);
 
-	auto alternate_currencies_link = Saylink::Create(
-		"#reload alternate_currencies",
-		false,
-		"#reload alternate_currencies"
-	);
+	auto alternate_currencies_link = Saylink::Silent("#reload alternate_currencies");
 
 	Message(
 		Chat::White,
@@ -11304,11 +11291,7 @@ void Client::SendReloadCommandMessages() {
 		).c_str()
 	);
 
-	auto blocked_spells_link = Saylink::Create(
-		"#reload blocked_spells",
-		false,
-		"#reload blocked_spells"
-	);
+	auto blocked_spells_link = Saylink::Silent("#reload blocked_spells");
 
 	Message(
 		Chat::White,
@@ -11318,11 +11301,7 @@ void Client::SendReloadCommandMessages() {
 		).c_str()
 	);
 
-	auto content_flags_link = Saylink::Create(
-		"#reload content_flags",
-		false,
-		"#reload content_flags"
-	);
+	auto content_flags_link = Saylink::Silent("#reload content_flags");
 
 	Message(
 		Chat::White,
@@ -11332,11 +11311,7 @@ void Client::SendReloadCommandMessages() {
 		).c_str()
 	);
 
-	auto doors_link = Saylink::Create(
-		"#reload doors",
-		false,
-		"#reload doors"
-	);
+	auto doors_link = Saylink::Silent("#reload doors");
 
 	Message(
 		Chat::White,
@@ -11346,14 +11321,10 @@ void Client::SendReloadCommandMessages() {
 		).c_str()
 	);
 
-	auto dztemplates_link = Saylink::Create("#reload dztemplates", false, "#reload dztemplates");
+	auto dztemplates_link = Saylink::Silent("#reload dztemplates");
 	Message(Chat::White, fmt::format("Usage: {} - Reloads Dynamic Zone Templates globally", dztemplates_link).c_str());
 
-	auto ground_spawns_link = Saylink::Create(
-		"#reload ground_spawns",
-		false,
-		"#reload ground_spawns"
-	);
+	auto ground_spawns_link = Saylink::Silent("#reload ground_spawns");
 
 	Message(
 		Chat::White,
@@ -11363,11 +11334,7 @@ void Client::SendReloadCommandMessages() {
 		).c_str()
 	);
 
-	auto level_mods_link = Saylink::Create(
-		"#reload level_mods",
-		false,
-		"#reload level_mods"
-	);
+	auto level_mods_link = Saylink::Silent("#reload level_mods");
 
 	Message(
 		Chat::White,
@@ -11377,11 +11344,7 @@ void Client::SendReloadCommandMessages() {
 		).c_str()
 	);
 
-	auto logs_link = Saylink::Create(
-		"#reload logs",
-		false,
-		"#reload logs"
-	);
+	auto logs_link = Saylink::Silent("#reload logs");
 
 	Message(
 		Chat::White,
@@ -11391,11 +11354,7 @@ void Client::SendReloadCommandMessages() {
 		).c_str()
 	);
 
-	auto merchants_link = Saylink::Create(
-		"#reload merchants",
-		false,
-		"#reload merchants"
-	);
+	auto merchants_link = Saylink::Silent("#reload merchants");
 
 	Message(
 		Chat::White,
@@ -11405,11 +11364,7 @@ void Client::SendReloadCommandMessages() {
 		).c_str()
 	);
 
-	auto npc_emotes_link = Saylink::Create(
-		"#reload npc_emotes",
-		false,
-		"#reload npc_emotes"
-	);
+	auto npc_emotes_link = Saylink::Silent("#reload npc_emotes");
 
 	Message(
 		Chat::White,
@@ -11419,11 +11374,7 @@ void Client::SendReloadCommandMessages() {
 		).c_str()
 	);
 
-	auto objects_link = Saylink::Create(
-		"#reload objects",
-		false,
-		"#reload objects"
-	);
+	auto objects_link = Saylink::Silent("#reload objects");
 
 	Message(
 		Chat::White,
@@ -11433,11 +11384,7 @@ void Client::SendReloadCommandMessages() {
 		).c_str()
 	);
 
-	auto perl_export_link = Saylink::Create(
-		"#reload perl_export",
-		false,
-		"#reload perl_export"
-	);
+	auto perl_export_link = Saylink::Silent("#reload perl_export");
 
 	Message(
 		Chat::White,
@@ -11447,23 +11394,9 @@ void Client::SendReloadCommandMessages() {
 		).c_str()
 	);
 
-	auto quest_link_one = Saylink::Create(
-		"#reload quest",
-		false,
-		"#reload quest"
-	);
-
-	auto quest_link_two = Saylink::Create(
-		"#reload quest",
-		false,
-		"0"
-	);
-
-	auto quest_link_three = Saylink::Create(
-		"#reload quest 1",
-		false,
-		"1"
-	);
+	auto quest_link_one = Saylink::Silent("#reload quest");
+	auto quest_link_two = Saylink::Silent("#reload quest", "0");
+	auto quest_link_three = Saylink::Silent("#reload quest 1", "1");
 
 	Message(
 		Chat::White,
@@ -11475,11 +11408,7 @@ void Client::SendReloadCommandMessages() {
 		).c_str()
 	);
 
-	auto rules_link = Saylink::Create(
-		"#reload rules",
-		false,
-		"#reload rules"
-	);
+	auto rules_link = Saylink::Silent("#reload rules");
 
 	Message(
 		Chat::White,
@@ -11489,11 +11418,7 @@ void Client::SendReloadCommandMessages() {
 		).c_str()
 	);
 
-	auto static_link = Saylink::Create(
-		"#reload static",
-		false,
-		"#reload static"
-	);
+	auto static_link = Saylink::Silent("#reload static");
 
 	Message(
 		Chat::White,
@@ -11503,11 +11428,7 @@ void Client::SendReloadCommandMessages() {
 		).c_str()
 	);
 
-	auto tasks_link = Saylink::Create(
-		"#reload tasks",
-		false,
-		"#reload tasks"
-	);
+	auto tasks_link = Saylink::Silent("#reload tasks");
 
 	Message(
 		Chat::White,
@@ -11517,11 +11438,7 @@ void Client::SendReloadCommandMessages() {
 		).c_str()
 	);
 
-	auto titles_link = Saylink::Create(
-		"#reload titles",
-		false,
-		"#reload titles"
-	);
+	auto titles_link = Saylink::Silent("#reload titles");
 
 	Message(
 		Chat::White,
@@ -11531,23 +11448,9 @@ void Client::SendReloadCommandMessages() {
 		).c_str()
 	);
 
-	auto traps_link_one = Saylink::Create(
-		"#reload traps",
-		false,
-		"#reload traps"
-	);
-
-	auto traps_link_two = Saylink::Create(
-		"#reload traps",
-		false,
-		"0"
-	);
-
-	auto traps_link_three = Saylink::Create(
-		"#reload traps 1",
-		false,
-		"1"
-	);
+	auto traps_link_one = Saylink::Silent("#reload traps");
+	auto traps_link_two = Saylink::Silent("#reload traps", "0");
+	auto traps_link_three = Saylink::Silent("#reload traps 1", "1");
 
 	Message(
 		Chat::White,
@@ -11559,11 +11462,7 @@ void Client::SendReloadCommandMessages() {
 		).c_str()
 	);
 
-	auto variables_link = Saylink::Create(
-		"#reload variables",
-		false,
-		"#reload variables"
-	);
+	auto variables_link = Saylink::Silent("#reload variables");
 
 	Message(
 		Chat::White,
@@ -11573,11 +11472,7 @@ void Client::SendReloadCommandMessages() {
 		).c_str()
 	);
 
-	auto veteran_rewards_link = Saylink::Create(
-		"#reload veteran_rewards",
-		false,
-		"#reload veteran_rewards"
-	);
+	auto veteran_rewards_link = Saylink::Silent("#reload veteran_rewards");
 
 	Message(
 		Chat::White,
@@ -11587,29 +11482,10 @@ void Client::SendReloadCommandMessages() {
 		).c_str()
 	);
 
-	auto world_link_one = Saylink::Create(
-		"#reload world",
-		false,
-		"#reload world"
-	);
-
-	auto world_link_two = Saylink::Create(
-		"#reload world",
-		false,
-		"0"
-	);
-
-	auto world_link_three = Saylink::Create(
-		"#reload world 1",
-		false,
-		"1"
-	);
-
-	auto world_link_four = Saylink::Create(
-		"#reload world 2",
-		false,
-		"2"
-	);
+	auto world_link_one = Saylink::Silent("#reload world");
+	auto world_link_two = Saylink::Silent("#reload world", "0");
+	auto world_link_three = Saylink::Silent("#reload world 1", "1");
+	auto world_link_four = Saylink::Silent("#reload world 2", "2");
 
 	Message(
 		Chat::White,
@@ -11622,11 +11498,7 @@ void Client::SendReloadCommandMessages() {
 		).c_str()
 	);
 
-	auto zone_link = Saylink::Create(
-		"#reload zone",
-		false,
-		"#reload zone"
-	);
+	auto zone_link = Saylink::Silent("#reload zone");
 
 	Message(
 		Chat::White,
@@ -11636,11 +11508,7 @@ void Client::SendReloadCommandMessages() {
 		).c_str()
 	);
 
-	auto zone_points_link = Saylink::Create(
-		"#reload zone_points",
-		false,
-		"#reload zone_points"
-	);
+	auto zone_points_link = Saylink::Silent("#reload zone_points");
 
 	Message(
 		Chat::White,

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4265,7 +4265,7 @@ void Client::Handle_OP_ClickDoor(const EQApplicationPacket *app)
 			fmt::format(
 				"Door ({}) [{}]",
 				currentdoor->GetEntityID(),
-				Saylink::Create("#door edit", true, "#door edit")
+				Saylink::Silent("#door edit", "#door edit")
 			).c_str()
 		);
 	}

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -606,13 +606,12 @@ void command_help(Client *c, const Seperator *sep)
 			continue;
 		}
 
-		command_link = Saylink::Create(
+		command_link = Saylink::Silent(
 			fmt::format(
 				"{}{}",
 				COMMAND_CHAR,
 				cur.first
 			),
-			false,
 			fmt::format(
 				"{}{}",
 				COMMAND_CHAR,
@@ -688,13 +687,12 @@ void command_findaliases(Client *c, const Seperator *sep)
 		return;
 	}
 
-	auto current_commmand_link = Saylink::Create(
+	auto current_commmand_link = Saylink::Silent(
 		fmt::format(
 			"{}{}",
 			COMMAND_CHAR,
 			command_iter->first
 		),
-		false,
 		fmt::format(
 			"{}{}",
 			COMMAND_CHAR,
@@ -713,13 +711,12 @@ void command_findaliases(Client *c, const Seperator *sep)
 			continue;
 		}
 
-		alias_link = Saylink::Create(
+		alias_link = Saylink::Silent(
 			fmt::format(
 				"{}{}",
 				COMMAND_CHAR,
 				a.first
 			),
-			false,
 			fmt::format(
 				"{}{}",
 				COMMAND_CHAR,

--- a/zone/dialogue_window.cpp
+++ b/zone/dialogue_window.cpp
@@ -326,7 +326,7 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 	if (responses.size() > 1) {
 		for (auto &r: responses) {
 			bracket_responses.emplace_back(
-				fmt::format("[{}]", Saylink::Create(r, false, r))
+				fmt::format("[{}]", Saylink::Create(r, false))
 			);
 		}
 	}

--- a/zone/gm_commands/databuckets.cpp
+++ b/zone/gm_commands/databuckets.cpp
@@ -68,7 +68,7 @@ void command_databuckets(Client *c, const Seperator *sep)
 			c->Message(
 				Chat::White,
 				"%s : %s",
-				Saylink::Create(del_saylink, false, "Delete").c_str(),
+				Saylink::Silent(del_saylink, "Delete").c_str(),
 				key.c_str(),
 				"  Value:  ",
 				value.c_str());

--- a/zone/gm_commands/door_manipulation.cpp
+++ b/zone/gm_commands/door_manipulation.cpp
@@ -560,7 +560,7 @@ void DoorManipulation::CommandHandler(Client *c, const Seperator *sep)
 			Chat::White,
 			fmt::format(
 				"{} | Shows available models in the current zone that you are in",
-				Saylink::Silent("#door showmodelszone", "#door showmodelszone")
+				Saylink::Silent("#door showmodelszone")
 			).c_str()
 		);
 
@@ -568,7 +568,7 @@ void DoorManipulation::CommandHandler(Client *c, const Seperator *sep)
 			Chat::White,
 			fmt::format(
 				"{} | Shows available models globally by first listing all global model files",
-				Saylink::Silent("#door showmodelsglobal", "#door showmodelsglobal")
+				Saylink::Silent("#door showmodelsglobal")
 			).c_str()
 		);
 
@@ -577,14 +577,14 @@ void DoorManipulation::CommandHandler(Client *c, const Seperator *sep)
 			Chat::White,
 			fmt::format(
 				"{} - Brings up editing interface for selected door",
-				Saylink::Silent("#door edit", "#door edit")
+				Saylink::Silent("#door edit")
 			).c_str()
 		);
 		c->Message(
 			Chat::White,
 			fmt::format(
 				"{} - lists doors in zone",
-				Saylink::Silent("#list doors", "#list doors")
+				Saylink::Silent("#list doors")
 			).c_str()
 		);
 

--- a/zone/gm_commands/dz.cpp
+++ b/zone/gm_commands/dz.cpp
@@ -42,12 +42,19 @@ void command_dz(Client *c, const Seperator *sep)
 					continue;
 				}
 
-				auto leader_saylink = Saylink::Create(
+				auto leader_saylink = Saylink::Silent(
 					fmt::format(
-						"#goto {}", expedition->GetLeaderName()), false, expedition->GetLeaderName());
-				auto zone_saylink   = Saylink::Create(
+						"#goto {}",
+						expedition->GetLeaderName()
+					),
+					expedition->GetLeaderName()
+				);
+				auto zone_saylink = Saylink::Silent(
 					fmt::format(
-						"#zoneinstance {}", dz->GetInstanceID()), false, "zone"
+						"#zoneinstance {}",
+						dz->GetInstanceID()
+					),
+					"zone"
 				);
 
 				auto seconds = dz->GetSecondsRemaining();
@@ -123,8 +130,12 @@ void command_dz(Client *c, const Seperator *sep)
 
 		for (const auto &dz : dynamic_zones) {
 			auto seconds      = dz->GetSecondsRemaining();
-			auto zone_saylink = Saylink::Create(
-				fmt::format("#zoneinstance {}", dz->GetInstanceID()), false, "zone"
+			auto zone_saylink = Saylink::Silent(
+				fmt::format(
+					"#zoneinstance {}",
+					dz->GetInstanceID()
+				),
+				"zone"
 			);
 
 			std::string aligned_type = fmt::format(
@@ -159,8 +170,12 @@ void command_dz(Client *c, const Seperator *sep)
 			bool is_expired  = now > expire_time;
 
 			if (!is_expired || strcasecmp(sep->arg[2], "all") == 0) {
-				auto zone_saylink = is_expired ? "zone" : Saylink::Create(
-					fmt::format("#zoneinstance {}", dz.instance), false, "zone"
+				auto zone_saylink = is_expired ? "zone" : Saylink::Silent(
+					fmt::format(
+						"#zoneinstance {}",
+						dz.instance
+					),
+					"zone"
 				);
 
 				c->Message(

--- a/zone/gm_commands/editmassrespawn.cpp
+++ b/zone/gm_commands/editmassrespawn.cpp
@@ -126,7 +126,7 @@ void command_editmassrespawn(Client *c, const Seperator *sep)
 
 				c->Message(
 					Chat::Yellow, "To apply these changes, click <%s> or type [%s]",
-					Saylink::Create(saylink, false, "Apply").c_str(),
+					Saylink::Silent(saylink, "Apply").c_str(),
 					saylink.c_str()
 				);
 			}

--- a/zone/gm_commands/faction.cpp
+++ b/zone/gm_commands/faction.cpp
@@ -56,9 +56,8 @@ void command_faction(Client *c, const Seperator *sep)
 			auto        faction_id     = std::stoul(row[0]);
 			std::string faction_name   = row[1];
 			std::string faction_value  = row[2];
-			std::string reset_link     = Saylink::Create(
+			std::string reset_link     = Saylink::Silent(
 				fmt::format("#faction reset {}", faction_id),
-				false,
 				"Reset"
 			);
 

--- a/zone/gm_commands/feature.cpp
+++ b/zone/gm_commands/feature.cpp
@@ -4,11 +4,7 @@ void command_feature(Client *c, const Seperator *sep)
 {
 	int arguments = sep->argnum;
 	if (arguments < 2 || !sep->IsNumber(2)) {
-		auto feature_save_link = Saylink::Create(
-			"#npcedit featuresave",
-			false,
-			"#npcedit featuresave"
-		);
+		auto feature_save_link = Saylink::Silent("#npcedit featuresave");
 
 		c->Message(Chat::White, "Usage: #feature beard [Beard] - Change your or your target's Beard");
 		c->Message(Chat::White, "Usage: #feature beardcolor [Beard Color] - Change your or your target's Beard Color");
@@ -67,11 +63,7 @@ void command_feature(Client *c, const Seperator *sep)
 		!is_tattoo &&
 		!is_texture
 	) {
-		auto feature_save_link = Saylink::Create(
-			"#npcedit featuresave",
-			false,
-			"#npcedit featuresave"
-		);
+		auto feature_save_link = Saylink::Silent("#npcedit featuresave");
 
 		c->Message(Chat::White, "Usage: #feature beard [Beard] - Change your or your target's Beard");
 		c->Message(Chat::White, "Usage: #feature beardcolor [Beard Color] - Change your or your target's Beard Color");

--- a/zone/gm_commands/findzone.cpp
+++ b/zone/gm_commands/findzone.cpp
@@ -60,10 +60,13 @@ void command_findzone(Client *c, const Seperator *sep)
 			break;
 		}
 
-		std::string command_zone   = Saylink::Create("#zone " + short_name, false, "zone");
-		std::string command_gmzone = Saylink::Create(
-			fmt::format("#gmzone {} {}", short_name, version),
-			false,
+		std::string command_zone   = Saylink::Silent("#zone " + short_name, "zone");
+		std::string command_gmzone = Saylink::Silent(
+			fmt::format(
+				"#gmzone {} {}",
+				short_name,
+				version
+			),
 			"gmzone"
 		);
 

--- a/zone/gm_commands/flagedit.cpp
+++ b/zone/gm_commands/flagedit.cpp
@@ -4,7 +4,7 @@ void command_flagedit(Client *c, const Seperator *sep)
 {
 	int arguments = sep->argnum;
 	if (!arguments) {
-		auto flags_link = Saylink::Create("#flags", false, "#flags");
+		auto flags_link = Saylink::Silent("#flags");
 		c->Message(
 			Chat::White,
 			"Usage: #flagedit lock [Zone ID|Zone Short Name] [Flag Name] - Set the specified flag name on the zone, locking the zone"
@@ -48,7 +48,7 @@ void command_flagedit(Client *c, const Seperator *sep)
 		!is_take &&
 		!is_unlock
 	) {
-		auto flags_link = Saylink::Create("#flags", false, "#flags");
+		auto flags_link = Saylink::Silent("#flags");
 		c->Message(
 			Chat::White,
 			"Usage: #flagedit lock [Zone ID|Zone Short Name] [Flag Name] - Set the specified flag name on the zone, locking the zone"

--- a/zone/gm_commands/gearup.cpp
+++ b/zone/gm_commands/gearup.cpp
@@ -161,9 +161,8 @@ void command_gearup(Client *c, const Seperator *sep)
 		std::string message;
 		for (auto   row = results.begin(); row != results.end(); ++row) {
 			int expansion = atoi(row[0]);
-			message += "[" + Saylink::Create(
+			message += "[" + Saylink::Silent(
 				fmt::format("#gearup {}", expansion),
-				false,
 				Expansion::ExpansionName[expansion]
 			) + "] ";
 

--- a/zone/gm_commands/itemsearch.cpp
+++ b/zone/gm_commands/itemsearch.cpp
@@ -19,9 +19,8 @@ void command_itemsearch(Client *c, const Seperator *sep)
 				std::string item_id          = std::to_string(item->ID);
 				std::string saylink_commands =
 								"[" +
-								Saylink::Create(
+								Saylink::Silent(
 									"#si " + item_id,
-									false,
 									"X"
 								) +
 								"] ";
@@ -30,9 +29,8 @@ void command_itemsearch(Client *c, const Seperator *sep)
 					std::string stack_size = std::to_string(item->StackSize);
 					saylink_commands +=
 						"[" +
-						Saylink::Create(
+						Saylink::Silent(
 							"#si " + item_id + " " + stack_size,
-							false,
 							stack_size
 						) +
 						"]";
@@ -77,9 +75,8 @@ void command_itemsearch(Client *c, const Seperator *sep)
 				std::string item_id          = std::to_string(item->ID);
 				std::string saylink_commands =
 								"[" +
-								Saylink::Create(
+								Saylink::Silent(
 									"#si " + item_id,
-									false,
 									"X"
 								) +
 								"] ";
@@ -87,9 +84,8 @@ void command_itemsearch(Client *c, const Seperator *sep)
 					std::string stack_size = std::to_string(item->StackSize);
 					saylink_commands +=
 						"[" +
-						Saylink::Create(
+						Saylink::Silent(
 							"#si " + item_id + " " + stack_size,
-							false,
 							stack_size
 						) +
 						"]";

--- a/zone/gm_commands/list.cpp
+++ b/zone/gm_commands/list.cpp
@@ -69,7 +69,7 @@ void command_list(Client *c, const Seperator *sep)
 				c->Message(
 					0,
 					"| %s | ID %5d | %s | x %.0f | y %0.f | z %.0f",
-					Saylink::Create(saylink, false, "Goto").c_str(),
+					Saylink::Silent(saylink, "Goto").c_str(),
 					entity->GetID(),
 					entity->GetName(),
 					entity->GetX(),
@@ -110,7 +110,7 @@ void command_list(Client *c, const Seperator *sep)
 				c->Message(
 					0,
 					"| %s | ID %5d | %s | x %.0f | y %0.f | z %.0f",
-					Saylink::Create(saylink, false, "Goto").c_str(),
+					Saylink::Silent(saylink, "Goto").c_str(),
 					entity->GetID(),
 					entity->GetName(),
 					entity->GetX(),
@@ -151,7 +151,7 @@ void command_list(Client *c, const Seperator *sep)
 				c->Message(
 					0,
 					"| %s | ID %5d | %s | x %.0f | y %0.f | z %.0f",
-					Saylink::Create(saylink, false, "Goto").c_str(),
+					Saylink::Silent(saylink, "Goto").c_str(),
 					entity->GetID(),
 					entity->GetName(),
 					entity->GetX(),
@@ -192,7 +192,7 @@ void command_list(Client *c, const Seperator *sep)
 				c->Message(
 					0,
 					"| %s | Entity ID %5d | Door ID %i | %s | x %.0f | y %0.f | z %.0f",
-					Saylink::Create(saylink, false, "Goto").c_str(),
+					Saylink::Silent(saylink, "Goto").c_str(),
 					entity->GetID(),
 					entity->GetDoorID(),
 					entity->GetDoorName(),
@@ -234,7 +234,7 @@ void command_list(Client *c, const Seperator *sep)
 				c->Message(
 					0,
 					"| %s | Entity ID %5d | Object DBID %i | %s | x %.0f | y %0.f | z %.0f",
-					Saylink::Create(saylink, false, "Goto").c_str(),
+					Saylink::Silent(saylink, "Goto").c_str(),
 					entity->GetID(),
 					entity->GetDBID(),
 					entity->GetModelName(),

--- a/zone/gm_commands/logs.cpp
+++ b/zone/gm_commands/logs.cpp
@@ -184,11 +184,7 @@ void command_logs(Client *c, const Seperator *sep)
 				next_category_id
 			);
 
-			auto next_list_link = Saylink::Create(
-				next_list_string,
-				false,
-				next_list_string
-			);
+			auto next_list_link = Saylink::Silent(next_list_string, next_list_string);
 
 			c->Message(
 				Chat::White,

--- a/zone/gm_commands/npceditmass.cpp
+++ b/zone/gm_commands/npceditmass.cpp
@@ -223,7 +223,7 @@ void command_npceditmass(Client *c, const Seperator *sep)
 				Chat::Yellow,
 				fmt::format(
 					"Would you like to {} these changes?",
-					Saylink::Create(saylink, false, "apply")
+					Saylink::Silent(saylink, "apply")
 				).c_str()
 			);
 

--- a/zone/gm_commands/nudge.cpp
+++ b/zone/gm_commands/nudge.cpp
@@ -9,11 +9,7 @@ void command_nudge(Client *c, const Seperator *sep)
 			Chat::White,
 			fmt::format(
 				"Note: Partial or mixed arguments allowed, example {}.",
-				Saylink::Create(
-					"#nudge x=5.0",
-					false,
-					"#nudge x=5.0"
-				)
+				Saylink::Silent("#nudge x=5.0")
 			).c_str()
 		);
 		return;

--- a/zone/gm_commands/qglobal.cpp
+++ b/zone/gm_commands/qglobal.cpp
@@ -50,11 +50,7 @@ void command_qglobal(Client *c, const Seperator *sep)
 			return;
 		}
 
-		auto repop_link = Saylink::Create(
-			"#repop",
-			false,
-			"repop"
-		);
+		auto repop_link = Saylink::Silent("#repop", "repop");
 
 		c->Message(
 			Chat::White,
@@ -83,11 +79,7 @@ void command_qglobal(Client *c, const Seperator *sep)
 			return;
 		}
 
-		auto repop_link = Saylink::Create(
-			"#repop",
-			false,
-			"repop"
-		);
+		auto repop_link = Saylink::Silent("#repop", "repop");
 
 		c->Message(
 			Chat::White,

--- a/zone/gm_commands/reload.cpp
+++ b/zone/gm_commands/reload.cpp
@@ -223,7 +223,7 @@ void command_reload(Client *c, const Seperator *sep)
 					"Zone Header Load {} | Zone: {}",
 					(
 						zone->LoadZoneCFG(zone->GetShortName(), zone->GetInstanceVersion()) ?
-						"Suceeded" :
+						"Succeeded" :
 						"Failed"
 					),
 					zone->GetZoneDescription()
@@ -267,7 +267,7 @@ void command_reload(Client *c, const Seperator *sep)
 				"Zone Header Load {} | Zone: {} ({}){}",
 				(
 					zone->LoadZoneCFG(zone_short_name, version) ?
-					"Suceeded" :
+					"Succeeded" :
 					"Failed"
 				),
 				zone_long_name,

--- a/zone/gm_commands/scale.cpp
+++ b/zone/gm_commands/scale.cpp
@@ -127,7 +127,7 @@ void command_scale(Client *c, const Seperator *sep)
 			c->Message(Chat::Yellow, "Found (%i) NPC's that match this search...", found_count);
 			c->Message(
 				Chat::Yellow, "To apply these changes, click <%s> or type %s",
-				Saylink::Create(saylink, false, "Apply").c_str(),
+				Saylink::Silent(saylink, "Apply").c_str(),
 				saylink.c_str()
 			);
 		}

--- a/zone/gm_commands/showskills.cpp
+++ b/zone/gm_commands/showskills.cpp
@@ -76,22 +76,14 @@ void command_showskills(Client *c, const Seperator *sep)
 			next_skill_id
 		);
 
-		auto next_list_link = Saylink::Create(
-			next_list_string,
-			false,
-			next_list_string
-		);
+		auto next_list_link = Saylink::Silent(next_list_string, next_list_string);
 
 		auto next_list_all_string = fmt::format(
 			"#showskills {} all",
 			next_skill_id
 		);
 
-		auto next_list_all_link = Saylink::Create(
-			next_list_all_string,
-			false,
-			next_list_all_string
-		);
+		auto next_list_all_link = Saylink::Silent(next_list_all_string, next_list_all_string);
 
 		c->Message(
 			Chat::White,

--- a/zone/gm_commands/spawneditmass.cpp
+++ b/zone/gm_commands/spawneditmass.cpp
@@ -107,7 +107,7 @@ void command_spawneditmass(Client *c, const Seperator *sep)
 			Chat::Yellow,
 			fmt::format(
 				"To apply these changes, click {} or type \"{}\".",
-				Saylink::Create(edit_link, false, "apply"),
+				Saylink::Silent(edit_link, "apply"),
 				edit_link
 			).c_str()
 		);

--- a/zone/gm_commands/task.cpp
+++ b/zone/gm_commands/task.cpp
@@ -18,7 +18,7 @@ void command_task(Client *c, const Seperator *sep)
 			Chat::White,
 			fmt::format(
 				"--- [{}] List active tasks for a client",
-				Saylink::Create("#task show", false, "show")
+				Saylink::Silent("#task show", "show")
 			).c_str()
 		);
 		c->Message(Chat::White, "--- update <task_id> <activity_id> [count] | Updates task");
@@ -28,42 +28,42 @@ void command_task(Client *c, const Seperator *sep)
 			Chat::White,
 			fmt::format(
 				"--- [{}] Reload all Task information from the database",
-				Saylink::Create("#task reloadall", false, "reloadall")
+				Saylink::Silent("#task reloadall", "reloadall")
 			).c_str()
 		);
 		c->Message(
 			Chat::White,
 			fmt::format(
 				"--- [{}] <task_id> Reload Task and Activity information for a single task",
-				Saylink::Create("#task reload task", false, "reload task")
+				Saylink::Silent("#task reload task", "reload task")
 			).c_str()
 		);
 		c->Message(
 			Chat::White,
 			fmt::format(
 				"--- [{}] Reload goal/reward list information",
-				Saylink::Create("#task reload lists", false, "reload lists")
+				Saylink::Silent("#task reload lists", "reload lists")
 			).c_str()
 		);
 		c->Message(
 			Chat::White,
 			fmt::format(
 				"--- [{}] Reload proximity information",
-				Saylink::Create("#task reload prox", false, "reload prox")
+				Saylink::Silent("#task reload prox", "reload prox")
 			).c_str()
 		);
 		c->Message(
 			Chat::White,
 			fmt::format(
 				"--- [{}] Reload task set information",
-				Saylink::Create("#task reload sets", false, "reload sets")
+				Saylink::Silent("#task reload sets", "reload sets")
 			).c_str()
 		);
 		c->Message(
 			Chat::White,
 			fmt::format(
 				"--- [{}] Purges targeted characters task timers",
-				Saylink::Create("#task purgetimers", false, "purgetimers")
+				Saylink::Silent("#task purgetimers", "purgetimers")
 			).c_str()
 		);
 
@@ -74,7 +74,7 @@ void command_task(Client *c, const Seperator *sep)
 			Chat::White,
 			fmt::format(
 				"--- [{}] Purges all active Shared Tasks in memory and database ",
-				Saylink::Create("#task sharedpurge", false, "sharedpurge")
+				Saylink::Silent("#task sharedpurge", "sharedpurge")
 			).c_str()
 		);
 		return;
@@ -112,7 +112,7 @@ void command_task(Client *c, const Seperator *sep)
 			Chat::White,
 			fmt::format(
 				"--- [{}] List active tasks for a client",
-				Saylink::Create("#task show", false, "show")
+				Saylink::Silent("#task show", "show")
 			).c_str()
 		);
 		c->Message(Chat::White, "--- update <task_id> <activity_id> [count] | Updates task");
@@ -122,42 +122,42 @@ void command_task(Client *c, const Seperator *sep)
 			Chat::White,
 			fmt::format(
 				"--- [{}] Reload all Task information from the database",
-				Saylink::Create("#task reloadall", false, "reloadall")
+				Saylink::Silent("#task reloadall", "reloadall")
 			).c_str()
 		);
 		c->Message(
 			Chat::White,
 			fmt::format(
 				"--- [{}] <task_id> Reload Task and Activity information for a single task",
-				Saylink::Create("#task reload task", false, "reload task")
+				Saylink::Silent("#task reload task", "reload task")
 			).c_str()
 		);
 		c->Message(
 			Chat::White,
 			fmt::format(
 				"--- [{}] Reload goal/reward list information",
-				Saylink::Create("#task reload lists", false, "reload lists")
+				Saylink::Silent("#task reload lists", "reload lists")
 			).c_str()
 		);
 		c->Message(
 			Chat::White,
 			fmt::format(
 				"--- [{}] Reload proximity information",
-				Saylink::Create("#task reload prox", false, "reload prox")
+				Saylink::Silent("#task reload prox", "reload prox")
 			).c_str()
 		);
 		c->Message(
 			Chat::White,
 			fmt::format(
 				"--- [{}] Reload task set information",
-				Saylink::Create("#task reload sets", false, "reload sets")
+				Saylink::Silent("#task reload sets", "reload sets")
 			).c_str()
 		);
 		c->Message(
 			Chat::White,
 			fmt::format(
 				"--- [{}] Purges targeted characters task timers",
-				Saylink::Create("#task purgetimers", false, "purgetimers")
+				Saylink::Silent("#task purgetimers", "purgetimers")
 			).c_str()
 		);
 
@@ -168,7 +168,7 @@ void command_task(Client *c, const Seperator *sep)
 			Chat::White,
 			fmt::format(
 				"--- [{}] Purges all active Shared Tasks in memory and database ",
-				Saylink::Create("#task sharedpurge", false, "sharedpurge")
+				Saylink::Silent("#task sharedpurge", "sharedpurge")
 			).c_str()
 		);
 		return;
@@ -260,7 +260,7 @@ void command_task(Client *c, const Seperator *sep)
 			Chat::White,
 			fmt::format(
 				"[WARNING] This will purge all active Shared Tasks [{}]?",
-				Saylink::Create("#task sharedpurge confirm", false, "confirm")
+				Saylink::Silent("#task sharedpurge confirm", "confirm")
 			).c_str()
 		);
 

--- a/zone/gm_commands/viewzoneloot.cpp
+++ b/zone/gm_commands/viewzoneloot.cpp
@@ -30,7 +30,7 @@ void command_viewzoneloot(Client *c, const Seperator *sep)
 			std::string npc_name     = current_npc->GetCleanName();
 			uint32      instance_id  = zone->GetInstanceID();
 			uint32      zone_id      = zone->GetZoneID();
-			std::string command_link = Saylink::Create(
+			std::string command_link = Saylink::Silent(
 				fmt::format(
 					"#{} {} {} {} {}",
 					(instance_id != 0 ? "zoneinstance" : "zone"),
@@ -39,7 +39,6 @@ void command_viewzoneloot(Client *c, const Seperator *sep)
 					current_npc->GetY(),
 					current_npc->GetZ()
 				),
-				false,
 				"Goto"
 			);
 			npc_link = fmt::format(

--- a/zone/gm_commands/who.cpp
+++ b/zone/gm_commands/who.cpp
@@ -98,12 +98,11 @@ void command_who(Client *c, const Seperator *sep)
 
 		std::string displayed_guild_name;
 		if (guild_name.length()) {
-			displayed_guild_name = Saylink::Create(
+			displayed_guild_name = Saylink::Silent(
 				fmt::format(
 					"#who \"{}\"",
 					guild_name
 				),
-				false,
 				fmt::format(
 					"<{}>",
 					guild_name
@@ -111,21 +110,19 @@ void command_who(Client *c, const Seperator *sep)
 			);
 		}
 
-		auto goto_saylink = Saylink::Create(
+		auto goto_saylink = Saylink::Silent(
 			fmt::format(
 				"#goto {}",
 				player_name
 			),
-			false,
 			"Goto"
 		);
 
-		auto summon_saylink = Saylink::Create(
+		auto summon_saylink = Saylink::Silent(
 			fmt::format(
 				"#summon {}",
 				player_name
 			),
-			false,
 			"Summon"
 		);
 
@@ -134,48 +131,43 @@ void command_who(Client *c, const Seperator *sep)
 			static_cast<uint8>(player_level)
 		);
 
-		auto class_saylink = Saylink::Create(
+		auto class_saylink = Saylink::Silent(
 			fmt::format(
 				"#who {}",
 				base_class_name
 			),
-			false,
 			display_class_name
 		);
 
-		auto race_saylink = Saylink::Create(
+		auto race_saylink = Saylink::Silent(
 			fmt::format(
 				"#who %s",
 				displayed_race_name
 			),
-			false,
 			displayed_race_name
 		);
 
-		auto zone_saylink = Saylink::Create(
+		auto zone_saylink = Saylink::Silent(
 			fmt::format(
 				"#who {}",
 				zone_short_name
 			),
-			false,
 			zone_long_name
 		);
 
-		auto account_saylink = Saylink::Create(
+		auto account_saylink = Saylink::Silent(
 			fmt::format(
 				"#who {}",
 				account_name
 			),
-			false,
 			account_name
 		);
 
-		auto account_ip_saylink = Saylink::Create(
+		auto account_ip_saylink = Saylink::Silent(
 			fmt::format(
 				"#who {}",
 				account_ip
 			),
-			false,
 			account_ip
 		);
 

--- a/zone/gm_commands/zheader.cpp
+++ b/zone/gm_commands/zheader.cpp
@@ -43,7 +43,7 @@ void command_zheader(Client *c, const Seperator *sep)
 			"Zone Header Load {} | Zone: {} ({}){}",
 			(
 				zone->LoadZoneCFG(zone_short_name, version) ?
-				"Suceeded" :
+				"Succeeded" :
 				"Failed"
 			),
 			zone_long_name,

--- a/zone/mob_info.cpp
+++ b/zone/mob_info.cpp
@@ -590,25 +590,31 @@ inline void NPCCommandsMenu(Client* client, NPC* npc)
 	std::string menu_commands;
 
 	if (npc->GetGrid() > 0) {
-		menu_commands += "[" + Saylink::Create("#grid show", false, "Grid Points") + "] ";
+		menu_commands += "[" + Saylink::Silent("#grid show", "Grid Points") + "] ";
 	}
 
 	if (npc->GetEmoteID() > 0) {
-		std::string saylink = StringFormat("#emotesearch %u", npc->GetEmoteID());
-		menu_commands += "[" + Saylink::Create(saylink, false, "Emotes") + "] ";
+		menu_commands += "[" + Saylink::Silent(fmt::format("#emotesearch {}", npc->GetEmoteID()), "Emotes") + "] ";
 	}
 
 	if (npc->GetLoottableID() > 0) {
-		menu_commands += "[" + Saylink::Create("#npcloot show", false, "Loot") + "] ";
+		menu_commands += "[" + Saylink::Silent("#npcloot show", "Loot") + "] ";
 	}
 
 	if (npc->IsProximitySet()) {
-		menu_commands += "[" + Saylink::Create("#proximity show", false, "Proximity") + "] ";
+		menu_commands += "[" + Saylink::Silent("#proximity show", "Proximity") + "] ";
 	}
 
 	if (menu_commands.length() > 0) {
-		std::string dev_menu = "[" + Saylink::Create("#devtools", false, "DevTools") + "] ";;
-		client->Message(Chat::White, "| %s [Show Commands] %s", dev_menu.c_str(), menu_commands.c_str());
+		const auto& dev_menu = Saylink::Silent("#devtools", "DevTools");
+		client->Message(
+			Chat::White,
+			fmt::format(
+				"| [{}] [Show Commands] {}",
+				dev_menu,
+				menu_commands
+			).c_str()
+		);
 	}
 }
 

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -1698,14 +1698,13 @@ void ClientTaskState::ShowClientTaskInfoMessage(ClientTaskInformation *task, Cli
 		std::vector<std::string> update_saylinks;
 
 		for (auto &increment: update_increments) {
-			auto task_update_saylink = Saylink::Create(
+			auto task_update_saylink = Saylink::Silent(
 				fmt::format(
 					"#task update {} {} {}",
 					task->task_id,
 					task->activity[activity_id].activity_id,
 					increment
 				),
-				false,
 				increment
 			);
 

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -3148,7 +3148,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 			zone->SetQuestHotReloadQueued(true);
 		} else if (request_zone_short_name == "all") {
 			std::string reload_quest_saylink = Saylink::Silent("#reload quest", "Locally");
-			std::string reload_world_saylink = Saylink::Silent("#reload world",	"Globally");
+			std::string reload_world_saylink = Saylink::Silent("#reload world", "Globally");
 			worldserver.SendEmoteMessage(
 				0,
 				0,

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -3147,16 +3147,8 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 		if (request_zone_short_name == local_zone_short_name || can_reload_global_script) {
 			zone->SetQuestHotReloadQueued(true);
 		} else if (request_zone_short_name == "all") {
-			std::string reload_quest_saylink = Saylink::Create(
-				"#reload quest",
-				false,
-				"Locally"
-			);
-			std::string reload_world_saylink = Saylink::Create(
-				"#reload world",
-				false,
-				"Globally"
-			);
+			std::string reload_quest_saylink = Saylink::Silent("#reload quest", "Locally");
+			std::string reload_world_saylink = Saylink::Silent("#reload world",	"Globally");
 			worldserver.SendEmoteMessage(
 				0,
 				0,


### PR DESCRIPTION
- This cleans up all non-silent GM Command Saylinks that we had before due to the way they worked before. All saylinks like this should be silent now.
- Add source short hand capability for say links with same link as text.