### PR TITLE
[Quest API] Add rule AlternateAugmentationSealer for using a different bagtype

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -744,6 +744,7 @@ RULE_BOOL(Inventory, DeleteTransformationMold, true, "False if you want mold to 
 RULE_BOOL(Inventory, AllowAnyWeaponTransformation, false, "Weapons can use any weapon transformation")
 RULE_BOOL(Inventory, TransformSummonedBags, false, "Transforms summoned bags into disenchanted ones instead of deleting")
 RULE_BOOL(Inventory, AllowMultipleOfSameAugment, false, "Allows multiple of the same augment to be placed in an item via #augmentitem or MQ2, set to true to allow")
+RULE_INT(Inventory, AlternateAugmentationSealer, 57, "Allows RoF+ clients to augment items from a special container type")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Client)

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -744,7 +744,7 @@ RULE_BOOL(Inventory, DeleteTransformationMold, true, "False if you want mold to 
 RULE_BOOL(Inventory, AllowAnyWeaponTransformation, false, "Weapons can use any weapon transformation")
 RULE_BOOL(Inventory, TransformSummonedBags, false, "Transforms summoned bags into disenchanted ones instead of deleting")
 RULE_BOOL(Inventory, AllowMultipleOfSameAugment, false, "Allows multiple of the same augment to be placed in an item via #augmentitem or MQ2, set to true to allow")
-RULE_INT(Inventory, AlternateAugmentationSealer, 57, "Allows RoF+ clients to augment items from a special container type")
+RULE_INT(Inventory, AlternateAugmentationSealer, 53, "Allows RoF+ clients to augment items from a special container type")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Client)

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -11960,3 +11960,11 @@ void Client::SendPath(Mob* target)
 
 	SendPathPacket(points);
 }
+
+void Client::UseAugmentContainer(int container_slot) {
+	auto in_augment = new AugmentItem_Struct[sizeof(AugmentItem_Struct)];
+	in_augment->container_slot = container_slot;
+	in_augment->augment_slot = -1;
+	Object::HandleAugmentation(this, in_augment, nullptr);
+	safe_delete_array(in_augment);
+}

--- a/zone/client.h
+++ b/zone/client.h
@@ -952,6 +952,7 @@ public:
 	void MemorizeSpell(uint32 slot, uint32 spellid, uint32 scribing, uint32 reduction = 0);
 
 	// Item methods
+	void UseAugmentContainer(int container_slot);
 	void EVENT_ITEM_ScriptStopReturn();
 	uint32 NukeItem(uint32 itemnum, uint8 where_to_check =
 			(invWhereWorn | invWherePersonal | invWhereBank | invWhereSharedBank | invWhereTrading | invWhereCursor));

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3032,6 +3032,12 @@ uint32 Lua_Client::GetItemCooldown(uint32 item_id)
 	return self->GetItemCooldown(item_id);
 }
 
+void Lua_Client::UseAugmentContainer(int container_slot)
+{
+	Lua_Safe_Call_Void();
+	self->UseAugmentContainer(container_slot);
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 	.def(luabind::constructor<>())
@@ -3553,6 +3559,7 @@ luabind::scope lua_register_client() {
 	.def("UpdateLDoNPoints", (void(Lua_Client::*)(uint32,int))&Lua_Client::UpdateLDoNPoints)
 	.def("UpdateTaskActivity", (void(Lua_Client::*)(int,int,int))&Lua_Client::UpdateTaskActivity)
 	.def("UseDiscipline", (bool(Lua_Client::*)(int,int))&Lua_Client::UseDiscipline)
+	.def("UseAugmentContainer", (void(Lua_Client::*)(int))&Lua_Client::UseAugmentContainer)
 	.def("WorldKick", (void(Lua_Client::*)(void))&Lua_Client::WorldKick);
 }
 

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -465,6 +465,7 @@ public:
 	void ResetItemCooldown(uint32 item_id);
 	void SetItemCooldown(uint32 item_id, uint32 in_time);
 	uint32 GetItemCooldown(uint32 item_id);
+	void UseAugmentContainer(int container_slot);
 
 	void ApplySpell(int spell_id);
 	void ApplySpell(int spell_id, int duration);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -2887,6 +2887,11 @@ uint32 Perl_Client_GetItemCooldown(Client* self, uint32 item_id)
 	return self->GetItemCooldown(item_id);
 }
 
+void Perl_Client_UseAugmentContainer(Client* self, int container_slot)
+{
+	self->UseAugmentContainer(container_slot);
+}
+
 void perl_register_client()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3414,6 +3419,7 @@ void perl_register_client()
 	package.add("UpdateWho", (void(*)(Client*))&Perl_Client_UpdateWho);
 	package.add("UpdateWho", (void(*)(Client*, uint8))&Perl_Client_UpdateWho);
 	package.add("UseDiscipline", &Perl_Client_UseDiscipline);
+	package.add("UseAugmentContainer", &Perl_Client_UseAugmentContainer);
 	package.add("WorldKick", &Perl_Client_WorldKick);
 }
 

--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -59,7 +59,7 @@ void Object::HandleAugmentation(Client* user, const AugmentItem_Struct* in_augme
 		inst = user_inv.GetItem(in_augment->container_slot);
 		if (inst) {
 			const EQ::ItemData* item = inst->GetItem();
-			if (item && inst->IsType(EQ::item::ItemClassBag) && item->BagType == EQ::item::BagTypeAugmentationSealer) { // We have found an appropriate inventory augmentation sealer
+			if (item && inst->IsType(EQ::item::ItemClassBag) && (item->BagType == EQ::item::BagTypeAugmentationSealer || item->BagType == RuleI(Inventory, AlternateAugmentationSealer))) { // We have found an appropriate inventory augmentation sealer
 				container = inst;
 
 				// Verify that no more than two items are in container to guarantee no inadvertant wipes.


### PR DESCRIPTION
…t bagtype as an alternate augmentation sealer. Use EVENT_COMBINE with UseAugmentContainer

Lua Example
```lua
function event_combine(e)
	local bag_id = e.self:GetItemIDAt(e.container_slot)
	if (bag_id == 1267) then
		e.self:UseAugmentContainer(e.container_slot)
		return 1;
	end
end
```

Perl Example
```perl
sub EVENT_COMBINE {
	my $bag_id = $client->GetItemIDAt($container_slot);
	if ($bag_id == 1267) {
		$client->UseAugmentContainer($container_slot); 
		return 1; #We did a custom combine return 1
	}
}
```