### PR TITLE
[Bug Fix] Fix Discovered Items with Alternate Currency and LDoN Adventure Merchants

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -2086,6 +2086,10 @@ void Client::Handle_OP_AdventureMerchantPurchase(const EQApplicationPacket *app)
 	if (item->MaxCharges != 0)
 		charges = item->MaxCharges;
 
+	if (RuleB(Character, EnableDiscoveredItems) && !GetGM() && !IsDiscovered(item->ID)) {
+		DiscoverItem(item->ID);
+	}
+
 	EQ::ItemInstance *inst = database.CreateItem(item, charges);
 	if (!AutoPutLootInInventory(*inst, true, true))
 	{

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -2632,6 +2632,10 @@ void Client::Handle_OP_AltCurrencyPurchase(const EQApplicationPacket *app)
 			RecordPlayerEventLog(PlayerEvent::MERCHANT_PURCHASE, e);
 		}
 
+		if (RuleB(Character, EnableDiscoveredItems) && !GetGM() && !IsDiscovered(item->ID)) {
+			DiscoverItem(item->ID);
+		}
+
 		EQ::ItemInstance *inst = database.CreateItem(item, charges);
 		if (!AutoPutLootInInventory(*inst, true, true))
 		{


### PR DESCRIPTION
# Notes
- Before now, alternate currency and LDoN adventure merchants did not trigger item discovery.