### PR TITLE
[Bug Fix] Mob scaling issue with min dmg set to zero while max dmg is not

### DIFF
--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -2613,6 +2613,11 @@ void NPC::ModifyNPCStat(const std::string& stat, const std::string& value)
 	else if (stat_lower == "min_hit") {
 		min_dmg     = Strings::ToInt(value);
 		// TODO: fix DB
+		if (min_dmg > max_dmg) {
+			const auto temporary_damage = max_dmg;
+			max_dmg = min_dmg;
+			min_dmg = temporary_damage;
+		}
 		base_damage = round((max_dmg - min_dmg) / 1.9);
 		min_damage  = min_dmg - round(base_damage / 10.0);
 		return;
@@ -2620,6 +2625,11 @@ void NPC::ModifyNPCStat(const std::string& stat, const std::string& value)
 	else if (stat_lower == "max_hit") {
 		max_dmg     = Strings::ToInt(value);
 		// TODO: fix DB
+		if (max_dmg < min_dmg) {
+			const auto temporary_damage = min_dmg;
+			min_dmg = max_dmg;
+			max_dmg = temporary_damage;
+		}
 		base_damage = round((max_dmg - min_dmg) / 1.9);
 		min_damage  = min_dmg - round(base_damage / 10.0);
 		return;

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -2611,25 +2611,31 @@ void NPC::ModifyNPCStat(const std::string& stat, const std::string& value)
 		return;
 	}
 	else if (stat_lower == "min_hit") {
-		min_dmg     = Strings::ToInt(value);
+		min_dmg = Strings::ToInt(value);
+
 		// TODO: fix DB
+
 		if (min_dmg > max_dmg) {
 			const auto temporary_damage = max_dmg;
 			max_dmg = min_dmg;
 			min_dmg = temporary_damage;
 		}
+
 		base_damage = round((max_dmg - min_dmg) / 1.9);
 		min_damage  = min_dmg - round(base_damage / 10.0);
 		return;
 	}
 	else if (stat_lower == "max_hit") {
-		max_dmg     = Strings::ToInt(value);
+		max_dmg = Strings::ToInt(value);
+
 		// TODO: fix DB
+
 		if (max_dmg < min_dmg) {
 			const auto temporary_damage = min_dmg;
 			min_dmg = max_dmg;
 			max_dmg = temporary_damage;
 		}
+
 		base_damage = round((max_dmg - min_dmg) / 1.9);
 		min_damage  = min_dmg - round(base_damage / 10.0);
 		return;

--- a/zone/npc_scale_manager.cpp
+++ b/zone/npc_scale_manager.cpp
@@ -134,7 +134,9 @@ void NpcScaleManager::ScaleNPC(
 	if (always_scale || (npc->GetPhR() == 0 && is_auto_scaled)) {
 		npc->ModifyNPCStat("phr", std::to_string(scale_data.physical_resist));
 	}
-	bool min_damage_set = false;
+
+	auto min_damage_set = false;
+
 	if (always_scale || npc->GetMinDMG() == 0) {
 		int64 min_dmg = scale_data.min_dmg;
 		if (RuleB(Combat, UseNPCDamageClassLevelMods)) {

--- a/zone/npc_scale_manager.cpp
+++ b/zone/npc_scale_manager.cpp
@@ -134,7 +134,7 @@ void NpcScaleManager::ScaleNPC(
 	if (always_scale || (npc->GetPhR() == 0 && is_auto_scaled)) {
 		npc->ModifyNPCStat("phr", std::to_string(scale_data.physical_resist));
 	}
-
+	bool min_damage_set = false;
 	if (always_scale || npc->GetMinDMG() == 0) {
 		int64 min_dmg = scale_data.min_dmg;
 		if (RuleB(Combat, UseNPCDamageClassLevelMods)) {
@@ -145,9 +145,10 @@ void NpcScaleManager::ScaleNPC(
 		}
 
 		npc->ModifyNPCStat("min_hit", std::to_string(min_dmg));
+		min_damage_set = true;
 	}
 
-	if (always_scale || npc->GetMaxDMG() == 0) {
+	if (always_scale || npc->GetMaxDMG() == 0 || min_damage_set) {
 		int64 max_dmg = scale_data.max_dmg;
 		if (RuleB(Combat, UseNPCDamageClassLevelMods)) {
 			uint32 class_level_damage_mod = GetClassLevelDamageMod(npc->GetLevel(), npc->GetClass());


### PR DESCRIPTION
A user on Ret submitted a bug where they were one shot by a low level mob. I was able to reproduce this and started to diagnose the issue. It seemed to be where a Min Dmg value of 0 and a max dmg value of 3 was set in the database for this NPC. 
![image](https://github.com/EQEmu/Server/assets/4657161/5362fa99-70e2-4cb9-948f-9acf1c3c9563)

The min dmg scaling kicks in, but you get into a situation where MIN DMG > MAX DMG (12 vs 3 in this case)
It leads to situations like thus. 
![image](https://github.com/EQEmu/Server/assets/4657161/cf15912f-e133-40a5-b2c0-d3a7630edcb4)

Looking at it deeper it seems to be in the calculation area for rounding. 

![image](https://github.com/EQEmu/Server/assets/4657161/c31afa87-1d13-4d25-a240-47ad9fa6030a)

I worked with Kingly and setup some sanity code to prevent wild situations of being hit for millions of damage, but needed to go one step further. 

I also changed it so that if you set Min Dmg to 0, it means max damage is also auto calculated... this had the mob working as I would expect a lvl 28 mob to be. 

![image](https://github.com/EQEmu/Server/assets/4657161/e644418a-216f-4ba9-a233-0580282fdf91)

