### PR TITLE
[Bug Fix] Handle_OP_AugmentItem could cause Zone crash

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -3104,12 +3104,12 @@ void Client::Handle_OP_AugmentItem(const EQApplicationPacket *app)
 								"{} {} {} {} {}",
 								tobe_auged->GetID(),
 								item_slot,
-								aug->GetID(),
+								old_aug->GetID(),
 								in_augment->augment_index,
 								false
 							);
 
-							args.push_back(aug);
+							args.push_back(old_aug);
 
 							parse->EventPlayer(EVENT_AUGMENT_REMOVE_CLIENT, this, export_string, 0, &args);
 						}


### PR DESCRIPTION
Was using incorrect variable, which was still initialized as a nullptr.