### PR TITLE
[Messages] Remove duplicate you have lost a level message

### DIFF
--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -783,8 +783,6 @@ void Client::SetEXP(uint64 set_exp, uint64 set_aaxp, bool isrezzexp) {
 			if (check_level == RuleI(Character, DeathExpLossLevel))
 				MessageString(Chat::Yellow, CORPSE_EXP_LOST);
 		}
-		else
-			MessageString(Chat::Experience, LOSE_LEVEL, ConvertArray(check_level, val1));
 
 		uint8 myoldlevel = GetLevel();
 


### PR DESCRIPTION
I have verified on titanium and rof2 that we always get 2 "you have LOST a level" messages and that the one in yellow is from OUR code, the one in RED I can find nowhere so I am thinking the client is generating it.

I cannot find anywhere in our code where the constant LOSE_LEVEL is used other than SetExp and nowhere do we send the entire message hard coded or use the value 442 in a message.

Therefore I think we can remove this message and rely on the client.