### PR TITLE
[Database] Address deadlock in player events

### DIFF
--- a/common/dbcore.cpp
+++ b/common/dbcore.cpp
@@ -298,3 +298,12 @@ void DBcore::SetOriginHost(const std::string &origin_host)
 {
 	DBcore::origin_host = origin_host;
 }
+
+std::string DBcore::Escape(const std::string& s)
+{
+	const std::size_t s_len = s.length();
+	std::vector<char> temp((s_len * 2) + 1, '\0');
+	mysql_real_escape_string(&mysql, temp.data(), s.c_str(), s_len);
+
+	return temp.data();
+}

--- a/common/dbcore.h
+++ b/common/dbcore.h
@@ -12,6 +12,7 @@
 
 #include <mysql.h>
 #include <string.h>
+#include <mutex>
 
 class DBcore {
 public:
@@ -56,6 +57,8 @@ private:
 	MYSQL   mysql;
 	Mutex   MDatabase;
 	eStatus pStatus;
+
+	std::mutex m_query_lock{};
 
 	std::string origin_host;
 

--- a/common/dbcore.h
+++ b/common/dbcore.h
@@ -28,6 +28,7 @@ public:
 	void TransactionBegin();
 	void TransactionCommit();
 	void TransactionRollback();
+	std::string Escape(const std::string& s);
 	uint32 DoEscapeString(char *tobuf, const char *frombuf, uint32 fromlen);
 	void ping();
 	MYSQL *getMySQL() { return &mysql; }

--- a/common/events/player_event_logs.cpp
+++ b/common/events/player_event_logs.cpp
@@ -113,7 +113,9 @@ bool PlayerEventLogs::IsEventEnabled(PlayerEvent::EventType event)
 // this processes any current player events on the queue
 void PlayerEventLogs::ProcessBatchQueue()
 {
+	m_batch_queue_lock.lock();
 	if (m_record_batch_queue.empty()) {
+		m_batch_queue_lock.unlock();
 		return;
 	}
 
@@ -128,7 +130,6 @@ void PlayerEventLogs::ProcessBatchQueue()
 	);
 
 	// empty
-	m_batch_queue_lock.lock();
 	m_record_batch_queue = {};
 	m_batch_queue_lock.unlock();
 }

--- a/common/repositories/base/base_player_event_logs_repository.h
+++ b/common/repositories/base/base_player_event_logs_repository.h
@@ -240,8 +240,8 @@ public:
 		v.push_back(columns[7] + " = " + std::to_string(e.z));
 		v.push_back(columns[8] + " = " + std::to_string(e.heading));
 		v.push_back(columns[9] + " = " + std::to_string(e.event_type_id));
-		v.push_back(columns[10] + " = '" + Strings::Escape(e.event_type_name) + "'");
-		v.push_back(columns[11] + " = '" + Strings::Escape(e.event_data) + "'");
+		v.push_back(columns[10] + " = '" + db.Escape(e.event_type_name) + "'");
+		v.push_back(columns[11] + " = '" + db.Escape(e.event_data) + "'");
 		v.push_back(columns[12] + " = FROM_UNIXTIME(" + (e.created_at > 0 ? std::to_string(e.created_at) : "null") + ")");
 
 		auto results = db.QueryDatabase(
@@ -274,8 +274,8 @@ public:
 		v.push_back(std::to_string(e.z));
 		v.push_back(std::to_string(e.heading));
 		v.push_back(std::to_string(e.event_type_id));
-		v.push_back("'" + Strings::Escape(e.event_type_name) + "'");
-		v.push_back("'" + Strings::Escape(e.event_data) + "'");
+		v.push_back("'" + db.Escape(e.event_type_name) + "'");
+		v.push_back("'" + db.Escape(e.event_data) + "'");
 		v.push_back("FROM_UNIXTIME(" + (e.created_at > 0 ? std::to_string(e.created_at) : "null") + ")");
 
 		auto results = db.QueryDatabase(
@@ -316,8 +316,8 @@ public:
 			v.push_back(std::to_string(e.z));
 			v.push_back(std::to_string(e.heading));
 			v.push_back(std::to_string(e.event_type_id));
-			v.push_back("'" + Strings::Escape(e.event_type_name) + "'");
-			v.push_back("'" + Strings::Escape(e.event_data) + "'");
+			v.push_back("'" + db.Escape(e.event_type_name) + "'");
+			v.push_back("'" + db.Escape(e.event_data) + "'");
 			v.push_back("FROM_UNIXTIME(" + (e.created_at > 0 ? std::to_string(e.created_at) : "null") + ")");
 
 			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");


### PR DESCRIPTION
### What

This addresses and issue that has been manifesting in world deadlocks lately influenced by player events.

This issue has been seen by multiple servers (Lazarus, PEQ, EZ, KMRA etc.)

This has been running on EZ for 2 days, confirmed no deadlocks, other folks have ran the same changes without issues.

Other notable things

* This uses native MySQL string escaping instead of the one we rolled on our own that is used all over the source. The MySQL client library native function is going to be more con-formative to character sets configured on the database instance and give the best escaping overall
* The mutex in player events was not locking before reading if the queue was empty, this can lead to racey memory access, deadlocks and memory corruption
