### PR TITLE
[Bug Fix] Fixed message on promote/demote permissions check.

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -3888,7 +3888,7 @@ void Client::Handle_OP_BoardBoat(const EQApplicationPacket *app)
 	}
 	controlling_boat_id = boat->GetID();	// set the client's BoatID to show that it's on this boat
 
-	Message(0, "Board boat: %s", boatname);
+	Message(Chat::White, "Board boat: %s", boatname);
 
 	return;
 }
@@ -3967,7 +3967,7 @@ void Client::Handle_OP_BuffRemoveRequest(const EQApplicationPacket *app)
 void Client::Handle_OP_Bug(const EQApplicationPacket *app)
 {
 	if (!RuleB(Bugs, ReportingSystemActive)) {
-		Message(Chat::White, "Bug reporting is disabled on this server.");
+		Message(Chat::Red, "Bug reporting is disabled on this server.");
 		return;
 	}
 
@@ -4133,7 +4133,7 @@ void Client::Handle_OP_CastSpell(const EQApplicationPacket *app)
 						else
 						{
 							database.SetMQDetectionFlag(account_name, name, "OP_CastSpell with item, did not meet req level.", zone->GetShortName());
-							Message(0, "Error: level not high enough.", castspell->inventoryslot);
+							Message(Chat::Red, "Error: level not high enough.", castspell->inventoryslot);
 							InterruptSpell(castspell->spell_id);
 						}
 					}
@@ -4153,18 +4153,18 @@ void Client::Handle_OP_CastSpell(const EQApplicationPacket *app)
 				}
 				else
 				{
-					Message(0, "Error: unknown item->Click.Type (0x%02x)", item->Click.Type);
+					Message(Chat::Red, "Error: unknown item->Click.Type (0x%02x)", item->Click.Type);
 				}
 			}
 			else
 			{
-				Message(0, "Error: item not found in inventory slot #%i", castspell->inventoryslot);
+				Message(Chat::Red, "Error: item not found in inventory slot #%i", castspell->inventoryslot);
 				InterruptSpell(castspell->spell_id);
 			}
 		}
 		else
 		{
-			Message(0, "Error: castspell->inventoryslot >= %i (0x%04x)", EQ::invslot::slotCursor, castspell->inventoryslot);
+			Message(Chat::Red, "Error: castspell->inventoryslot >= %i (0x%04x)", EQ::invslot::slotCursor, castspell->inventoryslot);
 			InterruptSpell(castspell->spell_id);
 		}
 	}
@@ -4291,7 +4291,7 @@ void Client::Handle_OP_ClickDoor(const EQApplicationPacket *app)
 	Doors* currentdoor = entity_list.FindDoor(cd->doorid);
 	if (!currentdoor)
 	{
-		Message(0, "Unable to find door, please notify a GM (DoorID: %i).", cd->doorid);
+		Message(Chat::Red, "Unable to find door, please notify a GM (DoorID: %i).", cd->doorid);
 		return;
 	}
 
@@ -6251,10 +6251,10 @@ void Client::Handle_OP_GMEmoteZone(const EQApplicationPacket *app)
 	GMEmoteZone_Struct* gmez = (GMEmoteZone_Struct*)app->pBuffer;
 	char* newmessage = nullptr;
 	if (strstr(gmez->text, "^") == 0)
-		entity_list.Message(0, 15, gmez->text);
+		entity_list.Message(Chat::White, 15, gmez->text);
 	else {
 		for (newmessage = strtok((char*)gmez->text, "^"); newmessage != nullptr; newmessage = strtok(nullptr, "^"))
-			entity_list.Message(0, 15, newmessage);
+			entity_list.Message(Chat::White, 15, newmessage);
 	}
 	return;
 }
@@ -6321,7 +6321,7 @@ void Client::Handle_OP_GMGoto(const EQApplicationPacket *app)
 		MovePC(zone->GetZoneID(), zone->GetInstanceID(), gt->GetX(), gt->GetY(), gt->GetZ(), gt->GetHeading());
 	}
 	else if (!worldserver.Connected())
-		Message(0, "Error: World server disconnected.");
+		Message(Chat::Red, "Error: World server disconnected.");
 	else {
 		auto pack = new ServerPacket(ServerOP_GMGoto, sizeof(ServerGMGoto_Struct));
 		memset(pack->pBuffer, 0, pack->size);
@@ -6367,7 +6367,7 @@ void Client::Handle_OP_GMKick(const EQApplicationPacket *app)
 	Client* client = entity_list.GetClientByName(gmk->name);
 	if (client == 0) {
 		if (!worldserver.Connected())
-			Message(0, "Error: World server disconnected");
+			Message(Chat::Red, "Error: World server disconnected");
 		else {
 			auto pack = new ServerPacket(ServerOP_KickPlayer, sizeof(ServerKickPlayer_Struct));
 			ServerKickPlayer_Struct* skp = (ServerKickPlayer_Struct*)pack->pBuffer;
@@ -6409,7 +6409,7 @@ void Client::Handle_OP_GMKill(const EQApplicationPacket *app)
 	}
 	else {
 		if (!worldserver.Connected())
-			Message(0, "Error: World server disconnected");
+			Message(Chat::Red, "Error: World server disconnected");
 		else {
 			auto pack = new ServerPacket(ServerOP_KillPlayer, sizeof(ServerKillPlayer_Struct));
 			ServerKillPlayer_Struct* skp = (ServerKillPlayer_Struct*)pack->pBuffer;
@@ -6580,7 +6580,7 @@ void Client::Handle_OP_GMSearchCorpse(const EQApplicationPacket *app)
 void Client::Handle_OP_GMServers(const EQApplicationPacket *app)
 {
 	if (!worldserver.Connected())
-		Message(0, "Error: World server disconnected");
+		Message(Chat::Red, "Error: World server disconnected");
 	else {
 		auto pack = new ServerPacket(ServerOP_ZoneStatus, strlen(GetName()) + 2);
 		memset(pack->pBuffer, (uint8)admin, 1);
@@ -7439,7 +7439,7 @@ void Client::Handle_OP_GuildBank(const EQApplicationPacket *app)
 		}
 		else
 		{
-			Message(0, "Unable to withdraw 0 quantity of %s", inst->GetItem()->Name);
+			Message(Chat::Red, "Unable to withdraw 0 quantity of %s", inst->GetItem()->Name);
 		}
 
 		safe_delete(inst);
@@ -7576,13 +7576,13 @@ void Client::Handle_OP_GuildDelete(const EQApplicationPacket *app)
 	LogGuilds("Received OP_GuildDelete");
 
 	if (!IsInAGuild() || !guild_mgr.IsGuildLeader(GuildID(), CharacterID()))
-		Message(0, "You are not a guild leader or not in a guild.");
+		Message(Chat::Red, "You are not a guild leader or not in a guild.");
 	else {
 		LogGuilds("Deleting guild [{}] ([{}])", guild_mgr.GetGuildName(GuildID()), GuildID());
 		if (!guild_mgr.DeleteGuild(GuildID()))
-			Message(0, "Guild delete failed.");
+			Message(Chat::Red, "Guild delete failed.");
 		else {
-			Message(0, "Guild successfully deleted.");
+			Message(Chat::White, "Guild successfully deleted.");
 		}
 	}
 }
@@ -7607,16 +7607,16 @@ void Client::Handle_OP_GuildDemote(const EQApplicationPacket *app)
 
 		CharGuildInfo gci;
 		if (!guild_mgr.GetCharInfo(demote->target, gci)) {
-			Message(0, "Unable to find '%s'", demote->target);
+			Message(Chat::Red, "Unable to find '%s'", demote->target);
 			return;
 		}
 		if (gci.guild_id != GuildID()) {
-			Message(0, "You aren't in the same guild, what do you think you are doing?");
+			Message(Chat::Red, "You aren't in the same guild, what do you think you are doing?");
 			return;
 		}
 
 		if (gci.rank < 1) {
-			Message(0, "%s cannot be demoted any further!", demote->target);
+			Message(Chat::Red, "%s cannot be demoted any further!", demote->target);
 			return;
 		}
 		uint8 rank = gci.rank - 1;
@@ -7632,7 +7632,7 @@ void Client::Handle_OP_GuildDemote(const EQApplicationPacket *app)
 			Message(Chat::Red, "Error while setting rank %d on '%s'.", rank, demote->target);
 			return;
 		}
-		Message(0, "Successfully demoted %s to rank %d", demote->target, rank);
+		Message(Chat::White, "Successfully demoted %s to rank %d", demote->target, rank);
 	}
 	//	SendGuildMembers(GuildID(), true);
 	return;
@@ -7650,11 +7650,11 @@ void Client::Handle_OP_GuildInvite(const EQApplicationPacket *app)
 	GuildCommand_Struct* gc = (GuildCommand_Struct*)app->pBuffer;
 
 	if (!IsInAGuild())
-		Message(0, "Error: You are not in a guild!");
+		Message(Chat::Red, "Error: You are not in a guild!");
 	else if (gc->officer > GUILD_MAX_RANK)
 		Message(Chat::Red, "Invalid rank.");
 	else if (!worldserver.Connected())
-		Message(0, "Error: World server disconnected");
+		Message(Chat::Red, "Error: World server disconnected");
 	else {
 
 		//ok, the invite is also used for changing rank as well.
@@ -7826,9 +7826,9 @@ void Client::Handle_OP_GuildInviteAccept(const EQApplicationPacket *app)
 
 	//uint32 tmpeq = gj->guildeqid;
 	if (IsInAGuild() && gj->response == GuildRank())
-		Message(0, "Error: You're already in a guild!");
+		Message(Chat::Red, "Error: You're already in a guild!");
 	else if (!worldserver.Connected())
-		Message(0, "Error: World server disconnected");
+		Message(Chat::Red, "Error: World server disconnected");
 	else {
 		LogGuilds("Guild Invite Accept: guild [{}], response [{}], inviter [{}], person [{}]",
 			gj->guildeqid, gj->response, gj->inviter, gj->newmember);
@@ -7919,11 +7919,11 @@ void Client::Handle_OP_GuildLeader(const EQApplicationPacket *app)
 	app->pBuffer[app->size - 1] = 0;
 	GuildMakeLeader* gml = (GuildMakeLeader*)app->pBuffer;
 	if (!IsInAGuild())
-		Message(0, "Error: You aren't in a guild!");
+		Message(Chat::Red, "Error: You aren't in a guild!");
 	else if (GuildRank() != GUILD_LEADER)
-		Message(0, "Error: You aren't the guild leader!");
+		Message(Chat::Red, "Error: You aren't the guild leader!");
 	else if (!worldserver.Connected())
-		Message(0, "Error: World server disconnected");
+		Message(Chat::Red, "Error: World server disconnected");
 	else {
 
 		//NOTE: we could do cross-zone lookups here...
@@ -7936,14 +7936,14 @@ void Client::Handle_OP_GuildLeader(const EQApplicationPacket *app)
 				newleader->GetName(), newleader->CharacterID());
 
 			if (guild_mgr.SetGuildLeader(GuildID(), newleader->CharacterID())) {
-				Message(0, "Successfully Transfered Leadership to %s.", gml->target);
+				Message(Chat::White, "Successfully Transfered Leadership to %s.", gml->target);
 				newleader->Message(Chat::Yellow, "%s has transfered the guild leadership into your hands.", GetName());
 			}
 			else
-				Message(0, "Could not change leadership at this time.");
+				Message(Chat::Red, "Could not change leadership at this time.");
 		}
 		else
-			Message(0, "Failed to change leader, could not find target.");
+			Message(Chat::Red, "Failed to change leader, could not find target.");
 	}
 	//	SendGuildMembers(GuildID(), true);
 	return;
@@ -7968,7 +7968,7 @@ void Client::Handle_OP_GuildManageBanker(const EQApplicationPacket *app)
 
 	if (!guild_mgr.GetCharInfo(gmb->member, gci))
 	{
-		Message(0, "Unable to find '%s'", gmb->member);
+		Message(Chat::Red, "Unable to find '%s'", gmb->member);
 		return;
 	}
 	bool IsCurrentlyABanker = guild_mgr.GetBankerFlag(gci.char_id);
@@ -7997,7 +7997,7 @@ void Client::Handle_OP_GuildManageBanker(const EQApplicationPacket *app)
 	}
 
 	if (gci.guild_id != GuildID()) {
-		Message(0, "You aren't in the same guild, what do you think you are doing?");
+		Message(Chat::Red, "You aren't in the same guild, what do you think you are doing?");
 		return;
 	}
 
@@ -8009,9 +8009,9 @@ void Client::Handle_OP_GuildManageBanker(const EQApplicationPacket *app)
 		}
 
 		if (NewBankerStatus)
-			Message(0, "%s has been made a guild banker.", gmb->member);
+			Message(Chat::White, "%s has been made a guild banker.", gmb->member);
 		else
-			Message(0, "%s is no longer a guild banker.", gmb->member);
+			Message(Chat::White, "%s is no longer a guild banker.", gmb->member);
 	}
 	if (IsCurrentlyAnAlt != NewAltStatus)
 	{
@@ -8021,9 +8021,9 @@ void Client::Handle_OP_GuildManageBanker(const EQApplicationPacket *app)
 		}
 
 		if (NewAltStatus)
-			Message(0, "%s has been marked as an alt.", gmb->member);
+			Message(Chat::White, "%s has been marked as an alt.", gmb->member);
 		else
-			Message(0, "%s is no longer marked as an alt.", gmb->member);
+			Message(Chat::White, "%s is no longer marked as an alt.", gmb->member);
 	}
 }
 
@@ -8043,21 +8043,21 @@ void Client::Handle_OP_GuildPromote(const EQApplicationPacket *app)
 	}
 
 	if (!IsInAGuild())
-		Message(0, "Error: You aren't in a guild!");
+		Message(Chat::Red, "Error: You aren't in a guild!");
 	else if (!guild_mgr.CheckPermission(GuildID(), GuildRank(), GUILD_PROMOTE))
 		Message(Chat::Red, "You don't have permission to promote.");
 	else if (!worldserver.Connected())
-		Message(0, "Error: World server disconnected");
+		Message(Chat::Red, "Error: World server disconnected");
 	else {
 		GuildPromoteStruct* promote = (GuildPromoteStruct*)app->pBuffer;
 
 		CharGuildInfo gci;
 		if (!guild_mgr.GetCharInfo(promote->target, gci)) {
-			Message(0, "Unable to find '%s'", promote->target);
+			Message(Chat::Red, "Unable to find '%s'", promote->target);
 			return;
 		}
 		if (gci.guild_id != GuildID()) {
-			Message(0, "You aren't in the same guild, what do you think you are doing?");
+			Message(Chat::Red, "You aren't in the same guild, what do you think you are doing?");
 			return;
 		}
 
@@ -8065,7 +8065,7 @@ void Client::Handle_OP_GuildPromote(const EQApplicationPacket *app)
 
 		if (rank > GUILD_OFFICER)
 		{
-			Message(0, "You cannot promote someone to be guild leader. You must use /guildleader.");
+			Message(Chat::Red, "You cannot promote someone to be guild leader. You must use /guildleader.");
 			return;
 		}
 
@@ -8080,7 +8080,7 @@ void Client::Handle_OP_GuildPromote(const EQApplicationPacket *app)
 			Message(Chat::Red, "Error while setting rank %d on '%s'.", rank, promote->target);
 			return;
 		}
-		Message(0, "Successfully promoted %s to rank %d", promote->target, rank);
+		Message(Chat::White, "Successfully promoted %s to rank %d", promote->target, rank);
 	}
 	return;
 }
@@ -8098,11 +8098,11 @@ void Client::Handle_OP_GuildPublicNote(const EQApplicationPacket *app)
 
 	CharGuildInfo gci;
 	if (!guild_mgr.GetCharInfo(gpn->target, gci)) {
-		Message(0, "Unable to find '%s'", gpn->target);
+		Message(Chat::Red, "Unable to find '%s'", gpn->target);
 		return;
 	}
 	if (gci.guild_id != GuildID()) {
-		Message(0, "You aren't in the same guild, what do you think you are doing?");
+		Message(Chat::Red, "You aren't in the same guild, what do you think you are doing?");
 		return;
 	}
 
@@ -8115,7 +8115,7 @@ void Client::Handle_OP_GuildPublicNote(const EQApplicationPacket *app)
 		Message(Chat::Red, "Failed to set public note on %s", gpn->target);
 	}
 	else {
-		Message(0, "Successfully changed public note on %s", gpn->target);
+		Message(Chat::White, "Successfully changed public note on %s", gpn->target);
 	}
 	//	SendGuildMembers(GuildID(), true);
 	return;
@@ -8131,7 +8131,7 @@ void Client::Handle_OP_GuildRemove(const EQApplicationPacket *app)
 	}
 	GuildCommand_Struct* gc = (GuildCommand_Struct*)app->pBuffer;
 	if (!IsInAGuild())
-		Message(0, "Error: You aren't in a guild!");
+		Message(Chat::Red, "Error: You aren't in a guild!");
 	// we can always remove ourself, otherwise, our rank needs remove permissions
 	else if (strcasecmp(gc->othername, GetName()) != 0 &&
 		!guild_mgr.CheckPermission(GuildID(), GuildRank(), GUILD_REMOVE))
@@ -8148,7 +8148,7 @@ void Client::Handle_OP_GuildRemove(const EQApplicationPacket *app)
 
 		if (client) {
 			if (!client->IsInGuild(GuildID())) {
-				Message(0, "You aren't in the same guild, what do you think you are doing?");
+				Message(Chat::Red, "You aren't in the same guild, what do you think you are doing?");
 				return;
 			}
 			char_id = client->CharacterID();
@@ -8160,11 +8160,11 @@ void Client::Handle_OP_GuildRemove(const EQApplicationPacket *app)
 		else {
 			CharGuildInfo gci;
 			if (!guild_mgr.GetCharInfo(gc->othername, gci)) {
-				Message(0, "Unable to find '%s'", gc->othername);
+				Message(Chat::Red, "Unable to find '%s'", gc->othername);
 				return;
 			}
 			if (gci.guild_id != GuildID()) {
-				Message(0, "You aren't in the same guild, what do you think you are doing?");
+				Message(Chat::Red, "You aren't in the same guild, what do you think you are doing?");
 				return;
 			}
 			char_id = gci.char_id;
@@ -8179,12 +8179,12 @@ void Client::Handle_OP_GuildRemove(const EQApplicationPacket *app)
 			GuildManageRemove_Struct* gm = (GuildManageRemove_Struct*)outapp->pBuffer;
 			gm->guildeqid = GuildID();
 			strcpy(gm->member, gc->othername);
-			Message(0, "%s successfully removed from your guild.", gc->othername);
+			Message(Chat::White, "%s successfully removed from your guild.", gc->othername);
 			entity_list.QueueClientsGuild(this, outapp, false, GuildID());
 			safe_delete(outapp);
 		}
 		else
-			Message(0, "Unable to remove %s from your guild.", gc->othername);
+			Message(Chat::Red, "Unable to remove %s from your guild.", gc->othername);
 	}
 	//	SendGuildMembers(GuildID(), true);
 	return;
@@ -8840,14 +8840,14 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 
 	const EQ::ItemInstance* inst = m_inv[slot_id];
 	if (!inst) {
-		Message(0, "Error: item not found in inventory slot #%i", slot_id);
+		Message(Chat::Red, "Error: item not found in inventory slot #%i", slot_id);
 		DeleteItemInInventory(slot_id, 0, true);
 		return;
 	}
 
 	const EQ::ItemData* item = inst->GetItem();
 	if (!item) {
-		Message(0, "Error: item not found in inventory slot #%i", slot_id);
+		Message(Chat::Red, "Error: item not found in inventory slot #%i", slot_id);
 		DeleteItemInInventory(slot_id, 0, true);
 		return;
 	}
@@ -8975,7 +8975,7 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 			{
 				if (inst->GetCharges() == 0)
 				{
-					//Message(0, "This item is out of charges.");
+					//Message(Chat::White, "This item is out of charges.");
 					MessageString(Chat::Red, ITEM_OUT_OF_CHARGES);
 					return;
 				}
@@ -9020,7 +9020,7 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 			{
 				if (clickaug->GetCharges() == 0)
 				{
-					//Message(0, "This item is out of charges.");
+					//Message(Chat::White, "This item is out of charges.");
 					MessageString(Chat::Red, ITEM_OUT_OF_CHARGES);
 					return;
 				}
@@ -9078,12 +9078,12 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 		}
 		else
 		{
-			Message(0, "Error: item not found in inventory slot #%i", slot_id);
+			Message(Chat::Red, "Error: item not found in inventory slot #%i", slot_id);
 		}
 	}
 	else
 	{
-		Message(0, "Error: Invalid inventory slot for using effects (inventory slot #%i)", slot_id);
+		Message(Chat::Red, "Error: Invalid inventory slot for using effects (inventory slot #%i)", slot_id);
 	}
 
 	return;
@@ -9308,7 +9308,7 @@ void Client::Handle_OP_LFGCommand(const EQApplicationPacket *app)
 		strn0cpy(LFGComments, lfg->Comments, sizeof(LFGComments));
 		break;
 	default:
-		Message(0, "Error: unknown LFG value %i", lfg->value);
+		Message(Chat::Red, "Error: unknown LFG value %i", lfg->value);
 	}
 
 	UpdateWho();
@@ -9335,7 +9335,7 @@ void Client::Handle_OP_LFGGetMatchesRequest(const EQApplicationPacket *app)
 	LFGGetMatchesRequest_Struct* gmrs = (LFGGetMatchesRequest_Struct*)app->pBuffer;
 
 	if (!worldserver.Connected())
-		Message(0, "Error: World server disconnected");
+		Message(Chat::Red, "Error: World server disconnected");
 	else {
 		auto pack = new ServerPacket(ServerOP_LFGMatches, sizeof(ServerLFGMatchesRequest_Struct));
 		ServerLFGMatchesRequest_Struct* smrs = (ServerLFGMatchesRequest_Struct*)pack->pBuffer;
@@ -9559,7 +9559,7 @@ void Client::Handle_OP_LFPGetMatchesRequest(const EQApplicationPacket *app)
 	LFPGetMatchesRequest_Struct* gmrs = (LFPGetMatchesRequest_Struct*)app->pBuffer;
 
 	if (!worldserver.Connected())
-		Message(0, "Error: World server disconnected");
+		Message(Chat::Red, "Error: World server disconnected");
 	else {
 		auto pack = new ServerPacket(ServerOP_LFPMatches, sizeof(ServerLFPMatchesRequest_Struct));
 		ServerLFPMatchesRequest_Struct* smrs = (ServerLFPMatchesRequest_Struct*)pack->pBuffer;
@@ -10924,17 +10924,17 @@ void Client::Handle_OP_Petition(const EQApplicationPacket *app)
 	if (app->size <= 1)
 		return;
 	if (!worldserver.Connected())
-		Message(0, "Error: World server disconnected");
+		Message(Chat::Red, "Error: World server disconnected");
 	/*else if(petition_list.FindPetitionByAccountName(AccountName()))
 	{
-	Message(0,"You already have a petition in queue, you cannot petition again until this one has been responded to or you have deleted the petition.");
+	Message(Chat::White,"You already have a petition in queue, you cannot petition again until this one has been responded to or you have deleted the petition.");
 	return;
 	}*/
 	else
 	{
 		if (petition_list.FindPetitionByAccountName(AccountName()))
 		{
-			Message(0, "You already have a petition in the queue, you must wait for it to be answered or use /deletepetition to delete it.");
+			Message(Chat::White, "You already have a petition in the queue, you must wait for it to be answered or use /deletepetition to delete it.");
 			return;
 		}
 		auto pet = new Petition(CharacterID());
@@ -10969,7 +10969,7 @@ void Client::Handle_OP_Petition(const EQApplicationPacket *app)
 
 void Client::Handle_OP_PetitionBug(const EQApplicationPacket *app)
 {
-	Message(0, "Petition Bugs are not supported, please use /bug.");
+	Message(Chat::White, "Petition Bugs are not supported, please use /bug.");
 
 	return;
 }
@@ -11002,7 +11002,7 @@ void Client::Handle_OP_PetitionCheckout(const EQApplicationPacket *app)
 		return;
 	}
 	if (!worldserver.Connected())
-		Message(0, "Error: World server disconnected");
+		Message(Chat::Red, "Error: World server disconnected");
 	else {
 		uint32 getpetnum = *((uint32*)app->pBuffer);
 		Petition* getpet = petition_list.GetPetitionByID(getpetnum);
@@ -11073,7 +11073,7 @@ void Client::Handle_OP_PetitionUnCheckout(const EQApplicationPacket *app)
 		return;
 	}
 	if (!worldserver.Connected())
-		Message(0, "Error: World server disconnected");
+		Message(Chat::Red, "Error: World server disconnected");
 	else {
 		uint32 getpetnum = *((uint32*)app->pBuffer);
 		Petition* getpet = petition_list.GetPetitionByID(getpetnum);
@@ -12818,7 +12818,7 @@ void Client::Handle_OP_SetGuildMOTD(const EQApplicationPacket *app)
 		guild_mgr.GetGuildName(GuildID()), GuildID(), GetName(), gmotd->motd);
 
 	if (!guild_mgr.SetGuildMOTD(GuildID(), gmotd->motd, GetName())) {
-		Message(0, "Motd update failed.");
+		Message(Chat::Red, "Motd update failed.");
 	}
 
 	return;
@@ -13573,7 +13573,7 @@ void Client::Handle_OP_ShopRequest(const EQApplicationPacket *app)
 	}
 	if (GetFeigned() || IsInvisible())
 	{
-		Message(0, "You cannot use a merchant right now.");
+		Message(Chat::White, "You cannot use a merchant right now.");
 		action = 0;
 	}
 	int primaryfaction = tmp->CastToNPC()->GetPrimaryFaction();
@@ -15412,7 +15412,7 @@ void Client::Handle_OP_YellForHelp(const EQApplicationPacket *app)
 void Client::Handle_OP_ResetAA(const EQApplicationPacket *app)
 {
 	if (Admin() >= AccountStatus::Guide) {
-		Message(0, "Resetting AA points.");
+		Message(Chat::White, "Resetting AA points.");
 		ResetAA();
 	}
 	return;

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -8045,7 +8045,7 @@ void Client::Handle_OP_GuildPromote(const EQApplicationPacket *app)
 	if (!IsInAGuild())
 		Message(0, "Error: You arent in a guild!");
 	else if (!guild_mgr.CheckPermission(GuildID(), GuildRank(), GUILD_PROMOTE))
-		Message(0, "You dont have permission to invite.");
+		Message(0, "You dont have permission to promote.");
 	else if (!worldserver.Connected())
 		Message(0, "Error: World server disconnected");
 	else {

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -7599,7 +7599,7 @@ void Client::Handle_OP_GuildDemote(const EQApplicationPacket *app)
 	if (!IsInAGuild())
 		Message(0, "Error: You arent in a guild!");
 	else if (!guild_mgr.CheckPermission(GuildID(), GuildRank(), GUILD_DEMOTE))
-		Message(0, "You dont have permission to invite.");
+		Message(0, "You dont have permission to demote.");
 	else if (!worldserver.Connected())
 		Message(0, "Error: World server disconnected");
 	else {

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4061,7 +4061,7 @@ void Client::Handle_OP_CastSpell(const EQApplicationPacket *app)
 	}
 	if (IsAIControlled()) {
 		MessageString(Chat::Red, NOT_IN_CONTROL);
-		//Message(Chat::Red, "You cant cast right now, you arent in control of yourself!");
+		//Message(Chat::Red, "You cant cast right now, You aren't in control of yourself!");
 		return;
 	}
 
@@ -7597,11 +7597,11 @@ void Client::Handle_OP_GuildDemote(const EQApplicationPacket *app)
 	}
 
 	if (!IsInAGuild())
-		Message(0, "Error: You arent in a guild!");
+		Message(Chat::Red, "Error: You aren't in a guild!");
 	else if (!guild_mgr.CheckPermission(GuildID(), GuildRank(), GUILD_DEMOTE))
-		Message(0, "You dont have permission to demote.");
+		Message(Chat::Red, "You don't have permission to demote.");
 	else if (!worldserver.Connected())
-		Message(0, "Error: World server disconnected");
+		Message(Chat::Red, "Error: World server disconnected");
 	else {
 		GuildDemoteStruct* demote = (GuildDemoteStruct*)app->pBuffer;
 
@@ -7674,7 +7674,7 @@ void Client::Handle_OP_GuildInvite(const EQApplicationPacket *app)
 				if (gc->officer < client->GuildRank()) {
 					//demotion
 					if (!guild_mgr.CheckPermission(GuildID(), GuildRank(), GUILD_DEMOTE)) {
-						Message(Chat::Red, "You dont have permission to demote.");
+						Message(Chat::Red, "You don't have permission to demote.");
 						return;
 					}
 
@@ -7696,7 +7696,7 @@ void Client::Handle_OP_GuildInvite(const EQApplicationPacket *app)
 				else if (gc->officer > client->GuildRank()) {
 					//promotion
 					if (!guild_mgr.CheckPermission(GuildID(), GuildRank(), GUILD_PROMOTE)) {
-						Message(Chat::Red, "You dont have permission to demote.");
+						Message(Chat::Red, "You don't have permission to demote.");
 						return;
 					}
 
@@ -7731,7 +7731,7 @@ void Client::Handle_OP_GuildInvite(const EQApplicationPacket *app)
 				}
 
 				if (!guild_mgr.CheckPermission(GuildID(), GuildRank(), GUILD_INVITE)) {
-					Message(Chat::Red, "You dont have permission to invite.");
+					Message(Chat::Red, "You don't have permission to invite.");
 					return;
 				}
 
@@ -7919,9 +7919,9 @@ void Client::Handle_OP_GuildLeader(const EQApplicationPacket *app)
 	app->pBuffer[app->size - 1] = 0;
 	GuildMakeLeader* gml = (GuildMakeLeader*)app->pBuffer;
 	if (!IsInAGuild())
-		Message(0, "Error: You arent in a guild!");
+		Message(0, "Error: You aren't in a guild!");
 	else if (GuildRank() != GUILD_LEADER)
-		Message(0, "Error: You arent the guild leader!");
+		Message(0, "Error: You aren't the guild leader!");
 	else if (!worldserver.Connected())
 		Message(0, "Error: World server disconnected");
 	else {
@@ -8043,9 +8043,9 @@ void Client::Handle_OP_GuildPromote(const EQApplicationPacket *app)
 	}
 
 	if (!IsInAGuild())
-		Message(0, "Error: You arent in a guild!");
+		Message(0, "Error: You aren't in a guild!");
 	else if (!guild_mgr.CheckPermission(GuildID(), GuildRank(), GUILD_PROMOTE))
-		Message(0, "You dont have permission to promote.");
+		Message(Chat::Red, "You don't have permission to promote.");
 	else if (!worldserver.Connected())
 		Message(0, "Error: World server disconnected");
 	else {
@@ -8131,13 +8131,13 @@ void Client::Handle_OP_GuildRemove(const EQApplicationPacket *app)
 	}
 	GuildCommand_Struct* gc = (GuildCommand_Struct*)app->pBuffer;
 	if (!IsInAGuild())
-		Message(0, "Error: You arent in a guild!");
+		Message(0, "Error: You aren't in a guild!");
 	// we can always remove ourself, otherwise, our rank needs remove permissions
 	else if (strcasecmp(gc->othername, GetName()) != 0 &&
 		!guild_mgr.CheckPermission(GuildID(), GuildRank(), GUILD_REMOVE))
-		Message(0, "You dont have permission to remove guild members.");
+		Message(Chat::Red, "You don't have permission to remove guild members.");
 	else if (!worldserver.Connected())
-		Message(0, "Error: World server disconnected");
+		Message(Chat::Red, "Error: World server disconnected");
 	else {
 #ifdef BOTS
 		if (Bot::ProcessGuildRemoval(this, gc->othername))


### PR DESCRIPTION
Old message when you attempted to promote or demote a player and did not have permissions to do so: "You dont have permission to invite."

New promote rejection message: "You dont have permission to promote."
New demote rejection message: "You dont have permission to demote."