### PR TITLE
[Tradeskills] Check if Combine would result in Lore Conflict.

### DIFF
--- a/zone/string_ids.h
+++ b/zone/string_ids.h
@@ -383,9 +383,9 @@
 #define FORAGE_MASTERY				6012	//Your forage mastery has enabled you to find something else!
 #define GUILD_BANK_CANNOT_DEPOSIT	6097	// Cannot deposit this item. Containers must be empty, and only one of each LORE and no NO TRADE or TEMPORARY items may be deposited.
 #define GUILD_BANK_FULL				6098	// There is no more room in the Guild Bank.
-#define GUILD_BANK_TRANSFERRED		6100	// '%1' transferred to Guild Bank from Deposits.
-#define GUILD_BANK_EMPTY_HANDS		6108	// You must empty your hands to withdraw from the Guild Bank.
-#define TRADESKILL_COMBINE_LORE		6199	// Combine would result in a LORE item (%1) you already possess.
+#define GUILD_BANK_TRANSFERRED  	6100	// '%1' transferred to Guild Bank from Deposits.
+#define GUILD_BANK_EMPTY_HANDS  	6108	// You must empty your hands to withdraw from the Guild Bank.
+#define TRADESKILL_COMBINE_LORE 	6199	// Combine would result in a LORE item (%1) you already possess.
 #define TRANSFORM_FAILED			6326	//This mold cannot be applied to your %1.
 #define TRANSFORM_COMPLETE			6327	//You have successfully transformed your %1.
 #define DETRANSFORM_FAILED			6341 	//%1 has no transformation that can be removed.

--- a/zone/string_ids.h
+++ b/zone/string_ids.h
@@ -385,6 +385,7 @@
 #define GUILD_BANK_FULL				6098	// There is no more room in the Guild Bank.
 #define GUILD_BANK_TRANSFERRED		6100	// '%1' transferred to Guild Bank from Deposits.
 #define GUILD_BANK_EMPTY_HANDS		6108	// You must empty your hands to withdraw from the Guild Bank.
+#define TRADESKILL_COMBINE_LORE		6199	// Combine would result in a LORE item (%1) you already possess.
 #define TRANSFORM_FAILED			6326	//This mold cannot be applied to your %1.
 #define TRANSFORM_COMPLETE			6327	//You have successfully transformed your %1.
 #define DETRANSFORM_FAILED			6341 	//%1 has no transformation that can be removed.

--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -253,6 +253,9 @@ void Object::HandleCombine(Client* user, const NewCombine_Struct* in_combine, Ob
 {
 	if (!user || !in_combine) {
 		LogError("Client or NewCombine_Struct not set in Object::HandleCombine");
+		auto outapp = new EQApplicationPacket(OP_TradeSkillCombine, 0);
+		user->QueuePacket(outapp);
+		safe_delete(outapp);
 		return;
 	}
 
@@ -278,6 +281,9 @@ void Object::HandleCombine(Client* user, const NewCombine_Struct* in_combine, Ob
 				Chat::Red,
 				"Error: Server is not aware of the tradeskill container you are attempting to use"
 			);
+			auto outapp = new EQApplicationPacket(OP_TradeSkillCombine, 0);
+			user->QueuePacket(outapp);
+			safe_delete(outapp);
 			return;
 		}
 		c_type         = worldo->m_type;
@@ -304,6 +310,9 @@ void Object::HandleCombine(Client* user, const NewCombine_Struct* in_combine, Ob
 
 	if (!inst || !inst->IsType(EQ::item::ItemClassBag)) {
 		user->Message(Chat::Red, "Error: Server does not recognize specified tradeskill container");
+		auto outapp = new EQApplicationPacket(OP_TradeSkillCombine, 0);
+		user->QueuePacket(outapp);
+		safe_delete(outapp);
 		return;
 	}
 
@@ -427,22 +436,34 @@ void Object::HandleCombine(Client* user, const NewCombine_Struct* in_combine, Ob
 	if (spec.tradeskill == EQ::skills::SkillAlchemy) {
 		if (user_pp.class_ != SHAMAN) {
 			user->Message(Chat::Red, "This tradeskill can only be performed by a shaman.");
+			auto outapp = new EQApplicationPacket(OP_TradeSkillCombine, 0);
+			user->QueuePacket(outapp);
+			safe_delete(outapp);
 			return;
 		}
 		else if (user_pp.level < MIN_LEVEL_ALCHEMY) {
 			user->Message(Chat::Red, "You cannot perform alchemy until you reach level %i.", MIN_LEVEL_ALCHEMY);
+			auto outapp = new EQApplicationPacket(OP_TradeSkillCombine, 0);
+			user->QueuePacket(outapp);
+			safe_delete(outapp);
 			return;
 		}
 	}
 	else if (spec.tradeskill == EQ::skills::SkillTinkering) {
 		if (user_pp.race != GNOME) {
 			user->Message(Chat::Red, "Only gnomes can tinker.");
+			auto outapp = new EQApplicationPacket(OP_TradeSkillCombine, 0);
+			user->QueuePacket(outapp);
+			safe_delete(outapp);
 			return;
 		}
 	}
 	else if (spec.tradeskill == EQ::skills::SkillMakePoison) {
 		if (user_pp.class_ != ROGUE) {
 			user->Message(Chat::Red, "Only rogues can mix poisons.");
+			auto outapp = new EQApplicationPacket(OP_TradeSkillCombine, 0);
+			user->QueuePacket(outapp);
+			safe_delete(outapp);
 			return;
 		}
 	}
@@ -456,6 +477,9 @@ void Object::HandleCombine(Client* user, const NewCombine_Struct* in_combine, Ob
 			linker.SetItemData(success_item_inst);
 			auto item_link = linker.GenerateLink();
 			user->MessageString(Chat::Red, TRADESKILL_COMBINE_LORE, item_link.c_str());
+			auto outapp = new EQApplicationPacket(OP_TradeSkillCombine, 0);
+			user->QueuePacket(outapp);
+			safe_delete(outapp);
 			return;
 		}
 	}
@@ -706,13 +730,13 @@ void Object::HandleAutoCombine(Client* user, const RecipeAutoCombine_Struct* rac
 	for (const auto& e : recipe_struct.onsuccess) {
 		auto success_item_inst = database.GetItem(e.first);
 		if (user->CheckLoreConflict(success_item_inst)) {
-			user->QueuePacket(outapp);
-			safe_delete(outapp);
 			EQ::SayLinkEngine linker;
 			linker.SetLinkType(EQ::saylink::SayLinkItemData);
 			linker.SetItemData(success_item_inst);
 			auto item_link = linker.GenerateLink();
 			user->MessageString(Chat::Red, TRADESKILL_COMBINE_LORE, item_link.c_str());
+			user->QueuePacket(outapp);
+			safe_delete(outapp);
 			return;
 		}
 	}

--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -451,7 +451,11 @@ void Object::HandleCombine(Client* user, const NewCombine_Struct* in_combine, Ob
 	for (const auto& e : spec.onsuccess) {
 		auto success_item_inst = database.GetItem(e.first);
 		if (user->CheckLoreConflict(success_item_inst)) {
-			user->MessageString(Chat::Red, TRADESKILL_COMBINE_LORE, success_item_inst->Name);
+			EQ::SayLinkEngine linker;
+			linker.SetLinkType(EQ::saylink::SayLinkItemData);
+			linker.SetItemData(success_item_inst);
+			auto item_link = linker.GenerateLink();
+			user->MessageString(Chat::Red, TRADESKILL_COMBINE_LORE, item_link.c_str());
 			return;
 		}
 	}
@@ -704,7 +708,11 @@ void Object::HandleAutoCombine(Client* user, const RecipeAutoCombine_Struct* rac
 		if (user->CheckLoreConflict(success_item_inst)) {
 			user->QueuePacket(outapp);
 			safe_delete(outapp);
-			user->MessageString(Chat::Red, TRADESKILL_COMBINE_LORE, success_item_inst->Name);
+			EQ::SayLinkEngine linker;
+			linker.SetLinkType(EQ::saylink::SayLinkItemData);
+			linker.SetItemData(success_item_inst);
+			auto item_link = linker.GenerateLink();
+			user->MessageString(Chat::Red, TRADESKILL_COMBINE_LORE, item_link.c_str());
 			return;
 		}
 	}

--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -447,6 +447,15 @@ void Object::HandleCombine(Client* user, const NewCombine_Struct* in_combine, Ob
 		}
 	}
 
+	// Check if Combine would result in Lore conflict
+	for (const auto& e : spec.onsuccess) {
+		auto success_item_inst = database.GetItem(e.first);
+		if (user->CheckLoreConflict(success_item_inst)) {
+			user->MessageString(Chat::Red, TRADESKILL_COMBINE_LORE, success_item_inst->Name);
+			return;
+		}
+	}
+
 	// final check for any additional quest requirements .. "check_zone" in this case - exported as variable [validate_type]
 	if (parse->PlayerHasQuestSub(EVENT_COMBINE_VALIDATE)) {
 		if (parse->EventPlayer(EVENT_COMBINE_VALIDATE, user, fmt::format("check_zone {}", zone->GetZoneID()), spec.recipe_id) != 0) {
@@ -687,6 +696,18 @@ void Object::HandleAutoCombine(Client* user, const RecipeAutoCombine_Struct* rac
 		}
 	}
 
+	DBTradeskillRecipe_Struct recipe_struct;
+
+	// Check if Combine would result in Lore conflict
+	for (const auto& e : recipe_struct.onsuccess) {
+		auto success_item_inst = database.GetItem(e.first);
+		if (user->CheckLoreConflict(success_item_inst)) {
+			user->QueuePacket(outapp);
+			safe_delete(outapp);
+			user->MessageString(Chat::Red, TRADESKILL_COMBINE_LORE, success_item_inst->Name);
+			return;
+		}
+	}
 	//otherwise, we found it all...
 	outp->reply_code = 0x00000000;	//success for finding it...
 	user->QueuePacket(outapp);


### PR DESCRIPTION
We previously were not checking if the results of a combine would cause a Lore Conflict, and resulting items would be eaten.

Message Client receives now, when there is a Lore Conflict, and preventing the combine from occurring.

Added Item Links 
![image](https://user-images.githubusercontent.com/109764533/219112596-2e007cf1-ae68-4a88-8b16-01ae8c53eae6.png)

(I have no idea what is with the formatting on string_ids.h everything I do seems to make it worse, but it looks fine in my IDE.