### PR TITLE
[Bots] Add Bot TRADE_EVENT & cleanup Bot Trades

### DIFF
--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -452,9 +452,9 @@ bool BotDatabase::LoadBot(const uint32 bot_id, Bot*& loaded_bot)
 		std::stoul(row[17]), // Beard Color
 		std::stoul(row[18]), // Drakkin Heritage
 		std::stoul(row[19]), // Drakkin Tattoo
-		std::stoul(row[19]), // Drakkin Details
-		std::stoi(row[20]), // Health
-		std::stoi(row[21]), // Mana
+		std::stoul(row[20]), // Drakkin Details
+		std::stoi(row[21]), // Health
+		std::stoi(row[22]), // Mana
 		d->MR,
 		d->CR,
 		d->DR,

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -1575,6 +1575,12 @@ void PerlembParser::ExportEventVariables(
 			perl->eval(std::string("++$").append(hashname).append("{$").append(package_name).append("::item2};").c_str());
 			perl->eval(std::string("++$").append(hashname).append("{$").append(package_name).append("::item3};").c_str());
 			perl->eval(std::string("++$").append(hashname).append("{$").append(package_name).append("::item4};").c_str());
+			if (npcmob->IsBot()) {
+				perl->eval(std::string("++$").append(hashname).append("{$").append(package_name).append("::item5};").c_str());
+				perl->eval(std::string("++$").append(hashname).append("{$").append(package_name).append("::item6};").c_str());
+				perl->eval(std::string("++$").append(hashname).append("{$").append(package_name).append("::item7};").c_str());
+				perl->eval(std::string("++$").append(hashname).append("{$").append(package_name).append("::item8};").c_str());
+			}
 			break;
 		}
 


### PR DESCRIPTION
Need to add support for returning stacks properly, and perform testing of different scenarios.
Need to test scripting of TRADE_EVENT/ITEM_EVENT