### PR TITLE
[Cleanup] Remove unused ctor and use default dtor in xtargetautohaters.h 

### DIFF
--- a/zone/xtargetautohaters.h
+++ b/zone/xtargetautohaters.h
@@ -15,8 +15,7 @@ struct HatersCount {
 };
 public:
 	XTargetAutoHaters() : m_client(nullptr), m_group(nullptr), m_raid(nullptr) {}
-	XTargetAutoHaters(Client *co, Group *go, Raid *ro) : m_client(co), m_group(go), m_raid(ro) {}
-	~XTargetAutoHaters() {}
+	~XTargetAutoHaters() = default;
 
 	void merge(XTargetAutoHaters &other);
 	void demerge(XTargetAutoHaters &other);

--- a/zone/zone_event_scheduler.cpp
+++ b/zone/zone_event_scheduler.cpp
@@ -108,7 +108,7 @@ void ZoneEventScheduler::Process(Zone *zone, WorldContentService *content_servic
 				}
 
 				if (e.event_type == ServerEvents::EVENT_TYPE_CONTENT_FLAG_CHANGE) {
-					auto flag_name = x;
+					auto flag_name = e.event_data;
 					if (!flag_name.empty()) {
 						LogScheduler(
 							"Activating Event [{}] scheduled content flag change, setting flag [{}] to enabled",

--- a/zone/zone_event_scheduler.cpp
+++ b/zone/zone_event_scheduler.cpp
@@ -108,7 +108,7 @@ void ZoneEventScheduler::Process(Zone *zone, WorldContentService *content_servic
 				}
 
 				if (e.event_type == ServerEvents::EVENT_TYPE_CONTENT_FLAG_CHANGE) {
-					auto flag_name = e.event_data;
+					auto flag_name = x;
 					if (!flag_name.empty()) {
 						LogScheduler(
 							"Activating Event [{}] scheduled content flag change, setting flag [{}] to enabled",


### PR DESCRIPTION
# Notes
- Utilize default dtor.
- Remove unused ctor.