### PR TITLE
[Tasks] Crash fix with data input sanitization

### DIFF
--- a/common/strings.cpp
+++ b/common/strings.cpp
@@ -192,7 +192,7 @@ std::string Strings::Escape(const std::string &s)
 bool Strings::IsNumber(const std::string &s)
 {
 	try {
-		auto r = stod(s);
+		auto r = stoi(s);
 		return true;
 	}
 	catch (std::exception &) {

--- a/zone/task_manager.cpp
+++ b/zone/task_manager.cpp
@@ -232,7 +232,9 @@ bool TaskManager::LoadTasks(int single_task)
 		);
 
 		for (auto &&e : zones) {
-			ad->zone_ids.push_back(std::stoi(e));
+			if (Strings::IsNumber(e)) {
+				ad->zone_ids.push_back(std::stoi(e));
+			}
 		}
 
 		ad->optional = a.optional;


### PR DESCRIPTION
Observed on KMRA

**Problem**

When `zones` field has `NaN` in it; the server doesn't handle it properly and crashes.

**Solution**

`Strings::IsNumber` was not attempting to `stoi` and did not throw an error when `NaN` was passed. Traded `stod` for `stoi` in the `IsNumber` helper. This could be swapper for a int64 try/catch later.

`zones` field is now resilient to non-integer input