### PR TITLE
[Cleanup] Cleanup discord.cpp and discord_manager.cpp

### DIFF
--- a/common/discord/discord.cpp
+++ b/common/discord/discord.cpp
@@ -27,9 +27,6 @@ void Discord::SendWebhookMessage(const std::string &message, const std::string &
 	cli.set_connection_timeout(0, 15000000); // 15 sec
 	cli.set_read_timeout(15, 0); // 15 seconds
 	cli.set_write_timeout(15, 0); // 15 seconds
-	httplib::Headers headers = {
-		{"Content-Type", "application/json"}
-	};
 
 	// payload
 	Json::Value p;
@@ -96,9 +93,6 @@ void Discord::SendPlayerEventMessage(
 	cli.set_connection_timeout(0, 15000000); // 15 sec
 	cli.set_read_timeout(15, 0); // 15 seconds
 	cli.set_write_timeout(15, 0); // 15 seconds
-	httplib::Headers headers = {
-		{"Content-Type", "application/json"}
-	};
 
 	std::string payload = PlayerEventLogs::GetDiscordPayloadFromEvent(e);
 	if (payload.empty()) {

--- a/common/discord/discord_manager.cpp
+++ b/common/discord/discord_manager.cpp
@@ -37,7 +37,7 @@ void DiscordManager::ProcessMessageQueue()
 					message,
 					webhook.webhook_url
 				);
-				message = "";
+				message.clear();
 			}
 
 			message += m;
@@ -51,7 +51,7 @@ void DiscordManager::ProcessMessageQueue()
 						webhook.webhook_url
 					);
 				}
-				message = "";
+				message.clear();
 			}
 		}
 		// final flush


### PR DESCRIPTION
# Notes
- Unused variables in `discord.cpp`.
- Use `.clear()` instead of setting to `""` in `discord_manager.cpp`.