### PR TITLE
Akkadius/better zclip

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -103,6 +103,7 @@ Mob::Mob(
 	attack_dw_timer(2000),
 	ranged_timer(2000),
 	hp_regen_per_second_timer(1000),
+	m_z_clip_check_timer(1000),
 	tic_timer(6000),
 	mana_timer(2000),
 	spellend_timer(0),

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1427,6 +1427,8 @@ protected:
 	int _GetRunSpeed() const;
 	int _GetFearSpeed() const;
 
+	Timer m_z_clip_check_timer;
+
 	virtual bool AI_EngagedCastCheck() { return(false); }
 	virtual bool AI_PursueCastCheck() { return(false); }
 	virtual bool AI_IdleCastCheck() { return(false); }

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -1071,6 +1071,15 @@ void Mob::AI_Process() {
 	}
 
 	if (engaged) {
+		if (IsNPC() && m_z_clip_check_timer.Check()) {
+			auto t = GetTarget();
+			if (t && DistanceNoZ(GetPosition(), t->GetPosition()) < 75 && std::abs(GetPosition().z - t->GetPosition().z) > 15 && !CheckLosFN(t)) {
+				LogDebug("Clip detection [{}]", GetCleanName());
+				GMMove(t->GetPosition().x, t->GetPosition().y, t->GetPosition().z, t->GetPosition().w);
+				FaceTarget(t);
+			}
+		}
+
 		if (!(m_PlayerState & static_cast<uint32>(PlayerState::Aggressive)))
 			SendAddPlayerState(PlayerState::Aggressive);
 

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -1074,7 +1074,6 @@ void Mob::AI_Process() {
 		if (IsNPC() && m_z_clip_check_timer.Check()) {
 			auto t = GetTarget();
 			if (t && DistanceNoZ(GetPosition(), t->GetPosition()) < 75 && std::abs(GetPosition().z - t->GetPosition().z) > 15 && !CheckLosFN(t)) {
-				LogDebug("Clip detection [{}]", GetCleanName());
 				GMMove(t->GetPosition().x, t->GetPosition().y, t->GetPosition().z, t->GetPosition().w);
 				FaceTarget(t);
 			}

--- a/zone/waypoints.cpp
+++ b/zone/waypoints.cpp
@@ -781,26 +781,24 @@ float Mob::GetFixedZ(const glm::vec3 &destination, int32 z_find_offset) {
 			return new_z;
 		}
 
-		new_z = FindDestGroundZ(destination, (-GetZOffset() / 2));
+		new_z = FindDestGroundZ(destination, ((-GetZOffset() / 2) + z_find_offset));
+
+		if (RuleB(Map, MobPathingVisualDebug)) {
+			DrawDebugCoordinateNode(
+				fmt::format("{} search z node", GetCleanName()),
+				glm::vec4{
+					m_Position.x,
+					m_Position.y,
+					((-GetZOffset() / 2) + z_find_offset),
+					m_Position.w
+				}
+			);
+		}
 		if (new_z != BEST_Z_INVALID) {
 			new_z += GetZOffset();
 
 			if (new_z < -2000) {
 				new_z = m_Position.z;
-			}
-		}
-
-		// prevent ceiling clipping
-		// if client is close in distance (not counting Z) and we clipped up into a ceiling
-		// this helps us snap back down (or up) if it were to happen
-		// other fixes were put in place to prevent clipping into the ceiling to begin with
-		if (std::abs(new_z - m_Position.z) > 15) {
-			LogFixZ("TRIGGER clipping detection");
-			auto t = GetTarget();
-			if (t && DistanceNoZ(GetPosition(), t->GetPosition()) < 20) {
-				new_z = FindDestGroundZ(t->GetPosition(), -t->GetZOffset());
-				new_z += GetZOffset();
-				GMMove(t->GetPosition().x, t->GetPosition().y, new_z, t->GetPosition().w);
 			}
 		}
 


### PR DESCRIPTION
### What

Augments https://github.com/EQEmu/Server/pull/2826 by adding back in the original `z_find_offset` (default 5) to the Z find. This has made Z finding more reliable on PEQ in conjunction to the previous changes.

This also moves Z clip detection out of the Z calculation function and moves it to a 1-second timer that happens while the NPC is engaged. 

If the NPC is close to the player in X/Y but the Z has fallen out of LOS, the NPC will recover to the player. This has worked remarkably well.

In conjunction with this, navmesh changes have been made to various zones to improve the mesh as we still have very gappy zones. See http://www.projecteq.net/forums/index.php?threads/server-update-2-20-2023.17509/ for example