### PR TITLE
[Commands] Cleanup #guild Command

### DIFF
--- a/zone/command.h
+++ b/zone/command.h
@@ -33,6 +33,7 @@ std::map<std::string, std::string> GetModifyNPCStatMap();
 std::string GetModifyNPCStatDescription(std::string stat);
 void SendNPCEditSubCommands(Client *c);
 void SendRuleSubCommands(Client *c);
+void SendGuildSubCommands(Client *c);
 
 // Commands
 void command_acceptrules(Client *c, const Seperator *sep);

--- a/zone/guild_mgr.h
+++ b/zone/guild_mgr.h
@@ -80,7 +80,8 @@ public:
 	//called by worldserver when it receives a message from world.
 	void ProcessWorldPacket(ServerPacket *pack);
 
-	void ListGuilds(Client *c) const;
+	void ListGuilds(Client *c, std::string search_criteria = std::string()) const;
+	void ListGuilds(Client *c, uint32 guild_id = 0) const;
 	void DescribeGuild(Client *c, uint32 guild_id) const;
 
 


### PR DESCRIPTION
# Commands
- Adds `#guild search [Search Criteria]` sub command.

# Notes
- Allows operators to search for a guild instead of listing all guilds at once.
- Adds a method for sending guild sub commands to make code drier.