### PR TITLE
[Bug Fix] Fix OOCMute not functioning

### DIFF
--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -1332,6 +1332,7 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 		case ServerOP_ItemStatus:
 		case ServerOP_KickPlayer:
 		case ServerOP_KillPlayer:
+		case ServerOP_OOCMute:
 		case ServerOP_OOZGroupMessage:
 		case ServerOP_Petition:
 		case ServerOP_RaidGroupSay:


### PR DESCRIPTION
# Notes
- #oocmute was not functioning as the packet wasn't being handled by the server.

# Image
![image](https://user-images.githubusercontent.com/89047260/219988809-cf5c907d-4f0b-421e-b067-8c09e0e792f9.png)