### PR TITLE
[Quest API] Fix Perl SetSimpleRoamBox Overloads

### DIFF
--- a/zone/perl_npc.cpp
+++ b/zone/perl_npc.cpp
@@ -584,6 +584,16 @@ bool Perl_NPC_GetCombatState(NPC* self) // @categories Script Utility
 	return self->GetCombatEvent();
 }
 
+void Perl_NPC_SetSimpleRoamBox(NPC* self, float box_size) // @categories Script Utility
+{
+	self->SetSimpleRoamBox(box_size);
+}
+
+void Perl_NPC_SetSimpleRoamBox(NPC* self, float box_size, float move_distance) // @categories Script Utility
+{
+	self->SetSimpleRoamBox(box_size, move_distance);
+}
+
 void Perl_NPC_SetSimpleRoamBox(NPC* self, float box_size, float move_distance, int move_delay) // @categories Script Utility
 {
 	self->SetSimpleRoamBox(box_size, move_distance, move_delay);


### PR DESCRIPTION
# Notes
- These overloads were non-functional as they didn't have a method to actually fall back to.