### PR TITLE
[API] Reload API

### DIFF
--- a/world/eqemu_api_world_data_service.cpp
+++ b/world/eqemu_api_world_data_service.cpp
@@ -18,19 +18,22 @@
  *
  */
 
+#include <fmt/format.h>
 #include "clientlist.h"
 #include "cliententry.h"
 #include "eqemu_api_world_data_service.h"
 #include "zoneserver.h"
 #include "zonelist.h"
 #include "../common/database_schema.h"
+#include "../common/zone_store.h"
+#include "worlddb.h"
 
 extern ZSList     zoneserver_list;
 extern ClientList client_list;
 
 void callGetZoneList(Json::Value &response)
 {
-	for (auto &zone : zoneserver_list.getZoneServerList()) {
+	for (auto &zone: zoneserver_list.getZoneServerList()) {
 		Json::Value row;
 
 		if (!zone->IsConnected()) {
@@ -64,44 +67,44 @@ void callGetZoneList(Json::Value &response)
 void callGetDatabaseSchema(Json::Value &response)
 {
 	Json::Value              player_tables_json;
-	std::vector<std::string> player_tables  = DatabaseSchema::GetPlayerTables();
-	for (const auto          &table : player_tables) {
+	std::vector<std::string> player_tables = DatabaseSchema::GetPlayerTables();
+	for (const auto          &table: player_tables) {
 		player_tables_json.append(table);
 	}
 
 	Json::Value              content_tables_json;
 	std::vector<std::string> content_tables = DatabaseSchema::GetContentTables();
-	for (const auto          &table : content_tables) {
+	for (const auto          &table: content_tables) {
 		content_tables_json.append(table);
 	}
 
 	Json::Value              server_tables_json;
-	std::vector<std::string> server_tables  = DatabaseSchema::GetServerTables();
-	for (const auto          &table : server_tables) {
+	std::vector<std::string> server_tables = DatabaseSchema::GetServerTables();
+	for (const auto          &table: server_tables) {
 		server_tables_json.append(table);
 	}
 
 	Json::Value              login_tables_json;
-	std::vector<std::string> login_tables   = DatabaseSchema::GetLoginTables();
-	for (const auto          &table : login_tables) {
+	std::vector<std::string> login_tables = DatabaseSchema::GetLoginTables();
+	for (const auto          &table: login_tables) {
 		login_tables_json.append(table);
 	}
 
 	Json::Value              state_tables_json;
-	std::vector<std::string> state_tables   = DatabaseSchema::GetStateTables();
-	for (const auto          &table : state_tables) {
+	std::vector<std::string> state_tables = DatabaseSchema::GetStateTables();
+	for (const auto          &table: state_tables) {
 		state_tables_json.append(table);
 	}
 
 	Json::Value              version_tables_json;
 	std::vector<std::string> version_tables = DatabaseSchema::GetVersionTables();
-	for (const auto          &table : version_tables) {
+	for (const auto          &table: version_tables) {
 		version_tables_json.append(table);
 	}
 
 	Json::Value                        character_table_columns_json;
 	std::map<std::string, std::string> character_table = DatabaseSchema::GetCharacterTables();
-	for (const auto                    &ctc : character_table) {
+	for (const auto                    &ctc: character_table) {
 		character_table_columns_json[ctc.first] = ctc.second;
 	}
 
@@ -123,17 +126,128 @@ void callGetClientList(Json::Value &response)
 	client_list.GetClientList(response);
 }
 
-void EQEmuApiWorldDataService::get(Json::Value &response, const std::vector<std::string> &args)
+void EQEmuApiWorldDataService::get(Json::Value &r, const std::vector<std::string> &args)
 {
-	std::string method = args[0];
+	const std::string &m = args[0];
+	if (m == "get_zone_list") {
+		callGetZoneList(r);
+	}
+	if (m == "get_database_schema") {
+		callGetDatabaseSchema(r);
+	}
+	if (m == "get_client_list") {
+		callGetClientList(r);
+	}
+	if (m == "reload") {
+		reload(r, args);
+	}
+}
 
-	if (method == "get_zone_list") {
-		callGetZoneList(response);
+struct Reload {
+	std::string command{};
+	uint16      opcode;
+	std::string desc{};
+};
+
+void EQEmuApiWorldDataService::reload(Json::Value &r, const std::vector<std::string> &args)
+{
+	std::vector<Reload> reload_types = {
+		Reload{.command = "aa", .opcode = ServerOP_ReloadAAData, .desc = "Alternate Advancement"},
+		Reload{.command = "alternate_currencies", .opcode = ServerOP_ReloadAlternateCurrencies, .desc = "Alternate Currencies"},
+		Reload{.command = "blocked_spells", .opcode = ServerOP_ReloadBlockedSpells, .desc = "Blocked Spells"},
+		Reload{.command = "commands", .opcode = ServerOP_ReloadCommands, .desc = "Commands"},
+		Reload{.command = "doors", .opcode = ServerOP_ReloadDoors, .desc = "Doors"},
+		Reload{.command = "dztemplates", .opcode = ServerOP_ReloadDzTemplates, .desc = "Dynamic Zone Templates"},
+		Reload{.command = "ground_spawns", .opcode = ServerOP_ReloadGroundSpawns, .desc = "Ground Spawns"},
+		Reload{.command = "level_mods", .opcode = ServerOP_ReloadLevelEXPMods, .desc = "Level Mods"},
+		Reload{.command = "logs", .opcode = ServerOP_ReloadLogs, .desc = "Log Settings"},
+		Reload{.command = "merchants", .opcode = ServerOP_ReloadMerchants, .desc = "Merchants"},
+		Reload{.command = "npc_emotes", .opcode = ServerOP_ReloadNPCEmotes, .desc = "NPC Emotes"},
+		Reload{.command = "objects", .opcode = ServerOP_ReloadObjects, .desc = "Objects"},
+		Reload{.command = "perl_export", .opcode = ServerOP_ReloadPerlExportSettings, .desc = "Perl Event Export Settings"},
+		Reload{.command = "rules", .opcode = ServerOP_ReloadRules, .desc = "Rules"},
+		Reload{.command = "static", .opcode = ServerOP_ReloadStaticZoneData, .desc = "Static Zone Data"},
+		Reload{.command = "tasks", .opcode = ServerOP_ReloadTasks, .desc = "Tasks"},
+		Reload{.command = "titles", .opcode = ServerOP_ReloadTitles, .desc = "Titles"},
+		Reload{.command = "traps", .opcode = ServerOP_ReloadTraps, .desc = "Traps"},
+		Reload{.command = "variables", .opcode = ServerOP_ReloadVariables, .desc = "Variables"},
+		Reload{.command = "veteran_rewards", .opcode = ServerOP_ReloadVeteranRewards, .desc = "Veteran Rewards"},
+		Reload{.command = "world", .opcode = ServerOP_ReloadWorld, .desc = "World"},
+		Reload{.command = "zone_points", .opcode = ServerOP_ReloadZonePoints, .desc = "Zone Points"},
+	};
+
+	std::vector<std::string> commands{};
+	commands.reserve(reload_types.size());
+	for (auto &c: reload_types) {
+		commands.emplace_back(c.command);
 	}
-	if (method == "get_database_schema") {
-		callGetDatabaseSchema(response);
+
+	std::string command = !args[1].empty() ? args[1] : "";
+	if (command.empty()) {
+		message(r, fmt::format("Need to provide a type to reload. Example(s) [{}]", Strings::Implode("|", commands)));
+		return;
 	}
-	if (method == "get_client_list") {
-		callGetClientList(response);
+
+	ServerPacket *pack = nullptr;
+
+	bool      found_command = false;
+	for (auto &c: reload_types) {
+		if (command == c.command) {
+			if (c.command == "world") {
+				uint8 global_repop = ReloadWorld::NoRepop;
+
+				if (Strings::IsNumber(args[2])) {
+					global_repop = static_cast<uint8>(std::stoul(args[2]));
+
+					if (global_repop > ReloadWorld::ForceRepop) {
+						global_repop = ReloadWorld::ForceRepop;
+					}
+				}
+
+				message(
+					r,
+					fmt::format(
+						"	Attempting to reload Quests {}worldwide.",
+						(
+							global_repop ?
+								(
+									global_repop == ReloadWorld::Repop ?
+										"and repop NPCs " :
+										"and forcefully repop NPCs "
+								) :
+								""
+						)
+					)
+				);
+
+				pack = new ServerPacket(ServerOP_ReloadWorld, sizeof(ReloadWorld_Struct));
+				auto RW = (ReloadWorld_Struct *) pack->pBuffer;
+				RW->global_repop = global_repop;
+			}
+			else {
+				pack = new ServerPacket(c.opcode, 0);
+				message(r, fmt::format("Reloading [{}] globally", c.desc));
+			}
+
+			found_command = true;
+		}
 	}
+
+	if (!found_command) {
+		message(r, fmt::format("Need to provide a type to reload. Example(s) [{}]", Strings::Implode("|", commands)));
+		return;
+	}
+
+	if (pack) {
+		zoneserver_list.SendPacket(pack);
+	}
+
+	safe_delete(pack);
+}
+
+void EQEmuApiWorldDataService::message(Json::Value &r, const std::string &message)
+{
+	Json::Value v;
+	v["message"] = message;
+	r.append(v);
 }

--- a/world/eqemu_api_world_data_service.h
+++ b/world/eqemu_api_world_data_service.h
@@ -25,7 +25,9 @@
 
 class EQEmuApiWorldDataService {
 public:
-	static void get(Json::Value &response, const std::vector<std::string> &args);
+	static void get(Json::Value &r, const std::vector<std::string> &args);
+	static void reload(Json::Value &r, const std::vector<std::string> &args);
+	static void message(Json::Value &r, const std::string &message);
 };
 
 


### PR DESCRIPTION
### What

This PR exposes world reloading functionality to be able to reload through currently the Telnet interface and eventually through an HTTP REST endpoint when I push the Worldserver API.

### Why

To enable tools such as Spire to reload server entities after things in the database have been edited

### Reload Types

* aa
* alternate_currencies
* blocked_spells
* commands
* content_flags
* doors
* dztemplates
* ground_spawns
* level_mods
* logs
* merchants
* npc_emotes
* objects
* perl_export
* rules
* static
* tasks
* titles
* traps
* variables
* veteran_rewards
* world
* zone
* zone_points

### Example

```
> api reload doors
{
  "data" : 
  [
    {
      "message" : "Reloading [Doors] globally"
    }
  ],
  "execution_time" : "0.000379",
  "method" : "reload"
}
> api reload
{
  "data" : 
  [
    {
      "message" : "Need to provide a type to reload. Example(s) [aa|alternate_currencies|blocked_spells|commands|doors|dztemplates|ground_spawns|level_mods|logs|merchants|npc_emotes|objects|perl_export|rules|static|tasks|titles|traps|variables|veteran_rewards|world|zone_points]"
    }
  ],
  "execution_time" : "0.000167",
  "method" : "reload"
}
```

![image](https://user-images.githubusercontent.com/3319450/211468147-0ab35ad8-4bdf-46c6-af0e-647006ad7596.png)
