### PR TITLE
Change all executables to use the default event loop run

### DIFF
--- a/eqlaunch/eqlaunch.cpp
+++ b/eqlaunch/eqlaunch.cpp
@@ -105,10 +105,16 @@ int main(int argc, char *argv[]) {
 	Log(Logs::Detail, Logs::Launcher, "Starting main loop...");
 
 	ProcLauncher *launch = ProcLauncher::get();
+
 	RunLoops = true;
-	while(RunLoops) {
+	auto loop_fn = [&](EQ::Timer* t) {
 		//Advance the timer to our current point in time
 		Timer::SetCurrentTime();
+
+		if (!RunLoops) {
+			EQ::EventLoop::Get().Shutdown();
+			return;
+		}
 
 		/*
 		* Let the process manager look for dead children
@@ -120,29 +126,31 @@ int main(int argc, char *argv[]) {
 		*/
 		zone = zones.begin();
 		zend = zones.end();
-		for(; zone != zend; ++zone) {
-			if(!zone->second->Process())
+		for (; zone != zend; ++zone) {
+			if (!zone->second->Process())
 				to_remove.insert(zone->first);
 		}
 
 		/*
 		* Kill off any zones which have stopped
 		*/
-		while(!to_remove.empty()) {
+		while (!to_remove.empty()) {
 			std::string rem = *to_remove.begin();
 			to_remove.erase(rem);
 			zone = zones.find(rem);
-			if(zone == zones.end()) {
+			if (zone == zones.end()) {
 				//wtf...
 				continue;
 			}
 			delete zone->second;
 			zones.erase(rem);
 		}
+	};
 
-		EQ::EventLoop::Get().Process();
-		Sleep(5);
-	}
+	EQ::Timer process_timer(loop_fn);
+	process_timer.Start(32, true);
+
+	EQ::EventLoop::Get().Run();
 
 	//try to be semi-nice about this... without waiting too long
 	zone = zones.begin();

--- a/loginserver/main.cpp
+++ b/loginserver/main.cpp
@@ -289,13 +289,20 @@ int main(int argc, char **argv)
 	LogInfo("[Config] [Security] IsPasswordLoginAllowed [{0}]", server.options.IsPasswordLoginAllowed());
 	LogInfo("[Config] [Security] IsUpdatingInsecurePasswords [{0}]", server.options.IsUpdatingInsecurePasswords());
 
-	while (run_server) {
+	auto loop_fn = [&](EQ::Timer* t) {
 		Timer::SetCurrentTime();
-		server.client_manager->Process();
-		EQ::EventLoop::Get().Process();
 
-		Sleep(5);
-	}
+		if (!run_server) {
+			EQ::EventLoop::Get().Shutdown();
+		}
+
+		server.client_manager->Process();
+	};
+
+	EQ::Timer process_timer(loop_fn);
+	process_timer.Start(32, true);
+
+	EQ::EventLoop::Get().Run();
 
 	LogInfo("Server Shutdown");
 

--- a/loginserver/main.cpp
+++ b/loginserver/main.cpp
@@ -294,6 +294,7 @@ int main(int argc, char **argv)
 
 		if (!run_server) {
 			EQ::EventLoop::Get().Shutdown();
+			return;
 		}
 
 		server.client_manager->Process();

--- a/queryserv/queryserv.cpp
+++ b/queryserv/queryserv.cpp
@@ -104,15 +104,24 @@ int main()
 	/* Load Looking For Guild Manager */
 	lfguildmanager.LoadDatabase();
 
-	while (RunLoops) {
+	auto loop_fn = [&](EQ::Timer* t) {
 		Timer::SetCurrentTime();
+
+		if (!RunLoops) {
+			EQ::EventLoop::Get().Shutdown();
+			return;
+		}
+
 		if (LFGuildExpireTimer.Check()) {
 			lfguildmanager.ExpireEntries();
 		}
+	};
 
-		EQ::EventLoop::Get().Process();
-		Sleep(5);
-	}
+	EQ::Timer process_timer(loop_fn);
+	process_timer.Start(32, true);
+
+	EQ::EventLoop::Get().Run();
+
 	LogSys.CloseFileLogs();
 }
 


### PR DESCRIPTION
Akkadius wanted me to change the executables that still were using event loop process to instead use event loop run because event loop process causes issues on windows under high load.

I ran through getting into a zone from login->world->zone and everything appears to work but could probably use some outside verification.