### PR TITLE
[Quest API] Export $item to Fishing and Forage Events in Perl

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -6304,7 +6304,9 @@ void Client::Handle_OP_Fishing(const EQApplicationPacket *app)
 	}
 
 	if (CanFish()) {
-		parse->EventPlayer(EVENT_FISH_START, this, "", 0);
+		if (parse->PlayerHasQuestSub(EVENT_FISH_START)) {
+			parse->EventPlayer(EVENT_FISH_START, this, "", 0);
+		}
 
 		//these will trigger GoFish() after a delay if we're able to actually fish, and if not, we won't stop the client from trying again immediately (although we may need to tell it to repop the button)
 		p_timers.Start(pTimerFishing, FishingReuseTime - 1);

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -1783,11 +1783,17 @@ void PerlembParser::ExportEventVariables(
 
 		case EVENT_FORAGE_SUCCESS: {
 			ExportVar(package_name.c_str(), "foraged_item", extradata);
+			if (extra_pointers && extra_pointers->size() == 1) {
+				ExportVar(package_name.c_str(), "item", "QuestItem", std::any_cast<EQ::ItemInstance*>(extra_pointers->at(0)));
+			}
 			break;
 		}
 
 		case EVENT_FISH_SUCCESS: {
 			ExportVar(package_name.c_str(), "fished_item", extradata);
+			if (extra_pointers && extra_pointers->size() == 1) {
+				ExportVar(package_name.c_str(), "item", "QuestItem", std::any_cast<EQ::ItemInstance*>(extra_pointers->at(0)));
+			}
 			break;
 		}
 

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -683,7 +683,7 @@ void EntityList::AddNPC(NPC *npc, bool send_spawn_packet, bool dont_queue)
 	npc_list.insert(std::pair<uint16, NPC *>(npc->GetID(), npc));
 	mob_list.insert(std::pair<uint16, Mob *>(npc->GetID(), npc));
 
-	if (parse->HasQuestSub(npc->GetNPCTypeID())) {
+	if (parse->HasQuestSub(npc->GetNPCTypeID(), EVENT_SPAWN)) {
 		parse->EventNPC(EVENT_SPAWN, npc, nullptr, "", 0);
 	}
 

--- a/zone/forage.cpp
+++ b/zone/forage.cpp
@@ -378,10 +378,6 @@ void Client::GoFish()
 				}
 
 				if (inst) {
-					std::vector<std::any> args;
-					args.push_back(inst);
-					parse->EventPlayer(EVENT_FISH_SUCCESS, this, "", inst->GetID(), &args);
-
 					if (player_event_logs.IsEventEnabled(PlayerEvent::FISH_SUCCESS)) {
 						auto e = PlayerEvent::FishSuccessEvent{
 							.item_id = inst->GetItem()->ID,
@@ -389,6 +385,12 @@ void Client::GoFish()
 						};
 
 						RecordPlayerEventLog(PlayerEvent::FISH_SUCCESS, e);
+					}
+
+					if (parse->PlayerHasQuestSub(EVENT_FISH_SUCCESS)) {
+						std::vector<std::any> args;
+						args.push_back(inst);
+						parse->EventPlayer(EVENT_FISH_SUCCESS, this, "", inst->GetID(), &args);
 					}
 				}
 			}
@@ -408,8 +410,10 @@ void Client::GoFish()
 				MessageString(Chat::Skills, FISHING_FAILED);	//You didn't catch anything.
 		}
 
-		parse->EventPlayer(EVENT_FISH_FAILURE, this, "", 0);
 		RecordPlayerEventLog(PlayerEvent::FISH_FAILURE, PlayerEvent::EmptyEvent{});
+		if (parse->PlayerHasQuestSub(EVENT_FISH_FAILURE)) {
+			parse->EventPlayer(EVENT_FISH_FAILURE, this, "", 0);
+		}
 	}
 
 	//chance to break fishing pole...
@@ -508,16 +512,18 @@ void Client::ForageItem(bool guarantee) {
 			}
 
 			if (inst) {
-				std::vector<std::any> args;
-				args.push_back(inst);
-				parse->EventPlayer(EVENT_FORAGE_SUCCESS, this, "", inst->GetID(), &args);
-
 				if (player_event_logs.IsEventEnabled(PlayerEvent::FORAGE_SUCCESS)) {
 					auto e = PlayerEvent::ForageSuccessEvent{
 						.item_id = inst->GetItem()->ID,
 						.item_name = inst->GetItem()->Name
 					};
 					RecordPlayerEventLog(PlayerEvent::FORAGE_SUCCESS, e);
+				}
+
+				if (parse->PlayerHasQuestSub(EVENT_FORAGE_SUCCESS)) {
+					std::vector<std::any> args;
+					args.push_back(inst);
+					parse->EventPlayer(EVENT_FORAGE_SUCCESS, this, "", inst->GetID(), &args);
 				}
 			}
 		}
@@ -529,8 +535,11 @@ void Client::ForageItem(bool guarantee) {
 		}
 	} else {
 		MessageString(Chat::Skills, FORAGE_FAILED);
-		parse->EventPlayer(EVENT_FORAGE_FAILURE, this, "", 0);
 		RecordPlayerEventLog(PlayerEvent::FORAGE_FAILURE, PlayerEvent::EmptyEvent{});
+
+		if (parse->PlayerHasQuestSub(EVENT_FORAGE_FAILURE)) {
+			parse->EventPlayer(EVENT_FORAGE_FAILURE, this, "", 0);
+		}
 	}
 
 	CheckIncreaseSkill(EQ::skills::SkillForage, nullptr, 5);

--- a/zone/forage.cpp
+++ b/zone/forage.cpp
@@ -388,8 +388,7 @@ void Client::GoFish()
 					}
 
 					if (parse->PlayerHasQuestSub(EVENT_FISH_SUCCESS)) {
-						std::vector<std::any> args;
-						args.push_back(inst);
+						std::vector<std::any> args = { inst };
 						parse->EventPlayer(EVENT_FISH_SUCCESS, this, "", inst->GetID(), &args);
 					}
 				}
@@ -521,8 +520,7 @@ void Client::ForageItem(bool guarantee) {
 				}
 
 				if (parse->PlayerHasQuestSub(EVENT_FORAGE_SUCCESS)) {
-					std::vector<std::any> args;
-					args.push_back(inst);
+					std::vector<std::any> args = { inst };
 					parse->EventPlayer(EVENT_FORAGE_SUCCESS, this, "", inst->GetID(), &args);
 				}
 			}


### PR DESCRIPTION
# Notes
- Exports `$item` to `EVENT_FISH_SUCCESS` in Perl.
- Exports `$item` to `EVENT_FORAGE_SUCCESS` in Perl.