### PR TITLE
[Quest API] Add GetAverageLevel() to Perl/Lua.

### DIFF
--- a/zone/lua_group.cpp
+++ b/zone/lua_group.cpp
@@ -77,12 +77,12 @@ int Lua_Group::GroupCount() {
 	return self->GroupCount();
 }
 
-int Lua_Group::GetHighestLevel() {
+uint32 Lua_Group::GetHighestLevel() {
 	Lua_Safe_Call_Int();
 	return self->GetHighestLevel();
 }
 
-int Lua_Group::GetLowestLevel() {
+uint32 Lua_Group::GetLowestLevel() {
 	Lua_Safe_Call_Int();
 	return self->GetLowestLevel();
 }
@@ -119,6 +119,11 @@ bool Lua_Group::DoesAnyMemberHaveExpeditionLockout(std::string expedition_name, 
 	return self->DoesAnyMemberHaveExpeditionLockout(expedition_name, event_name, max_check_count);
 }
 
+uint32 Lua_Group::GetAverageLevel() {
+	Lua_Safe_Call_Int();
+	return self->GetAvgLevel();
+}
+
 luabind::scope lua_register_group() {
 	return luabind::class_<Lua_Group>("Group")
 	.def(luabind::constructor<>())
@@ -128,11 +133,12 @@ luabind::scope lua_register_group() {
 	.def("DisbandGroup", (void(Lua_Group::*)(void))&Lua_Group::DisbandGroup)
 	.def("DoesAnyMemberHaveExpeditionLockout", (bool(Lua_Group::*)(std::string, std::string))&Lua_Group::DoesAnyMemberHaveExpeditionLockout)
 	.def("DoesAnyMemberHaveExpeditionLockout", (bool(Lua_Group::*)(std::string, std::string, int))&Lua_Group::DoesAnyMemberHaveExpeditionLockout)
-	.def("GetHighestLevel", (int(Lua_Group::*)(void))&Lua_Group::GetHighestLevel)
+	.def("GetAverageLevel", (uint32(Lua_Group::*)(void))&Lua_Group::GetAverageLevel)
+	.def("GetHighestLevel", (uint32(Lua_Group::*)(void))&Lua_Group::GetHighestLevel)
 	.def("GetID", (int(Lua_Group::*)(void))&Lua_Group::GetID)
 	.def("GetLeader", (Lua_Mob(Lua_Group::*)(void))&Lua_Group::GetLeader)
 	.def("GetLeaderName", (const char*(Lua_Group::*)(void))&Lua_Group::GetLeaderName)
-	.def("GetLowestLevel", (int(Lua_Group::*)(void))&Lua_Group::GetLowestLevel)
+	.def("GetLowestLevel", (uint32(Lua_Group::*)(void))&Lua_Group::GetLowestLevel)
 	.def("GetMember", (Lua_Mob(Lua_Group::*)(int))&Lua_Group::GetMember)
 	.def("GetTotalGroupDamage", (uint32(Lua_Group::*)(Lua_Mob))&Lua_Group::GetTotalGroupDamage)
 	.def("GroupCount", (int(Lua_Group::*)(void))&Lua_Group::GroupCount)

--- a/zone/lua_group.h
+++ b/zone/lua_group.h
@@ -39,8 +39,9 @@ public:
 	const char *GetLeaderName();
 	bool IsLeader(Lua_Mob leader);
 	int GroupCount();
-	int GetHighestLevel();
-	int GetLowestLevel();
+	uint32 GetAverageLevel();
+	uint32 GetHighestLevel();
+	uint32 GetLowestLevel();
 	void TeleportGroup(Lua_Mob sender, uint32 zone_id, uint32 instance_id, float x, float y, float z, float h);
 	int GetID();
 	Lua_Mob GetMember(int index);

--- a/zone/perl_groups.cpp
+++ b/zone/perl_groups.cpp
@@ -126,6 +126,11 @@ uint32_t Perl_Group_GetLowestLevel(Group* self) // @categories Script Utility, G
 	return self->GetLowestLevel();
 }
 
+uint32_t Perl_Group_GetAverageLevel(Group* self) // @categories Script Utility, Group
+{
+	return self->GetAvgLevel();
+}
+
 void perl_register_group()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -135,6 +140,7 @@ void perl_register_group()
 	package.add("DisbandGroup", &Perl_Group_DisbandGroup);
 	package.add("DoesAnyMemberHaveExpeditionLockout", (bool(*)(Group*, std::string, std::string))&Perl_Group_DoesAnyMemberHaveExpeditionLockout);
 	package.add("DoesAnyMemberHaveExpeditionLockout", (bool(*)(Group*, std::string, std::string, int))&Perl_Group_DoesAnyMemberHaveExpeditionLockout);
+	package.add("GetAverageLevel", &Perl_Group_GetAverageLevel);
 	package.add("GetHighestLevel", &Perl_Group_GetHighestLevel);
 	package.add("GetID", &Perl_Group_GetID);
 	package.add("GetLeader", &Perl_Group_GetLeader);


### PR DESCRIPTION
# Perl
- Add `$group->GetAverageLevel()` to Perl.

# Lua
- Add `group:GetAverageLevel()` to Lua.
- Convert `group:GetHighestLevel()` from `int` to `uint32` in Lua.
- Convert `group:GetLowestLevel()` from `int` to `uint32` in Lua.