### PR TITLE
[Fix] Fix issue where quest saylink responses would occur before the NPC's response

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -1192,10 +1192,6 @@ void Client::ChannelMessageReceived(uint8 chan_num, uint8 language, uint8 lang_s
 			sender = GetPet();
 		}
 
-		if (!is_silent) {
-			entity_list.ChannelMessage(sender, chan_num, language, lang_skill, message);
-		}
-
 		if (parse->PlayerHasQuestSub(EVENT_SAY)) {
 			parse->EventPlayer(EVENT_SAY, this, message, language);
 		}
@@ -1251,6 +1247,11 @@ void Client::ChannelMessageReceived(uint8 chan_num, uint8 language, uint8 lang_s
 				}
 			}
 		}
+
+		if (!is_silent) {
+			entity_list.ChannelMessage(sender, chan_num, language, lang_skill, message);
+		}
+
 		break;
 	}
 	case ChatChannel_UCSRelay:

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -1192,6 +1192,10 @@ void Client::ChannelMessageReceived(uint8 chan_num, uint8 language, uint8 lang_s
 			sender = GetPet();
 		}
 
+		if (!is_silent) {
+			entity_list.ChannelMessage(sender, chan_num, language, lang_skill, message);
+		}
+
 		if (parse->PlayerHasQuestSub(EVENT_SAY)) {
 			parse->EventPlayer(EVENT_SAY, this, message, language);
 		}
@@ -1247,11 +1251,6 @@ void Client::ChannelMessageReceived(uint8 chan_num, uint8 language, uint8 lang_s
 				}
 			}
 		}
-
-		if (!is_silent) {
-			entity_list.ChannelMessage(sender, chan_num, language, lang_skill, message);
-		}
-
 		break;
 	}
 	case ChatChannel_UCSRelay:

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -8737,11 +8737,11 @@ void Client::Handle_OP_ItemLinkClick(const EQApplicationPacket *app)
 		}
 
 		if (!response.empty()) {
-			ChannelMessageReceived(ChatChannel_Say, 0, 100, response.c_str(), nullptr, true);
-
 			if (!silentsaylink) {
 				Message(Chat::LightGray, "You say, '%s'", response.c_str());
 			}
+
+			ChannelMessageReceived(ChatChannel_Say, 0, 100, response.c_str(), nullptr, true);
 
 			return;
 		}


### PR DESCRIPTION
### What

Fix issue where quest saylink responses would occur before the NPC's response

### Before

![image](https://user-images.githubusercontent.com/3319450/221735429-d3995aec-3759-42f8-8874-10af3f7dbea1.png)

### After

![image](https://user-images.githubusercontent.com/3319450/221737545-061dfac5-96d0-4062-bc73-f614e9987387.png)


