### PR TITLE
[Cleanup] Remove SetGraveyard() from zone.cpp/zone.h

### DIFF
--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -2205,11 +2205,6 @@ bool Zone::HasGraveyard() {
 	return Result;
 }
 
-void Zone::SetGraveyard(uint32 zoneid, const glm::vec4& graveyardPosition) {
-	pgraveyard_zoneid = zoneid;
-	m_graveyard       = graveyardPosition;
-}
-
 void Zone::LoadZoneBlockedSpells()
 {
 	if (!blocked_spells) {

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -296,7 +296,6 @@ public:
 	void RequestUCSServerStatus();
 	void ResetAuth();
 	void SetDate(uint16 year, uint8 month, uint8 day, uint8 hour, uint8 minute);
-	void SetGraveyard(uint32 zoneid, const glm::vec4 &graveyardPosition);
 	void SetInstanceTimer(uint32 new_duration);
 	void SetStaticZone(bool sz) { staticzone = sz; }
 	void SetTime(uint8 hour, uint8 minute, bool update_world = true);


### PR DESCRIPTION
# Notes
- This is unused.