### PR TITLE
[Bots] HasBotItem to return slot_id instead of bool.

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -4478,23 +4478,19 @@ uint32 Bot::CountBotItem(uint32 item_id) {
 	return item_count;
 }
 
-bool Bot::HasBotItem(uint32 item_id) {
-	bool has_item = false;
-	EQ::ItemInstance *inst = nullptr;
+int16 Bot::HasBotItem(uint32 item_id) {
+	EQ::ItemInstance const *inst = nullptr;
 
 	for (uint16 slot_id = EQ::invslot::EQUIPMENT_BEGIN; slot_id <= EQ::invslot::EQUIPMENT_END; ++slot_id) {
 		inst = GetBotItem(slot_id);
 		if (!inst || !inst->GetItem()) {
 			continue;
 		}
-
 		if (inst->GetID() == item_id) {
-			has_item = true;
-			break;
+			return slot_id;
 		}
 	}
-
-	return has_item;
+	return INVALID_INDEX;
 }
 
 void Bot::RemoveBotItem(uint32 item_id) {

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -720,7 +720,7 @@ public:
 	uint32 CountBotItem(uint32 item_id);
 	std::map<uint16, uint32> GetBotItemSlots();
 	uint32 GetBotItemBySlot(uint16 slot_id);
-	bool HasBotItem(uint32 item_id);
+	int16 HasBotItem(uint32 item_id);
 	void RemoveBotItem(uint32 item_id);
 	uint32 GetTotalPlayTime();
 

--- a/zone/gm_commands/gearup.cpp
+++ b/zone/gm_commands/gearup.cpp
@@ -116,7 +116,7 @@ void command_gearup(Client *c, const Seperator *sep)
 			if (t->IsClient()) {
 				has_item = t->CastToClient()->GetInv().HasItem(item_id, 1, invWhereWorn) != INVALID_INDEX;
 			} else if (t->IsBot()) {
-				has_item = t->CastToBot()->HasBotItem(item_id);
+				has_item = t->CastToBot()->HasBotItem(item_id) != INVALID_INDEX;
 			}
 
 			bool can_wear_item = false;

--- a/zone/lua_bot.cpp
+++ b/zone/lua_bot.cpp
@@ -65,8 +65,8 @@ Lua_Mob Lua_Bot::GetOwner() {
 	return Lua_Mob(self->GetOwner());
 }
 
-bool Lua_Bot::HasBotItem(uint32 item_id) {
-	Lua_Safe_Call_Bool();
+int16 Lua_Bot::HasBotItem(uint32 item_id) {
+	Lua_Safe_Call_Int();
 	return self->HasBotItem(item_id);
 }
 
@@ -507,7 +507,7 @@ luabind::scope lua_register_bot() {
 	.def("GetRawItemAC", (int(Lua_Bot::*)(void))&Lua_Bot::GetRawItemAC)
 	.def("GetSpellDamage", (int(Lua_Bot::*)(void))&Lua_Bot::GetSpellDamage)
 	.def("HasAugmentEquippedByID", (bool(Lua_Bot::*)(uint32))&Lua_Bot::HasAugmentEquippedByID)
-	.def("HasBotItem", (bool(Lua_Bot::*)(uint32))&Lua_Bot::HasBotItem)
+	.def("HasBotItem", (int16(Lua_Bot::*)(uint32))&Lua_Bot::HasBotItem)
 	.def("HasBotSpellEntry", (bool(Lua_Bot::*)(uint16)) & Lua_Bot::HasBotSpellEntry)
 	.def("HasItemEquippedByID", (bool(Lua_Bot::*)(uint32))&Lua_Bot::HasItemEquippedByID)
 	.def("IsGrouped", (bool(Lua_Bot::*)(void))&Lua_Bot::IsGrouped)

--- a/zone/lua_bot.h
+++ b/zone/lua_bot.h
@@ -43,7 +43,7 @@ public:
 	uint32 GetBotItemIDBySlot(uint16 slot_id);
 	int GetExpansionBitmask();
 	Lua_Mob GetOwner();
-	bool HasBotItem(uint32 item_id);
+	int16 HasBotItem(uint32 item_id);
 	void OwnerMessage(std::string message);
 	bool ReloadBotDataBuckets();
 	bool ReloadBotOwnerDataBuckets();

--- a/zone/perl_bot.cpp
+++ b/zone/perl_bot.cpp
@@ -90,7 +90,7 @@ uint32 Perl_Bot_CountBotItem(Bot* self, uint32 item_id)
 	return self->CountBotItem(item_id);
 }
 
-bool Perl_Bot_HasBotItem(Bot* self, uint32 item_id)
+int16 Perl_Bot_HasBotItem(Bot* self, uint32 item_id)
 {
 	return self->HasBotItem(item_id);
 }


### PR DESCRIPTION
HasBotItem() should have originally returned the slot_id of the item_id equipped. this would make it coincide with the client method of  $client->inventory()->HasItem() returns the slot_id of the item_id equipped.

Bots already have a boolean check if an item is equipped by ID $bot->HasItemEquippedByID (uint32 item_id);