### PR TITLE
Add HasItemOnCorpse to quest APIs

### DIFF
--- a/zone/client.h
+++ b/zone/client.h
@@ -1439,6 +1439,7 @@ public:
 	uint32 GetCorpseCount() { return database.GetCharacterCorpseCount(CharacterID()); }
 	uint32 GetCorpseID(int corpse) { return database.GetCharacterCorpseID(CharacterID(), corpse); }
 	uint32 GetCorpseItemAt(int corpse_id, int slot_id) { return database.GetCharacterCorpseItemAt(corpse_id, slot_id); }
+	bool HasItemOnCorpse(uint32 item_id) { return database.CharacterHasItemOnCorpse(CharacterID(), item_id); }
 	void SuspendMinion(int value);
 	void Doppelganger(uint16 spell_id, Mob *target, const char *name_override, int pet_count, int pet_duration);
 	void NotifyNewTitlesAvailable();

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -2446,6 +2446,11 @@ bool Lua_Client::HasItemEquippedByID(uint32 item_id) {
 	return self->GetInv().HasItemEquippedByID(item_id);
 }
 
+bool Lua_Client::HasItemOnCorpse(uint32 item_id) {
+	Lua_Safe_Call_Bool();
+	return self->HasItemOnCorpse(item_id);
+}
+
 void Lua_Client::AddPlatinum(uint32 platinum) {
 	Lua_Safe_Call_Void();
 	self->AddPlatinum(platinum);
@@ -3288,6 +3293,7 @@ luabind::scope lua_register_client() {
 	.def("HasDisciplineLearned", (bool(Lua_Client::*)(uint16))&Lua_Client::HasDisciplineLearned)
 	.def("HasExpeditionLockout", (bool(Lua_Client::*)(std::string, std::string))&Lua_Client::HasExpeditionLockout)
 	.def("HasItemEquippedByID", (bool(Lua_Client::*)(uint32))&Lua_Client::HasItemEquippedByID)
+	.def("HasItemOnCorpse", (bool(Lua_Client::*)(int))&Lua_Client::HasItemOnCorpse)
 	.def("HasPEQZoneFlag", (bool(Lua_Client::*)(uint32))&Lua_Client::HasPEQZoneFlag)
 	.def("HasRecipeLearned", (bool(Lua_Client::*)(uint32))&Lua_Client::HasRecipeLearned)
 	.def("HasSkill", (bool(Lua_Client::*)(int))&Lua_Client::HasSkill)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -365,6 +365,7 @@ public:
 	int GetCorpseCount();
 	int GetCorpseID(int corpse);
 	int GetCorpseItemAt(int corpse, int slot);
+	bool HasItemOnCorpse(uint32 item_id);
 	void AssignToInstance(int instance_id);
 	void Freeze();
 	void UnFreeze();

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -1417,6 +1417,11 @@ uint32_t Perl_Client_GetCorpseItemAt(Client* self, uint32 corpse_id, uint16 slot
 	return self->GetCorpseItemAt(corpse_id, slot_id);
 }
 
+bool Perl_Client_HasItemOnCorpse(Client* self, uint32 item_id)
+{
+	return self->HasItemOnCorpse(item_id);
+}
+
 void Perl_Client_AssignToInstance(Client* self, uint16 instance_id) // @categories Adventures and Expeditions
 {
 	self->AssignToInstance(instance_id);
@@ -3150,6 +3155,7 @@ void perl_register_client()
 	package.add("HasDisciplineLearned", &Perl_Client_HasDisciplineLearned);
 	package.add("HasExpeditionLockout", &Perl_Client_HasExpeditionLockout);
 	package.add("HasItemEquippedByID", &Perl_Client_HasItemEquippedByID);
+	package.add("HasItemOnCorpse", &Perl_Client_HasItemOnCorpse);
 	package.add("HasPEQZoneFlag", &Perl_Client_HasPEQZoneFlag);
 	package.add("HasRecipeLearned", &Perl_Client_HasRecipeLearned);
 	package.add("HasSkill", &Perl_Client_HasSkill);

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -4071,6 +4071,19 @@ uint32 ZoneDatabase::GetCharacterCorpseItemAt(uint32 corpse_id, uint16 slotid) {
 	return itemid;
 }
 
+bool ZoneDatabase::CharacterHasItemOnCorpse(uint32 corpse_id, uint32 item_id) {
+	// just returns true/false, we don't check count or anything
+	auto query = fmt::format(
+	    "SELECT ci.item_id FROM character_corpse_items ci INNER JOIN character_corpses cc on "
+	    "cc.id = ci.corpse_id WHERE cc.charid = {0} AND (ci.item_id = {1} OR ci.aug_1 = {1} OR ci.aug_2 "
+	    "= {1} OR ci.aug_3 = {1} OR ci.aug_4 = {1} OR ci.aug_5 = {1} OR ci.aug_6 = {1}) LIMIT 1",
+	    corpse_id, item_id);
+	auto results = QueryDatabase(query);
+	if (results.Success() && results.RowCount() > 0)
+		return true;
+	return false;
+}
+
 bool ZoneDatabase::LoadCharacterCorpseData(uint32 corpse_id, PlayerCorpse_Struct* pcs){
 	std::string query = StringFormat(
 		"SELECT           \n"

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -4071,13 +4071,13 @@ uint32 ZoneDatabase::GetCharacterCorpseItemAt(uint32 corpse_id, uint16 slotid) {
 	return itemid;
 }
 
-bool ZoneDatabase::CharacterHasItemOnCorpse(uint32 corpse_id, uint32 item_id) {
+bool ZoneDatabase::CharacterHasItemOnCorpse(uint32 charid, uint32 item_id) {
 	// just returns true/false, we don't check count or anything
 	auto query = fmt::format(
 	    "SELECT ci.item_id FROM character_corpse_items ci INNER JOIN character_corpses cc on "
 	    "cc.id = ci.corpse_id WHERE cc.charid = {0} AND (ci.item_id = {1} OR ci.aug_1 = {1} OR ci.aug_2 "
 	    "= {1} OR ci.aug_3 = {1} OR ci.aug_4 = {1} OR ci.aug_5 = {1} OR ci.aug_6 = {1}) LIMIT 1",
-	    corpse_id, item_id);
+	    charid, item_id);
 	auto results = QueryDatabase(query);
 	if (results.Success() && results.RowCount() > 0)
 		return true;

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -454,6 +454,7 @@ public:
 	uint32		GetCharacterCorpseCount(uint32 char_id);
 	uint32		GetCharacterCorpseID(uint32 char_id, uint8 corpse);
 	uint32		GetCharacterCorpseItemAt(uint32 corpse_id, uint16 slotid);
+	bool		CharacterHasItemOnCorpse(uint32 charid, uint32 item_id);
 	uint32		GetPlayerCorpseTimeLeft(uint8 corpse, uint8 type);
 	void        SendCharacterCorpseToNonInstance(uint32 corpse_db_id);
 


### PR DESCRIPTION
Main motivation is PEQ's client_ext HasItem. The current API has SIGNIFICANT overhead and lacks the ability to search augs, which the rest of the HasItem searches do.