### PR TITLE
[Cleanup] Remove GetQGlobal() from qglobals.cpp/qglobals.h

### DIFF
--- a/zone/qglobals.cpp
+++ b/zone/qglobals.cpp
@@ -102,22 +102,6 @@ void QGlobalCache::GetQGlobals(std::list<QGlobal> &globals, NPC *n, Client *c, Z
 	}
 }
 
-bool QGlobalCache::GetQGlobal(QGlobal &g, std::string name, NPC *n, Client *c, Zone *z) {
-	std::list<QGlobal> globals;
-	QGlobalCache::GetQGlobals(globals, n, c, z);
-
-	auto iter = globals.begin();
-	while(iter != globals.end()) {
-		if(iter->name.compare(name) == 0) {
-			g = (*iter);
-			return true;
-		}
-		++iter;
-	}
-
-	return false;
-}
-
 void QGlobalCache::PurgeExpiredGlobals()
 {
 	if(!qGlobalBucket.size())

--- a/zone/qglobals.h
+++ b/zone/qglobals.h
@@ -31,7 +31,6 @@ public:
 	//assumes cacheA is already a valid or empty list and doesn't check for valid items.
 	static void Combine(std::list<QGlobal> &cacheA, std::list<QGlobal> cacheB, uint32 npcID, uint32 charID, uint32 zoneID);
 	static void GetQGlobals(std::list<QGlobal> &globals, NPC *n, Client *c, Zone *z);
-	static bool GetQGlobal(QGlobal &g, std::string name, NPC *n, Client *c, Zone *z);
 
 	void PurgeExpiredGlobals();
 	void LoadByNPCID(uint32 npcID); //npc


### PR DESCRIPTION
# Notes
- This is unused.