### PR TITLE
[Quest API] Add Bot::Camp() to Perl/Lua.

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -7728,21 +7728,18 @@ void Bot::DoEnduranceUpkeep() {
 		SetEndurance(GetEndurance() - upkeep_sum);
 }
 
-void Bot::Camp(bool databaseSave) {
+void Bot::Camp(bool save_to_database) {
 	Sit();
 
-	//auto group = GetGroup();
-	if(GetGroup())
+	if (GetGroup()) {
 		RemoveBotFromGroup(this, GetGroup());
-
-	// RemoveBotFromGroup() code is too complicated for this to work as-is (still needs to be addressed to prevent memory leaks)
-	//if (group->GroupCount() < 2)
-	//	group->DisbandGroup();
+	}
 
 	LeaveHealRotationMemberPool();
 
-	if(databaseSave)
+	if (save_to_database) {
 		Save();
+	}
 
 	Depop();
 }
@@ -8790,7 +8787,7 @@ void EntityList::AddBot(Bot *new_bot, bool send_spawn_packet, bool dont_queue) {
 		mob_list.insert(std::pair<uint16, Mob*>(new_bot->GetID(), new_bot));
 
 		parse->EventBot(EVENT_SPAWN, new_bot, nullptr, "", 0);
-		
+
 		new_bot->DispatchZoneControllerEvent(EVENT_SPAWN_ZONE, new_bot, "", 0, nullptr);
 	}
 }

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -216,7 +216,7 @@ public:
 	bool DoFinishedSpellSingleTarget(uint16 spell_id, Mob* spellTarget, EQ::spells::CastingSlot slot, bool &stopLogic);
 	bool DoFinishedSpellGroupTarget(uint16 spell_id, Mob* spellTarget, EQ::spells::CastingSlot slot, bool &stopLogic);
 	void SendBotArcheryWearChange(uint8 material_slot, uint32 material, uint32 color);
-	void Camp(bool databaseSave = true);
+	void Camp(bool save_to_database = true);
 	virtual void AddToHateList(Mob* other, int64 hate = 0, int64 damage = 0, bool iYellForHelp = true, bool bFrenzy = false, bool iBuffTic = false, bool pet_command = false);
 	virtual void SetTarget(Mob* mob);
 	virtual void Zone();

--- a/zone/lua_bot.cpp
+++ b/zone/lua_bot.cpp
@@ -360,6 +360,16 @@ uint32 Lua_Bot::GetBotID() {
 	return self->GetBotID();
 }
 
+void Lua_Bot::Camp() {
+	Lua_Safe_Call_Void();
+	self->Camp();
+}
+
+void Lua_Bot::Camp(bool save_to_database) {
+	Lua_Safe_Call_Void();
+	self->Camp(save_to_database);
+}
+
 luabind::scope lua_register_bot() {
 	return luabind::class_<Lua_Bot, Lua_Mob>("Bot")
 	.def(luabind::constructor<>())
@@ -378,6 +388,8 @@ luabind::scope lua_register_bot() {
 	.def("ApplySpellGroup", (void(Lua_Bot::*)(int))&Lua_Bot::ApplySpellGroup)
 	.def("ApplySpellGroup", (void(Lua_Bot::*)(int,int))&Lua_Bot::ApplySpellGroup)
 	.def("ApplySpellGroup", (void(Lua_Bot::*)(int,int,bool))&Lua_Bot::ApplySpellGroup)
+	.def("Camp", (void(Lua_Bot::*)(void))&Lua_Bot::Camp)
+	.def("Camp", (void(Lua_Bot::*)(bool))&Lua_Bot::Camp)
 	.def("CountBotItem", (uint32(Lua_Bot::*)(uint32))&Lua_Bot::CountBotItem)
 	.def("CountItemEquippedByID", (int(Lua_Bot::*)(uint32))&Lua_Bot::CountItemEquippedByID)
 	.def("Escape", (void(Lua_Bot::*)(void))&Lua_Bot::Escape)

--- a/zone/lua_bot.h
+++ b/zone/lua_bot.h
@@ -56,6 +56,8 @@ public:
 	void SendPayload(int payload_id);
 	void SendPayload(int payload_id, std::string payload_value);
 	uint32 GetBotID();
+	void Camp();
+	void Camp(bool save_to_database);
 
 	void ApplySpell(int spell_id);
 	void ApplySpell(int spell_id, int duration);

--- a/zone/perl_bot.cpp
+++ b/zone/perl_bot.cpp
@@ -376,6 +376,16 @@ uint32 Perl_Bot_GetBotID(Bot* self) // @categories Script Utility
 	return self->GetBotID();
 }
 
+void Perl_Bot_Camp(Bot* self) // @categories Script Utility
+{
+	self->Camp();
+}
+
+void Perl_Bot_Camp(Bot* self, bool save_to_database) // @categories Script Utility
+{
+	self->Camp(save_to_database);
+}
+
 void perl_register_bot()
 {
 	perl::interpreter state(PERL_GET_THX);
@@ -397,6 +407,8 @@ void perl_register_bot()
 	package.add("ApplySpellGroup", (void(*)(Bot*, int))&Perl_Bot_ApplySpellGroup);
 	package.add("ApplySpellGroup", (void(*)(Bot*, int, int))&Perl_Bot_ApplySpellGroup);
 	package.add("ApplySpellGroup", (void(*)(Bot*, int, int, bool))&Perl_Bot_ApplySpellGroup);
+	package.add("Camp", (void(*)(Bot*))&Perl_Bot_Camp);
+	package.add("Camp", (void(*)(Bot*, bool))&Perl_Bot_Camp);
 	package.add("CountAugmentEquippedByID", &Perl_Bot_CountAugmentEquippedByID);
 	package.add("CountBotItem", &Perl_Bot_CountBotItem);
 	package.add("CountItemEquippedByID", &Perl_Bot_CountItemEquippedByID);


### PR DESCRIPTION
# Perl
- Add `$bot->Camp()`.
- Add `$bot->Camp(save_to_database)`.

# Lua
- Add `bot:Camp()`.
- Add `bot:Camp(save_to_database)`.

# Notes
- Saves to database by default, overload is for edge case where a user may not want bot to save to database.