### PR TITLE
[Bug Fix] Fix ST_TargetsTarget Spells with Restrictions

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -2307,8 +2307,15 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, CastingSlot slot, in
 		}
 	}
 
+	//determine the type of spell target we have
+	CastAction_type CastAction;
+	if (!DetermineSpellTargets(spell_id, spell_target, ae_center, CastAction, slot, isproc)) {
+		LogSpells("Spell [{}]: Determine spell targets failure.", spell_id);
+		return(false);
+	}
+
 	//If spell was casted then we already checked these so skip, otherwise check here if being called directly from spell finished.
-	if (!from_casted_spell){
+	if (!from_casted_spell) {
 		if (!DoCastingChecksZoneRestrictions(true, spell_id)) {
 			LogSpells("Spell [{}]: Zone restriction failure.", spell_id);
 			return false;
@@ -2317,13 +2324,6 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, CastingSlot slot, in
 			LogSpells("Spell [{}]: Casting checks on Target failure.", spell_id);
 			return false;
 		}
-	}
-
-	//determine the type of spell target we have
-	CastAction_type CastAction;
-	if (!DetermineSpellTargets(spell_id, spell_target, ae_center, CastAction, slot, isproc)) {
-		LogSpells("Spell [{}]: Determine spell targets failure.", spell_id);
-		return(false);
 	}
 
 	LogSpells("Spell [{}]: target type [{}], target [{}], AE center [{}]", spell_id, CastAction, spell_target?spell_target->GetName():"NONE", ae_center?ae_center->GetName():"NONE");


### PR DESCRIPTION
This fixes ST_TargetsTarget Spells that are triggered from spell effects such as SE_ApplyEffect or SE_TriggerCast.

This was causing spells like Remote Manaflux which triggers a healing spell "Manaflux Enervation" on the TargetsTarget to fail as it has a restriction of "PCs and Mercs". It was doing the Target Restrictions against the original target of "Remote Manaflux" not the TargetsTarget (Client, Bot, Merc)