### PR TITLE
[Quest API] Cleanup Proximity Events

### DIFF
--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -2004,6 +2004,15 @@ void PerlembParser::ExportEventVariables(
 			break;
 		}
 
+		case EVENT_ENTER_AREA:
+		case EVENT_LEAVE_AREA: {
+			if (extra_pointers && extra_pointers->size() >= 2) {
+				ExportVar(package_name.c_str(), "area_id", *std::any_cast<int*>(extra_pointers->at(0)));
+				ExportVar(package_name.c_str(), "area_type", *std::any_cast<int*>(extra_pointers->at(1)));
+			}
+			break;
+		}
+
 		default: {
 			break;
 		}

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -4088,7 +4088,7 @@ void EntityList::ProcessMove(NPC *n, float x, float y, float z) {
 		std::vector<std::any> args;
 		args.push_back(&evt.area_id);
 		args.push_back(&evt.area_type);
-		
+
 		if (evt.event_id == EVENT_ENTER) {
 			parse->EventNPC(EVENT_ENTER, evt.npc, evt.client, "", 0);
 		} else if (evt.event_id == EVENT_EXIT) {

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -4084,10 +4084,16 @@ void EntityList::ProcessMove(NPC *n, float x, float y, float z) {
 
 	for (auto iter = events.begin(); iter != events.end(); ++iter) {
 		quest_proximity_event   &evt = (*iter);
+
 		std::vector<std::any> args;
 		args.push_back(&evt.area_id);
 		args.push_back(&evt.area_type);
-		parse->EventNPC(evt.event_id, evt.npc, evt.client, "", 0, &args);
+
+		if (evt.event_id == EVENT_ENTER_AREA) {
+			parse->EventNPC(EVENT_ENTER_AREA, evt.npc, evt.client, "", 0, &args);
+		} else if (evt.event_id == EVENT_LEAVE_AREA) {
+			parse->EventNPC(EVENT_LEAVE_AREA, evt.npc, evt.client, "", 0, &args);
+		}
 	}
 }
 

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -4088,8 +4088,12 @@ void EntityList::ProcessMove(NPC *n, float x, float y, float z) {
 		std::vector<std::any> args;
 		args.push_back(&evt.area_id);
 		args.push_back(&evt.area_type);
-
-		if (evt.event_id == EVENT_ENTER_AREA) {
+		
+		if (evt.event_id == EVENT_ENTER) {
+			parse->EventNPC(EVENT_ENTER, evt.npc, evt.client, "", 0);
+		} else if (evt.event_id == EVENT_EXIT) {
+			parse->EventNPC(EVENT_EXIT, evt.npc, evt.client, "", 0);
+		} else if (evt.event_id == EVENT_ENTER_AREA) {
 			parse->EventNPC(EVENT_ENTER_AREA, evt.npc, evt.client, "", 0, &args);
 		} else if (evt.event_id == EVENT_LEAVE_AREA) {
 			parse->EventNPC(EVENT_LEAVE_AREA, evt.npc, evt.client, "", 0, &args);

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -4023,10 +4023,6 @@ void EntityList::ProcessMove(Client *c, const glm::vec3& location)
 				parse->EventNPC(EVENT_LEAVE_AREA, evt.npc, evt.client, "", 0, &args);
 			}
 		} else {
-			std::vector<std::any> args;
-			args.push_back(&evt.area_id);
-			args.push_back(&evt.area_type);
-
 			if (evt.event_id == EVENT_ENTER) {
 				parse->EventPlayer(EVENT_ENTER, evt.client, "", 0);
 			} else if (evt.event_id == EVENT_EXIT) {

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -4007,14 +4007,35 @@ void EntityList::ProcessMove(Client *c, const glm::vec3& location)
 
 	for (auto iter = events.begin(); iter != events.end(); ++iter) {
 		quest_proximity_event& evt = (*iter);
+
+		std::vector<std::any> args;
+		args.push_back(&evt.area_id);
+		args.push_back(&evt.area_type);
+
 		if (evt.npc) {
-			std::vector<std::any> args;
-			parse->EventNPC(evt.event_id, evt.npc, evt.client, "", 0, &args);
+			if (evt.event_id == EVENT_ENTER) {
+				parse->EventNPC(EVENT_ENTER, evt.npc, evt.client, "", 0);
+			} else if (evt.event_id == EVENT_EXIT) {
+				parse->EventNPC(EVENT_EXIT, evt.npc, evt.client, "", 0);
+			} else if (evt.event_id == EVENT_ENTER_AREA) {
+				parse->EventNPC(EVENT_ENTER_AREA, evt.npc, evt.client, "", 0, &args);
+			} else if (evt.event_id == EVENT_LEAVE_AREA) {
+				parse->EventNPC(EVENT_LEAVE_AREA, evt.npc, evt.client, "", 0, &args);
+			}
 		} else {
 			std::vector<std::any> args;
 			args.push_back(&evt.area_id);
 			args.push_back(&evt.area_type);
-			parse->EventPlayer(evt.event_id, evt.client, "", 0, &args);
+
+			if (evt.event_id == EVENT_ENTER) {
+				parse->EventPlayer(EVENT_ENTER, evt.client, "", 0);
+			} else if (evt.event_id == EVENT_EXIT) {
+				parse->EventPlayer(EVENT_EXIT, evt.client, "", 0);
+			} else if (evt.event_id == EVENT_ENTER_AREA) {
+				parse->EventNPC(EVENT_ENTER_AREA, evt.npc, evt.client, "", 0, &args);
+			} else if (evt.event_id == EVENT_LEAVE_AREA) {
+				parse->EventNPC(EVENT_LEAVE_AREA, evt.npc, evt.client, "", 0, &args);
+			}
 		}
 	}
 }
@@ -5835,7 +5856,7 @@ void EntityList::DespawnGridNodes(int32 grid_id) {
 			mob->IsNPC() &&
 			mob->GetRace() == RACE_NODE_2254 &&
 			mob->EntityVariableExists("grid_id") &&
-			std::stoi(mob->GetEntityVariable("grid_id")) == grid_id) 
+			std::stoi(mob->GetEntityVariable("grid_id")) == grid_id)
 		{
 			mob->Depop();
 		}


### PR DESCRIPTION
# Perl
- Add `$area_id` export to EVENT_ENTER_AREA.
- Add `$area_type` export to EVENT_ENTER_AREA.
- Add `$area_id` export to EVENT_LEAVE_AREA.
- Add `$area_type` export to EVENT_LEAVE_AREA.

# Notes
- This is so Spire will parse these events properly.