### PR TITLE
[Bug Fix] Use macro to generate correct format specifier

### DIFF
--- a/common/strings_legacy.cpp
+++ b/common/strings_legacy.cpp
@@ -3,6 +3,7 @@
 #include <fmt/format.h>
 #include <algorithm>
 #include <cctype>
+#include <cinttypes>
 
 #ifdef _WINDOWS
 #include <windows.h>
@@ -243,7 +244,7 @@ char *RemoveApostrophes(const char *s)
 
 const char *ConvertArray(int64 input, char *returnchar)
 {
-	sprintf(returnchar, "%lld", input);
+	sprintf(returnchar, "%" PRId64, input);
 	return returnchar;
 }
 


### PR DESCRIPTION
Windows and Linux use different data models on 64 bit systems so "%lld"
isn't the same on them.