### PR TITLE
[Quest API] Add EVENT_TASKACCEPTED to Player scope

### DIFF
--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -242,6 +242,7 @@ LuaParser::LuaParser() {
 	PlayerArgumentDispatch[EVENT_DUEL_LOSE]                  = handle_player_duel_loss;
 	PlayerArgumentDispatch[EVENT_LOOT]                       = handle_player_loot;
 	PlayerArgumentDispatch[EVENT_TASK_STAGE_COMPLETE]        = handle_player_task_stage_complete;
+	PlayerArgumentDispatch[EVENT_TASK_ACCEPTED]				 = handle_player_task_accepted;
 	PlayerArgumentDispatch[EVENT_TASK_COMPLETE]              = handle_player_task_update;
 	PlayerArgumentDispatch[EVENT_TASK_UPDATE]                = handle_player_task_update;
 	PlayerArgumentDispatch[EVENT_TASK_BEFORE_UPDATE]         = handle_player_task_update;

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -242,7 +242,7 @@ LuaParser::LuaParser() {
 	PlayerArgumentDispatch[EVENT_DUEL_LOSE]                  = handle_player_duel_loss;
 	PlayerArgumentDispatch[EVENT_LOOT]                       = handle_player_loot;
 	PlayerArgumentDispatch[EVENT_TASK_STAGE_COMPLETE]        = handle_player_task_stage_complete;
-	PlayerArgumentDispatch[EVENT_TASK_ACCEPTED]				 = handle_player_task_accepted;
+	PlayerArgumentDispatch[EVENT_TASK_ACCEPTED]              = handle_player_task_accepted;
 	PlayerArgumentDispatch[EVENT_TASK_COMPLETE]              = handle_player_task_update;
 	PlayerArgumentDispatch[EVENT_TASK_UPDATE]                = handle_player_task_update;
 	PlayerArgumentDispatch[EVENT_TASK_BEFORE_UPDATE]         = handle_player_task_update;

--- a/zone/lua_parser_events.cpp
+++ b/zone/lua_parser_events.cpp
@@ -836,6 +836,18 @@ void handle_player_task_stage_complete(
 	lua_setfield(L, -2, "activity_id");
 }
 
+void handle_player_task_accepted(
+	QuestInterface* parse,
+	lua_State* L,
+	Client* client,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any>* extra_pointers
+) {
+	lua_pushinteger(L, std::stoi(data));
+	lua_setfield(L, -2, "task_id");
+}
+
 void handle_player_task_update(
 	QuestInterface *parse,
 	lua_State* L,

--- a/zone/lua_parser_events.h
+++ b/zone/lua_parser_events.h
@@ -383,6 +383,15 @@ void handle_player_task_stage_complete(
 	std::vector<std::any> *extra_pointers
 );
 
+void handle_player_task_accepted(
+	QuestInterface* parse,
+	lua_State* L,
+	Client* client,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any>* extra_pointers
+);
+
 void handle_player_task_update(
 	QuestInterface *parse,
 	lua_State* L,

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -2125,6 +2125,7 @@ void ClientTaskState::AcceptNewTask(
 	if (npc) {
 		parse->EventNPC(EVENT_TASK_ACCEPTED, npc, client, export_string, 0);
 	}
+	parse->EventPlayer(EVENT_TASK_ACCEPTED, client, export_string, 0);
 }
 
 void ClientTaskState::ProcessTaskProximities(Client *client, float x, float y, float z)


### PR DESCRIPTION
# Issue
Previously EVENT_TASKACCEPTED was only accesible in the NPC scope. 

# Change
This adds EVENT_TASKACCEPTED to the player scope for both Perl and Lua.

Tested on up-to-date binaries and works fine.