### PR TITLE
[Bug Fix] Avoid erase in discord queue range loop

### DIFF
--- a/common/discord_manager.cpp
+++ b/common/discord_manager.cpp
@@ -63,8 +63,7 @@ void DiscordManager::ProcessMessageQueue()
 				webhook.webhook_url
 			);
 		}
-
-		webhook_message_queue.erase(q.first);
 	}
+	webhook_message_queue.clear();
 	webhook_queue_lock.unlock();
 }


### PR DESCRIPTION
Erasing from the map inside the range loop invalidated the iterator used
internally by the loop. This caused ucs access violations under msvc
debug builds when a discord logging category was enabled.