### PR TITLE
[Hotfix] Fix for Item display issues when looting items from corpses.

### DIFF
--- a/common/eq_packet_structs.h
+++ b/common/eq_packet_structs.h
@@ -5524,9 +5524,9 @@ struct ServerLootItem_Struct {
 	uint32 aug_6;		  // uint32	aug_5;
 	bool attuned;
 	std::string custom_data;
-	uint32 ornamenticon;
-	uint32 ornamentidfile;
-	uint32 ornament_hero_model;
+	uint32 ornamenticon {};
+	uint32 ornamentidfile {};
+	uint32 ornament_hero_model {};
 	uint16 trivial_min_level;
 	uint16 trivial_max_level;
 	uint16 npc_min_level;


### PR DESCRIPTION
Resolves regression introduced in #3123 where items looted off a corpse will have an uninitialized ornamenticon, ornamentidfile, and ornament_hero_model values causing undefined behavior such as causing the incorrect item icons to be displayed.

As seen in the following screenshot:

https://cdn.discordapp.com/attachments/1089149382802284584/1089150391779860481/Exquisite_Rune.png
https://cdn.discordapp.com/attachments/1089149382802284584/1089149383192363058/Silverwing_Loop.png