### PR TITLE
[Backups] Fix database dump error reporting

### DIFF
--- a/common/database/database_dump_service.cpp
+++ b/common/database/database_dump_service.cpp
@@ -28,6 +28,7 @@
 #include "../database_schema.h"
 #include "../file.h"
 #include "../process/process.h"
+#include "../termcolor/rang.hpp"
 
 #include <ctime>
 
@@ -36,6 +37,7 @@
 #else
 
 #include <sys/time.h>
+#include <thread>
 
 #endif
 
@@ -145,7 +147,7 @@ std::string DatabaseDumpService::GetQueryServTables()
 
 std::string DatabaseDumpService::GetSystemTablesList()
 {
-	auto system_tables = DatabaseSchema::GetServerTables();
+	auto system_tables  = DatabaseSchema::GetServerTables();
 	auto version_tables = DatabaseSchema::GetVersionTables();
 
 	system_tables.insert(
@@ -199,7 +201,7 @@ std::string DatabaseDumpService::GetDumpFileNameWithPath()
 	return GetSetDumpPath() + GetDumpFileName();
 }
 
-void DatabaseDumpService::Dump()
+void DatabaseDumpService::DatabaseDump()
 {
 	if (!IsMySQLInstalled()) {
 		LogError("MySQL is not installed; Please check your PATH for a valid MySQL installation");
@@ -227,7 +229,7 @@ void DatabaseDumpService::Dump()
 		config->DatabaseUsername
 	);
 
-	std::string options = "--allow-keywords --extended-insert --max-allowed-packet=1G --net-buffer-length=32704";
+	std::string options = "--allow-keywords --extended-insert --max-allowed-packet=1G -f --net-buffer-length=32704";
 	if (IsDumpWithNoData()) {
 		options += " --no-data";
 	}
@@ -308,7 +310,7 @@ void DatabaseDumpService::Dump()
 	if (IsDumpDropTableSyntaxOnly()) {
 		std::vector<std::string> tables = Strings::Split(tables_to_dump, ' ');
 
-		for (auto &table : tables) {
+		for (auto &table: tables) {
 			std::cout << "DROP TABLE IF EXISTS `" << table << "`;" << std::endl;
 		}
 
@@ -320,6 +322,26 @@ void DatabaseDumpService::Dump()
 		std::string execution_result = Process::execute(execute_command);
 		if (!execution_result.empty() && IsDumpOutputToConsole()) {
 			std::cout << execution_result;
+		}
+	}
+
+	LogSys.EnableConsoleLogging();
+
+	if (!pipe_file.empty()) {
+		std::string file = fmt::format("{}.sql", GetDumpFileNameWithPath());
+		auto        r    = File::GetContents(file);
+		if (!r.error.empty()) {
+			LogError("{}", r.error);
+		}
+
+		for (auto &line: Strings::Split(r.contents, "\n")) {
+			if (Strings::Contains(line, "mysqldump:")) {
+				LogError("{}", line);
+				LogError("Database dump failed. Correct the error before continuing or trying again");
+				LogError("This is to prevent data loss on behalf of the server operator");
+				RemoveSqlBackup();
+				std::exit(1);
+			}
 		}
 	}
 
@@ -343,6 +365,7 @@ void DatabaseDumpService::Dump()
 					)
 				);
 				LogInfo("Compressed dump created at [{}.tar.gz]", GetDumpFileNameWithPath());
+				RemoveSqlBackup();
 			}
 			else if (Is7ZipAvailable()) {
 				Process::execute(
@@ -353,6 +376,7 @@ void DatabaseDumpService::Dump()
 					)
 				);
 				LogInfo("Compressed dump created at [{}.zip]", GetDumpFileNameWithPath());
+				RemoveSqlBackup();
 			}
 			else {
 				LogInfo("Compression requested, but no available compression binary was found");
@@ -534,4 +558,12 @@ bool DatabaseDumpService::IsDumpMercTables() const
 void DatabaseDumpService::SetDumpMercTables(bool dump_merc_tables)
 {
 	DatabaseDumpService::dump_merc_tables = dump_merc_tables;
+}
+
+void DatabaseDumpService::RemoveSqlBackup()
+{
+	std::string file = fmt::format("{}.sql", GetDumpFileNameWithPath());
+	if (File::Exists(file)) {
+		std::filesystem::remove(file);
+	}
 }

--- a/common/database/database_dump_service.cpp
+++ b/common/database/database_dump_service.cpp
@@ -229,7 +229,7 @@ void DatabaseDumpService::DatabaseDump()
 		config->DatabaseUsername
 	);
 
-	std::string options = "--allow-keywords --extended-insert --max-allowed-packet=1G -f --net-buffer-length=32704";
+	std::string options = "--allow-keywords --extended-insert --max-allowed-packet=1G --net-buffer-length=32704";
 	if (IsDumpWithNoData()) {
 		options += " --no-data";
 	}

--- a/common/database/database_dump_service.h
+++ b/common/database/database_dump_service.h
@@ -24,7 +24,7 @@
 
 class DatabaseDumpService {
 public:
-	void Dump();
+	void DatabaseDump();
 	bool IsDumpAllTables() const;
 	void SetDumpAllTables(bool dump_all_tables);
 	bool IsDumpWithNoData() const;
@@ -92,6 +92,7 @@ private:
 	std::string GetDumpFileNameWithPath();
 	std::string GetSetDumpPath();
 	std::string GetQueryServTables();
+	void RemoveSqlBackup();
 };
 
 

--- a/common/file.cpp
+++ b/common/file.cpp
@@ -37,6 +37,7 @@
 
 #include <fmt/format.h>
 #include <filesystem>
+#include <iostream>
 
 namespace fs = std::filesystem;
 
@@ -79,4 +80,27 @@ std::string File::FindEqemuConfigPath()
 std::string File::GetCwd()
 {
 	return fs::current_path().string();
+}
+
+FileContentsResult File::GetContents(const std::string &file_name)
+{
+	std::string   error;
+	std::ifstream f;
+	f.open(file_name);
+	std::string line;
+	std::string lines;
+	if (f.is_open()) {
+		while (f) {
+			std::getline(f, line);
+			lines += line + "\n";
+		}
+	}
+	else {
+		error = fmt::format("Couldn't open file [{}]", file_name);
+	}
+
+	return FileContentsResult{
+		.contents = lines,
+		.error = error,
+	};
 }

--- a/common/file.h
+++ b/common/file.h
@@ -25,10 +25,16 @@
 
 namespace fs = std::filesystem;
 
+struct FileContentsResult {
+	std::string contents;
+	std::string error;
+};
+
 class File {
 public:
 	static bool Exists(const std::string &name);
 	static void Makedir(const std::string& directory_name);
+	static FileContentsResult GetContents(const std::string &file_name);
 	static std::string FindEqemuConfigPath();
 	static std::string GetCwd();
 };

--- a/common/process/process.cpp
+++ b/common/process/process.cpp
@@ -4,7 +4,8 @@
 
 std::string Process::execute(const std::string &cmd)
 {
-	std::shared_ptr<FILE> pipe(popen(cmd.c_str(), "r"), pclose);
+	std::string           command = fmt::format("{} 2>&1", cmd);
+	std::shared_ptr<FILE> pipe(popen(command.c_str(), "r"), pclose);
 	if (!pipe) { return "ERROR"; }
 	char        buffer[128];
 	std::string result;

--- a/world/cli/database_dump.cpp
+++ b/world/cli/database_dump.cpp
@@ -36,9 +36,7 @@ void WorldserverCLI::DatabaseDump(int argc, char **argv, argh::parser &cmd, std:
 		s->SetDumpPath(cmd("--dump-path").str());
 	}
 
-	/**
-	 * Set Option
-	 */
+	// options
 	s->SetDumpContentTables(cmd[{"--content-tables"}] || dump_all);
 	s->SetDumpLoginServerTables(cmd[{"--login-tables"}] || dump_all);
 	s->SetDumpPlayerTables(cmd[{"--player-tables"}] || dump_all);
@@ -48,15 +46,11 @@ void WorldserverCLI::DatabaseDump(int argc, char **argv, argh::parser &cmd, std:
 	s->SetDumpSystemTables(cmd[{"--system-tables"}] || dump_all);
 	s->SetDumpQueryServerTables(cmd[{"--query-serv-tables"}] || dump_all);
 	s->SetDumpAllTables(dump_all);
-
 	s->SetDumpWithNoData(cmd[{"--table-structure-only"}]);
 	s->SetDumpTableLock(cmd[{"--table-lock"}]);
 	s->SetDumpWithCompression(cmd[{"--compress"}]);
 	s->SetDumpOutputToConsole(cmd[{"--dump-output-to-console"}]);
 	s->SetDumpDropTableSyntaxOnly(cmd[{"--drop-table-syntax-only"}]);
 
-	/**
-	 * Dump
-	 */
-	s->Dump();
+	s->DatabaseDump();
 }


### PR DESCRIPTION
### What

This PR fixes an issue where database dumps would not bubble `stderr` from the underlying process execution. Currently this pipes `stderr` to `stdout` so we don't miss errors, this could be later improved to hold a response object containing `status` `stderr` and `stdout`

This is to prevent server operators from experiencing any sort of data loss if they are missing a table that the database backup is trying to request explicitly. If a table is missing, `mysqldump` will normally stop. 

We could ignore this but this really is something that should be addressed immediately otherwise it could cause worse pain to ignore.

![image](https://user-images.githubusercontent.com/3319450/229331154-c8ab0adc-3da1-4cb8-a6cd-25790f91b081.png)

* We now cleanup SQL files after compression is requested and a compression binary is found
* When a `mysqldump` error is detected, the world process is exited forcefully
* Added file utility `File::GetContents(file_name)`

![image](https://user-images.githubusercontent.com/3319450/229331923-b484478a-390f-4381-85d9-4811fee7fef4.png)
