### PR TITLE
[Bots] Add Additional HeroicStr modifiers.

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -871,16 +871,16 @@ int Mob::ACSum(bool skip_caps)
 	int ac = 0; // this should be base AC whenever shrouds come around
 	ac += itembonuses.AC; // items + food + tribute
 	int shield_ac = 0;
-	if (HasShieldEquiped() && IsClient()) {
-		auto client = CastToClient();
-		auto inst = client->GetInv().GetItem(EQ::invslot::slotSecondary);
+	if (HasShieldEquiped() && (IsClient() || IsBot())) {
+		auto inst = (IsClient()) ? GetInv().GetItem(EQ::invslot::slotSecondary) : CastToBot()->GetBotItem(EQ::invslot::slotSecondary);
 		if (inst) {
-			if (inst->GetItemRecommendedLevel(true) <= GetLevel())
+			if (inst->GetItemRecommendedLevel(true) <= GetLevel()) {
 				shield_ac = inst->GetItemArmorClass(true);
-			else
-				shield_ac = client->CalcRecommendedLevelBonus(GetLevel(), inst->GetItemRecommendedLevel(true), inst->GetItemArmorClass(true));
+			} else {
+				shield_ac = CalcRecommendedLevelBonus(GetLevel(), inst->GetItemRecommendedLevel(true), inst->GetItemArmorClass(true));
+			}
 		}
-		shield_ac += client->GetHeroicSTR() / 10;
+		shield_ac += GetHeroicSTR() / 10;
 	}
 	// EQ math
 	ac = (ac * 4) / 3;
@@ -5793,16 +5793,16 @@ void Mob::CommonOutgoingHitSuccess(Mob* defender, DamageHitInfo &hit, ExtraAttac
 	TryCriticalHit(defender, hit, opts);
 
 	hit.damage_done += hit.min_damage;
-	if (IsClient()) {
+	if (IsClient() || IsBot()) {
 		int extra = 0;
 		switch (hit.skill) {
-		case EQ::skills::SkillThrowing:
-		case EQ::skills::SkillArchery:
-			extra = CastToClient()->GetHeroicDEX() / 10;
-			break;
-		default:
-			extra = CastToClient()->GetHeroicSTR() / 10;
-			break;
+			case EQ::skills::SkillThrowing:
+			case EQ::skills::SkillArchery:
+				extra = GetHeroicDEX() / 10;
+				break;
+			default:
+				extra = GetHeroicSTR() / 10;
+				break;
 		}
 		hit.damage_done += extra;
 	}

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -128,7 +128,7 @@ void Client::CalcBonuses()
 		consume_food_timer.SetTimer(timer);
 }
 
-int Client::CalcRecommendedLevelBonus(uint8 level, uint8 reclevel, int basestat)
+int Mob::CalcRecommendedLevelBonus(uint8 level, uint8 reclevel, int basestat)
 {
 	if( (reclevel > 0) && (level < reclevel) )
 	{

--- a/zone/client.h
+++ b/zone/client.h
@@ -1681,7 +1681,6 @@ protected:
 	void CalcItemBonuses(StatBonuses* newbon);
 	void AddItemBonuses(const EQ::ItemInstance *inst, StatBonuses* newbon, bool isAug = false, bool isTribute = false, int rec_override = 0, bool ammo_slot_item = false);
 	void AdditiveWornBonuses(const EQ::ItemInstance *inst, StatBonuses* newbon, bool isAug = false);
-	int CalcRecommendedLevelBonus(uint8 level, uint8 reclevel, int basestat);
 	void CalcEdibleBonuses(StatBonuses* newbon);
 	void ProcessItemCaps();
 	void MakeBuffFadePacket(uint16 spell_id, int slot_id, bool send_message = true);

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -657,7 +657,7 @@ public:
 	inline int32 GetHeroicStrikethrough() const  { return heroic_strikethrough; }
 	inline const bool GetKeepsSoldItems() const { return keeps_sold_items; }
 	inline void SetKeepsSoldItems(bool in_keeps_sold_items)  { keeps_sold_items = in_keeps_sold_items; }
-
+	int CalcRecommendedLevelBonus(uint8 level, uint8 reclevel, int basestat);
 	void CopyHateList(Mob* to);
 
 	//Group

--- a/zone/tune.cpp
+++ b/zone/tune.cpp
@@ -1040,16 +1040,16 @@ int64 Mob::TuneACSum(bool skip_caps, int ac_override, int add_ac)
 	}
 
 	int shield_ac = 0;
-	if (HasShieldEquiped() && IsClient()) {
-		auto client = CastToClient();
-		auto inst = client->GetInv().GetItem(EQ::invslot::slotSecondary);
+	if (HasShieldEquiped() && (IsClient() || IsBot())) {
+		auto inst = (IsClient()) ? GetInv().GetItem(EQ::invslot::slotSecondary) : CastToBot()->GetBotItem(EQ::invslot::slotSecondary);
 		if (inst) {
-			if (inst->GetItemRecommendedLevel(true) <= GetLevel())
+			if (inst->GetItemRecommendedLevel(true) <= GetLevel()) {
 				shield_ac = inst->GetItemArmorClass(true);
-			else
-				shield_ac = client->CalcRecommendedLevelBonus(GetLevel(), inst->GetItemRecommendedLevel(true), inst->GetItemArmorClass(true));
+			} else {
+				shield_ac = CalcRecommendedLevelBonus(GetLevel(), inst->GetItemRecommendedLevel(true),inst->GetItemArmorClass(true));
+			}
 		}
-		shield_ac += client->GetHeroicSTR() / 10;
+		shield_ac += GetHeroicSTR() / 10;
 	}
 	// EQ math
 	ac = (ac * 4) / 3;
@@ -1490,15 +1490,15 @@ void Mob::TuneCommonOutgoingHitSuccess(Mob* defender, DamageHitInfo &hit, ExtraA
 		hit.damage_done = min_mod;
 
 	hit.damage_done += hit.min_damage;
-	if (IsClient()) {
+	if (IsClient() || IsBot()) {
 		int extra = 0;
 		switch (hit.skill) {
 		case EQ::skills::SkillThrowing:
 		case EQ::skills::SkillArchery:
-			extra = CastToClient()->GetHeroicDEX() / 10;
+			extra = GetHeroicDEX() / 10;
 			break;
 		default:
-			extra = CastToClient()->GetHeroicSTR() / 10;
+			extra = GetHeroicSTR() / 10;
 			break;
 		}
 		hit.damage_done += extra;


### PR DESCRIPTION
Heroic Strength wasn't applying to Shield AC, and Weapon damage hits for Bots, in addition this also lets Heroic Dex to apply to Archery + Throwing for them too.