### PR TITLE
[Fix] Issue with AssignRaidToInstance that was using the groups repository instead of raid

### DIFF
--- a/common/database_instances.cpp
+++ b/common/database_instances.cpp
@@ -409,7 +409,7 @@ void Database::AssignRaidToInstance(uint32 raid_id, uint32 instance_id)
 	auto zone_id = GetInstanceZoneID(instance_id);
 	auto version = GetInstanceVersion(instance_id);
 
-	auto l = GroupIdRepository::GetWhere(
+	auto l = RaidMembersRepository::GetWhere(
 		*this,
 		fmt::format(
 			"raidid = {}",


### PR DESCRIPTION
### What

Fix issue with AssignRaidToInstance that was using the groups repository instead of raid