### PR TITLE
[BOTS] Split off Bot Spell Casting functions and Bot Spell Structs from mob_ai.cpp

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -7733,7 +7733,7 @@ bool Bot::DoFinishedSpellSingleTarget(uint16 spell_id, Mob* spellTarget, EQ::spe
 		if(IsGrouped() && (spellTarget->IsBot() || spellTarget->IsClient()) && RuleB(Bots, GroupBuffing)) {
 			bool noGroupSpell = false;
 			uint16 thespell = spell_id;
-			for(int i = 0; i < AIspells.size(); i++) {
+			for(int i = 0; i < AIBotSpells.size(); i++) {
 				int j = BotGetSpells(i);
 				int spelltype = BotGetSpellType(i);
 				bool spellequal = (j == thespell);
@@ -9194,7 +9194,7 @@ void Bot::CalcBotStats(bool showtext) {
 
 	CalcBonuses();
 
-	AI_AddNPCSpells(GetBotSpellID());
+	AI_AddBotSpells(GetBotSpellID());
 
 	if(showtext) {
 		GetBotOwner()->Message(Chat::Yellow, "%s has been updated.", GetCleanName());

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -136,6 +136,18 @@ public:
 		spellTypeIndexPreCombatBuffSong
 	};
 
+	struct AIBotSpells_Struct {
+		uint32	type;			// 0 = never, must be one (and only one) of the defined values
+		uint16	spellid;		// <= 0 = no spell
+		int16	manacost;		// -1 = use spdat, -2 = no cast time
+		uint32	time_cancast;	// when we can cast this spell next
+		int32	recast_delay;
+		int16	priority;
+		int16	resist_adjust;
+		int8	min_hp; // >0 won't cast if HP is below
+		int8	max_hp; // >0 won't cast if HP is above
+	};
+
 	static const uint32 SPELL_TYPE_FIRST = spellTypeIndexNuke;
 	static const uint32 SPELL_TYPE_LAST = spellTypeIndexPreCombatBuffSong;
 	static const uint32 SPELL_TYPE_COUNT = SPELL_TYPE_LAST + 1;
@@ -174,9 +186,9 @@ public:
 	virtual bool Save();
 	virtual void Depop();
 	void CalcBotStats(bool showtext = true);
-	uint16 BotGetSpells(int spellslot) { return AIspells[spellslot].spellid; }
-	uint32 BotGetSpellType(int spellslot) { return AIspells[spellslot].type; }
-	uint16 BotGetSpellPriority(int spellslot) { return AIspells[spellslot].priority; }
+	uint16 BotGetSpells(int spellslot) { return AIBotSpells[spellslot].spellid; }
+	uint32 BotGetSpellType(int spellslot) { return AIBotSpells[spellslot].type; }
+	uint16 BotGetSpellPriority(int spellslot) { return AIBotSpells[spellslot].priority; }
 	virtual float GetProcChances(float ProcBonus, uint16 hand);
 	virtual int GetHandToHandDamage(void);
 	virtual bool TryFinishingBlow(Mob *defender, int64 &damage);
@@ -220,7 +232,7 @@ public:
 	virtual void AddToHateList(Mob* other, int64 hate = 0, int64 damage = 0, bool iYellForHelp = true, bool bFrenzy = false, bool iBuffTic = false, bool pet_command = false);
 	virtual void SetTarget(Mob* mob);
 	virtual void Zone();
-	std::vector<AISpells_Struct> GetBotSpells() { return AIspells; }
+	std::vector<AIBotSpells_Struct> GetBotSpells() { return AIBotSpells; }
 	bool IsArcheryRange(Mob* target);
 	void ChangeBotArcherWeapons(bool isArcher);
 	void Sit();
@@ -349,6 +361,12 @@ public:
 	bool CheckLoreConflict(const EQ::ItemData* item);
 	virtual void UpdateEquipmentLight() { m_Light.Type[EQ::lightsource::LightEquipment] = m_inv.FindBrightestLightType(); m_Light.Level[EQ::lightsource::LightEquipment] = EQ::lightsource::TypeToLevel(m_Light.Type[EQ::lightsource::LightEquipment]); }
 	const EQ::InventoryProfile& GetBotInv() const { return m_inv; }
+
+	// Bot Spell Loading Methods
+	void AddSpellToBotList(int16 iPriority, uint16 iSpellID, uint32 iType, int16 iManaCost, int32 iRecastDelay, int16 iResistAdjust, int8 min_hp, int8 max_hp);
+    bool AI_AddBotSpells(uint32 iDBSpellsID);
+	bool IsSpellInBotList(DBBotSpells_Struct* spell_list, uint16 iSpellID);
+	std::vector<AIBotSpells_Struct> AIBotSpells;
 
 	// Static Class Methods
 	//static void DestroyBotRaidObjects(Client* client);	// Can be removed after bot raids are dumped

--- a/zone/botspellsai.cpp
+++ b/zone/botspellsai.cpp
@@ -1063,7 +1063,7 @@ bool Bot::AIDoSpellCast(uint8 i, Mob* tar, int32 mana_cost, uint32* oDontDoAgain
 	int32 manaCost = mana_cost;
 
 	if (manaCost == -1)
-		manaCost = spells[AIspells[i].spellid].mana;
+		manaCost = spells[AIBotSpells[i].spellid].mana;
 	else if (manaCost == -2)
 		manaCost = 0;
 
@@ -1074,7 +1074,7 @@ bool Bot::AIDoSpellCast(uint8 i, Mob* tar, int32 mana_cost, uint32* oDontDoAgain
 	if(RuleB(Bots, FinishBuffing)) {
 		if(manaCost > hasMana) {
 			// Let's have the bots complete the buff time process
-			if(AIspells[i].type & SpellType_Buff) {
+			if(AIBotSpells[i].type & SpellType_Buff) {
 				extraMana = manaCost - hasMana;
 				SetMana(manaCost);
 			}
@@ -1083,17 +1083,17 @@ bool Bot::AIDoSpellCast(uint8 i, Mob* tar, int32 mana_cost, uint32* oDontDoAgain
 
 	float dist2 = 0;
 
-	if (AIspells[i].type & SpellType_Escape) {
+	if (AIBotSpells[i].type & SpellType_Escape) {
 		dist2 = 0;
 	} else
 		dist2 = DistanceSquared(m_Position, tar->GetPosition());
 
-	if (((((spells[AIspells[i].spellid].target_type==ST_GroupTeleport && AIspells[i].type==2)
-				|| spells[AIspells[i].spellid].target_type==ST_AECaster
-				|| spells[AIspells[i].spellid].target_type==ST_Group
-				|| spells[AIspells[i].spellid].target_type==ST_AEBard)
-				&& dist2 <= spells[AIspells[i].spellid].aoe_range*spells[AIspells[i].spellid].aoe_range)
-				|| dist2 <= GetActSpellRange(AIspells[i].spellid, spells[AIspells[i].spellid].range)*GetActSpellRange(AIspells[i].spellid, spells[AIspells[i].spellid].range)) && (mana_cost <= GetMana() || GetMana() == GetMaxMana()))
+	if (((((spells[AIBotSpells[i].spellid].target_type==ST_GroupTeleport && AIBotSpells[i].type==2)
+				|| spells[AIBotSpells[i].spellid].target_type==ST_AECaster
+				|| spells[AIBotSpells[i].spellid].target_type==ST_Group
+				|| spells[AIBotSpells[i].spellid].target_type==ST_AEBard)
+				&& dist2 <= spells[AIBotSpells[i].spellid].aoe_range*spells[AIBotSpells[i].spellid].aoe_range)
+				|| dist2 <= GetActSpellRange(AIBotSpells[i].spellid, spells[AIBotSpells[i].spellid].range)*GetActSpellRange(AIBotSpells[i].spellid, spells[AIBotSpells[i].spellid].range)) && (mana_cost <= GetMana() || GetMana() == GetMaxMana()))
 	{
 		result = NPC::AIDoSpellCast(i, tar, mana_cost, oDontDoAgainBefore);
 
@@ -1107,7 +1107,7 @@ bool Bot::AIDoSpellCast(uint8 i, Mob* tar, int32 mana_cost, uint32* oDontDoAgain
 		extraMana = false;
 	}
 	else { //handle spell recast and recast timers
-		//if(GetClass() == BARD && IsGroupSpell(AIspells[i].spellid)) {
+		//if(GetClass() == BARD && IsGroupSpell(AISpells[i].spellid)) {
 		//	// Bard buff songs have been moved to their own npc spell type..
 		//	// Buff stacking is now checked as opposed to manipulating the timer to avoid rapid casting
 
@@ -1117,10 +1117,10 @@ bool Bot::AIDoSpellCast(uint8 i, Mob* tar, int32 mana_cost, uint32* oDontDoAgain
 		//else
 		//	AIspells[i].time_cancast = Timer::GetCurrentTime() + spells[AIspells[i].spellid].recast_time;
 
-		AIspells[i].time_cancast = Timer::GetCurrentTime() + spells[AIspells[i].spellid].recast_time;
+		AIBotSpells[i].time_cancast = Timer::GetCurrentTime() + spells[AIBotSpells[i].spellid].recast_time;
 
-		if(spells[AIspells[i].spellid].timer_id > 0) {
-			SetSpellRecastTimer(spells[AIspells[i].spellid].timer_id, spells[AIspells[i].spellid].recast_time);
+		if(spells[AIBotSpells[i].spellid].timer_id > 0) {
+			SetSpellRecastTimer(spells[AIBotSpells[i].spellid].timer_id, spells[AIBotSpells[i].spellid].recast_time);
 		}
 	}
 
@@ -1593,7 +1593,7 @@ std::list<BotSpell> Bot::GetBotSpellsForSpellEffect(Bot* botCaster, int spellEff
 	std::list<BotSpell> result;
 
 	if(botCaster && botCaster->AI_HasSpells()) {
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetBotSpells();
+		std::vector<AIBotSpells_Struct> botSpellList = botCaster->GetBotSpells();
 
 		for (int i = botSpellList.size() - 1; i >= 0; i--) {
 			if (botSpellList[i].spellid <= 0 || botSpellList[i].spellid >= SPDAT_RECORDS) {
@@ -1620,7 +1620,7 @@ std::list<BotSpell> Bot::GetBotSpellsForSpellEffectAndTargetType(Bot* botCaster,
 	std::list<BotSpell> result;
 
 	if(botCaster && botCaster->AI_HasSpells()) {
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetBotSpells();
+		std::vector<AIBotSpells_Struct> botSpellList = botCaster->GetBotSpells();
 
 		for (int i = botSpellList.size() - 1; i >= 0; i--) {
 			if (botSpellList[i].spellid <= 0 || botSpellList[i].spellid >= SPDAT_RECORDS) {
@@ -1649,7 +1649,7 @@ std::list<BotSpell> Bot::GetBotSpellsBySpellType(Bot* botCaster, uint32 spellTyp
 	std::list<BotSpell> result;
 
 	if(botCaster && botCaster->AI_HasSpells()) {
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetBotSpells();
+		std::vector<AIBotSpells_Struct> botSpellList = botCaster->GetBotSpells();
 
 		for (int i = botSpellList.size() - 1; i >= 0; i--) {
 			if (botSpellList[i].spellid <= 0 || botSpellList[i].spellid >= SPDAT_RECORDS) {
@@ -1676,7 +1676,7 @@ std::list<BotSpell_wPriority> Bot::GetPrioritizedBotSpellsBySpellType(Bot* botCa
 	std::list<BotSpell_wPriority> result;
 
 	if (botCaster && botCaster->AI_HasSpells()) {
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetBotSpells();
+		std::vector<AIBotSpells_Struct> botSpellList = botCaster->GetBotSpells();
 
 		for (int i = botSpellList.size() - 1; i >= 0; i--) {
 			if (botSpellList[i].spellid <= 0 || botSpellList[i].spellid >= SPDAT_RECORDS) {
@@ -1711,7 +1711,7 @@ BotSpell Bot::GetFirstBotSpellBySpellType(Bot* botCaster, uint32 spellType) {
 	result.ManaCost = 0;
 
 	if(botCaster && botCaster->AI_HasSpells()) {
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetBotSpells();
+		std::vector<AIBotSpells_Struct> botSpellList = botCaster->GetBotSpells();
 
 		for (int i = botSpellList.size() - 1; i >= 0; i--) {
 			if (botSpellList[i].spellid <= 0 || botSpellList[i].spellid >= SPDAT_RECORDS) {
@@ -1767,7 +1767,7 @@ BotSpell Bot::GetBestBotSpellForHealOverTime(Bot* botCaster) {
 
 	if(botCaster) {
 		std::list<BotSpell> botHoTSpellList = GetBotSpellsForSpellEffect(botCaster, SE_HealOverTime);
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetBotSpells();
+		std::vector<AIBotSpells_Struct> botSpellList = botCaster->GetBotSpells();
 
 		for(std::list<BotSpell>::iterator botSpellListItr = botHoTSpellList.begin(); botSpellListItr != botHoTSpellList.end(); ++botSpellListItr) {
 			// Assuming all the spells have been loaded into this list by level and in descending order
@@ -1803,7 +1803,7 @@ BotSpell Bot::GetBestBotSpellForPercentageHeal(Bot *botCaster) {
 	result.ManaCost = 0;
 
 	if(botCaster && botCaster->AI_HasSpells()) {
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetBotSpells();
+		std::vector<AIBotSpells_Struct> botSpellList = botCaster->GetBotSpells();
 
 		for (int i = botSpellList.size() - 1; i >= 0; i--) {
 			if (botSpellList[i].spellid <= 0 || botSpellList[i].spellid >= SPDAT_RECORDS) {
@@ -1909,7 +1909,7 @@ BotSpell Bot::GetBestBotSpellForGroupHealOverTime(Bot* botCaster) {
 
 	if(botCaster) {
 		std::list<BotSpell> botHoTSpellList = GetBotSpellsForSpellEffect(botCaster, SE_HealOverTime);
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetBotSpells();
+		std::vector<AIBotSpells_Struct> botSpellList = botCaster->GetBotSpells();
 
 		for(std::list<BotSpell>::iterator botSpellListItr = botHoTSpellList.begin(); botSpellListItr != botHoTSpellList.end(); ++botSpellListItr) {
 			// Assuming all the spells have been loaded into this list by level and in descending order
@@ -2320,7 +2320,7 @@ BotSpell Bot::GetDebuffBotSpell(Bot* botCaster, Mob *tar) {
 		return result;
 
 	if(botCaster && botCaster->AI_HasSpells()) {
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetBotSpells();
+		std::vector<AIBotSpells_Struct> botSpellList = botCaster->GetBotSpells();
 
 		for (int i = botSpellList.size() - 1; i >= 0; i--) {
 			if (botSpellList[i].spellid <= 0 || botSpellList[i].spellid >= SPDAT_RECORDS) {
@@ -2367,7 +2367,7 @@ BotSpell Bot::GetBestBotSpellForResistDebuff(Bot* botCaster, Mob *tar) {
 	bool needsDiseaseResistDebuff = (tar->GetDR() + level_mod) > 100 ? true: false;
 
 	if(botCaster && botCaster->AI_HasSpells()) {
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetBotSpells();
+		std::vector<AIBotSpells_Struct> botSpellList = botCaster->GetBotSpells();
 
 		for (int i = botSpellList.size() - 1; i >= 0; i--) {
 			if (botSpellList[i].spellid <= 0 || botSpellList[i].spellid >= SPDAT_RECORDS) {
@@ -2526,8 +2526,8 @@ int32 Bot::GetSpellRecastTimer(Bot *caster, int timer_index) {
 
 bool Bot::CheckSpellRecastTimers(Bot *caster, int SpellIndex) {
 	if(caster) {
-		if(caster->AIspells[SpellIndex].time_cancast < Timer::GetCurrentTime()) { //checks spell recast
-			if(GetSpellRecastTimer(caster, spells[caster->AIspells[SpellIndex].spellid].timer_id) < Timer::GetCurrentTime()) { //checks for spells on the same timer
+		if(caster->AIBotSpells[SpellIndex].time_cancast < Timer::GetCurrentTime()) { //checks spell recast
+			if(GetSpellRecastTimer(caster, spells[caster->AIBotSpells[SpellIndex].spellid].timer_id) < Timer::GetCurrentTime()) { //checks for spells on the same timer
 				return true; //can cast spell
 			}
 		}
@@ -2672,6 +2672,312 @@ uint8 Bot::GetChanceToCastBySpellType(uint32 spellType)
 	}
 
 	return database.botdb.GetSpellCastingChance(spell_type_index, class_index, stance_index, type_index);
+}
+
+DBBotSpells_Struct *ZoneDatabase::GetBotSpells(uint32 iDBSpellsID)
+{
+	if (iDBSpellsID == 0)
+		return nullptr;
+
+	auto it = bot_spells_cache.find(iDBSpellsID);
+
+	if (it != bot_spells_cache.end()) { // it's in the cache, easy =)
+		return &it->second;
+	}
+
+	if (!bot_spells_loadtried.count(iDBSpellsID)) { // no reason to ask the DB again if we have failed once already
+		bot_spells_loadtried.insert(iDBSpellsID);
+
+		std::string query = StringFormat("SELECT id, parent_list, attack_proc, proc_chance, "
+						 "range_proc, rproc_chance, defensive_proc, dproc_chance, "
+						 "fail_recast, engaged_no_sp_recast_min, engaged_no_sp_recast_max, "
+						 "engaged_b_self_chance, engaged_b_other_chance, engaged_d_chance, "
+						 "pursue_no_sp_recast_min, pursue_no_sp_recast_max, "
+						 "pursue_d_chance, idle_no_sp_recast_min, idle_no_sp_recast_max, "
+						 "idle_b_chance FROM npc_spells WHERE id=%d",
+						 iDBSpellsID);
+		auto results = QueryDatabase(query);
+		if (!results.Success()) {
+			return nullptr;
+		}
+
+		if (results.RowCount() != 1)
+			return nullptr;
+
+		auto row = results.begin();
+		DBBotSpells_Struct spell_set;
+
+		spell_set.parent_list = atoi(row[1]);
+		spell_set.attack_proc = atoi(row[2]);
+		spell_set.proc_chance = atoi(row[3]);
+		spell_set.range_proc = atoi(row[4]);
+		spell_set.rproc_chance = atoi(row[5]);
+		spell_set.defensive_proc = atoi(row[6]);
+		spell_set.dproc_chance = atoi(row[7]);
+		spell_set.fail_recast = atoi(row[8]);
+		spell_set.engaged_no_sp_recast_min = atoi(row[9]);
+		spell_set.engaged_no_sp_recast_max = atoi(row[10]);
+		spell_set.engaged_beneficial_self_chance = atoi(row[11]);
+		spell_set.engaged_beneficial_other_chance = atoi(row[12]);
+		spell_set.engaged_detrimental_chance = atoi(row[13]);
+		spell_set.pursue_no_sp_recast_min = atoi(row[14]);
+		spell_set.pursue_no_sp_recast_max = atoi(row[15]);
+		spell_set.pursue_detrimental_chance = atoi(row[16]);
+		spell_set.idle_no_sp_recast_min = atoi(row[17]);
+		spell_set.idle_no_sp_recast_max = atoi(row[18]);
+		spell_set.idle_beneficial_chance = atoi(row[19]);
+
+		// pulling fixed values from an auto-increment field is dangerous...
+		query = StringFormat(
+		    "SELECT spellid, type, minlevel, maxlevel, "
+		    "manacost, recast_delay, priority, min_hp, max_hp, resist_adjust "
+		    "FROM bot_spells_entries "
+		    "WHERE npc_spells_id=%d ORDER BY minlevel",
+		    iDBSpellsID);
+
+		results = QueryDatabase(query);
+
+		if (!results.Success()) {
+			return nullptr;
+		}
+
+		int entryIndex = 0;
+		for (row = results.begin(); row != results.end(); ++row, ++entryIndex) {
+			DBBotSpells_Entries_Struct entry;
+			int spell_id = atoi(row[0]);
+			entry.spellid = spell_id;
+			entry.type = atoul(row[1]);
+			entry.minlevel = atoi(row[2]);
+			entry.maxlevel = atoi(row[3]);
+			entry.manacost = atoi(row[4]);
+			entry.recast_delay = atoi(row[5]);
+			entry.priority = atoi(row[6]);
+			entry.min_hp = atoi(row[7]);
+			entry.max_hp = atoi(row[8]);
+
+			// some spell types don't make much since to be priority 0, so fix that
+			if (!(entry.type & SPELL_TYPES_INNATE) && entry.priority == 0)
+				entry.priority = 1;
+
+			if (row[9])
+				entry.resist_adjust = atoi(row[9]);
+			else if (IsValidSpell(spell_id))
+				entry.resist_adjust = spells[spell_id].resist_difficulty;
+
+			spell_set.entries.push_back(entry);
+		}
+
+		bot_spells_cache.insert(std::make_pair(iDBSpellsID, spell_set));
+
+		return &bot_spells_cache[iDBSpellsID];
+    }
+
+	return nullptr;
+}
+
+bool Bot::AI_AddBotSpells(uint32 iDBSpellsID) {
+	// ok, this function should load the list, and the parent list then shove them into the struct and sort
+	npc_spells_id = iDBSpellsID;
+	
+	AIBotSpells.clear();
+	if (iDBSpellsID == 0) {
+		AIautocastspell_timer->Disable();
+		return false;
+	}
+	DBBotSpells_Struct* spell_list = content_db.GetBotSpells(iDBSpellsID);
+	if (!spell_list) {
+		AIautocastspell_timer->Disable();
+		return false;
+	}
+	DBBotSpells_Struct* parentlist = content_db.GetBotSpells(spell_list->parent_list);
+#if MobAI_DEBUG_Spells >= 10
+	std::string debug_msg = StringFormat("Loading BotSpells onto %s: dbspellsid=%u, level=%u", GetName(), iDBSpellsID, GetLevel());
+	if (spell_list) {
+		debug_msg.append(StringFormat(" (found, %u), parentlist=%u", spell_list->entries.size(), spell_list->parent_list));
+		if (spell_list->parent_list) {
+			if (parentlist)
+				debug_msg.append(StringFormat(" (found, %u)", parentlist->entries.size()));
+			else
+				debug_msg.append(" (not found)");
+		}
+	}
+	else {
+		debug_msg.append(" (not found)");
+	}
+	LogAI("[{}]", debug_msg.c_str());
+
+#ifdef MobAI_DEBUG_Spells >= 25
+	if (parentlist) {
+		for (const auto &iter : parentlist->entries) {
+			LogAI("([{}]) [{}]", iter.spellid, spells[iter.spellid].name);
+		}
+	}
+	LogAI("fin (parent list)");
+	if (spell_list) {
+		for (const auto &iter : spell_list->entries) {
+			LogAI("([{}]) [{}]", iter.spellid, spells[iter.spellid].name);
+		}
+	}
+	LogAI("fin (spell list)");
+#endif
+
+#endif
+	uint16 attack_proc_spell = -1;
+	int8 proc_chance = 3;
+	uint16 range_proc_spell = -1;
+	int16 rproc_chance = 0;
+	uint16 defensive_proc_spell = -1;
+	int16 dproc_chance = 0;
+	uint32 _fail_recast = 0;
+	uint32 _engaged_no_sp_recast_min = 0;
+	uint32 _engaged_no_sp_recast_max = 0;
+	uint8 _engaged_beneficial_self_chance = 0;
+	uint8 _engaged_beneficial_other_chance = 0;
+	uint8 _engaged_detrimental_chance = 0;
+	uint32 _pursue_no_sp_recast_min = 0;
+	uint32 _pursue_no_sp_recast_max = 0;
+	uint8 _pursue_detrimental_chance = 0;
+	uint32 _idle_no_sp_recast_min = 0;
+	uint32 _idle_no_sp_recast_max = 0;
+	uint8 _idle_beneficial_chance = 0;
+
+	if (parentlist) {
+		attack_proc_spell = parentlist->attack_proc;
+		proc_chance = parentlist->proc_chance;
+		range_proc_spell = parentlist->range_proc;
+		rproc_chance = parentlist->rproc_chance;
+		defensive_proc_spell = parentlist->defensive_proc;
+		dproc_chance = parentlist->dproc_chance;
+		_fail_recast = parentlist->fail_recast;
+		_engaged_no_sp_recast_min = parentlist->engaged_no_sp_recast_min;
+		_engaged_no_sp_recast_max = parentlist->engaged_no_sp_recast_max;
+		_engaged_beneficial_self_chance = parentlist->engaged_beneficial_self_chance;
+		_engaged_beneficial_other_chance = parentlist->engaged_beneficial_other_chance;
+		_engaged_detrimental_chance = parentlist->engaged_detrimental_chance;
+		_pursue_no_sp_recast_min = parentlist->pursue_no_sp_recast_min;
+		_pursue_no_sp_recast_max = parentlist->pursue_no_sp_recast_max;
+		_pursue_detrimental_chance = parentlist->pursue_detrimental_chance;
+		_idle_no_sp_recast_min = parentlist->idle_no_sp_recast_min;
+		_idle_no_sp_recast_max = parentlist->idle_no_sp_recast_max;
+		_idle_beneficial_chance = parentlist->idle_beneficial_chance;
+		for (auto &e : parentlist->entries) {
+			if (GetLevel() >= e.minlevel && GetLevel() <= e.maxlevel && e.spellid > 0) {
+				if (!IsSpellInBotList(spell_list, e.spellid))
+				{
+					AddSpellToBotList(e.priority, e.spellid, e.type, e.manacost, e.recast_delay, e.resist_adjust, e.min_hp, e.max_hp);
+				}
+			}
+		}
+	}
+	if (spell_list->attack_proc >= 0) {
+		attack_proc_spell = spell_list->attack_proc;
+		proc_chance = spell_list->proc_chance;
+	}
+
+	if (spell_list->range_proc >= 0) {
+		range_proc_spell = spell_list->range_proc;
+		rproc_chance = spell_list->rproc_chance;
+	}
+
+	if (spell_list->defensive_proc >= 0) {
+		defensive_proc_spell = spell_list->defensive_proc;
+		dproc_chance = spell_list->dproc_chance;
+	}
+
+	//If any casting variables are defined in the current list, ignore those in the parent list.
+	if (spell_list->fail_recast || spell_list->engaged_no_sp_recast_min || spell_list->engaged_no_sp_recast_max
+		|| spell_list->engaged_beneficial_self_chance || spell_list->engaged_beneficial_other_chance || spell_list->engaged_detrimental_chance
+		|| spell_list->pursue_no_sp_recast_min || spell_list->pursue_no_sp_recast_max || spell_list->pursue_detrimental_chance
+		|| spell_list->idle_no_sp_recast_min || spell_list->idle_no_sp_recast_max || spell_list->idle_beneficial_chance) {
+		_fail_recast = spell_list->fail_recast;
+		_engaged_no_sp_recast_min = spell_list->engaged_no_sp_recast_min;
+		_engaged_no_sp_recast_max = spell_list->engaged_no_sp_recast_max;
+		_engaged_beneficial_self_chance = spell_list->engaged_beneficial_self_chance;
+		_engaged_beneficial_other_chance = spell_list->engaged_beneficial_other_chance;
+		_engaged_detrimental_chance = spell_list->engaged_detrimental_chance;
+		_pursue_no_sp_recast_min = spell_list->pursue_no_sp_recast_min;
+		_pursue_no_sp_recast_max = spell_list->pursue_no_sp_recast_max;
+		_pursue_detrimental_chance = spell_list->pursue_detrimental_chance;
+		_idle_no_sp_recast_min = spell_list->idle_no_sp_recast_min;
+		_idle_no_sp_recast_max = spell_list->idle_no_sp_recast_max;
+		_idle_beneficial_chance = spell_list->idle_beneficial_chance;
+	}
+
+	for (auto &e : spell_list->entries) {
+		if (GetLevel() >= e.minlevel && GetLevel() <= e.maxlevel && e.spellid > 0) {
+			AddSpellToBotList(e.priority, e.spellid, e.type, e.manacost, e.recast_delay, e.resist_adjust, e.min_hp, e.max_hp);
+		}
+	}
+
+	std::sort(AIBotSpells.begin(), AIBotSpells.end(), [](const AIBotSpells_Struct& a, const AIBotSpells_Struct& b) {
+		return a.priority > b.priority;
+	});
+
+	if (IsValidSpell(attack_proc_spell)) {
+		AddProcToWeapon(attack_proc_spell, true, proc_chance);
+
+		if(RuleB(Spells, NPCInnateProcOverride))
+			innate_proc_spell_id = attack_proc_spell;
+	}
+
+	if (IsValidSpell(range_proc_spell))
+		AddRangedProc(range_proc_spell, (rproc_chance + 100));
+
+	if (IsValidSpell(defensive_proc_spell))
+		AddDefensiveProc(defensive_proc_spell, (dproc_chance + 100));
+
+	//Set AI casting variables
+
+	AISpellVar.fail_recast = (_fail_recast) ? _fail_recast : RuleI(Spells, AI_SpellCastFinishedFailRecast);
+	AISpellVar.engaged_no_sp_recast_min = (_engaged_no_sp_recast_min) ? _engaged_no_sp_recast_min : RuleI(Spells, AI_EngagedNoSpellMinRecast);
+	AISpellVar.engaged_no_sp_recast_max = (_engaged_no_sp_recast_max) ? _engaged_no_sp_recast_max : RuleI(Spells, AI_EngagedNoSpellMaxRecast);
+	AISpellVar.engaged_beneficial_self_chance = (_engaged_beneficial_self_chance) ? _engaged_beneficial_self_chance : RuleI(Spells, AI_EngagedBeneficialSelfChance);
+	AISpellVar.engaged_beneficial_other_chance = (_engaged_beneficial_other_chance) ? _engaged_beneficial_other_chance : RuleI(Spells, AI_EngagedBeneficialOtherChance);
+	AISpellVar.engaged_detrimental_chance = (_engaged_detrimental_chance) ? _engaged_detrimental_chance : RuleI(Spells, AI_EngagedDetrimentalChance);
+	AISpellVar.pursue_no_sp_recast_min = (_pursue_no_sp_recast_min) ? _pursue_no_sp_recast_min : RuleI(Spells, AI_PursueNoSpellMinRecast);
+	AISpellVar.pursue_no_sp_recast_max = (_pursue_no_sp_recast_max) ? _pursue_no_sp_recast_max : RuleI(Spells, AI_PursueNoSpellMaxRecast);
+	AISpellVar.pursue_detrimental_chance = (_pursue_detrimental_chance) ? _pursue_detrimental_chance : RuleI(Spells, AI_PursueDetrimentalChance);
+	AISpellVar.idle_no_sp_recast_min = (_idle_no_sp_recast_min) ? _idle_no_sp_recast_min : RuleI(Spells, AI_IdleNoSpellMinRecast);
+	AISpellVar.idle_no_sp_recast_max = (_idle_no_sp_recast_max) ? _idle_no_sp_recast_max : RuleI(Spells, AI_IdleNoSpellMaxRecast);
+	AISpellVar.idle_beneficial_chance = (_idle_beneficial_chance) ? _idle_beneficial_chance : RuleI(Spells, AI_IdleBeneficialChance);
+
+	if (AIBotSpells.empty())
+		AIautocastspell_timer->Disable();
+	else
+		AIautocastspell_timer->Trigger();
+	return true;
+}
+
+void Bot::AddSpellToBotList(int16 iPriority, uint16 iSpellID, uint32 iType, int16 iManaCost, int32 iRecastDelay, int16 iResistAdjust, int8 min_hp, int8 max_hp)
+{
+
+	if(!IsValidSpell(iSpellID))
+		return;
+
+	HasAISpell = true;
+	AIBotSpells_Struct t;
+
+	t.priority = iPriority;
+	t.spellid = iSpellID;
+	t.type = iType;
+	t.manacost = iManaCost;
+	t.recast_delay = iRecastDelay;
+	t.time_cancast = 0;
+	t.resist_adjust = iResistAdjust;
+	t.min_hp = min_hp;
+	t.max_hp = max_hp;
+
+	AIBotSpells.push_back(t);
+
+	// If we're going from an empty list, we need to start the timer
+	if (AIBotSpells.size() == 1)
+		AIautocastspell_timer->Start(RandomTimer(0, 300), false);
+}
+
+bool Bot::IsSpellInBotList(DBBotSpells_Struct* spell_list, uint16 iSpellID) {
+	auto it = std::find_if(spell_list->entries.begin(), spell_list->entries.end(),
+			       [iSpellID](const DBBotSpells_Entries_Struct &a) { return a.spellid == iSpellID; });
+	return it != spell_list->entries.end();
 }
 
 #endif

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -1878,6 +1878,10 @@ bool Zone::Depop(bool StartSpawnTimer) {
 	// clear spell cache
 	database.ClearNPCSpells();
 
+#ifdef BOTS
+	database.ClearBotSpells();
+#endif
+
 	zone->spawn_group_list.ReloadSpawnGroups();
 
 	return true;

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -107,6 +107,46 @@ struct DBnpcspellseffects_Struct {
 	DBnpcspellseffects_entries_Struct entries[0];
 };
 
+#ifdef BOTS
+#pragma pack(1)
+struct DBBotSpells_Entries_Struct {
+	uint16		spellid;
+	uint8		minlevel;
+	uint8		maxlevel;
+	uint32		type;
+	int16		manacost;
+	int16		priority;
+	int32		recast_delay;
+	int16		resist_adjust;
+	int8		min_hp;
+	int8		max_hp;
+};
+#pragma pack()
+
+struct DBBotSpells_Struct {
+	uint32	parent_list;
+	uint16	attack_proc;
+	uint8	proc_chance;
+	uint16	range_proc;
+	int16	rproc_chance;
+	uint16	defensive_proc;
+	int16	dproc_chance;
+	uint32	fail_recast;
+	uint32	engaged_no_sp_recast_min;
+	uint32	engaged_no_sp_recast_max;
+	uint8	engaged_beneficial_self_chance;
+	uint8	engaged_beneficial_other_chance;
+	uint8	engaged_detrimental_chance;
+	uint32  pursue_no_sp_recast_min;
+	uint32  pursue_no_sp_recast_max;
+	uint8   pursue_detrimental_chance;
+	uint32  idle_no_sp_recast_min;
+	uint32  idle_no_sp_recast_max;
+	uint8	idle_beneficial_chance;
+	std::vector<DBBotSpells_Entries_Struct> entries;
+};
+#endif
+
 struct DBTradeskillRecipe_Struct {
 	EQ::skills::SkillType tradeskill;
 	int16 skill_needed;
@@ -491,6 +531,12 @@ public:
 	void ClearNPCSpells() { npc_spells_cache.clear(); npc_spells_loadtried.clear(); }
 	const NPCType* LoadNPCTypesData(uint32 id, bool bulk_load = false);
 
+#ifdef BOTS
+	/* BOTS */
+	DBBotSpells_Struct*				GetBotSpells(uint32 iDBSpellsID);
+	void ClearBotSpells() { bot_spells_cache.clear(); bot_spells_loadtried.clear(); }
+#endif
+
 	/* Mercs   */
 	const	NPCType*	GetMercType(uint32 id, uint16 raceid, uint32 clientlevel);
 	void	LoadMercEquipment(Merc *merc);
@@ -595,6 +641,10 @@ protected:
 	std::unordered_set<uint32> npc_spells_loadtried;
 	DBnpcspellseffects_Struct** npc_spellseffects_cache;
 	bool*				npc_spellseffects_loadtried;
+#ifdef BOTS
+	std::unordered_map<uint32, DBBotSpells_Struct> bot_spells_cache;
+	std::unordered_set<uint32> bot_spells_loadtried;
+#endif
 };
 
 extern ZoneDatabase database;


### PR DESCRIPTION
In preparation for adding Data Bucket support to bot_spells_entries I'm splitting off shared functions that Bots currently share with NPCs.

