### PR TITLE
[Bug Fix] Fix Beneficial Target of Target procs

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -4189,7 +4189,7 @@ void Mob::ExecWeaponProc(const EQ::ItemInstance *inst, uint16 spell_id, Mob *on,
 		twinproc = true;
 	}
 
-	if (IsBeneficialSpell(spell_id) && (!IsNPC() || (IsNPC() && CastToNPC()->GetInnateProcSpellID() != spell_id))) { // NPC innate procs don't take this path ever
+	if (IsBeneficialSpell(spell_id) && (!IsNPC() || (IsNPC() && CastToNPC()->GetInnateProcSpellID() != spell_id)) && spells[spell_id].target_type != ST_TargetsTarget) { // NPC innate procs don't take this path ever
 		SpellFinished(spell_id, this, EQ::spells::CastingSlot::Item, 0, -1, spells[spell_id].resist_difficulty, true, level_override);
 		if (twinproc) {
 			SpellFinished(spell_id, this, EQ::spells::CastingSlot::Item, 0, -1, spells[spell_id].resist_difficulty, true, level_override);


### PR DESCRIPTION
Beneficial Procs that were of Target Type ST_TargetsTarget were attempting to be cast on the Players Target, and not the Player's Targets Target, as we were passing the spells target as **this** for all Beneficial proc spells.

This changes the behavior to correctly pass the spell target as the players current target, which will result in the correct Target being used.
