### PR TITLE
[Bug Fix] Fix for transferring Raid Leader

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -12177,12 +12177,10 @@ void Client::Handle_OP_RaidCommand(const EQApplicationPacket* app)
 				//Added to remove all bots if the Bot_Owner is removed from the Raid
 				//Does not camp the Bots, just removes from the raid
 				if (c_to_disband) {
+					uint32 i = raid->GetPlayerIndex(raid_command_packet->leader_name);
+					raid->SetNewRaidLeader(i);
 					raid->HandleBotGroupDisband(c_to_disband->CharacterID());
 					raid->RemoveMember(raid_command_packet->leader_name);
-					if (raid->IsLeader(c_to_disband->GetName())) {
-						uint32 i = raid->GetPlayerIndex(raid_command_packet->leader_name);
-						raid->SetNewRaidLeader(i);
-					}
 					raid->SendGroupDisband(c_to_disband);
 					raid->GroupUpdate(group);
 					if (!raid->RaidCount()) {
@@ -12213,8 +12211,8 @@ void Client::Handle_OP_RaidCommand(const EQApplicationPacket* app)
 					break;
 				}
 			}
+			uint32 i = raid->GetPlayerIndex(raid_command_packet->leader_name);
 			if (group < 12) {
-				uint32 i = raid->GetPlayerIndex(raid_command_packet->leader_name);
 				if (raid->members[i].is_group_leader) { //assign group leader to someone else
 					for (int x = 0; x < MAX_RAID_MEMBERS; x++) {
 						if (strlen(raid->members[x].member_name) > 0 && i != x) {
@@ -12227,8 +12225,8 @@ void Client::Handle_OP_RaidCommand(const EQApplicationPacket* app)
 						}
 					}
 				}
-				raid->SetNewRaidLeader(i);
 			}
+			raid->SetNewRaidLeader(i);
 			raid->RemoveMember(raid_command_packet->leader_name);
 			Client* c = entity_list.GetClientByName(raid_command_packet->leader_name);
 			if (c) {

--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -2158,7 +2158,7 @@ void Raid::SetNewRaidLeader(uint32 i)
 				continue;
 			}
 
-			if (m.member && strlen(m.member_name) > 0 && strcmp(m.member_name, m.member_name) != 0) {
+			if (m.member && strlen(m.member_name) > 0 && strcmp(m.member_name, members[i].member_name) != 0) {
 				SetRaidLeader(members[i].member_name, m.member_name);
 				UpdateRaidAAs();
 				SendAllRaidLeadershipAA();


### PR DESCRIPTION
This fixes transferring of the raid leader role if the Raid Leader leaves the Raid while they are not in a group, this didn't appear to work correctly even before recent changes (tested on a revision before any raid changes) which means you could get into a scenario where you end up in a raid without a leader.