### PR TITLE
[Bug fix]#reload static should now properly fill the entity_lists for…

### DIFF
--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -1938,30 +1938,12 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 		content_service.SetExpansionContext()->ReloadContentFlags();
 		break;
 	}
-	case ServerOP_ReloadDoors:
-	{
-		if (zone && zone->IsLoaded()) {
-			zone->SendReloadMessage("Doors");
-			entity_list.RemoveAllDoors();
-			zone->LoadZoneDoors();
-			entity_list.RespawnAllDoors();
-		}
-		break;
-	}
 	case ServerOP_ReloadDzTemplates:
 	{
 		if (zone)
 		{
 			zone->SendReloadMessage("Dynamic Zone Templates");
 			zone->LoadDynamicZoneTemplates();
-		}
-		break;
-	}
-	case ServerOP_ReloadGroundSpawns:
-	{
-		if (zone && zone->IsLoaded()) {
-			zone->SendReloadMessage("Ground Spawns");
-			zone->LoadGroundSpawns();
 		}
 		break;
 	}
@@ -1994,15 +1976,6 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 		}
 		break;
 	}
-	case ServerOP_ReloadObjects:
-	{
-		if (zone && zone->IsLoaded()) {
-			zone->SendReloadMessage("Objects");
-			entity_list.RemoveAllObjects();
-			zone->LoadZoneObjects();
-		}
-		break;
-	}
 	case ServerOP_ReloadPerlExportSettings:
 	{
 		zone->SendReloadMessage("Perl Event Export Settings");
@@ -2015,6 +1988,9 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 		RuleManager::Instance()->LoadRules(&database, RuleManager::Instance()->GetActiveRuleset(), true);
 		break;
 	}
+	case ServerOP_ReloadDoors:
+	case ServerOP_ReloadGroundSpawns:
+	case ServerOP_ReloadObjects:
 	case ServerOP_ReloadStaticZoneData: {
 		if (zone && zone->IsLoaded()) {
 			zone->SendReloadMessage("Static Zone Data");

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -1231,6 +1231,8 @@ bool Zone::Init(bool is_static) {
 
 void Zone::ReloadStaticData() {
 	LogInfo("Reloading Zone Static Data");
+	entity_list.RemoveAllObjects(); //Ground spawns are also objects we clear list then fill it
+	entity_list.RemoveAllDoors(); //Some objects are also doors so clear list before filling
 
 	if (!content_db.LoadStaticZonePoints(&zone_point_list, GetShortName(), GetInstanceVersion())) {
 		LogError("Loading static zone points failed");
@@ -1249,14 +1251,12 @@ void Zone::ReloadStaticData() {
 		LogError("Reloading ground spawns failed. continuing");
 	}
 
-	entity_list.RemoveAllObjects();
 	LogInfo("Reloading World Objects from DB");
 	if (!LoadZoneObjects())
 	{
 		LogError("Reloading World Objects failed. continuing");
 	}
 
-	entity_list.RemoveAllDoors();
 	LoadZoneDoors();
 	entity_list.RespawnAllDoors();
 


### PR DESCRIPTION
… objects / doors / groundspawns

The individual #reload commands WILL still have issues when trying to use #list afterwards!