### PR TITLE
[Performance] Mail key is now cached during player load

### DIFF
--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -153,36 +153,34 @@ void SharedDatabase::SetMailKey(int CharID, int IPAddress, int MailKey)
 	}
 }
 
-std::string SharedDatabase::GetMailKey(int CharID, bool key_only)
+SharedDatabase::MailKeys SharedDatabase::GetMailKey(int character_id)
 {
-	const std::string query   = StringFormat("SELECT `mailkey` FROM `character_data` WHERE `id`='%i' LIMIT 1", CharID);
+	const std::string query   = StringFormat("SELECT `mailkey` FROM `character_data` WHERE `id`='%i' LIMIT 1", character_id);
 	auto              results = QueryDatabase(query);
 	if (!results.Success()) {
-		return std::string();
+		return MailKeys{};
 	}
 
 	if (!results.RowCount()) {
-
 		Log(Logs::General,
 			Logs::ClientLogin,
 			"Error: Mailkey for character id [%i] does not exist or could not be found",
-			CharID);
-		return {};
+			character_id
+		);
+		return MailKeys{};
 	}
 
 	auto &row = results.begin();
 	if (row != results.end()) {
 		std::string mail_key = row[0];
 
-		if (mail_key.length() > 8 && key_only) {
-			return mail_key.substr(8);
-		}
-		else {
-			return mail_key;
-		}
+		return MailKeys{
+			.mail_key = mail_key.substr(8),
+			.mail_key_full = mail_key
+		};
 	}
 
-	return {};
+	return MailKeys{};
 }
 
 bool SharedDatabase::SaveCursor(uint32 char_id, std::list<EQ::ItemInstance*>::const_iterator &start, std::list<EQ::ItemInstance*>::const_iterator &end)

--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -133,41 +133,45 @@ uint32 SharedDatabase::GetTotalTimeEntitledOnAccount(uint32 AccountID) {
 
 void SharedDatabase::SetMailKey(int CharID, int IPAddress, int MailKey)
 {
-	char MailKeyString[17];
+	char mail_key[17];
 
-	if (RuleB(Chat, EnableMailKeyIPVerification) == true)
-		sprintf(MailKeyString, "%08X%08X", IPAddress, MailKey);
-	else
-		sprintf(MailKeyString, "%08X", MailKey);
+	if (RuleB(Chat, EnableMailKeyIPVerification) == true) {
+		sprintf(mail_key, "%08X%08X", IPAddress, MailKey);
+	}
+	else {
+		sprintf(mail_key, "%08X", MailKey);
+	}
 
-	const std::string query = StringFormat("UPDATE character_data SET mailkey = '%s' WHERE id = '%i'",
-	                                       MailKeyString, CharID);
-	const auto results = QueryDatabase(query);
-	if (!results.Success())
-		LogError("SharedDatabase::SetMailKey({}, {}) : {}", CharID, MailKeyString, results.ErrorMessage().c_str());
+	const std::string query = StringFormat(
+		"UPDATE character_data SET mailkey = '%s' WHERE id = '%i'",
+		mail_key, CharID
+	);
 
+	const auto        results = QueryDatabase(query);
+	if (!results.Success()) {
+		LogError("SharedDatabase::SetMailKey({}, {}) : {}", CharID, mail_key, results.ErrorMessage().c_str());
+	}
 }
 
 std::string SharedDatabase::GetMailKey(int CharID, bool key_only)
 {
-	const std::string query = StringFormat("SELECT `mailkey` FROM `character_data` WHERE `id`='%i' LIMIT 1", CharID);
-	auto results = QueryDatabase(query);
-
+	const std::string query   = StringFormat("SELECT `mailkey` FROM `character_data` WHERE `id`='%i' LIMIT 1", CharID);
+	auto              results = QueryDatabase(query);
 	if (!results.Success()) {
-
-		Log(Logs::Detail, Logs::MySQLError, "Error retrieving mailkey from database: %s", results.ErrorMessage().c_str());
 		return std::string();
 	}
 
 	if (!results.RowCount()) {
 
-		Log(Logs::General, Logs::ClientLogin, "Error: Mailkey for character id [%i] does not exist or could not be found", CharID);
-		return std::string();
+		Log(Logs::General,
+			Logs::ClientLogin,
+			"Error: Mailkey for character id [%i] does not exist or could not be found",
+			CharID);
+		return {};
 	}
 
-	auto& row = results.begin();
+	auto &row = results.begin();
 	if (row != results.end()) {
-
 		std::string mail_key = row[0];
 
 		if (mail_key.length() > 8 && key_only) {
@@ -177,11 +181,8 @@ std::string SharedDatabase::GetMailKey(int CharID, bool key_only)
 			return mail_key;
 		}
 	}
-	else {
 
-		Log(Logs::General, Logs::MySQLError, "Internal MySQL error in SharedDatabase::GetMailKey(int, bool)");
-		return std::string();
-	}
+	return {};
 }
 
 bool SharedDatabase::SaveCursor(uint32 char_id, std::list<EQ::ItemInstance*>::const_iterator &start, std::list<EQ::ItemInstance*>::const_iterator &end)

--- a/common/shareddb.h
+++ b/common/shareddb.h
@@ -81,7 +81,11 @@ public:
 	bool SetGMInvul(uint32 account_id, bool gminvul);
 	bool SetGMFlymode(uint32 account_id, uint8 flymode);
 	void SetMailKey(int CharID, int IPAddress, int MailKey);
-	std::string GetMailKey(int CharID, bool key_only = false);
+	struct MailKeys {
+		std::string mail_key;
+		std::string mail_key_full;
+	};
+	MailKeys GetMailKey(int character_id);
 	bool SaveCursor(
 		uint32 char_id,
 		std::list<EQ::ItemInstance *>::const_iterator &start,

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -11238,7 +11238,7 @@ void Client::ReconnectUCS()
 {
 	EQApplicationPacket      *outapp         = nullptr;
 	std::string              buffer;
-	std::string              mail_key        = database.GetMailKey(CharacterID(), true);
+	std::string              mail_key        = m_mail_key;
 	EQ::versions::UCSVersion connection_type = EQ::versions::ucsUnknown;
 
 	// chat server packet

--- a/zone/client.h
+++ b/zone/client.h
@@ -2038,6 +2038,13 @@ private:
 	bool CanTradeFVNoDropItem();
 	void SendMobPositions();
 	void PlayerTradeEventLog(Trade *t, Trade *t2);
+
+	// full and partial mail key cache
+	std::string m_mail_key_full;
+	std::string m_mail_key;
+public:
+	const std::string &GetMailKeyFull() const;
+	const std::string &GetMailKey() const;
 };
 
 #endif

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1267,6 +1267,10 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 	database.LoadCharacterLeadershipAA(cid, &m_pp); /* Load Character Leadership AA's */
 	database.LoadCharacterTribute(cid, &m_pp); /* Load CharacterTribute */
 
+	// this pattern is strange
+	m_mail_key_full = database.GetMailKey(CharacterID());
+	m_mail_key      = database.GetMailKey(CharacterID(), true);
+
 	/* Load AdventureStats */
 	AdventureStats_Struct as;
 	if (database.GetAdventureStats(cid, &as))

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1268,8 +1268,10 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 	database.LoadCharacterTribute(cid, &m_pp); /* Load CharacterTribute */
 
 	// this pattern is strange
-	m_mail_key_full = database.GetMailKey(CharacterID());
-	m_mail_key      = database.GetMailKey(CharacterID(), true);
+	// this is remnants of the old way of doing things
+	auto mail_keys = database.GetMailKey(CharacterID());
+	m_mail_key_full = mail_keys.mail_key_full;
+	m_mail_key      = mail_keys.mail_key;
 
 	/* Load AdventureStats */
 	AdventureStats_Struct as;
@@ -11681,7 +11683,7 @@ void Client::Handle_OP_QueryUCSServerStatus(const EQApplicationPacket *app)
 		EQApplicationPacket* outapp = nullptr;
 		std::string buffer;
 
-		std::string MailKey = database.GetMailKey(CharacterID(), true);
+		std::string MailKey = GetMailKey();
 		EQ::versions::UCSVersion ConnectionType = EQ::versions::ucsUnknown;
 
 		// chat server packet

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -3018,3 +3018,13 @@ void Client::BuyerItemSearch(const EQApplicationPacket *app) {
 	QueuePacket(outapp);
 	safe_delete(outapp);
 }
+
+const std::string &Client::GetMailKeyFull() const
+{
+	return m_mail_key_full;
+}
+
+const std::string &Client::GetMailKey() const
+{
+	return m_mail_key;
+}

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -1132,8 +1132,6 @@ bool ZoneDatabase::SaveCharacterData(
 		return false;
 	}
 
-	const auto mail_key = database.GetMailKey(c->CharacterID());
-
 	clock_t t = std::clock(); /* Function timer start */
 	const auto query = fmt::format(
 		"REPLACE INTO `character_data` ("
@@ -1427,7 +1425,7 @@ bool ZoneDatabase::SaveCharacterData(
 		m_epp->perAA,
 		m_epp->expended_aa,
 		m_epp->last_invsnapshot_time,
-		mail_key.c_str()
+		c->GetMailKeyFull()
 	);
 	auto results = database.QueryDatabase(query);
 	LogDebug(


### PR DESCRIPTION
There is quite a bit of idle query volume of players constantly querying for mail key when it barely changes. When players save, the mail key is queried, when UCS reconnects the mail key is queried from the DB.

This PR loads the mail key into memory on player load and re-uses the cache where referenced in the code

**Query Example**

```
5/7/2023 9:27:18 PM SELECT `mailkey` FROM `character_data` WHERE `id`='687628' LIMIT 1 -- (1 row returned) (0.000318s)
5/7/2023 9:27:18 PM SELECT `mailkey` FROM `character_data` WHERE `id`='736323' LIMIT 1 -- (1 row returned) (0.000143s)
5/7/2023 9:27:18 PM SELECT `mailkey` FROM `character_data` WHERE `id`='732663' LIMIT 1 -- (1 row returned) (0.000369s)
5/7/2023 9:27:18 PM SELECT `mailkey` FROM `character_data` WHERE `id`='734796' LIMIT 1 -- (1 row returned) (0.000119s)
5/7/2023 9:27:18 PM SELECT `mailkey` FROM `character_data` WHERE `id`='736319' LIMIT 1 -- (1 row returned) (0.000104s)
5/7/2023 9:27:18 PM SELECT `mailkey` FROM `character_data` WHERE `id`='736328' LIMIT 1 -- (1 row returned) (0.000127s)
5/7/2023 9:27:18 PM SELECT `mailkey` FROM `character_data` WHERE `id`='737262' LIMIT 1 -- (1 row returned) (0.000258s)
5/7/2023 9:27:18 PM SELECT `mailkey` FROM `character_data` WHERE `id`='737260' LIMIT 1 -- (1 row returned) (0.000152s)
5/7/2023 9:27:18 PM SELECT `mailkey` FROM `character_data` WHERE `id`='736543' LIMIT 1 -- (1 row returned) (0.000203s)
5/7/2023 9:27:18 PM SELECT `mailkey` FROM `character_data` WHERE `id`='735928' LIMIT 1 -- (1 row returned) (0.000320s)
5/7/2023 9:27:18 PM SELECT `mailkey` FROM `character_data` WHERE `id`='721365' LIMIT 1 -- (1 row returned) (0.000148s)
5/7/2023 9:27:18 PM SELECT `mailkey` FROM `character_data` WHERE `id`='736478' LIMIT 1 -- (1 row returned) (0.000098s)
5/7/2023 9:27:18 PM SELECT `mailkey` FROM `character_data` WHERE `id`='736479' LIMIT 1 -- (1 row returned) (0.000110s)
5/7/2023 9:27:18 PM SELECT `mailkey` FROM `character_data` WHERE `id`='731688' LIMIT 1 -- (1 row returned) (0.000113s)
5/7/2023 9:27:18 PM SELECT `mailkey` FROM `character_data` WHERE `id`='730772' LIMIT 1 -- (1 row returned) (0.000299s)
5/7/2023 9:27:18 PM SELECT `mailkey` FROM `character_data` WHERE `id`='736036' LIMIT 1 -- (1 row returned) (0.000097s)
5/7/2023 9:27:18 PM SELECT `mailkey` FROM `character_data` WHERE `id`='735596' LIMIT 1 -- (1 row returned) (0.000097s)
5/7/2023 9:27:18 PM SELECT `mailkey` FROM `character_data` WHERE `id`='733150' LIMIT 1 -- (1 row returned) (0.000226s)
5/7/2023 9:27:18 PM SELECT `mailkey` FROM `character_data` WHERE `id`='736079' LIMIT 1 -- (1 row returned) (0.000356s)
5/7/2023 9:27:18 PM SELECT `mailkey` FROM `character_data` WHERE `id`='736326' LIMIT 1 -- (1 row returned) (0.000406s)
5/7/2023 9:27:18 PM SELECT `mailkey` FROM `character_data` WHERE `id`='736221' LIMIT 1 -- (1 row returned) (0.000335s)
5/7/2023 9:27:18 PM SELECT `mailkey` FROM `character_data` WHERE `id`='728323' LIMIT 1 -- (1 row returned) (0.000108s)
5/7/2023 9:27:18 PM SELECT `mailkey` FROM `character_data` WHERE `id`='736325' LIMIT 1 -- (1 row returned) (0.000275s)
```

**Testing Validation**

![image](https://user-images.githubusercontent.com/3319450/236739278-14c1ef9b-e457-4a70-8f24-26669cb6714d.png)

Tested after the multiple keys refactor as well. Sent mail, chatted in UCS, saved, camped, reloaded, read E-Mail, sent E-Mail

![image](https://user-images.githubusercontent.com/3319450/236742131-700f17ba-08c6-433a-b7f8-77ca61941c6b.png)
