### PR TITLE
[Strings] Add exception handling to converters themselves

### DIFF
--- a/common/strings.cpp
+++ b/common/strings.cpp
@@ -781,27 +781,72 @@ std::string Strings::Random(size_t length)
 // fails to cast to a number
 int Strings::ToInt(const std::string &s, int fallback)
 {
-	return Strings::IsNumber(s) ? std::stoi(s) : fallback;
+	if (!Strings::IsNumber(s)) {
+		return fallback;
+	}
+
+	try {
+		return std::stoi(s);
+	}
+	catch (std::exception &) {
+		return fallback;
+	}
 }
 
 int64 Strings::ToBigInt(const std::string &s, int64 fallback)
 {
-	return Strings::IsNumber(s) ? std::stoll(s) : fallback;
+	if (!Strings::IsNumber(s)) {
+		return fallback;
+	}
+
+	try {
+		return std::stoll(s);
+	}
+	catch (std::exception &) {
+		return fallback;
+	}
 }
 
 uint32 Strings::ToUnsignedInt(const std::string &s, uint32 fallback)
 {
-	return Strings::IsNumber(s) ? std::stoul(s) : fallback;
+	if (!Strings::IsNumber(s)) {
+		return fallback;
+	}
+
+	try {
+		return std::stoul(s);
+	}
+	catch (std::exception &) {
+		return fallback;
+	}
 }
 
 uint64 Strings::ToUnsignedBigInt(const std::string &s, uint64 fallback)
 {
-	return Strings::IsNumber(s) ? std::stoull(s) : fallback;
+	if (!Strings::IsNumber(s)) {
+		return fallback;
+	}
+
+	try {
+		return std::stoull(s);
+	}
+	catch (std::exception &) {
+		return fallback;
+	}
 }
 
 float Strings::ToFloat(const std::string &s, float fallback)
 {
-	return Strings::IsFloat(s) ? std::stof(s) : fallback;
+	if (!Strings::IsFloat(s)) {
+		return fallback;
+	}
+
+	try {
+		return std::stof(s);
+	}
+	catch (std::exception &) {
+		return fallback;
+	}
 }
 
 std::string Strings::RemoveNumbers(std::string s)


### PR DESCRIPTION
### What

This PR augments https://github.com/EQEmu/Server/pull/2873 where try/catch mechanisms are added to the actual string conversion functions for the sake of safety.

It combines performance improvements from the previous PR in conjunction with this current change by utilizing the fast functions for validating `IsNumber` and `IsFloat` early before passing the string into the converter.

We just ran into a situation where character loading produced `__throw_out_of_range` for a value (42949672950) fits outside normal integer range. While we should be responsible programmers and use proper types for loading data, we also should still utilize guard rails where they make sense and don't provide massive penalties otherwise. In this case, the penalty is extremely negligible and yields large safety benefits

**Before**

![image](https://user-images.githubusercontent.com/3319450/222936428-c17f46d0-604d-493b-83f5-02120aba65b9.png)

**After**

![image](https://user-images.githubusercontent.com/3319450/222936423-d360fc70-8bac-4749-affa-8c6b4edb0d04.png)
