### PR TITLE
[Player Events] Turn off KILLED_NPC (trash) off by default

### DIFF
--- a/common/events/player_event_logs.cpp
+++ b/common/events/player_event_logs.cpp
@@ -693,7 +693,7 @@ void PlayerEventLogs::SetSettingsDefaults()
 	m_settings[PlayerEvent::BANDOLIER_SWAP].event_enabled     = 0;
 	m_settings[PlayerEvent::DISCOVER_ITEM].event_enabled      = 1;
 	m_settings[PlayerEvent::POSSIBLE_HACK].event_enabled      = 1;
-	m_settings[PlayerEvent::KILLED_NPC].event_enabled         = 1;
+	m_settings[PlayerEvent::KILLED_NPC].event_enabled         = 0;
 	m_settings[PlayerEvent::KILLED_NAMED_NPC].event_enabled   = 1;
 	m_settings[PlayerEvent::KILLED_RAID_NPC].event_enabled    = 1;
 


### PR DESCRIPTION
### What

Turn off KILLED_NPC (trash) off by default. 

After running this on PEQ for a week it is by far the most spammy of events producing almost no value currently since `KILLED_NAMED_NPC` and `KILLED_RAID_NPC` are also enabled and those are more notable events to record.

At current rate after almost a week, we have 300MB of events

```
select event_type_id, event_type_name, count(*) as count from player_event_logs group by event_type_id order by count desc;
+---------------+--------------------+--------+
| event_type_id | event_type_name    | count  |
+---------------+--------------------+--------+
|            44 | Killed NPC         | 709472 |
|            46 | Killed Raid NPC    | 160395 |
|             2 | Zoning             |  51735 |
|             9 | Item Destroy       |  35199 |
|            45 | Killed Named NPC   |  20955 |
|            14 | Loot Item          |  19738 |
|            35 | Split Money        |  10827 |
|             3 | AA Gain            |   6885 |
|            15 | Merchant Purchase  |   5980 |
|            16 | Merchant Sell      |   3962 |
|             4 | AA Purchase        |   2122 |
|            31 | Death              |   2049 |
|            30 | Rez Accepted       |   1713 |
|            27 | Trade              |   1404 |
|            43 | Possible Hack      |   1397 |
|            12 | Level Gain         |    706 |
|            22 | NPC Handin         |    600 |
|            24 | Task Accept        |    156 |
|            33 | Combine Success    |    141 |
|             1 | GM Command         |     88 |
|            38 | Trader Purchase    |     77 |
|            39 | Trader Sell        |     77 |
|            25 | Task Update        |     72 |
|            13 | Level Loss         |     66 |
|            21 | Groundspawn Pickup |     57 |
|            32 | Combine Failure    |     26 |
|            26 | Task Complete      |     25 |
|            34 | Dropped Item       |     13 |
+---------------+--------------------+--------+
28 rows in set (1.34 sec)
```