### PR TITLE
[Bots] Fix Gender not saving as GetBaseGender on BotSave

### DIFF
--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -549,7 +549,7 @@ bool BotDatabase::SaveBot(Bot* bot_inst)
 	l.title                  = bot_inst->GetTitle();
 	l.suffix                 = bot_inst->GetSuffix();
 	l.zone_id                = bot_inst->GetLastZoneID();
-	l.gender                 = bot_inst->GetGender();
+	l.gender                 = bot_inst->GetBaseGender();
 	l.race                   = bot_inst->GetBaseRace();
 	l.class_                 = bot_inst->GetClass();
 	l.level                  = bot_inst->GetLevel();


### PR DESCRIPTION
Bots were not saving their Base Gender when saving. This could result in bots with illusions saving as gender 2 and becoming a male human model upon illusion fade.