### PR TITLE
[Crash] Fix possible dereference of nullptr in Client::CalcHPRegen

### DIFF
--- a/zone/client_mods.cpp
+++ b/zone/client_mods.cpp
@@ -288,7 +288,7 @@ int64 Client::CalcHPRegen(bool bCombat)
 
 	if (!bCombat && CanFastRegen() && (IsSitting() || CanMedOnHorse())) {
 		auto max_hp = GetMaxHP();
-		int fast_regen = 6 * (max_hp / zone->newzone_data.fast_regen_hp);
+		int64 fast_regen = 6 * (max_hp / (zone ? zone->newzone_data.fast_regen_hp : 180));
 		if (base < fast_regen) // weird, but what the client is doing
 			base = fast_regen;
 	}


### PR DESCRIPTION
As seen in http://spire.akkadius.com/dev/release/22.10.0?id=3353 it appears that the Zone Ptr could cause a crash if de-referenced in some circumstances, adding check to prevent dereference of a nullptr. 

Default Zone Fast Regen value used if nullptr. 

If this continues to be a problem, then it means that we have a dangling/uninitialized Zone Ptr... and will require further investigation.

