### PR TITLE
[Quest API] Add GetBotListByClientName() Class Overload to Perl/Lua.

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -5185,7 +5185,7 @@ std::vector<Bot *> EntityList::GetBotListByCharacterID(uint32 character_id, uint
 	return client_bot_list;
 }
 
-std::vector<Bot *> EntityList::GetBotListByClientName(std::string client_name)
+std::vector<Bot *> EntityList::GetBotListByClientName(std::string client_name, uint8 class_id)
 {
 	std::vector<Bot *> client_bot_list;
 
@@ -5196,7 +5196,8 @@ std::vector<Bot *> EntityList::GetBotListByClientName(std::string client_name)
 	for (const auto& b : bot_list) {
 		if (
 			b->GetOwner() &&
-			Strings::ToLower(b->GetOwner()->GetCleanName()) == Strings::ToLower(client_name)
+			Strings::ToLower(b->GetOwner()->GetCleanName()) == Strings::ToLower(client_name) &&
+			(!class_id || b->GetClass() == class_id)
 		) {
 			client_bot_list.push_back(b);
 		}

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -551,7 +551,7 @@ public:
 #ifdef BOTS
 	inline const std::list<Bot *> &GetBotList() { return bot_list; }
 	std::vector<Bot *> GetBotListByCharacterID(uint32 character_id, uint8 class_id = 0);
-	std::vector<Bot *> GetBotListByClientName(std::string client_name);
+	std::vector<Bot *> GetBotListByClientName(std::string client_name, uint8 class_id = 0);
 	void SignalAllBotsByOwnerCharacterID(uint32 character_id, int signal_id);
 	void SignalBotByBotID(uint32 bot_id, int signal_id);
 	void SignalBotByBotName(std::string bot_name, int signal_id);

--- a/zone/lua_entity_list.cpp
+++ b/zone/lua_entity_list.cpp
@@ -441,6 +441,20 @@ Lua_Bot_List Lua_EntityList::GetBotListByClientName(std::string client_name) {
 	return ret;
 }
 
+Lua_Bot_List Lua_EntityList::GetBotListByClientName(std::string client_name, uint8 class_id) {
+	Lua_Safe_Call_Class(Lua_Bot_List);
+	Lua_Bot_List ret;
+	auto bot_list = self->GetBotListByClientName(client_name, class_id);
+
+	if (bot_list.size()) {
+		for (auto bot : bot_list) {
+			ret.entries.push_back(Lua_Bot(bot));
+		}
+	}
+
+	return ret;
+}
+
 void Lua_EntityList::SignalAllBotsByOwnerCharacterID(uint32 character_id, int signal_id) {
 	Lua_Safe_Call_Void();
 	self->SignalAllBotsByOwnerCharacterID(character_id, signal_id);
@@ -638,6 +652,7 @@ luabind::scope lua_register_entity_list() {
 	.def("GetBotListByCharacterID", (Lua_Bot_List(Lua_EntityList::*)(uint32))&Lua_EntityList::GetBotListByCharacterID)
 	.def("GetBotListByCharacterID", (Lua_Bot_List(Lua_EntityList::*)(uint32,uint8))&Lua_EntityList::GetBotListByCharacterID)
 	.def("GetBotListByClientName", (Lua_Bot_List(Lua_EntityList::*)(std::string))&Lua_EntityList::GetBotListByClientName)
+	.def("GetBotListByClientName", (Lua_Bot_List(Lua_EntityList::*)(std::string,uint8))&Lua_EntityList::GetBotListByClientName)
 #endif
 	.def("GetClientByAccID", (Lua_Client(Lua_EntityList::*)(uint32))&Lua_EntityList::GetClientByAccID)
 	.def("GetClientByCharID", (Lua_Client(Lua_EntityList::*)(uint32))&Lua_EntityList::GetClientByCharID)

--- a/zone/lua_entity_list.h
+++ b/zone/lua_entity_list.h
@@ -137,6 +137,7 @@ public:
 	Lua_Bot_List GetBotListByCharacterID(uint32 character_id);
 	Lua_Bot_List GetBotListByCharacterID(uint32 character_id, uint8 class_id);
 	Lua_Bot_List GetBotListByClientName(std::string client_name);
+	Lua_Bot_List GetBotListByClientName(std::string client_name, uint8 class_id);
 	Lua_Bot GetRandomBot();
 	Lua_Bot GetRandomBot(float x, float y, float z, float distance);
 	Lua_Bot GetRandomBot(float x, float y, float z, float distance, Lua_Bot exclude_bot);

--- a/zone/perl_entity.cpp
+++ b/zone/perl_entity.cpp
@@ -450,6 +450,17 @@ perl::array Perl_EntityList_GetBotListByClientName(EntityList* self, std::string
 	return result;
 }
 
+perl::array Perl_EntityList_GetBotListByClientName(EntityList* self, std::string client_name, uint8 class_id) // @categories Script Utility, Bot
+{
+	perl::array result;
+	auto current_bot_list = self->GetBotListByClientName(client_name, class_id);
+	for (int i = 0; i < current_bot_list.size(); ++i)
+	{
+		result.push_back(current_bot_list[i]);
+	}
+	return result;
+}
+
 void Perl_EntityList_SignalAllBotsByOwnerCharacterID(EntityList* self, uint32_t character_id, int signal_id) // @categories Script Utility
 {
 	entity_list.SignalAllBotsByOwnerCharacterID(character_id, signal_id);
@@ -609,7 +620,8 @@ void perl_register_entitylist()
 	package.add("GetBotList", &Perl_EntityList_GetBotList);
 	package.add("GetBotListByCharacterID", (perl::array(*)(EntityList*, uint32))&Perl_EntityList_GetBotListByCharacterID);
 	package.add("GetBotListByCharacterID", (perl::array(*)(EntityList*, uint32, uint8))&Perl_EntityList_GetBotListByCharacterID);
-	package.add("GetBotListByClientName", &Perl_EntityList_GetBotListByClientName);
+	package.add("GetBotListByClientName", (perl::array(*)(EntityList*, std::string))&Perl_EntityList_GetBotListByClientName);
+	package.add("GetBotListByClientName", (perl::array(*)(EntityList*, std::string, uint8))&Perl_EntityList_GetBotListByClientName);
 #endif
 	package.add("GetClientByAccID", &Perl_EntityList_GetClientByAccID);
 	package.add("GetClientByCharID", &Perl_EntityList_GetClientByCharID);


### PR DESCRIPTION
# Perl
- Add `$entity_list->GetBotListByClientName(client_name, class_id)`.

# Lua
- Add `eq.get_entity_list():GetBotListByClientName(client_name, class_id)`.

# Notes
- Adds overload to get bots by client name and class ID.