### PR TITLE
[Commands] Allow clients with access level to #undye to undye themselves

### DIFF
--- a/zone/gm_commands/undye.cpp
+++ b/zone/gm_commands/undye.cpp
@@ -3,16 +3,22 @@
 void command_undye(Client *c, const Seperator *sep)
 {
 	auto target = c;
-	if (c->GetTarget() && c->GetTarget()->IsClient() && c->GetGM()) {
-		target = c->GetTarget()->CastToClient();
-	}
 
-	target->Undye();
-	c->Message(
-		Chat::White,
-		fmt::format(
-			"Undyed armor for {}.",
-			c->GetTargetDescription(target)
-		).c_str()
-	);
+	bool allowed=(c->GetGM() || c->GetTarget() == c);
+
+	if (allowed) {
+		target = c->GetTarget()->CastToClient();
+
+		target->Undye();
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"Undyed armor for {}.",
+				c->GetTargetDescription(target)
+			).c_str()
+		);
+	}
+	else {
+		c->Message(Chat::Red, "Only clients tagged as GM allowed to undye others");
+	}
 }


### PR DESCRIPTION
Some servers (at least mine) used #undyeme at access level 0 for their players.  The removal of the #2776 removed that access.

Since the control to #undye lies in the database access level, this change allows anyone with the correct access level in the db to #undye themselves, but only GMs to #undye others.

This restores the functionality without the need for the extra command.