### PR TITLE
[Bug Fix] ReloadQuests() on Zone::Init() to avoid cached global quests/plugins

### DIFF
--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -1213,6 +1213,8 @@ bool Zone::Init(bool is_static) {
 
 	npc_scale_manager->LoadScaleData();
 
+	parse->ReloadQuests();
+
 	// logging origination information
 	LogSys.origination_info.zone_short_name = zone->short_name;
 	LogSys.origination_info.zone_long_name  = zone->long_name;


### PR DESCRIPTION
# Notes
- Before this, quests/plugins would be cached in an old state, so you'd have to either enter the zone and `#reload quest` or `#reload world` to get them to update.