### PR TITLE
[Cleanup] Move variable definition to more relevant scope in DatabaseDumpService::Dump()

### DIFF
--- a/common/database/database_dump_service.cpp
+++ b/common/database/database_dump_service.cpp
@@ -293,14 +293,6 @@ void DatabaseDumpService::Dump()
 		pipe_file = fmt::format(" > {}.sql", GetDumpFileNameWithPath());
 	}
 
-	std::string execute_command = fmt::format(
-		"{} {} {} {}",
-		GetBaseMySQLDumpCommand(),
-		options,
-		tables_to_dump,
-		pipe_file
-	);
-
 	if (!File::Exists(GetSetDumpPath()) && !IsDumpOutputToConsole()) {
 		File::Makedir(GetSetDumpPath());
 	}
@@ -317,6 +309,14 @@ void DatabaseDumpService::Dump()
 		}
 	}
 	else {
+		const auto execute_command = fmt::format(
+			"{} {} {} {}",
+			GetBaseMySQLDumpCommand(),
+			options,
+			tables_to_dump,
+			pipe_file
+		);
+
 		std::string execution_result = Process::execute(execute_command);
 		if (!execution_result.empty() && IsDumpOutputToConsole()) {
 			std::cout << execution_result;


### PR DESCRIPTION
# Notes
- This was unused except for in this one spot, move to scope of condition where it's used.
- https://pvs-studio.com/en/docs/warnings/v821/