### PR TITLE
[Quest API] Add IsAutoFireEnabled() to Perl/Lua

### DIFF
--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3038,6 +3038,12 @@ void Lua_Client::UseAugmentContainer(int container_slot)
 	self->UseAugmentContainer(container_slot);
 }
 
+bool Lua_Client::IsAutoFireEnabled()
+{
+	Lua_Safe_Call_Bool();
+	return self->AutoFireEnabled();
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 	.def(luabind::constructor<>())
@@ -3296,6 +3302,7 @@ luabind::scope lua_register_client() {
 	.def("IncreaseSkill", (void(Lua_Client::*)(int))&Lua_Client::IncreaseSkill)
 	.def("IncreaseSkill", (void(Lua_Client::*)(int,int))&Lua_Client::IncreaseSkill)
 	.def("IncrementAA", (void(Lua_Client::*)(int))&Lua_Client::IncrementAA)
+	.def("IsAutoFireEnabled", (bool(Lua_Client::*)(void))&Lua_Client::IsAutoFireEnabled)
 	.def("IsCrouching", (bool(Lua_Client::*)(void))&Lua_Client::IsCrouching)
 	.def("IsDead", &Lua_Client::IsDead)
 	.def("IsDueling", (bool(Lua_Client::*)(void))&Lua_Client::IsDueling)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -466,6 +466,7 @@ public:
 	void SetItemCooldown(uint32 item_id, uint32 in_time);
 	uint32 GetItemCooldown(uint32 item_id);
 	void UseAugmentContainer(int container_slot);
+	bool IsAutoFireEnabled();
 
 	void ApplySpell(int spell_id);
 	void ApplySpell(int spell_id, int duration);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -2897,6 +2897,11 @@ void Perl_Client_UseAugmentContainer(Client* self, int container_slot)
 	self->UseAugmentContainer(container_slot);
 }
 
+bool Perl_Client_IsAutoFireEnabled(Client* self)
+{
+	return self->AutoFireEnabled();
+}
+
 void perl_register_client()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3159,6 +3164,7 @@ void perl_register_client()
 	package.add("IncreaseSkill", (void(*)(Client*, int))&Perl_Client_IncreaseSkill);
 	package.add("IncreaseSkill", (void(*)(Client*, int, int))&Perl_Client_IncreaseSkill);
 	package.add("IncrementAA", &Perl_Client_IncrementAA);
+	package.add("IsAutoFireEnabled", &Perl_Client_IsAutoFireEnabled);
 	package.add("IsBecomeNPC", &Perl_Client_IsBecomeNPC);
 	package.add("IsCrouching", &Perl_Client_IsCrouching);
 	package.add("IsDueling", &Perl_Client_IsDueling);


### PR DESCRIPTION
# Perl
- Add `$client->IsAutoFireEnabled()`.

# Lua
- Add `client:IsAutoFireEnabled()`.

# Notes
- Allows operators to check if a client has auto fire enabled.