### PR TITLE
[Quest API] (Performance) Check event exists before export and execute EVENT_DESPAWN and EVENT_DESPAWN_ZONE

### DIFF
--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -1114,11 +1114,21 @@ void NPC::Depop(bool start_spawn_timer) {
 	}
 
 	if (IsNPC()) {
-		parse->EventNPC(EVENT_DESPAWN, this, nullptr, "", 0);
-		DispatchZoneControllerEvent(EVENT_DESPAWN_ZONE, this, "", 0, nullptr);
+		if (parse->HasQuestSub(GetNPCTypeID(), EVENT_DESPAWN)) {
+			parse->EventNPC(EVENT_DESPAWN, this, nullptr, "", 0);
+		}
+
+		if (parse->HasQuestSub(ZONE_CONTROLLER_NPC_ID, EVENT_DESPAWN_ZONE)) {
+			DispatchZoneControllerEvent(EVENT_DESPAWN_ZONE, this, "", 0, nullptr);
+		}
 	} else if (IsBot()) {
-		parse->EventBot(EVENT_DESPAWN, CastToBot(), nullptr, "", 0);
-		DispatchZoneControllerEvent(EVENT_DESPAWN_ZONE, this, "", 0, nullptr);
+		if (parse->BotHasQuestSub(EVENT_DESPAWN)) {
+			parse->EventBot(EVENT_DESPAWN, CastToBot(), nullptr, "", 0);
+		}
+
+		if (parse->HasQuestSub(ZONE_CONTROLLER_NPC_ID, EVENT_DESPAWN_ZONE)) {
+			DispatchZoneControllerEvent(EVENT_DESPAWN_ZONE, this, "", 0, nullptr);
+		}
 	}
 
 	p_depop = true;


### PR DESCRIPTION
# Notes
- Optionally parse these events instead of always doing so.