### PR TITLE
[Quest API] Fix Perl EVENT_HP double parsing in Spire.

### DIFF
--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -1588,14 +1588,8 @@ void PerlembParser::ExportEventVariables(
 		}
 
 		case EVENT_HP: {
-			if (extradata == 1) {
-				ExportVar(package_name.c_str(), "hpevent", "-1");
-				ExportVar(package_name.c_str(), "inchpevent", data);
-			}
-			else {
-				ExportVar(package_name.c_str(), "hpevent", data);
-				ExportVar(package_name.c_str(), "inchpevent", "-1");
-			}
+			ExportVar(package_name.c_str(), "hpevent", extradata ? "-1" : data);
+			ExportVar(package_name.c_str(), "inchpevent", extradata ? data : "-1");
 			break;
 		}
 


### PR DESCRIPTION
This condition caused the variables to show twice due to the way Sprie parses the source code, and the condition itself is unnecessary since we can just use an inline ternary in this case.