### PR TITLE
[Quest API] Add HasSpellEffect() to Perl/Lua

### DIFF
--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -3000,6 +3000,11 @@ luabind::object Lua_Mob::GetBuffSpellIDs(lua_State* L) {
 	return t;
 }
 
+bool Lua_Mob::HasSpellEffect(int effect_id) {
+	Lua_Safe_Call_Bool();
+	return self->HasSpellEffect(effect_id);
+}
+
 luabind::scope lua_register_mob() {
 	return luabind::class_<Lua_Mob, Lua_Entity>("Mob")
 	.def(luabind::constructor<>())
@@ -3338,6 +3343,7 @@ luabind::scope lua_register_mob() {
 	.def("HasPet", (bool(Lua_Mob::*)(void))&Lua_Mob::HasPet)
 	.def("HasProcs", &Lua_Mob::HasProcs)
 	.def("HasShieldEquipped", (bool(Lua_Mob::*)(void))&Lua_Mob::HasShieldEquipped)
+	.def("HasSpellEffect", &Lua_Mob::HasSpellEffect)
 	.def("HasTimer", &Lua_Mob::HasTimer)
 	.def("HasTwoHandBluntEquipped", (bool(Lua_Mob::*)(void))&Lua_Mob::HasTwoHandBluntEquipped)
 	.def("HasTwoHanderEquipped", (bool(Lua_Mob::*)(void))&Lua_Mob::HasTwoHanderEquipped)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -539,6 +539,7 @@ public:
 	void StopAllTimers();
 	void StopTimer(const char* timer_name);
 	luabind::object GetBuffSpellIDs(lua_State* L);
+	bool HasSpellEffect(int effect_id);
 };
 
 #endif

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -6229,11 +6229,13 @@ bool Mob::HasSpellEffect(int effect_id)
 {
 	const auto buff_count = GetMaxTotalSlots();
 	for (int i = 0; i < buff_count; i++) {
-		if (!IsValidSpell(buffs[i].spellid)) {
+		const auto spell_id = buffs[i].spellid;
+
+		if (!IsValidSpell(spell_id)) {
 			continue;
 		}
 
-		if (IsEffectInSpell(buffs[i].spellid, effect_id)) {
+		if (IsEffectInSpell(spell_id, effect_id)) {
 			return true;
 		}
 	}

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -6227,20 +6227,18 @@ FACTION_VALUE Mob::GetSpecialFactionCon(Mob* iOther) {
 
 bool Mob::HasSpellEffect(int effect_id)
 {
-	int i;
-
-	int buff_count = GetMaxTotalSlots();
-	for(i = 0; i < buff_count; i++)
-	{
+	const auto buff_count = GetMaxTotalSlots();
+	for (int i = 0; i < buff_count; i++) {
 		if (!IsValidSpell(buffs[i].spellid)) {
 			continue;
 		}
 
 		if (IsEffectInSpell(buffs[i].spellid, effect_id)) {
-			return(1);
+			return true;
 		}
 	}
-	return(0);
+
+	return false;
 }
 
 int Mob::GetSpecialAbility(int ability)

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -2950,6 +2950,11 @@ perl::array Perl_Mob_GetBuffSpellIDs(Mob* self)
 	return l;
 }
 
+bool Perl_Mob_HasSpellEffect(Mob* self, int effect_id)
+{
+	return self->HasSpellEffect(effect_id);
+}
+
 void perl_register_mob()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3272,6 +3277,7 @@ void perl_register_mob()
 	package.add("HasPet", &Perl_Mob_HasPet);
 	package.add("HasProcs", &Perl_Mob_HasProcs);
 	package.add("HasShieldEquipped", &Perl_Mob_HasShieldEquipped);
+	package.add("HasSpellEffect", &Perl_Mob_HasSpellEffect);
 	package.add("HasTimer", &Perl_Mob_HasTimer);
 	package.add("HasTwoHandBluntEquipped", &Perl_Mob_HasTwoHandBluntEquipped);
 	package.add("HasTwoHanderEquipped", &Perl_Mob_HasTwoHanderEquipped);


### PR DESCRIPTION
# Perl
- Add `$mob->HasSpellEffect(effect_id)`.

# Lua
- Add `mob:HasSpellEffect(effect_id)`.

# Notes
- Allows operators to see if a Mob has an effect ID from any of their buffs.