### PR TITLE
[Bug Fix] Fix an issue where EVENT_TIMER timers would not be cleaned up after zone

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -518,7 +518,9 @@ Mob::Mob(
 }
 
 Mob::~Mob()
-{
+{ 
+	quest_manager.stopalltimers(this);
+
 	mMovementManager->RemoveMob(this);
 
 	AI_Stop();

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -375,11 +375,11 @@ private:
 
 	class QuestTimer {
 	public:
-		QuestTimer(int duration, Mob *_mob, std::string _name);
+		inline QuestTimer(int duration, Mob *_mob, std::string _name)
+			: mob(_mob), name(_name), Timer_(duration) { Timer_.Start(duration, false); }
 		Mob*   mob;
 		std::string name;
 		Timer Timer_;
-		uint32 charid;
 	};
 	class SignalTimer {
 	public:

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -375,11 +375,11 @@ private:
 
 	class QuestTimer {
 	public:
-		inline QuestTimer(int duration, Mob *_mob, std::string _name)
-			: mob(_mob), name(_name), Timer_(duration) { Timer_.Start(duration, false); }
+		QuestTimer(int duration, Mob *_mob, std::string _name);
 		Mob*   mob;
 		std::string name;
 		Timer Timer_;
+		uint32 charid;
 	};
 	class SignalTimer {
 	public:


### PR DESCRIPTION
Entries in the QTimerList for clients used mob as the key when deciding if a timer's client was in the zone and was the correct client.

If you log in character a, start a timer, log out character a and log in character b  (in the same zone from the same instance of client) character b inherits and runs character a's timer.

This PR adds charid as a secondary key for client timers.

Please note that the existing code cleans up timers when a client is no longer in zone.  My patch does the exact same thing if a clients character ID has changed.  I noticed that a previous patch (that I am not running yet) also checks to make sure that the client has an EVENT_TIMER subroutine.  That change is good, but it leaves the client timer in the QTimerList forever, until the Client leaves the zone.  So this fix also removed the timer in that case as well.