### PR TITLE
[Bug Fix] Fixing % based mob see invis

### DIFF
--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -2094,7 +2094,7 @@ const NPCType *ZoneDatabase::LoadNPCTypesData(uint32 npc_type_id, bool bulk_load
 			}
 		}
 
-		t->see_invis        = n.see_invis != 0;
+		t->see_invis        = n.see_invis;
 		t->see_invis_undead = n.see_invis_undead != 0;    // Set see_invis_undead flag
 
 		if (!RuleB(NPC, DisableLastNames) && !n.lastname.empty()) {


### PR DESCRIPTION
# Notes

This bug was preventing anything other than 0 or 1 to be passed to see_invis, but per the current design, see_invis can be anything from 0 to 25499, which can give you level 254 invis. See design notes in Mob::GetSeeInvisibleLevelFromNPCStat.