### PR TITLE
[Rule] Add Rule to allow ExtraDmgSkill/SPA 220 to effect Spell Skills

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -350,6 +350,7 @@ RULE_REAL(Watermap, FishingLineStepSize, 1, "Basic step size for fishing calc, t
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Spells)
+RULE_BOOL(Spells, AllowExtraDmgSkill, false, "Allow ExtraDmgSkill from Items, Spells, and AAs to apply ExtraDmgAmt when the ExtraDmgSkill matches the casted Spells Skill Type.")
 RULE_INT(Spells, BaseCritChance, 0, "Base percentage chance that everyone has to crit a spell")
 RULE_INT(Spells, BaseCritRatio, 100, "Base percentage bonus to damage on a successful spell crit. 100=2xdamage")
 RULE_INT(Spells, WizCritLevel, 12, "Level wizards first get spell crits")

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -42,11 +42,17 @@ float Mob::GetActSpellRange(uint16 spell_id, float range)
 
 int64 Mob::GetActSpellDamage(uint16 spell_id, int64 value, Mob* target) {
 
-	if (spells[spell_id].target_type == ST_Self)
+	if (spells[spell_id].target_type == ST_Self) {
 		return value;
+	}
 
-	if (IsNPC())
-		value += value*CastToNPC()->GetSpellFocusDMG()/100;
+	if (IsNPC()) {
+		value += value * CastToNPC()->GetSpellFocusDMG() / 100;
+
+		if (CastToNPC()->GetSpellScale()) {
+			value = int64(static_cast<float>(value) * CastToNPC()->GetSpellScale() / 100.0f);
+		}
+	}
 
 	bool Critical = false;
 	int64 base_value = value;
@@ -57,12 +63,13 @@ int64 Mob::GetActSpellDamage(uint16 spell_id, int64 value, Mob* target) {
 		value -= (GetLevel() - 40) * 20;
 
 	//This adds the extra damage from the AA Unholy Touch, 450 per level to the AA Improved Harm TOuch.
-	if (spell_id == SPELL_IMP_HARM_TOUCH && IsOfClientBot()) //Improved Harm Touch
+	if (spell_id == SPELL_IMP_HARM_TOUCH && IsOfClientBot()) { //Improved Harm Touch
 		value -= GetAA(aaUnholyTouch) * 450; //Unholy Touch
+	}
 
-		chance = RuleI(Spells, BaseCritChance); //Wizard base critical chance is 2% (Does not scale with level)
-		chance += itembonuses.CriticalSpellChance + spellbonuses.CriticalSpellChance + aabonuses.CriticalSpellChance;
-		chance += itembonuses.FrenziedDevastation + spellbonuses.FrenziedDevastation + aabonuses.FrenziedDevastation;
+	chance = RuleI(Spells, BaseCritChance); //Wizard base critical chance is 2% (Does not scale with level)
+	chance += itembonuses.CriticalSpellChance + spellbonuses.CriticalSpellChance + aabonuses.CriticalSpellChance;
+	chance += itembonuses.FrenziedDevastation + spellbonuses.FrenziedDevastation + aabonuses.FrenziedDevastation;
 
 	//Crtical Hit Calculation pathway
 	if (chance > 0 || (IsOfClientBot() && GetClass() == WIZARD && GetLevel() >= RuleI(Spells, WizCritLevel))) {
@@ -90,10 +97,11 @@ int64 Mob::GetActSpellDamage(uint16 spell_id, int64 value, Mob* target) {
 			}
 		}
 
-		if (IsOfClientBot() && GetClass() == WIZARD)
+		if (IsOfClientBot() && GetClass() == WIZARD) {
 			ratio += RuleI(Spells, WizCritRatio); //Default is zero
+		}
 
-		if (Critical){
+		if (Critical) {
 
 			value = base_value*ratio/100;
 
@@ -114,14 +122,17 @@ int64 Mob::GetActSpellDamage(uint16 spell_id, int64 value, Mob* target) {
 			value -= GetFocusEffect(focusFcDamageAmt2, spell_id);
 			value -= GetFocusEffect(focusFcAmplifyAmt, spell_id);
 
-			if (RuleB(Spells, IgnoreSpellDmgLvlRestriction) && !spells[spell_id].no_heal_damage_item_mod && itembonuses.SpellDmg)
-				value -= GetExtraSpellAmt(spell_id, itembonuses.SpellDmg, base_value)*ratio / 100;
+			if (RuleB(Spells, AllowExtraDmgSkill)) {
+				value -= GetSkillDmgAmt(spells[spell_id].skill) * ratio / 100;
+			}
 
-			else if(!spells[spell_id].no_heal_damage_item_mod && itembonuses.SpellDmg && spells[spell_id].classes[(GetClass() % 17) - 1] >= GetLevel() - 5)
-				value -= GetExtraSpellAmt(spell_id, itembonuses.SpellDmg, base_value)*ratio/100;
+			if (RuleB(Spells, IgnoreSpellDmgLvlRestriction) && !spells[spell_id].no_heal_damage_item_mod && itembonuses.SpellDmg) {
+				value -= GetExtraSpellAmt(spell_id, itembonuses.SpellDmg, base_value) * ratio / 100;
+			}
 
-			else if (IsNPC() && CastToNPC()->GetSpellScale())
-				value = int64(static_cast<float>(value) * CastToNPC()->GetSpellScale() / 100.0f);
+			else if (!spells[spell_id].no_heal_damage_item_mod && itembonuses.SpellDmg && spells[spell_id].classes[(GetClass() % 17) - 1] >= GetLevel() - 5) {
+				value -= GetExtraSpellAmt(spell_id, itembonuses.SpellDmg, base_value) * ratio / 100;
+			}
 
 			entity_list.FilteredMessageCloseString(
 				this, true, 100, Chat::SpellCrit, FilterSpellCrits,
@@ -153,14 +164,15 @@ int64 Mob::GetActSpellDamage(uint16 spell_id, int64 value, Mob* target) {
 	value -= GetFocusEffect(focusFcDamageAmt2, spell_id);
 	value -= GetFocusEffect(focusFcAmplifyAmt, spell_id);
 
+	if (RuleB(Spells, AllowExtraDmgSkill)) {
+		value -= GetSkillDmgAmt(spells[spell_id].skill);
+	}
+
 	if (RuleB(Spells, IgnoreSpellDmgLvlRestriction) && !spells[spell_id].no_heal_damage_item_mod && itembonuses.SpellDmg)
 		value -= GetExtraSpellAmt(spell_id, itembonuses.SpellDmg, base_value);
 
 	else if (!spells[spell_id].no_heal_damage_item_mod && itembonuses.SpellDmg && spells[spell_id].classes[(GetClass() % 17) - 1] >= GetLevel() - 5)
 		 value -= GetExtraSpellAmt(spell_id, itembonuses.SpellDmg, base_value);
-
-	if (IsNPC() && CastToNPC()->GetSpellScale())
-		value = int64(static_cast<float>(value) * CastToNPC()->GetSpellScale() / 100.0f);
 
 	return value;
 }
@@ -185,6 +197,10 @@ int64 Mob::GetActReflectedSpellDamage(uint16 spell_id, int64 value, int effectiv
 
 	value = value * effectiveness / 100;
 
+	if (RuleB(Spells, AllowExtraDmgSkill)) {
+		value -= GetSkillDmgAmt(spells[spell_id].skill);
+	}
+
 	if (!spells[spell_id].no_heal_damage_item_mod && itembonuses.SpellDmg) {
 		value -= GetExtraSpellAmt(spell_id, itembonuses.SpellDmg, base_spell_dmg);
 	}
@@ -199,6 +215,10 @@ int64 Mob::GetActDoTDamage(uint16 spell_id, int64 value, Mob* target, bool from_
 
 	if (IsNPC()) {
 		value += value * CastToNPC()->GetSpellFocusDMG() / 100;
+
+		if (CastToNPC()->GetSpellScale()) {
+			value = int64(static_cast<float>(value) * CastToNPC()->GetSpellScale() / 100.0f);
+		}
 	}
 
 	int64 base_value = value;
@@ -236,6 +256,10 @@ int64 Mob::GetActDoTDamage(uint16 spell_id, int64 value, Mob* target, bool from_
 			}
 		}
 
+		if (RuleB(Spells, AllowExtraDmgSkill)) {
+			extra_dmg += GetSkillDmgAmt(spells[spell_id].skill) * ratio / 100;
+		}
+
 		if (extra_dmg) {
 			int duration = CalcBuffDuration(this, target, spell_id);
 			if (duration > 0)
@@ -267,6 +291,10 @@ int64 Mob::GetActDoTDamage(uint16 spell_id, int64 value, Mob* target, bool from_
 			}
 		}
 
+		if (RuleB(Spells, AllowExtraDmgSkill)) {
+			extra_dmg += GetSkillDmgAmt(spells[spell_id].skill);
+		}
+
 		if (extra_dmg) {
 			int duration = CalcBuffDuration(this, target, spell_id);
 			if (duration > 0)
@@ -275,9 +303,6 @@ int64 Mob::GetActDoTDamage(uint16 spell_id, int64 value, Mob* target, bool from_
 
 		value -= extra_dmg;
 	}
-
-	if (IsNPC() && CastToNPC()->GetSpellScale())
-		value = int64(static_cast<float>(value) * CastToNPC()->GetSpellScale() / 100.0f);
 
 	return value;
 }
@@ -368,6 +393,10 @@ int64 Mob::GetActSpellHealing(uint16 spell_id, int64 value, Mob* target, bool fr
 	// Instant Heals
 	if (spells[spell_id].buff_duration < 1) {
 
+		if (RuleB(Spells, AllowExtraDmgSkill)) {
+			value += GetSkillDmgAmt(spells[spell_id].skill);
+		}
+
 		if (target) {
 			value += int64(base_value * target->GetFocusEffect(focusFcHealPctIncoming, spell_id, this)/100); //SPA 393 Add before critical
 			value += int64(base_value * target->GetFocusEffect(focusFcHealPctCritIncoming, spell_id, this)/100); //SPA 395 Add before critical (?)
@@ -420,6 +449,11 @@ int64 Mob::GetActSpellHealing(uint16 spell_id, int64 value, Mob* target, bool fr
 	else {
 		//Using IgnoreSpellDmgLvlRestriction to also allow healing to scale
 		int64 extra_heal = 0;
+
+		if (RuleB(Spells, AllowExtraDmgSkill)) {
+			extra_heal += GetSkillDmgAmt(spells[spell_id].skill);
+		}
+
 		if (RuleB(Spells, HOTsScaleWithHealAmt)) {
 			if (RuleB(Spells, IgnoreSpellDmgLvlRestriction) && !spells[spell_id].no_heal_damage_item_mod && itembonuses.HealAmt) {
 				extra_heal += GetExtraSpellAmt(spell_id, itembonuses.HealAmt, base_value);

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -54,6 +54,10 @@ int64 Mob::GetActSpellDamage(uint16 spell_id, int64 value, Mob* target) {
 		}
 	}
 
+	if (RuleB(Spells, AllowExtraDmgSkill) && RuleB(Character, ItemExtraSkillDamageCalcAsPercent) && GetSkillDmgAmt(spells[spell_id].skill) > 0) {
+		value *= std::abs(GetSkillDmgAmt(spells[spell_id].skill) / 100);
+	}
+
 	bool Critical = false;
 	int64 base_value = value;
 	int chance = 0;
@@ -122,7 +126,7 @@ int64 Mob::GetActSpellDamage(uint16 spell_id, int64 value, Mob* target) {
 			value -= GetFocusEffect(focusFcDamageAmt2, spell_id);
 			value -= GetFocusEffect(focusFcAmplifyAmt, spell_id);
 
-			if (RuleB(Spells, AllowExtraDmgSkill)) {
+			if (RuleB(Spells, AllowExtraDmgSkill) && !RuleB(Character, ItemExtraSkillDamageCalcAsPercent)) {
 				value -= GetSkillDmgAmt(spells[spell_id].skill) * ratio / 100;
 			}
 
@@ -164,7 +168,7 @@ int64 Mob::GetActSpellDamage(uint16 spell_id, int64 value, Mob* target) {
 	value -= GetFocusEffect(focusFcDamageAmt2, spell_id);
 	value -= GetFocusEffect(focusFcAmplifyAmt, spell_id);
 
-	if (RuleB(Spells, AllowExtraDmgSkill)) {
+	if (RuleB(Spells, AllowExtraDmgSkill) && !RuleB(Character, ItemExtraSkillDamageCalcAsPercent)) {
 		value -= GetSkillDmgAmt(spells[spell_id].skill);
 	}
 
@@ -193,11 +197,15 @@ int64 Mob::GetActReflectedSpellDamage(uint16 spell_id, int64 value, int effectiv
 		}
 	}
 
+	if (RuleB(Spells, AllowExtraDmgSkill) && RuleB(Character, ItemExtraSkillDamageCalcAsPercent) && GetSkillDmgAmt(spells[spell_id].skill) > 0) {
+		value *= std::abs(GetSkillDmgAmt(spells[spell_id].skill) / 100);
+	}
+
 	int64 base_spell_dmg = value;
 
 	value = value * effectiveness / 100;
 
-	if (RuleB(Spells, AllowExtraDmgSkill)) {
+	if (RuleB(Spells, AllowExtraDmgSkill) && !RuleB(Character, ItemExtraSkillDamageCalcAsPercent)) {
 		value -= GetSkillDmgAmt(spells[spell_id].skill);
 	}
 
@@ -219,6 +227,10 @@ int64 Mob::GetActDoTDamage(uint16 spell_id, int64 value, Mob* target, bool from_
 		if (CastToNPC()->GetSpellScale()) {
 			value = int64(static_cast<float>(value) * CastToNPC()->GetSpellScale() / 100.0f);
 		}
+	}
+
+	if (RuleB(Spells, AllowExtraDmgSkill) && RuleB(Character, ItemExtraSkillDamageCalcAsPercent) && GetSkillDmgAmt(spells[spell_id].skill) > 0) {
+		value *= std::abs(GetSkillDmgAmt(spells[spell_id].skill) / 100);
 	}
 
 	int64 base_value = value;
@@ -256,7 +268,7 @@ int64 Mob::GetActDoTDamage(uint16 spell_id, int64 value, Mob* target, bool from_
 			}
 		}
 
-		if (RuleB(Spells, AllowExtraDmgSkill)) {
+		if (RuleB(Spells, AllowExtraDmgSkill) && !RuleB(Character, ItemExtraSkillDamageCalcAsPercent)) {
 			extra_dmg += GetSkillDmgAmt(spells[spell_id].skill) * ratio / 100;
 		}
 
@@ -291,7 +303,7 @@ int64 Mob::GetActDoTDamage(uint16 spell_id, int64 value, Mob* target, bool from_
 			}
 		}
 
-		if (RuleB(Spells, AllowExtraDmgSkill)) {
+		if (RuleB(Spells, AllowExtraDmgSkill) && !RuleB(Character, ItemExtraSkillDamageCalcAsPercent)) {
 			extra_dmg += GetSkillDmgAmt(spells[spell_id].skill);
 		}
 
@@ -352,6 +364,14 @@ int64 Mob::GetActSpellHealing(uint16 spell_id, int64 value, Mob* target, bool fr
 
 	if (IsNPC()) {
 		value += value * CastToNPC()->GetSpellFocusHeal() / 100;
+
+		if (IsNPC() && CastToNPC()->GetHealScale()) {
+			value = int(static_cast<float>(value) * CastToNPC()->GetHealScale() / 100.0f);
+		}
+	}
+
+	if (RuleB(Spells, AllowExtraDmgSkill) && RuleB(Character, ItemExtraSkillDamageCalcAsPercent) && GetSkillDmgAmt(spells[spell_id].skill) > 0) {
+		value *= std::abs(GetSkillDmgAmt(spells[spell_id].skill) / 100);
 	}
 
 	int64 base_value = value;
@@ -393,7 +413,7 @@ int64 Mob::GetActSpellHealing(uint16 spell_id, int64 value, Mob* target, bool fr
 	// Instant Heals
 	if (spells[spell_id].buff_duration < 1) {
 
-		if (RuleB(Spells, AllowExtraDmgSkill)) {
+		if (RuleB(Spells, AllowExtraDmgSkill) && !RuleB(Character, ItemExtraSkillDamageCalcAsPercent)) {
 			value += GetSkillDmgAmt(spells[spell_id].skill);
 		}
 
@@ -413,7 +433,7 @@ int64 Mob::GetActSpellHealing(uint16 spell_id, int64 value, Mob* target, bool fr
 		}
 
 		if (target) {
-			value += value * target->GetHealRate() / 100;  //SPA 120 modifies value after Focus Applied but before critical
+			value += value * target->GetHealRate() / 100; //SPA 120 modifies value after Focus Applied but before critical
 		}
 
 		/*
@@ -426,10 +446,6 @@ int64 Mob::GetActSpellHealing(uint16 spell_id, int64 value, Mob* target, bool fr
 
 		if (target) {
 			value += target->GetFocusEffect(focusFcHealAmtIncoming, spell_id, this); //SPA 394 Add after critical
-		}
-
-		if (IsNPC() && CastToNPC()->GetHealScale()) {
-			value = int(static_cast<float>(value) * CastToNPC()->GetHealScale() / 100.0f);
 		}
 
 		if (critical_modifier > 1) {
@@ -450,7 +466,7 @@ int64 Mob::GetActSpellHealing(uint16 spell_id, int64 value, Mob* target, bool fr
 		//Using IgnoreSpellDmgLvlRestriction to also allow healing to scale
 		int64 extra_heal = 0;
 
-		if (RuleB(Spells, AllowExtraDmgSkill)) {
+		if (RuleB(Spells, AllowExtraDmgSkill) && !RuleB(Character, ItemExtraSkillDamageCalcAsPercent)) {
 			extra_heal += GetSkillDmgAmt(spells[spell_id].skill);
 		}
 
@@ -472,10 +488,6 @@ int64 Mob::GetActSpellHealing(uint16 spell_id, int64 value, Mob* target, bool fr
 		}
 
 		value *= critical_modifier;
-	}
-
-	if (IsNPC() && CastToNPC()->GetHealScale()) {
-		value = int(static_cast<float>(value) * CastToNPC()->GetHealScale() / 100.0f);
 	}
 
 	return value;


### PR DESCRIPTION
Allows you to set Spell Casting Skills to Item Field "ExtraDmgSkill" or SPA 220.

![image](https://user-images.githubusercontent.com/109764533/226115392-4cc63a51-82b6-4b50-a183-2cc55ca9c79b.png)

Items won't display the value, however these are displayed with #mystats window.

![image](https://user-images.githubusercontent.com/109764533/226115339-5c43bc6c-f92e-4e17-b0e6-237c18b096f5.png)
