### PR TITLE
[Quest API] Add Time String to Seconds Method to Perl/Lua.

### DIFF
--- a/common/strings.cpp
+++ b/common/strings.cpp
@@ -678,3 +678,41 @@ bool Strings::Contains(const std::string& subject, const std::string& search)
 {
 	return subject.find(search) != std::string::npos;
 }
+
+uint32 Strings::TimeToSeconds(std::string time_string)
+{
+	if (time_string.empty()) {
+		return 0;
+	}
+
+	uint32 duration = 0;
+
+	std::transform(time_string.begin(), time_string.end(), time_string.begin(), ::tolower);
+
+	std::string time_unit = time_string;
+	time_unit.erase(remove_if(time_unit.begin(), time_unit.end(), [](char c) { return !isdigit(c); }), time_unit.end());
+
+	auto unit = std::stoul(time_unit);
+
+	if (time_string.find('s') != std::string::npos) {
+		duration = unit;
+	}
+
+	if (time_string.find('m') != std::string::npos) {
+		duration = unit * 60;
+	}
+
+	if (time_string.find('h') != std::string::npos) {
+		duration = unit * 3600;
+	}
+
+	if (time_string.find('d') != std::string::npos) {
+		duration = unit * 86400;
+	}
+
+	if (time_string.find('y') != std::string::npos) {
+		duration = unit * 31556926;
+	}
+
+	return duration;
+}

--- a/common/strings.h
+++ b/common/strings.h
@@ -109,6 +109,7 @@ public:
 	static std::vector<std::string> Split(const std::string& s, const std::string& delimiter);
 	static std::vector<std::string> Wrap(std::vector<std::string> &src, std::string character);
 	static void FindReplace(std::string &string_subject, const std::string &search_string, const std::string &replace_string);
+	static uint32 TimeToSeconds(std::string time_string);
 
 	template<typename T>
 	static std::string

--- a/zone/data_bucket.cpp
+++ b/zone/data_bucket.cpp
@@ -21,7 +21,7 @@ void DataBucket::SetData(std::string bucket_key, std::string bucket_value, std::
 
 	if (!expires_time.empty()) {
 		if (isalpha(expires_time[0]) || isalpha(expires_time[expires_time.length() - 1])) {
-			expires_time_unix = (long long) std::time(nullptr) + DataBucket::ParseStringTimeToInt(expires_time);
+			expires_time_unix = (long long) std::time(nullptr) + Strings::TimeToSeconds(expires_time);
 		} else {
 			expires_time_unix = (long long) std::time(nullptr) + atoi(expires_time.c_str());
 		}
@@ -163,37 +163,4 @@ bool DataBucket::DeleteData(std::string bucket_key) {
 	auto results = database.QueryDatabase(query);
 
 	return results.Success();
-}
-
-/**
- * Converts string to integer for use when setting expiration times
- * @param time_string
- * @return
- */
-uint32 DataBucket::ParseStringTimeToInt(std::string time_string)
-{
-	uint32 duration = 0;
-
-	std::transform(time_string.begin(), time_string.end(), time_string.begin(), ::tolower);
-
-	if (time_string.length() < 1)
-		return 0;
-
-	std::string time_unit = time_string;
-	time_unit.erase(remove_if(time_unit.begin(), time_unit.end(), [](char c) { return !isdigit(c); }), time_unit.end());
-
-	uint32 unit = static_cast<uint32>(atoi(time_unit.c_str()));
-
-	if (time_string.find('s') != std::string::npos)
-		duration = unit;
-	if (time_string.find('m') != std::string::npos)
-		duration = unit * 60;
-	if (time_string.find('h') != std::string::npos)
-		duration = unit * 3600;
-	if (time_string.find('d') != std::string::npos)
-		duration = unit * 86400;
-	if (time_string.find('y') != std::string::npos)
-		duration = unit * 31556926;
-
-	return duration;
 }

--- a/zone/data_bucket.h
+++ b/zone/data_bucket.h
@@ -18,7 +18,6 @@ public:
 	static std::string GetDataRemaining(std::string bucket_key);
 private:
 	static uint64 DoesBucketExist(std::string bucket_key);
-	static uint32 ParseStringTimeToInt(std::string time_string);
 };
 
 

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -2320,7 +2320,12 @@ EQ::ItemInstance* Perl__createitem(uint32 item_id, int16 charges, uint32 augment
 
 std::string Perl__secondstotime(int duration)
 {
-	return quest_manager.secondstotime(duration);
+	return Strings::SecondsToTime(duration);
+}
+
+uint32 Perl__timetoseconds(std::string time_string)
+{
+	return Strings::TimeToSeconds(time_string);
 }
 
 std::string Perl__gethexcolorcode(std::string color_name)
@@ -4501,6 +4506,7 @@ void perl_register_quest()
 	package.add("task_setselector", (void(*)(int))&Perl__task_setselector);
 	package.add("task_setselector", (void(*)(int, bool))&Perl__task_setselector);
 	package.add("tasktimeleft", &Perl__tasktimeleft);
+	package.add("timetoseconds", &Perl__timetoseconds);
 	package.add("toggle_spawn_event", &Perl__toggle_spawn_event);
 	package.add("toggledoorstate", &Perl__toggledoorstate);
 	package.add("tracknpc", &Perl__tracknpc);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -1923,7 +1923,11 @@ void lua_remove_all_expedition_lockouts_by_char_id(uint32 char_id, std::string e
 }
 
 std::string lua_seconds_to_time(int duration) {
-	return quest_manager.secondstotime(duration);
+	return Strings::SecondsToTime(duration);
+}
+
+uint32 lua_time_to_seconds(std::string time_string) {
+	return Strings::TimeToSeconds(time_string);
 }
 
 std::string lua_get_hex_color_code(std::string color_name) {
@@ -4061,6 +4065,7 @@ luabind::scope lua_register_general() {
 		luabind::def("debug", (void(*)(std::string, int))&lua_debug),
 		luabind::def("log_combat", (void(*)(std::string))&lua_log_combat),
 		luabind::def("seconds_to_time", &lua_seconds_to_time),
+		luabind::def("time_to_seconds", &lua_time_to_seconds),
 		luabind::def("get_hex_color_code", &lua_get_hex_color_code),
 		luabind::def("get_aa_exp_modifier_by_char_id", (double(*)(uint32,uint32))&lua_get_aa_exp_modifier_by_char_id),
 		luabind::def("get_aa_exp_modifier_by_char_id", (double(*)(uint32,uint32,int16))&lua_get_aa_exp_modifier_by_char_id),

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -3576,10 +3576,6 @@ EQ::ItemInstance *QuestManager::CreateItem(uint32 item_id, int16 charges, uint32
 	return nullptr;
 }
 
-std::string QuestManager::secondstotime(int duration) {
-	return Strings::SecondsToTime(duration);
-}
-
 std::string QuestManager::gethexcolorcode(std::string color_name) {
 
 	for (auto color : html_colors) {

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -329,7 +329,6 @@ public:
 	bool DisableRecipe(uint32 recipe_id);
 	void ClearNPCTypeCache(int npctype_id);
 	void ReloadZoneStaticData();
-	std::string secondstotime(int duration);
 	std::string gethexcolorcode(std::string color_name);
 	double GetAAEXPModifierByCharID(uint32 character_id, uint32 zone_id, int16 instance_version = -1) const;
 	double GetEXPModifierByCharID(uint32 character_id, uint32 zone_id, int16 instance_version = -1) const;


### PR DESCRIPTION
# Perl
- Add `quest::timetoseconds(time_string)`.

# Lua
- Add `eq.time_to_seconds(time_string)`.

# Notes
- Allows operators to use this method in place of hardcoded values like `3600`.