### PR TITLE
[Rules] Optional summoning when already in melee range

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -518,6 +518,7 @@ RULE_BOOL(Combat, HeadshotOnlyHumanoids, true, "Enable or disable Headshot only 
 RULE_BOOL(Combat, EnableWarriorShielding, true, "Enable or disable Warrior Shielding Ability (/shield), true by default.")
 RULE_BOOL(Combat, BackstabIgnoresElemental, false, "Enable or disable Elemental weapon damage affecting backstab damage, false by default.")
 RULE_BOOL(Combat, BackstabIgnoresBane, false, "Enable or disable Bane weapon damage affecting backstab damage, false by default.")
+RULE_BOOL(Combat, SummonMeleeRange, true, "Enable or disable summoning of a player when already in melee range of the summoner.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(NPC)

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -3708,6 +3708,10 @@ bool Mob::HateSummon() {
 	if(target)
 	{
 		if(summon_level == 1) {
+			if (!RulesB(Combat, SummonMeleeRange) && CombatRange(target)) {
+				return false;
+			}
+
 			entity_list.MessageClose(this, true, 500, Chat::Say, "%s says 'You will not evade me, %s!' ", GetCleanName(), target->GetCleanName() );
 
 			float summoner_zoff = GetZOffset();

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -3708,10 +3708,6 @@ bool Mob::HateSummon() {
 	if(target)
 	{
 		if(summon_level == 1) {
-			if (!RuleB(Combat, SummonMeleeRange) && CombatRange(target)) {
-				return false;
-			}
-
 			entity_list.MessageClose(this, true, 500, Chat::Say, "%s says 'You will not evade me, %s!' ", GetCleanName(), target->GetCleanName() );
 
 			float summoner_zoff = GetZOffset();

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -3708,7 +3708,7 @@ bool Mob::HateSummon() {
 	if(target)
 	{
 		if(summon_level == 1) {
-			if (!RulesB(Combat, SummonMeleeRange) && CombatRange(target)) {
+			if (!RuleB(Combat, SummonMeleeRange) && CombatRange(target)) {
 				return false;
 			}
 

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -2189,9 +2189,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 						if (RuleR(Spells, CallOfTheHeroAggroClearDist) == 0 || caster->CalculateDistance(GetX(), GetY(), GetZ()) >= RuleR(Spells, CallOfTheHeroAggroClearDist)) {
 							entity_list.ClearAggro(this);
 						}
-					} else if (!RulesB(Combat, SummonMeleeRange) &&
-							   caster->GetZoneID() == GetZoneID() && caster->GetInstanceID() == GetInstanceID() &&
-							   caster->CombatRange(this)) {
+					} else if (!RuleB(Combat, SummonMeleeRange) && caster->GetZoneID() == GetZoneID() && caster->CombatRange(this)) {
 						break;
 					}
 

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -2189,6 +2189,10 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 						if (RuleR(Spells, CallOfTheHeroAggroClearDist) == 0 || caster->CalculateDistance(GetX(), GetY(), GetZ()) >= RuleR(Spells, CallOfTheHeroAggroClearDist)) {
 							entity_list.ClearAggro(this);
 						}
+					} else if (!RulesB(Combat, SummonMeleeRange) &&
+							   caster->GetZoneID() == GetZoneID() && caster->GetInstanceID() == GetInstanceID() &&
+							   caster->CombatRange(this)) {
+						break;
 					}
 
 					CastToClient()->MovePC(zone->GetZoneID(), zone->GetInstanceID(), caster->GetX(),


### PR DESCRIPTION
Add an optional rule to disable summon spells when the player is already within melee range of an NPC.

This kind of summoning is most apparent in North Temple of Veeshan, but might be in place elsewhere.