### PR TITLE
[Quest API] (Performance) Check equip or scale item events exist before export and execute

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -4009,7 +4009,10 @@ bool Client::CalcItemScale(uint32 slot_x, uint32 slot_y) {
 		if(inst->IsScaling())
 		{
 			uint16 oldexp = inst->GetExp();
-			parse->EventItem(EVENT_SCALE_CALC, this, inst, nullptr, "", 0);
+
+			if (parse->ItemHasQuestSub(inst, EVENT_SCALE_CALC)) {
+				parse->EventItem(EVENT_SCALE_CALC, this, inst, nullptr, "", 0);
+			}
 
 			if (inst->GetExp() != oldexp) {	// if the scaling factor changed, rescale the item and update the client
 				inst->ScaleItem();
@@ -4028,7 +4031,10 @@ bool Client::CalcItemScale(uint32 slot_x, uint32 slot_y) {
 			if(a_inst->IsScaling())
 			{
 				uint16 oldexp = a_inst->GetExp();
-				parse->EventItem(EVENT_SCALE_CALC, this, a_inst, nullptr, "", 0);
+
+				if (parse->ItemHasQuestSub(a_inst, EVENT_SCALE_CALC)) {
+					parse->EventItem(EVENT_SCALE_CALC, this, a_inst, nullptr, "", 0);
+				}
 
 				if (a_inst->GetExp() != oldexp)
 				{
@@ -4096,9 +4102,14 @@ bool Client::DoItemEnterZone(uint32 slot_x, uint32 slot_y) {
 		{
 			uint16 oldexp = inst->GetExp();
 
-			parse->EventItem(EVENT_ITEM_ENTER_ZONE, this, inst, nullptr, "", 0);
+			if (parse->ItemHasQuestSub(inst, EVENT_ITEM_ENTER_ZONE)) {
+				parse->EventItem(EVENT_ITEM_ENTER_ZONE, this, inst, nullptr, "", 0);
+			}
+
 			if (i <= EQ::invslot::EQUIPMENT_END) {
-				parse->EventItem(EVENT_EQUIP_ITEM, this, inst, nullptr, "", i);
+				if (parse->ItemHasQuestSub(inst, EVENT_EQUIP_ITEM)) {
+					parse->EventItem(EVENT_EQUIP_ITEM, this, inst, nullptr, "", i);
+				}
 			}
 
 			if (inst->GetExp() != oldexp) {	// if the scaling factor changed, rescale the item and update the client
@@ -4108,10 +4119,14 @@ bool Client::DoItemEnterZone(uint32 slot_x, uint32 slot_y) {
 			}
 		} else {
 			if (i <= EQ::invslot::EQUIPMENT_END) {
-				parse->EventItem(EVENT_EQUIP_ITEM, this, inst, nullptr, "", i);
+				if (parse->ItemHasQuestSub(inst, EVENT_EQUIP_ITEM)) {
+					parse->EventItem(EVENT_EQUIP_ITEM, this, inst, nullptr, "", i);
+				}
 			}
 
-			parse->EventItem(EVENT_ITEM_ENTER_ZONE, this, inst, nullptr, "", 0);
+			if (parse->ItemHasQuestSub(inst, EVENT_ITEM_ENTER_ZONE)) {
+				parse->EventItem(EVENT_ITEM_ENTER_ZONE, this, inst, nullptr, "", 0);
+			}
 		}
 
 		//iterate all augments
@@ -4125,7 +4140,9 @@ bool Client::DoItemEnterZone(uint32 slot_x, uint32 slot_y) {
 			{
 				uint16 oldexp = a_inst->GetExp();
 
-				parse->EventItem(EVENT_ITEM_ENTER_ZONE, this, a_inst, nullptr, "", 0);
+				if (parse->ItemHasQuestSub(a_inst, EVENT_ITEM_ENTER_ZONE)) {
+					parse->EventItem(EVENT_ITEM_ENTER_ZONE, this, a_inst, nullptr, "", 0);
+				}
 
 				if (a_inst->GetExp() != oldexp)
 				{
@@ -4134,7 +4151,9 @@ bool Client::DoItemEnterZone(uint32 slot_x, uint32 slot_y) {
 					update_slot = true;
 				}
 			} else {
-				parse->EventItem(EVENT_ITEM_ENTER_ZONE, this, a_inst, nullptr, "", 0);
+				if (parse->ItemHasQuestSub(a_inst, EVENT_ITEM_ENTER_ZONE)) {
+					parse->EventItem(EVENT_ITEM_ENTER_ZONE, this, a_inst, nullptr, "", 0);
+				}
 			}
 		}
 

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -5059,17 +5059,25 @@ void Bot::PerformTradeWithClient(int16 begin_slot_id, int16 end_slot_id, Client*
 
 			BotRemoveEquipItem(return_iterator.from_bot_slot);
 
-			const auto export_string = fmt::format(
-				"{} {}",
-				return_iterator.return_item_instance->IsStackable() ? return_iterator.return_item_instance->GetCharges() : 1,
-				return_iterator.from_bot_slot
-			);
+			if (parse->BotHasQuestSub(EVENT_UNEQUIP_ITEM_BOT)) {
+				const auto export_string = fmt::format(
+					"{} {}",
+					return_iterator.return_item_instance->IsStackable() ? return_iterator.return_item_instance->GetCharges() : 1,
+					return_iterator.from_bot_slot
+				);
 
-			std::vector<std::any> args;
+				std::vector<std::any> args = { return_iterator.return_item_instance };
 
-			args.emplace_back(return_iterator.return_item_instance);
+				parse->EventBot(
+					EVENT_UNEQUIP_ITEM_BOT,
+					this,
+					nullptr,
+					export_string,
+					return_iterator.return_item_instance->GetID(),
+					&args
+				);
+			}
 
-			parse->EventBot(EVENT_UNEQUIP_ITEM_BOT, this, nullptr, export_string , return_iterator.return_item_instance->GetID(), &args);
 			if (return_instance) {
 				EQ::SayLinkEngine linker;
 				linker.SetLinkType(EQ::saylink::SayLinkItemInst);
@@ -5119,17 +5127,24 @@ void Bot::PerformTradeWithClient(int16 begin_slot_id, int16 end_slot_id, Client*
 		m_inv.PutItem(trade_iterator.to_bot_slot, *trade_iterator.trade_item_instance);
 		BotAddEquipItem(trade_iterator.to_bot_slot, (trade_iterator.trade_item_instance ? trade_iterator.trade_item_instance->GetID() : 0));
 
-		const auto export_string = fmt::format(
-			"{} {}",
-			trade_iterator.trade_item_instance->IsStackable() ? trade_iterator.trade_item_instance->GetCharges() : 1,
-			trade_iterator.to_bot_slot
-		);
+		if (parse->BotHasQuestSub(EVENT_EQUIP_ITEM_BOT)) {
+			const auto export_string = fmt::format(
+				"{} {}",
+				trade_iterator.trade_item_instance->IsStackable() ? trade_iterator.trade_item_instance->GetCharges() : 1,
+				trade_iterator.to_bot_slot
+			);
 
-		std::vector<std::any> args;
+			std::vector<std::any> args = { trade_iterator.trade_item_instance };
 
-		args.emplace_back(trade_iterator.trade_item_instance);
-
-		parse->EventBot(EVENT_EQUIP_ITEM_BOT, this, nullptr, export_string, trade_iterator.trade_item_instance->GetID(), &args);
+			parse->EventBot(
+				EVENT_EQUIP_ITEM_BOT,
+				this,
+				nullptr,
+				export_string,
+				trade_iterator.trade_item_instance->GetID(),
+				&args
+			);
+		}
 
 		trade_iterator.trade_item_instance = nullptr; // actual deletion occurs in client delete below
 

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -5060,7 +5060,7 @@ void Bot::PerformTradeWithClient(int16 begin_slot_id, int16 end_slot_id, Client*
 			BotRemoveEquipItem(return_iterator.from_bot_slot);
 
 			if (parse->BotHasQuestSub(EVENT_UNEQUIP_ITEM_BOT)) {
-				const auto export_string = fmt::format(
+				const auto& export_string = fmt::format(
 					"{} {}",
 					return_iterator.return_item_instance->IsStackable() ? return_iterator.return_item_instance->GetCharges() : 1,
 					return_iterator.from_bot_slot
@@ -5128,7 +5128,7 @@ void Bot::PerformTradeWithClient(int16 begin_slot_id, int16 end_slot_id, Client*
 		BotAddEquipItem(trade_iterator.to_bot_slot, (trade_iterator.trade_item_instance ? trade_iterator.trade_item_instance->GetID() : 0));
 
 		if (parse->BotHasQuestSub(EVENT_EQUIP_ITEM_BOT)) {
-			const auto export_string = fmt::format(
+			const auto& export_string = fmt::format(
 				"{} {}",
 				trade_iterator.trade_item_instance->IsStackable() ? trade_iterator.trade_item_instance->GetCharges() : 1,
 				trade_iterator.to_bot_slot

--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -9479,7 +9479,7 @@ void bot_subcommand_inventory_remove(Client *c, const Seperator *sep)
 		);
 
 		if (parse->BotHasQuestSub(EVENT_UNEQUIP_ITEM_BOT)) {
-			const auto export_string = fmt::format(
+			const auto& export_string = fmt::format(
 				"{} {}",
 				inst->IsStackable() ? inst->GetCharges() : 1,
 				slot_id

--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -9478,17 +9478,17 @@ void bot_subcommand_inventory_remove(Client *c, const Seperator *sep)
 			)
 		);
 
-		const auto export_string = fmt::format(
-			"{} {}",
-			inst->IsStackable() ? inst->GetCharges() : 1,
-			slot_id
-		);
+		if (parse->BotHasQuestSub(EVENT_UNEQUIP_ITEM_BOT)) {
+			const auto export_string = fmt::format(
+				"{} {}",
+				inst->IsStackable() ? inst->GetCharges() : 1,
+				slot_id
+			);
 
-		std::vector<std::any> args;
+			std::vector<std::any> args = { inst };
 
-		args.emplace_back(inst);
-
-		parse->EventBot(EVENT_UNEQUIP_ITEM_BOT, my_bot, nullptr, export_string, inst->GetID(), &args);
+			parse->EventBot(EVENT_UNEQUIP_ITEM_BOT, my_bot, nullptr, export_string, inst->GetID(), &args);
+		}
 	}
 }
 

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -1432,7 +1432,11 @@ bool Client::AutoPutLootInInventory(EQ::ItemInstance& inst, bool try_worn, bool 
 					if (worn_slot_material != EQ::textures::materialInvalid) {
 						SendWearChange(worn_slot_material);
 					}
-					parse->EventItem(EVENT_EQUIP_ITEM, this, &inst, nullptr, "", i);
+
+					if (parse->ItemHasQuestSub(&inst, EVENT_EQUIP_ITEM)) {
+						parse->EventItem(EVENT_EQUIP_ITEM, this, &inst, nullptr, "", i);
+					}
+
 					return true;
 				}
 			}
@@ -2214,61 +2218,73 @@ bool Client::SwapItem(MoveItem_Struct* move_in) {
 
 		if (src_slot_id <= EQ::invslot::EQUIPMENT_END) {
 			if(src_inst) {
-				parse->EventItem(EVENT_UNEQUIP_ITEM, this, src_inst, nullptr, "", src_slot_id);
+				if (parse->ItemHasQuestSub(src_inst, EVENT_UNEQUIP_ITEM)) {
+					parse->EventItem(EVENT_UNEQUIP_ITEM, this, src_inst, nullptr, "", src_slot_id);
+				}
 
-				std::string export_string = fmt::format(
-					"{} {}",
-					src_inst->IsStackable() ? src_inst->GetCharges() : 1,
-					src_slot_id
-				);
+				if (parse->PlayerHasQuestSub(EVENT_UNEQUIP_ITEM_CLIENT)) {
+					const auto export_string = fmt::format(
+						"{} {}",
+						src_inst->IsStackable() ? src_inst->GetCharges() : 1,
+						src_slot_id
+					);
 
-				parse->EventPlayer(EVENT_UNEQUIP_ITEM_CLIENT, this, export_string, src_inst->GetItem()->ID);
+					parse->EventPlayer(EVENT_UNEQUIP_ITEM_CLIENT, this, export_string, src_inst->GetItem()->ID);
+				}
 			}
 
-			if(dst_inst) {
-				parse->EventItem(EVENT_EQUIP_ITEM, this, dst_inst, nullptr, "", src_slot_id);
+			if (dst_inst) {
+				if (parse->ItemHasQuestSub(dst_inst, EVENT_EQUIP_ITEM)) {
+					parse->EventItem(EVENT_EQUIP_ITEM, this, dst_inst, nullptr, "", src_slot_id);
+				}
 
-				std::string export_string = fmt::format(
-					"{} {}",
-					dst_inst->IsStackable() ? dst_inst->GetCharges() : 1,
-					src_slot_id
-				);
+				if (parse->PlayerHasQuestSub(EVENT_EQUIP_ITEM_CLIENT)) {
+					const auto export_string = fmt::format(
+						"{} {}",
+						dst_inst->IsStackable() ? dst_inst->GetCharges() : 1,
+						src_slot_id
+					);
 
-				parse->EventPlayer(EVENT_EQUIP_ITEM_CLIENT, this, export_string, dst_inst->GetItem()->ID);
+					parse->EventPlayer(EVENT_EQUIP_ITEM_CLIENT, this, export_string, dst_inst->GetItem()->ID);
+				}
 			}
 		}
 
 		if (dst_slot_id <= EQ::invslot::EQUIPMENT_END) {
-			if(dst_inst) {
-				parse->EventItem(EVENT_UNEQUIP_ITEM, this, dst_inst, nullptr, "", dst_slot_id);
+			if (dst_inst) {
+				if (parse->ItemHasQuestSub(dst_inst, EVENT_UNEQUIP_ITEM)) {
+					parse->EventItem(EVENT_UNEQUIP_ITEM, this, dst_inst, nullptr, "", dst_slot_id);
+				}
 
-				std::string export_string = fmt::format(
-					"{} {}",
-					dst_inst->IsStackable() ? dst_inst->GetCharges() : 1,
-					dst_slot_id
-				);
+				if (parse->PlayerHasQuestSub(EVENT_UNEQUIP_ITEM_CLIENT)) {
+					const auto export_string = fmt::format(
+						"{} {}",
+						dst_inst->IsStackable() ? dst_inst->GetCharges() : 1,
+						dst_slot_id
+					);
 
-				std::vector<std::any> args;
+					std::vector<std::any> args = { dst_inst };
 
-				args.emplace_back(dst_inst);
-
-				parse->EventPlayer(EVENT_UNEQUIP_ITEM_CLIENT, this, export_string, dst_inst->GetItem()->ID, &args);
+					parse->EventPlayer(EVENT_UNEQUIP_ITEM_CLIENT, this, export_string, dst_inst->GetItem()->ID, &args);
+				}
 			}
 
-			if(src_inst) {
-				parse->EventItem(EVENT_EQUIP_ITEM, this, src_inst, nullptr, "", dst_slot_id);
+			if (src_inst) {
+				if (parse->ItemHasQuestSub(src_inst, EVENT_EQUIP_ITEM)) {
+					parse->EventItem(EVENT_EQUIP_ITEM, this, src_inst, nullptr, "", dst_slot_id);
+				}
 
-				std::string export_string = fmt::format(
-					"{} {}",
-					src_inst->IsStackable() ? src_inst->GetCharges() : 1,
-					dst_slot_id
-				);
+				if (parse->PlayerHasQuestSub(EVENT_EQUIP_ITEM_CLIENT)) {
+					const auto export_string = fmt::format(
+						"{} {}",
+						src_inst->IsStackable() ? src_inst->GetCharges() : 1,
+						dst_slot_id
+					);
 
-				std::vector<std::any> args;
+					std::vector<std::any> args = { src_inst };
 
-				args.emplace_back(src_inst);
-
-				parse->EventPlayer(EVENT_EQUIP_ITEM_CLIENT, this, export_string, src_inst->GetItem()->ID, &args);
+					parse->EventPlayer(EVENT_EQUIP_ITEM_CLIENT, this, export_string, src_inst->GetItem()->ID, &args);
+				}
 			}
 		}
 	}

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -2223,7 +2223,7 @@ bool Client::SwapItem(MoveItem_Struct* move_in) {
 				}
 
 				if (parse->PlayerHasQuestSub(EVENT_UNEQUIP_ITEM_CLIENT)) {
-					const auto export_string = fmt::format(
+					const auto& export_string = fmt::format(
 						"{} {}",
 						src_inst->IsStackable() ? src_inst->GetCharges() : 1,
 						src_slot_id
@@ -2239,7 +2239,7 @@ bool Client::SwapItem(MoveItem_Struct* move_in) {
 				}
 
 				if (parse->PlayerHasQuestSub(EVENT_EQUIP_ITEM_CLIENT)) {
-					const auto export_string = fmt::format(
+					const auto& export_string = fmt::format(
 						"{} {}",
 						dst_inst->IsStackable() ? dst_inst->GetCharges() : 1,
 						src_slot_id
@@ -2257,7 +2257,7 @@ bool Client::SwapItem(MoveItem_Struct* move_in) {
 				}
 
 				if (parse->PlayerHasQuestSub(EVENT_UNEQUIP_ITEM_CLIENT)) {
-					const auto export_string = fmt::format(
+					const auto& export_string = fmt::format(
 						"{} {}",
 						dst_inst->IsStackable() ? dst_inst->GetCharges() : 1,
 						dst_slot_id
@@ -2275,7 +2275,7 @@ bool Client::SwapItem(MoveItem_Struct* move_in) {
 				}
 
 				if (parse->PlayerHasQuestSub(EVENT_EQUIP_ITEM_CLIENT)) {
-					const auto export_string = fmt::format(
+					const auto& export_string = fmt::format(
 						"{} {}",
 						src_inst->IsStackable() ? src_inst->GetCharges() : 1,
 						dst_slot_id


### PR DESCRIPTION
# Notes
- Optionally parse `EVENT_SCALE_CALC`, `EVENT_ITEM_ENTER_ZONE`, `EVENT_UNEQUIP_ITEM_BOT`, `EVENT_EQUIP_ITEM_BOT`, `EVENT_EQUIP_ITEM`, `EVENT_UNEQUIP_ITEM`, `EVENT_EQUIP_ITEM_CLIENT`, and `EVENT_UNEQUIP_ITEM_CLIENT`