### PR TITLE
[Logging] Improvements to GM Say Logging

### DIFF
--- a/common/eqemu_logsys.cpp
+++ b/common/eqemu_logsys.cpp
@@ -55,7 +55,7 @@ std::ofstream process_log;
  */
 EQEmuLogSys::EQEmuLogSys()
 {
-	m_on_log_gmsay_hook   = [](uint16 log_type, const std::string &) {};
+	m_on_log_gmsay_hook   = [](uint16 log_type, const char *func, const std::string &) {};
 	m_on_log_console_hook = [](uint16 log_type, const std::string &) {};
 }
 
@@ -412,7 +412,7 @@ void EQEmuLogSys::Out(
 		);
 	}
 	if (l.log_to_gmsay_enabled) {
-		m_on_log_gmsay_hook(log_category, output_message);
+		m_on_log_gmsay_hook(log_category, func, output_message);
 	}
 	if (l.log_to_file_enabled) {
 		EQEmuLogSys::ProcessLogWrite(

--- a/common/eqemu_logsys.h
+++ b/common/eqemu_logsys.h
@@ -344,7 +344,7 @@ public:
 	// gmsay
 	uint16 GetGMSayColorFromCategory(uint16 log_category);
 
-	EQEmuLogSys *SetGMSayHandler(std::function<void(uint16 log_type, const std::string &)> f)
+	EQEmuLogSys *SetGMSayHandler(const std::function<void(uint16 log_type, const char *func, const std::string &)>& f)
 	{
 		m_on_log_gmsay_hook = f;
 		return this;
@@ -375,15 +375,15 @@ public:
 private:
 
 	// reference to database
-	Database                                                                      *m_database;
-	std::function<void(uint16 log_category, const std::string &)>                 m_on_log_gmsay_hook;
-	std::function<void(uint16 log_category, int webhook_id, const std::string &)> m_on_log_discord_hook;
-	std::function<void(uint16 log_category, const std::string &)>                 m_on_log_console_hook;
-	DiscordWebhooks                                                               m_discord_webhooks[MAX_DISCORD_WEBHOOK_ID]{};
-	bool                                                                          m_file_logs_enabled = false;
-	int                                                                           m_log_platform      = 0;
-	std::string                                                                   m_platform_file_name;
-	std::string                                                                   m_log_path;
+	Database                                                                        *m_database;
+	std::function<void(uint16 log_category, const char *func, const std::string &)> m_on_log_gmsay_hook;
+	std::function<void(uint16 log_category, int webhook_id, const std::string &)>   m_on_log_discord_hook;
+	std::function<void(uint16 log_category, const std::string &)>                   m_on_log_console_hook;
+	DiscordWebhooks                                                                 m_discord_webhooks[MAX_DISCORD_WEBHOOK_ID]{};
+	bool                                                                            m_file_logs_enabled = false;
+	int                                                                             m_log_platform      = 0;
+	std::string                                                                     m_platform_file_name;
+	std::string                                                                     m_log_path;
 
 	void ProcessConsoleMessage(
 		uint16 log_category,

--- a/world/world_boot.cpp
+++ b/world/world_boot.cpp
@@ -30,7 +30,7 @@
 extern ZSList      zoneserver_list;
 extern WorldConfig Config;
 
-void WorldBoot::GMSayHookCallBackProcessWorld(uint16 log_category, std::string message)
+void WorldBoot::GMSayHookCallBackProcessWorld(uint16 log_category, const char *func, std::string message)
 {
 	// we don't want to loop up with chat messages
 	if (message.find("OP_SpecialMesg") != std::string::npos) {
@@ -71,7 +71,7 @@ void WorldBoot::GMSayHookCallBackProcessWorld(uint16 log_category, std::string m
 		AccountStatus::QuestTroupe,
 		LogSys.GetGMSayColorFromCategory(log_category),
 		"%s",
-		message.c_str()
+		fmt::format("[{}] [{}] {}", Logs::LogCategoryName[log_category], func, message).c_str()
 	);
 }
 

--- a/world/world_boot.h
+++ b/world/world_boot.h
@@ -6,7 +6,7 @@
 
 class WorldBoot {
 public:
-	static void GMSayHookCallBackProcessWorld(uint16 log_category, std::string message);
+	static void GMSayHookCallBackProcessWorld(uint16 log_category, const char *func, std::string message);
 	static bool HandleCommandInput(int argc, char **argv);
 	static bool LoadServerConfig();
 	static bool LoadDatabaseConnections();

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -327,7 +327,7 @@ public:
 	 * @param log_category
 	 * @param message
 	 */
-	static void GMSayHookCallBackProcess(uint16 log_category, std::string message)
+	static void GMSayHookCallBackProcess(uint16 log_category, const char *func, std::string message)
 	{
 		// we don't want to loop up with chat messages
 		if (message.find("OP_SpecialMesg") != std::string::npos) {
@@ -372,7 +372,7 @@ public:
 				0,
 				AccountStatus::QuestTroupe,
 				LogSys.GetGMSayColorFromCategory(log_category),
-				message.c_str()
+				fmt::format("[{}] [{}] {}", Logs::LogCategoryName[log_category], func, message).c_str()
 			);
 		}
 	}


### PR DESCRIPTION
**What**

GM Say logging now includes `[Category]` and `[Function]` as prefixes to give more context to the category being logged and what function the log came from

This removes the need to prefix in logging statements the function that the log statement is calling from, which we have littered all over the code base.

**Examples**

![image](https://user-images.githubusercontent.com/3319450/213596642-b25251e7-04bf-459d-a54c-fafb0c6a9be0.png)

![image](https://user-images.githubusercontent.com/3319450/213597142-3b4929d6-5bc9-44c9-b631-8134ab228d64.png)
