### PR TITLE
[Cleanup] Set Illusion bonuses to use spell ID instead of boolean

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -1649,7 +1649,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 		}
 
 		case SE_Illusion:
-			newbon->Illusion = true;
+			newbon->Illusion = rank.spell;
 			break;
 
 		case SE_IllusionPersistence:


### PR DESCRIPTION
# Notes
- Spell bonuses `Illusion` is the spell ID, not a boolean.