### PR TITLE
[Bot] Add Support for Bots to receive Auras, and other AoE Spells

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -2922,7 +2922,7 @@ void EntityList::ScanCloseMobs(
 	for (auto &e : mob_list) {
 		auto mob = e.second;
 
-		if (!mob->IsNPC() && !mob->IsClient()) {
+		if (!mob->IsNPC() && !mob->IsClient() && !mob->IsBot() && !mob->IsMerc()) {
 			continue;
 		}
 


### PR DESCRIPTION
Also provides support for Mercs.

Player Auras will land on Bots & Mercs now.
PBAE Buffs willl land on Bots & Mercs now.
MGB Buffs will land on Bots & Mercs now.
NPC detrimental spells should also function if they didn't before (PBAE spells)
