### PR TITLE
[Cleanup] Cleanup tradeskills.cpp

### DIFF
--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -871,7 +871,7 @@ void Client::SendTradeskillSearchResults(
 			!row[3] ||
 			!row[4] ||
 			!row[5]
-			) {
+		) {
 			continue;
 		}
 

--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -253,7 +253,7 @@ void Object::HandleCombine(Client* user, const NewCombine_Struct* in_combine, Ob
 		return;
 	}
 
-	if !in_combine) {
+	if (!in_combine) {
 		LogError("NewCombine_Struct not set in Object::HandleCombine");
 		auto outapp = new EQApplicationPacket(OP_TradeSkillCombine, 0);
 		user->QueuePacket(outapp);


### PR DESCRIPTION
# Notes
- Possible nullptrs in `Object::HandleCombine`.
- `spec->tradeskill != 75` is always true.
- `ei_is_valid` is always true.
- `name` is the same as a member variable, use `r_name` instead.
- `(200 - current_raw_skill) / 2` is implicitly cast, set variables to be floats and explicitly cast.