### PR TITLE
[Cleanup] Use default ctor/dtor in oriented_bounding_box.h

### DIFF
--- a/zone/oriented_bounding_box.h
+++ b/zone/oriented_bounding_box.h
@@ -7,9 +7,9 @@
 class OrientedBoundingBox
 {
 public:
-	OrientedBoundingBox() { }
+	OrientedBoundingBox() = default;
 	OrientedBoundingBox(const glm::vec3 &pos, const glm::vec3 &rot, const glm::vec3 &scale, const glm::vec3 &extents);
-	~OrientedBoundingBox() { }
+	~OrientedBoundingBox() = default;
 
 	bool ContainsPoint(const glm::vec3 &p) const;
 private:


### PR DESCRIPTION
# Notes
- Use default ctor/dtor instead of empty ones.