### PR TITLE
[Bug Fix] Fix issue with Group Pointers/Member roles

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1524,6 +1524,7 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 		GroupLeadershipAA_Struct GLAA;
 		memset(ln, 0, 64);
 		database.GetGroupLeadershipInfo(group->GetID(), ln, MainTankName, AssistName, PullerName, NPCMarkerName, mentoree_name, &mentor_percent, &GLAA);
+		group->LearnMembers();
 
 		if (!group->GetLeader()) {
 			Client *c = entity_list.GetClientByName(ln);
@@ -1538,7 +1539,6 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 		group->SetNPCMarker(NPCMarkerName);
 		group->SetGroupAAs(&GLAA);
 		group->SetGroupMentor(mentor_percent, mentoree_name);
-		group->LearnMembers();
 		JoinGroupXTargets(group);
 		group->UpdatePlayer(this);
 		LFG = false;

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1514,29 +1514,30 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 	}
 
 	if (group) {
-		// If the group leader is not set, pull the group leader infomrmation from the database.
-		if (!group->GetLeader()) {
-			char ln[64];
-			char MainTankName[64];
-			char AssistName[64];
-			char PullerName[64];
-			char NPCMarkerName[64];
-			char mentoree_name[64];
-			int mentor_percent;
-			GroupLeadershipAA_Struct GLAA;
-			memset(ln, 0, 64);
-			database.GetGroupLeadershipInfo(group->GetID(), ln, MainTankName, AssistName, PullerName, NPCMarkerName, mentoree_name, &mentor_percent, &GLAA);
-			Client *c = entity_list.GetClientByName(ln);
-			if (c)
-				group->SetLeader(c);
+		char ln[64];
+		char MainTankName[64];
+		char AssistName[64];
+		char PullerName[64];
+		char NPCMarkerName[64];
+		char mentoree_name[64];
+		int mentor_percent;
+		GroupLeadershipAA_Struct GLAA;
+		memset(ln, 0, 64);
+		database.GetGroupLeadershipInfo(group->GetID(), ln, MainTankName, AssistName, PullerName, NPCMarkerName, mentoree_name, &mentor_percent, &GLAA);
 
-			group->SetMainTank(MainTankName);
-			group->SetMainAssist(AssistName);
-			group->SetPuller(PullerName);
-			group->SetNPCMarker(NPCMarkerName);
-			group->SetGroupAAs(&GLAA);
-			group->SetGroupMentor(mentor_percent, mentoree_name);
+		if (!group->GetLeader()) {
+			Client *c = entity_list.GetClientByName(ln);
+			if (c) {
+				group->SetLeader(c);
+			}
 		}
+
+		group->SetMainTank(MainTankName);
+		group->SetMainAssist(AssistName);
+		group->SetPuller(PullerName);
+		group->SetNPCMarker(NPCMarkerName);
+		group->SetGroupAAs(&GLAA);
+		group->SetGroupMentor(mentor_percent, mentoree_name);
 		group->LearnMembers();
 		JoinGroupXTargets(group);
 		group->UpdatePlayer(this);

--- a/zone/groups.cpp
+++ b/zone/groups.cpp
@@ -1156,6 +1156,14 @@ bool Group::LearnMembers() {
 		);
 	}
 
+	memset(members,0,sizeof(Mob*) * MAX_GROUP_MEMBERS);
+
+	for(int i = 0; i < MAX_GROUP_MEMBERS; ++i)
+	{
+		memset(membername[i],0,64);
+		MemberRoles[i] = 0;
+	}
+
 	int memberIndex = 0;
 	for (const auto& member : rows) {
 		if (memberIndex >= MAX_GROUP_MEMBERS) {

--- a/zone/groups.cpp
+++ b/zone/groups.cpp
@@ -1156,10 +1156,9 @@ bool Group::LearnMembers() {
 		);
 	}
 
-	memset(members,0,sizeof(Mob*) * MAX_GROUP_MEMBERS);
-
 	for(int i = 0; i < MAX_GROUP_MEMBERS; ++i)
 	{
+		members[i] = nullptr;
 		memset(membername[i],0,64);
 		MemberRoles[i] = 0;
 	}


### PR DESCRIPTION
We weren't properly nulling Group membership prior to loading Group membership from the database.
This could cause issues where duplicate entries could appear causing a client to be in the group multiple times. 

We also weren't correctly handling Member Roles, causing these to possibly break when the group changed in some fashion.