### PR TITLE
[Fix] Fix NPC ghosting at safe coordinates

### DIFF
--- a/zone/client.h
+++ b/zone/client.h
@@ -2083,6 +2083,7 @@ private:
 	bool m_bot_precombat;
 
 	bool CanTradeFVNoDropItem();
+	void SendMobPositions();
 };
 
 #endif

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -778,6 +778,12 @@ void Client::CompleteConnect()
 
 	parse->EventPlayer(EVENT_ENTER_ZONE, this, "", 0);
 
+	// the way that the client deals with positions during the initial spawn struct
+	// is subtly different from how it deals with getting a position update
+	// if a mob is slightly in the wall or slightly clipping a floor they will be
+	// sent to a succor point
+	SendMobPositions();
+
 	SetLastPositionBeforeBulkUpdate(GetPosition());
 
 	/* This sub event is for if a player logs in for the first time since entering world. */
@@ -15729,4 +15735,15 @@ bool Client::CanTradeFVNoDropItem()
 	}
 
 	return false;
+}
+
+void Client::SendMobPositions()
+{
+	auto      p  = new EQApplicationPacket(OP_ClientUpdate, sizeof(PlayerPositionUpdateServer_Struct));
+	auto      *s = (PlayerPositionUpdateServer_Struct *) p->pBuffer;
+	for (auto &m: entity_list.GetMobList()) {
+		m.second->MakeSpawnUpdate(s);
+		QueuePacket(p, false);
+	}
+	safe_delete(p);
 }

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -719,7 +719,7 @@ void EntityList::AddNPC(NPC *npc, bool send_spawn_packet, bool dont_queue)
 	}
 
 	npc->SendPositionToClients();
-	
+
 	entity_list.ScanCloseMobs(npc->close_mobs, npc, true);
 
 	npc->DispatchZoneControllerEvent(EVENT_SPAWN_ZONE, npc, "", 0, nullptr);
@@ -846,8 +846,10 @@ void EntityList::CheckSpawnQueue()
 				NPC *pnpc = it->second;
 				pnpc->SendArmorAppearance();
 				pnpc->SetAppearance(pnpc->GetGuardPointAnim(), false);
-				if (!pnpc->IsTargetable())
+				if (!pnpc->IsTargetable()) {
 					pnpc->SendTargetable(false);
+				}
+				pnpc->SendPositionToClients();
 			}
 			safe_delete(outapp);
 			iterator.RemoveCurrent();

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -716,10 +716,10 @@ void EntityList::AddNPC(NPC *npc, bool send_spawn_packet, bool dont_queue)
 		if (npc->IsFindable()) {
 			UpdateFindableNPCState(npc, false);
 		}
-
-		npc->SendPositionToClients();
 	}
 
+	npc->SendPositionToClients();
+	
 	entity_list.ScanCloseMobs(npc->close_mobs, npc, true);
 
 	npc->DispatchZoneControllerEvent(EVENT_SPAWN_ZONE, npc, "", 0, nullptr);

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -716,6 +716,8 @@ void EntityList::AddNPC(NPC *npc, bool send_spawn_packet, bool dont_queue)
 		if (npc->IsFindable()) {
 			UpdateFindableNPCState(npc, false);
 		}
+
+		npc->SendPositionToClients();
 	}
 
 	entity_list.ScanCloseMobs(npc->close_mobs, npc, true);

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -3783,3 +3783,14 @@ int NPC::GetRolledItemCount(uint32 item_id)
 
 	return rolled_count;
 }
+
+void NPC::SendPositionToClients()
+{
+	auto      p  = new EQApplicationPacket(OP_ClientUpdate, sizeof(PlayerPositionUpdateServer_Struct));
+	auto      *s = (PlayerPositionUpdateServer_Struct *) p->pBuffer;
+	for (auto &c: entity_list.GetClientList()) {
+		MakeSpawnUpdate(s);
+		c.second->QueuePacket(p, false);
+	}
+	safe_delete(p);
+}

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -536,6 +536,8 @@ public:
 	void RecalculateSkills();
 	void ReloadSpells();
 
+	void SendPositionToClients();
+
 	static LootDropEntries_Struct NewLootDropEntry();
 
 protected:


### PR DESCRIPTION
### What

When zoning into some zones, NPCs can be "ghosted" at what appears to be zone ins or safe coordinates. This happens when NPCs are clipped into the geometry during the initial spawn of an NPC. The client auto corrects this by placing the actor in the safe coordinates. 

The client does other similar auto correcting behavior when the Z of a model is slightly in the ground, the client will correct it client side even if the server is wrong and the server is pushing the actor into the ground. 

The behavior occurs because the client treats the initial spawn struct differently than a position update. Years ago we used to brute force re-send position updates to the client even if they were on the other side of the zone and it "masked" the original problem because we sent the position always after the initial spawn packet (which is different).

Over the years with server side optimizations, we don't brute force send position updates regularly and we only send position updates for NPC's that are near and then re-send the entire zone when the client moves 600 units anywhere in the zone. This has had side affects that have been subtle and hard to pin down until now

### Solution

We send position update after the initial spawn struct, both for the initial spawn of an NPC and when a client enters the zone

**Before**

![image](https://user-images.githubusercontent.com/3319450/216750961-a62cf6da-42e7-4215-a26e-b8e9bee0cca9.png)

**After**

![image](https://user-images.githubusercontent.com/3319450/216751056-56b1b822-3309-4ae6-ae26-5759b75f11d9.png)
