### PR TITLE
[Doors] Have NPCs trigger double doors

### DIFF
--- a/common/strings.cpp
+++ b/common/strings.cpp
@@ -770,3 +770,16 @@ int Strings::ToInt(const std::string &s, int fallback)
 {
 	return Strings::IsNumber(s) ? std::stoi(s) : fallback;
 }
+
+std::string Strings::RemoveNumbers(std::string s)
+{
+	int      current = 0;
+	for (int i       = 0; i < s.length(); i++) {
+		if (!isdigit(s[i])) {
+			s[current] = s[i];
+			current++;
+		}
+	}
+
+	return s.substr(0, current);
+}

--- a/common/strings.h
+++ b/common/strings.h
@@ -88,6 +88,7 @@ public:
 	static bool Contains(const std::string& subject, const std::string& search);
 	static int  ToInt(const std::string &s, int fallback = 0);
 	static bool IsNumber(const std::string &s);
+	static std::string RemoveNumbers(std::string s);
 	static bool IsFloat(const std::string &s);
 	static const std::string ToLower(std::string s);
 	static const std::string ToUpper(std::string s);

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -999,7 +999,13 @@ void Mob::AI_Process() {
 				}
 
 				if (door->GetTriggerDoorID() > 0) {
-					continue;
+					auto trigger_door = entity_list.GetDoorsByDoorID(door->GetTriggerDoorID());
+					if (trigger_door) {
+						if (Strings::RemoveNumbers(door->GetDoorName()) !=
+							Strings::RemoveNumbers(trigger_door->GetDoorName())) {
+							continue;
+						}
+					}
 				}
 
 				if (door->GetDoorParam() > 0) {


### PR DESCRIPTION
### What 

This PR solves for a situation where NPC's clip through double doors because they have a trigger door and the current AI does not let them open doors that have a trigger door. This is usually because we don't want NPC's triggering for example a lever that elevates a platform.

We do want NPC's to be able to open double doors

### Solution

When an NPC walks into a door that has a trigger door, compare the names without numbers to see if they are complimentary. In majority cases double doors are similarly named but have a different number suffix.

This automatically solves for the following zones that fall under a similar pattern (https://gist.github.com/Akkadius/cfbc826c193b33a1c4687fd0001fb915)

* gfaydark
* soltemple
* citymist
* hole
* paineel
* sleeper
* katta
* potactics
* potorment
* tutorialb
* ikkinz


Example doors

```
select id, doorid, zone, `name`, triggerdoor from doors where doors.zone = 'soltemple' and doorid in (43, 44);
+------+--------+-----------+----------------+-------------+
| id   | doorid | zone      | name           | triggerdoor |
+------+--------+-----------+----------------+-------------+
| 6249 |     43 | soltemple | SOLTEMPDOOR400 |          44 |
| 6248 |     44 | soltemple | SOLTEMPDOOR401 |          43 |
+------+--------+-----------+----------------+-------------+
2 rows in set (0.00 sec)
```

### Demo

https://user-images.githubusercontent.com/3319450/216173181-365f1fd8-2424-4b19-94ac-1b7fb6b81e9f.mp4

