### PR TITLE
[Pets] Client Pet summoned by NPC should not change guard location.

### DIFF
--- a/zone/mob.h
+++ b/zone/mob.h
@@ -686,7 +686,7 @@ public:
 	float GetMovespeed() const { return IsRunning() ? GetRunspeed() : GetWalkspeed(); }
 	bool IsRunning() const { return m_is_running; }
 	void SetRunning(bool val) { m_is_running = val; }
-	virtual void GMMove(float x, float y, float z, float heading = 0.01);
+	virtual void GMMove(float x, float y, float z, float heading = 0.01, bool save_guard_spot = true);
 	virtual void GMMove(const glm::vec4 &position);
 	void SetDelta(const glm::vec4& delta);
 	void MakeSpawnUpdateNoDelta(PlayerPositionUpdateServer_Struct* spu);


### PR DESCRIPTION
On live, if an NPC summons a client pet that is on guard, the pet returns to its guard position.

On eqemu, the pet's guard position is changed to the summon location, which is incorrect.

This PR fixes this case.