### PR TITLE
[Cleanup] Use a constant reference for content_flags in SetContentFlags()

### DIFF
--- a/common/content/world_content_service.cpp
+++ b/common/content/world_content_service.cpp
@@ -120,7 +120,7 @@ std::vector<std::string> WorldContentService::GetContentFlagsDisabled()
 /**
  * @param content_flags
  */
-void WorldContentService::SetContentFlags(std::vector<ContentFlagsRepository::ContentFlags> content_flags)
+void WorldContentService::SetContentFlags(const std::vector<ContentFlagsRepository::ContentFlags>& content_flags)
 {
 	WorldContentService::content_flags = content_flags;
 }

--- a/common/content/world_content_service.h
+++ b/common/content/world_content_service.h
@@ -167,7 +167,7 @@ public:
 	std::vector<std::string> GetContentFlagsDisabled();
 	bool IsContentFlagEnabled(const std::string& content_flag);
 	bool IsContentFlagDisabled(const std::string& content_flag);
-	void SetContentFlags(std::vector<ContentFlagsRepository::ContentFlags> content_flags);
+	void SetContentFlags(const std::vector<ContentFlagsRepository::ContentFlags>& content_flags);
 	void ReloadContentFlags();
 	WorldContentService * SetExpansionContext();
 


### PR DESCRIPTION
# Notes
- This is more performant.
- https://pvs-studio.com/en/docs/warnings/v813/
- https://pvs-studio.com/en/docs/warnings/v820/