### PR TITLE
[Crash] Fix reload crashes

### DIFF
--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -1896,20 +1896,26 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 	}
 	case ServerOP_ReloadAAData:
 	{
-		zone->SendReloadMessage("Alternate Advancement Data");
-		zone->LoadAlternateAdvancement();
+		if (zone && zone->IsLoaded()) {
+			zone->SendReloadMessage("Alternate Advancement Data");
+			zone->LoadAlternateAdvancement();
+		}
 		break;
 	}
 	case ServerOP_ReloadAlternateCurrencies:
 	{
-		zone->SendReloadMessage("Alternate Currencies");
-		zone->LoadAlternateCurrencies();
+		if (zone && zone->IsLoaded()) {
+			zone->SendReloadMessage("Alternate Currencies");
+			zone->LoadAlternateCurrencies();
+		}
 		break;
 	}
 	case ServerOP_ReloadBlockedSpells:
 	{
-		zone->SendReloadMessage("Blocked Spells");
-		zone->LoadZoneBlockedSpells();
+		if (zone && zone->IsLoaded()) {
+			zone->SendReloadMessage("Blocked Spells");
+			zone->LoadZoneBlockedSpells();
+		}
 		break;
 	}
 	case ServerOP_ReloadCommands:
@@ -1926,10 +1932,12 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 	}
 	case ServerOP_ReloadDoors:
 	{
-		zone->SendReloadMessage("Doors");
-		entity_list.RemoveAllDoors();
-		zone->LoadZoneDoors();
-		entity_list.RespawnAllDoors();
+		if (zone && zone->IsLoaded()) {
+			zone->SendReloadMessage("Doors");
+			entity_list.RemoveAllDoors();
+			zone->LoadZoneDoors();
+			entity_list.RespawnAllDoors();
+		}
 		break;
 	}
 	case ServerOP_ReloadDzTemplates:
@@ -1943,8 +1951,10 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 	}
 	case ServerOP_ReloadGroundSpawns:
 	{
-		zone->SendReloadMessage("Ground Spawns");
-		zone->LoadGroundSpawns();
+		if (zone && zone->IsLoaded()) {
+			zone->SendReloadMessage("Ground Spawns");
+			zone->LoadGroundSpawns();
+		}
 		break;
 	}
 	case ServerOP_ReloadLevelEXPMods:
@@ -1960,21 +1970,27 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 		break;
 	}
 	case ServerOP_ReloadMerchants: {
-		zone->SendReloadMessage("Merchants");
-		entity_list.ReloadMerchants();
+		if (zone && zone->IsLoaded()) {
+			zone->SendReloadMessage("Merchants");
+			entity_list.ReloadMerchants();
+		}
 		break;
 	}
 	case ServerOP_ReloadNPCEmotes:
 	{
-		zone->SendReloadMessage("NPC Emotes");
-		zone->LoadNPCEmotes(&zone->NPCEmoteList);
+		if (zone && zone->IsLoaded()) {
+			zone->SendReloadMessage("NPC Emotes");
+			zone->LoadNPCEmotes(&zone->NPCEmoteList);
+		}
 		break;
 	}
 	case ServerOP_ReloadObjects:
 	{
-		zone->SendReloadMessage("Objects");
-		entity_list.RemoveAllObjects();
-		zone->LoadZoneObjects();
+		if (zone && zone->IsLoaded()) {
+			zone->SendReloadMessage("Objects");
+			entity_list.RemoveAllObjects();
+			zone->LoadZoneObjects();
+		}
 		break;
 	}
 	case ServerOP_ReloadPerlExportSettings:
@@ -1990,13 +2006,15 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 		break;
 	}
 	case ServerOP_ReloadStaticZoneData: {
-		zone->SendReloadMessage("Static Zone Data");
-		zone->ReloadStaticData();
+		if (zone && zone->IsLoaded()) {
+			zone->SendReloadMessage("Static Zone Data");
+			zone->ReloadStaticData();
+		}
 		break;
 	}
 	case ServerOP_ReloadTasks:
 	{
-		if (RuleB(Tasks, EnableTaskSystem)) {
+		if (RuleB(Tasks, EnableTaskSystem) && zone && zone->IsLoaded()) {
 			zone->SendReloadMessage("Tasks");
 			HandleReloadTasks(pack);
 		}
@@ -2005,26 +2023,35 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 	}
 	case ServerOP_ReloadTitles:
 	{
-		zone->SendReloadMessage("Titles");
-		title_manager.LoadTitles();
+		if (zone && zone->IsLoaded()) {
+			zone->SendReloadMessage("Titles");
+			title_manager.LoadTitles();
+		}
 		break;
 	}
 	case ServerOP_ReloadTraps:
 	{
-		zone->SendReloadMessage("Traps");
-		entity_list.UpdateAllTraps(true, true);
+		if (zone && zone->IsLoaded()) {
+			zone->SendReloadMessage("Traps");
+			entity_list.UpdateAllTraps(true, true);
+		}
+
 		break;
 	}
 	case ServerOP_ReloadVariables:
 	{
-		zone->SendReloadMessage("Variables");
-		database.LoadVariables();
+		if (zone && zone->IsLoaded()) {
+			zone->SendReloadMessage("Variables");
+			database.LoadVariables();
+		}
 		break;
 	}
 	case ServerOP_ReloadVeteranRewards:
 	{
-		zone->SendReloadMessage("Veteran Rewards");
-		zone->LoadVeteranRewards();
+		if (zone && zone->IsLoaded()) {
+			zone->SendReloadMessage("Veteran Rewards");
+			zone->LoadVeteranRewards();
+		}
 		break;
 	}
 	case ServerOP_ReloadWorld:
@@ -2037,15 +2064,19 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 	}
 	case ServerOP_ReloadZonePoints:
 	{
-		zone->SendReloadMessage("Zone Points");
-		content_db.LoadStaticZonePoints(&zone->zone_point_list, zone->GetShortName(), zone->GetInstanceVersion());
+		if (zone && zone->IsLoaded()) {
+			zone->SendReloadMessage("Zone Points");
+			content_db.LoadStaticZonePoints(&zone->zone_point_list, zone->GetShortName(), zone->GetInstanceVersion());
+		}
 		break;
 	}
 	case ServerOP_ReloadZoneData:
 	{
 		zone_store.LoadZones(content_db);
-		zone->LoadZoneCFG(zone->GetShortName(), zone->GetInstanceVersion());
-		zone->SendReloadMessage("Zone Data");
+		if (zone && zone->IsLoaded()) {
+			zone->LoadZoneCFG(zone->GetShortName(), zone->GetInstanceVersion());
+			zone->SendReloadMessage("Zone Data");
+		}
 		break;
 	}
 	case ServerOP_CameraShake:

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -2872,7 +2872,8 @@ std::string Zone::GetZoneDescription()
 	}
 
 	return fmt::format(
-		"{} ({}){}{}",
+		"PID ({}) {} ({}){}{}",
+		EQ::GetPID(),
 		GetLongName(),
 		GetZoneID(),
 		(


### PR DESCRIPTION
**Issue** 

Global reload commands are crashing zone processes that are not booted. While this doesn't affect players, it still is killing all standby processes needlessly every time for several different reload types. Fixed by adding zone checks to most reload commands

**Stack Example (One of them)**

```
[Zone] [Crash] stack trace for /home/eqemu/code/build/bin/zone pid=1684
[Zone] [Crash] [New LWP 1685]
[Zone] [Crash] [New LWP 1686]
[Zone] [Crash] [New LWP 1687]
[Zone] [Crash] [New LWP 1688]
[Zone] [Crash] [Thread debugging using libthread_db enabled]
[Zone] [Crash] Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
[Zone] [Crash] 0x00007fe79fce1207 in __GI___wait4 (pid=1754, stat_loc=0x0, options=0, usage=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:27
[Zone] [Crash] [Current thread is 1 (Thread 0x7fe79fbb1b00 (LWP 1684))]
[Zone] [Crash] #0  0x00007fe79fce1207 in __GI___wait4 (pid=1754, stat_loc=0x0, options=0, usage=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:27
[Zone] [Crash] #1  0x0000562daedd7c64 in print_trace () at ../common/crash.cpp:213
[Zone] [Crash] #2  <signal handler called>
[Zone] [Crash] #3  0x0000562dae09acb0 in Zone::GetInstanceVersion (this=0x0) at ../zone/zone.h:168
[Zone] [Crash] #4  0x0000562daed66746 in Zone::ReloadStaticData (this=0x0) at ../zone/zone.cpp:1250
[Zone] [Crash] #5  0x0000562daed45b53 in WorldServer::HandleMessage (this=0x562daf8b0820 <worldserver>, opcode=16660, p=...) at ../zone/worldserver.cpp:1994
[Zone] [Crash] #6  0x0000562daed58f62 in std::__invoke_impl<void, void (WorldServer::*&)(unsigned short, EQ::Net::Packet const&), WorldServer*&, unsigned short, EQ::Net::Packet&> (__f=@0x562db1602320: (void (WorldServer::*)(WorldServer * const, unsigned short, const EQ::Net::Packet &)) 0x562daed3dcd0 <WorldServer::HandleMessage(unsigned short, EQ::Net::Packet const&)>, __t=@0x562db1602330: 0x562daf8b0820 <worldserver>) at /usr/include/c++/10/bits/invoke.h:73
[Zone] [Crash] #7  0x0000562daed58ceb in std::__invoke<void (WorldServer::*&)(unsigned short, EQ::Net::Packet const&), WorldServer*&, unsigned short, EQ::Net::Packet&> (__fn=@0x562db1602320: (void (WorldServer::*)(WorldServer * const, unsigned short, const EQ::Net::Packet &)) 0x562daed3dcd0 <WorldServer::HandleMessage(unsigned short, EQ::Net::Packet const&)>) at /usr/include/c++/10/bits/invoke.h:95
[Zone] [Crash] #8  0x0000562daed58a96 in std::_Bind<void (WorldServer::*(WorldServer*, std::_Placeholder<1>, std::_Placeholder<2>))(unsigned short, EQ::Net::Packet const&)>::__call<void, unsigned short&&, EQ::Net::Packet&, 0ul, 1ul, 2ul>(std::tuple<unsigned short&&, EQ::Net::Packet&>&&, std::_Index_tuple<0ul, 1ul, 2ul>) (this=0x562db1602320, __args=...) at /usr/include/c++/10/functional:416
[Zone] [Crash] #9  0x0000562daed5873c in std::_Bind<void (WorldServer::*(WorldServer*, std::_Placeholder<1>, std::_Placeholder<2>))(unsigned short, EQ::Net::Packet const&)>::operator()<unsigned short, EQ::Net::Packet&, void>(unsigned short&&, EQ::Net::Packet&) (this=0x562db1602320) at /usr/include/c++/10/functional:499
[Zone] [Crash] #10 0x0000562daed58169 in std::__invoke_impl<void, std::_Bind<void (WorldServer::*(WorldServer*, std::_Placeholder<1>, std::_Placeholder<2>))(unsigned short, EQ::Net::Packet const&)>&, unsigned short, EQ::Net::Packet&>(std::__invoke_other, std::_Bind<void (WorldServer::*(WorldServer*, std::_Placeholder<1>, std::_Placeholder<2>))(unsigned short, EQ::Net::Packet const&)>&, unsigned short&&, EQ::Net::Packet&) (__f=...) at /usr/include/c++/10/bits/invoke.h:60
[Zone] [Crash] #11 0x0000562daed57785 in std::__invoke_r<void, std::_Bind<void (WorldServer::*(WorldServer*, std::_Placeholder<1>, std::_Placeholder<2>))(unsigned short, EQ::Net::Packet const&)>&, unsigned short, EQ::Net::Packet&>(std::_Bind<void (WorldServer::*(WorldServer*, std::_Placeholder<1>, std::_Placeholder<2>))(unsigned short, EQ::Net::Packet const&)>&, unsigned short&&, EQ::Net::Packet&) (__fn=...) at /usr/include/c++/10/bits/invoke.h:110
[Zone] [Crash] #12 0x0000562daed5675d in std::_Function_handler<void (unsigned short, EQ::Net::Packet&), std::_Bind<void (WorldServer::*(WorldServer*, std::_Placeholder<1>, std::_Placeholder<2>))(unsigned short, EQ::Net::Packet const&)> >::_M_invoke(std::_Any_data const&, unsigned short&&, EQ::Net::Packet&) (__functor=..., __args#0=@0x7ffca98455b4: 16660, __args#1=...) at /usr/include/c++/10/bits/std_function.h:291
[Zone] [Crash] #13 0x0000562daef22af9 in std::function<void (unsigned short, EQ::Net::Packet&)>::operator()(unsigned short, EQ::Net::Packet&) const (this=0x562db0c121c8, __args#0=16660, __args#1=...) at /usr/include/c++/10/bits/std_function.h:622
[Zone] [Crash] #14 0x0000562daef210ca in EQ::Net::ServertalkClient::ProcessMessage (this=0x562db0c120f0, p=...) at ../common/net/servertalk_client_connection.cpp:213
[Zone] [Crash] #15 0x0000562daef20ca9 in EQ::Net::ServertalkClient::ProcessReadBuffer (this=0x562db0c120f0) at ../common/net/servertalk_client_connection.cpp:161
[Zone] [Crash] #16 0x0000562daef20913 in EQ::Net::ServertalkClient::ProcessData (this=0x562db0c120f0, c=0x562db160dcb0, data=0x562db1611920 "\a", length=12) at ../common/net/servertalk_client_connection.cpp:93
[Zone] [Crash] #17 0x0000562daef25c17 in std::__invoke_impl<void, void (EQ::Net::ServertalkClient::*&)(EQ::Net::TCPConnection*, unsigned char const*, unsigned long), EQ::Net::ServertalkClient*&, EQ::Net::TCPConnection*, unsigned char const*, unsigned long> (__f=@0x562db160cb00: (void (EQ::Net::ServertalkClient::*)(EQ::Net::ServertalkClient * const, EQ::Net::TCPConnection *, const unsigned char *, unsigned long)) 0x562daef20896 <EQ::Net::ServertalkClient::ProcessData(EQ::Net::TCPConnection*, unsigned char const*, unsigned long)>, __t=@0x562db160cb10: 0x562db0c120f0) at /usr/include/c++/10/bits/invoke.h:73
[Zone] [Crash] #18 0x0000562daef25867 in std::__invoke<void (EQ::Net::ServertalkClient::*&)(EQ::Net::TCPConnection*, unsigned char const*, unsigned long), EQ::Net::ServertalkClient*&, EQ::Net::TCPConnection*, unsigned char const*, unsigned long> (__fn=@0x562db160cb00: (void (EQ::Net::ServertalkClient::*)(EQ::Net::ServertalkClient * const, EQ::Net::TCPConnection *, const unsigned char *, unsigned long)) 0x562daef20896 <EQ::Net::ServertalkClient::ProcessData(EQ::Net::TCPConnection*, unsigned char const*, unsigned long)>) at /usr/include/c++/10/bits/invoke.h:95
[Zone] [Crash] #19 0x0000562daef253cc in std::_Bind<void (EQ::Net::ServertalkClient::*(EQ::Net::ServertalkClient*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>))(EQ::Net::TCPConnection*, unsigned char const*, unsigned long)>::__call<void, EQ::Net::TCPConnection*&&, unsigned char const*&&, unsigned long&&, 0ul, 1ul, 2ul, 3ul>(std::tuple<EQ::Net::TCPConnection*&&, unsigned char const*&&, unsigned long&&>&&, std::_Index_tuple<0ul, 1ul, 2ul, 3ul>) (this=0x562db160cb00, __args=...) at /usr/include/c++/10/functional:416
[Zone] [Crash] #20 0x0000562daef24e13 in std::_Bind<void (EQ::Net::ServertalkClient::*(EQ::Net::ServertalkClient*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>))(EQ::Net::TCPConnection*, unsigned char const*, unsigned long)>::operator()<EQ::Net::TCPConnection*, unsigned char const*, unsigned long, void>(EQ::Net::TCPConnection*&&, unsigned char const*&&, unsigned long&&) (this=0x562db160cb00) at /usr/include/c++/10/functional:499
[Zone] [Crash] #21 0x0000562daef2465b in std::__invoke_impl<void, std::_Bind<void (EQ::Net::ServertalkClient::*(EQ::Net::ServertalkClient*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>))(EQ::Net::TCPConnection*, unsigned char const*, unsigned long)>&, EQ::Net::TCPConnection*, unsigned char const*, unsigned long>(std::__invoke_other, std::_Bind<void (EQ::Net::ServertalkClient::*(EQ::Net::ServertalkClient*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>))(EQ::Net::TCPConnection*, unsigned char const*, unsigned long)>&, EQ::Net::TCPConnection*&&, unsigned char const*&&, unsigned long&&) (__f=...) at /usr/include/c++/10/bits/invoke.h:60
[Zone] [Crash] #22 0x0000562daef23a3f in std::__invoke_r<void, std::_Bind<void (EQ::Net::ServertalkClient::*(EQ::Net::ServertalkClient*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>))(EQ::Net::TCPConnection*, unsigned char const*, unsigned long)>&, EQ::Net::TCPConnection*, unsigned char const*, unsigned long>(std::_Bind<void (EQ::Net::ServertalkClient::*(EQ::Net::ServertalkClient*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>))(EQ::Net::TCPConnection*, unsigned char const*, unsigned long)>&, EQ::Net::TCPConnection*&&, unsigned char const*&&, unsigned long&&) (__fn=...) at /usr/include/c++/10/bits/invoke.h:110
[Zone] [Crash] #23 0x0000562daef231b9 in std::_Function_handler<void (EQ::Net::TCPConnection*, unsigned char const*, unsigned long), std::_Bind<void (EQ::Net::ServertalkClient::*(EQ::Net::ServertalkClient*, std::_Placeholder<1>, std::_Placeholder<2>, std::_Placeholder<3>))(EQ::Net::TCPConnection*, unsigned char const*, unsigned long)> >::_M_invoke(std::_Any_data const&, EQ::Net::TCPConnection*&&, unsigned char const*&&, unsigned long&&) (__functor=..., __args#0=@0x7ffca9845d30: 0x562db160dcb0, __args#1=@0x7ffca9845d28: 0x562db1611920 "\a", __args#2=@0x7ffca9845d20: 12) at /usr/include/c++/10/bits/std_function.h:291
[Zone] [Crash] #24 0x0000562daef2719e in std::function<void (EQ::Net::TCPConnection*, unsigned char const*, unsigned long)>::operator()(EQ::Net::TCPConnection*, unsigned char const*, unsigned long) const (this=0x562db160dcb8, __args#0=0x562db160dcb0, __args#1=0x562db1611920 "\a", __args#2=12) at /usr/include/c++/10/bits/std_function.h:622
[Zone] [Crash] #25 0x0000562daef26768 in EQ::Net::TCPConnection::Read (this=0x562db160dcb0, data=0x562db1611920 "\a", count=12) at ../common/net/tcp_connection.cpp:127
[Zone] [Crash] #26 0x0000562daef264c4 in operator() (__closure=0x0, stream=0x562db105dd30, nread=12, buf=0x7ffca9845e50) at ../common/net/tcp_connection.cpp:76
[Zone] [Crash] #27 0x0000562daef2658e in _FUN () at ../common/net/tcp_connection.cpp:94
[Zone] [Crash] #28 0x0000562daf040f79 in uv__read (stream=stream@entry=0x562db105dd30) at ../submodules/libuv/src/unix/stream.c:1234
[Zone] [Crash] #29 0x0000562daf041668 in uv__stream_io (loop=<optimized out>, w=0x562db105ddb8, events=1) at ../submodules/libuv/src/unix/stream.c:1301
[Zone] [Crash] #30 0x0000562daf045333 in uv__io_poll (loop=loop@entry=0x7fe79fbb17a8, timeout=13) at ../submodules/libuv/src/unix/linux-core.c:379
[Zone] [Crash] #31 0x0000562daf03bb24 in uv_run (loop=0x7fe79fbb17a8, mode=UV_RUN_DEFAULT) at ../submodules/libuv/src/unix/core.c:361
[Zone] [Crash] #32 0x0000562dae8f6493 in EQ::EventLoop::Run (this=0x7fe79fbb17a8) at ../zone/../common/net/../event/event_loop.h:25
[Zone] [Crash] #33 0x0000562dae8f2e48 in main (argc=1, argv=0x7ffca984a128) at ../zone/main.cpp:600
[Zone] [Crash] [Inferior 1 (process 1684) detached]
```

**Testing**

![image](https://user-images.githubusercontent.com/3319450/193179366-5554b0b8-40d8-4948-9474-9c6b87ef3729.png)
