### PR TITLE
[Rules] Add Toggle for Warrior Shielding

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -491,6 +491,7 @@ RULE_INT(Combat, FrontalStunImmunityRaces, 512, "Bitmask for Races than have fro
 RULE_BOOL(Combat, NPCsUseFrontalStunImmunityRaces, true, "Enable or disable NPCs using frontal stun immunity Races from Combat:FrontalStunImmunityRaces, true by default.")
 RULE_BOOL(Combat, AssassinateOnlyHumanoids, true, "Enable or disable Assassinate only being allowed on Humanoids, true by default.")
 RULE_BOOL(Combat, HeadshotOnlyHumanoids, true, "Enable or disable Headshot only being allowed on Humanoids, true by default.")
+RULE_BOOL(Combat, EnableWarriorShielding, true, "Enable or disable Warrior Shielding Ability (/shield), true by default.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(NPC)

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -12978,10 +12978,14 @@ void Client::Handle_OP_Shielding(const EQApplicationPacket *app)
 		return;
 	}
 
-	pTimerType timer = pTimerShieldAbility;
+	if (!RuleB(Combat, EnableWarriorShielding)) {
+		Message(Chat::White, "/shield is disabled.");
+		return;
+	}
 
+	pTimerType timer = pTimerShieldAbility;
 	if (!p_timers.Expired(&database, timer, false)) {
-		uint32 remaining_time = p_timers.GetRemainingTime(timer);
+		auto remaining_time = p_timers.GetRemainingTime(timer);
 		Message(
 			Chat::White,
 			fmt::format(
@@ -12992,8 +12996,7 @@ void Client::Handle_OP_Shielding(const EQApplicationPacket *app)
 		return;
 	}
 
-	Shielding_Struct* shield = (Shielding_Struct*)app->pBuffer;
-
+	auto shield = (Shielding_Struct*) app->pBuffer;
 	if (ShieldAbility(shield->target_id, 15, 12000, 50, 25, true, false)) {
 		p_timers.Start(timer, SHIELD_ABILITY_RECAST_TIME);
 	}


### PR DESCRIPTION
This adds a toggle to disable the Warrior shielding ability. This will not stop the client-side message from sending when you do not have a target, but it will keep the ability from doing anything.

This message will not be disabled, but when you have a target and use it, it will tell you it's disabled.
![image](https://user-images.githubusercontent.com/89047260/197256319-f11c8400-3af1-4d7b-9c49-095bda450a04.png)
![image](https://user-images.githubusercontent.com/89047260/197256628-ba245b9d-9038-4f89-8e04-4694524f0dab.png)