### PR TITLE
[Cleanup] Cleanup zone/zoning.cpp

### DIFF
--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -72,18 +72,13 @@ void Client::Handle_OP_ZoneChange(const EQApplicationPacket *app) {
 				target_zone_id = zone->GetZoneID();
 				break;
 			case GMSummon:
+			case ZoneSolicited: //we told the client to zone somewhere, so we know where they are going.
 				target_zone_id = zonesummon_id;
 				break;
 			case GateToBindPoint:
-				target_zone_id = m_pp.binds[0].zone_id;
-				target_instance_id = m_pp.binds[0].instance_id;
-				break;
 			case ZoneToBindPoint:
 				target_zone_id = m_pp.binds[0].zone_id;
 				target_instance_id = m_pp.binds[0].instance_id;
-				break;
-			case ZoneSolicited: //we told the client to zone somewhere, so we know where they are going.
-				target_zone_id = zonesummon_id;
 				break;
 			case ZoneUnsolicited: //client came up with this on its own.
 				zone_point = zone->GetClosestZonePointWithoutZone(GetX(), GetY(), GetZ(), this, ZONEPOINT_NOZONE_RANGE);
@@ -645,7 +640,7 @@ void Client::ZonePC(uint32 zoneID, uint32 instance_id, float x, float y, float z
 
 	auto zd = GetZoneVersionWithFallback(zoneID, zone->GetInstanceVersion());
 	if (zd) {
-		pZoneName = strcpy(new char[strlen(zd->long_name.c_str()) + 1], zd->long_name.c_str());
+		pZoneName = strcpy(new char[zd->long_name.length() + 1], zd->long_name.c_str());
 	}
 
 	LogInfo(
@@ -791,8 +786,7 @@ void Client::ZonePC(uint32 zoneID, uint32 instance_id, float x, float y, float z
 			FastQueuePacket(&outapp);
 		}
 		else if(zm == EvacToSafeCoords) {
-			auto outapp =
-			    new EQApplicationPacket(OP_RequestClientZoneChange, sizeof(RequestClientZoneChange_Struct));
+			auto outapp = new EQApplicationPacket(OP_RequestClientZoneChange, sizeof(RequestClientZoneChange_Struct));
 			RequestClientZoneChange_Struct* gmg = (RequestClientZoneChange_Struct*) outapp->pBuffer;
 
 			// if we are in the same zone we want to evac to, client will not send OP_ZoneChange back to do an actual
@@ -803,12 +797,11 @@ void Client::ZonePC(uint32 zoneID, uint32 instance_id, float x, float y, float z
 			// 76 is orignial Plane of Hate
 			// WildcardX 27 January 2008. Tested this for 6.2 and Titanium clients.
 
-			if(GetZoneID() == 1)
+			if (GetZoneID() == 1) {
 				gmg->zone_id = 2;
-			else if(GetZoneID() == 2)
+			} else {
 				gmg->zone_id = 1;
-			else
-				gmg->zone_id = 1;
+			}
 
 			gmg->x = x;
 			gmg->y = y;


### PR DESCRIPTION
# Notes
- Duplicate outcome cases in `Client::Handle_OP_ZoneChange`.
- Use `.length()` over `strlen` in array defintition.
- Remove unnecessary `else if` in `Client::ZonePC`