### PR TITLE
[Bug Fix] Correct Mend reuse time and add reduction support.

### DIFF
--- a/common/features.h
+++ b/common/features.h
@@ -132,7 +132,7 @@ enum {	//reuse times
 	InstillDoubtReuseTime = 9,
 	FishingReuseTime = 11,
 	ForagingReuseTime = 50,
-	MendReuseTime = 290,
+	MendReuseTime = 360,
 	BashReuseTime = 5,
 	BackstabReuseTime = 9,
 	KickReuseTime = 5,

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -9951,7 +9951,7 @@ void Client::Handle_OP_Mend(const EQApplicationPacket *app)
 		Message(Chat::Red, "Ability recovery time not yet met.");
 		return;
 	}
-	p_timers.Start(pTimerMend, MendReuseTime - 1);
+	p_timers.Start(pTimerMend, (MendReuseTime - GetSkillReuseTime(EQ::skills::SkillMend)));
 
 	int mendhp = GetMaxHP() / 4;
 	int currenthp = GetHP();
@@ -9963,9 +9963,11 @@ void Client::Handle_OP_Mend(const EQApplicationPacket *app)
 			mendhp *= 2;
 			MessageString(Chat::LightBlue, MEND_CRITICAL);
 		}
+		else {
+			MessageString(Chat::LightBlue, MEND_SUCCESS);
+		}
 		SetHP(GetHP() + mendhp);
 		SendHPUpdate();
-		MessageString(Chat::LightBlue, MEND_SUCCESS);
 	}
 	else {
 		/* the purpose of the following is to make the chance to worsen wounds much less common,


### PR DESCRIPTION
Notes:

Previously, the server-side reuse of Mend was set to 290 seconds rather than 360 seconds (6 minutes).

Mend was not accepting reduction timers from potential items, buffs or AAs (Hastened Mend).

Mend was outputting duplicate success messages on critical mends, it will now only output a regular Mend message upon success (You mend your wounds and heal some damage) or the critical message upon critical success (You magically mend your wounds and heal considerable damage), not both.