### PR TITLE
[Bug Fix] Fix Splurt Formula Causing Damage

### DIFF
--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -3565,7 +3565,7 @@ snare has both of them negative, yet their range should work the same:
 			if(ticdif < 0)
 				ticdif = 0;
 
-			result = updownsign * (ubase - (12 * ticdif));
+			result = ubase - (12 * ticdif);
 			degenerating_effects = true;
 			break;
 		}


### PR DESCRIPTION
# Notes
- According to https://github.com/EQEmu/Server/issues/2500 the recourse causes damage instead of healing, this fixes that.