### PR TITLE
[Telnet] Telnet encoding fix

### DIFF
--- a/common/net/tcp_connection.cpp
+++ b/common/net/tcp_connection.cpp
@@ -142,7 +142,7 @@ void EQ::Net::TCPConnection::Write(const char *data, size_t count)
 
 	WriteBaton *baton = new WriteBaton;
 	baton->connection = this;
-	baton->buffer = new char[count];;
+	baton->buffer = new char[count];
 
 	uv_write_t *write_req = new uv_write_t;
 	memset(write_req, 0, sizeof(uv_write_t));

--- a/world/clientlist.cpp
+++ b/world/clientlist.cpp
@@ -268,8 +268,8 @@ void ClientList::SendCLEList(const int16& admin, const char* to, WorldTCPConnect
 		strcpy(newline, "\r\n");
 	else
 		strcpy(newline, "^");
-	std::vector<char> out;
 
+	auto out = fmt::memory_buffer();
 	iterator.Reset();
 	while(iterator.MoreElements()) {
 		ClientListEntry* cle = iterator.GetData();
@@ -1008,7 +1008,7 @@ void ClientList::ConsoleSendWhoAll(const char* to, int16 admin, Who_All_Struct* 
 	if (whom)
 		whomlen = strlen(whom->whom);
 
-	std::vector<char> out;
+	auto out = fmt::memory_buffer();
 	fmt::format_to(std::back_inserter(out), "Players on server:");
 	if (connection->IsConsole())
 		fmt::format_to(std::back_inserter(out), "\r\n");

--- a/world/zonelist.cpp
+++ b/world/zonelist.cpp
@@ -311,7 +311,7 @@ void ZSList::SendZoneStatus(const char* to, int16 admin, WorldTCPConnection* con
 		strcpy(locked, "No");
 	}
 
-	std::vector<char> out;
+	auto out = fmt::memory_buffer();
 
 	if (connection->IsConsole()) {
 		fmt::format_to(std::back_inserter(out), "World Locked: {}\r\n", locked);


### PR DESCRIPTION
### What

Fixes an issue with the `fmt` (9.0) upgrade that causes encoding issues on output

![image](https://user-images.githubusercontent.com/3319450/229982666-485427b9-0212-4104-93cd-b302184b0902.png)

Fixed

```
> zonestatus
World Locked: No
Zoneservers online:
#1   :: D :: 127.0.0.1:53438 ::  1 :: xxx:7000 :: poair (215) :: (726505)
1 servers listed. 1 servers online.
0 zones are static zones, 1 zones are booted zones, 0 zones available.
```