### PR TITLE
[Crash] Fix Bot Crash in Bot::Bot Constructor.

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -253,7 +253,7 @@ Bot::Bot(uint32 botID, uint32 botOwnerCharacterID, uint32 botSpellsID, double to
 		}
 	} else {
 		//reapply some buffs
-		uint32 buff_count = GetMaxTotalSlots();
+		uint32 buff_count = GetMaxBuffSlots();
 		for (uint32 j1 = 0; j1 < buff_count; j1++) {
 			if (!IsValidSpell(buffs[j1].spellid)) {
 				continue;

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -147,10 +147,10 @@ public:
 	void Damage(Mob* from, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, bool avoidable = true, int8 buffslot = -1,
 		bool iBuffTic = false, eSpecialAttacks special = eSpecialAttacks::None) override;
 
-	bool HasRaid() override { return (GetRaid() ? true : false); }
-	bool HasGroup() override { return (GetGroup() ? true : false); }
-	Raid* GetRaid() override { return entity_list.GetRaidByMob(this); }
-	Group* GetGroup() override { return entity_list.GetGroupByMob(this); }
+	bool HasRaid() final { return (GetRaid() ? true : false); }
+	bool HasGroup() final { return (GetGroup() ? true : false); }
+	Raid* GetRaid() final { return entity_list.GetRaidByMob(this); }
+	Group* GetGroup() final { return entity_list.GetGroupByMob(this); }
 
 	// Common, but informal "interfaces" with Client object
 	uint32 CharacterID() { return GetBotID(); } // Just returns the Bot Id
@@ -354,8 +354,8 @@ public:
 	void AI_Bot_Start(uint32 iMoveDelay = 0);
 
 	// Mob AI Virtual Override Methods
-	void AI_Process() override;
-	void AI_Stop() override;
+	void AI_Process() final;
+	void AI_Stop() final;
 
 	// Mob Spell Virtual Override Methods
 	void SpellProcess() override;
@@ -365,7 +365,17 @@ public:
 	void DoBuffTic(const Buffs_Struct &buff, int slot, Mob* caster = nullptr) override;
 	virtual bool CastSpell(uint16 spell_id, uint16 target_id, EQ::spells::CastingSlot slot = EQ::spells::CastingSlot::Item, int32 casttime = -1, int32 mana_cost = -1, uint32* oSpellWillFinish = 0,
 						uint32 item_slot = 0xFFFFFFFF, int16 *resist_adjust = nullptr, uint32 aa_id = 0);
-	virtual bool SpellOnTarget(uint16 spell_id, Mob* spelltar);
+	bool SpellOnTarget(
+			uint16 spell_id,
+			Mob* spelltar,
+			int reflect_effectiveness = 0,
+			bool use_resist_adjust = false,
+			int16 resist_adjust = 0,
+			bool isproc = false,
+			int level_override = -1,
+			int duration_override = 0,
+			bool disable_buff_overwrite = false
+	) final;
 	bool IsImmuneToSpell(uint16 spell_id, Mob *caster) override;
 	virtual bool DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_center, CastAction_type &CastAction, EQ::spells::CastingSlot slot);
 	virtual bool DoCastSpell(uint16 spell_id, uint16 target_id, EQ::spells::CastingSlot slot = EQ::spells::CastingSlot::Item, int32 casttime = -1, int32 mana_cost = -1,
@@ -376,10 +386,10 @@ public:
 		bool IsFromSpell = false, ExtraAttackOptions *opts = nullptr) override
 			{ return Mob::Attack(other, Hand, FromRiposte, IsStrikethrough, IsFromSpell, opts); }
 
-	[[nodiscard]] int GetMaxBuffSlots() const override { return EQ::spells::LONG_BUFFS; }
-	[[nodiscard]] int GetMaxSongSlots() const override { return EQ::spells::SHORT_BUFFS; }
-	[[nodiscard]] int GetMaxDiscSlots() const override { return EQ::spells::DISC_BUFFS; }
-	[[nodiscard]] int GetMaxTotalSlots() const override { return EQ::spells::TOTAL_BUFFS; }
+	[[nodiscard]] int GetMaxBuffSlots() const final { return EQ::spells::LONG_BUFFS; }
+	[[nodiscard]] int GetMaxSongSlots() const final { return EQ::spells::SHORT_BUFFS; }
+	[[nodiscard]] int GetMaxDiscSlots() const final { return EQ::spells::DISC_BUFFS; }
+	[[nodiscard]] int GetMaxTotalSlots() const final { return EQ::spells::TOTAL_BUFFS; }
 
 	bool GetBotOwnerDataBuckets();
 	bool GetBotDataBuckets();

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -514,7 +514,7 @@ public:
 	virtual bool Death(Mob* killerMob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill) = 0;
 	virtual void Damage(Mob* from, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill,
 		bool avoidable = true, int8 buffslot = -1, bool iBuffTic = false, eSpecialAttacks special = eSpecialAttacks::None) = 0;
-	virtual void SetHP(int64 hp);
+	void SetHP(int64 hp);
 	bool ChangeHP(Mob* other, int32 amount, uint16 spell_id = 0, int8 buffslot = -1, bool iBuffTic = false);
 	inline void SetOOCRegen(int64 new_ooc_regen) { ooc_regen = new_ooc_regen; }
 	virtual void Heal();
@@ -628,7 +628,7 @@ public:
 	virtual void SetEndurance(int32 newEnd) { return; }
 	int64 GetItemHPBonuses();
 	int64 GetSpellHPBonuses();
-	virtual const int64& SetMana(int64 amount);
+	const int64& SetMana(int64 amount);
 	inline float GetManaRatio() const { return max_mana == 0 ? 100 :
 		((static_cast<float>(current_mana) / max_mana) * 100); }
 	virtual int64 CalcMaxMana();


### PR DESCRIPTION
Fixes a crash where bot_owner could be nullptr, detected with crash analysis http://spire.akkadius.com/dev/release/22.2.0?id=347
Cleaned up Bot Constructor & Deconstructors to not call virtual override methods (change to Final) for code smell purposes.