### PR TITLE
[Quest API] (Performance) Check spell or cast events exist before export and execute

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -14973,32 +14973,34 @@ void Client::Handle_OP_Translocate(const EQApplicationPacket *app)
 			zone->GetInstanceID() == PendingTranslocateData.instance_id
 		);
 
-		if (parse->EventSpell(EVENT_SPELL_EFFECT_TRANSLOCATE_COMPLETE, nullptr, this, spell_id, "", 0) == 0) {
-			// If the spell has a translocate to bind effect, AND we are already in the zone the client
-			// is bound in, use the GoToBind method. If we send OP_Translocate in this case, the client moves itself
-			// to the bind coords it has from the PlayerProfile, but with the X and Y reversed. I suspect they are
-			// reversed in the pp, and since spells like Gate are handled serverside, this has not mattered before.
-			if (
-				IsTranslocateSpell(spell_id) &&
-				in_translocate_zone
-			) {
-				PendingTranslocate = false;
-				GoToBind();
-				return;
-			}
+		if (parse->SpellHasQuestSub(spell_id, EVENT_SPELL_EFFECT_TRANSLOCATE_COMPLETE)) {
+			if (parse->EventSpell(EVENT_SPELL_EFFECT_TRANSLOCATE_COMPLETE, nullptr, this, spell_id, "", 0) == 0) {
+				// If the spell has a translocate to bind effect, AND we are already in the zone the client
+				// is bound in, use the GoToBind method. If we send OP_Translocate in this case, the client moves itself
+				// to the bind coords it has from the PlayerProfile, but with the X and Y reversed. I suspect they are
+				// reversed in the pp, and since spells like Gate are handled serverside, this has not mattered before.
+				if (
+					IsTranslocateSpell(spell_id) &&
+					in_translocate_zone
+				) {
+					PendingTranslocate = false;
+					GoToBind();
+					return;
+				}
 
-			////Was sending the packet back to initiate client zone...
-			////but that could be abusable, so lets go through proper channels
-			MovePC(
-				PendingTranslocateData.zone_id,
-				PendingTranslocateData.instance_id,
-				PendingTranslocateData.x,
-				PendingTranslocateData.y,
-				PendingTranslocateData.z,
-				PendingTranslocateData.heading,
-				0,
-				ZoneSolicited
-			);
+				////Was sending the packet back to initiate client zone...
+				////but that could be abusable, so lets go through proper channels
+				MovePC(
+					PendingTranslocateData.zone_id,
+					PendingTranslocateData.instance_id,
+					PendingTranslocateData.x,
+					PendingTranslocateData.y,
+					PendingTranslocateData.z,
+					PendingTranslocateData.heading,
+					0,
+					ZoneSolicited
+				);
+			}
 		}
 	}
 

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -162,7 +162,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 		}
 	}
 
-	std::string export_string = fmt::format(
+	const auto& export_string = fmt::format(
 		"{} {} {} {}",
 		caster ? caster->GetID() : 0,
 		buffslot >= 0 ? buffs[buffslot].ticsremaining : 0,
@@ -3797,7 +3797,7 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 
 	const SPDat_Spell_Struct &spell = spells[buff.spellid];
 
-	const auto export_string = fmt::format(
+	const auto& export_string = fmt::format(
 		"{} {} {} {}",
 		caster ? caster->GetID() : 0,
 		buffs[slot].ticsremaining,
@@ -4154,7 +4154,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 
 	LogSpells("Fading buff [{}] from slot [{}]", buffs[slot].spellid, slot);
 
-	const auto export_string = fmt::format(
+	const auto& export_string = fmt::format(
 		"{} {} {} {}",
 		buffs[slot].casterid,
 		buffs[slot].ticsremaining,

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -171,19 +171,25 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 	);
 
 	if (IsClient()) {
-		if (parse->EventSpell(EVENT_SPELL_EFFECT_CLIENT, nullptr, CastToClient(), spell_id, export_string, 0) != 0) {
-			CalcBonuses();
-			return true;
+		if (parse->SpellHasQuestSub(spell_id, EVENT_SPELL_EFFECT_CLIENT)) {
+			if (parse->EventSpell(EVENT_SPELL_EFFECT_CLIENT, nullptr, CastToClient(), spell_id, export_string, 0) != 0) {
+				CalcBonuses();
+				return true;
+			}
 		}
 	} else if (IsNPC()) {
-		if (parse->EventSpell(EVENT_SPELL_EFFECT_NPC, this, nullptr, spell_id, export_string, 0) != 0) {
-			CalcBonuses();
-			return true;
+		if (parse->SpellHasQuestSub(spell_id, EVENT_SPELL_EFFECT_NPC)) {
+			if (parse->EventSpell(EVENT_SPELL_EFFECT_NPC, this, nullptr, spell_id, export_string, 0) != 0) {
+				CalcBonuses();
+				return true;
+			}
 		}
 	} else if (IsBot()) {
-		if (parse->EventSpell(EVENT_SPELL_EFFECT_BOT, this, nullptr, spell_id, export_string, 0) != 0) {
-			CalcBonuses();
-			return true;
+		if (parse->SpellHasQuestSub(spell_id, EVENT_SPELL_EFFECT_BOT)) {
+			if (parse->EventSpell(EVENT_SPELL_EFFECT_BOT, this, nullptr, spell_id, export_string, 0) != 0) {
+				CalcBonuses();
+				return true;
+			}
 		}
 	}
 
@@ -3791,7 +3797,7 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 
 	const SPDat_Spell_Struct &spell = spells[buff.spellid];
 
-	std::string export_string = fmt::format(
+	const auto export_string = fmt::format(
 		"{} {} {} {}",
 		caster ? caster->GetID() : 0,
 		buffs[slot].ticsremaining,
@@ -3800,16 +3806,22 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 	);
 
 	if (IsClient()) {
-		if (parse->EventSpell(EVENT_SPELL_EFFECT_BUFF_TIC_CLIENT, nullptr, CastToClient(), buff.spellid, export_string, 0) != 0) {
-			return;
+		if (parse->SpellHasQuestSub(buff.spellid, EVENT_SPELL_EFFECT_BUFF_TIC_CLIENT)) {
+			if (parse->EventSpell(EVENT_SPELL_EFFECT_BUFF_TIC_CLIENT, nullptr, CastToClient(), buff.spellid, export_string, 0) != 0) {
+				return;
+			}
 		}
 	} else if (IsNPC()) {
-		if (parse->EventSpell(EVENT_SPELL_EFFECT_BUFF_TIC_NPC, this, nullptr, buff.spellid, export_string, 0) != 0) {
-			return;
+		if (parse->SpellHasQuestSub(buff.spellid, EVENT_SPELL_EFFECT_BUFF_TIC_NPC)) {
+			if (parse->EventSpell(EVENT_SPELL_EFFECT_BUFF_TIC_NPC, this, nullptr, buff.spellid, export_string, 0) != 0) {
+				return;
+			}
 		}
 	} else if (IsBot()) {
-		if (parse->EventSpell(EVENT_SPELL_EFFECT_BUFF_TIC_BOT, this, nullptr, buff.spellid, export_string, 0) != 0) {
-			return;
+		if (parse->SpellHasQuestSub(buff.spellid, EVENT_SPELL_EFFECT_BUFF_TIC_BOT)) {
+			if (parse->EventSpell(EVENT_SPELL_EFFECT_BUFF_TIC_BOT, this, nullptr, buff.spellid, export_string, 0) != 0) {
+				return;
+			}
 		}
 	}
 
@@ -4142,7 +4154,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 
 	LogSpells("Fading buff [{}] from slot [{}]", buffs[slot].spellid, slot);
 
-	std::string export_string = fmt::format(
+	const auto export_string = fmt::format(
 		"{} {} {} {}",
 		buffs[slot].casterid,
 		buffs[slot].ticsremaining,
@@ -4150,17 +4162,25 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 		slot
 	);
 
+	const auto has_fade_event = parse->SpellHasQuestSub(buffs[slot].spellid, EVENT_SPELL_FADE);
+
 	if (IsClient()) {
-		if (parse->EventSpell(EVENT_SPELL_FADE, nullptr, CastToClient(), buffs[slot].spellid, export_string, 0) != 0) {
-			return;
+		if (has_fade_event) {
+			if (parse->EventSpell(EVENT_SPELL_FADE, nullptr, CastToClient(), buffs[slot].spellid, export_string, 0) != 0) {
+				return;
+			}
 		}
 	} else if (IsNPC()) {
-		if (parse->EventSpell(EVENT_SPELL_FADE, this, nullptr, buffs[slot].spellid, export_string, 0) != 0) {
-			return;
+		if (has_fade_event) {
+			if (parse->EventSpell(EVENT_SPELL_FADE, this, nullptr, buffs[slot].spellid, export_string, 0) != 0) {
+				return;
+			}
 		}
 	} else if (IsBot()) {
-		if (parse->EventSpell(EVENT_SPELL_FADE, this, nullptr, buffs[slot].spellid, export_string, 0) != 0) {
-			return;
+		if (has_fade_event) {
+			if (parse->EventSpell(EVENT_SPELL_FADE, this, nullptr, buffs[slot].spellid, export_string, 0) != 0) {
+				return;
+			}
 		}
 	}
 

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -162,16 +162,15 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 		}
 	}
 
-	const auto& export_string = fmt::format(
-		"{} {} {} {}",
-		caster ? caster->GetID() : 0,
-		buffslot >= 0 ? buffs[buffslot].ticsremaining : 0,
-		caster ? caster->GetLevel() : 0,
-		buffslot
-	);
-
 	if (IsClient()) {
 		if (parse->SpellHasQuestSub(spell_id, EVENT_SPELL_EFFECT_CLIENT)) {
+			const auto &export_string = fmt::format(
+				"{} {} {} {}",
+				caster ? caster->GetID() : 0,
+				buffslot >= 0 ? buffs[buffslot].ticsremaining : 0,
+				caster ? caster->GetLevel() : 0,
+				buffslot
+			);
 			if (parse->EventSpell(EVENT_SPELL_EFFECT_CLIENT, nullptr, CastToClient(), spell_id, export_string, 0) != 0) {
 				CalcBonuses();
 				return true;
@@ -179,6 +178,13 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 		}
 	} else if (IsNPC()) {
 		if (parse->SpellHasQuestSub(spell_id, EVENT_SPELL_EFFECT_NPC)) {
+			const auto &export_string = fmt::format(
+				"{} {} {} {}",
+				caster ? caster->GetID() : 0,
+				buffslot >= 0 ? buffs[buffslot].ticsremaining : 0,
+				caster ? caster->GetLevel() : 0,
+				buffslot
+			);
 			if (parse->EventSpell(EVENT_SPELL_EFFECT_NPC, this, nullptr, spell_id, export_string, 0) != 0) {
 				CalcBonuses();
 				return true;
@@ -186,6 +192,13 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 		}
 	} else if (IsBot()) {
 		if (parse->SpellHasQuestSub(spell_id, EVENT_SPELL_EFFECT_BOT)) {
+			const auto &export_string = fmt::format(
+				"{} {} {} {}",
+				caster ? caster->GetID() : 0,
+				buffslot >= 0 ? buffs[buffslot].ticsremaining : 0,
+				caster ? caster->GetLevel() : 0,
+				buffslot
+			);
 			if (parse->EventSpell(EVENT_SPELL_EFFECT_BOT, this, nullptr, spell_id, export_string, 0) != 0) {
 				CalcBonuses();
 				return true;
@@ -4154,15 +4167,17 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 
 	LogSpells("Fading buff [{}] from slot [{}]", buffs[slot].spellid, slot);
 
-	const auto& export_string = fmt::format(
-		"{} {} {} {}",
-		buffs[slot].casterid,
-		buffs[slot].ticsremaining,
-		buffs[slot].casterlevel,
-		slot
-	);
-
 	const auto has_fade_event = parse->SpellHasQuestSub(buffs[slot].spellid, EVENT_SPELL_FADE);
+	std::string export_string = "";
+	if (has_fade_event) {
+		export_string = fmt::format(
+			"{} {} {} {}",
+			buffs[slot].casterid,
+			buffs[slot].ticsremaining,
+			buffs[slot].casterlevel,
+			slot
+		);
+	}
 
 	if (IsClient()) {
 		if (has_fade_event) {

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -237,7 +237,7 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 		}
 	}
 
-	const auto export_string = fmt::format(
+	const auto& export_string = fmt::format(
 		"{} {} {}",
 		spell_id,
 		GetID(),
@@ -1642,7 +1642,7 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 	// at this point the spell has successfully been cast
 	//
 
-	const auto export_string = fmt::format(
+	const auto& export_string = fmt::format(
 		"{} {} {}",
 		spell_id,
 		GetID(),
@@ -3654,7 +3654,7 @@ bool Mob::SpellOnTarget(
 	);
 
 	/* Send the EVENT_CAST_ON event */
-	const auto export_string = fmt::format(
+	const auto& export_string = fmt::format(
 		"{} {} {}",
 		spell_id,
 		GetID(),

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -237,15 +237,14 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 		}
 	}
 
-	const auto& export_string = fmt::format(
-		"{} {} {}",
-		spell_id,
-		GetID(),
-		GetCasterLevel(spell_id)
-	);
-
 	if (IsClient()) {
 		if (parse->PlayerHasQuestSub(EVENT_CAST_BEGIN)) {
+			const auto& export_string = fmt::format(
+				"{} {} {}",
+				spell_id,
+				GetID(),
+				GetCasterLevel(spell_id)
+			);
 			if (parse->EventPlayer(EVENT_CAST_BEGIN, CastToClient(), export_string, 0) != 0) {
 				if (IsDiscipline(spell_id)) {
 					CastToClient()->SendDisciplineTimer(spells[spell_id].timer_id, 0);
@@ -258,10 +257,22 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 		}
 	} else if (IsNPC()) {
 		if (parse->HasQuestSub(GetNPCTypeID(), EVENT_CAST_BEGIN)) {
+			const auto& export_string = fmt::format(
+				"{} {} {}",
+				spell_id,
+				GetID(),
+				GetCasterLevel(spell_id)
+			);
 			parse->EventNPC(EVENT_CAST_BEGIN, CastToNPC(), nullptr, export_string, 0);
 		}
 	} else if (IsBot()) {
 		if (parse->BotHasQuestSub(EVENT_CAST_BEGIN)) {
+			const auto& export_string = fmt::format(
+				"{} {} {}",
+				spell_id,
+				GetID(),
+				GetCasterLevel(spell_id)
+			);
 			parse->EventBot(EVENT_CAST_BEGIN, CastToBot(), nullptr, export_string, 0);
 		}
 	}
@@ -3653,24 +3664,34 @@ bool Mob::SpellOnTarget(
 		(spellOwner->IsClient() ? FilterPCSpells : FilterNPCSpells) /* EQ Filter Type: (8 or 9) */
 	);
 
-	/* Send the EVENT_CAST_ON event */
-	const auto& export_string = fmt::format(
-		"{} {} {}",
-		spell_id,
-		GetID(),
-		caster_level
-	);
-
 	if (spelltar->IsNPC()) {
 		if (parse->HasQuestSub(spelltar->GetNPCTypeID(), EVENT_CAST_ON)) {
+			const auto& export_string = fmt::format(
+				"{} {} {}",
+				spell_id,
+				GetID(),
+				caster_level
+			);
 			parse->EventNPC(EVENT_CAST_ON, spelltar->CastToNPC(), this, export_string, 0);
 		}
 	} else if (spelltar->IsClient()) {
 		if (parse->PlayerHasQuestSub(EVENT_CAST_ON)) {
+			const auto& export_string = fmt::format(
+				"{} {} {}",
+				spell_id,
+				GetID(),
+				caster_level
+			);
 			parse->EventPlayer(EVENT_CAST_ON, spelltar->CastToClient(), export_string, 0);
 		}
 	} else if (spelltar->IsBot()) {
 		if (parse->BotHasQuestSub(EVENT_CAST_ON)) {
+			const auto& export_string = fmt::format(
+				"{} {} {}",
+				spell_id,
+				GetID(),
+				caster_level
+			);
 			parse->EventBot(EVENT_CAST_ON, spelltar->CastToBot(), this, export_string, 0);
 		}
 	}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -237,25 +237,33 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 		}
 	}
 
-	std::string export_string = fmt::format(
+	const auto export_string = fmt::format(
 		"{} {} {}",
 		spell_id,
 		GetID(),
 		GetCasterLevel(spell_id)
 	);
+
 	if (IsClient()) {
-		if (parse->EventPlayer(EVENT_CAST_BEGIN, CastToClient(), export_string, 0) != 0) {
-			if (IsDiscipline(spell_id)) {
-				CastToClient()->SendDisciplineTimer(spells[spell_id].timer_id, 0);
-			} else {
-				CastToClient()->SendSpellBarEnable(spell_id);
+		if (parse->PlayerHasQuestSub(EVENT_CAST_BEGIN)) {
+			if (parse->EventPlayer(EVENT_CAST_BEGIN, CastToClient(), export_string, 0) != 0) {
+				if (IsDiscipline(spell_id)) {
+					CastToClient()->SendDisciplineTimer(spells[spell_id].timer_id, 0);
+				}
+				else {
+					CastToClient()->SendSpellBarEnable(spell_id);
+				}
+				return false;
 			}
-			return false;
 		}
 	} else if (IsNPC()) {
-		parse->EventNPC(EVENT_CAST_BEGIN, CastToNPC(), nullptr, export_string, 0);
+		if (parse->HasQuestSub(GetNPCTypeID(), EVENT_CAST_BEGIN)) {
+			parse->EventNPC(EVENT_CAST_BEGIN, CastToNPC(), nullptr, export_string, 0);
+		}
 	} else if (IsBot()) {
-		parse->EventBot(EVENT_CAST_BEGIN, CastToBot(), nullptr, export_string, 0);
+		if (parse->BotHasQuestSub(EVENT_CAST_BEGIN)) {
+			parse->EventBot(EVENT_CAST_BEGIN, CastToBot(), nullptr, export_string, 0);
+		}
 	}
 
 	//To prevent NPC ghosting when spells are cast from scripts
@@ -1634,18 +1642,25 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 	// at this point the spell has successfully been cast
 	//
 
-	std::string export_string = fmt::format(
+	const auto export_string = fmt::format(
 		"{} {} {}",
 		spell_id,
 		GetID(),
 		GetCasterLevel(spell_id)
 	);
+
 	if (IsClient()) {
-		parse->EventPlayer(EVENT_CAST, CastToClient(), export_string, 0);
+		if (parse->PlayerHasQuestSub(EVENT_CAST)) {
+			parse->EventPlayer(EVENT_CAST, CastToClient(), export_string, 0);
+		}
 	} else if (IsNPC()) {
-		parse->EventNPC(EVENT_CAST, CastToNPC(), nullptr, export_string, 0);
+		if (parse->HasQuestSub(GetNPCTypeID(), EVENT_CAST)) {
+			parse->EventNPC(EVENT_CAST, CastToNPC(), nullptr, export_string, 0);
+		}
 	} else if (IsBot()) {
-		parse->EventBot(EVENT_CAST, CastToBot(), nullptr, export_string, 0);
+		if (parse->BotHasQuestSub(EVENT_CAST)) {
+			parse->EventBot(EVENT_CAST, CastToBot(), nullptr, export_string, 0);
+		}
 	}
 
 	if(bard_song_mode)
@@ -3647,11 +3662,17 @@ bool Mob::SpellOnTarget(
 	);
 
 	if (spelltar->IsNPC()) {
-		parse->EventNPC(EVENT_CAST_ON, spelltar->CastToNPC(), this, export_string, 0);
+		if (parse->HasQuestSub(spelltar->GetNPCTypeID(), EVENT_CAST_ON)) {
+			parse->EventNPC(EVENT_CAST_ON, spelltar->CastToNPC(), this, export_string, 0);
+		}
 	} else if (spelltar->IsClient()) {
-		parse->EventPlayer(EVENT_CAST_ON, spelltar->CastToClient(), export_string, 0);
+		if (parse->PlayerHasQuestSub(EVENT_CAST_ON)) {
+			parse->EventPlayer(EVENT_CAST_ON, spelltar->CastToClient(), export_string, 0);
+		}
 	} else if (spelltar->IsBot()) {
-		parse->EventBot(EVENT_CAST_ON, spelltar->CastToBot(), this, export_string, 0);
+		if (parse->BotHasQuestSub(EVENT_CAST_ON)) {
+			parse->EventBot(EVENT_CAST_ON, spelltar->CastToBot(), this, export_string, 0);
+		}
 	}
 
 	mod_spell_cast(spell_id, spelltar, reflect_effectiveness, use_resist_adjust, resist_adjust, isproc);


### PR DESCRIPTION
# Notes
- Optionally parses `EVENT_CAST`, `EVENT_CAST_BEGIN`, `EVENT_CAST_ON`, `EVENT_SPELL_EFFECT_NPC`, `EVENT_SPELL_EFFECT_CLIENT`, `EVENT_SPELL_EFFECT_BOT`, `EVENT_SPELL_EFFECT_BUFF_TIC_CLIENT`, `EVENT_SPELL_EFFECT_BUFF_TIC_NPC`, `EVENT_SPELL_EFFECT_BUFF_TIC_BOT`, `EVENT_SPELL_FADE`, and `EVENT_SPELL_EFFECT_TRANSLOCATE_COMPLETE`.