### PR TITLE
[Performance] Character tribute is now bulk saved

### DIFF
--- a/common/database_schema.h
+++ b/common/database_schema.h
@@ -68,7 +68,7 @@ namespace DatabaseSchema {
 			{"character_spells",               "id"},
 			{"character_task_timers",          "character_id"},
 			{"character_tasks",                "charid"},
-			{"character_tribute",              "id"},
+			{"character_tribute",              "character_id"},
 			{"completed_tasks",                "charid"},
 			{"data_buckets",                   "id"},
 			{"faction_values",                 "char_id"},

--- a/common/repositories/base/base_character_tribute_repository.h
+++ b/common/repositories/base/base_character_tribute_repository.h
@@ -1,0 +1,354 @@
+/**
+ * DO NOT MODIFY THIS FILE
+ *
+ * This repository was automatically generated and is NOT to be modified directly.
+ * Any repository modifications are meant to be made to the repository extending the base.
+ * Any modifications to base repositories are to be made by the generator only
+ *
+ * @generator ./utils/scripts/generators/repository-generator.pl
+ * @docs https://eqemu.gitbook.io/server/in-development/developer-area/repositories
+ */
+
+#ifndef EQEMU_BASE_CHARACTER_TRIBUTE_REPOSITORY_H
+#define EQEMU_BASE_CHARACTER_TRIBUTE_REPOSITORY_H
+
+#include "../../database.h"
+#include "../../strings.h"
+#include <ctime>
+
+
+class BaseCharacterTributeRepository {
+public:
+	struct CharacterTribute {
+		int32_t  id;
+		uint32_t character_id;
+		uint8_t  tier;
+		uint32_t tribute;
+	};
+
+	static std::string PrimaryKey()
+	{
+		return std::string("id");
+	}
+
+	static std::vector<std::string> Columns()
+	{
+		return {
+			"id",
+			"character_id",
+			"tier",
+			"tribute",
+		};
+	}
+
+	static std::vector<std::string> SelectColumns()
+	{
+		return {
+			"id",
+			"character_id",
+			"tier",
+			"tribute",
+		};
+	}
+
+	static std::string ColumnsRaw()
+	{
+		return std::string(Strings::Implode(", ", Columns()));
+	}
+
+	static std::string SelectColumnsRaw()
+	{
+		return std::string(Strings::Implode(", ", SelectColumns()));
+	}
+
+	static std::string TableName()
+	{
+		return std::string("character_tribute");
+	}
+
+	static std::string BaseSelect()
+	{
+		return fmt::format(
+			"SELECT {} FROM {}",
+			SelectColumnsRaw(),
+			TableName()
+		);
+	}
+
+	static std::string BaseInsert()
+	{
+		return fmt::format(
+			"INSERT INTO {} ({}) ",
+			TableName(),
+			ColumnsRaw()
+		);
+	}
+
+	static CharacterTribute NewEntity()
+	{
+		CharacterTribute e{};
+
+		e.id           = 0;
+		e.character_id = 0;
+		e.tier         = 0;
+		e.tribute      = 0;
+
+		return e;
+	}
+
+	static CharacterTribute GetCharacterTribute(
+		const std::vector<CharacterTribute> &character_tributes,
+		int character_tribute_id
+	)
+	{
+		for (auto &character_tribute : character_tributes) {
+			if (character_tribute.id == character_tribute_id) {
+				return character_tribute;
+			}
+		}
+
+		return NewEntity();
+	}
+
+	static CharacterTribute FindOne(
+		Database& db,
+		int character_tribute_id
+	)
+	{
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} WHERE {} = {} LIMIT 1",
+				BaseSelect(),
+				PrimaryKey(),
+				character_tribute_id
+			)
+		);
+
+		auto row = results.begin();
+		if (results.RowCount() == 1) {
+			CharacterTribute e{};
+
+			e.id           = static_cast<int32_t>(atoi(row[0]));
+			e.character_id = static_cast<uint32_t>(strtoul(row[1], nullptr, 10));
+			e.tier         = static_cast<uint8_t>(strtoul(row[2], nullptr, 10));
+			e.tribute      = static_cast<uint32_t>(strtoul(row[3], nullptr, 10));
+
+			return e;
+		}
+
+		return NewEntity();
+	}
+
+	static int DeleteOne(
+		Database& db,
+		int character_tribute_id
+	)
+	{
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"DELETE FROM {} WHERE {} = {}",
+				TableName(),
+				PrimaryKey(),
+				character_tribute_id
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
+
+	static int UpdateOne(
+		Database& db,
+		const CharacterTribute &e
+	)
+	{
+		std::vector<std::string> v;
+
+		auto columns = Columns();
+
+		v.push_back(columns[1] + " = " + std::to_string(e.character_id));
+		v.push_back(columns[2] + " = " + std::to_string(e.tier));
+		v.push_back(columns[3] + " = " + std::to_string(e.tribute));
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"UPDATE {} SET {} WHERE {} = {}",
+				TableName(),
+				Strings::Implode(", ", v),
+				PrimaryKey(),
+				e.id
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
+
+	static CharacterTribute InsertOne(
+		Database& db,
+		CharacterTribute e
+	)
+	{
+		std::vector<std::string> v;
+
+		v.push_back(std::to_string(e.id));
+		v.push_back(std::to_string(e.character_id));
+		v.push_back(std::to_string(e.tier));
+		v.push_back(std::to_string(e.tribute));
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} VALUES ({})",
+				BaseInsert(),
+				Strings::Implode(",", v)
+			)
+		);
+
+		if (results.Success()) {
+			e.id = results.LastInsertedID();
+			return e;
+		}
+
+		e = NewEntity();
+
+		return e;
+	}
+
+	static int InsertMany(
+		Database& db,
+		const std::vector<CharacterTribute> &entries
+	)
+	{
+		std::vector<std::string> insert_chunks;
+
+		for (auto &e: entries) {
+			std::vector<std::string> v;
+
+			v.push_back(std::to_string(e.id));
+			v.push_back(std::to_string(e.character_id));
+			v.push_back(std::to_string(e.tier));
+			v.push_back(std::to_string(e.tribute));
+
+			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
+		}
+
+		std::vector<std::string> v;
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} VALUES {}",
+				BaseInsert(),
+				Strings::Implode(",", insert_chunks)
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
+
+	static std::vector<CharacterTribute> All(Database& db)
+	{
+		std::vector<CharacterTribute> all_entries;
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{}",
+				BaseSelect()
+			)
+		);
+
+		all_entries.reserve(results.RowCount());
+
+		for (auto row = results.begin(); row != results.end(); ++row) {
+			CharacterTribute e{};
+
+			e.id           = static_cast<int32_t>(atoi(row[0]));
+			e.character_id = static_cast<uint32_t>(strtoul(row[1], nullptr, 10));
+			e.tier         = static_cast<uint8_t>(strtoul(row[2], nullptr, 10));
+			e.tribute      = static_cast<uint32_t>(strtoul(row[3], nullptr, 10));
+
+			all_entries.push_back(e);
+		}
+
+		return all_entries;
+	}
+
+	static std::vector<CharacterTribute> GetWhere(Database& db, const std::string &where_filter)
+	{
+		std::vector<CharacterTribute> all_entries;
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} WHERE {}",
+				BaseSelect(),
+				where_filter
+			)
+		);
+
+		all_entries.reserve(results.RowCount());
+
+		for (auto row = results.begin(); row != results.end(); ++row) {
+			CharacterTribute e{};
+
+			e.id           = static_cast<int32_t>(atoi(row[0]));
+			e.character_id = static_cast<uint32_t>(strtoul(row[1], nullptr, 10));
+			e.tier         = static_cast<uint8_t>(strtoul(row[2], nullptr, 10));
+			e.tribute      = static_cast<uint32_t>(strtoul(row[3], nullptr, 10));
+
+			all_entries.push_back(e);
+		}
+
+		return all_entries;
+	}
+
+	static int DeleteWhere(Database& db, const std::string &where_filter)
+	{
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"DELETE FROM {} WHERE {}",
+				TableName(),
+				where_filter
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
+
+	static int Truncate(Database& db)
+	{
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"TRUNCATE TABLE {}",
+				TableName()
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
+
+	static int64 GetMaxId(Database& db)
+	{
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"SELECT COALESCE(MAX({}), 0) FROM {}",
+				PrimaryKey(),
+				TableName()
+			)
+		);
+
+		return (results.Success() && results.begin()[0] ? strtoll(results.begin()[0], nullptr, 10) : 0);
+	}
+
+	static int64 Count(Database& db, const std::string &where_filter = "")
+	{
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"SELECT COUNT(*) FROM {} {}",
+				TableName(),
+				(where_filter.empty() ? "" : "WHERE " + where_filter)
+			)
+		);
+
+		return (results.Success() && results.begin()[0] ? strtoll(results.begin()[0], nullptr, 10) : 0);
+	}
+
+};
+
+#endif //EQEMU_BASE_CHARACTER_TRIBUTE_REPOSITORY_H

--- a/common/repositories/character_tribute_repository.h
+++ b/common/repositories/character_tribute_repository.h
@@ -1,0 +1,50 @@
+#ifndef EQEMU_CHARACTER_TRIBUTE_REPOSITORY_H
+#define EQEMU_CHARACTER_TRIBUTE_REPOSITORY_H
+
+#include "../database.h"
+#include "../strings.h"
+#include "base/base_character_tribute_repository.h"
+
+class CharacterTributeRepository: public BaseCharacterTributeRepository {
+public:
+
+    /**
+     * This file was auto generated and can be modified and extended upon
+     *
+     * Base repository methods are automatically
+     * generated in the "base" version of this repository. The base repository
+     * is immutable and to be left untouched, while methods in this class
+     * are used as extension methods for more specific persistence-layer
+     * accessors or mutators.
+     *
+     * Base Methods (Subject to be expanded upon in time)
+     *
+     * Note: Not all tables are designed appropriately to fit functionality with all base methods
+     *
+     * InsertOne
+     * UpdateOne
+     * DeleteOne
+     * FindOne
+     * GetWhere(std::string where_filter)
+     * DeleteWhere(std::string where_filter)
+     * InsertMany
+     * All
+     *
+     * Example custom methods in a repository
+     *
+     * CharacterTributeRepository::GetByZoneAndVersion(int zone_id, int zone_version)
+     * CharacterTributeRepository::GetWhereNeverExpires()
+     * CharacterTributeRepository::GetWhereXAndY()
+     * CharacterTributeRepository::DeleteWhereXAndY()
+     *
+     * Most of the above could be covered by base methods, but if you as a developer
+     * find yourself re-using logic for other parts of the code, its best to just make a
+     * method that can be re-used easily elsewhere especially if it can use a base repository
+     * method and encapsulate filters there
+     */
+
+	// Custom extended repository methods here
+
+};
+
+#endif //EQEMU_CHARACTER_TRIBUTE_REPOSITORY_H

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9227
+#define CURRENT_BINARY_DATABASE_VERSION 9228
 
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9039
 

--- a/utils/sql/db_update_manifest.txt
+++ b/utils/sql/db_update_manifest.txt
@@ -481,6 +481,7 @@
 9225|2023_01_21_bots_raid_members.sql|SHOW COLUMNS FROM `raid_members` LIKE 'bot_id'|empty|
 9226|2023_03_17_corpse_fields.sql|SHOW COLUMNS FROM `character_corpse_items` LIKE 'custom_data'|empty|
 9227|2023_03_24_npc_scale_global_base_verify.sql|SHOW COLUMNS FROM `npc_scale_global_base` LIKE 'heroic_strikethrough'|not_empty|
+9228|2023_05_08_character_tribute_primary_key.sql|SHOW COLUMNS FROM `character_tribute` LIKE 'character_id'|empty|
 
 # Upgrade conditions:
 # 	This won't be needed after this system is implemented, but it is used database that are not

--- a/utils/sql/git/required/2023_05_08_character_tribute_primary_key.sql
+++ b/utils/sql/git/required/2023_05_08_character_tribute_primary_key.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `character_tribute` 
+CHANGE COLUMN `id` `character_id` int(11) UNSIGNED NOT NULL DEFAULT 0,
+ADD COLUMN `id` int(11) NOT NULL AUTO_INCREMENT FIRST,
+ADD PRIMARY KEY (`id`);

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -713,7 +713,7 @@ bool Client::Save(uint8 iCommitNow) {
 
 	p_timers.Store(&database);
 
-	database.SaveCharacterTribute(CharacterID(), &m_pp);
+	database.SaveCharacterTribute(this);
 	SaveTaskState(); /* Save Character Task */
 
 	LogFood("Client::Save - hunger_level: [{}] thirst_level: [{}]", m_pp.hunger_level, m_pp.thirst_level);

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1265,7 +1265,7 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 	database.LoadCharacterDisciplines(cid, &m_pp); /* Load Character Disciplines */
 	database.LoadCharacterLanguages(cid, &m_pp); /* Load Character Languages */
 	database.LoadCharacterLeadershipAA(cid, &m_pp); /* Load Character Leadership AA's */
-	database.LoadCharacterTribute(cid, &m_pp); /* Load CharacterTribute */
+	database.LoadCharacterTribute(this); /* Load CharacterTribute */
 
 	/* Load AdventureStats */
 	AdventureStats_Struct as;

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -970,7 +970,7 @@ void ZoneDatabase::LoadCharacterTribute(Client* c){
 	auto i = 0;
 
 	for (const auto& e : l) {
-		if (e.tribute != TRIBUTE_NONE){
+		if (e.tribute != TRIBUTE_NONE) {
 			c->GetPP().tributes[i].tier    = e.tier;
 			c->GetPP().tributes[i].tribute = e.tribute;
 			i++;

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -1083,9 +1083,9 @@ void ZoneDatabase::SaveCharacterTribute(Client* c)
 		}
 	}
 
-	if (tribute_count > 0) {
-		CharacterTributeRepository::DeleteWhere(database, fmt::format("character_id = {}", c->CharacterID()));
+	CharacterTributeRepository::DeleteWhere(database, fmt::format("character_id = {}", c->CharacterID()));
 
+	if (tribute_count > 0) {
 		CharacterTributeRepository::InsertMany(database, tributes);
 	}
 }

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -11,6 +11,7 @@
 #include "zone.h"
 #include "zonedb.h"
 #include "aura.h"
+#include "../common/repositories/character_tribute_repository.h"
 #include "../common/repositories/character_disciplines_repository.h"
 #include "../common/repositories/npc_types_repository.h"
 
@@ -953,23 +954,23 @@ bool ZoneDatabase::LoadCharacterBandolier(uint32 character_id, PlayerProfile_Str
 	return true;
 }
 
-bool ZoneDatabase::LoadCharacterTribute(uint32 character_id, PlayerProfile_Struct* pp){
-	std::string query = StringFormat("SELECT `tier`, `tribute` FROM `character_tribute` WHERE `id` = %u", character_id);
-	auto results = database.QueryDatabase(query);
-	int i = 0;
-	for (i = 0; i < EQ::invtype::TRIBUTE_SIZE; i++){
-		pp->tributes[i].tribute = 0xFFFFFFFF;
-		pp->tributes[i].tier = 0;
+void ZoneDatabase::LoadCharacterTribute(Client* c){
+	const auto& l = CharacterTributeRepository::GetWhere(database, fmt::format("character_id = {}", c->CharacterID()));
+
+	for (auto& t : c->GetPP().tributes) {
+		t.tier    = 0;
+		t.tribute = TRIBUTE_NONE;
 	}
-	i = 0;
-	for (auto& row = results.begin(); row != results.end(); ++row) {
-		if(Strings::ToInt(row[1]) != TRIBUTE_NONE){
-			pp->tributes[i].tier = Strings::ToInt(row[0]);
-			pp->tributes[i].tribute = Strings::ToInt(row[1]);
+
+	auto i = 0;
+
+	for (const auto& e : l) {
+		if (e.tribute != TRIBUTE_NONE){
+			c->GetPP().tributes[i].tier    = e.tier;
+			c->GetPP().tributes[i].tribute = e.tribute;
 			i++;
 		}
 	}
-	return true;
 }
 
 bool ZoneDatabase::LoadCharacterPotions(uint32 character_id, PlayerProfile_Struct *pp)
@@ -1072,18 +1073,35 @@ bool ZoneDatabase::SaveCharacterDisc(uint32 character_id, uint32 slot_id, uint32
 	return true;
 }
 
-bool ZoneDatabase::SaveCharacterTribute(uint32 character_id, PlayerProfile_Struct* pp){
-	std::string query = StringFormat("DELETE FROM `character_tribute` WHERE `id` = %u", character_id);
-	QueryDatabase(query);
-	/* Save Tributes only if we have values... */
-	for (int i = 0; i < EQ::invtype::TRIBUTE_SIZE; i++){
-		if (pp->tributes[i].tribute >= 0 && pp->tributes[i].tribute != TRIBUTE_NONE){
-			std::string query = StringFormat("REPLACE INTO `character_tribute` (id, tier, tribute) VALUES (%u, %u, %u)", character_id, pp->tributes[i].tier, pp->tributes[i].tribute);
-			QueryDatabase(query);
-			LogDebug("ZoneDatabase::SaveCharacterTribute for character ID: [{}], tier:[{}] tribute:[{}] done", character_id, pp->tributes[i].tier, pp->tributes[i].tribute);
+void ZoneDatabase::SaveCharacterTribute(Client* c)
+{
+	std::vector<CharacterTributeRepository::CharacterTribute> tributes = {};
+	CharacterTributeRepository::CharacterTribute tribute = {};
+
+	uint32 tribute_count = 0;
+	for (auto& t : c->GetPP().tributes) {
+		if (t.tribute != TRIBUTE_NONE) {
+			tribute_count++;
 		}
 	}
-	return true;
+
+	tributes.reserve(tribute_count);
+
+	for (auto& t : c->GetPP().tributes) {
+		if (t.tribute != TRIBUTE_NONE) {
+			tribute.character_id = c->CharacterID();
+			tribute.tier         = t.tier;
+			tribute.tribute      = t.tribute;
+
+			tributes.emplace_back(tribute);
+		}
+	}
+
+	if (tribute_count > 0) {
+		CharacterTributeRepository::DeleteWhere(database, fmt::format("character_id = {}", c->CharacterID()));
+
+		CharacterTributeRepository::InsertMany(database, tributes);
+	}
 }
 
 bool ZoneDatabase::SaveCharacterBandolier(uint32 character_id, uint8 bandolier_id, uint8 bandolier_slot, uint32 item_id, uint32 icon, const char* bandolier_name)

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -304,7 +304,7 @@ struct CharacterCorpseItemEntry
 	uint32 ornament_hero_model;
 };
 
-struct CharacterCorpseEntry 
+struct CharacterCorpseEntry
 {
 	bool locked;
 	uint32 exp;
@@ -442,7 +442,6 @@ public:
 	bool LoadCharacterPotions(uint32 character_id, PlayerProfile_Struct* pp);
 	bool LoadCharacterSkills(uint32 character_id, PlayerProfile_Struct* pp);
 	bool LoadCharacterSpellBook(uint32 character_id, PlayerProfile_Struct* pp);
-	bool LoadCharacterTribute(uint32 character_id, PlayerProfile_Struct* pp);
 
 	bool SaveCharacterAA(uint32 character_id, uint32 aa_id, uint32 current_level, uint32 charges);
 	bool SaveCharacterBandolier(uint32 character_id, uint8 bandolier_id, uint8 bandolier_slot, uint32 item_id, uint32 icon, const char* bandolier_name);
@@ -457,7 +456,6 @@ public:
 	bool SaveCharacterPotionBelt(uint32 character_id, uint8 potion_id, uint32 item_id, uint32 icon);
 	bool SaveCharacterSkill(uint32 character_id, uint32 skill_id, uint32 value);
 	bool SaveCharacterSpell(uint32 character_id, uint32 spell_id, uint32 slot_id);
-	bool SaveCharacterTribute(uint32 character_id, PlayerProfile_Struct* pp);
 
 	double GetAAEXPModifier(uint32 character_id, uint32 zone_id, int16 instance_version = -1) const;
 	double GetEXPModifier(uint32 character_id, uint32 zone_id, int16 instance_version = -1) const;
@@ -665,6 +663,9 @@ public:
 
 	// bot database add-on to eliminate the need for a second database connection
 	BotDatabase botdb;
+
+	static void LoadCharacterTribute(Client* c);
+	static void SaveCharacterTribute(Client* c);
 
 protected:
 	void ZDBInitVars();


### PR DESCRIPTION
This pull request combines individual `character_tribute` queries during `Save()` into one.

This pull request also adds a primary key of `id` to `character_tribute` and renames the pre-existing `id` column to `character_id`, this allows us to use repositories for this table.

![image](https://github.com/EQEmu/Server/assets/89047260/37e58a2f-42aa-4106-9287-33f48a3a2e17)