### PR TITLE
[Cleanup] Remove unused variable in Database::CopyCharacter()

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -2272,7 +2272,6 @@ bool Database::CopyCharacter(
 			new_rows.emplace_back(new_values);
 		}
 
-		std::string              insert_values;
 		std::vector<std::string> insert_rows;
 
 		for (auto &r: new_rows) {


### PR DESCRIPTION
# Notes
- This variable was created but never used.
- https://pvs-studio.com/en/docs/warnings/v808/