### PR TITLE
[Quest API] Export $hate_entity to EVENT_HATE_LIST in Perl

### DIFF
--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -1743,6 +1743,7 @@ void PerlembParser::ExportEventVariables(
 
 		case EVENT_HATE_LIST: {
 			ExportVar(package_name.c_str(), "hate_state", data);
+			ExportVar(package_name.c_str(), "hate_entity", "Mob", mob);
 			break;
 		}
 

--- a/zone/hate_list.cpp
+++ b/zone/hate_list.cpp
@@ -66,7 +66,9 @@ void HateList::WipeHateList()
 		Mob* m = (*iterator)->entity_on_hatelist;
 		if (m)
 		{
-			parse->EventNPC(EVENT_HATE_LIST, hate_owner->CastToNPC(), m, "0", 0);
+			if (parse->HasQuestSub(hate_owner->GetNPCTypeID(), EVENT_HATE_LIST)) {
+				parse->EventNPC(EVENT_HATE_LIST, hate_owner->CastToNPC(), m, "0", 0);
+			}
 
 			if (m->IsClient()) {
 				m->CastToClient()->DecrementAggroCount();
@@ -183,18 +185,20 @@ Mob* HateList::GetClosestEntOnHateList(Mob *hater, bool skip_mezzed) {
 
 void HateList::AddEntToHateList(Mob *in_entity, int64 in_hate, int64 in_damage, bool in_is_entity_frenzied, bool iAddIfNotExist)
 {
-	if (!in_entity)
+	if (!in_entity) {
 		return;
+	}
 
-	if (in_entity->IsCorpse())
+	if (in_entity->IsCorpse()) {
 		return;
+	}
 
-	if (in_entity->IsClient() && in_entity->CastToClient()->IsDead())
+	if (in_entity->IsClient() && in_entity->CastToClient()->IsDead()) {
 		return;
+	}
 
 	struct_HateList *entity = Find(in_entity);
-	if (entity)
-	{
+	if (entity) {
 		entity->hatelist_damage += (in_damage >= 0) ? in_damage : 0;
 		entity->stored_hate_amount += in_hate;
 		entity->is_entity_frenzy = in_is_entity_frenzied;
@@ -209,8 +213,7 @@ void HateList::AddEntToHateList(Mob *in_entity, int64 in_hate, int64 in_damage, 
 			entity->stored_hate_amount,
 			entity->hatelist_damage
 		);
-	}
-	else if (iAddIfNotExist) {
+	} else if (iAddIfNotExist) {
 		entity = new struct_HateList;
 		entity->entity_on_hatelist = in_entity;
 		entity->hatelist_damage = (in_damage >= 0) ? in_damage : 0;
@@ -219,7 +222,10 @@ void HateList::AddEntToHateList(Mob *in_entity, int64 in_hate, int64 in_damage, 
 		entity->oor_count = 0;
 		entity->last_modified = Timer::GetCurrentTime();
 		list.push_back(entity);
-		parse->EventNPC(EVENT_HATE_LIST, hate_owner->CastToNPC(), in_entity, "1", 0);
+
+		if (parse->HasQuestSub(hate_owner->GetNPCTypeID(), EVENT_HATE_LIST)) {
+			parse->EventNPC(EVENT_HATE_LIST, hate_owner->CastToNPC(), in_entity, "1", 0);
+		}
 
 		if (in_entity->IsClient()) {
 			in_entity->CastToClient()->IncrementAggroCount(hate_owner->CastToNPC()->IsRaidTarget());
@@ -229,30 +235,32 @@ void HateList::AddEntToHateList(Mob *in_entity, int64 in_hate, int64 in_damage, 
 
 bool HateList::RemoveEntFromHateList(Mob *in_entity)
 {
-	if (!in_entity)
+	if (!in_entity) {
 		return false;
+	}
 
 	bool is_found = false;
 	auto iterator = list.begin();
 
-	while (iterator != list.end())
-	{
-		if ((*iterator)->entity_on_hatelist == in_entity)
-		{
+	while (iterator != list.end()) {
+		if ((*iterator)->entity_on_hatelist == in_entity) {
 			is_found = true;
 
-			if (in_entity && in_entity->IsClient())
+			if (in_entity && in_entity->IsClient()) {
 				in_entity->CastToClient()->DecrementAggroCount();
+			}
 
 			delete (*iterator);
 			iterator = list.erase(iterator);
 
-			if (in_entity)
-				parse->EventNPC(EVENT_HATE_LIST, hate_owner->CastToNPC(), in_entity, "0", 0);
-
-		}
-		else
+			if (in_entity) {
+				if (parse->HasQuestSub(hate_owner->GetNPCTypeID(), EVENT_HATE_LIST)) {
+					parse->EventNPC(EVENT_HATE_LIST, hate_owner->CastToNPC(), in_entity, "0", 0);
+				}
+			}
+		} else {
 			++iterator;
+		}
 	}
 	return is_found;
 }
@@ -811,19 +819,23 @@ void HateList::RemoveStaleEntries(int time_ms, float dist)
 		if (m) {
 			bool remove = false;
 
-			if (cur_time - (*it)->last_modified > time_ms)
+			if (cur_time - (*it)->last_modified > time_ms) {
 				remove = true;
+			}
 
 			if (!remove && DistanceSquaredNoZ(hate_owner->GetPosition(), m->GetPosition()) > dist2) {
 				(*it)->oor_count++;
-				if ((*it)->oor_count == 2)
+				if ((*it)->oor_count == 2) {
 					remove = true;
+				}
 			} else if ((*it)->oor_count != 0) {
 				(*it)->oor_count = 0;
 			}
 
 			if (remove) {
-				parse->EventNPC(EVENT_HATE_LIST, hate_owner->CastToNPC(), m, "0", 0);
+				if (parse->HasQuestSub(hate_owner->GetNPCTypeID(), EVENT_HATE_LIST)) {
+					parse->EventNPC(EVENT_HATE_LIST, hate_owner->CastToNPC(), m, "0", 0);
+				}
 
 				if (m->IsClient()) {
 					m->CastToClient()->DecrementAggroCount();


### PR DESCRIPTION
# Notes
- Exports `$hate_entity` to `EVENT_HATE_LIST`.
- Allows operators to see which mob is joining/leaving an NPC's hatelist.