### PR TITLE
[Zone Shutdown] Fix for resetting shutdown timer

### DIFF
--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -1859,7 +1859,7 @@ void Zone::ResetShutdownTimer() {
 		zone->GetZoneDescription()
 	);
 
-	autoshutdown_timer.SetTimer(autoshutdown_timer.GetDuration());
+	autoshutdown_timer.Start(autoshutdown_timer.GetDuration(), true);
 }
 
 bool Zone::Depop(bool StartSpawnTimer) {


### PR DESCRIPTION
Noticed while testing current master for PEQ after months of catching up on updates that the reset shutdown timer isn't properly resetting the timer for the zone.

Would see logs like this where the remaining time actually never goes back to the hour as intended

**Before**

```
[10-11-2022 16:08:52] [Zone] [Info] [ResetShutdownTimer] Reset to [1 Hour] from original remaining time [54 Minutes and 7 Seconds] duration [1 Hour] zone [PID (189596) The Grey (171)]
```

**After**

```
==> /home/eqemu/server/logs/zone/halas_version_0_inst_id_0_port_7002_196826.log <==
[10-11-2022 16:34:57] [Zone] [Info] [ResetShutdownTimer] Reset to [1 Hour] from original remaining time [59 Minutes and 29 Seconds] duration [1 Hour] zone [PID (196826) Halas (29)]

==> /home/eqemu/server/logs/zone/nexus_version_0_inst_id_0_port_7000_196821.log <==
[10-11-2022 16:35:08] [Zone] [Info] [ResetShutdownTimer] Reset to [1 Hour] from original remaining time [59 Minutes and 39 Seconds] duration [1 Hour] zone [PID (196821) Nexus (152)]

==> /home/eqemu/server/logs/zone/nexus_version_0_inst_id_0_port_7000_196821.log <==
[10-11-2022 16:35:16] [Zone] [Info] [ResetShutdownTimer] Reset to [1 Hour] from original remaining time [59 Minutes and 53 Seconds] duration [1 Hour] zone [PID (196821) Nexus (152)]
```
