### PR TITLE
[Bug Fix] Fix luamod GetExperienceForKill return value

### DIFF
--- a/zone/lua_mod.cpp
+++ b/zone/lua_mod.cpp
@@ -584,7 +584,6 @@ void LuaMod::GetEXPForLevel(Client *self, uint16 level, uint32 &returnValue, boo
 void LuaMod::GetExperienceForKill(Client *self, Mob *against, uint64 &returnValue, bool &ignoreDefault)
 {
 	int start = lua_gettop(L);
-	uint64 retval = 0;
 
 	try {
 		if (!m_has_get_experience_for_kill) {
@@ -617,7 +616,7 @@ void LuaMod::GetExperienceForKill(Client *self, Mob *against, uint64 &returnValu
 
 			auto returnValueObj = ret["ReturnValue"];
 			if (luabind::type(returnValueObj) == LUA_TNUMBER) {
-				returnValue = luabind::object_cast<uint32>(returnValueObj);
+				returnValue = luabind::object_cast<uint64>(returnValueObj);
 			}
 		}
 	}


### PR DESCRIPTION
Return value (uint64) is being cast to a uint32. Maybe a copy and paste from above functions (which correctly cast to a uint32).

Remove unused variable.