### PR TITLE
[Commands] Add #setanon Command

### DIFF
--- a/common/eq_constants.h
+++ b/common/eq_constants.h
@@ -1016,7 +1016,7 @@ enum FVNoDropFlagRule
 	AdminOnly = 2
 };
 
-enum Anonymity
+enum Anonymity : uint8
 {
 	NotAnonymous,
 	Anonymous,

--- a/common/eq_constants.h
+++ b/common/eq_constants.h
@@ -1016,4 +1016,11 @@ enum FVNoDropFlagRule
 	AdminOnly = 2
 };
 
+enum Anonymity
+{
+	NotAnonymous,
+	Anonymous,
+	Roleplaying
+};
+
 #endif /*COMMON_EQ_CONSTANTS_H*/

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -287,6 +287,7 @@ int command_init(void)
 		command_add("setadventurepoints", "[Theme] [Points] - Set your or your player target's available Adventure Points by Theme", AccountStatus::GMLeadAdmin, command_set_adventure_points) ||
 		command_add("setaltcurrency", "[Currency ID] [Amount] - Set your or your target's available Alternate Currency by Currency ID", AccountStatus::GMAdmin, command_setaltcurrency) ||
 		command_add("setanim", "[Animation ID (IDs are 0 to 4)] - Set target's appearance to Animation ID", AccountStatus::GMMgmt, command_setanim) ||
+		command_add("setanon", "[Anonymous Flag] - Set you or your target's Anonymous Flag (0 = Not Anonymous, 1 = Anonymous, 2 = Roleplaying)", AccountStatus::QuestTroupe, command_setanon) ||
 		command_add("setcrystals", "[value] - Set your or your player target's available radiant or ebon crystals", AccountStatus::GMAdmin, command_setcrystals) ||
 		command_add("setendurance", "[Endurance] - Set your or your target's Endurance", AccountStatus::GMAdmin, command_setendurance) ||
 		command_add("setfaction", "[Faction ID] - Sets targeted NPC's faction in the database", AccountStatus::GMAreas, command_setfaction) ||
@@ -1119,6 +1120,7 @@ void command_bot(Client *c, const Seperator *sep)
 #include "gm_commands/setaaxp.cpp"
 #include "gm_commands/setaltcurrency.cpp"
 #include "gm_commands/setanim.cpp"
+#include "gm_commands/setanon.cpp"
 #include "gm_commands/setcrystals.cpp"
 #include "gm_commands/setendurance.cpp"
 #include "gm_commands/setfaction.cpp"

--- a/zone/command.h
+++ b/zone/command.h
@@ -232,6 +232,7 @@ void command_setaapts(Client *c, const Seperator *sep);
 void command_setaaxp(Client *c, const Seperator *sep);
 void command_setaltcurrency(Client *c, const Seperator *sep);
 void command_setanim(Client *c, const Seperator *sep);
+void command_setanon(Client *c, const Seperator *sep);
 void command_setcrystals(Client *c, const Seperator *sep);
 void command_setendurance(Client *c, const Seperator *sep);
 void command_setfaction(Client *c, const Seperator *sep);

--- a/zone/gm_commands/setanon.cpp
+++ b/zone/gm_commands/setanon.cpp
@@ -1,0 +1,42 @@
+#include "../client.h"
+
+void command_setanon(Client *c, const Seperator *sep)
+{
+	auto arguments = sep->argnum;
+	if (!arguments || !sep->IsNumber(1)) {
+		c->Message(Chat::White, "Usage: #setanon [Anonymous Flag]");
+		c->Message(Chat::White, "Note: 0 = Not Anonymous, 1 = Anonymous, 2 = Roleplaying");
+		return;
+	}
+
+	const uint8 anon_flag = static_cast<uint8>(std::stoul(sep->arg[1]));
+	auto t = c;
+	if (c->GetTarget() && c->GetTarget()->IsClient() && c->GetGM()) {
+		t = c->GetTarget()->CastToClient();
+	}
+
+	std::string anon_setting;
+	if (anon_flag == Anonymity::NotAnonymous) {
+		anon_setting = "no longer Anonymous or Roleplaying";
+	} else if (anon_flag == Anonymity::Anonymous) {
+		anon_setting = "now Anonymous";
+	} else if (anon_flag == Anonymity::Roleplaying) {
+		anon_setting = "now Roleplaying";
+	} else {
+		c->Message(Chat::White, "Usage: #setanon [Anonymous Flag]");
+		c->Message(Chat::White, "Note: 0 = Not Anonymous, 1 = Anonymous, 2 = Roleplaying");
+		return;
+	}
+
+	c->SetAnon(anon_flag);
+
+	c->Message(
+		Chat::White,
+		fmt::format(
+			"{} {} {}.",
+			c->GetTargetDescription(t, TargetDescriptionType::UCYou),
+			c == t ? "are" : "is",
+			anon_setting
+		).c_str()
+	);
+}

--- a/zone/gm_commands/setanon.cpp
+++ b/zone/gm_commands/setanon.cpp
@@ -59,8 +59,6 @@ void command_setanon(Client *c, const Seperator *sep)
 			return;
 		}
 
-		const std::string character_name = e.name;
-
 		e.anon = anon_flag;
 
 		auto updated = CharacterDataRepository::UpdateOne(content_db, e);
@@ -70,7 +68,7 @@ void command_setanon(Client *c, const Seperator *sep)
 				Chat::White,
 				fmt::format(
 					"Failed to change Anonymous Flag for {} ({}).",
-					character_name,
+					e.name,
 					character_id
 				).c_str()
 			);
@@ -95,7 +93,7 @@ void command_setanon(Client *c, const Seperator *sep)
 			Chat::White,
 			fmt::format(
 				"{} ({}) is {}.",
-				character_name,
+				e.name,
 				character_id,
 				anon_setting
 			).c_str()

--- a/zone/gm_commands/setanon.cpp
+++ b/zone/gm_commands/setanon.cpp
@@ -1,42 +1,104 @@
 #include "../client.h"
+#include "../../common/repositories/character_data_repository.h"
 
 void command_setanon(Client *c, const Seperator *sep)
 {
 	auto arguments = sep->argnum;
-	if (!arguments || !sep->IsNumber(1)) {
+	if (!arguments || !sep->IsNumber(1) || arguments > 2) {
 		c->Message(Chat::White, "Usage: #setanon [Anonymous Flag]");
+		c->Message(Chat::White, "Usage: #setanon [Character ID] [Anonymous Flag]");
 		c->Message(Chat::White, "Note: 0 = Not Anonymous, 1 = Anonymous, 2 = Roleplaying");
 		return;
 	}
 
-	const uint8 anon_flag = static_cast<uint8>(std::stoul(sep->arg[1]));
-	auto t = c;
-	if (c->GetTarget() && c->GetTarget()->IsClient() && c->GetGM()) {
-		t = c->GetTarget()->CastToClient();
+	if (arguments == 1) {
+		const uint8 anon_flag = static_cast<uint8>(std::stoul(sep->arg[1]));
+		auto t = c;
+		if (c->GetTarget() && c->GetTarget()->IsClient() && c->GetGM()) {
+			t = c->GetTarget()->CastToClient();
+		}
+
+		std::string anon_setting;
+		if (anon_flag == Anonymity::NotAnonymous) {
+			anon_setting = "no longer Anonymous or Roleplaying";
+		} else if (anon_flag == Anonymity::Anonymous) {
+			anon_setting = "now Anonymous";
+		} else if (anon_flag == Anonymity::Roleplaying) {
+			anon_setting = "now Roleplaying";
+		} else {
+			c->Message(Chat::White, "Usage: #setanon [Anonymous Flag]");
+			c->Message(Chat::White, "Usage: #setanon [Character ID] [Anonymous Flag]");
+			c->Message(Chat::White, "Note: 0 = Not Anonymous, 1 = Anonymous, 2 = Roleplaying");
+			return;
+		}
+
+		c->SetAnon(anon_flag);
+
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"{} {} {}.",
+				c->GetTargetDescription(t, TargetDescriptionType::UCYou),
+				c == t ? "are" : "is",
+				anon_setting
+			).c_str()
+		);
+	} else if (arguments == 2) {
+		const auto character_id = std::stoi(sep->arg[1]);
+		const uint8 anon_flag = static_cast<uint8>(std::stoul(sep->arg[2]));
+
+		auto e = CharacterDataRepository::FindOne(content_db, character_id);
+		if (!e.id) {
+			c->Message(
+				Chat::White,
+				fmt::format(
+					"Character ID {} does not exist or is invalid.",
+					character_id
+				).c_str()
+			);
+			return;
+		}
+
+		const std::string character_name = e.name;
+
+		e.anon = anon_flag;
+
+		auto updated = CharacterDataRepository::UpdateOne(content_db, e);
+
+		if (!updated) {
+			c->Message(
+				Chat::White,
+				fmt::format(
+					"Failed to change Anonymous Flag for {} ({}).",
+					character_name,
+					character_id
+				).c_str()
+			);
+			return;
+		}
+
+		std::string anon_setting;
+		if (anon_flag == Anonymity::NotAnonymous) {
+			anon_setting = "no longer Anonymous or Roleplaying";
+		} else if (anon_flag == Anonymity::Anonymous) {
+			anon_setting = "now Anonymous";
+		} else if (anon_flag == Anonymity::Roleplaying) {
+			anon_setting = "now Roleplaying";
+		} else {
+			c->Message(Chat::White, "Usage: #setanon [Anonymous Flag]");
+			c->Message(Chat::White, "Usage: #setanon [Character ID] [Anonymous Flag]");
+			c->Message(Chat::White, "Note: 0 = Not Anonymous, 1 = Anonymous, 2 = Roleplaying");
+			return;
+		}
+
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"{} ({}) is {}.",
+				character_name,
+				character_id,
+				anon_setting
+			).c_str()
+		);
 	}
-
-	std::string anon_setting;
-	if (anon_flag == Anonymity::NotAnonymous) {
-		anon_setting = "no longer Anonymous or Roleplaying";
-	} else if (anon_flag == Anonymity::Anonymous) {
-		anon_setting = "now Anonymous";
-	} else if (anon_flag == Anonymity::Roleplaying) {
-		anon_setting = "now Roleplaying";
-	} else {
-		c->Message(Chat::White, "Usage: #setanon [Anonymous Flag]");
-		c->Message(Chat::White, "Note: 0 = Not Anonymous, 1 = Anonymous, 2 = Roleplaying");
-		return;
-	}
-
-	c->SetAnon(anon_flag);
-
-	c->Message(
-		Chat::White,
-		fmt::format(
-			"{} {} {}.",
-			c->GetTargetDescription(t, TargetDescriptionType::UCYou),
-			c == t ? "are" : "is",
-			anon_setting
-		).c_str()
-	);
 }


### PR DESCRIPTION
# Commands
- Adds `#setanon [Anonymous Flag]`.
- Adds `#setanon [Character ID] [Anonymous Flag]`.

# Notes
- Allows operators to turn on/off a player's anonymous flag so they can view their Magelo.
- Flags are 0 = Not Anonymous, 1 = Anonymous, 2 = Roleplaying