### PR TITLE
[Quest API] Cleanup string copies and push_backs.

### DIFF
--- a/eqlaunch/zone_launch.cpp
+++ b/eqlaunch/zone_launch.cpp
@@ -65,12 +65,12 @@ void ZoneLaunch::Start() {
 
 	if(m_port) {
 		std::string arg = m_zone + std::string(":") + std::to_string(m_port);
-		spec->args.push_back(arg);
+		spec->args.emplace_back(arg);
 	} else {
-		spec->args.push_back(m_zone);
+		spec->args.emplace_back(m_zone);
 	}
 
-	spec->args.push_back(m_launcherName);
+	spec->args.emplace_back(m_launcherName);
 	spec->handler = this;
 	spec->logFile = m_config->LogPrefix + m_zone + m_config->LogSuffix;
 

--- a/world/eqw_parser.cpp
+++ b/world/eqw_parser.cpp
@@ -218,8 +218,8 @@ EQWParser::~EQWParser() {
 bool EQWParser::eval_file(const char * packagename, const char * filename, std::string &error)
 {
 	std::vector<std::string> args;
-	args.push_back(packagename);
-	args.push_back(filename);
+	args.emplace_back(packagename);
+	args.emplace_back(filename);
 	return(dosub("eval_file", args, error));
 }
 

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2788,7 +2788,7 @@ bool NPC::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillTy
 	combat_record.Stop();
 
 	/* Zone controller process EVENT_DEATH_ZONE (Death events) */
-	args.push_back(this);
+	args.emplace_back(this);
 	DispatchZoneControllerEvent(EVENT_DEATH_ZONE, oos, export_string, 0, &args);
 
 	return true;
@@ -3881,7 +3881,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 			if (IsBot() && has_bot_taken_event) {
 				parse->EventBot(EVENT_DAMAGE_TAKEN, CastToBot(), attacker ? attacker : nullptr, export_string, 0);
 			} else if (IsClient() && has_player_taken_event) {
-				args.push_back(attacker ? attacker : nullptr);
+				args.emplace_back(attacker ? attacker : nullptr);
 				parse->EventPlayer(EVENT_DAMAGE_TAKEN, CastToClient(), export_string, 0, &args);
 			} else if (IsNPC() && has_npc_taken_event) {
 				parse->EventNPC(EVENT_DAMAGE_TAKEN, CastToNPC(), attacker ? attacker : nullptr, export_string, 0);
@@ -3905,7 +3905,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 			if (attacker->IsBot() && has_bot_given_event) {
 				parse->EventBot(EVENT_DAMAGE_GIVEN, attacker->CastToBot(), this, export_string, 0);
 			} else if (attacker->IsClient() && has_player_given_event) {
-				args.push_back(this);
+				args.emplace_back(this);
 				parse->EventPlayer(EVENT_DAMAGE_GIVEN, attacker->CastToClient(), export_string, 0, &args);
 			} else if (attacker->IsNPC() && has_npc_given_event) {
 				parse->EventNPC(EVENT_DAMAGE_GIVEN, attacker->CastToNPC(), this, export_string, 0);

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -468,7 +468,7 @@ int Client::HandlePacket(const EQApplicationPacket *app)
 		if (ConnectingOpcodes.count(opcode) != 1) {
 			//Hate const cast but everything in lua needs to be non-const even if i make it non-mutable
 			std::vector<std::any> args;
-			args.push_back(const_cast<EQApplicationPacket*>(app));
+			args.emplace_back(const_cast<EQApplicationPacket*>(app));
 			parse->EventPlayer(EVENT_UNHANDLED_OPCODE, this, "", 1, &args);
 
 			break;
@@ -492,7 +492,7 @@ int Client::HandlePacket(const EQApplicationPacket *app)
 		p = ConnectedOpcodes[opcode];
 		if (p == nullptr) {
 			std::vector<std::any> args;
-			args.push_back(const_cast<EQApplicationPacket*>(app));
+			args.emplace_back(const_cast<EQApplicationPacket*>(app));
 			parse->EventPlayer(EVENT_UNHANDLED_OPCODE, this, "", 0, &args);
 
 			break;
@@ -3092,11 +3092,11 @@ void Client::Handle_OP_AugmentItem(const EQApplicationPacket *app)
 							CalcBonuses();
 
 							std::vector<std::any> args;
-							args.push_back(old_aug);
+							args.emplace_back(old_aug);
 							parse->EventItem(EVENT_UNAUGMENT_ITEM, this, tobe_auged, nullptr, "", in_augment->augment_index, &args);
 
 							args.assign(1, tobe_auged);
-							args.push_back(false);
+							args.emplace_back(false);
 							parse->EventItem(EVENT_AUGMENT_REMOVE, this, old_aug, nullptr, "", in_augment->augment_index, &args);
 
 							const auto export_string = fmt::format(
@@ -3108,7 +3108,7 @@ void Client::Handle_OP_AugmentItem(const EQApplicationPacket *app)
 								false
 							);
 
-							args.push_back(old_aug);
+							args.emplace_back(old_aug);
 
 							parse->EventPlayer(EVENT_AUGMENT_REMOVE_CLIENT, this, export_string, 0, &args);
 						}
@@ -3119,13 +3119,13 @@ void Client::Handle_OP_AugmentItem(const EQApplicationPacket *app)
 						aug = tobe_auged->GetAugment(in_augment->augment_index);
 						if (aug) {
 							std::vector<std::any> args;
-							args.push_back(aug);
+							args.emplace_back(aug);
 							parse->EventItem(EVENT_AUGMENT_ITEM, this, tobe_auged, nullptr, "", in_augment->augment_index, &args);
 
 							args.assign(1, tobe_auged);
 							parse->EventItem(EVENT_AUGMENT_INSERT, this, aug, nullptr, "", in_augment->augment_index, &args);
 
-							args.push_back(aug);
+							args.emplace_back(aug);
 
 							const auto export_string = fmt::format(
 								"{} {} {} {}",
@@ -3187,14 +3187,14 @@ void Client::Handle_OP_AugmentItem(const EQApplicationPacket *app)
 				aug = tobe_auged->GetAugment(in_augment->augment_index);
 				if (aug) {
 					std::vector<std::any> args;
-					args.push_back(aug);
+					args.emplace_back(aug);
 					parse->EventItem(EVENT_UNAUGMENT_ITEM, this, tobe_auged, nullptr, "", in_augment->augment_index, &args);
 
 					args.assign(1, tobe_auged);
-					args.push_back(false);
+					args.emplace_back(false);
 					parse->EventItem(EVENT_AUGMENT_REMOVE, this, aug, nullptr, "", in_augment->augment_index, &args);
 
-					args.push_back(aug);
+					args.emplace_back(aug);
 
 					const auto export_string = fmt::format(
 						"{} {} {} {} {}",
@@ -3251,14 +3251,14 @@ void Client::Handle_OP_AugmentItem(const EQApplicationPacket *app)
 				aug = tobe_auged->GetAugment(in_augment->augment_index);
 				if (aug) {
 					std::vector<std::any> args;
-					args.push_back(aug);
+					args.emplace_back(aug);
 					parse->EventItem(EVENT_UNAUGMENT_ITEM, this, tobe_auged, nullptr, "", in_augment->augment_index, &args);
 
 					args.assign(1, tobe_auged);
-					args.push_back(true);
+					args.emplace_back(true);
 					parse->EventItem(EVENT_AUGMENT_REMOVE, this, aug, nullptr, "", in_augment->augment_index, &args);
 
-					args.push_back(aug);
+					args.emplace_back(aug);
 
 					const auto export_string = fmt::format(
 						"{} {} {} {} {}",
@@ -4359,7 +4359,7 @@ void Client::Handle_OP_ClickDoor(const EQApplicationPacket *app)
 
 	std::string export_string = fmt::format("{}", cd->doorid);
 	std::vector<std::any> args;
-	args.push_back(currentdoor);
+	args.emplace_back(currentdoor);
 	if (parse->EventPlayer(EVENT_CLICK_DOOR, this, export_string, 0, &args) == 0)
 	{
 		currentdoor->HandleClick(this, 0);
@@ -4382,7 +4382,7 @@ void Client::Handle_OP_ClickObject(const EQApplicationPacket *app)
 		object->HandleClick(this, click_object);
 
 		std::vector<std::any> args;
-		args.push_back(object);
+		args.emplace_back(object);
 
 		std::string export_string = fmt::format("{}", click_object->drop_id);
 		parse->EventPlayer(EVENT_CLICK_OBJECT, this, export_string, GetID(), &args);

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -1427,8 +1427,8 @@ void Corpse::LootItem(Client *client, const EQApplicationPacket *app)
 			GetID()
 		);
 		std::vector<std::any> args;
-		args.push_back(inst);
-		args.push_back(this);
+		args.emplace_back(inst);
+		args.emplace_back(this);
 		bool prevent_loot = false;
 		if (RuleB(Zone, UseZoneController)) {
 			auto controller = entity_list.GetNPCByNPCTypeID(ZONE_CONTROLLER_NPC_ID);

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -361,7 +361,7 @@ int PerlembParser::EventCommon(
 }
 
 int PerlembParser::EventNPC(
-	QuestEventID evt, NPC *npc, Mob *mob, std::string data, uint32 extra_data,
+	QuestEventID evt, NPC *npc, Mob *mob, const std::string& data, uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 )
 {
@@ -369,7 +369,7 @@ int PerlembParser::EventNPC(
 }
 
 int PerlembParser::EventGlobalNPC(
-	QuestEventID evt, NPC *npc, Mob *mob, std::string data, uint32 extra_data,
+	QuestEventID evt, NPC *npc, Mob *mob, const std::string& data, uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 )
 {
@@ -377,7 +377,7 @@ int PerlembParser::EventGlobalNPC(
 }
 
 int PerlembParser::EventPlayer(
-	QuestEventID evt, Client *client, std::string data, uint32 extra_data,
+	QuestEventID evt, Client *client, const std::string& data, uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 )
 {
@@ -385,7 +385,7 @@ int PerlembParser::EventPlayer(
 }
 
 int PerlembParser::EventGlobalPlayer(
-	QuestEventID evt, Client *client, std::string data, uint32 extra_data,
+	QuestEventID evt, Client *client, const std::string& data, uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 )
 {
@@ -393,7 +393,7 @@ int PerlembParser::EventGlobalPlayer(
 }
 
 int PerlembParser::EventItem(
-	QuestEventID evt, Client *client, EQ::ItemInstance *item, Mob *mob, std::string data, uint32 extra_data,
+	QuestEventID evt, Client *client, EQ::ItemInstance *item, Mob *mob, const std::string& data, uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 )
 {
@@ -402,7 +402,7 @@ int PerlembParser::EventItem(
 }
 
 int PerlembParser::EventSpell(
-	QuestEventID evt, Mob *mob, Client *client, uint32 spell_id, std::string data, uint32 extra_data,
+	QuestEventID evt, Mob *mob, Client *client, uint32 spell_id, const std::string& data, uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 )
 {
@@ -2152,7 +2152,7 @@ int PerlembParser::EventBot(
 	QuestEventID evt,
 	Bot *bot,
 	Mob *mob,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -2163,7 +2163,7 @@ int PerlembParser::EventGlobalBot(
 	QuestEventID evt,
 	Bot *bot,
 	Mob *mob,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {

--- a/zone/embparser.h
+++ b/zone/embparser.h
@@ -52,7 +52,7 @@ public:
 		QuestEventID evt,
 		NPC* npc,
 		Mob *init,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	);
@@ -60,21 +60,21 @@ public:
 		QuestEventID evt,
 		NPC* npc,
 		Mob *init,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	);
 	virtual int EventPlayer(
 		QuestEventID evt,
 		Client *client,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	);
 	virtual int EventGlobalPlayer(
 		QuestEventID evt,
 		Client *client,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	);
@@ -83,7 +83,7 @@ public:
 		Client *client,
 		EQ::ItemInstance *item,
 		Mob *mob,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	);
@@ -92,7 +92,7 @@ public:
 		Mob* mob,
 		Client *client,
 		uint32 spell_id,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	);
@@ -100,7 +100,7 @@ public:
 		QuestEventID evt,
 		Bot *bot,
 		Mob *init,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	);
@@ -108,7 +108,7 @@ public:
 		QuestEventID evt,
 		Bot *bot,
 		Mob *init,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	);

--- a/zone/embperl.cpp
+++ b/zone/embperl.cpp
@@ -230,8 +230,8 @@ void Embperl::init_eval_file(void)
 int Embperl::eval_file(const char * packagename, const char * filename)
 {
 	std::vector<std::string> args;
-	args.push_back(packagename);
-	args.push_back(filename);
+	args.emplace_back(packagename);
+	args.emplace_back(filename);
 
 	return dosub("main::eval_file", &args);
 }

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -1784,8 +1784,8 @@ void EntityList::DuelMessage(Mob *winner, Mob *loser, bool flee)
 {
 	if (winner->GetLevelCon(winner->GetLevel(), loser->GetLevel()) > 2) {
 		std::vector<std::any> args;
-		args.push_back(winner);
-		args.push_back(loser);
+		args.emplace_back(winner);
+		args.emplace_back(loser);
 
 		parse->EventPlayer(EVENT_DUEL_WIN, winner->CastToClient(), loser->GetName(), loser->CastToClient()->CharacterID(), &args);
 		parse->EventPlayer(EVENT_DUEL_LOSE, loser->CastToClient(), winner->GetName(), winner->CastToClient()->CharacterID(), &args);
@@ -3642,7 +3642,7 @@ void EntityList::ClearFeignAggro(Mob *targ)
 
 			if (targ->IsClient()) {
 				std::vector<std::any> args;
-				args.push_back(it->second);
+				args.emplace_back(it->second);
 				int i = parse->EventPlayer(EVENT_FEIGN_DEATH, targ->CastToClient(), "", 0, &args);
 				if (i != 0) {
 					++it;
@@ -3989,8 +3989,8 @@ void EntityList::ProcessMove(Client *c, const glm::vec3& location)
 		quest_proximity_event& evt = (*iter);
 
 		std::vector<std::any> args;
-		args.push_back(&evt.area_id);
-		args.push_back(&evt.area_type);
+		args.emplace_back(&evt.area_id);
+		args.emplace_back(&evt.area_type);
 
 		if (evt.npc) {
 			if (evt.event_id == EVENT_ENTER) {
@@ -4066,8 +4066,8 @@ void EntityList::ProcessMove(NPC *n, float x, float y, float z) {
 		quest_proximity_event   &evt = (*iter);
 
 		std::vector<std::any> args;
-		args.push_back(&evt.area_id);
-		args.push_back(&evt.area_type);
+		args.emplace_back(&evt.area_id);
+		args.emplace_back(&evt.area_type);
 
 		if (evt.event_id == EVENT_ENTER) {
 			parse->EventNPC(EVENT_ENTER, evt.npc, evt.client, "", 0);

--- a/zone/forage.cpp
+++ b/zone/forage.cpp
@@ -375,7 +375,7 @@ void Client::GoFish()
 
 				if (inst) {
 					std::vector<std::any> args;
-					args.push_back(inst);
+					args.emplace_back(inst);
 					parse->EventPlayer(EVENT_FISH_SUCCESS, this, "", inst->GetID(), &args);
 				}
 			}
@@ -495,7 +495,7 @@ void Client::ForageItem(bool guarantee) {
 
 			if (inst) {
 				std::vector<std::any> args;
-				args.push_back(inst);
+				args.emplace_back(inst);
 				parse->EventPlayer(EVENT_FORAGE_SUCCESS, this, "", inst->GetID(), &args);
 			}
 		}

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -76,9 +76,9 @@ void load_encounter_with_data(std::string name, std::string info_str) {
 	entity_list.AddEncounter(enc);
 	lua_encounters[name] = enc;
 	lua_encounters_loaded[name] = true;
-	std::vector<std::any> info_ptrs;
-	info_ptrs.push_back(&info_str);
-	parse->EventEncounter(EVENT_ENCOUNTER_LOAD, name, "", 0, &info_ptrs);
+	std::vector<std::any> args;
+	args.emplace_back(&info_str);
+	parse->EventEncounter(EVENT_ENCOUNTER_LOAD, name, "", 0, &args);
 }
 
 void unload_encounter(std::string name) {
@@ -138,9 +138,9 @@ void unload_encounter_with_data(std::string name, std::string info_str) {
 	lua_encounters[name]->Depop();
 	lua_encounters.erase(name);
 	lua_encounters_loaded.erase(name);
-	std::vector<std::any> info_ptrs;
-	info_ptrs.push_back(&info_str);
-	parse->EventEncounter(EVENT_ENCOUNTER_UNLOAD, name, "", 0, &info_ptrs);
+	std::vector<std::any> args;
+	args.emplace_back(&info_str);
+	parse->EventEncounter(EVENT_ENCOUNTER_UNLOAD, name, "", 0, &args);
 }
 
 void register_event(std::string package_name, std::string name, int evt, luabind::adl::object func) {

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -335,7 +335,7 @@ LuaParser::~LuaParser() {
 	}
 }
 
-int LuaParser::EventNPC(QuestEventID evt, NPC* npc, Mob *init, std::string data, uint32 extra_data,
+int LuaParser::EventNPC(QuestEventID evt, NPC* npc, Mob *init, const std::string& data, uint32 extra_data,
 						std::vector<std::any> *extra_pointers) {
 	evt = ConvertLuaEvent(evt);
 	if(evt >= _LargestEventID) {
@@ -354,7 +354,7 @@ int LuaParser::EventNPC(QuestEventID evt, NPC* npc, Mob *init, std::string data,
 	return _EventNPC(package_name, evt, npc, init, data, extra_data, extra_pointers);
 }
 
-int LuaParser::EventGlobalNPC(QuestEventID evt, NPC* npc, Mob *init, std::string data, uint32 extra_data,
+int LuaParser::EventGlobalNPC(QuestEventID evt, NPC* npc, Mob *init, const std::string& data, uint32 extra_data,
 							  std::vector<std::any> *extra_pointers) {
 	evt = ConvertLuaEvent(evt);
 	if(evt >= _LargestEventID) {
@@ -372,7 +372,7 @@ int LuaParser::EventGlobalNPC(QuestEventID evt, NPC* npc, Mob *init, std::string
 	return _EventNPC("global_npc", evt, npc, init, data, extra_data, extra_pointers);
 }
 
-int LuaParser::_EventNPC(std::string package_name, QuestEventID evt, NPC* npc, Mob *init, std::string data, uint32 extra_data,
+int LuaParser::_EventNPC(std::string package_name, QuestEventID evt, NPC* npc, Mob *init, const std::string& data, uint32 extra_data,
 						 std::vector<std::any> *extra_pointers, luabind::adl::object *l_func) {
 	const char *sub_name = LuaEvents[evt];
 
@@ -432,7 +432,7 @@ int LuaParser::_EventNPC(std::string package_name, QuestEventID evt, NPC* npc, M
 	return 0;
 }
 
-int LuaParser::EventPlayer(QuestEventID evt, Client *client, std::string data, uint32 extra_data,
+int LuaParser::EventPlayer(QuestEventID evt, Client *client, const std::string& data, uint32 extra_data,
 		std::vector<std::any> *extra_pointers) {
 	evt = ConvertLuaEvent(evt);
 	if(evt >= _LargestEventID) {
@@ -450,7 +450,7 @@ int LuaParser::EventPlayer(QuestEventID evt, Client *client, std::string data, u
 	return _EventPlayer("player", evt, client, data, extra_data, extra_pointers);
 }
 
-int LuaParser::EventGlobalPlayer(QuestEventID evt, Client *client, std::string data, uint32 extra_data,
+int LuaParser::EventGlobalPlayer(QuestEventID evt, Client *client, const std::string& data, uint32 extra_data,
 		std::vector<std::any> *extra_pointers) {
 	evt = ConvertLuaEvent(evt);
 	if(evt >= _LargestEventID) {
@@ -468,7 +468,7 @@ int LuaParser::EventGlobalPlayer(QuestEventID evt, Client *client, std::string d
 	return _EventPlayer("global_player", evt, client, data, extra_data, extra_pointers);
 }
 
-int LuaParser::_EventPlayer(std::string package_name, QuestEventID evt, Client *client, std::string data, uint32 extra_data,
+int LuaParser::_EventPlayer(std::string package_name, QuestEventID evt, Client *client, const std::string& data, uint32 extra_data,
 							std::vector<std::any> *extra_pointers, luabind::adl::object *l_func) {
 	const char *sub_name = LuaEvents[evt];
 	int start = lua_gettop(L);
@@ -526,7 +526,7 @@ int LuaParser::_EventPlayer(std::string package_name, QuestEventID evt, Client *
 	return 0;
 }
 
-int LuaParser::EventItem(QuestEventID evt, Client *client, EQ::ItemInstance *item, Mob *mob, std::string data, uint32 extra_data,
+int LuaParser::EventItem(QuestEventID evt, Client *client, EQ::ItemInstance *item, Mob *mob, const std::string& data, uint32 extra_data,
 		std::vector<std::any> *extra_pointers) {
 	evt = ConvertLuaEvent(evt);
 	if(evt >= _LargestEventID) {
@@ -547,7 +547,7 @@ int LuaParser::EventItem(QuestEventID evt, Client *client, EQ::ItemInstance *ite
 }
 
 int LuaParser::_EventItem(std::string package_name, QuestEventID evt, Client *client, EQ::ItemInstance *item, Mob *mob,
-						  std::string data, uint32 extra_data, std::vector<std::any> *extra_pointers, luabind::adl::object *l_func) {
+						  const std::string& data, uint32 extra_data, std::vector<std::any> *extra_pointers, luabind::adl::object *l_func) {
 	const char *sub_name = LuaEvents[evt];
 
 	int start = lua_gettop(L);
@@ -611,7 +611,7 @@ int LuaParser::_EventItem(std::string package_name, QuestEventID evt, Client *cl
 	return 0;
 }
 
-int LuaParser::EventSpell(QuestEventID evt, Mob* mob, Client *client, uint32 spell_id, std::string data, uint32 extra_data,
+int LuaParser::EventSpell(QuestEventID evt, Mob* mob, Client *client, uint32 spell_id, const std::string& data, uint32 extra_data,
 						  std::vector<std::any> *extra_pointers) {
 	evt = ConvertLuaEvent(evt);
 	if(evt >= _LargestEventID) {
@@ -627,7 +627,7 @@ int LuaParser::EventSpell(QuestEventID evt, Mob* mob, Client *client, uint32 spe
 	return _EventSpell(package_name, evt, mob, client, spell_id, data, extra_data, extra_pointers);
 }
 
-int LuaParser::_EventSpell(std::string package_name, QuestEventID evt, Mob* mob, Client *client, uint32 spell_id, std::string data, uint32 extra_data,
+int LuaParser::_EventSpell(std::string package_name, QuestEventID evt, Mob* mob, Client *client, uint32 spell_id, const std::string& data, uint32 extra_data,
 						   std::vector<std::any> *extra_pointers, luabind::adl::object *l_func) {
 	const char *sub_name = LuaEvents[evt];
 
@@ -693,7 +693,7 @@ int LuaParser::_EventSpell(std::string package_name, QuestEventID evt, Mob* mob,
 	return 0;
 }
 
-int LuaParser::EventEncounter(QuestEventID evt, std::string encounter_name, std::string data, uint32 extra_data, std::vector<std::any> *extra_pointers) {
+int LuaParser::EventEncounter(QuestEventID evt, std::string encounter_name, const std::string& data, uint32 extra_data, std::vector<std::any> *extra_pointers) {
 	evt = ConvertLuaEvent(evt);
 	if(evt >= _LargestEventID) {
 		return 0;
@@ -708,7 +708,7 @@ int LuaParser::EventEncounter(QuestEventID evt, std::string encounter_name, std:
 	return _EventEncounter(package_name, evt, encounter_name, data, extra_data, extra_pointers);
 }
 
-int LuaParser::_EventEncounter(std::string package_name, QuestEventID evt, std::string encounter_name, std::string data, uint32 extra_data,
+int LuaParser::_EventEncounter(std::string package_name, QuestEventID evt, std::string encounter_name, const std::string& data, uint32 extra_data,
 							   std::vector<std::any> *extra_pointers) {
 	const char *sub_name = LuaEvents[evt];
 
@@ -1238,7 +1238,7 @@ void LuaParser::MapFunctions(lua_State *L) {
 	}
 }
 
-int LuaParser::DispatchEventNPC(QuestEventID evt, NPC* npc, Mob *init, std::string data, uint32 extra_data,
+int LuaParser::DispatchEventNPC(QuestEventID evt, NPC* npc, Mob *init, const std::string& data, uint32 extra_data,
 								 std::vector<std::any> *extra_pointers) {
 	evt = ConvertLuaEvent(evt);
 	if(evt >= _LargestEventID) {
@@ -1284,7 +1284,7 @@ int LuaParser::DispatchEventNPC(QuestEventID evt, NPC* npc, Mob *init, std::stri
     return ret;
 }
 
-int LuaParser::DispatchEventPlayer(QuestEventID evt, Client *client, std::string data, uint32 extra_data,
+int LuaParser::DispatchEventPlayer(QuestEventID evt, Client *client, const std::string& data, uint32 extra_data,
 									std::vector<std::any> *extra_pointers) {
 	evt = ConvertLuaEvent(evt);
 	if(evt >= _LargestEventID) {
@@ -1313,7 +1313,7 @@ int LuaParser::DispatchEventPlayer(QuestEventID evt, Client *client, std::string
     return ret;
 }
 
-int LuaParser::DispatchEventItem(QuestEventID evt, Client *client, EQ::ItemInstance *item, Mob *mob, std::string data, uint32 extra_data,
+int LuaParser::DispatchEventItem(QuestEventID evt, Client *client, EQ::ItemInstance *item, Mob *mob, const std::string& data, uint32 extra_data,
 								  std::vector<std::any> *extra_pointers) {
 	evt = ConvertLuaEvent(evt);
 	if(evt >= _LargestEventID) {
@@ -1359,7 +1359,7 @@ int LuaParser::DispatchEventItem(QuestEventID evt, Client *client, EQ::ItemInsta
     return ret;
 }
 
-int LuaParser::DispatchEventSpell(QuestEventID evt, Mob* mob, Client *client, uint32 spell_id, std::string data, uint32 extra_data,
+int LuaParser::DispatchEventSpell(QuestEventID evt, Mob* mob, Client *client, uint32 spell_id, const std::string& data, uint32 extra_data,
 								   std::vector<std::any> *extra_pointers) {
 	evt = ConvertLuaEvent(evt);
 	if(evt >= _LargestEventID) {
@@ -1513,7 +1513,7 @@ int LuaParser::EventBot(
 	QuestEventID evt,
 	Bot *bot,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1537,7 +1537,7 @@ int LuaParser::EventGlobalBot(
 	QuestEventID evt,
 	Bot *bot,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1562,7 +1562,7 @@ int LuaParser::_EventBot(
 	QuestEventID evt,
 	Bot *bot,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers,
 	luabind::adl::object *l_func
@@ -1628,7 +1628,7 @@ int LuaParser::DispatchEventBot(
 	QuestEventID evt,
 	Bot *bot,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {

--- a/zone/lua_parser.h
+++ b/zone/lua_parser.h
@@ -40,7 +40,7 @@ public:
 		QuestEventID evt,
 		NPC* npc,
 		Mob *init,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	);
@@ -48,21 +48,21 @@ public:
 		QuestEventID evt,
 		NPC* npc,
 		Mob *init,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	);
 	virtual int EventPlayer(
 		QuestEventID evt,
 		Client *client,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	);
 	virtual int EventGlobalPlayer(
 		QuestEventID evt,
 		Client *client,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	);
@@ -71,7 +71,7 @@ public:
 		Client *client,
 		EQ::ItemInstance *item,
 		Mob *mob,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	);
@@ -80,14 +80,14 @@ public:
 		Mob* mob,
 		Client *client,
 		uint32 spell_id,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	);
 	virtual int EventEncounter(
 		QuestEventID evt,
 		std::string encounter_name,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	);
@@ -95,7 +95,7 @@ public:
 		QuestEventID evt,
 		Bot *bot,
 		Mob *init,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	);
@@ -103,7 +103,7 @@ public:
 		QuestEventID evt,
 		Bot *bot,
 		Mob *init,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	);
@@ -140,14 +140,14 @@ public:
 		QuestEventID evt,
 		NPC* npc,
 		Mob *init,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	);
 	virtual int DispatchEventPlayer(
 		QuestEventID evt,
 		Client *client,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	);
@@ -156,7 +156,7 @@ public:
 		Client *client,
 		EQ::ItemInstance *item,
 		Mob *mob,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	);
@@ -165,7 +165,7 @@ public:
 		Mob* mob,
 		Client *client,
 		uint32 spell_id,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	);
@@ -173,7 +173,7 @@ public:
 		QuestEventID evt,
 		Bot *bot,
 		Mob *init,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	);
@@ -207,7 +207,7 @@ private:
 		QuestEventID evt,
 		NPC* npc,
 		Mob *init,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers,
 		luabind::adl::object *l_func = nullptr
@@ -216,7 +216,7 @@ private:
 		std::string package_name,
 		QuestEventID evt,
 		Client *client,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers,
 		luabind::adl::object *l_func = nullptr
@@ -227,7 +227,7 @@ private:
 		Client *client,
 		EQ::ItemInstance *item,
 		Mob *mob,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers,
 		luabind::adl::object *l_func = nullptr
@@ -238,7 +238,7 @@ private:
 		Mob* mob,
 		Client *client,
 		uint32 spell_id,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers,
 		luabind::adl::object *l_func = nullptr
@@ -247,7 +247,7 @@ private:
 		std::string package_name,
 		QuestEventID evt,
 		std::string encounter_name,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	);
@@ -256,7 +256,7 @@ private:
 		QuestEventID evt,
 		Bot *bot,
 		Mob *init,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers,
 		luabind::adl::object *l_func = nullptr

--- a/zone/lua_parser_events.cpp
+++ b/zone/lua_parser_events.cpp
@@ -32,7 +32,7 @@ void handle_npc_event_say(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -55,7 +55,7 @@ void handle_npc_event_trade(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -113,7 +113,7 @@ void handle_npc_event_hp(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -137,7 +137,7 @@ void handle_npc_single_mob(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -152,7 +152,7 @@ void handle_npc_single_client(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -162,27 +162,12 @@ void handle_npc_single_client(
 	lua_setfield(L, -2, "other");
 }
 
-void handle_npc_single_npc(
-	QuestInterface *parse,
-	lua_State* L,
-	NPC* npc,
-	Mob *init,
-	std::string data,
-	uint32 extra_data,
-	std::vector<std::any> *extra_pointers
-) {
-	Lua_NPC l_npc(reinterpret_cast<NPC*>(init));
-	luabind::adl::object l_npc_o = luabind::adl::object(L, l_npc);
-	l_npc_o.push(L);
-	lua_setfield(L, -2, "other");
-}
-
 void handle_npc_task_accepted(
 	QuestInterface *parse,
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -200,7 +185,7 @@ void handle_npc_popup(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -218,7 +203,7 @@ void handle_npc_waypoint(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -236,7 +221,7 @@ void handle_npc_hate(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -245,7 +230,7 @@ void handle_npc_hate(
 	l_mob_o.push(L);
 	lua_setfield(L, -2, "other");
 
-	lua_pushboolean(L, std::stoi(data) == 0 ? false : true);
+	lua_pushboolean(L, std::stoi(data) != 0);
 	lua_setfield(L, -2, "joined");
 }
 
@@ -255,7 +240,7 @@ void handle_npc_signal(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -268,7 +253,7 @@ void handle_npc_payload(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -286,7 +271,7 @@ void handle_npc_timer(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -299,7 +284,7 @@ void handle_npc_death(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -353,7 +338,7 @@ void handle_npc_cast(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -376,7 +361,7 @@ void handle_npc_area(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -392,7 +377,7 @@ void handle_npc_null(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -403,7 +388,7 @@ void handle_npc_loot_zone(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -428,7 +413,7 @@ void handle_npc_spawn_zone(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -443,7 +428,7 @@ void handle_npc_despawn_zone(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -458,7 +443,7 @@ void handle_npc_damage(
 	lua_State* L,
 	NPC* npc,
 	Mob* init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -476,16 +461,16 @@ void handle_npc_damage(
 	lua_pushnumber(L, std::stoi(sep.arg[3]));
 	lua_setfield(L, -2, "skill_id");
 
-	lua_pushboolean(L, std::stoi(sep.arg[4]) == 0 ? false : true);
+	lua_pushboolean(L, std::stoi(sep.arg[4]) != 0);
 	lua_setfield(L, -2, "is_damage_shield");
 
-	lua_pushboolean(L, std::stoi(sep.arg[5]) == 0 ? false : true);
+	lua_pushboolean(L, std::stoi(sep.arg[5]) != 0);
 	lua_setfield(L, -2, "is_avoidable");
 
 	lua_pushnumber(L, std::stoi(sep.arg[6]));
 	lua_setfield(L, -2, "buff_slot");
 
-	lua_pushboolean(L, std::stoi(sep.arg[7]) == 0 ? false : true);
+	lua_pushboolean(L, std::stoi(sep.arg[7]) != 0);
 	lua_setfield(L, -2, "is_buff_tic");
 
 	lua_pushnumber(L, std::stoi(sep.arg[8]));
@@ -502,7 +487,7 @@ void handle_player_say(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -517,7 +502,7 @@ void handle_player_environmental_damage(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -536,7 +521,7 @@ void handle_player_death(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -575,7 +560,7 @@ void handle_player_timer(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -587,7 +572,7 @@ void handle_player_discover_item(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -609,7 +594,7 @@ void handle_player_fish_forage_success(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -623,7 +608,7 @@ void handle_player_click_object(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -637,7 +622,7 @@ void handle_player_click_door(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -651,7 +636,7 @@ void handle_player_signal(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -663,7 +648,7 @@ void handle_player_payload(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -680,7 +665,7 @@ void handle_player_popup_response(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -692,7 +677,7 @@ void handle_player_pick_up(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -706,7 +691,7 @@ void handle_player_cast(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -736,7 +721,7 @@ void handle_player_task_fail(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -748,7 +733,7 @@ void handle_player_zone(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -777,7 +762,7 @@ void handle_player_duel_win(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -791,7 +776,7 @@ void handle_player_duel_loss(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -805,7 +790,7 @@ void handle_player_loot(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -824,7 +809,7 @@ void handle_player_task_stage_complete(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -840,7 +825,7 @@ void handle_player_task_update(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -859,7 +844,7 @@ void handle_player_command(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -884,7 +869,7 @@ void handle_player_combine(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -899,7 +884,7 @@ void handle_player_feign(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -913,7 +898,7 @@ void handle_player_area(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -928,7 +913,7 @@ void handle_player_respawn(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -943,7 +928,7 @@ void handle_player_packet(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -960,7 +945,7 @@ void handle_player_null(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -970,7 +955,7 @@ void handle_player_use_skill(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -986,7 +971,7 @@ void handle_test_buff(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -996,7 +981,7 @@ void handle_player_combine_validate(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1027,7 +1012,7 @@ void handle_player_bot_command(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1052,7 +1037,7 @@ void handle_player_warp(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1071,7 +1056,7 @@ void handle_player_quest_combine(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1083,7 +1068,7 @@ void handle_player_consider(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1095,7 +1080,7 @@ void handle_player_consider_corpse(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1107,7 +1092,7 @@ void handle_player_inspect(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1121,7 +1106,7 @@ void handle_player_aa_buy(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1143,7 +1128,7 @@ void handle_player_aa_gain(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1155,7 +1140,7 @@ void handle_player_level_up(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1167,7 +1152,7 @@ void handle_player_level_down(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1179,7 +1164,7 @@ void handle_player_gm_command(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1191,7 +1176,7 @@ void handle_player_bot_create(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1216,7 +1201,7 @@ void handle_player_damage(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1234,16 +1219,16 @@ void handle_player_damage(
 	lua_pushnumber(L, std::stoi(sep.arg[3]));
 	lua_setfield(L, -2, "skill_id");
 
-	lua_pushboolean(L, std::stoi(sep.arg[4]) == 0 ? false : true);
+	lua_pushboolean(L, std::stoi(sep.arg[4]) != 0);
 	lua_setfield(L, -2, "is_damage_shield");
 
-	lua_pushboolean(L, std::stoi(sep.arg[5]) == 0 ? false : true);
+	lua_pushboolean(L, std::stoi(sep.arg[5]) != 0);
 	lua_setfield(L, -2, "is_avoidable");
 
 	lua_pushnumber(L, std::stoi(sep.arg[6]));
 	lua_setfield(L, -2, "buff_slot");
 
-	lua_pushboolean(L, std::stoi(sep.arg[7]) == 0 ? false : true);
+	lua_pushboolean(L, std::stoi(sep.arg[7]) != 0);
 	lua_setfield(L, -2, "is_buff_tic");
 
 	lua_pushnumber(L, std::stoi(sep.arg[8]));
@@ -1264,7 +1249,7 @@ void handle_item_click(
 	Client* client,
 	EQ::ItemInstance* item,
 	Mob *mob,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1278,7 +1263,7 @@ void handle_item_timer(
 	Client* client,
 	EQ::ItemInstance* item,
 	Mob *mob,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1292,7 +1277,7 @@ void handle_item_proc(
 	Client* client,
 	EQ::ItemInstance* item,
 	Mob *mob,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1320,7 +1305,7 @@ void handle_item_loot(
 	Client* client,
 	EQ::ItemInstance* item,
 	Mob *mob,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1343,7 +1328,7 @@ void handle_item_equip(
 	Client* client,
 	EQ::ItemInstance* item,
 	Mob *mob,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1357,7 +1342,7 @@ void handle_item_augment(
 	Client* client,
 	EQ::ItemInstance* item,
 	Mob *mob,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1376,7 +1361,7 @@ void handle_item_augment_insert(
 	Client* client,
 	EQ::ItemInstance* item,
 	Mob *mob,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1395,7 +1380,7 @@ void handle_item_augment_remove(
 	Client* client,
 	EQ::ItemInstance* item,
 	Mob *mob,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1417,7 +1402,7 @@ void handle_item_null(
 	Client* client,
 	EQ::ItemInstance* item,
 	Mob *mob,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1430,7 +1415,7 @@ void handle_spell_event(
 	Mob* mob,
 	Client* client,
 	uint32 spell_id,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1479,7 +1464,7 @@ void handle_translocate_finish(
 	Mob* mob,
 	Client* client,
 	uint32 spell_id,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1504,7 +1489,7 @@ void handle_player_equip_item(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1531,7 +1516,7 @@ void handle_spell_null(
 	Mob* mob,
 	Client* client,
 	uint32 spell_id,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1541,7 +1526,7 @@ void handle_encounter_timer(
 	QuestInterface *parse,
 	lua_State* L,
 	Encounter* encounter,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1553,7 +1538,7 @@ void handle_encounter_load(
 	QuestInterface *parse,
 	lua_State* L,
 	Encounter* encounter,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1574,7 +1559,7 @@ void handle_encounter_unload(
 	QuestInterface *parse,
 	lua_State* L,
 	Encounter* encounter,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1589,7 +1574,7 @@ void handle_encounter_null(
 	QuestInterface *parse,
 	lua_State* L,
 	Encounter* encounter,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1599,7 +1584,7 @@ void handle_player_skill_up(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1621,7 +1606,7 @@ void handle_player_language_skill_up(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1640,7 +1625,7 @@ void handle_player_alt_currency_merchant(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1665,7 +1650,7 @@ void handle_player_merchant(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1690,7 +1675,7 @@ void handle_player_augment_insert(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1722,7 +1707,7 @@ void handle_player_augment_remove(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1760,7 +1745,7 @@ void handle_bot_null(
 	lua_State* L,
 	Bot* bot,
 	Mob* init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1771,7 +1756,7 @@ void handle_bot_cast(
 	lua_State* L,
 	Bot* bot,
 	Mob* init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1802,7 +1787,7 @@ void handle_bot_combat(
 	lua_State* L,
 	Bot* bot,
 	Mob* init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1811,7 +1796,7 @@ void handle_bot_combat(
 	l_mob_o.push(L);
 	lua_setfield(L, -2, "other");
 
-	lua_pushboolean(L, std::stoi(data) == 0 ? false : true);
+	lua_pushboolean(L, std::stoi(data) != 0);
 	lua_setfield(L, -2, "joined");
 }
 
@@ -1820,7 +1805,7 @@ void handle_bot_death(
 	lua_State* L,
 	Bot* bot,
 	Mob* init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1857,7 +1842,7 @@ void handle_bot_popup_response(
 	lua_State* L,
 	Bot* bot,
 	Mob* init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1875,7 +1860,7 @@ void handle_bot_say(
 	lua_State* L,
 	Bot* bot,
 	Mob* init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1896,7 +1881,7 @@ void handle_bot_signal(
 	lua_State* L,
 	Bot* bot,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1909,7 +1894,7 @@ void handle_bot_payload(
 	lua_State* L,
 	Bot* bot,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1927,7 +1912,7 @@ void handle_bot_slay(
 	lua_State* L,
 	Bot* bot,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1942,7 +1927,7 @@ void handle_bot_target_change(
 	lua_State* L,
 	Bot* bot,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1957,7 +1942,7 @@ void handle_bot_timer(
 	lua_State* L,
 	Bot* bot,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1970,7 +1955,7 @@ void handle_bot_trade(
 	lua_State* L,
 	Bot* bot,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -2028,7 +2013,7 @@ void handle_bot_use_skill(
 	lua_State* L,
 	Bot* bot,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -2045,7 +2030,7 @@ void handle_bot_equip_item(
 	lua_State* L,
 	Bot* bot,
 	Mob* init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -2071,7 +2056,7 @@ void handle_bot_damage(
 	lua_State* L,
 	Bot* bot,
 	Mob* init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -2089,16 +2074,16 @@ void handle_bot_damage(
 	lua_pushnumber(L, std::stoi(sep.arg[3]));
 	lua_setfield(L, -2, "skill_id");
 
-	lua_pushboolean(L, std::stoi(sep.arg[4]) == 0 ? false : true);
+	lua_pushboolean(L, std::stoi(sep.arg[4]) != 0);
 	lua_setfield(L, -2, "is_damage_shield");
 
-	lua_pushboolean(L, std::stoi(sep.arg[5]) == 0 ? false : true);
+	lua_pushboolean(L, std::stoi(sep.arg[5]) != 0);
 	lua_setfield(L, -2, "is_avoidable");
 
 	lua_pushnumber(L, std::stoi(sep.arg[6]));
 	lua_setfield(L, -2, "buff_slot");
 
-	lua_pushboolean(L, std::stoi(sep.arg[7]) == 0 ? false : true);
+	lua_pushboolean(L, std::stoi(sep.arg[7]) != 0);
 	lua_setfield(L, -2, "is_buff_tic");
 
 	lua_pushnumber(L, std::stoi(sep.arg[8]));

--- a/zone/lua_parser_events.h
+++ b/zone/lua_parser_events.h
@@ -2,12 +2,12 @@
 #define _EQE_LUA_PARSER_EVENTS_H
 #ifdef LUA_EQEMU
 
-typedef void(*NPCArgumentHandler)(QuestInterface*, lua_State*, NPC*, Mob*, std::string, uint32, std::vector<std::any>*);
-typedef void(*PlayerArgumentHandler)(QuestInterface*, lua_State*, Client*, std::string, uint32, std::vector<std::any>*);
-typedef void(*ItemArgumentHandler)(QuestInterface*, lua_State*, Client*, EQ::ItemInstance*, Mob*, std::string, uint32, std::vector<std::any>*);
-typedef void(*SpellArgumentHandler)(QuestInterface*, lua_State*, Mob*, Client*, uint32, std::string, uint32, std::vector<std::any>*);
-typedef void(*EncounterArgumentHandler)(QuestInterface*, lua_State*, Encounter* encounter, std::string, uint32, std::vector<std::any>*);
-typedef void(*BotArgumentHandler)(QuestInterface*, lua_State*, Bot*, Mob*, std::string, uint32, std::vector<std::any>*);
+typedef void(*NPCArgumentHandler)(QuestInterface*, lua_State*, NPC*, Mob*, const std::string&, uint32, std::vector<std::any>*);
+typedef void(*PlayerArgumentHandler)(QuestInterface*, lua_State*, Client*, const std::string&, uint32, std::vector<std::any>*);
+typedef void(*ItemArgumentHandler)(QuestInterface*, lua_State*, Client*, EQ::ItemInstance*, Mob*, const std::string&, uint32, std::vector<std::any>*);
+typedef void(*SpellArgumentHandler)(QuestInterface*, lua_State*, Mob*, Client*, uint32, const std::string&, uint32, std::vector<std::any>*);
+typedef void(*EncounterArgumentHandler)(QuestInterface*, lua_State*, Encounter* encounter, const std::string&, uint32, std::vector<std::any>*);
+typedef void(*BotArgumentHandler)(QuestInterface*, lua_State*, Bot*, Mob*, const std::string&, uint32, std::vector<std::any>*);
 
 // NPC
 void handle_npc_event_say(
@@ -15,7 +15,7 @@ void handle_npc_event_say(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -25,7 +25,7 @@ void handle_npc_event_trade(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -35,7 +35,7 @@ void handle_npc_event_hp(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -45,7 +45,7 @@ void handle_npc_single_mob(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -55,17 +55,7 @@ void handle_npc_single_client(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
-	uint32 extra_data,
-	std::vector<std::any> *extra_pointers
-);
-
-void handle_npc_single_npc(
-	QuestInterface *parse,
-	lua_State* L,
-	NPC* npc,
-	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -75,7 +65,7 @@ void handle_npc_task_accepted(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -85,7 +75,7 @@ void handle_npc_popup(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -95,7 +85,7 @@ void handle_npc_waypoint(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -105,7 +95,7 @@ void handle_npc_hate(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -115,7 +105,7 @@ void handle_npc_signal(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -125,7 +115,7 @@ void handle_npc_timer(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -135,7 +125,7 @@ void handle_npc_death(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -145,7 +135,7 @@ void handle_npc_cast(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -155,7 +145,7 @@ void handle_npc_area(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -165,7 +155,7 @@ void handle_npc_null(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -175,7 +165,7 @@ void handle_npc_loot_zone(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -185,7 +175,7 @@ void handle_npc_spawn_zone(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -195,7 +185,7 @@ void handle_npc_payload(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -205,7 +195,7 @@ void handle_npc_despawn_zone(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -215,7 +205,7 @@ void handle_npc_damage(
 	lua_State* L,
 	NPC* npc,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -225,7 +215,7 @@ void handle_player_say(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -234,7 +224,7 @@ void handle_player_environmental_damage(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -243,7 +233,7 @@ void handle_player_death(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -252,7 +242,7 @@ void handle_player_timer(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -261,7 +251,7 @@ void handle_player_discover_item(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -270,7 +260,7 @@ void handle_player_fish_forage_success(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -279,7 +269,7 @@ void handle_player_click_object(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -288,7 +278,7 @@ void handle_player_click_door(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -297,7 +287,7 @@ void handle_player_signal(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -306,7 +296,7 @@ void handle_player_popup_response(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -315,7 +305,7 @@ void handle_player_pick_up(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -324,7 +314,7 @@ void handle_player_cast(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -333,7 +323,7 @@ void handle_player_task_fail(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -342,7 +332,7 @@ void handle_player_zone(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -351,7 +341,7 @@ void handle_player_duel_win(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -360,7 +350,7 @@ void handle_player_duel_loss(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -369,7 +359,7 @@ void handle_player_loot(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -378,7 +368,7 @@ void handle_player_task_stage_complete(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -387,7 +377,7 @@ void handle_player_task_update(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -396,7 +386,7 @@ void handle_player_command(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -405,7 +395,7 @@ void handle_player_combine(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -414,7 +404,7 @@ void handle_player_feign(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -423,7 +413,7 @@ void handle_player_area(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -432,7 +422,7 @@ void handle_player_respawn(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -441,7 +431,7 @@ void handle_player_packet(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -450,7 +440,7 @@ void handle_player_null(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -459,7 +449,7 @@ void handle_player_use_skill(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -468,7 +458,7 @@ void handle_test_buff(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -477,7 +467,7 @@ void handle_player_combine_validate(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -486,7 +476,7 @@ void handle_player_bot_command(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -495,7 +485,7 @@ void handle_player_warp(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -504,7 +494,7 @@ void handle_player_quest_combine(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -513,7 +503,7 @@ void handle_player_consider(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -522,7 +512,7 @@ void handle_player_consider_corpse(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -531,7 +521,7 @@ void handle_player_equip_item(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -540,7 +530,7 @@ void handle_player_skill_up(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -549,7 +539,7 @@ void handle_player_language_skill_up(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -558,7 +548,7 @@ void handle_player_alt_currency_merchant(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -567,7 +557,7 @@ void handle_player_merchant(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -576,7 +566,7 @@ void handle_player_inspect(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -585,7 +575,7 @@ void handle_player_aa_buy(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -594,7 +584,7 @@ void handle_player_aa_gain(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -603,7 +593,7 @@ void handle_player_payload(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -612,7 +602,7 @@ void handle_player_level_up(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -621,7 +611,7 @@ void handle_player_level_down(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -630,7 +620,7 @@ void handle_player_gm_command(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -639,7 +629,7 @@ void handle_player_bot_create(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -648,7 +638,7 @@ void handle_player_augment_insert(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -657,7 +647,7 @@ void handle_player_augment_remove(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -666,7 +656,7 @@ void handle_player_damage(
 	QuestInterface *parse,
 	lua_State* L,
 	Client* client,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -678,7 +668,7 @@ void handle_item_click(
 	Client* client,
 	EQ::ItemInstance* item,
 	Mob *mob,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -689,7 +679,7 @@ void handle_item_timer(
 	Client* client,
 	EQ::ItemInstance* item,
 	Mob *mob,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -700,7 +690,7 @@ void handle_item_proc(
 	Client* client,
 	EQ::ItemInstance* item,
 	Mob *mob,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -711,7 +701,7 @@ void handle_item_loot(
 	Client* client,
 	EQ::ItemInstance* item,
 	Mob *mob,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -722,7 +712,7 @@ void handle_item_equip(
 	Client* client,
 	EQ::ItemInstance* item,
 	Mob *mob,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -733,7 +723,7 @@ void handle_item_augment(
 	Client* client,
 	EQ::ItemInstance* item,
 	Mob *mob,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -744,7 +734,7 @@ void handle_item_augment_insert(
 	Client* client,
 	EQ::ItemInstance* item,
 	Mob *mob,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -755,7 +745,7 @@ void handle_item_augment_remove(
 	Client* client,
 	EQ::ItemInstance* item,
 	Mob *mob,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -766,7 +756,7 @@ void handle_item_null(
 	Client* client,
 	EQ::ItemInstance* item,
 	Mob *mob,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -778,7 +768,7 @@ void handle_spell_event(
 	Mob* mob,
 	Client* client,
 	uint32 spell_id,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -789,7 +779,7 @@ void handle_translocate_finish(
 	Mob* mob,
 	Client* client,
 	uint32 spell_id,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -800,7 +790,7 @@ void handle_spell_null(
 	Mob* mob,
 	Client* client,
 	uint32 spell_id,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -810,7 +800,7 @@ void handle_encounter_timer(
 	QuestInterface *parse,
 	lua_State* L,
 	Encounter* encounter,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -819,7 +809,7 @@ void handle_encounter_load(
 	QuestInterface *parse,
 	lua_State* L,
 	Encounter* encounter,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -828,7 +818,7 @@ void handle_encounter_unload(
 	QuestInterface *parse,
 	lua_State* L,
 	Encounter* encounter,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -837,7 +827,7 @@ void handle_encounter_null(
 	QuestInterface *parse,
 	lua_State* L,
 	Encounter* encounter,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -848,7 +838,7 @@ void handle_bot_null(
 	lua_State* L,
 	Bot* bot,
 	Mob* init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -858,7 +848,7 @@ void handle_bot_cast(
 	lua_State* L,
 	Bot* bot,
 	Mob* init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -868,7 +858,7 @@ void handle_bot_combat(
 	lua_State* L,
 	Bot* bot,
 	Mob* init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -878,7 +868,7 @@ void handle_bot_death(
 	lua_State* L,
 	Bot* bot,
 	Mob* init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -888,7 +878,7 @@ void handle_bot_popup_response(
 	lua_State* L,
 	Bot* bot,
 	Mob* init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -898,7 +888,7 @@ void handle_bot_say(
 	lua_State* L,
 	Bot* bot,
 	Mob* init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -908,7 +898,7 @@ void handle_bot_signal(
 	lua_State* L,
 	Bot* bot,
 	Mob* init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -918,7 +908,7 @@ void handle_bot_slay(
 	lua_State* L,
 	Bot* bot,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -928,7 +918,7 @@ void handle_bot_target_change(
 	lua_State* L,
 	Bot* bot,
 	Mob* init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -938,7 +928,7 @@ void handle_bot_timer(
 	lua_State* L,
 	Bot* bot,
 	Mob* init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -948,7 +938,7 @@ void handle_bot_trade(
 	lua_State* L,
 	Bot* bot,
 	Mob* init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -958,7 +948,7 @@ void handle_bot_use_skill(
 	lua_State* L,
 	Bot* bot,
 	Mob* init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -968,7 +958,7 @@ void handle_bot_payload(
 	lua_State* L,
 	Bot* bot,
 	Mob* init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -978,7 +968,7 @@ void handle_bot_equip_item(
 	lua_State* L,
 	Bot* bot,
 	Mob* init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );
@@ -988,7 +978,7 @@ void handle_bot_damage(
 	lua_State* L,
 	Bot* bot,
 	Mob* init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 );

--- a/zone/object.cpp
+++ b/zone/object.cpp
@@ -519,7 +519,7 @@ bool Object::HandleClick(Client* sender, const ClickObject_Struct* click_object)
 
 			std::string export_string = fmt::format("{}", item->ID);
 			std::vector<std::any> args;
-			args.push_back(m_inst);
+			args.emplace_back(m_inst);
 			if(parse->EventPlayer(EVENT_PLAYER_PICKUP, sender, export_string, GetID(), &args))
 			{
 				auto outapp = new EQApplicationPacket(OP_ClickObject, sizeof(ClickObject_Struct));

--- a/zone/quest_interface.h
+++ b/zone/quest_interface.h
@@ -33,25 +33,25 @@ namespace EQ
 
 class QuestInterface {
 public:
-	virtual int EventNPC(QuestEventID evt, NPC* npc, Mob *init, std::string data, uint32 extra_data,
+	virtual int EventNPC(QuestEventID evt, NPC* npc, Mob *init, const std::string& data, uint32 extra_data,
 		std::vector<std::any> *extra_pointers) { return 0; }
-	virtual int EventGlobalNPC(QuestEventID evt, NPC* npc, Mob *init, std::string data, uint32 extra_data,
+	virtual int EventGlobalNPC(QuestEventID evt, NPC* npc, Mob *init, const std::string& data, uint32 extra_data,
 		std::vector<std::any> *extra_pointers) { return 0; }
-	virtual int EventPlayer(QuestEventID evt, Client *client, std::string data, uint32 extra_data,
+	virtual int EventPlayer(QuestEventID evt, Client *client, const std::string& data, uint32 extra_data,
 		std::vector<std::any> *extra_pointers) { return 0; }
-	virtual int EventGlobalPlayer(QuestEventID evt, Client *client, std::string data, uint32 extra_data,
+	virtual int EventGlobalPlayer(QuestEventID evt, Client *client, const std::string& data, uint32 extra_data,
 		std::vector<std::any> *extra_pointers) { return 0; }
-	virtual int EventItem(QuestEventID evt, Client *client, EQ::ItemInstance *item, Mob *mob, std::string data, uint32 extra_data,
+	virtual int EventItem(QuestEventID evt, Client *client, EQ::ItemInstance *item, Mob *mob, const std::string& data, uint32 extra_data,
 		std::vector<std::any> *extra_pointers) { return 0; }
-	virtual int EventSpell(QuestEventID evt, Mob* mob, Client *client, uint32 spell_id, std::string data, uint32 extra_data,
+	virtual int EventSpell(QuestEventID evt, Mob* mob, Client *client, uint32 spell_id, const std::string& data, uint32 extra_data,
 		std::vector<std::any> *extra_pointers) { return 0; }
-	virtual int EventEncounter(QuestEventID evt, std::string encounter_name, std::string data, uint32 extra_data,
+	virtual int EventEncounter(QuestEventID evt, std::string encounter_name, const std::string& data, uint32 extra_data,
 		std::vector<std::any> *extra_pointers) { return 0; }
 	virtual int EventBot(
 		QuestEventID evt,
 		Bot *bot,
 		Mob *init,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointer
 	) {
@@ -62,7 +62,7 @@ public:
 		QuestEventID evt,
 		Bot *bot,
 		Mob *init,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	) {
@@ -90,19 +90,19 @@ public:
 	virtual void LoadBotScript(std::string filename) { }
 	virtual void LoadGlobalBotScript(std::string filename) { }
 
-	virtual int DispatchEventNPC(QuestEventID evt, NPC* npc, Mob *init, std::string data, uint32 extra_data,
+	virtual int DispatchEventNPC(QuestEventID evt, NPC* npc, Mob *init, const std::string& data, uint32 extra_data,
 		std::vector<std::any> *extra_pointers) { return 0; }
-	virtual int DispatchEventPlayer(QuestEventID evt, Client *client, std::string data, uint32 extra_data,
+	virtual int DispatchEventPlayer(QuestEventID evt, Client *client, const std::string& data, uint32 extra_data,
 		std::vector<std::any> *extra_pointers) { return 0; }
-	virtual int DispatchEventItem(QuestEventID evt, Client *client, EQ::ItemInstance *item, Mob *mob, std::string data, uint32 extra_data,
+	virtual int DispatchEventItem(QuestEventID evt, Client *client, EQ::ItemInstance *item, Mob *mob, const std::string& data, uint32 extra_data,
 		std::vector<std::any> *extra_pointers) { return 0; }
-	virtual int DispatchEventSpell(QuestEventID evt, Mob* mob, Client *client, uint32 spell_id, std::string data, uint32 extra_data,
+	virtual int DispatchEventSpell(QuestEventID evt, Mob* mob, Client *client, uint32 spell_id, const std::string& data, uint32 extra_data,
 		std::vector<std::any> *extra_pointers) { return 0; }
 	virtual int DispatchEventBot(
 		QuestEventID evt,
 		Bot *bot,
 		Mob *init,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	) {

--- a/zone/quest_parser_collection.cpp
+++ b/zone/quest_parser_collection.cpp
@@ -293,7 +293,7 @@ bool QuestParserCollection::HasEncounterSub(QuestEventID evt, const std::string&
 	return false;
 }
 
-int QuestParserCollection::EventNPC(QuestEventID evt, NPC *npc, Mob *init, std::string data, uint32 extra_data,
+int QuestParserCollection::EventNPC(QuestEventID evt, NPC *npc, Mob *init, const std::string& data, uint32 extra_data,
 									std::vector<std::any> *extra_pointers) {
 	int rd = DispatchEventNPC(evt, npc, init, data, extra_data, extra_pointers);
 	int rl = EventNPCLocal(evt, npc, init, data, extra_data, extra_pointers);
@@ -311,7 +311,7 @@ int QuestParserCollection::EventNPC(QuestEventID evt, NPC *npc, Mob *init, std::
 	return 0;
 }
 
-int QuestParserCollection::EventNPCLocal(QuestEventID evt, NPC* npc, Mob *init, std::string data, uint32 extra_data,
+int QuestParserCollection::EventNPCLocal(QuestEventID evt, NPC* npc, Mob *init, const std::string& data, uint32 extra_data,
 										 std::vector<std::any> *extra_pointers) {
 	auto iter = _npc_quest_status.find(npc->GetNPCTypeID());
 	if(iter != _npc_quest_status.end()) {
@@ -334,7 +334,7 @@ int QuestParserCollection::EventNPCLocal(QuestEventID evt, NPC* npc, Mob *init, 
 	return 0;
 }
 
-int QuestParserCollection::EventNPCGlobal(QuestEventID evt, NPC* npc, Mob *init, std::string data, uint32 extra_data,
+int QuestParserCollection::EventNPCGlobal(QuestEventID evt, NPC* npc, Mob *init, const std::string& data, uint32 extra_data,
 										  std::vector<std::any> *extra_pointers) {
 	if(_global_npc_quest_status != QuestUnloaded && _global_npc_quest_status != QuestFailedToLoad) {
 		auto qiter = _interfaces.find(_global_npc_quest_status);
@@ -354,7 +354,7 @@ int QuestParserCollection::EventNPCGlobal(QuestEventID evt, NPC* npc, Mob *init,
 	return 0;
 }
 
-int QuestParserCollection::EventPlayer(QuestEventID evt, Client *client, std::string data, uint32 extra_data,
+int QuestParserCollection::EventPlayer(QuestEventID evt, Client *client, const std::string& data, uint32 extra_data,
 									   std::vector<std::any> *extra_pointers) {
 	int rd = DispatchEventPlayer(evt, client, data, extra_data, extra_pointers);
 	int rl = EventPlayerLocal(evt, client, data, extra_data, extra_pointers);
@@ -372,7 +372,7 @@ int QuestParserCollection::EventPlayer(QuestEventID evt, Client *client, std::st
 	return 0;
 }
 
-int QuestParserCollection::EventPlayerLocal(QuestEventID evt, Client *client, std::string data, uint32 extra_data,
+int QuestParserCollection::EventPlayerLocal(QuestEventID evt, Client *client, const std::string& data, uint32 extra_data,
 											std::vector<std::any> *extra_pointers) {
 	if(_player_quest_status == QuestUnloaded) {
 		std::string filename;
@@ -391,7 +391,7 @@ int QuestParserCollection::EventPlayerLocal(QuestEventID evt, Client *client, st
 	return 0;
 }
 
-int QuestParserCollection::EventPlayerGlobal(QuestEventID evt, Client *client, std::string data, uint32 extra_data,
+int QuestParserCollection::EventPlayerGlobal(QuestEventID evt, Client *client, const std::string& data, uint32 extra_data,
 											 std::vector<std::any> *extra_pointers) {
 	if(_global_player_quest_status == QuestUnloaded) {
 		std::string filename;
@@ -410,7 +410,7 @@ int QuestParserCollection::EventPlayerGlobal(QuestEventID evt, Client *client, s
 	return 0;
 }
 
-int QuestParserCollection::EventItem(QuestEventID evt, Client *client, EQ::ItemInstance *item, Mob *mob, std::string data, uint32 extra_data,
+int QuestParserCollection::EventItem(QuestEventID evt, Client *client, EQ::ItemInstance *item, Mob *mob, const std::string& data, uint32 extra_data,
 									 std::vector<std::any> *extra_pointers) {
 	// needs pointer validation check on 'item' argument
 
@@ -463,7 +463,7 @@ int QuestParserCollection::EventSpell(
 	Mob* mob,
 	Client *client,
 	uint32 spell_id,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -503,7 +503,7 @@ int QuestParserCollection::EventSpell(
 	return 0;
 }
 
-int QuestParserCollection::EventEncounter(QuestEventID evt, std::string encounter_name, std::string data, uint32 extra_data,
+int QuestParserCollection::EventEncounter(QuestEventID evt, std::string encounter_name, const std::string& data, uint32 extra_data,
 										  std::vector<std::any> *extra_pointers) {
 	auto iter = _encounter_quest_status.find(encounter_name);
 	if(iter != _encounter_quest_status.end()) {
@@ -994,7 +994,7 @@ void QuestParserCollection::GetErrors(std::list<std::string> &quest_errors) {
 	}
 }
 
-int QuestParserCollection::DispatchEventNPC(QuestEventID evt, NPC* npc, Mob *init, std::string data, uint32 extra_data,
+int QuestParserCollection::DispatchEventNPC(QuestEventID evt, NPC* npc, Mob *init, const std::string& data, uint32 extra_data,
 											 std::vector<std::any> *extra_pointers) {
     int ret = 0;
 	auto iter = _load_precedence.begin();
@@ -1008,7 +1008,7 @@ int QuestParserCollection::DispatchEventNPC(QuestEventID evt, NPC* npc, Mob *ini
     return ret;
 }
 
-int QuestParserCollection::DispatchEventPlayer(QuestEventID evt, Client *client, std::string data, uint32 extra_data,
+int QuestParserCollection::DispatchEventPlayer(QuestEventID evt, Client *client, const std::string& data, uint32 extra_data,
 												std::vector<std::any> *extra_pointers) {
     int ret = 0;
 	auto iter = _load_precedence.begin();
@@ -1022,7 +1022,7 @@ int QuestParserCollection::DispatchEventPlayer(QuestEventID evt, Client *client,
     return ret;
 }
 
-int QuestParserCollection::DispatchEventItem(QuestEventID evt, Client *client, EQ::ItemInstance *item, Mob *mob, std::string data,
+int QuestParserCollection::DispatchEventItem(QuestEventID evt, Client *client, EQ::ItemInstance *item, Mob *mob, const std::string& data,
 											  uint32 extra_data, std::vector<std::any> *extra_pointers) {
     int ret = 0;
 	auto iter = _load_precedence.begin();
@@ -1041,7 +1041,7 @@ int QuestParserCollection::DispatchEventSpell(
 	Mob* mob,
 	Client *client,
 	uint32 spell_id,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1083,7 +1083,7 @@ int QuestParserCollection::DispatchEventBot(
 	QuestEventID evt,
 	Bot *bot,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1105,7 +1105,7 @@ int QuestParserCollection::EventBot(
 	QuestEventID evt,
 	Bot *bot,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1129,7 +1129,7 @@ int QuestParserCollection::EventBotLocal(
 	QuestEventID evt,
 	Bot *bot,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {
@@ -1155,7 +1155,7 @@ int QuestParserCollection::EventBotGlobal(
 	QuestEventID evt,
 	Bot *bot,
 	Mob *init,
-	std::string data,
+	const std::string& data,
 	uint32 extra_data,
 	std::vector<std::any> *extra_pointers
 ) {

--- a/zone/quest_parser_collection.h
+++ b/zone/quest_parser_collection.h
@@ -73,22 +73,22 @@ public:
 	bool ItemHasQuestSub(EQ::ItemInstance *itm, QuestEventID evt, bool check_encounters = false);
 	bool BotHasQuestSub(QuestEventID evt);
 
-	int EventNPC(QuestEventID evt, NPC* npc, Mob *init, std::string data, uint32 extra_data,
+	int EventNPC(QuestEventID evt, NPC* npc, Mob *init, const std::string& data, uint32 extra_data,
 		std::vector<std::any> *extra_pointers = nullptr);
-	int EventPlayer(QuestEventID evt, Client *client, std::string data, uint32 extra_data,
+	int EventPlayer(QuestEventID evt, Client *client, const std::string& data, uint32 extra_data,
 		std::vector<std::any> *extra_pointers = nullptr);
-	int EventItem(QuestEventID evt, Client *client, EQ::ItemInstance *item, Mob *mob, std::string data, uint32 extra_data,
+	int EventItem(QuestEventID evt, Client *client, EQ::ItemInstance *item, Mob *mob, const std::string& data, uint32 extra_data,
 		std::vector<std::any> *extra_pointers = nullptr);
-	int EventSpell(QuestEventID evt, Mob* mob, Client *client, uint32 spell_id, std::string data, uint32 extra_data,
+	int EventSpell(QuestEventID evt, Mob* mob, Client *client, uint32 spell_id, const std::string& data, uint32 extra_data,
 		std::vector<std::any> *extra_pointers = nullptr);
-	int EventEncounter(QuestEventID evt, std::string encounter_name, std::string data, uint32 extra_data,
+	int EventEncounter(QuestEventID evt, std::string encounter_name, const std::string& data, uint32 extra_data,
 		std::vector<std::any> *extra_pointers = nullptr);
 
 	int EventBot(
 		QuestEventID evt,
 		Bot *bot,
 		Mob *init,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers = nullptr
 	);
@@ -129,15 +129,15 @@ private:
 	bool BotHasQuestSubLocal(QuestEventID evt);
 	bool BotHasQuestSubGlobal(QuestEventID evt);
 
-	int EventNPCLocal(QuestEventID evt, NPC* npc, Mob *init, std::string data, uint32 extra_data, std::vector<std::any> *extra_pointers);
-	int EventNPCGlobal(QuestEventID evt, NPC* npc, Mob *init, std::string data, uint32 extra_data, std::vector<std::any> *extra_pointers);
-	int EventPlayerLocal(QuestEventID evt, Client *client, std::string data, uint32 extra_data,	std::vector<std::any> *extra_pointers);
-	int EventPlayerGlobal(QuestEventID evt, Client *client, std::string data, uint32 extra_data, std::vector<std::any> *extra_pointers);
+	int EventNPCLocal(QuestEventID evt, NPC* npc, Mob *init, const std::string& data, uint32 extra_data, std::vector<std::any> *extra_pointers);
+	int EventNPCGlobal(QuestEventID evt, NPC* npc, Mob *init, const std::string& data, uint32 extra_data, std::vector<std::any> *extra_pointers);
+	int EventPlayerLocal(QuestEventID evt, Client *client, const std::string& data, uint32 extra_data,	std::vector<std::any> *extra_pointers);
+	int EventPlayerGlobal(QuestEventID evt, Client *client, const std::string& data, uint32 extra_data, std::vector<std::any> *extra_pointers);
 	int EventBotLocal(
 		QuestEventID evt,
 		Bot *bot,
 		Mob *init,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	);
@@ -145,7 +145,7 @@ private:
 		QuestEventID evt,
 		Bot *bot,
 		Mob *init,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	);
@@ -160,19 +160,19 @@ private:
 	QuestInterface *GetQIByBotQuest(std::string &filename);
 	QuestInterface *GetQIByGlobalBotQuest(std::string &filename);
 
-	int DispatchEventNPC(QuestEventID evt, NPC* npc, Mob *init, std::string data, uint32 extra_data,
+	int DispatchEventNPC(QuestEventID evt, NPC* npc, Mob *init, const std::string& data, uint32 extra_data,
 		std::vector<std::any> *extra_pointers);
-	int DispatchEventPlayer(QuestEventID evt, Client *client, std::string data, uint32 extra_data,
+	int DispatchEventPlayer(QuestEventID evt, Client *client, const std::string& data, uint32 extra_data,
 		std::vector<std::any> *extra_pointers);
-	int DispatchEventItem(QuestEventID evt, Client *client, EQ::ItemInstance *item, Mob *mob, std::string data, uint32 extra_data,
+	int DispatchEventItem(QuestEventID evt, Client *client, EQ::ItemInstance *item, Mob *mob, const std::string& data, uint32 extra_data,
 		std::vector<std::any> *extra_pointers);
-	int DispatchEventSpell(QuestEventID evt, Mob* mob, Client *client, uint32 spell_id, std::string data, uint32 extra_data,
+	int DispatchEventSpell(QuestEventID evt, Mob* mob, Client *client, uint32 spell_id, const std::string& data, uint32 extra_data,
 		std::vector<std::any> *extra_pointers);
 	int DispatchEventBot(
 		QuestEventID evt,
 		Bot *bot,
 		Mob *init,
-		std::string data,
+		const std::string& data,
 		uint32 extra_data,
 		std::vector<std::any> *extra_pointers
 	);

--- a/zone/spawn2.cpp
+++ b/zone/spawn2.cpp
@@ -1058,10 +1058,10 @@ bool SpawnConditionManager::LoadSpawnConditions(const char* zone_name, uint32 in
 		event.next.month  = atoi(row[6]);
 		event.next.year   = atoi(row[7]);
 
-		event.enabled  = atoi(row[8]) == 0 ? false : true;
+		event.enabled  = atoi(row[8]) != 0;
 		event.action   = (SpawnEvent::Action) atoi(row[9]);
 		event.argument = atoi(row[10]);
-		event.strict   = atoi(row[11]) == 0 ? false : true;
+		event.strict   = atoi(row[11]) != 0;
 
 		spawn_events.push_back(event);
 

--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -135,13 +135,13 @@ void Object::HandleAugmentation(Client* user, const AugmentItem_Struct* in_augme
 			EQ::ItemInstance *aug = tobe_auged->GetAugment(slot);
 			if(aug) {
 				std::vector<std::any> args;
-				args.push_back(aug);
+				args.emplace_back(aug);
 				parse->EventItem(EVENT_AUGMENT_ITEM, user, tobe_auged, nullptr, "", slot, &args);
 
 				args.assign(1, tobe_auged);
 				parse->EventItem(EVENT_AUGMENT_INSERT, user, aug, nullptr, "", slot, &args);
 
-				args.push_back(aug);
+				args.emplace_back(aug);
 
 				const auto export_string = fmt::format(
 					"{} {} {} {}",
@@ -177,11 +177,11 @@ void Object::HandleAugmentation(Client* user, const AugmentItem_Struct* in_augme
 				return;
 			}
 			std::vector<std::any> args;
-			args.push_back(aug);
+			args.emplace_back(aug);
 			parse->EventItem(EVENT_UNAUGMENT_ITEM, user, tobe_auged, nullptr, "", slot, &args);
 
 			args.assign(1, tobe_auged);
-			args.push_back(&is_solvent);
+			args.emplace_back(&is_solvent);
 
 			parse->EventItem(EVENT_AUGMENT_REMOVE, user, aug, nullptr, "", slot, &args);
 		}


### PR DESCRIPTION
# Notes
- Several places use `push_back` instead of `emplace_back`.
- Several places use `std::string` instead of `const std::string&`.
- Several places were using ternaries for `true` and `false` instead of just checking `!= 0`.