### PR TITLE
[Quest API] Add Augment Slot support to does_augment_fit

### DIFF
--- a/common/item_instance.cpp
+++ b/common/item_instance.cpp
@@ -358,15 +358,26 @@ int8 EQ::ItemInstance::AvailableAugmentSlot(int32 augment_type) const
 	return (i <= invaug::SOCKET_END) ? i : INVALID_INDEX;
 }
 
-bool EQ::ItemInstance::IsAugmentSlotAvailable(int32 augtype, uint8 slot) const
+bool EQ::ItemInstance::IsAugmentSlotAvailable(int32 augment_type, uint8 slot) const
 {
-	if (!m_item || !m_item->IsClassCommon())
-		 return false;
+	if (!m_item || !m_item->IsClassCommon()) {
+		return false;
+	}
 
-	if ((!GetItem(slot) && m_item->AugSlotVisible[slot]) && augtype == -1 || (m_item->AugSlotType[slot] && ((1 << (m_item->AugSlotType[slot] - 1)) & augtype))) {
+	if (
+		(
+			!GetItem(slot) &&
+			m_item->AugSlotVisible[slot]
+		) && augment_type == -1 ||
+		(
+			m_item->AugSlotType[slot] &&
+			((1 << (m_item->AugSlotType[slot] - 1)) & augment_type)
+		)
+	) {
 		return true;
 	}
-		return false;
+
+	return false;
 }
 
 // Retrieve item inside container

--- a/common/item_instance.cpp
+++ b/common/item_instance.cpp
@@ -368,7 +368,8 @@ bool EQ::ItemInstance::IsAugmentSlotAvailable(int32 augment_type, uint8 slot) co
 		(
 			!GetItem(slot) &&
 			m_item->AugSlotVisible[slot]
-		) && augment_type == -1 ||
+		) &&
+		augment_type == -1 ||
 		(
 			m_item->AugSlotType[slot] &&
 			((1 << (m_item->AugSlotType[slot] - 1)) & augment_type)

--- a/common/item_instance.h
+++ b/common/item_instance.h
@@ -101,8 +101,8 @@ namespace EQ
 		//
 		bool IsAugmentable() const;
 		bool AvailableWearSlot(uint32 aug_wear_slots) const;
-		int8 AvailableAugmentSlot(int32 augtype) const;
-		bool IsAugmentSlotAvailable(int32 augtype, uint8 slot) const;
+		int8 AvailableAugmentSlot(int32 augment_type) const;
+		bool IsAugmentSlotAvailable(int32 augment_type, uint8 slot) const;
 		inline int32 GetAugmentType() const { return ((m_item) ? m_item->AugType : 0); }
 
 		inline bool IsExpendable() const { return ((m_item) ? ((m_item->Click.Type == item::ItemEffectExpendable) || (m_item->ItemType == item::ItemTypePotion)) : false); }

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -3981,6 +3981,11 @@ int8 Perl__does_augment_fit(EQ::ItemInstance* inst, uint32 augment_id)
 	return quest_manager.DoesAugmentFit(inst, augment_id);
 }
 
+int8 Perl__does_augment_fit(EQ::ItemInstance* inst, uint32 augment_id, uint8 augment_slot)
+{
+	return quest_manager.DoesAugmentFit(inst, augment_id, augment_slot);
+}
+
 void perl_register_quest()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -4326,7 +4331,8 @@ void perl_register_quest()
 	package.add("doanim", (void(*)(int, int, bool))&Perl__doanim);
 	package.add("doanim", (void(*)(int, int, bool, int))&Perl__doanim);
 	package.add("do_augment_slots_match", &Perl__do_augment_slots_match);
-	package.add("does_augment_fit", &Perl__does_augment_fit);
+	package.add("does_augment_fit", (int8(*)(EQ::ItemInstance*, uint32))&Perl__does_augment_fit);
+	package.add("does_augment_fit", (int8(*)(EQ::ItemInstance*, uint32, uint8))&Perl__does_augment_fit);
 	package.add("echo", &Perl__echo);
 	package.add("emote", &Perl__emote);
 	package.add("enable_proximity_say", &Perl__enable_proximity_say);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -3700,6 +3700,11 @@ int8 lua_does_augment_fit(Lua_ItemInst inst, uint32 augment_id)
 	return quest_manager.DoesAugmentFit(inst, augment_id);
 }
 
+int8 lua_does_augment_fit(Lua_ItemInst inst, uint32 augment_id, uint8 augment_slot)
+{
+	return quest_manager.DoesAugmentFit(inst, augment_id, augment_slot);
+}
+
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
 	cur = table[#name]; \
 	if(luabind::type(cur) != LUA_TNIL) { \
@@ -4217,7 +4222,8 @@ luabind::scope lua_register_general() {
 		luabind::def("do_anim", (void(*)(int,int,bool))&lua_do_anim),
 		luabind::def("do_anim", (void(*)(int,int,bool,int))&lua_do_anim),
 		luabind::def("do_augment_slots_match", &lua_do_augment_slots_match),
-		luabind::def("does_augment_fit", &lua_does_augment_fit),
+		luabind::def("does_augment_fit", (int8(*)(Lua_ItemInst, uint32))&lua_does_augment_fit),
+		luabind::def("does_augment_fit", (int8(*)(Lua_ItemInst, uint32, uint8))&lua_does_augment_fit),
 		/*
 			Cross Zone
 		*/

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -3969,7 +3969,7 @@ bool QuestManager::DoAugmentSlotsMatch(uint32 item_one, uint32 item_two)
 	return true;
 }
 
-int8 QuestManager::DoesAugmentFit(EQ::ItemInstance* inst, uint32 augment_id)
+int8 QuestManager::DoesAugmentFit(EQ::ItemInstance* inst, uint32 augment_id, uint8 augment_slot)
 {
 	if (!inst) {
 		return INVALID_INDEX;
@@ -3977,6 +3977,13 @@ int8 QuestManager::DoesAugmentFit(EQ::ItemInstance* inst, uint32 augment_id)
 
 	const auto* aug_inst = database.GetItem(augment_id);
 	if (!aug_inst) {
+		return INVALID_INDEX;
+	}
+
+	if (
+		augment_slot != 255 &&
+		!inst->IsAugmentSlotAvailable(aug_inst->AugType, augment_slot)
+	) {
 		return INVALID_INDEX;
 	}
 

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -346,7 +346,7 @@ public:
 	std::string GetRecipeName(uint32 recipe_id);
 	bool HasRecipeLearned(uint32 recipe_id);
 	bool DoAugmentSlotsMatch(uint32 item_one, uint32 item_two);
-	int8 DoesAugmentFit(EQ::ItemInstance* inst, uint32 augment_id);
+	int8 DoesAugmentFit(EQ::ItemInstance* inst, uint32 augment_id, uint8 augment_slot = 255);
 
 	Bot *GetBot() const;
 	Client *GetInitiator() const;


### PR DESCRIPTION
# Notes
- Allows you to check if the supplied augment ID fits in the specified augment slot of the item instance provided.