### PR TITLE
[Reload API] Add world handlers for certain opcodes

### DIFF
--- a/world/eqemu_api_world_data_service.cpp
+++ b/world/eqemu_api_world_data_service.cpp
@@ -224,6 +224,13 @@ void EQEmuApiWorldDataService::reload(Json::Value &r, const std::vector<std::str
 			else {
 				pack = new ServerPacket(c.opcode, 0);
 				message(r, fmt::format("Reloading [{}] globally", c.desc));
+
+				if (c.opcode == ServerOP_ReloadLogs) {
+					LogSys.LoadLogDatabaseSettings();
+				}
+				else if (c.opcode == ServerOP_ReloadRules) {
+					RuleManager::Instance()->LoadRules(&database, RuleManager::Instance()->GetActiveRuleset(), true);
+				}
 			}
 
 			found_command = true;


### PR DESCRIPTION
### What

Add world handlers for certain opcodes. Because world is the one sending the packets instead of zone originating them, we aren't hitting the world opcode handlers that would otherwise reload rules/logs. This adds handling for it