### PR TITLE
[Feature] Change #scribespells to be aware of spellgroups & ranks

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10507,6 +10507,8 @@ std::vector<int> Client::GetMemmedSpells() {
 
 std::vector<int> Client::GetScribeableSpells(uint8 min_level, uint8 max_level) {
 	std::vector<int> scribeable_spells;
+	std::vector<int> spell_group_cache = BuildSpellGroupCache(max_level);
+
 	for (uint16 spell_id = 0; spell_id < SPDAT_RECORDS; ++spell_id) {
 		bool scribeable = true;
 		if (!IsValidSpell(spell_id)) {
@@ -10548,17 +10550,19 @@ std::vector<int> Client::GetScribeableSpells(uint8 min_level, uint8 max_level) {
 		}
 
 		if (spells[spell_id].spell_group) { 
-			uint32 highest_spell_id = GetHighestSpellinSpellGroup(spells[spell_id].spell_group);
-			if (
-				spells[highest_spell_id].classes[m_pp.class_ - 1] >= min_level &&
-				spells[highest_spell_id].classes[m_pp.class_ - 1] <= max_level &&
-				spell_id != highest_spell_id
-			) {
-				continue;
+			for (auto it = spell_group_cache.begin(); it != spell_group_cache.end(); it++) {
+				if (
+					spells[*it].classes[m_pp.class_ - 1] >= min_level &&
+					spells[*it].classes[m_pp.class_ - 1] <= max_level &&
+					spell_id == *it
+				) {
+					if (scribeable) {
+						scribeable_spells.push_back(spell_id);
+					}
+					continue;
+				}
 			}
-		}
-		
-		if (scribeable) {
+		} else if (scribeable) {
 			scribeable_spells.push_back(spell_id);
 		}
 	}

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10549,12 +10549,12 @@ std::vector<int> Client::GetScribeableSpells(uint8 min_level, uint8 max_level) {
 
 		if (spells[spell_id].spell_group) { 
 			uint32 highest_spell_id = GetHighestSpellinSpellGroup(spells[spell_id].spell_group);
-			if (spells[highest_spell_id].classes[m_pp.class_ - 1] <= max_level) {
-				if (spells[highest_spell_id].classes[m_pp.class_ - 1] >= min_level) {
-					if (spell_id != highest_spell_id) {
-						continue;
-					}
-				}
+			if (
+				spells[highest_spell_id].classes[m_pp.class_ - 1] >= min_level &&
+				spells[highest_spell_id].classes[m_pp.class_ - 1] <= max_level &&
+				spell_id != highest_spell_id
+			) {
+				continue;
 			}
 		}
 		

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10543,23 +10543,28 @@ std::vector<int> Client::GetScribeableSpells(uint8 min_level, uint8 max_level) {
 			continue;
 		}
 
-		if (RuleB(Spells, EnableSpellGlobals) && !SpellGlobalCheck(spell_id, CharacterID())) {
+		if (
+			RuleB(Spells, EnableSpellGlobals) &&
+			!SpellGlobalCheck(spell_id, CharacterID())
+		) {
 			scribeable = false;
-		} else if (RuleB(Spells, EnableSpellBuckets) && !SpellBucketCheck(spell_id, CharacterID())) {
+		} else if (
+			RuleB(Spells, EnableSpellBuckets) &&
+			!SpellBucketCheck(spell_id, CharacterID())
+		) {
 			scribeable = false;
 		}
 
 		if (spells[spell_id].spell_group) {
-			if (spell_group_cache.find(spells[spell_id].spell_group) != spell_group_cache.end()) {
-				for (const auto& s : spell_group_cache.find(spells[spell_id].spell_group)->second) {
+			const auto& g = spell_group_cache.find(spells[spell_id].spell_group);
+			if (g != spell_group_cache.end()) {
+				for (const auto& s : g->second) {
 					if (
-						spells[s].classes[m_pp.class_ - 1] >= min_level &&
-						spells[s].classes[m_pp.class_ - 1] <= max_level &&
-						s == spell_id
+						EQ::ValueWithin(min_level, max_level, spells[s].classes[m_pp.class_ - 1]) &&
+						s == spell_id &&
+						scribeable
 					) {
-						if (scribeable) {
-							scribeable_spells.push_back(spell_id);
-						}
+						scribeable_spells.push_back(spell_id);
 					}
 					continue;
 				}

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10557,6 +10557,7 @@ std::vector<int> Client::GetScribeableSpells(uint8 min_level, uint8 max_level) {
 				}
 			}
 		}
+		
 		if (scribeable) {
 			scribeable_spells.push_back(spell_id);
 		}

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10547,11 +10547,11 @@ std::vector<int> Client::GetScribeableSpells(uint8 min_level, uint8 max_level) {
 			scribeable = false;
 		}
 
-		if(spells[spell_id].spell_group) { 
-			int highest_spell_id = GetHighestSpellinSpellGroup(spells[spell_id].spell_group);
-			if(spells[highest_spell_id].classes[m_pp.class_ - 1] <= max_level) {
+		if (spells[spell_id].spell_group) { 
+			uint32 highest_spell_id = GetHighestSpellinSpellGroup(spells[spell_id].spell_group);
+			if (spells[highest_spell_id].classes[m_pp.class_ - 1] <= max_level) {
 				if (spells[highest_spell_id].classes[m_pp.class_ - 1] >= min_level) {
-					if(spell_id != highest_spell_id) {
+					if (spell_id != highest_spell_id) {
 						continue;
 					}
 				}
@@ -10567,7 +10567,7 @@ std::vector<int> Client::GetScribeableSpells(uint8 min_level, uint8 max_level) {
 
 std::vector<int> Client::GetScribedSpells() {
 	std::vector<int> scribed_spells;
-	for(int index = 0; index < EQ::spells::SPELLBOOK_SIZE; index++) {
+	for (int index = 0; index < EQ::spells::SPELLBOOK_SIZE; index++) {
 		if (IsValidSpell(m_pp.spell_book[index])) {
 			scribed_spells.push_back(m_pp.spell_book[index]);
 		}

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10507,7 +10507,7 @@ std::vector<int> Client::GetMemmedSpells() {
 
 std::vector<int> Client::GetScribeableSpells(uint8 min_level, uint8 max_level) {
 	std::vector<int> scribeable_spells;
-	std::vector<int> spell_group_cache = BuildSpellGroupCache(max_level);
+	std::unordered_map<uint32, std::vector<uint16>> spell_group_cache = LoadSpellGroupCache(min_level, max_level);
 
 	for (uint16 spell_id = 0; spell_id < SPDAT_RECORDS; ++spell_id) {
 		bool scribeable = true;
@@ -10549,15 +10549,17 @@ std::vector<int> Client::GetScribeableSpells(uint8 min_level, uint8 max_level) {
 			scribeable = false;
 		}
 
-		if (spells[spell_id].spell_group) { 
-			for (auto it = spell_group_cache.begin(); it != spell_group_cache.end(); it++) {
-				if (
-					spells[*it].classes[m_pp.class_ - 1] >= min_level &&
-					spells[*it].classes[m_pp.class_ - 1] <= max_level &&
-					spell_id == *it
-				) {
-					if (scribeable) {
-						scribeable_spells.push_back(spell_id);
+		if (spells[spell_id].spell_group) {
+			if (spell_group_cache.find(spells[spell_id].spell_group) != spell_group_cache.end()) {
+				for (const auto& s : spell_group_cache.find(spells[spell_id].spell_group)->second) {
+					if (
+						spells[s].classes[m_pp.class_ - 1] >= min_level &&
+						spells[s].classes[m_pp.class_ - 1] <= max_level &&
+						s == spell_id
+					) {
+						if (scribeable) {
+							scribeable_spells.push_back(spell_id);
+						}
 					}
 					continue;
 				}

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10547,6 +10547,16 @@ std::vector<int> Client::GetScribeableSpells(uint8 min_level, uint8 max_level) {
 			scribeable = false;
 		}
 
+		if(spells[spell_id].spell_group) { 
+			int highest_spell_id = GetHighestSpellinSpellGroup(spells[spell_id].spell_group);
+			if(spells[highest_spell_id].classes[m_pp.class_ - 1] <= max_level) {
+				if (spells[highest_spell_id].classes[m_pp.class_ - 1] >= min_level) {
+					if(spell_id != highest_spell_id) {
+						continue;
+					}
+				}
+			}
+		}
 		if (scribeable) {
 			scribeable_spells.push_back(spell_id);
 		}

--- a/zone/client.h
+++ b/zone/client.h
@@ -1062,6 +1062,7 @@ public:
 	inline uint32 GetSpellByBookSlot(int book_slot) { return m_pp.spell_book[book_slot]; }
 	inline bool HasSpellScribed(int spellid) { return FindSpellBookSlotBySpellID(spellid) != -1; }
 	uint32 GetHighestScribedSpellinSpellGroup(uint32 spell_group);
+	uint32 GetHighestSpellinSpellGroup(uint32 spell_group);
 	uint16 GetMaxSkillAfterSpecializationRules(EQ::skills::SkillType skillid, uint16 maxSkill);
 	void SendPopupToClient(const char *Title, const char *Text, uint32 PopupID = 0, uint32 Buttons = 0, uint32 Duration = 0);
 	void SendFullPopup(const char *Title, const char *Text, uint32 PopupID = 0, uint32 NegativeID = 0, uint32 Buttons = 0, uint32 Duration = 0, const char *ButtonName0 = 0, const char *ButtonName1 = 0, uint32 SoundControls = 0);

--- a/zone/client.h
+++ b/zone/client.h
@@ -1062,7 +1062,7 @@ public:
 	inline uint32 GetSpellByBookSlot(int book_slot) { return m_pp.spell_book[book_slot]; }
 	inline bool HasSpellScribed(int spellid) { return FindSpellBookSlotBySpellID(spellid) != -1; }
 	uint32 GetHighestScribedSpellinSpellGroup(uint32 spell_group);
-	uint32 GetHighestSpellinSpellGroup(uint32 spell_group);
+	std::vector<int> BuildSpellGroupCache(uint8 max_level);
 	uint16 GetMaxSkillAfterSpecializationRules(EQ::skills::SkillType skillid, uint16 maxSkill);
 	void SendPopupToClient(const char *Title, const char *Text, uint32 PopupID = 0, uint32 Buttons = 0, uint32 Duration = 0);
 	void SendFullPopup(const char *Title, const char *Text, uint32 PopupID = 0, uint32 NegativeID = 0, uint32 Buttons = 0, uint32 Duration = 0, const char *ButtonName0 = 0, const char *ButtonName1 = 0, uint32 SoundControls = 0);

--- a/zone/client.h
+++ b/zone/client.h
@@ -1062,7 +1062,7 @@ public:
 	inline uint32 GetSpellByBookSlot(int book_slot) { return m_pp.spell_book[book_slot]; }
 	inline bool HasSpellScribed(int spellid) { return FindSpellBookSlotBySpellID(spellid) != -1; }
 	uint32 GetHighestScribedSpellinSpellGroup(uint32 spell_group);
-	std::vector<int> BuildSpellGroupCache(uint8 max_level);
+	std::unordered_map<uint32, std::vector<uint16>> LoadSpellGroupCache(uint8 min_level, uint8 max_level);
 	uint16 GetMaxSkillAfterSpecializationRules(EQ::skills::SkillType skillid, uint16 maxSkill);
 	void SendPopupToClient(const char *Title, const char *Text, uint32 PopupID = 0, uint32 Buttons = 0, uint32 Duration = 0);
 	void SendFullPopup(const char *Title, const char *Text, uint32 PopupID = 0, uint32 NegativeID = 0, uint32 Buttons = 0, uint32 Duration = 0, const char *ButtonName0 = 0, const char *ButtonName1 = 0, uint32 SoundControls = 0);

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -5524,12 +5524,12 @@ std::unordered_map<uint32, std::vector<uint16>> Client::LoadSpellGroupCache(uint
     std::unordered_map<uint32, std::vector<uint16>> spell_group_cache;
 
     const auto query = fmt::format(
-        "SELECT a.spellgroup, a.id, a.rank "
+		"SELECT a.spellgroup, a.id, a.rank "
 		"FROM spells_new a "
 		"INNER JOIN ("
-   		"SELECT spellgroup, MAX(rank) rank "
-    	"FROM spells_new "
-    	"GROUP BY spellgroup) "
+		"SELECT spellgroup, MAX(rank) rank "
+		"FROM spells_new "
+		"GROUP BY spellgroup) "
 		"b ON a.spellgroup = b.spellgroup AND a.rank = b.rank "
 		"WHERE a.spellgroup IN (SELECT DISTINCT spellgroup FROM spells_new WHERE spellgroup != 0 and classes{} BETWEEN {} AND {}) ORDER BY rank DESC",
 		m_pp.class_, min_level, max_level

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -182,7 +182,7 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 	}
 
 	//Goal of Spells:UseSpellImpliedTargeting is to replicate the EQ2 feature where spells will 'pass through' invalid targets to target's target to try to find a valid target.
-    if (RuleB(Spells,UseSpellImpliedTargeting) && IsClient()) {
+	if (RuleB(Spells,UseSpellImpliedTargeting) && IsClient()) {
 		Mob* spell_target = entity_list.GetMobID(target_id);
 		if (spell_target) {
 			Mob* targets_target = spell_target->GetTarget();
@@ -202,7 +202,7 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 				}
 			}
 		}
-    }
+	}
 
 	if (!DoCastingChecksOnCaster(spell_id, slot) ||
 		!DoCastingChecksZoneRestrictions(true, spell_id) ||
@@ -2278,7 +2278,7 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, CastingSlot slot, in
 		}
 	}
 
-    //Guard Assist Code
+	//Guard Assist Code
 	if (RuleB(Character, PVPEnableGuardFactionAssist) && spell_target && IsDetrimentalSpell(spell_id) && spell_target != this) {
 		if (IsClient() && spell_target->IsClient()|| (HasOwner() && GetOwner()->IsClient() && spell_target->IsClient())) {
 			auto& mob_list = entity_list.GetCloseMobList(spell_target);
@@ -2591,8 +2591,8 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, CastingSlot slot, in
 		case Beam:
 		{
 			BeamDirectional(spell_id, resist_adjust);
- 			break;
- 		}
+			break;
+		}
 
 		case TargetRing:
 		{
@@ -2885,7 +2885,7 @@ int CalcBuffDuration_formula(int level, int formula, int duration)
 		temp = 10 * (level + 10);
 		break;
 	case 50: // Permanent. Cancelled by casting/combat for perm invis, non-lev zones for lev, curing poison/curse
-		 // counters, etc.
+		// counters, etc.
 		return -1;
 	case 51: // Permanent. Cancelled when out of range of aura.
 		return -4;
@@ -3108,7 +3108,7 @@ int Mob::CheckStackConflict(uint16 spellid1, int caster_level1, uint16 spellid2,
 			continue;
 
 		if (IsBardOnlyStackEffect(effect1) && GetSpellLevel(spellid1, BARD) != 255 &&
-		    GetSpellLevel(spellid2, BARD) != 255)
+			GetSpellLevel(spellid2, BARD) != 255)
 			continue;
 
 		// big ol' list according to the client, wasn't that nice!
@@ -3541,7 +3541,7 @@ bool Mob::SpellOnTarget(uint16 spell_id, Mob *spelltar, int reflect_effectivenes
 	// other AE spells this is redundant, oh well
 	// 1 = PCs, 2 = NPCs
 	if (spells[spell_id].pcnpc_only_flag && spells[spell_id].target_type != ST_AETargetHateList &&
-	    spells[spell_id].target_type != ST_HateList) {
+		spells[spell_id].target_type != ST_HateList) {
 		if (spells[spell_id].pcnpc_only_flag == 1 && !spelltar->IsClient() && !spelltar->IsMerc() && !spelltar->IsBot())
 			return false;
 		else if (spells[spell_id].pcnpc_only_flag == 2 && (spelltar->IsClient() || spelltar->IsMerc() || spelltar->IsBot()))
@@ -5521,9 +5521,9 @@ uint32 Client::GetHighestScribedSpellinSpellGroup(uint32 spell_group)
 }
 
 std::unordered_map<uint32, std::vector<uint16>> Client::LoadSpellGroupCache(uint8 min_level, uint8 max_level) {
-    std::unordered_map<uint32, std::vector<uint16>> spell_group_cache;
+	std::unordered_map<uint32, std::vector<uint16>> spell_group_cache;
 
-    const auto query = fmt::format(
+	const auto query = fmt::format(
 		"SELECT a.spellgroup, a.id, a.rank "
 		"FROM spells_new a "
 		"INNER JOIN ("
@@ -5533,7 +5533,7 @@ std::unordered_map<uint32, std::vector<uint16>> Client::LoadSpellGroupCache(uint
 		"b ON a.spellgroup = b.spellgroup AND a.rank = b.rank "
 		"WHERE a.spellgroup IN (SELECT DISTINCT spellgroup FROM spells_new WHERE spellgroup != 0 and classes{} BETWEEN {} AND {}) ORDER BY rank DESC",
 		m_pp.class_, min_level, max_level
-    );
+	);
 
 	auto results = database.QueryDatabase(query);
 	if (!results.Success() || !results.RowCount()) {
@@ -6367,7 +6367,7 @@ void Mob::BeamDirectional(uint16 spell_id, int16 resist_adjust)
 
 	while (iter != targets_in_range.end()) {
 		if (!(*iter) || (beneficial_targets && ((*iter)->IsNPC() && !(*iter)->IsPetOwnerClient())) ||
-		    (*iter)->BehindMob(this, (*iter)->GetX(), (*iter)->GetY())) {
+			(*iter)->BehindMob(this, (*iter)->GetX(), (*iter)->GetY())) {
 			++iter;
 			continue;
 		}
@@ -6456,7 +6456,7 @@ void Mob::ConeDirectional(uint16 spell_id, int16 resist_adjust)
 		}
 
 		float heading_to_target =
-		    (CalculateHeadingToTarget((*iter)->GetX(), (*iter)->GetY()) * 360.0f / 512.0f);
+			(CalculateHeadingToTarget((*iter)->GetX(), (*iter)->GetY()) * 360.0f / 512.0f);
 
 		while (heading_to_target < 0.0f)
 			heading_to_target += 360.0f;
@@ -6500,7 +6500,7 @@ void Mob::ConeDirectional(uint16 spell_id, int16 resist_adjust)
 
 		if (angle_start > angle_end) {
 			if ((heading_to_target >= angle_start && heading_to_target <= 360.0f) ||
-			    (heading_to_target >= 0.0f && heading_to_target <= angle_end)) {
+				(heading_to_target >= 0.0f && heading_to_target <= angle_end)) {
 				if (CheckLosFN((*iter)) || spells[spell_id].npc_no_los) {
 					(*iter)->CalcSpellPowerDistanceMod(spell_id, 0, this);
 					SpellOnTarget(spell_id, (*iter), 0, true, resist_adjust);

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -5520,25 +5520,22 @@ uint32 Client::GetHighestScribedSpellinSpellGroup(uint32 spell_group)
 	return highest_spell_id;
 }
 
-uint32 Client::GetHighestSpellinSpellGroup(uint32 spell_group)
-{
+std::vector<int> Client::BuildSpellGroupCache(uint8 max_level) {
 	//Typical live spells follow 1/5/10 rank value for actual ranks 1/2/3, but this can technically be set as anything.
+	std::vector<int> spell_group_cache;
 
-	int highest_rank = 0; //highest ranked found in spellgroup
-	uint32 highest_spell_id = 0;  //spell_id of the highest ranked spell
+	std::string query = fmt::format(
+		"SELECT MAX(id) FROM spells_new WHERE classes{} <= {} group by spellgroup",
+		 m_pp.class_, max_level
+	);
 
-	for (int i = 0; i < SPDAT_RECORDS; i++) {
-		if (
-			IsValidSpell(i) &&
-			spells[i].spell_group == spell_group &&
-			highest_rank < spells[i].rank
-		) {
-			highest_rank = spells[i].rank;
-			highest_spell_id = i;
-		}
+	auto results = database.QueryDatabase(query);
+
+	for (auto row = results.begin(); row != results.end(); ++row) {
+		spell_group_cache.push_back(atoi(row[0]));
 	}
 
-	return highest_spell_id;
+	return spell_group_cache;
 }
 
 bool Client::SpellGlobalCheck(uint16 spell_id, uint32 character_id) {

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -5527,16 +5527,17 @@ uint32 Client::GetHighestSpellinSpellGroup(uint32 spell_group)
 	int highest_rank = 0; //highest ranked found in spellgroup
 	uint32 highest_spell_id = 0;  //spell_id of the highest ranked spell
 
-	for (int i = 0; i < EQ::spells::SPELL_ID_MAX; i++) {
-		if (IsValidSpell(i)) {
-			if (spells[i].spell_group == spell_group) {
-				if (highest_rank < spells[i].rank) {
-					highest_rank = spells[i].rank;
-					highest_spell_id = i;
-				}
-			}
+	for (int i = 0; i < SPDAT_RECORDS; i++) {
+		if (
+			IsValidSpell(i) &&
+			spells[i].spell_group == spell_group &&
+			highest_rank < spells[i].rank
+		) {
+			highest_rank = spells[i].rank;
+			highest_spell_id = i;
 		}
 	}
+
 	return highest_spell_id;
 }
 

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -5532,7 +5532,7 @@ std::unordered_map<uint32, std::vector<uint16>> Client::LoadSpellGroupCache(uint
     	"GROUP BY spellgroup) "
 		"b ON a.spellgroup = b.spellgroup AND a.rank = b.rank "
 		"WHERE a.spellgroup IN (SELECT DISTINCT spellgroup FROM spells_new WHERE spellgroup != 0 and classes{} BETWEEN {} AND {}) ORDER BY rank DESC",
-    	m_pp.class_, min_level, max_level
+		m_pp.class_, min_level, max_level
     );
 
 	auto results = database.QueryDatabase(query);

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -5520,6 +5520,26 @@ uint32 Client::GetHighestScribedSpellinSpellGroup(uint32 spell_group)
 	return highest_spell_id;
 }
 
+uint32 Client::GetHighestSpellinSpellGroup(uint32 spell_group)
+{
+	//Typical live spells follow 1/5/10 rank value for actual ranks 1/2/3, but this can technically be set as anything.
+
+	int highest_rank = 0; //highest ranked found in spellgroup
+	uint32 highest_spell_id = 0;  //spell_id of the highest ranked spell
+
+	for (int i = 0; i < EQ::spells::SPELL_ID_MAX; i++) {
+		if (IsValidSpell(i)) {
+			if (spells[i].spell_group == spell_group) {
+				if (highest_rank < spells[i].rank) {
+					highest_rank = spells[i].rank;
+					highest_spell_id = i;
+				}
+			}
+		}
+	}
+	return highest_spell_id;
+}
+
 bool Client::SpellGlobalCheck(uint16 spell_id, uint32 character_id) {
 	std::string query = fmt::format(
 		"SELECT qglobal, value FROM spell_globals WHERE spellid = {}",


### PR DESCRIPTION
#scribespells previously wasn't aware of ranked spells.

This change will check if there's a higher rank spell available based on the max/min levels specified, and only learn the highest rank spell.

Fixes #727  
