### PR TITLE
[Quest API] Add Goto Player Teleport Methods.

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -9397,40 +9397,40 @@ bool Client::GotoPlayer(std::string player_name)
 	return false;
 }
 
-bool Client::GotoPlayerGroup(std::string player_name) {
+bool Client::GotoPlayerGroup(const std::string& player_name)
+{
 	if (!GetGroup()) {
 		return GotoPlayer(player_name);
-	} else {
-		auto client_group = GetGroup();
-		for (int member_index = 0; member_index < MAX_GROUP_MEMBERS; member_index++) {
-			if (client_group->members[member_index] && client_group->members[member_index]->IsClient()) {
-				auto group_member = client_group->members[member_index]->CastToClient();
-				if (!group_member->GotoPlayer(player_name)) {
-					return false;
-				}
+	}
+
+	for (auto &m: GetGroup()->members) {
+		if (m && m->IsClient()) {
+			auto c = m->CastToClient();
+			if (!c->GotoPlayer(player_name)) {
+				return false;
 			}
 		}
-
-		return true;
 	}
+
+	return true;
 }
 
-bool Client::GotoPlayerRaid(std::string player_name) {
+bool Client::GotoPlayerRaid(const std::string& player_name)
+{
 	if (!GetRaid()) {
 		return GotoPlayer(player_name);
-	} else {
-		auto client_raid = GetRaid();
-		for (int member_index = 0; member_index < MAX_RAID_MEMBERS; member_index++) {
-			if (client_raid->members[member_index].member && client_raid->members[member_index].member->IsClient()) {
-				auto raid_member = client_raid->members[member_index].member->CastToClient();
-				if (!raid_member->GotoPlayer(player_name)) {
-					return false;
-				}
+	}
+	
+	for (auto &m: GetRaid()->members) {
+		if (m.member && m.member->IsClient()) {
+			auto c = m.member->CastToClient();
+			if (!c->GotoPlayer(player_name)) {
+				return false;
 			}
 		}
-
-		return true;
 	}
+
+	return true;
 }
 
 glm::vec4 &Client::GetLastPositionBeforeBulkUpdate()

--- a/zone/client.h
+++ b/zone/client.h
@@ -243,6 +243,8 @@ public:
 	void SendChatLineBreak(uint16 color = Chat::White);
 
 	bool GotoPlayer(std::string player_name);
+	bool GotoPlayerGroup(std::string player_name);
+	bool GotoPlayerRaid(std::string player_name);
 
 	//abstract virtual function implementations required by base abstract class
 	virtual bool Death(Mob* killerMob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill);

--- a/zone/client.h
+++ b/zone/client.h
@@ -243,8 +243,8 @@ public:
 	void SendChatLineBreak(uint16 color = Chat::White);
 
 	bool GotoPlayer(std::string player_name);
-	bool GotoPlayerGroup(std::string player_name);
-	bool GotoPlayerRaid(std::string player_name);
+	bool GotoPlayerGroup(const std::string& player_name);
+	bool GotoPlayerRaid(const std::string& player_name);
 
 	//abstract virtual function implementations required by base abstract class
 	virtual bool Death(Mob* killerMob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill);

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -2555,6 +2555,36 @@ void Lua_Client::TaskSelector(luabind::adl::object table) {
 	self->TaskQuestSetSelector(self, task_count, tasks);
 }
 
+bool Lua_Client::TeleportToPlayerByCharID(uint32 character_id) {
+	Lua_Safe_Call_Bool();
+	return self->GotoPlayer(database.GetCharNameByID(character_id));
+}
+
+bool Lua_Client::TeleportToPlayerByName(std::string player_name) {
+	Lua_Safe_Call_Bool();
+	return self->GotoPlayer(player_name);
+}
+
+bool Lua_Client::TeleportGroupToPlayerByCharID(uint32 character_id) {
+	Lua_Safe_Call_Bool();
+	return self->GotoPlayerGroup(database.GetCharNameByID(character_id));
+}
+
+bool Lua_Client::TeleportGroupToPlayerByName(std::string player_name) {
+	Lua_Safe_Call_Bool();
+	return self->GotoPlayerGroup(player_name);
+}
+
+bool Lua_Client::TeleportRaidToPlayerByCharID(uint32 character_id) {
+	Lua_Safe_Call_Bool();
+	return self->GotoPlayerRaid(database.GetCharNameByID(character_id));
+}
+
+bool Lua_Client::TeleportRaidToPlayerByName(std::string player_name) {
+	Lua_Safe_Call_Bool();
+	return self->GotoPlayerRaid(player_name);
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 	.def(luabind::constructor<>())
@@ -2951,6 +2981,12 @@ luabind::scope lua_register_client() {
 	.def("TakePlatinum", (bool(Lua_Client::*)(uint32))&Lua_Client::TakePlatinum)
 	.def("TakePlatinum", (bool(Lua_Client::*)(uint32,bool))&Lua_Client::TakePlatinum)
 	.def("TaskSelector", (void(Lua_Client::*)(luabind::adl::object))&Lua_Client::TaskSelector)
+	.def("TeleportToPlayerByCharID", (bool(Lua_Client::*)(uint32))&Lua_Client::TeleportToPlayerByCharID)
+	.def("TeleportToPlayerByName", (bool(Lua_Client::*)(std::string))&Lua_Client::TeleportToPlayerByName)
+	.def("TeleportGroupToPlayerByCharID", (bool(Lua_Client::*)(uint32))&Lua_Client::TeleportGroupToPlayerByCharID)
+	.def("TeleportGroupToPlayerByName", (bool(Lua_Client::*)(std::string))&Lua_Client::TeleportGroupToPlayerByName)
+	.def("TeleportRaidToPlayerByCharID", (bool(Lua_Client::*)(uint32))&Lua_Client::TeleportRaidToPlayerByCharID)
+	.def("TeleportRaidToPlayerByName", (bool(Lua_Client::*)(std::string))&Lua_Client::TeleportRaidToPlayerByName)
 	.def("Thirsty", (bool(Lua_Client::*)(void))&Lua_Client::Thirsty)
 	.def("TrainDisc", (void(Lua_Client::*)(int))&Lua_Client::TrainDisc)
 	.def("TrainDiscBySpellID", (void(Lua_Client::*)(int32))&Lua_Client::TrainDiscBySpellID)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -118,6 +118,12 @@ public:
 	void MoveZoneInstance(uint16 instance_id);
 	void MoveZoneInstanceGroup(uint16 instance_id);
 	void MoveZoneInstanceRaid(uint16 instance_id);
+	bool TeleportToPlayerByCharID(uint32 character_id);
+	bool TeleportToPlayerByName(std::string player_name);
+	bool TeleportGroupToPlayerByCharID(uint32 character_id);
+	bool TeleportGroupToPlayerByName(std::string player_name);
+	bool TeleportRaidToPlayerByCharID(uint32 character_id);
+	bool TeleportRaidToPlayerByName(std::string player_name);
 	void ChangeLastName(std::string last_name);
 	int GetFactionLevel(uint32 char_id, uint32 npc_id, uint32 race, uint32 class_, uint32 deity, uint32 faction, Lua_NPC npc);
 	void SetFactionLevel(uint32 char_id, uint32 npc_id, int char_class, int char_race, int char_deity);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -2399,6 +2399,36 @@ void Perl_Client_TaskSelector(Client* self, perl::array task_ids)
 	self->TaskQuestSetSelector(self, task_count, tasks);
 }
 
+bool Perl_Client_TeleportToPlayerByCharacterID(Client* self, uint32 character_id)
+{
+	return self->GotoPlayer(database.GetCharNameByID(character_id));
+}
+
+bool Perl_Client_TeleportToPlayerByName(Client* self, std::string player_name)
+{
+	return self->GotoPlayer(player_name);
+}
+
+bool Perl_Client_TeleportGroupToPlayerByCharacterID(Client* self, uint32 character_id)
+{
+	return self->GotoPlayerGroup(database.GetCharNameByID(character_id));
+}
+
+bool Perl_Client_TeleportGroupToPlayerByName(Client* self, std::string player_name)
+{
+	return self->GotoPlayerGroup(player_name);
+}
+
+bool Perl_Client_TeleportRaidToPlayerByCharacterID(Client* self, uint32 character_id)
+{
+	return self->GotoPlayerRaid(database.GetCharNameByID(character_id));
+}
+
+bool Perl_Client_TeleportRaidToPlayerByName(Client* self, std::string player_name)
+{
+	return self->GotoPlayerRaid(player_name);
+}
+
 void perl_register_client()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -2799,6 +2829,12 @@ void perl_register_client()
 	package.add("TakeMoneyFromPP", (bool(*)(Client*, uint64_t, bool))&Perl_Client_TakeMoneyFromPP);
 	package.add("TakePlatinum", (bool(*)(Client*, uint32))&Perl_Client_TakePlatinum);
 	package.add("TakePlatinum", (bool(*)(Client*, uint32, bool))&Perl_Client_TakePlatinum);
+	package.add("TeleportToPlayerByCharID", &Perl_Client_TeleportToPlayerByCharacterID);
+	package.add("TeleportToPlayerByName", &Perl_Client_TeleportToPlayerByName);
+	package.add("TeleportGroupToPlayerByCharID", &Perl_Client_TeleportGroupToPlayerByCharacterID);
+	package.add("TeleportGroupToPlayerByName", &Perl_Client_TeleportGroupToPlayerByName);
+	package.add("TeleportRaidToPlayerByCharID", &Perl_Client_TeleportRaidToPlayerByCharacterID);
+	package.add("TeleportRaidToPlayerByName", &Perl_Client_TeleportRaidToPlayerByName);
 	package.add("TaskSelector", &Perl_Client_TaskSelector);
 	package.add("Thirsty", &Perl_Client_Thirsty);
 	package.add("TrainDiscBySpellID", &Perl_Client_TrainDiscBySpellID);


### PR DESCRIPTION
These methods will allow server operators to teleport players directly to other players via the quest API using the #goto command's functionality.
- Add $client->TeleportToPlayerByCharID(character_id) to Perl.
- Add $client->TeleportToPlayerByName(player_name) to Perl.
- Add $client->TeleportGroupToPlayerByCharID(character_id) to Perl.
- Add $client->TeleportGroupToPlayerByName(player_name) to Perl.
- Add $client->TeleportRaidToPlayerByCharID(character_id) to Perl.
- Add $client->TeleportRaidToPlayerByName(player_name) to Perl.
- Add client:TeleportToPlayerByCharID(character_id) to Lua.
- Add client:TeleportToPlayerByName(player_name) to Lua.
- Add client:TeleportGroupToPlayerByCharID(character_id) to Lua.
- Add client:TeleportGroupToPlayerByName(player_name) to Lua.
- Add client:TeleportRaidToPlayerByCharID(character_id) to Lua.
- Add client:TeleportRaidToPlayerByName(player_name) to Lua.