### PR TITLE
[Logging] Add raw opcode when emu translated opcode is not found (OP_Unknown) via (C->S)

### DIFF
--- a/loginserver/client.cpp
+++ b/loginserver/client.cpp
@@ -26,10 +26,11 @@ bool Client::Process()
 {
 	EQApplicationPacket *app = m_connection->PopPacket();
 	while (app) {
+		auto o = m_connection->GetOpcodeManager();
 		LogPacketClientServer(
 			"[{}] [{:#06x}] Size [{}] {}",
 			OpcodeManager::EmuToName(app->GetOpcode()),
-			m_connection->GetOpcodeManager()->EmuToEQ(app->GetOpcode()),
+			o->EmuToEQ(app->GetOpcode()) == 0 ? app->GetProtocolOpcode() : o->EmuToEQ(app->GetOpcode()),
 			app->Size(),
 			(LogSys.IsLogEnabled(Logs::Detail, Logs::PacketClientServer) ? DumpPacketToString(app) : "")
 		);

--- a/ucs/clientlist.cpp
+++ b/ucs/clientlist.cpp
@@ -643,10 +643,11 @@ void Clientlist::Process()
 		while (KeyValid && !(*it)->GetForceDisconnect() && (app = (*it)->ClientStream->PopPacket())) {
 			EmuOpcode opcode = app->GetOpcode();
 
+			auto o = (*it)->ClientStream->GetOpcodeManager();
 			LogPacketClientServer(
 				"[{}] [{:#06x}] Size [{}] {}",
 				OpcodeManager::EmuToName(app->GetOpcode()),
-				(*it)->ClientStream->GetOpcodeManager()->EmuToEQ(app->GetOpcode()),
+				o->EmuToEQ(app->GetOpcode()) == 0 ? app->GetProtocolOpcode() : o->EmuToEQ(app->GetOpcode()),
 				app->Size(),
 				(LogSys.IsLogEnabled(Logs::Detail, Logs::PacketClientServer) ? DumpPacketToString(app) : "")
 			);

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -1010,10 +1010,11 @@ bool Client::HandlePacket(const EQApplicationPacket *app) {
 
 	EmuOpcode opcode = app->GetOpcode();
 
+	auto o = eqs->GetOpcodeManager();
 	LogPacketClientServer(
 		"[{}] [{:#06x}] Size [{}] {}",
 		OpcodeManager::EmuToName(app->GetOpcode()),
-		eqs->GetOpcodeManager()->EmuToEQ(app->GetOpcode()),
+		o->EmuToEQ(app->GetOpcode()) == 0 ? app->GetProtocolOpcode() : o->EmuToEQ(app->GetOpcode()),
 		app->Size(),
 		(LogSys.IsLogEnabled(Logs::Detail, Logs::PacketClientServer) ? DumpPacketToString(app) : "")
 	);

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -446,10 +446,11 @@ void ClearMappedOpcode(EmuOpcode op)
 // client methods
 int Client::HandlePacket(const EQApplicationPacket *app)
 {
+	auto o = eqs->GetOpcodeManager();
 	LogPacketClientServer(
 		"[{}] [{:#06x}] Size [{}] {}",
 		OpcodeManager::EmuToName(app->GetOpcode()),
-		eqs->GetOpcodeManager()->EmuToEQ(app->GetOpcode()),
+		o->EmuToEQ(app->GetOpcode()) == 0 ? app->GetProtocolOpcode() : o->EmuToEQ(app->GetOpcode()),
 		app->Size(),
 		(LogSys.IsLogEnabled(Logs::Detail, Logs::PacketClientServer) ? DumpPacketToString(app) : "")
 	);


### PR DESCRIPTION
### What

Adds the raw EQ opcode instead of `0x0000` when the opcode is `OP_Unknown`

We run the internal opcode through the patch translator and get the patch-specific opcode and when there's nothing that matches we simply get `0x0000` this at least gives us the protocol level opcode if we didn't find one through translators

![image](https://user-images.githubusercontent.com/3319450/217175495-34f00057-17b1-48ab-9833-fd03f94d90ed.png)
