### PR TITLE
[Tasks] Add rule to update multiple task elements

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -557,6 +557,7 @@ RULE_BOOL(TaskSystem, EnableTaskProximity, true, "Enable task proximity system")
 RULE_INT(TaskSystem, RequestCooldownTimerSeconds, 15, "Seconds between allowing characters to request tasks (live-like default: 15 seconds)")
 RULE_INT(TaskSystem, SharedTasksWorldProcessRate, 6000, "Timer interval (milliseconds) that shared tasks are processed in world")
 RULE_INT(TaskSystem, SharedTasksTerminateTimerMS, 120000, "Delay (milliseconds) until a shared task is terminated if requirements are no longer met after member removal (default: 2 minutes)")
+RULE_BOOL(TaskSystem, UpdateOneElementPerTask, true, "If true (live-like) task updates only increment the first matching activity. If false all matching elements will be incremented.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Range)

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -592,7 +592,11 @@ int ClientTaskState::UpdateTasks(Client* client, const TaskUpdateFilter& filter,
 
 				int updated = IncrementDoneCount(client, task, client_task.slot, client_activity.activity_id, count);
 				max_updated = std::max(max_updated, updated);
-				break; // only one element updated per task, move to next task
+
+				if (RuleB(TaskSystem, UpdateOneElementPerTask))
+				{
+					break; // only one element updated per task, move to next task
+				}
 			}
 		}
 	}


### PR DESCRIPTION
On live if a task update would affect multiple elements, only the first
one gets updated. This was added as part of the changes in 7482cfc0.

Setting `UpdateOneElementPerTask` to false will restore the old behavior
that increments all active elements matching the task update criteria.