### PR TITLE
[Bots] Add Additional HeroicAgi/Dex Modifiers.

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -248,8 +248,9 @@ int Mob::compute_defense()
 {
 	int defense = GetSkill(EQ::skills::SkillDefense) * 400 / 225;
 	defense += (8000 * (GetAGI() - 40)) / 36000;
-	if (IsClient())
-		defense += CastToClient()->GetHeroicAGI() / 10;
+	if (IsClient() || IsBot()) {
+		defense += GetHeroicAGI() / 10;
+	}
 
 	//516 SE_AC_Mitigation_Max_Percent
 	auto ac_bonus = itembonuses.AC_Mitigation_Max_Percent + aabonuses.AC_Mitigation_Max_Percent + spellbonuses.AC_Mitigation_Max_Percent;

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -2173,8 +2173,9 @@ int Mob::TryHeadShot(Mob *defender, EQ::skills::SkillType skillInUse)
 		if (HeadShot_Dmg && HeadShot_Level && (defender->GetLevel() <= HeadShot_Level)) {
 			int chance = GetDEX();
 			chance = 100 * chance / (chance + 3500);
-			if (IsClient())
-				chance += CastToClient()->GetHeroicDEX() / 25;
+			if (IsClient() || IsBot()) {
+				chance += GetHeroicDEX() / 25;
+			}
 			chance *= 10;
 			int norm = aabonuses.HSLevel[SBIndex::FINISHING_EFFECT_LEVEL_CHANCE_BONUS];
 			if (norm > 0)
@@ -2204,8 +2205,9 @@ int Mob::TryAssassinate(Mob *defender, EQ::skills::SkillType skillInUse)
 		int chance = GetDEX();
 		if (skillInUse == EQ::skills::SkillBackstab) {
 			chance = 100 * chance / (chance + 3500);
-			if (IsClient())
-				chance += CastToClient()->GetHeroicDEX();
+			if (IsClient() || IsBot()) {
+				chance += GetHeroicDEX();
+			}
 			chance *= 10;
 			int norm = aabonuses.AssassinateLevel[SBIndex::FINISHING_EFFECT_LEVEL_CHANCE_BONUS];
 			if (norm > 0)

--- a/zone/tune.cpp
+++ b/zone/tune.cpp
@@ -1348,12 +1348,12 @@ int64 Mob::Tunecompute_defense(int avoidance_override, int add_avoidance)
 {
 	int defense = GetSkill(EQ::skills::SkillDefense) * 400 / 225;
 	defense += (8000 * (GetAGI() - 40)) / 36000;
-	if (IsClient()) {
+	if (IsClient() || IsBot()) {
 		if (avoidance_override) {
 			defense = avoidance_override;
 		}
-		else {
-			defense += CastToClient()->GetHeroicAGI() / 10;
+		else {orp
+			defense += GetHeroicAGI() / 10;
 		}
 		defense += add_avoidance; //1 pt = 10 heroic agi
 	}

--- a/zone/tune.cpp
+++ b/zone/tune.cpp
@@ -1352,7 +1352,7 @@ int64 Mob::Tunecompute_defense(int avoidance_override, int add_avoidance)
 		if (avoidance_override) {
 			defense = avoidance_override;
 		}
-		else {orp
+		else {
 			defense += GetHeroicAGI() / 10;
 		}
 		defense += add_avoidance; //1 pt = 10 heroic agi


### PR DESCRIPTION
Allows Bots to benefit from HeroicAgi to their defense calculations.
Allows Bots to benefit from Heroic Dex for chance to Headshot or Assassinate