### PR TITLE
[Quest API] Export $item and $corpse to EVENT_LOOT and EVENT_LOOT_ZONE in Perl

### DIFF
--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -1420,17 +1420,18 @@ void Corpse::LootItem(Client *client, const EQApplicationPacket *app)
 			}
 		}
 
-		std::string export_string = fmt::format(
+		const auto export_string = fmt::format(
 			"{} {} {} {}",
 			inst->GetItem()->ID,
 			inst->GetCharges(),
 			EntityList::RemoveNumbers(corpse_name),
 			GetID()
 		);
-		std::vector<std::any> args;
-		args.push_back(inst);
-		args.push_back(this);
-		bool prevent_loot = false;
+
+		std::vector<std::any> args = { inst, this };
+
+		auto prevent_loot = false;
+
 		if (RuleB(Zone, UseZoneController)) {
 			auto controller = entity_list.GetNPCByNPCTypeID(ZONE_CONTROLLER_NPC_ID);
 			if (controller) {

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -1420,22 +1420,21 @@ void Corpse::LootItem(Client *client, const EQApplicationPacket *app)
 			}
 		}
 
-		const auto& export_string = fmt::format(
-			"{} {} {} {}",
-			inst->GetItem()->ID,
-			inst->GetCharges(),
-			EntityList::RemoveNumbers(corpse_name),
-			GetID()
-		);
-
-		std::vector<std::any> args = { inst, this };
-
 		auto prevent_loot = false;
 
 		if (RuleB(Zone, UseZoneController)) {
 			auto controller = entity_list.GetNPCByNPCTypeID(ZONE_CONTROLLER_NPC_ID);
 			if (controller) {
 				if (parse->HasQuestSub(ZONE_CONTROLLER_NPC_ID, EVENT_LOOT_ZONE)) {
+					const auto& export_string = fmt::format(
+						"{} {} {} {}",
+						inst->GetItem()->ID,
+						inst->GetCharges(),
+						EntityList::RemoveNumbers(corpse_name),
+						GetID()
+					);
+
+					std::vector<std::any> args = { inst, this };
 					if (parse->EventNPC(EVENT_LOOT_ZONE, controller, client, export_string, 0, &args) != 0) {
 						prevent_loot = true;
 					}
@@ -1444,6 +1443,15 @@ void Corpse::LootItem(Client *client, const EQApplicationPacket *app)
 		}
 
 		if (parse->PlayerHasQuestSub(EVENT_LOOT)) {
+			const auto& export_string = fmt::format(
+				"{} {} {} {}",
+				inst->GetItem()->ID,
+				inst->GetCharges(),
+				EntityList::RemoveNumbers(corpse_name),
+				GetID()
+			);
+
+			std::vector<std::any> args = { inst, this };
 			if (parse->EventPlayer(EVENT_LOOT, client, export_string, 0, &args) != 0) {
 				prevent_loot = true;
 			}
@@ -1474,6 +1482,15 @@ void Corpse::LootItem(Client *client, const EQApplicationPacket *app)
 		}
 
 		if (parse->ItemHasQuestSub(inst, EVENT_LOOT)) {
+			const auto& export_string = fmt::format(
+				"{} {} {} {}",
+				inst->GetItem()->ID,
+				inst->GetCharges(),
+				EntityList::RemoveNumbers(corpse_name),
+				GetID()
+			);
+
+			std::vector<std::any> args = { inst, this };
 			if (parse->EventItem(EVENT_LOOT, client, inst, this, export_string, 0, &args) != 0) {
 				prevent_loot = true;
 			}

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -1469,7 +1469,7 @@ void Corpse::LootItem(Client *client, const EQApplicationPacket *app)
 		}
 
 		// do we want this to have a fail option too? Sure?
-		if (parse->EventItem(EVENT_LOOT, client, inst, this, export_string, 0) != 0) {
+		if (parse->EventItem(EVENT_LOOT, client, inst, this, export_string, 0, &args) != 0) {
 			prevent_loot = true;
 		}
 

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -1433,15 +1433,19 @@ void Corpse::LootItem(Client *client, const EQApplicationPacket *app)
 		bool prevent_loot = false;
 		if (RuleB(Zone, UseZoneController)) {
 			auto controller = entity_list.GetNPCByNPCTypeID(ZONE_CONTROLLER_NPC_ID);
-			if (controller){
-				if (parse->EventNPC(EVENT_LOOT_ZONE, controller, client, export_string, 0, &args) != 0) {
-					prevent_loot = true;
+			if (controller) {
+				if (parse->HasQuestSub(ZONE_CONTROLLER_NPC_ID, EVENT_LOOT_ZONE)) {
+					if (parse->EventNPC(EVENT_LOOT_ZONE, controller, client, export_string, 0, &args) != 0) {
+						prevent_loot = true;
+					}
 				}
 			}
 		}
 
-		if (parse->EventPlayer(EVENT_LOOT, client, export_string, 0, &args) != 0) {
-			prevent_loot = true;
+		if (parse->PlayerHasQuestSub(EVENT_LOOT)) {
+			if (parse->EventPlayer(EVENT_LOOT, client, export_string, 0, &args) != 0) {
+				prevent_loot = true;
+			}
 		}
 
 		if (player_event_logs.IsEventEnabled(PlayerEvent::LOOT_ITEM) && !IsPlayerCorpse()) {
@@ -1468,9 +1472,10 @@ void Corpse::LootItem(Client *client, const EQApplicationPacket *app)
 			}
 		}
 
-		// do we want this to have a fail option too? Sure?
-		if (parse->EventItem(EVENT_LOOT, client, inst, this, export_string, 0, &args) != 0) {
-			prevent_loot = true;
+		if (parse->ItemHasQuestSub(inst, EVENT_LOOT)) {
+			if (parse->EventItem(EVENT_LOOT, client, inst, this, export_string, 0, &args) != 0) {
+				prevent_loot = true;
+			}
 		}
 
 		if (prevent_loot) {

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -1420,7 +1420,7 @@ void Corpse::LootItem(Client *client, const EQApplicationPacket *app)
 			}
 		}
 
-		const auto export_string = fmt::format(
+		const auto& export_string = fmt::format(
 			"{} {} {} {}",
 			inst->GetItem()->ID,
 			inst->GetCharges(),

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -1614,8 +1614,17 @@ void PerlembParser::ExportEventVariables(
 			Seperator sep(data);
 			ExportVar(package_name.c_str(), "looted_id", sep.arg[0]);
 			ExportVar(package_name.c_str(), "looted_charges", sep.arg[1]);
-			ExportVar(package_name.c_str(), "corpse", sep.arg[2]);
+			ExportVar(package_name.c_str(), "corpse_name", sep.arg[2]);
 			ExportVar(package_name.c_str(), "corpse_id", sep.arg[3]);
+
+			if (extra_pointers && extra_pointers->size() >= 1) {
+				ExportVar(package_name.c_str(), "item", "QuestItem", std::any_cast<EQ::ItemInstance*>(extra_pointers->at(0)));
+			}
+
+			if (extra_pointers && extra_pointers->size() == 2) {
+				ExportVar(package_name.c_str(), "corpse", "Corpse", std::any_cast<Corpse*>(extra_pointers->at(1)));
+			}
+
 			break;
 		}
 


### PR DESCRIPTION
# Notes
- Exports `$item` and `$corpse` to `EVENT_LOOT` in Perl.
- Exports `$item` and `$corpse` to `EVENT_LOOT_ZONE` in Perl.