### PR TITLE
[Bot Commands] Toggle Enforce Spell Settings

### DIFF
--- a/zone/bot.h
+++ b/zone/bot.h
@@ -638,6 +638,7 @@ public:
 	void LoadBotSpellSettings();
 	bool UpdateBotSpellSetting(uint16 spell_id, BotSpellSetting* bs);
 	void SetBotEnforceSpellSetting(bool enforcespellsettings, bool save = false);
+	bool GetBotEnforceSpellSetting() const { return m_enforce_spell_settings; }
 
 	static void SpawnBotGroupByName(Client* c, std::string botgroup_name, uint32 leader_id);
 

--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -10782,7 +10782,7 @@ void bot_command_enforce_spell_list(Client* c, const Seperator *sep)
 		c->Message(
 			Chat::White,
 			fmt::format(
-				"Usage: {} [1/0 or blank to toggle]",
+				"Usage: {} [True/False or blank to toggle]",
 				sep->arg[0]
 			).c_str()
 		);
@@ -10795,19 +10795,8 @@ void bot_command_enforce_spell_list(Client* c, const Seperator *sep)
 		return;
 	}
 
-	bool enforce_state = false;
-	bool toggle_enforce = true;
-	if (sep->IsNumber(1)) {
-		toggle_enforce = false;
-		enforce_state = std::stoi(sep->arg[1]) ? true : false;
-	} 
-
-	if (toggle_enforce) {
-		my_bot->SetBotEnforceSpellSetting(!my_bot->GetBotEnforceSpellSetting(), true);
-	}
-	else {
-		my_bot->SetBotEnforceSpellSetting(enforce_state, true);
-	}
+	bool enforce_state = (sep->argnum > 0) ? Strings::ToBool(sep->arg[1]) : !my_bot->GetBotEnforceSpellSetting();
+	my_bot->SetBotEnforceSpellSetting(enforce_state, true);
 
 	c->Message(
 		Chat::White,

--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -10782,7 +10782,7 @@ void bot_command_enforce_spell_list(Client* c, const Seperator *sep)
 		c->Message(
 			Chat::White,
 			fmt::format(
-				"Usage: {} [True/False]",
+				"Usage: {} [1/0 or blank to toggle]",
 				sep->arg[0]
 			).c_str()
 		);
@@ -10795,20 +10795,26 @@ void bot_command_enforce_spell_list(Client* c, const Seperator *sep)
 		return;
 	}
 
-	bool toggle = (
-		sep->IsNumber(1) ?
-		(std::stoi(sep->arg[1]) ? true : false) :
-		atobool(sep->arg[1])
-	);
+	bool enforce_state = false;
+	bool toggle_enforce = true;
+	if (sep->IsNumber(1)) {
+		toggle_enforce = false;
+		enforce_state = std::stoi(sep->arg[1]) ? true : false;
+	} 
 
-	my_bot->SetBotEnforceSpellSetting(toggle, true);
+	if (toggle_enforce) {
+		my_bot->SetBotEnforceSpellSetting(!my_bot->GetBotEnforceSpellSetting(), true);
+	}
+	else {
+		my_bot->SetBotEnforceSpellSetting(enforce_state, true);
+	}
 
 	c->Message(
 		Chat::White,
 		fmt::format(
 			"{}'s Spell Settings List entries are now {}.",
 			my_bot->GetCleanName(),
-			toggle ? "enforced" : "optional"
+			my_bot->GetBotEnforceSpellSetting() ? "enforced" : "optional"
 		).c_str()
 	);
 }

--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -10782,7 +10782,7 @@ void bot_command_enforce_spell_list(Client* c, const Seperator *sep)
 		c->Message(
 			Chat::White,
 			fmt::format(
-				"Usage: {} [True/False or blank to toggle]",
+				"Usage: {} [True|False] (Blank to toggle]",
 				sep->arg[0]
 			).c_str()
 		);

--- a/zone/bot_structs.h
+++ b/zone/bot_structs.h
@@ -85,7 +85,7 @@ struct BotSpellSetting {
 	uint8  max_level;
 	int8   min_hp;
 	int8   max_hp;
-	bool   is_enabled;
+	bool   is_enabled = true;
 };
 
 struct BotSpells_Struct {


### PR DESCRIPTION
Let players easily toggle ^enforcespellsettings
Make default behavior for spells added to Spell Settings List to be enabled by default.