### PR TITLE
[Illusions] RandomizeFeatures and SetGender were killing db texture

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -2576,7 +2576,7 @@ bool Mob::RandomizeFeatures(bool send_illusion, bool set_variables)
 {
 	if (IsPlayerRace(GetRace())) {
 		uint8 current_gender = GetGender();
-		uint8 new_texture = 0xFF;
+		uint8 new_texture = GetTexture();
 		uint8 new_helm_texture = 0xFF;
 		uint8 new_hair_color = 0xFF;
 		uint8 new_beard_color = 0xFF;

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -1798,7 +1798,7 @@ void Perl_Mob_SetRace(Mob* self, int32 race) // @categories Stats and Attributes
 
 void Perl_Mob_SetGender(Mob* self, int32 gender) // @categories Stats and Attributes
 {
-	self->SendIllusionPacket(self->GetRace(), gender);
+	self->SendIllusionPacket(self->GetRace(), gender, self->GetTexture());
 }
 
 // todo: SendIllusion should be sent in a hash like lua


### PR DESCRIPTION
If you use RandomizeFeatures() or SetGender() from a quest, they were indirectly setting texture to FF for all PC races.

I say indirectly because for some reason SendIlusion does not use texture if the mob is a PC race.  

I don't think anyone using RandomizeFeatures() or SetGender() wants the side effect of trashing texture, so I modified both calls to pass in current mob texture, preserving it.