### PR TITLE
[Bug Fix] Move EVENT_SPAWN for adding NPCs back to original spot, also add NPCs…

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -8521,6 +8521,9 @@ Client* EntityList::GetBotOwnerByBotID(const uint32 bot_id)  {
 void EntityList::AddBot(Bot *new_bot, bool send_spawn_packet, bool dont_queue) {
 	if (new_bot) {
 		new_bot->SetID(GetFreeID());
+		bot_list.push_back(new_bot);
+		mob_list.insert(std::pair<uint16, Mob*>(new_bot->GetID(), new_bot));
+		parse->EventBot(EVENT_SPAWN, new_bot, nullptr, "", 0);
 		new_bot->SetSpawned();
 		if (send_spawn_packet) {
 			if (dont_queue) {
@@ -8537,11 +8540,6 @@ void EntityList::AddBot(Bot *new_bot, bool send_spawn_packet, bool dont_queue) {
 				safe_delete(ns);
 			}
 		}
-
-		bot_list.push_back(new_bot);
-		mob_list.insert(std::pair<uint16, Mob*>(new_bot->GetID(), new_bot));
-
-		parse->EventBot(EVENT_SPAWN, new_bot, nullptr, "", 0);
 
 		new_bot->DispatchZoneControllerEvent(EVENT_SPAWN_ZONE, new_bot, "", 0, nullptr);
 	}

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -697,7 +697,12 @@ void EntityList::AddNPC(NPC *npc, bool send_spawn_packet, bool dont_queue)
 			owner->SetPetID(npc->GetID());
 		}
 	}
-
+	
+	npc_list.insert(std::pair<uint16, NPC *>(npc->GetID(), npc));
+	mob_list.insert(std::pair<uint16, Mob *>(npc->GetID(), npc));
+	
+	parse->EventNPC(EVENT_SPAWN, npc, nullptr, "", 0);
+	
 	const auto emote_id = npc->GetEmoteID();
 	if (emote_id != 0) {
 		npc->DoNPCEmote(EQ::constants::EmoteEventTypes::OnSpawn, emote_id);
@@ -730,11 +735,6 @@ void EntityList::AddNPC(NPC *npc, bool send_spawn_packet, bool dont_queue)
 			UpdateFindableNPCState(npc, false);
 		}
 	}
-
-	npc_list.insert(std::pair<uint16, NPC *>(npc->GetID(), npc));
-	mob_list.insert(std::pair<uint16, Mob *>(npc->GetID(), npc));
-
-	parse->EventNPC(EVENT_SPAWN, npc, nullptr, "", 0);
 
 	entity_list.ScanCloseMobs(npc->close_mobs, npc, true);
 


### PR DESCRIPTION
… to npc/mob list before parsing

Allows you to change NPCs before spawning rather than after