### PR TITLE
[Crash] Fix Crash in Mob::FindType

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -5849,8 +5849,7 @@ uint16 Mob::GetSpellIDFromSlot(uint8 slot)
 bool Mob::FindType(uint16 type, bool bOffensive, uint16 threshold) {
 	int buff_count = GetMaxTotalSlots();
 	for (int i = 0; i < buff_count; i++) {
-		if (buffs[i].spellid != SPELL_UNKNOWN) {
-
+		if (IsValidSpell(buffs[i].spellid)) {
 			for (int j = 0; j < EFFECT_COUNT; j++) {
 				// adjustments necessary for offensive npc casting behavior
 				if (bOffensive) {


### PR DESCRIPTION
Limited checks were being performed in Mob::FindType to determine if returned spell_id was valid. obviously we should also try to determine why an invalid spell ID can be entered into Buffs_Struct in the first place. But I wanted a fix to resolve the crashing seeing on karana.