### PR TITLE
[Bug Fix] Resolve issue with max buff count being 25 in ROF2.

### DIFF
--- a/common/eq_packet_structs.h
+++ b/common/eq_packet_structs.h
@@ -29,7 +29,7 @@
 #include "textures.h"
 
 
-static const uint32 BUFF_COUNT = 25;
+static const uint32 BUFF_COUNT = 42;
 static const uint32 PET_BUFF_COUNT = 30;
 static const uint32 MAX_MERC = 100;
 static const uint32 MAX_MERC_GRADES = 10;


### PR DESCRIPTION
# Notes
- This allows ROF2 to properly utilize their max buff count.
- May cause issues with older clients.