### PR TITLE
[Bug Fix] Cursor Coin Upon Death

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -204,6 +204,7 @@ RULE_REAL(Character, FullGroupEXPModifier, 2.16, "Sets the group experience modi
 RULE_BOOL(Character, IgnoreLevelBasedHasteCaps, false, "Ignores hard coded level based haste caps.")
 RULE_BOOL(Character, EnableRaidEXPModifier, true, "Enable or disable the raid experience modifier, default is true")
 RULE_BOOL(Character, EnableRaidMemberEXPModifier, true, "Enable or disable the raid experience modifier based on members in raid, default is true")
+RULE_BOOL(Character, LeaveCursorMoneyOnCorpse, false, "Enable or disable leaving cursor money on player corpses")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Mercs)

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -395,11 +395,15 @@ Corpse::Corpse(Client* client, int32 in_rezexp) : Mob (
 			!RuleB(Character, RespawnFromHover) ||
 			client->ClientVersion() < EQ::versions::ClientVersion::SoF
 		) {
-			SetCash(pp->copper, pp->silver, pp->gold, pp->platinum);
-			pp->copper   = 0;
-			pp->silver   = 0;
-			pp->gold     = 0;
-			pp->platinum = 0;
+			SetCash((pp->copper + pp->copper_cursor), (pp->silver + pp->silver_cursor), (pp->gold + pp->gold_cursor), (pp->platinum + pp->platinum_cursor));
+			pp->copper			= 0;
+			pp->copper_cursor	= 0;
+			pp->silver			= 0;
+			pp->silver_cursor	= 0;
+			pp->gold			= 0;
+			pp->gold_cursor		= 0;
+			pp->platinum		= 0;
+			pp->platinum_cursor = 0;
 		}
 
 		// get their tints

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -395,15 +395,29 @@ Corpse::Corpse(Client* client, int32 in_rezexp) : Mob (
 			!RuleB(Character, RespawnFromHover) ||
 			client->ClientVersion() < EQ::versions::ClientVersion::SoF
 		) {
-			SetCash((pp->copper + pp->copper_cursor), (pp->silver + pp->silver_cursor), (pp->gold + pp->gold_cursor), (pp->platinum + pp->platinum_cursor));
-			pp->copper			= 0;
-			pp->copper_cursor	= 0;
-			pp->silver			= 0;
-			pp->silver_cursor	= 0;
-			pp->gold			= 0;
-			pp->gold_cursor		= 0;
-			pp->platinum		= 0;
-			pp->platinum_cursor = 0;
+			auto corpse_copper   = pp->copper;
+			auto corpse_silver   = pp->silver;
+			auto corpse_gold     = pp->gold;
+			auto corpse_platinum = pp->platinum;
+
+			pp->copper   = 0;
+			pp->silver   = 0;
+			pp->gold     = 0;
+			pp->platinum = 0;
+
+			if (RuleB(Character, LeaveCursorMoneyOnCorpse)) {
+				corpse_copper += pp->copper_cursor;
+				corpse_silver += pp->silver_cursor;
+				corpse_gold += pp->gold_cursor;
+				corpse_platinum += pp->platinum_cursor;
+
+				pp->copper_cursor   = 0;
+				pp->silver_cursor   = 0;
+				pp->gold_cursor     = 0;
+				pp->platinum_cursor = 0;
+			}
+
+			SetCash(corpse_copper, corpse_silver, corpse_gold, corpse_platinum);
 		}
 
 		// get their tints


### PR DESCRIPTION
Upon death if a character has coin on cursor it will not transfer to the corpse, rather stay on cursor after death. This fix will remove all coin on cursor and save it to the corpse.