### PR TITLE
[Bug Fix] HasPet() Zone Crashes

### DIFF
--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1052,7 +1052,7 @@ public:
 	inline uint16 GetOwnerID() const { return ownerid; }
 	inline virtual bool HasOwner() { if(GetOwnerID()==0){return false;} return( entity_list.GetMob(GetOwnerID()) != 0); }
 	inline virtual bool IsPet() { return(HasOwner() && !IsMerc()); }
-	inline bool HasPet() const { if(GetPetID()==0){return false;} return (entity_list.GetMob(GetPetID()) != 0);}
+	bool HasPet();
 	inline bool HasTempPetsActive() const { return(hasTempPet); }
 	inline void SetTempPetsActive(bool i) { hasTempPet = i; }
 	inline int16 GetTempPetCount() const { return count_TempPet; }

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1052,7 +1052,7 @@ public:
 	inline uint16 GetOwnerID() const { return ownerid; }
 	inline virtual bool HasOwner() { if(GetOwnerID()==0){return false;} return( entity_list.GetMob(GetOwnerID()) != 0); }
 	inline virtual bool IsPet() { return(HasOwner() && !IsMerc()); }
-	bool HasPet();
+	bool HasPet() const;
 	inline bool HasTempPetsActive() const { return(hasTempPet); }
 	inline void SetTempPetsActive(bool i) { hasTempPet = i; }
 	inline int16 GetTempPetCount() const { return count_TempPet; }

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -3573,8 +3573,8 @@ void NPC::AIYellForHelp(Mob *sender, Mob *attacker)
 
 	LogAIYellForHelp(
 		"NPC [{}] ID [{}] is starting to scan",
-		(!this ? "NULL MOB" : GetCleanName()),
-		(!this ? 0 : GetID())
+		GetCleanName(),
+		GetID()
 	);
 
 	for (auto &close_mob : entity_list.GetCloseMobList(sender)) {

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -3573,8 +3573,8 @@ void NPC::AIYellForHelp(Mob *sender, Mob *attacker)
 
 	LogAIYellForHelp(
 		"NPC [{}] ID [{}] is starting to scan",
-		GetCleanName(),
-		GetID()
+		(!this ? "NULL MOB" : GetCleanName()),
+		(!this ? 0 : GetID())
 	);
 
 	for (auto &close_mob : entity_list.GetCloseMobList(sender)) {

--- a/zone/pets.cpp
+++ b/zone/pets.cpp
@@ -529,6 +529,26 @@ Mob* Mob::GetPet() {
 	return(tmp);
 }
 
+bool Mob::HasPet() {
+
+	if (GetPetID() == 0) {
+		return false;
+	}
+
+	auto m = entity_list.GetMob(GetPetID());
+	if (!m) {
+		SetPetID(0);
+		return false;
+	}
+
+	if (m->GetOwnerID() != GetID()) {
+		SetPetID(0);
+		return false;
+	}
+
+	return true;
+}
+
 void Mob::SetPet(Mob* newpet) {
 	Mob* oldpet = GetPet();
 	if (oldpet) {

--- a/zone/pets.cpp
+++ b/zone/pets.cpp
@@ -529,20 +529,18 @@ Mob* Mob::GetPet() {
 	return(tmp);
 }
 
-bool Mob::HasPet() {
+bool Mob::HasPet() const {
 
 	if (GetPetID() == 0) {
 		return false;
 	}
 
-	auto m = entity_list.GetMob(GetPetID());
+	const auto m = entity_list.GetMob(GetPetID());
 	if (!m) {
-		SetPetID(0);
 		return false;
 	}
 
 	if (m->GetOwnerID() != GetID()) {
-		SetPetID(0);
 		return false;
 	}
 

--- a/zone/pets.cpp
+++ b/zone/pets.cpp
@@ -530,7 +530,6 @@ Mob* Mob::GetPet() {
 }
 
 bool Mob::HasPet() const {
-
 	if (GetPetID() == 0) {
 		return false;
 	}


### PR DESCRIPTION
Fixes numerous Zone Crashes that I've seen on KMRA recently where null instance is passed into methods.

here's some where HasPet() returns true, but GetPet() returns null... causing a crash.

[crash_lopingplains_version_0_inst_id_0_port_7061_684812.log](https://github.com/EQEmu/Server/files/10421306/crash_lopingplains_version_0_inst_id_0_port_7061_684812.log)
[crash_oldfieldofbone_version_0_inst_id_0_port_7033_3364593.log](https://github.com/EQEmu/Server/files/10421307/crash_oldfieldofbone_version_0_inst_id_0_port_7033_3364593.log)
[crash_lopingplains_version_0_inst_id_0_port_7043_1953522.log](https://github.com/EQEmu/Server/files/10421308/crash_lopingplains_version_0_inst_id_0_port_7043_1953522.log)
