### PR TITLE
[Bots] Add Quest API Methods

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -10989,7 +10989,6 @@ void Bot::Escape()
 {
 	entity_list.RemoveFromTargets(this, true);
 	SetInvisible(Invisibility::Invisible);
-	MessageString(Chat::Skills, ESCAPE);
 }
 
 void Bot::Fling(float value, float target_x, float target_y, float target_z, bool ignore_los, bool clip_through_walls, bool calculate_speed) {
@@ -11044,89 +11043,6 @@ int32 Bot::GetRawItemAC()
 	return Total;
 }
 
-void Bot::IncStats(uint8 type,int16 increase_val){
-	if(type>STAT_DISEASE){
-		printf("Error in Client::IncStats, received invalid type of: %i\n",type);
-		return;
-	}
-	auto outapp = new EQApplicationPacket(OP_IncreaseStats, sizeof(IncreaseStat_Struct));
-	IncreaseStat_Struct* iss=(IncreaseStat_Struct*)outapp->pBuffer;
-	switch(type){
-		case STAT_STR:
-			if(increase_val>0)
-				iss->str=increase_val;
-			if((STR+increase_val*2)<0)
-				STR=0;
-			else if((STR+increase_val*2)>255)
-				STR=255;
-			else
-				STR+=increase_val*2;
-			break;
-		case STAT_STA:
-			if(increase_val>0)
-				iss->sta=increase_val;
-			if((STA+increase_val*2)<0)
-				STA=0;
-			else if((STA+increase_val*2)>255)
-				STA=255;
-			else
-				STA+=increase_val*2;
-			break;
-		case STAT_AGI:
-			if(increase_val>0)
-				iss->agi=increase_val;
-			if((AGI+increase_val*2)<0)
-				AGI=0;
-			else if((AGI+increase_val*2)>255)
-				AGI=255;
-			else
-				AGI+=increase_val*2;
-			break;
-		case STAT_DEX:
-			if(increase_val>0)
-				iss->dex=increase_val;
-			if((DEX+increase_val*2)<0)
-				DEX=0;
-			else if((DEX+increase_val*2)>255)
-				DEX=255;
-			else
-				DEX+=increase_val*2;
-			break;
-		case STAT_INT:
-			if(increase_val>0)
-				iss->int_=increase_val;
-			if((INT+increase_val*2)<0)
-				INT=0;
-			else if((INT+increase_val*2)>255)
-				INT=255;
-			else
-				INT+=increase_val*2;
-			break;
-		case STAT_WIS:
-			if(increase_val>0)
-				iss->wis=increase_val;
-			if((WIS+increase_val*2)<0)
-				WIS=0;
-			else if((WIS+increase_val*2)>255)
-				WIS=255;
-			else
-				WIS+=increase_val*2;
-			break;
-		case STAT_CHA:
-			if(increase_val>0)
-				iss->cha=increase_val;
-			if((CHA+increase_val*2)<0)
-				CHA=0;
-			else if((CHA+increase_val*2)>255)
-				CHA=255;
-			else
-				CHA+=increase_val*2;
-			break;
-	}
-	GetBotOwner()->CastToClient()->QueuePacket(outapp);
-	safe_delete(outapp);
-}
-
 void Bot::SendSpellAnim(uint16 targetid, uint16 spell_id)
 {
 	if (!targetid || !IsValidSpell(spell_id))
@@ -11142,90 +11058,6 @@ void Bot::SendSpellAnim(uint16 targetid, uint16 spell_id)
 
 	app.priority = 1;
 	entity_list.QueueCloseClients(this, &app, false, RuleI(Range, SpellParticles));
-}
-
-void Bot::SetStats(uint8 type,int16 set_val) 
-{
-	if(type>STAT_DISEASE){
-		printf("[Bot::SetStats] received invalid type of: %i\n",type);
-		return;
-	}
-	auto outapp = new EQApplicationPacket(OP_IncreaseStats, sizeof(IncreaseStat_Struct));
-	IncreaseStat_Struct* iss=(IncreaseStat_Struct*)outapp->pBuffer;
-	switch(type){
-		case STAT_STR:
-			if(set_val>0)
-				iss->str=set_val;
-			if(set_val<0)
-				STR=0;
-			else if(set_val>255)
-				STR=255;
-			else
-				STR=set_val;
-			break;
-		case STAT_STA:
-			if(set_val>0)
-				iss->sta=set_val;
-			if(set_val<0)
-				STA=0;
-			else if(set_val>255)
-				STA=255;
-			else
-				STA=set_val;
-			break;
-		case STAT_AGI:
-			if(set_val>0)
-				iss->agi=set_val;
-			if(set_val<0)
-				AGI=0;
-			else if(set_val>255)
-				AGI=255;
-			else
-				AGI=set_val;
-			break;
-		case STAT_DEX:
-			if(set_val>0)
-				iss->dex=set_val;
-			if(set_val<0)
-				DEX=0;
-			else if(set_val>255)
-				DEX=255;
-			else
-				DEX=set_val;
-			break;
-		case STAT_INT:
-			if(set_val>0)
-				iss->int_=set_val;
-			if(set_val<0)
-				INT=0;
-			else if(set_val>255)
-				INT=255;
-			else
-				INT=set_val;
-			break;
-		case STAT_WIS:
-			if(set_val>0)
-				iss->wis=set_val;
-			if(set_val<0)
-				WIS=0;
-			else if(set_val>255)
-				WIS=255;
-			else
-				WIS=set_val;
-			break;
-		case STAT_CHA:
-			if(set_val>0)
-				iss->cha=set_val;
-			if(set_val<0)
-				CHA=0;
-			else if(set_val>255)
-				CHA=255;
-			else
-				CHA=set_val;
-		break;
-	}
-	GetBotOwner()->CastToClient()->QueuePacket(outapp);
-	safe_delete(outapp);
 }
 
 uint8 Bot::spell_casting_chances[SPELL_TYPE_COUNT][PLAYER_CLASS_COUNT][EQ::constants::STANCE_TYPE_COUNT][cntHSND] = { 0 };

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -390,7 +390,6 @@ public:
 	bool CheckLoreConflict(const EQ::ItemData* item);
 	virtual void UpdateEquipmentLight() { m_Light.Type[EQ::lightsource::LightEquipment] = m_inv.FindBrightestLightType(); m_Light.Level[EQ::lightsource::LightEquipment] = EQ::lightsource::TypeToLevel(m_Light.Type[EQ::lightsource::LightEquipment]); }
 	inline EQ::InventoryProfile& GetBotInv() { return m_inv; }
-	inline const EQ::InventoryProfile& GetBotInv() const { return m_inv; }
 
 	// Static Class Methods
 	//static void DestroyBotRaidObjects(Client* client);	// Can be removed after bot raids are dumped
@@ -590,9 +589,7 @@ public:
 	int32 GetItemIDAt(int16 slot_id);
 	int32 GetAugmentIDAt(int16 slot_id, uint8 augslot);
 	int32 GetRawItemAC();
-	void IncStats(uint8 type,int16 increase_val);
 	void SendSpellAnim(uint16 targetid, uint16 spell_id);
-	void SetStats(uint8 type,int16 set_val); 
 	void SetSpellDuration(int spell_id, int duration = 0, ApplySpellType apply_type = ApplySpellType::Solo, bool allow_pets = false, bool is_raid_group_only = true);
 
 	// "SET" Class Methods

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -389,7 +389,8 @@ public:
 	void EquipBot(std::string* error_message);
 	bool CheckLoreConflict(const EQ::ItemData* item);
 	virtual void UpdateEquipmentLight() { m_Light.Type[EQ::lightsource::LightEquipment] = m_inv.FindBrightestLightType(); m_Light.Level[EQ::lightsource::LightEquipment] = EQ::lightsource::TypeToLevel(m_Light.Type[EQ::lightsource::LightEquipment]); }
-	const EQ::InventoryProfile& GetBotInv() const { return m_inv; }
+	inline EQ::InventoryProfile& GetBotInv() { return m_inv; }
+	inline const EQ::InventoryProfile& GetBotInv() const { return m_inv; }
 
 	// Static Class Methods
 	//static void DestroyBotRaidObjects(Client* client);	// Can be removed after bot raids are dumped
@@ -581,6 +582,18 @@ public:
 
 	// "Quest API" Methods
 	bool HasBotSpellEntry(uint16 spellid);
+	void ApplySpell(int spell_id, int duration = 0, ApplySpellType apply_type = ApplySpellType::Solo, bool allow_pets = false, bool is_raid_group_only = true);
+	void BreakInvis();
+	void Escape();
+	void Fling(float value, float target_x, float target_y, float target_z, bool ignore_los = false, bool clip_through_walls = false, bool calculate_speed = false);
+	std::vector<Mob*> GetApplySpellList(ApplySpellType apply_type, bool allow_pets, bool is_raid_group_only);
+	int32 GetItemIDAt(int16 slot_id);
+	int32 GetAugmentIDAt(int16 slot_id, uint8 augslot);
+	int32 GetRawItemAC();
+	void IncStats(uint8 type,int16 increase_val);
+	void SendSpellAnim(uint16 targetid, uint16 spell_id);
+	void SetStats(uint8 type,int16 set_val); 
+	void SetSpellDuration(int spell_id, int duration = 0, ApplySpellType apply_type = ApplySpellType::Solo, bool allow_pets = false, bool is_raid_group_only = true);
 
 	// "SET" Class Methods
 	void SetBotSpellID(uint32 newSpellID);

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -25,6 +25,10 @@
 #include "zonedb.h"
 #include "../common/zone_store.h"
 
+#ifdef BOTS
+#include "bot.h"
+#endif
+
 extern WorldServer worldserver;
 
 // @merth: this needs to be touched up
@@ -4204,3 +4208,66 @@ int EQ::InventoryProfile::GetItemStatValue(uint32 item_id, const char* identifie
 	safe_delete(inst);
 	return stat;
 }
+
+#ifdef BOTS
+// Returns a slot's item ID (returns INVALID_ID if not found)
+int32 Bot::GetItemIDAt(int16 slot_id) {
+	if (slot_id <= EQ::invslot::POSSESSIONS_END && slot_id >= EQ::invslot::POSSESSIONS_BEGIN) {
+		if ((((uint64)1 << slot_id) & GetBotInv().GetLookup()->PossessionsBitmask) == 0)
+			return INVALID_ID;
+	}
+	else if (slot_id <= EQ::invbag::GENERAL_BAGS_END && slot_id >= EQ::invbag::GENERAL_BAGS_BEGIN) {
+		auto temp_slot = EQ::invslot::GENERAL_BEGIN + ((slot_id - EQ::invbag::GENERAL_BAGS_BEGIN) / EQ::invbag::SLOT_COUNT);
+		if ((((uint64)1 << temp_slot) & GetBotInv().GetLookup()->PossessionsBitmask) == 0)
+			return INVALID_ID;
+	}
+	else if (slot_id <= EQ::invslot::BANK_END && slot_id >= EQ::invslot::BANK_BEGIN) {
+		if ((slot_id - EQ::invslot::BANK_BEGIN) >= GetBotInv().GetLookup()->InventoryTypeSize.Bank)
+			return INVALID_ID;
+	}
+	else if (slot_id <= EQ::invbag::BANK_BAGS_END && slot_id >= EQ::invbag::BANK_BAGS_BEGIN) {
+		auto temp_slot = (slot_id - EQ::invbag::BANK_BAGS_BEGIN) / EQ::invbag::SLOT_COUNT;
+		if (temp_slot >= GetBotInv().GetLookup()->InventoryTypeSize.Bank)
+			return INVALID_ID;
+	}
+
+	const EQ::ItemInstance* inst = m_inv[slot_id];
+	if (inst)
+		return inst->GetItem()->ID;
+
+	// None found
+	return INVALID_ID;
+}
+
+// Returns an augment's ID that's in an item (returns INVALID_ID if not found)
+// Pass in the slot ID of the item and which augslot you want to check (0-5)
+int32 Bot::GetAugmentIDAt(int16 slot_id, uint8 augslot) {
+	if (slot_id <= EQ::invslot::POSSESSIONS_END && slot_id >= EQ::invslot::POSSESSIONS_BEGIN) {
+		if ((((uint64)1 << slot_id) & GetBotInv().GetLookup()->PossessionsBitmask) == 0)
+			return INVALID_ID;
+	}
+	else if (slot_id <= EQ::invbag::GENERAL_BAGS_END && slot_id >= EQ::invbag::GENERAL_BAGS_BEGIN) {
+		auto temp_slot = EQ::invslot::GENERAL_BEGIN + ((slot_id - EQ::invbag::GENERAL_BAGS_BEGIN) / EQ::invbag::SLOT_COUNT);
+		if ((((uint64)1 << temp_slot) & GetBotInv().GetLookup()->PossessionsBitmask) == 0)
+			return INVALID_ID;
+	}
+	else if (slot_id <= EQ::invslot::BANK_END && slot_id >= EQ::invslot::BANK_BEGIN) {
+		if ((slot_id - EQ::invslot::BANK_BEGIN) >= GetBotInv().GetLookup()->InventoryTypeSize.Bank)
+			return INVALID_ID;
+	}
+	else if (slot_id <= EQ::invbag::BANK_BAGS_END && slot_id >= EQ::invbag::BANK_BAGS_BEGIN) {
+		auto temp_slot = (slot_id - EQ::invbag::BANK_BAGS_BEGIN) / EQ::invbag::SLOT_COUNT;
+		if (temp_slot >= GetBotInv().GetLookup()->InventoryTypeSize.Bank)
+			return INVALID_ID;
+	}
+
+	const EQ::ItemInstance* inst = m_inv[slot_id];
+	if (inst && inst->GetAugmentItemID(augslot)) {
+		return inst->GetAugmentItemID(augslot);
+	}
+
+	// None found
+	return INVALID_ID;
+}
+
+#endif

--- a/zone/lua_bot.cpp
+++ b/zone/lua_bot.cpp
@@ -9,7 +9,6 @@
 #include "lua_iteminst.h"
 #include "lua_mob.h"
 #include "lua_group.h"
-#include "lua_raid.h"
 
 void Lua_Bot::AddBotItem(uint16 slot_id, uint32 item_id) {
 	Lua_Safe_Call_Void();
@@ -176,26 +175,6 @@ void Lua_Bot::ApplySpellGroup(int spell_id, int duration, bool allow_pets) {
 	self->ApplySpell(spell_id, duration, ApplySpellType::Group, allow_pets);
 }
 
-void Lua_Bot::ApplySpellRaid(int spell_id) {
-	Lua_Safe_Call_Void();
-	self->ApplySpell(spell_id, 0, ApplySpellType::Raid);
-}
-
-void Lua_Bot::ApplySpellRaid(int spell_id, int duration) {
-	Lua_Safe_Call_Void();
-	self->ApplySpell(spell_id, duration, ApplySpellType::Raid);
-}
-
-void Lua_Bot::ApplySpellRaid(int spell_id, int duration, bool allow_pets) {
-	Lua_Safe_Call_Void();
-	self->ApplySpell(spell_id, duration, ApplySpellType::Raid, allow_pets);
-}
-
-void Lua_Bot::ApplySpellRaid(int spell_id, int duration, bool allow_pets, bool is_raid_group_only) {
-	Lua_Safe_Call_Void();
-	self->ApplySpell(spell_id, duration, ApplySpellType::Raid, allow_pets, is_raid_group_only);
-}
-
 void Lua_Bot::SetSpellDuration(int spell_id) {
 	Lua_Safe_Call_Void();
 	self->SetSpellDuration(spell_id);
@@ -224,26 +203,6 @@ void Lua_Bot::SetSpellDurationGroup(int spell_id, int duration) {
 void Lua_Bot::SetSpellDurationGroup(int spell_id, int duration, bool allow_pets) {
 	Lua_Safe_Call_Void();
 	self->SetSpellDuration(spell_id, duration, ApplySpellType::Group, allow_pets);
-}
-
-void Lua_Bot::SetSpellDurationRaid(int spell_id) {
-	Lua_Safe_Call_Void();
-	self->SetSpellDuration(spell_id, 0, ApplySpellType::Raid);
-}
-
-void Lua_Bot::SetSpellDurationRaid(int spell_id, int duration) {
-	Lua_Safe_Call_Void();
-	self->SetSpellDuration(spell_id, duration, ApplySpellType::Raid);
-}
-
-void Lua_Bot::SetSpellDurationRaid(int spell_id, int duration, bool allow_pets) {
-	Lua_Safe_Call_Void();
-	self->SetSpellDuration(spell_id, duration, ApplySpellType::Raid, allow_pets);
-}
-
-void Lua_Bot::SetSpellDurationRaid(int spell_id, int duration, bool allow_pets, bool is_raid_group_only) {
-	Lua_Safe_Call_Void();
-	self->SetSpellDuration(spell_id, duration, ApplySpellType::Raid, allow_pets, is_raid_group_only);
 }
 
 int Lua_Bot::CountAugmentEquippedByID(uint32 item_id) {
@@ -351,11 +310,6 @@ Lua_Group Lua_Bot::GetGroup() {
 	return self->GetGroup();
 }
 
-Lua_Raid Lua_Bot::GetRaid() {
-	Lua_Safe_Call_Class(Lua_Raid);
-	return self->GetRaid();
-}
-
 int Lua_Bot::GetHealAmount() {
 	Lua_Safe_Call_Int();
 	return self->GetHealAmt();
@@ -376,24 +330,9 @@ int Lua_Bot::GetRawItemAC() {
 	return self->GetRawItemAC();
 }
 
-bool Lua_Bot::InZone() {
-	Lua_Safe_Call_Bool();
-	return self->InZone();
-}
-
-void Lua_Bot::IncStats(int type, int value) {
-	Lua_Safe_Call_Void();
-	self->IncStats(type, value);
-}
-
 bool Lua_Bot::IsGrouped() {
 	Lua_Safe_Call_Bool();
 	return self->IsGrouped();
-}
-
-bool Lua_Bot::IsRaidGrouped() {
-	Lua_Safe_Call_Bool();
-	return self->IsRaidGrouped();
 }
 
 bool Lua_Bot::IsStanding() {
@@ -404,11 +343,6 @@ bool Lua_Bot::IsStanding() {
 bool Lua_Bot::IsSitting() {
 	Lua_Safe_Call_Bool();
 	return self->IsSitting();
-}
-
-void Lua_Bot::SetStats(int type, int value) {
-	Lua_Safe_Call_Void();
-	self->SetStats(type, value);
 }
 
 void Lua_Bot::Sit() {
@@ -439,10 +373,6 @@ luabind::scope lua_register_bot() {
 	.def("ApplySpellGroup", (void(Lua_Bot::*)(int))&Lua_Bot::ApplySpellGroup)
 	.def("ApplySpellGroup", (void(Lua_Bot::*)(int,int))&Lua_Bot::ApplySpellGroup)
 	.def("ApplySpellGroup", (void(Lua_Bot::*)(int,int,bool))&Lua_Bot::ApplySpellGroup)
-	.def("ApplySpellRaid", (void(Lua_Bot::*)(int))&Lua_Bot::ApplySpellRaid)
-	.def("ApplySpellRaid", (void(Lua_Bot::*)(int,int))&Lua_Bot::ApplySpellRaid)
-	.def("ApplySpellRaid", (void(Lua_Bot::*)(int,int,bool))&Lua_Bot::ApplySpellRaid)
-	.def("ApplySpellRaid", (void(Lua_Bot::*)(int,int,bool,bool))&Lua_Bot::ApplySpellRaid)
 	.def("CountBotItem", (uint32(Lua_Bot::*)(uint32))&Lua_Bot::CountBotItem)
 	.def("CountItemEquippedByID", (int(Lua_Bot::*)(uint32))&Lua_Bot::CountItemEquippedByID)
 	.def("Escape", (void(Lua_Bot::*)(void))&Lua_Bot::Escape)
@@ -467,17 +397,13 @@ luabind::scope lua_register_bot() {
 	.def("GetHealAmount", (int(Lua_Bot::*)(void))&Lua_Bot::GetHealAmount)
 	.def("GetInstrumentMod", (int(Lua_Bot::*)(int))&Lua_Bot::GetInstrumentMod)
 	.def("GetOwner", (Lua_Mob(Lua_Bot::*)(void))&Lua_Bot::GetOwner)
-	.def("GetRaid", (Lua_Raid(Lua_Bot::*)(void))&Lua_Bot::GetRaid)
 	.def("GetRawItemAC", (int(Lua_Bot::*)(void))&Lua_Bot::GetRawItemAC)
 	.def("GetSpellDamage", (int(Lua_Bot::*)(void))&Lua_Bot::GetSpellDamage)
 	.def("HasAugmentEquippedByID", (bool(Lua_Bot::*)(uint32))&Lua_Bot::HasAugmentEquippedByID)
 	.def("HasBotItem", (bool(Lua_Bot::*)(uint32))&Lua_Bot::HasBotItem)
 	.def("HasBotSpellEntry", (bool(Lua_Bot::*)(uint16)) & Lua_Bot::HasBotSpellEntry)
 	.def("HasItemEquippedByID", (bool(Lua_Bot::*)(uint32))&Lua_Bot::HasItemEquippedByID)
-	.def("InZone", (bool(Lua_Bot::*)(void))&Lua_Bot::InZone)
-	.def("IncStats", (void(Lua_Bot::*)(int,int))&Lua_Bot::IncStats)
 	.def("IsGrouped", (bool(Lua_Bot::*)(void))&Lua_Bot::IsGrouped)
-	.def("IsRaidGrouped", (bool(Lua_Bot::*)(void))&Lua_Bot::IsRaidGrouped)
 	.def("IsSitting", (bool(Lua_Bot::*)(void))&Lua_Bot::IsSitting)
 	.def("IsStanding", (bool(Lua_Bot::*)(void))&Lua_Bot::IsStanding)
 	.def("OwnerMessage", (void(Lua_Bot::*)(std::string))&Lua_Bot::OwnerMessage)
@@ -494,13 +420,8 @@ luabind::scope lua_register_bot() {
 	.def("SetSpellDurationGroup", (void(Lua_Bot::*)(int))&Lua_Bot::SetSpellDurationGroup)
 	.def("SetSpellDurationGroup", (void(Lua_Bot::*)(int,int))&Lua_Bot::SetSpellDurationGroup)
 	.def("SetSpellDurationGroup", (void(Lua_Bot::*)(int,int,bool))&Lua_Bot::SetSpellDurationGroup)
-	.def("SetSpellDurationRaid", (void(Lua_Bot::*)(int))&Lua_Bot::SetSpellDurationRaid)
-	.def("SetSpellDurationRaid", (void(Lua_Bot::*)(int,int))&Lua_Bot::SetSpellDurationRaid)
-	.def("SetSpellDurationRaid", (void(Lua_Bot::*)(int,int,bool))&Lua_Bot::SetSpellDurationRaid)
-	.def("SetSpellDurationRaid", (void(Lua_Bot::*)(int,int,bool,bool))&Lua_Bot::SetSpellDurationRaid)
 	.def("SendPayload", (void(Lua_Bot::*)(int))&Lua_Bot::SendPayload)
 	.def("SendPayload", (void(Lua_Bot::*)(int,std::string))&Lua_Bot::SendPayload)
-	.def("SetStats", (void(Lua_Bot::*)(int,int))&Lua_Bot::SetStats)
 	.def("Signal", (void(Lua_Bot::*)(int))&Lua_Bot::Signal)
 	.def("Sit", (void(Lua_Bot::*)(void))&Lua_Bot::Sit)
 	.def("Stand", (void(Lua_Bot::*)(void))&Lua_Bot::Stand);

--- a/zone/lua_bot.cpp
+++ b/zone/lua_bot.cpp
@@ -8,6 +8,8 @@
 #include "lua_bot.h"
 #include "lua_iteminst.h"
 #include "lua_mob.h"
+#include "lua_group.h"
+#include "lua_raid.h"
 
 void Lua_Bot::AddBotItem(uint16 slot_id, uint32 item_id) {
 	Lua_Safe_Call_Void();
@@ -144,6 +146,281 @@ void Lua_Bot::SendPayload(int payload_id, std::string payload_value) {
 	self->SendPayload(payload_id, payload_value);
 }
 
+void Lua_Bot::ApplySpell(int spell_id) {
+	Lua_Safe_Call_Void();
+	self->ApplySpell(spell_id);
+}
+
+void Lua_Bot::ApplySpell(int spell_id, int duration) {
+	Lua_Safe_Call_Void();
+	self->ApplySpell(spell_id, duration);
+}
+
+void Lua_Bot::ApplySpell(int spell_id, int duration, bool allow_pets) {
+	Lua_Safe_Call_Void();
+	self->ApplySpell(spell_id, duration, ApplySpellType::Solo, allow_pets);
+}
+
+void Lua_Bot::ApplySpellGroup(int spell_id) {
+	Lua_Safe_Call_Void();
+	self->ApplySpell(spell_id, 0, ApplySpellType::Group);
+}
+
+void Lua_Bot::ApplySpellGroup(int spell_id, int duration) {
+	Lua_Safe_Call_Void();
+	self->ApplySpell(spell_id, duration, ApplySpellType::Group);
+}
+
+void Lua_Bot::ApplySpellGroup(int spell_id, int duration, bool allow_pets) {
+	Lua_Safe_Call_Void();
+	self->ApplySpell(spell_id, duration, ApplySpellType::Group, allow_pets);
+}
+
+void Lua_Bot::ApplySpellRaid(int spell_id) {
+	Lua_Safe_Call_Void();
+	self->ApplySpell(spell_id, 0, ApplySpellType::Raid);
+}
+
+void Lua_Bot::ApplySpellRaid(int spell_id, int duration) {
+	Lua_Safe_Call_Void();
+	self->ApplySpell(spell_id, duration, ApplySpellType::Raid);
+}
+
+void Lua_Bot::ApplySpellRaid(int spell_id, int duration, bool allow_pets) {
+	Lua_Safe_Call_Void();
+	self->ApplySpell(spell_id, duration, ApplySpellType::Raid, allow_pets);
+}
+
+void Lua_Bot::ApplySpellRaid(int spell_id, int duration, bool allow_pets, bool is_raid_group_only) {
+	Lua_Safe_Call_Void();
+	self->ApplySpell(spell_id, duration, ApplySpellType::Raid, allow_pets, is_raid_group_only);
+}
+
+void Lua_Bot::SetSpellDuration(int spell_id) {
+	Lua_Safe_Call_Void();
+	self->SetSpellDuration(spell_id);
+}
+
+void Lua_Bot::SetSpellDuration(int spell_id, int duration) {
+	Lua_Safe_Call_Void();
+	self->SetSpellDuration(spell_id, duration);
+}
+
+void Lua_Bot::SetSpellDuration(int spell_id, int duration, bool allow_pets) {
+	Lua_Safe_Call_Void();
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Solo, allow_pets);
+}
+
+void Lua_Bot::SetSpellDurationGroup(int spell_id) {
+	Lua_Safe_Call_Void();
+	self->SetSpellDuration(spell_id, 0, ApplySpellType::Group);
+}
+
+void Lua_Bot::SetSpellDurationGroup(int spell_id, int duration) {
+	Lua_Safe_Call_Void();
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Group);
+}
+
+void Lua_Bot::SetSpellDurationGroup(int spell_id, int duration, bool allow_pets) {
+	Lua_Safe_Call_Void();
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Group, allow_pets);
+}
+
+void Lua_Bot::SetSpellDurationRaid(int spell_id) {
+	Lua_Safe_Call_Void();
+	self->SetSpellDuration(spell_id, 0, ApplySpellType::Raid);
+}
+
+void Lua_Bot::SetSpellDurationRaid(int spell_id, int duration) {
+	Lua_Safe_Call_Void();
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Raid);
+}
+
+void Lua_Bot::SetSpellDurationRaid(int spell_id, int duration, bool allow_pets) {
+	Lua_Safe_Call_Void();
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Raid, allow_pets);
+}
+
+void Lua_Bot::SetSpellDurationRaid(int spell_id, int duration, bool allow_pets, bool is_raid_group_only) {
+	Lua_Safe_Call_Void();
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Raid, allow_pets, is_raid_group_only);
+}
+
+int Lua_Bot::CountAugmentEquippedByID(uint32 item_id) {
+	Lua_Safe_Call_Int();
+	return self->GetBotInv().CountAugmentEquippedByID(item_id);
+}
+
+bool Lua_Bot::HasAugmentEquippedByID(uint32 item_id) {
+	Lua_Safe_Call_Bool();
+	return self->GetBotInv().HasAugmentEquippedByID(item_id);
+}
+
+int Lua_Bot::CountItemEquippedByID(uint32 item_id) {
+	Lua_Safe_Call_Int();
+	return self->GetBotInv().CountItemEquippedByID(item_id);
+}
+
+bool Lua_Bot::HasItemEquippedByID(uint32 item_id) {
+	Lua_Safe_Call_Bool();
+	return self->GetBotInv().HasItemEquippedByID(item_id);
+}
+
+void Lua_Bot::Escape() {
+	Lua_Safe_Call_Void();
+	self->Escape();
+}
+
+void Lua_Bot::Fling(float target_x, float target_y, float target_z) {
+	Lua_Safe_Call_Void();
+	self->Fling(0, target_x, target_y, target_z, false, false, true);
+}
+
+void Lua_Bot::Fling(float target_x, float target_y, float target_z, bool ignore_los) {
+	Lua_Safe_Call_Void();
+	self->Fling(0, target_x, target_y, target_z, ignore_los, false, true);
+}
+
+void Lua_Bot::Fling(float target_x, float target_y, float target_z, bool ignore_los, bool clip_through_walls) {
+	Lua_Safe_Call_Void();
+	self->Fling(0, target_x, target_y, target_z, ignore_los, clip_through_walls, true);
+}
+
+void Lua_Bot::Fling(float value, float target_x, float target_y, float target_z) {
+	Lua_Safe_Call_Void();
+	self->Fling(value, target_x, target_y, target_z);
+}
+
+void Lua_Bot::Fling(float value, float target_x, float target_y, float target_z, bool ignore_los) {
+	Lua_Safe_Call_Void();
+	self->Fling(value, target_x, target_y, target_z, ignore_los);
+}
+
+void Lua_Bot::Fling(float value, float target_x, float target_y, float target_z, bool ignore_los, bool clip_through_walls) {
+	Lua_Safe_Call_Void();
+	self->Fling(value, target_x, target_y, target_z, ignore_los, clip_through_walls);
+}
+
+int Lua_Bot::GetItemIDAt(int slot_id) {
+	Lua_Safe_Call_Int();
+	return self->GetItemIDAt(slot_id);
+}
+
+int Lua_Bot::GetAugmentIDAt(int slot_id, int aug_slot) {
+	Lua_Safe_Call_Int();
+	return self->GetAugmentIDAt(slot_id, aug_slot);
+}
+
+int Lua_Bot::GetBaseSTR() {
+	Lua_Safe_Call_Int();
+	return self->GetBaseSTR();
+}
+
+int Lua_Bot::GetBaseSTA() {
+	Lua_Safe_Call_Int();
+	return self->GetBaseSTA();
+}
+
+int Lua_Bot::GetBaseCHA() {
+	Lua_Safe_Call_Int();
+	return self->GetBaseCHA();
+}
+
+int Lua_Bot::GetBaseDEX() {
+	Lua_Safe_Call_Int();
+	return self->GetBaseDEX();
+}
+
+int Lua_Bot::GetBaseINT() {
+	Lua_Safe_Call_Int();
+	return self->GetBaseINT();
+}
+
+int Lua_Bot::GetBaseAGI() {
+	Lua_Safe_Call_Int();
+	return self->GetBaseAGI();
+}
+
+int Lua_Bot::GetBaseWIS() {
+	Lua_Safe_Call_Int();
+	return self->GetBaseWIS();
+}
+
+Lua_Group Lua_Bot::GetGroup() {
+	Lua_Safe_Call_Class(Lua_Group);
+	return self->GetGroup();
+}
+
+Lua_Raid Lua_Bot::GetRaid() {
+	Lua_Safe_Call_Class(Lua_Raid);
+	return self->GetRaid();
+}
+
+int Lua_Bot::GetHealAmount() {
+	Lua_Safe_Call_Int();
+	return self->GetHealAmt();
+}
+
+int Lua_Bot::GetSpellDamage() {
+	Lua_Safe_Call_Int();
+	return self->GetSpellDmg();
+}
+
+int Lua_Bot::GetInstrumentMod(int spell_id) {
+	Lua_Safe_Call_Int();
+	return self->GetInstrumentMod(spell_id);
+}
+
+int Lua_Bot::GetRawItemAC() {
+	Lua_Safe_Call_Int();
+	return self->GetRawItemAC();
+}
+
+bool Lua_Bot::InZone() {
+	Lua_Safe_Call_Bool();
+	return self->InZone();
+}
+
+void Lua_Bot::IncStats(int type, int value) {
+	Lua_Safe_Call_Void();
+	self->IncStats(type, value);
+}
+
+bool Lua_Bot::IsGrouped() {
+	Lua_Safe_Call_Bool();
+	return self->IsGrouped();
+}
+
+bool Lua_Bot::IsRaidGrouped() {
+	Lua_Safe_Call_Bool();
+	return self->IsRaidGrouped();
+}
+
+bool Lua_Bot::IsStanding() {
+	Lua_Safe_Call_Bool();
+	return self->IsStanding();
+}
+
+bool Lua_Bot::IsSitting() {
+	Lua_Safe_Call_Bool();
+	return self->IsSitting();
+}
+
+void Lua_Bot::SetStats(int type, int value) {
+	Lua_Safe_Call_Void();
+	self->SetStats(type, value);
+}
+
+void Lua_Bot::Sit() {
+	Lua_Safe_Call_Void();
+	self->Sit();
+}
+
+void Lua_Bot::Stand() {
+	Lua_Safe_Call_Void();
+	self->Stand();
+}
+
 luabind::scope lua_register_bot() {
 	return luabind::class_<Lua_Bot, Lua_Mob>("Bot")
 	.def(luabind::constructor<>())
@@ -156,13 +433,53 @@ luabind::scope lua_register_bot() {
 	.def("AddBotItem", (void(Lua_Bot::*)(uint16,uint32,int16,bool,uint32,uint32,uint32,uint32))&Lua_Bot::AddBotItem)
 	.def("AddBotItem", (void(Lua_Bot::*)(uint16,uint32,int16,bool,uint32,uint32,uint32,uint32,uint32))&Lua_Bot::AddBotItem)
 	.def("AddBotItem", (void(Lua_Bot::*)(uint16,uint32,int16,bool,uint32,uint32,uint32,uint32,uint32,uint32))&Lua_Bot::AddBotItem)
+	.def("ApplySpell", (void(Lua_Bot::*)(int))&Lua_Bot::ApplySpell)
+	.def("ApplySpell", (void(Lua_Bot::*)(int,int))&Lua_Bot::ApplySpell)
+	.def("ApplySpell", (void(Lua_Bot::*)(int,int,bool))&Lua_Bot::ApplySpell)
+	.def("ApplySpellGroup", (void(Lua_Bot::*)(int))&Lua_Bot::ApplySpellGroup)
+	.def("ApplySpellGroup", (void(Lua_Bot::*)(int,int))&Lua_Bot::ApplySpellGroup)
+	.def("ApplySpellGroup", (void(Lua_Bot::*)(int,int,bool))&Lua_Bot::ApplySpellGroup)
+	.def("ApplySpellRaid", (void(Lua_Bot::*)(int))&Lua_Bot::ApplySpellRaid)
+	.def("ApplySpellRaid", (void(Lua_Bot::*)(int,int))&Lua_Bot::ApplySpellRaid)
+	.def("ApplySpellRaid", (void(Lua_Bot::*)(int,int,bool))&Lua_Bot::ApplySpellRaid)
+	.def("ApplySpellRaid", (void(Lua_Bot::*)(int,int,bool,bool))&Lua_Bot::ApplySpellRaid)
 	.def("CountBotItem", (uint32(Lua_Bot::*)(uint32))&Lua_Bot::CountBotItem)
+	.def("CountItemEquippedByID", (int(Lua_Bot::*)(uint32))&Lua_Bot::CountItemEquippedByID)
+	.def("Escape", (void(Lua_Bot::*)(void))&Lua_Bot::Escape)
+	.def("Fling", (void(Lua_Bot::*)(float,float,float))&Lua_Bot::Fling)
+	.def("Fling", (void(Lua_Bot::*)(float,float,float,bool))&Lua_Bot::Fling)
+	.def("Fling", (void(Lua_Bot::*)(float,float,float,bool,bool))&Lua_Bot::Fling)
+	.def("Fling", (void(Lua_Bot::*)(float,float,float,float))&Lua_Bot::Fling)
+	.def("Fling", (void(Lua_Bot::*)(float,float,float,float,bool))&Lua_Bot::Fling)
+	.def("Fling", (void(Lua_Bot::*)(float,float,float,float,bool,bool))&Lua_Bot::Fling)
+	.def("GetAugmentIDAt", (int(Lua_Bot::*)(int,int))&Lua_Bot::GetAugmentIDAt)
+	.def("GetBaseAGI", (int(Lua_Bot::*)(void))&Lua_Bot::GetBaseAGI)
+	.def("GetBaseCHA", (int(Lua_Bot::*)(void))&Lua_Bot::GetBaseCHA)
+	.def("GetBaseDEX", (int(Lua_Bot::*)(void))&Lua_Bot::GetBaseDEX)
+	.def("GetBaseINT", (int(Lua_Bot::*)(void))&Lua_Bot::GetBaseINT)
+	.def("GetBaseSTA", (int(Lua_Bot::*)(void))&Lua_Bot::GetBaseSTA)
+	.def("GetBaseSTR", (int(Lua_Bot::*)(void))&Lua_Bot::GetBaseSTR)
+	.def("GetBaseWIS", (int(Lua_Bot::*)(void))&Lua_Bot::GetBaseWIS)
 	.def("GetBotItem", (Lua_ItemInst(Lua_Bot::*)(uint16))&Lua_Bot::GetBotItem)
 	.def("GetBotItemIDBySlot", (uint32(Lua_Bot::*)(uint16))&Lua_Bot::GetBotItemIDBySlot)
 	.def("GetExpansionBitmask", (int(Lua_Bot::*)(void))&Lua_Bot::GetExpansionBitmask)
+	.def("GetGroup", (Lua_Group(Lua_Bot::*)(void))&Lua_Bot::GetGroup)
+	.def("GetHealAmount", (int(Lua_Bot::*)(void))&Lua_Bot::GetHealAmount)
+	.def("GetInstrumentMod", (int(Lua_Bot::*)(int))&Lua_Bot::GetInstrumentMod)
 	.def("GetOwner", (Lua_Mob(Lua_Bot::*)(void))&Lua_Bot::GetOwner)
+	.def("GetRaid", (Lua_Raid(Lua_Bot::*)(void))&Lua_Bot::GetRaid)
+	.def("GetRawItemAC", (int(Lua_Bot::*)(void))&Lua_Bot::GetRawItemAC)
+	.def("GetSpellDamage", (int(Lua_Bot::*)(void))&Lua_Bot::GetSpellDamage)
+	.def("HasAugmentEquippedByID", (bool(Lua_Bot::*)(uint32))&Lua_Bot::HasAugmentEquippedByID)
 	.def("HasBotItem", (bool(Lua_Bot::*)(uint32))&Lua_Bot::HasBotItem)
 	.def("HasBotSpellEntry", (bool(Lua_Bot::*)(uint16)) & Lua_Bot::HasBotSpellEntry)
+	.def("HasItemEquippedByID", (bool(Lua_Bot::*)(uint32))&Lua_Bot::HasItemEquippedByID)
+	.def("InZone", (bool(Lua_Bot::*)(void))&Lua_Bot::InZone)
+	.def("IncStats", (void(Lua_Bot::*)(int,int))&Lua_Bot::IncStats)
+	.def("IsGrouped", (bool(Lua_Bot::*)(void))&Lua_Bot::IsGrouped)
+	.def("IsRaidGrouped", (bool(Lua_Bot::*)(void))&Lua_Bot::IsRaidGrouped)
+	.def("IsSitting", (bool(Lua_Bot::*)(void))&Lua_Bot::IsSitting)
+	.def("IsStanding", (bool(Lua_Bot::*)(void))&Lua_Bot::IsStanding)
 	.def("OwnerMessage", (void(Lua_Bot::*)(std::string))&Lua_Bot::OwnerMessage)
 	.def("ReloadBotDataBuckets", (bool(Lua_Bot::*)(void))&Lua_Bot::ReloadBotDataBuckets)
 	.def("ReloadBotOwnerDataBuckets", (bool(Lua_Bot::*)(void))&Lua_Bot::ReloadBotOwnerDataBuckets)
@@ -171,9 +488,22 @@ luabind::scope lua_register_bot() {
 	.def("RemoveBotItem", (void(Lua_Bot::*)(uint32))&Lua_Bot::RemoveBotItem)
 	.def("SetExpansionBitmask", (void(Lua_Bot::*)(int))&Lua_Bot::SetExpansionBitmask)
 	.def("SetExpansionBitmask", (void(Lua_Bot::*)(int,bool))&Lua_Bot::SetExpansionBitmask)
+	.def("SetSpellDuration", (void(Lua_Bot::*)(int))&Lua_Bot::SetSpellDuration)
+	.def("SetSpellDuration", (void(Lua_Bot::*)(int,int))&Lua_Bot::SetSpellDuration)
+	.def("SetSpellDuration", (void(Lua_Bot::*)(int,int,bool))&Lua_Bot::SetSpellDuration)
+	.def("SetSpellDurationGroup", (void(Lua_Bot::*)(int))&Lua_Bot::SetSpellDurationGroup)
+	.def("SetSpellDurationGroup", (void(Lua_Bot::*)(int,int))&Lua_Bot::SetSpellDurationGroup)
+	.def("SetSpellDurationGroup", (void(Lua_Bot::*)(int,int,bool))&Lua_Bot::SetSpellDurationGroup)
+	.def("SetSpellDurationRaid", (void(Lua_Bot::*)(int))&Lua_Bot::SetSpellDurationRaid)
+	.def("SetSpellDurationRaid", (void(Lua_Bot::*)(int,int))&Lua_Bot::SetSpellDurationRaid)
+	.def("SetSpellDurationRaid", (void(Lua_Bot::*)(int,int,bool))&Lua_Bot::SetSpellDurationRaid)
+	.def("SetSpellDurationRaid", (void(Lua_Bot::*)(int,int,bool,bool))&Lua_Bot::SetSpellDurationRaid)
 	.def("SendPayload", (void(Lua_Bot::*)(int))&Lua_Bot::SendPayload)
 	.def("SendPayload", (void(Lua_Bot::*)(int,std::string))&Lua_Bot::SendPayload)
-	.def("Signal", (void(Lua_Bot::*)(int))&Lua_Bot::Signal);
+	.def("SetStats", (void(Lua_Bot::*)(int,int))&Lua_Bot::SetStats)
+	.def("Signal", (void(Lua_Bot::*)(int))&Lua_Bot::Signal)
+	.def("Sit", (void(Lua_Bot::*)(void))&Lua_Bot::Sit)
+	.def("Stand", (void(Lua_Bot::*)(void))&Lua_Bot::Stand);
 }
 
 #endif

--- a/zone/lua_bot.h
+++ b/zone/lua_bot.h
@@ -9,7 +9,6 @@ class Bot;
 class Lua_Bot;
 class Lua_Mob;
 class Lua_Group;
-class Lua_Raid;
 
 namespace luabind {
 	struct scope;
@@ -65,11 +64,6 @@ public:
 	void ApplySpellGroup(int spell_id, int duration);
 	void ApplySpellGroup(int spell_id, int duration, bool allow_pets);
 
-	void ApplySpellRaid(int spell_id);
-	void ApplySpellRaid(int spell_id, int duration);
-	void ApplySpellRaid(int spell_id, int duration, bool allow_pets);
-	void ApplySpellRaid(int spell_id, int duration, bool allow_pets, bool is_raid_group_only);
-
 	void SetSpellDuration(int spell_id);
 	void SetSpellDuration(int spell_id, int duration);
 	void SetSpellDuration(int spell_id, int duration, bool allow_pets);
@@ -103,15 +97,11 @@ public:
 	int GetBaseINT();
 	int GetBaseAGI();
 	int GetBaseWIS();
-	bool InZone();
-	virtual Lua_Group GetGroup();
-	virtual Lua_Raid GetRaid();
+
+	Lua_Group GetGroup();
 	int GetRawItemAC();
 
-	void SetStats(int type, int value);
-	void IncStats(int type, int value);
 	bool IsGrouped();
-	bool IsRaidGrouped();
 	bool IsStanding();
 	bool IsSitting();
 	void Sit();

--- a/zone/lua_bot.h
+++ b/zone/lua_bot.h
@@ -8,6 +8,8 @@
 class Bot;
 class Lua_Bot;
 class Lua_Mob;
+class Lua_Group;
+class Lua_Raid;
 
 namespace luabind {
 	struct scope;
@@ -54,6 +56,73 @@ public:
 	bool HasBotSpellEntry(uint16 spellid);
 	void SendPayload(int payload_id);
 	void SendPayload(int payload_id, std::string payload_value);
+
+	void ApplySpell(int spell_id);
+	void ApplySpell(int spell_id, int duration);
+	void ApplySpell(int spell_id, int duration, bool allow_pets);
+
+	void ApplySpellGroup(int spell_id);
+	void ApplySpellGroup(int spell_id, int duration);
+	void ApplySpellGroup(int spell_id, int duration, bool allow_pets);
+
+	void ApplySpellRaid(int spell_id);
+	void ApplySpellRaid(int spell_id, int duration);
+	void ApplySpellRaid(int spell_id, int duration, bool allow_pets);
+	void ApplySpellRaid(int spell_id, int duration, bool allow_pets, bool is_raid_group_only);
+
+	void SetSpellDuration(int spell_id);
+	void SetSpellDuration(int spell_id, int duration);
+	void SetSpellDuration(int spell_id, int duration, bool allow_pets);
+
+	void SetSpellDurationGroup(int spell_id);
+	void SetSpellDurationGroup(int spell_id, int duration);
+	void SetSpellDurationGroup(int spell_id, int duration, bool allow_pets);
+
+	void SetSpellDurationRaid(int spell_id);
+	void SetSpellDurationRaid(int spell_id, int duration);
+	void SetSpellDurationRaid(int spell_id, int duration, bool allow_pets);
+	void SetSpellDurationRaid(int spell_id, int duration, bool allow_pets, bool is_raid_group_only);
+
+	int CountAugmentEquippedByID(uint32 item_id);
+	int CountItemEquippedByID(uint32 item_id);
+	bool HasAugmentEquippedByID(uint32 item_id);
+	bool HasItemEquippedByID(uint32 item_id);
+	int GetHealAmount();
+	int GetSpellDamage();
+
+	void Escape();
+	int GetInstrumentMod(int spell_id);
+
+	int GetItemIDAt(int slot_id);
+	int GetAugmentIDAt(int slot_id, int aug_slot);
+
+	int GetBaseSTR();
+	int GetBaseSTA();
+	int GetBaseCHA();
+	int GetBaseDEX();
+	int GetBaseINT();
+	int GetBaseAGI();
+	int GetBaseWIS();
+	bool InZone();
+	virtual Lua_Group GetGroup();
+	virtual Lua_Raid GetRaid();
+	int GetRawItemAC();
+
+	void SetStats(int type, int value);
+	void IncStats(int type, int value);
+	bool IsGrouped();
+	bool IsRaidGrouped();
+	bool IsStanding();
+	bool IsSitting();
+	void Sit();
+	void Stand();
+
+	void Fling(float target_x, float target_y, float target_z);
+	void Fling(float target_x, float target_y, float target_z, bool ignore_los);
+	void Fling(float target_x, float target_y, float target_z, bool ignore_los, bool clip_through_walls);
+	void Fling(float value, float target_x, float target_y, float target_z);
+	void Fling(float value, float target_x, float target_y, float target_z, bool ignore_los);
+	void Fling(float value, float target_x, float target_y, float target_z, bool ignore_los, bool clip_through_walls);
 };
 
 #endif

--- a/zone/lua_group.h
+++ b/zone/lua_group.h
@@ -8,6 +8,10 @@ class Group;
 class Lua_Mob;
 class Lua_Client;
 
+#ifdef BOTS
+class Lua_Bot;
+#endif
+
 namespace luabind {
 	struct scope;
 }

--- a/zone/perl_bot.cpp
+++ b/zone/perl_bot.cpp
@@ -86,26 +86,6 @@ void Perl_Bot_ApplySpellGroup(Bot* self, int spell_id, int duration, bool allow_
 	self->ApplySpell(spell_id, duration, ApplySpellType::Group, allow_pets);
 }
 
-void Perl_Bot_ApplySpellRaid(Bot* self, int spell_id)
-{
-	self->ApplySpell(spell_id, 0, ApplySpellType::Raid);
-}
-
-void Perl_Bot_ApplySpellRaid(Bot* self, int spell_id, int duration)
-{
-	self->ApplySpell(spell_id, duration, ApplySpellType::Raid);
-}
-
-void Perl_Bot_ApplySpellRaid(Bot* self, int spell_id, int duration, bool allow_pets)
-{
-	self->ApplySpell(spell_id, duration, ApplySpellType::Raid, allow_pets);
-}
-
-void Perl_Bot_ApplySpellRaid(Bot* self, int spell_id, int duration, bool allow_pets, bool is_raid_group_only)
-{
-	self->ApplySpell(spell_id, duration, ApplySpellType::Raid, allow_pets, is_raid_group_only);
-}
-
 uint32 Perl_Bot_CountBotItem(Bot* self, uint32 item_id)
 {
 	return self->CountBotItem(item_id);
@@ -164,16 +144,6 @@ EQ::ItemInstance* Perl_Bot_GetBotItem(Bot* self, uint16 slot_id)
 uint32 Perl_Bot_GetBotItemIDBySlot(Bot* self, uint16 slot_id)
 {
 	return self->GetBotItemBySlot(slot_id);
-}
-
-bool Perl_Bot_InZone(Bot* self) // @categories Script Utility
-{
-	return self->InZone();
-}
-
-void Perl_Bot_IncStats(Bot* self, uint8 type, uint16 increase_val) // @categories Account and Character, Stats and Attributes
-{
-	self->IncStats(type, increase_val);
 }
 
 bool Perl_Bot_IsStanding(Bot* self) // @categories Account and Character
@@ -321,19 +291,9 @@ EQ::ItemInstance* Perl_Bot_GetItemAt(Bot* self, uint32 slot) // @categories Inve
 	return self->GetBotInv().GetItem(slot);
 }
 
-Raid* Perl_Bot_GetRaid(Bot* self) // @categories Account and Character, Raid
-{
-	return self->GetRaid();
-}
-
 bool Perl_Bot_IsGrouped(Bot* self) // @categories Account and Character, Group
 {
 	return self->IsGrouped();
-}
-
-bool Perl_Bot_IsRaidGrouped(Bot* self) // @categories Account and Character, Group, Raid
-{
-	return self->IsRaidGrouped();
 }
 
 void Perl_Bot_SetExpansionBitmask(Bot* self, int expansion_bitmask)
@@ -344,11 +304,6 @@ void Perl_Bot_SetExpansionBitmask(Bot* self, int expansion_bitmask)
 void Perl_Bot_SetExpansionBitmask(Bot* self, int expansion_bitmask, bool save)
 {
 	self->SetExpansionBitmask(expansion_bitmask, save);
-}
-
-void Perl_Bot_SetStats(Bot* self, uint8 type, uint16 increase_val) // @categories Account and Character, Stats and Attributes
-{
-	self->SetStats(type, increase_val);
 }
 
 void Perl_Bot_SetSpellDuration(Bot* self, int spell_id)
@@ -379,26 +334,6 @@ void Perl_Bot_SetSpellDurationGroup(Bot* self, int spell_id, int duration)
 void Perl_Bot_SetSpellDurationGroup(Bot* self, int spell_id, int duration, bool allow_pets)
 {
 	self->SetSpellDuration(spell_id, duration, ApplySpellType::Group, allow_pets);
-}
-
-void Perl_Bot_SetSpellDurationRaid(Bot* self, int spell_id)
-{
-	self->ApplySpell(spell_id, 0, ApplySpellType::Raid);
-}
-
-void Perl_Bot_SetSpellDurationRaid(Bot* self, int spell_id, int duration)
-{
-	self->ApplySpell(spell_id, duration, ApplySpellType::Raid);
-}
-
-void Perl_Bot_SetSpellDurationRaid(Bot* self, int spell_id, int duration, bool allow_pets)
-{
-	self->SetSpellDuration(spell_id, duration, ApplySpellType::Raid, allow_pets);
-}
-
-void Perl_Bot_SetSpellDurationRaid(Bot* self, int spell_id, int duration, bool allow_pets, bool is_raid_group_only)
-{
-	self->SetSpellDuration(spell_id, duration, ApplySpellType::Raid, allow_pets, is_raid_group_only);
 }
 
 bool Perl_Bot_ReloadBotDataBuckets(Bot* self)
@@ -457,10 +392,6 @@ void perl_register_bot()
 	package.add("ApplySpellGroup", (void(*)(Bot*, int))&Perl_Bot_ApplySpellGroup);
 	package.add("ApplySpellGroup", (void(*)(Bot*, int, int))&Perl_Bot_ApplySpellGroup);
 	package.add("ApplySpellGroup", (void(*)(Bot*, int, int, bool))&Perl_Bot_ApplySpellGroup);
-	package.add("ApplySpellRaid", (void(*)(Bot*, int))&Perl_Bot_ApplySpellRaid);
-	package.add("ApplySpellRaid", (void(*)(Bot*, int, int))&Perl_Bot_ApplySpellRaid);
-	package.add("ApplySpellRaid", (void(*)(Bot*, int, int, bool))&Perl_Bot_ApplySpellRaid);
-	package.add("ApplySpellRaid", (void(*)(Bot*, int, int, bool, bool))&Perl_Bot_ApplySpellRaid);
 	package.add("CountAugmentEquippedByID", &Perl_Bot_CountAugmentEquippedByID);
 	package.add("CountBotItem", &Perl_Bot_CountBotItem); 
 	package.add("CountItemEquippedByID", &Perl_Bot_CountItemEquippedByID);
@@ -489,17 +420,13 @@ void perl_register_bot()
 	package.add("GetItemAt", &Perl_Bot_GetItemAt);
 	package.add("GetItemIDAt", &Perl_Bot_GetItemIDAt);
 	package.add("GetOwner", &Perl_Bot_GetOwner);
-	package.add("GetRaid", &Perl_Bot_GetRaid);
 	package.add("GetRawItemAC", &Perl_Bot_GetRawItemAC);
 	package.add("GetSpellDamage", &Perl_Bot_GetSpellDamage);
 	package.add("HasAugmentEquippedByID", &Perl_Bot_HasAugmentEquippedByID);
 	package.add("HasBotItem", &Perl_Bot_HasBotItem);
 	package.add("HasBotSpellEntry", &Perl_Bot_HasBotSpellEntry);
 	package.add("HasItemEquippedByID", &Perl_Bot_HasItemEquippedByID);
-	package.add("InZone", &Perl_Bot_InZone);
-	package.add("IncStats", &Perl_Bot_IncStats);
 	package.add("IsGrouped", &Perl_Bot_IsGrouped);
-	package.add("IsRaidGrouped", &Perl_Bot_IsRaidGrouped);
 	package.add("IsSitting", &Perl_Bot_IsSitting);
 	package.add("IsStanding", &Perl_Bot_IsStanding);
 	package.add("OwnerMessage", &Perl_Bot_OwnerMessage);
@@ -519,11 +446,6 @@ void perl_register_bot()
 	package.add("SetSpellDurationGroup", (void(*)(Bot*, int))&Perl_Bot_SetSpellDurationGroup);
 	package.add("SetSpellDurationGroup", (void(*)(Bot*, int, int))&Perl_Bot_SetSpellDurationGroup);
 	package.add("SetSpellDurationGroup", (void(*)(Bot*, int, int, bool))&Perl_Bot_SetSpellDurationGroup);
-	package.add("SetSpellDurationRaid", (void(*)(Bot*, int))&Perl_Bot_SetSpellDurationRaid);
-	package.add("SetSpellDurationRaid", (void(*)(Bot*, int, int))&Perl_Bot_SetSpellDurationRaid);
-	package.add("SetSpellDurationRaid", (void(*)(Bot*, int, int, bool))&Perl_Bot_SetSpellDurationRaid);
-	package.add("SetSpellDurationRaid", (void(*)(Bot*, int, int, bool, bool))&Perl_Bot_SetSpellDurationRaid);
-	package.add("SetStats", &Perl_Bot_SetStats);
 	package.add("Signal", &Perl_Bot_Signal);
 	package.add("Sit", &Perl_Bot_Sit);
 	package.add("Stand", &Perl_Bot_Stand);

--- a/zone/perl_bot.cpp
+++ b/zone/perl_bot.cpp
@@ -56,6 +56,56 @@ void Perl_Bot_AddBotItem(Bot* self, uint16 slot_id, uint32 item_id, uint16 charg
 	self->AddBotItem(slot_id, item_id, charges, attuned, aug1, aug2, aug3, aug4, aug5, aug6);
 }
 
+void Perl_Bot_ApplySpell(Bot* self, int spell_id)
+{
+	self->ApplySpell(spell_id);
+}
+
+void Perl_Bot_ApplySpell(Bot* self, int spell_id, int duration)
+{
+	self->ApplySpell(spell_id, duration);
+}
+
+void Perl_Bot_ApplySpell(Bot* self, int spell_id, int duration, bool allow_pets)
+{
+	self->ApplySpell(spell_id, duration, ApplySpellType::Solo, allow_pets);
+}
+
+void Perl_Bot_ApplySpellGroup(Bot* self, int spell_id)
+{
+	self->ApplySpell(spell_id, 0, ApplySpellType::Group);
+}
+
+void Perl_Bot_ApplySpellGroup(Bot* self, int spell_id, int duration)
+{
+	self->ApplySpell(spell_id, duration, ApplySpellType::Group);
+}
+
+void Perl_Bot_ApplySpellGroup(Bot* self, int spell_id, int duration, bool allow_pets)
+{
+	self->ApplySpell(spell_id, duration, ApplySpellType::Group, allow_pets);
+}
+
+void Perl_Bot_ApplySpellRaid(Bot* self, int spell_id)
+{
+	self->ApplySpell(spell_id, 0, ApplySpellType::Raid);
+}
+
+void Perl_Bot_ApplySpellRaid(Bot* self, int spell_id, int duration)
+{
+	self->ApplySpell(spell_id, duration, ApplySpellType::Raid);
+}
+
+void Perl_Bot_ApplySpellRaid(Bot* self, int spell_id, int duration, bool allow_pets)
+{
+	self->ApplySpell(spell_id, duration, ApplySpellType::Raid, allow_pets);
+}
+
+void Perl_Bot_ApplySpellRaid(Bot* self, int spell_id, int duration, bool allow_pets, bool is_raid_group_only)
+{
+	self->ApplySpell(spell_id, duration, ApplySpellType::Raid, allow_pets, is_raid_group_only);
+}
+
 uint32 Perl_Bot_CountBotItem(Bot* self, uint32 item_id)
 {
 	return self->CountBotItem(item_id);
@@ -71,6 +121,41 @@ void Perl_Bot_RemoveBotItem(Bot* self, uint32 item_id)
 	return self->RemoveBotItem(item_id);
 }
 
+EQ::ItemInstance* Perl_Bot_GetAugmentAt(Bot* self, uint32 slot, uint32 aug_slot)
+{
+	EQ::ItemInstance* inst = self->GetBotInv().GetItem(slot);
+	if (inst)
+	{
+		return inst->GetAugment(aug_slot);
+	}
+	return nullptr;
+}
+
+int Perl_Bot_CountAugmentEquippedByID(Bot* self, uint32 item_id)
+{
+	return self->GetBotInv().CountAugmentEquippedByID(item_id);
+}
+
+bool Perl_Bot_HasAugmentEquippedByID(Bot* self, uint32 item_id)
+{
+	return self->GetBotInv().HasAugmentEquippedByID(item_id);
+}
+
+int Perl_Bot_CountItemEquippedByID(Bot* self, uint32 item_id)
+{
+	return self->GetBotInv().CountItemEquippedByID(item_id);
+}
+
+bool Perl_Bot_HasItemEquippedByID(Bot* self, uint32 item_id)
+{
+	return self->GetBotInv().HasItemEquippedByID(item_id);
+}
+
+int Perl_Bot_GetRawItemAC(Bot* self) // @categories Inventory and Items
+{
+	return self->GetRawItemAC();
+}
+
 EQ::ItemInstance* Perl_Bot_GetBotItem(Bot* self, uint16 slot_id)
 {
 	return self->GetBotItem(slot_id);
@@ -79,6 +164,36 @@ EQ::ItemInstance* Perl_Bot_GetBotItem(Bot* self, uint16 slot_id)
 uint32 Perl_Bot_GetBotItemIDBySlot(Bot* self, uint16 slot_id)
 {
 	return self->GetBotItemBySlot(slot_id);
+}
+
+bool Perl_Bot_InZone(Bot* self) // @categories Script Utility
+{
+	return self->InZone();
+}
+
+void Perl_Bot_IncStats(Bot* self, uint8 type, uint16 increase_val) // @categories Account and Character, Stats and Attributes
+{
+	self->IncStats(type, increase_val);
+}
+
+bool Perl_Bot_IsStanding(Bot* self) // @categories Account and Character
+{
+	return self->IsStanding();
+}
+
+void Perl_Bot_Sit(Bot* self)
+{
+	self->Sit();
+}
+
+bool Perl_Bot_IsSitting(Bot* self) // @categories Account and Character
+{
+	return self->IsSitting();
+}
+
+void Perl_Bot_SendSpellAnim(Bot* self, uint16 targetid, uint16 spell_id)
+{
+	self->SendSpellAnim(targetid, spell_id);
 }
 
 void Perl_Bot_Signal(Bot* self, int signal_id)
@@ -96,6 +211,131 @@ int Perl_Bot_GetExpansionBitmask(Bot* self)
 	return self->GetExpansionBitmask();
 }
 
+void Perl_Bot_Escape(Bot* self) // @categories Account and Character, Skills and Recipes
+{
+	self->Escape();
+}
+
+void Perl_Bot_Fling(Bot* self, float target_x, float target_y, float target_z)
+{
+	self->Fling(0, target_x, target_y, target_z, false, false, true);
+}
+
+void Perl_Bot_Fling(Bot* self, float target_x, float target_y, float target_z, bool ignore_los)
+{
+	self->Fling(0, target_x, target_y, target_z, ignore_los, false, true);
+}
+
+void Perl_Bot_Fling(Bot* self, float target_x, float target_y, float target_z, bool ignore_los, bool clip_through_walls)
+{
+	self->Fling(0, target_x, target_y, target_z, ignore_los, clip_through_walls, true);
+}
+
+void Perl_Bot_Fling(Bot* self, float value, float target_x, float target_y, float target_z)
+{
+	self->Fling(value, target_x, target_y, target_z);
+}
+
+void Perl_Bot_Fling(Bot* self, float value, float target_x, float target_y, float target_z, bool ignore_los)
+{
+	self->Fling(value, target_x, target_y, target_z, ignore_los);
+}
+
+void Perl_Bot_Fling(Bot* self, float value, float target_x, float target_y, float target_z, bool ignore_los, bool clip_through_walls)
+{
+	self->Fling(value, target_x, target_y, target_z, ignore_los, clip_through_walls);
+}
+
+void Perl_Bot_Stand(Bot* self) // @categories Script Utility
+{
+	self->Stand();
+}
+
+int Perl_Bot_GetItemIDAt(Bot* self, int16 slot_id) // @categories Inventory and Items
+{
+	return self->GetItemIDAt(slot_id);
+}
+
+int Perl_Bot_GetAugmentIDAt(Bot* self, int16 slot_id, uint8 aug_slot) // @categories Inventory and Items
+{
+	return self->GetAugmentIDAt(slot_id, aug_slot);
+}
+
+int Perl_Bot_GetBaseSTR(Bot* self) // @categories Stats and Attributes
+{
+	return self->GetBaseSTR();
+}
+
+int Perl_Bot_GetBaseSTA(Bot* self) // @categories Stats and Attributes
+{
+	return self->GetBaseSTA();
+}
+
+int Perl_Bot_GetBaseCHA(Bot* self) // @categories Stats and Attributes
+{
+	return self->GetBaseCHA();
+}
+
+int Perl_Bot_GetBaseDEX(Bot* self) // @categories Stats and Attributes
+{
+	return self->GetBaseDEX();
+}
+
+int Perl_Bot_GetBaseINT(Bot* self) // @categories Stats and Attributes
+{
+	return self->GetBaseINT();
+}
+
+int Perl_Bot_GetBaseAGI(Bot* self) // @categories Stats and Attributes
+{
+	return self->GetBaseAGI();
+}
+
+int Perl_Bot_GetBaseWIS(Bot* self) // @categories Stats and Attributes
+{
+	return self->GetBaseWIS();
+}
+
+Group* Perl_Bot_GetGroup(Bot* self) // @categories Account and Character, Group
+{
+	return self->GetGroup();
+}
+
+int Perl_Bot_GetHealAmount(Bot* self)
+{
+	return self->GetHealAmt();
+}
+
+int Perl_Bot_GetSpellDamage(Bot* self)
+{
+	return self->GetSpellDmg();
+}
+
+int Perl_Bot_GetInstrumentMod(Bot* self, uint16 spell_id) // @categories Spells and Disciplines
+{
+	return self->GetInstrumentMod(spell_id);
+}
+
+EQ::ItemInstance* Perl_Bot_GetItemAt(Bot* self, uint32 slot) // @categories Inventory and Items
+{
+	return self->GetBotInv().GetItem(slot);
+}
+
+Raid* Perl_Bot_GetRaid(Bot* self) // @categories Account and Character, Raid
+{
+	return self->GetRaid();
+}
+
+bool Perl_Bot_IsGrouped(Bot* self) // @categories Account and Character, Group
+{
+	return self->IsGrouped();
+}
+
+bool Perl_Bot_IsRaidGrouped(Bot* self) // @categories Account and Character, Group, Raid
+{
+	return self->IsRaidGrouped();
+}
+
 void Perl_Bot_SetExpansionBitmask(Bot* self, int expansion_bitmask)
 {
 	self->SetExpansionBitmask(expansion_bitmask);
@@ -104,6 +344,61 @@ void Perl_Bot_SetExpansionBitmask(Bot* self, int expansion_bitmask)
 void Perl_Bot_SetExpansionBitmask(Bot* self, int expansion_bitmask, bool save)
 {
 	self->SetExpansionBitmask(expansion_bitmask, save);
+}
+
+void Perl_Bot_SetStats(Bot* self, uint8 type, uint16 increase_val) // @categories Account and Character, Stats and Attributes
+{
+	self->SetStats(type, increase_val);
+}
+
+void Perl_Bot_SetSpellDuration(Bot* self, int spell_id)
+{
+	self->SetSpellDuration(spell_id);
+}
+
+void Perl_Bot_SetSpellDuration(Bot* self, int spell_id, int duration)
+{
+	self->SetSpellDuration(spell_id, duration);
+}
+
+void Perl_Bot_SetSpellDuration(Bot* self, int spell_id, int duration, bool allow_pets)
+{
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Solo, allow_pets);
+}
+
+void Perl_Bot_SetSpellDurationGroup(Bot* self, int spell_id)
+{
+	self->SetSpellDuration(spell_id, 0, ApplySpellType::Group);
+}
+
+void Perl_Bot_SetSpellDurationGroup(Bot* self, int spell_id, int duration)
+{
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Group);
+}
+
+void Perl_Bot_SetSpellDurationGroup(Bot* self, int spell_id, int duration, bool allow_pets)
+{
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Group, allow_pets);
+}
+
+void Perl_Bot_SetSpellDurationRaid(Bot* self, int spell_id)
+{
+	self->ApplySpell(spell_id, 0, ApplySpellType::Raid);
+}
+
+void Perl_Bot_SetSpellDurationRaid(Bot* self, int spell_id, int duration)
+{
+	self->ApplySpell(spell_id, duration, ApplySpellType::Raid);
+}
+
+void Perl_Bot_SetSpellDurationRaid(Bot* self, int spell_id, int duration, bool allow_pets)
+{
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Raid, allow_pets);
+}
+
+void Perl_Bot_SetSpellDurationRaid(Bot* self, int spell_id, int duration, bool allow_pets, bool is_raid_group_only)
+{
+	self->SetSpellDuration(spell_id, duration, ApplySpellType::Raid, allow_pets, is_raid_group_only);
 }
 
 bool Perl_Bot_ReloadBotDataBuckets(Bot* self)
@@ -156,13 +451,57 @@ void perl_register_bot()
 	package.add("AddBotItem", (void(*)(Bot*, uint16, uint32, uint16, bool, uint32, uint32, uint32, uint32))&Perl_Bot_AddBotItem);
 	package.add("AddBotItem", (void(*)(Bot*, uint16, uint32, uint16, bool, uint32, uint32, uint32, uint32, uint32))&Perl_Bot_AddBotItem);
 	package.add("AddBotItem", (void(*)(Bot*, uint16, uint32, uint16, bool, uint32, uint32, uint32, uint32, uint32, uint32))&Perl_Bot_AddBotItem);
-	package.add("CountBotItem", &Perl_Bot_CountBotItem);
+	package.add("ApplySpell", (void(*)(Bot*, int))&Perl_Bot_ApplySpell);
+	package.add("ApplySpell", (void(*)(Bot*, int, int))&Perl_Bot_ApplySpell);
+	package.add("ApplySpell", (void(*)(Bot*, int, int, bool))&Perl_Bot_ApplySpell);
+	package.add("ApplySpellGroup", (void(*)(Bot*, int))&Perl_Bot_ApplySpellGroup);
+	package.add("ApplySpellGroup", (void(*)(Bot*, int, int))&Perl_Bot_ApplySpellGroup);
+	package.add("ApplySpellGroup", (void(*)(Bot*, int, int, bool))&Perl_Bot_ApplySpellGroup);
+	package.add("ApplySpellRaid", (void(*)(Bot*, int))&Perl_Bot_ApplySpellRaid);
+	package.add("ApplySpellRaid", (void(*)(Bot*, int, int))&Perl_Bot_ApplySpellRaid);
+	package.add("ApplySpellRaid", (void(*)(Bot*, int, int, bool))&Perl_Bot_ApplySpellRaid);
+	package.add("ApplySpellRaid", (void(*)(Bot*, int, int, bool, bool))&Perl_Bot_ApplySpellRaid);
+	package.add("CountAugmentEquippedByID", &Perl_Bot_CountAugmentEquippedByID);
+	package.add("CountBotItem", &Perl_Bot_CountBotItem); 
+	package.add("CountItemEquippedByID", &Perl_Bot_CountItemEquippedByID);
+	package.add("Escape", &Perl_Bot_Escape);
+	package.add("Fling", (void(*)(Bot*, float, float, float))&Perl_Bot_Fling);
+	package.add("Fling", (void(*)(Bot*, float, float, float, bool))&Perl_Bot_Fling);
+	package.add("Fling", (void(*)(Bot*, float, float, float, bool, bool))&Perl_Bot_Fling);
+	package.add("Fling", (void(*)(Bot*, float, float, float, float))&Perl_Bot_Fling);
+	package.add("Fling", (void(*)(Bot*, float, float, float, float, bool))&Perl_Bot_Fling);
+	package.add("Fling", (void(*)(Bot*, float, float, float, float, bool, bool))&Perl_Bot_Fling);
+	package.add("GetAugmentAt", &Perl_Bot_GetAugmentAt);
+	package.add("GetAugmentIDAt", &Perl_Bot_GetAugmentIDAt);
+	package.add("GetBaseAGI", &Perl_Bot_GetBaseAGI);
+	package.add("GetBaseCHA", &Perl_Bot_GetBaseCHA);
+	package.add("GetBaseDEX", &Perl_Bot_GetBaseDEX);
+	package.add("GetBaseINT", &Perl_Bot_GetBaseINT);
+	package.add("GetBaseSTA", &Perl_Bot_GetBaseSTA);
+	package.add("GetBaseSTR", &Perl_Bot_GetBaseSTR);
+	package.add("GetBaseWIS", &Perl_Bot_GetBaseWIS);
 	package.add("GetBotItem", &Perl_Bot_GetBotItem);
 	package.add("GetBotItemIDBySlot", &Perl_Bot_GetBotItemIDBySlot);
 	package.add("GetExpansionBitmask", &Perl_Bot_GetExpansionBitmask);
+	package.add("GetGroup", &Perl_Bot_GetGroup);
+	package.add("GetHealAmount", &Perl_Bot_GetHealAmount);
+	package.add("GetInstrumentMod", &Perl_Bot_GetInstrumentMod);
+	package.add("GetItemAt", &Perl_Bot_GetItemAt);
+	package.add("GetItemIDAt", &Perl_Bot_GetItemIDAt);
 	package.add("GetOwner", &Perl_Bot_GetOwner);
+	package.add("GetRaid", &Perl_Bot_GetRaid);
+	package.add("GetRawItemAC", &Perl_Bot_GetRawItemAC);
+	package.add("GetSpellDamage", &Perl_Bot_GetSpellDamage);
+	package.add("HasAugmentEquippedByID", &Perl_Bot_HasAugmentEquippedByID);
 	package.add("HasBotItem", &Perl_Bot_HasBotItem);
 	package.add("HasBotSpellEntry", &Perl_Bot_HasBotSpellEntry);
+	package.add("HasItemEquippedByID", &Perl_Bot_HasItemEquippedByID);
+	package.add("InZone", &Perl_Bot_InZone);
+	package.add("IncStats", &Perl_Bot_IncStats);
+	package.add("IsGrouped", &Perl_Bot_IsGrouped);
+	package.add("IsRaidGrouped", &Perl_Bot_IsRaidGrouped);
+	package.add("IsSitting", &Perl_Bot_IsSitting);
+	package.add("IsStanding", &Perl_Bot_IsStanding);
 	package.add("OwnerMessage", &Perl_Bot_OwnerMessage);
 	package.add("ReloadBotDataBuckets", &Perl_Bot_ReloadBotDataBuckets);
 	package.add("ReloadBotOwnerDataBuckets", &Perl_Bot_ReloadBotOwnerDataBuckets);
@@ -171,9 +510,23 @@ void perl_register_bot()
 	package.add("RemoveBotItem", &Perl_Bot_RemoveBotItem);
 	package.add("SendPayload", (void(*)(Bot*, int))&Perl_Bot_SendPayload);
 	package.add("SendPayload", (void(*)(Bot*, int, std::string))&Perl_Bot_SendPayload);
+	package.add("SendSpellAnim", &Perl_Bot_SendSpellAnim);
 	package.add("SetExpansionBitmask", (void(*)(Bot*, int))&Perl_Bot_SetExpansionBitmask);
 	package.add("SetExpansionBitmask", (void(*)(Bot*, int, bool))&Perl_Bot_SetExpansionBitmask);
+	package.add("SetSpellDuration", (void(*)(Bot*, int))&Perl_Bot_SetSpellDuration);
+	package.add("SetSpellDuration", (void(*)(Bot*, int, int))&Perl_Bot_SetSpellDuration);
+	package.add("SetSpellDuration", (void(*)(Bot*, int, int, bool))&Perl_Bot_SetSpellDuration);
+	package.add("SetSpellDurationGroup", (void(*)(Bot*, int))&Perl_Bot_SetSpellDurationGroup);
+	package.add("SetSpellDurationGroup", (void(*)(Bot*, int, int))&Perl_Bot_SetSpellDurationGroup);
+	package.add("SetSpellDurationGroup", (void(*)(Bot*, int, int, bool))&Perl_Bot_SetSpellDurationGroup);
+	package.add("SetSpellDurationRaid", (void(*)(Bot*, int))&Perl_Bot_SetSpellDurationRaid);
+	package.add("SetSpellDurationRaid", (void(*)(Bot*, int, int))&Perl_Bot_SetSpellDurationRaid);
+	package.add("SetSpellDurationRaid", (void(*)(Bot*, int, int, bool))&Perl_Bot_SetSpellDurationRaid);
+	package.add("SetSpellDurationRaid", (void(*)(Bot*, int, int, bool, bool))&Perl_Bot_SetSpellDurationRaid);
+	package.add("SetStats", &Perl_Bot_SetStats);
 	package.add("Signal", &Perl_Bot_Signal);
+	package.add("Sit", &Perl_Bot_Sit);
+	package.add("Stand", &Perl_Bot_Stand);
 }
 
 #endif //EMBPERL_XS_CLASSES


### PR DESCRIPTION
Adds following Perl & Lua Methods:

$bot->ApplySpell
$bot->ApplySpellGroup
$bot->ApplySpellRaid
$bot->CountAugmentEquippedByID
$bot->CountItemEquippedByID
$bot->Escape
$bot->Fling
$bot->GetAugmentAt
$bot->GetAugmentIDAt
$bot->GetBaseAGI
$bot->GetBaseCHA
$bot->GetBaseDEX
$bot->GetBaseINT
$bot->GetBaseSTA
$bot->GetBaseSTR
$bot->GetBaseWIS
$bot->GetGroup
$bot->GetHealAmount
$bot->GetInstrumentMod
$bot->GetItemAt
$bot->GetItemIDAt
$bot->GetRaid
$bot->GetRawItemAC
$bot->GetSpellDamage
$bot->HasAugmentEquippedByID
$bot->HasItemEquippedByID
$bot->InZone
$bot->IncStats
$bot->IsGrouped
$bot->IsRaidGrouped
$bot->IsSitting
$bot->IsStanding
$bot->SendSpellAnim
$bot->SetSpellDuration
$bot->SetSpellDurationGroup
$bot->SetSpellDurationRaid
$bot->SetStats
$bot->Sit
$bot->Stand