### PR TITLE
[Cleanup] Fix shared_tasks.cpp/shared_tasks.cpp variable named same as class member

### DIFF
--- a/common/shared_tasks.cpp
+++ b/common/shared_tasks.cpp
@@ -47,9 +47,9 @@ const SharedTasksRepository::SharedTasks &SharedTask::GetDbSharedTask() const
 	return m_db_shared_task;
 }
 
-void SharedTask::SetDbSharedTask(const SharedTasksRepository::SharedTasks &m_db_shared_task)
+void SharedTask::SetDbSharedTask(const SharedTasksRepository::SharedTasks &db_shared_task)
 {
-	SharedTask::m_db_shared_task = m_db_shared_task;
+	SharedTask::m_db_shared_task = db_shared_task;
 }
 
 SharedTaskRequest SharedTask::GetRequestCharacters(Database &db, uint32_t requested_character_id)

--- a/common/shared_tasks.cpp
+++ b/common/shared_tasks.cpp
@@ -47,9 +47,9 @@ const SharedTasksRepository::SharedTasks &SharedTask::GetDbSharedTask() const
 	return m_db_shared_task;
 }
 
-void SharedTask::SetDbSharedTask(const SharedTasksRepository::SharedTasks &db_shared_task)
+void SharedTask::SetDbSharedTask(const SharedTasksRepository::SharedTasks &t)
 {
-	SharedTask::m_db_shared_task = db_shared_task;
+	SharedTask::m_db_shared_task = t;
 }
 
 SharedTaskRequest SharedTask::GetRequestCharacters(Database &db, uint32_t requested_character_id)

--- a/common/shared_tasks.h
+++ b/common/shared_tasks.h
@@ -216,7 +216,7 @@ public:
 
 	// active record of database shared task
 	const SharedTasksRepository::SharedTasks &GetDbSharedTask() const;
-	void SetDbSharedTask(const SharedTasksRepository::SharedTasks &m_db_shared_task);
+	void SetDbSharedTask(const SharedTasksRepository::SharedTasks &db_shared_task);
 
 	std::vector<SharedTaskActivityStateEntry> m_shared_task_activity_state;
 	std::vector<SharedTaskMember>             m_members;

--- a/common/shared_tasks.h
+++ b/common/shared_tasks.h
@@ -216,7 +216,7 @@ public:
 
 	// active record of database shared task
 	const SharedTasksRepository::SharedTasks &GetDbSharedTask() const;
-	void SetDbSharedTask(const SharedTasksRepository::SharedTasks &db_shared_task);
+	void SetDbSharedTask(const SharedTasksRepository::SharedTasks &t);
 
 	std::vector<SharedTaskActivityStateEntry> m_shared_task_activity_state;
 	std::vector<SharedTaskMember>             m_members;


### PR DESCRIPTION
# Notes
- This variable was named `m_db_shared_task` which is the same as `SharedTask::m_db_shared_task`.