### PR TITLE
[Doors] Fix doors triggering invalid zone fetches of dest_zone of "none"

### DIFF
--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -54,11 +54,10 @@ Doors::Doors(const DoorsRepository::Doors &door) :
 	strn0cpy(m_destination_zone_name, door.dest_zone.c_str(), sizeof(m_destination_zone_name));
 
 	// destination helpers
-	std::string destination_zone = m_destination_zone_name;
-	if (Strings::ToLower(destination_zone) != "none" && !destination_zone.empty()) {
+	if (Strings::ToLower(door.dest_zone) != "none" && !door.dest_zone.empty()) {
 		m_has_destination_zone = true;
 	}
-	if (Strings::ToLower(destination_zone) == Strings::ToLower(door.zone)) {
+	if (Strings::ToLower(door.dest_zone) == Strings::ToLower(door.zone)) {
 		m_same_destination_zone = true;
 	}
 

--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -53,6 +53,15 @@ Doors::Doors(const DoorsRepository::Doors &door) :
 	strn0cpy(m_door_name, door.name.c_str(), sizeof(m_door_name));
 	strn0cpy(m_destination_zone_name, door.dest_zone.c_str(), sizeof(m_destination_zone_name));
 
+	// destination helpers
+	std::string destination_zone = m_destination_zone_name;
+	if (Strings::ToLower(destination_zone) != "none" && !destination_zone.empty()) {
+		m_has_destination_zone = true;
+	}
+	if (Strings::ToLower(destination_zone) == Strings::ToLower(door.zone)) {
+		m_same_destination_zone = true;
+	}
+
 	m_database_id             = door.id;
 	m_door_id                 = door.doorid;
 	m_incline                 = door.incline;
@@ -450,7 +459,7 @@ void Doors::HandleClick(Client *sender, uint8 trigger)
 			m_close_timer.Start();
 		}
 
-		if (strncmp(m_destination_zone_name, "NONE", strlen("NONE")) == 0) {
+		if (!HasDestinationZone()) {
 			SetOpenState(true);
 		}
 	}
@@ -497,19 +506,15 @@ void Doors::HandleClick(Client *sender, uint8 trigger)
 		}
 	}
 
-	/**
-	 * Teleport door
-	 */
-	if (((m_open_type == 57) || (m_open_type == 58)) &&
-		(strncmp(m_destination_zone_name, "NONE", strlen("NONE")) != 0)) {
+	// teleport door
+	if (((m_open_type == 57) || (m_open_type == 58)) && HasDestinationZone()) {
+		bool has_key_required = (required_key_item && ((required_key_item == player_key) || sender->GetGM()));
 
-		/**
-		 * If click destination is same zone and doesn't require a key
-		 */
-		if ((strncmp(m_destination_zone_name, m_zone_name, strlen(m_zone_name)) == 0) && (!required_key_item)) {
+		if (IsDestinationZoneSame() && (!required_key_item)) {
 			if (!disable_add_to_key_ring) {
 				sender->KeyRingAdd(player_key);
 			}
+
 			sender->MovePC(
 				zone->GetZoneID(),
 				zone->GetInstanceID(),
@@ -519,14 +524,7 @@ void Doors::HandleClick(Client *sender, uint8 trigger)
 				m_destination.w
 			);
 		}
-			/**
-			 * If requires a key
-			 */
-		else if (
-			(!IsDoorOpen() || m_open_type == 58) &&
-			(required_key_item && ((required_key_item == player_key) || sender->GetGM()))
-			) {
-
+		else if ((!IsDoorOpen() || m_open_type == 58) && has_key_required) {
 			if (!disable_add_to_key_ring) {
 				sender->KeyRingAdd(player_key);
 			}
@@ -895,4 +893,14 @@ float Doors::GetZ()
 float Doors::GetHeading()
 {
 	return m_position.w;
+}
+
+bool Doors::HasDestinationZone() const
+{
+	return m_has_destination_zone;
+}
+
+bool Doors::IsDestinationZoneSame() const
+{
+	return m_same_destination_zone;
 }

--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -54,10 +54,11 @@ Doors::Doors(const DoorsRepository::Doors &door) :
 	strn0cpy(m_destination_zone_name, door.dest_zone.c_str(), sizeof(m_destination_zone_name));
 
 	// destination helpers
-	if (Strings::ToLower(door.dest_zone) != "none" && !door.dest_zone.empty()) {
+	if (!door.dest_zone.empty() && Strings::ToLower(door.dest_zone) != "none" && !door.dest_zone.empty()) {
 		m_has_destination_zone = true;
 	}
-	if (Strings::ToLower(door.dest_zone) == Strings::ToLower(door.zone)) {
+	if (!door.dest_zone.empty() && !door.zone.empty() &&
+		Strings::ToLower(door.dest_zone) == Strings::ToLower(door.zone)) {
 		m_same_destination_zone = true;
 	}
 

--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -57,8 +57,7 @@ Doors::Doors(const DoorsRepository::Doors &door) :
 	if (!door.dest_zone.empty() && Strings::ToLower(door.dest_zone) != "none" && !door.dest_zone.empty()) {
 		m_has_destination_zone = true;
 	}
-	if (!door.dest_zone.empty() && !door.zone.empty() &&
-		Strings::ToLower(door.dest_zone) == Strings::ToLower(door.zone)) {
+	if (!door.dest_zone.empty() && !door.zone.empty() && Strings::EqualFold(door.dest_zone, door.zone)) {
 		m_same_destination_zone = true;
 	}
 

--- a/zone/doors.h
+++ b/zone/doors.h
@@ -72,8 +72,8 @@ public:
 
 private:
 
-	bool      m_has_destination_zone;
-	bool      m_same_destination_zone;
+	bool      m_has_destination_zone = false;
+	bool      m_same_destination_zone = false;
 	uint32    m_database_id;
 	uint8     m_door_id;
 	char      m_zone_name[32];

--- a/zone/doors.h
+++ b/zone/doors.h
@@ -67,8 +67,13 @@ public:
 	float GetZ();
 	float GetHeading();
 
+	bool HasDestinationZone() const;
+	bool IsDestinationZoneSame() const;
+
 private:
 
+	bool      m_has_destination_zone;
+	bool      m_same_destination_zone;
 	uint32    m_database_id;
 	uint8     m_door_id;
 	char      m_zone_name[32];


### PR DESCRIPTION
### What

@noudess reported his zone was spamming

```
 Zone |    Info    | operator() New client from [192.168.0.5:62944] -- [paineel] (Paineel) inst_id [0]
 Zone |    Info    | GetZoneID Failed to get zone_name [none] -- [paineel] (Paineel) inst_id [0]
```

This sources from door logic when opening a door and the code is not properly checking for "none". The code makes attempts to do so but my guess is some sort of case sensitivity / collation is occurring with the database.

This PR attempts to clean some of that up and make the code a bit more readable.

This PR also needs to be tested to ensure no regressions