### PR TITLE
[DB Updates] Add Windows MySQL path auto detection for users where the path is not found

### DIFF
--- a/utils/scripts/eqemu_server.pl
+++ b/utils/scripts/eqemu_server.pl
@@ -1199,6 +1199,25 @@ sub get_mysql_path
                 }
             }
         }
+        if ($path eq "") {
+            my @files;
+            my $start_dir = trim(`echo %programfiles%`);
+            find(
+                sub {
+                    if ($#files > 0) {
+                        return;
+                    }
+                    push @files, $File::Find::name unless $File::Find::name!~/mysql.exe/i;
+                },
+                $start_dir
+            );
+            for my $file (@files) {
+                if ($file=~/mysql.exe/i) {
+                    $path = $file;
+                    last;
+                }
+            }
+        }
     }
     if ($OS eq "Linux") {
         $path = `which mysql`;


### PR DESCRIPTION
### What

Windows has a tendenancy to be unreliable when manipulating the `Path` environment variable. Many folks even after an installation are still missing their path. That's even after our use of https://github.com/therootcompany/pathman within the installer.

This adds a file walker to find the MySQL binary automatically as a second measure if the path is not found. This is leading to updates not running for folks.

Long term solution will be to just embed database updates within the server binary and take it out of the script; we can also do some update checking to further reduce this issue