### PR TITLE
[Crash] Crash fix where invalid input to #heromodel would crash zone

### DIFF
--- a/zone/gm_commands/heromodel.cpp
+++ b/zone/gm_commands/heromodel.cpp
@@ -21,7 +21,7 @@ void command_heromodel(Client *c, const Seperator *sep)
 		t = c->GetTarget();
 	}
 
-	auto hero_forge_model = std::stoul(sep->arg[1]);
+	auto hero_forge_model = Strings::IsNumber(sep->arg[1]) ? std::stoul(sep->arg[1]) : 0;
 
 	if (arguments > 1) {
 		auto slot = static_cast<uint8>(std::stoul(sep->arg[2]));


### PR DESCRIPTION
### What

Crash fix where invalid input to #heromodel would crash zone

Seen @ http://spire.akkadius.com/dev/release/22.3.0?id=510