### PR TITLE
[Bug Fix] Fix for Lore Components where component is returned.

### DIFF
--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -1866,11 +1866,11 @@ bool ZoneDatabase::DisableRecipe(uint32 recipe_id)
 bool Client::CheckTradeskillLoreConflict(int32 recipe_id)
 {
 	auto recipe_entries = TradeskillRecipeEntriesRepository::GetWhere(
-			content_db,
-			fmt::format(
-					"recipe_id = {} ORDER BY componentcount DESC",
-					recipe_id
-			)
+		content_db,
+		fmt::format(
+			"recipe_id = {} ORDER BY componentcount DESC",
+			recipe_id
+		)
 	);
 	if (recipe_entries.empty()) {
 		return false;
@@ -1878,22 +1878,22 @@ bool Client::CheckTradeskillLoreConflict(int32 recipe_id)
 
 	const EQ::ItemData* f_item_inst = nullptr;
 	const EQ::ItemData* e_item_inst = nullptr;
-	for (auto& f : recipe_entries) {
+	for (auto &f : recipe_entries) {
 		if (f.item_id) {
 			f_item_inst = database.GetItem(f.item_id);
-			for (auto &e: recipe_entries) {
+			for (auto &e : recipe_entries) {
 				if (e.item_id && f_item_inst && f_item_inst->LoreGroup != 0) {
 					e_item_inst = database.GetItem(e.item_id);
 					if (
 						e_item_inst &&
 						e_item_inst->LoreGroup != 0 &&
+						(
+							e.item_id == f.item_id ||
 							(
-								e.item_id == f.item_id ||
-								(
-									f_item_inst->LoreGroup > 0 &&
-									f_item_inst->LoreGroup == e_item_inst->LoreGroup
-								)
-							) &&
+								f_item_inst->LoreGroup > 0 &&
+								f_item_inst->LoreGroup == e_item_inst->LoreGroup
+							)
+						) &&
 						e.componentcount == 0 &&
 						f.componentcount > 0
 					) {
@@ -1901,10 +1901,12 @@ bool Client::CheckTradeskillLoreConflict(int32 recipe_id)
 					}
 				}
 			}
+
 			if (f_item_inst) {
 				if (f_item_inst->LoreGroup == 0 || f.componentcount > 0 || f.iscontainer) {
 					continue;
 				}
+
 				if (CheckLoreConflict(f_item_inst)) {
 					EQ::SayLinkEngine linker;
 					linker.SetLinkType(EQ::saylink::SayLinkItemData);

--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -1881,22 +1881,23 @@ bool Client::CheckTradeskillLoreConflict(int32 recipe_id)
 			if (f.componentcount > 0 && e.item_id == f.item_id && e.componentcount == 0) {
 				e.item_id = 0;
 			}
-			auto item_inst = database.GetItem(e.item_id);
-			if (item_inst) {
-				if (item_inst->LoreGroup >= 0 || e.componentcount > 0 || e.iscontainer) {
-					continue;
-				}
-				if (CheckLoreConflict(item_inst)) {
-					EQ::SayLinkEngine linker;
-					linker.SetLinkType(EQ::saylink::SayLinkItemData);
-					linker.SetItemData(item_inst);
-					auto item_link = linker.GenerateLink();
-					MessageString(Chat::Red, TRADESKILL_COMBINE_LORE, item_link.c_str());
-					return true;
-				}
+		}
+		auto item_inst = database.GetItem(f.item_id);
+		if (item_inst) {
+			if (item_inst->LoreGroup >= 0 || f.componentcount > 0 || f.iscontainer) {
+				continue;
+			}
+			if (CheckLoreConflict(item_inst)) {
+				EQ::SayLinkEngine linker;
+				linker.SetLinkType(EQ::saylink::SayLinkItemData);
+				linker.SetItemData(item_inst);
+				auto item_link = linker.GenerateLink();
+				MessageString(Chat::Red, TRADESKILL_COMBINE_LORE, item_link.c_str());
+				return true;
 			}
 		}
 	}
+
 	return false;
 }
 


### PR DESCRIPTION
This resolves issues seen with BiC quest line combines, where the item is returned on success, fail, salvage. However the recipe entries for each different return type are split between multiple rows. 

My previous PR was meant to fix the above, but was incorrect logic. my testing failed to find this, as the checks worked correctly on the first component if it was lore, not later components.

The correct implementation is to loop through all components first before performing any lore checks, allowing us to exclude any components that are lore, but have a separate row for return on success, fail, salvage.

Verified all previous use cases work as expected as well, meaning:

- Combine uses a lore container, which is returned.
- Combines that have a Lore Group component (Epic Lore Group, or other above 0) and return the same lore-group on success.
- Components are lore, and returned on success, fail, salvage (but in same row entry)
