### PR TITLE
[Quest API] Add Client Augment Events to Perl/Lua.

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -3101,8 +3101,9 @@ void Client::Handle_OP_AugmentItem(const EQApplicationPacket *app)
 							parse->EventItem(EVENT_AUGMENT_REMOVE, this, old_aug, nullptr, "", in_augment->augment_index, &args);
 
 							const auto export_string = fmt::format(
-								"{} {} {} {}",
+								"{} {} {} {} {}",
 								tobe_auged->GetID(),
+								item_slot,
 								aug->GetID(),
 								in_augment->augment_index,
 								false
@@ -3128,8 +3129,9 @@ void Client::Handle_OP_AugmentItem(const EQApplicationPacket *app)
 							args.push_back(aug);
 
 							const auto export_string = fmt::format(
-								"{} {} {}",
+								"{} {} {} {}",
 								tobe_auged->GetID(),
+								item_slot,
 								aug->GetID(),
 								in_augment->augment_index
 							);
@@ -3196,8 +3198,9 @@ void Client::Handle_OP_AugmentItem(const EQApplicationPacket *app)
 					args.push_back(aug);
 
 					const auto export_string = fmt::format(
-						"{} {} {} {}",
+						"{} {} {} {} {}",
 						tobe_auged->GetID(),
+						item_slot,
 						aug->GetID(),
 						in_augment->augment_index,
 						false
@@ -3259,8 +3262,9 @@ void Client::Handle_OP_AugmentItem(const EQApplicationPacket *app)
 					args.push_back(aug);
 
 					const auto export_string = fmt::format(
-						"{} {} {} {}",
+						"{} {} {} {} {}",
 						tobe_auged->GetID(),
+						item_slot,
 						aug->GetID(),
 						in_augment->augment_index,
 						true

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -3099,6 +3099,18 @@ void Client::Handle_OP_AugmentItem(const EQApplicationPacket *app)
 							args.assign(1, tobe_auged);
 							args.push_back(false);
 							parse->EventItem(EVENT_AUGMENT_REMOVE, this, old_aug, nullptr, "", in_augment->augment_index, &args);
+
+							const auto export_string = fmt::format(
+								"{} {} {} {}",
+								tobe_auged->GetID(),
+								aug->GetID(),
+								in_augment->augment_index,
+								false
+							);
+
+							args.push_back(aug);
+
+							parse->EventPlayer(EVENT_AUGMENT_REMOVE_CLIENT, this, export_string, 0, &args);
 						}
 
 						tobe_auged->PutAugment(in_augment->augment_index, *new_aug);
@@ -3112,6 +3124,17 @@ void Client::Handle_OP_AugmentItem(const EQApplicationPacket *app)
 
 							args.assign(1, tobe_auged);
 							parse->EventItem(EVENT_AUGMENT_INSERT, this, aug, nullptr, "", in_augment->augment_index, &args);
+
+							args.push_back(aug);
+
+							const auto export_string = fmt::format(
+								"{} {} {}",
+								tobe_auged->GetID(),
+								aug->GetID(),
+								in_augment->augment_index
+							);
+
+							parse->EventPlayer(EVENT_AUGMENT_INSERT_CLIENT, this, export_string, 0, &args);
 						} else {
 							Message(
 								Chat::Red,
@@ -3165,9 +3188,22 @@ void Client::Handle_OP_AugmentItem(const EQApplicationPacket *app)
 					std::vector<std::any> args;
 					args.push_back(aug);
 					parse->EventItem(EVENT_UNAUGMENT_ITEM, this, tobe_auged, nullptr, "", in_augment->augment_index, &args);
+
 					args.assign(1, tobe_auged);
 					args.push_back(false);
 					parse->EventItem(EVENT_AUGMENT_REMOVE, this, aug, nullptr, "", in_augment->augment_index, &args);
+
+					args.push_back(aug);
+
+					const auto export_string = fmt::format(
+						"{} {} {} {}",
+						tobe_auged->GetID(),
+						aug->GetID(),
+						in_augment->augment_index,
+						false
+					);
+
+					parse->EventPlayer(EVENT_AUGMENT_REMOVE_CLIENT, this, export_string, 0, &args);
 				} else {
 					Message(Chat::Red, "Error: Could not find augmentation to remove at index %i. Aborting.", in_augment->augment_index);
 					return;
@@ -3215,9 +3251,22 @@ void Client::Handle_OP_AugmentItem(const EQApplicationPacket *app)
 					std::vector<std::any> args;
 					args.push_back(aug);
 					parse->EventItem(EVENT_UNAUGMENT_ITEM, this, tobe_auged, nullptr, "", in_augment->augment_index, &args);
+
 					args.assign(1, tobe_auged);
 					args.push_back(true);
 					parse->EventItem(EVENT_AUGMENT_REMOVE, this, aug, nullptr, "", in_augment->augment_index, &args);
+
+					args.push_back(aug);
+
+					const auto export_string = fmt::format(
+						"{} {} {} {}",
+						tobe_auged->GetID(),
+						aug->GetID(),
+						in_augment->augment_index,
+						true
+					);
+
+					parse->EventPlayer(EVENT_AUGMENT_REMOVE_CLIENT, this, export_string, 0, &args);
 				} else {
 					Message(
 						Chat::Red,

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -1950,9 +1950,12 @@ void PerlembParser::ExportEventVariables(
 		case EVENT_AUGMENT_REMOVE_CLIENT: {
 			Seperator sep(data);
 			ExportVar(package_name.c_str(), "item_id", sep.arg[0]);
-			ExportVar(package_name.c_str(), "augment_id", sep.arg[1]);
-			ExportVar(package_name.c_str(), "augment_slot", sep.arg[2]);
-			ExportVar(package_name.c_str(), "destroyed", sep.arg[3]);
+			ExportVar(package_name.c_str(), "item_slot", sep.arg[1]);
+			ExportVar(package_name.c_str(), "augment_id", sep.arg[2]);
+			ExportVar(package_name.c_str(), "augment_slot", sep.arg[3]);
+			if (sep.argnum >= 4) {
+				ExportVar(package_name.c_str(), "destroyed", sep.arg[4]);
+			}
 			break;
 		}
 

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -169,7 +169,10 @@ const char *QuestEventSubroutines[_LargestEventID] = {
 	"EVENT_DESPAWN",
 	"EVENT_DESPAWN_ZONE",
 	"EVENT_BOT_CREATE",
-	"EVENT_SPELL_EFFECT_BOT", // Add new events before these or Lua crashes
+	"EVENT_AUGMENT_INSERT_CLIENT",
+	"EVENT_AUGMENT_REMOVE_CLIENT",
+	// Add new events before these or Lua crashes
+	"EVENT_SPELL_EFFECT_BOT",
 	"EVENT_SPELL_EFFECT_BUFF_TIC_BOT"
 };
 
@@ -1940,6 +1943,16 @@ void PerlembParser::ExportEventVariables(
 			ExportVar(package_name.c_str(), "item_id", extradata);
 			ExportVar(package_name.c_str(), "item_quantity", sep.arg[0]);
 			ExportVar(package_name.c_str(), "slot_id", sep.arg[1]);
+			break;
+		}
+
+		case EVENT_AUGMENT_INSERT_CLIENT:
+		case EVENT_AUGMENT_REMOVE_CLIENT: {
+			Seperator sep(data);
+			ExportVar(package_name.c_str(), "item_id", sep.arg[0]);
+			ExportVar(package_name.c_str(), "augment_id", sep.arg[1]);
+			ExportVar(package_name.c_str(), "augment_slot", sep.arg[2]);
+			ExportVar(package_name.c_str(), "destroyed", sep.arg[3]);
 			break;
 		}
 

--- a/zone/event_codes.h
+++ b/zone/event_codes.h
@@ -112,7 +112,10 @@ typedef enum {
 	EVENT_DESPAWN,
 	EVENT_DESPAWN_ZONE,
 	EVENT_BOT_CREATE,
-	EVENT_SPELL_EFFECT_BOT, // Add new events before these or Lua crashes
+	EVENT_AUGMENT_INSERT_CLIENT,
+	EVENT_AUGMENT_REMOVE_CLIENT,
+	// Add new events before these or Lua crashes
+	EVENT_SPELL_EFFECT_BOT,
 	EVENT_SPELL_EFFECT_BUFF_TIC_BOT,
 	_LargestEventID
 } QuestEventID;

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -4623,7 +4623,9 @@ luabind::scope lua_register_events() {
 			luabind::value("gm_command", static_cast<int>(EVENT_GM_COMMAND)),
 			luabind::value("despawn", static_cast<int>(EVENT_DESPAWN)),
 			luabind::value("despawn_zone", static_cast<int>(EVENT_DESPAWN_ZONE)),
-			luabind::value("bot_create", static_cast<int>(EVENT_BOT_CREATE))
+			luabind::value("bot_create", static_cast<int>(EVENT_BOT_CREATE)),
+			luabind::value("augment_insert_client", static_cast<int>(EVENT_AUGMENT_INSERT_CLIENT)),
+			luabind::value("augment_remove_client", static_cast<int>(EVENT_AUGMENT_REMOVE_CLIENT))
 		)];
 }
 

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -156,6 +156,8 @@ const char *LuaEvents[_LargestEventID] = {
 	"event_despawn",
 	"event_despawn_zone",
 	"event_bot_create",
+	"event_augment_insert_client",
+	"event_augment_remove_client",
 };
 
 extern Zone *zone;
@@ -272,6 +274,8 @@ LuaParser::LuaParser() {
 	PlayerArgumentDispatch[EVENT_LEVEL_DOWN] = handle_player_level_down;
 	PlayerArgumentDispatch[EVENT_GM_COMMAND] = handle_player_gm_command;
 	PlayerArgumentDispatch[EVENT_BOT_CREATE] = handle_player_bot_create;
+	PlayerArgumentDispatch[EVENT_AUGMENT_INSERT_CLIENT] = handle_player_augment_insert;
+	PlayerArgumentDispatch[EVENT_AUGMENT_REMOVE_CLIENT] = handle_player_augment_remove;
 
 	ItemArgumentDispatch[EVENT_ITEM_CLICK] = handle_item_click;
 	ItemArgumentDispatch[EVENT_ITEM_CLICK_CAST] = handle_item_click;

--- a/zone/lua_parser_events.cpp
+++ b/zone/lua_parser_events.cpp
@@ -1597,6 +1597,67 @@ void handle_player_merchant(
 	lua_setfield(L, -2, "item_cost");
 }
 
+void handle_player_augment_insert(
+	QuestInterface *parse,
+	lua_State* L,
+	Client* client,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any> *extra_pointers
+) {
+	Lua_ItemInst l_item(std::any_cast<EQ::ItemInstance*>(extra_pointers->at(0)));
+	luabind::adl::object l_item_o = luabind::adl::object(L, l_item);
+	l_item_o.push(L);
+	lua_setfield(L, -2, "item");
+
+	Lua_ItemInst l_augment(std::any_cast<EQ::ItemInstance*>(extra_pointers->at(1)));
+	luabind::adl::object l_augment_o = luabind::adl::object(L, l_augment);
+	l_augment_o.push(L);
+	lua_setfield(L, -2, "augment");
+
+	Seperator sep(data.c_str());
+	lua_pushinteger(L, std::stoul(sep.arg[0]));
+	lua_setfield(L, -2, "item_id");
+
+	lua_pushinteger(L, std::stoul(sep.arg[1]));
+	lua_setfield(L, -2, "augment_id");
+
+	lua_pushinteger(L, std::stoul(sep.arg[2]));
+	lua_setfield(L, -2, "augment_slot");
+}
+
+void handle_player_augment_remove(
+	QuestInterface *parse,
+	lua_State* L,
+	Client* client,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any> *extra_pointers
+) {
+	Lua_ItemInst l_item(std::any_cast<EQ::ItemInstance*>(extra_pointers->at(0)));
+	luabind::adl::object l_item_o = luabind::adl::object(L, l_item);
+	l_item_o.push(L);
+	lua_setfield(L, -2, "item");
+
+	Lua_ItemInst l_augment(std::any_cast<EQ::ItemInstance*>(extra_pointers->at(2)));
+	luabind::adl::object l_augment_o = luabind::adl::object(L, l_augment);
+	l_augment_o.push(L);
+	lua_setfield(L, -2, "augment");
+
+	Seperator sep(data.c_str());
+	lua_pushinteger(L, std::stoul(sep.arg[0]));
+	lua_setfield(L, -2, "item_id");
+
+	lua_pushinteger(L, std::stoul(sep.arg[1]));
+	lua_setfield(L, -2, "augment_id");
+
+	lua_pushinteger(L, std::stoul(sep.arg[2]));
+	lua_setfield(L, -2, "augment_slot");
+
+	lua_pushboolean(L, Strings::ToBool(sep.arg[3]));
+	lua_setfield(L, -2, "destroyed");
+}
+
 // Bot
 
 #ifdef BOTS

--- a/zone/lua_parser_events.cpp
+++ b/zone/lua_parser_events.cpp
@@ -1619,10 +1619,13 @@ void handle_player_augment_insert(
 	lua_pushinteger(L, std::stoul(sep.arg[0]));
 	lua_setfield(L, -2, "item_id");
 
-	lua_pushinteger(L, std::stoul(sep.arg[1]));
-	lua_setfield(L, -2, "augment_id");
+	lua_pushinteger(L, std::stoi(sep.arg[1]));
+	lua_setfield(L, -2, "item_slot");
 
 	lua_pushinteger(L, std::stoul(sep.arg[2]));
+	lua_setfield(L, -2, "augment_id");
+
+	lua_pushinteger(L, std::stoul(sep.arg[3]));
 	lua_setfield(L, -2, "augment_slot");
 }
 
@@ -1648,13 +1651,16 @@ void handle_player_augment_remove(
 	lua_pushinteger(L, std::stoul(sep.arg[0]));
 	lua_setfield(L, -2, "item_id");
 
-	lua_pushinteger(L, std::stoul(sep.arg[1]));
-	lua_setfield(L, -2, "augment_id");
+	lua_pushinteger(L, std::stoi(sep.arg[1]));
+	lua_setfield(L, -2, "item_slot");
 
 	lua_pushinteger(L, std::stoul(sep.arg[2]));
+	lua_setfield(L, -2, "augment_id");
+
+	lua_pushinteger(L, std::stoul(sep.arg[3]));
 	lua_setfield(L, -2, "augment_slot");
 
-	lua_pushboolean(L, Strings::ToBool(sep.arg[3]));
+	lua_pushboolean(L, Strings::ToBool(sep.arg[4]));
 	lua_setfield(L, -2, "destroyed");
 }
 

--- a/zone/lua_parser_events.h
+++ b/zone/lua_parser_events.h
@@ -637,6 +637,24 @@ void handle_player_bot_create(
 	std::vector<std::any> *extra_pointers
 );
 
+void handle_player_augment_insert(
+	QuestInterface *parse,
+	lua_State* L,
+	Client* client,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any> *extra_pointers
+);
+
+void handle_player_augment_remove(
+	QuestInterface *parse,
+	lua_State* L,
+	Client* client,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any> *extra_pointers
+);
+
 
 // Item
 void handle_item_click(

--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -140,6 +140,17 @@ void Object::HandleAugmentation(Client* user, const AugmentItem_Struct* in_augme
 
 				args.assign(1, tobe_auged);
 				parse->EventItem(EVENT_AUGMENT_INSERT, user, aug, nullptr, "", slot, &args);
+
+				args.push_back(aug);
+
+				const auto export_string = fmt::format(
+					"{} {} {}",
+					tobe_auged->GetID(),
+					aug->GetID(),
+					slot
+				);
+
+				parse->EventPlayer(EVENT_AUGMENT_INSERT_CLIENT, user, export_string, 0, &args);
 			}
 
 			item_one_to_push = tobe_auged->Clone();

--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -144,8 +144,9 @@ void Object::HandleAugmentation(Client* user, const AugmentItem_Struct* in_augme
 				args.push_back(aug);
 
 				const auto export_string = fmt::format(
-					"{} {} {}",
+					"{} {} {} {}",
 					tobe_auged->GetID(),
+					-1,
 					aug->GetID(),
 					slot
 				);


### PR DESCRIPTION
# Perl
- Add `EVENT_AUGMENT_INSERT_CLIENT`, exports `$augment_id`, `$augment_slot`, `$item_id`, and `$item_slot`.
- Add `EVENT_AUGMENT_REMOVE_CLIENT`, exports `$augment_id`, `$augment_slot`, `$destroyed`, `$item_id`, and `$item_slot`.

# Lua
- Add `event_augment_insert_client`, exports `e.augment`, `e.augment_id`, `e.augment_slot`, `e.item`, `e.item_id`, and `e.item_slot`.
- Add `event_augment_remove_client`, exports `e.augment`, `e.augment_id`, `e.augment_slot`, `e.destroyed`, `e.item`, `e.item_id`, and `e.item_slot`.

# Notes
- Allows operators to use augment insert and augment remove events outside of an item script.
- `$item_slot`/`e.item_slot` return `-1` if using a container.