### PR TITLE
[Pathing] More z-clip improvements, Wurm and Spectral Iksar race adjustments

### DIFF
--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -1073,9 +1073,15 @@ void Mob::AI_Process() {
 	if (engaged) {
 		if (IsNPC() && m_z_clip_check_timer.Check()) {
 			auto t = GetTarget();
-			if (t && DistanceNoZ(GetPosition(), t->GetPosition()) < 75 && std::abs(GetPosition().z - t->GetPosition().z) > 15 && !CheckLosFN(t)) {
-				GMMove(t->GetPosition().x, t->GetPosition().y, t->GetPosition().z, t->GetPosition().w);
-				FaceTarget(t);
+			if (t) {
+				float self_z   = GetZ() - GetZOffset();
+				float target_z = t->GetPosition().z - t->GetZOffset();
+				if (DistanceNoZ(GetPosition(), t->GetPosition()) < 75 &&
+					std::abs(self_z - target_z) >= 25 && !CheckLosFN(t)) {
+					float new_z = FindDestGroundZ(t->GetPosition());
+					GMMove(t->GetPosition().x, t->GetPosition().y, new_z + GetZOffset(), t->GetPosition().w, false);
+					FaceTarget(t);
+				}
 			}
 		}
 

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -159,6 +159,9 @@ NPC::NPC(const NPCType *npc_type_data, Spawn2 *in_respawn, const glm::vec4 &posi
 	if (race == RACE_LAVA_DRAGON_49) {
 		size = 5;
 	}
+	if (race == RACE_WURM_158) {
+		size = 15;
+	}
 
 	taunting             = false;
 	proximity            = nullptr;

--- a/zone/waypoints.cpp
+++ b/zone/waypoints.cpp
@@ -934,6 +934,7 @@ float Mob::GetZOffset() const {
 		case RACE_AMYGDALAN_663:
 			offset = 5.0f;
 			break;
+		case RACE_SPECTRAL_IKSAR_147:
 		case RACE_SANDMAN_664:
 			offset = 4.0f;
 			break;


### PR DESCRIPTION
### What

* Improve z-clipping logic, use Z offset calculations
* Z-clipping reset no longer resets NPC "guard" location (spawn point)
* Wurms (Race 158) as a fixed size model are now statically set to size 15 on spawn to make up for data issues
* Adjust Spectral Iksar (Race 147) offset causing an edge case where it would clip into the ground just below the surface mesh in Trakanon 

### Not returning to spawn point

Below the NPC does not return to spawn point after z-clip correction, this has been fixed.

https://user-images.githubusercontent.com/3319450/221330680-0506a994-a5ad-4025-9b66-d66ad6588a8d.mp4

#### Wurm Clipping

Wurm is falsely detected as under or below player simply because the size of the NPC is not taken into consideration in relation to the player. Both player and NPC offsets are taken into account and this no longer occurs.

![3be7b16806b5a4b8c68973a313c235c4-min](https://user-images.githubusercontent.com/3319450/221330554-131cc61d-7d9c-4a9d-84de-f10a0aa78f61.gif)

#### Spectral Iksar Issue

NPC's model offset was adjusted and after 10-20 minutes I've not observed any clips into the geometry below the top floor

![cda9f7eb1ba6e0c42769eca8d6fe20f7-min](https://user-images.githubusercontent.com/3319450/221330462-acadf786-5db9-4938-8dfb-2145a297d62b.gif)

