### PR TITLE
[Logging] Remove noisy raid/group/forage errors

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -552,12 +552,10 @@ void EntityList::MobProcess()
 #endif
 				Group *g = GetGroupByMob(mob);
 				if(g) {
-					LogError("About to delete a client still in a group");
 					g->DelMember(mob);
 				}
 				Raid *r = entity_list.GetRaidByClient(mob->CastToClient());
 				if(r) {
-					LogError("About to delete a client still in a raid");
 					r->MemberZoned(mob->CastToClient());
 				}
 				entity_list.RemoveClient(id);

--- a/zone/forage.cpp
+++ b/zone/forage.cpp
@@ -92,7 +92,6 @@ uint32 ZoneDatabase::GetZoneForage(uint32 ZoneID, uint8 skill) {
 
 		item[index]   = atoi(row[0]);
 		chance[index] = atoi(row[1]) + chancepool;
-		LogError("Possible Forage: [{}] with a [{}] chance", item[index], chance[index]);
 		chancepool = chance[index];
 	}
 


### PR DESCRIPTION
### What

Remove noisy raid/group/forage errors

Since we are bubbling `stderr` properly in our `Error` category, errors have become more noticeable. For example in the Windows Perl launcher, `stdout` is squashed, but `stderr` still makes it through

I'm sure there are more errors that are noisy but these ones at least produce no value and are not real errors, they are more debugging.

Reported by Tossica on Discord

![image](https://user-images.githubusercontent.com/3319450/219793230-d29746b2-3c62-42b2-882c-68fbde1aac0a.png)
