### PR TITLE
[Cleanup] Remove unnecessary setting of spell_type_index in Bot::GetChanceToCastBySpellType()

### DIFF
--- a/zone/botspellsai.cpp
+++ b/zone/botspellsai.cpp
@@ -2996,9 +2996,9 @@ uint8 Bot::GetChanceToCastBySpellType(uint32 spellType)
 		spell_type_index = spellTypeIndexPreCombatBuffSong;
 		break;
 	default:
-		spell_type_index = SPELL_TYPE_COUNT;
 		break;
 	}
+
 	if (spell_type_index >= SPELL_TYPE_COUNT)
 		return 0;
 


### PR DESCRIPTION
# Notes
- The default is already `SPELL_TYPE_COUNT`, no need to set it again.