### PR TITLE
[Feature] Add Type 49545 to Spell Resistrictions

### DIFF
--- a/common/spdat.h
+++ b/common/spdat.h
@@ -514,6 +514,7 @@ enum SpellRestriction
 	IS_SUMMONED_OR_UNDEAD                                                     = 49326, //
 	IS_CLASS_CASTER_PRIEST                                                    = 49529, //
 	IS_END_OR_MANA_ABOVE_20_PCT                                               = 49543, // You must have at least 20% of your maximum mana and endurance to use this ability.	//pure melee class check end, other check mana
+	IS_END_OR_MANA_BELOW_10_PCT                                               = 49545, // 																			//pure melee class check end, other check mana, hybrid check both
 	IS_END_OR_MANA_BELOW_30_PCT                                               = 49573, // Your target already has 30% or more of their maximum mana or endurance.	//pure melee class check the, other check more
 	IS_CLASS_BARD2                                                            = 49574, //
 	IS_NOT_CLASS_BARD                                                         = 49575, //

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -8066,7 +8066,18 @@ bool Mob::PassCastRestriction(int value)
 			}
 			break;
 		}
-
+		case IS_END_OR_MANA_BELOW_10_PCT: {
+			if (IsNonSpellFighterClass(GetClass()) && CastToClient()->GetEndurancePercent() <= 10) {
+				return true;
+			}
+			else if (!IsNonSpellFighterClass(GetClass()) && GetManaRatio() <= 10) {
+				return true;
+			} 
+			else if (IsHybridClass(GetClass()) && CastToClient()->GetEndurancePercent() <= 10) {
+				return true;
+			}
+			break;
+		}
 		case IS_END_OR_MANA_BELOW_30_PCT:
 		case IS_END_OR_MANA_BELOW_30_PCT2: {
 			if (IsNonSpellFighterClass(GetClass()) && CastToClient()->GetEndurancePercent() <= 30) {


### PR DESCRIPTION
Type 49545 - endurance or mana drops below 10%
Used in live spell Reaver's Bargain, doesn't appear to have any corresponding message in live dbstr.