### PR TITLE
[Commands] Add #findcurrency Command

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -140,6 +140,7 @@ int command_init(void)
 		command_add("findaliases", "[Search Criteria]- Searches for available command aliases, by alias or command", AccountStatus::Player, command_findaliases) ||
 		command_add("findcharacter", "[Search Criteria] - Search for a character", AccountStatus::Guide, command_findcharacter) ||
 		command_add("findclass", "[Search Criteria] - Search for a class", AccountStatus::Guide, command_findclass) ||
+		command_add("findcurrency", "[Search Criteria] - Search for an alternate currency", AccountStatus::Guide, command_findcurrency) ||
 		command_add("findfaction", "[Search Criteria] - Search for a faction", AccountStatus::Guide, command_findfaction) ||
 		command_add("findnpctype", "[Search Criteria] - Search database NPC types", AccountStatus::GMAdmin, command_findnpctype) ||
 		command_add("findrace", "[Search Criteria] - Search for a race", AccountStatus::Guide, command_findrace) ||
@@ -982,6 +983,7 @@ void command_bot(Client *c, const Seperator *sep)
 #include "gm_commands/findaa.cpp"
 #include "gm_commands/findcharacter.cpp"
 #include "gm_commands/findclass.cpp"
+#include "gm_commands/findcurrency.cpp"
 #include "gm_commands/findfaction.cpp"
 #include "gm_commands/findnpctype.cpp"
 #include "gm_commands/findrace.cpp"

--- a/zone/command.h
+++ b/zone/command.h
@@ -90,6 +90,7 @@ void command_findaa(Client *c, const Seperator *sep);
 void command_findaliases(Client *c, const Seperator *sep);
 void command_findcharacter(Client *c, const Seperator *sep);
 void command_findclass(Client *c, const Seperator *sep);
+void command_findcurrency(Client *c, const Seperator *sep);
 void command_findfaction(Client *c, const Seperator *sep);
 void command_findnpctype(Client *c, const Seperator *sep);
 void command_findrace(Client *c, const Seperator *sep);

--- a/zone/gm_commands/findcurrency.cpp
+++ b/zone/gm_commands/findcurrency.cpp
@@ -49,7 +49,7 @@ void command_findcurrency(Client *c, const Seperator *sep)
 				(
 					can_summon_items ?
 						fmt::format(
-							" [{}]",
+							" | {}",
 							Saylink::Silent(
 								fmt::format(
 									"#summonitem {} {}",
@@ -90,7 +90,7 @@ void command_findcurrency(Client *c, const Seperator *sep)
 					(
 						can_summon_items ?
 						fmt::format(
-							" [{}]",
+							" | {}",
 							Saylink::Silent(
 								fmt::format(
 									"#summonitem {} {}",

--- a/zone/gm_commands/findcurrency.cpp
+++ b/zone/gm_commands/findcurrency.cpp
@@ -1,0 +1,134 @@
+#include "../client.h"
+
+void command_findcurrency(Client *c, const Seperator *sep)
+{
+	const auto arguments = sep->argnum;
+	if (!arguments) {
+		c->Message(Chat::White, "Usage: #findcurrency [Search Criteria]");
+		return;
+	}
+
+	const auto can_summon_items = c->Admin() >= GetCommandStatus(c, "summonitem");
+
+	if (sep->IsNumber(1)) {
+		const auto item_id     = Strings::ToUnsignedInt(sep->arg[1]);
+		const auto currency_id = zone->GetCurrencyID(item_id);
+
+		if (!currency_id) {
+			c->Message(
+				Chat::White,
+				fmt::format(
+					"There is no currency with an item ID of {}.",
+					item_id
+				).c_str()
+			);
+
+			return;
+		}
+
+		const auto item_data = database.GetItem(item_id);
+		if (!item_data) {
+			c->Message(
+				Chat::White,
+				fmt::format(
+					"Item ID {} does not exist.",
+					item_id
+				).c_str()
+			);
+
+			return;
+		}
+
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"Currency {} | {} ({}){}",
+				currency_id,
+				database.CreateItemLink(item_id),
+				item_id,
+				(
+					can_summon_items ?
+						fmt::format(
+							" [{}]",
+							Saylink::Silent(
+								fmt::format(
+									"#summonitem {} {}",
+									item_id,
+									item_data->StackSize
+								),
+								"Summon"
+							)
+						) :
+						""
+				)
+			).c_str()
+		);
+
+		return;
+	}
+
+	const std::string search_criteria  = sep->argplus[1];
+
+	uint32 found_count = 0;
+
+	for (const auto& e : zone->AlternateCurrencies) {
+		const auto item_data = database.GetItem(e.item_id);
+		if (!item_data) {
+			continue;
+		}
+
+		const std::string item_name = Strings::ToLower(item_data->Name);
+
+		if (Strings::Contains(item_name, Strings::ToLower(search_criteria))) {
+			c->Message(
+				Chat::White,
+				fmt::format(
+					"Currency {} | {} ({}){}",
+					e.id,
+					database.CreateItemLink(e.item_id),
+					e.item_id,
+					(
+						can_summon_items ?
+						fmt::format(
+							" [{}]",
+							Saylink::Silent(
+								fmt::format(
+									"#summonitem {} {}",
+									e.item_id,
+									item_data->StackSize
+								),
+								"Summon"
+							)
+						) :
+						""
+					)
+				).c_str()
+			);
+
+			found_count++;
+		}
+	}
+
+	if (!found_count) {
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"No currencies were found matching '{}'.",
+				search_criteria
+			).c_str()
+		);
+
+		return;
+	}
+
+	c->Message(
+		Chat::White,
+		fmt::format(
+			"{} currenc{} found matching '{}'.",
+			found_count,
+			found_count != 1 ? "ies were" : "y was",
+			search_criteria
+		).c_str()
+	);
+}
+

--- a/zone/gm_commands/findcurrency.cpp
+++ b/zone/gm_commands/findcurrency.cpp
@@ -48,18 +48,18 @@ void command_findcurrency(Client *c, const Seperator *sep)
 				item_id,
 				(
 					can_summon_items ?
-						fmt::format(
-							" | {}",
-							Saylink::Silent(
-								fmt::format(
-									"#summonitem {} {}",
-									item_id,
-									item_data->StackSize
-								),
-								"Summon"
-							)
-						) :
-						""
+					fmt::format(
+						" | {}",
+						Saylink::Silent(
+							fmt::format(
+								"#summonitem {} {}",
+								item_id,
+								item_data->StackSize
+							),
+							"Summon"
+						)
+					) :
+					""
 				)
 			).c_str()
 		);


### PR DESCRIPTION
# Notes
- Allows you to find alternate currencies by item ID or name.
- Has a saylink for summoning a stack of the currency if the GM can use the `#summonitem` command.