### PR TITLE
[HotFix] Resolve issue with Bot Casting after zoning.

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -4003,6 +4003,21 @@ bool Bot::Spawn(Client* botCharacterOwner) {
 
 		m_targetable = true;
 		entity_list.AddBot(this, true, true);
+
+		GetBotOwnerDataBuckets();
+		GetBotDataBuckets();
+		LoadBotSpellSettings();
+		if (!AI_AddBotSpells(GetBotSpellID())) {
+			GetBotOwner()->CastToClient()->Message(
+				Chat::White,
+				fmt::format(
+					"Failed to load spells for '{}' (ID {}).",
+					GetCleanName(),
+					GetBotID()
+				).c_str()
+			);
+		}
+
 		// Load pet
 		LoadPet();
 		SentPositionPacket(0.0f, 0.0f, 0.0f, 0.0f, 0);

--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -6686,20 +6686,6 @@ void bot_subcommand_bot_spawn(Client *c, const Seperator *sep)
 		return;
 	}
 
-	my_bot->GetBotOwnerDataBuckets();
-	my_bot->GetBotDataBuckets();
-	my_bot->LoadBotSpellSettings();
-	if (!my_bot->AI_AddBotSpells(my_bot->GetBotSpellID())) {
-		c->Message(
-			Chat::White,
-			fmt::format(
-				"Failed to load spells for '{}' (ID {}).",
-				bot_name,
-				bot_id
-			).c_str()
-		);
-	}
-
 	static std::string bot_spawn_message[17] = {
 		"I am ready to fight!", // DEFAULT
 		"A solid weapon is my ally!", // WARRIOR


### PR DESCRIPTION
Following methods were moved out of Bot Loading Constructor as they could cause potential crashes, were moved to ^spawn method, which doesn't load on zones/botspawngroups.

**GetBotOwnerDataBuckets();
GetBotDataBuckets();
LoadBotSpellSettings();**

Moved to Bot::Spawn and verified this method is called properly on Spawn, Bot Spawn Groups, and Zoning.
Compiled and tested change.