### PR TITLE
[Player Events] Create new event ITEM_CREATION

### DIFF
--- a/common/events/player_event_logs.cpp
+++ b/common/events/player_event_logs.cpp
@@ -696,6 +696,7 @@ void PlayerEventLogs::SetSettingsDefaults()
 	m_settings[PlayerEvent::KILLED_NPC].event_enabled         = 1;
 	m_settings[PlayerEvent::KILLED_NAMED_NPC].event_enabled   = 1;
 	m_settings[PlayerEvent::KILLED_RAID_NPC].event_enabled    = 1;
+	m_settings[PlayerEvent::ITEM_CREATION].event_enabled      = 1;
 
 	for (int i = PlayerEvent::GM_COMMAND; i != PlayerEvent::MAX; i++) {
 		m_settings[i].retention_days = RETENTION_DAYS_DEFAULT;

--- a/common/events/player_events.h
+++ b/common/events/player_events.h
@@ -55,6 +55,7 @@ namespace PlayerEvent {
 		KILLED_NPC,
 		KILLED_NAMED_NPC,
 		KILLED_RAID_NPC,
+		ITEM_CREATION,
 		MAX // dont remove
 	};
 
@@ -110,7 +111,8 @@ namespace PlayerEvent {
 		"Possible Hack",
 		"Killed NPC",
 		"Killed Named NPC",
-		"Killed Raid NPC"
+		"Killed Raid NPC",
+		"Item Creation"
 	};
 
 	// Generic struct used by all events
@@ -180,6 +182,40 @@ namespace PlayerEvent {
 		{
 			ar(
 				CEREAL_NVP(noop)
+			);
+		}
+	};
+
+	// used in Trade event
+	struct ItemCreationEvent {
+		int64       item_id;
+		std::string item_name;
+		uint16      to_slot;
+		int16       charges;
+		uint32      aug1;
+		uint32      aug2;
+		uint32      aug3;
+		uint32      aug4;
+		uint32      aug5;
+		uint32      aug6;
+		bool        attuned;
+
+		// cereal
+		template<class Archive>
+		void serialize(Archive &ar)
+		{
+			ar(
+				CEREAL_NVP(item_id),
+				CEREAL_NVP(item_name),
+				CEREAL_NVP(to_slot),
+				CEREAL_NVP(charges),
+				CEREAL_NVP(aug1),
+				CEREAL_NVP(aug2),
+				CEREAL_NVP(aug3),
+				CEREAL_NVP(aug4),
+				CEREAL_NVP(aug5),
+				CEREAL_NVP(aug6),
+				CEREAL_NVP(attuned)
 			);
 		}
 	};

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -794,6 +794,23 @@ bool Client::SummonItem(uint32 item_id, int16 charges, uint32 aug1, uint32 aug2,
 		}
 	}
 
+	if (player_event_logs.IsEventEnabled(PlayerEvent::ITEM_CREATION)) {
+		auto e = PlayerEvent::ItemCreationEvent{};
+		e.item_id   = item->ID;
+		e.item_name = item->Name;
+		e.to_slot   = to_slot;
+		e.charges   = charges;
+		e.aug1      = aug1;
+		e.aug2      = aug2;
+		e.aug3      = aug3;
+		e.aug4      = aug4;
+		e.aug5      = aug5;
+		e.aug6      = aug6;
+		e.attuned   = attuned;
+
+		RecordPlayerEventLog(PlayerEvent::ITEM_CREATION, e);
+	}
+
 	// put item into inventory
 	if (to_slot == EQ::invslot::slotCursor) {
 		PushItemOnCursor(*inst);
@@ -848,13 +865,13 @@ void Client::DropItem(int16 slot_id, bool recurse)
 				}
 			}
 		}
-		
+
 		std::string message = fmt::format(
 			"Tried to drop an item on the ground that was no-drop! item_name [{}] item_id ({})",
 			invalid_drop->GetItem()->Name,
 			invalid_drop->GetItem()->ID
 		);
-		
+
 		invalid_drop = nullptr;
 		RecordPlayerEventLog(PlayerEvent::POSSIBLE_HACK, PlayerEvent::PossibleHackEvent{.message = message});
 		GetInv().DeleteItem(slot_id);


### PR DESCRIPTION
### What

Created new player event `ITEM_CREATION` that is invoked during SummonItem. It is not a catch-all and events like this will likely need to be refined over time.

### Event Log Explorer Example

![image](https://user-images.githubusercontent.com/3319450/219611090-5f4b5465-a5a4-4e95-8aa7-9baad316d443.png)
