### PR TITLE
[Cleanup] Remove unnecessary conditions in Client::Consume()

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -8360,9 +8360,6 @@ void Client::Consume(const EQ::ItemData *item, uint8 type, int16 slot, bool auto
 		return;
 
 	if (type == EQ::item::ItemTypeFood) {
-		if (increase < 0)
-			return;
-
 		m_pp.hunger_level += increase;
 
 		LogFood("Consuming food, points added to hunger_level: [{}] - current_hunger: [{}]", increase, m_pp.hunger_level);
@@ -8375,9 +8372,6 @@ void Client::Consume(const EQ::ItemData *item, uint8 type, int16 slot, bool auto
 		LogFood("Eating from slot: [{}]", (int)slot);
 
 	} else {
-		if (increase < 0)
-			return;
-
 		m_pp.thirst_level += increase;
 
 		DeleteItemInInventory(slot, 1);


### PR DESCRIPTION
# Notes
- We check `increase < 0` prior to this, so this can't ever happen.