### PR TITLE
[Bots] Move Bot Spell Loading process to Bot Constructor 

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -405,6 +405,10 @@ Bot::Bot(uint32 botID, uint32 botOwnerCharacterID, uint32 botSpellsID, double to
 		bot_owner->Message(Chat::White, "&s for '%s'", BotDatabase::fail::LoadBuffs(), GetCleanName());
 	}
 
+	GetBotOwnerDataBuckets();
+	GetBotDataBuckets();
+	AI_AddBotSpells(GetBotSpellID());
+
 	CalcBotStats(false);
 	hp_regen = CalcHPRegen();
 	mana_regen = CalcManaRegen();
@@ -9417,10 +9421,6 @@ void Bot::CalcBotStats(bool showtext) {
 	//	GetBotOwner()->CastToClient()->Message(Chat::White, "%s save failed!", GetCleanName());
 
 	CalcBonuses();
-
-	GetBotOwnerDataBuckets();
-	GetBotDataBuckets();
-	AI_AddBotSpells(GetBotSpellID());
 
 	if(showtext) {
 		GetBotOwner()->Message(Chat::Yellow, "%s has been updated.", GetCleanName());


### PR DESCRIPTION
Process will be run when spawning bots, or on zone. moved out of CalcBotStats to reduce number of DB queries.

Will eventually look at storing Bot Spell Entries in memory, and do data bucket comparisons via that method.