### PR TITLE
[Cleanup] Use default ctor instead of an empty ctor.

### DIFF
--- a/common/eqdb.cpp
+++ b/common/eqdb.cpp
@@ -23,9 +23,6 @@
 
 EQDB EQDB::s_EQDB;
 
-EQDB::EQDB() {
-}
-
 unsigned int EQDB::field_count() {
 	return mysql_field_count(mysql_ref);
 }

--- a/common/eqdb.h
+++ b/common/eqdb.h
@@ -27,7 +27,7 @@
 
 //this is the main object exported to perl.
 class EQDB {
-	EQDB();
+	EQDB() = default;
 public:
 	static EQDB *Singleton() { return(&s_EQDB); }
 


### PR DESCRIPTION
# Notes
- Use `= default;` instead of an empty ctor.
- https://pvs-studio.com/en/docs/warnings/v832/