### PR TITLE
[Cleanup] Remove CalcPetHp from spdat.h

### DIFF
--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1563,7 +1563,6 @@ bool IsInstrumentModAppliedToSpellEffect(int32 spell_id, int effect);
 bool IsPulsingBardSong(int32 spell_id);
 uint32 GetProcLimitTimer(int32 spell_id, int proc_type);
 bool IgnoreCastingRestriction(int32 spell_id);
-int CalcPetHp(int levelb, int classb, int STA = 75);
 int GetSpellEffectDescNum(uint16 spell_id);
 DmgShieldType GetDamageShieldType(uint16 spell_id, int32 DSType = 0);
 bool DetrimentalSpellAllowsRest(uint16 spell_id);


### PR DESCRIPTION
# Notes
- This is unused.