### PR TITLE
[Zoning] Fix zone race condition

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -634,11 +634,14 @@ bool Client::Save(uint8 iCommitNow) {
 		return false;
 
 	/* Wrote current basics to PP for saves */
-	m_pp.x = m_Position.x;
-	m_pp.y = m_Position.y;
-	m_pp.z = m_Position.z;
+	if (!lock_save_position) {
+		m_pp.x       = m_Position.x;
+		m_pp.y       = m_Position.y;
+		m_pp.z       = m_Position.z;
+		m_pp.heading = m_Position.w;
+	}
+
 	m_pp.guildrank = guildrank;
-	m_pp.heading = m_Position.w;
 
 	/* Mana and HP */
 	if (GetHP() <= 0) {

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -232,8 +232,9 @@ Client::Client(EQStreamInterface* ieqs)
 	linkdead_timer.Disable();
 	zonesummon_id = 0;
 	zonesummon_ignorerestrictions = 0;
-	bZoning = false;
-	zone_mode = ZoneUnsolicited;
+	bZoning              = false;
+	m_lock_save_position = false;
+	zone_mode            = ZoneUnsolicited;
 	casting_spell_id = 0;
 	npcflag = false;
 	npclevel = 0;
@@ -634,7 +635,7 @@ bool Client::Save(uint8 iCommitNow) {
 		return false;
 
 	/* Wrote current basics to PP for saves */
-	if (!lock_save_position) {
+	if (!m_lock_save_position) {
 		m_pp.x       = m_Position.x;
 		m_pp.y       = m_Position.y;
 		m_pp.z       = m_Position.z;
@@ -11829,4 +11830,14 @@ bool Client::HasRecipeLearned(uint32 recipe_id)
 	}
 
 	return false;
+}
+
+bool Client::IsLockSavePosition() const
+{
+	return m_lock_save_position;
+}
+
+void Client::SetLockSavePosition(bool lock_save_position)
+{
+	Client::m_lock_save_position = lock_save_position;
 }

--- a/zone/client.h
+++ b/zone/client.h
@@ -1801,6 +1801,8 @@ private:
 	int32 max_end;
 	int32 current_endurance;
 
+	bool lock_save_position = false;
+
 	PlayerProfile_Struct m_pp;
 	ExtendedProfile_Struct m_epp;
 	EQ::InventoryProfile m_inv;

--- a/zone/client.h
+++ b/zone/client.h
@@ -1801,7 +1801,12 @@ private:
 	int32 max_end;
 	int32 current_endurance;
 
-	bool lock_save_position = false;
+	// https://github.com/EQEmu/Server/pull/2479
+	bool m_lock_save_position = false;
+public:
+	bool IsLockSavePosition() const;
+	void SetLockSavePosition(bool lock_save_position);
+private:
 
 	PlayerProfile_Struct m_pp;
 	ExtendedProfile_Struct m_epp;

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -365,6 +365,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 				zc2->success = ZONE_ERROR_NOTREADY;
 				entity->CastToMob()->SetZone(ztz->current_zone_id, ztz->current_instance_id);
 				entity->CastToClient()->SetZoning(false);
+				entity->CastToClient()->SetLockSavePosition(false);
 			}
 			else {
 				entity->CastToClient()->UpdateWho(1);

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -1859,7 +1859,7 @@ void Zone::ResetShutdownTimer() {
 		zone->GetZoneDescription()
 	);
 
-	autoshutdown_timer.SetTimer(autoshutdown_timer.GetDuration());
+	autoshutdown_timer.Start(autoshutdown_timer.GetDuration(), true);
 }
 
 bool Zone::Depop(bool StartSpawnTimer) {

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -1859,7 +1859,7 @@ void Zone::ResetShutdownTimer() {
 		zone->GetZoneDescription()
 	);
 
-	autoshutdown_timer.Start(autoshutdown_timer.GetDuration(), true);
+	autoshutdown_timer.SetTimer(autoshutdown_timer.GetDuration());
 }
 
 bool Zone::Depop(bool StartSpawnTimer) {

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -467,6 +467,8 @@ void Client::DoZoneSuccess(ZoneChange_Struct *zc, uint16 zone_id, uint32 instanc
 	//Force a save so its waiting for them when they zone
 	Save(2);
 
+	lock_save_position = true;
+
 	if (zone_id == zone->GetZoneID() && instance_id == zone->GetInstanceID()) {
 		// No need to ask worldserver if we're zoning to ourselves (most
 		// likely to a bind point), also fixes a bug since the default response was failure

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -394,6 +394,8 @@ void Client::SendZoneCancel(ZoneChange_Struct *zc) {
 	zone_mode = ZoneUnsolicited;
 	// reset since we're not zoning anymore
 	bZoning = false;
+	// remove save position lock
+	m_lock_save_position = false;
 }
 
 void Client::SendZoneError(ZoneChange_Struct *zc, int8 err)
@@ -413,6 +415,8 @@ void Client::SendZoneError(ZoneChange_Struct *zc, int8 err)
 	zone_mode = ZoneUnsolicited;
 	// reset since we're not zoning anymore
 	bZoning = false;
+	// remove save position lock
+	m_lock_save_position = false;
 }
 
 void Client::DoZoneSuccess(ZoneChange_Struct *zc, uint16 zone_id, uint32 instance_id, float dest_x, float dest_y, float dest_z, float dest_h, int8 ignore_r) {
@@ -467,7 +471,7 @@ void Client::DoZoneSuccess(ZoneChange_Struct *zc, uint16 zone_id, uint32 instanc
 	//Force a save so its waiting for them when they zone
 	Save(2);
 
-	lock_save_position = true;
+	m_lock_save_position = true;
 
 	if (zone_id == zone->GetZoneID() && instance_id == zone->GetInstanceID()) {
 		// No need to ask worldserver if we're zoning to ourselves (most


### PR DESCRIPTION
**Problem**

Players end up in seemingly random locations in the destination zone

This is a race condition that can occur on all servers, but shows itself more prevalent on servers like PEQ where folks are running 30-60 box armies.

When a player crosses a zone line, a save is issued in `character_data` representing the destination `zone_id` `zone_instance` and `x` `y` `z` etc. The receiving zone then loads this to place the character properly on the other side.

The race condition is that when players cross a zone line, while x/y/z gets saved, there is a small chance that the players current X,Y,Z in the zone prior to the actual zoning gets updated when the client sends its client position update one last time before the client gets deconstructed (Where save is called again, saving the wrong x/y/z from the source zone)

**Solution**

When we perform a successful zone, we save the destination x/y/z and we lock further location over writing in the database in the very small time before the client object is desconstructed. 

**Testing**

Tested with a player on PEQ Sandbox with 35 characters. Zoned successfully with no character displacements in all attempts (20+ zones) whereas it would happen fairly consistenly between Nexus and Netherbian