### PR TITLE
[Hotfix] Compiling fails on FMT 9.1 with Bots

### DIFF
--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -5487,7 +5487,7 @@ void bot_subcommand_bot_create(Client *c, const Seperator *sep)
 			}
 
 			window_text.append(
-				fmt::format(
+				fmt::format("{} {}",
 					class_substrs[i + 1],
 					(i + 1)
 				)
@@ -5512,7 +5512,7 @@ void bot_subcommand_bot_create(Client *c, const Seperator *sep)
 			}
 
 			window_text.append(
-				fmt::format(
+				fmt::format("{}, {}",
 					race_substrs[i + 1],
 					race_values[i + 1]
 				)
@@ -5531,7 +5531,7 @@ void bot_subcommand_bot_create(Client *c, const Seperator *sep)
 			window_text.append(message_separator);
 
 			window_text.append(
-				fmt::format(
+				fmt::format("{}, {}",
 					gender_substrs[i],
 					i
 				)


### PR DESCRIPTION
quick fix (causes minor formatting issue), is properly fixed under Akkadius/player-event-logging branch.