### PR TITLE
[Rule] Add rule for NPC Level Based Buff Restrictions.

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -426,6 +426,7 @@ RULE_BOOL(Spells, BuffsFadeOnDeath, true, "Disable to keep buffs from fading on 
 RULE_BOOL(Spells, IllusionsAlwaysPersist, false, "Allows Illusions to persist beyond death and zoning always.")
 RULE_BOOL(Spells, UseItemCastMessage, false, "Enable to use the \"item begins to glow\" messages when casting from an item.")
 RULE_BOOL(Spells, TargetsTargetRequiresCombatRange, true, "Disable to remove combat range requirement from Target's Target Spell Target Type")
+RULE_BOOL(Spells, NPCBuffLevelRestrictions, false, "Impose BuffLevelRestrictions on NPCs if true")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Combat)

--- a/zone/client.h
+++ b/zone/client.h
@@ -561,7 +561,6 @@ public:
 
 	int32 GetActSpellCost(uint16 spell_id, int32);
 	virtual bool CheckFizzle(uint16 spell_id);
-	virtual bool CheckSpellLevelRestriction(uint16 spell_id);
 	virtual int GetCurrentBuffSlots() const;
 	virtual int GetCurrentSongSlots() const;
 	virtual int GetCurrentDiscSlots() const { return 1; }

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -373,7 +373,7 @@ public:
 	bool DoCastingChecksZoneRestrictions(bool check_on_casting, int32 spell_id);
 	bool DoCastingChecksOnTarget(bool check_on_casting, int32 spell_id, Mob* spell_target);
 	virtual bool CheckFizzle(uint16 spell_id);
-	virtual bool CheckSpellLevelRestriction(uint16 spell_id);
+	virtual bool CheckSpellLevelRestriction(Mob *caster, uint16 spell_id);
 	virtual bool IsImmuneToSpell(uint16 spell_id, Mob *caster);
 	virtual float GetAOERange(uint16 spell_id);
 	void InterruptSpell(uint16 spellid = SPELL_UNKNOWN);

--- a/zone/pets.cpp
+++ b/zone/pets.cpp
@@ -735,11 +735,11 @@ bool ZoneDatabase::GetBasePetItems(int32 equipmentset, uint32 *items) {
 	return true;
 }
 
-bool Pet::CheckSpellLevelRestriction(uint16 spell_id)
+bool Pet::CheckSpellLevelRestriction(Mob *caster, uint16 spell_id)
 {
 	auto owner = GetOwner();
 	if (owner)
-		return owner->CheckSpellLevelRestriction(spell_id);
+		return owner->CheckSpellLevelRestriction(caster, spell_id);
 	return true;
 }
 

--- a/zone/pets.h
+++ b/zone/pets.h
@@ -7,7 +7,7 @@ struct NPCType;
 class Pet : public NPC {
 	public:
 		Pet(NPCType *type_data, Mob *owner, PetType type, uint16 spell_id, int16 power);
-		virtual bool CheckSpellLevelRestriction(uint16 spell_id);
+		virtual bool CheckSpellLevelRestriction(Mob *caster, uint16 spell_id);
 
 	};
 

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3215,9 +3215,14 @@ bool Mob::CheckSpellLevelRestriction(Mob *caster, uint16 spell_id)
 		return false;
 	}
 
+	if (caster->IsClient() && caster->CastToClient()->GetGM()) {
+		LogSpells("[CheckSpellLevelRestriction] GM casting - No restrictions");
+		return true;
+	}
+
 	// NON GM clients might be restricted by rule setting
 	if (caster->IsClient()) {
-		if (RuleB(Spells, BuffLevelRestrictions) && !caster->CastToClient()->GetGM()) {
+		if (RuleB(Spells, BuffLevelRestrictions)) {
 			check_for_restrictions = true;
 		}
 	}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -1149,7 +1149,7 @@ void Mob::InterruptSpell(uint16 message, uint16 color, uint16 spellid)
 			bard_song_mode = true;
 		} else {
 			spellid = casting_spell_id;
-		} 
+		}
 	}
 
 	LogSpells("Interrupt: casting_spell_id [{}] casting_spell_slot [{}]",

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -734,10 +734,6 @@ bool Mob::DoCastingChecksOnTarget(bool check_on_casting, int32 spell_id, Mob *sp
 	*/
 
 	bool ignore_on_casting = false;
-	bool ignore_if_npc_or_gm = false;
-	if (!IsClient() || (IsClient() && CastToClient()->GetGM())) {
-		ignore_if_npc_or_gm = true;
-	}
 
 	if (check_on_casting){
 
@@ -804,15 +800,9 @@ bool Mob::DoCastingChecksOnTarget(bool check_on_casting, int32 spell_id, Mob *sp
 	/*
 		Prevent buffs from being cast on targets who don't meet level restriction
 	*/
-	if (!ignore_if_npc_or_gm && RuleB(Spells, BuffLevelRestrictions)) {
-		// casting_spell_targetid is guaranteed to be what we went, check for ST_Self for now should work though
-		if (spells[spell_id].target_type != ST_Self && !spell_target->CheckSpellLevelRestriction(spell_id)) {
-			LogSpells("Spell [{}] failed: recipient did not meet the level restrictions", spell_id);
-			if (!IsBardSong(spell_id)) {
-				MessageString(Chat::SpellFailure, SPELL_TOO_POWERFUL);
-			}
-			return false;
-		}
+
+	if (!spell_target->CheckSpellLevelRestriction(this, spell_id)) {
+		return false;
 	}
 	/*
 		Prevents buff from being cast based on tareget ing PC OR NPC (1 = PCs, 2 = NPCs)
@@ -1159,8 +1149,11 @@ void Mob::InterruptSpell(uint16 message, uint16 color, uint16 spellid)
 			bard_song_mode = true;
 		} else {
 			spellid = casting_spell_id;
-		}
+		} 
 	}
+
+	LogSpells("Interrupt: casting_spell_id [{}] casting_spell_slot [{}]",
+		casting_spell_id, (int) casting_spell_slot);
 
 	if(casting_spell_id && IsNPC()) {
 		CastToNPC()->AI_Event_SpellCastFinished(false, static_cast<uint16>(casting_spell_slot));
@@ -1276,8 +1269,9 @@ void Mob::StopCastSpell(int32 spell_id, bool send_spellbar_enable)
 		-AA that fail at CastSpell because they never get timer set.
 		-Instant cast items that fail at CastSpell because they never get timer set.
 	*/
-	if (casting_spell_id && IsNPC()) {
-		CastToNPC()->AI_Event_SpellCastFinished(false, static_cast<uint16>(casting_spell_slot));
+	// Often called before spell_id and slot are set.  For NPCs always update AI
+	if (IsNPC()) {
+		CastToNPC()->AI_Event_SpellCastFinished(false, 1);
 	}
 
 	if (send_spellbar_enable) {
@@ -3211,29 +3205,55 @@ int Mob::CheckStackConflict(uint16 spellid1, int caster_level1, uint16 spellid2,
 // spells 1-50: no restrictons
 // 51-65: SpellLevel/2+15
 // 66+ Group Spells 62, Single Target 61
-bool Mob::CheckSpellLevelRestriction(uint16 spell_id)
+bool Mob::CheckSpellLevelRestriction(Mob *caster, uint16 spell_id)
 {
-	return true;
-}
+	bool check_for_restrictions = false;
+	bool can_cast = true;
 
-bool Client::CheckSpellLevelRestriction(uint16 spell_id)
-{
-	int SpellLevel = GetMinLevel(spell_id);
+	if (!caster) {
+		LogSpells("CheckSpellLevelRestriction: No caster");
+		return false;
+	}
 
-	// Only check for beneficial buffs
-	if (IsBuffSpell(spell_id) && IsBeneficialSpell(spell_id)) {
-		if (SpellLevel > 65) {
-			if (IsGroupSpell(spell_id) && GetLevel() < 62)
-				return false;
-			else if (GetLevel() < 61)
-				return false;
-		} else if (SpellLevel > 50) { // 51-65
-			if (GetLevel() < (SpellLevel / 2 + 15))
-				return false;
+	// NON GM clients might be restricted by rule setting
+	if (caster->IsClient()) {
+		if (RuleB(Spells, BuffLevelRestrictions) && !caster->CastToClient()->GetGM()) {
+			check_for_restrictions = true;
+		}
+	}
+	// NPCS might be restricted by rule setting
+	else if (RuleB(Spells, NPCBuffLevelRestrictions)) {
+		check_for_restrictions = true;
+	}
+
+	if (check_for_restrictions) {
+		int spell_level = GetMinLevel(spell_id);
+
+		// Only check for beneficial buffs
+		if (IsBuffSpell(spell_id) && IsBeneficialSpell(spell_id)) {
+			if (spell_level > 65) {
+				if (IsGroupSpell(spell_id) && GetLevel() < 62) {
+					can_cast = false;
+				}
+				else if (GetLevel() < 61) {
+					can_cast = false;
+				}
+			} else if (spell_level > 50) { // 51-65
+				if (GetLevel() < (spell_level / 2 + 15)) {
+					can_cast = false;
+				}
+			}
 		}
 	}
 
-	return true;
+	if (!can_cast) {
+		LogSpells("Spell [{}] failed: recipient did not meet the level restrictions", spell_id);
+		if (!IsBardSong(spell_id)) {
+			caster->MessageString(Chat::SpellFailure, SPELL_TOO_POWERFUL);
+		}
+	}
+
+	return can_cast;
 }
 
 uint32 Mob::GetFirstBuffSlot(bool disc, bool song)
@@ -4176,12 +4196,7 @@ bool Mob::SpellOnTarget(
 	}
 
 	// make sure spelltar is high enough level for the buff
-	if (RuleB(Spells, BuffLevelRestrictions) && !spelltar->CheckSpellLevelRestriction(spell_id)) {
-		LogSpells("Spell [{}] failed: recipient did not meet the level restrictions", spell_id);
-		if (!IsBardSong(spell_id)) {
-			MessageString(Chat::SpellFailure, SPELL_TOO_POWERFUL);
-		}
-
+	if (!spelltar->CheckSpellLevelRestriction(this, spell_id)) {
 		safe_delete(action_packet);
 		return false;
 	}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3211,7 +3211,7 @@ bool Mob::CheckSpellLevelRestriction(Mob *caster, uint16 spell_id)
 	bool can_cast = true;
 
 	if (!caster) {
-		LogSpells("CheckSpellLevelRestriction: No caster");
+		LogSpells("[CheckSpellLevelRestriction] No caster");
 		return false;
 	}
 


### PR DESCRIPTION
Added a rule that allows server ops to apply "SPELL_TOO_POWERFUL" rule to NPCs just like PCs.

NPCBuffLevelRestrictions (default off to retain existing functionality)

While debuging this I found that NPC spells from the AI that fail in the CastSpell() portion of the spell casting chain do not recover ever - as the code relies on the casting_spell_id  and the spell slot to be valid in every function that calls the AI with AI_Event_SpellCastFinished.  As these variables are not set until later in the casting chain, the  AI was never getting reset.

This bug was much more obvious when setting my new rule, as NPC spells fail in the checking stage alot more.

This is a DRAFT PR until someone more adept with spells than I ok's the change.

I did test all the variant cases and it works, and I put a log locally if an NPC ever cast a spell not using slot 1 and I didnt see any.  Not sure that matters, but the AI only resets on slot 1, and since slot was not set, I pass in 1.