### PR TITLE
[HotFix] Fix Raid Invites causing client desync issues

### DIFF
--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -1509,7 +1509,7 @@ bool Raid::LearnMembers()
 
         members[index].member = nullptr;
         strn0cpy(members[index].membername, row[0], 64);
-        int groupNum = Strings::ToInt(row[1]);
+		uint32 groupNum = Strings::ToUnsignedInt(row[1]);
         if(groupNum > 11)
             members[index].GroupNumber = 0xFFFFFFFF;
         else


### PR DESCRIPTION
Fixes Bug where Raid invites would never move a client to groupless state in the raid from the client perspective, Database however would show accurate group ID. 

```groupNum``` was incorrectly declared as an int prior to change in #2873, so it was incorrectly set to use Strings::ToInt.

 This was causing all sorts of undefined behavior when inviting to a raid:

* clients showing as in a raid group in the raid window, but not in their party.
* Ability to accidentally invite a 7th player to Group 0, which would cause a client crash, and failure to log back into the game world.

