### PR TITLE
[Crash] Add Checks for out of bounds & dereferencing nullptrs

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -2740,8 +2740,8 @@ bool Bot::IsValidTarget(Client* bot_owner, Client* leash_owner, float lo_distanc
 	}
 
 	bool valid_target_state = HOLDING || !tar->IsNPC() || tar->IsMezzed() || lo_distance > leash_distance || tar_distance > leash_distance;
-	bool valid_target = !GetAttackingFlag() && !CheckLosFN(tar) && !leash_owner->CheckLosFN(tar);
-	bool valid_bo_target= !GetAttackingFlag() && NOT_PULLING_BOT && !leash_owner->AutoAttackEnabled() && !tar->GetHateAmount(this) && !tar->GetHateAmount(leash_owner);
+	bool valid_target 		= !GetAttackingFlag() && !CheckLosFN(tar) && !leash_owner->CheckLosFN(tar);
+	bool valid_bo_target	= !GetAttackingFlag() && NOT_PULLING_BOT && !leash_owner->AutoAttackEnabled() && !tar->GetHateAmount(this) && !tar->GetHateAmount(leash_owner);
 
 	if (valid_target_state || valid_target || !IsAttackAllowed(tar) || (bo_alt_combat && valid_bo_target)) {
 		// Normally, we wouldn't want to do this without class checks..but, too many issues can arise if we let enchanter animation pets run rampant

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -2739,9 +2739,9 @@ bool Bot::IsValidTarget(Client* bot_owner, Client* leash_owner, float lo_distanc
 		return false;
 	}
 
-	bool valid_target_state = HOLDING || !tar->IsNPC() || tar->IsMezzed() || lo_distance > leash_distance || tar_distance > leash_distance;
-	bool valid_target 		= !GetAttackingFlag() && !CheckLosFN(tar) && !leash_owner->CheckLosFN(tar);
-	bool valid_bo_target	= !GetAttackingFlag() && NOT_PULLING_BOT && !leash_owner->AutoAttackEnabled() && !tar->GetHateAmount(this) && !tar->GetHateAmount(leash_owner);
+	bool valid_target_state		= HOLDING || !tar->IsNPC() || tar->IsMezzed() || lo_distance > leash_distance || tar_distance > leash_distance;
+	bool valid_target 			= !GetAttackingFlag() && !CheckLosFN(tar) && !leash_owner->CheckLosFN(tar);
+	bool valid_bo_target		= !GetAttackingFlag() && NOT_PULLING_BOT && !leash_owner->AutoAttackEnabled() && !tar->GetHateAmount(this) && !tar->GetHateAmount(leash_owner);
 
 	if (valid_target_state || valid_target || !IsAttackAllowed(tar) || (bo_alt_combat && valid_bo_target)) {
 		// Normally, we wouldn't want to do this without class checks..but, too many issues can arise if we let enchanter animation pets run rampant

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -2740,7 +2740,7 @@ bool Bot::IsValidTarget(Client* bot_owner, Client* leash_owner, float lo_distanc
 	}
 
 	bool valid_target_state		= HOLDING || !tar->IsNPC() || tar->IsMezzed() || lo_distance > leash_distance || tar_distance > leash_distance;
-	bool valid_target 			= !GetAttackingFlag() && !CheckLosFN(tar) && !leash_owner->CheckLosFN(tar);
+	bool valid_target 		= !GetAttackingFlag() && !CheckLosFN(tar) && !leash_owner->CheckLosFN(tar);
 	bool valid_bo_target		= !GetAttackingFlag() && NOT_PULLING_BOT && !leash_owner->AutoAttackEnabled() && !tar->GetHateAmount(this) && !tar->GetHateAmount(leash_owner);
 
 	if (valid_target_state || valid_target || !IsAttackAllowed(tar) || (bo_alt_combat && valid_bo_target)) {

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -2735,18 +2735,15 @@ void Bot::CalcMeleeDistances(const Mob* tar, const EQ::ItemInstance* const& p_it
 
 bool Bot::IsValidTarget(Client* bot_owner, Client* leash_owner, float lo_distance, float leash_distance, bool bo_alt_combat, Mob* tar, float tar_distance) {
 
-	if (HOLDING ||
-		!tar->IsNPC() ||
-		tar->IsMezzed() ||
-		lo_distance > leash_distance ||
-		tar_distance > leash_distance ||
-		(!GetAttackingFlag() && !CheckLosFN(tar) && !leash_owner->CheckLosFN(tar)) || // This is suppose to keep bots from attacking things behind walls
-		!IsAttackAllowed(tar) ||
-		(bo_alt_combat &&
-			(!GetAttackingFlag() && NOT_PULLING_BOT && !leash_owner->AutoAttackEnabled() && !tar->GetHateAmount(this) && !tar->GetHateAmount(leash_owner))
-		)
-	)
-	{
+	if (!tar || !bot_owner || !leash_owner) {
+		return false;
+	}
+
+	bool valid_target_state = HOLDING || !tar->IsNPC() || tar->IsMezzed() || lo_distance > leash_distance || tar_distance > leash_distance;
+	bool valid_target = !GetAttackingFlag() && !CheckLosFN(tar) && !leash_owner->CheckLosFN(tar);
+	bool valid_bo_target= !GetAttackingFlag() && NOT_PULLING_BOT && !leash_owner->AutoAttackEnabled() && !tar->GetHateAmount(this) && !tar->GetHateAmount(leash_owner);
+
+	if (valid_target_state || valid_target || !IsAttackAllowed(tar) || (bo_alt_combat && valid_bo_target)) {
 		// Normally, we wouldn't want to do this without class checks..but, too many issues can arise if we let enchanter animation pets run rampant
 		if (HasPet()) {
 			GetPet()->RemoveFromHateList(tar);

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -2739,9 +2739,9 @@ bool Bot::IsValidTarget(Client* bot_owner, Client* leash_owner, float lo_distanc
 		return false;
 	}
 
-	bool valid_target_state		= HOLDING || !tar->IsNPC() || tar->IsMezzed() || lo_distance > leash_distance || tar_distance > leash_distance;
-	bool valid_target 		= !GetAttackingFlag() && !CheckLosFN(tar) && !leash_owner->CheckLosFN(tar);
-	bool valid_bo_target		= !GetAttackingFlag() && NOT_PULLING_BOT && !leash_owner->AutoAttackEnabled() && !tar->GetHateAmount(this) && !tar->GetHateAmount(leash_owner);
+	bool valid_target_state = HOLDING || !tar->IsNPC() || tar->IsMezzed() || lo_distance > leash_distance || tar_distance > leash_distance;
+	bool valid_target       = !GetAttackingFlag() && !CheckLosFN(tar) && !leash_owner->CheckLosFN(tar);
+	bool valid_bo_target    = !GetAttackingFlag() && NOT_PULLING_BOT && !leash_owner->AutoAttackEnabled() && !tar->GetHateAmount(this) && !tar->GetHateAmount(leash_owner);
 
 	if (valid_target_state || valid_target || !IsAttackAllowed(tar) || (bo_alt_combat && valid_bo_target)) {
 		// Normally, we wouldn't want to do this without class checks..but, too many issues can arise if we let enchanter animation pets run rampant

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -207,11 +207,11 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 		}
 	}
 
-	if(IsVirusSpell(spell_id)) {
-
+	if (IsVirusSpell(spell_id) && buffslot > -1) {
 		if (!viral_timer.Enabled()) {
 			viral_timer.Start(1000);
 		}
+
 		buffs[buffslot].virus_spread_time = zone->random.Int(GetViralMinSpreadTime(spell_id), GetViralMaxSpreadTime(spell_id));
 	}
 
@@ -819,20 +819,20 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 
 				// define spells with fixed duration
 				// charm spells with -1 in field 209 are all of fixed duration, so lets use that instead of spell_ids
-				if(spells[spell_id].no_resist)
+				if (spells[spell_id].no_resist) {
 					bBreak = true;
-
-				if (!bBreak)
-				{
-					int resistMod = static_cast<int>(partial) + (GetCHA()/25);
-					resistMod = resistMod > 100 ? 100 : resistMod;
-					buffs[buffslot].ticsremaining = resistMod * buffs[buffslot].ticsremaining / 100;
 				}
 
-				if (IsClient() || IsBot())
-				{
-					if(buffs[buffslot].ticsremaining > RuleI(Character, MaxCharmDurationForPlayerCharacter))
+				if (buffslot > -1) {
+					if (!bBreak) {
+						int resistMod = static_cast<int>(partial) + (GetCHA() / 25);
+						resistMod = resistMod > 100 ? 100 : resistMod;
+						buffs[buffslot].ticsremaining = resistMod * buffs[buffslot].ticsremaining / 100;
+					}
+
+					if (IsOfClientBot() && buffs[buffslot].ticsremaining > RuleI(Character, MaxCharmDurationForPlayerCharacter)) {
 						buffs[buffslot].ticsremaining = RuleI(Character, MaxCharmDurationForPlayerCharacter);
+					}
 				}
 
 				break;
@@ -887,8 +887,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Fear: %+i", effect_value);
 #endif
-				if (IsClient() || IsBot())
-				{
+				if (IsOfClientBot() && buffslot > -1) {
 					if (buffs[buffslot].ticsremaining > RuleI(Character, MaxFearDurationForPlayerCharacter)) {
 						buffs[buffslot].ticsremaining = RuleI(Character, MaxFearDurationForPlayerCharacter);
 					}
@@ -902,13 +901,11 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					}
 
 					CalculateNewFearpoint();
-					if (currently_fleeing)
-					{
+					if (currently_fleeing) {
 						break;
 					}
 				}
-				else
-				{
+				else if (buffslot > -1) {
 					Stun(buffs[buffslot].ticsremaining * 6000 - (6000 - tic_timer.GetRemainingTime()));
 				}
 				break;
@@ -1307,8 +1304,9 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Invulnerability");
 #endif
-				if(spell_id==4789) // Touch of the Divine - Divine Save
-					buffs[buffslot].ticsremaining = spells[spell_id].buff_duration; // Prevent focus/aa buff extension
+				if (spell_id == 4789 && buffslot > -1) { // Touch of the Divine - Divine Save
+					buffs[buffslot].ticsremaining = spells[spell_id].buff_duration;
+				} // Prevent focus/aa buff extension
 
 				SetInvul(true);
 				break;
@@ -1355,7 +1353,9 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Melee Absorb Rune: %+i", effect_value);
 #endif
-				buffs[buffslot].melee_rune = effect_value;
+				if (buffslot > -1) {
+					buffs[buffslot].melee_rune = effect_value;
+				}
 				break;
 			}
 
@@ -1364,47 +1364,60 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Spell Absorb Rune: %+i", effect_value);
 #endif
-				if(effect_value > 0)
+				if (effect_value > 0 && buffslot > -1) {
 					buffs[buffslot].magic_rune = effect_value;
+				}
 
 				break;
 			}
 
 			case SE_MitigateMeleeDamage:
 			{
-				buffs[buffslot].melee_rune = spells[spell_id].max_value[i];
+				if (buffslot > -1) {
+					buffs[buffslot].melee_rune = spells[spell_id].max_value[i];
+				}
 				break;
 			}
 
 			case SE_MeleeThresholdGuard:
 			{
-				buffs[buffslot].melee_rune = spells[spell_id].max_value[i];
+				if (buffslot > -1) {
+					buffs[buffslot].melee_rune = spells[spell_id].max_value[i];
+				}
 				break;
 			}
 
 			case SE_SpellThresholdGuard:
 			{
-				buffs[buffslot].magic_rune = spells[spell_id].max_value[i];
+				if (buffslot > -1) {
+					buffs[buffslot].magic_rune = spells[spell_id].max_value[i];
+				}
 				break;
 			}
 
 			case SE_MitigateSpellDamage:
 			{
-				buffs[buffslot].magic_rune = spells[spell_id].max_value[i];
+				if (buffslot > -1) {
+					buffs[buffslot].magic_rune = spells[spell_id].max_value[i];
+				}
 				break;
 			}
 
 			case SE_MitigateDotDamage:
 			{
-				buffs[buffslot].dot_rune = spells[spell_id].max_value[i];
+				if (buffslot > -1) {
+					buffs[buffslot].dot_rune = spells[spell_id].max_value[i];
+				}
 				break;
 			}
 
 			case SE_DistanceRemoval:
 			{
-				buffs[buffslot].caston_x = int(GetX());
-				buffs[buffslot].caston_y = int(GetY());
-				buffs[buffslot].caston_z = int(GetZ());
+				if (buffslot > -1) {
+					buffs[buffslot].caston_x = int(GetX());
+					buffs[buffslot].caston_y = int(GetY());
+					buffs[buffslot].caston_z = int(GetZ());
+				}
 				break;
 			}
 
@@ -1434,7 +1447,9 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 							caster->spellbonuses.UnfailingDivinity;
 				}
 
-				buffs[buffslot].ExtraDIChance = mod;
+				if (buffslot > -1) {
+					buffs[buffslot].ExtraDIChance = mod;
+				}
   				break;
  			}
 
@@ -1694,7 +1709,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 #endif
 				rooted = true;
 
-				if (caster){
+				if (caster && buffslot > -1) {
 					buffs[buffslot].RootBreakChance = caster->aabonuses.RootBreakChance +
 													caster->itembonuses.RootBreakChance +
 													caster->spellbonuses.RootBreakChance;


### PR DESCRIPTION
Added checks to prevent crashes as seen in the below instances:

http://spire.akkadius.com/dev/release/22.8.0?id=2826
http://spire.akkadius.com/dev/release/22.8.0?id=2830

Mob::SpellEffect needs refactored eventually, but these checks should help ensure we don't call an out of bounds memory address. 

buffslot can be either -2, -1 or a positive value (that should be valid) so anywhere we use buffslot to access buffs[buffslot] we need to ensure there's a check to ensure we're not out of bounds.

