### PR TITLE
[Quest API] Add client->SignalClient() overload to Perl

### DIFF
--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -2755,6 +2755,11 @@ void Perl_Client_Signal(Client* self, int signal_id)
 	self->Signal(signal_id);
 }
 
+void Perl_Client_SignalClient(Client* self, int signal_id) // @categories Script Utility
+{
+	self->Signal(signal_id);
+}
+
 std::string Perl_Client_GetGuildPublicNote(Client* self)
 {
 	return self->GetGuildPublicNote();
@@ -3362,6 +3367,7 @@ void perl_register_client()
 	package.add("SetTitleSuffix", (void(*)(Client*, std::string, bool))&Perl_Client_SetTitleSuffix);
 	package.add("SetZoneFlag", &Perl_Client_SetZoneFlag);
 	package.add("Signal", &Perl_Client_Signal);
+	package.add("SignalClient", &Perl_Client_SignalClient);
 	package.add("SilentMessage", &Perl_Client_SilentMessage);
 	package.add("Sit", &Perl_Client_Sit);
 	package.add("SlotConvert2", &Perl_Client_SlotConvert2);


### PR DESCRIPTION
# Notes
- Fixes an issue with Guild Lobby quests not properly using `client` as first parameter in `mob->SignalClient(client, signal_id)` method.