### PR TITLE
[Quest API] Add LDoN Methods to Perl/Lua

### DIFF
--- a/zone/lua_npc.cpp
+++ b/zone/lua_npc.cpp
@@ -701,6 +701,66 @@ void Lua_NPC::SetKeepsSoldItems(bool keeps_sold_items) {
 	self->SetKeepsSoldItems(keeps_sold_items);
 }
 
+bool Lua_NPC::IsLDoNTrapped() {
+	Lua_Safe_Call_Bool();
+	return self->IsLDoNTrapped();
+}
+
+void Lua_NPC::SetLDoNTrapped(bool is_trapped) {
+	Lua_Safe_Call_Void();
+	self->SetLDoNTrapped(is_trapped);
+}
+
+uint8 Lua_NPC::GetLDoNTrapType() {
+	Lua_Safe_Call_Int();
+	return self->GetLDoNTrapType();
+}
+
+void Lua_NPC::SetLDoNTrapType(uint8 trap_type) {
+	Lua_Safe_Call_Void();
+	self->SetLDoNTrapType(trap_type);
+}
+
+uint16 Lua_NPC::GetLDoNTrapSpellID() {
+	Lua_Safe_Call_Int();
+	return self->GetLDoNTrapSpellID();
+}
+
+void Lua_NPC::SetLDoNTrapSpellID(uint16 spell_id) {
+	Lua_Safe_Call_Void();
+	self->SetLDoNTrapSpellID(spell_id);
+}
+
+bool Lua_NPC::IsLDoNLocked() {
+	Lua_Safe_Call_Bool();
+	return self->IsLDoNLocked();
+}
+
+void Lua_NPC::SetLDoNLocked(bool is_locked) {
+	Lua_Safe_Call_Void();
+	self->SetLDoNLocked(is_locked);
+}
+
+uint16 Lua_NPC::GetLDoNLockedSkill() {
+	Lua_Safe_Call_Int();
+	return self->GetLDoNLockedSkill();
+}
+
+void Lua_NPC::SetLDoNLockedSkill(uint16 skill_value) {
+	Lua_Safe_Call_Void();
+	self->SetLDoNLockedSkill(skill_value);
+}
+
+bool Lua_NPC::IsLDoNTrapDetected() {
+	Lua_Safe_Call_Bool();
+	return self->IsLDoNTrapDetected();
+}
+
+void Lua_NPC::SetLDoNTrapDetected(bool is_detected) {
+	Lua_Safe_Call_Void();
+	self->SetLDoNTrapDetected(is_detected);
+}
+
 luabind::scope lua_register_npc() {
 	return luabind::class_<Lua_NPC, Lua_Mob>("NPC")
 	.def(luabind::constructor<>())
@@ -753,6 +813,9 @@ luabind::scope lua_register_npc() {
 	.def("GetMaxDamage", (uint32(Lua_NPC::*)(int))&Lua_NPC::GetMaxDamage)
 	.def("GetMaxWp", (int(Lua_NPC::*)(void))&Lua_NPC::GetMaxWp)
 	.def("GetMinDMG", (uint32(Lua_NPC::*)(void))&Lua_NPC::GetMinDMG)
+	.def("GetLDoNLockedSkill", (uint16(Lua_NPC::*)(void))&Lua_NPC::GetLDoNLockedSkill)
+	.def("GetLDoNTrapType", (uint8(Lua_NPC::*)(void))&Lua_NPC::GetLDoNTrapType)
+	.def("GetLDoNTrapSpellID", (uint16(Lua_NPC::*)(void))&Lua_NPC::GetLDoNTrapSpellID)
 	.def("GetNPCFactionID", (int(Lua_NPC::*)(void))&Lua_NPC::GetNPCFactionID)
 	.def("GetNPCHate", (int64(Lua_NPC::*)(Lua_Mob))&Lua_NPC::GetNPCHate)
 	.def("GetNPCSpellsID", (int(Lua_NPC::*)(void))&Lua_NPC::GetNPCSpellsID)
@@ -784,6 +847,9 @@ luabind::scope lua_register_npc() {
 	.def("HasItem", (bool(Lua_NPC::*)(uint32))&Lua_NPC::HasItem)
 	.def("IsAnimal", (bool(Lua_NPC::*)(void))&Lua_NPC::IsAnimal)
 	.def("IsGuarding", (bool(Lua_NPC::*)(void))&Lua_NPC::IsGuarding)
+	.def("IsLDoNLocked", (bool(Lua_NPC::*)(void))&Lua_NPC::IsLDoNLocked)
+	.def("IsLDoNTrapped", (bool(Lua_NPC::*)(void))&Lua_NPC::IsLDoNTrapped)
+	.def("IsLDoNTrapDetected", (bool(Lua_NPC::*)(void))&Lua_NPC::IsLDoNTrapDetected)
 	.def("IsOnHatelist", (bool(Lua_NPC::*)(Lua_Mob))&Lua_NPC::IsOnHatelist)
 	.def("IsRaidTarget", (bool(Lua_NPC::*)(void))&Lua_NPC::IsRaidTarget)
 	.def("IsRareSpawn", (bool(Lua_NPC::*)(void))&Lua_NPC::IsRareSpawn)
@@ -817,6 +883,12 @@ luabind::scope lua_register_npc() {
 	.def("SetGold", (void(Lua_NPC::*)(uint32))&Lua_NPC::SetGold)
 	.def("SetGrid", (void(Lua_NPC::*)(int))&Lua_NPC::SetGrid)
 	.def("SetKeepsSoldItems", (void(Lua_NPC::*)(bool))&Lua_NPC::SetKeepsSoldItems)
+	.def("SetLDoNLocked", (void(Lua_NPC::*)(bool))&Lua_NPC::SetLDoNLocked)
+	.def("SetLDoNLockedSkill", (void(Lua_NPC::*)(uint16))&Lua_NPC::SetLDoNLockedSkill)
+	.def("SetLDoNTrapped", (void(Lua_NPC::*)(bool))&Lua_NPC::SetLDoNTrapped)
+	.def("SetLDoNTrapDetected", (void(Lua_NPC::*)(bool))&Lua_NPC::SetLDoNTrapDetected)
+	.def("SetLDoNTrapSpellID", (void(Lua_NPC::*)(uint16))&Lua_NPC::SetLDoNTrapSpellID)
+	.def("SetLDoNTrapType", (void(Lua_NPC::*)(uint8))&Lua_NPC::SetLDoNTrapType)
 	.def("SetNPCFactionID", (void(Lua_NPC::*)(int))&Lua_NPC::SetNPCFactionID)
 	.def("SetPetSpellID", (void(Lua_NPC::*)(int))&Lua_NPC::SetPetSpellID)
 	.def("SetPlatinum", (void(Lua_NPC::*)(uint32))&Lua_NPC::SetPlatinum)

--- a/zone/lua_npc.h
+++ b/zone/lua_npc.h
@@ -161,6 +161,18 @@ public:
 	void SendPayload(int payload_id, std::string payload_value);
 	bool GetKeepsSoldItems();
 	void SetKeepsSoldItems(bool keeps_sold_items);
+	bool IsLDoNTrapped();
+	void SetLDoNTrapped(bool is_trapped);
+	uint8 GetLDoNTrapType();
+	void SetLDoNTrapType(uint8 trap_type);
+	uint16 GetLDoNTrapSpellID();
+	void SetLDoNTrapSpellID(uint16 spell_id);
+	bool IsLDoNLocked();
+	void SetLDoNLocked(bool is_locked);
+	uint16 GetLDoNLockedSkill();
+	void SetLDoNLockedSkill(uint16 skill_value);
+	bool IsLDoNTrapDetected();
+	void SetLDoNTrapDetected(bool is_detected);
 };
 
 #endif

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -371,16 +371,16 @@ NPC::NPC(const NPCType *npc_type_data, Spawn2 *in_respawn, const glm::vec4 &posi
 		}
 	}
 
-	ldon_trapped       = false;
-	ldon_trap_type     = 0;
-	ldon_spell_id      = 0;
-	ldon_locked        = false;
-	ldon_locked_skill  = 0;
-	ldon_trap_detected = false;
+	SetLDoNTrapped(false);
+	SetLDoNTrapType(0);
+	SetLDoNTrapSpellID(0);
+	SetLDoNLocked(false);
+	SetLDoNLockedSkill(0);
+	SetLDoNTrapDetected(false);
 
 	if (npc_type_data->trap_template > 0) {
 		std::map<uint32, std::list<LDoNTrapTemplate *> >::iterator trap_ent_iter;
-		std::list<LDoNTrapTemplate *>                              trap_list;
+		std::list<LDoNTrapTemplate *> trap_list;
 
 		trap_ent_iter = zone->ldon_trap_entry_list.find(npc_type_data->trap_template);
 		if (trap_ent_iter != zone->ldon_trap_entry_list.end()) {
@@ -390,26 +390,25 @@ NPC::NPC(const NPCType *npc_type_data, Spawn2 *in_respawn, const glm::vec4 &posi
 				std::advance(trap_list_iter, zone->random.Int(0, trap_list.size() - 1));
 				LDoNTrapTemplate *trap_template = (*trap_list_iter);
 				if (trap_template) {
-					if ((uint8) trap_template->spell_id > 0) {
-						ldon_trapped  = true;
-						ldon_spell_id = trap_template->spell_id;
-					}
-					else {
-						ldon_trapped  = false;
-						ldon_spell_id = 0;
+					if (trap_template->spell_id > 0) {
+						SetLDoNTrapped(true);
+						SetLDoNTrapSpellID(trap_template->spell_id);
+					} else {
+						SetLDoNTrapped(false);
+						SetLDoNTrapSpellID(0);
 					}
 
-					ldon_trap_type     = (uint8) trap_template->type;
+					SetLDoNTrapType(static_cast<uint8>(trap_template->type));
+
 					if (trap_template->locked > 0) {
-						ldon_locked       = true;
-						ldon_locked_skill = trap_template->skill;
-					}
-					else {
-						ldon_locked       = false;
-						ldon_locked_skill = 0;
+						SetLDoNLocked(true);
+						SetLDoNLockedSkill(trap_template->skill);
+					} else {
+						SetLDoNLocked(false);
+						SetLDoNLockedSkill(0);
 					}
 
-					ldon_trap_detected = 0;
+					SetLDoNTrapDetected(false);
 				}
 			}
 		}

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -119,7 +119,7 @@ public:
 	virtual void Damage(Mob* from, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, bool avoidable = true, int8 buffslot = -1, bool iBuffTic = false, eSpecialAttacks special = eSpecialAttacks::None);
 	bool Attack(Mob* other, int Hand = EQ::invslot::slotPrimary, bool FromRiposte = false, bool IsStrikethrough = false,
 		bool IsFromSpell = false, ExtraAttackOptions *opts = nullptr) override;
-	virtual bool HasRaid() { return false; } 
+	virtual bool HasRaid() { return false; }
 	virtual bool HasGroup() { return false; }
 	virtual Raid* GetRaid() { return 0; }
 	virtual Group* GetGroup() { return 0; }
@@ -413,22 +413,22 @@ public:
 	void	ModifyNPCStat(std::string stat, std::string value);
 	virtual void SetLevel(uint8 in_level, bool command = false);
 
-	bool IsLDoNTrapped() const { return (ldon_trapped); }
+	bool IsLDoNTrapped() const { return ldon_trapped; }
 	void SetLDoNTrapped(bool n) { ldon_trapped = n; }
 
-	uint8 GetLDoNTrapType() const { return (ldon_trap_type); }
+	uint8 GetLDoNTrapType() const { return ldon_trap_type; }
 	void SetLDoNTrapType(uint8 n) { ldon_trap_type = n; }
 
-	uint16 GetLDoNTrapSpellID() const { return (ldon_spell_id); }
+	uint16 GetLDoNTrapSpellID() const { return ldon_spell_id; }
 	void SetLDoNTrapSpellID(uint16 n) { ldon_spell_id = n; }
 
-	bool IsLDoNLocked() const { return (ldon_locked); }
+	bool IsLDoNLocked() const { return ldon_locked; }
 	void SetLDoNLocked(bool n) { ldon_locked = n; }
 
-	uint16 GetLDoNLockedSkill() const { return (ldon_locked_skill); }
+	uint16 GetLDoNLockedSkill() const { return ldon_locked_skill; }
 	void SetLDoNLockedSkill(uint16 n) { ldon_locked_skill = n; }
 
-	bool IsLDoNTrapDetected() const { return (ldon_trap_detected); }
+	bool IsLDoNTrapDetected() const { return ldon_trap_detected; }
 	void SetLDoNTrapDetected(bool n) { ldon_trap_detected = n; }
 
 	const bool GetCombatEvent() const { return combat_event; }

--- a/zone/perl_npc.cpp
+++ b/zone/perl_npc.cpp
@@ -690,6 +690,66 @@ void Perl_NPC_SetKeepsSoldItems(NPC* self, bool keeps_sold_items)
 	self->SetKeepsSoldItems(keeps_sold_items);
 }
 
+bool Perl_NPC_IsLDoNTrapped(NPC* self)
+{
+	return self->IsLDoNTrapped();
+}
+
+void Perl_NPC_SetLDoNTrapped(NPC* self, bool is_trapped)
+{
+	self->SetLDoNTrapped(is_trapped);
+}
+
+uint8 Perl_NPC_GetLDoNTrapType(NPC* self)
+{
+	return self->GetLDoNTrapType();
+}
+
+void Perl_NPC_SetLDoNTrapType(NPC* self, uint8 trap_type)
+{
+	self->SetLDoNTrapType(trap_type);
+}
+
+uint16 Perl_NPC_GetLDoNTrapSpellID(NPC* self)
+{
+	return self->GetLDoNTrapSpellID();
+}
+
+void Perl_NPC_SetLDoNTrapSpellID(NPC* self, uint16 spell_id)
+{
+	self->SetLDoNTrapSpellID(spell_id);
+}
+
+bool Perl_NPC_IsLDoNLocked(NPC* self)
+{
+	return self->IsLDoNLocked();
+}
+
+void Perl_NPC_SetLDoNLocked(NPC* self, bool is_locked)
+{
+	self->SetLDoNLocked(is_locked);
+}
+
+uint16 Perl_NPC_GetLDoNLockedSkill(NPC* self)
+{
+	return self->GetLDoNLockedSkill();
+}
+
+void Perl_NPC_SetLDoNLockedSkill(NPC* self, uint16 skill_value)
+{
+	self->SetLDoNLockedSkill(skill_value);
+}
+
+bool Perl_NPC_IsLDoNTrapDetected(NPC* self)
+{
+	return self->IsLDoNTrapDetected();
+}
+
+void Perl_NPC_SetLDoNTrapDetected(NPC* self, bool is_detected)
+{
+	self->SetLDoNTrapDetected(is_detected);
+}
+
 void perl_register_npc()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -742,6 +802,9 @@ void perl_register_npc()
 	package.add("GetHealScale", &Perl_NPC_GetHealScale);
 	package.add("GetItemIDBySlot", &Perl_NPC_GetItemIDBySlot);
 	package.add("GetKeepsSoldItems", &Perl_NPC_GetKeepsSoldItems);
+	package.add("GetLDoNLockedSkill", &Perl_NPC_GetLDoNLockedSkill);
+	package.add("GetLDoNTrapType", &Perl_NPC_GetLDoNTrapType);
+	package.add("GetLDoNTrapSpellID", &Perl_NPC_GetLDoNTrapSpellID);
 	package.add("GetLootList", &Perl_NPC_GetLootList);
 	package.add("GetLoottableID", &Perl_NPC_GetLoottableID);
 	package.add("GetMaxDMG", &Perl_NPC_GetMaxDMG);
@@ -777,6 +840,9 @@ void perl_register_npc()
 	package.add("HasItem", &Perl_NPC_HasItem);
 	package.add("IsAnimal", &Perl_NPC_IsAnimal);
 	package.add("IsGuarding", &Perl_NPC_IsGuarding);
+	package.add("IsLDoNLocked", &Perl_NPC_IsLDoNLocked);
+	package.add("IsLDoNTrapped", &Perl_NPC_IsLDoNTrapped);
+	package.add("IsLDoNTrapDetected", &Perl_NPC_IsLDoNTrapDetected);;
 	package.add("IsOnHatelist", &Perl_NPC_IsOnHatelist);
 	package.add("IsRaidTarget", &Perl_NPC_IsRaidTarget);
 	package.add("IsRareSpawn", &Perl_NPC_IsRareSpawn);
@@ -811,6 +877,12 @@ void perl_register_npc()
 	package.add("SendPayload", (void(*)(NPC*, int, std::string))&Perl_NPC_SendPayload);
 	package.add("SetCopper", &Perl_NPC_SetCopper);
 	package.add("SetKeepsSoldItems", &Perl_NPC_SetKeepsSoldItems);
+	package.add("SetLDoNLocked", &Perl_NPC_SetLDoNLocked);
+	package.add("SetLDoNLockedSkill", &Perl_NPC_SetLDoNLockedSkill);
+	package.add("SetLDoNTrapped", &Perl_NPC_SetLDoNTrapped);
+	package.add("SetLDoNTrapDetected", &Perl_NPC_SetLDoNTrapDetected);
+	package.add("SetLDoNTrapSpellID", &Perl_NPC_SetLDoNTrapSpellID);
+	package.add("SetLDoNTrapType", &Perl_NPC_SetLDoNTrapType);
 	package.add("SetGold", &Perl_NPC_SetGold);
 	package.add("SetGrid", &Perl_NPC_SetGrid);
 	package.add("SetNPCFactionID", &Perl_NPC_SetNPCFactionID);


### PR DESCRIPTION
# Perl
- Add `$npc->GetLDoNLockedSkill()`.
- Add `$npc->GetLDoNTrapType()`.
- Add `$npc->GetLDoNTrapSpellID()`.
- Add `$npc->IsLDoNLocked()`.
- Add `$npc->IsLDoNTrapped()`.
- Add `$npc->IsLDoNTrapDetected()`.
- Add `$npc->SetLDoNLocked(is_locked)`.
- Add `$npc->SetLDoNLockedSkill(skill_value)`.
- Add `$npc->SetLDoNTrapped(is_trapped)`.
- Add `$npc->SetLDoNTrapDetected(is_detected)`.
- Add `$npc->SetLDoNTrapSpellID(spell_id)`.
- Add `$npc->SetLDoNTrapType(trap_type)`.

# Lua
- Add `npc:GetLDoNLockedSkill()`.
- Add `npc:GetLDoNTrapType()`.
- Add `npc:GetLDoNTrapSpellID()`.
- Add `npc:IsLDoNLocked()`.
- Add `npc:IsLDoNTrapped()`.
- Add `npc:IsLDoNTrapDetected()`.
- Add `npc:SetLDoNLocked(is_locked)`.
- Add `npc:SetLDoNLockedSkill(skill_value)`.
- Add `npc:SetLDoNTrapped(is_trapped)`.
- Add `npc:SetLDoNTrapDetected(is_detected)`.
- Add `npc:SetLDoNTrapSpellID(spell_id)`.
- Add `npc:SetLDoNTrapType(trap_type)`.

# Notes
- Adds these methods to allow LDoN traps to be set by a script.