### PR TITLE
[Quest API] (Performance) Check event exists before export and execute EVENT_GM_COMMAND

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -591,7 +591,9 @@ int command_realdispatch(Client *c, std::string message, bool ignore_status)
 		return -1;
 	}
 
-	parse->EventPlayer(EVENT_GM_COMMAND, c, message, 0);
+	if (parse->PlayerHasQuestSub(EVENT_GM_COMMAND)) {
+		parse->EventPlayer(EVENT_GM_COMMAND, c, message, 0);
+	}
 
 	cur->function(c, &sep);	// Dispatch C++ Command
 


### PR DESCRIPTION
# Notes
- Optionally parse this event instead of always doing so.