### PR TITLE
[Commands] Remove #undyeme Command.

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -333,7 +333,6 @@ int command_init(void)
 		command_add("trapinfo", "Gets infomation about the traps currently spawned in the zone.", AccountStatus::QuestTroupe, command_trapinfo) ||
 		command_add("tune", "Calculate statistical values related to combat.", AccountStatus::GMAdmin, command_tune) ||
 		command_add("undye", "Remove dye from all of your or your target's armor slots", AccountStatus::GMAdmin, command_undye) ||
-		command_add("undyeme", "Remove dye from all of your armor slots", AccountStatus::Player, command_undyeme) ||
 		command_add("unfreeze", "Unfreeze your target", AccountStatus::QuestTroupe, command_unfreeze) ||
 		command_add("unmemspell", "[Spell ID] - Unmemorize a Spell by ID for you or your target", AccountStatus::Guide, command_unmemspell) ||
 		command_add("unmemspells", " Unmemorize all spells for you or your target", AccountStatus::Guide, command_unmemspells) ||
@@ -1169,7 +1168,6 @@ void command_bot(Client *c, const Seperator *sep)
 #include "gm_commands/trapinfo.cpp"
 #include "gm_commands/tune.cpp"
 #include "gm_commands/undye.cpp"
-#include "gm_commands/undyeme.cpp"
 #include "gm_commands/unfreeze.cpp"
 #include "gm_commands/unmemspell.cpp"
 #include "gm_commands/unmemspells.cpp"

--- a/zone/command.h
+++ b/zone/command.h
@@ -284,7 +284,6 @@ void command_traindisc(Client *c, const Seperator *sep);
 void command_trapinfo(Client *c, const Seperator *sep);
 void command_tune(Client *c, const Seperator *sep);
 void command_undye(Client *c, const Seperator *sep);
-void command_undyeme(Client *c, const Seperator *sep);
 void command_unfreeze(Client *c, const Seperator *sep);
 void command_unlock(Client *c, const Seperator *sep);
 void command_unmemspell(Client *c, const Seperator *sep);

--- a/zone/gm_commands/undye.cpp
+++ b/zone/gm_commands/undye.cpp
@@ -3,7 +3,7 @@
 void command_undye(Client *c, const Seperator *sep)
 {
 	auto target = c;
-	if (c->GetTarget() && c->GetTarget()->IsClient()) {
+	if (c->GetTarget() && c->GetTarget()->IsClient() && c->GetGM()) {
 		target = c->GetTarget()->CastToClient();
 	}
 

--- a/zone/gm_commands/undyeme.cpp
+++ b/zone/gm_commands/undyeme.cpp
@@ -1,7 +1,0 @@
-#include "../client.h"
-
-void command_undyeme(Client *c, const Seperator *sep)
-{
-	c->Undye();
-	c->Message(Chat::White, "Undyed armor for yourself.");
-}


### PR DESCRIPTION
# Notes
- Removes redundant `#undyeme` command.
- Adds `GetGM()` check to `#undye` so players can't undye other players.