### PR TITLE
[Quest API] Fix LDoN Methods in Perl/Lua

### DIFF
--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -849,9 +849,19 @@ void Perl__addldonwin(uint32 theme_id)
 	quest_manager.addldonwin(theme_id);
 }
 
+void Perl__removeldonwin(uint32 theme_id)
+{
+	quest_manager.removeldonwin(theme_id);
+}
+
 void Perl__addldonloss(uint32 theme_id)
 {
 	quest_manager.addldonloss(theme_id);
+}
+
+void Perl__removeldonloss(uint32 theme_id)
+{
+	quest_manager.removeldonloss(theme_id);
 }
 
 void Perl__setnexthpevent(int at_mob_percentage)
@@ -4632,6 +4642,8 @@ void perl_register_quest()
 	package.add("remove_expedition_lockout_by_char_id", &Perl__remove_expedition_lockout_by_char_id);
 	package.add("removeitem", (void(*)(uint32_t))&Perl__removeitem);
 	package.add("removeitem", (void(*)(uint32_t, int))&Perl__removeitem);
+	package.add("removeldonloss", &Perl__removeldonloss);
+	package.add("removeldonwin", &Perl__removeldonwin);
 	package.add("removetitle", &Perl__removetitle);
 	package.add("rename", &Perl__rename);
 	package.add("repopzone", &Perl__repopzone);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -1987,7 +1987,7 @@ void lua_remove_ldon_loss(uint32 theme_id) {
 }
 
 void lua_remove_ldon_win(uint32 theme_id) {
-	quest_manager.addldonwin(theme_id);
+	quest_manager.removeldonwin(theme_id);
 }
 
 std::string lua_get_clean_npc_name_by_id(uint32 npc_id) {

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -1763,36 +1763,42 @@ void QuestManager::resume() {
 	owner->CastToNPC()->ResumeWandering();
 }
 
-void QuestManager::addldonpoints(uint32 theme_id, int points) {
+void QuestManager::addldonpoints(uint32 theme_id, int points)
+{
 	QuestManagerCurrentQuestVars();
-	if(initiator)
+	if (initiator) {
 		initiator->UpdateLDoNPoints(theme_id, points);
+	}
 }
 
-void QuestManager::addldonloss(uint32 theme_id) {
+void QuestManager::addldonloss(uint32 theme_id)
+{
 	QuestManagerCurrentQuestVars();
-	if(initiator) {
+	if (initiator) {
 		initiator->UpdateLDoNWinLoss(theme_id);
 	}
 }
 
-void QuestManager::addldonwin(uint32 theme_id) {
+void QuestManager::addldonwin(uint32 theme_id)
+{
 	QuestManagerCurrentQuestVars();
-	if(initiator) {
+	if (initiator) {
 		initiator->UpdateLDoNWinLoss(theme_id, true);
 	}
 }
 
-void QuestManager::removeldonloss(uint32 theme_id) {
+void QuestManager::removeldonloss(uint32 theme_id)
+{
 	QuestManagerCurrentQuestVars();
-	if(initiator) {
+	if (initiator) {
 		initiator->UpdateLDoNWinLoss(theme_id, false, true);
 	}
 }
 
-void QuestManager::removeldonwin(uint32 theme_id) {
+void QuestManager::removeldonwin(uint32 theme_id)
+{
 	QuestManagerCurrentQuestVars();
-	if(initiator) {
+	if (initiator) {
 		initiator->UpdateLDoNWinLoss(theme_id, true, true);
 	}
 }
@@ -3609,14 +3615,14 @@ void QuestManager::UpdateZoneHeader(std::string type, std::string value) {
 EQ::ItemInstance *QuestManager::CreateItem(uint32 item_id, int16 charges, uint32 augment_one, uint32 augment_two, uint32 augment_three, uint32 augment_four, uint32 augment_five, uint32 augment_six, bool attuned) const {
 	if (database.GetItem(item_id)) {
 		return database.CreateItem(
-			item_id, 
-			charges, 
-			augment_one, 
-			augment_two, 
-			augment_three, 
-			augment_four, 
-			augment_five, 
-			augment_six, 
+			item_id,
+			charges,
+			augment_one,
+			augment_two,
+			augment_three,
+			augment_four,
+			augment_five,
+			augment_six,
 			attuned
 		);
 	}


### PR DESCRIPTION
# Perl
- Add `quest::removeldonloss(theme_id)`.
- Add `quest::removeldonwin(theme_id)`.

# Lua
- Fix `eq.remove_ldon_win(theme_id)` as it was using `quest_manager.addldonwin(theme_id)` instead of `quest_manager.removeldonwin(theme_id)`.