### PR TITLE
[Cleanup] Cleanup always true/false statements in shareddb.cpp

### DIFF
--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -619,7 +619,7 @@ bool SharedDatabase::GetInventory(uint32 char_id, EQ::InventoryProfile *inv)
 		}
 		else if (slot_id <= EQ::invbag::BANK_BAGS_END && slot_id >= EQ::invbag::BANK_BAGS_BEGIN) { // Titanium check
 			const auto parent_index = ((slot_id - EQ::invbag::BANK_BAGS_BEGIN) / EQ::invbag::SLOT_COUNT);
-			if (parent_index < EQ::invslot::SLOT_BEGIN || parent_index >= bank_size) {
+			if (parent_index >= bank_size) {
 				cv_conflict = true;
 				continue;
 			}
@@ -1564,24 +1564,28 @@ EQ::ItemInstance* SharedDatabase::CreateBaseItem(const EQ::ItemData* item, int16
 	if (item) {
 		// if maxcharges is -1 that means it is an unlimited use item.
 		// set it to 1 charge so that it is usable on creation
-		if (charges == 0 && item->MaxCharges == -1)
+		if (charges == 0 && item->MaxCharges == -1) {
 			charges = 1;
+		}
+
 		// Stackable items need a minimum charge of 1 to remain moveable.
-		if(charges <= 0 && item->Stackable)
+		if (charges <= 0 && item->Stackable) {
 			charges = 1;
+		}
 
 		inst = new EQ::ItemInstance(item, charges);
 
-		if (inst == nullptr) {
+		if (!inst) {
 			LogError("Error: valid item data returned a null reference for EQ::ItemInstance creation in SharedDatabase::CreateBaseItem()");
 			LogError("Item Data = ID: {}, Name: {}, Charges: {}", item->ID, item->Name, charges);
 			return nullptr;
 		}
 
-		if(item->CharmFileID != 0 || (item->LoreGroup >= 1000 && item->LoreGroup != -1)) {
+		if (item->CharmFileID != 0 || item->LoreGroup >= 1000) {
 			inst->Initialize(this);
 		}
 	}
+
 	return inst;
 }
 


### PR DESCRIPTION
# Notes
- `parent_index < EQ::invslot::SLOT_BEGIN` was always `false`.
- `item->LoreGroup != -1` was always `true`.