### PR TITLE
[Cleanup] Cleanup Strings::ToInt uses.

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -812,7 +812,7 @@ uint32 Database::GetAccountIDByChar(const char* charname, uint32* oCharID) {
 
 	auto row = results.begin();
 
-	uint32 accountId = Strings::ToInt(row[0]);
+	uint32 accountId = Strings::ToUnsignedInt(row[0]);
 
 	if (oCharID)
 		*oCharID = Strings::ToUnsignedInt(row[1]);

--- a/common/database_conversions.cpp
+++ b/common/database_conversions.cpp
@@ -499,7 +499,7 @@ bool Database::CheckDatabaseConvertPPDeblob(){
 	ExtendedProfile_Struct* e_pp;
 	uint32 pplen = 0;
 	uint32 i;
-	int character_id = 0;
+	uint32 character_id = 0;
 	int account_id = 0;
 	int number_of_characters = 0;
 	int printppdebug = 0; /* Prints Player Profile */
@@ -929,12 +929,12 @@ bool Database::CheckDatabaseConvertPPDeblob(){
 
 		for (auto row = results.begin(); row != results.end(); ++row) {
 			char_iter_count++;
-			squery = StringFormat("SELECT `id`, `profile`, `name`, `level`, `account_id`, `firstlogon`, `lfg`, `lfp`, `mailkey`, `xtargets`, `inspectmessage`, `extprofile` FROM `character_` WHERE `id` = %i", Strings::ToInt(row[0]));
+			squery = StringFormat("SELECT `id`, `profile`, `name`, `level`, `account_id`, `firstlogon`, `lfg`, `lfp`, `mailkey`, `xtargets`, `inspectmessage`, `extprofile` FROM `character_` WHERE `id` = %i", Strings::ToUnsignedInt(row[0]));
 			auto results2 = QueryDatabase(squery);
 			auto row2 = results2.begin();
 			pp = (Convert::PlayerProfile_Struct*)row2[1];
 			e_pp = (ExtendedProfile_Struct*)row2[11];
-			character_id = Strings::ToInt(row[0]);
+			character_id = Strings::ToUnsignedInt(row[0]);
 			account_id = Strings::ToInt(row2[4]);
 			/* Convert some data from the character_ table that is still relevant */
 			firstlogon = Strings::ToUnsignedInt(row2[5]);

--- a/common/events/player_events.h
+++ b/common/events/player_events.h
@@ -384,7 +384,7 @@ namespace PlayerEvent {
 	};
 
 	struct AAPurchasedEvent {
-		int32 aa_id;
+		uint32 aa_id;
 		int32 aa_cost;
 		int32 aa_previous_id;
 		int32 aa_next_id;

--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -964,7 +964,7 @@ void SharedDatabase::LoadItems(void *data, uint32 size, int32 items, uint32 max_
 
 		// Flags
 		item.ArtifactFlag = Strings::ToBool(row[ItemField::artifactflag]);
-		item.Attuneable = !disable_attuneable && Strings::ToBool(row[ItemField::attuneable]) != 0;
+		item.Attuneable = !disable_attuneable && Strings::ToBool(row[ItemField::attuneable]);
 		item.BenefitFlag = Strings::ToBool(row[ItemField::benefitflag]) != 0;
 		item.FVNoDrop = Strings::ToInt(row[ItemField::fvnodrop]) != 0;
 		item.Magic = Strings::ToBool(row[ItemField::magic]) != 0;

--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -965,9 +965,9 @@ void SharedDatabase::LoadItems(void *data, uint32 size, int32 items, uint32 max_
 		// Flags
 		item.ArtifactFlag = Strings::ToBool(row[ItemField::artifactflag]);
 		item.Attuneable = !disable_attuneable && Strings::ToBool(row[ItemField::attuneable]);
-		item.BenefitFlag = Strings::ToBool(row[ItemField::benefitflag]) != 0;
-		item.FVNoDrop = Strings::ToInt(row[ItemField::fvnodrop]) != 0;
-		item.Magic = Strings::ToBool(row[ItemField::magic]) != 0;
+		item.BenefitFlag = Strings::ToBool(row[ItemField::benefitflag]);
+		item.FVNoDrop = Strings::ToBool(row[ItemField::fvnodrop]);
+		item.Magic = Strings::ToBool(row[ItemField::magic]);
 		item.NoDrop = disable_no_drop ? static_cast<uint8>(255) : static_cast<uint8>(Strings::ToUnsignedInt(row[ItemField::nodrop]));
 		item.NoPet = !disable_no_pet && Strings::ToBool(row[ItemField::nopet]);
 		item.NoRent = disable_no_rent ? static_cast<uint8>(255) : static_cast<uint8>(Strings::ToUnsignedInt(row[ItemField::norent]));

--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -964,7 +964,7 @@ void SharedDatabase::LoadItems(void *data, uint32 size, int32 items, uint32 max_
 
 		// Flags
 		item.ArtifactFlag = Strings::ToBool(row[ItemField::artifactflag]);
-		item.Attuneable = !disable_attuneable && Strings::ToInt(row[ItemField::attuneable]) != 0;
+		item.Attuneable = !disable_attuneable && Strings::ToBool(row[ItemField::attuneable]) != 0;
 		item.BenefitFlag = Strings::ToBool(row[ItemField::benefitflag]) != 0;
 		item.FVNoDrop = Strings::ToInt(row[ItemField::fvnodrop]) != 0;
 		item.Magic = Strings::ToBool(row[ItemField::magic]) != 0;

--- a/loginserver/database.cpp
+++ b/loginserver/database.cpp
@@ -32,7 +32,7 @@ Database::Database(
 		user.c_str(),
 		pass.c_str(),
 		name.c_str(),
-		Strings::ToInt(port),
+		Strings::ToUnsignedInt(port),
 		&errnum,
 		errbuf
 	)
@@ -93,7 +93,7 @@ bool Database::GetLoginDataFromAccountInfo(
 
 	auto row = results.begin();
 
-	id       = Strings::ToInt(row[0]);
+	id       = Strings::ToUnsignedInt(row[0]);
 	password = row[1];
 
 	LogDebug(
@@ -145,7 +145,7 @@ bool Database::GetLoginTokenDataFromToken(
 		}
 
 		if (strcmp(row[2], "login_server_id") == 0) {
-			db_account_id  = Strings::ToInt(row[3]);
+			db_account_id  = Strings::ToUnsignedInt(row[3]);
 			found_login_id = true;
 			continue;
 		}
@@ -373,7 +373,7 @@ Database::DbWorldRegistration Database::GetWorldRegistration(
 	r.server_list_type        = Strings::ToInt(row[3]);
 	r.is_server_trusted       = Strings::ToInt(row[2]) > 0;
 	r.server_list_description = row[4];
-	r.server_admin_id         = Strings::ToInt(row[5]);
+	r.server_admin_id         = Strings::ToUnsignedInt(row[5]);
 
 	if (r.server_admin_id <= 0) {
 		return r;
@@ -513,7 +513,7 @@ bool Database::CreateWorldRegistration(
 
 	auto row = results.begin();
 
-	id = Strings::ToInt(row[0]);
+	id = Strings::ToUnsignedInt(row[0]);
 	auto insert_query = fmt::format(
 		"INSERT INTO login_world_servers SET id = {0}, long_name = '{1}', short_name = '{2}', last_ip_address = '{3}', \n"
 		"login_server_list_type_id = 3, login_server_admin_id = {4}, is_server_trusted = 0, tag_description = ''",

--- a/zone/aa.cpp
+++ b/zone/aa.cpp
@@ -1448,9 +1448,9 @@ bool ZoneDatabase::LoadAlternateAdvancement(Client *c) {
 
 	int i = 0;
 	for(auto row = results.begin(); row != results.end(); ++row) {
-		uint32 aa = Strings::ToInt(row[0]);
-		uint32 value = Strings::ToInt(row[1]);
-		uint32 charges = Strings::ToInt(row[2]);
+		uint32 aa = Strings::ToUnsignedInt(row[0]);
+		uint32 value = Strings::ToUnsignedInt(row[1]);
+		uint32 charges = Strings::ToUnsignedInt(row[2]);
 
 		auto rank = zone->GetAlternateAdvancementRank(aa);
 		if(!rank) {
@@ -1775,7 +1775,7 @@ bool ZoneDatabase::LoadAlternateAdvancementAbilities(std::unordered_map<int, std
 	if(results.Success()) {
 		for(auto row = results.begin(); row != results.end(); ++row) {
 			auto ability = new AA::Ability;
-			ability->id = Strings::ToInt(row[0]);
+			ability->id = Strings::ToUnsignedInt(row[0]);
 			ability->name = row[1];
 			ability->category = Strings::ToInt(row[2]);
 			//EQ client has classes left shifted by one bit for some odd reason
@@ -1786,8 +1786,8 @@ bool ZoneDatabase::LoadAlternateAdvancementAbilities(std::unordered_map<int, std
 			ability->status = Strings::ToInt(row[7]);
 			ability->type = Strings::ToInt(row[8]);
 			ability->charges = Strings::ToInt(row[9]);
-			ability->grant_only = Strings::ToInt(row[10]) != 0 ? true : false;
-			ability->reset_on_death = Strings::ToInt(row[11]) != 0 ? true : false;
+			ability->grant_only = Strings::ToBool(row[10]);
+			ability->reset_on_death = Strings::ToBool(row[11]);
 			ability->first_rank_id = Strings::ToInt(row[12]);
 			ability->first = nullptr;
 
@@ -1814,7 +1814,7 @@ bool ZoneDatabase::LoadAlternateAdvancementAbilities(std::unordered_map<int, std
 	if(results.Success()) {
 		for(auto row = results.begin(); row != results.end(); ++row) {
 			auto rank = new AA::Rank;
-			rank->id = Strings::ToInt(row[0]);
+			rank->id = Strings::ToUnsignedInt(row[0]);
 			rank->upper_hotkey_sid = Strings::ToInt(row[1]);
 			rank->lower_hotkey_sid = Strings::ToInt(row[2]);
 			rank->title_sid = Strings::ToInt(row[3]);
@@ -1846,8 +1846,8 @@ bool ZoneDatabase::LoadAlternateAdvancementAbilities(std::unordered_map<int, std
 	if(results.Success()) {
 		for(auto row = results.begin(); row != results.end(); ++row) {
 			AA::RankEffect effect;
-			int rank_id = Strings::ToInt(row[0]);
-			effect.slot = Strings::ToInt(row[1]);
+			uint32 rank_id = Strings::ToUnsignedInt(row[0]);
+			effect.slot = Strings::ToUnsignedInt(row[1]);
 			effect.effect_id = Strings::ToInt(row[2]);
 			effect.base_value = Strings::ToInt(row[3]);
 			effect.limit_value = Strings::ToInt(row[4]);
@@ -1871,7 +1871,7 @@ bool ZoneDatabase::LoadAlternateAdvancementAbilities(std::unordered_map<int, std
 	results = QueryDatabase(query);
 	if(results.Success()) {
 		for(auto row = results.begin(); row != results.end(); ++row) {
-			int rank_id = Strings::ToInt(row[0]);
+			uint32 rank_id = Strings::ToUnsignedInt(row[0]);
 			int aa_id = Strings::ToInt(row[1]);
 			int points = Strings::ToInt(row[2]);
 

--- a/zone/aa_ability.h
+++ b/zone/aa_ability.h
@@ -41,7 +41,7 @@ public:
 	Rank *GetRankByPointsSpent(int current_level);
 	int GetMaxLevel(Mob *who);
 
-	int id;
+	uint32 id;
 	std::string name;
 	int category;
 	int classes;

--- a/zone/aa_rank.h
+++ b/zone/aa_rank.h
@@ -29,7 +29,7 @@ public:
 	Rank() { }
 	~Rank() { }
 
-	int id;
+	uint32 id;
 	int upper_hotkey_sid;
 	int lower_hotkey_sid;
 	int title_sid;

--- a/zone/aa_rank_effects.h
+++ b/zone/aa_rank_effects.h
@@ -27,7 +27,7 @@ namespace AA
 
 struct RankEffect
 {
-	int slot;
+	uint32 slot;
 	int effect_id;
 	int base_value;
 	int limit_value;

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -3463,7 +3463,7 @@ void Bot::FillSpawnStruct(NewSpawn_Struct* ns, Mob* ForWho) {
 
 			if(item) {
 				if(strlen(item->IDFile) > 2)
-					ns->spawn.equipment.Primary.Material = Strings::ToInt(&item->IDFile[2]);
+					ns->spawn.equipment.Primary.Material = Strings::ToUnsignedInt(&item->IDFile[2]);
 
 
 				ns->spawn.equipment_tint.Primary.Color = GetEquipmentColor(EQ::textures::weaponPrimary);
@@ -3476,7 +3476,7 @@ void Bot::FillSpawnStruct(NewSpawn_Struct* ns, Mob* ForWho) {
 
 			if(item) {
 				if(strlen(item->IDFile) > 2)
-					ns->spawn.equipment.Secondary.Material = Strings::ToInt(&item->IDFile[2]);
+					ns->spawn.equipment.Secondary.Material = Strings::ToUnsignedInt(&item->IDFile[2]);
 
 				ns->spawn.equipment_tint.Secondary.Color = GetEquipmentColor(EQ::textures::weaponSecondary);
 			}

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -1262,7 +1262,7 @@ bool Client::CanEnterZone(const std::string& zone_short_name, int16 instance_ver
 		return false;
 	}
 
-	if (!z->flag_needed.empty() && Strings::IsNumber(z->flag_needed) && Strings::ToInt(z->flag_needed) == 1) {
+	if (!z->flag_needed.empty() && Strings::IsNumber(z->flag_needed) && Strings::ToBool(z->flag_needed)) {
 		if (Admin() < minStatusToIgnoreZoneFlags && !HasZoneFlag(z->zoneidnumber)) {
 			LogInfo(
 				"Character [{}] does not have the flag to be in this zone [{}]!",


### PR DESCRIPTION
Corrected a number of instances where Strings::ToInt was being used incorrectly, where ToBool or ToUnsignedInt would be preferred. Will continue cleanup of these as I have time.