### PR TITLE
[Cleanup] Remove unreachable code in Client::SendMercPersonalInfo()

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -7590,9 +7590,6 @@ void Client::SendMercPersonalInfo()
 				return;
 			}
 		}
-		Log(Logs::General, Logs::Mercenaries, "SendMercPersonalInfo Send Successful for %s.", GetName());
-
-		SendMercMerchantResponsePacket(0);
 	}
 	else
 	{


### PR DESCRIPTION
# Notes
- This cannot be reached due to prior returns.