### PR TITLE
[Quests] Improve Quest Error Handling

### DIFF
--- a/common/eqemu_logsys.cpp
+++ b/common/eqemu_logsys.cpp
@@ -140,6 +140,8 @@ EQEmuLogSys *EQEmuLogSys::LoadLogSettingsDefaults()
 	log_settings[Logs::ChecksumVerification].log_to_gmsay   = static_cast<uint8>(Logs::General);
 	log_settings[Logs::CombatRecord].log_to_gmsay           = static_cast<uint8>(Logs::General);
 	log_settings[Logs::Discord].log_to_console              = static_cast<uint8>(Logs::General);
+	log_settings[Logs::QuestErrors].log_to_gmsay            = static_cast<uint8>(Logs::General);
+	log_settings[Logs::QuestErrors].log_to_console          = static_cast<uint8>(Logs::General);
 
 	/**
 	 * RFC 5424
@@ -254,6 +256,7 @@ uint16 EQEmuLogSys::GetWindowsConsoleColorFromCategory(uint16 log_category)
 			return Console::Color::Yellow;
 		case Logs::MySQLError:
 		case Logs::Error:
+		case Logs::QuestErrors:
 			return Console::Color::LightRed;
 		case Logs::MySQLQuery:
 		case Logs::Debug:
@@ -281,6 +284,7 @@ std::string EQEmuLogSys::GetLinuxConsoleColorFromCategory(uint16 log_category)
 		case Logs::Normal:
 			return LC_YELLOW;
 		case Logs::MySQLError:
+		case Logs::QuestErrors:
 		case Logs::Warning:
 		case Logs::Critical:
 		case Logs::Error:
@@ -311,6 +315,7 @@ uint16 EQEmuLogSys::GetGMSayColorFromCategory(uint16 log_category)
 		case Logs::Normal:
 			return Chat::Yellow;
 		case Logs::MySQLError:
+		case Logs::QuestErrors:
 		case Logs::Error:
 			return Chat::Red;
 		case Logs::MySQLQuery:
@@ -625,7 +630,11 @@ EQEmuLogSys *EQEmuLogSys::LoadLogDatabaseSettings()
 		bool is_missing_in_database = std::find(db_categories.begin(), db_categories.end(), i) == db_categories.end();
 		bool is_deprecated_category = Strings::Contains(fmt::format("{}", Logs::LogCategoryName[i]), "Deprecated");
 		if (!is_missing_in_database && is_deprecated_category) {
-			LogInfo("Logging category [{}] ({}) is now deprecated, deleting from database", Logs::LogCategoryName[i], i);
+			LogInfo(
+				"Logging category [{}] ({}) is now deprecated, deleting from database",
+				Logs::LogCategoryName[i],
+				i
+			);
 			LogsysCategoriesRepository::DeleteOne(*m_database, i);
 		}
 
@@ -754,7 +763,7 @@ const std::string &EQEmuLogSys::GetLogPath() const
 	return m_log_path;
 }
 
-EQEmuLogSys * EQEmuLogSys::SetLogPath(const std::string &log_path)
+EQEmuLogSys *EQEmuLogSys::SetLogPath(const std::string &log_path)
 {
 	EQEmuLogSys::m_log_path = log_path;
 

--- a/common/eqemu_logsys.h
+++ b/common/eqemu_logsys.h
@@ -136,6 +136,7 @@ namespace Logs {
 		PacketClientServer,
 		PacketServerToServer,
 		Bugs,
+		QuestErrors,
 		MaxCategoryID /* Don't Remove this */
 	};
 
@@ -229,7 +230,8 @@ namespace Logs {
 		"Packet-S->C",
 		"Packet-C->S",
 		"Packet-S->S",
-		"Bugs"
+		"Bugs",
+		"QuestErrors"
 	};
 }
 

--- a/common/eqemu_logsys_log_aliases.h
+++ b/common/eqemu_logsys_log_aliases.h
@@ -861,6 +861,16 @@
         OutF(LogSys, Logs::Detail, Logs::Bugs, __FILE__, __func__, __LINE__, message, ##__VA_ARGS__);\
 } while (0)
 
+#define LogQuestErrors(message, ...) do {\
+    if (LogSys.IsLogEnabled(Logs::General, Logs::QuestErrors))\
+        OutF(LogSys, Logs::General, Logs::QuestErrors, __FILE__, __func__, __LINE__, message, ##__VA_ARGS__);\
+} while (0)
+
+#define LogQuestErrorsDetail(message, ...) do {\
+    if (LogSys.IsLogEnabled(Logs::Detail, Logs::QuestErrors))\
+        OutF(LogSys, Logs::Detail, Logs::QuestErrors, __FILE__, __func__, __LINE__, message, ##__VA_ARGS__);\
+} while (0)
+
 #define Log(debug_level, log_category, message, ...) do {\
     if (LogSys.IsLogEnabled(debug_level, log_category))\
         LogSys.Out(debug_level, log_category, __FILE__, __func__, __LINE__, message, ##__VA_ARGS__);\

--- a/zone/quest_interface.h
+++ b/zone/quest_interface.h
@@ -71,7 +71,7 @@ public:
 		return 0;
 	}
 #endif
-	
+
 	virtual bool HasQuestSub(uint32 npcid, QuestEventID evt) { return false; }
 	virtual bool HasGlobalQuestSub(QuestEventID evt) { return false; }
 	virtual bool PlayerHasQuestSub(QuestEventID evt) { return false; }
@@ -120,14 +120,14 @@ public:
 		return 0;
 	}
 #endif
-	
+
 	virtual void AddVar(std::string name, std::string val) { }
 	virtual std::string GetVar(std::string name) { return std::string(); }
 	virtual void Init() { }
 	virtual void ReloadQuests() { }
 	virtual uint32 GetIdentifier() = 0;
 	virtual void RemoveEncounter(const std::string &name) { }
-	
+
 	//TODO: Set maximum quest errors instead of hard coding it
 	virtual void GetErrors(std::list<std::string> &quest_errors) {
 		quest_errors.insert(quest_errors.end(), errors_.begin(), errors_.end());
@@ -135,13 +135,14 @@ public:
 
 	virtual void AddError(std::string error) {
 		LogQuests("{}", error);
+		LogQuestErrors("{}", error);
 
 		errors_.push_back(error);
 		if(errors_.size() > 30) {
 			errors_.pop_front();
 		}
 	}
-	
+
 protected:
 	std::list<std::string> errors_;
 };


### PR DESCRIPTION
As a server operator, I want to be able to be aware when errors happen reliably in my scripts in real time and not have to go through potentially many manual steps to find out. Error feedback should be immediate and simple.

**Solution**

* Add Logging category `QuestErrors` that is enabled by default for **console** and **gmsay**. This ensures that errors are always bubbled to the surface and doesn't require things to be turned on to be aware of them.
* All Quest API errors will by default emit to this category, which will show immediately in console or gmsay
* Perl syntax checking is now occurring since the eval API is not properly picking syntax issues up

**Examples**

**Perl**

```
[Zone] [QuestErrors] Error Compiling NPC Quest File [quests/qrg/zone_controller.pl] NPC ID [10] Error [Missing right curly or square bracket at quests/qrg/zone_controller.pl line 24, at end of line
syntax error at quests/qrg/zone_controller.pl line 24, at EOF
quests/qrg/zone_controller.pl had compilation errors.]
```

![image](https://user-images.githubusercontent.com/3319450/206991959-0872bb30-0f33-4374-92c8-139d19dcd3ab.png)

**Lua**

```
[Zone] [QuestErrors] quests/qrg/Vesteri_Nomanoi.lua:14: '=' expected near 'if'
```
![image](https://user-images.githubusercontent.com/3319450/206991927-ce9bc018-2c7b-4621-9aaa-fe2cdb04107c.png)


