### PR TITLE
[Bug Fix] Fix for Raid Disband if leader not in same zone.

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -12185,7 +12185,7 @@ void Client::Handle_OP_RaidCommand(const EQApplicationPacket* app)
 					}
 					raid->SendGroupDisband(c_to_disband);
 					raid->GroupUpdate(group);
-					if (!raid->RaidCount() || !raid->GetLeader()) {
+					if (!raid->RaidCount()) {
 						raid->DisbandRaid();
 					}
 					break;


### PR DESCRIPTION
This fixes an issue where a player could disband the raid if the Raid leader was not in the same zone as them (only if Bot rule was enabled)