### PR TITLE
[Crash] Add additional raid integrity checks on Bot Spawn.

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -422,12 +422,6 @@ Bot::Bot(uint32 botID, uint32 botOwnerCharacterID, uint32 botSpellsID, double to
 	}
 
 	cur_end = max_end;
-
-	// Safety Check to confirm we have a valid raid
-	if (HasRaid() && !GetRaid()->IsRaidMember(GetBotOwner()->CastToClient())) {
-		Bot::RemoveBotFromRaid(this);
-	}
-
 }
 
 Bot::~Bot() {
@@ -3307,11 +3301,16 @@ bool Bot::Spawn(Client* botCharacterOwner) {
 		}
 
 		if (auto raid = entity_list.GetRaidByBotName(GetName())) {
-			raid->VerifyRaid();
-			SetRaidGrouped(true);
+			// Safety Check to confirm we have a valid raid
+			if (raid->IsRaidMember(GetBotOwner()->CastToClient())) {
+				Bot::RemoveBotFromRaid(this);
+			} else {
+				raid->LearnMembers();
+				SetRaidGrouped(true);
+			}
 		}
 		else if (auto group = entity_list.GetGroupByMobName(GetName())) {
-			group->VerifyGroup();
+			group->LearnMembers();
 			SetGrouped(true);
 		}
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -6999,7 +6999,7 @@ void Client::Handle_OP_GroupDisband(const EQApplicationPacket *app)
 		//we have a raid.. see if we're in a raid group
 		uint32 grp = raid->GetGroup(memberToDisband->GetName());
 		bool wasGrpLdr = raid->members[raid->GetPlayerIndex(memberToDisband->GetName())].is_group_leader;
-		if (grp < 12) {
+		if (grp < MAX_RAID_GROUPS) {
 			if (wasGrpLdr) {
 				raid->SetGroupLeader(memberToDisband->GetName(), false);
 				for (int x = 0; x < MAX_RAID_MEMBERS; x++) {

--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -1148,8 +1148,8 @@ void Raid::SendRaidAddAll(const char *who)
 			auto ram = (RaidAddMember_Struct*)outapp->pBuffer;
 			ram->raidGen.action = raidAdd;
 			ram->raidGen.parameter = m.group_number;
-			strn0cpy(ram->raidGen.leader_name, m.member_name, 64);
-			strn0cpy(ram->raidGen.player_name, m.member_name, 64);
+			strn0cpy(ram->raidGen.leader_name, m.member_name, sizeof(ram->raidGen.leader_name));
+			strn0cpy(ram->raidGen.player_name, m.member_name, sizeof(ram->raidGen.player_name));
 			ram->isGroupLeader = m.is_group_leader;
 			ram->_class = m._class;
 			ram->level = m.level;
@@ -1371,21 +1371,21 @@ void Raid::SendGroupUpdate(Client *to)
 	for (const auto& m : members) {
 		if (m.group_number == grp && strlen(m.member_name) > 0) {
 			if (m.is_group_leader) {
-				strn0cpy(gu->leadersname, m.member_name, 64);
+				strn0cpy(gu->leadersname, m.member_name, sizeof(gu->leadersname));
 				if (strcmp(to->GetName(), m.member_name) != 0) {
-					strn0cpy(gu->membername[i], m.member_name, 64);
+					strn0cpy(gu->membername[i], m.member_name, sizeof(gu->membername[i]));
 					++i;
 				}
 			}
 			else if (strcmp(to->GetName(), m.member_name) != 0) {
-				strn0cpy(gu->membername[i], m.member_name, 64);
+				strn0cpy(gu->membername[i], m.member_name, sizeof(gu->membername[i]));
 				++i;
 			}
 		}
 	}
 
 	if (strlen(gu->leadersname) < 1) {
-		strn0cpy(gu->leadersname, to->GetName(), 64);
+		strn0cpy(gu->leadersname, to->GetName(), sizeof(gu->leadersname));
 	}
 
 	strn0cpy(gu->yourname, to->GetName(), 64);

--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -1361,27 +1361,25 @@ void Raid::SendGroupUpdate(Client *to)
 	auto outapp = new EQApplicationPacket(OP_GroupUpdate, sizeof(GroupUpdate2_Struct));
 	auto gu = (GroupUpdate2_Struct*)outapp->pBuffer;
 	gu->action = groupActUpdate;
-	int i = 0;
 	uint32 grp = GetGroup(to->GetName());
 	if (grp >= MAX_RAID_GROUPS) {
 		safe_delete(outapp);
 		return;
 	}
 
+	int i = 0;
 	for (const auto& m : members) {
 		if (m.group_number == grp && strlen(m.member_name) > 0) {
 			if (m.is_group_leader) {
 				strn0cpy(gu->leadersname, m.member_name, 64);
 				if (strcmp(to->GetName(), m.member_name) != 0) {
 					strn0cpy(gu->membername[i], m.member_name, 64);
-					i++;
+					++i;
 				}
 			}
-			else {
-				if (strcmp(to->GetName(), m.member_name) != 0) {
-					strn0cpy(gu->membername[i], m.member_name, 64);
-					i++;
-				}
+			else if (strcmp(to->GetName(), m.member_name) != 0) {
+				strn0cpy(gu->membername[i], m.member_name, 64);
+				++i;
 			}
 		}
 	}
@@ -1404,7 +1402,7 @@ void Raid::GroupUpdate(uint32 gid, bool initial)
 	}
 
 	for (const auto& m : members) {
-		if (strlen(m.member_name) > 0 && m.group_number == gid && m.member) {
+		if (m.member && m.group_number == gid && strlen(m.member_name) > 0) {
 			SendGroupUpdate(m.member);
 			SendGroupLeadershipAA(m.member, gid);
 		}

--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -1126,8 +1126,8 @@ void Raid::SendRaidAdd(const char *who, Client *to)
 			auto ram = (RaidAddMember_Struct*)outapp->pBuffer;
 			ram->raidGen.action = raidAdd;
 			ram->raidGen.parameter = m.group_number;
-			strn0cpy(ram->raidGen.leader_name, m.member_name, 64);
-			strn0cpy(ram->raidGen.player_name, m.member_name, 64);
+			strn0cpy(ram->raidGen.leader_name, m.member_name, sizeof(ram->raidGen.leader_name));
+			strn0cpy(ram->raidGen.player_name, m.member_name, sizeof(ram->raidGen.player_name));
 			ram->_class = m._class;
 			ram->level = m.level;
 			ram->isGroupLeader = m.is_group_leader;

--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -1148,8 +1148,8 @@ void Raid::SendRaidAddAll(const char *who)
 			auto ram = (RaidAddMember_Struct*)outapp->pBuffer;
 			ram->raidGen.action = raidAdd;
 			ram->raidGen.parameter = m.group_number;
-			strcpy(ram->raidGen.leader_name, m.member_name);
-			strcpy(ram->raidGen.player_name, m.member_name);
+			strn0cpy(ram->raidGen.leader_name, m.member_name, 64);
+			strn0cpy(ram->raidGen.player_name, m.member_name, 64);
 			ram->isGroupLeader = m.is_group_leader;
 			ram->_class = m._class;
 			ram->level = m.level;


### PR DESCRIPTION
This PR adds an additional integrity check when we spawn Bots to ensure we don't have an invalid Raid state.