### PR TITLE
[Tasks] Make Task Selector Cooldown Optional

### DIFF
--- a/zone/client.h
+++ b/zone/client.h
@@ -1166,27 +1166,16 @@ public:
 	{
 		if (task_state) { task_state->UpdateTasksOnTouch(this, dz_switch_id); }
 	}
-	inline void TaskSetSelector(Mob *mob, int task_set_id)
+	inline void TaskSetSelector(Mob* mob, int task_set_id, bool ignore_cooldown)
 	{
-		if (task_manager) {
-			task_manager->TaskSetSelector(
-				this,
-				task_state,
-				mob,
-				task_set_id
-			);
+		if (task_manager && task_state) {
+			task_manager->TaskSetSelector(this, mob, task_set_id, ignore_cooldown);
 		}
 	}
-	inline void TaskQuestSetSelector(Mob *mob, int count, int *tasks)
+	inline void TaskQuestSetSelector(Mob* mob, const std::vector<int>& tasks, bool ignore_cooldown)
 	{
-		if (task_manager) {
-			task_manager->TaskQuestSetSelector(
-				this,
-				task_state,
-				mob,
-				count,
-				tasks
-			);
+		if (task_manager && task_state) {
+			task_manager->TaskQuestSetSelector(this, mob, tasks, ignore_cooldown);
 		}
 	}
 	inline void EnableTask(int task_count, int *task_list)

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -1088,17 +1088,32 @@ void Perl__taskselector(perl::array task_ids)
 		throw std::runtime_error(fmt::format("Exceeded max number of task offers [{}]", MAXCHOOSERENTRIES));
 	}
 
-	int tasks[MAXCHOOSERENTRIES];
+	std::vector<int> tasks;
 	for (int i = 0; i < task_ids.size(); ++i)
 	{
-		tasks[i] = task_ids[i];
+		tasks.push_back(task_ids[i]);
 	}
-	quest_manager.taskselector(static_cast<int>(task_ids.size()), tasks);
+	quest_manager.taskselector(tasks);
+}
+
+void Perl__taskselector_nocooldown(perl::array task_ids)
+{
+	std::vector<int> tasks;
+	for (int i = 0; i < task_ids.size() && i < MAXCHOOSERENTRIES; ++i)
+	{
+		tasks.push_back(task_ids[i]);
+	}
+	quest_manager.taskselector(tasks, true);
 }
 
 void Perl__task_setselector(int task_set_id)
 {
 	quest_manager.tasksetselector(task_set_id);
+}
+
+void Perl__task_setselector(int task_set_id, bool ignore_cooldown)
+{
+	quest_manager.tasksetselector(task_set_id, ignore_cooldown);
 }
 
 void Perl__enabletask(perl::array task_ids)
@@ -4240,7 +4255,9 @@ void perl_register_quest()
 	package.add("surname", &Perl__surname);
 	package.add("targlobal", &Perl__targlobal);
 	package.add("taskselector", &Perl__taskselector);
-	package.add("task_setselector", &Perl__task_setselector);
+	package.add("taskselector_nocooldown", &Perl__taskselector_nocooldown);
+	package.add("task_setselector", (void(*)(int))&Perl__task_setselector);
+	package.add("task_setselector", (void(*)(int, bool))&Perl__task_setselector);
 	package.add("tasktimeleft", &Perl__tasktimeleft);
 	package.add("toggle_spawn_event", &Perl__toggle_spawn_event);
 	package.add("toggledoorstate", &Perl__toggledoorstate);

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -2512,32 +2512,25 @@ int Lua_Client::GetSpellDamage() {
 }
 
 void Lua_Client::TaskSelector(luabind::adl::object table) {
+	TaskSelector(table, false);
+}
+
+void Lua_Client::TaskSelector(luabind::adl::object table, bool ignore_cooldown) {
 	Lua_Safe_Call_Void();
 
 	if(luabind::type(table) != LUA_TTABLE) {
 		return;
 	}
 
-	int tasks[MAXCHOOSERENTRIES] = { 0 };
-	int task_count = 0;
-
+	std::vector<int> tasks;
 	for(int i = 1; i <= MAXCHOOSERENTRIES; ++i) {
 		auto cur = table[i];
-		int cur_value = 0;
-		if(luabind::type(cur) != LUA_TNIL) {
-			try {
-				cur_value = luabind::object_cast<int>(cur);
-			} catch(luabind::cast_failed &) {
-			}
-		} else {
-			task_count = i - 1;
-			break;
+		if (luabind::type(cur) == LUA_TNUMBER) {
+			tasks.push_back(luabind::object_cast<int>(cur));
 		}
-
-		tasks[i - 1] = cur_value;
 	}
 
-	self->TaskQuestSetSelector(self, task_count, tasks);
+	self->TaskQuestSetSelector(self, tasks, ignore_cooldown);
 }
 
 bool Lua_Client::TeleportToPlayerByCharID(uint32 character_id) {
@@ -2983,6 +2976,7 @@ luabind::scope lua_register_client() {
 	.def("TakePlatinum", (bool(Lua_Client::*)(uint32))&Lua_Client::TakePlatinum)
 	.def("TakePlatinum", (bool(Lua_Client::*)(uint32,bool))&Lua_Client::TakePlatinum)
 	.def("TaskSelector", (void(Lua_Client::*)(luabind::adl::object))&Lua_Client::TaskSelector)
+	.def("TaskSelector", (void(Lua_Client::*)(luabind::adl::object, bool))&Lua_Client::TaskSelector)
 	.def("TeleportToPlayerByCharID", (bool(Lua_Client::*)(uint32))&Lua_Client::TeleportToPlayerByCharID)
 	.def("TeleportToPlayerByName", (bool(Lua_Client::*)(std::string))&Lua_Client::TeleportToPlayerByName)
 	.def("TeleportGroupToPlayerByCharID", (bool(Lua_Client::*)(uint32))&Lua_Client::TeleportGroupToPlayerByCharID)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -437,6 +437,7 @@ public:
 	void SetPrimaryWeaponOrnamentation(uint32 model_id);
 	void SetSecondaryWeaponOrnamentation(uint32 model_id);
 	void TaskSelector(luabind::adl::object table);
+	void TaskSelector(luabind::adl::object table, bool ignore_cooldown);
 
 	void SetClientMaxLevel(uint8 max_level);
 	uint8 GetClientMaxLevel();

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -597,28 +597,33 @@ bool lua_bury_player_corpse(uint32 char_id) {
 	return quest_manager.buryplayercorpse(char_id);
 }
 
-void lua_task_selector(luabind::adl::object table) {
+void lua_task_selector(luabind::adl::object table, bool ignore_cooldown) {
 	if(luabind::type(table) != LUA_TTABLE) {
 		return;
 	}
 
-	int tasks[MAXCHOOSERENTRIES] = { 0 };
-	int count = 0;
-
+	std::vector<int> tasks;
 	for (int i = 1; i <= MAXCHOOSERENTRIES; ++i)
 	{
 		if (luabind::type(table[i]) == LUA_TNUMBER)
 		{
-			tasks[i - 1] = luabind::object_cast<int>(table[i]);
-			++count;
+			tasks.push_back(luabind::object_cast<int>(table[i]));
 		}
 	}
 
-	quest_manager.taskselector(count, tasks);
+	quest_manager.taskselector(tasks, ignore_cooldown);
+}
+
+void lua_task_selector(luabind::adl::object table) {
+	lua_task_selector(table, false);
 }
 
 void lua_task_set_selector(int task_set) {
 	quest_manager.tasksetselector(task_set);
+}
+
+void lua_task_set_selector(int task_set, bool ignore_cooldown) {
+	quest_manager.tasksetselector(task_set, ignore_cooldown);
 }
 
 void lua_enable_task(luabind::adl::object table) {
@@ -3703,8 +3708,10 @@ luabind::scope lua_register_general() {
 		luabind::def("get_player_corpse_count_by_zone_id", &lua_get_player_corpse_count_by_zone_id),
 		luabind::def("get_player_buried_corpse_count", &lua_get_player_buried_corpse_count),
 		luabind::def("bury_player_corpse", &lua_bury_player_corpse),
-		luabind::def("task_selector", &lua_task_selector),
-		luabind::def("task_set_selector", &lua_task_set_selector),
+		luabind::def("task_selector", (void(*)(luabind::adl::object))&lua_task_selector),
+		luabind::def("task_selector", (void(*)(luabind::adl::object, bool))&lua_task_selector),
+		luabind::def("task_set_selector", (void(*)(int))&lua_task_set_selector),
+		luabind::def("task_set_selector", (void(*)(int, bool))&lua_task_set_selector),
 		luabind::def("enable_task", &lua_enable_task),
 		luabind::def("disable_task", &lua_disable_task),
 		luabind::def("is_task_enabled", &lua_is_task_enabled),

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -2407,16 +2407,24 @@ int Perl_Client_GetSpellDamage(Client* self)
 
 void Perl_Client_TaskSelector(Client* self, perl::array task_ids)
 {
-	int tasks[MAXCHOOSERENTRIES] = { 0 };
-	int task_count = 0;
-
+	std::vector<int> tasks;
 	for (int i = 0; i < task_ids.size() && i < MAXCHOOSERENTRIES; ++i)
 	{
-		tasks[i] = task_ids[i];
-		++task_count;
+		tasks.push_back(task_ids[i]);
 	}
 
-	self->TaskQuestSetSelector(self, task_count, tasks);
+	self->TaskQuestSetSelector(self, tasks, false);
+}
+
+void Perl_Client_TaskSelectorNoCooldown(Client* self, perl::array task_ids)
+{
+	std::vector<int> tasks;
+	for (int i = 0; i < task_ids.size() && i < MAXCHOOSERENTRIES; ++i)
+	{
+		tasks.push_back(task_ids[i]);
+	}
+
+	self->TaskQuestSetSelector(self, tasks, true);
 }
 
 bool Perl_Client_TeleportToPlayerByCharacterID(Client* self, uint32 character_id)
@@ -2872,6 +2880,7 @@ void perl_register_client()
 	package.add("TeleportRaidToPlayerByCharID", &Perl_Client_TeleportRaidToPlayerByCharacterID);
 	package.add("TeleportRaidToPlayerByName", &Perl_Client_TeleportRaidToPlayerByName);
 	package.add("TaskSelector", &Perl_Client_TaskSelector);
+	package.add("TaskSelectorNoCooldown", &Perl_Client_TaskSelectorNoCooldown);
 	package.add("Thirsty", &Perl_Client_Thirsty);
 	package.add("TrainDiscBySpellID", &Perl_Client_TrainDiscBySpellID);
 	package.add("UnFreeze", &Perl_Client_UnFreeze);

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -2294,10 +2294,10 @@ bool QuestManager::createBot(const char *name, const char *lastname, uint8 level
 
 #endif //BOTS
 
-void QuestManager::taskselector(int taskcount, int *tasks) {
+void QuestManager::taskselector(const std::vector<int>& tasks, bool ignore_cooldown) {
 	QuestManagerCurrentQuestVars();
 	if(RuleB(TaskSystem, EnableTaskSystem) && initiator && owner && task_manager)
-		initiator->TaskQuestSetSelector(owner, taskcount, tasks);
+		initiator->TaskQuestSetSelector(owner, tasks, ignore_cooldown);
 }
 void QuestManager::enabletask(int taskcount, int *tasks) {
 	QuestManagerCurrentQuestVars();
@@ -2322,11 +2322,11 @@ bool QuestManager::istaskenabled(int taskid) {
 	return false;
 }
 
-void QuestManager::tasksetselector(int tasksetid) {
+void QuestManager::tasksetselector(int tasksetid, bool ignore_cooldown) {
 	QuestManagerCurrentQuestVars();
 	Log(Logs::General, Logs::Tasks, "[UPDATE] TaskSetSelector called for task set %i", tasksetid);
 	if(RuleB(TaskSystem, EnableTaskSystem) && initiator && owner && task_manager)
-		initiator->TaskSetSelector(owner, tasksetid);
+		initiator->TaskSetSelector(owner, tasksetid, ignore_cooldown);
 }
 
 bool QuestManager::istaskactive(int task) {

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -210,8 +210,8 @@ public:
 	void playerfeature(char *feature, int setting);
 	void npcfeature(char *feature, int setting);
 	void popup(const char *title, const char *text, uint32 popupid, uint32 buttons, uint32 Duration);
-	void taskselector(int taskcount, int *tasks);
-	void tasksetselector(int tasksettid);
+	void taskselector(const std::vector<int>& tasks, bool ignore_cooldown = false);
+	void tasksetselector(int tasksettid, bool ignore_cooldown = false);
 	void enabletask(int taskcount, int *tasks);
 	void disabletask(int taskcount, int *tasks);
 	bool istaskenabled(int taskid);

--- a/zone/task_manager.h
+++ b/zone/task_manager.h
@@ -24,20 +24,14 @@ public:
 	bool LoadTaskSets();
 	bool LoadClientState(Client *client, ClientTaskState *client_task_state);
 	bool SaveClientState(Client *client, ClientTaskState *client_task_state);
-	void SendTaskSelector(Client *client, Mob *mob, int task_count, int *task_list);
+	void SendTaskSelector(Client* client, Mob* mob, const std::vector<int>& tasks);
 	bool ValidateLevel(int task_id, int player_level);
 	std::string GetTaskName(uint32 task_id);
 	TaskType GetTaskType(uint32 task_id);
-	void TaskSetSelector(Client *client, ClientTaskState *client_task_state, Mob *mob, int task_set_id);
+	void TaskSetSelector(Client* client, Mob* mob, int task_set_id, bool ignore_cooldown);
 	// task list provided by QuestManager (perl/lua)
-	void TaskQuestSetSelector(
-		Client *client,
-		ClientTaskState *client_task_state,
-		Mob *mob,
-		int count,
-		int *tasks
-	);
-	void SharedTaskSelector(Client* client, Mob* mob, int count, const int* tasks);
+	void TaskQuestSetSelector(Client* client, Mob* mob, const std::vector<int>& tasks, bool ignore_cooldown);
+	void SharedTaskSelector(Client* client, Mob* mob, const std::vector<int>& tasks, bool ignore_cooldown);
 	void SendActiveTasksToClient(Client *client, bool task_complete = false);
 	void SendSingleActiveTaskToClient(
 		Client *client,
@@ -92,7 +86,7 @@ private:
 	// shared tasks
 	void SyncClientSharedTaskWithPersistedState(Client *c, ClientTaskState *cts);
 	void SyncClientSharedTaskRemoveLocalIfNotExists(Client *c, ClientTaskState *cts);
-	void SendSharedTaskSelector(Client* client, Mob* mob, int task_count, int* task_list);
+	void SendSharedTaskSelector(Client* client, Mob* mob, const std::vector<int>& tasks);
 	void SyncClientSharedTaskStateToLocal(Client *c);
 };
 


### PR DESCRIPTION
Some live npcs ignore the request cooldown timer (tutorialb)

A separate function had to be used for perl because the apis use an
array instead of array reference which won't allow a bool overload

This also replaces the fixed array and count args with a vector