### PR TITLE
[Pathing] Improvements to handling tight corridors pathing, clipping detection and recovery

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -317,6 +317,7 @@ RULE_BOOL(Map, FixPathingZOnSendTo, false, "Try to repair Z coordinates in the S
 RULE_BOOL(Map, FixZWhenPathing, true, "Automatically fix NPC Z coordinates when moving/pathing/engaged (Far less CPU intensive than its predecessor)")
 RULE_REAL(Map, DistanceCanTravelBeforeAdjustment, 10.0, "Distance a mob can path before FixZ is called, depends on FixZWhenPathing")
 RULE_BOOL(Map, MobZVisualDebug, false, "Displays spell effects determining whether or not NPC is hitting Best Z calcs (blue for hit, red for miss)")
+RULE_BOOL(Map, MobPathingVisualDebug, false, "Displays nodes in pathing points in realtime to help with visual debugging")
 RULE_REAL(Map, FixPathingZMaxDeltaSendTo, 20, "At runtime in SendTo: maximum change in Z to allow the BestZ code to apply")
 RULE_INT(Map, FindBestZHeightAdjust, 1, "Adds this to the current Z before seeking the best Z position")
 RULE_CATEGORY_END()

--- a/zone/gm_commands/loc.cpp
+++ b/zone/gm_commands/loc.cpp
@@ -29,6 +29,7 @@ void command_loc(Client *c, const Seperator *sep)
 		glm::vec3 hit;
 
 		auto best_z = zone->zonemap->FindBestZ(tarloc, &hit);
+		auto fixed_z = c->GetFixedZ(c->GetPosition());
 
 		if (best_z != BEST_Z_INVALID) {
 			c->Message(
@@ -37,6 +38,14 @@ void command_loc(Client *c, const Seperator *sep)
 					"Best Z for {} | {:.2f}",
 					c->GetTargetDescription(target, TargetDescriptionType::UCSelf),
 					best_z
+				).c_str()
+			);
+			c->Message(
+				Chat::White,
+				fmt::format(
+					"Fixed Z for {} | {:.2f}",
+					c->GetTargetDescription(target, TargetDescriptionType::UCSelf),
+					fixed_z
 				).c_str()
 			);
 		} else {

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1451,6 +1451,8 @@ public:
 	void SetManualFollow(bool flag) { m_manual_follow = flag; }
 	bool GetManualFollow() const { return m_manual_follow; }
 
+	void DrawDebugCoordinateNode(std::string node_name, const glm::vec4 vec);
+
 protected:
 	void CommonDamage(Mob* other, int64 &damage, const uint16 spell_id, const EQ::skills::SkillType attack_skill, bool &avoidable, const int8 buffslot, const bool iBuffTic, eSpecialAttacks specal = eSpecialAttacks::None);
 	static uint16 GetProcID(uint16 spell_id, uint8 effect_index);

--- a/zone/mob_movement_manager.cpp
+++ b/zone/mob_movement_manager.cpp
@@ -138,7 +138,7 @@ public:
 			return true;
 		}
 
-		//Send a movement packet when you start moving		
+		//Send a movement packet when you start moving
 		double current_time  = static_cast<double>(Timer::GetCurrentTime()) / 1000.0;
 		int    current_speed = 0;
 
@@ -1053,6 +1053,13 @@ void MobMovementManager::FillCommandStruct(
 	position_update->delta_z       = FloatToEQ13(delta_z);
 	position_update->delta_heading = FloatToEQ10(delta_heading);
 	position_update->animation     = (mob->IsBot() ? (int) ((float) anim / 1.785714f) : anim);
+
+	if (RuleB(Map, MobPathingVisualDebug)) {
+		mob->DrawDebugCoordinateNode(
+			fmt::format("{} position update", mob->GetCleanName()),
+			mob->GetPosition()
+		);
+	}
 }
 
 /**
@@ -1093,7 +1100,7 @@ void MobMovementManager::UpdatePath(Mob *who, float x, float y, float z, MobMove
 		}
 	// Below for npcs that can traverse land or water so they don't sink
 	else if (who->GetFlyMode() == GravityBehavior::Water &&
-			 zone->watermap->InLiquid(who->GetPosition()) && 
+			 zone->watermap->InLiquid(who->GetPosition()) &&
 			 zone->watermap->InLiquid(glm::vec3(x, y, z)) &&
 			 zone->zonemap->CheckLoS(who->GetPosition(), glm::vec3(x, y, z))) {
 		auto iter = _impl->Entries.find(who);

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -6415,7 +6415,7 @@ void Client::SetItemRecastTimer(int32 spell_id, uint32 inventory_slot)
 	recast_delay = std::max(recast_delay, 0);
 
 	if (recast_delay > 0) {
-		
+
 		if (recast_type != RECAST_TYPE_UNLINKED_ITEM) {
 			GetPTimers().Start((pTimerItemStart + recast_type), static_cast<uint32>(recast_delay));
 			database.UpdateItemRecast(
@@ -6441,14 +6441,14 @@ void Client::SetItemRecastTimer(int32 spell_id, uint32 inventory_slot)
 void Client::DeleteItemRecastTimer(uint32 item_id)
 {
     const auto* d = database.GetItem(item_id);
-    
+
     if (!d) {
         return;
     }
 
     const auto recast_type = d->RecastType != RECAST_TYPE_UNLINKED_ITEM ? d->RecastType : item_id;
     const int timer_id = d->RecastType != RECAST_TYPE_UNLINKED_ITEM ? (pTimerItemStart + recast_type) : (pTimerNegativeItemReuse * item_id);
-    
+
     database.DeleteItemRecast(CharacterID(), recast_type);
     GetPTimers().Clear(&database, timer_id);
 
@@ -7001,4 +7001,18 @@ void Mob::SetHP(int64 hp)
 	}
 
 	current_hp = hp;
+}
+
+void Mob::DrawDebugCoordinateNode(std::string node_name, const glm::vec4 vec)
+{
+	NPC* node = nullptr;
+	for (const auto& n : entity_list.GetNPCList()) {
+		if (n.second->GetCleanName() == node_name) {
+			node = n.second;
+			break;
+		}
+	}
+	if (!node) {
+		node = NPC::SpawnNodeNPC(node_name, "", GetPosition());
+	}
 }


### PR DESCRIPTION
### What

Issue that has plagued servers for years now is that NPC's will Z correct and clip into the ceilings, causing all kinds of nasty pathing and aggro issues which are annoying for players and server operators

### Solution

Two parts

* NPC's now calculate ground Z by targetting the true ground below them, not using their model and offset Z to perform the calculation. This would result in larger sized NPC's and models finding the ceiling to be closer than the ground below them and thus clipping into the ceiling
* When an NPC clips - which should happen far less frequently now. There is a mechanism to recover them when their previous Z is all of a sudden dramatically different from what it was previously and the NPC is still close to the player (Not taking Z into consideration), the NPC will gracefully recover to the player

**Before**

https://user-images.githubusercontent.com/3319450/216793442-8e7fe7dd-c185-4295-9212-28eeea584d14.mp4

**After**

https://user-images.githubusercontent.com/3319450/216793667-84204fd1-d365-4429-b5bf-c7aa8ac5c7dc.mp4

### More Testing (After fix)

**Karnors warlord room (Reported by Tossica)**

https://cdn.discordapp.com/attachments/557677602706423982/1071590989472469032/karnor-warlord-room.mp4

**Plane of Valor hill clipping (Reported by Nite)**

https://cdn.discordapp.com/attachments/557677602706423982/1071588397484875876/povalor-clipping-hill.mp4

https://cdn.discordapp.com/attachments/557677602706423982/1071587008608215100/povalor-clipping.mp4

**Dalnir (reported by Seppuku)**

https://cdn.discordapp.com/attachments/557677602706423982/1071580070633812058/dalnir.mp4

**Veeshan**

https://cdn.discordapp.com/attachments/557677602706423982/1071575844079804517/clipping-no-debug.mp4

### Visual Debugging

Visual debuggers were added (expensive) via rules `Map:MobPathingVisualDebug` which will illustrate position update targets as well as when a new fixed Z were calculated. Adding too many of these can create a lot of visual noise that makes it hard to understand what is occurring. Visual debugging is also an expensive operation which will make the mobs appear like they are moving in "stop motion"

### Misc

* Wurm models as seen in Veeshans Peak had the wrong offset so they were clipping into the floor during testing, they have been corrected
* #loc now also displays `GetFixedZ` not just ground z

