### PR TITLE
[Performance] Change to use Pass by reference where valid.

### DIFF
--- a/common/crash.cpp
+++ b/common/crash.cpp
@@ -125,7 +125,7 @@ public:
 		StackWalker::OnOutput(szText);
 	}
 
-	const std::vector<std::string>& const GetLines() { return _lines; }
+	const std::vector<std::string>& GetLines() { return _lines; }
 private:
 	std::vector<std::string> _lines;
 };

--- a/common/database.cpp
+++ b/common/database.cpp
@@ -999,7 +999,7 @@ bool Database::GetVariable(std::string varname, std::string &varvalue)
 	return false;
 }
 
-bool Database::SetVariable(const std::string varname, const std::string &varvalue)
+bool Database::SetVariable(const std::string& varname, const std::string &varvalue)
 {
 	std::string escaped_name = Strings::Escape(varname);
 	std::string escaped_value = Strings::Escape(varvalue);

--- a/common/database.h
+++ b/common/database.h
@@ -235,7 +235,7 @@ public:
 	/* Database Variables */
 
 	bool	GetVariable(std::string varname, std::string &varvalue);
-	bool	SetVariable(const std::string varname, const std::string &varvalue);
+	bool	SetVariable(const std::string& varname, const std::string &varvalue);
 	bool	LoadVariables();
 
 	/* General Queries */

--- a/common/dbcore.cpp
+++ b/common/dbcore.cpp
@@ -74,7 +74,7 @@ void DBcore::ping()
 	m_mutex->unlock();
 }
 
-MySQLRequestResult DBcore::QueryDatabase(std::string query, bool retryOnFailureOnce)
+MySQLRequestResult DBcore::QueryDatabase(const std::string& query, bool retryOnFailureOnce)
 {
 	auto r = QueryDatabase(query.c_str(), query.length(), retryOnFailureOnce);
 	return r;

--- a/common/dbcore.h
+++ b/common/dbcore.h
@@ -24,7 +24,7 @@ public:
 	~DBcore();
 	eStatus GetStatus() { return pStatus; }
 	MySQLRequestResult QueryDatabase(const char *query, uint32 querylen, bool retryOnFailureOnce = true);
-	MySQLRequestResult QueryDatabase(std::string query, bool retryOnFailureOnce = true);
+	MySQLRequestResult QueryDatabase(const std::string& query, bool retryOnFailureOnce = true);
 	void TransactionBegin();
 	void TransactionCommit();
 	void TransactionRollback();

--- a/common/eq_limits.h
+++ b/common/eq_limits.h
@@ -129,7 +129,7 @@ namespace EQ
 
 			LookupEntry(const LookupEntry *lookup_entry) { }
 			LookupEntry(
-				InventoryTypeSize_Struct InventoryTypeSize,
+				const InventoryTypeSize_Struct& InventoryTypeSize,
 				uint64 EquipmentBitmask,
 				uint64 GeneralBitmask,
 				uint64 CursorBitmask,

--- a/common/proc_launcher.cpp
+++ b/common/proc_launcher.cpp
@@ -64,7 +64,7 @@ void ProcLauncher::Process() {
 		if(GetExitCodeProcess(cur->second->proc_info.hProcess, &res)) {
 			//got exit code, see if its still running...
 			if(res == STILL_ACTIVE) {
-				cur++;
+				++cur;
 				continue;
 			}
 			//else, it died, handle properly
@@ -76,7 +76,7 @@ void ProcLauncher::Process() {
 
 		//if we get here, the current process died.
 		tmp = cur;
-		tmp++;
+		++tmp;
 		ProcessTerminated(cur);
 		cur = tmp;
 	}
@@ -174,7 +174,7 @@ ProcLauncher::ProcRef ProcLauncher::Launch(Spec *&to_launch) {
 	std::vector<std::string>::iterator cur, end;
 	cur = it->args.begin();
 	end = it->args.end();
-	for(; cur != end; cur++) {
+	for(; cur != end; ++cur) {
 		args += " ";
 		args += *cur;
 	}
@@ -306,7 +306,7 @@ void ProcLauncher::TerminateAll(bool final) {
 		std::map<ProcRef, Spec *>::iterator cur, end;
 		cur = m_running.begin();
 		end = m_running.end();
-		for(; cur != end; cur++) {
+		for(; cur != end; ++cur) {
 			Terminate(cur->first, true);
 		}
 	} else {
@@ -317,7 +317,7 @@ void ProcLauncher::TerminateAll(bool final) {
 		std::map<ProcRef, Spec *>::iterator cur, end;
 		cur = running.begin();
 		end = running.end();
-		for(; cur != end; cur++) {
+		for(; cur != end; ++cur) {
 			Terminate(cur->first, true);
 			safe_delete(cur->second);
 		}

--- a/common/profanity_manager.cpp
+++ b/common/profanity_manager.cpp
@@ -258,7 +258,7 @@ bool EQ::ProfanityManager::clear_database_entries(DBcore *db) {
 	return true;
 }
 
-bool EQ::ProfanityManager::check_for_existing_entry(std::string profanity) {
+bool EQ::ProfanityManager::check_for_existing_entry(const std::string& profanity) {
 	if (profanity.empty()) {
 		return false;
 	}

--- a/common/profanity_manager.h
+++ b/common/profanity_manager.h
@@ -53,7 +53,7 @@ namespace EQ
 	private:
 		static bool load_database_entries(DBcore *db);
 		static bool clear_database_entries(DBcore *db);
-		static bool check_for_existing_entry(std::string profanity);
+		static bool check_for_existing_entry(const std::string& profanity);
 		
 	};
 

--- a/common/rulesys.cpp
+++ b/common/rulesys.cpp
@@ -141,11 +141,11 @@ bool RuleManager::SetRule(const std::string &rule_name, const std::string &rule_
 
 	switch (type) {
 		case IntRule:
-			m_RuleIntValues[index] = Strings::ToInt(rule_value.c_str());
+			m_RuleIntValues[index] = Strings::ToInt(rule_value);
 			LogRules("Set rule [{}] to value [{}]", rule_name, m_RuleIntValues[index]);
 			break;
 		case RealRule:
-			m_RuleRealValues[index] = Strings::ToFloat(rule_value.c_str());
+			m_RuleRealValues[index] = Strings::ToFloat(rule_value);
 			LogRules("Set rule [{}] to value [{:.2f}]", rule_name, m_RuleRealValues[index]);
 			break;
 		case BoolRule:

--- a/common/say_link.cpp
+++ b/common/say_link.cpp
@@ -294,7 +294,7 @@ void EQ::SayLinkEngine::generate_text()
 	m_LinkText = "null";
 }
 
-std::string EQ::SayLinkEngine::GenerateQuestSaylink(std::string saylink_text, bool silent, std::string link_name)
+std::string EQ::SayLinkEngine::GenerateQuestSaylink(const std::string& saylink_text, bool silent, const std::string& link_name)
 {
 	uint32 saylink_id = 0;
 

--- a/common/say_link.h
+++ b/common/say_link.h
@@ -101,7 +101,7 @@ namespace EQ
 		const std::string& LinkBody() { return m_LinkBody; }	// contains string format: '<LinkBody>'
 		const std::string& LinkText() { return m_LinkText; }	// contains string format: '<LinkText>'
 
-		static std::string GenerateQuestSaylink(std::string saylink_text, bool silent, std::string link_name);
+		static std::string GenerateQuestSaylink(const std::string& saylink_text, bool silent, const std::string& link_name);
 
 		void Reset();
 

--- a/common/zone_store.cpp
+++ b/common/zone_store.cpp
@@ -174,7 +174,7 @@ ZoneRepository::Zone *ZoneStore::GetZone(const char *in_zone_name)
 	return nullptr;
 }
 
-ZoneRepository::Zone *ZoneStore::GetZone(std::string in_zone_name)
+ZoneRepository::Zone *ZoneStore::GetZone(const std::string& in_zone_name)
 {
 	for (auto &z: m_zones) {
 		if (z.short_name == in_zone_name) {

--- a/common/zone_store.h
+++ b/common/zone_store.h
@@ -35,7 +35,7 @@ public:
 
 	ZoneRepository::Zone *GetZone(uint32 zone_id, int version = 0);
 	ZoneRepository::Zone *GetZone(const char *in_zone_name);
-	ZoneRepository::Zone *GetZone(std::string in_zone_name);
+	ZoneRepository::Zone *GetZone(const std::string& in_zone_name);
 	uint32 GetZoneID(const char *in_zone_name);
 	uint32 GetZoneID(std::string zone_name);
 	std::string GetZoneName(uint32 zone_id);
@@ -53,7 +53,7 @@ extern ZoneStore zone_store;
  * Global helpers
  */
 inline uint32 ZoneID(const char *in_zone_name) { return zone_store.GetZoneID(in_zone_name); }
-inline uint32 ZoneID(std::string zone_name) { return zone_store.GetZoneID(zone_name); }
+inline uint32 ZoneID(const std::string& zone_name) { return zone_store.GetZoneID(zone_name); }
 inline const char *ZoneName(uint32 zone_id, bool error_unknown = false)
 {
 	return zone_store.GetZoneName(

--- a/loginserver/client.cpp
+++ b/loginserver/client.cpp
@@ -489,7 +489,7 @@ bool Client::VerifyLoginHash(
  * @param db_loginserver
  */
 void Client::DoSuccessfulLogin(
-	const std::string in_account_name,
+	const std::string& in_account_name,
 	int db_account_id,
 	const std::string &db_loginserver
 )

--- a/loginserver/client.h
+++ b/loginserver/client.h
@@ -175,7 +175,7 @@ public:
 		const std::string &password_hash
 	);
 
-	void DoSuccessfulLogin(const std::string in_account_name, int db_account_id, const std::string &db_loginserver);
+	void DoSuccessfulLogin(const std::string& in_account_name, int db_account_id, const std::string &db_loginserver);
 	void CreateLocalAccount(const std::string &username, const std::string &password);
 	void CreateEQEmuAccount(const std::string &in_account_name, const std::string &in_account_password, unsigned int loginserver_account_id);
 

--- a/loginserver/options.h
+++ b/loginserver/options.h
@@ -71,10 +71,10 @@ public:
 	inline void AutoLinkAccounts(bool b) { auto_link_accounts = b; }
 	inline bool CanAutoLinkAccounts() const { return auto_link_accounts; }
 
-	inline void EQEmuLoginServerAddress(std::string v) { eqemu_loginserver_address = v; }
+	inline void EQEmuLoginServerAddress(const std::string& v) { eqemu_loginserver_address = v; }
 	inline std::string GetEQEmuLoginServerAddress() const { return eqemu_loginserver_address; }
 
-	inline void DefaultLoginServerName(std::string v) { default_loginserver_name = v; }
+	inline void DefaultLoginServerName(const std::string& v) { default_loginserver_name = v; }
 	inline std::string GetDefaultLoginServerName() const { return default_loginserver_name; }
 
 	inline void UpdateInsecurePasswords(bool b) { update_insecure_passwords = b; }

--- a/ucs/chatchannel.cpp
+++ b/ucs/chatchannel.cpp
@@ -32,7 +32,7 @@ void ServerToClient45SayLink(std::string& clientSayLink, const std::string& serv
 void ServerToClient50SayLink(std::string& clientSayLink, const std::string& serverSayLink);
 void ServerToClient55SayLink(std::string& clientSayLink, const std::string& serverSayLink);
 
-ChatChannel::ChatChannel(std::string inName, std::string inOwner, std::string inPassword, bool inPermanent, int inMinimumStatus) :
+ChatChannel::ChatChannel(const std::string& inName, const std::string& inOwner, const std::string& inPassword, bool inPermanent, int inMinimumStatus) :
 	m_delete_timer(0) {
 
 	m_name = inName;
@@ -137,7 +137,7 @@ ChatChannel *ChatChannelList::CreateChannel(
 	return new_channel;
 }
 
-ChatChannel* ChatChannelList::FindChannel(std::string Name) {
+ChatChannel* ChatChannelList::FindChannel(const std::string& Name) {
 
 	std::string normalized_name = CapitaliseName(Name);
 
@@ -283,7 +283,7 @@ void ChatChannel::SetPassword(const std::string& in_password) {
 	}
 }
 
-void ChatChannel::SetOwner(std::string& in_owner) {
+void ChatChannel::SetOwner(const std::string& in_owner) {
 
 	m_owner = in_owner;
 
@@ -659,7 +659,7 @@ ChatChannel *ChatChannelList::RemoveClientFromChannel(const std::string& in_chan
 	std::string channel_name = in_channel_name;
 
 	if (in_channel_name.length() > 0 && isdigit(channel_name[0])) {
-		channel_name = c->ChannelSlotName(Strings::ToInt(in_channel_name.c_str()));
+		channel_name = c->ChannelSlotName(Strings::ToInt(in_channel_name));
 	}
 
 	auto *required_channel = FindChannel(channel_name);
@@ -784,7 +784,7 @@ bool ChatChannel::HasVoice(std::string inVoiced)
 	return std::find(std::begin(m_voiced), std::end(m_voiced), inVoiced) != std::end(m_voiced);
 }
 
-std::string CapitaliseName(std::string inString) {
+std::string CapitaliseName(const std::string& inString) {
 
 	std::string NormalisedName = inString;
 

--- a/ucs/chatchannel.h
+++ b/ucs/chatchannel.h
@@ -76,7 +76,7 @@ class ChatChannelList {
 
 public:
 	ChatChannel* CreateChannel(const std::string& name, const std::string& owner, const std::string& password, bool permanent, int minimum_status, bool save_to_database = false);
-	ChatChannel* FindChannel(const std::string& Name);
+	ChatChannel* FindChannel(const std::string& name);
 	ChatChannel* AddClientToChannel(std::string channel_name, Client* c, bool command_directed = false);
 	ChatChannel* RemoveClientFromChannel(const std::string& in_channel_name, Client* c, bool command_directed = false);
 	void RemoveChannel(ChatChannel *Channel);

--- a/ucs/chatchannel.h
+++ b/ucs/chatchannel.h
@@ -15,7 +15,7 @@ class ChatChannel {
 
 public:
 
-	ChatChannel(std::string inName, std::string inOwner, std::string inPassword, bool inPermanent, int inMinimumStatus = 0);
+	ChatChannel(const std::string& inName, const std::string& inOwner, const std::string& inPassword, bool inPermanent, int inMinimumStatus = 0);
 	~ChatChannel();
 
 	void AddClient(Client *c);
@@ -29,7 +29,7 @@ public:
 	void SetPassword(const std::string& in_password);
 	bool IsOwner(const std::string& name) { return (m_owner == name); }
 	const std::string& GetPassword() { return m_password; }
-	void SetOwner(std::string& inOwner);
+	void SetOwner(const std::string& in_owner);
 	std::string& GetOwnerName();
 	void SetTemporary();
 	void SetPermanent();
@@ -76,7 +76,7 @@ class ChatChannelList {
 
 public:
 	ChatChannel* CreateChannel(const std::string& name, const std::string& owner, const std::string& password, bool permanent, int minimum_status, bool save_to_database = false);
-	ChatChannel* FindChannel(std::string name);
+	ChatChannel* FindChannel(const std::string& Name);
 	ChatChannel* AddClientToChannel(std::string channel_name, Client* c, bool command_directed = false);
 	ChatChannel* RemoveClientFromChannel(const std::string& in_channel_name, Client* c, bool command_directed = false);
 	void RemoveChannel(ChatChannel *Channel);
@@ -91,8 +91,8 @@ public:
 	static void AddToFilteredNames(const std::string& name);
 	static bool IsOnChannelBlockList(const std::string& channel_name);
 	static bool IsOnFilteredNameList(const std::string& channel_name);
-	static inline void SetChannelBlockList(std::vector<std::string> new_list) { m_blocked_channel_names = new_list; }
-	static inline void SetFilteredNameList(std::vector<std::string> new_list) { m_filtered_names = new_list; }
+	static inline void SetChannelBlockList(const std::vector<std::string>& new_list) { m_blocked_channel_names = new_list; }
+	static inline void SetFilteredNameList(const std::vector<std::string>& new_list) { m_filtered_names = new_list; }
 private:
 
 	LinkedList<ChatChannel*> ChatChannels;
@@ -101,6 +101,6 @@ private:
 
 };
 
-std::string CapitaliseName(std::string inString);
+std::string CapitaliseName(const std::string& inString);
 
 #endif

--- a/ucs/clientlist.cpp
+++ b/ucs/clientlist.cpp
@@ -348,7 +348,7 @@ static void ProcessMailTo(Client *c, std::string MailMessage) {
 	}
 }
 
-static void ProcessMailTo(Client *c, std::string from, std::string subject, std::string message) {
+static void ProcessMailTo(Client *c, const std::string& from, const std::string& subject, const std::string& message) {
 }
 
 static void ProcessSetMessageStatus(std::string SetMessageCommand) {
@@ -878,7 +878,7 @@ void Clientlist::ProcessOPMailCommand(Client *c, std::string command_string, boo
 		break;
 
 	case CommandGetBody:
-		database.SendBody(c, Strings::ToInt(parameters.c_str()));
+		database.SendBody(c, Strings::ToInt(parameters));
 		break;
 
 	case CommandMailTo:
@@ -983,7 +983,7 @@ void Client::SendMailBoxes() {
 	safe_delete(outapp);
 }
 
-Client *Clientlist::FindCharacter(std::string CharacterName) {
+Client *Clientlist::FindCharacter(const std::string& CharacterName) {
 
 	std::list<Client*>::iterator Iterator;
 
@@ -1243,7 +1243,7 @@ void Client::LeaveAllChannels(bool send_updated_channel_list, bool command_direc
 }
 
 
-void Client::ProcessChannelList(std::string Input) {
+void Client::ProcessChannelList(const std::string& Input) {
 
 	if (Input.length() == 0) {
 
@@ -1255,7 +1255,7 @@ void Client::ProcessChannelList(std::string Input) {
 	std::string ChannelName = Input;
 
 	if (isdigit(ChannelName[0]))
-		ChannelName = ChannelSlotName(Strings::ToInt(ChannelName.c_str()));
+		ChannelName = ChannelSlotName(Strings::ToInt(ChannelName));
 
 	ChatChannel *RequiredChannel = ChannelList->FindChannel(ChannelName);
 
@@ -1521,7 +1521,7 @@ void Client::SendChannelMessageByNumber(std::string Message) {
 
 }
 
-void Client::SendChannelMessage(std::string ChannelName, std::string Message, Client *Sender) {
+void Client::SendChannelMessage(const std::string& ChannelName, const std::string& Message, Client *Sender) {
 
 	if (!Sender) return;
 
@@ -1548,7 +1548,7 @@ void Client::SendChannelMessage(std::string ChannelName, std::string Message, Cl
 	safe_delete(outapp);
 }
 
-void Client::ToggleAnnounce(std::string State)
+void Client::ToggleAnnounce(const std::string& State)
 {
 	if (State == "")
 		Announce = !Announce;
@@ -1615,7 +1615,7 @@ void Client::GeneralChannelMessage(const char *Characters) {
 
 }
 
-void Client::GeneralChannelMessage(std::string Message) {
+void Client::GeneralChannelMessage(const std::string& Message) {
 
 	auto outapp = new EQApplicationPacket(OP_ChannelMessage, Message.length() + 3);
 	char *PacketBuffer = (char *)outapp->pBuffer;
@@ -1659,7 +1659,7 @@ void Client::SetChannelPassword(std::string ChannelPassword) {
 	std::string ChannelName = ChannelPassword.substr(ChannelStart);
 
 	if ((ChannelName.length() > 0) && isdigit(ChannelName[0]))
-		ChannelName = ChannelSlotName(Strings::ToInt(ChannelName.c_str()));
+		ChannelName = ChannelSlotName(Strings::ToInt(ChannelName));
 
 	std::string Message;
 
@@ -1724,7 +1724,7 @@ void Client::SetChannelOwner(std::string CommandString) {
 	std::string ChannelName = CapitaliseName(CommandString.substr(ChannelStart));
 
 	if ((ChannelName.length() > 0) && isdigit(ChannelName[0]))
-		ChannelName = ChannelSlotName(Strings::ToInt(ChannelName.c_str()));
+		ChannelName = ChannelSlotName(Strings::ToInt(ChannelName));
 
 	LogInfo("Set owner of channel [[{}]] to [[{}]]", ChannelName.c_str(), NewOwner.c_str());
 
@@ -1770,7 +1770,7 @@ void Client::OPList(std::string CommandString) {
 	std::string ChannelName = CapitaliseName(CommandString.substr(ChannelStart));
 
 	if ((ChannelName.length() > 0) && isdigit(ChannelName[0]))
-		ChannelName = ChannelSlotName(Strings::ToInt(ChannelName.c_str()));
+		ChannelName = ChannelSlotName(Strings::ToInt(ChannelName));
 
 	ChatChannel *RequiredChannel = ChannelList->FindChannel(ChannelName);
 
@@ -1813,7 +1813,7 @@ void Client::ChannelInvite(std::string CommandString) {
 	std::string ChannelName = CapitaliseName(CommandString.substr(ChannelStart));
 
 	if ((ChannelName.length() > 0) && isdigit(ChannelName[0]))
-		ChannelName = ChannelSlotName(Strings::ToInt(ChannelName.c_str()));
+		ChannelName = ChannelSlotName(Strings::ToInt(ChannelName));
 
 	LogInfo("[[{}]] invites [[{}]] to channel [[{}]]", GetName().c_str(), Invitee.c_str(), ChannelName.c_str());
 
@@ -1883,7 +1883,7 @@ void Client::ChannelModerate(std::string CommandString) {
 	std::string ChannelName = CapitaliseName(CommandString.substr(ChannelStart));
 
 	if ((ChannelName.length() > 0) && isdigit(ChannelName[0]))
-		ChannelName = ChannelSlotName(Strings::ToInt(ChannelName.c_str()));
+		ChannelName = ChannelSlotName(Strings::ToInt(ChannelName));
 
 	ChatChannel *RequiredChannel = ChannelList->FindChannel(ChannelName);
 
@@ -1941,7 +1941,7 @@ void Client::ChannelGrantModerator(std::string CommandString) {
 	std::string ChannelName = CapitaliseName(CommandString.substr(ChannelStart));
 
 	if ((ChannelName.length() > 0) && isdigit(ChannelName[0]))
-		ChannelName = ChannelSlotName(Strings::ToInt(ChannelName.c_str()));
+		ChannelName = ChannelSlotName(Strings::ToInt(ChannelName));
 
 	LogInfo("[[{}]] gives [[{}]] moderator rights to channel [[{}]]", GetName().c_str(), Moderator.c_str(), ChannelName.c_str());
 
@@ -2022,7 +2022,7 @@ void Client::ChannelGrantVoice(std::string CommandString) {
 	std::string ChannelName = CapitaliseName(CommandString.substr(ChannelStart));
 
 	if ((ChannelName.length() > 0) && isdigit(ChannelName[0]))
-		ChannelName = ChannelSlotName(Strings::ToInt(ChannelName.c_str()));
+		ChannelName = ChannelSlotName(Strings::ToInt(ChannelName));
 
 	LogInfo("[[{}]] gives [[{}]] voice to channel [[{}]]", GetName().c_str(), Voicee.c_str(), ChannelName.c_str());
 
@@ -2110,7 +2110,7 @@ void Client::ChannelKick(std::string CommandString) {
 	std::string ChannelName = CapitaliseName(CommandString.substr(ChannelStart));
 
 	if ((ChannelName.length() > 0) && isdigit(ChannelName[0]))
-		ChannelName = ChannelSlotName(Strings::ToInt(ChannelName.c_str()));
+		ChannelName = ChannelSlotName(Strings::ToInt(ChannelName));
 
 	LogInfo("[[{}]] kicks [[{}]] from channel [[{}]]", GetName().c_str(), Kickee.c_str(), ChannelName.c_str());
 
@@ -2279,7 +2279,7 @@ void Client::SetConnectionType(char c) {
 	}
 }
 
-Client *Clientlist::IsCharacterOnline(std::string CharacterName) {
+Client *Clientlist::IsCharacterOnline(const std::string& CharacterName) {
 
 	// This method is used to determine if the character we are a sending an email to is connected to the mailserver,
 	// so we can send them a new email notification.
@@ -2307,7 +2307,7 @@ Client *Clientlist::IsCharacterOnline(std::string CharacterName) {
 	return nullptr;
 }
 
-int Client::GetMailBoxNumber(std::string CharacterName) {
+int Client::GetMailBoxNumber(const std::string& CharacterName) {
 
 	for (unsigned int i = 0; i < Characters.size(); i++)
 		if (Characters[i].Name == CharacterName)
@@ -2316,7 +2316,7 @@ int Client::GetMailBoxNumber(std::string CharacterName) {
 	return -1;
 }
 
-void Client::SendNotification(int MailBoxNumber, std::string Subject, std::string From, int MessageID) {
+void Client::SendNotification(int MailBoxNumber, const std::string& Subject, const std::string& From, int MessageID) {
 
 	char TimeStamp[100];
 

--- a/ucs/clientlist.h
+++ b/ucs/clientlist.h
@@ -98,18 +98,18 @@ public:
 	void AddToChannelList(ChatChannel *JoinedChannel);
 	void RemoveFromChannelList(ChatChannel *JoinedChannel);
 	void SendChannelMessage(std::string Message);
-	void SendChannelMessage(std::string ChannelName, std::string Message, Client *Sender);
+	void SendChannelMessage(const std::string& ChannelName, const std::string& Message, Client *Sender);
 	void SendChannelMessageByNumber(std::string Message);
 	void SendChannelList();
 	void CloseConnection();
-	void ToggleAnnounce(std::string State);
+	void ToggleAnnounce(const std::string& State);
 	bool IsAnnounceOn() { return (Announce == true); }
 	void AnnounceJoin(ChatChannel *Channel, Client *c);
 	void AnnounceLeave(ChatChannel *Channel, Client *c);
-	void GeneralChannelMessage(std::string Message);
+	void GeneralChannelMessage(const std::string& Message);
 	void GeneralChannelMessage(const char *Characters);
 	void SetChannelPassword(std::string ChannelPassword);
-	void ProcessChannelList(std::string CommandString);
+	void ProcessChannelList(const std::string& Input);
 	void AccountUpdate();
 	int ChannelCount();
 	std::string RemoveDuplicateChannels(std::string& in_channels);
@@ -139,14 +139,14 @@ public:
 	inline bool GetForceDisconnect() { return ForceDisconnect; }
 	std::string MailBoxName();
 	int GetMailBoxNumber() { return CurrentMailBox; }
-	int GetMailBoxNumber(std::string CharacterName);
+	int GetMailBoxNumber(const std::string& CharacterName);
 
 	void SetConnectionType(char c);
 	ConnectionType GetConnectionType() { return TypeOfConnection; }
 	EQ::versions::ClientVersion GetClientVersion() { return ClientVersion_; }
 
 	inline bool IsMailConnection() { return (TypeOfConnection == ConnectionTypeMail) || (TypeOfConnection == ConnectionTypeCombined); }
-	void SendNotification(int MailBoxNumber, std::string From, std::string Subject, int MessageID);
+	void SendNotification(int MailBoxNumber, const std::string& Subject, const std::string& From, int MessageID);
 	void ChangeMailBox(int NewMailBox);
 	inline void SetMailBox(int NewMailBox) { CurrentMailBox = NewMailBox; }
 	void SendFriends();
@@ -184,10 +184,10 @@ public:
 	Clientlist(int MailPort);
 	void	Process();
 	void	CloseAllConnections();
-	Client *FindCharacter(std::string CharacterName);
+	Client *FindCharacter(const std::string& CharacterName);
 	void	CheckForStaleConnectionsAll();
 	void	CheckForStaleConnections(Client *c);
-	Client *IsCharacterOnline(std::string CharacterName);
+	Client *IsCharacterOnline(const std::string& CharacterName);
 	void ProcessOPMailCommand(Client* c, std::string command_string, bool command_directed = false);
 
 private:

--- a/ucs/database.cpp
+++ b/ucs/database.cpp
@@ -142,7 +142,7 @@ int UCSDatabase::FindAccount(const char *characterName, Client *client)
 	return accountID;
 }
 
-bool UCSDatabase::VerifyMailKey(std::string characterName, int IPAddress, std::string MailKey)
+bool UCSDatabase::VerifyMailKey(const std::string& characterName, int IPAddress, const std::string& MailKey)
 {
 
 	std::string query = StringFormat(

--- a/ucs/database.h
+++ b/ucs/database.h
@@ -40,7 +40,7 @@ class UCSDatabase : public Database {
 public:
 	int FindAccount(const char *CharacterName, Client *c);
 	int FindCharacter(const char *CharacterName);
-	bool VerifyMailKey(std::string CharacterName, int IPAddress, std::string MailKey);
+	bool VerifyMailKey(const std::string& characterName, int IPAddress, const std::string& MailKey);
 	bool GetVariable(const char* varname, char* varvalue, uint16 varvalue_len);
 	bool LoadChatChannels();
 	void LoadReservedNamesFromDB();

--- a/ucs/worldserver.cpp
+++ b/ucs/worldserver.cpp
@@ -43,7 +43,7 @@ extern const ucsconfig *Config;
 extern UCSDatabase       database;
 extern DiscordManager  discord_manager;
 
-void ProcessMailTo(Client *c, std::string from, std::string subject, std::string message);
+void ProcessMailTo(Client *c, const std::string& from, const std::string& subject, const std::string& message);
 
 void Client45ToServerSayLink(std::string& serverSayLink, const std::string& clientSayLink);
 void Client50ToServerSayLink(std::string& serverSayLink, const std::string& clientSayLink);

--- a/world/adventure.cpp
+++ b/world/adventure.cpp
@@ -82,7 +82,7 @@ void Adventure::RemovePlayer(std::string character_name)
 	}
 }
 
-bool Adventure::PlayerExists(std::string character_name)
+bool Adventure::PlayerExists(const std::string& character_name)
 {
 	auto iter = players.begin();
 	while(iter != players.end())

--- a/world/adventure.h
+++ b/world/adventure.h
@@ -71,7 +71,7 @@ public:
 	bool IsActive();
 	void AddPlayer(std::string character_name, bool add_client_to_instance = true);
 	void RemovePlayer(std::string character_name);
-	bool PlayerExists(std::string character_name);
+	bool PlayerExists(const std::string& character_name);
 	bool CreateInstance();
 	void IncrementCount();
 	void IncrementAssassinationCount();

--- a/world/launcher_link.cpp
+++ b/world/launcher_link.cpp
@@ -106,7 +106,7 @@ void LauncherLink::ProcessMessage(uint16 opcode, EQ::Net::Packet &p)
 		cur = result.begin();
 		end = result.end();
 		ZoneState zs;
-		for (; cur != end; cur++) {
+		for (; cur != end; ++cur) {
 			zs.port = cur->port;
 			zs.up = false;
 			zs.starts = 0;
@@ -232,7 +232,7 @@ void LauncherLink::BootDynamics(uint8 new_count) {
 		std::map<std::string, ZoneState>::iterator cur, end;
 		cur = m_states.begin();
 		end = m_states.end();
-		for (; cur != end; cur++) {
+		for (; cur != end; ++cur) {
 			StopZone(cur->first.c_str());
 		}
 	}
@@ -244,7 +244,7 @@ void LauncherLink::BootDynamics(uint8 new_count) {
 		std::map<std::string, ZoneState>::iterator cur, end;
 		cur = m_states.begin();
 		end = m_states.end();
-		for (; cur != end; cur++) {
+		for (; cur != end; ++cur) {
 			if (cur->first.find("dynamic_") == 0) {
 				if (found >= new_count) {
 					//this zone exceeds the number of allowed booted zones.
@@ -266,7 +266,7 @@ void LauncherLink::GetZoneList(std::vector<std::string> &l) {
 	std::map<std::string, ZoneState>::iterator cur, end;
 	cur = m_states.begin();
 	end = m_states.end();
-	for (; cur != end; cur++) {
+	for (; cur != end; ++cur) {
 		l.push_back(cur->first.c_str());
 	}
 }

--- a/world/world_config.h
+++ b/world/world_config.h
@@ -59,8 +59,8 @@ public:
 	static void LockWorld() { if (_world_config) _world_config->Locked=true; }
 	static void UnlockWorld() { if (_world_config) _world_config->Locked=false; }
 
-	static void SetWorldAddress(std::string addr) { if (_world_config) _world_config->WorldAddress=addr; }
-	static void SetLocalAddress(std::string addr) { if (_world_config) _world_config->LocalAddress=addr; }
+	static void SetWorldAddress(const std::string& addr) { if (_world_config) _world_config->WorldAddress=addr; }
+	static void SetLocalAddress(const std::string& addr) { if (_world_config) _world_config->LocalAddress=addr; }
 
 	void Dump() const;
 };

--- a/zone/combat_record.cpp
+++ b/zone/combat_record.cpp
@@ -2,7 +2,7 @@
 #include "../common/eqemu_logsys.h"
 #include "../common/strings.h"
 
-void CombatRecord::Start(std::string in_mob_name)
+void CombatRecord::Start(const std::string& in_mob_name)
 {
 	m_start_time      = std::time(nullptr);
 	m_end_time        = 0;

--- a/zone/combat_record.h
+++ b/zone/combat_record.h
@@ -7,7 +7,7 @@
 
 class CombatRecord {
 public:
-	void Start(std::string in_mob_name);
+	void Start(const std::string& in_mob_name);
 	void Stop();
 	bool InCombat() const;
 	void ProcessHPEvent(int64 hp, int64 current_hp);

--- a/zone/embperl.cpp
+++ b/zone/embperl.cpp
@@ -102,7 +102,7 @@ void Embperl::DoInit() {
 	try {
 		init_eval_file();
 	}
-	catch(std::string e)
+	catch(std::string& e)
 	{
 		//remember... lasterr() is no good if we crap out here, in construction
 		LogQuests("Perl Error [{}]", e);
@@ -142,7 +142,7 @@ void Embperl::DoInit() {
 		perl_command = "main::eval_file('plugin', '" + Config->PluginPlFile + "');";
 		eval_pv(perl_command.c_str(), FALSE);
 	}
-	catch(std::string e)
+	catch(std::string& e)
 	{
 		LogQuests("Warning [{}]: [{}]", Config->PluginPlFile, e);
 	}
@@ -160,7 +160,7 @@ void Embperl::DoInit() {
 			"}";
 		eval_pv(perl_command.c_str(),FALSE);
 	}
-	catch(std::string e)
+	catch(std::string& e)
 	{
 		LogQuests("Warning [{}]", e);
 	}

--- a/zone/raids.h
+++ b/zone/raids.h
@@ -147,7 +147,7 @@ public:
 	void	AddRaidLooter(const char* looter);
 	void	RemoveRaidLooter(const char* looter);
 
-	inline void	SetRaidMOTD(std::string in_motd) { motd = in_motd; };
+	inline void	SetRaidMOTD(const std::string& in_motd) { motd = in_motd; };
 
 	//util func
 	//keeps me from having to keep iterating through the list


### PR DESCRIPTION
Clean uses where we were passing by value where the value isn't a nullptr.
Clean uses where we were using postfix vs prefix operators on a non-primitive type.
Clean uses of converting a std::string to a c_string where the expected type is a std::string.
Catches should be passed by reference.