### PR TITLE
[Quest API] Add SendIllusion overloads/parameters to Perl/Lua

### DIFF
--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -1567,22 +1567,22 @@ void Lua_Mob::SendIllusionPacket(luabind::adl::object illusion) {
 		return;
 	}
 
-	uint16     race             = RACE_HUMAN_1;
-	uint8      gender           = MALE;
-	uint8      texture          = 255;
-	uint8      helmtexture      = 255;
-	uint8      haircolor        = 255;
-	uint8      beardcolor       = 255;
-	uint8      eyecolor1        = 255;
-	uint8      eyecolor2        = 255;
-	uint8      hairstyle        = 255;
-	uint8      luclinface       = 255;
-	uint8      beard            = 255;
+	uint16     race             = self->GetRace();
+	uint8      gender           = self->GetGender();
+	uint8      texture          = self->GetTexture();
+	uint8      helmtexture      = self->GetHelmTexture();
+	uint8      haircolor        = self->GetHairColor();
+	uint8      beardcolor       = self->GetBeardColor();
+	uint8      eyecolor1        = self->GetEyeColor1();
+	uint8      eyecolor2        = self->GetEyeColor2();
+	uint8      hairstyle        = self->GetHairStyle();
+	uint8      luclinface       = self->GetLuclinFace();
+	uint8      beard            = self->GetBeard();
 	uint8      aa_title         = 255;
-	uint32     drakkin_heritage = 4294967295;
-	uint32     drakkin_tattoo   = 4294967295;
-	uint32     drakkin_details  = 4294967295;
-	float      size             = -1.0f;
+	uint32     drakkin_heritage = self->GetDrakkinHeritage();
+	uint32     drakkin_tattoo   = self->GetDrakkinTattoo();
+	uint32     drakkin_details  = self->GetDrakkinDetails();
+	float      size             = self->GetSize();
 	Lua_Client target           = Lua_Client();
 
 	auto cur = illusion["race"];

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -1567,24 +1567,24 @@ void Lua_Mob::SendIllusionPacket(luabind::adl::object illusion) {
 		return;
 	}
 
-	uint16     race             = self->GetRace();
-	uint8      gender           = self->GetGender();
-	uint8      texture          = self->GetTexture();
-	uint8      helmtexture      = self->GetHelmTexture();
-	uint8      haircolor        = self->GetHairColor();
-	uint8      beardcolor       = self->GetBeardColor();
-	uint8      eyecolor1        = self->GetEyeColor1();
-	uint8      eyecolor2        = self->GetEyeColor2();
-	uint8      hairstyle        = self->GetHairStyle();
-	uint8      luclinface       = self->GetLuclinFace();
-	uint8      beard            = self->GetBeard();
-	uint8      aa_title         = 255;
-	uint32     drakkin_heritage = self->GetDrakkinHeritage();
-	uint32     drakkin_tattoo   = self->GetDrakkinTattoo();
-	uint32     drakkin_details  = self->GetDrakkinDetails();
-	float      size             = self->GetSize();
-	bool       send_appearances = true;
-	Lua_Client target           = Lua_Client();
+	uint16     race                    = self->GetRace();
+	uint8      gender                  = self->GetGender();
+	uint8      texture                 = self->GetTexture();
+	uint8      helmtexture             = self->GetHelmTexture();
+	uint8      haircolor               = self->GetHairColor();
+	uint8      beardcolor              = self->GetBeardColor();
+	uint8      eyecolor1               = self->GetEyeColor1();
+	uint8      eyecolor2               = self->GetEyeColor2();
+	uint8      hairstyle               = self->GetHairStyle();
+	uint8      luclinface              = self->GetLuclinFace();
+	uint8      beard                   = self->GetBeard();
+	uint8      aa_title                = 255;
+	uint32     drakkin_heritage        = self->GetDrakkinHeritage();
+	uint32     drakkin_tattoo          = self->GetDrakkinTattoo();
+	uint32     drakkin_details         = self->GetDrakkinDetails();
+	float      size                    = self->GetSize();
+	bool       send_appearance_effects = true;
+	Lua_Client target                  = Lua_Client();
 
 	auto cur = illusion["race"];
 	if (luabind::type(cur) != LUA_TNIL) {
@@ -1714,10 +1714,10 @@ void Lua_Mob::SendIllusionPacket(luabind::adl::object illusion) {
 		}
 	}
 
-	cur = illusion["send_appearances"];
+	cur = illusion["send_appearance_effects"];
 	if (luabind::type(cur) != LUA_TNIL) {
 		try {
-			send_appearances = luabind::object_cast<bool>(cur);
+			send_appearance_effects = luabind::object_cast<bool>(cur);
 		} catch (luabind::cast_failed &) {
 		}
 	}
@@ -1747,7 +1747,7 @@ void Lua_Mob::SendIllusionPacket(luabind::adl::object illusion) {
 		drakkin_tattoo,
 		drakkin_details,
 		size,
-		send_appearances,
+		send_appearance_effects,
 		target
 	);
 }

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -1583,6 +1583,7 @@ void Lua_Mob::SendIllusionPacket(luabind::adl::object illusion) {
 	uint32     drakkin_tattoo   = self->GetDrakkinTattoo();
 	uint32     drakkin_details  = self->GetDrakkinDetails();
 	float      size             = self->GetSize();
+	bool       send_appearances = true;
 	Lua_Client target           = Lua_Client();
 
 	auto cur = illusion["race"];
@@ -1713,6 +1714,14 @@ void Lua_Mob::SendIllusionPacket(luabind::adl::object illusion) {
 		}
 	}
 
+	cur = illusion["send_appearances"];
+	if (luabind::type(cur) != LUA_TNIL) {
+		try {
+			send_appearances = luabind::object_cast<bool>(cur);
+		} catch (luabind::cast_failed &) {
+		}
+	}
+
 	cur = illusion["target"];
 	if (luabind::type(cur) != LUA_TNIL) {
 		try {
@@ -1738,7 +1747,7 @@ void Lua_Mob::SendIllusionPacket(luabind::adl::object illusion) {
 		drakkin_tattoo,
 		drakkin_details,
 		size,
-		true,
+		send_appearances,
 		target
 	);
 }

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -1567,153 +1567,180 @@ void Lua_Mob::SendIllusionPacket(luabind::adl::object illusion) {
 		return;
 	}
 
-	int race = RACE_DOUG_0;
-	int gender = 255;
-	int texture = 255;
-	int helmtexture = 255;
-	int haircolor = 255;
-	int beardcolor = 255;
-	int eyecolor1 = 255;
-	int eyecolor2 = 255;
-	int hairstyle = 255;
-	int luclinface = 255;
-	int beard = 255;
-	int aa_title = 255;
-	uint32 drakkin_heritage = 4294967295;
-	uint32 drakkin_tattoo = 4294967295;
-	uint32 drakkin_details = 4294967295;
-	float size = -1.0f;
+	uint16     race             = RACE_HUMAN_1;
+	uint8      gender           = MALE;
+	uint8      texture          = 255;
+	uint8      helmtexture      = 255;
+	uint8      haircolor        = 255;
+	uint8      beardcolor       = 255;
+	uint8      eyecolor1        = 255;
+	uint8      eyecolor2        = 255;
+	uint8      hairstyle        = 255;
+	uint8      luclinface       = 255;
+	uint8      beard            = 255;
+	uint8      aa_title         = 255;
+	uint32     drakkin_heritage = 4294967295;
+	uint32     drakkin_tattoo   = 4294967295;
+	uint32     drakkin_details  = 4294967295;
+	float      size             = -1.0f;
+	Lua_Client target           = Lua_Client();
 
 	auto cur = illusion["race"];
-	if(luabind::type(cur) != LUA_TNIL) {
+	if (luabind::type(cur) != LUA_TNIL) {
 		try {
-			race = luabind::object_cast<int>(cur);
-		} catch(luabind::cast_failed &) {
+			race = luabind::object_cast<uint16>(cur);
+		} catch (luabind::cast_failed &) {
 		}
 	}
 
 	cur = illusion["gender"];
-	if(luabind::type(cur) != LUA_TNIL) {
+	if (luabind::type(cur) != LUA_TNIL) {
 		try {
-			gender = luabind::object_cast<int>(cur);
-		} catch(luabind::cast_failed &) {
+			gender = luabind::object_cast<uint8>(cur);
+		} catch (luabind::cast_failed &) {
 		}
 	}
 
 	cur = illusion["texture"];
-	if(luabind::type(cur) != LUA_TNIL) {
+	if (luabind::type(cur) != LUA_TNIL) {
 		try {
-			texture = luabind::object_cast<int>(cur);
-		} catch(luabind::cast_failed &) {
+			texture = luabind::object_cast<uint8>(cur);
+		} catch (luabind::cast_failed &) {
 		}
 	}
 
 	cur = illusion["helmtexture"];
-	if(luabind::type(cur) != LUA_TNIL) {
+	if (luabind::type(cur) != LUA_TNIL) {
 		try {
-			helmtexture = luabind::object_cast<int>(cur);
-		} catch(luabind::cast_failed &) {
+			helmtexture = luabind::object_cast<uint8>(cur);
+		} catch (luabind::cast_failed &) {
 		}
 	}
 
 	cur = illusion["haircolor"];
-	if(luabind::type(cur) != LUA_TNIL) {
+	if (luabind::type(cur) != LUA_TNIL) {
 		try {
-			haircolor = luabind::object_cast<int>(cur);
-		} catch(luabind::cast_failed &) {
+			haircolor = luabind::object_cast<uint8>(cur);
+		} catch (luabind::cast_failed &) {
 		}
 	}
 
 	cur = illusion["beardcolor"];
-	if(luabind::type(cur) != LUA_TNIL) {
+	if (luabind::type(cur) != LUA_TNIL) {
 		try {
-			beardcolor = luabind::object_cast<int>(cur);
-		} catch(luabind::cast_failed &) {
+			beardcolor = luabind::object_cast<uint8>(cur);
+		} catch (luabind::cast_failed &) {
 		}
 	}
 
 	cur = illusion["eyecolor1"];
-	if(luabind::type(cur) != LUA_TNIL) {
+	if (luabind::type(cur) != LUA_TNIL) {
 		try {
-			eyecolor1 = luabind::object_cast<int>(cur);
-		} catch(luabind::cast_failed &) {
+			eyecolor1 = luabind::object_cast<uint8>(cur);
+		} catch (luabind::cast_failed &) {
 		}
 	}
 
 	cur = illusion["eyecolor2"];
-	if(luabind::type(cur) != LUA_TNIL) {
+	if (luabind::type(cur) != LUA_TNIL) {
 		try {
-			eyecolor2 = luabind::object_cast<int>(cur);
-		} catch(luabind::cast_failed &) {
+			eyecolor2 = luabind::object_cast<uint8>(cur);
+		} catch (luabind::cast_failed &) {
 		}
 	}
 
 	cur = illusion["hairstyle"];
-	if(luabind::type(cur) != LUA_TNIL) {
+	if (luabind::type(cur) != LUA_TNIL) {
 		try {
-			hairstyle = luabind::object_cast<int>(cur);
-		} catch(luabind::cast_failed &) {
+			hairstyle = luabind::object_cast<uint8>(cur);
+		} catch (luabind::cast_failed &) {
 		}
 	}
 
 	cur = illusion["luclinface"];
-	if(luabind::type(cur) != LUA_TNIL) {
+	if (luabind::type(cur) != LUA_TNIL) {
 		try {
-			luclinface = luabind::object_cast<int>(cur);
-		} catch(luabind::cast_failed &) {
+			luclinface = luabind::object_cast<uint8>(cur);
+		} catch (luabind::cast_failed &) {
 		}
 	}
 
 	cur = illusion["beard"];
-	if(luabind::type(cur) != LUA_TNIL) {
+	if (luabind::type(cur) != LUA_TNIL) {
 		try {
-			beard = luabind::object_cast<int>(cur);
-		} catch(luabind::cast_failed &) {
+			beard = luabind::object_cast<uint8>(cur);
+		} catch (luabind::cast_failed &) {
 		}
 	}
 
 	cur = illusion["aa_title"];
-	if(luabind::type(cur) != LUA_TNIL) {
+	if (luabind::type(cur) != LUA_TNIL) {
 		try {
-			aa_title = luabind::object_cast<int>(cur);
-		} catch(luabind::cast_failed &) {
+			aa_title = luabind::object_cast<uint8>(cur);
+		} catch (luabind::cast_failed &) {
 		}
 	}
 
 	cur = illusion["drakkin_heritage"];
-	if(luabind::type(cur) != LUA_TNIL) {
+	if (luabind::type(cur) != LUA_TNIL) {
 		try {
-			drakkin_heritage = luabind::object_cast<int>(cur);
-		} catch(luabind::cast_failed &) {
+			drakkin_heritage = luabind::object_cast<uint32>(cur);
+		} catch (luabind::cast_failed &) {
 		}
 	}
 
 	cur = illusion["drakkin_tattoo"];
-	if(luabind::type(cur) != LUA_TNIL) {
+	if (luabind::type(cur) != LUA_TNIL) {
 		try {
-			drakkin_tattoo = luabind::object_cast<int>(cur);
-		} catch(luabind::cast_failed &) {
+			drakkin_tattoo = luabind::object_cast<uint32>(cur);
+		} catch (luabind::cast_failed &) {
 		}
 	}
 
 	cur = illusion["drakkin_details"];
-	if(luabind::type(cur) != LUA_TNIL) {
+	if (luabind::type(cur) != LUA_TNIL) {
 		try {
-			drakkin_details = luabind::object_cast<int>(cur);
-		} catch(luabind::cast_failed &) {
+			drakkin_details = luabind::object_cast<uint32>(cur);
+		} catch (luabind::cast_failed &) {
 		}
 	}
 
 	cur = illusion["size"];
-	if(luabind::type(cur) != LUA_TNIL) {
+	if (luabind::type(cur) != LUA_TNIL) {
 		try {
 			size = luabind::object_cast<float>(cur);
-		} catch(luabind::cast_failed &) {
+		} catch (luabind::cast_failed &) {
 		}
 	}
 
-	self->SendIllusionPacket(race, gender, texture, helmtexture, haircolor, beardcolor, eyecolor1, eyecolor2, hairstyle, luclinface,
-		beard, aa_title, drakkin_heritage, drakkin_tattoo, drakkin_details, size);
+	cur = illusion["target"];
+	if (luabind::type(cur) != LUA_TNIL) {
+		try {
+			target = luabind::object_cast<Lua_Client>(cur);
+		} catch (luabind::cast_failed &) {
+		}
+	}
+
+	self->SendIllusionPacket(
+		race,
+		gender,
+		texture,
+		helmtexture,
+		haircolor,
+		beardcolor,
+		eyecolor1,
+		eyecolor2,
+		hairstyle,
+		luclinface,
+		beard,
+		aa_title,
+		drakkin_heritage,
+		drakkin_tattoo,
+		drakkin_details,
+		size,
+		true,
+		target
+	);
 }
 
 void Lua_Mob::ChangeRace(int in) {

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -518,7 +518,7 @@ Mob::Mob(
 }
 
 Mob::~Mob()
-{ 
+{
 	quest_manager.stopalltimers(this);
 
 	mMovementManager->RemoveMob(this);
@@ -2418,7 +2418,8 @@ void Mob::SendIllusionPacket(
 	uint32 in_drakkin_tattoo,
 	uint32 in_drakkin_details,
 	float in_size,
-	bool send_appearance_effects
+	bool send_appearance_effects,
+	Client* target
 )
 {
 	uint8  new_texture     = in_texture;
@@ -2521,7 +2522,12 @@ void Mob::SendIllusionPacket(
 	is->drakkin_details  = new_drakkin_details;
 	is->size             = size;
 
-	entity_list.QueueClients(this, outapp);
+	if (!target) {
+		entity_list.QueueClients(this, outapp);
+	} else {
+		target->QueuePacket(outapp, false);
+	}
+
 	safe_delete(outapp);
 
 	/* Refresh armor and tints after send illusion packet */
@@ -2532,7 +2538,7 @@ void Mob::SendIllusionPacket(
 	}
 
 	LogSpells(
-		"Illusion: Race [{}] Gender [{}] Texture [{}] HelmTexture [{}] HairColor [{}] BeardColor [{}] EyeColor1 [{}] EyeColor2 [{}] HairStyle [{}] Face [{}] DrakkinHeritage [{}] DrakkinTattoo [{}] DrakkinDetails [{}] Size [{}]",
+		"Illusion: Race [{}] Gender [{}] Texture [{}] HelmTexture [{}] HairColor [{}] BeardColor [{}] EyeColor1 [{}] EyeColor2 [{}] HairStyle [{}] Face [{}] DrakkinHeritage [{}] DrakkinTattoo [{}] DrakkinDetails [{}] Size [{}] Target [{}]",
 		race,
 		gender,
 		new_texture,
@@ -2546,7 +2552,8 @@ void Mob::SendIllusionPacket(
 		new_drakkin_heritage,
 		new_drakkin_tattoo,
 		new_drakkin_details,
-		size
+		size,
+		target ? target->GetCleanName() : "No Target"
 	);
 }
 

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -899,7 +899,8 @@ public:
 		uint32 in_drakkin_tattoo = 0xFFFFFFFF,
 		uint32 in_drakkin_details = 0xFFFFFFFF,
 		float in_size = -1.0f,
-		bool send_appearance_effects = true
+		bool send_appearance_effects = true,
+		Client* target = nullptr
 	);
 	void CloneAppearance(Mob* other, bool clone_name = false);
 	void SetFaceAppearance(const FaceChange_Struct& face, bool skip_sender = false);

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -1861,6 +1861,82 @@ void Perl_Mob_SendIllusion(Mob* self, uint16 race, uint8 gender, uint8 texture, 
 	self->SendIllusionPacket(race, gender, texture, helmtexture, haircolor, beardcolor, 0xFF, 0xFF, hairstyle, face, beard, 0xFF, drakkin_heritage, drakkin_tattoo, drakkin_details, size);
 }
 
+void Perl_Mob_SendIllusion(Mob* self, uint16 race, uint8 gender, uint8 texture, uint8 helmtexture, uint8 face, uint8 hairstyle, uint8 haircolor, uint8 beard, uint8 beardcolor, uint32 drakkin_heritage, uint32 drakkin_tattoo, uint32 drakkin_details, float size, Client* target) // @categories Script Utility
+{
+	self->SendIllusionPacket(race, gender, texture, helmtexture, haircolor, beardcolor, 0xFF, 0xFF, hairstyle, face, beard, 0xFF, drakkin_heritage, drakkin_tattoo, drakkin_details, size, true, target);
+}
+
+void Perl_Mob_SendIllusionPacket(Mob* self, perl::reference table_ref)
+{
+	perl::hash table = table_ref;
+	if (!table.exists("race")) {
+		return;
+	}
+
+	uint16  race             = table["race"];
+	uint8   gender           = table.exists("gender") ? table["gender"] : MALE;
+	uint8   texture          = table.exists("texture") ? table["texture"] : 255;
+	uint8   helmtexture      = table.exists("helmtexture") ? table["helmtexture"] : 255;
+	uint8   haircolor        = table.exists("haircolor") ? table["haircolor"] : 255;
+	uint8   beardcolor       = table.exists("beardcolor") ? table["beardcolor"] : 255;
+	uint8   eyecolor1        = table.exists("eyecolor1") ? table["eyecolor1"] : 255;
+	uint8   eyecolor2        = table.exists("eyecolor2") ? table["eyecolor2"] : 255;
+	uint8   hairstyle        = table.exists("hairstyle") ? table["hairstyle"] : 255;
+	uint8   luclinface       = table.exists("luclinface") ? table["luclinface"] : 255;
+	uint8   beard            = table.exists("beard") ? table["beard"] : 255;
+	uint8   aa_title         = table.exists("aa_title") ? table["aa_title"] : 255;
+	uint32  drakkin_heritage = table.exists("drakkin_heritage") ? table["drakkin_heritage"] : 4294967295;
+	uint32  drakkin_tattoo   = table.exists("drakkin_tattoo") ? table["drakkin_tattoo"] : 4294967295;
+	uint32  drakkin_details  = table.exists("drakkin_details") ? table["drakkin_details"] : 4294967295;
+	float   size             = table.exists("size") ? table["size"] : -1.0f;
+	Client* target           = table.exists("target") ? static_cast<Client*>(table["target"]) : nullptr;
+
+	if (self->IsClient()) {
+		self->CastToClient()->Message(
+			Chat::White,
+			fmt::format(
+				"Illusion: Race [{}] Gender [{}] Texture [{}] HelmTexture [{}] HairColor [{}] BeardColor [{}] EyeColor1 [{}] EyeColor2 [{}] HairStyle [{}] Face [{}] DrakkinHeritage [{}] DrakkinTattoo [{}] DrakkinDetails [{}] Size [{}] Target [{}]",
+				race,
+				gender,
+				texture,
+				helmtexture,
+				haircolor,
+				beardcolor,
+				eyecolor1,
+				eyecolor2,
+				hairstyle,
+				luclinface,
+				drakkin_heritage,
+				drakkin_tattoo,
+				drakkin_details,
+				size,
+				target ? target->GetCleanName() : "No Target"
+			).c_str()
+		);
+	}
+
+	self->SendIllusionPacket(
+		race,
+		gender,
+		texture,
+		helmtexture,
+		haircolor,
+		beardcolor,
+		eyecolor1,
+		eyecolor2,
+		hairstyle,
+		luclinface,
+		beard,
+		aa_title,
+		drakkin_heritage,
+		drakkin_tattoo,
+		drakkin_details,
+		size,
+		true,
+		target
+	);
+}
+
 void Perl_Mob_CameraEffect(Mob* self, uint32 duration) // @categories Script Utility
 {
 	self->CameraEffect(duration, 0.03125f);
@@ -3292,6 +3368,8 @@ void perl_register_mob()
 	package.add("SendIllusion", (void(*)(Mob*, uint16, uint8, uint8, uint8, uint8, uint8, uint8, uint8, uint8, uint32, uint32))&Perl_Mob_SendIllusion);
 	package.add("SendIllusion", (void(*)(Mob*, uint16, uint8, uint8, uint8, uint8, uint8, uint8, uint8, uint8, uint32, uint32, uint32))&Perl_Mob_SendIllusion);
 	package.add("SendIllusion", (void(*)(Mob*, uint16, uint8, uint8, uint8, uint8, uint8, uint8, uint8, uint8, uint32, uint32, uint32, float))&Perl_Mob_SendIllusion);
+	package.add("SendIllusion", (void(*)(Mob*, uint16, uint8, uint8, uint8, uint8, uint8, uint8, uint8, uint8, uint32, uint32, uint32, float, Client*))&Perl_Mob_SendIllusion);
+	package.add("SendIllusionPacket", (void(*)(Mob*, perl::reference))&Perl_Mob_SendIllusionPacket);
 	package.add("SendTo", &Perl_Mob_SendTo);
 	package.add("SendToFixZ", &Perl_Mob_SendToFixZ);
 	package.add("SendWearChange", &Perl_Mob_SendWearChange);

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -1869,26 +1869,23 @@ void Perl_Mob_SendIllusion(Mob* self, uint16 race, uint8 gender, uint8 texture, 
 void Perl_Mob_SendIllusionPacket(Mob* self, perl::reference table_ref)
 {
 	perl::hash table = table_ref;
-	if (!table.exists("race")) {
-		return;
-	}
 
-	uint16  race             = table["race"];
-	uint8   gender           = table.exists("gender") ? table["gender"] : MALE;
-	uint8   texture          = table.exists("texture") ? table["texture"] : 255;
-	uint8   helmtexture      = table.exists("helmtexture") ? table["helmtexture"] : 255;
-	uint8   haircolor        = table.exists("haircolor") ? table["haircolor"] : 255;
-	uint8   beardcolor       = table.exists("beardcolor") ? table["beardcolor"] : 255;
-	uint8   eyecolor1        = table.exists("eyecolor1") ? table["eyecolor1"] : 255;
-	uint8   eyecolor2        = table.exists("eyecolor2") ? table["eyecolor2"] : 255;
-	uint8   hairstyle        = table.exists("hairstyle") ? table["hairstyle"] : 255;
-	uint8   luclinface       = table.exists("luclinface") ? table["luclinface"] : 255;
-	uint8   beard            = table.exists("beard") ? table["beard"] : 255;
+	uint16  race             = table.exists("race") ? table["race"] : self->GetRace();
+	uint8   gender           = table.exists("gender") ? table["gender"] : self->GetGender();
+	uint8   texture          = table.exists("texture") ? table["texture"] : self->GetTexture();
+	uint8   helmtexture      = table.exists("helmtexture") ? table["helmtexture"] : self->GetHelmTexture();
+	uint8   haircolor        = table.exists("haircolor") ? table["haircolor"] : self->GetHairColor();
+	uint8   beardcolor       = table.exists("beardcolor") ? table["beardcolor"] : self->GetBeardColor();
+	uint8   eyecolor1        = table.exists("eyecolor1") ? table["eyecolor1"] : self->GetEyeColor1();
+	uint8   eyecolor2        = table.exists("eyecolor2") ? table["eyecolor2"] : self->GetEyeColor2();
+	uint8   hairstyle        = table.exists("hairstyle") ? table["hairstyle"] : self->GetHairStyle();
+	uint8   luclinface       = table.exists("luclinface") ? table["luclinface"] : self->GetLuclinFace();
+	uint8   beard            = table.exists("beard") ? table["beard"] : self->GetBeard();
 	uint8   aa_title         = table.exists("aa_title") ? table["aa_title"] : 255;
-	uint32  drakkin_heritage = table.exists("drakkin_heritage") ? table["drakkin_heritage"] : 4294967295;
-	uint32  drakkin_tattoo   = table.exists("drakkin_tattoo") ? table["drakkin_tattoo"] : 4294967295;
-	uint32  drakkin_details  = table.exists("drakkin_details") ? table["drakkin_details"] : 4294967295;
-	float   size             = table.exists("size") ? table["size"] : -1.0f;
+	uint32  drakkin_heritage = table.exists("drakkin_heritage") ? table["drakkin_heritage"] : self->GetDrakkinHeritage();
+	uint32  drakkin_tattoo   = table.exists("drakkin_tattoo") ? table["drakkin_tattoo"] : self->GetDrakkinTattoo();
+	uint32  drakkin_details  = table.exists("drakkin_details") ? table["drakkin_details"] : self->GetDrakkinDetails();
+	float   size             = table.exists("size") ? table["size"] : self->GetSize();
 	Client* target           = table.exists("target") ? static_cast<Client*>(table["target"]) : nullptr;
 
 	if (self->IsClient()) {

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -1906,7 +1906,7 @@ void Perl_Mob_SendIllusionPacket(Mob* self, perl::reference table_ref)
 		drakkin_tattoo,
 		drakkin_details,
 		size,
-		send_appearances,
+		send_appearance_effects,
 		target
 	);
 }

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -1886,31 +1886,8 @@ void Perl_Mob_SendIllusionPacket(Mob* self, perl::reference table_ref)
 	uint32  drakkin_tattoo   = table.exists("drakkin_tattoo") ? table["drakkin_tattoo"] : self->GetDrakkinTattoo();
 	uint32  drakkin_details  = table.exists("drakkin_details") ? table["drakkin_details"] : self->GetDrakkinDetails();
 	float   size             = table.exists("size") ? table["size"] : self->GetSize();
-	Client* target           = table.exists("target") ? static_cast<Client*>(table["target"]) : nullptr;
-
-	if (self->IsClient()) {
-		self->CastToClient()->Message(
-			Chat::White,
-			fmt::format(
-				"Illusion: Race [{}] Gender [{}] Texture [{}] HelmTexture [{}] HairColor [{}] BeardColor [{}] EyeColor1 [{}] EyeColor2 [{}] HairStyle [{}] Face [{}] DrakkinHeritage [{}] DrakkinTattoo [{}] DrakkinDetails [{}] Size [{}] Target [{}]",
-				race,
-				gender,
-				texture,
-				helmtexture,
-				haircolor,
-				beardcolor,
-				eyecolor1,
-				eyecolor2,
-				hairstyle,
-				luclinface,
-				drakkin_heritage,
-				drakkin_tattoo,
-				drakkin_details,
-				size,
-				target ? target->GetCleanName() : "No Target"
-			).c_str()
-		);
-	}
+	bool    send_appearances = table.exists("send_appearances") ? table["send_appearances"] : true;
+	Client* target           = table.exists("target") ? static_cast<Client *>(table["target"]) : nullptr;
 
 	self->SendIllusionPacket(
 		race,
@@ -1929,7 +1906,7 @@ void Perl_Mob_SendIllusionPacket(Mob* self, perl::reference table_ref)
 		drakkin_tattoo,
 		drakkin_details,
 		size,
-		true,
+		send_appearances,
 		target
 	);
 }

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -1870,24 +1870,24 @@ void Perl_Mob_SendIllusionPacket(Mob* self, perl::reference table_ref)
 {
 	perl::hash table = table_ref;
 
-	uint16  race             = table.exists("race") ? table["race"] : self->GetRace();
-	uint8   gender           = table.exists("gender") ? table["gender"] : self->GetGender();
-	uint8   texture          = table.exists("texture") ? table["texture"] : self->GetTexture();
-	uint8   helmtexture      = table.exists("helmtexture") ? table["helmtexture"] : self->GetHelmTexture();
-	uint8   haircolor        = table.exists("haircolor") ? table["haircolor"] : self->GetHairColor();
-	uint8   beardcolor       = table.exists("beardcolor") ? table["beardcolor"] : self->GetBeardColor();
-	uint8   eyecolor1        = table.exists("eyecolor1") ? table["eyecolor1"] : self->GetEyeColor1();
-	uint8   eyecolor2        = table.exists("eyecolor2") ? table["eyecolor2"] : self->GetEyeColor2();
-	uint8   hairstyle        = table.exists("hairstyle") ? table["hairstyle"] : self->GetHairStyle();
-	uint8   luclinface       = table.exists("luclinface") ? table["luclinface"] : self->GetLuclinFace();
-	uint8   beard            = table.exists("beard") ? table["beard"] : self->GetBeard();
-	uint8   aa_title         = table.exists("aa_title") ? table["aa_title"] : 255;
-	uint32  drakkin_heritage = table.exists("drakkin_heritage") ? table["drakkin_heritage"] : self->GetDrakkinHeritage();
-	uint32  drakkin_tattoo   = table.exists("drakkin_tattoo") ? table["drakkin_tattoo"] : self->GetDrakkinTattoo();
-	uint32  drakkin_details  = table.exists("drakkin_details") ? table["drakkin_details"] : self->GetDrakkinDetails();
-	float   size             = table.exists("size") ? table["size"] : self->GetSize();
-	bool    send_appearances = table.exists("send_appearances") ? table["send_appearances"] : true;
-	Client* target           = table.exists("target") ? static_cast<Client *>(table["target"]) : nullptr;
+	uint16  race                    = table.exists("race") ? table["race"] : self->GetRace();
+	uint8   gender                  = table.exists("gender") ? table["gender"] : self->GetGender();
+	uint8   texture                 = table.exists("texture") ? table["texture"] : self->GetTexture();
+	uint8   helmtexture             = table.exists("helmtexture") ? table["helmtexture"] : self->GetHelmTexture();
+	uint8   haircolor               = table.exists("haircolor") ? table["haircolor"] : self->GetHairColor();
+	uint8   beardcolor              = table.exists("beardcolor") ? table["beardcolor"] : self->GetBeardColor();
+	uint8   eyecolor1               = table.exists("eyecolor1") ? table["eyecolor1"] : self->GetEyeColor1();
+	uint8   eyecolor2               = table.exists("eyecolor2") ? table["eyecolor2"] : self->GetEyeColor2();
+	uint8   hairstyle               = table.exists("hairstyle") ? table["hairstyle"] : self->GetHairStyle();
+	uint8   luclinface              = table.exists("luclinface") ? table["luclinface"] : self->GetLuclinFace();
+	uint8   beard                   = table.exists("beard") ? table["beard"] : self->GetBeard();
+	uint8   aa_title                = table.exists("aa_title") ? table["aa_title"] : 255;
+	uint32  drakkin_heritage        = table.exists("drakkin_heritage") ? table["drakkin_heritage"] : self->GetDrakkinHeritage();
+	uint32  drakkin_tattoo          = table.exists("drakkin_tattoo") ? table["drakkin_tattoo"] : self->GetDrakkinTattoo();
+	uint32  drakkin_details         = table.exists("drakkin_details") ? table["drakkin_details"] : self->GetDrakkinDetails();
+	float   size                    = table.exists("size") ? table["size"] : self->GetSize();
+	bool    send_appearance_effects = table.exists("send_appearance_effects") ? table["send_appearance_effects"] : true;
+	Client* target                  = table.exists("target") ? static_cast<Client *>(table["target"]) : nullptr;
 
 	self->SendIllusionPacket(
 		race,


### PR DESCRIPTION
# Perl
- Add `$mob->SendIllusion(race, gender, texture, helmtexture, face, hairstyle, haircolor, beard, beardcolor, drakkin_heritage, drakkin_tattoo, drakkin_details, size, target)`.
- Add `$mob->SendIllusionPacket(illusion_table_ref)`.

# Lua
- Add `target` to `mob:SendIllusion(table)`.
- Cleanup data types.

# Notes
- Adds overloads with a specific client capability and a hash capability in Perl.

# Perl Hash Example
```pl
sub EVENT_SAY {
	if ($text=~/#a/i) {
		my %illusion_data = (
			"race" => 522,
			"gender" => 0,
			"texture" => 3,
			"size" => 20
		);
		$client->SendIllusionPacket(\%illusion_data);
	}
}
```