### PR TITLE
[Bug Fix] #npcstats command displying incorrect faction

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1693,7 +1693,7 @@ void Mob::ShowStats(Client* client)
 
 		// Faction
 		if (target->GetNPCFactionID()) {
-			auto faction_id = target->GetNPCFactionID();
+			auto faction_id = target->GetPrimaryFaction();
 			auto faction_name = content_db.GetFactionName(faction_id);
 			client->Message(
 				Chat::White,


### PR DESCRIPTION
GM command npcstats was displaying incorrect faction text.