### PR TITLE
[Quest API] Add option to Ignore Mods to CalcEXP

### DIFF
--- a/zone/client.h
+++ b/zone/client.h
@@ -627,7 +627,7 @@ public:
 
 	uint64 GetExperienceForKill(Mob *against);
 	void AddEXP(uint64 in_add_exp, uint8 conlevel = 0xFF, bool resexp = false);
-	uint64 CalcEXP(uint8 conlevel = 0xFF);
+	uint64 CalcEXP(uint8 conlevel = 0xFF, bool ignore_mods = false);
 	void CalculateNormalizedAAExp(uint64 &add_aaxp, uint8 conlevel, bool resexp);
 	void CalculateStandardAAExp(uint64 &add_aaxp, uint8 conlevel, bool resexp);
 	void CalculateLeadershipExp(uint64 &add_exp, uint8 conlevel);

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -104,7 +104,7 @@ static uint32 MaxBankedRaidLeadershipPoints(int Level)
 	return 10;
 }
 
-uint64 Client::CalcEXP(uint8 conlevel) {
+uint64 Client::CalcEXP(uint8 conlevel, bool ignore_mods) {
 
 	uint64 in_add_exp = EXP_FORMULA;
 
@@ -115,87 +115,82 @@ uint64 Client::CalcEXP(uint8 conlevel) {
 	float totalmod = 1.0;
 	float zemmod = 1.0;
 	//get modifiers
-	if(RuleR(Character, ExpMultiplier) >= 0){
+	if (RuleR(Character, ExpMultiplier) >= 0 && !ignore_mods) {
 		totalmod *= RuleR(Character, ExpMultiplier);
 	}
 
-	if(zone->newzone_data.zone_exp_multiplier >= 0){
+	if (zone->newzone_data.zone_exp_multiplier >= 0 && !ignore_mods) {
 		zemmod *= zone->newzone_data.zone_exp_multiplier;
 	}
 
-	if(RuleB(Character,UseRaceClassExpBonuses))
-	{
-		if(GetBaseRace() == HALFLING){
+	if (RuleB(Character,UseRaceClassExpBonuses) && !ignore_mods) {
+		if (GetBaseRace() == HALFLING) {
 			totalmod *= 1.05;
 		}
 
-		if(GetClass() == ROGUE || GetClass() == WARRIOR){
+		if ((GetClass() == ROGUE || GetClass() == WARRIOR) && !ignore_mods) {
 			totalmod *= 1.05;
 		}
 	}
 
-	if(zone->IsHotzone())
-	{
+	if (zone->IsHotzone() && !ignore_mods) {
 		totalmod += RuleR(Zone, HotZoneBonus);
 	}
 
 	in_add_exp = uint64(float(in_add_exp) * totalmod * zemmod);
 
-	if(RuleB(Character,UseXPConScaling))
-	{
+	if (RuleB(Character,UseXPConScaling)) {
 		if (conlevel != 0xFF) {
-			switch (conlevel)
-			{
-			case CON_GRAY:
-				in_add_exp = 0;
-				return 0;
-			case CON_GREEN:
-				in_add_exp = in_add_exp * RuleI(Character, GreenModifier) / 100;
-				break;
-			case CON_LIGHTBLUE:
-				in_add_exp = in_add_exp * RuleI(Character, LightBlueModifier)/100;
-				break;
-			case CON_BLUE:
-				in_add_exp = in_add_exp * RuleI(Character, BlueModifier)/100;
-				break;
-			case CON_WHITE:
-				in_add_exp = in_add_exp * RuleI(Character, WhiteModifier)/100;
-				break;
-			case CON_YELLOW:
-				in_add_exp = in_add_exp * RuleI(Character, YellowModifier)/100;
-				break;
-			case CON_RED:
-				in_add_exp = in_add_exp * RuleI(Character, RedModifier)/100;
-				break;
+			switch (conlevel) {
+				case CON_GRAY:
+					in_add_exp = 0;
+					return 0;
+				case CON_GREEN:
+					in_add_exp = in_add_exp * RuleI(Character, GreenModifier) / 100;
+					break;
+				case CON_LIGHTBLUE:
+					in_add_exp = in_add_exp * RuleI(Character, LightBlueModifier)/100;
+					break;
+				case CON_BLUE:
+					in_add_exp = in_add_exp * RuleI(Character, BlueModifier)/100;
+					break;
+				case CON_WHITE:
+					in_add_exp = in_add_exp * RuleI(Character, WhiteModifier)/100;
+					break;
+				case CON_YELLOW:
+					in_add_exp = in_add_exp * RuleI(Character, YellowModifier)/100;
+					break;
+				case CON_RED:
+					in_add_exp = in_add_exp * RuleI(Character, RedModifier)/100;
+					break;
 			}
 		}
 	}
 
 	float aatotalmod = 1.0;
-	if(zone->newzone_data.zone_exp_multiplier >= 0){
+	if (zone->newzone_data.zone_exp_multiplier >= 0) {
 		aatotalmod *= zone->newzone_data.zone_exp_multiplier;
 	}
 
 
 
-	if(RuleB(Character,UseRaceClassExpBonuses))
-	{
+	if (RuleB(Character,UseRaceClassExpBonuses)) {
 		if(GetBaseRace() == HALFLING){
 			aatotalmod *= 1.05;
 		}
 
-		if(GetClass() == ROGUE || GetClass() == WARRIOR){
+		if (GetClass() == ROGUE || GetClass() == WARRIOR) {
 			aatotalmod *= 1.05;
 		}
 	}
 
-	if(RuleB(Zone, LevelBasedEXPMods)){
-		if(zone->level_exp_mod[GetLevel()].ExpMod){
+	if (RuleB(Zone, LevelBasedEXPMods) && !ignore_mods) {
+		if (zone->level_exp_mod[GetLevel()].ExpMod) {
 			in_add_exp *= zone->level_exp_mod[GetLevel()].ExpMod;
 		}
 	}
 
-	if (RuleR(Character, FinalExpMultiplier) >= 0) {
+	if (RuleR(Character, FinalExpMultiplier) >= 0 && !ignore_mods) {
 		in_add_exp *= RuleR(Character, FinalExpMultiplier);
 	}
 

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -1597,9 +1597,14 @@ float Perl_Client_GetTargetRingZ(Client* self) // @categories Script Utility
 	return self->GetTargetRingZ();
 }
 
-uint32_t Perl_Client_CalcEXP(Client* self, uint8 conlevel)
+uint64_t Perl_Client_CalcEXP(Client* self, uint8 conlevel)
 {
 	return self->CalcEXP(conlevel);
+}
+
+uint64_t Perl_Client_CalcEXP(Client* self, uint8 conlevel, bool ignore_mods)
+{
+	return self->CalcEXP(conlevel, ignore_mods);
 }
 
 void Perl_Client_QuestReward(Client* self, Mob* mob) // @categories Currency and Points, Experience and Level, Inventory and Items, Faction
@@ -2914,7 +2919,8 @@ void perl_register_client()
 	package.add("AssignToInstance", &Perl_Client_AssignToInstance);
 	package.add("AutoSplitEnabled", &Perl_Client_AutoSplitEnabled);
 	package.add("BreakInvis", &Perl_Client_BreakInvis);
-	package.add("CalcEXP", &Perl_Client_CalcEXP);
+	package.add("CalcEXP", (uint64(*)(Client*, uint8))&Perl_Client_CalcEXP);
+	package.add("CalcEXP", (uint64(*)(Client*, uint8, bool))&Perl_Client_CalcEXP);
 	package.add("CalcPriceMod", (float(*)(Client*))&Perl_Client_CalcPriceMod);
 	package.add("CalcPriceMod", (float(*)(Client*, Mob*))&Perl_Client_CalcPriceMod);
 	package.add("CalcPriceMod", (float(*)(Client*, Mob*, bool))&Perl_Client_CalcPriceMod);


### PR DESCRIPTION
Adds additional overload for Perl quest API. 

$client->CalcExp(uint8 conlevel, bool ignore_mods)