### PR TITLE
[Quest API] Add Door Methods to Perl/Lua.

### DIFF
--- a/zone/lua_door.cpp
+++ b/zone/lua_door.cpp
@@ -176,6 +176,11 @@ void Lua_Door::ForceClose(Lua_Mob sender, bool alt_mode) {
 	self->ForceClose(sender, alt_mode);
 }
 
+uint32 Lua_Door::GetID() {
+	Lua_Safe_Call_Int();
+	return self->GetID();
+}
+
 luabind::scope lua_register_door() {
 	return luabind::class_<Lua_Door, Lua_Entity>("Door")
 	.def(luabind::constructor<>())
@@ -191,6 +196,7 @@ luabind::scope lua_register_door() {
 	.def("GetDoorID", (uint32(Lua_Door::*)(void))&Lua_Door::GetDoorID)
 	.def("GetDoorName", (const char*(Lua_Door::*)(void))&Lua_Door::GetDoorName)
 	.def("GetHeading", (float(Lua_Door::*)(void))&Lua_Door::GetHeading)
+	.def("GetID", (uint32(Lua_Door::*)(void))&Lua_Door::GetID)
 	.def("GetIncline", (uint32(Lua_Door::*)(void))&Lua_Door::GetIncline)
 	.def("GetKeyItem", (uint32(Lua_Door::*)(void))&Lua_Door::GetKeyItem)
 	.def("GetLockPick", (uint32(Lua_Door::*)(void))&Lua_Door::GetLockPick)

--- a/zone/lua_door.h
+++ b/zone/lua_door.h
@@ -62,6 +62,7 @@ public:
 	void ForceOpen(Lua_Mob sender, bool alt_mode);
 	void ForceClose(Lua_Mob sender);
 	void ForceClose(Lua_Mob sender, bool alt_mode);
+	uint32 GetID();
 };
 
 #endif

--- a/zone/perl_doors.cpp
+++ b/zone/perl_doors.cpp
@@ -149,12 +149,47 @@ void Perl_Doors_CreateDatabaseEntry(Doors* self) // @categories Doors
 	self->CreateDatabaseEntry();
 }
 
+void Perl_Doors_ForceClose(Doors* self, Mob* sender)
+{
+	self->ForceClose(sender);
+}
+
+void Perl_Doors_ForceClose(Doors* self, Mob* sender, bool alt_mode)
+{
+	self->ForceClose(sender, alt_mode);
+}
+
+void Perl_Doors_ForceOpen(Doors* self, Mob* sender)
+{
+	self->ForceOpen(sender);
+}
+
+void Perl_Doors_ForceOpen(Doors* self, Mob* sender, bool alt_mode)
+{
+	self->ForceOpen(sender, alt_mode);
+}
+
+bool Perl_Doors_GetDisableTimer(Doors* self)
+{
+	return self->GetDisableTimer();
+}
+
+void Perl_Doors_SetDisableTimer(Doors* self, bool disable_timer)
+{
+	self->SetDisableTimer(disable_timer);
+}
+
 void perl_register_doors()
 {
 	perl::interpreter perl(PERL_GET_THX);
 
 	auto package = perl.new_class<Doors>("Doors");
 	package.add("CreateDatabaseEntry", &Perl_Doors_CreateDatabaseEntry);
+	package.add("ForceClose", (void(*)(Doors*, Mob*))&Perl_Doors_ForceClose);
+	package.add("ForceClose", (void(*)(Doors*, Mob*, bool))&Perl_Doors_ForceClose);
+	package.add("ForceOpen", (void(*)(Doors*, Mob*))&Perl_Doors_ForceOpen);
+	package.add("ForceOpen", (void(*)(Doors*, Mob*, bool))&Perl_Doors_ForceOpen);
+	package.add("GetDisableTimer", &Perl_Doors_GetDisableTimer);
 	package.add("GetDoorDBID", &Perl_Doors_GetDoorDBID);
 	package.add("GetDoorID", &Perl_Doors_GetDoorID);
 	package.add("GetHeading", &Perl_Doors_GetHeading);
@@ -169,6 +204,7 @@ void perl_register_doors()
 	package.add("GetX", &Perl_Doors_GetX);
 	package.add("GetY", &Perl_Doors_GetY);
 	package.add("GetZ", &Perl_Doors_GetZ);
+	package.add("SetDisableTimer", &Perl_Doors_SetDisableTimer);
 	package.add("SetHeading", &Perl_Doors_SetHeading);
 	package.add("SetIncline", &Perl_Doors_SetIncline);
 	package.add("SetKeyItem", &Perl_Doors_SetKeyItem);


### PR DESCRIPTION
# Perl
- Add `$door->ForceClose(sender)`.
- Add `$door->ForceClose(sender, alt_mode)`.
- Add `$door->ForceOpen(sender)`.
- Add `$door->ForceOpen(sender, alt_mode)`.
- Add `$door->GetDisableTimer()`.
- Add `$door->SetDisableTimer(disable_timer)`.

# Lua
- Add `door:GetID()`.

# Notes
- Makes Perl/Lua Door scripting capabilities 1:1.