### PR TITLE
[Quest API] (Performance) Check event EVENT_PAYLOAD or EVENT_SIGNAL exist before export and execute

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -9176,14 +9176,18 @@ void Bot::SpawnBotGroupByName(Client* c, std::string botgroup_name, uint32 leade
 
 void Bot::Signal(int signal_id)
 {
-	const auto export_string = fmt::format("{}", signal_id);
-	parse->EventBot(EVENT_SIGNAL, this, nullptr, export_string, 0);
+	if (parse->BotHasQuestSub(EVENT_SIGNAL)) {
+		parse->EventBot(EVENT_SIGNAL, this, nullptr, std::to_string(signal_id), 0);
+	}
 }
 
 void Bot::SendPayload(int payload_id, std::string payload_value)
 {
-	const auto export_string = fmt::format("{} {}", payload_id, payload_value);
-	parse->EventBot(EVENT_PAYLOAD, this, nullptr, export_string, 0);
+	if (parse->BotHasQuestSub(EVENT_PAYLOAD)) {
+		const auto &export_string = fmt::format("{} {}", payload_id, payload_value);
+
+		parse->EventBot(EVENT_PAYLOAD, this, nullptr, export_string, 0);
+	}
 }
 
 void Bot::OwnerMessage(std::string message)

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -9184,7 +9184,7 @@ void Bot::Signal(int signal_id)
 void Bot::SendPayload(int payload_id, std::string payload_value)
 {
 	if (parse->BotHasQuestSub(EVENT_PAYLOAD)) {
-		const auto &export_string = fmt::format("{} {}", payload_id, payload_value);
+		const auto& export_string = fmt::format("{} {}", payload_id, payload_value);
 
 		parse->EventBot(EVENT_PAYLOAD, this, nullptr, export_string, 0);
 	}

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -5169,14 +5169,18 @@ void Client::ShowSkillsWindow()
 
 void Client::Signal(int signal_id)
 {
-	const auto export_string = fmt::format("{}", signal_id);
-	parse->EventPlayer(EVENT_SIGNAL, this, export_string, 0);
+	if (parse->PlayerHasQuestSub(EVENT_SIGNAL)) {
+		parse->EventPlayer(EVENT_SIGNAL, this, std::to_string(signal_id), 0);
+	}
 }
 
 void Client::SendPayload(int payload_id, std::string payload_value)
 {
-	const auto export_string = fmt::format("{} {}", payload_id, payload_value);
-	parse->EventPlayer(EVENT_PAYLOAD, this, export_string, 0);
+	if (parse->PlayerHasQuestSub(EVENT_PAYLOAD)) {
+		const auto& export_string = fmt::format("{} {}", payload_id, payload_value);
+
+		parse->EventPlayer(EVENT_PAYLOAD, this, export_string, 0);
+	}
 }
 
 void Client::SendRewards()

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -2469,8 +2469,10 @@ void NPC::CheckSignal() {
 	if (!signal_q.empty()) {
 		int signal_id = signal_q.front();
 		signal_q.pop_front();
-		const auto export_string = fmt::format("{}", signal_id);
-		parse->EventNPC(EVENT_SIGNAL, this, nullptr, export_string, 0);
+
+		if (parse->HasQuestSub(GetNPCTypeID(), EVENT_SIGNAL)) {
+			parse->EventNPC(EVENT_SIGNAL, this, nullptr, std::to_string(signal_id), 0);
+		}
 	}
 }
 

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -3056,8 +3056,11 @@ void NPC::SignalNPC(int _signal_id)
 
 void NPC::SendPayload(int payload_id, std::string payload_value)
 {
-	const auto export_string = fmt::format("{} {}", payload_id, payload_value);
-	parse->EventNPC(EVENT_PAYLOAD, this, nullptr, export_string, 0);
+	if (parse->HasQuestSub(GetNPCTypeID(), EVENT_PAYLOAD)) {
+		const auto& export_string = fmt::format("{} {}", payload_id, payload_value);
+
+		parse->EventNPC(EVENT_PAYLOAD, this, nullptr, export_string, 0);
+	}
 }
 
 NPC_Emote_Struct* NPC::GetNPCEmote(uint32 emoteid, uint8 event_) {


### PR DESCRIPTION
# Notes
- Optionally parse these events instead of always doing so.