### PR TITLE
[Bots] Cleanup Bot Spell Functions, reduce reliance on NPC Functions/Attributes

### DIFF
--- a/common/emu_constants.h
+++ b/common/emu_constants.h
@@ -217,6 +217,25 @@ namespace EQ
 			stanceBurnAE
 		};
 
+		enum BotSpellIDs : int {
+			Warrior = 3001,
+			Cleric,
+			Paladin,
+			Ranger,
+			Shadowknight,
+			Druid,
+			Monk,
+			Bard,
+			Rogue,
+			Shaman,
+			Necromancer,
+			Wizard,
+			Magician,
+			Enchanter,
+			Beastlord,
+			Berserker
+		};
+
 		enum GravityBehavior : int8 {
 			Ground,
 			Flying,

--- a/common/eqemu_logsys_log_aliases.h
+++ b/common/eqemu_logsys_log_aliases.h
@@ -38,6 +38,11 @@
         OutF(LogSys, Logs::General, Logs::AI, __FILE__, __func__, __LINE__, message, ##__VA_ARGS__);\
 } while (0)
 
+#define LogAIModerate(message, ...) do {\
+    if (LogSys.IsLogEnabled(Logs::General, Logs::AI))\
+        OutF(LogSys, Logs::Moderate, Logs::AI, __FILE__, __func__, __LINE__, message, ##__VA_ARGS__);\
+} while (0)
+
 #define LogAIDetail(message, ...) do {\
     if (LogSys.IsLogEnabled(Logs::Detail, Logs::AI))\
         OutF(LogSys, Logs::Detail, Logs::AI, __FILE__, __func__, __LINE__, message, ##__VA_ARGS__);\

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -843,7 +843,7 @@ void Bot::GenerateBaseStats()
 	int32 CorruptionResist = _baseCorrup;
 
 	// pulling fixed values from an auto-increment field is dangerous...
-	switch(GetClass()) {
+	switch (GetClass()) {
 		case WARRIOR:
 			BotSpellID = 3001;
 			Strength += 10;
@@ -2300,7 +2300,7 @@ void Bot::BotRangedAttack(Mob* other) {
 	if (spellbonuses.NegateIfCombat)
 		BuffFadeByEffect(SE_NegateIfCombat);
 
-	if(hidden || improved_hidden) {
+	if (hidden || improved_hidden) {
 		hidden = false;
 		improved_hidden = false;
 		EQApplicationPacket* outapp = new EQApplicationPacket(OP_SpawnAppearance, sizeof(SpawnAppearance_Struct));
@@ -6471,9 +6471,9 @@ void Bot::DoClassAttacks(Mob *target, bool IsRiposte) {
 		return;
 	}
 
-	if(ka_time) {
+	if (ka_time) {
 
-		switch(GetClass()) {
+		switch (GetClass()) {
 			case SHADOWKNIGHT: {
 				CastSpell(SPELL_NPC_HARM_TOUCH, target->GetID());
 				knightattack_timer.Start(HarmTouchReuseTime * 1000);
@@ -6571,9 +6571,9 @@ void Bot::DoClassAttacks(Mob *target, bool IsRiposte) {
 	int level = GetLevel();
 	int reuse = (TauntReuseTime * 1000);
 	bool did_attack = false;
-	switch(GetClass()) {
+	switch (GetClass()) {
 		case WARRIOR:
-			if(level >= RuleI(Combat, NPCBashKickLevel)) {
+			if (level >= RuleI(Combat, NPCBashKickLevel)) {
 				bool canBash = false;
 				if ((GetRace() == OGRE || GetRace() == TROLL || GetRace() == BARBARIAN) || (m_inv.GetItem(EQ::invslot::slotSecondary) && m_inv.GetItem(EQ::invslot::slotSecondary)->GetItem()->ItemType == EQ::item::ItemTypeShield) || (m_inv.GetItem(EQ::invslot::slotPrimary) && m_inv.GetItem(EQ::invslot::slotPrimary)->GetItem()->IsType2HWeapon() && GetAA(aa2HandBash) >= 1))
 					canBash = true;
@@ -6593,7 +6593,7 @@ void Bot::DoClassAttacks(Mob *target, bool IsRiposte) {
 		case CLERIC:
 		case SHADOWKNIGHT:
 		case PALADIN:
-			if(level >= RuleI(Combat, NPCBashKickLevel)) {
+			if (level >= RuleI(Combat, NPCBashKickLevel)) {
 				if ((GetRace() == OGRE || GetRace() == TROLL || GetRace() == BARBARIAN) || (m_inv.GetItem(EQ::invslot::slotSecondary) && m_inv.GetItem(EQ::invslot::slotSecondary)->GetItem()->ItemType == EQ::item::ItemTypeShield) || (m_inv.GetItem(EQ::invslot::slotPrimary) && m_inv.GetItem(EQ::invslot::slotPrimary)->GetItem()->IsType2HWeapon() && GetAA(aa2HandBash) >= 1))
 					skill_to_use = EQ::skills::SkillBash;
 			}
@@ -7483,7 +7483,7 @@ bool Bot::CastSpell(uint16 spell_id, uint16 target_id, EQ::spells::CastingSlot s
 			}
 		}
 
-		if(IsDetrimentalSpell(spell_id) && !zone->CanDoCombat()) {
+		if (IsDetrimentalSpell(spell_id) && !zone->CanDoCombat()) {
 			MessageString(Chat::White, SPELL_WOULDNT_HOLD);
 			if(casting_spell_id)
 				AI_Bot_Event_SpellCastFinished(false, static_cast<uint16>(casting_spell_slot));
@@ -7774,7 +7774,7 @@ bool Bot::DoFinishedSpellSingleTarget(uint16 spell_id, Mob* spellTarget, EQ::spe
 		if(IsGrouped() && (spellTarget->IsBot() || spellTarget->IsClient()) && RuleB(Bots, GroupBuffing)) {
 			bool noGroupSpell = false;
 			uint16 thespell = spell_id;
-			for(int i = 0; i < AIBot_spells.size(); i++) {
+			for (int i = 0; i < AIBot_spells.size(); i++) {
 				int j = BotGetSpells(i);
 				int spelltype = BotGetSpellType(i);
 				bool spellequal = (j == thespell);
@@ -8319,7 +8319,7 @@ int64 Bot::CalcManaRegen() {
 
 uint64 Bot::GetClassHPFactor() {
 	uint32 factor;
-	switch(GetClass()) {
+	switch (GetClass()) {
 		case BEASTLORD:
 		case BERSERKER:
 		case MONK:

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -2178,7 +2178,7 @@ void Bot::AI_Bot_Start(uint32 iMoveDelay) {
 	if (!pAIControlled)
 		return;
 
-	if (AIspells.empty()) {
+	if (AIBot_spells.empty()) {
 		AIautocastspell_timer = std::make_unique<Timer>(1000);
 		AIautocastspell_timer->Disable();
 	} else {
@@ -2199,7 +2199,7 @@ void Bot::AI_Bot_Start(uint32 iMoveDelay) {
 void Bot::AI_Bot_Init()
 {
 	AIautocastspell_timer.reset(nullptr);
-	casting_spell_AIindex = static_cast<uint8>(AIspells.size());
+	casting_spell_AIindex = static_cast<uint8>(AIBot_spells.size());
 
 	roambox_max_x = 0;
 	roambox_max_y = 0;
@@ -7773,7 +7773,7 @@ bool Bot::DoFinishedSpellSingleTarget(uint16 spell_id, Mob* spellTarget, EQ::spe
 		if(IsGrouped() && (spellTarget->IsBot() || spellTarget->IsClient()) && RuleB(Bots, GroupBuffing)) {
 			bool noGroupSpell = false;
 			uint16 thespell = spell_id;
-			for(int i = 0; i < AIspells.size(); i++) {
+			for(int i = 0; i < AIBot_spells.size(); i++) {
 				int j = BotGetSpells(i);
 				int spelltype = BotGetSpellType(i);
 				bool spellequal = (j == thespell);

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -9235,7 +9235,7 @@ void Bot::CalcBotStats(bool showtext) {
 
 	CalcBonuses();
 
-	AI_AddNPCSpells(GetBotSpellID());
+	AI_AddBotSpells(GetBotSpellID());
 
 	if(showtext) {
 		GetBotOwner()->Message(Chat::Yellow, "%s has been updated.", GetCleanName());

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -2175,8 +2175,9 @@ bool Bot::Process()
 
 void Bot::AI_Bot_Start(uint32 iMoveDelay) {
 	Mob::AI_Start(iMoveDelay);
-	if (!pAIControlled)
+	if (!pAIControlled) {
 		return;
+	}
 
 	if (AIBot_spells.empty()) {
 		AIautocastspell_timer = std::make_unique<Timer>(1000);
@@ -2299,7 +2300,7 @@ void Bot::BotRangedAttack(Mob* other) {
 	if (spellbonuses.NegateIfCombat)
 		BuffFadeByEffect(SE_NegateIfCombat);
 
-	if(hidden || improved_hidden){
+	if(hidden || improved_hidden) {
 		hidden = false;
 		improved_hidden = false;
 		EQApplicationPacket* outapp = new EQApplicationPacket(OP_SpawnAppearance, sizeof(SpawnAppearance_Struct));
@@ -5201,7 +5202,7 @@ bool Bot::Attack(Mob* other, int Hand, bool FromRiposte, bool IsStrikethrough, b
 #endif
 		//Live AA - Sinister Strikes *Adds weapon damage bonus to offhand weapon.
 		if (Hand == EQ::invslot::slotSecondary) {
-			if (aabonuses.SecondaryDmgInc || itembonuses.SecondaryDmgInc || spellbonuses.SecondaryDmgInc){
+			if (aabonuses.SecondaryDmgInc || itembonuses.SecondaryDmgInc || spellbonuses.SecondaryDmgInc) {
 				ucDamageBonus = GetWeaponDamageBonus(weapon ? weapon->GetItem() : (const EQ::ItemData*) nullptr);
 				my_hit.min_damage = ucDamageBonus;
 				hate += ucDamageBonus;
@@ -6470,9 +6471,9 @@ void Bot::DoClassAttacks(Mob *target, bool IsRiposte) {
 		return;
 	}
 
-	if(ka_time){
+	if(ka_time) {
 
-		switch(GetClass()){
+		switch(GetClass()) {
 			case SHADOWKNIGHT: {
 				CastSpell(SPELL_NPC_HARM_TOUCH, target->GetID());
 				knightattack_timer.Start(HarmTouchReuseTime * 1000);
@@ -6572,7 +6573,7 @@ void Bot::DoClassAttacks(Mob *target, bool IsRiposte) {
 	bool did_attack = false;
 	switch(GetClass()) {
 		case WARRIOR:
-			if(level >= RuleI(Combat, NPCBashKickLevel)){
+			if(level >= RuleI(Combat, NPCBashKickLevel)) {
 				bool canBash = false;
 				if ((GetRace() == OGRE || GetRace() == TROLL || GetRace() == BARBARIAN) || (m_inv.GetItem(EQ::invslot::slotSecondary) && m_inv.GetItem(EQ::invslot::slotSecondary)->GetItem()->ItemType == EQ::item::ItemTypeShield) || (m_inv.GetItem(EQ::invslot::slotPrimary) && m_inv.GetItem(EQ::invslot::slotPrimary)->GetItem()->IsType2HWeapon() && GetAA(aa2HandBash) >= 1))
 					canBash = true;
@@ -6592,7 +6593,7 @@ void Bot::DoClassAttacks(Mob *target, bool IsRiposte) {
 		case CLERIC:
 		case SHADOWKNIGHT:
 		case PALADIN:
-			if(level >= RuleI(Combat, NPCBashKickLevel)){
+			if(level >= RuleI(Combat, NPCBashKickLevel)) {
 				if ((GetRace() == OGRE || GetRace() == TROLL || GetRace() == BARBARIAN) || (m_inv.GetItem(EQ::invslot::slotSecondary) && m_inv.GetItem(EQ::invslot::slotSecondary)->GetItem()->ItemType == EQ::item::ItemTypeShield) || (m_inv.GetItem(EQ::invslot::slotPrimary) && m_inv.GetItem(EQ::invslot::slotPrimary)->GetItem()->IsType2HWeapon() && GetAA(aa2HandBash) >= 1))
 					skill_to_use = EQ::skills::SkillBash;
 			}
@@ -7046,7 +7047,7 @@ int64 Bot::GetActSpellDamage(uint16 spell_id, int64 value, Mob* target) {
 		}
 
 		else if (GetClass() == WIZARD || (IsMerc() && GetClass() == CASTERDPS)) {
-			if ((GetLevel() >= RuleI(Spells, WizCritLevel)) && zone->random.Roll(RuleI(Spells, WizCritChance))){
+			if ((GetLevel() >= RuleI(Spells, WizCritLevel)) && zone->random.Roll(RuleI(Spells, WizCritChance))) {
 				//Wizard innate critical chance is calculated seperately from spell effect and is not a set ratio. (20-70 is parse confirmed)
 				ratio += zone->random.Int(20,70);
 				Critical = true;
@@ -7482,7 +7483,7 @@ bool Bot::CastSpell(uint16 spell_id, uint16 target_id, EQ::spells::CastingSlot s
 			}
 		}
 
-		if(IsDetrimentalSpell(spell_id) && !zone->CanDoCombat()){
+		if(IsDetrimentalSpell(spell_id) && !zone->CanDoCombat()) {
 			MessageString(Chat::White, SPELL_WOULDNT_HOLD);
 			if(casting_spell_id)
 				AI_Bot_Event_SpellCastFinished(false, static_cast<uint16>(casting_spell_slot));
@@ -7873,7 +7874,7 @@ void Bot::CalcBonuses() {
 	end_regen = CalcEnduranceRegen();
 }
 
-int64 Bot::CalcHPRegenCap(){
+int64 Bot::CalcHPRegenCap() {
 	int level = GetLevel();
 	int64 hpregen_cap = 0;
 	hpregen_cap = (RuleI(Character, ItemHealthRegenCap) + itembonuses.HeroicSTA / 25);
@@ -7881,7 +7882,7 @@ int64 Bot::CalcHPRegenCap(){
 	return (hpregen_cap * RuleI(Character, HPRegenMultiplier) / 100);
 }
 
-int64 Bot::CalcManaRegenCap(){
+int64 Bot::CalcManaRegenCap() {
 	int64 cap = RuleI(Character, ItemManaRegenCap) + aabonuses.ItemManaRegenCap;
 	switch(GetCasterClass()) {
 		case 'I':
@@ -9141,7 +9142,7 @@ void Bot::AddItemBonuses(const EQ::ItemInstance *inst, StatBonuses* newbon, bool
 		}
 	}
 
-	if (item->SkillModValue != 0 && item->SkillModType <= EQ::skills::HIGHEST_SKILL){
+	if (item->SkillModValue != 0 && item->SkillModType <= EQ::skills::HIGHEST_SKILL) {
 		if ((item->SkillModValue > 0 && newbon->skillmod[item->SkillModType] < item->SkillModValue) ||
 			(item->SkillModValue < 0 && newbon->skillmod[item->SkillModType] > item->SkillModValue))
 		{

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -749,7 +749,7 @@ private:
 	static uint8 spell_casting_chances[SPELL_TYPE_COUNT][PLAYER_CLASS_COUNT][EQ::constants::STANCE_TYPE_COUNT][cntHSND];
 };
 
-bool IsSpellInBotList(DBnpcspells_Struct* spell_list, uint16 iSpellID);
+bool IsSpellInBotList(DBbotspells_Struct* spell_list, uint16 iSpellID);
 
 #endif // BOTS
 

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -220,7 +220,7 @@ public:
 	virtual void AddToHateList(Mob* other, int64 hate = 0, int64 damage = 0, bool iYellForHelp = true, bool bFrenzy = false, bool iBuffTic = false, bool pet_command = false);
 	virtual void SetTarget(Mob* mob);
 	virtual void Zone();
-	std::vector<AISpells_Struct> GetBotSpells() { return AIspells; }
+	std::vector<AISpells_Struct> GetAIBotSpells() { return AIspells; }
 	bool IsArcheryRange(Mob* target);
 	void ChangeBotArcherWeapons(bool isArcher);
 	void Sit();
@@ -308,6 +308,9 @@ public:
 	void DoEnduranceRegen();	//This Regenerates endurance
 	void DoEnduranceUpkeep();	//does the endurance upkeep
 
+	bool AI_AddBotSpells(uint32 iDBSpellsID);
+	void AddSpellToBotList(int16 iPriority, uint16 iSpellID, uint32 iType, int16 iManaCost, int32 iRecastDelay, int16 iResistAdjust, int8 min_hp, int8 max_hp);
+	void AI_Bot_Event_SpellCastFinished(bool iCastSucceeded, uint16 slot);
 	// AI Methods
 	virtual bool AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes);
 	virtual bool AI_EngagedCastCheck();
@@ -320,6 +323,10 @@ public:
 	void SetStopMeleeLevel(uint8 level);
 	void SetGuardMode();
 	void SetHoldMode();
+
+	// Bot AI Methods
+	void AI_Bot_Init();
+	void AI_Bot_Start(uint32 iMoveDelay = 0);
 
 	// Mob AI Virtual Override Methods
 	virtual void AI_Process();

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -749,6 +749,8 @@ private:
 	static uint8 spell_casting_chances[SPELL_TYPE_COUNT][PLAYER_CLASS_COUNT][EQ::constants::STANCE_TYPE_COUNT][cntHSND];
 };
 
+bool IsSpellInBotList(DBnpcspells_Struct* spell_list, uint16 iSpellID);
+
 #endif // BOTS
 
 #endif // BOT_H

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -174,9 +174,9 @@ public:
 	virtual bool Save();
 	virtual void Depop();
 	void CalcBotStats(bool showtext = true);
-	uint16 BotGetSpells(int spellslot) { return AIspells[spellslot].spellid; }
-	uint32 BotGetSpellType(int spellslot) { return AIspells[spellslot].type; }
-	uint16 BotGetSpellPriority(int spellslot) { return AIspells[spellslot].priority; }
+	uint16 BotGetSpells(int spellslot) { return AIBot_spells[spellslot].spellid; }
+	uint32 BotGetSpellType(int spellslot) { return AIBot_spells[spellslot].type; }
+	uint16 BotGetSpellPriority(int spellslot) { return AIBot_spells[spellslot].priority; }
 	virtual float GetProcChances(float ProcBonus, uint16 hand);
 	virtual int GetHandToHandDamage(void);
 	virtual bool TryFinishingBlow(Mob *defender, int64 &damage);
@@ -220,7 +220,6 @@ public:
 	virtual void AddToHateList(Mob* other, int64 hate = 0, int64 damage = 0, bool iYellForHelp = true, bool bFrenzy = false, bool iBuffTic = false, bool pet_command = false);
 	virtual void SetTarget(Mob* mob);
 	virtual void Zone();
-	std::vector<AISpells_Struct> GetAIBotSpells() { return AIspells; }
 	bool IsArcheryRange(Mob* target);
 	void ChangeBotArcherWeapons(bool isArcher);
 	void Sit();
@@ -644,7 +643,6 @@ private:
 	// Class Members
 	uint32 _botID;
 	uint32 _botOwnerCharacterID;
-	//uint32 _botSpellID;
 	bool _spawnStatus;
 	Mob* _botOwner;
 	bool _botOrderAttack;

--- a/zone/botspellsai.cpp
+++ b/zone/botspellsai.cpp
@@ -2955,7 +2955,7 @@ DBbotspells_Struct *ZoneDatabase::GetBotSpells(uint32 iDBSpellsID)
 		}
 
 		Bot_Spells_Cache.insert(std::make_pair(iDBSpellsID, spell_set));
-		
+
 		return &Bot_Spells_Cache[iDBSpellsID];
     }
 

--- a/zone/botspellsai.cpp
+++ b/zone/botspellsai.cpp
@@ -39,7 +39,7 @@ bool Bot::AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes) {
 		return false;
 
 	if (iChance < 100) {
-		if (zone->random.Int(0, 100) > iChance){
+		if (zone->random.Int(0, 100) > iChance) {
 			return false;
 		}
 	}
@@ -87,13 +87,14 @@ bool Bot::AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes) {
 
 				Mob* addMob = GetFirstIncomingMobToMez(this, botSpell);
 
-				if(!addMob){
+				if(!addMob) {
 					//Say("!addMob.");
-					break;}
-
-				if(!(!addMob->IsImmuneToSpell(botSpell.SpellId, this) && addMob->CanBuffStack(botSpell.SpellId, botLevel, true) >= 0))
 					break;
+				}
 
+				if(!(!addMob->IsImmuneToSpell(botSpell.SpellId, this) && addMob->CanBuffStack(botSpell.SpellId, botLevel, true) >= 0)) {
+					break;
+				}
 				castedSpell = AIDoSpellCast(botSpell.SpellIndex, addMob, botSpell.ManaCost);
 
 				if(castedSpell)
@@ -135,27 +136,30 @@ bool Bot::AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes) {
 						if(hpr < 35) {
 							botSpell = GetBestBotSpellForFastHeal(this);
 						}
-						else if(hpr >= 35 && hpr < 70){
-							if(GetNumberNeedingHealedInGroup(60, false) >= 3)
+						else if(hpr >= 35 && hpr < 70) {
+							if(GetNumberNeedingHealedInGroup(60, false) >= 3) {
 								botSpell = GetBestBotSpellForGroupHeal(this);
-
-							if(botSpell.SpellId == 0)
+							}
+							if(botSpell.SpellId == 0) {
 								botSpell = GetBestBotSpellForPercentageHeal(this);
+							}
 						}
-						else if(hpr >= 70 && hpr < 95){
-							if(GetNumberNeedingHealedInGroup(80, false) >= 3)
+						else if(hpr >= 70 && hpr < 95) {
+							if(GetNumberNeedingHealedInGroup(80, false) >= 3) {
 								botSpell = GetBestBotSpellForGroupHealOverTime(this);
-
-							if(hasAggro)
+							}
+							if(hasAggro) {
 								botSpell = GetBestBotSpellForPercentageHeal(this);
+							}
 						}
 						else {
-							if(!tar->FindType(SE_HealOverTime))
+							if(!tar->FindType(SE_HealOverTime)) {
 								botSpell = GetBestBotSpellForHealOverTime(this);
+							}
 						}
 					}
 					else if ((botClass == CLERIC) || (botClass == DRUID) || (botClass == SHAMAN) || (botClass == PALADIN)) {
-						if(GetNumberNeedingHealedInGroup(40, true) >= 2){
+						if(GetNumberNeedingHealedInGroup(40, true) >= 2) {
 							botSpell = GetBestBotSpellForGroupCompleteHeal(this);
 
 							if(botSpell.SpellId == 0)
@@ -169,7 +173,7 @@ bool Bot::AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes) {
 									botSpell = GetBestBotSpellForPercentageHeal(this);
 							}
 						}
-						else if(GetNumberNeedingHealedInGroup(60, true) >= 2){
+						else if(GetNumberNeedingHealedInGroup(60, true) >= 2) {
 							botSpell = GetBestBotSpellForGroupHeal(this);
 
 							if(botSpell.SpellId == 0)
@@ -223,7 +227,7 @@ bool Bot::AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes) {
 					if(botSpell.SpellId == 0)
 						botSpell = GetFirstBotSpellForSingleTargetHeal(this);
 
-					if(botSpell.SpellId == 0 && botClass == BARD){
+					if(botSpell.SpellId == 0 && botClass == BARD) {
 						botSpell = GetFirstBotSpellBySpellType(this, SpellType_Heal);
 					}
 
@@ -257,7 +261,7 @@ bool Bot::AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes) {
 							}
 						}*/
 						if(botClass != BARD) {
-							if(IsGroupSpell(botSpell.SpellId)){
+							if(IsGroupSpell(botSpell.SpellId)) {
 								if(HasGroup()) {
 									Group *g = GetGroup();
 
@@ -347,7 +351,7 @@ bool Bot::AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes) {
 					// Put the zone levitate and movement check here since bots are able to bypass the client casting check
 					if((IsEffectInSpell(selectedBotSpell.SpellId, SE_Levitate) && !zone->CanLevitate())
 						|| (IsEffectInSpell(selectedBotSpell.SpellId, SE_MovementSpeed) && !zone->CanCastOutdoor())) {
-							if(botClass != BARD || !IsSpellUsableThisZoneType(selectedBotSpell.SpellId, zone->GetZoneType())){
+							if(botClass != BARD || !IsSpellUsableThisZoneType(selectedBotSpell.SpellId, zone->GetZoneType())) {
 								continue;
 							}
 					}
@@ -926,7 +930,7 @@ bool Bot::AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes) {
 
 				if(castedSpell) {
 					if(botClass != BARD) {
-						if(IsGroupSpell(botSpell.SpellId)){
+						if(IsGroupSpell(botSpell.SpellId)) {
 							Group *g;
 
 							if(HasGroup()) {
@@ -1557,7 +1561,7 @@ bool Bot::AIHealRotation(Mob* tar, bool useFastHeals) {
 		if(botSpell.SpellId == 0)
 			botSpell = GetFirstBotSpellForSingleTargetHeal(this);
 
-		if(botSpell.SpellId == 0){
+		if(botSpell.SpellId == 0) {
 			botSpell = GetFirstBotSpellBySpellType(this, SpellType_Heal);
 		}
 	}
@@ -2674,8 +2678,6 @@ uint8 Bot::GetChanceToCastBySpellType(uint32 spellType)
 	return database.botdb.GetSpellCastingChance(spell_type_index, class_index, stance_index, type_index);
 }
 
-bool IsSpellInBotList(DBnpcspells_Struct* spell_list, uint16 iSpellID);
-
 bool Bot::AI_AddBotSpells(uint32 iDBSpellsID) {
 	// ok, this function should load the list, and the parent list then shove them into the struct and sort
 	npc_spells_id = iDBSpellsID;
@@ -2690,7 +2692,7 @@ bool Bot::AI_AddBotSpells(uint32 iDBSpellsID) {
 		return false;
 	}
 	DBnpcspells_Struct* parentlist = content_db.GetBotSpells(spell_list->parent_list);
-#if MobAI_DEBUG_Spells >= 10
+
 	std::string debug_msg = StringFormat("Loading NPCSpells onto %s: dbspellsid=%u, level=%u", GetName(), iDBSpellsID, GetLevel());
 	if (spell_list) {
 		debug_msg.append(StringFormat(" (found, %u), parentlist=%u", spell_list->entries.size(), spell_list->parent_list));
@@ -2704,24 +2706,22 @@ bool Bot::AI_AddBotSpells(uint32 iDBSpellsID) {
 	else {
 		debug_msg.append(" (not found)");
 	}
-	LogAI("[{}]", debug_msg.c_str());
+	LogAIDetail("[{}]", debug_msg.c_str());
 
-#ifdef MobAI_DEBUG_Spells >= 25
+
 	if (parentlist) {
 		for (const auto &iter : parentlist->entries) {
 			LogAI("([{}]) [{}]", iter.spellid, spells[iter.spellid].name);
 		}
 	}
-	LogAI("fin (parent list)");
+	LogAIModerate("fin (parent list)");
 	if (spell_list) {
 		for (const auto &iter : spell_list->entries) {
-			LogAI("([{}]) [{}]", iter.spellid, spells[iter.spellid].name);
+			LogAIDetail("([{}]) [{}]", iter.spellid, spells[iter.spellid].name);
 		}
 	}
-	LogAI("fin (spell list)");
-#endif
+	LogAIModerate("fin (spell list)");
 
-#endif
 	uint16 attack_proc_spell = -1;
 	int8 proc_chance = 3;
 	uint16 range_proc_spell = -1;
@@ -2816,15 +2816,18 @@ bool Bot::AI_AddBotSpells(uint32 iDBSpellsID) {
 	if (IsValidSpell(attack_proc_spell)) {
 		AddProcToWeapon(attack_proc_spell, true, proc_chance);
 
-		if(RuleB(Spells, NPCInnateProcOverride))
+		if(RuleB(Spells, NPCInnateProcOverride)) { 
 			innate_proc_spell_id = attack_proc_spell;
+		}
 	}
 
-	if (IsValidSpell(range_proc_spell))
+	if (IsValidSpell(range_proc_spell)) {
 		AddRangedProc(range_proc_spell, (rproc_chance + 100));
+	}
 
-	if (IsValidSpell(defensive_proc_spell))
+	if (IsValidSpell(defensive_proc_spell)) {
 		AddDefensiveProc(defensive_proc_spell, (dproc_chance + 100));
+	}
 
 	//Set AI casting variables
 
@@ -2841,10 +2844,11 @@ bool Bot::AI_AddBotSpells(uint32 iDBSpellsID) {
 	AISpellVar.idle_no_sp_recast_max = (_idle_no_sp_recast_max) ? _idle_no_sp_recast_max : RuleI(Spells, AI_IdleNoSpellMaxRecast);
 	AISpellVar.idle_beneficial_chance = (_idle_beneficial_chance) ? _idle_beneficial_chance : RuleI(Spells, AI_IdleBeneficialChance);
 
-	if (AIBot_spells.empty())
+	if (AIBot_spells.empty()) {
 		AIautocastspell_timer->Disable();
-	else
+	} else {
 		AIautocastspell_timer->Trigger();
+	}
 	return true;
 }
 
@@ -2856,8 +2860,9 @@ bool IsSpellInBotList(DBnpcspells_Struct* spell_list, uint16 iSpellID) {
 
 DBnpcspells_Struct *ZoneDatabase::GetBotSpells(uint32 iDBSpellsID)
 {
-	if (iDBSpellsID == 0)
+	if (iDBSpellsID == 0) {
 		return nullptr;
+	}
 
 	auto it = npc_spells_cache.find(iDBSpellsID);
 
@@ -2881,8 +2886,9 @@ DBnpcspells_Struct *ZoneDatabase::GetBotSpells(uint32 iDBSpellsID)
 			return nullptr;
 		}
 
-		if (results.RowCount() != 1)
+		if (results.RowCount() != 1) {
 			return nullptr;
+		}
 
 		auto row = results.begin();
 		DBnpcspells_Struct spell_set;
@@ -2938,11 +2944,12 @@ DBnpcspells_Struct *ZoneDatabase::GetBotSpells(uint32 iDBSpellsID)
 			if (!(entry.type & SPELL_TYPES_INNATE) && entry.priority == 0)
 				entry.priority = 1;
 
-			if (row[9])
+			if (row[9]) {
 				entry.resist_adjust = atoi(row[9]);
-			else if (IsValidSpell(spell_id))
+			}
+			else if (IsValidSpell(spell_id)) {
 				entry.resist_adjust = spells[spell_id].resist_difficulty;
-
+			}
 			spell_set.entries.push_back(entry);
 		}
 
@@ -2959,8 +2966,9 @@ void Bot::AddSpellToBotList(int16 iPriority, uint16 iSpellID, uint32 iType,
 							int16 iManaCost, int32 iRecastDelay, int16 iResistAdjust, int8 min_hp, int8 max_hp)
 {
 
-	if(!IsValidSpell(iSpellID))
+	if(!IsValidSpell(iSpellID)) {
 		return;
+	}
 
 	HasAISpell = true;
 	BotSpells_Struct t;
@@ -2978,8 +2986,9 @@ void Bot::AddSpellToBotList(int16 iPriority, uint16 iSpellID, uint32 iType,
 	AIBot_spells.push_back(t);
 
 	// If we're going from an empty list, we need to start the timer
-	if (AIBot_spells.empty())
+	if (AIBot_spells.empty()) {
 		AIautocastspell_timer->Start(RandomTimer(0, 300), false);
+	}
 }
 
 //this gets called from InterruptSpell() for failure or SpellFinished() for success
@@ -2988,21 +2997,24 @@ void Bot::AI_Bot_Event_SpellCastFinished(bool iCastSucceeded, uint16 slot) {
 		uint32 recovery_time = 0;
 		if (iCastSucceeded) {
 			if (casting_spell_AIindex < AIBot_spells.size()) {
-					recovery_time += spells[AIBot_spells[casting_spell_AIindex].spellid].recovery_time;
-					if (AIBot_spells[casting_spell_AIindex].recast_delay >= 0)
-					{
-						if (AIBot_spells[casting_spell_AIindex].recast_delay < 10000)
-							AIBot_spells[casting_spell_AIindex].time_cancast = Timer::GetCurrentTime() + (AIBot_spells[casting_spell_AIindex].recast_delay*1000);
+				recovery_time += spells[AIBot_spells[casting_spell_AIindex].spellid].recovery_time;
+				if (AIBot_spells[casting_spell_AIindex].recast_delay >= 0) {
+					if (AIBot_spells[casting_spell_AIindex].recast_delay < 10000) {
+						AIBot_spells[casting_spell_AIindex].time_cancast = Timer::GetCurrentTime() + (AIBot_spells[casting_spell_AIindex].recast_delay*1000);
 					}
-					else
-						AIBot_spells[casting_spell_AIindex].time_cancast = Timer::GetCurrentTime() + spells[AIBot_spells[casting_spell_AIindex].spellid].recast_time;
+				}
+				else {
+					AIBot_spells[casting_spell_AIindex].time_cancast = Timer::GetCurrentTime() + spells[AIBot_spells[casting_spell_AIindex].spellid].recast_time;
+				}
 			}
-			if (recovery_time < AIautocastspell_timer->GetSetAtTrigger())
+			if (recovery_time < AIautocastspell_timer->GetSetAtTrigger()) {
 				recovery_time = AIautocastspell_timer->GetSetAtTrigger();
+			}
 			AIautocastspell_timer->Start(recovery_time, false);
 		}
-		else
+		else {
 			AIautocastspell_timer->Start(AISpellVar.fail_recast, false);
+		}
 		casting_spell_AIindex = AIBot_spells.size();
 	}
 }

--- a/zone/botspellsai.cpp
+++ b/zone/botspellsai.cpp
@@ -87,12 +87,12 @@ bool Bot::AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes) {
 
 				Mob* addMob = GetFirstIncomingMobToMez(this, botSpell);
 
-				if(!addMob) {
+				if (!addMob) {
 					//Say("!addMob.");
 					break;
 				}
 
-				if(!(!addMob->IsImmuneToSpell(botSpell.SpellId, this) && addMob->CanBuffStack(botSpell.SpellId, botLevel, true) >= 0)) {
+				if (!(!addMob->IsImmuneToSpell(botSpell.SpellId, this) && addMob->CanBuffStack(botSpell.SpellId, botLevel, true) >= 0)) {
 					break;
 				}
 				castedSpell = AIDoSpellCast(botSpell.SpellIndex, addMob, botSpell.ManaCost);
@@ -136,61 +136,65 @@ bool Bot::AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes) {
 						if(hpr < 35) {
 							botSpell = GetBestBotSpellForFastHeal(this);
 						}
-						else if(hpr >= 35 && hpr < 70) {
-							if(GetNumberNeedingHealedInGroup(60, false) >= 3) {
+						else if (hpr >= 35 && hpr < 70) {
+							if (GetNumberNeedingHealedInGroup(60, false) >= 3) {
 								botSpell = GetBestBotSpellForGroupHeal(this);
 							}
-							if(botSpell.SpellId == 0) {
+							if (botSpell.SpellId == 0) {
 								botSpell = GetBestBotSpellForPercentageHeal(this);
 							}
 						}
-						else if(hpr >= 70 && hpr < 95) {
-							if(GetNumberNeedingHealedInGroup(80, false) >= 3) {
+						else if (hpr >= 70 && hpr < 95) {
+							if (GetNumberNeedingHealedInGroup(80, false) >= 3) {
 								botSpell = GetBestBotSpellForGroupHealOverTime(this);
 							}
-							if(hasAggro) {
+							if (hasAggro) {
 								botSpell = GetBestBotSpellForPercentageHeal(this);
 							}
 						}
 						else {
-							if(!tar->FindType(SE_HealOverTime)) {
+							if (!tar->FindType(SE_HealOverTime)) {
 								botSpell = GetBestBotSpellForHealOverTime(this);
 							}
 						}
 					}
 					else if ((botClass == CLERIC) || (botClass == DRUID) || (botClass == SHAMAN) || (botClass == PALADIN)) {
-						if(GetNumberNeedingHealedInGroup(40, true) >= 2) {
+						if (GetNumberNeedingHealedInGroup(40, true) >= 2) {
 							botSpell = GetBestBotSpellForGroupCompleteHeal(this);
 
-							if(botSpell.SpellId == 0)
+							if (botSpell.SpellId == 0) {
 								botSpell = GetBestBotSpellForGroupHeal(this);
-
-							if(botSpell.SpellId == 0)
+							}
+							if (botSpell.SpellId == 0) {
 								botSpell = GetBestBotSpellForGroupHealOverTime(this);
-
-							if(hpr < 40) {
-								if(botSpell.SpellId == 0)
+							}
+							if (hpr < 40) {
+								if (botSpell.SpellId == 0) {
 									botSpell = GetBestBotSpellForPercentageHeal(this);
+								}
 							}
 						}
-						else if(GetNumberNeedingHealedInGroup(60, true) >= 2) {
+						else if (GetNumberNeedingHealedInGroup(60, true) >= 2) {
 							botSpell = GetBestBotSpellForGroupHeal(this);
 
-							if(botSpell.SpellId == 0)
+							if (botSpell.SpellId == 0) {
 								botSpell = GetBestBotSpellForGroupHealOverTime(this);
-
-							if(hpr < 40) {
+							}
+							if (hpr < 40) {
 								if(botSpell.SpellId == 0)
 									botSpell = GetBestBotSpellForPercentageHeal(this);
 							}
 						}
-						else if(hpr < 40)
+						else if (hpr < 40) {
 							botSpell = GetBestBotSpellForPercentageHeal(this);
-						else if(hpr >= 40 && hpr < 75)
+						}
+						else if (hpr >= 40 && hpr < 75) {
 							botSpell = GetBestBotSpellForRegularSingleTargetHeal(this);
+						}
 						else {
-							if(hpr < 90 && !tar->FindType(SE_HealOverTime))
+							if (hpr < 90 && !tar->FindType(SE_HealOverTime)) {
 								botSpell = GetBestBotSpellForHealOverTime(this);
+							}
 						}
 					}
 					else {
@@ -217,17 +221,18 @@ bool Bot::AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes) {
 						}
 
 						//If we're at specified mana % or below, don't heal as hybrid
-						if(tar->GetHPRatio() <= hpRatioToCast)
+						if (tar->GetHPRatio() <= hpRatioToCast) {
 							botSpell = GetBestBotSpellForRegularSingleTargetHeal(this);
+						}
 					}
 
-					if(botSpell.SpellId == 0)
+					if (botSpell.SpellId == 0) {
 						botSpell = GetBestBotSpellForRegularSingleTargetHeal(this);
-
-					if(botSpell.SpellId == 0)
+					}
+					if (botSpell.SpellId == 0) {
 						botSpell = GetFirstBotSpellForSingleTargetHeal(this);
-
-					if(botSpell.SpellId == 0 && botClass == BARD) {
+					}
+					if (botSpell.SpellId == 0 && botClass == BARD) {
 						botSpell = GetFirstBotSpellBySpellType(this, SpellType_Heal);
 					}
 
@@ -261,8 +266,8 @@ bool Bot::AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes) {
 							}
 						}*/
 						if(botClass != BARD) {
-							if(IsGroupSpell(botSpell.SpellId)) {
-								if(HasGroup()) {
+							if (IsGroupSpell(botSpell.SpellId)) {
+								if (HasGroup()) {
 									Group *g = GetGroup();
 
 									if(g) {
@@ -349,14 +354,14 @@ bool Bot::AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes) {
 					}
 
 					// Put the zone levitate and movement check here since bots are able to bypass the client casting check
-					if((IsEffectInSpell(selectedBotSpell.SpellId, SE_Levitate) && !zone->CanLevitate())
+					if ((IsEffectInSpell(selectedBotSpell.SpellId, SE_Levitate) && !zone->CanLevitate())
 						|| (IsEffectInSpell(selectedBotSpell.SpellId, SE_MovementSpeed) && !zone->CanCastOutdoor())) {
-							if(botClass != BARD || !IsSpellUsableThisZoneType(selectedBotSpell.SpellId, zone->GetZoneType())) {
+							if (botClass != BARD || !IsSpellUsableThisZoneType(selectedBotSpell.SpellId, zone->GetZoneType())) {
 								continue;
 							}
 					}
 
-					switch(tar->GetArchetype())
+					switch (tar->GetArchetype())
 					{
 						case ARCHETYPE_CASTER:
 							//TODO: probably more caster specific spell effects in here
@@ -495,8 +500,8 @@ bool Bot::AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes) {
 						botSpell = GetBestBotSpellForNukeByTargetType(this, ST_Summoned);
 				}
 
-				if(botClass == PALADIN || botClass == DRUID || botClass == CLERIC || botClass == ENCHANTER || botClass == WIZARD) {
-					if(botSpell.SpellId == 0) {
+				if (botClass == PALADIN || botClass == DRUID || botClass == CLERIC || botClass == ENCHANTER || botClass == WIZARD) {
+					if (botSpell.SpellId == 0) {
 						uint8 stunChance = (tar->IsCasting() ? 30: 15);
 
 						if(botClass == PALADIN)
@@ -917,29 +922,29 @@ bool Bot::AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes) {
 			break;
 		}
 		case SpellType_Cure: {
-			if(GetNeedsCured(tar) && (tar->DontCureMeBefore() < Timer::GetCurrentTime()) && !(GetNumberNeedingHealedInGroup(25, false) > 0) && !(GetNumberNeedingHealedInGroup(40, false) > 2))
+			if (GetNeedsCured(tar) && (tar->DontCureMeBefore() < Timer::GetCurrentTime()) && !(GetNumberNeedingHealedInGroup(25, false) > 0) && !(GetNumberNeedingHealedInGroup(40, false) > 2))
 			{
 				botSpell = GetBestBotSpellForCure(this, tar);
 
-				if(botSpell.SpellId == 0)
+				if (botSpell.SpellId == 0)
 					break;
 
 				uint32 TempDontCureMeBeforeTime = tar->DontCureMeBefore();
 
 				castedSpell = AIDoSpellCast(botSpell.SpellIndex, tar, botSpell.ManaCost, &TempDontCureMeBeforeTime);
 
-				if(castedSpell) {
-					if(botClass != BARD) {
-						if(IsGroupSpell(botSpell.SpellId)) {
+				if (castedSpell) {
+					if (botClass != BARD) {
+						if (IsGroupSpell(botSpell.SpellId)) {
 							Group *g;
 
-							if(HasGroup()) {
+							if (HasGroup()) {
 								Group *g = GetGroup();
 
-								if(g) {
-									for( int i = 0; i<MAX_GROUP_MEMBERS; i++) {
-										if(g->members[i] && !g->members[i]->qglobal) {
-											if(TempDontCureMeBeforeTime != tar->DontCureMeBefore())
+								if (g) {
+									for ( int i = 0; i<MAX_GROUP_MEMBERS; i++) {
+										if (g->members[i] && !g->members[i]->qglobal) {
+											if (TempDontCureMeBeforeTime != tar->DontCureMeBefore())
 												g->members[i]->SetDontCureMeBefore(Timer::GetCurrentTime() + 4000);
 										}
 									}
@@ -947,8 +952,9 @@ bool Bot::AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes) {
 							}
 						}
 						else {
-							if(TempDontCureMeBeforeTime != tar->DontCureMeBefore())
+							if (TempDontCureMeBeforeTime != tar->DontCureMeBefore()) {
 								tar->SetDontCureMeBefore(Timer::GetCurrentTime() + 4000);
+							}
 						}
 					}
 				}
@@ -1557,13 +1563,13 @@ bool Bot::AIHealRotation(Mob* tar, bool useFastHeals) {
 	else {
 		botSpell = GetBestBotSpellForPercentageHeal(this);
 
-		if(botSpell.SpellId == 0)
+		if (botSpell.SpellId == 0) {
 			botSpell = GetBestBotSpellForRegularSingleTargetHeal(this);
-
-		if(botSpell.SpellId == 0)
+		}
+		if (botSpell.SpellId == 0) {
 			botSpell = GetFirstBotSpellForSingleTargetHeal(this);
-
-		if(botSpell.SpellId == 0) {
+		}
+		if (botSpell.SpellId == 0) {
 			botSpell = GetFirstBotSpellBySpellType(this, SpellType_Heal);
 		}
 	}
@@ -2817,7 +2823,7 @@ bool Bot::AI_AddBotSpells(uint32 iDBSpellsID) {
 	if (IsValidSpell(attack_proc_spell)) {
 		AddProcToWeapon(attack_proc_spell, true, proc_chance);
 
-		if(RuleB(Spells, NPCInnateProcOverride)) { 
+		if (RuleB(Spells, NPCInnateProcOverride)) { 
 			innate_proc_spell_id = attack_proc_spell;
 		}
 	}

--- a/zone/botspellsai.cpp
+++ b/zone/botspellsai.cpp
@@ -1593,7 +1593,7 @@ std::list<BotSpell> Bot::GetBotSpellsForSpellEffect(Bot* botCaster, int spellEff
 	std::list<BotSpell> result;
 
 	if(botCaster && botCaster->AI_HasSpells()) {
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetBotSpells();
+		std::vector<AISpells_Struct> botSpellList = botCaster->GetAIBotSpells();
 
 		for (int i = botSpellList.size() - 1; i >= 0; i--) {
 			if (botSpellList[i].spellid <= 0 || botSpellList[i].spellid >= SPDAT_RECORDS) {
@@ -1620,7 +1620,7 @@ std::list<BotSpell> Bot::GetBotSpellsForSpellEffectAndTargetType(Bot* botCaster,
 	std::list<BotSpell> result;
 
 	if(botCaster && botCaster->AI_HasSpells()) {
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetBotSpells();
+		std::vector<AISpells_Struct> botSpellList = botCaster->GetAIBotSpells();
 
 		for (int i = botSpellList.size() - 1; i >= 0; i--) {
 			if (botSpellList[i].spellid <= 0 || botSpellList[i].spellid >= SPDAT_RECORDS) {
@@ -1649,7 +1649,7 @@ std::list<BotSpell> Bot::GetBotSpellsBySpellType(Bot* botCaster, uint32 spellTyp
 	std::list<BotSpell> result;
 
 	if(botCaster && botCaster->AI_HasSpells()) {
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetBotSpells();
+		std::vector<AISpells_Struct> botSpellList = botCaster->GetAIBotSpells();
 
 		for (int i = botSpellList.size() - 1; i >= 0; i--) {
 			if (botSpellList[i].spellid <= 0 || botSpellList[i].spellid >= SPDAT_RECORDS) {
@@ -1676,7 +1676,7 @@ std::list<BotSpell_wPriority> Bot::GetPrioritizedBotSpellsBySpellType(Bot* botCa
 	std::list<BotSpell_wPriority> result;
 
 	if (botCaster && botCaster->AI_HasSpells()) {
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetBotSpells();
+		std::vector<AISpells_Struct> botSpellList = botCaster->GetAIBotSpells();
 
 		for (int i = botSpellList.size() - 1; i >= 0; i--) {
 			if (botSpellList[i].spellid <= 0 || botSpellList[i].spellid >= SPDAT_RECORDS) {
@@ -1711,7 +1711,7 @@ BotSpell Bot::GetFirstBotSpellBySpellType(Bot* botCaster, uint32 spellType) {
 	result.ManaCost = 0;
 
 	if(botCaster && botCaster->AI_HasSpells()) {
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetBotSpells();
+		std::vector<AISpells_Struct> botSpellList = botCaster->GetAIBotSpells();
 
 		for (int i = botSpellList.size() - 1; i >= 0; i--) {
 			if (botSpellList[i].spellid <= 0 || botSpellList[i].spellid >= SPDAT_RECORDS) {
@@ -1767,7 +1767,7 @@ BotSpell Bot::GetBestBotSpellForHealOverTime(Bot* botCaster) {
 
 	if(botCaster) {
 		std::list<BotSpell> botHoTSpellList = GetBotSpellsForSpellEffect(botCaster, SE_HealOverTime);
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetBotSpells();
+		std::vector<AISpells_Struct> botSpellList = botCaster->GetAIBotSpells();
 
 		for(std::list<BotSpell>::iterator botSpellListItr = botHoTSpellList.begin(); botSpellListItr != botHoTSpellList.end(); ++botSpellListItr) {
 			// Assuming all the spells have been loaded into this list by level and in descending order
@@ -1803,7 +1803,7 @@ BotSpell Bot::GetBestBotSpellForPercentageHeal(Bot *botCaster) {
 	result.ManaCost = 0;
 
 	if(botCaster && botCaster->AI_HasSpells()) {
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetBotSpells();
+		std::vector<AISpells_Struct> botSpellList = botCaster->GetAIBotSpells();
 
 		for (int i = botSpellList.size() - 1; i >= 0; i--) {
 			if (botSpellList[i].spellid <= 0 || botSpellList[i].spellid >= SPDAT_RECORDS) {
@@ -1909,7 +1909,7 @@ BotSpell Bot::GetBestBotSpellForGroupHealOverTime(Bot* botCaster) {
 
 	if(botCaster) {
 		std::list<BotSpell> botHoTSpellList = GetBotSpellsForSpellEffect(botCaster, SE_HealOverTime);
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetBotSpells();
+		std::vector<AISpells_Struct> botSpellList = botCaster->GetAIBotSpells();
 
 		for(std::list<BotSpell>::iterator botSpellListItr = botHoTSpellList.begin(); botSpellListItr != botHoTSpellList.end(); ++botSpellListItr) {
 			// Assuming all the spells have been loaded into this list by level and in descending order
@@ -2320,7 +2320,7 @@ BotSpell Bot::GetDebuffBotSpell(Bot* botCaster, Mob *tar) {
 		return result;
 
 	if(botCaster && botCaster->AI_HasSpells()) {
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetBotSpells();
+		std::vector<AISpells_Struct> botSpellList = botCaster->GetAIBotSpells();
 
 		for (int i = botSpellList.size() - 1; i >= 0; i--) {
 			if (botSpellList[i].spellid <= 0 || botSpellList[i].spellid >= SPDAT_RECORDS) {
@@ -2367,7 +2367,7 @@ BotSpell Bot::GetBestBotSpellForResistDebuff(Bot* botCaster, Mob *tar) {
 	bool needsDiseaseResistDebuff = (tar->GetDR() + level_mod) > 100 ? true: false;
 
 	if(botCaster && botCaster->AI_HasSpells()) {
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetBotSpells();
+		std::vector<AISpells_Struct> botSpellList = botCaster->GetAIBotSpells();
 
 		for (int i = botSpellList.size() - 1; i >= 0; i--) {
 			if (botSpellList[i].spellid <= 0 || botSpellList[i].spellid >= SPDAT_RECORDS) {
@@ -2672,6 +2672,339 @@ uint8 Bot::GetChanceToCastBySpellType(uint32 spellType)
 	}
 
 	return database.botdb.GetSpellCastingChance(spell_type_index, class_index, stance_index, type_index);
+}
+
+bool IsSpellInBotList(DBnpcspells_Struct* spell_list, uint16 iSpellID);
+
+bool Bot::AI_AddBotSpells(uint32 iDBSpellsID) {
+	// ok, this function should load the list, and the parent list then shove them into the struct and sort
+	npc_spells_id = iDBSpellsID;
+	AIspells.clear();
+	if (iDBSpellsID == 0) {
+		AIautocastspell_timer->Disable();
+		return false;
+	}
+	DBnpcspells_Struct* spell_list = content_db.GetBotSpells(iDBSpellsID);
+	if (!spell_list) {
+		AIautocastspell_timer->Disable();
+		return false;
+	}
+	DBnpcspells_Struct* parentlist = content_db.GetBotSpells(spell_list->parent_list);
+#if MobAI_DEBUG_Spells >= 10
+	std::string debug_msg = StringFormat("Loading NPCSpells onto %s: dbspellsid=%u, level=%u", GetName(), iDBSpellsID, GetLevel());
+	if (spell_list) {
+		debug_msg.append(StringFormat(" (found, %u), parentlist=%u", spell_list->entries.size(), spell_list->parent_list));
+		if (spell_list->parent_list) {
+			if (parentlist)
+				debug_msg.append(StringFormat(" (found, %u)", parentlist->entries.size()));
+			else
+				debug_msg.append(" (not found)");
+		}
+	}
+	else {
+		debug_msg.append(" (not found)");
+	}
+	LogAI("[{}]", debug_msg.c_str());
+
+#ifdef MobAI_DEBUG_Spells >= 25
+	if (parentlist) {
+		for (const auto &iter : parentlist->entries) {
+			LogAI("([{}]) [{}]", iter.spellid, spells[iter.spellid].name);
+		}
+	}
+	LogAI("fin (parent list)");
+	if (spell_list) {
+		for (const auto &iter : spell_list->entries) {
+			LogAI("([{}]) [{}]", iter.spellid, spells[iter.spellid].name);
+		}
+	}
+	LogAI("fin (spell list)");
+#endif
+
+#endif
+	uint16 attack_proc_spell = -1;
+	int8 proc_chance = 3;
+	uint16 range_proc_spell = -1;
+	int16 rproc_chance = 0;
+	uint16 defensive_proc_spell = -1;
+	int16 dproc_chance = 0;
+	uint32 _fail_recast = 0;
+	uint32 _engaged_no_sp_recast_min = 0;
+	uint32 _engaged_no_sp_recast_max = 0;
+	uint8 _engaged_beneficial_self_chance = 0;
+	uint8 _engaged_beneficial_other_chance = 0;
+	uint8 _engaged_detrimental_chance = 0;
+	uint32 _pursue_no_sp_recast_min = 0;
+	uint32 _pursue_no_sp_recast_max = 0;
+	uint8 _pursue_detrimental_chance = 0;
+	uint32 _idle_no_sp_recast_min = 0;
+	uint32 _idle_no_sp_recast_max = 0;
+	uint8 _idle_beneficial_chance = 0;
+
+	if (parentlist) {
+		attack_proc_spell = parentlist->attack_proc;
+		proc_chance = parentlist->proc_chance;
+		range_proc_spell = parentlist->range_proc;
+		rproc_chance = parentlist->rproc_chance;
+		defensive_proc_spell = parentlist->defensive_proc;
+		dproc_chance = parentlist->dproc_chance;
+		_fail_recast = parentlist->fail_recast;
+		_engaged_no_sp_recast_min = parentlist->engaged_no_sp_recast_min;
+		_engaged_no_sp_recast_max = parentlist->engaged_no_sp_recast_max;
+		_engaged_beneficial_self_chance = parentlist->engaged_beneficial_self_chance;
+		_engaged_beneficial_other_chance = parentlist->engaged_beneficial_other_chance;
+		_engaged_detrimental_chance = parentlist->engaged_detrimental_chance;
+		_pursue_no_sp_recast_min = parentlist->pursue_no_sp_recast_min;
+		_pursue_no_sp_recast_max = parentlist->pursue_no_sp_recast_max;
+		_pursue_detrimental_chance = parentlist->pursue_detrimental_chance;
+		_idle_no_sp_recast_min = parentlist->idle_no_sp_recast_min;
+		_idle_no_sp_recast_max = parentlist->idle_no_sp_recast_max;
+		_idle_beneficial_chance = parentlist->idle_beneficial_chance;
+		for (auto &e : parentlist->entries) {
+			if (GetLevel() >= e.minlevel && GetLevel() <= e.maxlevel && e.spellid > 0) {
+				if (!IsSpellInBotList(spell_list, e.spellid))
+				{
+					AddSpellToBotList(e.priority, e.spellid, e.type, e.manacost, e.recast_delay, e.resist_adjust, e.min_hp, e.max_hp);
+				}
+			}
+		}
+	}
+	if (spell_list->attack_proc >= 0) {
+		attack_proc_spell = spell_list->attack_proc;
+		proc_chance = spell_list->proc_chance;
+	}
+
+	if (spell_list->range_proc >= 0) {
+		range_proc_spell = spell_list->range_proc;
+		rproc_chance = spell_list->rproc_chance;
+	}
+
+	if (spell_list->defensive_proc >= 0) {
+		defensive_proc_spell = spell_list->defensive_proc;
+		dproc_chance = spell_list->dproc_chance;
+	}
+
+	//If any casting variables are defined in the current list, ignore those in the parent list.
+	if (spell_list->fail_recast || spell_list->engaged_no_sp_recast_min || spell_list->engaged_no_sp_recast_max
+		|| spell_list->engaged_beneficial_self_chance || spell_list->engaged_beneficial_other_chance || spell_list->engaged_detrimental_chance
+		|| spell_list->pursue_no_sp_recast_min || spell_list->pursue_no_sp_recast_max || spell_list->pursue_detrimental_chance
+		|| spell_list->idle_no_sp_recast_min || spell_list->idle_no_sp_recast_max || spell_list->idle_beneficial_chance) {
+		_fail_recast = spell_list->fail_recast;
+		_engaged_no_sp_recast_min = spell_list->engaged_no_sp_recast_min;
+		_engaged_no_sp_recast_max = spell_list->engaged_no_sp_recast_max;
+		_engaged_beneficial_self_chance = spell_list->engaged_beneficial_self_chance;
+		_engaged_beneficial_other_chance = spell_list->engaged_beneficial_other_chance;
+		_engaged_detrimental_chance = spell_list->engaged_detrimental_chance;
+		_pursue_no_sp_recast_min = spell_list->pursue_no_sp_recast_min;
+		_pursue_no_sp_recast_max = spell_list->pursue_no_sp_recast_max;
+		_pursue_detrimental_chance = spell_list->pursue_detrimental_chance;
+		_idle_no_sp_recast_min = spell_list->idle_no_sp_recast_min;
+		_idle_no_sp_recast_max = spell_list->idle_no_sp_recast_max;
+		_idle_beneficial_chance = spell_list->idle_beneficial_chance;
+	}
+
+	for (auto &e : spell_list->entries) {
+		if (GetLevel() >= e.minlevel && GetLevel() <= e.maxlevel && e.spellid > 0) {
+			AddSpellToBotList(e.priority, e.spellid, e.type, e.manacost, e.recast_delay, e.resist_adjust, e.min_hp, e.max_hp);
+		}
+	}
+
+	std::sort(AIspells.begin(), AIspells.end(), [](const AISpells_Struct& a, const AISpells_Struct& b) {
+		return a.priority > b.priority;
+	});
+
+	if (IsValidSpell(attack_proc_spell)) {
+		AddProcToWeapon(attack_proc_spell, true, proc_chance);
+
+		if(RuleB(Spells, NPCInnateProcOverride))
+			innate_proc_spell_id = attack_proc_spell;
+	}
+
+	if (IsValidSpell(range_proc_spell))
+		AddRangedProc(range_proc_spell, (rproc_chance + 100));
+
+	if (IsValidSpell(defensive_proc_spell))
+		AddDefensiveProc(defensive_proc_spell, (dproc_chance + 100));
+
+	//Set AI casting variables
+
+	AISpellVar.fail_recast = (_fail_recast) ? _fail_recast : RuleI(Spells, AI_SpellCastFinishedFailRecast);
+	AISpellVar.engaged_no_sp_recast_min = (_engaged_no_sp_recast_min) ? _engaged_no_sp_recast_min : RuleI(Spells, AI_EngagedNoSpellMinRecast);
+	AISpellVar.engaged_no_sp_recast_max = (_engaged_no_sp_recast_max) ? _engaged_no_sp_recast_max : RuleI(Spells, AI_EngagedNoSpellMaxRecast);
+	AISpellVar.engaged_beneficial_self_chance = (_engaged_beneficial_self_chance) ? _engaged_beneficial_self_chance : RuleI(Spells, AI_EngagedBeneficialSelfChance);
+	AISpellVar.engaged_beneficial_other_chance = (_engaged_beneficial_other_chance) ? _engaged_beneficial_other_chance : RuleI(Spells, AI_EngagedBeneficialOtherChance);
+	AISpellVar.engaged_detrimental_chance = (_engaged_detrimental_chance) ? _engaged_detrimental_chance : RuleI(Spells, AI_EngagedDetrimentalChance);
+	AISpellVar.pursue_no_sp_recast_min = (_pursue_no_sp_recast_min) ? _pursue_no_sp_recast_min : RuleI(Spells, AI_PursueNoSpellMinRecast);
+	AISpellVar.pursue_no_sp_recast_max = (_pursue_no_sp_recast_max) ? _pursue_no_sp_recast_max : RuleI(Spells, AI_PursueNoSpellMaxRecast);
+	AISpellVar.pursue_detrimental_chance = (_pursue_detrimental_chance) ? _pursue_detrimental_chance : RuleI(Spells, AI_PursueDetrimentalChance);
+	AISpellVar.idle_no_sp_recast_min = (_idle_no_sp_recast_min) ? _idle_no_sp_recast_min : RuleI(Spells, AI_IdleNoSpellMinRecast);
+	AISpellVar.idle_no_sp_recast_max = (_idle_no_sp_recast_max) ? _idle_no_sp_recast_max : RuleI(Spells, AI_IdleNoSpellMaxRecast);
+	AISpellVar.idle_beneficial_chance = (_idle_beneficial_chance) ? _idle_beneficial_chance : RuleI(Spells, AI_IdleBeneficialChance);
+
+	if (AIspells.empty())
+		AIautocastspell_timer->Disable();
+	else
+		AIautocastspell_timer->Trigger();
+	return true;
+}
+
+bool IsSpellInBotList(DBnpcspells_Struct* spell_list, uint16 iSpellID) {
+	auto it = std::find_if(spell_list->entries.begin(), spell_list->entries.end(),
+			       [iSpellID](const DBnpcspells_entries_Struct &a) { return a.spellid == iSpellID; });
+	return it != spell_list->entries.end();
+}
+
+DBnpcspells_Struct *ZoneDatabase::GetBotSpells(uint32 iDBSpellsID)
+{
+	if (iDBSpellsID == 0)
+		return nullptr;
+
+	auto it = npc_spells_cache.find(iDBSpellsID);
+
+	if (it != npc_spells_cache.end()) { // it's in the cache, easy =)
+		return &it->second;
+	}
+
+	if (!npc_spells_loadtried.count(iDBSpellsID)) { // no reason to ask the DB again if we have failed once already
+		npc_spells_loadtried.insert(iDBSpellsID);
+
+		std::string query = StringFormat("SELECT id, parent_list, attack_proc, proc_chance, "
+						 "range_proc, rproc_chance, defensive_proc, dproc_chance, "
+						 "fail_recast, engaged_no_sp_recast_min, engaged_no_sp_recast_max, "
+						 "engaged_b_self_chance, engaged_b_other_chance, engaged_d_chance, "
+						 "pursue_no_sp_recast_min, pursue_no_sp_recast_max, "
+						 "pursue_d_chance, idle_no_sp_recast_min, idle_no_sp_recast_max, "
+						 "idle_b_chance FROM npc_spells WHERE id=%d",
+						 iDBSpellsID);
+		auto results = QueryDatabase(query);
+		if (!results.Success()) {
+			return nullptr;
+		}
+
+		if (results.RowCount() != 1)
+			return nullptr;
+
+		auto row = results.begin();
+		DBnpcspells_Struct spell_set;
+
+		spell_set.parent_list = atoi(row[1]);
+		spell_set.attack_proc = atoi(row[2]);
+		spell_set.proc_chance = atoi(row[3]);
+		spell_set.range_proc = atoi(row[4]);
+		spell_set.rproc_chance = atoi(row[5]);
+		spell_set.defensive_proc = atoi(row[6]);
+		spell_set.dproc_chance = atoi(row[7]);
+		spell_set.fail_recast = atoi(row[8]);
+		spell_set.engaged_no_sp_recast_min = atoi(row[9]);
+		spell_set.engaged_no_sp_recast_max = atoi(row[10]);
+		spell_set.engaged_beneficial_self_chance = atoi(row[11]);
+		spell_set.engaged_beneficial_other_chance = atoi(row[12]);
+		spell_set.engaged_detrimental_chance = atoi(row[13]);
+		spell_set.pursue_no_sp_recast_min = atoi(row[14]);
+		spell_set.pursue_no_sp_recast_max = atoi(row[15]);
+		spell_set.pursue_detrimental_chance = atoi(row[16]);
+		spell_set.idle_no_sp_recast_min = atoi(row[17]);
+		spell_set.idle_no_sp_recast_max = atoi(row[18]);
+		spell_set.idle_beneficial_chance = atoi(row[19]);
+
+		// pulling fixed values from an auto-increment field is dangerous...
+		query = StringFormat(
+		    "SELECT spellid, type, minlevel, maxlevel, "
+		    "manacost, recast_delay, priority, min_hp, max_hp, resist_adjust "
+		    "FROM bot_spells_entries "
+		    "WHERE npc_spells_id=%d ORDER BY minlevel",
+		    iDBSpellsID);
+		results = QueryDatabase(query);
+
+		if (!results.Success()) {
+			return nullptr;
+		}
+
+		int entryIndex = 0;
+		for (row = results.begin(); row != results.end(); ++row, ++entryIndex) {
+			DBnpcspells_entries_Struct entry;
+			int spell_id = atoi(row[0]);
+			entry.spellid = spell_id;
+			entry.type = atoul(row[1]);
+			entry.minlevel = atoi(row[2]);
+			entry.maxlevel = atoi(row[3]);
+			entry.manacost = atoi(row[4]);
+			entry.recast_delay = atoi(row[5]);
+			entry.priority = atoi(row[6]);
+			entry.min_hp = atoi(row[7]);
+			entry.max_hp = atoi(row[8]);
+
+			// some spell types don't make much since to be priority 0, so fix that
+			if (!(entry.type & SPELL_TYPES_INNATE) && entry.priority == 0)
+				entry.priority = 1;
+
+			if (row[9])
+				entry.resist_adjust = atoi(row[9]);
+			else if (IsValidSpell(spell_id))
+				entry.resist_adjust = spells[spell_id].resist_difficulty;
+
+			spell_set.entries.push_back(entry);
+		}
+
+		npc_spells_cache.insert(std::make_pair(iDBSpellsID, spell_set));
+
+		return &npc_spells_cache[iDBSpellsID];
+    }
+
+	return nullptr;
+}
+
+// adds a spell to the list, taking into account priority and resorting list as needed.
+void Bot::AddSpellToBotList(int16 iPriority, uint16 iSpellID, uint32 iType,
+							int16 iManaCost, int32 iRecastDelay, int16 iResistAdjust, int8 min_hp, int8 max_hp)
+{
+
+	if(!IsValidSpell(iSpellID))
+		return;
+
+	HasAISpell = true;
+	AISpells_Struct t;
+
+	t.priority = iPriority;
+	t.spellid = iSpellID;
+	t.type = iType;
+	t.manacost = iManaCost;
+	t.recast_delay = iRecastDelay;
+	t.time_cancast = 0;
+	t.resist_adjust = iResistAdjust;
+	t.min_hp = min_hp;
+	t.max_hp = max_hp;
+
+	AIspells.push_back(t);
+
+	// If we're going from an empty list, we need to start the timer
+	if (AIspells.size() == 1)
+		AIautocastspell_timer->Start(RandomTimer(0, 300), false);
+}
+
+//this gets called from InterruptSpell() for failure or SpellFinished() for success
+void Bot::AI_Bot_Event_SpellCastFinished(bool iCastSucceeded, uint16 slot) {
+	if (slot == 1) {
+		uint32 recovery_time = 0;
+		if (iCastSucceeded) {
+			if (casting_spell_AIindex < AIspells.size()) {
+					recovery_time += spells[AIspells[casting_spell_AIindex].spellid].recovery_time;
+					if (AIspells[casting_spell_AIindex].recast_delay >= 0)
+					{
+						if (AIspells[casting_spell_AIindex].recast_delay < 10000)
+							AIspells[casting_spell_AIindex].time_cancast = Timer::GetCurrentTime() + (AIspells[casting_spell_AIindex].recast_delay*1000);
+					}
+					else
+						AIspells[casting_spell_AIindex].time_cancast = Timer::GetCurrentTime() + spells[AIspells[casting_spell_AIindex].spellid].recast_time;
+			}
+			if (recovery_time < AIautocastspell_timer->GetSetAtTrigger())
+				recovery_time = AIautocastspell_timer->GetSetAtTrigger();
+			AIautocastspell_timer->Start(recovery_time, false);
+		}
+		else
+			AIautocastspell_timer->Start(AISpellVar.fail_recast, false);
+		casting_spell_AIindex = AIspells.size();
+	}
 }
 
 #endif

--- a/zone/botspellsai.cpp
+++ b/zone/botspellsai.cpp
@@ -1063,7 +1063,7 @@ bool Bot::AIDoSpellCast(uint8 i, Mob* tar, int32 mana_cost, uint32* oDontDoAgain
 	int32 manaCost = mana_cost;
 
 	if (manaCost == -1)
-		manaCost = spells[AIspells[i].spellid].mana;
+		manaCost = spells[AIBot_spells[i].spellid].mana;
 	else if (manaCost == -2)
 		manaCost = 0;
 
@@ -1074,7 +1074,7 @@ bool Bot::AIDoSpellCast(uint8 i, Mob* tar, int32 mana_cost, uint32* oDontDoAgain
 	if(RuleB(Bots, FinishBuffing)) {
 		if(manaCost > hasMana) {
 			// Let's have the bots complete the buff time process
-			if(AIspells[i].type & SpellType_Buff) {
+			if(AIBot_spells[i].type & SpellType_Buff) {
 				extraMana = manaCost - hasMana;
 				SetMana(manaCost);
 			}
@@ -1083,17 +1083,17 @@ bool Bot::AIDoSpellCast(uint8 i, Mob* tar, int32 mana_cost, uint32* oDontDoAgain
 
 	float dist2 = 0;
 
-	if (AIspells[i].type & SpellType_Escape) {
+	if (AIBot_spells[i].type & SpellType_Escape) {
 		dist2 = 0;
 	} else
 		dist2 = DistanceSquared(m_Position, tar->GetPosition());
 
-	if (((((spells[AIspells[i].spellid].target_type==ST_GroupTeleport && AIspells[i].type==2)
-				|| spells[AIspells[i].spellid].target_type==ST_AECaster
-				|| spells[AIspells[i].spellid].target_type==ST_Group
-				|| spells[AIspells[i].spellid].target_type==ST_AEBard)
-				&& dist2 <= spells[AIspells[i].spellid].aoe_range*spells[AIspells[i].spellid].aoe_range)
-				|| dist2 <= GetActSpellRange(AIspells[i].spellid, spells[AIspells[i].spellid].range)*GetActSpellRange(AIspells[i].spellid, spells[AIspells[i].spellid].range)) && (mana_cost <= GetMana() || GetMana() == GetMaxMana()))
+	if (((((spells[AIBot_spells[i].spellid].target_type==ST_GroupTeleport && AIBot_spells[i].type==2)
+				|| spells[AIBot_spells[i].spellid].target_type==ST_AECaster
+				|| spells[AIBot_spells[i].spellid].target_type==ST_Group
+				|| spells[AIBot_spells[i].spellid].target_type==ST_AEBard)
+				&& dist2 <= spells[AIBot_spells[i].spellid].aoe_range*spells[AIBot_spells[i].spellid].aoe_range)
+				|| dist2 <= GetActSpellRange(AIBot_spells[i].spellid, spells[AIBot_spells[i].spellid].range)*GetActSpellRange(AIBot_spells[i].spellid, spells[AIBot_spells[i].spellid].range)) && (mana_cost <= GetMana() || GetMana() == GetMaxMana()))
 	{
 		result = NPC::AIDoSpellCast(i, tar, mana_cost, oDontDoAgainBefore);
 
@@ -1107,20 +1107,20 @@ bool Bot::AIDoSpellCast(uint8 i, Mob* tar, int32 mana_cost, uint32* oDontDoAgain
 		extraMana = false;
 	}
 	else { //handle spell recast and recast timers
-		//if(GetClass() == BARD && IsGroupSpell(AIspells[i].spellid)) {
+		//if(GetClass() == BARD && IsGroupSpell(AIBot_spells[i].spellid)) {
 		//	// Bard buff songs have been moved to their own npc spell type..
 		//	// Buff stacking is now checked as opposed to manipulating the timer to avoid rapid casting
 
-		//	//AIspells[i].time_cancast = (spells[AIspells[i].spellid].recast_time > (spells[AIspells[i].spellid].buffduration * 6000)) ? Timer::GetCurrentTime() + spells[AIspells[i].spellid].recast_time : Timer::GetCurrentTime() + spells[AIspells[i].spellid].buffduration * 6000;
-		//	//spellend_timer.Start(spells[AIspells[i].spellid].cast_time);
+		//	//AIBot_spells[i].time_cancast = (spells[AIBot_spells[i].spellid].recast_time > (spells[AIBot_spells[i].spellid].buffduration * 6000)) ? Timer::GetCurrentTime() + spells[AIBot_spells[i].spellid].recast_time : Timer::GetCurrentTime() + spells[AIBot_spells[i].spellid].buffduration * 6000;
+		//	//spellend_timer.Start(spells[AIBot_spells[i].spellid].cast_time);
 		//}
 		//else
-		//	AIspells[i].time_cancast = Timer::GetCurrentTime() + spells[AIspells[i].spellid].recast_time;
+		//	AIBot_spells[i].time_cancast = Timer::GetCurrentTime() + spells[AIBot_spells[i].spellid].recast_time;
 
-		AIspells[i].time_cancast = Timer::GetCurrentTime() + spells[AIspells[i].spellid].recast_time;
+		AIBot_spells[i].time_cancast = Timer::GetCurrentTime() + spells[AIBot_spells[i].spellid].recast_time;
 
-		if(spells[AIspells[i].spellid].timer_id > 0) {
-			SetSpellRecastTimer(spells[AIspells[i].spellid].timer_id, spells[AIspells[i].spellid].recast_time);
+		if(spells[AIBot_spells[i].spellid].timer_id > 0) {
+			SetSpellRecastTimer(spells[AIBot_spells[i].spellid].timer_id, spells[AIBot_spells[i].spellid].recast_time);
 		}
 	}
 
@@ -1593,7 +1593,7 @@ std::list<BotSpell> Bot::GetBotSpellsForSpellEffect(Bot* botCaster, int spellEff
 	std::list<BotSpell> result;
 
 	if(botCaster && botCaster->AI_HasSpells()) {
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetAIBotSpells();
+		std::vector<BotSpells_Struct> botSpellList = botCaster->AIBot_spells;
 
 		for (int i = botSpellList.size() - 1; i >= 0; i--) {
 			if (botSpellList[i].spellid <= 0 || botSpellList[i].spellid >= SPDAT_RECORDS) {
@@ -1620,7 +1620,7 @@ std::list<BotSpell> Bot::GetBotSpellsForSpellEffectAndTargetType(Bot* botCaster,
 	std::list<BotSpell> result;
 
 	if(botCaster && botCaster->AI_HasSpells()) {
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetAIBotSpells();
+		std::vector<BotSpells_Struct> botSpellList = botCaster->AIBot_spells;
 
 		for (int i = botSpellList.size() - 1; i >= 0; i--) {
 			if (botSpellList[i].spellid <= 0 || botSpellList[i].spellid >= SPDAT_RECORDS) {
@@ -1649,7 +1649,7 @@ std::list<BotSpell> Bot::GetBotSpellsBySpellType(Bot* botCaster, uint32 spellTyp
 	std::list<BotSpell> result;
 
 	if(botCaster && botCaster->AI_HasSpells()) {
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetAIBotSpells();
+		std::vector<BotSpells_Struct> botSpellList = botCaster->AIBot_spells;
 
 		for (int i = botSpellList.size() - 1; i >= 0; i--) {
 			if (botSpellList[i].spellid <= 0 || botSpellList[i].spellid >= SPDAT_RECORDS) {
@@ -1676,7 +1676,7 @@ std::list<BotSpell_wPriority> Bot::GetPrioritizedBotSpellsBySpellType(Bot* botCa
 	std::list<BotSpell_wPriority> result;
 
 	if (botCaster && botCaster->AI_HasSpells()) {
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetAIBotSpells();
+		std::vector<BotSpells_Struct> botSpellList = botCaster->AIBot_spells;
 
 		for (int i = botSpellList.size() - 1; i >= 0; i--) {
 			if (botSpellList[i].spellid <= 0 || botSpellList[i].spellid >= SPDAT_RECORDS) {
@@ -1711,7 +1711,7 @@ BotSpell Bot::GetFirstBotSpellBySpellType(Bot* botCaster, uint32 spellType) {
 	result.ManaCost = 0;
 
 	if(botCaster && botCaster->AI_HasSpells()) {
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetAIBotSpells();
+		std::vector<BotSpells_Struct> botSpellList = botCaster->AIBot_spells;
 
 		for (int i = botSpellList.size() - 1; i >= 0; i--) {
 			if (botSpellList[i].spellid <= 0 || botSpellList[i].spellid >= SPDAT_RECORDS) {
@@ -1767,7 +1767,7 @@ BotSpell Bot::GetBestBotSpellForHealOverTime(Bot* botCaster) {
 
 	if(botCaster) {
 		std::list<BotSpell> botHoTSpellList = GetBotSpellsForSpellEffect(botCaster, SE_HealOverTime);
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetAIBotSpells();
+		std::vector<BotSpells_Struct> botSpellList = botCaster->AIBot_spells;
 
 		for(std::list<BotSpell>::iterator botSpellListItr = botHoTSpellList.begin(); botSpellListItr != botHoTSpellList.end(); ++botSpellListItr) {
 			// Assuming all the spells have been loaded into this list by level and in descending order
@@ -1803,7 +1803,7 @@ BotSpell Bot::GetBestBotSpellForPercentageHeal(Bot *botCaster) {
 	result.ManaCost = 0;
 
 	if(botCaster && botCaster->AI_HasSpells()) {
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetAIBotSpells();
+		std::vector<BotSpells_Struct> botSpellList = botCaster->AIBot_spells;
 
 		for (int i = botSpellList.size() - 1; i >= 0; i--) {
 			if (botSpellList[i].spellid <= 0 || botSpellList[i].spellid >= SPDAT_RECORDS) {
@@ -1909,7 +1909,7 @@ BotSpell Bot::GetBestBotSpellForGroupHealOverTime(Bot* botCaster) {
 
 	if(botCaster) {
 		std::list<BotSpell> botHoTSpellList = GetBotSpellsForSpellEffect(botCaster, SE_HealOverTime);
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetAIBotSpells();
+		std::vector<BotSpells_Struct> botSpellList = botCaster->AIBot_spells;
 
 		for(std::list<BotSpell>::iterator botSpellListItr = botHoTSpellList.begin(); botSpellListItr != botHoTSpellList.end(); ++botSpellListItr) {
 			// Assuming all the spells have been loaded into this list by level and in descending order
@@ -2320,7 +2320,7 @@ BotSpell Bot::GetDebuffBotSpell(Bot* botCaster, Mob *tar) {
 		return result;
 
 	if(botCaster && botCaster->AI_HasSpells()) {
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetAIBotSpells();
+		std::vector<BotSpells_Struct> botSpellList = botCaster->AIBot_spells;
 
 		for (int i = botSpellList.size() - 1; i >= 0; i--) {
 			if (botSpellList[i].spellid <= 0 || botSpellList[i].spellid >= SPDAT_RECORDS) {
@@ -2367,7 +2367,7 @@ BotSpell Bot::GetBestBotSpellForResistDebuff(Bot* botCaster, Mob *tar) {
 	bool needsDiseaseResistDebuff = (tar->GetDR() + level_mod) > 100 ? true: false;
 
 	if(botCaster && botCaster->AI_HasSpells()) {
-		std::vector<AISpells_Struct> botSpellList = botCaster->GetAIBotSpells();
+		std::vector<BotSpells_Struct> botSpellList = botCaster->AIBot_spells;
 
 		for (int i = botSpellList.size() - 1; i >= 0; i--) {
 			if (botSpellList[i].spellid <= 0 || botSpellList[i].spellid >= SPDAT_RECORDS) {
@@ -2526,8 +2526,8 @@ int32 Bot::GetSpellRecastTimer(Bot *caster, int timer_index) {
 
 bool Bot::CheckSpellRecastTimers(Bot *caster, int SpellIndex) {
 	if(caster) {
-		if(caster->AIspells[SpellIndex].time_cancast < Timer::GetCurrentTime()) { //checks spell recast
-			if(GetSpellRecastTimer(caster, spells[caster->AIspells[SpellIndex].spellid].timer_id) < Timer::GetCurrentTime()) { //checks for spells on the same timer
+		if(caster->AIBot_spells[SpellIndex].time_cancast < Timer::GetCurrentTime()) { //checks spell recast
+			if(GetSpellRecastTimer(caster, spells[caster->AIBot_spells[SpellIndex].spellid].timer_id) < Timer::GetCurrentTime()) { //checks for spells on the same timer
 				return true; //can cast spell
 			}
 		}
@@ -2679,7 +2679,7 @@ bool IsSpellInBotList(DBnpcspells_Struct* spell_list, uint16 iSpellID);
 bool Bot::AI_AddBotSpells(uint32 iDBSpellsID) {
 	// ok, this function should load the list, and the parent list then shove them into the struct and sort
 	npc_spells_id = iDBSpellsID;
-	AIspells.clear();
+	AIBot_spells.clear();
 	if (iDBSpellsID == 0) {
 		AIautocastspell_timer->Disable();
 		return false;
@@ -2809,7 +2809,7 @@ bool Bot::AI_AddBotSpells(uint32 iDBSpellsID) {
 		}
 	}
 
-	std::sort(AIspells.begin(), AIspells.end(), [](const AISpells_Struct& a, const AISpells_Struct& b) {
+	std::sort(AIBot_spells.begin(), AIBot_spells.end(), [](const BotSpells_Struct& a, const BotSpells_Struct& b) {
 		return a.priority > b.priority;
 	});
 
@@ -2841,7 +2841,7 @@ bool Bot::AI_AddBotSpells(uint32 iDBSpellsID) {
 	AISpellVar.idle_no_sp_recast_max = (_idle_no_sp_recast_max) ? _idle_no_sp_recast_max : RuleI(Spells, AI_IdleNoSpellMaxRecast);
 	AISpellVar.idle_beneficial_chance = (_idle_beneficial_chance) ? _idle_beneficial_chance : RuleI(Spells, AI_IdleBeneficialChance);
 
-	if (AIspells.empty())
+	if (AIBot_spells.empty())
 		AIautocastspell_timer->Disable();
 	else
 		AIautocastspell_timer->Trigger();
@@ -2963,7 +2963,7 @@ void Bot::AddSpellToBotList(int16 iPriority, uint16 iSpellID, uint32 iType,
 		return;
 
 	HasAISpell = true;
-	AISpells_Struct t;
+	BotSpells_Struct t;
 
 	t.priority = iPriority;
 	t.spellid = iSpellID;
@@ -2975,10 +2975,10 @@ void Bot::AddSpellToBotList(int16 iPriority, uint16 iSpellID, uint32 iType,
 	t.min_hp = min_hp;
 	t.max_hp = max_hp;
 
-	AIspells.push_back(t);
+	AIBot_spells.push_back(t);
 
 	// If we're going from an empty list, we need to start the timer
-	if (AIspells.size() == 1)
+	if (AIBot_spells.empty())
 		AIautocastspell_timer->Start(RandomTimer(0, 300), false);
 }
 
@@ -2987,15 +2987,15 @@ void Bot::AI_Bot_Event_SpellCastFinished(bool iCastSucceeded, uint16 slot) {
 	if (slot == 1) {
 		uint32 recovery_time = 0;
 		if (iCastSucceeded) {
-			if (casting_spell_AIindex < AIspells.size()) {
-					recovery_time += spells[AIspells[casting_spell_AIindex].spellid].recovery_time;
-					if (AIspells[casting_spell_AIindex].recast_delay >= 0)
+			if (casting_spell_AIindex < AIBot_spells.size()) {
+					recovery_time += spells[AIBot_spells[casting_spell_AIindex].spellid].recovery_time;
+					if (AIBot_spells[casting_spell_AIindex].recast_delay >= 0)
 					{
-						if (AIspells[casting_spell_AIindex].recast_delay < 10000)
-							AIspells[casting_spell_AIindex].time_cancast = Timer::GetCurrentTime() + (AIspells[casting_spell_AIindex].recast_delay*1000);
+						if (AIBot_spells[casting_spell_AIindex].recast_delay < 10000)
+							AIBot_spells[casting_spell_AIindex].time_cancast = Timer::GetCurrentTime() + (AIBot_spells[casting_spell_AIindex].recast_delay*1000);
 					}
 					else
-						AIspells[casting_spell_AIindex].time_cancast = Timer::GetCurrentTime() + spells[AIspells[casting_spell_AIindex].spellid].recast_time;
+						AIBot_spells[casting_spell_AIindex].time_cancast = Timer::GetCurrentTime() + spells[AIBot_spells[casting_spell_AIindex].spellid].recast_time;
 			}
 			if (recovery_time < AIautocastspell_timer->GetSetAtTrigger())
 				recovery_time = AIautocastspell_timer->GetSetAtTrigger();
@@ -3003,7 +3003,7 @@ void Bot::AI_Bot_Event_SpellCastFinished(bool iCastSucceeded, uint16 slot) {
 		}
 		else
 			AIautocastspell_timer->Start(AISpellVar.fail_recast, false);
-		casting_spell_AIindex = AIspells.size();
+		casting_spell_AIindex = AIBot_spells.size();
 	}
 }
 

--- a/zone/merc.cpp
+++ b/zone/merc.cpp
@@ -2138,11 +2138,11 @@ bool Merc::AICastSpell(int8 iChance, uint32 iSpellTypes) {
 									}
 									else {
 										//check for heal over time. if not present, try it first
-										if(!tar->FindType(SE_HealOverTime)) {
+										if (!tar->FindType(SE_HealOverTime)) {
 											selectedMercSpell = GetBestMercSpellForHealOverTime(this);
 
 											//get regular heal
-											if(selectedMercSpell.spellid == 0) {
+											if (selectedMercSpell.spellid == 0) {
 												selectedMercSpell = GetBestMercSpellForRegularSingleTargetHeal(this);
 											}
 										}

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -2988,16 +2988,9 @@ DBnpcspells_Struct *ZoneDatabase::GetNPCSpells(uint32 iDBSpellsID)
 		query = StringFormat(
 		    "SELECT spellid, type, minlevel, maxlevel, "
 		    "manacost, recast_delay, priority, min_hp, max_hp, resist_adjust "
-#ifdef BOTS
-		    "FROM %s "
-		    "WHERE npc_spells_id=%d ORDER BY minlevel",
-		    (iDBSpellsID >= 3001 && iDBSpellsID <= 3016 ? "bot_spells_entries" : "npc_spells_entries"),
-		    iDBSpellsID);
-#else
 		    "FROM npc_spells_entries "
 		    "WHERE npc_spells_id=%d ORDER BY minlevel",
 		    iDBSpellsID);
-#endif
 		results = QueryDatabase(query);
 
 		if (!results.Success()) {

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -31,6 +31,7 @@
 #include "../common/linked_list.h"
 #include "../common/servertalk.h"
 #include "../common/say_link.h"
+#include "../common/data_verification.h"
 
 #include "client.h"
 #include "entity.h"
@@ -41,6 +42,10 @@
 #include "quest_parser_collection.h"
 #include "water_map.h"
 #include "npc_scale_manager.h"
+
+#ifdef BOTS
+#include "bot.h"
+#endif
 
 #include <cctype>
 #include <stdio.h>
@@ -309,8 +314,16 @@ NPC::NPC(const NPCType *npc_type_data, Spawn2 *in_respawn, const glm::vec4 &posi
 	AISpellVar.idle_no_sp_recast_max           = static_cast<uint32>(RuleI(Spells, AI_IdleNoSpellMaxRecast));
 	AISpellVar.idle_beneficial_chance          = static_cast<uint8> (RuleI(Spells, AI_IdleBeneficialChance));
 
-	AI_Init();
-	AI_Start();
+	// It's possible for IsBot() to not be set yet during Bot loading, so have to use an alternative to catch Bots
+	if (!EQ::ValueWithin(npc_type_data->npc_spells_id, 3001, 3016)) {
+		AI_Init();
+		AI_Start();
+#ifdef BOTS
+	} else {
+		CastToBot()->AI_Bot_Init();
+		CastToBot()->AI_Bot_Start();
+#endif
+	}
 
 	d_melee_texture1 = npc_type_data->d_melee_texture1;
 	d_melee_texture2 = npc_type_data->d_melee_texture2;

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -315,7 +315,7 @@ NPC::NPC(const NPCType *npc_type_data, Spawn2 *in_respawn, const glm::vec4 &posi
 	AISpellVar.idle_beneficial_chance          = static_cast<uint8> (RuleI(Spells, AI_IdleBeneficialChance));
 
 	// It's possible for IsBot() to not be set yet during Bot loading, so have to use an alternative to catch Bots
-	if (!EQ::ValueWithin(npc_type_data->npc_spells_id, 3001, 3016)) {
+	if (!EQ::ValueWithin(npc_type_data->npc_spells_id, EQ::constants::BotSpellIDs::Warrior, EQ::constants::BotSpellIDs::Berserker)) {
 		AI_Init();
 		AI_Start();
 #ifdef BOTS

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -75,7 +75,7 @@ struct BotSpells_Struct {
 	uint32 time_cancast;	// when we can cast this spell next
 	int32  recast_delay;
 	int16  priority;
-	int32  resist_adjust;
+	int16  resist_adjust;
 	int16  min_hp;			// >0 won't cast if HP is below
 	int16  max_hp;			// >0 won't cast if HP is above
 };

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -68,6 +68,18 @@ struct AISpells_Struct {
 	int8	max_hp; // >0 won't cast if HP is above
 };
 
+struct BotSpells_Struct {
+	uint32 type;			// 0 = never, must be one (and only one) of the defined values
+	int16  spellid;			// <= 0 = no spell
+	int16  manacost;		// -1 = use spdat, -2 = no cast time
+	uint32 time_cancast;	// when we can cast this spell next
+	int32  recast_delay;
+	int16  priority;
+	int32  resist_adjust;
+	int16  min_hp;			// >0 won't cast if HP is below
+	int16  max_hp;			// >0 won't cast if HP is above
+};
+
 struct AISpellsEffects_Struct {
 	uint16	spelleffectid;
 	int32	base_value;
@@ -585,6 +597,7 @@ protected:
 
 	uint32*	pDontCastBefore_casting_spell;
 	std::vector<AISpells_Struct> AIspells;
+	std::vector<BotSpells_Struct> AIBot_spells; //Will eventually be moved to Bot Class once Bots are no longer reliant on NPC constructor
 	bool HasAISpell;
 	virtual bool AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes, bool bInnates = false);
 	virtual bool AIDoSpellCast(uint8 i, Mob* tar, int32 mana_cost, uint32* oDontDoAgainBefore = 0);

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -1874,7 +1874,8 @@ bool Zone::Depop(bool StartSpawnTimer) {
 
 	// clear spell cache
 	database.ClearNPCSpells();
-
+	database.ClearBotSpells();
+	
 	zone->spawn_group_list.ReloadSpawnGroups();
 
 	return true;

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -491,6 +491,9 @@ public:
 	void ClearNPCSpells() { npc_spells_cache.clear(); npc_spells_loadtried.clear(); }
 	const NPCType* LoadNPCTypesData(uint32 id, bool bulk_load = false);
 
+	/*Bots	*/
+	DBnpcspells_Struct*				GetBotSpells(uint32 iDBSpellsID);
+
 	/* Mercs   */
 	const	NPCType*	GetMercType(uint32 id, uint16 raceid, uint32 clientlevel);
 	void	LoadMercEquipment(Merc *merc);

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -107,6 +107,44 @@ struct DBnpcspellseffects_Struct {
 	DBnpcspellseffects_entries_Struct entries[0];
 };
 
+#pragma pack(1)
+struct DBbotspells_entries_Struct {
+	uint16	spellid;
+	uint8	minlevel;
+	uint8	maxlevel;
+	uint32	type;
+	int16	manacost;
+	int16	priority;
+	int32	recast_delay;
+	int16	resist_adjust;
+	int8	min_hp;
+	int8	max_hp;
+};
+#pragma pack()
+
+struct DBbotspells_Struct {
+	uint32	parent_list;
+	uint16	attack_proc;
+	uint8	proc_chance;
+	uint16	range_proc;
+	int16	rproc_chance;
+	uint16	defensive_proc;
+	int16	dproc_chance;
+	uint32	fail_recast;
+	uint32	engaged_no_sp_recast_min;
+	uint32	engaged_no_sp_recast_max;
+	uint8	engaged_beneficial_self_chance;
+	uint8	engaged_beneficial_other_chance;
+	uint8	engaged_detrimental_chance;
+	uint32  pursue_no_sp_recast_min;
+	uint32  pursue_no_sp_recast_max;
+	uint8   pursue_detrimental_chance;
+	uint32  idle_no_sp_recast_min;
+	uint32  idle_no_sp_recast_max;
+	uint8	idle_beneficial_chance;
+	std::vector<DBbotspells_entries_Struct> entries;
+};
+
 struct DBTradeskillRecipe_Struct {
 	EQ::skills::SkillType tradeskill;
 	int16 skill_needed;
@@ -492,7 +530,8 @@ public:
 	const NPCType* LoadNPCTypesData(uint32 id, bool bulk_load = false);
 
 	/*Bots	*/
-	DBnpcspells_Struct*	GetBotSpells(uint32 iDBSpellsID);
+	DBbotspells_Struct*	GetBotSpells(uint32 iDBSpellsID);
+	void ClearBotSpells() { Bot_Spells_Cache.clear(); Bot_Spells_LoadTried.clear(); }
 
 	/* Mercs   */
 	const	NPCType*	GetMercType(uint32 id, uint16 raceid, uint32 clientlevel);
@@ -598,6 +637,8 @@ protected:
 	std::unordered_set<uint32> npc_spells_loadtried;
 	DBnpcspellseffects_Struct** npc_spellseffects_cache;
 	bool*				npc_spellseffects_loadtried;
+	std::unordered_map<uint32, DBbotspells_Struct> Bot_Spells_Cache;
+	std::unordered_set<uint32> Bot_Spells_LoadTried;
 };
 
 extern ZoneDatabase database;

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -492,7 +492,7 @@ public:
 	const NPCType* LoadNPCTypesData(uint32 id, bool bulk_load = false);
 
 	/*Bots	*/
-	DBnpcspells_Struct*				GetBotSpells(uint32 iDBSpellsID);
+	DBnpcspells_Struct*	GetBotSpells(uint32 iDBSpellsID);
 
 	/* Mercs   */
 	const	NPCType*	GetMercType(uint32 id, uint16 raceid, uint32 clientlevel);


### PR DESCRIPTION
In Preparation of adding new Spell fields to Bot_Spells_Entries, I figured it would be easiest to separate the Spell functions Bots use.
This will reduce the chance of any issues popping up with NPC casting by splitting these off now.

Eventually I'd like to look into fully splitting off Bots. 