### PR TITLE
[Bug Fix] NPC Armor Upgrade to a slot not handled correctly

### DIFF
--- a/zone/loottables.cpp
+++ b/zone/loottables.cpp
@@ -396,12 +396,14 @@ void NPC::AddLootDrop(
 							}
 							else {
 								// Unequip old item
-								ServerLootItem_Struct *olditem=GetItem(i);
+								auto* olditem = GetItem(i);
+
 								olditem->equip_slot = EQ::invslot::SLOT_INVALID;
 
 								equipment[i] = item2->ID;
+
 								foundslot = i;
-								found = true;
+								found     = true;
 							}
 						} // end if ac
 					}

--- a/zone/loottables.cpp
+++ b/zone/loottables.cpp
@@ -395,6 +395,10 @@ void NPC::AddLootDrop(
 								foundslot = i;
 							}
 							else {
+								// Unequip old item
+								ServerLootItem_Struct *olditem=GetItem(i);
+								olditem->equip_slot = EQ::invslot::SLOT_INVALID;
+
 								equipment[i] = item2->ID;
 								foundslot = i;
 								found = true;

--- a/zone/loottables.cpp
+++ b/zone/loottables.cpp
@@ -395,10 +395,6 @@ void NPC::AddLootDrop(
 								foundslot = i;
 							}
 							else {
-								// Unequip old item
-								ServerLootItem_Struct *olditem=GetItem(i);
-								olditem->equip_slot = EQ::invslot::SLOT_INVALID;
-
 								equipment[i] = item2->ID;
 								foundslot = i;
 								found = true;


### PR DESCRIPTION
If you trade a pet a new helm(replacing one currently in use), the helm does not replace as the item counted in Bonuses until you zone.  This was due to two items in itemlist having the same equip-slot.