### PR TITLE
[Cleanup] Remove bool return from GetSharedPlatinum()

### DIFF
--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -425,17 +425,13 @@ bool SharedDatabase::DeleteSharedBankSlot(uint32 char_id, int16 slot_id) {
 
 int32 SharedDatabase::GetSharedPlatinum(uint32 account_id)
 {
-	const std::string query = StringFormat("SELECT sharedplat FROM account WHERE id = '%i'", account_id);
-    auto results = QueryDatabase(query);
-    if (!results.Success()) {
-		return false;
-    }
+	const auto query   = fmt::format("SELECT sharedplat FROM account WHERE id = {}", account_id);
+	auto       results = QueryDatabase(query);
+	if (!results.Success() || !results.RowCount()) {
+		return 0;
+	}
 
-    if (results.RowCount() != 1)
-        return 0;
-
-	auto& row = results.begin();
-
+	auto row = results.begin();
 	return Strings::ToInt(row[0]);
 }
 


### PR DESCRIPTION
# Notes
- This was returning `false` and implicitly converting it to an integer.