### PR TITLE
[Cleanup] Remove last_max_hp from mob.h

### DIFF
--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1772,7 +1772,6 @@ protected:
 
 	int8 last_hp_percent;
 	int32 last_hp;
-	int32 last_max_hp;
 
 	int cur_wp;
 	glm::vec4 m_CurrentWayPoint;


### PR DESCRIPTION
# Notes
- This is unused.