### PR TITLE
[Cleanup] Remove always true condition in Strings::Commify()

### DIFF
--- a/common/strings.cpp
+++ b/common/strings.cpp
@@ -287,15 +287,12 @@ std::string Strings::Commify(const std::string &number)
 	for (i = string_length - 3; i >= 0; i -= 3) {
 		if (i > 0) {
 			temp_string = "," + number.substr(static_cast<unsigned long>(i), 3) + temp_string;
-		}
-		else {
+		} else {
 			temp_string = number.substr(static_cast<unsigned long>(i), 3) + temp_string;
 		}
 	}
 
-	if (i < 0) {
-		temp_string = number.substr(0, static_cast<unsigned long>(3 + i)) + temp_string;
-	}
+	temp_string = number.substr(0, static_cast<unsigned long>(3 + i)) + temp_string;
 
 	return temp_string;
 }


### PR DESCRIPTION
# Notes
- `i < 0` was always true.