### PR TITLE
[Hotfix] Resolve loading of inventory

### DIFF
--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -515,7 +515,8 @@ bool SharedDatabase::GetSharedBank(uint32 id, EQ::InventoryProfile *inv, bool is
 	}
 
 	auto results = QueryDatabase(query);
-	if (!results.Success() || !results.RowCount()) {
+	// If we have no results we still need to return true
+	if (!results.Success()) {
 		return false;
 	}
 


### PR DESCRIPTION
This resolves regression introduced in #3190, we need to return true from GetSharedBank() or the player inventory will fail to load.