### PR TITLE
[Pets] Client Pet summoned by NPC should not change guard location.

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -3715,17 +3715,30 @@ bool Mob::HateSummon() {
 			new_pos = target->TryMoveAlong(new_pos, 5.0f, angle);
 
 			if (target->IsClient()) {
-				target->CastToClient()->MovePC(zone->GetZoneID(), zone->GetInstanceID(), new_pos.x, new_pos.y, new_pos.z, new_pos.w, 0, SummonPC);
-			}
-			else {
+				target->CastToClient()->MovePC(
+					zone->GetZoneID(),
+					zone->GetInstanceID(),
+					new_pos.x,
+					new_pos.y,
+					new_pos.z,
+					new_pos.w,
+					0,
+					SummonPC
+				);
+			} else {
 				bool target_is_client_pet = (
-												target->IsPet() &&
-												target->IsPetOwnerClient()
-											);
+					target->IsPet() &&
+					target->IsPetOwnerClient()
+				);
 				bool set_new_guard_spot = !(IsNPC() && target_is_client_pet);
 
-				target->GMMove(new_pos.x, new_pos.y, new_pos.z, new_pos.w,
-								set_new_guard_spot);
+				target->GMMove(
+					new_pos.x,
+					new_pos.y,
+					new_pos.z,
+					new_pos.w,
+					set_new_guard_spot
+				);
 			}
 
 			return true;

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -2374,14 +2374,14 @@ void Mob::ShowBuffList(Client* client) {
 	}
 }
 
-void Mob::GMMove(float x, float y, float z, float heading) {
+void Mob::GMMove(float x, float y, float z, float heading, bool save_guard_spot) {
 	m_Position.x = x;
 	m_Position.y = y;
 	m_Position.z = z;
 	SetHeading(heading);
 	mMovementManager->SendCommandToClients(this, 0.0, 0.0, 0.0, 0.0, 0, ClientRangeAny);
 
-	if (IsNPC()) {
+	if (IsNPC() && save_guard_spot) {
 		CastToNPC()->SaveGuardSpot(glm::vec4(x, y, z, heading));
 	}
 }
@@ -3714,10 +3714,19 @@ bool Mob::HateSummon() {
 			// probably should be like half melee range, but we can't get melee range nicely because reasons :)
 			new_pos = target->TryMoveAlong(new_pos, 5.0f, angle);
 
-			if (target->IsClient())
+			if (target->IsClient()) {
 				target->CastToClient()->MovePC(zone->GetZoneID(), zone->GetInstanceID(), new_pos.x, new_pos.y, new_pos.z, new_pos.w, 0, SummonPC);
-			else
-				target->GMMove(new_pos.x, new_pos.y, new_pos.z, new_pos.w);
+			}
+			else {
+				bool target_is_client_pet = (
+												target->IsPet() &&
+												target->IsPetOwnerClient()
+											);
+				bool set_new_guard_spot = !(IsNPC() && target_is_client_pet);
+
+				target->GMMove(new_pos.x, new_pos.y, new_pos.z, new_pos.w,
+								set_new_guard_spot);
+			}
 
 			return true;
 		} else if(summon_level == 2) {

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -686,7 +686,7 @@ public:
 	float GetMovespeed() const { return IsRunning() ? GetRunspeed() : GetWalkspeed(); }
 	bool IsRunning() const { return m_is_running; }
 	void SetRunning(bool val) { m_is_running = val; }
-	virtual void GMMove(float x, float y, float z, float heading = 0.01);
+	virtual void GMMove(float x, float y, float z, float heading = 0.01, bool save_guard_spot = true);
 	virtual void GMMove(const glm::vec4 &position);
 	void SetDelta(const glm::vec4& delta);
 	void MakeSpawnUpdateNoDelta(PlayerPositionUpdateServer_Struct* spu);


### PR DESCRIPTION
On live, if an NPC summons a client pet that is on guard, the pet returns to its guard position.

On eqemu, the pet's guard position is changed to the summon location, which is incorrect.

This PR fixes this case.