### PR TITLE
[Zoning] Possible zoning under world fix

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -918,6 +918,10 @@ void Client::CompleteConnect()
 		GoToSafeCoords(ZoneID("arena"), 0);
 		return;
 	}
+
+	// force resending of position when finally complete
+	// in hopes to alleviating race condition under-world issues
+	MovePC(zone->GetZoneID(), zone->GetInstanceID(), GetX(), GetY(), GetZ(), GetHeading());
 }
 
 // connecting opcode handlers


### PR DESCRIPTION
Force resending of position after client actually connects since the issue appears to be related to a race condition of packets and the client puts itself under the world, lets bring it back to where it should be (hopefully)

This might need additional investigation but is worth testing on PEQ test server