### PR TITLE
[Hotfix] Fix EVENT_SPELL_EFFECT_TRANSLOCATE_COMPLETE regression caused by  #2897

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -15239,7 +15239,6 @@ void Client::Handle_OP_Translocate(const EQApplicationPacket *app)
 		);
 
 		int quest_return = 0;
-
 		if (parse->SpellHasQuestSub(spell_id, EVENT_SPELL_EFFECT_TRANSLOCATE_COMPLETE)) {
 			quest_return = parse->EventSpell(EVENT_SPELL_EFFECT_TRANSLOCATE_COMPLETE, nullptr, this, spell_id, "", 0);
 		}

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -15238,34 +15238,38 @@ void Client::Handle_OP_Translocate(const EQApplicationPacket *app)
 			zone->GetInstanceID() == PendingTranslocateData.instance_id
 		);
 
-		if (parse->SpellHasQuestSub(spell_id, EVENT_SPELL_EFFECT_TRANSLOCATE_COMPLETE)) {
-			if (parse->EventSpell(EVENT_SPELL_EFFECT_TRANSLOCATE_COMPLETE, nullptr, this, spell_id, "", 0) == 0) {
-				// If the spell has a translocate to bind effect, AND we are already in the zone the client
-				// is bound in, use the GoToBind method. If we send OP_Translocate in this case, the client moves itself
-				// to the bind coords it has from the PlayerProfile, but with the X and Y reversed. I suspect they are
-				// reversed in the pp, and since spells like Gate are handled serverside, this has not mattered before.
-				if (
-					IsTranslocateSpell(spell_id) &&
-					in_translocate_zone
-				) {
-					PendingTranslocate = false;
-					GoToBind();
-					return;
-				}
+		int quest_return = 0;
 
-				////Was sending the packet back to initiate client zone...
-				////but that could be abusable, so lets go through proper channels
-				MovePC(
-					PendingTranslocateData.zone_id,
-					PendingTranslocateData.instance_id,
-					PendingTranslocateData.x,
-					PendingTranslocateData.y,
-					PendingTranslocateData.z,
-					PendingTranslocateData.heading,
-					0,
-					ZoneSolicited
-				);
+		if (parse->SpellHasQuestSub(spell_id, EVENT_SPELL_EFFECT_TRANSLOCATE_COMPLETE)) {
+			quest_return = parse->EventSpell(EVENT_SPELL_EFFECT_TRANSLOCATE_COMPLETE, nullptr, this, spell_id, "", 0);
+		}
+
+		if (quest_return == 0) {
+			// If the spell has a translocate to bind effect, AND we are already in the zone the client
+			// is bound in, use the GoToBind method. If we send OP_Translocate in this case, the client moves itself
+			// to the bind coords it has from the PlayerProfile, but with the X and Y reversed. I suspect they are
+			// reversed in the pp, and since spells like Gate are handled serverside, this has not mattered before.
+			if (
+				IsTranslocateSpell(spell_id) &&
+				in_translocate_zone
+				) {
+				PendingTranslocate = false;
+				GoToBind();
+				return;
 			}
+
+			////Was sending the packet back to initiate client zone...
+			////but that could be abusable, so lets go through proper channels
+			MovePC(
+				PendingTranslocateData.zone_id,
+				PendingTranslocateData.instance_id,
+				PendingTranslocateData.x,
+				PendingTranslocateData.y,
+				PendingTranslocateData.z,
+				PendingTranslocateData.heading,
+				0,
+				ZoneSolicited
+			);
 		}
 	}
 


### PR DESCRIPTION
### What

Fixes a regression where logic that was expected to happen when no quest was available is no longer able to execute. Moved the zero-state logic out of band from behind the `SpellHasQuestSub` gating

Regression caused by #2897