### PR TITLE
[Quest API] (Performance) Check event EVENT_WAYPOINT_ARRIVE or EVENT_WAYPOINT_DEPART exist before export and execute

### DIFF
--- a/zone/cheat_manager.cpp
+++ b/zone/cheat_manager.cpp
@@ -43,17 +43,13 @@ void CheatManager::CheatDetected(CheatTypes type, glm::vec3 position1, glm::vec3
 					zone->GetShortName()
 				);
 				LogCheat(fmt::runtime(message));
-
-				if (parse->PlayerHasQuestSub(EVENT_WARP)) {
-					const auto& export_string = fmt::format(
-						"{} {} {}",
-						position1.x,
-						position1.y,
-						position1.z
-					);
-
-					parse->EventPlayer(EVENT_WARP, m_target, export_string, 0);
-				}
+				std::string export_string = fmt::format(
+					"{} {} {}",
+					position1.x,
+					position1.y,
+					position1.z
+				);
+				parse->EventPlayer(EVENT_WARP, m_target, export_string, 0);
 			}
 			break;
 		case MQWarpAbsolute:
@@ -76,19 +72,14 @@ void CheatManager::CheatDetected(CheatTypes type, glm::vec3 position1, glm::vec3
 					zone->GetShortName()
 				);
 				LogCheat(fmt::runtime(message));
-
-				if (parse->PlayerHasQuestSub(EVENT_WARP)) {
-					const auto& export_string = fmt::format(
-						"{} {} {}",
-						position1.x,
-						position1.y,
-						position1.z
-					);
-
-					parse->EventPlayer(EVENT_WARP, m_target, export_string, 0);;
-				}
-
-				m_time_since_last_warp_detection.Start(2500)
+				std::string export_string = fmt::format(
+					"{} {} {}",
+					position1.x,
+					position1.y,
+					position1.z
+				);
+				parse->EventPlayer(EVENT_WARP, m_target, export_string, 0);
+				m_time_since_last_warp_detection.Start(2500);
 			}
 			break;
 		case MQWarpShadowStep:

--- a/zone/cheat_manager.cpp
+++ b/zone/cheat_manager.cpp
@@ -43,13 +43,17 @@ void CheatManager::CheatDetected(CheatTypes type, glm::vec3 position1, glm::vec3
 					zone->GetShortName()
 				);
 				LogCheat(fmt::runtime(message));
-				std::string export_string = fmt::format(
-					"{} {} {}",
-					position1.x,
-					position1.y,
-					position1.z
-				);
-				parse->EventPlayer(EVENT_WARP, m_target, export_string, 0);
+
+				if (parse->PlayerHasQuestSub(EVENT_WARP)) {
+					const auto& export_string = fmt::format(
+						"{} {} {}",
+						position1.x,
+						position1.y,
+						position1.z
+					);
+
+					parse->EventPlayer(EVENT_WARP, m_target, export_string, 0);
+				}
 			}
 			break;
 		case MQWarpAbsolute:
@@ -72,14 +76,19 @@ void CheatManager::CheatDetected(CheatTypes type, glm::vec3 position1, glm::vec3
 					zone->GetShortName()
 				);
 				LogCheat(fmt::runtime(message));
-				std::string export_string = fmt::format(
-					"{} {} {}",
-					position1.x,
-					position1.y,
-					position1.z
-				);
-				parse->EventPlayer(EVENT_WARP, m_target, export_string, 0);
-				m_time_since_last_warp_detection.Start(2500);
+
+				if (parse->PlayerHasQuestSub(EVENT_WARP)) {
+					const auto& export_string = fmt::format(
+						"{} {} {}",
+						position1.x,
+						position1.y,
+						position1.z
+					);
+
+					parse->EventPlayer(EVENT_WARP, m_target, export_string, 0);;
+				}
+
+				m_time_since_last_warp_detection.Start(2500)
 			}
 			break;
 		case MQWarpShadowStep:

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -1753,9 +1753,10 @@ void NPC::AI_DoMovement() {
 						RotateTo(m_CurrentWayPoint.w);
 					}
 
-					//kick off event_waypoint arrive
-					std::string export_string = fmt::format("{}", cur_wp);
-					parse->EventNPC(EVENT_WAYPOINT_ARRIVE, CastToNPC(), nullptr, export_string, 0);
+					if (parse->HasQuestSub(GetNPCTypeID(), EVENT_WAYPOINT_ARRIVE)) {
+						parse->EventNPC(EVENT_WAYPOINT_ARRIVE, CastToNPC(), nullptr, std::to_string(cur_wp), 0);
+					}
+
 					// No need to move as we are there.  Next loop will
 					// take care of normal grids, even at pause 0.
 					// We do need to call and setup a wp if we're cur_wp=-2
@@ -1871,9 +1872,9 @@ void NPC::AI_SetupNextWaypoint() {
 		entity_list.OpenDoorsNear(this);
 
 		if (!DistractedFromGrid) {
-			//kick off event_waypoint depart
-			std::string export_string = fmt::format("{}", cur_wp);
-			parse->EventNPC(EVENT_WAYPOINT_DEPART, CastToNPC(), nullptr, export_string, 0);
+			if (parse->HasQuestSub(GetNPCTypeID(), EVENT_WAYPOINT_DEPART)) {
+				parse->EventNPC(EVENT_WAYPOINT_DEPART, CastToNPC(), nullptr, std::to_string(cur_wp), 0);
+			}
 
 			//setup our next waypoint, if we are still on our normal grid
 			//remember that the quest event above could have done anything it wanted with our grid

--- a/zone/waypoints.cpp
+++ b/zone/waypoints.cpp
@@ -165,10 +165,12 @@ void NPC::ResumeWandering()
 
 		if (m_CurrentWayPoint.x == GetX() && m_CurrentWayPoint.y == GetY())
 		{	// are we we at a waypoint? if so, trigger event and start to next
-			std::string export_string = fmt::format("{}", cur_wp);
 			CalculateNewWaypoint();
 			SetAppearance(eaStanding, false);
-			parse->EventNPC(EVENT_WAYPOINT_DEPART, this, nullptr, export_string, 0);
+
+			if (parse->HasQuestSub(GetNPCTypeID(), EVENT_WAYPOINT_DEPART)) {
+				parse->EventNPC(EVENT_WAYPOINT_DEPART, this, nullptr, std::to_string(cur_wp), 0);
+			}
 		}	// if not currently at a waypoint, we continue on to the one we were headed to before the stop
 	}
 	else


### PR DESCRIPTION
# Notes
- Optionally parse these events instead of always doing so.