### PR TITLE
[Cleanup] Remove item_timers from questmgr.cpp/questmgr.h

### DIFF
--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -74,7 +74,6 @@ QuestManager quest_manager;
 
 QuestManager::QuestManager() {
 	HaveProximitySays = false;
-	item_timers = 0;
 }
 
 QuestManager::~QuestManager() {
@@ -3609,14 +3608,14 @@ void QuestManager::UpdateZoneHeader(std::string type, std::string value) {
 EQ::ItemInstance *QuestManager::CreateItem(uint32 item_id, int16 charges, uint32 augment_one, uint32 augment_two, uint32 augment_three, uint32 augment_four, uint32 augment_five, uint32 augment_six, bool attuned) const {
 	if (database.GetItem(item_id)) {
 		return database.CreateItem(
-			item_id, 
-			charges, 
-			augment_one, 
-			augment_two, 
-			augment_three, 
-			augment_four, 
-			augment_five, 
-			augment_six, 
+			item_id,
+			charges,
+			augment_one,
+			augment_two,
+			augment_three,
+			augment_four,
+			augment_five,
+			augment_six,
 			attuned
 		);
 	}

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -391,7 +391,6 @@ private:
 	std::list<QuestTimer>	QTimerList;
 	std::list<SignalTimer>	STimerList;
 	std::list<PausedTimer>	PTimerList;
-
 };
 
 extern QuestManager quest_manager;

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -391,7 +391,6 @@ private:
 	std::list<QuestTimer>	QTimerList;
 	std::list<SignalTimer>	STimerList;
 	std::list<PausedTimer>	PTimerList;
-	size_t item_timers;
 
 };
 


### PR DESCRIPTION
# Notes
- This is unused.