### PR TITLE
[Quest API] Add GetLeader() and GetLeaderName() to Perl/Lua.

### DIFF
--- a/zone/lua_raid.cpp
+++ b/zone/lua_raid.cpp
@@ -83,6 +83,11 @@ bool Lua_Raid::IsLeader(Lua_Client c) {
 	return self->IsLeader(c);
 }
 
+Lua_Client Lua_Raid::GetLeader() {
+	Lua_Safe_Call_Class(Lua_Client);
+	return self->GetLeader();
+}
+
 bool Lua_Raid::IsGroupLeader(const char *name) {
 	Lua_Safe_Call_Bool();
 	return self->IsGroupLeader(name);
@@ -181,6 +186,7 @@ luabind::scope lua_register_raid() {
 	.def("IsGroupLeader", (bool(Lua_Raid::*)(Lua_Client))&Lua_Raid::IsGroupLeader)
 	.def("IsLeader", (bool(Lua_Raid::*)(const char*))&Lua_Raid::IsLeader)
 	.def("IsLeader", (bool(Lua_Raid::*)(Lua_Client))&Lua_Raid::IsLeader)
+	.def("GetLeader", (Lua_Client(Lua_Raid::*)(void)) & Lua_Raid::GetLeader)
 	.def("IsRaidMember", (bool(Lua_Raid::*)(const char*))&Lua_Raid::IsRaidMember)
 	.def("IsRaidMember", (bool(Lua_Raid::*)(Lua_Client))&Lua_Raid::IsRaidMember)
 	.def("RaidCount", (int(Lua_Raid::*)(void))&Lua_Raid::RaidCount)

--- a/zone/lua_raid.cpp
+++ b/zone/lua_raid.cpp
@@ -192,7 +192,7 @@ luabind::scope lua_register_raid() {
 	.def("IsLeader", (bool(Lua_Raid::*)(const char*))&Lua_Raid::IsLeader)
 	.def("IsLeader", (bool(Lua_Raid::*)(Lua_Client))&Lua_Raid::IsLeader)
 	.def("GetLeader", (Lua_Client(Lua_Raid::*)(void))&Lua_Raid::GetLeader)
-	.def("GetLeaderName", (Lua_Client(Lua_Raid::*)(void)) & Lua_Raid::GetLeaderName)
+	.def("GetLeaderName", (std::string(Lua_Raid::*)(void)) & Lua_Raid::GetLeaderName)
 	.def("IsRaidMember", (bool(Lua_Raid::*)(const char*))&Lua_Raid::IsRaidMember)
 	.def("IsRaidMember", (bool(Lua_Raid::*)(Lua_Client))&Lua_Raid::IsRaidMember)
 	.def("RaidCount", (int(Lua_Raid::*)(void))&Lua_Raid::RaidCount)

--- a/zone/lua_raid.cpp
+++ b/zone/lua_raid.cpp
@@ -88,6 +88,11 @@ Lua_Client Lua_Raid::GetLeader() {
 	return self->GetLeader();
 }
 
+std::string Lua_Raid::GetLeaderName() {
+	Lua_Safe_Call_String();
+	return self->GetLeaderName();
+}
+
 bool Lua_Raid::IsGroupLeader(const char *name) {
 	Lua_Safe_Call_Bool();
 	return self->IsGroupLeader(name);
@@ -186,7 +191,8 @@ luabind::scope lua_register_raid() {
 	.def("IsGroupLeader", (bool(Lua_Raid::*)(Lua_Client))&Lua_Raid::IsGroupLeader)
 	.def("IsLeader", (bool(Lua_Raid::*)(const char*))&Lua_Raid::IsLeader)
 	.def("IsLeader", (bool(Lua_Raid::*)(Lua_Client))&Lua_Raid::IsLeader)
-	.def("GetLeader", (Lua_Client(Lua_Raid::*)(void)) & Lua_Raid::GetLeader)
+	.def("GetLeader", (Lua_Client(Lua_Raid::*)(void))&Lua_Raid::GetLeader)
+	.def("GetLeaderName", (Lua_Client(Lua_Raid::*)(void)) & Lua_Raid::GetLeaderName)
 	.def("IsRaidMember", (bool(Lua_Raid::*)(const char*))&Lua_Raid::IsRaidMember)
 	.def("IsRaidMember", (bool(Lua_Raid::*)(Lua_Client))&Lua_Raid::IsRaidMember)
 	.def("RaidCount", (int(Lua_Raid::*)(void))&Lua_Raid::RaidCount)

--- a/zone/lua_raid.h
+++ b/zone/lua_raid.h
@@ -41,6 +41,7 @@ public:
 	bool IsLeader(const char *c);
 	bool IsLeader(Lua_Client c);
 	Lua_Client GetLeader();
+	std::string GetLeaderName();
 	bool IsGroupLeader(const char *name);
 	bool IsGroupLeader(Lua_Client c);
 	int GetHighestLevel();

--- a/zone/lua_raid.h
+++ b/zone/lua_raid.h
@@ -40,6 +40,7 @@ public:
 	void BalanceHP(int penalty, uint32 group_id);
 	bool IsLeader(const char *c);
 	bool IsLeader(Lua_Client c);
+	Lua_Client GetLeader();
 	bool IsGroupLeader(const char *name);
 	bool IsGroupLeader(Lua_Client c);
 	int GetHighestLevel();

--- a/zone/perl_raids.cpp
+++ b/zone/perl_raids.cpp
@@ -78,7 +78,7 @@ bool Perl_Raid_IsLeader(Raid* self, Client* c) // @categories Raid
 	return self->IsLeader(c);
 }
 
-Mob* Perl_Raid_GetLeader(Raid* self) // @categories Raid
+Client* Perl_Raid_GetLeader(Raid* self) // @categories Raid
 {
 	return self->GetLeader();
 }

--- a/zone/perl_raids.cpp
+++ b/zone/perl_raids.cpp
@@ -78,6 +78,16 @@ bool Perl_Raid_IsLeader(Raid* self, Client* c) // @categories Raid
 	return self->IsLeader(c);
 }
 
+Mob* Perl_Raid_GetLeader(Raid* self) // @categories Raid
+{
+	return self->GetLeader();
+}
+
+std::string Perl_Raid_GetLeaderName(Raid* self) // @categories Raid
+{
+	return self->GetLeaderName();
+}
+
 bool Perl_Raid_IsGroupLeader(Raid* self, const char* who) // @categories Group, Raid
 {
 	return self->IsGroupLeader(who);
@@ -165,6 +175,8 @@ void perl_register_raid()
 	package.add("GetID", &Perl_Raid_GetID);
 	package.add("GetLowestLevel", &Perl_Raid_GetLowestLevel);
 	package.add("GetMember", &Perl_Raid_GetMember);
+	package.add("GetLeader", &Perl_Raid_GetLeader);
+	package.add("GetLeaderName", &Perl_Raid_GetLeaderName);
 	package.add("GetTotalRaidDamage", &Perl_Raid_GetTotalRaidDamage);
 	package.add("GroupCount", &Perl_Raid_GroupCount);
 	package.add("IsGroupLeader", (bool(*)(Raid*, const char*))&Perl_Raid_IsGroupLeader);

--- a/zone/raids.h
+++ b/zone/raids.h
@@ -103,8 +103,8 @@ public:
 	~Raid();
 
 	void SetLeader(Client* c) { leader = c; }
-	Client* GetLeader() { return leader; }
-	const char* GetLeaderName() { return leader->CastToMob()->GetCleanName(); }
+	inline	Client* GetLeader() { return leader; };
+	std::string GetLeaderName() { return leadername; }
 	bool IsLeader(Client* c) { return c == leader; }
 	bool IsLeader(const char* name) { return !strcmp(leadername, name); }
 	void SetRaidLeader(const char *wasLead, const char *name);

--- a/zone/raids.h
+++ b/zone/raids.h
@@ -104,6 +104,7 @@ public:
 
 	void SetLeader(Client* c) { leader = c; }
 	Client* GetLeader() { return leader; }
+	const char* GetLeaderName() { return leader->GetCleanName(); };
 	bool IsLeader(Client* c) { return c == leader; }
 	bool IsLeader(const char* name) { return !strcmp(leadername, name); }
 	void SetRaidLeader(const char *wasLead, const char *name);

--- a/zone/raids.h
+++ b/zone/raids.h
@@ -104,7 +104,7 @@ public:
 
 	void SetLeader(Client* c) { leader = c; }
 	Client* GetLeader() { return leader; }
-	std::string GetLeaderName() { return leadername; }
+	std::string GetLeaderName() { return std::string(leadername); }
 	bool IsLeader(Client* c) { return c == leader; }
 	bool IsLeader(const char* name) { return !strcmp(leadername, name); }
 	void SetRaidLeader(const char *wasLead, const char *name);

--- a/zone/raids.h
+++ b/zone/raids.h
@@ -104,7 +104,7 @@ public:
 
 	void SetLeader(Client* c) { leader = c; }
 	Client* GetLeader() { return leader; }
-	const char* GetLeaderName() { return leader->GetCleanName(); };
+	const char* GetLeaderName() { return leader->CastToMob()->GetCleanName(); }
 	bool IsLeader(Client* c) { return c == leader; }
 	bool IsLeader(const char* name) { return !strcmp(leadername, name); }
 	void SetRaidLeader(const char *wasLead, const char *name);

--- a/zone/raids.h
+++ b/zone/raids.h
@@ -104,7 +104,7 @@ public:
 
 	void SetLeader(Client* c) { leader = c; }
 	Client* GetLeader() { return leader; }
-	std::string GetLeaderName() { return std::string(leadername); }
+	std::string GetLeaderName() { return leadername; }
 	bool IsLeader(Client* c) { return c == leader; }
 	bool IsLeader(const char* name) { return !strcmp(leadername, name); }
 	void SetRaidLeader(const char *wasLead, const char *name);

--- a/zone/raids.h
+++ b/zone/raids.h
@@ -103,7 +103,7 @@ public:
 	~Raid();
 
 	void SetLeader(Client* c) { leader = c; }
-	inline	Client* GetLeader() { return leader; };
+	Client* GetLeader() { return leader; }
 	std::string GetLeaderName() { return leadername; }
 	bool IsLeader(Client* c) { return c == leader; }
 	bool IsLeader(const char* name) { return !strcmp(leadername, name); }


### PR DESCRIPTION
# Perl
- Add `$raid->getLeader();`.
- Add `$raid->getLeaderName();`.

# Lua
- Add `raid:GetLeader()`.
- Add `raid:GetLeaderName()`.

# Notes
- Returns raid leader information, similar to the associated group methods.