### PR TITLE
[Fix] Checkmarks and X characters in popup messages

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -5168,7 +5168,7 @@ void Client::ShowSkillsWindow()
 			"<td>{}</td>",
 			(
 				skill_maxed ?
-				"<c \"#00FF00\">✔</c>" :
+				"<c \"#00FF00\">Max</c>" :
 				fmt::format(
 					"{}/{}",
 					current_skill,

--- a/zone/gm_commands/ginfo.cpp
+++ b/zone/gm_commands/ginfo.cpp
@@ -45,7 +45,7 @@ void command_ginfo(Client *c, const Seperator *sep)
 		if (target_group->membername[group_member][0] == '\0') {
 			continue;
 		}
-		
+
 		bool is_assist = target_group->MemberRoles[group_member] & RoleAssist;
 		bool is_puller = target_group->MemberRoles[group_member] & RolePuller;
 		bool is_tank = target_group->MemberRoles[group_member] & RoleTank;
@@ -61,10 +61,10 @@ void command_ginfo(Client *c, const Seperator *sep)
 					target_group->membername[group_member]
 				)
 			),
-			target_group->members[group_member] ? "<c \"#00FF00\">✔</c>" : "<c \"#F62217\">❌</c>",
-			is_assist ? "<c \"#00FF00\">✔</c>" : "<c \"#F62217\">❌</c>",
-			is_puller ? "<c \"#00FF00\">✔</c>" : "<c \"#F62217\">❌</c>",
-			is_tank ? "<c \"#00FF00\">✔</c>" : "<c \"#F62217\">❌</c>"
+			target_group->members[group_member] ? "<c \"#00FF00\">Y</c>" : "<c \"#F62217\">N</c>",
+			is_assist ? "<c \"#00FF00\">Y</c>" : "<c \"#F62217\">N</c>",
+			is_puller ? "<c \"#00FF00\">Y</c>" : "<c \"#F62217\">N</c>",
+			is_tank ? "<c \"#00FF00\">Y</c>" : "<c \"#F62217\">N</c>"
 		);
 	}
 

--- a/zone/guild_mgr.cpp
+++ b/zone/guild_mgr.cpp
@@ -338,14 +338,14 @@ void ZoneGuildManager::DescribeGuild(Client *c, uint32 guild_id) const {
 	popup_text += "</tr>";
 
 	for (uint8 guild_rank = 0; guild_rank <= GUILD_MAX_RANK; guild_rank++) {
-		auto can_hear_guild_chat = info->ranks[guild_rank].permissions[GUILD_HEAR] ? "<c \"#00FF00\">✔</c>" : "<c \"#F62217\">❌</c>";
-		auto can_speak_guild_chat = info->ranks[guild_rank].permissions[GUILD_SPEAK] ? "<c \"#00FF00\">✔</c>" : "<c \"#F62217\">❌</c>";
-		auto can_invite = info->ranks[guild_rank].permissions[GUILD_INVITE] ? "<c \"#00FF00\">✔</c>" : "<c \"#F62217\">❌</c>";
-		auto can_remove = info->ranks[guild_rank].permissions[GUILD_REMOVE] ? "<c \"#00FF00\">✔</c>" : "<c \"#F62217\">❌</c>";
-		auto can_promote = info->ranks[guild_rank].permissions[GUILD_PROMOTE] ? "<c \"#00FF00\">✔</c>" : "<c \"#F62217\">❌</c>";
-		auto can_demote = info->ranks[guild_rank].permissions[GUILD_DEMOTE] ? "<c \"#00FF00\">✔</c>" : "<c \"#F62217\">❌</c>";
-		auto can_set_motd = info->ranks[guild_rank].permissions[GUILD_MOTD] ? "<c \"#00FF00\">✔</c>" : "<c \"#F62217\">❌</c>";
-		auto can_war_peace = info->ranks[guild_rank].permissions[GUILD_WARPEACE] ? "<c \"#00FF00\">✔</c>" : "<c \"#F62217\">❌</c>";
+		auto can_hear_guild_chat = info->ranks[guild_rank].permissions[GUILD_HEAR] ? "<c \"#00FF00\">Y</c>" : "<c \"#F62217\">N</c>";
+		auto can_speak_guild_chat = info->ranks[guild_rank].permissions[GUILD_SPEAK] ? "<c \"#00FF00\">Y</c>" : "<c \"#F62217\">N</c>";
+		auto can_invite = info->ranks[guild_rank].permissions[GUILD_INVITE] ? "<c \"#00FF00\">Y</c>" : "<c \"#F62217\">N</c>";
+		auto can_remove = info->ranks[guild_rank].permissions[GUILD_REMOVE] ? "<c \"#00FF00\">Y</c>" : "<c \"#F62217\">N</c>";
+		auto can_promote = info->ranks[guild_rank].permissions[GUILD_PROMOTE] ? "<c \"#00FF00\">Y</c>" : "<c \"#F62217\">N</c>";
+		auto can_demote = info->ranks[guild_rank].permissions[GUILD_DEMOTE] ? "<c \"#00FF00\">Y</c>" : "<c \"#F62217\">N</c>";
+		auto can_set_motd = info->ranks[guild_rank].permissions[GUILD_MOTD] ? "<c \"#00FF00\">Y</c>" : "<c \"#F62217\">N</c>";
+		auto can_war_peace = info->ranks[guild_rank].permissions[GUILD_WARPEACE] ? "<c \"#00FF00\">Y</c>" : "<c \"#F62217\">N</c>";
 		popup_text += fmt::format(
 			"<tr>"
 			"<td>{} ({})</td>"


### PR DESCRIPTION
# Notes
- Due to changing the popups to use strings, these show as squares, instead of the proper character.