### PR TITLE
[Bug Fix] Fix edge cases where camped bots would be left in a raid

### DIFF
--- a/zone/bot_raid.cpp
+++ b/zone/bot_raid.cpp
@@ -118,7 +118,6 @@ void Raid::HandleBotGroupDisband(uint32 owner, uint32 gid)
 
 // we need to cleanup any camped/offline bots when the owner leaves the Raid
 void Raid::HandleOfflineBots(uint32 owner) {
-
 	std::list<BotsAvailableList> bots_list;
 	if (!database.botdb.LoadBotsList(owner, bots_list)) {
 		return;

--- a/zone/bot_raid.cpp
+++ b/zone/bot_raid.cpp
@@ -116,6 +116,31 @@ void Raid::HandleBotGroupDisband(uint32 owner, uint32 gid)
 	}
 }
 
+// we need to cleanup any camped/offline bots when the owner leaves the Raid
+void Raid::HandleOfflineBots(uint32 owner) {
+
+	std::list<BotsAvailableList> bots_list;
+	if (!database.botdb.LoadBotsList(owner, bots_list)) {
+		return;
+	}
+
+	for (const auto& b: bots_list) {
+		if (IsRaidMember(b.Name)) {
+			for (const auto& m: members) {
+				if (m.is_bot && strcmp(m.member_name, b.Name) == 0) {
+					uint32 gid = GetGroup(m.member_name);
+					SendRaidGroupRemove(m.member_name, gid);
+					RemoveMember(m.member_name);
+					GroupUpdate(gid);
+					if (!RaidCount()) {
+						DisbandRaid();
+					}
+				}
+			}
+		}
+	}
+}
+
 uint8 Bot::GetNumberNeedingHealedInRaidGroup(uint8& need_healed, uint8 hpr, bool includePets, Raid* raid) {
 
 	if (raid) {
@@ -170,8 +195,8 @@ void Bot::CreateBotRaid(Mob* invitee, Client* invitor, bool group_invite, Raid* 
 	Group* g_invitee = invitee->GetGroup();
 	Group* g_invitor = invitor->GetGroup();
 
-	if (g_invitee && invitor->IsClient()) {
-		if (!g_invitee->IsLeader(invitee)) {
+	if (g_invitee && invitor->IsClient() && !g_invitee->IsLeader(invitee)) {
+		if (g_invitee->GetLeader()) {
 			invitor->Message(
 				Chat::Red,
 				fmt::format(
@@ -179,6 +204,9 @@ void Bot::CreateBotRaid(Mob* invitee, Client* invitor, bool group_invite, Raid* 
 					g_invitee->GetLeader()->GetCleanName()
 				).c_str()
 			);
+			return;
+		} else {
+			invitor->Message(Chat::Red, "You can only invite group leaders or ungrouped bots.");
 			return;
 		}
 	}

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -12177,6 +12177,7 @@ void Client::Handle_OP_RaidCommand(const EQApplicationPacket* app)
 				//Added to remove all bots if the Bot_Owner is removed from the Raid
 				//Does not camp the Bots, just removes from the raid
 				if (c_to_disband) {
+					raid->HandleOfflineBots(c_to_disband->CharacterID());
 					raid->HandleBotGroupDisband(c_to_disband->CharacterID());
 					raid->RemoveMember(raid_command_packet->leader_name);
 					if (raid->IsLeader(c_to_disband->GetName())) {

--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -1703,11 +1703,10 @@ void Raid::VerifyRaid()
 				//attribute before calling a client function or casting to client.
 				b = entity_list.GetBotByBotName(m.member_name);
 				m.member = b->CastToClient();
-				m.is_bot = true; //Used to identify those members who are Bots
+				m.is_bot = true;
 			}
 			else {
 				m.member = nullptr;
-				m.is_bot = false;
 			}
 		}
 

--- a/zone/raids.h
+++ b/zone/raids.h
@@ -256,6 +256,7 @@ public:
 	std::vector<Bot*> GetRaidGroupBotMembers(uint32 gid);
 	std::vector<Bot*> GetRaidBotMembers(uint32 owner = 0);
 	void HandleBotGroupDisband(uint32 owner, uint32 gid = RAID_GROUPLESS);
+	void HandleOfflineBots(uint32 owner);
 
 	RaidMember members[MAX_RAID_MEMBERS];
 	char leadername[64];


### PR DESCRIPTION
Camped/offline Bots could be left in an existing Raid in specific scenarios if there owner had left the raid. 