### PR TITLE
[Feature] Instance Version Specific Experience Modifiers

### DIFF
--- a/utils/sql/db_update_manifest.txt
+++ b/utils/sql/db_update_manifest.txt
@@ -451,7 +451,7 @@
 9195|2022_07_23_dz_templates.sql|SHOW TABLES like 'dynamic_zone_templates'|empty|
 9196|2022_07_30_merchantlist_temp.sql|SHOW COLUMNS FROM `merchantlist_temp` LIKE 'zone_id'|empty|
 9197|2022_08_01_drop_expansion_account.sql|SHOW COLUMNS FROM `account` LIKE 'expansion'|notempty|
-9198|2022_08_14_exp_modifier_instance_version.sql|SHOW COLUMNS FROM `character_exp_modifiers` LIKE 'instance_version'|empty|
+9198|2022_08_14_exp_modifier_instance_versions.sql|SHOW COLUMNS FROM `character_exp_modifiers` LIKE 'instance_version'|empty|
 
 # Upgrade conditions:
 # 	This won't be needed after this system is implemented, but it is used database that are not

--- a/utils/sql/db_update_manifest.txt
+++ b/utils/sql/db_update_manifest.txt
@@ -451,6 +451,7 @@
 9195|2022_07_23_dz_templates.sql|SHOW TABLES like 'dynamic_zone_templates'|empty|
 9196|2022_07_30_merchantlist_temp.sql|SHOW COLUMNS FROM `merchantlist_temp` LIKE 'zone_id'|empty|
 9197|2022_08_01_drop_expansion_account.sql|SHOW COLUMNS FROM `account` LIKE 'expansion'|notempty|
+9198|2022_08_14_exp_modifier_instance_version.sql|SHOW COLUMNS FROM `character_exp_modifiers` LIKE 'instance_version'|empty|
 
 # Upgrade conditions:
 # 	This won't be needed after this system is implemented, but it is used database that are not

--- a/utils/sql/git/required/2022_08_14_exp_modifier_instance_versions.sql
+++ b/utils/sql/git/required/2022_08_14_exp_modifier_instance_versions.sql
@@ -1,0 +1,4 @@
+ALTER TABLE character_exp_modifiers 
+ADD COLUMN instance_version int NOT NULL DEFAULT -1 AFTER zone_id,
+DROP PRIMARY KEY,
+ADD PRIMARY KEY (character_id, zone_id, instance_version) USING BTREE;

--- a/zone/client.h
+++ b/zone/client.h
@@ -600,10 +600,10 @@ public:
 
 	inline uint32 GetEXP() const { return m_pp.exp; }
 
-	inline double GetAAEXPModifier(uint32 zone_id) const { return database.GetAAEXPModifier(CharacterID(), zone_id); };
-	inline double GetEXPModifier(uint32 zone_id) const { return database.GetEXPModifier(CharacterID(), zone_id); };
-	inline void SetAAEXPModifier(uint32 zone_id, double aa_modifier) { database.SetAAEXPModifier(CharacterID(), zone_id, aa_modifier); };
-	inline void SetEXPModifier(uint32 zone_id, double exp_modifier) { database.SetEXPModifier(CharacterID(), zone_id, exp_modifier); };
+	inline double GetAAEXPModifier(uint32 zone_id, int16 instance_version = -1) const { return database.GetAAEXPModifier(CharacterID(), zone_id, instance_version); };
+	inline double GetEXPModifier(uint32 zone_id, int16 instance_version = -1) const { return database.GetEXPModifier(CharacterID(), zone_id, instance_version); };
+	inline void SetAAEXPModifier(uint32 zone_id, double aa_modifier, int16 instance_version = -1) { database.SetAAEXPModifier(CharacterID(), zone_id, aa_modifier, instance_version); };
+	inline void SetEXPModifier(uint32 zone_id, double exp_modifier, int16 instance_version = -1) { database.SetEXPModifier(CharacterID(), zone_id, exp_modifier, instance_version); };
 
 	bool UpdateLDoNPoints(uint32 theme_id, int points);
 	void SetPVPPoints(uint32 Points) { m_pp.PVPCurrentPoints = Points; }

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -2258,9 +2258,19 @@ double Perl__getaaexpmodifierbycharid(uint32 character_id, uint32 zone_id)
 	return quest_manager.GetAAEXPModifierByCharID(character_id, zone_id);
 }
 
+double Perl__getaaexpmodifierbycharid(uint32 character_id, uint32 zone_id, int16 instance_version)
+{
+	return quest_manager.GetAAEXPModifierByCharID(character_id, zone_id, instance_version);
+}
+
 double Perl__getexpmodifierbycharid(uint32 character_id, uint32 zone_id)
 {
 	return quest_manager.GetEXPModifierByCharID(character_id, zone_id);
+}
+
+double Perl__getexpmodifierbycharid(uint32 character_id, uint32 zone_id, int16 instance_version)
+{
+	return quest_manager.GetEXPModifierByCharID(character_id, zone_id, instance_version);
 }
 
 void Perl__setaaexpmodifierbycharid(uint32 character_id, uint32 zone_id, double aa_modifier)
@@ -2268,9 +2278,19 @@ void Perl__setaaexpmodifierbycharid(uint32 character_id, uint32 zone_id, double 
 	quest_manager.SetAAEXPModifierByCharID(character_id, zone_id, aa_modifier);
 }
 
+void Perl__setaaexpmodifierbycharid(uint32 character_id, uint32 zone_id, double aa_modifier, int16 instance_version)
+{
+	quest_manager.SetAAEXPModifierByCharID(character_id, zone_id, aa_modifier, instance_version);
+}
+
 void Perl__setexpmodifierbycharid(uint32 character_id, uint32 zone_id, double exp_modifier)
 {
 	quest_manager.SetEXPModifierByCharID(character_id, zone_id, exp_modifier);
+}
+
+void Perl__setexpmodifierbycharid(uint32 character_id, uint32 zone_id, double exp_modifier, int16 instance_version)
+{
+	quest_manager.SetEXPModifierByCharID(character_id, zone_id, exp_modifier, instance_version);
 }
 
 std::string Perl__getcleannpcnamebyid(uint32 npc_id)
@@ -4011,7 +4031,8 @@ void perl_register_quest()
 	package.add("forcedoorclose", (void(*)(uint32, bool))&Perl__forcedoorclose);
 	package.add("forcedooropen", (void(*)(uint32))&Perl__forcedooropen);
 	package.add("forcedooropen", (void(*)(uint32, bool))&Perl__forcedooropen);
-	package.add("getaaexpmodifierbycharid", &Perl__getaaexpmodifierbycharid);
+	package.add("getaaexpmodifierbycharid", (double(*)(uint32, uint32))&Perl__getaaexpmodifierbycharid);
+	package.add("getaaexpmodifierbycharid", (double(*)(uint32, uint32, int16))&Perl__getaaexpmodifierbycharid);
 	package.add("getbodytypename", &Perl__getbodytypename);
 	package.add("getcharidbyname", &Perl__getcharidbyname);
 	package.add("getclassname", (std::string(*)(uint8))&Perl__getclassname);
@@ -4020,7 +4041,8 @@ void perl_register_quest()
 	package.add("getconsiderlevelname", &Perl__getconsiderlevelname);
 	package.add("gethexcolorcode", &Perl__gethexcolorcode);
 	package.add("getcurrencyid", &Perl__getcurrencyid);
-	package.add("getexpmodifierbycharid", &Perl__getexpmodifierbycharid);
+	package.add("getexpmodifierbycharid", (double(*)(uint32, uint32))&Perl__getexpmodifierbycharid);
+	package.add("getexpmodifierbycharid", (double(*)(uint32, uint32, int16))&Perl__getexpmodifierbycharid);
 	package.add("get_expedition", &Perl__get_expedition);
 	package.add("get_expedition_by_char_id", &Perl__get_expedition_by_char_id);
 	package.add("get_expedition_by_dz_id", &Perl__get_expedition_by_dz_id);
@@ -4150,14 +4172,16 @@ void perl_register_quest()
 	package.add("scribespells", (int(*)(int, int))&Perl__scribespells);
 	package.add("secondstotime", &Perl__secondstotime);
 	package.add("selfcast", &Perl__selfcast);
-	package.add("setaaexpmodifierbycharid", &Perl__setaaexpmodifierbycharid);
+	package.add("setaaexpmodifierbycharid", (void(*)(uint32, uint32, double))&Perl__setaaexpmodifierbycharid);
+	package.add("setaaexpmodifierbycharid", (void(*)(uint32, uint32, double, int16))&Perl__setaaexpmodifierbycharid);
 	package.add("set_proximity", (void(*)(float, float, float, float))&Perl__set_proximity);
 	package.add("set_proximity", (void(*)(float, float, float, float, float, float))&Perl__set_proximity);
 	package.add("set_proximity", (void(*)(float, float, float, float, float, float, bool))&Perl__set_proximity);
 	package.add("set_zone_flag", &Perl__set_zone_flag);
 	package.add("setallskill", &Perl__setallskill);
 	package.add("setanim", &Perl__setanim);
-	package.add("setexpmodifierbycharid", &Perl__setexpmodifierbycharid);
+	package.add("setexpmodifierbycharid", (void(*)(uint32, uint32, double))&Perl__setexpmodifierbycharid);
+	package.add("setexpmodifierbycharid", (void(*)(uint32, uint32, double, int16))&Perl__setexpmodifierbycharid);
 	package.add("setglobal", &Perl__setglobal);
 	package.add("setguild", &Perl__setguild);
 	package.add("sethp", &Perl__sethp);

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -329,7 +329,7 @@ void Client::CalculateStandardAAExp(uint32 &add_aaxp, uint8 conlevel, bool resex
 	}
 
 	if (RuleB(Character, EnableCharacterEXPMods)) {
-		add_aaxp *= GetAAEXPModifier(GetZoneID());
+		add_aaxp *= GetAAEXPModifier(zone->GetZoneID(), zone->GetInstanceVersion());
 	}
 
 	add_aaxp = (uint32)(RuleR(Character, AAExpMultiplier) * add_aaxp * aatotalmod);
@@ -492,7 +492,7 @@ void Client::CalculateExp(uint32 in_add_exp, uint32 &add_exp, uint32 &add_aaxp, 
 	}
 
 	if (RuleB(Character, EnableCharacterEXPMods)) {
-		add_exp *= GetEXPModifier(GetZoneID());
+		add_exp *= GetEXPModifier(zone->GetZoneID(), zone->GetInstanceVersion());
 	}
 
 	add_exp = GetEXP() + add_exp;

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -2178,9 +2178,19 @@ double Lua_Client::GetAAEXPModifier(uint32 zone_id) {
 	return self->GetAAEXPModifier(zone_id);
 }
 
+double Lua_Client::GetAAEXPModifier(uint32 zone_id, int16 instance_version) {
+	Lua_Safe_Call_Real();
+	return self->GetAAEXPModifier(zone_id, instance_version);
+}
+
 double Lua_Client::GetEXPModifier(uint32 zone_id) {
 	Lua_Safe_Call_Real();
 	return self->GetEXPModifier(zone_id);
+}
+
+double Lua_Client::GetEXPModifier(uint32 zone_id, int16 instance_version) {
+	Lua_Safe_Call_Real();
+	return self->GetEXPModifier(zone_id, instance_version);
 }
 
 void Lua_Client::SetAAEXPModifier(uint32 zone_id, double aa_modifier) {
@@ -2188,9 +2198,19 @@ void Lua_Client::SetAAEXPModifier(uint32 zone_id, double aa_modifier) {
 	self->SetAAEXPModifier(zone_id, aa_modifier);
 }
 
+void Lua_Client::SetAAEXPModifier(uint32 zone_id, double aa_modifier, int16 instance_version) {
+	Lua_Safe_Call_Void();
+	self->SetAAEXPModifier(zone_id, aa_modifier, instance_version);
+}
+
 void Lua_Client::SetEXPModifier(uint32 zone_id, double exp_modifier) {
 	Lua_Safe_Call_Void();
 	self->SetEXPModifier(zone_id, exp_modifier);
+}
+
+void Lua_Client::SetEXPModifier(uint32 zone_id, double exp_modifier, int16 instance_version) {
+	Lua_Safe_Call_Void();
+	self->SetEXPModifier(zone_id, exp_modifier, instance_version);
 }
 
 void Lua_Client::AddLDoNLoss(uint32 theme_id) {
@@ -2643,6 +2663,7 @@ luabind::scope lua_register_client() {
 	.def("ForageItem", (void(Lua_Client::*)(void))&Lua_Client::ForageItem)
 	.def("Freeze", (void(Lua_Client::*)(void))&Lua_Client::Freeze)
 	.def("GetAAEXPModifier", (double(Lua_Client::*)(uint32))&Lua_Client::GetAAEXPModifier)
+	.def("GetAAEXPModifier", (double(Lua_Client::*)(uint32,int16))&Lua_Client::GetAAEXPModifier)
 	.def("GetAAExp", (uint32(Lua_Client::*)(void))&Lua_Client::GetAAExp)
 	.def("GetAAPercent", (uint32(Lua_Client::*)(void))&Lua_Client::GetAAPercent)
 	.def("GetAAPoints", (int(Lua_Client::*)(void))&Lua_Client::GetAAPoints)
@@ -2687,6 +2708,7 @@ luabind::scope lua_register_client() {
 	.def("GetDuelTarget", (int(Lua_Client::*)(void))&Lua_Client::GetDuelTarget)
 	.def("GetEXP", (uint32(Lua_Client::*)(void))&Lua_Client::GetEXP)
 	.def("GetEXPModifier", (double(Lua_Client::*)(uint32))&Lua_Client::GetEXPModifier)
+	.def("GetEXPModifier", (double(Lua_Client::*)(uint32,int16))&Lua_Client::GetEXPModifier)
 	.def("GetEbonCrystals", (uint32(Lua_Client::*)(void))&Lua_Client::GetEbonCrystals)
 	.def("GetEndurance", (int(Lua_Client::*)(void))&Lua_Client::GetEndurance)
 	.def("GetEndurancePercent", (int(Lua_Client::*)(void))&Lua_Client::GetEndurancePercent)
@@ -2875,6 +2897,7 @@ luabind::scope lua_register_client() {
 	.def("SendWebLink", (void(Lua_Client::*)(const char *))&Lua_Client::SendWebLink)
 	.def("SendZoneFlagInfo", (void(Lua_Client::*)(Lua_Client))&Lua_Client::SendZoneFlagInfo)
 	.def("SetAAEXPModifier", (void(Lua_Client::*)(uint32,double))&Lua_Client::SetAAEXPModifier)
+	.def("SetAAEXPModifier", (void(Lua_Client::*)(uint32,double,int16))&Lua_Client::SetAAEXPModifier)
 	.def("SetAAPoints", (void(Lua_Client::*)(int))&Lua_Client::SetAAPoints)
 	.def("SetAATitle", (void(Lua_Client::*)(std::string))&Lua_Client::SetAATitle)
 	.def("SetAATitle", (void(Lua_Client::*)(std::string,bool))&Lua_Client::SetAATitle)
@@ -2901,6 +2924,7 @@ luabind::scope lua_register_client() {
 	.def("SetEXP", (void(Lua_Client::*)(uint32,uint32))&Lua_Client::SetEXP)
 	.def("SetEXP", (void(Lua_Client::*)(uint32,uint32,bool))&Lua_Client::SetEXP)
 	.def("SetEXPModifier", (void(Lua_Client::*)(uint32,double))&Lua_Client::SetEXPModifier)
+	.def("SetEXPModifier", (void(Lua_Client::*)(uint32,double,int16))&Lua_Client::SetEXPModifier)
 	.def("SetEbonCrystals", (void(Lua_Client::*)(uint32))&Lua_Client::SetEbonCrystals)
 	.def("SetEndurance", (void(Lua_Client::*)(int))&Lua_Client::SetEndurance)
 	.def("SetEnvironmentDamageModifier", (void(Lua_Client::*)(int))&Lua_Client::SetEnvironmentDamageModifier)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -73,9 +73,13 @@ public:
 	int GetWeight();
 	uint32 GetEXP();
 	double GetEXPModifier(uint32 zone_id);
+	double GetEXPModifier(uint32 zone_id, int16 instance_version);
 	double GetAAEXPModifier(uint32 zone_id);
+	double GetAAEXPModifier(uint32 zone_id, int16 instance_version);
 	void SetAAEXPModifier(uint32 zone_id, double aa_modifier);
+	void SetAAEXPModifier(uint32 zone_id, double aa_modifier, int16 instance_version);
 	void SetEXPModifier(uint32 zone_id, double exp_modifier);
+	void SetEXPModifier(uint32 zone_id, double exp_modifier, int16 instance_version);
 	uint32 GetAAExp();
 	uint32 GetAAPercent();
 	uint32 GetTotalSecondsPlayed();

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -1877,16 +1877,32 @@ double lua_get_aa_exp_modifier_by_char_id(uint32 character_id, uint32 zone_id) {
 	return database.GetAAEXPModifier(character_id, zone_id);
 }
 
+double lua_get_aa_exp_modifier_by_char_id(uint32 character_id, uint32 zone_id, int16 instance_version) {
+	return database.GetAAEXPModifier(character_id, zone_id, instance_version);
+}
+
 double lua_get_exp_modifier_by_char_id(uint32 character_id, uint32 zone_id) {
 	return database.GetEXPModifier(character_id, zone_id);
+}
+
+double lua_get_exp_modifier_by_char_id(uint32 character_id, uint32 zone_id, int16 instance_version) {
+	return database.GetEXPModifier(character_id, zone_id, instance_version);
 }
 
 void lua_set_aa_exp_modifier_by_char_id(uint32 character_id, uint32 zone_id, double aa_modifier) {
 	database.SetAAEXPModifier(character_id, zone_id, aa_modifier);
 }
 
+void lua_set_aa_exp_modifier_by_char_id(uint32 character_id, uint32 zone_id, double aa_modifier, int16 instance_version) {
+	database.SetAAEXPModifier(character_id, zone_id, aa_modifier, instance_version);
+}
+
 void lua_set_exp_modifier_by_char_id(uint32 character_id, uint32 zone_id, double exp_modifier) {
 	database.SetEXPModifier(character_id, zone_id, exp_modifier);
+}
+
+void lua_set_exp_modifier_by_char_id(uint32 character_id, uint32 zone_id, double exp_modifier, int16 instance_version) {
+	database.SetEXPModifier(character_id, zone_id, exp_modifier, instance_version);
 }
 
 void lua_add_ldon_loss(uint32 theme_id) {
@@ -3826,10 +3842,14 @@ luabind::scope lua_register_general() {
 		luabind::def("log_combat", (void(*)(std::string))&lua_log_combat),
 		luabind::def("seconds_to_time", &lua_seconds_to_time),
 		luabind::def("get_hex_color_code", &lua_get_hex_color_code),
-		luabind::def("get_aa_exp_modifier_by_char_id", &lua_get_aa_exp_modifier_by_char_id),
-		luabind::def("get_exp_modifier_by_char_id", &lua_get_exp_modifier_by_char_id),
-		luabind::def("set_aa_exp_modifier_by_char_id", &lua_set_aa_exp_modifier_by_char_id),
-		luabind::def("set_exp_modifier_by_char_id", &lua_set_exp_modifier_by_char_id),
+		luabind::def("get_aa_exp_modifier_by_char_id", (double(*)(uint32,uint32))&lua_get_aa_exp_modifier_by_char_id),
+		luabind::def("get_aa_exp_modifier_by_char_id", (double(*)(uint32,uint32,int16))&lua_get_aa_exp_modifier_by_char_id),
+		luabind::def("get_exp_modifier_by_char_id", (double(*)(uint32,uint32))&lua_get_exp_modifier_by_char_id),
+		luabind::def("get_exp_modifier_by_char_id", (double(*)(uint32,uint32,int16))&lua_get_exp_modifier_by_char_id),
+		luabind::def("set_aa_exp_modifier_by_char_id", (void(*)(uint32,uint32,double))&lua_set_aa_exp_modifier_by_char_id),
+		luabind::def("set_aa_exp_modifier_by_char_id", (void(*)(uint32,uint32,double,int16))&lua_set_aa_exp_modifier_by_char_id),
+		luabind::def("set_exp_modifier_by_char_id", (void(*)(uint32,uint32,double))&lua_set_exp_modifier_by_char_id),
+		luabind::def("set_exp_modifier_by_char_id", (void(*)(uint32,uint32,double,int16))&lua_set_exp_modifier_by_char_id),
 		luabind::def("add_ldon_loss", &lua_add_ldon_loss),
 		luabind::def("add_ldon_points", &lua_add_ldon_points),
 		luabind::def("add_ldon_win", &lua_add_ldon_win),

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -2086,19 +2086,39 @@ double Perl_Client_GetAAEXPModifier(Client* self, uint32 zone_id)
 	return self->GetAAEXPModifier(zone_id);
 }
 
+double Perl_Client_GetAAEXPModifier(Client* self, uint32 zone_id, int16 instance_version)
+{
+	return self->GetAAEXPModifier(zone_id, instance_version);
+}
+
 double Perl_Client_GetEXPModifier(Client* self, uint32 zone_id)
 {
 	return self->GetEXPModifier(zone_id);
 }
 
-void Perl_Client_SetAAEXPModifier(Client* self, uint32 zone_id, float aa_modifier)
+double Perl_Client_GetEXPModifier(Client* self, uint32 zone_id, int16 instance_version)
+{
+	return self->GetEXPModifier(zone_id, instance_version);
+}
+
+void Perl_Client_SetAAEXPModifier(Client* self, uint32 zone_id, double aa_modifier)
 {
 	self->SetAAEXPModifier(zone_id, aa_modifier);
 }
 
-void Perl_Client_SetEXPModifier(Client* self, uint32 zone_id, float exp_modifier)
+void Perl_Client_SetAAEXPModifier(Client* self, uint32 zone_id, double aa_modifier, int16 instance_version)
+{
+	self->SetAAEXPModifier(zone_id, aa_modifier, instance_version);
+}
+
+void Perl_Client_SetEXPModifier(Client* self, uint32 zone_id, double exp_modifier)
 {
 	self->SetEXPModifier(zone_id, exp_modifier);
+}
+
+void Perl_Client_SetEXPModifier(Client* self, uint32 zone_id, double exp_modifier, int16 instance_version)
+{
+	self->SetEXPModifier(zone_id, exp_modifier, instance_version);
 }
 
 void Perl_Client_AddLDoNLoss(Client* self, uint32 theme_id)
@@ -2482,7 +2502,8 @@ void perl_register_client()
 	package.add("ForageItem", &Perl_Client_ForageItem);
 	package.add("Freeze", &Perl_Client_Freeze);
 	package.add("GMKill", &Perl_Client_GMKill);
-	package.add("GetAAEXPModifier", &Perl_Client_GetAAEXPModifier);
+	package.add("GetAAEXPModifier", (double(*)(Client*, uint32))&Perl_Client_GetAAEXPModifier);
+	package.add("GetAAEXPModifier", (double(*)(Client*, uint32, int16))&Perl_Client_GetAAEXPModifier);
 	package.add("GetAAExp", &Perl_Client_GetAAExp);
 	package.add("GetAALevel", &Perl_Client_GetAALevel);
 	package.add("GetAAPercent", &Perl_Client_GetAAPercent);
@@ -2531,7 +2552,8 @@ void perl_register_client()
 	package.add("GetDuelTarget", &Perl_Client_GetDuelTarget);
 	package.add("GetEnvironmentDamageModifier", &Perl_Client_GetEnvironmentDamageModifier);
 	package.add("GetEXP", &Perl_Client_GetEXP);
-	package.add("GetEXPModifier", &Perl_Client_GetEXPModifier);
+	package.add("GetEXPModifier", (double(*)(Client*, uint32))&Perl_Client_GetEXPModifier);
+	package.add("GetEXPModifier", (double(*)(Client*, uint32, int16))&Perl_Client_GetEXPModifier);
 	package.add("GetEbonCrystals", &Perl_Client_GetEbonCrystals);
 	package.add("GetEndurance", &Perl_Client_GetEndurance);
 	package.add("GetEnduranceRatio", &Perl_Client_GetEnduranceRatio);
@@ -2719,7 +2741,8 @@ void perl_register_client()
 	package.add("SendToInstance", &Perl_Client_SendToInstance);
 	package.add("SendWebLink", &Perl_Client_SendWebLink);
 	package.add("SendZoneFlagInfo", &Perl_Client_SendZoneFlagInfo);
-	package.add("SetAAEXPModifier", &Perl_Client_SetAAEXPModifier);
+	package.add("SetAAEXPModifier", (void(*)(Client*, uint32, double))&Perl_Client_SetAAEXPModifier);
+	package.add("SetAAEXPModifier", (void(*)(Client*, uint32, double, int16))&Perl_Client_SetAAEXPModifier);
 	package.add("SetAAPoints", &Perl_Client_SetAAPoints);
 	package.add("SetAATitle", (void(*)(Client*, std::string))&Perl_Client_SetAATitle);
 	package.add("SetAATitle", (void(*)(Client*, std::string, bool))&Perl_Client_SetAATitle);
@@ -2747,7 +2770,8 @@ void perl_register_client()
 	package.add("SetDueling", &Perl_Client_SetDueling);
 	package.add("SetEXP", (void(*)(Client*, uint32, uint32))&Perl_Client_SetEXP);
 	package.add("SetEXP", (void(*)(Client*, uint32, uint32, bool))&Perl_Client_SetEXP);
-	package.add("SetEXPModifier", &Perl_Client_SetEXPModifier);
+	package.add("SetEXPModifier", (void(*)(Client*, uint32, double))&Perl_Client_SetEXPModifier);
+	package.add("SetEXPModifier", (void(*)(Client*, uint32, double, int16))&Perl_Client_SetEXPModifier);
 	package.add("SetEbonCrystals", &Perl_Client_SetEbonCrystals);
 	package.add("SetEndurance", &Perl_Client_SetEndurance);
 	package.add("SetEnvironmentDamageModifier", &Perl_Client_SetEnvironmentDamageModifier);

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -3401,20 +3401,20 @@ std::string QuestManager::gethexcolorcode(std::string color_name) {
 	return std::string();
 }
 
-double QuestManager::GetAAEXPModifierByCharID(uint32 character_id, uint32 zone_id) const {
-	return database.GetAAEXPModifier(character_id, zone_id);
+double QuestManager::GetAAEXPModifierByCharID(uint32 character_id, uint32 zone_id, int16 instance_version) const {
+	return database.GetAAEXPModifier(character_id, zone_id, instance_version);
 }
 
-double QuestManager::GetEXPModifierByCharID(uint32 character_id, uint32 zone_id) const {
-	return database.GetEXPModifier(character_id, zone_id);
+double QuestManager::GetEXPModifierByCharID(uint32 character_id, uint32 zone_id, int16 instance_version) const {
+	return database.GetEXPModifier(character_id, zone_id, instance_version);
 }
 
-void QuestManager::SetAAEXPModifierByCharID(uint32 character_id, uint32 zone_id, double aa_modifier) {
-	database.SetAAEXPModifier(character_id, zone_id, aa_modifier);
+void QuestManager::SetAAEXPModifierByCharID(uint32 character_id, uint32 zone_id, double aa_modifier, int16 instance_version) {
+	database.SetAAEXPModifier(character_id, zone_id, aa_modifier, instance_version);
 }
 
-void QuestManager::SetEXPModifierByCharID(uint32 character_id, uint32 zone_id, double exp_modifier) {
-	database.SetEXPModifier(character_id, zone_id, exp_modifier);
+void QuestManager::SetEXPModifierByCharID(uint32 character_id, uint32 zone_id, double exp_modifier, int16 instance_version) {
+	database.SetEXPModifier(character_id, zone_id, exp_modifier, instance_version);
 }
 
 std::string QuestManager::getgendername(uint32 gender_id) {

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -325,10 +325,10 @@ public:
 	void ReloadZoneStaticData();
 	std::string secondstotime(int duration);
 	std::string gethexcolorcode(std::string color_name);
-	double GetAAEXPModifierByCharID(uint32 character_id, uint32 zone_id) const;
-	double GetEXPModifierByCharID(uint32 character_id, uint32 zone_id) const;
-	void SetAAEXPModifierByCharID(uint32 character_id, uint32 zone_id, double aa_modifier);
-	void SetEXPModifierByCharID(uint32 character_id, uint32 zone_id, double exp_modifier);
+	double GetAAEXPModifierByCharID(uint32 character_id, uint32 zone_id, int16 instance_version = -1) const;
+	double GetEXPModifierByCharID(uint32 character_id, uint32 zone_id, int16 instance_version = -1) const;
+	void SetAAEXPModifierByCharID(uint32 character_id, uint32 zone_id, double aa_modifier, int16 instance_version = -1);
+	void SetEXPModifierByCharID(uint32 character_id, uint32 zone_id, double exp_modifier, int16 instance_version = -1);
 	std::string getgendername(uint32 gender_id);
 	std::string getdeityname(uint32 deity_id);
 	std::string getinventoryslotname(int16 slot_id);

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -4842,8 +4842,8 @@ uint32 ZoneDatabase::SaveSaylinkID(const char* saylink_text)
 	return results.LastInsertedID();
 }
 
-double ZoneDatabase::GetAAEXPModifier(uint32 character_id, uint32 zone_id) const {
-	std::string query = fmt::format(
+double ZoneDatabase::GetAAEXPModifier(uint32 character_id, uint32 zone_id, int16 instance_version) const {
+	const auto& query = fmt::format(
 		SQL(
 			SELECT
 			`aa_modifier`
@@ -4852,22 +4852,26 @@ double ZoneDatabase::GetAAEXPModifier(uint32 character_id, uint32 zone_id) const
 			WHERE
 			`character_id` = {}
 			AND
-			(`zone_id` = {} OR `zone_id` = 0)
-			ORDER BY `zone_id` DESC
+			(`zone_id` = {} OR `zone_id` = 0) AND
+			(`instance_version` = {} OR `instance_version` = -1)
+			ORDER BY `zone_id`, `instance_version` DESC
 			LIMIT 1
 		),
 		character_id,
-		zone_id
+		zone_id,
+		instance_version
 	);
+
 	auto results = database.QueryDatabase(query);
 	for (auto& row = results.begin(); row != results.end(); ++row) {
 		return atof(row[0]);
 	}
+
 	return 1.0f;
 }
 
-double ZoneDatabase::GetEXPModifier(uint32 character_id, uint32 zone_id) const {
-	std::string query = fmt::format(
+double ZoneDatabase::GetEXPModifier(uint32 character_id, uint32 zone_id, int16 instance_version) const {
+	const auto& query = fmt::format(
 		SQL(
 			SELECT
 			`exp_modifier`
@@ -4876,48 +4880,54 @@ double ZoneDatabase::GetEXPModifier(uint32 character_id, uint32 zone_id) const {
 			WHERE
 			`character_id` = {}
 			AND
-			(`zone_id` = {} OR `zone_id` = 0)
-			ORDER BY `zone_id` DESC
+			(`zone_id` = {} OR `zone_id` = 0) AND
+			(`instance_version` = {} OR `instance_version` = -1)
+			ORDER BY `zone_id`, `instance_version` DESC
 			LIMIT 1
 		),
 		character_id,
-		zone_id
+		zone_id,
+		instance_version
 	);
+
 	auto results = database.QueryDatabase(query);
 	for (auto& row = results.begin(); row != results.end(); ++row) {
 		return atof(row[0]);
 	}
+
 	return 1.0f;
 }
 
-void ZoneDatabase::SetAAEXPModifier(uint32 character_id, uint32 zone_id, double aa_modifier) {
-	float exp_modifier = GetEXPModifier(character_id, zone_id);
+void ZoneDatabase::SetAAEXPModifier(uint32 character_id, uint32 zone_id, double aa_modifier, int16 instance_version) {
+	float exp_modifier = GetEXPModifier(character_id, zone_id, instance_version);
 	std::string query = fmt::format(
 		SQL(
 			REPLACE INTO
 			`character_exp_modifiers`
 			VALUES
-			({}, {}, {}, {})
+			({}, {}, {}, {}, {})
 		),
 		character_id,
 		zone_id,
+		instance_version,
 		aa_modifier,
 		exp_modifier
 	);
 	database.QueryDatabase(query);
 }
 
-void ZoneDatabase::SetEXPModifier(uint32 character_id, uint32 zone_id, double exp_modifier) {
-	float aa_modifier = GetAAEXPModifier(character_id, zone_id);
+void ZoneDatabase::SetEXPModifier(uint32 character_id, uint32 zone_id, double exp_modifier, int16 instance_version) {
+	float aa_modifier = GetAAEXPModifier(character_id, zone_id, instance_version);
 	std::string query = fmt::format(
 		SQL(
 			REPLACE INTO
 			`character_exp_modifiers`
 			VALUES
-			({}, {}, {}, {})
+			({}, {}, {}, {}, {})
 		),
 		character_id,
 		zone_id,
+		instance_version,
 		aa_modifier,
 		exp_modifier
 	);

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -4843,7 +4843,7 @@ uint32 ZoneDatabase::SaveSaylinkID(const char* saylink_text)
 }
 
 double ZoneDatabase::GetAAEXPModifier(uint32 character_id, uint32 zone_id, int16 instance_version) const {
-	const auto& query = fmt::format(
+	const std::string query = fmt::format(
 		SQL(
 			SELECT
 			`aa_modifier`
@@ -4871,7 +4871,7 @@ double ZoneDatabase::GetAAEXPModifier(uint32 character_id, uint32 zone_id, int16
 }
 
 double ZoneDatabase::GetEXPModifier(uint32 character_id, uint32 zone_id, int16 instance_version) const {
-	const auto& query = fmt::format(
+	const std::string query = fmt::format(
 		SQL(
 			SELECT
 			`exp_modifier`

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -370,10 +370,10 @@ public:
 	bool SaveCharacterSpell(uint32 character_id, uint32 spell_id, uint32 slot_id);
 	bool SaveCharacterTribute(uint32 character_id, PlayerProfile_Struct* pp);
 	
-	double GetAAEXPModifier(uint32 character_id, uint32 zone_id) const;
-	double GetEXPModifier(uint32 character_id, uint32 zone_id) const;
-	void SetAAEXPModifier(uint32 character_id, uint32 zone_id, double aa_modifier);
-	void SetEXPModifier(uint32 character_id, uint32 zone_id, double exp_modifier);
+	double GetAAEXPModifier(uint32 character_id, uint32 zone_id, int16 instance_version = -1) const;
+	double GetEXPModifier(uint32 character_id, uint32 zone_id, int16 instance_version = -1) const;
+	void SetAAEXPModifier(uint32 character_id, uint32 zone_id, double aa_modifier, int16 instance_version = -1);
+	void SetEXPModifier(uint32 character_id, uint32 zone_id, double exp_modifier, int16 instance_version = -1);
 
 	/* Character Inventory  */
 	bool	NoRentExpired(const char* name);


### PR DESCRIPTION
Allows Operators to set experience modifiers to be instance version specific so that you can have different versions of the same zone have different modifiers.

If there is not one found, it defaults to `zone_id` 0 for global and `instance_version` -1 for global.