### PR TITLE
[Bug Fix] Check Rule "Bots Enabled" to prevent bot database calls on connect

### DIFF
--- a/zone/bot_raid.cpp
+++ b/zone/bot_raid.cpp
@@ -300,7 +300,10 @@ void Bot::ProcessBotGroupAdd(Group* group, Raid* raid, Client* client, bool new_
 
 void Client::SpawnRaidBotsOnConnect(Raid* raid) {
 	std::list<BotsAvailableList> bots_list;
-	database.botdb.LoadBotsList(CharacterID(), bots_list);
+	if (!database.botdb.LoadBotsList(CharacterID(), bots_list) || bots_list.empty()) {
+		return;
+	}
+
 	std::vector<RaidMember> r_members = raid->GetMembers();
 	for (const auto& m: r_members) {
 		if (strlen(m.member_name) != 0) {

--- a/zone/bot_raid.cpp
+++ b/zone/bot_raid.cpp
@@ -302,17 +302,19 @@ void Client::SpawnRaidBotsOnConnect(Raid* raid) {
 	std::list<BotsAvailableList> bots_list;
 	database.botdb.LoadBotsList(CharacterID(), bots_list);
 	std::vector<RaidMember> r_members = raid->GetMembers();
-	for (const RaidMember& iter: r_members) {
-		if (strlen(iter.member_name) != 0) {
-			for (const BotsAvailableList& b_iter: bots_list) {
-				if (strcmp(iter.member_name, b_iter.Name) == 0) {
+	for (const auto& m: r_members) {
+		if (strlen(m.member_name) != 0) {
+
+			for (const auto& b: bots_list) {
+				if (strcmp(m.member_name, b.Name) == 0) {
 					std::string buffer = "^spawn ";
-					buffer.append(iter.member_name);
+					buffer.append(m.member_name);
 					bot_command_real_dispatch(this, buffer.c_str());
-					Bot* b = entity_list.GetBotByBotName(iter.member_name);
-					if (b) {
-						b->SetRaidGrouped(true);
-						b->p_raid_instance = raid;
+					auto bot = entity_list.GetBotByBotName(m.member_name);
+
+					if (bot) {
+						bot->SetRaidGrouped(true);
+						bot->p_raid_instance = raid;
 					}
 				}
 			}

--- a/zone/client.h
+++ b/zone/client.h
@@ -2033,6 +2033,7 @@ public:
 	void SetBotSpawnLimit(int new_spawn_limit, uint8 class_id = NO_CLASS);
 
 	void CampAllBots(uint8 class_id = NO_CLASS);
+	void SpawnRaidBotsOnConnect(Raid* raid);
 
 private:
 	bool bot_owner_options[_booCount];
@@ -2042,7 +2043,6 @@ private:
 	bool CanTradeFVNoDropItem();
 	void SendMobPositions();
 	void PlayerTradeEventLog(Trade *t, Trade *t2);
-
 };
 
 #endif

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -607,28 +607,8 @@ void Client::CompleteConnect()
 		if (raid) {
 			SetRaidGrouped(true);
 			raid->LearnMembers();
-			std::list<BotsAvailableList> bots_list;
-			database.botdb.LoadBotsList(this->CharacterID(), bots_list);
-			std::vector<RaidMember> r_members = raid->GetMembers();
-			for (const RaidMember& iter : r_members) {
-				if (iter.member_name) {
-					for (const BotsAvailableList& b_iter : bots_list)
-					{
-						if (strcmp(iter.member_name, b_iter.Name) == 0)
-						{
-							char buffer[71] = "^spawn ";
-							strcat(buffer, iter.member_name);
-							bot_command_real_dispatch(this, buffer);
-							Bot* b = entity_list.GetBotByBotName(iter.member_name);
-							if (b)
-							{
-								b->SetRaidGrouped(true);
-								b->p_raid_instance = raid;
-								//b->SetFollowID(this->GetID());
-							}
-						}
-					}
-				}
+			if (RuleB(Bots, Enabled)) {
+				SpawnRaidBotsOnConnect(raid);
 			}
 			raid->VerifyRaid();
 			raid->GetRaidDetails();


### PR DESCRIPTION
Added check to verify Rule (Bots, Enabled) is true before we attempt to summon any Bots the owner previously had in their raid when they connect. Without this we were trying to run a database query against bot_data even if the server didn't have the bot schema.

https://cdn.discordapp.com/attachments/1090037315394613389/1090037447703937085/image.png