### PR TITLE
[Bug Fix] Fix for OOZ Group updates when removing/inviting Bots

### DIFF
--- a/zone/bot_raid.cpp
+++ b/zone/bot_raid.cpp
@@ -188,6 +188,10 @@ void Bot::ProcessRaidInvite(Mob* invitee, Client* invitor, bool group_invite) {
 
 	Raid* raid = entity_list.GetRaidByClient(invitor);
 
+	if (raid->RaidCount() >= MAX_RAID_MEMBERS) {
+		invitor->MessageString(Chat::Red, RAID_IS_FULL);
+		return;
+	}
 	Bot::CreateBotRaid(invitee, invitor, group_invite, raid);
 }
 

--- a/zone/bot_raid.cpp
+++ b/zone/bot_raid.cpp
@@ -188,7 +188,7 @@ void Bot::ProcessRaidInvite(Mob* invitee, Client* invitor, bool group_invite) {
 
 	Raid* raid = entity_list.GetRaidByClient(invitor);
 
-	if (raid->RaidCount() >= MAX_RAID_MEMBERS) {
+	if (raid && raid->RaidCount() >= MAX_RAID_MEMBERS) {
 		invitor->MessageString(Chat::Red, RAID_IS_FULL);
 		return;
 	}

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -4162,7 +4162,7 @@ bool Client::GroupFollow(Client* inviter) {
 			if (iraid == raid) {
 				//both in same raid
 				uint32 ngid = raid->GetGroup(inviter->GetName());
-				if (raid->GroupCount(ngid) < 6) {
+				if (raid->GroupCount(ngid) < MAX_GROUP_MEMBERS) {
 					raid->MoveMember(GetName(), ngid);
 					raid->SendGroupDisband(this);
 					raid->GroupUpdate(ngid);
@@ -4183,7 +4183,7 @@ bool Client::GroupFollow(Client* inviter) {
 				if (!GetXTargetAutoMgr()->empty())
 					SetDirtyAutoHaters();
 
-				if (raid->GroupCount(groupToUse) < 6)
+				if (raid->GroupCount(groupToUse) < MAX_GROUP_MEMBERS)
 				{
 					raid->SendRaidCreate(this);
 					raid->SendMakeLeaderPacketTo(raid->leadername, this);

--- a/zone/string_ids.h
+++ b/zone/string_ids.h
@@ -358,6 +358,7 @@
 #define WHOALL_NO_RESULTS			5029	//There are no players in EverQuest that match those who filters.
 #define TELL_QUEUED_MESSAGE			5045	//You told %1 '%T2. %3'
 #define TOLD_NOT_ONLINE				5046	//%1 is not online at this time.
+#define RAID_IS_FULL				5048	//The raid is full.
 #define ZONING_NO_EXPANSION         5052	//The zone that you are attempting to enter is part of an expansion that you do not yet own.  You may need to return to the Login screen and enter an account key for that expansion.  If you have received this message in error, please /petition or send an email to EQAccounts@soe.sony.com
 #define PETITION_NO_DELETE			5053	//You do not have a petition in the queue.
 #define PETITION_DELETED			5054	//Your petition was successfully deleted.
@@ -460,6 +461,7 @@
 #define NO_ABILITY_OUT_OF_COMBAT	9194	//You can not use this ability while out of combat.
 #define LESSER_SPELL_VERSION        11004   //%1 is a lesser version of %2 and cannot be scribed
 #define AE_RAMPAGE					11015	//%1 goes on a WILD RAMPAGE!
+#define GROUP_IS_FULL				12000	//You cannot join that group, it is full.
 #define FACE_ACCEPTED				12028	//Facial features accepted.
 #define TRACKING_BEGIN				12040   //You begin tracking %1.
 #define SPELL_LEVEL_TO_LOW			12048	//You will have to achieve level %1 before you can scribe the %2.


### PR DESCRIPTION
Previously we were not handling OOZ group updates when a Bot joined or left a group gracefully, this likely was causing undefined behavior, and also a source of potential crashes.

Also added Group/Raid full checks and relevant string_ids.