### PR TITLE
[Cleanup] Remove GetStartCount() and InitStartTimer() from zone_launch.cpp and zone_launch.h

### DIFF
--- a/eqlaunch/zone_launch.cpp
+++ b/eqlaunch/zone_launch.cpp
@@ -28,11 +28,6 @@
 int ZoneLaunch::s_running = 0;	//the number of zones running under this launcher
 Timer ZoneLaunch::s_startTimer(1);	//I do not trust this things state after static initialization
 
-void ZoneLaunch::InitStartTimer() {
-	s_startTimer.Start(1);
-	s_startTimer.Trigger();
-}
-
 ZoneLaunch::ZoneLaunch(WorldServer *world, const char *launcher_name,
 const char *zone_name, uint16 port, const EQEmuConfig *config)
 : m_state(StateStartPending),

--- a/eqlaunch/zone_launch.h
+++ b/eqlaunch/zone_launch.h
@@ -39,10 +39,6 @@ public:
 	void SendStatus() const;
 
 	const char *GetZone() const { return(m_zone.c_str()); }
-	uint32 GetStartCount() const { return(m_startCount); }
-
-	//should only be called during process init to setup the start timer.
-	static void InitStartTimer();
 
 protected:
 	bool IsRunning() const { return(m_state == StateStarted || m_state == StateStopPending || m_state == StateRestartPending); }


### PR DESCRIPTION
# Notes
- These are unused.