### PR TITLE
[Bot/Merc] Cleanup Fast Rest Regen

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -2147,16 +2147,12 @@ bool Bot::Process()
 
 	SpellProcess();
 
-	if(tic_timer.Check()) {
+	if (tic_timer.Check()) {
 
 		// 6 seconds, or whatever the rule is set to has passed, send this position to everyone to avoid ghosting
-		if(!IsMoving() && !IsEngaged()) {
-
-			if(IsSitting()) {
-
-				if (!rest_timer.Enabled()) {
-					rest_timer.Start(RuleI(Character, RestRegenTimeToActivate) * 1000);
-				}
+		if (!IsEngaged()) {
+			if (!rest_timer.Enabled()) {
+				rest_timer.Start(RuleI(Character, RestRegenTimeToActivate) * 1000);
 			}
 		}
 
@@ -2277,25 +2273,21 @@ void Bot::SpellProcess() {
 }
 
 void Bot::BotMeditate(bool isSitting) {
-	if(isSitting) {
-		if(GetManaRatio() < 99.0f || GetHPRatio() < 99.0f) {
-			if (!IsEngaged() && !IsSitting())
+	if (isSitting) {
+		if (GetManaRatio() < 99.0f || GetHPRatio() < 99.0f) {
+			if (!IsEngaged() && !IsSitting()) {
 				Sit();
+			}
 		} else {
-			if(IsSitting())
+			if (IsSitting()) {
 				Stand();
+			}
 		}
 	} else {
-		if(IsSitting())
+		if (IsSitting()) {
 			Stand();
+		}
 	}
-
-	if(IsSitting()) {
-		if(!rest_timer.Enabled())
-			rest_timer.Start(RuleI(Character, RestRegenTimeToActivate) * 1000);
-	}
-	else
-		rest_timer.Disable();
 }
 
 void Bot::BotRangedAttack(Mob* other) {

--- a/zone/merc.cpp
+++ b/zone/merc.cpp
@@ -1269,13 +1269,11 @@ bool Merc::Process()
 	if(tic_timer.Check())
 	{
 		//6 seconds, or whatever the rule is set to has passed, send this position to everyone to avoid ghosting
-		if(!IsMoving() && !IsEngaged())
+		if (!IsEngaged())
 		{
 			SentPositionPacket(0.0f, 0.0f, 0.0f, 0.0f, 0);
-			if(IsSitting()) {
-				if(!rest_timer.Enabled()) {
-					rest_timer.Start(RuleI(Character, RestRegenTimeToActivate) * 1000);
-				}
+			if (!rest_timer.Enabled()) {
+				rest_timer.Start(RuleI(Character, RestRegenTimeToActivate) * 1000);
 			}
 		}
 
@@ -4305,32 +4303,26 @@ void Merc::MercMeditate(bool isSitting) {
 	{
 		return;
 	}
-	if(isSitting) {
+	if (isSitting) {
 		// If the merc is a caster and has less than 99% mana while its not engaged, he needs to sit to meditate
-		if(GetManaRatio() < 99.0f)
+		if (GetManaRatio() < 99.0f)
 		{
-			if(!IsSitting())
+			if(!IsSitting()) {
 				Sit();
+			}
 		}
 		else
 		{
-			if(IsSitting())
+			if (IsSitting()) {
 				Stand();
+			}
 		}
 	}
 	else
 	{
-		if(IsSitting())
+		if (IsSitting()) {
 			Stand();
-	}
-
-	if(IsSitting()) {
-		if(!rest_timer.Enabled()) {
-			rest_timer.Start(RuleI(Character, RestRegenTimeToActivate) * 1000);
 		}
-	}
-	else {
-		rest_timer.Disable();
 	}
 }
 


### PR DESCRIPTION
Rest Regen timer was only starting if the Bot was sitting, and resetting itself on movement.

Rest Timer should start when out of combat, and only start again once engaged.