### PR TITLE
[Performance] Character bind is now bulk saved

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -656,10 +656,10 @@ bool Client::Save(uint8 iCommitNow) {
 	/* Save Character Currency */
 	database.SaveCharacterCurrency(CharacterID(), &m_pp);
 
-	/* Save Current Bind Points */
-	for (int i = 0; i < 5; i++)
-		if (m_pp.binds[i].zone_id)
-			database.SaveCharacterBindPoint(CharacterID(), m_pp.binds[i], i);
+	// save character binds
+	// this may not need to be called in Save() but it's here for now
+	// to maintain the current behavior
+	database.SaveCharacterBinds(this);
 
 	/* Save Character Buffs */
 	database.SaveBuffs(this);

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -13,6 +13,7 @@
 #include "aura.h"
 #include "../common/repositories/character_disciplines_repository.h"
 #include "../common/repositories/npc_types_repository.h"
+#include "../common/repositories/character_bind_repository.h"
 
 #include <ctime>
 #include <iostream>
@@ -1027,25 +1028,6 @@ bool ZoneDatabase::LoadCharacterBindPoint(uint32 character_id, PlayerProfile_Str
 bool ZoneDatabase::SaveCharacterLanguage(uint32 character_id, uint32 lang_id, uint32 value){
 	std::string query = StringFormat("REPLACE INTO `character_languages` (id, lang_id, value) VALUES (%u, %u, %u)", character_id, lang_id, value); QueryDatabase(query);
 	LogDebug("ZoneDatabase::SaveCharacterLanguage for character ID: [{}], lang_id:[{}] value:[{}] done", character_id, lang_id, value);
-	return true;
-}
-
-bool ZoneDatabase::SaveCharacterBindPoint(uint32 character_id, const BindStruct &bind, uint32 bind_num)
-{
-	/* Save Home Bind Point */
-	std::string query =
-	    StringFormat("REPLACE INTO `character_bind` (id, zone_id, instance_id, x, y, z, heading, slot) VALUES (%u, "
-			 "%u, %u, %f, %f, %f, %f, %i)",
-			 character_id, bind.zone_id, bind.instance_id, bind.x, bind.y, bind.z, bind.heading, bind_num);
-
-	LogDebug("ZoneDatabase::SaveCharacterBindPoint for character ID: [{}] zone_id: [{}] instance_id: [{}] position: [{}] [{}] [{}] [{}] bind_num: [{}]",
-		character_id, bind.zone_id, bind.instance_id, bind.x, bind.y, bind.z, bind.heading, bind_num);
-
-	auto results = QueryDatabase(query);
-	if (!results.RowsAffected())
-		LogDebug("ERROR Bind Home Save: [{}]. [{}]", results.ErrorMessage().c_str(),
-			query.c_str());
-
 	return true;
 }
 
@@ -4518,5 +4500,54 @@ void ZoneDatabase::UpdateGMStatus(uint32 accID, int newStatus)
 			accID
 		);
 		database.QueryDatabase(query);
+	}
+}
+
+void ZoneDatabase::SaveCharacterBinds(Client *c)
+{
+	// bulk save character binds
+	std::vector<CharacterBindRepository::CharacterBind> binds = {};
+	CharacterBindRepository::CharacterBind bind = {};
+
+	// count character binds
+	int bind_count = 0;
+	for (auto & b : c->GetPP().binds) {
+		if (b.zone_id) {
+			bind_count++;
+		}
+	}
+
+	LogInfo("bind count is [{}]", bind_count);
+
+	// allocate memory for binds
+	binds.reserve(bind_count);
+
+	// copy binds to vector
+	int i = 0;
+	for (auto &b: c->GetPP().binds) {
+		if (b.zone_id) {
+			// copy bind data
+			bind.id          = c->CharacterID();
+			bind.zone_id     = b.zone_id;
+			bind.instance_id = b.instance_id;
+			bind.x           = b.x;
+			bind.y           = b.y;
+			bind.z           = b.z;
+			bind.heading     = b.heading;
+			bind.slot        = i;
+
+			// add bind to vector
+			binds.emplace_back(bind);
+
+			i++;
+		}
+	}
+
+	// save binds
+	if (bind_count > 0) {
+		// delete old binds
+		CharacterBindRepository::DeleteWhere(database, fmt::format("id = {}", c->CharacterID()));
+		// save new binds
+		CharacterBindRepository::InsertMany(database, binds);
 	}
 }

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -304,7 +304,7 @@ struct CharacterCorpseItemEntry
 	uint32 ornament_hero_model;
 };
 
-struct CharacterCorpseEntry 
+struct CharacterCorpseEntry
 {
 	bool locked;
 	uint32 exp;
@@ -446,7 +446,6 @@ public:
 
 	bool SaveCharacterAA(uint32 character_id, uint32 aa_id, uint32 current_level, uint32 charges);
 	bool SaveCharacterBandolier(uint32 character_id, uint8 bandolier_id, uint8 bandolier_slot, uint32 item_id, uint32 icon, const char* bandolier_name);
-	bool SaveCharacterBindPoint(uint32 character_id, const BindStruct &bind, uint32 bind_number);
 	bool SaveCharacterCurrency(uint32 character_id, PlayerProfile_Struct* pp);
 	bool SaveCharacterData(Client* c, PlayerProfile_Struct* pp, ExtendedProfile_Struct* m_epp);
 	bool SaveCharacterDisc(uint32 character_id, uint32 slot_id, uint32 disc_id);
@@ -666,6 +665,7 @@ public:
 	// bot database add-on to eliminate the need for a second database connection
 	BotDatabase botdb;
 
+	static void SaveCharacterBinds(Client *c);
 protected:
 	void ZDBInitVars();
 

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -906,7 +906,7 @@ void Client::SetBindPoint(int bind_number, int to_zone, int to_instance, const g
 		m_pp.binds[bind_number].y = location.y;
 		m_pp.binds[bind_number].z = location.z;
 	}
-	database.SaveCharacterBindPoint(CharacterID(), m_pp.binds[bind_number], bind_number);
+	database.SaveCharacterBinds(this);
 }
 
 void Client::SetBindPoint2(int bind_number, int to_zone, int to_instance, const glm::vec4 &location)
@@ -929,7 +929,8 @@ void Client::SetBindPoint2(int bind_number, int to_zone, int to_instance, const 
 		m_pp.binds[bind_number].z = location.z;
 		m_pp.binds[bind_number].heading = location.w;
 	}
-	database.SaveCharacterBindPoint(CharacterID(), m_pp.binds[bind_number], bind_number);
+
+	database.SaveCharacterBinds(this);
 }
 
 void Client::GoToBind(uint8 bind_number) {

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -890,22 +890,27 @@ void NPC::Gate(uint8 bind_number) {
 
 void Client::SetBindPoint(int bind_number, int to_zone, int to_instance, const glm::vec3 &location)
 {
-	if (bind_number < 0 || bind_number >= 4)
+	if (bind_number < 0 || bind_number >= 4) {
 		bind_number = 0;
+	}
 
 	if (to_zone == -1) {
-		m_pp.binds[bind_number].zone_id = zone->GetZoneID();
-		m_pp.binds[bind_number].instance_id = (zone->GetInstanceID() != 0 && zone->IsInstancePersistent()) ? zone->GetInstanceID() : 0;
-		m_pp.binds[bind_number].x = m_Position.x;
-		m_pp.binds[bind_number].y = m_Position.y;
-		m_pp.binds[bind_number].z = m_Position.z;
-	} else {
-		m_pp.binds[bind_number].zone_id = to_zone;
-		m_pp.binds[bind_number].instance_id = to_instance;
-		m_pp.binds[bind_number].x = location.x;
-		m_pp.binds[bind_number].y = location.y;
-		m_pp.binds[bind_number].z = location.z;
+		m_pp.binds[bind_number].zone_id     = zone->GetZoneID();
+		m_pp.binds[bind_number].instance_id = (zone->GetInstanceID() != 0 && zone->IsInstancePersistent())? zone->GetInstanceID() : 0;
+		m_pp.binds[bind_number].x           = m_Position.x;
+		m_pp.binds[bind_number].y           = m_Position.y;
+		m_pp.binds[bind_number].z           = m_Position.z;
+		m_pp.binds[bind_number].heading     = GetHeading();
 	}
+	else {
+		m_pp.binds[bind_number].zone_id     = to_zone;
+		m_pp.binds[bind_number].instance_id = to_instance;
+		m_pp.binds[bind_number].x           = location.x;
+		m_pp.binds[bind_number].y           = location.y;
+		m_pp.binds[bind_number].z           = location.z;
+		m_pp.binds[bind_number].heading     = GetHeading();
+	}
+
 	database.SaveCharacterBinds(this);
 }
 


### PR DESCRIPTION
This PR combines individual `character_bind` queries during `Save()` into one

This also fixes a long time bug where character heading is not being properly saved in bind

```
  Zone |   Query    | QueryDatabase DELETE FROM character_bind WHERE id = 1 -- (5 rows affected) (0.008630s)-- [poair] (The Plane of Air) inst_id [0]
  Zone |   Query    | QueryDatabase INSERT INTO character_bind (id, slot, zone_id, instance_id, x, y, z, heading)  VALUES (1,0,189,0,18.000000,-147.000000,20.000000,192.000000),(1,1,29,0,-456.000000,560.000000,-26.000000,192.000000),(1,2,29,0,-456.000000,560.000000,-26.000000,192.000000),(1,3,29,0,-456.000000,560.000000,-26.000000,192.000000),(1,4,29,0,-456.000000,560.000000,-26.000000,192.000000) -- (5 rows affected) (0.000310s)-- [poair] (The Plane of Air) inst_id [0]
```