### PR TITLE
[Quest API] Add SignalAllBotsByOwnerName() to Perl/Lua.

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -5250,6 +5250,18 @@ void EntityList::SignalAllBotsByOwnerCharacterID(uint32 character_id, int signal
 	}
 }
 
+void EntityList::SignalAllBotsByOwnerName(std::string owner_name, int signal_id)
+{
+	auto client_bot_list = GetBotListByClientName(owner_name);
+	if (client_bot_list.empty()) {
+		return;
+	}
+
+	for (const auto& b : client_bot_list) {
+		b->Signal(signal_id);
+	}
+}
+
 void EntityList::SignalBotByBotID(uint32 bot_id, int signal_id)
 {
 	auto b = GetBotByBotID(bot_id);

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -553,6 +553,7 @@ public:
 	std::vector<Bot *> GetBotListByCharacterID(uint32 character_id, uint8 class_id = 0);
 	std::vector<Bot *> GetBotListByClientName(std::string client_name, uint8 class_id = 0);
 	void SignalAllBotsByOwnerCharacterID(uint32 character_id, int signal_id);
+	void SignalAllBotsByOwnerName(std::string owner_name, int signal_id);
 	void SignalBotByBotID(uint32 bot_id, int signal_id);
 	void SignalBotByBotName(std::string bot_name, int signal_id);
 #endif

--- a/zone/lua_entity_list.cpp
+++ b/zone/lua_entity_list.cpp
@@ -470,6 +470,11 @@ void Lua_EntityList::SignalAllBotsByOwnerCharacterID(uint32 character_id, int si
 	self->SignalAllBotsByOwnerCharacterID(character_id, signal_id);
 }
 
+void Lua_EntityList::SignalAllBotsByOwnerName(std::string owner_name, int signal_id) {
+	Lua_Safe_Call_Void();
+	self->SignalAllBotsByOwnerName(owner_name, signal_id);
+}
+
 void Lua_EntityList::SignalBotByBotID(uint32 bot_id, int signal_id) {
 	Lua_Safe_Call_Void();
 	self->SignalBotByBotID(bot_id, signal_id);
@@ -734,6 +739,7 @@ luabind::scope lua_register_entity_list() {
 	.def("ReplaceWithTarget", (void(Lua_EntityList::*)(Lua_Mob, Lua_Mob))&Lua_EntityList::ReplaceWithTarget)
 #ifdef BOTS
 	.def("SignalAllBotsByOwnerCharacterID", (void(Lua_EntityList::*)(uint32, int))&Lua_EntityList::SignalAllBotsByOwnerCharacterID)
+	.def("SignalAllBotsByOwnerName", (void(Lua_EntityList::*)(std::string, int))&Lua_EntityList::SignalAllBotsByOwnerName)
 #endif
 	.def("SignalAllClients", (void(Lua_EntityList::*)(int))&Lua_EntityList::SignalAllClients)
 #ifdef BOTS

--- a/zone/lua_entity_list.h
+++ b/zone/lua_entity_list.h
@@ -144,6 +144,7 @@ public:
 	Lua_Bot GetRandomBot(float x, float y, float z, float distance);
 	Lua_Bot GetRandomBot(float x, float y, float z, float distance, Lua_Bot exclude_bot);
 	void SignalAllBotsByOwnerCharacterID(uint32 character_id, int signal_id);
+	void SignalAllBotsByOwnerName(std::string owner_name, int signal_id);
 	void SignalBotByBotID(uint32 bot_id, int signal_id);
 	void SignalBotByBotName(std::string bot_name, int signal_id);
 #endif

--- a/zone/perl_entity.cpp
+++ b/zone/perl_entity.cpp
@@ -476,6 +476,11 @@ void Perl_EntityList_SignalAllBotsByOwnerCharacterID(EntityList* self, uint32_t 
 	entity_list.SignalAllBotsByOwnerCharacterID(character_id, signal_id);
 }
 
+void Perl_EntityList_SignalAllBotsByOwnerName(EntityList* self, std::string owner_name, int signal_id) // @categories Script Utility
+{
+	entity_list.SignalAllBotsByOwnerName(owner_name, signal_id);
+}
+
 void Perl_EntityList_SignalBotByBotID(EntityList* self, uint32_t bot_id, int signal_id) // @categories Script Utility
 {
 	entity_list.SignalBotByBotID(bot_id, signal_id);
@@ -716,6 +721,7 @@ void perl_register_entitylist()
 	package.add("ReplaceWithTarget", &Perl_EntityList_ReplaceWithTarget);
 #ifdef BOTS
 	package.add("SignalAllBotsByOwnerCharacterID", &Perl_EntityList_SignalAllBotsByOwnerCharacterID);
+	package.add("SignalAllBotsByOwnerName", &Perl_EntityList_SignalAllBotsByOwnerName);
 #endif
 	package.add("SignalAllClients", &Perl_EntityList_SignalAllClients);
 #ifdef BOTS


### PR DESCRIPTION
# Perl
- Add `$entity_list->SignalAllBotsByOwnerName(owner_name)`.

# Lua
- Add `eq.get_entity_list():SignalAllBotsByOwnerName(owner_name)`.

# Notes
- Adds a way to signal all bots by owner name instead of only character ID.