### PR TITLE
[Quest API] Export $door to EVENT_CLICKDOOR in Perl

### DIFF
--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -1602,6 +1602,9 @@ void PerlembParser::ExportEventVariables(
 		case EVENT_CLICK_DOOR: {
 			ExportVar(package_name.c_str(), "doorid", data);
 			ExportVar(package_name.c_str(), "version", zone->GetInstanceVersion());
+			if (extra_pointers && extra_pointers->size() == 1) {
+				ExportVar(package_name.c_str(), "door", "Doors", std::any_cast<Doors*>(extra_pointers->at(0)));
+			}
 			break;
 		}
 


### PR DESCRIPTION
# Notes
- Exports `$door` to `EVENT_CLICKDOOR` in Perl so you don't have to grab it from entity list.