### PR TITLE
[Quest API] Add HasBotSpellEntry() to Perl/Lua.

### DIFF
--- a/zone/bot.h
+++ b/zone/bot.h
@@ -557,6 +557,9 @@ public:
 	inline InspectMessage_Struct& GetInspectMessage() { return _botInspectMessage; }
 	inline const InspectMessage_Struct& GetInspectMessage() const { return _botInspectMessage; }
 
+	// "Quest API" Methods 
+	bool CheckBotSpellEntries(int spellid);
+	
 	// "SET" Class Methods
 	void SetBotSpellID(uint32 newSpellID);
 	virtual void SetSpawnStatus(bool spawnStatus) { _spawnStatus = spawnStatus; }

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -558,7 +558,7 @@ public:
 	inline const InspectMessage_Struct& GetInspectMessage() const { return _botInspectMessage; }
 
 	// "Quest API" Methods 
-	bool CheckBotSpellEntries(int spellid);
+	bool HasBotSpellEntry(uint16 spellid);
 	
 	// "SET" Class Methods
 	void SetBotSpellID(uint32 newSpellID);

--- a/zone/botspellsai.cpp
+++ b/zone/botspellsai.cpp
@@ -3185,7 +3185,7 @@ void Bot::AI_Bot_Event_SpellCastFinished(bool iCastSucceeded, uint16 slot) {
 	}
 }
 
-bool Bot::CheckBotSpellEntries(int spellid) {
+bool Bot::HasBotSpellEntry(uint16 spellid) {
 	
 	auto* spell_list = content_db.GetBotSpells(GetBotSpellID());
 

--- a/zone/botspellsai.cpp
+++ b/zone/botspellsai.cpp
@@ -3185,4 +3185,49 @@ void Bot::AI_Bot_Event_SpellCastFinished(bool iCastSucceeded, uint16 slot) {
 	}
 }
 
+bool Bot::CheckBotSpellEntries(int spellid) {
+	
+	auto* spell_list = content_db.GetBotSpells(GetBotSpellID());
+
+	if (!spell_list) {
+		return false;
+	}
+
+	auto debug_msg = fmt::format(
+		"Loading BotSpells onto {}: dbspellsid={}, level={}",
+		GetName(),
+		GetBotSpellID(),
+		GetLevel()
+	);
+
+	if (spell_list) {
+		debug_msg.append(
+			fmt::format(
+				" (found, {})",
+				spell_list->entries.size()
+			)
+		);
+	}
+	else {
+		debug_msg.append(" (not found)");
+	}
+
+	if (spell_list) {
+		for (const auto& iter : spell_list->entries) {
+			LogAIDetail("([{}]) [{}]", iter.spellid, spells[iter.spellid].name);
+		}
+	}
+
+	LogAIModerate("fin (spell list)");
+
+	// Check if Spell ID is found in Bot Spell Entries
+	for (auto& e : spell_list->entries) {
+		if (spellid == e.spellid) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 #endif

--- a/zone/botspellsai.cpp
+++ b/zone/botspellsai.cpp
@@ -3193,33 +3193,6 @@ bool Bot::HasBotSpellEntry(uint16 spellid) {
 		return false;
 	}
 
-	auto debug_msg = fmt::format(
-		"Loading BotSpells onto {}: dbspellsid={}, level={}",
-		GetName(),
-		GetBotSpellID(),
-		GetLevel()
-	);
-
-	if (spell_list) {
-		debug_msg.append(
-			fmt::format(
-				" (found, {})",
-				spell_list->entries.size()
-			)
-		);
-	}
-	else {
-		debug_msg.append(" (not found)");
-	}
-
-	if (spell_list) {
-		for (const auto& iter : spell_list->entries) {
-			LogAIDetail("([{}]) [{}]", iter.spellid, spells[iter.spellid].name);
-		}
-	}
-
-	LogAIModerate("fin (spell list)");
-
 	// Check if Spell ID is found in Bot Spell Entries
 	for (auto& e : spell_list->entries) {
 		if (spellid == e.spellid) {

--- a/zone/lua_bot.cpp
+++ b/zone/lua_bot.cpp
@@ -132,12 +132,12 @@ luabind::scope lua_register_bot() {
 	.def("GetExpansionBitmask", (int(Lua_Bot::*)(void)) & Lua_Bot::GetExpansionBitmask)
 	.def("GetOwner", (Lua_Mob(Lua_Bot::*)(void)) & Lua_Bot::GetOwner)
 	.def("HasBotItem", (bool(Lua_Bot::*)(uint32)) & Lua_Bot::HasBotItem)
+	.def("HasBotSpellEntry", (bool(Lua_Bot::*)(uint16)) & Lua_Bot::HasBotSpellEntry)
 	.def("OwnerMessage", (void(Lua_Bot::*)(std::string)) & Lua_Bot::OwnerMessage)
 	.def("RemoveBotItem", (void(Lua_Bot::*)(uint32)) & Lua_Bot::RemoveBotItem)
 	.def("SetExpansionBitmask", (void(Lua_Bot::*)(int)) & Lua_Bot::SetExpansionBitmask)
 	.def("SetExpansionBitmask", (void(Lua_Bot::*)(int, bool)) & Lua_Bot::SetExpansionBitmask)
-	.def("SignalBot", (void(Lua_Bot::*)(int)) & Lua_Bot::SignalBot)
-	.def("HasBotSpellEntry", (bool(Lua_Bot::*)(uint16)) & Lua_Bot::HasBotSpellEntry);
+	.def("SignalBot", (void(Lua_Bot::*)(int)) & Lua_Bot::SignalBot);
 }
 
 #endif

--- a/zone/lua_bot.cpp
+++ b/zone/lua_bot.cpp
@@ -109,35 +109,35 @@ void Lua_Bot::SetExpansionBitmask(int expansion_bitmask, bool save) {
 	self->SetExpansionBitmask(expansion_bitmask, save);
 }
 
-bool Lua_Bot::CheckBotSpellEntries(int spellid) {
+bool Lua_Bot::HasBotSpellEntry(uint16 spellid) {
 	Lua_Safe_Call_Bool();
-	return self->CheckBotSpellEntries(spellid);
+	return self->HasBotSpellEntry(spellid);
 }
 
 luabind::scope lua_register_bot() {
 	return luabind::class_<Lua_Bot, Lua_Mob>("Bot")
-		.def(luabind::constructor<>())
-		.def("AddBotItem", (void(Lua_Bot::*)(uint16, uint32)) & Lua_Bot::AddBotItem)
-		.def("AddBotItem", (void(Lua_Bot::*)(uint16, uint32, int16)) & Lua_Bot::AddBotItem)
-		.def("AddBotItem", (void(Lua_Bot::*)(uint16, uint32, int16, bool)) & Lua_Bot::AddBotItem)
-		.def("AddBotItem", (void(Lua_Bot::*)(uint16, uint32, int16, bool, uint32)) & Lua_Bot::AddBotItem)
-		.def("AddBotItem", (void(Lua_Bot::*)(uint16, uint32, int16, bool, uint32, uint32)) & Lua_Bot::AddBotItem)
-		.def("AddBotItem", (void(Lua_Bot::*)(uint16, uint32, int16, bool, uint32, uint32, uint32)) & Lua_Bot::AddBotItem)
-		.def("AddBotItem", (void(Lua_Bot::*)(uint16, uint32, int16, bool, uint32, uint32, uint32, uint32)) & Lua_Bot::AddBotItem)
-		.def("AddBotItem", (void(Lua_Bot::*)(uint16, uint32, int16, bool, uint32, uint32, uint32, uint32, uint32)) & Lua_Bot::AddBotItem)
-		.def("AddBotItem", (void(Lua_Bot::*)(uint16, uint32, int16, bool, uint32, uint32, uint32, uint32, uint32, uint32)) & Lua_Bot::AddBotItem)
-		.def("CountBotItem", (uint32(Lua_Bot::*)(uint32)) & Lua_Bot::CountBotItem)
-		.def("GetBotItem", (Lua_ItemInst(Lua_Bot::*)(uint16)) & Lua_Bot::GetBotItem)
-		.def("GetBotItemIDBySlot", (uint32(Lua_Bot::*)(uint16)) & Lua_Bot::GetBotItemIDBySlot)
-		.def("GetExpansionBitmask", (int(Lua_Bot::*)(void)) & Lua_Bot::GetExpansionBitmask)
-		.def("GetOwner", (Lua_Mob(Lua_Bot::*)(void)) & Lua_Bot::GetOwner)
-		.def("HasBotItem", (bool(Lua_Bot::*)(uint32)) & Lua_Bot::HasBotItem)
-		.def("OwnerMessage", (void(Lua_Bot::*)(std::string)) & Lua_Bot::OwnerMessage)
-		.def("RemoveBotItem", (void(Lua_Bot::*)(uint32)) & Lua_Bot::RemoveBotItem)
-		.def("SetExpansionBitmask", (void(Lua_Bot::*)(int)) & Lua_Bot::SetExpansionBitmask)
-		.def("SetExpansionBitmask", (void(Lua_Bot::*)(int, bool)) & Lua_Bot::SetExpansionBitmask)
-		.def("SignalBot", (void(Lua_Bot::*)(int)) & Lua_Bot::SignalBot)
-		.def("CheckBotSpellEntries", (bool(Lua_Bot::*)(int)) & Lua_Bot::CheckBotSpellEntries);
+	.def(luabind::constructor<>())
+	.def("AddBotItem", (void(Lua_Bot::*)(uint16, uint32)) & Lua_Bot::AddBotItem)
+	.def("AddBotItem", (void(Lua_Bot::*)(uint16, uint32, int16)) & Lua_Bot::AddBotItem)
+	.def("AddBotItem", (void(Lua_Bot::*)(uint16, uint32, int16, bool)) & Lua_Bot::AddBotItem)
+	.def("AddBotItem", (void(Lua_Bot::*)(uint16, uint32, int16, bool, uint32)) & Lua_Bot::AddBotItem)
+	.def("AddBotItem", (void(Lua_Bot::*)(uint16, uint32, int16, bool, uint32, uint32)) & Lua_Bot::AddBotItem)
+	.def("AddBotItem", (void(Lua_Bot::*)(uint16, uint32, int16, bool, uint32, uint32, uint32)) & Lua_Bot::AddBotItem)
+	.def("AddBotItem", (void(Lua_Bot::*)(uint16, uint32, int16, bool, uint32, uint32, uint32, uint32)) & Lua_Bot::AddBotItem)
+	.def("AddBotItem", (void(Lua_Bot::*)(uint16, uint32, int16, bool, uint32, uint32, uint32, uint32, uint32)) & Lua_Bot::AddBotItem)
+	.def("AddBotItem", (void(Lua_Bot::*)(uint16, uint32, int16, bool, uint32, uint32, uint32, uint32, uint32, uint32)) & Lua_Bot::AddBotItem)
+	.def("CountBotItem", (uint32(Lua_Bot::*)(uint32)) & Lua_Bot::CountBotItem)
+	.def("GetBotItem", (Lua_ItemInst(Lua_Bot::*)(uint16)) & Lua_Bot::GetBotItem)
+	.def("GetBotItemIDBySlot", (uint32(Lua_Bot::*)(uint16)) & Lua_Bot::GetBotItemIDBySlot)
+	.def("GetExpansionBitmask", (int(Lua_Bot::*)(void)) & Lua_Bot::GetExpansionBitmask)
+	.def("GetOwner", (Lua_Mob(Lua_Bot::*)(void)) & Lua_Bot::GetOwner)
+	.def("HasBotItem", (bool(Lua_Bot::*)(uint32)) & Lua_Bot::HasBotItem)
+	.def("OwnerMessage", (void(Lua_Bot::*)(std::string)) & Lua_Bot::OwnerMessage)
+	.def("RemoveBotItem", (void(Lua_Bot::*)(uint32)) & Lua_Bot::RemoveBotItem)
+	.def("SetExpansionBitmask", (void(Lua_Bot::*)(int)) & Lua_Bot::SetExpansionBitmask)
+	.def("SetExpansionBitmask", (void(Lua_Bot::*)(int, bool)) & Lua_Bot::SetExpansionBitmask)
+	.def("SignalBot", (void(Lua_Bot::*)(int)) & Lua_Bot::SignalBot)
+	.def("HasBotSpellEntry", (bool(Lua_Bot::*)(uint16)) & Lua_Bot::HasBotSpellEntry);
 }
 
 #endif

--- a/zone/lua_bot.cpp
+++ b/zone/lua_bot.cpp
@@ -109,34 +109,35 @@ void Lua_Bot::SetExpansionBitmask(int expansion_bitmask, bool save) {
 	self->SetExpansionBitmask(expansion_bitmask, save);
 }
 
-bool Lua_Bot::IsSpellInBotSpellEntries(int spellid) {
+bool Lua_Bot::CheckBotSpellEntries(int spellid) {
 	Lua_Safe_Call_Bool();
 	return self->CheckBotSpellEntries(spellid);
 }
 
 luabind::scope lua_register_bot() {
 	return luabind::class_<Lua_Bot, Lua_Mob>("Bot")
-	.def(luabind::constructor<>())
-	.def("AddBotItem", (void(Lua_Bot::*)(uint16,uint32))&Lua_Bot::AddBotItem)
-	.def("AddBotItem", (void(Lua_Bot::*)(uint16,uint32,int16))&Lua_Bot::AddBotItem)
-	.def("AddBotItem", (void(Lua_Bot::*)(uint16,uint32,int16,bool))&Lua_Bot::AddBotItem)
-	.def("AddBotItem", (void(Lua_Bot::*)(uint16,uint32,int16,bool,uint32))&Lua_Bot::AddBotItem)
-	.def("AddBotItem", (void(Lua_Bot::*)(uint16,uint32,int16,bool,uint32,uint32))&Lua_Bot::AddBotItem)
-	.def("AddBotItem", (void(Lua_Bot::*)(uint16,uint32,int16,bool,uint32,uint32,uint32))&Lua_Bot::AddBotItem)
-	.def("AddBotItem", (void(Lua_Bot::*)(uint16,uint32,int16,bool,uint32,uint32,uint32,uint32))&Lua_Bot::AddBotItem)
-	.def("AddBotItem", (void(Lua_Bot::*)(uint16,uint32,int16,bool,uint32,uint32,uint32,uint32,uint32))&Lua_Bot::AddBotItem)
-	.def("AddBotItem", (void(Lua_Bot::*)(uint16,uint32,int16,bool,uint32,uint32,uint32,uint32,uint32,uint32))&Lua_Bot::AddBotItem)
-	.def("CountBotItem", (uint32(Lua_Bot::*)(uint32))&Lua_Bot::CountBotItem)
-	.def("GetBotItem", (Lua_ItemInst(Lua_Bot::*)(uint16))&Lua_Bot::GetBotItem)
-	.def("GetBotItemIDBySlot", (uint32(Lua_Bot::*)(uint16))&Lua_Bot::GetBotItemIDBySlot)
-	.def("GetExpansionBitmask", (int(Lua_Bot::*)(void))&Lua_Bot::GetExpansionBitmask)
-	.def("GetOwner", (Lua_Mob(Lua_Bot::*)(void))&Lua_Bot::GetOwner)
-	.def("HasBotItem", (bool(Lua_Bot::*)(uint32))&Lua_Bot::HasBotItem)
-	.def("OwnerMessage", (void(Lua_Bot::*)(std::string))&Lua_Bot::OwnerMessage)
-	.def("RemoveBotItem", (void(Lua_Bot::*)(uint32))&Lua_Bot::RemoveBotItem)
-	.def("SetExpansionBitmask", (void(Lua_Bot::*)(int))&Lua_Bot::SetExpansionBitmask)
-	.def("SetExpansionBitmask", (void(Lua_Bot::*)(int,bool))&Lua_Bot::SetExpansionBitmask)
-	.def("SignalBot", (void(Lua_Bot::*)(int))&Lua_Bot::SignalBot);
+		.def(luabind::constructor<>())
+		.def("AddBotItem", (void(Lua_Bot::*)(uint16, uint32)) & Lua_Bot::AddBotItem)
+		.def("AddBotItem", (void(Lua_Bot::*)(uint16, uint32, int16)) & Lua_Bot::AddBotItem)
+		.def("AddBotItem", (void(Lua_Bot::*)(uint16, uint32, int16, bool)) & Lua_Bot::AddBotItem)
+		.def("AddBotItem", (void(Lua_Bot::*)(uint16, uint32, int16, bool, uint32)) & Lua_Bot::AddBotItem)
+		.def("AddBotItem", (void(Lua_Bot::*)(uint16, uint32, int16, bool, uint32, uint32)) & Lua_Bot::AddBotItem)
+		.def("AddBotItem", (void(Lua_Bot::*)(uint16, uint32, int16, bool, uint32, uint32, uint32)) & Lua_Bot::AddBotItem)
+		.def("AddBotItem", (void(Lua_Bot::*)(uint16, uint32, int16, bool, uint32, uint32, uint32, uint32)) & Lua_Bot::AddBotItem)
+		.def("AddBotItem", (void(Lua_Bot::*)(uint16, uint32, int16, bool, uint32, uint32, uint32, uint32, uint32)) & Lua_Bot::AddBotItem)
+		.def("AddBotItem", (void(Lua_Bot::*)(uint16, uint32, int16, bool, uint32, uint32, uint32, uint32, uint32, uint32)) & Lua_Bot::AddBotItem)
+		.def("CountBotItem", (uint32(Lua_Bot::*)(uint32)) & Lua_Bot::CountBotItem)
+		.def("GetBotItem", (Lua_ItemInst(Lua_Bot::*)(uint16)) & Lua_Bot::GetBotItem)
+		.def("GetBotItemIDBySlot", (uint32(Lua_Bot::*)(uint16)) & Lua_Bot::GetBotItemIDBySlot)
+		.def("GetExpansionBitmask", (int(Lua_Bot::*)(void)) & Lua_Bot::GetExpansionBitmask)
+		.def("GetOwner", (Lua_Mob(Lua_Bot::*)(void)) & Lua_Bot::GetOwner)
+		.def("HasBotItem", (bool(Lua_Bot::*)(uint32)) & Lua_Bot::HasBotItem)
+		.def("OwnerMessage", (void(Lua_Bot::*)(std::string)) & Lua_Bot::OwnerMessage)
+		.def("RemoveBotItem", (void(Lua_Bot::*)(uint32)) & Lua_Bot::RemoveBotItem)
+		.def("SetExpansionBitmask", (void(Lua_Bot::*)(int)) & Lua_Bot::SetExpansionBitmask)
+		.def("SetExpansionBitmask", (void(Lua_Bot::*)(int, bool)) & Lua_Bot::SetExpansionBitmask)
+		.def("SignalBot", (void(Lua_Bot::*)(int)) & Lua_Bot::SignalBot)
+		.def("CheckBotSpellEntries", (bool(Lua_Bot::*)(int)) & Lua_Bot::CheckBotSpellEntries);
 }
 
 #endif

--- a/zone/lua_bot.cpp
+++ b/zone/lua_bot.cpp
@@ -109,6 +109,11 @@ void Lua_Bot::SetExpansionBitmask(int expansion_bitmask, bool save) {
 	self->SetExpansionBitmask(expansion_bitmask, save);
 }
 
+bool Lua_Bot::IsSpellInBotSpellEntries(int spellid) {
+	Lua_Safe_Call_Bool();
+	return self->CheckBotSpellEntries(spellid);
+}
+
 luabind::scope lua_register_bot() {
 	return luabind::class_<Lua_Bot, Lua_Mob>("Bot")
 	.def(luabind::constructor<>())

--- a/zone/lua_bot.h
+++ b/zone/lua_bot.h
@@ -47,6 +47,7 @@ public:
 	void SetExpansionBitmask(int expansion_bitmask);
 	void SetExpansionBitmask(int expansion_bitmask, bool save);
 	void SignalBot(int signal_id);
+	bool IsSpellInBotSpellEntries(int spellid);
 };
 
 #endif

--- a/zone/lua_bot.h
+++ b/zone/lua_bot.h
@@ -47,7 +47,7 @@ public:
 	void SetExpansionBitmask(int expansion_bitmask);
 	void SetExpansionBitmask(int expansion_bitmask, bool save);
 	void SignalBot(int signal_id);
-	bool CheckBotSpellEntries(int spellid);
+	bool HasBotSpellEntry(uint16 spellid);
 };
 
 #endif

--- a/zone/lua_bot.h
+++ b/zone/lua_bot.h
@@ -47,7 +47,7 @@ public:
 	void SetExpansionBitmask(int expansion_bitmask);
 	void SetExpansionBitmask(int expansion_bitmask, bool save);
 	void SignalBot(int signal_id);
-	bool IsSpellInBotSpellEntries(int spellid);
+	bool CheckBotSpellEntries(int spellid);
 };
 
 #endif

--- a/zone/perl_bot.cpp
+++ b/zone/perl_bot.cpp
@@ -106,7 +106,7 @@ void Perl_Bot_SetExpansionBitmask(Bot* self, int expansion_bitmask, bool save)
 	self->SetExpansionBitmask(expansion_bitmask, save);
 }
 
-bool Perl_Bot_IsSpellInBotSpellEntries(Bot* self, int spellid)
+bool Perl_Bot_CheckBotSpellEntries(Bot* self, int spellid)
 {
 	return self->CheckBotSpellEntries(spellid);
 }
@@ -137,6 +137,7 @@ void perl_register_bot()
 	package.add("SetExpansionBitmask", (void(*)(Bot*, int))&Perl_Bot_SetExpansionBitmask);
 	package.add("SetExpansionBitmask", (void(*)(Bot*, int, bool))&Perl_Bot_SetExpansionBitmask);
 	package.add("SignalBot", &Perl_Bot_SignalBot);
+	package.add("CheckBotSpellEntries", &Perl_Bot_CheckBotSpellEntries);
 }
 
 #endif //EMBPERL_XS_CLASSES

--- a/zone/perl_bot.cpp
+++ b/zone/perl_bot.cpp
@@ -132,12 +132,12 @@ void perl_register_bot()
 	package.add("GetExpansionBitmask", &Perl_Bot_GetExpansionBitmask);
 	package.add("GetOwner", &Perl_Bot_GetOwner);
 	package.add("HasBotItem", &Perl_Bot_HasBotItem);
+	package.add("HasBotSpellEntry", &Perl_Bot_HasBotSpellEntry);
 	package.add("OwnerMessage", &Perl_Bot_OwnerMessage);
 	package.add("RemoveBotItem", &Perl_Bot_RemoveBotItem);
 	package.add("SetExpansionBitmask", (void(*)(Bot*, int))&Perl_Bot_SetExpansionBitmask);
 	package.add("SetExpansionBitmask", (void(*)(Bot*, int, bool))&Perl_Bot_SetExpansionBitmask);
 	package.add("SignalBot", &Perl_Bot_SignalBot);
-	package.add("HasBotSpellEntry", &Perl_Bot_HasBotSpellEntry);
 }
 
 #endif //EMBPERL_XS_CLASSES

--- a/zone/perl_bot.cpp
+++ b/zone/perl_bot.cpp
@@ -106,9 +106,9 @@ void Perl_Bot_SetExpansionBitmask(Bot* self, int expansion_bitmask, bool save)
 	self->SetExpansionBitmask(expansion_bitmask, save);
 }
 
-bool Perl_Bot_CheckBotSpellEntries(Bot* self, int spellid)
+bool Perl_Bot_HasBotSpellEntry(Bot* self, uint16 spellid)
 {
-	return self->CheckBotSpellEntries(spellid);
+	return self->HasBotSpellEntry(spellid);
 }
 
 void perl_register_bot()
@@ -137,7 +137,7 @@ void perl_register_bot()
 	package.add("SetExpansionBitmask", (void(*)(Bot*, int))&Perl_Bot_SetExpansionBitmask);
 	package.add("SetExpansionBitmask", (void(*)(Bot*, int, bool))&Perl_Bot_SetExpansionBitmask);
 	package.add("SignalBot", &Perl_Bot_SignalBot);
-	package.add("CheckBotSpellEntries", &Perl_Bot_CheckBotSpellEntries);
+	package.add("HasBotSpellEntry", &Perl_Bot_HasBotSpellEntry);
 }
 
 #endif //EMBPERL_XS_CLASSES

--- a/zone/perl_bot.cpp
+++ b/zone/perl_bot.cpp
@@ -106,6 +106,11 @@ void Perl_Bot_SetExpansionBitmask(Bot* self, int expansion_bitmask, bool save)
 	self->SetExpansionBitmask(expansion_bitmask, save);
 }
 
+bool Perl_Bot_IsSpellInBotSpellEntries(Bot* self, int spellid)
+{
+	return self->CheckBotSpellEntries(spellid);
+}
+
 void perl_register_bot()
 {
 	perl::interpreter state(PERL_GET_THX);


### PR DESCRIPTION
Add Perl & Lua method to validate if a Spell ID is in the Bot Spells Entries based on the Bot Class.

Perl: $bot->CheckBotSpellEntries;
Lua: bot:CheckBotSpellEntries;
