### PR TITLE
[Tradeskills] Fix regression caused by #2932

### DIFF
--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -471,6 +471,9 @@ void Object::HandleCombine(Client* user, const NewCombine_Struct* in_combine, Ob
 	// Check if Combine would result in Lore conflict
 	for (const auto& e : spec.onsuccess) {
 		auto success_item_inst = database.GetItem(e.first);
+		if (success_item_inst->LoreGroup > 0) {
+			continue;
+		}
 		if (user->CheckLoreConflict(success_item_inst)) {
 			EQ::SayLinkEngine linker;
 			linker.SetLinkType(EQ::saylink::SayLinkItemData);


### PR DESCRIPTION
Will skip Lore Conflict check where a loregroup > 0 is used. Will want to eventually implement a better solution when I have time that doesn't completely ignore the loregroup in these scenarios but instead does checks based on stacks, and if item is part of the combine.