### PR TITLE
[Hotfix] Fix mob item bonus calc

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -146,7 +146,7 @@ void Mob::CalcItemBonuses(StatBonuses* b) {
 	int16 i;
 
 	for (i = EQ::invslot::BONUS_BEGIN; i <= EQ::invslot::BONUS_SKILL_END; i++) {
-		const EQ::ItemInstance* inst = m_inv[i];
+		const EQ::ItemInstance* inst = GetInv().GetItem(i);
 		if (!inst) {
 			continue;
 		}


### PR DESCRIPTION
Fetch inventory using the `InventoryProfile` method `GetItem(int16 slot_id)` the prior `m_inv` direct access never appeared to actually work