### PR TITLE
[Bug Fix] Self Only Spells now work again (BuffSpellRestrictions)

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3195,6 +3195,11 @@ bool Mob::CheckSpellLevelRestriction(Mob *caster, uint16 spell_id)
 	bool check_for_restrictions = false;
 	bool can_cast = true;
 
+	if (spells[spell_id].target_type == ST_Self) {
+		LogSpells("[CheckSpellLevelRestriction] Self Only spell - no restrictions");
+		return true;
+	}
+
 	if (!caster) {
 		LogSpells("[CheckSpellLevelRestriction] No caster");
 		return false;

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3192,9 +3192,6 @@ int Mob::CheckStackConflict(uint16 spellid1, int caster_level1, uint16 spellid2,
 // 66+ Group Spells 62, Single Target 61
 bool Mob::CheckSpellLevelRestriction(Mob *caster, uint16 spell_id)
 {
-	bool check_for_restrictions = false;
-	bool can_cast = true;
-
 	if (spells[spell_id].target_type == ST_Self) {
 		LogSpells("[CheckSpellLevelRestriction] Self Only spell - no restrictions");
 		return true;
@@ -3209,6 +3206,9 @@ bool Mob::CheckSpellLevelRestriction(Mob *caster, uint16 spell_id)
 		LogSpells("[CheckSpellLevelRestriction] GM casting - No restrictions");
 		return true;
 	}
+
+	bool check_for_restrictions = false;
+	bool can_cast = true;
 
 	// NON GM clients might be restricted by rule setting
 	if (caster->IsClient()) {


### PR DESCRIPTION
My changes in PR: https://github.com/EQEmu/Server/pull/2708 broke self only spell (if someone else is targetted),

This PR assures that self only spells always work.

Should resolve issue: https://github.com/EQEmu/Server/issues/2923

@Natedog2012 