### PR TITLE
[Commands] Cleanup #depop Command.

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -120,7 +120,7 @@ int command_init(void)
 		command_add("dbspawn2", "[Spawngroup ID] [Respawn] [Variance] [Condition ID] [Condition Minimum] - Spawn an NPC from a predefined row in the spawn2 table, Respawn and Variance are in Seconds (condition is optional)", AccountStatus::GMAdmin, command_dbspawn2) ||
 		command_add("delacct", "[accountname] - Delete an account", AccountStatus::GMLeadAdmin, command_delacct) ||
 		command_add("delpetition", "[petition number] - Delete a petition", AccountStatus::ApprenticeGuide, command_delpetition) ||
-		command_add("depop", "Depop your NPC target", AccountStatus::Guide, command_depop) ||
+		command_add("depop", "[Start Spawn Timer] Depop your NPC target and optionally start their spawn timer (false by default)", AccountStatus::Guide, command_depop) ||
 		command_add("depopzone", "Depop the zone", AccountStatus::GMAdmin, command_depopzone) ||
 		command_add("devtools", "Manages devtools", AccountStatus::GMMgmt, command_devtools) ||
 		command_add("disablerecipe",  "[Recipe ID] - Disables a Recipe", AccountStatus::QuestTroupe, command_disablerecipe) ||

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -120,7 +120,7 @@ int command_init(void)
 		command_add("dbspawn2", "[Spawngroup ID] [Respawn] [Variance] [Condition ID] [Condition Minimum] - Spawn an NPC from a predefined row in the spawn2 table, Respawn and Variance are in Seconds (condition is optional)", AccountStatus::GMAdmin, command_dbspawn2) ||
 		command_add("delacct", "[accountname] - Delete an account", AccountStatus::GMLeadAdmin, command_delacct) ||
 		command_add("delpetition", "[petition number] - Delete a petition", AccountStatus::ApprenticeGuide, command_delpetition) ||
-		command_add("depop", "[Start Spawn Timer] Depop your NPC target and optionally start their spawn timer (false by default)", AccountStatus::Guide, command_depop) ||
+		command_add("depop", "[Start Spawn Timer] - Depop your NPC target and optionally start their spawn timer (false by default)", AccountStatus::Guide, command_depop) ||
 		command_add("depopzone", "Depop the zone", AccountStatus::GMAdmin, command_depopzone) ||
 		command_add("devtools", "Manages devtools", AccountStatus::GMMgmt, command_devtools) ||
 		command_add("disablerecipe",  "[Recipe ID] - Disables a Recipe", AccountStatus::QuestTroupe, command_disablerecipe) ||

--- a/zone/gm_commands/depop.cpp
+++ b/zone/gm_commands/depop.cpp
@@ -3,12 +3,25 @@
 
 void command_depop(Client *c, const Seperator *sep)
 {
-	if (c->GetTarget() == 0 || !(c->GetTarget()->IsNPC() || c->GetTarget()->IsNPCCorpse())) {
-		c->Message(Chat::White, "You must have a NPC target for this command. (maybe you meant #depopzone?)");
+	if (!c->GetTarget() || !c->GetTarget()->IsNPC()) {
+		c->Message(Chat::White, "You must target an NPC to use this command.");
+		return;
 	}
-	else {
-		c->Message(Chat::White, "Depoping '%s'.", c->GetTarget()->GetName());
-		c->GetTarget()->Depop();
-	}
-}
 
+	auto start_spawn_timer = false;
+
+	if (sep->IsNumber(1)) {
+		start_spawn_timer = std::stoi(sep->arg[1]) ? true : false;
+	}
+
+	c->Message(
+		Chat::White,
+		fmt::format(
+			"Depopping {}{}.",
+			c->GetTargetDescription(c->GetTarget()),
+			start_spawn_timer ? " and starting their spawn timer" : ""
+		).c_str()
+	);
+
+	c->GetTarget()->Depop(start_spawn_timer);
+}


### PR DESCRIPTION
- Cleanup messages and logic.
- Add optional `start_spawn_timer` parameter to start spawn timer of NPC when depopped.