### PR TITLE
[Bot] Change SaveTimers to Replace instead of Insert.

### DIFF
--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -962,7 +962,10 @@ bool BotDatabase::SaveTimers(Bot* bot_inst)
 		if (bot_timers[timer_index] <= Timer::GetCurrentTime())
 			continue;
 
-		query = StringFormat("REPLACE INTO `bot_timers` (`bot_id`, `timer_id`, `timer_value`) VALUES ('%u', '%u', '%u')", bot_inst->GetBotID(), (timer_index + 1), bot_timers[timer_index]);
+		query = fmt::format(
+				"REPLACE INTO `bot_timers` (`bot_id`, `timer_id`, `timer_value`) VALUES ('%u', '%u', '%u')",
+				bot_inst->GetBotID(), (timer_index + 1), bot_timers[timer_index]
+		);
 		auto results = database.QueryDatabase(query);
 		if (!results.Success()) {
 			DeleteTimers(bot_inst->GetBotID());

--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -963,7 +963,7 @@ bool BotDatabase::SaveTimers(Bot* bot_inst)
 			continue;
 
 		query = fmt::format(
-				"REPLACE INTO `bot_timers` (`bot_id`, `timer_id`, `timer_value`) VALUES ('%u', '%u', '%u')",
+				"REPLACE INTO `bot_timers` (`bot_id`, `timer_id`, `timer_value`) VALUES ('{}', '{}', '{}')",
 				bot_inst->GetBotID(), (timer_index + 1), bot_timers[timer_index]
 		);
 		auto results = database.QueryDatabase(query);

--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -962,7 +962,7 @@ bool BotDatabase::SaveTimers(Bot* bot_inst)
 		if (bot_timers[timer_index] <= Timer::GetCurrentTime())
 			continue;
 
-		query = StringFormat("INSERT INTO `bot_timers` (`bot_id`, `timer_id`, `timer_value`) VALUES ('%u', '%u', '%u')", bot_inst->GetBotID(), (timer_index + 1), bot_timers[timer_index]);
+		query = StringFormat("REPLACE INTO `bot_timers` (`bot_id`, `timer_id`, `timer_value`) VALUES ('%u', '%u', '%u')", bot_inst->GetBotID(), (timer_index + 1), bot_timers[timer_index]);
 		auto results = database.QueryDatabase(query);
 		if (!results.Success()) {
 			DeleteTimers(bot_inst->GetBotID());


### PR DESCRIPTION
Change to Replace instead of Insert to reduce scenarios where the timer is expired, and the old entry hasn't been cleaned up yet.

Client Timers use a "Replace" Statement to store Timers as well.