### PR TITLE
[Crash] Fix crash with uninitialized item instance, and Bot timeout

### DIFF
--- a/common/item_instance.cpp
+++ b/common/item_instance.cpp
@@ -57,51 +57,29 @@ static inline int32 GetNextItemInstSerialNumber() {
 // class EQ::ItemInstance
 //
 EQ::ItemInstance::ItemInstance(const ItemData* item, int16 charges) {
-	m_use_type = ItemInstNormal;
 
 	if (item) {
 		m_item = new ItemData(*item);
 	}
 
-	m_charges      = charges;
-	m_price        = 0;
-	m_attuned      = false;
-	m_merchantslot = 0;
+	m_charges = charges;
 
 	if (m_item && m_item->IsClassCommon()) {
 		m_color = m_item->Color;
-	} else {
-		m_color = 0;
 	}
 
-	m_merchantcount = 1;
 	m_SerialNumber  = GetNextItemInstSerialNumber();
-
-	m_exp                 = 0;
-	m_evolveLvl           = 0;
-	m_activated           = false;
-	m_scaledItem          = nullptr;
-	m_evolveInfo          = nullptr;
-	m_scaling             = false;
-	m_ornamenticon        = 0;
-	m_ornamentidfile      = 0;
-	m_ornament_hero_model = 0;
-	m_recast_timestamp    = 0;
-	m_new_id_file         = 0;
 }
 
 EQ::ItemInstance::ItemInstance(SharedDatabase *db, uint32 item_id, int16 charges) {
-	m_use_type = ItemInstNormal;
+
 	m_item     = db->GetItem(item_id);
 
 	if (m_item) {
 		m_item = new ItemData(*m_item);
 	}
 
-	m_charges      = charges;
-	m_price        = 0;
-	m_merchantslot = 0;
-	m_attuned      = false;
+	m_charges = charges;
 
 	if (m_item && m_item->IsClassCommon()) {
 		m_color = m_item->Color;
@@ -109,42 +87,11 @@ EQ::ItemInstance::ItemInstance(SharedDatabase *db, uint32 item_id, int16 charges
 		m_color = 0;
 	}
 
-	m_merchantcount = 1;
 	m_SerialNumber  = GetNextItemInstSerialNumber();
-
-	m_exp                 = 0;
-	m_evolveLvl           = 0;
-	m_activated           = false;
-	m_scaledItem          = nullptr;
-	m_evolveInfo          = nullptr;
-	m_scaling             = false;
-	m_ornamenticon        = 0;
-	m_ornamentidfile      = 0;
-	m_ornament_hero_model = 0;
-	m_recast_timestamp    = 0;
-	m_new_id_file         = 0;
 }
 
 EQ::ItemInstance::ItemInstance(ItemInstTypes use_type) {
 	m_use_type     = use_type;
-	m_item         = nullptr;
-	m_charges      = 0;
-	m_price        = 0;
-	m_attuned      = false;
-	m_merchantslot = 0;
-	m_color        = 0;
-
-	m_exp                 = 0;
-	m_evolveLvl           = 0;
-	m_activated           = false;
-	m_scaledItem          = nullptr;
-	m_evolveInfo          = nullptr;
-	m_scaling             = false;
-	m_ornamenticon        = 0;
-	m_ornamentidfile      = 0;
-	m_ornament_hero_model = 0;
-	m_recast_timestamp    = 0;
-	m_new_id_file         = 0;
 }
 
 // Make a copy of an EQ::ItemInstance object

--- a/common/item_instance.h
+++ b/common/item_instance.h
@@ -304,28 +304,28 @@ namespace EQ
 
 		void _PutItem(uint8 index, ItemInstance* inst) { m_contents[index] = inst; }
 
-		ItemInstTypes		m_use_type {};	// Usage type for item
-		const ItemData*		m_item {};		// Ptr to item data
-		int16				m_charges {};	// # of charges for chargeable items
-		uint32				m_price {};	// Bazaar /trader price
-		uint32				m_color {};
-		uint32				m_merchantslot {};
-		int16				m_currentslot {};
-		bool				m_attuned {};
-		int32				m_merchantcount {};		//number avaliable on the merchant, -1=unlimited
-		int32				m_SerialNumber {};	// Unique identifier for this instance of an item. Needed for Bazaar.
-		uint32				m_exp {};
-		int8				m_evolveLvl {};
-		bool				m_activated {};
-		ItemData*			m_scaledItem {};
-		::EvolveInfo*		m_evolveInfo {};
-		bool				m_scaling {};
-		uint32				m_ornamenticon {};
-		uint32				m_ornamentidfile {};
-		uint32				m_new_id_file {};
-		uint32				m_ornament_hero_model {};
-		uint32				m_recast_timestamp {};
-		int                 m_task_delivered_count {};
+		ItemInstTypes		m_use_type {ItemInstNormal};	// Usage type for item
+		const ItemData*		m_item {nullptr};		// Ptr to item data
+		int16				m_charges {0};	// # of charges for chargeable items
+		uint32				m_price {0};	// Bazaar /trader price
+		uint32				m_color {0};
+		uint32				m_merchantslot {0};
+		int16				m_currentslot {0};
+		bool				m_attuned {false};
+		int32				m_merchantcount {1}; //number avaliable on the merchant, -1=unlimited
+		int32				m_SerialNumber {0};	// Unique identifier for this instance of an item. Needed for Bazaar.
+		uint32				m_exp {0};
+		int8				m_evolveLvl {0};
+		bool				m_activated {false};
+		ItemData*			m_scaledItem {nullptr};
+		::EvolveInfo*		m_evolveInfo {nullptr};
+		bool				m_scaling {false};
+		uint32				m_ornamenticon {0};
+		uint32				m_ornamentidfile {0};
+		uint32				m_new_id_file {0};
+		uint32				m_ornament_hero_model {0};
+		uint32				m_recast_timestamp {0};
+		int                 m_task_delivered_count {0};
 
 		// Items inside of this item (augs or contents) {};
 		std::map<uint8, ItemInstance*>		m_contents {}; // Zero-based index: min=0, max=9

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -3002,24 +3002,23 @@ void Mob::AddToHateList(Mob* other, int64 hate /*= 0*/, int64 damage /*= 0*/, bo
 
 	// if other is a bot, add the bots client to the hate list
 	if (RuleB(Bots, Enabled)) {
-		while (other->IsBot()) {
-
+		 if (other->IsBot()) {
 			auto other_ = other->CastToBot();
+
 			if (!other_ || !other_->GetBotOwner()) {
-				break;
+				return;
 			}
 
 			auto owner_ = other_->GetBotOwner()->CastToClient();
 			if (!owner_ || owner_->IsDead() ||
 				!owner_->InZone()) { // added isdead and inzone checks to avoid issues in AddAutoXTarget(...) below
-				break;
+				return;
 			}
 
 			if (owner_->GetFeigned()) {
 				AddFeignMemory(owner_);
 			}
 			else if (!hate_list.IsEntOnHateList(owner_)) {
-
 				hate_list.AddEntToHateList(owner_, 0, 0, false, true);
 				owner_->AddAutoXTarget(this); // this was being called on dead/out-of-zone clients
 			}


### PR DESCRIPTION
This PR fixes a crash where an uninitialized item instance is called (this forces a nullptr on initialization), this also fixes a "crash" where the zone would get stuck in a while loop.

I believe both of these are regression issues, however the while loop has been in place for a very significant time (years) it's likely that this code was never actually being hit before.

http://spire.akkadius.com/dev/release/22.9.1-dev?id=3186