### PR TITLE
[Quest API] Add SendGMCommand() to Perl/Lua.

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -1118,7 +1118,7 @@ void Client::ChannelMessageReceived(uint8 chan_num, uint8 language, uint8 lang_s
 	}
 	case ChatChannel_Say: { /* Say */
 		if (message[0] == COMMAND_CHAR) {
-			if (command_dispatch(this, message) == -2) {
+			if (command_dispatch(this, message, false) == -2) {
 				if (parse->PlayerHasQuestSub(EVENT_COMMAND)) {
 					int i = parse->EventPlayer(EVENT_COMMAND, this, message, 0);
 					if (i == 0 && !RuleB(Chat, SuppressCommandErrors)) {
@@ -11742,4 +11742,8 @@ void Client::AddAAPoints(uint32 points)
 	}
 
 	SendAlternateAdvancementStats();
+}
+
+bool Client::SendGMCommand(std::string message, bool ignore_status) {
+	return command_dispatch(this, message, ignore_status) > 0 ? true : false;
 }

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -11745,5 +11745,5 @@ void Client::AddAAPoints(uint32 points)
 }
 
 bool Client::SendGMCommand(std::string message, bool ignore_status) {
-	return command_dispatch(this, message, ignore_status) > 0 ? true : false;
+	return command_dispatch(this, message, ignore_status) >= 0 ? true : false;
 }

--- a/zone/client.h
+++ b/zone/client.h
@@ -908,6 +908,8 @@ public:
 	int GetSpentAA() { return m_pp.aapoints_spent; }
 	uint32 GetRequiredAAExperience();
 
+	bool SendGMCommand(std::string message, bool ignore_status = false);
+
 	//old AA methods that we still use
 	void ResetAA();
 	void RefundAA();

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -48,7 +48,7 @@ int command_count; // how many commands we have
 
 // this is the pointer to the dispatch function, updated once
 // init has been performed to point at the real function
-int (*command_dispatch)(Client *,std::string) = command_notavail;
+int (*command_dispatch)(Client *,std::string,bool) = command_notavail;
 
 std::map<std::string, CommandRecord *> commandlist;
 std::map<std::string, std::string> commandaliases;
@@ -63,7 +63,7 @@ std::map<std::string, uint8> commands_map;
  *	not used
  *
  */
-int command_notavail(Client *c, std::string message)
+int command_notavail(Client *c, std::string message, bool ignore_status)
 {
 	c->Message(Chat::White, "Commands not available.");
 	return -1;
@@ -557,7 +557,7 @@ uint8 GetCommandStatus(Client *c, std::string command_name) {
  *	message		- what the client typed
  *
  */
-int command_realdispatch(Client *c, std::string message)
+int command_realdispatch(Client *c, std::string message, bool ignore_status)
 {
 	Seperator sep(message.c_str(), ' ', 10, 100, true); // "three word argument" should be considered 1 arg
 
@@ -570,7 +570,7 @@ int command_realdispatch(Client *c, std::string message)
 	}
 
 	auto cur = commandlist[cstr];
-	if (c->Admin() < cur->admin) {
+	if (!ignore_status && c->Admin() < cur->admin) {
 		c->Message(Chat::White, "Your status is not high enough to use this command.");
 		return -1;
 	}

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -48,7 +48,7 @@ int command_count; // how many commands we have
 
 // this is the pointer to the dispatch function, updated once
 // init has been performed to point at the real function
-int (*command_dispatch)(Client *,std::string,bool) = command_notavail;
+int (*command_dispatch)(Client *, std::string, bool) = command_notavail;
 
 std::map<std::string, CommandRecord *> commandlist;
 std::map<std::string, std::string> commandaliases;

--- a/zone/command.h
+++ b/zone/command.h
@@ -17,7 +17,7 @@ typedef struct {
 	CmdFuncPtr function; // null means perl function
 } CommandRecord;
 
-extern int (*command_dispatch)(Client *,std::string,bool);
+extern int (*command_dispatch)(Client *, std::string, bool);
 extern int command_count; // Commands Loaded Count
 
 // Command Utilities

--- a/zone/command.h
+++ b/zone/command.h
@@ -17,15 +17,15 @@ typedef struct {
 	CmdFuncPtr function; // null means perl function
 } CommandRecord;
 
-extern int (*command_dispatch)(Client *,std::string);
+extern int (*command_dispatch)(Client *,std::string,bool);
 extern int command_count; // Commands Loaded Count
 
 // Command Utilities
 int command_init(void);
 void command_deinit(void);
 int command_add(std::string command_name, std::string description, uint8 admin, CmdFuncPtr function);
-int command_notavail(Client *c, std::string message);
-int command_realdispatch(Client *c, std::string message);
+int command_notavail(Client *c, std::string message, bool ignore_status);
+int command_realdispatch(Client *c, std::string message, bool ignore_status);
 void command_logcommand(Client *c, std::string message);
 uint8 GetCommandStatus(Client *c, std::string command_name);
 void ListModifyNPCStatMap(Client *c);

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -2593,6 +2593,16 @@ bool Lua_Client::HasRecipeLearned(uint32 recipe_id) {
 	return self->HasRecipeLearned(recipe_id);
 }
 
+bool Lua_Client::SendGMCommand(std::string message) {
+	Lua_Safe_Call_Bool();
+	return self->SendGMCommand(message);
+}
+
+bool Lua_Client::SendGMCommand(std::string message, bool ignore_status) {
+	Lua_Safe_Call_Bool();
+	return self->SendGMCommand(message, ignore_status);
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 	.def(luabind::constructor<>())
@@ -2913,7 +2923,9 @@ luabind::scope lua_register_client() {
 	.def("ScribeSpells", (uint16(Lua_Client::*)(uint8,uint8))&Lua_Client::ScribeSpells)
 	.def("SendColoredText", (void(Lua_Client::*)(uint32, std::string))&Lua_Client::SendColoredText)
 	.def("SendItemScale", (void(Lua_Client::*)(Lua_ItemInst))&Lua_Client::SendItemScale)
-	.def("SendMarqueeMessage", (void(Lua_Client::*)(uint32, uint32, uint32, uint32, uint32, std::string))&Lua_Client::SendMarqueeMessage)
+	.def("SendGMCommand", (bool(Lua_Client::*)(std::string))&Lua_Client::SendGMCommand)
+	.def("SendGMCommand", (bool(Lua_Client::*)(std::string,bool))&Lua_Client::SendGMCommand)
+	.def("SendMarqueeMessage", (void(Lua_Client::*)(uint32,uint32,uint32,uint32,uint32,std::string))&Lua_Client::SendMarqueeMessage)
 	.def("SendOPTranslocateConfirm", (void(Lua_Client::*)(Lua_Mob,int))&Lua_Client::SendOPTranslocateConfirm)
 	.def("SendPEQZoneFlagInfo", (void(Lua_Client::*)(Lua_Client))&Lua_Client::SendPEQZoneFlagInfo)
 	.def("SendSound", (void(Lua_Client::*)(void))&Lua_Client::SendSound)

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -2925,7 +2925,7 @@ luabind::scope lua_register_client() {
 	.def("SendItemScale", (void(Lua_Client::*)(Lua_ItemInst))&Lua_Client::SendItemScale)
 	.def("SendGMCommand", (bool(Lua_Client::*)(std::string))&Lua_Client::SendGMCommand)
 	.def("SendGMCommand", (bool(Lua_Client::*)(std::string,bool))&Lua_Client::SendGMCommand)
-	.def("SendMarqueeMessage", (void(Lua_Client::*)(uint32,uint32,uint32,uint32,uint32,std::string))&Lua_Client::SendMarqueeMessage)
+	.def("SendMarqueeMessage", (void(Lua_Client::*)(uint32, uint32, uint32, uint32, uint32, std::string))&Lua_Client::SendMarqueeMessage)
 	.def("SendOPTranslocateConfirm", (void(Lua_Client::*)(Lua_Mob,int))&Lua_Client::SendOPTranslocateConfirm)
 	.def("SendPEQZoneFlagInfo", (void(Lua_Client::*)(Lua_Client))&Lua_Client::SendPEQZoneFlagInfo)
 	.def("SendSound", (void(Lua_Client::*)(void))&Lua_Client::SendSound)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -446,6 +446,9 @@ public:
 	void SetClientMaxLevel(uint8 max_level);
 	uint8 GetClientMaxLevel();
 
+	bool SendGMCommand(std::string message);
+	bool SendGMCommand(std::string message, bool ignore_status);
+
 	void DialogueWindow(std::string markdown);
 
 	Lua_Expedition  CreateExpedition(luabind::object expedition_info);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -2487,6 +2487,16 @@ bool Perl_Client_HasRecipeLearned(Client* self, uint32 recipe_id) // @categories
 	return self->HasRecipeLearned(recipe_id);
 }
 
+bool Perl_Client_SendGMCommand(Client* self, std::string message) // @categories Script Utility
+{
+	return self->SendGMCommand(message);
+}
+
+bool Perl_Client_SendGMCommand(Client* self, std::string message, bool ignore_status) // @categories Script Utility
+{
+	return self->SendGMCommand(message, ignore_status);
+}
+
 void perl_register_client()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -2805,6 +2815,8 @@ void perl_register_client()
 	package.add("ScribeSpell", (void(*)(Client*, uint16, int, bool))&Perl_Client_ScribeSpell);
 	package.add("ScribeSpells", &Perl_Client_ScribeSpells);
 	package.add("SendColoredText", &Perl_Client_SendColoredText);
+	package.add("SendGMCommand", (bool(*)(Client*, std::string))&Perl_Client_SendGMCommand);
+	package.add("SendGMCommand", (bool(*)(Client*, std::string, bool))&Perl_Client_SendGMCommand);
 	package.add("SendMarqueeMessage", &Perl_Client_SendMarqueeMessage);
 	package.add("SendOPTranslocateConfirm", &Perl_Client_SendOPTranslocateConfirm);
 	package.add("SendPEQZoneFlagInfo", &Perl_Client_SendPEQZoneFlagInfo);


### PR DESCRIPTION
# Perl
- Add `$client->SendGMCommand(message)` to Perl.
- Add `$client->SendGMCommand(message, ignore_status)` to Perl.

# Lua
- Add `client:SendGMCommand(message)` to Lua.
- Add `client:SendGMCommand(message, ignore_status)` to Lua.

# Notes
- `ignore_status` allows you to have players use GM commands that they are not the required status level for through the Quest API.
- `ignore_status` is default false, so if you don't send it, it checks and makes sure the player can use the command you're sending before allowing it.