### PR TITLE
[Bug Fix] Touch Of Vinitras was ignoring ignore Pets as target of Death Touch rule 

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -2270,7 +2270,7 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, CastingSlot slot, in
 		return false;
 
 	//Death Touch targets the pet owner instead of the pet when said pet is tanking.
-	if ((RuleB(Spells, CazicTouchTargetsPetOwner) && spell_target && spell_target->HasOwner()) && spell_id == SPELL_CAZIC_TOUCH || spell_id == SPELL_TOUCH_OF_VINITRAS) {
+	if ((RuleB(Spells, CazicTouchTargetsPetOwner) && spell_target && spell_target->HasOwner()) && (spell_id == SPELL_CAZIC_TOUCH || spell_id == SPELL_TOUCH_OF_VINITRAS)) {
 		Mob* owner =  spell_target->GetOwner();
 
 		if (owner) {


### PR DESCRIPTION
Death Touch targets the pet owner instead of the pet when said pet is tanking. via the rule CazicTouchTargetsPetOwner. 
Touch Of Vinitras was ignoring this rule.
