### PR TITLE
[Bug Fix] Fix for interrupting item casts to no longer lock the client if cast time of item greater than 0

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4200,6 +4200,7 @@ void Client::Handle_OP_CastSpell(const EQApplicationPacket *app)
 							}
 							else {
 								InterruptSpell(castspell->spell_id);
+								SendSpellBarEnable(castspell->spell_id);
 								return;
 							}
 						}
@@ -4238,6 +4239,7 @@ void Client::Handle_OP_CastSpell(const EQApplicationPacket *app)
 						}
 						else {
 							InterruptSpell(castspell->spell_id);
+							SendSpellBarEnable(castspell->spell_id);
 							return;
 						}
 					}
@@ -9045,6 +9047,10 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 						else {
 							CastSpell(item->Click.Effect, target_id, CastingSlot::Item, item->CastTime, 0, 0, slot_id);
 						}
+					} else {
+						InterruptSpell(item->Click.Effect);
+						SendSpellBarEnable(item->Click.Effect);
+						return;
 					}
 				}
 				else
@@ -9113,6 +9119,10 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 						else {
 							CastSpell(augitem->Click.Effect, target_id, CastingSlot::Item, augitem->CastTime, 0, 0, slot_id);
 						}
+					} else {
+						InterruptSpell(item->Click.Effect);
+						SendSpellBarEnable(item->Click.Effect);
+						return;
 					}
 				}
 				else


### PR DESCRIPTION
Anytime we interrupt the client we need to "SendSpellBarEnable" to make sure it doesn't lock the client up. This allows you to stop item spell casts with scripts.