### PR TITLE
[Quest API] Allow CreateInstance to be used without a Client initiator.

### DIFF
--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -2780,30 +2780,33 @@ std::string QuestManager::getcleannpcnamebyid(uint32 npc_id) {
 	return res;
 }
 
-uint16 QuestManager::CreateInstance(const char *zone, int16 version, uint32 duration)
+uint16 QuestManager::CreateInstance(const char *zone_short_name, int16 version, uint32 duration)
 {
 	QuestManagerCurrentQuestVars();
-	if(initiator)
-	{
-		uint32 zone_id = ZoneID(zone);
-		if(zone_id == 0)
-			return 0;
 
-		uint16 id = 0;
-		if(!database.GetUnusedInstanceID(id))
-		{
-			initiator->Message(Chat::Red, "Server was unable to find a free instance id.");
-			return 0;
-		}
-
-		if(!database.CreateInstance(id, zone_id, version, duration))
-		{
-			initiator->Message(Chat::Red, "Server was unable to create a new instance.");
-			return 0;
-		}
-		return id;
+	uint32 zone_id = ZoneID(zone_short_name);
+	if (!zone_id) {
+		return 0;
 	}
-	return 0;
+
+	uint16 instance_id = 0;
+	if (!database.GetUnusedInstanceID(instance_id)) {
+		if (initiator) {
+			initiator->Message(Chat::Red, "Server was unable to find a free instance id.");
+		}
+
+		return 0;
+	}
+
+	if (!database.CreateInstance(instance_id, zone_id, version, duration)) {
+		if (initiator) {
+			initiator->Message(Chat::Red, "Server was unable to create a new instance.");
+		}
+
+		return 0;
+	}
+
+	return instance_id;
 }
 
 void QuestManager::DestroyInstance(uint16 instance_id)

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -2780,7 +2780,7 @@ std::string QuestManager::getcleannpcnamebyid(uint32 npc_id) {
 	return res;
 }
 
-uint16 QuestManager::CreateInstance(const char *zone_short_name, int16 version, uint32 duration)
+uint16 QuestManager::CreateInstance(const char *zone_short_name, int16 instance_version, uint32 duration)
 {
 	QuestManagerCurrentQuestVars();
 
@@ -2798,7 +2798,7 @@ uint16 QuestManager::CreateInstance(const char *zone_short_name, int16 version, 
 		return 0;
 	}
 
-	if (!database.CreateInstance(instance_id, zone_id, version, duration)) {
+	if (!database.CreateInstance(instance_id, zone_id, instance_version, duration)) {
 		if (initiator) {
 			initiator->Message(Chat::Red, "Server was unable to create a new instance.");
 		}

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -254,7 +254,7 @@ public:
 	void UpdateSpawnTimer(uint32 id, uint32 newTime);
 	void MerchantSetItem(uint32 NPCid, uint32 itemid, uint32 quantity = 0);
 	uint32 MerchantCountItem(uint32 NPCid, uint32 itemid);
-	uint16 CreateInstance(const char *zone_short_name, int16 version, uint32 duration);
+	uint16 CreateInstance(const char *zone_short_name, int16 instance_version, uint32 duration);
 	void UpdateInstanceTimer(uint16 instance_id, uint32 new_duration);
 	void UpdateZoneHeader(std::string type, std::string value);
 	uint32 GetInstanceTimer();

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -254,7 +254,7 @@ public:
 	void UpdateSpawnTimer(uint32 id, uint32 newTime);
 	void MerchantSetItem(uint32 NPCid, uint32 itemid, uint32 quantity = 0);
 	uint32 MerchantCountItem(uint32 NPCid, uint32 itemid);
-	uint16 CreateInstance(const char *zone, int16 version, uint32 duration);
+	uint16 CreateInstance(const char *zone_short_name, int16 version, uint32 duration);
 	void UpdateInstanceTimer(uint16 instance_id, uint32 new_duration);
 	void UpdateZoneHeader(std::string type, std::string value);
 	uint32 GetInstanceTimer();


### PR DESCRIPTION
Currently, you have to create the instance with a client initiator, whether that's in an NPC's EVENT_SAY /EVENT_ITEM or in a player script.

This will allow you to create instances without needing a client, but if there is one and there are errors, the messages will be sent to the client.