### PR TITLE
[Quest API] Add Spell GetActX methods to Perl/Lua

### DIFF
--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -165,7 +165,7 @@ int64 Mob::GetActSpellDamage(uint16 spell_id, int64 value, Mob* target) {
 	return value;
 }
 
-int64 Mob::GetActReflectedSpellDamage(int32 spell_id, int64 value, int effectiveness) {
+int64 Mob::GetActReflectedSpellDamage(uint16 spell_id, int64 value, int effectiveness) {
 	/*
 		Reflected spells use the spells base damage before any modifiers or formulas applied.
 		That value can then be modifier by the reflect spells 'max' value, defined here as effectiveness

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -2839,6 +2839,66 @@ float Lua_Mob::GetDefaultRaceSize() {
 	return self->GetDefaultRaceSize();
 }
 
+float Lua_Mob::GetActSpellRange(uint16 spell_id, float range) {
+	Lua_Safe_Call_Real();
+	return self->GetActSpellRange(spell_id, range);
+}
+
+int64 Lua_Mob::GetActSpellDamage(uint16 spell_id, int64 value) {
+	Lua_Safe_Call_Int();
+	return self->GetActSpellDamage(spell_id, value);
+}
+
+int64 Lua_Mob::GetActSpellDamage(uint16 spell_id, int64 value, Lua_Mob target) {
+	Lua_Safe_Call_Int();
+	return self->GetActSpellDamage(spell_id, value, target);
+}
+
+int64 Lua_Mob::GetActDoTDamage(uint16 spell_id, int64 value, Lua_Mob target) {
+	Lua_Safe_Call_Int();
+	return self->GetActDoTDamage(spell_id, value, target);
+}
+
+int64 Lua_Mob::GetActDoTDamage(uint16 spell_id, int64 value, Lua_Mob target, bool from_buff_tic) {
+	Lua_Safe_Call_Int();
+	return self->GetActDoTDamage(spell_id, value, target, from_buff_tic);
+}
+
+int64 Lua_Mob::GetActSpellHealing(uint16 spell_id, int64 value) {
+	Lua_Safe_Call_Int();
+	return self->GetActSpellHealing(spell_id, value);
+}
+
+int64 Lua_Mob::GetActSpellHealing(uint16 spell_id, int64 value, Lua_Mob target) {
+	Lua_Safe_Call_Int();
+	return self->GetActSpellHealing(spell_id, value, target);
+}
+
+int64 Lua_Mob::GetActSpellHealing(uint16 spell_id, int64 value, Lua_Mob target, bool from_buff_tic) {
+	Lua_Safe_Call_Int();
+	return self->GetActSpellHealing(spell_id, value, target, from_buff_tic);
+}
+
+int Lua_Mob::GetActSpellCost(uint16 spell_id, int cost) {
+	Lua_Safe_Call_Int();
+	return self->GetActSpellCost(spell_id, cost);
+}
+
+int Lua_Mob::GetActSpellDuration(uint16 spell_id, int duration) {
+	Lua_Safe_Call_Int();
+	return self->GetActSpellDuration(spell_id, duration);
+}
+
+int Lua_Mob::GetActSpellCasttime(uint16 spell_id, uint32 cast_time) {
+	Lua_Safe_Call_Int();
+	return self->GetActSpellCasttime(spell_id, cast_time);
+}
+
+int64 Lua_Mob::GetActReflectedSpellDamage(uint16 spell_id, int64 value, int effectiveness) {
+	Lua_Safe_Call_Int();
+	return self->GetActReflectedSpellDamage(spell_id, value, effectiveness);
+}
+
 luabind::scope lua_register_mob() {
 	return luabind::class_<Lua_Mob, Lua_Entity>("Mob")
 	.def(luabind::constructor<>())
@@ -3011,6 +3071,18 @@ luabind::scope lua_register_mob() {
 	.def("GetAC", &Lua_Mob::GetAC)
 	.def("GetAGI", &Lua_Mob::GetAGI)
 	.def("GetATK", &Lua_Mob::GetATK)
+	.def("GetActDoTDamage", (int64(Lua_Mob::*)(uint16,int64,Lua_Mob))&Lua_Mob::GetActDoTDamage)
+	.def("GetActDoTDamage", (int64(Lua_Mob::*)(uint16,int64,Lua_Mob,bool))&Lua_Mob::GetActDoTDamage)
+	.def("GetActReflectedSpellDamage", &Lua_Mob::GetActReflectedSpellDamage)
+	.def("GetActSpellCasttime", &Lua_Mob::GetActSpellCasttime)
+	.def("GetActSpellCost", &Lua_Mob::GetActSpellCost)
+	.def("GetActSpellDuration", &Lua_Mob::GetActSpellDuration)
+	.def("GetActSpellDamage", (int64(Lua_Mob::*)(uint16,int64))&Lua_Mob::GetActSpellDamage)
+	.def("GetActSpellDamage", (int64(Lua_Mob::*)(uint16,int64,Lua_Mob))&Lua_Mob::GetActSpellDamage)
+	.def("GetActSpellHealing", (int64(Lua_Mob::*)(uint16,int64))&Lua_Mob::GetActSpellHealing)
+	.def("GetActSpellHealing", (int64(Lua_Mob::*)(uint16,int64,Lua_Mob))&Lua_Mob::GetActSpellHealing)
+	.def("GetActSpellHealing", (int64(Lua_Mob::*)(uint16,int64,Lua_Mob,bool))&Lua_Mob::GetActSpellHealing)
+	.def("GetActSpellRange", &Lua_Mob::GetActSpellRange)
 	.def("GetAggroRange", (float(Lua_Mob::*)(void))&Lua_Mob::GetAggroRange)
 	.def("GetAllowBeneficial", (bool(Lua_Mob::*)(void))&Lua_Mob::GetAllowBeneficial)
 	.def("GetAppearance", (uint32(Lua_Mob::*)(void))&Lua_Mob::GetAppearance)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -516,6 +516,18 @@ public:
 	bool IsFindable();
 	bool IsTrackable();
 	float GetDefaultRaceSize();
+	int64 GetActDoTDamage(uint16 spell_id, int64 value, Lua_Mob target);
+	int64 GetActDoTDamage(uint16 spell_id, int64 value, Lua_Mob target, bool from_buff_tic);
+	int64 GetActReflectedSpellDamage(uint16 spell_id, int64 value, int effectiveness);
+	int GetActSpellCasttime(uint16 spell_id, uint32 cast_time);
+	int GetActSpellCost(uint16 spell_id, int cost);
+	int64 GetActSpellDamage(uint16 spell_id, int64 value);
+	int64 GetActSpellDamage(uint16 spell_id, int64 value, Lua_Mob target);
+	int GetActSpellDuration(uint16 spell_id, int duration);
+	int64 GetActSpellHealing(uint16 spell_id, int64 value);
+	int64 GetActSpellHealing(uint16 spell_id, int64 value, Lua_Mob target);
+	int64 GetActSpellHealing(uint16 spell_id, int64 value, Lua_Mob target, bool from_buff_tic);
+	float GetActSpellRange(uint16 spell_id, float range);
 };
 
 #endif

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -326,7 +326,7 @@ public:
 	int32 GetActSpellCost(uint16 spell_id, int32 cost);
 	virtual int32 GetActSpellDuration(uint16 spell_id, int32 duration);
 	int32 GetActSpellCasttime(uint16 spell_id, int32 casttime);
-	virtual int64 GetActReflectedSpellDamage(int32 spell_id, int64 value, int effectiveness);
+	virtual int64 GetActReflectedSpellDamage(uint16 spell_id, int64 value, int effectiveness);
 	float ResistSpell(uint8 resist_type, uint16 spell_id, Mob *caster, bool use_resist_override = false,
 		int resist_override = 0, bool CharismaCheck = false, bool CharmTick = false, bool IsRoot = false,
 		int level_override = -1);

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -731,9 +731,34 @@ int64_t Perl_Mob_GetActSpellDamage(Mob* self, uint16 spell_id, int64 value) // @
 	return self->GetActSpellDamage(spell_id, value);
 }
 
+int64_t Perl_Mob_GetActSpellDamage(Mob* self, uint16 spell_id, int64 value, Mob* target) // @categories Spells and Disciplines
+{
+	return self->GetActSpellDamage(spell_id, value, target);
+}
+
+int64_t Perl_Mob_GetActDoTDamage(Mob* self, uint16 spell_id, int64 value, Mob* target) // @categories Spells and Disciplines
+{
+	return self->GetActDoTDamage(spell_id, value, target);
+}
+
+int64_t Perl_Mob_GetActDoTDamage(Mob* self, uint16 spell_id, int64 value, Mob* target, bool from_buff_tic) // @categories Spells and Disciplines
+{
+	return self->GetActDoTDamage(spell_id, value, target, from_buff_tic);
+}
+
 int64_t Perl_Mob_GetActSpellHealing(Mob* self, uint16 spell_id, int64 value) // @categories Spells and Disciplines
 {
 	return self->GetActSpellHealing(spell_id, value);
+}
+
+int64_t Perl_Mob_GetActSpellHealing(Mob* self, uint16 spell_id, int64 value, Mob* target) // @categories Spells and Disciplines
+{
+	return self->GetActSpellHealing(spell_id, value, target);
+}
+
+int64_t Perl_Mob_GetActSpellHealing(Mob* self, uint16 spell_id, int64 value, Mob* target, bool from_buff_tic) // @categories Spells and Disciplines
+{
+	return self->GetActSpellHealing(spell_id, value, target, from_buff_tic);
 }
 
 int Perl_Mob_GetActSpellCost(Mob* self, uint16 spell_id, int32 cost) // @categories Spells and Disciplines
@@ -749,6 +774,11 @@ int Perl_Mob_GetActSpellDuration(Mob* self, uint16 spell_id, int32 duration) // 
 int Perl_Mob_GetActSpellCasttime(Mob* self, uint16 spell_id, uint32 cast_time) // @categories Spells and Disciplines
 {
 	return self->GetActSpellCasttime(spell_id, cast_time);
+}
+
+int64 Perl_Mob_GetActReflectedSpellDamage(Mob* self, uint16 spell_id, int64 value, int effectiveness) // @categories Spells and Disciplines
+{
+	return self->GetActReflectedSpellDamage(spell_id, value, effectiveness);
 }
 
 float Perl_Mob_ResistSpell(Mob* self, uint8 resist_type, uint16 spell_id, Mob* caster) // @categories Spells and Disciplines, Script Utility
@@ -2958,11 +2988,17 @@ void perl_register_mob()
 	package.add("GetAC", &Perl_Mob_GetAC);
 	package.add("GetAGI", &Perl_Mob_GetAGI);
 	package.add("GetATK", &Perl_Mob_GetATK);
+	package.add("GetActDoTDamage", (int64_t(*)(Mob*, uint16, int64, Mob*))&Perl_Mob_GetActDoTDamage);
+	package.add("GetActDoTDamage", (int64_t(*)(Mob*, uint16, int64, Mob*, bool))&Perl_Mob_GetActDoTDamage);
+	package.add("GetActReflectedSpellDamage", &Perl_Mob_GetActReflectedSpellDamage);
 	package.add("GetActSpellCasttime", &Perl_Mob_GetActSpellCasttime);
 	package.add("GetActSpellCost", &Perl_Mob_GetActSpellCost);
-	package.add("GetActSpellDamage", &Perl_Mob_GetActSpellDamage);
+	package.add("GetActSpellDamage", (int64_t(*)(Mob*, uint16, int64))&Perl_Mob_GetActSpellDamage);
+	package.add("GetActSpellDamage", (int64_t(*)(Mob*, uint16, int64, Mob*))&Perl_Mob_GetActSpellDamage);
 	package.add("GetActSpellDuration", &Perl_Mob_GetActSpellDuration);
-	package.add("GetActSpellHealing", &Perl_Mob_GetActSpellHealing);
+	package.add("GetActSpellHealing", (int64_t(*)(Mob*, uint16, int64))&Perl_Mob_GetActSpellHealing);
+	package.add("GetActSpellHealing", (int64_t(*)(Mob*, uint16, int64, Mob*))&Perl_Mob_GetActSpellHealing);
+	package.add("GetActSpellHealing", (int64_t(*)(Mob*, uint16, int64, Mob*, bool))&Perl_Mob_GetActSpellHealing);
 	package.add("GetActSpellRange", &Perl_Mob_GetActSpellRange);
 	package.add("GetAggroRange", &Perl_Mob_GetAggroRange);
 	package.add("GetAllowBeneficial", &Perl_Mob_GetAllowBeneficial);


### PR DESCRIPTION
# Perl
- Add `$mob->GetActDoTDamage(spell_id, value, target)`.
- Add `$mob->GetActDoTDamage(spell_id, value, target, from_buff_tic)`.
- Add `$mob->GetActReflectedSpellDamage(spell_id, value, effectiveness)`.
- Add `$mob->GetActSpellDamage(spell_id, value, target)`.
- Add `$mob->GetActSpellHealing(spell_id, value, target)`.
- Add `$mob->GetActSpellHealing(spell_id, value, target, from_buff_tic)`.

# Lua
- Add `mob:GetActDoTDamage(spell_id, value, target)`.
- Add `mob:GetActDoTDamage(spell_id, value, target, from_buff_tic)`.
- Add `mob:GetActReflectedSpellDamage(spell_id, value, effectiveness)`.
- Add `mob:GetActSpellCasttime(spell_id, cast_time)`.
- Add `mob:GetActSpellCost(spell_id, cost)`.
- Add `mob:GetActSpellDamage(spell_id, value)`.
- Add `mob:GetActSpellDamage(spell_id, value, target)`.
- Add `mob:GetActSpellDuration(spell_id, duration)`.
- Add `mob:GetActSpellHealing(spell_id, value)`.
- Add `mob:GetActSpellHealing(spell_id, value, target)`.
- Add `mob:GetActSpellHealing(spell_id, value, target, from_buff_tic)`.
- Add `mob:GetActSpellRange(spell_id, range)`.

 # Notes
- Allows operators to get various spell related values.