### PR TITLE
[Feature] AA Cap Limit

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -685,7 +685,7 @@ RULE_REAL(AA, ModernAAScalingStartPercent, 1000, "1000% or 10x AA experience at 
 RULE_INT(AA, ModernAAScalingAAMinimum, 0, "The minimum number of earned AA before AA experience scaling begins")
 RULE_INT(AA, ModernAAScalingAALimit, 4000, "The number of earned AA when AA experience scaling ends")
 RULE_BOOL(AA, SoundForAAEarned, false, "Play sound when AA point earned")
-RULE_INT(AA, UnusedAAPointCap, 30, "Cap for Unused AA Points.  Default: 30.  NOTE: DO NOT LOWER THIS WITHOUT KNOWING WHAT YOU ARE DOING. MAY RESULT IN PLAYERS LOSING AAs.")
+RULE_INT(AA, UnusedAAPointCap, -1, "Cap for Unused AA Points.  Default: -1.  NOTE: DO NOT LOWER THIS WITHOUT KNOWING WHAT YOU ARE DOING. MAY RESULT IN PLAYERS LOSING AAs.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Console)

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -685,6 +685,7 @@ RULE_REAL(AA, ModernAAScalingStartPercent, 1000, "1000% or 10x AA experience at 
 RULE_INT(AA, ModernAAScalingAAMinimum, 0, "The minimum number of earned AA before AA experience scaling begins")
 RULE_INT(AA, ModernAAScalingAALimit, 4000, "The number of earned AA when AA experience scaling ends")
 RULE_BOOL(AA, SoundForAAEarned, false, "Play sound when AA point earned")
+RULE_INT(AA, UnusedAAPointCap, 30, "Cap for Unused AA Points.  Default: 30.  NOTE: DO NOT LOWER THIS WITHOUT KNOWING WHAT YOU ARE DOING. MAY RESULT IN PLAYERS LOSING AAs.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Console)

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -505,7 +505,7 @@ void Client::AddEXP(uint32 in_add_exp, uint8 conlevel, bool resexp) {
 	uint32 exp = 0;
 	uint32 aaexp = 0;
 
-	if (m_epp.perAA<0 || m_epp.perAA>100) {
+	if (m_epp.perAA < 0 || m_epp.perAA > 100) {
 		m_epp.perAA = 0;    // stop exploit with sanity check
 	}
 
@@ -546,7 +546,7 @@ void Client::AddEXP(uint32 in_add_exp, uint8 conlevel, bool resexp) {
 	// Doing this here means potentially one kill wasted worth of experience, but easiest to put it here than to rewrite this function.
 	int aa_cap = RuleI(AA, UnusedAAPointCap);
 
-	if (aa_cap > 0 && aaexp > 0) {
+	if (aa_cap >= 0 && aaexp > 0) {
 		if (m_pp.aapoints == aa_cap) {
 			MessageString(Chat::Red, AA_CAP);
 			aaexp = 0;

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -544,14 +544,18 @@ void Client::AddEXP(uint32 in_add_exp, uint8 conlevel, bool resexp) {
 
 	// Check for Unused AA Cap.  If at or above cap, set AAs to cap, set aaexp to 0 and set aa percentage to 0.
 	// Doing this here means potentially one kill wasted worth of experience, but easiest to put it here than to rewrite this function.
-	if (aaexp > 0) {
-		int aa_cap = RuleI(AA, UnusedAAPointCap);
+	int aa_cap = RuleI(AA, UnusedAAPointCap);
+
+	if (aa_cap > 0 && aaexp > 0) {
+		char val1[20] = {0};
+		char val2[20] = {0};
+		
 		if (m_pp.aapoints == aa_cap) {
 			MessageString(Chat::Red, AA_CAP);
 			aaexp = 0;
 			m_epp.perAA = 0;
 		} else if (m_pp.aapoints > aa_cap) {
-			MessageString(Chat::Red, OVER_AA_CAP);
+			MessageString(Chat::Red, OVER_AA_CAP, ConvertArray(aa_cap, val1), ConvertArray(aa_cap, val2));
 			m_pp.aapoints = aa_cap;
 			aaexp = 0;
 			m_epp.perAA = 0;

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -505,8 +505,9 @@ void Client::AddEXP(uint32 in_add_exp, uint8 conlevel, bool resexp) {
 	uint32 exp = 0;
 	uint32 aaexp = 0;
 
-	if (m_epp.perAA<0 || m_epp.perAA>100)
-		m_epp.perAA=0;	// stop exploit with sanity check
+	if (m_epp.perAA<0 || m_epp.perAA>100) {
+		m_epp.perAA = 0;    // stop exploit with sanity check
+	}
 
 	// Calculate regular XP
 	CalculateExp(in_add_exp, exp, aaexp, conlevel, resexp);
@@ -539,6 +540,22 @@ void Client::AddEXP(uint32 in_add_exp, uint8 conlevel, bool resexp) {
 	if (aaexp < had_aaexp)
 	{
 		aaexp = had_aaexp;	//watch for wrap
+	}
+
+	// Check for Unused AA Cap.  If at or above cap, set AAs to cap, set aaexp to 0 and set aa percentage to 0.
+	// Doing this here means potentially one kill wasted worth of experience, but easiest to put it here than to rewrite this function.
+	if (aaexp > 0) {
+		int aa_cap = RuleI(AA, UnusedAAPointCap);
+		if (m_pp.aapoints == aa_cap) {
+			MessageString(Chat::Red, AA_CAP);
+			aaexp = 0;
+			m_epp.perAA = 0;
+		} else if (m_pp.aapoints > aa_cap) {
+			MessageString(Chat::Red, OVER_AA_CAP);
+			m_pp.aapoints = aa_cap;
+			aaexp = 0;
+			m_epp.perAA = 0;
+		}
 	}
 
 	// AA Sanity Checking for players who set aa exp and deleveled below allowed aa level.

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -547,15 +547,12 @@ void Client::AddEXP(uint32 in_add_exp, uint8 conlevel, bool resexp) {
 	int aa_cap = RuleI(AA, UnusedAAPointCap);
 
 	if (aa_cap > 0 && aaexp > 0) {
-		char val1[20] = {0};
-		char val2[20] = {0};
-		
 		if (m_pp.aapoints == aa_cap) {
 			MessageString(Chat::Red, AA_CAP);
 			aaexp = 0;
 			m_epp.perAA = 0;
 		} else if (m_pp.aapoints > aa_cap) {
-			MessageString(Chat::Red, OVER_AA_CAP, ConvertArray(aa_cap, val1), ConvertArray(aa_cap, val2));
+			MessageString(Chat::Red, OVER_AA_CAP, fmt::format_int(aa_cap).c_str(), fmt::format_int(aa_cap).c_str());
 			m_pp.aapoints = aa_cap;
 			aaexp = 0;
 			m_epp.perAA = 0;

--- a/zone/string_ids.h
+++ b/zone/string_ids.h
@@ -181,7 +181,7 @@
 #define PET_SPELLHOLD_SET_ON		702		//The pet spellhold mode has been set to on.
 #define PET_SPELLHOLD_SET_OFF		703		//The pet spellhold mode has been set to off.
 #define GUILD_NAME_IN_USE			711		//You cannot create a guild with that name, that guild already exists on this server.
-#define AA_CAP                      1000    //You have reached the AA point cap, and cannot gain any further experience until some of your stored AA point pool is used.
+#define AA_CAP						1000	//You have reached the AA point cap, and cannot gain any further experience until some of your stored AA point pool is used.
 #define GM_GAINXP					1002	//[GM] You have gained %1 AXP and %2 EXP (%3).
 #define MALE_SLAYUNDEAD				1007	//%1's holy blade cleanses his target!(%2)
 #define FEMALE_SLAYUNDEAD			1008	//%1's holy blade cleanses her target!(%2)
@@ -296,7 +296,7 @@
 #define ALREADY_SHIELDING			3280	//Either you or your target is already shielding another.
 #define START_SHIELDING				3281	//%1 begins to use %2 as a living shield!
 #define END_SHIELDING				3282	//%1 ceases protecting %2.
-#define OVER_AA_CAP                 3374    //Warning: You are currently over the earned Advancement point limit of %1. Please spend some of your stored AA points. The NEXT time you zone all of your AA points over %2 will be deleted. You MUST spend the extra points now.
+#define OVER_AA_CAP					3374	//Warning: You are currently over the earned Advancement point limit of %1. Please spend some of your stored AA points. The NEXT time you zone all of your AA points over %2 will be deleted. You MUST spend the extra points now.
 #define TRADESKILL_MISSING_ITEM		3455	//You are missing a %1.
 #define TRADESKILL_MISSING_COMPONENTS	3456	//Sorry, but you don't have everything you need for this recipe in your general inventory.
 #define TRADESKILL_LEARN_RECIPE		3457	//You have learned the recipe %1!

--- a/zone/string_ids.h
+++ b/zone/string_ids.h
@@ -181,6 +181,7 @@
 #define PET_SPELLHOLD_SET_ON		702		//The pet spellhold mode has been set to on.
 #define PET_SPELLHOLD_SET_OFF		703		//The pet spellhold mode has been set to off.
 #define GUILD_NAME_IN_USE			711		//You cannot create a guild with that name, that guild already exists on this server.
+#define AA_CAP                      1000    //You have reached the AA point cap, and cannot gain any further experience until some of your stored AA point pool is used.
 #define GM_GAINXP					1002	//[GM] You have gained %1 AXP and %2 EXP (%3).
 #define MALE_SLAYUNDEAD				1007	//%1's holy blade cleanses his target!(%2)
 #define FEMALE_SLAYUNDEAD			1008	//%1's holy blade cleanses her target!(%2)
@@ -295,6 +296,7 @@
 #define ALREADY_SHIELDING			3280	//Either you or your target is already shielding another.
 #define START_SHIELDING				3281	//%1 begins to use %2 as a living shield!
 #define END_SHIELDING				3282	//%1 ceases protecting %2.
+#define OVER_AA_CAP                 3374    //Warning: You are currently over the earned Advancement point limit of %1. Please spend some of your stored AA points. The NEXT time you zone all of your AA points over %2 will be deleted. You MUST spend the extra points now.
 #define TRADESKILL_MISSING_ITEM		3455	//You are missing a %1.
 #define TRADESKILL_MISSING_COMPONENTS	3456	//Sorry, but you don't have everything you need for this recipe in your general inventory.
 #define TRADESKILL_LEARN_RECIPE		3457	//You have learned the recipe %1!


### PR DESCRIPTION
Will force unused AA points to the cap if they exceed the cap. Will also force AA Percentage to 0%. NOTE: The variable, UnusedAAPointCap, should NOT be lowered once implemented without first checking the DB for how many Unused AAs people have.  The next time they gain any EXP, it WILL drop them to cap.  Also, PCs should be given warning prior to this patch going to Live, to ensure they have a chance to spend any AAs above the cap, else they will lose them.