### PR TITLE
[Bug Fix] Fix bots equipping augments.

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -4859,6 +4859,10 @@ void Bot::PerformTradeWithClient(int16 begin_slot_id, int16 end_slot_id, Client*
 					continue;
 				}
 
+				if (trade_instance->GetItem()->ItemType == EQ::item::ItemTypeAugmentation) {
+					continue;
+				}
+
 				//if (stage_loop == stageStackable) {
 				//	// TODO: implement
 				//	continue;


### PR DESCRIPTION
# Notes
- Bots didn't check if the item was an augment before equipping, this stops them from equipping them.