### PR TITLE
[Cleanup] Remove GetTransformation() and GetInvertedTransformation() from oriented_bounding_box.h

### DIFF
--- a/zone/oriented_bounding_box.h
+++ b/zone/oriented_bounding_box.h
@@ -12,9 +12,6 @@ public:
 	~OrientedBoundingBox() { }
 
 	bool ContainsPoint(const glm::vec3 &p) const;
-	
-	glm::mat4& GetTransformation() { return transformation; }
-	glm::mat4& GetInvertedTransformation() { return inverted_transformation; }
 private:
 	float min_x, max_x;
 	float min_y, max_y;


### PR DESCRIPTION
# Notes
- These are unused.