### PR TITLE
[Player Events] Add QS processing, mutex tweaks

### DIFF
--- a/common/events/player_event_logs.cpp
+++ b/common/events/player_event_logs.cpp
@@ -140,10 +140,6 @@ void PlayerEventLogs::AddToQueue(const PlayerEventLogsRepository::PlayerEventLog
 	m_batch_queue_lock.lock();
 	m_record_batch_queue.emplace_back(log);
 	m_batch_queue_lock.unlock();
-
-	if (m_record_batch_queue.size() >= RuleI(Logging, BatchPlayerEventProcessChunkSize)) {
-		ProcessBatchQueue();
-	}
 }
 
 // fills common event data in the SendEvent function
@@ -610,7 +606,7 @@ std::string PlayerEventLogs::GetDiscordPayloadFromEvent(const PlayerEvent::Playe
 // general process function, used in world or QS depending on rule Logging:PlayerEventsQSProcess
 void PlayerEventLogs::Process()
 {
-	if (m_process_batch_events_timer.Check()) {
+	if (m_process_batch_events_timer.Check() || m_record_batch_queue.size() >= RuleI(Logging, BatchPlayerEventProcessChunkSize)) {
 		ProcessBatchQueue();
 	}
 

--- a/common/events/player_event_logs.cpp
+++ b/common/events/player_event_logs.cpp
@@ -607,7 +607,7 @@ std::string PlayerEventLogs::GetDiscordPayloadFromEvent(const PlayerEvent::Playe
 	return payload;
 }
 
-// general process function, used in world or UCS depending on rule Logging:PlayerEventsQSProcess
+// general process function, used in world or QS depending on rule Logging:PlayerEventsQSProcess
 void PlayerEventLogs::Process()
 {
 	if (m_process_batch_events_timer.Check()) {

--- a/queryserv/queryserv.cpp
+++ b/queryserv/queryserv.cpp
@@ -33,6 +33,7 @@
 #include "worldserver.h"
 #include "../common/path_manager.h"
 #include "../common/zone_store.h"
+#include "../common/events/player_event_logs.h"
 #include <list>
 #include <signal.h>
 #include <thread>
@@ -47,6 +48,7 @@ WorldServer           *worldserver = 0;
 EQEmuLogSys           LogSys;
 PathManager           path;
 ZoneStore             zone_store;
+PlayerEventLogs       player_event_logs;
 
 void CatchSignal(int sig_num)
 {
@@ -106,6 +108,9 @@ int main()
 	/* Load Looking For Guild Manager */
 	lfguildmanager.LoadDatabase();
 
+	Timer player_event_process_timer(1000);
+	player_event_logs.SetDatabase(&database)->Init();
+
 	auto loop_fn = [&](EQ::Timer* t) {
 		Timer::SetCurrentTime();
 
@@ -116,6 +121,10 @@ int main()
 
 		if (LFGuildExpireTimer.Check()) {
 			lfguildmanager.ExpireEntries();
+		}
+
+		if (player_event_process_timer.Check()) {
+			player_event_logs.Process();
 		}
 	};
 

--- a/queryserv/worldserver.cpp
+++ b/queryserv/worldserver.cpp
@@ -29,6 +29,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include "lfguild.h"
 #include "queryservconfig.h"
 #include "worldserver.h"
+#include "../common/events/player_events.h"
+#include "../common/events/player_event_logs.h"
 #include <iomanip>
 #include <iostream>
 #include <stdarg.h>
@@ -87,6 +89,17 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 {
 	switch (opcode) {
 		case 0: {
+			break;
+		}
+		case ServerOP_PlayerEvent: {
+			auto                         n = PlayerEvent::PlayerEventContainer{};
+			auto                         s = (ServerSendPlayerEvent_Struct *) p.Data();
+			EQ::Util::MemoryStreamReader ss(s->cereal_data, s->cereal_size);
+			cereal::BinaryInputArchive   archive(ss);
+			archive(n);
+
+			player_event_logs.AddToQueue(n.player_event_log);
+
 			break;
 		}
 		case ServerOP_KeepAlive: {

--- a/ucs/ucs.cpp
+++ b/ucs/ucs.cpp
@@ -179,8 +179,6 @@ int main() {
 	std::signal(SIGKILL, CatchSignal);
 	std::signal(SIGSEGV, CatchSignal);
 
-	std::thread(PlayerEventQueueListener).detach();
-
 	worldserver = new WorldServer;
 
 	// uncomment to simulate timed crash for catching SIGSEV

--- a/ucs/ucs.cpp
+++ b/ucs/ucs.cpp
@@ -179,6 +179,8 @@ int main() {
 	std::signal(SIGKILL, CatchSignal);
 	std::signal(SIGSEGV, CatchSignal);
 
+	std::thread(PlayerEventQueueListener).detach();
+
 	worldserver = new WorldServer;
 
 	// uncomment to simulate timed crash for catching SIGSEV


### PR DESCRIPTION
### What

* Implement processing in QS (Apparently I had forgotten to hook this up)
* Remove player event processor from its own thread and bring into main thread
* Revert dbcore mutex changes for now to original mutex usage

### QS Processing

Proof given `Logging:PlayerEventsQSProcess` is enabled

![image](https://user-images.githubusercontent.com/3319450/220852713-f15b73af-d36a-461b-a1aa-c3f5c475d0a6.png)
