### PR TITLE
[Commands] #scribespells triggered error on mysql keyword rank

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -5683,11 +5683,11 @@ std::unordered_map<uint32, std::vector<uint16>> Client::LoadSpellGroupCache(uint
 		"SELECT a.spellgroup, a.id, a.rank "
 		"FROM spells_new a "
 		"INNER JOIN ("
-		"SELECT spellgroup, MAX(rank) rank "
+		"SELECT spellgroup, MAX(`rank`) `rank` "
 		"FROM spells_new "
 		"GROUP BY spellgroup) "
 		"b ON a.spellgroup = b.spellgroup AND a.rank = b.rank "
-		"WHERE a.spellgroup IN (SELECT DISTINCT spellgroup FROM spells_new WHERE spellgroup != 0 and classes{} BETWEEN {} AND {}) ORDER BY rank DESC",
+		"WHERE a.spellgroup IN (SELECT DISTINCT spellgroup FROM spells_new WHERE spellgroup != 0 and classes{} BETWEEN {} AND {}) ORDER BY `rank` DESC",
 		m_pp.class_, min_level, max_level
 	);
 


### PR DESCRIPTION
#scribespells was causing errors on my server (using mySQL) due to using the keywork rank.

![image](https://user-images.githubusercontent.com/8644833/213885820-ae0d9e42-ebd6-4c44-b8f4-40f5ed4bf6c5.png)

escaping the keyword fixed the problem and #scribespells works for me.

Can someone vouch for MariaDB with this fix?