### PR TITLE
[Bot] Update Bot Logic to ignore ST_TargetsTarget when buffing

### DIFF
--- a/zone/botspellsai.cpp
+++ b/zone/botspellsai.cpp
@@ -371,12 +371,15 @@ bool Bot::AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes) {
 						continue;
 					}
 					// Validate target
-
-					if (!((spells[selectedBotSpell.SpellId].target_type == ST_Target || spells[selectedBotSpell.SpellId].target_type == ST_Pet || tar == this ||
-						spells[selectedBotSpell.SpellId].target_type == ST_Group || spells[selectedBotSpell.SpellId].target_type == ST_GroupTeleport ||
-						(botClass == BARD && spells[selectedBotSpell.SpellId].target_type == ST_AEBard))
-						&& !tar->IsImmuneToSpell(selectedBotSpell.SpellId, this)
-						&& (tar->CanBuffStack(selectedBotSpell.SpellId, botLevel, true) >= 0))) {
+					// TODO: Add ST_TargetsTarget support for Buffing.
+					if (!((spells[selectedBotSpell.SpellId].target_type == ST_Target || 
+						spells[selectedBotSpell.SpellId].target_type == ST_Pet || 
+						(tar == this && !spells[selectedBotSpell.SpellId].target_type == ST_TargetsTarget) ||
+						spells[selectedBotSpell.SpellId].target_type == ST_Group || 
+						spells[selectedBotSpell.SpellId].target_type == ST_GroupTeleport ||
+						(botClass == BARD && spells[selectedBotSpell.SpellId].target_type == ST_AEBard)) &&
+						!tar->IsImmuneToSpell(selectedBotSpell.SpellId, this) &&
+						(tar->CanBuffStack(selectedBotSpell.SpellId, botLevel, true) >= 0))) {
 							continue;
 					}
 

--- a/zone/botspellsai.cpp
+++ b/zone/botspellsai.cpp
@@ -372,15 +372,21 @@ bool Bot::AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes) {
 					}
 					// Validate target
 					// TODO: Add ST_TargetsTarget support for Buffing.
-					if (!((spells[selectedBotSpell.SpellId].target_type == ST_Target || 
-						spells[selectedBotSpell.SpellId].target_type == ST_Pet || 
-						(tar == this && spells[selectedBotSpell.SpellId].target_type != ST_TargetsTarget) ||
-						spells[selectedBotSpell.SpellId].target_type == ST_Group || 
-						spells[selectedBotSpell.SpellId].target_type == ST_GroupTeleport ||
-						(botClass == BARD && spells[selectedBotSpell.SpellId].target_type == ST_AEBard)) &&
-						!tar->IsImmuneToSpell(selectedBotSpell.SpellId, this) &&
-						(tar->CanBuffStack(selectedBotSpell.SpellId, botLevel, true) >= 0))) {
-							continue;
+					if (
+						!(
+							(
+								spells[selectedBotSpell.SpellId].target_type == ST_Target || 
+								spells[selectedBotSpell.SpellId].target_type == ST_Pet || 
+								(tar == this && spells[selectedBotSpell.SpellId].target_type != ST_TargetsTarget) ||
+								spells[selectedBotSpell.SpellId].target_type == ST_Group || 
+								spells[selectedBotSpell.SpellId].target_type == ST_GroupTeleport ||
+								(botClass == BARD && spells[selectedBotSpell.SpellId].target_type == ST_AEBard)
+							) &&
+							!tar->IsImmuneToSpell(selectedBotSpell.SpellId, this) &&
+							tar->CanBuffStack(selectedBotSpell.SpellId, botLevel, true) >= 0
+						)
+					) {
+						continue;
 					}
 
 					// Put the zone levitate and movement check here since bots are able to bypass the client casting check

--- a/zone/botspellsai.cpp
+++ b/zone/botspellsai.cpp
@@ -374,7 +374,7 @@ bool Bot::AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes) {
 					// TODO: Add ST_TargetsTarget support for Buffing.
 					if (!((spells[selectedBotSpell.SpellId].target_type == ST_Target || 
 						spells[selectedBotSpell.SpellId].target_type == ST_Pet || 
-						(tar == this && !spells[selectedBotSpell.SpellId].target_type == ST_TargetsTarget) ||
+						(tar == this && spells[selectedBotSpell.SpellId].target_type != ST_TargetsTarget) ||
 						spells[selectedBotSpell.SpellId].target_type == ST_Group || 
 						spells[selectedBotSpell.SpellId].target_type == ST_GroupTeleport ||
 						(botClass == BARD && spells[selectedBotSpell.SpellId].target_type == ST_AEBard)) &&


### PR DESCRIPTION
Fixes issue where Bots will spam cast ST_TargetsTarget buffs (and never successfully buff)
Will need to build Target of Target support for Bots, and revisit, 
