### PR TITLE
[Cleanup] Remove unused client queued work variable in client.cpp/client.h

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -241,7 +241,6 @@ Client::Client(EQStreamInterface *ieqs) : Mob(
 	casting_spell_id = 0;
 	npcflag = false;
 	npclevel = 0;
-	pQueuedSaveWorkID = 0;
 	position_update_same_count = 0;
 	fishing_timer.Disable();
 	dead_timer.Disable();

--- a/zone/client.h
+++ b/zone/client.h
@@ -1777,7 +1777,6 @@ private:
 	bool medding;
 	uint16 horseId;
 	bool revoked;
-	uint32 pQueuedSaveWorkID;
 	uint16 pClientSideTarget;
 	uint32 weight;
 	bool berserk;


### PR DESCRIPTION
# Notes
- This is unused.