### PR TITLE
[Bug Fix] Fix log messages when players join channel

### DIFF
--- a/ucs/chatchannel.cpp
+++ b/ucs/chatchannel.cpp
@@ -48,10 +48,10 @@ ChatChannel::ChatChannel(std::string inName, std::string inOwner, std::string in
 	m_moderated = false;
 
 	LogDebug(
-		"New ChatChannel created: Name: [{}], Owner: [{}], Password: [{}], MinStatus: [{}]",
-		m_name.c_str(),
-		m_owner.c_str(),
-		m_password.c_str(),
+		"New ChatChannel created: Name: [{}] Owner: [{}] Password: [{}] MinStatus: [{}]",
+		m_name,
+		m_owner,
+		m_password,
 		m_minimum_status
 	);
 

--- a/ucs/chatchannel.cpp
+++ b/ucs/chatchannel.cpp
@@ -667,7 +667,7 @@ ChatChannel *ChatChannelList::RemoveClientFromChannel(const std::string& in_chan
 	}
 
 	LogDebug("Client [{}] removed from channel [{}]. Channel is owned by {}. Command directed: {}", c->GetName(), channel_name, required_channel->GetOwnerName(), command_directed);
-	if (c->GetName() == required_channel->GetOwnerName() && command_directed) { // Check if the client that is leaving is the the channel owner
+	if (c->GetName() == required_channel->GetOwnerName() && command_directed) { // Check if the client that is leaving is the channel owner
 		LogDebug("Owner left the channel [{}], removing channel from database...", channel_name);
 		database.DeleteChatChannel(channel_name); // Remove the channel from the database.
 		LogDebug("Flagging [{}] channel as temporary...", channel_name);

--- a/ucs/clientlist.cpp
+++ b/ucs/clientlist.cpp
@@ -795,7 +795,7 @@ void Clientlist::ProcessOPMailCommand(Client *c, std::string command_string, boo
 			//Append saved channels to params
 			auto const savedChannels = database.CurrentPlayerChannels(c->GetName());
 			if (savedChannels.length() > 0) {
-				parameters = parameters + ", " + savedChannels;
+				parameters += fmt::format(", {}", savedChannels);
 			}
 			parameters = RemoveDuplicateChannels(parameters);
 		}

--- a/ucs/clientlist.cpp
+++ b/ucs/clientlist.cpp
@@ -793,9 +793,9 @@ void Clientlist::ProcessOPMailCommand(Client *c, std::string command_string, boo
 	case CommandJoin:
 		if (!command_directed) {
 			//Append saved channels to params
-			auto const savedChannels = database.CurrentPlayerChannels(c->GetName());
-			if (savedChannels.length() > 0) {
-				parameters += fmt::format(", {}", savedChannels);
+			const auto saved_channels = database.CurrentPlayerChannels(c->GetName());
+			if (saved_channels.length() > 0) {
+				parameters += fmt::format(", {}", saved_channels);
 			}
 			parameters = RemoveDuplicateChannels(parameters);
 		}

--- a/ucs/clientlist.cpp
+++ b/ucs/clientlist.cpp
@@ -794,8 +794,8 @@ void Clientlist::ProcessOPMailCommand(Client *c, std::string command_string, boo
 		if (!command_directed) {
 			//Append saved channels to params
 			const auto saved_channels = database.CurrentPlayerChannels(c->GetName());
-			if (saved_channels.length() > 0) {
-				parameters += fmt::format(", {}", saved_channels);
+			if (!saved_channels.empty()) {
+				parameters += fmt::format(", {}", Strings::Join(saved_channels, ", "));
 			}
 			parameters = RemoveDuplicateChannels(parameters);
 		}

--- a/ucs/clientlist.cpp
+++ b/ucs/clientlist.cpp
@@ -793,7 +793,10 @@ void Clientlist::ProcessOPMailCommand(Client *c, std::string command_string, boo
 	case CommandJoin:
 		if (!command_directed) {
 			//Append saved channels to params
-			parameters = parameters + ", " + database.CurrentPlayerChannels(c->GetName());
+			auto const savedChannels = database.CurrentPlayerChannels(c->GetName());
+			if (savedChannels.length() > 0) {
+				parameters = parameters + ", " + savedChannels;
+			}
 			parameters = RemoveDuplicateChannels(parameters);
 		}
 		c->JoinChannels(parameters, command_directed);

--- a/ucs/database.cpp
+++ b/ucs/database.cpp
@@ -346,6 +346,7 @@ std::vector<std::string> UCSDatabase::CurrentPlayerChannels(const std::string& p
 	for (auto &e: rows) {
 		channels.emplace_back(e.name);
 	}
+	LogDebug("Player [{}] has the following permanent channels saved to the database: [{}].", player_name, Strings::Join(channels, ", "));
 	return channels;
 }
 

--- a/ucs/database.cpp
+++ b/ucs/database.cpp
@@ -336,16 +336,16 @@ void UCSDatabase::DeleteChatChannel(const std::string& channel_name)
 	LogInfo("Deleting channel [{}] from the database.", channel_name);
 }
 
-std::string UCSDatabase::CurrentPlayerChannels(const std::string& player_name) {
-	int current_player_channel_count = CurrentPlayerChannelCount(player_name);
-	if (current_player_channel_count == 0) {
-		return "";
+std::vector<std::string> UCSDatabase::CurrentPlayerChannels(const std::string& player_name) {
+	auto rows = ChatchannelsRepository::GetWhere(*this,	fmt::format("`owner` = '{}' LIMIT 1", Strings::Escape(player_name)));
+	if (rows.empty()) {
+		return {};
 	}
-	const auto rquery = fmt::format("SELECT GROUP_CONCAT(`name` SEPARATOR ', ') FROM chatchannels WHERE `owner` = '{}'; ", Strings::Escape(player_name));
-	auto results = QueryDatabase(rquery);
-	auto row = results.begin();
-	std::string channels = row[0];
-	LogDebug("Player [{}] has the following permanent channels saved to the database: [{}].", player_name, channels);
+	std::vector<std::string> channels = {};
+	channels.reserve(rows.size());
+	for (auto &e: rows) {
+		channels.emplace_back(e.name);
+	}
 	return channels;
 }
 

--- a/ucs/database.cpp
+++ b/ucs/database.cpp
@@ -337,7 +337,7 @@ void UCSDatabase::DeleteChatChannel(const std::string& channel_name)
 }
 
 std::vector<std::string> UCSDatabase::CurrentPlayerChannels(const std::string& player_name) {
-	auto rows = ChatchannelsRepository::GetWhere(*this,	fmt::format("`owner` = '{}' LIMIT 1", Strings::Escape(player_name)));
+	auto rows = ChatchannelsRepository::GetWhere(*this,	fmt::format("`owner` = '{}'", Strings::Escape(player_name)));
 	if (rows.empty()) {
 		return {};
 	}
@@ -346,7 +346,7 @@ std::vector<std::string> UCSDatabase::CurrentPlayerChannels(const std::string& p
 	for (auto &e: rows) {
 		channels.emplace_back(e.name);
 	}
-	LogDebug("Player [{}] has the following permanent channels saved to the database: [{}].", player_name, Strings::Join(channels, ", "));
+	LogDebug("Player [{}] has the following [{}] permanent channels saved to the database: [{}].", player_name, rows.size(), Strings::Join(channels, ", "));
 	return channels;
 }
 

--- a/ucs/database.h
+++ b/ucs/database.h
@@ -52,7 +52,7 @@ public:
 	void SaveChatChannel(const std::string& channel_name, const std::string& channel_owner, const std::string& channel_password, const uint16& min_status);
 	void DeleteChatChannel(const std::string& channel_name);
 	int CurrentPlayerChannelCount(const std::string& player_name);
-	std::string CurrentPlayerChannels(const std::string& player_name);
+	std::vector<std::string> CurrentPlayerChannels(const std::string& player_name);
 	void GetAccountStatus(Client *c);
 	void SetChannelPassword(const std::string& channel_name, const std::string& password);
 	void SetChannelOwner(const std::string& channel_name, const std::string& owner);


### PR DESCRIPTION
Removes trailing commas/spaces from UCS log messages when no saved channels exist during load.