### PR TITLE
[Feature] Update HateMod used by SPA 114 to Int32.

### DIFF
--- a/zone/common.h
+++ b/zone/common.h
@@ -413,7 +413,7 @@ struct StatBonuses {
 	uint32	windMod;
 	uint32	stringedMod;
 	uint32	songModCap;
-	int8	hatemod;
+	int32	hatemod;
 	int64	EnduranceReduction;
 
 	int32	StrikeThrough;						// PoP: Strike Through %

--- a/zone/lua_stat_bonuses.cpp
+++ b/zone/lua_stat_bonuses.cpp
@@ -380,7 +380,7 @@ uint32 Lua_StatBonuses::GetsongModCap() const {
 	return self->songModCap;
 }
 
-int8 Lua_StatBonuses::Gethatemod() const {
+int32 Lua_StatBonuses::Gethatemod() const {
 	Lua_Safe_Call_Int();
 	return self->hatemod;
 }

--- a/zone/lua_stat_bonuses.h
+++ b/zone/lua_stat_bonuses.h
@@ -100,7 +100,7 @@ public:
 	uint32 GetwindMod() const;
 	uint32 GetstringedMod() const;
 	uint32 GetsongModCap() const;
-	int8 Gethatemod() const;
+	int32 Gethatemod() const;
 	int64 GetEnduranceReduction() const;
 	int32 GetStrikeThrough() const;
 	int32 GetMeleeMitigation() const;


### PR DESCRIPTION
HateMod was previously Int8, which would cause overflow issues when using newer spells from Live.