### PR TITLE
[Quest API] Add SplitMoney() overload with Client splitter to Perl.

### DIFF
--- a/zone/perl_groups.cpp
+++ b/zone/perl_groups.cpp
@@ -51,6 +51,11 @@ void Perl_Group_SplitMoney(Group* self, uint32 copper, uint32 silver, uint32 gol
 	self->SplitMoney(copper, silver, gold, platinum);
 }
 
+void Perl_Group_SplitMoney(Group* self, uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Client* splitter) // @categories Currency and Points, Script Utility, Group
+{
+	self->SplitMoney(copper, silver, gold, platinum, splitter);
+}
+
 void Perl_Group_SetLeader(Group* self, Mob* new_leader) // @categories Account and Character, Script Utility, Group
 {
 	self->SetLeader(new_leader);
@@ -151,7 +156,8 @@ void perl_register_group()
 	package.add("SendHPPacketsTo", &Perl_Group_SendHPPacketsTo);
 	package.add("SetLeader", &Perl_Group_SetLeader);
 	package.add("SplitExp", &Perl_Group_SplitExp);
-	package.add("SplitMoney", &Perl_Group_SplitMoney);
+	package.add("SplitMoney", (void(*)(Group*, uint32, uint32, uint32, uint32))&Perl_Group_SplitMoney);
+	package.add("SplitMoney", (void(*)(Group*, uint32, uint32, uint32, uint32, Client*))&Perl_Group_SplitMoney);
 	package.add("TeleportGroup", &Perl_Group_TeleportGroup);
 }
 

--- a/zone/perl_raids.cpp
+++ b/zone/perl_raids.cpp
@@ -47,6 +47,11 @@ void Perl_Raid_SplitMoney(Raid* self, uint32 gid, uint32 copper, uint32 silver, 
 	self->SplitMoney(gid, copper, silver, gold, platinum);
 }
 
+void Perl_Raid_SplitMoney(Raid* self, uint32 gid, uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Client* splitter) // @categories Currency and Points, Raid
+{
+	self->SplitMoney(gid, copper, silver, gold, platinum, splitter);
+}
+
 void Perl_Raid_BalanceHP(Raid* self, int32_t penalty, uint32_t group_id) // @categories Raid
 {
 	self->BalanceHP(penalty, group_id);
@@ -133,7 +138,8 @@ void perl_register_raid()
 	package.add("IsRaidMember", &Perl_Raid_IsRaidMember);
 	package.add("RaidCount", &Perl_Raid_RaidCount);
 	package.add("SplitExp", &Perl_Raid_SplitExp);
-	package.add("SplitMoney", &Perl_Raid_SplitMoney);
+	package.add("SplitMoney", (void(*)(Raid*, uint32, uint32, uint32, uint32, uint32))&Perl_Raid_SplitMoney);
+	package.add("SplitMoney", (void(*)(Raid*, uint32, uint32, uint32, uint32, uint32, Client*))&Perl_Raid_SplitMoney);
 	package.add("TeleportGroup", &Perl_Raid_TeleportGroup);
 	package.add("TeleportRaid", &Perl_Raid_TeleportRaid);
 }


### PR DESCRIPTION
# Perl
- Add `$group->SplitMoney(copper, silver, gold, platinum, splitter)` to Perl.
- Add `$raid->SplitMoney(group_id, copper, silver, gold, platinum, splitter)` to Perl.