### PR TITLE
[Quest API] Add Hotzone Methods to Perl/Lua.

### DIFF
--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -3849,6 +3849,24 @@ void Perl__zonemarquee(uint32 type, uint32 priority, uint32 fade_in, uint32 fade
 	entity_list.Marquee(type, priority, fade_in, fade_out, duration, message);
 }
 
+bool Perl__ishotzone()
+{
+	if (!zone) {
+		return false;
+	}
+
+	return zone->IsHotzone();
+}
+
+void Perl__sethotzone(bool is_hotzone)
+{
+	if (!zone) {
+		return;
+	}
+
+	zone->SetIsHotzone(is_hotzone);
+}
+
 void perl_register_quest()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -4284,6 +4302,7 @@ void perl_register_quest()
 	package.add("incstat", &Perl__incstat);
 	package.add("isdisctome", &Perl__isdisctome);
 	package.add("isdooropen", &Perl__isdooropen);
+	package.add("ishotzone", &Perl__ishotzone);
 	package.add("isnpcspawned", &Perl__isnpcspawned);
 	package.add("istaskactive", &Perl__istaskactive);
 	package.add("istaskactivityactive", &Perl__istaskactivityactive);
@@ -4385,6 +4404,7 @@ void perl_register_quest()
 	package.add("setglobal", &Perl__setglobal);
 	package.add("setguild", &Perl__setguild);
 	package.add("sethp", &Perl__sethp);
+	package.add("sethotzone", &Perl__sethotzone);
 	package.add("setlanguage", &Perl__setlanguage);
 	package.add("setnexthpevent", &Perl__setnexthpevent);
 	package.add("setnextinchpevent", &Perl__setnextinchpevent);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -3561,6 +3561,24 @@ void lua_zone_marquee(uint32 type, uint32 priority, uint32 fade_in, uint32 fade_
 	entity_list.Marquee(type, priority, fade_in, fade_out, duration, message);
 }
 
+bool lua_is_hotzone()
+{
+	if (!zone) {
+		return false;
+	}
+
+	return zone->IsHotzone();
+}
+
+void lua_set_hotzone(bool is_hotzone)
+{
+	if (!zone) {
+		return;
+	}
+
+	zone->SetIsHotzone(is_hotzone);
+}
+
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
 	cur = table[#name]; \
 	if(luabind::type(cur) != LUA_TNIL) { \
@@ -4052,6 +4070,8 @@ luabind::scope lua_register_general() {
 		luabind::def("zone_marquee", (void(*)(uint32,std::string))&lua_zone_marquee),
 		luabind::def("zone_marquee", (void(*)(uint32,std::string,uint32))&lua_zone_marquee),
 		luabind::def("zone_marquee", (void(*)(uint32,uint32,uint32,uint32,uint32,std::string))&lua_zone_marquee),
+		luabind::def("is_hotzone", (bool(*)(void))&lua_is_hotzone),
+		luabind::def("set_hotzone", (void(*)(bool))&lua_set_hotzone),
 
 		/*
 			Cross Zone

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -204,17 +204,18 @@ void QuestManager::write(const char *file, const char *str) {
 	fclose (pFile);
 }
 
-Mob* QuestManager::spawn2(int npc_type, int grid, int unused, const glm::vec4& position) {
-	const NPCType* tmp = 0;
-	if (tmp = content_db.LoadNPCTypesData(npc_type))
-	{
-		auto npc = new NPC(tmp, nullptr, position, GravityBehavior::Water);
+Mob* QuestManager::spawn2(int npc_id, int grid, int unused, const glm::vec4& position) {
+	const NPCType* t = 0;
+	if (t = content_db.LoadNPCTypesData(npc_id)) {
+		auto npc = new NPC(t, nullptr, position, GravityBehavior::Water);
 		npc->AddLootTable();
-		if (npc->DropsGlobalLoot())
+		if (npc->DropsGlobalLoot()) {
 			npc->CheckGlobalLootTables();
-		entity_list.AddNPC(npc,true,true);
-		if(grid > 0)
-		{
+		}
+
+		entity_list.AddNPC(npc, true, true);
+
+		if (grid) {
 			npc->AssignWaypoints(grid);
 		}
 


### PR DESCRIPTION
# Perl
- Add `quest::ishotzone()`.
- Add `quest::sethotzone(is_hotzone)`.

# Lua
- Add `eq.is_hotzone()`.
- Add `eq.set_hotzone(is_hotzone)`.

# Notes
- Allows operators to toggle hotzone flags within a script dynamically, for stuff like making an instance a hotzone, but not necessarily all versions of the zone.