### PR TITLE
[Cleanup] Remove extraneous check for NegateAttacks in SE_NegateAttacks

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -3199,8 +3199,13 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 
 			case SE_NegateAttacks:
 			{
-				if (!new_bonus->NegateAttacks[SBIndex::NEGATE_ATK_EXISTS] ||
-					((new_bonus->NegateAttacks[SBIndex::NEGATE_ATK_EXISTS] && new_bonus->NegateAttacks[SBIndex::NEGATE_ATK_MAX_DMG_ABSORB_PER_HIT]) && (new_bonus->NegateAttacks[SBIndex::NEGATE_ATK_MAX_DMG_ABSORB_PER_HIT] < max_value))){
+				if (
+					!new_bonus->NegateAttacks[SBIndex::NEGATE_ATK_EXISTS] ||
+					(
+						new_bonus->NegateAttacks[SBIndex::NEGATE_ATK_MAX_DMG_ABSORB_PER_HIT] &&
+						new_bonus->NegateAttacks[SBIndex::NEGATE_ATK_MAX_DMG_ABSORB_PER_HIT] < max_value
+					)
+				) {
 					new_bonus->NegateAttacks[SBIndex::NEGATE_ATK_EXISTS]                 = 1;
 					new_bonus->NegateAttacks[SBIndex::NEGATE_ATK_BUFFSLOT]               = buffslot;
 					new_bonus->NegateAttacks[SBIndex::NEGATE_ATK_MAX_DMG_ABSORB_PER_HIT] = max_value;


### PR DESCRIPTION
# Notes
- We checked both, we only need to check one.