### PR TITLE
[Cleanup] Remove extraneous parentheses around math in Mob::ApplySpellsBonuses()

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -2167,7 +2167,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				}
 				else if ((effect_value - 100) < 0) { // Slow
 					int real_slow_value = (100 - effect_value) * -1;
-					real_slow_value -= ((real_slow_value * GetSlowMitigation()/100));
+					real_slow_value -= (real_slow_value * GetSlowMitigation()/100);
 					if (real_slow_value < new_bonus->haste)
 						new_bonus->haste = real_slow_value;
 				}
@@ -2184,7 +2184,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				}
 				else if ((effect_value - 100) < 0) { // Slow
 					int real_slow_value = (100 - effect_value) * -1;
-					real_slow_value -= ((real_slow_value * GetSlowMitigation()/100));
+					real_slow_value -= (real_slow_value * GetSlowMitigation()/100);
 					if (real_slow_value < new_bonus->hastetype2)
 						new_bonus->hastetype2 = real_slow_value;
 				}
@@ -2194,7 +2194,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 			case SE_AttackSpeed3:
 			{
 				if (effect_value < 0){ //Slow
-					effect_value -= ((effect_value * GetSlowMitigation()/100));
+					effect_value -= (effect_value * GetSlowMitigation()/100);
 					if (effect_value < new_bonus->hastetype3)
 						new_bonus->hastetype3 = effect_value;
 				}
@@ -2218,7 +2218,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 					effect_value = effect_value * -1;
 
 				if (effect_value > 0 && effect_value > new_bonus->inhibitmelee) {
-					effect_value -= ((effect_value * GetSlowMitigation()/100));
+					effect_value -= (effect_value * GetSlowMitigation()/100);
 					if (effect_value > new_bonus->inhibitmelee)
 						new_bonus->inhibitmelee = effect_value;
 				}


### PR DESCRIPTION
# Notes
- Extra parentheses.