### PR TITLE
[Logging] Remove loginserver unhandled error

### DIFF
--- a/loginserver/client.cpp
+++ b/loginserver/client.cpp
@@ -77,11 +77,6 @@ bool Client::Process()
 				Handle_Play((const char *) app->pBuffer);
 				break;
 			}
-			default: {
-				char dump[64];
-				app->build_header_dump(dump);
-				LogError("Received unhandled application packet from the client: [{}]", dump);
-			}
 		}
 
 		delete app;


### PR DESCRIPTION
Remove error log that largely confuses people anyways because its not really an error. This is captured in the new Client -> Server logging if the server operator or developer chooses to use it