### PR TITLE
[Crash] Fix for crash in Raid::QueuePacket

### DIFF
--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -611,9 +611,8 @@ void Raid::RaidGroupSay(const char *msg, Client *c, uint8 language, uint8 lang_s
 
 uint32 Raid::GetPlayerIndex(const char *name)
 {
-	for(int x = 0; x < MAX_RAID_MEMBERS; x++)
-	{
-		if(strcmp(name, members[x].member_name) == 0) {
+	for (int x = 0; x < MAX_RAID_MEMBERS; x++) {
+		if (strcmp(name, members[x].member_name) == 0) {
 			return x;
 		}
 	}
@@ -808,10 +807,6 @@ void Raid::BalanceMana(int32 penalty, uint32 gid, float range, Mob* caster, int3
 	int manataken_tmp = 0;
 
 	for (const auto& m : members) {
-		if (m.is_bot) {
-			continue;
-		}
-
 		if (m.member && m.group_number == gid && m.member->GetMaxMana() > 0) {
 			distance = DistanceSquared(caster->GetPosition(), m.member->GetPosition());
 
@@ -839,14 +834,14 @@ void Raid::BalanceMana(int32 penalty, uint32 gid, float range, Mob* caster, int3
 				if ((m.member->GetMaxMana() - manataken) < 1) {
 					m.member->SetMana(1);
 
-					if (m.member->IsClient()) {
+					if (!m.is_bot && m.member->IsClient()) {
 						m.member->CastToClient()->SendManaUpdate();
 					}
 				}
 				else {
 					m.member->SetMana(m.member->GetMaxMana() - manataken);
 
-					if (m.member->IsClient()) {
+					if (!m.is_bot && m.member->IsClient()) {
 						m.member->CastToClient()->SendManaUpdate();
 					}
 				}
@@ -875,6 +870,9 @@ void Raid::SplitMoney(uint32 gid, uint32 copper, uint32 silver, uint32 gold, uin
 
 	uint8 member_count = 0;
 	for (const auto& m : members) {
+		if (m.is_bot) {
+			continue;
+		}
 		if (m.member && m.group_number == gid && m.member->IsClient()) {
 			member_count++;
 		}
@@ -914,6 +912,9 @@ void Raid::SplitMoney(uint32 gid, uint32 copper, uint32 silver, uint32 gold, uin
 	auto platinum_split = platinum / member_count;
 
 	for (const auto& m : members) {
+		if (m.is_bot) {
+			continue;
+		}
 		if (m.member && m.group_number == gid && m.member->IsClient()) { // If Group Member is Client
 			m.member->AddMoneyToPP(
 				copper_split,
@@ -952,6 +953,9 @@ void Raid::SplitMoney(uint32 gid, uint32 copper, uint32 silver, uint32 gold, uin
 void Raid::TeleportGroup(Mob* sender, uint32 zoneID, uint16 instance_id, float x, float y, float z, float heading, uint32 gid)
 {
 	for (const auto& m : members) {
+		if (m.is_bot) {
+			continue;
+		}
 		if (m.member && m.group_number == gid && m.member->IsClient()) {
 			m.member->MovePC(zoneID, instance_id, x, y, z, heading, 0, ZoneSolicited);
 		}
@@ -961,6 +965,9 @@ void Raid::TeleportGroup(Mob* sender, uint32 zoneID, uint16 instance_id, float x
 void Raid::TeleportRaid(Mob* sender, uint32 zoneID, uint16 instance_id, float x, float y, float z, float heading)
 {
 	for (const auto& m : members) {
+		if (m.is_bot) {
+			continue;
+		}
 		if (m.member && m.member->IsClient()) {
 			m.member->MovePC(zoneID, instance_id, x, y, z, heading, 0, ZoneSolicited);
 		}
@@ -981,6 +988,9 @@ void Raid::AddRaidLooter(const char* looter)
 	auto results = database.QueryDatabase(query);
 
 	for (auto& m : members) {
+		if (m.is_bot) {
+			continue;
+		}
 		if (strcmp(looter, m.member_name) == 0) {
 			m.is_looter = true;
 			break;
@@ -1002,6 +1012,9 @@ void Raid::RemoveRaidLooter(const char* looter)
 	auto results = database.QueryDatabase(query);
 
 	for (auto& m: members) {
+		if (m.is_bot) {
+			continue;
+		}
 		if (strcmp(looter, m.member_name) == 0) {
 			m.is_looter = false;
 			break;
@@ -1094,6 +1107,9 @@ void Raid::SendRaidAdd(const char *who, Client *to)
 	std::vector<RaidMember> rm = GetMembers();
 
 	for (const auto& m : rm) {
+		if (m.is_bot) {
+			continue;
+		}
 		if (strcmp(m.member_name, who) == 0) {
 			auto outapp = new EQApplicationPacket(OP_RaidUpdate, sizeof(RaidAddMember_Struct));
 			auto ram = (RaidAddMember_Struct*)outapp->pBuffer;
@@ -1116,6 +1132,9 @@ void Raid::SendRaidAddAll(const char *who)
 	std::vector<RaidMember> rm = GetMembers();
 
 	for (const auto& m : rm) {
+		if (m.is_bot) {
+			continue;
+		}
 		if (strcmp(m.member_name, who) == 0) {
 			auto outapp = new EQApplicationPacket(OP_RaidUpdate, sizeof(RaidAddMember_Struct));
 			auto ram = (RaidAddMember_Struct*)outapp->pBuffer;
@@ -1141,6 +1160,9 @@ void Raid::SendRaidRemove(const char *who, Client *to)
 	}
 
 	for (const auto& m : members) {
+		if (m.is_bot) {
+			continue;
+		}
 		if (strcmp(m.member_name, who) == 0) {
 			auto outapp = new EQApplicationPacket(OP_RaidUpdate, sizeof(RaidGeneral_Struct));
 			auto rg = (RaidGeneral_Struct*)outapp->pBuffer;
@@ -1158,6 +1180,9 @@ void Raid::SendRaidRemove(const char *who, Client *to)
 void Raid::SendRaidRemoveAll(const char *who)
 {
 	for (const auto& m : members) {
+		if (m.is_bot) {
+			continue;
+		}
 		if (strcmp(m.member_name, who) == 0) {
 			auto outapp = new EQApplicationPacket(OP_RaidUpdate, sizeof(RaidGeneral_Struct));
 			auto rg = (RaidGeneral_Struct*)outapp->pBuffer;
@@ -1249,6 +1274,9 @@ void Raid::SendBulkRaid(Client *to)
 	}
 
 	for (const auto& m : members) {
+		if (m.is_bot) {
+			continue;
+		}
 		if (strlen(m.member_name) > 0 && (strcmp(m.member_name, to->GetName()) != 0)) {
 			SendRaidAdd(m.member_name, to);
 		}
@@ -1258,6 +1286,9 @@ void Raid::SendBulkRaid(Client *to)
 void Raid::QueuePacket(const EQApplicationPacket *app, bool ack_req)
 {
 	for (const auto& m : members) {
+		if (m.is_bot) {
+			continue;
+		}
 		if (m.member && m.member->IsClient()) {
 			m.member->QueuePacket(app, ack_req);
 		}
@@ -1502,6 +1533,9 @@ void Raid::SendRaidMOTD()
 	}
 
 	for (const auto& m: members) {
+		if (m.is_bot) {
+			continue;
+		}
 		if (m.member) {
 			SendRaidMOTD(m.member);
 		}
@@ -1911,6 +1945,9 @@ const char *Raid::GetClientNameByIndex(uint8 index)
 void Raid::RaidMessageString(Mob* sender, uint32 type, uint32 string_id, const char* message,const char* message2,const char* message3,const char* message4,const char* message5,const char* message6,const char* message7,const char* message8,const char* message9, uint32 distance)
 {
 	for (const auto& m : members) {
+		if (m.is_bot) {
+			continue;
+		}
 		if (m.member && m.member->IsClient() && m.member != sender) {
 			m.member->MessageString(type, string_id, message, message2, message3, message4, message5, message6,
 									message7, message8, message9, distance);

--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -807,6 +807,9 @@ void Raid::BalanceMana(int32 penalty, uint32 gid, float range, Mob* caster, int3
 	int manataken_tmp = 0;
 
 	for (const auto& m : members) {
+		if (m.is_bot) {
+			continue;
+		}
 		if (m.member && m.group_number == gid && m.member->GetMaxMana() > 0) {
 			distance = DistanceSquared(caster->GetPosition(), m.member->GetPosition());
 
@@ -827,6 +830,9 @@ void Raid::BalanceMana(int32 penalty, uint32 gid, float range, Mob* caster, int3
 	manataken /= numMem;
 
 	for (const auto& m : members) {
+		if (m.is_bot) {
+			continue;
+		}
 		if (m.member && m.group_number == gid) {
 			distance = DistanceSquared(caster->GetPosition(), m.member->GetPosition());
 
@@ -834,14 +840,14 @@ void Raid::BalanceMana(int32 penalty, uint32 gid, float range, Mob* caster, int3
 				if ((m.member->GetMaxMana() - manataken) < 1) {
 					m.member->SetMana(1);
 
-					if (!m.is_bot && m.member->IsClient()) {
+					if (m.member->IsClient()) {
 						m.member->CastToClient()->SendManaUpdate();
 					}
 				}
 				else {
 					m.member->SetMana(m.member->GetMaxMana() - manataken);
 
-					if (!m.is_bot && m.member->IsClient()) {
+					if (m.member->IsClient()) {
 						m.member->CastToClient()->SendManaUpdate();
 					}
 				}


### PR DESCRIPTION
Added additional checks to further exclude bots before calling any client methods. Would rather be safe in the event someone incorrectly uses one of these methods without checking if ```m.is_bot```