### PR TITLE
[Commands] Remove #profiledump and #profilereset Commands.

### DIFF
--- a/zone/command.h
+++ b/zone/command.h
@@ -197,11 +197,6 @@ void command_petitioninfo(Client *c, const Seperator *sep);
 void command_picklock(Client *c, const Seperator *sep);
 void command_profanity(Client *c, const Seperator *sep);
 
-#ifdef EQPROFILE
-void command_profiledump(Client *c, const Seperator *sep);
-void command_profilereset(Client *c, const Seperator *sep);
-#endif
-
 void command_proximity(Client *c, const Seperator *sep);
 void command_push(Client *c, const Seperator *sep);
 void command_pvp(Client *c, const Seperator *sep);

--- a/zone/gm_commands/profilereset.cpp
+++ b/zone/gm_commands/profilereset.cpp
@@ -1,8 +1,0 @@
-#include "../client.h"
-
-void command_profilereset(Client *c, const Seperator *sep)
-{
-	ResetZoneProfile();
-}
-#endif
-


### PR DESCRIPTION
- These commands don't seem to be used anymore.