### PR TITLE
[Quest API] (Performance) Check event EVENT_AA_BUY or EVENT_AA_GAIN exist before export and execute

### DIFF
--- a/zone/aa.cpp
+++ b/zone/aa.cpp
@@ -1226,7 +1226,7 @@ void Client::FinishAlternateAdvancementPurchase(AA::Rank *rank, bool ignore_cost
 	}
 
 	if (parse->PlayerHasQuestSub(EVENT_AA_BUY)) {
-		const auto export_string = fmt::format(
+		const auto& export_string = fmt::format(
 			"{} {} {} {}",
 			cost,
 			rank->id,

--- a/zone/aa.cpp
+++ b/zone/aa.cpp
@@ -1225,15 +1225,17 @@ void Client::FinishAlternateAdvancementPurchase(AA::Rank *rank, bool ignore_cost
 		}
 	}
 
-	const auto export_string = fmt::format(
-		"{} {} {} {}",
-		cost,
-		rank->id,
-		rank->prev_id,
-		rank->next_id
-	);
+	if (parse->PlayerHasQuestSub(EVENT_AA_BUY)) {
+		const auto export_string = fmt::format(
+			"{} {} {} {}",
+			cost,
+			rank->id,
+			rank->prev_id,
+			rank->next_id
+		);
 
-	parse->EventPlayer(EVENT_AA_BUY, this, export_string, 0);
+		parse->EventPlayer(EVENT_AA_BUY, this, export_string, 0);
+	}
 
 	CalcBonuses();
 

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -721,12 +721,9 @@ void Client::SetEXP(uint64 set_exp, uint64 set_aaxp, bool isrezzexp) {
 			SendSound();
 		}
 
-		const auto export_string = fmt::format(
-			"{}",
-			gained
-		);
-
-		parse->EventPlayer(EVENT_AA_GAIN, this, export_string, 0);
+		if (parse->PlayerHasQuestSub(EVENT_AA_GAIN)) {
+			parse->EventPlayer(EVENT_AA_GAIN, this, std::to_string(gained), 0);
+		}
 
 		/* QS: PlayerLogAARate */
 		if (RuleB(QueryServ, PlayerLogAARate)){


### PR DESCRIPTION
# Notes
- Optionally parse these events instead of always doing so.