### PR TITLE
[Quest API] Export $spawned to EVENT_SPAWN_ZONE in Perl

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -8322,7 +8322,11 @@ void EntityList::AddBot(Bot *new_bot, bool send_spawn_packet, bool dont_queue) {
 		new_bot->SetID(GetFreeID());
 		bot_list.push_back(new_bot);
 		mob_list.insert(std::pair<uint16, Mob*>(new_bot->GetID(), new_bot));
-		parse->EventBot(EVENT_SPAWN, new_bot, nullptr, "", 0);
+
+		if (parse->BotHasQuestSub(EVENT_SPAWN)) {
+			parse->EventBot(EVENT_SPAWN, new_bot, nullptr, "", 0);
+		}
+
 		new_bot->SetSpawned();
 		if (send_spawn_packet) {
 			if (dont_queue) {
@@ -8340,7 +8344,9 @@ void EntityList::AddBot(Bot *new_bot, bool send_spawn_packet, bool dont_queue) {
 			}
 		}
 
-		new_bot->DispatchZoneControllerEvent(EVENT_SPAWN_ZONE, new_bot, "", 0, nullptr);
+		if (parse->HasQuestSub(ZONE_CONTROLLER_NPC_ID, EVENT_SPAWN_ZONE)) {
+			new_bot->DispatchZoneControllerEvent(EVENT_SPAWN_ZONE, new_bot, "", 0, nullptr);
+		}
 	}
 }
 

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -1860,6 +1860,7 @@ void PerlembParser::ExportEventVariables(
 			ExportVar(package_name.c_str(), "spawned_entity_id", mob->GetID());
 			ExportVar(package_name.c_str(), "spawned_bot_id", mob->IsBot() ? mob->CastToBot()->GetBotID() : 0);
 			ExportVar(package_name.c_str(), "spawned_npc_id", mob->IsNPC() ? mob->GetNPCTypeID() : 0);
+			ExportVar(package_name.c_str(), "spawned", "Mob", mob);
 			break;
 		}
 

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -683,7 +683,9 @@ void EntityList::AddNPC(NPC *npc, bool send_spawn_packet, bool dont_queue)
 	npc_list.insert(std::pair<uint16, NPC *>(npc->GetID(), npc));
 	mob_list.insert(std::pair<uint16, Mob *>(npc->GetID(), npc));
 
-	parse->EventNPC(EVENT_SPAWN, npc, nullptr, "", 0);
+	if (parse->HasQuestSub(npc->GetNPCTypeID())) {
+		parse->EventNPC(EVENT_SPAWN, npc, nullptr, "", 0);
+	}
 
 	const auto emote_id = npc->GetEmoteID();
 	if (emote_id != 0) {
@@ -722,7 +724,9 @@ void EntityList::AddNPC(NPC *npc, bool send_spawn_packet, bool dont_queue)
 
 	entity_list.ScanCloseMobs(npc->close_mobs, npc, true);
 
-	npc->DispatchZoneControllerEvent(EVENT_SPAWN_ZONE, npc, "", 0, nullptr);
+	if (parse->HasQuestSub(ZONE_CONTROLLER_NPC_ID, EVENT_SPAWN_ZONE)) {
+		npc->DispatchZoneControllerEvent(EVENT_SPAWN_ZONE, npc, "", 0, nullptr);
+	}
 
 	if (zone->HasMap() && zone->HasWaterMap()) {
 		npc->SetSpawnedInWater(false);


### PR DESCRIPTION
# Notes
- Exports `$spawned` to `EVENT_SPAWN_ZONE` in Perl.
- Allows operators to use the mob reference instead of having to grab it from entity list.