### PR TITLE
[Quest API] (Performance) Check event EVENT_ENTER_ZONE or EVENT_ZONE exist before export and execute

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -777,7 +777,9 @@ void Client::CompleteConnect()
 	TotalKarma = database.GetKarma(AccountID());
 	SendDisciplineTimers();
 
-	parse->EventPlayer(EVENT_ENTER_ZONE, this, "", 0);
+	if (parse->PlayerHasQuestSub(EVENT_ENTER_ZONE)) {
+		parse->EventPlayer(EVENT_ENTER_ZONE, this, "", 0);
+	}
 
 	// the way that the client deals with positions during the initial spawn struct
 	// is subtly different from how it deals with getting a position update

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -201,19 +201,21 @@ void Client::Handle_OP_ZoneChange(const EQApplicationPacket *app) {
 	min_status   = zone_data->min_status;
 	min_level    = zone_data->min_level;
 
-	const auto& export_string = fmt::format(
-		"{} {} {} {} {} {}",
-		zone->GetZoneID(),
-		zone->GetInstanceID(),
-		zone->GetInstanceVersion(),
-		target_zone_id,
-		target_instance_id,
-		target_instance_version
-	);
+	if (parse->PlayerHasQuestSub(EVENT_ZONE)) {
+		const auto& export_string = fmt::format(
+			"{} {} {} {} {} {}",
+			zone->GetZoneID(),
+			zone->GetInstanceID(),
+			zone->GetInstanceVersion(),
+			target_zone_id,
+			target_instance_id,
+			target_instance_version
+		);
 
-	if (parse->EventPlayer(EVENT_ZONE, this, export_string, 0) != 0) {
-		SendZoneCancel(zc);
-		return;
+		if (parse->EventPlayer(EVENT_ZONE, this, export_string, 0) != 0) {
+			SendZoneCancel(zc);
+			return;
+		}
 	}
 
 	//handle circumvention of zone restrictions


### PR DESCRIPTION
# Notes
- Optionally parse these events instead of always doing so.