### PR TITLE
[Bug Fix] Fix duplicate messages in #npcedit

### DIFF
--- a/zone/gm_commands/npcedit.cpp
+++ b/zone/gm_commands/npcedit.cpp
@@ -420,24 +420,18 @@ void command_npcedit(Client *c, const Seperator *sep)
 	} else if (!strcasecmp(sep->arg[1], "special_attacks")) {
 		std::string special_attacks = sep->argplus[2];
 		n.npcspecialattks = special_attacks;
-		c->Message(
-			Chat::Yellow,
-			fmt::format(
-				"{} is now using the following Special Attacks '{}'.",
-				npc_id_string,
-				special_attacks
-			).c_str()
+		d =  fmt::format(
+			"{} is now using the following Special Attacks '{}'.",
+			npc_id_string,
+			special_attacks
 		);
 	} else if (!strcasecmp(sep->arg[1], "special_abilities")) {
 		std::string special_abilities = sep->argplus[2];
 		n.special_abilities = special_abilities;
-		c->Message(
-			Chat::Yellow,
-			fmt::format(
-				"{} is now using the following Special Abilities '{}'.",
-				npc_id_string,
-				special_abilities
-			).c_str()
+		d = fmt::format(
+			"{} is now using the following Special Abilities '{}'.",
+			npc_id_string,
+			special_abilities
 		);
 	} else if (!strcasecmp(sep->arg[1], "aggroradius")) {
 		if (sep->IsNumber(2)) {


### PR DESCRIPTION
# Notes
- `#npcedit special_attacks` and `#npcedit special_abilities` send duplicate messages since the `d` variable wasn't being set and a message was being sent instead, meaning a message was sent inside the condition as well as a blank message at the bottom of the command.