### PR TITLE
[Quest API] Add CampAllBots() to Perl/Lua.

### DIFF
--- a/common/classes.h
+++ b/common/classes.h
@@ -20,6 +20,7 @@
 
 #include "../common/types.h"
 
+#define NO_CLASS 0
 #define WARRIOR 1
 #define CLERIC 2
 #define PALADIN 3

--- a/common/inventory_profile.h
+++ b/common/inventory_profile.h
@@ -26,6 +26,8 @@
 
 
 #include "item_instance.h"
+#include "classes.h"
+#include "races.h"
 
 #include <list>
 #include <vector>
@@ -130,7 +132,7 @@ namespace EQ
 
 		// Swap items in inventory
 		enum SwapItemFailState : int8 { swapInvalid = -1, swapPass = 0, swapNotAllowed, swapNullData, swapRaceClass, swapDeity, swapLevel };
-		bool SwapItem(int16 source_slot, int16 destination_slot, SwapItemFailState& fail_state, uint16 race_id = 0, uint8 class_id = 0, uint16 deity_id = 0, uint8 level = 0);
+		bool SwapItem(int16 source_slot, int16 destination_slot, SwapItemFailState& fail_state, uint16 race_id = RACE_DOUG_0, uint8 class_id = NO_CLASS, uint16 deity_id = deity::DeityType::DeityUnknown, uint8 level = 0);
 
 		// Remove item from inventory
 		bool DeleteItem(int16 slot_id, int16 quantity = 0);

--- a/common/item_instance.cpp
+++ b/common/item_instance.cpp
@@ -1249,7 +1249,7 @@ int EQ::ItemInstance::GetItemBaneDamageBody(bool augments) const
 
 int EQ::ItemInstance::GetItemBaneDamageRace(bool augments) const
 {
-	int race = 0;
+	int race = RACE_DOUG_0;
 	const auto item = GetItem();
 	if (item) {
 		race = item->BaneDmgRace;

--- a/world/lfplist.cpp
+++ b/world/lfplist.cpp
@@ -23,6 +23,7 @@
 #include "zonelist.h"
 
 #include "../common/misc_functions.h"
+#include "../common/classes.h"
 
 extern ClientList client_list;
 extern ZSList zoneserver_list;
@@ -32,7 +33,7 @@ GroupLFP::GroupLFP(uint32 inLeaderID) {
 	LeaderID = inLeaderID;
 	for (auto &member : Members) {
 		member.Name[0] = '\0';
-		member.Class = 0;
+		member.Class = NO_CLASS;
 		member.Level = 0;
 		member.Zone = 0;
 	}
@@ -76,7 +77,7 @@ void GroupLFP::SetDetails(ServerLFPUpdate_Struct *Update) {
 				Members[i].GuildID = CLE->GuildID();
 			}
 			else {
-				Members[i].Class = 0;
+				Members[i].Class = NO_CLASS;
 				Members[i].Level = 0;
 				Members[i].Zone = 0;
 				Members[i].GuildID = 0xFFFF;

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -6220,11 +6220,14 @@ void Bot::EquipBot(std::string* error_message) {
 	UpdateEquipmentLight();
 }
 
-void Bot::BotOrderCampAll(Client* c) {
-	if(c) {
-		std::list<Bot*> BotList = entity_list.GetBotsByBotOwnerCharacterID(c->CharacterID());
-		for(std::list<Bot*>::iterator botListItr = BotList.begin(); botListItr != BotList.end(); ++botListItr)
-			(*botListItr)->Camp();
+void Bot::BotOrderCampAll(Client* c, uint8 class_id) {
+	if (c) {
+		const auto& l = entity_list.GetBotsByBotOwnerCharacterID(c->CharacterID());
+		for (const auto& b : l) {
+			if (!class_id || b->GetClass() == class_id) {
+				b->Camp();
+			}
+		}
 	}
 }
 

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -393,14 +393,14 @@ public:
 	// Static Class Methods
 	//static void DestroyBotRaidObjects(Client* client);	// Can be removed after bot raids are dumped
 	static Bot* LoadBot(uint32 botID);
-	static uint32 SpawnedBotCount(const uint32 owner_id, uint8 class_id = 0);
+	static uint32 SpawnedBotCount(const uint32 owner_id, uint8 class_id = NO_CLASS);
 	static void LevelBotWithClient(Client* client, uint8 level, bool sendlvlapp);
 	//static bool SetBotOwnerCharacterID(uint32 botID, uint32 botOwnerCharacterID, std::string* error_message);
 	static bool IsBotAttackAllowed(Mob* attacker, Mob* target, bool& hasRuleDefined);
 	static Bot* GetBotByBotClientOwnerAndBotName(Client* c, std::string botName);
 	static void ProcessBotGroupInvite(Client* c, std::string botName);
 	static void ProcessBotGroupDisband(Client* c, std::string botName);
-	static void BotOrderCampAll(Client* c);
+	static void BotOrderCampAll(Client* c, uint8 class_id = NO_CLASS);
 	static void ProcessBotInspectionRequest(Bot* inspectedBot, Client* client);
 	static void LoadAndSpawnAllZonedBots(Client* bot_owner);
 	static bool GroupHasBot(Group* group);

--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -6548,7 +6548,7 @@ void bot_subcommand_bot_spawn(Client *c, const Seperator *sep)
 	std::string bot_name = sep->arg[1];
 
 	uint32 bot_id = 0;
-	uint8 bot_class = 0;
+	uint8 bot_class = NO_CLASS;
 	if (!database.botdb.LoadBotID(c->CharacterID(), bot_name, bot_id, bot_class)) {
 		c->Message(
 			Chat::White,

--- a/zone/bot_command.h
+++ b/zone/bot_command.h
@@ -687,7 +687,7 @@ void helper_command_depart_list(Client* bot_owner, Bot* druid_bot, Bot* wizard_b
 bool helper_is_help_or_usage(const char* arg);
 bool helper_no_available_bots(Client *bot_owner, Bot *my_bot = nullptr);
 void helper_send_available_subcommands(Client *bot_owner, const char* command_simile, const std::list<const char*>& subcommand_list);
-void helper_send_usage_required_bots(Client *bot_owner, BCEnum::SpType spell_type, uint8 bot_class = 0);
+void helper_send_usage_required_bots(Client *bot_owner, BCEnum::SpType spell_type, uint8 bot_class = NO_CLASS);
 bool helper_spell_check_fail(STBaseEntry* local_entry);
 bool helper_spell_list_fail(Client *bot_owner, bcst_list* spell_list, BCEnum::SpType spell_type);
 #endif

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -4091,7 +4091,7 @@ void Client::UpdateLFP() {
 
 	for(unsigned int i=0; i<MAX_GROUP_MEMBERS; i++) {
 		LFPMembers[i].Name[0] = '\0';
-		LFPMembers[i].Class = 0;
+		LFPMembers[i].Class = NO_CLASS;
 		LFPMembers[i].Level = 0;
 		LFPMembers[i].Zone = 0;
 	}

--- a/zone/client.h
+++ b/zone/client.h
@@ -2068,12 +2068,14 @@ public:
 	bool GetBotPrecombat() { return m_bot_precombat; }
 	void SetBotPrecombat(bool flag = true) { m_bot_precombat = flag; }
 
-	int GetBotRequiredLevel(uint8 class_id = 0);
-	uint32 GetBotCreationLimit(uint8 class_id = 0);
-	int GetBotSpawnLimit(uint8 class_id = 0);
-	void SetBotCreationLimit(uint32 new_creation_limit, uint8 class_id = 0);
-	void SetBotRequiredLevel(int new_required_level, uint8 class_id = 0);
-	void SetBotSpawnLimit(int new_spawn_limit, uint8 class_id = 0);
+	int GetBotRequiredLevel(uint8 class_id = NO_CLASS);
+	uint32 GetBotCreationLimit(uint8 class_id = NO_CLASS);
+	int GetBotSpawnLimit(uint8 class_id = NO_CLASS);
+	void SetBotCreationLimit(uint32 new_creation_limit, uint8 class_id = NO_CLASS);
+	void SetBotRequiredLevel(int new_required_level, uint8 class_id = NO_CLASS);
+	void SetBotSpawnLimit(int new_spawn_limit, uint8 class_id = NO_CLASS);
+
+	void CampAllBots(uint8 class_id = NO_CLASS);
 
 private:
 	bool bot_owner_options[_booCount];

--- a/zone/client_bot.cpp
+++ b/zone/client_bot.cpp
@@ -1,5 +1,6 @@
 #ifdef BOTS
 
+#include "bot.h"
 #include "client.h"
 
 bool Client::GetBotOption(BotOwnerOption boo) const {
@@ -154,6 +155,11 @@ void Client::SetBotSpawnLimit(int new_spawn_limit, uint8 class_id)
 	);
 
 	SetBucket(bucket_name, std::to_string(new_spawn_limit));
+}
+
+void Client::CampAllBots(uint8 class_id)
+{
+	Bot::BotOrderCampAll(this, class_id);
 }
 
 #endif

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -9515,7 +9515,7 @@ void Client::Handle_OP_LFPCommand(const EQApplicationPacket *app)
 
 	for (unsigned int i = 0; i<MAX_GROUP_MEMBERS; i++) {
 		LFPMembers[i].Name[0] = '\0';
-		LFPMembers[i].Class = 0;
+		LFPMembers[i].Class = NO_CLASS;
 		LFPMembers[i].Level = 0;
 		LFPMembers[i].Zone = 0;
 		LFPMembers[i].GuildID = 0xFFFF;

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -5027,9 +5027,9 @@ void EntityList::ZoneWho(Client *c, Who_All_Struct *Who)
 				FormatMSGID = 5024; // 5024 %T1[ANONYMOUS] %2 %3
 			else if (ClientEntry->GetAnon() == 2)
 				FormatMSGID = 5023; // 5023 %T1[ANONYMOUS] %2 %3 %4
-			uint32 PlayerClass = 0;
+			uint32 PlayerClass = NO_CLASS;
 			uint32 PlayerLevel = 0;
-			uint32 PlayerRace = 0;
+			uint32 PlayerRace = RACE_DOUG_0;
 			uint32 ZoneMSGID = 0xFFFFFFFF;
 
 			if (ClientEntry->GetAnon()==0) {

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -550,8 +550,8 @@ public:
 	inline const std::unordered_map<uint16, Client *> &GetClientList() { return client_list; }
 #ifdef BOTS
 	inline const std::list<Bot *> &GetBotList() { return bot_list; }
-	std::vector<Bot *> GetBotListByCharacterID(uint32 character_id, uint8 class_id = 0);
-	std::vector<Bot *> GetBotListByClientName(std::string client_name, uint8 class_id = 0);
+	std::vector<Bot *> GetBotListByCharacterID(uint32 character_id, uint8 class_id = NO_CLASS);
+	std::vector<Bot *> GetBotListByClientName(std::string client_name, uint8 class_id = NO_CLASS);
 	void SignalAllBotsByOwnerCharacterID(uint32 character_id, int signal_id);
 	void SignalAllBotsByOwnerName(std::string owner_name, int signal_id);
 	void SignalBotByBotID(uint32 bot_id, int signal_id);

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3010,6 +3010,18 @@ void Lua_Client::SetBotSpawnLimit(int new_spawn_limit, uint8 class_id)
 	self->SetBotSpawnLimit(new_spawn_limit, class_id);
 }
 
+void Lua_Client::CampAllBots()
+{
+	Lua_Safe_Call_Void();
+	self->CampAllBots();
+}
+
+void Lua_Client::CampAllBots(uint8 class_id)
+{
+	Lua_Safe_Call_Void();
+	self->CampAllBots(class_id);
+}
+
 #endif
 
 luabind::scope lua_register_client() {
@@ -3070,6 +3082,10 @@ luabind::scope lua_register_client() {
 	.def("CalcEXP", (uint64(Lua_Client::*)(uint8))&Lua_Client::CalcEXP)
 	.def("CalcEXP", (uint64(Lua_Client::*)(uint8,bool))&Lua_Client::CalcEXP)
 	.def("CalcPriceMod", (float(Lua_Client::*)(Lua_Mob,bool))&Lua_Client::CalcPriceMod)
+#ifdef BOTS
+	.def("CampAllBots", (void(Lua_Client::*)(void))&Lua_Client::CampAllBots)
+	.def("CampAllBots", (void(Lua_Client::*)(uint8))&Lua_Client::CampAllBots)
+#endif
 	.def("CanEnterZone", (bool(Lua_Client::*)(std::string))&Lua_Client::CanEnterZone)
 	.def("CanEnterZone", (bool(Lua_Client::*)(std::string,int16))&Lua_Client::CanEnterZone)
 	.def("CanHaveSkill", (bool(Lua_Client::*)(int))&Lua_Client::CanHaveSkill)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -537,6 +537,8 @@ public:
 	void SetBotCreationLimit(uint32 new_creation_limit, uint8 class_id);
 	void SetBotSpawnLimit(int new_spawn_limit);
 	void SetBotSpawnLimit(int new_spawn_limit, uint8 class_id);
+	void CampAllBots();
+	void CampAllBots(uint8 class_id);
 
 #endif
 

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -1571,7 +1571,7 @@ void Lua_Mob::SendIllusionPacket(luabind::adl::object illusion) {
 		return;
 	}
 
-	int race = 0;
+	int race = RACE_DOUG_0;
 	int gender = 255;
 	int texture = 255;
 	int helmtexture = 255;

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -2871,6 +2871,16 @@ void Perl_Client_SetBotSpawnLimit(Client* self, int new_spawn_limit, uint8 class
 	self->SetBotSpawnLimit(new_spawn_limit, class_id);
 }
 
+void Perl_Client_CampAllBots(Client* self)
+{
+	self->CampAllBots();
+}
+
+void Perl_Client_CampAllBots(Client* self, uint8 class_id)
+{
+	self->CampAllBots(class_id);
+}
+
 #endif
 
 void perl_register_client()
@@ -2934,6 +2944,10 @@ void perl_register_client()
 	package.add("CalcPriceMod", (float(*)(Client*))&Perl_Client_CalcPriceMod);
 	package.add("CalcPriceMod", (float(*)(Client*, Mob*))&Perl_Client_CalcPriceMod);
 	package.add("CalcPriceMod", (float(*)(Client*, Mob*, bool))&Perl_Client_CalcPriceMod);
+#ifdef BOTS
+	package.add("CampAllBots", (void(*)(Client*))&Perl_Client_CampAllBots);
+	package.add("CampAllBots", (void(*)(Client*, uint8))&Perl_Client_CampAllBots);
+#endif
 	package.add("CanEnterZone", (bool(*)(Client*, std::string))&Perl_Client_CanEnterZone);
 	package.add("CanEnterZone", (bool(*)(Client*, std::string, int16))&Perl_Client_CanEnterZone);
 	package.add("CanHaveSkill", &Perl_Client_CanHaveSkill);

--- a/zone/petitions.cpp
+++ b/zone/petitions.cpp
@@ -71,8 +71,8 @@ void Petition::SendPetitionToPlayer(Client* clientto) {
 Petition::Petition(uint32 id)
 {
 	petid = id;
-	charclass = 0;
-	charrace = 0;
+	charclass = NO_CLASS;
+	charrace = RACE_DOUG_0;
 	charlevel = 0;
 	checkouts = 0;
 	unavailables = 0;

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -362,8 +362,8 @@ public:
 	inline bool ProximitySayInUse() { return HaveProximitySays; }
 
 #ifdef BOTS
-	int createbotcount(uint8 class_id = 0);
-	int spawnbotcount(uint8 class_id = 0);
+	int createbotcount(uint8 class_id = NO_CLASS);
+	int spawnbotcount(uint8 class_id = NO_CLASS);
 	bool botquest();
 	bool createBot(const char *name, const char *lastname, uint8 level, uint16 race, uint8 botclass, uint8 gender);
 #endif


### PR DESCRIPTION
# Perl
- Add `$client->CampAllBots()`.
- Add `$client->CampAllBots(class_id)`.

# Lua
- Add `client:CampAllBots()`.
- Add `client:CampAllBots(class_id)`.

# Notes
- Adds constants for `NO_CLASS` which is class `0` and uses `RACE_DOUG_0` for any spots that use race ID `0`.
- Cleans up magic number usage of race/class of `0`.