### PR TITLE
[Tasks] Only allow shared task completion once

### DIFF
--- a/world/shared_task_manager.cpp
+++ b/world/shared_task_manager.cpp
@@ -1724,6 +1724,12 @@ bool SharedTaskManager::HandleCompletedActivities(SharedTask* s)
 void SharedTaskManager::HandleCompletedTask(SharedTask* s)
 {
 	auto db_task = s->GetDbSharedTask();
+	if (db_task.completion_time > 0)
+	{
+		LogTasksDetail("[HandleCompletedTask] shared task [{}] already completed", db_task.id);
+		return;
+	}
+
 	LogTasksDetail("[HandleCompletedTask] Marking shared task [{}] completed", db_task.id);
 	db_task.completion_time = std::time(nullptr);
 	db_task.is_locked = true;


### PR DESCRIPTION
This prevents re-triggering completion when a shared task contains
optional elements