### PR TITLE
[Bug Fix] Add omitted function call in UCS.

### DIFF
--- a/ucs/database.cpp
+++ b/ucs/database.cpp
@@ -225,6 +225,7 @@ bool UCSDatabase::GetVariable(const char *varname, char *varvalue, uint16 varval
 
 bool UCSDatabase::LoadChatChannels()
 {
+	LoadFilteredNamesFromDB();
 	LoadReservedNamesFromDB();
 	LogInfo("Loading chat channels from the database");
 


### PR DESCRIPTION
LoadFilteredNamesFromDB() was not being called when channels were loaded.