### PR TITLE
[Cleanup] Add check for owner in quest::resumetimer()

### DIFF
--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -648,6 +648,10 @@ void QuestManager::pausetimer(const char* timer_name, Mob* mob) {
 void QuestManager::resumetimer(const char* timer_name, Mob* mob) {
 	QuestManagerCurrentQuestVars();
 
+	if (!mob && !owner) {
+		return;
+	}
+
 	std::list<QuestTimer>::iterator cur = QTimerList.begin(), end;
 	std::list<PausedTimer>::iterator pcur = PTimerList.begin(), pend;
 	PausedTimer pt;


### PR DESCRIPTION
# Notes
- We didn't check for owner before doing `owner->GetName()`.