### PR TITLE
[Quest API] Export target to EVENT_TARGET_CHANGE in Perl/Lua.

### DIFF
--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -1561,6 +1561,13 @@ void PerlembParser::ExportEventVariables(
 			break;
 		}
 
+		case EVENT_TARGET_CHANGE: {
+			if (extra_pointers && extra_pointers->size() == 1) {
+				ExportVar(package_name.c_str(), "target", "Mob", std::any_cast<Mob*>(extra_pointers->at(0)));
+			}
+			break;
+		}
+
 		case EVENT_WAYPOINT_ARRIVE:
 		case EVENT_WAYPOINT_DEPART: {
 			ExportVar(package_name.c_str(), "wp", data);

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -286,6 +286,7 @@ LuaParser::LuaParser() {
 	PlayerArgumentDispatch[EVENT_ITEM_CLICK_CAST_CLIENT]     = handle_player_item_click;
 	PlayerArgumentDispatch[EVENT_ITEM_CLICK_CLIENT]          = handle_player_item_click;
 	PlayerArgumentDispatch[EVENT_DESTROY_ITEM_CLIENT]        = handle_player_destroy_item;
+	PlayerArgumentDispatch[EVENT_TARGET_CHANGE]              = handle_player_target_change;
 
 	ItemArgumentDispatch[EVENT_ITEM_CLICK]      = handle_item_click;
 	ItemArgumentDispatch[EVENT_ITEM_CLICK_CAST] = handle_item_click;

--- a/zone/lua_parser_events.cpp
+++ b/zone/lua_parser_events.cpp
@@ -1340,6 +1340,22 @@ void handle_player_destroy_item(
 	}
 }
 
+void handle_player_target_change(
+	QuestInterface *parse,
+	lua_State* L,
+	Client* client,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any> *extra_pointers
+) {
+	if (extra_pointers && extra_pointers->size() == 1) {
+		Lua_Mob              l_mob(std::any_cast<Mob*>(extra_pointers->at(0)));
+		luabind::adl::object l_mob_o = luabind::adl::object(L, l_mob);
+		l_mob_o.push(L);
+		lua_setfield(L, -2, "other");
+	}
+}
+
 // Item
 void handle_item_click(
 	QuestInterface *parse,

--- a/zone/lua_parser_events.h
+++ b/zone/lua_parser_events.h
@@ -698,6 +698,15 @@ void handle_player_destroy_item(
 	std::vector<std::any> *extra_pointers
 );
 
+void handle_player_target_change(
+	QuestInterface *parse,
+	lua_State* L,
+	Client* client,
+	std::string data,
+	uint32 extra_data,
+	std::vector<std::any> *extra_pointers
+);
+
 // Item
 void handle_item_click(
 	QuestInterface *parse,

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -4259,11 +4259,14 @@ void Mob::SetTarget(Mob *mob)
 	target = mob;
 	entity_list.UpdateHoTT(this);
 
+	std::vector<std::any> args;
+
+	args.emplace_back(mob);
+
 	if (IsNPC()) {
-		parse->EventNPC(EVENT_TARGET_CHANGE, CastToNPC(), mob, "", 0);
-	}
-	else if (IsClient()) {
-		parse->EventPlayer(EVENT_TARGET_CHANGE, CastToClient(), "", 0);
+		parse->EventNPC(EVENT_TARGET_CHANGE, CastToNPC(), mob, "", 0, &args);
+	} else if (IsClient()) {
+		parse->EventPlayer(EVENT_TARGET_CHANGE, CastToClient(), "", 0, &args);
 
 		if (CastToClient()->admin > AccountStatus::GMMgmt) {
 			DisplayInfo(mob);
@@ -4271,7 +4274,7 @@ void Mob::SetTarget(Mob *mob)
 
 		CastToClient()->SetBotPrecombat(false); // Any change in target will nullify this flag (target == mob checked above)
 	} else if (IsBot()) {
-		parse->EventBot(EVENT_TARGET_CHANGE, CastToBot(), mob, "", 0);
+		parse->EventBot(EVENT_TARGET_CHANGE, CastToBot(), mob, "", 0, &args);
 	}
 
 	if (IsPet() && GetOwner() && GetOwner()->IsClient()) {

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -4258,9 +4258,9 @@ void Mob::SetTarget(Mob *mob)
 
 	target = mob;
 	entity_list.UpdateHoTT(this);
-	
+
 	const auto has_target_change_event = (
-		parse->HasQuestSub(EVENT_TARGET_CHANGE) ||
+		parse->HasQuestSub(GetNPCTypeID(), EVENT_TARGET_CHANGE) ||
 		parse->PlayerHasQuestSub(EVENT_TARGET_CHANGE) ||
 		parse->BotHasQuestSub(EVENT_TARGET_CHANGE)
 	);

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -4271,7 +4271,7 @@ void Mob::SetTarget(Mob *mob)
 		args.emplace_back(mob);
 
 		if (IsNPC()) {
-			if (parse->HasQuestSub(EVENT_TARGET_CHANGE)) {
+			if (parse->HasQuestSub(GetNPCTypeID(), EVENT_TARGET_CHANGE)) {
 				parse->EventNPC(EVENT_TARGET_CHANGE, CastToNPC(), mob, "", 0, &args);
 			}
 		} else if (IsClient()) {


### PR DESCRIPTION
# Perl
- Export `$target` to `EVENT_TARGET_CHANGE`.

# Lua
- Export `e.other` to `event_target_change`.

# Notes
- Allows operators to not have to grab bot, Client, or NPC's target in Perl with `GetTarget()`.
- Allows operators to not have to grab Client's target in Lua with `GetTarget()`.