### PR TITLE
[Quest API] Add Charges/Augment/Attuned Support to Varlink.

### DIFF
--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -1525,15 +1525,24 @@ bool SharedDatabase::LoadFactionAssociation(const std::string &prefix)
 }
 
 // Create appropriate EQ::ItemInstance class
-EQ::ItemInstance* SharedDatabase::CreateItem(uint32 item_id, int16 charges, uint32 aug1, uint32 aug2, uint32 aug3, uint32 aug4, uint32 aug5, uint32 aug6, uint8 attuned)
-{
+EQ::ItemInstance* SharedDatabase::CreateItem(
+	uint32 item_id,
+	int16 charges,
+	uint32 aug1,
+	uint32 aug2,
+	uint32 aug3,
+	uint32 aug4,
+	uint32 aug5,
+	uint32 aug6,
+	bool attuned
+) {
 	EQ::ItemInstance* inst = nullptr;
 
 	const EQ::ItemData* item = GetItem(item_id);
 	if (item) {
 		inst = CreateBaseItem(item, charges);
 
-		if (inst == nullptr) {
+		if (!inst) {
 			LogError("Error: valid item data returned a null reference for EQ::ItemInstance creation in SharedDatabase::CreateItem()");
 			LogError("Item Data = ID: {}, Name: {}, Charges: {}", item->ID, item->Name, charges);
 			return nullptr;
@@ -1553,13 +1562,22 @@ EQ::ItemInstance* SharedDatabase::CreateItem(uint32 item_id, int16 charges, uint
 
 
 // Create appropriate EQ::ItemInstance class
-EQ::ItemInstance* SharedDatabase::CreateItem(const EQ::ItemData* item, int16 charges, uint32 aug1, uint32 aug2, uint32 aug3, uint32 aug4, uint32 aug5, uint32 aug6, uint8 attuned)
-{
+EQ::ItemInstance* SharedDatabase::CreateItem(
+	const EQ::ItemData* item,
+	int16 charges,
+	uint32 aug1,
+	uint32 aug2,
+	uint32 aug3,
+	uint32 aug4,
+	uint32 aug5,
+	uint32 aug6,
+	bool attuned
+) {
 	EQ::ItemInstance* inst = nullptr;
 	if (item) {
 		inst = CreateBaseItem(item, charges);
 
-		if (inst == nullptr) {
+		if (!inst) {
 			LogError("Error: valid item data returned a null reference for EQ::ItemInstance creation in SharedDatabase::CreateItem()");
 			LogError("Item Data = ID: {}, Name: {}, Charges: {}", item->ID, item->Name, charges);
 			return nullptr;

--- a/common/shareddb.h
+++ b/common/shareddb.h
@@ -126,7 +126,7 @@ public:
 		uint32 aug4 = 0,
 		uint32 aug5 = 0,
 		uint32 aug6 = 0,
-		uint8 attuned = 0
+		bool attuned = 0
 	);
 	EQ::ItemInstance *CreateItem(
 		const EQ::ItemData *item,
@@ -137,7 +137,7 @@ public:
 		uint32 aug4 = 0,
 		uint32 aug5 = 0,
 		uint32 aug6 = 0,
-		uint8 attuned = 0
+		bool attuned = 0
 	);
 	EQ::ItemInstance *CreateBaseItem(const EQ::ItemData *item, int16 charges = 0);
 

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -1443,12 +1443,6 @@ uint32_t Perl__MerchantCountItem(uint32 npc_id, uint32 item_id)
 	return quest_manager.MerchantCountItem(npc_id, item_id);
 }
 
-std::string Perl__varlink(int item_id)
-{
-	char text[250] = { 0 };
-	return quest_manager.varlink(text, item_id);
-}
-
 int Perl__CreateInstance(const char* zone_name, int16 version, int32 duration)
 {
 	return quest_manager.CreateInstance(zone_name, version, duration);
@@ -3936,6 +3930,51 @@ void Perl__set_proximity_range(float x_range, float y_range, float z_range, bool
 	quest_manager.set_proximity_range(x_range, y_range, z_range, enable_say);
 }
 
+std::string Perl__varlink(uint32 item_id)
+{
+	return quest_manager.varlink(item_id);
+}
+
+std::string Perl__varlink(uint32 item_id, int16 charges)
+{
+	return quest_manager.varlink(item_id, charges);
+}
+
+std::string Perl__varlink(uint32 item_id, int16 charges, uint32 aug1)
+{
+	return quest_manager.varlink(item_id, charges, aug1);
+}
+
+std::string Perl__varlink(uint32 item_id, int16 charges, uint32 aug1, uint32 aug2)
+{
+	return quest_manager.varlink(item_id, charges, aug1, aug2);
+}
+
+std::string Perl__varlink(uint32 item_id, int16 charges, uint32 aug1, uint32 aug2, uint32 aug3)
+{
+	return quest_manager.varlink(item_id, charges, aug1, aug2, aug3);
+}
+
+std::string Perl__varlink(uint32 item_id, int16 charges, uint32 aug1, uint32 aug2, uint32 aug3, uint32 aug4)
+{
+	return quest_manager.varlink(item_id, charges, aug1, aug2, aug3, aug4);
+}
+
+std::string Perl__varlink(uint32 item_id, int16 charges, uint32 aug1, uint32 aug2, uint32 aug3, uint32 aug4, uint32 aug5)
+{
+	return quest_manager.varlink(item_id, charges, aug1, aug2, aug3, aug4, aug5);
+}
+
+std::string Perl__varlink(uint32 item_id, int16 charges, uint32 aug1, uint32 aug2, uint32 aug3, uint32 aug4, uint32 aug5, uint32 aug6)
+{
+	return quest_manager.varlink(item_id, charges, aug1, aug2, aug3, aug4, aug5, aug6);
+}
+
+std::string Perl__varlink(uint32 item_id, int16 charges, uint32 aug1, uint32 aug2, uint32 aug3, uint32 aug4, uint32 aug5, uint32 aug6, bool attuned)
+{
+	return quest_manager.varlink(item_id, charges, aug1, aug2, aug3, aug4, aug5, aug6, attuned);
+}
+
 void perl_register_quest()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -4540,7 +4579,15 @@ void perl_register_quest()
 	package.add("updatetaskactivity", (void(*)(int, int, int))&Perl__updatetaskactivity);
 	package.add("updatetaskactivity", (void(*)(int, int, int, bool))&Perl__updatetaskactivity);
 	package.add("UpdateZoneHeader", &Perl__UpdateZoneHeader);
-	package.add("varlink", &Perl__varlink);
+	package.add("varlink", (std::string(*)(uint32))&Perl__varlink);
+	package.add("varlink", (std::string(*)(uint32, int16))&Perl__varlink);
+	package.add("varlink", (std::string(*)(uint32, int16, uint32))&Perl__varlink);
+	package.add("varlink", (std::string(*)(uint32, int16, uint32, uint32))&Perl__varlink);
+	package.add("varlink", (std::string(*)(uint32, int16, uint32, uint32, uint32))&Perl__varlink);
+	package.add("varlink", (std::string(*)(uint32, int16, uint32, uint32, uint32, uint32))&Perl__varlink);
+	package.add("varlink", (std::string(*)(uint32, int16, uint32, uint32, uint32, uint32, uint32))&Perl__varlink);
+	package.add("varlink", (std::string(*)(uint32, int16, uint32, uint32, uint32, uint32, uint32, uint32))&Perl__varlink);
+	package.add("varlink", (std::string(*)(uint32, int16, uint32, uint32, uint32, uint32, uint32, uint32, bool))&Perl__varlink);
 	package.add("voicetell", &Perl__voicetell);
 	package.add("we", &Perl__we);
 	package.add("wearchange", (void(*)(uint8, uint16))&Perl__wearchange);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -881,12 +881,6 @@ int lua_merchant_count_item(uint32 npc_id, uint32 item_id) {
 	return quest_manager.MerchantCountItem(npc_id, item_id);
 }
 
-std::string lua_item_link(int item_id) {
-	char text[250] = { 0 };
-
-	return quest_manager.varlink(text, item_id);
-}
-
 std::string lua_get_item_name(uint32 item_id) {
 	return quest_manager.getitemname(item_id);
 }
@@ -3656,6 +3650,42 @@ void lua_do_anim(int animation_id, int animation_speed, bool ackreq, int filter)
 	quest_manager.doanim(animation_id, animation_speed, ackreq, static_cast<eqFilterType>(filter));
 }
 
+std::string lua_item_link(uint32 item_id) {
+	return quest_manager.varlink(item_id);
+}
+
+std::string lua_item_link(uint32 item_id, int16 charges) {
+	return quest_manager.varlink(item_id, charges);
+}
+
+std::string lua_item_link(uint32 item_id, int16 charges, uint32 aug1) {
+	return quest_manager.varlink(item_id, charges, aug1);
+}
+
+std::string lua_item_link(uint32 item_id, int16 charges, uint32 aug1, uint32 aug2) {
+	return quest_manager.varlink(item_id, charges, aug1, aug2);
+}
+
+std::string lua_item_link(uint32 item_id, int16 charges, uint32 aug1, uint32 aug2, uint32 aug3) {
+	return quest_manager.varlink(item_id, charges, aug1, aug2, aug3);
+}
+
+std::string lua_item_link(uint32 item_id, int16 charges, uint32 aug1, uint32 aug2, uint32 aug3, uint32 aug4) {
+	return quest_manager.varlink(item_id, charges, aug1, aug2, aug3, aug4);
+}
+
+std::string lua_item_link(uint32 item_id, int16 charges, uint32 aug1, uint32 aug2, uint32 aug3, uint32 aug4, uint32 aug5) {
+	return quest_manager.varlink(item_id, charges, aug1, aug2, aug3, aug4, aug5);
+}
+
+std::string lua_item_link(uint32 item_id, int16 charges, uint32 aug1, uint32 aug2, uint32 aug3, uint32 aug4, uint32 aug5, uint32 aug6) {
+	return quest_manager.varlink(item_id, charges, aug1, aug2, aug3, aug4, aug5, aug6);
+}
+
+std::string lua_item_link(uint32 item_id, int16 charges, uint32 aug1, uint32 aug2, uint32 aug3, uint32 aug4, uint32 aug5, uint32 aug6, bool attuned) {
+	return quest_manager.varlink(item_id, charges, aug1, aug2, aug3, aug4, aug5, aug6, attuned);
+}
+
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
 	cur = table[#name]; \
 	if(luabind::type(cur) != LUA_TNIL) { \
@@ -3992,7 +4022,15 @@ luabind::scope lua_register_general() {
 		luabind::def("merchant_set_item", (void(*)(uint32,uint32))&lua_merchant_set_item),
 		luabind::def("merchant_set_item", (void(*)(uint32,uint32,uint32))&lua_merchant_set_item),
 		luabind::def("merchant_count_item", &lua_merchant_count_item),
-		luabind::def("item_link", &lua_item_link),
+		luabind::def("item_link", (std::string(*)(uint32))&lua_item_link),
+		luabind::def("item_link", (std::string(*)(uint32,int16))&lua_item_link),
+		luabind::def("item_link", (std::string(*)(uint32,int16,uint32))&lua_item_link),
+		luabind::def("item_link", (std::string(*)(uint32,int16,uint32,uint32))&lua_item_link),
+		luabind::def("item_link", (std::string(*)(uint32,int16,uint32,uint32,uint32))&lua_item_link),
+		luabind::def("item_link", (std::string(*)(uint32,int16,uint32,uint32,uint32,uint32))&lua_item_link),
+		luabind::def("item_link", (std::string(*)(uint32,int16,uint32,uint32,uint32,uint32,uint32))&lua_item_link),
+		luabind::def("item_link", (std::string(*)(uint32,int16,uint32,uint32,uint32,uint32,uint32,uint32))&lua_item_link),
+		luabind::def("item_link", (std::string(*)(uint32,int16,uint32,uint32,uint32,uint32,uint32,uint32,bool))&lua_item_link),
 		luabind::def("get_item_name", (std::string(*)(uint32))&lua_get_item_name),
 		luabind::def("say_link", (std::string(*)(const char*,bool,const char*))&lua_say_link),
 		luabind::def("say_link", (std::string(*)(const char*,bool))&lua_say_link),

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -2904,19 +2904,38 @@ uint32 QuestManager::MerchantCountItem(uint32 NPCid, uint32 itemid) {
 }
 
 // Item Link for use in Variables - "my $example_link = quest::varlink(item_id);"
-const char* QuestManager::varlink(char* perltext, int item_id) {
+std::string QuestManager::varlink(
+	uint32 item_id,
+	int16 charges,
+	uint32 aug1,
+	uint32 aug2,
+	uint32 aug3,
+	uint32 aug4,
+	uint32 aug5,
+	uint32 aug6,
+	bool attuned
+) {
 	QuestManagerCurrentQuestVars();
-	const EQ::ItemData* item = database.GetItem(item_id);
-	if (!item)
+	const auto *item = database.CreateItem(
+		item_id,
+		charges,
+		aug1,
+		aug2,
+		aug3,
+		aug4,
+		aug5,
+		aug6,
+		attuned
+	);
+	if (!item) {
 		return "INVALID ITEM ID IN VARLINK";
+	}
 
 	EQ::SayLinkEngine linker;
-	linker.SetLinkType(EQ::saylink::SayLinkItemData);
-	linker.SetItemData(item);
+	linker.SetLinkType(EQ::saylink::SayLinkItemInst);
+	linker.SetItemInst(item);
 
-	strcpy(perltext, linker.GenerateLink().c_str());
-
-	return perltext;
+	return linker.GenerateLink();
 }
 
 std::string QuestManager::getitemname(uint32 item_id) {

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -281,7 +281,7 @@ public:
 	void MovePCInstance(int zone_id, int instance_id, const glm::vec4& position);
 	void FlagInstanceByGroupLeader(uint32 zone, int16 version);
 	void FlagInstanceByRaidLeader(uint32 zone, int16 version);
-	const char* varlink(char* perltext, int item_id);
+	std::string varlink(uint32 item_id, int16 charges = 0, uint32 aug1 = 0, uint32 aug2 = 0, uint32 aug3 = 0, uint32 aug4 = 0, uint32 aug5 = 0, uint32 aug6 = 0, bool attuned = false);
 	std::string saylink(char *saylink_text, bool silent, const char *link_name);
 	std::string getcharnamebyid(uint32 char_id);
 	uint32 getcharidbyname(const char* name);


### PR DESCRIPTION
# Perl
- Add `quest::varlink(item_id, charges)`.
- Add `quest::varlink(item_id, charges, aug1)`.
- Add `quest::varlink(item_id, charges, aug1, aug2)`.
- Add `quest::varlink(item_id, charges, aug1, aug2, aug3)`.
- Add `quest::varlink(item_id, charges, aug1, aug2, aug3, aug4)`.
- Add `quest::varlink(item_id, charges, aug1, aug2, aug3, aug4, aug5)`.
- Add `quest::varlink(item_id, charges, aug1, aug2, aug3, aug4, aug5, aug6)`.
- Add `quest::varlink(item_id, charges, aug1, aug2, aug3, aug4, aug5, aug6, attuned)`.

# Lua
- Add `eq.item_link(item_id, charges)`.
- Add `eq.item_link(item_id, charges, aug1)`.
- Add `eq.item_link(item_id, charges, aug1, aug2)`.
- Add `eq.item_link(item_id, charges, aug1, aug2, aug3)`.
- Add `eq.item_link(item_id, charges, aug1, aug2, aug3, aug4)`.
- Add `eq.item_link(item_id, charges, aug1, aug2, aug3, aug4, aug5)`.
- Add `eq.item_link(item_id, charges, aug1, aug2, aug3, aug4, aug5, aug6)`.
- Add `eq.item_link(item_id, charges, aug1, aug2, aug3, aug4, aug5, aug6, attuned)`.

# Notes
- Allows operators to link items with specific charges, augments, and attuned flag.
- Gives much more versatility to the varlink/item_link methods.