### PR TITLE
[Bug Fix] Fix crash in EVENT_DISCOVER_ITEM

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -4094,7 +4094,7 @@ void Client::DiscoverItem(uint32 item_id) {
 
 	if (parse->PlayerHasQuestSub(EVENT_DISCOVER_ITEM)) {
 		auto* item = database.CreateItem(item_id);
-		std::vector<std::any> args = {item};
+		std::vector<std::any> args = { item };
 
 		parse->EventPlayer(EVENT_DISCOVER_ITEM, this, "", item_id, &args);
 	}

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -4093,7 +4093,7 @@ void Client::DiscoverItem(uint32 item_id) {
 	}
 
 	if (parse->PlayerHasQuestSub(EVENT_DISCOVER_ITEM)) {
-		const auto* item = database.GetItem(item_id);
+		auto* item = database.CreateItem(item_id);
 		std::vector<std::any> args = {item};
 
 		parse->EventPlayer(EVENT_DISCOVER_ITEM, this, "", item_id, &args);


### PR DESCRIPTION
# Notes
- `const` didn't like the `std::any_cast`, also was passing `EQ::ItemData*` instead of `EQ::ItemInstance*`.

## Picture
![image](https://user-images.githubusercontent.com/89047260/218895479-a46d8cee-8095-44df-9adc-8a289de0190d.png)

## Example Script
```pl
sub EVENT_DISCOVER_ITEM {
	quest::debug("itemid " . $itemid);
	quest::debug("item " . $item->GetName() . " (" . $item->GetID() . ")");
}
```

## Crash Log
```
[02-14-2023 18:34:25] [Zone] [Crash] #9  0x000055ee20d68df4 in std::__throw_bad_any_cast () at /usr/include/c++/10/any:63
[02-14-2023 18:34:25] [Zone] [Crash] #10 0x000055ee20d6a277 in std::any_cast<EQ::ItemInstance*> (__any=std::any containing const EQ::ItemInstance * = {...}) at /usr/include/c++/10/any:475
```