### PR TITLE
[Bots] Prevent interrupt spam when OOM

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -1158,10 +1158,16 @@ void Mob::InterruptSpell(uint16 message, uint16 color, uint16 spellid)
 	uint16 message_other;
 	bool bard_song_mode = false; //has the bard song gone to auto repeat mode
 	if (!IsValidSpell(spellid)) {
-		if(bardsong) {
+		if (bardsong) {
 			spellid = bardsong;
 			bard_song_mode = true;
-		} else {
+		}
+		else {
+			if (IsBot() && !message && !color && !spellid) { // this is to prevent bots from spamming interrupts messages when trying to cast while OOM
+				ZeroCastingVars();	// resets all the state keeping stuff
+				LogSpells("Spell [{}] has been interrupted - Bot [{}] doesn't have enough mana", spellid, GetCleanName());
+				return;
+			}
 			spellid = casting_spell_id;
 		}
 	}


### PR DESCRIPTION
Notes:

https://user-images.githubusercontent.com/53322305/223123434-2bcba221-d13f-4320-9995-e6a3619ccb84.mp4

Bots currently do not do a mana check until the spell cast has already been started which results in an interrupt immediately after. If it is the last spell for a bot to cast, it tends to result in interrupt spam until the bot has enough mana. This will block the interrupt spam if the spell is invalid.