### PR TITLE
[Cleanup] Cleanup cheap-to-copy reference to use value instead in eq_stream_ident.cpp/eq_stream_ident.h

### DIFF
--- a/common/eq_stream_ident.cpp
+++ b/common/eq_stream_ident.cpp
@@ -26,7 +26,7 @@ EQStreamIdentifier::~EQStreamIdentifier() {
 	}
 }
 
-void EQStreamIdentifier::RegisterPatch(const EQStreamInterface::Signature &sig, const char *name, OpcodeManager ** opcodes, const StructStrategy *structs) {
+void EQStreamIdentifier::RegisterPatch(EQStreamInterface::Signature sig, const char *name, OpcodeManager ** opcodes, const StructStrategy *structs) {
 	auto p = new Patch;
 	p->signature = sig;
 	p->name = name;

--- a/common/eq_stream_ident.h
+++ b/common/eq_stream_ident.h
@@ -18,7 +18,7 @@ public:
 	~EQStreamIdentifier();
 
 	//registration interface.
-	void RegisterPatch(const EQStreamInterface::Signature &sig, const char *name, OpcodeManager ** opcodes, const StructStrategy *structs);
+	void RegisterPatch(EQStreamInterface::Signature sig, const char *name, OpcodeManager ** opcodes, const StructStrategy *structs);
 
 	//main processing interface
 	void Process();


### PR DESCRIPTION
# Notes
- More performant to pass by value than by reference.