### PR TITLE
[Quest API] Add WearChange Overloads to Perl/Lua.

### DIFF
--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -65,7 +65,7 @@ void Lua_Mob::SetLevel(int level, bool command) {
 	self->SetLevel(level, command);
 }
 
-void Lua_Mob::SendWearChange(int material_slot) {
+void Lua_Mob::SendWearChange(uint8 material_slot) {
 	Lua_Safe_Call_Void();
 	self->SendWearChange(material_slot);
 }
@@ -1866,17 +1866,17 @@ void Lua_Mob::SetSlotTint(int material_slot, int red_tint, int green_tint, int b
 	self->SetSlotTint(material_slot, red_tint, green_tint, blue_tint);
 }
 
-void Lua_Mob::WearChange(int material_slot, int texture) {
+void Lua_Mob::WearChange(uint8 material_slot, uint16 texture) {
 	Lua_Safe_Call_Void();
 	self->WearChange(material_slot, texture);
 }
 
-void Lua_Mob::WearChange(int material_slot, int texture, uint32 color) {
+void Lua_Mob::WearChange(uint8 material_slot, uint16 texture, uint32 color) {
 	Lua_Safe_Call_Void();
 	self->WearChange(material_slot, texture, color);
 }
 
-void Lua_Mob::WearChange(int material_slot, int texture, uint32 color, uint32 heros_forge_model) {
+void Lua_Mob::WearChange(uint8 material_slot, uint16 texture, uint32 color, uint32 heros_forge_model) {
 	Lua_Safe_Call_Void();
 	self->WearChange(material_slot, texture, color, heros_forge_model);
 }
@@ -3178,6 +3178,7 @@ luabind::scope lua_register_mob() {
 	.def("SetSeeInvisibleUndeadLevel", (void(Lua_Mob::*)(uint8))&Lua_Mob::SetSeeInvisibleUndeadLevel)
 	.def("SendAppearanceEffect", (void(Lua_Mob::*)(uint32,uint32,uint32,uint32,uint32))&Lua_Mob::SendAppearanceEffect)
 	.def("SendAppearanceEffect", (void(Lua_Mob::*)(uint32,uint32,uint32,uint32,uint32,Lua_Client))&Lua_Mob::SendAppearanceEffect)
+	.def("SendWearChange", (void(Lua_Mob::*)(uint8))&Lua_Mob::SendWearChange)
 	.def("SendBeginCast", &Lua_Mob::SendBeginCast)
 	.def("SendIllusionPacket", (void(Lua_Mob::*)(luabind::adl::object))&Lua_Mob::SendIllusionPacket)
 	.def("SendSpellEffect", (void(Lua_Mob::*)(uint32,uint32,uint32,bool,uint32))&Lua_Mob::SendSpellEffect)
@@ -3249,9 +3250,9 @@ luabind::scope lua_register_mob() {
 	.def("TryMoveAlong", (void(Lua_Mob::*)(float,float,bool))&Lua_Mob::TryMoveAlong)
 	.def("UnStun", (void(Lua_Mob::*)(void))&Lua_Mob::UnStun)
 	.def("WalkTo", (void(Lua_Mob::*)(double, double, double))&Lua_Mob::WalkTo)
-	.def("WearChange", (void(Lua_Mob::*)(int,int))&Lua_Mob::WearChange)
-	.def("WearChange", (void(Lua_Mob::*)(int,int,uint32))&Lua_Mob::WearChange)
-	.def("WearChange", (void(Lua_Mob::*)(int,int,uint32,uint32))&Lua_Mob::WearChange)
+	.def("WearChange", (void(Lua_Mob::*)(uint8,uint16))&Lua_Mob::WearChange)
+	.def("WearChange", (void(Lua_Mob::*)(uint8,uint16,uint32))&Lua_Mob::WearChange)
+	.def("WearChange", (void(Lua_Mob::*)(uint8,uint16,uint32,uint32))&Lua_Mob::WearChange)
 	.def("WipeHateList", (void(Lua_Mob::*)(void))&Lua_Mob::WipeHateList);
 }
 

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -1866,9 +1866,19 @@ void Lua_Mob::SetSlotTint(int material_slot, int red_tint, int green_tint, int b
 	self->SetSlotTint(material_slot, red_tint, green_tint, blue_tint);
 }
 
+void Lua_Mob::WearChange(int material_slot, int texture) {
+	Lua_Safe_Call_Void();
+	self->WearChange(material_slot, texture);
+}
+
 void Lua_Mob::WearChange(int material_slot, int texture, uint32 color) {
 	Lua_Safe_Call_Void();
 	self->WearChange(material_slot, texture, color);
+}
+
+void Lua_Mob::WearChange(int material_slot, int texture, uint32 color, uint32 heros_forge_model) {
+	Lua_Safe_Call_Void();
+	self->WearChange(material_slot, texture, color, heros_forge_model);
 }
 
 void Lua_Mob::DoKnockback(Lua_Mob caster, uint32 push_back, uint32 push_up) {
@@ -3239,7 +3249,9 @@ luabind::scope lua_register_mob() {
 	.def("TryMoveAlong", (void(Lua_Mob::*)(float,float,bool))&Lua_Mob::TryMoveAlong)
 	.def("UnStun", (void(Lua_Mob::*)(void))&Lua_Mob::UnStun)
 	.def("WalkTo", (void(Lua_Mob::*)(double, double, double))&Lua_Mob::WalkTo)
+	.def("WearChange", (void(Lua_Mob::*)(int,int))&Lua_Mob::WearChange)
 	.def("WearChange", (void(Lua_Mob::*)(int,int,uint32))&Lua_Mob::WearChange)
+	.def("WearChange", (void(Lua_Mob::*)(int,int,uint32,uint32))&Lua_Mob::WearChange)
 	.def("WipeHateList", (void(Lua_Mob::*)(void))&Lua_Mob::WipeHateList);
 }
 

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -46,7 +46,7 @@ public:
 	bool BehindMob(Lua_Mob other, float x, float y);
 	void SetLevel(int level);
 	void SetLevel(int level, bool command);
-	void SendWearChange(int material_slot);
+	void SendWearChange(uint8 material_slot);
 	bool IsMoving();
 	bool IsFeared();
 	bool IsBlind();
@@ -377,9 +377,9 @@ public:
 	void TarGlobal(const char *varname, const char *value, const char *duration, int npc_id, int char_id, int zone_id);
 	void DelGlobal(const char *varname);
 	void SetSlotTint(int material_slot, int red_tint, int green_tint, int blue_tint);
-	void WearChange(int material_slot, int texture);
-	void WearChange(int material_slot, int texture, uint32 color);
-	void WearChange(int material_slot, int texture, uint32 color, uint32 heros_forge_model);
+	void WearChange(uint8 material_slot, uint16 texture);
+	void WearChange(uint8 material_slot, uint16 texture, uint32 color);
+	void WearChange(uint8 material_slot, uint16 texture, uint32 color, uint32 heros_forge_model);
 	void DoKnockback(Lua_Mob caster, uint32 push_back, uint32 push_up);
 	void AddNimbusEffect(int effect_id);
 	void RemoveNimbusEffect(int effect_id);

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -377,7 +377,9 @@ public:
 	void TarGlobal(const char *varname, const char *value, const char *duration, int npc_id, int char_id, int zone_id);
 	void DelGlobal(const char *varname);
 	void SetSlotTint(int material_slot, int red_tint, int green_tint, int blue_tint);
+	void WearChange(int material_slot, int texture);
 	void WearChange(int material_slot, int texture, uint32 color);
+	void WearChange(int material_slot, int texture, uint32 color, uint32 heros_forge_model);
 	void DoKnockback(Lua_Mob caster, uint32 push_back, uint32 push_up);
 	void AddNimbusEffect(int effect_id);
 	void RemoveNimbusEffect(int effect_id);

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -296,7 +296,7 @@ public:
 	virtual void SendTextureWC(uint8 slot, uint16 texture, uint32 hero_forge_model = 0, uint32 elite_material = 0, uint32 unknown06 = 0, uint32 unknown18 = 0);
 	virtual void SendWearChange(uint8 material_slot, Client *one_client = nullptr);
 	virtual void SetSlotTint(uint8 material_slot, uint8 red_tint, uint8 green_tint, uint8 blue_tint);
-	virtual void WearChange(uint8 material_slot, uint16 texture, uint32 color, uint32 hero_forge_model = 0);
+	virtual void WearChange(uint8 material_slot, uint16 texture, uint32 color = 0, uint32 hero_forge_model = 0);
 
 	void ChangeSize(float in_size, bool bNoRestriction = false);
 	void DoAnim(const int animation_id, int animation_speed = 0, bool ackreq = true, eqFilterType filter = FilterNone);

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -1938,6 +1938,11 @@ void Perl_Mob_SetSlotTint(Mob* self, uint8 material_slot, uint8 red_tint, uint8 
 	self->SetSlotTint(material_slot, red_tint, green_tint, blue_tint);
 }
 
+void Perl_Mob_WearChange(Mob* self, uint8 material_slot, uint16 texture) // @categories Script Utility
+{
+	self->WearChange(material_slot, texture);
+}
+
 void Perl_Mob_WearChange(Mob* self, uint8 material_slot, uint16 texture, uint32 color) // @categories Script Utility
 {
 	self->WearChange(material_slot, texture, color);
@@ -3279,6 +3284,7 @@ void perl_register_mob()
 	package.add("TypesTempPet", (void(*)(Mob*, uint32, const char*, uint32, bool, Mob*))&Perl_Mob_TypesTempPet);
 	package.add("TypesTempPet", (void(*)(Mob*, uint32, const char*, uint32, bool, Mob*, bool))&Perl_Mob_TypesTempPet);
 	package.add("WalkTo", &Perl_Mob_WalkTo);
+	package.add("WearChange", (void(*)(Mob*, uint8, uint16))&Perl_Mob_WearChange);
 	package.add("WearChange", (void(*)(Mob*, uint8, uint16, uint32))&Perl_Mob_WearChange);
 	package.add("WearChange", (void(*)(Mob*, uint8, uint16, uint32, uint32))&Perl_Mob_WearChange);
 	package.add("WipeHateList", &Perl_Mob_WipeHateList);


### PR DESCRIPTION
# Perl
- Add `$mob->WearChange(slot, texture)`.

# Lua
- Add `mob:WearChange(slot, texture)`.
- Add `mob:WearChange(slot, texture, color, heros_forge_model)`.
- Add `mob:SendWearChange(slot)`.

# Notes
- These overloads allow you to not have to send color.
- Lua didn't have an overload with Hero's Forge Model.
- SendWearChange existed in Lua, it just didn't have a definition.