### PR TITLE
[Rules] MeleePushChance applies to players

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -4211,8 +4211,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 		else
 			a->special = 0;
 		a->hit_heading = attacker ? attacker->GetHeading() : 0.0f;
-		if (RuleB(Combat, MeleePush) && damage > 0 && !IsRooted() &&
-			(IsClient() || zone->random.Roll(RuleI(Combat, MeleePushChance)))) {
+		if (RuleB(Combat, MeleePush) && damage > 0 && !IsRooted() && zone->random.Roll(RuleI(Combat, MeleePushChance))) {
 			a->force = EQ::skills::GetSkillMeleePushForce(skill_used);
 			if (IsNPC()) {
 				if (attacker && attacker->IsNPC()) {


### PR DESCRIPTION
Currently, the `Combat:MeleePush` rule is being applied to both clients and NPCs, but the `Combat:MeleePushChance` rule is only being applied to NPCs.

I'm putting this change out there for consideration, since it seems like it could be a net benefit to have the MeleePush rules applied consistently to the same entity types, but I also don't know the entire history around this and could be missing important context.

Based on comments from the original implementation, https://github.com/EQEmu/Server/commit/06f4fd49efc1dde83c4f18b0f20a93b709798436, there appears to be some uncertainty around whether clients should always get pushed or not, but I haven't been able to find a follow-up.