### PR TITLE
[Cleanup] Remove unnecessary setting of reuse variable in Bot::DoClassAttacks()

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -5141,7 +5141,7 @@ void Bot::DoClassAttacks(Mob *target, bool IsRiposte) {
 	float HasteModifier = (GetHaste() * 0.01f);
 	uint16 skill_to_use = -1;
 	int level = GetLevel();
-	int reuse = (TauntReuseTime * 1000);
+	int reuse = (TauntReuseTime * 1000); // Same as Bash and Kick
 	bool did_attack = false;
 	switch (GetClass()) {
 		case WARRIOR:
@@ -5204,7 +5204,6 @@ void Bot::DoClassAttacks(Mob *target, bool IsRiposte) {
 			if (GetWeaponDamage(target, GetBotItem(EQ::invslot::slotSecondary)) <= 0 && GetWeaponDamage(target, GetBotItem(EQ::invslot::slotShoulders)) <= 0)
 				dmg = DMG_INVULNERABLE;
 
-			reuse = (BashReuseTime * 1000);
 			DoSpecialAttackDamage(target, EQ::skills::SkillBash, dmg, 0, -1, reuse);
 			did_attack = true;
 		}
@@ -5231,7 +5230,6 @@ void Bot::DoClassAttacks(Mob *target, bool IsRiposte) {
 			if (GetWeaponDamage(target, GetBotItem(EQ::invslot::slotFeet)) <= 0)
 				dmg = DMG_INVULNERABLE;
 
-			reuse = (KickReuseTime * 1000);
 			DoSpecialAttackDamage(target, EQ::skills::SkillKick, dmg, 0, -1, reuse);
 			did_attack = true;
 		}


### PR DESCRIPTION
# Notes
- Bash, Kick, and Taunt have the same reuse time, no reason to set it to the same value.