### PR TITLE
[Quest API] Add BuffCount() Overloads to Perl/Lua.

### DIFF
--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -323,11 +323,6 @@ uint16 Lua_Mob::FindBuffBySlot(int slot) {
 	return self->FindBuffBySlot(slot);
 }
 
-uint32 Lua_Mob::BuffCount() {
-	Lua_Safe_Call_Int();
-	return self->BuffCount();
-}
-
 bool Lua_Mob::FindType(int type) {
 	Lua_Safe_Call_Bool();
 	return self->FindType(type);
@@ -2757,6 +2752,21 @@ bool Lua_Mob::IsAttackAllowed(Lua_Mob target, bool is_spell_attack) {
 	return self->IsAttackAllowed(target, is_spell_attack);
 }
 
+uint32 Lua_Mob::BuffCount() {
+	Lua_Safe_Call_Int();
+	return self->BuffCount();
+}
+
+uint32 Lua_Mob::BuffCount(bool is_beneficial) {
+	Lua_Safe_Call_Int();
+	return self->BuffCount(is_beneficial);
+}
+
+uint32 Lua_Mob::BuffCount(bool is_beneficial, bool is_detrimental) {
+	Lua_Safe_Call_Int();
+	return self->BuffCount(is_beneficial, is_detrimental);
+}
+
 #ifdef BOTS
 void Lua_Mob::DamageAreaBots(int64 damage) {
 	Lua_Safe_Call_Void();
@@ -2848,7 +2858,9 @@ luabind::scope lua_register_mob() {
 	.def("BehindMob", (bool(Lua_Mob::*)(Lua_Mob,float))&Lua_Mob::BehindMob)
 	.def("BehindMob", (bool(Lua_Mob::*)(Lua_Mob,float,float))&Lua_Mob::BehindMob)
 	.def("BehindMob", (bool(Lua_Mob::*)(void))&Lua_Mob::BehindMob)
-	.def("BuffCount", &Lua_Mob::BuffCount)
+	.def("BuffCount", (uint32(Lua_Mob::*)(void))&Lua_Mob::BuffCount)
+	.def("BuffCount", (uint32(Lua_Mob::*)(bool))&Lua_Mob::BuffCount)
+	.def("BuffCount", (uint32(Lua_Mob::*)(bool,bool))&Lua_Mob::BuffCount)
 	.def("BuffFadeAll", (void(Lua_Mob::*)(void))&Lua_Mob::BuffFadeAll)
 	.def("BuffFadeByEffect", (void(Lua_Mob::*)(int))&Lua_Mob::BuffFadeByEffect)
 	.def("BuffFadeByEffect", (void(Lua_Mob::*)(int,int))&Lua_Mob::BuffFadeByEffect)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -94,6 +94,8 @@ public:
 	bool FindBuff(int spell_id);
 	uint16 FindBuffBySlot(int slot);
 	uint32 BuffCount();
+	uint32 BuffCount(bool is_beneficial);
+	uint32 BuffCount(bool is_beneficial, bool is_detrimental);
 	bool FindType(int type);
 	bool FindType(int type, bool offensive);
 	bool FindType(int type, bool offensive, int threshold);

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -443,7 +443,7 @@ public:
 	int32 RuneAbsorb(int64 damage, uint16 type);
 	bool FindBuff(uint16 spell_id);
 	uint16 FindBuffBySlot(int slot);
-	uint32 BuffCount();
+	uint32 BuffCount(bool is_beneficial = true, bool is_detrimental = true);
 	bool FindType(uint16 type, bool bOffensive = false, uint16 threshold = 100);
 	int16 GetBuffSlotFromType(uint16 type);
 	uint16 GetSpellIDFromSlot(uint8 slot);

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -338,11 +338,6 @@ int Perl_Mob_FindBuffBySlot(Mob* self, int slot) // @categories Spells and Disci
 	return self->FindBuffBySlot(slot);
 }
 
-int Perl_Mob_BuffCount(Mob* self) // @categories Script Utility, Spells and Disciplines
-{
-	return self->BuffCount();
-}
-
 bool Perl_Mob_FindType(Mob* self, uint16_t type) // @categories Script Utility
 {
 	return self->FindType(type);
@@ -2703,6 +2698,21 @@ bool Perl_Mob_IsAttackAllowed(Mob* self, Mob* target, bool is_spell_attack)
 	return self->IsAttackAllowed(target, is_spell_attack);
 }
 
+uint32 Perl_Mob_BuffCount(Mob* self) // @categories Script Utility, Spells and Disciplines
+{
+	return self->BuffCount();
+}
+
+uint32 Perl_Mob_BuffCount(Mob* self, bool is_beneficial) // @categories Script Utility, Spells and Disciplines
+{
+	return self->BuffCount(is_beneficial);
+}
+
+uint32 Perl_Mob_BuffCount(Mob* self, bool is_beneficial, bool is_detrimental) // @categories Script Utility, Spells and Disciplines
+{
+	return self->BuffCount(is_beneficial, is_detrimental);
+}
+
 #ifdef BOTS
 void Perl_Mob_DamageAreaBots(Mob* self, int64 damage) // @categories Hate and Aggro
 {
@@ -2801,7 +2811,9 @@ void perl_register_mob()
 	package.add("BehindMob", (bool(*)(Mob*, Mob*))&Perl_Mob_BehindMob);
 	package.add("BehindMob", (bool(*)(Mob*, Mob*, float))&Perl_Mob_BehindMob);
 	package.add("BehindMob", (bool(*)(Mob*, Mob*, float, float))&Perl_Mob_BehindMob);
-	package.add("BuffCount", &Perl_Mob_BuffCount);
+	package.add("BuffCount", (uint32(*)(Mob*))&Perl_Mob_BuffCount);
+	package.add("BuffCount", (uint32(*)(Mob*, bool))&Perl_Mob_BuffCount);
+	package.add("BuffCount", (uint32(*)(Mob*, bool, bool))&Perl_Mob_BuffCount);
 	package.add("BuffFadeAll", &Perl_Mob_BuffFadeAll);
 	package.add("BuffFadeByEffect", (void(*)(Mob*, int))&Perl_Mob_BuffFadeByEffect);
 	package.add("BuffFadeByEffect", (void(*)(Mob*, int, int))&Perl_Mob_BuffFadeByEffect);

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4369,11 +4369,18 @@ uint16 Mob::FindBuffBySlot(int slot) {
 	return 0;
 }
 
-uint32 Mob::BuffCount() {
+uint32 Mob::BuffCount(bool is_beneficial, bool is_detrimental) {
 	uint32 active_buff_count = 0;
 	int buff_count = GetMaxTotalSlots();
 	for (int buff_slot = 0; buff_slot < buff_count; buff_slot++) {
-		if (IsValidSpell(buffs[buff_slot].spellid)) {
+		const auto is_spell_beneficial = IsBeneficialSpell(buffs[buff_slot].spellid);
+		if (
+			IsValidSpell(buffs[buff_slot].spellid) &&
+			(
+				(is_beneficial && is_spell_beneficial) ||
+				(is_detrimental && !is_spell_beneficial)
+			)
+		) {
 			active_buff_count++;
 		}
 	}


### PR DESCRIPTION
# Perl
- Add `$mob->BuffCount(is_beneficial)`.
- Add `$mob->BuffCount(is_beneficial, is_detrimental)`.

# Lua
- Add `mob:BuffCount(is_beneficial)`.
- Add `mob:BuffCount(is_beneficial, is_detrimental)`.

 # Notes
- Allows operators to count only beneficial or detrimental buffs a mob has instead of always counting all buffs.