### PR TITLE
[Bug Fix] Fix Silent Saylinks Sending Message to Others.

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -830,7 +830,7 @@ void Client::FastQueuePacket(EQApplicationPacket** app, bool ack_req, CLIENT_CON
 	return;
 }
 
-void Client::ChannelMessageReceived(uint8 chan_num, uint8 language, uint8 lang_skill, const char* orig_message, const char* targetname) {
+void Client::ChannelMessageReceived(uint8 chan_num, uint8 language, uint8 lang_skill, const char* orig_message, const char* targetname, bool is_silent) {
 	char message[4096];
 	strn0cpy(message, orig_message, sizeof(message));
 
@@ -1168,7 +1168,10 @@ void Client::ChannelMessageReceived(uint8 chan_num, uint8 language, uint8 lang_s
 		if (GetPet() && GetTarget() == GetPet() && GetPet()->FindType(SE_VoiceGraft))
 			sender = GetPet();
 
-		entity_list.ChannelMessage(sender, chan_num, language, lang_skill, message);
+		if (!is_silent) {
+			entity_list.ChannelMessage(sender, chan_num, language, lang_skill, message);
+		}
+
 		parse->EventPlayer(EVENT_SAY, this, message, language);
 
 		if (sender != this)

--- a/zone/client.h
+++ b/zone/client.h
@@ -328,7 +328,7 @@ public:
 	void LogMerchant(Client* player, Mob* merchant, uint32 quantity, uint32 price, const EQ::ItemData* item, bool buying);
 	void QueuePacket(const EQApplicationPacket* app, bool ack_req = true, CLIENT_CONN_STATUS = CLIENT_CONNECTINGALL, eqFilterType filter=FilterNone);
 	void FastQueuePacket(EQApplicationPacket** app, bool ack_req = true, CLIENT_CONN_STATUS = CLIENT_CONNECTINGALL);
-	void ChannelMessageReceived(uint8 chan_num, uint8 language, uint8 lang_skill, const char* orig_message, const char* targetname=nullptr);
+	void ChannelMessageReceived(uint8 chan_num, uint8 language, uint8 lang_skill, const char* orig_message, const char* targetname = nullptr, bool is_silent = false);
 	void ChannelMessageSend(const char* from, const char* to, uint8 chan_num, uint8 language, uint8 lang_skill, const char* message, ...);
 	void Message(uint32 type, const char* message, ...);
 	void FilteredMessage(Mob *sender, uint32 type, eqFilterType filter, const char* message, ...);

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -8528,7 +8528,7 @@ void Client::Handle_OP_ItemLinkClick(const EQApplicationPacket *app)
 				return;
 			}
 
-			ChannelMessageReceived(ChatChannel_Say, 0, 100, response.c_str());
+			ChannelMessageReceived(ChatChannel_Say, 0, 100, response.c_str(), true);
 
 			if (!silentsaylink) {
 				Message(Chat::LightGray, "You say, '%s'", response.c_str());
@@ -11133,7 +11133,7 @@ void Client::Handle_OP_PopupResponse(const EQApplicationPacket *app)
 			if (EntityVariableExists(DIAWIND_RESPONSE_ONE_KEY.c_str())) {
 				response = GetEntityVariable(DIAWIND_RESPONSE_ONE_KEY.c_str());
 				if (!response.empty()) {
-					ChannelMessageReceived(8, 0, 100, response.c_str());
+					ChannelMessageReceived(8, 0, 100, response.c_str(), true);
 				}
 			}
 			break;
@@ -11142,7 +11142,7 @@ void Client::Handle_OP_PopupResponse(const EQApplicationPacket *app)
 			if (EntityVariableExists(DIAWIND_RESPONSE_TWO_KEY.c_str())) {
 				response = GetEntityVariable(DIAWIND_RESPONSE_TWO_KEY.c_str());
 				if (!response.empty()) {
-					ChannelMessageReceived(8, 0, 100, response.c_str());
+					ChannelMessageReceived(8, 0, 100, response.c_str(), true);
 				}
 			}
 			break;

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -8528,7 +8528,7 @@ void Client::Handle_OP_ItemLinkClick(const EQApplicationPacket *app)
 				return;
 			}
 
-			ChannelMessageReceived(ChatChannel_Say, 0, 100, response.c_str(), true);
+			ChannelMessageReceived(ChatChannel_Say, 0, 100, response.c_str(), nullptr, true);
 
 			if (!silentsaylink) {
 				Message(Chat::LightGray, "You say, '%s'", response.c_str());
@@ -11133,7 +11133,7 @@ void Client::Handle_OP_PopupResponse(const EQApplicationPacket *app)
 			if (EntityVariableExists(DIAWIND_RESPONSE_ONE_KEY.c_str())) {
 				response = GetEntityVariable(DIAWIND_RESPONSE_ONE_KEY.c_str());
 				if (!response.empty()) {
-					ChannelMessageReceived(8, 0, 100, response.c_str(), true);
+					ChannelMessageReceived(8, 0, 100, response.c_str(), nullptr, true);
 				}
 			}
 			break;
@@ -11142,7 +11142,7 @@ void Client::Handle_OP_PopupResponse(const EQApplicationPacket *app)
 			if (EntityVariableExists(DIAWIND_RESPONSE_TWO_KEY.c_str())) {
 				response = GetEntityVariable(DIAWIND_RESPONSE_TWO_KEY.c_str());
 				if (!response.empty()) {
-					ChannelMessageReceived(8, 0, 100, response.c_str(), true);
+					ChannelMessageReceived(8, 0, 100, response.c_str(), nullptr, true);
 				}
 			}
 			break;

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -1566,7 +1566,7 @@ void Perl_Client_SilentMessage(Client* self, const char* message) // @categories
 				if (self->GetTarget()->CastToNPC()->IsMoving() &&
 					  !self->GetTarget()->CastToNPC()->IsOnHatelist(self->GetTarget()))
 					self->GetTarget()->CastToNPC()->PauseWandering(RuleI(NPC, SayPauseTimeInSec));
-				self->ChannelMessageReceived(8, 0, 100, message);
+				self->ChannelMessageReceived(8, 0, 100, message, true);
 			}
 		}
 	}

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -1566,7 +1566,7 @@ void Perl_Client_SilentMessage(Client* self, const char* message) // @categories
 				if (self->GetTarget()->CastToNPC()->IsMoving() &&
 					  !self->GetTarget()->CastToNPC()->IsOnHatelist(self->GetTarget()))
 					self->GetTarget()->CastToNPC()->PauseWandering(RuleI(NPC, SayPauseTimeInSec));
-				self->ChannelMessageReceived(8, 0, 100, message, true);
+				self->ChannelMessageReceived(8, 0, 100, message, nullptr, true);
 			}
 		}
 	}


### PR DESCRIPTION
Silent saylinks wouldn't send to sender, but to everyone else, so they could see what your saylinks were.

Added an optional `is_silent` bool to ChannelMessageReceived to account for this where necessary.