### PR TITLE
[Tradeskills] Fix for Lore Conflict

### DIFF
--- a/zone/client.h
+++ b/zone/client.h
@@ -792,6 +792,7 @@ public:
 	void SendTradeskillDetails(uint32 recipe_id);
 	bool TradeskillExecute(DBTradeskillRecipe_Struct *spec);
 	void CheckIncreaseTradeskill(int16 bonusstat, int16 stat_modifier, float skillup_modifier, uint16 success_modifier, EQ::skills::SkillType tradeskill);
+	bool CheckTradeskillLoreConflict(DBTradeskillRecipe_Struct& spec, MySQLRequestResult& results);
 	void InitInnates();
 
 	void GMKill();

--- a/zone/client.h
+++ b/zone/client.h
@@ -792,7 +792,7 @@ public:
 	void SendTradeskillDetails(uint32 recipe_id);
 	bool TradeskillExecute(DBTradeskillRecipe_Struct *spec);
 	void CheckIncreaseTradeskill(int16 bonusstat, int16 stat_modifier, float skillup_modifier, uint16 success_modifier, EQ::skills::SkillType tradeskill);
-	bool CheckTradeskillLoreConflict(DBTradeskillRecipe_Struct& spec, MySQLRequestResult& results);
+	bool CheckTradeskillLoreConflict(int32 recipe_id);
 	void InitInnates();
 
 	void GMKill();

--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -475,7 +475,7 @@ void Object::HandleCombine(Client* user, const NewCombine_Struct* in_combine, Ob
 	                                 spec.recipe_id);
 	auto results = content_db.QueryDatabase(query);
 
-	if(!results.Success() || results.RowCount() < 1 || results.RowCount() > 10) {
+	if (!results.Success() || results.RowCount() < 1 || results.RowCount() > 10) {
 		auto outapp = new EQApplicationPacket(OP_TradeSkillCombine, 0);
 		user->QueuePacket(outapp);
 		safe_delete(outapp);

--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -1879,7 +1879,7 @@ bool Client::CheckTradeskillLoreConflict(int32 recipe_id)
 	for (auto& e : recipe_entries) {
 		auto item_inst = database.GetItem(e.item_id);
 		if (item_inst) {
-			if (item_inst->LoreGroup == 0 || e.componentcount > 0) {
+			if (item_inst->LoreGroup == 0 || e.componentcount > 0 || e.iscontainer) {
 				continue;
 			}
 			if (CheckLoreConflict(item_inst)) {


### PR DESCRIPTION
This fixes a regression issue where components of the combine could be lore, causing the combine to fail on the lore check if the components were returned on success, failure, or salvage.
