### PR TITLE
[Quest API] Add zone data methods to Perl/Lua

### DIFF
--- a/common/zone_store.cpp
+++ b/common/zone_store.cpp
@@ -18,6 +18,29 @@
  *
  */
 
+#define DEFAULT_MINIMUM_CLIP 50.0f
+#define DEFAULT_MAXIMUM_CLIP 175.0f
+#define DEFAULT_ZONE_FAST_REGEN 180
+#define DEFAULT_ZONE_GRAVITY 0.4f
+#define DEFAULT_ZONE_MIN_MAX_EXPANSION -1
+#define DEFAULT_ZONE_MAX_AGGRO_DISTANCE 600
+#define DEFAULT_ZONE_MAX_MOVEMENT_UPDATE_RANGE 600
+#define DEFAULT_ZONE_RUNSPEED 0.4f
+#define DEFAULT_ZONE_SHUTDOWN_DELAY 3600000
+#define DEFAULT_ZONE_TYPE 1
+#define FOG_SLOT_ONE 1
+#define FOG_SLOT_TWO 2
+#define FOG_SLOT_THREE 3
+#define FOG_SLOT_FOUR 4
+#define RAIN_SLOT_ONE 1
+#define RAIN_SLOT_TWO 2
+#define RAIN_SLOT_THREE 3
+#define RAIN_SLOT_FOUR 4
+#define SNOW_SLOT_ONE 1
+#define SNOW_SLOT_TWO 2
+#define SNOW_SLOT_THREE 3
+#define SNOW_SLOT_FOUR 4
+
 #include "zone_store.h"
 #include "../common/content/world_content_service.h"
 #include "stacktrace/backward.hpp"
@@ -209,4 +232,1116 @@ ZoneRepository::Zone *ZoneStore::GetZoneWithFallback(uint32 zone_id, int version
 	LogInfo("Failed to get zone by zone_id [{}] version [{}]", zone_id, version);
 
 	return nullptr;
+}
+
+glm::vec4 ZoneStore::GetZoneSafeCoordinates(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return glm::vec4(z.safe_x, z.safe_y, z.safe_z, z.safe_heading);
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return glm::vec4(z.safe_x, z.safe_y, z.safe_z, z.safe_heading);
+		}
+	}
+
+	return glm::vec4(0.f);
+}
+
+float ZoneStore::GetZoneGraveyardID(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.graveyard_id;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.graveyard_id;
+		}
+	}
+
+	return 0;
+}
+
+uint8 ZoneStore::GetZoneMinimumLevel(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.min_level;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.min_level;
+		}
+	}
+
+	return 0;
+}
+
+uint8 ZoneStore::GetZoneMaximumLevel(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.max_level;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.max_level;
+		}
+	}
+
+	return UINT8_MAX;
+}
+
+uint8 ZoneStore::GetZoneMinimumStatus(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.min_status;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.min_status;
+		}
+	}
+
+	return 0;
+}
+
+int ZoneStore::GetZoneTimeZone(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.min_status;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.min_status;
+		}
+	}
+
+	return 0;
+}
+
+int ZoneStore::GetZoneMaximumPlayers(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.maxclients;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.maxclients;
+		}
+	}
+
+	return 0;
+}
+
+uint32 ZoneStore::GetZoneRuleSet(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.ruleset;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.ruleset;
+		}
+	}
+
+	return 0;
+}
+
+const std::string& ZoneStore::GetZoneNote(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.note;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.note;
+		}
+	}
+
+	const auto& note = std::string();
+	return note;
+}
+
+float ZoneStore::GetZoneUnderworld(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.underworld;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.underworld;
+		}
+	}
+
+	return 0.0f;
+}
+
+float ZoneStore::GetZoneMinimumClip(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.minclip;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.minclip;
+		}
+	}
+
+	return DEFAULT_MINIMUM_CLIP;
+}
+
+float ZoneStore::GetZoneMaximumClip(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.maxclip;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.maxclip;
+		}
+	}
+
+	return DEFAULT_MAXIMUM_CLIP;
+}
+
+float ZoneStore::GetZoneFogMinimumClip(uint32 zone_id, uint8 slot, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			switch (slot) {
+				case FOG_SLOT_ONE:
+					return z.fog_minclip1;
+				case FOG_SLOT_TWO:
+					return z.fog_minclip2;
+				case FOG_SLOT_THREE:
+					return z.fog_minclip3;
+				case FOG_SLOT_FOUR:
+					return z.fog_minclip4;
+				default:
+					return z.fog_minclip;
+			}
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			switch (slot) {
+				case FOG_SLOT_ONE:
+					return z.fog_minclip1;
+				case FOG_SLOT_TWO:
+					return z.fog_minclip2;
+				case FOG_SLOT_THREE:
+					return z.fog_minclip3;
+				case FOG_SLOT_FOUR:
+					return z.fog_minclip4;
+				default:
+					return z.fog_minclip;
+			}
+		}
+	}
+
+	return DEFAULT_MINIMUM_CLIP;
+}
+
+float ZoneStore::GetZoneFogMaximumClip(uint32 zone_id, uint8 slot, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			switch (slot) {
+				case FOG_SLOT_ONE:
+					return z.fog_maxclip1;
+				case FOG_SLOT_TWO:
+					return z.fog_maxclip2;
+				case FOG_SLOT_THREE:
+					return z.fog_maxclip3;
+				case FOG_SLOT_FOUR:
+					return z.fog_maxclip4;
+				default:
+					return z.fog_maxclip;
+			}
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			switch (slot) {
+				case FOG_SLOT_ONE:
+					return z.fog_maxclip1;
+				case FOG_SLOT_TWO:
+					return z.fog_maxclip2;
+				case FOG_SLOT_THREE:
+					return z.fog_maxclip3;
+				case FOG_SLOT_FOUR:
+					return z.fog_maxclip4;
+				default:
+					return z.fog_maxclip;
+			}
+		}
+	}
+
+	return DEFAULT_MAXIMUM_CLIP;
+}
+
+uint8 ZoneStore::GetZoneFogRed(uint32 zone_id, uint8 slot, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			switch (slot) {
+				case FOG_SLOT_ONE:
+					return z.fog_red1;
+				case FOG_SLOT_TWO:
+					return z.fog_red2;
+				case FOG_SLOT_THREE:
+					return z.fog_red3;
+				case FOG_SLOT_FOUR:
+					return z.fog_red4;
+				default:
+					return z.fog_red;
+			}
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			switch (slot) {
+				case FOG_SLOT_ONE:
+					return z.fog_red1;
+				case FOG_SLOT_TWO:
+					return z.fog_red2;
+				case FOG_SLOT_THREE:
+					return z.fog_red3;
+				case FOG_SLOT_FOUR:
+					return z.fog_red4;
+				default:
+					return z.fog_red;
+			}
+		}
+	}
+
+	return 0;
+}
+
+uint8 ZoneStore::GetZoneFogGreen(uint32 zone_id, uint8 slot, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			switch (slot) {
+				case FOG_SLOT_ONE:
+					return z.fog_green1;
+				case FOG_SLOT_TWO:
+					return z.fog_green2;
+				case FOG_SLOT_THREE:
+					return z.fog_green3;
+				case FOG_SLOT_FOUR:
+					return z.fog_green4;
+				default:
+					return z.fog_green;
+			}
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			switch (slot) {
+				case FOG_SLOT_ONE:
+					return z.fog_green1;
+				case FOG_SLOT_TWO:
+					return z.fog_green2;
+				case FOG_SLOT_THREE:
+					return z.fog_green3;
+				case FOG_SLOT_FOUR:
+					return z.fog_green4;
+				default:
+					return z.fog_green;
+			}
+		}
+	}
+
+	return 0;
+}
+
+uint8 ZoneStore::GetZoneFogBlue(uint32 zone_id, uint8 slot, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			switch (slot) {
+				case FOG_SLOT_ONE:
+					return z.fog_blue1;
+				case FOG_SLOT_TWO:
+					return z.fog_blue2;
+				case FOG_SLOT_THREE:
+					return z.fog_blue3;
+				case FOG_SLOT_FOUR:
+					return z.fog_blue4;
+				default:
+					return z.fog_blue;
+			}
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			switch (slot) {
+				case FOG_SLOT_ONE:
+					return z.fog_blue1;
+				case FOG_SLOT_TWO:
+					return z.fog_blue2;
+				case FOG_SLOT_THREE:
+					return z.fog_blue3;
+				case FOG_SLOT_FOUR:
+					return z.fog_blue4;
+				default:
+					return z.fog_blue;
+			}
+		}
+	}
+
+	return 0;
+}
+
+uint8 ZoneStore::GetZoneSky(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.sky;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.sky;
+		}
+	}
+
+	return 0;
+}
+
+uint8 ZoneStore::GetZoneZType(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.ztype;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.ztype;
+		}
+	}
+
+	return 0;
+}
+
+float ZoneStore::GetZoneExperienceMultiplier(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.zone_exp_multiplier;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.zone_exp_multiplier;
+		}
+	}
+
+	return 1.0f;
+}
+
+float ZoneStore::GetZoneWalkSpeed(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.walkspeed;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.walkspeed;
+		}
+	}
+
+	return DEFAULT_ZONE_RUNSPEED;
+}
+
+uint8 ZoneStore::GetZoneTimeType(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.time_type;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.time_type;
+		}
+	}
+
+	return 0;
+}
+
+float ZoneStore::GetZoneFogDensity(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.fog_density;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.fog_density;
+		}
+	}
+
+	return 0.0f;
+}
+
+const std::string& ZoneStore::GetZoneFlagNeeded(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.flag_needed;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.flag_needed;
+		}
+	}
+
+	const auto& flag_needed = std::string();
+	return flag_needed;
+}
+
+int8 ZoneStore::GetZoneCanBind(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.canbind;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.canbind;
+		}
+	}
+
+	return 0;
+}
+
+int8 ZoneStore::GetZoneCanCombat(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.cancombat;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.cancombat;
+		}
+	}
+
+	return 0;
+}
+
+int8 ZoneStore::GetZoneCanLevitate(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.canlevitate;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.canlevitate;
+		}
+	}
+
+	return 0;
+}
+
+int8 ZoneStore::GetZoneCastOutdoor(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.castoutdoor;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.castoutdoor;
+		}
+	}
+
+	return 0;
+}
+
+uint8 ZoneStore::GetZoneHotzone(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.hotzone;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.hotzone;
+		}
+	}
+
+	return 0;
+}
+
+uint8 ZoneStore::GetZoneInstanceType(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.insttype;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.insttype;
+		}
+	}
+
+	return 0;
+}
+
+uint64 ZoneStore::GetZoneShutdownDelay(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.shutdowndelay;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.shutdowndelay;
+		}
+	}
+
+	return DEFAULT_ZONE_SHUTDOWN_DELAY;
+}
+
+int8 ZoneStore::GetZonePEQZone(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.peqzone;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.peqzone;
+		}
+	}
+
+	return 0;
+}
+
+int8 ZoneStore::GetZoneExpansion(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.expansion;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.expansion;
+		}
+	}
+
+	return 0;
+}
+
+int8 ZoneStore::GetZoneBypassExpansionCheck(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.bypass_expansion_check;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.bypass_expansion_check;
+		}
+	}
+
+	return 0;
+}
+
+uint8 ZoneStore::GetZoneSuspendBuffs(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.suspendbuffs;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.suspendbuffs;
+		}
+	}
+
+	return 0;
+}
+
+int ZoneStore::GetZoneRainChance(uint32 zone_id, uint8 slot, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			switch (slot) {
+				case RAIN_SLOT_TWO:
+					return z.rain_chance2;
+				case RAIN_SLOT_THREE:
+					return z.rain_chance3;
+				case RAIN_SLOT_FOUR:
+					return z.rain_chance4;
+				case RAIN_SLOT_ONE:
+				default:
+					return z.rain_chance1;
+			}
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			switch (slot) {
+				case RAIN_SLOT_TWO:
+					return z.rain_chance2;
+				case RAIN_SLOT_THREE:
+					return z.rain_chance3;
+				case RAIN_SLOT_FOUR:
+					return z.rain_chance4;
+				case RAIN_SLOT_ONE:
+				default:
+					return z.rain_chance1;
+			}
+		}
+	}
+
+	return 0;
+}
+
+int ZoneStore::GetZoneRainDuration(uint32 zone_id, uint8 slot, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			switch (slot) {
+				case RAIN_SLOT_TWO:
+					return z.rain_duration2;
+				case RAIN_SLOT_THREE:
+					return z.rain_duration3;
+				case RAIN_SLOT_FOUR:
+					return z.rain_duration4;
+				case RAIN_SLOT_ONE:
+				default:
+					return z.rain_duration1;
+			}
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			switch (slot) {
+				case RAIN_SLOT_TWO:
+					return z.rain_duration2;
+				case RAIN_SLOT_THREE:
+					return z.rain_duration3;
+				case RAIN_SLOT_FOUR:
+					return z.rain_duration4;
+				case RAIN_SLOT_ONE:
+				default:
+					return z.rain_duration1;
+			}
+		}
+	}
+
+	return 0;
+}
+
+int ZoneStore::GetZoneSnowChance(uint32 zone_id, uint8 slot, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			switch (slot) {
+				case SNOW_SLOT_TWO:
+					return z.snow_chance2;
+				case SNOW_SLOT_THREE:
+					return z.snow_chance3;
+				case SNOW_SLOT_FOUR:
+					return z.snow_chance4;
+				case SNOW_SLOT_ONE:
+				default:
+					return z.snow_chance1;
+			}
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			switch (slot) {
+				case SNOW_SLOT_TWO:
+					return z.snow_chance2;
+				case SNOW_SLOT_THREE:
+					return z.snow_chance3;
+				case SNOW_SLOT_FOUR:
+					return z.snow_chance4;
+				case SNOW_SLOT_ONE:
+				default:
+					return z.snow_chance1;
+			}
+		}
+	}
+
+	return 0;
+}
+
+int ZoneStore::GetZoneSnowDuration(uint32 zone_id, uint8 slot, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			switch (slot) {
+				case SNOW_SLOT_TWO:
+					return z.snow_duration2;
+				case SNOW_SLOT_THREE:
+					return z.snow_duration3;
+				case SNOW_SLOT_FOUR:
+					return z.snow_duration4;
+				case SNOW_SLOT_ONE:
+				default:
+					return z.snow_duration1;
+			}
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			switch (slot) {
+				case SNOW_SLOT_TWO:
+					return z.snow_duration2;
+				case SNOW_SLOT_THREE:
+					return z.snow_duration3;
+				case SNOW_SLOT_FOUR:
+					return z.snow_duration4;
+				case SNOW_SLOT_ONE:
+				default:
+					return z.snow_duration1;
+			}
+		}
+	}
+
+	return 0;
+}
+
+float ZoneStore::GetZoneGravity(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.gravity;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.gravity;
+		}
+	}
+
+	return DEFAULT_ZONE_GRAVITY;
+}
+
+int ZoneStore::GetZoneType(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.type;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.type;
+		}
+	}
+
+	return DEFAULT_ZONE_TYPE;
+}
+
+int8 ZoneStore::GetZoneSkyLock(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.skylock;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.skylock;
+		}
+	}
+
+	return 0;
+}
+
+int ZoneStore::GetZoneFastRegenHP(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.fast_regen_hp;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.fast_regen_hp;
+		}
+	}
+
+	return DEFAULT_ZONE_FAST_REGEN;
+}
+
+int ZoneStore::GetZoneFastRegenMana(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.fast_regen_mana;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.fast_regen_mana;
+		}
+	}
+
+	return DEFAULT_ZONE_FAST_REGEN;
+}
+
+int ZoneStore::GetZoneFastRegenEndurance(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.fast_regen_endurance;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.fast_regen_endurance;
+		}
+	}
+
+	return DEFAULT_ZONE_FAST_REGEN;
+}
+
+int ZoneStore::GetZoneNPCMaximumAggroDistance(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.npc_max_aggro_dist;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.npc_max_aggro_dist;
+		}
+	}
+
+	return DEFAULT_ZONE_MAX_AGGRO_DISTANCE;
+}
+
+uint32 ZoneStore::GetZoneMaximumMovementUpdateRange(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.max_movement_update_range;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.max_movement_update_range;
+		}
+	}
+
+	return DEFAULT_ZONE_MAX_MOVEMENT_UPDATE_RANGE;
+}
+
+int8 ZoneStore::GetZoneMinimumExpansion(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.min_expansion;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.min_expansion;
+		}
+	}
+
+	return DEFAULT_ZONE_MIN_MAX_EXPANSION;
+}
+
+int8 ZoneStore::GetZoneMaximumExpansion(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.max_expansion;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.max_expansion;
+		}
+	}
+
+	return DEFAULT_ZONE_MIN_MAX_EXPANSION;
+}
+
+const std::string& ZoneStore::GetZoneContentFlags(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.content_flags;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.content_flags;
+		}
+	}
+
+	const auto& content_flags = std::string();
+	return content_flags;
+}
+
+const std::string& ZoneStore::GetZoneContentFlagsDisabled(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.content_flags_disabled;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.content_flags_disabled;
+		}
+	}
+
+	const auto& content_flags_disabled = std::string();
+	return content_flags_disabled;
+}
+
+int ZoneStore::GetZoneUnderworldTeleportIndex(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.underworld_teleport_index;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.underworld_teleport_index;
+		}
+	}
+
+	return 0;
+}
+
+int ZoneStore::GetZoneLavaDamage(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.lava_damage;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.lava_damage;
+		}
+	}
+
+	return 0;
+}
+
+int ZoneStore::GetZoneMinimumLavaDamage(uint32 zone_id, int version)
+{
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == version) {
+			return z.min_lava_damage;
+		}
+	}
+
+	for (auto &z: m_zones) {
+		if (z.zoneidnumber == zone_id && z.version == 0) {
+			return z.min_lava_damage;
+		}
+	}
+
+	return 0;
 }

--- a/common/zone_store.h
+++ b/common/zone_store.h
@@ -24,6 +24,8 @@
 #include "../common/repositories/zone_repository.h"
 #include "../common/repositories/base/base_content_flags_repository.h"
 
+#include <glm/vec4.hpp>
+
 class ZoneStore {
 public:
 	ZoneStore();
@@ -43,6 +45,62 @@ public:
 	const char *GetZoneName(uint32 zone_id, bool error_unknown = false);
 	const char *GetZoneLongName(uint32 zone_id, bool error_unknown = false);
 	ZoneRepository::Zone *GetZoneWithFallback(uint32 zone_id, int version = 0);
+
+	glm::vec4 GetZoneSafeCoordinates(uint32 zone_id, int version = 0);
+	float GetZoneGraveyardID(uint32 zone_id, int version = 0);
+	uint8 GetZoneMinimumLevel(uint32 zone_id, int version = 0);
+	uint8 GetZoneMaximumLevel(uint32 zone_id, int version = 0);
+	uint8 GetZoneMinimumStatus(uint32 zone_id, int version = 0);
+	int GetZoneTimeZone(uint32 zone_id, int version = 0);
+	int GetZoneMaximumPlayers(uint32 zone_id, int version = 0);
+	uint32 GetZoneRuleSet(uint32 zone_id, int version = 0);
+	const std::string& GetZoneNote(uint32 zone_id, int version = 0);
+	float GetZoneUnderworld(uint32 zone_id, int version = 0);
+	float GetZoneMinimumClip(uint32 zone_id, int version = 0);
+	float GetZoneMaximumClip(uint32 zone_id, int version = 0);
+	float GetZoneFogMinimumClip(uint32 zone_id, uint8 slot = 0, int version = 0);
+	float GetZoneFogMaximumClip(uint32 zone_id, uint8 slot = 0, int version = 0);
+	uint8 GetZoneFogRed(uint32 zone_id, uint8 slot = 0, int version = 0);
+	uint8 GetZoneFogGreen(uint32 zone_id, uint8 slot = 0, int version = 0);
+	uint8 GetZoneFogBlue(uint32 zone_id, uint8 slot = 0, int version = 0);
+	uint8 GetZoneSky(uint32 zone_id, int version = 0);
+	uint8 GetZoneZType(uint32 zone_id, int version = 0);
+	float GetZoneExperienceMultiplier(uint32 zone_id, int version = 0);
+	float GetZoneWalkSpeed(uint32 zone_id, int version = 0);
+	uint8 GetZoneTimeType(uint32 zone_id, int version = 0);
+	float GetZoneFogDensity(uint32 zone_id, int version = 0);
+	const std::string& GetZoneFlagNeeded(uint32 zone_id, int version = 0);
+	int8 GetZoneCanBind(uint32 zone_id, int version = 0);
+	int8 GetZoneCanCombat(uint32 zone_id, int version = 0);
+	int8 GetZoneCanLevitate(uint32 zone_id, int version = 0);
+	int8 GetZoneCastOutdoor(uint32 zone_id, int version = 0);
+	uint8 GetZoneHotzone(uint32 zone_id, int version = 0);
+	uint8 GetZoneInstanceType(uint32 zone_id, int version = 0);
+	uint64 GetZoneShutdownDelay(uint32 zone_id, int version = 0);
+	int8 GetZonePEQZone(uint32 zone_id, int version = 0);
+	int8 GetZoneExpansion(uint32 zone_id, int version = 0);
+	int8 GetZoneBypassExpansionCheck(uint32 zone_id, int version = 0);
+	uint8 GetZoneSuspendBuffs(uint32 zone_id, int version = 0);
+	int GetZoneRainChance(uint32 zone_id, uint8 slot = 0, int version = 0);
+	int GetZoneRainDuration(uint32 zone_id, uint8 slot = 0, int version = 0);
+	int GetZoneSnowChance(uint32 zone_id, uint8 slot = 0, int version = 0);
+	int GetZoneSnowDuration(uint32 zone_id, uint8 slot = 0, int version = 0);
+	float GetZoneGravity(uint32 zone_id, int version = 0);
+	int GetZoneType(uint32 zone_id, int version = 0);
+	int8 GetZoneSkyLock(uint32 zone_id, int version = 0);
+	int GetZoneFastRegenHP(uint32 zone_id, int version = 0);
+	int GetZoneFastRegenMana(uint32 zone_id, int version = 0);
+	int GetZoneFastRegenEndurance(uint32 zone_id, int version = 0);
+	int GetZoneNPCMaximumAggroDistance(uint32 zone_id, int version = 0);
+	uint32 GetZoneMaximumMovementUpdateRange(uint32 zone_id, int version = 0);
+	int8 GetZoneMinimumExpansion(uint32 zone_id, int version = 0);
+	int8 GetZoneMaximumExpansion(uint32 zone_id, int version = 0);
+	const std::string& GetZoneContentFlags(uint32 zone_id, int version = 0);
+	const std::string& GetZoneContentFlagsDisabled(uint32 zone_id, int version = 0);
+	int GetZoneUnderworldTeleportIndex(uint32 zone_id, int version = 0);
+	int GetZoneLavaDamage(uint32 zone_id, int version = 0);
+	int GetZoneMinimumLavaDamage(uint32 zone_id, int version = 0);
+
 private:
 	std::vector<ZoneRepository::Zone> m_zones;
 };

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -18,6 +18,7 @@
 
 #include "../common/features.h"
 #include "../common/content/world_content_service.h"
+#include "../common/zone_store.h"
 
 #ifdef EMBPERL
 #ifdef EMBPERL_XS
@@ -4119,6 +4120,621 @@ void Perl__send_player_handin_event()
 	quest_manager.SendPlayerHandinEvent();
 }
 
+float Perl__GetZoneSafeX(uint32 zone_id)
+{
+	return zone_store.GetZoneSafeCoordinates(zone_id).x;
+}
+
+float Perl__GetZoneSafeX(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneSafeCoordinates(zone_id, version).x;
+}
+
+float Perl__GetZoneSafeY(uint32 zone_id)
+{
+	return zone_store.GetZoneSafeCoordinates(zone_id).y;
+}
+
+float Perl__GetZoneSafeY(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneSafeCoordinates(zone_id, version).y;
+}
+
+float Perl__GetZoneSafeZ(uint32 zone_id)
+{
+	return zone_store.GetZoneSafeCoordinates(zone_id).z;
+}
+
+float Perl__GetZoneSafeZ(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneSafeCoordinates(zone_id, version).z;
+}
+
+float Perl__GetZoneSafeHeading(uint32 zone_id)
+{
+	return zone_store.GetZoneSafeCoordinates(zone_id).w;
+}
+
+float Perl__GetZoneSafeHeading(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneSafeCoordinates(zone_id, version).w;
+}
+
+float Perl__GetZoneGraveyardID(uint32 zone_id)
+{
+	return zone_store.GetZoneGraveyardID(zone_id);
+}
+
+float Perl__GetZoneGraveyardID(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneGraveyardID(zone_id, version);
+}
+
+uint8 Perl__GetZoneMinimumLevel(uint32 zone_id)
+{
+	return zone_store.GetZoneMinimumLevel(zone_id);
+}
+
+uint8 Perl__GetZoneMinimumLevel(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneMinimumLevel(zone_id, version);
+}
+
+uint8 Perl__GetZoneMaximumLevel(uint32 zone_id)
+{
+	return zone_store.GetZoneMaximumLevel(zone_id);
+}
+
+uint8 Perl__GetZoneMaximumLevel(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneMaximumLevel(zone_id, version);
+}
+
+uint8 Perl__GetZoneMinimumStatus(uint32 zone_id)
+{
+	return zone_store.GetZoneMinimumStatus(zone_id);
+}
+
+uint8 Perl__GetZoneMinimumStatus(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneMinimumStatus(zone_id, version);
+}
+
+int Perl__GetZoneTimeZone(uint32 zone_id)
+{
+	return zone_store.GetZoneTimeZone(zone_id);
+}
+
+int Perl__GetZoneTimeZone(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneTimeZone(zone_id, version);
+}
+
+int Perl__GetZoneMaximumPlayers(uint32 zone_id)
+{
+	return zone_store.GetZoneMaximumPlayers(zone_id);
+}
+
+int Perl__GetZoneMaximumPlayers(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneMaximumPlayers(zone_id, version);
+}
+
+uint32 Perl__GetZoneRuleSet(uint32 zone_id)
+{
+	return zone_store.GetZoneRuleSet(zone_id);
+}
+
+uint32 Perl__GetZoneRuleSet(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneRuleSet(zone_id, version);
+}
+
+std::string Perl__GetZoneNote(uint32 zone_id)
+{
+	return zone_store.GetZoneNote(zone_id);
+}
+
+std::string Perl__GetZoneNote(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneNote(zone_id, version);
+}
+
+float Perl__GetZoneUnderworld(uint32 zone_id)
+{
+	return zone_store.GetZoneUnderworld(zone_id);
+}
+
+float Perl__GetZoneUnderworld(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneUnderworld(zone_id, version);
+}
+
+float Perl__GetZoneMinimumClip(uint32 zone_id)
+{
+	return zone_store.GetZoneMinimumClip(zone_id);
+}
+
+float Perl__GetZoneMinimumClip(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneMinimumClip(zone_id, version);
+}
+
+float Perl__GetZoneMaximumClip(uint32 zone_id)
+{
+	return zone_store.GetZoneMaximumClip(zone_id);
+}
+
+float Perl__GetZoneMaximumClip(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneMaximumClip(zone_id, version);
+}
+
+float Perl__GetZoneFogMinimumClip(uint32 zone_id)
+{
+	return zone_store.GetZoneFogMinimumClip(zone_id);
+}
+
+float Perl__GetZoneFogMinimumClip(uint32 zone_id, uint8 slot)
+{
+	return zone_store.GetZoneFogMinimumClip(zone_id, slot);
+}
+
+float Perl__GetZoneFogMinimumClip(uint32 zone_id, uint8 slot, int version)
+{
+	return zone_store.GetZoneFogMinimumClip(zone_id, slot, version);
+}
+
+float Perl__GetZoneFogMaximumClip(uint32 zone_id)
+{
+	return zone_store.GetZoneFogMaximumClip(zone_id);
+}
+
+float Perl__GetZoneFogMaximumClip(uint32 zone_id, uint8 slot)
+{
+	return zone_store.GetZoneFogMaximumClip(zone_id, slot);
+}
+
+float Perl__GetZoneFogMaximumClip(uint32 zone_id, uint8 slot, int version)
+{
+	return zone_store.GetZoneFogMaximumClip(zone_id, slot, version);
+}
+
+uint8 Perl__GetZoneFogRed(uint32 zone_id)
+{
+	return zone_store.GetZoneFogRed(zone_id);
+}
+
+uint8 Perl__GetZoneFogRed(uint32 zone_id, uint8 slot)
+{
+	return zone_store.GetZoneFogRed(zone_id, slot);
+}
+
+uint8 Perl__GetZoneFogRed(uint32 zone_id, uint8 slot, int version)
+{
+	return zone_store.GetZoneFogRed(zone_id, slot, version);
+}
+
+uint8 Perl__GetZoneFogGreen(uint32 zone_id)
+{
+	return zone_store.GetZoneFogGreen(zone_id);
+}
+
+uint8 Perl__GetZoneFogGreen(uint32 zone_id, uint8 slot)
+{
+	return zone_store.GetZoneFogGreen(zone_id, slot);
+}
+
+uint8 Perl__GetZoneFogGreen(uint32 zone_id, uint8 slot, int version)
+{
+	return zone_store.GetZoneFogGreen(zone_id, slot, version);
+}
+
+uint8 Perl__GetZoneFogBlue(uint32 zone_id)
+{
+	return zone_store.GetZoneFogBlue(zone_id);
+}
+
+uint8 Perl__GetZoneFogBlue(uint32 zone_id, uint8 slot)
+{
+	return zone_store.GetZoneFogBlue(zone_id, slot);
+}
+
+uint8 Perl__GetZoneFogBlue(uint32 zone_id, uint8 slot, int version)
+{
+	return zone_store.GetZoneFogBlue(zone_id, slot, version);
+}
+
+uint8 Perl__GetZoneSky(uint32 zone_id)
+{
+	return zone_store.GetZoneSky(zone_id);
+}
+
+uint8 Perl__GetZoneSky(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneSky(zone_id, version);
+}
+
+uint8 Perl__GetZoneZType(uint32 zone_id)
+{
+	return zone_store.GetZoneZType(zone_id);
+}
+
+uint8 Perl__GetZoneZType(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneZType(zone_id, version);
+}
+
+float Perl__GetZoneExperienceMultiplier(uint32 zone_id)
+{
+	return zone_store.GetZoneExperienceMultiplier(zone_id);
+}
+
+float Perl__GetZoneExperienceMultiplier(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneExperienceMultiplier(zone_id, version);
+}
+
+float Perl__GetZoneWalkSpeed(uint32 zone_id)
+{
+	return zone_store.GetZoneWalkSpeed(zone_id);
+}
+
+float Perl__GetZoneWalkSpeed(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneWalkSpeed(zone_id, version);
+}
+
+uint8 Perl__GetZoneTimeType(uint32 zone_id)
+{
+	return zone_store.GetZoneTimeType(zone_id);
+}
+
+uint8 Perl__GetZoneTimeType(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneTimeType(zone_id, version);
+}
+
+float Perl__GetZoneFogDensity(uint32 zone_id)
+{
+	return zone_store.GetZoneFogDensity(zone_id);
+}
+
+float Perl__GetZoneFogDensity(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneFogDensity(zone_id, version);
+}
+
+std::string Perl__GetZoneFlagNeeded(uint32 zone_id)
+{
+	return zone_store.GetZoneFlagNeeded(zone_id);
+}
+
+std::string Perl__GetZoneFlagNeeded(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneFlagNeeded(zone_id, version);
+}
+
+int8 Perl__GetZoneCanBind(uint32 zone_id)
+{
+	return zone_store.GetZoneCanBind(zone_id);
+}
+
+int8 Perl__GetZoneCanBind(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneCanBind(zone_id, version);
+}
+
+int8 Perl__GetZoneCanCombat(uint32 zone_id)
+{
+	return zone_store.GetZoneCanCombat(zone_id);
+}
+
+int8 Perl__GetZoneCanCombat(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneCanCombat(zone_id, version);
+}
+
+int8 Perl__GetZoneCanLevitate(uint32 zone_id)
+{
+	return zone_store.GetZoneCanLevitate(zone_id);
+}
+
+int8 Perl__GetZoneCanLevitate(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneCanLevitate(zone_id, version);
+}
+
+int8 Perl__GetZoneCastOutdoor(uint32 zone_id)
+{
+	return zone_store.GetZoneCastOutdoor(zone_id);
+}
+
+int8 Perl__GetZoneCastOutdoor(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneCastOutdoor(zone_id, version);
+}
+
+uint8 Perl__GetZoneHotzone(uint32 zone_id)
+{
+	return zone_store.GetZoneHotzone(zone_id);
+}
+
+uint8 Perl__GetZoneHotzone(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneHotzone(zone_id, version);
+}
+
+uint8 Perl__GetZoneInstanceType(uint32 zone_id)
+{
+	return zone_store.GetZoneInstanceType(zone_id);
+}
+
+uint8 Perl__GetZoneInstanceType(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneInstanceType(zone_id, version);
+}
+
+uint64 Perl__GetZoneShutdownDelay(uint32 zone_id)
+{
+	return zone_store.GetZoneShutdownDelay(zone_id);
+}
+
+uint64 Perl__GetZoneShutdownDelay(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneShutdownDelay(zone_id, version);
+}
+
+int8 Perl__GetZonePEQZone(uint32 zone_id)
+{
+	return zone_store.GetZonePEQZone(zone_id);
+}
+
+int8 Perl__GetZonePEQZone(uint32 zone_id, int version)
+{
+	return zone_store.GetZonePEQZone(zone_id, version);
+}
+
+int8 Perl__GetZoneExpansion(uint32 zone_id)
+{
+	return zone_store.GetZoneExpansion(zone_id);
+}
+
+int8 Perl__GetZoneExpansion(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneExpansion(zone_id, version);
+}
+
+int8 Perl__GetZoneBypassExpansionCheck(uint32 zone_id)
+{
+	return zone_store.GetZoneBypassExpansionCheck(zone_id);
+}
+
+int8 Perl__GetZoneBypassExpansionCheck(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneBypassExpansionCheck(zone_id, version);
+}
+
+uint8 Perl__GetZoneSuspendBuffs(uint32 zone_id)
+{
+	return zone_store.GetZoneSuspendBuffs(zone_id);
+}
+
+uint8 Perl__GetZoneSuspendBuffs(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneSuspendBuffs(zone_id, version);
+}
+
+int Perl__GetZoneRainChance(uint32 zone_id)
+{
+	return zone_store.GetZoneRainChance(zone_id);
+}
+
+int Perl__GetZoneRainChance(uint32 zone_id, uint8 slot)
+{
+	return zone_store.GetZoneRainChance(zone_id, slot);
+}
+
+int Perl__GetZoneRainChance(uint32 zone_id, uint8 slot, int version)
+{
+	return zone_store.GetZoneRainChance(zone_id, slot, version);
+}
+
+int Perl__GetZoneRainDuration(uint32 zone_id)
+{
+	return zone_store.GetZoneRainDuration(zone_id);
+}
+
+int Perl__GetZoneRainDuration(uint32 zone_id, uint8 slot)
+{
+	return zone_store.GetZoneRainDuration(zone_id, slot);
+}
+
+int Perl__GetZoneRainDuration(uint32 zone_id, uint8 slot, int version)
+{
+	return zone_store.GetZoneRainDuration(zone_id, slot, version);
+}
+
+int Perl__GetZoneSnowChance(uint32 zone_id)
+{
+	return zone_store.GetZoneSnowChance(zone_id);
+}
+
+int Perl__GetZoneSnowChance(uint32 zone_id, uint8 slot)
+{
+	return zone_store.GetZoneSnowChance(zone_id, slot);
+}
+
+int Perl__GetZoneSnowChance(uint32 zone_id, uint8 slot, int version)
+{
+	return zone_store.GetZoneSnowChance(zone_id, slot, version);
+}
+
+int Perl__GetZoneSnowDuration(uint32 zone_id)
+{
+	return zone_store.GetZoneSnowDuration(zone_id);
+}
+
+int Perl__GetZoneSnowDuration(uint32 zone_id, uint8 slot)
+{
+	return zone_store.GetZoneSnowDuration(zone_id, slot);
+}
+
+int Perl__GetZoneSnowDuration(uint32 zone_id, uint8 slot, int version)
+{
+	return zone_store.GetZoneSnowDuration(zone_id, slot, version);
+}
+
+float Perl__GetZoneGravity(uint32 zone_id)
+{
+	return zone_store.GetZoneGravity(zone_id);
+}
+
+float Perl__GetZoneGravity(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneGravity(zone_id, version);
+}
+
+int Perl__GetZoneType(uint32 zone_id)
+{
+	return zone_store.GetZoneType(zone_id);
+}
+
+int Perl__GetZoneType(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneType(zone_id, version);
+}
+
+int8 Perl__GetZoneSkyLock(uint32 zone_id)
+{
+	return zone_store.GetZoneSkyLock(zone_id);
+}
+
+int8 Perl__GetZoneSkyLock(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneSkyLock(zone_id, version);
+}
+
+int Perl__GetZoneFastRegenHP(uint32 zone_id)
+{
+	return zone_store.GetZoneFastRegenHP(zone_id);
+}
+
+int Perl__GetZoneFastRegenHP(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneFastRegenHP(zone_id, version);
+}
+
+int Perl__GetZoneFastRegenMana(uint32 zone_id)
+{
+	return zone_store.GetZoneFastRegenMana(zone_id);
+}
+
+int Perl__GetZoneFastRegenMana(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneFastRegenMana(zone_id, version);
+}
+
+int Perl__GetZoneFastRegenEndurance(uint32 zone_id)
+{
+	return zone_store.GetZoneFastRegenEndurance(zone_id);
+}
+
+int Perl__GetZoneFastRegenEndurance(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneFastRegenEndurance(zone_id, version);
+}
+
+int Perl__GetZoneNPCMaximumAggroDistance(uint32 zone_id)
+{
+	return zone_store.GetZoneNPCMaximumAggroDistance(zone_id);
+}
+
+int Perl__GetZoneNPCMaximumAggroDistance(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneNPCMaximumAggroDistance(zone_id, version);
+}
+
+uint32 Perl__GetZoneMaximumMovementUpdateRange(uint32 zone_id)
+{
+	return zone_store.GetZoneMaximumMovementUpdateRange(zone_id);
+}
+
+uint32 Perl__GetZoneMaximumMovementUpdateRange(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneMaximumMovementUpdateRange(zone_id, version);
+}
+
+int8 Perl__GetZoneMinimumExpansion(uint32 zone_id)
+{
+	return zone_store.GetZoneMinimumExpansion(zone_id);
+}
+
+int8 Perl__GetZoneMinimumExpansion(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneMinimumExpansion(zone_id, version);
+}
+
+int8 Perl__GetZoneMaximumExpansion(uint32 zone_id)
+{
+	return zone_store.GetZoneMaximumExpansion(zone_id);
+}
+
+int8 Perl__GetZoneMaximumExpansion(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneMaximumExpansion(zone_id, version);
+}
+
+std::string Perl__GetZoneContentFlags(uint32 zone_id)
+{
+	return zone_store.GetZoneContentFlags(zone_id);
+}
+
+std::string Perl__GetZoneContentFlags(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneContentFlags(zone_id, version);
+}
+
+std::string Perl__GetZoneContentFlagsDisabled(uint32 zone_id)
+{
+	return zone_store.GetZoneContentFlagsDisabled(zone_id);
+}
+
+std::string Perl__GetZoneContentFlagsDisabled(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneContentFlagsDisabled(zone_id, version);
+}
+
+int Perl__GetZoneUnderworldTeleportIndex(uint32 zone_id)
+{
+	return zone_store.GetZoneUnderworldTeleportIndex(zone_id);
+}
+
+int Perl__GetZoneUnderworldTeleportIndex(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneUnderworldTeleportIndex(zone_id, version);
+}
+
+int Perl__GetZoneLavaDamage(uint32 zone_id)
+{
+	return zone_store.GetZoneLavaDamage(zone_id);
+}
+
+int Perl__GetZoneLavaDamage(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneLavaDamage(zone_id, version);
+}
+
+int Perl__GetZoneMinimumLavaDamage(uint32 zone_id)
+{
+	return zone_store.GetZoneMinimumLavaDamage(zone_id);
+}
+
+int Perl__GetZoneMinimumLavaDamage(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneMinimumLavaDamage(zone_id, version);
+}
+
 void perl_register_quest()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -4155,10 +4771,133 @@ void perl_register_quest()
 	package.add("GetSpellResistType", &Perl__GetSpellResistType);
 	package.add("GetSpellTargetType", &Perl__GetSpellTargetType);
 	package.add("GetTimeSeconds", &Perl__GetTimeSeconds);
+	package.add("GetZoneBypassExpansionCheck", (int8(*)(uint32))&Perl__GetZoneBypassExpansionCheck);
+	package.add("GetZoneBypassExpansionCheck", (int8(*)(uint32, int))&Perl__GetZoneBypassExpansionCheck);
+	package.add("GetZoneCanBind", (int8(*)(uint32))&Perl__GetZoneCanBind);
+	package.add("GetZoneCanBind", (int8(*)(uint32, int))&Perl__GetZoneCanBind);
+	package.add("GetZoneCanCombat", (int8(*)(uint32))&Perl__GetZoneCanCombat);
+	package.add("GetZoneCanCombat", (int8(*)(uint32, int))&Perl__GetZoneCanCombat);
+	package.add("GetZoneCanLevitate", (int8(*)(uint32))&Perl__GetZoneCanLevitate);
+	package.add("GetZoneCanLevitate", (int8(*)(uint32, int))&Perl__GetZoneCanLevitate);
+	package.add("GetZoneCastOutdoor", (int8(*)(uint32))&Perl__GetZoneCastOutdoor);
+	package.add("GetZoneCastOutdoor", (int8(*)(uint32, int))&Perl__GetZoneCastOutdoor);
+	package.add("GetZoneContentFlags", (std::string(*)(uint32))&Perl__GetZoneContentFlags);
+	package.add("GetZoneContentFlags", (std::string(*)(uint32, int))&Perl__GetZoneContentFlags);
+	package.add("GetZoneContentFlagsDisabled", (std::string(*)(uint32))&Perl__GetZoneContentFlagsDisabled);
+	package.add("GetZoneContentFlagsDisabled", (std::string(*)(uint32, int))&Perl__GetZoneContentFlagsDisabled);
+	package.add("GetZoneGraveyardID", (float(*)(uint32))&Perl__GetZoneGraveyardID);
+	package.add("GetZoneGraveyardID", (float(*)(uint32, int))&Perl__GetZoneGraveyardID);
+	package.add("GetZoneHotzone", (uint8(*)(uint32))&Perl__GetZoneHotzone);
+	package.add("GetZoneHotzone", (uint8(*)(uint32, int))&Perl__GetZoneHotzone);
+	package.add("GetZoneInstanceType", (uint8(*)(uint32))&Perl__GetZoneInstanceType);
+	package.add("GetZoneInstanceType", (uint8(*)(uint32, int))&Perl__GetZoneInstanceType);
 	package.add("GetZoneID", &Perl__GetZoneID);
+	package.add("GetZoneExpansion", (int8(*)(uint32))&Perl__GetZoneExpansion);
+	package.add("GetZoneExpansion", (int8(*)(uint32, int))&Perl__GetZoneExpansion);
+	package.add("GetZoneExperienceMultiplier", (float(*)(uint32))&Perl__GetZoneExperienceMultiplier);
+	package.add("GetZoneExperienceMultiplier", (float(*)(uint32, int))&Perl__GetZoneExperienceMultiplier);
+	package.add("GetZoneFastRegenHP", (int(*)(uint32))&Perl__GetZoneFastRegenHP);
+	package.add("GetZoneFastRegenHP", (int(*)(uint32, int))&Perl__GetZoneFastRegenHP);
+	package.add("GetZoneFastRegenMana", (int(*)(uint32))&Perl__GetZoneFastRegenMana);
+	package.add("GetZoneFastRegenMana", (int(*)(uint32, int))&Perl__GetZoneFastRegenMana);
+	package.add("GetZoneFastRegenEndurance", (int(*)(uint32))&Perl__GetZoneFastRegenEndurance);
+	package.add("GetZoneFastRegenEndurance", (int(*)(uint32, int))&Perl__GetZoneFastRegenEndurance);
+	package.add("GetZoneFlagNeeded", (std::string(*)(uint32))&Perl__GetZoneFlagNeeded);
+	package.add("GetZoneFlagNeeded", (std::string(*)(uint32, int))&Perl__GetZoneFlagNeeded);
+	package.add("GetZoneFogMaximumClip", (float(*)(uint32))&Perl__GetZoneFogMaximumClip);
+	package.add("GetZoneFogMaximumClip", (float(*)(uint32, uint8))&Perl__GetZoneFogMaximumClip);
+	package.add("GetZoneFogMaximumClip", (float(*)(uint32, uint8, int))&Perl__GetZoneFogMaximumClip);
+	package.add("GetZoneFogMinimumClip", (float(*)(uint32))&Perl__GetZoneFogMinimumClip);
+	package.add("GetZoneFogMinimumClip", (float(*)(uint32, uint8))&Perl__GetZoneFogMinimumClip);
+	package.add("GetZoneFogMinimumClip", (float(*)(uint32, uint8, int))&Perl__GetZoneFogMinimumClip);
+	package.add("GetZoneFogBlue", (uint8(*)(uint32))&Perl__GetZoneFogBlue);
+	package.add("GetZoneFogBlue", (uint8(*)(uint32, uint8))&Perl__GetZoneFogBlue);
+	package.add("GetZoneFogBlue", (uint8(*)(uint32, uint8, int))&Perl__GetZoneFogBlue);
+	package.add("GetZoneFogDensity", (float(*)(uint32))&Perl__GetZoneFogDensity);
+	package.add("GetZoneFogDensity", (float(*)(uint32, int))&Perl__GetZoneFogDensity);
+	package.add("GetZoneFogGreen", (uint8(*)(uint32))&Perl__GetZoneFogGreen);
+	package.add("GetZoneFogGreen", (uint8(*)(uint32, uint8))&Perl__GetZoneFogGreen);
+	package.add("GetZoneFogGreen", (uint8(*)(uint32, uint8, int))&Perl__GetZoneFogGreen);
+	package.add("GetZoneFogRed", (uint8(*)(uint32))&Perl__GetZoneFogRed);
+	package.add("GetZoneFogRed", (uint8(*)(uint32, uint8))&Perl__GetZoneFogRed);
+	package.add("GetZoneFogRed", (uint8(*)(uint32, uint8, int))&Perl__GetZoneFogRed);
+	package.add("GetZoneGravity", (float(*)(uint32))&Perl__GetZoneMaximumClip);
+	package.add("GetZoneGravity", (float(*)(uint32, int))&Perl__GetZoneMaximumClip);
+	package.add("GetZoneMaximumClip", (float(*)(uint32))&Perl__GetZoneMaximumClip);
+	package.add("GetZoneMaximumClip", (float(*)(uint32, int))&Perl__GetZoneMaximumClip);
+	package.add("GetZoneMaximumExpansion", (int8(*)(uint32))&Perl__GetZoneMaximumExpansion);
+	package.add("GetZoneMaximumExpansion", (int8(*)(uint32, int))&Perl__GetZoneMaximumExpansion);
+	package.add("GetZoneMaximumLevel", (uint8(*)(uint32))&Perl__GetZoneMaximumLevel);
+	package.add("GetZoneMaximumLevel", (uint8(*)(uint32, int))&Perl__GetZoneMaximumLevel);
+	package.add("GetZoneMaximumMovementUpdateRange", (uint32(*)(uint32))&Perl__GetZoneMaximumMovementUpdateRange);
+	package.add("GetZoneMaximumMovementUpdateRange", (uint32(*)(uint32, int))&Perl__GetZoneMaximumMovementUpdateRange);
+	package.add("GetZoneMaximumPlayers", (int(*)(uint32))&Perl__GetZoneMaximumPlayers);
+	package.add("GetZoneMaximumPlayers", (int(*)(uint32, int))&Perl__GetZoneMaximumPlayers);
+	package.add("GetZoneMinimumClip", (float(*)(uint32))&Perl__GetZoneMinimumClip);
+	package.add("GetZoneMinimumClip", (float(*)(uint32, int))&Perl__GetZoneMinimumClip);
+	package.add("GetZoneMinimumExpansion", (int8(*)(uint32))&Perl__GetZoneMinimumExpansion);
+	package.add("GetZoneMinimumExpansion", (int8(*)(uint32, int))&Perl__GetZoneMinimumExpansion);
+	package.add("GetZoneMinimumLavaDamage", (int(*)(uint32))&Perl__GetZoneMinimumLavaDamage);
+	package.add("GetZoneMinimumLavaDamage", (int(*)(uint32, int))&Perl__GetZoneMinimumLavaDamage);
+	package.add("GetZoneMinimumLevel", (uint8(*)(uint32))&Perl__GetZoneMinimumLevel);
+	package.add("GetZoneMinimumLevel", (uint8(*)(uint32, int))&Perl__GetZoneMinimumLevel);
+	package.add("GetZoneMinimumStatus", (uint8(*)(uint32))&Perl__GetZoneMinimumStatus);
+	package.add("GetZoneMinimumStatus", (uint8(*)(uint32, int))&Perl__GetZoneMinimumStatus);
+	package.add("GetZoneNote", (std::string(*)(uint32))&Perl__GetZoneNote);
+	package.add("GetZoneNote", (std::string(*)(uint32, int))&Perl__GetZoneNote);
+	package.add("GetZoneNPCMaximumAggroDistance", (int(*)(uint32))&Perl__GetZoneNPCMaximumAggroDistance);
+	package.add("GetZoneNPCMaximumAggroDistance", (int(*)(uint32, int))&Perl__GetZoneNPCMaximumAggroDistance);
+	package.add("GetZoneLavaDamage", (int(*)(uint32))&Perl__GetZoneLavaDamage);
+	package.add("GetZoneLavaDamage", (int(*)(uint32, int))&Perl__GetZoneLavaDamage);
 	package.add("GetZoneLongName", &Perl__GetZoneLongName);
 	package.add("GetZoneLongNameByID", &Perl__GetZoneLongNameByID);
+	package.add("GetZonePEQZone", (int8(*)(uint32))&Perl__GetZonePEQZone);
+	package.add("GetZonePEQZone", (int8(*)(uint32, int))&Perl__GetZonePEQZone);
+	package.add("GetZoneRainChance", (int(*)(uint32))&Perl__GetZoneRainChance);
+	package.add("GetZoneRainChance", (int(*)(uint32, uint8))&Perl__GetZoneRainChance);
+	package.add("GetZoneRainChance", (int(*)(uint32, uint8, int))&Perl__GetZoneRainChance);
+	package.add("GetZoneRainDuration", (int(*)(uint32))&Perl__GetZoneRainDuration);
+	package.add("GetZoneRainDuration", (int(*)(uint32, uint8))&Perl__GetZoneRainDuration);
+	package.add("GetZoneRainDuration", (int(*)(uint32, uint8, int))&Perl__GetZoneRainDuration);
+	package.add("GetZoneRuleSet", (uint32(*)(uint32))&Perl__GetZoneRuleSet);
+	package.add("GetZoneRuleSet", (uint32(*)(uint32, int))&Perl__GetZoneRuleSet);
+	package.add("GetZoneSafeHeading", (float(*)(uint32))&Perl__GetZoneSafeHeading);
+	package.add("GetZoneSafeHeading", (float(*)(uint32, int))&Perl__GetZoneSafeHeading);
+	package.add("GetZoneSafeX", (float(*)(uint32))&Perl__GetZoneSafeX);
+	package.add("GetZoneSafeX", (float(*)(uint32, int))&Perl__GetZoneSafeX);
+	package.add("GetZoneSafeY", (float(*)(uint32))&Perl__GetZoneSafeY);
+	package.add("GetZoneSafeY", (float(*)(uint32, int))&Perl__GetZoneSafeY);
+	package.add("GetZoneSafeZ", (float(*)(uint32))&Perl__GetZoneSafeZ);
+	package.add("GetZoneSafeZ", (float(*)(uint32, int))&Perl__GetZoneSafeZ);
+	package.add("GetZoneShutdownDelay", (uint64(*)(uint32))&Perl__GetZoneShutdownDelay);
+	package.add("GetZoneShutdownDelay", (uint64(*)(uint32, int))&Perl__GetZoneShutdownDelay);
+	package.add("GetZoneSky", (uint8(*)(uint32))&Perl__GetZoneSky);
+	package.add("GetZoneSky", (uint8(*)(uint32, int))&Perl__GetZoneSky);
+	package.add("GetZoneSkyLock", (int8(*)(uint32))&Perl__GetZoneSkyLock);
+	package.add("GetZoneSkyLock", (int8(*)(uint32, int))&Perl__GetZoneSkyLock);
+	package.add("GetZoneSnowChance", (int(*)(uint32))&Perl__GetZoneSnowChance);
+	package.add("GetZoneSnowChance", (int(*)(uint32, uint8))&Perl__GetZoneSnowChance);
+	package.add("GetZoneSnowChance", (int(*)(uint32, uint8, int))&Perl__GetZoneSnowChance);
+	package.add("GetZoneSnowDuration", (int(*)(uint32))&Perl__GetZoneSnowDuration);
+	package.add("GetZoneSnowDuration", (int(*)(uint32, uint8))&Perl__GetZoneSnowDuration);
+	package.add("GetZoneSnowDuration", (int(*)(uint32, uint8, int))&Perl__GetZoneSnowDuration);
+	package.add("GetZoneSuspendBuffs", (uint8(*)(uint32))&Perl__GetZoneSuspendBuffs);
+	package.add("GetZoneSuspendBuffs", (uint8(*)(uint32, int))&Perl__GetZoneSuspendBuffs);
+	package.add("GetZoneZType", (uint8(*)(uint32))&Perl__GetZoneZType);
+	package.add("GetZoneZType", (uint8(*)(uint32, int))&Perl__GetZoneZType);
 	package.add("GetZoneShortName", &Perl__GetZoneShortName);
+	package.add("GetZoneTimeType", (uint8(*)(uint32))&Perl__GetZoneTimeType);
+	package.add("GetZoneTimeType", (uint8(*)(uint32, int))&Perl__GetZoneTimeType);
+	package.add("GetZoneTimeZone", (int(*)(uint32))&Perl__GetZoneTimeZone);
+	package.add("GetZoneTimeZone", (int(*)(uint32, int))&Perl__GetZoneTimeZone);
+	package.add("GetZoneType", (int(*)(uint32))&Perl__GetZoneType);
+	package.add("GetZoneType", (int(*)(uint32, int))&Perl__GetZoneType);
+	package.add("GetZoneUnderworld", (float(*)(uint32))&Perl__GetZoneUnderworld);
+	package.add("GetZoneUnderworld", (float(*)(uint32, int))&Perl__GetZoneUnderworld);
+	package.add("GetZoneUnderworldTeleportIndex", (int(*)(uint32))&Perl__GetZoneUnderworldTeleportIndex);
+	package.add("GetZoneUnderworldTeleportIndex", (int(*)(uint32, int))&Perl__GetZoneUnderworldTeleportIndex);
+	package.add("GetZoneWalkSpeed", (float(*)(uint32))&Perl__GetZoneWalkSpeed);
+	package.add("GetZoneWalkSpeed", (float(*)(uint32, int))&Perl__GetZoneWalkSpeed);
 	package.add("set_rule", &Perl__set_rule);
 	package.add("get_rule", &Perl__get_rule);
 	package.add("get_data", &Perl__get_data);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -3806,6 +3806,601 @@ void lua_send_player_handin_event()
 	quest_manager.SendPlayerHandinEvent();
 }
 
+float lua_get_zone_safe_x(uint32 zone_id)
+{
+	return zone_store.GetZoneSafeCoordinates(zone_id).x;
+}
+
+float lua_get_zone_safe_x(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneSafeCoordinates(zone_id, version).x;
+}
+
+float lua_get_zone_safe_y(uint32 zone_id)
+{
+	return zone_store.GetZoneSafeCoordinates(zone_id).y;
+}
+
+float lua_get_zone_safe_y(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneSafeCoordinates(zone_id, version).y;
+}
+
+float lua_get_zone_safe_z(uint32 zone_id)
+{
+	return zone_store.GetZoneSafeCoordinates(zone_id).z;
+}
+
+float lua_get_zone_safe_z(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneSafeCoordinates(zone_id, version).z;
+}
+
+float lua_get_zone_safe_heading(uint32 zone_id)
+{
+	return zone_store.GetZoneSafeCoordinates(zone_id).w;
+}
+
+float lua_get_zone_safe_heading(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneSafeCoordinates(zone_id, version).w;
+}
+
+float lua_get_zone_graveyard_id(uint32 zone_id)
+{
+	return zone_store.GetZoneGraveyardID(zone_id);
+}
+
+float lua_get_zone_graveyard_id(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneGraveyardID(zone_id, version);
+}
+
+uint8 lua_get_zone_minimum_level(uint32 zone_id)
+{
+	return zone_store.GetZoneMinimumLevel(zone_id);
+}
+
+uint8 lua_get_zone_minimum_level(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneMinimumLevel(zone_id, version);
+}
+
+uint8 lua_get_zone_maximum_level(uint32 zone_id)
+{
+	return zone_store.GetZoneMaximumLevel(zone_id);
+}
+
+uint8 lua_get_zone_maximum_level(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneMaximumLevel(zone_id, version);
+}
+
+uint8 lua_get_zone_minimum_status(uint32 zone_id)
+{
+	return zone_store.GetZoneMinimumStatus(zone_id);
+}
+
+uint8 lua_get_zone_minimum_status(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneMinimumStatus(zone_id, version);
+}
+
+int lua_get_zone_time_zone(uint32 zone_id)
+{
+	return zone_store.GetZoneTimeZone(zone_id);
+}
+
+int lua_get_zone_time_zone(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneTimeZone(zone_id, version);
+}
+
+int lua_get_zone_maximum_players(uint32 zone_id)
+{
+	return zone_store.GetZoneMaximumPlayers(zone_id);
+}
+
+int lua_get_zone_maximum_players(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneMaximumPlayers(zone_id, version);
+}
+
+uint32 lua_get_zone_rule_set(uint32 zone_id)
+{
+	return zone_store.GetZoneRuleSet(zone_id);
+}
+
+uint32 lua_get_zone_rule_set(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneRuleSet(zone_id, version);
+}
+
+std::string lua_get_zone_note(uint32 zone_id)
+{
+	return zone_store.GetZoneNote(zone_id);
+}
+
+std::string lua_get_zone_note(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneNote(zone_id, version);
+}
+
+float lua_get_zone_underworld(uint32 zone_id)
+{
+	return zone_store.GetZoneUnderworld(zone_id);
+}
+
+float lua_get_zone_underworld(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneUnderworld(zone_id, version);
+}
+
+float lua_get_zone_minimum_clip(uint32 zone_id)
+{
+	return zone_store.GetZoneMinimumClip(zone_id);
+}
+
+float lua_get_zone_minimum_clip(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneMinimumClip(zone_id, version);
+}
+
+float lua_get_zone_maximum_clip(uint32 zone_id)
+{
+	return zone_store.GetZoneMaximumClip(zone_id);
+}
+
+float lua_get_zone_maximum_clip(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneMaximumClip(zone_id, version);
+}
+
+float lua_get_zone_fog_minimum_clip(uint32 zone_id)
+{
+	return zone_store.GetZoneFogMinimumClip(zone_id);
+}
+
+float lua_get_zone_fog_minimum_clip(uint32 zone_id, uint8 slot)
+{
+	return zone_store.GetZoneFogMinimumClip(zone_id, slot);
+}
+
+float lua_get_zone_fog_minimum_clip(uint32 zone_id, uint8 slot, int version)
+{
+	return zone_store.GetZoneFogMinimumClip(zone_id, slot);
+}
+
+float lua_get_zone_fog_maximum_clip(uint32 zone_id)
+{
+	return zone_store.GetZoneFogMaximumClip(zone_id);
+}
+
+float lua_get_zone_fog_maximum_clip(uint32 zone_id, uint8 slot)
+{
+	return zone_store.GetZoneFogMaximumClip(zone_id, slot);
+}
+
+float lua_get_zone_fog_maximum_clip(uint32 zone_id, uint8 slot, int version)
+{
+	return zone_store.GetZoneFogMaximumClip(zone_id, slot, version);
+}
+
+uint8 lua_get_zone_fog_red(uint32 zone_id)
+{
+	return zone_store.GetZoneFogRed(zone_id);
+}
+
+uint8 lua_get_zone_fog_red(uint32 zone_id, uint8 slot)
+{
+	return zone_store.GetZoneFogRed(zone_id, slot);
+}
+
+uint8 lua_get_zone_fog_red(uint32 zone_id, uint8 slot, int version)
+{
+	return zone_store.GetZoneFogRed(zone_id, slot, version);
+}
+
+uint8 lua_get_zone_fog_green(uint32 zone_id)
+{
+	return zone_store.GetZoneFogGreen(zone_id);
+}
+
+uint8 lua_get_zone_fog_green(uint32 zone_id, uint8 slot)
+{
+	return zone_store.GetZoneFogGreen(zone_id, slot);
+}
+
+uint8 lua_get_zone_fog_green(uint32 zone_id, uint8 slot, int version)
+{
+	return zone_store.GetZoneFogGreen(zone_id, slot, version);
+}
+
+uint8 lua_get_zone_fog_blue(uint32 zone_id)
+{
+	return zone_store.GetZoneFogBlue(zone_id);
+}
+
+uint8 lua_get_zone_fog_blue(uint32 zone_id, uint8 slot)
+{
+	return zone_store.GetZoneFogBlue(zone_id, slot);
+}
+
+uint8 lua_get_zone_fog_blue(uint32 zone_id, uint8 slot, int version)
+{
+	return zone_store.GetZoneFogBlue(zone_id, slot, version);
+}
+
+uint8 lua_get_zone_sky(uint32 zone_id)
+{
+	return zone_store.GetZoneSky(zone_id);
+}
+
+uint8 lua_get_zone_sky(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneSky(zone_id, version);
+}
+
+uint8 lua_get_zone_ztype(uint32 zone_id)
+{
+	return zone_store.GetZoneZType(zone_id);
+}
+
+uint8 lua_get_zone_ztype(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneZType(zone_id, version);
+}
+
+float lua_get_zone_experience_multiplier(uint32 zone_id)
+{
+	return zone_store.GetZoneExperienceMultiplier(zone_id);
+}
+
+float lua_get_zone_experience_multiplier(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneExperienceMultiplier(zone_id, version);
+}
+
+float lua_get_zone_walk_speed(uint32 zone_id)
+{
+	return zone_store.GetZoneWalkSpeed(zone_id);
+}
+
+float lua_get_zone_walk_speed(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneWalkSpeed(zone_id, version);
+}
+
+uint8 lua_get_zone_time_type(uint32 zone_id)
+{
+	return zone_store.GetZoneTimeType(zone_id);
+}
+
+uint8 lua_get_zone_time_type(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneTimeType(zone_id, version);
+}
+
+float lua_get_zone_fog_density(uint32 zone_id)
+{
+	return zone_store.GetZoneFogDensity(zone_id);
+}
+
+float lua_get_zone_fog_density(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneFogDensity(zone_id, version);
+}
+
+std::string lua_get_zone_flag_needed(uint32 zone_id)
+{
+	return zone_store.GetZoneFlagNeeded(zone_id);
+}
+
+std::string lua_get_zone_flag_needed(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneFlagNeeded(zone_id, version);
+}
+
+int8 lua_get_zone_can_bind(uint32 zone_id)
+{
+	return zone_store.GetZoneCanBind(zone_id);
+}
+
+int8 lua_get_zone_can_bind(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneCanBind(zone_id, version);
+}
+
+int8 lua_get_zone_can_combat(uint32 zone_id)
+{
+	return zone_store.GetZoneCanCombat(zone_id);
+}
+
+int8 lua_get_zone_can_combat(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneCanCombat(zone_id, version);
+}
+
+int8 lua_get_zone_can_levitate(uint32 zone_id)
+{
+	return zone_store.GetZoneCanLevitate(zone_id);
+}
+
+int8 lua_get_zone_can_levitate(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneCanLevitate(zone_id, version);
+}
+
+int8 lua_get_zone_cast_outdoor(uint32 zone_id)
+{
+	return zone_store.GetZoneCastOutdoor(zone_id);
+}
+
+int8 lua_get_zone_cast_outdoor(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneCastOutdoor(zone_id, version);
+}
+
+uint8 lua_get_zone_hotzone(uint32 zone_id)
+{
+	return zone_store.GetZoneHotzone(zone_id);
+}
+
+uint8 lua_get_zone_hotzone(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneHotzone(zone_id, version);
+}
+
+uint8 lua_get_zone_instance_type(uint32 zone_id)
+{
+	return zone_store.GetZoneInstanceType(zone_id);
+}
+
+uint8 lua_get_zone_instance_type(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneInstanceType(zone_id, version);
+}
+
+uint64 lua_get_zone_shutdown_delay(uint32 zone_id)
+{
+	return zone_store.GetZoneShutdownDelay(zone_id);
+}
+
+uint64 lua_get_zone_shutdown_delay(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneShutdownDelay(zone_id, version);
+}
+
+int8 lua_get_zone_peqzone(uint32 zone_id)
+{
+	return zone_store.GetZonePEQZone(zone_id);
+}
+
+int8 lua_get_zone_peqzone(uint32 zone_id, int version)
+{
+	return zone_store.GetZonePEQZone(zone_id, version);
+}
+
+int8 lua_get_zone_expansion(uint32 zone_id)
+{
+	return zone_store.GetZoneExpansion(zone_id);
+}
+
+int8 lua_get_zone_expansion(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneExpansion(zone_id, version);
+}
+
+int8 lua_get_zone_bypass_expansion_check(uint32 zone_id)
+{
+	return zone_store.GetZoneBypassExpansionCheck(zone_id);
+}
+
+int8 lua_get_zone_bypass_expansion_check(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneBypassExpansionCheck(zone_id, version);
+}
+
+int8 lua_get_zone_suspend_buffs(uint32 zone_id)
+{
+	return zone_store.GetZoneSuspendBuffs(zone_id);
+}
+
+int8 lua_get_zone_suspend_buffs(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneSuspendBuffs(zone_id, version);
+}
+
+int lua_get_zone_rain_chance(uint32 zone_id)
+{
+	return zone_store.GetZoneRainChance(zone_id);
+}
+
+int lua_get_zone_rain_chance(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneRainChance(zone_id, version);
+}
+
+int lua_get_zone_rain_duration(uint32 zone_id)
+{
+	return zone_store.GetZoneRainDuration(zone_id);
+}
+
+int lua_get_zone_rain_duration(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneRainDuration(zone_id, version);
+}
+
+int lua_get_zone_snow_chance(uint32 zone_id)
+{
+	return zone_store.GetZoneSnowChance(zone_id);
+}
+
+int lua_get_zone_snow_chance(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneSnowChance(zone_id, version);
+}
+
+int lua_get_zone_snow_duration(uint32 zone_id)
+{
+	return zone_store.GetZoneSnowDuration(zone_id);
+}
+
+int lua_get_zone_snow_duration(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneSnowDuration(zone_id, version);
+}
+
+float lua_get_zone_gravity(uint32 zone_id)
+{
+	return zone_store.GetZoneGravity(zone_id);
+}
+
+float lua_get_zone_gravity(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneGravity(zone_id, version);
+}
+
+int lua_get_zone_type(uint32 zone_id)
+{
+	return zone_store.GetZoneType(zone_id);
+}
+
+int lua_get_zone_type(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneType(zone_id, version);
+}
+
+int lua_get_zone_sky_lock(uint32 zone_id)
+{
+	return zone_store.GetZoneSkyLock(zone_id);
+}
+
+int lua_get_zone_sky_lock(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneSkyLock(zone_id, version);
+}
+
+int lua_get_zone_fast_regen_hp(uint32 zone_id)
+{
+	return zone_store.GetZoneFastRegenHP(zone_id);
+}
+
+int lua_get_zone_fast_regen_hp(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneFastRegenHP(zone_id, version);
+}
+
+int lua_get_zone_fast_regen_mana(uint32 zone_id)
+{
+	return zone_store.GetZoneFastRegenMana(zone_id);
+}
+
+int lua_get_zone_fast_regen_mana(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneFastRegenMana(zone_id, version);
+}
+
+int lua_get_zone_fast_regen_endurance(uint32 zone_id)
+{
+	return zone_store.GetZoneFastRegenEndurance(zone_id);
+}
+
+int lua_get_zone_fast_regen_endurance(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneFastRegenEndurance(zone_id, version);
+}
+
+int lua_get_zone_npc_maximum_aggro_distance(uint32 zone_id)
+{
+	return zone_store.GetZoneNPCMaximumAggroDistance(zone_id);
+}
+
+int lua_get_zone_npc_maximum_aggro_distance(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneNPCMaximumAggroDistance(zone_id, version);
+}
+
+uint32 lua_get_zone_maximum_movement_update_range(uint32 zone_id)
+{
+	return zone_store.GetZoneMaximumMovementUpdateRange(zone_id);
+}
+
+uint32 lua_get_zone_maximum_movement_update_range(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneMaximumMovementUpdateRange(zone_id, version);
+}
+
+int8 lua_get_zone_minimum_expansion(uint32 zone_id)
+{
+	return zone_store.GetZoneMinimumExpansion(zone_id);
+}
+
+int8 lua_get_zone_minimum_expansion(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneMinimumExpansion(zone_id, version);
+}
+
+int8 lua_get_zone_maximum_expansion(uint32 zone_id)
+{
+	return zone_store.GetZoneMaximumExpansion(zone_id);
+}
+
+int8 lua_get_zone_maximum_expansion(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneMaximumExpansion(zone_id, version);
+}
+
+std::string lua_get_zone_content_flags(uint32 zone_id)
+{
+	return zone_store.GetZoneContentFlags(zone_id);
+}
+
+std::string lua_get_zone_content_flags(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneContentFlags(zone_id, version);
+}
+
+std::string lua_get_zone_content_flags_disabled(uint32 zone_id)
+{
+	return zone_store.GetZoneContentFlagsDisabled(zone_id);
+}
+
+std::string lua_get_zone_content_flags_disabled(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneContentFlagsDisabled(zone_id, version);
+}
+
+int lua_get_zone_underworld_teleport_index(uint32 zone_id)
+{
+	return zone_store.GetZoneUnderworldTeleportIndex(zone_id);
+}
+
+int lua_get_zone_underworld_teleport_index(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneUnderworldTeleportIndex(zone_id, version);
+}
+
+int lua_get_zone_lava_damage(uint32 zone_id)
+{
+	return zone_store.GetZoneLavaDamage(zone_id);
+}
+
+int lua_get_zone_lava_damage(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneLavaDamage(zone_id, version);
+}
+
+int lua_get_zone_minimum_lava_damage(uint32 zone_id)
+{
+	return zone_store.GetZoneMinimumLavaDamage(zone_id);
+}
+
+int lua_get_zone_minimum_lava_damage(uint32 zone_id, int version)
+{
+	return zone_store.GetZoneMinimumLavaDamage(zone_id, version);
+}
+
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
 	cur = table[#name]; \
 	if(luabind::type(cur) != LUA_TNIL) { \
@@ -4337,6 +4932,125 @@ luabind::scope lua_register_general() {
 		luabind::def("get_recipe_salvage_count", (int8(*)(uint32,uint32))&lua_get_recipe_salvage_count),
 		luabind::def("get_recipe_success_count", (int8(*)(uint32,uint32))&lua_get_recipe_success_count),
 		luabind::def("send_player_handin_event", (void(*)(void))&lua_send_player_handin_event),
+		luabind::def("get_zone_safe_x", (float(*)(uint32))&lua_get_zone_safe_x),
+		luabind::def("get_zone_safe_x", (float(*)(uint32,int))&lua_get_zone_safe_x),
+		luabind::def("get_zone_safe_y", (float(*)(uint32))&lua_get_zone_safe_y),
+		luabind::def("get_zone_safe_y", (float(*)(uint32,int))&lua_get_zone_safe_y),
+		luabind::def("get_zone_safe_z", (float(*)(uint32))&lua_get_zone_safe_z),
+		luabind::def("get_zone_safe_z", (float(*)(uint32,int))&lua_get_zone_safe_z),
+		luabind::def("get_zone_safe_heading", (float(*)(uint32))&lua_get_zone_safe_heading),
+		luabind::def("get_zone_safe_heading", (float(*)(uint32,int))&lua_get_zone_safe_heading),
+		luabind::def("get_zone_graveyard_id", (float(*)(uint32))&lua_get_zone_graveyard_id),
+		luabind::def("get_zone_graveyard_id", (float(*)(uint32,int))&lua_get_zone_graveyard_id),
+		luabind::def("get_zone_minimum_level", (uint8(*)(uint32))&lua_get_zone_minimum_level),
+		luabind::def("get_zone_minimum_level", (uint8(*)(uint32,int))&lua_get_zone_minimum_level),
+		luabind::def("get_zone_maximum_level", (uint8(*)(uint32))&lua_get_zone_maximum_level),
+		luabind::def("get_zone_maximum_level", (uint8(*)(uint32,int))&lua_get_zone_maximum_level),
+		luabind::def("get_zone_minimum_status", (uint8(*)(uint32))&lua_get_zone_minimum_status),
+		luabind::def("get_zone_minimum_status", (uint8(*)(uint32,int))&lua_get_zone_minimum_status),
+		luabind::def("get_zone_time_zone", (int(*)(uint32))&lua_get_zone_time_zone),
+		luabind::def("get_zone_time_zone", (int(*)(uint32,int))&lua_get_zone_time_zone),
+		luabind::def("get_zone_maximum_players", (int(*)(uint32))&lua_get_zone_maximum_players),
+		luabind::def("get_zone_maximum_players", (int(*)(uint32,int))&lua_get_zone_maximum_players),
+		luabind::def("get_zone_rule_set", (uint32(*)(uint32))&lua_get_zone_rule_set),
+		luabind::def("get_zone_rule_set", (uint32(*)(uint32,int))&lua_get_zone_rule_set),
+		luabind::def("get_zone_note", (std::string(*)(uint32))&lua_get_zone_note),
+		luabind::def("get_zone_note", (std::string(*)(uint32,int))&lua_get_zone_note),
+		luabind::def("get_zone_underworld", (float(*)(uint32))&lua_get_zone_underworld),
+		luabind::def("get_zone_underworld", (float(*)(uint32,int))&lua_get_zone_underworld),
+		luabind::def("get_zone_minimum_clip", (float(*)(uint32))&lua_get_zone_minimum_clip),
+		luabind::def("get_zone_minimum_clip", (float(*)(uint32,int))&lua_get_zone_minimum_clip),
+		luabind::def("get_zone_maximum_clip", (float(*)(uint32))&lua_get_zone_maximum_clip),
+		luabind::def("get_zone_maximum_clip", (float(*)(uint32,int))&lua_get_zone_maximum_clip),
+		luabind::def("get_zone_fog_minimum_clip", (float(*)(uint32))&lua_get_zone_fog_minimum_clip),
+		luabind::def("get_zone_fog_minimum_clip", (float(*)(uint32,uint8))&lua_get_zone_fog_minimum_clip),
+		luabind::def("get_zone_fog_minimum_clip", (float(*)(uint32,uint8,int))&lua_get_zone_fog_minimum_clip),
+		luabind::def("get_zone_fog_maximum_clip", (float(*)(uint32))&lua_get_zone_fog_maximum_clip),
+		luabind::def("get_zone_fog_maximum_clip", (float(*)(uint32,uint8))&lua_get_zone_fog_maximum_clip),
+		luabind::def("get_zone_fog_maximum_clip", (float(*)(uint32,uint8,int))&lua_get_zone_fog_maximum_clip),
+		luabind::def("get_zone_fog_red", (uint8(*)(uint32))&lua_get_zone_fog_red),
+		luabind::def("get_zone_fog_red", (uint8(*)(uint32,uint8))&lua_get_zone_fog_red),
+		luabind::def("get_zone_fog_red", (uint8(*)(uint32,uint8,int))&lua_get_zone_fog_red),
+		luabind::def("get_zone_fog_green", (uint8(*)(uint32))&lua_get_zone_fog_green),
+		luabind::def("get_zone_fog_green", (uint8(*)(uint32,uint8))&lua_get_zone_fog_green),
+		luabind::def("get_zone_fog_green", (uint8(*)(uint32,uint8,int))&lua_get_zone_fog_green),
+		luabind::def("get_zone_fog_blue", (uint8(*)(uint32))&lua_get_zone_fog_blue),
+		luabind::def("get_zone_fog_blue", (uint8(*)(uint32,uint8))&lua_get_zone_fog_blue),
+		luabind::def("get_zone_fog_blue", (uint8(*)(uint32,uint8,int))&lua_get_zone_fog_blue),
+		luabind::def("get_zone_sky", (uint8(*)(uint32))&lua_get_zone_sky),
+		luabind::def("get_zone_sky", (uint8(*)(uint32,int))&lua_get_zone_sky),
+		luabind::def("get_zone_ztype", (uint8(*)(uint32))&lua_get_zone_ztype),
+		luabind::def("get_zone_ztype", (uint8(*)(uint32,int))&lua_get_zone_ztype),
+		luabind::def("get_zone_experience_multiplier", (float(*)(uint32))&lua_get_zone_experience_multiplier),
+		luabind::def("get_zone_experience_multiplier", (float(*)(uint32,int))&lua_get_zone_experience_multiplier),
+		luabind::def("get_zone_walk_speed", (float(*)(uint32))&lua_get_zone_walk_speed),
+		luabind::def("get_zone_walk_speed", (float(*)(uint32,int))&lua_get_zone_walk_speed),
+		luabind::def("get_zone_time_type", (uint8(*)(uint32))&lua_get_zone_time_type),
+		luabind::def("get_zone_time_type", (uint8(*)(uint32,int))&lua_get_zone_time_type),
+		luabind::def("get_zone_fog_density", (float(*)(uint32))&lua_get_zone_fog_density),
+		luabind::def("get_zone_fog_density", (float(*)(uint32,int))&lua_get_zone_fog_density),
+		luabind::def("get_zone_flag_needed", (std::string(*)(uint32))&lua_get_zone_flag_needed),
+		luabind::def("get_zone_flag_needed", (std::string(*)(uint32,int))&lua_get_zone_flag_needed),
+		luabind::def("get_zone_can_bind", (int8(*)(uint32))&lua_get_zone_can_bind),
+		luabind::def("get_zone_can_bind", (int8(*)(uint32,int))&lua_get_zone_can_bind),
+		luabind::def("get_zone_can_combat", (int8(*)(uint32))&lua_get_zone_can_combat),
+		luabind::def("get_zone_can_combat", (int8(*)(uint32,int))&lua_get_zone_can_combat),
+		luabind::def("get_zone_can_levitate", (int8(*)(uint32))&lua_get_zone_can_levitate),
+		luabind::def("get_zone_can_levitate", (int8(*)(uint32,int))&lua_get_zone_can_levitate),
+		luabind::def("get_zone_cast_outdoor", (int8(*)(uint32))&lua_get_zone_cast_outdoor),
+		luabind::def("get_zone_cast_outdoor", (int8(*)(uint32,int))&lua_get_zone_cast_outdoor),
+		luabind::def("get_zone_hotzone", (uint8(*)(uint32))&lua_get_zone_hotzone),
+		luabind::def("get_zone_hotzone", (uint8(*)(uint32,int))&lua_get_zone_hotzone),
+		luabind::def("get_zone_instance_type", (uint8(*)(uint32))&lua_get_zone_instance_type),
+		luabind::def("get_zone_instance_type", (uint8(*)(uint32,int))&lua_get_zone_instance_type),
+		luabind::def("get_zone_shutdown_delay", (uint64(*)(uint32))&lua_get_zone_shutdown_delay),
+		luabind::def("get_zone_shutdown_delay", (uint64(*)(uint32,int))&lua_get_zone_shutdown_delay),
+			luabind::def("get_zone_peqzone", (int8(*)(uint32))&lua_get_zone_peqzone),
+			luabind::def("get_zone_peqzone", (int8(*)(uint32,int))&lua_get_zone_peqzone),
+			luabind::def("get_zone_expansion", (int8(*)(uint32))&lua_get_zone_expansion),
+			luabind::def("get_zone_expansion", (int8(*)(uint32,int))&lua_get_zone_expansion),
+			luabind::def("get_zone_bypass_expansion_check", (int8(*)(uint32))&lua_get_zone_bypass_expansion_check),
+			luabind::def("get_zone_bypass_expansion_check", (int8(*)(uint32,int))&lua_get_zone_bypass_expansion_check),
+			luabind::def("get_zone_suspend_buffs", (int8(*)(uint32))&lua_get_zone_suspend_buffs),
+			luabind::def("get_zone_suspend_buffs", (int8(*)(uint32,int))&lua_get_zone_suspend_buffs),
+			luabind::def("get_zone_rain_chance", (int(*)(uint32))&lua_get_zone_rain_chance),
+			luabind::def("get_zone_rain_chance", (int(*)(uint32,int))&lua_get_zone_rain_chance),
+			luabind::def("get_zone_rain_duration", (int(*)(uint32))&lua_get_zone_rain_duration),
+			luabind::def("get_zone_rain_duration", (int(*)(uint32,int))&lua_get_zone_rain_duration),
+			luabind::def("get_zone_snow_chance", (int(*)(uint32))&lua_get_zone_snow_chance),
+			luabind::def("get_zone_snow_chance", (int(*)(uint32,int))&lua_get_zone_snow_chance),
+			luabind::def("get_zone_snow_duration", (int(*)(uint32))&lua_get_zone_snow_duration),
+			luabind::def("get_zone_snow_duration", (int(*)(uint32,int))&lua_get_zone_snow_duration),
+			luabind::def("get_zone_gravity", (float(*)(uint32))&lua_get_zone_gravity),
+			luabind::def("get_zone_gravity", (float(*)(uint32,int))&lua_get_zone_gravity),
+			luabind::def("get_zone_type", (int(*)(uint32))&lua_get_zone_type),
+			luabind::def("get_zone_type", (int(*)(uint32,int))&lua_get_zone_type),
+			luabind::def("get_zone_sky_lock", (int(*)(uint32))&lua_get_zone_sky_lock),
+			luabind::def("get_zone_sky_lock", (int(*)(uint32,int))&lua_get_zone_sky_lock),
+			luabind::def("get_zone_fast_regen_hp", (int(*)(uint32))&lua_get_zone_fast_regen_hp),
+			luabind::def("get_zone_fast_regen_hp", (int(*)(uint32,int))&lua_get_zone_fast_regen_hp),
+			luabind::def("get_zone_fast_regen_mana", (int(*)(uint32))&lua_get_zone_fast_regen_mana),
+			luabind::def("get_zone_fast_regen_mana", (int(*)(uint32,int))&lua_get_zone_fast_regen_mana),
+			luabind::def("get_zone_fast_regen_endurance", (int(*)(uint32))&lua_get_zone_fast_regen_endurance),
+			luabind::def("get_zone_fast_regen_endurance", (int(*)(uint32,int))&lua_get_zone_fast_regen_endurance),
+			luabind::def("get_zone_npc_maximum_aggro_distance", (int(*)(uint32))&lua_get_zone_npc_maximum_aggro_distance),
+			luabind::def("get_zone_npc_maximum_aggro_distance", (int(*)(uint32,int))&lua_get_zone_npc_maximum_aggro_distance),
+			luabind::def("get_zone_npc_maximum_movement_update_range", (uint32(*)(uint32))&lua_get_zone_maximum_movement_update_range),
+			luabind::def("get_zone_npc_maximum_movement_update_range", (uint32(*)(uint32,int))&lua_get_zone_maximum_movement_update_range),
+			luabind::def("get_zone_minimum_expansion", (int8(*)(uint32))&lua_get_zone_minimum_expansion),
+			luabind::def("get_zone_minimum_expansion", (int8(*)(uint32,int))&lua_get_zone_minimum_expansion),
+			luabind::def("get_zone_maximum_expansion", (int8(*)(uint32))&lua_get_zone_maximum_expansion),
+			luabind::def("get_zone_maximum_expansion", (int8(*)(uint32,int))&lua_get_zone_maximum_expansion),
+			luabind::def("get_zone_content_flags", (std::string(*)(uint32))&lua_get_zone_content_flags),
+			luabind::def("get_zone_content_flags", (std::string(*)(uint32,int))&lua_get_zone_content_flags),
+			luabind::def("get_zone_content_flags_disabled", (std::string(*)(uint32))&lua_get_zone_content_flags_disabled),
+			luabind::def("get_zone_content_flags_disabled", (std::string(*)(uint32,int))&lua_get_zone_content_flags_disabled),
+			luabind::def("get_zone_underworld_teleport_index", (int(*)(uint32))&lua_get_zone_underworld_teleport_index),
+			luabind::def("get_zone_underworld_teleport_index", (int(*)(uint32,int))&lua_get_zone_underworld_teleport_index),
+			luabind::def("get_zone_lava_damage", (int(*)(uint32))&lua_get_zone_lava_damage),
+			luabind::def("get_zone_lava_damage", (int(*)(uint32,int))&lua_get_zone_lava_damage),
+			luabind::def("get_zone_minimum_lava_damage", (int(*)(uint32))&lua_get_zone_minimum_lava_damage),
+			luabind::def("get_zone_minimum_lava_damage", (int(*)(uint32,int))&lua_get_zone_minimum_lava_damage),
 		/*
 			Cross Zone
 		*/


### PR DESCRIPTION
# Perl
- Add `quest::GetZoneSafeX(zone_id)`.
- Add `quest::GetZoneSafeX(zone_id, version)`.
- Add `quest::GetZoneSafeY(zone_id)`.
- Add `quest::GetZoneSafeY(zone_id, version)`.
- Add `quest::GetZoneSafeZ(zone_id)`.
- Add `quest::GetZoneSafeZ(zone_id, version)`.
- Add `quest::GetZoneSafeHeading(zone_id)`.
- Add `quest::GetZoneSafeHeading(zone_id, version)`.
- Add `quest::GetZoneMinimumLevel(zone_id)`.
- Add `quest::GetZoneMinimumLevel(zone_id, version)`.
- Add `quest::GetZoneMaximumLevel(zone_id)`.
- Add `quest::GetZoneMaximumLevel(zone_id, version)`.
- Add `quest::GetZoneMinimumStatus(zone_id)`.
- Add `quest::GetZoneMinimumStatus(zone_id, version)`.
- Add `quest::GetZoneTimeZone(zone_id)`.
- Add `quest::GetZoneTimeZone(zone_id, version)`.
- Add `quest::GetZoneMaximumPlayers(zone_id)`.
- Add `quest::GetZoneMaximumPlayers(zone_id, version)`.
- Add `quest::GetZoneRuleSet(zone_id)`.
- Add `quest::GetZoneRuleSet(zone_id, version)`.
- Add `quest::GetZoneNote(zone_id)`.
- Add `quest::GetZoneNote(zone_id, version)`.
- Add `quest::GetZoneUnderworld(zone_id)`.
- Add `quest::GetZoneUnderworld(zone_id, version)`.
- Add `quest::GetZoneMinimumClip(zone_id)`.
- Add `quest::GetZoneMinimumClip(zone_id, version)`.
- Add `quest::GetZoneMaximumClip(zone_id)`.
- Add `quest::GetZoneMaximumClip(zone_id, version)`.
- Add `quest::GetZoneFogMinimumClip(zone_id)`.
- Add `quest::GetZoneFogMinimumClip(zone_id, slot)`.
- Add `quest::GetZoneFogMinimumClip(zone_id, slot, version)`.
- Add `quest::GetZoneFogMaximumClip(zone_id)`.
- Add `quest::GetZoneFogMaximumClip(zone_id, slot)`.
- Add `quest::GetZoneFogMaximumClip(zone_id, slot, version)`.
- Add `quest::GetZoneFogRed(zone_id)`.
- Add `quest::GetZoneFogRed(zone_id, slot)`.
- Add `quest::GetZoneFogRed(zone_id, slot, version)`.
- Add `quest::GetZoneFogGreen(zone_id)`.
- Add `quest::GetZoneFogGreen(zone_id, slot)`.
- Add `quest::GetZoneFogGreen(zone_id, slot, version)`.
- Add `quest::GetZoneFogBlue(zone_id)`.
- Add `quest::GetZoneFogBlue(zone_id, slot)`.
- Add `quest::GetZoneFogBlue(zone_id, slot, version)`.
- Add `quest::GetZoneSky(zone_id)`.
- Add `quest::GetZoneSky(zone_id, version)`.
- Add `quest::GetZoneZType(zone_id)`.
- Add `quest::GetZoneZType(zone_id, version)`.
- Add `quest::GetZoneExperienceMultiplier(zone_id)`.
- Add `quest::GetZoneExperienceMultiplier(zone_id, version)`.
- Add `quest::GetZoneWalkSpeed(zone_id)`.
- Add `quest::GetZoneWalkSpeed(zone_id, version)`.
- Add `quest::GetZoneTimeType(zone_id)`.
- Add `quest::GetZoneTimeType(zone_id, version)`.
- Add `quest::GetZoneFogDensity(zone_id)`.
- Add `quest::GetZoneFogDensity(zone_id, version)`.
- Add `quest::GetZoneFlagNeeded(zone_id)`.
- Add `quest::GetZoneFlagNeeded(zone_id, version)`.
- Add `quest::GetZoneCanBind(zone_id)`.
- Add `quest::GetZoneCanBind(zone_id, version)`.
- Add `quest::GetZoneCanCombat(zone_id)`.
- Add `quest::GetZoneCanCombat(zone_id, version)`.
- Add `quest::GetZoneCanLevitate(zone_id)`.
- Add `quest::GetZoneCanLevitate(zone_id, version)`.
- Add `quest::GetZoneCastOutdoor(zone_id)`.
- Add `quest::GetZoneCastOutdoor(zone_id, version)`.
- Add `quest::GetZoneHotzone(zone_id)`.
- Add `quest::GetZoneHotzone(zone_id, version)`.
- Add `quest::GetZoneInstanceType(zone_id)`.
- Add `quest::GetZoneInstanceType(zone_id, version)`.
- Add `quest::GetZoneShutdownDelay(zone_id)`.
- Add `quest::GetZoneShutdownDelay(zone_id, version)`.
- Add `quest::GetZonePEQZone(zone_id)`.
- Add `quest::GetZonePEQZone(zone_id, version)`.
- Add `quest::GetZoneExpansion(zone_id)`.
- Add `quest::GetZoneExpansion(zone_id, version)`.
- Add `quest::GetZoneBypassExpansionCheck(zone_id)`.
- Add `quest::GetZoneBypassExpansionCheck(zone_id, version)`.
- Add `quest::GetZoneSuspendBuffs(zone_id)`.
- Add `quest::GetZoneSuspendBuffs(zone_id, version)`.
- Add `quest::GetZoneRainChance(zone_id)`.
- Add `quest::GetZoneRainChance(zone_id, slot)`.
- Add `quest::GetZoneRainChance(zone_id, slot, version)`.
- Add `quest::GetZoneRainDuration(zone_id)`.
- Add `quest::GetZoneRainDuration(zone_id, slot)`.
- Add `quest::GetZoneRainDuration(zone_id, slot, version)`.
- Add `quest::GetZoneSnowChance(zone_id)`.
- Add `quest::GetZoneSnowChance(zone_id, slot)`.
- Add `quest::GetZoneSnowChance(zone_id, slot, version)`.
- Add `quest::GetZoneSnowDuration(zone_id)`.
- Add `quest::GetZoneSnowDuration(zone_id, slot)`.
- Add `quest::GetZoneSnowDuration(zone_id, slot, version)`.
- Add `quest::GetZoneGravity(zone_id)`.
- Add `quest::GetZoneGravity(zone_id, version)`.
- Add `quest::GetZoneType(zone_id)`.
- Add `quest::GetZoneType(zone_id, version)`.
- Add `quest::GetZoneSkyLock(zone_id)`.
- Add `quest::GetZoneSkyLock(zone_id, version)`.
- Add `quest::GetZoneFastRegenHP(zone_id)`.
- Add `quest::GetZoneFastRegenHP(zone_id, version)`.
- Add `quest::GetZoneFastRegenMana(zone_id)`.
- Add `quest::GetZoneFastRegenMana(zone_id, version)`.
- Add `quest::GetZoneFastRegenEndurance(zone_id)`.
- Add `quest::GetZoneFastRegenEndurance(zone_id, version)`.
- Add `quest::GetZoneNPCMaximumAggroDistance(zone_id)`.
- Add `quest::GetZoneNPCMaximumAggroDistance(zone_id, version)`.
- Add `quest::GetZoneMaximumMovementUpdateRange(zone_id)`.
- Add `quest::GetZoneMaximumMovementUpdateRange(zone_id, version)`.
- Add `quest::GetZoneMinimumExpansion(zone_id)`.
- Add `quest::GetZoneMinimumExpansion(zone_id, version)`.
- Add `quest::GetZoneMaximumExpansion(zone_id)`.
- Add `quest::GetZoneMaximumExpansion(zone_id, version)`.
- Add `quest::GetZoneContentFlags(zone_id)`.
- Add `quest::GetZoneContentFlags(zone_id, version)`.
- Add `quest::GetZoneContentFlagsDisabled(zone_id)`.
- Add `quest::GetZoneContentFlagsDisabled(zone_id, version)`.
- Add `quest::GetZoneUnderworldTeleportIndex(zone_id)`.
- Add `quest::GetZoneUnderworldTeleportIndex(zone_id, version)`.
- Add `quest::GetZoneLavaDamage(zone_id)`.
- Add `quest::GetZoneLavaDamage(zone_id, version)`.
- Add `quest::GetZoneMinimumLavaDamage(zone_id)`.
- Add `quest::GetZoneMinimumLavaDamage(zone_id, version)`.

# Lua
- Add `eq.get_zone_safe_x(zone_id)`.
- Add `eq.get_zone_safe_x(zone_id, version)`.
- Add `eq.get_zone_safe_y(zone_id)`.
- Add `eq.get_zone_safe_y(zone_id, version)`.
- Add `eq.get_zone_safe_z(zone_id)`.
- Add `eq.get_zone_safe_z(zone_id, version)`.
- Add `eq.get_zone_safe_heading(zone_id)`.
- Add `eq.get_zone_safe_heading(zone_id, version)`.
- Add `eq.get_zone_minimum_level(zone_id)`.
- Add `eq.get_zone_minimum_level(zone_id, version)`.
- Add `eq.get_zone_maximum_level(zone_id)`.
- Add `eq.get_zone_maximum_level(zone_id, version)`.
- Add `eq.get_zone_minimum_status(zone_id)`.
- Add `eq.get_zone_minimum_status(zone_id, version)`.
- Add `eq.get_zone_time_zone(zone_id)`.
- Add `eq.get_zone_time_zone(zone_id, version)`.
- Add `eq.get_zone_maximum_players(zone_id)`.
- Add `eq.get_zone_maximum_players(zone_id, version)`.
- Add `eq.get_zone_rule_set(zone_id)`.
- Add `eq.get_zone_rule_set(zone_id, version)`.
- Add `eq.get_zone_note(zone_id)`.
- Add `eq.get_zone_note(zone_id, version)`.
- Add `eq.get_zone_underworld(zone_id)`.
- Add `eq.get_zone_underworld(zone_id, version)`.
- Add `eq.get_zone_minimum_clip(zone_id)`.
- Add `eq.get_zone_minimum_clip(zone_id, version)`.
- Add `eq.get_zone_maximum_clip(zone_id)`.
- Add `eq.get_zone_maximum_clip(zone_id, version)`.
- Add `eq.get_zone_fog_minimum_clip(zone_id)`.
- Add `eq.get_zone_fog_minimum_clip(zone_id, slot)`.
- Add `eq.get_zone_fog_minimum_clip(zone_id, slot, version)`.
- Add `eq.get_zone_fog_maximum_clip(zone_id)`.
- Add `eq.get_zone_fog_maximum_clip(zone_id, slot)`.
- Add `eq.get_zone_fog_maximum_clip(zone_id, slot, version)`.
- Add `eq.get_zone_fog_red(zone_id)`.
- Add `eq.get_zone_fog_red(zone_id, slot)`.
- Add `eq.get_zone_fog_red(zone_id, slot, version)`.
- Add `eq.get_zone_fog_green(zone_id)`.
- Add `eq.get_zone_fog_green(zone_id, slot)`.
- Add `eq.get_zone_fog_green(zone_id, slot, version)`.
- Add `eq.get_zone_fog_blue(zone_id)`.
- Add `eq.get_zone_fog_blue(zone_id, slot)`.
- Add `eq.get_zone_fog_blue(zone_id, slot, version)`.
- Add `eq.get_zone_sky(zone_id)`.
- Add `eq.get_zone_sky(zone_id, version)`.
- Add `eq.get_zone_ztype(zone_id)`.
- Add `eq.get_zone_ztype(zone_id, version)`.
- Add `eq.get_zone_experience_multiplier(zone_id)`.
- Add `eq.get_zone_experience_multiplier(zone_id, version)`.
- Add `eq.get_zone_walk_speed(zone_id)`.
- Add `eq.get_zone_walk_speed(zone_id, version)`.
- Add `eq.get_zone_time_type(zone_id)`.
- Add `eq.get_zone_time_type(zone_id, version)`.
- Add `eq.get_zone_fog_density(zone_id)`.
- Add `eq.get_zone_fog_density(zone_id, version)`.
- Add `eq.get_zone_flag_needed(zone_id)`.
- Add `eq.get_zone_flag_needed(zone_id, version)`.
- Add `eq.get_zone_can_bind(zone_id)`.
- Add `eq.get_zone_can_bind(zone_id, version)`.
- Add `eq.get_zone_can_combat(zone_id)`.
- Add `eq.get_zone_can_combat(zone_id, version)`.
- Add `eq.get_zone_can_levitate(zone_id)`.
- Add `eq.get_zone_can_levitate(zone_id, version)`.
- Add `eq.get_zone_cast_outdoor(zone_id)`.
- Add `eq.get_zone_cast_outdoor(zone_id, version)`.
- Add `eq.get_zone_hotzone(zone_id)`.
- Add `eq.get_zone_hotzone(zone_id, version)`.
- Add `eq.get_zone_instance_type(zone_id)`.
- Add `eq.get_zone_instance_type(zone_id, version)`.
- Add `eq.get_zone_shutdown_delay(zone_id)`.
- Add `eq.get_zone_shutdown_delay(zone_id, version)`.
- Add `eq.get_zone_peqzone(zone_id)`.
- Add `eq.get_zone_peqzone(zone_id, version)`.
- Add `eq.get_zone_expansion(zone_id)`.
- Add `eq.get_zone_expansion(zone_id, version)`.
- Add `eq.get_zone_bypass_expansion_check(zone_id)`.
- Add `eq.get_zone_bypass_expansion_check(zone_id, version)`.
- Add `eq.get_zone_suspend_buffs(zone_id)`.
- Add `eq.get_zone_suspend_buffs(zone_id, version)`.
- Add `eq.get_zone_rain_chance(zone_id)`.
- Add `eq.get_zone_rain_chance(zone_id, slot)`.
- Add `eq.get_zone_rain_chance(zone_id, slot, version)`.
- Add `eq.get_zone_rain_duration(zone_id)`.
- Add `eq.get_zone_rain_duration(zone_id, slot)`.
- Add `eq.get_zone_rain_duration(zone_id, slot, version)`.
- Add `eq.get_zone_snow_chance(zone_id)`.
- Add `eq.get_zone_snow_chance(zone_id, slot)`.
- Add `eq.get_zone_snow_chance(zone_id, slot, version)`.
- Add `eq.get_zone_snow_duration(zone_id)`.
- Add `eq.get_zone_snow_duration(zone_id, slot)`.
- Add `eq.get_zone_snow_duration(zone_id, slot, version)`.
- Add `eq.get_zone_gravity(zone_id)`.
- Add `eq.get_zone_gravity(zone_id, version)`.
- Add `eq.get_zone_type(zone_id)`.
- Add `eq.get_zone_type(zone_id, version)`.
- Add `eq.get_zone_sky_lock(zone_id)`.
- Add `eq.get_zone_sky_lock(zone_id, version)`.
- Add `eq.get_zone_fast_regen_hp(zone_id)`.
- Add `eq.get_zone_fast_regen_hp(zone_id, version)`.
- Add `eq.get_zone_fast_regen_mana(zone_id)`.
- Add `eq.get_zone_fast_regen_mana(zone_id, version)`.
- Add `eq.get_zone_fast_regen_endurance(zone_id)`.
- Add `eq.get_zone_fast_regen_endurance(zone_id, version)`.
- Add `eq.get_zone_npc_maximum_aggro_distance(zone_id)`.
- Add `eq.get_zone_npc_maximum_aggro_distance(zone_id, version)`.
- Add `eq.get_zone_maximum_movement_update_range(zone_id)`.
- Add `eq.get_zone_maximum_movement_update_range(zone_id, version)`.
- Add `eq.get_zone_minimum_expansion(zone_id)`.
- Add `eq.get_zone_minimum_expansion(zone_id, version)`.
- Add `eq.get_zone_maximum_expansion(zone_id)`.
- Add `eq.get_zone_maximum_expansion(zone_id, version)`.
- Add `eq.get_zone_content_flags(zone_id)`.
- Add `eq.get_zone_content_flags(zone_id, version)`.
- Add `eq.get_zone_content_flags_disabled(zone_id)`.
- Add `eq.get_zone_content_flags_disabled(zone_id, version)`.
- Add `eq.get_zone_underworld_teleport_index(zone_id)`.
- Add `eq.get_zone_underworld_teleport_index(zone_id, version)`.
- Add `eq.get_zone_lava_damage(zone_id)`.
- Add `eq.get_zone_lava_damage(zone_id, version)`.
- Add `eq.get_zone_minimum_lava_damage(zone_id)`.
- Add `eq.get_zone_minimum_lava_damage(zone_id, version)`.

# Notes
- These methods add support for reading every value that the `zone` table contains, allowing operators to get any information about a specific zone and version they could need.
- Version defaults to `0` which is what most zones use by default.