### PR TITLE
[Quest API] Add EVENT_BOT_CREATE to Perl/Lua

### DIFF
--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -9907,6 +9907,18 @@ uint32 helper_bot_create(Client *bot_owner, std::string bot_name, uint8 bot_clas
 	);
 
 	bot_id = my_bot->GetBotID();
+
+	const auto export_string = fmt::format(
+		"{} {} {} {} {}",
+		bot_name,
+		bot_id,
+		bot_race,
+		bot_class,
+		bot_gender
+	);
+
+	parse->EventPlayer(EVENT_BOT_CREATE, bot_owner, export_string, 0);
+
 	safe_delete(my_bot);
 
 	return bot_id;

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -168,10 +168,9 @@ const char *QuestEventSubroutines[_LargestEventID] = {
 	"EVENT_GM_COMMAND",
 	"EVENT_DESPAWN",
 	"EVENT_DESPAWN_ZONE",
-#ifdef BOTS
 	"EVENT_SPELL_EFFECT_BOT",
 	"EVENT_SPELL_EFFECT_BUFF_TIC_BOT",
-#endif
+	"EVENT_BOT_CREATE"
 };
 
 PerlembParser::PerlembParser() : perl(nullptr)
@@ -1120,14 +1119,10 @@ void PerlembParser::GetQuestTypes(
 	if (
 		event == EVENT_SPELL_EFFECT_CLIENT ||
 		event == EVENT_SPELL_EFFECT_NPC ||
-#ifdef BOTS
 		event == EVENT_SPELL_EFFECT_BOT ||
-#endif
 		event == EVENT_SPELL_EFFECT_BUFF_TIC_CLIENT ||
 		event == EVENT_SPELL_EFFECT_BUFF_TIC_NPC ||
-#ifdef BOTS
 		event == EVENT_SPELL_EFFECT_BUFF_TIC_BOT ||
-#endif
 		event == EVENT_SPELL_FADE ||
 		event == EVENT_SPELL_EFFECT_TRANSLOCATE_COMPLETE
 	) {
@@ -1573,14 +1568,12 @@ void PerlembParser::ExportEventVariables(
 			perl->eval(fmt::format("++${}{{${}::item3}};", hash_name, package_name).c_str());
 			perl->eval(fmt::format("++${}{{${}::item4}};", hash_name, package_name).c_str());
 
-#ifdef BOTS
 			if (npcmob->IsBot()) {
 				perl->eval(fmt::format("++${}{{${}::item5}};", hash_name, package_name).c_str());
 				perl->eval(fmt::format("++${}{{${}::item6}};", hash_name, package_name).c_str());
 				perl->eval(fmt::format("++${}{{${}::item7}};", hash_name, package_name).c_str());
 				perl->eval(fmt::format("++${}{{${}::item8}};", hash_name, package_name).c_str());
 			}
-#endif
 
 			break;
 		}
@@ -1754,14 +1747,10 @@ void PerlembParser::ExportEventVariables(
 		}
 
 
-#ifdef BOTS
 		case EVENT_SPELL_EFFECT_BUFF_TIC_BOT:
-#endif
 		case EVENT_SPELL_EFFECT_BUFF_TIC_CLIENT:
 		case EVENT_SPELL_EFFECT_BUFF_TIC_NPC:
-#ifdef BOTS
 		case EVENT_SPELL_EFFECT_BOT:
-#endif
 		case EVENT_SPELL_EFFECT_CLIENT:
 		case EVENT_SPELL_EFFECT_NPC:
 		case EVENT_SPELL_FADE: {
@@ -2049,6 +2038,16 @@ void PerlembParser::ExportEventVariables(
 #endif
 			}
 
+			break;
+		}
+
+		case EVENT_BOT_CREATE: {
+			Seperator sep(data);
+			ExportVar(package_name.c_str(), "bot_name", sep.arg[0]);
+			ExportVar(package_name.c_str(), "bot_id", sep.arg[1]);
+			ExportVar(package_name.c_str(), "bot_race", sep.arg[2]);
+			ExportVar(package_name.c_str(), "bot_class", sep.arg[3]);
+			ExportVar(package_name.c_str(), "bot_gender", sep.arg[4]);
 			break;
 		}
 

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -168,9 +168,9 @@ const char *QuestEventSubroutines[_LargestEventID] = {
 	"EVENT_GM_COMMAND",
 	"EVENT_DESPAWN",
 	"EVENT_DESPAWN_ZONE",
-	"EVENT_SPELL_EFFECT_BOT",
-	"EVENT_SPELL_EFFECT_BUFF_TIC_BOT",
-	"EVENT_BOT_CREATE"
+	"EVENT_BOT_CREATE",
+	"EVENT_SPELL_EFFECT_BOT", // Add new events before this or Lua crashes
+	"EVENT_SPELL_EFFECT_BUFF_TIC_BOT"
 };
 
 PerlembParser::PerlembParser() : perl(nullptr)

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -169,7 +169,7 @@ const char *QuestEventSubroutines[_LargestEventID] = {
 	"EVENT_DESPAWN",
 	"EVENT_DESPAWN_ZONE",
 	"EVENT_BOT_CREATE",
-	"EVENT_SPELL_EFFECT_BOT", // Add new events before this or Lua crashes
+	"EVENT_SPELL_EFFECT_BOT", // Add new events before these or Lua crashes
 	"EVENT_SPELL_EFFECT_BUFF_TIC_BOT"
 };
 

--- a/zone/event_codes.h
+++ b/zone/event_codes.h
@@ -111,10 +111,9 @@ typedef enum {
 	EVENT_GM_COMMAND,
 	EVENT_DESPAWN,
 	EVENT_DESPAWN_ZONE,
-#ifdef BOTS
-	EVENT_SPELL_EFFECT_BOT,
+	EVENT_BOT_CREATE,
+	EVENT_SPELL_EFFECT_BOT, // Add new events before these or Lua crashes
 	EVENT_SPELL_EFFECT_BUFF_TIC_BOT,
-#endif
 	_LargestEventID
 } QuestEventID;
 

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -4617,7 +4617,8 @@ luabind::scope lua_register_events() {
 			luabind::value("level_down", static_cast<int>(EVENT_LEVEL_DOWN)),
 			luabind::value("gm_command", static_cast<int>(EVENT_GM_COMMAND)),
 			luabind::value("despawn", static_cast<int>(EVENT_DESPAWN)),
-			luabind::value("despawn_zone", static_cast<int>(EVENT_DESPAWN_ZONE))
+			luabind::value("despawn_zone", static_cast<int>(EVENT_DESPAWN_ZONE)),
+			luabind::value("bot_create", static_cast<int>(EVENT_BOT_CREATE))
 		)];
 }
 

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -155,6 +155,7 @@ const char *LuaEvents[_LargestEventID] = {
 	"event_gm_command",
 	"event_despawn",
 	"event_despawn_zone",
+	"event_bot_create",
 };
 
 extern Zone *zone;
@@ -269,6 +270,7 @@ LuaParser::LuaParser() {
 	PlayerArgumentDispatch[EVENT_LEVEL_UP] = handle_player_level_up;
 	PlayerArgumentDispatch[EVENT_LEVEL_DOWN] = handle_player_level_down;
 	PlayerArgumentDispatch[EVENT_GM_COMMAND] = handle_player_gm_command;
+	PlayerArgumentDispatch[EVENT_BOT_CREATE] = handle_player_bot_create;
 
 	ItemArgumentDispatch[EVENT_ITEM_CLICK] = handle_item_click;
 	ItemArgumentDispatch[EVENT_ITEM_CLICK_CAST] = handle_item_click;
@@ -1399,16 +1401,12 @@ QuestEventID LuaParser::ConvertLuaEvent(QuestEventID evt) {
 	case EVENT_NPC_SLAY:
 		return EVENT_SLAY;
 		break;
-#ifdef BOTS
 	case EVENT_SPELL_EFFECT_BOT:
-#endif
 	case EVENT_SPELL_EFFECT_CLIENT:
 	case EVENT_SPELL_EFFECT_NPC:
 		return EVENT_SPELL_EFFECT_CLIENT;
 		break;
-#ifdef BOTS
 	case EVENT_SPELL_EFFECT_BUFF_TIC_BOT:
-#endif
 	case EVENT_SPELL_EFFECT_BUFF_TIC_CLIENT:
 	case EVENT_SPELL_EFFECT_BUFF_TIC_NPC:
 		return EVENT_SPELL_EFFECT_BUFF_TIC_CLIENT;

--- a/zone/lua_parser_events.cpp
+++ b/zone/lua_parser_events.cpp
@@ -1128,6 +1128,31 @@ void handle_player_gm_command(
 	lua_setfield(L, -2, "message");
 }
 
+void handle_player_bot_create(
+	QuestInterface *parse,
+	lua_State* L,
+	Client* client,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any> *extra_pointers
+) {
+	Seperator sep(data.c_str());
+	lua_pushstring(L, sep.arg[0]);
+	lua_setfield(L, -2, "bot_name");
+
+	lua_pushinteger(L, std::stoi(sep.arg[1]));
+	lua_setfield(L, -2, "bot_id");
+
+	lua_pushinteger(L, std::stoi(sep.arg[2]));
+	lua_setfield(L, -2, "bot_race");
+
+	lua_pushinteger(L, std::stoi(sep.arg[3]));
+	lua_setfield(L, -2, "bot_class");
+
+	lua_pushinteger(L, std::stoi(sep.arg[4]));
+	lua_setfield(L, -2, "bot_gender");
+}
+
 // Item
 void handle_item_click(
 	QuestInterface *parse,

--- a/zone/lua_parser_events.h
+++ b/zone/lua_parser_events.h
@@ -618,6 +618,15 @@ void handle_player_gm_command(
 	std::vector<std::any> *extra_pointers
 );
 
+void handle_player_bot_create(
+	QuestInterface *parse,
+	lua_State* L,
+	Client* client,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any> *extra_pointers
+);
+
 
 // Item
 void handle_item_click(

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -2426,6 +2426,17 @@ bool QuestManager::createBot(const char *name, const char *lastname, uint8 level
 						new_bot->GetBotID()
 					).c_str()
 				);
+
+				const auto export_string = fmt::format(
+					"{} {} {} {} {}",
+					name,
+					new_bot->GetBotID(),
+					race,
+					botclass,
+					gender
+				);
+
+				parse->EventPlayer(EVENT_BOT_CREATE, initiator, export_string, 0);
 				return true;
 			}
 		}

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -179,13 +179,11 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 			CalcBonuses();
 			return true;
 		}
-#ifdef BOTS
 	} else if (IsBot()) {
 		if (parse->EventSpell(EVENT_SPELL_EFFECT_BOT, this, nullptr, spell_id, export_string, 0) != 0) {
 			CalcBonuses();
 			return true;
 		}
-#endif
 	}
 
 	if(IsVirusSpell(spell_id)) {
@@ -3793,12 +3791,10 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 		if (parse->EventSpell(EVENT_SPELL_EFFECT_BUFF_TIC_NPC, this, nullptr, buff.spellid, export_string, 0) != 0) {
 			return;
 		}
-#ifdef BOTS
 	} else if (IsBot()) {
 		if (parse->EventSpell(EVENT_SPELL_EFFECT_BUFF_TIC_BOT, this, nullptr, buff.spellid, export_string, 0) != 0) {
 			return;
 		}
-#endif
 	}
 
 	for (int i = 0; i < EFFECT_COUNT; i++) {


### PR DESCRIPTION
# Perl
- Add `EVENT_BOT_CREATE`.
- Exports `$bot_id`, `$bot_name`, `$bot_class`, `$bot_race`, and `$bot_gender`.

# Lua
- Add `event_bot_create`.
- Exports `e.bot_id`, `e.bot_name`, `e.bot_class`, `e.bot_race`, and `e.bot_gender`.