### PR TITLE
[Cleanup] Use .clear() instead of setting string to empty in eqemu_command_handler.cpp

### DIFF
--- a/common/cli/eqemu_command_handler.cpp
+++ b/common/cli/eqemu_command_handler.cpp
@@ -160,7 +160,7 @@ namespace EQEmuCommand {
 			 */
 			std::string command_section;
 			for (auto   &it: in_function_map) {
-				description = "";
+				description.clear();
 
 				(it.second)(argc, argv, cmd, description);
 


### PR DESCRIPTION
# Notes
- `x = ""` has less performance than `x.clear()`.
- https://pvs-studio.com/en/docs/warnings/v815/