### PR TITLE
[UCS/BugFix] Fix crash when Removing empty password protected channel.

### DIFF
--- a/ucs/chatchannel.cpp
+++ b/ucs/chatchannel.cpp
@@ -701,11 +701,11 @@ void ChatChannelList::Process() {
 			LogDebug("Empty temporary password protected channel [{}] being destroyed",
 				CurrentChannel->GetName().c_str());
 
-			RemoveChannel(CurrentChannel);
+			iterator.RemoveCurrent();
 		}
-
-		iterator.Advance();
-
+		else {
+			iterator.Advance();
+		}
 	}
 }
 


### PR DESCRIPTION
To recreate existing crash quickly:

Set rule Channels:DeleteTimer to 1
Add this to a char's INI file: channelAutoJoin=cheesehoppers:Ditrid to add a temp password protected channel
Log that character in
Log that charecter out
In about 2 minutes the UCS will throw a segv and crash

The problem comes from using an second iterator on the same linked list to removecurrent.  The top iterator was getting corrupted.

Tested and it now works everytime.
