### PR TITLE
[Quest API] Add GetGuildPublicNote() to Perl/Lua.

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -11977,3 +11977,17 @@ void Client::SetSpellDuration(
 		m->SetBuffDuration(spell_id, duration);
 	}
 }
+
+std::string Client::GetGuildPublicNote()
+{
+	if (!IsInAGuild()) {
+		return std::string();
+	}
+
+	CharGuildInfo gci;
+	if (!guild_mgr.GetCharInfo(character_id, gci)) {
+		return std::string();
+	}
+
+	return gci.public_note;
+}

--- a/zone/client.h
+++ b/zone/client.h
@@ -1667,6 +1667,8 @@ public:
 
 	std::map<std::string,std::string> GetMerchantDataBuckets();
 
+	std::string GetGuildPublicNote();
+
 protected:
 	friend class Mob;
 	void CalcItemBonuses(StatBonuses* newbon);

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -2855,6 +2855,12 @@ luabind::object Lua_Client::GetZoneFlags(lua_State* L) {
 	return t;
 }
 
+std::string Lua_Client::GetGuildPublicNote()
+{
+	Lua_Safe_Call_String();
+	return self->GetGuildPublicNote();
+}
+
 #ifdef BOTS
 
 int Lua_Client::GetBotRequiredLevel()
@@ -3112,6 +3118,7 @@ luabind::scope lua_register_client() {
 	.def("GetGMStatus", (int16(Lua_Client::*)(void))&Lua_Client::GetGMStatus)
 	.def("GetGroup", (Lua_Group(Lua_Client::*)(void))&Lua_Client::GetGroup)
 	.def("GetGroupPoints", (uint32(Lua_Client::*)(void))&Lua_Client::GetGroupPoints)
+	.def("GetGuildPublicNote", (std::string(Lua_Client::*)(void))&Lua_Client::GetGuildPublicNote)
 	.def("GetHorseId", (int(Lua_Client::*)(void))&Lua_Client::GetHorseId)
 	.def("GetHealAmount", (int(Lua_Client::*)(void))&Lua_Client::GetHealAmount)
 	.def("GetHunger", (int(Lua_Client::*)(void))&Lua_Client::GetHunger)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -450,6 +450,7 @@ public:
 	void UpdateAdmin(bool from_database);
 	luabind::object GetPEQZoneFlags(lua_State* L);
 	luabind::object GetZoneFlags(lua_State* L);
+	std::string GetGuildPublicNote();
 
 	void ApplySpell(int spell_id);
 	void ApplySpell(int spell_id, int duration);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -2732,6 +2732,11 @@ perl::array Perl_Client_GetZoneFlags(Client* self)
 	return a;
 }
 
+std::string Perl_Client_GetGuildPublicNote(Client* self)
+{
+	return self->GetGuildPublicNote();
+}
+
 #ifdef BOTS
 
 int Perl_Client_GetBotRequiredLevel(Client* self)
@@ -2981,6 +2986,7 @@ void perl_register_client()
 	package.add("GetGMStatus", &Perl_Client_GetGMStatus);
 	package.add("GetGroup", &Perl_Client_GetGroup);
 	package.add("GetGroupPoints", &Perl_Client_GetGroupPoints);
+	package.add("GetGuildPublicNote", &Perl_Client_GetGuildPublicNote);
 	package.add("GetHorseId", &Perl_Client_GetHorseId);
 	package.add("GetHealAmount", &Perl_Client_GetHealAmount);
 	package.add("GetHunger", &Perl_Client_GetHunger);


### PR DESCRIPTION
# Perl
- Add `$client->GetGuildPublicNote()`.

# Lua
- Add `client:GetGuildPublicNote()`.

# Notes
- Allows operators to grab a player's public note in there guild if they wanted to.