### PR TITLE
[Crash] Fix UCS crash that occurs during log reloading

### DIFF
--- a/ucs/ucs.cpp
+++ b/ucs/ucs.cpp
@@ -144,6 +144,8 @@ int main() {
 		->LoadLogDatabaseSettings()
 		->StartFileLogs();
 
+	player_event_logs.SetDatabase(&database)->Init();
+
 	char tmp[64];
 
 	// ucs has no 'reload rules' handler


### PR DESCRIPTION
### What

This fixes a crash that occurs when UCS receives a packet to reload log settings. This is because there isn't a valid database pointer held within the player event logging manager within the context of UCS. We fix this by instantiating player event logs and passing the database connection instance pointer to the class.

### Crash Samples

* http://spire.akkadius.com/dev/release/22.9.1?id=3298
* http://spire.akkadius.com/dev/release/22.10.0?id=3380