### PR TITLE
[Quest API] Add Area Damage Methods to Perl/Lua.

### DIFF
--- a/common/emu_constants.h
+++ b/common/emu_constants.h
@@ -334,7 +334,7 @@ namespace EQ
 		enum WeatherTypes : uint8 {
 			None,
 			Raining,
-			Snowing	
+			Snowing
 		};
 
 		enum EmoteEventTypes : uint8 {
@@ -578,6 +578,13 @@ enum BucketComparison : uint8 {
 	BucketIsNotAny,
 	BucketIsBetween,
 	BucketIsNotBetween
+};
+
+enum EntityFilterTypes : uint8 {
+	All,
+	Bots,
+	Clients,
+	NPCs
 };
 
 #endif /*COMMON_EMU_CONSTANTS_H*/

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -5832,9 +5832,9 @@ std::vector<Mob*> EntityList::GetFilteredEntityList(Mob* sender, uint32 distance
 		return l;
 	}
 
-	const auto         squared_distance = (distance * distance);
+	const auto squared_distance = (distance * distance);
 	const auto position = sender->GetPosition();
-	for (auto          &m: mob_list) {
+	for (auto &m: mob_list) {
 		if (!m.second) {
 			continue;
 		}

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -15,6 +15,7 @@
 	along with this program; if not, write to the Free Software
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
+#include "../common/data_verification.h"
 #include "../common/global_define.h"
 #include <stdlib.h>
 #include <stdio.h>
@@ -5820,6 +5821,70 @@ void EntityList::Marquee(
 	for (const auto& c : client_list) {
 		if (c.second) {
 			c.second->SendMarqueeMessage(type, priority, fade_in, fade_out, duration, message);
+		}
+	}
+}
+
+std::vector<Mob*> EntityList::GetFilteredEntityList(Mob* sender, uint32 distance, uint8 filter_type)
+{
+	std::vector<Mob *> l;
+	if (!sender) {
+		return l;
+	}
+
+	const auto         squared_distance = (distance * distance);
+	const auto position = sender->GetPosition();
+	for (auto          &m: mob_list) {
+		if (!m.second) {
+			continue;
+		}
+
+		if (m.second == sender) {
+			continue;
+		}
+
+		if (
+			distance &&
+			DistanceSquaredNoZ(
+				position,
+				m.second->GetPosition()
+			) > squared_distance
+		) {
+			continue;
+		}
+
+		if (
+			(filter_type == EntityFilterTypes::Bots && !m.second->IsBot()) ||
+			(filter_type == EntityFilterTypes::Clients && !m.second->IsClient()) ||
+			(filter_type == EntityFilterTypes::NPCs && !m.second->IsNPC())
+		) {
+			continue;
+		}
+
+		l.push_back(m.second);
+	}
+
+	return l;
+}
+
+void EntityList::DamageArea(Mob* sender, int64 damage, uint32 distance, uint8 filter_type, bool is_percentage)
+{
+	if (!sender) {
+		return;
+	}
+
+	if (damage <= 0) {
+		return;
+	}
+
+	const auto& l = GetFilteredEntityList(sender, distance, filter_type);
+	for (const auto& e : l) {
+		if (is_percentage) {
+			const auto damage_percentage = EQ::Clamp(damage, static_cast<int64>(1), static_cast<int64>(100));
+			const auto total_damage = (e->GetMaxHP() / 100) * damage_percentage;
+			e->Damage(sender, total_damage, SPELL_UNKNOWN, EQ::skills::SkillEagleStrike);
+		} else {
+			e->Damage(sender, damage, SPELL_UNKNOWN, EQ::skills::SkillEagleStrike);
 		}
 	}
 }

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -26,6 +26,7 @@
 #include "../common/servertalk.h"
 #include "../common/bodytypes.h"
 #include "../common/eq_constants.h"
+#include "../common/emu_constants.h"
 
 #include "position.h"
 #include "zonedump.h"
@@ -338,6 +339,9 @@ public:
 	void	StopMobAI();
 
 	void DescribeAggro(Client *to_who, NPC *from_who, float dist, bool verbose);
+
+	std::vector<Mob*> GetFilteredEntityList(Mob* sender, uint32 distance = 0, uint8 filter_type = EntityFilterTypes::All);
+	void DamageArea(Mob* sender, int64 damage, uint32 distance = 0, uint8 filter_type = EntityFilterTypes::All, bool is_percentage = false);
 
 	void	Marquee(uint32 type, std::string message, uint32 duration = 3000);
 	void	Marquee(uint32 type, uint32 priority, uint32 fade_in, uint32 fade_out, uint32 duration, std::string message);

--- a/zone/hate_list.cpp
+++ b/zone/hate_list.cpp
@@ -1005,43 +1005,49 @@ void HateList::DamageHateList(int64 damage, uint32 distance, uint8 filter_type, 
 		return;
 	}
 
-	const auto& h_list = GetFilteredHateList(distance, filter_type);
-	for (const auto& h : h_list) {
-		auto hate_entry = h->entity_on_hatelist;
+	const auto& l = GetFilteredHateList(distance, filter_type);
+	for (const auto& h : l) {
+		auto e = h->entity_on_hatelist;
 		if (is_percentage) {
 			const auto damage_percentage = EQ::Clamp(damage, static_cast<int64>(1), static_cast<int64>(100));
-			const auto total_damage = hate_entry->GetMaxHP() / damage_percentage * 100;
-			hate_entry->Damage(hate_owner, total_damage, SPELL_UNKNOWN, EQ::skills::SkillEagleStrike);
+			const auto total_damage = (e->GetMaxHP() / 100) * damage_percentage;
+			e->Damage(hate_owner, total_damage, SPELL_UNKNOWN, EQ::skills::SkillEagleStrike);
 		} else {
-			hate_entry->Damage(hate_owner, damage, SPELL_UNKNOWN, EQ::skills::SkillEagleStrike);
+			e->Damage(hate_owner, damage, SPELL_UNKNOWN, EQ::skills::SkillEagleStrike);
 		}
 	}
 }
 
 std::list<struct_HateList*> HateList::GetFilteredHateList(uint32 distance, uint8 filter_type)
 {
-	std::list<struct_HateList*> filtered_hate_list;
+	std::list<struct_HateList*> l;
 	const auto squared_distance = (distance * distance);
 	for (auto h : list) {
-		auto hate_entry = h->entity_on_hatelist;
-		if (
-			(
-				!distance ||
-				DistanceSquaredNoZ(
-					hate_owner->GetPosition(),
-					hate_entry->GetPosition()
-				) <= squared_distance
-			) &&
-			(
-				filter_type == HateListFilterTypes::All ||
-				(filter_type == HateListFilterTypes::Bots && hate_entry->IsBot()) ||
-				(filter_type == HateListFilterTypes::Clients && hate_entry->IsClient()) ||
-				(filter_type == HateListFilterTypes::NPCs && hate_entry->IsNPC())
-			)
-		) {
-			filtered_hate_list.push_back(h);
+		auto e = h->entity_on_hatelist;
+		if (!e) {
+			continue;
 		}
+
+		if (
+			distance &&
+			DistanceSquaredNoZ(
+				hate_owner->GetPosition(),
+				e->GetPosition()
+			) > squared_distance
+		) {
+			continue;
+		}
+
+		if (
+			(filter_type == EntityFilterTypes::Bots && !e->IsBot()) ||
+			(filter_type == EntityFilterTypes::Clients && !e->IsClient()) ||
+			(filter_type == EntityFilterTypes::NPCs && !e->IsNPC())
+		) {
+			continue;
+		}
+
+		l.push_back(h);
 	}
 
-	return filtered_hate_list;
+	return l;
 }

--- a/zone/hate_list.h
+++ b/zone/hate_list.h
@@ -19,6 +19,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #ifndef HATELIST_H
 #define HATELIST_H
 
+#include "../common/emu_constants.h"
+
 class Client;
 class Group;
 class Mob;
@@ -32,13 +34,6 @@ struct struct_HateList {
 	bool   is_entity_frenzy;
 	int8   oor_count; // count on how long we've been out of range
 	uint32 last_modified; // we need to remove this if it gets higher than 10 mins
-};
-
-enum HateListFilterTypes : uint8 {
-	All,
-	Bots,
-	Clients,
-	NPCs
 };
 
 class HateList {
@@ -73,13 +68,13 @@ public:
 	std::list<struct_HateList *> &GetHateList() { return list; }
 	std::list<struct_HateList *> GetFilteredHateList(
 		uint32 distance = 0,
-		uint8 filter_type = HateListFilterTypes::All
+		uint8 filter_type = EntityFilterTypes::All
 	);
 
 	void DamageHateList(
 		int64 damage,
 		uint32 distance = 0,
-		uint8 filter_type = HateListFilterTypes::All,
+		uint8 filter_type = EntityFilterTypes::All,
 		bool is_percentage = false
 	);
 

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -2519,59 +2519,59 @@ void Lua_Mob::DamageHateList(int64 damage, uint32 distance) {
 
 void Lua_Mob::DamageHateListClients(int64 damage) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, 0, HateListFilterTypes::Clients);
+	self->DamageHateList(damage, 0, EntityFilterTypes::Clients);
 }
 
 void Lua_Mob::DamageHateListClients(int64 damage, uint32 distance) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, distance, HateListFilterTypes::Clients);
+	self->DamageHateList(damage, distance, EntityFilterTypes::Clients);
 }
 
 void Lua_Mob::DamageHateListNPCs(int64 damage) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, 0, HateListFilterTypes::NPCs);
+	self->DamageHateList(damage, 0, EntityFilterTypes::NPCs);
 }
 
 void Lua_Mob::DamageHateListNPCs(int64 damage, uint32 distance) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, distance, HateListFilterTypes::NPCs);
+	self->DamageHateList(damage, distance, EntityFilterTypes::NPCs);
 }
 
 void Lua_Mob::DamageHateListPercentage(int64 damage) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, 0, HateListFilterTypes::All, true);
+	self->DamageHateList(damage, 0, EntityFilterTypes::All, true);
 }
 
 void Lua_Mob::DamageHateListPercentage(int64 damage, uint32 distance) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, distance, HateListFilterTypes::All, true);
+	self->DamageHateList(damage, distance, EntityFilterTypes::All, true);
 }
 
 void Lua_Mob::DamageHateListClientsPercentage(int64 damage) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, 0, HateListFilterTypes::Clients, true);
+	self->DamageHateList(damage, 0, EntityFilterTypes::Clients, true);
 }
 
 void Lua_Mob::DamageHateListClientsPercentage(int64 damage, uint32 distance) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, distance, HateListFilterTypes::Clients, true);
+	self->DamageHateList(damage, distance, EntityFilterTypes::Clients, true);
 }
 
 void Lua_Mob::DamageHateListNPCsPercentage(int64 damage) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, 0, HateListFilterTypes::NPCs, true);
+	self->DamageHateList(damage, 0, EntityFilterTypes::NPCs, true);
 }
 
 void Lua_Mob::DamageHateListNPCsPercentage(int64 damage, uint32 distance) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, distance, HateListFilterTypes::NPCs, true);
+	self->DamageHateList(damage, distance, EntityFilterTypes::NPCs, true);
 }
 
 Lua_HateList Lua_Mob::GetHateListClients() {
 	Lua_Safe_Call_Class(Lua_HateList);
 	Lua_HateList ret;
 
-	auto h_list = self->GetFilteredHateList(0, HateListFilterTypes::Clients);
+	auto h_list = self->GetFilteredHateList(EntityFilterTypes::Clients);
 	for (auto h : h_list) {
 		Lua_HateEntry e(h);
 		ret.entries.push_back(e);
@@ -2584,7 +2584,7 @@ Lua_HateList Lua_Mob::GetHateListClients(uint32 distance) {
 	Lua_Safe_Call_Class(Lua_HateList);
 	Lua_HateList ret;
 
-	auto h_list = self->GetFilteredHateList(distance, HateListFilterTypes::Clients);
+	auto h_list = self->GetFilteredHateList(EntityFilterTypes::Clients, distance);
 	for (auto h : h_list) {
 		Lua_HateEntry e(h);
 		ret.entries.push_back(e);
@@ -2597,7 +2597,7 @@ Lua_HateList Lua_Mob::GetHateListNPCs() {
 	Lua_Safe_Call_Class(Lua_HateList);
 	Lua_HateList ret;
 
-	auto h_list = self->GetFilteredHateList(0, HateListFilterTypes::NPCs);
+	auto h_list = self->GetFilteredHateList(EntityFilterTypes::NPCs);
 	for (auto h : h_list) {
 		Lua_HateEntry e(h);
 		ret.entries.push_back(e);
@@ -2610,7 +2610,7 @@ Lua_HateList Lua_Mob::GetHateListNPCs(uint32 distance) {
 	Lua_Safe_Call_Class(Lua_HateList);
 	Lua_HateList ret;
 
-	auto h_list = self->GetFilteredHateList(distance, HateListFilterTypes::NPCs);
+	auto h_list = self->GetFilteredHateList(EntityFilterTypes::NPCs, distance);
 	for (auto h : h_list) {
 		Lua_HateEntry e(h);
 		ret.entries.push_back(e);
@@ -2619,32 +2619,112 @@ Lua_HateList Lua_Mob::GetHateListNPCs(uint32 distance) {
 	return ret;
 }
 
+void Lua_Mob::DamageArea(int64 damage) {
+	Lua_Safe_Call_Void();
+	self->DamageArea(damage);
+}
+
+void Lua_Mob::DamageArea(int64 damage, uint32 distance) {
+	Lua_Safe_Call_Void();
+	self->DamageArea(damage, distance);
+}
+
+void Lua_Mob::DamageAreaPercentage(int64 damage) {
+	Lua_Safe_Call_Void();
+	self->DamageArea(damage, 0, EntityFilterTypes::All, true);
+}
+
+void Lua_Mob::DamageAreaPercentage(int64 damage, uint32 distance) {
+	Lua_Safe_Call_Void();
+	self->DamageArea(damage, distance, EntityFilterTypes::All, true);
+}
+
+void Lua_Mob::DamageAreaClients(int64 damage) {
+	Lua_Safe_Call_Void();
+	self->DamageArea(damage, 0, EntityFilterTypes::Clients);
+}
+
+void Lua_Mob::DamageAreaClients(int64 damage, uint32 distance) {
+	Lua_Safe_Call_Void();
+	self->DamageArea(damage, distance, EntityFilterTypes::Clients);
+}
+
+void Lua_Mob::DamageAreaClientsPercentage(int64 damage) {
+	Lua_Safe_Call_Void();
+	self->DamageArea(damage, 0, EntityFilterTypes::Clients, true);
+}
+
+void Lua_Mob::DamageAreaClientsPercentage(int64 damage, uint32 distance) {
+	Lua_Safe_Call_Void();
+	self->DamageArea(damage, distance, EntityFilterTypes::Clients, true);
+}
+
+void Lua_Mob::DamageAreaNPCs(int64 damage) {
+	Lua_Safe_Call_Void();
+	self->DamageArea(damage, 0, EntityFilterTypes::NPCs);
+}
+
+void Lua_Mob::DamageAreaNPCs(int64 damage, uint32 distance) {
+	Lua_Safe_Call_Void();
+	self->DamageArea(damage, distance, EntityFilterTypes::NPCs);
+}
+
+void Lua_Mob::DamageAreaNPCsPercentage(int64 damage) {
+	Lua_Safe_Call_Void();
+	self->DamageArea(damage, 0, EntityFilterTypes::NPCs, true);
+}
+
+void Lua_Mob::DamageAreaNPCsPercentage(int64 damage, uint32 distance) {
+	Lua_Safe_Call_Void();
+	self->DamageArea(damage, distance, EntityFilterTypes::NPCs, true);
+}
+
 #ifdef BOTS
+void Lua_Mob::DamageAreaBots(int64 damage) {
+	Lua_Safe_Call_Void();
+	self->DamageArea(damage, 0, EntityFilterTypes::Bots);
+}
+
+void Lua_Mob::DamageAreaBots(int64 damage, uint32 distance) {
+	Lua_Safe_Call_Void();
+	self->DamageArea(damage, distance, EntityFilterTypes::Bots);
+}
+
+void Lua_Mob::DamageAreaBotsPercentage(int64 damage) {
+	Lua_Safe_Call_Void();
+	self->DamageArea(damage, 0, EntityFilterTypes::Bots, true);
+}
+
+void Lua_Mob::DamageAreaBotsPercentage(int64 damage, uint32 distance) {
+	Lua_Safe_Call_Void();
+	self->DamageArea(damage, distance, EntityFilterTypes::Bots, true);
+}
+
 void Lua_Mob::DamageHateListBots(int64 damage) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, 0, HateListFilterTypes::Bots);
+	self->DamageHateList(damage, 0, EntityFilterTypes::Bots);
 }
 
 void Lua_Mob::DamageHateListBots(int64 damage, uint32 distance) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, distance, HateListFilterTypes::Bots);
+	self->DamageHateList(damage, distance, EntityFilterTypes::Bots);
 }
 
 void Lua_Mob::DamageHateListBotsPercentage(int64 damage) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, 0, HateListFilterTypes::Bots, true);
+	self->DamageHateList(damage, 0, EntityFilterTypes::Bots, true);
 }
 
 void Lua_Mob::DamageHateListBotsPercentage(int64 damage, uint32 distance) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, distance, HateListFilterTypes::Bots, true);
+	self->DamageHateList(damage, distance, EntityFilterTypes::Bots, true);
 }
 
 Lua_HateList Lua_Mob::GetHateListBots() {
 	Lua_Safe_Call_Class(Lua_HateList);
 	Lua_HateList ret;
 
-	auto h_list = self->GetFilteredHateList(0, HateListFilterTypes::Bots);
+	auto h_list = self->GetFilteredHateList(EntityFilterTypes::Bots);
 	for (auto h : h_list) {
 		Lua_HateEntry e(h);
 		ret.entries.push_back(e);
@@ -2657,7 +2737,7 @@ Lua_HateList Lua_Mob::GetHateListBots(uint32 distance) {
 	Lua_Safe_Call_Class(Lua_HateList);
 	Lua_HateList ret;
 
-	auto h_list = self->GetFilteredHateList(distance, HateListFilterTypes::Bots);
+	auto h_list = self->GetFilteredHateList(EntityFilterTypes::Bots, distance);
 	for (auto h : h_list) {
 		Lua_HateEntry e(h);
 		ret.entries.push_back(e);
@@ -2753,6 +2833,24 @@ luabind::scope lua_register_mob() {
 	.def("Damage", (void(Lua_Mob::*)(Lua_Mob,int64,int,int,bool))&Lua_Mob::Damage)
 	.def("Damage", (void(Lua_Mob::*)(Lua_Mob,int64,int,int,bool,int))&Lua_Mob::Damage)
 	.def("Damage", (void(Lua_Mob::*)(Lua_Mob,int64,int,int,bool,int,bool))&Lua_Mob::Damage)
+	.def("DamageArea", (void(Lua_Mob::*)(int64))&Lua_Mob::DamageArea)
+	.def("DamageArea", (void(Lua_Mob::*)(int64,uint32))&Lua_Mob::DamageArea)
+	.def("DamageAreaPercentage", (void(Lua_Mob::*)(int64))&Lua_Mob::DamageAreaPercentage)
+	.def("DamageAreaPercentage", (void(Lua_Mob::*)(int64,uint32))&Lua_Mob::DamageAreaPercentage)
+#ifdef BOTS
+	.def("DamageAreaBots", (void(Lua_Mob::*)(int64))&Lua_Mob::DamageAreaBots)
+	.def("DamageAreaBots", (void(Lua_Mob::*)(int64,uint32))&Lua_Mob::DamageAreaBots)
+	.def("DamageAreaBotsPercentage", (void(Lua_Mob::*)(int64))&Lua_Mob::DamageAreaBotsPercentage)
+	.def("DamageAreaBotsPercentage", (void(Lua_Mob::*)(int64,uint32))&Lua_Mob::DamageAreaBotsPercentage)
+#endif
+	.def("DamageAreaClients", (void(Lua_Mob::*)(int64))&Lua_Mob::DamageAreaClients)
+	.def("DamageAreaClients", (void(Lua_Mob::*)(int64,uint32))&Lua_Mob::DamageAreaClients)
+	.def("DamageAreaClientsPercentage", (void(Lua_Mob::*)(int64))&Lua_Mob::DamageAreaClientsPercentage)
+	.def("DamageAreaClientsPercentage", (void(Lua_Mob::*)(int64,uint32))&Lua_Mob::DamageAreaClientsPercentage)
+	.def("DamageAreaNPCs", (void(Lua_Mob::*)(int64))&Lua_Mob::DamageAreaNPCs)
+	.def("DamageAreaNPCs", (void(Lua_Mob::*)(int64,uint32))&Lua_Mob::DamageAreaNPCs)
+	.def("DamageAreaNPCsPercentage", (void(Lua_Mob::*)(int64))&Lua_Mob::DamageAreaNPCsPercentage)
+	.def("DamageAreaNPCsPercentage", (void(Lua_Mob::*)(int64,uint32))&Lua_Mob::DamageAreaNPCsPercentage)
 	.def("DamageHateList", (void(Lua_Mob::*)(int64))&Lua_Mob::DamageHateList)
 	.def("DamageHateList", (void(Lua_Mob::*)(int64,uint32))&Lua_Mob::DamageHateList)
 #ifdef BOTS

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -86,7 +86,7 @@ public:
 	bool HasProcs();
 	bool IsInvisible();
 	bool IsInvisible(Lua_Mob other);
-    void SetInvisible(int state);
+	void SetInvisible(int state);
 	uint8 GetInvisibleLevel();
 	uint8 GetInvisibleUndeadLevel();
 	void SetSeeInvisibleLevel(uint8 invisible_level);
@@ -94,7 +94,7 @@ public:
 	bool FindBuff(int spell_id);
 	uint16 FindBuffBySlot(int slot);
 	uint32 BuffCount();
-    bool FindType(int type);
+	bool FindType(int type);
 	bool FindType(int type, bool offensive);
 	bool FindType(int type, bool offensive, int threshold);
 	int GetBuffSlotFromType(int slot);
@@ -476,6 +476,24 @@ public:
 	void SetBuffDuration(int spell_id, int duration);
 	void CloneAppearance(Lua_Mob other);
 	void CloneAppearance(Lua_Mob other, bool clone_name);
+	void DamageArea(int64 damage);
+	void DamageArea(int64 damage, uint32 distance);
+	void DamageAreaPercentage(int64 damage);
+	void DamageAreaPercentage(int64 damage, uint32 distance);
+#ifdef BOTS
+	void DamageAreaBots(int64 damage);
+	void DamageAreaBots(int64 damage, uint32 distance);
+	void DamageAreaBotsPercentage(int64 damage);
+	void DamageAreaBotsPercentage(int64 damage, uint32 distance);
+#endif
+	void DamageAreaClients(int64 damage);
+	void DamageAreaClients(int64 damage, uint32 distance);
+	void DamageAreaClientsPercentage(int64 damage);
+	void DamageAreaClientsPercentage(int64 damage, uint32 distance);
+	void DamageAreaNPCs(int64 damage);
+	void DamageAreaNPCs(int64 damage, uint32 distance);
+	void DamageAreaNPCsPercentage(int64 damage);
+	void DamageAreaNPCsPercentage(int64 damage, uint32 distance);
 	void DamageHateList(int64 damage);
 	void DamageHateList(int64 damage, uint32 distance);
 	void DamageHateListPercentage(int64 damage);

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -727,8 +727,9 @@ public:
 	bool IsOnFeignMemory(Mob *attacker) const;
 	void PrintHateListToClient(Client *who) { hate_list.PrintHateListToClient(who); }
 	std::list<struct_HateList*>& GetHateList() { return hate_list.GetHateList(); }
-	std::list<struct_HateList*> GetFilteredHateList(uint8 filter_type = HateListFilterTypes::All, uint32 distance = 0) { return hate_list.GetFilteredHateList(filter_type, distance); }
-	void DamageHateList(uint32 damage, uint8 damage_target_type = HateListFilterTypes::All, uint32 distance = 0, bool is_percentage = false) { hate_list.DamageHateList(damage, damage_target_type, distance, is_percentage); }
+	std::list<struct_HateList*> GetFilteredHateList(uint8 filter_type = EntityFilterTypes::All, uint32 distance = 0) { return hate_list.GetFilteredHateList(distance, filter_type); }
+	void DamageHateList(int64 damage, uint32 distance = 0, uint8 filter_type = EntityFilterTypes::All, bool is_percentage = false) { hate_list.DamageHateList(damage, distance, filter_type, is_percentage); }
+	void DamageArea(int64 damage, uint32 distance = 0, uint8 filter_type = EntityFilterTypes::All, bool is_percentage = false) { entity_list.DamageArea(this, damage, distance, filter_type, is_percentage); }
 	bool CheckLosFN(Mob* other);
 	bool CheckLosFN(float posX, float posY, float posZ, float mobSize);
 	static bool CheckLosFN(glm::vec3 posWatcher, float sizeWatcher, glm::vec3 posTarget, float sizeTarget);

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -2346,7 +2346,7 @@ perl::array Perl_Mob_GetHateListByDistance(Mob* self, uint32 distance) // @categ
 {
 	perl::array result;
 
-	auto h_list = self->GetFilteredHateList(HateListFilterTypes::All, distance);
+	auto h_list = self->GetFilteredHateList(distance, EntityFilterTypes::All);
 	for (auto h : h_list) {
 		result.push_back(h);
 	}
@@ -2484,6 +2484,66 @@ Mob* Perl_Mob_GetOwner(Mob* self) // @categories Script Utility, Pet
 	return self->GetOwner();
 }
 
+void Perl_Mob_DamageArea(Mob* self, int64 damage) // @categories Hate and Aggro
+{
+	self->DamageArea(damage);
+}
+
+void Perl_Mob_DamageArea(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
+{
+	self->DamageArea(damage, distance, EntityFilterTypes::All);
+}
+
+void Perl_Mob_DamageAreaPercentage(Mob* self, int64 damage) // @categories Hate and Aggro
+{
+	self->DamageArea(damage, 0, EntityFilterTypes::All, true);
+}
+
+void Perl_Mob_DamageAreaPercentage(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
+{
+	self->DamageArea(damage, distance, EntityFilterTypes::All, true);
+}
+
+void Perl_Mob_DamageAreaClients(Mob* self, int64 damage) // @categories Hate and Aggro
+{
+	self->DamageArea(damage, 0, EntityFilterTypes::Clients);
+}
+
+void Perl_Mob_DamageAreaClients(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
+{
+	self->DamageArea(damage, distance, EntityFilterTypes::Clients);
+}
+
+void Perl_Mob_DamageAreaClientsPercentage(Mob* self, int64 damage) // @categories Hate and Aggro
+{
+	self->DamageArea(damage, 0, EntityFilterTypes::Clients, true);
+}
+
+void Perl_Mob_DamageAreaClientsPercentage(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
+{
+	self->DamageArea(damage, distance, EntityFilterTypes::Clients, true);
+}
+
+void Perl_Mob_DamageAreaNPCs(Mob* self, int64 damage) // @categories Hate and Aggro
+{
+	self->DamageArea(damage, 0, EntityFilterTypes::NPCs);
+}
+
+void Perl_Mob_DamageAreaNPCs(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
+{
+	self->DamageArea(damage, distance, EntityFilterTypes::NPCs);
+}
+
+void Perl_Mob_DamageAreaNPCsPercentage(Mob* self, int64 damage) // @categories Hate and Aggro
+{
+	self->DamageArea(damage, 0, EntityFilterTypes::NPCs, true);
+}
+
+void Perl_Mob_DamageAreaNPCsPercentage(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
+{
+	self->DamageArea(damage, distance, EntityFilterTypes::NPCs, true);
+}
+
 void Perl_Mob_DamageHateList(Mob* self, int64 damage) // @categories Hate and Aggro
 {
 	self->DamageHateList(damage);
@@ -2491,64 +2551,64 @@ void Perl_Mob_DamageHateList(Mob* self, int64 damage) // @categories Hate and Ag
 
 void Perl_Mob_DamageHateList(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, distance);
+	self->DamageHateList(damage, distance, EntityFilterTypes::All);
 }
 
 void Perl_Mob_DamageHateListPercentage(Mob* self, int64 damage) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, 0, HateListFilterTypes::All, true);
+	self->DamageHateList(damage, 0, EntityFilterTypes::All, true);
 }
 
 void Perl_Mob_DamageHateListPercentage(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, distance, HateListFilterTypes::All, true);
+	self->DamageHateList(damage, distance, EntityFilterTypes::All, true);
 }
 
 void Perl_Mob_DamageHateListClients(Mob* self, int64 damage) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, 0, HateListFilterTypes::Clients);
+	self->DamageHateList(damage, 0, EntityFilterTypes::Clients);
 }
 
 void Perl_Mob_DamageHateListClients(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, distance, HateListFilterTypes::Clients);
+	self->DamageHateList(damage, distance, EntityFilterTypes::Clients);
 }
 
 void Perl_Mob_DamageHateListClientsPercentage(Mob* self, int64 damage) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, 0, HateListFilterTypes::Clients, true);
+	self->DamageHateList(damage, 0, EntityFilterTypes::Clients, true);
 }
 
 void Perl_Mob_DamageHateListClientsPercentage(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, distance, HateListFilterTypes::Clients, true);
+	self->DamageHateList(damage, distance, EntityFilterTypes::Clients, true);
 }
 
 void Perl_Mob_DamageHateListNPCs(Mob* self, int64 damage) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, 0, HateListFilterTypes::NPCs);
+	self->DamageHateList(damage, 0, EntityFilterTypes::NPCs);
 }
 
 void Perl_Mob_DamageHateListNPCs(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, distance, HateListFilterTypes::NPCs);
+	self->DamageHateList(damage, distance, EntityFilterTypes::NPCs);
 }
 
 void Perl_Mob_DamageHateListNPCsPercentage(Mob* self, int64 damage) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, 0, HateListFilterTypes::NPCs, true);
+	self->DamageHateList(damage, 0, EntityFilterTypes::NPCs, true);
 }
 
 void Perl_Mob_DamageHateListNPCsPercentage(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, distance, HateListFilterTypes::NPCs, true);
+	self->DamageHateList(damage, distance, EntityFilterTypes::NPCs, true);
 }
 
 perl::array Perl_Mob_GetHateListClients(Mob* self)
 {
 	perl::array result;
 
-	auto h_list = self->GetFilteredHateList(0, HateListFilterTypes::Clients);
+	auto h_list = self->GetFilteredHateList(EntityFilterTypes::Clients);
 	for (auto h : h_list) {
 		result.push_back(h);
 	}
@@ -2560,7 +2620,7 @@ perl::array Perl_Mob_GetHateListClients(Mob* self, uint32 distance)
 {
 	perl::array result;
 
-	auto h_list = self->GetFilteredHateList(distance, HateListFilterTypes::Clients);
+	auto h_list = self->GetFilteredHateList(distance, EntityFilterTypes::Clients);
 	for (auto h : h_list) {
 		result.push_back(h);
 	}
@@ -2572,7 +2632,7 @@ perl::array Perl_Mob_GetHateListNPCs(Mob* self)
 {
 	perl::array result;
 
-	auto h_list = self->GetFilteredHateList(0, HateListFilterTypes::NPCs);
+	auto h_list = self->GetFilteredHateList(EntityFilterTypes::NPCs);
 	for (auto h : h_list) {
 		result.push_back(h);
 	}
@@ -2584,7 +2644,7 @@ perl::array Perl_Mob_GetHateListNPCs(Mob* self, uint32 distance)
 {
 	perl::array result;
 
-	auto h_list = self->GetFilteredHateList(distance, HateListFilterTypes::NPCs);
+	auto h_list = self->GetFilteredHateList(distance, EntityFilterTypes::NPCs);
 	for (auto h : h_list) {
 		result.push_back(h);
 	}
@@ -2593,31 +2653,51 @@ perl::array Perl_Mob_GetHateListNPCs(Mob* self, uint32 distance)
 }
 
 #ifdef BOTS
+void Perl_Mob_DamageAreaBots(Mob* self, int64 damage) // @categories Hate and Aggro
+{
+	self->DamageArea(damage, 0, EntityFilterTypes::Bots);
+}
+
+void Perl_Mob_DamageAreaBots(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
+{
+	self->DamageArea(damage, distance, EntityFilterTypes::Bots);
+}
+
+void Perl_Mob_DamageAreaBotsPercentage(Mob* self, int64 damage) // @categories Hate and Aggro
+{
+	self->DamageArea(damage, 0, EntityFilterTypes::Bots, true);
+}
+
+void Perl_Mob_DamageAreaBotsPercentage(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
+{
+	self->DamageArea(damage, distance, EntityFilterTypes::Bots, true);
+}
+
 void Perl_Mob_DamageHateListBots(Mob* self, int64 damage) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, 0, HateListFilterTypes::Bots);
+	self->DamageHateList(damage, 0, EntityFilterTypes::Bots);
 }
 
 void Perl_Mob_DamageHateListBots(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, distance, HateListFilterTypes::Bots);
+	self->DamageHateList(damage, distance, EntityFilterTypes::Bots);
 }
 
 void Perl_Mob_DamageHateListBotsPercentage(Mob* self, int64 damage) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, 0, HateListFilterTypes::Bots, true);
+	self->DamageHateList(damage, 0, EntityFilterTypes::Bots, true);
 }
 
 void Perl_Mob_DamageHateListBotsPercentage(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, distance, HateListFilterTypes::Bots, true);
+	self->DamageHateList(damage, distance, EntityFilterTypes::Bots, true);
 }
 
 perl::array Perl_Mob_GetHateListBots(Mob* self)
 {
 	perl::array result;
 
-	auto h_list = self->GetFilteredHateList(0, HateListFilterTypes::Bots);
+	auto h_list = self->GetFilteredHateList(EntityFilterTypes::Bots);
 	for (auto h : h_list) {
 		result.push_back(h);
 	}
@@ -2629,7 +2709,7 @@ perl::array Perl_Mob_GetHateListBots(Mob* self, uint32 distance)
 {
 	perl::array result;
 
-	auto h_list = self->GetFilteredHateList(distance, HateListFilterTypes::Bots);
+	auto h_list = self->GetFilteredHateList(distance, EntityFilterTypes::Bots);
 	for (auto h : h_list)
 	{
 		result.push_back(h);
@@ -2724,6 +2804,24 @@ void perl_register_mob()
 	package.add("Damage", (void(*)(Mob*, Mob*, int64, uint16_t, int, bool))&Perl_Mob_Damage);
 	package.add("Damage", (void(*)(Mob*, Mob*, int64, uint16_t, int, bool, int8_t))&Perl_Mob_Damage);
 	package.add("Damage", (void(*)(Mob*, Mob*, int64, uint16_t, int, bool, int8_t, bool))&Perl_Mob_Damage);
+	package.add("DamageArea", (void(*)(Mob*, int64))&Perl_Mob_DamageArea);
+	package.add("DamageArea", (void(*)(Mob*, int64, uint32))&Perl_Mob_DamageArea);
+#ifdef BOTS
+	package.add("DamageAreaBots", (void(*)(Mob*, int64))&Perl_Mob_DamageAreaBots);
+	package.add("DamageAreaBots", (void(*)(Mob*, int64, uint32))&Perl_Mob_DamageAreaBots);
+	package.add("DamageAreaBotsPercentage", (void(*)(Mob*, int64))&Perl_Mob_DamageAreaBotsPercentage);
+	package.add("DamageAreaBotsPercentage", (void(*)(Mob*, int64, uint32))&Perl_Mob_DamageAreaBotsPercentage);
+#endif
+	package.add("DamageAreaClients", (void(*)(Mob*, int64))&Perl_Mob_DamageAreaClients);
+	package.add("DamageAreaClients", (void(*)(Mob*, int64, uint32))&Perl_Mob_DamageAreaClients);
+	package.add("DamageAreaClientsPercentage", (void(*)(Mob*, int64))&Perl_Mob_DamageAreaClientsPercentage);
+	package.add("DamageAreaClientsPercentage", (void(*)(Mob*, int64, uint32))&Perl_Mob_DamageAreaClientsPercentage);
+	package.add("DamageAreaNPCs", (void(*)(Mob*, int64))&Perl_Mob_DamageAreaNPCs);
+	package.add("DamageAreaNPCs", (void(*)(Mob*, int64, uint32))&Perl_Mob_DamageAreaNPCs);
+	package.add("DamageAreaNPCsPercentage", (void(*)(Mob*, int64))&Perl_Mob_DamageAreaNPCsPercentage);
+	package.add("DamageAreaNPCsPercentage", (void(*)(Mob*, int64, uint32))&Perl_Mob_DamageAreaNPCsPercentage);
+	package.add("DamageAreaPercentage", (void(*)(Mob*, int64))&Perl_Mob_DamageAreaPercentage);
+	package.add("DamageAreaPercentage", (void(*)(Mob*, int64, uint32))&Perl_Mob_DamageAreaPercentage);
 	package.add("DamageHateList", (void(*)(Mob*, int64))&Perl_Mob_DamageHateList);
 	package.add("DamageHateList", (void(*)(Mob*, int64, uint32))&Perl_Mob_DamageHateList);
 #ifdef BOTS


### PR DESCRIPTION
# Perl
- Add `$mob->DamageArea(damage)`.
- Add `$mob->DamageArea(damage, distance)`.
- Add `$mob->DamageAreaBots(damage)`.
- Add `$mob->DamageAreaBots(damage, distance)`.
- Add `$mob->DamageAreaClients(damage)`.
- Add `$mob->DamageAreaClients(damage, distance)`.
- Add `$mob->DamageAreaNPCs(damage)`.
- Add `$mob->DamageAreaNPCs(damage, distance)`.
- Add `$mob->DamageAreaPercentage(damage)`.
- Add `$mob->DamageAreaPercentage(damage, distance)`.
- Add `$mob->DamageAreaBotsPercentage(damage)`.
- Add `$mob->DamageAreaBotsPercentage(damage, distance)`.
- Add `$mob->DamageAreaClientsPercentage(damage)`.
- Add `$mob->DamageAreaClientsPercentage(damage, distance)`.
- Add `$mob->DamageAreaNPCsPercentage(damage)`.
- Add `$mob->DamageAreaNPCsPercentage(damage, distance)`.

# Lua
- Add `mob:DamageArea(damage)`.
- Add `mob:DamageArea(damage, distance)`.
- Add `mob:DamageAreaBots(damage)`.
- Add `mob:DamageAreaBots(damage, distance)`.
- Add `mob:DamageAreaClients(damage)`.
- Add `mob:DamageAreaClients(damage, distance)`.
- Add `mob:DamageAreaNPCs(damage)`.
- Add `mob:DamageAreaNPCs(damage, distance)`.
- Add `mob:DamageAreaPercentage(damage)`.
- Add `mob:DamageAreaPercentage(damage, distance)`.
- Add `mob:DamageAreaBotsPercentage(damage)`.
- Add `mob:DamageAreaBotsPercentage(damage, distance)`.
- Add `mob:DamageAreaClientsPercentage(damage)`.
- Add `mob:DamageAreaClientsPercentage(damage, distance)`.
- Add `mob:DamageAreaNPCsPercentage(damage)`.
- Add `mob:DamageAreaNPCsPercentage(damage, distance)`.

# Notes
- Cleanup parameter order of damage methods.
- These methods allow you to damage all Bots, Clients, Mobs, or NPCs in a zone or by distance from the Mob.
- Fix math with percentage damage.