### PR TITLE
[Doors] Remove door dev tools spam on client controlled doors

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -583,6 +583,7 @@ RULE_INT(Range, SongMessages, 75, "The packet range in which song messages are s
 RULE_INT(Range, ClientPositionUpdates, 300, "Distance in which the own changed position is communicated to other clients")
 RULE_INT(Range, CriticalDamage, 80, "The packet range in which critical hit messages are sent")
 RULE_INT(Range, MobCloseScanDistance, 600, "Close scan distance")
+RULE_INT(Range, MaxDistanceToClickDoors, 30, "Max distance that a client can click a door from (Client says 'You can't reach that' at 25)")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Bots)

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -583,7 +583,7 @@ RULE_INT(Range, SongMessages, 75, "The packet range in which song messages are s
 RULE_INT(Range, ClientPositionUpdates, 300, "Distance in which the own changed position is communicated to other clients")
 RULE_INT(Range, CriticalDamage, 80, "The packet range in which critical hit messages are sent")
 RULE_INT(Range, MobCloseScanDistance, 600, "Close scan distance")
-RULE_INT(Range, MaxDistanceToClickDoors, 30, "Max distance that a client can click a door from (Client says 'You can't reach that' at 25)")
+RULE_INT(Range, MaxDistanceToClickDoors, 100, "Max distance that a client can click a door from (Client says 'You can't reach that' at roughly 25-50 for most doors)")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Bots)

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4387,7 +4387,7 @@ void Client::Handle_OP_ClickDoor(const EQApplicationPacket *app)
 		distance
 	);
 
-	bool within_distance = distance < RuleI(Range, MaxDistanceToOpenDoors);
+	bool within_distance = distance < RuleI(Range, MaxDistanceToClickDoors);
 
 	// distance gate this because some doors are client controlled and the client
 	// will spam door click even across the zone to force a door back into desired state

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4387,9 +4387,11 @@ void Client::Handle_OP_ClickDoor(const EQApplicationPacket *app)
 		distance
 	);
 
+	bool within_distance = distance < RuleI(Range, MaxDistanceToOpenDoors);
+
 	// distance gate this because some doors are client controlled and the client
 	// will spam door click even across the zone to force a door back into desired state
-	if (IsDevToolsEnabled() && distance < RuleI(Range, MaxDistanceToOpenDoors)) {
+	if (IsDevToolsEnabled() && within_distance) {
 		SetDoorToolEntityId(currentdoor->GetEntityID());
 		DoorManipulation::CommandHeader(this);
 		Message(
@@ -4402,13 +4404,21 @@ void Client::Handle_OP_ClickDoor(const EQApplicationPacket *app)
 		);
 	}
 
-	std::string export_string = fmt::format("{}", cd->doorid);
-	std::vector<std::any> args;
-	args.push_back(currentdoor);
-	if (parse->EventPlayer(EVENT_CLICK_DOOR, this, export_string, 0, &args) == 0)
-	{
+	// don't spam scripts with client controlled doors if not within distance
+	if (within_distance) {
+		std::string           export_string = fmt::format("{}", cd->doorid);
+		std::vector<std::any> args;
+		args.push_back(currentdoor);
+		if (parse->EventPlayer(EVENT_CLICK_DOOR, this, export_string, 0, &args) == 0) {
+			currentdoor->HandleClick(this, 0);
+		}
+	}
+	else {
+		// we let this pass because client controlled doors require this to force the linked doors
+		// back into state
 		currentdoor->HandleClick(this, 0);
 	}
+
 }
 
 void Client::Handle_OP_ClickObject(const EQApplicationPacket *app)

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4379,15 +4379,24 @@ void Client::Handle_OP_ClickDoor(const EQApplicationPacket *app)
 		return;
 	}
 
-	// set door selected
-	if (IsDevToolsEnabled()) {
+	float distance = DistanceNoZ(GetPosition(), currentdoor->GetPosition());
+
+	LogDoors(
+		"Door [{}] client handle, client distance from door [{:.2f}]",
+		currentdoor->GetDoorID(),
+		distance
+	);
+
+	// distance gate this because some doors are client controlled and the client
+	// will spam door click even across the zone to force a door back into desired state
+	if (IsDevToolsEnabled() && distance < RuleI(Range, MaxDistanceToOpenDoors)) {
 		SetDoorToolEntityId(currentdoor->GetEntityID());
 		DoorManipulation::CommandHeader(this);
 		Message(
 			Chat::White,
 			fmt::format(
 				"Door ({}) [{}]",
-				currentdoor->GetEntityID(),
+				currentdoor->GetDoorID(),
 				Saylink::Silent("#door edit")
 			).c_str()
 		);

--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -121,6 +121,7 @@ Doors::~Doors()
 bool Doors::Process()
 {
 	if (m_close_timer.Enabled() && m_close_timer.Check() && IsDoorOpen()) {
+		LogDoorsDetail("door open and timer triggered door_id [{}] open_type [{}]", GetDoorID(), m_open_type);
 		if (m_open_type == 40 || GetTriggerType() == 1) {
 			auto            outapp = new EQApplicationPacket(OP_MoveDoor, sizeof(MoveDoor_Struct));
 			MoveDoor_Struct *md    = (MoveDoor_Struct *) outapp->pBuffer;
@@ -627,11 +628,13 @@ void Doors::ForceOpen(Mob *sender, bool alt_mode)
 	if (!alt_mode) { // original function
 		if (!m_is_open) {
 			if (!m_disable_timer) {
+				LogDoorsDetail("door_id [{}] starting timer", md->doorid);
 				m_close_timer.Start();
 			}
 			m_is_open = true;
 		}
 		else {
+			LogDoorsDetail("door_id [{}] disable timer", md->doorid);
 			m_close_timer.Disable();
 			if (!m_disable_timer) {
 				m_is_open = false;
@@ -640,6 +643,7 @@ void Doors::ForceOpen(Mob *sender, bool alt_mode)
 	}
 	else { // alternative function
 		if (!m_disable_timer) {
+			LogDoorsDetail("door_id [{}] alt starting timer", md->doorid);
 			m_close_timer.Start();
 		}
 		m_is_open = true;
@@ -840,7 +844,7 @@ void Doors::CreateDatabaseEntry()
 
 		return;
 	}
-	
+
 	auto e = DoorsRepository::NewEntity();
 
 	e.id           = GetDoorDBID();


### PR DESCRIPTION
### What 

In certain zones, there are client controlled doors that are triggered or linked to other doors that the client will try to force into a desired state. It causes spam for GM's in various zones. This is even more so when many clients are in the zone all trying to force the state of the door simultaneously. 

![image](https://user-images.githubusercontent.com/3319450/216758400-f6645abe-f441-44e9-b0ef-c5cfa3ec3b2d.png)

It's fine to let the client control these doors, but the spam can be unruly and lead to believe that there is a deeper issue.

### Solution

The solution for now is to distance check these doors for clients before trying to display the dev tools prompt and triggering quest door click events.

If not within distance, we still process `HandleClick` internally to let the client trigger the door back to the state it should be per normal

