### PR TITLE
[Lua] Resolve stoi Exception

### DIFF
--- a/common/strings.cpp
+++ b/common/strings.cpp
@@ -763,3 +763,10 @@ std::string Strings::Random(size_t length)
 	std::generate_n(str.begin(), length, randchar);
 	return str;
 }
+
+// a wrapper for stoi which will return a fallback if the string
+// fails to cast to a number
+bool Strings::Stoi(const std::string &s, int fallback)
+{
+	return Strings::IsNumber(s) ? std::stoi(s) : fallback;
+}

--- a/common/strings.cpp
+++ b/common/strings.cpp
@@ -766,7 +766,7 @@ std::string Strings::Random(size_t length)
 
 // a wrapper for stoi which will return a fallback if the string
 // fails to cast to a number
-bool Strings::Stoi(const std::string &s, int fallback)
+int Strings::ToInt(const std::string &s, int fallback)
 {
 	return Strings::IsNumber(s) ? std::stoi(s) : fallback;
 }

--- a/common/strings.h
+++ b/common/strings.h
@@ -86,7 +86,7 @@ class Strings {
 public:
 	static bool Contains(std::vector<std::string> container, std::string element);
 	static bool Contains(const std::string& subject, const std::string& search);
-	static bool Stoi(const std::string &s, int fallback = -1);
+	static int  ToInt(const std::string &s, int fallback = 0);
 	static bool IsNumber(const std::string &s);
 	static bool IsFloat(const std::string &s);
 	static const std::string ToLower(std::string s);

--- a/common/strings.h
+++ b/common/strings.h
@@ -86,6 +86,7 @@ class Strings {
 public:
 	static bool Contains(std::vector<std::string> container, std::string element);
 	static bool Contains(const std::string& subject, const std::string& search);
+	static bool Stoi(const std::string &s, int fallback = -1);
 	static bool IsNumber(const std::string &s);
 	static bool IsFloat(const std::string &s);
 	static const std::string ToLower(std::string s);

--- a/zone/lua_parser_events.cpp
+++ b/zone/lua_parser_events.cpp
@@ -120,12 +120,12 @@ void handle_npc_event_hp(
 	if(extra_data == 1) {
 		lua_pushinteger(L, -1);
 		lua_setfield(L, -2, "hp_event");
-		lua_pushinteger(L, std::stoi(data));
+		lua_pushinteger(L, Strings::Stoi(data));
 		lua_setfield(L, -2, "inc_hp_event");
 	}
 	else
 	{
-		lua_pushinteger(L, std::stoi(data));
+		lua_pushinteger(L, Strings::Stoi(data));
 		lua_setfield(L, -2, "hp_event");
 		lua_pushinteger(L, -1);
 		lua_setfield(L, -2, "inc_hp_event");
@@ -191,7 +191,7 @@ void handle_npc_task_accepted(
 	l_client_o.push(L);
 	lua_setfield(L, -2, "other");
 
-	lua_pushinteger(L, std::stoi(data));
+	lua_pushinteger(L, Strings::Stoi(data));
 	lua_setfield(L, -2, "task_id");
 }
 
@@ -209,7 +209,7 @@ void handle_npc_popup(
 	l_mob_o.push(L);
 	lua_setfield(L, -2, "other");
 
-	lua_pushinteger(L, std::stoi(data));
+	lua_pushinteger(L, Strings::Stoi(data));
 	lua_setfield(L, -2, "popup_id");
 }
 
@@ -227,7 +227,7 @@ void handle_npc_waypoint(
 	l_mob_o.push(L);
 	lua_setfield(L, -2, "other");
 
-	lua_pushinteger(L, std::stoi(data));
+	lua_pushinteger(L, Strings::Stoi(data));
 	lua_setfield(L, -2, "wp");
 }
 
@@ -245,7 +245,7 @@ void handle_npc_hate(
 	l_mob_o.push(L);
 	lua_setfield(L, -2, "other");
 
-	lua_pushboolean(L, std::stoi(data) == 0 ? false : true);
+	lua_pushboolean(L, Strings::Stoi(data) == 0 ? false : true);
 	lua_setfield(L, -2, "joined");
 }
 
@@ -259,7 +259,7 @@ void handle_npc_signal(
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
-	lua_pushinteger(L, std::stoi(data));
+	lua_pushinteger(L, Strings::Stoi(data));
 	lua_setfield(L, -2, "signal");
 }
 
@@ -274,7 +274,7 @@ void handle_npc_payload(
 ) {
 	Seperator sep(data.c_str());
 
-	lua_pushinteger(L, std::stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
 	lua_setfield(L, -2, "payload_id");
 
 	lua_pushstring(L, sep.argplus[1]);
@@ -309,13 +309,13 @@ void handle_npc_death(
 	lua_setfield(L, -2, "other");
 
 	Seperator sep(data.c_str());
-	lua_pushinteger(L, std::stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
 	lua_setfield(L, -2, "killer_id");
 
-	lua_pushinteger(L, std::stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
 	lua_setfield(L, -2, "damage");
 
-	int spell_id = std::stoi(sep.arg[2]);
+	int spell_id = Strings::Stoi(sep.arg[2]);
 	if(IsValidSpell(spell_id)) {
 		Lua_Spell l_spell(&spells[spell_id]);
 		luabind::adl::object l_spell_o = luabind::adl::object(L, l_spell);
@@ -328,7 +328,7 @@ void handle_npc_death(
 		lua_setfield(L, -2, "spell");
 	}
 
-	lua_pushinteger(L, std::stoi(sep.arg[3]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[3]));
 	lua_setfield(L, -2, "skill_id");
 
 	if (extra_pointers && extra_pointers->size() >= 1)
@@ -357,7 +357,7 @@ void handle_npc_cast(
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
-	int spell_id = std::stoi(data);
+	int spell_id = Strings::Stoi(data);
 	if(IsValidSpell(spell_id)) {
 		Lua_Spell l_spell(&spells[spell_id]);
 		luabind::adl::object l_spell_o = luabind::adl::object(L, l_spell);
@@ -522,13 +522,13 @@ void handle_player_environmental_damage(
 	std::vector<std::any> *extra_pointers
 ) {
 	Seperator sep(data.c_str());
-	lua_pushinteger(L, std::stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
 	lua_setfield(L, -2, "env_damage");
 
-	lua_pushinteger(L, std::stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
 	lua_setfield(L, -2, "env_damage_type");
 
-	lua_pushinteger(L, std::stoi(sep.arg[2]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[2]));
 	lua_setfield(L, -2, "env_final_damage");
 }
 
@@ -542,19 +542,19 @@ void handle_player_death(
 ) {
 	Seperator sep(data.c_str());
 
-	Mob *o = entity_list.GetMobID(std::stoi(sep.arg[0]));
+	Mob *o = entity_list.GetMobID(Strings::Stoi(sep.arg[0]));
 	Lua_Mob l_mob(o);
 	luabind::adl::object l_mob_o = luabind::adl::object(L, l_mob);
 	l_mob_o.push(L);
 	lua_setfield(L, -2, "other");
 
-	lua_pushinteger(L, std::stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
 	lua_setfield(L, -2, "killer_id");
 
-	lua_pushinteger(L, std::stoi(sep.arg[2]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[2]));
 	lua_setfield(L, -2, "damage");
 
-	int spell_id = std::stoi(sep.arg[3]);
+	int spell_id = Strings::Stoi(sep.arg[3]);
 	if(IsValidSpell(spell_id)) {
 		Lua_Spell l_spell(&spells[spell_id]);
 		luabind::adl::object l_spell_o = luabind::adl::object(L, l_spell);
@@ -567,7 +567,7 @@ void handle_player_death(
 		lua_setfield(L, -2, "spell");
 	}
 
-	lua_pushinteger(L, std::stoi(sep.arg[4]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[4]));
 	lua_setfield(L, -2, "skill");
 }
 
@@ -655,7 +655,7 @@ void handle_player_signal(
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
-	lua_pushinteger(L, std::stoi(data));
+	lua_pushinteger(L, Strings::Stoi(data));
 	lua_setfield(L, -2, "signal");
 }
 
@@ -669,7 +669,7 @@ void handle_player_payload(
 ) {
 	Seperator sep(data.c_str());
 
-	lua_pushinteger(L, std::stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
 	lua_setfield(L, -2, "payload_id");
 
 	lua_pushstring(L, sep.argplus[1]);
@@ -684,7 +684,7 @@ void handle_player_popup_response(
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
-	lua_pushinteger(L, std::stoi(data));
+	lua_pushinteger(L, Strings::Stoi(data));
 	lua_setfield(L, -2, "popup_id");
 }
 
@@ -712,7 +712,7 @@ void handle_player_cast(
 ) {
 	Seperator sep(data.c_str());
 
-	int spell_id = std::stoi(sep.arg[0]);
+	int spell_id = Strings::Stoi(sep.arg[0]);
 	if(IsValidSpell(spell_id)) {
 		Lua_Spell l_spell(&spells[spell_id]);
 		luabind::adl::object l_spell_o = luabind::adl::object(L, l_spell);
@@ -725,10 +725,10 @@ void handle_player_cast(
 
 	lua_setfield(L, -2, "spell");
 
-	lua_pushinteger(L, std::stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
 	lua_setfield(L, -2, "caster_id");
 
-	lua_pushinteger(L, std::stoi(sep.arg[2]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[2]));
 	lua_setfield(L, -2, "caster_level");
 }
 
@@ -740,7 +740,7 @@ void handle_player_task_fail(
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
-	lua_pushinteger(L, std::stoi(data));
+	lua_pushinteger(L, Strings::Stoi(data));
 	lua_setfield(L, -2, "task_id");
 }
 
@@ -754,22 +754,22 @@ void handle_player_zone(
 ) {
 	Seperator sep(data.c_str());
 
-	lua_pushinteger(L, std::stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
 	lua_setfield(L, -2, "from_zone_id");
 
-	lua_pushinteger(L, std::stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
 	lua_setfield(L, -2, "from_instance_id");
 
-	lua_pushinteger(L, std::stoi(sep.arg[2]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[2]));
 	lua_setfield(L, -2, "from_instance_version");
 
-	lua_pushinteger(L, std::stoi(sep.arg[3]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[3]));
 	lua_setfield(L, -2, "zone_id");
 
-	lua_pushinteger(L, std::stoi(sep.arg[4]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[4]));
 	lua_setfield(L, -2, "instance_id");
 
-	lua_pushinteger(L, std::stoi(sep.arg[5]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[5]));
 	lua_setfield(L, -2, "instance_version");
 }
 
@@ -829,10 +829,10 @@ void handle_player_task_stage_complete(
 	std::vector<std::any> *extra_pointers
 ) {
 	Seperator sep(data.c_str());
-	lua_pushinteger(L, std::stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
 	lua_setfield(L, -2, "task_id");
 
-	lua_pushinteger(L, std::stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
 	lua_setfield(L, -2, "activity_id");
 }
 
@@ -845,13 +845,13 @@ void handle_player_task_update(
 	std::vector<std::any> *extra_pointers
 ) {
 	Seperator sep(data.c_str());
-	lua_pushinteger(L, std::stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
 	lua_setfield(L, -2, "count");
 
-	lua_pushinteger(L, std::stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
 	lua_setfield(L, -2, "activity_id");
 
-	lua_pushinteger(L, std::stoi(sep.arg[2]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[2]));
 	lua_setfield(L, -2, "task_id");
 }
 
@@ -932,7 +932,7 @@ void handle_player_respawn(
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
-	lua_pushinteger(L, std::stoi(data));
+	lua_pushinteger(L, Strings::Stoi(data));
 	lua_setfield(L, -2, "option");
 
 	lua_pushboolean(L, extra_data == 1 ? true : false);
@@ -975,10 +975,10 @@ void handle_player_use_skill(
 	std::vector<std::any> *extra_pointers
 ) {
 	Seperator sep(data.c_str());
-	lua_pushinteger(L, std::stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
 	lua_setfield(L, -2, "skill_id");
 
-	lua_pushinteger(L, std::stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
 	lua_setfield(L, -2, "skill_level");
 }
 
@@ -1010,10 +1010,10 @@ void handle_player_combine_validate(
 	int zone_id = -1;
 	int tradeskill_id = -1;
 	if (strcmp(sep.arg[0], "check_zone") == 0) {
-		zone_id = std::stoi(sep.arg[1]);
+		zone_id = Strings::Stoi(sep.arg[1]);
 	}
 	else if (strcmp(sep.arg[0], "check_tradeskill") == 0) {
-		tradeskill_id = std::stoi(sep.arg[1]);
+		tradeskill_id = Strings::Stoi(sep.arg[1]);
 	}
 
 	lua_pushinteger(L, zone_id);
@@ -1075,7 +1075,7 @@ void handle_player_quest_combine(
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
-	lua_pushinteger(L, std::stoi(data));
+	lua_pushinteger(L, Strings::Stoi(data));
 	lua_setfield(L, -2, "container_slot");
  }
 
@@ -1087,7 +1087,7 @@ void handle_player_consider(
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
-	lua_pushinteger(L, std::stoi(data));
+	lua_pushinteger(L, Strings::Stoi(data));
 	lua_setfield(L, -2, "entity_id");
 }
 
@@ -1099,7 +1099,7 @@ void handle_player_consider_corpse(
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
-	lua_pushinteger(L, std::stoi(data));
+	lua_pushinteger(L, Strings::Stoi(data));
 	lua_setfield(L, -2, "corpse_entity_id");
 }
 
@@ -1126,16 +1126,16 @@ void handle_player_aa_buy(
 	std::vector<std::any> *extra_pointers
 ) {
 	Seperator sep(data.c_str());
-	lua_pushinteger(L, std::stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
 	lua_setfield(L, -2, "aa_cost");
 
-	lua_pushinteger(L, std::stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
 	lua_setfield(L, -2, "aa_id");
 
-	lua_pushinteger(L, std::stoi(sep.arg[2]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[2]));
 	lua_setfield(L, -2, "aa_previous_id");
 
-	lua_pushinteger(L, std::stoi(sep.arg[3]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[3]));
 	lua_setfield(L, -2, "aa_next_id");
 }
 
@@ -1147,7 +1147,7 @@ void handle_player_aa_gain(
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
-	lua_pushinteger(L, std::stoi(data));
+	lua_pushinteger(L, Strings::Stoi(data));
 	lua_setfield(L, -2, "aa_gained");
 }
 
@@ -1199,16 +1199,16 @@ void handle_player_bot_create(
 	lua_pushstring(L, sep.arg[0]);
 	lua_setfield(L, -2, "bot_name");
 
-	lua_pushinteger(L, std::stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
 	lua_setfield(L, -2, "bot_id");
 
-	lua_pushinteger(L, std::stoi(sep.arg[2]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[2]));
 	lua_setfield(L, -2, "bot_race");
 
-	lua_pushinteger(L, std::stoi(sep.arg[3]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[3]));
 	lua_setfield(L, -2, "bot_class");
 
-	lua_pushinteger(L, std::stoi(sep.arg[4]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[4]));
 	lua_setfield(L, -2, "bot_gender");
 }
 
@@ -1483,16 +1483,16 @@ void handle_spell_event(
 
 	Seperator sep(data.c_str());
 
-	lua_pushinteger(L, std::stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
 	lua_setfield(L, -2, "caster_id");
 
-	lua_pushinteger(L, std::stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
 	lua_setfield(L, -2, "tics_remaining");
 
-	lua_pushinteger(L, std::stoi(sep.arg[2]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[2]));
 	lua_setfield(L, -2, "caster_level");
 
-	lua_pushinteger(L, std::stoi(sep.arg[3]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[3]));
 	lua_setfield(L, -2, "buff_slot");
 
 	Lua_Spell l_spell(spell_id);
@@ -1541,10 +1541,10 @@ void handle_player_equip_item(
 
 	Seperator sep(data.c_str());
 
-	lua_pushnumber(L, std::stoi(sep.arg[0]));
+	lua_pushnumber(L, Strings::Stoi(sep.arg[0]));
 	lua_setfield(L, -2, "item_quantity");
 
-	lua_pushnumber(L, std::stoi(sep.arg[1]));
+	lua_pushnumber(L, Strings::Stoi(sep.arg[1]));
 	lua_setfield(L, -2, "slot_id");
 
 	Lua_ItemInst l_item(extra_data);
@@ -1632,16 +1632,16 @@ void handle_player_skill_up(
 	std::vector<std::any> *extra_pointers
 ) {
 	Seperator sep(data.c_str());
-	lua_pushinteger(L, std::stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
 	lua_setfield(L, -2, "skill_id");
 
-	lua_pushinteger(L, std::stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
 	lua_setfield(L, -2, "skill_value");
 
-	lua_pushinteger(L, std::stoi(sep.arg[2]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[2]));
 	lua_setfield(L, -2, "skill_max");
 
-	lua_pushinteger(L, std::stoi(sep.arg[3]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[3]));
 	lua_setfield(L, -2, "is_tradeskill");
 }
 
@@ -1654,13 +1654,13 @@ void handle_player_language_skill_up(
 	std::vector<std::any> *extra_pointers
 ) {
 	Seperator sep(data.c_str());
-	lua_pushinteger(L, std::stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
 	lua_setfield(L, -2, "skill_id");
 
-	lua_pushinteger(L, std::stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
 	lua_setfield(L, -2, "skill_value");
 
-	lua_pushinteger(L, std::stoi(sep.arg[2]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[2]));
 	lua_setfield(L, -2, "skill_max");
 }
 
@@ -1673,19 +1673,19 @@ void handle_player_alt_currency_merchant(
 	std::vector<std::any> *extra_pointers
 ) {
 	Seperator sep(data.c_str());
-	lua_pushinteger(L, std::stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
 	lua_setfield(L, -2, "currency_id");
 
-	lua_pushinteger(L, std::stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
 	lua_setfield(L, -2, "npc_id");
 
-	lua_pushinteger(L, std::stoi(sep.arg[2]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[2]));
 	lua_setfield(L, -2, "merchant_id");
 
-	lua_pushinteger(L, std::stoi(sep.arg[3]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[3]));
 	lua_setfield(L, -2, "item_id");
 
-	lua_pushinteger(L, std::stoi(sep.arg[4]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[4]));
 	lua_setfield(L, -2, "item_cost");
 }
 
@@ -1698,19 +1698,19 @@ void handle_player_merchant(
 	std::vector<std::any> *extra_pointers
 ) {
 	Seperator sep(data.c_str());
-	lua_pushinteger(L, std::stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
 	lua_setfield(L, -2, "npc_id");
 
-	lua_pushinteger(L, std::stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
 	lua_setfield(L, -2, "merchant_id");
 
-	lua_pushinteger(L, std::stoi(sep.arg[2]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[2]));
 	lua_setfield(L, -2, "item_id");
 
-	lua_pushinteger(L, std::stoi(sep.arg[3]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[3]));
 	lua_setfield(L, -2, "item_quantity");
 
-	lua_pushinteger(L, std::stoi(sep.arg[4]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[4]));
 	lua_setfield(L, -2, "item_cost");
 }
 
@@ -1736,7 +1736,7 @@ void handle_player_augment_insert(
 	lua_pushinteger(L, std::stoul(sep.arg[0]));
 	lua_setfield(L, -2, "item_id");
 
-	lua_pushinteger(L, std::stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
 	lua_setfield(L, -2, "item_slot");
 
 	lua_pushinteger(L, std::stoul(sep.arg[2]));
@@ -1768,7 +1768,7 @@ void handle_player_augment_remove(
 	lua_pushinteger(L, std::stoul(sep.arg[0]));
 	lua_setfield(L, -2, "item_id");
 
-	lua_pushinteger(L, std::stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
 	lua_setfield(L, -2, "item_slot");
 
 	lua_pushinteger(L, std::stoul(sep.arg[2]));
@@ -1805,7 +1805,7 @@ void handle_bot_cast(
 ) {
 	Seperator sep(data.c_str());
 
-	int spell_id = std::stoi(sep.arg[0]);
+	int spell_id = Strings::Stoi(sep.arg[0]);
 	if (IsValidSpell(spell_id)) {
 		Lua_Spell l_spell(&spells[spell_id]);
 		luabind::adl::object l_spell_o = luabind::adl::object(L, l_spell);
@@ -1818,10 +1818,10 @@ void handle_bot_cast(
 
 	lua_setfield(L, -2, "spell");
 
-	lua_pushinteger(L, std::stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
 	lua_setfield(L, -2, "caster_id");
 
-	lua_pushinteger(L, std::stoi(sep.arg[2]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[2]));
 	lua_setfield(L, -2, "caster_level");
 }
 
@@ -1839,7 +1839,7 @@ void handle_bot_combat(
 	l_mob_o.push(L);
 	lua_setfield(L, -2, "other");
 
-	lua_pushboolean(L, std::stoi(data) == 0 ? false : true);
+	lua_pushboolean(L, Strings::Stoi(data) == 0 ? false : true);
 	lua_setfield(L, -2, "joined");
 }
 
@@ -1854,16 +1854,16 @@ void handle_bot_death(
 ) {
 	Seperator sep(data.c_str());
 
-	Mob *o = entity_list.GetMobID(std::stoi(sep.arg[0]));
+	Mob *o = entity_list.GetMobID(Strings::Stoi(sep.arg[0]));
 	Lua_Mob l_mob(o);
 	luabind::adl::object l_mob_o = luabind::adl::object(L, l_mob);
 	l_mob_o.push(L);
 	lua_setfield(L, -2, "other");
 
-	lua_pushinteger(L, std::stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
 	lua_setfield(L, -2, "damage");
 
-	int spell_id = std::stoi(sep.arg[2]);
+	int spell_id = Strings::Stoi(sep.arg[2]);
 	if (IsValidSpell(spell_id)) {
 		Lua_Spell l_spell(&spells[spell_id]);
 		luabind::adl::object l_spell_o = luabind::adl::object(L, l_spell);
@@ -1876,7 +1876,7 @@ void handle_bot_death(
 		lua_setfield(L, -2, "spell");
 	}
 
-	lua_pushinteger(L, std::stoi(sep.arg[3]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[3]));
 	lua_setfield(L, -2, "skill");
 }
 
@@ -1894,7 +1894,7 @@ void handle_bot_popup_response(
 	l_mob_o.push(L);
 	lua_setfield(L, -2, "other");
 
-	lua_pushinteger(L, std::stoi(data));
+	lua_pushinteger(L, Strings::Stoi(data));
 	lua_setfield(L, -2, "popup_id");
 }
 
@@ -1928,7 +1928,7 @@ void handle_bot_signal(
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
-	lua_pushinteger(L, std::stoi(data));
+	lua_pushinteger(L, Strings::Stoi(data));
 	lua_setfield(L, -2, "signal");
 }
 
@@ -1943,7 +1943,7 @@ void handle_bot_payload(
 ) {
 	Seperator sep(data.c_str());
 
-	lua_pushinteger(L, std::stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
 	lua_setfield(L, -2, "payload_id");
 
 	lua_pushstring(L, sep.argplus[1]);
@@ -2061,10 +2061,10 @@ void handle_bot_use_skill(
 	std::vector<std::any> *extra_pointers
 ) {
 	Seperator sep(data.c_str());
-	lua_pushinteger(L, std::stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
 	lua_setfield(L, -2, "skill_id");
 
-	lua_pushinteger(L, std::stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
 	lua_setfield(L, -2, "skill_level");
 }
 

--- a/zone/lua_parser_events.cpp
+++ b/zone/lua_parser_events.cpp
@@ -227,7 +227,7 @@ void handle_npc_waypoint(
 	l_mob_o.push(L);
 	lua_setfield(L, -2, "other");
 
-	lua_pushinteger(L, Strings::Stoi(data));
+	lua_pushinteger(L, Strings::Stoi(data, -1));
 	lua_setfield(L, -2, "wp");
 }
 

--- a/zone/lua_parser_events.cpp
+++ b/zone/lua_parser_events.cpp
@@ -120,12 +120,12 @@ void handle_npc_event_hp(
 	if(extra_data == 1) {
 		lua_pushinteger(L, -1);
 		lua_setfield(L, -2, "hp_event");
-		lua_pushinteger(L, Strings::Stoi(data));
+		lua_pushinteger(L, Strings::ToInt(data));
 		lua_setfield(L, -2, "inc_hp_event");
 	}
 	else
 	{
-		lua_pushinteger(L, Strings::Stoi(data));
+		lua_pushinteger(L, Strings::ToInt(data));
 		lua_setfield(L, -2, "hp_event");
 		lua_pushinteger(L, -1);
 		lua_setfield(L, -2, "inc_hp_event");
@@ -191,7 +191,7 @@ void handle_npc_task_accepted(
 	l_client_o.push(L);
 	lua_setfield(L, -2, "other");
 
-	lua_pushinteger(L, Strings::Stoi(data));
+	lua_pushinteger(L, Strings::ToInt(data));
 	lua_setfield(L, -2, "task_id");
 }
 
@@ -209,7 +209,7 @@ void handle_npc_popup(
 	l_mob_o.push(L);
 	lua_setfield(L, -2, "other");
 
-	lua_pushinteger(L, Strings::Stoi(data));
+	lua_pushinteger(L, Strings::ToInt(data));
 	lua_setfield(L, -2, "popup_id");
 }
 
@@ -227,7 +227,7 @@ void handle_npc_waypoint(
 	l_mob_o.push(L);
 	lua_setfield(L, -2, "other");
 
-	lua_pushinteger(L, Strings::Stoi(data, -1));
+	lua_pushinteger(L, Strings::ToInt(data, -1));
 	lua_setfield(L, -2, "wp");
 }
 
@@ -245,7 +245,7 @@ void handle_npc_hate(
 	l_mob_o.push(L);
 	lua_setfield(L, -2, "other");
 
-	lua_pushboolean(L, Strings::Stoi(data) == 0 ? false : true);
+	lua_pushboolean(L, Strings::ToInt(data) == 0 ? false : true);
 	lua_setfield(L, -2, "joined");
 }
 
@@ -259,7 +259,7 @@ void handle_npc_signal(
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
-	lua_pushinteger(L, Strings::Stoi(data));
+	lua_pushinteger(L, Strings::ToInt(data));
 	lua_setfield(L, -2, "signal");
 }
 
@@ -274,7 +274,7 @@ void handle_npc_payload(
 ) {
 	Seperator sep(data.c_str());
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[0]));
 	lua_setfield(L, -2, "payload_id");
 
 	lua_pushstring(L, sep.argplus[1]);
@@ -309,13 +309,13 @@ void handle_npc_death(
 	lua_setfield(L, -2, "other");
 
 	Seperator sep(data.c_str());
-	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[0]));
 	lua_setfield(L, -2, "killer_id");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[1]));
 	lua_setfield(L, -2, "damage");
 
-	int spell_id = Strings::Stoi(sep.arg[2]);
+	int spell_id = Strings::ToInt(sep.arg[2]);
 	if(IsValidSpell(spell_id)) {
 		Lua_Spell l_spell(&spells[spell_id]);
 		luabind::adl::object l_spell_o = luabind::adl::object(L, l_spell);
@@ -328,7 +328,7 @@ void handle_npc_death(
 		lua_setfield(L, -2, "spell");
 	}
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[3]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[3]));
 	lua_setfield(L, -2, "skill_id");
 
 	if (extra_pointers && extra_pointers->size() >= 1)
@@ -357,7 +357,7 @@ void handle_npc_cast(
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
-	int spell_id = Strings::Stoi(data);
+	int spell_id = Strings::ToInt(data);
 	if(IsValidSpell(spell_id)) {
 		Lua_Spell l_spell(&spells[spell_id]);
 		luabind::adl::object l_spell_o = luabind::adl::object(L, l_spell);
@@ -522,13 +522,13 @@ void handle_player_environmental_damage(
 	std::vector<std::any> *extra_pointers
 ) {
 	Seperator sep(data.c_str());
-	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[0]));
 	lua_setfield(L, -2, "env_damage");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[1]));
 	lua_setfield(L, -2, "env_damage_type");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[2]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[2]));
 	lua_setfield(L, -2, "env_final_damage");
 }
 
@@ -542,19 +542,19 @@ void handle_player_death(
 ) {
 	Seperator sep(data.c_str());
 
-	Mob *o = entity_list.GetMobID(Strings::Stoi(sep.arg[0]));
+	Mob *o = entity_list.GetMobID(Strings::ToInt(sep.arg[0]));
 	Lua_Mob l_mob(o);
 	luabind::adl::object l_mob_o = luabind::adl::object(L, l_mob);
 	l_mob_o.push(L);
 	lua_setfield(L, -2, "other");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[1]));
 	lua_setfield(L, -2, "killer_id");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[2]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[2]));
 	lua_setfield(L, -2, "damage");
 
-	int spell_id = Strings::Stoi(sep.arg[3]);
+	int spell_id = Strings::ToInt(sep.arg[3]);
 	if(IsValidSpell(spell_id)) {
 		Lua_Spell l_spell(&spells[spell_id]);
 		luabind::adl::object l_spell_o = luabind::adl::object(L, l_spell);
@@ -567,7 +567,7 @@ void handle_player_death(
 		lua_setfield(L, -2, "spell");
 	}
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[4]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[4]));
 	lua_setfield(L, -2, "skill");
 }
 
@@ -655,7 +655,7 @@ void handle_player_signal(
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
-	lua_pushinteger(L, Strings::Stoi(data));
+	lua_pushinteger(L, Strings::ToInt(data));
 	lua_setfield(L, -2, "signal");
 }
 
@@ -669,7 +669,7 @@ void handle_player_payload(
 ) {
 	Seperator sep(data.c_str());
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[0]));
 	lua_setfield(L, -2, "payload_id");
 
 	lua_pushstring(L, sep.argplus[1]);
@@ -684,7 +684,7 @@ void handle_player_popup_response(
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
-	lua_pushinteger(L, Strings::Stoi(data));
+	lua_pushinteger(L, Strings::ToInt(data));
 	lua_setfield(L, -2, "popup_id");
 }
 
@@ -712,7 +712,7 @@ void handle_player_cast(
 ) {
 	Seperator sep(data.c_str());
 
-	int spell_id = Strings::Stoi(sep.arg[0]);
+	int spell_id = Strings::ToInt(sep.arg[0]);
 	if(IsValidSpell(spell_id)) {
 		Lua_Spell l_spell(&spells[spell_id]);
 		luabind::adl::object l_spell_o = luabind::adl::object(L, l_spell);
@@ -725,10 +725,10 @@ void handle_player_cast(
 
 	lua_setfield(L, -2, "spell");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[1]));
 	lua_setfield(L, -2, "caster_id");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[2]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[2]));
 	lua_setfield(L, -2, "caster_level");
 }
 
@@ -740,7 +740,7 @@ void handle_player_task_fail(
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
-	lua_pushinteger(L, Strings::Stoi(data));
+	lua_pushinteger(L, Strings::ToInt(data));
 	lua_setfield(L, -2, "task_id");
 }
 
@@ -754,22 +754,22 @@ void handle_player_zone(
 ) {
 	Seperator sep(data.c_str());
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[0]));
 	lua_setfield(L, -2, "from_zone_id");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[1]));
 	lua_setfield(L, -2, "from_instance_id");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[2]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[2]));
 	lua_setfield(L, -2, "from_instance_version");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[3]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[3]));
 	lua_setfield(L, -2, "zone_id");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[4]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[4]));
 	lua_setfield(L, -2, "instance_id");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[5]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[5]));
 	lua_setfield(L, -2, "instance_version");
 }
 
@@ -829,10 +829,10 @@ void handle_player_task_stage_complete(
 	std::vector<std::any> *extra_pointers
 ) {
 	Seperator sep(data.c_str());
-	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[0]));
 	lua_setfield(L, -2, "task_id");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[1]));
 	lua_setfield(L, -2, "activity_id");
 }
 
@@ -845,13 +845,13 @@ void handle_player_task_update(
 	std::vector<std::any> *extra_pointers
 ) {
 	Seperator sep(data.c_str());
-	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[0]));
 	lua_setfield(L, -2, "count");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[1]));
 	lua_setfield(L, -2, "activity_id");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[2]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[2]));
 	lua_setfield(L, -2, "task_id");
 }
 
@@ -932,7 +932,7 @@ void handle_player_respawn(
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
-	lua_pushinteger(L, Strings::Stoi(data));
+	lua_pushinteger(L, Strings::ToInt(data));
 	lua_setfield(L, -2, "option");
 
 	lua_pushboolean(L, extra_data == 1 ? true : false);
@@ -975,10 +975,10 @@ void handle_player_use_skill(
 	std::vector<std::any> *extra_pointers
 ) {
 	Seperator sep(data.c_str());
-	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[0]));
 	lua_setfield(L, -2, "skill_id");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[1]));
 	lua_setfield(L, -2, "skill_level");
 }
 
@@ -1010,10 +1010,10 @@ void handle_player_combine_validate(
 	int zone_id = -1;
 	int tradeskill_id = -1;
 	if (strcmp(sep.arg[0], "check_zone") == 0) {
-		zone_id = Strings::Stoi(sep.arg[1]);
+		zone_id = Strings::ToInt(sep.arg[1]);
 	}
 	else if (strcmp(sep.arg[0], "check_tradeskill") == 0) {
-		tradeskill_id = Strings::Stoi(sep.arg[1]);
+		tradeskill_id = Strings::ToInt(sep.arg[1]);
 	}
 
 	lua_pushinteger(L, zone_id);
@@ -1075,7 +1075,7 @@ void handle_player_quest_combine(
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
-	lua_pushinteger(L, Strings::Stoi(data));
+	lua_pushinteger(L, Strings::ToInt(data));
 	lua_setfield(L, -2, "container_slot");
  }
 
@@ -1087,7 +1087,7 @@ void handle_player_consider(
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
-	lua_pushinteger(L, Strings::Stoi(data));
+	lua_pushinteger(L, Strings::ToInt(data));
 	lua_setfield(L, -2, "entity_id");
 }
 
@@ -1099,7 +1099,7 @@ void handle_player_consider_corpse(
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
-	lua_pushinteger(L, Strings::Stoi(data));
+	lua_pushinteger(L, Strings::ToInt(data));
 	lua_setfield(L, -2, "corpse_entity_id");
 }
 
@@ -1126,16 +1126,16 @@ void handle_player_aa_buy(
 	std::vector<std::any> *extra_pointers
 ) {
 	Seperator sep(data.c_str());
-	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[0]));
 	lua_setfield(L, -2, "aa_cost");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[1]));
 	lua_setfield(L, -2, "aa_id");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[2]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[2]));
 	lua_setfield(L, -2, "aa_previous_id");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[3]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[3]));
 	lua_setfield(L, -2, "aa_next_id");
 }
 
@@ -1147,7 +1147,7 @@ void handle_player_aa_gain(
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
-	lua_pushinteger(L, Strings::Stoi(data));
+	lua_pushinteger(L, Strings::ToInt(data));
 	lua_setfield(L, -2, "aa_gained");
 }
 
@@ -1199,16 +1199,16 @@ void handle_player_bot_create(
 	lua_pushstring(L, sep.arg[0]);
 	lua_setfield(L, -2, "bot_name");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[1]));
 	lua_setfield(L, -2, "bot_id");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[2]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[2]));
 	lua_setfield(L, -2, "bot_race");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[3]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[3]));
 	lua_setfield(L, -2, "bot_class");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[4]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[4]));
 	lua_setfield(L, -2, "bot_gender");
 }
 
@@ -1483,16 +1483,16 @@ void handle_spell_event(
 
 	Seperator sep(data.c_str());
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[0]));
 	lua_setfield(L, -2, "caster_id");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[1]));
 	lua_setfield(L, -2, "tics_remaining");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[2]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[2]));
 	lua_setfield(L, -2, "caster_level");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[3]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[3]));
 	lua_setfield(L, -2, "buff_slot");
 
 	Lua_Spell l_spell(spell_id);
@@ -1541,10 +1541,10 @@ void handle_player_equip_item(
 
 	Seperator sep(data.c_str());
 
-	lua_pushnumber(L, Strings::Stoi(sep.arg[0]));
+	lua_pushnumber(L, Strings::ToInt(sep.arg[0]));
 	lua_setfield(L, -2, "item_quantity");
 
-	lua_pushnumber(L, Strings::Stoi(sep.arg[1]));
+	lua_pushnumber(L, Strings::ToInt(sep.arg[1]));
 	lua_setfield(L, -2, "slot_id");
 
 	Lua_ItemInst l_item(extra_data);
@@ -1632,16 +1632,16 @@ void handle_player_skill_up(
 	std::vector<std::any> *extra_pointers
 ) {
 	Seperator sep(data.c_str());
-	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[0]));
 	lua_setfield(L, -2, "skill_id");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[1]));
 	lua_setfield(L, -2, "skill_value");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[2]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[2]));
 	lua_setfield(L, -2, "skill_max");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[3]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[3]));
 	lua_setfield(L, -2, "is_tradeskill");
 }
 
@@ -1654,13 +1654,13 @@ void handle_player_language_skill_up(
 	std::vector<std::any> *extra_pointers
 ) {
 	Seperator sep(data.c_str());
-	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[0]));
 	lua_setfield(L, -2, "skill_id");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[1]));
 	lua_setfield(L, -2, "skill_value");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[2]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[2]));
 	lua_setfield(L, -2, "skill_max");
 }
 
@@ -1673,19 +1673,19 @@ void handle_player_alt_currency_merchant(
 	std::vector<std::any> *extra_pointers
 ) {
 	Seperator sep(data.c_str());
-	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[0]));
 	lua_setfield(L, -2, "currency_id");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[1]));
 	lua_setfield(L, -2, "npc_id");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[2]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[2]));
 	lua_setfield(L, -2, "merchant_id");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[3]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[3]));
 	lua_setfield(L, -2, "item_id");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[4]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[4]));
 	lua_setfield(L, -2, "item_cost");
 }
 
@@ -1698,19 +1698,19 @@ void handle_player_merchant(
 	std::vector<std::any> *extra_pointers
 ) {
 	Seperator sep(data.c_str());
-	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[0]));
 	lua_setfield(L, -2, "npc_id");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[1]));
 	lua_setfield(L, -2, "merchant_id");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[2]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[2]));
 	lua_setfield(L, -2, "item_id");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[3]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[3]));
 	lua_setfield(L, -2, "item_quantity");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[4]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[4]));
 	lua_setfield(L, -2, "item_cost");
 }
 
@@ -1736,7 +1736,7 @@ void handle_player_augment_insert(
 	lua_pushinteger(L, std::stoul(sep.arg[0]));
 	lua_setfield(L, -2, "item_id");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[1]));
 	lua_setfield(L, -2, "item_slot");
 
 	lua_pushinteger(L, std::stoul(sep.arg[2]));
@@ -1768,7 +1768,7 @@ void handle_player_augment_remove(
 	lua_pushinteger(L, std::stoul(sep.arg[0]));
 	lua_setfield(L, -2, "item_id");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[1]));
 	lua_setfield(L, -2, "item_slot");
 
 	lua_pushinteger(L, std::stoul(sep.arg[2]));
@@ -1805,7 +1805,7 @@ void handle_bot_cast(
 ) {
 	Seperator sep(data.c_str());
 
-	int spell_id = Strings::Stoi(sep.arg[0]);
+	int spell_id = Strings::ToInt(sep.arg[0]);
 	if (IsValidSpell(spell_id)) {
 		Lua_Spell l_spell(&spells[spell_id]);
 		luabind::adl::object l_spell_o = luabind::adl::object(L, l_spell);
@@ -1818,10 +1818,10 @@ void handle_bot_cast(
 
 	lua_setfield(L, -2, "spell");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[1]));
 	lua_setfield(L, -2, "caster_id");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[2]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[2]));
 	lua_setfield(L, -2, "caster_level");
 }
 
@@ -1839,7 +1839,7 @@ void handle_bot_combat(
 	l_mob_o.push(L);
 	lua_setfield(L, -2, "other");
 
-	lua_pushboolean(L, Strings::Stoi(data) == 0 ? false : true);
+	lua_pushboolean(L, Strings::ToInt(data) == 0 ? false : true);
 	lua_setfield(L, -2, "joined");
 }
 
@@ -1854,16 +1854,16 @@ void handle_bot_death(
 ) {
 	Seperator sep(data.c_str());
 
-	Mob *o = entity_list.GetMobID(Strings::Stoi(sep.arg[0]));
+	Mob *o = entity_list.GetMobID(Strings::ToInt(sep.arg[0]));
 	Lua_Mob l_mob(o);
 	luabind::adl::object l_mob_o = luabind::adl::object(L, l_mob);
 	l_mob_o.push(L);
 	lua_setfield(L, -2, "other");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[1]));
 	lua_setfield(L, -2, "damage");
 
-	int spell_id = Strings::Stoi(sep.arg[2]);
+	int spell_id = Strings::ToInt(sep.arg[2]);
 	if (IsValidSpell(spell_id)) {
 		Lua_Spell l_spell(&spells[spell_id]);
 		luabind::adl::object l_spell_o = luabind::adl::object(L, l_spell);
@@ -1876,7 +1876,7 @@ void handle_bot_death(
 		lua_setfield(L, -2, "spell");
 	}
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[3]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[3]));
 	lua_setfield(L, -2, "skill");
 }
 
@@ -1894,7 +1894,7 @@ void handle_bot_popup_response(
 	l_mob_o.push(L);
 	lua_setfield(L, -2, "other");
 
-	lua_pushinteger(L, Strings::Stoi(data));
+	lua_pushinteger(L, Strings::ToInt(data));
 	lua_setfield(L, -2, "popup_id");
 }
 
@@ -1928,7 +1928,7 @@ void handle_bot_signal(
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
-	lua_pushinteger(L, Strings::Stoi(data));
+	lua_pushinteger(L, Strings::ToInt(data));
 	lua_setfield(L, -2, "signal");
 }
 
@@ -1943,7 +1943,7 @@ void handle_bot_payload(
 ) {
 	Seperator sep(data.c_str());
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[0]));
 	lua_setfield(L, -2, "payload_id");
 
 	lua_pushstring(L, sep.argplus[1]);
@@ -2061,10 +2061,10 @@ void handle_bot_use_skill(
 	std::vector<std::any> *extra_pointers
 ) {
 	Seperator sep(data.c_str());
-	lua_pushinteger(L, Strings::Stoi(sep.arg[0]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[0]));
 	lua_setfield(L, -2, "skill_id");
 
-	lua_pushinteger(L, Strings::Stoi(sep.arg[1]));
+	lua_pushinteger(L, Strings::ToInt(sep.arg[1]));
 	lua_setfield(L, -2, "skill_level");
 }
 


### PR DESCRIPTION
### What

It's been reported by numerous operators since https://github.com/EQEmu/Server/pull/2635 that Lua is throwing exceptions for `stoi` calls within the source. While this may not necessarily be breaking anything, it can cause Lua to throw exceptions and become noise to operators.

![image](https://user-images.githubusercontent.com/3319450/212538612-748fd443-53e5-4fb5-abec-55875606dac1.png)

### Solution

This may not fix all places that this occurs, but a common place where `std::stoi` is called and many assumptions are made about inputs are in all of the event bindings where we pass in inputs from event calls. To cleanly mitigate this issue for now, I've added a strings wrapper that will detect for a validity of a string before providing a fallback `default -1` and a fallback can be provided in general for other use cases.