### PR TITLE
[Memory Leak] Fix large memory leak introduced in CalcItemBonuses

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -146,18 +146,7 @@ void Mob::CalcItemBonuses(StatBonuses* b) {
 	int16 i;
 
 	for (i = EQ::invslot::BONUS_BEGIN; i <= EQ::invslot::BONUS_SKILL_END; i++) {
-		const EQ::ItemInstance* inst = nullptr;
-		if (IsOfClientBotMerc()) {
-			inst = GetInv().GetItem(i);
-		} else {
-			const auto* item = CastToNPC()->GetItem(i);
-			if (!item) {
-				continue;
-			}
-
-			inst = database.CreateItem(item->item_id);
-		}
-
+		const EQ::ItemInstance* inst = m_inv[i];
 		if (!inst) {
 			continue;
 		}


### PR DESCRIPTION
Lazarus updated to master and started having zones grow to several GB's of memory before the OS runs out of memory and kills the zone. It had been happening for several weeks now and become a big issue of stability and zones would OOM kill many times throughout a given day. Notably, EZ and PEQ have not updated for a few months to see the issue at the same scale

![image](https://user-images.githubusercontent.com/3319450/236657338-742ea16d-d813-4e40-91dc-35580a7c5fc3.png)

I ran https://github.com/KDE/heaptrack on a problem zone given common zones the behavior was introduced in so we can collect data to understand the issue.

![image](https://user-images.githubusercontent.com/3319450/236656459-865fedbc-1987-49e4-a613-9439016a44ca.png)

The issue stems from constantly creating new item instances which `new`'s up new objects every time CalcBonuses is called and never destroys them.

This reverts changes made in https://github.com/EQEmu/Server/pull/3136/files for a small part of the offending code https://github.com/EQEmu/Server/pull/3136/files#diff-66d4c1caa8c324b219b395e271593e026eaf6baf97851378de2ba8a8f145d102R165

I'm not sure the intention of the original code but it is trying to grab items on an NPC but newing up an instance each time. NPC's store their notion of "equipment" slightly different than `m_inv` (EQ::InventoryProfile) on the Mob object. My suggestion is that we hold the instance cached in an inventory array for NPC's just as we do for the Mob object to fetch this data in a hot path. Even if we safe delete this new item being created its excessive and wasted allocations for something we can simply cache when an item is added to an NPC.

This PR will at least stop the bleeding for now and an alternative will need to be put in place to restore the intent of the added code on March 25th

