### PR TITLE
[Database] Add fallback migration for logsys columns

### DIFF
--- a/common/version.h
+++ b/common/version.h
@@ -34,7 +34,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9208
+#define CURRENT_BINARY_DATABASE_VERSION 9209
 
 #ifdef BOTS
 	#define CURRENT_BINARY_BOTS_DATABASE_VERSION 9029

--- a/utils/sql/db_update_manifest.txt
+++ b/utils/sql/db_update_manifest.txt
@@ -462,6 +462,7 @@
 9206|2022_09_03_fix_door_destination_headings.sql|SELECT * FROM db_version WHERE version >= 9206|empty|
 9207|2022_09_03_fix_zone_point_heading_data.sql|SELECT * FROM db_version WHERE version >= 9207|empty|
 9208|2022_09_25_task_concat_matchlists.sql|SHOW COLUMNS FROM `task_activities` LIKE 'npc_id'|not_empty|
+9209|2022_09_28_discord_webhooks.sql|SHOW COLUMNS FROM `logsys_categories` LIKE 'log_to_discord'|empty|
 
 # Upgrade conditions:
 # 	This won't be needed after this system is implemented, but it is used database that are not

--- a/utils/sql/git/required/2022_09_28_discord_webhooks.sql
+++ b/utils/sql/git/required/2022_09_28_discord_webhooks.sql
@@ -1,0 +1,4 @@
+ALTER TABLE logsys_categories
+    ADD log_to_discord smallint(11) default 0 AFTER log_to_gmsay;
+ALTER TABLE logsys_categories
+    ADD discord_webhook_id int(11) default 0 AFTER log_to_discord;


### PR DESCRIPTION
There's been instances where this has been repeatedly getting missed even though a CREATE and an ALTER runs together in the same file. The CREATE has been running without the ALTER. This is a no-op for folks who have the columns and catches it for those who aren't getting the update in the earlier migration