### PR TITLE
[Cleanup] Cleanup macros in features.h

### DIFF
--- a/common/features.h
+++ b/common/features.h
@@ -218,14 +218,14 @@ enum {	//some random constants
 #define HARD_LEVEL_CAP 127
 
 //the square of the maximum range at whihc you could possibly use NPC services (shop, tribute, etc)
-#define USE_NPC_RANGE2 200*200		//arbitrary right now
+#define USE_NPC_RANGE2 40000		//arbitrary right now
 
 // Squared range for rampage 75.0 * 75.0 for now
 #define NPC_RAMPAGE_RANGE2 5625.0f
 
 //the formula for experience for killing a mob.
 //level is the only valid variable to use
-#define EXP_FORMULA level*level*75*35/10
+#define EXP_FORMULA (level * level * 75 * 35 / 10)
 
 #define HIGHEST_AA_VALUE 35
 
@@ -295,7 +295,7 @@ Developer configuration
 
 #define COMMON_PROFILE
 
-#define PROFILE_DUMP_TIME 3*60
+#define PROFILE_DUMP_TIME 180
 #endif	//EQPROFILE
 
 


### PR DESCRIPTION
# Notes
- These needed to either be wrapped in parentheses or simplified to their values.
- https://pvs-studio.com/en/docs/warnings/v1003/