### PR TITLE
[Crash] Fix world crash in player event processing

### DIFF
--- a/common/events/player_event_logs.cpp
+++ b/common/events/player_event_logs.cpp
@@ -5,6 +5,7 @@
 #include "../rulesys.h"
 
 const uint32 PROCESS_RETENTION_TRUNCATION_TIMER_INTERVAL = 60 * 60 * 1000; // 1 hour
+const uint32 MAX_BATCH_QUEUE_FLUSH_SIZE = 10000;
 
 // general initialization routine
 void PlayerEventLogs::Init()
@@ -139,6 +140,10 @@ void PlayerEventLogs::AddToQueue(const PlayerEventLogsRepository::PlayerEventLog
 	m_batch_queue_lock.lock();
 	m_record_batch_queue.emplace_back(log);
 	m_batch_queue_lock.unlock();
+
+	if (m_record_batch_queue.size() >= MAX_BATCH_QUEUE_FLUSH_SIZE) {
+		ProcessBatchQueue();
+	}
 }
 
 // fills common event data in the SendEvent function

--- a/common/events/player_event_logs.cpp
+++ b/common/events/player_event_logs.cpp
@@ -5,7 +5,6 @@
 #include "../rulesys.h"
 
 const uint32 PROCESS_RETENTION_TRUNCATION_TIMER_INTERVAL = 60 * 60 * 1000; // 1 hour
-const uint32 MAX_BATCH_QUEUE_FLUSH_SIZE = 10000;
 
 // general initialization routine
 void PlayerEventLogs::Init()
@@ -141,7 +140,7 @@ void PlayerEventLogs::AddToQueue(const PlayerEventLogsRepository::PlayerEventLog
 	m_record_batch_queue.emplace_back(log);
 	m_batch_queue_lock.unlock();
 
-	if (m_record_batch_queue.size() >= MAX_BATCH_QUEUE_FLUSH_SIZE) {
+	if (m_record_batch_queue.size() >= RuleI(Logging, BatchPlayerEventProcessChunkSize)) {
 		ProcessBatchQueue();
 	}
 }

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -783,6 +783,7 @@ RULE_BOOL(Logging, PrintFileFunctionAndLine, false, "Ex: [World Server] [net.cpp
 RULE_BOOL(Logging, WorldGMSayLogging, true, "Relay worldserver logging to zone processes via GM say output")
 RULE_BOOL(Logging, PlayerEventsQSProcess, false, "Have query server process player events instead of world. Useful when wanting to use a dedicated server and database for processing player events on separate disk")
 RULE_INT(Logging, BatchPlayerEventProcessIntervalSeconds, 5, "This is the interval in which player events are processed in world or qs")
+RULE_INT(Logging, BatchPlayerEventProcessChunkSize, 10000, "This is the cap of events that can be inserted into the queue before a force flush. This is to keep from hitting MySQL max_allowed_packet and killing the connection")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(HotReload)


### PR DESCRIPTION
### What

Fix world crash in player event processing where batch MySQL insertions when the bulk insert query exceeds `max_allowed_packet`

"When a MySQL client or the mysqld server receives a packet bigger than max_allowed_packet bytes, it issues an ER_NET_PACKET_TOO_LARGE error and closes the connection."

This forces batch insertion of 10k entries if the queue reaches that size before it has had a chance to flush

I've only observed this on larger servers such as Lazarus, PEQ, EZ where the event generation would produce enough of a batch insertion size to trigger this event within a 5 second flush interval.

### Observed Crashes

- http://spire.akkadius.com/dev/release/22.3.0-dev?id=433
- http://spire.akkadius.com/dev/release/22.4.0-dev?id=635

### Reproduction

![image](https://user-images.githubusercontent.com/3319450/219900628-e90d7ea5-2453-4299-ad9e-7dc8a59be657.png)

### Fix

![image](https://user-images.githubusercontent.com/3319450/219900638-67592e3b-4eee-40e5-8a13-6a061c39b3ef.png)
