### PR TITLE
[Cleanup] Remove extra assignment of current_endurance in Client ctor

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -310,8 +310,6 @@ Client::Client(EQStreamInterface *ieqs) : Mob(
 	HideCorpseMode = HideCorpseNone;
 	PendingGuildInvitation = false;
 
-	current_endurance = 0;
-
 	InitializeBuffSlots();
 
 	adventure_request_timer = nullptr;


### PR DESCRIPTION
# Notes
- We already assign `current_endurance` to `0`, no need to do it again.