### PR TITLE
[Quest API] Add GetAugmentIDsBySlotID() to Perl/Lua.

### DIFF
--- a/common/inventory_profile.cpp
+++ b/common/inventory_profile.cpp
@@ -1718,3 +1718,16 @@ int16 EQ::InventoryProfile::_HasItemByLoreGroup(ItemInstQueue& iqueue, uint32 lo
 
 	return EQ::invslot::SLOT_INVALID;
 }
+
+std::vector<uint32> EQ::InventoryProfile::GetAugmentIDsBySlotID(int16 slot_id)
+{
+	std::vector<uint32> augments;
+	const auto* item = GetItem(slot_id);
+	if (item) {
+		for (uint8 i = invaug::SOCKET_BEGIN; i <= invaug::SOCKET_END; i++) {
+			augments.push_back(item->GetAugment(i) ? item->GetAugmentItemID(i) : 0);
+		}
+	}
+
+	return augments;
+}

--- a/common/inventory_profile.cpp
+++ b/common/inventory_profile.cpp
@@ -1723,6 +1723,7 @@ std::vector<uint32> EQ::InventoryProfile::GetAugmentIDsBySlotID(int16 slot_id)
 {
 	std::vector<uint32> augments;
 	const auto* item = GetItem(slot_id);
+
 	if (item) {
 		for (uint8 i = invaug::SOCKET_BEGIN; i <= invaug::SOCKET_END; i++) {
 			augments.push_back(item->GetAugment(i) ? item->GetAugmentItemID(i) : 0);

--- a/common/inventory_profile.h
+++ b/common/inventory_profile.h
@@ -28,6 +28,7 @@
 #include "item_instance.h"
 
 #include <list>
+#include <vector>
 
 
 //FatherNitwit: location bits for searching specific
@@ -151,6 +152,9 @@ namespace EQ
 
 		// Check how many of a specific augment the player has equipped by Item ID
 		int CountAugmentEquippedByID(uint32 item_id);
+
+		// Get a list of augments from a specific slot ID
+		std::vector<uint32> GetAugmentIDsBySlotID(int16 slot_id);
 
 		// Check whether there is space for the specified number of the specified item.
 		bool HasSpaceForItem(const ItemData *ItemToTry, int16 Quantity);

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -650,7 +650,7 @@ luabind::object Lua_Client::GetLearnableDisciplines(lua_State* L) {
 	if (d_) {
 		auto self = reinterpret_cast<NativeType*>(d_);
 		auto learnable_disciplines = self->GetLearnableDisciplines();
-		int index = 0;
+		int index = 1;
 		for (auto spell_id : learnable_disciplines) {
 			lua_table[index] = spell_id;
 			index++;
@@ -664,7 +664,7 @@ luabind::object Lua_Client::GetLearnableDisciplines(lua_State* L, uint8 min_leve
 	if (d_) {
 		auto self = reinterpret_cast<NativeType*>(d_);
 		auto learnable_disciplines = self->GetLearnableDisciplines(min_level);
-		int index = 0;
+		int index = 1;
 		for (auto spell_id : learnable_disciplines) {
 			lua_table[index] = spell_id;
 			index++;
@@ -678,7 +678,7 @@ luabind::object Lua_Client::GetLearnableDisciplines(lua_State* L, uint8 min_leve
 	if (d_) {
 		auto self = reinterpret_cast<NativeType*>(d_);
 		auto learnable_disciplines = self->GetLearnableDisciplines(min_level, max_level);
-		int index = 0;
+		int index = 1;
 		for (auto spell_id : learnable_disciplines) {
 			lua_table[index] = spell_id;
 			index++;
@@ -692,7 +692,7 @@ luabind::object Lua_Client::GetLearnedDisciplines(lua_State* L) {
 	if (d_) {
 		auto self = reinterpret_cast<NativeType*>(d_);
 		auto learned_disciplines = self->GetLearnedDisciplines();
-		int index = 0;
+		int index = 1;
 		for (auto spell_id : learned_disciplines) {
 			lua_table[index] = spell_id;
 			index++;
@@ -706,7 +706,7 @@ luabind::object Lua_Client::GetMemmedSpells(lua_State* L) {
 	if (d_) {
 		auto self = reinterpret_cast<NativeType*>(d_);
 		auto memmed_spells = self->GetMemmedSpells();
-		int index = 0;
+		int index = 1;
 		for (auto spell_id : memmed_spells) {
 			lua_table[index] = spell_id;
 			index++;
@@ -720,7 +720,7 @@ luabind::object Lua_Client::GetScribeableSpells(lua_State* L) {
 	if (d_) {
 		auto self = reinterpret_cast<NativeType*>(d_);
 		auto scribeable_spells = self->GetScribeableSpells();
-		int index = 0;
+		int index = 1;
 		for (auto spell_id : scribeable_spells) {
 			lua_table[index] = spell_id;
 			index++;
@@ -734,7 +734,7 @@ luabind::object Lua_Client::GetScribeableSpells(lua_State* L, uint8 min_level) {
 	if (d_) {
 		auto self = reinterpret_cast<NativeType*>(d_);
 		auto scribeable_spells = self->GetScribeableSpells(min_level);
-		int index = 0;
+		int index = 1;
 		for (auto spell_id : scribeable_spells) {
 			lua_table[index] = spell_id;
 			index++;
@@ -748,7 +748,7 @@ luabind::object Lua_Client::GetScribeableSpells(lua_State* L, uint8 min_level, u
 	if (d_) {
 		auto self = reinterpret_cast<NativeType*>(d_);
 		auto scribeable_spells = self->GetScribeableSpells(min_level, max_level);
-		int index = 0;
+		int index = 1;
 		for (auto spell_id : scribeable_spells) {
 			lua_table[index] = spell_id;
 			index++;
@@ -762,7 +762,7 @@ luabind::object Lua_Client::GetScribedSpells(lua_State* L) {
 	if (d_) {
 		auto self = reinterpret_cast<NativeType*>(d_);
 		auto scribed_spells = self->GetScribedSpells();
-		int index = 0;
+		int index = 1;
 		for (auto spell_id : scribed_spells) {
 			lua_table[index] = spell_id;
 			index++;
@@ -2892,6 +2892,20 @@ void Lua_Client::MaxSkills()
 	self->MaxSkills();
 }
 
+luabind::object Lua_Client::GetAugmentIDsBySlotID(lua_State* L, int16 slot_id) {
+	auto lua_table = luabind::newtable(L);
+	if (d_) {
+		auto self = reinterpret_cast<NativeType*>(d_);
+		auto augments = self->GetInv().GetAugmentIDsBySlotID(slot_id);
+		int index = 1;
+		for (auto item_id : augments) {
+			lua_table[index] = item_id;
+			index++;
+		}
+	}
+	return lua_table;
+}
+
 #ifdef BOTS
 
 int Lua_Client::GetBotRequiredLevel()
@@ -3092,6 +3106,7 @@ luabind::scope lua_register_client() {
 	.def("GetAlternateCurrencyValue", (int(Lua_Client::*)(uint32))&Lua_Client::GetAlternateCurrencyValue)
 	.def("GetAnon", (int(Lua_Client::*)(void))&Lua_Client::GetAnon)
 	.def("GetAugmentIDAt", (int(Lua_Client::*)(int,int))&Lua_Client::GetAugmentIDAt)
+	.def("GetAugmentIDsBySlotID", (luabind::object(Lua_Client::*)(lua_State* L,int16))&Lua_Client::GetAugmentIDsBySlotID)
 	.def("GetBaseAGI", (int(Lua_Client::*)(void))&Lua_Client::GetBaseAGI)
 	.def("GetBaseCHA", (int(Lua_Client::*)(void))&Lua_Client::GetBaseCHA)
 	.def("GetBaseDEX", (int(Lua_Client::*)(void))&Lua_Client::GetBaseDEX)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -454,6 +454,7 @@ public:
 	void SendPayload(int payload_id, std::string payload_value);
 	std::string GetGuildPublicNote();
 	void MaxSkills();
+	luabind::object GetAugmentIDsBySlotID(lua_State* L, int16 slot_id);
 
 	void ApplySpell(int spell_id);
 	void ApplySpell(int spell_id, int duration);

--- a/zone/lua_inventory.cpp
+++ b/zone/lua_inventory.cpp
@@ -184,6 +184,20 @@ bool Lua_Inventory::HasItemEquippedByID(uint32 item_id) {
 	return self->HasItemEquippedByID(item_id);
 }
 
+luabind::object Lua_Inventory::GetAugmentIDsBySlotID(lua_State* L, int16 slot_id) {
+	auto lua_table = luabind::newtable(L);
+	if (d_) {
+		auto self = reinterpret_cast<NativeType*>(d_);
+		auto augments = self->GetAugmentIDsBySlotID(slot_id);
+		int index = 1;
+		for (auto item_id : augments) {
+			lua_table[index] = item_id;
+			index++;
+		}
+	}
+	return lua_table;
+}
+
 luabind::scope lua_register_inventory() {
 	return luabind::class_<Lua_Inventory>("Inventory")
 	.def(luabind::constructor<>())
@@ -201,6 +215,7 @@ luabind::scope lua_register_inventory() {
 	.def("FindFreeSlot", (int(Lua_Inventory::*)(bool,bool))&Lua_Inventory::FindFreeSlot)
 	.def("FindFreeSlot", (int(Lua_Inventory::*)(bool,bool,int))&Lua_Inventory::FindFreeSlot)
 	.def("FindFreeSlot", (int(Lua_Inventory::*)(bool,bool,int,bool))&Lua_Inventory::FindFreeSlot)
+	.def("GetAugmentIDsBySlotID", (luabind::object(Lua_Inventory::*)(lua_State* L,int16))&Lua_Inventory::GetAugmentIDsBySlotID)
 	.def("GetItem", (Lua_ItemInst(Lua_Inventory::*)(int))&Lua_Inventory::GetItem)
 	.def("GetItem", (Lua_ItemInst(Lua_Inventory::*)(int,int))&Lua_Inventory::GetItem)
 	.def("GetSlotByItemInst", (int(Lua_Inventory::*)(Lua_ItemInst))&Lua_Inventory::GetSlotByItemInst)

--- a/zone/lua_inventory.h
+++ b/zone/lua_inventory.h
@@ -68,6 +68,7 @@ public:
 	bool CanItemFitInContainer(Lua_Item item, Lua_Item container);
 	bool SupportsContainers(int slot_id);
 	int GetSlotByItemInst(Lua_ItemInst inst);
+	luabind::object GetAugmentIDsBySlotID(lua_State* L, int16 slot_id);
 };
 
 #endif

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -2772,6 +2772,18 @@ void Perl_Client_MaxSkills(Client* self)
 	self->MaxSkills();
 }
 
+perl::array Perl_Client_GetAugmentIDsBySlotID(Client* self, int16 slot_id)
+{
+	perl::array result;
+	auto augments = self->GetInv().GetAugmentIDsBySlotID(slot_id);
+
+	for (int i = 0; i < augments.size(); ++i) {
+		result.push_back(augments[i]);
+	}
+
+	return result;
+}
+
 #ifdef BOTS
 
 int Perl_Client_GetBotRequiredLevel(Client* self)
@@ -2958,6 +2970,7 @@ void perl_register_client()
 	package.add("GetAnon", &Perl_Client_GetAnon);
 	package.add("GetAugmentAt", &Perl_Client_GetAugmentAt);
 	package.add("GetAugmentIDAt", &Perl_Client_GetAugmentIDAt);
+	package.add("GetAugmentIDsBySlotID", &Perl_Client_GetAugmentIDsBySlotID);
 	package.add("GetBaseAGI", &Perl_Client_GetBaseAGI);
 	package.add("GetBaseCHA", &Perl_Client_GetBaseCHA);
 	package.add("GetBaseDEX", &Perl_Client_GetBaseDEX);

--- a/zone/perl_inventory.cpp
+++ b/zone/perl_inventory.cpp
@@ -166,6 +166,18 @@ int Perl_Inventory_CountItemEquippedByID(EQ::InventoryProfile* self, uint32_t it
 	return self->CountItemEquippedByID(item_id);
 }
 
+perl::array Perl_Inventory_GetAugmentIDsBySlotID(EQ::InventoryProfile* self, int16 slot_id)
+{
+	perl::array result;
+	auto augments = self->GetAugmentIDsBySlotID(slot_id);
+
+	for (int i = 0; i < augments.size(); ++i) {
+		result.push_back(augments[i]);
+	}
+
+	return result;
+}
+
 void perl_register_inventory()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -180,6 +192,7 @@ void perl_register_inventory()
 	package.add("FindFreeSlot", (int(*)(EQ::InventoryProfile*, bool, bool))&Perl_Inventory_FindFreeSlot);
 	package.add("FindFreeSlot", (int(*)(EQ::InventoryProfile*, bool, bool, uint8_t))&Perl_Inventory_FindFreeSlot);
 	package.add("FindFreeSlot", (int(*)(EQ::InventoryProfile*, bool, bool, uint8_t, bool))&Perl_Inventory_FindFreeSlot);
+	package.add("GetAugmentIDsBySlotID", &Perl_Inventory_GetAugmentIDsBySlotID);
 	package.add("GetBagIndex", &Perl_Inventory_GetBagIndex);
 	package.add("GetItem", &Perl_Inventory_GetItem);
 	package.add("GetMaterialFromSlot", &Perl_Inventory_GetMaterialFromSlot);


### PR DESCRIPTION
# Perl
- Add `$client->GetAugmentIDsBySlotID(slot_id)`.
- Add `$inventory->GetAugmentIDsBySlotID(slot_id)`.

# Lua
- Add `client:GetAugmentIDsBySlotID(slot_id)`.
- Add `inventory:GetAugmentIDsBySlotID(slot_id)`.

# Notes
- Allows operators to get a list of augments from a specific slot instead of having to build a plugin or something to do it.
- Fix issue with Lua tables starting at index `1` versus index `0`, so you lost the first value of the table due to this.