### PR TITLE
[Quest API] Add SendChannelMessage() to Perl/Lua

### DIFF
--- a/world/console.cpp
+++ b/world/console.cpp
@@ -361,7 +361,7 @@ void ConsoleTell(
 	auto join_args = args;
 	join_args.erase(join_args.begin(), join_args.begin() + 1);
 
-	zoneserver_list.SendChannelMessage(tmpname, to.c_str(), 7, 0, Strings::Join(join_args, " ").c_str());
+	zoneserver_list.SendChannelMessage(tmpname, to.c_str(), ChatChannel_Tell, 0, Strings::Join(join_args, " ").c_str());
 }
 
 /**
@@ -382,7 +382,7 @@ void ConsoleBroadcast(
 	char tmpname[64];
 	tmpname[0] = '*';
 	strcpy(&tmpname[1], connection->UserName().c_str());
-	zoneserver_list.SendChannelMessage(tmpname, 0, 6, 0, Strings::Join(args, " ").c_str());
+	zoneserver_list.SendChannelMessage(tmpname, 0, ChatChannel_Broadcast, 0, Strings::Join(args, " ").c_str());
 }
 
 /**
@@ -403,7 +403,7 @@ void ConsoleGMSay(
 	char tmpname[64];
 	tmpname[0] = '*';
 	strcpy(&tmpname[1], connection->UserName().c_str());
-	zoneserver_list.SendChannelMessage(tmpname, 0, 11, 0, Strings::Join(args, " ").c_str());
+	zoneserver_list.SendChannelMessage(tmpname, 0, ChatChannel_GMSAY, 0, Strings::Join(args, " ").c_str());
 }
 
 /**
@@ -457,7 +457,7 @@ void ConsoleOOC(
 	char tmpname[64];
 	tmpname[0] = '*';
 	strcpy(&tmpname[1], connection->UserName().c_str());
-	zoneserver_list.SendChannelMessage(tmpname, 0, 5, 0, Strings::Join(args, " ").c_str());
+	zoneserver_list.SendChannelMessage(tmpname, 0, ChatChannel_OOC, 0, Strings::Join(args, " ").c_str());
 }
 
 /**
@@ -478,7 +478,7 @@ void ConsoleAuction(
 	char tmpname[64];
 	tmpname[0] = '*';
 	strcpy(&tmpname[1], connection->UserName().c_str());
-	zoneserver_list.SendChannelMessage(tmpname, 0, 4, 0, Strings::Join(args, " ").c_str());
+	zoneserver_list.SendChannelMessage(tmpname, 0, ChatChannel_Auction, 0, Strings::Join(args, " ").c_str());
 }
 
 /**

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -463,7 +463,8 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 				}
 
 				auto cle = client_list.FindCharacter(scm->deliverto);
-				if (
+
+					if (
 					!cle ||
 					cle->Online() < CLE_Status::Zoning ||
 					(

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -463,8 +463,7 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 				}
 
 				auto cle = client_list.FindCharacter(scm->deliverto);
-
-					if (
+				if (
 					!cle ||
 					cle->Online() < CLE_Status::Zoning ||
 					(

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -1062,7 +1062,7 @@ void Client::ChannelMessageReceived(uint8 chan_num, uint8 language, uint8 lang_s
 			if(!global_channel_timer.Check())
 			{
 				if(strlen(targetname) == 0)
-					ChannelMessageReceived(7, language, lang_skill, message, "discard"); //Fast typer or spammer??
+					ChannelMessageReceived(ChatChannel_Tell, language, lang_skill, message, "discard"); //Fast typer or spammer??
 				else
 					return;
 			}

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -11469,7 +11469,7 @@ void Client::Handle_OP_PopupResponse(const EQApplicationPacket *app)
 			if (EntityVariableExists(DIAWIND_RESPONSE_ONE_KEY)) {
 				response = GetEntityVariable(DIAWIND_RESPONSE_ONE_KEY);
 				if (!response.empty()) {
-					ChannelMessageReceived(8, 0, 100, response.c_str(), nullptr, true);
+					ChannelMessageReceived(ChatChannel_Say, 0, 100, response.c_str(), nullptr, true);
 				}
 			}
 			break;
@@ -11478,7 +11478,7 @@ void Client::Handle_OP_PopupResponse(const EQApplicationPacket *app)
 			if (EntityVariableExists(DIAWIND_RESPONSE_TWO_KEY)) {
 				response = GetEntityVariable(DIAWIND_RESPONSE_TWO_KEY);
 				if (!response.empty()) {
-					ChannelMessageReceived(8, 0, 100, response.c_str(), nullptr, true);
+					ChannelMessageReceived(ChatChannel_Say, 0, 100, response.c_str(), nullptr, true);
 				}
 			}
 			break;

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -4735,6 +4735,21 @@ int Perl__GetZoneMinimumLavaDamage(uint32 zone_id, int version)
 	return zone_store.GetZoneMinimumLavaDamage(zone_id, version);
 }
 
+void Perl__send_channel_message(uint8 channel_number, uint32 guild_id, uint8 language_id, uint8 language_skill, const char* message)
+{
+	quest_manager.SendChannelMessage(channel_number, guild_id, language_id, language_skill, message);
+}
+
+void Perl__send_channel_message(Client* from, uint8 channel_number, uint32 guild_id, uint8 language_id, uint8 language_skill, const char* message)
+{
+	quest_manager.SendChannelMessage(from, channel_number, guild_id, language_id, language_skill, message);
+}
+
+void Perl__send_channel_message(Client* from, const char* to, uint8 channel_number, uint32 guild_id, uint8 language_id, uint8 language_skill, const char* message)
+{
+	quest_manager.SendChannelMessage(from, to, channel_number, guild_id, language_id, language_skill, message);
+}
+
 void perl_register_quest()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -5404,6 +5419,9 @@ void perl_register_quest()
 	package.add("secondstotime", &Perl__secondstotime);
 	package.add("selfcast", &Perl__selfcast);
 	package.add("send_player_handin_event", &Perl__send_player_handin_event);
+	package.add("send_channel_message", (void(*)(uint8, uint32, uint8, uint8, const char*))&Perl__send_channel_message);
+	package.add("send_channel_message", (void(*)(Client*, uint8, uint32, uint8, uint8, const char*))&Perl__send_channel_message);
+	package.add("send_channel_message", (void(*)(Client*, const char*, uint8, uint32, uint8, uint8, const char*))&Perl__send_channel_message);
 	package.add("setaaexpmodifierbycharid", (void(*)(uint32, uint32, double))&Perl__setaaexpmodifierbycharid);
 	package.add("setaaexpmodifierbycharid", (void(*)(uint32, uint32, double, int16))&Perl__setaaexpmodifierbycharid);
 	package.add("set_proximity", (void(*)(float, float, float, float))&Perl__set_proximity);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -4413,7 +4413,7 @@ void lua_send_channel_message(Lua_Client from, uint8 channel_number, uint32 guil
 
 void lua_send_channel_message(Lua_Client from, const char* to, uint8 channel_number, uint32 guild_id, uint8 language_id, uint8 language_skill, const char* message)
 {
-	quest_manager.SendChannelMessage(from, to, channel_number, guild_id, language, language_skill, message);
+	quest_manager.SendChannelMessage(from, to, channel_number, guild_id, language_id, language_skill, message);
 }
 
 #define LuaCreateNPCParse(name, c_type, default_value) do { \

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -4401,6 +4401,21 @@ int lua_get_zone_minimum_lava_damage(uint32 zone_id, int version)
 	return zone_store.GetZoneMinimumLavaDamage(zone_id, version);
 }
 
+void lua_send_channel_message(uint8 channel_number, uint32 guild_id, uint8 language_id, uint8 language_skill, const char* message)
+{
+	quest_manager.SendChannelMessage(channel_number, guild_id, language_id, language_skill, message);
+}
+
+void lua_send_channel_message(Lua_Client from, uint8 channel_number, uint32 guild_id, uint8 language_id, uint8 language_skill, const char* message)
+{
+	quest_manager.SendChannelMessage(from, channel_number, guild_id, language_id, language_skill, message);
+}
+
+void lua_send_channel_message(Lua_Client from, const char* to, uint8 channel_number, uint32 guild_id, uint8 language_id, uint8 language_skill, const char* message)
+{
+	quest_manager.SendChannelMessage(from, to, channel_number, guild_id, language, language_skill, message);
+}
+
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
 	cur = table[#name]; \
 	if(luabind::type(cur) != LUA_TNIL) { \
@@ -5005,52 +5020,55 @@ luabind::scope lua_register_general() {
 		luabind::def("get_zone_instance_type", (uint8(*)(uint32,int))&lua_get_zone_instance_type),
 		luabind::def("get_zone_shutdown_delay", (uint64(*)(uint32))&lua_get_zone_shutdown_delay),
 		luabind::def("get_zone_shutdown_delay", (uint64(*)(uint32,int))&lua_get_zone_shutdown_delay),
-			luabind::def("get_zone_peqzone", (int8(*)(uint32))&lua_get_zone_peqzone),
-			luabind::def("get_zone_peqzone", (int8(*)(uint32,int))&lua_get_zone_peqzone),
-			luabind::def("get_zone_expansion", (int8(*)(uint32))&lua_get_zone_expansion),
-			luabind::def("get_zone_expansion", (int8(*)(uint32,int))&lua_get_zone_expansion),
-			luabind::def("get_zone_bypass_expansion_check", (int8(*)(uint32))&lua_get_zone_bypass_expansion_check),
-			luabind::def("get_zone_bypass_expansion_check", (int8(*)(uint32,int))&lua_get_zone_bypass_expansion_check),
-			luabind::def("get_zone_suspend_buffs", (int8(*)(uint32))&lua_get_zone_suspend_buffs),
-			luabind::def("get_zone_suspend_buffs", (int8(*)(uint32,int))&lua_get_zone_suspend_buffs),
-			luabind::def("get_zone_rain_chance", (int(*)(uint32))&lua_get_zone_rain_chance),
-			luabind::def("get_zone_rain_chance", (int(*)(uint32,int))&lua_get_zone_rain_chance),
-			luabind::def("get_zone_rain_duration", (int(*)(uint32))&lua_get_zone_rain_duration),
-			luabind::def("get_zone_rain_duration", (int(*)(uint32,int))&lua_get_zone_rain_duration),
-			luabind::def("get_zone_snow_chance", (int(*)(uint32))&lua_get_zone_snow_chance),
-			luabind::def("get_zone_snow_chance", (int(*)(uint32,int))&lua_get_zone_snow_chance),
-			luabind::def("get_zone_snow_duration", (int(*)(uint32))&lua_get_zone_snow_duration),
-			luabind::def("get_zone_snow_duration", (int(*)(uint32,int))&lua_get_zone_snow_duration),
-			luabind::def("get_zone_gravity", (float(*)(uint32))&lua_get_zone_gravity),
-			luabind::def("get_zone_gravity", (float(*)(uint32,int))&lua_get_zone_gravity),
-			luabind::def("get_zone_type", (int(*)(uint32))&lua_get_zone_type),
-			luabind::def("get_zone_type", (int(*)(uint32,int))&lua_get_zone_type),
-			luabind::def("get_zone_sky_lock", (int(*)(uint32))&lua_get_zone_sky_lock),
-			luabind::def("get_zone_sky_lock", (int(*)(uint32,int))&lua_get_zone_sky_lock),
-			luabind::def("get_zone_fast_regen_hp", (int(*)(uint32))&lua_get_zone_fast_regen_hp),
-			luabind::def("get_zone_fast_regen_hp", (int(*)(uint32,int))&lua_get_zone_fast_regen_hp),
-			luabind::def("get_zone_fast_regen_mana", (int(*)(uint32))&lua_get_zone_fast_regen_mana),
-			luabind::def("get_zone_fast_regen_mana", (int(*)(uint32,int))&lua_get_zone_fast_regen_mana),
-			luabind::def("get_zone_fast_regen_endurance", (int(*)(uint32))&lua_get_zone_fast_regen_endurance),
-			luabind::def("get_zone_fast_regen_endurance", (int(*)(uint32,int))&lua_get_zone_fast_regen_endurance),
-			luabind::def("get_zone_npc_maximum_aggro_distance", (int(*)(uint32))&lua_get_zone_npc_maximum_aggro_distance),
-			luabind::def("get_zone_npc_maximum_aggro_distance", (int(*)(uint32,int))&lua_get_zone_npc_maximum_aggro_distance),
-			luabind::def("get_zone_npc_maximum_movement_update_range", (uint32(*)(uint32))&lua_get_zone_maximum_movement_update_range),
-			luabind::def("get_zone_npc_maximum_movement_update_range", (uint32(*)(uint32,int))&lua_get_zone_maximum_movement_update_range),
-			luabind::def("get_zone_minimum_expansion", (int8(*)(uint32))&lua_get_zone_minimum_expansion),
-			luabind::def("get_zone_minimum_expansion", (int8(*)(uint32,int))&lua_get_zone_minimum_expansion),
-			luabind::def("get_zone_maximum_expansion", (int8(*)(uint32))&lua_get_zone_maximum_expansion),
-			luabind::def("get_zone_maximum_expansion", (int8(*)(uint32,int))&lua_get_zone_maximum_expansion),
-			luabind::def("get_zone_content_flags", (std::string(*)(uint32))&lua_get_zone_content_flags),
-			luabind::def("get_zone_content_flags", (std::string(*)(uint32,int))&lua_get_zone_content_flags),
-			luabind::def("get_zone_content_flags_disabled", (std::string(*)(uint32))&lua_get_zone_content_flags_disabled),
-			luabind::def("get_zone_content_flags_disabled", (std::string(*)(uint32,int))&lua_get_zone_content_flags_disabled),
-			luabind::def("get_zone_underworld_teleport_index", (int(*)(uint32))&lua_get_zone_underworld_teleport_index),
-			luabind::def("get_zone_underworld_teleport_index", (int(*)(uint32,int))&lua_get_zone_underworld_teleport_index),
-			luabind::def("get_zone_lava_damage", (int(*)(uint32))&lua_get_zone_lava_damage),
-			luabind::def("get_zone_lava_damage", (int(*)(uint32,int))&lua_get_zone_lava_damage),
-			luabind::def("get_zone_minimum_lava_damage", (int(*)(uint32))&lua_get_zone_minimum_lava_damage),
-			luabind::def("get_zone_minimum_lava_damage", (int(*)(uint32,int))&lua_get_zone_minimum_lava_damage),
+		luabind::def("get_zone_peqzone", (int8(*)(uint32))&lua_get_zone_peqzone),
+		luabind::def("get_zone_peqzone", (int8(*)(uint32,int))&lua_get_zone_peqzone),
+		luabind::def("get_zone_expansion", (int8(*)(uint32))&lua_get_zone_expansion),
+		luabind::def("get_zone_expansion", (int8(*)(uint32,int))&lua_get_zone_expansion),
+		luabind::def("get_zone_bypass_expansion_check", (int8(*)(uint32))&lua_get_zone_bypass_expansion_check),
+		luabind::def("get_zone_bypass_expansion_check", (int8(*)(uint32,int))&lua_get_zone_bypass_expansion_check),
+		luabind::def("get_zone_suspend_buffs", (int8(*)(uint32))&lua_get_zone_suspend_buffs),
+		luabind::def("get_zone_suspend_buffs", (int8(*)(uint32,int))&lua_get_zone_suspend_buffs),
+		luabind::def("get_zone_rain_chance", (int(*)(uint32))&lua_get_zone_rain_chance),
+		luabind::def("get_zone_rain_chance", (int(*)(uint32,int))&lua_get_zone_rain_chance),
+		luabind::def("get_zone_rain_duration", (int(*)(uint32))&lua_get_zone_rain_duration),
+		luabind::def("get_zone_rain_duration", (int(*)(uint32,int))&lua_get_zone_rain_duration),
+		luabind::def("get_zone_snow_chance", (int(*)(uint32))&lua_get_zone_snow_chance),
+		luabind::def("get_zone_snow_chance", (int(*)(uint32,int))&lua_get_zone_snow_chance),
+		luabind::def("get_zone_snow_duration", (int(*)(uint32))&lua_get_zone_snow_duration),
+		luabind::def("get_zone_snow_duration", (int(*)(uint32,int))&lua_get_zone_snow_duration),
+		luabind::def("get_zone_gravity", (float(*)(uint32))&lua_get_zone_gravity),
+		luabind::def("get_zone_gravity", (float(*)(uint32,int))&lua_get_zone_gravity),
+		luabind::def("get_zone_type", (int(*)(uint32))&lua_get_zone_type),
+		luabind::def("get_zone_type", (int(*)(uint32,int))&lua_get_zone_type),
+		luabind::def("get_zone_sky_lock", (int(*)(uint32))&lua_get_zone_sky_lock),
+		luabind::def("get_zone_sky_lock", (int(*)(uint32,int))&lua_get_zone_sky_lock),
+		luabind::def("get_zone_fast_regen_hp", (int(*)(uint32))&lua_get_zone_fast_regen_hp),
+		luabind::def("get_zone_fast_regen_hp", (int(*)(uint32,int))&lua_get_zone_fast_regen_hp),
+		luabind::def("get_zone_fast_regen_mana", (int(*)(uint32))&lua_get_zone_fast_regen_mana),
+		luabind::def("get_zone_fast_regen_mana", (int(*)(uint32,int))&lua_get_zone_fast_regen_mana),
+		luabind::def("get_zone_fast_regen_endurance", (int(*)(uint32))&lua_get_zone_fast_regen_endurance),
+		luabind::def("get_zone_fast_regen_endurance", (int(*)(uint32,int))&lua_get_zone_fast_regen_endurance),
+		luabind::def("get_zone_npc_maximum_aggro_distance", (int(*)(uint32))&lua_get_zone_npc_maximum_aggro_distance),
+		luabind::def("get_zone_npc_maximum_aggro_distance", (int(*)(uint32,int))&lua_get_zone_npc_maximum_aggro_distance),
+		luabind::def("get_zone_npc_maximum_movement_update_range", (uint32(*)(uint32))&lua_get_zone_maximum_movement_update_range),
+		luabind::def("get_zone_npc_maximum_movement_update_range", (uint32(*)(uint32,int))&lua_get_zone_maximum_movement_update_range),
+		luabind::def("get_zone_minimum_expansion", (int8(*)(uint32))&lua_get_zone_minimum_expansion),
+		luabind::def("get_zone_minimum_expansion", (int8(*)(uint32,int))&lua_get_zone_minimum_expansion),
+		luabind::def("get_zone_maximum_expansion", (int8(*)(uint32))&lua_get_zone_maximum_expansion),
+		luabind::def("get_zone_maximum_expansion", (int8(*)(uint32,int))&lua_get_zone_maximum_expansion),
+		luabind::def("get_zone_content_flags", (std::string(*)(uint32))&lua_get_zone_content_flags),
+		luabind::def("get_zone_content_flags", (std::string(*)(uint32,int))&lua_get_zone_content_flags),
+		luabind::def("get_zone_content_flags_disabled", (std::string(*)(uint32))&lua_get_zone_content_flags_disabled),
+		luabind::def("get_zone_content_flags_disabled", (std::string(*)(uint32,int))&lua_get_zone_content_flags_disabled),
+		luabind::def("get_zone_underworld_teleport_index", (int(*)(uint32))&lua_get_zone_underworld_teleport_index),
+		luabind::def("get_zone_underworld_teleport_index", (int(*)(uint32,int))&lua_get_zone_underworld_teleport_index),
+		luabind::def("get_zone_lava_damage", (int(*)(uint32))&lua_get_zone_lava_damage),
+		luabind::def("get_zone_lava_damage", (int(*)(uint32,int))&lua_get_zone_lava_damage),
+		luabind::def("get_zone_minimum_lava_damage", (int(*)(uint32))&lua_get_zone_minimum_lava_damage),
+		luabind::def("get_zone_minimum_lava_damage", (int(*)(uint32,int))&lua_get_zone_minimum_lava_damage),
+		luabind::def("send_channel_message", (void(*)(uint8,uint32,uint8,uint8,const char*))&lua_send_channel_message),
+		luabind::def("send_channel_message", (void(*)(Lua_Client,uint8,uint32,uint8,uint8,const char*))&lua_send_channel_message),
+		luabind::def("send_channel_message", (void(*)(Lua_Client,const char*,uint8,uint32,uint8,uint8,const char*))&lua_send_channel_message),
 		/*
 			Cross Zone
 		*/

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -1555,7 +1555,7 @@ void Perl_Client_SilentMessage(Client* self, const char* message) // @categories
 				if (self->GetTarget()->CastToNPC()->IsMoving() &&
 					  !self->GetTarget()->CastToNPC()->IsOnHatelist(self->GetTarget()))
 					self->GetTarget()->CastToNPC()->PauseWandering(RuleI(NPC, SayPauseTimeInSec));
-				self->ChannelMessageReceived(8, 0, 100, message, nullptr, true);
+				self->ChannelMessageReceived(ChatChannel_Say, 0, 100, message, nullptr, true);
 			}
 		}
 	}

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -2887,6 +2887,21 @@ void QuestManager::we(int type, const char *str) {
 	);
 }
 
+void QuestManager::SendChannelMessage(uint8 channel_number, uint32 guild_id, uint8 language_id, uint8 language_skill, const char* message)
+{
+	worldserver.SendChannelMessage(0, 0, channel_number, guild_id, language_id, language_skill, message);
+}
+
+void QuestManager::SendChannelMessage(Client* from, uint8 channel_number, uint32 guild_id, uint8 language_id, uint8 language_skill, const char* message)
+{
+	worldserver.SendChannelMessage(from, 0, channel_number, guild_id, language_id, language_skill, message);
+}
+
+void QuestManager::SendChannelMessage(Client* from, const char* to, uint8 channel_number, uint32 guild_id, uint8 language_id, uint8 language_skill, const char* message)
+{
+	worldserver.SendChannelMessage(from, to, channel_number, guild_id, language_id, language_skill, message);
+}
+
 void QuestManager::message(uint32 type, const char *message) {
 	QuestManagerCurrentQuestVars();
 	if (!initiator) {

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -349,7 +349,7 @@ public:
 	int8 DoesAugmentFit(EQ::ItemInstance* inst, uint32 augment_id, uint8 augment_slot = 255);
 	void SendPlayerHandinEvent();
 	void SendChannelMessage(uint8 channel_number, uint32 guild_id, uint8 language_id, uint8 language_skill, const char* message);
-	void SendChannelMessage(Client* from, uint8 channel_number, uint32 guild_id, language_id language, uint8 language_skill, const char* message);
+	void SendChannelMessage(Client* from, uint8 channel_number, uint32 guild_id, uint8 language_id, uint8 language_skill, const char* message);
 	void SendChannelMessage(Client* from, const char* to, uint8 channel_number, uint32 guild_id, uint8 language_id, uint8 language_skill, const char* message);
 
 	Bot *GetBot() const;

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -348,6 +348,9 @@ public:
 	bool DoAugmentSlotsMatch(uint32 item_one, uint32 item_two);
 	int8 DoesAugmentFit(EQ::ItemInstance* inst, uint32 augment_id, uint8 augment_slot = 255);
 	void SendPlayerHandinEvent();
+	void SendChannelMessage(uint8 channel_number, uint32 guild_id, uint8 language_id, uint8 language_skill, const char* message);
+	void SendChannelMessage(Client* from, uint8 channel_number, uint32 guild_id, language_id language, uint8 language_skill, const char* message);
+	void SendChannelMessage(Client* from, const char* to, uint8 channel_number, uint32 guild_id, uint8 language_id, uint8 language_skill, const char* message);
 
 	Bot *GetBot() const;
 	Client *GetInitiator() const;


### PR DESCRIPTION
# Perl
- Add `quest::send_channel_message(channel_number, guild_id, language_id, language_skill, message)`.
- Add `quest::send_channel_message(from, channel_number, guild_id, language_id, language_skill, message)`.
- Add `quest::send_channel_message(from, to, channel_number, guild_id, language_id, language_skill, message)`.

# Lua
- Add `eq.send_channel_message(channel_number, guild_id, language_id, language_skill, message)`.
- Add `eq.send_channel_message(from, channel_number, guild_id, language_id, language_skill, message)`.
- Add `eq.send_channel_message(from, to, channel_number, guild_id, language_id, language_skill, message)`.

# Notes
- This allows operators to send channel messages from scripts like a broadcast or tell.
- Cleaned up spots where we were using magic numbers for channels instead of our constants.