### PR TITLE
[Groundspawns] Fix issue where groundspawns appear floating high off the ground

### DIFF
--- a/zone/object.cpp
+++ b/zone/object.cpp
@@ -71,6 +71,8 @@ Object::Object(uint32 id, uint32 type, uint32 icon, const Object_Struct& object,
 	m_data.size = object.size;
 	m_data.tilt_x = object.tilt_x;
 	m_data.tilt_y = object.tilt_y;
+
+	FixZ();
 }
 
 //creating a re-ocurring ground spawn.
@@ -99,6 +101,8 @@ Object::Object(const EQ::ItemInstance* inst, char* name,float max_x,float min_x,
 	respawn_timer.Disable();
 	strcpy(m_data.object_name, name);
 	RandomSpawn(false);
+
+	FixZ();
 
 	// Hardcoded portion for unknown members
 	m_data.unknown024	= 0x7f001194;
@@ -167,6 +171,8 @@ Object::Object(Client* client, const EQ::ItemInstance* inst)
 			strcpy(m_data.object_name, DEFAULT_OBJECT_NAME);
 		}
 	}
+
+	FixZ();
 }
 
 Object::Object(const EQ::ItemInstance *inst, float x, float y, float z, float heading, uint32 decay_time)
@@ -223,6 +229,8 @@ Object::Object(const EQ::ItemInstance *inst, float x, float y, float z, float he
 			strcpy(m_data.object_name, DEFAULT_OBJECT_NAME);
 		}
 	}
+
+	FixZ();
 }
 
 Object::Object(const char *model, float x, float y, float z, float heading, uint8 type, uint32 decay_time)
@@ -246,6 +254,8 @@ Object::Object(const char *model, float x, float y, float z, float heading, uint
 	m_data.y = y;
 	m_data.z = z;
 	m_data.zone_id = zone->GetZoneID();
+
+	FixZ();
 
 	if (decay_time)
 		decay_timer.Start();
@@ -1156,4 +1166,16 @@ void Object::SetEntityVariable(std::string variable_name, std::string variable_v
 	}
 
 	o_EntityVariables[variable_name] = variable_value;
+}
+
+void Object::FixZ()
+{
+	float best_z = BEST_Z_INVALID;
+	if (zone->zonemap != nullptr) {
+		auto dest = glm::vec3(m_data.x, m_data.y, m_data.z + 5);
+		best_z = zone->zonemap->FindBestZ(dest, nullptr);
+		if (best_z != BEST_Z_INVALID) {
+			m_data.z = best_z;
+		}
+	}
 }

--- a/zone/object.h
+++ b/zone/object.h
@@ -204,6 +204,7 @@ protected:
 
 	Timer respawn_timer;
 	Timer decay_timer;
+	void FixZ();
 };
 
 #endif


### PR DESCRIPTION
### What

Correct Z on spawn for groundspawns to keep them from floating high off the ground.

Titanium would correct this automatically client side, RoF2+ does not. We did this for tradeskills and it worked well

**Before**

![image](https://user-images.githubusercontent.com/3319450/218710648-e0690d3d-ba88-4b57-a11b-adf9798b5815.png)

**After**

![image](https://user-images.githubusercontent.com/3319450/218710308-999f855e-1940-4a51-8cfd-510041f26538.png)
