### PR TITLE
[Fix] Clamp Item Ldon Sell Back Rates.

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -2696,10 +2696,9 @@ void Client::Handle_OP_AltCurrencySell(const EQApplicationPacket *app)
 
 			if (item->ID == inst->GetItem()->ID) {
 				// 06/11/2016 This formula matches RoF2 client side calculation.
-				
-				cost = EQ::Clamp(static_cast<uint32>(ml.alt_currency_cost),
-						static_cast<uint32>((ml.alt_currency_cost + 1) * item->LDoNSellBackRate / 100), 
-						static_cast<uint32>(ml.alt_currency_cost));
+				cost = EQ::Clamp(cost,
+					EQ::ClampUpper(static_cast<uint32>((ml.alt_currency_cost + 1) * item->LDoNSellBackRate / 100), (static_cast<uint32>(ml.alt_currency_cost))),
+					static_cast<uint32>(ml.alt_currency_cost));
 				found = true;
 				break;
 			}
@@ -2804,8 +2803,8 @@ void Client::Handle_OP_AltCurrencySellSelection(const EQApplicationPacket *app)
 
 				if (item->ID == inst->GetItem()->ID) {
 					// 06/11/2016 This formula matches RoF2 client side calculation.
-					cost = EQ::Clamp(static_cast<uint32>(ml.alt_currency_cost),
-							static_cast<uint32>((ml.alt_currency_cost + 1) * item->LDoNSellBackRate / 100), 
+					cost = EQ::Clamp(cost,
+							EQ::ClampUpper(static_cast<uint32>((ml.alt_currency_cost + 1) * item->LDoNSellBackRate / 100), (static_cast<uint32>(ml.alt_currency_cost))),
 							static_cast<uint32>(ml.alt_currency_cost));
 					found = true;
 					break;

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -2212,10 +2212,11 @@ void Client::Handle_OP_AdventureMerchantSell(const EQApplicationPacket *app)
 
 	// 06/11/2016 This formula matches RoF2 client side calculation.
 	uint32 price = EQ::Clamp(
-				price, 
+				price,
 				EQ::ClampUpper(
 					(item->LDoNPrice + 1) * item->LDoNSellBackRate / 100, item->LDoNPrice),
-					 item->LDoNPrice);
+					item->LDoNPrice
+				);
 
 	if (price == 0)
 	{
@@ -2703,7 +2704,7 @@ void Client::Handle_OP_AltCurrencySell(const EQApplicationPacket *app)
 			cost = EQ::Clamp(
 				cost,
 				EQ::ClampUpper(
-					static_cast<uint32>((ml.alt_currency_cost + 1) * item->LDoNSellBackRate / 100),\
+					static_cast<uint32>((ml.alt_currency_cost + 1) * item->LDoNSellBackRate / 100),
 					static_cast<uint32>(ml.alt_currency_cost)
 				),
 				static_cast<uint32>(ml.alt_currency_cost)
@@ -2815,7 +2816,7 @@ void Client::Handle_OP_AltCurrencySellSelection(const EQApplicationPacket *app)
 				cost = EQ::Clamp(
 					cost,
 					EQ::ClampUpper(
-						static_cast<uint32>((ml.alt_currency_cost + 1) * item->LDoNSellBackRate / 100),\
+						static_cast<uint32>((ml.alt_currency_cost + 1) * item->LDoNSellBackRate / 100),
 						static_cast<uint32>(ml.alt_currency_cost)
 					),
 					static_cast<uint32>(ml.alt_currency_cost)

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -2211,7 +2211,7 @@ void Client::Handle_OP_AdventureMerchantSell(const EQApplicationPacket *app)
 	}
 
 	// 06/11/2016 This formula matches RoF2 client side calculation.
-	int32 price = EQ::Clamp(item->LDoNPrice, (item->LDoNPrice + 1) * item->LDoNSellBackRate / 100, item->LDoNPrice);
+	int32 price = EQ::Clamp(static_cast<uint32>(price), EQ::ClampUpper((item->LDoNPrice + 1) * item->LDoNSellBackRate / 100, item->LDoNPrice), item->LDoNPrice);
 
 	if (price == 0)
 	{

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -2211,7 +2211,7 @@ void Client::Handle_OP_AdventureMerchantSell(const EQApplicationPacket *app)
 	}
 
 	// 06/11/2016 This formula matches RoF2 client side calculation.
-	int32 price = EQ::Clamp(static_cast<uint32>(price), EQ::ClampUpper((item->LDoNPrice + 1) * item->LDoNSellBackRate / 100, item->LDoNPrice), item->LDoNPrice);
+	uint32 price = EQ::Clamp(price, EQ::ClampUpper((item->LDoNPrice + 1) * item->LDoNSellBackRate / 100, item->LDoNPrice), item->LDoNPrice);
 
 	if (price == 0)
 	{

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -2211,7 +2211,7 @@ void Client::Handle_OP_AdventureMerchantSell(const EQApplicationPacket *app)
 	}
 
 	// 06/11/2016 This formula matches RoF2 client side calculation.
-	int32 price = (item->LDoNPrice + 1) * item->LDoNSellBackRate / 100;
+	int32 price = EQ::Clamp(item->LDoNPrice, (item->LDoNPrice + 1) * item->LDoNSellBackRate / 100, item->LDoNPrice);
 
 	if (price == 0)
 	{
@@ -2696,7 +2696,10 @@ void Client::Handle_OP_AltCurrencySell(const EQApplicationPacket *app)
 
 			if (item->ID == inst->GetItem()->ID) {
 				// 06/11/2016 This formula matches RoF2 client side calculation.
-				cost = (ml.alt_currency_cost + 1) * item->LDoNSellBackRate / 100;
+				
+				cost = EQ::Clamp(static_cast<size_t>(ml.alt_currency_cost),
+						static_cast<size_t>((ml.alt_currency_cost + 1) * item->LDoNSellBackRate / 100), 
+						static_cast<size_t>(ml.alt_currency_cost));
 				found = true;
 				break;
 			}
@@ -2801,7 +2804,9 @@ void Client::Handle_OP_AltCurrencySellSelection(const EQApplicationPacket *app)
 
 				if (item->ID == inst->GetItem()->ID) {
 					// 06/11/2016 This formula matches RoF2 client side calculation.
-					cost = (ml.alt_currency_cost + 1) * item->LDoNSellBackRate / 100;
+					cost = EQ::Clamp(static_cast<size_t>(ml.alt_currency_cost),
+							static_cast<size_t>((ml.alt_currency_cost + 1) * item->LDoNSellBackRate / 100), 
+							static_cast<size_t>(ml.alt_currency_cost));
 					found = true;
 					break;
 				}

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -2697,9 +2697,9 @@ void Client::Handle_OP_AltCurrencySell(const EQApplicationPacket *app)
 			if (item->ID == inst->GetItem()->ID) {
 				// 06/11/2016 This formula matches RoF2 client side calculation.
 				
-				cost = EQ::Clamp(static_cast<size_t>(ml.alt_currency_cost),
-						static_cast<size_t>((ml.alt_currency_cost + 1) * item->LDoNSellBackRate / 100), 
-						static_cast<size_t>(ml.alt_currency_cost));
+				cost = EQ::Clamp(static_cast<uint32>(ml.alt_currency_cost),
+						static_cast<uint32>((ml.alt_currency_cost + 1) * item->LDoNSellBackRate / 100), 
+						static_cast<uint32>(ml.alt_currency_cost));
 				found = true;
 				break;
 			}
@@ -2804,9 +2804,9 @@ void Client::Handle_OP_AltCurrencySellSelection(const EQApplicationPacket *app)
 
 				if (item->ID == inst->GetItem()->ID) {
 					// 06/11/2016 This formula matches RoF2 client side calculation.
-					cost = EQ::Clamp(static_cast<size_t>(ml.alt_currency_cost),
-							static_cast<size_t>((ml.alt_currency_cost + 1) * item->LDoNSellBackRate / 100), 
-							static_cast<size_t>(ml.alt_currency_cost));
+					cost = EQ::Clamp(static_cast<uint32>(ml.alt_currency_cost),
+							static_cast<uint32>((ml.alt_currency_cost + 1) * item->LDoNSellBackRate / 100), 
+							static_cast<uint32>(ml.alt_currency_cost));
 					found = true;
 					break;
 				}

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -2214,8 +2214,8 @@ void Client::Handle_OP_AdventureMerchantSell(const EQApplicationPacket *app)
 	uint32 price = EQ::Clamp(
 		price,
 		EQ::ClampUpper(
-		(item->LDoNPrice + 1) * item->LDoNSellBackRate / 100,
-		item->LDoNPrice
+			(item->LDoNPrice + 1) * item->LDoNSellBackRate / 100,
+			item->LDoNPrice
 		),
 		item->LDoNPrice
 	);

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -2212,11 +2212,13 @@ void Client::Handle_OP_AdventureMerchantSell(const EQApplicationPacket *app)
 
 	// 06/11/2016 This formula matches RoF2 client side calculation.
 	uint32 price = EQ::Clamp(
-				price,
-				EQ::ClampUpper(
-					(item->LDoNPrice + 1) * item->LDoNSellBackRate / 100, item->LDoNPrice),
-					item->LDoNPrice
-				);
+		price,
+		EQ::ClampUpper(
+		(item->LDoNPrice + 1) * item->LDoNSellBackRate / 100,
+		item->LDoNPrice
+		),
+		item->LDoNPrice
+	);
 
 	if (price == 0)
 	{
@@ -2701,14 +2703,14 @@ void Client::Handle_OP_AltCurrencySell(const EQApplicationPacket *app)
 
 			if (item->ID == inst->GetItem()->ID) {
 				// 06/11/2016 This formula matches RoF2 client side calculation.
-			cost = EQ::Clamp(
-				cost,
-				EQ::ClampUpper(
-					static_cast<uint32>((ml.alt_currency_cost + 1) * item->LDoNSellBackRate / 100),
+				cost = EQ::Clamp(
+					cost,
+					EQ::ClampUpper(
+						static_cast<uint32>((ml.alt_currency_cost + 1) * item->LDoNSellBackRate / 100),
+						static_cast<uint32>(ml.alt_currency_cost)
+					),
 					static_cast<uint32>(ml.alt_currency_cost)
-				),
-				static_cast<uint32>(ml.alt_currency_cost)
-			);
+				);
 				found = true;
 				break;
 			}
@@ -2813,14 +2815,14 @@ void Client::Handle_OP_AltCurrencySellSelection(const EQApplicationPacket *app)
 
 				if (item->ID == inst->GetItem()->ID) {
 					// 06/11/2016 This formula matches RoF2 client side calculation.
-				cost = EQ::Clamp(
-					cost,
-					EQ::ClampUpper(
-						static_cast<uint32>((ml.alt_currency_cost + 1) * item->LDoNSellBackRate / 100),
+					cost = EQ::Clamp(
+						cost,
+						EQ::ClampUpper(
+							static_cast<uint32>((ml.alt_currency_cost + 1) * item->LDoNSellBackRate / 100),
+							static_cast<uint32>(ml.alt_currency_cost)
+						),
 						static_cast<uint32>(ml.alt_currency_cost)
-					),
-					static_cast<uint32>(ml.alt_currency_cost)
-				);
+					);
 					found = true;
 					break;
 				}

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -2211,7 +2211,11 @@ void Client::Handle_OP_AdventureMerchantSell(const EQApplicationPacket *app)
 	}
 
 	// 06/11/2016 This formula matches RoF2 client side calculation.
-	uint32 price = EQ::Clamp(price, EQ::ClampUpper((item->LDoNPrice + 1) * item->LDoNSellBackRate / 100, item->LDoNPrice), item->LDoNPrice);
+	uint32 price = EQ::Clamp(
+				price, 
+				EQ::ClampUpper(
+					(item->LDoNPrice + 1) * item->LDoNSellBackRate / 100, item->LDoNPrice),
+					 item->LDoNPrice);
 
 	if (price == 0)
 	{
@@ -2696,9 +2700,14 @@ void Client::Handle_OP_AltCurrencySell(const EQApplicationPacket *app)
 
 			if (item->ID == inst->GetItem()->ID) {
 				// 06/11/2016 This formula matches RoF2 client side calculation.
-				cost = EQ::Clamp(cost,
-					EQ::ClampUpper(static_cast<uint32>((ml.alt_currency_cost + 1) * item->LDoNSellBackRate / 100), (static_cast<uint32>(ml.alt_currency_cost))),
-					static_cast<uint32>(ml.alt_currency_cost));
+			cost = EQ::Clamp(
+				cost,
+				EQ::ClampUpper(
+					static_cast<uint32>((ml.alt_currency_cost + 1) * item->LDoNSellBackRate / 100),\
+					static_cast<uint32>(ml.alt_currency_cost)
+				),
+				static_cast<uint32>(ml.alt_currency_cost)
+			);
 				found = true;
 				break;
 			}
@@ -2803,9 +2812,14 @@ void Client::Handle_OP_AltCurrencySellSelection(const EQApplicationPacket *app)
 
 				if (item->ID == inst->GetItem()->ID) {
 					// 06/11/2016 This formula matches RoF2 client side calculation.
-					cost = EQ::Clamp(cost,
-							EQ::ClampUpper(static_cast<uint32>((ml.alt_currency_cost + 1) * item->LDoNSellBackRate / 100), (static_cast<uint32>(ml.alt_currency_cost))),
-							static_cast<uint32>(ml.alt_currency_cost));
+				cost = EQ::Clamp(
+					cost,
+					EQ::ClampUpper(
+						static_cast<uint32>((ml.alt_currency_cost + 1) * item->LDoNSellBackRate / 100),\
+						static_cast<uint32>(ml.alt_currency_cost)
+					),
+					static_cast<uint32>(ml.alt_currency_cost)
+				);
 					found = true;
 					break;
 				}


### PR DESCRIPTION
Clamp Item Ldon Sell Back Rates to prevent potential abuse if set to 100 or higher, could return more then the item is originally sold for.