### PR TITLE
[Bug Fix] Fix Bot ^spellsettingsadd command

### DIFF
--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -10342,7 +10342,7 @@ void bot_command_spell_settings_add(Client *c, const Seperator *sep)
 	bs.min_hp = min_hp;
 	bs.max_hp = max_hp;
 
-	if (!my_bot->UpdateBotSpellSetting(spell_id, &bs)) {
+	if (!my_bot->AddBotSpellSetting(spell_id, &bs)) {
 		c->Message(
 			Chat::White,
 			fmt::format(


### PR DESCRIPTION
Fix for ^spellsettingsadd Bot command to work. couldn't add new entries as ^spellsettingsupdate requires a Spell List entry to exist.

![image](https://user-images.githubusercontent.com/109764533/205140392-d45bdb7e-2367-45a5-a992-697a0ad58868.png)
