### PR TITLE
[Quest API] Add $target export to EVENT_INSPECT in Perl

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -9241,7 +9241,7 @@ void Client::Handle_OP_LDoNInspect(const EQApplicationPacket *app)
 	auto* t = GetTarget();
 	if (t && t->GetClass() == LDON_TREASURE && !t->IsAura()) {
 		if (parse->PlayerHasQuestSub(EVENT_INSPECT)) {
-			std::vector<std::any> args = {t};
+			std::vector<std::any> args = { t };
 			if (parse->EventPlayer(EVENT_INSPECT, this, "", t->GetID(), &args) == 0) {
 				Message(Chat::Yellow, fmt::format("{}", t->GetCleanName()).c_str());
 			}

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -9238,13 +9238,13 @@ void Client::Handle_OP_LDoNDisarmTraps(const EQApplicationPacket *app)
 
 void Client::Handle_OP_LDoNInspect(const EQApplicationPacket *app)
 {
-	Mob * target = GetTarget();
-	if (target && target->GetClass() == LDON_TREASURE && !target->IsAura())
-	{
-		std::vector<std::any> args = { target };
-		if (parse->EventPlayer(EVENT_INSPECT, this, "", target->GetID(), &args) == 0)
-		{
-			Message(Chat::Yellow, "%s", target->GetCleanName());
+	auto* t = GetTarget();
+	if (t && t->GetClass() == LDON_TREASURE && !t->IsAura()) {
+		if (parse->PlayerHasQuestSub(EVENT_INSPECT)) {
+			std::vector<std::any> args = {t};
+			if (parse->EventPlayer(EVENT_INSPECT, this, "", t->GetID(), &args) == 0) {
+				Message(Chat::Yellow, fmt::format("{}", t->GetCleanName()).c_str());
+			}
 		}
 	}
 }

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -2014,6 +2014,9 @@ void PerlembParser::ExportEventVariables(
 
 		case EVENT_INSPECT: {
 			ExportVar(package_name.c_str(), "target_id", extradata);
+			if (extra_pointers && extra_pointers->size() == 1) {
+				ExportVar(package_name.c_str(), "target", "Mob", std::any_cast<Mob*>(extra_pointers->at(0)));
+			}
 			break;
 		}
 


### PR DESCRIPTION
# Notes
- Exports `$target` to `EVENT_INSPECT`.
- Allows operators to get information from target directly instead of using entity list.