### PR TITLE
[QS] Database class name change

### DIFF
--- a/queryserv/database.cpp
+++ b/queryserv/database.cpp
@@ -50,56 +50,8 @@
 #include "../common/strings.h"
 #include "../common/servertalk.h"
 
-Database::Database()
-{
-	DBInitVars();
-}
 
-/*
-Establish a connection to a mysql database with the supplied parameters
-*/
-
-Database::Database(const char *host, const char *user, const char *passwd, const char *database, uint32 port)
-{
-	DBInitVars();
-	Connect(host, user, passwd, database, port);
-}
-
-bool Database::Connect(const char *host, const char *user, const char *passwd, const char *database, uint32 port)
-{
-	uint32 errnum = 0;
-	char   errbuf[MYSQL_ERRMSG_SIZE];
-	if (!Open(host, user, passwd, database, port, &errnum, errbuf)) {
-		LogError("Failed to connect to database: Error: {}", errbuf);
-		HandleMysqlError(errnum);
-
-		return false;
-	}
-	else {
-		LogInfo("Using database [{}] at [{}]:[{}]", database, host, port);
-		return true;
-	}
-}
-
-void Database::DBInitVars()
-{
-
-}
-
-
-void Database::HandleMysqlError(uint32 errnum)
-{
-}
-
-/*
-
-Close the connection to the database
-*/
-Database::~Database()
-{
-}
-
-void Database::AddSpeech(
+void QSDatabase::AddSpeech(
 	const char *from,
 	const char *to,
 	const char *message,
@@ -134,7 +86,7 @@ void Database::AddSpeech(
 
 }
 
-void Database::LogPlayerDropItem(QSPlayerDropItem_Struct *QS)
+void QSDatabase::LogPlayerDropItem(QSPlayerDropItem_Struct *QS)
 {
 
 	std::string query = StringFormat(
@@ -173,7 +125,7 @@ void Database::LogPlayerDropItem(QSPlayerDropItem_Struct *QS)
 	}
 }
 
-void Database::LogPlayerTrade(QSPlayerLogTrade_Struct *QS, uint32 detailCount)
+void QSDatabase::LogPlayerTrade(QSPlayerLogTrade_Struct *QS, uint32 detailCount)
 {
 
 	std::string query   = StringFormat(
@@ -220,7 +172,7 @@ void Database::LogPlayerTrade(QSPlayerLogTrade_Struct *QS, uint32 detailCount)
 
 }
 
-void Database::LogPlayerHandin(QSPlayerLogHandin_Struct *QS, uint32 detailCount)
+void QSDatabase::LogPlayerHandin(QSPlayerLogHandin_Struct *QS, uint32 detailCount)
 {
 
 	std::string query   = StringFormat(
@@ -269,7 +221,7 @@ void Database::LogPlayerHandin(QSPlayerLogHandin_Struct *QS, uint32 detailCount)
 
 }
 
-void Database::LogPlayerNPCKill(QSPlayerLogNPCKill_Struct *QS, uint32 members)
+void QSDatabase::LogPlayerNPCKill(QSPlayerLogNPCKill_Struct *QS, uint32 members)
 {
 
 	std::string query   = StringFormat(
@@ -306,7 +258,7 @@ void Database::LogPlayerNPCKill(QSPlayerLogNPCKill_Struct *QS, uint32 members)
 
 }
 
-void Database::LogPlayerDelete(QSPlayerLogDelete_Struct *QS, uint32 items)
+void QSDatabase::LogPlayerDelete(QSPlayerLogDelete_Struct *QS, uint32 items)
 {
 
 	std::string query   = StringFormat(
@@ -345,7 +297,7 @@ void Database::LogPlayerDelete(QSPlayerLogDelete_Struct *QS, uint32 items)
 
 }
 
-void Database::LogPlayerMove(QSPlayerLogMove_Struct *QS, uint32 items)
+void QSDatabase::LogPlayerMove(QSPlayerLogMove_Struct *QS, uint32 items)
 {
 	/* These are item moves */
 
@@ -385,7 +337,7 @@ void Database::LogPlayerMove(QSPlayerLogMove_Struct *QS, uint32 items)
 	}
 }
 
-void Database::LogMerchantTransaction(QSMerchantLogTransaction_Struct *QS, uint32 items)
+void QSDatabase::LogMerchantTransaction(QSMerchantLogTransaction_Struct *QS, uint32 items)
 {
 	/* Merchant transactions are from the perspective of the merchant, not the player */
 	std::string query   = StringFormat(
@@ -433,7 +385,7 @@ void Database::LogMerchantTransaction(QSMerchantLogTransaction_Struct *QS, uint3
 }
 
 // this function does not delete the ServerPacket, so it must be handled at call site
-void Database::GeneralQueryReceive(ServerPacket *pack)
+void QSDatabase::GeneralQueryReceive(ServerPacket *pack)
 {
 	/*
 		These are general queries passed from anywhere in zone instead of packing structures and breaking them down again and again

--- a/queryserv/database.h
+++ b/queryserv/database.h
@@ -26,7 +26,7 @@
 #include "../common/eqemu_logsys.h"
 #include "../common/global_define.h"
 #include "../common/types.h"
-#include "../common/dbcore.h"
+#include "../common/database.h"
 #include "../common/linked_list.h"
 #include "../common/servertalk.h"
 #include <string>
@@ -36,13 +36,8 @@
 //atoi is not uint32 or uint32 safe!!!!
 #define atoul(str) strtoul(str, nullptr, 10)
 
-class Database : public DBcore {
+class QSDatabase : public Database {
 public:
-	Database();
-	Database(const char* host, const char* user, const char* passwd, const char* database,uint32 port);
-	bool Connect(const char* host, const char* user, const char* passwd, const char* database,uint32 port);
-	~Database();
-
 	void AddSpeech(const char* from, const char* to, const char* message, uint16 minstatus, uint32 guilddbid, uint8 type);
 	void LogPlayerTrade(QSPlayerLogTrade_Struct* QS, uint32 DetailCount);
 	void LogPlayerDropItem(QSPlayerDropItem_Struct* QS);

--- a/queryserv/lfguild.cpp
+++ b/queryserv/lfguild.cpp
@@ -8,7 +8,7 @@
 #include "../common/rulesys.h"
 
 extern WorldServer *worldserver;
-extern Database database;
+extern QSDatabase database;
 
 PlayerLookingForGuild::PlayerLookingForGuild(char *Name, char *Comments, uint32 Level, uint32 Class, uint32 AACount, uint32 Timezone, uint32 TimePosted)
 {

--- a/queryserv/queryserv.cpp
+++ b/queryserv/queryserv.cpp
@@ -32,19 +32,21 @@
 #include "lfguild.h"
 #include "worldserver.h"
 #include "../common/path_manager.h"
+#include "../common/zone_store.h"
 #include <list>
 #include <signal.h>
 #include <thread>
 
 volatile bool RunLoops = true;
 
-Database              database;
+QSDatabase              database;
 LFGuildManager        lfguildmanager;
 std::string           WorldShortName;
 const queryservconfig *Config;
 WorldServer           *worldserver = 0;
 EQEmuLogSys           LogSys;
 PathManager           path;
+ZoneStore             zone_store;
 
 void CatchSignal(int sig_num)
 {

--- a/queryserv/worldserver.cpp
+++ b/queryserv/worldserver.cpp
@@ -39,7 +39,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
 extern WorldServer           worldserver;
 extern const queryservconfig *Config;
-extern Database              database;
+extern QSDatabase              database;
 extern LFGuildManager        lfguildmanager;
 
 WorldServer::WorldServer()


### PR DESCRIPTION
### What

Similar to https://github.com/EQEmu/Server/pull/2742. Work done already in the player eventing branch to be PR'ed soon.

This PR addresses an issue that prevents developers from using repositories within QS because it clashes with `./common/database.h` `Database` class.

Similarly to `ZoneDatabase` and `WorldDatabase` QS's database was renamed from `Database` to `QSDatabase` and inherits `Database` so it can use commonly leveraged connect, disconnect logic that was copy and pasted way back