### PR TITLE
[Bug Fix] Fix for Discipline Loading from Database causing issues with slot_ids

### DIFF
--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -814,20 +814,24 @@ bool ZoneDatabase::LoadCharacterLeadershipAA(uint32 character_id, PlayerProfile_
 }
 
 bool ZoneDatabase::LoadCharacterDisciplines(uint32 character_id, PlayerProfile_Struct* pp){
-	std::string query = StringFormat(
-		"SELECT				  "
-		"disc_id			  "
-		"FROM				  "
+	auto query = fmt::format(
+		"SELECT "
+		"disc_id, slot_id "
+		"FROM "
 		"`character_disciplines`"
-		"WHERE `id` = %u ORDER BY `slot_id`", character_id);
+		"WHERE `id` = {} ORDER BY `slot_id`", character_id);
 	auto results = database.QueryDatabase(query);
-	int i = 0;
 
+	if (!results.Success() || !results.RowCount()) {
+		return false;
+	}
+
+	int i = 0;
 	/* Initialize Disciplines */
 	memset(pp->disciplines.values, 0, (sizeof(pp->disciplines.values[0]) * MAX_PP_DISCIPLINES));
 	for (auto& row = results.begin(); row != results.end(); ++row) {
 		if (i < MAX_PP_DISCIPLINES)
-			pp->disciplines.values[i] = atoi(row[0]);
+			pp->disciplines.values[Strings::ToInt(row[1])] = atoi(row[0]);
         ++i;
     }
 	return true;

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -13,6 +13,7 @@
 #include "zonedb.h"
 #include "aura.h"
 #include "../common/repositories/criteria/content_filter_criteria.h"
+#include "../common/repositories/character_disciplines_repository.h"
 #include "../common/repositories/npc_types_repository.h"
 
 #include <ctime>
@@ -814,26 +815,27 @@ bool ZoneDatabase::LoadCharacterLeadershipAA(uint32 character_id, PlayerProfile_
 }
 
 bool ZoneDatabase::LoadCharacterDisciplines(uint32 character_id, PlayerProfile_Struct* pp){
-	auto query = fmt::format(
-		"SELECT "
-		"disc_id, slot_id "
-		"FROM "
-		"`character_disciplines`"
-		"WHERE `id` = {} ORDER BY `slot_id`", character_id);
-	auto results = database.QueryDatabase(query);
 
-	if (!results.Success() || !results.RowCount()) {
+	auto character_disciplines = CharacterDisciplinesRepository::GetWhere(
+		database, fmt::format(
+			"`id` = {} ORDER BY `slot_id`",
+			character_id
+		)
+	);
+
+	if (character_disciplines.empty()) {
 		return false;
 	}
 
 	int i = 0;
 	/* Initialize Disciplines */
 	memset(pp->disciplines.values, 0, (sizeof(pp->disciplines.values[0]) * MAX_PP_DISCIPLINES));
-	for (auto& row = results.begin(); row != results.end(); ++row) {
-		if (i < MAX_PP_DISCIPLINES)
-			pp->disciplines.values[Strings::ToInt(row[1])] = atoi(row[0]);
-        ++i;
-    }
+	for (auto& row : character_disciplines) {
+		if (i < MAX_PP_DISCIPLINES && IsValidSpell(row.disc_id)) {
+			pp->disciplines.values[row.slot_id] = row.disc_id;
+		}
+		++i;
+	}
 	return true;
 }
 


### PR DESCRIPTION
If a Server Operator attempts to cleanup disciplines after they are learned from the database, they may encounter issues after the fact when players try to learn new disciplines due to how we were loading data into the Disciplines_Struct.

We were loading data in with no accounting for Slot_id, so when learning a new Discipline if an older row was deleted the Struct would not match up with the correct Slot_id numbers, causing players to overwrite disciplines they have already learned.

This allows a null entry to be added to the Disciplines_Struct.disciplines.value, so when we learn a new discipline it'll find the null and insert to the slot that is free, and not try to insert at the end.