### PR TITLE
[Crash] Websocket Crash fix race when fetching log categories

### DIFF
--- a/zone/api_service.cpp
+++ b/zone/api_service.cpp
@@ -829,7 +829,7 @@ Json::Value ApiGetZoneAttributes(EQ::Net::WebsocketServerConnection *connection,
 
 Json::Value ApiGetLogsysCategories(EQ::Net::WebsocketServerConnection *connection, Json::Value params)
 {
-	if (zone->GetZoneID() == 0) {
+	if (zone && zone->GetZoneID() == 0) {
 		throw EQ::Net::WebsocketException("Zone must be loaded to invoke this call");
 	}
 

--- a/zone/api_service.cpp
+++ b/zone/api_service.cpp
@@ -829,7 +829,7 @@ Json::Value ApiGetZoneAttributes(EQ::Net::WebsocketServerConnection *connection,
 
 Json::Value ApiGetLogsysCategories(EQ::Net::WebsocketServerConnection *connection, Json::Value params)
 {
-	if (zone && zone->GetZoneID() == 0) {
+	if (!zone || (zone && zone->GetZoneID() == 0)) {
 		throw EQ::Net::WebsocketException("Zone must be loaded to invoke this call");
 	}
 


### PR DESCRIPTION
**Trace**

```
[09-28-2022 20:38:31] [Zone] [Crash] C:\Code\Server\zone\zone.h (173): Zone::GetZoneID 
[09-28-2022 20:38:31] [Zone] [Crash] C:\Code\Server\zone\api_service.cpp (832): ApiGetLogsysCategories 
[09-28-2022 20:38:31] [Zone] [Crash] C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.33.31629\include\type_traits (1558): std::invoke<Json::Value (__cdecl*&)(EQ::Net::WebsocketServerConnection *,Json::Value),EQ::Net::WebsocketServerConnection *,Json::Value const &> 
[09-28-2022 20:38:31] [Zone] [Crash] C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.33.31629\include\functional (670): std::_Invoker_ret<Json::Value>::_Call<Json::Value (__cdecl*&)(EQ::Net::WebsocketServerConnection *,Json::Value),EQ::Net::WebsocketServerConnection *,Json::Value const &> 
[09-28-2022 20:38:31] [Zone] [Crash] C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.33.31629\include\functional (831): std::_Func_impl_no_alloc<Json::Value (__cdecl*)(EQ::Net::WebsocketServerConnection *,Json::Value),Json::Value,EQ::Net::WebsocketServerConnection *,Json::Value const &>::_Do_call 
[09-28-2022 20:38:31] [Zone] [Crash] C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.33.31629\include\functional (878): std::_Func_class<Json::Value,EQ::Net::WebsocketServerConnection *,Json::Value const &>::operator() 
[09-28-2022 20:38:31] [Zone] [Crash] C:\Code\Server\common\net\websocket_server.cpp (119): EQ::Net::WebsocketServer::HandleRequest 
```