### PR TITLE
[Rules] Add Rule to restrict too powerful NPC buffs.

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -426,6 +426,7 @@ RULE_BOOL(Spells, BuffsFadeOnDeath, true, "Disable to keep buffs from fading on 
 RULE_BOOL(Spells, IllusionsAlwaysPersist, false, "Allows Illusions to persist beyond death and zoning always.")
 RULE_BOOL(Spells, UseItemCastMessage, false, "Enable to use the \"item begins to glow\" messages when casting from an item.")
 RULE_BOOL(Spells, TargetsTargetRequiresCombatRange, true, "Disable to remove combat range requirement from Target's Target Spell Target Type")
+RULE_BOOL(Spells, NPCBuffLevelRestrictions, false, "Impose BuffLevelRestrictions on NPCs if true")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Combat)

--- a/zone/client.h
+++ b/zone/client.h
@@ -561,7 +561,6 @@ public:
 
 	int32 GetActSpellCost(uint16 spell_id, int32);
 	virtual bool CheckFizzle(uint16 spell_id);
-	virtual bool CheckSpellLevelRestriction(Mob *caster, uint16 spell_id);
 	virtual int GetCurrentBuffSlots() const;
 	virtual int GetCurrentSongSlots() const;
 	virtual int GetCurrentDiscSlots() const { return 1; }

--- a/zone/client.h
+++ b/zone/client.h
@@ -561,6 +561,7 @@ public:
 
 	int32 GetActSpellCost(uint16 spell_id, int32);
 	virtual bool CheckFizzle(uint16 spell_id);
+	virtual bool CheckSpellLevelRestriction(Mob *caster, uint16 spell_id);
 	virtual int GetCurrentBuffSlots() const;
 	virtual int GetCurrentSongSlots() const;
 	virtual int GetCurrentDiscSlots() const { return 1; }

--- a/zone/client.h
+++ b/zone/client.h
@@ -561,7 +561,6 @@ public:
 
 	int32 GetActSpellCost(uint16 spell_id, int32);
 	virtual bool CheckFizzle(uint16 spell_id);
-	virtual bool CheckSpellLevelRestriction(uint16 spell_id);
 	virtual int GetCurrentBuffSlots() const;
 	virtual int GetCurrentSongSlots() const;
 	virtual int GetCurrentDiscSlots() const { return 1; }

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -370,7 +370,7 @@ public:
 	bool DoCastingChecksZoneRestrictions(bool check_on_casting, int32 spell_id);
 	bool DoCastingChecksOnTarget(bool check_on_casting, int32 spell_id, Mob* spell_target);
 	virtual bool CheckFizzle(uint16 spell_id);
-	virtual bool CheckSpellLevelRestriction(uint16 spell_id);
+	virtual bool CheckSpellLevelRestriction(Mob *caster, uint16 spell_id);
 	virtual bool IsImmuneToSpell(uint16 spell_id, Mob *caster);
 	virtual float GetAOERange(uint16 spell_id);
 	void InterruptSpell(uint16 spellid = SPELL_UNKNOWN);

--- a/zone/pets.cpp
+++ b/zone/pets.cpp
@@ -735,6 +735,15 @@ bool ZoneDatabase::GetBasePetItems(int32 equipmentset, uint32 *items) {
 	return true;
 }
 
+bool Pet::CheckSpellLevelRestriction(Mob *caster, uint16 spell_id)
+{
+	auto owner = GetOwner();
+	if (owner) {
+		return owner->CheckSpellLevelRestriction(caster, spell_id);
+	}
+	return true;
+}
+
 BeastlordPetData::PetStruct ZoneDatabase::GetBeastlordPetData(uint16 race_id) {
 	BeastlordPetData::PetStruct beastlord_pet_data;
 	std::string query = fmt::format(

--- a/zone/pets.cpp
+++ b/zone/pets.cpp
@@ -735,14 +735,6 @@ bool ZoneDatabase::GetBasePetItems(int32 equipmentset, uint32 *items) {
 	return true;
 }
 
-bool Pet::CheckSpellLevelRestriction(uint16 spell_id)
-{
-	auto owner = GetOwner();
-	if (owner)
-		return owner->CheckSpellLevelRestriction(spell_id);
-	return true;
-}
-
 BeastlordPetData::PetStruct ZoneDatabase::GetBeastlordPetData(uint16 race_id) {
 	BeastlordPetData::PetStruct beastlord_pet_data;
 	std::string query = fmt::format(

--- a/zone/pets.h
+++ b/zone/pets.h
@@ -7,7 +7,7 @@ struct NPCType;
 class Pet : public NPC {
 	public:
 		Pet(NPCType *type_data, Mob *owner, PetType type, uint16 spell_id, int16 power);
-		virtual bool CheckSpellLevelRestriction(uint16 spell_id);
+		virtual bool CheckSpellLevelRestriction(Mob *caster, uint16 spell_id);
 
 	};
 

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3218,19 +3218,19 @@ bool Mob::CheckSpellLevelRestriction(Mob *caster, uint16 spell_id)
 	}
 
 	if (check_for_restrictions) {
-		int SpellLevel = GetMinLevel(spell_id);
+		int spell_level = GetMinLevel(spell_id);
 
 		// Only check for beneficial buffs
 		if (IsBuffSpell(spell_id) && IsBeneficialSpell(spell_id)) {
-			if (SpellLevel > 65) {
+			if (spell_level > 65) {
 				if (IsGroupSpell(spell_id) && GetLevel() < 62) {
 					can_cast = false;
 				}
 				else if (GetLevel() < 61) {
 					can_cast = false;
 				}
-			} else if (SpellLevel > 50) { // 51-65
-				if (GetLevel() < (SpellLevel / 2 + 15)) {
+			} else if (spell_level > 50) { // 51-65
+				if (GetLevel() < (spell_level / 2 + 15)) {
 					can_cast = false;
 				}
 			}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -1153,7 +1153,7 @@ void Mob::InterruptSpell(uint16 message, uint16 color, uint16 spellid)
 	}
 
 	if(IsNPC()) {
-		CastToNPC()->AI_Event_SpellCastFinished(false, CastingSlot::Gem1);
+		CastToNPC()->AI_Event_SpellCastFinished(false, 1);
 	}
 
 	if(casting_spell_aa_id && IsClient()) { //Rest AA Timer on failed cast

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3240,7 +3240,7 @@ bool Mob::CheckSpellLevelRestriction(Mob *caster, uint16 spell_id)
 	if (!can_cast) {
 		LogSpells("Spell [{}] failed: recipient did not meet the level restrictions", spell_id);
 		if (!IsBardSong(spell_id)) {
-			MessageString(Chat::SpellFailure, SPELL_TOO_POWERFUL);
+			caster->MessageString(Chat::SpellFailure, SPELL_TOO_POWERFUL);
 		}
 	}
 

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -1152,8 +1152,8 @@ void Mob::InterruptSpell(uint16 message, uint16 color, uint16 spellid)
 		}
 	}
 
-	if(casting_spell_id && IsNPC()) {
-		CastToNPC()->AI_Event_SpellCastFinished(false, static_cast<uint16>(casting_spell_slot));
+	if(IsNPC()) {
+		CastToNPC()->AI_Event_SpellCastFinished(false, CastingSlot::Gem1);
 	}
 
 	if(casting_spell_aa_id && IsClient()) { //Rest AA Timer on failed cast
@@ -3206,6 +3206,11 @@ bool Mob::CheckSpellLevelRestriction(Mob *caster, uint16 spell_id)
 	bool check_for_restrictions = false;
 	bool can_cast = true;
 
+	if (!caster) {
+		LogSpells("CheckSpellLevelRestriction: No caster");
+		return false;
+	}
+
 	// NON GM clients might be restricted by rule setting
 	if (caster->IsClient()) {
 		if (RuleB(Spells, BuffLevelRestrictions) && !caster->CastToClient()->GetGM()) {
@@ -3241,6 +3246,9 @@ bool Mob::CheckSpellLevelRestriction(Mob *caster, uint16 spell_id)
 		LogSpells("Spell [{}] failed: recipient did not meet the level restrictions", spell_id);
 		if (!IsBardSong(spell_id)) {
 			caster->MessageString(Chat::SpellFailure, SPELL_TOO_POWERFUL);
+			if (!caster->IsClient()) {
+				caster->InterruptSpell();
+			}
 		}
 	}
 

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -801,7 +801,7 @@ bool Mob::DoCastingChecksOnTarget(bool check_on_casting, int32 spell_id, Mob *sp
 		Prevent buffs from being cast on targets who don't meet level restriction
 	*/
 
-	if (!spell_target->CheckSpellLevelRestriction(spell_id)) {
+	if (!spell_target->CheckSpellLevelRestriction(this, spell_id)) {
 		return false;
 	}
 	/*
@@ -3201,14 +3201,14 @@ int Mob::CheckStackConflict(uint16 spellid1, int caster_level1, uint16 spellid2,
 // spells 1-50: no restrictons
 // 51-65: SpellLevel/2+15
 // 66+ Group Spells 62, Single Target 61
-bool Mob::CheckSpellLevelRestriction(uint16 spell_id)
+bool Mob::CheckSpellLevelRestriction(Mob *caster, uint16 spell_id)
 {
 	bool check_for_restrictions = false;
 	bool can_cast = true;
 
 	// NON GM clients might be restricted by rule setting
-	if (IsClient()) {
-		if (RuleB(Spells, BuffLevelRestrictions) && !CastToClient()->GetGM()) {
+	if (caster->IsClient()) {
+		if (RuleB(Spells, BuffLevelRestrictions) && !caster->CastToClient()->GetGM()) {
 			check_for_restrictions = true;
 		}
 	}
@@ -4187,7 +4187,7 @@ bool Mob::SpellOnTarget(
 	}
 
 	// make sure spelltar is high enough level for the buff
-	if (!spelltar->CheckSpellLevelRestriction(spell_id)) {
+	if (!spelltar->CheckSpellLevelRestriction(this, spell_id)) {
 		safe_delete(action_packet);
 		return false;
 	}


### PR DESCRIPTION
Added a new rule (false by default to retain existing behavior) to allow server ops to restrict NPC casted buffs using the same logic as PC restricted buffs.

Restructured the code a bit to centralize duplicate code and clarify.