### PR TITLE
[Feature] Make ornamentations work with any augment type

### DIFF
--- a/common/item_instance.cpp
+++ b/common/item_instance.cpp
@@ -659,11 +659,11 @@ bool EQ::ItemInstance::UpdateOrnamentationInfo()
 
 			return true;
 		}
-	} else {
-		SetOrnamentIcon(0);
-		SetOrnamentHeroModel(0);
-		SetOrnamentationIDFile(0);
 	}
+
+	SetOrnamentIcon(0);
+	SetOrnamentHeroModel(0);
+	SetOrnamentationIDFile(0);
 
 	return false;
 }

--- a/common/item_instance.cpp
+++ b/common/item_instance.cpp
@@ -587,7 +587,12 @@ bool EQ::ItemInstance::IsOrnamentationAugment(EQ::ItemInstance* augment) const
 		return false;
 	}
 
-	const std::string idfile = augment->GetItem()->IDFile;
+	const auto augment_item = augment->GetItem();
+	if (!augment_item) {
+		return false;
+	}
+
+	const std::string& idfile = augment_item->IDFile;
 
 	if (
 		EQ::ValueWithin(
@@ -599,7 +604,7 @@ bool EQ::ItemInstance::IsOrnamentationAugment(EQ::ItemInstance* augment) const
 			idfile != "IT63" &&
 			idfile != "IT64"
 		) ||
-		augment->GetItem()->HerosForgeModel
+		augment_item->HerosForgeModel
 	) {
 		return true;
 	}
@@ -616,7 +621,7 @@ EQ::ItemInstance* EQ::ItemInstance::GetOrnamentationAugment() const
 	for (int i = invaug::SOCKET_BEGIN; i <= invaug::SOCKET_END; i++) {
 		const auto augment = GetAugment(i);
 		if (augment && IsOrnamentationAugment(augment)) {
-			return GetAugment(i);
+			return augment;
 		}
 	}
 
@@ -645,14 +650,17 @@ bool EQ::ItemInstance::UpdateOrnamentationInfo()
 		return false;
 	}
 
-	if (GetOrnamentationAugment()) {
-		const auto augment = GetOrnamentationAugment()->GetItem();
-		if (augment) {
-			SetOrnamentIcon(augment->Icon);
-			SetOrnamentHeroModel(augment->HerosForgeModel);
+	const auto augment = GetOrnamentationAugment();
 
-			if (strlen(augment->IDFile) > 2) {
-				SetOrnamentationIDFile(Strings::ToUnsignedInt(&augment->IDFile[2]));
+	if (augment) {
+		const auto augment_item = GetOrnamentationAugment()->GetItem();
+
+		if (augment_item) {
+			SetOrnamentIcon(augment_item->Icon);
+			SetOrnamentHeroModel(augment_item->HerosForgeModel);
+
+			if (strlen(augment_item->IDFile) > 2) {
+				SetOrnamentationIDFile(Strings::ToUnsignedInt(&augment_item->IDFile[2]));
 			} else {
 				SetOrnamentationIDFile(0);
 			}

--- a/common/item_instance.h
+++ b/common/item_instance.h
@@ -51,6 +51,11 @@ typedef enum {
 	byFlagNotSet	//apply action if the flag is NOT set
 } byFlagSetting;
 
+enum OrnamentationAugmentTypes {
+	StandardOrnamentation = 20,
+	SpecialOrnamentation = 21
+};
+
 class SharedDatabase;
 
 // ########################################
@@ -136,7 +141,8 @@ namespace EQ
 		bool IsAugmented();
 		bool ContainsAugmentByID(uint32 item_id);
 		int CountAugmentByID(uint32 item_id);
-		ItemInstance* GetOrnamentationAug(int32 ornamentationAugtype) const;
+		bool IsOrnamentationAugment(EQ::ItemInstance* augment) const;
+		ItemInstance* GetOrnamentationAugment() const;
 		bool UpdateOrnamentationInfo();
 		static bool CanTransform(const ItemData *ItemToTry, const ItemData *Container, bool AllowAll = false);
 

--- a/common/patches/rof.cpp
+++ b/common/patches/rof.cpp
@@ -5218,7 +5218,6 @@ namespace RoF
 		/**
 		 * Ornamentation
 		 */
-		int    ornamentation_augment_type = RuleI(Character, OrnamentationAugmentType);
 		uint32 ornamentation_icon         = (inst->GetOrnamentationIcon() ? inst->GetOrnamentationIcon() : 0);
 		uint32 hero_model                 = 0;
 

--- a/common/patches/rof2.cpp
+++ b/common/patches/rof2.cpp
@@ -5477,7 +5477,6 @@ namespace RoF2
 		/**
 		 * Ornamentation
 		 */
-		int    ornamentation_augment_type = RuleI(Character, OrnamentationAugmentType);
 		uint32 ornamentation_icon         = (inst->GetOrnamentationIcon() ? inst->GetOrnamentationIcon() : 0);
 		uint32 hero_model                 = 0;
 

--- a/common/patches/uf.cpp
+++ b/common/patches/uf.cpp
@@ -3851,13 +3851,14 @@ namespace UF
 			ob.write((const char*)&evotop, sizeof(UF::structs::EvolvingItem));
 		}
 
-		uint16 ornament_icon = 0;
-		const auto augment = inst->GetOrnamentationAugment();
-		if (augment) {
-			const auto item = augment->GetItem();
-			ornament_icon = item->Icon;
+		uint16     ornament_icon = 0;
+		const auto augment       = inst->GetOrnamentationAugment();
 
-			ob.write(item->IDFile, strlen(item->IDFile));
+		if (augment) {
+			const auto augment_item = augment->GetItem();
+			ornament_icon = augment_item->Icon;
+
+			ob.write(augment_item->IDFile, strlen(augment_item->IDFile));
 		}
 		else if (inst->GetOrnamentationIDFile() && inst->GetOrnamentationIcon()) {
 			ornament_icon = inst->GetOrnamentationIcon();

--- a/common/patches/uf.cpp
+++ b/common/patches/uf.cpp
@@ -3851,17 +3851,16 @@ namespace UF
 			ob.write((const char*)&evotop, sizeof(UF::structs::EvolvingItem));
 		}
 
-		//ORNAMENT IDFILE / ICON -
-		int ornamentationAugtype = RuleI(Character, OrnamentationAugmentType);
-		uint16 ornaIcon = 0;
-		if (inst->GetOrnamentationAug(ornamentationAugtype)) {
-			const EQ::ItemData *aug_weap = inst->GetOrnamentationAug(ornamentationAugtype)->GetItem();
-			ornaIcon = aug_weap->Icon;
+		uint16 ornament_icon = 0;
+		const auto augment = inst->GetOrnamentationAugment();
+		if (augment) {
+			const auto item = augment->GetItem();
+			ornament_icon = item->Icon;
 
-			ob.write(aug_weap->IDFile, strlen(aug_weap->IDFile));
+			ob.write(item->IDFile, strlen(item->IDFile));
 		}
 		else if (inst->GetOrnamentationIDFile() && inst->GetOrnamentationIcon()) {
-			ornaIcon = inst->GetOrnamentationIcon();
+			ornament_icon = inst->GetOrnamentationIcon();
 			char tmp[30]; memset(tmp, 0x0, 30); sprintf(tmp, "IT%d", inst->GetOrnamentationIDFile());
 
 			ob.write(tmp, strlen(tmp));
@@ -3870,7 +3869,7 @@ namespace UF
 
 		UF::structs::ItemSerializationHeaderFinish hdrf;
 
-		hdrf.ornamentIcon = ornaIcon;
+		hdrf.ornamentIcon = ornament_icon;
 		hdrf.unknown060 = 0; //This is Always 0.. or it breaks shit..
 		hdrf.unknown061 = 0; //possibly ornament / special ornament
 		hdrf.isCopied = 0; //Flag for item to be 'Copied'

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -136,7 +136,6 @@ RULE_BOOL(Character, EnableFoodRequirement, true, "If disabled, food is no longe
 RULE_INT(Character, BaseInstrumentSoftCap, 36, "Softcap for instrument mods, 36 commonly referred to as 3.6 as well")
 RULE_BOOL(Character, UseSpellFileSongCap, true, "When they removed the AA that increased the cap they removed the above and just use the spell field")
 RULE_INT(Character, BaseRunSpeedCap, 158, "Base Run Speed Cap, on live it's 158% which will give you a runspeed of 1.580 hard capped to 225")
-RULE_INT(Character, OrnamentationAugmentType, 20, "Ornamentation Augment Type")
 RULE_REAL(Character, EnvironmentDamageMulipliter, 1, "Multiplier for environmental damage like fall damage.")
 RULE_BOOL(Character, UnmemSpellsOnDeath, true, "Setting whether at death all memorized Spells are forgotten")
 RULE_REAL(Character, TradeskillUpAlchemy, 2.0, "Alchemy skillup rate adjustment. Lower is faster")

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -5620,7 +5620,6 @@ void Client::ProcessInspectRequest(Client *requestee, Client *requester)
 
 		const EQ::ItemData     *item                      = nullptr;
 		const EQ::ItemInstance *inst                      = nullptr;
-		int                    ornamentation_augment_type = RuleI(Character, OrnamentationAugmentType);
 
 		for (int16 L = EQ::invslot::EQUIPMENT_BEGIN; L <= EQ::invslot::EQUIPMENT_END; L++) {
 			inst = requestee->GetInv().GetItem(L);
@@ -5631,8 +5630,9 @@ void Client::ProcessInspectRequest(Client *requestee, Client *requester)
 					strcpy(insr->itemnames[L], item->Name);
 
 					const EQ::ItemData *aug_item = nullptr;
-					if (inst->GetOrnamentationAug(ornamentation_augment_type)) {
-						aug_item = inst->GetOrnamentationAug(ornamentation_augment_type)->GetItem();
+					const auto augment = inst->GetOrnamentationAugment();
+					if (augment) {
+						aug_item = augment->GetItem();
 					}
 
 					if (aug_item) {

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -5629,14 +5629,15 @@ void Client::ProcessInspectRequest(Client *requestee, Client *requester)
 				if (item) {
 					strcpy(insr->itemnames[L], item->Name);
 
-					const EQ::ItemData *aug_item = nullptr;
-					const auto augment = inst->GetOrnamentationAugment();
+					const EQ::ItemData *augment_item = nullptr;
+					const auto         augment       = inst->GetOrnamentationAugment();
+
 					if (augment) {
-						aug_item = augment->GetItem();
+						augment_item = augment->GetItem();
 					}
 
-					if (aug_item) {
-						insr->itemicons[L] = aug_item->Icon;
+					if (augment_item) {
+						insr->itemicons[L] = augment_item->Icon;
 					} else if (inst->GetOrnamentationIcon()) {
 						insr->itemicons[L] = inst->GetOrnamentationIcon();
 					} else {

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -8633,8 +8633,7 @@ void Client::Handle_OP_InspectAnswer(const EQApplicationPacket *app)
 			if (inst) {
 				const auto augment = inst->GetOrnamentationAugment();
 				if (augment) {
-					const auto aug_item = augment->GetItem();
-					insr->itemicons[L] = aug_item->Icon;
+					insr->itemicons[L] = augment->GetItem()->Icon;
 				} else if (inst->GetOrnamentationIcon()) {
 					insr->itemicons[L] = inst->GetOrnamentationIcon();
 				}

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -8613,47 +8613,51 @@ void Client::Handle_OP_Illusion(const EQApplicationPacket *app)
 
 void Client::Handle_OP_InspectAnswer(const EQApplicationPacket *app)
 {
-
 	if (app->size != sizeof(InspectResponse_Struct)) {
 		LogError("Wrong size: OP_InspectAnswer, size=[{}], expected [{}]", app->size, sizeof(InspectResponse_Struct));
 		return;
 	}
 
 	//Fills the app sent from client.
-	EQApplicationPacket* outapp = app->Copy();
-	InspectResponse_Struct* insr = (InspectResponse_Struct*)outapp->pBuffer;
-	Mob* tmp = entity_list.GetMob(insr->TargetID);
-	const EQ::ItemData* item = nullptr;
+	auto               outapp = app->Copy();
+	auto               insr   = (InspectResponse_Struct *) outapp->pBuffer;
+	auto               tmp    = entity_list.GetMob(insr->TargetID);
+	const EQ::ItemData *item  = nullptr;
 
-	int ornamentationAugtype = RuleI(Character, OrnamentationAugmentType);
-	for (int16 L = EQ::invslot::EQUIPMENT_BEGIN; L <= EQ::invslot::EQUIPMENT_END; L++) {
-		const EQ::ItemInstance* inst = GetInv().GetItem(L);
+	for (int16 L                    = EQ::invslot::EQUIPMENT_BEGIN; L <= EQ::invslot::EQUIPMENT_END; L++) {
+		const auto inst = GetInv().GetItem(L);
 		item = inst ? inst->GetItem() : nullptr;
 
 		if (item) {
 			strcpy(insr->itemnames[L], item->Name);
-			if (inst && inst->GetOrnamentationAug(ornamentationAugtype)) {
-				const EQ::ItemData *aug_item = inst->GetOrnamentationAug(ornamentationAugtype)->GetItem();
-				insr->itemicons[L] = aug_item->Icon;
-			}
-			else if (inst->GetOrnamentationIcon()) {
-				insr->itemicons[L] = inst->GetOrnamentationIcon();
-			}
-			else {
+			if (inst) {
+				const auto augment = inst->GetOrnamentationAugment();
+				if (augment) {
+					const auto aug_item = augment->GetItem();
+					insr->itemicons[L] = aug_item->Icon;
+				} else if (inst->GetOrnamentationIcon()) {
+					insr->itemicons[L] = inst->GetOrnamentationIcon();
+				}
+			} else {
 				insr->itemicons[L] = item->Icon;
 			}
+		} else {
+			insr->itemicons[L] = 0xFFFFFFFF;
 		}
-		else { insr->itemicons[L] = 0xFFFFFFFF; }
 	}
 
-	InspectMessage_Struct* newmessage = (InspectMessage_Struct*)insr->text;
-	InspectMessage_Struct& playermessage = GetInspectMessage();
-	memcpy(&playermessage, newmessage, sizeof(InspectMessage_Struct));
-	database.SaveCharacterInspectMessage(CharacterID(), &playermessage);
+	auto message         = (InspectMessage_Struct *) insr->text;
+	auto inspect_message = GetInspectMessage();
 
-	if (tmp != 0 && tmp->IsClient()) { tmp->CastToClient()->QueuePacket(outapp); } // Send answer to requester
+	memcpy(&inspect_message, message, sizeof(InspectMessage_Struct));
+	database.SaveCharacterInspectMessage(CharacterID(), &inspect_message);
 
-	return;
+	if (
+		tmp &&
+		tmp->IsClient()
+	) {
+		tmp->CastToClient()->QueuePacket(outapp);
+	} // Send answer to requester
 }
 
 void Client::Handle_OP_InspectMessageUpdate(const EQApplicationPacket *app)

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -8632,6 +8632,7 @@ void Client::Handle_OP_InspectAnswer(const EQApplicationPacket *app)
 			strcpy(insr->itemnames[L], item->Name);
 			if (inst) {
 				const auto augment = inst->GetOrnamentationAugment();
+
 				if (augment) {
 					insr->itemicons[L] = augment->GetItem()->Icon;
 				} else if (inst->GetOrnamentationIcon()) {

--- a/zone/mob_appearance.cpp
+++ b/zone/mob_appearance.cpp
@@ -231,8 +231,10 @@ int32 Mob::GetEquipmentMaterial(uint8 material_slot) const
 				}
 
 				const auto* inst = CastToClient()->m_inv[inventory_slot];
+
 				if (inst) {
 					const auto augment = inst->GetOrnamentationAugment();
+
 					if (augment) {
 						item = augment->GetItem();
 						if (item && strlen(item->IDFile) > 2 && Strings::IsNumber(&item->IDFile[2])) {
@@ -318,6 +320,7 @@ int32 Mob::GetHerosForgeModel(uint8 material_slot) const
 				const auto inst = CastToClient()->m_inv[slot];
 				if (inst) {
 					const auto augment = inst->GetOrnamentationAugment();
+
 					if (augment) {
 						item       = augment->GetItem();
 						hero_model = item->HerosForgeModel;


### PR DESCRIPTION
# Notes
- On Live there are augments that are not type 20/21 and are ornamentations.
- We also only allow a singular augment type to be ornamentation augment types, this will allow you to use any augment type as an ornamentation if it has a proper Hero's Forge model or a non-IT63/non-IT64 idfile.
- Remove `Character:OrnamentationAugmentType` rule as it's no longer necessary.
- This will not break any servers using the previous rule functionality as it will check the augment itself for things that make it a valid ornamentation.