### PR TITLE
[Quest API] Add Instance Methods to Perl/Lua.

### DIFF
--- a/common/database.h
+++ b/common/database.h
@@ -161,7 +161,6 @@ public:
 	std::vector<uint16> GetInstanceIDs(uint32 zone_id, uint32 character_id);
 	uint8_t GetInstanceVersion(uint16 instance_id);
 	uint32 GetTimeRemainingInstance(uint16 instance_id, bool &is_perma);
-	uint32 VersionFromInstanceID(uint16 instance_id);
 	uint32 GetInstanceZoneID(uint16 instance_id);
 
 	void AssignGroupToInstance(uint32 gid, uint32 instance_id);

--- a/common/database.h
+++ b/common/database.h
@@ -145,31 +145,31 @@ public:
 
 	/* Instancing */
 
-	bool AddClientToInstance(uint16 instance_id, uint32 char_id);
-	bool CharacterInInstanceGroup(uint16 instance_id, uint32 char_id);
+	bool AddClientToInstance(uint16 instance_id, uint32 character_id);
+	bool CheckInstanceByCharID(uint16 instance_id, uint32 character_id);
 	bool CheckInstanceExists(uint16 instance_id);
 	bool CheckInstanceExpired(uint16 instance_id);
 	bool CreateInstance(uint16 instance_id, uint32 zone_id, uint32 version, uint32 duration);
 	bool GetUnusedInstanceID(uint16 &instance_id);
-	bool GlobalInstance(uint16 instance_id);
+	bool IsGlobalInstance(uint16 instance_id);
 	bool RemoveClientFromInstance(uint16 instance_id, uint32 char_id);
 	bool RemoveClientsFromInstance(uint16 instance_id);
-	bool VerifyInstanceAlive(uint16 instance_id, uint32 char_id);
+	bool VerifyInstanceAlive(uint16 instance_id, uint32 character_id);
 	bool VerifyZoneInstance(uint32 zone_id, uint16 instance_id);
 
 	uint16 GetInstanceID(uint32 zone, uint32 charid, int16 version);
-	uint16 GetInstanceVersion(uint16 instance_id);
+	std::vector<uint16> GetInstanceIDs(uint32 zone_id, uint32 character_id);
+	uint8_t GetInstanceVersion(uint16 instance_id);
 	uint32 GetTimeRemainingInstance(uint16 instance_id, bool &is_perma);
 	uint32 VersionFromInstanceID(uint16 instance_id);
-	uint32 ZoneIDFromInstanceID(uint16 instance_id);
+	uint32 GetInstanceZoneID(uint16 instance_id);
 
 	void AssignGroupToInstance(uint32 gid, uint32 instance_id);
 	void AssignRaidToInstance(uint32 rid, uint32 instance_id);
-	void BuryCorpsesInInstance(uint16 instance_id);
 	void DeleteInstance(uint16 instance_id);
-	void FlagInstanceByGroupLeader(uint32 zone, int16 version, uint32 charid, uint32 gid);
-	void FlagInstanceByRaidLeader(uint32 zone, int16 version, uint32 charid, uint32 rid);
-	void GetCharactersInInstance(uint16 instance_id, std::list<uint32> &charid_list);
+	void FlagInstanceByGroupLeader(uint32 zone_id, int16 version, uint32 charid, uint32 group_id);
+	void FlagInstanceByRaidLeader(uint32 zone_id, int16 version, uint32 charid, uint32 raid_id);
+	void GetCharactersInInstance(uint16 instance_id, std::list<uint32> &character_ids);
 	void PurgeExpiredInstances();
 	void SetInstanceDuration(uint16 instance_id, uint32 new_duration);
 

--- a/common/database_instances.cpp
+++ b/common/database_instances.cpp
@@ -20,8 +20,16 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include "../common/rulesys.h"
 #include "../common/strings.h"
 #include "../common/timer.h"
+#include "../common/repositories/character_corpses_repository.h"
 #include "../common/repositories/dynamic_zone_members_repository.h"
 #include "../common/repositories/dynamic_zones_repository.h"
+#include "../common/repositories/group_id_repository.h"
+#include "../common/repositories/instance_list_repository.h"
+#include "../common/repositories/instance_list_player_repository.h"
+#include "../common/repositories/raid_members_repository.h"
+#include "../common/repositories/respawn_times_repository.h"
+#include "../common/repositories/spawn_condition_values_repository.h"
+
 
 #include "database.h"
 
@@ -46,110 +54,82 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  * @param char_id
  * @return
  */
-bool Database::AddClientToInstance(uint16 instance_id, uint32 char_id)
+bool Database::AddClientToInstance(uint16 instance_id, uint32 character_id)
 {
-	std::string query = StringFormat(
-		"REPLACE INTO `instance_list_player` (id, charid) "
-		"VALUES "
-		"(%lu, %lu)",
-		(unsigned long) instance_id,
-		(unsigned long) char_id
-	);
+	auto e = InstanceListPlayerRepository::NewEntity();
 
-	auto results = QueryDatabase(query);
+	e.id = instance_id;
+	e.charid = character_id;
 
-	return results.Success();
+	return InstanceListPlayerRepository::InsertOne(*this, e).id ? true : false;
 }
 
-bool Database::CharacterInInstanceGroup(uint16 instance_id, uint32 char_id)
+bool Database::CheckInstanceByCharID(uint16 instance_id, uint32 character_id)
 {
-
-	std::string query = StringFormat("SELECT charid FROM instance_list_player where id=%u AND charid=%u", instance_id, char_id);
-	auto results = QueryDatabase(query);
-
-	if (!results.Success())
+	if (!instance_id) {
 		return false;
+	}
 
-	if (results.RowCount() != 1)
+	auto l = InstanceListPlayerRepository::GetWhere(
+		*this,
+		fmt::format(
+			"id = {} AND charid = {}",
+			instance_id,
+			character_id
+		)
+	);
+	if (l.empty() || !l[0].id) {
 		return false;
+	}
 
 	return true;
 }
 
 bool Database::CheckInstanceExists(uint16 instance_id) {
-	std::string query = StringFormat(
-		"SELECT "
-		"`id`  "
-		"FROM  "
-		"`instance_list`  "
-		"WHERE  "
-		"`id` = %u",
-		instance_id
-		);
-	auto results = QueryDatabase(query);
-
-	if (!results.Success())
+	if (!instance_id) {
 		return false;
+	}
 
-	if (results.RowCount() == 0)
+	auto i = InstanceListRepository::FindOne(*this, instance_id);
+	if (!i.id) {
 		return false;
+	}
 
 	return true;
 }
 
 bool Database::CheckInstanceExpired(uint16 instance_id)
 {
-
-	int32  start_time    = 0;
-	int32  duration      = 0;
-	uint32 never_expires = 0;
-
-	std::string query = StringFormat(
-		"SELECT start_time, duration, never_expires FROM instance_list WHERE id=%u",
-		instance_id
-	);
-
-	auto results = QueryDatabase(query);
-
-	if (!results.Success()) {
+	if (!instance_id) {
 		return true;
 	}
 
-	if (results.RowCount() == 0) {
+	auto i = InstanceListRepository::FindOne(*this, instance_id);
+	if (!i.id) {
 		return true;
 	}
 
-	auto row = results.begin();
-
-	start_time    = atoi(row[0]);
-	duration      = atoi(row[1]);
-	never_expires = atoi(row[2]);
-
-	if (never_expires == 1) {
+	if (i.never_expires) {
 		return false;
 	}
 
 	timeval tv{};
 	gettimeofday(&tv, nullptr);
 
-	return (start_time + duration) <= tv.tv_sec;
-
+	return (i.start_time + i.duration) <= tv.tv_sec;
 }
 
 bool Database::CreateInstance(uint16 instance_id, uint32 zone_id, uint32 version, uint32 duration)
 {
-	std::string query = StringFormat(
-		"INSERT INTO instance_list (id, zone, version, start_time, duration)"
-		" values (%u, %u, %u, UNIX_TIMESTAMP(), %u)",
-		instance_id,
-		zone_id,
-		version,
-		duration
-	);
+	auto e = InstanceListRepository::NewEntity();
 
-	auto results = QueryDatabase(query);
+	e.id = instance_id;
+	e.zone = zone_id;
+	e.version = version;
+	e.start_time = std::time(nullptr);
+	e.duration = duration;
 
-	return results.Success();
+	return InstanceListRepository::InsertOne(*this, e).id ? true : false;
 }
 
 bool Database::GetUnusedInstanceID(uint16 &instance_id)
@@ -235,57 +215,48 @@ bool Database::GetUnusedInstanceID(uint16 &instance_id)
 	return true;
 }
 
-bool Database::GlobalInstance(uint16 instance_id)
+bool Database::IsGlobalInstance(uint16 instance_id)
 {
-	std::string query = StringFormat(
-		"SELECT "
-		"is_global "
-		"FROM "
-		"instance_list "
-		"WHERE "
-		"id = %u "
-		"LIMIT 1 ",
-		instance_id
-		);
-	auto results = QueryDatabase(query);
-
-	if (!results.Success())
+	if (!instance_id) {
 		return false;
+	}
 
-	if (results.RowCount() == 0)
+	auto i = InstanceListRepository::FindOne(*this, instance_id);
+	if (!i.id) {
 		return false;
+	}
 
-	auto row = results.begin();
-
-	return (atoi(row[0]) == 1) ? true : false;
+	return i.is_global ? true : false;
 }
 
 bool Database::RemoveClientFromInstance(uint16 instance_id, uint32 char_id)
 {
-	std::string query = StringFormat("DELETE FROM instance_list_player WHERE id=%lu AND charid=%lu",
-		(unsigned long)instance_id, (unsigned long)char_id);
-	auto results = QueryDatabase(query);
-
-	return results.Success();
+	return InstanceListPlayerRepository::DeleteWhere(
+		*this,
+		fmt::format(
+			"id = {} AND charid = {}",
+			instance_id,
+			char_id
+		)
+	) ?
+	true :
+	false;
 }
 
 
 bool Database::RemoveClientsFromInstance(uint16 instance_id)
 {
-	std::string query = StringFormat("DELETE FROM instance_list_player WHERE id=%lu", (unsigned long)instance_id);
-	auto results = QueryDatabase(query);
-
-	return results.Success();
+	return InstanceListPlayerRepository::DeleteOne(content_db, instance_id) ? true : false;
 }
 
-bool Database::VerifyInstanceAlive(uint16 instance_id, uint32 char_id)
+bool Database::VerifyInstanceAlive(uint16 instance_id, uint32 character_id)
 {
 	//we are not saved to this instance so set our instance to 0
-	if (!GlobalInstance(instance_id) && !CharacterInInstanceGroup(instance_id, char_id))
+	if (!IsGlobalInstance(instance_id) && !CheckInstanceByCharID(instance_id, character_id)) {
 		return false;
+	}
 
-	if (CheckInstanceExpired(instance_id))
-	{
+	if (CheckInstanceExpired(instance_id)) {
 		DeleteInstance(instance_id);
 		return false;
 	}
@@ -295,99 +266,102 @@ bool Database::VerifyInstanceAlive(uint16 instance_id, uint32 char_id)
 
 bool Database::VerifyZoneInstance(uint32 zone_id, uint16 instance_id)
 {
-
-	std::string query = StringFormat("SELECT id FROM instance_list where id=%u AND zone=%u", instance_id, zone_id);
-	auto results = QueryDatabase(query);
-
-	if (!results.Success())
+	auto l = InstanceListRepository::GetWhere(
+		*this,
+		fmt::format(
+			"id = {} AND zone = {}",
+			instance_id,
+			zone_id
+		)
+	);
+	if (l.empty() || !l[0].id) {
 		return false;
-
-	if (results.RowCount() == 0)
-		return false;
+	}
 
 	return true;
 }
 
-uint16 Database::GetInstanceID(uint32 zone, uint32 character_id, int16 version)
+uint16 Database::GetInstanceID(uint32 zone_id, uint32 character_id, int16 version)
 {
-	if (!zone)
+	if (!zone_id) {
 		return 0;
+	}
 
-	std::string query = StringFormat(
-		"SELECT "
-		"instance_list.id "
-		"FROM "
-		"instance_list, "
-		"instance_list_player "
-		"WHERE "
-		"instance_list.zone = %u "
-		"AND instance_list.version = %u "
-		"AND instance_list.id = instance_list_player.id "
-		"AND instance_list_player.charid = %u "
-		"LIMIT 1; ",
-		zone,
+	const auto query = fmt::format(
+		"SELECT instance_list.id FROM "
+		"instance_list, instance_list_player WHERE "
+		"instance_list.zone = {} AND "
+		"instance_list.version = {} AND "
+		"instance_list.id = instance_list_player.id AND "
+		"instance_list_player.charid = {} "
+		"LIMIT 1;",
+		zone_id,
 		version,
 		character_id
-		);
+	);
 	auto results = QueryDatabase(query);
 
-	if (!results.Success())
+	if (!results.Success() || !results.RowCount()) {
 		return 0;
-
-	if (results.RowCount() == 0)
-		return 0;
+	}
 
 	auto row = results.begin();
 
-	return atoi(row[0]);
+	return static_cast<uint16>(std::stoul(row[0]));
 }
 
-uint16 Database::GetInstanceVersion(uint16 instance_id) {
-	if (instance_id == 0)
-		return 0;
+std::vector<uint16> Database::GetInstanceIDs(uint32 zone_id, uint32 character_id)
+{
+	std::vector<uint16> l;
 
-	std::string query = StringFormat("SELECT version FROM instance_list where id=%u", instance_id);
+	if (!zone_id) {
+		return l;
+	}
+
+	const auto query = fmt::format(
+		"SELECT instance_list.id FROM "
+		"instance_list, instance_list_player WHERE "
+		"instance_list.zone = {} AND "
+		"instance_list.id = instance_list_player.id AND "
+		"instance_list_player.charid = {}",
+		zone_id,
+		character_id
+	);
 	auto results = QueryDatabase(query);
 
-	if (!results.Success())
-		return 0;
+	if (!results.Success() || !results.RowCount()) {
+		return l;
+	}
 
-	if (results.RowCount() == 0)
-		return 0;
+	for (auto row : results) {
+		l.push_back(static_cast<uint16>(std::stoul(row[0])));
+	}
 
-	auto row = results.begin();
-	return atoi(row[0]);
+	return l;
+}
+
+uint8_t Database::GetInstanceVersion(uint16 instance_id) {
+	if (!instance_id) {
+		return 0;
+	}
+
+	auto i = InstanceListRepository::FindOne(*this, instance_id);
+	if (!i.id) {
+		return 0;
+	}
+
+	return i.version;
 }
 
 uint32 Database::GetTimeRemainingInstance(uint16 instance_id, bool &is_perma)
 {
-	uint32 start_time = 0;
-	uint32 duration = 0;
-	uint32 never_expires = 0;
-
-	std::string query = StringFormat("SELECT start_time, duration, never_expires FROM instance_list WHERE id=%u", instance_id);
-	auto results = QueryDatabase(query);
-
-	if (!results.Success())
-	{
+	auto i = InstanceListRepository::FindOne(*this, instance_id);
+	if (!i.id) {
 		is_perma = false;
 		return 0;
 	}
 
-	if (results.RowCount() == 0)
-	{
-		is_perma = false;
-		return 0;
-	}
-
-	auto row = results.begin();
-
-	start_time = atoi(row[0]);
-	duration = atoi(row[1]);
-	never_expires = atoi(row[2]);
-
-	if (never_expires == 1)
-	{
+	if (i.never_expires) {
 		is_perma = true;
 		return 0;
 	}
@@ -396,204 +370,175 @@ uint32 Database::GetTimeRemainingInstance(uint16 instance_id, bool &is_perma)
 
 	timeval tv;
 	gettimeofday(&tv, nullptr);
-	return ((start_time + duration) - tv.tv_sec);
+	return ((i.start_time + i.duration) - tv.tv_sec);
 }
 
-uint32 Database::VersionFromInstanceID(uint16 instance_id)
+uint32 Database::GetInstanceZoneID(uint16 instance_id)
 {
-
-	std::string query = StringFormat("SELECT version FROM instance_list where id=%u", instance_id);
-	auto results = QueryDatabase(query);
-
-	if (!results.Success())
+	if (!instance_id) {
 		return 0;
+	}
 
-	if (results.RowCount() == 0)
+	auto i = InstanceListRepository::FindOne(*this, instance_id);
+	if (!i.id) {
 		return 0;
+	}
 
-	auto row = results.begin();
-
-	return atoi(row[0]);
-}
-
-uint32 Database::ZoneIDFromInstanceID(uint16 instance_id)
-{
-
-	std::string query = StringFormat("SELECT zone FROM instance_list where id=%u", instance_id);
-	auto results = QueryDatabase(query);
-
-	if (!results.Success())
-		return 0;
-
-	if (results.RowCount() == 0)
-		return 0;
-
-	auto row = results.begin();
-
-	return atoi(row[0]);
+	return i.zone;
 }
 
 void Database::AssignGroupToInstance(uint32 group_id, uint32 instance_id)
 {
+	auto zone_id = GetInstanceZoneID(instance_id);
+	auto version = GetInstanceVersion(instance_id);
 
-	uint32 zone_id = ZoneIDFromInstanceID(instance_id);
-	uint16 version = VersionFromInstanceID(instance_id);
-
-	std::string query = StringFormat("SELECT `charid` FROM `group_id` WHERE `groupid` = %u", group_id);
-	auto results = QueryDatabase(query);
-
-	if (!results.Success())
+	auto l = GroupIdRepository::GetWhere(
+		*this,
+		fmt::format(
+			"groupid = {}",
+			group_id
+		)
+	);
+	if (l.empty() || !l[0].groupid) {
 		return;
+	}
 
-	for (auto row = results.begin(); row != results.end(); ++row)
-	{
-		uint32 charid = atoi(row[0]);
-		if (GetInstanceID(zone_id, charid, version) == 0)
-			AddClientToInstance(instance_id, charid);
+	for (const auto& e : l) {
+		if (!GetInstanceID(zone_id, e.charid, version)) {
+			AddClientToInstance(instance_id, e.charid);
+		}
 	}
 }
 
 void Database::AssignRaidToInstance(uint32 raid_id, uint32 instance_id)
 {
+	auto zone_id = GetInstanceZoneID(instance_id);
+	auto version = GetInstanceVersion(instance_id);
 
-	uint32 zone_id = ZoneIDFromInstanceID(instance_id);
-	uint16 version = VersionFromInstanceID(instance_id);
-
-	std::string query = StringFormat("SELECT `charid` FROM `raid_members` WHERE `raidid` = %u", raid_id);
-	auto results = QueryDatabase(query);
-
-	if (!results.Success())
-		return;
-
-	for (auto row = results.begin(); row != results.end(); ++row)
-	{
-		uint32 charid = atoi(row[0]);
-		if (GetInstanceID(zone_id, charid, version) == 0)
-			AddClientToInstance(instance_id, charid);
-	}
-}
-
-void Database::BuryCorpsesInInstance(uint16 instance_id) {
-	QueryDatabase(
+	auto l = GroupIdRepository::GetWhere(
+		*this,
 		fmt::format(
-			"UPDATE character_corpses SET is_buried = 1, instance_id = 0 WHERE instance_id = {}",
-			instance_id
+			"raidid = {}",
+			raid_id
 		)
 	);
+	if (l.empty() || !l[0].groupid) {
+		return;
+	}
+
+	for (const auto& e : l) {
+		if (!GetInstanceID(zone_id, e.charid, version)) {
+			AddClientToInstance(instance_id, e.charid);
+		}
+	}
 }
 
 void Database::DeleteInstance(uint16 instance_id)
 {
 	std::string query;
 
-	query = StringFormat("DELETE FROM instance_list_player WHERE id=%u", instance_id);
-	QueryDatabase(query);
+	InstanceListPlayerRepository::DeleteWhere(*this, fmt::format("id = {}", instance_id));
 
-	query = StringFormat("DELETE FROM respawn_times WHERE instance_id=%u", instance_id);
-	QueryDatabase(query);
+	RespawnTimesRepository::DeleteWhere(*this, fmt::format("instance_id = {}", instance_id));
 
-	query = StringFormat("DELETE FROM spawn_condition_values WHERE instance_id=%u", instance_id);
-	QueryDatabase(query);
+	SpawnConditionValuesRepository::DeleteWhere(*this, fmt::format("instance_id = {}", instance_id));
 
 	DynamicZoneMembersRepository::DeleteByInstance(*this, instance_id);
 	DynamicZonesRepository::DeleteWhere(*this, fmt::format("instance_id = {}", instance_id));
 
-	BuryCorpsesInInstance(instance_id);
+	CharacterCorpsesRepository::BuryInstance(*this, instance_id);
 }
 
-void Database::FlagInstanceByGroupLeader(uint32 zone, int16 version, uint32 charid, uint32 gid)
+void Database::FlagInstanceByGroupLeader(uint32 zone_id, int16 version, uint32 character_id, uint32 group_id)
 {
-	uint16 id = GetInstanceID(zone, charid, version);
-	if (id != 0)
+	auto instance_id = GetInstanceID(zone_id, character_id, version);
+	if (instance_id) {
 		return;
+	}
 
 	char ln[128];
 	memset(ln, 0, 128);
-	GetGroupLeadershipInfo(gid, ln);
-	uint32 l_charid = GetCharacterID((const char*)ln);
-	uint16 l_id = GetInstanceID(zone, l_charid, version);
+	GetGroupLeadershipInfo(group_id, ln);
 
-	if (l_id == 0)
+	auto group_leader_id = GetCharacterID((const char*)ln);
+	auto group_leader_instance_id = GetInstanceID(zone_id, group_leader_id, version);
+
+	if (!group_leader_instance_id) {
 		return;
+	}
 
-	AddClientToInstance(l_id, charid);
+	AddClientToInstance(group_leader_instance_id, character_id);
 }
 
-void Database::FlagInstanceByRaidLeader(uint32 zone, int16 version, uint32 charid, uint32 rid)
+void Database::FlagInstanceByRaidLeader(uint32 zone_id, int16 version, uint32 character_id, uint32 raid_id)
 {
-	uint16 id = GetInstanceID(zone, charid, version);
-	if (id != 0)
+	uint16 instance_id = GetInstanceID(zone_id, character_id, version);
+	if (instance_id) {
 		return;
+	}
 
-	uint32 l_charid = GetCharacterID(GetRaidLeaderName(rid));
-	uint16 l_id = GetInstanceID(zone, l_charid, version);
+	auto raid_leader_id = GetCharacterID(GetRaidLeaderName(raid_id));
+	auto raid_leader_instance_id = GetInstanceID(zone_id, raid_leader_id, version);
 
-	if (l_id == 0)
+	if (!raid_leader_instance_id) {
 		return;
+	}
 
-	AddClientToInstance(l_id, charid);
+	AddClientToInstance(raid_leader_instance_id, character_id);
 }
 
-void Database::GetCharactersInInstance(uint16 instance_id, std::list<uint32> &charid_list) {
-
-	std::string query = StringFormat("SELECT `charid` FROM `instance_list_player` WHERE `id` = %u", instance_id);
-	auto results = QueryDatabase(query);
-
-	if (!results.Success())
+void Database::GetCharactersInInstance(uint16 instance_id, std::list<uint32> &character_ids)
+{
+	auto l = InstanceListPlayerRepository::GetWhere(*this, fmt::format("id = {}", instance_id));
+	if (l.empty() || !l[0].id) {
 		return;
+	}
 
-	for (auto row = results.begin(); row != results.end(); ++row)
-		charid_list.push_back(atoi(row[0]));
+	for (const auto& e : l) {
+		character_ids.push_back(e.charid);
+	}
 }
 
 void Database::PurgeExpiredInstances()
 {
-
 	/**
 	 * Delay purging by a day so that we can continue using adjacent free instance id's
 	 * from the table without risking the chance we immediately re-allocate a zone that freshly expired but
 	 * has not been fully de-allocated
 	 */
-	std::string query =
-		SQL(
-			SELECT
-				id
-			FROM
-				instance_list
-			where
-			(start_time + duration) <= (UNIX_TIMESTAMP() - 86400)
-			and never_expires = 0
-		);
-
-	auto results = QueryDatabase(query);
-
-	if (!results.Success()) {
-		return;
-	}
-
-	if (results.RowCount() == 0) {
+	auto l = InstanceListRepository::GetWhere(
+		*this,
+		"(start_time + duration) <= (UNIX_TIMESTAMP() - 86400) AND never_expires = 0"
+	);
+	if (l.empty() || !l[0].id) {
 		return;
 	}
 
 	std::vector<std::string> instance_ids;
-	for (auto row = results.begin(); row != results.end(); ++row) {
-		instance_ids.emplace_back(row[0]);
+	for (const auto& e : l) {
+		instance_ids.emplace_back(std::to_string(e.id));
 	}
 
-	std::string imploded_instance_ids = Strings::Implode(",", instance_ids);
+	const auto imploded_instance_ids = Strings::Implode(",", instance_ids);
 
-	QueryDatabase(fmt::format("DELETE FROM instance_list WHERE id IN ({})", imploded_instance_ids));
-	QueryDatabase(fmt::format("DELETE FROM instance_list_player WHERE id IN ({})", imploded_instance_ids));
-	QueryDatabase(fmt::format("DELETE FROM respawn_times WHERE instance_id IN ({})", imploded_instance_ids));
-	QueryDatabase(fmt::format("DELETE FROM spawn_condition_values WHERE instance_id IN ({})", imploded_instance_ids));
-	QueryDatabase(fmt::format("UPDATE character_corpses SET is_buried = 1, instance_id = 0 WHERE instance_id IN ({})", imploded_instance_ids));
+	InstanceListRepository::DeleteWhere(*this, fmt::format("id IN ({})", imploded_instance_ids));
+	InstanceListPlayerRepository::DeleteWhere(*this, fmt::format("id IN ({})", imploded_instance_ids));
+	RespawnTimesRepository::DeleteWhere(*this, fmt::format("instance_id IN ({})", imploded_instance_ids));
+	SpawnConditionValuesRepository::DeleteWhere(*this, fmt::format("instance_id IN ({})", imploded_instance_ids));
+	CharacterCorpsesRepository::BuryInstances(*this, imploded_instance_ids);
 	DynamicZoneMembersRepository::DeleteByManyInstances(*this, imploded_instance_ids);
 	DynamicZonesRepository::DeleteWhere(*this, fmt::format("instance_id IN ({})", imploded_instance_ids));
 }
 
 void Database::SetInstanceDuration(uint16 instance_id, uint32 new_duration)
 {
-	std::string query = StringFormat("UPDATE `instance_list` SET start_time=UNIX_TIMESTAMP(), "
-		"duration=%u WHERE id=%u", new_duration, instance_id);
-	auto results = QueryDatabase(query);
+	auto i = InstanceListRepository::FindOne(*this, instance_id);
+	if (!i.id) {
+		return;
+	}
+
+	i.start_time = std::time(nullptr);
+	i.duration = new_duration;
+
+	InstanceListRepository::UpdateOne(*this, i);
 }

--- a/common/repositories/character_corpses_repository.h
+++ b/common/repositories/character_corpses_repository.h
@@ -47,9 +47,8 @@ public:
 	static int BuryInstance(Database& db, uint16 instance_id) {
 		auto results = db.QueryDatabase(
 			fmt::format(
-				"UPDATE {} SET is_buried = 1, instance_id = 0 WHERE {} = {}",
+				"UPDATE {} SET is_buried = 1, instance_id = 0 WHERE instance_id = {}",
 				TableName(),
-				PrimaryKey(),
 				instance_id
 			)
 		);
@@ -61,9 +60,8 @@ public:
 	{
 		auto results = db.QueryDatabase(
 			fmt::format(
-				"UPDATE {} SET is_buried = 1, instance_id = 0 WHERE {} IN ({})",
+				"UPDATE {} SET is_buried = 1, instance_id = 0 WHERE instance_id IN ({})",
 				TableName(),
-				PrimaryKey(),
 				joined_instance_ids
 			)
 		);

--- a/common/repositories/character_corpses_repository.h
+++ b/common/repositories/character_corpses_repository.h
@@ -44,7 +44,32 @@ public:
      */
 
 	// Custom extended repository methods here
+	static int BuryInstance(Database& db, uint16 instance_id) {
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"UPDATE {} SET is_buried = 1, instance_id = 0 WHERE {} = {}",
+				TableName(),
+				PrimaryKey(),
+				instance_id
+			)
+		);
 
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
+
+	static int BuryInstances(Database& db, const std::string& joined_instance_ids)
+	{
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"UPDATE {} SET is_buried = 1, instance_id = 0 WHERE {} IN ({})",
+				TableName(),
+				PrimaryKey(),
+				joined_instance_ids
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
 };
 
 #endif //EQEMU_CHARACTER_CORPSES_REPOSITORY_H

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -1464,23 +1464,57 @@ int Perl__GetInstanceID(const char* zone_name, uint16 version)
 	return quest_manager.GetInstanceID(zone_name, version);
 }
 
-int Perl__GetInstanceIDByCharID(const char* zone_name, int16 version, uint32 char_id)
+uint8 Perl__GetInstanceVersionByID(uint16 instance_id)
 {
-	return quest_manager.GetInstanceIDByCharID(zone_name, version, char_id);
+	return database.GetInstanceVersion(instance_id);
+}
+
+uint32 Perl__GetInstanceZoneIDByID(uint16 instance_id)
+{
+	return database.GetInstanceZoneID(instance_id);
+}
+
+perl::array Perl__GetInstanceIDs(std::string zone_name)
+{
+	perl::array result;
+
+	const auto instance_ids = quest_manager.GetInstanceIDs(zone_name);
+	for (int i = 0; i < instance_ids.size(); i++) {
+		result.push_back(instance_ids[i]);
+	}
+
+	return result;
+}
+
+int Perl__GetInstanceIDByCharID(const char* zone_name, int16 version, uint32 character_id)
+{
+	return quest_manager.GetInstanceIDByCharID(zone_name, version, character_id);
+}
+
+perl::array Perl__GetInstanceIDsByCharID(std::string zone_name, uint32 character_id)
+{
+	perl::array result;
+
+	const auto instance_ids = quest_manager.GetInstanceIDs(zone_name, character_id);
+	for (int i = 0; i < instance_ids.size(); i++) {
+		result.push_back(instance_ids[i]);
+	}
+
+	return result;
 }
 
 std::string Perl__GetCharactersInInstance(uint16 instance_id)
 {
-	std::list<uint32> char_id_list;
+	std::list<uint32> character_ids;
 	std::string char_id_string = "No players in that instance.";
 
-	database.GetCharactersInInstance(instance_id, char_id_list);
+	database.GetCharactersInInstance(instance_id, character_ids);
 
-	if (char_id_list.size() > 0)
+	if (character_ids.size() > 0)
 	{
-		char_id_string = fmt::format("{} player(s) in instance: ", char_id_list.size());
-		auto iter = char_id_list.begin();
-		while (iter != char_id_list.end()) {
+		char_id_string = fmt::format("{} player(s) in instance: ", character_ids.size());
+		auto iter = character_ids.begin();
+		while (iter != character_ids.end()) {
 			char char_name[64];
 			database.GetCharName(*iter, char_name);
 			char_id_string += char_name;
@@ -1488,7 +1522,7 @@ std::string Perl__GetCharactersInInstance(uint16 instance_id)
 			char_id_string += itoa(*iter);
 			char_id_string += ")";
 			++iter;
-			if (iter != char_id_list.end())
+			if (iter != character_ids.end())
 				char_id_string += ", ";
 		}
 	}
@@ -1501,9 +1535,9 @@ void Perl__AssignToInstance(uint16 instance_id)
 	quest_manager.AssignToInstance(instance_id);
 }
 
-void Perl__AssignToInstanceByCharID(uint16 instance_id, uint32 char_id)
+void Perl__AssignToInstanceByCharID(uint16 instance_id, uint32 character_id)
 {
-	quest_manager.AssignToInstanceByCharID(instance_id, char_id);
+	quest_manager.AssignToInstanceByCharID(instance_id, character_id);
 }
 
 void Perl__AssignGroupToInstance(uint16 instance_id)
@@ -1521,14 +1555,14 @@ void Perl__RemoveFromInstance(uint16 instance_id)
 	quest_manager.RemoveFromInstance(instance_id);
 }
 
-void Perl__RemoveFromInstanceByCharID(uint16 instance_id, uint32 char_id)
+void Perl__RemoveFromInstanceByCharID(uint16 instance_id, uint32 character_id)
 {
-	quest_manager.RemoveFromInstanceByCharID(instance_id, char_id);
+	quest_manager.RemoveFromInstanceByCharID(instance_id, character_id);
 }
 
-bool Perl__CheckInstanceByCharID(uint16 instance_id, uint32 char_id)
+bool Perl__CheckInstanceByCharID(uint16 instance_id, uint32 character_id)
 {
-	return quest_manager.CheckInstanceByCharID(instance_id, char_id);
+	return quest_manager.CheckInstanceByCharID(instance_id, character_id);
 }
 
 void Perl__RemoveAllFromInstance(uint16 instance_id)
@@ -3898,6 +3932,10 @@ void perl_register_quest()
 	package.add("GetCharactersInInstance", &Perl__GetCharactersInInstance);
 	package.add("GetInstanceID", &Perl__GetInstanceID);
 	package.add("GetInstanceIDByCharID", &Perl__GetInstanceIDByCharID);
+	package.add("GetInstanceIDs", &Perl__GetInstanceIDs);
+	package.add("GetInstanceIDsByCharID", &Perl__GetInstanceIDsByCharID);
+	package.add("GetInstanceVersionByID", &Perl__GetInstanceVersionByID);
+	package.add("GetInstanceZoneIDByID", &Perl__GetInstanceZoneIDByID);
 	package.add("GetSpellResistType", &Perl__GetSpellResistType);
 	package.add("GetSpellTargetType", &Perl__GetSpellTargetType);
 	package.add("GetTimeSeconds", &Perl__GetTimeSeconds);

--- a/zone/gm_commands/instance.cpp
+++ b/zone/gm_commands/instance.cpp
@@ -97,9 +97,9 @@ void command_instance(Client *c, const Seperator *sep)
 			return;
 		}
 
-		uint32 zone_id = database.ZoneIDFromInstanceID(instance_id);
-		uint32 version = database.VersionFromInstanceID(instance_id);
-		uint32 current_id  = database.GetInstanceID(zone_id, character_id, version);
+		auto zone_id = database.GetInstanceZoneID(instance_id);
+		auto version = database.GetInstanceVersion(instance_id);
+		auto current_id  = database.GetInstanceID(zone_id, character_id, version);
 		if (!current_id) {
 			c->Message(
 				Chat::White,

--- a/zone/gm_commands/zone_instance.cpp
+++ b/zone/gm_commands/zone_instance.cpp
@@ -25,7 +25,7 @@ void command_zone_instance(Client *c, const Seperator *sep)
 		return;
 	}
 
-	auto zone_id = database.ZoneIDFromInstanceID(instance_id);
+	auto zone_id = database.GetInstanceZoneID(instance_id);
 	if (!zone_id) {
 		c->Message(
 			Chat::White,
@@ -36,11 +36,11 @@ void command_zone_instance(Client *c, const Seperator *sep)
 		);
 		return;
 	}
-	
-	if (!database.CharacterInInstanceGroup(instance_id, c->CharacterID())) {
+
+	if (!database.CheckInstanceByCharID(instance_id, c->CharacterID())) {
 		database.AddClientToInstance(instance_id, c->CharacterID());
 	}
-	
+
 	if (!database.VerifyInstanceAlive(instance_id, c->CharacterID())) {
 		c->Message(
 			Chat::White,

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -1002,16 +1002,46 @@ int lua_get_instance_id(const char *zone, uint32 version) {
 	return quest_manager.GetInstanceID(zone, version);
 }
 
-int lua_get_instance_id_by_char_id(const char *zone, uint32 version, uint32 char_id) {
-	return quest_manager.GetInstanceIDByCharID(zone, version, char_id);
+uint8 lua_get_instance_version_by_id(uint16 instance_id) {
+	return database.GetInstanceVersion(instance_id);
+}
+
+uint32 lua_get_instance_zone_id_by_id(uint16 instance_id) {
+	return database.GetInstanceZoneID(instance_id);
+}
+
+luabind::adl::object lua_get_instance_ids(lua_State* L, std::string zone_name) {
+	luabind::adl::object ret = luabind::newtable(L);
+
+	auto instance_ids = quest_manager.GetInstanceIDs(zone_name);
+	for (int i = 0; i < instance_ids.size(); i++) {
+		ret[i] = instance_ids[i];
+	}
+
+	return ret;
+}
+
+luabind::adl::object lua_get_instance_ids_by_char_id(lua_State* L, std::string zone_name, uint32 character_id) {
+	luabind::adl::object ret = luabind::newtable(L);
+
+	auto instance_ids = quest_manager.GetInstanceIDs(zone_name, character_id);
+	for (int i = 0; i < instance_ids.size(); i++) {
+		ret[i] = instance_ids[i];
+	}
+
+	return ret;
+}
+
+int lua_get_instance_id_by_char_id(const char *zone, uint32 version, uint32 character_id) {
+	return quest_manager.GetInstanceIDByCharID(zone, version, character_id);
 }
 
 void lua_assign_to_instance(uint32 instance_id) {
 	quest_manager.AssignToInstance(instance_id);
 }
 
-void lua_assign_to_instance_by_char_id(uint32 instance_id, uint32 char_id) {
-	quest_manager.AssignToInstanceByCharID(instance_id, char_id);
+void lua_assign_to_instance_by_char_id(uint32 instance_id, uint32 character_id) {
+	quest_manager.AssignToInstanceByCharID(instance_id, character_id);
 }
 
 void lua_assign_group_to_instance(uint32 instance_id) {
@@ -1026,12 +1056,12 @@ void lua_remove_from_instance(uint32 instance_id) {
 	quest_manager.RemoveFromInstance(instance_id);
 }
 
-void lua_remove_from_instance_by_char_id(uint32 instance_id, uint32 char_id) {
-	quest_manager.RemoveFromInstanceByCharID(instance_id, char_id);
+void lua_remove_from_instance_by_char_id(uint32 instance_id, uint32 character_id) {
+	quest_manager.RemoveFromInstanceByCharID(instance_id, character_id);
 }
 
-bool lua_check_instance_by_char_id(uint32 instance_id, uint32 char_id) {
-	return quest_manager.CheckInstanceByCharID(instance_id, char_id);
+bool lua_check_instance_by_char_id(uint32 instance_id, uint32 character_id) {
+	return quest_manager.CheckInstanceByCharID(instance_id, character_id);
 }
 
 void lua_remove_all_from_instance(uint32 instance_id) {
@@ -1215,11 +1245,11 @@ int lua_get_zone_instance_version() {
 luabind::adl::object lua_get_characters_in_instance(lua_State *L, uint16 instance_id) {
 	luabind::adl::object ret = luabind::newtable(L);
 
-	std::list<uint32> charid_list;
+	std::list<uint32> character_ids;
 	uint16 i = 1;
-	database.GetCharactersInInstance(instance_id,charid_list);
-	auto iter = charid_list.begin();
-	while(iter != charid_list.end()) {
+	database.GetCharactersInInstance(instance_id, character_ids);
+	auto iter = character_ids.begin();
+	while(iter != character_ids.end()) {
 		ret[i] = *iter;
 		++i;
 		++iter;
@@ -3939,8 +3969,12 @@ luabind::scope lua_register_general() {
 		luabind::def("update_instance_timer", &lua_update_instance_timer),
 		luabind::def("get_instance_id", &lua_get_instance_id),
 		luabind::def("get_instance_id_by_char_id", &lua_get_instance_id_by_char_id),
+		luabind::def("get_instance_ids", &lua_get_instance_ids),
+		luabind::def("get_instance_ids_by_char_id", &lua_get_instance_id_by_char_id),
 		luabind::def("get_instance_timer", &lua_get_instance_timer),
 		luabind::def("get_instance_timer_by_id", &lua_get_instance_timer_by_id),
+		luabind::def("get_instance_version_by_id", &lua_get_instance_version_by_id),
+		luabind::def("get_instance_zone_id_by_id", &lua_get_instance_zone_id_by_id),
 		luabind::def("get_characters_in_instance", &lua_get_characters_in_instance),
 		luabind::def("assign_to_instance", &lua_assign_to_instance),
 		luabind::def("assign_to_instance_by_char_id", &lua_assign_to_instance_by_char_id),

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -3007,6 +3007,20 @@ uint16 QuestManager::GetInstanceID(const char *zone, int16 version)
 	return 0;
 }
 
+std::vector<uint16> QuestManager::GetInstanceIDs(std::string zone_name, uint32 character_id)
+{
+	if (!character_id) {
+		QuestManagerCurrentQuestVars();
+		if (initiator) {
+			return database.GetInstanceIDs(ZoneID(zone_name), initiator->CharacterID());
+		}
+
+		return { };
+	}
+
+	return database.GetInstanceIDs(ZoneID(zone_name), character_id);
+}
+
 uint16 QuestManager::GetInstanceIDByCharID(const char *zone, int16 version, uint32 char_id) {
 	return database.GetInstanceID(ZoneID(zone), char_id, version);
 }
@@ -3069,7 +3083,7 @@ void QuestManager::RemoveFromInstanceByCharID(uint16 instance_id, uint32 char_id
 }
 
 bool QuestManager::CheckInstanceByCharID(uint16 instance_id, uint32 char_id) {
-	return database.CharacterInInstanceGroup(instance_id, char_id);
+	return database.CheckInstanceByCharID(instance_id, char_id);
 }
 
 void QuestManager::RemoveAllFromInstance(uint16 instance_id)
@@ -3077,14 +3091,14 @@ void QuestManager::RemoveAllFromInstance(uint16 instance_id)
 	QuestManagerCurrentQuestVars();
 	if (initiator)
 	{
-		std::list<uint32> charid_list;
+		std::list<uint32> character_ids;
 
 		if (database.RemoveClientsFromInstance(instance_id))
 			initiator->Message(Chat::Say, "Removed all players from instance.");
 		else
 		{
-			database.GetCharactersInInstance(instance_id, charid_list);
-			initiator->Message(Chat::Say, "Failed to remove %i player(s) from instance.", charid_list.size()); // once the expedition system is in, this message it not relevant
+			database.GetCharactersInInstance(instance_id, character_ids);
+			initiator->Message(Chat::Say, "Failed to remove %i player(s) from instance.", character_ids.size()); // once the expedition system is in, this message it not relevant
 		}
 	}
 }

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -265,6 +265,7 @@ public:
 	uint32 GetInstanceTimerByID(uint16 instance_id = 0);
 	void DestroyInstance(uint16 instance_id);
 	uint16 GetInstanceID(const char *zone, int16 version);
+	std::vector<uint16> GetInstanceIDs(std::string zone_name, uint32 character_id = 0);
 	uint16 GetInstanceIDByCharID(const char *zone, int16 version, uint32 char_id);
 	void AssignToInstance(uint16 instance_id);
 	void AssignToInstanceByCharID(uint16 instance_id, uint32 char_id);

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -545,11 +545,11 @@ void Client::MoveZoneRaid(const char *zone_short_name, const glm::vec4 &location
 }
 
 void Client::MoveZoneInstance(uint16 instance_id, const glm::vec4 &location) {
-	if (!database.CharacterInInstanceGroup(instance_id, CharacterID())) {
+	if (!database.CheckInstanceByCharID(instance_id, CharacterID())) {
 		database.AddClientToInstance(instance_id, CharacterID());
 	}
 
-	ProcessMovePC(database.ZoneIDFromInstanceID(instance_id), instance_id, location.x, location.y, location.z, location.w, 3, ZoneToSafeCoords);
+	ProcessMovePC(database.GetInstanceZoneID(instance_id), instance_id, location.x, location.y, location.z, location.w, 3, ZoneToSafeCoords);
 }
 
 void Client::MoveZoneInstanceGroup(uint16 instance_id, const glm::vec4 &location) {


### PR DESCRIPTION
# Perl
- Add `quest::GetInstanceIDs(zone_name)`.
- Add `quest::GetInstanceIDsByCharID(zone_name, character_id)`.
- Add `quest::GetInstanceVersionByID(instance_id)`.
- Add `quest::GetInstanceZoneIDByID(instance_id)`.

# Lua
- Add `eq.get_instance_ids(zone_name)`.
- Add `eq.get_instance_ids_by_char_id(zone_name, character_id)`.
- Add `eq.get_instance_version_by_id(instance_id)`.
- Add `eq.get_instance_zone_id_by_id(instance_id)`.

# Notes
- The instance IDs methods return arrays of IDs for looping so you can check on mass the instances a player has for a zone.
- Keeps operators from having to guess which possible versions of a zone a player has an instance for or loop through them all to find out.
- Cleanup `common/database_instances.cpp` to mostly use repositories where possible.