### PR TITLE
[NPC Scaling] Recalculate Skills and Reload Spells on Level Change

### DIFF
--- a/zone/lua_npc.cpp
+++ b/zone/lua_npc.cpp
@@ -675,6 +675,12 @@ bool Lua_NPC::IsRareSpawn()
 	return self->IsRareSpawn();
 }
 
+void Lua_NPC::ReloadSpells()
+{
+	Lua_Safe_Call_Void();
+	self->ReloadSpells();
+}
+
 luabind::scope lua_register_npc() {
 	return luabind::class_<Lua_NPC, Lua_Mob>("NPC")
 	.def(luabind::constructor<>())
@@ -769,6 +775,7 @@ luabind::scope lua_register_npc() {
 	.def("PauseWandering", (void(Lua_NPC::*)(int))&Lua_NPC::PauseWandering)
 	.def("PickPocket", (void(Lua_NPC::*)(Lua_Client))&Lua_NPC::PickPocket)
 	.def("RecalculateSkills", (void(Lua_NPC::*)(void))&Lua_NPC::RecalculateSkills)
+	.def("ReloadSpells", (void(Lua_NPC::*)(void))&Lua_NPC::ReloadSpells)
 	.def("RemoveAISpell", (void(Lua_NPC::*)(int))&Lua_NPC::RemoveAISpell)
 	.def("RemoveAISpellEffect", (void(Lua_NPC::*)(int))&Lua_NPC::RemoveAISpellEffect)
 	.def("RemoveCash", (void(Lua_NPC::*)(void))&Lua_NPC::RemoveCash)

--- a/zone/lua_npc.h
+++ b/zone/lua_npc.h
@@ -140,6 +140,7 @@ public:
 	void SetSimpleRoamBox(float box_size, float move_distance);
 	void SetSimpleRoamBox(float box_size, float move_distance, int move_delay);
 	void RecalculateSkills();
+	void ReloadSpells();
 	void ScaleNPC(uint8 npc_level);
 	bool IsRaidTarget();
 	bool IsRareSpawn();

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -3642,9 +3642,15 @@ void NPC::RecalculateSkills()
 	}
 }
 
+void NPC::ReloadSpells() {
+	AI_AddNPCSpells(GetNPCSpellsID());
+}
+
 void NPC::ScaleNPC(uint8 npc_level) {
 	if (GetLevel() != npc_level) {
 		SetLevel(npc_level);
+		RecalculateSkills();
+		ReloadSpells();
 	}
 	npc_scale_manager->ResetNPCScaling(this);
 	npc_scale_manager->ScaleNPC(this);

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -3644,6 +3644,7 @@ void NPC::RecalculateSkills()
 
 void NPC::ReloadSpells() {
 	AI_AddNPCSpells(GetNPCSpellsID());
+	AI_AddNPCSpellsEffects(GetNPCSpellsEffectsID());
 }
 
 void NPC::ScaleNPC(uint8 npc_level) {
@@ -3652,6 +3653,7 @@ void NPC::ScaleNPC(uint8 npc_level) {
 		RecalculateSkills();
 		ReloadSpells();
 	}
+
 	npc_scale_manager->ResetNPCScaling(this);
 	npc_scale_manager->ScaleNPC(this);
 }

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -541,6 +541,7 @@ public:
 	void ScaleNPC(uint8 npc_level);
 
 	void RecalculateSkills();
+	void ReloadSpells();
 
 	static LootDropEntries_Struct NewLootDropEntry();
 protected:

--- a/zone/perl_npc.cpp
+++ b/zone/perl_npc.cpp
@@ -665,6 +665,11 @@ bool Perl_NPC_IsRareSpawn(NPC* self)
 	return self->IsRareSpawn();
 }
 
+void Perl_NPC_ReloadSpells(NPC* self)
+{
+	self->ReloadSpells();
+}
+
 void perl_register_npc()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -765,6 +770,7 @@ void perl_register_npc()
 	package.add("PauseWandering", &Perl_NPC_PauseWandering);
 	package.add("PickPocket", &Perl_NPC_PickPocket);
 	package.add("RecalculateSkills", &Perl_NPC_RecalculateSkills);
+	package.add("ReloadSpells", &Perl_NPC_ReloadSpells);
 	package.add("RemoveAISpell", &Perl_NPC_RemoveSpellFromNPCList);
 	package.add("RemoveAISpellEffect", &Perl_NPC_RemoveAISpellEffect);
 	package.add("RemoveCash", &Perl_NPC_RemoveCash);


### PR DESCRIPTION
- Add $npc->ReloadSpells() to Perl.
- Add npc:ReloadSpells() to Lua.

Example of using ScaleNPC method with various levels on an NPC with spells.

**Level 62 Rytan**
![image](https://user-images.githubusercontent.com/89047260/188277883-e0c4d582-53f7-401c-9579-4c0f3a70e184.png)
**Level 20 Rytan**
![image](https://user-images.githubusercontent.com/89047260/188277896-aadb2682-5c0d-470c-aa5b-da2688a741c7.png)
**Level 1 Rytan**
![image](https://user-images.githubusercontent.com/89047260/188277929-6f7039aa-9c9d-4a5e-87b5-8af1c47b9086.png)

Previously, you would you have to manually call RecalculateSkills() after you scale the NPC, now the call is built in to the scaling.

Spells did not reload when NPCs were scaled, causing them to continue to use their low/high level spells depending upon which way their level had been scaled, this has been adding to the scaling method. This will make NPCs properly use their level-based spells.

RecalculateSkills() and ReloadSpells() can still be used manually if people scale using something other than the source scaling method. Having this functionality built in to the scaling itself just makes more sense to me. Open to any  ideas or thoughts.