### PR TITLE
[Quest API] Add Client Spell Methods to Perl/Lua.

### DIFF
--- a/common/emu_constants.h
+++ b/common/emu_constants.h
@@ -580,11 +580,17 @@ enum BucketComparison : uint8 {
 	BucketIsNotBetween
 };
 
-enum EntityFilterTypes : uint8 {
+enum class EntityFilterType {
 	All,
 	Bots,
 	Clients,
 	NPCs
+};
+
+enum class ApplySpellType {
+	Solo,
+	Group,
+	Raid
 };
 
 #endif /*COMMON_EMU_CONSTANTS_H*/

--- a/zone/aggro.cpp
+++ b/zone/aggro.cpp
@@ -1518,7 +1518,7 @@ bool Mob::PassCharismaCheck(Mob* caster, uint16 spell_id) {
 void Mob::RogueEvade(Mob *other)
 {
 	int64 amount = other->GetHateAmount(this) * zone->random.Int(40, 70) / 100;
-	other->SetHateAmountOnEnt(this, std::max((int64)100, amount));
+	other->SetHateAmountOnEnt(this, std::max(static_cast<int64>(100), amount));
 
 	return;
 }

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -1199,7 +1199,7 @@ void Client::ChannelMessageReceived(uint8 chan_num, uint8 language, uint8 lang_s
 				CheckEmoteHail(t, message);
 
 				if (DistanceNoZ(m_Position, t->GetPosition()) <= RuleI(Range, Say)) {
-					
+
 					parse->EventNPC(EVENT_SAY, t, this, message, language);
 
 					if (RuleB(TaskSystem, EnableTaskSystem)) {
@@ -11804,4 +11804,109 @@ void Client::AddAAPoints(uint32 points)
 
 bool Client::SendGMCommand(std::string message, bool ignore_status) {
 	return command_dispatch(this, message, ignore_status) >= 0 ? true : false;
+}
+
+std::vector<Mob*> Client::GetApplySpellList(
+	ApplySpellType apply_type,
+	bool allow_pets,
+	bool is_raid_group_only,
+	bool allow_bots
+) {
+	std::vector<Mob*> l;
+
+	if (apply_type == ApplySpellType::Raid && IsRaidGrouped()) {
+		auto* r = GetRaid();
+		auto group_id = r->GetGroup(this);
+		if (r && EQ::ValueWithin(group_id, 0, (MAX_RAID_GROUPS - 1))) {
+			for (auto i = 0; i < MAX_RAID_MEMBERS; i++) {
+				auto* m = r->members[i].member;
+				if (m && m->IsClient() && (!is_raid_group_only || r->GetGroup(m) == group_id)) {
+					l.push_back(m);
+
+					if (allow_pets && m->HasPet()) {
+						l.push_back(m->GetPet());
+					}
+
+#ifdef BOTS
+					if (allow_bots) {
+						const auto& sbl = entity_list.GetBotListByCharacterID(m->CharacterID());
+						for (const auto& b : sbl) {
+							l.push_back(b);
+						}
+					}
+#endif
+				}
+			}
+		}
+	} else if (apply_type == ApplySpellType::Group && IsGrouped()) {
+		auto* g = GetGroup();
+		if (g) {
+			for (auto i = 0; i < MAX_GROUP_MEMBERS; i++) {
+				auto* m = g->members[i];
+				if (m && m->IsClient()) {
+					l.push_back(m->CastToClient());
+
+					if (allow_pets && m->HasPet()) {
+						l.push_back(m->GetPet());
+					}
+
+#ifdef BOTS
+					if (allow_bots) {
+						const auto& sbl = entity_list.GetBotListByCharacterID(m->CastToClient()->CharacterID());
+						for (const auto& b : sbl) {
+							l.push_back(b);
+						}
+					}
+#endif
+				}
+			}
+		}
+	} else {
+		l.push_back(this);
+
+		if (allow_pets && HasPet()) {
+			l.push_back(GetPet());
+		}
+
+#ifdef BOTS
+		if (allow_bots) {
+			const auto& sbl = entity_list.GetBotListByCharacterID(CharacterID());
+			for (const auto& b : sbl) {
+				l.push_back(b);
+			}
+		}
+#endif
+	}
+
+	return l;
+}
+
+void Client::ApplySpell(
+	int spell_id,
+	int duration,
+	ApplySpellType apply_type,
+	bool allow_pets,
+	bool is_raid_group_only,
+	bool allow_bots
+) {
+	const auto& l = GetApplySpellList(apply_type, allow_pets, is_raid_group_only, allow_bots);
+
+	for (const auto& m : l) {
+		m->ApplySpellBuff(spell_id, duration);
+	}
+}
+
+void Client::SetSpellDuration(
+	int spell_id,
+	int duration,
+	ApplySpellType apply_type,
+	bool allow_pets,
+	bool is_raid_group_only,
+	bool allow_bots
+) {
+	const auto& l = GetApplySpellList(apply_type, allow_pets, is_raid_group_only, allow_bots);
+
+	for (const auto& m : l) {
+		m->SetBuffDuration(spell_id, duration);
+	}
 }

--- a/zone/client.h
+++ b/zone/client.h
@@ -910,6 +910,31 @@ public:
 
 	bool SendGMCommand(std::string message, bool ignore_status = false);
 
+	std::vector<Mob*> GetApplySpellList(
+		ApplySpellType apply_type,
+		bool allow_pets,
+		bool is_raid_group_only,
+		bool allow_bots
+	);
+
+	void ApplySpell(
+		int spell_id,
+		int duration = 0,
+		ApplySpellType apply_type = ApplySpellType::Solo,
+		bool allow_pets = false,
+		bool is_raid_group_only = true,
+		bool allow_bots = false
+	);
+
+	void SetSpellDuration(
+		int spell_id,
+		int duration = 0,
+		ApplySpellType apply_type = ApplySpellType::Solo,
+		bool allow_pets = false,
+		bool is_raid_group_only = true,
+		bool allow_bots = false
+	);
+
 	//old AA methods that we still use
 	void ResetAA();
 	void RefundAA();

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -5858,9 +5858,9 @@ void EntityList::Marquee(
 	}
 }
 
-std::vector<Mob*> EntityList::GetFilteredEntityList(Mob* sender, uint32 distance, uint8 filter_type)
+std::vector<Mob*> EntityList::GetFilteredEntityList(Mob* sender, uint32 distance, EntityFilterType filter_type)
 {
-	std::vector<Mob *> l;
+	std::vector<Mob*> l;
 	if (!sender) {
 		return l;
 	}
@@ -5887,9 +5887,9 @@ std::vector<Mob*> EntityList::GetFilteredEntityList(Mob* sender, uint32 distance
 		}
 
 		if (
-			(filter_type == EntityFilterTypes::Bots && !m.second->IsBot()) ||
-			(filter_type == EntityFilterTypes::Clients && !m.second->IsClient()) ||
-			(filter_type == EntityFilterTypes::NPCs && !m.second->IsNPC())
+			(filter_type == EntityFilterType::Bots && !m.second->IsBot()) ||
+			(filter_type == EntityFilterType::Clients && !m.second->IsClient()) ||
+			(filter_type == EntityFilterType::NPCs && !m.second->IsNPC())
 		) {
 			continue;
 		}
@@ -5900,8 +5900,13 @@ std::vector<Mob*> EntityList::GetFilteredEntityList(Mob* sender, uint32 distance
 	return l;
 }
 
-void EntityList::DamageArea(Mob* sender, int64 damage, uint32 distance, uint8 filter_type, bool is_percentage)
-{
+void EntityList::DamageArea(
+	Mob* sender,
+	int64 damage,
+	uint32 distance,
+	EntityFilterType filter_type,
+	bool is_percentage
+) {
 	if (!sender) {
 		return;
 	}

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -340,8 +340,19 @@ public:
 
 	void DescribeAggro(Client *to_who, NPC *from_who, float dist, bool verbose);
 
-	std::vector<Mob*> GetFilteredEntityList(Mob* sender, uint32 distance = 0, uint8 filter_type = EntityFilterTypes::All);
-	void DamageArea(Mob* sender, int64 damage, uint32 distance = 0, uint8 filter_type = EntityFilterTypes::All, bool is_percentage = false);
+	std::vector<Mob*> GetFilteredEntityList(
+		Mob* sender,
+		uint32 distance = 0,
+		EntityFilterType filter_type = EntityFilterType::All
+	);
+
+	void DamageArea(
+		Mob* sender,
+		int64 damage,
+		uint32 distance = 0,
+		EntityFilterType filter_type = EntityFilterType::All,
+		bool is_percentage = false
+	);
 
 	void	Marquee(uint32 type, std::string message, uint32 duration = 3000);
 	void	Marquee(uint32 type, uint32 priority, uint32 fade_in, uint32 fade_out, uint32 duration, std::string message);

--- a/zone/hate_list.cpp
+++ b/zone/hate_list.cpp
@@ -999,13 +999,13 @@ NPC* HateList::GetRandomNPCOnHateList(bool skip_mezzed)
 	return nullptr;
 }
 
-void HateList::DamageHateList(int64 damage, uint32 distance, uint8 filter_type, bool is_percentage)
+void HateList::DamageHateList(int64 damage, uint32 distance, EntityFilterType filter_type, bool is_percentage)
 {
 	if (damage <= 0) {
 		return;
 	}
 
-	const auto& l = GetFilteredHateList(distance, filter_type);
+	const auto& l = GetFilteredHateList(filter_type, distance);
 	for (const auto& h : l) {
 		auto e = h->entity_on_hatelist;
 		if (is_percentage) {
@@ -1018,7 +1018,7 @@ void HateList::DamageHateList(int64 damage, uint32 distance, uint8 filter_type, 
 	}
 }
 
-std::list<struct_HateList*> HateList::GetFilteredHateList(uint32 distance, uint8 filter_type)
+std::list<struct_HateList*> HateList::GetFilteredHateList(EntityFilterType filter_type, uint32 distance)
 {
 	std::list<struct_HateList*> l;
 	const auto squared_distance = (distance * distance);
@@ -1039,9 +1039,9 @@ std::list<struct_HateList*> HateList::GetFilteredHateList(uint32 distance, uint8
 		}
 
 		if (
-			(filter_type == EntityFilterTypes::Bots && !e->IsBot()) ||
-			(filter_type == EntityFilterTypes::Clients && !e->IsClient()) ||
-			(filter_type == EntityFilterTypes::NPCs && !e->IsNPC())
+			(filter_type == EntityFilterType::Bots && !e->IsBot()) ||
+			(filter_type == EntityFilterType::Clients && !e->IsClient()) ||
+			(filter_type == EntityFilterType::NPCs && !e->IsNPC())
 		) {
 			continue;
 		}

--- a/zone/hate_list.h
+++ b/zone/hate_list.h
@@ -66,15 +66,16 @@ public:
 	int64 GetEntHateAmount(Mob *ent, bool in_damage = false);
 
 	std::list<struct_HateList *> &GetHateList() { return list; }
+
 	std::list<struct_HateList *> GetFilteredHateList(
-		uint32 distance = 0,
-		uint8 filter_type = EntityFilterTypes::All
+		EntityFilterType filter_type = EntityFilterType::All,
+		uint32 distance = 0
 	);
 
 	void DamageHateList(
 		int64 damage,
 		uint32 distance = 0,
-		uint8 filter_type = EntityFilterTypes::All,
+		EntityFilterType filter_type = EntityFilterType::All,
 		bool is_percentage = false
 	);
 

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -2613,6 +2613,168 @@ void Lua_Client::SendMarqueeMessage(uint32 type, uint32 priority, uint32 fade_in
 	self->SendMarqueeMessage(type, priority, fade_in, fade_out, duration, message);
 }
 
+void Lua_Client::ApplySpell(int spell_id) {
+	Lua_Safe_Call_Void();
+	self->ApplySpell(spell_id);
+}
+
+void Lua_Client::ApplySpell(int spell_id, int duration) {
+	Lua_Safe_Call_Void();
+	self->ApplySpell(spell_id, duration);
+}
+
+void Lua_Client::ApplySpell(int spell_id, int duration, bool allow_pets) {
+	Lua_Safe_Call_Void();
+	self->ApplySpell(spell_id, duration, ApplySpellType::Solo, allow_pets);
+}
+
+void Lua_Client::ApplySpell(int spell_id, int duration, bool allow_pets, bool is_raid_group_only) {
+	Lua_Safe_Call_Void();
+	self->ApplySpell(spell_id, duration, ApplySpellType::Solo, allow_pets, is_raid_group_only);
+}
+
+#ifdef BOTS
+void Lua_Client::ApplySpell(int spell_id, int duration, bool allow_pets, bool is_raid_group_only, bool allow_bots) {
+	Lua_Safe_Call_Void();
+	self->ApplySpell(spell_id, duration, ApplySpellType::Solo, allow_pets, is_raid_group_only, allow_bots);
+}
+#endif
+
+void Lua_Client::ApplySpellGroup(int spell_id) {
+	Lua_Safe_Call_Void();
+	self->ApplySpell(spell_id, 0, ApplySpellType::Group);
+}
+
+void Lua_Client::ApplySpellGroup(int spell_id, int duration) {
+	Lua_Safe_Call_Void();
+	self->ApplySpell(spell_id, duration, ApplySpellType::Group);
+}
+
+void Lua_Client::ApplySpellGroup(int spell_id, int duration, bool allow_pets) {
+	Lua_Safe_Call_Void();
+	self->ApplySpell(spell_id, duration, ApplySpellType::Group, allow_pets);
+}
+
+void Lua_Client::ApplySpellGroup(int spell_id, int duration, bool allow_pets, bool is_raid_group_only) {
+	Lua_Safe_Call_Void();
+	self->ApplySpell(spell_id, duration, ApplySpellType::Group, allow_pets, is_raid_group_only);
+}
+
+#ifdef BOTS
+void Lua_Client::ApplySpellGroup(int spell_id, int duration, bool allow_pets, bool is_raid_group_only, bool allow_bots) {
+	Lua_Safe_Call_Void();
+	self->ApplySpell(spell_id, duration, ApplySpellType::Group, allow_pets, is_raid_group_only, allow_bots);
+}
+#endif
+
+void Lua_Client::ApplySpellRaid(int spell_id) {
+	Lua_Safe_Call_Void();
+	self->ApplySpell(spell_id, 0, ApplySpellType::Raid);
+}
+
+void Lua_Client::ApplySpellRaid(int spell_id, int duration) {
+	Lua_Safe_Call_Void();
+	self->ApplySpell(spell_id, duration, ApplySpellType::Raid);
+}
+
+void Lua_Client::ApplySpellRaid(int spell_id, int duration, bool allow_pets) {
+	Lua_Safe_Call_Void();
+	self->ApplySpell(spell_id, duration, ApplySpellType::Raid, allow_pets);
+}
+
+void Lua_Client::ApplySpellRaid(int spell_id, int duration, bool allow_pets, bool is_raid_group_only) {
+	Lua_Safe_Call_Void();
+	self->ApplySpell(spell_id, duration, ApplySpellType::Raid, allow_pets, is_raid_group_only);
+}
+
+#ifdef BOTS
+void Lua_Client::ApplySpellRaid(int spell_id, int duration, bool allow_pets, bool is_raid_group_only, bool allow_bots) {
+	Lua_Safe_Call_Void();
+	self->ApplySpell(spell_id, duration, ApplySpellType::Raid, allow_pets, is_raid_group_only, allow_bots);
+}
+#endif
+
+void Lua_Client::SetSpellDuration(int spell_id) {
+	Lua_Safe_Call_Void();
+	self->SetSpellDuration(spell_id);
+}
+
+void Lua_Client::SetSpellDuration(int spell_id, int duration) {
+	Lua_Safe_Call_Void();
+	self->SetSpellDuration(spell_id, duration);
+}
+
+void Lua_Client::SetSpellDuration(int spell_id, int duration, bool allow_pets) {
+	Lua_Safe_Call_Void();
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Solo, allow_pets);
+}
+
+void Lua_Client::SetSpellDuration(int spell_id, int duration, bool allow_pets, bool is_raid_group_only) {
+	Lua_Safe_Call_Void();
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Solo, allow_pets, is_raid_group_only);
+}
+
+#ifdef BOTS
+void Lua_Client::SetSpellDuration(int spell_id, int duration, bool allow_pets, bool is_raid_group_only, bool allow_bots) {
+	Lua_Safe_Call_Void();
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Solo, allow_pets, is_raid_group_only, allow_bots);
+}
+#endif
+
+void Lua_Client::SetSpellDurationGroup(int spell_id) {
+	Lua_Safe_Call_Void();
+	self->SetSpellDuration(spell_id, 0, ApplySpellType::Group);
+}
+
+void Lua_Client::SetSpellDurationGroup(int spell_id, int duration) {
+	Lua_Safe_Call_Void();
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Group);
+}
+
+void Lua_Client::SetSpellDurationGroup(int spell_id, int duration, bool allow_pets) {
+	Lua_Safe_Call_Void();
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Group, allow_pets);
+}
+
+void Lua_Client::SetSpellDurationGroup(int spell_id, int duration, bool allow_pets, bool is_raid_group_only) {
+	Lua_Safe_Call_Void();
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Group, allow_pets, is_raid_group_only);
+}
+
+#ifdef BOTS
+void Lua_Client::SetSpellDurationGroup(int spell_id, int duration, bool allow_pets, bool is_raid_group_only, bool allow_bots) {
+	Lua_Safe_Call_Void();
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Group, allow_pets, is_raid_group_only, allow_bots);
+}
+#endif
+
+void Lua_Client::SetSpellDurationRaid(int spell_id) {
+	Lua_Safe_Call_Void();
+	self->SetSpellDuration(spell_id, 0, ApplySpellType::Raid);
+}
+
+void Lua_Client::SetSpellDurationRaid(int spell_id, int duration) {
+	Lua_Safe_Call_Void();
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Raid);
+}
+
+void Lua_Client::SetSpellDurationRaid(int spell_id, int duration, bool allow_pets) {
+	Lua_Safe_Call_Void();
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Raid, allow_pets);
+}
+
+void Lua_Client::SetSpellDurationRaid(int spell_id, int duration, bool allow_pets, bool is_raid_group_only) {
+	Lua_Safe_Call_Void();
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Raid, allow_pets, is_raid_group_only);
+}
+
+#ifdef BOTS
+void Lua_Client::SetSpellDurationRaid(int spell_id, int duration, bool allow_pets, bool is_raid_group_only, bool allow_bots) {
+	Lua_Safe_Call_Void();
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Group, allow_pets, is_raid_group_only, allow_bots);
+}
+#endif
+
 #ifdef BOTS
 
 int Lua_Client::GetBotRequiredLevel()
@@ -2717,6 +2879,27 @@ luabind::scope lua_register_client() {
 	.def("AddPVPPoints", (void(Lua_Client::*)(uint32))&Lua_Client::AddPVPPoints)
 	.def("AddSkill", (void(Lua_Client::*)(int,int))&Lua_Client::AddSkill)
 	.def("Admin", (int16(Lua_Client::*)(void))&Lua_Client::Admin)
+	.def("ApplySpell", (void(Lua_Client::*)(int))&Lua_Client::ApplySpell)
+	.def("ApplySpell", (void(Lua_Client::*)(int,int))&Lua_Client::ApplySpell)
+	.def("ApplySpell", (void(Lua_Client::*)(int,int,bool))&Lua_Client::ApplySpell)
+	.def("ApplySpell", (void(Lua_Client::*)(int,int,bool,bool))&Lua_Client::ApplySpell)
+#ifdef BOTS
+	.def("ApplySpell", (void(Lua_Client::*)(int,int,bool,bool,bool))&Lua_Client::ApplySpell)
+#endif
+	.def("ApplySpellGroup", (void(Lua_Client::*)(int))&Lua_Client::ApplySpellGroup)
+	.def("ApplySpellGroup", (void(Lua_Client::*)(int,int))&Lua_Client::ApplySpellGroup)
+	.def("ApplySpellGroup", (void(Lua_Client::*)(int,int,bool))&Lua_Client::ApplySpellGroup)
+	.def("ApplySpellGroup", (void(Lua_Client::*)(int,int,bool,bool))&Lua_Client::ApplySpellGroup)
+#ifdef BOTS
+	.def("ApplySpellGroup", (void(Lua_Client::*)(int,int,bool,bool,bool))&Lua_Client::ApplySpellGroup)
+#endif
+	.def("ApplySpellRaid", (void(Lua_Client::*)(int))&Lua_Client::ApplySpellRaid)
+	.def("ApplySpellRaid", (void(Lua_Client::*)(int,int))&Lua_Client::ApplySpellRaid)
+	.def("ApplySpellRaid", (void(Lua_Client::*)(int,int,bool))&Lua_Client::ApplySpellRaid)
+	.def("ApplySpellRaid", (void(Lua_Client::*)(int,int,bool,bool))&Lua_Client::ApplySpellRaid)
+#ifdef BOTS
+	.def("ApplySpellRaid", (void(Lua_Client::*)(int,int,bool,bool,bool))&Lua_Client::ApplySpellRaid)
+#endif
 	.def("AssignTask", (void(Lua_Client::*)(int))&Lua_Client::AssignTask)
 	.def("AssignTask", (void(Lua_Client::*)(int,int))&Lua_Client::AssignTask)
 	.def("AssignTask", (void(Lua_Client::*)(int,int,bool))&Lua_Client::AssignTask)
@@ -3099,6 +3282,27 @@ luabind::scope lua_register_client() {
 	.def("SetSecondaryWeaponOrnamentation", (void(Lua_Client::*)(uint32))&Lua_Client::SetSecondaryWeaponOrnamentation)
 	.def("SetSkill", (void(Lua_Client::*)(int,int))&Lua_Client::SetSkill)
 	.def("SetSkillPoints", (void(Lua_Client::*)(int))&Lua_Client::SetSkillPoints)
+	.def("SetSpellDuration", (void(Lua_Client::*)(int))&Lua_Client::SetSpellDuration)
+	.def("SetSpellDuration", (void(Lua_Client::*)(int,int))&Lua_Client::SetSpellDuration)
+	.def("SetSpellDuration", (void(Lua_Client::*)(int,int,bool))&Lua_Client::SetSpellDuration)
+	.def("SetSpellDuration", (void(Lua_Client::*)(int,int,bool,bool))&Lua_Client::SetSpellDuration)
+#ifdef BOTS
+	.def("SetSpellDuration", (void(Lua_Client::*)(int,int,bool,bool,bool))&Lua_Client::SetSpellDuration)
+#endif
+	.def("SetSpellDurationGroup", (void(Lua_Client::*)(int))&Lua_Client::SetSpellDurationGroup)
+	.def("SetSpellDurationGroup", (void(Lua_Client::*)(int,int))&Lua_Client::SetSpellDurationGroup)
+	.def("SetSpellDurationGroup", (void(Lua_Client::*)(int,int,bool))&Lua_Client::SetSpellDurationGroup)
+	.def("SetSpellDurationGroup", (void(Lua_Client::*)(int,int,bool,bool))&Lua_Client::SetSpellDurationGroup)
+#ifdef BOTS
+	.def("SetSpellDurationGroup", (void(Lua_Client::*)(int,int,bool,bool,bool))&Lua_Client::SetSpellDurationGroup)
+#endif
+	.def("SetSpellDurationRaid", (void(Lua_Client::*)(int))&Lua_Client::SetSpellDurationRaid)
+	.def("SetSpellDurationRaid", (void(Lua_Client::*)(int,int))&Lua_Client::SetSpellDurationRaid)
+	.def("SetSpellDurationRaid", (void(Lua_Client::*)(int,int,bool))&Lua_Client::SetSpellDurationRaid)
+	.def("SetSpellDurationRaid", (void(Lua_Client::*)(int,int,bool,bool))&Lua_Client::SetSpellDurationRaid)
+#ifdef BOTS
+	.def("SetSpellDurationRaid", (void(Lua_Client::*)(int,int,bool,bool,bool))&Lua_Client::SetSpellDurationRaid)
+#endif
 	.def("SetStartZone", (void(Lua_Client::*)(int))&Lua_Client::SetStartZone)
 	.def("SetStartZone", (void(Lua_Client::*)(int,float))&Lua_Client::SetStartZone)
 	.def("SetStartZone", (void(Lua_Client::*)(int,float,float))&Lua_Client::SetStartZone)
@@ -3108,7 +3312,7 @@ luabind::scope lua_register_client() {
 	.def("SetTint", (void(Lua_Client::*)(int,uint32))&Lua_Client::SetTint)
 	.def("SetTitleSuffix", (void(Lua_Client::*)(const char *))&Lua_Client::SetTitleSuffix)
 	.def("SetZoneFlag", (void(Lua_Client::*)(uint32))&Lua_Client::SetZoneFlag)
-	.def("Signal", (void(Lua_Client::*)(int))&Lua_Client::Signal)
+	.def("Signal", (void(Lua_Client::*)(uint32))&Lua_Client::Signal)
 	.def("Sit", (void(Lua_Client::*)(void))&Lua_Client::Sit)
 	.def("Stand", (void(Lua_Client::*)(void))&Lua_Client::Stand)
 	.def("SummonBaggedItems", (void(Lua_Client::*)(uint32,luabind::adl::object))&Lua_Client::SummonBaggedItems)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -435,6 +435,55 @@ public:
 	int GetHealAmount();
 	int GetSpellDamage();
 
+	void ApplySpell(int spell_id);
+	void ApplySpell(int spell_id, int duration);
+	void ApplySpell(int spell_id, int duration, bool allow_pets);
+	void ApplySpell(int spell_id, int duration, bool allow_pets, bool is_raid_group_only);
+#ifdef BOTS
+	void ApplySpell(int spell_id, int duration, bool allow_pets, bool is_raid_group_only, bool allow_bots);
+#endif
+
+	void ApplySpellGroup(int spell_id);
+	void ApplySpellGroup(int spell_id, int duration);
+	void ApplySpellGroup(int spell_id, int duration, bool allow_pets);
+	void ApplySpellGroup(int spell_id, int duration, bool allow_pets, bool is_raid_group_only);
+#ifdef BOTS
+	void ApplySpellGroup(int spell_id, int duration, bool allow_pets, bool is_raid_group_only, bool allow_bots);
+#endif
+
+	void ApplySpellRaid(int spell_id);
+	void ApplySpellRaid(int spell_id, int duration);
+	void ApplySpellRaid(int spell_id, int duration, bool allow_pets);
+	void ApplySpellRaid(int spell_id, int duration, bool allow_pets, bool is_raid_group_only);
+#ifdef BOTS
+	void ApplySpellRaid(int spell_id, int duration, bool allow_pets, bool is_raid_group_only, bool allow_bots);
+#endif
+
+	void SetSpellDuration(int spell_id);
+	void SetSpellDuration(int spell_id, int duration);
+	void SetSpellDuration(int spell_id, int duration, bool allow_pets);
+	void SetSpellDuration(int spell_id, int duration, bool allow_pets, bool is_raid_group_only);
+#ifdef BOTS
+	void SetSpellDuration(int spell_id, int duration, bool allow_pets, bool is_raid_group_only, bool allow_bots);
+#endif
+
+	void SetSpellDurationGroup(int spell_id);
+	void SetSpellDurationGroup(int spell_id, int duration);
+	void SetSpellDurationGroup(int spell_id, int duration, bool allow_pets);
+	void SetSpellDurationGroup(int spell_id, int duration, bool allow_pets, bool is_raid_group_only);
+#ifdef BOTS
+	void SetSpellDurationGroup(int spell_id, int duration, bool allow_pets, bool is_raid_group_only, bool allow_bots);
+#endif
+
+	void SetSpellDurationRaid(int spell_id);
+	void SetSpellDurationRaid(int spell_id, int duration);
+	void SetSpellDurationRaid(int spell_id, int duration, bool allow_pets);
+	void SetSpellDurationRaid(int spell_id, int duration, bool allow_pets, bool is_raid_group_only);
+#ifdef BOTS
+	void SetSpellDurationRaid(int spell_id, int duration, bool allow_pets, bool is_raid_group_only, bool allow_bots);
+#endif
+
+
 	int GetEnvironmentDamageModifier();
 	void SetEnvironmentDamageModifier(int value);
 	bool GetInvulnerableEnvironmentDamage();

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -1382,7 +1382,7 @@ void Lua_Mob::Signal(int signal_id) {
 #ifdef BOTS
 	} else if (self->IsBot()) {
 		self->CastToBot()->SignalBot(signal_id);
-#endif	
+#endif
 	}
 }
 
@@ -2376,7 +2376,7 @@ Lua_HateList Lua_Mob::GetHateListByDistance(uint32 distance) {
 	Lua_Safe_Call_Class(Lua_HateList);
 	Lua_HateList ret;
 
-	auto h_list = self->GetFilteredHateList(distance);
+	auto h_list = self->GetFilteredHateList(EntityFilterType::All, distance);
 	for (auto h : h_list) {
 		Lua_HateEntry e(h);
 		ret.entries.push_back(e);
@@ -2524,59 +2524,59 @@ void Lua_Mob::DamageHateList(int64 damage, uint32 distance) {
 
 void Lua_Mob::DamageHateListClients(int64 damage) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, 0, EntityFilterTypes::Clients);
+	self->DamageHateList(damage, 0, EntityFilterType::Clients);
 }
 
 void Lua_Mob::DamageHateListClients(int64 damage, uint32 distance) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, distance, EntityFilterTypes::Clients);
+	self->DamageHateList(damage, distance, EntityFilterType::Clients);
 }
 
 void Lua_Mob::DamageHateListNPCs(int64 damage) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, 0, EntityFilterTypes::NPCs);
+	self->DamageHateList(damage, 0, EntityFilterType::NPCs);
 }
 
 void Lua_Mob::DamageHateListNPCs(int64 damage, uint32 distance) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, distance, EntityFilterTypes::NPCs);
+	self->DamageHateList(damage, distance, EntityFilterType::NPCs);
 }
 
 void Lua_Mob::DamageHateListPercentage(int64 damage) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, 0, EntityFilterTypes::All, true);
+	self->DamageHateList(damage, 0, EntityFilterType::All, true);
 }
 
 void Lua_Mob::DamageHateListPercentage(int64 damage, uint32 distance) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, distance, EntityFilterTypes::All, true);
+	self->DamageHateList(damage, distance, EntityFilterType::All, true);
 }
 
 void Lua_Mob::DamageHateListClientsPercentage(int64 damage) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, 0, EntityFilterTypes::Clients, true);
+	self->DamageHateList(damage, 0, EntityFilterType::Clients, true);
 }
 
 void Lua_Mob::DamageHateListClientsPercentage(int64 damage, uint32 distance) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, distance, EntityFilterTypes::Clients, true);
+	self->DamageHateList(damage, distance, EntityFilterType::Clients, true);
 }
 
 void Lua_Mob::DamageHateListNPCsPercentage(int64 damage) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, 0, EntityFilterTypes::NPCs, true);
+	self->DamageHateList(damage, 0, EntityFilterType::NPCs, true);
 }
 
 void Lua_Mob::DamageHateListNPCsPercentage(int64 damage, uint32 distance) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, distance, EntityFilterTypes::NPCs, true);
+	self->DamageHateList(damage, distance, EntityFilterType::NPCs, true);
 }
 
 Lua_HateList Lua_Mob::GetHateListClients() {
 	Lua_Safe_Call_Class(Lua_HateList);
 	Lua_HateList ret;
 
-	auto h_list = self->GetFilteredHateList(EntityFilterTypes::Clients);
+	auto h_list = self->GetFilteredHateList(EntityFilterType::Clients);
 	for (auto h : h_list) {
 		Lua_HateEntry e(h);
 		ret.entries.push_back(e);
@@ -2589,7 +2589,7 @@ Lua_HateList Lua_Mob::GetHateListClients(uint32 distance) {
 	Lua_Safe_Call_Class(Lua_HateList);
 	Lua_HateList ret;
 
-	auto h_list = self->GetFilteredHateList(EntityFilterTypes::Clients, distance);
+	auto h_list = self->GetFilteredHateList(EntityFilterType::Clients, distance);
 	for (auto h : h_list) {
 		Lua_HateEntry e(h);
 		ret.entries.push_back(e);
@@ -2602,7 +2602,7 @@ Lua_HateList Lua_Mob::GetHateListNPCs() {
 	Lua_Safe_Call_Class(Lua_HateList);
 	Lua_HateList ret;
 
-	auto h_list = self->GetFilteredHateList(EntityFilterTypes::NPCs);
+	auto h_list = self->GetFilteredHateList(EntityFilterType::NPCs);
 	for (auto h : h_list) {
 		Lua_HateEntry e(h);
 		ret.entries.push_back(e);
@@ -2615,7 +2615,7 @@ Lua_HateList Lua_Mob::GetHateListNPCs(uint32 distance) {
 	Lua_Safe_Call_Class(Lua_HateList);
 	Lua_HateList ret;
 
-	auto h_list = self->GetFilteredHateList(EntityFilterTypes::NPCs, distance);
+	auto h_list = self->GetFilteredHateList(EntityFilterType::NPCs, distance);
 	for (auto h : h_list) {
 		Lua_HateEntry e(h);
 		ret.entries.push_back(e);
@@ -2636,100 +2636,100 @@ void Lua_Mob::DamageArea(int64 damage, uint32 distance) {
 
 void Lua_Mob::DamageAreaPercentage(int64 damage) {
 	Lua_Safe_Call_Void();
-	self->DamageArea(damage, 0, EntityFilterTypes::All, true);
+	self->DamageArea(damage, 0, EntityFilterType::All, true);
 }
 
 void Lua_Mob::DamageAreaPercentage(int64 damage, uint32 distance) {
 	Lua_Safe_Call_Void();
-	self->DamageArea(damage, distance, EntityFilterTypes::All, true);
+	self->DamageArea(damage, distance, EntityFilterType::All, true);
 }
 
 void Lua_Mob::DamageAreaClients(int64 damage) {
 	Lua_Safe_Call_Void();
-	self->DamageArea(damage, 0, EntityFilterTypes::Clients);
+	self->DamageArea(damage, 0, EntityFilterType::Clients);
 }
 
 void Lua_Mob::DamageAreaClients(int64 damage, uint32 distance) {
 	Lua_Safe_Call_Void();
-	self->DamageArea(damage, distance, EntityFilterTypes::Clients);
+	self->DamageArea(damage, distance, EntityFilterType::Clients);
 }
 
 void Lua_Mob::DamageAreaClientsPercentage(int64 damage) {
 	Lua_Safe_Call_Void();
-	self->DamageArea(damage, 0, EntityFilterTypes::Clients, true);
+	self->DamageArea(damage, 0, EntityFilterType::Clients, true);
 }
 
 void Lua_Mob::DamageAreaClientsPercentage(int64 damage, uint32 distance) {
 	Lua_Safe_Call_Void();
-	self->DamageArea(damage, distance, EntityFilterTypes::Clients, true);
+	self->DamageArea(damage, distance, EntityFilterType::Clients, true);
 }
 
 void Lua_Mob::DamageAreaNPCs(int64 damage) {
 	Lua_Safe_Call_Void();
-	self->DamageArea(damage, 0, EntityFilterTypes::NPCs);
+	self->DamageArea(damage, 0, EntityFilterType::NPCs);
 }
 
 void Lua_Mob::DamageAreaNPCs(int64 damage, uint32 distance) {
 	Lua_Safe_Call_Void();
-	self->DamageArea(damage, distance, EntityFilterTypes::NPCs);
+	self->DamageArea(damage, distance, EntityFilterType::NPCs);
 }
 
 void Lua_Mob::DamageAreaNPCsPercentage(int64 damage) {
 	Lua_Safe_Call_Void();
-	self->DamageArea(damage, 0, EntityFilterTypes::NPCs, true);
+	self->DamageArea(damage, 0, EntityFilterType::NPCs, true);
 }
 
 void Lua_Mob::DamageAreaNPCsPercentage(int64 damage, uint32 distance) {
 	Lua_Safe_Call_Void();
-	self->DamageArea(damage, distance, EntityFilterTypes::NPCs, true);
+	self->DamageArea(damage, distance, EntityFilterType::NPCs, true);
 }
 
 #ifdef BOTS
 void Lua_Mob::DamageAreaBots(int64 damage) {
 	Lua_Safe_Call_Void();
-	self->DamageArea(damage, 0, EntityFilterTypes::Bots);
+	self->DamageArea(damage, 0, EntityFilterType::Bots);
 }
 
 void Lua_Mob::DamageAreaBots(int64 damage, uint32 distance) {
 	Lua_Safe_Call_Void();
-	self->DamageArea(damage, distance, EntityFilterTypes::Bots);
+	self->DamageArea(damage, distance, EntityFilterType::Bots);
 }
 
 void Lua_Mob::DamageAreaBotsPercentage(int64 damage) {
 	Lua_Safe_Call_Void();
-	self->DamageArea(damage, 0, EntityFilterTypes::Bots, true);
+	self->DamageArea(damage, 0, EntityFilterType::Bots, true);
 }
 
 void Lua_Mob::DamageAreaBotsPercentage(int64 damage, uint32 distance) {
 	Lua_Safe_Call_Void();
-	self->DamageArea(damage, distance, EntityFilterTypes::Bots, true);
+	self->DamageArea(damage, distance, EntityFilterType::Bots, true);
 }
 
 void Lua_Mob::DamageHateListBots(int64 damage) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, 0, EntityFilterTypes::Bots);
+	self->DamageHateList(damage, 0, EntityFilterType::Bots);
 }
 
 void Lua_Mob::DamageHateListBots(int64 damage, uint32 distance) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, distance, EntityFilterTypes::Bots);
+	self->DamageHateList(damage, distance, EntityFilterType::Bots);
 }
 
 void Lua_Mob::DamageHateListBotsPercentage(int64 damage) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, 0, EntityFilterTypes::Bots, true);
+	self->DamageHateList(damage, 0, EntityFilterType::Bots, true);
 }
 
 void Lua_Mob::DamageHateListBotsPercentage(int64 damage, uint32 distance) {
 	Lua_Safe_Call_Void();
-	self->DamageHateList(damage, distance, EntityFilterTypes::Bots, true);
+	self->DamageHateList(damage, distance, EntityFilterType::Bots, true);
 }
 
 Lua_HateList Lua_Mob::GetHateListBots() {
 	Lua_Safe_Call_Class(Lua_HateList);
 	Lua_HateList ret;
 
-	auto h_list = self->GetFilteredHateList(EntityFilterTypes::Bots);
+	auto h_list = self->GetFilteredHateList(EntityFilterType::Bots);
 	for (auto h : h_list) {
 		Lua_HateEntry e(h);
 		ret.entries.push_back(e);
@@ -2742,7 +2742,7 @@ Lua_HateList Lua_Mob::GetHateListBots(uint32 distance) {
 	Lua_Safe_Call_Class(Lua_HateList);
 	Lua_HateList ret;
 
-	auto h_list = self->GetFilteredHateList(EntityFilterTypes::Bots, distance);
+	auto h_list = self->GetFilteredHateList(EntityFilterType::Bots, distance);
 	for (auto h : h_list) {
 		Lua_HateEntry e(h);
 		ret.entries.push_back(e);

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -351,9 +351,18 @@ public:
 	bool SpellFinished(uint16 spell_id, Mob *target, EQ::spells::CastingSlot slot = EQ::spells::CastingSlot::Item, int mana_used = 0,
 		uint32 inventory_slot = 0xFFFFFFFF, int16 resist_adjust = 0, bool isproc = false, int level_override = -1, uint32 timer = 0xFFFFFFFF, uint32 timer_duration = 0, bool from_casted_spell = false, uint32 aa_id = 0);
 	void SendBeginCast(uint16 spell_id, uint32 casttime);
-	virtual bool SpellOnTarget(uint16 spell_id, Mob* spelltar, int reflect_effectiveness = 0,
-		bool use_resist_adjust = false, int16 resist_adjust = 0, bool isproc = false, int level_override = -1, int32 duration_override = 0, bool disable_buff_overrwrite = false);
-	virtual bool SpellEffect(Mob* caster, uint16 spell_id, float partial = 100, int level_override = -1, int reflect_effectiveness = 0, int32 duration_override = 0, bool disable_buff_overrwrite = false);
+	virtual bool SpellOnTarget(
+		uint16 spell_id,Mo
+		b* spelltar,
+		int reflect_effectiveness = 0,
+		bool use_resist_adjust = false,
+		int16 resist_adjust = 0,
+		bool isproc = false,
+		int level_override = -1,
+		int duration_override = 0,
+		bool disable_buff_overwrite = false
+	);
+	virtual bool SpellEffect(Mob* caster, uint16 spell_id, float partial = 100, int level_override = -1, int reflect_effectiveness = 0, int32 duration_override = 0, bool disable_buff_overwrite = false);
 	virtual bool DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_center,
 		CastAction_type &CastAction, EQ::spells::CastingSlot slot, bool isproc = false);
 	bool DoCastingChecksOnCaster(int32 spell_id, EQ::spells::CastingSlot slot);
@@ -409,7 +418,7 @@ public:
 	bool IsAffectedByBuff(uint16 spell_id);
 	bool IsAffectedByBuffByGlobalGroup(GlobalGroup group);
 	void BuffModifyDurationBySpellID(uint16 spell_id, int32 newDuration);
-	int AddBuff(Mob *caster, const uint16 spell_id, int duration = 0, int32 level_override = -1, bool disable_buff_overrwrite = false);
+	int AddBuff(Mob *caster, const uint16 spell_id, int duration = 0, int32 level_override = -1, bool disable_buff_overwrite = false);
 	int CanBuffStack(uint16 spellid, uint8 caster_level, bool iFailIfOverwrite = false);
 	int CalcBuffDuration(Mob *caster, Mob *target, uint16 spell_id, int32 caster_level_override = -1);
 	void SendPetBuffsToClient();
@@ -464,8 +473,8 @@ public:
 	void GetAppearenceEffects();
 	void ClearAppearenceEffects();
 	void SendSavedAppearenceEffects(Client *receiver);
-	void SetBuffDuration(int32 spell_id, int32 duration = 0);
-	void ApplySpellBuff(int32 spell_id, int32 duration = 0);
+	void SetBuffDuration(int spell_id, int duration = 0);
+	void ApplySpellBuff(int spell_id, int duration = 0);
 	int GetBuffStatValueBySpell(int32 spell_id, const char* stat_identifier);
 	int GetBuffStatValueBySlot(uint8 slot, const char* stat_identifier);
 
@@ -727,15 +736,35 @@ public:
 	bool IsOnFeignMemory(Mob *attacker) const;
 	void PrintHateListToClient(Client *who) { hate_list.PrintHateListToClient(who); }
 	std::list<struct_HateList*>& GetHateList() { return hate_list.GetHateList(); }
-	std::list<struct_HateList*> GetFilteredHateList(uint8 filter_type = EntityFilterTypes::All, uint32 distance = 0) { return hate_list.GetFilteredHateList(distance, filter_type); }
-	void DamageHateList(int64 damage, uint32 distance = 0, uint8 filter_type = EntityFilterTypes::All, bool is_percentage = false) { hate_list.DamageHateList(damage, distance, filter_type, is_percentage); }
-	void DamageArea(int64 damage, uint32 distance = 0, uint8 filter_type = EntityFilterTypes::All, bool is_percentage = false) { entity_list.DamageArea(this, damage, distance, filter_type, is_percentage); }
 	bool CheckLosFN(Mob* other);
 	bool CheckLosFN(float posX, float posY, float posZ, float mobSize);
 	static bool CheckLosFN(glm::vec3 posWatcher, float sizeWatcher, glm::vec3 posTarget, float sizeTarget);
 	inline void SetLastLosState(bool value) { last_los_check = value; }
 	inline bool CheckLastLosState() const { return last_los_check; }
 	std::string GetMobDescription();
+
+	std::list<struct_HateList*> GetFilteredHateList(
+		EntityFilterType filter_type = EntityFilterType::All,
+		uint32 distance = 0
+	) {
+		return hate_list.GetFilteredHateList(filter_type, distance);
+	}
+	void DamageHateList(
+		int64 damage,
+		uint32 distance = 0,
+		EntityFilterType filter_type = EntityFilterType::All,
+		bool is_percentage = false
+	) {
+		hate_list.DamageHateList(damage, distance, filter_type, is_percentage);
+	}
+	void DamageArea(
+		int64 damage,
+		uint32 distance = 0,
+		EntityFilterType filter_type = EntityFilterType::All,
+		bool is_percentage = false
+	) {
+		entity_list.DamageArea(this, damage, distance, filter_type, is_percentage);
+	}
 
 	//Quest
 	void CameraEffect(uint32 duration, float intensity, Client *c = nullptr, bool global = false);

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -352,8 +352,8 @@ public:
 		uint32 inventory_slot = 0xFFFFFFFF, int16 resist_adjust = 0, bool isproc = false, int level_override = -1, uint32 timer = 0xFFFFFFFF, uint32 timer_duration = 0, bool from_casted_spell = false, uint32 aa_id = 0);
 	void SendBeginCast(uint16 spell_id, uint32 casttime);
 	virtual bool SpellOnTarget(
-		uint16 spell_id,Mo
-		b* spelltar,
+		uint16 spell_id,
+		Mob* spelltar,
 		int reflect_effectiveness = 0,
 		bool use_resist_adjust = false,
 		int16 resist_adjust = 0,
@@ -749,6 +749,7 @@ public:
 	) {
 		return hate_list.GetFilteredHateList(filter_type, distance);
 	}
+
 	void DamageHateList(
 		int64 damage,
 		uint32 distance = 0,
@@ -757,6 +758,7 @@ public:
 	) {
 		hate_list.DamageHateList(damage, distance, filter_type, is_percentage);
 	}
+
 	void DamageArea(
 		int64 damage,
 		uint32 distance = 0,

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -2507,6 +2507,168 @@ void Perl_Client_SendMarqueeMessage(Client* self, uint32 type, uint32 priority, 
 	self->SendMarqueeMessage(type, priority, fade_in, fade_out, duration, message);
 }
 
+void Perl_Client_ApplySpell(Client* self, int spell_id)
+{
+	self->ApplySpell(spell_id);
+}
+
+void Perl_Client_ApplySpell(Client* self, int spell_id, int duration)
+{
+	self->ApplySpell(spell_id, duration);
+}
+
+void Perl_Client_ApplySpell(Client* self, int spell_id, int duration, bool allow_pets)
+{
+	self->ApplySpell(spell_id, duration, ApplySpellType::Solo, allow_pets);
+}
+
+void Perl_Client_ApplySpell(Client* self, int spell_id, int duration, bool allow_pets, bool is_raid_group_only)
+{
+	self->ApplySpell(spell_id, duration, ApplySpellType::Solo, allow_pets, is_raid_group_only);
+}
+
+#ifdef BOTS
+void Perl_Client_ApplySpell(Client* self, int spell_id, int duration, bool allow_pets, bool is_raid_group_only, bool allow_bots)
+{
+	self->ApplySpell(spell_id, duration, ApplySpellType::Solo, allow_pets, is_raid_group_only, allow_bots);
+}
+#endif
+
+void Perl_Client_ApplySpellGroup(Client* self, int spell_id)
+{
+	self->ApplySpell(spell_id, 0, ApplySpellType::Group);
+}
+
+void Perl_Client_ApplySpellGroup(Client* self, int spell_id, int duration)
+{
+	self->ApplySpell(spell_id, duration, ApplySpellType::Group);
+}
+
+void Perl_Client_ApplySpellGroup(Client* self, int spell_id, int duration, bool allow_pets)
+{
+	self->ApplySpell(spell_id, duration, ApplySpellType::Group, allow_pets);
+}
+
+void Perl_Client_ApplySpellGroup(Client* self, int spell_id, int duration, bool allow_pets, bool is_raid_group_only)
+{
+	self->ApplySpell(spell_id, duration, ApplySpellType::Group, allow_pets, is_raid_group_only);
+}
+
+#ifdef BOTS
+void Perl_Client_ApplySpellGroup(Client* self, int spell_id, int duration, bool allow_pets, bool is_raid_group_only, bool allow_bots)
+{
+	self->ApplySpell(spell_id, duration, ApplySpellType::Group, allow_pets, is_raid_group_only, allow_bots);
+}
+#endif
+
+void Perl_Client_ApplySpellRaid(Client* self, int spell_id)
+{
+	self->ApplySpell(spell_id, 0, ApplySpellType::Raid);
+}
+
+void Perl_Client_ApplySpellRaid(Client* self, int spell_id, int duration)
+{
+	self->ApplySpell(spell_id, duration, ApplySpellType::Raid);
+}
+
+void Perl_Client_ApplySpellRaid(Client* self, int spell_id, int duration, bool allow_pets)
+{
+	self->ApplySpell(spell_id, duration, ApplySpellType::Raid, allow_pets);
+}
+
+void Perl_Client_ApplySpellRaid(Client* self, int spell_id, int duration, bool allow_pets, bool is_raid_group_only)
+{
+	self->ApplySpell(spell_id, duration, ApplySpellType::Raid, allow_pets, is_raid_group_only);
+}
+
+#ifdef BOTS
+void Perl_Client_ApplySpellRaid(Client* self, int spell_id, int duration, bool allow_pets, bool is_raid_group_only, bool allow_bots)
+{
+	self->ApplySpell(spell_id, duration, ApplySpellType::Raid, allow_pets, is_raid_group_only, allow_bots);
+}
+#endif
+
+void Perl_Client_SetSpellDuration(Client* self, int spell_id)
+{
+	self->SetSpellDuration(spell_id);
+}
+
+void Perl_Client_SetSpellDuration(Client* self, int spell_id, int duration)
+{
+	self->SetSpellDuration(spell_id, duration);
+}
+
+void Perl_Client_SetSpellDuration(Client* self, int spell_id, int duration, bool allow_pets)
+{
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Solo, allow_pets);
+}
+
+void Perl_Client_SetSpellDuration(Client* self, int spell_id, int duration, bool allow_pets, bool is_raid_group_only)
+{
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Solo, allow_pets, is_raid_group_only);
+}
+
+#ifdef BOTS
+void Perl_Client_SetSpellDuration(Client* self, int spell_id, int duration, bool allow_pets, bool is_raid_group_only, bool allow_bots)
+{
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Solo, allow_pets, is_raid_group_only, allow_bots);
+}
+#endif
+
+void Perl_Client_SetSpellDurationGroup(Client* self, int spell_id)
+{
+	self->SetSpellDuration(spell_id, 0, ApplySpellType::Group);
+}
+
+void Perl_Client_SetSpellDurationGroup(Client* self, int spell_id, int duration)
+{
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Group);
+}
+
+void Perl_Client_SetSpellDurationGroup(Client* self, int spell_id, int duration, bool allow_pets)
+{
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Group, allow_pets);
+}
+
+void Perl_Client_SetSpellDurationGroup(Client* self, int spell_id, int duration, bool allow_pets, bool is_raid_group_only)
+{
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Group, allow_pets, is_raid_group_only);
+}
+
+#ifdef BOTS
+void Perl_Client_SetSpellDurationGroup(Client* self, int spell_id, int duration, bool allow_pets, bool is_raid_group_only, bool allow_bots)
+{
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Group, allow_pets, is_raid_group_only, allow_bots);
+}
+#endif
+
+void Perl_Client_SetSpellDurationRaid(Client* self, int spell_id)
+{
+	self->ApplySpell(spell_id, 0, ApplySpellType::Raid);
+}
+
+void Perl_Client_SetSpellDurationRaid(Client* self, int spell_id, int duration)
+{
+	self->ApplySpell(spell_id, duration, ApplySpellType::Raid);
+}
+
+void Perl_Client_SetSpellDurationRaid(Client* self, int spell_id, int duration, bool allow_pets)
+{
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Raid, allow_pets);
+}
+
+void Perl_Client_SetSpellDurationRaid(Client* self, int spell_id, int duration, bool allow_pets, bool is_raid_group_only)
+{
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Raid, allow_pets, is_raid_group_only);
+}
+
+#ifdef BOTS
+void Perl_Client_SetSpellDurationRaid(Client* self, int spell_id, int duration, bool allow_pets, bool is_raid_group_only, bool allow_bots)
+{
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Raid, allow_pets, is_raid_group_only, allow_bots);
+}
+#endif
+
 #ifdef BOTS
 
 int Perl_Client_GetBotRequiredLevel(Client* self)
@@ -2602,6 +2764,15 @@ void perl_register_client()
 	package.add("AddPVPPoints", &Perl_Client_AddPVPPoints);
 	package.add("AddSkill", &Perl_Client_AddSkill);
 	package.add("Admin", &Perl_Client_Admin);
+	package.add("ApplySpell", (void(*)(Client*, int))&Perl_Client_ApplySpell);
+	package.add("ApplySpell", (void(*)(Client*, int, int))&Perl_Client_ApplySpell);
+	package.add("ApplySpell", (void(*)(Client*, int, int, bool))&Perl_Client_ApplySpell);
+	package.add("ApplySpellGroup", (void(*)(Client*, int))&Perl_Client_ApplySpellGroup);
+	package.add("ApplySpellGroup", (void(*)(Client*, int, int))&Perl_Client_ApplySpellGroup);
+	package.add("ApplySpellGroup", (void(*)(Client*, int, int, bool))&Perl_Client_ApplySpellGroup);
+	package.add("ApplySpellRaid", (void(*)(Client*, int))&Perl_Client_ApplySpellRaid);
+	package.add("ApplySpellRaid", (void(*)(Client*, int, int))&Perl_Client_ApplySpellRaid);
+	package.add("ApplySpellRaid", (void(*)(Client*, int, int, bool))&Perl_Client_ApplySpellRaid);
 	package.add("AssignTask", (void(*)(Client*, int))&Perl_Client_AssignTask);
 	package.add("AssignTask", (void(*)(Client*, int, int))&Perl_Client_AssignTask);
 	package.add("AssignTask", (void(*)(Client*, int, int, bool))&Perl_Client_AssignTask);
@@ -2984,6 +3155,27 @@ void perl_register_client()
 	package.add("SetSecondaryWeaponOrnamentation", &Perl_Client_SetSecondaryWeaponOrnamentation);
 	package.add("SetSkill", &Perl_Client_SetSkill);
 	package.add("SetSkillPoints", &Perl_Client_SetSkillPoints);
+	package.add("SetSpellDuration", (void(*)(Client*, int))&Perl_Client_SetSpellDuration);
+	package.add("SetSpellDuration", (void(*)(Client*, int, int))&Perl_Client_SetSpellDuration);
+	package.add("SetSpellDuration", (void(*)(Client*, int, int, bool))&Perl_Client_SetSpellDuration);
+	package.add("SetSpellDuration", (void(*)(Client*, int, int, bool, bool))&Perl_Client_SetSpellDuration);
+#ifdef BOTS
+	package.add("SetSpellDuration", (void(*)(Client*, int, int, bool, bool, bool))&Perl_Client_SetSpellDuration);
+#endif
+	package.add("SetSpellDurationGroup", (void(*)(Client*, int))&Perl_Client_SetSpellDurationGroup);
+	package.add("SetSpellDurationGroup", (void(*)(Client*, int, int))&Perl_Client_SetSpellDurationGroup);
+	package.add("SetSpellDurationGroup", (void(*)(Client*, int, int, bool))&Perl_Client_SetSpellDurationGroup);
+	package.add("SetSpellDurationGroup", (void(*)(Client*, int, int, bool, bool))&Perl_Client_SetSpellDurationGroup);
+#ifdef BOTS
+	package.add("SetSpellDurationGroup", (void(*)(Client*, int, int, bool, bool, bool))&Perl_Client_SetSpellDurationGroup);
+#endif
+	package.add("SetSpellDurationRaid", (void(*)(Client*, int))&Perl_Client_SetSpellDurationRaid);
+	package.add("SetSpellDurationRaid", (void(*)(Client*, int, int))&Perl_Client_SetSpellDurationRaid);
+	package.add("SetSpellDurationRaid", (void(*)(Client*, int, int, bool))&Perl_Client_SetSpellDurationRaid);
+	package.add("SetSpellDurationRaid", (void(*)(Client*, int, int, bool, bool))&Perl_Client_SetSpellDurationRaid);
+#ifdef BOTS
+	package.add("SetSpellDurationRaid", (void(*)(Client*, int, int, bool, bool, bool))&Perl_Client_SetSpellDurationRaid);
+#endif
 	package.add("SetStartZone", (void(*)(Client*, uint32))&Perl_Client_SetStartZone);
 	package.add("SetStartZone", (void(*)(Client*, uint32, float, float, float))&Perl_Client_SetStartZone);
 	package.add("SetStartZone", (void(*)(Client*, uint32, float, float, float, float))&Perl_Client_SetStartZone);

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -2346,7 +2346,7 @@ perl::array Perl_Mob_GetHateListByDistance(Mob* self, uint32 distance) // @categ
 {
 	perl::array result;
 
-	auto h_list = self->GetFilteredHateList(distance, EntityFilterTypes::All);
+	auto h_list = self->GetFilteredHateList(EntityFilterType::All, distance);
 	for (auto h : h_list) {
 		result.push_back(h);
 	}
@@ -2491,57 +2491,57 @@ void Perl_Mob_DamageArea(Mob* self, int64 damage) // @categories Hate and Aggro
 
 void Perl_Mob_DamageArea(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
 {
-	self->DamageArea(damage, distance, EntityFilterTypes::All);
+	self->DamageArea(damage, distance, EntityFilterType::All);
 }
 
 void Perl_Mob_DamageAreaPercentage(Mob* self, int64 damage) // @categories Hate and Aggro
 {
-	self->DamageArea(damage, 0, EntityFilterTypes::All, true);
+	self->DamageArea(damage, 0, EntityFilterType::All, true);
 }
 
 void Perl_Mob_DamageAreaPercentage(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
 {
-	self->DamageArea(damage, distance, EntityFilterTypes::All, true);
+	self->DamageArea(damage, distance, EntityFilterType::All, true);
 }
 
 void Perl_Mob_DamageAreaClients(Mob* self, int64 damage) // @categories Hate and Aggro
 {
-	self->DamageArea(damage, 0, EntityFilterTypes::Clients);
+	self->DamageArea(damage, 0, EntityFilterType::Clients);
 }
 
 void Perl_Mob_DamageAreaClients(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
 {
-	self->DamageArea(damage, distance, EntityFilterTypes::Clients);
+	self->DamageArea(damage, distance, EntityFilterType::Clients);
 }
 
 void Perl_Mob_DamageAreaClientsPercentage(Mob* self, int64 damage) // @categories Hate and Aggro
 {
-	self->DamageArea(damage, 0, EntityFilterTypes::Clients, true);
+	self->DamageArea(damage, 0, EntityFilterType::Clients, true);
 }
 
 void Perl_Mob_DamageAreaClientsPercentage(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
 {
-	self->DamageArea(damage, distance, EntityFilterTypes::Clients, true);
+	self->DamageArea(damage, distance, EntityFilterType::Clients, true);
 }
 
 void Perl_Mob_DamageAreaNPCs(Mob* self, int64 damage) // @categories Hate and Aggro
 {
-	self->DamageArea(damage, 0, EntityFilterTypes::NPCs);
+	self->DamageArea(damage, 0, EntityFilterType::NPCs);
 }
 
 void Perl_Mob_DamageAreaNPCs(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
 {
-	self->DamageArea(damage, distance, EntityFilterTypes::NPCs);
+	self->DamageArea(damage, distance, EntityFilterType::NPCs);
 }
 
 void Perl_Mob_DamageAreaNPCsPercentage(Mob* self, int64 damage) // @categories Hate and Aggro
 {
-	self->DamageArea(damage, 0, EntityFilterTypes::NPCs, true);
+	self->DamageArea(damage, 0, EntityFilterType::NPCs, true);
 }
 
 void Perl_Mob_DamageAreaNPCsPercentage(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
 {
-	self->DamageArea(damage, distance, EntityFilterTypes::NPCs, true);
+	self->DamageArea(damage, distance, EntityFilterType::NPCs, true);
 }
 
 void Perl_Mob_DamageHateList(Mob* self, int64 damage) // @categories Hate and Aggro
@@ -2551,64 +2551,64 @@ void Perl_Mob_DamageHateList(Mob* self, int64 damage) // @categories Hate and Ag
 
 void Perl_Mob_DamageHateList(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, distance, EntityFilterTypes::All);
+	self->DamageHateList(damage, distance, EntityFilterType::All);
 }
 
 void Perl_Mob_DamageHateListPercentage(Mob* self, int64 damage) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, 0, EntityFilterTypes::All, true);
+	self->DamageHateList(damage, 0, EntityFilterType::All, true);
 }
 
 void Perl_Mob_DamageHateListPercentage(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, distance, EntityFilterTypes::All, true);
+	self->DamageHateList(damage, distance, EntityFilterType::All, true);
 }
 
 void Perl_Mob_DamageHateListClients(Mob* self, int64 damage) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, 0, EntityFilterTypes::Clients);
+	self->DamageHateList(damage, 0, EntityFilterType::Clients);
 }
 
 void Perl_Mob_DamageHateListClients(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, distance, EntityFilterTypes::Clients);
+	self->DamageHateList(damage, distance, EntityFilterType::Clients);
 }
 
 void Perl_Mob_DamageHateListClientsPercentage(Mob* self, int64 damage) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, 0, EntityFilterTypes::Clients, true);
+	self->DamageHateList(damage, 0, EntityFilterType::Clients, true);
 }
 
 void Perl_Mob_DamageHateListClientsPercentage(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, distance, EntityFilterTypes::Clients, true);
+	self->DamageHateList(damage, distance, EntityFilterType::Clients, true);
 }
 
 void Perl_Mob_DamageHateListNPCs(Mob* self, int64 damage) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, 0, EntityFilterTypes::NPCs);
+	self->DamageHateList(damage, 0, EntityFilterType::NPCs);
 }
 
 void Perl_Mob_DamageHateListNPCs(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, distance, EntityFilterTypes::NPCs);
+	self->DamageHateList(damage, distance, EntityFilterType::NPCs);
 }
 
 void Perl_Mob_DamageHateListNPCsPercentage(Mob* self, int64 damage) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, 0, EntityFilterTypes::NPCs, true);
+	self->DamageHateList(damage, 0, EntityFilterType::NPCs, true);
 }
 
 void Perl_Mob_DamageHateListNPCsPercentage(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, distance, EntityFilterTypes::NPCs, true);
+	self->DamageHateList(damage, distance, EntityFilterType::NPCs, true);
 }
 
 perl::array Perl_Mob_GetHateListClients(Mob* self)
 {
 	perl::array result;
 
-	auto h_list = self->GetFilteredHateList(EntityFilterTypes::Clients);
+	auto h_list = self->GetFilteredHateList(EntityFilterType::Clients);
 	for (auto h : h_list) {
 		result.push_back(h);
 	}
@@ -2620,7 +2620,7 @@ perl::array Perl_Mob_GetHateListClients(Mob* self, uint32 distance)
 {
 	perl::array result;
 
-	auto h_list = self->GetFilteredHateList(distance, EntityFilterTypes::Clients);
+	auto h_list = self->GetFilteredHateList(EntityFilterType::Clients, distance);
 	for (auto h : h_list) {
 		result.push_back(h);
 	}
@@ -2632,7 +2632,7 @@ perl::array Perl_Mob_GetHateListNPCs(Mob* self)
 {
 	perl::array result;
 
-	auto h_list = self->GetFilteredHateList(EntityFilterTypes::NPCs);
+	auto h_list = self->GetFilteredHateList(EntityFilterType::NPCs);
 	for (auto h : h_list) {
 		result.push_back(h);
 	}
@@ -2644,7 +2644,7 @@ perl::array Perl_Mob_GetHateListNPCs(Mob* self, uint32 distance)
 {
 	perl::array result;
 
-	auto h_list = self->GetFilteredHateList(distance, EntityFilterTypes::NPCs);
+	auto h_list = self->GetFilteredHateList(EntityFilterType::NPCs, distance);
 	for (auto h : h_list) {
 		result.push_back(h);
 	}
@@ -2655,49 +2655,49 @@ perl::array Perl_Mob_GetHateListNPCs(Mob* self, uint32 distance)
 #ifdef BOTS
 void Perl_Mob_DamageAreaBots(Mob* self, int64 damage) // @categories Hate and Aggro
 {
-	self->DamageArea(damage, 0, EntityFilterTypes::Bots);
+	self->DamageArea(damage, 0, EntityFilterType::Bots);
 }
 
 void Perl_Mob_DamageAreaBots(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
 {
-	self->DamageArea(damage, distance, EntityFilterTypes::Bots);
+	self->DamageArea(damage, distance, EntityFilterType::Bots);
 }
 
 void Perl_Mob_DamageAreaBotsPercentage(Mob* self, int64 damage) // @categories Hate and Aggro
 {
-	self->DamageArea(damage, 0, EntityFilterTypes::Bots, true);
+	self->DamageArea(damage, 0, EntityFilterType::Bots, true);
 }
 
 void Perl_Mob_DamageAreaBotsPercentage(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
 {
-	self->DamageArea(damage, distance, EntityFilterTypes::Bots, true);
+	self->DamageArea(damage, distance, EntityFilterType::Bots, true);
 }
 
 void Perl_Mob_DamageHateListBots(Mob* self, int64 damage) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, 0, EntityFilterTypes::Bots);
+	self->DamageHateList(damage, 0, EntityFilterType::Bots);
 }
 
 void Perl_Mob_DamageHateListBots(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, distance, EntityFilterTypes::Bots);
+	self->DamageHateList(damage, distance, EntityFilterType::Bots);
 }
 
 void Perl_Mob_DamageHateListBotsPercentage(Mob* self, int64 damage) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, 0, EntityFilterTypes::Bots, true);
+	self->DamageHateList(damage, 0, EntityFilterType::Bots, true);
 }
 
 void Perl_Mob_DamageHateListBotsPercentage(Mob* self, int64 damage, uint32 distance) // @categories Hate and Aggro
 {
-	self->DamageHateList(damage, distance, EntityFilterTypes::Bots, true);
+	self->DamageHateList(damage, distance, EntityFilterType::Bots, true);
 }
 
 perl::array Perl_Mob_GetHateListBots(Mob* self)
 {
 	perl::array result;
 
-	auto h_list = self->GetFilteredHateList(EntityFilterTypes::Bots);
+	auto h_list = self->GetFilteredHateList(EntityFilterType::Bots);
 	for (auto h : h_list) {
 		result.push_back(h);
 	}
@@ -2709,7 +2709,7 @@ perl::array Perl_Mob_GetHateListBots(Mob* self, uint32 distance)
 {
 	perl::array result;
 
-	auto h_list = self->GetFilteredHateList(distance, EntityFilterTypes::Bots);
+	auto h_list = self->GetFilteredHateList(EntityFilterType::Bots, distance);
 	for (auto h : h_list)
 	{
 		result.push_back(h);

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -46,7 +46,7 @@ extern WorldServer worldserver;
 
 // the spell can still fail here, if the buff can't stack
 // in this case false will be returned, true otherwise
-bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_override, int reflect_effectiveness, int32 duration_override, bool disable_buff_overrwrite)
+bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_override, int reflect_effectiveness, int32 duration_override, bool disable_buff_overwrite)
 {
 	int caster_level, buffslot, effect, effect_value, i;
 	EQ::ItemInstance *SummonedItem=nullptr;
@@ -119,7 +119,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 			}
 			else
 			{
-				buffslot = AddBuff(caster, spell_id, duration_override, -1, disable_buff_overrwrite);
+				buffslot = AddBuff(caster, spell_id, duration_override, -1, disable_buff_overwrite);
 			}
 			if(buffslot == -1)	// stacking failure
 				return false;
@@ -186,7 +186,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 			return true;
 		}
 #endif
-	}	
+	}
 
 	if(IsVirusSpell(spell_id)) {
 
@@ -8091,7 +8091,7 @@ bool Mob::PassCastRestriction(int value)
 			}
 			else if (!IsNonSpellFighterClass(GetClass()) && GetManaRatio() <= 10) {
 				return true;
-			} 
+			}
 			else if (IsHybridClass(GetClass()) && CastToClient()->GetEndurancePercent() <= 10) {
 				return true;
 			}
@@ -10292,7 +10292,7 @@ bool Mob::HasPersistDeathIllusion(int32 spell_id) {
 	return false;
 }
 
-void Mob::SetBuffDuration(int32 spell_id, int32 duration) {
+void Mob::SetBuffDuration(int spell_id, int duration) {
 
 	/*
 		Will refresh the buff with specified spell_id to the specified duration
@@ -10331,7 +10331,7 @@ void Mob::SetBuffDuration(int32 spell_id, int32 duration) {
 	}
 }
 
-void Mob::ApplySpellBuff(int32 spell_id, int32 duration)
+void Mob::ApplySpellBuff(int spell_id, int duration)
 {
 	/*
 		Used for quest command to apply a new buff with custom duration.
@@ -10340,11 +10340,12 @@ void Mob::ApplySpellBuff(int32 spell_id, int32 duration)
 	if (!IsValidSpell(spell_id)) {
 		return;
 	}
+
 	if (!spells[spell_id].buff_duration) {
 		return;
 	}
 
-	if (duration < -1) {
+	if (duration <= -1) {
 		duration = PERMANENT_BUFF_DURATION;
 	}
 


### PR DESCRIPTION
# Perl
- Add `$client->ApplySpell(spell_id)`.
- Add `$client->ApplySpell(spell_id, duration)`.
- Add `$client->ApplySpell(spell_id, duration, allow_pets)`.
- Add `$client->ApplySpell(spell_id, duration, allow_pets, is_raid_group_only)`.
- Add `$client->ApplySpell(spell_id, duration, allow_pets, is_raid_group_only, allow_bots)`.
- Add `$client->ApplySpellGroup(spell_id)`.
- Add `$client->ApplySpellGroup(spell_id, duration)`.
- Add `$client->ApplySpellGroup(spell_id, duration, allow_pets)`.
- Add `$client->ApplySpellGroup(spell_id, duration, allow_pets, is_raid_group_only)`.
- Add `$client->ApplySpellGroup(spell_id, duration, allow_pets, is_raid_group_only, allow_bots)`.
- Add `$client->ApplySpellRaid(spell_id)`.
- Add `$client->ApplySpellRaid(spell_id, duration)`.
- Add `$client->ApplySpellRaid(spell_id, duration, allow_pets)`.
- Add `$client->ApplySpellRaid(spell_id, duration, allow_pets, is_raid_group_only)`.
- Add `$client->ApplySpellRaid(spell_id, duration, allow_pets, is_raid_group_only, allow_bots)`.
- Add `$client->SetSpellDuration(spell_id)`.
- Add `$client->SetSpellDuration(spell_id, duration)`.
- Add `$client->SetSpellDuration(spell_id, duration, allow_pets)`.
- Add `$client->SetSpellDuration(spell_id, duration, allow_pets, is_raid_group_only)`.
- Add `$client->SetSpellDuration(spell_id, duration, allow_pets, is_raid_group_only, allow_bots)`.
- Add `$client->SetSpellDurationGroup(spell_id)`.
- Add `$client->SetSpellDurationGroup(spell_id, duration)`.
- Add `$client->SetSpellDurationGroup(spell_id, duration, allow_pets)`.
- Add `$client->SetSpellDurationGroup(spell_id, duration, allow_pets, is_raid_group_only)`.
- Add `$client->SetSpellDurationGroup(spell_id, duration, allow_pets, is_raid_group_only, allow_bots)`.
- Add `$client->SetSpellDurationRaid(spell_id)`.
- Add `$client->SetSpellDurationRaid(spell_id, duration)`.
- Add `$client->SetSpellDurationRaid(spell_id, duration, allow_pets)`.
- Add `$client->SetSpellDurationRaid(spell_id, duration, allow_pets, is_raid_group_only)`.
- Add `$client->SetSpellDurationRaid(spell_id, duration, allow_pets, is_raid_group_only, allow_bots)`.

# Lua
- Add `client:ApplySpell(spell_id)`.
- Add `client:ApplySpell(spell_id, duration)`.
- Add `client:ApplySpell(spell_id, duration, allow_pets)`.
- Add `client:ApplySpell(spell_id, duration, allow_pets, is_raid_group_only)`.
- Add `client:ApplySpell(spell_id, duration, allow_pets, is_raid_group_only, allow_bots)`.
- Add `client:ApplySpellGroup(spell_id)`.
- Add `client:ApplySpellGroup(spell_id, duration)`.
- Add `client:ApplySpellGroup(spell_id, duration, allow_pets)`.
- Add `client:ApplySpellGroup(spell_id, duration, allow_pets, is_raid_group_only)`.
- Add `client:ApplySpellGroup(spell_id, duration, allow_pets, is_raid_group_only, allow_bots)`.
- Add `client:ApplySpellRaid(spell_id)`.
- Add `client:ApplySpellRaid(spell_id, duration)`.
- Add `client:ApplySpellRaid(spell_id, duration, allow_pets)`.
- Add `client:ApplySpellRaid(spell_id, duration, allow_pets, is_raid_group_only)`.
- Add `client:ApplySpellRaid(spell_id, duration, allow_pets, is_raid_group_only, allow_bots)`.
- Add `client:SetSpellDuration(spell_id)`.
- Add `client:SetSpellDuration(spell_id, duration)`.
- Add `client:SetSpellDuration(spell_id, duration, allow_pets)`.
- Add `client:SetSpellDuration(spell_id, duration, allow_pets, is_raid_group_only)`.
- Add `client:SetSpellDuration(spell_id, duration, allow_pets, is_raid_group_only, allow_bots)`.
- Add `client:SetSpellDurationGroup(spell_id)`.
- Add `client:SetSpellDurationGroup(spell_id, duration)`.
- Add `client:SetSpellDurationGroup(spell_id, duration, allow_pets)`.
- Add `client:SetSpellDurationGroup(spell_id, duration, allow_pets, is_raid_group_only)`.
- Add `client:SetSpellDurationGroup(spell_id, duration, allow_pets, is_raid_group_only, allow_bots)`.
- Add `client:SetSpellDurationRaid(spell_id)`.
- Add `client:SetSpellDurationRaid(spell_id, duration)`.
- Add `client:SetSpellDurationRaid(spell_id, duration, allow_pets)`.
- Add `client:SetSpellDurationRaid(spell_id, duration, allow_pets, is_raid_group_only)`.
- Add `client:SetSpellDurationRaid(spell_id, duration, allow_pets, is_raid_group_only, allow_bots)`.

# Notes
- Allows operators extremely easy shorthands to cast on entire groups and raid groups and optionally include their bots and pets.
- Default functionality for Raid is that it only casts on your group, set `is_raid_group_only` to `false` to cast on the entire Raid.