### PR TITLE
[Cleanup] Remove pDontCastBefore_casting_spell from zone/npc.h

### DIFF
--- a/zone/npc.h
+++ b/zone/npc.h
@@ -584,7 +584,6 @@ protected:
 	uint32	npc_spells_id;
 	uint8	casting_spell_AIindex;
 
-	uint32*	pDontCastBefore_casting_spell;
 	std::vector<AISpells_Struct> AIspells;
 	bool HasAISpell;
 	virtual bool AICastSpell(Mob* tar, uint8 iChance, uint32 iSpellTypes, bool bInnates = false);


### PR DESCRIPTION
# Notes
- This is unused.