### PR TITLE
[Quest API] Fix Lua Door/Object Create Methods.

### DIFF
--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -1348,42 +1348,42 @@ int Perl__getlevel(uint8 type)
 	return quest_manager.getlevel(type);
 }
 
-int Perl__CreateGroundObject(uint32_t item_id, float x, float y, float z, float heading)
+uint16 Perl__CreateGroundObject(uint32_t item_id, float x, float y, float z, float heading)
 {
 	return quest_manager.CreateGroundObject(item_id, glm::vec4(x, y, z, heading));
 }
 
-int Perl__CreateGroundObject(uint32_t item_id, float x, float y, float z, float heading, uint32_t decay_time_ms)
+uint16 Perl__CreateGroundObject(uint32_t item_id, float x, float y, float z, float heading, uint32_t decay_time_ms)
 {
 	return quest_manager.CreateGroundObject(item_id, glm::vec4(x, y, z, heading), decay_time_ms);
 }
 
-int Perl__CreateGroundObjectFromModel(const char* modelname, float x, float y, float z, float heading)
+uint16 Perl__CreateGroundObjectFromModel(const char* modelname, float x, float y, float z, float heading)
 {
 	return quest_manager.CreateGroundObjectFromModel(modelname, glm::vec4(x, y, z, heading));
 }
 
-int Perl__CreateGroundObjectFromModel(const char* modelname, float x, float y, float z, float heading, uint8_t object_type)
+uint16 Perl__CreateGroundObjectFromModel(const char* modelname, float x, float y, float z, float heading, uint8_t object_type)
 {
 	return quest_manager.CreateGroundObjectFromModel(modelname, glm::vec4(x, y, z, heading), object_type);
 }
 
-int Perl__CreateGroundObjectFromModel(const char* modelname, float x, float y, float z, float heading, uint8_t object_type, uint32_t decay_time_ms)
+uint16 Perl__CreateGroundObjectFromModel(const char* modelname, float x, float y, float z, float heading, uint8_t object_type, uint32_t decay_time_ms)
 {
 	return quest_manager.CreateGroundObjectFromModel(modelname, glm::vec4(x, y, z, heading), object_type, decay_time_ms);
 }
 
-int Perl__CreateDoor(const char* modelname, float x, float y, float z, float heading)
+uint16 Perl__CreateDoor(const char* modelname, float x, float y, float z, float heading)
 {
 	return quest_manager.CreateDoor(modelname, x, y, z, heading, 58, 100);
 }
 
-int Perl__CreateDoor(const char* modelname, float x, float y, float z, float heading, uint8_t object_type)
+uint16 Perl__CreateDoor(const char* modelname, float x, float y, float z, float heading, uint8_t object_type)
 {
 	return quest_manager.CreateDoor(modelname, x, y, z, heading, object_type, 100);
 }
 
-int Perl__CreateDoor(const char* modelname, float x, float y, float z, float heading, uint8_t object_type, uint16_t size)
+uint16 Perl__CreateDoor(const char* modelname, float x, float y, float z, float heading, uint8_t object_type, uint16_t size)
 {
 	return quest_manager.CreateDoor(modelname, x, y, z, heading, object_type, size);
 }
@@ -4036,14 +4036,14 @@ void perl_register_quest()
 	package.add("completedtasksinset", &Perl__completedtasksinset);
 	package.add("countitem", &Perl__countitem);
 	package.add("countspawnednpcs", &Perl__countspawnednpcs);
-	package.add("createdoor", (int(*)(const char*, float, float, float, float))&Perl__CreateDoor);
-	package.add("createdoor", (int(*)(const char*, float, float, float, float, uint8_t))&Perl__CreateDoor);
-	package.add("createdoor", (int(*)(const char*, float, float, float, float, uint8_t, uint16_t))&Perl__CreateDoor);
-	package.add("creategroundobject", (int(*)(uint32_t, float, float, float, float))&Perl__CreateGroundObject);
-	package.add("creategroundobject", (int(*)(uint32_t, float, float, float, float, uint32_t))&Perl__CreateGroundObject);
-	package.add("creategroundobjectfrommodel", (int(*)(const char*, float, float, float, float))&Perl__CreateGroundObjectFromModel);
-	package.add("creategroundobjectfrommodel", (int(*)(const char*, float, float, float, float, uint8_t))&Perl__CreateGroundObjectFromModel);
-	package.add("creategroundobjectfrommodel", (int(*)(const char*, float, float, float, float, uint8_t, uint32_t))&Perl__CreateGroundObjectFromModel);
+	package.add("createdoor", (uint16(*)(const char*, float, float, float, float))&Perl__CreateDoor);
+	package.add("createdoor", (uint16(*)(const char*, float, float, float, float, uint8_t))&Perl__CreateDoor);
+	package.add("createdoor", (uint16(*)(const char*, float, float, float, float, uint8_t, uint16_t))&Perl__CreateDoor);
+	package.add("creategroundobject", (uint16(*)(uint32_t, float, float, float, float))&Perl__CreateGroundObject);
+	package.add("creategroundobject", (uint16(*)(uint32_t, float, float, float, float, uint32_t))&Perl__CreateGroundObject);
+	package.add("creategroundobjectfrommodel", (uint16(*)(const char*, float, float, float, float))&Perl__CreateGroundObjectFromModel);
+	package.add("creategroundobjectfrommodel", (uint16(*)(const char*, float, float, float, float, uint8_t))&Perl__CreateGroundObjectFromModel);
+	package.add("creategroundobjectfrommodel", (uint16(*)(const char*, float, float, float, float, uint8_t, uint32_t))&Perl__CreateGroundObjectFromModel);
 	package.add("createguild", &Perl__createguild);
 	package.add("createitem", (EQ::ItemInstance*(*)(uint32))&Perl__createitem);
 	package.add("createitem", (EQ::ItemInstance*(*)(uint32, int16))&Perl__createitem);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -813,28 +813,36 @@ int lua_get_level(int type) {
 	return quest_manager.getlevel(type);
 }
 
-void lua_create_ground_object(uint32 item_id, float x, float y, float z, float h) {
-	quest_manager.CreateGroundObject(item_id, glm::vec4(x, y, z, h));
+uint16 lua_create_ground_object(uint32 item_id, float x, float y, float z, float h) {
+	return quest_manager.CreateGroundObject(item_id, glm::vec4(x, y, z, h));
 }
 
-void lua_create_ground_object(uint32 item_id, float x, float y, float z, float h, uint32 decay_time) {
-	quest_manager.CreateGroundObject(item_id, glm::vec4(x, y, z, h), decay_time);
+uint16 lua_create_ground_object(uint32 item_id, float x, float y, float z, float h, uint32 decay_time) {
+	return quest_manager.CreateGroundObject(item_id, glm::vec4(x, y, z, h), decay_time);
 }
 
-void lua_create_ground_object_from_model(const char *model, float x, float y, float z, float h) {
-	quest_manager.CreateGroundObjectFromModel(model, glm::vec4(x, y, z, h));
+uint16 lua_create_ground_object_from_model(const char *model, float x, float y, float z, float h) {
+	return quest_manager.CreateGroundObjectFromModel(model, glm::vec4(x, y, z, h));
 }
 
-void lua_create_ground_object_from_model(const char *model, float x, float y, float z, float h, int type) {
-	quest_manager.CreateGroundObjectFromModel(model, glm::vec4(x, y, z, h), type);
+uint16 lua_create_ground_object_from_model(const char *model, float x, float y, float z, float h, uint8 type) {
+	return quest_manager.CreateGroundObjectFromModel(model, glm::vec4(x, y, z, h), type);
 }
 
-void lua_create_ground_object_from_model(const char *model, float x, float y, float z, float h, int type, uint32 decay_time) {
-	quest_manager.CreateGroundObjectFromModel(model, glm::vec4(x, y, z, h), type, decay_time);
+uint16 lua_create_ground_object_from_model(const char *model, float x, float y, float z, float h, uint8 type, uint32 decay_time) {
+	return quest_manager.CreateGroundObjectFromModel(model, glm::vec4(x, y, z, h), type, decay_time);
 }
 
-void lua_create_door(const char *model, float x, float y, float z, float h, int open_type, int size) {
-	quest_manager.CreateDoor(model, x, y, z, h, open_type, size);
+uint16 lua_create_door(const char *model, float x, float y, float z, float h) {
+	return quest_manager.CreateDoor(model, x, y, z, h, 58, 100);
+}
+
+uint16 lua_create_door(const char *model, float x, float y, float z, float h, uint8 open_type) {
+	return quest_manager.CreateDoor(model, x, y, z, h, open_type, 100);
+}
+
+uint16 lua_create_door(const char *model, float x, float y, float z, float h, uint8 open_type, uint16 size) {
+	return quest_manager.CreateDoor(model, x, y, z, h, open_type, size);
 }
 
 void lua_modify_npc_stat(std::string stat, std::string value) {
@@ -3967,12 +3975,14 @@ luabind::scope lua_register_general() {
 		luabind::def("message", &lua_message),
 		luabind::def("whisper", &lua_whisper),
 		luabind::def("get_level", &lua_get_level),
-		luabind::def("create_ground_object", (void(*)(uint32,float,float,float,float))&lua_create_ground_object),
-		luabind::def("create_ground_object", (void(*)(uint32,float,float,float,float,uint32))&lua_create_ground_object),
-		luabind::def("create_ground_object_from_model", (void(*)(const char*,float,float,float,float))&lua_create_ground_object_from_model),
-		luabind::def("create_ground_object_from_model", (void(*)(const char*,float,float,float,float,int))&lua_create_ground_object_from_model),
-		luabind::def("create_ground_object_from_model", (void(*)(const char*,float,float,float,float,int,uint32))&lua_create_ground_object_from_model),
-		luabind::def("create_door", &lua_create_door),
+		luabind::def("create_ground_object", (uint16(*)(uint32,float,float,float,float))&lua_create_ground_object),
+		luabind::def("create_ground_object", (uint16(*)(uint32,float,float,float,float,uint32))&lua_create_ground_object),
+		luabind::def("create_ground_object_from_model", (uint16(*)(const char*,float,float,float,float))&lua_create_ground_object_from_model),
+		luabind::def("create_ground_object_from_model", (uint16(*)(const char*,float,float,float,float,uint8))&lua_create_ground_object_from_model),
+		luabind::def("create_ground_object_from_model", (uint16(*)(const char*,float,float,float,float,uint8,uint32))&lua_create_ground_object_from_model),
+		luabind::def("create_door", (uint16(*)(const char*,float,float,float,float))&lua_create_door),
+		luabind::def("create_door", (uint16(*)(const char*,float,float,float,float,uint8))&lua_create_door),
+		luabind::def("create_door", (uint16(*)(const char*,float,float,float,float,uint8,uint16))&lua_create_door),
 		luabind::def("modify_npc_stat", &lua_modify_npc_stat),
 		luabind::def("collect_items", &lua_collect_items),
 		luabind::def("count_item", &lua_count_item),


### PR DESCRIPTION
# Lua
- Add `eq.create_door(model_name, x, y, z, h)`.
- Add `eq.create_door(model_name, x, y, z, h, open_type)`.

# Notes
- Lua door/object create methods were `void` type instead of `uint16`, so you couldn't get the entity ID of the door you created.
- Converted Perl's door/object create methods to return `uint16` instead of `int` as well.