### PR TITLE
[PVP] Add PVP Teams Functionality

### DIFF
--- a/zone/aggro.cpp
+++ b/zone/aggro.cpp
@@ -719,6 +719,17 @@ bool Mob::IsAttackAllowed(Mob *target, bool isSpellAttack)
 					c2->GetDuelTarget() == c1->GetID()
 				)
 					return true;
+				else if // if server is pvp teams race or deity opposite teams can fight
+				(
+					RuleI(World, PVPSettings) >= 2 && RuleI(World, PVPSettings) <= 4 &&
+					c1->GetPVPTeam() != c2->GetPVPTeam() 
+				)
+					return true;
+				else if // if server is discord pvp they can fight
+				(
+					RuleI(World, PVPSettings) >= 6
+				)
+					return true;
 				else
 					return false;
 			}

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -2698,6 +2698,38 @@ uint16 Client::GetMaxSkillAfterSpecializationRules(EQ::skills::SkillType skillid
 	return Result;
 }
 
+uint8 Client::GetPVPTeam() {
+	if (RuleI(World, PVPSettings) == 2) {
+		int myrace = GetRace();
+		// humans
+		if (myrace == 1 || myrace == 2 || myrace == 3 || myrace == 522) {
+			return 1;
+		// elves
+		} else if (myrace == 4 || myrace == 5 || myrace == 7 || myrace == 130) {
+			return 2;
+		// short
+		} else if (myrace == 8 || myrace == 11 || myrace == 12 || myrace == 330) {
+			return 3;
+		// evil
+		} else if (myrace == 6 || myrace == 9 || myrace == 10 || myrace == 128) {
+			return 4;
+		}
+	} else if (RuleI(World, PVPSettings) == 4) {
+		int mydeity = GetDeity();
+		//good deity
+		if (mydeity == 204 || mydeity == 208 || mydeity == 212 || mydeity == 210 || mydeity == 215) {
+			return 1;
+		//evil deity
+		} else if (mydeity == 201 || mydeity == 203 || mydeity == 206 || mydeity == 211) {
+			return 2;
+		} else {
+		//others
+			return 3;
+		}
+	}
+	return 0;
+}
+
 void Client::SetPVP(bool toggle, bool message) {
 	m_pp.pvp = toggle ? 1 : 0;
 
@@ -9046,10 +9078,6 @@ void Client::CheckRegionTypeChanges()
 
 	// region type changed
 	last_region_type = new_region;
-
-	// PVP is the only state we need to keep track of, so we can just return now for PVP servers
-	if (RuleI(World, PVPSettings) > 0)
-		return;
 
 	if (last_region_type == RegionTypePVP)
 		temp_pvp = true;

--- a/zone/client.h
+++ b/zone/client.h
@@ -405,6 +405,7 @@ public:
 	void SetGM(bool toggle);
 	void SetPVP(bool toggle, bool message = true);
 
+	uint8 GetPVPTeam();
 	inline bool GetPVP(bool inc_temp = true) const { return m_pp.pvp != 0 || (inc_temp && temp_pvp); }
 	inline bool GetGM() const { return m_pp.gm != 0; }
 
@@ -419,6 +420,7 @@ public:
 	inline uint16 GetBaseRace() const { return m_pp.race; }
 	inline uint16 GetBaseClass() const { return m_pp.class_; }
 	inline uint8 GetBaseGender() const { return m_pp.gender; }
+	inline uint8 GetBaseDeity() const { return m_pp.deity; }
 	inline uint8 GetBaseFace() const { return m_pp.face; }
 	inline uint8 GetBaseHairColor() const { return m_pp.haircolor; }
 	inline uint8 GetBaseBeardColor() const { return m_pp.beardcolor; }


### PR DESCRIPTION
This allows the PVPSettings world rule for vz/tz (2), sullon (4), and discord (>5) to appropriately allow PvP combat between racial and deity based teams or FFA. I briefly confirmed teams and diety combat works correctly.

Removed the code referenced by this comment:

"// PVP is the only state we need to keep track of, so we can just return now for PVP servers"

This would only be true for Rallos Zek otherwise this functionality prevents temporary PvP areas (arena, etc) from allowing inter-team fighting on vz/tz or sz rule sets. Removing this just means for Rallos Zek ruleset server this functionality will needlessly occur but has no negative impact.