### PR TITLE
[Cleanup] Remove unnecessary skill_to_use check in Bot::DoClassAttacks()

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -5193,9 +5193,6 @@ void Bot::DoClassAttacks(Mob *target, bool IsRiposte) {
 			break;
 	}
 
-	if (skill_to_use == -1)
-		return;
-
 	int64 dmg = GetBaseSkillDamage(static_cast<EQ::skills::SkillType>(skill_to_use), GetTarget());
 
 	if (skill_to_use == EQ::skills::SkillBash) {


### PR DESCRIPTION
# Notes
- `skill_to_use` will never be `-1` as it passes through the switch and checks class.