### PR TITLE
[Quest API] Add GetBuffSpellIDs() to Perl/Lua

### DIFF
--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -2985,6 +2985,21 @@ void Lua_Mob::StopTimer(const char* timer_name) {
 	quest_manager.stoptimer(timer_name, self);
 }
 
+luabind::object Lua_Mob::GetBuffSpellIDs(lua_State* L) {
+	auto t = luabind::newtable(L);
+	if (d_) {
+		auto self = reinterpret_cast<NativeType*>(d_);
+		auto l = self->GetBuffSpellIDs();
+		auto i = 1;
+		for (const auto& v : l) {
+			t[i] = v;
+			i++;
+		}
+	}
+
+	return t;
+}
+
 luabind::scope lua_register_mob() {
 	return luabind::class_<Lua_Mob, Lua_Entity>("Mob")
 	.def(luabind::constructor<>())
@@ -3184,6 +3199,7 @@ luabind::scope lua_register_mob() {
 	.def("GetBucketKey", (std::string(Lua_Mob::*)(void))&Lua_Mob::GetBucketKey)
 	.def("GetBucketRemaining", (std::string(Lua_Mob::*)(std::string))&Lua_Mob::GetBucketRemaining)
 	.def("GetBuffSlotFromType", &Lua_Mob::GetBuffSlotFromType)
+	.def("GetBuffSpellIDs", &Lua_Mob::GetBuffSpellIDs)
 	.def("GetBuffStatValueBySlot", (void(Lua_Mob::*)(uint8, const char*))& Lua_Mob::GetBuffStatValueBySlot)
 	.def("GetBuffStatValueBySpell", (void(Lua_Mob::*)(int, const char*))&Lua_Mob::GetBuffStatValueBySpell)
 	.def("GetCHA", &Lua_Mob::GetCHA)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -538,6 +538,7 @@ public:
 	void SetTimerMS(const char* timer_name, int milliseconds);
 	void StopAllTimers();
 	void StopTimer(const char* timer_name);
+	luabind::object GetBuffSpellIDs(lua_State* L);
 };
 
 #endif

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -441,6 +441,7 @@ public:
 	void DoGravityEffect();
 	void DamageShield(Mob* other, bool spell_ds = false);
 	int32 RuneAbsorb(int64 damage, uint16 type);
+	std::vector<uint16> GetBuffSpellIDs();
 	bool FindBuff(uint16 spell_id);
 	uint16 FindBuffBySlot(int slot);
 	uint32 BuffCount(bool is_beneficial = true, bool is_detrimental = true);

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -2937,6 +2937,19 @@ void Perl_Mob_StopTimer(Mob* self, const char* timer_name)
 	quest_manager.stoptimer(timer_name, self);
 }
 
+perl::array Perl_Mob_GetBuffSpellIDs(Mob* self)
+{
+	perl::array l;
+
+	const auto& b = self->GetBuffSpellIDs();
+
+	for (const auto& e : b) {
+		l.push_back(e);
+	}
+
+	return l;
+}
+
 void perl_register_mob()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3117,6 +3130,7 @@ void perl_register_mob()
 	package.add("GetBucketKey", &Perl_Mob_GetBucketKey);
 	package.add("GetBucketRemaining", &Perl_Mob_GetBucketRemaining);
 	package.add("GetBuffSlotFromType", &Perl_Mob_GetBuffSlotFromType);
+	package.add("GetBuffSpellIDs", &Perl_Mob_GetBuffSpellIDs);
 	package.add("GetBuffStatValueBySpell", &Perl_Mob_GetBuffStatValueBySpell);
 	package.add("GetBuffStatValueBySlot", &Perl_Mob_GetBuffStatValueBySlot);
 	package.add("GetCHA", &Perl_Mob_GetCHA);

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4375,6 +4375,20 @@ void Corpse::CastRezz(uint16 spellid, Mob* Caster)
 	safe_delete(outapp);
 }
 
+std::vector<uint16> Mob::GetBuffSpellIDs()
+{
+	std::vector<uint16> l;
+
+	for (int i = 0; i < GetMaxTotalSlots(); i++) {
+		const auto& e = buffs[i].spellid;
+		if (IsValidSpell(e)) {
+			l.emplace_back(e);
+		}
+	}
+
+	return l;
+}
+
 bool Mob::FindBuff(uint16 spell_id)
 {
 	uint32 buff_count = GetMaxTotalSlots();


### PR DESCRIPTION
# Perl
- Add `$mob->GetBuffSpellIDs()`.

# Lua
- Add `$mob->GetBuffSpellIDs()`.

# Notes
- These methods allow operators to get a list of a mob's buff IDs without having to loop through their buffs themselves.