### PR TITLE
[Quest API] (Performance) Check event EVENT_TEST_BUFF exists before export and execute 

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -14318,8 +14318,10 @@ void Client::Handle_OP_TestBuff(const EQApplicationPacket *app)
 	if (!RuleB(Character, EnableTestBuff)) {
 		return;
 	}
-	parse->EventPlayer(EVENT_TEST_BUFF, this, "", 0);
-	return;
+
+	if (parse->PlayerHasQuestSub(EVENT_TEST_BUFF)) {
+		parse->EventPlayer(EVENT_TEST_BUFF, this, "", 0);
+	}
 }
 
 void Client::Handle_OP_TGB(const EQApplicationPacket *app)


### PR DESCRIPTION
# Notes
- Optionally parse this event instead of always doing so.