### PR TITLE
[Pathing] Fix pathing z-correctness for certain models

### DIFF
--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -146,7 +146,9 @@ NPC::NPC(const NPCType *npc_type_data, Spawn2 *in_respawn, const glm::vec4 &posi
 
 	swarm_timer.Disable();
 
-	if (size <= 0.0f) {
+	// lava dragon is a fixed size model and should always use its default
+	// otherwise pathing issues
+	if (size <= 0.0f || race == RACE_LAVA_DRAGON_49) {
 		size = GetRaceGenderDefaultHeight(race, gender);
 	}
 
@@ -2649,7 +2651,7 @@ void NPC::ModifyNPCStat(const char *identifier, const char *new_value)
 		AI_AddNPCSpellsEffects(atoi(val.c_str()));
 		CalcBonuses();
 		return;
-	} 
+	}
 	else if (id == "heroic_strikethrough") {
 		heroic_strikethrough = atoi(val.c_str());
 		return;

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -146,10 +146,14 @@ NPC::NPC(const NPCType *npc_type_data, Spawn2 *in_respawn, const glm::vec4 &posi
 
 	swarm_timer.Disable();
 
+	if (size <= 0.0f || ) {
+		size = GetRaceGenderDefaultHeight(race, gender);
+	}
+
 	// lava dragon is a fixed size model and should always use its default
 	// otherwise pathing issues
-	if (size <= 0.0f || race == RACE_LAVA_DRAGON_49) {
-		size = GetRaceGenderDefaultHeight(race, gender);
+	if (race == RACE_LAVA_DRAGON_49) {
+		size = 6;
 	}
 
 	taunting       = false;

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -153,7 +153,7 @@ NPC::NPC(const NPCType *npc_type_data, Spawn2 *in_respawn, const glm::vec4 &posi
 	// lava dragon is a fixed size model and should always use its default
 	// otherwise pathing issues
 	if (race == RACE_LAVA_DRAGON_49) {
-		size = 6;
+		size = 5;
 	}
 
 	taunting       = false;

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -146,7 +146,7 @@ NPC::NPC(const NPCType *npc_type_data, Spawn2 *in_respawn, const glm::vec4 &posi
 
 	swarm_timer.Disable();
 
-	if (size <= 0.0f || ) {
+	if (size <= 0.0f) {
 		size = GetRaceGenderDefaultHeight(race, gender);
 	}
 

--- a/zone/waypoints.cpp
+++ b/zone/waypoints.cpp
@@ -878,8 +878,6 @@ float Mob::GetZOffset() const {
 			offset = 1.0f;
 			break;
 		case RACE_DRAGON_438:
-			offset = 0.776f;
-			break;
 		case RACE_DRAGON_452:
 			offset = 0.776f;
 			break;
@@ -889,9 +887,8 @@ float Mob::GetZOffset() const {
 		case RACE_SPIDER_440:
 			offset = 0.938f;
 			break;
+		case RACE_IMP_46:
 		case RACE_SNAKE_468:
-			offset = 1.0f;
-			break;
 		case RACE_CORATHUS_459:
 			offset = 1.0f;
 			break;
@@ -902,8 +899,6 @@ float Mob::GetZOffset() const {
 			offset = 1.2f;
 			break;
 		case RACE_GOO_549:
-			offset = 0.5f;
-			break;
 		case RACE_GOO_548:
 			offset = 0.5f;
 			break;
@@ -920,14 +915,13 @@ float Mob::GetZOffset() const {
 			offset = 4.0f;
 			break;
 		case RACE_ARMOR_OF_MARR_323:
-			offset = 5.0f;
-			break;
 		case RACE_AMYGDALAN_663:
 			offset = 5.0f;
 			break;
 		case RACE_SANDMAN_664:
 			offset = 4.0f;
 			break;
+		case RACE_LAVA_DRAGON_49:
 		case RACE_ALARAN_SENTRY_STONE_703:
 			offset = 9.0f;
 			break;
@@ -937,9 +931,31 @@ float Mob::GetZOffset() const {
 		case RACE_BLIND_DREAMER_669:
 			offset = 7.0f;
 			break;
-		case RACE_GORAL_687:
-			offset = 2.0f;
+		case RACE_SIREN_187:
+		case RACE_HALAS_CITIZEN_90:
+		case RACE_OTTERMAN_190:
+			offset = .5f;
 			break;
+		case RACE_COLDAIN_183:
+			offset = .6f;
+			break;
+		case RACE_WEREWOLF_14:
+			offset = 1.2f;
+			break;
+		case RACE_DWARF_8:
+			offset = .7f;
+			break;
+		case RACE_HORSE_216:
+			offset = 1.4f;
+			break;
+		case RACE_ENCHANTED_ARMOR_175:
+		case RACE_TIGER_63:
+			offset = 1.75f;
+			break;
+		case RACE_STATUE_OF_RALLOS_ZEK_66:
+			offset = 1.0f;
+			break;
+		case RACE_GORAL_687:
 		case RACE_SELYRAH_686:
 			offset = 2.0f;
 			break;


### PR DESCRIPTION
Issue originally reported in #support-pathing (Discord) by Symetrix.

**Reproduction**

Pull Xygoz in Veeshan's Peek up/down steep hill from spawn and he will clip in and out of the floor

![12b2a5043f8869ded889b54c552a5d79](https://user-images.githubusercontent.com/3319450/189514145-ad406417-65a2-4efe-8ac7-dadd401a773e.gif)

**Problem(s)**

1. Xygoz is a fixed race model (5 size is default) but the server data has him set to 1
2. Dragon race 49 is missing proper Z offsets for its model

**Solution(s)**

* Updated GetZOffset to include remaining models from `Resources/SPOffsets.ini`
* Set static race dragon (49) to always be size 5 regardless of what is set in the database

Both of these solutions combined result in a dragon that does not clip through the floor under steep terrain and calculates Z positioning correctly with the server
