### PR TITLE
[Bug Fix] Fix Aug Clicks when Item has no Click Effect, but has a Click Type.

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -8971,8 +8971,15 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 					return;
 				}
 			}
-			else if ((item->Click.Type == EQ::item::ItemEffectClick) || (item->Click.Type == EQ::item::ItemEffectExpendable) || (item->Click.Type == EQ::item::ItemEffectEquipClick) || (item->Click.Type == EQ::item::ItemEffectClick2))
-			{
+			else if (
+				item->Click.Effect > 0 &&
+				(
+					(item->Click.Type == EQ::item::ItemEffectClick) ||
+					(item->Click.Type == EQ::item::ItemEffectExpendable) ||
+					(item->Click.Type == EQ::item::ItemEffectEquipClick) ||
+					(item->Click.Type == EQ::item::ItemEffectClick2)
+				)
+			) {
 				if (inst->GetCharges() == 0)
 				{
 					//Message(Chat::White, "This item is out of charges.");


### PR DESCRIPTION
Fixes instances where Server Operators set no Click Effect on an item, but leave Click Type set to a non-zero value.

This would prevent Aug Clickies from working correctly inside the item, along with some Events.