### PR TITLE
[Bug Fix] Fix NPC Reference in EVENT_SPAWN

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -8760,14 +8760,14 @@ void EntityList::AddBot(Bot *new_bot, bool send_spawn_packet, bool dont_queue) {
 				AddToSpawnQueue(new_bot->GetID(), &ns);
 				safe_delete(ns);
 			}
-
-			new_bot->DispatchZoneControllerEvent(EVENT_SPAWN_ZONE, new_bot, "", 0, nullptr);
 		}
 
 		bot_list.push_back(new_bot);
 		mob_list.insert(std::pair<uint16, Mob*>(new_bot->GetID(), new_bot));
 
 		parse->EventBot(EVENT_SPAWN, new_bot, nullptr, "", 0);
+		
+		new_bot->DispatchZoneControllerEvent(EVENT_SPAWN_ZONE, new_bot, "", 0, nullptr);
 	}
 }
 

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -8761,13 +8761,13 @@ void EntityList::AddBot(Bot *new_bot, bool send_spawn_packet, bool dont_queue) {
 				safe_delete(ns);
 			}
 
-			parse->EventBot(EVENT_SPAWN, new_bot, nullptr, "", 0);
-
 			new_bot->DispatchZoneControllerEvent(EVENT_SPAWN_ZONE, new_bot, "", 0, nullptr);
 		}
 
 		bot_list.push_back(new_bot);
 		mob_list.insert(std::pair<uint16, Mob*>(new_bot->GetID(), new_bot));
+
+		parse->EventBot(EVENT_SPAWN, new_bot, nullptr, "", 0);
 	}
 }
 

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -278,7 +278,7 @@ public:
 	bool	MakeTrackPacket(Client* client);
 	void	SendTraders(Client* client);
 	void	AddClient(Client*);
-	void	AddNPC(NPC*, bool SendSpawnPacket = true, bool dontqueue = false);
+	void	AddNPC(NPC*, bool send_spawn_packet = true, bool dont_queue = false);
 	void	AddMerc(Merc*, bool SendSpawnPacket = true, bool dontqueue = false);
 	void	AddCorpse(Corpse* pc, uint32 in_id = 0xFFFFFFFF);
 	void	AddObject(Object*, bool SendSpawnPacket = true);


### PR DESCRIPTION
# Notes
- Event parsing was too early and memory wasn't fully allocated, meaning that sometimes you could use the NPC reference and other times you couldn't.
- Most people worked around this by setting timers in `EVENT_SPAWN` then using `EVENT_TIMER` to handle the stuff they wanted to do on spawn.

# Example Code in Perl
```pl
sub EVENT_SPAWN {
	quest::shout($npc->GetCleanName() . " just spawned with an ID of " . $npc->GetID() . " and an NPC Type ID of " . $npc->GetNPCTypeID() . ".");
}
```

# Screenshot
![image](https://user-images.githubusercontent.com/89047260/211206056-5457bef9-5802-4e5d-b12a-3b74b3f57182.png)