### PR TITLE
[Quest API] (Performance) Check task events exist before export and execute

### DIFF
--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -565,13 +565,19 @@ int ClientTaskState::UpdateTasks(Client* client, const TaskUpdateFilter& filter,
 
 			if (CanUpdate(client, filter, client_task.task_id, activity, client_activity))
 			{
-				auto args = fmt::format("{} {} {}", count, client_activity.activity_id, client_task.task_id);
-				if (parse->EventPlayer(EVENT_TASK_BEFORE_UPDATE, client, args, 0) != 0)
-				{
-					LogTasks("client [{}] task [{}]-[{}] update prevented by quest",
-						client->GetName(), client_task.task_id, client_activity.activity_id);
+				if (parse->PlayerHasQuestSub(EVENT_TASK_BEFORE_UPDATE)) {
+					const auto export_string = fmt::format(
+						"{} {} {}",
+						count,
+						client_activity.activity_id,
+						client_task.task_id
+					);
+					if (parse->EventPlayer(EVENT_TASK_BEFORE_UPDATE, client, export_string, 0) != 0) {
+						LogTasks("client [{}] task [{}]-[{}] update prevented by quest",
+								 client->GetName(), client_task.task_id, client_activity.activity_id);
 
-					continue;
+						continue;
+					}
 				}
 
 				LogTasks("client [{}] task [{}] activity [{}] increment [{}]",
@@ -854,13 +860,15 @@ int ClientTaskState::IncrementDoneCount(
 	info->activity[activity_id].done_count += count;
 
 	if (!ignore_quest_update) {
-		std::string export_string = fmt::format(
-			"{} {} {}",
-			info->activity[activity_id].done_count,
-			info->activity[activity_id].activity_id,
-			info->task_id
-		);
-		parse->EventPlayer(EVENT_TASK_UPDATE, client, export_string, 0);
+		if (parse->PlayerHasQuestSub(EVENT_TASK_UPDATE)) {
+			const auto export_string = fmt::format(
+				"{} {} {}",
+				info->activity[activity_id].done_count,
+				info->activity[activity_id].activity_id,
+				info->task_id
+			);
+			parse->EventPlayer(EVENT_TASK_UPDATE, client, export_string, 0);
+		}
 	}
 
 	if (task_data->type != TaskType::Shared) {
@@ -896,12 +904,14 @@ int ClientTaskState::IncrementDoneCount(
 		task_manager->SendSingleActiveTaskToClient(client, *info, task_complete, false);
 
 		if (!ignore_quest_update) {
-			std::string export_string = fmt::format(
-				"{} {}",
-				info->task_id,
-				info->activity[activity_id].activity_id
-			);
-			parse->EventPlayer(EVENT_TASK_STAGE_COMPLETE, client, export_string, 0);
+			if (parse->PlayerHasQuestSub(EVENT_TASK_STAGE_COMPLETE)) {
+				const auto export_string = fmt::format(
+					"{} {}",
+					info->task_id,
+					info->activity[activity_id].activity_id
+				);
+				parse->EventPlayer(EVENT_TASK_STAGE_COMPLETE, client, export_string, 0);
+			}
 		}
 		/* QS: PlayerLogTaskUpdates :: Update */
 		if (RuleB(QueryServ, PlayerLogTaskUpdates)) {
@@ -993,13 +1003,16 @@ int ClientTaskState::IncrementDoneCount(
 
 int ClientTaskState::DispatchEventTaskComplete(Client* client, ClientTaskInformation& info, int activity_id)
 {
-	std::string export_string = fmt::format(
-		"{} {} {}",
-		info.activity[activity_id].done_count,
-		info.activity[activity_id].activity_id,
-		info.task_id
-	);
-	return parse->EventPlayer(EVENT_TASK_COMPLETE, client, export_string, 0);
+	if (parse->PlayerHasQuestSub(EVENT_TASK_COMPLETE)) {
+		const auto export_string = fmt::format(
+			"{} {} {}",
+			info.activity[activity_id].done_count,
+			info.activity[activity_id].activity_id,
+			info.task_id
+		);
+		return parse->EventPlayer(EVENT_TASK_COMPLETE, client, export_string, 0);
+	}
+	return 0;
 }
 
 void ClientTaskState::RewardTask(Client *c, const TaskInformation *ti, ClientTaskInformation& client_task)
@@ -2150,7 +2163,6 @@ void ClientTaskState::AcceptNewTask(
 	client->MessageString(Chat::DefaultText, YOU_ASSIGNED_TASK, task->title.c_str());
 
 	task_manager->SaveClientState(client, this);
-	std::string export_string = std::to_string(task_id);
 
 	NPC *npc = entity_list.GetID(npc_type_id)->CastToNPC();
 	if (npc) {
@@ -2176,7 +2188,10 @@ void ClientTaskState::AcceptNewTask(
 			RecordPlayerEventLogWithClient(client, PlayerEvent::TASK_ACCEPT, e);
 		}
 	}
-	parse->EventPlayer(EVENT_TASK_ACCEPTED, client, export_string, 0);
+
+	if (parse->PlayerHasQuestSub(EVENT_TASK_ACCEPTED)) {
+		parse->EventPlayer(EVENT_TASK_ACCEPTED, client, std::to_string(task_id), 0);
+	}
 }
 
 void ClientTaskState::ProcessTaskProximities(Client *client, float x, float y, float z)

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -566,12 +566,13 @@ int ClientTaskState::UpdateTasks(Client* client, const TaskUpdateFilter& filter,
 			if (CanUpdate(client, filter, client_task.task_id, activity, client_activity))
 			{
 				if (parse->PlayerHasQuestSub(EVENT_TASK_BEFORE_UPDATE)) {
-					const auto export_string = fmt::format(
+					const auto& export_string = fmt::format(
 						"{} {} {}",
 						count,
 						client_activity.activity_id,
 						client_task.task_id
 					);
+
 					if (parse->EventPlayer(EVENT_TASK_BEFORE_UPDATE, client, export_string, 0) != 0) {
 						LogTasks(
 							"client [{}] task [{}]-[{}] update prevented by quest",
@@ -870,12 +871,13 @@ int ClientTaskState::IncrementDoneCount(
 
 	if (!ignore_quest_update) {
 		if (parse->PlayerHasQuestSub(EVENT_TASK_UPDATE)) {
-			const auto export_string = fmt::format(
+			const auto& export_string = fmt::format(
 				"{} {} {}",
 				info->activity[activity_id].done_count,
 				info->activity[activity_id].activity_id,
 				info->task_id
 			);
+
 			parse->EventPlayer(EVENT_TASK_UPDATE, client, export_string, 0);
 		}
 	}
@@ -914,11 +916,12 @@ int ClientTaskState::IncrementDoneCount(
 
 		if (!ignore_quest_update) {
 			if (parse->PlayerHasQuestSub(EVENT_TASK_STAGE_COMPLETE)) {
-				const auto export_string = fmt::format(
+				const auto& export_string = fmt::format(
 					"{} {}",
 					info->task_id,
 					info->activity[activity_id].activity_id
 				);
+
 				parse->EventPlayer(EVENT_TASK_STAGE_COMPLETE, client, export_string, 0);
 			}
 		}
@@ -1013,14 +1016,16 @@ int ClientTaskState::IncrementDoneCount(
 int ClientTaskState::DispatchEventTaskComplete(Client* client, ClientTaskInformation& info, int activity_id)
 {
 	if (parse->PlayerHasQuestSub(EVENT_TASK_COMPLETE)) {
-		const auto export_string = fmt::format(
+		const auto& export_string = fmt::format(
 			"{} {} {}",
 			info.activity[activity_id].done_count,
 			info.activity[activity_id].activity_id,
 			info.task_id
 		);
+
 		return parse->EventPlayer(EVENT_TASK_COMPLETE, client, export_string, 0);
 	}
+
 	return 0;
 }
 

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -2166,8 +2166,6 @@ void ClientTaskState::AcceptNewTask(
 
 	NPC *npc = entity_list.GetID(npc_type_id)->CastToNPC();
 	if (npc) {
-		parse->EventNPC(EVENT_TASK_ACCEPTED, npc, client, std::to_string(task_id), 0);
-
 		if (player_event_logs.IsEventEnabled(PlayerEvent::TASK_ACCEPT)) {
 			auto e = PlayerEvent::TaskAcceptEvent{
 				.npc_id = static_cast<uint32>(npc_type_id),
@@ -2176,6 +2174,10 @@ void ClientTaskState::AcceptNewTask(
 				.task_name = task_manager->GetTaskName(static_cast<uint32>(task_id)),
 			};
 			RecordPlayerEventLogWithClient(client, PlayerEvent::TASK_ACCEPT, e);
+		}
+
+		if (parse->HasQuestSub(npc->GetNPCTypeID(), EVENT_TASK_ACCEPTED)) {
+			parse->EventNPC(EVENT_TASK_ACCEPTED, npc, client, std::to_string(task_id), 0);
 		}
 	} else {
 		if (player_event_logs.IsEventEnabled(PlayerEvent::TASK_ACCEPT)) {
@@ -2186,7 +2188,6 @@ void ClientTaskState::AcceptNewTask(
 				.task_name = task_manager->GetTaskName(static_cast<uint32>(task_id)),
 			};
 			RecordPlayerEventLogWithClient(client, PlayerEvent::TASK_ACCEPT, e);
-		}
 	}
 
 	if (parse->PlayerHasQuestSub(EVENT_TASK_ACCEPTED)) {

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -566,32 +566,22 @@ int ClientTaskState::UpdateTasks(Client* client, const TaskUpdateFilter& filter,
 			if (CanUpdate(client, filter, client_task.task_id, activity, client_activity))
 			{
 				if (parse->PlayerHasQuestSub(EVENT_TASK_BEFORE_UPDATE)) {
-					const auto& export_string = fmt::format(
+					const auto export_string = fmt::format(
 						"{} {} {}",
 						count,
 						client_activity.activity_id,
 						client_task.task_id
 					);
-
 					if (parse->EventPlayer(EVENT_TASK_BEFORE_UPDATE, client, export_string, 0) != 0) {
-						LogTasks(
-							"client [{}] task [{}]-[{}] update prevented by quest",
-							client->GetName(),
-							client_task.task_id,
-							client_activity.activity_id
-						);
+						LogTasks("client [{}] task [{}]-[{}] update prevented by quest",
+								 client->GetName(), client_task.task_id, client_activity.activity_id);
 
 						continue;
 					}
 				}
 
-				LogTasks(
-					"client [{}] task [{}] activity [{}] increment [{}]",
-					client->GetName(),
-					client_task.task_id,
-					client_activity.activity_id,
-					count
-				);
+				LogTasks("client [{}] task [{}] activity [{}] increment [{}]",
+					client->GetName(), client_task.task_id, client_activity.activity_id, count);
 
 				int updated = IncrementDoneCount(client, task, client_task.slot, client_activity.activity_id, count);
 				max_updated = std::max(max_updated, updated);
@@ -871,13 +861,12 @@ int ClientTaskState::IncrementDoneCount(
 
 	if (!ignore_quest_update) {
 		if (parse->PlayerHasQuestSub(EVENT_TASK_UPDATE)) {
-			const auto& export_string = fmt::format(
+			const auto export_string = fmt::format(
 				"{} {} {}",
 				info->activity[activity_id].done_count,
 				info->activity[activity_id].activity_id,
 				info->task_id
 			);
-
 			parse->EventPlayer(EVENT_TASK_UPDATE, client, export_string, 0);
 		}
 	}
@@ -916,12 +905,11 @@ int ClientTaskState::IncrementDoneCount(
 
 		if (!ignore_quest_update) {
 			if (parse->PlayerHasQuestSub(EVENT_TASK_STAGE_COMPLETE)) {
-				const auto& export_string = fmt::format(
+				const auto export_string = fmt::format(
 					"{} {}",
 					info->task_id,
 					info->activity[activity_id].activity_id
 				);
-
 				parse->EventPlayer(EVENT_TASK_STAGE_COMPLETE, client, export_string, 0);
 			}
 		}
@@ -1016,16 +1004,14 @@ int ClientTaskState::IncrementDoneCount(
 int ClientTaskState::DispatchEventTaskComplete(Client* client, ClientTaskInformation& info, int activity_id)
 {
 	if (parse->PlayerHasQuestSub(EVENT_TASK_COMPLETE)) {
-		const auto& export_string = fmt::format(
+		const auto export_string = fmt::format(
 			"{} {} {}",
 			info.activity[activity_id].done_count,
 			info.activity[activity_id].activity_id,
 			info.task_id
 		);
-
 		return parse->EventPlayer(EVENT_TASK_COMPLETE, client, export_string, 0);
 	}
-
 	return 0;
 }
 
@@ -2180,7 +2166,7 @@ void ClientTaskState::AcceptNewTask(
 
 	NPC *npc = entity_list.GetID(npc_type_id)->CastToNPC();
 	if (npc) {
-		parse->EventNPC(EVENT_TASK_ACCEPTED, npc, client, export_string, 0);
+		parse->EventNPC(EVENT_TASK_ACCEPTED, npc, client, std::to_string(task_id), 0);
 
 		if (player_event_logs.IsEventEnabled(PlayerEvent::TASK_ACCEPT)) {
 			auto e = PlayerEvent::TaskAcceptEvent{

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -573,15 +573,24 @@ int ClientTaskState::UpdateTasks(Client* client, const TaskUpdateFilter& filter,
 						client_task.task_id
 					);
 					if (parse->EventPlayer(EVENT_TASK_BEFORE_UPDATE, client, export_string, 0) != 0) {
-						LogTasks("client [{}] task [{}]-[{}] update prevented by quest",
-								 client->GetName(), client_task.task_id, client_activity.activity_id);
+						LogTasks(
+							"client [{}] task [{}]-[{}] update prevented by quest",
+							client->GetName(),
+							client_task.task_id,
+							client_activity.activity_id
+						);
 
 						continue;
 					}
 				}
 
-				LogTasks("client [{}] task [{}] activity [{}] increment [{}]",
-					client->GetName(), client_task.task_id, client_activity.activity_id, count);
+				LogTasks(
+					"client [{}] task [{}] activity [{}] increment [{}]",
+					client->GetName(),
+					client_task.task_id,
+					client_activity.activity_id,
+					count
+				);
 
 				int updated = IncrementDoneCount(client, task, client_task.slot, client_activity.activity_id, count);
 				max_updated = std::max(max_updated, updated);

--- a/zone/tasks.cpp
+++ b/zone/tasks.cpp
@@ -96,9 +96,9 @@ void Client::SendTaskActivityComplete(
 
 void Client::SendTaskFailed(int task_id, int task_index, TaskType task_type)
 {
-	// 0x54eb
-	std::string export_string = fmt::format("{}", task_id);
-	parse->EventPlayer(EVENT_TASK_FAIL, this, export_string, 0);
+	if (parse->PlayerHasQuestSub(EVENT_TASK_FAIL)) {
+		parse->EventPlayer(EVENT_TASK_FAIL, this, std::to_string(task_id), 0);
+	}
 
 	TaskActivityComplete_Struct *task_activity_complete;
 


### PR DESCRIPTION
# Notes
- Optionally parses `EVENT_TASK_BEFORE_UPDATE`, `EVENT_TASK_ACCEPTED`, `EVENT_TASK_STAGE_COMPLETE`, `EVENT_TASK_UPDATE`, `EVENT_TASK_COMPLETE`, and `EVENT_TASK_FAIL`.