### PR TITLE
[Bug Fix] Fix loading world shared task state

### DIFF
--- a/world/shared_task_manager.cpp
+++ b/world/shared_task_manager.cpp
@@ -356,7 +356,7 @@ void SharedTaskManager::LoadSharedTaskState()
 						e.step           = ad.step;
 						e.optional       = ad.optional;
 						e.req_activity_id = ad.req_activity_id;
-						e.activity_state = sta.completed_time == 0 ? ActivityHidden : ActivityCompleted;
+						e.activity_state = sta.completed_time > 0 ? ActivityCompleted : ActivityHidden;
 					}
 				}
 


### PR DESCRIPTION
The default for this field is -1 not 0, so on world restarts this was
marking all elements completed