### PR TITLE
[Quest API] (Performance) Check event EVENT_TRADE exists before export and execute

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -5166,8 +5166,11 @@ void Bot::PerformTradeWithClient(int16 begin_slot_id, int16 end_slot_id, Client*
 			std::vector<EQ::ItemInstance*> items(insts, insts + std::size(insts));
 
 			// Check if EVENT_TRADE accepts any items
-			std::vector<std::any> item_list(items.begin(), items.end());
-			parse->EventBot(EVENT_TRADE, this, client, "", 0, &item_list);
+			if (parse->BotHasQuestSub(EVENT_TRADE)) {
+				std::vector<std::any> item_list(items.begin(), items.end());
+				parse->EventBot(EVENT_TRADE, this, client, "", 0, &item_list);
+			}
+
 			CalcBotStats(false);
 
 		} else {
@@ -5182,8 +5185,11 @@ void Bot::PerformTradeWithClient(int16 begin_slot_id, int16 end_slot_id, Client*
 			std::vector<EQ::ItemInstance*> items(insts, insts + std::size(insts));
 
 			// Check if EVENT_TRADE accepts any items
-			std::vector<std::any> item_list(items.begin(), items.end());
-			parse->EventBot(EVENT_TRADE, this, client, "", 0, &item_list);
+			if (parse->BotHasQuestSub(EVENT_TRADE)) {
+				std::vector<std::any> item_list(items.begin(), items.end());
+				parse->EventBot(EVENT_TRADE, this, client, "", 0, &item_list);
+			}
+
 			CalcBotStats(false);
 		}
 	}

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -990,8 +990,10 @@ void Client::FinishTrade(Mob* tradingWith, bool finalizer, void* event_entry, st
 			tradingWith->FaceTarget(this);
 		}
 
-		std::vector<std::any> item_list(items.begin(), items.end());
-		parse->EventNPC(EVENT_TRADE, tradingWith->CastToNPC(), this, "", 0, &item_list);
+		if (parse->HasQuestSub(tradingWith->GetNPCTypeID(), EVENT_TRADE)) {
+			std::vector<std::any> item_list(items.begin(), items.end());
+			parse->EventNPC(EVENT_TRADE, tradingWith->CastToNPC(), this, "", 0, &item_list);
+		}
 
 		for(int i = 0; i < 4; ++i) {
 			if(insts[i]) {


### PR DESCRIPTION
# Notes
- Optionally parse this event instead of always doing so.