### PR TITLE
[Crash] Stability Fixes

### DIFF
--- a/common/zone_store.cpp
+++ b/common/zone_store.cpp
@@ -196,6 +196,19 @@ ZoneRepository::Zone *ZoneStore::GetZone(const char *in_zone_name)
 	return nullptr;
 }
 
+ZoneRepository::Zone *ZoneStore::GetZone(std::string in_zone_name)
+{
+	for (auto &z: m_zones) {
+		if (z.short_name == in_zone_name) {
+			return &z;
+		}
+	}
+
+	LogInfo("[GetZone] Failed to get zone by zone_name (std::string) [{}]", in_zone_name);
+
+	return nullptr;
+}
+
 const std::vector<ZoneRepository::Zone> &ZoneStore::GetZones() const
 {
 	return m_zones;

--- a/common/zone_store.cpp
+++ b/common/zone_store.cpp
@@ -182,8 +182,6 @@ ZoneRepository::Zone *ZoneStore::GetZone(std::string in_zone_name)
 		}
 	}
 
-	LogInfo("[GetZone] Failed to get zone by zone_name (std::string) [{}]", in_zone_name);
-
 	return nullptr;
 }
 

--- a/common/zone_store.cpp
+++ b/common/zone_store.cpp
@@ -82,22 +82,6 @@ const char *ZoneStore::GetZoneName(uint32 zone_id, bool error_unknown)
 		return "UNKNOWN";
 	}
 
-	LogInfo(
-		"[GetZoneName] Failed to get zone name by zone_id [{}] error_unknown [{}] printing stack",
-		zone_id,
-		(error_unknown ? "true" : "false")
-	);
-
-
-	// print stack when invalid input
-	if (zone_id == 0) {
-		backward::StackTrace st;
-		backward::TraceResolver e = {};
-		st.load_here(32);
-		backward::Printer p;
-		p.print(st);
-	}
-
 	return nullptr;
 }
 
@@ -117,12 +101,6 @@ const char *ZoneStore::GetZoneLongName(uint32 zone_id, bool error_unknown)
 	if (error_unknown) {
 		return "UNKNOWN";
 	}
-
-	LogInfo(
-		"[GetZoneLongName] Failed to get zone long name by zone_id [{}] error_unknown [{}]",
-		zone_id,
-		(error_unknown ? "true" : "false")
-	);
 
 	return nullptr;
 }

--- a/common/zone_store.h
+++ b/common/zone_store.h
@@ -35,6 +35,7 @@ public:
 
 	ZoneRepository::Zone *GetZone(uint32 zone_id, int version = 0);
 	ZoneRepository::Zone *GetZone(const char *in_zone_name);
+	ZoneRepository::Zone *GetZone(std::string in_zone_name);
 	uint32 GetZoneID(const char *in_zone_name);
 	uint32 GetZoneID(std::string zone_name);
 	std::string GetZoneName(uint32 zone_id);

--- a/world/cli/test.cpp
+++ b/world/cli/test.cpp
@@ -8,5 +8,14 @@ void WorldserverCLI::TestCommand(int argc, char **argv, argh::parser &cmd, std::
 		return;
 	}
 
-	zone_store.GetZoneName(0, false);
+	zone_store.LoadZones(database);
+
+	const char* zonename = ZoneName(0);
+	if (zonename == 0) {
+		LogInfo("Zone name is 0");
+	}
+	if (zonename == nullptr) {
+		LogInfo("Zone name is nullptr");
+	}
+
 }

--- a/world/clientlist.cpp
+++ b/world/clientlist.cpp
@@ -611,6 +611,7 @@ void ClientList::SendWhoAll(uint32 fromid,const char* to, int16 admin, Who_All_S
 		// if zone is not valid, advance
 		if (countcle->zone() == 0) {
 			countclients.Advance();
+			continue;
 		}
 
 		const char* tmpZone = ZoneName(countcle->zone());
@@ -693,7 +694,14 @@ void ClientList::SendWhoAll(uint32 fromid,const char* to, int16 admin, Who_All_S
 	while(iterator.MoreElements()) {
 		cle = iterator.GetData();
 
+		// if zone is not valid, advance
+		if (cle->zone() == 0) {
+			iterator.Advance();
+			continue;
+		}
+
 		const char* tmpZone = ZoneName(cle->zone());
+
 		if (
 	(cle->Online() >= CLE_Status::Zoning) &&
 	(!cle->GetGM() || cle->Anon() != 1 || admin >= cle->Admin()) &&
@@ -1076,6 +1084,13 @@ void ClientList::ConsoleSendWhoAll(const char* to, int16 admin, Who_All_Struct* 
 	iterator.Reset();
 	while (iterator.MoreElements()) {
 		cle = iterator.GetData();
+
+		// if zone is not valid, advance
+		if (cle->zone() == 0) {
+			iterator.Advance();
+			continue;
+		}
+
 		const char* tmpZone = ZoneName(cle->zone());
 		if (
 			(cle->Online() >= CLE_Status::Zoning)

--- a/world/clientlist.cpp
+++ b/world/clientlist.cpp
@@ -607,7 +607,6 @@ void ClientList::SendWhoAll(uint32 fromid,const char* to, int16 admin, Who_All_S
 	countclients.Reset();
 	while(countclients.MoreElements()){
 		countcle = countclients.GetData();
-
 		const char* tmpZone = ZoneName(countcle->zone());
 		if (
 	(countcle->Online() >= CLE_Status::Zoning) &&
@@ -687,7 +686,6 @@ void ClientList::SendWhoAll(uint32 fromid,const char* to, int16 admin, Who_All_S
 	int idx=-1;
 	while(iterator.MoreElements()) {
 		cle = iterator.GetData();
-
 		const char* tmpZone = ZoneName(cle->zone());
 
 		if (
@@ -1072,7 +1070,6 @@ void ClientList::ConsoleSendWhoAll(const char* to, int16 admin, Who_All_Struct* 
 	iterator.Reset();
 	while (iterator.MoreElements()) {
 		cle = iterator.GetData();
-
 		const char* tmpZone = ZoneName(cle->zone());
 		if (
 			(cle->Online() >= CLE_Status::Zoning)

--- a/world/clientlist.cpp
+++ b/world/clientlist.cpp
@@ -608,12 +608,6 @@ void ClientList::SendWhoAll(uint32 fromid,const char* to, int16 admin, Who_All_S
 	while(countclients.MoreElements()){
 		countcle = countclients.GetData();
 
-		// if zone is not valid, advance
-		if (countcle->zone() == 0) {
-			countclients.Advance();
-			continue;
-		}
-
 		const char* tmpZone = ZoneName(countcle->zone());
 		if (
 	(countcle->Online() >= CLE_Status::Zoning) &&
@@ -693,12 +687,6 @@ void ClientList::SendWhoAll(uint32 fromid,const char* to, int16 admin, Who_All_S
 	int idx=-1;
 	while(iterator.MoreElements()) {
 		cle = iterator.GetData();
-
-		// if zone is not valid, advance
-		if (cle->zone() == 0) {
-			iterator.Advance();
-			continue;
-		}
 
 		const char* tmpZone = ZoneName(cle->zone());
 
@@ -1084,12 +1072,6 @@ void ClientList::ConsoleSendWhoAll(const char* to, int16 admin, Who_All_Struct* 
 	iterator.Reset();
 	while (iterator.MoreElements()) {
 		cle = iterator.GetData();
-
-		// if zone is not valid, advance
-		if (cle->zone() == 0) {
-			iterator.Advance();
-			continue;
-		}
 
 		const char* tmpZone = ZoneName(cle->zone());
 		if (

--- a/world/clientlist.cpp
+++ b/world/clientlist.cpp
@@ -607,6 +607,12 @@ void ClientList::SendWhoAll(uint32 fromid,const char* to, int16 admin, Who_All_S
 	countclients.Reset();
 	while(countclients.MoreElements()){
 		countcle = countclients.GetData();
+
+		// if zone is not valid, advance
+		if (countcle->zone() == 0) {
+			countclients.Advance();
+		}
+
 		const char* tmpZone = ZoneName(countcle->zone());
 		if (
 	(countcle->Online() >= CLE_Status::Zoning) &&

--- a/zone/gm_commands/zone.cpp
+++ b/zone/gm_commands/zone.cpp
@@ -10,15 +10,12 @@ void command_zone(Client *c, const Seperator *sep)
 
 	// input: (first arg)
 	// zone identifier can be a string of a zone name or its ID
-	std::string zone_identifier = sep->arg[1];
+	std::string zone_input = sep->arg[1];
+	uint32      zone_id    = 0;
 
-	// zone can be name or id, based on input
-	std::string zone_name;
-	uint32      zone_id = 0;
-	
 	// if input is id
-	if (Strings::IsNumber(zone_identifier)) {
-		zone_id = std::stoi(zone_identifier);
+	if (Strings::IsNumber(zone_input)) {
+		zone_id = std::stoi(zone_input);
 
 		// validate
 		if (!GetZone(zone_id)) {
@@ -27,24 +24,22 @@ void command_zone(Client *c, const Seperator *sep)
 		}
 	}
 	else {
-		zone_name = fmt::format("{}", zone_identifier);
-
 		// validate
-		if (!zone_store.GetZone(zone_name)) {
-			c->Message(Chat::White, fmt::format("Could not find zone by short_name [{}]", zone_name).c_str());
+		if (!zone_store.GetZone(zone_input)) {
+			c->Message(Chat::White, fmt::format("Could not find zone by short_name [{}]", zone_input).c_str());
 			return;
 		}
 
 		// validate we got id
-		zone_id = ZoneID(zone_name);
+		zone_id = ZoneID(zone_input);
 		if (zone_id == 0) {
-			c->Message(Chat::White, fmt::format("Could not find zone id by short_name [{}]", zone_name).c_str());
+			c->Message(Chat::White, fmt::format("Could not find zone id by short_name [{}]", zone_input).c_str());
 			return;
 		}
 	}
 
 	// if zone identifier is a number and the id is 0, send to safe coordinates of the local zone
-	if (Strings::IsNumber(zone_identifier) && zone_id == 0) {
+	if (Strings::IsNumber(zone_input) && zone_id == 0) {
 		c->Message(Chat::White, "Sending you to the safe coordinates of this zone.");
 
 		c->MovePC(


### PR DESCRIPTION
This PR addresses a few things from working with operators to get their servers fixed

* #zone command has extra validation to no longer crash on bad inputs. Also keeps zone from sending bad zone requests to world
* Zone store log helpers no longer print warnings that have become noise, making operators think there is a problem when certain logic safely uses some of the cases
* Remove stack trace debugging for zone store methods

![image](https://user-images.githubusercontent.com/3319450/196005255-fd7e7d79-2247-455d-91df-7cf92ffa3a93.png)
