### PR TITLE
[Bug Fix] Add SE_MakeDrunk to avoid error message.

### DIFF
--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -374,13 +374,16 @@ bool IsAEDurationSpell(uint16 spell_id)
 		There are plenty of spells with aoe_duration set at single digit numbers, but these
 		do not act as duration effects.
 	*/
-	if (IsValidSpell(spell_id) && 
+	if (
+		IsValidSpell(spell_id) &&
 		spells[spell_id].aoe_duration >= 2500 &&
-		(	spells[spell_id].target_type == ST_AETarget || 
+		(
+			spells[spell_id].target_type == ST_AETarget ||
 			spells[spell_id].target_type == ST_UndeadAE ||
 			spells[spell_id].target_type == ST_AECaster ||
-			spells[spell_id].target_type == ST_Ring)
-		) {
+			spells[spell_id].target_type == ST_Ring
+		)
+	) {
 		return true;
 	}
 
@@ -1482,6 +1485,7 @@ bool IsInstrumentModAppliedToSpellEffect(int32 spell_id, int effect)
 		case SE_WaterBreathing:
 		case SE_ModelSize:
 		case SE_ChangeHeight:
+		case SE_MakeDrunk:
 			return false;
 		default:
 			return true;
@@ -1494,15 +1498,17 @@ bool IsPulsingBardSong(int32 spell_id)
 	if (!IsValidSpell(spell_id)) {
 		return false;
 	}
-	
-	if (spells[spell_id].buff_duration == 0xFFFF ||
+
+	if (
+		spells[spell_id].buff_duration == 0xFFFF ||
 		spells[spell_id].recast_time> 0 ||
-		spells[spell_id].mana > 0 || 
-		IsEffectInSpell(spell_id, SE_TemporaryPets) || 
-		IsEffectInSpell(spell_id, SE_Familiar)) {
+		spells[spell_id].mana > 0 ||
+		IsEffectInSpell(spell_id, SE_TemporaryPets) ||
+		IsEffectInSpell(spell_id, SE_Familiar)
+	) {
 		return false;
 	}
-	
+
 	return true;
 }
 

--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -1501,7 +1501,7 @@ bool IsPulsingBardSong(int32 spell_id)
 
 	if (
 		spells[spell_id].buff_duration == 0xFFFF ||
-		spells[spell_id].recast_time> 0 ||
+		spells[spell_id].recast_time > 0 ||
 		spells[spell_id].mana > 0 ||
 		IsEffectInSpell(spell_id, SE_TemporaryPets) ||
 		IsEffectInSpell(spell_id, SE_Familiar)

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -894,7 +894,7 @@ typedef enum {
 #define SE_SpellDamageShield			157	// implemented, @DS, causes non-melee damage on caster of a spell, base: Amt DS (negative), limit: none, max: unknown (same as base but +)
 #define SE_Reflect						158 // implemented, @SpellMisc, reflect casted detrimental spell back at caster, base: chance pct, limit: resist modifier (positive value reduces resists), max: pct of base dmg mod (50=50pct of base)
 #define SE_AllStats						159	// implemented
-//#define SE_MakeDrunk					160 // *not implemented - Effect works entirely client side (Should check against tolerance)
+#define SE_MakeDrunk					160 // *not implemented - Effect works entirely client side (Should check against tolerance)
 #define SE_MitigateSpellDamage			161	// implemented, @Runes, mitigate incoming spell damage by percentage until rune fades, base: percent mitigation, limit: max dmg absorbed per hit, max: rune amt, Note: If placed on item or AA, will provide stackable percent mitigation.
 #define SE_MitigateMeleeDamage			162	// implemented - rune with max value
 #define SE_NegateAttacks				163	// implemented
@@ -927,7 +927,7 @@ typedef enum {
 #define SE_EndurancePool				190	// implemented
 #define SE_Amnesia						191	// implemented - Silence vs Melee Effect
 #define SE_Hate							192	// implemented - Instant and hate over time.
-#define SE_SkillAttack					193	// implemented,  
+#define SE_SkillAttack					193	// implemented,
 #define SE_FadingMemories				194	// implemented, @Aggro, Remove from hate lists and make invisible. Can set max level of NPCs that can be affected. base: success chance, limit: max level (ROF2), max: max level (modern client), Note: Support for max level requires Rule (Spells, UseFadingMemoriesMaxLevel) to be true. If used from limit field, then it set as the level, ie. max level of 75 would use limit value of 75. If set from max field, max level 75 would use max value of 1075, if you want to set it so it checks a level range above the spell target then for it to only work on mobs 5 levels or below you set max value to 5.
 #define SE_StunResist					195	// implemented
 #define SE_StrikeThrough				196	// implemented

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -129,10 +129,10 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 	}
 
 #ifdef SPELL_EFFECT_SPAM
-		Message(0, "You are affected by spell '%s' (id %d)", spell.name, spell_id);
+		Message(Chat::White, "You are affected by spell '%s' (id %d)", spell.name, spell_id);
 		if(buffslot >= 0)
 		{
-			Message(0, "Buff slot:  %d  Duration:  %d tics", buffslot, buffs[buffslot].ticsremaining);
+			Message(Chat::White, "Buff slot:  %d  Duration:  %d tics", buffslot, buffs[buffslot].ticsremaining);
 		}
 #endif
 
@@ -3318,12 +3318,12 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Unknown Effect ID %d", effect);
 #else
-				Message(0, "Unknown spell effect %d in spell %s (id %d)", effect, spell.name, spell_id);
+				Message(Chat::White, "Unknown spell effect %d in spell %s (id %d)", effect, spell.name, spell_id);
 #endif
 			}
 		}
 #ifdef SPELL_EFFECT_SPAM
-		Message(0, ". . . Effect #%i: %s", i + 1, (effect_desc && effect_desc[0]) ? effect_desc : "Unknown");
+		Message(Chat::White, ". . . Effect #%i: %s", i + 1, (effect_desc && effect_desc[0]) ? effect_desc : "Unknown");
 #endif
 	}
 
@@ -6973,7 +6973,7 @@ bool Mob::TryDeathSave() {
 					HealAmt = GetMaxHP() - GetHP();
 
 				SetHP((GetHP()+HealAmt));
-				Message(263, "The gods have healed you for %i points of damage.", HealAmt);
+				Message(Chat::Emote, "The gods have healed you for %i points of damage.", HealAmt);
 
 				if(spellbonuses.DeathSave[SBIndex::DEATH_SAVE_TYPE] == 2)
 					entity_list.MessageCloseString(
@@ -7012,7 +7012,7 @@ bool Mob::TryDeathSave() {
 						HealAmt = GetMaxHP() - GetHP();
 
 					SetHP((GetHP()+HealAmt));
-					Message(263, "The gods have healed you for %i points of damage.", HealAmt);
+					Message(Chat::Emote, "The gods have healed you for %i points of damage.", HealAmt);
 
 					if(spellbonuses.DeathSave[SBIndex::DEATH_SAVE_TYPE] == 2)
 						entity_list.MessageCloseString(

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -3072,6 +3072,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 			case SE_ResistCold:
 			case SE_ResistFire:
 			case SE_AllStats:
+			case SE_MakeDrunk:
 			case SE_CHA:
 			case SE_WIS:
 			case SE_INT:


### PR DESCRIPTION
Currently sends error message about unknown spell effect ID.