### PR TITLE
[Cleanup] Remove DoBuffWearOffEffect() from mob.h

### DIFF
--- a/zone/mob.h
+++ b/zone/mob.h
@@ -917,7 +917,6 @@ public:
 	bool PassCharismaCheck(Mob* caster, uint16 spell_id);
 	bool TryDeathSave();
 	bool TryDivineSave();
-	void DoBuffWearOffEffect(uint32 index);
 	void TryTriggerOnCastFocusEffect(focusType type, uint16 spell_id);
 	bool TryTriggerOnCastProc(uint16 focusspellid, uint16 spell_id, uint16 proc_spellid);
 	bool TrySpellTrigger(Mob *target, uint32 spell_id, int effect);


### PR DESCRIPTION
# Notes
- This is unused.