### PR TITLE
[Cleanup] Remove unnecessary botCaster check in Bot::GetDebuffBotSpell()

### DIFF
--- a/zone/botspellsai.cpp
+++ b/zone/botspellsai.cpp
@@ -2672,7 +2672,7 @@ BotSpell Bot::GetDebuffBotSpell(Bot* botCaster, Mob *tar) {
 	if (!tar || !botCaster)
 		return result;
 
-	if (botCaster && botCaster->AI_HasSpells()) {
+	if (botCaster->AI_HasSpells()) {
 		std::vector<BotSpells_Struct> botSpellList = botCaster->AIBot_spells;
 
 		for (int i = botSpellList.size() - 1; i >= 0; i--) {


### PR DESCRIPTION
# Notes
- We already check if `botCaster` is invalid above, no need to do so again.