### PR TITLE
[Bug Fix] Allow High Level Spells to be Unmemorized.

### DIFF
--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -1093,7 +1093,7 @@ void Client::OPMemorizeSpell(const EQApplicationPacket* app)
 		return;
 	}
 
-	const auto* m = (MemorizeSpell_Struct *) app->pBuffer;
+	const auto* m = (MemorizeSpell_Struct*) app->pBuffer;
 
 	if (!IsValidSpell(m->spell_id)) {
 		Message(

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -1083,72 +1083,86 @@ void Client::OPTGB(const EQApplicationPacket *app)
 
 void Client::OPMemorizeSpell(const EQApplicationPacket* app)
 {
-	if(app->size != sizeof(MemorizeSpell_Struct))
-	{
-		LogError("[Client::OPMemorizeSpell] Wrong size on OP_MemorizeSpell. Got: [{}] Expected: [{}]", app->size, sizeof(MemorizeSpell_Struct));
+	if (app->size != sizeof(MemorizeSpell_Struct)) {
+		LogError(
+			"[Client::OPMemorizeSpell] Wrong size on OP_MemorizeSpell. Got: [{}] Expected: [{}]",
+			app->size,
+			sizeof(MemorizeSpell_Struct)
+		);
 		DumpPacket(app);
 		return;
 	}
 
-	const MemorizeSpell_Struct* memspell = (const MemorizeSpell_Struct*) app->pBuffer;
+	const auto* m = (MemorizeSpell_Struct *) app->pBuffer;
 
-	if(!IsValidSpell(memspell->spell_id))
-	{
-		Message(Chat::Red, "Unexpected error: spell id out of range");
+	if (!IsValidSpell(m->spell_id)) {
+		Message(
+			Chat::Red,
+			fmt::format(
+				"Spell ID {} does not exist or is invalid.",
+				m->spell_id
+			).c_str()
+		);
 		return;
 	}
 
-	if
-	(
-		GetClass() > 16 ||
-		GetLevel() < spells[memspell->spell_id].classes[GetClass()-1]
-	)
-	{
-		char val1[20]={0};
-		MessageString(Chat::Red,SPELL_LEVEL_TO_LOW,ConvertArray(spells[memspell->spell_id].classes[GetClass()-1],val1),spells[memspell->spell_id].name);
-		//Message(Chat::Red, "Unexpected error: Class cant use this spell at your level!");
+	if (
+		m->scribing != memSpellForget &&
+		(
+			!EQ::ValueWithin(GetClass(), PLAYER_CLASS_WARRIOR, PLAYER_CLASS_BERSERKER) ||
+			GetLevel() < spells[m->spell_id].classes[GetClass() - 1]
+		)
+	) {
+		MessageString(
+			Chat::Red,
+			SPELL_LEVEL_TO_LOW,
+			std::to_string(spells[m->spell_id].classes[GetClass() - 1]).c_str(),
+			spells[m->spell_id].name
+		);
 		return;
 	}
 
-	switch(memspell->scribing)
-	{
-		case memSpellScribing:	{	// scribing spell to book
-			const EQ::ItemInstance* inst = m_inv[EQ::invslot::slotCursor];
+	switch (m->scribing) {
+		case memSpellScribing: {
+			const auto* inst = m_inv[EQ::invslot::slotCursor];
 
-			if (inst && inst->IsClassCommon())
-			{
-				const EQ::ItemData* item = inst->GetItem();
+			if (inst && inst->IsClassCommon()) {
+				const auto* item = inst->GetItem();
 
-				if (RuleB(Character, RestrictSpellScribing) && !item->IsEquipable(GetRace(), GetClass())) {
+				if (
+					RuleB(Character, RestrictSpellScribing) &&
+					!item->IsEquipable(GetRace(), GetClass())
+				) {
 					MessageString(Chat::Red, CANNOT_USE_ITEM);
 					break;
 				}
 
-				if(item && item->Scroll.Effect == (int32)(memspell->spell_id))
-				{
-					ScribeSpell(memspell->spell_id, memspell->slot);
+				if (item && item->Scroll.Effect == static_cast<int32>(m->spell_id)) {
+					ScribeSpell(m->spell_id, m->slot);
 					DeleteItemInInventory(EQ::invslot::slotCursor, 1, true);
+				} else {
+					Message(Chat::Red, "Scribing spell: Item Instance exists but item does not or spell ids do not match.");
 				}
-				else
-					Message(0,"Scribing spell: inst exists but item does not or spell ids do not match.");
-			}
-			else
-				Message(0,"Scribing a spell without an inst on your cursor?");
-			break;
-		}
-		case memSpellMemorize:	{	// memming spell
-			if(HasSpellScribed(memspell->spell_id))
-			{
-				MemSpell(memspell->spell_id, memspell->slot);
-			}
-			else
-			{
-				database.SetMQDetectionFlag(AccountName(), GetName(), "OP_MemorizeSpell but we don't have this spell scribed...", zone->GetShortName());
+			} else {
+				Message(Chat::Red, "Scribing a spell without an Item Instance on your cursor?");
 			}
 			break;
 		}
-		case memSpellForget:	{	// unmemming spell
-			UnmemSpell(memspell->slot);
+		case memSpellMemorize: {
+			if (HasSpellScribed(m->spell_id)) {
+				MemSpell(m->spell_id, m->slot);
+			} else {
+				database.SetMQDetectionFlag(
+					AccountName(),
+					GetName(),
+					"OP_MemorizeSpell but we don't have this spell scribed...",
+					zone->GetShortName()
+				);
+			}
+			break;
+		}
+		case memSpellForget: {
+			UnmemSpell(m->slot);
 			break;
 		}
 	}


### PR DESCRIPTION
# Notes
- If you deleveled below a spell's level, you couldn't unmemorize it, this fixes that.