### PR TITLE
[Logging] Remove function prefixes

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -391,7 +391,7 @@ bool Database::DeleteCharacter(char *character_name)
 	}
 
 	if (character_id <= 0) {
-		LogError("[DeleteCharacter] Invalid Character ID [{}]", character_name);
+		LogError("Invalid Character ID [{}]", character_name);
 		return false;
 	}
 
@@ -431,7 +431,7 @@ bool Database::DeleteCharacter(char *character_name)
 			character_id
 		);
 		QueryDatabase(query);
-		LogInfo("[DeleteCharacter] character_name [{}] ({}) bots are being [{}]", character_name, character_id, delete_type);
+		LogInfo("character_name [{}] ({}) bots are being [{}]", character_name, character_id, delete_type);
 #endif
 
 		return true;
@@ -444,7 +444,7 @@ bool Database::DeleteCharacter(char *character_name)
 		QueryDatabase(fmt::format("DELETE FROM {} WHERE {} = {}", table_name, character_id_column_name, character_id));
 	}
 
-	LogInfo("[DeleteCharacter] character_name [{}] ({}) is being [{}]", character_name, character_id, delete_type);
+	LogInfo("character_name [{}] ({}) is being [{}]", character_name, character_id, delete_type);
 
 	return true;
 }
@@ -2356,7 +2356,7 @@ void Database::SourceDatabaseTableFromUrl(std::string table_name, std::string ur
 		uri request_uri(url);
 
 		LogHTTP(
-			"[SourceDatabaseTableFromUrl] parsing url [{}] path [{}] host [{}] query_string [{}] protocol [{}] port [{}]",
+			"parsing url [{}] path [{}] host [{}] query_string [{}] protocol [{}] port [{}]",
 			url,
 			request_uri.get_path(),
 			request_uri.get_host(),
@@ -2410,7 +2410,7 @@ void Database::SourceDatabaseTableFromUrl(std::string table_name, std::string ur
 
 	}
 	catch (std::invalid_argument iae) {
-		LogError("[SourceDatabaseTableFromUrl] URI parser error [{}]", iae.what());
+		LogError("URI parser error [{}]", iae.what());
 	}
 }
 

--- a/common/discord/discord.cpp
+++ b/common/discord/discord.cpp
@@ -48,7 +48,7 @@ void Discord::SendWebhookMessage(const std::string &message, const std::string &
 	while (retry) {
 		if (auto res = cli.Post(endpoint.c_str(), payload.str(), "application/json")) {
 			if (res->status != 200 && res->status != 204) {
-				LogError("[Discord Client] Code [{}] Error [{}]", res->status, res->body);
+				LogError("Code [{}] Error [{}]", res->status, res->body);
 			}
 			if (res->status == 429) {
 				if (!res->body.empty()) {

--- a/common/ip_util.cpp
+++ b/common/ip_util.cpp
@@ -198,7 +198,7 @@ std::string IpUtil::DNSLookupSync(const std::string &addr, int port)
 				std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
 				if (std::chrono::duration_cast<std::chrono::milliseconds>(end - begin).count() > 1500) {
 					LogInfo(
-						"[DNSLookupSync] Deadline exceeded [{}]",
+						"Deadline exceeded [{}]",
 						1500
 					);
 					running = false;

--- a/common/server_event_scheduler.cpp
+++ b/common/server_event_scheduler.cpp
@@ -109,7 +109,7 @@ bool ServerEventScheduler::ValidateEventReadyToActivate(
 
 	if (now_time_unix >= start_time_unix && (doesnt_end || now_time_unix < end_time_unix)) {
 		LogSchedulerDetail(
-			"[ValidateEventReadyToActivate] now_time [{}] start_time [{}] doesnt_end [{}] end_time [{}]",
+			"now_time [{}] start_time [{}] doesnt_end [{}] end_time [{}]",
 			now_time_unix,
 			start_time_unix,
 			doesnt_end ? "true" : "false",
@@ -131,7 +131,7 @@ ServerEventScheduler *ServerEventScheduler::SetDatabase(Database *db)
 bool ServerEventScheduler::ValidateDatabaseConnection()
 {
 	if (!m_database) {
-		LogError("[ServerEventScheduler::LoadScheduledEvents] No database connection");
+		LogError("No database connection");
 		return false;
 	}
 
@@ -174,7 +174,7 @@ bool ServerEventScheduler::CheckIfEventsChanged()
 					dbe.created_at != e.created_at ||
 					dbe.deleted_at != e.deleted_at
 					) {
-					LogSchedulerDetail("[CheckIfEventsChanged] Field change detected");
+					LogSchedulerDetail("Field change detected");
 					m_events = events;
 					return true;
 				}

--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -1919,7 +1919,7 @@ void SharedDatabase::LoadSpells(void *data, int max_spells) {
     }
 
     if(results.ColumnCount() <= SPELL_LOAD_FIELD_COUNT) {
-		LogSpells("[SharedDatabase::LoadSpells] Fatal error loading spells: Spell field count < SPELL_LOAD_FIELD_COUNT([{}])", SPELL_LOAD_FIELD_COUNT);
+		LogSpells("Fatal error loading spells: Spell field count < SPELL_LOAD_FIELD_COUNT([{}])", SPELL_LOAD_FIELD_COUNT);
 		return;
     }
 
@@ -1928,9 +1928,9 @@ void SharedDatabase::LoadSpells(void *data, int max_spells) {
     for (auto& row = results.begin(); row != results.end(); ++row) {
 	    const int tempid = atoi(row[0]);
         if(tempid >= max_spells) {
-      LogSpells("[SharedDatabase::LoadSpells] Non fatal error: spell.id >= max_spells, ignoring");
-            continue;
-        }
+			LogSpells("Non fatal error: spell.id >= max_spells, ignoring");
+			continue;
+		}
 
         ++counter;
         sp[tempid].id = tempid;

--- a/common/zone_store.cpp
+++ b/common/zone_store.cpp
@@ -60,7 +60,7 @@ uint32 ZoneStore::GetZoneID(std::string zone_name)
 		}
 	}
 
-	LogInfo("[GetZoneID] Failed to get zone_name [{}]", zone_name);
+	LogInfo("Failed to get zone_name [{}]", zone_name);
 
 	return 0;
 }
@@ -117,7 +117,7 @@ std::string ZoneStore::GetZoneName(uint32 zone_id)
 		}
 	}
 
-	LogInfo("[GetZoneName] Failed to get zone long name by zone_id [{}]", zone_id);
+	LogInfo("Failed to get zone long name by zone_id [{}]", zone_id);
 
 	return {};
 }
@@ -134,7 +134,7 @@ std::string ZoneStore::GetZoneLongName(uint32 zone_id)
 		}
 	}
 
-	LogInfo("[GetZoneLongName] Failed to get zone long name by zone_id [{}]", zone_id);
+	LogInfo("Failed to get zone long name by zone_id [{}]", zone_id);
 
 	return {};
 }
@@ -152,7 +152,7 @@ ZoneRepository::Zone *ZoneStore::GetZone(uint32 zone_id, int version)
 		}
 	}
 
-	LogInfo("[GetZone] Failed to get zone by zone_id [{}] version [{}]", zone_id, version);
+	LogInfo("Failed to get zone by zone_id [{}] version [{}]", zone_id, version);
 
 	return nullptr;
 }
@@ -169,7 +169,7 @@ ZoneRepository::Zone *ZoneStore::GetZone(const char *in_zone_name)
 		}
 	}
 
-	LogInfo("[GetZone] Failed to get zone by zone_name [{}]", in_zone_name);
+	LogInfo("Failed to get zone by zone_name [{}]", in_zone_name);
 
 	return nullptr;
 }
@@ -206,7 +206,7 @@ ZoneRepository::Zone *ZoneStore::GetZoneWithFallback(uint32 zone_id, int version
 		}
 	}
 
-	LogInfo("[GetZoneWithFallback] Failed to get zone by zone_id [{}] version [{}]", zone_id, version);
+	LogInfo("Failed to get zone by zone_id [{}] version [{}]", zone_id, version);
 
 	return nullptr;
 }

--- a/loginserver/account_management.cpp
+++ b/loginserver/account_management.cpp
@@ -150,7 +150,7 @@ uint32 AccountManagement::CheckLoginserverUserCredentials(
 
 	if (!login_server_admin.loaded) {
 		LogError(
-			"CheckLoginUserCredentials account [{0}] source_loginserver [{1}] not found!",
+			"account [{0}] source_loginserver [{1}] not found!",
 			in_account_username,
 			source_loginserver
 		);
@@ -167,7 +167,7 @@ uint32 AccountManagement::CheckLoginserverUserCredentials(
 
 	if (!validated_credentials) {
 		LogError(
-			"CheckLoginUserCredentials account [{0}] source_loginserver [{1}] invalid credentials!",
+			"account [{0}] source_loginserver [{1}] invalid credentials!",
 			in_account_username,
 			source_loginserver
 		);
@@ -176,7 +176,7 @@ uint32 AccountManagement::CheckLoginserverUserCredentials(
 	}
 
 	LogInfo(
-		"CheckLoginUserCredentials account [{0}] source_loginserver [{1}] credentials validated success!",
+		"account [{0}] source_loginserver [{1}] credentials validated success!",
 		in_account_username,
 		source_loginserver
 	);
@@ -206,7 +206,7 @@ bool AccountManagement::UpdateLoginserverUserCredentials(
 
 	if (!login_server_account.loaded) {
 		LogError(
-			"ChangeLoginserverUserCredentials account [{0}] source_loginserver [{1}] not found!",
+			"account [{0}] source_loginserver [{1}] not found!",
 			in_account_username,
 			source_loginserver
 		);
@@ -225,7 +225,7 @@ bool AccountManagement::UpdateLoginserverUserCredentials(
 	);
 
 	LogInfo(
-		"ChangeLoginserverUserCredentials account [{0}] source_loginserver [{1}] credentials updated!",
+		"account [{0}] source_loginserver [{1}] credentials updated!",
 		in_account_username,
 		source_loginserver
 	);
@@ -401,7 +401,7 @@ uint32 AccountManagement::CheckExternalLoginserverUserCredentials(
 			while (running) {
 				std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
 				if (std::chrono::duration_cast<std::chrono::milliseconds>(end - begin).count() > REQUEST_TIMEOUT_MS) {
-					LogInfo("[CheckExternalLoginserverUserCredentials] Deadline exceeded [{}]", REQUEST_TIMEOUT_MS);
+					LogInfo("Deadline exceeded [{}]", REQUEST_TIMEOUT_MS);
 					running = false;
 				}
 

--- a/loginserver/client.cpp
+++ b/loginserver/client.cpp
@@ -223,7 +223,7 @@ void Client::Handle_Login(const char *data, unsigned int size)
 			if (server.db->GetLoginDataFromAccountInfo(user, db_loginserver, db_account_password_hash, db_account_id)) {
 				result = VerifyLoginHash(user, db_loginserver, cred, db_account_password_hash);
 
-				LogDebug("[VerifyLoginHash] Success [{0}]", (result ? "true" : "false"));
+				LogDebug("Success [{0}]", (result ? "true" : "false"));
 			}
 			else {
 				m_client_status = cs_creating_account;
@@ -332,7 +332,7 @@ void Client::AttemptLoginAccountCreation(
 	const std::string &loginserver
 )
 {
-	LogInfo("[AttemptLoginAccountCreation] user [{}] loginserver [{}]", user, loginserver);
+	LogInfo("user [{}] loginserver [{}]", user, loginserver);
 
 #ifdef LSPX
 	if (loginserver == "eqemu") {
@@ -351,7 +351,7 @@ void Client::AttemptLoginAccountCreation(
 		);
 
 		if (account_id > 0) {
-			LogInfo("[AttemptLoginAccountCreation] Found and creating eqemu account [{}]", account_id);
+			LogInfo("Found and creating eqemu account [{}]", account_id);
 			CreateEQEmuAccount(user, pass, account_id);
 			return;
 		}

--- a/loginserver/world_server.cpp
+++ b/loginserver/world_server.cpp
@@ -80,7 +80,7 @@ void WorldServer::Reset()
 void WorldServer::ProcessNewLSInfo(uint16_t opcode, const EQ::Net::Packet &packet)
 {
 	LogNetcode(
-		"[ProcessNewLSInfo] Application packet received from server [{:#04x}] [Size: {}]\n{}",
+		"Application packet received from server [{:#04x}] [Size: {}]\n{}",
 		opcode,
 		packet.Length(),
 		packet.ToString()
@@ -125,7 +125,7 @@ void WorldServer::ProcessNewLSInfo(uint16_t opcode, const EQ::Net::Packet &packe
 void WorldServer::ProcessLSStatus(uint16_t opcode, const EQ::Net::Packet &packet)
 {
 	LogNetcode(
-		"[ProcessLSStatus] Application packet received from server [{:#04x}] [Size: {}]\n{}",
+		"Application packet received from server [{:#04x}] [Size: {}]\n{}",
 		opcode,
 		packet.Length(),
 		packet.ToString()
@@ -159,7 +159,7 @@ void WorldServer::ProcessLSStatus(uint16_t opcode, const EQ::Net::Packet &packet
 void WorldServer::ProcessUserToWorldResponseLegacy(uint16_t opcode, const EQ::Net::Packet &packet)
 {
 	LogNetcode(
-		"[ProcessUserToWorldResponseLegacy] Application packet received from server [{:#04x}] [Size: {}]\n{}",
+		"Application packet received from server [{:#04x}] [Size: {}]\n{}",
 		opcode,
 		packet.Length(),
 		packet.ToString()
@@ -255,7 +255,7 @@ void WorldServer::ProcessUserToWorldResponseLegacy(uint16_t opcode, const EQ::Ne
 void WorldServer::ProcessUserToWorldResponse(uint16_t opcode, const EQ::Net::Packet &packet)
 {
 	LogNetcode(
-		"[ProcessUserToWorldResponse] Application packet received from server [{:#04x}] [Size: {}]\n{}",
+		"Application packet received from server [{:#04x}] [Size: {}]\n{}",
 		opcode,
 		packet.Length(),
 		packet.ToString()
@@ -362,7 +362,7 @@ void WorldServer::ProcessUserToWorldResponse(uint16_t opcode, const EQ::Net::Pac
 void WorldServer::ProcessLSAccountUpdate(uint16_t opcode, const EQ::Net::Packet &packet)
 {
 	LogNetcode(
-		"[ProcessLSAccountUpdate] Application packet received from server [{:#04x}] [Size: {}]\n{}",
+		"Application packet received from server [{:#04x}] [Size: {}]\n{}",
 		opcode,
 		packet.Length(),
 		packet.ToString()
@@ -458,7 +458,7 @@ void WorldServer::Handle_NewLSInfo(ServerNewLSInfo_Struct *new_world_server_info
 
 		if (login_server_admin.loaded) {
 			LogDebug(
-				"WorldServer::Handle_NewLSInfo | Attempting to authenticate world admin... [{0}] ({1}) against worldserver [{2}]",
+				"Attempting to authenticate world admin... [{0}] ({1}) against worldserver [{2}]",
 				GetAccountName(),
 				login_server_admin.id,
 				GetServerShortName()
@@ -471,7 +471,7 @@ void WorldServer::Handle_NewLSInfo(ServerNewLSInfo_Struct *new_world_server_info
 				login_server_admin.account_password
 			)) {
 				LogDebug(
-					"WorldServer::Handle_NewLSInfo | Authenticating world admin... [{0}] ({1}) success! World ({2})",
+					"Authenticating world admin... [{0}] ({1}) success! World ({2})",
 					GetAccountName(),
 					login_server_admin.id,
 					GetServerShortName()
@@ -600,7 +600,7 @@ void WorldServer::SendClientAuth(
 	m_connection->Send(ServerOP_LSClientAuth, outapp);
 
 	LogNetcode(
-		"[ServerOP_LSClientAuth] Sending [{:#04x}] [Size: {}]\n{}",
+		"Sending [{:#04x}] [Size: {}]\n{}",
 		ServerOP_LSClientAuth,
 		outapp.Length(),
 		outapp.ToString()

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -238,7 +238,7 @@ void Client::SendCharInfo() {
 		QueuePacket(outapp);
 	}
 	else {
-		LogInfo("[Error] Database did not return an OP_SendCharInfo packet for account [{}]", GetAccountID());
+		LogError("Database did not return an OP_SendCharInfo packet for account [{}]", GetAccountID());
 	}
 	safe_delete(outapp);
 }
@@ -1256,7 +1256,7 @@ bool Client::ChecksumVerificationCRCEQGame(uint64 checksum)
 		checksumint = atoll(checksumvar.c_str());
 	}
 	else {
-		LogChecksumVerification("[checksum_crc1_eqgame] variable not set in variables table.");
+		LogChecksumVerification("variable not set in variables table.");
 		return true;
 	}
 
@@ -1302,7 +1302,7 @@ bool Client::ChecksumVerificationCRCBaseData(uint64 checksum)
 		checksumint = atoll(checksumvar.c_str());
 	}
 	else {
-		LogChecksumVerification("[checksum_crc3_basedata] variable not set in variables table.");
+		LogChecksumVerification("variable not set in variables table.");
 		return true;
 	}
 

--- a/world/cliententry.cpp
+++ b/world/cliententry.cpp
@@ -58,7 +58,7 @@ ClientListEntry::ClientListEntry(
 	ClearVars(true);
 
 	LogDebug(
-		"ClientListEntry in_id [{0}] in_loginserver_id [{1}] in_loginserver_name [{2}] in_login_name [{3}] in_login_key [{4}] "
+		"in_id [{0}] in_loginserver_id [{1}] in_loginserver_name [{2}] in_login_name [{3}] in_login_key [{4}] "
 		" in_is_world_admin [{5}] ip [{6}] local [{7}]",
 		in_id,
 		in_loginserver_id,
@@ -325,7 +325,7 @@ bool ClientListEntry::CheckStale()
 bool ClientListEntry::CheckAuth(uint32 loginserver_account_id, const char *key_password)
 {
 	LogDebug(
-		"ClientListEntry::CheckAuth ls_account_id [{0}] key_password [{1}] plskey [{2}]",
+		"ls_account_id [{0}] key_password [{1}] plskey [{2}]",
 		loginserver_account_id,
 		key_password,
 		plskey
@@ -333,7 +333,7 @@ bool ClientListEntry::CheckAuth(uint32 loginserver_account_id, const char *key_p
 	if (pLSID == loginserver_account_id && strncmp(plskey, key_password, 10) == 0) {
 
 		LogDebug(
-			"ClientListEntry::CheckAuth ls_account_id [{0}] key_password [{1}] plskey [{2}] lsid [{3}] paccountid [{4}]",
+			"ls_account_id [{0}] key_password [{1}] plskey [{2}] lsid [{3}] paccountid [{4}]",
 			loginserver_account_id,
 			key_password,
 			plskey,

--- a/world/launcher_link.cpp
+++ b/world/launcher_link.cpp
@@ -111,7 +111,7 @@ void LauncherLink::ProcessMessage(uint16 opcode, EQ::Net::Packet &p)
 			zs.port = cur->port;
 			zs.up = false;
 			zs.starts = 0;
-			LogInfo("[{}]: Loaded zone [{}] on port [{}]", m_name.c_str(), cur->name.c_str(), zs.port);
+			LogInfo("[{}] Loaded zone [{}] on port [{}]", m_name.c_str(), cur->name.c_str(), zs.port);
 			m_states[cur->name] = zs;
 		}
 
@@ -127,10 +127,10 @@ void LauncherLink::ProcessMessage(uint16 opcode, EQ::Net::Packet &p)
 		std::map<std::string, ZoneState>::iterator res;
 		res = m_states.find(it->short_name);
 		if (res == m_states.end()) {
-			LogInfo("[{}]: reported state for zone [{}] which it does not have", m_name.c_str(), it->short_name);
+			LogInfo("[{}] reported state for zone [{}] which it does not have", m_name.c_str(), it->short_name);
 			break;
 		}
-		LogInfo("[{}]: [{}] reported state [{}] ([{}] starts)", m_name.c_str(), it->short_name, it->running ? "STARTED" : "STOPPED", it->start_count);
+		LogInfo("[{}] [{}] reported state [{}] ([{}] starts)", m_name.c_str(), it->short_name, it->running ? "STARTED" : "STOPPED", it->start_count);
 		res->second.up = it->running;
 		res->second.starts = it->start_count;
 		break;
@@ -153,7 +153,7 @@ void LauncherLink::BootZone(const char *short_name, uint16 port) {
 	zs.port = port;
 	zs.up = false;
 	zs.starts = 0;
-	LogInfo("[{}]: Loaded zone [{}] on port [{}]", m_name.c_str(), short_name, zs.port);
+	LogInfo("[{}] Loaded zone [{}] on port [{}]", m_name.c_str(), short_name, zs.port);
 	m_states[short_name] = zs;
 
 	StartZone(short_name, port);

--- a/world/login_server.cpp
+++ b/world/login_server.cpp
@@ -62,14 +62,14 @@ LoginServer::~LoginServer()
 void LoginServer::ProcessUsertoWorldReqLeg(uint16_t opcode, EQ::Net::Packet &p)
 {
 	const WorldConfig *Config = WorldConfig::get();
-	LogNetcode("[ProcessUsertoWorldReqLeg] Received ServerPacket from LS OpCode {:#04x}", opcode);
+	LogNetcode("Received ServerPacket from LS OpCode {:#04x}", opcode);
 
 	UsertoWorldRequestLegacy_Struct *utwr  = (UsertoWorldRequestLegacy_Struct *) p.Data();
 	uint32                          id     = database.GetAccountIDFromLSID("eqemu", utwr->lsaccountid);
 	int16                           status = database.CheckStatus(id);
 
 	LogDebug(
-		"[ProcessUsertoWorldReqLeg] id [{}] status [{}] account_id [{}] world_id [{}] from_id [{}] to_id [{}] ip [{}]",
+		"id [{}] status [{}] account_id [{}] world_id [{}] from_id [{}] to_id [{}] ip [{}]",
 		id,
 		status,
 		utwr->lsaccountid,
@@ -94,7 +94,7 @@ void LoginServer::ProcessUsertoWorldReqLeg(uint16_t opcode, EQ::Net::Packet &p)
 	if (Config->Locked) {
 		if (status < (RuleI(GM, MinStatusToBypassLockedServer))) {
 			LogDebug(
-				"[ProcessUsertoWorldReqLeg] Server locked and status is not high enough for account_id [{0}]",
+				"Server locked and status is not high enough for account_id [{0}]",
 				utwr->lsaccountid
 			);
 			utwrs->response = UserToWorldStatusWorldUnavail;
@@ -105,21 +105,21 @@ void LoginServer::ProcessUsertoWorldReqLeg(uint16_t opcode, EQ::Net::Packet &p)
 
 	int32 x = Config->MaxClients;
 	if ((int32) numplayers >= x && x != -1 && x != 255 && status < (RuleI(GM, MinStatusToBypassLockedServer))) {
-		LogDebug("[ProcessUsertoWorldReqLeg] World at capacity account_id [{0}]", utwr->lsaccountid);
+		LogDebug("World at capacity account_id [{0}]", utwr->lsaccountid);
 		utwrs->response = UserToWorldStatusWorldAtCapacity;
 		SendPacket(&outpack);
 		return;
 	}
 
 	if (status == -1) {
-		LogDebug("[ProcessUsertoWorldReqLeg] User suspended account_id [{0}]", utwr->lsaccountid);
+		LogDebug("User suspended account_id [{0}]", utwr->lsaccountid);
 		utwrs->response = UserToWorldStatusSuspended;
 		SendPacket(&outpack);
 		return;
 	}
 
 	if (status == -2) {
-		LogDebug("[ProcessUsertoWorldReqLeg] User banned account_id [{0}]", utwr->lsaccountid);
+		LogDebug("User banned account_id [{0}]", utwr->lsaccountid);
 		utwrs->response = UserToWorldStatusBanned;
 		SendPacket(&outpack);
 		return;
@@ -127,14 +127,14 @@ void LoginServer::ProcessUsertoWorldReqLeg(uint16_t opcode, EQ::Net::Packet &p)
 
 	if (RuleB(World, EnforceCharacterLimitAtLogin)) {
 		if (client_list.IsAccountInGame(utwr->lsaccountid)) {
-			LogDebug("[ProcessUsertoWorldReqLeg] User already online account_id [{0}]", utwr->lsaccountid);
+			LogDebug("User already online account_id [{0}]", utwr->lsaccountid);
 			utwrs->response = UserToWorldStatusAlreadyOnline;
 			SendPacket(&outpack);
 			return;
 		}
 	}
 
-	LogDebug("[ProcessUsertoWorldReqLeg] Sent response to account_id [{0}]", utwr->lsaccountid);
+	LogDebug("Sent response to account_id [{0}]", utwr->lsaccountid);
 
 	SendPacket(&outpack);
 }
@@ -142,14 +142,14 @@ void LoginServer::ProcessUsertoWorldReqLeg(uint16_t opcode, EQ::Net::Packet &p)
 void LoginServer::ProcessUsertoWorldReq(uint16_t opcode, EQ::Net::Packet &p)
 {
 	const WorldConfig *Config = WorldConfig::get();
-	LogNetcode("[ProcessUsertoWorldReq] Received ServerPacket from LS OpCode {:#04x}", opcode);
+	LogNetcode("Received ServerPacket from LS OpCode {:#04x}", opcode);
 
 	UsertoWorldRequest_Struct *utwr  = (UsertoWorldRequest_Struct *) p.Data();
 	uint32                    id     = database.GetAccountIDFromLSID(utwr->login, utwr->lsaccountid);
 	int16                     status = database.CheckStatus(id);
 
 	LogDebug(
-		"[ProcessUsertoWorldReq] id [{}] status [{}] account_id [{}] world_id [{}] from_id [{}] to_id [{}] ip [{}]",
+		"id [{}] status [{}] account_id [{}] world_id [{}] from_id [{}] to_id [{}] ip [{}]",
 		id,
 		status,
 		utwr->lsaccountid,
@@ -175,7 +175,7 @@ void LoginServer::ProcessUsertoWorldReq(uint16_t opcode, EQ::Net::Packet &p)
 	if (Config->Locked == true) {
 		if (status < (RuleI(GM, MinStatusToBypassLockedServer))) {
 			LogDebug(
-				"[ProcessUsertoWorldReq] Server locked and status is not high enough for account_id [{0}]",
+				"Server locked and status is not high enough for account_id [{0}]",
 				utwr->lsaccountid
 			);
 			utwrs->response = UserToWorldStatusWorldUnavail;
@@ -186,21 +186,21 @@ void LoginServer::ProcessUsertoWorldReq(uint16_t opcode, EQ::Net::Packet &p)
 
 	int32 x = Config->MaxClients;
 	if ((int32) numplayers >= x && x != -1 && x != 255 && status < (RuleI(GM, MinStatusToBypassLockedServer))) {
-		LogDebug("[ProcessUsertoWorldReq] World at capacity account_id [{0}]", utwr->lsaccountid);
+		LogDebug("World at capacity account_id [{0}]", utwr->lsaccountid);
 		utwrs->response = UserToWorldStatusWorldAtCapacity;
 		SendPacket(&outpack);
 		return;
 	}
 
 	if (status == -1) {
-		LogDebug("[ProcessUsertoWorldReq] User suspended account_id [{0}]", utwr->lsaccountid);
+		LogDebug("User suspended account_id [{0}]", utwr->lsaccountid);
 		utwrs->response = UserToWorldStatusSuspended;
 		SendPacket(&outpack);
 		return;
 	}
 
 	if (status == -2) {
-		LogDebug("[ProcessUsertoWorldReq] User banned account_id [{0}]", utwr->lsaccountid);
+		LogDebug("User banned account_id [{0}]", utwr->lsaccountid);
 		utwrs->response = UserToWorldStatusBanned;
 		SendPacket(&outpack);
 		return;
@@ -208,14 +208,14 @@ void LoginServer::ProcessUsertoWorldReq(uint16_t opcode, EQ::Net::Packet &p)
 
 	if (RuleB(World, EnforceCharacterLimitAtLogin)) {
 		if (client_list.IsAccountInGame(utwr->lsaccountid)) {
-			LogDebug("[ProcessUsertoWorldReq] User already online account_id [{0}]", utwr->lsaccountid);
+			LogDebug("User already online account_id [{0}]", utwr->lsaccountid);
 			utwrs->response = UserToWorldStatusAlreadyOnline;
 			SendPacket(&outpack);
 			return;
 		}
 	}
 
-	LogDebug("[ProcessUsertoWorldReq] Sent response to account_id [{0}]", utwr->lsaccountid);
+	LogDebug("Sent response to account_id [{0}]", utwr->lsaccountid);
 
 	SendPacket(&outpack);
 }

--- a/world/shared_task_manager.cpp
+++ b/world/shared_task_manager.cpp
@@ -48,7 +48,7 @@ void SharedTaskManager::AttemptSharedTaskCreation(
 	auto task = GetSharedTaskDataByTaskId(requested_task_id);
 	if (task.id != 0 && task.type == TASK_TYPE_SHARED) {
 		LogTasksDetail(
-			"[AttemptSharedTaskCreation] Found Shared Task ({}) [{}]",
+			"Found Shared Task ({}) [{}]",
 			requested_task_id,
 			task.title
 		);
@@ -58,12 +58,12 @@ void SharedTaskManager::AttemptSharedTaskCreation(
 	// todo: this should be online group/raid members only (avoid queries)
 	auto request = SharedTask::GetRequestCharacters(*m_database, requested_character_id);
 	if (!CanRequestSharedTask(task.id, request)) {
-		LogTasksDetail("[AttemptSharedTaskCreation] Shared task validation failed");
+		LogTasksDetail("Shared task validation failed");
 		return;
 	}
 
 	for (auto& m: request.members) {
-		LogTasksDetail("[AttemptSharedTaskCreation] Request Members [{}]", m.character_name);
+		LogTasksDetail("Request Members [{}]", m.character_name);
  	}
 
 	// new shared task instance
@@ -181,7 +181,7 @@ void SharedTaskManager::AttemptSharedTaskCreation(
 	LoadDynamicZoneTemplate(&inserted);
 
 	LogTasks(
-		"[AttemptSharedTaskCreation] shared_task_id [{}] created successfully | task_id [{}] member_count [{}] activity_count [{}] current tasks in state [{}]",
+		"shared_task_id [{}] created successfully | task_id [{}] member_count [{}] activity_count [{}] current tasks in state [{}]",
 		new_shared_task.GetDbSharedTask().id,
 		task.id,
 		request.members.size(),
@@ -192,7 +192,7 @@ void SharedTaskManager::AttemptSharedTaskCreation(
 
 void SharedTaskManager::RemoveMember(SharedTask* s, const SharedTaskMember& member, bool remove_from_db)
 {
-	LogTasksDetail("[RemoveMember] shared_task_id [{}] member [{}]", s->GetDbSharedTask().id, member.character_name);
+	LogTasksDetail("shared_task_id [{}] member [{}]", s->GetDbSharedTask().id, member.character_name);
 
 	RemovePlayerFromSharedTask(s, member.character_id);
 	SendRemovePlayerFromSharedTaskPacket(member.character_id, s->GetDbSharedTask().task_id, remove_from_db);
@@ -217,12 +217,12 @@ void SharedTaskManager::RemoveMember(SharedTask* s, const SharedTaskMember& memb
 void SharedTaskManager::RemoveEveryoneFromSharedTask(SharedTask *t, uint32 requested_character_id)
 {
 	// caller validates leader
-	LogTasksDetail("[RemoveEveryoneFromSharedTask] Leader [{}]", requested_character_id);
+	LogTasksDetail("Leader [{}]", requested_character_id);
 
 	// inform clients of removal
 	for (auto &m: t->GetMembers()) {
 		LogTasksDetail(
-			"[RemoveEveryoneFromSharedTask] Sending removal to [{}] task_id [{}]",
+			"Sending removal to [{}] task_id [{}]",
 			m.character_id,
 			t->GetTaskData().id
 		);
@@ -244,7 +244,7 @@ void SharedTaskManager::RemoveEveryoneFromSharedTask(SharedTask *t, uint32 reque
 
 void SharedTaskManager::Terminate(SharedTask& s, bool send_fail, bool erase)
 {
-	LogTasksDetail("[Terminate] shared task [{}]", s.GetDbSharedTask().id);
+	LogTasksDetail("shared task [{}]", s.GetDbSharedTask().id);
 	for (const auto& member : s.GetMembers())
 	{
 		if (send_fail)
@@ -266,7 +266,7 @@ void SharedTaskManager::Terminate(SharedTask& s, bool send_fail, bool erase)
 void SharedTaskManager::DeleteSharedTask(int64 shared_task_id)
 {
 	LogTasksDetail(
-		"[DeleteSharedTask] shared_task_id [{}]",
+		"shared_task_id [{}]",
 		shared_task_id
 	);
 
@@ -291,7 +291,7 @@ void SharedTaskManager::DeleteSharedTask(int64 shared_task_id)
 
 void SharedTaskManager::LoadSharedTaskState()
 {
-	LogTasksDetail("[LoadSharedTaskState] Restoring state from the database");
+	LogTasksDetail("Restoring state from the database");
 
 	// load shared tasks
 	std::vector<SharedTask> shared_tasks = {};
@@ -325,7 +325,7 @@ void SharedTaskManager::LoadSharedTaskState()
 		SharedTask ns = {};
 
 		LogTasksDetail(
-			"[LoadSharedTaskState] Loading shared_task_id [{}] task_id [{}]",
+			"Loading shared_task_id [{}] task_id [{}]",
 			s.id,
 			s.task_id
 		);
@@ -336,7 +336,7 @@ void SharedTaskManager::LoadSharedTaskState()
 		// set database task data for internal referencing
 		auto task_data = GetSharedTaskDataByTaskId(s.task_id);
 
-		LogTasksDetail("[LoadSharedTaskState] [GetSharedTaskDataByTaskId] task_id [{}]", task_data.id);
+		LogTasksDetail("[GetSharedTaskDataByTaskId] task_id [{}]", task_data.id);
 
 		ns.SetTaskData(task_data);
 
@@ -363,7 +363,7 @@ void SharedTaskManager::LoadSharedTaskState()
 				for (auto &ad: activities_data) {
 					if (ad.taskid == s.task_id && ad.activityid == sta.activity_id) {
 						LogTasksDetail(
-							"[LoadSharedTaskState] shared_task_id [{}] task_id [{}] activity_id [{}] done_count [{}] max_done_count (goalcount) [{}]",
+							"shared_task_id [{}] task_id [{}] activity_id [{}] done_count [{}] max_done_count (goalcount) [{}]",
 							s.id,
 							s.task_id,
 							sta.activity_id,
@@ -409,7 +409,7 @@ void SharedTaskManager::LoadSharedTaskState()
 				shared_task_members.emplace_back(member);
 
 				LogTasksDetail(
-					"[LoadSharedTaskState] shared_task_id [{}] adding member character_id [{}] character_name [{}] is_leader [{}]",
+					"shared_task_id [{}] adding member character_id [{}] character_name [{}] is_leader [{}]",
 					s.id,
 					member.character_id,
 					member.character_name,
@@ -429,7 +429,7 @@ void SharedTaskManager::LoadSharedTaskState()
 				ns.dynamic_zone_ids.emplace_back(static_cast<uint32_t>(dz_entry.dynamic_zone_id));
 
 				LogTasksDetail(
-					"[LoadSharedTaskState] shared_task_id [{}] adding dynamic_zone_id [{}]",
+					"shared_task_id [{}] adding dynamic_zone_id [{}]",
 					s.id,
 					dz_entry.dynamic_zone_id
 				);
@@ -437,7 +437,7 @@ void SharedTaskManager::LoadSharedTaskState()
 		}
 
 		LogTasks(
-			"[LoadSharedTaskState] Loaded shared task state | shared_task_id [{}] task_id [{}] task_title [{}] member_count [{}] state_activity_count [{}]",
+			"Loaded shared task state | shared_task_id [{}] task_id [{}] task_title [{}] member_count [{}] state_activity_count [{}]",
 			s.id,
 			task_data.id,
 			task_data.title,
@@ -451,7 +451,7 @@ void SharedTaskManager::LoadSharedTaskState()
 	SetSharedTasks(shared_tasks);
 
 	LogTasks(
-		"[LoadSharedTaskState] Loaded [{}] shared tasks",
+		"Loaded [{}] shared tasks",
 		m_shared_tasks.size()
 	);
 
@@ -463,7 +463,7 @@ SharedTaskManager *SharedTaskManager::LoadTaskData()
 	m_task_data          = TasksRepository::All(*m_content_database);
 	m_task_activity_data = TaskActivitiesRepository::All(*m_content_database);
 
-	LogTasks("[LoadTaskData] Loaded tasks [{}] activities [{}]", m_task_data.size(), m_task_activity_data.size());
+	LogTasks("Loaded tasks [{}] activities [{}]", m_task_data.size(), m_task_activity_data.size());
 
 	return this;
 }
@@ -504,7 +504,7 @@ void SharedTaskManager::SharedTaskActivityUpdate(
 	auto shared_task = FindSharedTaskByTaskIdAndCharacterId(task_id, source_character_id);
 	if (shared_task) {
 		LogTasksDetail(
-			"[SharedTaskActivityUpdate] shared_task_id [{}] character_id [{}] task_id [{}] activity_id [{}] done_count [{}]",
+			"shared_task_id [{}] character_id [{}] task_id [{}] activity_id [{}] done_count [{}]",
 			shared_task->GetDbSharedTask().id,
 			source_character_id,
 			task_id,
@@ -518,7 +518,7 @@ void SharedTaskManager::SharedTaskActivityUpdate(
 				// discard updates out of bounds
 				if (a.done_count == a.max_done_count) {
 					LogTasksDetail(
-						"[SharedTaskActivityUpdate] done_count [{}] is greater than max [{}] discarding...",
+						"done_count [{}] is greater than max [{}] discarding...",
 						done_count,
 						a.max_done_count
 					);
@@ -528,7 +528,7 @@ void SharedTaskManager::SharedTaskActivityUpdate(
 				// if we are progressing
 				if (a.done_count < done_count) {
 					LogTasksDetail(
-						"[SharedTaskActivityUpdate] Propagating update for shared_task_id [{}] character_id [{}] task_id [{}] activity_id [{}] old_done_count [{}] new_done_count [{}]",
+						"Propagating update for shared_task_id [{}] character_id [{}] task_id [{}] activity_id [{}] old_done_count [{}] new_done_count [{}]",
 						shared_task->GetDbSharedTask().id,
 						source_character_id,
 						task_id,
@@ -560,7 +560,7 @@ void SharedTaskManager::SharedTaskActivityUpdate(
 					shared_task->SetSharedTaskActivityState(shared_task->m_shared_task_activity_state);
 
 					LogTasksDetail(
-						"[SharedTaskActivityUpdate] Debug done_count [{}]",
+						"Debug done_count [{}]",
 						a.done_count
 					);
 
@@ -591,7 +591,7 @@ void SharedTaskManager::SharedTaskActivityUpdate(
 				}
 
 				LogTasksDetail(
-					"[SharedTaskActivityUpdate] Discarding duplicate update for shared_task_id [{}] character_id [{}] task_id [{}] activity_id [{}] done_count [{}] ignore_quest_update [{}]",
+					"Discarding duplicate update for shared_task_id [{}] character_id [{}] task_id [{}] activity_id [{}] done_count [{}] ignore_quest_update [{}]",
 					shared_task->GetDbSharedTask().id,
 					source_character_id,
 					task_id,
@@ -810,10 +810,10 @@ void SharedTaskManager::PrintSharedTaskState()
 	for (auto &s: m_shared_tasks) {
 		auto task = GetSharedTaskDataByTaskId(s.GetDbSharedTask().task_id);
 
-		LogTasksDetail("[PrintSharedTaskState] # Shared Task");
+		LogTasksDetail("# Shared Task");
 
 		LogTasksDetail(
-			"[PrintSharedTaskState] shared_task_id [{}] task_id [{}] task_title [{}] member_count [{}] state_activity_count [{}]",
+			"shared_task_id [{}] task_id [{}] task_title [{}] member_count [{}] state_activity_count [{}]",
 			s.GetDbSharedTask().id,
 			task.id,
 			task.title,
@@ -821,12 +821,12 @@ void SharedTaskManager::PrintSharedTaskState()
 			s.GetActivityState().size()
 		);
 
-		LogTasksDetail("[PrintSharedTaskState] # Activities");
+		LogTasksDetail("# Activities");
 
 		// activity state
 		for (auto &a: s.m_shared_task_activity_state) {
 			LogTasksDetail(
-				"[PrintSharedTaskState] -- activity_id [{}] done_count [{}] max_done_count [{}] completed_time [{}]",
+				"-- activity_id [{}] done_count [{}] max_done_count [{}] completed_time [{}]",
 				a.activity_id,
 				a.done_count,
 				a.max_done_count,
@@ -834,22 +834,22 @@ void SharedTaskManager::PrintSharedTaskState()
 			);
 		}
 
-		LogTasksDetail("[PrintSharedTaskState] # Members");
+		LogTasksDetail("# Members");
 
 		// members
 		for (auto &m: s.m_members) {
 			LogTasksDetail(
-				"[PrintSharedTaskState] -- character_id [{}] is_leader [{}]",
+				"-- character_id [{}] is_leader [{}]",
 				m.character_id,
 				m.is_leader
 			);
 		}
 
-		LogTasksDetail("[PrintSharedTaskState] # Dynamic Zones");
+		LogTasksDetail("# Dynamic Zones");
 
 		for (auto &dz_id: s.dynamic_zone_ids) {
 			LogTasksDetail(
-				"[PrintSharedTaskState] -- dynamic_zone_id [{}]",
+				"-- dynamic_zone_id [{}]",
 				dz_id
 			);
 		}
@@ -897,7 +897,7 @@ void SharedTaskManager::MakeLeaderByPlayerName(SharedTask *s, const std::string 
 	std::vector<SharedTaskMember> members = s->GetMembers();
 	for (auto                     &m: members) {
 		LogTasksDetail(
-			"[MakeLeaderByPlayerName] character_id [{}] m.character_id [{}]",
+			"character_id [{}] m.character_id [{}]",
 			new_leader.character_id,
 			m.character_id
 		);
@@ -908,7 +908,7 @@ void SharedTaskManager::MakeLeaderByPlayerName(SharedTask *s, const std::string 
 		if (new_leader.character_id == m.character_id) {
 			found_new_leader = true;
 			LogTasksDetail(
-				"[MakeLeaderByPlayerName] shared_task_id [{}] character_name [{}]",
+				"shared_task_id [{}] character_name [{}]",
 				s->GetDbSharedTask().id,
 				character_name
 			);
@@ -1092,7 +1092,7 @@ SharedTask* SharedTaskManager::FindSharedTaskByDzId(uint32_t dz_id)
 void SharedTaskManager::QueueActiveInvitation(int64 shared_task_id, int64 character_id)
 {
 	LogTasksDetail(
-		"[QueueActiveInvitation] shared_task_id [{}] character_id [{}]",
+		"shared_task_id [{}] character_id [{}]",
 		shared_task_id,
 		character_id
 	);
@@ -1107,7 +1107,7 @@ void SharedTaskManager::QueueActiveInvitation(int64 shared_task_id, int64 charac
 bool SharedTaskManager::IsInvitationActive(uint32 shared_task_id, uint32 character_id)
 {
 	LogTasksDetail(
-		"[IsInvitationActive] shared_task_id [{}] character_id [{}]",
+		"shared_task_id [{}] character_id [{}]",
 		shared_task_id,
 		character_id
 	);
@@ -1124,7 +1124,7 @@ bool SharedTaskManager::IsInvitationActive(uint32 shared_task_id, uint32 charact
 void SharedTaskManager::RemoveActiveInvitation(int64 shared_task_id, int64 character_id)
 {
 	LogTasksDetail(
-		"[RemoveActiveInvitation] shared_task_id [{}] character_id [{}] pre_removal_count [{}]",
+		"shared_task_id [{}] character_id [{}] pre_removal_count [{}]",
 		shared_task_id,
 		character_id,
 		m_active_invitations.size()
@@ -1143,7 +1143,7 @@ void SharedTaskManager::RemoveActiveInvitation(int64 shared_task_id, int64 chara
 	);
 
 	LogTasksDetail(
-		"[RemoveActiveInvitation] shared_task_id [{}] character_id [{}] post_removal_count [{}]",
+		"shared_task_id [{}] character_id [{}] post_removal_count [{}]",
 		shared_task_id,
 		character_id,
 		m_active_invitations.size()
@@ -1721,7 +1721,7 @@ SharedTaskManager *SharedTaskManager::PurgeExpiredSharedTasks()
 	auto      now = std::time(nullptr);
 	for (auto &s: m_shared_tasks) {
 		if (s.GetDbSharedTask().expire_time > 0 && s.GetDbSharedTask().expire_time <= now) {
-			LogTasksDetail("[PurgeExpiredSharedTasks] Deleting expired task [{}]", s.GetDbSharedTask().id);
+			LogTasksDetail("Deleting expired task [{}]", s.GetDbSharedTask().id);
 			delete_tasks.push_back(s.GetDbSharedTask().id);
 		}
 	}
@@ -1773,11 +1773,11 @@ void SharedTaskManager::HandleCompletedTask(SharedTask* s)
 	auto db_task = s->GetDbSharedTask();
 	if (db_task.completion_time > 0)
 	{
-		LogTasksDetail("[HandleCompletedTask] shared task [{}] already completed", db_task.id);
+		LogTasksDetail("shared task [{}] already completed", db_task.id);
 		return;
 	}
 
-	LogTasksDetail("[HandleCompletedTask] Marking shared task [{}] completed", db_task.id);
+	LogTasksDetail("Marking shared task [{}] completed", db_task.id);
 	db_task.completion_time = std::time(nullptr);
 	db_task.is_locked = true;
 	SharedTasksRepository::UpdateOne(*m_database, db_task);

--- a/world/world_boot.cpp
+++ b/world/world_boot.cpp
@@ -102,9 +102,9 @@ bool WorldBoot::HandleCommandInput(int argc, char **argv)
 
 bool WorldBoot::LoadServerConfig()
 {
-	LogInfo("[WorldBoot::LoadServerConfig] Loading server configuration");
+	LogInfo("Loading server configuration");
 	if (!WorldConfig::LoadConfig()) {
-		LogError("[WorldBoot::LoadServerConfig] Loading server configuration failed");
+		LogError("Loading server configuration failed");
 		return false;
 	}
 

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2503,7 +2503,7 @@ bool NPC::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillTy
 		// handle task credit on behalf of the killer
 		if (RuleB(TaskSystem, EnableTaskSystem)) {
 			LogTasksDetail(
-				"[NPC::Death] Triggering HandleUpdateTasksOnKill for [{}] npc [{}]",
+				"Triggering HandleUpdateTasksOnKill for [{}] npc [{}]",
 				give_exp_client->GetCleanName(),
 				GetNPCTypeID()
 			);
@@ -3320,14 +3320,14 @@ int64 Mob::ReduceDamage(int64 damage)
 			int64 damage_to_reduce = damage * spellbonuses.MeleeThresholdGuard[SBIndex::THRESHOLDGUARD_MITIGATION_PERCENT] / 100;
 			if (damage_to_reduce >= buffs[slot].melee_rune)
 			{
-				LogSpellsDetail("[Mob::ReduceDamage] SE_MeleeThresholdGuard [{}] damage negated, [{}] damage remaining, fading buff", damage_to_reduce, buffs[slot].melee_rune);
+				LogSpellsDetail("SE_MeleeThresholdGuard [{}] damage negated, [{}] damage remaining, fading buff", damage_to_reduce, buffs[slot].melee_rune);
 				damage -= buffs[slot].melee_rune;
 				if (!TryFadeEffect(slot))
 					BuffFadeBySlot(slot);
 			}
 			else
 			{
-				LogSpellsDetail("[Mob::ReduceDamage] SE_MeleeThresholdGuard [{}] damage negated, [{}] damage remaining", damage_to_reduce, buffs[slot].melee_rune);
+				LogSpellsDetail("SE_MeleeThresholdGuard [{}] damage negated, [{}] damage remaining", damage_to_reduce, buffs[slot].melee_rune);
 				buffs[slot].melee_rune = (buffs[slot].melee_rune - damage_to_reduce);
 				damage -= damage_to_reduce;
 			}
@@ -3345,14 +3345,14 @@ int64 Mob::ReduceDamage(int64 damage)
 
 			if (spellbonuses.MitigateMeleeRune[SBIndex::MITIGATION_RUNE_MAX_HP_AMT] && (damage_to_reduce >= buffs[slot].melee_rune))
 			{
-				LogSpellsDetail("[Mob::ReduceDamage] SE_MitigateMeleeDamage [{}] damage negated, [{}] damage remaining, fading buff", damage_to_reduce, buffs[slot].melee_rune);
+				LogSpellsDetail("SE_MitigateMeleeDamage [{}] damage negated, [{}] damage remaining, fading buff", damage_to_reduce, buffs[slot].melee_rune);
 				damage -= buffs[slot].melee_rune;
 				if (!TryFadeEffect(slot))
 					BuffFadeBySlot(slot);
 			}
 			else
 			{
-				LogSpellsDetail("[Mob::ReduceDamage] SE_MitigateMeleeDamage [{}] damage negated, [{}] damage remaining", damage_to_reduce, buffs[slot].melee_rune);
+				LogSpellsDetail("SE_MitigateMeleeDamage [{}] damage negated, [{}] damage remaining", damage_to_reduce, buffs[slot].melee_rune);
 
 				if (spellbonuses.MitigateMeleeRune[SBIndex::MITIGATION_RUNE_MAX_HP_AMT])
 					buffs[slot].melee_rune = (buffs[slot].melee_rune - damage_to_reduce);
@@ -3471,14 +3471,14 @@ int64 Mob::AffectMagicalDamage(int64 damage, uint16 spell_id, const bool iBuffTi
 
 				if (spellbonuses.MitigateSpellRune[SBIndex::MITIGATION_RUNE_MAX_HP_AMT] && (damage_to_reduce >= buffs[slot].magic_rune))
 				{
-					LogSpellsDetail("[Mob::AffectMagicalDamage] SE_MitigateSpellDamage [{}] damage negated, [{}] damage remaining, fading buff", damage_to_reduce, buffs[slot].magic_rune);
+					LogSpellsDetail("SE_MitigateSpellDamage [{}] damage negated, [{}] damage remaining, fading buff", damage_to_reduce, buffs[slot].magic_rune);
 					damage -= buffs[slot].magic_rune;
 					if (!TryFadeEffect(slot))
 						BuffFadeBySlot(slot);
 				}
 				else
 				{
-					LogSpellsDetail("[Mob::AffectMagicalDamage] SE_MitigateMeleeDamage [{}] damage negated, [{}] damage remaining", damage_to_reduce, buffs[slot].magic_rune);
+					LogSpellsDetail("SE_MitigateMeleeDamage [{}] damage negated, [{}] damage remaining", damage_to_reduce, buffs[slot].magic_rune);
 
 					if (spellbonuses.MitigateSpellRune[SBIndex::MITIGATION_RUNE_MAX_HP_AMT])
 						buffs[slot].magic_rune = (buffs[slot].magic_rune - damage_to_reduce);

--- a/zone/aura.cpp
+++ b/zone/aura.cpp
@@ -964,7 +964,7 @@ bool ZoneDatabase::GetAuraEntry(uint16 spell_id, AuraRecord &record)
 void Mob::AddAura(Aura *aura, AuraRecord &record)
 {
 	LogAura(
-		"[AddAura] aura owner [{}] spawn_id [{}] aura_name [{}]",
+		"aura owner [{}] spawn_id [{}] aura_name [{}]",
 		GetCleanName(),
 		aura->GetID(),
 		aura->GetCleanName()
@@ -999,7 +999,7 @@ void Mob::AddAura(Aura *aura, AuraRecord &record)
 void Mob::AddTrap(Aura *aura, AuraRecord &record)
 {
 	LogAura(
-		"[AddTrap] aura owner [{}] spawn_id [{}] aura_name [{}]",
+		"aura owner [{}] spawn_id [{}] aura_name [{}]",
 		GetCleanName(),
 		aura->GetID(),
 		aura->GetCleanName()
@@ -1048,7 +1048,7 @@ void Mob::RemoveAllAuras()
 		for (auto &e : aura_mgr.auras) {
 			if (e.aura) {
 				LogAura(
-					"[RemoveAllAuras] aura owner [{}] spawn_id [{}] aura_name [{}]",
+					"aura owner [{}] spawn_id [{}] aura_name [{}]",
 					GetCleanName(),
 					e.spawn_id,
 					e.name
@@ -1065,7 +1065,7 @@ void Mob::RemoveAllAuras()
 		for (auto &e : trap_mgr.auras) {
 			if (e.aura) {
 				LogAura(
-					"[RemoveAllAuras] trap owner [{}] spawn_id [{}] aura_name [{}]",
+					"trap owner [{}] spawn_id [{}] aura_name [{}]",
 					GetCleanName(),
 					e.spawn_id,
 					e.name
@@ -1085,7 +1085,7 @@ void Mob::RemoveAura(int spawn_id, bool skip_strip, bool expired)
 		auto &aura = aura_mgr.auras[i];
 		if (aura.spawn_id == spawn_id) {
 			LogAura(
-				"[RemoveAura] mob [{}] spawn_id [{}] skip_strip [{}] expired [{}]",
+				"mob [{}] spawn_id [{}] skip_strip [{}] expired [{}]",
 				GetCleanName(),
 				spawn_id,
 				skip_strip ? "true" : "false",

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -1622,7 +1622,7 @@ int32 Bot::acmod() {
 	else
 		return (65 + ((agility - 300) / 21));
 
-	LogError("[Bot::acmod] Agility [{}] Level [{}]",agility,level);
+	LogError("Agility [{}] Level [{}]",agility,level);
 	return 0;
 }
 
@@ -2146,7 +2146,7 @@ bool Bot::Process()
 
 	if (mob_close_scan_timer.Check()) {
 		LogAIScanCloseDetail(
-			"[Bot::Process] is_moving [{}] bot [{}] timer [{}]",
+			"is_moving [{}] bot [{}] timer [{}]",
 			moving ? "true" : "false",
 			GetCleanName(),
 			mob_close_scan_timer.GetDuration()
@@ -2304,7 +2304,7 @@ void Bot::BotRangedAttack(Mob* other) {
 	//make sure the attack and ranged timers are up
 	//if the ranged timer is disabled, then they have no ranged weapon and shouldent be attacking anyhow
 	if((attack_timer.Enabled() && !attack_timer.Check(false)) || (ranged_timer.Enabled() && !ranged_timer.Check())) {
-		LogCombatDetail("[Bot::BotRangedAttack] Bot Archery attack canceled. Timer not up. Attack [{}] ranged [{}]", attack_timer.GetRemainingTime(), ranged_timer.GetRemainingTime());
+		LogCombatDetail("Bot Archery attack canceled. Timer not up. Attack [{}] ranged [{}]", attack_timer.GetRemainingTime(), ranged_timer.GetRemainingTime());
 		Message(0, "Error: Timer not up. Attack %d, ranged %d", attack_timer.GetRemainingTime(), ranged_timer.GetRemainingTime());
 		return;
 	}
@@ -2322,7 +2322,7 @@ void Bot::BotRangedAttack(Mob* other) {
 	if(!RangeWeapon || !Ammo)
 		return;
 
-	LogCombatDetail("[Bot::BotRangedAttack] Shooting [{}] with bow [{}] ([{}]) and arrow [{}] ([{}])", other->GetCleanName(), RangeWeapon->Name, RangeWeapon->ID, Ammo->Name, Ammo->ID);
+	LogCombatDetail("Shooting [{}] with bow [{}] ([{}]) and arrow [{}] ([{}])", other->GetCleanName(), RangeWeapon->Name, RangeWeapon->ID, Ammo->Name, Ammo->ID);
 	if(!IsAttackAllowed(other) || IsCasting() || DivineAura() || IsStunned() || IsMezzed() || (GetAppearance() == eaDead))
 		return;
 
@@ -3506,7 +3506,7 @@ void Bot::AI_Process()
 
 				if (GetTarget() && !IsRooted()) {
 
-					LogAIDetail("[Bot::AI_Process] Pursuing [{}] while engaged", GetTarget()->GetCleanName());
+					LogAIDetail("Pursuing [{}] while engaged", GetTarget()->GetCleanName());
 					Goal = GetTarget()->GetPosition();
 					if (DistanceSquared(m_Position, Goal) <= leash_distance) {
 						RunTo(Goal.x, Goal.y, Goal.z);
@@ -3892,7 +3892,7 @@ void Bot::PetAIProcess() {
 				else if (botPet->GetTarget() && botPet->GetAIMovementTimer()->Check()) {
 					botPet->SetRunAnimSpeed(0);
 					if(!botPet->IsRooted()) {
-						LogAIDetail("[Bot::AI_Process] Pursuing [{}] while engaged", botPet->GetTarget()->GetCleanName());
+						LogAIDetail("Pursuing [{}] while engaged", botPet->GetTarget()->GetCleanName());
 						botPet->RunTo(botPet->GetTarget()->GetX(), botPet->GetTarget()->GetY(), botPet->GetTarget()->GetZ());
 						return;
 					} else {
@@ -4454,7 +4454,7 @@ void Bot::AddBotItem(
 
 	if (!inst) {
 		LogError(
-			"[Bot::AI_Process] Bot:AddItem Invalid Item data: ID [{}] Charges [{}] Aug1 [{}] Aug2 [{}] Aug3 [{}] Aug4 [{}] Aug5 [{}] Aug6 [{}] Attuned [{}]",
+			"Bot:AddItem Invalid Item data: ID [{}] Charges [{}] Aug1 [{}] Aug2 [{}] Aug3 [{}] Aug4 [{}] Aug5 [{}] Aug6 [{}] Attuned [{}]",
 			item_id,
 			charges,
 			augment_one,
@@ -4469,7 +4469,7 @@ void Bot::AddBotItem(
 	}
 
 	if (!database.botdb.SaveItemBySlot(this, slot_id, inst)) {
-		LogError("[Bot::AI_Process] Failed to save item by slot to slot [{}] for [{}].", slot_id, GetCleanName());
+		LogError("Failed to save item by slot to slot [{}] for [{}].", slot_id, GetCleanName());
 		safe_delete(inst);
 		return;
 	}
@@ -4720,7 +4720,7 @@ void Bot::PerformTradeWithClient(int16 begin_slot_id, int16 end_slot_id, Client*
 		}
 
 		if (!trade_instance->GetItem()) {
-			LogError("[Bot::PerformTradeWithClient] could not find item from instance in trade for [{}] with [{}] in slot [{}].", client->GetCleanName(), GetCleanName(), trade_index);
+			LogError("could not find item from instance in trade for [{}] with [{}] in slot [{}].", client->GetCleanName(), GetCleanName(), trade_index);
 			client->Message(
 				Chat::White,
 				fmt::format(
@@ -4739,7 +4739,7 @@ void Bot::PerformTradeWithClient(int16 begin_slot_id, int16 end_slot_id, Client*
 		auto item_link = linker.GenerateLink();
 
 		if (trade_index != invslot::slotCursor && !trade_instance->IsDroppable()) {
-			LogError("[Bot::PerformTradeWithClient] trade hack detected by [{}] with [{}].", client->GetCleanName(), GetCleanName());
+			LogError("trade hack detected by [{}] with [{}].", client->GetCleanName(), GetCleanName());
 			client->Message(Chat::White, "Trade hack detected, the trade has been cancelled.");
 			client->ResetTrade();
 			return;
@@ -4828,14 +4828,14 @@ void Bot::PerformTradeWithClient(int16 begin_slot_id, int16 end_slot_id, Client*
 			}
 
 			if (trade_instance->GetItem()->LoreGroup == -1 && check_iterator.trade_item_instance->GetItem()->ID == trade_instance->GetItem()->ID) {
-				LogError("[Bot::PerformTradeWithClient] trade hack detected by [{}] with [{}].", client->GetCleanName(), GetCleanName());
+				LogError("trade hack detected by [{}] with [{}].", client->GetCleanName(), GetCleanName());
 				client->Message(Chat::White, "Trade hack detected, the trade has been cancelled.");
 				client->ResetTrade();
 				return;
 			}
 
 			if ((trade_instance->GetItem()->LoreGroup > 0) && (check_iterator.trade_item_instance->GetItem()->LoreGroup == trade_instance->GetItem()->LoreGroup)) {
-				LogError("[Bot::PerformTradeWithClient] trade hack detected by [{}] with [{}].", client->GetCleanName(), GetCleanName());
+				LogError("trade hack detected by [{}] with [{}].", client->GetCleanName(), GetCleanName());
 				client->Message(Chat::White, "Trade hack detected, the trade has been cancelled.");
 				client->ResetTrade();
 				return;
@@ -4959,7 +4959,7 @@ void Bot::PerformTradeWithClient(int16 begin_slot_id, int16 end_slot_id, Client*
 		}
 
 		if (!return_instance->GetItem()) {
-			LogError("[Bot::PerformTradeWithClient] error processing bot slot [{}] for [{}] in trade with [{}].", return_iterator.from_bot_slot, GetCleanName(), client->GetCleanName());
+			LogError("error processing bot slot [{}] for [{}] in trade with [{}].", return_iterator.from_bot_slot, GetCleanName(), client->GetCleanName());
 			client->Message(
 				Chat::White,
 				fmt::format(
@@ -5285,7 +5285,7 @@ void Bot::Damage(Mob *from, int64 damage, uint16 spell_id, EQ::skills::SkillType
 
 	//handle EVENT_ATTACK. Resets after we have not been attacked for 12 seconds
 	if(attacked_timer.Check()) {
-		LogCombat("[Bot::Damage] Triggering EVENT_ATTACK due to attack by [{}]", from->GetName());
+		LogCombat("Triggering EVENT_ATTACK due to attack by [{}]", from->GetName());
 		parse->EventBot(EVENT_ATTACK, this, from, "", 0);
 	}
 
@@ -5293,7 +5293,7 @@ void Bot::Damage(Mob *from, int64 damage, uint16 spell_id, EQ::skills::SkillType
 	// if spell is lifetap add hp to the caster
 	if (spell_id != SPELL_UNKNOWN && IsLifetapSpell(spell_id)) {
 		int64 healed = GetActSpellHealing(spell_id, damage);
-		LogCombatDetail("[Bot::Damage] Applying lifetap heal of [{}] to [{}]", healed, GetCleanName());
+		LogCombatDetail("Applying lifetap heal of [{}] to [{}]", healed, GetCleanName());
 		HealDamage(healed);
 		entity_list.FilteredMessageClose(this, true, RuleI(Range, SpellMessages), Chat::Emote, FilterSocials, "%s beams a smile at %s", GetCleanName(), from->GetCleanName() );
 	}
@@ -5324,7 +5324,7 @@ void Bot::Damage(Mob *from, int64 damage, uint16 spell_id, EQ::skills::SkillType
 bool Bot::Attack(Mob* other, int Hand, bool FromRiposte, bool IsStrikethrough, bool IsFromSpell, ExtraAttackOptions *opts) {
 	if (!other) {
 		SetTarget(nullptr);
-		LogErrorDetail("[Bot::Attack] A null Mob object was passed to Bot::Attack for evaluation!");
+		LogErrorDetail("A null Mob object was passed to Bot::Attack for evaluation!");
 		return false;
 	}
 
@@ -5342,20 +5342,20 @@ bool Bot::Attack(Mob* other, int Hand, bool FromRiposte, bool IsStrikethrough, b
 	// takes more to compare a call result, load for a call, load a compare to address and compare, and finally
 	// push a value to an address than to just load for a call and push a value to an address.
 
-	LogCombat("[Bot::Attack] Attacking [{}] with hand [{}] [{}]", other->GetCleanName(), Hand, (FromRiposte ? "(this is a riposte)" : ""));
+	LogCombat("Attacking [{}] with hand [{}] [{}]", other->GetCleanName(), Hand, (FromRiposte ? "(this is a riposte)" : ""));
 	if ((IsCasting() && (GetClass() != BARD) && !IsFromSpell) || (!IsAttackAllowed(other))) {
 		if(GetOwnerID())
 			entity_list.MessageClose(this, 1, 200, 10, "%s says, '%s is not a legal target master.'", GetCleanName(), GetTarget()->GetCleanName());
 
 		if(other) {
 			RemoveFromHateList(other);
-			LogCombat("[Bot::Attack] I am not allowed to attack [{}]", other->GetCleanName());
+			LogCombat("I am not allowed to attack [{}]", other->GetCleanName());
 		}
 		return false;
 	}
 
 	if(DivineAura()) {//cant attack while invulnerable
-		LogCombat("[Bot::Attack] Attack canceled, Divine Aura is in effect");
+		LogCombat("Attack canceled, Divine Aura is in effect");
 		return false;
 	}
 
@@ -5373,19 +5373,19 @@ bool Bot::Attack(Mob* other, int Hand, bool FromRiposte, bool IsStrikethrough, b
 
 	if(weapon != nullptr) {
 		if (!weapon->IsWeapon()) {
-			LogCombat("[Bot::Attack] Attack canceled, Item [{}] ([{}]) is not a weapon", weapon->GetItem()->Name, weapon->GetID());
+			LogCombat("Attack canceled, Item [{}] ([{}]) is not a weapon", weapon->GetItem()->Name, weapon->GetID());
 			return false;
 		}
-		LogCombat("[Bot::Attack] Attacking with weapon: [{}] ([{}])", weapon->GetItem()->Name, weapon->GetID());
+		LogCombat("Attacking with weapon: [{}] ([{}])", weapon->GetItem()->Name, weapon->GetID());
 	}
 	else
-		LogCombat("[Bot::Attack] Attacking without a weapon");
+		LogCombat("Attacking without a weapon");
 
 	// calculate attack_skill and skillinuse depending on hand and weapon
 	// also send Packet to near clients
 	DamageHitInfo my_hit;
 	my_hit.skill = AttackAnimation(Hand, weapon);
-	LogCombat("[Bot::Attack] Attacking with [{}] in slot [{}] using skill [{}]", weapon?weapon->GetItem()->Name:"Fist", Hand, my_hit.skill);
+	LogCombat("Attacking with [{}] in slot [{}] using skill [{}]", weapon?weapon->GetItem()->Name:"Fist", Hand, my_hit.skill);
 
 	// Now figure out damage
 	my_hit.damage_done = 1;
@@ -5433,7 +5433,7 @@ bool Bot::Attack(Mob* other, int Hand, bool FromRiposte, bool IsStrikethrough, b
 			}
 		}
 
-		LogCombat("[Bot::Attack] Damage calculated: base [{}] min damage [{}] skill [{}]", my_hit.base_damage, my_hit.min_damage, my_hit.skill);
+		LogCombat("Damage calculated: base [{}] min damage [{}] skill [{}]", my_hit.base_damage, my_hit.min_damage, my_hit.skill);
 
 		int hit_chance_bonus = 0;
 		my_hit.offense = offense(my_hit.skill);
@@ -5451,7 +5451,7 @@ bool Bot::Attack(Mob* other, int Hand, bool FromRiposte, bool IsStrikethrough, b
 
 		DoAttack(other, my_hit, opts, FromRiposte);
 
-		LogCombat("[Bot::Attack] Final damage after all reductions: [{}]", my_hit.damage_done);
+		LogCombat("Final damage after all reductions: [{}]", my_hit.damage_done);
 	} else {
 		my_hit.damage_done = DMG_INVULNERABLE;
 	}
@@ -5515,7 +5515,7 @@ float Bot::GetProcChances(float ProcBonus, uint16 hand) {
 		ProcChance += (ProcChance * ProcBonus / 100.0f);
 	}
 
-	LogCombat("[Bot::GetProcChances] Proc chance [{}] ([{}] from bonuses)", ProcChance, ProcBonus);
+	LogCombat("Proc chance [{}] ([{}] from bonuses)", ProcChance, ProcBonus);
 	return ProcChance;
 }
 
@@ -5569,13 +5569,13 @@ bool Bot::TryFinishingBlow(Mob *defender, int64 &damage)
 		int fb_damage = aabonuses.FinishingBlow[1];
 		int levelreq = aabonuses.FinishingBlowLvl[0];
 		if (defender->GetLevel() <= levelreq && (chance >= zone->random.Int(1, 1000))) {
-			LogCombat("[Bot::TryFinishingBlow] Landed a finishing blow: levelreq at [{}] other level [{}]",
+			LogCombat("Landed a finishing blow: levelreq at [{}] other level [{}]",
 				levelreq, defender->GetLevel());
 			entity_list.MessageCloseString(this, false, 200, Chat::MeleeCrit, FINISHING_BLOW, GetName());
 			damage = fb_damage;
 			return true;
 		} else {
-			LogCombat("[Bot::TryFinishingBlow] failed a finishing blow: levelreq at [{}] other level [{}]",
+			LogCombat("failed a finishing blow: levelreq at [{}] other level [{}]",
 				levelreq, defender->GetLevel());
 			return false;
 		}
@@ -5584,14 +5584,14 @@ bool Bot::TryFinishingBlow(Mob *defender, int64 &damage)
 }
 
 void Bot::DoRiposte(Mob* defender) {
-	LogCombatDetail("[Bot::DoRiposte] Preforming a riposte");
+	LogCombatDetail("Preforming a riposte");
 	if (!defender)
 		return;
 
 	defender->Attack(this, EQ::invslot::slotPrimary, true);
 	int32 DoubleRipChance = (defender->GetAABonuses().GiveDoubleRiposte[0] + defender->GetSpellBonuses().GiveDoubleRiposte[0] + defender->GetItemBonuses().GiveDoubleRiposte[0]);
 	if(DoubleRipChance && (DoubleRipChance >= zone->random.Int(0, 100))) {
-		LogCombatDetail("[Bot::DoRiposte] Preforming a double riposte ([{}] percent chance)", DoubleRipChance);
+		LogCombatDetail("Preforming a double riposte ([{}] percent chance)", DoubleRipChance);
 		defender->Attack(this, EQ::invslot::slotPrimary, true);
 	}
 
@@ -6327,7 +6327,7 @@ int64 Bot::CalcMaxMana() {
 			break;
 		}
 		default: {
-			LogDebug("[Bot::CalcMaxMana] Invalid Class [{}] in CalcMaxMana", GetCasterClass());
+			LogDebug("Invalid Class [{}] in CalcMaxMana", GetCasterClass());
 			max_mana = 0;
 			break;
 		}
@@ -6527,7 +6527,7 @@ bool Bot::CastSpell(
 		}
 
 		if (DivineAura()) {
-			LogSpellsDetail("[Bot::CastSpell] Spell casting canceled: cannot cast while Divine Aura is in effect");
+			LogSpellsDetail("Spell casting canceled: cannot cast while Divine Aura is in effect");
 			InterruptSpell(173, 0x121, false);
 			return false;
 		}
@@ -6543,7 +6543,7 @@ bool Bot::CastSpell(
 		}
 
 		if (HasActiveSong()) {
-			LogSpellsDetail("[Bot::CastSpell] Casting a new spell/song while singing a song. Killing old song [{}]", bardsong);
+			LogSpellsDetail("Casting a new spell/song while singing a song. Killing old song [{}]", bardsong);
 			bardsong = 0;
 			bardsong_target_id = 0;
 			bardsong_slot = EQ::spells::CastingSlot::Gem1;
@@ -6758,7 +6758,7 @@ bool Bot::DoFinishedSpellSingleTarget(uint16 spell_id, Mob* spellTarget, EQ::spe
 					if((spelltypeequal || spelltypetargetequal) || spelltypeclassequal || slotequal) {
 						if(((spells[thespell].effect_id[0] == 0) && (spells[thespell].base_value[0] < 0)) &&
 							(spellTarget->GetHP() < ((spells[thespell].base_value[0] * (-1)) + 100))) {
-							LogSpells("[Bot::DoFinishedSpellSingleTarget] GroupBuffing failure");
+							LogSpells("GroupBuffing failure");
 							return false;
 						}
 

--- a/zone/botspellsai.cpp
+++ b/zone/botspellsai.cpp
@@ -1204,7 +1204,7 @@ bool Bot::AIDoSpellCast(uint8 i, Mob* tar, int32 mana_cost, uint32* oDontDoAgain
 		)
 	) {
 		casting_spell_AIindex = i;
-		LogAI("[Bot::AIDoSpellCast] spellid [{}] tar [{}] mana [{}] Name [{}]", AIBot_spells[i].spellid, tar->GetName(), mana_cost, spells[AIBot_spells[i].spellid].name);
+		LogAI("spellid [{}] tar [{}] mana [{}] Name [{}]", AIBot_spells[i].spellid, tar->GetName(), mana_cost, spells[AIBot_spells[i].spellid].name);
 		result = Mob::CastSpell(AIBot_spells[i].spellid, tar->GetID(), EQ::spells::CastingSlot::Gem2, spells[AIBot_spells[i].spellid].cast_time, AIBot_spells[i].manacost == -2 ? 0 : mana_cost, oDontDoAgainBefore, -1, -1, 0, &(AIBot_spells[i].resist_adjust));
 
 		if (IsCasting() && IsSitting())
@@ -1751,10 +1751,10 @@ bool Bot::AIHealRotation(Mob* tar, bool useFastHeals) {
 		}
 	}
 
-	LogAIDetail("[Bot::AIHealRotation] heal spellid [{}] fastheals [{}] casterlevel [{}]",
+	LogAIDetail("heal spellid [{}] fastheals [{}] casterlevel [{}]",
 		botSpell.SpellId, ((useFastHeals) ? ('T') : ('F')), GetLevel());
 
-	LogAIDetail("[Bot::AIHealRotation] target [{}] current_time [{}] donthealmebefore [{}]", tar->GetCleanName(), Timer::GetCurrentTime(), tar->DontHealMeBefore());
+	LogAIDetail("target [{}] current_time [{}] donthealmebefore [{}]", tar->GetCleanName(), Timer::GetCurrentTime(), tar->DontHealMeBefore());
 
 	// If there is still no spell id, then there isn't going to be one so we are done
 	if (botSpell.SpellId == 0)

--- a/zone/client_mods.cpp
+++ b/zone/client_mods.cpp
@@ -581,7 +581,7 @@ int64 Client::CalcMaxMana()
 				break;
 			}
 		default: {
-				LogSpells("[Client::CalcMaxMana] Invalid Class [{}] in CalcMaxMana", GetCasterClass());
+				LogSpells("Invalid Class [{}] in CalcMaxMana", GetCasterClass());
 				max_mana = 0;
 				break;
 			}
@@ -599,7 +599,7 @@ int64 Client::CalcMaxMana()
 			current_mana = curMana_cap;
 		}
 	}
-	LogSpells("[Client::CalcMaxMana] for [{}] returning [{}]", GetName(), max_mana);
+	LogSpells("for [{}] returning [{}]", GetName(), max_mana);
 	return max_mana;
 }
 
@@ -1663,7 +1663,7 @@ uint32 Mob::GetInstrumentMod(uint16 spell_id)
 		}
 	}
 
-	LogSpells("[Mob::GetInstrumentMod] Name [{}] spell [{}] mod [{}] modcap [{}]\n", GetName(), spell_id, effectmod, effectmodcap);
+	LogSpells("Name [{}] spell [{}] mod [{}] modcap [{}]\n", GetName(), spell_id, effectmod, effectmodcap);
 
 	return effectmod;
 }

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -3955,14 +3955,14 @@ void Client::Handle_OP_Buff(const EQApplicationPacket *app)
 	*/
 	if (app->size != sizeof(SpellBuffPacket_Struct))
 	{
-		LogError("[Client::Handle_OP_Buff] Size mismatch in OP_Buff. expected [{}] got [{}]", sizeof(SpellBuffPacket_Struct), app->size);
+		LogError("Size mismatch in OP_Buff. expected [{}] got [{}]", sizeof(SpellBuffPacket_Struct), app->size);
 		DumpPacket(app);
 		return;
 	}
 
 	SpellBuffPacket_Struct* sbf = (SpellBuffPacket_Struct*)app->pBuffer;
 	uint32 spid = sbf->buff.spellid;
-	LogSpells("[Client::Handle_OP_Buff] Client requested that buff with spell id [{}] be canceled", spid);
+	LogSpells("Client requested that buff with spell id [{}] be canceled", spid);
 
 	//something about IsDetrimentalSpell() crashes this portion of code..
 	//tbh we shouldn't use it anyway since this is a simple red vs blue buff check and
@@ -4126,7 +4126,7 @@ void Client::Handle_OP_CastSpell(const EQApplicationPacket *app)
 
 	m_TargetRing = glm::vec3(castspell->x_pos, castspell->y_pos, castspell->z_pos);
 
-	LogSpells("[Client::Handle_OP_CastSpell] OP CastSpell: slot [{}] spell [{}] target [{}] inv [{}]", castspell->slot, castspell->spell_id, castspell->target_id, (unsigned long)castspell->inventoryslot);
+	LogSpells("OP CastSpell: slot [{}] spell [{}] target [{}] inv [{}]", castspell->slot, castspell->spell_id, castspell->target_id, (unsigned long)castspell->inventoryslot);
 	CastingSlot slot = static_cast<CastingSlot>(castspell->slot);
 
 	/* Memorized Spell */
@@ -4226,7 +4226,7 @@ void Client::Handle_OP_CastSpell(const EQApplicationPacket *app)
 	/* Discipline -- older clients use the same slot as items, but we translate to it's own */
 	else if (slot == CastingSlot::Discipline) {
 		if (!UseDiscipline(castspell->spell_id, castspell->target_id)) {
-			LogSpells("[Client::Handle_OP_CastSpell] Unknown ability being used by [{}] spell being cast is: [{}]\n", GetName(), castspell->spell_id);
+			LogSpells("Unknown ability being used by [{}] spell being cast is: [{}]\n", GetName(), castspell->spell_id);
 			InterruptSpell(castspell->spell_id);
 			return;
 		}
@@ -8764,7 +8764,7 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 	using EQ::spells::CastingSlot;
 	if (app->size != sizeof(ItemVerifyRequest_Struct))
 	{
-		LogError("[Client::Handle_OP_ItemVerifyRequest] OP size error: OP_ItemVerifyRequest expected:[{}] got:[{}]", sizeof(ItemVerifyRequest_Struct), app->size);
+		LogError("OP size error: OP_ItemVerifyRequest expected:[{}] got:[{}]", sizeof(ItemVerifyRequest_Struct), app->size);
 		return;
 	}
 
@@ -8793,7 +8793,7 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 	}
 
 	if (slot_id < 0) {
-		LogDebug("[Client::Handle_OP_ItemVerifyRequest] Unknown slot being used by [{}] slot being used is [{}]", GetName(), request->slot);
+		LogDebug("Unknown slot being used by [{}] slot being used is [{}]", GetName(), request->slot);
 		return;
 	}
 
@@ -8854,7 +8854,7 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 	if (spell_id > 0 && (spells[spell_id].target_type == ST_Pet || spells[spell_id].target_type == ST_SummonedPet))
 		target_id = GetPetID();
 
-	LogDebug("[Client::Handle_OP_ItemVerifyRequest] OP ItemVerifyRequest: spell=[{}] target=[{}] inv=[{}]", spell_id, target_id, slot_id);
+	LogDebug("OP ItemVerifyRequest: spell=[{}] target=[{}] inv=[{}]", spell_id, target_id, slot_id);
 
 	if (m_inv.SupportsClickCasting(slot_id) || ((item->ItemType == EQ::item::ItemTypePotion || item->PotionBelt) && m_inv.SupportsPotionBeltCasting(slot_id))) // sanity check
 	{
@@ -8892,7 +8892,7 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 
 		if ((spell_id <= 0) && (item->ItemType != EQ::item::ItemTypeFood && item->ItemType != EQ::item::ItemTypeDrink && item->ItemType != EQ::item::ItemTypeAlcohol && item->ItemType != EQ::item::ItemTypeSpell))
 		{
-			LogDebug("[Client::Handle_OP_ItemVerifyRequest] Item with no effect right clicked by [{}]", GetName());
+			LogDebug("Item with no effect right clicked by [{}]", GetName());
 		}
 		else if (inst->IsClassCommon())
 		{
@@ -8953,7 +8953,7 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 							SendItemRecastTimer(item->RecastType); //Problem: When you loot corpse, recast display is not present. This causes it to display again. Could not get to display when sending from looting.
 							MessageString(Chat::Red, SPELL_RECAST);
 							SendSpellBarEnable(item->Click.Effect);
-							LogSpells("[Client::Handle_OP_ItemVerifyRequest] Casting of [{}] canceled: item spell reuse timer not expired", spell_id);
+							LogSpells("Casting of [{}] canceled: item spell reuse timer not expired", spell_id);
 							return;
 						}
 					}
@@ -8995,7 +8995,7 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 					if (augitem->RecastDelay > 0)
 					{
 						if (!GetPTimers().Expired(&database, (pTimerItemStart + augitem->RecastType), false)) {
-							LogSpells("[Client::Handle_OP_ItemVerifyRequest] Casting of [{}] canceled: item spell reuse timer from augment not expired", spell_id);
+							LogSpells("Casting of [{}] canceled: item spell reuse timer from augment not expired", spell_id);
 							MessageString(Chat::Red, SPELL_RECAST);
 							SendSpellBarEnable(augitem->Click.Effect);
 							return;
@@ -9033,12 +9033,12 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 				{
 					if (item->ItemType != EQ::item::ItemTypeFood && item->ItemType != EQ::item::ItemTypeDrink && item->ItemType != EQ::item::ItemTypeAlcohol)
 					{
-						LogDebug("[Client::Handle_OP_ItemVerifyRequest] Error: unknown item->Click.Type ([{}])", item->Click.Type);
+						LogDebug("Error: unknown item->Click.Type ([{}])", item->Click.Type);
 					}
 				}
 				else
 				{
-					LogDebug("[Client::Handle_OP_ItemVerifyRequest] Error: unknown item->Click.Type ([{}])", item->Click.Type);
+					LogDebug("Error: unknown item->Click.Type ([{}])", item->Click.Type);
 				}
 			}
 		}
@@ -12270,7 +12270,7 @@ void Client::Handle_OP_RecipesSearch(const EQApplicationPacket *app)
 	p_recipes_search_struct->query[55] = '\0';	//just to be sure.
 
 	LogTradeskills(
-		"[Handle_OP_RecipesSearch] Requested search recipes for object_type [{}] some_id [{}]",
+		"Requested search recipes for object_type [{}] some_id [{}]",
 		p_recipes_search_struct->object_type,
 		p_recipes_search_struct->some_id
 	);
@@ -14475,7 +14475,7 @@ void Client::Handle_OP_Trader(const EQApplicationPacket *app)
 		{
 		case BazaarTrader_EndTraderMode: {
 			Trader_EndTrader();
-			LogTrading("Client::Handle_OP_Trader: End Trader Session");
+			LogTrading("End Trader Session");
 			break;
 		}
 		case BazaarTrader_EndTransaction: {
@@ -14484,16 +14484,16 @@ void Client::Handle_OP_Trader(const EQApplicationPacket *app)
 			if (c)
 			{
 				c->WithCustomer(0);
-				LogTrading("Client::Handle_OP_Trader: End Transaction");
+				LogTrading("End Transaction");
 			}
 			else
-				LogTrading("Client::Handle_OP_Trader: Null Client Pointer");
+				LogTrading("Null Client Pointer");
 
 			break;
 		}
 		case BazaarTrader_ShowItems: {
 			Trader_ShowItems();
-			LogTrading("Client::Handle_OP_Trader: Show Trader Items");
+			LogTrading("Show Trader Items");
 			break;
 		}
 		default: {
@@ -14516,7 +14516,7 @@ void Client::Handle_OP_Trader(const EQApplicationPacket *app)
 		{
 			GetItems_Struct* gis = GetTraderItems();
 
-			LogTrading("Client::Handle_OP_Trader: Start Trader Mode");
+			LogTrading("Start Trader Mode");
 			// Verify there are no NODROP or items with a zero price
 			bool TradeItemsValid = true;
 
@@ -14580,7 +14580,7 @@ void Client::Handle_OP_Trader(const EQApplicationPacket *app)
 			}
 		}
 		else {
-			LogTrading("Client::Handle_OP_Trader: Unknown TraderStruct code of: [{}]\n",
+			LogTrading("Unknown TraderStruct code of: [{}]\n",
 				ints->Code);
 
 			LogError("Unknown TraderStruct code of: [{}]\n", ints->Code);
@@ -14590,18 +14590,18 @@ void Client::Handle_OP_Trader(const EQApplicationPacket *app)
 	{
 		TraderStatus_Struct* tss = (TraderStatus_Struct*)app->pBuffer;
 
-		LogTrading("Client::Handle_OP_Trader: Trader Status Code: [{}]", tss->Code);
+		LogTrading("Trader Status Code: [{}]", tss->Code);
 
 		switch (tss->Code)
 		{
 		case BazaarTrader_EndTraderMode: {
 			Trader_EndTrader();
-			LogTrading("Client::Handle_OP_Trader: End Trader Session");
+			LogTrading("End Trader Session");
 			break;
 		}
 		case BazaarTrader_ShowItems: {
 			Trader_ShowItems();
-			LogTrading("Client::Handle_OP_Trader: Show Trader Items");
+			LogTrading("Show Trader Items");
 			break;
 		}
 		default: {
@@ -14614,7 +14614,7 @@ void Client::Handle_OP_Trader(const EQApplicationPacket *app)
 	}
 	else if (app->size == sizeof(TraderPriceUpdate_Struct))
 	{
-		LogTrading("Client::Handle_OP_Trader: Trader Price Update");
+		LogTrading("Trader Price Update");
 		HandleTraderPriceUpdate(app);
 	}
 	else {
@@ -14815,18 +14815,18 @@ void Client::Handle_OP_TraderShop(const EQApplicationPacket *app)
 			if (c)
 			{
 				c->WithCustomer(0);
-				LogTrading("Client::Handle_OP_Trader: End Transaction - Code [{}]", Command);
+				LogTrading("End Transaction - Code [{}]", Command);
 			}
 			else
 			{
-				LogTrading("Client::Handle_OP_Trader: Null Client Pointer for Trader - Code [{}]", Command);
+				LogTrading("Null Client Pointer for Trader - Code [{}]", Command);
 			}
 			EQApplicationPacket empty(OP_ShopEndConfirm);
 			QueuePacket(&empty);
 		}
 		else
 		{
-			LogTrading("Client::Handle_OP_Trader: Unhandled Code [{}]", Command);
+			LogTrading("Unhandled Code [{}]", Command);
 		}
 	}
 	else
@@ -15419,7 +15419,7 @@ void Client::Handle_OP_SharedTaskRemovePlayer(const EQApplicationPacket *app)
 	auto *r = (SharedTaskRemovePlayer_Struct *) app->pBuffer;
 
 	LogTasks(
-		"[Handle_OP_SharedTaskRemovePlayer] field1 [{}] field2 [{}] player_name [{}]",
+		"field1 [{}] field2 [{}] player_name [{}]",
 		r->field1,
 		r->field2,
 		r->player_name
@@ -15441,7 +15441,7 @@ void Client::Handle_OP_SharedTaskRemovePlayer(const EQApplicationPacket *app)
 		strn0cpy(rp->player_name, r->player_name, sizeof(r->player_name));
 
 		LogTasks(
-			"[Handle_OP_SharedTaskRemovePlayer] source_character_id [{}] task_id [{}] player_name [{}]",
+			"source_character_id [{}] task_id [{}] player_name [{}]",
 			rp->source_character_id,
 			rp->task_id,
 			rp->player_name
@@ -15466,7 +15466,7 @@ void Client::Handle_OP_SharedTaskAddPlayer(const EQApplicationPacket *app)
 	auto *r = (SharedTaskAddPlayer_Struct *) app->pBuffer;
 
 	LogTasks(
-		"[SharedTaskAddPlayer_Struct] field1 [{}] field2 [{}] player_name [{}]",
+		"field1 [{}] field2 [{}] player_name [{}]",
 		r->field1,
 		r->field2,
 		r->player_name
@@ -15491,7 +15491,7 @@ void Client::Handle_OP_SharedTaskAddPlayer(const EQApplicationPacket *app)
 		strn0cpy(rp->player_name, r->player_name, sizeof(r->player_name));
 
 		LogTasks(
-			"[Handle_OP_SharedTaskRemovePlayer] source_character_id [{}] task_id [{}] player_name [{}]",
+			"source_character_id [{}] task_id [{}] player_name [{}]",
 			rp->source_character_id,
 			rp->task_id,
 			rp->player_name
@@ -15516,7 +15516,7 @@ void Client::Handle_OP_SharedTaskMakeLeader(const EQApplicationPacket *app)
 
 	auto *r = (SharedTaskMakeLeader_Struct *) app->pBuffer;
 	LogTasks(
-		"[SharedTaskMakeLeader_Struct] field1 [{}] field2 [{}] player_name [{}]",
+		"field1 [{}] field2 [{}] player_name [{}]",
 		r->field1,
 		r->field2,
 		r->player_name
@@ -15538,7 +15538,7 @@ void Client::Handle_OP_SharedTaskMakeLeader(const EQApplicationPacket *app)
 		strn0cpy(rp->player_name, r->player_name, sizeof(r->player_name));
 
 		LogTasks(
-			"[Handle_OP_SharedTaskRemovePlayer] source_character_id [{}] task_id [{}] player_name [{}]",
+			"source_character_id [{}] task_id [{}] player_name [{}]",
 			rp->source_character_id,
 			rp->task_id,
 			rp->player_name
@@ -15563,7 +15563,7 @@ void Client::Handle_OP_SharedTaskInviteResponse(const EQApplicationPacket *app)
 
 	auto *r = (SharedTaskInviteResponse_Struct *) app->pBuffer;
 	LogTasks(
-		"[SharedTaskInviteResponse] unknown00 [{}] invite_id [{}] accepted [{}]",
+		"unknown00 [{}] invite_id [{}] accepted [{}]",
 		r->unknown00,
 		r->invite_id,
 		r->accepted
@@ -15584,7 +15584,7 @@ void Client::Handle_OP_SharedTaskInviteResponse(const EQApplicationPacket *app)
 	strn0cpy(c->player_name, GetName(), sizeof(c->player_name));
 
 	LogTasks(
-		"[ServerOP_SharedTaskInviteAcceptedPlayer] source_character_id [{}] shared_task_id [{}]",
+		"source_character_id [{}] shared_task_id [{}]",
 		c->source_character_id,
 		c->shared_task_id
 	);
@@ -15599,7 +15599,7 @@ void Client::Handle_OP_SharedTaskAccept(const EQApplicationPacket* app)
 	auto buf = reinterpret_cast<SharedTaskAccept_Struct*>(app->pBuffer);
 
 	LogTasksDetail(
-		"[OP_SharedTaskAccept] unknown00 [{}] unknown04 [{}] npc_entity_id [{}] task_id [{}]",
+		"unknown00 [{}] unknown04 [{}] npc_entity_id [{}] task_id [{}]",
 		buf->unknown00,
 		buf->unknown04,
 		buf->npc_entity_id,

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -1006,7 +1006,7 @@ void Client::OPRezzAnswer(uint32 Action, uint32 SpellID, uint16 ZoneID, uint16 I
 {
 	if(PendingRezzXP < 0) {
 		// pendingrezexp is set to -1 if we are not expecting an OP_RezzAnswer
-		LogSpells("[Client::OPRezzAnswer] Unexpected OP_RezzAnswer. Ignoring it");
+		LogSpells("Unexpected OP_RezzAnswer. Ignoring it");
 		Message(Chat::Red, "You have already been resurrected.\n");
 		return;
 	}
@@ -1016,7 +1016,7 @@ void Client::OPRezzAnswer(uint32 Action, uint32 SpellID, uint16 ZoneID, uint16 I
 		// Mark the corpse as rezzed in the database, just in case the corpse has buried, or the zone the
 		// corpse is in has shutdown since the rez spell was cast.
 		database.MarkCorpseAsRezzed(PendingRezzDBID);
-		LogSpells("[Client::OPRezzAnswer] Player [{}] got a [{}] Rezz spellid [{}] in zone[{}] instance id [{}]",
+		LogSpells("Player [{}] got a [{}] Rezz spellid [{}] in zone[{}] instance id [{}]",
 				name, (uint16)spells[SpellID].base_value[0],
 				SpellID, ZoneID, InstanceID);
 
@@ -1085,7 +1085,7 @@ void Client::OPMemorizeSpell(const EQApplicationPacket* app)
 {
 	if (app->size != sizeof(MemorizeSpell_Struct)) {
 		LogError(
-			"[Client::OPMemorizeSpell] Wrong size on OP_MemorizeSpell. Got: [{}] Expected: [{}]",
+			"Wrong size on OP_MemorizeSpell. Got: [{}] Expected: [{}]",
 			app->size,
 			sizeof(MemorizeSpell_Struct)
 		);
@@ -1851,7 +1851,7 @@ void Client::DoStaminaHungerUpdate()
 	auto outapp = new EQApplicationPacket(OP_Stamina, sizeof(Stamina_Struct));
 	Stamina_Struct *sta = (Stamina_Struct *)outapp->pBuffer;
 
-	LogFood("Client::DoStaminaHungerUpdate() hunger_level: [{}] thirst_level: [{}] before loss", m_pp.hunger_level, m_pp.thirst_level);
+	LogFood("hunger_level: [{}] thirst_level: [{}] before loss", m_pp.hunger_level, m_pp.thirst_level);
 
 	if (zone->GetZoneID() != 151 && !GetGM()) {
 		int loss = RuleI(Character, FoodLossPerUpdate);
@@ -1872,7 +1872,7 @@ void Client::DoStaminaHungerUpdate()
 		sta->water = 6000;
 	}
 
-	LogFood("Client::DoStaminaHungerUpdate() Current hunger_level: [{}] = ([{}] minutes left) thirst_level: [{}] = ([{}] minutes left) - after loss",
+	LogFood("Current hunger_level: [{}] = ([{}] minutes left) thirst_level: [{}] = ([{}] minutes left) - after loss",
 	    m_pp.hunger_level, m_pp.hunger_level, m_pp.thirst_level, m_pp.thirst_level);
 
 	FastQueuePacket(&outapp);
@@ -2066,7 +2066,7 @@ void Client::HandleRespawnFromHover(uint32 Option)
 		{
 			if (PendingRezzXP < 0 || PendingRezzSpellID == 0)
 			{
-				LogSpells("[Client::HandleRespawnFromHover] Unexpected Rezz from hover request");
+				LogSpells("Unexpected Rezz from hover request");
 				safe_delete(default_to_bind);
 				return;
 			}
@@ -2101,10 +2101,10 @@ void Client::HandleRespawnFromHover(uint32 Option)
 
 			if (corpse && corpse->IsCorpse())
 			{
-				LogSpells("[Client::HandleRespawnFromHover] Hover Rez in zone [{}] for corpse [{}]",
+				LogSpells("Hover Rez in zone [{}] for corpse [{}]",
 						zone->GetShortName(), PendingRezzCorpseName.c_str());
 
-				LogSpells("[Client::HandleRespawnFromHover] Found corpse. Marking corpse as rezzed");
+				LogSpells("Found corpse. Marking corpse as rezzed");
 
 				corpse->IsRezzed(true);
 				corpse->CompleteResurrection();

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -838,7 +838,7 @@ void Client::SetEXP(uint64 set_exp, uint64 set_aaxp, bool isrezzexp) {
 void Client::SetLevel(uint8 set_level, bool command)
 {
 	if (GetEXPForLevel(set_level) == 0xFFFFFFFF) {
-		LogError("Client::SetLevel() GetEXPForLevel([{}]) = 0xFFFFFFFF", set_level);
+		LogError("GetEXPForLevel([{}]) = 0xFFFFFFFF", set_level);
 		return;
 	}
 

--- a/zone/groups.cpp
+++ b/zone/groups.cpp
@@ -825,7 +825,7 @@ void Group::CastGroupSpell(Mob* caster, uint16 spell_id) {
 					caster->SpellOnTarget(spell_id, members[z]->GetPet());
 #endif
 			} else
-				LogSpells("[Group::CastGroupSpell] Group spell: [{}] is out of range [{}] at distance [{}] from [{}]", members[z]->GetName(), range, distance, caster->GetName());
+				LogSpells("Group spell: [{}] is out of range [{}] at distance [{}] from [{}]", members[z]->GetName(), range, distance, caster->GetName());
 		}
 	}
 

--- a/zone/heal_rotation.cpp
+++ b/zone/heal_rotation.cpp
@@ -122,7 +122,7 @@ bool HealRotation::RemoveMemberFromPool(Bot* hr_member)
 {
 	if (!hr_member)
 		return true;
-	
+
 	for (auto member_iter : m_member_pool) {
 		if (member_iter != hr_member)
 			continue;
@@ -145,7 +145,7 @@ bool HealRotation::RemoveTargetFromPool(Mob* hr_target)
 	for (auto target_iter : m_target_pool) {
 		if (target_iter != hr_target)
 			continue;
-		
+
 		if (m_hot_target == hr_target) {
 			m_hot_target = nullptr;
 			m_hot_active = false;
@@ -168,9 +168,9 @@ bool HealRotation::ClearMemberPool()
 	m_cycle_pool.clear();
 	m_casting_target_poke = false;
 	m_active_heal_target = false;
-	
+
 	if (!ClearTargetPool())
-		LogError("HealRotation::ClearTargetPool() failed to clear m_target_pool (size: [{}])", m_target_pool.size());
+		LogError("failed to clear m_target_pool (size: [{}])", m_target_pool.size());
 
 	auto clear_list = const_cast<const std::list<Bot*>&>(m_member_pool);
 	for (auto member_iter : clear_list)
@@ -184,7 +184,7 @@ bool HealRotation::ClearTargetPool()
 	m_hot_target = nullptr;
 	m_hot_active = false;
 	m_is_active = false;
-	
+
 	auto clear_list = const_cast<const std::list<Mob*>&>(m_target_pool);
 	for (auto target_iter : clear_list)
 		target_iter->LeaveHealRotationTargetPool();
@@ -251,7 +251,7 @@ Bot* HealRotation::CastingMember()
 {
 	if (!m_is_active && !m_hot_active)
 		return nullptr;
-	
+
 	if (m_cycle_pool.empty()) {
 		cycle_refresh();
 
@@ -266,7 +266,7 @@ bool HealRotation::PokeCastingTarget()
 {
 	if (m_hot_target && m_hot_active)
 		return true;
-	
+
 	if (!m_is_active)
 		return false;
 
@@ -295,7 +295,7 @@ Mob* HealRotation::CastingTarget()
 {
 	if (m_hot_target && m_hot_active)
 		return m_hot_target;
-	
+
 	if (!m_is_active)
 		return nullptr;
 	if (!m_active_heal_target)
@@ -549,7 +549,7 @@ void HealRotation::ResetArmorTypeHPLimits()
 	m_safe_hp_ratio[ARMOR_TYPE_LEATHER] = SAFE_HP_RATIO_LEATHER;
 	m_safe_hp_ratio[ARMOR_TYPE_CHAIN] = SAFE_HP_RATIO_CHAIN;
 	m_safe_hp_ratio[ARMOR_TYPE_PLATE] = SAFE_HP_RATIO_PLATE;
-	
+
 	m_critical_hp_ratio[ARMOR_TYPE_UNKNOWN] = CRITICAL_HP_RATIO_BASE;
 	m_critical_hp_ratio[ARMOR_TYPE_CLOTH] = CRITICAL_HP_RATIO_CLOTH;
 	m_critical_hp_ratio[ARMOR_TYPE_LEATHER] = CRITICAL_HP_RATIO_LEATHER;
@@ -561,7 +561,7 @@ bool HealRotation::valid_state()
 {
 	m_member_pool.remove(nullptr);
 	m_member_pool.remove_if([](Mob* l) {return (!IsHealRotationMemberClass(l->GetClass())); });
-	
+
 	cycle_refresh();
 
 	if (m_member_pool.empty() && !m_consumed) { // Consumes HealRotation at this point
@@ -578,7 +578,7 @@ void HealRotation::cycle_refresh()
 	m_cycle_pool.clear();
 	if (m_member_pool.empty())
 		return;
-	
+
 	m_cycle_pool = m_member_pool;
 
 	m_is_active = true;
@@ -654,7 +654,7 @@ void HealRotation::bias_targets()
 		m_active_heal_target = false;
 		return;
 	}
-	
+
 	// attempt to clear invalid target pool entries
 	m_target_pool.remove(nullptr);
 	m_target_pool.remove_if([](Mob* l) {
@@ -798,7 +798,7 @@ void HealRotation::bias_targets()
 		});
 		if (healable_target(true, true))
 			break;
-		
+
 		sort_type = 106;
 		m_target_pool.sort([](Mob* l, Mob* r) {
 			if (GT_ALIVE(l, r))

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -3688,7 +3688,6 @@ bool Client::InterrogateInventory(Client* requester, bool log, bool silent, bool
 
 	if (log) {
 		LogError("Target interrogate inventory flag: [{}]", (GetInterrogateInvState() ? "TRUE" : "FALSE"));
-		LogDebug("[CLIENT] Client::InterrogateInventory() -- End");
 	}
 	if (!silent) {
 		requester->Message(Chat::Default, "Target interrogation flag: %s", (GetInterrogateInvState() ? "TRUE" : "FALSE"));

--- a/zone/loottables.cpp
+++ b/zone/loottables.cpp
@@ -322,7 +322,7 @@ void NPC::AddLootDrop(
 		linker.SetItemData(item2);
 
 		LogLoot(
-			"[NPC::AddLootDrop] NPC [{}] Item ({}) [{}] charges [{}] chance [{}] trivial min/max [{}/{}] npc min/max [{}/{}]",
+			"NPC [{}] Item ({}) [{}] charges [{}] chance [{}] trivial min/max [{}/{}] npc min/max [{}/{}]",
 			GetName(),
 			item2->ID,
 			linker.GenerateLink(),

--- a/zone/merc.cpp
+++ b/zone/merc.cpp
@@ -911,9 +911,6 @@ int64 Merc::CalcMaxMana()
 			current_mana = curMana_cap;
 	}
 
-#if EQDEBUG >= 11
-	LogDebug("Merc::CalcMaxMana() called for [{}] - returning [{}]", GetName(), max_mana);
-#endif
 	return max_mana;
 }
 

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1425,7 +1425,7 @@ void Mob::SendHPUpdate(bool force_update_all)
 		if (current_hp != last_hp || force_update_all) {
 
 			LogHPUpdate(
-				"[SendHPUpdate] Update HP of self [{}] current_hp [{}] max_hp [{}] last_hp [{}]",
+				"Update HP of self [{}] current_hp [{}] max_hp [{}] last_hp [{}]",
 				GetCleanName(),
 				current_hp,
 				max_hp,
@@ -1453,14 +1453,14 @@ void Mob::SendHPUpdate(bool force_update_all)
 	auto current_hp_percent = GetIntHPRatio();
 
 	LogHPUpdateDetail(
-		"[SendHPUpdate] Client [{}] HP is [{}] last [{}]",
+		"Client [{}] HP is [{}] last [{}]",
 		GetCleanName(),
 		current_hp_percent,
 		last_hp_percent
 	);
 
 	if (current_hp_percent == last_hp_percent && !force_update_all) {
-		LogHPUpdateDetail("[SendHPUpdate] Same HP for mob [{}] skipping update", GetCleanName());
+		LogHPUpdateDetail("Same HP for mob [{}] skipping update", GetCleanName());
 		ResetHPUpdateTimer();
 		return;
 	}
@@ -1470,7 +1470,7 @@ void Mob::SendHPUpdate(bool force_update_all)
 			CastToClient()->SendHPUpdateMarquee();
 		}
 
-		LogHPUpdate("[SendHPUpdate] HP Changed for mob [{}] send update", GetCleanName());
+		LogHPUpdate("HP Changed for mob [{}] send update", GetCleanName());
 
 		last_hp_percent = current_hp_percent;
 	}
@@ -2553,7 +2553,7 @@ void Mob::SendIllusionPacket(
 	}
 
 	LogSpells(
-		"[Mob::SendIllusionPacket] Illusion: Race [{}] Gender [{}] Texture [{}] HelmTexture [{}] HairColor [{}] BeardColor [{}] EyeColor1 [{}] EyeColor2 [{}] HairStyle [{}] Face [{}] DrakkinHeritage [{}] DrakkinTattoo [{}] DrakkinDetails [{}] Size [{}]",
+		"Illusion: Race [{}] Gender [{}] Texture [{}] HelmTexture [{}] HairColor [{}] BeardColor [{}] EyeColor1 [{}] EyeColor2 [{}] HairStyle [{}] Face [{}] DrakkinHeritage [{}] DrakkinTattoo [{}] DrakkinDetails [{}] Size [{}]",
 		race,
 		gender,
 		new_texture,
@@ -4134,7 +4134,7 @@ void Mob::ExecWeaponProc(const EQ::ItemInstance *inst, uint16 spell_id, Mob *on,
 	if(!IsValidSpell(spell_id)) { // Check for a valid spell otherwise it will crash through the function
 		if(IsClient()){
 			Message(0, "Invalid spell proc %u", spell_id);
-			LogSpells("[Mob::ExecWeaponProc] Player [{}] Weapon Procced invalid spell [{}]", GetName(), spell_id);
+			LogSpells("Player [{}] Weapon Procced invalid spell [{}]", GetName(), spell_id);
 		}
 		return;
 	}

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -131,7 +131,7 @@ bool NPC::AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes, bool bInnates
 				&& (AIspells[i].time_cancast + (zone->random.Int(0, 4) * 500)) <= Timer::GetCurrentTime() //break up the spelling casting over a period of time.
 				) {
 
-				LogAI("[Mob::AICastSpell] Casting: spellid [{}] tar [{}] dist2[[{}]]<=[{}] mana_cost[[{}]]<=[{}] cancast[[{}]]<=[{}] type [{}]",
+				LogAI("Casting: spellid [{}] tar [{}] dist2[[{}]]<=[{}] mana_cost[[{}]]<=[{}] cancast[[{}]]<=[{}] type [{}]",
 					AIspells[i].spellid, tar->GetName(), dist2, (spells[AIspells[i].spellid].range * spells[AIspells[i].spellid].range), mana_cost, GetMana(), AIspells[i].time_cancast, Timer::GetCurrentTime(), AIspells[i].type);
 
 				switch (AIspells[i].type) {
@@ -363,7 +363,7 @@ bool NPC::AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes, bool bInnates
 				}
 			}
 			else {
-				LogAI("[Mob::AICastSpell] NotCasting: spellid [{}] tar [{}] dist2[[{}]]<=[{}] mana_cost[[{}]]<=[{}] cancast[[{}]]<=[{}] type [{}]",
+				LogAI("NotCasting: spellid [{}] tar [{}] dist2[[{}]]<=[{}] mana_cost[[{}]]<=[{}] cancast[[{}]]<=[{}] type [{}]",
 					AIspells[i].spellid, tar->GetName(), dist2, (spells[AIspells[i].spellid].range * spells[AIspells[i].spellid].range), mana_cost, GetMana(), AIspells[i].time_cancast, Timer::GetCurrentTime(), AIspells[i].type);
 			}
 		}
@@ -372,7 +372,7 @@ bool NPC::AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes, bool bInnates
 }
 
 bool NPC::AIDoSpellCast(uint8 i, Mob* tar, int32 mana_cost, uint32* oDontDoAgainBefore) {
-	LogAI("[Mob::AIDoSpellCast] spellid [{}] tar [{}] mana [{}] Name [{}]", AIspells[i].spellid, tar->GetName(), mana_cost, spells[AIspells[i].spellid].name);
+	LogAI("spellid [{}] tar [{}] mana [{}] Name [{}]", AIspells[i].spellid, tar->GetName(), mana_cost, spells[AIspells[i].spellid].name);
 	casting_spell_AIindex = i;
 
 	return CastSpell(AIspells[i].spellid, tar->GetID(), EQ::spells::CastingSlot::Gem2, AIspells[i].manacost == -2 ? 0 : -1, mana_cost, oDontDoAgainBefore, -1, -1, 0, &(AIspells[i].resist_adjust));
@@ -2062,7 +2062,7 @@ bool NPC::AI_IdleCastCheck() {
 				//last duration it was set to... try to put up a more reasonable timer...
 				AIautocastspell_timer->Start(RandomTimer(AISpellVar.idle_no_sp_recast_min, AISpellVar.idle_no_sp_recast_max), false);
 
-				LogSpells("[NPC::AI_IdleCastCheck] Mob [{}] Min [{}] Max [{}]", GetCleanName(), AISpellVar.idle_no_sp_recast_min, AISpellVar.idle_no_sp_recast_max);
+				LogSpells("Mob [{}] Min [{}] Max [{}]", GetCleanName(), AISpellVar.idle_no_sp_recast_min, AISpellVar.idle_no_sp_recast_max);
 
 			}	//else, spell casting finishing will reset the timer.
 		}	//else, spell casting finishing will reset the timer.

--- a/zone/mob_appearance.cpp
+++ b/zone/mob_appearance.cpp
@@ -45,7 +45,7 @@
 void Mob::SetMobTextureProfile(uint8 material_slot, uint16 texture, uint32 color, uint32 hero_forge_model)
 {
 	Log(Logs::Detail, Logs::MobAppearance,
-		"Mob::SetMobTextureProfile [%s] material_slot: %u texture: %u color: %u hero_forge_model: %u",
+		"[%s] material_slot: %u texture: %u color: %u hero_forge_model: %u",
 		GetCleanName(),
 		material_slot,
 		texture,
@@ -214,7 +214,7 @@ int32 Mob::GetEquipmentMaterial(uint8 material_slot) const
 	int32 texture_profile_material = GetTextureProfileMaterial(material_slot);
 
 	Log(Logs::Detail, Logs::MobAppearance,
-		"Mob::GetEquipmentMaterial [%s] material_slot: %u texture_profile_material: %i",
+		"[%s] material_slot: %u texture_profile_material: %i",
 		clean_name,
 		material_slot,
 		texture_profile_material
@@ -397,7 +397,7 @@ void Mob::SendArmorAppearance(Client *one_client)
 	 * The other packets work for primary/secondary.
 	 */
 
-	LogMobAppearance("[SendArmorAppearance] [{}]", GetCleanName());
+	LogMobAppearance("[{}]", GetCleanName());
 
 	if (IsPlayerRace(race)) {
 		if (!IsClient()) {
@@ -426,7 +426,7 @@ void Mob::SendWearChange(uint8 material_slot, Client *one_client)
 	auto packet       = new EQApplicationPacket(OP_WearChange, sizeof(WearChange_Struct));
 	auto *wear_change = (WearChange_Struct *) packet->pBuffer;
 
-	Log(Logs::Detail, Logs::MobAppearance, "Mob::SendWearChange [%s]",
+	Log(Logs::Detail, Logs::MobAppearance, "[%s]",
 		GetCleanName()
 	);
 

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -1803,7 +1803,7 @@ int32 NPC::GetEquipmentMaterial(uint8 material_slot) const
 {
 	int32 texture_profile_material = GetTextureProfileMaterial(material_slot);
 
-	Log(Logs::Detail, Logs::MobAppearance, "NPC::GetEquipmentMaterial [%s] material_slot: %u",
+	Log(Logs::Detail, Logs::MobAppearance, "[%s] material_slot: %u",
 		clean_name,
 		material_slot
 	);

--- a/zone/npc_scale_manager.cpp
+++ b/zone/npc_scale_manager.cpp
@@ -464,7 +464,7 @@ bool NpcScaleManager::ApplyGlobalBaseScalingToNPCStatically(NPC *&npc)
 
 	if (!g.level) {
 		LogNPCScaling(
-			"NpcScaleManager::ApplyGlobalBaseScalingToNPCStatically NPC: [{}] - scaling data not found for type: [{}] level: [{}]",
+			"NPC: [{}] - scaling data not found for type: [{}] level: [{}]",
 			npc->GetCleanName(),
 			npc_type,
 			npc_level
@@ -522,7 +522,7 @@ bool NpcScaleManager::ApplyGlobalBaseScalingToNPCDynamically(NPC *&npc)
 
 	if (!d.level) {
 		LogNPCScaling(
-			"NpcScaleManager::ApplyGlobalBaseScalingToNPCDynamically NPC: [{}] - scaling data not found for type: [{}] level: [{}]",
+			"NPC: [{}] - scaling data not found for type: [{}] level: [{}]",
 			npc->GetCleanName(),
 			npc_type,
 			npc_level

--- a/zone/object.cpp
+++ b/zone/object.cpp
@@ -341,7 +341,7 @@ const EQ::ItemInstance* Object::GetItem(uint8 index) {
 void Object::PutItem(uint8 index, const EQ::ItemInstance* inst)
 {
 	if (index > 9) {
-		LogError("Object::PutItem: Invalid index specified ([{}])", index);
+		LogError("Invalid index specified ([{}])", index);
 		return;
 	}
 
@@ -477,7 +477,7 @@ void Object::RandomSpawn(bool send_packet) {
 		}
 	}
 
-	LogInfo("Object::RandomSpawn([{}]): [{}] ([{}], [{}], [{}])", m_data.object_name, m_inst->GetID(), m_data.x, m_data.y, m_data.z);
+	LogInfo("[{}] [{}] ([{}] [{}] [{}])", m_data.object_name, m_inst->GetID(), m_data.x, m_data.y, m_data.z);
 
 	respawn_timer.Disable();
 

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -3373,7 +3373,7 @@ void QuestManager::voicetell(const char *str, int macronum, int racenum, int gen
 			safe_delete(outapp);
 		}
 		else
-			LogQuests("QuestManager::voicetell from [{}]. Client [{}] not found", owner->GetName(), str);
+			LogQuests("from [{}]. Client [{}] not found", owner->GetName(), str);
 	}
 }
 

--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -566,7 +566,7 @@ void Raid::CastGroupSpell(Mob* caster, uint16 spellid, uint32 gid)
 #endif
 				}
 				else{
-					LogSpells("[Raid::CastGroupSpell] Raid spell: [{}] is out of range [{}] at distance [{}] from [{}]", members[x].member->GetName(), range, distance, caster->GetName());
+					LogSpells("Raid spell: [{}] is out of range [{}] at distance [{}] from [{}]", members[x].member->GetName(), range, distance, caster->GetName());
 				}
 			}
 		}

--- a/zone/spawn2.cpp
+++ b/zone/spawn2.cpp
@@ -157,13 +157,13 @@ bool Spawn2::Process() {
 	if (timer.Check()) {
 		timer.Disable();
 
-		LogSpawns("Spawn2 [{}]: Timer has triggered", spawn2_id);
+		LogSpawns("[{}]: Timer has triggered", spawn2_id);
 
 		//first check our spawn condition, if this isnt active
 		//then we reset the timer and try again next time.
 		if (condition_id != SC_AlwaysEnabled
 			&& !zone->spawn_conditions.Check(condition_id, condition_min_value)) {
-			LogSpawns("Spawn2 [{}]: spawning prevented by spawn condition [{}]", spawn2_id, condition_id);
+			LogSpawns("[{}]: spawning prevented by spawn condition [{}]", spawn2_id, condition_id);
 			Reset();
 			return (true);
 		}

--- a/zone/spawngroup.cpp
+++ b/zone/spawngroup.cpp
@@ -319,7 +319,7 @@ bool ZoneDatabase::LoadSpawnGroupsByID(int spawn_group_id, SpawnGroupList *spawn
 
 	for (auto row = results.begin(); row != results.end(); ++row) {
 		LogSpawnsDetail(
-			"[LoadSpawnGroupsByID] Loading spawn_group spawn_group_id [{}] name [{}] spawn_limit [{}] dist [{}]",
+			"Loading spawn_group spawn_group_id [{}] name [{}] spawn_limit [{}] dist [{}]",
 			row[0],
 			row[1],
 			row[2],
@@ -377,7 +377,7 @@ bool ZoneDatabase::LoadSpawnGroupsByID(int spawn_group_id, SpawnGroupList *spawn
 		);
 
 		LogSpawnsDetail(
-			"[LoadSpawnGroupsByID] Loading spawn_entry spawn_group_id [{}] npc_id [{}] chance [{}] condition_value_filter [{}] spawn_limit [{}]",
+			"Loading spawn_entry spawn_group_id [{}] npc_id [{}] chance [{}] condition_value_filter [{}] spawn_limit [{}]",
 			row[0],
 			row[1],
 			row[2],

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -1630,7 +1630,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				if (IsCorpse() && CastToCorpse()->IsPlayerCorpse()) {
 
 					if(caster)
-						LogSpells("[Mob::SpellEffect] corpse being rezzed using spell [{}] by [{}]",
+						LogSpells("corpse being rezzed using spell [{}] by [{}]",
 							spell_id, caster->GetName());
 
 					CastToCorpse()->CastRezz(spell_id, caster);
@@ -3360,7 +3360,7 @@ int64 Mob::CalcSpellEffectValue(uint16 spell_id, int effect_id, int caster_level
 		&& IsInstrumentModAppliedToSpellEffect(spell_id, spells[spell_id].effect_id[effect_id])) {
 			oval = effect_value;
 			effect_value = effect_value * static_cast<int>(instrument_mod) / 10;
-			LogSpells("[Mob::CalcSpellEffectValue] Effect value [{}] altered with bard modifier of [{}] to yeild [{}]",
+			LogSpells("Effect value [{}] altered with bard modifier of [{}] to yeild [{}]",
 				oval, instrument_mod, effect_value);
 	}
 	/*
@@ -3387,7 +3387,7 @@ int64 Mob::CalcSpellEffectValue(uint16 spell_id, int effect_id, int caster_level
 		int mod = caster->GetFocusEffect(focusFcBaseEffects, spell_id);
 		effect_value += effect_value * mod / 100;
 
-		LogSpells("[Mob::CalcSpellEffectValue] Instant Effect value [{}] altered with base effects modifier of [{}] to yeild [{}]",
+		LogSpells("Instant Effect value [{}] altered with base effects modifier of [{}] to yeild [{}]",
 			oval, mod, effect_value);
 	}
 	//This is checked from Mob::ApplySpellBonuses, applied to buffs that receive bonuses. See above, must be in 10% intervals to work.
@@ -3398,7 +3398,7 @@ int64 Mob::CalcSpellEffectValue(uint16 spell_id, int effect_id, int caster_level
 			oval = effect_value;
 			effect_value = effect_value * static_cast<int>(instrument_mod) / 10;
 
-			LogSpells("[Mob::CalcSpellEffectValue] Bonus Effect value [{}] altered with base effects modifier of [{}] to yeild [{}]",
+			LogSpells("Bonus Effect value [{}] altered with base effects modifier of [{}] to yeild [{}]",
 				oval, instrument_mod, effect_value);
 		}
 	}
@@ -3472,7 +3472,7 @@ snare has both of them negative, yet their range should work the same:
 		updownsign = 1;
 	}
 
-	LogSpells("[Mob::CalcSpellEffectValue_formula] spell [{}] formula [{}] base [{}] max [{}] lvl [{}] Up/Down [{}]",
+	LogSpells("spell [{}] formula [{}] base [{}] max [{}] lvl [{}] Up/Down [{}]",
 		spell_id, formula, base_value, max_value, caster_level, updownsign);
 
 	switch(formula)
@@ -3695,7 +3695,7 @@ snare has both of them negative, yet their range should work the same:
 				result = ubase * (caster_level * (formula - 2000) + 1);
 			}
 			else
-				LogDebug("[Mob::CalcSpellEffectValue_formula] Unknown spell effect value forumula [{}]", formula);
+				LogDebug("Unknown spell effect value forumula [{}]", formula);
 		}
 	}
 
@@ -3720,7 +3720,7 @@ snare has both of them negative, yet their range should work the same:
 	if (base_value < 0 && result > 0)
 		result *= -1;
 
-	LogSpells("[Mob::CalcSpellEffectValue_formula] Result: [{}] (orig [{}]) cap [{}] [{}]", result, oresult, max_value, (base_value < 0 && result > 0)?"Inverted due to negative base":"");
+	LogSpells("Result: [{}] (orig [{}]) cap [{}] [{}]", result, oresult, max_value, (base_value < 0 && result > 0)?"Inverted due to negative base":"");
 
 	return result;
 }
@@ -3748,12 +3748,12 @@ void Mob::BuffProcess()
 					--buffs[buffs_i].ticsremaining;
 
 					if (buffs[buffs_i].ticsremaining < 0) {
-						LogSpells("[Mob::BuffProcess] Buff [{}] in slot [{}] has expired. Fading", buffs[buffs_i].spellid, buffs_i);
+						LogSpells("Buff [{}] in slot [{}] has expired. Fading", buffs[buffs_i].spellid, buffs_i);
 						BuffFadeBySlot(buffs_i);
 					}
 					else
 					{
-						LogSpells("[Mob::BuffProcess] Buff [{}] in slot [{}] has [{}] tics remaining", buffs[buffs_i].spellid, buffs_i, buffs[buffs_i].ticsremaining);
+						LogSpells("Buff [{}] in slot [{}] has [{}] tics remaining", buffs[buffs_i].spellid, buffs_i, buffs[buffs_i].ticsremaining);
 					}
 				}
 				else if (IsClient() && !(CastToClient()->ClientVersionBit() & EQ::versions::maskSoFAndLater))
@@ -4135,7 +4135,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 	if (IsClient() && !CastToClient()->IsDead())
 		CastToClient()->MakeBuffFadePacket(buffs[slot].spellid, slot);
 
-	LogSpells("[Mob::BuffFadeBySlot] Fading buff [{}] from slot [{}]", buffs[slot].spellid, slot);
+	LogSpells("Fading buff [{}] from slot [{}]", buffs[slot].spellid, slot);
 
 	std::string export_string = fmt::format(
 		"{} {} {} {}",
@@ -5497,7 +5497,7 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 						}
 						break;
 					default:
-						LogInfo("CalcFocusEffect: unknown limit spelltype [{}]", focus_spell.base_value[i]);
+						LogInfo("unknown limit spelltype [{}]", focus_spell.base_value[i]);
 						break;
 				}
 				break;
@@ -6074,7 +6074,7 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				// this spits up a lot of garbage when calculating spell focuses
 				// since they have all kinds of extra effects on them.
 				default:
-					LogInfo("CalcFocusEffect: unknown effectid [{}]",
+					LogInfo("unknown effectid [{}]",
 						focus_spell.effect_id[i]);
 #endif
 		}
@@ -9690,21 +9690,21 @@ bool Mob::PassCharmTargetRestriction(Mob *target) {
 
 	if (target->IsClient() && IsClient()) {
 		MessageString(Chat::Red, CANNOT_AFFECT_PC);
-		LogSpells("[Mob::PassCharmTargetRestriction] Spell casting canceled: Can not cast charm on a client.");
+		LogSpells("Spell casting canceled: Can not cast charm on a client.");
 		return false;
 	}
 	else if (target->IsCorpse()) {
-		LogSpells("[Mob::PassCharmTargetRestriction] Spell casting canceled: Can not cast charm on a corpse.");
+		LogSpells("Spell casting canceled: Can not cast charm on a corpse.");
 		return false;
 	}
 	else if (GetPet() && IsClient()) {
 		MessageString(Chat::Red, ONLY_ONE_PET);
-		LogSpells("[Mob::PassCharmTargetRestriction] Spell casting canceled: Can not cast charm if you have a pet.");
+		LogSpells("Spell casting canceled: Can not cast charm if you have a pet.");
 		return false;
 	}
 	else if (target->GetOwner()) {
 		MessageString(Chat::Red, CANNOT_CHARM);
-		LogSpells("[Mob::PassCharmTargetRestriction] Spell casting canceled: Can not cast charm on a pet.");
+		LogSpells("Spell casting canceled: Can not cast charm on a pet.");
 		return false;
 	}
 	return true;

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -47,7 +47,7 @@ ClientTaskState::~ClientTaskState()
 void ClientTaskState::SendTaskHistory(Client *client, int task_index)
 {
 
-	LogTasks("[SendTaskHistory] Task history requested for completed task index [{}]", task_index);
+	LogTasks("Task history requested for completed task index [{}]", task_index);
 
 	// We only sent the most recent 50 completed tasks, so we need to offset the Index the client sent to us.
 
@@ -153,9 +153,9 @@ void ClientTaskState::EnableTask(int character_id, int task_count, int *task_lis
 		}
 	}
 
-	LogTasksDetail("[EnableTask] New enabled task list");
+	LogTasksDetail("New enabled task list");
 	for (int enabled_task : m_enabled_tasks) {
-		LogTasksDetail("[EnableTask] enabled [{}] character_id [{}]", enabled_task, character_id);
+		LogTasksDetail("enabled [{}] character_id [{}]", enabled_task, character_id);
 	}
 
 	if (tasks_enabled.empty()) {
@@ -173,7 +173,7 @@ void ClientTaskState::EnableTask(int character_id, int task_count, int *task_lis
 		database.QueryDatabase(query);
 	}
 	else {
-		LogTasks("[EnableTask] Called for character_id [{}] but, no tasks exist", character_id);
+		LogTasks("Called for character_id [{}] but, no tasks exist", character_id);
 	}
 }
 
@@ -206,9 +206,9 @@ void ClientTaskState::DisableTask(int character_id, int task_count, int *task_li
 		}
 	}
 
-	LogTasks("[DisableTask] New enabled task list ");
+	LogTasks("New enabled task list ");
 	for (int enabled_task : m_enabled_tasks) {
-		LogTasks("[DisableTask] enabled_tasks [{}]", enabled_task);
+		LogTasks("enabled_tasks [{}]", enabled_task);
 	}
 
 	if (tasks_disabled.empty()) {
@@ -234,7 +234,7 @@ void ClientTaskState::DisableTask(int character_id, int task_count, int *task_li
 	}
 	else {
 		LogTasks(
-			"[DisableTask] DisableTask called for character_id [{}] ... but, no tasks exist",
+			"DisableTask called for character_id [{}] ... but, no tasks exist",
 			character_id
 		);
 	}
@@ -358,7 +358,7 @@ int ClientTaskState::GetActiveTaskID(int index)
 
 static void DeleteCompletedTaskFromDatabase(int character_id, int task_id)
 {
-	LogTasks("[DeleteCompletedTasksFromDatabase] character_id [{}], task_id [{}]", character_id, task_id);
+	LogTasks("character_id [{}], task_id [{}]", character_id, task_id);
 
 	CompletedTasksRepository::DeleteWhere(
 		database,
@@ -369,7 +369,7 @@ static void DeleteCompletedTaskFromDatabase(int character_id, int task_id)
 bool ClientTaskState::UnlockActivities(Client* client, ClientTaskInformation& task_info)
 {
 	LogTasksDetail(
-		"[UnlockActivities] Fetching task info for character_id [{}] task [{}] slot [{}] accepted_time [{}] updated [{}]",
+		"Fetching task info for character_id [{}] task [{}] slot [{}] accepted_time [{}] updated [{}]",
 		client->CharacterID(),
 		task_info.task_id,
 		task_info.slot,
@@ -387,7 +387,7 @@ bool ClientTaskState::UnlockActivities(Client* client, ClientTaskInformation& ta
 	{
 		if (task_info.activity[i].activity_id >= 0) {
 			LogTasksDetail(
-				"[UnlockActivities] character_id [{}] task [{}] activity_id [{}] done_count [{}] activity_state [{}] updated [{}]",
+				"character_id [{}] task [{}] activity_id [{}] done_count [{}] activity_state [{}] updated [{}]",
 				client->CharacterID(),
 				task_info.task_id,
 				task_info.activity[i].activity_id,
@@ -405,7 +405,7 @@ bool ClientTaskState::UnlockActivities(Client* client, ClientTaskInformation& ta
 		ClientActivityInformation& client_activity = task_info.activity[activity_id];
 		if (client_activity.activity_state == ActivityHidden)
 		{
-			LogTasksDetail("[UnlockActivities] task [{}] activity [{}] (ActivityActive)", task_info.task_id, activity_id);
+			LogTasksDetail("task [{}] activity [{}] (ActivityActive)", task_info.task_id, activity_id);
 			client_activity.activity_state = ActivityActive;
 			client_activity.updated = true;
 		}
@@ -436,7 +436,7 @@ void ClientTaskState::RecordCompletedTask(uint32_t character_id, const TaskInfor
 
 		size_t erased = m_completed_tasks.size() - before;
 
-		LogTasksDetail("[RecordCompletedTask] KeepOneRecord erased [{}] elements", erased);
+		LogTasksDetail("KeepOneRecord erased [{}] elements", erased);
 
 		if (erased > 0)
 		{
@@ -456,7 +456,7 @@ void ClientTaskState::RecordCompletedTask(uint32_t character_id, const TaskInfor
 			completed.activity_done[i] = (client_task.activity[i].activity_state == ActivityCompleted);
 		}
 
-		LogTasksDetail("[RecordCompletedTask] [{}] for character [{}]", client_task.task_id, character_id);
+		LogTasksDetail("[{}] for character [{}]", client_task.task_id, character_id);
 		m_completed_tasks.push_back(completed);
 	}
 }
@@ -497,7 +497,7 @@ bool ClientTaskState::CanUpdate(Client* client, const TaskUpdateFilter& filter, 
 
 	if (!activity.CheckZone(zone->GetZoneID(), zone->GetInstanceVersion()))
 	{
-		LogTasks("[CanUpdate] client [{}] task [{}]-[{}] failed zone filter", client->GetName(), task_id, client_activity.activity_id);
+		LogTasks("client [{}] task [{}]-[{}] failed zone filter", client->GetName(), task_id, client_activity.activity_id);
 		return false;
 	}
 
@@ -508,7 +508,7 @@ bool ClientTaskState::CanUpdate(Client* client, const TaskUpdateFilter& filter, 
 		    pos.y < activity.min_y || pos.y > activity.max_y ||
 		    pos.z < activity.min_z || pos.z > activity.max_z)
 		{
-			LogTasksDetail("[CanUpdate] client [{}] task [{}]-[{}] failed area filter", client->GetName(), task_id, client_activity.activity_id);
+			LogTasksDetail("client [{}] task [{}]-[{}] failed area filter", client->GetName(), task_id, client_activity.activity_id);
 			return false;
 		}
 	}
@@ -517,7 +517,7 @@ bool ClientTaskState::CanUpdate(Client* client, const TaskUpdateFilter& filter, 
 	if (!activity.item_id_list.empty() && filter.item_id != 0 &&
 	    !Tasks::IsInMatchList(activity.item_id_list, std::to_string(filter.item_id)))
 	{
-		LogTasks("[CanUpdate] client [{}] task [{}]-[{}] failed item match filter", client->GetName(), task_id, client_activity.activity_id);
+		LogTasks("client [{}] task [{}]-[{}] failed item match filter", client->GetName(), task_id, client_activity.activity_id);
 		return false;
 	}
 
@@ -527,7 +527,7 @@ bool ClientTaskState::CanUpdate(Client* client, const TaskUpdateFilter& filter, 
 	     !Tasks::IsInMatchListPartial(activity.npc_match_list, filter.mob->GetCleanName()) &&
 	     !Tasks::IsInMatchList(activity.npc_match_list, std::to_string(filter.mob->GetNPCTypeID())))))
 	{
-		LogTasks("[CanUpdate] client [{}] task [{}]-[{}] failed npc match filter", client->GetName(), task_id, client_activity.activity_id);
+		LogTasks("client [{}] task [{}]-[{}] failed npc match filter", client->GetName(), task_id, client_activity.activity_id);
 		return false;
 	}
 
@@ -567,13 +567,13 @@ int ClientTaskState::UpdateTasks(Client* client, const TaskUpdateFilter& filter,
 				auto args = fmt::format("{} {} {}", count, client_activity.activity_id, client_task.task_id);
 				if (parse->EventPlayer(EVENT_TASK_BEFORE_UPDATE, client, args, 0) != 0)
 				{
-					LogTasks("[UpdateTasks] client [{}] task [{}]-[{}] update prevented by quest",
+					LogTasks("client [{}] task [{}]-[{}] update prevented by quest",
 						client->GetName(), client_task.task_id, client_activity.activity_id);
 
 					continue;
 				}
 
-				LogTasks("[UpdateTasks] client [{}] task [{}] activity [{}] increment [{}]",
+				LogTasks("client [{}] task [{}] activity [{}] increment [{}]",
 					client->GetName(), client_task.task_id, client_activity.activity_id, count);
 
 				int updated = IncrementDoneCount(client, task, client_task.slot, client_activity.activity_id, count);
@@ -627,7 +627,7 @@ bool ClientTaskState::HasExploreTask(Client* client) const
 	auto result = FindTask(client, filter);
 	bool has_explore = result.first != 0;
 
-	LogTasksDetail("[HasExploreTask] client [{}] has explore task in current zone [{}]", client->GetName(), has_explore);
+	LogTasksDetail("client [{}] has explore task in current zone [{}]", client->GetName(), has_explore);
 	return has_explore;
 }
 
@@ -686,7 +686,7 @@ void ClientTaskState::UpdateTasksForItem(Client* client, TaskActivityType type, 
 	//
 	// Type should be one of ActivityTradeSkill, ActivityFish or ActivityForage
 
-	LogTasks("[UpdateTasksForItem] activity_type [{}] item_id [{}] count [{}]", static_cast<int>(type), item_id, count);
+	LogTasks("activity_type [{}] item_id [{}] count [{}]", static_cast<int>(type), item_id, count);
 
 	TaskUpdateFilter filter{};
 	filter.type = type;
@@ -697,7 +697,7 @@ void ClientTaskState::UpdateTasksForItem(Client* client, TaskActivityType type, 
 
 void ClientTaskState::UpdateTasksOnLoot(Client* client, Corpse* corpse, int item_id, int count)
 {
-	LogTasks("[UpdateTasksOnLoot] corpse [{}] item_id [{}] count [{}]", corpse->GetName(), item_id, count);
+	LogTasks("corpse [{}] item_id [{}] count [{}]", corpse->GetName(), item_id, count);
 
 	TaskUpdateFilter filter{};
 	filter.type = TaskActivityType::Loot;
@@ -709,7 +709,7 @@ void ClientTaskState::UpdateTasksOnLoot(Client* client, Corpse* corpse, int item
 
 void ClientTaskState::UpdateTasksOnExplore(Client* client, const glm::vec4& pos)
 {
-	LogTasksDetail("[UpdateTasksOnExplore] client [{}]", client->GetName());
+	LogTasksDetail("client [{}]", client->GetName());
 
 	TaskUpdateFilter filter{};
 	filter.type = TaskActivityType::Explore;
@@ -721,7 +721,7 @@ void ClientTaskState::UpdateTasksOnExplore(Client* client, const glm::vec4& pos)
 
 bool ClientTaskState::UpdateTasksOnDeliver(Client* client, std::vector<EQ::ItemInstance*>& items, Trade& trade, NPC* npc)
 {
-	LogTasks("[UpdateTasksOnDeliver] npc [{}]", npc->GetName());
+	LogTasks("npc [{}]", npc->GetName());
 
 	bool is_updated = false;
 
@@ -765,7 +765,7 @@ bool ClientTaskState::UpdateTasksOnDeliver(Client* client, std::vector<EQ::ItemI
 
 void ClientTaskState::UpdateTasksOnTouch(Client *client, int dz_switch_id)
 {
-	LogTasks("[UpdateTasksOnTouch] dz switch [{}] ", dz_switch_id);
+	LogTasks("dz switch [{}] ", dz_switch_id);
 
 	TaskUpdateFilter filter{};
 	filter.type = TaskActivityType::Touch;
@@ -801,7 +801,7 @@ int ClientTaskState::IncrementDoneCount(
 	}
 
 	LogTasks(
-		"[IncrementDoneCount] client [{}] task_id [{}] activity_id [{}] count [{}]",
+		"client [{}] task_id [{}] activity_id [{}] count [{}]",
 		client->GetCleanName(),
 		info->task_id,
 		activity_id,
@@ -827,7 +827,7 @@ int ClientTaskState::IncrementDoneCount(
 		r->ignore_quest_update = ignore_quest_update;
 
 		LogTasksDetail(
-			"[IncrementDoneCount] shared_task sending client [{}] task_id [{}] activity_id [{}] count [{}] ignore_quest_update [{}]",
+			"shared_task sending client [{}] task_id [{}] activity_id [{}] count [{}] ignore_quest_update [{}]",
 			r->source_character_id,
 			r->task_id,
 			r->activity_id,
@@ -874,7 +874,7 @@ int ClientTaskState::IncrementDoneCount(
 	info->activity[activity_id].updated = true;
 	// Have we reached the goal count for this activity_information ?
 	if (info->activity[activity_id].done_count >= task_data->activity_information[activity_id].goal_count) {
-		LogTasks("[IncrementDoneCount] done_count [{}] goal_count [{}] activity_id [{}]",
+		LogTasks("done_count [{}] goal_count [{}] activity_id [{}]",
 			info->activity[activity_id].done_count,
 			task_data->activity_information[activity_id].goal_count,
 			activity_id
@@ -884,7 +884,7 @@ int ClientTaskState::IncrementDoneCount(
 		info->activity[activity_id].activity_state = ActivityCompleted;
 		// Unlock subsequent activities for this task
 		bool task_complete = UnlockActivities(client, *info);
-		LogTasks("[IncrementDoneCount] task_complete is [{}]", task_complete);
+		LogTasks("task_complete is [{}]", task_complete);
 		// shared tasks only send update messages on activity completion
 		if (task_data->type == TaskType::Shared) {
 			client->MessageString(Chat::DefaultText, TASK_UPDATED, task_data->title.c_str());
@@ -1053,7 +1053,7 @@ void ClientTaskState::RewardTask(Client *c, const TaskInformation *ti, ClientTas
 
 		c->CashReward(copper, silver, gold, platinum);
 	}
-	
+
 	auto experience_reward = ti->experience_reward;
 	if (experience_reward > 0) {
 		c->AddEXP(experience_reward);
@@ -1102,7 +1102,7 @@ bool ClientTaskState::IsTaskActive(int task_id)
 void ClientTaskState::FailTask(Client *client, int task_id)
 {
 	LogTasks(
-		"[FailTask] Failing task for character [{}] task_id [{}] task_count [{}]",
+		"Failing task for character [{}] task_id [{}] task_count [{}]",
 		client->GetCleanName(),
 		task_id,
 		m_active_task_count
@@ -1139,7 +1139,7 @@ void ClientTaskState::FailTask(Client *client, int task_id)
 
 bool ClientTaskState::IsTaskActivityActive(int task_id, int activity_id)
 {
-	LogTasks("[IsTaskActivityActive] task_id [{}] activity_id [{}]", task_id, activity_id);
+	LogTasks("task_id [{}] activity_id [{}]", task_id, activity_id);
 
 	// Quick sanity check
 	if (activity_id < 0) {
@@ -1192,7 +1192,7 @@ bool ClientTaskState::IsTaskActivityActive(int task_id, int activity_id)
 	}
 
 	LogTasks(
-		"[IsTaskActivityActive] (Update) task_id [{}] activity_id [{}] activity_state [{}]",
+		"(Update) task_id [{}] activity_id [{}] activity_state [{}]",
 		task_id,
 		activity_id,
 		info->activity[activity_id].activity_state
@@ -1523,7 +1523,7 @@ int ClientTaskState::IsTaskCompleted(int task_id)
 	}
 
 	for (auto &completed_task : m_completed_tasks) {
-		LogTasks("[IsTaskCompleted] Comparing compelted task [{}] with [{}]", completed_task.task_id, task_id);
+		LogTasks("Comparing compelted task [{}] with [{}]", completed_task.task_id, task_id);
 		if (completed_task.task_id == task_id) {
 			return 1;
 		}
@@ -1649,7 +1649,7 @@ ActivityState ClientTaskState::GetTaskActivityState(TaskType task_type, int inde
 	}
 
 	LogTasksDetail(
-		"-- [GetTaskActivityState] task_type [{}] ({}) index [{}] activity_id [{}] activity_state [{}] ({})",
+		"-- task_type [{}] ({}) index [{}] activity_id [{}] activity_state [{}] ({})",
 		Tasks::GetTaskTypeIdentifier(task_type),
 		Tasks::GetTaskTypeDescription(task_type),
 		index,
@@ -1815,7 +1815,7 @@ void ClientTaskState::KickPlayersSharedTask(Client* client)
 void ClientTaskState::RemoveTask(Client *client, int sequence_number, TaskType task_type)
 {
 	int character_id = client->CharacterID();
-	Log(Logs::General, Logs::Tasks, "[UPDATE] ClientTaskState Cancel Task %i ", sequence_number);
+	Log(Logs::General, Logs::Tasks, "ClientTaskState Cancel Task %i ", sequence_number);
 
 	int task_id = -1;
 	switch (task_type) {
@@ -1869,14 +1869,14 @@ void ClientTaskState::RemoveTaskByTaskID(Client *client, uint32 task_id)
 	switch (task_manager->GetTaskType(task_id)) {
 		case TaskType::Task: {
 			if (m_active_task.task_id == task_id) {
-				LogTasks("[UPDATE] RemoveTaskByTaskID found Task [{}]", task_id);
+				LogTasks("RemoveTaskByTaskID found Task [{}]", task_id);
 				CancelTask(client, TASKSLOTTASK, TaskType::Task, true);
 			}
 			break;
 		}
 		case TaskType::Shared: {
 			if (m_active_shared_task.task_id == task_id) {
-				LogTasks("[UPDATE] RemoveTaskByTaskID found Shared Task [{}]", task_id);
+				LogTasks("RemoveTaskByTaskID found Shared Task [{}]", task_id);
 				CancelTask(client, TASKSLOTSHAREDTASK, TaskType::Shared, true);
 			}
 			break;
@@ -1884,7 +1884,7 @@ void ClientTaskState::RemoveTaskByTaskID(Client *client, uint32 task_id)
 		case TaskType::Quest: {
 			for (int active_quest = 0; active_quest < MAXACTIVEQUESTS; active_quest++) {
 				if (m_active_quests[active_quest].task_id == task_id) {
-					LogTasks("[UPDATE] RemoveTaskByTaskID found Quest [{}] at index [{}]", task_id, active_quest);
+					LogTasks("RemoveTaskByTaskID found Quest [{}] at index [{}]", task_id, active_quest);
 					CancelTask(client, active_quest, TaskType::Quest, true);
 				}
 			}
@@ -1918,7 +1918,7 @@ void ClientTaskState::AcceptNewTask(
 	// intercept and pass to world first before processing normally
 	if (!client->m_requesting_shared_task && task->type == TaskType::Shared) {
 		LogTasksDetail(
-			"[AcceptNewTask] Initiating shared_task request | task_id [{}] character_id [{}] name [{}]",
+			"Initiating shared_task request | task_id [{}] character_id [{}] name [{}]",
 			task_id,
 			client->CharacterID(),
 			client->GetCleanName()
@@ -2047,7 +2047,7 @@ void ClientTaskState::AcceptNewTask(
 		case TaskType::Quest:
 			for (int task_index = 0; task_index < MAXACTIVEQUESTS; task_index++) {
 				Log(Logs::General, Logs::Tasks,
-					"[UPDATE] ClientTaskState Looking for free slot in slot %i, found task_id of %i", task_index,
+					"ClientTaskState Looking for free slot in slot %i, found task_id of %i", task_index,
 					m_active_quests[task_index].task_id);
 				if (m_active_quests[task_index].task_id == 0) {
 					active_slot = &m_active_quests[task_index];
@@ -2163,7 +2163,7 @@ void ClientTaskState::SharedTaskIncrementDoneCount(
 	info->activity[activity_id].done_count = done_count;
 
 	LogTasksDetail(
-		"[SharedTaskIncrementDoneCount] Setting task_id [{}] to absolute done_count value of [{}] via increment [{}]",
+		"Setting task_id [{}] to absolute done_count value of [{}] via increment [{}]",
 		task_id,
 		info->activity[activity_id].done_count,
 		done_count
@@ -2250,7 +2250,7 @@ void ClientTaskState::CreateTaskDynamicZone(Client* client, int task_id, Dynamic
 
 void ClientTaskState::ListTaskTimers(Client* client)
 {
-	LogTasksDetail("[ListTaskTimers] Client [{}]", client->GetCleanName());
+	LogTasksDetail("Client [{}]", client->GetCleanName());
 
 	// this isn't live-like but we need to throttle query (alternative is caching timers)
 	if (!client->m_list_task_timers_rate_limit.Check()) {
@@ -2361,7 +2361,7 @@ void ClientTaskState::SyncSharedTaskZoneClientDoneCountState(
 			}
 
 			LogTasksDetail(
-				"[IncrementDoneCount] Setting internally client [{}] to donecount [{}]",
+				"Setting internally client [{}] to donecount [{}]",
 				c->GetCleanName(),
 				done_count
 			);

--- a/zone/task_manager.cpp
+++ b/zone/task_manager.cpp
@@ -37,7 +37,7 @@ bool TaskManager::LoadTaskSets()
 
 	for (auto &task_set: rows) {
 		m_task_sets[task_set.id].push_back(task_set.taskid);
-		LogTasksDetail("[LoadTaskSets] Adding task_id [{}] to task_set [{}]", task_set.taskid, task_set.id);
+		LogTasksDetail("Adding task_id [{}] to task_set [{}]", task_set.taskid, task_set.id);
 	}
 
 	return true;
@@ -49,7 +49,7 @@ bool TaskManager::LoadTasks(int single_task)
 	std::string query;
 	if (single_task == 0) {
 		if (!LoadTaskSets()) {
-			LogTasks("[TaskManager::LoadTasks] LoadTaskSets failed");
+			LogTasks("LoadTaskSets failed");
 		}
 
 		task_query_filter = fmt::format("id > 0");
@@ -64,7 +64,7 @@ bool TaskManager::LoadTasks(int single_task)
 
 		if (task_id <= 0) {
 			// This shouldn't happen, as the SELECT is bounded by MAXTASKS
-			LogError("[TASKS]Task ID [{}] out of range while loading tasks from database", task_id);
+			LogError("Task ID [{}] out of range while loading tasks from database", task_id);
 			continue;
 		}
 
@@ -100,7 +100,7 @@ bool TaskManager::LoadTasks(int single_task)
 		m_task_data.try_emplace(task_id, std::move(ti));
 
 		LogTasksDetail(
-			"[LoadTasks] (Task) task_id [{}] type [{}] () duration [{}] duration_code [{}] title [{}] description [{}] "
+			"(Task) task_id [{}] type [{}] () duration [{}] duration_code [{}] title [{}] description [{}] "
 			" reward_text [{}] reward_id_list [{}] cash_reward [{}] exp_reward [{}] reward_method [{}] faction_reward [{}] min_level [{}] "
 			" max_level [{}] level_spread [{}] min_players [{}] max_players [{}] repeatable [{}] completion_emote [{}]"
 			" replay_group [{}] replay_timer_seconds [{}] request_group [{}] request_timer_seconds [{}]",
@@ -157,7 +157,7 @@ bool TaskManager::LoadTasks(int single_task)
 
 			// This shouldn't happen, as the SELECT is bounded by MAXTASKS
 			LogTasks(
-				"[LoadTasks] Error: Task or activity_information ID ([{}], [{}]) out of range while loading activities from database",
+				"Error: Task or activity_information ID ([{}], [{}]) out of range while loading activities from database",
 				task_id,
 				activity_id
 			);
@@ -167,7 +167,7 @@ bool TaskManager::LoadTasks(int single_task)
 		auto task_data = GetTaskData(task_id);
 		if (!task_data) {
 			LogTasks(
-				"[LoadTasks] Error: activity_information for non-existent task ([{}], [{}]) while loading activities from database",
+				"Error: activity_information for non-existent task ([{}], [{}]) while loading activities from database",
 				task_id,
 				activity_id
 			);
@@ -184,7 +184,7 @@ bool TaskManager::LoadTasks(int single_task)
 		// Change to (activityID != (Tasks[taskID]->activity_count + 1)) to index from 1
 		if (activity_id != task_data->activity_count) {
 			LogTasks(
-				"[LoadTasks] Error: Activities for Task [{}] (activity_id [{}]) are not sequential starting at 0. Not loading task ",
+				"Error: Activities for Task [{}] (activity_id [{}]) are not sequential starting at 0. Not loading task ",
 				task_id,
 				activity_id
 			);
@@ -240,7 +240,7 @@ bool TaskManager::LoadTasks(int single_task)
 		ad->optional = a.optional;
 
 		LogTasksDetail(
-			"[LoadTasks] (Activity) task_id [{}] activity_id [{}] slot [{}] activity_type [{}] goal_method [{}] goal_count [{}] zones [{}]"
+			"(Activity) task_id [{}] activity_id [{}] slot [{}] activity_type [{}] goal_method [{}] goal_count [{}] zones [{}]"
 			" target_name [{}] item_list [{}] skill_list [{}] spell_list [{}] description_override [{}]",
 			task_id,
 			activity_id,
@@ -274,11 +274,11 @@ bool TaskManager::SaveClientState(Client *client, ClientTaskState *cts)
 		return false;
 	}
 
-	constexpr const char *ERR_MYSQLERROR = "[TASKS]Error in TaskManager::SaveClientState {}";
+	constexpr const char *ERR_MYSQLERROR = "Error in TaskManager::SaveClientState {}";
 
 	int character_id = client->CharacterID();
 
-	LogTasks("[SaveClientState] character_id [{}]", character_id);
+	LogTasks("character_id [{}]", character_id);
 
 	if (cts->m_active_task_count > 0 ||
 		cts->m_active_task.task_id != TASKSLOTEMPTY ||
@@ -295,7 +295,7 @@ bool TaskManager::SaveClientState(Client *client, ClientTaskState *cts)
 			if (active_task.updated) {
 
 				LogTasks(
-					"[SaveClientState] character_id [{}] updating task_index [{}] task_id [{}]",
+					"character_id [{}] updating task_index [{}] task_id [{}]",
 					character_id,
 					slot,
 					task_id
@@ -333,7 +333,7 @@ bool TaskManager::SaveClientState(Client *client, ClientTaskState *cts)
 				}
 
 				LogTasks(
-					"[SaveClientState] Updating activity character_id [{}] updating task_index [{}] task_id [{}] activity_index [{}]",
+					"Updating activity character_id [{}] updating task_index [{}] task_id [{}] activity_index [{}]",
 					character_id,
 					slot,
 					task_id,
@@ -586,7 +586,7 @@ void TaskManager::TaskSetSelector(Client* client, Mob* mob, int task_set_id, boo
 
 	// A task_id of 0 in a TaskSet indicates that all Tasks in the set are enabled for all players.
 	if (m_task_sets[task_set_id][0] == 0) {
-		LogTasks("[TaskSetSelector] TaskSets[{}][0] == 0. All Tasks in Set enabled.", task_set_id);
+		LogTasks("TaskSets[{}][0] == 0. All Tasks in Set enabled.", task_set_id);
 		all_enabled = true;
 	}
 
@@ -628,7 +628,7 @@ void TaskManager::TaskQuestSetSelector(Client* client, Mob* mob, const std::vect
 	int player_level    = client->GetLevel();
 	ClientTaskState* client_task_state = client->GetTaskState();
 
-	LogTasks("[UPDATE] TaskQuestSetSelector called with size [{}]", tasks.size());
+	LogTasks("TaskQuestSetSelector called with size [{}]", tasks.size());
 
 	if (tasks.empty()) {
 		return;
@@ -674,7 +674,7 @@ void TaskManager::TaskQuestSetSelector(Client* client, Mob* mob, const std::vect
 
 void TaskManager::SharedTaskSelector(Client* client, Mob* mob, const std::vector<int>& tasks, bool ignore_cooldown)
 {
-	LogTasks("[UPDATE] SharedTaskSelector called with size [{}]", tasks.size());
+	LogTasks("SharedTaskSelector called with size [{}]", tasks.size());
 
 	if (tasks.empty()) {
 		return;
@@ -748,26 +748,26 @@ bool TaskManager::CanOfferSharedTask(int task_id, const SharedTaskRequest& reque
 	const auto task = GetTaskData(task_id);
 	if (!task)
 	{
-		LogTasksDetail("[CanOfferSharedTask] task data for task id [{}] not found", task_id);
+		LogTasksDetail("task data for task id [{}] not found", task_id);
 		return false;
 	}
 
 	if (task->type != TaskType::Shared)
 	{
-		LogTasksDetail("[CanOfferSharedTask] task [{}] is not a shared task type", task_id);
+		LogTasksDetail("task [{}] is not a shared task type", task_id);
 		return false;
 	}
 
 	if (task->min_level > 0 && request.lowest_level < task->min_level)
 	{
-		LogTasksDetail("[CanOfferSharedTask] lowest level [{}] is below task [{}] min level [{}]",
+		LogTasksDetail("lowest level [{}] is below task [{}] min level [{}]",
 			request.lowest_level, task_id, task->min_level);
 		return false;
 	}
 
 	if (task->max_level > 0 && request.highest_level > task->max_level)
 	{
-		LogTasksDetail("[CanOfferSharedTask] highest level [{}] exceeds task [{}] max level [{}]",
+		LogTasksDetail("highest level [{}] exceeds task [{}] max level [{}]",
 			request.highest_level, task_id, task->max_level);
 		return false;
 	}
@@ -831,7 +831,7 @@ void TaskManager::SendTaskSelector(Client* client, Mob* mob, const std::vector<i
 
 void TaskManager::SendSharedTaskSelector(Client* client, Mob* mob, const std::vector<int>& task_list)
 {
-	LogTasks("SendSharedTaskSelector for [{}] Tasks", task_list.size());
+	LogTasks("[{}] Tasks", task_list.size());
 
 	// request timer is only set when shared task selection shown (not for failed validations)
 	client->StartTaskRequestCooldownTimer();
@@ -890,7 +890,7 @@ void TaskManager::SendCompletedTasksToClient(Client *c, ClientTaskState *cts)
 	}
 
 	LogTasks(
-		"[SendCompletedTasksToClient] completed task count [{}] first tank to send is [{}] last is [{}]",
+		"completed task count [{}] first tank to send is [{}] last is [{}]",
 		cts->m_completed_tasks.size(),
 		first_task_to_send,
 		last_task_to_send
@@ -1008,7 +1008,7 @@ void TaskManager::SendActiveTaskToClient(
 		false
 	);
 
-	LogTasks("[SendActiveTasksToClient] task_id [{}] activity_count [{}] task_index [{}]",
+	LogTasks("task_id [{}] activity_count [{}] task_index [{}]",
 			 task_id,
 			 GetActivityCount(task_id),
 			 task_index);
@@ -1018,7 +1018,7 @@ void TaskManager::SendActiveTaskToClient(
 	for (int activity_id = 0; activity_id < GetActivityCount(task_id); activity_id++) {
 		if (client->GetTaskActivityState(task_type, fixed_index, activity_id) != ActivityHidden) {
 			LogTasks(
-				"[SendActiveTasksToClient] (Long Update) task_id [{}] activity_id [{}] fixed_index [{}] task_complete [{}]",
+				"(Long Update) task_id [{}] activity_id [{}] fixed_index [{}] task_complete [{}]",
 				task_id,
 				activity_id,
 				fixed_index,
@@ -1046,7 +1046,7 @@ void TaskManager::SendActiveTaskToClient(
 		}
 		else {
 			LogTasks(
-				"[SendActiveTasksToClient] (Short Update) task_id [{}] activity_id [{}] fixed_index [{}]",
+				"(Short Update) task_id [{}] activity_id [{}] fixed_index [{}]",
 				task_id,
 				activity_id,
 				fixed_index
@@ -1084,7 +1084,7 @@ void TaskManager::SendActiveTasksToClient(Client *client, bool task_complete)
 		}
 
 		LogTasksDetail("--");
-		LogTasksDetail("[SendActiveTasksToClient] Task [{}]", task_data->title);
+		LogTasksDetail("Task [{}]", task_data->title);
 
 		SendActiveTaskToClient(&state->m_active_quests[task_index], client, task_index, task_complete);
 	}
@@ -1112,13 +1112,13 @@ void TaskManager::SendSingleActiveTaskToClient(
 	);
 	Log(Logs::General,
 		Logs::Tasks,
-		"[UPDATE] SendSingleActiveTasksToClient: Task %i, Activities: %i",
+		"SendSingleActiveTasksToClient: Task %i, Activities: %i",
 		task_id,
 		GetActivityCount(task_id));
 
 	for (int activity_id = 0; activity_id < GetActivityCount(task_id); activity_id++) {
 		if (task_info.activity[activity_id].activity_state != ActivityHidden) {
-			LogTasks("[SendSingleActiveTaskToClient] Long [{}] [{}] complete [{}]",
+			LogTasks("Long [{}] [{}] complete [{}]",
 					 task_id,
 					 activity_id,
 					 task_complete);
@@ -1130,7 +1130,7 @@ void TaskManager::SendSingleActiveTaskToClient(
 			}
 		}
 		else {
-			LogTasks("[SendSingleActiveTaskToClient] Short [{}] [{}]", task_id, activity_id);
+			LogTasks("Short [{}] [{}]", task_id, activity_id);
 			SendTaskActivityShort(client, task_id, activity_id, task_info.slot);
 		}
 	}
@@ -1253,7 +1253,7 @@ bool TaskManager::LoadClientState(Client *client, ClientTaskState *cts)
 
 	cts->m_active_task_count = 0;
 
-	LogTasks("[LoadClientState] for character_id [{}]", character_id);
+	LogTasks("for character_id [{}]", character_id);
 
 	// in a case where a client somehow lost local state with what state exists in world - we need
 	// to perform an inverse sync where we inject the task
@@ -1274,7 +1274,7 @@ bool TaskManager::LoadClientState(Client *client, ClientTaskState *cts)
 
 		if (task_id < 0) {
 			LogTasks(
-				"[LoadClientState] Error: task_id [{}] out of range while loading character tasks from database",
+				"Error: task_id [{}] out of range while loading character tasks from database",
 				task_id
 			);
 			continue;
@@ -1286,14 +1286,14 @@ bool TaskManager::LoadClientState(Client *client, ClientTaskState *cts)
 		auto task_info = cts->GetClientTaskInfo(type, slot);
 		if (task_info == nullptr) {
 			LogTasks(
-				"[LoadClientState] Error: slot [{}] out of range while loading character tasks from database",
+				"Error: slot [{}] out of range while loading character tasks from database",
 				slot
 			);
 			continue;
 		}
 
 		if (task_info->task_id != TASKSLOTEMPTY) {
-			LogTasks("[LoadClientState] Error: slot [{}] for task [{}] is already occupied", slot, task_id);
+			LogTasks("Error: slot [{}] for task [{}] is already occupied", slot, task_id);
 			continue;
 		}
 
@@ -1312,7 +1312,7 @@ bool TaskManager::LoadClientState(Client *client, ClientTaskState *cts)
 		}
 
 		LogTasks(
-			"[LoadClientState] character_id [{}] task_id [{}] slot [{}] accepted_time [{}] was_rewarded [{}]",
+			"character_id [{}] task_id [{}] slot [{}] accepted_time [{}] was_rewarded [{}]",
 			character_id,
 			task_id,
 			slot,
@@ -1322,7 +1322,7 @@ bool TaskManager::LoadClientState(Client *client, ClientTaskState *cts)
 	}
 
 	// Load Activities
-	LogTasks("[LoadClientState] Loading activities for character_id [{}]", character_id);
+	LogTasks("Loading activities for character_id [{}]", character_id);
 
 	auto character_activities = CharacterActivitiesRepository::GetWhere(
 		database,
@@ -1333,7 +1333,7 @@ bool TaskManager::LoadClientState(Client *client, ClientTaskState *cts)
 		int task_id = character_activity.taskid;
 		if (task_id < 0) {
 			LogTasks(
-				"[LoadClientState] Error: task_id [{}] out of range while loading character activities from database character_id [{}]",
+				"Error: task_id [{}] out of range while loading character activities from database character_id [{}]",
 				task_id,
 				character_id
 			);
@@ -1343,7 +1343,7 @@ bool TaskManager::LoadClientState(Client *client, ClientTaskState *cts)
 		int activity_id = character_activity.activityid;
 		if ((activity_id < 0) || (activity_id >= MAXACTIVITIESPERTASK)) {
 			LogTasks(
-				"[LoadClientState] Error: activity_id [{}] out of range while loading character activities from database character_id [{}]",
+				"Error: activity_id [{}] out of range while loading character activities from database character_id [{}]",
 				activity_id,
 				character_id
 			);
@@ -1373,7 +1373,7 @@ bool TaskManager::LoadClientState(Client *client, ClientTaskState *cts)
 
 		if (task_info == nullptr) {
 			LogTasks(
-				"[LoadClientState] Error: activity_id [{}] found for task_id [{}] which client does not have character_id [{}]",
+				"Error: activity_id [{}] found for task_id [{}] which client does not have character_id [{}]",
 				activity_id,
 				task_id,
 				character_id
@@ -1394,7 +1394,7 @@ bool TaskManager::LoadClientState(Client *client, ClientTaskState *cts)
 		task_info->activity[activity_id].updated = false;
 
 		LogTasks(
-			"[LoadClientState] character_id [{}] task_id [{}] activity_id [{}] done_count [{}] completed [{}]",
+			"character_id [{}] task_id [{}] activity_id [{}] done_count [{}] completed [{}]",
 			character_id,
 			task_id,
 			activity_id,
@@ -1423,7 +1423,7 @@ bool TaskManager::LoadClientState(Client *client, ClientTaskState *cts)
 		for (auto &character_completed_task: character_completed_tasks) {
 			int task_id = character_completed_task.taskid;
 			if (task_id <= 0) {
-				LogError("[TASKS]Task ID [{}] out of range while loading completed tasks from database", task_id);
+				LogError("Task ID [{}] out of range while loading completed tasks from database", task_id);
 				continue;
 			}
 
@@ -1433,7 +1433,7 @@ bool TaskManager::LoadClientState(Client *client, ClientTaskState *cts)
 			// completed.
 			int activity_id = character_completed_task.activityid;
 			if ((activity_id < -1) || (activity_id >= MAXACTIVITIESPERTASK)) {
-				LogError("[TASKS]activity_information ID [{}] out of range while loading completed tasks from database",
+				LogError("activity_information ID [{}] out of range while loading completed tasks from database",
 						 activity_id);
 				continue;
 			}
@@ -1487,7 +1487,7 @@ bool TaskManager::LoadClientState(Client *client, ClientTaskState *cts)
 		for (auto row = results.begin(); row != results.end(); ++row) {
 			int task_id = atoi(row[0]);
 			cts->m_enabled_tasks.push_back(task_id);
-			LogTasksDetail("[LoadClientState] Adding task_id [{}] to enabled tasks", task_id);
+			LogTasksDetail("Adding task_id [{}] to enabled tasks", task_id);
 		}
 	}
 
@@ -1509,7 +1509,7 @@ bool TaskManager::LoadClientState(Client *client, ClientTaskState *cts)
 				task_id
 			);
 
-			LogError("[LoadClientState] Character [{}] has task [{}] which does not exist", character_id, task_id);
+			LogError("Character [{}] has task [{}] which does not exist", character_id, task_id);
 			cts->m_active_tasks[task_index].task_id = TASKSLOTEMPTY;
 			continue;
 		}
@@ -1523,7 +1523,7 @@ bool TaskManager::LoadClientState(Client *client, ClientTaskState *cts)
 				);
 
 				LogTasks(
-					"[LoadClientState] Fatal error in character [{}] task state. activity_information [{}] for Task [{}] either missing from client state or from task",
+					"Fatal error in character [{}] task state. activity_information [{}] for Task [{}] either missing from client state or from task",
 					character_id,
 					activity_index,
 					task_id
@@ -1535,7 +1535,7 @@ bool TaskManager::LoadClientState(Client *client, ClientTaskState *cts)
 	}
 
 	LogTasksDetail(
-		"[LoadClientState] m_active_task task_id is [{}] slot [{}]",
+		"m_active_task task_id is [{}] slot [{}]",
 		cts->m_active_task.task_id,
 		cts->m_active_task.slot
 	);
@@ -1544,7 +1544,7 @@ bool TaskManager::LoadClientState(Client *client, ClientTaskState *cts)
 
 		// purely debugging
 		LogTasksDetail(
-			"[LoadClientState] Fetching task info for character_id [{}] task [{}] slot [{}] accepted_time [{}] updated [{}]",
+			"Fetching task info for character_id [{}] task [{}] slot [{}] accepted_time [{}] updated [{}]",
 			character_id,
 			cts->m_active_task.task_id,
 			cts->m_active_task.slot,
@@ -1557,7 +1557,7 @@ bool TaskManager::LoadClientState(Client *client, ClientTaskState *cts)
 			for (int i = 0; i < task_data->activity_count; i++) {
 				if (cts->m_active_task.activity[i].activity_id >= 0) {
 					LogTasksDetail(
-						"[LoadClientState] -- character_id [{}] task [{}] activity_id [{}] done_count [{}] activity_state [{}] updated [{}]",
+						"-- character_id [{}] task [{}] activity_id [{}] done_count [{}] activity_state [{}] updated [{}]",
 						character_id,
 						cts->m_active_task.task_id,
 						cts->m_active_task.activity[i].activity_id,
@@ -1572,7 +1572,7 @@ bool TaskManager::LoadClientState(Client *client, ClientTaskState *cts)
 
 	// shared task
 	LogTasksDetail(
-		"[LoadClientState] m_active_shared_task task_id is [{}] slot [{}]",
+		"m_active_shared_task task_id is [{}] slot [{}]",
 		cts->m_active_shared_task.task_id,
 		cts->m_active_shared_task.slot
 	);
@@ -1587,7 +1587,7 @@ bool TaskManager::LoadClientState(Client *client, ClientTaskState *cts)
 		}
 	}
 
-	LogTasksDetail("[LoadClientState] for Character ID [{}] DONE!", character_id);
+	LogTasksDetail("for Character ID [{}] DONE!", character_id);
 	LogTasksDetail("---", character_id);
 
 	return true;
@@ -1645,7 +1645,7 @@ void TaskManager::SyncClientSharedTaskWithPersistedState(Client *c, ClientTaskSt
 					for (auto &a: activities) {
 
 						LogTasksDetail(
-							"[LoadClientState] shared_task loop local [{}] shared [{}]",
+							"shared_task loop local [{}] shared [{}]",
 							shared_task->activity[a.activity_id].done_count,
 							a.done_count
 						);
@@ -1674,7 +1674,7 @@ void TaskManager::SyncClientSharedTaskWithPersistedState(Client *c, ClientTaskSt
 						// live does this as long as the shared task is still active when entering game
 						if (!shared_task->was_rewarded && IsActiveTaskComplete(*shared_task))
 						{
-							LogTasksDetail("[LoadClientState] Syncing shared task completion for client [{}]", c->GetName());
+							LogTasksDetail("Syncing shared task completion for client [{}]", c->GetName());
 							const auto task_data = GetTaskData(shared_task->task_id);
 							cts->AddReplayTimer(c, *shared_task, *task_data); // live updates a fresh timer
 							cts->DispatchEventTaskComplete(c, *shared_task, task_data->activity_count - 1);
@@ -1706,7 +1706,7 @@ void TaskManager::SyncClientSharedTaskRemoveLocalIfNotExists(Client *c, ClientTa
 		// if we don't actually have a membership anywhere, remove ourself locally
 		if (members.empty()) {
 			LogTasksDetail(
-				"[SyncClientSharedTaskRemoveLocalIfNotExists] Client [{}] Shared task [{}] doesn't exist in world, removing from local",
+				"Client [{}] Shared task [{}] doesn't exist in world, removing from local",
 				c->GetCleanName(),
 				cts->m_active_shared_task.task_id
 			);
@@ -1751,7 +1751,7 @@ void TaskManager::SyncClientSharedTaskStateToLocal(
 	}
 
 	if (!has_character_shared_task) {
-		LogTasksDetail("[SyncClientSharedTaskStateToLocal] We don't have a shared character task locally");
+		LogTasksDetail("We don't have a shared character task locally");
 		auto stm = SharedTaskMembersRepository::GetWhere(
 			database,
 			fmt::format(
@@ -1761,14 +1761,14 @@ void TaskManager::SyncClientSharedTaskStateToLocal(
 		);
 
 		if (!stm.empty()) {
-			LogTasksDetail("[SyncClientSharedTaskStateToLocal] We have membership in database");
+			LogTasksDetail("We have membership in database");
 			auto s = SharedTasksRepository::FindOne(
 				database,
 				(int) stm.front().shared_task_id
 			);
 
 			if (s.id > 0) {
-				LogTasksDetail("[SyncClientSharedTaskStateToLocal] Creating entity");
+				LogTasksDetail("Creating entity");
 
 				// create task locally
 				auto ct = CharacterTasksRepository::NewEntity();
@@ -1813,7 +1813,7 @@ void TaskManager::HandleUpdateTasksOnKill(Client* client, NPC* npc)
 			continue;
 		}
 
-		LogTasksDetail("[HandleUpdateTasksOnKill] Looping through client [{}]", c->GetCleanName());
+		LogTasksDetail("Looping through client [{}]", c->GetCleanName());
 
 		c->GetTaskState()->UpdateTasksOnKill(c, client, npc);
 	}

--- a/zone/tasks.cpp
+++ b/zone/tasks.cpp
@@ -112,7 +112,7 @@ void Client::SendTaskFailed(int task_id, int task_index, TaskType task_type)
 	task_activity_complete->task_completed = 0; //Fail
 	task_activity_complete->stage_complete = 0; // 0 for task complete or failed.
 
-	LogTasks("[SendTaskFailed] Sending failure to client [{}]", GetCleanName());
+	LogTasks("Sending failure to client [{}]", GetCleanName());
 
 	QueuePacket(outapp);
 	safe_delete(outapp);

--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -240,7 +240,7 @@ void Object::HandleCombine(Client* user, const NewCombine_Struct* in_combine, Ob
 	}
 
 	LogTradeskills(
-		"[HandleCombine] container_slot [{}] guildtribute_slot [{}]",
+		"container_slot [{}] guildtribute_slot [{}]",
 		in_combine->container_slot,
 		in_combine->guildtribute_slot
 	);
@@ -326,7 +326,7 @@ void Object::HandleCombine(Client* user, const NewCombine_Struct* in_combine, Ob
 		safe_delete(outapp);
 
 		LogTradeskills(
-			"[HandleCombine] inst_item [{}] container_item [{}]",
+			"inst_item [{}] container_item [{}]",
 			inst->GetItem()->ID,
 			container->GetItem()->ID
 		);
@@ -335,7 +335,7 @@ void Object::HandleCombine(Client* user, const NewCombine_Struct* in_combine, Ob
 	}
 
 	if (container->GetItem() && container->GetItem()->BagType == EQ::item::BagTypeDetransformationmold) {
-		LogTradeskillsDetail("[HandleCombine] Check 1");
+		LogTradeskillsDetail("Check 1");
 
 		const EQ::ItemInstance* inst = container->GetItem(0);
 		if (inst && inst->GetOrnamentationIcon() && inst->GetOrnamentationIcon()) {
@@ -365,7 +365,7 @@ void Object::HandleCombine(Client* user, const NewCombine_Struct* in_combine, Ob
 
 	if (!content_db.GetTradeRecipe(container, c_type, some_id, user->CharacterID(), &spec)) {
 
-		LogTradeskillsDetail("[HandleCombine] Check 2");
+		LogTradeskillsDetail("Check 2");
 
 		user->MessageString(Chat::Emote,TRADESKILL_NOCOMBINE);
 		auto outapp = new EQApplicationPacket(OP_TradeSkillCombine, 0);
@@ -382,7 +382,7 @@ void Object::HandleCombine(Client* user, const NewCombine_Struct* in_combine, Ob
 	// bit 6 (0x20): unlisted recipe flag
 	if ((spec.must_learn & 0xF) == 1 && !spec.has_learnt) {
 
-		LogTradeskillsDetail("[HandleCombine] Check 3");
+		LogTradeskillsDetail("Check 3");
 
 		// Made up message for the client. Just giving a DNC is the other option.
 		user->Message(Chat::LightBlue, "You need to learn how to combine these first.");
@@ -1213,9 +1213,9 @@ void Client::CheckIncreaseTradeskill(int16 bonusstat, int16 stat_modifier, float
 			NotifyNewTitlesAvailable();
 	}
 
-	LogTradeskills("[CheckIncreaseTradeskill] skillup_modifier: [{}] , success_modifier: [{}] , stat modifier: [{}]", skillup_modifier , success_modifier , stat_modifier);
-	LogTradeskills("[CheckIncreaseTradeskill] Stage1 chance was: [{}] percent", chance_stage1);
-	LogTradeskills("[CheckIncreaseTradeskill] Stage2 chance was: [{}] percent. 0 percent means stage1 failed", chance_stage2);
+	LogTradeskills("skillup_modifier: [{}] , success_modifier: [{}] , stat modifier: [{}]", skillup_modifier , success_modifier , stat_modifier);
+	LogTradeskills("Stage1 chance was: [{}] percent", chance_stage1);
+	LogTradeskills("Stage2 chance was: [{}] percent. 0 percent means stage1 failed", chance_stage2);
 }
 
 bool ZoneDatabase::GetTradeRecipe(
@@ -1227,7 +1227,7 @@ bool ZoneDatabase::GetTradeRecipe(
 )
 {
 	if (container == nullptr) {
-		LogTradeskills("[GetTradeRecipe] Container null");
+		LogTradeskills("Container null");
 		return false;
 	}
 
@@ -1246,7 +1246,7 @@ bool ZoneDatabase::GetTradeRecipe(
 	uint32      count = 0;
 	uint32      sum   = 0;
 	for (uint8  i     = 0; i < 10; i++) { // <watch> TODO: need to determine if this is bound to world/item container size
-		LogTradeskills("[GetTradeRecipe] Fetching item [{}]", i);
+		LogTradeskills("Fetching item [{}]", i);
 
 		const EQ::ItemInstance *inst = container->GetItem(i);
 		if (!inst) {
@@ -1255,7 +1255,7 @@ bool ZoneDatabase::GetTradeRecipe(
 
 		const EQ::ItemData *item = database.GetItem(inst->GetItem()->ID);
 		if (!item) {
-			LogTradeskills("[GetTradeRecipe] item [{}] not found!", inst->GetItem()->ID);
+			LogTradeskills("item [{}] not found!", inst->GetItem()->ID);
 			continue;
 		}
 
@@ -1271,7 +1271,7 @@ bool ZoneDatabase::GetTradeRecipe(
 		count++;
 
 		LogTradeskills(
-			"[GetTradeRecipe] Item in container index [{}] item [{}] found [{}]",
+			"Item in container index [{}] item [{}] found [{}]",
 			i,
 			item->ID,
 			count
@@ -1415,7 +1415,7 @@ bool ZoneDatabase::GetTradeRecipe(
 			}
 
 			LogTradeskills(
-				"[GetTradeRecipe] Component count loop [{}] item [{}] recipe component_count [{}]",
+				"Component count loop [{}] item [{}] recipe component_count [{}]",
 				component_count,
 				item->ID,
 				atoi(row[1])
@@ -1505,7 +1505,7 @@ bool ZoneDatabase::GetTradeRecipe(
 	);
 
 	if (!r.empty() && r[0].recipe_id) { //If this exists we learned it
-		LogTradeskills("[GetTradeRecipe] made_count [{}]", r[0].madecount);
+		LogTradeskills("made_count [{}]", r[0].madecount);
 
 		spec->has_learnt = true;
 		spec->madecount  = (uint32) r[0].madecount;
@@ -1612,7 +1612,7 @@ void Client::LearnRecipe(uint32 recipe_id)
 	}
 
 	LogTradeskills(
-		"[LearnRecipe] recipe_id [{}] name [{}] learned [{}]",
+		"recipe_id [{}] name [{}] learned [{}]",
 		recipe_id,
 		tradeskill_recipe.name,
 		results.RowCount()

--- a/zone/waypoints.cpp
+++ b/zone/waypoints.cpp
@@ -792,7 +792,7 @@ float Mob::GetFixedZ(const glm::vec3 &destination, int32 z_find_offset) {
 
 		auto duration = timer.elapsed();
 
-		LogFixZ("Mob::GetFixedZ() ([{}]) returned [{}] at [{}], [{}], [{}] - Took [{}]",
+		LogFixZ("[{}] returned [{}] at [{}] [{}] [{}] - Took [{}]",
 			GetCleanName(),
 			new_z,
 			destination.x,

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -3450,7 +3450,7 @@ bool WorldServer::SendVoiceMacro(Client* From, uint32 Type, char* Target, uint32
 
 bool WorldServer::RezzPlayer(EQApplicationPacket* rpack, uint32 rezzexp, uint32 dbid, uint16 opcode)
 {
-	LogSpells("[WorldServer::RezzPlayer] rezzexp is [{}] (0 is normal for RezzComplete", rezzexp);
+	LogSpells("rezzexp is [{}] (0 is normal for RezzComplete", rezzexp);
 	auto pack = new ServerPacket(ServerOP_RezzPlayer, sizeof(RezzPlayer_Struct));
 	RezzPlayer_Struct* sem = (RezzPlayer_Struct*)pack->pBuffer;
 	sem->rezzopcode = opcode;
@@ -3459,9 +3459,9 @@ bool WorldServer::RezzPlayer(EQApplicationPacket* rpack, uint32 rezzexp, uint32 
 	sem->dbid = dbid;
 	bool ret = SendPacket(pack);
 	if (ret)
-		LogSpells("[WorldServer::RezzPlayer] Sending player rezz packet to world spellid:[{}]", sem->rez.spellid);
+		LogSpells("Sending player rezz packet to world spellid:[{}]", sem->rez.spellid);
 	else
-		LogSpells("[WorldServer::RezzPlayer] NOT Sending player rezz packet to world");
+		LogSpells("NOT Sending player rezz packet to world");
 
 	safe_delete(pack);
 	return ret;

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -595,7 +595,7 @@ void Zone::LoadTempMerchantData()
 		temp_merchant_list.origslot = temp_merchant_list.slot;
 
 		LogMerchants(
-			"[LoadTempMerchantData] Loading merchant temp items npc_id [{}] slot [{}] charges [{}] item [{}] origslot [{}]",
+			"Loading merchant temp items npc_id [{}] slot [{}] charges [{}] item [{}] origslot [{}]",
 			npc_id,
 			temp_merchant_list.slot,
 			temp_merchant_list.charges,
@@ -904,7 +904,7 @@ void Zone::Shutdown(bool quiet)
 	zone->ldon_trap_entry_list.clear();
 
 	LogInfo(
-		"[Zone Shutdown] Zone [{}] zone_id [{}] version [{}] instance_id [{}]",
+		"Zone [{}] zone_id [{}] version [{}] instance_id [{}]",
 		zone->GetShortName(),
 		zone->GetZoneID(),
 		zone->GetInstanceVersion(),
@@ -914,7 +914,7 @@ void Zone::Shutdown(bool quiet)
 	zone->SetZoneHasCurrentTime(false);
 	if (!quiet) {
 		LogInfo(
-			"[Zone Shutdown] Zone [{}] zone_id [{}] version [{}] instance_id [{}] Going to sleep",
+			"Zone [{}] zone_id [{}] version [{}] instance_id [{}] Going to sleep",
 			zone->GetShortName(),
 			zone->GetZoneID(),
 			zone->GetInstanceVersion(),
@@ -933,7 +933,7 @@ void Zone::Shutdown(bool quiet)
 	LogSys.CloseFileLogs();
 
 	if (RuleB(Zone, KillProcessOnDynamicShutdown)) {
-		LogInfo("[Zone Shutdown] Shutting down");
+		LogInfo("Shutting down");
 		EQ::EventLoop::Get().Shutdown();
 	}
 }
@@ -1290,7 +1290,7 @@ bool Zone::LoadZoneCFG(const char* filename, uint16 instance_version)
 	auto z = zone_store.GetZoneWithFallback(ZoneID(filename), instance_version);
 
 	if (!z) {
-		LogError("[LoadZoneCFG] Failed to load zone data for [{}] instance_version [{}]", filename, instance_version);
+		LogError("Failed to load zone data for [{}] instance_version [{}]", filename, instance_version);
 		return false;
 	}
 
@@ -1840,7 +1840,7 @@ void Zone::StartShutdownTimer(uint32 set_time)
 
 void Zone::ResetShutdownTimer() {
 	LogInfo(
-		"[ResetShutdownTimer] Reset to [{}] from original remaining time [{}] duration [{}] zone [{}]",
+		"Reset to [{}] from original remaining time [{}] duration [{}] zone [{}]",
 		Strings::SecondsToTime(autoshutdown_timer.GetDuration(), true),
 		Strings::SecondsToTime(autoshutdown_timer.GetRemainingTime(), true),
 		Strings::SecondsToTime(autoshutdown_timer.GetDuration(), true),
@@ -2950,7 +2950,7 @@ void Zone::SendDiscordMessage(const std::string& webhook_name, const std::string
 	}
 
 	if (not_found) {
-		LogDiscord("[SendDiscordMessage] Did not find valid webhook by webhook name [{}]", webhook_name);
+		LogDiscord("Did not find valid webhook by webhook name [{}]", webhook_name);
 	}
 }
 

--- a/zone/zone_reload.cpp
+++ b/zone/zone_reload.cpp
@@ -32,11 +32,11 @@ void ZoneReload::HotReloadQuests()
 	if (RuleB(HotReload, QuestsRepopWithReload)) {
 		zone->Repop();
 	}
-	
+
 	zone->SetQuestHotReloadQueued(false);
 
 	LogHotReload(
-		"[Quests] Reloading [{}] repop [{}] reset_timers [{}] repop_when_not_in_combat [{}] Time [{:.4f}]",
+		"Reloading [{}] repop [{}] reset_timers [{}] repop_when_not_in_combat [{}] Time [{:.4f}]",
 		zone->GetShortName(),
 		(RuleB(HotReload, QuestsRepopWithReload) ? "true" : "false"),
 		(RuleB(HotReload, QuestsResetTimersWithReload) ? "true" : "false"),

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -1635,7 +1635,7 @@ bool ZoneDatabase::SaveCharacterInvSnapshot(uint32 character_id) {
 		character_id
 	);
 	auto results = database.QueryDatabase(query);
-	LogInventory("ZoneDatabase::SaveCharacterInventorySnapshot [{}] ([{}])", character_id, (results.Success() ? "pass" : "fail"));
+	LogInventory("[{}] ([{}])", character_id, (results.Success() ? "pass" : "fail"));
 	return results.Success();
 }
 
@@ -1852,7 +1852,7 @@ bool ZoneDatabase::RestoreCharacterInvSnapshot(uint32 character_id, uint32 times
 	// we should know what we're doing by the time we call this function..but,
 	// this is to prevent inventory deletions where no timestamp entries exists
 	if (!ValidateCharacterInvSnapshotTimestamp(character_id, timestamp)) {
-		LogError("ZoneDatabase::RestoreCharacterInvSnapshot() called for id: [{}] without valid snapshot entries @ [{}]", character_id, timestamp);
+		LogError("called for id: [{}] without valid snapshot entries @ [{}]", character_id, timestamp);
 		return false;
 	}
 
@@ -1917,7 +1917,7 @@ bool ZoneDatabase::RestoreCharacterInvSnapshot(uint32 character_id, uint32 times
 	);
 	results = database.QueryDatabase(query);
 
-	LogInventory("ZoneDatabase::RestoreCharacterInvSnapshot() [{}] snapshot for [{}] @ [{}]",
+	LogInventory("[{}] snapshot for [{}] @ [{}]",
 		(results.Success() ? "restored" : "failed to restore"), character_id, timestamp);
 
 	return results.Success();

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -195,7 +195,7 @@ void Client::Handle_OP_ZoneChange(const EQApplicationPacket *app) {
 	int16 min_status = AccountStatus::Player;
 	uint8 min_level  = 0;
 
-	LogInfo("[Handle_OP_ZoneChange] Loaded zone flag [{}]", zone_data->flag_needed);
+	LogInfo("Loaded zone flag [{}]", zone_data->flag_needed);
 
 	safe_x       = zone_data->safe_x;
 	safe_y       = zone_data->safe_y;
@@ -636,7 +636,7 @@ void Client::ZonePC(uint32 zoneID, uint32 instance_id, float x, float y, float z
 	}
 
 	LogInfo(
-		"[ZonePC] Client [{}] zone_id [{}] x [{}] y [{}] z [{}] heading [{}] ignorerestrictions [{}] zone_mode [{}]",
+		"Client [{}] zone_id [{}] x [{}] y [{}] z [{}] heading [{}] ignorerestrictions [{}] zone_mode [{}]",
 		GetCleanName(),
 		zoneID,
 		x,


### PR DESCRIPTION
### What

With PR's https://github.com/EQEmu/Server/pull/2765 and https://github.com/EQEmu/Server/pull/2755 brings code function prefixes to logging statements automatically. This removes the need to manually have them in our logging statements all over the code and in many cases will have double of the same information with the prior logging changes.

This PR removes most places in the code where the function is inserted as part of the logging statement