### PR TITLE
[Rules] Add World:MaximumQuestErrors Rule

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -297,6 +297,7 @@ RULE_BOOL(World, StartZoneSameAsBindOnCreation, true, "Should the start zone alw
 RULE_BOOL(World, EnforceCharacterLimitAtLogin, false, "Enforce the limit for characters that are online at login")
 RULE_BOOL(World, EnableDevTools, true, "Enable or Disable the Developer Tools globally (Most of the time you want this enabled)")
 RULE_BOOL(World, EnableChecksumVerification, false, "Enable or Disable the Checksum Verification for eqgame.exe and spells_us.txt")
+RULE_INT(World, MaximumQuestErrors, 30, "Changes the maximum number of quest errors that can be displayed in #questerrors, default is 30")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Zone)

--- a/zone/gm_commands/questerrors.cpp
+++ b/zone/gm_commands/questerrors.cpp
@@ -11,8 +11,15 @@ void command_questerrors(Client *c, const Seperator *sep)
 
 		int error_index = 0;
 		for (auto quest_error : quest_errors) {
-			if (error_index >= 30) {
-				c->Message(Chat::White, "Maximum of 30 errors shown.");
+			if (error_index >= RuleI(World, MaximumQuestErrors)) {
+				c->Message(
+					Chat::White,
+					fmt::format(
+						"Maximum of {} error{} shown.",
+						RuleI(World, MaximumQuestErrors),
+						RuleI(World, MaximumQuestErrors) != 1 ? "s" : ""
+					).c_str()
+				);
 				break;
 			}
 

--- a/zone/quest_interface.h
+++ b/zone/quest_interface.h
@@ -116,7 +116,6 @@ public:
 	virtual uint32 GetIdentifier() = 0;
 	virtual void RemoveEncounter(const std::string &name) { }
 
-	//TODO: Set maximum quest errors instead of hard coding it
 	virtual void GetErrors(std::list<std::string> &quest_errors) {
 		quest_errors.insert(quest_errors.end(), errors_.begin(), errors_.end());
 	}

--- a/zone/quest_interface.h
+++ b/zone/quest_interface.h
@@ -126,7 +126,7 @@ public:
 		LogQuestErrors("{}", Strings::Trim(error));
 
 		errors_.push_back(error);
-		if(errors_.size() > 30) {
+		if (errors_.size() > RuleI(World, MaximumQuestErrors)) {
 			errors_.pop_front();
 		}
 	}


### PR DESCRIPTION
# Notes
- Allows operators to display more than 30 errors with #questerrors if they want.