### PR TITLE
[Cleanup] Remove GetDamageMultiplier() from client.h

### DIFF
--- a/zone/client.h
+++ b/zone/client.h
@@ -1595,7 +1595,6 @@ public:
 	void SetAccountFlag(std::string flag, std::string val);
 	std::string GetAccountFlag(std::string flag);
 	void SetGMStatus(int16 new_status);
-	float GetDamageMultiplier(EQ::skills::SkillType how_long_has_this_been_missing);
 	void Consume(const EQ::ItemData *item, uint8 type, int16 slot, bool auto_consume);
 	void PlayMP3(const char* fname);
 	void ExpeditionSay(const char *str, int ExpID);


### PR DESCRIPTION
# Notes
- This is unused.