### PR TITLE
[Fix] Fix strcpy-param-overlap

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1135,7 +1135,6 @@ void Mob::SetSpawnLastNameByClass(NewSpawn_Struct* ns)
 			strcpy(ns->spawn.lastName, "Mercenary Liaison");
 			break;
 		default:
-			strcpy(ns->spawn.lastName, ns->spawn.lastName);
 			break;
 	}
 }


### PR DESCRIPTION
Redundant strcpy.

Fix strcpy-param-overlap in Mob::SetSpawnLastNameByClass(struct NewSpawn_Struct *) C:\Repo\Server\zone\mob.cpp:1138