### PR TITLE
[Diawind] Plus sign markdown fix

### DIFF
--- a/zone/dialogue_window.cpp
+++ b/zone/dialogue_window.cpp
@@ -69,12 +69,13 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 	std::string animation = Strings::GetBetween(output, "+", "+");
 	if (!animation.empty()) {
 		LogDiaWind("Client [{}] Animation is not empty, contents are [{}]", c->GetCleanName(), animation);
-		Strings::FindReplace(output, fmt::format("+{}+", animation), "");
 
 		// we treat the animation field differently if it is a number
+		bool found_animation = false;
 		if (Strings::IsNumber(animation)) {
 			LogDiaWindDetail("Client [{}] Animation is a number, firing animation [{}]", c->GetCleanName(), animation);
 			target->DoAnim(std::stoi(animation));
+			found_animation = true;
 		}
 		else {
 			for (auto &a: animations) {
@@ -86,8 +87,13 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 						a.first
 					);
 					target->DoAnim(a.second);
+					found_animation = true;
 				}
 			}
+		}
+
+		if (found_animation) {
+			Strings::FindReplace(output, fmt::format("+{}+", animation), "");
 		}
 	}
 


### PR DESCRIPTION
### Original Problem

"Balloon
 — Today at 9:35 AM
I have a DiaWind box that explains some bonuses (e.g. +10 STR), but the + is being interpreted as an animation command and the display gets very screwy.  Is there a way to show a specific character without it being interpreted?  I've tried prefixing with the usual special chars and also using html &#43; to no avail."

### Fix 

We only replace content between plus signs when an animation is found