### PR TITLE
[Bots] Add Lore Check for Augments.

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -4776,7 +4776,8 @@ void Bot::PerformTradeWithClient(int16 begin_slot_id, int16 end_slot_id, Client*
 			client->Message(
 					Chat::Yellow,
 					fmt::format(
-							"This bot already has {}, the trade has been cancelled!",
+							"{} already has {}, the trade has been cancelled!",
+							GetCleanName(),
 							item_link
 					).c_str()
 			);

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -4758,6 +4758,32 @@ void Bot::PerformTradeWithClient(int16 begin_slot_id, int16 end_slot_id, Client*
 			}
 		}
 
+		for (int m = EQ::invaug::SOCKET_BEGIN; m <= EQ::invaug::SOCKET_END; ++m) {
+			const auto augment = trade_instance->GetAugment(m);
+			if (!augment) {
+				continue;
+			}
+
+			if (!CheckLoreConflict(augment->GetItem())) {
+				continue;
+			}
+
+			linker.SetLinkType(EQ::saylink::SayLinkItemInst);
+			linker.SetItemInst(augment);
+
+			item_link = linker.GenerateLink();
+
+			client->Message(
+					Chat::Yellow,
+					fmt::format(
+							"This bot already has {}, the trade has been cancelled!",
+							item_link
+					).c_str()
+			);
+			client->ResetTrade();
+			return;
+		}
+
 		if (CheckLoreConflict(trade_instance->GetItem())) {
 			if (trade_event_exists) {
 				event_trade.push_back(ClientTrade(trade_instance, trade_index));


### PR DESCRIPTION
Bots were not checking if they had an Augment equipped that matches the loregroup of an augment being given to them in a piece of equipment. 