### PR TITLE
[Feature] Add Heroic Strikethrough & HP Regen Per Second to GM Entity Info

### DIFF
--- a/zone/mob_info.cpp
+++ b/zone/mob_info.cpp
@@ -404,6 +404,10 @@ inline std::string GetMobAttributeByString(Mob *mob, const std::string &attribut
 			return Strings::Commify(std::to_string(npc->GetAvoidanceRating())) + scaling_modified;
 		}
 
+		if (attribute == "heroic_strikethrough") {
+			return Strings::Commify(std::to_string(npc->GetHeroicStrikethrough())) + scaling_modified;
+		}
+
 		npc->GetNPCEmote(npc->GetEmoteID(), 0);
 	}
 
@@ -729,6 +733,7 @@ void Mob::DisplayInfo(Mob *mob)
 				"spell_scale",
 				"heal_scale",
 				"avoidance",
+				"heroic_strikethrough",
 			};
 
 			window_text += WriteDisplayInfoSection(mob, "NPC Stats", npc_stats, 1, true);

--- a/zone/mob_info.cpp
+++ b/zone/mob_info.cpp
@@ -746,6 +746,7 @@ void Mob::DisplayInfo(Mob *mob)
 				"min_hit",
 				"max_hit",
 				"hp_regen",
+				"hp_regen_per_second",
 				"attack_delay",
 				"spell_scale",
 				"heal_scale",

--- a/zone/mob_info.cpp
+++ b/zone/mob_info.cpp
@@ -377,8 +377,17 @@ inline std::string GetMobAttributeByString(Mob *mob, const std::string &attribut
 				scaling_modified = " *";
 			}
 
-			return Strings::Commify(std::to_string((int) npc->GetHPRegen())) + scaling_modified;
+			return Strings::Commify(std::to_string(npc->GetHPRegen())) + scaling_modified;
 		}
+
+		if (attribute == "hp_regen_per_second") {
+			if (mob->EntityVariableExists("modify_stat_hp_regen_per_second")) {
+				scaling_modified = " *";
+			}
+
+			return Strings::Commify(std::to_string(npc->GetHPRegenPerSecond())) + scaling_modified;
+		}
+
 		if (attribute == "attack_delay") {
 			if (mob->EntityVariableExists("modify_stat_attack_delay")) {
 				scaling_modified = " *";
@@ -401,10 +410,18 @@ inline std::string GetMobAttributeByString(Mob *mob, const std::string &attribut
 			return Strings::Commify(std::to_string((int) npc->GetHealScale())) + scaling_modified;
 		}
 		if (attribute == "avoidance") {
+			if (mob->EntityVariableExists("modify_stat_avoidance")) {
+				scaling_modified = " *";
+			}
+
 			return Strings::Commify(std::to_string(npc->GetAvoidanceRating())) + scaling_modified;
 		}
 
 		if (attribute == "heroic_strikethrough") {
+			if (mob->EntityVariableExists("modify_stat_heroic_strikethrough")) {
+				scaling_modified = " *";
+			}
+
 			return Strings::Commify(std::to_string(npc->GetHeroicStrikethrough())) + scaling_modified;
 		}
 


### PR DESCRIPTION
Adds NPC Stat Heroic Strikethrough  and HP Regen Per Second to the GM Entity Info Window.

![image](https://user-images.githubusercontent.com/109764533/224509532-b0c183b7-27c0-486a-a969-434933811a3d.png)


