### PR TITLE
[Quest API] Add DoesAugmentFit() to Perl/Lua.

### DIFF
--- a/common/item_instance.cpp
+++ b/common/item_instance.cpp
@@ -332,19 +332,30 @@ bool EQ::ItemInstance::AvailableWearSlot(uint32 aug_wear_slots) const {
 	return (index <= EQ::invslot::EQUIPMENT_END);
 }
 
-int8 EQ::ItemInstance::AvailableAugmentSlot(int32 augtype) const
+int8 EQ::ItemInstance::AvailableAugmentSlot(int32 augment_type) const
 {
-	if (!m_item || !m_item->IsClassCommon())
+	if (!m_item || !m_item->IsClassCommon()) {
 		return INVALID_INDEX;
-
-	int index = invaug::SOCKET_BEGIN;
-	for (; index <= invaug::SOCKET_END; ++index) {
-		if (GetItem(index)) { continue; }
-		if (augtype == -1 || (m_item->AugSlotType[index] && ((1 << (m_item->AugSlotType[index] - 1)) & augtype)))
-			break;
 	}
 
-	return (index <= invaug::SOCKET_END) ? index : INVALID_INDEX;
+	auto i = invaug::SOCKET_BEGIN;
+	for (; i <= invaug::SOCKET_END; ++i) {
+		if (GetItem(i)) {
+			continue;
+		}
+
+		if (
+			augment_type == -1 ||
+			(
+				m_item->AugSlotType[i] &&
+				((1 << (m_item->AugSlotType[i] - 1)) & augment_type)
+			)
+		) {
+			break;
+		}
+	}
+
+	return (i <= invaug::SOCKET_END) ? i : INVALID_INDEX;
 }
 
 bool EQ::ItemInstance::IsAugmentSlotAvailable(int32 augtype, uint8 slot) const

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -3980,6 +3980,11 @@ bool Perl__do_augment_slots_match(uint32 item_one, uint32 item_two)
 	return quest_manager.DoAugmentSlotsMatch(item_one, item_two);
 }
 
+int8 Perl__does_augment_fit(EQ::ItemInstance* inst, uint32 augment_id)
+{
+	return quest_manager.DoesAugmentFit(inst, augment_id);
+}
+
 void perl_register_quest()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -4327,6 +4332,7 @@ void perl_register_quest()
 	package.add("doanim", (void(*)(int, int, bool))&Perl__doanim);
 	package.add("doanim", (void(*)(int, int, bool, int))&Perl__doanim);
 	package.add("do_augment_slots_match", &Perl__do_augment_slots_match);
+	package.add("does_augment_fit", &Perl__does_augment_fit);
 	package.add("echo", &Perl__echo);
 	package.add("emote", &Perl__emote);
 	package.add("enable_proximity_say", &Perl__enable_proximity_say);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -3691,6 +3691,11 @@ bool lua_do_augment_slots_match(uint32 item_one, uint32 item_two)
 	return quest_manager.DoAugmentSlotsMatch(item_one, item_two);
 }
 
+int8 lua_does_augment_fit(EQ::ItemInstance* inst, uint32 augment_id)
+{
+	return quest_manager.DoesAugmentFit(inst, augment_id);
+}
+
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
 	cur = table[#name]; \
 	if(luabind::type(cur) != LUA_TNIL) { \
@@ -4207,6 +4212,7 @@ luabind::scope lua_register_general() {
 		luabind::def("do_anim", (void(*)(int,int,bool))&lua_do_anim),
 		luabind::def("do_anim", (void(*)(int,int,bool,int))&lua_do_anim),
 		luabind::def("do_augment_slots_match", &lua_do_augment_slots_match),
+		luabind::def("does_augment_fit", &lua_does_augment_fit),
 		/*
 			Cross Zone
 		*/

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -3947,7 +3947,8 @@ void QuestManager::marquee(uint32 type, uint32 priority, uint32 fade_in, uint32 
 	initiator->SendMarqueeMessage(type, priority, fade_in, fade_out, duration, message);
 }
 
-bool QuestManager::DoAugmentSlotsMatch(uint32 item_one, uint32 item_two) {
+bool QuestManager::DoAugmentSlotsMatch(uint32 item_one, uint32 item_two)
+{
 	const auto* inst_one = database.GetItem(item_one);
 	if (!inst_one) {
 		return false;
@@ -3965,4 +3966,18 @@ bool QuestManager::DoAugmentSlotsMatch(uint32 item_one, uint32 item_two) {
 	}
 
 	return true;
+}
+
+int8 QuestManager::DoesAugmentFit(EQ::ItemInstance* inst, uint32 augment_id)
+{
+	if (!inst) {
+		return INVALID_INDEX;
+	}
+
+	const auto* aug_inst = database.GetItem(augment_id);
+	if (!aug_inst) {
+		return INVALID_INDEX;
+	}
+
+	return inst->AvailableAugmentSlot(aug_inst->AugType);
 }

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -346,6 +346,7 @@ public:
 	std::string GetRecipeName(uint32 recipe_id);
 	bool HasRecipeLearned(uint32 recipe_id);
 	bool DoAugmentSlotsMatch(uint32 item_one, uint32 item_two);
+	int8 DoesAugmentFit(EQ::ItemInstance* inst, uint32 augment_id);
 
 #ifdef BOTS
 	Bot *GetBot() const;


### PR DESCRIPTION
# Perl
- Add `quest::does_augment_fit(item, augment_id)`.

# Lua
- Add `eq.does_augment_fit(item, augment_id)`.

# Notes
- Returns the augment slot index where the augment fits within the item instance provided, returns `-1` if it doesn't fit or has no open slot to fit in.