### PR TITLE
[Commands] Cleanup #emote Command.

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -132,7 +132,7 @@ int command_init(void)
 		command_add("dz", "Manage expeditions and dynamic zone instances", AccountStatus::QuestTroupe, command_dz) ||
 		command_add("dzkickplayers", "Removes all players from current expedition. (/kickplayers alternative for pre-RoF clients)", AccountStatus::Player, command_dzkickplayers) ||
 		command_add("editmassrespawn", "[name-search] [second-value] - Mass (Zone wide) NPC respawn timer editing command", AccountStatus::GMAdmin, command_editmassrespawn) ||
-		command_add("emote", "['name'/'world'/'zone'] [type] [message] - Send an emote message", AccountStatus::QuestTroupe, command_emote) ||
+		command_add("emote", "[Name|World|Zone] [type] [message] - Send an emote message by name, to the world, or to your zone (^ separator allows multiple messages to be sent at once)", AccountStatus::QuestTroupe, command_emote) ||
 		command_add("emotesearch", "[Search Criteria] - Search for NPC Emotes", AccountStatus::QuestTroupe, command_emotesearch) ||
 		command_add("emoteview", "Lists all NPC Emotes", AccountStatus::QuestTroupe, command_emoteview) ||
 		command_add("emptyinventory", "Clears your or your target's entire inventory (Equipment, General, Bank, and Shared Bank)", AccountStatus::GMImpossible, command_emptyinventory) ||

--- a/zone/gm_commands/emote.cpp
+++ b/zone/gm_commands/emote.cpp
@@ -5,41 +5,53 @@ extern WorldServer worldserver;
 
 void command_emote(Client *c, const Seperator *sep)
 {
-	if (sep->arg[3][0] == 0) {
-		c->Message(Chat::White, "Usage: #emote [name | world | zone] type# message");
+	auto arguments = sep->argnum;
+	if (arguments < 3 || !sep->IsNumber(2)) {
+		c->Message(Chat::White, "Usage: #emote name [Type] [Message]");
+		c->Message(Chat::White, "Usage: #emote world [Type] [Message]");
+		c->Message(Chat::White, "Usage: #emote zone [Type] [Message]");
+		return;
 	}
-	else {
-		if (strcasecmp(sep->arg[1], "zone") == 0) {
-			char *newmessage = 0;
-			if (strstr(sep->arg[3], "^") == 0) {
-				entity_list.Message(0, atoi(sep->arg[2]), sep->argplus[3]);
-			}
-			else {
-				for (newmessage = strtok((char *) sep->arg[3], "^");
-					newmessage != nullptr;
-					newmessage = strtok(nullptr, "^"))
-					entity_list.Message(0, atoi(sep->arg[2]), newmessage);
-			}
+
+	if (!worldserver.Connected()) {
+		c->Message(Chat::White, "Error: World server disconnected!");
+		return;
+	}
+
+	bool is_world = !strcasecmp(sep->arg[1], "world");
+	bool is_zone = !strcasecmp(sep->arg[1], "zone");
+
+	const std::string emote_message = sep->argplus[3];
+	const auto emote_type = std::stoul(sep->arg[2]);
+
+	if (is_zone) {
+		if (!Strings::Contains(emote_message, "^")) {
+			entity_list.Message(0, emote_type, emote_message.c_str());
+			return;
 		}
-		else if (!worldserver.Connected()) {
-			c->Message(Chat::White, "Error: World server disconnected");
+
+		for (const auto& m : Strings::Split(emote_message, "^")) {
+			entity_list.Message(0, emote_type, m.c_str());
 		}
-		else if (!strcasecmp(sep->arg[1], "world")) {
+	} else {
+		if (!Strings::Contains(emote_message, "^")) {
 			worldserver.SendEmoteMessage(
+				is_world ? 0 : sep->arg[1],
 				0,
-				0,
-				atoi(sep->arg[2]),
-				sep->argplus[3]
+				emote_type,
+				emote_message.c_str()
 			);
+			return;
 		}
-		else {
+
+		for (const auto& m : Strings::Split(emote_message, "^")) {
 			worldserver.SendEmoteMessage(
-				sep->arg[1],
+				is_world ? 0 : sep->arg[1],
 				0,
-				atoi(sep->arg[2]),
-				sep->argplus[3]
+				emote_type,
+				m.c_str()
 			);
-		}
+ 		}
 	}
 }
 

--- a/zone/gm_commands/emote.cpp
+++ b/zone/gm_commands/emote.cpp
@@ -7,7 +7,7 @@ void command_emote(Client *c, const Seperator *sep)
 {
 	auto arguments = sep->argnum;
 	if (arguments < 3 || !sep->IsNumber(2)) {
-		c->Message(Chat::White, "Usage: #emote name [Type] [Message]");
+		c->Message(Chat::White, "Usage: #emote [Name] [Type] [Message]");
 		c->Message(Chat::White, "Usage: #emote world [Type] [Message]");
 		c->Message(Chat::White, "Usage: #emote zone [Type] [Message]");
 		return;


### PR DESCRIPTION
- Cleanup messages and logic.
- Allow `^` separator to send multiple messages by name, world, or zone.