### PR TITLE
[Bots] Verify Group Integrity during Bot::AddBotToGroup

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -4565,6 +4565,7 @@ bool Bot::AddBotToGroup(Bot* bot, Group* group) {
 						group->SendUpdate(groupActUpdate, TempLeader);
 					}
 				}
+				group->VerifyGroup();
 				Result = true;
 			}
 		}


### PR DESCRIPTION
**What:** This PR aims to ensure the Bots Group is in a valid state when being joined. these checks are already being performed on Bot::LoadAndSpawnAllZonedBots, but not all scenarios are covered such as Bot group autospawn functionality, and regular invites.

**Why:**

Numerous crashes are being seen caused likely by dangling Group member pointers. This can be seen in the following crashes where we check if the pointer is nullptr, pointer is not null, and yet we still crash when trying to call a member function:

http://spire.akkadius.com/dev/release/22.4.2?id=691
http://spire.akkadius.com/dev/release/22.4.2?id=690
http://spire.akkadius.com/dev/release/22.4.2?id=709