### PR TITLE
[Bug Fix] BuffLevelRestrictions were restricting group buffs

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3205,8 +3205,10 @@ bool Mob::CheckSpellLevelRestriction(Mob *caster, uint16 spell_id)
 
 	// NON GM clients might be restricted by rule setting
 	if (caster->IsClient()) {
-		if (RuleB(Spells, BuffLevelRestrictions)) {
-			check_for_restrictions = true;
+		if (IsClient()) { // Only restrict client on client for this rule
+			if (RuleB(Spells, BuffLevelRestrictions)) {
+				check_for_restrictions = true;
+			}
 		}
 	}
 	// NPCS might be restricted by rule setting


### PR DESCRIPTION
BuffLevelRestrictions were restricting group buffs if mob targetted at the time of casting.

This is due to the MOB::CheckSpellRestrictions being eliminated and a missing check in the shared version after my PR that added the NPCBuffRestrictions rule and did some refactoring and cleanup:

https://github.com/EQEmu/Server/pull/2708/files
