### PR TITLE
[Quest API] (Performance) Check event EVENT_TICK exists before export and execute 

### DIFF
--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -898,7 +898,10 @@ bool NPC::Process()
 	}
 
 	if (tic_timer.Check()) {
-		parse->EventNPC(EVENT_TICK, this, nullptr, "", 0);
+		if (parse->HasQuestSub(GetNPCTypeID(), EVENT_TICK)) {
+			parse->EventNPC(EVENT_TICK, this, nullptr, "", 0);
+		}
+
 		BuffProcess();
 
 		if (currently_fleeing) {


### PR DESCRIPTION
# Notes
- Optionally parse this event instead of always doing so.