### PR TITLE
[Bots] Cleanup AI_IdleCastCheck Logic

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -2470,6 +2470,7 @@ void Bot::AI_Process()
 	}
 
 	// We also need a leash owner and follow mob (subset of primary AI criteria)
+	bot_group->VerifyGroup();
 	Client* leash_owner = (bot_group->GetLeader() && bot_group->GetLeader()->IsClient() ? bot_group->GetLeader()->CastToClient() : bot_owner);
 	if (!leash_owner) {
 		return;

--- a/zone/botspellsai.cpp
+++ b/zone/botspellsai.cpp
@@ -1303,8 +1303,7 @@ bool Bot::AI_IdleCastCheck() {
 
 		if (HasGroup() && GetGroup()->GetLeader() && GetGroup()->GetLeader()->IsClient()) {
 			test_against = GetGroup()->GetLeader()->CastToClient();
-		}
-		else if (GetOwner() && GetOwner()->IsClient()) {
+		} else if (GetOwner() && GetOwner()->IsClient()) {
 			test_against = GetOwner()->CastToClient();
 		}
 
@@ -1317,17 +1316,12 @@ bool Bot::AI_IdleCastCheck() {
 		// Healers WITHOUT pets will check if a heal is needed before buffing.
 		case CLERIC:
 		case PALADIN:
-		case RANGER:
-		case MONK:
-		case ROGUE:
-		case WARRIOR:
-		case BERSERKER: {
+		case RANGER: {
 			if (!entity_list.Bot_AICheckCloseBeneficialSpells(this, 100, BotAISpellRange, SpellType_Cure)) {
 				if (!AICastSpell(this, 100, SpellType_Heal)) {
 					if (!entity_list.Bot_AICheckCloseBeneficialSpells(this, 100, BotAISpellRange, SpellType_Heal)) {
 						if (!AICastSpell(this, 100, SpellType_Buff)) {
 							if (!entity_list.Bot_AICheckCloseBeneficialSpells(this, 100, BotAISpellRange, SpellType_Buff)) {
-								//
 							}
 						}
 					}
@@ -1337,13 +1331,42 @@ bool Bot::AI_IdleCastCheck() {
 			result = true;
 			break;
 		}
+		case MONK:
+		case ROGUE:
+		case WARRIOR:
+		case BERSERKER: {
+			if (!AICastSpell(this, 100, SpellType_Heal)) {
+				if (!AICastSpell(this, 100, SpellType_Buff)) {
+					if (!entity_list.Bot_AICheckCloseBeneficialSpells(this, 100, BotAISpellRange, SpellType_Buff)) {
+					}
+				}
+			}
+
+			result = true;
+			break;
+		}
 		// Pets class will first cast their pet, then buffs
-		case DRUID:
+
 		case MAGICIAN:
 		case SHADOWKNIGHT:
-		case SHAMAN:
 		case NECROMANCER:
-		case ENCHANTER:
+		case ENCHANTER: {
+			if (!AICastSpell(this, 100, SpellType_Pet)) {
+				if (!AICastSpell(GetPet(), 100, SpellType_Cure)) {
+					if (!AICastSpell(this, 100, SpellType_Buff)) {
+						if (!AICastSpell(GetPet(), 100, SpellType_Heal)) {
+							if (!entity_list.Bot_AICheckCloseBeneficialSpells(this, 100, BotAISpellRange, SpellType_Buff)) {
+							}
+						}
+					}
+				}
+			}
+
+			result = true;
+			break;
+		}
+		case DRUID:
+		case SHAMAN:
 		case BEASTLORD: {
 			if (!entity_list.Bot_AICheckCloseBeneficialSpells(this, 100, BotAISpellRange, SpellType_Cure)) {
 				if (!AICastSpell(this, 100, SpellType_Pet)) {

--- a/zone/botspellsai.cpp
+++ b/zone/botspellsai.cpp
@@ -1335,9 +1335,11 @@ bool Bot::AI_IdleCastCheck() {
 		case ROGUE:
 		case WARRIOR:
 		case BERSERKER: {
-			if (!AICastSpell(this, 100, SpellType_Heal)) {
-				if (!AICastSpell(this, 100, SpellType_Buff)) {
-					if (!entity_list.Bot_AICheckCloseBeneficialSpells(this, 100, BotAISpellRange, SpellType_Buff)) {
+			if (!AICastSpell(this, 100, SpellType_Cure)) {
+				if (!AICastSpell(this, 100, SpellType_Heal)) {
+					if (!AICastSpell(this, 100, SpellType_Buff)) {
+						if (!entity_list.Bot_AICheckCloseBeneficialSpells(this, 100, BotAISpellRange, SpellType_Buff)) {
+						}
 					}
 				}
 			}
@@ -1352,10 +1354,12 @@ bool Bot::AI_IdleCastCheck() {
 		case NECROMANCER:
 		case ENCHANTER: {
 			if (!AICastSpell(this, 100, SpellType_Pet)) {
-				if (!AICastSpell(GetPet(), 100, SpellType_Cure)) {
-					if (!AICastSpell(this, 100, SpellType_Buff)) {
-						if (!AICastSpell(GetPet(), 100, SpellType_Heal)) {
-							if (!entity_list.Bot_AICheckCloseBeneficialSpells(this, 100, BotAISpellRange, SpellType_Buff)) {
+				if (!AICastSpell(this, 100, SpellType_Cure)) {
+					if (!AICastSpell(GetPet(), 100, SpellType_Cure)) {
+						if (!AICastSpell(this, 100, SpellType_Buff)) {
+							if (!AICastSpell(GetPet(), 100, SpellType_Heal)) {
+								if (!entity_list.Bot_AICheckCloseBeneficialSpells(this, 100, BotAISpellRange, SpellType_Buff)) {
+								}
 							}
 						}
 					}
@@ -1388,16 +1392,12 @@ bool Bot::AI_IdleCastCheck() {
 		}
 		case WIZARD: { // This can eventually be move into the BEASTLORD case handler once pre-combat is fully implemented
 			if (pre_combat) {
-				if (!entity_list.Bot_AICheckCloseBeneficialSpells(this, 100, BotAISpellRange, SpellType_Cure)) {
-					if (!AICastSpell(this, 100, SpellType_Pet)) {
+				if (!AICastSpell(this, 100, SpellType_Pet)) {
+					if (!AICastSpell(this, 100, SpellType_Cure)) {
 						if (!AICastSpell(this, 100, SpellType_Heal)) {
-							if (!entity_list.Bot_AICheckCloseBeneficialSpells(this, 100, BotAISpellRange, SpellType_Heal)) {
-								if (!AICastSpell(this, 100, SpellType_Buff)) {
-									if (!AICastSpell(GetPet(), 100, SpellType_Heal)) {
-										if (!entity_list.Bot_AICheckCloseBeneficialSpells(this, 100, BotAISpellRange, SpellType_PreCombatBuff)) {
-											if (!entity_list.Bot_AICheckCloseBeneficialSpells(this, 100, BotAISpellRange, SpellType_Buff)) {
-											}
-										}
+							if (!AICastSpell(this, 100, SpellType_Buff)) {
+								if (!entity_list.Bot_AICheckCloseBeneficialSpells(this, 100, BotAISpellRange, SpellType_PreCombatBuff)) {
+									if (!entity_list.Bot_AICheckCloseBeneficialSpells(this, 100, BotAISpellRange, SpellType_Buff)) {
 									}
 								}
 							}
@@ -1406,15 +1406,11 @@ bool Bot::AI_IdleCastCheck() {
 				}
 			}
 			else {
-				if (!entity_list.Bot_AICheckCloseBeneficialSpells(this, 100, BotAISpellRange, SpellType_Cure)) {
+				if (!AICastSpell(this, 100, SpellType_Cure)) {
 					if (!AICastSpell(this, 100, SpellType_Pet)) {
 						if (!AICastSpell(this, 100, SpellType_Heal)) {
-							if (!entity_list.Bot_AICheckCloseBeneficialSpells(this, 100, BotAISpellRange, SpellType_Heal)) {
-								if (!AICastSpell(this, 100, SpellType_Buff)) {
-									if (!AICastSpell(GetPet(), 100, SpellType_Heal)) {
-										if (!entity_list.Bot_AICheckCloseBeneficialSpells(this, 100, BotAISpellRange, SpellType_Buff)) {
-										}
-									}
+							if (!AICastSpell(this, 100, SpellType_Buff)) {
+								if (!entity_list.Bot_AICheckCloseBeneficialSpells(this, 100, BotAISpellRange, SpellType_Buff)) {
 								}
 							}
 						}


### PR DESCRIPTION
Cleaned up Logic in AI_IdleCastCheck Logic to not be as wasteful (Melee classes don't heal others, either do pure int casters, cept pets, etc)

Also added bot_group->VerifyGroup(); to attempt to help with stability.

Bot::AI_IdleCastCheck will eventually need to be refactored when I have time, should be split off into additional methods.