### PR TITLE
[Rules] Remove Guild Bank Zone ID Rule

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -274,7 +274,6 @@ RULE_BOOL(World, EnableTutorialButton, true, "Setting whether the Tutorial butto
 RULE_BOOL(World, EnableReturnHomeButton, true, "Setting whether the Return Home button should be active")
 RULE_INT(World, MaxLevelForTutorial, 10, "The highest level with which you can enter the tutorial")
 RULE_INT(World, TutorialZoneID, 189, "Zone ID of the tutorial")
-RULE_INT(World, GuildBankZoneID, 345, "Zone ID of the guild bank")
 RULE_INT(World, MinOfflineTimeToReturnHome, 21600, "Minimum offline time to activate the Return Home button. 21600 seconds is 6 Hours")
 RULE_INT(World, MaxClientsPerIP, -1, "Maximum number of clients allowed to connect per IP address if account status is < AddMaxClientsStatus. Default value: -1 (feature disabled)")
 RULE_INT(World, ExemptMaxClientsStatus, -1, "Exempt accounts from the MaxClientsPerIP and AddMaxClientsStatus rules, if their status is >= this value. Default value: -1 (feature disabled)")

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -867,7 +867,7 @@ void Client::CompleteConnect()
 	CalcItemScale();
 	DoItemEnterZone();
 
-	if (zone->GetZoneID() == RuleI(World, GuildBankZoneID) && GuildBanks)
+	if (zone->GetZoneID() == Zones::GUILDHALL && GuildBanks)
 		GuildBanks->SendGuildBank(this);
 
 	if (ClientVersion() >= EQ::versions::ClientVersion::SoD)
@@ -1426,7 +1426,7 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 			}
 		}
 		m_pp.guildrank = rank;
-		if (zone->GetZoneID() == RuleI(World, GuildBankZoneID))
+		if (zone->GetZoneID() == Zones::GUILDHALL)
 			GuildBanker = (guild_mgr.IsGuildLeader(GuildID(), CharacterID()) || guild_mgr.GetBankerFlag(CharacterID()));
 	}
 	m_pp.guildbanker = GuildBanker;
@@ -7446,7 +7446,7 @@ void Client::Handle_OP_GuildBank(const EQApplicationPacket *app)
 	if (!GuildBanks)
 		return;
 
-	if ((int)zone->GetZoneID() != RuleI(World, GuildBankZoneID))
+	if (zone->GetZoneID() != Zones::GUILDHALL)
 	{
 		Message(Chat::Red, "The Guild Bank is not available in this zone.");
 
@@ -7796,7 +7796,7 @@ void Client::Handle_OP_GuildCreate(const EQApplicationPacket *app)
 		{
 			Message(Chat::Yellow, "You are now the leader of %s", GuildName);
 
-			if (zone->GetZoneID() == RuleI(World, GuildBankZoneID) && GuildBanks)
+			if (zone->GetZoneID() == Zones::GUILDHALL && GuildBanks)
 				GuildBanks->SendGuildBank(this);
 			SendGuildRanks();
 		}
@@ -8126,7 +8126,7 @@ void Client::Handle_OP_GuildInviteAccept(const EQApplicationPacket *app)
 				Message(Chat::Red, "There was an error during the invite, DB may now be inconsistent.");
 				return;
 			}
-			if (zone->GetZoneID() == RuleI(World, GuildBankZoneID) && GuildBanks)
+			if (zone->GetZoneID() == Zones::GUILDHALL && GuildBanks)
 				GuildBanks->SendGuildBank(this);
 		}
 	}

--- a/zone/guild.cpp
+++ b/zone/guild.cpp
@@ -236,7 +236,7 @@ void Client::RefreshGuildInfo()
 	guild_id = info.guild_id;
 	GuildBanker = info.banker || guild_mgr.IsGuildLeader(GuildID(), CharacterID());
 
-	if(((int)zone->GetZoneID() == RuleI(World, GuildBankZoneID)))
+	if(zone->GetZoneID() == Zones::GUILDHALL)
 	{
 		if(WasBanker != GuildBanker)
 		{

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -1059,7 +1059,7 @@ Zone::Zone(uint32 in_zoneid, uint32 in_instanceid, const char* in_short_name)
 	did_adventure_actions = false;
 	database.QGlobalPurge();
 
-	if(zoneid == RuleI(World, GuildBankZoneID))
+	if(zoneid == Zones::GUILDHALL)
 		GuildBanks = new GuildBankManager;
 	else
 		GuildBanks = nullptr;


### PR DESCRIPTION
# Notes
- This rule is useless as guild bank zone ID is hard-coded into the client.