### PR TITLE
[Bug Fix] Fix issue with spawning Mercs

### DIFF
--- a/zone/merc.cpp
+++ b/zone/merc.cpp
@@ -4302,7 +4302,7 @@ Merc* Merc::LoadMerc(Client *c, MercTemplate* merc_template, uint32 merchant_id,
 		
 		const NPCType* npc_type_to_copy = nullptr;
 		if (c) {
-			const NPCType* npc_type_to_copy = content_db.GetMercType(merc_template->MercNPCID, merc_template->RaceID, c->GetLevel());
+			npc_type_to_copy = content_db.GetMercType(merc_template->MercNPCID, merc_template->RaceID, c->GetLevel());
 		}
 
 		if(npc_type_to_copy != nullptr)


### PR DESCRIPTION
Issue with scope, where we were declaring npc_type_to_copy inside a block statement which was recently added to ensure validity of the client ptr. this would cause npc_type_to_copy to always be nullptr. 