### PR TITLE
[Quest API] Add GetRandomClient(), GetRandomMob() and GetRandomNPC() overloads to Perl/Lua.

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -1865,12 +1865,20 @@ Client *EntityList::GetClientByLSID(uint32 iLSID)
 
 Client *EntityList::GetRandomClient(const glm::vec3& location, float distance, Client *exclude_client)
 {
+	auto is_whole_zone = false;
+	if (location.x == 0.0f && location.y == 0.0f) {
+		is_whole_zone = true;
+	}
+
 	std::vector<Client*> clients_in_range;
 
 	for (const auto& client : client_list) {
 		if (
 			client.second != exclude_client &&
-			DistanceSquared(static_cast<glm::vec3>(client.second->GetPosition()), location) <= distance
+			(
+				is_whole_zone ||
+				DistanceSquared(static_cast<glm::vec3>(client.second->GetPosition()), location) <= distance
+			)
 		) {
 			clients_in_range.push_back(client.second);
 		}
@@ -1885,12 +1893,20 @@ Client *EntityList::GetRandomClient(const glm::vec3& location, float distance, C
 
 NPC* EntityList::GetRandomNPC(const glm::vec3& location, float distance, NPC* exclude_npc)
 {
+	auto is_whole_zone = false;
+	if (location.x == 0.0f && location.y == 0.0f) {
+		is_whole_zone = true;
+	}
+
 	std::vector<NPC*> npcs_in_range;
 
 	for (const auto& npc : npc_list) {
 		if (
 			npc.second != exclude_npc &&
-			DistanceSquared(static_cast<glm::vec3>(npc.second->GetPosition()), location) <= distance
+			(
+				is_whole_zone ||
+				DistanceSquared(static_cast<glm::vec3>(npc.second->GetPosition()), location) <= distance
+			)
 		) {
 			npcs_in_range.push_back(npc.second);
 		}
@@ -1905,12 +1921,20 @@ NPC* EntityList::GetRandomNPC(const glm::vec3& location, float distance, NPC* ex
 
 Mob* EntityList::GetRandomMob(const glm::vec3& location, float distance, Mob* exclude_mob)
 {
+	auto is_whole_zone = false;
+	if (location.x == 0.0f && location.y == 0.0f) {
+		is_whole_zone = true;
+	}
+
 	std::vector<Mob*> mobs_in_range;
 
 	for (const auto& mob : mob_list) {
 		if (
 			mob.second != exclude_mob &&
-			DistanceSquared(static_cast<glm::vec3>(mob.second->GetPosition()), location) <= distance
+			(
+				is_whole_zone ||
+				DistanceSquared(static_cast<glm::vec3>(mob.second->GetPosition()), location) <= distance
+			)
 		) {
 			mobs_in_range.push_back(mob.second);
 		}

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -189,9 +189,9 @@ public:
 	Client *GetClientByWID(uint32 iWID);
 	Client *GetClientByLSID(uint32 iLSID);
 	Client *GetClient(uint32 ip, uint16 port);
-	Client* GetRandomClient(const glm::vec3& location, float distance, Client* exclude_client = nullptr);
-	NPC* GetRandomNPC(const glm::vec3& location, float distance, NPC* exclude_npc = nullptr);
-	Mob* GetRandomMob(const glm::vec3& location, float distance, Mob* exclude_mob = nullptr);
+	Client* GetRandomClient(const glm::vec3& location = glm::vec3(0.f), float distance = 0, Client* exclude_client = nullptr);
+	NPC* GetRandomNPC(const glm::vec3& location = glm::vec3(0.f), float distance = 0, NPC* exclude_npc = nullptr);
+	Mob* GetRandomMob(const glm::vec3& location = glm::vec3(0.f), float distance = 0, Mob* exclude_mob = nullptr);
 	Group *GetGroupByMob(Mob* mob);
 	bool IsInSameGroupOrRaidGroup(Client *client1, Client *client2);
 	Group *GetGroupByClient(Client* client);

--- a/zone/lua_entity_list.cpp
+++ b/zone/lua_entity_list.cpp
@@ -331,6 +331,11 @@ void Lua_EntityList::MessageGroup(Lua_Mob who, bool skip_close, uint32 type, con
 	self->MessageGroup(who, skip_close, type, message);
 }
 
+Lua_Client Lua_EntityList::GetRandomClient() {
+	Lua_Safe_Call_Class(Lua_Client);
+	return self->GetRandomClient();
+}
+
 Lua_Client Lua_EntityList::GetRandomClient(float x, float y, float z, float distance) {
 	Lua_Safe_Call_Class(Lua_Client);
 	return self->GetRandomClient(glm::vec3(x, y, z), distance);
@@ -520,6 +525,11 @@ void Lua_EntityList::ChannelMessage(Lua_Mob from, int channel_num, int language,
 	self->ChannelMessage(from, channel_num, language, message);
 }
 
+Lua_Mob Lua_EntityList::GetRandomMob() {
+	Lua_Safe_Call_Class(Lua_Mob);
+	return self->GetRandomMob();
+}
+
 Lua_Mob Lua_EntityList::GetRandomMob(float x, float y, float z, float distance) {
 	Lua_Safe_Call_Class(Lua_Mob);
 	return self->GetRandomMob(glm::vec3(x, y, z), distance);
@@ -528,6 +538,11 @@ Lua_Mob Lua_EntityList::GetRandomMob(float x, float y, float z, float distance) 
 Lua_Mob Lua_EntityList::GetRandomMob(float x, float y, float z, float distance, Lua_Mob exclude_mob) {
 	Lua_Safe_Call_Class(Lua_Mob);
 	return self->GetRandomMob(glm::vec3(x, y, z), distance, exclude_mob);
+}
+
+Lua_NPC Lua_EntityList::GetRandomNPC() {
+	Lua_Safe_Call_Class(Lua_NPC);
+	return self->GetRandomNPC();
 }
 
 Lua_NPC Lua_EntityList::GetRandomNPC(float x, float y, float z, float distance) {
@@ -594,10 +609,13 @@ luabind::scope lua_register_entity_list() {
 	.def("GetObjectList", (Lua_Object_List(Lua_EntityList::*)(void))&Lua_EntityList::GetObjectList)
 	.def("GetRaidByClient", (Lua_Raid(Lua_EntityList::*)(Lua_Client))&Lua_EntityList::GetRaidByClient)
 	.def("GetRaidByID", (Lua_Raid(Lua_EntityList::*)(int))&Lua_EntityList::GetRaidByID)
-	.def("GetRandomClient", (Lua_Client(Lua_EntityList::*)(float, float, float, float))&Lua_EntityList::GetRandomClient)
-	.def("GetRandomClient", (Lua_Client(Lua_EntityList::*)(float, float, float, float, Lua_Client))&Lua_EntityList::GetRandomClient)
+	.def("GetRandomClient", (Lua_Client(Lua_EntityList::*)(void))&Lua_EntityList::GetRandomClient)
+	.def("GetRandomClient", (Lua_Client(Lua_EntityList::*)(float,float,float,float))&Lua_EntityList::GetRandomClient)
+	.def("GetRandomClient", (Lua_Client(Lua_EntityList::*)(float,float,float,float, Lua_Client))&Lua_EntityList::GetRandomClient)
+	.def("GetRandomMob", (Lua_Mob(Lua_EntityList::*)(void))&Lua_EntityList::GetRandomMob)
 	.def("GetRandomMob", (Lua_Mob(Lua_EntityList::*)(float,float,float,float))&Lua_EntityList::GetRandomMob)
 	.def("GetRandomMob", (Lua_Mob(Lua_EntityList::*)(float,float,float,float,Lua_Mob))&Lua_EntityList::GetRandomMob)
+	.def("GetRandomNPC", (Lua_NPC(Lua_EntityList::*)(void))&Lua_EntityList::GetRandomNPC)
 	.def("GetRandomNPC", (Lua_NPC(Lua_EntityList::*)(float,float,float,float))&Lua_EntityList::GetRandomNPC)
 	.def("GetRandomNPC", (Lua_NPC(Lua_EntityList::*)(float,float,float,float,Lua_NPC))&Lua_EntityList::GetRandomNPC)
 	.def("GetShuffledClientList", (Lua_Client_List(Lua_EntityList::*)(void))&Lua_EntityList::GetShuffledClientList)

--- a/zone/lua_entity_list.cpp
+++ b/zone/lua_entity_list.cpp
@@ -611,7 +611,7 @@ luabind::scope lua_register_entity_list() {
 	.def("GetRaidByID", (Lua_Raid(Lua_EntityList::*)(int))&Lua_EntityList::GetRaidByID)
 	.def("GetRandomClient", (Lua_Client(Lua_EntityList::*)(void))&Lua_EntityList::GetRandomClient)
 	.def("GetRandomClient", (Lua_Client(Lua_EntityList::*)(float,float,float,float))&Lua_EntityList::GetRandomClient)
-	.def("GetRandomClient", (Lua_Client(Lua_EntityList::*)(float,float,float,float, Lua_Client))&Lua_EntityList::GetRandomClient)
+	.def("GetRandomClient", (Lua_Client(Lua_EntityList::*)(float,float,float,float,Lua_Client))&Lua_EntityList::GetRandomClient)
 	.def("GetRandomMob", (Lua_Mob(Lua_EntityList::*)(void))&Lua_EntityList::GetRandomMob)
 	.def("GetRandomMob", (Lua_Mob(Lua_EntityList::*)(float,float,float,float))&Lua_EntityList::GetRandomMob)
 	.def("GetRandomMob", (Lua_Mob(Lua_EntityList::*)(float,float,float,float,Lua_Mob))&Lua_EntityList::GetRandomMob)

--- a/zone/lua_entity_list.h
+++ b/zone/lua_entity_list.h
@@ -108,10 +108,13 @@ public:
 	void RemoveFromHateLists(Lua_Mob who);
 	void RemoveFromHateLists(Lua_Mob who, bool set_to_one);
 	void MessageGroup(Lua_Mob who, bool skip_close, uint32 type, const char *message);
+	Lua_Client GetRandomClient();
 	Lua_Client GetRandomClient(float x, float y, float z, float distance);
 	Lua_Client GetRandomClient(float x, float y, float z, float distance, Lua_Client exclude_client);
+	Lua_Mob GetRandomMob();
 	Lua_Mob GetRandomMob(float x, float y, float z, float distance);
 	Lua_Mob GetRandomMob(float x, float y, float z, float distance, Lua_Mob exclude_mob);
+	Lua_NPC GetRandomNPC();
 	Lua_NPC GetRandomNPC(float x, float y, float z, float distance);
 	Lua_NPC GetRandomNPC(float x, float y, float z, float distance, Lua_NPC exclude_npc);
 	Lua_Mob_List GetMobList();

--- a/zone/perl_entity.cpp
+++ b/zone/perl_entity.cpp
@@ -352,6 +352,11 @@ void Perl_EntityList_MessageGroup(EntityList* self, Mob* sender, bool skip_close
 	self->MessageGroup(sender, skip_close, emote_color_type, message);
 }
 
+Client* Perl_EntityList_GetRandomClient(EntityList* self) // @categories Account and Character, Script Utility
+{
+	return entity_list.GetRandomClient();
+}
+
 Client* Perl_EntityList_GetRandomClient(EntityList* self, float x, float y, float z, float distance) // @categories Account and Character, Script Utility
 {
 	return entity_list.GetRandomClient(glm::vec3(x, y, z), (distance * distance));
@@ -496,6 +501,11 @@ void Perl_EntityList_SignalAllClients(EntityList* self, uint32_t data) // @categ
 	entity_list.SignalAllClients(data);
 }
 
+Mob* Perl_EntityList_GetRandomMob(EntityList* self) // @categories Account and Character, Script Utility
+{
+	return entity_list.GetRandomMob();
+}
+
 Mob* Perl_EntityList_GetRandomMob(EntityList* self, float x, float y, float z, float distance) // @categories Account and Character, Script Utility
 {
 	return entity_list.GetRandomMob(glm::vec3(x, y, z), (distance * distance));
@@ -504,6 +514,11 @@ Mob* Perl_EntityList_GetRandomMob(EntityList* self, float x, float y, float z, f
 Mob* Perl_EntityList_GetRandomMob(EntityList* self, float x, float y, float z, float distance, Mob* exclude_mob) // @categories Account and Character, Script Utility
 {
 	return entity_list.GetRandomMob(glm::vec3(x, y, z), (distance * distance), exclude_mob);
+}
+
+NPC* Perl_EntityList_GetRandomNPC(EntityList* self) // @categories Account and Character, Script Utility
+{
+	return entity_list.GetRandomNPC();
 }
 
 NPC* Perl_EntityList_GetRandomNPC(EntityList* self, float x, float y, float z, float distance) // @categories Account and Character, Script Utility
@@ -569,10 +584,13 @@ void perl_register_entitylist()
 	package.add("GetObjectList", &Perl_EntityList_GetObjectList);
 	package.add("GetRaidByClient", &Perl_EntityList_GetRaidByClient);
 	package.add("GetRaidByID", &Perl_EntityList_GetRaidByID);
+	package.add("GetRandomClient", (Client*(*)(EntityList*))&Perl_EntityList_GetRandomClient);
 	package.add("GetRandomClient", (Client*(*)(EntityList*, float, float, float, float))&Perl_EntityList_GetRandomClient);
 	package.add("GetRandomClient", (Client*(*)(EntityList*, float, float, float, float, Client*))&Perl_EntityList_GetRandomClient);
+	package.add("GetRandomMob", (Mob*(*)(EntityList*))&Perl_EntityList_GetRandomMob);
 	package.add("GetRandomMob", (Mob*(*)(EntityList*, float, float, float, float))&Perl_EntityList_GetRandomMob);
 	package.add("GetRandomMob", (Mob*(*)(EntityList*, float, float, float, float, Mob*))&Perl_EntityList_GetRandomMob);
+	package.add("GetRandomNPC", (NPC*(*)(EntityList*))&Perl_EntityList_GetRandomNPC);
 	package.add("GetRandomNPC", (NPC*(*)(EntityList*, float, float, float, float))&Perl_EntityList_GetRandomNPC);
 	package.add("GetRandomNPC", (NPC*(*)(EntityList*, float, float, float, float, NPC*))&Perl_EntityList_GetRandomNPC);
 	package.add("HalveAggro", &Perl_EntityList_HalveAggro);


### PR DESCRIPTION
# Perl
- Add `$entity_list->GetRandomClient()` to Perl.
- Add `$entity_list->GetRandomMob()` to Perl.
- Add `$entity_list->GetRandomNPC()` to Perl.

# Lua
- Add `eq.get_entity_list():GetRandomClient()` to Lua.
- Add `eq.get_entity_list():GetRandomMob()` to Lua.
- Add `eq.get_entity_list():GetRandomNPC()` to Lua.

# Notes
- We didn't have overloads before without XYZ, so was harder to do a zone-wide random.