### PR TITLE
[Cleanup] Wake The Dead argument was named the same as a member variable in Mob

### DIFF
--- a/zone/aa.cpp
+++ b/zone/aa.cpp
@@ -288,7 +288,7 @@ void Mob::TypesTemporaryPets(uint32 typesid, Mob *targ, const char *name_overrid
 	delete made_npc;
 }
 
-void Mob::WakeTheDead(uint16 spell_id, Corpse *corpse_to_use, Mob *target, uint32 duration) {
+void Mob::WakeTheDead(uint16 spell_id, Corpse *corpse_to_use, Mob *tar, uint32 duration) {
 
 	/*
 		SPA 299 Wake The Dead, 'animateDead' should be temp pet, always spawns 1 pet from corpse, max value is duration
@@ -493,8 +493,8 @@ void Mob::WakeTheDead(uint16 spell_id, Corpse *corpse_to_use, Mob *target, uint3
 		swarm_pet_npc->GetSwarmInfo()->owner_id = GetID();
 
 		//give the pets somebody to "love"
-		if (target != nullptr) {
-			swarm_pet_npc->AddToHateList(target, 10000, 1000);
+		if (tar != nullptr) {
+			swarm_pet_npc->AddToHateList(tar, 10000, 1000);
 			swarm_pet_npc->GetSwarmInfo()->target = 0;
 		}
 
@@ -507,8 +507,8 @@ void Mob::WakeTheDead(uint16 spell_id, Corpse *corpse_to_use, Mob *target, uint3
 	}
 
 	//the target of these swarm pets will take offense to being cast on...
-	if (target != nullptr)
-		target->AddToHateList(this, 1, 0);
+	if (tar != nullptr)
+		tar->AddToHateList(this, 1, 0);
 
 	// The other pointers we make are handled elsewhere.
 	delete made_npc;


### PR DESCRIPTION
# Notes
- Member variable is also named `target`.