### PR TITLE
[Bots] Add Virtual Override for Bot::Attack

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -3375,7 +3375,7 @@ void Bot::AI_Process()
 				TEST_COMBATANTS();
 				if (attack_timer.Check()) { // Process primary weapon attacks
 
-					Mob::Attack(tar, EQ::invslot::slotPrimary);
+					Attack(tar, EQ::invslot::slotPrimary);
 
 					TEST_COMBATANTS();
 					TriggerDefensiveProcs(tar, EQ::invslot::slotPrimary, false);
@@ -3389,19 +3389,19 @@ void Bot::AI_Process()
 					if (CanThisClassDoubleAttack()) {
 
 						if (CheckBotDoubleAttack()) {
-							Mob::Attack(tar, EQ::invslot::slotPrimary, true);
+							Attack(tar, EQ::invslot::slotPrimary, true);
 						}
 
 						TEST_COMBATANTS();
 						if (GetSpecialAbility(SPECATK_TRIPLE) && CheckBotDoubleAttack(true)) {
 							// tripleSuccess = true;
-							Mob::Attack(tar, EQ::invslot::slotPrimary, true);
+							Attack(tar, EQ::invslot::slotPrimary, true);
 						}
 
 						TEST_COMBATANTS();
 						// quad attack, does this belong here??
 						if (GetSpecialAbility(SPECATK_QUAD) && CheckBotDoubleAttack(true)) {
-							Mob::Attack(tar, EQ::invslot::slotPrimary, true);
+							Attack(tar, EQ::invslot::slotPrimary, true);
 						}
 					}
 
@@ -3413,10 +3413,10 @@ void Bot::AI_Process()
 						if (zone->random.Int(0, 100) < flurrychance) {
 
 							MessageString(Chat::NPCFlurry, YOU_FLURRY);
-							Mob::Attack(tar, EQ::invslot::slotPrimary, false);
+							Attack(tar, EQ::invslot::slotPrimary, false);
 
 							TEST_COMBATANTS();
-							Mob::Attack(tar, EQ::invslot::slotPrimary, false);
+							Attack(tar, EQ::invslot::slotPrimary, false);
 						}
 					}
 
@@ -3429,7 +3429,7 @@ void Bot::AI_Process()
 						if (p_item && p_item->GetItem()->IsType2HWeapon()) {
 
 							if (zone->random.Int(0, 100) < ExtraAttackChanceBonus) {
-								Mob::Attack(tar, EQ::invslot::slotPrimary, false);
+								Attack(tar, EQ::invslot::slotPrimary, false);
 							}
 						}
 					}
@@ -3467,7 +3467,7 @@ void Bot::AI_Process()
 							float random = zone->random.Real(0, 1);
 							if (random < DualWieldProbability) { // Max 78% of DW
 
-								Mob::Attack(tar, EQ::invslot::slotSecondary);	// Single attack with offhand
+								Attack(tar, EQ::invslot::slotSecondary);	// Single attack with offhand
 
 								TEST_COMBATANTS();
 								TryCombatProcs(s_item, tar, EQ::invslot::slotSecondary);
@@ -3476,7 +3476,7 @@ void Bot::AI_Process()
 								if (CanThisClassDoubleAttack() && CheckBotDoubleAttack()) {
 
 									if (tar->GetHP() > -10) {
-										Mob::Attack(tar, EQ::invslot::slotSecondary);	// Single attack with offhand
+										Attack(tar, EQ::invslot::slotSecondary);	// Single attack with offhand
 									}
 								}
 							}

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -372,6 +372,9 @@ public:
 						uint32* oSpellWillFinish = 0, uint32 item_slot = 0xFFFFFFFF, uint32 aa_id = 0);
 	inline int64 GetFocusEffect(focusType type, uint16 spell_id, Mob *caster = nullptr, bool from_buff_tic = false) override
 		{ return Mob::GetFocusEffect(type, spell_id, caster, from_buff_tic); }
+	inline bool Attack(Mob* other, int Hand = EQ::invslot::slotPrimary, bool FromRiposte = false, bool IsStrikethrough = false,
+		bool IsFromSpell = false, ExtraAttackOptions *opts = nullptr) override
+			{ return Mob::Attack(other, Hand, FromRiposte, IsStrikethrough, IsFromSpell, opts); }
 
 	bool GetBotOwnerDataBuckets();
 	bool GetBotDataBuckets();


### PR DESCRIPTION
**What:**

Adding a Virtual Override to point Bot::Attack to Mob::Attack, 

**Why**

As NPC has a virtual override of Attack, Bots will attempt to use that first if not specified.
This is to prevent anyone from accidentally removing the bot.cpp Mob::Attack() entries thinking they were a mistake. 