### PR TITLE
[Quest API] Add Entity Variable Methods to Perl/Lua.

### DIFF
--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -2699,6 +2699,16 @@ luabind::object Lua_Mob::GetEntityVariables(lua_State* L) {
 	return t;
 }
 
+bool Lua_Mob::ClearEntityVariables() {
+	Lua_Safe_Call_Bool();
+	return self->ClearEntityVariables();
+}
+
+bool Lua_Mob::DeleteEntityVariable(std::string variable_name) {
+	Lua_Safe_Call_Bool();
+	return self->DeleteEntityVariable(variable_name);
+}
+
 void Lua_Mob::SetEntityVariable(std::string variable_name, std::string variable_value) {
 	Lua_Safe_Call_Void();
 	self->SetEntityVariable(variable_name, variable_value);
@@ -2855,6 +2865,7 @@ luabind::scope lua_register_mob() {
 	.def("CheckLoSToLoc", (bool(Lua_Mob::*)(double,double,double))&Lua_Mob::CheckLoSToLoc)
 	.def("CheckLoSToLoc", (bool(Lua_Mob::*)(double,double,double,double))&Lua_Mob::CheckLoSToLoc)
 	.def("CheckNumHitsRemaining", &Lua_Mob::CheckNumHitsRemaining)
+	.def("ClearEntityVariables", (bool(Lua_Mob::*)(void))&Lua_Mob::ClearEntityVariables)
 	.def("ClearSpecialAbilities", (void(Lua_Mob::*)(void))&Lua_Mob::ClearSpecialAbilities)
 	.def("CloneAppearance", (void(Lua_Mob::*)(Lua_Mob))&Lua_Mob::CloneAppearance)
 	.def("CloneAppearance", (void(Lua_Mob::*)(Lua_Mob,bool))&Lua_Mob::CloneAppearance)
@@ -2901,6 +2912,7 @@ luabind::scope lua_register_mob() {
 	.def("DamageHateListPercentage", (void(Lua_Mob::*)(int64,uint32))&Lua_Mob::DamageHateListPercentage)
 	.def("DelGlobal", (void(Lua_Mob::*)(const char*))&Lua_Mob::DelGlobal)
 	.def("DeleteBucket", (void(Lua_Mob::*)(std::string))&Lua_Mob::DeleteBucket)
+	.def("DeleteEntityVariable", (bool(Lua_Mob::*)(std::string))&Lua_Mob::DeleteEntityVariable)
 	.def("Depop", (void(Lua_Mob::*)(bool))&Lua_Mob::Depop)
 	.def("Depop", (void(Lua_Mob::*)(void))&Lua_Mob::Depop)
 	.def("DivineAura", (bool(Lua_Mob::*)(void))&Lua_Mob::DivineAura)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -301,6 +301,8 @@ public:
 	bool SetAA(int rank_id, int new_value, int charges);
 	bool DivineAura();
 	void SetOOCRegen(int64 new_ooc_regen);
+	bool ClearEntityVariables();
+	bool DeleteEntityVariable(std::string variable_name);
 	std::string GetEntityVariable(std::string variable_name);
 	luabind::object GetEntityVariables(lua_State* L);
 	void SetEntityVariable(std::string variable_name, std::string variable_value);

--- a/zone/lua_object.cpp
+++ b/zone/lua_object.cpp
@@ -183,6 +183,16 @@ luabind::object Lua_Object::GetEntityVariables(lua_State* L) {
 	return t;
 }
 
+bool Lua_Object::ClearEntityVariables() {
+	Lua_Safe_Call_Bool();
+	return self->ClearEntityVariables();
+}
+
+bool Lua_Object::DeleteEntityVariable(std::string variable_name) {
+	Lua_Safe_Call_Bool();
+	return self->DeleteEntityVariable(variable_name);
+}
+
 void Lua_Object::SetEntityVariable(std::string variable_name, std::string variable_value) {
 	Lua_Safe_Call_Void();
 	self->SetEntityVariable(variable_name, variable_value);
@@ -198,10 +208,12 @@ luabind::scope lua_register_object() {
 	.def(luabind::constructor<>())
 	.property("null", &Lua_Object::Null)
 	.property("valid", &Lua_Object::Valid)
+	.def("ClearEntityVariables", (bool(Lua_Object::*)(void))&Lua_Object::ClearEntityVariables)
 	.def("ClearUser", (void(Lua_Object::*)(void))&Lua_Object::ClearUser)
 	.def("Close", (void(Lua_Object::*)(void))&Lua_Object::Close)
 	.def("Delete", (void(Lua_Object::*)(bool))&Lua_Object::Delete)
 	.def("Delete", (void(Lua_Object::*)(void))&Lua_Object::Delete)
+	.def("DeleteEntityVariable", (bool(Lua_Object::*)(std::string))&Lua_Object::DeleteEntityVariable)
 	.def("DeleteItem", (void(Lua_Object::*)(int))&Lua_Object::DeleteItem)
 	.def("Depop", (void(Lua_Object::*)(void))&Lua_Object::Depop)
 	.def("EntityVariableExists", (bool(Lua_Object::*)(std::string))&Lua_Object::EntityVariableExists)

--- a/zone/lua_object.h
+++ b/zone/lua_object.h
@@ -60,6 +60,8 @@ public:
 	void Delete(bool reset_state);
 	bool IsGroundSpawn();
 	void Close();
+	bool ClearEntityVariables();
+	bool DeleteEntityVariable(std::string variable_name);
 	std::string GetEntityVariable(std::string variable_name);
 	luabind::object GetEntityVariables(lua_State* L);
 	void SetEntityVariable(std::string variable_name, std::string variable_value);

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -4473,11 +4473,7 @@ bool Mob::ClearEntityVariables()
 
 bool Mob::DeleteEntityVariable(std::string variable_name)
 {
-	if (m_EntityVariables.empty()) {
-		return false;
-	}
-
-	if (variable_name.empty()) {
+	if (m_EntityVariables.empty() || variable_name.empty()) {
 		return false;
 	}
 
@@ -4492,11 +4488,7 @@ bool Mob::DeleteEntityVariable(std::string variable_name)
 
 std::string Mob::GetEntityVariable(std::string variable_name)
 {
-	if (m_EntityVariables.empty()) {
-		return std::string();
-	}
-
-	if (variable_name.empty()) {
+	if (m_EntityVariables.empty() || variable_name.empty()) {
 		return std::string();
 	}
 
@@ -4524,11 +4516,7 @@ std::vector<std::string> Mob::GetEntityVariables()
 
 bool Mob::EntityVariableExists(std::string variable_name)
 {
-	if (m_EntityVariables.empty()) {
-		return false;
-	}
-
-	if (variable_name.empty()) {
+	if (m_EntityVariables.empty() || variable_name.empty()) {
 		return false;
 	}
 
@@ -4542,6 +4530,10 @@ bool Mob::EntityVariableExists(std::string variable_name)
 
 void Mob::SetEntityVariable(std::string variable_name, std::string variable_value)
 {
+	if (variable_name.empty()) {
+		return;
+	}
+
 	m_EntityVariables[variable_name] = variable_value;
 }
 

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -4461,8 +4461,45 @@ void Mob::SetDelta(const glm::vec4& delta) {
 	m_Delta = delta;
 }
 
+bool Mob::ClearEntityVariables()
+{
+	if (m_EntityVariables.empty()) {
+		return false;
+	}
+
+	m_EntityVariables.clear();
+	return true;
+}
+
+bool Mob::DeleteEntityVariable(std::string variable_name)
+{
+	if (m_EntityVariables.empty()) {
+		return false;
+	}
+
+	if (variable_name.empty()) {
+		return false;
+	}
+
+	auto v = m_EntityVariables.find(variable_name);
+	if (v == m_EntityVariables.end()) {
+		return false;
+	}
+
+	m_EntityVariables.erase(v);
+	return true;
+}
+
 std::string Mob::GetEntityVariable(std::string variable_name)
 {
+	if (m_EntityVariables.empty()) {
+		return std::string();
+	}
+
+	if (variable_name.empty()) {
+		return std::string();
+	}
+
 	const auto& v = m_EntityVariables.find(variable_name);
 	if (v != m_EntityVariables.end()) {
 		return v->second;
@@ -4487,6 +4524,14 @@ std::vector<std::string> Mob::GetEntityVariables()
 
 bool Mob::EntityVariableExists(std::string variable_name)
 {
+	if (m_EntityVariables.empty()) {
+		return false;
+	}
+
+	if (variable_name.empty()) {
+		return false;
+	}
+
 	const auto& v = m_EntityVariables.find(variable_name);
 	if (v != m_EntityVariables.end()) {
 		return true;

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1130,6 +1130,8 @@ public:
 	virtual void AI_ShutDown();
 	virtual void AI_Process();
 
+	bool ClearEntityVariables();
+	bool DeleteEntityVariable(std::string variable_name);
 	std::string GetEntityVariable(std::string variable_name);
 	std::vector<std::string> GetEntityVariables();
 	void SetEntityVariable(std::string variable_name, std::string variable_value);

--- a/zone/object.cpp
+++ b/zone/object.cpp
@@ -1057,13 +1057,41 @@ void Object::SetHeading(float heading)
 	safe_delete(app2);
 }
 
-void Object::SetEntityVariable(std::string variable_name, std::string variable_value)
+bool Object::ClearEntityVariables()
 {
-	o_EntityVariables[variable_name] = variable_value;
+	if (o_EntityVariables.empty()) {
+		return false;
+	}
+
+	o_EntityVariables.clear();
+	return true;
+}
+
+bool Object::DeleteEntityVariable(std::string variable_name)
+{
+	if (o_EntityVariables.empty()) {
+		return false;
+	}
+
+	if (variable_name.empty()) {
+		return false;
+	}
+
+	auto v = o_EntityVariables.find(variable_name);
+	if (v == o_EntityVariables.end()) {
+		return false;
+	}
+
+	o_EntityVariables.erase(v);
+	return true;
 }
 
 std::string Object::GetEntityVariable(std::string variable_name)
 {
+	if (o_EntityVariables.empty()) {
+		return std::string();
+	}
+
 	if (variable_name.empty()) {
 		return std::string();
 	}
@@ -1092,6 +1120,10 @@ std::vector<std::string> Object::GetEntityVariables()
 
 bool Object::EntityVariableExists(std::string variable_name)
 {
+	if (o_EntityVariables.empty()) {
+		return false;
+	}
+
 	if (variable_name.empty()) {
 		return false;
 	}
@@ -1102,4 +1134,9 @@ bool Object::EntityVariableExists(std::string variable_name)
 	}
 
 	return false;
+}
+
+void Object::SetEntityVariable(std::string variable_name, std::string variable_value)
+{
+	o_EntityVariables[variable_name] = variable_value;
 }

--- a/zone/object.cpp
+++ b/zone/object.cpp
@@ -1069,11 +1069,7 @@ bool Object::ClearEntityVariables()
 
 bool Object::DeleteEntityVariable(std::string variable_name)
 {
-	if (o_EntityVariables.empty()) {
-		return false;
-	}
-
-	if (variable_name.empty()) {
+	if (o_EntityVariables.empty() || variable_name.empty()) {
 		return false;
 	}
 
@@ -1088,11 +1084,7 @@ bool Object::DeleteEntityVariable(std::string variable_name)
 
 std::string Object::GetEntityVariable(std::string variable_name)
 {
-	if (o_EntityVariables.empty()) {
-		return std::string();
-	}
-
-	if (variable_name.empty()) {
+	if (o_EntityVariables.empty() || variable_name.empty()) {
 		return std::string();
 	}
 
@@ -1120,11 +1112,7 @@ std::vector<std::string> Object::GetEntityVariables()
 
 bool Object::EntityVariableExists(std::string variable_name)
 {
-	if (o_EntityVariables.empty()) {
-		return false;
-	}
-
-	if (variable_name.empty()) {
+	if (o_EntityVariables.empty() || variable_name.empty()) {
 		return false;
 	}
 
@@ -1138,5 +1126,9 @@ bool Object::EntityVariableExists(std::string variable_name)
 
 void Object::SetEntityVariable(std::string variable_name, std::string variable_value)
 {
+	if (variable_name.empty()) {
+		return;
+	}
+
 	o_EntityVariables[variable_name] = variable_value;
 }

--- a/zone/object.h
+++ b/zone/object.h
@@ -171,6 +171,8 @@ public:
 	void SetDisplayName(const char *in_name);
 	const char *GetDisplayName() const { return m_display_name; }
 
+	bool ClearEntityVariables();
+	bool DeleteEntityVariable(std::string variable_name);
 	std::string GetEntityVariable(std::string variable_name);
 	std::vector<std::string> GetEntityVariables();
 	void SetEntityVariable(std::string variable_name, std::string variable_value);

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -2641,6 +2641,16 @@ perl::array Perl_Mob_GetHateListNPCs(Mob* self, uint32 distance)
 	return result;
 }
 
+bool Perl_Mob_ClearEntityVariables(Mob* self) // @categories Script Utility
+{
+	return self->ClearEntityVariables();
+}
+
+bool Perl_Mob_DeleteEntityVariable(Mob* self, std::string variable_name) // @categories Script Utility
+{
+	return self->DeleteEntityVariable(variable_name);
+}
+
 bool Perl_Mob_EntityVariableExists(Mob* self, std::string variable_name) // @categories Script Utility
 {
 	return self->EntityVariableExists(variable_name);
@@ -2811,6 +2821,7 @@ void perl_register_mob()
 	package.add("CheckLoS", &Perl_Mob_CheckLoS);
 	package.add("CheckLoSToLoc", (bool(*)(Mob*, float, float, float))&Perl_Mob_CheckLoSToLoc);
 	package.add("CheckLoSToLoc", (bool(*)(Mob*, float, float, float, float))&Perl_Mob_CheckLoSToLoc);
+	package.add("ClearEntityVariables", &Perl_Mob_ClearEntityVariables);
 	package.add("ClearFeignMemory", &Perl_Mob_ClearFeignMemory);
 	package.add("ClearSpecialAbilities", &Perl_Mob_ClearSpecialAbilities);
 	package.add("CloneAppearance", (void(*)(Mob*, Mob*))&Perl_Mob_CloneAppearance);
@@ -2858,6 +2869,7 @@ void perl_register_mob()
 	package.add("DamageHateListPercentage", (void(*)(Mob*, int64, uint32))&Perl_Mob_DamageHateListPercentage);
 	package.add("DelGlobal", &Perl_Mob_DelGlobal);
 	package.add("DeleteBucket", &Perl_Mob_DeleteBucket);
+	package.add("DeleteEntityVariable", &Perl_Mob_DeleteEntityVariable);
 	package.add("Depop", (void(*)(Mob*))&Perl_Mob_Depop);
 	package.add("Depop", (void(*)(Mob*, bool))&Perl_Mob_Depop);
 	package.add("DivineAura", &Perl_Mob_DivineAura);

--- a/zone/perl_object.cpp
+++ b/zone/perl_object.cpp
@@ -206,6 +206,16 @@ float Perl_Object_GetTiltY(Object* self) // @categories Objects
 	return self->GetTiltY();
 }
 
+bool Perl_Object_ClearEntityVariables(Object* self) // @categories Script Utility
+{
+	return self->ClearEntityVariables();
+}
+
+bool Perl_Object_DeleteEntityVariable(Object* self, std::string variable_name) // @categories Script Utility
+{
+	return self->DeleteEntityVariable(variable_name);
+}
+
 bool Perl_Object_EntityVariableExists(Object* self, std::string variable_name) // @categories Objects
 {
 	return self->EntityVariableExists(variable_name);
@@ -239,10 +249,12 @@ void perl_register_object()
 
 	auto package = perl.new_class<Object>("Object");
 	package.add_base_class("Entity");
+	package.add("ClearEntityVariables", &Perl_Object_ClearEntityVariables);
 	package.add("ClearUser", &Perl_Object_ClearUser);
 	package.add("Close", &Perl_Object_Close);
 	package.add("Delete", (void(*)(Object*))&Perl_Object_Delete);
 	package.add("Delete", (void(*)(Object*, bool))&Perl_Object_Delete);
+	package.add("DeleteEntityVariable", &Perl_Object_DeleteEntityVariable);
 	package.add("DeleteItem", &Perl_Object_DeleteItem);
 	package.add("Depop", &Perl_Object_Depop);
 	package.add("EntityVariableExists", &Perl_Object_EntityVariableExists);


### PR DESCRIPTION
# Perl
- Add `$mob->ClearEntityVariables()`.
- Add `$mob->DeleteEntityVariable(variable_name)`.
- Add `$object->ClearEntityVariables()`.
- Add `$object->DeleteEntityVariable(variable_name)`.

# Lua
- Add `mob:ClearEntityVariables()`.
- Add `mob:DeleteEntityVariable(variable_name)`.
- Add `object:ClearEntityVariables()`.
- Add `object:DeleteEntityVariable(variable_name)`.

# Notes
- Allows operators to clear all entity variables or delete one by name, previously you just had to set to an empty value to clear after being set.
- These methods return a `bool` so they can be used conditionally if somehow the clear or delete fails due to not having any entity variables or the entity variable provided doesn't exist on the mob/object.