### PR TITLE
[Cleanup] Remove GetEscapingEntOnHateList() from hate_list.cpp/hate_list.h

### DIFF
--- a/zone/hate_list.cpp
+++ b/zone/hate_list.cpp
@@ -591,29 +591,6 @@ Mob *HateList::GetRandomEntOnHateList(bool skip_mezzed)
 	return nullptr;
 }
 
-Mob *HateList::GetEscapingEntOnHateList() {
-	// function is still in design stage
-
-	for (auto iter : list) {
-		if (!iter->entity_on_hatelist)
-			continue;
-
-		if (!iter->entity_on_hatelist->IsFeared())
-			continue;
-
-		if (iter->entity_on_hatelist->IsRooted())
-			continue;
-		if (iter->entity_on_hatelist->IsMezzed())
-			continue;
-		if (iter->entity_on_hatelist->IsStunned())
-			continue;
-
-		return iter->entity_on_hatelist;
-	}
-
-	return nullptr;
-}
-
 Mob *HateList::GetEscapingEntOnHateList(Mob *center, float range, bool first) {
 	// function is still in design stage
 

--- a/zone/hate_list.h
+++ b/zone/hate_list.h
@@ -46,7 +46,6 @@ public:
 	Mob *GetEntWithMostHateOnList(Mob *center, Mob *skip = nullptr, bool skip_mezzed = false);
 	Mob *GetRandomEntOnHateList(bool skip_mezzed = false);
 	Mob *GetEntWithMostHateOnList(bool skip_mezzed = false);
-	Mob *GetEscapingEntOnHateList(); // returns first eligble entity
 	Mob *GetEscapingEntOnHateList(Mob *center, float range = 0.0f, bool first = false);
 
 	Bot* GetRandomBotOnHateList(bool skip_mezzed = false);


### PR DESCRIPTION
# Notes
- This is unused.