### PR TITLE
[Quest API] (Performance) Check event EVENT_WARP exists before export and execute

### DIFF
--- a/zone/cheat_manager.cpp
+++ b/zone/cheat_manager.cpp
@@ -43,13 +43,17 @@ void CheatManager::CheatDetected(CheatTypes type, glm::vec3 position1, glm::vec3
 					zone->GetShortName()
 				);
 				LogCheat(fmt::runtime(message));
-				std::string export_string = fmt::format(
-					"{} {} {}",
-					position1.x,
-					position1.y,
-					position1.z
-				);
-				parse->EventPlayer(EVENT_WARP, m_target, export_string, 0);
+
+				if (parse->PlayerHasQuestSub(EVENT_WARP)) {
+					const auto& export_string = fmt::format(
+						"{} {} {}",
+						position1.x,
+						position1.y,
+						position1.z
+					);
+
+					parse->EventPlayer(EVENT_WARP, m_target, export_string, 0);
+				}
 			}
 			break;
 		case MQWarpAbsolute:
@@ -72,14 +76,19 @@ void CheatManager::CheatDetected(CheatTypes type, glm::vec3 position1, glm::vec3
 					zone->GetShortName()
 				);
 				LogCheat(fmt::runtime(message));
-				std::string export_string = fmt::format(
-					"{} {} {}",
-					position1.x,
-					position1.y,
-					position1.z
-				);
-				parse->EventPlayer(EVENT_WARP, m_target, export_string, 0);
-				m_time_since_last_warp_detection.Start(2500);
+
+				if (parse->PlayerHasQuestSub(EVENT_WARP)) {
+					const auto& export_string = fmt::format(
+						"{} {} {}",
+						position1.x,
+						position1.y,
+						position1.z
+					);
+
+					parse->EventPlayer(EVENT_WARP, m_target, export_string, 0);;
+				}
+
+				m_time_since_last_warp_detection.Start(2500)
 			}
 			break;
 		case MQWarpShadowStep:


### PR DESCRIPTION
# Notes
- Parse this event optionally instead of always doing so.