### PR TITLE
[Quest API] Add Group/Raid overloads to Perl/Lua.

### DIFF
--- a/zone/lua_group.cpp
+++ b/zone/lua_group.cpp
@@ -1,5 +1,7 @@
 #ifdef LUA_EQEMU
 
+#include "../common/data_verification.h"
+
 #include "lua.hpp"
 #include <luabind/luabind.hpp>
 #include <luabind/object.hpp>
@@ -32,7 +34,12 @@ void Lua_Group::SplitExp(uint32 exp, Lua_Mob other) {
 	self->SplitExp(exp, other);
 }
 
-void Lua_Group::GroupMessage(Lua_Mob sender, int language, const char *message) {
+void Lua_Group::GroupMessage(Lua_Mob sender, const char* message) {
+	Lua_Safe_Call_Void();
+	self->GroupMessage(sender, 0, 100, message);
+}
+
+void Lua_Group::GroupMessage(Lua_Mob sender, int language, const char* message) {
 	Lua_Safe_Call_Void();
 	self->GroupMessage(sender, language, 100, message);
 }
@@ -97,14 +104,14 @@ int Lua_Group::GetID() {
 	return self->GetID();
 }
 
-Lua_Mob Lua_Group::GetMember(int index) {
+Lua_Mob Lua_Group::GetMember(int member_index) {
 	Lua_Safe_Call_Class(Lua_Mob);
 
-	if(index >= 6 || index < 0) {
+	if (!EQ::ValueWithin(member_index, 0, 5)) {
 		return Lua_Mob();
 	}
 
-	return self->members[index];
+	return self->members[member_index];
 }
 
 bool Lua_Group::DoesAnyMemberHaveExpeditionLockout(std::string expedition_name, std::string event_name)
@@ -136,7 +143,8 @@ luabind::scope lua_register_group() {
 	.def("GetMember", (Lua_Mob(Lua_Group::*)(int))&Lua_Group::GetMember)
 	.def("GetTotalGroupDamage", (uint32(Lua_Group::*)(Lua_Mob))&Lua_Group::GetTotalGroupDamage)
 	.def("GroupCount", (int(Lua_Group::*)(void))&Lua_Group::GroupCount)
-	.def("GroupMessage", (void(Lua_Group::*)(Lua_Mob,int,const char* message))&Lua_Group::GroupMessage)
+	.def("GroupMessage", (void(Lua_Group::*)(Lua_Mob,const char*))&Lua_Group::GroupMessage)
+	.def("GroupMessage", (void(Lua_Group::*)(Lua_Mob,int,const char*))&Lua_Group::GroupMessage)
 	.def("IsGroupMember", (bool(Lua_Group::*)(Lua_Mob))&Lua_Group::IsGroupMember)
 	.def("IsLeader", (bool(Lua_Group::*)(Lua_Mob))&Lua_Group::IsLeader)
 	.def("SetLeader", (void(Lua_Group::*)(Lua_Mob))&Lua_Group::SetLeader)

--- a/zone/lua_group.h
+++ b/zone/lua_group.h
@@ -30,7 +30,8 @@ public:
 	bool IsGroupMember(Lua_Mob mob);
 	void CastGroupSpell(Lua_Mob caster, int spell_id);
 	void SplitExp(uint32 exp, Lua_Mob other);
-	void GroupMessage(Lua_Mob sender, int language, const char *message);
+	void GroupMessage(Lua_Mob sender, const char* message);
+	void GroupMessage(Lua_Mob sender, int language, const char* message);
 	uint32 GetTotalGroupDamage(Lua_Mob other);
 	void SplitMoney(uint32 copper, uint32 silver, uint32 gold, uint32 platinum);
 	void SplitMoney(uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Lua_Client splitter);
@@ -43,7 +44,7 @@ public:
 	int GetLowestLevel();
 	void TeleportGroup(Lua_Mob sender, uint32 zone_id, uint32 instance_id, float x, float y, float z, float h);
 	int GetID();
-	Lua_Mob GetMember(int index);
+	Lua_Mob GetMember(int member_index);
 	bool DoesAnyMemberHaveExpeditionLockout(std::string expedition_name, std::string event_name);
 	bool DoesAnyMemberHaveExpeditionLockout(std::string expedition_name, std::string event_name, int max_check_count);
 };

--- a/zone/lua_raid.cpp
+++ b/zone/lua_raid.cpp
@@ -1,5 +1,7 @@
 #ifdef LUA_EQEMU
 
+#include "../common/data_verification.h"
+
 #include "lua.hpp"
 #include <luabind/luabind.hpp>
 #include <luabind/object.hpp>
@@ -91,9 +93,9 @@ int Lua_Raid::GetLowestLevel() {
 	return self->GetLowestLevel();
 }
 
-Lua_Client Lua_Raid::GetClientByIndex(int index) {
+Lua_Client Lua_Raid::GetClientByIndex(int member_index) {
 	Lua_Safe_Call_Class(Lua_Client);
-	return self->GetClientByIndex(index);
+	return self->GetClientByIndex(member_index);
 }
 
 void Lua_Raid::TeleportGroup(Lua_Mob sender, uint32 zone_id, uint32 instance_id, float x, float y, float z, float h, uint32 group_id) {
@@ -111,24 +113,27 @@ int Lua_Raid::GetID() {
 	return self->GetID();
 }
 
-Lua_Client Lua_Raid::GetMember(int index) {
+Lua_Client Lua_Raid::GetMember(int member_index) {
 	Lua_Safe_Call_Class(Lua_Client);
 
-	if(index >= 72 || index < 0) {
+	if (!EQ::ValueWithin(member_index, 0, 71)) {
 		return Lua_Client();
 	}
 
-	return self->members[index].member;
+	return self->members[member_index].member;
 }
 
-int Lua_Raid::GetGroupNumber(int index) {
+int Lua_Raid::GetGroupNumber(int member_index) {
 	Lua_Safe_Call_Int();
 
-	if(index >= 72 || index < 0 || self->members[index].GroupNumber == RAID_GROUPLESS) {
+	if (
+		!EQ::ValueWithin(member_index, 0, 71) ||
+		self->members[member_index].GroupNumber == RAID_GROUPLESS
+	) {
 		return -1;
 	}
 
-	return self->members[index].GroupNumber;
+	return self->members[member_index].GroupNumber;
 }
 
 bool Lua_Raid::DoesAnyMemberHaveExpeditionLockout(std::string expedition_name, std::string event_name)

--- a/zone/lua_raid.h
+++ b/zone/lua_raid.h
@@ -42,12 +42,12 @@ public:
 	bool IsGroupLeader(const char *name);
 	int GetHighestLevel();
 	int GetLowestLevel();
-	Lua_Client GetClientByIndex(int index);
+	Lua_Client GetClientByIndex(int member_index);
 	void TeleportGroup(Lua_Mob sender, uint32 zone_id, uint32 instance_id, float x, float y, float z, float h, uint32 group_id);
 	void TeleportRaid(Lua_Mob sender, uint32 zone_id, uint32 instance_id, float x, float y, float z, float h);
 	int GetID();
-	Lua_Client GetMember(int index);
-	int GetGroupNumber(int index);
+	Lua_Client GetMember(int member_index);
+	int GetGroupNumber(int member_index);
 	bool DoesAnyMemberHaveExpeditionLockout(std::string expedition_name, std::string event_name);
 	bool DoesAnyMemberHaveExpeditionLockout(std::string expedition_name, std::string event_name, int max_check_count);
 };

--- a/zone/perl_groups.cpp
+++ b/zone/perl_groups.cpp
@@ -2,6 +2,7 @@
 
 #ifdef EMBPERL_XS_CLASSES
 
+#include "../common/data_verification.h"
 #include "../common/global_define.h"
 #include "embperl.h"
 #include "groups.h"
@@ -34,10 +35,10 @@ void Perl_Group_GroupMessage(Group* self, Mob* sender, const char* message) // @
 
 void Perl_Group_GroupMessage(Group* self, Mob* sender, uint8_t language, const char* message) // @categories Script Utility, Group
 {
-	if ((language >= MAX_PP_LANGUAGE) || (language < 0))
-	{
+	if (!EQ::ValueWithin(language, 0, (MAX_PP_LANGUAGE - 1))) {
 		language = 0;
 	}
+
 	self->GroupMessage(sender, language, 100, message);
 }
 
@@ -101,13 +102,13 @@ uint32_t Perl_Group_GetID(Group* self) // @categories Script Utility, Group
 	return self->GetID();
 }
 
-Client* Perl_Group_GetMember(Group* self, int group_index) // @categories Account and Character, Script Utility, Group
+Client* Perl_Group_GetMember(Group* self, int member_index) // @categories Account and Character, Script Utility, Group
 {
 	Mob* member = nullptr;
-	if (group_index >= 0 && group_index < 6)
-	{
-		member = self->members[group_index];
+	if (EQ::ValueWithin(member_index, 0, 5)) {
+		member = self->members[member_index];
 	}
+
 	return member ? member->CastToClient() : nullptr;
 }
 

--- a/zone/perl_raids.cpp
+++ b/zone/perl_raids.cpp
@@ -2,6 +2,7 @@
 
 #ifdef EMBPERL_XS_CLASSES
 
+#include "../common/data_verification.h"
 #include "../common/global_define.h"
 #include "embperl.h"
 #include "raids.h"
@@ -32,6 +33,11 @@ uint32_t Perl_Raid_GetGroup(Raid* self, const char* name) // @categories Group, 
 	return self->GetGroup(name);
 }
 
+uint32_t Perl_Raid_GetGroup(Raid* self, Client* client) // @categories Group, Raid
+{
+	return self->GetGroup(client);
+}
+
 void Perl_Raid_SplitExp(Raid* self, uint32 experience, Mob* other) // @categories Experience and Level, Raid
 {
 	self->SplitExp(experience, other);
@@ -57,6 +63,11 @@ bool Perl_Raid_IsLeader(Raid* self, const char* name) // @categories Raid
 	return self->IsLeader(name);
 }
 
+bool Perl_Raid_IsLeader(Raid* self, Client* client) // @categories Raid
+{
+	return self->IsLeader(client);
+}
+
 bool Perl_Raid_IsGroupLeader(Raid* self, const char* who) // @categories Group, Raid
 {
 	return self->IsGroupLeader(who);
@@ -72,9 +83,9 @@ uint32_t Perl_Raid_GetLowestLevel(Raid* self) // @categories Raid
 	return self->GetLowestLevel();
 }
 
-Client* Perl_Raid_GetClientByIndex(Raid* self, uint16_t raid_index) // @categories Raid
+Client* Perl_Raid_GetClientByIndex(Raid* self, uint16_t member_index) // @categories Raid
 {
-	return self->GetClientByIndex(raid_index);
+	return self->GetClientByIndex(member_index);
 }
 
 void Perl_Raid_TeleportGroup(Raid* self, Mob* sender, uint32 zone_id, float x, float y, float z, float heading, uint32 group_id) // @categories Group, Raid
@@ -92,13 +103,13 @@ uint32_t Perl_Raid_GetID(Raid* self) // @categories Raid
 	return self->GetID();
 }
 
-Client* Perl_Raid_GetMember(Raid* self, int index) // @categories Raid
+Client* Perl_Raid_GetMember(Raid* self, int member_index) // @categories Raid
 {
-	if (index < 0 || index >= MAX_RAID_MEMBERS)
-	{
+	if (!EQ::ValueWithin(member_index, 0, (MAX_RAID_MEMBERS - 1))) {
 		return nullptr;
 	}
-	return self->members[index].member;
+
+	return self->members[member_index].member;
 }
 
 bool Perl_Raid_DoesAnyMemberHaveExpeditionLockout(Raid* self, std::string expedition_name, std::string event_name)
@@ -111,6 +122,17 @@ bool Perl_Raid_DoesAnyMemberHaveExpeditionLockout(Raid* self, std::string expedi
 	return self->DoesAnyMemberHaveExpeditionLockout(expedition_name, event_name, max_check_count);
 }
 
+int Perl_Raid_GetGroupNumber(Raid* self, int member_index) {
+	if (
+		!EQ::ValueWithin(member_index, 0, 71) ||
+		self->members[member_index].GroupNumber == RAID_GROUPLESS
+	) {
+		return -1;
+	}
+
+	return self->members[member_index].GroupNumber;
+}
+
 void perl_register_raid()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -121,7 +143,9 @@ void perl_register_raid()
 	package.add("DoesAnyMemberHaveExpeditionLockout", (bool(*)(Raid*, std::string, std::string))&Perl_Raid_DoesAnyMemberHaveExpeditionLockout);
 	package.add("DoesAnyMemberHaveExpeditionLockout", (bool(*)(Raid*, std::string, std::string, int))&Perl_Raid_DoesAnyMemberHaveExpeditionLockout);
 	package.add("GetClientByIndex", &Perl_Raid_GetClientByIndex);
-	package.add("GetGroup", &Perl_Raid_GetGroup);
+	package.add("GetGroup", (uint32(*)(Raid*, const char*))&Perl_Raid_GetGroup);
+	package.add("GetGroup", (uint32(*)(Raid*, Client*))&Perl_Raid_GetGroup);
+	package.add("GetGroupNumber", &Perl_Raid_GetGroupNumber);
 	package.add("GetHighestLevel", &Perl_Raid_GetHighestLevel);
 	package.add("GetID", &Perl_Raid_GetID);
 	package.add("GetLowestLevel", &Perl_Raid_GetLowestLevel);
@@ -129,7 +153,8 @@ void perl_register_raid()
 	package.add("GetTotalRaidDamage", &Perl_Raid_GetTotalRaidDamage);
 	package.add("GroupCount", &Perl_Raid_GroupCount);
 	package.add("IsGroupLeader", &Perl_Raid_IsGroupLeader);
-	package.add("IsLeader", &Perl_Raid_IsLeader);
+	package.add("IsLeader", (bool(*)(Raid*, const char*))&Perl_Raid_IsLeader);
+	package.add("IsLeader", (bool(*)(Raid*, Client*))&Perl_Raid_IsLeader);
 	package.add("IsRaidMember", &Perl_Raid_IsRaidMember);
 	package.add("RaidCount", &Perl_Raid_RaidCount);
 	package.add("SplitExp", &Perl_Raid_SplitExp);


### PR DESCRIPTION
# Perl
- Add `$raid->GetGroup(client)` to Perl.
- Add `$raid->GetGroupMember(member_index)` to Perl.
- Add `$raid->IsLeader(client)` to Perl.

# Lua
- Add `group:GroupMessage(sender, message)` to Lua.