### PR TITLE
[Quest API] Export $item to Client/Bot Equip Events in Perl

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -5144,14 +5144,7 @@ void Bot::PerformTradeWithClient(int16 begin_slot_id, int16 end_slot_id, Client*
 
 		args.emplace_back(trade_iterator.trade_item_instance);
 
-		parse->EventBot(
-			EVENT_EQUIP_ITEM_BOT,
-			this,
-			nullptr,
-			export_string,
-			trade_iterator.trade_item_instance->GetID()
-			&args
-		);
+		parse->EventBot(EVENT_EQUIP_ITEM_BOT, this, nullptr, export_string, trade_iterator.trade_item_instance->GetID(), &args);
 
 		trade_iterator.trade_item_instance = nullptr; // actual deletion occurs in client delete below
 

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -5080,7 +5080,11 @@ void Bot::PerformTradeWithClient(int16 begin_slot_id, int16 end_slot_id, Client*
 				return_iterator.from_bot_slot
 			);
 
-			parse->EventBot(EVENT_UNEQUIP_ITEM_BOT, this, nullptr, export_string , return_iterator.return_item_instance->GetID());
+			std::vector<std::any> args;
+
+			args.emplace_back(return_iterator.return_item_instance);
+
+			parse->EventBot(EVENT_UNEQUIP_ITEM_BOT, this, nullptr, export_string , return_iterator.return_item_instance->GetID(), &args);
 			if (return_instance) {
 				EQ::SayLinkEngine linker;
 				linker.SetLinkType(EQ::saylink::SayLinkItemInst);
@@ -5136,7 +5140,18 @@ void Bot::PerformTradeWithClient(int16 begin_slot_id, int16 end_slot_id, Client*
 			trade_iterator.to_bot_slot
 		);
 
-		parse->EventBot(EVENT_EQUIP_ITEM_BOT, this, nullptr, export_string , trade_iterator.trade_item_instance->GetID());
+		std::vector<std::any> args;
+
+		args.emplace_back(trade_iterator.trade_item_instance);
+
+		parse->EventBot(
+			EVENT_EQUIP_ITEM_BOT,
+			this,
+			nullptr,
+			export_string,
+			trade_iterator.trade_item_instance->GetID()
+			&args
+		);
 
 		trade_iterator.trade_item_instance = nullptr; // actual deletion occurs in client delete below
 

--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -9484,7 +9484,11 @@ void bot_subcommand_inventory_remove(Client *c, const Seperator *sep)
 			slot_id
 		);
 
-		parse->EventBot(EVENT_UNEQUIP_ITEM_BOT, my_bot, nullptr, export_string, inst->GetID());
+		std::vector<std::any> args;
+
+		args.emplace_back(inst);
+
+		parse->EventBot(EVENT_UNEQUIP_ITEM_BOT, my_bot, nullptr, export_string, inst->GetID(), &args);
 	}
 }
 

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -1724,6 +1724,7 @@ void PerlembParser::ExportEventVariables(
 					ExportVar(package_name.c_str(), "item_id", item->GetID());
 					ExportVar(package_name.c_str(), "item_name", item->GetItem()->Name);
 					ExportVar(package_name.c_str(), "spell_id", item->GetItem()->Click.Effect);
+					ExportVar(package_name.c_str(), "item", "QuestItem", item);
 				}
 			}
 			break;

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -1918,6 +1918,9 @@ void PerlembParser::ExportEventVariables(
 			ExportVar(package_name.c_str(), "item_id", extradata);
 			ExportVar(package_name.c_str(), "item_quantity", sep.arg[0]);
 			ExportVar(package_name.c_str(), "slot_id", sep.arg[1]);
+			if (extra_pointers && extra_pointers->size() == 1) {
+				ExportVar(package_name.c_str(), "item", "QuestItem", std::any_cast<EQ::ItemInstance*>(extra_pointers->at(0)));
+			}
 			break;
 		}
 
@@ -1927,6 +1930,9 @@ void PerlembParser::ExportEventVariables(
 			ExportVar(package_name.c_str(), "item_id", extradata);
 			ExportVar(package_name.c_str(), "item_quantity", sep.arg[0]);
 			ExportVar(package_name.c_str(), "slot_id", sep.arg[1]);
+			if (extra_pointers && extra_pointers->size() == 1) {
+				ExportVar(package_name.c_str(), "item", "QuestItem", std::any_cast<EQ::ItemInstance*>(extra_pointers->at(0)));
+			}
 			break;
 		}
 

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -2248,7 +2248,11 @@ bool Client::SwapItem(MoveItem_Struct* move_in) {
 					dst_slot_id
 				);
 
-				parse->EventPlayer(EVENT_UNEQUIP_ITEM_CLIENT, this, export_string, dst_inst->GetItem()->ID);
+				std::vector<std::any> args;
+
+				args.emplace_back(dst_inst);
+
+				parse->EventPlayer(EVENT_UNEQUIP_ITEM_CLIENT, this, export_string, dst_inst->GetItem()->ID, &args);
 			}
 
 			if(src_inst) {
@@ -2260,7 +2264,11 @@ bool Client::SwapItem(MoveItem_Struct* move_in) {
 					dst_slot_id
 				);
 
-				parse->EventPlayer(EVENT_EQUIP_ITEM_CLIENT, this, export_string, src_inst->GetItem()->ID);
+				std::vector<std::any> args;
+
+				args.emplace_back(src_inst);
+
+				parse->EventPlayer(EVENT_EQUIP_ITEM_CLIENT, this, export_string, src_inst->GetItem()->ID, &args);
 			}
 		}
 	}


### PR DESCRIPTION
# Notes
- Exports `$item` to `EVENT_EQUIP_ITEM_CLIENT`, `EVENT_UNEQUIP_ITEM_CLIENT`, `EVENT_EQUIP_ITEM_BOT`, `EVENT_UNEQUIP_ITEM_BOT`, `EVENT_ITEM_CLICK_CLIENT`, and `EVENT_ITEM_CLICK_CAST_CLIENT`.