### PR TITLE
[Quest API] Add GetHateListClosest(), GetHateListClosestBot(), GetHateListClosestClient(), and GetHateListClosestNPC() methods/overloads to Perl/Lua

### DIFF
--- a/common/emu_constants.h
+++ b/common/emu_constants.h
@@ -593,13 +593,6 @@ enum class ApplySpellType {
 	Raid
 };
 
-enum class ClosestEntityType {
-	Any,
-	Bot,
-	Client,
-	NPC
-};
-
 
 namespace HeroicBonusBucket
 {

--- a/common/emu_constants.h
+++ b/common/emu_constants.h
@@ -593,6 +593,13 @@ enum class ApplySpellType {
 	Raid
 };
 
+enum class ClosestEntityType {
+	Any,
+	Bot,
+	Client,
+	NPC
+};
+
 
 namespace HeroicBonusBucket
 {

--- a/zone/hate_list.cpp
+++ b/zone/hate_list.cpp
@@ -155,7 +155,7 @@ Mob* HateList::GetDamageTopOnHateList(Mob* hater)
 	return current;
 }
 
-Mob* HateList::GetClosestEntOnHateList(Mob *hater, bool skip_mezzed, ClosestEntityType entity_type) {
+Mob* HateList::GetClosestEntOnHateList(Mob *hater, bool skip_mezzed, EntityFilterType entity_type) {
 	Mob* close_entity = nullptr;
 	float close_distance = 99999.9f;
 	float this_distance;
@@ -170,22 +170,22 @@ Mob* HateList::GetClosestEntOnHateList(Mob *hater, bool skip_mezzed, ClosestEnti
 		}
 
 		switch (entity_type) {
-			case ClosestEntityType::Bot:
+			case EntityFilterType::Bot:
 				if (!e->entity_on_hatelist->IsBot()) {
 					continue;
 				}
 				break;
-			case ClosestEntityType::Client:
+			case EntityFilterType::Client:
 				if (!e->entity_on_hatelist->IsClient()) {
 					continue;
 				}
 				break;
-			case ClosestEntityType::NPC:
+			case EntityFilterType::NPC:
 				if (!e->entity_on_hatelist->IsNPC()) {
 					continue;
 				}
 				break;
-			case ClosestEntityType::Any:
+			case EntityFilterType::All:
 			default:
 				break;
 		}

--- a/zone/hate_list.cpp
+++ b/zone/hate_list.cpp
@@ -180,6 +180,34 @@ Mob* HateList::GetClosestEntOnHateList(Mob *hater, bool skip_mezzed) {
 
 	return close_entity;
 }
+Mob* HateList::GetClosestClientOnHateList(Mob* hater, bool skip_mezzed) {
+	Mob* close_entity = nullptr;
+	float close_distance = 99999.9f;
+	float this_distance;
+
+	auto iterator = list.begin();
+	while (iterator != list.end()) {
+		if (skip_mezzed && (*iterator)->entity_on_hatelist->IsMezzed()) {
+			++iterator;
+			continue;
+		}
+		if (!(*iterator)->entity_on_hatelist->IsClient()) {
+			++iterator;
+			continue;
+		}
+		this_distance = DistanceSquaredNoZ((*iterator)->entity_on_hatelist->GetPosition(), hater->GetPosition());
+		if ((*iterator)->entity_on_hatelist != nullptr && this_distance <= close_distance) {
+			close_distance = this_distance;
+			close_entity = (*iterator)->entity_on_hatelist;
+		}
+		++iterator;
+	}
+
+	if ((!close_entity && hater->IsNPC()) || (close_entity && close_entity->DivineAura()))
+		close_entity = hater->CastToNPC()->GetHateTop();
+
+	return close_entity;
+}
 
 void HateList::AddEntToHateList(Mob *in_entity, int64 in_hate, int64 in_damage, bool in_is_entity_frenzied, bool iAddIfNotExist)
 {

--- a/zone/hate_list.cpp
+++ b/zone/hate_list.cpp
@@ -170,17 +170,17 @@ Mob* HateList::GetClosestEntOnHateList(Mob *hater, bool skip_mezzed, EntityFilte
 		}
 
 		switch (entity_type) {
-			case EntityFilterType::Bot:
+			case EntityFilterType::Bots:
 				if (!e->entity_on_hatelist->IsBot()) {
 					continue;
 				}
 				break;
-			case EntityFilterType::Client:
+			case EntityFilterType::Clients:
 				if (!e->entity_on_hatelist->IsClient()) {
 					continue;
 				}
 				break;
-			case EntityFilterType::NPC:
+			case EntityFilterType::NPCs:
 				if (!e->entity_on_hatelist->IsNPC()) {
 					continue;
 				}

--- a/zone/hate_list.h
+++ b/zone/hate_list.h
@@ -42,6 +42,7 @@ public:
 	~HateList();
 
 	Mob *GetClosestEntOnHateList(Mob *hater, bool skip_mezzed = false);
+	Mob* GetClosestClientOnHateList(Mob* hater, bool skip_mezzed = false);
 	Mob *GetDamageTopOnHateList(Mob *hater); // didn't add 'skip_mezzed' due to calls being in ::Death()
 	Mob *GetEntWithMostHateOnList(Mob *center, Mob *skip = nullptr, bool skip_mezzed = false);
 	Mob *GetRandomEntOnHateList(bool skip_mezzed = false);

--- a/zone/hate_list.h
+++ b/zone/hate_list.h
@@ -41,8 +41,7 @@ public:
 	HateList();
 	~HateList();
 
-	Mob *GetClosestEntOnHateList(Mob *hater, bool skip_mezzed = false);
-	Mob* GetClosestClientOnHateList(Mob* hater, bool skip_mezzed = false);
+	Mob *GetClosestEntOnHateList(Mob *hater, bool skip_mezzed = false, ClosestEntityType entity_type = ClosestEntityType::Any);
 	Mob *GetDamageTopOnHateList(Mob *hater); // didn't add 'skip_mezzed' due to calls being in ::Death()
 	Mob *GetEntWithMostHateOnList(Mob *center, Mob *skip = nullptr, bool skip_mezzed = false);
 	Mob *GetRandomEntOnHateList(bool skip_mezzed = false);

--- a/zone/hate_list.h
+++ b/zone/hate_list.h
@@ -41,7 +41,7 @@ public:
 	HateList();
 	~HateList();
 
-	Mob *GetClosestEntOnHateList(Mob *hater, bool skip_mezzed = false, ClosestEntityType entity_type = ClosestEntityType::Any);
+	Mob *GetClosestEntOnHateList(Mob *hater, bool skip_mezzed = false, EntityFilterType entity_type = EntityFilterType::Any);
 	Mob *GetDamageTopOnHateList(Mob *hater); // didn't add 'skip_mezzed' due to calls being in ::Death()
 	Mob *GetEntWithMostHateOnList(Mob *center, Mob *skip = nullptr, bool skip_mezzed = false);
 	Mob *GetRandomEntOnHateList(bool skip_mezzed = false);

--- a/zone/hate_list.h
+++ b/zone/hate_list.h
@@ -41,7 +41,7 @@ public:
 	HateList();
 	~HateList();
 
-	Mob *GetClosestEntOnHateList(Mob *hater, bool skip_mezzed = false, EntityFilterType entity_type = EntityFilterType::Any);
+	Mob *GetClosestEntOnHateList(Mob *hater, bool skip_mezzed = false, EntityFilterType entity_type = EntityFilterType::All);
 	Mob *GetDamageTopOnHateList(Mob *hater); // didn't add 'skip_mezzed' due to calls being in ::Death()
 	Mob *GetEntWithMostHateOnList(Mob *center, Mob *skip = nullptr, bool skip_mezzed = false);
 	Mob *GetRandomEntOnHateList(bool skip_mezzed = false);

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -2376,10 +2376,41 @@ Lua_Mob Lua_Mob::GetHateClosest() {
 	return Lua_Mob(self->GetHateClosest());
 }
 
-Lua_Mob Lua_Mob::GetHateClosestClient() {
+Lua_Mob Lua_Mob::GetHateClosest(bool skip_mezzed) {
 	Lua_Safe_Call_Class(Lua_Mob);
-	return Lua_Mob(self->GetHateClosestClient());
+	return Lua_Mob(self->GetHateClosest(skip_mezzed));
 }
+
+Lua_Bot Lua_Mob::GetHateClosestBot() {
+	Lua_Safe_Call_Class(Lua_Bot);
+	return Lua_Bot(self->GetHateClosestBot());
+}
+
+Lua_Bot Lua_Mob::GetHateClosestBot(bool skip_mezzed) {
+	Lua_Safe_Call_Class(Lua_Bot);
+	return Lua_Bot(self->GetHateClosestBot());
+}
+
+Lua_Client Lua_Mob::GetHateClosestClient() {
+	Lua_Safe_Call_Class(Lua_Client);
+	return Lua_Client(self->GetHateClosestClient());
+}
+
+Lua_Client Lua_Mob::GetHateClosestClient(bool skip_mezzed) {
+	Lua_Safe_Call_Class(Lua_Client);
+	return Lua_Client(self->GetHateClosestClient(skip_mezzed));
+}
+
+Lua_NPC Lua_Mob::GetHateClosestNPC() {
+	Lua_Safe_Call_Class(Lua_NPC);
+	return Lua_NPC(self->GetHateClosestNPC());
+}
+
+Lua_NPC Lua_Mob::GetHateClosestNPC(bool skip_mezzed) {
+	Lua_Safe_Call_Class(Lua_NPC);
+	return Lua_NPC(self->GetHateClosestNPC(skip_mezzed));
+}
+
 Lua_HateList Lua_Mob::GetHateListByDistance() {
 	Lua_Safe_Call_Class(Lua_HateList);
 	Lua_HateList ret;
@@ -3257,8 +3288,14 @@ luabind::scope lua_register_mob() {
 	.def("GetHaste", (int(Lua_Mob::*)(void))&Lua_Mob::GetHaste)
 	.def("GetHateAmount", (int64(Lua_Mob::*)(Lua_Mob))&Lua_Mob::GetHateAmount)
 	.def("GetHateAmount", (int64(Lua_Mob::*)(Lua_Mob,bool))&Lua_Mob::GetHateAmount)
-	.def("GetHateClosest", &Lua_Mob::GetHateClosest)
-	.def("GetHateClosestClient", &Lua_Mob::GetHateClosestClient)
+	.def("GetHateClosest", (Lua_Mob(Lua_Mob::*)(void))&Lua_Mob::GetHateClosest)
+	.def("GetHateClosest", (Lua_Mob(Lua_Mob::*)(bool))&Lua_Mob::GetHateClosest)
+	.def("GetHateClosestBot", (Lua_Bot(Lua_Mob::*)(void))&Lua_Mob::GetHateClosestBot)
+	.def("GetHateClosestBot", (Lua_Bot(Lua_Mob::*)(bool))&Lua_Mob::GetHateClosestBot)
+	.def("GetHateClosestClient", (Lua_Client(Lua_Mob::*)(void))&Lua_Mob::GetHateClosestClient)
+	.def("GetHateClosestClient", (Lua_Client(Lua_Mob::*)(bool))&Lua_Mob::GetHateClosestClient)
+	.def("GetHateClosestNPC", (Lua_NPC(Lua_Mob::*)(void))&Lua_Mob::GetHateClosestNPC)
+	.def("GetHateClosestNPC", (Lua_NPC(Lua_Mob::*)(bool))&Lua_Mob::GetHateClosestNPC)
 	.def("GetHateDamageTop", (Lua_Mob(Lua_Mob::*)(Lua_Mob))&Lua_Mob::GetHateDamageTop)
 	.def("GetHateList", &Lua_Mob::GetHateList)
 	.def("GetHateListBots", (Lua_HateList(Lua_Mob::*)(void))&Lua_Mob::GetHateListBots)

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -2376,6 +2376,10 @@ Lua_Mob Lua_Mob::GetHateClosest() {
 	return Lua_Mob(self->GetHateClosest());
 }
 
+Lua_Mob Lua_Mob::GetHateClosestClient() {
+	Lua_Safe_Call_Class(Lua_Mob);
+	return Lua_Mob(self->GetHateClosestClient());
+}
 Lua_HateList Lua_Mob::GetHateListByDistance() {
 	Lua_Safe_Call_Class(Lua_HateList);
 	Lua_HateList ret;
@@ -3254,6 +3258,7 @@ luabind::scope lua_register_mob() {
 	.def("GetHateAmount", (int64(Lua_Mob::*)(Lua_Mob))&Lua_Mob::GetHateAmount)
 	.def("GetHateAmount", (int64(Lua_Mob::*)(Lua_Mob,bool))&Lua_Mob::GetHateAmount)
 	.def("GetHateClosest", &Lua_Mob::GetHateClosest)
+	.def("GetHateClosestClient", &Lua_Mob::GetHateClosestClient)
 	.def("GetHateDamageTop", (Lua_Mob(Lua_Mob::*)(Lua_Mob))&Lua_Mob::GetHateDamageTop)
 	.def("GetHateList", &Lua_Mob::GetHateList)
 	.def("GetHateListBots", (Lua_HateList(Lua_Mob::*)(void))&Lua_Mob::GetHateListBots)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -227,7 +227,13 @@ public:
 	Lua_Client GetHateRandomClient();
 	Lua_NPC GetHateRandomNPC();
 	Lua_Mob GetHateClosest();
-	Lua_Mob GetHateClosestClient();
+	Lua_Mob GetHateClosest(bool skip_mezzed);
+	Lua_Bot GetHateClosestBot();
+	Lua_Bot GetHateClosestBot(bool skip_mezzed);
+	Lua_Client GetHateClosestClient();
+	Lua_Client GetHateClosestClient(bool skip_mezzed);
+	Lua_NPC GetHateClosestNPC();
+	Lua_NPC GetHateClosestNPC(bool skip_mezzed);
 	void AddToHateList(Lua_Mob other);
 	void AddToHateList(Lua_Mob other, int64 hate);
 	void AddToHateList(Lua_Mob other, int64 hate, int64 damage);

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -227,6 +227,7 @@ public:
 	Lua_Client GetHateRandomClient();
 	Lua_NPC GetHateRandomNPC();
 	Lua_Mob GetHateClosest();
+	Lua_Mob GetHateClosestClient();
 	void AddToHateList(Lua_Mob other);
 	void AddToHateList(Lua_Mob other, int64 hate);
 	void AddToHateList(Lua_Mob other, int64 hate, int64 damage);

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -732,7 +732,7 @@ public:
 	NPC* GetHateRandomNPC() { return hate_list.GetRandomNPCOnHateList(); }
 	Bot* GetHateRandomBot() { return hate_list.GetRandomBotOnHateList(); }
 	Mob* GetHateMost() { return hate_list.GetEntWithMostHateOnList();}
-	Mob* GetHateClosest(bool skip_mezzed = false) { return hate_list.GetClosestEntOnHateList(this); }
+	Mob* GetHateClosest(bool skip_mezzed = false) { return hate_list.GetClosestEntOnHateList(this, skip_mezzed); }
 	Bot* GetHateClosestBot(bool skip_mezzed = false) { return hate_list.GetClosestEntOnHateList(this, skip_mezzed, EntityFilterType::Bots)->CastToBot(); }
 	Client* GetHateClosestClient(bool skip_mezzed = false) { return hate_list.GetClosestEntOnHateList(this, skip_mezzed, EntityFilterType::Clients)->CastToClient(); }
 	NPC* GetHateClosestNPC(bool skip_mezzed = false) { return hate_list.GetClosestEntOnHateList(this, skip_mezzed, EntityFilterType::NPCs)->CastToNPC(); }

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -733,9 +733,9 @@ public:
 	Bot* GetHateRandomBot() { return hate_list.GetRandomBotOnHateList(); }
 	Mob* GetHateMost() { return hate_list.GetEntWithMostHateOnList();}
 	Mob* GetHateClosest(bool skip_mezzed = false) { return hate_list.GetClosestEntOnHateList(this); }
-	Bot* GetHateClosestBot(bool skip_mezzed = false) { return hate_list.GetClosestEntOnHateList(this, skip_mezzed, EntityFilterType::Bot)->CastToBot(); }
-	Client* GetHateClosestClient(bool skip_mezzed = false) { return hate_list.GetClosestEntOnHateList(this, skip_mezzed, EntityFilterType::Client)->CastToClient(); }
-	NPC* GetHateClosestNPC(bool skip_mezzed = false) { return hate_list.GetClosestEntOnHateList(this, skip_mezzed, EntityFilterType::NPC)->CastToNPC(); }
+	Bot* GetHateClosestBot(bool skip_mezzed = false) { return hate_list.GetClosestEntOnHateList(this, skip_mezzed, EntityFilterType::Bots)->CastToBot(); }
+	Client* GetHateClosestClient(bool skip_mezzed = false) { return hate_list.GetClosestEntOnHateList(this, skip_mezzed, EntityFilterType::Clients)->CastToClient(); }
+	NPC* GetHateClosestNPC(bool skip_mezzed = false) { return hate_list.GetClosestEntOnHateList(this, skip_mezzed, EntityFilterType::NPCs)->CastToNPC(); }
 	bool IsEngaged() { return(!hate_list.IsHateListEmpty()); }
 	bool HasPrimaryAggro() { return PrimaryAggro; }
 	bool HasAssistAggro() { return AssistAggro; }

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -733,9 +733,9 @@ public:
 	Bot* GetHateRandomBot() { return hate_list.GetRandomBotOnHateList(); }
 	Mob* GetHateMost() { return hate_list.GetEntWithMostHateOnList();}
 	Mob* GetHateClosest(bool skip_mezzed = false) { return hate_list.GetClosestEntOnHateList(this); }
-	Bot* GetHateClosestBot(bool skip_mezzed = false) { return hate_list.GetClosestEntOnHateList(this, skip_mezzed, ClosestEntityType::Bot)->CastToBot(); }
-	Client* GetHateClosestClient(bool skip_mezzed = false) { return hate_list.GetClosestEntOnHateList(this, skip_mezzed, ClosestEntityType::Client)->CastToClient(); }
-	NPC* GetHateClosestNPC(bool skip_mezzed = false) { return hate_list.GetClosestEntOnHateList(this, skip_mezzed, ClosestEntityType::NPC)->CastToNPC(); }
+	Bot* GetHateClosestBot(bool skip_mezzed = false) { return hate_list.GetClosestEntOnHateList(this, skip_mezzed, EntityFilterType::Bot)->CastToBot(); }
+	Client* GetHateClosestClient(bool skip_mezzed = false) { return hate_list.GetClosestEntOnHateList(this, skip_mezzed, EntityFilterType::Client)->CastToClient(); }
+	NPC* GetHateClosestNPC(bool skip_mezzed = false) { return hate_list.GetClosestEntOnHateList(this, skip_mezzed, EntityFilterType::NPC)->CastToNPC(); }
 	bool IsEngaged() { return(!hate_list.IsHateListEmpty()); }
 	bool HasPrimaryAggro() { return PrimaryAggro; }
 	bool HasAssistAggro() { return AssistAggro; }

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -732,8 +732,10 @@ public:
 	NPC* GetHateRandomNPC() { return hate_list.GetRandomNPCOnHateList(); }
 	Bot* GetHateRandomBot() { return hate_list.GetRandomBotOnHateList(); }
 	Mob* GetHateMost() { return hate_list.GetEntWithMostHateOnList();}
-	Mob* GetHateClosest() { return hate_list.GetClosestEntOnHateList(this); }
-	Mob* GetHateClosestClient() { return hate_list.GetClosestClientOnHateList(this); }
+	Mob* GetHateClosest(bool skip_mezzed = false) { return hate_list.GetClosestEntOnHateList(this); }
+	Bot* GetHateClosestBot(bool skip_mezzed = false) { return hate_list.GetClosestEntOnHateList(this, skip_mezzed, ClosestEntityType::Bot)->CastToBot(); }
+	Client* GetHateClosestClient(bool skip_mezzed = false) { return hate_list.GetClosestEntOnHateList(this, skip_mezzed, ClosestEntityType::Client)->CastToClient(); }
+	NPC* GetHateClosestNPC(bool skip_mezzed = false) { return hate_list.GetClosestEntOnHateList(this, skip_mezzed, ClosestEntityType::NPC)->CastToNPC(); }
 	bool IsEngaged() { return(!hate_list.IsHateListEmpty()); }
 	bool HasPrimaryAggro() { return PrimaryAggro; }
 	bool HasAssistAggro() { return AssistAggro; }

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -733,6 +733,7 @@ public:
 	Bot* GetHateRandomBot() { return hate_list.GetRandomBotOnHateList(); }
 	Mob* GetHateMost() { return hate_list.GetEntWithMostHateOnList();}
 	Mob* GetHateClosest() { return hate_list.GetClosestEntOnHateList(this); }
+	Mob* GetHateClosestClient() { return hate_list.GetClosestClientOnHateList(this); }
 	bool IsEngaged() { return(!hate_list.IsHateListEmpty()); }
 	bool HasPrimaryAggro() { return PrimaryAggro; }
 	bool HasAssistAggro() { return AssistAggro; }

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -2436,9 +2436,40 @@ Mob* Perl_Mob_GetHateClosest(Mob* self) // @categories Hate and Aggro
 {
 	return self->GetHateClosest();
 }
-Mob* Perl_Mob_GetHateClosestClient(Mob* self) // @categories Hate and Aggro
+
+Mob* Perl_Mob_GetHateClosest(Mob* self, bool skip_mezzed) // @categories Hate and Aggro
+{
+	return self->GetHateClosest(skip_mezzed);
+}
+
+Bot* Perl_Mob_GetHateClosestBot(Mob* self) // @categories Hate and Aggro
+{
+	return self->GetHateClosestBot();
+}
+
+Bot* Perl_Mob_GetHateClosestBot(Mob* self, bool skip_mezzed) // @categories Hate and Aggro
+{
+	return self->GetHateClosestBot(skip_mezzed);
+}
+
+Client* Perl_Mob_GetHateClosestClient(Mob* self) // @categories Hate and Aggro
 {
 	return self->GetHateClosestClient();
+}
+
+Client* Perl_Mob_GetHateClosestClient(Mob* self, bool skip_mezzed) // @categories Hate and Aggro
+{
+	return self->GetHateClosestClient(skip_mezzed);
+}
+
+NPC* Perl_Mob_GetHateClosestNPC(Mob* self) // @categories Hate and Aggro
+{
+	return self->GetHateClosestNPC();
+}
+
+NPC* Perl_Mob_GetHateClosestNPC(Mob* self, bool skip_mezzed) // @categories Hate and Aggro
+{
+	return self->GetHateClosestNPC(skip_mezzed);
 }
 
 std::string Perl_Mob_GetLastName(Mob* self) // @categories Script Utility
@@ -3197,8 +3228,14 @@ void perl_register_mob()
 	package.add("GetHaste", &Perl_Mob_GetHaste);
 	package.add("GetHateAmount", (int64_t(*)(Mob*, Mob*))&Perl_Mob_GetHateAmount);
 	package.add("GetHateAmount", (int64_t(*)(Mob*, Mob*, bool))&Perl_Mob_GetHateAmount);
-	package.add("GetHateClosest", &Perl_Mob_GetHateClosest);
-	package.add("GetHateClosestClient", &Perl_Mob_GetHateClosestClient);
+	package.add("GetHateClosest", (Mob*(*)(Mob*))&Perl_Mob_GetHateClosest);
+	package.add("GetHateClosest", (Mob*(*)(Mob*, bool))&Perl_Mob_GetHateClosest);
+	package.add("GetHateClosestBot", (Bot*(*)(Mob*))&Perl_Mob_GetHateClosestBot);
+	package.add("GetHateClosestBot", (Bot*(*)(Mob*, bool))&Perl_Mob_GetHateClosestBot);
+	package.add("GetHateClosestClient", (Client*(*)(Mob*))&Perl_Mob_GetHateClosestClient);
+	package.add("GetHateClosestClient", (Client*(*)(Mob*, bool))&Perl_Mob_GetHateClosestClient);
+	package.add("GetHateClosestNPC", (NPC*(*)(Mob*))&Perl_Mob_GetHateClosestNPC);
+	package.add("GetHateClosestNPC", (NPC*(*)(Mob*, bool))&Perl_Mob_GetHateClosestNPC);
 	package.add("GetHateDamageTop", &Perl_Mob_GetHateDamageTop);
 	package.add("GetHateList", &Perl_Mob_GetHateList);
 	package.add("GetHateListBots", (perl::array(*)(Mob*))&Perl_Mob_GetHateListBots);

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -2436,6 +2436,10 @@ Mob* Perl_Mob_GetHateClosest(Mob* self) // @categories Hate and Aggro
 {
 	return self->GetHateClosest();
 }
+Mob* Perl_Mob_GetHateClosestClient(Mob* self) // @categories Hate and Aggro
+{
+	return self->GetHateClosestClient();
+}
 
 std::string Perl_Mob_GetLastName(Mob* self) // @categories Script Utility
 {
@@ -3194,6 +3198,7 @@ void perl_register_mob()
 	package.add("GetHateAmount", (int64_t(*)(Mob*, Mob*))&Perl_Mob_GetHateAmount);
 	package.add("GetHateAmount", (int64_t(*)(Mob*, Mob*, bool))&Perl_Mob_GetHateAmount);
 	package.add("GetHateClosest", &Perl_Mob_GetHateClosest);
+	package.add("GetHateClosestClient", &Perl_Mob_GetHateClosestClient);
 	package.add("GetHateDamageTop", &Perl_Mob_GetHateDamageTop);
 	package.add("GetHateList", &Perl_Mob_GetHateList);
 	package.add("GetHateListBots", (perl::array(*)(Mob*))&Perl_Mob_GetHateListBots);


### PR DESCRIPTION
Had the need in a new event to get the closest client on the hate list, random existed but not closest, and closest hate seems to be able to return pets.

Copied the closest and just added a small filter to make sure they were a client. 