### PR TITLE
[MySQL] Add keepalives to UCS and Loginserver

### DIFF
--- a/loginserver/main.cpp
+++ b/loginserver/main.cpp
@@ -288,8 +288,15 @@ int main(int argc, char **argv)
 	LogInfo("[Config] [Security] IsPasswordLoginAllowed [{0}]", server.options.IsPasswordLoginAllowed());
 	LogInfo("[Config] [Security] IsUpdatingInsecurePasswords [{0}]", server.options.IsUpdatingInsecurePasswords());
 
+	Timer keepalive(INTERSERVER_TIMER); // does auto-reconnect
+
 	auto loop_fn = [&](EQ::Timer* t) {
 		Timer::SetCurrentTime();
+
+		if (keepalive.Check()) {
+			keepalive.Start();
+			server.db->ping();
+		}
 
 		if (!run_server) {
 			EQ::EventLoop::Get().Shutdown();

--- a/ucs/ucs.cpp
+++ b/ucs/ucs.cpp
@@ -114,7 +114,7 @@ int main() {
 	Timer ChannelListProcessTimer(60000);
 	Timer ClientConnectionPruneTimer(60000);
 
-	Timer InterserverTimer(INTERSERVER_TIMER); // does auto-reconnect
+	Timer keepalive(INTERSERVER_TIMER); // does auto-reconnect
 
 	LogInfo("Starting EQEmu Universal Chat Server");
 
@@ -188,6 +188,10 @@ int main() {
 //	crash_test.detach();
 
 	auto loop_fn = [&](EQ::Timer* t) {
+		if (keepalive.Check()) {
+			keepalive.Start();
+			database.ping();
+		}
 
 		Timer::SetCurrentTime();
 


### PR DESCRIPTION
### What

This adds MySQL keepalives to both UCS and Loginserver to MySQL. Zone and World already have them and have had them for a long time.

This hasn't posed any issues but recently @noudess reported an issue with his MySQL 8 instance and it appears MySQL 8 is going to be a bit more sensitive.

This PR keeps the connection fresh by issuing pings every 10 seconds

### Reported Issue

Noudess "This message always comes out on 1st login attempt after an account has been logged out for long periods of time.  Can someone help me find where this is in the code?  I searched for some of this text and cannot find it.  From just the error message, it feels like some previous logout was missed and a new attempt to login triggers the error.  After 1 failure to login, all works again as normal.

Message:

[02-16-2023 10:34:38] [Login] [QueryErr] [4031] [The client was disconnected by the server because of inactivity. See wait_timeout and interactive_timeout for configuring this behavior.]
[SELECT id, account_password FROM login_accounts WHERE account_name = 'Paul3' AND source_loginserver = 'local' LIMIT 1]"