### PR TITLE
[Quest API] Add DoAnim Overloads to Perl/Lua.

### DIFF
--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -640,6 +640,21 @@ void Perl__doanim(int animation_id)
 	quest_manager.doanim(animation_id);
 }
 
+void Perl__doanim(int animation_id, int animation_speed)
+{
+	quest_manager.doanim(animation_id, animation_speed);
+}
+
+void Perl__doanim(int animation_id, int animation_speed, bool ackreq)
+{
+	quest_manager.doanim(animation_id, animation_speed, ackreq);
+}
+
+void Perl__doanim(int animation_id, int animation_speed, bool ackreq, int filter)
+{
+	quest_manager.doanim(animation_id, animation_speed, ackreq, static_cast<eqFilterType>(filter));
+}
+
 void Perl__addskill(int skill_id, int value)
 {
 	quest_manager.addskill(skill_id, value);
@@ -4263,7 +4278,10 @@ void perl_register_quest()
 	package.add("disablerecipe", &Perl__disablerecipe);
 	package.add("disabletask", &Perl__disabletask);
 	package.add("discordsend", &Perl__discordsend);
-	package.add("doanim", &Perl__doanim);
+	package.add("doanim", (void(*)(int))&Perl__doanim);
+	package.add("doanim", (void(*)(int, int))&Perl__doanim);
+	package.add("doanim", (void(*)(int, int, bool))&Perl__doanim);
+	package.add("doanim", (void(*)(int, int, bool, int))&Perl__doanim);
 	package.add("echo", &Perl__echo);
 	package.add("emote", &Perl__emote);
 	package.add("enable_proximity_say", &Perl__enable_proximity_say);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -3628,6 +3628,26 @@ void lua_set_proximity_range(float x_range, float y_range, float z_range, bool e
 	quest_manager.set_proximity_range(x_range, y_range, z_range, enable_say);
 }
 
+void lua_do_anim(int animation_id)
+{
+	quest_manager.doanim(animation_id);
+}
+
+void lua_do_anim(int animation_id, int animation_speed)
+{
+	quest_manager.doanim(animation_id, animation_speed);
+}
+
+void lua_do_anim(int animation_id, int animation_speed, bool ackreq)
+{
+	quest_manager.doanim(animation_id, animation_speed, ackreq);
+}
+
+void lua_do_anim(int animation_id, int animation_speed, bool ackreq, int filter)
+{
+	quest_manager.doanim(animation_id, animation_speed, ackreq, static_cast<eqFilterType>(filter));
+}
+
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
 	cur = table[#name]; \
 	if(luabind::type(cur) != LUA_TNIL) { \
@@ -4129,7 +4149,10 @@ luabind::scope lua_register_general() {
 		luabind::def("zone_marquee", (void(*)(uint32,uint32,uint32,uint32,uint32,std::string))&lua_zone_marquee),
 		luabind::def("is_hotzone", (bool(*)(void))&lua_is_hotzone),
 		luabind::def("set_hotzone", (void(*)(bool))&lua_set_hotzone),
-
+		luabind::def("do_anim", (void(*)(int))&lua_do_anim),
+		luabind::def("do_anim", (void(*)(int,int))&lua_do_anim),
+		luabind::def("do_anim", (void(*)(int,int,bool))&lua_do_anim),
+		luabind::def("do_anim", (void(*)(int,int,bool,int))&lua_do_anim),
 		/*
 			Cross Zone
 		*/

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -243,24 +243,24 @@ void Lua_Mob::SetHP(int64 hp) {
 	self->SetHP(hp);
 }
 
-void Lua_Mob::DoAnim(int anim_num) {
+void Lua_Mob::DoAnim(int animation_id) {
 	Lua_Safe_Call_Void();
-	self->DoAnim(anim_num);
+	self->DoAnim(animation_id);
 }
 
-void Lua_Mob::DoAnim(int anim_num, int type) {
+void Lua_Mob::DoAnim(int animation_id, int animation_speed) {
 	Lua_Safe_Call_Void();
-	self->DoAnim(anim_num, type);
+	self->DoAnim(animation_id, animation_speed);
 }
 
-void Lua_Mob::DoAnim(int anim_num, int type, bool ackreq) {
+void Lua_Mob::DoAnim(int animation_id, int animation_speed, bool ackreq) {
 	Lua_Safe_Call_Void();
-	self->DoAnim(anim_num, type, ackreq);
+	self->DoAnim(animation_id, animation_speed, ackreq);
 }
 
-void Lua_Mob::DoAnim(int anim_num, int type, bool ackreq, int filter) {
+void Lua_Mob::DoAnim(int animation_id, int animation_speed, bool ackreq, int filter) {
 	Lua_Safe_Call_Void();
-	self->DoAnim(anim_num, type, ackreq, static_cast<eqFilterType>(filter));
+	self->DoAnim(animation_id, animation_speed, ackreq, static_cast<eqFilterType>(filter));
 }
 
 void Lua_Mob::ChangeSize(double in_size) {

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -70,10 +70,10 @@ public:
 	uint32 GetLevelCon(int other);
 	uint32 GetLevelCon(int my, int other);
 	void SetHP(int64 hp);
-	void DoAnim(int anim_num);
-	void DoAnim(int anim_num, int type);
-	void DoAnim(int anim_num, int type, bool ackreq);
-	void DoAnim(int anim_num, int type, bool ackreq, int filter);
+	void DoAnim(int animation_id);
+	void DoAnim(int animation_id, int animation_speed);
+	void DoAnim(int animation_id, int animation_speed, bool ackreq);
+	void DoAnim(int animation_id, int animation_speed, bool ackreq, int filter);
 	void ChangeSize(double in_size);
 	void ChangeSize(double in_size, bool no_restriction);
 	bool RandomizeFeatures();

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -257,14 +257,24 @@ void Perl_Mob_SetHP(Mob* self, int64_t hp) // @categories Stats and Attributes
 	self->SetHP(hp);
 }
 
-void Perl_Mob_DoAnim(Mob* self, int anim_num) // @categories Script Utility
+void Perl_Mob_DoAnim(Mob* self, int animation_id) // @categories Script Utility
 {
-	self->DoAnim(anim_num);
+	self->DoAnim(animation_id);
 }
 
-void Perl_Mob_DoAnim(Mob* self, int anim_num, int type) // @categories Script Utility
+void Perl_Mob_DoAnim(Mob* self, int animation_id, int animation_speed) // @categories Script Utility
 {
-	self->DoAnim(anim_num, type);
+	self->DoAnim(animation_id, animation_speed);
+}
+
+void Perl_Mob_DoAnim(Mob* self, int animation_id, int animation_speed, bool ackreq) // @categories Script Utility
+{
+	self->DoAnim(animation_id, animation_speed, ackreq);
+}
+
+void Perl_Mob_DoAnim(Mob* self, int animation_id, int animation_speed, bool ackreq, int filter) // @categories Script Utility
+{
+	self->DoAnim(animation_id, animation_speed, ackreq, static_cast<eqFilterType>(filter));
 }
 
 void Perl_Mob_ChangeSize(Mob* self, float in_size) // @categories Script Utility
@@ -2881,6 +2891,8 @@ void perl_register_mob()
 	package.add("DivineAura", &Perl_Mob_DivineAura);
 	package.add("DoAnim", (void(*)(Mob*, int))&Perl_Mob_DoAnim);
 	package.add("DoAnim", (void(*)(Mob*, int, int))&Perl_Mob_DoAnim);
+	package.add("DoAnim", (void(*)(Mob*, int, int, bool))&Perl_Mob_DoAnim);
+	package.add("DoAnim", (void(*)(Mob*, int, int, bool, int))&Perl_Mob_DoAnim);
 	package.add("DoArcheryAttackDmg", &Perl_Mob_DoArcheryAttackDmg);
 	package.add("DoKnockback", &Perl_Mob_DoKnockback);
 	package.add("DoMeleeSkillAttackDmg", &Perl_Mob_DoMeleeSkillAttackDmg);

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -1234,9 +1234,9 @@ void QuestManager::movegrp(int zoneid, float x, float y, float z) {
 	}
 }
 
-void QuestManager::doanim(int anim_id) {
+void QuestManager::doanim(int animation_id, int animation_speed, bool ackreq, eqFilterType filter) {
 	QuestManagerCurrentQuestVars();
-	owner->DoAnim(anim_id);
+	owner->DoAnim(animation_id, animation_speed, ackreq, filter);
 }
 
 void QuestManager::addskill(int skill_id, int value) {

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -140,7 +140,7 @@ public:
 	void movepc(int zone_id, float x, float y, float z, float heading);
 	void gmmove(float x, float y, float z);
 	void movegrp(int zoneid, float x, float y, float z);
-	void doanim(int anim_id);
+	void doanim(int animation_id, int animation_speed = 1, bool ackreq = true, eqFilterType filter = FilterNone);
 	void addskill(int skill_id, int value);
 	void setlanguage(int skill_id, int value);
 	void setskill(int skill_id, int value);


### PR DESCRIPTION
# Perl
- Add `$mob->DoAnim(animation_id, animation_speed, ackreq)`.
- Add `$mob->DoAnim(animation_id, animation_speed, ackreq, filter)`.
- Add `quest::doanim(animation_id, animation_speed)`.
- Add `quest::doanim(animation_id, animation_speed, ackreq)`.
- Add `quest::doanim(animation_id, animation_speed, ackreq, filter)`.

# Lua
- Add `eq.do_anim(animation_id)`.
- Add `eq.do_anim(animation_id, animation_speed)`.
- Add `eq.do_anim(animation_id, animation_speed, ackreq)`.
- Add `eq.do_anim(animation_id, animation_speed, ackreq, filter)`.

# Notes
- Adds overloads and cleans up spots where `animation_speed` was named `type` erroneously.