### PR TITLE
[Quest API] (Performance) Check event exists before export and execute EVENT_LEVEL_UP and EVENT_LEVEL_DOWN

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -13581,7 +13581,7 @@ void Client::Handle_OP_ShopPlayerBuy(const EQApplicationPacket *app)
 		safe_delete(qspack);
 	}
 	// end QS code
-	
+
 	if (parse->PlayerHasQuestSub(EVENT_MERCHANT_BUY)) {
 		const auto& export_string = fmt::format(
 			"{} {} {} {} {}",

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -871,8 +871,11 @@ void Client::SetLevel(uint8 set_level, bool command)
 
 	if (set_level > m_pp.level) {
 		int levels_gained = (set_level - m_pp.level);
-		const auto export_string = fmt::format("{}", levels_gained);
-		parse->EventPlayer(EVENT_LEVEL_UP, this, export_string, 0);
+
+		if (parse->PlayerHasQuestSub(EVENT_LEVEL_UP)) {
+			parse->EventPlayer(EVENT_LEVEL_UP, this, std::to_string(levels_gained), 0);
+		}
+
 		if (player_event_logs.IsEventEnabled(PlayerEvent::LEVEL_GAIN)) {
 			auto e = PlayerEvent::LevelGainedEvent{
 				.from_level = m_pp.level,
@@ -882,7 +885,6 @@ void Client::SetLevel(uint8 set_level, bool command)
 
 			RecordPlayerEventLog(PlayerEvent::LEVEL_GAIN, e);
 		}
-								
 
 		if (RuleB(QueryServ, PlayerLogLevels)) {
 			const auto event_desc = fmt::format(
@@ -896,8 +898,11 @@ void Client::SetLevel(uint8 set_level, bool command)
 		}
 	} else if (set_level < m_pp.level) {
 		int levels_lost = (m_pp.level - set_level);
-		const auto export_string = fmt::format("{}", levels_lost);
-		parse->EventPlayer(EVENT_LEVEL_DOWN, this, export_string, 0);
+
+		if (parse->PlayerHasQuestSub(EVENT_LEVEL_DOWN)) {
+			parse->EventPlayer(EVENT_LEVEL_DOWN, this, std::to_string(levels_lost), 0);
+		}
+
 		if (player_event_logs.IsEventEnabled(PlayerEvent::LEVEL_LOSS)) {
 			auto e = PlayerEvent::LevelLostEvent{
 				.from_level = m_pp.level,


### PR DESCRIPTION
# Notes
- Optionally parses these events instead of always doing so.