### PR TITLE
[Quest API] Add Recipe Methods

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -63,6 +63,7 @@ extern volatile bool RunLoops;
 #include "../common/expedition_lockout_timer.h"
 #include "cheat_manager.h"
 
+#include "../common/repositories/char_recipe_list_repository.h"
 #include "../common/repositories/character_spells_repository.h"
 #include "../common/repositories/character_disciplines_repository.h"
 #include "../common/repositories/character_data_repository.h"
@@ -11758,4 +11759,32 @@ void Client::SetTrackingID(uint32 entity_id)
 	TrackingID = entity_id;
 
 	MessageString(Chat::Skills, TRACKING_BEGIN, m->GetCleanName());
+}
+
+int Client::GetRecipeMadeCount(uint32 recipe_id)
+{
+	auto r = CharRecipeListRepository::GetWhere(
+		database,
+		fmt::format("char_id = {} AND recipe_id = {}", CharacterID(), recipe_id)
+	);
+
+	if (!r.empty() && r[0].recipe_id) {
+		return r[0].madecount;
+	}
+
+	return 0;
+}
+
+bool Client::HasRecipeLearned(uint32 recipe_id)
+{
+	auto r = CharRecipeListRepository::GetWhere(
+		database,
+		fmt::format("char_id = {} AND recipe_id = {}", CharacterID(), recipe_id)
+	);
+
+	if (!r.empty() && r[0].recipe_id) {
+		return true;
+	}
+
+	return false;
 }

--- a/zone/client.h
+++ b/zone/client.h
@@ -334,7 +334,9 @@ public:
 	void FilteredMessage(Mob *sender, uint32 type, eqFilterType filter, const char* message, ...);
 	void VoiceMacroReceived(uint32 Type, char *Target, uint32 MacroNumber);
 	void SendSound();
-	void LearnRecipe(uint32 recipeID);
+	void LearnRecipe(uint32 recipe_id);
+	int GetRecipeMadeCount(uint32 recipe_id);
+	bool HasRecipeLearned(uint32 recipe_id);
 	bool CanIncreaseTradeskill(EQ::skills::SkillType tradeskill);
 
 	EQApplicationPacket* ReturnItemPacket(int16 slot_id, const EQ::ItemInstance* inst, ItemPacketType packet_type);

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -3676,6 +3676,21 @@ void Perl__tracknpc(uint32 entity_id)
 	quest_manager.TrackNPC(entity_id);
 }
 
+int Perl__getrecipemadecount(uint32 recipe_id)
+{
+	return quest_manager.GetRecipeMadeCount(recipe_id);
+}
+
+std::string Perl__getrecipename(uint32 recipe_id)
+{
+	return quest_manager.GetRecipeName(recipe_id);
+}
+
+bool Perl__hasrecipelearned(uint32 recipe_id)
+{
+	return quest_manager.HasRecipeLearned(recipe_id);
+}
+
 void perl_register_quest()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -4082,6 +4097,8 @@ void perl_register_quest()
 	package.add("getplayerburiedcorpsecount", &Perl__getplayerburiedcorpsecount);
 	package.add("getplayercorpsecount", &Perl__getplayercorpsecount);
 	package.add("getplayercorpsecountbyzoneid", &Perl__getplayercorpsecountbyzoneid);
+	package.add("getrecipemadecount", &Perl__getrecipemadecount);
+	package.add("getrecipename", &Perl__getrecipename);
 	package.add("gettaskactivitydonecount", &Perl__gettaskactivitydonecount);
 	package.add("gettaskname", &Perl__gettaskname);
 	package.add("gettimerdurationMS", &Perl__gettimerdurationMS);
@@ -4096,6 +4113,7 @@ void perl_register_quest()
 	package.add("gmsay", (void(*)(const char*, int, bool, int))&Perl__gmsay);
 	package.add("gmsay", (void(*)(const char*, int, bool, int, int))&Perl__gmsay);
 	package.add("has_zone_flag", &Perl__has_zone_flag);
+	package.add("hasrecipelearned", &Perl__hasrecipelearned);
 	package.add("hastimer", &Perl__hastimer);
 	package.add("incstat", &Perl__incstat);
 	package.add("isdisctome", &Perl__isdisctome);

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -2605,6 +2605,16 @@ bool Lua_Client::TeleportRaidToPlayerByName(std::string player_name) {
 	return self->GotoPlayerRaid(player_name);
 }
 
+int Lua_Client::GetRecipeMadeCount(uint32 recipe_id) {
+	Lua_Safe_Call_Int();
+	return self->GetRecipeMadeCount(recipe_id);
+}
+
+bool Lua_Client::HasRecipeLearned(uint32 recipe_id) {
+	Lua_Safe_Call_Bool();
+	return self->HasRecipeLearned(recipe_id);
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 	.def(luabind::constructor<>())
@@ -2789,6 +2799,7 @@ luabind::scope lua_register_client() {
 	.def("GetRaidPoints", (uint32(Lua_Client::*)(void))&Lua_Client::GetRaidPoints)
 	.def("GetRawItemAC", (int(Lua_Client::*)(void))&Lua_Client::GetRawItemAC)
 	.def("GetRawSkill", (int(Lua_Client::*)(int))&Lua_Client::GetRawSkill)
+	.def("GetRecipeMadeCount", (int(Lua_Client::*)(uint32))&Lua_Client::GetRecipeMadeCount)
 	.def("GetScribeableSpells", (luabind::object(Lua_Client::*)(lua_State* L))&Lua_Client::GetScribeableSpells)
 	.def("GetScribeableSpells", (luabind::object(Lua_Client::*)(lua_State* L,uint8))&Lua_Client::GetScribeableSpells)
 	.def("GetScribeableSpells", (luabind::object(Lua_Client::*)(lua_State* L,uint8,uint8))&Lua_Client::GetScribeableSpells)
@@ -2814,6 +2825,7 @@ luabind::scope lua_register_client() {
 	.def("HasExpeditionLockout", (bool(Lua_Client::*)(std::string, std::string))&Lua_Client::HasExpeditionLockout)
 	.def("HasItemEquippedByID", (bool(Lua_Client::*)(uint32))&Lua_Client::HasItemEquippedByID)
 	.def("HasPEQZoneFlag", (bool(Lua_Client::*)(uint32))&Lua_Client::HasPEQZoneFlag)
+	.def("HasRecipeLearned", (bool(Lua_Client::*)(uint32))&Lua_Client::HasRecipeLearned)
 	.def("HasSkill", (bool(Lua_Client::*)(int))&Lua_Client::HasSkill)
 	.def("HasSpellScribed", (bool(Lua_Client::*)(int))&Lua_Client::HasSpellScribed)
 	.def("HasZoneFlag", (bool(Lua_Client::*)(uint32))&Lua_Client::HasZoneFlag)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -310,7 +310,9 @@ public:
 	void UpdateGroupAAs(int points, uint32 type);
 	uint32 GetGroupPoints();
 	uint32 GetRaidPoints();
-	void LearnRecipe(uint32 recipe);
+	void LearnRecipe(uint32 recipe_id);
+	int GetRecipeMadeCount(uint32 recipe_id);
+	bool HasRecipeLearned(uint32 recipe_id);
 	int GetEndurance();
 	int GetMaxEndurance();
 	int GetEndurancePercent();

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -3414,6 +3414,18 @@ void lua_track_npc(uint32 entity_id) {
 	quest_manager.TrackNPC(entity_id);
 }
 
+int lua_get_recipe_made_count(uint32 recipe_id) {
+	return quest_manager.GetRecipeMadeCount(recipe_id);
+}
+
+std::string lua_get_recipe_name(uint32 recipe_id) {
+	return quest_manager.GetRecipeName(recipe_id);
+}
+
+bool lua_has_recipe_learned(uint32 recipe_id) {
+	return quest_manager.HasRecipeLearned(recipe_id);
+}
+
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
 	cur = table[#name]; \
 	if(luabind::type(cur) != LUA_TNIL) { \
@@ -3874,6 +3886,9 @@ luabind::scope lua_register_general() {
 		luabind::def("check_name_filter", &lua_check_name_filter),
 		luabind::def("discord_send", &lua_discord_send),
 		luabind::def("track_npc", &lua_track_npc),
+		luabind::def("get_recipe_made_count", &lua_get_recipe_made_count),
+		luabind::def("get_recipe_name", &lua_get_recipe_name),
+		luabind::def("has_recipe_learned", &lua_has_recipe_learned),
 
 		/*
 			Cross Zone

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -2449,6 +2449,16 @@ bool Perl_Client_TeleportRaidToPlayerByName(Client* self, std::string player_nam
 	return self->GotoPlayerRaid(player_name);
 }
 
+int Perl_Client_GetRecipeMadeCount(Client* self, uint32 recipe_id) // @categories Skills and Recipes
+{
+	return self->GetRecipeMadeCount(recipe_id);
+}
+
+bool Perl_Client_HasRecipeLearned(Client* self, uint32 recipe_id) // @categories Skills and Recipes
+{
+	return self->HasRecipeLearned(recipe_id);
+}
+
 void perl_register_client()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -2636,6 +2646,7 @@ void perl_register_client()
 	package.add("GetRaidPoints", &Perl_Client_GetRaidPoints);
 	package.add("GetRawItemAC", &Perl_Client_GetRawItemAC);
 	package.add("GetRawSkill", &Perl_Client_GetRawSkill);
+	package.add("GetRecipeMadeCount", &Perl_Client_GetRecipeMadeCount);
 	package.add("GetScribeableSpells", (perl::array(*)(Client*))&Perl_Client_GetScribeableSpells);
 	package.add("GetScribeableSpells", (perl::array(*)(Client*, uint8))&Perl_Client_GetScribeableSpells);
 	package.add("GetScribeableSpells", (perl::array(*)(Client*, uint8, uint8))&Perl_Client_GetScribeableSpells);
@@ -2663,6 +2674,7 @@ void perl_register_client()
 	package.add("HasExpeditionLockout", &Perl_Client_HasExpeditionLockout);
 	package.add("HasItemEquippedByID", &Perl_Client_HasItemEquippedByID);
 	package.add("HasPEQZoneFlag", &Perl_Client_HasPEQZoneFlag);
+	package.add("HasRecipeLearned", &Perl_Client_HasRecipeLearned);
 	package.add("HasSkill", &Perl_Client_HasSkill);
 	package.add("HasSpellScribed", &Perl_Client_HasSpellScribed);
 	package.add("HasZoneFlag", &Perl_Client_HasZoneFlag);

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -39,6 +39,8 @@
 #include "dialogue_window.h"
 #include "string_ids.h"
 
+#include "../common/repositories/tradeskill_recipe_repository.h"
+
 #include <iostream>
 #include <limits.h>
 #include <list>
@@ -3163,13 +3165,6 @@ void QuestManager::voicetell(const char *str, int macronum, int racenum, int gen
 	}
 }
 
-void QuestManager::LearnRecipe(uint32 recipe_id) {
-	QuestManagerCurrentQuestVars();
-	if(!initiator)
-		return;
-	initiator->LearnRecipe(recipe_id);
-}
-
 void QuestManager::SendMail(const char *to, const char *from, const char *subject, const char *message) {
 	if(to == nullptr || from == nullptr || subject == nullptr || message == nullptr) {
 		return;
@@ -3682,4 +3677,44 @@ void QuestManager::TrackNPC(uint32 entity_id) {
 	}
 
 	initiator->SetTrackingID(entity_id);
+}
+
+int QuestManager::GetRecipeMadeCount(uint32 recipe_id) {
+	QuestManagerCurrentQuestVars();
+	if (!initiator) {
+		return 0;
+	}
+
+	return initiator->GetRecipeMadeCount(recipe_id);
+}
+
+std::string QuestManager::GetRecipeName(uint32 recipe_id) {
+	auto r = TradeskillRecipeRepository::GetWhere(
+		database,
+		fmt::format("id = {}", recipe_id)
+	);
+
+	if (!r.empty() && r[0].id) {
+		return r[0].name;
+	}
+
+	return std::string();
+}
+
+bool QuestManager::HasRecipeLearned(uint32 recipe_id) {
+	QuestManagerCurrentQuestVars();
+	if (!initiator) {
+		return false;
+	}
+
+	return initiator->HasRecipeLearned(recipe_id);
+}
+
+void QuestManager::LearnRecipe(uint32 recipe_id) {
+	QuestManagerCurrentQuestVars();
+	if (!initiator) {
+		return;
+	}
+
+	initiator->LearnRecipe(recipe_id);
 }

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -337,6 +337,9 @@ public:
 	const SPDat_Spell_Struct *getspell(uint32 spell_id);
 	std::string getenvironmentaldamagename(uint8 damage_type);
 	void TrackNPC(uint32 entity_id);
+	int GetRecipeMadeCount(uint32 recipe_id);
+	std::string GetRecipeName(uint32 recipe_id);
+	bool HasRecipeLearned(uint32 recipe_id);
 
 	Client *GetInitiator() const;
 	NPC *GetNPC() const;


### PR DESCRIPTION
- Add $client->GetRecipeMadeCount(recipe_id) to Perl.
- Add $client->HasRecipeLearned(recipe_id) to Perl.
- Add quest::getrecipemadecount(recipe_id) to Perl.
- Add quest::getrecipename(recipe_id) to Perl.
- Add quest::hasrecipelearned(recipe_id) to Perl.
- Add client:GetRecipeMadeCount(recipe_id) to Lua.
- Add client:HasRecipeLearned(recipe_id) to Lua.
- Add eq.get_recipe_made_count(recipe_id) to Lua.
- Add eq.get_recipe_name(recipe_id) to Lua.
- Add eq.has_recipe_learned(recipe_id) to Lua.