### PR TITLE
[FMT] Bump to 7.1.3 from 5.3.0

### DIFF
--- a/common/repositories/character_expedition_lockouts_repository.h
+++ b/common/repositories/character_expedition_lockouts_repository.h
@@ -75,7 +75,7 @@ public:
 		Database& db, const std::vector<uint32_t>& character_ids,
 		const std::string& expedition_name, const std::string& ordered_event_name)
 	{
-		auto joined_character_ids = fmt::join(character_ids, ",");
+		auto joined_character_ids = Strings::Join(character_ids, ",");
 
 		auto results = db.QueryDatabase(fmt::format(SQL(
 			SELECT

--- a/common/repositories/dynamic_zone_members_repository.h
+++ b/common/repositories/dynamic_zone_members_repository.h
@@ -172,7 +172,7 @@ public:
 				DELETE FROM {}
 				WHERE dynamic_zone_id IN ({});
 			),
-				TableName(), fmt::join(dynamic_zone_ids, ",")
+				TableName(), Strings::Join(dynamic_zone_ids, ",")
 			));
 		}
 	}

--- a/common/repositories/expedition_lockouts_repository.h
+++ b/common/repositories/expedition_lockouts_repository.h
@@ -75,7 +75,7 @@ public:
 			FROM expedition_lockouts
 			WHERE expedition_id IN ({})
 		),
-			fmt::join(expedition_ids, ",")
+			Strings::Join(expedition_ids, ",")
 		));
 
 		all_entries.reserve(results.RowCount());

--- a/common/repositories/expeditions_repository.h
+++ b/common/repositories/expeditions_repository.h
@@ -62,7 +62,7 @@ public:
 
 		std::vector<CharacterExpedition> entries;
 
-		auto joined_character_names = fmt::format("'{}'", fmt::join(character_names, "','"));
+		auto joined_character_names = fmt::format("'{}'", Strings::Join(character_names, "','"));
 
 		auto results = db.QueryDatabase(fmt::format(SQL(
 			SELECT

--- a/common/strings.cpp
+++ b/common/strings.cpp
@@ -225,6 +225,20 @@ std::string Strings::Join(const std::vector<std::string> &ar, const std::string 
 	return ret;
 }
 
+std::string Strings::Join(const std::vector<uint32_t> &ar, const std::string &delim)
+{
+	std::string ret;
+	for (size_t i = 0; i < ar.size(); ++i) {
+		if (i != 0) {
+			ret += delim;
+		}
+
+		ret += std::to_string(ar[i]);
+	}
+
+	return ret;
+}
+
 void
 Strings::FindReplace(std::string &string_subject, const std::string &search_string, const std::string &replace_string)
 {

--- a/common/strings.cpp
+++ b/common/strings.cpp
@@ -213,30 +213,12 @@ bool Strings::IsFloat(const std::string &s)
 
 std::string Strings::Join(const std::vector<std::string> &ar, const std::string &delim)
 {
-	std::string ret;
-	for (size_t i = 0; i < ar.size(); ++i) {
-		if (i != 0) {
-			ret += delim;
-		}
-
-		ret += ar[i];
-	}
-
-	return ret;
+	return fmt::format("{}", fmt::join(ar, delim));
 }
 
 std::string Strings::Join(const std::vector<uint32_t> &ar, const std::string &delim)
 {
-	std::string ret;
-	for (size_t i = 0; i < ar.size(); ++i) {
-		if (i != 0) {
-			ret += delim;
-		}
-
-		ret += std::to_string(ar[i]);
-	}
-
-	return ret;
+	return fmt::format("{}", fmt::join(ar, delim));
 }
 
 void

--- a/common/strings.cpp
+++ b/common/strings.cpp
@@ -211,16 +211,6 @@ bool Strings::IsFloat(const std::string &s)
 	}
 }
 
-std::string Strings::Join(const std::vector<std::string> &ar, const std::string &delim)
-{
-	return fmt::format("{}", fmt::join(ar, delim));
-}
-
-std::string Strings::Join(const std::vector<uint32_t> &ar, const std::string &delim)
-{
-	return fmt::format("{}", fmt::join(ar, delim));
-}
-
 void
 Strings::FindReplace(std::string &string_subject, const std::string &search_string, const std::string &replace_string)
 {

--- a/common/strings.h
+++ b/common/strings.h
@@ -99,6 +99,7 @@ public:
 	static std::string GetBetween(const std::string &s, std::string start_delim, std::string stop_delim);
 	static std::string Implode(std::string glue, std::vector<std::string> src);
 	static std::string Join(const std::vector<std::string> &ar, const std::string &delim);
+	static std::string Join(const std::vector<uint32_t> &ar, const std::string &delim);
 	static std::string MillisecondsToTime(int duration);
 	static std::string Money(uint32 platinum, uint32 gold = 0, uint32 silver = 0, uint32 copper = 0);
 	static std::string NumberToWords(unsigned long long int n);

--- a/common/strings.h
+++ b/common/strings.h
@@ -98,8 +98,12 @@ public:
 	static std::string Escape(const std::string &s);
 	static std::string GetBetween(const std::string &s, std::string start_delim, std::string stop_delim);
 	static std::string Implode(std::string glue, std::vector<std::string> src);
-	static std::string Join(const std::vector<std::string> &ar, const std::string &delim);
-	static std::string Join(const std::vector<uint32_t> &ar, const std::string &delim);
+	template<typename Range>
+	static std::string Join(Range &&ar, const std::string &delim)
+	{
+		return fmt::format("{}", fmt::join(ar, delim));
+	};
+
 	static std::string MillisecondsToTime(int duration);
 	static std::string Money(uint32 platinum, uint32 gold = 0, uint32 silver = 0, uint32 copper = 0);
 	static std::string NumberToWords(unsigned long long int n);

--- a/world/dynamic_zone_manager.cpp
+++ b/world/dynamic_zone_manager.cpp
@@ -28,9 +28,9 @@ void DynamicZoneManager::PurgeExpiredDynamicZones()
 		LogDynamicZones("Purging [{}] dynamic zone(s)", dz_ids.size());
 
 		DynamicZoneMembersRepository::DeleteWhere(database,
-			fmt::format("dynamic_zone_id IN ({})", fmt::join(dz_ids, ",")));
+			fmt::format("dynamic_zone_id IN ({})", Strings::Join(dz_ids, ",")));
 		DynamicZonesRepository::DeleteWhere(database,
-			fmt::format("id IN ({})", fmt::join(dz_ids, ",")));
+			fmt::format("id IN ({})", Strings::Join(dz_ids, ",")));
 	}
 }
 
@@ -145,7 +145,7 @@ void DynamicZoneManager::Process()
 		// need to look up expedition ids until lockouts are moved to dynamic zones
 		std::vector<uint32_t> expedition_ids;
 		auto expeditions = ExpeditionsRepository::GetWhere(database,
-			fmt::format("dynamic_zone_id IN ({})", fmt::join(dynamic_zone_ids, ",")));
+			fmt::format("dynamic_zone_id IN ({})", Strings::Join(dynamic_zone_ids, ",")));
 
 		if (!expeditions.empty())
 		{
@@ -154,14 +154,14 @@ void DynamicZoneManager::Process()
 				expedition_ids.emplace_back(expedition.id);
 			}
 			ExpeditionLockoutsRepository::DeleteWhere(database,
-				fmt::format("expedition_id IN ({})", fmt::join(expedition_ids, ",")));
+				fmt::format("expedition_id IN ({})", Strings::Join(expedition_ids, ",")));
 		}
 
 		ExpeditionsRepository::DeleteWhere(database,
-			fmt::format("dynamic_zone_id IN ({})", fmt::join(dynamic_zone_ids, ",")));
+			fmt::format("dynamic_zone_id IN ({})", Strings::Join(dynamic_zone_ids, ",")));
 		DynamicZoneMembersRepository::RemoveAllMembers(database, dynamic_zone_ids);
 		DynamicZonesRepository::DeleteWhere(database,
-			fmt::format("id IN ({})", fmt::join(dynamic_zone_ids, ",")));
+			fmt::format("id IN ({})", Strings::Join(dynamic_zone_ids, ",")));
 	}
 }
 

--- a/world/expedition_database.cpp
+++ b/world/expedition_database.cpp
@@ -60,7 +60,7 @@ void ExpeditionDatabase::PurgeExpiredExpeditions()
 
 		if (!expedition_ids.empty())
 		{
-			auto joined_expedition_ids = fmt::join(expedition_ids, ",");
+			auto joined_expedition_ids = Strings::Join(expedition_ids, ",");
 			ExpeditionsRepository::DeleteWhere(database, fmt::format("id IN ({})", joined_expedition_ids));
 			ExpeditionLockoutsRepository::DeleteWhere(database, fmt::format("expedition_id IN ({})", joined_expedition_ids));
 			DynamicZoneMembersRepository::RemoveAllMembers(database, dynamic_zone_ids);

--- a/world/shared_task_manager.cpp
+++ b/world/shared_task_manager.cpp
@@ -312,7 +312,7 @@ void SharedTaskManager::LoadSharedTaskState()
 
 		shared_task_character_data = CharacterDataRepository::GetWhere(
 			*m_database,
-			fmt::format("id IN ({})", fmt::join(character_ids, ","))
+			fmt::format("id IN ({})", Strings::Join(character_ids, ","))
 		);
 	}
 
@@ -1294,7 +1294,7 @@ std::vector<CharacterTaskTimersRepository::CharacterTaskTimers> SharedTaskManage
 				OR (timer_group > 0 AND timer_type = {} AND timer_group = {}))
 			AND expire_time > NOW() ORDER BY timer_type ASC LIMIT 1
 		),
-		fmt::join(character_ids, ","),
+		Strings::Join(character_ids, ","),
 		task.id,
 		static_cast<int>(TaskTimerType::Replay),
 		task.replay_timer_group,
@@ -1632,7 +1632,7 @@ void SharedTaskManager::AddReplayTimers(SharedTask *s)
 				s->GetTaskData().id,
 				s->GetTaskData().replay_timer_group,
 				static_cast<int>(TaskTimerType::Replay),
-				fmt::join(s->member_id_history, ",")
+				Strings::Join(s->member_id_history, ",")
 			));
 
 			CharacterTaskTimersRepository::InsertMany(*m_database, task_timers);

--- a/world/shared_task_world_messaging.cpp
+++ b/world/shared_task_world_messaging.cpp
@@ -323,7 +323,7 @@ void SharedTaskWorldMessaging::HandleZoneMessage(ServerPacket *pack)
 					}
 				}
 
-				std::string player_list = fmt::format("{}", fmt::join(player_names, ", "));
+				std::string player_list = fmt::format("{}", Strings::Join(player_names, ", "));
 				client_list.SendCharacterMessageID(buf->source_character_id, Chat::Yellow, TaskStr::MEMBERS_PRINT, {player_list});
 			}
 

--- a/zone/expedition.h
+++ b/zone/expedition.h
@@ -29,6 +29,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <cassert>
 
 class Client;
 class EQApplicationPacket;

--- a/zone/task_manager.cpp
+++ b/zone/task_manager.cpp
@@ -700,7 +700,7 @@ void TaskManager::SharedTaskSelector(Client* client, Mob* mob, const std::vector
 	if (request.group_type != SharedTaskRequestGroupType::Solo) {
 		auto shared_task_members = SharedTaskMembersRepository::GetWhere(
 			database,
-			fmt::format("character_id IN ({}) LIMIT 1", fmt::join(request.character_ids, ",")));
+			fmt::format("character_id IN ({}) LIMIT 1", Strings::Join(request.character_ids, ",")));
 
 		if (!shared_task_members.empty()) {
 			validation_failed = true;


### PR DESCRIPTION
This bumps the [FMT](https://github.com/fmtlib/fmt) library to 7.1.3 - breaking our usage of `fmt::join` and swapped for our strings function.

More work will need to be done to get us to 9.1.0

This does at least shave us down some compile time roughly 10-20 seconds

```
# cpp17 with fmt 5.3.0 (3m7.506s)
# cpp17 with fmt 7.1.3 (2m56.933s)
```