### PR TITLE
[Cleanup] Remove casting_spell_type from mob.h

### DIFF
--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1644,7 +1644,6 @@ protected:
 	uint32 casting_spell_inventory_slot;
 	uint32 casting_spell_timer;
 	uint32 casting_spell_timer_duration;
-	uint32 casting_spell_type;
 	int16 casting_spell_resist_adjust;
 	uint32 casting_spell_aa_id;
 	uint32 casting_spell_recast_adjust;


### PR DESCRIPTION
# Notes
- This is unused.