### PR TITLE
[Cleanup] Remove _GetMovementSpeed() from mob.h

### DIFF
--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1440,7 +1440,6 @@ public:
 protected:
 	void CommonDamage(Mob* other, int64 &damage, const uint16 spell_id, const EQ::skills::SkillType attack_skill, bool &avoidable, const int8 buffslot, const bool iBuffTic, eSpecialAttacks specal = eSpecialAttacks::None);
 	static uint16 GetProcID(uint16 spell_id, uint8 effect_index);
-	float _GetMovementSpeed(int mod) const;
 	int _GetWalkSpeed() const;
 	int _GetRunSpeed() const;
 	int _GetFearSpeed() const;


### PR DESCRIPTION
# Notes
- This is unused.