### PR TITLE
[Player Events] Fix rare out of bound issue when loading event types

### DIFF
--- a/common/events/player_event_logs.cpp
+++ b/common/events/player_event_logs.cpp
@@ -30,6 +30,9 @@ void PlayerEventLogs::Init()
 	std::vector<int> db{};
 	db.reserve(s.size());
 	for (auto &e: s) {
+		if (e.id >= PlayerEvent::MAX) {
+			continue;
+		}
 		m_settings[e.id] = e;
 		db.emplace_back(e.id);
 	}


### PR DESCRIPTION
### What

Fix rare out of bound issue when loading event types when the database has more events stored than what is defined locally