### PR TITLE
[Bug Fix] Fix for undefined MySQL library behavior.

### DIFF
--- a/client_files/export/main.cpp
+++ b/client_files/export/main.cpp
@@ -86,7 +86,16 @@ int main(int argc, char **argv)
 			return 1;
 		}
 	} else {
-		content_db.SetMysql(database.getMySQL());
+		if (!content_db.Connect(
+			Config->DatabaseHost.c_str(),
+			Config->DatabaseUsername.c_str(),
+			Config->DatabasePassword.c_str(),
+			Config->DatabaseDB.c_str(),
+			Config->DatabasePort
+		)) {
+			LogError("Cannot continue without a content database connection");
+			return 1;
+		}
 	}
 
 	LogSys.SetDatabase(&database)

--- a/client_files/export/main.cpp
+++ b/client_files/export/main.cpp
@@ -86,16 +86,7 @@ int main(int argc, char **argv)
 			return 1;
 		}
 	} else {
-		if (!content_db.Connect(
-			Config->DatabaseHost.c_str(),
-			Config->DatabaseUsername.c_str(),
-			Config->DatabasePassword.c_str(),
-			Config->DatabaseDB.c_str(),
-			Config->DatabasePort
-		)) {
-			LogError("Cannot continue without a content database connection");
-			return 1;
-		}
+		content_db.SetMySQL(database);
 	}
 
 	LogSys.SetDatabase(&database)

--- a/client_files/import/main.cpp
+++ b/client_files/import/main.cpp
@@ -83,7 +83,16 @@ int main(int argc, char **argv) {
 			return 1;
 		}
 	} else {
-		content_db.SetMysql(database.getMySQL());
+		if (!content_db.Connect(
+			Config->DatabaseHost.c_str(),
+			Config->DatabaseUsername.c_str(),
+			Config->DatabasePassword.c_str(),
+			Config->DatabaseDB.c_str(),
+			Config->DatabasePort
+		)) {
+			LogError("Cannot continue without a content database connection");
+			return 1;
+		}
 	}
 
 	LogSys.SetDatabase(&database)

--- a/client_files/import/main.cpp
+++ b/client_files/import/main.cpp
@@ -83,16 +83,7 @@ int main(int argc, char **argv) {
 			return 1;
 		}
 	} else {
-		if (!content_db.Connect(
-			Config->DatabaseHost.c_str(),
-			Config->DatabaseUsername.c_str(),
-			Config->DatabasePassword.c_str(),
-			Config->DatabaseDB.c_str(),
-			Config->DatabasePort
-		)) {
-			LogError("Cannot continue without a content database connection");
-			return 1;
-		}
+		content_db.SetMySQL(database);
 	}
 
 	LogSys.SetDatabase(&database)

--- a/common/dbcore.cpp
+++ b/common/dbcore.cpp
@@ -34,16 +34,16 @@
 
 DBcore::DBcore()
 {
-	mysql           = mysql_init(nullptr);
-	mysqlOwner		= true;
-	pHost           = nullptr;
-	pUser           = nullptr;
-	pPassword       = nullptr;
-	pDatabase       = nullptr;
-	pCompress       = false;
-	pSSL            = false;
-	pStatus         = Closed;
-	m_mutex         = new Mutex;
+	mysql      = mysql_init(nullptr);
+	mysqlOwner = true;
+	pHost      = nullptr;
+	pUser      = nullptr;
+	pPassword  = nullptr;
+	pDatabase  = nullptr;
+	pCompress  = false;
+	pSSL       = false;
+	pStatus    = Closed;
+	m_mutex    = new Mutex;
 }
 
 DBcore::~DBcore()

--- a/common/dbcore.cpp
+++ b/common/dbcore.cpp
@@ -284,11 +284,6 @@ bool DBcore::Open(uint32 *errnum, char *errbuf)
 	}
 }
 
-void DBcore::SetMysql(MYSQL *mysql)
-{
-	DBcore::mysql = *mysql;
-}
-
 const std::string &DBcore::GetOriginHost() const
 {
 	return origin_host;

--- a/common/dbcore.cpp
+++ b/common/dbcore.cpp
@@ -294,7 +294,7 @@ std::string DBcore::Escape(const std::string& s)
 {
 	const std::size_t s_len = s.length();
 	std::vector<char> temp((s_len * 2) + 1, '\0');
-	mysql_real_escape_string(&mysql, temp.data(), s.c_str(), s_len);
+	mysql_real_escape_string(mysql, temp.data(), s.c_str(), s_len);
 
 	return temp.data();
 }

--- a/common/dbcore.h
+++ b/common/dbcore.h
@@ -31,8 +31,6 @@ public:
 	std::string Escape(const std::string& s);
 	uint32 DoEscapeString(char *tobuf, const char *frombuf, uint32 fromlen);
 	void ping();
-	MYSQL *getMySQL() { return &mysql; }
-	void SetMysql(MYSQL *mysql);
 
 	const std::string &GetOriginHost() const;
 	void SetOriginHost(const std::string &origin_host);

--- a/common/dbcore.h
+++ b/common/dbcore.h
@@ -37,7 +37,12 @@ public:
 
 	bool DoesTableExist(std::string table_name);
 
-	void SetMySQL(const DBcore& o) { mysql = o.mysql; mysqlOwner = false; }
+	void SetMySQL(const DBcore &o)
+	{
+		mysql      = o.mysql;
+		mysqlOwner = false;
+	}
+	void SetMutex(Mutex *mutex);
 
 protected:
 	bool Open(
@@ -56,8 +61,8 @@ private:
 	bool Open(uint32 *errnum = nullptr, char *errbuf = nullptr);
 
 	MYSQL*  mysql;
-	bool	mysqlOwner;
-	Mutex   MDatabase;
+	bool    mysqlOwner;
+	Mutex   *m_mutex;
 	eStatus pStatus;
 
 	std::mutex m_query_lock{};

--- a/common/dbcore.h
+++ b/common/dbcore.h
@@ -37,6 +37,8 @@ public:
 
 	bool DoesTableExist(std::string table_name);
 
+	void SetMySQL(const DBcore& o) { mysql = o.mysql; mysqlOwner = false; }
+
 protected:
 	bool Open(
 		const char *iHost,
@@ -53,7 +55,8 @@ protected:
 private:
 	bool Open(uint32 *errnum = nullptr, char *errbuf = nullptr);
 
-	MYSQL   mysql;
+	MYSQL*  mysql;
+	bool	mysqlOwner;
 	Mutex   MDatabase;
 	eStatus pStatus;
 

--- a/shared_memory/main.cpp
+++ b/shared_memory/main.cpp
@@ -124,16 +124,7 @@ int main(int argc, char **argv)
 			return 1;
 		}
 	} else {
-		if (!content_db.Connect(
-			Config->DatabaseHost.c_str(),
-			Config->DatabaseUsername.c_str(),
-			Config->DatabasePassword.c_str(),
-			Config->DatabaseDB.c_str(),
-			Config->DatabasePort
-		)) {
-			LogError("Cannot continue without a content database connection");
-			return 1;
-		}
+		content_db.SetMySQL(database);
 	}
 
 	LogSys.SetDatabase(&database)

--- a/shared_memory/main.cpp
+++ b/shared_memory/main.cpp
@@ -124,7 +124,16 @@ int main(int argc, char **argv)
 			return 1;
 		}
 	} else {
-		content_db.SetMysql(database.getMySQL());
+		if (!content_db.Connect(
+			Config->DatabaseHost.c_str(),
+			Config->DatabaseUsername.c_str(),
+			Config->DatabasePassword.c_str(),
+			Config->DatabaseDB.c_str(),
+			Config->DatabasePort
+		)) {
+			LogError("Cannot continue without a content database connection");
+			return 1;
+		}
 	}
 
 	LogSys.SetDatabase(&database)

--- a/world/cli/database_concurrency.cpp
+++ b/world/cli/database_concurrency.cpp
@@ -1,0 +1,73 @@
+#include <thread>
+#include "../../common/repositories/zone_repository.h"
+#include "../../common/eqemu_config.h"
+#include <signal.h>
+
+Database db;
+Database db2;
+
+volatile sig_atomic_t stop;
+void inthand(int signum) {
+	stop = 1;
+}
+
+[[noreturn]] void DatabaseTest()
+{
+	while (true) {
+		LogInfo("DatabaseTest Query");
+		db.QueryDatabase("SELECT 1");
+	}
+}
+
+[[noreturn]] void DatabaseTestSecondConnection()
+{
+	while (true) {
+		LogInfo("DatabaseTest Query");
+		db2.QueryDatabase("SELECT 1");
+	}
+}
+
+
+void WorldserverCLI::TestDatabaseConcurrency(int argc, char **argv, argh::parser &cmd, std::string &description)
+{
+	description = "Test command to test database concurrency";
+
+	if (cmd[{"-h", "--help"}]) {
+		return;
+	}
+
+	signal(SIGINT, inthand);
+
+	LogInfo("Database test");
+
+	auto mutex = new Mutex;
+
+	auto c = EQEmuConfig::get();
+	LogInfo("Connecting to MySQL");
+	if (!db.Connect(
+		c->DatabaseHost.c_str(),
+		c->DatabaseUsername.c_str(),
+		c->DatabasePassword.c_str(),
+		c->DatabaseDB.c_str(),
+		c->DatabasePort
+	)) {
+		LogError("Cannot continue without a database connection");
+		return;
+	}
+
+	db.SetMutex(mutex);
+
+	db2.SetMySQL(db);
+
+	db2.SetMutex(mutex);
+
+	std::thread(DatabaseTest).detach();
+	std::thread(DatabaseTest).detach();
+	std::thread(DatabaseTestSecondConnection).detach();
+
+	while (!stop) {
+
+	}
+
+	safe_delete(mutex);
+}

--- a/world/main.cpp
+++ b/world/main.cpp
@@ -478,6 +478,8 @@ int main(int argc, char **argv)
 	LogInfo("Signaling HTTP service to stop");
 	LogSys.CloseFileLogs();
 
+	WorldBoot::Shutdown();
+
 	return 0;
 }
 

--- a/world/world_boot.cpp
+++ b/world/world_boot.cpp
@@ -153,17 +153,7 @@ bool WorldBoot::LoadDatabaseConnections()
 		}
 	}
 	else {
-		if (!content_db.Connect(
-			c->DatabaseHost.c_str(),
-			c->DatabaseUsername.c_str(),
-			c->DatabasePassword.c_str(),
-			c->DatabaseDB.c_str(),
-			c->DatabasePort,
-			"content"
-		)) {
-			LogError("Cannot continue without a content database connection");
-			return false;
-		}
+		content_db.SetMySQL(database);
 	}
 
 	return true;

--- a/world/world_boot.cpp
+++ b/world/world_boot.cpp
@@ -153,7 +153,17 @@ bool WorldBoot::LoadDatabaseConnections()
 		}
 	}
 	else {
-		content_db.SetMysql(database.getMySQL());
+		if (!content_db.Connect(
+			c->DatabaseHost.c_str(),
+			c->DatabaseUsername.c_str(),
+			c->DatabasePassword.c_str(),
+			c->DatabaseDB.c_str(),
+			c->DatabasePort,
+			"content"
+		)) {
+			LogError("Cannot continue without a content database connection");
+			return false;
+		}
 	}
 
 	return true;

--- a/world/world_boot.h
+++ b/world/world_boot.h
@@ -15,6 +15,7 @@ public:
 	static void RegisterLoginservers();
 	static bool DatabaseLoadRoutines(int argc, char **argv);
 	static void CheckForPossibleConfigurationIssues();
+	static void Shutdown();
 };
 
 

--- a/world/world_server_cli.cpp
+++ b/world/world_server_cli.cpp
@@ -31,10 +31,12 @@ void WorldserverCLI::CommandHandler(int argc, char **argv)
 	function_map["test:expansion"]              = &WorldserverCLI::ExpansionTestCommand;
 	function_map["test:repository"]             = &WorldserverCLI::TestRepository;
 	function_map["test:repository2"]            = &WorldserverCLI::TestRepository2;
+	function_map["test:db-concurrency"]         = &WorldserverCLI::TestDatabaseConcurrency;
 
 	EQEmuCommand::HandleMenu(function_map, cmd, argc, argv);
 }
 
+#include "cli/database_concurrency.cpp"
 #include "cli/copy_character.cpp"
 #include "cli/database_dump.cpp"
 #include "cli/database_get_schema.cpp"

--- a/world/world_server_cli.h
+++ b/world/world_server_cli.h
@@ -18,6 +18,7 @@ public:
 	static void ExpansionTestCommand(int argc, char **argv, argh::parser &cmd, std::string &description);
 	static void TestRepository(int argc, char **argv, argh::parser &cmd, std::string &description);
 	static void TestRepository2(int argc, char **argv, argh::parser &cmd, std::string &description);
+	static void TestDatabaseConcurrency(int argc, char **argv, argh::parser &cmd, std::string &description);
 };
 
 

--- a/zone/main.cpp
+++ b/zone/main.cpp
@@ -258,17 +258,7 @@ int main(int argc, char** argv) {
 			return 1;
 		}
 	} else {
-		if (!content_db.Connect(
-			Config->DatabaseHost.c_str(),
-			Config->DatabaseUsername.c_str(),
-			Config->DatabasePassword.c_str(),
-			Config->DatabaseDB.c_str(),
-			Config->DatabasePort,
-			"content"
-		)) {
-			LogError("Cannot continue without a content database connection");
-			return 1;
-		}
+		content_db.SetMySQL(database);
 	}
 
 	/* Register Log System and Settings */

--- a/zone/main.cpp
+++ b/zone/main.cpp
@@ -258,7 +258,17 @@ int main(int argc, char** argv) {
 			return 1;
 		}
 	} else {
-		content_db.SetMysql(database.getMySQL());
+		if (!content_db.Connect(
+			Config->DatabaseHost.c_str(),
+			Config->DatabaseUsername.c_str(),
+			Config->DatabasePassword.c_str(),
+			Config->DatabaseDB.c_str(),
+			Config->DatabasePort,
+			"content"
+		)) {
+			LogError("Cannot continue without a content database connection");
+			return 1;
+		}
 	}
 
 	/* Register Log System and Settings */


### PR DESCRIPTION
The MYSQL structure in the MySQL C api is not copy aware. This isn't enforced because, well, C doesn't enforce anything really. 
See: [MySQL Structures](https://dev.mysql.com/doc/c-api/8.0/en/c-api-data-structures.html)

This changes the copy of an existing connection to instead create a second backup connection with the same data as what is being copied.  This does introduce another connection into the mix which are a limited resource but given the potential seriousness of the bug in question it seems like a fair tradeoff for now.  

Long term we can rewrite the dbcore class to use a underlying pointer instead of a pinned in place variable.