### PR TITLE
[Rules] Add ResurrectionEffectsBlock

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -434,7 +434,7 @@ RULE_BOOL(Spells, IllusionsAlwaysPersist, false, "Allows Illusions to persist be
 RULE_BOOL(Spells, UseItemCastMessage, false, "Enable to use the \"item begins to glow\" messages when casting from an item.")
 RULE_BOOL(Spells, TargetsTargetRequiresCombatRange, true, "Disable to remove combat range requirement from Target's Target Spell Target Type")
 RULE_BOOL(Spells, NPCBuffLevelRestrictions, false, "Impose BuffLevelRestrictions on NPCs if true")
-RULE_BOOL(Spells, ResurrectionEffectsBlock, false, "If enabled, resurrection effects cannot be overwritten.")
+RULE_BOOL(Spells, ResurrectionEffectsBlock, true, "If enabled, resurrection effects cannot be overwritten.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Combat)

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -434,6 +434,7 @@ RULE_BOOL(Spells, IllusionsAlwaysPersist, false, "Allows Illusions to persist be
 RULE_BOOL(Spells, UseItemCastMessage, false, "Enable to use the \"item begins to glow\" messages when casting from an item.")
 RULE_BOOL(Spells, TargetsTargetRequiresCombatRange, true, "Disable to remove combat range requirement from Target's Target Spell Target Type")
 RULE_BOOL(Spells, NPCBuffLevelRestrictions, false, "Impose BuffLevelRestrictions on NPCs if true")
+RULE_BOOL(Spells, ResurrectionEffectsBlock, false, "If enabled, resurrection effects cannot be overwritten.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Combat)

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3161,6 +3161,11 @@ int Mob::CheckStackConflict(uint16 spellid1, int caster_level1, uint16 spellid2,
 		}
 		if (sp2_value != sp1_value)
 			values_equal = false;
+
+		if (RuleB(Spells, ResurrectionEffectsBlock) && IsResurrectionEffects(spellid1)) {
+			LogSpells("ResurrectionEffectsBlock triggered -- [{}] is blocked by [{}]", sp2.name, sp1.name);
+			return -1;	// can't stack
+		}
 		//we dont return here... a better value on this one effect dosent mean they are
 		//all better...
 


### PR DESCRIPTION
Notes:

This adds the rule Spells:ResurrectionEffectsBlock that will prevent anything from overwriting Resurrection Sickness Effects. Currently they are able to be overwritten by certain spells.

Default state: Disabled/False.