### PR TITLE
[Cleanup] Fix skill_used being used as boolean in Mob::CommonDamage()

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -3887,9 +3887,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 			damage = ReduceAllDamage(damage);
 			TryTriggerThreshHold(damage, SE_TriggerMeleeThreshold, attacker);
 
-			if (skill_used)
-				CheckNumHitsRemaining(NumHit::IncomingHitSuccess);
-
+			CheckNumHitsRemaining(NumHit::IncomingHitSuccess);
 		}
 		else {
 			int64 origdmg = damage;


### PR DESCRIPTION
# Notes
- This is unnecessary as we always have a skill value.