### PR TITLE
[Cleanup] Remove FlushLootStats() from npc.h

### DIFF
--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -3778,11 +3778,6 @@ void NPC::SetRecordLootStats(bool record_loot_stats)
 	NPC::m_record_loot_stats = record_loot_stats;
 }
 
-void NPC::FlushLootStats()
-{
-	m_rolled_items = {};
-}
-
 const std::vector<uint32> &NPC::GetRolledItems() const
 {
 	return m_rolled_items;

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -115,7 +115,6 @@ public:
 	// loot recording / simulator
 	bool IsRecordLootStats() const;
 	void SetRecordLootStats(bool record_loot_stats);
-	void FlushLootStats();
 	const std::vector<uint32> &GetRolledItems() const;
 	int GetRolledItemCount(uint32 item_id);
 


### PR DESCRIPTION
# Notes
- This is unused.