### PR TITLE
[Cleanup] Remove unused query variable in Database::DeleteInstance()

### DIFF
--- a/common/database_instances.cpp
+++ b/common/database_instances.cpp
@@ -429,8 +429,6 @@ void Database::AssignRaidToInstance(uint32 raid_id, uint32 instance_id)
 
 void Database::DeleteInstance(uint16 instance_id)
 {
-	std::string query;
-
 	InstanceListPlayerRepository::DeleteWhere(*this, fmt::format("id = {}", instance_id));
 
 	RespawnTimesRepository::DeleteWhere(*this, fmt::format("instance_id = {}", instance_id));


### PR DESCRIPTION
# Notes
- Variable was defined but never used.