### PR TITLE
[Merchant] LDoNSellBackRate support for Merchant:EnableAltCurrencySell Rule

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -2695,7 +2695,8 @@ void Client::Handle_OP_AltCurrencySell(const EQApplicationPacket *app)
 				continue;
 
 			if (item->ID == inst->GetItem()->ID) {
-				cost = ml.alt_currency_cost;
+				// 06/11/2016 This formula matches RoF2 client side calculation.
+				cost = (ml.alt_currency_cost + 1) * item->LDoNSellBackRate / 100;
 				found = true;
 				break;
 			}
@@ -2799,7 +2800,8 @@ void Client::Handle_OP_AltCurrencySellSelection(const EQApplicationPacket *app)
 					continue;
 
 				if (item->ID == inst->GetItem()->ID) {
-					cost = ml.alt_currency_cost;
+					// 06/11/2016 This formula matches RoF2 client side calculation.
+					cost = (ml.alt_currency_cost + 1) * item->LDoNSellBackRate / 100;
 					found = true;
 					break;
 				}


### PR DESCRIPTION
Adds support for Merchants to buyback Alt Currency items at a percentage value using the item LDoNSellBackRate attribute.

Currently this was only being supported for Adventure Merchants.