### PR TITLE
[Bots] Optimize inventory loading.

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -4078,7 +4078,6 @@ std::map<uint16, uint32> Bot::GetBotItemSlots()
 				GetCleanName()
 			).c_str()
 		);
-		return m;
 	}
 
 	return m;

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -4019,7 +4019,7 @@ bool Bot::Spawn(Client* botCharacterOwner) {
 		const auto& m = GetBotItemSlots();
 		uint8 material_from_slot = 0xFF;
 		for (int slot_id = EQ::invslot::EQUIPMENT_BEGIN; slot_id <= EQ::invslot::EQUIPMENT_END; ++slot_id) {
-			if (m.find(slot_id) != l.end()) {
+			if (m.find(slot_id) != m.end()) {
 				material_from_slot = EQ::InventoryProfile::CalcMaterialFromSlot(slot_id);
 				if (material_from_slot != 0xFF) {
 					SendWearChange(material_from_slot);

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -558,9 +558,9 @@ public:
 	inline InspectMessage_Struct& GetInspectMessage() { return _botInspectMessage; }
 	inline const InspectMessage_Struct& GetInspectMessage() const { return _botInspectMessage; }
 
-	// "Quest API" Methods 
+	// "Quest API" Methods
 	bool HasBotSpellEntry(uint16 spellid);
-	
+
 	// "SET" Class Methods
 	void SetBotSpellID(uint32 newSpellID);
 	virtual void SetSpawnStatus(bool spawnStatus) { _spawnStatus = spawnStatus; }
@@ -672,6 +672,7 @@ public:
 		uint32 augment_six = 0
 	);
 	uint32 CountBotItem(uint32 item_id);
+	std::map<uint16, uint32> GetBotItemSlots();
 	uint32 GetBotItemBySlot(uint16 slot_id);
 	bool HasBotItem(uint32 item_id);
 	void RemoveBotItem(uint32 item_id);

--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -1375,7 +1375,7 @@ bool BotDatabase::LoadItemSlots(const uint32 bot_id, std::map<uint16, uint32>& m
 			bot_id
 		)
 	);
-	if (l.empty() || !l[0].inventories_index) {
+	if (l.empty()) {
 		return false;
 	}
 

--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -24,6 +24,8 @@
 #include "../common/strings.h"
 #include "../common/eqemu_logsys.h"
 
+#include "../common/repositories/bot_inventories_repository.h"
+
 #include "zonedb.h"
 #include "../common/zone_store.h"
 #include "bot.h"
@@ -1356,6 +1358,30 @@ bool BotDatabase::LoadItemBySlot(const uint32 bot_id, const uint32 slot_id, uint
 
 	auto row = results.begin();
 	item_id = atoi(row[0]);
+
+	return true;
+}
+
+bool BotDatabase::LoadItemSlots(const uint32 bot_id, std::map<uint16, uint32>& m)
+{
+	if (!bot_id) {
+		return false;
+	}
+
+	const auto& l = BotInventoriesRepository::GetWhere(
+		database,
+		fmt::format(
+			"bot_id = {}",
+			bot_id
+		).c_str()
+	);
+	if (l.empty() || !l[0].inventories_index) {
+		return false;
+	}
+
+	for (const auto& e : l) {
+		m.insert(std::pair<uint16, uint32>(e.slot_id, e.item_id));
+	}
 
 	return true;
 }
@@ -3276,7 +3302,6 @@ const char* BotDatabase::fail::QueryInventoryCount() { return "Failed to query i
 const char* BotDatabase::fail::LoadItems() { return "Failed to load items"; }
 const char* BotDatabase::fail::SaveItems() { return "Failed to save items"; }
 const char* BotDatabase::fail::DeleteItems() { return "Failed to delete items"; }
-const char* BotDatabase::fail::LoadItemBySlot() { return "Failed to load item by slot"; }
 const char* BotDatabase::fail::SaveItemBySlot() { return "Failed to save item by slot"; }
 const char* BotDatabase::fail::DeleteItemBySlot() { return "Failed to delete item by slot"; }
 const char* BotDatabase::fail::LoadEquipmentColor() { return "Failed to load equipment color"; }

--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -1373,7 +1373,7 @@ bool BotDatabase::LoadItemSlots(const uint32 bot_id, std::map<uint16, uint32>& m
 		fmt::format(
 			"bot_id = {}",
 			bot_id
-		).c_str()
+		)
 	);
 	if (l.empty() || !l[0].inventories_index) {
 		return false;

--- a/zone/bot_database.h
+++ b/zone/bot_database.h
@@ -89,6 +89,7 @@ public:
 	bool SaveItems(Bot* bot_inst);
 	bool DeleteItems(const uint32 bot_id);
 
+	bool LoadItemSlots(const uint32 bot_id, std::map<uint16, uint32>& m);
 	bool LoadItemBySlot(Bot* bot_inst);
 	bool LoadItemBySlot(const uint32 bot_id, const uint32 slot_id, uint32& item_id);
 	bool SaveItemBySlot(Bot* bot_inst, const uint32 slot_id, const EQ::ItemInstance* item_inst);
@@ -219,7 +220,6 @@ public:
 		static const char* LoadItems();
 		static const char* SaveItems();
 		static const char* DeleteItems();
-		static const char* LoadItemBySlot();
 		static const char* SaveItemBySlot();
 		static const char* DeleteItemBySlot();
 		static const char* LoadEquipmentColor();


### PR DESCRIPTION
# Before
![image](https://user-images.githubusercontent.com/89047260/204163406-aa0fe734-57ca-4d70-a56b-329c5c1c1d85.png)

# After
![image](https://user-images.githubusercontent.com/89047260/204163421-9a24fccd-f291-4864-bdef-8c5ee5e4b5c3.png)

# Notes
- Bots previously were running 23 individual queries to load their inventory versus grabbing their inventory all at once and referencing it in memory.