### PR TITLE
[Cleanup] Remove unnecessary spell_list validation check in botspellsai.cpp

### DIFF
--- a/zone/botspellsai.cpp
+++ b/zone/botspellsai.cpp
@@ -3053,23 +3053,16 @@ bool Bot::AI_AddBotSpells(uint32 bot_spell_id) {
 		GetLevel()
 	);
 
-	if (spell_list) {
-		debug_msg.append(
-			fmt::format(
-				" (found, {})",
-				spell_list->entries.size()
-			)
-		);
+	debug_msg.append(
+		fmt::format(
+			" (found, {})",
+			spell_list->entries.size()
+		)
+	);
 
-		LogAI("[{}]", debug_msg);
-		for (const auto &iter : spell_list->entries) {
-			LogAIDetail("([{}]) [{}]", iter.spellid, spells[iter.spellid].name);
-		}
-	}
-	else
-	{
-		debug_msg.append(" (not found)");
-		LogAI("[{}]", debug_msg);
+	LogAI("[{}]", debug_msg);
+	for (const auto &iter: spell_list->entries) {
+		LogAIDetail("([{}]) [{}]", iter.spellid, spells[iter.spellid].name);
 	}
 
 	LogAI("fin (spell list)");


### PR DESCRIPTION
# Notes
- We check if valid above, no need to do it again.