### PR TITLE
[Console] Add IS_TTY to force terminal coloring output

### DIFF
--- a/common/termcolor/rang.hpp
+++ b/common/termcolor/rang.hpp
@@ -42,6 +42,8 @@
 #include <cstring>
 #include <iostream>
 
+inline bool g_is_forced_tty = std::getenv("IS_TTY");
+
 namespace rang {
 
 /* For better compability with most of terminals do not use any style settings
@@ -220,6 +222,10 @@ inline bool isMsysPty(int fd) noexcept
 
 inline bool isTerminal(const std::streambuf *osbuf) noexcept
 {
+	if (g_is_forced_tty) {
+		return g_is_forced_tty;
+	}
+
 using std::cerr;
 using std::clog;
 using std::cout;


### PR DESCRIPTION
### What 

Add `IS_TTY` to force terminal coloring output

This is used to enable outside processes to force terminal output to be colored. For example, Spire Admin panel has a pre-flight checks that is ran to ensure the server is in working order and has no errors. The output gets sent as ANSI and parsed from ANSI to HTML to give the colored resemblance of what you would expect to see in the console.

![image](https://user-images.githubusercontent.com/3319450/222841898-68d555d3-a71e-4d8f-8814-243b8023782e.png)
