### PR TITLE
[Rules] Fix rule updates regression that affected bot booting checks

### DIFF
--- a/common/database_conversions.cpp
+++ b/common/database_conversions.cpp
@@ -476,10 +476,11 @@ bool Database::CheckDatabaseConversions() {
 	CheckDatabaseConvertPPDeblob();
 	CheckDatabaseConvertCorpseDeblob();
 
-	RuleManager::Instance()->LoadRules(this, "default", false);
+	auto *r = RuleManager::Instance();
+	r->LoadRules(this, "default", false);
 	if (!RuleB(Bots, Enabled) && DoesTableExist("bot_data")) {
 		LogInfo("Bot tables found but rule not enabled, enabling");
-		RuleManager::Instance()->SetRule("Bots:Enabled", "true", this, true, true);
+		r->SetRule("Bots:Enabled", "true", this, true, true);
 	}
 
 	/* Run EQEmu Server script (Checks for database updates) */

--- a/common/rulesys.cpp
+++ b/common/rulesys.cpp
@@ -385,7 +385,16 @@ void RuleManager::_SaveRule(Database *db, RuleType type, uint16 index) {
 		e.rule_value = rule_value;
 		e.notes      = rule_notes;
 
-		RuleValuesRepository::UpdateOne(*db, e);
+		db->QueryDatabase(
+			fmt::format(
+				"UPDATE rule_values SET rule_value = '{}', notes = '{}' WHERE ruleset_id = {} AND rule_name = '{}'",
+				rule_value,
+				Strings::Escape(rule_notes),
+				e.ruleset_id,
+				e.rule_name
+			)
+		);
+
 		return;
 	}
 

--- a/world/cli/database_version.cpp
+++ b/world/cli/database_version.cpp
@@ -1,5 +1,6 @@
 #include "../../common/version.h"
 #include "../../common/json/json.h"
+#include "../../common/rulesys.h"
 
 void WorldserverCLI::DatabaseVersion(int argc, char **argv, argh::parser &cmd, std::string &description)
 {
@@ -9,13 +10,13 @@ void WorldserverCLI::DatabaseVersion(int argc, char **argv, argh::parser &cmd, s
 		return;
 	}
 
-	Json::Value database_version;
+	Json::Value v;
 
-	database_version["database_version"]      = CURRENT_BINARY_DATABASE_VERSION;
-	database_version["bots_database_version"] = CURRENT_BINARY_BOTS_DATABASE_VERSION;
+	v["database_version"]      = CURRENT_BINARY_DATABASE_VERSION;
+	v["bots_database_version"] = RuleB(Bots, Enabled) ? CURRENT_BINARY_BOTS_DATABASE_VERSION : 0;
 
 	std::stringstream payload;
-	payload << database_version;
+	payload << v;
 
 	std::cout << payload.str() << std::endl;
 }

--- a/world/world_boot.cpp
+++ b/world/world_boot.cpp
@@ -290,15 +290,15 @@ bool WorldBoot::DatabaseLoadRoutines(int argc, char **argv)
 		}
 	}
 
-	if (!ignore_db) {
-		LogInfo("Checking Database Conversions");
-		database.CheckDatabaseConversions();
-	}
-
 	// logging system init
 	auto logging = LogSys.SetDatabase(&database)
 		->SetLogPath(path.GetLogPath())
 		->LoadLogDatabaseSettings();
+
+	if (!ignore_db) {
+		LogInfo("Checking Database Conversions");
+		database.CheckDatabaseConversions();
+	}
 
 	if (RuleB(Logging, WorldGMSayLogging)) {
 		logging->SetGMSayHandler(&WorldBoot::GMSayHookCallBackProcessWorld);


### PR DESCRIPTION
### What

During bootup of a server, when bot tables exist but the rule is not enabled or set, there will be a query error that shows up each time the server is booted - making operators think that there is an issue. 

This fixes a regression in https://github.com/EQEmu/Server/pull/2593 that caused rules to not be able to be updated if they already exist. The table does not have a primary key (such as `id`) to bind to in order for the `UpdateOne` to work properly. 

This change replaces it with a raw update to restore functionality.

```
World |  QueryErr  | QueryDatabase [1064] [You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'rule_notes = 'Enable of disable bot functionality, default is false' WHERE ru...' at line [1
UPDATE] rule_values SET rule_value = true rule_notes = 'Enable of disable bot functionality, default is false' WHERE ruleset_id = 1 AND rule_name = 'Bots:Enabled'] 
```