### PR TITLE
[Bug Fix] Fix issues with Lua tables not starting at index 1

### DIFF
--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -2828,7 +2828,7 @@ luabind::object Lua_Client::GetPEQZoneFlags(lua_State* L) {
 	if (d_) {
 		auto self = reinterpret_cast<NativeType*>(d_);
 		auto l = self->GetPEQZoneFlags();
-		auto i = 0;
+		auto i = 1;
 		for (const auto& f : l) {
 			t[i] = f;
 			i++;
@@ -2843,7 +2843,7 @@ luabind::object Lua_Client::GetZoneFlags(lua_State* L) {
 	if (d_) {
 		auto self = reinterpret_cast<NativeType*>(d_);
 		auto l = self->GetZoneFlags();
-		auto i = 0;
+		auto i = 1;
 		for (const auto& f : l) {
 			t[i] = f;
 			i++;

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -2709,7 +2709,7 @@ luabind::object Lua_Mob::GetEntityVariables(lua_State* L) {
 	if (d_) {
 		auto self = reinterpret_cast<NativeType*>(d_);
 		auto l = self->GetEntityVariables();
-		auto i = 0;
+		auto i = 1;
 		for (const auto& v : l) {
 			t[i] = v;
 			i++;

--- a/zone/lua_object.cpp
+++ b/zone/lua_object.cpp
@@ -173,7 +173,7 @@ luabind::object Lua_Object::GetEntityVariables(lua_State* L) {
 	if (d_) {
 		auto self = reinterpret_cast<NativeType*>(d_);
 		auto l = self->GetEntityVariables();
-		auto i = 0;
+		auto i = 1;
 		for (const auto& v : l) {
 			t[i] = v;
 			i++;


### PR DESCRIPTION
# Notes
- This would cause the first item in the table to be inaccessible since Lua tables start at index `1` instead of index `0`.
- All other spots using Lua tables have their indexes starting at `1`.