### PR TITLE
[Feature] Add Support for "Show Mine Only" Filters

### DIFF
--- a/common/eq_constants.h
+++ b/common/eq_constants.h
@@ -718,7 +718,7 @@ typedef enum {
 	FilterPetMisses = 21,		//0=show, 1=hide
 	FilterFocusEffects = 22,	//0=show, 1=hide
 	FilterPetSpells = 23,		//0=show, 1=hide
-	FilterHealOverTime = 24,	//0=show, 1=hide
+	FilterHealOverTime = 24,	//0=show, 1=mine only, 2=hide
 	FilterUnknown25 = 25,
 	FilterUnknown26 = 26,
 	FilterUnknown27 = 27,

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -4050,12 +4050,14 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 							attacker->MessageString(Chat::DamageShield, OTHER_HIT_NONMELEE, GetCleanName(), ConvertArray(damage, val1));
 					}
 					else {
-						entity_list.MessageCloseString(
-							this, /* Sender */
-							true, /* Skip Sender */
+						entity_list.FilteredMessageCloseString(
+							attacker, /* Sender */
+							false, /* Sender is attacker, so do not skip */
 							RuleI(Range, SpellMessages),
 							Chat::NonMelee, /* 283 */
+							FilterSpellDamage, /* FilterType: 13 */
 							HIT_NON_MELEE, /* %1 hit %2 for %3 points of non-melee damage. */
+							0,
 							attacker->GetCleanName(), /* Message1 */
 							GetCleanName(), /* Message2 */
 							ConvertArray(damage, val1) /* Message3 */

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -4217,7 +4217,7 @@ void Mob::HealDamage(uint64 amount, Mob *caster, uint16 spell_id)
 				// message to target
 				if (IsClient() && caster != this) {
 					if (CastToClient()->ClientVersionBit() & EQ::versions::maskSoFAndLater)
-						FilteredMessageString(this, Chat::NonMelee, FilterHealOverTime,
+						FilteredMessageString(caster, Chat::NonMelee, FilterHealOverTime,
 							HOT_HEALED_OTHER, caster->GetCleanName(),
 							itoa(acthealed), spells[spell_id].name);
 					else
@@ -4233,7 +4233,7 @@ void Mob::HealDamage(uint64 amount, Mob *caster, uint16 spell_id)
 						YOU_HEAL, GetCleanName(), itoa(acthealed));
 			}
 		}
-		else {
+		else if (this->CastToClient()->GetFilter(FilterHealOverTime) != (FilterShowSelfOnly || FilterHide)) {
 			Message(Chat::NonMelee, "You have been healed for %d points of damage.", acthealed);
 		}
 	}

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -3152,10 +3152,9 @@ void Client::ServerFilter(SetServerFilter_Struct* filter){
 	if (ClientVersionBit() & EQ::versions::maskSoDAndLater) {
 		if (filter->filters[FilterHealOverTime] == 0)
 			ClientFilters[FilterHealOverTime] = FilterShow;
-		// This is called 'Show Mine Only' in the clients, but functions the same as show
-		// so instead of apply special logic, just set to show
+		// This is called 'Show Mine Only' in the clients
 		else if (filter->filters[FilterHealOverTime] == 1)
-			ClientFilters[FilterHealOverTime] = FilterShow;
+			ClientFilters[FilterHealOverTime] = FilterShowSelfOnly;
 		else
 			ClientFilters[FilterHealOverTime] = FilterHide;
 	} else {

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -3273,14 +3273,12 @@ bool Client::FilteredMessageCheck(Mob *sender, eqFilterType filter)
 	else if (mode == FilterHide)
 		return false;
 
-	if (!sender && mode == FilterHide) {
+	if (sender != this && (mode == FilterHide || mode == FilterShowSelfOnly)) {
 		return false;
 	} else if (sender) {
 		if (this == sender) {
 			if (mode == FilterHide) // don't need to check others
 				return false;
-		} else if (mode == FilterShowSelfOnly) { // we know sender isn't us
-			return false;
 		} else if (mode == FilterShowGroupOnly) {
 			Group *g = GetGroup();
 			Raid *r = GetRaid();

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -123,9 +123,9 @@ int64 Mob::GetActSpellDamage(uint16 spell_id, int64 value, Mob* target) {
 			else if (IsNPC() && CastToNPC()->GetSpellScale())
 				value = int64(static_cast<float>(value) * CastToNPC()->GetSpellScale() / 100.0f);
 
-			entity_list.MessageCloseString(
-				this, true, 100, Chat::SpellCrit,
-				OTHER_CRIT_BLAST, GetName(), itoa(-value));
+			entity_list.FilteredMessageCloseString(
+				this, true, 100, Chat::SpellCrit, FilterSpellCrits,
+				OTHER_CRIT_BLAST, 0, GetName(), itoa(-value));
 
 			if (IsClient())
 				MessageString(Chat::SpellCrit, YOU_CRIT_BLAST, itoa(-value));


### PR DESCRIPTION
This adds support for the "Show Only Mine" Filter to function properly with the following Filter Types:

Spell Damage/Non-Melee Hits
Critical Melee Hits
Spell Crits.

I also noticed that DoT Damage was now working for "Show Group Only" where as I believe it was previously failing. 
DoT Damage could already be filtered with "Show Only Mine" I believe.

Tested commits by setting up two characters, and going through all possible filters for the above fields.

I'll raise a new PR if I find any issues with the other filter mode "Show Group Only" (that wasn't supported)


