### PR TITLE
[Quest API] Export $item to EVENT_PLAYER_PICKUP in Perl.

### DIFF
--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -1680,6 +1680,9 @@ void PerlembParser::ExportEventVariables(
 		case EVENT_PLAYER_PICKUP: {
 			ExportVar(package_name.c_str(), "picked_up_id", data);
 			ExportVar(package_name.c_str(), "picked_up_entity_id", extradata);
+			if (extra_pointers && extra_pointers->size() == 1) {
+				ExportVar(package_name.c_str(), "item", "QuestItem", std::any_cast<EQ::ItemInstance*>(extra_pointers->at(0)));
+			}
 			break;
 		}
 

--- a/zone/object.cpp
+++ b/zone/object.cpp
@@ -529,8 +529,8 @@ bool Object::HandleClick(Client* sender, const ClickObject_Struct* click_object)
 			}
 
 			if (parse->PlayerHasQuestSub(EVENT_PLAYER_PICKUP)) {
-				std::vector<std::any> args;
-				args.push_back(m_inst);
+				std::vector<std::any> args = { m_inst };
+
 				if (parse->EventPlayer(EVENT_PLAYER_PICKUP, sender, std::to_string(item->ID), GetID(), &args)) {
 					auto outapp = new EQApplicationPacket(OP_ClickObject, sizeof(ClickObject_Struct));
 					memcpy(outapp->pBuffer, click_object, sizeof(ClickObject_Struct));

--- a/zone/object.cpp
+++ b/zone/object.cpp
@@ -534,7 +534,7 @@ bool Object::HandleClick(Client* sender, const ClickObject_Struct* click_object)
 				if (parse->EventPlayer(EVENT_PLAYER_PICKUP, sender, std::to_string(item->ID), GetID(), &args)) {
 					auto outapp = new EQApplicationPacket(OP_ClickObject, sizeof(ClickObject_Struct));
 					memcpy(outapp->pBuffer, click_object, sizeof(ClickObject_Struct));
-					auto* co = (ClickObject_Struct *) outapp->pBuffer;
+					auto* co = (ClickObject_Struct*) outapp->pBuffer;
 					co->drop_id = 0;
 					entity_list.QueueClients(nullptr, outapp, false);
 					safe_delete(outapp);

--- a/zone/object.cpp
+++ b/zone/object.cpp
@@ -528,25 +528,23 @@ bool Object::HandleClick(Client* sender, const ClickObject_Struct* click_object)
 				RecordPlayerEventLogWithClient(sender, PlayerEvent::GROUNDSPAWN_PICKUP, e);
 			}
 
-			std::string export_string = fmt::format("{}", item->ID);
-			std::vector<std::any> args;
-			args.push_back(m_inst);
-			if(parse->EventPlayer(EVENT_PLAYER_PICKUP, sender, export_string, GetID(), &args))
-			{
-				auto outapp = new EQApplicationPacket(OP_ClickObject, sizeof(ClickObject_Struct));
-				memcpy(outapp->pBuffer, click_object, sizeof(ClickObject_Struct));
-				ClickObject_Struct* co = (ClickObject_Struct*)outapp->pBuffer;
-				co->drop_id = 0;
-				entity_list.QueueClients(nullptr, outapp, false);
-				safe_delete(outapp);
+			if (parse->PlayerHasQuestSub(EVENT_PLAYER_PICKUP)) {
+				std::vector<std::any> args;
+				args.push_back(m_inst);
+				if (parse->EventPlayer(EVENT_PLAYER_PICKUP, sender, std::to_string(item->ID), GetID(), &args)) {
+					auto outapp = new EQApplicationPacket(OP_ClickObject, sizeof(ClickObject_Struct));
+					memcpy(outapp->pBuffer, click_object, sizeof(ClickObject_Struct));
+					auto* co = (ClickObject_Struct *) outapp->pBuffer;
+					co->drop_id = 0;
+					entity_list.QueueClients(nullptr, outapp, false);
+					safe_delete(outapp);
 
-				// No longer using a tradeskill object
-				sender->SetTradeskillObject(nullptr);
-				user = nullptr;
+					sender->SetTradeskillObject(nullptr);
+					user = nullptr;
 
-				return true;
+					return true;
+				}
 			}
-
 
 			// Transfer item to client
 			sender->PutItemInInventory(EQ::invslot::slotCursor, *m_inst, false);


### PR DESCRIPTION
# Notes
- Exports `$item` to `EVENT_PLAYER_PICKUP` in Perl so that you have access to the item itself.