### PR TITLE
[Cleanup] Unconditional return in for loop in GetRaidByCharID()

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -2043,10 +2043,12 @@ uint32 Database::GetRaidIDByCharID(uint32 character_id) {
 		character_id
 	);
 	auto results = QueryDatabase(query);
-	for (auto row = results.begin(); row != results.end(); ++row) {
-		return Strings::ToUnsignedInt(row[0]);
+	if (!results.Success() || !results.RowCount()) {
+		return 0;
 	}
-	return 0;
+
+	auto row = results.begin();
+	return Strings::ToUnsignedInt(row[0]);
 }
 
 int Database::CountInvSnapshots() {


### PR DESCRIPTION
# Notes
- This is improper and should just check if we have no result, return `0`, otherwise return `row[0]` of the row we queried.