### PR TITLE
[Cleanup] Remove ExportVarComplex() from embparser.cpp/embparser.h

### DIFF
--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -835,25 +835,6 @@ void PerlembParser::ExportVar(const char *pkgprefix, const char *varname, float 
 	}
 }
 
-void PerlembParser::ExportVarComplex(const char *pkgprefix, const char *varname, const char *value)
-{
-
-	if (!perl) {
-		return;
-	}
-	try {
-		perl->eval(std::string("$").append(pkgprefix).append("::").append(varname).append("=").append(value).append(";").c_str());
-	}
-	catch (std::string e) {
-		AddError(
-			fmt::format(
-				"Error exporting Perl variable [{}]",
-				e
-			)
-		);
-	}
-}
-
 void PerlembParser::ExportVar(const char *pkgprefix, const char *varname, const char *value)
 {
 	if (!perl) {

--- a/zone/embparser.h
+++ b/zone/embparser.h
@@ -145,7 +145,6 @@ private:
 	void ExportVar(const char *pkgprefix, const char *varname, uint32 value);
 	void ExportVar(const char *pkgprefix, const char *varname, float value);
 	void ExportVar(const char* pkgprefix, const char* varname, const char* classname, void* value);
-	void ExportVarComplex(const char *pkgprefix, const char *varname, const char *value);
 
 	int EventCommon(
 		QuestEventID event,


### PR DESCRIPTION
# Notes
- This is unused.