### PR TITLE
[Cleanup] Fix filter condition in attack.cpp

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -4460,8 +4460,10 @@ void Mob::HealDamage(uint64 amount, Mob* caster, uint16 spell_id)
 					caster->FilteredMessageString(caster, Chat::NonMelee, FilterSpellDamage,
 						YOU_HEAL, GetCleanName(), itoa(acthealed));
 			}
-		}
-		else if (CastToClient()->GetFilter(FilterHealOverTime) != (FilterShowSelfOnly || FilterHide)) {
+		} else if (
+			CastToClient()->GetFilter(FilterHealOverTime) != FilterShowSelfOnly ||
+			CastToClient()->GetFilter(FilterHealOverTime) != FilterHide
+		) {
 			Message(Chat::NonMelee, "You have been healed for %d points of damage.", acthealed);
 		}
 	}


### PR DESCRIPTION
# Notes
- This condition was causing them to be used as `booleans` versus being checked individually.

# Image
![image](https://user-images.githubusercontent.com/89047260/229388988-ddce3080-7985-4904-8962-af19405660fe.png)