### PR TITLE
[Windows] Fix MSVC compilation bug via workaround

### DIFF
--- a/common/json/json_archive_single_line.h
+++ b/common/json/json_archive_single_line.h
@@ -111,7 +111,7 @@ namespace cereal
 				@param indentChar The type of character to indent with
 				@param indentLength The number of indentChar to use for indentation
 							   (0 corresponds to no indentation) */
-			explicit Options( int precision = JSONWriterSL::Writer::kDefaultMaxDecimalPlaces,
+			explicit Options( int precision = 324,
 							  IndentChar indentChar = IndentChar::space,
 							  unsigned int indentLength = 4,
 							  bool singleLine = false) :


### PR DESCRIPTION
### What

Fixes a MSVC compilation bug via workaround. There are other references in the class that follow the alias properly but it doesn't in the constructor. Not worth trying to fix and statically inserted the value. This is a class I inserted for JSON minification for player events

```
16>------ Skipped Build: Project: INSTALL, Configuration: Debug x64 ------
16>Project not selected to build for this solution configuration 
========== Build: 11 succeeded, 0 failed, 13 up-to-date, 5 skipped ==========
```