### PR TITLE
[Messages] Remove duplicate heal message for healing yourself

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -4447,11 +4447,19 @@ void Mob::HealDamage(uint64 amount, Mob* caster, uint16 spell_id)
 				}
 			}
 			else { // normal heals
-				FilteredMessageString(caster, Chat::NonMelee, FilterSpellDamage,
-					YOU_HEALED, caster->GetCleanName(), itoa(acthealed));
+				// Message to caster
+				if (caster->IsClient()) {
+					caster->FilteredMessageString(caster, Chat::NonMelee,
+						FilterSpellDamage, YOU_HEAL, GetCleanName(),
+						itoa(acthealed));
+					}
 
-					caster->FilteredMessageString(caster, Chat::NonMelee, FilterSpellDamage,
-						YOU_HEAL, GetCleanName(), itoa(acthealed));
+				// Message to target
+				if (IsClient() && caster != this) {
+					FilteredMessageString(caster, Chat::NonMelee,
+					FilterSpellDamage, YOU_HEALED, caster->GetCleanName(),
+					itoa(acthealed));
+				}
 			}
 		} else if (
 			CastToClient()->GetFilter(FilterHealOverTime) != FilterShowSelfOnly ||


### PR DESCRIPTION
Healing yourself with a spell that does > 100 hp of healing was resulting in:

[Tue May 02 16:18:46 2023] Logg has healed you for 350 points.
[Tue May 02 16:18:46 2023] You have healed Logg for 350 points.

Fixed to only display one message in this case.