### PR TITLE
[Bug Fix] Fix nullptr spell in BCSpells::Load() 

### DIFF
--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -130,7 +130,10 @@ public:
 				continue;
 			}
 
-			if (spells[spell_id].target_type != ST_Target && spells[spell_id].cast_restriction != 0) { // watch
+			if (
+				spells[spell_id].target_type != ST_Target &&
+				spells[spell_id].cast_restriction != 0
+			) {
 				continue;
 			}
 

--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -122,10 +122,17 @@ public:
 		}
 
 		for (int spell_id = 2; spell_id < SPDAT_RECORDS; ++spell_id) {
-			if (spells[spell_id].player_1[0] == '\0')
+			if (!IsValidSpell(spell_id)) {
 				continue;
-			if (spells[spell_id].target_type != ST_Target && spells[spell_id].cast_restriction != 0) // watch
+			}
+
+			if (spells[spell_id].player_1[0] == '\0') {
 				continue;
+			}
+
+			if (spells[spell_id].target_type != ST_Target && spells[spell_id].cast_restriction != 0) { // watch
+				continue;
+			}
 
 			auto target_type = BCEnum::TT_None;
 			switch (spells[spell_id].target_type) {


### PR DESCRIPTION
# Notes
- Fix possible `nullptr` where we didn't check if spell was valid before using it.