### PR TITLE
[Quest API] Add MaxSkills() to Perl/Lua.

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -12000,14 +12000,13 @@ std::string Client::GetGuildPublicNote()
 
 void Client::MaxSkills()
 {
-	for (const auto &skills_iter : EQ::skills::GetSkillTypeMap()) {
-		auto skill_id            = skills_iter.first;
+	for (const auto &s : EQ::skills::GetSkillTypeMap()) {
 		auto current_skill_value = (
-			EQ::skills::IsSpecializedSkill(skill_id) ?
+			EQ::skills::IsSpecializedSkill(s.first) ?
 			50 :
-			content_db.GetSkillCap(GetClass(), skill_id, GetLevel())
+			content_db.GetSkillCap(GetClass(), s.first, GetLevel())
 		);
 
-		SetSkill(skill_id, current_skill_value);
+		SetSkill(s.first, current_skill_value);
 	}
 }

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -12003,7 +12003,7 @@ void Client::MaxSkills()
 	for (const auto &s : EQ::skills::GetSkillTypeMap()) {
 		auto current_skill_value = (
 			EQ::skills::IsSpecializedSkill(s.first) ?
-			50 :
+			MAX_SPECIALIZED_SKILL :
 			content_db.GetSkillCap(GetClass(), s.first, GetLevel())
 		);
 

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -12007,6 +12007,8 @@ void Client::MaxSkills()
 			content_db.GetSkillCap(GetClass(), s.first, GetLevel())
 		);
 
-		SetSkill(s.first, current_skill_value);
+		if (GetSkill(s.first) < current_skill_value) {
+			SetSkill(s.first, current_skill_value);
+		}
 	}
 }

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -11997,3 +11997,17 @@ std::string Client::GetGuildPublicNote()
 
 	return gci.public_note;
 }
+
+void Client::MaxSkills()
+{
+	for (const auto &skills_iter : EQ::skills::GetSkillTypeMap()) {
+		auto skill_id            = skills_iter.first;
+		auto current_skill_value = (
+			EQ::skills::IsSpecializedSkill(skill_id) ?
+			50 :
+			content_db.GetSkillCap(GetClass(), skill_id, GetLevel())
+		);
+
+		SetSkill(skill_id, current_skill_value);
+	}
+}

--- a/zone/client.h
+++ b/zone/client.h
@@ -87,6 +87,7 @@ namespace EQ
 #define CLIENT_LD_TIMEOUT 30000 // length of time client stays in zone after LDing
 #define TARGETING_RANGE 200 // range for /assist and /target
 #define XTARGET_HARDCAP 20
+#define MAX_SPECIALIZED_SKILL 50
 
 extern Zone* zone;
 extern TaskManager *task_manager;

--- a/zone/client.h
+++ b/zone/client.h
@@ -783,6 +783,7 @@ public:
 	uint16 MaxSkill(EQ::skills::SkillType skillid, uint16 class_, uint16 level) const;
 	inline uint16 MaxSkill(EQ::skills::SkillType skillid) const { return MaxSkill(skillid, GetClass(), GetLevel()); }
 	uint8 SkillTrainLevel(EQ::skills::SkillType skillid, uint16 class_);
+	void MaxSkills();
 
 	void SendTradeskillSearchResults(const std::string &query, unsigned long objtype, unsigned long someid);
 	void SendTradeskillDetails(uint32 recipe_id);

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -210,7 +210,7 @@ int command_init(void)
 		command_add("logs", "Manage anything to do with logs", AccountStatus::GMImpossible, command_logs) ||
 		command_add("makepet", "[Pet Name] - Make a pet", AccountStatus::Guide, command_makepet) ||
 		command_add("mana", "Fill your or your target's mana", AccountStatus::Guide, command_mana) ||
-		command_add("maxskills", "Maxes skills for you.", AccountStatus::GMMgmt, command_max_all_skills) ||
+		command_add("maxskills", "Maxes skills for you or your player target.", AccountStatus::GMMgmt, command_max_all_skills) ||
 		command_add("memspell", "[Spell ID] [Spell Gem] - Memorize a Spell by ID to the specified Spell Gem for you or your target", AccountStatus::Guide, command_memspell) ||
 		command_add("merchant_close_shop", "Closes a merchant shop", AccountStatus::GMAdmin, command_merchantcloseshop) ||
 		command_add("merchant_open_shop", "Opens a merchants shop", AccountStatus::GMAdmin, command_merchantopenshop) ||

--- a/zone/gm_commands/max_all_skills.cpp
+++ b/zone/gm_commands/max_all_skills.cpp
@@ -2,19 +2,19 @@
 
 void command_max_all_skills(Client *c, const Seperator *sep)
 {
-	if (c) {
-		Client    *client_target = (c->GetTarget() ? (c->GetTarget()->IsClient() ? c->GetTarget()->CastToClient() : c)
-			: c);
-		auto      Skills         = EQ::skills::GetSkillTypeMap();
-		for (auto &skills_iter : Skills) {
-			auto skill_id            = skills_iter.first;
-			auto current_skill_value = (
-				(EQ::skills::IsSpecializedSkill(skill_id)) ?
-					50 :
-					content_db.GetSkillCap(client_target->GetClass(), skill_id, client_target->GetLevel())
-			);
-			client_target->SetSkill(skill_id, current_skill_value);
-		}
+	auto t = c;
+	if (c->GetTarget() && c->GetTarget()->IsClient()) {
+		t = c->GetTarget()->CastToClient();
 	}
+
+	t->MaxSkills();
+
+	c->Message(
+		Chat::White,
+		fmt::format(
+			"Maxed skills for {}.",
+			c->GetTargetDescription(t)
+		).c_str()
+	);
 }
 

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -2871,6 +2871,12 @@ std::string Lua_Client::GetGuildPublicNote()
 	return self->GetGuildPublicNote();
 }
 
+void Lua_Client::MaxSkills()
+{
+	Lua_Safe_Call_Void();
+	self->MaxSkills();
+}
+
 #ifdef BOTS
 
 int Lua_Client::GetBotRequiredLevel()
@@ -3233,6 +3239,7 @@ luabind::scope lua_register_client() {
 	.def("Marquee", (void(Lua_Client::*)(uint32, std::string, uint32))&Lua_Client::SendMarqueeMessage)
 	.def("Marquee", (void(Lua_Client::*)(uint32, uint32, uint32, uint32, uint32, std::string))&Lua_Client::SendMarqueeMessage)
 	.def("MaxSkill", (int(Lua_Client::*)(int))&Lua_Client::MaxSkill)
+	.def("MaxSkills", (void(Lua_Client::*)(void))&Lua_Client::MaxSkills)
 	.def("MemSpell", (void(Lua_Client::*)(int,int))&Lua_Client::MemSpell)
 	.def("MemSpell", (void(Lua_Client::*)(int,int,bool))&Lua_Client::MemSpell)
 	.def("MemmedCount", (int(Lua_Client::*)(void))&Lua_Client::MemmedCount)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -453,6 +453,7 @@ public:
 	void SendPayload(int payload_id);
 	void SendPayload(int payload_id, std::string payload_value);
 	std::string GetGuildPublicNote();
+	void MaxSkills();
 
 	void ApplySpell(int spell_id);
 	void ApplySpell(int spell_id, int duration);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -2752,6 +2752,11 @@ std::string Perl_Client_GetGuildPublicNote(Client* self)
 	return self->GetGuildPublicNote();
 }
 
+void Perl_Client_MaxSkills(Client* self)
+{
+	self->MaxSkills();
+}
+
 #ifdef BOTS
 
 int Perl_Client_GetBotRequiredLevel(Client* self)
@@ -3108,6 +3113,7 @@ void perl_register_client()
 	package.add("MaxSkill", (int(*)(Client*, uint16))&Perl_Client_MaxSkill);
 	package.add("MaxSkill", (int(*)(Client*, uint16, uint16))&Perl_Client_MaxSkill);
 	package.add("MaxSkill", (int(*)(Client*, uint16, uint16, uint16))&Perl_Client_MaxSkill);
+	package.add("MaxSkills", &Perl_Client_MaxSkills);
 	package.add("MemSpell", (void(*)(Client*, uint16, int))&Perl_Client_MemSpell);
 	package.add("MemSpell", (void(*)(Client*, uint16, int, bool))&Perl_Client_MemSpell);
 	package.add("MemmedCount", &Perl_Client_MemmedCount);


### PR DESCRIPTION
# Perl
- Add `$client->MaxSkills()`.

# Lua
- Add `client:MaxSkills()`.

# Notes
- Allows operators an easy short hand for maxing a player's skills for their level without needing to do all the looping and stuff on their own.