### PR TITLE
[Bug Fix] Fix possible crash in ProcessSpecialAbilities.

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -6283,10 +6283,14 @@ void Mob::ClearSpecialAbilities() {
 void Mob::ProcessSpecialAbilities(const std::string &str) {
 	ClearSpecialAbilities();
 
-	std::vector<std::string> sp = Strings::Split(str, '^');
-	for(auto iter = sp.begin(); iter != sp.end(); ++iter) {
-		std::vector<std::string> sub_sp = Strings::Split((*iter), ',');
-		if(sub_sp.size() >= 2) {
+	const auto& sp = Strings::Split(str, '^');
+	for (const auto& s : sp) {
+		const auto& sub_sp = Strings::Split(s, ',');
+		if (
+			sub_sp.size() >= 2 &&
+			Strings::IsNumber(sub_sp[0]) &&
+			Strings::IsNumber(sub_sp[1])
+		) {
 			int ability = std::stoi(sub_sp[0]);
 			int value = std::stoi(sub_sp[1]);
 
@@ -6313,7 +6317,9 @@ void Mob::ProcessSpecialAbilities(const std::string &str) {
 					break;
 				}
 
-				SetSpecialAbilityParam(ability, p, std::stoi(sub_sp[i]));
+				if (Strings::IsNumber(sub_sp[i])) {
+					SetSpecialAbilityParam(ability, p, std::stoi(sub_sp[i]));
+				}
 			}
 		}
 	}


### PR DESCRIPTION
# Notes
- Passing an invalid special ability along such as `4,1,,-1,100` currently causes a crash since every `,` assumes it's followed by a number.
- Fixed by making sure first and second parameters are numbers and then when looping additional parameters we also check if they are numbers.