### PR TITLE
[Hotfix] Fix crash where dropped items crash Lua logic

### DIFF
--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -164,7 +164,7 @@ const char *LuaEvents[_LargestEventID] = {
 	"event_damage_taken",
 	"event_item_click_client",
 	"event_item_click_cast_client",
-	"event_destroy_item_client"
+	"event_destroy_item_client",
 	"event_drop_item_client"
 };
 


### PR DESCRIPTION
### What

This fixes a crash seen all over servers who have updated recently where dropping an item crashes the zone.

Example crash @ http://spire.akkadius.com/dev/release/22.3.0-dev?id=439