### PR TITLE
[Cleanup] Add check for owner in quest::pausetimer()

### DIFF
--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -611,6 +611,10 @@ void QuestManager::stopalltimers(Mob *mob) {
 void QuestManager::pausetimer(const char* timer_name, Mob* mob) {
 	QuestManagerCurrentQuestVars();
 
+	if (!mob && !owner) {
+		return;
+	}
+
 	std::list<QuestTimer>::iterator cur = QTimerList.begin(), end;
 	std::list<PausedTimer>::iterator pcur = PTimerList.begin(), pend;
 	PausedTimer pt;


### PR DESCRIPTION
# Notes
- We didn't check for `owner` before doing `owner->GetName()`.