### PR TITLE
[Bug Fix] Fix Heroic INT/WIS Bonuses

### DIFF
--- a/common/classes.cpp
+++ b/common/classes.cpp
@@ -633,14 +633,14 @@ bool IsINTCasterClass(uint8 class_id)
 bool IsHeroicINTCasterClass(uint8 class_id)
 {
 	switch (class_id) {
-	case NECROMANCER:
-	case WIZARD:
-	case MAGICIAN:
-	case ENCHANTER:
-	case SHADOWKNIGHT:
-		return true;
-	default:
-		return false;
+		case NECROMANCER:
+		case WIZARD:
+		case MAGICIAN:
+		case ENCHANTER:
+		case SHADOWKNIGHT:
+			return true;
+		default:
+			return false;
 	}
 }
 
@@ -659,15 +659,15 @@ bool IsWISCasterClass(uint8 class_id)
 bool IsHeroicWISCasterClass(uint8 class_id)
 {
 	switch (class_id) {
-	case CLERIC:
-	case DRUID:
-	case SHAMAN:
-	case PALADIN:
-	case BEASTLORD:
-	case RANGER:
-		return true;
-	default:
-		return false;
+		case CLERIC:
+		case DRUID:
+		case SHAMAN:
+		case PALADIN:
+		case BEASTLORD:
+		case RANGER:
+			return true;
+		default:
+			return false;
 	}
 }
 

--- a/common/classes.cpp
+++ b/common/classes.cpp
@@ -629,6 +629,7 @@ bool IsINTCasterClass(uint8 class_id)
 			return false;
 	}
 }
+
 bool IsHeroicINTCasterClass(uint8 class_id)
 {
 	switch (class_id) {
@@ -654,6 +655,7 @@ bool IsWISCasterClass(uint8 class_id)
 			return false;
 	}
 }
+
 bool IsHeroicWISCasterClass(uint8 class_id)
 {
 	switch (class_id) {
@@ -668,6 +670,7 @@ bool IsHeroicWISCasterClass(uint8 class_id)
 		return false;
 	}
 }
+
 bool IsPlateClass(uint8 class_id)
 {
 	switch (class_id) {

--- a/common/classes.cpp
+++ b/common/classes.cpp
@@ -629,6 +629,19 @@ bool IsINTCasterClass(uint8 class_id)
 			return false;
 	}
 }
+bool IsHeroicINTCasterClass(uint8 class_id)
+{
+	switch (class_id) {
+	case NECROMANCER:
+	case WIZARD:
+	case MAGICIAN:
+	case ENCHANTER:
+	case SHADOWKNIGHT:
+		return true;
+	default:
+		return false;
+	}
+}
 
 bool IsWISCasterClass(uint8 class_id)
 {
@@ -641,7 +654,20 @@ bool IsWISCasterClass(uint8 class_id)
 			return false;
 	}
 }
-
+bool IsHeroicWISCasterClass(uint8 class_id)
+{
+	switch (class_id) {
+	case CLERIC:
+	case DRUID:
+	case SHAMAN:
+	case PALADIN:
+	case BEASTLORD:
+	case RANGER:
+		return true;
+	default:
+		return false;
+	}
+}
 bool IsPlateClass(uint8 class_id)
 {
 	switch (class_id) {

--- a/common/classes.h
+++ b/common/classes.h
@@ -140,7 +140,8 @@ bool IsHybridClass(uint8 class_id);
 bool IsCasterClass(uint8 class_id);
 bool IsINTCasterClass(uint8 class_id);
 bool IsWISCasterClass(uint8 class_id);
-
+bool IsHeroicINTCasterClass(uint8 class_id);
+bool IsHeroicWISCasterClass(uint8 class_id);
 bool IsPlateClass(uint8 class_id);
 bool IsChainClass(uint8 class_id);
 bool IsLeatherClass(uint8 class_id);

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -5948,26 +5948,26 @@ void Mob::CalcHeroicBonuses(StatBonuses* newbon)
 
 void Mob::SetHeroicWisBonuses(StatBonuses* n)
 {
-	n->heroic_max_mana += IsWISCasterClass(GetClass()) ? GetHeroicWIS() * RuleR(Character, HeroicWisdomMultiplier) * 10 : 0;
-	n->heroic_mana_regen += IsWISCasterClass(GetClass()) ? GetHeroicWIS() * RuleR(Character, HeroicWisdomMultiplier) / 25 : 0;
+	n->heroic_max_mana += IsHeroicWISCasterClass(GetClass()) ? GetHeroicWIS() * RuleR(Character, HeroicWisdomMultiplier) * 10 : 0;
+	n->heroic_mana_regen += IsHeroicWISCasterClass(GetClass()) ? GetHeroicWIS() * RuleR(Character, HeroicWisdomMultiplier) / 25 : 0;
 	n->HealAmt += GetHeroicWIS() * RuleR(Character, HeroicWisdomIncreaseHealAmtMultiplier);
 
 	if (RuleB(Character, HeroicStatsUseDataBucketsToScale)) {
-		n->heroic_max_mana += IsWISCasterClass(GetClass()) ? GetHeroicWIS() * CheckHeroicBonusesDataBuckets(HeroicBonusBucket::WisMaxMana) * 10 : 0;
-		n->heroic_mana_regen += IsWISCasterClass(GetClass()) ? GetHeroicWIS() * CheckHeroicBonusesDataBuckets(HeroicBonusBucket::WisManaRegen) / 25 : 0;
+		n->heroic_max_mana += IsHeroicWISCasterClass(GetClass()) ? GetHeroicWIS() * CheckHeroicBonusesDataBuckets(HeroicBonusBucket::WisMaxMana) * 10 : 0;
+		n->heroic_mana_regen += IsHeroicWISCasterClass(GetClass()) ? GetHeroicWIS() * CheckHeroicBonusesDataBuckets(HeroicBonusBucket::WisManaRegen) / 25 : 0;
 		n->HealAmt += GetHeroicWIS() * CheckHeroicBonusesDataBuckets(HeroicBonusBucket::WisHealAmt);
 	}
 }
 
 void Mob::SetHeroicIntBonuses(StatBonuses* n)
 {
-	n->heroic_max_mana += IsINTCasterClass(GetClass()) ? GetHeroicINT() * RuleR(Character, HeroicIntelligenceMultiplier) * 10 : 0;
-	n->heroic_mana_regen += IsINTCasterClass(GetClass()) ? GetHeroicINT() * RuleR(Character, HeroicIntelligenceMultiplier) / 25 : 0;
+	n->heroic_max_mana += IsHeroicINTCasterClass(GetClass()) ? GetHeroicINT() * RuleR(Character, HeroicIntelligenceMultiplier) * 10 : 0;
+	n->heroic_mana_regen += IsHeroicINTCasterClass(GetClass()) ? GetHeroicINT() * RuleR(Character, HeroicIntelligenceMultiplier) / 25 : 0;
 	n->SpellDmg += GetHeroicINT() * RuleR(Character, HeroicIntelligenceIncreaseSpellDmgMultiplier);
 
 	if (RuleB(Character, HeroicStatsUseDataBucketsToScale)) {
-		n->heroic_max_mana += IsINTCasterClass(GetClass()) ? GetHeroicINT() * CheckHeroicBonusesDataBuckets(HeroicBonusBucket::IntMaxMana) * 10 : 0;
-		n->heroic_mana_regen += IsINTCasterClass(GetClass()) ? GetHeroicINT() * CheckHeroicBonusesDataBuckets(HeroicBonusBucket::IntManaRegen) / 25 : 0;
+		n->heroic_max_mana += IsHeroicINTCasterClass(GetClass()) ? GetHeroicINT() * CheckHeroicBonusesDataBuckets(HeroicBonusBucket::IntMaxMana) * 10 : 0;
+		n->heroic_mana_regen += IsHeroicINTCasterClass(GetClass()) ? GetHeroicINT() * CheckHeroicBonusesDataBuckets(HeroicBonusBucket::IntManaRegen) / 25 : 0;
 		n->SpellDmg += GetHeroicINT() * CheckHeroicBonusesDataBuckets(HeroicBonusBucket::IntSpellDmg);
 	}
 }


### PR DESCRIPTION
So users on Retribution server were complaining about their manastones actually reducing mana from max mana, and basically capping  quite a bit under their real max mana. I traced it down to the patch done about 2 months ago on heroic stat changes. I made these modifications to correct it and seems to work fine. This seems to have only impacted Pal/SK/Ranger/Beastlord. 
Made new Is Checks to make sure I didn't impact logic that is located in other places. 