### PR TITLE
[Quest API] Add Mob Hate Methods to Perl/Lua.

### DIFF
--- a/zone/hate_list.cpp
+++ b/zone/hate_list.cpp
@@ -850,19 +850,6 @@ void HateList::RemoveStaleEntries(int time_ms, float dist)
 	}
 }
 
-std::list<struct_HateList*> HateList::GetHateListByDistance(int distance)
-{
-	std::list<struct_HateList*> hate_list;
-	int squared_distance = (distance * distance);
-	for (auto hate_iterator : list) {
-		auto hate_entry = hate_iterator->entity_on_hatelist;
-		if (distance == 0 || (distance > 0 && DistanceSquaredNoZ(hate_owner->GetPosition(), hate_entry->GetPosition()) <= squared_distance)) {
-			hate_list.push_back(hate_iterator);
-		}
-	}
-	return hate_list;
-}
-
 #ifdef BOTS
 Bot* HateList::GetRandomBotOnHateList(bool skip_mezzed)
 {
@@ -1010,4 +997,73 @@ NPC* HateList::GetRandomNPCOnHateList(bool skip_mezzed)
 	}
 
 	return nullptr;
+}
+
+void HateList::DamageHateList(int64 damage, uint32 distance, uint8 filter_type, bool is_percentage)
+{
+	if (damage <= 0) {
+		return;
+	}
+
+	std::list<struct_HateList*> damage_list;
+	const auto squared_distance = (distance * distance);
+	for (auto h : list) {
+		auto hate_entry = h->entity_on_hatelist;
+		if (
+			(
+				!distance ||
+				DistanceSquaredNoZ(
+					hate_owner->GetPosition(),
+					hate_entry->GetPosition()
+				) <= squared_distance
+			) &&
+			(
+				filter_type == HateListFilterTypes::All ||
+				(filter_type == HateListFilterTypes::Bots && hate_entry->IsBot()) ||
+				(filter_type == HateListFilterTypes::Clients && hate_entry->IsClient()) ||
+				(filter_type == HateListFilterTypes::NPCs && hate_entry->IsNPC())
+			)
+		) {
+			damage_list.push_back(h);
+		}
+	}
+
+	for (const auto& d : damage_list) {
+		auto hate_entry = d->entity_on_hatelist;
+		if (is_percentage) {
+			const auto damage_percentage = EQ::Clamp(damage, static_cast<int64>(1), static_cast<int64>(100));
+			const auto total_damage = hate_entry->GetMaxHP() / damage_percentage * 100;
+			hate_entry->Damage(hate_owner, total_damage, SPELL_UNKNOWN, EQ::skills::SkillEagleStrike);
+		} else {
+			hate_entry->Damage(hate_owner, damage, SPELL_UNKNOWN, EQ::skills::SkillEagleStrike);
+		}
+	}
+}
+
+std::list<struct_HateList*> HateList::GetFilteredHateList(uint32 distance, uint8 filter_type)
+{
+	std::list<struct_HateList*> filtered_hate_list;
+	const auto squared_distance = (distance * distance);
+	for (auto h : list) {
+		auto hate_entry = h->entity_on_hatelist;
+		if (
+			(
+				!distance ||
+				DistanceSquaredNoZ(
+					hate_owner->GetPosition(),
+					hate_entry->GetPosition()
+				) <= squared_distance
+			) &&
+			(
+				filter_type == HateListFilterTypes::All ||
+				(filter_type == HateListFilterTypes::Bots && hate_entry->IsBot()) ||
+				(filter_type == HateListFilterTypes::Clients && hate_entry->IsClient()) ||
+				(filter_type == HateListFilterTypes::NPCs && hate_entry->IsNPC())
+			)
+		) {
+			filtered_hate_list.push_back(h);
+		}
+	}
+
+	return filtered_hate_list;
 }

--- a/zone/hate_list.cpp
+++ b/zone/hate_list.cpp
@@ -1005,31 +1005,9 @@ void HateList::DamageHateList(int64 damage, uint32 distance, uint8 filter_type, 
 		return;
 	}
 
-	std::list<struct_HateList*> damage_list;
-	const auto squared_distance = (distance * distance);
-	for (auto h : list) {
+	const auto& h_list = GetFilteredHateList(distance, filter_type);
+	for (const auto& h : h_list) {
 		auto hate_entry = h->entity_on_hatelist;
-		if (
-			(
-				!distance ||
-				DistanceSquaredNoZ(
-					hate_owner->GetPosition(),
-					hate_entry->GetPosition()
-				) <= squared_distance
-			) &&
-			(
-				filter_type == HateListFilterTypes::All ||
-				(filter_type == HateListFilterTypes::Bots && hate_entry->IsBot()) ||
-				(filter_type == HateListFilterTypes::Clients && hate_entry->IsClient()) ||
-				(filter_type == HateListFilterTypes::NPCs && hate_entry->IsNPC())
-			)
-		) {
-			damage_list.push_back(h);
-		}
-	}
-
-	for (const auto& d : damage_list) {
-		auto hate_entry = d->entity_on_hatelist;
 		if (is_percentage) {
 			const auto damage_percentage = EQ::Clamp(damage, static_cast<int64>(1), static_cast<int64>(100));
 			const auto total_damage = hate_entry->GetMaxHP() / damage_percentage * 100;

--- a/zone/hate_list.h
+++ b/zone/hate_list.h
@@ -34,6 +34,13 @@ struct struct_HateList {
 	uint32 last_modified; // we need to remove this if it gets higher than 10 mins
 };
 
+enum HateListFilterTypes : uint8 {
+	All,
+	Bots,
+	Clients,
+	NPCs
+};
+
 class HateList {
 public:
 	HateList();
@@ -64,7 +71,17 @@ public:
 	int64 GetEntHateAmount(Mob *ent, bool in_damage = false);
 
 	std::list<struct_HateList *> &GetHateList() { return list; }
-	std::list<struct_HateList *> GetHateListByDistance(int distance = 0);
+	std::list<struct_HateList *> GetFilteredHateList(
+		uint32 distance = 0,
+		uint8 filter_type = HateListFilterTypes::All
+	);
+
+	void DamageHateList(
+		int64 damage,
+		uint32 distance = 0,
+		uint8 filter_type = HateListFilterTypes::All,
+		bool is_percentage = false
+	);
 
 	void AddEntToHateList(
 		Mob *ent,

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -2357,22 +2357,26 @@ Lua_Mob Lua_Mob::GetHateClosest() {
 Lua_HateList Lua_Mob::GetHateListByDistance() {
 	Lua_Safe_Call_Class(Lua_HateList);
 	Lua_HateList ret;
-	auto list = self->GetHateListByDistance();
-	for (auto hate_entry : list) {
-		Lua_HateEntry entry(hate_entry);
-		ret.entries.push_back(entry);
+
+	auto h_list = self->GetFilteredHateList();
+	for (auto h : h_list) {
+		Lua_HateEntry e(h);
+		ret.entries.push_back(e);
 	}
+
 	return ret;
 }
 
-Lua_HateList Lua_Mob::GetHateListByDistance(int distance) {
+Lua_HateList Lua_Mob::GetHateListByDistance(uint32 distance) {
 	Lua_Safe_Call_Class(Lua_HateList);
 	Lua_HateList ret;
-	auto list = self->GetHateListByDistance(distance);
-	for (auto hate_entry : list) {
-		Lua_HateEntry entry(hate_entry);
-		ret.entries.push_back(entry);
+
+	auto h_list = self->GetFilteredHateList(distance);
+	for (auto h : h_list) {
+		Lua_HateEntry e(h);
+		ret.entries.push_back(e);
 	}
+
 	return ret;
 }
 
@@ -2503,6 +2507,166 @@ uint16 Lua_Mob::GetOwnerID() {
 	return self->GetOwnerID();
 }
 
+void Lua_Mob::DamageHateList(int64 damage) {
+	Lua_Safe_Call_Void();
+	self->DamageHateList(damage);
+}
+
+void Lua_Mob::DamageHateList(int64 damage, uint32 distance) {
+	Lua_Safe_Call_Void();
+	self->DamageHateList(damage, distance);
+}
+
+void Lua_Mob::DamageHateListClients(int64 damage) {
+	Lua_Safe_Call_Void();
+	self->DamageHateList(damage, 0, HateListFilterTypes::Clients);
+}
+
+void Lua_Mob::DamageHateListClients(int64 damage, uint32 distance) {
+	Lua_Safe_Call_Void();
+	self->DamageHateList(damage, distance, HateListFilterTypes::Clients);
+}
+
+void Lua_Mob::DamageHateListNPCs(int64 damage) {
+	Lua_Safe_Call_Void();
+	self->DamageHateList(damage, 0, HateListFilterTypes::NPCs);
+}
+
+void Lua_Mob::DamageHateListNPCs(int64 damage, uint32 distance) {
+	Lua_Safe_Call_Void();
+	self->DamageHateList(damage, distance, HateListFilterTypes::NPCs);
+}
+
+void Lua_Mob::DamageHateListPercentage(int64 damage) {
+	Lua_Safe_Call_Void();
+	self->DamageHateList(damage, 0, HateListFilterTypes::All, true);
+}
+
+void Lua_Mob::DamageHateListPercentage(int64 damage, uint32 distance) {
+	Lua_Safe_Call_Void();
+	self->DamageHateList(damage, distance, HateListFilterTypes::All, true);
+}
+
+void Lua_Mob::DamageHateListClientsPercentage(int64 damage) {
+	Lua_Safe_Call_Void();
+	self->DamageHateList(damage, 0, HateListFilterTypes::Clients, true);
+}
+
+void Lua_Mob::DamageHateListClientsPercentage(int64 damage, uint32 distance) {
+	Lua_Safe_Call_Void();
+	self->DamageHateList(damage, distance, HateListFilterTypes::Clients, true);
+}
+
+void Lua_Mob::DamageHateListNPCsPercentage(int64 damage) {
+	Lua_Safe_Call_Void();
+	self->DamageHateList(damage, 0, HateListFilterTypes::NPCs, true);
+}
+
+void Lua_Mob::DamageHateListNPCsPercentage(int64 damage, uint32 distance) {
+	Lua_Safe_Call_Void();
+	self->DamageHateList(damage, distance, HateListFilterTypes::NPCs, true);
+}
+
+Lua_HateList Lua_Mob::GetHateListClients() {
+	Lua_Safe_Call_Class(Lua_HateList);
+	Lua_HateList ret;
+
+	auto h_list = self->GetFilteredHateList(0, HateListFilterTypes::Clients);
+	for (auto h : h_list) {
+		Lua_HateEntry e(h);
+		ret.entries.push_back(e);
+	}
+
+	return ret;
+}
+
+Lua_HateList Lua_Mob::GetHateListClients(uint32 distance) {
+	Lua_Safe_Call_Class(Lua_HateList);
+	Lua_HateList ret;
+
+	auto h_list = self->GetFilteredHateList(distance, HateListFilterTypes::Clients);
+	for (auto h : h_list) {
+		Lua_HateEntry e(h);
+		ret.entries.push_back(e);
+	}
+
+	return ret;
+}
+
+Lua_HateList Lua_Mob::GetHateListNPCs() {
+	Lua_Safe_Call_Class(Lua_HateList);
+	Lua_HateList ret;
+
+	auto h_list = self->GetFilteredHateList(0, HateListFilterTypes::NPCs);
+	for (auto h : h_list) {
+		Lua_HateEntry e(h);
+		ret.entries.push_back(e);
+	}
+
+	return ret;
+}
+
+Lua_HateList Lua_Mob::GetHateListNPCs(uint32 distance) {
+	Lua_Safe_Call_Class(Lua_HateList);
+	Lua_HateList ret;
+
+	auto h_list = self->GetFilteredHateList(distance, HateListFilterTypes::NPCs);
+	for (auto h : h_list) {
+		Lua_HateEntry e(h);
+		ret.entries.push_back(e);
+	}
+
+	return ret;
+}
+
+#ifdef BOTS
+void Lua_Mob::DamageHateListBots(int64 damage) {
+	Lua_Safe_Call_Void();
+	self->DamageHateList(damage, 0, HateListFilterTypes::Bots);
+}
+
+void Lua_Mob::DamageHateListBots(int64 damage, uint32 distance) {
+	Lua_Safe_Call_Void();
+	self->DamageHateList(damage, distance, HateListFilterTypes::Bots);
+}
+
+void Lua_Mob::DamageHateListBotsPercentage(int64 damage) {
+	Lua_Safe_Call_Void();
+	self->DamageHateList(damage, 0, HateListFilterTypes::Bots, true);
+}
+
+void Lua_Mob::DamageHateListBotsPercentage(int64 damage, uint32 distance) {
+	Lua_Safe_Call_Void();
+	self->DamageHateList(damage, distance, HateListFilterTypes::Bots, true);
+}
+
+Lua_HateList Lua_Mob::GetHateListBots() {
+	Lua_Safe_Call_Class(Lua_HateList);
+	Lua_HateList ret;
+
+	auto h_list = self->GetFilteredHateList(0, HateListFilterTypes::Bots);
+	for (auto h : h_list) {
+		Lua_HateEntry e(h);
+		ret.entries.push_back(e);
+	}
+
+	return ret;
+}
+
+Lua_HateList Lua_Mob::GetHateListBots(uint32 distance) {
+	Lua_Safe_Call_Class(Lua_HateList);
+	Lua_HateList ret;
+
+	auto h_list = self->GetFilteredHateList(distance, HateListFilterTypes::Bots);
+	for (auto h : h_list) {
+		Lua_HateEntry e(h);
+		ret.entries.push_back(e);
+	}
+
+	return ret;
+}
+#endif
+
 luabind::scope lua_register_mob() {
 	return luabind::class_<Lua_Mob, Lua_Entity>("Mob")
 	.def(luabind::constructor<>())
@@ -2589,6 +2753,24 @@ luabind::scope lua_register_mob() {
 	.def("Damage", (void(Lua_Mob::*)(Lua_Mob,int64,int,int,bool))&Lua_Mob::Damage)
 	.def("Damage", (void(Lua_Mob::*)(Lua_Mob,int64,int,int,bool,int))&Lua_Mob::Damage)
 	.def("Damage", (void(Lua_Mob::*)(Lua_Mob,int64,int,int,bool,int,bool))&Lua_Mob::Damage)
+	.def("DamageHateList", (void(Lua_Mob::*)(int64))&Lua_Mob::DamageHateList)
+	.def("DamageHateList", (void(Lua_Mob::*)(int64,uint32))&Lua_Mob::DamageHateList)
+#ifdef BOTS
+	.def("DamageHateListBots", (void(Lua_Mob::*)(int64))&Lua_Mob::DamageHateListBots)
+	.def("DamageHateListBots", (void(Lua_Mob::*)(int64,uint32))&Lua_Mob::DamageHateListBots)
+	.def("DamageHateListBotsPercentage", (void(Lua_Mob::*)(int64))&Lua_Mob::DamageHateListBots)
+	.def("DamageHateListBotsPercentage", (void(Lua_Mob::*)(int64,uint32))&Lua_Mob::DamageHateListBots)
+#endif
+	.def("DamageHateListClients", (void(Lua_Mob::*)(int64))&Lua_Mob::DamageHateListClients)
+	.def("DamageHateListClients", (void(Lua_Mob::*)(int64,uint32))&Lua_Mob::DamageHateListClients)
+	.def("DamageHateListClientsPercentage", (void(Lua_Mob::*)(int64))&Lua_Mob::DamageHateListClientsPercentage)
+	.def("DamageHateListClientsPercentage", (void(Lua_Mob::*)(int64,uint32))&Lua_Mob::DamageHateListClientsPercentage)
+	.def("DamageHateListNPCs", (void(Lua_Mob::*)(int64))&Lua_Mob::DamageHateListNPCs)
+	.def("DamageHateListNPCs", (void(Lua_Mob::*)(int64,uint32))&Lua_Mob::DamageHateListNPCs)
+	.def("DamageHateListNPCsPercentage", (void(Lua_Mob::*)(int64))&Lua_Mob::DamageHateListNPCsPercentage)
+	.def("DamageHateListNPCsPercentage", (void(Lua_Mob::*)(int64,uint32))&Lua_Mob::DamageHateListNPCsPercentage)
+	.def("DamageHateListPercentage", (void(Lua_Mob::*)(int64))&Lua_Mob::DamageHateListPercentage)
+	.def("DamageHateListPercentage", (void(Lua_Mob::*)(int64,uint32))&Lua_Mob::DamageHateListPercentage)
 	.def("DelGlobal", (void(Lua_Mob::*)(const char*))&Lua_Mob::DelGlobal)
 	.def("DeleteBucket", (void(Lua_Mob::*)(std::string))&Lua_Mob::DeleteBucket)
 	.def("Depop", (void(Lua_Mob::*)(bool))&Lua_Mob::Depop)
@@ -2690,8 +2872,16 @@ luabind::scope lua_register_mob() {
 	.def("GetHateClosest", &Lua_Mob::GetHateClosest)
 	.def("GetHateDamageTop", (Lua_Mob(Lua_Mob::*)(Lua_Mob))&Lua_Mob::GetHateDamageTop)
 	.def("GetHateList", &Lua_Mob::GetHateList)
-	.def("GetHateListByDistance", (Lua_HateList(Lua_Mob::*)(int))&Lua_Mob::GetHateListByDistance)
+#ifdef BOTS
+	.def("GetHateListBots", (Lua_HateList(Lua_Mob::*)(void))&Lua_Mob::GetHateListBots)
+	.def("GetHateListBots", (Lua_HateList(Lua_Mob::*)(uint32))&Lua_Mob::GetHateListBots)
+#endif
+	.def("GetHateListClients", (Lua_HateList(Lua_Mob::*)(void))&Lua_Mob::GetHateListClients)
+	.def("GetHateListClients", (Lua_HateList(Lua_Mob::*)(uint32))&Lua_Mob::GetHateListClients)
+	.def("GetHateListNPCs", (Lua_HateList(Lua_Mob::*)(void))&Lua_Mob::GetHateListNPCs)
+	.def("GetHateListNPCs", (Lua_HateList(Lua_Mob::*)(uint32))&Lua_Mob::GetHateListNPCs)
 	.def("GetHateListByDistance", (Lua_HateList(Lua_Mob::*)(void))&Lua_Mob::GetHateListByDistance)
+	.def("GetHateListByDistance", (Lua_HateList(Lua_Mob::*)(uint32))&Lua_Mob::GetHateListByDistance)
 	.def("GetHateRandom", (Lua_Mob(Lua_Mob::*)(void))&Lua_Mob::GetHateRandom)
 #ifdef BOTS
 	.def("GetHateRandomBot", (Lua_Bot(Lua_Mob::*)(void))&Lua_Mob::GetHateRandomBot)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -211,9 +211,17 @@ public:
 	uint16 GetOwnerID();
 	Lua_Mob GetUltimateOwner();
 	Lua_HateList GetHateList();
+#ifdef BOTS
+	Lua_HateList GetHateListBots();
+	Lua_HateList GetHateListBots(uint32 distance);
+#endif
+	Lua_HateList GetHateListClients();
+	Lua_HateList GetHateListClients(uint32 distance);
+	Lua_HateList GetHateListNPCs();
+	Lua_HateList GetHateListNPCs(uint32 distance);
 	Lua_HateList GetShuffledHateList();
 	Lua_HateList GetHateListByDistance();
-	Lua_HateList GetHateListByDistance(int distance);
+	Lua_HateList GetHateListByDistance(uint32 distance);
 	Lua_Mob GetHateTop();
 	Lua_Mob GetHateDamageTop(Lua_Mob other);
 	Lua_Mob GetHateRandom();
@@ -468,6 +476,24 @@ public:
 	void SetBuffDuration(int spell_id, int duration);
 	void CloneAppearance(Lua_Mob other);
 	void CloneAppearance(Lua_Mob other, bool clone_name);
+	void DamageHateList(int64 damage);
+	void DamageHateList(int64 damage, uint32 distance);
+	void DamageHateListPercentage(int64 damage);
+	void DamageHateListPercentage(int64 damage, uint32 distance);
+#ifdef BOTS
+	void DamageHateListBots(int64 damage);
+	void DamageHateListBots(int64 damage, uint32 distance);
+	void DamageHateListBotsPercentage(int64 damage);
+	void DamageHateListBotsPercentage(int64 damage, uint32 distance);
+#endif
+	void DamageHateListClients(int64 damage);
+	void DamageHateListClients(int64 damage, uint32 distance);
+	void DamageHateListClientsPercentage(int64 damage);
+	void DamageHateListClientsPercentage(int64 damage, uint32 distance);
+	void DamageHateListNPCs(int64 damage);
+	void DamageHateListNPCs(int64 damage, uint32 distance);
+	void DamageHateListNPCsPercentage(int64 damage);
+	void DamageHateListNPCsPercentage(int64 damage, uint32 distance);
 };
 
 #endif

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -727,7 +727,8 @@ public:
 	bool IsOnFeignMemory(Mob *attacker) const;
 	void PrintHateListToClient(Client *who) { hate_list.PrintHateListToClient(who); }
 	std::list<struct_HateList*>& GetHateList() { return hate_list.GetHateList(); }
-	std::list<struct_HateList*> GetHateListByDistance(int distance = 0) { return hate_list.GetHateListByDistance(distance); }
+	std::list<struct_HateList*> GetFilteredHateList(uint8 filter_type = HateListFilterTypes::All, uint32 distance = 0) { return hate_list.GetFilteredHateList(filter_type, distance); }
+	void DamageHateList(uint32 damage, uint8 damage_target_type = HateListFilterTypes::All, uint32 distance = 0, bool is_percentage = false) { hate_list.DamageHateList(damage, damage_target_type, distance, is_percentage); }
 	bool CheckLosFN(Mob* other);
 	bool CheckLosFN(float posX, float posY, float posZ, float mobSize);
 	static bool CheckLosFN(glm::vec3 posWatcher, float sizeWatcher, glm::vec3 posTarget, float sizeTarget);

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -2333,22 +2333,24 @@ bool Perl_Mob_IsHorse(Mob* self) // @categories Script Utility
 perl::array Perl_Mob_GetHateListByDistance(Mob* self) // @categories Hate and Aggro
 {
 	perl::array result;
-	auto list = self->GetHateListByDistance();
-	for (auto hate_entry : list)
-	{
-		result.push_back(hate_entry);
+
+	auto h_list = self->GetFilteredHateList();
+	for (auto h : h_list) {
+		result.push_back(h);
 	}
+
 	return result;
 }
 
-perl::array Perl_Mob_GetHateListByDistance(Mob* self, int distance) // @categories Hate and Aggro
+perl::array Perl_Mob_GetHateListByDistance(Mob* self, uint32 distance) // @categories Hate and Aggro
 {
 	perl::array result;
-	auto list = self->GetHateListByDistance(distance);
-	for (auto hate_entry : list)
-	{
-		result.push_back(hate_entry);
+
+	auto h_list = self->GetFilteredHateList(HateListFilterTypes::All, distance);
+	for (auto h : h_list) {
+		result.push_back(h);
 	}
+
 	return result;
 }
 
@@ -2482,7 +2484,160 @@ Mob* Perl_Mob_GetOwner(Mob* self) // @categories Script Utility, Pet
 	return self->GetOwner();
 }
 
+void Perl_Mob_DamageHateList(Mob* self, int64 damage) // @categories Hate and Aggro
+{
+	self->DamageHateList(damage);
+}
+
+void Perl_Mob_DamageHateList(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
+{
+	self->DamageHateList(damage, distance);
+}
+
+void Perl_Mob_DamageHateListPercentage(Mob* self, int64 damage) // @categories Hate and Aggro
+{
+	self->DamageHateList(damage, 0, HateListFilterTypes::All, true);
+}
+
+void Perl_Mob_DamageHateListPercentage(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
+{
+	self->DamageHateList(damage, distance, HateListFilterTypes::All, true);
+}
+
+void Perl_Mob_DamageHateListClients(Mob* self, int64 damage) // @categories Hate and Aggro
+{
+	self->DamageHateList(damage, 0, HateListFilterTypes::Clients);
+}
+
+void Perl_Mob_DamageHateListClients(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
+{
+	self->DamageHateList(damage, distance, HateListFilterTypes::Clients);
+}
+
+void Perl_Mob_DamageHateListClientsPercentage(Mob* self, int64 damage) // @categories Hate and Aggro
+{
+	self->DamageHateList(damage, 0, HateListFilterTypes::Clients, true);
+}
+
+void Perl_Mob_DamageHateListClientsPercentage(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
+{
+	self->DamageHateList(damage, distance, HateListFilterTypes::Clients, true);
+}
+
+void Perl_Mob_DamageHateListNPCs(Mob* self, int64 damage) // @categories Hate and Aggro
+{
+	self->DamageHateList(damage, 0, HateListFilterTypes::NPCs);
+}
+
+void Perl_Mob_DamageHateListNPCs(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
+{
+	self->DamageHateList(damage, distance, HateListFilterTypes::NPCs);
+}
+
+void Perl_Mob_DamageHateListNPCsPercentage(Mob* self, int64 damage) // @categories Hate and Aggro
+{
+	self->DamageHateList(damage, 0, HateListFilterTypes::NPCs, true);
+}
+
+void Perl_Mob_DamageHateListNPCsPercentage(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
+{
+	self->DamageHateList(damage, distance, HateListFilterTypes::NPCs, true);
+}
+
+perl::array Perl_Mob_GetHateListClients(Mob* self)
+{
+	perl::array result;
+
+	auto h_list = self->GetFilteredHateList(0, HateListFilterTypes::Clients);
+	for (auto h : h_list) {
+		result.push_back(h);
+	}
+
+	return result;
+}
+
+perl::array Perl_Mob_GetHateListClients(Mob* self, uint32 distance)
+{
+	perl::array result;
+
+	auto h_list = self->GetFilteredHateList(distance, HateListFilterTypes::Clients);
+	for (auto h : h_list) {
+		result.push_back(h);
+	}
+
+	return result;
+}
+
+perl::array Perl_Mob_GetHateListNPCs(Mob* self)
+{
+	perl::array result;
+
+	auto h_list = self->GetFilteredHateList(0, HateListFilterTypes::NPCs);
+	for (auto h : h_list) {
+		result.push_back(h);
+	}
+
+	return result;
+}
+
+perl::array Perl_Mob_GetHateListNPCs(Mob* self, uint32 distance)
+{
+	perl::array result;
+
+	auto h_list = self->GetFilteredHateList(distance, HateListFilterTypes::NPCs);
+	for (auto h : h_list) {
+		result.push_back(h);
+	}
+
+	return result;
+}
+
 #ifdef BOTS
+void Perl_Mob_DamageHateListBots(Mob* self, int64 damage) // @categories Hate and Aggro
+{
+	self->DamageHateList(damage, 0, HateListFilterTypes::Bots);
+}
+
+void Perl_Mob_DamageHateListBots(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
+{
+	self->DamageHateList(damage, distance, HateListFilterTypes::Bots);
+}
+
+void Perl_Mob_DamageHateListBotsPercentage(Mob* self, int64 damage) // @categories Hate and Aggro
+{
+	self->DamageHateList(damage, 0, HateListFilterTypes::Bots, true);
+}
+
+void Perl_Mob_DamageHateListBotsPercentage(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
+{
+	self->DamageHateList(damage, distance, HateListFilterTypes::Bots, true);
+}
+
+perl::array Perl_Mob_GetHateListBots(Mob* self)
+{
+	perl::array result;
+
+	auto h_list = self->GetFilteredHateList(0, HateListFilterTypes::Bots);
+	for (auto h : h_list) {
+		result.push_back(h);
+	}
+
+	return result;
+}
+
+perl::array Perl_Mob_GetHateListBots(Mob* self, uint32 distance)
+{
+	perl::array result;
+
+	auto h_list = self->GetFilteredHateList(distance, HateListFilterTypes::Bots);
+	for (auto h : h_list)
+	{
+		result.push_back(h);
+	}
+
+	return result;
+}
+
 Bot* Perl_Mob_CastToBot(Mob* self)
 {
 	return self->CastToBot();
@@ -2569,6 +2724,24 @@ void perl_register_mob()
 	package.add("Damage", (void(*)(Mob*, Mob*, int64, uint16_t, int, bool))&Perl_Mob_Damage);
 	package.add("Damage", (void(*)(Mob*, Mob*, int64, uint16_t, int, bool, int8_t))&Perl_Mob_Damage);
 	package.add("Damage", (void(*)(Mob*, Mob*, int64, uint16_t, int, bool, int8_t, bool))&Perl_Mob_Damage);
+	package.add("DamageHateList", (void(*)(Mob*, int64))&Perl_Mob_DamageHateList);
+	package.add("DamageHateList", (void(*)(Mob*, int64, uint32))&Perl_Mob_DamageHateList);
+#ifdef BOTS
+	package.add("DamageHateListBots", (void(*)(Mob*, int64))&Perl_Mob_DamageHateListBots);
+	package.add("DamageHateListBots", (void(*)(Mob*, int64, uint32))&Perl_Mob_DamageHateListBots);
+	package.add("DamageHateListBotsPercentage", (void(*)(Mob*, int64))&Perl_Mob_DamageHateListBotsPercentage);
+	package.add("DamageHateListBotsPercentage", (void(*)(Mob*, int64, uint32))&Perl_Mob_DamageHateListBotsPercentage);
+#endif
+	package.add("DamageHateListClients", (void(*)(Mob*, int64))&Perl_Mob_DamageHateListClients);
+	package.add("DamageHateListClients", (void(*)(Mob*, int64, uint32))&Perl_Mob_DamageHateListClients);
+	package.add("DamageHateListClientsPercentage", (void(*)(Mob*, int64))&Perl_Mob_DamageHateListClientsPercentage);
+	package.add("DamageHateListClientsPercentage", (void(*)(Mob*, int64, uint32))&Perl_Mob_DamageHateListClientsPercentage);
+	package.add("DamageHateListNPCs", (void(*)(Mob*, int64))&Perl_Mob_DamageHateListNPCs);
+	package.add("DamageHateListNPCs", (void(*)(Mob*, int64, uint32))&Perl_Mob_DamageHateListNPCs);
+	package.add("DamageHateListNPCsPercentage", (void(*)(Mob*, int64))&Perl_Mob_DamageHateListNPCsPercentage);
+	package.add("DamageHateListNPCsPercentage", (void(*)(Mob*, int64, uint32))&Perl_Mob_DamageHateListNPCsPercentage);
+	package.add("DamageHateListPercentage", (void(*)(Mob*, int64))&Perl_Mob_DamageHateListPercentage);
+	package.add("DamageHateListPercentage", (void(*)(Mob*, int64, uint32))&Perl_Mob_DamageHateListPercentage);
 	package.add("DelGlobal", &Perl_Mob_DelGlobal);
 	package.add("DeleteBucket", &Perl_Mob_DeleteBucket);
 	package.add("Depop", (void(*)(Mob*))&Perl_Mob_Depop);
@@ -2672,8 +2845,16 @@ void perl_register_mob()
 	package.add("GetHateClosest", &Perl_Mob_GetHateClosest);
 	package.add("GetHateDamageTop", &Perl_Mob_GetHateDamageTop);
 	package.add("GetHateList", &Perl_Mob_GetHateList);
+#ifdef BOTS
+	package.add("GetHateListBots", (perl::array(*)(Mob*))&Perl_Mob_GetHateListBots);
+	package.add("GetHateListBots", (perl::array(*)(Mob*, uint32))&Perl_Mob_GetHateListBots);
+#endif
+	package.add("GetHateListClients", (perl::array(*)(Mob*))&Perl_Mob_GetHateListClients);
+	package.add("GetHateListClients", (perl::array(*)(Mob*, uint32))&Perl_Mob_GetHateListClients);
+	package.add("GetHateListNPCs", (perl::array(*)(Mob*))&Perl_Mob_GetHateListNPCs);
+	package.add("GetHateListNPCs", (perl::array(*)(Mob*, uint32))&Perl_Mob_GetHateListNPCs);
 	package.add("GetHateListByDistance", (perl::array(*)(Mob*))&Perl_Mob_GetHateListByDistance);
-	package.add("GetHateListByDistance", (perl::array(*)(Mob*, int))&Perl_Mob_GetHateListByDistance);
+	package.add("GetHateListByDistance", (perl::array(*)(Mob*, uint32))&Perl_Mob_GetHateListByDistance);
 	package.add("GetHateRandom", &Perl_Mob_GetHateRandom);
 #ifdef BOTS
 	package.add("GetHateRandomBot", &Perl_Mob_GetHateRandomBot);


### PR DESCRIPTION
# Perl
- Add `$mob->DamageHateList(damage)` to Perl.
- Add `$mob->DamageHateList(damage, distance)` to Perl.
- Add `$mob->DamageHateListPercentage(damage)` to Perl.
- Add `$mob->DamageHateListPercentage(damage, distance)` to Perl.
- Add `$mob->DamageHateListBots(damage)` to Perl.
- Add `$mob->DamageHateListBots(damage, distance)` to Perl.
- Add `$mob->DamageHateListBotsPercentage(damage)` to Perl.
- Add `$mob->DamageHateListBotsPercentage(damage, distance)` to Perl.
- Add `$mob->DamageHateListClients(damage)` to Perl.
- Add `$mob->DamageHateListClients(damage, distance)` to Perl.
- Add `$mob->DamageHateListClientsPercentage(damage)` to Perl.
- Add `$mob->DamageHateListClientsPercentage(damage, distance)` to Perl.
- Add `$mob->DamageHateListNPCs(damage)` to Perl.
- Add `$mob->DamageHateListNPCs(damage, distance)` to Perl.
- Add `$mob->DamageHateListNPCsPercentage(damage)` to Perl.
- Add `$mob->DamageHateListNPCsPercentage(damage, distance)` to Perl.
- Add `$mob->GetHateListBots()` to Perl.
- Add `$mob->GetHateListBots(distance)` to Perl.
- Add `$mob->GetHateListClients()` to Perl.
- Add `$mob->GetHateListClients(distance)` to Perl.
- Add `$mob->GetHateListNPCs()` to Perl.
- Add `$mob->GetHateListNPCs(distance)` to Perl.

# Lua
- Add `mob:DamageHateList(damage)` to Lua.
- Add `mob:DamageHateList(damage, distance)` to Lua.
- Add `mob:DamageHateListPercentage(damage)` to Lua.
- Add `mob:DamageHateListPercentage(damage, distance)` to Lua.
- Add `mob:DamageHateListBots(damage)` to Lua.
- Add `mob:DamageHateListBots(damage, distance)` to Lua.
- Add `mob:DamageHateListBotsPercentage(damage)` to Lua.
- Add `mob:DamageHateListBotsPercentage(damage, distance)` to Lua.
- Add `mob:DamageHateListClients(damage)` to Lua.
- Add `mob:DamageHateListClients(damage, distance)` to Lua.
- Add `mob:DamageHateListClientsPercentage(damage)` to Lua.
- Add `mob:DamageHateListClientsPercentage(damage, distance)` to Lua.
- Add `mob:DamageHateListNPCs(damage)` to Lua.
- Add `mob:DamageHateListNPCs(damage, distance)` to Lua.
- Add `mob:DamageHateListNPCsPercentage(damage)` to Lua.
- Add `mob:DamageHateListNPCsPercentage(damage, distance)` to Lua.
- Add `mob:GetHateListBots()` to Lua.
- Add `mob:GetHateListBots(distance)` to Lua.
- Add `mob:GetHateListClients()` to Lua.
- Add `mob:GetHateListClients(distance)` to Lua.
- Add `mob:GetHateListNPCs()` to Lua.
- Add `mob:GetHateListNPCs(distance)` to Lua.

# Notes
- Offers an extreme amount of short hands when grabbing hate list entities by a specific type or damaging a specific type of entity on an NPC's hatelist.
- Should save operators having to use `GetHateList()` then loop it to get the entries they want to do something.
- Removed source method for `GetHateListByDistance()` since I just use the catch all GetFilteredHateList() method for all that functionality now.