### PR TITLE
[Crash] Fix rarer world crash issue where scheduler database was not available

### DIFF
--- a/common/server_event_scheduler.cpp
+++ b/common/server_event_scheduler.cpp
@@ -143,6 +143,10 @@ bool ServerEventScheduler::ValidateDatabaseConnection()
 // this helps inform decisions to tell all zones to reload their events
 bool ServerEventScheduler::CheckIfEventsChanged()
 {
+	if (!m_database) {
+		return false;
+	}
+
 	auto events = ServerScheduledEventsRepository::GetWhere(*m_database, "deleted_at is null");
 
 	// first check if the size changed, if it did this is the easiest step


### PR DESCRIPTION
Found in a crash report linked below

http://spire.akkadius.com/dev/release/22.1.1?id=8