### PR TITLE
[Bug Fix] Camping was causing player to leave raid, causing unexpected behavior

### DIFF
--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -189,9 +189,10 @@ bool Client::Process() {
 		}
 
 		if (camp_timer.Check()) {
-			Raid* raid = entity_list.GetRaidByClient(this);
-			if (raid)
-				raid->RemoveMember(this->GetName());
+			Raid *myraid = entity_list.GetRaidByClient(this);
+			if (myraid) {
+				myraid->MemberZoned(this);
+			}
 			LeaveGroup();
 			Save();
 			if (GetMerc())


### PR DESCRIPTION
Previous to #2782 clients were not removed from a raid when they camped, would prefer to retain old functionality in this regard, believe this was added mistakenly.