### PR TITLE
[Pathing] Improve roambox logic

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -2240,16 +2240,16 @@ void Bot::AI_Bot_Init()
 	AIautocastspell_timer.reset(nullptr);
 	casting_spell_AIindex = static_cast<uint8>(AIBot_spells.size());
 
-	roambox_max_x = 0;
-	roambox_max_y = 0;
-	roambox_min_x = 0;
-	roambox_min_y = 0;
-	roambox_distance = 0;
-	roambox_destination_x = 0;
-	roambox_destination_y = 0;
-	roambox_destination_z = 0;
-	roambox_min_delay = 2500;
-	roambox_delay = 2500;
+	m_roambox.max_x     = 0;
+	m_roambox.max_y     = 0;
+	m_roambox.min_x     = 0;
+	m_roambox.min_y     = 0;
+	m_roambox.distance  = 0;
+	m_roambox.dest_x    = 0;
+	m_roambox.dest_y    = 0;
+	m_roambox.dest_z    = 0;
+	m_roambox.delay     = 2500;
+	m_roambox.min_delay = 2500;
 }
 
 void Bot::SpellProcess() {

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -404,16 +404,16 @@ void NPC::AI_Init()
 	AIautocastspell_timer.reset(nullptr);
 	casting_spell_AIindex = static_cast<uint8>(AIspells.size());
 
-	roambox_max_x = 0;
-	roambox_max_y = 0;
-	roambox_min_x = 0;
-	roambox_min_y = 0;
-	roambox_distance = 0;
-	roambox_destination_x = 0;
-	roambox_destination_y = 0;
-	roambox_destination_z = 0;
-	roambox_min_delay = 2500;
-	roambox_delay = 2500;
+	m_roambox.max_x     = 0;
+	m_roambox.max_y     = 0;
+	m_roambox.min_x     = 0;
+	m_roambox.min_y     = 0;
+	m_roambox.distance  = 0;
+	m_roambox.dest_x    = 0;
+	m_roambox.dest_y    = 0;
+	m_roambox.dest_z    = 0;
+	m_roambox.delay     = 2500;
+	m_roambox.min_delay = 2500;
 }
 
 void Client::AI_Init()
@@ -1592,170 +1592,9 @@ void NPC::AI_DoMovement() {
 		return;
 	}
 
-	/**
-	 * Roambox logic sets precedence
-	 */
-	if (roambox_distance > 0) {
-
-		// Check if we're already moving to a WP
-		// If so, if we're not moving we have arrived and need to set delay
-
-		if (GetCWP() == EQ::WaypointStatus::RoamBoxPauseInProgress && !IsMoving()) {
-			// We have arrived
-
-			int roambox_move_delay = EQ::ClampLower(GetRoamboxDelay(), GetRoamboxMinDelay());
-			int move_delay_max     = (roambox_move_delay > 0 ? roambox_move_delay : (int) GetRoamboxMinDelay() * 4);
-			int random_timer       = RandomTimer(
-				GetRoamboxMinDelay(),
-				move_delay_max
-			);
-
-			LogNPCRoamBoxDetail(
-				"({}) Timer calc | random_timer [{}] roambox_move_delay [{}] move_min [{}] move_max [{}]",
-				GetCleanName(),
-				random_timer,
-				roambox_move_delay,
-				(int) GetRoamboxMinDelay(),
-				move_delay_max
-			);
-
-			time_until_can_move = Timer::GetCurrentTime() + random_timer;
-			SetCurrentWP(0);
-			return;
-		}
-
-		// Set a new destination
-		if (!IsMoving() && time_until_can_move < Timer::GetCurrentTime()) {
-
-			// make several attempts to find a valid next move in the box
-			bool can_path = false;
-			for (int i = 0; i < 10; i++) {
-				auto move_x      = static_cast<float>(zone->random.Real(-roambox_distance, roambox_distance));
-				auto move_y      = static_cast<float>(zone->random.Real(-roambox_distance, roambox_distance));
-				auto requested_x = EQ::Clamp((GetX() + move_x), roambox_min_x, roambox_max_x);
-				auto requested_y = EQ::Clamp((GetY() + move_y), roambox_min_y, roambox_max_y);
-				auto requested_z = GetGroundZ(requested_x, requested_y);
-
-				std::vector<float> heights = {0, 250, -250};
-				for (auto &h: heights) {
-					if (CheckLosFN(requested_x, requested_y, requested_z + h, GetSize())) {
-						LogNPCRoamBox(
-							"[{}] Found line of sight to path attempt [{}] at height [{}]",
-							GetCleanName(),
-							i,
-							h
-						);
-						can_path = true;
-						break;
-					}
-				}
-
-				if (!can_path) {
-					LogNPCRoamBox(
-						"[{}] | Failed line of sight to path attempt [{}]",
-						GetCleanName(),
-						i
-					);
-					continue;
-				}
-
-				roambox_destination_x = requested_x;
-				roambox_destination_y = requested_y;
-
-				/**
-				 * If our roambox was configured with large distances, chances of hitting the min or max end of
-				 * the clamp is high, this causes NPC's to gather on the border of a box, to reduce clustering
-				 * either lower the roambox distance or the code will do a simple random between min - max when it
-				 * hits the min or max of the clamp
-				 */
-				if (roambox_destination_x == roambox_min_x || roambox_destination_x == roambox_max_x) {
-					roambox_destination_x = static_cast<float>(zone->random.Real(roambox_min_x, roambox_max_x));
-				}
-
-				if (roambox_destination_y == roambox_min_y || roambox_destination_y == roambox_max_y) {
-					roambox_destination_y = static_cast<float>(zone->random.Real(roambox_min_y, roambox_max_y));
-				}
-
-				/**
-				 * If mob was not spawned in water, let's not randomly roam them into water
-				 * if the roam box was sloppily configured
-				 */
-				if (!GetWasSpawnedInWater()) {
-					roambox_destination_z = GetGroundZ(roambox_destination_x, roambox_destination_y);
-					if (zone->HasMap() && zone->HasWaterMap()) {
-						auto position = glm::vec3(
-							roambox_destination_x,
-							roambox_destination_y,
-							roambox_destination_z
-						);
-
-						/**
-						 * If someone brought us into water when we naturally wouldn't path there, return to spawn
-						 */
-						if (zone->watermap->InLiquid(position) && zone->watermap->InLiquid(m_Position)) {
-							roambox_destination_x = m_SpawnPoint.x;
-							roambox_destination_y = m_SpawnPoint.y;
-						}
-
-						if (zone->watermap->InLiquid(position)) {
-							LogNPCRoamBoxDetail("[{}] | My destination is in water and I don't belong there!", GetCleanName());
-
-							return;
-						}
-					}
-				}
-				else { // Mob was in water, make sure new spot is in water also
-					roambox_destination_z = m_Position.z;
-					auto position = glm::vec3(
-						roambox_destination_x,
-						roambox_destination_y,
-						m_Position.z + 15
-					);
-					if (zone->HasWaterMap() && !zone->watermap->InLiquid(position)) {
-						roambox_destination_x = m_SpawnPoint.x;
-						roambox_destination_y = m_SpawnPoint.y;
-						roambox_destination_z = m_SpawnPoint.z;
-					}
-				}
-
-				LogNPCRoamBox(
-					"[{}] | Pathing to [{}] [{}] [{}]",
-					GetCleanName(),
-					roambox_destination_x,
-					roambox_destination_y,
-					roambox_destination_z
-				);
-
-				LogNPCRoamBox(
-					"NPC ({}) distance [{}] X (min/max) [{} / {}] Y (min/max) [{} / {}] | Dest x/y/z [{} / {} / {}]",
-					GetCleanName(),
-					roambox_distance,
-					roambox_min_x,
-					roambox_max_x,
-					roambox_min_y,
-					roambox_max_y,
-					roambox_destination_x,
-					roambox_destination_y,
-					roambox_destination_z
-				);
-
-				if (can_path) {
-					SetCurrentWP(EQ::WaypointStatus::RoamBoxPauseInProgress);
-					NavigateTo(roambox_destination_x, roambox_destination_y, roambox_destination_z);
-					return;
-				}
-			}
-
-			// failed to find path, reset timer
-			int roambox_move_delay = EQ::ClampLower(GetRoamboxDelay(), GetRoamboxMinDelay());
-			int move_delay_max     = (roambox_move_delay > 0 ? roambox_move_delay : (int) GetRoamboxMinDelay() * 4);
-			int random_timer       = RandomTimer(
-				GetRoamboxMinDelay(),
-				move_delay_max
-			);
-			time_until_can_move = Timer::GetCurrentTime() + random_timer;
-		}
-
+	// Roambox logic sets precedence
+	if (m_roambox.distance > 0) {
+		HandleRoambox();
 		return;
 	}
 	else if (roamer) {

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -80,6 +80,19 @@ struct AISpellsVar_Struct {
 	uint8	idle_beneficial_chance;
 };
 
+struct Roambox {
+	float  max_x;
+	float  max_y;
+	float  min_x;
+	float  min_y;
+	float  distance;
+	float  dest_x;
+	float  dest_y;
+	float  dest_z;
+	uint32 delay;
+	uint32 min_delay;
+};
+
 class SwarmPet;
 class Client;
 class Group;
@@ -538,6 +551,8 @@ public:
 
 protected:
 
+	void HandleRoambox();
+
 	const NPCType*	NPCTypedata;
 	NPCType*	NPCTypedata_ours;	//special case for npcs with uniquely created data.
 
@@ -635,16 +650,8 @@ protected:
 	glm::vec4 m_GuardPoint;
 	glm::vec4 m_GuardPointSaved;
 	EmuAppearance guard_anim;
-	float roambox_max_x;
-	float roambox_max_y;
-	float roambox_min_x;
-	float roambox_min_y;
-	float roambox_distance;
-	float roambox_destination_x;
-	float roambox_destination_y;
-	float roambox_destination_z;
-	uint32 roambox_delay;
-	uint32 roambox_min_delay;
+
+	Roambox m_roambox = {};
 
 	uint16	skills[EQ::skills::HIGHEST_SKILL + 1];
 

--- a/zone/waypoints.cpp
+++ b/zone/waypoints.cpp
@@ -66,14 +66,14 @@ void NPC::AI_SetRoambox(
 	uint32 min_delay
 )
 {
-	roambox_distance      = distance;
-	roambox_max_x         = max_x;
-	roambox_min_x         = min_x;
-	roambox_max_y         = max_y;
-	roambox_min_y         = min_y;
-	roambox_destination_x = roambox_max_x + 1; // this will trigger a recalc
-	roambox_delay         = delay;
-	roambox_min_delay     = min_delay;
+	m_roambox.distance  = distance;
+	m_roambox.max_x     = max_x;
+	m_roambox.min_x     = min_x;
+	m_roambox.max_y     = max_y;
+	m_roambox.min_y     = min_y;
+	m_roambox.dest_x    = max_x + 1; // this will trigger a recalc
+	m_roambox.delay     = delay;
+	m_roambox.min_delay = min_delay;
 }
 
 void NPC::DisplayWaypointInfo(Client *client) {


### PR DESCRIPTION
### What

This improves roambox logic to have a little bit more intelligence and in many ways feel more natural

* Roamboxes will make up to 10 attempts to find a valid x,y,z within the box before waiting for next interval
* Roamboxes will now use LOS checks to determine a destination with pillar search
* Roamboxes will do a "pillar search" for valid line of sight to the requested x,y to try to attempt to path. This means, instead of just doing line of sight at the current Z of the NPC, it will attempt (current_z - 250) and (current_z + 250) with LOS checks. This solves for the scenario where when in a pit and you try to LOS against the best Z of a X/Y just over a slope, the NPC will not be able to see it, however if you add 250 degrees to it, the NPC should be able to see above that point. This should still prevent cases where an NPC would try to path outside of a wall or somewhere it clearly cannot get to

**Pit Distribution Test**

All NPC's were spawned at the same spot

Initial spawn

![image](https://user-images.githubusercontent.com/3319450/220841240-9845c7d7-5a07-4952-bf52-410a65fd3d29.png)

1 minute after spawn

![image](https://user-images.githubusercontent.com/3319450/220840470-fea2d1f5-bc98-4c57-8f04-88bdf8a6dbe6.png)

Few minutes after spawn

![image](https://user-images.githubusercontent.com/3319450/220840825-c1e4e2b9-15c7-4f37-bae3-9e3397413b90.png)

**Map Escape Prevention Test**

NPC's spawned on top of a wall, the test here is to prevent NPC's from just mindlessly roaming outside of the map. All NPC's stay well within the boundaries

![image](https://user-images.githubusercontent.com/3319450/220841101-390a7249-5e26-462f-94aa-d5226a9edb0b.png)

![image](https://user-images.githubusercontent.com/3319450/220841305-5c409e25-3856-4d53-8c48-e8c36e03cb79.png)

