### PR TITLE
[Quest API] (Performance) Check event EVENT_LANGUAGE_SKILL_UP, EVENT_SKILL_UP, or EVENT_USE_SKILL exist before export and execute

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1451,12 +1451,14 @@ void Mob::DoAttack(Mob *other, DamageHitInfo &hit, ExtraAttackOptions *opts, boo
 		}
 
 		if (IsBot()) {
-			const auto export_string = fmt::format(
-				"{} {}",
-				hit.skill,
-				GetSkill(hit.skill)
-			);
-			parse->EventBot(EVENT_USE_SKILL, CastToBot(), nullptr, export_string, 0);
+			if (parse->BotHasQuestSub(EVENT_USE_SKILL)) {
+				const auto export_string = fmt::format(
+					"{} {}",
+					hit.skill,
+					GetSkill(hit.skill)
+				);
+				parse->EventBot(EVENT_USE_SKILL, CastToBot(), nullptr, export_string, 0);
+			}
 		}
 	}
 }

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1452,11 +1452,12 @@ void Mob::DoAttack(Mob *other, DamageHitInfo &hit, ExtraAttackOptions *opts, boo
 
 		if (IsBot()) {
 			if (parse->BotHasQuestSub(EVENT_USE_SKILL)) {
-				const auto export_string = fmt::format(
+				const auto& export_string = fmt::format(
 					"{} {}",
 					hit.skill,
 					GetSkill(hit.skill)
 				);
+
 				parse->EventBot(EVENT_USE_SKILL, CastToBot(), nullptr, export_string, 0);
 			}
 		}

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -2528,7 +2528,7 @@ bool Client::CheckIncreaseSkill(EQ::skills::SkillType skillid, Mob *against_who,
 	auto maxskill = GetMaxSkillAfterSpecializationRules(skillid, MaxSkill(skillid));
 
 	if (parse->PlayerHasQuestSub(EVENT_USE_SKILL)) {
-		const auto export_string = fmt::format(
+		const auto& export_string = fmt::format(
 			"{} {}",
 			skillid,
 			skillval
@@ -2582,7 +2582,7 @@ bool Client::CheckIncreaseSkill(EQ::skills::SkillType skillid, Mob *against_who,
 			}
 
 			if (parse->PlayerHasQuestSub(EVENT_SKILL_UP)) {
-				const auto export_string = fmt::format(
+				const auto& export_string = fmt::format(
 					"{} {} {} {}",
 					skillid,
 					skillval + 1,
@@ -2622,7 +2622,7 @@ void Client::CheckLanguageSkillIncrease(uint8 langid, uint8 TeacherSkill) {
 			IncreaseLanguageSkill(langid);	// increase the language skill by 1
 
 			if (parse->PlayerHasQuestSub(EVENT_LANGUAGE_SKILL_UP)) {
-				const auto export_string = fmt::format(
+				const auto& export_string = fmt::format(
 					"{} {} {}",
 					langid,
 					LangSkill + 1,


### PR DESCRIPTION
# Notes
- Optionally parse these events instead of always doing so.