### PR TITLE
[Cleanup] Utilize .empty() instead of checking for an empty string in Database::ReserveName()

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -353,7 +353,7 @@ bool Database::ReserveName(uint32 account_id, char* name) {
 
 	query = StringFormat("INSERT INTO `character_data` SET `account_id` = %i, `name` = '%s'", account_id, name);
 	results = QueryDatabase(query);
-	if (!results.Success() || results.ErrorMessage() != ""){ return false; }
+	if (!results.Success() || !results.ErrorMessage().empty()){ return false; }
 
 	// Put character into the default guild if rule is being used.
 	int guild_id = RuleI(Character, DefaultGuild);
@@ -363,7 +363,7 @@ bool Database::ReserveName(uint32 account_id, char* name) {
 		if (character_id > -1) {
 			query = StringFormat("INSERT INTO `guild_members` SET `char_id` = %i, `guild_id` = '%i'", character_id, guild_id);
 			results = QueryDatabase(query);
-			if (!results.Success() || results.ErrorMessage() != ""){
+			if (!results.Success() || !results.ErrorMessage().empty()){
 				LogInfo("Could not put character [{}] into default Guild", name);
 			}
 		}


### PR DESCRIPTION
# Notes
- This is more performant.
- https://pvs-studio.com/en/docs/warnings/v815/