### PR TITLE
[Bug Fix] Correct Forward Declaration compilation warning

### DIFF
--- a/zone/lua_iteminst.cpp
+++ b/zone/lua_iteminst.cpp
@@ -17,6 +17,13 @@ Lua_ItemInst::Lua_ItemInst(int item_id, int charges) {
 	cloned_ = true;
 }
 
+Lua_ItemInst::~Lua_ItemInst() {
+	if (cloned_) {
+		EQ::ItemInstance *ptr = GetLuaPtrData();
+		delete ptr;
+	}
+}
+
 Lua_ItemInst& Lua_ItemInst::operator=(const Lua_ItemInst& o) {
 	if(o.cloned_) {
 		cloned_ = true;

--- a/zone/lua_iteminst.h
+++ b/zone/lua_iteminst.h
@@ -4,8 +4,7 @@
 
 #include "lua_ptr.h"
 
-// Forward declarations
-#include "lua_item.h"
+// Forward declaration
 class Lua_Item;
 
 namespace EQ

--- a/zone/lua_iteminst.h
+++ b/zone/lua_iteminst.h
@@ -4,6 +4,8 @@
 
 #include "lua_ptr.h"
 
+// Forward declarations
+#include "lua_item.h"
 class Lua_Item;
 
 namespace EQ
@@ -28,7 +30,7 @@ public:
 	Lua_ItemInst(EQ::ItemInstance *d, bool cloned) : Lua_Ptr(d), cloned_(cloned) { }
 	Lua_ItemInst& operator=(const Lua_ItemInst& o);
 	Lua_ItemInst(const Lua_ItemInst& o);
-	virtual ~Lua_ItemInst() { if(cloned_) { EQ::ItemInstance *ptr = GetLuaPtrData(); if(ptr) { delete ptr; } } }
+	virtual ~Lua_ItemInst();
 
 	operator EQ::ItemInstance*() {
 		return reinterpret_cast<EQ::ItemInstance*>(GetLuaPtrData());


### PR DESCRIPTION
Fixes a warning where EQ::ItemInstance is an incomplete type due to destructor not being implemented in source, but instead under header.