### PR TITLE
[Bot] Add GetBotOwnerByBotID Method

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -8752,18 +8752,29 @@ Bot* EntityList::GetBotByBotName(std::string botName) {
 	return Result;
 }
 
-Client* EntityList::GetBotOwnerByBotEntityID(uint16 entityID) {
-	Client* Result = nullptr;
-	if (entityID > 0) {
+Client* EntityList::GetBotOwnerByBotEntityID(uint32 entityID) {
+	Client* c = nullptr;
+	if (entityID) {
 		for (std::list<Bot*>::iterator botListItr = bot_list.begin(); botListItr != bot_list.end(); ++botListItr) {
 			Bot* tempBot = *botListItr;
 			if (tempBot && tempBot->GetID() == entityID) {
-				Result = tempBot->GetBotOwner()->CastToClient();
+				c = tempBot->GetBotOwner()->CastToClient();
 				break;
 			}
 		}
 	}
-	return Result;
+	return c;
+}
+
+Client* EntityList::GetBotOwnerByBotID(const uint32 bot_id)  {
+	Client* c = nullptr;
+	if (bot_id) {
+		const auto owner_id = database.botdb.GetOwnerID(bot_id);
+		if (owner_id) {
+			c = GetClientByCharID(owner_id);
+		}
+	}
+	return c;
 }
 
 void EntityList::AddBot(Bot *new_bot, bool send_spawn_packet, bool dont_queue) {

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -8752,28 +8752,31 @@ Bot* EntityList::GetBotByBotName(std::string botName) {
 	return Result;
 }
 
-Client* EntityList::GetBotOwnerByBotEntityID(uint32 entityID) {
+Client* EntityList::GetBotOwnerByBotEntityID(uint32 entity_id) {
 	Client* c = nullptr;
-	if (entityID) {
-		for (std::list<Bot*>::iterator botListItr = bot_list.begin(); botListItr != bot_list.end(); ++botListItr) {
-			Bot* tempBot = *botListItr;
-			if (tempBot && tempBot->GetID() == entityID) {
-				c = tempBot->GetBotOwner()->CastToClient();
+
+	if (entity_id) {
+		for (const auto& b : bot_list) {
+			if (b && b->GetID() == entity_id) {
+				c = b->GetBotOwner()->CastToClient();
 				break;
 			}
 		}
 	}
+
 	return c;
 }
 
 Client* EntityList::GetBotOwnerByBotID(const uint32 bot_id)  {
 	Client* c = nullptr;
+
 	if (bot_id) {
 		const auto owner_id = database.botdb.GetOwnerID(bot_id);
 		if (owner_id) {
 			c = GetClientByCharID(owner_id);
 		}
 	}
+
 	return c;
 }
 
@@ -8801,7 +8804,7 @@ void EntityList::AddBot(Bot *new_bot, bool send_spawn_packet, bool dont_queue) {
 		mob_list.insert(std::pair<uint16, Mob*>(new_bot->GetID(), new_bot));
 
 		parse->EventBot(EVENT_SPAWN, new_bot, nullptr, "", 0);
-		
+
 		new_bot->DispatchZoneControllerEvent(EVENT_SPAWN_ZONE, new_bot, "", 0, nullptr);
 	}
 }

--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -319,6 +319,27 @@ bool BotDatabase::LoadOwnerID(const uint32 bot_id, uint32& owner_id)
 	return true;
 }
 
+uint32 BotDatabase::GetOwnerID(const uint32 bot_id)
+{
+	if (!bot_id) {
+		return 0;
+	}
+
+	query = StringFormat("SELECT `owner_id` FROM `bot_data` WHERE `bot_id` = '%u' LIMIT 1", bot_id);
+	auto results = database.QueryDatabase(query);
+	if (!results.Success()) {
+		return 0;
+	}
+	if (!results.RowCount()) {
+		return 0;
+	}
+
+	auto row = results.begin();
+	const auto owner_id = atoi(row[0]);
+
+	return owner_id;
+}
+
 bool BotDatabase::LoadBotID(const uint32 owner_id, const std::string& bot_name, uint32& bot_id)
 {
 	if (!owner_id || bot_name.empty()) {

--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -325,19 +325,12 @@ uint32 BotDatabase::GetOwnerID(const uint32 bot_id)
 		return 0;
 	}
 
-	query = StringFormat("SELECT `owner_id` FROM `bot_data` WHERE `bot_id` = '%u' LIMIT 1", bot_id);
-	auto results = database.QueryDatabase(query);
-	if (!results.Success()) {
-		return 0;
-	}
-	if (!results.RowCount()) {
+	const auto& l = BotDataRepository::FindOne(database, bot_id);
+	if (!l.bot_id) {
 		return 0;
 	}
 
-	auto row = results.begin();
-	const auto owner_id = atoi(row[0]);
-
-	return owner_id;
+	return l.owner_id;
 }
 
 bool BotDatabase::LoadBotID(const uint32 owner_id, const std::string& bot_name, uint32& bot_id)

--- a/zone/bot_database.h
+++ b/zone/bot_database.h
@@ -55,6 +55,7 @@ public:
 
 	bool LoadOwnerID(const std::string& bot_name, uint32& owner_id);
 	bool LoadOwnerID(const uint32 bot_id, uint32& owner_id);
+	uint32 GetOwnerID(const uint32 bot_id);
 	bool LoadBotID(const uint32 owner_id, const std::string& bot_name, uint32& bot_id);
 	bool LoadBotID(const uint32 owner_id, const std::string& bot_name, uint32& bot_id, uint8& bot_class_id);
 

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -2025,6 +2025,21 @@ void PerlembParser::ExportEventVariables(
 			break;
 		}
 
+		case EVENT_DESPAWN: {
+			ExportVar(package_name.c_str(), "despawned_entity_id", npcmob->GetID());
+
+			if (npcmob->IsNPC()) {
+				ExportVar(package_name.c_str(), "despawned_bot_id", 0);
+				ExportVar(package_name.c_str(), "despawned_npc_id", npcmob->GetNPCTypeID());
+#ifdef BOTS
+			} else if (npcmob->IsBot()) {
+				ExportVar(package_name.c_str(), "despawned_bot_id", npcmob->CastToBot()->GetBotID());
+				ExportVar(package_name.c_str(), "despawned_npc_id", 0);
+#endif
+			}
+
+			break;
+		}
 		case EVENT_DESPAWN_ZONE: {
 			ExportVar(package_name.c_str(), "despawned_entity_id", mob->GetID());
 

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -628,7 +628,8 @@ private:
 		Mob* GetMobByBotID(uint32 botID);
 		Bot* GetBotByBotID(uint32 botID);
 		Bot* GetBotByBotName(std::string botName);
-		Client* GetBotOwnerByBotEntityID(uint16 entityID);
+		Client* GetBotOwnerByBotEntityID(uint32 entityID);
+		Client* GetBotOwnerByBotID(const uint32 bot_id);
 		std::list<Bot*> GetBotsByBotOwnerCharacterID(uint32 botOwnerCharacterID);
 
 		bool Bot_AICheckCloseBeneficialSpells(Bot* caster, uint8 iChance, float iRange, uint32 iSpellTypes); // TODO: Evaluate this closesly in hopes to eliminate

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -628,7 +628,7 @@ private:
 		Mob* GetMobByBotID(uint32 botID);
 		Bot* GetBotByBotID(uint32 botID);
 		Bot* GetBotByBotName(std::string botName);
-		Client* GetBotOwnerByBotEntityID(uint32 entityID);
+		Client* GetBotOwnerByBotEntityID(uint32 entity_id);
 		Client* GetBotOwnerByBotID(const uint32 bot_id);
 		std::list<Bot*> GetBotsByBotOwnerCharacterID(uint32 botOwnerCharacterID);
 

--- a/zone/lua_entity_list.cpp
+++ b/zone/lua_entity_list.cpp
@@ -399,6 +399,11 @@ Lua_Bot_List Lua_EntityList::GetBotList() {
 	return ret;
 }
 
+Lua_Client Lua_EntityList::GetBotOwnerByBotID(uint32 bot_id) {
+	Lua_Safe_Call_Class(Lua_Client);
+	return Lua_Client(self->GetBotOwnerByBotID(bot_id));
+}
+
 Lua_Bot_List Lua_EntityList::GetBotListByCharacterID(uint32 character_id) {
 	Lua_Safe_Call_Class(Lua_Bot_List);
 	Lua_Bot_List ret;
@@ -649,6 +654,7 @@ luabind::scope lua_register_entity_list() {
 	.def("GetBotByID", (Lua_Bot(Lua_EntityList::*)(uint32))&Lua_EntityList::GetBotByID)
 	.def("GetBotByName", (Lua_Bot(Lua_EntityList::*)(std::string))&Lua_EntityList::GetBotByName)
 	.def("GetBotList", (Lua_Bot_List(Lua_EntityList::*)(void))&Lua_EntityList::GetBotList)
+	.def("GetBotOwnerByBotID", (Lua_Client(Lua_EntityList::*)(uint32))&Lua_EntityList::GetBotOwnerByBotID)
 	.def("GetBotListByCharacterID", (Lua_Bot_List(Lua_EntityList::*)(uint32))&Lua_EntityList::GetBotListByCharacterID)
 	.def("GetBotListByCharacterID", (Lua_Bot_List(Lua_EntityList::*)(uint32,uint8))&Lua_EntityList::GetBotListByCharacterID)
 	.def("GetBotListByClientName", (Lua_Bot_List(Lua_EntityList::*)(std::string))&Lua_EntityList::GetBotListByClientName)

--- a/zone/lua_entity_list.cpp
+++ b/zone/lua_entity_list.cpp
@@ -399,6 +399,11 @@ Lua_Bot_List Lua_EntityList::GetBotList() {
 	return ret;
 }
 
+Lua_Client Lua_EntityList::GetBotOwnerByBotEntityID(uint32 entity_id) {
+	Lua_Safe_Call_Class(Lua_Client);
+	return Lua_Client(self->GetBotOwnerByBotEntityID(entity_id));
+}
+
 Lua_Client Lua_EntityList::GetBotOwnerByBotID(uint32 bot_id) {
 	Lua_Safe_Call_Class(Lua_Client);
 	return Lua_Client(self->GetBotOwnerByBotID(bot_id));
@@ -654,6 +659,7 @@ luabind::scope lua_register_entity_list() {
 	.def("GetBotByID", (Lua_Bot(Lua_EntityList::*)(uint32))&Lua_EntityList::GetBotByID)
 	.def("GetBotByName", (Lua_Bot(Lua_EntityList::*)(std::string))&Lua_EntityList::GetBotByName)
 	.def("GetBotList", (Lua_Bot_List(Lua_EntityList::*)(void))&Lua_EntityList::GetBotList)
+	.def("GetBotOwnerByBotEntityID", (Lua_Client(Lua_EntityList::*)(uint32))&Lua_EntityList::GetBotOwnerByBotEntityID)
 	.def("GetBotOwnerByBotID", (Lua_Client(Lua_EntityList::*)(uint32))&Lua_EntityList::GetBotOwnerByBotID)
 	.def("GetBotListByCharacterID", (Lua_Bot_List(Lua_EntityList::*)(uint32))&Lua_EntityList::GetBotListByCharacterID)
 	.def("GetBotListByCharacterID", (Lua_Bot_List(Lua_EntityList::*)(uint32,uint8))&Lua_EntityList::GetBotListByCharacterID)

--- a/zone/lua_entity_list.h
+++ b/zone/lua_entity_list.h
@@ -133,6 +133,7 @@ public:
 #ifdef BOTS
 	Lua_Bot GetBotByID(uint32 bot_id);
 	Lua_Bot GetBotByName(std::string bot_name);
+	Lua_Client GetBotOwnerByBotEntityID(uint32 entity_id);
 	Lua_Client GetBotOwnerByBotID(uint32 bot_id);
 	Lua_Bot_List GetBotList();
 	Lua_Bot_List GetBotListByCharacterID(uint32 character_id);

--- a/zone/lua_entity_list.h
+++ b/zone/lua_entity_list.h
@@ -133,6 +133,7 @@ public:
 #ifdef BOTS
 	Lua_Bot GetBotByID(uint32 bot_id);
 	Lua_Bot GetBotByName(std::string bot_name);
+	Lua_Client GetBotOwnerByBotID(uint32 bot_id);
 	Lua_Bot_List GetBotList();
 	Lua_Bot_List GetBotListByCharacterID(uint32 character_id);
 	Lua_Bot_List GetBotListByCharacterID(uint32 character_id, uint8 class_id);

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -213,7 +213,6 @@ LuaParser::LuaParser() {
 	NPCArgumentDispatch[EVENT_LOOT_ZONE] = handle_npc_loot_zone;
 	NPCArgumentDispatch[EVENT_SPAWN_ZONE] = handle_npc_spawn_zone;
 	NPCArgumentDispatch[EVENT_PAYLOAD] = handle_npc_payload;
-	NPCArgumentDispatch[EVENT_DESPAWN] = handle_npc_despawn;
 	NPCArgumentDispatch[EVENT_DESPAWN_ZONE] = handle_npc_despawn_zone;
 
 	PlayerArgumentDispatch[EVENT_SAY] = handle_player_say;

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -213,6 +213,8 @@ LuaParser::LuaParser() {
 	NPCArgumentDispatch[EVENT_LOOT_ZONE] = handle_npc_loot_zone;
 	NPCArgumentDispatch[EVENT_SPAWN_ZONE] = handle_npc_spawn_zone;
 	NPCArgumentDispatch[EVENT_PAYLOAD] = handle_npc_payload;
+	NPCArgumentDispatch[EVENT_DESPAWN] = handle_npc_despawn;
+	NPCArgumentDispatch[EVENT_DESPAWN_ZONE] = handle_npc_despawn_zone;
 
 	PlayerArgumentDispatch[EVENT_SAY] = handle_player_say;
 	PlayerArgumentDispatch[EVENT_ENVIRONMENTAL_DAMAGE] = handle_player_environmental_damage;

--- a/zone/lua_parser_events.cpp
+++ b/zone/lua_parser_events.cpp
@@ -438,6 +438,36 @@ void handle_npc_spawn_zone(
 	lua_setfield(L, -2, "other");
 }
 
+void handle_npc_despawn(
+	QuestInterface *parse,
+	lua_State* L,
+	NPC* npc,
+	Mob *init,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any> *extra_pointers
+) {
+	Lua_Mob l_mob(init);
+	luabind::adl::object l_mob_o = luabind::adl::object(L, l_mob);
+	l_mob_o.push(L);
+	lua_setfield(L, -2, "other");
+}
+
+void handle_npc_despawn_zone(
+	QuestInterface *parse,
+	lua_State* L,
+	NPC* npc,
+	Mob *init,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any> *extra_pointers
+) {
+	Lua_Mob l_mob(init);
+	luabind::adl::object l_mob_o = luabind::adl::object(L, l_mob);
+	l_mob_o.push(L);
+	lua_setfield(L, -2, "other");
+}
+
 // Player
 void handle_player_say(
 	QuestInterface *parse,

--- a/zone/lua_parser_events.cpp
+++ b/zone/lua_parser_events.cpp
@@ -438,21 +438,6 @@ void handle_npc_spawn_zone(
 	lua_setfield(L, -2, "other");
 }
 
-void handle_npc_despawn(
-	QuestInterface *parse,
-	lua_State* L,
-	NPC* npc,
-	Mob *init,
-	std::string data,
-	uint32 extra_data,
-	std::vector<std::any> *extra_pointers
-) {
-	Lua_Mob l_mob(init);
-	luabind::adl::object l_mob_o = luabind::adl::object(L, l_mob);
-	l_mob_o.push(L);
-	lua_setfield(L, -2, "other");
-}
-
 void handle_npc_despawn_zone(
 	QuestInterface *parse,
 	lua_State* L,

--- a/zone/lua_parser_events.h
+++ b/zone/lua_parser_events.h
@@ -203,6 +203,26 @@ void handle_npc_payload(
 	std::vector<std::any> *extra_pointers
 );
 
+void handle_npc_despawn(
+	QuestInterface *parse,
+	lua_State* L,
+	NPC* npc,
+	Mob *init,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any> *extra_pointers
+);
+
+void handle_npc_despawn_zone(
+	QuestInterface *parse,
+	lua_State* L,
+	NPC* npc,
+	Mob *init,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any> *extra_pointers
+);
+
 // Player
 void handle_player_say(
 	QuestInterface *parse,

--- a/zone/lua_parser_events.h
+++ b/zone/lua_parser_events.h
@@ -203,16 +203,6 @@ void handle_npc_payload(
 	std::vector<std::any> *extra_pointers
 );
 
-void handle_npc_despawn(
-	QuestInterface *parse,
-	lua_State* L,
-	NPC* npc,
-	Mob *init,
-	std::string data,
-	uint32 extra_data,
-	std::vector<std::any> *extra_pointers
-);
-
 void handle_npc_despawn_zone(
 	QuestInterface *parse,
 	lua_State* L,

--- a/zone/perl_entity.cpp
+++ b/zone/perl_entity.cpp
@@ -406,6 +406,11 @@ Bot* Perl_EntityList_GetBotByName(EntityList* self, std::string bot_name) // @ca
 	return self->GetBotByBotName(bot_name);
 }
 
+Client* Perl_EntityList_GetBotOwnerByBotID(EntityList* self, uint32_t bot_id) // @categories Script Utility, Bot
+{
+	return self->GetBotOwnerByBotID(bot_id);
+}
+
 perl::array Perl_EntityList_GetBotList(EntityList* self) // @categories Script Utility, Bot
 {
 	perl::array result;
@@ -618,6 +623,7 @@ void perl_register_entitylist()
 	package.add("GetBotByID", &Perl_EntityList_GetBotByID);
 	package.add("GetBotByName", &Perl_EntityList_GetBotByName);
 	package.add("GetBotList", &Perl_EntityList_GetBotList);
+	package.add("GetBotOwnerByBotID", (Client*(*)(EntityList*, uint32))&Perl_EntityList_GetBotOwnerByBotID);
 	package.add("GetBotListByCharacterID", (perl::array(*)(EntityList*, uint32))&Perl_EntityList_GetBotListByCharacterID);
 	package.add("GetBotListByCharacterID", (perl::array(*)(EntityList*, uint32, uint8))&Perl_EntityList_GetBotListByCharacterID);
 	package.add("GetBotListByClientName", (perl::array(*)(EntityList*, std::string))&Perl_EntityList_GetBotListByClientName);

--- a/zone/perl_entity.cpp
+++ b/zone/perl_entity.cpp
@@ -406,6 +406,11 @@ Bot* Perl_EntityList_GetBotByName(EntityList* self, std::string bot_name) // @ca
 	return self->GetBotByBotName(bot_name);
 }
 
+Client* Perl_EntityList_GetBotOwnerByBotEntityID(EntityList* self, uint32_t entity_id) // @categories Script Utility, Bot
+{
+	return self->GetBotOwnerByBotEntityID(entity_id);
+}
+
 Client* Perl_EntityList_GetBotOwnerByBotID(EntityList* self, uint32_t bot_id) // @categories Script Utility, Bot
 {
 	return self->GetBotOwnerByBotID(bot_id);
@@ -623,6 +628,7 @@ void perl_register_entitylist()
 	package.add("GetBotByID", &Perl_EntityList_GetBotByID);
 	package.add("GetBotByName", &Perl_EntityList_GetBotByName);
 	package.add("GetBotList", &Perl_EntityList_GetBotList);
+	package.add("GetBotOwnerByBotEntityID", (Client*(*)(EntityList*, uint32))&Perl_EntityList_GetBotOwnerByBotEntityID);
 	package.add("GetBotOwnerByBotID", (Client*(*)(EntityList*, uint32))&Perl_EntityList_GetBotOwnerByBotID);
 	package.add("GetBotListByCharacterID", (perl::array(*)(EntityList*, uint32))&Perl_EntityList_GetBotListByCharacterID);
 	package.add("GetBotListByCharacterID", (perl::array(*)(EntityList*, uint32, uint8))&Perl_EntityList_GetBotListByCharacterID);


### PR DESCRIPTION
# Perl
- Add `$entity_list->GetBotOwnerByBotID(bot_id)`.
- Add `$entity_list->GetBotOwnerByBotEntityID(entity_id)`.
- Add `$despawned_entity_id` export to `EVENT_DESPAWN`.
- Add `$despawned_bot_id` export to `EVENT_DESPAWN`.
- Add `$despawned_npc_id` export to `EVENT_DESPAWN`.

# Lua
- Add `eq.get_entity_list():GetBotOwnerByBotID(bot_id)`.
- Add `eq.get_entity_list():GetBotOwnerByBotEntityID(entity_id)`.
- Add `e.other` export to `EVENT_DESPAWN_ZONE`.

