### PR TITLE
[Bug Fix] Remove unnecessary log messages.

### DIFF
--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -1007,8 +1007,12 @@ void Client::LoadZoneFlags() {
 	);
 	auto results = database.QueryDatabase(query);
 
-	if (!results.Success() || !results.RowCount()) {
+	if (!results.Success()) {
 		LogError("MySQL Error while trying to load zone flags for [{}]: [{}]", GetName(), results.ErrorMessage().c_str());
+		return;
+	}
+
+	if (!results.RowCount()) {
 		return;
 	}
 
@@ -1130,8 +1134,7 @@ void Client::LoadPEQZoneFlags() {
 			CharacterID()
 		)
 	);
-	if (l.empty() || !l[0].id){
-		LogError("MySQL Error while trying to load PEQZone flags for [{}].", GetName());
+	if (l.empty()) {
 		return;
 	}
 


### PR DESCRIPTION
# Notes
- These logs were extraneous and unnecessary, they fired any time a player had no flags, which is usually 100% of the time since most servers aren't using this functionality.