### PR TITLE
[Lua Bind] Fix INT64 Support for Windows.

### DIFF
--- a/libs/luabind/luabind/detail/policy.hpp
+++ b/libs/luabind/luabind/detail/policy.hpp
@@ -142,11 +142,11 @@ namespace luabind { namespace detail
 	{
 		static const T& t;
 
-		BOOST_STATIC_CONSTANT(bool, value = 
+		BOOST_STATIC_CONSTANT(bool, value =
 			sizeof(is_policy_cons_test(t)) == sizeof(yes_t));
 
 		typedef boost::mpl::bool_<value> type;
-	};	
+	};
 
 	template<bool>
 	struct is_string_literal
@@ -160,7 +160,7 @@ namespace luabind { namespace detail
 	{
 		static no_t helper(indirection_layer);
 	};
-	
+
 
     namespace mpl = boost::mpl;
 
@@ -217,7 +217,7 @@ namespace luabind { namespace detail
 		template<class T>
 		void apply(lua_State* L, T* ptr)
 		{
-			if (ptr == 0) 
+			if (ptr == 0)
 			{
 				lua_pushnil(L);
 				return;
@@ -251,7 +251,7 @@ namespace luabind { namespace detail
 		}
 
 		template<class T>
-		void converter_postcall(lua_State*, by_pointer<T>, int) 
+		void converter_postcall(lua_State*, by_pointer<T>, int)
 		{}
 	};
 
@@ -328,7 +328,7 @@ namespace luabind { namespace detail
 		template<class T>
 		void apply(lua_State* L, const T* ptr)
 		{
-			if (ptr == 0) 
+			if (ptr == 0)
 			{
 				lua_pushnil(L);
 				return;
@@ -472,7 +472,7 @@ namespace luabind { namespace detail
         {
             return 1;
         }
-		
+
 		void apply(lua_State* L, int val)
 		{
 			lua_pushnumber(L, val);
@@ -483,7 +483,7 @@ namespace luabind { namespace detail
 		{
 			return static_cast<T>(static_cast<int>(lua_tonumber(L, index)));
 		}
-		
+
 		template<class T>
 		static int match(lua_State* L, by_value<T>, int index)
 		{
@@ -532,7 +532,7 @@ namespace luabind { namespace detail
 		template<class T>
 		static int match(lua_State* L, by_const_reference<T>, int index)
 		{
-			return value_wrapper_traits<T>::check(L, index) 
+			return value_wrapper_traits<T>::check(L, index)
                 ? (std::numeric_limits<int>::max)() / LUABIND_MAX_ARITY
                 : -1;
 		}
@@ -694,9 +694,11 @@ LUABIND_NUMBER_CONVERTER(unsigned char, integer)
 LUABIND_NUMBER_CONVERTER(signed short, integer)
 LUABIND_NUMBER_CONVERTER(unsigned short, integer)
 LUABIND_NUMBER_CONVERTER(signed int, integer)
+LUABIND_NUMBER_CONVERTER(signed long long, integer)
 
 LUABIND_NUMBER_CONVERTER(unsigned int, number)
 LUABIND_NUMBER_CONVERTER(unsigned long, number)
+LUABIND_NUMBER_CONVERTER(unsigned long long, number)
 
 LUABIND_NUMBER_CONVERTER(signed long, integer)
 LUABIND_NUMBER_CONVERTER(float, number)


### PR DESCRIPTION
# Notes
- Temporary fix for `int64` and `uint64` support in Lua on Windows.