### PR TITLE
[Revert] Placing task rewards in free slots

### DIFF
--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -1008,8 +1008,7 @@ void ClientTaskState::RewardTask(Client *client, const TaskInformation *task_inf
 	switch (task_information->reward_method) {
 		case METHODSINGLEID: {
 			if (task_information->reward_id) {
-				int16_t slot = client->GetInv().FindFreeSlot(false, true);
-				client->SummonItem(task_information->reward_id, -1, 0, 0, 0, 0, 0, 0, false, slot);
+				client->SummonItem(task_information->reward_id);
 				item_data = database.GetItem(task_information->reward_id);
 				if (item_data) {
 					client->MessageString(Chat::Yellow, YOU_HAVE_BEEN_GIVEN, item_data->Name);
@@ -1020,8 +1019,7 @@ void ClientTaskState::RewardTask(Client *client, const TaskInformation *task_inf
 		case METHODLIST: {
 			reward_list = task_manager->m_goal_list_manager.GetListContents(task_information->reward_id);
 			for (int item_id : reward_list) {
-				int16_t slot = client->GetInv().FindFreeSlot(false, true);
-				client->SummonItem(item_id, -1, 0, 0, 0, 0, 0, 0, false, slot);
+				client->SummonItem(item_id);
 				item_data = database.GetItem(item_id);
 				if (item_data) {
 					client->MessageString(Chat::Yellow, YOU_HAVE_BEEN_GIVEN, item_data->Name);


### PR DESCRIPTION
This reverts the changes until an alternative method can be found to properly place rewards in inventory since this doesn't auto stack items

Revert "[Tasks] Let task reward find free bag slots (#2431)"

This reverts commit b4e46c1f7e317f871336e02d91961953d329eaf4.

Revert "[Tasks] Place task item rewards in free slots (#2300)"

This reverts commit f381453dbd857f73b23a69548225912ceb3a49fd.

This will probably need to use something like `AutoPutLootInInventory` or something but I'm not familiar with the inventory api and don't want to look into an alternative right now.
