### PR TITLE
[Bug Fixes] Fix Out of Bound Memory Access in zone/bonuses.cpp.

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -1932,7 +1932,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 			effect_value = se_base;
 			limit_value = se_limit;
 			max_value = se_max;
-			i = EFFECT_COUNT; //End the loop
+			i = (EFFECT_COUNT - 1); // AISpellEffects do a single pass
 		}
 
 		switch (spell_effect_id)


### PR DESCRIPTION
Fixes for potential Out of Bound memory access issues across misc code in zone/bonuses.cpp.

Appears to resolve 3 potential bugs:

1. `if (spells[spell_id].base_value[i] != 0)`

`Assuming 'IsAISpellEffect' is true | 
Loop condition is true. Entering loop body |
'IsAISpellEffect' is true | 
Taking false branch | 
Control jumps to 'case 10:' at line 2119`

2. ``switch(spells[spell_id].limit_value[i]``

`Assuming 'IsAISpellEffect' is true | 
Loop condition is true. Entering loop body | 
'IsAISpellEffect' is true | 
Taking false branch | 
Control jumps to 'case 262:' at line 2185`

3. `new_bonus->HPToManaConvert = spells[spell_id].base_value[i];`

`Assuming 'IsAISpellEffect' is true | 
Loop condition is true. Entering loop body| 
'IsAISpellEffect' is true | 
Taking false branch | 
Control jumps to 'case 324:' at line 2995 | 
Assuming field 'HPToManaConvert' is 0`



