### PR TITLE
[Fix] Zone Flags Regression

### DIFF
--- a/zone/client.h
+++ b/zone/client.h
@@ -1352,7 +1352,7 @@ public:
 	void ClearPendingAdventureDoorClick() { safe_delete(adventure_door_timer); }
 	void ClearPendingAdventureData();
 
-	bool CanEnterZone(std::string zone_short_name = "", int16 instance_version = -1);
+	bool CanEnterZone(const std::string& zone_short_name = "", int16 instance_version = -1);
 
 	int GetAggroCount();
 	void IncrementAggroCount(bool raid_target = false);

--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -265,6 +265,19 @@ void Doors::HandleClick(Client *sender, uint8 trigger)
 		}
 	}
 
+	// enforce flags before they hit zoning process
+	auto z = GetZone(m_destination_zone_name, 0);
+	if (!z->flag_needed.empty() && Strings::IsNumber(z->flag_needed) && std::stoi(z->flag_needed) == 1) {
+		if (sender->Admin() < minStatusToIgnoreZoneFlags && !sender->HasZoneFlag(z->zoneidnumber)) {
+			LogInfo(
+				"Character [{}] does not have the flag to be in this zone [{}]!",
+				sender->GetCleanName(),
+				z->flag_needed
+			);
+			sender->MessageString(Chat::LightBlue, DOORS_LOCKED);
+		}
+	}
+
 	/**
 	 * Guild Doors
 	 *

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -1198,7 +1198,7 @@ void Client::SetPEQZoneFlag(uint32 zone_id) {
 	}
 }
 
-bool Client::CanEnterZone(std::string zone_short_name, int16 instance_version) {
+bool Client::CanEnterZone(const std::string& zone_short_name, int16 instance_version) {
 	//check some critial rules to see if this char needs to be booted from the zone
 	//only enforce rules here which are serious enough to warrant being kicked from
 	//the zone
@@ -1246,11 +1246,8 @@ bool Client::CanEnterZone(std::string zone_short_name, int16 instance_version) {
 		return false;
 	}
 
-	if (!z->flag_needed.empty()) {
-		if (
-			Admin() < minStatusToIgnoreZoneFlags &&
-			!HasZoneFlag(zone->GetZoneID())
-		) {
+	if (!z->flag_needed.empty() && Strings::IsNumber(z->flag_needed) && std::stoi(z->flag_needed) == 1) {
+		if (Admin() < minStatusToIgnoreZoneFlags && !HasZoneFlag(z->zoneidnumber)) {
 			LogInfo(
 				"Character [{}] does not have the flag to be in this zone [{}]!",
 				GetCleanName(),


### PR DESCRIPTION
### What

This fixes a regression of desired behavior in zone flag checks. This one is interesting because the code change that changed the behavior is actually correct and cleans things up but revealed problems in our data. This fixes

* An issue where zone flags were being checked against the current zone and not the destination zone
* Previous behavior where zone flags with string types are not enforced
* Zones with flags are now additionally enforced earlier in the process to keep clients from getting punted to 0,0,0 in the zone right before the zoning process

**Example Issue**

Trakanon uses a key to enter the zone. On the zone table row there is `flag_needed` on the row but it wasn't truly enforced before and it is a non-bool. ProjectEQ quests also do nothing to award the flag to enter the zone.

```
select zoneidnumber, short_name, flag_needed from zone where flag_needed != '';
+--------------+------------+-----------------+
| zoneidnumber | short_name | flag_needed     |
+--------------+------------+-----------------+
|          209 | bothunder  | 1               |
|          105 | charasis   | Key to Charasis |
|          200 | codecay    | 1               |
|          211 | hohonora   | 1               |
|          220 | hohonorb   | 1               |
|          293 | kodtaz     | 1               |
|          221 | nightmareb | 1               |
|          215 | poair      | 1               |
|          218 | poeartha   | 1               |
|          222 | poearthb   | 1               |
|          217 | pofire     | 1               |
|          210 | postorms   | 1               |
|          214 | potactics  | 1               |
|          219 | potimea    | 1               |
|          223 | potimeb    | 1               |
|          207 | potorment  | 1               |
|          208 | povalor    | 1               |
|          213 | powar      | 0               |
|          216 | powater    | 1               |
|          295 | qvic       | 1               |
|           89 | sebilis    | Trakanon Idol   |
|          128 | sleeper    | Sleeper's Key   |
|          212 | solrotower | 1               |
|          297 | txevu      | 1               |
+--------------+------------+-----------------+
```

**Action Items**

If `sebilis` `sleeper` and `charasis` should be truly enforced at a flag level, they need their columns set to `1` and the flag needs to be awarded to the character somewhere within the quest system. For now this restores the previous behavior