### PR TITLE
[Quest API] Add Group/Raid Overloads to Perl/Lua.

### DIFF
--- a/zone/groups.cpp
+++ b/zone/groups.cpp
@@ -833,26 +833,28 @@ void Group::CastGroupSpell(Mob* caster, uint16 spell_id) {
 	disbandcheck = true;
 }
 
-bool Group::IsGroupMember(Mob* client)
+bool Group::IsGroupMember(Mob* c)
 {
-	bool Result = false;
-
-	if(client) {
-		for (uint32 i = 0; i < MAX_GROUP_MEMBERS; i++) {
-			if (members[i] == client)
-				Result = true;
+	if (c) {
+		for (const auto &m: members) {
+			if (m == c) {
+				return true;
+			}
 		}
 	}
 
-	return Result;
+	return false;
 }
 
-bool Group::IsGroupMember(const char *Name)
+bool Group::IsGroupMember(const char *name)
 {
-	if(Name)
-		for(uint32 i = 0; i < MAX_GROUP_MEMBERS; i++)
-			if((strlen(Name) == strlen(membername[i])) && !strncmp(membername[i], Name, strlen(Name)))
+	if (name) {
+		for (const auto& m : membername) {
+			if (!strcmp(m, name)) {
 				return true;
+			}
+		}
+	}
 
 	return false;
 }
@@ -2472,5 +2474,17 @@ bool Group::DoesAnyMemberHaveExpeditionLockout(
 			}
 		}
 	}
+	return false;
+}
+
+bool Group::IsLeader(const char* name) {
+	if (name) {
+		for (const auto& m : membername) {
+			if (!strcmp(m, name)) {
+				return true;
+			}
+		}
+	}
+
 	return false;
 }

--- a/zone/groups.h
+++ b/zone/groups.h
@@ -65,8 +65,8 @@ public:
 #ifdef BOTS
 	void	GetBotList(std::list<Bot*>& bot_list, bool clear_list = true);
 #endif
-	bool	IsGroupMember(Mob* client);
-	bool	IsGroupMember(const char *Name);
+	bool	IsGroupMember(Mob* c);
+	bool	IsGroupMember(const char* name);
 	bool	Process();
 	bool	IsGroup()			{ return true; }
 	void	SendGroupJoinOOZ(Mob* NewMember);
@@ -76,16 +76,17 @@ public:
 	void	GroupMessageString(Mob* sender, uint32 type, uint32 string_id, const char* message,const char* message2=0,const char* message3=0,const char* message4=0,const char* message5=0,const char* message6=0,const char* message7=0,const char* message8=0,const char* message9=0, uint32 distance = 0);
 	uint32	GetTotalGroupDamage(Mob* other);
 	void	SplitMoney(uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Client *splitter = nullptr);
-	inline	void SetLeader(Mob* newleader){ leader=newleader; };
+	inline	void SetLeader(Mob* c){ leader = c; };
 	inline	Mob* GetLeader() { return leader; };
 	const char*	GetLeaderName() { return membername[0]; };
 	void	SendHPManaEndPacketsTo(Mob* newmember);
 	void	SendHPPacketsFrom(Mob* member);
 	void	SendManaPacketFrom(Mob* member);
-	void SendEndurancePacketFrom(Mob* member);
+	void	SendEndurancePacketFrom(Mob* member);
 	bool	UpdatePlayer(Mob* update);
 	void	MemberZoned(Mob* removemob);
-	inline	bool IsLeader(Mob* leadertest) { return leadertest==leader; };
+	bool	IsLeader(const char* name);
+	inline bool IsLeader(Mob* m) { return m == leader; };
 	uint8	GroupCount();
 	uint32	GetHighestLevel();
 	uint32	GetLowestLevel();
@@ -142,10 +143,10 @@ public:
 	void	QueueClients(Mob *sender, const EQApplicationPacket *app, bool ack_required = true, bool ignore_sender = true, float distance = 0);
 	void	ChangeLeader(Mob* newleader);
 	const char *GetClientNameByIndex(uint8 index);
-	void UpdateXTargetMarkedNPC(uint32 Number, Mob *m);
-	void SetDirtyAutoHaters();
+	void	UpdateXTargetMarkedNPC(uint32 Number, Mob *m);
+	void	SetDirtyAutoHaters();
 	inline XTargetAutoHaters *GetXTargetAutoMgr() { return &m_autohatermgr; }
-	void JoinRaidXTarget(Raid *raid, bool first = false);
+	void	JoinRaidXTarget(Raid *raid, bool first = false);
 
 	void SetGroupMentor(int percent, char *name);
 	void ClearGroupMentor();

--- a/zone/lua_group.cpp
+++ b/zone/lua_group.cpp
@@ -19,9 +19,14 @@ void Lua_Group::DisbandGroup() {
 	self->DisbandGroup();
 }
 
-bool Lua_Group::IsGroupMember(Lua_Mob mob) {
+bool Lua_Group::IsGroupMember(const char* name) {
 	Lua_Safe_Call_Bool();
-	return self->IsGroupMember(mob);
+	return self->IsGroupMember(name);
+}
+
+bool Lua_Group::IsGroupMember(Lua_Mob c) {
+	Lua_Safe_Call_Bool();
+	return self->IsGroupMember(c);
 }
 
 void Lua_Group::CastGroupSpell(Lua_Mob caster, int spell_id) {
@@ -59,9 +64,9 @@ void Lua_Group::SplitMoney(uint32 copper, uint32 silver, uint32 gold, uint32 pla
 	self->SplitMoney(copper, silver, gold, platinum, splitter);
 }
 
-void Lua_Group::SetLeader(Lua_Mob leader) {
+void Lua_Group::SetLeader(Lua_Mob c) {
 	Lua_Safe_Call_Void();
-	self->SetLeader(leader);
+	self->SetLeader(c);
 }
 
 Lua_Mob Lua_Group::GetLeader() {
@@ -74,9 +79,14 @@ const char *Lua_Group::GetLeaderName() {
 	return self->GetLeaderName();
 }
 
-bool Lua_Group::IsLeader(Lua_Mob leader) {
+bool Lua_Group::IsLeader(const char* name) {
 	Lua_Safe_Call_Bool();
-	return self->IsLeader(leader);
+	return self->IsLeader(name);
+}
+
+bool Lua_Group::IsLeader(Lua_Mob c) {
+	Lua_Safe_Call_Bool();
+	return self->IsLeader(c);
 }
 
 int Lua_Group::GroupCount() {
@@ -151,7 +161,9 @@ luabind::scope lua_register_group() {
 	.def("GroupCount", (int(Lua_Group::*)(void))&Lua_Group::GroupCount)
 	.def("GroupMessage", (void(Lua_Group::*)(Lua_Mob,const char*))&Lua_Group::GroupMessage)
 	.def("GroupMessage", (void(Lua_Group::*)(Lua_Mob,int,const char*))&Lua_Group::GroupMessage)
+	.def("IsGroupMember", (bool(Lua_Group::*)(const char*))&Lua_Group::IsGroupMember)
 	.def("IsGroupMember", (bool(Lua_Group::*)(Lua_Mob))&Lua_Group::IsGroupMember)
+	.def("IsLeader", (bool(Lua_Group::*)(const char*))&Lua_Group::IsLeader)
 	.def("IsLeader", (bool(Lua_Group::*)(Lua_Mob))&Lua_Group::IsLeader)
 	.def("SetLeader", (void(Lua_Group::*)(Lua_Mob))&Lua_Group::SetLeader)
 	.def("SplitExp", (void(Lua_Group::*)(uint32,Lua_Mob))&Lua_Group::SplitExp)

--- a/zone/lua_group.h
+++ b/zone/lua_group.h
@@ -27,7 +27,8 @@ public:
 	}
 
 	void DisbandGroup();
-	bool IsGroupMember(Lua_Mob mob);
+	bool IsGroupMember(const char* name);
+	bool IsGroupMember(Lua_Mob c);
 	void CastGroupSpell(Lua_Mob caster, int spell_id);
 	void SplitExp(uint32 exp, Lua_Mob other);
 	void GroupMessage(Lua_Mob sender, const char* message);
@@ -35,10 +36,11 @@ public:
 	uint32 GetTotalGroupDamage(Lua_Mob other);
 	void SplitMoney(uint32 copper, uint32 silver, uint32 gold, uint32 platinum);
 	void SplitMoney(uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Lua_Client splitter);
-	void SetLeader(Lua_Mob leader);
+	void SetLeader(Lua_Mob c);
 	Lua_Mob GetLeader();
 	const char *GetLeaderName();
-	bool IsLeader(Lua_Mob leader);
+	bool IsLeader(const char* name);
+	bool IsLeader(Lua_Mob c);
 	int GroupCount();
 	uint32 GetAverageLevel();
 	uint32 GetHighestLevel();

--- a/zone/lua_raid.cpp
+++ b/zone/lua_raid.cpp
@@ -18,6 +18,11 @@ bool Lua_Raid::IsRaidMember(const char *name) {
 	return self->IsRaidMember(name);
 }
 
+bool Lua_Raid::IsRaidMember(Lua_Client c) {
+	Lua_Safe_Call_Bool();
+	return self->IsRaidMember(c);
+}
+
 void Lua_Raid::CastGroupSpell(Lua_Mob caster, int spell_id, uint32 group_id) {
 	Lua_Safe_Call_Void();
 	self->CastGroupSpell(caster, spell_id, group_id);
@@ -81,6 +86,11 @@ bool Lua_Raid::IsLeader(Lua_Client c) {
 bool Lua_Raid::IsGroupLeader(const char *name) {
 	Lua_Safe_Call_Bool();
 	return self->IsGroupLeader(name);
+}
+
+bool Lua_Raid::IsGroupLeader(Lua_Client c) {
+	Lua_Safe_Call_Bool();
+	return self->IsGroupLeader(c);
 }
 
 int Lua_Raid::GetHighestLevel() {
@@ -168,8 +178,11 @@ luabind::scope lua_register_raid() {
 	.def("GetTotalRaidDamage", (uint32(Lua_Raid::*)(Lua_Mob))&Lua_Raid::GetTotalRaidDamage)
 	.def("GroupCount", (int(Lua_Raid::*)(uint32))&Lua_Raid::GroupCount)
 	.def("IsGroupLeader", (bool(Lua_Raid::*)(const char*))&Lua_Raid::IsGroupLeader)
+	.def("IsGroupLeader", (bool(Lua_Raid::*)(Lua_Client))&Lua_Raid::IsGroupLeader)
 	.def("IsLeader", (bool(Lua_Raid::*)(const char*))&Lua_Raid::IsLeader)
+	.def("IsLeader", (bool(Lua_Raid::*)(Lua_Client))&Lua_Raid::IsLeader)
 	.def("IsRaidMember", (bool(Lua_Raid::*)(const char*))&Lua_Raid::IsRaidMember)
+	.def("IsRaidMember", (bool(Lua_Raid::*)(Lua_Client))&Lua_Raid::IsRaidMember)
 	.def("RaidCount", (int(Lua_Raid::*)(void))&Lua_Raid::RaidCount)
 	.def("SplitExp", (void(Lua_Raid::*)(uint32,Lua_Mob))&Lua_Raid::SplitExp)
 	.def("SplitMoney", (void(Lua_Raid::*)(uint32,uint32,uint32,uint32,uint32))&Lua_Raid::SplitMoney)

--- a/zone/lua_raid.h
+++ b/zone/lua_raid.h
@@ -27,6 +27,7 @@ public:
 	}
 
 	bool IsRaidMember(const char *name);
+	bool IsRaidMember(Lua_Client c);
 	void CastGroupSpell(Lua_Mob caster, int spell_id, uint32 group_id);
 	int GroupCount(uint32 group_id);
 	int RaidCount();
@@ -40,6 +41,7 @@ public:
 	bool IsLeader(const char *c);
 	bool IsLeader(Lua_Client c);
 	bool IsGroupLeader(const char *name);
+	bool IsGroupLeader(Lua_Client c);
 	int GetHighestLevel();
 	int GetLowestLevel();
 	Lua_Client GetClientByIndex(int member_index);

--- a/zone/perl_groups.cpp
+++ b/zone/perl_groups.cpp
@@ -12,9 +12,14 @@ void Perl_Group_DisbandGroup(Group* self) // @categories Script Utility, Group
 	self->DisbandGroup();
 }
 
-bool Perl_Group_IsGroupMember(Group* self, Mob* client) // @categories Account and Character, Script Utility, Group
+bool Perl_Group_IsGroupMember(Group* self, Mob* c) // @categories Account and Character, Script Utility, Group
 {
-	return self->IsGroupMember(client);
+	return self->IsGroupMember(c);
+}
+
+bool Perl_Group_IsGroupMember(Group* self, const char* name) // @categories Account and Character, Script Utility, Group
+{
+	return self->IsGroupMember(name);
 }
 
 void Perl_Group_CastGroupSpell(Group* self, Mob* caster, uint16 spell_id) // @categories Account and Character, Script Utility, Group
@@ -82,9 +87,14 @@ void Perl_Group_SendHPPacketsFrom(Group* self, Mob* new_member) // @categories S
 	self->SendHPPacketsFrom(new_member);
 }
 
-bool Perl_Group_IsLeader(Group* self, Mob* leadertest) // @categories Account and Character, Script Utility, Group
+bool Perl_Group_IsLeader(Group* self, Mob* c) // @categories Account and Character, Script Utility, Group
 {
-	return self->IsLeader(leadertest);
+	return self->IsLeader(c);
+}
+
+bool Perl_Group_IsLeader(Group* self, const char* name) // @categories Account and Character, Script Utility, Group
+{
+	return self->IsLeader(name);
 }
 
 int Perl_Group_GroupCount(Group* self) // @categories Script Utility, Group
@@ -157,8 +167,10 @@ void perl_register_group()
 	package.add("GroupCount", &Perl_Group_GroupCount);
 	package.add("GroupMessage", (void(*)(Group*, Mob*, const char*))&Perl_Group_GroupMessage);
 	package.add("GroupMessage", (void(*)(Group*, Mob*, uint8_t, const char*))&Perl_Group_GroupMessage);
-	package.add("IsGroupMember", &Perl_Group_IsGroupMember);
-	package.add("IsLeader", &Perl_Group_IsLeader);
+	package.add("IsGroupMember", (bool(*)(Group*, const char*))&Perl_Group_IsGroupMember);
+	package.add("IsGroupMember", (bool(*)(Group*, Mob*))&Perl_Group_IsGroupMember);
+	package.add("IsLeader", (bool(*)(Group*, const char*))&Perl_Group_IsLeader);
+	package.add("IsLeader", (bool(*)(Group*, Mob*))&Perl_Group_IsLeader);
 	package.add("SendHPPacketsFrom", &Perl_Group_SendHPPacketsFrom);
 	package.add("SendHPPacketsTo", &Perl_Group_SendHPPacketsTo);
 	package.add("SetLeader", &Perl_Group_SetLeader);

--- a/zone/perl_raids.cpp
+++ b/zone/perl_raids.cpp
@@ -13,6 +13,11 @@ bool Perl_Raid_IsRaidMember(Raid* self, const char* name) // @categories Raid
 	return self->IsRaidMember(name);
 }
 
+bool Perl_Raid_IsRaidMember(Raid* self, Client* c) // @categories Raid
+{
+	return self->IsRaidMember(c);
+}
+
 void Perl_Raid_CastGroupSpell(Raid* self, Mob* caster, uint16 spell_id, uint32 group_id) // @categories Group, Raid
 {
 	self->CastGroupSpell(caster, spell_id, group_id);
@@ -68,14 +73,19 @@ bool Perl_Raid_IsLeader(Raid* self, const char* name) // @categories Raid
 	return self->IsLeader(name);
 }
 
-bool Perl_Raid_IsLeader(Raid* self, Client* client) // @categories Raid
+bool Perl_Raid_IsLeader(Raid* self, Client* c) // @categories Raid
 {
-	return self->IsLeader(client);
+	return self->IsLeader(c);
 }
 
 bool Perl_Raid_IsGroupLeader(Raid* self, const char* who) // @categories Group, Raid
 {
 	return self->IsGroupLeader(who);
+}
+
+bool Perl_Raid_IsGroupLeader(Raid* self, Client* c) // @categories Group, Raid
+{
+	return self->IsGroupLeader(c);
 }
 
 uint32_t Perl_Raid_GetHighestLevel(Raid* self) // @categories Raid
@@ -157,10 +167,12 @@ void perl_register_raid()
 	package.add("GetMember", &Perl_Raid_GetMember);
 	package.add("GetTotalRaidDamage", &Perl_Raid_GetTotalRaidDamage);
 	package.add("GroupCount", &Perl_Raid_GroupCount);
-	package.add("IsGroupLeader", &Perl_Raid_IsGroupLeader);
+	package.add("IsGroupLeader", (bool(*)(Raid*, const char*))&Perl_Raid_IsGroupLeader);
+	package.add("IsGroupLeader", (bool(*)(Raid*, Client*))&Perl_Raid_IsGroupLeader);
 	package.add("IsLeader", (bool(*)(Raid*, const char*))&Perl_Raid_IsLeader);
 	package.add("IsLeader", (bool(*)(Raid*, Client*))&Perl_Raid_IsLeader);
-	package.add("IsRaidMember", &Perl_Raid_IsRaidMember);
+	package.add("IsRaidMember", (bool(*)(Raid*, const char*))&Perl_Raid_IsRaidMember);
+	package.add("IsRaidMember", (bool(*)(Raid*, Client*))&Perl_Raid_IsRaidMember);
 	package.add("RaidCount", &Perl_Raid_RaidCount);
 	package.add("SplitExp", &Perl_Raid_SplitExp);
 	package.add("SplitMoney", (void(*)(Raid*, uint32, uint32, uint32, uint32, uint32))&Perl_Raid_SplitMoney);

--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -354,12 +354,26 @@ void Raid::UpdateRaidAAs()
 	SaveRaidLeaderAA();
 }
 
-bool Raid::IsGroupLeader(const char *who)
+bool Raid::IsGroupLeader(const char* name)
 {
-	for(int x = 0; x < MAX_RAID_MEMBERS; x++)
-	{
-		if(strcmp(who, members[x].membername) == 0){
-			return members[x].IsGroupLeader;
+	if (name) {
+		for (const auto &m: members) {
+			if (!strcmp(m.membername, name)) {
+				return m.IsGroupLeader;
+			}
+		}
+	}
+
+	return false;
+}
+
+bool Raid::IsGroupLeader(Client *c)
+{
+	if (c) {
+		for (const auto &m: members) {
+			if (m.member == c) {
+				return true;
+			}
 		}
 	}
 
@@ -890,12 +904,29 @@ void Raid::RemoveRaidLooter(const char* looter)
 	safe_delete(pack);
 }
 
-bool Raid::IsRaidMember(const char *name){
-	for(int x = 0; x < MAX_RAID_MEMBERS; x++)
-	{
-		if(strcmp(name, members[x].membername) == 0)
-			return true;
+bool Raid::IsRaidMember(const char *name)
+{
+	if (name) {
+		for (const auto &m: members) {
+			if (!strcmp(m.membername, name)) {
+				return true;
+			}
+		}
 	}
+
+	return false;
+}
+
+bool Raid::IsRaidMember(Client* c)
+{
+	if (c) {
+		for (const auto &m: members) {
+			if (m.member == c) {
+				return true;
+			}
+		}
+	}
+
 	return false;
 }
 

--- a/zone/raids.h
+++ b/zone/raids.h
@@ -102,10 +102,10 @@ public:
 	Raid(uint32 raidID);
 	~Raid();
 
-	void SetLeader(Client *newLeader) { leader = newLeader; }
+	void SetLeader(Client* c) { leader = c; }
 	Client* GetLeader() { return leader; }
-	bool IsLeader(Client *c) { return leader==c; }
-	bool IsLeader(const char* name) { return (strcmp(leadername, name)==0); }
+	bool IsLeader(Client* c) { return c == leader; }
+	bool IsLeader(const char* name) { return !strcmp(leadername, name); }
 	void SetRaidLeader(const char *wasLead, const char *name);
 
 	bool	Process();
@@ -118,8 +118,10 @@ public:
 	void	SetGroupLeader(const char *who, bool glFlag = true);
 	Client	*GetGroupLeader(uint32 group_id);
 	void	RemoveGroupLeader(const char *who);
-	bool	IsGroupLeader(const char *who);
-	bool	IsRaidMember(const char *name);
+	bool	IsGroupLeader(const char* name);
+	bool	IsGroupLeader(Client *c);
+	bool	IsRaidMember(const char* name);
+	bool	IsRaidMember(Client *c);
 	void	UpdateLevel(const char *name, int newLevel);
 
 	uint32	GetFreeGroup();


### PR DESCRIPTION
# Perl
- Add `$group->IsGroupMember(name)`.
- Add `$group->IsLeader(name)`.
- Add `$raid->IsRaidMember(client)`.
- Add `$raid->IsGroupLeader(client)`.

# Lua
- Add `group:IsGroupMember(name)`.
- Add `group:IsLeader(name)`.
- Add `raid:IsGroupLeader(client)`.
- Add `raid:IsLeader(client)`.
- Add `raid:IsRaidMember(client)`.

# Notes
- Adds overloads to these methods allowing operators to get by name or reference.