### PR TITLE
[Quest API] Add IsAttackAllowed() to Perl/Lua.

### DIFF
--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -2253,11 +2253,6 @@ int16 Lua_Mob::GetMeleeMinDamageMod_SE(uint16 skill)
 	return self->GetMeleeMinDamageMod_SE(skill);
 }
 
-bool Lua_Mob::IsAttackAllowed(Lua_Mob target, bool isSpellAttack) {
-	Lua_Safe_Call_Bool();
-	return self->IsAttackAllowed(target, isSpellAttack);
-}
-
 bool Lua_Mob::IsCasting() {
 	Lua_Safe_Call_Bool();
 	return self->IsCasting();
@@ -2752,6 +2747,16 @@ void Lua_Mob::CopyHateList(Lua_Mob to) {
 	self->CopyHateList(to);
 }
 
+bool Lua_Mob::IsAttackAllowed(Lua_Mob target) {
+	Lua_Safe_Call_Bool();
+	return self->IsAttackAllowed(target);
+}
+
+bool Lua_Mob::IsAttackAllowed(Lua_Mob target, bool is_spell_attack) {
+	Lua_Safe_Call_Bool();
+	return self->IsAttackAllowed(target, is_spell_attack);
+}
+
 #ifdef BOTS
 void Lua_Mob::DamageAreaBots(int64 damage) {
 	Lua_Safe_Call_Void();
@@ -3157,7 +3162,8 @@ luabind::scope lua_register_mob() {
 	.def("InterruptSpell", (void(Lua_Mob::*)(void))&Lua_Mob::InterruptSpell)
 	.def("IsAIControlled", (bool(Lua_Mob::*)(void))&Lua_Mob::IsAIControlled)
 	.def("IsAmnesiad", (bool(Lua_Mob::*)(void))&Lua_Mob::IsAmnesiad)
-	.def("IsAttackAllowed", &Lua_Mob::IsAttackAllowed)
+	.def("IsAttackAllowed", (bool(Lua_Mob::*)(Lua_Mob))&Lua_Mob::IsAttackAllowed)
+	.def("IsAttackAllowed", (bool(Lua_Mob::*)(Lua_Mob,bool))&Lua_Mob::IsAttackAllowed)
 	.def("IsBeneficialAllowed", (bool(Lua_Mob::*)(Lua_Mob))&Lua_Mob::IsBeneficialAllowed)
 	.def("IsBerserk", &Lua_Mob::IsBerserk)
 	.def("IsBlind", (bool(Lua_Mob::*)(void))&Lua_Mob::IsBlind)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -456,7 +456,6 @@ public:
 	Lua_StatBonuses GetAABonuses();
 	int16 GetMeleeDamageMod_SE(uint16 skill);
 	int16 GetMeleeMinDamageMod_SE(uint16 skill);
-	bool IsAttackAllowed(Lua_Mob target, bool isSpellAttack);
 	bool IsCasting();
 	int AttackAnimation(int Hand, Lua_ItemInst weapon);
 	int GetWeaponDamage(Lua_Mob against, Lua_ItemInst weapon);
@@ -520,6 +519,8 @@ public:
 	void DamageHateListNPCsPercentage(int64 damage);
 	void DamageHateListNPCsPercentage(int64 damage, uint32 distance);
 	void CopyHateList(Lua_Mob to);
+	bool IsAttackAllowed(Lua_Mob target);
+	bool IsAttackAllowed(Lua_Mob target, bool is_spell_attack);
 };
 
 #endif

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -2693,6 +2693,16 @@ void Perl_Mob_CopyHateList(Mob* self, Mob* to)
 	self->CopyHateList(to);
 }
 
+bool Perl_Mob_IsAttackAllowed(Mob* self, Mob* target)
+{
+	return self->IsAttackAllowed(target);
+}
+
+bool Perl_Mob_IsAttackAllowed(Mob* self, Mob* target, bool is_spell_attack)
+{
+	return self->IsAttackAllowed(target, is_spell_attack);
+}
+
 #ifdef BOTS
 void Perl_Mob_DamageAreaBots(Mob* self, int64 damage) // @categories Hate and Aggro
 {
@@ -3100,6 +3110,8 @@ void perl_register_mob()
 	package.add("InterruptSpell", (void(*)(Mob*, uint16))&Perl_Mob_InterruptSpell);
 	package.add("IsAIControlled", &Perl_Mob_IsAIControlled);
 	package.add("IsAmnesiad", &Perl_Mob_IsAmnesiad);
+	package.add("IsAttackAllowed", (bool(*)(Mob*, Mob*))&Perl_Mob_IsAttackAllowed);
+	package.add("IsAttackAllowed", (bool(*)(Mob*, Mob*, bool))&Perl_Mob_IsAttackAllowed);
 	package.add("IsBeacon", &Perl_Mob_IsBeacon);
 	package.add("IsBeneficialAllowed", &Perl_Mob_IsBeneficialAllowed);
 	package.add("IsBlind", &Perl_Mob_IsBlind);


### PR DESCRIPTION
# Perl
- Add `$mob->IsAttackAllowed(target)`.
- Add `$mob->IsAttackAllowed(target, is_spell_attack)`.

# Lua
- Add `mob:IsAttackAllowed(target)`.

# Notes
- Lua had `mob:IsAttackAllowed(target, is_spell_attack)` but not the other overload.
- Perl had neither.