### PR TITLE
[Bug Fix] Fix botgrouplist to display unique entries.

### DIFF
--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -7192,7 +7192,13 @@ void bot_subcommand_botgroup_add_member(Client *c, const Seperator *sep)
 	std::list<Bot*> sbl;
 	MyBots::PopulateSBL_ByNamedBot(c, sbl, sep->arg[1]);
 	if (sbl.empty()) {
-		c->Message(Chat::White, "You must name a new member as a bot that you own to use this command.");
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"Usage: (<target_leader>) {} [member_name]",
+				sep->arg[0]
+			).c_str()
+		);
 		return;
 	}
 

--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -2624,7 +2624,7 @@ bool BotDatabase::LoadBotGroupsListByOwnerID(const uint32 owner_id, std::list<st
 
 
 	query = fmt::format(
-		"SELECT group_name, group_leader_id FROM "
+		"SELECT DISTINCT(group_name), group_leader_id FROM "
 		"bot_groups bg INNER JOIN bot_group_members bgm "
 		"ON bg.groups_index = bgm.groups_index "
 		"WHERE bgm.bot_id IN "


### PR DESCRIPTION
Was displaying Group name per Bot, instead of unique Bot Group Name.