### PR TITLE
[Doors] Fix issue where NPC's wouldn't open doors because door param overflow

### DIFF
--- a/zone/doors.h
+++ b/zone/doors.h
@@ -38,7 +38,7 @@ public:
 	uint16 GetSize() { return m_size; }
 	uint32 GetClientVersionMask() { return m_client_version_mask; }
 	uint32 GetDoorDBID() { return m_database_id; }
-	uint32 GetDoorParam() { return m_door_param; }
+	int32 GetDoorParam() { return m_door_param; }
 	uint32 GetEntityID() { return m_entity_id; }
 	uint32 GetGuildID() { return m_guild_id; }
 	uint32 GetKeyItem() { return m_key_item_id; }
@@ -82,7 +82,7 @@ private:
 	uint8     m_no_key_ring;
 	uint8     m_trigger_door;
 	uint8     m_trigger_type;
-	uint32    m_door_param;
+	int32     m_door_param;
 	uint16    m_size;
 	int       m_invert_state;
 	uint32    m_entity_id;


### PR DESCRIPTION
### What

This fixes a datatype issue preventing NPC's from being able to open doors because their AI logic checks for `door_param > 0` then don't open door. 

Because `-1` or sub-zero values are being loaded into an unsigned integer, this is overflowing those values into positives causing the discrepancy in behavior.

Tested and fixed, in Griegs End, all doors are `-1`

https://user-images.githubusercontent.com/3319450/219086126-1152ba0b-0146-4896-91b5-74c8c1099358.mp4

```
select count(*) as count, door_param from doors group by door_param having count > 10;
+-------+------------+
| count | door_param |
+-------+------------+
|    54 |         -3 |
|  7497 |         -1 |
|  8032 |          0 |
|   125 |          1 |
|    22 |          2 |
|    83 |          5 |
|   109 |          6 |
|    33 |          7 |
|    31 |          9 |
|   267 |         10 |
|    85 |         11 |
|   114 |         12 |
|   107 |         13 |
|    97 |         14 |
|    55 |         15 |
|   140 |         16 |
|    18 |         17 |
|    11 |         20 |
|    83 |         23 |
|    11 |         24 |
|    12 |         25 |
|    18 |         30 |
|    11 |         32 |
|    15 |         64 |
|    21 |         65 |
|    13 |         66 |
|    14 |         67 |
|    11 |         70 |
|    62 |        100 |
|    18 |        101 |
|    22 |        102 |
|   172 |        103 |
|    99 |        104 |
|   152 |        105 |
|    23 |        112 |
|    52 |        116 |
|    14 |        120 |
|    42 |        122 |
|    13 |        128 |
|   622 |        132 |
|    23 |        142 |
|    19 |        145 |
|    13 |        190 |
|   105 |       1500 |
+-------+------------+
44 rows in set (0.00 sec)
```
