### PR TITLE
[Player Events] Add logging category to hold processing batch logs

### DIFF
--- a/common/eqemu_logsys.h
+++ b/common/eqemu_logsys.h
@@ -136,6 +136,7 @@ namespace Logs {
 		PacketServerToServer,
 		Bugs,
 		QuestErrors,
+		PlayerEvents,
 		MaxCategoryID /* Don't Remove this */
 	};
 
@@ -230,7 +231,8 @@ namespace Logs {
 		"Packet C->S",
 		"Packet S->S",
 		"Bugs",
-		"QuestErrors"
+		"QuestErrors",
+		"PlayerEvents",
 	};
 }
 

--- a/common/eqemu_logsys_log_aliases.h
+++ b/common/eqemu_logsys_log_aliases.h
@@ -784,6 +784,16 @@
         OutF(LogSys, Logs::Detail, Logs::QuestErrors, __FILE__, __func__, __LINE__, message, ##__VA_ARGS__);\
 } while (0)
 
+#define LogPlayerEvents(message, ...) do {\
+    if (LogSys.IsLogEnabled(Logs::General, Logs::PlayerEvents))\
+        OutF(LogSys, Logs::General, Logs::PlayerEvents, __FILE__, __func__, __LINE__, message, ##__VA_ARGS__);\
+} while (0)
+
+#define LogPlayerEventsDetail(message, ...) do {\
+    if (LogSys.IsLogEnabled(Logs::Detail, Logs::PlayerEvents))\
+        OutF(LogSys, Logs::Detail, Logs::PlayerEvents, __FILE__, __func__, __LINE__, message, ##__VA_ARGS__);\
+} while (0)
+
 #define Log(debug_level, log_category, message, ...) do {\
     if (LogSys.IsLogEnabled(debug_level, log_category))\
         LogSys.Out(debug_level, log_category, __FILE__, __func__, __LINE__, message, ##__VA_ARGS__);\

--- a/common/events/player_event_logs.cpp
+++ b/common/events/player_event_logs.cpp
@@ -121,7 +121,7 @@ void PlayerEventLogs::ProcessBatchQueue()
 
 	// flush many
 	PlayerEventLogsRepository::InsertMany(*m_database, m_record_batch_queue);
-	LogPlayerEvents(
+	LogPlayerEventsDetail(
 		"Processing batch player event log queue of [{}] took [{}]",
 		m_record_batch_queue.size(),
 		benchmark.elapsed()

--- a/common/events/player_event_logs.cpp
+++ b/common/events/player_event_logs.cpp
@@ -121,7 +121,7 @@ void PlayerEventLogs::ProcessBatchQueue()
 
 	// flush many
 	PlayerEventLogsRepository::InsertMany(*m_database, m_record_batch_queue);
-	LogInfo(
+	LogPlayerEvents(
 		"Processing batch player event log queue of [{}] took [{}]",
 		m_record_batch_queue.size(),
 		benchmark.elapsed()


### PR DESCRIPTION
### What

Add logging category to hold processing batch logs

Reported by Perc in Discord

![image](https://user-images.githubusercontent.com/3319450/219797637-99bef935-11aa-49f2-b485-9a17b051f9e4.png)

These batch processing messages on a populated server can get pretty noisy since they are flushing every 5 seconds. They are useful and we don't want to completely get rid of them but we can put them behind a new `PlayerEvents` category that is disabled by default