### PR TITLE
[Quest API] Add Owner methods to Perl/Lua.

### DIFF
--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -2728,7 +2728,7 @@ luabind::scope lua_register_mob() {
 	.def("GetNimbusEffect3", (uint8(Lua_Mob::*)(void))&Lua_Mob::GetNimbusEffect3)
 	.def("GetOrigBodyType", &Lua_Mob::GetOrigBodyType)
 	.def("GetOwner", &Lua_Mob::GetOwner)
-	.def("GetOwner", &Lua_Mob::GetOwnerID)
+	.def("GetOwnerID", &Lua_Mob::GetOwnerID)
 	.def("GetPR", &Lua_Mob::GetPR)
 	.def("GetPet", &Lua_Mob::GetPet)
 	.def("GetPetOrder", (int(Lua_Mob::*)(void))&Lua_Mob::GetPetOrder)

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -2488,6 +2488,11 @@ void Lua_Mob::CloneAppearance(Lua_Mob other, bool clone_name) {
 	self->CloneAppearance(other, clone_name);
 }
 
+uint16 Lua_Mob::GetOwnerID() {
+	Lua_Safe_Call_Int();
+	return self->GetOwnerID();
+}
+
 luabind::scope lua_register_mob() {
 	return luabind::class_<Lua_Mob, Lua_Entity>("Mob")
 	.def(luabind::constructor<>())
@@ -2723,6 +2728,7 @@ luabind::scope lua_register_mob() {
 	.def("GetNimbusEffect3", (uint8(Lua_Mob::*)(void))&Lua_Mob::GetNimbusEffect3)
 	.def("GetOrigBodyType", &Lua_Mob::GetOrigBodyType)
 	.def("GetOwner", &Lua_Mob::GetOwner)
+	.def("GetOwner", &Lua_Mob::GetOwnerID)
 	.def("GetPR", &Lua_Mob::GetPR)
 	.def("GetPet", &Lua_Mob::GetPet)
 	.def("GetPetOrder", (int(Lua_Mob::*)(void))&Lua_Mob::GetPetOrder)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -206,6 +206,7 @@ public:
 	void SpellEffect(Lua_Mob caster, int spell_id, double partial);
 	Lua_Mob GetPet();
 	Lua_Mob GetOwner();
+	uint16 GetOwnerID();
 	Lua_Mob GetUltimateOwner();
 	Lua_HateList GetHateList();
 	Lua_HateList GetShuffledHateList();

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -1035,7 +1035,7 @@ void Perl_Mob_SetOwnerID(Mob* self, uint16 new_owner_id) // @categories Pet
 	self->SetOwnerID(new_owner_id);
 }
 
-int Perl_Mob_GetOwnerID(Mob* self) // @categories Script Utility, Pet
+uint16 Perl_Mob_GetOwnerID(Mob* self) // @categories Script Utility, Pet
 {
 	return self->GetOwnerID();
 }
@@ -2467,6 +2467,11 @@ void Perl_Mob_CloneAppearance(Mob* self, Mob* other, bool clone_name) // @catego
 	self->CloneAppearance(other, clone_name);
 }
 
+Mob* Perl_Mob_GetOwner(Mob* self) // @categories Script Utility, Pet
+{
+	return self->GetOwner();
+}
+
 #ifdef BOTS
 Bot* Perl_Mob_CastToBot(Mob* self)
 {
@@ -2701,6 +2706,7 @@ void perl_register_mob()
 	package.add("GetNimbusEffect1", &Perl_Mob_GetNimbusEffect1);
 	package.add("GetNimbusEffect2", &Perl_Mob_GetNimbusEffect2);
 	package.add("GetNimbusEffect3", &Perl_Mob_GetNimbusEffect3);
+	package.add("GetOwner", &Perl_Mob_GetOwner);
 	package.add("GetOwnerID", &Perl_Mob_GetOwnerID);
 	package.add("GetPR", &Perl_Mob_GetPR);
 	package.add("GetPetID", &Perl_Mob_GetPetID);


### PR DESCRIPTION
# Perl
- Add `$mob->GetOwner()` to Perl.

# Lua
- Add `mob:GetOwnerID()` to Lua.

# Notes
- `GetOwner()` exists in Lua, but not Perl.
- `GetOwnerID()` exists in Perl, but not Lua.