### PR TITLE
[Cleanup] Use default dtor instead of empty dtor for EQTime in eqtime.cpp/eqtime.h

### DIFF
--- a/common/eqtime.cpp
+++ b/common/eqtime.cpp
@@ -58,10 +58,6 @@ EQTime::EQTime()
 	SetCurrentEQTimeOfDay(start, time(0));
 }
 
-EQTime::~EQTime()
-{
-}
-
 //getEQTimeOfDay - Reads timeConvert and writes the result to eqTimeOfDay
 //This function was written by the ShowEQ Project.
 //Input: Current Time (as a time_t), a pointer to the TimeOfDay_Struct that will be written to.

--- a/common/eqtime.h
+++ b/common/eqtime.h
@@ -18,7 +18,7 @@ public:
 	//Constructor/destructor
 	EQTime(TimeOfDay_Struct start_eq, time_t start_real);
 	EQTime();
-	~EQTime();
+	~EQTime() = default;
 
 	//Get functions
 	int GetCurrentEQTimeOfDay( TimeOfDay_Struct *eqTimeOfDay ) { return(GetCurrentEQTimeOfDay(time(nullptr), eqTimeOfDay)); }


### PR DESCRIPTION
# Notes
- This is better than using an empty dtor.