### PR TITLE
[Fix] Fix issue where Lore groundspawn pickups will desync ROF2+

### DIFF
--- a/zone/object.cpp
+++ b/zone/object.cpp
@@ -493,21 +493,27 @@ void Object::RandomSpawn(bool send_packet) {
 
 bool Object::HandleClick(Client* sender, const ClickObject_Struct* click_object)
 {
-	if(m_ground_spawn){//This is a Cool Groundspawn
+	if(m_ground_spawn) {//This is a Cool Groundspawn
 		respawn_timer.Start();
 	}
 	if (m_type == OT_DROPPEDITEM) {
 		bool cursordelete = false;
+		bool duplicate_lore = false;
 		if (m_inst && sender) {
 			// if there is a lore conflict, delete the offending item from the server inventory
 			// the client updates itself and takes care of sending "duplicate lore item" messages
 			auto item = m_inst->GetItem();
-			if(sender->CheckLoreConflict(item)) {
+			if (sender->CheckLoreConflict(item)) {
+				duplicate_lore = true;
 				int16 loreslot = sender->GetInv().HasItem(item->ID, 0, invWhereBank);
-				if (loreslot != INVALID_INDEX) // if the duplicate is in the bank, delete it.
+				if (loreslot != INVALID_INDEX) { // if the duplicate is in the bank, delete it.
 					sender->DeleteItemInInventory(loreslot);
-				else
-					cursordelete = true;	// otherwise, we delete the new one
+					LogInfo("Deleting in loreslot [{}]", loreslot);
+				}
+				else {
+					cursordelete = true;
+					LogInfo("Cursor delete groundspawn");
+				}    // otherwise, we delete the new one
 			}
 
 			if (item->RecastDelay) {
@@ -560,8 +566,9 @@ bool Object::HandleClick(Client* sender, const ClickObject_Struct* click_object)
 				sender->DiscoverItem(item->ID);
 			}
 
-			if(cursordelete)	// delete the item if it's a duplicate lore. We have to do this because the client expects the item packet
-				sender->DeleteItemInInventory(EQ::invslot::slotCursor);
+			if (cursordelete) {    // delete the item if it's a duplicate lore. We have to do this because the client expects the item packet
+				sender->DeleteItemInInventory(EQ::invslot::slotCursor, 1, true);
+			}
 
 			sender->DropItemQS(m_inst, true);
 
@@ -581,8 +588,18 @@ bool Object::HandleClick(Client* sender, const ClickObject_Struct* click_object)
 
 		// Remove object
 		content_db.DeleteObject(m_id);
-		if(!m_ground_spawn)
+		if (!m_ground_spawn) {
 			entity_list.RemoveEntity(GetID());
+		}
+
+		// we have to delete the entity on click or the client desyncs
+		// this is a way to immediately respawn the groundspawn after killing it and
+		// deleting the item from the player
+		// I believe older clients somehow sent this automatically but we are no longer with ROF2+
+		if (duplicate_lore) {
+			sender->Message(Chat::Yellow, "Duplicate lore item detected");
+			respawn_timer.Trigger();
+		}
 	} else {
 		// Tradeskill item
 		auto outapp = new EQApplicationPacket(OP_ClickObjectAction, sizeof(ClickObjectAction_Struct));

--- a/zone/object.cpp
+++ b/zone/object.cpp
@@ -508,11 +508,9 @@ bool Object::HandleClick(Client* sender, const ClickObject_Struct* click_object)
 				int16 loreslot = sender->GetInv().HasItem(item->ID, 0, invWhereBank);
 				if (loreslot != INVALID_INDEX) { // if the duplicate is in the bank, delete it.
 					sender->DeleteItemInInventory(loreslot);
-					LogInfo("Deleting in loreslot [{}]", loreslot);
 				}
 				else {
 					cursordelete = true;
-					LogInfo("Cursor delete groundspawn");
 				}    // otherwise, we delete the new one
 			}
 


### PR DESCRIPTION
### What

Was investigating an issue around groundspawns and found that ROF2+ lore groundspawn pickups desync the client entirely.

This change properly sends the cursor deletion packet to the client, sends the groundspawn despawn to other clients to prevent expected state (desync) and then immediately respawns the groundspawn

![image](https://user-images.githubusercontent.com/3319450/218702711-5d49539d-e8f8-45ed-a5e6-c823d9c37441.png)
