### PR TITLE
[Cleanup] Remove GetDamageReceived() and GetHealReceived() from combat_record.cpp/combat_record.h

### DIFF
--- a/zone/combat_record.cpp
+++ b/zone/combat_record.cpp
@@ -71,13 +71,3 @@ float CombatRecord::GetHealedReceivedPerSecond() const
 	double time_in_combat = TimeInCombat();
 	return time_in_combat > 0 ? (m_heal_received / time_in_combat) : m_heal_received;
 }
-
-int64 CombatRecord::GetDamageReceived() const
-{
-	return m_damage_received;
-}
-
-int64 CombatRecord::GetHealReceived() const
-{
-	return m_heal_received;
-}

--- a/zone/combat_record.h
+++ b/zone/combat_record.h
@@ -12,8 +12,6 @@ public:
 	bool InCombat() const;
 	void ProcessHPEvent(int64 hp, int64 current_hp);
 	double TimeInCombat() const;
-	int64 GetDamageReceived() const;
-	int64 GetHealReceived() const;
 	float GetDamageReceivedPerSecond() const;
 	float GetHealedReceivedPerSecond() const;
 private:


### PR DESCRIPTION
# Notes
- These are unused.