### PR TITLE
[Quest API] Add SendPath() to Perl/Lua.

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -11727,9 +11727,7 @@ void Client::MaxSkills()
 
 void Client::SendPath(Mob* target)
 {
-
 	if (!target) {
-		//empty length packet == not found.
 		EQApplicationPacket outapp(OP_FindPersonReply, 0);
 		QueuePacket(&outapp);
 		return;

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -11724,3 +11724,130 @@ void Client::MaxSkills()
 		}
 	}
 }
+
+void Client::SendPath(Mob* target)
+{
+
+	if (!target) {
+		//empty length packet == not found.
+		EQApplicationPacket outapp(OP_FindPersonReply, 0);
+		QueuePacket(&outapp);
+		return;
+	}
+
+
+	if (
+		!RuleB(Pathing, Find) &&
+		RuleB(Bazaar, EnableWarpToTrader) &&
+		target->IsClient() &&
+		(
+			target->CastToClient()->Trader ||
+			target->CastToClient()->Buyer
+		)
+	) {
+		Message(
+			Chat::Yellow,
+			fmt::format(
+				"Moving you to Trader {}.",
+				target->GetName()
+			).c_str()
+		);
+		MovePC(
+			zone->GetZoneID(),
+			zone->GetInstanceID(),
+			target->GetX(),
+			target->GetY(),
+			target->GetZ(),
+			0.0f
+		);
+		return;
+	}
+
+	std::vector<FindPerson_Point> points;
+
+	if (!RuleB(Pathing, Find) || !zone->pathing) {
+		points.clear();
+		FindPerson_Point a;
+		FindPerson_Point b;
+
+		a.x = GetX();
+		a.y = GetY();
+		a.z = GetZ();
+		b.x = target->GetX();
+		b.y = target->GetY();
+		b.z = target->GetZ();
+
+		points.push_back(a);
+		points.push_back(b);
+	} else {
+		glm::vec3 path_start(
+			GetX(),
+			GetY(),
+			GetZ() + (GetSize() < 6.0 ? 6 : GetSize()) * HEAD_POSITION
+		);
+
+		glm::vec3 path_end(
+			target->GetX(),
+			target->GetY(),
+			target->GetZ() + (target->GetSize() < 6.0 ? 6 : target->GetSize()) * HEAD_POSITION
+		);
+
+		bool partial = false;
+		bool stuck = false;
+		auto path_list = zone->pathing->FindRoute(path_start, path_end, partial, stuck);
+
+		if (path_list.empty() || partial) {
+			EQApplicationPacket outapp(OP_FindPersonReply, 0);
+			QueuePacket(&outapp);
+			return;
+		}
+
+		// Live appears to send the points in this order:
+		// Final destination.
+		// Current Position.
+		// rest of the points.
+		FindPerson_Point p;
+
+		int point_number = 0;
+
+		bool leads_to_teleporter = false;
+
+		auto v = path_list.back();
+
+		p.x = v.pos.x;
+		p.y = v.pos.y;
+		p.z = v.pos.z;
+		points.push_back(p);
+
+		p.x = GetX();
+		p.y = GetY();
+		p.z = GetZ();
+		points.push_back(p);
+
+		for (const auto& n : path_list) {
+			if (n.teleport) {
+				leads_to_teleporter = true;
+				break;
+			}
+
+			glm::vec3 v = n.pos;
+			p.x = v.x;
+			p.y = v.y;
+			p.z = v.z;
+
+			points.push_back(p);
+
+			++point_number;
+		}
+
+		if (!leads_to_teleporter) {
+			p.x = target->GetX();
+			p.y = target->GetY();
+			p.z = target->GetZ();
+
+			points.push_back(p);
+		}
+	}
+
+	SendPathPacket(points);
+}

--- a/zone/client.h
+++ b/zone/client.h
@@ -756,6 +756,8 @@ public:
 	uint32 GetMoney(uint8 type, uint8 subtype);
 	int GetAccountAge();
 
+	void SendPath(Mob* target);
+
 	bool IsDiscovered(uint32 itemid);
 	void DiscoverItem(uint32 itemid);
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -6058,107 +6058,11 @@ void Client::Handle_OP_FindPersonRequest(const EQApplicationPacket *app)
 	if (app->size != sizeof(FindPersonRequest_Struct))
 		printf("Error in FindPersonRequest_Struct. Expected size of: %zu, but got: %i\n", sizeof(FindPersonRequest_Struct), app->size);
 	else {
-		FindPersonRequest_Struct* t = (FindPersonRequest_Struct*)app->pBuffer;
+		auto* t = (FindPersonRequest_Struct*)app->pBuffer;
 
-		std::vector<FindPerson_Point> points;
-		Mob* target = entity_list.GetMob(t->npc_id);
+		auto* m = entity_list.GetMob(t->npc_id);
 
-		if (target == nullptr) {
-			//empty length packet == not found.
-			EQApplicationPacket outapp(OP_FindPersonReply, 0);
-			QueuePacket(&outapp);
-			return;
-		}
-
-		if (!RuleB(Pathing, Find) && RuleB(Bazaar, EnableWarpToTrader) && target->IsClient() && (target->CastToClient()->Trader ||
-			target->CastToClient()->Buyer)) {
-			Message(Chat::Yellow, "Moving you to Trader %s", target->GetName());
-			MovePC(zone->GetZoneID(), zone->GetInstanceID(), target->GetX(), target->GetY(), target->GetZ(), 0.0f);
-		}
-
-		if (!RuleB(Pathing, Find) || !zone->pathing)
-		{
-			//fill in the path array...
-			//
-			points.clear();
-			FindPerson_Point a;
-			FindPerson_Point b;
-
-			a.x = GetX();
-			a.y = GetY();
-			a.z = GetZ();
-			b.x = target->GetX();
-			b.y = target->GetY();
-			b.z = target->GetZ();
-
-			points.push_back(a);
-			points.push_back(b);
-		}
-		else
-		{
-			glm::vec3 Start(GetX(), GetY(), GetZ() + (GetSize() < 6.0 ? 6 : GetSize()) * HEAD_POSITION);
-			glm::vec3 End(target->GetX(), target->GetY(), target->GetZ() + (target->GetSize() < 6.0 ? 6 : target->GetSize()) * HEAD_POSITION);
-
-			bool partial = false;
-			bool stuck = false;
-			auto pathlist = zone->pathing->FindRoute(Start, End, partial, stuck);
-
-			if (pathlist.empty() || partial)
-			{
-				EQApplicationPacket outapp(OP_FindPersonReply, 0);
-				QueuePacket(&outapp);
-				return;
-			}
-
-			// Live appears to send the points in this order:
-			// Final destination.
-			// Current Position.
-			// rest of the points.
-			FindPerson_Point p;
-
-			int PointNumber = 0;
-
-			bool LeadsToTeleporter = false;
-
-			auto v = pathlist.back();
-
-			p.x = v.pos.x;
-			p.y = v.pos.y;
-			p.z = v.pos.z;
-			points.push_back(p);
-
-			p.x = GetX();
-			p.y = GetY();
-			p.z = GetZ();
-			points.push_back(p);
-
-			for (auto Iterator = pathlist.begin(); Iterator != pathlist.end(); ++Iterator)
-			{
-				if ((*Iterator).teleport) // Teleporter
-				{
-					LeadsToTeleporter = true;
-					break;
-				}
-
-				glm::vec3 v = (*Iterator).pos;
-				p.x = v.x;
-				p.y = v.y;
-				p.z = v.z;
-				points.push_back(p);
-				++PointNumber;
-			}
-
-			if (!LeadsToTeleporter)
-			{
-				p.x = target->GetX();
-				p.y = target->GetY();
-				p.z = target->GetZ();
-
-				points.push_back(p);
-			}
-		}
-
-		SendPathPacket(points);
+		SendPath(m);
 	}
 }
 

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -2936,6 +2936,12 @@ bool Lua_Client::CanEnterZone(std::string zone_short_name, int16 instance_versio
 	return self->CanEnterZone(zone_short_name, instance_version);
 }
 
+void Lua_Client::SendPath(Lua_Mob target)
+{
+	Lua_Safe_Call_Void();
+	self->SendPath(target);
+}
+
 #ifdef BOTS
 
 int Lua_Client::GetBotRequiredLevel()
@@ -3413,6 +3419,7 @@ luabind::scope lua_register_client() {
 	.def("SendMarqueeMessage", (void(Lua_Client::*)(uint32, std::string, uint32))&Lua_Client::SendMarqueeMessage)
 	.def("SendMarqueeMessage", (void(Lua_Client::*)(uint32, uint32, uint32, uint32, uint32, std::string))&Lua_Client::SendMarqueeMessage)
 	.def("SendOPTranslocateConfirm", (void(Lua_Client::*)(Lua_Mob,int))&Lua_Client::SendOPTranslocateConfirm)
+	.def("SendPath", (void(Lua_Client::*)(Lua_Mob))&Lua_Client::SendPath)
 	.def("SendPEQZoneFlagInfo", (void(Lua_Client::*)(Lua_Client))&Lua_Client::SendPEQZoneFlagInfo)
 	.def("SendSound", (void(Lua_Client::*)(void))&Lua_Client::SendSound)
 	.def("SendToGuildHall", (void(Lua_Client::*)(void))&Lua_Client::SendToGuildHall)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -461,6 +461,7 @@ public:
 	uint64 CalcEXP(uint8 consider_level, bool ignore_modifiers);
 	bool CanEnterZone(std::string zone_short_name);
 	bool CanEnterZone(std::string zone_short_name, int16 instance_version);
+	void SendPath(Lua_Mob target);
 
 	void ApplySpell(int spell_id);
 	void ApplySpell(int spell_id, int duration);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -2809,6 +2809,11 @@ bool Perl_Client_CanEnterZone(Client* self, std::string zone_short_name, int16 i
 	return self->CanEnterZone(zone_short_name, instance_version);
 }
 
+void Perl_Client_SendPath(Client* self, Mob* target)
+{
+	self->SendPath(target);
+}
+
 #ifdef BOTS
 
 int Perl_Client_GetBotRequiredLevel(Client* self)
@@ -3271,6 +3276,7 @@ void perl_register_client()
 	package.add("SendOPTranslocateConfirm", &Perl_Client_SendOPTranslocateConfirm);
 	package.add("SendPayload", (void(*)(Client*, int))&Perl_Client_SendPayload);
 	package.add("SendPayload", (void(*)(Client*, int, std::string))&Perl_Client_SendPayload);
+	package.add("SendPath", &Perl_Client_SendPath);
 	package.add("SendPEQZoneFlagInfo", &Perl_Client_SendPEQZoneFlagInfo);
 	package.add("SendSound", &Perl_Client_SendSound);
 	package.add("SendSpellAnim", &Perl_Client_SendSpellAnim);


### PR DESCRIPTION
# Perl
- Add `$client->SendPath(target)`.

# Lua
- Add `client:SendPath(target)`.

# Notes
- Allows operators to send a path to a target arbitrarily with a script.