### PR TITLE
[Repositories] Add Cereal support to repository generator

### DIFF
--- a/common/repositories/template/base_repository.template
+++ b/common/repositories/template/base_repository.template
@@ -15,6 +15,7 @@
 #include "../../database.h"
 #include "../../strings.h"
 #include <ctime>
+{{ADDITIONAL_INCLUDES}}
 
 class Base{{TABLE_NAME_CLASS}}Repository {
 public:

--- a/utils/scripts/generators/repository-generator.pl
+++ b/utils/scripts/generators/repository-generator.pl
@@ -111,6 +111,10 @@ if ($requested_table_to_generate ne "all") {
     @tables = ($requested_table_to_generate);
 }
 
+my @cereal_enabled_tables = (
+    "player_event_logs"
+);
+
 my $generated_base_repository_files = "";
 my $generated_repository_files      = "";
 
@@ -154,6 +158,11 @@ foreach my $table_to_generate (@tables) {
     if ($table_to_generate ~~ @table_ignore_list) {
         print "Table [$table_to_generate] is on ignore list... skipping...\n";
         $table_found_in_schema = 0;
+    }
+
+    my $cereal_enabled = 0;
+    if ($table_to_generate ~~ @cereal_enabled_tables) {
+        $cereal_enabled = 1;
     }
 
     if ($table_found_in_schema == 0 && ($requested_table_to_generate eq "" || $requested_table_to_generate eq "all")) {
@@ -210,6 +219,7 @@ foreach my $table_to_generate (@tables) {
     my $column_names_quoted        = "";
     my $select_column_names_quoted = "";
     my $table_struct_columns       = "";
+    my $cereal_columns             = "";
     my $update_one_entries         = "";
     my $all_entries                = "";
     my $index                      = 0;
@@ -258,6 +268,10 @@ foreach my $table_to_generate (@tables) {
 
         # struct
         $table_struct_columns .= sprintf("\t\t\%-${longest_data_type_length}s %s;\n", $struct_data_type, $column_name_formatted);
+
+        if ($cereal_enabled == 1) {
+            $cereal_columns .= sprintf("\t\t\t\tCEREAL_NVP(%s),\n", $column_name_formatted);
+        }
 
         # new entity
         $default_entries .= sprintf("\t\te.%-${longest_column_length}s = %s;\n", $column_name_formatted, $default_value);
@@ -400,6 +414,22 @@ foreach my $table_to_generate (@tables) {
         $database_connection = "content_db";
     }
 
+    my $additional_includes = "";
+    if ($cereal_enabled) {
+        chomp($cereal_columns);
+        # remove the last comma "," from string
+        $cereal_columns = substr($cereal_columns, 0, -1);
+
+        $table_struct_columns .= "
+		// cereal
+		template<class Archive>
+		void serialize(Archive &ar)
+		{
+			ar(\n" . $cereal_columns . "\n\t\t\t);\n\t\t}";
+
+        $additional_includes .= "#include <cereal/cereal.hpp>";
+    }
+
     chomp($column_names_quoted);
     chomp($select_column_names_quoted);
     chomp($table_struct_columns);
@@ -435,6 +465,7 @@ foreach my $table_to_generate (@tables) {
     $new_base_repository =~ s/\{\{INSERT_MANY_ENTRIES}}/$insert_many_entries/g;
     $new_base_repository =~ s/\{\{ALL_ENTRIES}}/$all_entries/g;
     $new_base_repository =~ s/\{\{GENERATED_DATE}}/$generated_date/g;
+    $new_base_repository =~ s/\{\{ADDITIONAL_INCLUDES}}/$additional_includes/g;
 
     # Extended repository
     my $new_repository = $repository_template;


### PR DESCRIPTION
This PR adds support for automatically generating Cereal library serialization against a repositories data model struct automatically. It also appends the cereal include to the repository automatically.

This is utilized in an upcoming PR for player events

**Before**

```cpp
struct PlayerEventLogs {
	int64_t     id;
	int64_t     account_id;
	int64_t     character_id;
	int32_t     zone_id;
	int32_t     instance_id;
	float       x;
	float       y;
	float       z;
	float       heading;
	int32_t     event_type_id;
	std::string event_type_name;
	std::string event_data;
	time_t      created_at;
};
```

**After**

```cpp
struct PlayerEventLogs {
	int64_t     id;
	int64_t     account_id;
	int64_t     character_id;
	int32_t     zone_id;
	int32_t     instance_id;
	float       x;
	float       y;
	float       z;
	float       heading;
	int32_t     event_type_id;
	std::string event_type_name;
	std::string event_data;
	time_t      created_at;

	// cereal
	template<class Archive>
	void serialize(Archive &ar)
	{
		ar(
			CEREAL_NVP(id),
			CEREAL_NVP(account_id),
			CEREAL_NVP(character_id),
			CEREAL_NVP(zone_id),
			CEREAL_NVP(instance_id),
			CEREAL_NVP(x),
			CEREAL_NVP(y),
			CEREAL_NVP(z),
			CEREAL_NVP(heading),
			CEREAL_NVP(event_type_id),
			CEREAL_NVP(event_type_name),
			CEREAL_NVP(event_data),
			CEREAL_NVP(created_at)
		);
	}
};
```
