### PR TITLE
[Cleanup] Fix possible overflows in Client::AddPlatinum() and Client::TakePlatinum()

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -2222,7 +2222,7 @@ uint32 Client::GetCarriedPlatinum() {
 
 bool Client::TakePlatinum(uint32 platinum, bool update_client) {
 	if (GetCarriedPlatinum() >= platinum) {
-		auto copper = static_cast<uint64>(platinum * 1000);
+		const auto copper = static_cast<uint64>(platinum) * 1000;
 		return TakeMoneyFromPP(copper, update_client);
 	}
 
@@ -2316,7 +2316,7 @@ bool Client::TakeMoneyFromPP(uint64 copper, bool update_client) {
 }
 
 void Client::AddPlatinum(uint32 platinum, bool update_client) {
-	auto copper = static_cast<uint64>(platinum * 1000);
+	const auto copper = static_cast<uint64>(platinum) * 1000;
 	AddMoneyToPP(copper, update_client);
 }
 


### PR DESCRIPTION
# Notes
- Fix possible overflows by casting properly.