### PR TITLE
[Cleanup] Remove unused BotAA struct in bot_structs.h

### DIFF
--- a/zone/bot.h
+++ b/zone/bot.h
@@ -832,7 +832,6 @@ private:
 
 	std::shared_ptr<HealRotation> m_member_of_heal_rotation;
 
-	std::map<uint32, BotAA> botAAs;
 	InspectMessage_Struct _botInspectMessage;
 	bool _altoutofcombatbehavior;
 	bool _showhelm;

--- a/zone/bot_structs.h
+++ b/zone/bot_structs.h
@@ -71,12 +71,6 @@ struct BotCastingRoles {
 	//bool RaidDoter;
 };
 
-struct BotAA {
-	uint32 aa_id;
-	uint8 req_level;
-	uint8 total_levels;
-};
-
 struct BotSpellSetting {
 	int16  priority;
 	uint8  min_level;


### PR DESCRIPTION
# Notes
- This is unused.