### PR TITLE
[Quest API] Add Bot Methods to Lua.

### DIFF
--- a/common/item_instance.cpp
+++ b/common/item_instance.cpp
@@ -534,10 +534,11 @@ bool EQ::ItemInstance::IsNoneEmptyContainer()
 }
 
 // Retrieve augment inside item
-EQ::ItemInstance* EQ::ItemInstance::GetAugment(uint8 slot) const
+EQ::ItemInstance* EQ::ItemInstance::GetAugment(uint8 augment_index) const
 {
-	if (m_item && m_item->IsClassCommon())
-		return GetItem(slot);
+	if (m_item && m_item->IsClassCommon()) {
+		return GetItem(augment_index);
+	}
 
 	return nullptr;
 }
@@ -663,12 +664,13 @@ bool EQ::ItemInstance::CanTransform(const ItemData *ItemToTry, const ItemData *C
 	return false;
 }
 
-uint32 EQ::ItemInstance::GetAugmentItemID(uint8 slot) const
+uint32 EQ::ItemInstance::GetAugmentItemID(uint8 augment_index) const
 {
-	if (!m_item || !m_item->IsClassCommon())
+	if (!m_item || !m_item->IsClassCommon()) {
 		return 0;
+	}
 
-	return GetItemID(slot);
+	return GetItemID(augment_index);
 }
 
 // Add an augment to the item

--- a/common/item_instance.h
+++ b/common/item_instance.h
@@ -127,8 +127,8 @@ namespace EQ
 		//
 		// Augments
 		//
-		ItemInstance* GetAugment(uint8 slot) const;
-		uint32 GetAugmentItemID(uint8 slot) const;
+		ItemInstance* GetAugment(uint8 augment_index) const;
+		uint32 GetAugmentItemID(uint8 augment_index) const;
 		void PutAugment(uint8 slot, const ItemInstance& inst);
 		void PutAugment(SharedDatabase *db, uint8 slot, uint32 item_id);
 		void DeleteAugment(uint8 slot);

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -10170,17 +10170,19 @@ int32 Bot::GetRawItemAC()
 	return Total;
 }
 
-void Bot::SendSpellAnim(uint16 targetid, uint16 spell_id)
+void Bot::SendSpellAnim(uint16 target_id, uint16 spell_id)
 {
-	if (!targetid || !IsValidSpell(spell_id))
+	if (!target_id || !IsValidSpell(spell_id)) {
 		return;
+	}
 
 	EQApplicationPacket app(OP_Action, sizeof(Action_Struct));
-	Action_Struct* a = (Action_Struct*)app.pBuffer;
-	a->target = targetid;
-	a->source = GetID();
-	a->type = 231;
-	a->spell = spell_id;
+	auto* a = (Action_Struct*) app.pBuffer;
+
+	a->target      = target_id;
+	a->source      = GetID();
+	a->type        = 231;
+	a->spell       = spell_id;
 	a->hit_heading = GetHeading();
 
 	app.priority = 1;

--- a/zone/lua_bot.cpp
+++ b/zone/lua_bot.cpp
@@ -260,16 +260,6 @@ void Lua_Bot::Fling(float value, float target_x, float target_y, float target_z,
 	self->Fling(value, target_x, target_y, target_z, ignore_los, clip_through_walls);
 }
 
-int Lua_Bot::GetItemIDAt(int slot_id) {
-	Lua_Safe_Call_Int();
-	return self->GetItemIDAt(slot_id);
-}
-
-int Lua_Bot::GetAugmentIDAt(int slot_id, int aug_slot) {
-	Lua_Safe_Call_Int();
-	return self->GetAugmentIDAt(slot_id, aug_slot);
-}
-
 int Lua_Bot::GetBaseSTR() {
 	Lua_Safe_Call_Int();
 	return self->GetBaseSTR();
@@ -370,6 +360,40 @@ void Lua_Bot::Camp(bool save_to_database) {
 	self->Camp(save_to_database);
 }
 
+Lua_ItemInst Lua_Bot::GetAugmentAt(int16 slot_id, uint8 augment_index)
+{
+	Lua_Safe_Call_Class(Lua_ItemInst);
+
+	auto* inst = self->GetInv().GetItem(slot_id);
+	if (inst) {
+		return Lua_ItemInst(inst->GetAugment(augment_index));
+	}
+
+	return Lua_ItemInst();
+}
+
+int Lua_Bot::GetAugmentIDAt(int16 slot_id, uint8 augment_index) {
+	Lua_Safe_Call_Int();
+	return self->GetAugmentIDAt(slot_id, augment_index);
+}
+
+int Lua_Bot::GetItemIDAt(int16 slot_id) {
+	Lua_Safe_Call_Int();
+	return self->GetItemIDAt(slot_id);
+}
+
+Lua_ItemInst Lua_Bot::GetItemAt(int16 slot_id) // @categories Inventory and Items
+{
+	Lua_Safe_Call_Class(Lua_ItemInst);
+	return Lua_ItemInst(self->GetInv().GetItem(slot_id));
+}
+
+void Lua_Bot::SendSpellAnim(uint16 target_id, uint16 spell_id)
+{
+	Lua_Safe_Call_Void();
+	self->SendSpellAnim(target_id, spell_id);
+}
+
 luabind::scope lua_register_bot() {
 	return luabind::class_<Lua_Bot, Lua_Mob>("Bot")
 	.def(luabind::constructor<>())
@@ -399,7 +423,8 @@ luabind::scope lua_register_bot() {
 	.def("Fling", (void(Lua_Bot::*)(float,float,float,float))&Lua_Bot::Fling)
 	.def("Fling", (void(Lua_Bot::*)(float,float,float,float,bool))&Lua_Bot::Fling)
 	.def("Fling", (void(Lua_Bot::*)(float,float,float,float,bool,bool))&Lua_Bot::Fling)
-	.def("GetAugmentIDAt", (int(Lua_Bot::*)(int,int))&Lua_Bot::GetAugmentIDAt)
+	.def("GetAugmentAt", (Lua_ItemInst(Lua_Bot::*)(int16,uint8))&Lua_Bot::GetAugmentAt)
+	.def("GetAugmentIDAt", (int(Lua_Bot::*)(int16,uint8))&Lua_Bot::GetAugmentIDAt)
 	.def("GetBaseAGI", (int(Lua_Bot::*)(void))&Lua_Bot::GetBaseAGI)
 	.def("GetBaseCHA", (int(Lua_Bot::*)(void))&Lua_Bot::GetBaseCHA)
 	.def("GetBaseDEX", (int(Lua_Bot::*)(void))&Lua_Bot::GetBaseDEX)
@@ -414,6 +439,8 @@ luabind::scope lua_register_bot() {
 	.def("GetGroup", (Lua_Group(Lua_Bot::*)(void))&Lua_Bot::GetGroup)
 	.def("GetHealAmount", (int(Lua_Bot::*)(void))&Lua_Bot::GetHealAmount)
 	.def("GetInstrumentMod", (int(Lua_Bot::*)(int))&Lua_Bot::GetInstrumentMod)
+	.def("GetItemAt", (Lua_ItemInst(Lua_Bot::*)(int16))&Lua_Bot::GetItemAt)
+	.def("GetItemIDAt", (int(Lua_Bot::*)(int16))&Lua_Bot::GetItemIDAt)
 	.def("GetOwner", (Lua_Mob(Lua_Bot::*)(void))&Lua_Bot::GetOwner)
 	.def("GetRawItemAC", (int(Lua_Bot::*)(void))&Lua_Bot::GetRawItemAC)
 	.def("GetSpellDamage", (int(Lua_Bot::*)(void))&Lua_Bot::GetSpellDamage)
@@ -430,6 +457,7 @@ luabind::scope lua_register_bot() {
 	.def("ReloadBotSpells", (bool(Lua_Bot::*)(void))&Lua_Bot::ReloadBotSpells)
 	.def("ReloadBotSpellSettings", (void(Lua_Bot::*)(void))&Lua_Bot::ReloadBotSpellSettings)
 	.def("RemoveBotItem", (void(Lua_Bot::*)(uint32))&Lua_Bot::RemoveBotItem)
+	.def("SendSpellAnim", (void(Lua_Bot::*)(uint16,uint16))&Lua_Bot::SendSpellAnim)
 	.def("SetExpansionBitmask", (void(Lua_Bot::*)(int))&Lua_Bot::SetExpansionBitmask)
 	.def("SetExpansionBitmask", (void(Lua_Bot::*)(int,bool))&Lua_Bot::SetExpansionBitmask)
 	.def("SetSpellDuration", (void(Lua_Bot::*)(int))&Lua_Bot::SetSpellDuration)

--- a/zone/lua_bot.h
+++ b/zone/lua_bot.h
@@ -58,6 +58,11 @@ public:
 	uint32 GetBotID();
 	void Camp();
 	void Camp(bool save_to_database);
+	Lua_ItemInst GetAugmentAt(int16 slot_id, uint8 augment_index);
+	int GetAugmentIDAt(int16 slot_id, uint8 augment_index);
+	Lua_ItemInst GetItemAt(int16 slot_id);
+	int GetItemIDAt(int16 slot_id);
+	void SendSpellAnim(uint16 target_id, uint16 spell_id);
 
 	void ApplySpell(int spell_id);
 	void ApplySpell(int spell_id, int duration);
@@ -89,9 +94,6 @@ public:
 
 	void Escape();
 	int GetInstrumentMod(int spell_id);
-
-	int GetItemIDAt(int slot_id);
-	int GetAugmentIDAt(int slot_id, int aug_slot);
 
 	int GetBaseSTR();
 	int GetBaseSTA();

--- a/zone/perl_bot.cpp
+++ b/zone/perl_bot.cpp
@@ -101,13 +101,13 @@ void Perl_Bot_RemoveBotItem(Bot* self, uint32 item_id)
 	return self->RemoveBotItem(item_id);
 }
 
-EQ::ItemInstance* Perl_Bot_GetAugmentAt(Bot* self, uint32 slot, uint32 aug_slot)
+EQ::ItemInstance* Perl_Bot_GetAugmentAt(Bot* self, int16 slot_id, uint8 augment_index)
 {
-	EQ::ItemInstance* inst = self->GetInv().GetItem(slot);
-	if (inst)
-	{
-		return inst->GetAugment(aug_slot);
+	auto* inst = self->GetInv().GetItem(slot_id);
+	if (inst) {
+		return inst->GetAugment(augment_index);
 	}
+
 	return nullptr;
 }
 
@@ -161,9 +161,9 @@ bool Perl_Bot_IsSitting(Bot* self) // @categories Account and Character
 	return self->IsSitting();
 }
 
-void Perl_Bot_SendSpellAnim(Bot* self, uint16 targetid, uint16 spell_id)
+void Perl_Bot_SendSpellAnim(Bot* self, uint16 target_id, uint16 spell_id)
 {
-	self->SendSpellAnim(targetid, spell_id);
+	self->SendSpellAnim(target_id, spell_id);
 }
 
 void Perl_Bot_Signal(Bot* self, int signal_id)
@@ -286,9 +286,9 @@ int Perl_Bot_GetInstrumentMod(Bot* self, uint16 spell_id) // @categories Spells 
 	return self->GetInstrumentMod(spell_id);
 }
 
-EQ::ItemInstance* Perl_Bot_GetItemAt(Bot* self, uint32 slot) // @categories Inventory and Items
+EQ::ItemInstance* Perl_Bot_GetItemAt(Bot* self, int16 slot_id) // @categories Inventory and Items
 {
-	return self->GetInv().GetItem(slot);
+	return self->GetInv().GetItem(slot_id);
 }
 
 bool Perl_Bot_IsGrouped(Bot* self) // @categories Account and Character, Group

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -6323,17 +6323,19 @@ void NPC::UninitializeBuffSlots()
 	safe_delete_array(buffs);
 }
 
-void Client::SendSpellAnim(uint16 targetid, uint16 spell_id)
+void Client::SendSpellAnim(uint16 target_id, uint16 spell_id)
 {
-	if (!targetid || !IsValidSpell(spell_id))
+	if (!target_id || !IsValidSpell(spell_id)) {
 		return;
+	}
 
 	EQApplicationPacket app(OP_Action, sizeof(Action_Struct));
-	Action_Struct* a = (Action_Struct*)app.pBuffer;
-	a->target = targetid;
-	a->source = GetID();
-	a->type = 231;
-	a->spell = spell_id;
+	auto* a = (Action_Struct*) app.pBuffer;
+
+	a->target      = target_id;
+	a->source      = GetID();
+	a->type        = 231;
+	a->spell       = spell_id;
 	a->hit_heading = GetHeading();
 
 	app.priority = 1;


### PR DESCRIPTION
# Perl
- Minor cleanup of variable types.

 # Lua
- Add `bot:GetAugmentAt(slot_id, augment_index)`.
- Add `bot:GetItemAt(slot_id)`.
- Add `bot:SendSpellAnim(target_id, spell_id)`.
- Properly implemented `bot:GetItemIDAt(slot_id)`.

# Notes
- `bot:GetItemIDAt` existed in Lua, but didn't have a bind definition, so was non-functional.
- This makes Perl/Lua bot methods 1:1 as Perl had 75 and Lua had 72, they now both have 75.