### PR TITLE
[BugFix/NPCs] Fix issue with NPCs no longer using some armor.

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -58,8 +58,8 @@ void Mob::CalcBonuses()
 void NPC::CalcBonuses()
 {
 	memset(&itembonuses, 0, sizeof(StatBonuses));
+
 	if (GetOwner() || RuleB(NPC, UseItemBonusesForNonPets)) {
-		memset(&itembonuses, 0, sizeof(StatBonuses));
 		CalcItemBonuses(&itembonuses);
 	}
 

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -58,15 +58,9 @@ void Mob::CalcBonuses()
 void NPC::CalcBonuses()
 {
 	memset(&itembonuses, 0, sizeof(StatBonuses));
-	if (RuleB(NPC, UseItemBonusesForNonPets)) {
+	if (GetOwner() || RuleB(NPC, UseItemBonusesForNonPets)) {
 		memset(&itembonuses, 0, sizeof(StatBonuses));
 		CalcItemBonuses(&itembonuses);
-	}
-	else {
-		if (GetOwner()) {
-			memset(&itembonuses, 0, sizeof(StatBonuses));
-			CalcItemBonuses(&itembonuses);
-		}
 	}
 
 	// This has to happen last, so we actually take the item bonuses into account.
@@ -268,7 +262,7 @@ void Mob::AddItemBonuses(const EQ::ItemInstance* inst, StatBonuses* b, bool is_a
 		return;
 	}
 
-	if (!is_tribute && !inst->IsEquipable(GetBaseRace(), GetClass())) {
+	if (IsClient() && !is_tribute && !inst->IsEquipable(GetBaseRace(), GetClass())) {
 		if (item->ItemType != EQ::item::ItemTypeFood && item->ItemType != EQ::item::ItemTypeDrink) {
 			return;
 		}
@@ -276,14 +270,14 @@ void Mob::AddItemBonuses(const EQ::ItemInstance* inst, StatBonuses* b, bool is_a
 
 	const auto current_level = GetLevel();
 
-	if (current_level < inst->GetItemRequiredLevel(true)) {
+	if (IsClient() && current_level < inst->GetItemRequiredLevel(true)) {
 		return;
 	}
 
 	if (!is_ammo_item) {
 		const auto recommended_level = is_augment ? recommended_level_override : inst->GetItemRecommendedLevel(true);
 
-		if (current_level >= recommended_level) {
+		if (IsNPC() || current_level >= recommended_level) {
 			b->HP += item->HP;
 			b->Mana += item->Mana;
 			b->Endurance += item->Endur;

--- a/zone/loottables.cpp
+++ b/zone/loottables.cpp
@@ -361,11 +361,12 @@ void NPC::AddLootDrop(
 		SetArrowEquipped(true);
 	}
 
+	bool found = false; // track if we found an empty slot we fit into
+
 	if (loot_drop.equip_item > 0) {
 		uint8 eslot = 0xFF;
 		char newid[20];
 		const EQ::ItemData* compitem = nullptr;
-		bool found = false; // track if we found an empty slot we fit into
 		int32 foundslot = -1; // for multi-slot items
 
 		// Equip rules are as follows:
@@ -500,7 +501,6 @@ void NPC::AddLootDrop(
 
 		}
 		if (found) {
-			CalcBonuses(); // This is less than ideal for bulk adding of items
 			item->equip_slot = foundslot;
 		}
 	}
@@ -509,6 +509,10 @@ void NPC::AddLootDrop(
 		itemlist->push_back(item);
 	}
 	else safe_delete(item);
+
+	if (found) {
+		CalcBonuses();
+	}
 
 	if (IsRecordLootStats()) {
 		m_rolled_items.emplace_back(item->item_id);


### PR DESCRIPTION
This PR is to resolve a problem brought up [here](https://discord.com/channels/212663220849213441/1098664193357520996).

The issue is that pets were often not using armor traded to them any longer because the Bonuses code had been consolidated into a single module and that module was applying some client restrictions like race/class, which cannot pass for pets. (As an aside, the same problem was created for NPCs of various races).

That consolidation was done in [PR](https://github.com/EQEmu/Server/pull/3136).

While working on this, I also found a longer term problem in that an item traded to a pet was not actually impacting that pet's AC or other stats until another event which would impact bonuses occurred. The older code did not have this issue, as NPCs were using their internal equipment array which was updated when AddLootDrop() called CalcBonuses.  Now, however, the combined Bonuses code uses the itemlist via the NPC.h interface.  So the call to CalcBonuses needed to be moved below where itemlist was updated in AddLootDrop().

I also cleaned up and if/else section in bonuses.cpp where one if is cleaner.