### PR TITLE
[Bug Fix] AltCurrencySelectItemReply_Struct was not handled correctly.

### DIFF
--- a/common/emu_oplist.h
+++ b/common/emu_oplist.h
@@ -35,7 +35,7 @@ N(OP_AltCurrencyMerchantRequest),
 N(OP_AltCurrencyPurchase),
 N(OP_AltCurrencyReclaim),
 N(OP_AltCurrencySell),
-N(OP_AltCurrencySellSelection),
+N(OP_AltCurrencySellSelection), 		// Used by eqstr_us.txt 8066, 8068, 8069 		
 N(OP_Animation),
 N(OP_AnnoyingZoneUnknown),
 N(OP_ApplyPoison),

--- a/common/eq_packet_structs.h
+++ b/common/eq_packet_structs.h
@@ -5163,10 +5163,10 @@ struct AltCurrencySelectItemReply_Struct {
 /*000*/ uint32	unknown000;
 /*004*/ uint8	unknown004; //0xff
 /*005*/ uint8	unknown005; //0xff
-/*006*/ uint8	unknown006; //0xff
-/*007*/ uint8	unknown007; //0xff
-/*008*/ char	item_name[64];
-/*072*/ uint32	unknown074;
+/*006*/ uint16	unknown006; //0xffff
+/*008*/ uint16	unknown008; //0xffff
+/*010*/ char	item_name[64];
+/*074*/ uint16	unknown074;
 /*076*/ uint32	cost;
 /*080*/ uint32	unknown080;
 /*084*/ uint32	unknown084;

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -2849,8 +2849,8 @@ void Client::Handle_OP_AltCurrencySellSelection(const EQApplicationPacket *app)
 		AltCurrencySelectItemReply_Struct *reply = (AltCurrencySelectItemReply_Struct*)outapp->pBuffer;
 		reply->unknown004 = 0xFF;
 		reply->unknown005 = 0xFF;
-		reply->unknown006 = 0xFF;
-		reply->unknown007 = 0xFF;
+		reply->unknown006 = 0xFFFF;
+		reply->unknown008 = 0xFFFF;
 		strcpy(reply->item_name, inst->GetItem()->Name);
 		reply->cost = cost;
 		FastQueuePacket(&outapp);


### PR DESCRIPTION
Item Name offset was off by 2 Bytes, causing first part of the Item Name to be cut off.

![image](https://user-images.githubusercontent.com/109764533/210287635-f745c851-9d71-4340-9fd0-f31c660ee506.png)

Fixed offset, confirmed working on RoF2.

![image](https://user-images.githubusercontent.com/109764533/210287602-3da2e6db-be5d-4a97-889b-8a34216f79b4.png)
