### PR TITLE
[Commands] Cleanup #level Command

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -198,7 +198,7 @@ int command_init(void)
 		command_add("kill", "Kill your target", AccountStatus::GMAdmin, command_kill) ||
 		command_add("killallnpcs", "[npc_name] - Kills all npcs by search name, leave blank for all attackable NPC's", AccountStatus::GMMgmt, command_killallnpcs) ||
 		command_add("lastname", "[Last Name] - Set your or your player target's last name (use \"-1\" to remove last name)", AccountStatus::Guide, command_lastname) ||
-		command_add("level", "[Level] - Set your target's level", AccountStatus::Steward, command_level) ||
+		command_add("level", "[Level] - Set your or your target's level", AccountStatus::Steward, command_level) ||
 		command_add("list", "[npcs|players|corpses|doors|objects] [search] - Search entities", AccountStatus::ApprenticeGuide, command_list) ||
 		command_add("listpetition", "List petitions", AccountStatus::Guide, command_listpetition) ||
 		command_add("lootsim", "[npc_type_id] [loottable_id] [iterations] - Runs benchmark simulations using real loot logic to report numbers and data", AccountStatus::GMImpossible, command_lootsim) ||

--- a/zone/gm_commands/level.cpp
+++ b/zone/gm_commands/level.cpp
@@ -2,22 +2,21 @@
 
 void command_level(Client *c, const Seperator *sep)
 {
-	int arguments = sep->argnum;
+	const auto arguments = sep->argnum;
 	if (!arguments || !sep->IsNumber(1)) {
 		c->Message(Chat::White, "Usage: #level [Level]");
 		return;
 	}
 
-	auto target = c->GetTarget();
-	if (!target) {
-		c->Message(Chat::White, "You must have a target to use this command.");
-		return;
+	Mob* t = c;
+	if (c->GetTarget()) {
+		t = c->GetTarget();
 	}
 
 	auto level = static_cast<uint8>(Strings::ToUnsignedInt(sep->arg[1]));
 	auto max_level = static_cast<uint8>(RuleI(Character, MaxLevel));
 
-	if (c->Admin() < RuleI(GM, MinStatusToLevelTarget)) {
+	if (c != t && c->Admin() < RuleI(GM, MinStatusToLevelTarget)) {
 		c->Message(Chat::White, "Your status is not high enough to change another person's level.");
 		return;
 	}
@@ -37,12 +36,12 @@ void command_level(Client *c, const Seperator *sep)
 		return;
 	}
 
-	target->SetLevel(level, true);
-	if (target->IsClient()) {
-		target->CastToClient()->SendLevelAppearance();
+	t->SetLevel(level, true);
+	if (t->IsClient()) {
+		t->CastToClient()->SendLevelAppearance();
 
 		if (RuleB(Bots, Enabled) && RuleB(Bots, BotLevelsWithOwner)) {
-			Bot::LevelBotWithClient(target->CastToClient(), level, true);
+			Bot::LevelBotWithClient(t->CastToClient(), level, true);
 		}
 	}
 }


### PR DESCRIPTION
# Notes
- Cleanup messages and logic.
- Defaults target to GM so that you don't have to target yourself to use the command.