### PR TITLE
[Bug Fix] Fix issue with Bot::LoadAndSpawnAllZonedBots.

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -4220,19 +4220,6 @@ void Bot::LoadAndSpawnAllZonedBots(Client* bot_owner) {
 				auto spawned_bots_count = 0;
 				auto bot_spawn_limit = bot_owner->GetBotSpawnLimit();
 
-				worldserver.SendEmoteMessage(
-					0,
-					0,
-					AccountStatus::Player,
-					Chat::Yellow,
-					fmt::format(
-						"Spawned bot limit for {} is {} bot{}.",
-						bot_owner->GetCleanName(),
-						bot_spawn_limit,
-						bot_spawn_limit != 1 ? "s" : ""
-					).c_str()
-				);
-
 				if (!database.botdb.LoadAutoSpawnBotGroupsByOwnerID(bot_owner->CharacterID(), auto_spawn_botgroups)) {
 					bot_owner->Message(Chat::White, "Failed to load auto spawn bot groups by group ID.");
 					return;
@@ -4254,25 +4241,17 @@ void Bot::LoadAndSpawnAllZonedBots(Client* bot_owner) {
 							continue;
 						}
 
+						if (spawned_bots_count >= bot_spawn_limit) {
+							database.SetGroupID(b->GetCleanName(), 0, b->GetBotID());
+							continue;
+						}
+
 						if (!b->Spawn(bot_owner)) {
 							safe_delete(b);
 							continue;
 						}
 
 						spawned_bots_count++;
-
-						worldserver.SendEmoteMessage(
-							0,
-							0,
-							AccountStatus::Player,
-							Chat::Yellow,
-							fmt::format(
-								"Spawned bot count for {} is now {} bot{}.",
-								bot_owner->GetCleanName(),
-								spawned_bots_count,
-								spawned_bots_count != 1 ? "s" : ""
-							).c_str()
-						);
 
 						g->UpdatePlayer(b);
 
@@ -4282,22 +4261,6 @@ void Bot::LoadAndSpawnAllZonedBots(Client* bot_owner) {
 
 						if (!bot_owner->HasGroup()) {
 							database.SetGroupID(b->GetCleanName(), 0, b->GetBotID());
-						}
-
-						if (spawned_bots_count >= bot_spawn_limit) {
-							worldserver.SendEmoteMessage(
-								0,
-								0,
-								AccountStatus::Player,
-								Chat::Yellow,
-								fmt::format(
-									"Spawn limit for {} reached at {} bot{}.",
-									bot_owner->GetCleanName(),
-									bot_spawn_limit,
-									bot_spawn_limit != 1 ? "s" : ""
-								).c_str()
-							);
-							break;
 						}
 					}
 				}

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -4262,6 +4262,7 @@ void Bot::LoadAndSpawnAllZonedBots(Client* bot_owner) {
 							g->UpdatePlayer(bot_owner);
 							continue;
 						}
+
 						if (!b->Spawn(bot_owner)) {
 							safe_delete(b);
 							continue;

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -4220,6 +4220,19 @@ void Bot::LoadAndSpawnAllZonedBots(Client* bot_owner) {
 				auto spawned_bots_count = 0;
 				auto bot_spawn_limit = bot_owner->GetBotSpawnLimit();
 
+				worldserver.SendEmoteMessage(
+					0,
+					0,
+					AccountStatus::Player,
+					Chat::Yellow,
+					fmt::format(
+						"Spawned bot limit for {} is {} bot{}.",
+						bot_owner->GetCleanName(),
+						bot_spawn_limit,
+						bot_spawn_limit != 1 ? "s" : ""
+					).c_str()
+				);
+
 				if (!database.botdb.LoadAutoSpawnBotGroupsByOwnerID(bot_owner->CharacterID(), auto_spawn_botgroups)) {
 					bot_owner->Message(Chat::White, "Failed to load auto spawn bot groups by group ID.");
 					return;
@@ -4236,10 +4249,6 @@ void Bot::LoadAndSpawnAllZonedBots(Client* bot_owner) {
 
 				if (!active_bots.empty()) {
 					for (const auto& bot_id : active_bots) {
-						if (spawned_bots_count >= bot_spawn_limit) {
-							break;
-						}
-
 						auto* b = Bot::LoadBot(bot_id);
 						if (!b) {
 							continue;
@@ -4252,6 +4261,19 @@ void Bot::LoadAndSpawnAllZonedBots(Client* bot_owner) {
 
 						spawned_bots_count++;
 
+						worldserver.SendEmoteMessage(
+							0,
+							0,
+							AccountStatus::Player,
+							Chat::Yellow,
+							fmt::format(
+								"Spawned bot count for {} is now {} bot{}.",
+								bot_owner->GetCleanName(),
+								spawned_bots_count,
+								spawned_bots_count != 1 ? "s" : ""
+							).c_str()
+						);
+
 						g->UpdatePlayer(b);
 
 						if (g->IsGroupMember(bot_owner) && g->IsGroupMember(b)) {
@@ -4260,6 +4282,22 @@ void Bot::LoadAndSpawnAllZonedBots(Client* bot_owner) {
 
 						if (!bot_owner->HasGroup()) {
 							database.SetGroupID(b->GetCleanName(), 0, b->GetBotID());
+						}
+
+						if (spawned_bots_count >= bot_spawn_limit) {
+							worldserver.SendEmoteMessage(
+								0,
+								0,
+								AccountStatus::Player,
+								Chat::Yellow,
+								fmt::format(
+									"Spawn limit for {} reached at {} bot{}.",
+									bot_owner->GetCleanName(),
+									bot_spawn_limit,
+									bot_spawn_limit != 1 ? "s" : ""
+								).c_str()
+							);
+							break;
 						}
 					}
 				}

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -4248,7 +4248,7 @@ void Bot::LoadAndSpawnAllZonedBots(Client* bot_owner) {
 							continue;
 						}
 
-						if (spawned_bots_count >= bot_spawn_limit) {
+						if (bot_spawn_limit >= 0 && spawned_bots_count >= bot_spawn_limit) {
 							database.SetGroupID(b->GetCleanName(), 0, b->GetBotID());
 							g->UpdatePlayer(bot_owner);
 							continue;
@@ -4257,7 +4257,7 @@ void Bot::LoadAndSpawnAllZonedBots(Client* bot_owner) {
 						auto spawned_bot_count_class = bot_class_spawned_count[b->GetClass() - 1];
 						auto bot_spawn_limit_class = bot_class_spawn_limits[b->GetClass() - 1];
 
-						if (spawned_bot_count_class >= bot_spawn_limit_class) {
+						if (bot_spawn_limit_class >= 0 && spawned_bot_count_class >= bot_spawn_limit_class) {
 							database.SetGroupID(b->GetCleanName(), 0, b->GetBotID());
 							g->UpdatePlayer(bot_owner);
 							continue;
@@ -9611,7 +9611,7 @@ void Bot::SpawnBotGroupByName(Client* c, std::string botgroup_name, uint32 leade
 			return;
 		}
 
-		if (spawned_bot_count >= bot_spawn_limit) {
+		if (bot_spawn_limit >= 0 && spawned_bot_count >= bot_spawn_limit) {
 			c->Message(
 				Chat::White,
 				fmt::format(
@@ -9627,7 +9627,7 @@ void Bot::SpawnBotGroupByName(Client* c, std::string botgroup_name, uint32 leade
 		auto spawned_bot_count_class = bot_class_spawned_count[member->GetClass() - 1];
 		auto bot_spawn_limit_class = bot_class_spawn_limits[member->GetClass() - 1];
 
-		if (spawned_bot_count_class >= bot_spawn_limit_class) {
+		if (bot_spawn_limit_class >= 0 && spawned_bot_count_class >= bot_spawn_limit_class) {
 			c->Message(
 				Chat::White,
 				fmt::format(

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -4242,8 +4242,8 @@ void Bot::LoadAndSpawnAllZonedBots(Client* bot_owner) {
 						}
 
 						if (spawned_bots_count >= bot_spawn_limit) {
-							g->UpdatePlayer(bot_owner);
 							database.SetGroupID(b->GetCleanName(), 0, b->GetBotID());
+							g->UpdatePlayer(bot_owner);
 							continue;
 						}
 

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -4212,6 +4212,13 @@ void Bot::LoadAndSpawnAllZonedBots(Client* bot_owner) {
 	if (bot_owner) {
 		std::list<std::pair<uint32,std::string>> auto_spawn_botgroups;
 		if (bot_owner->HasGroup()) {
+			std::vector<int> bot_class_spawn_limits;
+			std::vector<int> bot_class_spawned_count = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+
+			for (uint8 class_id = WARRIOR; class_id <= BERSERKER; class_id++) {
+				bot_class_spawn_limits[class_id - 1] = bot_owner->GetBotSpawnLimit(class_id);
+			}
+
 			auto* g = bot_owner->GetGroup();
 			if (g) {
 				uint32 group_id = g->GetID();
@@ -4247,12 +4254,21 @@ void Bot::LoadAndSpawnAllZonedBots(Client* bot_owner) {
 							continue;
 						}
 
+						auto spawned_bot_count_class = bot_class_spawned_count[b->GetClass() - 1];
+						auto bot_spawn_limit_class = bot_class_spawn_limits[b->GetClass() - 1];
+
+						if (spawned_bot_count_class >= bot_spawn_limit_class) {
+							database.SetGroupID(b->GetCleanName(), 0, b->GetBotID());
+							g->UpdatePlayer(bot_owner);
+							continue;
+						}
 						if (!b->Spawn(bot_owner)) {
 							safe_delete(b);
 							continue;
 						}
 
 						spawned_bots_count++;
+						bot_class_spawned_count[b->GetClass() - 1]++;
 
 						g->UpdatePlayer(b);
 
@@ -9576,7 +9592,7 @@ void Bot::SpawnBotGroupByName(Client* c, std::string botgroup_name, uint32 leade
 	std::vector<int> bot_class_spawn_limits;
 	std::vector<int> bot_class_spawned_count = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
-	for (uint8 class_id = WARRIOR; class_id < BERSERKER; class_id++) {
+	for (uint8 class_id = WARRIOR; class_id <= BERSERKER; class_id++) {
 		bot_class_spawn_limits[class_id - 1] = c->GetBotSpawnLimit(class_id);
 	}
 

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -4242,6 +4242,7 @@ void Bot::LoadAndSpawnAllZonedBots(Client* bot_owner) {
 						}
 
 						if (spawned_bots_count >= bot_spawn_limit) {
+							g->UpdatePlayer(bot_owner);
 							database.SetGroupID(b->GetCleanName(), 0, b->GetBotID());
 							continue;
 						}


### PR DESCRIPTION
# Notes
- Resolves an issue where players could spawn more bots than allowed due to an edge-case where spawn limit by class/globally wasn't being checked on zone for individual bots nor spawn groups.
- Removes bots from group if they don't properly spawn.