### PR TITLE
[Bug Fix] Remove duplicate logic in GetActSpellHealing reducing HOT criticals

### DIFF
--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -437,8 +437,7 @@ int64 Mob::GetActSpellHealing(uint16 spell_id, int64 value, Mob* target, bool fr
 			}
 		}
 
-		if (critical_chance && zone->random.Roll(critical_chance))
-			value *= critical_modifier;
+		value *= critical_modifier;
 	}
 
 	if (IsNPC() && CastToNPC()->GetHealScale()) {


### PR DESCRIPTION
# Notes
- Removes duplicate critical chance roll in `Mob::GetActSpellHealing`.
- Not sure if this was Live-like or an oversight, but it seems to drastically reduce the possibility of a HOT getting a critical.
- A 1% chance becomes a 0.01% chance being we have to roll twice.