### PR TITLE
[Bug Fix] Fix #zone 0.

### DIFF
--- a/zone/gm_commands/zone.cpp
+++ b/zone/gm_commands/zone.cpp
@@ -18,7 +18,7 @@ void command_zone(Client *c, const Seperator *sep)
 		zone_id = std::stoi(zone_input);
 
 		// validate
-		if (!GetZone(zone_id)) {
+		if (zone_id != 0 && !GetZone(zone_id)) {
 			c->Message(Chat::White, fmt::format("Could not find zone by id [{}]", zone_id).c_str());
 			return;
 		}


### PR DESCRIPTION
# Notes
- `#zone 0` was used to send you to safe coordinates, this has been broken for a while now.