### PR TITLE
[Optimization] Handle channel name filter checks in memory

### DIFF
--- a/ucs/chatchannel.cpp
+++ b/ucs/chatchannel.cpp
@@ -837,11 +837,8 @@ void ChatChannelList::AddToFilteredNames(const std::string& name) {
 		return;
 	}
 
-	// Check if name is already in the FilteredNames vector
-	bool is_found = Strings::Contains(ChatChannelList::GetFilteredNames(), name);
-
 	// Add name to the filtered names vector if it is not already present
-	if (!is_found) {
+	if (!Strings::Contains(ChatChannelList::GetFilteredNames(), name)) {
 		auto filtered_names = GetFilteredNames(); // Get current filter name list
 		filtered_names.push_back(name); // Add new name to local filtered names list
 		SetFilteredNameList(filtered_names); // Set filtered names list to match local filtered names list

--- a/ucs/chatchannel.cpp
+++ b/ucs/chatchannel.cpp
@@ -803,8 +803,18 @@ bool ChatChannelList::IsOnChannelBlockList(const std::string& channel_name) {
 	}
 
 	// Check if channel_name is already in the BlockedChannelNames vector
-	return Strings::Contains(ChatChannelList::GetBlockedChannelNames(), channel_name);
+	return Strings::Contains(GetBlockedChannelNames(), channel_name);
 }
+
+bool ChatChannelList::IsOnFilteredNameList(const std::string& name) {
+	if (name.empty()) {
+		return false;
+	}
+
+	// Check if name is already in the filtered name vector
+	return Strings::Contains(GetFilteredNames(), name);
+}
+
 
 void ChatChannelList::AddToChannelBlockList(const std::string& channel_name) {
 	if (channel_name.empty()) {
@@ -819,6 +829,22 @@ void ChatChannelList::AddToChannelBlockList(const std::string& channel_name) {
 		auto blocked_channel_names = GetBlockedChannelNames(); // Get current blocked list
 		blocked_channel_names.push_back(channel_name); // Add new name to local blocked list
 		SetChannelBlockList(blocked_channel_names); // Set blocked list to match local blocked list
+	}
+}
+
+void ChatChannelList::AddToFilteredNames(const std::string& name) {
+	if (name.empty()) {
+		return;
+	}
+
+	// Check if name is already in the FilteredNames vector
+	bool is_found = Strings::Contains(ChatChannelList::GetFilteredNames(), name);
+
+	// Add name to the filtered names vector if it is not already present
+	if (!is_found) {
+		auto filtered_names = GetFilteredNames(); // Get current filter name list
+		filtered_names.push_back(name); // Add new name to local filtered names list
+		SetFilteredNameList(filtered_names); // Set filtered names list to match local filtered names list
 	}
 }
 

--- a/ucs/chatchannel.h
+++ b/ucs/chatchannel.h
@@ -84,14 +84,20 @@ public:
 	void SendAllChannels(Client *c);
 	void Process();
 	static inline std::vector<std::string> GetBlockedChannelNames() { return m_blocked_channel_names; }
+	static inline std::vector<std::string> GetFilteredNames() { return m_filtered_names; }
 	static inline void ClearChannelBlockList() { m_blocked_channel_names.clear(); };
+	static inline void ClearFilteredNameList() { m_filtered_names.clear(); };
 	static void AddToChannelBlockList(const std::string& channel_name);
+	static void AddToFilteredNames(const std::string& name);
 	static bool IsOnChannelBlockList(const std::string& channel_name);
+	static bool IsOnFilteredNameList(const std::string& channel_name);
 	static inline void SetChannelBlockList(std::vector<std::string> new_list) { m_blocked_channel_names = new_list; }
+	static inline void SetFilteredNameList(std::vector<std::string> new_list) { m_filtered_names = new_list; }
 private:
 
 	LinkedList<ChatChannel*> ChatChannels;
 	static inline std::vector<std::string> m_blocked_channel_names;
+	static inline std::vector<std::string> m_filtered_names;
 
 };
 

--- a/ucs/database.cpp
+++ b/ucs/database.cpp
@@ -273,7 +273,7 @@ void UCSDatabase::LoadFilteredNamesFromDB()
 		LogDebug("No filtered names exist in the database...");
 	}
 
-	for (auto& e : names) {
+	for (const auto& e : names) {
 		ChatChannelList::AddToFilteredNames(e.name);
 	}
 
@@ -378,7 +378,7 @@ bool UCSDatabase::CheckChannelNameFilter(const std::string& channel_name)
 {
 	LogDebug("Checking if [{}] is on the name filter", channel_name);
 
-	for (auto &e: ChatChannelList::GetFilteredNames()) {
+	for (const auto &e: ChatChannelList::GetFilteredNames()) {
 		if (Strings::Contains(Strings::ToLower(channel_name), Strings::ToLower(e))) {
 			LogInfo("Failed to pass name filter check for [{}] against word [{}]", channel_name, e);
 			return false;

--- a/ucs/database.cpp
+++ b/ucs/database.cpp
@@ -264,6 +264,22 @@ void UCSDatabase::LoadReservedNamesFromDB()
 	LogInfo("Loaded [{}] reserved channel name(s)", channels.size());
 }
 
+void UCSDatabase::LoadFilteredNamesFromDB()
+{
+	ChatChannelList::ClearFilteredNameList();
+
+	auto names = NameFilterRepository::All(*this);
+	if (names.empty()) {
+		LogDebug("No filtered names exist in the database...");
+	}
+
+	for (auto& e : names) {
+		ChatChannelList::AddToFilteredNames(e.name);
+	}
+
+	LogInfo("Loaded [{}] filtered channel name(s)", names.size());
+}
+
 bool UCSDatabase::IsChatChannelInDB(const std::string& channel_name)
 {
 	auto r = ChatchannelsRepository::Count(
@@ -362,11 +378,9 @@ bool UCSDatabase::CheckChannelNameFilter(const std::string& channel_name)
 {
 	LogDebug("Checking if [{}] is on the name filter", channel_name);
 
-	// TODO: This should potentially just be pulled into memory at some other point
-	// This if fine for now
-	for (auto &e: NameFilterRepository::All(*this)) {
-		if (Strings::Contains(Strings::ToLower(channel_name), Strings::ToLower(e.name))) {
-			LogInfo("Failed to pass name filter check for [{}] against word [{}]", channel_name, e.name);
+	for (auto &e: ChatChannelList::GetFilteredNames()) {
+		if (Strings::Contains(Strings::ToLower(channel_name), Strings::ToLower(e))) {
+			LogInfo("Failed to pass name filter check for [{}] against word [{}]", channel_name, e);
 			return false;
 		}
 	}

--- a/ucs/database.h
+++ b/ucs/database.h
@@ -45,6 +45,7 @@ public:
 	bool GetVariable(const char* varname, char* varvalue, uint16 varvalue_len);
 	bool LoadChatChannels();
 	void LoadReservedNamesFromDB();
+	void LoadFilteredNamesFromDB();
 	bool IsChatChannelInDB(const std::string& channel_name);
 	bool CheckChannelNameFilter(const std::string& channel_name);
 	void SaveChatChannel(const std::string& channel_name, const std::string& channel_owner, const std::string& channel_password, const uint16& min_status);


### PR DESCRIPTION
What:
These changes are an optimization to the changes introduced in PR #2706: name filters are loaded into memory when the server loads and new channels are compared against these memory values vs hitting the database each time.