### PR TITLE
[Quest API] Add DoAugmentSlotsMatch() to Perl/Lua.

### DIFF
--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -3936,6 +3936,11 @@ void Perl__set_proximity_range(float x_range, float y_range, float z_range, bool
 	quest_manager.set_proximity_range(x_range, y_range, z_range, enable_say);
 }
 
+bool Perl__do_augment_slots_match(uint32 item_one, uint32 item_two)
+{
+	return quest_manager.DoAugmentSlotsMatch(item_one, item_two);
+}
+
 void perl_register_quest()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -4282,6 +4287,7 @@ void perl_register_quest()
 	package.add("doanim", (void(*)(int, int))&Perl__doanim);
 	package.add("doanim", (void(*)(int, int, bool))&Perl__doanim);
 	package.add("doanim", (void(*)(int, int, bool, int))&Perl__doanim);
+	package.add("do_augment_slots_match", &Perl__do_augment_slots_match);
 	package.add("echo", &Perl__echo);
 	package.add("emote", &Perl__emote);
 	package.add("enable_proximity_say", &Perl__enable_proximity_say);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -3656,6 +3656,11 @@ void lua_do_anim(int animation_id, int animation_speed, bool ackreq, int filter)
 	quest_manager.doanim(animation_id, animation_speed, ackreq, static_cast<eqFilterType>(filter));
 }
 
+bool lua_do_augment_slots_match(uint32 item_one, uint32 item_two)
+{
+	return quest_manager.DoAugmentSlotsMatch(item_one, item_two);
+}
+
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
 	cur = table[#name]; \
 	if(luabind::type(cur) != LUA_TNIL) { \
@@ -4163,6 +4168,7 @@ luabind::scope lua_register_general() {
 		luabind::def("do_anim", (void(*)(int,int))&lua_do_anim),
 		luabind::def("do_anim", (void(*)(int,int,bool))&lua_do_anim),
 		luabind::def("do_anim", (void(*)(int,int,bool,int))&lua_do_anim),
+		luabind::def("do_augment_slots_match", &lua_do_augment_slots_match),
 		/*
 			Cross Zone
 		*/

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -3927,3 +3927,23 @@ void QuestManager::marquee(uint32 type, uint32 priority, uint32 fade_in, uint32 
 
 	initiator->SendMarqueeMessage(type, priority, fade_in, fade_out, duration, message);
 }
+
+bool QuestManager::DoAugmentSlotsMatch(uint32 item_one, uint32 item_two) {
+	const auto* inst_one = database.GetItem(item_one);
+	if (!inst_one) {
+		return false;
+	}
+
+	const auto* inst_two = database.GetItem(item_two);
+	if (!inst_two) {
+		return false;
+	}
+
+	for (auto i = EQ::invaug::SOCKET_BEGIN; i <= EQ::invaug::SOCKET_END; i++) {
+		if (inst_one->AugSlotType[i] != inst_two->AugSlotType[i]) {
+			return false;
+		}
+	}
+
+	return true;
+}

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -345,6 +345,7 @@ public:
 	int GetRecipeMadeCount(uint32 recipe_id);
 	std::string GetRecipeName(uint32 recipe_id);
 	bool HasRecipeLearned(uint32 recipe_id);
+	bool DoAugmentSlotsMatch(uint32 item_one, uint32 item_two);
 
 #ifdef BOTS
 	Bot *GetBot() const;


### PR DESCRIPTION
# Perl
- Add `quest::do_augment_slots_match(item_one, item_two)`.

# Lua
- Add `eq.do_augment_slots_match(item_one, item_two)`.

# Notes
- Allows operators to see if augments slots across two items match for something like moving augments from one item to another.