### PR TITLE
[Rules] Rule to allow cap on % XP gain per kill

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -196,7 +196,7 @@ RULE_BOOL(Character, OnInviteReceiveAlreadyinGroupMessage, true, "If you want cl
 RULE_BOOL(Character, PetZoneWithOwner, true, "Should Pets Zone with Owner")
 RULE_BOOL(Character, FullManaOnDeath, true, "On death set mana to full")
 RULE_BOOL(Character, FullEndurOnDeath, true, "On death set endurance to full")
-RULE_INT(Character, KillExperiencePercentCap, -1, "If you want there to be a percent cap of a player's current level. -1 disables the cap; 0 blocks all (non-aa) xp.")
+RULE_INT(Character, ExperiencePercentCapPerKill, -1, "Caps the percentage of experience that can be gained per kill. -1 disables the cap; 0 blocks all (non-aa) xp.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Mercs)

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -196,7 +196,7 @@ RULE_BOOL(Character, OnInviteReceiveAlreadyinGroupMessage, true, "If you want cl
 RULE_BOOL(Character, PetZoneWithOwner, true, "Should Pets Zone with Owner")
 RULE_BOOL(Character, FullManaOnDeath, true, "On death set mana to full")
 RULE_BOOL(Character, FullEndurOnDeath, true, "On death set endurance to full")
-RULE_INT(Character, KillExperiencePercentCap, 100, "If you want there to be a percent cap (0-100) of a player's current level. 100 disables the cap; 0 blocks all xp.")
+RULE_INT(Character, KillExperiencePercentCap, 100, "If you want there to be a percent cap (0-100) of a player's current level. 100 disables the cap; 0 blocks all (non-aa) xp.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Mercs)

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -196,6 +196,7 @@ RULE_BOOL(Character, OnInviteReceiveAlreadyinGroupMessage, true, "If you want cl
 RULE_BOOL(Character, PetZoneWithOwner, true, "Should Pets Zone with Owner")
 RULE_BOOL(Character, FullManaOnDeath, true, "On death set mana to full")
 RULE_BOOL(Character, FullEndurOnDeath, true, "On death set endurance to full")
+RULE_INT(Character, KillExperiencePercentCap, 100, "If you want there to be a percent cap (0-100) of a player's current level. 100 disables the cap; 0 blocks all xp.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Mercs)

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -196,7 +196,7 @@ RULE_BOOL(Character, OnInviteReceiveAlreadyinGroupMessage, true, "If you want cl
 RULE_BOOL(Character, PetZoneWithOwner, true, "Should Pets Zone with Owner")
 RULE_BOOL(Character, FullManaOnDeath, true, "On death set mana to full")
 RULE_BOOL(Character, FullEndurOnDeath, true, "On death set endurance to full")
-RULE_INT(Character, KillExperiencePercentCap, 100, "If you want there to be a percent cap (0-100) of a player's current level. 100 disables the cap; 0 blocks all (non-aa) xp.")
+RULE_INT(Character, KillExperiencePercentCap, -1, "If you want there to be a percent cap of a player's current level. -1 disables the cap; 0 blocks all (non-aa) xp.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Mercs)

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -503,7 +503,7 @@ void Client::CalculateExp(uint32 in_add_exp, uint32 &add_exp, uint32 &add_aaxp, 
 		auto experience_for_level = (GetEXPForLevel(GetLevel() + 1) - GetEXPForLevel(GetLevel()));
 		auto exp_percent = static_cast<uint32>(std::ceil(static_cast<float>(add_exp / experience_for_level) * 100.0f));
 		if (exp_percent > kill_percent_xp_cap) {
-			add_exp = static_cast<uint32>(std::floor(experience_for_level * (kill_percent_xp_cap / 100.0)));
+			add_exp = static_cast<uint32>(std::floor(experience_for_level * (kill_percent_xp_cap / 100.0f)));
 		}
 	}
 }

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -440,7 +440,7 @@ void Client::CalculateExp(uint32 in_add_exp, uint32 &add_exp, uint32 &add_aaxp, 
 		//Enforce Percent XP Cap per kill, if rule is enabled
 		int kill_percent_xp_cap = RuleI(Character, KillExperiencePercentCap);
 		if (kill_percent_xp_cap >= 0) { // If the cap is == -1, do nothing
-			uint32  experience_for_level = (uint32 )(GetEXPForLevel(GetLevel() + 1) - GetEXPForLevel(GetLevel())); // Amt of xp needed to complete current level
+			uint32  experience_for_level = (uint32)(GetEXPForLevel(GetLevel() + 1) - GetEXPForLevel(GetLevel())); // Amt of xp needed to complete current level
 			uint8 exp_percent = ceil((float)((float)add_exp / experience_for_level) * 100); // Percent of current level earned
 			if (exp_percent > kill_percent_xp_cap) { // Determine if the earned XP percent is higher than the percent cap
 				add_exp = floor(experience_for_level * (kill_percent_xp_cap / 100.0)); // Set the added xp to the set cap.

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -439,11 +439,11 @@ void Client::CalculateExp(uint32 in_add_exp, uint32 &add_exp, uint32 &add_aaxp, 
 
 		//Enforce Percent XP Cap per kill, if rule is enabled
 		int kill_percent_xp_cap = RuleI(Character, ExperiencePercentCapPerKill);
-		bool should_percentage_cap = kill_percent_xp_cap >= 0;
+		bool should_percentage_cap = (kill_percent_xp_cap >= 0);
 		if (should_percentage_cap) { 
 			uint32 experience_for_level = (uint32)(GetEXPForLevel(GetLevel() + 1) - GetEXPForLevel(GetLevel())); // Amt of xp needed to complete current level
-			uint8 exp_percent = ceil((float)((float)add_exp / experience_for_level) * 100); // Percent of current level earned
-			bool gained_exp_higher_than_cap = exp_percent > kill_percent_xp_cap;
+			uint32 exp_percent = ceil((float)((float)add_exp / experience_for_level) * 100); // Percent of current level earned
+			bool gained_exp_higher_than_cap = (exp_percent > kill_percent_xp_cap);
 			if (gained_exp_higher_than_cap) { 
 				add_exp = floor(experience_for_level * (kill_percent_xp_cap / 100.0)); // Set the added xp to the set cap.
 			}

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -439,10 +439,10 @@ void Client::CalculateExp(uint32 in_add_exp, uint32 &add_exp, uint32 &add_aaxp, 
 		//Enforce Percent XP Cap per kill, if rule is enabled
 		int kill_percent_xp_cap = RuleI(Character, ExperiencePercentCapPerKill);
 		if (kill_percent_xp_cap >= 0) {
-			auto experience_for_level = (GetEXPForLevel(GetLevel() + 1) - GetEXPForLevel(GetLevel())); // Amt of xp needed to complete current level
-			auto exp_percent = static_cast<uint32>(std::ceil(static_cast<float>(add_exp / experience_for_level) * 100.0f)); // Percent of current level earned
+			auto experience_for_level = (GetEXPForLevel(GetLevel() + 1) - GetEXPForLevel(GetLevel()));
+			auto exp_percent = static_cast<uint32>(std::ceil(static_cast<float>(add_exp / experience_for_level) * 100.0f));
 			if (exp_percent > kill_percent_xp_cap) {
-				add_exp = std::floor(experience_for_level * (kill_percent_xp_cap / 100.0)); // Set the added xp to the set cap.
+				add_exp = static_cast<uint32>(std::floor(experience_for_level * (kill_percent_xp_cap / 100.0)));
 			}
 		}
 

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -436,16 +436,6 @@ void Client::CalculateExp(uint32 in_add_exp, uint32 &add_exp, uint32 &add_aaxp, 
 		//take that amount away from regular exp
 		add_exp -= add_aaxp;
 
-		//Enforce Percent XP Cap per kill, if rule is enabled
-		int kill_percent_xp_cap = RuleI(Character, ExperiencePercentCapPerKill);
-		if (kill_percent_xp_cap >= 0) {
-			auto experience_for_level = (GetEXPForLevel(GetLevel() + 1) - GetEXPForLevel(GetLevel()));
-			auto exp_percent = static_cast<uint32>(std::ceil(static_cast<float>(add_exp / experience_for_level) * 100.0f));
-			if (exp_percent > kill_percent_xp_cap) {
-				add_exp = static_cast<uint32>(std::floor(experience_for_level * (kill_percent_xp_cap / 100.0)));
-			}
-		}
-
 		float totalmod = 1.0;
 		float zemmod = 1.0;
 
@@ -506,6 +496,16 @@ void Client::CalculateExp(uint32 in_add_exp, uint32 &add_exp, uint32 &add_aaxp, 
 	}
 
 	add_exp = GetEXP() + add_exp;
+	
+	//Enforce Percent XP Cap per kill, if rule is enabled
+	int kill_percent_xp_cap = RuleI(Character, ExperiencePercentCapPerKill);
+	if (kill_percent_xp_cap >= 0) {
+		auto experience_for_level = (GetEXPForLevel(GetLevel() + 1) - GetEXPForLevel(GetLevel()));
+		auto exp_percent = static_cast<uint32>(std::ceil(static_cast<float>(add_exp / experience_for_level) * 100.0f));
+		if (exp_percent > kill_percent_xp_cap) {
+			add_exp = static_cast<uint32>(std::floor(experience_for_level * (kill_percent_xp_cap / 100.0)));
+		}
+	}
 }
 
 void Client::AddEXP(uint32 in_add_exp, uint8 conlevel, bool resexp) {

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -438,15 +438,8 @@ void Client::CalculateExp(uint32 in_add_exp, uint32 &add_exp, uint32 &add_aaxp, 
 		add_exp -= add_aaxp;
 
 		//Enforce Percent XP Cap per kill, if rule is enabled
-		unsigned short KillPercentXPCap = RuleI(Character, KillExperiencePercentCap);
-		// Enforce bounds
-		if (KillPercentXPCap > 100) {
-			KillPercentXPCap = 100;
-		}
-		else if (KillPercentXPCap < 0) {
-			KillPercentXPCap = 0;
-		}
-		if (KillPercentXPCap < 100) { // If the cap is >= 100, do nothing
+		int KillPercentXPCap = RuleI(Character, KillExperiencePercentCap);
+		if (KillPercentXPCap >= 0) { // If the cap is == -1, do nothing
 			unsigned long int ExperienceForLevel = (unsigned long int)(GetEXPForLevel(GetLevel() + 1) - GetEXPForLevel(GetLevel())); // Amt of xp needed to complete current level
 			unsigned short exp_percent = ceil((float)((float)add_exp / ExperienceForLevel) * 100); // Percent of current level earned
 			if (exp_percent > KillPercentXPCap) { // Determine if the earned XP percent is higher than the percent cap

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -438,12 +438,12 @@ void Client::CalculateExp(uint32 in_add_exp, uint32 &add_exp, uint32 &add_aaxp, 
 		add_exp -= add_aaxp;
 
 		//Enforce Percent XP Cap per kill, if rule is enabled
-		int KillPercentXPCap = RuleI(Character, KillExperiencePercentCap);
-		if (KillPercentXPCap >= 0) { // If the cap is == -1, do nothing
-			unsigned long int ExperienceForLevel = (unsigned long int)(GetEXPForLevel(GetLevel() + 1) - GetEXPForLevel(GetLevel())); // Amt of xp needed to complete current level
-			unsigned short exp_percent = ceil((float)((float)add_exp / ExperienceForLevel) * 100); // Percent of current level earned
-			if (exp_percent > KillPercentXPCap) { // Determine if the earned XP percent is higher than the percent cap
-				add_exp = floor(ExperienceForLevel * (KillPercentXPCap / 100.0)); // Set the added xp to the set cap.
+		int kill_percent_xp_cap = RuleI(Character, KillExperiencePercentCap);
+		if (kill_percent_xp_cap >= 0) { // If the cap is == -1, do nothing
+			uint32  experience_for_level = (uint32 )(GetEXPForLevel(GetLevel() + 1) - GetEXPForLevel(GetLevel())); // Amt of xp needed to complete current level
+			uint8 exp_percent = ceil((float)((float)add_exp / experience_for_level) * 100); // Percent of current level earned
+			if (exp_percent > kill_percent_xp_cap) { // Determine if the earned XP percent is higher than the percent cap
+				add_exp = floor(experience_for_level * (kill_percent_xp_cap / 100.0)); // Set the added xp to the set cap.
 			}
 		}
 

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -205,7 +205,7 @@ uint32 Client::CalcEXP(uint8 conlevel) {
 		float ExperienceForLevel = (float)(GetEXPForLevel(GetLevel() + 1) - GetEXPForLevel(GetLevel()) * (float)100); // Amt of xp needed to complete current level
 		float exp_percent = (float)((float)exp_gained / ExperienceForLevel); // Percent of current level earned
 		if (exp_percent > KillPercentXPCap) { // Detirmine if the earned XP percent is higher than the percent cap
-			in_add_exp = floor(ExperienceForLevel * (KillPercentXPCap / 100.0));
+			in_add_exp = floor(ExperienceForLevel * (KillPercentXPCap / 100.0)); // Set the added xp to the set cap.
 		}
 	}
 

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -439,12 +439,10 @@ void Client::CalculateExp(uint32 in_add_exp, uint32 &add_exp, uint32 &add_aaxp, 
 
 		//Enforce Percent XP Cap per kill, if rule is enabled
 		int kill_percent_xp_cap = RuleI(Character, ExperiencePercentCapPerKill);
-		bool should_percentage_cap = (kill_percent_xp_cap >= 0);
-		if (should_percentage_cap) { 
+		if (kill_percent_xp_cap >= 0) {
 			uint32 experience_for_level = (uint32)(GetEXPForLevel(GetLevel() + 1) - GetEXPForLevel(GetLevel())); // Amt of xp needed to complete current level
 			uint32 exp_percent = ceil((float)((float)add_exp / experience_for_level) * 100); // Percent of current level earned
-			bool gained_exp_higher_than_cap = (exp_percent > kill_percent_xp_cap);
-			if (gained_exp_higher_than_cap) { 
+			if (exp_percent > kill_percent_xp_cap) {
 				add_exp = floor(experience_for_level * (kill_percent_xp_cap / 100.0)); // Set the added xp to the set cap.
 			}
 		}

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -430,7 +430,6 @@ void Client::CalculateExp(uint32 in_add_exp, uint32 &add_exp, uint32 &add_aaxp, 
 
 	if (!resexp)
 	{
-		
 		//figure out how much of this goes to AAs
 		add_aaxp = add_exp * m_epp.perAA / 100;
 
@@ -440,10 +439,10 @@ void Client::CalculateExp(uint32 in_add_exp, uint32 &add_exp, uint32 &add_aaxp, 
 		//Enforce Percent XP Cap per kill, if rule is enabled
 		int kill_percent_xp_cap = RuleI(Character, ExperiencePercentCapPerKill);
 		if (kill_percent_xp_cap >= 0) {
-			uint32 experience_for_level = (uint32)(GetEXPForLevel(GetLevel() + 1) - GetEXPForLevel(GetLevel())); // Amt of xp needed to complete current level
-			uint32 exp_percent = ceil((float)((float)add_exp / experience_for_level) * 100); // Percent of current level earned
+			auto experience_for_level = (GetEXPForLevel(GetLevel() + 1) - GetEXPForLevel(GetLevel())); // Amt of xp needed to complete current level
+			auto exp_percent = static_cast<uint32>(std::ceil(static_cast<float>(add_exp / experience_for_level) * 100.0f)); // Percent of current level earned
 			if (exp_percent > kill_percent_xp_cap) {
-				add_exp = floor(experience_for_level * (kill_percent_xp_cap / 100.0)); // Set the added xp to the set cap.
+				add_exp = std::floor(experience_for_level * (kill_percent_xp_cap / 100.0)); // Set the added xp to the set cap.
 			}
 		}
 

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -200,12 +200,12 @@ uint32 Client::CalcEXP(uint8 conlevel) {
 	}
 
 	unsigned short KillPercentXPCap = RuleI(Character, KillExperiencePercentCap);
-	if (KillPercentXPCap < 100) { // If the cap is 100, do nothing
+	if (KillPercentXPCap < 100) { // If the cap is >= 100, do nothing
 		uint32 exp_gained = in_add_exp;
-		float ExperienceForLevel = (float)(GetEXPForLevel(GetLevel() + 1) - GetEXPForLevel(GetLevel()) * (float)100);
+		float ExperienceForLevel = (float)(GetEXPForLevel(GetLevel() + 1) - GetEXPForLevel(GetLevel()) * (float)100); // Amt of xp needed to complete current level
 		float exp_percent = (float)((float)exp_gained / ExperienceForLevel); // Percent of current level earned
 		if (exp_percent > KillPercentXPCap) { // Detirmine if the earned XP percent is higher than the percent cap
-			in_add_exp = floor(m_pp.exp * KillPercentXPCap / 100.0);
+			in_add_exp = floor(ExperienceForLevel * (KillPercentXPCap / 100.0));
 		}
 	}
 

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -438,11 +438,13 @@ void Client::CalculateExp(uint32 in_add_exp, uint32 &add_exp, uint32 &add_aaxp, 
 		add_exp -= add_aaxp;
 
 		//Enforce Percent XP Cap per kill, if rule is enabled
-		int kill_percent_xp_cap = RuleI(Character, KillExperiencePercentCap);
-		if (kill_percent_xp_cap >= 0) { // If the cap is == -1, do nothing
-			uint32  experience_for_level = (uint32)(GetEXPForLevel(GetLevel() + 1) - GetEXPForLevel(GetLevel())); // Amt of xp needed to complete current level
+		int kill_percent_xp_cap = RuleI(Character, ExperiencePercentCapPerKill);
+		bool should_percentage_cap = kill_percent_xp_cap >= 0;
+		if (should_percentage_cap) { 
+			uint32 experience_for_level = (uint32)(GetEXPForLevel(GetLevel() + 1) - GetEXPForLevel(GetLevel())); // Amt of xp needed to complete current level
 			uint8 exp_percent = ceil((float)((float)add_exp / experience_for_level) * 100); // Percent of current level earned
-			if (exp_percent > kill_percent_xp_cap) { // Determine if the earned XP percent is higher than the percent cap
+			bool gained_exp_higher_than_cap = exp_percent > kill_percent_xp_cap;
+			if (gained_exp_higher_than_cap) { 
 				add_exp = floor(experience_for_level * (kill_percent_xp_cap / 100.0)); // Set the added xp to the set cap.
 			}
 		}

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -199,6 +199,16 @@ uint32 Client::CalcEXP(uint8 conlevel) {
 		in_add_exp *= RuleR(Character, FinalExpMultiplier);
 	}
 
+	unsigned short KillPercentXPCap = RuleI(Character, KillExperiencePercentCap);
+	if (KillPercentXPCap < 100) { // If the cap is 100, do nothing
+		uint32 exp_gained = in_add_exp;
+		float ExperienceForLevel = (float)(GetEXPForLevel(GetLevel() + 1) - GetEXPForLevel(GetLevel()) * (float)100);
+		float exp_percent = (float)((float)exp_gained / ExperienceForLevel); // Percent of current level earned
+		if (exp_percent > KillPercentXPCap) { // Detirmine if the earned XP percent is higher than the percent cap
+			in_add_exp = floor(m_pp.exp * KillPercentXPCap / 100.0);
+		}
+	}
+
 	return in_add_exp;
 }
 


### PR DESCRIPTION
This adds the following rule:

Character:ExperiencePercentCapPerKill: (-1=disabled, 0+ enforced) (default = -1)

This rule allows server operators to cap experience gains to a percent of the players current level. Note that this cap is enforced AFTER AA exp is removed.

This cap is also enforced before any XP modifiers.

Tested and working on my local dev server.