### PR TITLE
[Quest API] (Performance) Check event EVENT_RESPAWN exists before export and execute

### DIFF
--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -2147,8 +2147,9 @@ void Client::HandleRespawnFromHover(uint32 Option)
 		}
 
 		//After they've respawned into the same zone, trigger EVENT_RESPAWN
-		std::string export_string = fmt::format("{}", Option);
-		parse->EventPlayer(EVENT_RESPAWN, this, export_string, is_rez ? 1 : 0);
+		if (parse->PlayerHasQuestSub(EVENT_RESPAWN)) {
+			parse->EventPlayer(EVENT_RESPAWN, this, std::to_string(Option), is_rez ? 1 : 0);
+		}
 
 		//Pop Rez option from the respawn options list;
 		//easiest way to make sure it stays at the end and


### PR DESCRIPTION
# Notes
- Optionally parse this event instead of always doing so.