### PR TITLE
[Cleanup] Use constant reference and check for empty string properly in dbcore.cpp

### DIFF
--- a/common/dbcore.cpp
+++ b/common/dbcore.cpp
@@ -80,7 +80,7 @@ MySQLRequestResult DBcore::QueryDatabase(const std::string& query, bool retryOnF
 	return r;
 }
 
-bool DBcore::DoesTableExist(std::string table_name)
+bool DBcore::DoesTableExist(const std::string& table_name)
 {
 	auto results = QueryDatabase(fmt::format("SHOW TABLES LIKE '{}'", table_name));
 
@@ -136,7 +136,7 @@ MySQLRequestResult DBcore::QueryDatabase(const char *query, uint32 querylen, boo
 		/**
 		 * Error logging
 		 */
-		if (mysql_errno(mysql) > 0 && strlen(query) > 0) {
+		if (mysql_errno(mysql) > 0 && query[0] != '\0') {
 			LogMySQLError("[{}] [{}]\n[{}]", mysql_errno(mysql), mysql_error(mysql), query);
 		}
 

--- a/common/dbcore.h
+++ b/common/dbcore.h
@@ -35,7 +35,7 @@ public:
 	const std::string &GetOriginHost() const;
 	void SetOriginHost(const std::string &origin_host);
 
-	bool DoesTableExist(std::string table_name);
+	bool DoesTableExist(const std::string& table_name);
 
 	void SetMySQL(const DBcore &o)
 	{


### PR DESCRIPTION
# Notes
- Passing by constant reference is more performant.
- Checking for empty string with `!= '\0'` is more performant.
- https://pvs-studio.com/en/docs/warnings/v805/
- https://pvs-studio.com/en/docs/warnings/v813/