### PR TITLE
[Quest API] Fix EVENT_TIMER crash when entity is no longer available

### DIFF
--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -88,13 +88,13 @@ void QuestManager::Process() {
 	end = QTimerList.end();
 	while (cur != end) {
 		if (cur->Timer_.Enabled() && cur->Timer_.Check()) {
-			if (entity_list.IsMobInZone(cur->mob)) {
-				if (cur->mob && cur->mob->IsNPC()) {
+			if (cur->mob && entity_list.IsMobInZone(cur->mob)) {
+				if (cur->mob->IsNPC()) {
 					if (parse->HasQuestSub(cur->mob->GetNPCTypeID(), EVENT_TIMER)) {
 						parse->EventNPC(EVENT_TIMER, cur->mob->CastToNPC(), nullptr, cur->name, 0);
 					}
 				}
-				else if (cur->mob && cur->mob->IsEncounter()) {
+				else if (cur->mob->IsEncounter()) {
 					parse->EventEncounter(
 						EVENT_TIMER,
 						cur->mob->CastToEncounter()->GetEncounterName(),
@@ -103,13 +103,13 @@ void QuestManager::Process() {
 						nullptr
 					);
 				}
-				else if (cur->mob && cur->mob->IsClient()) {
+				else if (cur->mob->IsClient()) {
 					if (parse->PlayerHasQuestSub(EVENT_TIMER)) {
 						//this is inheriently unsafe if we ever make it so more than npc/client start timers
 						parse->EventPlayer(EVENT_TIMER, cur->mob->CastToClient(), cur->name, 0);
 					}
 				}
-				else if (cur->mob && cur->mob->IsBot()) {
+				else if (cur->mob->IsBot()) {
 					if (parse->BotHasQuestSub(EVENT_TIMER)) {
 						parse->EventBot(EVENT_TIMER, cur->mob->CastToBot(), nullptr, cur->name, 0);
 					}

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -88,19 +88,28 @@ void QuestManager::Process() {
 	end = QTimerList.end();
 	while (cur != end) {
 		if (cur->Timer_.Enabled() && cur->Timer_.Check()) {
-			if(entity_list.IsMobInZone(cur->mob)) {
-				if(cur->mob->IsNPC()) {
+			if (entity_list.IsMobInZone(cur->mob)) {
+				if (cur->mob && cur->mob->IsNPC()) {
 					if (parse->HasQuestSub(cur->mob->GetNPCTypeID(), EVENT_TIMER)) {
 						parse->EventNPC(EVENT_TIMER, cur->mob->CastToNPC(), nullptr, cur->name, 0);
 					}
-				} else if (cur->mob->IsEncounter()) {
-					parse->EventEncounter(EVENT_TIMER, cur->mob->CastToEncounter()->GetEncounterName(), cur->name, 0, nullptr);
-				} else if (cur->mob->IsClient()) {
+				}
+				else if (cur->mob && cur->mob->IsEncounter()) {
+					parse->EventEncounter(
+						EVENT_TIMER,
+						cur->mob->CastToEncounter()->GetEncounterName(),
+						cur->name,
+						0,
+						nullptr
+					);
+				}
+				else if (cur->mob && cur->mob->IsClient()) {
 					if (parse->PlayerHasQuestSub(EVENT_TIMER)) {
 						//this is inheriently unsafe if we ever make it so more than npc/client start timers
 						parse->EventPlayer(EVENT_TIMER, cur->mob->CastToClient(), cur->name, 0);
 					}
-				} else if (cur->mob->IsBot()) {
+				}
+				else if (cur->mob && cur->mob->IsBot()) {
 					if (parse->BotHasQuestSub(EVENT_TIMER)) {
 						parse->EventBot(EVENT_TIMER, cur->mob->CastToBot(), nullptr, cur->name, 0);
 					}
@@ -109,12 +118,15 @@ void QuestManager::Process() {
 				//we MUST reset our iterator since the quest could have removed/added any
 				//number of timers... worst case we have to check a bunch of timers twice
 				cur = QTimerList.begin();
-				end = QTimerList.end();	//dunno if this is needed, cant hurt...
-			} else {
+				end = QTimerList.end();    //dunno if this is needed, cant hurt...
+			}
+			else {
 				cur = QTimerList.erase(cur);
 			}
-		} else
+		}
+		else {
 			++cur;
+		}
 	}
 
 	auto cur_iter = STimerList.begin();


### PR DESCRIPTION
### What

Fix EVENT_TIMER crash when entity is no longer available

Checks pointer before trying to access

Crash originally reported by @noudess 

```
[02-23-2023 13:39:25] [Zone] [Crash] #0  0x00007f3ed0f2149f in __GI___wait4 (pid=32889, stat_loc=0x0, options=0, usage=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:30
[02-23-2023 13:39:25] [Zone] [Crash] #1  0x0000559269973d0b in print_trace () at /home/felinicity/server-013023/Server/common/crash.cpp:284
[02-23-2023 13:39:25] [Zone] [Crash] #2  <signal handler called>
[02-23-2023 13:39:25] [Zone] [Crash] #3  __strlen_sse2 () at ../sysdeps/x86_64/multiarch/strlen-vec.S:126
[02-23-2023 13:39:25] [Zone] [Crash] #4  0x00007f3ed14a55cb in Perl_sv_setpv () from /lib/x86_64-linux-gnu/libperl.so.5.34
[02-23-2023 13:39:25] [Zone] [Crash] #5  0x00005592692672b7 in Embperl::setstr (val=0x559200000000 <error: Cannot access memory at address 0x559200000000>, varname=<optimized out>, this=0x55926a76b2e0) at /home/felinicity/server-013023/Server/zone/embperl.h:130
[02-23-2023 13:39:25] [Zone] [Crash] #6  PerlembParser::ExportVar (this=0x55926aac4f50, pkgprefix=<optimized out>, varname=0x559269beda97 "timer", value=0x559200000000 <error: Cannot access memory at address 0x559200000000>) at /home/felinicity/server-013023/Server/zone/embparser.cpp:859
[02-23-2023 13:39:25] [Zone] [Crash] #7  0x0000559269270faa in PerlembParser::EventCommon (this=0x55926aac4f50, event=EVENT_TIMER, objid=0, data=0x559200000000 <error: Cannot access memory at address 0x559200000000>, npcmob=0x0, item_inst=0x0, spell=0x0, mob=0x55926c3b9860, extradata=0, global=true, extra_pointers=0x0) at /home/felinicity/server-013023/Server/zone/embparser.cpp:345
[02-23-2023 13:39:25] [Zone] [Crash] #8  0x00005592692711d1 in PerlembParser::EventGlobalPlayer (this=<optimized out>, evt=<optimized out>, client=<optimized out>, data=..., extra_data=<optimized out>, extra_pointers=<optimized out>) at /home/felinicity/server-013023/Server/zone/embparser.cpp:394
[02-23-2023 13:39:25] [Zone] [Crash] #9  0x0000559269825643 in QuestParserCollection::EventPlayer (this=this@entry=0x55926a60f770, evt=evt@entry=EVENT_TIMER, client=<optimized out>, data=<error: Cannot access memory at address 0x559200000000>, extra_data=extra_data@entry=0, extra_pointers=extra_pointers@entry=0x0) at /home/felinicity/server-013023/Server/zone/quest_parser_collection.cpp:361
[02-23-2023 13:39:25] [Zone] [Crash] #10 0x000055926980b5d4 in QuestManager::Process (this=0x55926a02c460 <quest_manager>) at /home/felinicity/server-013023/Server/zone/questmgr.cpp:97
[02-23-2023 13:39:25] [Zone] [Crash] #11 0x0000559269604ff2 in operator() (__closure=0x55926aadc090, t=<optimized out>) at /home/felinicity/server-013023/Server/zone/main.cpp:572
[02-23-2023 13:39:25] [Zone] [Crash] #12 0x000055926960569e in std::function<void (EQ::Timer*)>::operator()(EQ::Timer*) const (__args#0=<optimized out>, this=<optimized out>) at /usr/include/c++/11/bits/std_function.h:590
[02-23-2023 13:39:25] [Zone] [Crash] #13 EQ::Timer::Execute (this=<optimized out>) at /home/felinicity/server-013023/Server/zone/../common/net/../event/timer.h:61
[02-23-2023 13:39:25] [Zone] [Crash] #14 EQ::Timer::Start(unsigned long, bool)::{lambda(uv_timer_s*)#1}::operator()(uv_timer_s*) const (handle=<optimized out>, __closure=<optimized out>) at /home/felinicity/server-013023/Server/zone/../common/net/../event/timer.h:38
[02-23-2023 13:39:25] [Zone] [Crash] #15 EQ::Timer::Start(unsigned long, bool)::{lambda(uv_timer_s*)#1}::_FUN(uv_timer_s*) () at /home/felinicity/server-013023/Server/zone/../common/net/../event/timer.h:39
[02-23-2023 13:39:25] [Zone] [Crash] #16 0x0000559269b915a5 in uv__run_timers (loop=loop@entry=0x7f3ed0d0e7b0) at /home/felinicity/server-013023/Server/submodules/libuv/src/timer.c:178
[02-23-2023 13:39:25] [Zone] [Crash] #17 0x0000559269b94fda in uv_run (loop=0x7f3ed0d0e7b0, mode=UV_RUN_DEFAULT) at /home/felinicity/server-013023/Server/submodules/libuv/src/unix/core.c:393
[02-23-2023 13:39:25] [Zone] [Crash] #18 0x0000559268ec6267 in EQ::EventLoop::Run (this=<optimized out>) at /home/felinicity/server-013023/Server/zone/../common/net/../event/event_loop.h:25
```