### PR TITLE
[Bots] Fix trading with bots when in an illusion.

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -4761,7 +4761,7 @@ void Bot::PerformTradeWithClient(int16 begin_slot_id, int16 end_slot_id, Client*
 		if (
 			!trade_instance->IsClassEquipable(GetClass()) ||
 			GetLevel() < trade_instance->GetItem()->ReqLevel ||
-			(!trade_instance->IsRaceEquipable(GetRace()) && !RuleB(Bots, AllowBotEquipAnyRaceGear))
+			(!trade_instance->IsRaceEquipable(GetBaseRace()) && !RuleB(Bots, AllowBotEquipAnyRaceGear))
 		) {
 			if (trade_event_exists) {
 				event_trade.push_back(ClientTrade(trade_instance, trade_index));


### PR DESCRIPTION
Trade check was not checking GetBaseRace and would fail if the bot's illusion couldn't equip the item.