### PR TITLE
[Quest API/Cleanup] Add several spell methods to Perl/Lua

### DIFF
--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -77,6 +77,7 @@
 #include "classes.h"
 #include "spdat.h"
 #include "../common/rulesys.h"
+#include "../common/strings.h"
 
 #ifndef WIN32
 #include <stdlib.h>
@@ -88,11 +89,11 @@
 
 bool IsTargetableAESpell(uint16 spell_id)
 {
-	if (IsValidSpell(spell_id) && spells[spell_id].target_type == ST_AETarget) {
-		return true;
+	if (!IsValidSpell(spell_id)) {
+		return false;
 	}
 
-	return false;
+	return spells[spell_id].target_type == ST_AETarget;
 }
 
 bool IsSacrificeSpell(uint16 spell_id)
@@ -102,21 +103,24 @@ bool IsSacrificeSpell(uint16 spell_id)
 
 bool IsLifetapSpell(uint16 spell_id)
 {
-    if (
-        IsValidSpell(spell_id) &&
-        (
-            spells[spell_id].target_type == ST_Tap ||
-            spells[spell_id].target_type == ST_TargetAETap ||
-            spell_id == SPELL_ANCIENT_LIFEBANE
-        )
-    ) {
-        return true;
-    }
+	if (!IsValidSpell(spell_id)) {
+		return false;
+	}
 
-    return false;
+	const auto& spell = spells[spell_id];
+
+	if (
+		spell.target_type == ST_Tap ||
+		spell.target_type == ST_TargetAETap ||
+		spell_id == SPELL_ANCIENT_LIFEBANE
+	) {
+		return true;
+	}
+
+	return false;
 }
 
-bool IsMezSpell(uint16 spell_id)
+bool IsMesmerizeSpell(uint16 spell_id)
 {
 	return IsEffectInSpell(spell_id, SE_Mez);
 }
@@ -126,32 +130,50 @@ bool IsStunSpell(uint16 spell_id)
 	return IsEffectInSpell(spell_id, SE_Stun);
 }
 
-bool IsSummonSpell(uint16 spellid)
+bool IsSummonSpell(uint16 spell_id)
 {
-	for (int o = 0; o < EFFECT_COUNT; o++) {
-		uint32 tid = spells[spellid].effect_id[o];
-		if (tid == SE_SummonPet || tid == SE_SummonItem || tid == SE_SummonPC)
+	if (!IsValidSpell(spell_id)) {
+		return false;
+	}
+
+	const auto& spell = spells[spell_id];
+
+	for (int i = 0; i < EFFECT_COUNT; i++) {
+		const auto effect_id = spell.effect_id[i];
+		if (
+			effect_id == SE_SummonPet ||
+			effect_id == SE_SummonItem ||
+			effect_id == SE_SummonPC
+		) {
 			return true;
+		}
 	}
 
 	return false;
 }
 
-bool IsEvacSpell(uint16 spellid)
+bool IsDamageSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spellid, SE_Succor);
-}
-
-bool IsDamageSpell(uint16 spellid)
-{
-	if (IsLifetapSpell(spellid))
+	if (IsLifetapSpell(spell_id)) {
 		return false;
+	}
 
-	for (int o = 0; o < EFFECT_COUNT; o++) {
-		uint32 tid = spells[spellid].effect_id[o];
-		if (spells[spellid].base_value[o] < 0 &&
-			((tid == SE_CurrentHPOnce) || (tid == SE_CurrentHP && spells[spellid].buff_duration < 1)))
+	const auto& spell = spells[spell_id];
+
+	for (int i = 0; i < EFFECT_COUNT; i++) {
+		const auto effect_id = spell.effect_id[i];
+		if (
+			spell.base_value[i] < 0 &&
+			(
+				effect_id == SE_CurrentHPOnce ||
+				(
+					effect_id == SE_CurrentHP &&
+					spell.buff_duration < 1
+				)
+			)
+		) {
 			return true;
+		}
 	}
 
 	return false;
@@ -165,49 +187,83 @@ bool IsFearSpell(uint16 spell_id)
 
 bool IsCureSpell(uint16 spell_id)
 {
-	const SPDat_Spell_Struct &sp = spells[spell_id];
-
-	bool CureEffect = false;
-
-	for(int i = 0; i < EFFECT_COUNT; i++){
-		if (sp.effect_id[i] == SE_DiseaseCounter || sp.effect_id[i] == SE_PoisonCounter
-			|| sp.effect_id[i] == SE_CurseCounter || sp.effect_id[i] == SE_CorruptionCounter)
-			CureEffect = true;
+	if (!IsValidSpell(spell_id)) {
+		return false;
 	}
 
-	if (CureEffect && IsBeneficialSpell(spell_id))
+	auto has_cure_effect = false;
+
+	const auto& spell = spells[spell_id];
+
+	for (int i = 0; i < EFFECT_COUNT; i++) {
+		if (
+			spell.effect_id[i] == SE_DiseaseCounter ||
+			spell.effect_id[i] == SE_PoisonCounter ||
+			spell.effect_id[i] == SE_CurseCounter ||
+			spell.effect_id[i] == SE_CorruptionCounter
+		) {
+			has_cure_effect = true;
+		}
+	}
+
+	if (
+		has_cure_effect &&
+		IsBeneficialSpell(spell_id)
+	) {
 		return true;
+	}
 
 	return false;
 }
 
 bool IsSlowSpell(uint16 spell_id)
 {
-	const SPDat_Spell_Struct &sp = spells[spell_id];
+	if (!IsValidSpell(spell_id)) {
+		return false;
+	}
 
-	for(int i = 0; i < EFFECT_COUNT; i++)
-		if ((sp.effect_id[i] == SE_AttackSpeed && sp.base_value[i] < 100) ||
-				(sp.effect_id[i] == SE_AttackSpeed4))
+	const auto& spell = spells[spell_id];
+
+	for (int i = 0; i < EFFECT_COUNT; i++) {
+		const auto effect_id = spell.effect_id[i];
+		if (
+			effect_id == SE_AttackSpeed4 ||
+			(
+				effect_id == SE_AttackSpeed &&
+				spell.base_value[i] < 100
+			)
+		) {
 			return true;
+		}
+	}
 
 	return false;
 }
 
 bool IsHasteSpell(uint16 spell_id)
 {
-	const SPDat_Spell_Struct &sp = spells[spell_id];
+	if (!IsValidSpell(spell_id)) {
+		return false;
+	}
 
-	for(int i = 0; i < EFFECT_COUNT; i++)
-		if(sp.effect_id[i] == SE_AttackSpeed)
-			return (sp.base_value[i] < 100);
+	const auto& spell = spells[spell_id];
+
+	for (int i = 0; i < EFFECT_COUNT; i++) {
+		if (spell.effect_id[i] == SE_AttackSpeed) {
+			return (spell.base_value[i] < 100);
+		}
+	}
 
 	return false;
 }
 
 bool IsHarmonySpell(uint16 spell_id)
 {
-	// IsEffectInSpell(spell_id, SE_Lull) - Lull is not calculated anywhere atm
-	return (IsEffectInSpell(spell_id, SE_Harmony) || IsEffectInSpell(spell_id, SE_ChangeFrenzyRad));
+	return (
+		IsEffectInSpell(spell_id, SE_ChangeFrenzyRad) ||
+		IsEffectInSpell(spell_id, SE_Harmony) ||
+		IsEffectInSpell(spell_id, SE_Lull)
+	);
 }
 
 bool IsPercentalHealSpell(uint16 spell_id)
@@ -217,49 +273,88 @@ bool IsPercentalHealSpell(uint16 spell_id)
 
 bool IsGroupOnlySpell(uint16 spell_id)
 {
-	return IsValidSpell(spell_id) && spells[spell_id].good_effect == 2;
+	if (!IsValidSpell(spell_id)) {
+		return false;
+	}
+
+	return spells[spell_id].good_effect == BENEFICIAL_EFFECT_GROUP_ONLY;
 }
 
 bool IsBeneficialSpell(uint16 spell_id)
 {
-	if (!IsValidSpell(spell_id))
+	if (!IsValidSpell(spell_id)) {
 		return false;
+	}
 
 	// You'd think just checking goodEffect flag would be enough?
-	if (spells[spell_id].good_effect == 1) {
+	if (spells[spell_id].good_effect == BENEFICIAL_EFFECT) {
 		// If the target type is ST_Self or ST_Pet and is a SE_CancleMagic spell
 		// it is not Beneficial
-		SpellTargetType tt = spells[spell_id].target_type;
-		if (tt != ST_Self && tt != ST_Pet &&
-				IsEffectInSpell(spell_id, SE_CancelMagic))
+		const auto target_type = spells[spell_id].target_type;
+		if (
+			target_type != ST_Self &&
+			target_type != ST_Pet &&
+			IsEffectInSpell(spell_id, SE_CancelMagic)
+		) {
 			return false;
+		}
 
-		// When our targettype is ST_Target, ST_AETarget, ST_Aniaml, ST_Undead, or ST_Pet
+		// When our targetarget_typeype is ST_Target, ST_AETarget, ST_Aniaml, ST_Undead, or ST_Pet
 		// We need to check more things!
-		if (tt == ST_Target || tt == ST_AETarget || tt == ST_Animal ||
-				tt == ST_Undead || tt == ST_Pet) {
-			uint16 sai = spells[spell_id].spell_affect_index;
+		if (
+			target_type == ST_Target ||
+			target_type == ST_AETarget ||
+			target_type == ST_Animal ||
+			target_type == ST_Undead ||
+			target_type == ST_Pet
+		) {
+			const auto spell_affect_index = spells[spell_id].spell_affect_index;
 
 			// If the resisttype is magic and SpellAffectIndex is Calm/memblur/dispell sight
 			// it's not beneficial
 			if (spells[spell_id].resist_type == RESIST_MAGIC) {
 				// checking these SAI cause issues with the rng defensive proc line
 				// So I guess instead of fixing it for real, just a quick hack :P
-				if (spells[spell_id].effect_id[0] != SE_DefensiveProc &&
-				    (sai == SAI_Calm || sai == SAI_Dispell_Sight || sai == SAI_Memory_Blur ||
-				     sai == SAI_Calm_Song))
+				if (
+					spells[spell_id].effect_id[0] != SE_DefensiveProc &&
+					(
+						spell_affect_index == SAI_Calm ||
+						spell_affect_index == SAI_Dispell_Sight ||
+						spell_affect_index == SAI_Memory_Blur ||
+						spell_affect_index == SAI_Calm_Song
+					)
+				) {
 					return false;
+				}
 			} else {
 				// If the resisttype is not magic and spell is Bind Sight or Cast Sight
 				// It's not beneficial
-				if ((sai == SAI_Calm && IsEffectInSpell(spell_id, SE_Harmony)) || (sai == SAI_Calm_Song && IsEffectInSpell(spell_id, SE_BindSight)) || (sai == SAI_Dispell_Sight && spells[spell_id].skill == 18 && !IsEffectInSpell(spell_id, SE_VoiceGraft)))
+				if (
+					(
+						spell_affect_index == SAI_Calm &&
+						IsEffectInSpell(spell_id, SE_Harmony)
+					) ||
+					(
+						spell_affect_index == SAI_Calm_Song &&
+						IsEffectInSpell(spell_id, SE_BindSight)
+					) ||
+					(
+						spell_affect_index == SAI_Dispell_Sight &&
+						spells[spell_id].skill == EQ::skills::SkillDivination &&
+						!IsEffectInSpell(spell_id, SE_VoiceGraft)
+					)
+				) {
 					return false;
+				}
 			}
 		}
 	}
 
 	// And finally, if goodEffect is not 0 or if it's a group spell it's beneficial
-	return spells[spell_id].good_effect != 0 || IsGroupSpell(spell_id);
+	return (
+		spells[spell_id].good_effect != DETRIMENTAL_EFFECT ||
+		IsGroupSpell(spell_id)
+	);
 }
 
 bool IsDetrimentalSpell(uint16 spell_id)
@@ -267,17 +362,16 @@ bool IsDetrimentalSpell(uint16 spell_id)
 	return !IsBeneficialSpell(spell_id);
 }
 
-bool IsInvisSpell(uint16 spell_id)
+bool IsInvisibleSpell(uint16 spell_id)
 {
-	if (IsEffectInSpell(spell_id, SE_Invisibility) ||
+	return (
+		IsEffectInSpell(spell_id, SE_Invisibility) ||
 		IsEffectInSpell(spell_id, SE_Invisibility2) ||
 		IsEffectInSpell(spell_id, SE_InvisVsUndead) ||
 		IsEffectInSpell(spell_id, SE_InvisVsUndead2) ||
 		IsEffectInSpell(spell_id, SE_InvisVsAnimals) ||
-		IsEffectInSpell(spell_id, SE_ImprovedInvisAnimals)) {
-		return true;
-	}
-	return false;
+		IsEffectInSpell(spell_id, SE_ImprovedInvisAnimals)
+	);
 }
 
 bool IsInvulnerabilitySpell(uint16 spell_id)
@@ -285,7 +379,7 @@ bool IsInvulnerabilitySpell(uint16 spell_id)
 	return IsEffectInSpell(spell_id, SE_DivineAura);
 }
 
-bool IsCHDurationSpell(uint16 spell_id)
+bool IsCompleteHealDurationSpell(uint16 spell_id)
 {
 	return IsEffectInSpell(spell_id, SE_CompleteHeal);
 }
@@ -312,11 +406,19 @@ bool IsSummonSkeletonSpell(uint16 spell_id)
 
 bool IsSummonPetSpell(uint16 spell_id)
 {
-	if (IsEffectInSpell(spell_id, SE_SummonPet) ||
-			IsEffectInSpell(spell_id, SE_SummonBSTPet))
-		return true;
+	return (
+		IsEffectInSpell(spell_id, SE_SummonPet) ||
+		IsEffectInSpell(spell_id, SE_SummonBSTPet) ||
+		IsEffectInSpell(spell_id, SE_Familiar)
+	);
+}
 
-	return false;
+bool IsPetSpell(uint16 spell_id)
+{
+	return (
+		IsSummonPetSpell(spell_id) ||
+		IsSummonSkeletonSpell(spell_id)
+	);
 }
 
 bool IsSummonPCSpell(uint16 spell_id)
@@ -334,12 +436,12 @@ bool IsBlindSpell(uint16 spell_id)
 	return IsEffectInSpell(spell_id, SE_Blind);
 }
 
-bool IsEffectHitpointsSpell(uint16 spell_id)
+bool IsHealthSpell(uint16 spell_id)
 {
 	return IsEffectInSpell(spell_id, SE_CurrentHP);
 }
 
-bool IsReduceCastTimeSpell(uint16 spell_id)
+bool IsCastTimeReductionSpell(uint16 spell_id)
 {
 	return IsEffectInSpell(spell_id, SE_IncreaseSpellHaste);
 }
@@ -349,12 +451,12 @@ bool IsIncreaseDurationSpell(uint16 spell_id)
 	return IsEffectInSpell(spell_id, SE_IncreaseSpellDuration);
 }
 
-bool IsReduceManaSpell(uint16 spell_id)
+bool IsManaCostReductionSpell(uint16 spell_id)
 {
 	return IsEffectInSpell(spell_id, SE_ReduceManaCost);
 }
 
-bool IsExtRangeSpell(uint16 spell_id)
+bool IsIncreaseRangeSpell(uint16 spell_id)
 {
 	return IsEffectInSpell(spell_id, SE_IncreaseRange);
 }
@@ -371,18 +473,23 @@ bool IsImprovedDamageSpell(uint16 spell_id)
 
 bool IsAEDurationSpell(uint16 spell_id)
 {
+	if (!IsValidSpell(spell_id)) {
+		return false;
+	}
+
+	const auto& spell = spells[spell_id];
+
 	/*
 		There are plenty of spells with aoe_duration set at single digit numbers, but these
 		do not act as duration effects.
 	*/
 	if (
-		IsValidSpell(spell_id) &&
-		spells[spell_id].aoe_duration >= 2500 &&
+		spell.aoe_duration >= 2500 &&
 		(
-			spells[spell_id].target_type == ST_AETarget ||
-			spells[spell_id].target_type == ST_UndeadAE ||
-			spells[spell_id].target_type == ST_AECaster ||
-			spells[spell_id].target_type == ST_Ring
+			spell.target_type == ST_AETarget ||
+			spell.target_type == ST_UndeadAE ||
+			spell.target_type == ST_AECaster ||
+			spell.target_type == ST_Ring
 		)
 	) {
 		return true;
@@ -393,64 +500,114 @@ bool IsAEDurationSpell(uint16 spell_id)
 
 bool IsPureNukeSpell(uint16 spell_id)
 {
-	int i, effect_count = 0;
-
-	if (!IsValidSpell(spell_id))
+	if (!IsValidSpell(spell_id)) {
 		return false;
+	}
 
-	for (i = 0; i < EFFECT_COUNT; i++)
-		if (!IsBlankSpellEffect(spell_id, i))
+	auto effect_count = 0;
+
+	for (int i = 0; i < EFFECT_COUNT; i++) {
+		if (!IsBlankSpellEffect(spell_id, i)) {
 			effect_count++;
+		}
+	}
 
-	if (effect_count == 1 && IsEffectInSpell(spell_id, SE_CurrentHP) &&
-			spells[spell_id].buff_duration == 0 && IsDamageSpell(spell_id))
+	if (
+		effect_count == 1 &&
+		IsEffectInSpell(spell_id, SE_CurrentHP) &&
+		spells[spell_id].buff_duration == 0 &&
+		IsDamageSpell(spell_id)
+	) {
 		return true;
+	}
 
 	return false;
 }
 
 bool IsAENukeSpell(uint16 spell_id)
 {
-	if (IsValidSpell(spell_id) && IsPureNukeSpell(spell_id) &&
-			spells[spell_id].aoe_range > 0)
+	if (!IsValidSpell(spell_id)) {
+		return false;
+	}
+
+	if (
+		IsPureNukeSpell(spell_id) &&
+		spells[spell_id].aoe_range > 0
+	) {
 		return true;
+	}
 
 	return false;
 }
 
 bool IsPBAENukeSpell(uint16 spell_id)
 {
-	if (IsValidSpell(spell_id) && IsPureNukeSpell(spell_id) &&
-			spells[spell_id].aoe_range > 0 && spells[spell_id].target_type == ST_AECaster)
+	if (!IsValidSpell(spell_id)) {
+		return false;
+	}
+
+	const auto& spell = spells[spell_id];
+
+	if (
+		IsPureNukeSpell(spell_id) &&
+		spell.aoe_range > 0 &&
+		spell.target_type == ST_AECaster
+	) {
 		return true;
+	}
 
 	return false;
 }
 
 bool IsAERainNukeSpell(uint16 spell_id)
 {
-	if (IsValidSpell(spell_id) && IsPureNukeSpell(spell_id) &&
-			spells[spell_id].aoe_range > 0 && spells[spell_id].aoe_duration > 1000)
+	if (!IsValidSpell(spell_id)) {
+		return false;
+	}
+
+	const auto& spell = spells[spell_id];
+
+	if (
+		IsPureNukeSpell(spell_id) &&
+		spell.aoe_range > 0 &&
+		spell.aoe_duration > 1000
+	) {
 		return true;
+	}
 
 	return false;
 }
 
-bool IsPartialCapableSpell(uint16 spell_id)
+bool IsPartialResistableSpell(uint16 spell_id)
 {
-	if (spells[spell_id].no_partial_resist)
+	if (!IsValidSpell(spell_id)) {
 		return false;
+	}
+
+	const auto& spell = spells[spell_id];
+
+	if (spell.no_partial_resist) {
+		return false;
+	}
 
 	// spell uses 600 (partial) scale if first effect is damage, else it uses 200 scale.
 	// this includes DoTs.  no_partial_resist excludes spells like necro snares
 	for (int o = 0; o < EFFECT_COUNT; o++) {
-		auto tid = spells[spell_id].effect_id[o];
+		const auto effect_id = spell.effect_id[o];
 
-		if (IsBlankSpellEffect(spell_id, o))
+		if (IsBlankSpellEffect(spell_id, o)) {
 			continue;
+		}
 
-		if ((tid == SE_CurrentHPOnce || tid == SE_CurrentHP) && spells[spell_id].base_value[o] < 0)
+		if (
+			spell.base_value[o] < 0 &&
+			(
+				effect_id == SE_CurrentHPOnce ||
+				effect_id == SE_CurrentHP
+			)
+		) {
 			return true;
+		}
 
 		return false;
 	}
@@ -462,270 +619,320 @@ bool IsResistableSpell(uint16 spell_id)
 {
 	// for now only detrimental spells are resistable. later on i will
 	// add specific exceptions for the beneficial spells that are resistable
-	if (IsDetrimentalSpell(spell_id))
-		return true;
-
-	return false;
+	return IsDetrimentalSpell(spell_id);
 }
 
 // checks if this spell affects your group
 bool IsGroupSpell(uint16 spell_id)
 {
-	if (IsValidSpell(spell_id) &&
-			(spells[spell_id].target_type == ST_AEBard ||
-			 spells[spell_id].target_type == ST_Group ||
-			 spells[spell_id].target_type == ST_GroupTeleport))
-		return true;
+	if (!IsValidSpell(spell_id)) {
+		return false;
+	}
 
-	return false;
+	const auto& spell = spells[spell_id];
+
+	return (
+		spell.target_type == ST_AEBard ||
+		spell.target_type == ST_Group ||
+		spell.target_type == ST_GroupTeleport
+	);
 }
 
 // checks if this spell can be targeted
 bool IsTGBCompatibleSpell(uint16 spell_id)
 {
-	if (IsValidSpell(spell_id) &&
-			(!IsDetrimentalSpell(spell_id) && spells[spell_id].buff_duration != 0 &&
-			 !IsBardSong(spell_id) && !IsEffectInSpell(spell_id, SE_Illusion)))
+	if (!IsValidSpell(spell_id)) {
+		return false;
+	}
+
+	if (
+		!IsDetrimentalSpell(spell_id) &&
+		spells[spell_id].buff_duration != 0 &&
+		!IsBardSong(spell_id) &&
+		!IsEffectInSpell(spell_id, SE_Illusion)
+	) {
 		return true;
+	}
 
 	return false;
 }
 
 bool IsBardSong(uint16 spell_id)
 {
-	if (IsValidSpell(spell_id) && spells[spell_id].classes[BARD - 1] < 255 && !spells[spell_id].is_discipline)
-		return true;
-
-	return false;
-}
-
-bool IsEffectInSpell(uint16 spellid, int effect)
-{
-	int j;
-
-	if (!IsValidSpell(spellid))
+	if (!IsValidSpell(spell_id)) {
 		return false;
+	}
 
-	for (j = 0; j < EFFECT_COUNT; j++)
-		if (spells[spellid].effect_id[j] == effect)
-			return true;
+	const auto& spell = spells[spell_id];
+
+	if (
+		spell.classes[BARD - 1] < UINT8_MAX &&
+		!spell.is_discipline
+	) {
+		return true;
+	}
 
 	return false;
 }
 
+bool IsEffectInSpell(uint16 spell_id, int effect_id)
+{
+	if (!IsValidSpell(spell_id)) {
+		return false;
+	}
 
-uint16 GetTriggerSpellID(uint16 spell_id, uint32 effect) {
+	const auto& spell = spells[spell_id];
 
-	for (int index = 0; index < EFFECT_COUNT; index++) {
+	for (int i = 0; i < EFFECT_COUNT; i++) {
+		if (spell.effect_id[i] == effect_id) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+uint16 GetSpellTriggerSpellID(uint16 spell_id, int effect_id)
+{
+	if (!IsValidSpell(spell_id)) {
+		return false;
+	}
+
+	const auto& spell = spells[spell_id];
+
+	for (int i = 0; i < EFFECT_COUNT; i++) {
 		if (
-			spells[spell_id].effect_id[index] == SE_TriggerOnCast ||
-			spells[spell_id].effect_id[index] == SE_SpellTrigger ||
-			spells[spell_id].effect_id[index] == SE_ApplyEffect ||
-			spells[spell_id].effect_id[index] == SE_Trigger_Spell_Non_Item
+			spell.effect_id[i] == SE_TriggerOnCast ||
+			spell.effect_id[i] == SE_SpellTrigger ||
+			spell.effect_id[i] == SE_ApplyEffect ||
+			spell.effect_id[i] == SE_Trigger_Spell_Non_Item
 		) {
-			int apply_effect_spell_id = spells[spell_id].limit_value[index];
-			if (IsEffectInSpell(apply_effect_spell_id, effect)) {
-				if (IsValidSpell(apply_effect_spell_id)) {
-					return apply_effect_spell_id;
-				}
+			const auto trigger_spell_id = spell.limit_value[i];
+			if (
+				IsValidSpell(trigger_spell_id) &&
+				IsEffectInSpell(trigger_spell_id, effect_id)
+			) {
+				return trigger_spell_id;
 			}
 		}
 	}
+
 	return 0;
 }
 
 // arguments are spell id and the index of the effect to check.
 // this is used in loops that process effects inside a spell to skip
 // the blanks
-bool IsBlankSpellEffect(uint16 spellid, int effect_index)
+bool IsBlankSpellEffect(uint16 spell_id, int effect_index)
 {
-	int effect, base_value, formula;
+	if (!IsValidSpell(spell_id)) {
+		return false;
+	}
 
-	effect = spells[spellid].effect_id[effect_index];
-	base_value = spells[spellid].base_value[effect_index];
-	formula = spells[spellid].formula[effect_index];
+	const auto& spell = spells[spell_id];
+
+	const auto effect     = spell.effect_id[effect_index];
+	const auto base_value = spell.base_value[effect_index];
+	const auto formula    = spell.formula[effect_index];
 
 	// SE_CHA is "spacer"
 	// SE_Stacking* are also considered blank where this is used
-	if (effect == SE_Blank || (effect == SE_CHA && base_value == 0 && formula == 100) ||
-			effect == SE_StackingCommand_Block || effect == SE_StackingCommand_Overwrite)
+	if (
+		effect == SE_Blank ||
+		(
+			effect == SE_CHA &&
+			base_value == 0 &&
+			formula == 100
+		) ||
+		effect == SE_StackingCommand_Block ||
+		effect == SE_StackingCommand_Overwrite
+	) {
 		return true;
+	}
 
 	return false;
 }
 
 // checks some things about a spell id, to see if we can proceed
-bool IsValidSpell(uint32 spellid)
+bool IsValidSpell(uint32 spell_id)
 {
-	if (SPDAT_RECORDS > 0 && spellid != 0 && spellid != 1 &&
-			spellid != 0xFFFFFFFF && spellid < SPDAT_RECORDS && spells[spellid].player_1[0])
+	if (
+		SPDAT_RECORDS > 0 &&
+		spell_id >= 2 &&
+		spell_id != UINT32_MAX &&
+		spell_id < SPDAT_RECORDS &&
+		spells[spell_id].player_1[0]
+	) {
 		return true;
+	}
 
 	return false;
 }
 
 // returns the lowest level of any caster which can use the spell
-int GetMinLevel(uint16 spell_id)
+uint8 GetSpellMinimumLevel(uint16 spell_id)
 {
-	int r, min = 255;
-	const SPDat_Spell_Struct &spell = spells[spell_id];
-	for (r = 0; r < PLAYER_CLASS_COUNT; r++)
-		if (spell.classes[r] < min)
-			min = spell.classes[r];
+	if (!IsValidSpell(spell_id)) {
+		return UINT8_MAX;
+	}
+
+	uint8 minimum_level = UINT8_MAX;
+
+	const auto& spell = spells[spell_id];
+
+	for (int i = 0; i < PLAYER_CLASS_COUNT; i++) {
+		if (spell.classes[i] < minimum_level) {
+			minimum_level = spell.classes[i];
+		}
+	}
 
 	// if we can't cast the spell return 0
 	// just so it wont screw up calculations used in other areas of the code
 	// seen 127, 254, 255
-	if (min >= 127)
-		return 0;
-	else
-		return min;
+	return minimum_level;
 }
 
-int GetSpellLevel(uint16 spell_id, int classa)
+uint8 GetSpellLevel(uint16 spell_id, uint8 class_id)
 {
-	if (classa >= PLAYER_CLASS_COUNT)
-		return 255;
+	if (!IsValidSpell(spell_id)) {
+		return UINT8_MAX;
+	}
 
-	const SPDat_Spell_Struct &spell = spells[spell_id];
-	return spell.classes[classa - 1];
+	if (class_id >= PLAYER_CLASS_COUNT) {
+		return UINT8_MAX;
+	}
+
+	return spells[spell_id].classes[class_id - 1];
 }
 
 // this will find the first occurrence of effect. this is handy
 // for spells like mez and charm, but if the effect appears more than once
 // in a spell this will just give back the first one.
-int GetSpellEffectIndex(uint16 spell_id, int effect)
+int GetSpellEffectIndex(uint16 spell_id, int effect_id)
 {
-	int i;
-
-	if (!IsValidSpell(spell_id))
+	if (!IsValidSpell(spell_id)) {
 		return -1;
+	}
 
-	for (i = 0; i < EFFECT_COUNT; i++)
-		if (spells[spell_id].effect_id[i] == effect)
+	const auto& spell = spells[spell_id];
+
+	for (int i = 0; i < EFFECT_COUNT; i++) {
+		if (spell.effect_id[i] == effect_id) {
 			return i;
+		}
+	}
 
 	return -1;
 }
 
-// returns the level required to use the spell if that class/level
-// can use it, 0 otherwise
-// note: this isn't used by anything right now
-int CanUseSpell(uint16 spellid, int classa, int level)
+int CalculatePoisonCounters(uint16 spell_id)
 {
-	int level_to_use;
-
-	if (!IsValidSpell(spellid) || classa >= PLAYER_CLASS_COUNT)
+	if (!IsValidSpell(spell_id)) {
 		return 0;
-
-	level_to_use = spells[spellid].classes[classa - 1];
-
-	if (level_to_use && level_to_use != 255 && level >= level_to_use)
-		return level_to_use;
-
-	return 0;
-}
-
-bool BeneficialSpell(uint16 spell_id)
-{
-	if (spell_id <= 0 || spell_id >= SPDAT_RECORDS
-			/*|| spells[spell_id].stacking == 27*/ )
-		return true;
-
-	switch (spells[spell_id].good_effect) {
-		case 1:
-		case 3:
-			return true;
 	}
 
-	return false;
-}
+	const auto& spell = spells[spell_id];
 
-bool GroupOnlySpell(uint16 spell_id)
-{
-	switch (spells[spell_id].good_effect) {
-		case 2:
-		case 3:
-			return true;
+	auto counters = 0;
+
+	for (int i = 0; i < EFFECT_COUNT; i++) {
+		if (
+			spell.effect_id[i] == SE_PoisonCounter &&
+			spell.base_value[i] > 0
+		) {
+			counters += spell.base_value[i];
+		}
 	}
 
-	switch (spell_id) {
-		case 1771:
-			return true;
+	return counters;
+}
+
+int CalculateDiseaseCounters(uint16 spell_id)
+{
+	if (!IsValidSpell(spell_id)) {
+		return 0;
 	}
 
-	return false;
+	const auto& spell = spells[spell_id];
+
+	auto counters = 0;
+
+	for (int i = 0; i < EFFECT_COUNT; i++) {
+		if (
+			spell.effect_id[i] == SE_DiseaseCounter &&
+			spell.base_value[i] > 0
+		) {
+			counters += spell.base_value[i];
+		}
+	}
+
+	return counters;
 }
 
-int32 CalculatePoisonCounters(uint16 spell_id)
+int CalculateCurseCounters(uint16 spell_id)
 {
-	if (!IsValidSpell(spell_id))
+	if (!IsValidSpell(spell_id)) {
 		return 0;
+	}
 
-	int32 Counters = 0;
-	for (int i = 0; i < EFFECT_COUNT; i++)
-		if (spells[spell_id].effect_id[i] == SE_PoisonCounter &&
-				spells[spell_id].base_value[i] > 0)
-			Counters += spells[spell_id].base_value[i];
+	const auto& spell = spells[spell_id];
 
-	return Counters;
+	auto counters = 0;
+
+	for (int i = 0; i < EFFECT_COUNT; i++) {
+		if (
+			spell.effect_id[i] == SE_CurseCounter &&
+			spell.base_value[i] > 0
+		) {
+			counters += spell.base_value[i];
+		}
+	}
+
+	return counters;
 }
 
-int32 CalculateDiseaseCounters(uint16 spell_id)
+int CalculateCorruptionCounters(uint16 spell_id)
 {
-	if (!IsValidSpell(spell_id))
+	if (!IsValidSpell(spell_id)) {
 		return 0;
+	}
 
-	int32 Counters = 0;
-	for (int i = 0; i < EFFECT_COUNT; i++)
-		if(spells[spell_id].effect_id[i] == SE_DiseaseCounter &&
-				spells[spell_id].base_value[i] > 0)
-			Counters += spells[spell_id].base_value[i];
+	const auto& spell = spells[spell_id];
 
-	return Counters;
+	auto counters = 0;
+
+	for (int i = 0; i < EFFECT_COUNT; i++) {
+		if (
+			spell.effect_id[i] == SE_CorruptionCounter &&
+			spell.base_value[i] > 0) {
+
+			counters += spell.base_value[i];
+		}
+	}
+
+	return counters;
 }
 
-int32 CalculateCurseCounters(uint16 spell_id)
+int CalculateCounters(uint16 spell_id)
 {
-	if (!IsValidSpell(spell_id))
+	if (!IsValidSpell(spell_id)) {
 		return 0;
+	}
 
-	int32 Counters = 0;
-	for (int i = 0; i < EFFECT_COUNT; i++)
-		if(spells[spell_id].effect_id[i] == SE_CurseCounter &&
-				spells[spell_id].base_value[i] > 0)
-			Counters += spells[spell_id].base_value[i];
-
-	return Counters;
-}
-
-int32 CalculateCorruptionCounters(uint16 spell_id)
-{
-	if (!IsValidSpell(spell_id))
-		return 0;
-
-	int32 Counters = 0;
-	for (int i = 0; i < EFFECT_COUNT; i++)
-		if (spells[spell_id].effect_id[i] == SE_CorruptionCounter &&
-				spells[spell_id].base_value[i] > 0)
-			Counters += spells[spell_id].base_value[i];
-
-	return Counters;
-}
-
-int32 CalculateCounters(uint16 spell_id)
-{
-	int32 counter = CalculatePoisonCounters(spell_id);
-	if (counter != 0)
+	auto counter = CalculatePoisonCounters(spell_id);
+	if (counter) {
 		return counter;
+	}
 
 	counter = CalculateDiseaseCounters(spell_id);
-	if (counter != 0)
+	if (counter) {
 		return counter;
+	}
 
 	counter = CalculateCurseCounters(spell_id);
-	if (counter != 0)
+	if (counter) {
 		return counter;
+	}
 
 	counter = CalculateCorruptionCounters(spell_id);
 	return counter;
@@ -733,123 +940,159 @@ int32 CalculateCounters(uint16 spell_id)
 
 bool IsDisciplineBuff(uint16 spell_id)
 {
-	if (!IsValidSpell(spell_id))
+	if (!IsValidSpell(spell_id)) {
 		return false;
+	}
 
-	if (spells[spell_id].is_discipline && spells[spell_id].target_type == ST_Self)
+	const auto& spell = spells[spell_id];
+
+	if (
+		spell.is_discipline &&
+		spell.target_type == ST_Self
+	) {
 		return true;
+	}
 
 	return false;
 }
 
 bool IsDiscipline(uint16 spell_id)
 {
-	if (!IsValidSpell(spell_id))
+	if (!IsValidSpell(spell_id)) {
 		return false;
+	}
 
-	if (spells[spell_id].mana == 0 &&
-			(spells[spell_id].endurance_cost || spells[spell_id].endurance_upkeep))
+	const auto& spell = spells[spell_id];
+
+	if (
+		spell.mana == 0 &&
+		(
+			spell.endurance_cost ||
+			spell.endurance_upkeep
+		)
+	) {
 		return true;
+	}
 
 	return false;
 }
 
 bool IsCombatSkill(uint16 spell_id)
 {
-	if (!IsValidSpell(spell_id))
+	if (!IsValidSpell(spell_id)) {
 		return false;
+	}
+
+	const auto& spell = spells[spell_id];
 
 	//Check if Discipline
-	if ((spells[spell_id].mana == 0 &&	(spells[spell_id].endurance_cost || spells[spell_id].endurance_upkeep)))
+	if (
+		spell.mana == 0 &&
+		(
+			spell.endurance_cost ||
+			spell.endurance_upkeep
+		)
+	) {
 		return true;
+	}
 
 	return false;
 }
 
 bool IsResurrectionEffects(uint16 spell_id)
 {
+	if (!IsValidSpell(spell_id)) {
+		return false;
+	}
+
 	// spell id 756 is Resurrection Effects spell
-	if (IsValidSpell(spell_id) && (spell_id == RuleI(Character, ResurrectionSicknessSpellID) || spell_id == RuleI(Character, OldResurrectionSicknessSpellID))) {
+	if (
+		spell_id == RuleI(Character, ResurrectionSicknessSpellID) ||
+		spell_id == RuleI(Character, OldResurrectionSicknessSpellID)
+	) {
 		return true;
 	}
 
 	return false;
 }
 
-int8 GetResurrectionSicknessCheck(uint16 spell_id1, uint16 spell_id2)
+int8 GetSpellResurrectionSicknessCheck(uint16 spell_id_one, uint16 spell_id_two)
 {
-	if (RuleI(Spells, ResurrectionEffectBlock) == RES_EFFECTS_BLOCK) {
-		LogSpells("[{}] is blocked by [{}]", spells[spell_id2].name, spells[spell_id1].name);
-		return -1; // can't stack
+	if (
+		!IsValidSpell(spell_id_one) ||
+		!IsValidSpell(spell_id_two)
+	) {
+		return RuleI(Spells, ResurrectionEffectBlock);
 	}
-	else if (RuleI(Spells, ResurrectionEffectBlock) == RES_EFFECTS_BLOCK_WITH_BUFFS) {
+
+	const int8  rule_value = RuleI(Spells, ResurrectionEffectBlock);
+	const auto& spell_one  = spells[spell_id_one];
+	const auto& spell_two  = spells[spell_id_two];
+
+	if (rule_value == RES_EFFECTS_BLOCK) {
+		LogSpells(
+			"[{}] is blocked by [{}]",
+			spell_two.name,
+			spell_one.name
+		);
+		return RES_EFFECTS_CANNOT_STACK;
+	} else if (rule_value == RES_EFFECTS_BLOCK_WITH_BUFFS) {
 		LogSpells(
 			"[{}] is blocked by [{}], moving to empty slot if available",
-			spells[spell_id2].name,
-			spells[spell_id1].name
+			spell_one.name,
+			spell_two.name
 		);
 		return MOVE_NEW_SLOT; // move to empty slot if available
 	}
+
 	return NO_RES_EFFECTS_BLOCK;
 }
 
 bool IsRuneSpell(uint16 spell_id)
 {
-	if (IsValidSpell(spell_id))
-		for (int i = 0; i < EFFECT_COUNT; i++)
-			if (spells[spell_id].effect_id[i] == SE_Rune)
-				return true;
-
-	return false;
+	return IsEffectInSpell(spell_id, SE_Rune);
 }
 
 bool IsMagicRuneSpell(uint16 spell_id)
 {
-	if(IsValidSpell(spell_id))
-		for(int i = 0; i < EFFECT_COUNT; i++)
-			if(spells[spell_id].effect_id[i] == SE_AbsorbMagicAtt)
-				return true;
-
-	return false;
+	return IsEffectInSpell(spell_id, SE_AbsorbMagicAtt);
 }
 
 bool IsManaTapSpell(uint16 spell_id)
 {
-	if (IsValidSpell(spell_id))
-		for (int i = 0; i < EFFECT_COUNT; i++)
-			if (spells[spell_id].effect_id[i] == SE_CurrentMana &&
-					spells[spell_id].target_type == ST_Tap)
-				return true;
-
-	return false;
+	return (
+		IsEffectInSpell(spell_id, SE_CurrentMana) &&
+		spells[spell_id].target_type == ST_Tap
+	);
 }
 
-bool IsAllianceSpellLine(uint16 spell_id)
+bool IsAllianceSpell(uint16 spell_id)
 {
-	if (IsEffectInSpell(spell_id, SE_AddFaction))
-		return true;
-
-	return false;
+	return IsEffectInSpell(spell_id, SE_AddFaction);
 }
 
 bool IsDeathSaveSpell(uint16 spell_id)
 {
-	if (IsEffectInSpell(spell_id, SE_DeathSave))
-		return true;
-
-	return false;
+	return IsEffectInSpell(spell_id, SE_DeathSave);
 }
 
 // Deathsave spells with base of 1 are partial
 bool IsPartialDeathSaveSpell(uint16 spell_id)
 {
-	if (!IsValidSpell(spell_id))
+	if (!IsValidSpell(spell_id)) {
 		return false;
+	}
 
-	for (int i = 0; i < EFFECT_COUNT; i++)
-		if (spells[spell_id].effect_id[i] == SE_DeathSave &&
-				spells[spell_id].base_value[i] == 1)
+	const auto& spell = spells[spell_id];
+
+	for (int i = 0; i < EFFECT_COUNT; i++) {
+		if (
+			spell.effect_id[i] == SE_DeathSave &&
+			spell.base_value[i] == PARTIAL_DEATH_SAVE
+		) {
 			return true;
+		}
+	}
 
 	return false;
 }
@@ -857,121 +1100,122 @@ bool IsPartialDeathSaveSpell(uint16 spell_id)
 // Deathsave spells with base 2 are "full"
 bool IsFullDeathSaveSpell(uint16 spell_id)
 {
-	if (!IsValidSpell(spell_id))
+	if (!IsValidSpell(spell_id)) {
 		return false;
+	}
 
-	for (int i = 0; i < EFFECT_COUNT; i++)
-		if (spells[spell_id].effect_id[i] == SE_DeathSave &&
-				spells[spell_id].base_value[i] == 2)
+	const auto& spell = spells[spell_id];
+
+	for (int i = 0; i < EFFECT_COUNT; i++) {
+		if (
+			spell.effect_id[i] == SE_DeathSave &&
+			spell.base_value[i] == FULL_DEATH_SAVE
+		) {
 			return true;
+		}
+	}
 
 	return false;
 }
 
 bool IsShadowStepSpell(uint16 spell_id)
 {
-	if (IsEffectInSpell(spell_id, SE_ShadowStep))
-		return true;
-
-	return false;
+	return IsEffectInSpell(spell_id, SE_ShadowStep);
 }
 
 bool IsSuccorSpell(uint16 spell_id)
 {
-	if (IsEffectInSpell(spell_id, SE_Succor))
-		return true;
-
-	return false;
+	return IsEffectInSpell(spell_id, SE_Succor);
 }
 
 bool IsTeleportSpell(uint16 spell_id)
 {
-	if (IsEffectInSpell(spell_id, SE_Teleport))
-		return true;
-
-	return false;
+	return IsEffectInSpell(spell_id, SE_Teleport);
 }
 
 bool IsTranslocateSpell(uint16 spell_id)
 {
-	if (IsEffectInSpell(spell_id, SE_Translocate))
-		return true;
-
-	return false;
+	return IsEffectInSpell(spell_id, SE_Translocate);
 }
 
 bool IsGateSpell(uint16 spell_id)
 {
-	if (IsEffectInSpell(spell_id, SE_Gate))
-		return true;
-
-	return false;
+	return IsEffectInSpell(spell_id, SE_Gate);
 }
 
-bool IsPlayerIllusionSpell(uint16 spell_id)
+bool IsIllusionSpell(uint16 spell_id)
 {
-	if (IsEffectInSpell(spell_id, SE_Illusion) &&
-			spells[spell_id].target_type == ST_Self)
-		return true;
-
-	return false;
+	return (
+		IsEffectInSpell(spell_id, SE_Illusion) &&
+		spells[spell_id].target_type == ST_Self
+	);
 }
 
-int GetSpellEffectDescNum(uint16 spell_id)
+int GetSpellEffectDescriptionNumber(uint16 spell_id)
 {
-	if (IsValidSpell(spell_id))
+	if (IsValidSpell(spell_id)) {
 		return spells[spell_id].effect_description_id;
+	}
 
 	return -1;
 }
 
-DmgShieldType GetDamageShieldType(uint16 spell_id, int32 DSType)
+DmgShieldType GetDamageShieldType(uint16 spell_id, int damage_shield_type)
 {
-	// If we have a DamageShieldType for this spell from the damageshieldtypes table, return that,
-	// else, make a guess, based on the resist type. Default return value is DS_THORNS
-	if (IsValidSpell(spell_id)) {
-		LogSpells("DamageShieldType for spell [{}] ([{}]) is [{}]", spell_id,
-			spells[spell_id].name, spells[spell_id].damage_shield_type);
-
-		if (spells[spell_id].damage_shield_type)
-			return (DmgShieldType) spells[spell_id].damage_shield_type;
-
-		switch (spells[spell_id].resist_type) {
-			case RESIST_COLD:
-				return DS_TORMENT;
-			case RESIST_FIRE:
-				return DS_BURN;
-			case RESIST_DISEASE:
-				return DS_DECAY;
-			default:
-				return DS_THORNS;
-		}
+	if (!IsValidSpell(spell_id)) {
+		return DS_THORNS;
 	}
 
-	else if (DSType)
-		return (DmgShieldType) DSType;
+	const auto& spell = spells[spell_id];
+
+	// If we have a DamageShieldType for this spell from the damageshieldtypes table, return that,
+	// else, make a guess, based on the resist type. Default return value is DS_THORNS
+	LogSpells(
+		"DamageShieldType for spell [{}] ([{}]) is [{}]",
+		spell_id,
+		spell.name,
+		spell.damage_shield_type
+	);
+
+	if (spell.damage_shield_type) {
+		return static_cast<DmgShieldType>(spell.damage_shield_type);
+	}
+
+	switch (spells[spell_id].resist_type) {
+		case RESIST_COLD:
+			return DS_TORMENT;
+		case RESIST_FIRE:
+			return DS_BURN;
+		case RESIST_DISEASE:
+			return DS_DECAY;
+		default:
+			return DS_THORNS;
+	}
+
+	if (damage_shield_type) {
+		return static_cast<DmgShieldType>(damage_shield_type);
+	}
 
 	return DS_THORNS;
 }
 
 bool IsLDoNObjectSpell(uint16 spell_id)
 {
-	if (IsEffectInSpell(spell_id, SE_AppraiseLDonChest) ||
-			IsEffectInSpell(spell_id, SE_DisarmLDoNTrap) ||
-			IsEffectInSpell(spell_id, SE_UnlockLDoNChest))
-		return true;
-
-	return false;
+	return (
+		IsEffectInSpell(spell_id, SE_AppraiseLDonChest) ||
+		IsEffectInSpell(spell_id, SE_DisarmLDoNTrap) ||
+		IsEffectInSpell(spell_id, SE_UnlockLDoNChest)
+	);
 }
 
-int32 GetSpellResistType(uint16 spell_id)
+int GetSpellResistType(uint16 spell_id)
 {
 	return spells[spell_id].resist_type;
 }
 
-int32 GetSpellTargetType(uint16 spell_id)
+int GetSpellTargetType(uint16 spell_id)
 {
-	return (int32)spells[spell_id].target_type;
+	return static_cast<int>(spells[spell_id].target_type);
 }
 
 bool IsHealOverTimeSpell(uint16 spell_id)
@@ -979,7 +1223,7 @@ bool IsHealOverTimeSpell(uint16 spell_id)
 	if (
 		(
 			IsEffectInSpell(spell_id, SE_HealOverTime) ||
-			GetTriggerSpellID(spell_id, SE_HealOverTime)
+			GetSpellTriggerSpellID(spell_id, SE_HealOverTime)
 		) &&
 		!IsGroupSpell(spell_id)
 	) {
@@ -996,58 +1240,84 @@ bool IsCompleteHealSpell(uint16 spell_id)
 			spell_id == SPELL_COMPLETE_HEAL ||
 			IsEffectInSpell(spell_id, SE_CompleteHeal) ||
 			IsPercentalHealSpell(spell_id) ||
-			GetTriggerSpellID(spell_id, SE_CompleteHeal)
+			GetSpellTriggerSpellID(spell_id, SE_CompleteHeal)
 		) &&
 		!IsGroupSpell(spell_id)
 	) {
 		return true;
 	}
+
 	return false;
 }
 
 bool IsFastHealSpell(uint16 spell_id)
 {
-	const int MaxFastHealCastingTime = 2000;
+	spell_id = (
+		IsEffectInSpell(spell_id, SE_CurrentHP) ?
+		spell_id :
+		GetSpellTriggerSpellID(spell_id, SE_CurrentHP)
+	);
 
-	spell_id = (IsEffectInSpell(spell_id, SE_CurrentHP)) ? spell_id : GetTriggerSpellID(spell_id, SE_CurrentHP);
 	if (!spell_id) {
-		spell_id = (IsEffectInSpell(spell_id, SE_CurrentHPOnce)) ? spell_id : GetTriggerSpellID(spell_id, SE_CurrentHPOnce);
+		spell_id = (
+			IsEffectInSpell(spell_id, SE_CurrentHPOnce) ?
+			spell_id :
+			GetSpellTriggerSpellID(spell_id, SE_CurrentHPOnce)
+		);
 	}
+
 	if (spell_id) {
-		if (spells[spell_id].cast_time <= MaxFastHealCastingTime && spells[spell_id].good_effect && !IsGroupSpell(spell_id)) {
+		if (
+			spells[spell_id].cast_time <= MAX_FAST_HEAL_CASTING_TIME &&
+			spells[spell_id].good_effect &&
+			!IsGroupSpell(spell_id)
+		) {
 			for (int i = 0; i < EFFECT_COUNT; i++) {
 				if (
+					spells[spell_id].base_value[i] > 0 &&
 					(
 						spells[spell_id].effect_id[i] == SE_CurrentHP ||
 						spells[spell_id].effect_id[i] == SE_CurrentHPOnce
-					) &&
-					spells[spell_id].base_value[i] > 0
+					)
 				) {
 					return true;
 				}
 			}
 		}
 	}
+
 	return false;
 }
 
 bool IsVeryFastHealSpell(uint16 spell_id)
 {
-	const int MaxFastHealCastingTime = 1000;
+	spell_id = (
+		IsEffectInSpell(spell_id, SE_CurrentHP) ?
+		spell_id :
+		GetSpellTriggerSpellID(spell_id, SE_CurrentHP)
+	);
 
-	spell_id = (IsEffectInSpell(spell_id, SE_CurrentHP)) ? spell_id : GetTriggerSpellID(spell_id, SE_CurrentHP);
 	if (!spell_id) {
-		spell_id = (IsEffectInSpell(spell_id, SE_CurrentHPOnce)) ? spell_id : GetTriggerSpellID(spell_id, SE_CurrentHPOnce);
+		spell_id = (
+			IsEffectInSpell(spell_id, SE_CurrentHPOnce) ?
+			spell_id :
+			GetSpellTriggerSpellID(spell_id, SE_CurrentHPOnce)
+		);
 	}
+
 	if (spell_id) {
-		if (spells[spell_id].cast_time <= MaxFastHealCastingTime && spells[spell_id].good_effect && !IsGroupSpell(spell_id)) {
+		if (
+			spells[spell_id].cast_time <= MAX_VERY_FAST_HEAL_CASTING_TIME &&
+			spells[spell_id].good_effect &&
+			!IsGroupSpell(spell_id)
+		) {
 			for (int i = 0; i < EFFECT_COUNT; i++) {
 				if (
+					spells[spell_id].base_value[i] > 0 &&
 					(
 						spells[spell_id].effect_id[i] == SE_CurrentHP ||
 						spells[spell_id].effect_id[i] == SE_CurrentHPOnce
-					) &&
-					spells[spell_id].base_value[i] > 0
+					)
 				) {
 					return true;
 				}
@@ -1060,20 +1330,35 @@ bool IsVeryFastHealSpell(uint16 spell_id)
 
 bool IsRegularSingleTargetHealSpell(uint16 spell_id)
 {
-	spell_id = (IsEffectInSpell(spell_id, SE_CurrentHP)) ? spell_id : GetTriggerSpellID(spell_id, SE_CurrentHP);
+	spell_id = (
+		IsEffectInSpell(spell_id, SE_CurrentHP) ?
+		spell_id :
+		GetSpellTriggerSpellID(spell_id, SE_CurrentHP)
+	);
+
 	if (!spell_id) {
-		spell_id = (IsEffectInSpell(spell_id, SE_CurrentHPOnce)) ? spell_id : GetTriggerSpellID(spell_id, SE_CurrentHPOnce);
+		spell_id = (
+			IsEffectInSpell(spell_id, SE_CurrentHPOnce) ?
+			spell_id :
+			GetSpellTriggerSpellID(spell_id, SE_CurrentHPOnce)
+		);
 	}
+
 	if (spell_id) {
-		if (spells[spell_id].target_type == ST_Target && !IsCompleteHealSpell(spell_id) && !IsHealOverTimeSpell(spell_id) && !IsGroupSpell(spell_id)) {
+		if (
+			spells[spell_id].target_type == ST_Target &&
+			!IsCompleteHealSpell(spell_id) &&
+			!IsHealOverTimeSpell(spell_id) &&
+			!IsGroupSpell(spell_id)
+		) {
 			for (int i = 0; i < EFFECT_COUNT; i++) {
 				if (
+					spells[spell_id].base_value[i] > 0 &&
+					spells[spell_id].buff_duration == 0 &&
 					(
 						spells[spell_id].effect_id[i] == SE_CurrentHP ||
 						spells[spell_id].effect_id[i] == SE_CurrentHPOnce
-					) &&
-					spells[spell_id].base_value[i] > 0 &&
-					spells[spell_id].buff_duration == 0
+					)
 				) {
 					return true;
 				}
@@ -1086,437 +1371,551 @@ bool IsRegularSingleTargetHealSpell(uint16 spell_id)
 
 bool IsRegularGroupHealSpell(uint16 spell_id)
 {
-	spell_id = (IsEffectInSpell(spell_id, SE_CurrentHP)) ? spell_id : GetTriggerSpellID(spell_id, SE_CurrentHP);
+	spell_id = (
+		IsEffectInSpell(spell_id, SE_CurrentHP) ?
+		spell_id :
+		GetSpellTriggerSpellID(spell_id, SE_CurrentHP)
+	);
+
 	if (!spell_id) {
-		spell_id = (IsEffectInSpell(spell_id, SE_CurrentHPOnce)) ? spell_id : GetTriggerSpellID(spell_id, SE_CurrentHPOnce);
+		spell_id = (
+			IsEffectInSpell(spell_id, SE_CurrentHPOnce) ?
+			spell_id :
+			GetSpellTriggerSpellID(spell_id, SE_CurrentHPOnce)
+		);
 	}
+
 	if (spell_id) {
-		if (IsGroupSpell(spell_id) && !IsCompleteHealSpell(spell_id) && !IsHealOverTimeSpell(spell_id)) {
+		if (
+			IsGroupSpell(spell_id) &&
+			!IsCompleteHealSpell(spell_id) &&
+			!IsHealOverTimeSpell(spell_id)
+		) {
 			for (int i = 0; i < EFFECT_COUNT; i++) {
 				if (
+					spells[spell_id].base_value[i] > 0 &&
+					spells[spell_id].buff_duration == 0 &&
 					(
 						spells[spell_id].effect_id[i] == SE_CurrentHP ||
 						spells[spell_id].effect_id[i] == SE_CurrentHPOnce
-					) &&
-					spells[spell_id].base_value[i] > 0 &&
-					spells[spell_id].buff_duration == 0
+					)
 				) {
 					return true;
 				}
 			}
 		}
 	}
+
 	return false;
 }
 
 bool IsGroupCompleteHealSpell(uint16 spell_id)
 {
-	if (IsGroupSpell(spell_id) && IsCompleteHealSpell(spell_id))
+	if (
+		IsGroupSpell(spell_id) &&
+		IsCompleteHealSpell(spell_id)
+	) {
 		return true;
+	}
 
 	return false;
 }
 
 bool IsGroupHealOverTimeSpell(uint16 spell_id)
 {
-	if( IsGroupSpell(spell_id) && IsHealOverTimeSpell(spell_id) && spells[spell_id].buff_duration < 10)
+	if (
+		IsGroupSpell(spell_id) &&
+		IsHealOverTimeSpell(spell_id) &&
+		spells[spell_id].buff_duration < 10
+	) {
 		return true;
+	}
 
 	return false;
 }
 
 bool IsDebuffSpell(uint16 spell_id)
 {
-	if (IsBeneficialSpell(spell_id) || IsEffectHitpointsSpell(spell_id) || IsStunSpell(spell_id) ||
-			IsMezSpell(spell_id) || IsCharmSpell(spell_id) || IsSlowSpell(spell_id) ||
-			IsEffectInSpell(spell_id, SE_Root) || IsEffectInSpell(spell_id, SE_CancelMagic) ||
-			IsEffectInSpell(spell_id, SE_MovementSpeed) || IsFearSpell(spell_id) || IsEffectInSpell(spell_id, SE_InstantHate))
+	if (
+		IsBeneficialSpell(spell_id) ||
+		IsHealthSpell(spell_id) ||
+		IsStunSpell(spell_id) ||
+		IsMesmerizeSpell(spell_id) ||
+		IsCharmSpell(spell_id) ||
+		IsSlowSpell(spell_id) ||
+		IsEffectInSpell(spell_id, SE_Root) ||
+		IsEffectInSpell(spell_id, SE_CancelMagic) ||
+		IsEffectInSpell(spell_id, SE_MovementSpeed) ||
+		IsFearSpell(spell_id) ||
+		IsEffectInSpell(spell_id, SE_InstantHate)
+	) {
 		return false;
-	else
-		return true;
+	}
+
+	return true;
 }
 
 bool IsResistDebuffSpell(uint16 spell_id)
 {
-	if ((IsEffectInSpell(spell_id, SE_ResistFire) || IsEffectInSpell(spell_id, SE_ResistCold) ||
-				IsEffectInSpell(spell_id, SE_ResistPoison) || IsEffectInSpell(spell_id, SE_ResistDisease) ||
-				IsEffectInSpell(spell_id, SE_ResistMagic) || IsEffectInSpell(spell_id, SE_ResistAll) ||
-				IsEffectInSpell(spell_id, SE_ResistCorruption)) && !IsBeneficialSpell(spell_id))
+	if (
+		!IsBeneficialSpell(spell_id) &&
+		(
+			IsEffectInSpell(spell_id, SE_ResistFire) ||
+			IsEffectInSpell(spell_id, SE_ResistCold) ||
+			IsEffectInSpell(spell_id, SE_ResistPoison) ||
+			IsEffectInSpell(spell_id, SE_ResistDisease) ||
+			IsEffectInSpell(spell_id, SE_ResistMagic) ||
+			IsEffectInSpell(spell_id, SE_ResistAll) ||
+			IsEffectInSpell(spell_id, SE_ResistCorruption)
+		)
+	) {
 		return true;
-	else
-		return false;
+	}
+
+	return false;
 }
 
 bool IsSelfConversionSpell(uint16 spell_id)
 {
-	if (GetSpellTargetType(spell_id) == ST_Self && IsEffectInSpell(spell_id, SE_CurrentMana) &&
-			IsEffectInSpell(spell_id, SE_CurrentHP) && spells[spell_id].base_value[GetSpellEffectIndex(spell_id, SE_CurrentMana)] > 0 &&
-			spells[spell_id].base_value[GetSpellEffectIndex(spell_id, SE_CurrentHP)] < 0)
+	if (
+		GetSpellTargetType(spell_id) == ST_Self &&
+		IsEffectInSpell(spell_id, SE_CurrentMana) &&
+		IsEffectInSpell(spell_id, SE_CurrentHP) &&
+		spells[spell_id].base_value[GetSpellEffectIndex(spell_id, SE_CurrentMana)] > 0 &&
+		spells[spell_id].base_value[GetSpellEffectIndex(spell_id, SE_CurrentHP)] < 0
+	) {
 		return true;
-	else
-		return false;
+	}
+
+	return false;
 }
 
 // returns true for both detrimental and beneficial buffs
 bool IsBuffSpell(uint16 spell_id)
 {
-	if (IsValidSpell(spell_id) && (spells[spell_id].buff_duration || spells[spell_id].buff_duration_formula))
+	if (
+		IsValidSpell(spell_id) &&
+		(
+			spells[spell_id].buff_duration ||
+			spells[spell_id].buff_duration_formula
+		)
+	) {
 		return true;
+	}
 
 	return false;
 }
 
 bool IsPersistDeathSpell(uint16 spell_id)
 {
-	if (IsValidSpell(spell_id) && spells[spell_id].persist_death)
+	if (
+		IsValidSpell(spell_id) &&
+		spells[spell_id].persist_death
+	) {
 		return true;
+	}
 
 	return false;
 }
 
 bool IsSuspendableSpell(uint16 spell_id)
 {
-	if (IsValidSpell(spell_id) && spells[spell_id].suspendable)
+	if (
+		IsValidSpell(spell_id) &&
+		spells[spell_id].suspendable
+	) {
 		return true;
+	}
 
 	return false;
 }
 
-uint32 GetMorphTrigger(uint32 spell_id)
-{
-	for (int i = 0; i < EFFECT_COUNT; ++i)
-		if (spells[spell_id].effect_id[i] == SE_CastOnFadeEffect)
-			return spells[spell_id].base_value[i];
-
-	return 0;
-}
-
-bool IsCastonFadeDurationSpell(uint16 spell_id)
+bool IsCastOnFadeDurationSpell(uint16 spell_id)
 {
 	for (int i = 0; i < EFFECT_COUNT; ++i) {
-		if (spells[spell_id].effect_id[i] == SE_CastOnFadeEffect
-			|| spells[spell_id].effect_id[i] == SE_CastOnFadeEffectNPC
-			|| spells[spell_id].effect_id[i] == SE_CastOnFadeEffectAlways){
-
-		return true;
+		if (
+			spells[spell_id].effect_id[i] == SE_CastOnFadeEffect ||
+			spells[spell_id].effect_id[i] == SE_CastOnFadeEffectNPC ||
+			spells[spell_id].effect_id[i] == SE_CastOnFadeEffectAlways
+		) {
+			return true;
 		}
 	}
+
 	return false;
 }
 
-bool IsPowerDistModSpell(uint16 spell_id)
+bool IsDistanceModifierSpell(uint16 spell_id)
 {
-	if (IsValidSpell(spell_id) &&
-		(spells[spell_id].max_distance_mod || spells[spell_id].min_distance_mod) && spells[spell_id].max_distance > spells[spell_id].min_distance)
+	if (
+		IsValidSpell(spell_id) &&
+		spells[spell_id].max_distance > spells[spell_id].min_distance &&
+		(
+			spells[spell_id].max_distance_mod ||
+			spells[spell_id].min_distance_mod
+		)
+	) {
 		return true;
+	}
 
 	return false;
 }
 
-uint32 GetPartialMeleeRuneReduction(uint32 spell_id)
+int GetSpellPartialMeleeRuneReduction(uint16 spell_id)
 {
-	for (int i = 0; i < EFFECT_COUNT; ++i)
-		if (spells[spell_id].effect_id[i] == SE_MitigateMeleeDamage)
+	for (int i = 0; i < EFFECT_COUNT; ++i) {
+		if (spells[spell_id].effect_id[i] == SE_MitigateMeleeDamage) {
 			return spells[spell_id].base_value[i];
+		}
+	}
 
 	return 0;
 }
 
-uint32 GetPartialMagicRuneReduction(uint32 spell_id)
+int GetSpellPartialMagicRuneReduction(uint16 spell_id)
 {
-	for (int i = 0; i < EFFECT_COUNT; ++i)
-		if (spells[spell_id].effect_id[i] == SE_MitigateSpellDamage)
+	for (int i = 0; i < EFFECT_COUNT; ++i) {
+		if (spells[spell_id].effect_id[i] == SE_MitigateSpellDamage) {
 			return spells[spell_id].base_value[i];
+		}
+	}
 
 	return 0;
 }
 
-uint32 GetPartialMeleeRuneAmount(uint32 spell_id)
+int GetSpellPartialMeleeRuneAmount(uint16 spell_id)
 {
-	for (int i = 0; i < EFFECT_COUNT; ++i)
-		if (spells[spell_id].effect_id[i] == SE_MitigateMeleeDamage)
+	for (int i = 0; i < EFFECT_COUNT; ++i) {
+		if (spells[spell_id].effect_id[i] == SE_MitigateMeleeDamage) {
 			return spells[spell_id].max_value[i];
+		}
+	}
 
 	return 0;
 }
 
-uint32 GetPartialMagicRuneAmount(uint32 spell_id)
+int GetSpellPartialMagicRuneAmount(uint16 spell_id)
 {
-	for (int i = 0; i < EFFECT_COUNT; ++i)
-		if (spells[spell_id].effect_id[i] == SE_MitigateSpellDamage)
+	for (int i = 0; i < EFFECT_COUNT; ++i) {
+		if (spells[spell_id].effect_id[i] == SE_MitigateSpellDamage) {
 			return spells[spell_id].max_value[i];
+		}
+	}
 
 	return 0;
 }
 
-
-bool DetrimentalSpellAllowsRest(uint16 spell_id)
+bool IsRestAllowedSpell(uint16 spell_id)
 {
-	if (IsValidSpell(spell_id))
-		return spells[spell_id].allow_rest;
+	if (!IsValidSpell(spell_id)) {
+		return false;
+	}
 
-	return false;
+	return spells[spell_id].allow_rest;
 }
 
-bool NoDetrimentalSpellAggro(uint16 spell_id)
+bool IsNoDetrimentalSpellAggroSpell(uint16 spell_id)
 {
-	if (IsValidSpell(spell_id))
-		return spells[spell_id].no_detrimental_spell_aggro;
+	if (!IsValidSpell(spell_id)) {
+		return false;
+	}
 
-	return false;
+	return spells[spell_id].no_detrimental_spell_aggro;
 }
 
-bool IsStackableDot(uint16 spell_id)
+bool IsStackableDOT(uint16 spell_id)
 {
 	// rules according to client
-	if (!IsValidSpell(spell_id))
+	if (!IsValidSpell(spell_id)) {
 		return false;
+	}
+
 	const auto &spell = spells[spell_id];
-	if (spell.unstackable_dot || spell.good_effect || !spell.buff_duration_formula)
+
+	if (
+		spell.unstackable_dot ||
+		spell.good_effect ||
+		!spell.buff_duration_formula) {
 		return false;
-	return IsEffectInSpell(spell_id, SE_CurrentHP) || IsEffectInSpell(spell_id, SE_GravityEffect);
+	}
+
+	return (
+		IsEffectInSpell(spell_id, SE_CurrentHP) ||
+		IsEffectInSpell(spell_id, SE_GravityEffect)
+	);
 }
 
-bool IsBardOnlyStackEffect(int effect)
+bool IsBardOnlyStackEffect(int effect_id)
 {
-	switch(effect) {
-	/*case SE_CurrentMana:
-	case SE_ManaRegen_v2:
-	case SE_CurrentHP:
-	case SE_HealOverTime:*/
-	case SE_BardAEDot:
-		return true;
-	default:
-		return false;
+	switch (effect_id) {
+		case SE_BardAEDot:
+			return true;
+		default:
+			return false;
 	}
 }
 
-bool IsCastWhileInvis(uint16 spell_id)
+bool IsCastWhileInvisibleSpell(uint16 spell_id)
 {
-	if (!IsValidSpell(spell_id))
+	if (!IsValidSpell(spell_id)) {
 		return false;
+	}
+
 	const auto &spell = spells[spell_id];
-	if (spell.sneak || spell.cast_not_standing)
+
+	if (
+		spell.cast_not_standing ||
+		spell.sneak
+	) {
 		return true;
+	}
+
 	return false;
 }
 
-bool IsEffectIgnoredInStacking(int spa)
+bool IsEffectIgnoredInStacking(int effect_id)
 {
 	// this should match RoF2
-	switch (spa) {
-	case SE_SeeInvis:
-	case SE_DiseaseCounter:
-	case SE_PoisonCounter:
-	case SE_Levitate:
-	case SE_InfraVision:
-	case SE_UltraVision:
-	case SE_CurrentHPOnce:
-	case SE_CurseCounter:
-	case SE_ImprovedDamage:
-	case SE_ImprovedHeal:
-	case SE_SpellResistReduction:
-	case SE_IncreaseSpellHaste:
-	case SE_IncreaseSpellDuration:
-	case SE_IncreaseRange:
-	case SE_SpellHateMod:
-	case SE_ReduceReagentCost:
-	case SE_ReduceManaCost:
-	case SE_FcStunTimeMod:
-	case SE_LimitMaxLevel:
-	case SE_LimitResist:
-	case SE_LimitTarget:
-	case SE_LimitEffect:
-	case SE_LimitSpellType:
-	case SE_LimitSpell:
-	case SE_LimitMinDur:
-	case SE_LimitInstant:
-	case SE_LimitMinLevel:
-	case SE_LimitCastTimeMin:
-	case SE_LimitCastTimeMax:
-	case SE_StackingCommand_Block:
-	case SE_StackingCommand_Overwrite:
-	case SE_PetPowerIncrease:
-	case SE_SkillDamageAmount:
-	case SE_ChannelChanceSpells:
-	case SE_Blank:
-	case SE_FcDamageAmt:
-	case SE_SpellDurationIncByTic:
-	case SE_FcSpellVulnerability:
-	case SE_FcDamageAmtIncoming:
-	case SE_FcDamagePctCrit:
-	case SE_FcDamageAmtCrit:
-	case SE_ReduceReuseTimer:
-	case SE_LimitCombatSkills:
-	case SE_BlockNextSpellFocus:
-	case SE_SpellTrigger:
-	case SE_LimitManaMin:
-	case SE_CorruptionCounter:
-	case SE_ApplyEffect:
-	case SE_NegateSpellEffect:
-	case SE_LimitSpellGroup:
-	case SE_LimitManaMax:
-	case SE_FcHealAmt:
-	case SE_FcHealPctIncoming:
-	case SE_FcHealAmtIncoming:
-	case SE_FcHealPctCritIncoming:
-	case SE_FcHealAmtCrit:
-	case SE_LimitClass:
-	case SE_LimitRace:
-	case SE_FcBaseEffects:
-	case SE_FFItemClass:
-	case SE_SkillDamageAmount2:
-	case SE_FcLimitUse:
-	case SE_FcIncreaseNumHits:
-	case SE_LimitUseMin:
-	case SE_LimitUseType:
-	case SE_GravityEffect:
-	case 425:
-	//Spell effects implemented after ROF2, following same pattern, lets assume these should go here.
-	case SE_Fc_Spell_Damage_Pct_IncomingPC:
-	case SE_Fc_Spell_Damage_Amt_IncomingPC:
-	case SE_Ff_CasterClass:
-	case SE_Ff_Same_Caster:
-	case SE_Proc_Timer_Modifier:
-	case SE_Weapon_Stance:
-	case SE_TwinCastBlocker:
-	case SE_Fc_CastTimeAmt:
-	case SE_Fc_CastTimeMod2:
-	case SE_Ff_DurationMax:
-	case SE_Ff_Endurance_Max:
-	case SE_Ff_Endurance_Min:
-	case SE_Ff_ReuseTimeMin:
-	case SE_Ff_ReuseTimeMax:
-	case SE_Ff_Value_Min:
-	case SE_Ff_Value_Max:
-	case SE_Ff_FocusTimerMin:
-		return true;
-	default:
-		return false;
+	switch (effect_id) {
+		case SE_SeeInvis:
+		case SE_DiseaseCounter:
+		case SE_PoisonCounter:
+		case SE_Levitate:
+		case SE_InfraVision:
+		case SE_UltraVision:
+		case SE_CurrentHPOnce:
+		case SE_CurseCounter:
+		case SE_ImprovedDamage:
+		case SE_ImprovedHeal:
+		case SE_SpellResistReduction:
+		case SE_IncreaseSpellHaste:
+		case SE_IncreaseSpellDuration:
+		case SE_IncreaseRange:
+		case SE_SpellHateMod:
+		case SE_ReduceReagentCost:
+		case SE_ReduceManaCost:
+		case SE_FcStunTimeMod:
+		case SE_LimitMaxLevel:
+		case SE_LimitResist:
+		case SE_LimitTarget:
+		case SE_LimitEffect:
+		case SE_LimitSpellType:
+		case SE_LimitSpell:
+		case SE_LimitMinDur:
+		case SE_LimitInstant:
+		case SE_LimitMinLevel:
+		case SE_LimitCastTimeMin:
+		case SE_LimitCastTimeMax:
+		case SE_StackingCommand_Block:
+		case SE_StackingCommand_Overwrite:
+		case SE_PetPowerIncrease:
+		case SE_SkillDamageAmount:
+		case SE_ChannelChanceSpells:
+		case SE_Blank:
+		case SE_FcDamageAmt:
+		case SE_SpellDurationIncByTic:
+		case SE_FcSpellVulnerability:
+		case SE_FcDamageAmtIncoming:
+		case SE_FcDamagePctCrit:
+		case SE_FcDamageAmtCrit:
+		case SE_ReduceReuseTimer:
+		case SE_LimitCombatSkills:
+		case SE_BlockNextSpellFocus:
+		case SE_SpellTrigger:
+		case SE_LimitManaMin:
+		case SE_CorruptionCounter:
+		case SE_ApplyEffect:
+		case SE_NegateSpellEffect:
+		case SE_LimitSpellGroup:
+		case SE_LimitManaMax:
+		case SE_FcHealAmt:
+		case SE_FcHealPctIncoming:
+		case SE_FcHealAmtIncoming:
+		case SE_FcHealPctCritIncoming:
+		case SE_FcHealAmtCrit:
+		case SE_LimitClass:
+		case SE_LimitRace:
+		case SE_FcBaseEffects:
+		case SE_FFItemClass:
+		case SE_SkillDamageAmount2:
+		case SE_FcLimitUse:
+		case SE_FcIncreaseNumHits:
+		case SE_LimitUseMin:
+		case SE_LimitUseType:
+		case SE_GravityEffect:
+		case SE_Display:
+			//Spell effects implemented after ROF2, following same pattern, lets assume these should go here.
+		case SE_Fc_Spell_Damage_Pct_IncomingPC:
+		case SE_Fc_Spell_Damage_Amt_IncomingPC:
+		case SE_Ff_CasterClass:
+		case SE_Ff_Same_Caster:
+		case SE_Proc_Timer_Modifier:
+		case SE_Weapon_Stance:
+		case SE_TwinCastBlocker:
+		case SE_Fc_CastTimeAmt:
+		case SE_Fc_CastTimeMod2:
+		case SE_Ff_DurationMax:
+		case SE_Ff_Endurance_Max:
+		case SE_Ff_Endurance_Min:
+		case SE_Ff_ReuseTimeMin:
+		case SE_Ff_ReuseTimeMax:
+		case SE_Ff_Value_Min:
+		case SE_Ff_Value_Max:
+		case SE_Ff_FocusTimerMin:
+			return true;
+		default:
+			return false;
 	}
 }
 
-bool IsFocusLimit(int spa)
+bool IsFocusLimit(int effect_id)
 {
-	switch (spa) {
-	case SE_LimitMaxLevel:
-	case SE_LimitResist:
-	case SE_LimitTarget:
-	case SE_LimitEffect:
-	case SE_LimitSpellType:
-	case SE_LimitSpell:
-	case SE_LimitMinDur:
-	case SE_LimitInstant:
-	case SE_LimitMinLevel:
-	case SE_LimitCastTimeMin:
-	case SE_LimitCastTimeMax:
-	case SE_LimitCombatSkills:
-	case SE_LimitManaMin:
-	case SE_LimitSpellGroup:
-	case SE_LimitManaMax:
-	case SE_LimitSpellClass:
-	case SE_LimitSpellSubclass:
-	case SE_LimitClass:
-	case SE_LimitRace:
-	case SE_LimitCastingSkill:
-	case SE_LimitUseMin:
-	case SE_LimitUseType:
-	case SE_Ff_Override_NotFocusable:
-	case SE_Ff_CasterClass:
-	case SE_Ff_Same_Caster:
-	case SE_Ff_DurationMax:
-	case SE_Ff_Endurance_Max:
-	case SE_Ff_Endurance_Min:
-	case SE_Ff_ReuseTimeMin:
-	case SE_Ff_ReuseTimeMax:
-	case SE_Ff_Value_Min:
-	case SE_Ff_Value_Max:
-	case SE_Ff_FocusTimerMin:
-	case SE_FFItemClass:
-		return true;
-	default:
-		return false;
+	switch (effect_id) {
+		case SE_LimitMaxLevel:
+		case SE_LimitResist:
+		case SE_LimitTarget:
+		case SE_LimitEffect:
+		case SE_LimitSpellType:
+		case SE_LimitSpell:
+		case SE_LimitMinDur:
+		case SE_LimitInstant:
+		case SE_LimitMinLevel:
+		case SE_LimitCastTimeMin:
+		case SE_LimitCastTimeMax:
+		case SE_LimitCombatSkills:
+		case SE_LimitManaMin:
+		case SE_LimitSpellGroup:
+		case SE_LimitManaMax:
+		case SE_LimitSpellClass:
+		case SE_LimitSpellSubclass:
+		case SE_LimitClass:
+		case SE_LimitRace:
+		case SE_LimitCastingSkill:
+		case SE_LimitUseMin:
+		case SE_LimitUseType:
+		case SE_Ff_Override_NotFocusable:
+		case SE_Ff_CasterClass:
+		case SE_Ff_Same_Caster:
+		case SE_Ff_DurationMax:
+		case SE_Ff_Endurance_Max:
+		case SE_Ff_Endurance_Min:
+		case SE_Ff_ReuseTimeMin:
+		case SE_Ff_ReuseTimeMax:
+		case SE_Ff_Value_Min:
+		case SE_Ff_Value_Max:
+		case SE_Ff_FocusTimerMin:
+		case SE_FFItemClass:
+			return true;
+		default:
+			return false;
 	}
 }
 
-uint32 GetNimbusEffect(uint16 spell_id)
+int GetSpellNimbusEffect(uint16 spell_id)
 {
-	if (IsValidSpell(spell_id))
-		return (int32)spells[spell_id].nimbus_effect;
-
-	return 0;
-}
-
-int32 GetFuriousBash(uint16 spell_id)
-{
-	if (!IsValidSpell(spell_id))
+	if (!IsValidSpell(spell_id)) {
 		return 0;
+	}
+
+	return spells[spell_id].nimbus_effect;
+}
+
+int GetSpellFuriousBash(uint16 spell_id)
+{
+	if (!IsValidSpell(spell_id)) {
+		return 0;
+	}
 
 	bool found_effect_limit = false;
-	int32 mod = 0;
+	auto mod                = 0;
 
-	for (int i = 0; i < EFFECT_COUNT; ++i)
-		if (spells[spell_id].effect_id[i] == SE_SpellHateMod)
+	for (int i = 0; i < EFFECT_COUNT; ++i) {
+		if (spells[spell_id].effect_id[i] == SE_SpellHateMod) {
 			mod = spells[spell_id].base_value[i];
-		else if (spells[spell_id].effect_id[i] == SE_LimitEffect && spells[spell_id].base_value[i] == 999)
+		} else if (
+			spells[spell_id].effect_id[i] == SE_LimitEffect &&
+			spells[spell_id].base_value[i] == 999
+		) {
 			found_effect_limit = true;
+		}
+	}
 
-	if (found_effect_limit)
+	if (found_effect_limit) {
 		return mod;
-	else
-		return 0;
+	}
+
+	return 0;
 }
 
 bool IsShortDurationBuff(uint16 spell_id)
 {
-	if (IsValidSpell(spell_id) && spells[spell_id].short_buff_box != 0)
-		return true;
+	if (!IsValidSpell(spell_id)) {
+		return false;
+	}
 
-	return false;
+	return spells[spell_id].short_buff_box != 0;
 }
 
-bool IsSpellUsableThisZoneType(uint16 spell_id, uint8 zone_type)
+bool IsSpellUsableInThisZoneType(uint16 spell_id, uint8 zone_type)
 {
+	if (!IsValidSpell(spell_id)) {
+		return false;
+	}
+
 	//check if spell can be cast in any zone (-1 or 255), then if spell zonetype matches zone's zonetype
 	// || spells[spell_id].zonetype == 255 comparing signed 8 bit int to 255 is always false
-	if (IsValidSpell(spell_id) && (spells[spell_id].zone_type == -1 ||
-				spells[spell_id].zone_type == zone_type))
+	if (
+		spells[spell_id].zone_type == -1 ||
+		spells[spell_id].zone_type == zone_type
+	) {
 		return true;
+	}
 
 	return false;
 }
 
 const char* GetSpellName(uint16 spell_id)
 {
-    return spells[spell_id].name;
+	if (!IsValidSpell(spell_id)) {
+		return "";
+	}
+
+	return spells[spell_id].name;
 }
 
-bool SpellRequiresTarget(int spell_id)
+bool IsTargetRequiredForSpell(uint16 spell_id)
 {
-	if (spells[spell_id].target_type == ST_AEClientV1 ||
-		spells[spell_id].target_type == ST_Self ||
-		spells[spell_id].target_type == ST_AECaster ||
-		spells[spell_id].target_type == ST_Ring ||
-		spells[spell_id].target_type == ST_Beam) {
+	if (!IsValidSpell(spell_id)) {
 		return false;
 	}
+
+	const auto& spell = spells[spell_id];
+
+	if (
+		spell.target_type == ST_AEClientV1 ||
+		spell.target_type == ST_Self ||
+		spell.target_type == ST_AECaster ||
+		spell.target_type == ST_Ring ||
+		spell.target_type == ST_Beam
+	) {
+		return false;
+	}
+
 	return true;
 }
 
-bool IsInstrumentModAppliedToSpellEffect(int32 spell_id, int effect)
+bool IsInstrumentModifierAppliedToSpellEffect(uint16 spell_id, int effect_id)
 {
+	if (!IsValidSpell(spell_id)) {
+		return false;
+	}
 
 	//Effects that are verified modifiable by bard instrument/singing mods, or highly likely due to similiar type of effect.
-	switch (effect) {
-
+	switch (effect_id) {
 		//Only modify instant endurance or mana effects (Ie. Mana drain, Crescendo line)
 		case SE_CurrentEndurance:
 		case SE_CurrentMana: {
-			if (spells[spell_id].buff_duration == 0) {
-				return true;
-			}
-			//Mana regen is not modified.
-			return false;
+			return spells[spell_id].buff_duration == 0;
 		}
 
 		case SE_CurrentHP:
@@ -1608,7 +2007,7 @@ bool IsInstrumentModAppliedToSpellEffect(int32 spell_id, int effect)
 	//Allowing anything not confirmed to be restricted / allowed to receive modifiers, as to not inhbit anyone making custom bard songs.
 }
 
-bool IsPulsingBardSong(int32 spell_id)
+bool IsPulsingBardSong(uint16 spell_id)
 {
 	if (!IsValidSpell(spell_id)) {
 		return false;
@@ -1627,21 +2026,21 @@ bool IsPulsingBardSong(int32 spell_id)
 	return true;
 }
 
-int GetSpellStatValue(uint32 spell_id, const char* stat_identifier, uint8 slot)
+int GetSpellStatValue(uint16 spell_id, const char* stat_identifier, uint8 slot)
 {
-	if (!IsValidSpell(spell_id))
+	if (!IsValidSpell(spell_id)) {
 		return 0;
-
-	if (!stat_identifier)
-		return 0;
-
-	if (slot > 0)
-		slot -= 1;
-
-	std::string id = stat_identifier;
-	for(uint32 i = 0; i < id.length(); ++i) {
-		id[i] = tolower(id[i]);
 	}
+
+	if (!stat_identifier) {
+		return 0;
+	}
+
+	if (slot > 0) {
+		slot -= 1;
+	}
+
+	const auto id = Strings::ToLower(stat_identifier);
 
 	if (slot < 16) {
 		if (id == "classes") { return spells[spell_id].classes[slot]; }
@@ -1741,41 +2140,62 @@ int GetSpellStatValue(uint32 spell_id, const char* stat_identifier, uint8 slot)
 	return 0;
 }
 
-bool IsVirusSpell(int32 spell_id)
+bool IsVirusSpell(uint16 spell_id)
 {
-	if (GetViralMinSpreadTime(spell_id) && GetViralMaxSpreadTime(spell_id) && GetViralSpreadRange(spell_id)){
-		return true;
+	if (!IsValidSpell(spell_id)) {
+		return false;
 	}
-	return false;
+
+	return (
+		GetSpellViralMinimumSpreadTime(spell_id) &&
+		GetSpellViralMaximumSpreadTime(spell_id) &&
+		GetSpellViralSpreadRange(spell_id)
+	);
 }
 
-int32 GetViralMinSpreadTime(int32 spell_id)
+int GetSpellViralMinimumSpreadTime(uint16 spell_id)
 {
-	return spells[spell_id].viral_targets;
-}
-
-int32 GetViralMaxSpreadTime(int32 spell_id)
-{
-	return spells[spell_id].viral_timer;
-}
-
-int32 GetViralSpreadRange(int32 spell_id)
-{
-	return spells[spell_id].viral_range;
-}
-
-uint32 GetProcLimitTimer(int32 spell_id, int proc_type) {
-
-	//This allows for support for effects that may have multiple different proc types and timers.
 	if (!IsValidSpell(spell_id)) {
 		return 0;
 	}
 
-	bool use_next_timer = false;
+	return spells[spell_id].viral_targets;
+}
+
+int GetSpellViralMaximumSpreadTime(uint16 spell_id)
+{
+	if (!IsValidSpell(spell_id)) {
+		return 0;
+	}
+
+	return spells[spell_id].viral_timer;
+}
+
+int GetSpellViralSpreadRange(uint16 spell_id)
+{
+	if (!IsValidSpell(spell_id)) {
+		return 0;
+	}
+
+	return spells[spell_id].viral_range;
+}
+
+int GetSpellProcLimitTimer(uint16 spell_id, int proc_type)
+{
+	if (!IsValidSpell(spell_id)) {
+		return 0;
+	}
+
+	//This allows for support for effects that may have multiple different proc types and timers.
+	auto use_next_timer = false;
+
 	for (int i = 0; i < EFFECT_COUNT; ++i) {
 
 		if (proc_type == ProcType::MELEE_PROC) {
-			if (spells[spell_id].effect_id[i] == SE_WeaponProc || spells[spell_id].effect_id[i] == SE_AddMeleeProc) {
+			if (
+				spells[spell_id].effect_id[i] == SE_WeaponProc ||
+				spells[spell_id].effect_id[i] == SE_AddMeleeProc
+			) {
 				use_next_timer = true;
 			}
 		}
@@ -1792,16 +2212,24 @@ uint32 GetProcLimitTimer(int32 spell_id, int proc_type) {
 			}
 		}
 
-		if (use_next_timer && spells[spell_id].effect_id[i] == SE_Proc_Timer_Modifier) {
+		if (
+			use_next_timer &&
+			spells[spell_id].effect_id[i] == SE_Proc_Timer_Modifier
+		) {
 			return spells[spell_id].limit_value[i];
 		}
 	}
+
 	return 0;
 }
 
-bool CastRestrictedSpell(int spellid)
+bool IsCastRestrictedSpell(uint16 spell_id)
 {
-	switch (spellid) {
+	if (!IsValidSpell(spell_id)) {
+		return false;
+	}
+
+	switch (spell_id) {
 		case SPELL_TOUCH_OF_VINITRAS:
 		case SPELL_DESPERATE_HOPE:
 		case SPELL_CHARM:
@@ -1831,20 +2259,52 @@ bool CastRestrictedSpell(int spellid)
 		case SPELL_SHAPECHANGE60:
 		case SPELL_COMMAND_OF_DRUZZIL:
 		case SPELL_SHAPECHANGE70:
+		case SPELL_GMHP25K:
+		case SPELL_GMHP50K:
+		case SPELL_GMHP100K:
+		case SPELL_GMHP225K:
+		case SPELL_GMHP475K:
+		case SPELL_GMHP925K:
+		case SPELL_GMHP2M:
+		case SPELL_GMHP3M:
+		case SPELL_GMHP5M:
+		case SPELL_GUIDE_ACTING_ONE:
+		case SPELL_GUIDE_ALLIANCE_ONE:
+		case SPELL_GUIDE_CANCEL_MAGIC_ONE:
+		case SPELL_GUIDE_JOURNEY_ONE:
+		case SPELL_GUIDE_VISION_ONE:
+		case SPELL_GUIDE_HEALTH_ONE:
+		case SPELL_GUIDE_INVULNERABILITY_ONE:
+		case SPELL_GUIDE_BOLT_ONE:
+		case SPELL_GUIDE_MEMORY_BLUR_ONE:
+		case SPELL_GUIDE_ACTING_TWO:
+		case SPELL_GUIDE_CANCEL_MAGIC_TWO:
+		case SPELL_GUIDE_JOURNEY_TWO:
+		case SPELL_GUIDE_VISION_TWO:
+		case SPELL_GUIDE_HEALTH_TWO:
+		case SPELL_GUIDE_INVULNERABILITY_TWO:
+		case SPELL_GUIDE_BOLT_TWO:
+		case SPELL_GUIDE_MEMORY_BLUR_TWO:
+		case SPELL_GUIDE_ALLIANCE_TWO:
+		case SPELL_GUIDE_EVACUATION:
+		case SPELL_GUIDE_LEVITATION:
+		case SPELL_GUIDE_SPELL_HASTE:
+		case SPELL_GUIDE_HASTE:
 			return true;
 		default:
 			return false;
 	}
 }
 
-bool IgnoreCastingRestriction(int32 spell_id) {
+bool IsCastNotStandingSpell(uint16 spell_id) {
+	if (!IsValidSpell(spell_id)) {
+		return false;
+	}
+
 	/*
 		field 'cast_not_standing' allows casting when sitting, stunned, mezed, Divine Aura, through SPA 343 Interrupt casting
 		Likely also allows for casting while feared, but need to confirm. Possibly also while charmed.
 		This field also allows for damage to ignore DA immunity.
 	*/
-	if (spells[spell_id].cast_not_standing) {
-		return true;
-	}
-	return false;
+	return spells[spell_id].cast_not_standing;
 }

--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -1877,7 +1877,7 @@ bool IsSpellUsableInThisZoneType(uint16 spell_id, uint8 zone_type)
 const char* GetSpellName(uint16 spell_id)
 {
 	if (!IsValidSpell(spell_id)) {
-		return "";
+		return "INVALID SPELL ID IN GETSPELLNAME";
 	}
 
 	return spells[spell_id].name;

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -171,6 +171,37 @@
 #define SPELL_ILLUSION_MALE 1732
 #define SPELL_UNSUMMON_SELF 892
 #define SPELL_ANCIENT_LIFEBANE 2115
+#define SPELL_GMHP25K 6817
+#define SPELL_GMHP50K 6818
+#define SPELL_GMHP100K 6819
+#define SPELL_GMHP225K 6820
+#define SPELL_GMHP475K 6821
+#define SPELL_GMHP925K 6822
+#define SPELL_GMHP2M 6823
+#define SPELL_GMHP3M 6824
+#define SPELL_GMHP5M 39851
+#define SPELL_GUIDE_ACTING_ONE 778
+#define SPELL_GUIDE_ALLIANCE_ONE 810
+#define SPELL_GUIDE_CANCEL_MAGIC_ONE 811
+#define SPELL_GUIDE_JOURNEY_ONE 813
+#define SPELL_GUIDE_VISION_ONE 814
+#define SPELL_GUIDE_HEALTH_ONE 815
+#define SPELL_GUIDE_INVULNERABILITY_ONE 816
+#define SPELL_GUIDE_BOLT_ONE 817
+#define SPELL_GUIDE_MEMORY_BLUR_ONE 818
+#define SPELL_GUIDE_ACTING_TWO 1209
+#define SPELL_GUIDE_CANCEL_MAGIC_TWO 1211
+#define SPELL_GUIDE_JOURNEY_TWO 1212
+#define SPELL_GUIDE_VISION_TWO 1213
+#define SPELL_GUIDE_HEALTH_TWO 1214
+#define SPELL_GUIDE_INVULNERABILITY_TWO 1215
+#define SPELL_GUIDE_BOLT_TWO 1216
+#define SPELL_GUIDE_MEMORY_BLUR_TWO 1217
+#define SPELL_GUIDE_ALLIANCE_TWO 1219
+#define SPELL_GUIDE_EVACUATION 3921
+#define SPELL_GUIDE_LEVITATION 39852
+#define SPELL_GUIDE_SPELL_HASTE 39853
+#define SPELL_GUIDE_HASTE 39854
 
 //spellgroup ids
 #define SPELLGROUP_FRENZIED_BURNOUT 2754
@@ -202,10 +233,21 @@
 #define INSTRUMENT_HORN 13012
 
 //option types for the rule Spells:ResurrectionEffectBlock
+#define RES_EFFECTS_CANNOT_STACK -1
 #define NO_RES_EFFECTS_BLOCK 0
 #define RES_EFFECTS_BLOCK 1
 #define RES_EFFECTS_BLOCK_WITH_BUFFS 2
 #define MOVE_NEW_SLOT 2
+
+#define PARTIAL_DEATH_SAVE 1
+#define FULL_DEATH_SAVE 2
+
+#define MAX_FAST_HEAL_CASTING_TIME 2000
+#define MAX_VERY_FAST_HEAL_CASTING_TIME 1000
+
+#define DETRIMENTAL_EFFECT 0
+#define BENEFICIAL_EFFECT 1
+#define BENEFICIAL_EFFECT_GROUP_ONLY 2
 
 const uint32 MobAISpellRange=100; // max range of buffs
 
@@ -1163,7 +1205,7 @@ typedef enum {
 #define SE_LimitUseMin					422 // implemented, @Ff Minium amount of numhits for a spell to be focused, base: numhit amt
 #define SE_LimitUseType					423 // implemented,	@Ff Focus will only affect if has this numhits type, base: numhit type
 #define SE_GravityEffect				424 // implemented - Pulls/pushes you toward/away the mob at a set pace
-//#define SE_Display					425 // *not implemented - Illusion: Flying Dragon(21626)
+#define SE_Display						425 // *not implemented - Illusion: Flying Dragon(21626)
 #define SE_IncreaseExtTargetWindow		426 // *not implmented[AA] - increases the capacity of your extended target window
 #define SE_SkillProcAttempt				427 // implemented - chance to proc when using a skill(ie taunt)
 #define SE_LimitToSkill					428 // implemented, @Procs, limits what combat skills will effect a skill proc, base: skill value, limit: none, max: none
@@ -1446,7 +1488,7 @@ extern int32 SPDAT_RECORDS;
 bool IsTargetableAESpell(uint16 spell_id);
 bool IsSacrificeSpell(uint16 spell_id);
 bool IsLifetapSpell(uint16 spell_id);
-bool IsMezSpell(uint16 spell_id);
+bool IsMesmerizeSpell(uint16 spell_id);
 bool IsStunSpell(uint16 spell_id);
 bool IsSlowSpell(uint16 spell_id);
 bool IsHasteSpell(uint16 spell_id);
@@ -1455,22 +1497,23 @@ bool IsPercentalHealSpell(uint16 spell_id);
 bool IsGroupOnlySpell(uint16 spell_id);
 bool IsBeneficialSpell(uint16 spell_id);
 bool IsDetrimentalSpell(uint16 spell_id);
-bool IsInvisSpell(uint16 spell_id);
+bool IsInvisibleSpell(uint16 spell_id);
 bool IsInvulnerabilitySpell(uint16 spell_id);
-bool IsCHDurationSpell(uint16 spell_id);
+bool IsCompleteHealDurationSpell(uint16 spell_id);
 bool IsPoisonCounterSpell(uint16 spell_id);
 bool IsDiseaseCounterSpell(uint16 spell_id);
 bool IsSummonItemSpell(uint16 spell_id);
 bool IsSummonSkeletonSpell(uint16 spell_id);
 bool IsSummonPetSpell(uint16 spell_id);
 bool IsSummonPCSpell(uint16 spell_id);
+bool IsPetSpell(uint16 spell_id);
 bool IsCharmSpell(uint16 spell_id);
 bool IsBlindSpell(uint16 spell_id);
-bool IsEffectHitpointsSpell(uint16 spell_id);
-bool IsReduceCastTimeSpell(uint16 spell_id);
+bool IsHealthSpell(uint16 spell_id);
+bool IsCastTimeReductionSpell(uint16 spell_id);
 bool IsIncreaseDurationSpell(uint16 spell_id);
-bool IsReduceManaSpell(uint16 spell_id);
-bool IsExtRangeSpell(uint16 spell_id);
+bool IsManaCostReductionSpell(uint16 spell_id);
+bool IsIncreaseRangeSpell(uint16 spell_id);
 bool IsImprovedHealingSpell(uint16 spell_id);
 bool IsImprovedDamageSpell(uint16 spell_id);
 bool IsAEDurationSpell(uint16 spell_id);
@@ -1478,26 +1521,22 @@ bool IsPureNukeSpell(uint16 spell_id);
 bool IsAENukeSpell(uint16 spell_id);
 bool IsPBAENukeSpell(uint16 spell_id);
 bool IsAERainNukeSpell(uint16 spell_id);
-bool IsPartialCapableSpell(uint16 spell_id);
+bool IsPartialResistableSpell(uint16 spell_id);
 bool IsResistableSpell(uint16 spell_id);
 bool IsGroupSpell(uint16 spell_id);
 bool IsTGBCompatibleSpell(uint16 spell_id);
 bool IsBardSong(uint16 spell_id);
-bool IsEffectInSpell(uint16 spellid, int effect);
-uint16 GetTriggerSpellID(uint16 spell_id, uint32 effect);
-bool IsBlankSpellEffect(uint16 spellid, int effect_index);
-bool IsValidSpell(uint32 spellid);
-bool IsSummonSpell(uint16 spellid);
-bool IsEvacSpell(uint16 spellid);
-bool IsDamageSpell(uint16 spellid);
-bool IsFearSpell(uint16 spellid);
-bool IsCureSpell(uint16 spellid);
-bool BeneficialSpell(uint16 spell_id);
-bool GroupOnlySpell(uint16 spell_id);
-int GetSpellEffectIndex(uint16 spell_id, int effect);
-int CanUseSpell(uint16 spellid, int classa, int level);
-int GetMinLevel(uint16 spell_id);
-int GetSpellLevel(uint16 spell_id, int classa);
+bool IsEffectInSpell(uint16 spell_id, int effect_id);
+uint16 GetSpellTriggerSpellID(uint16 spell_id, int effect_id);
+bool IsBlankSpellEffect(uint16 spell_id, int effect_index);
+bool IsValidSpell(uint32 spell_id);
+bool IsSummonSpell(uint16 spell_id);
+bool IsDamageSpell(uint16 spell_id);
+bool IsFearSpell(uint16 spell_id);
+bool IsCureSpell(uint16 spell_id);
+int GetSpellEffectIndex(uint16 spell_id, int effect_id);
+uint8 GetSpellMinimumLevel(uint16 spell_id);
+uint8 GetSpellLevel(uint16 spell_id, uint8 class_id);
 int CalcBuffDuration_formula(int level, int formula, int duration);
 int32 CalculatePoisonCounters(uint16 spell_id);
 int32 CalculateDiseaseCounters(uint16 spell_id);
@@ -1508,11 +1547,11 @@ bool IsDisciplineBuff(uint16 spell_id);
 bool IsDiscipline(uint16 spell_id);
 bool IsCombatSkill(uint16 spell_id);
 bool IsResurrectionEffects(uint16 spell_id);
-int8 GetResurrectionSicknessCheck(uint16 spell_id1, uint16 spell_id2);
+int8 GetSpellResurrectionSicknessCheck(uint16 spell_id_one, uint16 spell_id_two);
 bool IsRuneSpell(uint16 spell_id);
 bool IsMagicRuneSpell(uint16 spell_id);
 bool IsManaTapSpell(uint16 spell_id);
-bool IsAllianceSpellLine(uint16 spell_id);
+bool IsAllianceSpell(uint16 spell_id);
 bool IsDeathSaveSpell(uint16 spell_id);
 bool IsFullDeathSaveSpell(uint16 spell_id);
 bool IsPartialDeathSaveSpell(uint16 spell_id);
@@ -1521,10 +1560,10 @@ bool IsSuccorSpell(uint16 spell_id);
 bool IsTeleportSpell(uint16 spell_id);
 bool IsTranslocateSpell(uint16 spell_id);
 bool IsGateSpell(uint16 spell_id);
-bool IsPlayerIllusionSpell(uint16 spell_id); // seveian 2008-09-23
+bool IsIllusionSpell(uint16 spell_id);
 bool IsLDoNObjectSpell(uint16 spell_id);
-int32 GetSpellResistType(uint16 spell_id);
-int32 GetSpellTargetType(uint16 spell_id);
+int GetSpellResistType(uint16 spell_id);
+int GetSpellTargetType(uint16 spell_id);
 bool IsHealOverTimeSpell(uint16 spell_id);
 bool IsCompleteHealSpell(uint16 spell_id);
 bool IsFastHealSpell(uint16 spell_id);
@@ -1539,37 +1578,36 @@ bool IsSelfConversionSpell(uint16 spell_id);
 bool IsBuffSpell(uint16 spell_id);
 bool IsPersistDeathSpell(uint16 spell_id);
 bool IsSuspendableSpell(uint16 spell_id);
-uint32 GetMorphTrigger(uint32 spell_id);
-bool IsCastonFadeDurationSpell(uint16 spell_id);
-bool IsPowerDistModSpell(uint16 spell_id);
-uint32 GetPartialMeleeRuneReduction(uint32 spell_id);
-uint32 GetPartialMagicRuneReduction(uint32 spell_id);
-uint32 GetPartialMeleeRuneAmount(uint32 spell_id);
-uint32 GetPartialMagicRuneAmount(uint32 spell_id);
-bool NoDetrimentalSpellAggro(uint16 spell_id);
-bool IsStackableDot(uint16 spell_id);
-bool IsBardOnlyStackEffect(int effect);
-bool IsCastWhileInvis(uint16 spell_id);
-bool IsEffectIgnoredInStacking(int spa);
-bool IsFocusLimit(int spa);
-bool SpellRequiresTarget(int target_type);
-bool IsVirusSpell(int32 spell_id);
-int GetViralMinSpreadTime(int32 spell_id);
-int GetViralMaxSpreadTime(int32 spell_id);
-int GetViralSpreadRange(int32 spell_id);
-bool IsInstrumentModAppliedToSpellEffect(int32 spell_id, int effect);
-bool IsPulsingBardSong(int32 spell_id);
-uint32 GetProcLimitTimer(int32 spell_id, int proc_type);
-bool IgnoreCastingRestriction(int32 spell_id);
-int GetSpellEffectDescNum(uint16 spell_id);
-DmgShieldType GetDamageShieldType(uint16 spell_id, int32 DSType = 0);
-bool DetrimentalSpellAllowsRest(uint16 spell_id);
-uint32 GetNimbusEffect(uint16 spell_id);
-int32 GetFuriousBash(uint16 spell_id);
+bool IsCastOnFadeDurationSpell(uint16 spell_id);
+bool IsDistanceModifierSpell(uint16 spell_id);
+int GetSpellPartialMeleeRuneReduction(uint16 spell_id);
+int GetSpellPartialMagicRuneReduction(uint16 spell_id);
+int GetSpellPartialMeleeRuneAmount(uint16 spell_id);
+int GetSpellPartialMagicRuneAmount(uint16 spell_id);
+bool IsNoDetrimentalSpellAggroSpell(uint16 spell_id);
+bool IsStackableDOT(uint16 spell_id);
+bool IsBardOnlyStackEffect(int effect_id);
+bool IsCastWhileInvisibleSpell(uint16 spell_id);
+bool IsEffectIgnoredInStacking(int effect_id);
+bool IsFocusLimit(int effect_id);
+bool IsTargetRequiredForSpell(uint16 spell_id);
+bool IsVirusSpell(uint16 spell_id);
+int GetSpellViralMinimumSpreadTime(uint16 spell_id);
+int GetSpellViralMaximumSpreadTime(uint16 spell_id);
+int GetSpellViralSpreadRange(uint16 spell_id);
+bool IsInstrumentModifierAppliedToSpellEffect(uint16 spell_id, int effect_id);
+bool IsPulsingBardSong(uint16 spell_id);
+int GetSpellProcLimitTimer(uint16 spell_id, int proc_type);
+bool IsCastNotStandingSpell(uint16 spell_id);
+int GetSpellEffectDescriptionNumber(uint16 spell_id);
+DmgShieldType GetDamageShieldType(uint16 spell_id, int damage_shield_type = 0);
+bool IsRestAllowedSpell(uint16 spell_id);
+int GetSpellNimbusEffect(uint16 spell_id);
+int GetSpellFuriousBash(uint16 spell_id);
 bool IsShortDurationBuff(uint16 spell_id);
-bool IsSpellUsableThisZoneType(uint16 spell_id, uint8 zone_type);
+bool IsSpellUsableInThisZoneType(uint16 spell_id, uint8 zone_type);
 const char *GetSpellName(uint16 spell_id);
-int GetSpellStatValue(uint32 spell_id, const char* stat_identifier, uint8 slot = 0);
-bool CastRestrictedSpell(int spellid);
+int GetSpellStatValue(uint16 spell_id, const char* stat_identifier, uint8 slot = 0);
+bool IsCastRestrictedSpell(uint16 spell_id);
 
 #endif

--- a/zone/aa.cpp
+++ b/zone/aa.cpp
@@ -1320,7 +1320,7 @@ void Client::ActivateAlternateAdvancementAbility(int rank_id, int target_id) {
 		timer_duration = 0;
 	}
 
-	if (!IsCastWhileInvis(rank->spell))
+	if (!IsCastWhileInvisibleSpell(rank->spell))
 		CommonBreakInvisible();
 
 	if (spells[rank->spell].sneak && (!hidden || (hidden && (Timer::GetCurrentTime() - tmHidden) < 4000))) {
@@ -1333,7 +1333,7 @@ void Client::ActivateAlternateAdvancementAbility(int rank_id, int target_id) {
 		target_id = GetPetID();
 
 	// extra handling for cast_not_standing spells
-	if (!IgnoreCastingRestriction(rank->spell)) {
+	if (!IsCastNotStandingSpell(rank->spell)) {
 		if (GetAppearance() == eaSitting) // we need to stand!
 			SetAppearance(eaStanding, false);
 

--- a/zone/aggro.cpp
+++ b/zone/aggro.cpp
@@ -1161,7 +1161,7 @@ bool Mob::CheckLosFN(glm::vec3 posWatcher, float sizeWatcher, glm::vec3 posTarge
 //offensive spell aggro
 int32 Mob::CheckAggroAmount(uint16 spell_id, Mob *target, bool isproc)
 {
-	if (NoDetrimentalSpellAggro(spell_id))
+	if (IsNoDetrimentalSpellAggroSpell(spell_id))
 		return 0;
 
 	int32 AggroAmount = 0;

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2958,7 +2958,7 @@ void Mob::AddToHateList(Mob* other, int64 hate /*= 0*/, int64 damage /*= 0*/, bo
 	if (GetSpecialAbility(IMMUNE_AGGRO_CLIENT) && other->IsClient())
 		return;
 
-	if (IsValidSpell(spell_id) && NoDetrimentalSpellAggro(spell_id))
+	if (IsValidSpell(spell_id) && IsNoDetrimentalSpellAggroSpell(spell_id))
 		return;
 
 	if (other == myowner)

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -259,7 +259,7 @@ Bot::Bot(uint32 botID, uint32 botOwnerCharacterID, uint32 botSpellsID, double to
 
 			const SPDat_Spell_Struct& spell = spells[buffs[j1].spellid];
 
-			if (int NimbusEffect = GetNimbusEffect(buffs[j1].spellid); NimbusEffect && !IsNimbusEffectActive(NimbusEffect)) {
+			if (int NimbusEffect = GetSpellNimbusEffect(buffs[j1].spellid); NimbusEffect && !IsNimbusEffectActive(NimbusEffect)) {
 				SendSpellEffect(NimbusEffect, 500, 0, 1, 3000, true);
 			}
 
@@ -4890,7 +4890,7 @@ void Bot::DoSpecialAttackDamage(Mob *who, EQ::skills::SkillType skill, int32 max
 			if (botweapon->ItemType == EQ::item::ItemTypeShield)
 				hate += botweapon->AC;
 
-			hate = (hate * (100 + GetFuriousBash(botweapon->Focus.Effect)) / 100);
+			hate = (hate * (100 + GetSpellFuriousBash(botweapon->Focus.Effect)) / 100);
 		}
 	}
 
@@ -5536,7 +5536,7 @@ int32 Bot::GetActSpellDuration(uint16 spell_id, int32 duration) {
 			increase += 20;
 	}
 
-	if (IsMezSpell(spell_id))
+	if (IsMesmerizeSpell(spell_id))
 		tic_inc += GetAA(aaMesmerizationMastery);
 
 	return (((duration * increase) / 100) + tic_inc);
@@ -6326,7 +6326,7 @@ void Bot::CalcRestState() {
 	for (unsigned int j = 0; j < buff_count; j++) {
 		if (IsValidSpell(buffs[j].spellid)) {
 			if (IsDetrimentalSpell(buffs[j].spellid) && (buffs[j].ticsremaining > 0))
-				if (!DetrimentalSpellAllowsRest(buffs[j].spellid))
+				if (!IsRestAllowedSpell(buffs[j].spellid))
 					return;
 		}
 	}

--- a/zone/botspellsai.cpp
+++ b/zone/botspellsai.cpp
@@ -110,7 +110,7 @@ bool Bot::BotCastSong(Mob* tar, uint8 botLevel) {
 			continue;
 		if (!CheckSpellRecastTimers(this, iter.SpellIndex))
 			continue;
-		if (!IsSpellUsableThisZoneType(iter.SpellId, zone->GetZoneType()))
+		if (!IsSpellUsableInThisZoneType(iter.SpellId, zone->GetZoneType()))
 			continue;
 		switch (spells[iter.SpellId].target_type) {
 		case ST_AEBard:
@@ -144,7 +144,7 @@ bool Bot::BotCastCombatSong(Mob* tar, uint8 botLevel) {
 			continue;
 		if (!CheckSpellRecastTimers(this, iter.SpellIndex))
 			continue;
-		if (!IsSpellUsableThisZoneType(iter.SpellId, zone->GetZoneType()))
+		if (!IsSpellUsableInThisZoneType(iter.SpellId, zone->GetZoneType()))
 			continue;
 		switch (spells[iter.SpellId].target_type) {
 		case ST_AEBard:
@@ -176,7 +176,7 @@ bool Bot::BotCastHateReduction(Mob* tar, uint8 botLevel, const BotSpell& botSpel
 				continue;
 			if (!CheckSpellRecastTimers(this, iter.SpellIndex))
 				continue;
-			if (!IsSpellUsableThisZoneType(iter.SpellId, zone->GetZoneType()))
+			if (!IsSpellUsableInThisZoneType(iter.SpellId, zone->GetZoneType()))
 				continue;
 			if (spells[iter.SpellId].target_type != ST_Target)
 				continue;
@@ -316,7 +316,7 @@ bool Bot::BotCastSlow(Mob* tar, uint8 botLevel, uint8 botClass, BotSpell& botSpe
 						continue;
 					}
 
-					if (!IsSpellUsableThisZoneType(iter.SpellId, zone->GetZoneType())) {
+					if (!IsSpellUsableInThisZoneType(iter.SpellId, zone->GetZoneType())) {
 						continue;
 					}
 
@@ -582,7 +582,7 @@ bool Bot::BotCastCombatBuff(Mob* tar, uint8 botLevel, uint8 botClass) {
 			if (
 				((IsEffectInSpell(s.SpellId, SE_Levitate) && !zone->CanLevitate()) ||
 				(IsEffectInSpell(s.SpellId, SE_MovementSpeed) && !zone->CanCastOutdoor())) &&
-				(botClass != BARD || !IsSpellUsableThisZoneType(s.SpellId, zone->GetZoneType()))
+				(botClass != BARD || !IsSpellUsableInThisZoneType(s.SpellId, zone->GetZoneType()))
 			) {
 				continue;
 			}
@@ -892,7 +892,7 @@ bool Bot::BotCastBuff(Mob* tar, uint8 botLevel, uint8 botClass) {
 					(IsEffectInSpell(s.SpellId, SE_Levitate) && !zone->CanLevitate()) ||
 					(IsEffectInSpell(s.SpellId, SE_MovementSpeed) && !zone->CanCastOutdoor())
 				) &&
-				(botClass != BARD || !IsSpellUsableThisZoneType(s.SpellId, zone->GetZoneType()))
+				(botClass != BARD || !IsSpellUsableInThisZoneType(s.SpellId, zone->GetZoneType()))
 			) {
 				continue;
 			}
@@ -1902,7 +1902,7 @@ std::list<BotSpell> Bot::GetBotSpellsForSpellEffect(Bot* botCaster, int spellEff
 				continue;
 			}
 
-			if (IsEffectInSpell(botSpellList[i].spellid, spellEffect) || GetTriggerSpellID(botSpellList[i].spellid, spellEffect)) {
+			if (IsEffectInSpell(botSpellList[i].spellid, spellEffect) || GetSpellTriggerSpellID(botSpellList[i].spellid, spellEffect)) {
 				BotSpell botSpell;
 				botSpell.SpellId = botSpellList[i].spellid;
 				botSpell.SpellIndex = i;
@@ -1940,7 +1940,7 @@ std::list<BotSpell> Bot::GetBotSpellsForSpellEffectAndTargetType(Bot* botCaster,
 			if (
 				(
 					IsEffectInSpell(botSpellList[i].spellid, spellEffect) ||
-					GetTriggerSpellID(botSpellList[i].spellid, spellEffect)
+					GetSpellTriggerSpellID(botSpellList[i].spellid, spellEffect)
 				) &&
 				spells[botSpellList[i].spellid].target_type == targetType
 			) {
@@ -2313,7 +2313,7 @@ BotSpell Bot::GetBestBotSpellForMez(Bot* botCaster) {
 		for (std::list<BotSpell>::iterator botSpellListItr = botSpellList.begin(); botSpellListItr != botSpellList.end(); ++botSpellListItr) {
 			// Assuming all the spells have been loaded into this list by level and in descending order
 			if (
-				IsMezSpell(botSpellListItr->SpellId) &&
+				IsMesmerizeSpell(botSpellListItr->SpellId) &&
 				CheckSpellRecastTimers(botCaster, botSpellListItr->SpellIndex)
 			) {
 				result.SpellId = botSpellListItr->SpellId;
@@ -2388,7 +2388,7 @@ BotSpell Bot::GetBestBotSpellForDiseaseBasedSlow(Bot* botCaster) {
 Mob* Bot::GetFirstIncomingMobToMez(Bot* botCaster, BotSpell botSpell) {
 	Mob* result = 0;
 
-	if (botCaster && IsMezSpell(botSpell.SpellId)) {
+	if (botCaster && IsMesmerizeSpell(botSpell.SpellId)) {
 
 		std::list<NPC*> npc_list;
 		entity_list.GetNPCList(npc_list);

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -656,7 +656,7 @@ void Client::CompleteConnect()
 
 		const SPDat_Spell_Struct &spell = spells[buffs[j1].spellid];
 
-		int NimbusEffect = GetNimbusEffect(buffs[j1].spellid);
+		int NimbusEffect = GetSpellNimbusEffect(buffs[j1].spellid);
 		if (NimbusEffect) {
 			if (!IsNimbusEffectActive(NimbusEffect))
 				SendSpellEffect(NimbusEffect, 500, 0, 1, 3000, true);
@@ -721,17 +721,17 @@ void Client::CompleteConnect()
 			case SE_AddMeleeProc:
 			case SE_WeaponProc:
 			{
-				AddProcToWeapon(GetProcID(buffs[j1].spellid, x1), false, 100 + spells[buffs[j1].spellid].limit_value[x1], buffs[j1].spellid, buffs[j1].casterlevel, GetProcLimitTimer(buffs[j1].spellid, ProcType::MELEE_PROC));
+				AddProcToWeapon(GetProcID(buffs[j1].spellid, x1), false, 100 + spells[buffs[j1].spellid].limit_value[x1], buffs[j1].spellid, buffs[j1].casterlevel, GetSpellProcLimitTimer(buffs[j1].spellid, ProcType::MELEE_PROC));
 				break;
 			}
 			case SE_DefensiveProc:
 			{
-				AddDefensiveProc(GetProcID(buffs[j1].spellid, x1), 100 + spells[buffs[j1].spellid].limit_value[x1], buffs[j1].spellid, GetProcLimitTimer(buffs[j1].spellid, ProcType::DEFENSIVE_PROC));
+				AddDefensiveProc(GetProcID(buffs[j1].spellid, x1), 100 + spells[buffs[j1].spellid].limit_value[x1], buffs[j1].spellid, GetSpellProcLimitTimer(buffs[j1].spellid, ProcType::DEFENSIVE_PROC));
 				break;
 			}
 			case SE_RangedProc:
 			{
-				AddRangedProc(GetProcID(buffs[j1].spellid, x1), 100 + spells[buffs[j1].spellid].limit_value[x1], buffs[j1].spellid, GetProcLimitTimer(buffs[j1].spellid, ProcType::RANGED_PROC));
+				AddRangedProc(GetProcID(buffs[j1].spellid, x1), 100 + spells[buffs[j1].spellid].limit_value[x1], buffs[j1].spellid, GetSpellProcLimitTimer(buffs[j1].spellid, ProcType::RANGED_PROC));
 				break;
 			}
 			}
@@ -9232,7 +9232,7 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 						return;
 					}
 					if (i == 0) {
-						if (!IsCastWhileInvis(item->Click.Effect)) {
+						if (!IsCastWhileInvisibleSpell(item->Click.Effect)) {
 							CommonBreakInvisible(); // client can't do this for us :(
 						}
 						if (GetClass() == BARD){
@@ -9304,7 +9304,7 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 					}
 
 					if (i == 0) {
-						if (!IsCastWhileInvis(augitem->Click.Effect)) {
+						if (!IsCastWhileInvisibleSpell(augitem->Click.Effect)) {
 							CommonBreakInvisible(); // client can't do this for us :(
 						}
 						if (GetClass() == BARD) {

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -1035,7 +1035,7 @@ void Client::OPRezzAnswer(uint32 Action, uint32 SpellID, uint16 ZoneID, uint16 I
 			BuffFadeNonPersistDeath();
 		}
 
-		int SpellEffectDescNum = GetSpellEffectDescNum(SpellID);
+		int SpellEffectDescNum = GetSpellEffectDescriptionNumber(SpellID);
 		// Rez spells with Rez effects have this DescNum (first is Titanium, second is 6.2 Client)
 		if(RuleB(Character, UseResurrectionSickness) && SpellEffectDescNum == 82 || SpellEffectDescNum == 39067) {
 			SetHP(GetMaxHP() / 5);
@@ -1968,7 +1968,7 @@ void Client::CalcRestState()
 	for (unsigned int j = 0; j < buff_count; j++) {
 		if(IsValidSpell(buffs[j].spellid)) {
 			if(IsDetrimentalSpell(buffs[j].spellid) && (buffs[j].ticsremaining > 0))
-				if(!DetrimentalSpellAllowsRest(buffs[j].spellid))
+				if(!IsRestAllowedSpell(buffs[j].spellid))
 					return;
 		}
 	}

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -810,9 +810,9 @@ void Client::SendDisciplineUpdate() {
 
 bool Client::UseDiscipline(uint32 spell_id, uint32 target) {
 	// Dont let client waste a reuse timer if they can't use the disc
-	if ((IsStunned() && !IgnoreCastingRestriction(spell_id))||
+	if ((IsStunned() && !IsCastNotStandingSpell(spell_id))||
 		IsFeared() ||
-		(IsMezzed() && !IgnoreCastingRestriction(spell_id)) ||
+		(IsMezzed() && !IsCastNotStandingSpell(spell_id)) ||
 		IsAmnesiad() ||
 		IsPet())
 	{
@@ -837,7 +837,7 @@ bool Client::UseDiscipline(uint32 spell_id, uint32 target) {
 		return false;
 	}
 
-	if (DivineAura() && !IgnoreCastingRestriction(spell_id)) {
+	if (DivineAura() && !IsCastNotStandingSpell(spell_id)) {
 		return false;
 	}
 

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -528,10 +528,10 @@ std::string Perl__getspellname(uint32 spell_id)
 	return quest_manager.getspellname(spell_id);
 }
 
-int Perl__get_spell_level(uint32_t spell_id, int class_id)
+uint8 Perl__get_spell_level(uint16 spell_id, uint8 class_id)
 {
-	int spell_level = IsValidSpell(spell_id) ? GetSpellLevel(spell_id, class_id) : 0;
-	return (spell_level > RuleI(Character, MaxLevel)) ? 0 : spell_level;
+	const auto spell_level = GetSpellLevel(spell_id, class_id);
+	return spell_level > RuleI(Character, MaxLevel) ? UINT8_MAX : spell_level;
 }
 
 std::string Perl__getskillname(int skill_id)
@@ -1695,14 +1695,489 @@ bool Perl__IsRunning()
 	return quest_manager.IsRunning();
 }
 
-bool Perl__IsEffectInSpell(uint32 spell_id, uint32 effect_id)
+bool Perl__IsEffectInSpell(uint16 spell_id, int effect_id)
 {
 	return IsEffectInSpell(spell_id, effect_id);
 }
 
 bool Perl__IsBeneficialSpell(uint16 spell_id)
 {
-	return BeneficialSpell(spell_id);
+	return IsBeneficialSpell(spell_id);
+}
+
+bool Perl__IsDetrimentalSpell(uint16 spell_id)
+{
+	return IsDetrimentalSpell(spell_id);
+}
+
+bool Perl__IsTargetableAESpell(uint16 spell_id)
+{
+	return IsTargetableAESpell(spell_id);
+}
+
+bool Perl__IsSacrificeSpell(uint16 spell_id)
+{
+	return IsSacrificeSpell(spell_id);
+}
+
+bool Perl__IsLifetapSpell(uint16 spell_id)
+{
+	return IsLifetapSpell(spell_id);
+}
+
+bool Perl__IsMesmerizeSpell(uint16 spell_id)
+{
+	return IsMesmerizeSpell(spell_id);
+}
+
+bool Perl__IsStunSpell(uint16 spell_id)
+{
+	return IsStunSpell(spell_id);
+}
+
+bool Perl__IsSummonSpell(uint16 spell_id)
+{
+	return IsSummonSpell(spell_id);
+}
+
+bool Perl__IsDamageSpell(uint16 spell_id)
+{
+	return IsDamageSpell(spell_id);
+}
+
+bool Perl__IsFearSpell(uint16 spell_id)
+{
+	return IsFearSpell(spell_id);
+}
+
+bool Perl__IsCureSpell(uint16 spell_id)
+{
+	return IsCureSpell(spell_id);
+}
+
+bool Perl__IsHasteSpell(uint16 spell_id)
+{
+	return IsHasteSpell(spell_id);
+}
+
+bool Perl__IsHarmonySpell(uint16 spell_id)
+{
+	return IsHarmonySpell(spell_id);
+}
+
+bool Perl__IsPercentalHealSpell(uint16 spell_id)
+{
+	return IsPercentalHealSpell(spell_id);
+}
+
+bool Perl__IsGroupOnlySpell(uint16 spell_id)
+{
+	return IsGroupOnlySpell(spell_id);
+}
+
+bool Perl__IsInvisibleSpell(uint16 spell_id)
+{
+	return IsInvisibleSpell(spell_id);
+}
+
+bool Perl__IsInvulnerabilitySpell(uint16 spell_id)
+{
+	return IsInvulnerabilitySpell(spell_id);
+}
+
+bool Perl__IsCompleteHealDurationSpell(uint16 spell_id)
+{
+	return IsCompleteHealDurationSpell(spell_id);
+}
+
+bool Perl__IsPoisonCounterSpell(uint16 spell_id)
+{
+	return IsPoisonCounterSpell(spell_id);
+}
+
+bool Perl__IsDiseaseCounterSpell(uint16 spell_id)
+{
+	return IsDiseaseCounterSpell(spell_id);
+}
+
+bool Perl__IsSummonItemSpell(uint16 spell_id)
+{
+	return IsSummonItemSpell(spell_id);
+}
+
+bool Perl__IsSummonSkeletonSpell(uint16 spell_id)
+{
+	return IsSummonSkeletonSpell(spell_id);
+}
+
+bool Perl__IsSummonPetSpell(uint16 spell_id)
+{
+	return IsSummonPetSpell(spell_id);
+}
+
+bool Perl__IsPetSpell(uint16 spell_id)
+{
+	return IsPetSpell(spell_id);
+}
+
+bool Perl__IsSummonPCSpell(uint16 spell_id)
+{
+	return IsSummonPCSpell(spell_id);
+}
+
+bool Perl__IsCharmSpell(uint16 spell_id)
+{
+	return IsCharmSpell(spell_id);
+}
+
+bool Perl__IsBlindSpell(uint16 spell_id)
+{
+	return IsBlindSpell(spell_id);
+}
+
+bool Perl__IsHealthSpell(uint16 spell_id)
+{
+	return IsHealthSpell(spell_id);
+}
+
+bool Perl__IsCastTimeReductionSpell(uint16 spell_id)
+{
+	return IsCastTimeReductionSpell(spell_id);
+}
+
+bool Perl__IsIncreaseDurationSpell(uint16 spell_id)
+{
+	return IsIncreaseDurationSpell(spell_id);
+}
+
+bool Perl__IsManaCostReductionSpell(uint16 spell_id)
+{
+	return IsManaCostReductionSpell(spell_id);
+}
+
+bool Perl__IsIncreaseRangeSpell(uint16 spell_id)
+{
+	return IsIncreaseRangeSpell(spell_id);
+}
+
+bool Perl__IsImprovedHealingSpell(uint16 spell_id)
+{
+	return IsImprovedHealingSpell(spell_id);
+}
+
+bool Perl__IsImprovedDamageSpell(uint16 spell_id)
+{
+	return IsImprovedDamageSpell(spell_id);
+}
+
+bool Perl__IsAEDurationSpell(uint16 spell_id)
+{
+	return IsAEDurationSpell(spell_id);
+}
+
+bool Perl__IsPureNukeSpell(uint16 spell_id)
+{
+	return IsPureNukeSpell(spell_id);
+}
+
+bool Perl__IsAENukeSpell(uint16 spell_id)
+{
+	return IsAENukeSpell(spell_id);
+}
+
+bool Perl__IsPBAENukeSpell(uint16 spell_id)
+{
+	return IsPBAENukeSpell(spell_id);
+}
+
+bool Perl__IsAERainNukeSpell(uint16 spell_id)
+{
+	return IsAERainNukeSpell(spell_id);
+}
+
+bool Perl__IsPartialResistableSpell(uint16 spell_id)
+{
+	return IsPartialResistableSpell(spell_id);
+}
+
+bool Perl__IsResistableSpell(uint16 spell_id)
+{
+	return IsResistableSpell(spell_id);
+}
+
+bool Perl__IsGroupSpell(uint16 spell_id)
+{
+	return IsGroupSpell(spell_id);
+}
+
+bool Perl__IsTGBCompatibleSpell(uint16 spell_id)
+{
+	return IsTGBCompatibleSpell(spell_id);
+}
+
+bool Perl__IsBardSong(uint16 spell_id)
+{
+	return IsBardSong(spell_id);
+}
+
+bool Perl__IsPulsingBardSong(uint16 spell_id)
+{
+	return IsPulsingBardSong(spell_id);
+}
+
+bool Perl__IsDisciplineBuff(uint16 spell_id)
+{
+	return IsDisciplineBuff(spell_id);
+}
+
+bool Perl__IsDiscipline(uint16 spell_id)
+{
+	return IsDiscipline(spell_id);
+}
+
+bool Perl__IsCombatSkill(uint16 spell_id)
+{
+	return IsCombatSkill(spell_id);
+}
+
+bool Perl__IsResurrectionEffects(uint16 spell_id)
+{
+	return IsResurrectionEffects(spell_id);
+}
+
+bool Perl__IsRuneSpell(uint16 spell_id)
+{
+	return IsRuneSpell(spell_id);
+}
+
+bool Perl__IsMagicRuneSpell(uint16 spell_id)
+{
+	return IsMagicRuneSpell(spell_id);
+}
+
+bool Perl__IsManaTapSpell(uint16 spell_id)
+{
+	return IsManaTapSpell(spell_id);
+}
+
+bool Perl__IsAllianceSpell(uint16 spell_id)
+{
+	return IsAllianceSpell(spell_id);
+}
+
+bool Perl__IsDeathSaveSpell(uint16 spell_id)
+{
+	return IsDeathSaveSpell(spell_id);
+}
+
+bool Perl__IsPartialDeathSaveSpell(uint16 spell_id)
+{
+	return IsPartialDeathSaveSpell(spell_id);
+}
+
+bool Perl__IsFullDeathSaveSpell(uint16 spell_id)
+{
+	return IsFullDeathSaveSpell(spell_id);
+}
+
+bool Perl__IsShadowStepSpell(uint16 spell_id)
+{
+	return IsShadowStepSpell(spell_id);
+}
+
+bool Perl__IsSuccorSpell(uint16 spell_id)
+{
+	return IsSuccorSpell(spell_id);
+}
+
+bool Perl__IsTeleportSpell(uint16 spell_id)
+{
+	return IsTeleportSpell(spell_id);
+}
+
+bool Perl__IsTranslocateSpell(uint16 spell_id)
+{
+	return IsTranslocateSpell(spell_id);
+}
+
+bool Perl__IsGateSpell(uint16 spell_id)
+{
+	return IsGateSpell(spell_id);
+}
+
+bool Perl__IsIllusionSpell(uint16 spell_id)
+{
+	return IsIllusionSpell(spell_id);
+}
+
+bool Perl__IsLDoNObjectSpell(uint16 spell_id)
+{
+	return IsLDoNObjectSpell(spell_id);
+}
+
+bool Perl__IsHealOverTimeSpell(uint16 spell_id)
+{
+	return IsHealOverTimeSpell(spell_id);
+}
+
+bool Perl__IsCompleteHealSpell(uint16 spell_id)
+{
+	return IsCompleteHealSpell(spell_id);
+}
+
+bool Perl__IsFastHealSpell(uint16 spell_id)
+{
+	return IsFastHealSpell(spell_id);
+}
+
+bool Perl__IsVeryFastHealSpell(uint16 spell_id)
+{
+	return IsVeryFastHealSpell(spell_id);
+}
+
+bool Perl__IsRegularSingleTargetHealSpell(uint16 spell_id)
+{
+	return IsRegularSingleTargetHealSpell(spell_id);
+}
+
+bool Perl__IsRegularGroupHealSpell(uint16 spell_id)
+{
+	return IsRegularGroupHealSpell(spell_id);
+}
+
+bool Perl__IsGroupCompleteHealSpell(uint16 spell_id)
+{
+	return IsGroupCompleteHealSpell(spell_id);
+}
+
+bool Perl__IsGroupHealOverTimeSpell(uint16 spell_id)
+{
+	return IsGroupHealOverTimeSpell(spell_id);
+}
+
+bool Perl__IsDebuffSpell(uint16 spell_id)
+{
+	return IsDebuffSpell(spell_id);
+}
+
+bool Perl__IsResistDebuffSpell(uint16 spell_id)
+{
+	return IsResistDebuffSpell(spell_id);
+}
+
+bool Perl__IsSelfConversionSpell(uint16 spell_id)
+{
+	return IsSelfConversionSpell(spell_id);
+}
+
+bool Perl__IsBuffSpell(uint16 spell_id)
+{
+	return IsBuffSpell(spell_id);
+}
+
+bool Perl__IsPersistDeathSpell(uint16 spell_id)
+{
+	return IsPersistDeathSpell(spell_id);
+}
+
+bool Perl__IsSuspendableSpell(uint16 spell_id)
+{
+	return IsSuspendableSpell(spell_id);
+}
+
+bool Perl__IsCastOnFadeDurationSpell(uint16 spell_id)
+{
+	return IsCastOnFadeDurationSpell(spell_id);
+}
+
+bool Perl__IsDistanceModifierSpell(uint16 spell_id)
+{
+	return IsDistanceModifierSpell(spell_id);
+}
+
+bool Perl__IsRestAllowedSpell(uint16 spell_id)
+{
+	return IsRestAllowedSpell(spell_id);
+}
+
+bool Perl__IsNoDetrimentalSpellAggroSpell(uint16 spell_id)
+{
+	return IsNoDetrimentalSpellAggroSpell(spell_id);
+}
+
+bool Perl__IsStackableDOT(uint16 spell_id)
+{
+	return IsStackableDOT(spell_id);
+}
+
+bool Perl__IsShortDurationBuff(uint16 spell_id)
+{
+	return IsShortDurationBuff(spell_id);
+}
+
+bool Perl__IsTargetRequiredForSpell(uint16 spell_id)
+{
+	return IsTargetRequiredForSpell(spell_id);
+}
+
+bool Perl__IsVirusSpell(uint16 spell_id)
+{
+	return IsVirusSpell(spell_id);
+}
+
+bool Perl__IsValidSpell(uint16 spell_id)
+{
+	return IsValidSpell(spell_id);
+}
+
+bool Perl__IsEffectIgnoredInStacking(int effect_id)
+{
+	return IsEffectIgnoredInStacking(effect_id);
+}
+
+bool Perl__IsFocusLimit(int effect_id)
+{
+	return IsFocusLimit(effect_id);
+}
+
+bool Perl__IsBardOnlyStackEffect(int effect_id)
+{
+	return IsBardOnlyStackEffect(effect_id);
+}
+
+bool Perl__IsCastWhileInvisibleSpell(uint16 spell_id)
+{
+	return IsCastWhileInvisibleSpell(spell_id);
+}
+
+bool Perl__IsCastRestrictedSpell(uint16 spell_id)
+{
+	return IsCastRestrictedSpell(spell_id);
+}
+
+bool Perl__IsCastNotStandingSpell(uint16 spell_id)
+{
+	return IsCastNotStandingSpell(spell_id);
+}
+
+bool Perl__IsInstrumentModifierAppliedToSpellEffect(uint16 spell_id, int effect_id)
+{
+	return IsInstrumentModifierAppliedToSpellEffect(spell_id, effect_id);
+}
+
+bool Perl__IsBlankSpellEffect(uint16 spell_id, int effect_index)
+{
+	return IsBlankSpellEffect(spell_id, effect_index);
+}
+
+uint16 Perl__GetSpellTriggerSpellID(uint16 spell_id, int effect_id)
+{
+	return GetSpellTriggerSpellID(spell_id, effect_id);
+}
+
+uint8 Perl__GetSpellMinimumLevel(uint16 spell_id)
+{
+	return GetSpellMinimumLevel(spell_id);
 }
 
 int Perl__GetSpellResistType(uint16 spell_id)
@@ -1713,6 +2188,106 @@ int Perl__GetSpellResistType(uint16 spell_id)
 int Perl__GetSpellTargetType(uint16 spell_id)
 {
 	return GetSpellTargetType(spell_id);
+}
+
+int Perl__GetSpellPartialMeleeRuneReduction(uint16 spell_id)
+{
+	return GetSpellPartialMeleeRuneReduction(spell_id);
+}
+
+int Perl__GetSpellPartialMagicRuneReduction(uint16 spell_id)
+{
+	return GetSpellPartialMagicRuneReduction(spell_id);
+}
+
+int Perl__GetSpellPartialMeleeRuneAmount(uint16 spell_id)
+{
+	return GetSpellPartialMeleeRuneAmount(spell_id);
+}
+
+int Perl__GetSpellPartialMagicRuneAmount(uint16 spell_id)
+{
+	return GetSpellPartialMagicRuneAmount(spell_id);
+}
+
+int Perl__GetSpellViralMinimumSpreadTime(uint16 spell_id)
+{
+	return GetSpellViralMinimumSpreadTime(spell_id);
+}
+
+int Perl__GetSpellViralMaximumSpreadTime(uint16 spell_id)
+{
+	return GetSpellViralMaximumSpreadTime(spell_id);
+}
+
+int Perl__GetSpellViralSpreadRange(uint16 spell_id)
+{
+	return GetSpellViralSpreadRange(spell_id);
+}
+
+int Perl__GetSpellProcLimitTimer(uint16 spell_id, int proc_type)
+{
+	return GetSpellProcLimitTimer(spell_id, proc_type);
+}
+
+int Perl__GetSpellEffectDescriptionNumber(uint16 spell_id)
+{
+	return GetSpellEffectDescriptionNumber(spell_id);
+}
+
+int Perl__GetSpellFuriousBash(uint16 spell_id)
+{
+	return GetSpellFuriousBash(spell_id);
+}
+
+bool Perl__IsSpellUsableInThisZoneType(uint16 spell_id)
+{
+	return IsSpellUsableInThisZoneType(spell_id, zone->GetZoneType());
+}
+
+bool Perl__IsSpellUsableInThisZoneType(uint16 spell_id, uint8 zone_type)
+{
+	return IsSpellUsableInThisZoneType(spell_id, zone_type);
+}
+
+int Perl__GetSpellEffectIndex(uint16 spell_id, int effect_id)
+{
+	return GetSpellEffectIndex(spell_id, effect_id);
+}
+
+int Perl__CalculatePoisonCounters(uint16 spell_id)
+{
+	return CalculatePoisonCounters(spell_id);
+}
+
+int Perl__CalculateDiseaseCounters(uint16 spell_id)
+{
+	return CalculateDiseaseCounters(spell_id);
+}
+
+int Perl__CalculateCurseCounters(uint16 spell_id)
+{
+	return CalculateCurseCounters(spell_id);
+}
+
+int Perl__CalculateCorruptionCounters(uint16 spell_id)
+{
+	return CalculateCorruptionCounters(spell_id);
+}
+
+int Perl__CalculateCounters(uint16 spell_id)
+{
+	return CalculateCounters(spell_id);
+}
+
+int8 Perl__GetSpellResurrectionSicknessCheck(uint16 spell_id_one, uint16 spell_id_two)
+{
+	return GetSpellResurrectionSicknessCheck(spell_id_one, spell_id_two);
+}
+
+int Perl__GetSpellNimbusEffect(uint16 spell_id)
+{
+	return GetSpellNimbusEffect(spell_id);
 }
 
 void Perl__FlyMode(GravityBehavior flymode)
@@ -4762,7 +5337,11 @@ void perl_register_quest()
 	package.add("createbotcount", (int(*)())&Perl__createbotcount);
 	package.add("createbotcount", (int(*)(uint8))&Perl__createbotcount);
 	package.add("createBot", &Perl__createBot);
-
+	package.add("CalculateCorruptionCounters", &Perl__CalculateCorruptionCounters);
+	package.add("CalculateCounters", &Perl__CalculateCounters);
+	package.add("CalculateCurseCounters", &Perl__CalculateCurseCounters);
+	package.add("CalculateDiseaseCounters", &Perl__CalculateDiseaseCounters);
+	package.add("CalculatePoisonCounters", &Perl__CalculatePoisonCounters);
 	package.add("AssignGroupToInstance", &Perl__AssignGroupToInstance);
 	package.add("AssignRaidToInstance", &Perl__AssignRaidToInstance);
 	package.add("AssignToInstance", &Perl__AssignToInstance);
@@ -4783,8 +5362,23 @@ void perl_register_quest()
 	package.add("GetInstanceIDsByCharID", &Perl__GetInstanceIDsByCharID);
 	package.add("GetInstanceVersionByID", &Perl__GetInstanceVersionByID);
 	package.add("GetInstanceZoneIDByID", &Perl__GetInstanceZoneIDByID);
+	package.add("GetSpellPartialMagicRuneReduction", &Perl__GetSpellPartialMagicRuneReduction);
+	package.add("GetSpellPartialMagicRuneAmount", &Perl__GetSpellPartialMagicRuneAmount);
+	package.add("GetSpellPartialMeleeRuneReduction", &Perl__GetSpellPartialMeleeRuneReduction);
+	package.add("GetSpellPartialMeleeRuneAmount", &Perl__GetSpellPartialMeleeRuneAmount);
+	package.add("GetSpellProcLimitTimer", &Perl__GetSpellProcLimitTimer);
+	package.add("GetSpellResurrectionSicknessCheck", &Perl__GetSpellResurrectionSicknessCheck);
+	package.add("GetSpellEffectDescriptionNumber", &Perl__GetSpellEffectDescriptionNumber);
+	package.add("GetSpellEffectIndex", &Perl__GetSpellEffectIndex);
+	package.add("GetSpellFuriousBash", &Perl__GetSpellFuriousBash);
+	package.add("GetSpellMinimumLevel", &Perl__GetSpellMinimumLevel);
+	package.add("GetSpellNimbusEffect", &Perl__GetSpellNimbusEffect);
 	package.add("GetSpellResistType", &Perl__GetSpellResistType);
 	package.add("GetSpellTargetType", &Perl__GetSpellTargetType);
+	package.add("GetSpellTriggerSpellID", &Perl__GetSpellTriggerSpellID);
+	package.add("GetSpellViralMaximumSpreadTime", &Perl__GetSpellViralMaximumSpreadTime);
+	package.add("GetSpellViralMinimumSpreadTime", &Perl__GetSpellViralMinimumSpreadTime);
+	package.add("GetSpellViralSpreadRange", &Perl__GetSpellViralSpreadRange);
 	package.add("GetTimeSeconds", &Perl__GetTimeSeconds);
 	package.add("GetZoneBypassExpansionCheck", (int8(*)(uint32))&Perl__GetZoneBypassExpansionCheck);
 	package.add("GetZoneBypassExpansionCheck", (int8(*)(uint32, int))&Perl__GetZoneBypassExpansionCheck);
@@ -4913,19 +5507,105 @@ void perl_register_quest()
 	package.add("GetZoneUnderworldTeleportIndex", (int(*)(uint32, int))&Perl__GetZoneUnderworldTeleportIndex);
 	package.add("GetZoneWalkSpeed", (float(*)(uint32))&Perl__GetZoneWalkSpeed);
 	package.add("GetZoneWalkSpeed", (float(*)(uint32, int))&Perl__GetZoneWalkSpeed);
-	package.add("set_rule", &Perl__set_rule);
-	package.add("get_rule", &Perl__get_rule);
-	package.add("get_data", &Perl__get_data);
-	package.add("get_data_expires", &Perl__get_data_expires);
-	package.add("get_data_remaining", &Perl__get_data_remaining);
-	package.add("set_data", (void(*)(std::string, std::string))&Perl__set_data);
-	package.add("set_data", (void(*)(std::string, std::string, std::string))&Perl__set_data);
-	package.add("delete_data", &Perl__delete_data);
+	package.add("IsAEDurationSpell", &Perl__IsAEDurationSpell);
+	package.add("IsAENukeSpell", &Perl__IsAENukeSpell);
+	package.add("IsAERainNukeSpell", &Perl__IsAERainNukeSpell);
+	package.add("IsAllianceSpell", &Perl__IsAllianceSpell);
+	package.add("IsBardOnlyStackEffect", &Perl__IsBardOnlyStackEffect);
+	package.add("IsBardSong", &Perl__IsBardSong);
 	package.add("IsBeneficialSpell", &Perl__IsBeneficialSpell);
+	package.add("IsBlankSpellEffect", &Perl__IsBlankSpellEffect);
+	package.add("IsBlindSpell", &Perl__IsBlindSpell);
+	package.add("IsBuffSpell", &Perl__IsBuffSpell);
+	package.add("IsCastOnFadeDurationSpell", &Perl__IsCastOnFadeDurationSpell);
+	package.add("IsCastNotStandingSpell", &Perl__IsCastNotStandingSpell);
+	package.add("IsCastRestrictedSpell", &Perl__IsCastRestrictedSpell);
+	package.add("IsCastTimeReductionSpell", &Perl__IsCastTimeReductionSpell);
+	package.add("IsCastWhileInvisibleSpell", &Perl__IsCastWhileInvisibleSpell);
+	package.add("IsCharmSpell", &Perl__IsCharmSpell);
+	package.add("IsCombatSkill", &Perl__IsCombatSkill);
+	package.add("IsCompleteHealSpell", &Perl__IsCompleteHealSpell);
+	package.add("IsCompleteHealDurationSpell", &Perl__IsCompleteHealDurationSpell);
+	package.add("IsCureSpell", &Perl__IsCureSpell);
+	package.add("IsDamageSpell", &Perl__IsDamageSpell);
+	package.add("IsDeathSaveSpell", &Perl__IsDeathSaveSpell);
+	package.add("IsDebuffSpell", &Perl__IsDebuffSpell);
+	package.add("IsDetrimentalSpell", &Perl__IsDetrimentalSpell);
+	package.add("IsDiscipline", &Perl__IsDiscipline);
+	package.add("IsDisciplineBuff", &Perl__IsDisciplineBuff);
+	package.add("IsDiseaseCounterSpell", &Perl__IsDiseaseCounterSpell);
+	package.add("IsDistanceModifierSpell", &Perl__IsDistanceModifierSpell);
+	package.add("IsEffectIgnoredInStacking", &Perl__IsEffectIgnoredInStacking);
 	package.add("IsEffectInSpell", &Perl__IsEffectInSpell);
+	package.add("IsFastHealSpell", &Perl__IsFastHealSpell);
+	package.add("IsFearSpell", &Perl__IsFearSpell);
+	package.add("IsFocusLimit", &Perl__IsFocusLimit);
+	package.add("IsFullDeathSaveSpell", &Perl__IsFullDeathSaveSpell);
+	package.add("IsGateSpell", &Perl__IsGateSpell);
+	package.add("IsGroupCompleteHealSpell", &Perl__IsGroupCompleteHealSpell);
+	package.add("IsGroupHealOverTimeSpell", &Perl__IsGroupHealOverTimeSpell);
+	package.add("IsGroupOnlySpell", &Perl__IsGroupOnlySpell);
+	package.add("IsGroupSpell", &Perl__IsGroupSpell);
+	package.add("IsHarmonySpell", &Perl__IsHarmonySpell);
+	package.add("IsHasteSpell", &Perl__IsHasteSpell);
+	package.add("IsHealOverTimeSpell", &Perl__IsHealOverTimeSpell);
+	package.add("IsHealthSpell", &Perl__IsHealthSpell);
+	package.add("IsIllusionSpell", &Perl__IsIllusionSpell);
+	package.add("IsImprovedDamageSpell", &Perl__IsImprovedDamageSpell);
+	package.add("IsImprovedHealingSpell", &Perl__IsImprovedHealingSpell);
+	package.add("IsIncreaseDurationSpell", &Perl__IsIncreaseDurationSpell);
+	package.add("IsIncreaseRangeSpell", &Perl__IsIncreaseRangeSpell);
+	package.add("IsInstrumentModifierAppliedToSpellEffect", &Perl__IsInstrumentModifierAppliedToSpellEffect);
+	package.add("IsInvisibleSpell", &Perl__IsInvisibleSpell);
+	package.add("IsInvulnerabilitySpell", &Perl__IsInvulnerabilitySpell);
+	package.add("IsLDoNObjectSpell", &Perl__IsLDoNObjectSpell);
+	package.add("IsLifetapSpell", &Perl__IsLifetapSpell);
+	package.add("IsMagicRuneSpell", &Perl__IsMagicRuneSpell);
+	package.add("IsManaCostReductionSpell", &Perl__IsManaCostReductionSpell);
+	package.add("IsManaTapSpell", &Perl__IsManaTapSpell);
+	package.add("IsMesmerizeSpell", &Perl__IsMesmerizeSpell);
+	package.add("IsNoDetrimentalSpellAggroSpell", &Perl__IsNoDetrimentalSpellAggroSpell);
+	package.add("IsPartialDeathSaveSpell", &Perl__IsPartialDeathSaveSpell);
+	package.add("IsPartialResistableSpell", &Perl__IsPartialResistableSpell);
+	package.add("IsPBAENukeSpell", &Perl__IsPBAENukeSpell);
+	package.add("IsPercentalHealSpell", &Perl__IsPercentalHealSpell);
+	package.add("IsPersistDeathSpell", &Perl__IsPersistDeathSpell);
+	package.add("IsPetSpell", &Perl__IsPetSpell);
+	package.add("IsPoisonCounterSpell", &Perl__IsPoisonCounterSpell);
+	package.add("IsPulsingBardSong", &Perl__IsPulsingBardSong);
+	package.add("IsPureNukeSpell", &Perl__IsPureNukeSpell);
 	package.add("IsRaining", &Perl__IsRaining);
-	package.add("IsSnowing", &Perl__IsSnowing);
+	package.add("IsRegularGroupHealSpell", &Perl__IsRegularGroupHealSpell);
+	package.add("IsRegularSingleTargetHealSpell", &Perl__IsRegularSingleTargetHealSpell);
+	package.add("IsResistableSpell", &Perl__IsResistableSpell);
+	package.add("IsResistDebuffSpell", &Perl__IsResistDebuffSpell);
+	package.add("IsRestAllowedSpell", &Perl__IsRestAllowedSpell);
+	package.add("IsResurrectionEffects", &Perl__IsResurrectionEffects);
+	package.add("IsRuneSpell", &Perl__IsRuneSpell);
 	package.add("IsRunning", &Perl__IsRunning);
+	package.add("IsSacrificeSpell", &Perl__IsSacrificeSpell);
+	package.add("IsSelfConversionSpell", &Perl__IsSelfConversionSpell);
+	package.add("IsShadowStepSpell", &Perl__IsShadowStepSpell);
+	package.add("IsShortDurationBuff", &Perl__IsShortDurationBuff);
+	package.add("IsSnowing", &Perl__IsSnowing);
+	package.add("IsSpellUsableInThisZoneType", (bool(*)(uint16))&Perl__IsSpellUsableInThisZoneType);
+	package.add("IsSpellUsableInThisZoneType", (bool(*)(uint16, uint8))&Perl__IsSpellUsableInThisZoneType);
+	package.add("IsStackableDOT", &Perl__IsStackableDOT);
+	package.add("IsStunSpell", &Perl__IsStunSpell);
+	package.add("IsSuccorSpell", &Perl__IsSuccorSpell);
+	package.add("IsSummonItemSpell", &Perl__IsSummonItemSpell);
+	package.add("IsSummonPCSpell", &Perl__IsSummonPCSpell);
+	package.add("IsSummonPetSpell", &Perl__IsSummonPetSpell);
+	package.add("IsSummonSkeletonSpell", &Perl__IsSummonSkeletonSpell);
+	package.add("IsSummonSpell", &Perl__IsSummonSpell);
+	package.add("IsSuspendableSpell", &Perl__IsSuspendableSpell);
+	package.add("IsTargetableAESpell", &Perl__IsTargetableAESpell);
+	package.add("IsTargetRequiredForSpell", &Perl__IsTargetRequiredForSpell);
+	package.add("IsTeleportSpell", &Perl__IsTeleportSpell);
+	package.add("IsTranslocateSpell", &Perl__IsTranslocateSpell);
+	package.add("IsVeryFastHealSpell", &Perl__IsVeryFastHealSpell);
+	package.add("IsVirusSpell", &Perl__IsVirusSpell);
+	package.add("IsValidSpell", &Perl__IsValidSpell);
 	package.add("LearnRecipe", &Perl__LearnRecipe);
 	package.add("MerchantCountItem", &Perl__MerchantCountItem);
 	package.add("MerchantSetItem", (void(*)(uint32, uint32))&Perl__MerchantSetItem);
@@ -5199,6 +5879,7 @@ void perl_register_quest()
 	package.add("worldwideupdateactivity", (void(*)(uint32, int, int, uint8, uint8))&Perl__worldwideupdateactivity);
 	package.add("debug", (void(*)(const char*))&Perl__debug);
 	package.add("debug", (void(*)(const char*, int))&Perl__debug);
+	package.add("delete_data", &Perl__delete_data);
 	package.add("delglobal", &Perl__delglobal);
 	package.add("depop", (void(*)())&Perl__depop);
 	package.add("depop", (void(*)(int))&Perl__depop);
@@ -5253,6 +5934,9 @@ void perl_register_quest()
 	package.add("getconsiderlevelname", &Perl__getconsiderlevelname);
 	package.add("gethexcolorcode", &Perl__gethexcolorcode);
 	package.add("getcurrencyid", &Perl__getcurrencyid);
+	package.add("get_data", &Perl__get_data);
+	package.add("get_data_expires", &Perl__get_data_expires);
+	package.add("get_data_remaining", &Perl__get_data_remaining);
 	package.add("get_dz_task_id", &Perl__get_dz_task_id);
 	package.add("getexpmodifierbycharid", (double(*)(uint32, uint32))&Perl__getexpmodifierbycharid);
 	package.add("getexpmodifierbycharid", (double(*)(uint32, uint32, int16))&Perl__getexpmodifierbycharid);
@@ -5270,6 +5954,7 @@ void perl_register_quest()
 	package.add("getlanguagename", &Perl__getlanguagename);
 	package.add("getldonthemename", &Perl__getldonthemename);
 	package.add("getnpcnamebyid", &Perl__getnpcnamebyid);
+	package.add("get_rule", &Perl__get_rule);
 	package.add("get_spawn_condition", (int(*)(const char*, uint16))&Perl__get_spawn_condition);
 	package.add("get_spawn_condition", (int(*)(const char*, uint32, uint16))&Perl__get_spawn_condition);
 	package.add("getcharnamebyid", &Perl__getcharnamebyid);
@@ -5424,12 +6109,15 @@ void perl_register_quest()
 	package.add("send_channel_message", (void(*)(Client*, const char*, uint8, uint32, uint8, uint8, const char*))&Perl__send_channel_message);
 	package.add("setaaexpmodifierbycharid", (void(*)(uint32, uint32, double))&Perl__setaaexpmodifierbycharid);
 	package.add("setaaexpmodifierbycharid", (void(*)(uint32, uint32, double, int16))&Perl__setaaexpmodifierbycharid);
+	package.add("set_data", (void(*)(std::string, std::string))&Perl__set_data);
+	package.add("set_data", (void(*)(std::string, std::string, std::string))&Perl__set_data);
 	package.add("set_proximity", (void(*)(float, float, float, float))&Perl__set_proximity);
 	package.add("set_proximity", (void(*)(float, float, float, float, float, float))&Perl__set_proximity);
 	package.add("set_proximity", (void(*)(float, float, float, float, float, float, bool))&Perl__set_proximity);
 	package.add("set_proximity_range", (void(*)(float, float))&Perl__set_proximity_range);
 	package.add("set_proximity_range", (void(*)(float, float, float))&Perl__set_proximity_range);
 	package.add("set_proximity_range", (void(*)(float, float, float, bool))&Perl__set_proximity_range);
+	package.add("set_rule", &Perl__set_rule);
 	package.add("set_zone_flag", &Perl__set_zone_flag);
 	package.add("setallskill", &Perl__setallskill);
 	package.add("setanim", &Perl__setanim);

--- a/zone/gm_commands/castspell.cpp
+++ b/zone/gm_commands/castspell.cpp
@@ -21,7 +21,7 @@ void command_castspell(Client *c, const Seperator *sep)
 	else {
 		uint16 spell_id = Strings::ToUnsignedInt(sep->arg[1]);
 
-		if (CastRestrictedSpell(spell_id) && c->Admin() < commandCastSpecials) {
+		if (IsCastRestrictedSpell(spell_id) && c->Admin() < commandCastSpecials) {
 			c->Message(Chat::Red, "Unable to cast spell.");
 		}
 		else if (spell_id >= SPDAT_RECORDS) {

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -4416,6 +4416,607 @@ void lua_send_channel_message(Lua_Client from, const char* to, uint8 channel_num
 	quest_manager.SendChannelMessage(from, to, channel_number, guild_id, language_id, language_skill, message);
 }
 
+uint8 lua_get_spell_level(uint16 spell_id, uint8 class_id)
+{
+	const auto spell_level = GetSpellLevel(spell_id, class_id);
+	return spell_level > RuleI(Character, MaxLevel) ? UINT8_MAX : spell_level;
+}
+
+bool lua_is_effect_in_spell(uint16 spell_id, int effect_id)
+{
+	return IsEffectInSpell(spell_id, effect_id);
+}
+
+bool lua_is_beneficial_spell(uint16 spell_id)
+{
+	return IsBeneficialSpell(spell_id);
+}
+
+bool lua_is_detrimental_spell(uint16 spell_id)
+{
+	return IsDetrimentalSpell(spell_id);
+}
+
+bool lua_is_targetable_ae_spell(uint16 spell_id)
+{
+	return IsTargetableAESpell(spell_id);
+}
+
+bool lua_is_sacrifice_spell(uint16 spell_id)
+{
+	return IsSacrificeSpell(spell_id);
+}
+
+bool lua_is_lifetap_spell(uint16 spell_id)
+{
+	return IsLifetapSpell(spell_id);
+}
+
+bool lua_is_mesmerize_spell(uint16 spell_id)
+{
+	return IsMesmerizeSpell(spell_id);
+}
+
+bool lua_is_stun_spell(uint16 spell_id)
+{
+	return IsStunSpell(spell_id);
+}
+
+bool lua_is_summon_spell(uint16 spell_id)
+{
+	return IsSummonSpell(spell_id);
+}
+
+bool lua_is_damage_spell(uint16 spell_id)
+{
+	return IsDamageSpell(spell_id);
+}
+
+bool lua_is_fear_spell(uint16 spell_id)
+{
+	return IsFearSpell(spell_id);
+}
+
+bool lua_is_cure_spell(uint16 spell_id)
+{
+	return IsCureSpell(spell_id);
+}
+
+bool lua_is_haste_spell(uint16 spell_id)
+{
+	return IsHasteSpell(spell_id);
+}
+
+bool lua_is_harmony_spell(uint16 spell_id)
+{
+	return IsHarmonySpell(spell_id);
+}
+
+bool lua_is_percental_heal_spell(uint16 spell_id)
+{
+	return IsPercentalHealSpell(spell_id);
+}
+
+bool lua_is_group_only_spell(uint16 spell_id)
+{
+	return IsGroupOnlySpell(spell_id);
+}
+
+bool lua_is_invisible_spell(uint16 spell_id)
+{
+	return IsInvisibleSpell(spell_id);
+}
+
+bool lua_is_invulnerability_spell(uint16 spell_id)
+{
+	return IsInvulnerabilitySpell(spell_id);
+}
+
+bool lua_is_complete_heal_duration_spell(uint16 spell_id)
+{
+	return IsCompleteHealDurationSpell(spell_id);
+}
+
+bool lua_is_poison_counter_spell(uint16 spell_id)
+{
+	return IsPoisonCounterSpell(spell_id);
+}
+
+bool lua_is_disease_counter_spell(uint16 spell_id)
+{
+	return IsDiseaseCounterSpell(spell_id);
+}
+
+bool lua_is_summon_item_spell(uint16 spell_id)
+{
+	return IsSummonItemSpell(spell_id);
+}
+
+bool lua_is_summon_skeleton_spell(uint16 spell_id)
+{
+	return IsSummonSkeletonSpell(spell_id);
+}
+
+bool lua_is_summon_pet_spell(uint16 spell_id)
+{
+	return IsSummonPetSpell(spell_id);
+}
+
+bool lua_is_pet_spell(uint16 spell_id)
+{
+	return IsPetSpell(spell_id);
+}
+
+bool lua_is_summon_pc_spell(uint16 spell_id)
+{
+	return IsSummonPCSpell(spell_id);
+}
+
+bool lua_is_charm_spell(uint16 spell_id)
+{
+	return IsCharmSpell(spell_id);
+}
+
+bool lua_is_blind_spell(uint16 spell_id)
+{
+	return IsBlindSpell(spell_id);
+}
+
+bool lua_is_health_spell(uint16 spell_id)
+{
+	return IsHealthSpell(spell_id);
+}
+
+bool lua_is_cast_time_reduction_spell(uint16 spell_id)
+{
+	return IsCastTimeReductionSpell(spell_id);
+}
+
+bool lua_is_increase_duration_spell(uint16 spell_id)
+{
+	return IsIncreaseDurationSpell(spell_id);
+}
+
+bool lua_is_mana_cost_reduction_spell(uint16 spell_id)
+{
+	return IsManaCostReductionSpell(spell_id);
+}
+
+bool lua_is_increase_range_spell(uint16 spell_id)
+{
+	return IsIncreaseRangeSpell(spell_id);
+}
+
+bool lua_is_improved_healing_spell(uint16 spell_id)
+{
+	return IsImprovedHealingSpell(spell_id);
+}
+
+bool lua_is_improved_damage_spell(uint16 spell_id)
+{
+	return IsImprovedDamageSpell(spell_id);
+}
+
+bool lua_is_ae_duration_spell(uint16 spell_id)
+{
+	return IsAEDurationSpell(spell_id);
+}
+
+bool lua_is_pure_nuke_spell(uint16 spell_id)
+{
+	return IsPureNukeSpell(spell_id);
+}
+
+bool lua_is_ae_nuke_spell(uint16 spell_id)
+{
+	return IsAENukeSpell(spell_id);
+}
+
+bool lua_is_pbae_nuke_spell(uint16 spell_id)
+{
+	return IsPBAENukeSpell(spell_id);
+}
+
+bool lua_is_ae_rain_nuke_spell(uint16 spell_id)
+{
+	return IsAERainNukeSpell(spell_id);
+}
+
+bool lua_is_partial_resistable_spell(uint16 spell_id)
+{
+	return IsPartialResistableSpell(spell_id);
+}
+
+bool lua_is_resistable_spell(uint16 spell_id)
+{
+	return IsResistableSpell(spell_id);
+}
+
+bool lua_is_group_spell(uint16 spell_id)
+{
+	return IsGroupSpell(spell_id);
+}
+
+bool lua_is_tgb_compatible_spell(uint16 spell_id)
+{
+	return IsTGBCompatibleSpell(spell_id);
+}
+
+bool lua_is_bard_song(uint16 spell_id)
+{
+	return IsBardSong(spell_id);
+}
+
+bool lua_is_pulsing_bard_song(uint16 spell_id)
+{
+	return IsPulsingBardSong(spell_id);
+}
+
+bool lua_is_discipline_buff(uint16 spell_id)
+{
+	return IsDisciplineBuff(spell_id);
+}
+
+bool lua_is_discipline(uint16 spell_id)
+{
+	return IsDiscipline(spell_id);
+}
+
+bool lua_is_combat_skill(uint16 spell_id)
+{
+	return IsCombatSkill(spell_id);
+}
+
+bool lua_is_resurrection_effects(uint16 spell_id)
+{
+	return IsResurrectionEffects(spell_id);
+}
+
+bool lua_is_rune_spell(uint16 spell_id)
+{
+	return IsRuneSpell(spell_id);
+}
+
+bool lua_is_magic_rune_spell(uint16 spell_id)
+{
+	return IsMagicRuneSpell(spell_id);
+}
+
+bool lua_is_mana_tap_spell(uint16 spell_id)
+{
+	return IsManaTapSpell(spell_id);
+}
+
+bool lua_is_alliance_spell(uint16 spell_id)
+{
+	return IsAllianceSpell(spell_id);
+}
+
+bool lua_is_death_save_spell(uint16 spell_id)
+{
+	return IsDeathSaveSpell(spell_id);
+}
+
+bool lua_is_partial_death_save_spell(uint16 spell_id)
+{
+	return IsPartialDeathSaveSpell(spell_id);
+}
+
+bool lua_is_full_death_save_spell(uint16 spell_id)
+{
+	return IsFullDeathSaveSpell(spell_id);
+}
+
+bool lua_is_shadow_step_spell(uint16 spell_id)
+{
+	return IsShadowStepSpell(spell_id);
+}
+
+bool lua_is_succor_spell(uint16 spell_id)
+{
+	return IsSuccorSpell(spell_id);
+}
+
+bool lua_is_teleport_spell(uint16 spell_id)
+{
+	return IsTeleportSpell(spell_id);
+}
+
+bool lua_is_translocate_spell(uint16 spell_id)
+{
+	return IsTranslocateSpell(spell_id);
+}
+
+bool lua_is_gate_spell(uint16 spell_id)
+{
+	return IsGateSpell(spell_id);
+}
+
+bool lua_is_illusion_spell(uint16 spell_id)
+{
+	return IsIllusionSpell(spell_id);
+}
+
+bool lua_is_ldon_object_spell(uint16 spell_id)
+{
+	return IsLDoNObjectSpell(spell_id);
+}
+
+bool lua_is_heal_over_time_spell(uint16 spell_id)
+{
+	return IsHealOverTimeSpell(spell_id);
+}
+
+bool lua_is_complete_heal_spell(uint16 spell_id)
+{
+	return IsCompleteHealSpell(spell_id);
+}
+
+bool lua_is_fast_heal_spell(uint16 spell_id)
+{
+	return IsFastHealSpell(spell_id);
+}
+
+bool lua_is_very_fast_heal_spell(uint16 spell_id)
+{
+	return IsVeryFastHealSpell(spell_id);
+}
+
+bool lua_is_regular_single_target_heal_spell(uint16 spell_id)
+{
+	return IsRegularSingleTargetHealSpell(spell_id);
+}
+
+bool lua_is_regular_group_heal_spell(uint16 spell_id)
+{
+	return IsRegularGroupHealSpell(spell_id);
+}
+
+bool lua_is_group_complete_heal_spell(uint16 spell_id)
+{
+	return IsGroupCompleteHealSpell(spell_id);
+}
+
+bool lua_is_group_heal_over_time_spell(uint16 spell_id)
+{
+	return IsGroupHealOverTimeSpell(spell_id);
+}
+
+bool lua_is_debuff_spell(uint16 spell_id)
+{
+	return IsDebuffSpell(spell_id);
+}
+
+bool lua_is_resist_debuff_spell(uint16 spell_id)
+{
+	return IsResistDebuffSpell(spell_id);
+}
+
+bool lua_is_self_conversion_spell(uint16 spell_id)
+{
+	return IsSelfConversionSpell(spell_id);
+}
+
+bool lua_is_buff_spell(uint16 spell_id)
+{
+	return IsBuffSpell(spell_id);
+}
+
+bool lua_is_persist_death_spell(uint16 spell_id)
+{
+	return IsPersistDeathSpell(spell_id);
+}
+
+bool lua_is_suspendable_spell(uint16 spell_id)
+{
+	return IsSuspendableSpell(spell_id);
+}
+
+bool lua_is_cast_on_fade_duration_spell(uint16 spell_id)
+{
+	return IsCastOnFadeDurationSpell(spell_id);
+}
+
+bool lua_is_distance_modifier_spell(uint16 spell_id)
+{
+	return IsDistanceModifierSpell(spell_id);
+}
+
+bool lua_is_rest_allowed_spell(uint16 spell_id)
+{
+	return IsRestAllowedSpell(spell_id);
+}
+
+bool lua_is_no_detrimental_spell_aggro_spell(uint16 spell_id)
+{
+	return IsNoDetrimentalSpellAggroSpell(spell_id);
+}
+
+bool lua_is_stackable_dot(uint16 spell_id)
+{
+	return IsStackableDOT(spell_id);
+}
+
+bool lua_is_short_duration_buff(uint16 spell_id)
+{
+	return IsShortDurationBuff(spell_id);
+}
+
+bool lua_is_target_required_for_spell(uint16 spell_id)
+{
+	return IsTargetRequiredForSpell(spell_id);
+}
+
+bool lua_is_virus_spell(uint16 spell_id)
+{
+	return IsVirusSpell(spell_id);
+}
+
+bool lua_is_valid_spell(uint16 spell_id)
+{
+	return IsValidSpell(spell_id);
+}
+
+bool lua_is_effect_ignored_in_stacking(int effect_id)
+{
+	return IsEffectIgnoredInStacking(effect_id);
+}
+
+bool lua_is_focus_limit(int effect_id)
+{
+	return IsFocusLimit(effect_id);
+}
+
+bool lua_is_bard_only_stack_effect(int effect_id)
+{
+	return IsBardOnlyStackEffect(effect_id);
+}
+
+bool lua_is_cast_while_invisible_spell(uint16 spell_id)
+{
+	return IsCastWhileInvisibleSpell(spell_id);
+}
+
+bool lua_is_cast_restricted_spell(uint16 spell_id)
+{
+	return IsCastRestrictedSpell(spell_id);
+}
+
+bool lua_is_cast_not_standing_spell(uint16 spell_id)
+{
+	return IsCastNotStandingSpell(spell_id);
+}
+
+bool lua_is_instrument_modifier_applied_to_spell_effect(uint16 spell_id, int effect_id)
+{
+	return IsInstrumentModifierAppliedToSpellEffect(spell_id, effect_id);
+}
+
+bool lua_is_blank_spell_effect(uint16 spell_id, int effect_index)
+{
+	return IsBlankSpellEffect(spell_id, effect_index);
+}
+
+uint16 lua_get_spell_trigger_spell_id(uint16 spell_id, int effect_id)
+{
+	return GetSpellTriggerSpellID(spell_id, effect_id);
+}
+
+uint8 lua_get_spell_minimum_level(uint16 spell_id)
+{
+	return GetSpellMinimumLevel(spell_id);
+}
+
+int lua_get_spell_resist_type(uint16 spell_id)
+{
+	return GetSpellResistType(spell_id);
+}
+
+int lua_get_spell_target_type(uint16 spell_id)
+{
+	return GetSpellTargetType(spell_id);
+}
+
+int lua_get_spell_partial_melee_rune_reduction(uint16 spell_id)
+{
+	return GetSpellPartialMeleeRuneReduction(spell_id);
+}
+
+int lua_get_spell_partial_magic_rune_reduction(uint16 spell_id)
+{
+	return GetSpellPartialMagicRuneReduction(spell_id);
+}
+
+int lua_get_spell_partial_melee_rune_amount(uint16 spell_id)
+{
+	return GetSpellPartialMeleeRuneAmount(spell_id);
+}
+
+int lua_get_spell_partial_magic_rune_amount(uint16 spell_id)
+{
+	return GetSpellPartialMagicRuneAmount(spell_id);
+}
+
+int lua_get_spell_viral_minimum_spread_time(uint16 spell_id)
+{
+	return GetSpellViralMinimumSpreadTime(spell_id);
+}
+
+int lua_get_spell_viral_maximum_spread_time(uint16 spell_id)
+{
+	return GetSpellViralMaximumSpreadTime(spell_id);
+}
+
+int lua_get_spell_viral_spread_range(uint16 spell_id)
+{
+	return GetSpellViralSpreadRange(spell_id);
+}
+
+int lua_get_spell_proc_limit_timer(uint16 spell_id, int proc_type)
+{
+	return GetSpellProcLimitTimer(spell_id, proc_type);
+}
+
+int lua_get_spell_effect_description_number(uint16 spell_id)
+{
+	return GetSpellEffectDescriptionNumber(spell_id);
+}
+
+int lua_get_spell_furious_bash(uint16 spell_id)
+{
+	return GetSpellFuriousBash(spell_id);
+}
+
+bool lua_is_spell_usable_in_this_zone_type(uint16 spell_id)
+{
+	return IsSpellUsableInThisZoneType(spell_id, zone->GetZoneType());
+}
+
+bool lua_is_spell_usable_in_this_zone_type(uint16 spell_id, uint8 zone_type)
+{
+	return IsSpellUsableInThisZoneType(spell_id, zone_type);
+}
+
+int lua_get_spell_effect_index(uint16 spell_id, int effect_id)
+{
+	return GetSpellEffectIndex(spell_id, effect_id);
+}
+
+int lua_calculate_poison_counters(uint16 spell_id)
+{
+	return CalculatePoisonCounters(spell_id);
+}
+
+int lua_calculate_disease_counters(uint16 spell_id)
+{
+	return CalculateDiseaseCounters(spell_id);
+}
+
+int lua_calculate_curse_counters(uint16 spell_id)
+{
+	return CalculateCurseCounters(spell_id);
+}
+
+int lua_calculate_corruption_counters(uint16 spell_id)
+{
+	return CalculateCorruptionCounters(spell_id);
+}
+
+int lua_calculate_counters(uint16 spell_id)
+{
+	return CalculateCounters(spell_id);
+}
+
+int8 lua_get_spell_resurrection_sickness_check(uint16 spell_id_one, uint16 spell_id_two)
+{
+	return GetSpellResurrectionSicknessCheck(spell_id_one, spell_id_two);
+}
+
+int lua_get_spell_nimbus_effect(uint16 spell_id)
+{
+	return GetSpellNimbusEffect(spell_id);
+}
+
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
 	cur = table[#name]; \
 	if(luabind::type(cur) != LUA_TNIL) { \
@@ -5069,6 +5670,126 @@ luabind::scope lua_register_general() {
 		luabind::def("send_channel_message", (void(*)(uint8,uint32,uint8,uint8,const char*))&lua_send_channel_message),
 		luabind::def("send_channel_message", (void(*)(Lua_Client,uint8,uint32,uint8,uint8,const char*))&lua_send_channel_message),
 		luabind::def("send_channel_message", (void(*)(Lua_Client,const char*,uint8,uint32,uint8,uint8,const char*))&lua_send_channel_message),
+		luabind::def("get_spell_level", &lua_get_spell_level),
+		luabind::def("is_effect_in_spell", &lua_is_effect_in_spell),
+		luabind::def("is_beneficial_spell", &lua_is_beneficial_spell),
+		luabind::def("is_detrimental_spell", &lua_is_detrimental_spell),
+		luabind::def("is_targetable_ae_spell", &lua_is_targetable_ae_spell),
+		luabind::def("is_sacrifice_spell", &lua_is_sacrifice_spell),
+		luabind::def("is_lifetap_spell", &lua_is_lifetap_spell),
+		luabind::def("is_mesmerize_spell", &lua_is_mesmerize_spell),
+		luabind::def("is_stun_spell", &lua_is_stun_spell),
+		luabind::def("is_summon_spell", &lua_is_summon_spell),
+		luabind::def("is_damage_spell", &lua_is_damage_spell),
+		luabind::def("is_fear_spell", &lua_is_fear_spell),
+		luabind::def("is_cure_spell", &lua_is_cure_spell),
+		luabind::def("is_haste_spell", &lua_is_haste_spell),
+		luabind::def("is_harmony_spell", &lua_is_harmony_spell),
+		luabind::def("is_percental_heal_spell", &lua_is_percental_heal_spell),
+		luabind::def("is_group_only_spell", &lua_is_group_only_spell),
+		luabind::def("is_invisible_spell", &lua_is_invisible_spell),
+		luabind::def("is_invulnerability_spell", &lua_is_invulnerability_spell),
+		luabind::def("is_complete_heal_duration_spell", &lua_is_complete_heal_duration_spell),
+		luabind::def("is_poison_counter_spell", &lua_is_poison_counter_spell),
+		luabind::def("is_disease_counter_spell", &lua_is_disease_counter_spell),
+		luabind::def("is_summon_item_spell", &lua_is_summon_item_spell),
+		luabind::def("is_summon_skeleton_spell", &lua_is_summon_skeleton_spell),
+		luabind::def("is_summon_pet_spell", &lua_is_summon_pet_spell),
+		luabind::def("is_pet_spell", &lua_is_pet_spell),
+		luabind::def("is_summon_pc_spell", &lua_is_summon_pc_spell),
+		luabind::def("is_charm_spell", &lua_is_charm_spell),
+		luabind::def("is_blind_spell", &lua_is_blind_spell),
+		luabind::def("is_health_spell", &lua_is_health_spell),
+		luabind::def("is_cast_time_reduction_spell", &lua_is_cast_time_reduction_spell),
+		luabind::def("is_increase_duration_spell", &lua_is_increase_duration_spell),
+		luabind::def("is_mana_cost_reduction_spell", &lua_is_mana_cost_reduction_spell),
+		luabind::def("is_increase_range_spell", &lua_is_increase_range_spell),
+		luabind::def("is_improved_healing_spell", &lua_is_improved_healing_spell),
+		luabind::def("is_improved_damage_spell", &lua_is_improved_damage_spell),
+		luabind::def("is_ae_duration_spell", &lua_is_ae_duration_spell),
+		luabind::def("is_pure_nuke_spell", &lua_is_pure_nuke_spell),
+		luabind::def("is_ae_nuke_spell", &lua_is_ae_nuke_spell),
+		luabind::def("is_pbae_nuke_spell", &lua_is_pbae_nuke_spell),
+		luabind::def("is_ae_rain_nuke_spell", &lua_is_ae_rain_nuke_spell),
+		luabind::def("is_partial_resistable_spell", &lua_is_partial_resistable_spell),
+		luabind::def("is_resistable_spell", &lua_is_resistable_spell),
+		luabind::def("is_group_spell", &lua_is_group_spell),
+		luabind::def("is_tgb_compatible_spell", &lua_is_tgb_compatible_spell),
+		luabind::def("is_bard_song", &lua_is_bard_song),
+		luabind::def("is_pulsing_bard_song", &lua_is_pulsing_bard_song),
+		luabind::def("is_discipline_buff", &lua_is_discipline_buff),
+		luabind::def("is_discipline", &lua_is_discipline),
+		luabind::def("is_combat_skill", &lua_is_combat_skill),
+		luabind::def("is_resurrection_effects", &lua_is_resurrection_effects),
+		luabind::def("is_rune_spell", &lua_is_rune_spell),
+		luabind::def("is_magic_rune_spell", &lua_is_magic_rune_spell),
+		luabind::def("is_mana_tap_spell", &lua_is_mana_tap_spell),
+		luabind::def("is_alliance_spell", &lua_is_alliance_spell),
+		luabind::def("is_death_save_spell", &lua_is_death_save_spell),
+		luabind::def("is_partial_death_save_spell", &lua_is_partial_death_save_spell),
+		luabind::def("is_full_death_save_spell", &lua_is_full_death_save_spell),
+		luabind::def("is_shadow_step_spell", &lua_is_shadow_step_spell),
+		luabind::def("is_succor_spell", &lua_is_succor_spell),
+		luabind::def("is_teleport_spell", &lua_is_teleport_spell),
+		luabind::def("is_translocate_spell", &lua_is_translocate_spell),
+		luabind::def("is_gate_spell", &lua_is_gate_spell),
+		luabind::def("is_illusion_spell", &lua_is_illusion_spell),
+		luabind::def("is_ldon_object_spell", &lua_is_ldon_object_spell),
+		luabind::def("is_heal_over_time_spell", &lua_is_heal_over_time_spell),
+		luabind::def("is_complete_heal_spell", &lua_is_complete_heal_spell),
+		luabind::def("is_fast_heal_spell", &lua_is_fast_heal_spell),
+		luabind::def("is_very_fast_heal_spell", &lua_is_very_fast_heal_spell),
+		luabind::def("is_regular_single_target_heal_spell", &lua_is_regular_single_target_heal_spell),
+		luabind::def("is_regular_group_heal_spell", &lua_is_regular_group_heal_spell),
+		luabind::def("is_group_complete_heal_spell", &lua_is_group_complete_heal_spell),
+		luabind::def("is_group_heal_over_time_spell", &lua_is_group_heal_over_time_spell),
+		luabind::def("is_debuff_spell", &lua_is_debuff_spell),
+		luabind::def("is_resist_debuff_spell", &lua_is_resist_debuff_spell),
+		luabind::def("is_self_conversion_spell", &lua_is_self_conversion_spell),
+		luabind::def("is_buff_spell", &lua_is_buff_spell),
+		luabind::def("is_persist_death_spell", &lua_is_persist_death_spell),
+		luabind::def("is_suspendable_spell", &lua_is_suspendable_spell),
+		luabind::def("is_cast_on_fade_duration_spell", &lua_is_cast_on_fade_duration_spell),
+		luabind::def("is_distance_modifier_spell", &lua_is_distance_modifier_spell),
+		luabind::def("is_rest_allowed_spell", &lua_is_rest_allowed_spell),
+		luabind::def("is_no_detrimental_spell_aggro_spell", &lua_is_no_detrimental_spell_aggro_spell),
+		luabind::def("is_stackable_dot", &lua_is_stackable_dot),
+		luabind::def("is_short_duration_buff", &lua_is_short_duration_buff),
+		luabind::def("is_target_required_for_spell", &lua_is_target_required_for_spell),
+		luabind::def("is_virus_spell", &lua_is_virus_spell),
+		luabind::def("is_valid_spell", &lua_is_valid_spell),
+		luabind::def("is_effect_ignored_in_stacking", &lua_is_effect_ignored_in_stacking),
+		luabind::def("is_focus_limit", &lua_is_focus_limit),
+		luabind::def("is_bard_only_stack_effect", &lua_is_bard_only_stack_effect),
+		luabind::def("is_cast_while_invisible_spell", &lua_is_cast_while_invisible_spell),
+		luabind::def("is_cast_restricted_spell", &lua_is_cast_restricted_spell),
+		luabind::def("is_cast_not_standing_spell", &lua_is_cast_not_standing_spell),
+		luabind::def("is_instrument_modifier_applied_to_spell_effect", &lua_is_instrument_modifier_applied_to_spell_effect),
+		luabind::def("is_blank_spell_effect", &lua_is_blank_spell_effect),
+		luabind::def("get_spell_trigger_spell_id", &lua_get_spell_trigger_spell_id),
+		luabind::def("get_spell_minimum_level", &lua_get_spell_minimum_level),
+		luabind::def("get_spell_resist_type", &lua_get_spell_resist_type),
+		luabind::def("get_spell_target_type", &lua_get_spell_target_type),
+		luabind::def("get_spell_partial_melee_rune_reduction", &lua_get_spell_partial_melee_rune_reduction),
+		luabind::def("get_spell_partial_magic_rune_reduction", &lua_get_spell_partial_magic_rune_reduction),
+		luabind::def("get_spell_partial_melee_rune_amount", &lua_get_spell_partial_melee_rune_amount),
+		luabind::def("get_spell_partial_magic_rune_amount", &lua_get_spell_partial_magic_rune_amount),
+		luabind::def("get_spell_viral_minimum_spread_time", &lua_get_spell_viral_minimum_spread_time),
+		luabind::def("get_spell_viral_maximum_spread_time", &lua_get_spell_viral_maximum_spread_time),
+		luabind::def("get_spell_viral_spread_range", &lua_get_spell_viral_spread_range),
+		luabind::def("get_spell_proc_limit_timer", &lua_get_spell_proc_limit_timer),
+		luabind::def("get_spell_effect_description_number", &lua_get_spell_effect_description_number),
+		luabind::def("get_spell_furious_bash", &lua_get_spell_furious_bash),
+		luabind::def("is_spell_usable_in_this_zone_type", (bool(*)(uint16))&lua_is_spell_usable_in_this_zone_type),
+		luabind::def("is_spell_usable_in_this_zone_type", (bool(*)(uint16,uint8))&lua_is_spell_usable_in_this_zone_type),
+		luabind::def("get_spell_effect_index", &lua_get_spell_effect_index),
+		luabind::def("calculate_poison_counters", &lua_calculate_poison_counters),
+		luabind::def("calculate_disease_counters", &lua_calculate_disease_counters),
+		luabind::def("calculate_curse_counters", &lua_calculate_curse_counters),
+		luabind::def("calculate_corruption_counters", &lua_calculate_corruption_counters),
+		luabind::def("calculate_counters", &lua_calculate_counters),
+		luabind::def("get_spell_resurrection_sickness_check", &lua_get_spell_resurrection_sickness_check),
+		luabind::def("get_spell_nimbus_effect", &lua_get_spell_nimbus_effect),
 		/*
 			Cross Zone
 		*/

--- a/zone/merc.cpp
+++ b/zone/merc.cpp
@@ -770,7 +770,7 @@ void Merc::CalcRestState() {
 	for (unsigned int j = 0; j < buff_count; j++) {
 		if(IsValidSpell(buffs[j].spellid)) {
 			if(IsDetrimentalSpell(buffs[j].spellid) && (buffs[j].ticsremaining > 0))
-				if(!DetrimentalSpellAllowsRest(buffs[j].spellid))
+				if(!IsRestAllowedSpell(buffs[j].spellid))
 					return;
 		}
 	}
@@ -4299,7 +4299,7 @@ Merc* Merc::LoadMerc(Client *c, MercTemplate* merc_template, uint32 merchant_id,
 	if(merc_template)
 	{
 		//TODO: Maybe add a way of updating client merc stats in a seperate function? like, for example, on leveling up.
-		
+
 		const NPCType* npc_type_to_copy = nullptr;
 		if (c) {
 			npc_type_to_copy = content_db.GetMercType(merc_template->MercNPCID, merc_template->RaceID, c->GetLevel());

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -4391,7 +4391,7 @@ int Mob::CountDispellableBuffs()
 		if(buffs[x].counters)
 			continue;
 
-		if(spells[buffs[x].spellid].good_effect == 0)
+		if(spells[buffs[x].spellid].good_effect == DETRIMENTAL_EFFECT)
 			continue;
 
 		if(IsValidSpell(buffs[x].spellid) && spells[buffs[x].spellid].buff_duration_formula != DF_Permanent) {

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -653,7 +653,7 @@ void Client::AI_SpellCast()
 		slot_to_use = static_cast<EQ::spells::CastingSlot>(slots[idx]);
 	}
 
-	if(IsMezSpell(spell_to_cast) || IsFearSpell(spell_to_cast))
+	if(IsMesmerizeSpell(spell_to_cast) || IsFearSpell(spell_to_cast))
 	{
 		Mob *tar = entity_list.GetTargetForMez(this);
 		if(!tar)

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -1194,7 +1194,7 @@ bool NPC::DatabaseCastAccepted(int spell_id) {
 			break;
 		}
 		default:
-			if(spells[spell_id].good_effect == 1 && !(spells[spell_id].buff_duration == 0 && GetHPRatio() == 100) && !IsEngaged())
+			if(spells[spell_id].good_effect == BENEFICIAL_EFFECT && !(spells[spell_id].buff_duration == 0 && GetHPRatio() == 100) && !IsEngaged())
 				return true;
 			return false;
 		}

--- a/zone/pets.cpp
+++ b/zone/pets.cpp
@@ -538,13 +538,13 @@ void NPC::SetPetState(SpellBuff_Struct *pet_buffs, uint32 *items) {
 					case SE_WeaponProc:
 						// We need to reapply buff based procs
 						// We need to do this here so suspended pets also regain their procs.
-						AddProcToWeapon(GetProcID(buffs[j1].spellid,x1), false, 100+spells[buffs[j1].spellid].limit_value[x1], buffs[j1].spellid, buffs[j1].casterlevel, GetProcLimitTimer(buffs[j1].spellid, ProcType::MELEE_PROC));
+						AddProcToWeapon(GetProcID(buffs[j1].spellid,x1), false, 100+spells[buffs[j1].spellid].limit_value[x1], buffs[j1].spellid, buffs[j1].casterlevel, GetSpellProcLimitTimer(buffs[j1].spellid, ProcType::MELEE_PROC));
 						break;
 					case SE_DefensiveProc:
-						AddDefensiveProc(GetProcID(buffs[j1].spellid, x1), 100 + spells[buffs[j1].spellid].limit_value[x1], buffs[j1].spellid, GetProcLimitTimer(buffs[j1].spellid, ProcType::DEFENSIVE_PROC));
+						AddDefensiveProc(GetProcID(buffs[j1].spellid, x1), 100 + spells[buffs[j1].spellid].limit_value[x1], buffs[j1].spellid, GetSpellProcLimitTimer(buffs[j1].spellid, ProcType::DEFENSIVE_PROC));
 						break;
 					case SE_RangedProc:
-						AddRangedProc(GetProcID(buffs[j1].spellid, x1), 100 + spells[buffs[j1].spellid].limit_value[x1], buffs[j1].spellid, GetProcLimitTimer(buffs[j1].spellid, ProcType::RANGED_PROC));
+						AddRangedProc(GetProcID(buffs[j1].spellid, x1), 100 + spells[buffs[j1].spellid].limit_value[x1], buffs[j1].spellid, GetSpellProcLimitTimer(buffs[j1].spellid, ProcType::RANGED_PROC));
 						break;
 					case SE_Charm:
 					case SE_Rune:

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -241,7 +241,7 @@ void Mob::DoSpecialAttackDamage(Mob *who, EQ::skills::SkillType skill, int32 bas
 					hate += item->GetItem()->AC;
 				}
 				const EQ::ItemData *itm = item->GetItem();
-				auto fbash = GetFuriousBash(itm->Focus.Effect);
+				auto fbash = GetSpellFuriousBash(itm->Focus.Effect);
 				hate = hate * (100 + fbash) / 100;
 				if (fbash)
 					MessageString(Chat::FocusEffect, GLOWS_RED, itm->Name);
@@ -2347,7 +2347,7 @@ void Mob::DoMeleeSkillAttackDmg(Mob *other, int32 weapon_damage, EQ::skills::Ski
 					hate += item->GetItem()->AC;
 				}
 				const EQ::ItemData *itm = item->GetItem();
-				hate = hate * (100 + GetFuriousBash(itm->Focus.Effect)) / 100;
+				hate = hate * (100 + GetSpellFuriousBash(itm->Focus.Effect)) / 100;
 			}
 		}
 

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -1331,7 +1331,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				snprintf(effect_desc, _EDLEN, "Blind: %+i", effect_value);
 #endif
 				// 'cure blind'
-				if (IsDistanceModifierSpell(spell_id) && spells[spell_id].buff_duration == 0) {
+				if (IsBeneficialSpell(spell_id) && spells[spell_id].buff_duration == 0) {
 					int buff_count = GetMaxBuffSlots();
 					for (int slot = 0; slot < buff_count; slot++) {
 						if (IsValidSpell(buffs[slot].spellid) && IsEffectInSpell(buffs[slot].spellid, SE_Blind)) {

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -212,11 +212,11 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 			viral_timer.Start(1000);
 		}
 
-		buffs[buffslot].virus_spread_time = zone->random.Int(GetViralMinSpreadTime(spell_id), GetViralMaxSpreadTime(spell_id));
+		buffs[buffslot].virus_spread_time = zone->random.Int(GetSpellViralMinimumSpreadTime(spell_id), GetSpellViralMaximumSpreadTime(spell_id));
 	}
 
 
-	if (!IsPowerDistModSpell(spell_id))
+	if (!IsDistanceModifierSpell(spell_id))
 		SetSpellPowerDistanceMod(0);
 
 	bool spell_trigger_cast_complete = false; //Used with SE_Spell_Trigger and SE_Chance_Best_in_Spell_Grp, true when spell has been triggered.
@@ -1331,7 +1331,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				snprintf(effect_desc, _EDLEN, "Blind: %+i", effect_value);
 #endif
 				// 'cure blind'
-				if (BeneficialSpell(spell_id) && spells[spell_id].buff_duration == 0) {
+				if (IsDistanceModifierSpell(spell_id) && spells[spell_id].buff_duration == 0) {
 					int buff_count = GetMaxBuffSlots();
 					for (int slot = 0; slot < buff_count; slot++) {
 						if (IsValidSpell(buffs[slot].spellid) && IsEffectInSpell(buffs[slot].spellid, SE_Blind)) {
@@ -1873,7 +1873,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Weapon Proc: %s (id %d)", spells[effect_value].name, procid);
 #endif
-				AddProcToWeapon(procid, false, 100 + spells[spell_id].limit_value[i], spell_id, caster_level, GetProcLimitTimer(spell_id, ProcType::MELEE_PROC));
+				AddProcToWeapon(procid, false, 100 + spells[spell_id].limit_value[i], spell_id, caster_level, GetSpellProcLimitTimer(spell_id, ProcType::MELEE_PROC));
 				break;
 			}
 
@@ -1883,7 +1883,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Ranged Proc: %+i", effect_value);
 #endif
-				AddRangedProc(procid, 100 + spells[spell_id].limit_value[i], spell_id, GetProcLimitTimer(spell_id, ProcType::RANGED_PROC));
+				AddRangedProc(procid, 100 + spells[spell_id].limit_value[i], spell_id, GetSpellProcLimitTimer(spell_id, ProcType::RANGED_PROC));
 				break;
 			}
 
@@ -1893,7 +1893,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Defensive Proc: %s (id %d)", spells[effect_value].name, procid);
 #endif
-				AddDefensiveProc(procid, 100 + spells[spell_id].limit_value[i], spell_id, GetProcLimitTimer(spell_id, ProcType::DEFENSIVE_PROC));
+				AddDefensiveProc(procid, 100 + spells[spell_id].limit_value[i], spell_id, GetSpellProcLimitTimer(spell_id, ProcType::DEFENSIVE_PROC));
 				break;
 			}
 
@@ -3400,7 +3400,7 @@ int64 Mob::CalcSpellEffectValue(uint16 spell_id, int effect_id, int caster_level
 
 	// this doesn't actually need to be a song to get mods, just the right skill
 	if (EQ::skills::IsBardInstrumentSkill(spells[spell_id].skill)
-		&& IsInstrumentModAppliedToSpellEffect(spell_id, spells[spell_id].effect_id[effect_id])) {
+		&& IsInstrumentModifierAppliedToSpellEffect(spell_id, spells[spell_id].effect_id[effect_id])) {
 			oval = effect_value;
 			effect_value = effect_value * static_cast<int>(instrument_mod) / 10;
 			LogSpells("Effect value [{}] altered with bard modifier of [{}] to yeild [{}]",
@@ -3959,7 +3959,7 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 		}
 
 		case SE_WipeHateList: {
-			if (IsMezSpell(buff.spellid)) {
+			if (IsMesmerizeSpell(buff.spellid)) {
 				break;
 			}
 
@@ -4054,7 +4054,7 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 		case SE_InterruptCasting: {
 			if (IsCasting()) {
 				const auto &spell = spells[casting_spell_id];
-				if (!IgnoreCastingRestriction(spell.id) && zone->random.Roll(spells[buff.spellid].base_value[i])) {
+				if (!IsCastNotStandingSpell(spell.id) && zone->random.Roll(spells[buff.spellid].base_value[i])) {
 					InterruptSpell();
 				}
 			}
@@ -4363,7 +4363,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 								for (unsigned int j = 0; j < buff_count; j++) {
 									if (IsValidSpell(tar->GetBuffs()[j].spellid)) {
 										auto spell = spells[tar->GetBuffs()[j].spellid];
-										if (spell.good_effect == 0 && IsEffectInSpell(spell.id, SE_CurrentHP) && tar->GetBuffs()[j].casterid == GetID()) {
+										if (spell.good_effect == DETRIMENTAL_EFFECT && IsEffectInSpell(spell.id, SE_CurrentHP) && tar->GetBuffs()[j].casterid == GetID()) {
 											tar->BuffFadeBySpellID(spell.id);
 										}
 									}
@@ -4377,7 +4377,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 						for (unsigned int j = 0; j < buff_count; j++) {
 							if (IsValidSpell(GetBuffs()[j].spellid )) {
 								auto spell = spells[GetBuffs()[j].spellid];
-								if (spell.good_effect == 0 && IsEffectInSpell(spell.id, SE_CurrentHP)) {
+								if (spell.good_effect == DETRIMENTAL_EFFECT && IsEffectInSpell(spell.id, SE_CurrentHP)) {
 									BuffFadeBySpellID(spell.id);
 								}
 							}
@@ -4785,7 +4785,7 @@ int64 Mob::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 					LimitInclude[IncludeExistsSELimitEffect] = true;
 					// they use 33 here for all classes ... unsure if the type check is really needed
 					if (base_value == SE_SummonPet && type == focusReagentCost) {
-						if (IsSummonPetSpell(spell_id) || IsSummonSkeletonSpell(spell_id)) {
+						if (IsPetSpell(spell_id)) {
 							LimitInclude[IncludeFoundSELimitEffect] = true;
 						}
 					}
@@ -6262,7 +6262,7 @@ bool Mob::TryTriggerOnCastProc(uint16 focusspellid, uint16 spell_id, uint16 proc
 			return true;
 		}
 		// Edge cases where proc spell does not require a target such as PBAE, allows proc to still occur even if target potentially dead. Live spells exist with PBAE procs.
-		else if (!SpellRequiresTarget(proc_spellid)) {
+		else if (!IsTargetRequiredForSpell(proc_spellid)) {
 			SpellFinished(proc_spellid, this, EQ::spells::CastingSlot::Item, 0, -1, spells[proc_spellid].resist_difficulty);
 			return true;
 		}
@@ -9608,7 +9608,7 @@ void Mob::CastSpellOnLand(Mob* caster, int32 spell_id)
 
 void Mob::CalcSpellPowerDistanceMod(uint16 spell_id, float range, Mob* caster)
 {
-	if (IsPowerDistModSpell(spell_id)){
+	if (IsDistanceModifierSpell(spell_id)){
 
 		float distance = 0;
 
@@ -9959,7 +9959,7 @@ void Mob::VirusEffectProcess()
 			}
 
 			if (buffs[buffs_i].virus_spread_time <= 0) {
-				buffs[buffs_i].virus_spread_time = zone->random.Int(GetViralMinSpreadTime(buffs[buffs_i].spellid), GetViralMaxSpreadTime(buffs[buffs_i].spellid));
+				buffs[buffs_i].virus_spread_time = zone->random.Int(GetSpellViralMinimumSpreadTime(buffs[buffs_i].spellid), GetSpellViralMaximumSpreadTime(buffs[buffs_i].spellid));
 				SpreadVirusEffect(buffs[buffs_i].spellid, buffs[buffs_i].casterid, buffs[buffs_i].ticsremaining);
 				stop_timer = false;
 			}
@@ -9982,7 +9982,7 @@ void Mob::SpreadVirusEffect(int32 spell_id, uint32 caster_id, int32 buff_tics_re
 	std::vector<Mob *> targets_in_range = entity_list.GetTargetsForVirusEffect(
 		this,
 		caster,
-		GetViralSpreadRange(spell_id),
+		GetSpellViralSpreadRange(spell_id),
 		spells[spell_id].pcnpc_only_flag,
 		spell_id
 	);


### PR DESCRIPTION
# Perl
- Add `quest::CalculateCorruptionCounters(spell_id)`.
- Add `quest::CalculateCounters(spell_id)`.
- Add `quest::CalculateCurseCounters(spell_id)`.
- Add `quest::CalculateDiseaseCounters(spell_id)`.
- Add `quest::CalculatePoisonCounters(spell_id)`.
- Add `quest::GetSpellEffectDescriptionNumber(spell_id)`.
- Add `quest::GetSpellEffectIndex(spell_id, effect_id)`.
- Add `quest::GetSpellFuriousBash(spell_id)`.
- Add `quest::GetSpellMinimumLevel(spell_id)`.
- Add `quest::GetSpellNimbusEffect(spell_id)`.
- Add `quest::GetSpellPartialMagicRuneAmount(spell_id)`.
- Add `quest::GetSpellPartialMagicRuneReduction(spell_id)`.
- Add `quest::GetSpellPartialMeleeRuneAmount(spell_id)`.
- Add `quest::GetSpellPartialMeleeRuneReduction(spell_id)`.
- Add `quest::GetSpellProcLimitTimer(spell_id)`.
- Add `quest::GetSpellResistType(spell_id)`.
- Add `quest::GetSpellResurrectionSicknessCheck(spell_id_one, spell_id_two)`.
- Add `quest::GetSpellTargetType(spell_id)`.
- Add `quest::GetSpellTriggerSpellID(spell_id)`.
- Add `quest::GetSpellViralMaximumSpreadTime(spell_id)`.
- Add `quest::GetSpellViralMinimumSpreadTime(spell_id)`.
- Add `quest::GetSpellViralSpreadRange(spell_id)`.
- Add `quest::IsAEDurationSpell(spell_id)`.
- Add `quest::IsAENukeSpell(spell_id)`.
- Add `quest::IsAERainNukeSpell(spell_id)`.
- Add `quest::IsAllianceSpell(spell_id)`.
- Add `quest::IsBardOnlyStackEffect(effect_id)`.
- Add `quest::IsBardSong(spell_id)`.
- Add `quest::IsBlankSpellEffect(spell_id, effect_index)`.
- Add `quest::IsBlindSpell(spell_id)`.
- Add `quest::IsBuffSpell(spell_id)`.
- Add `quest::IsCastNotStandingSpell(spell_id)`.
- Add `quest::IsCastOnFadeDurationSpell(spell_id)`.
- Add `quest::IsCastRestrictedSpell(spell_id)`.
- Add `quest::IsCastTimeReductionSpell(spell_id)`.
- Add `quest::IsCastWhileInvisibleSpell(spell_id)`.
- Add `quest::IsCharmSpell(spell_id)`.
- Add `quest::IsCombatSkill(spell_id)`.
- Add `quest::IsCompleteHealDurationSpell(spell_id)`.
- Add `quest::IsCompleteHealSpell(spell_id)`.
- Add `quest::IsCureSpell(spell_id)`.
- Add `quest::IsDamageSpell(spell_id)`.
- Add `quest::IsDeathSaveSpell(spell_id)`.
- Add `quest::IsDebuffSpell(spell_id)`.
- Add `quest::IsDetrimentalSpell(spell_id)`.
- Add `quest::IsDiscipline(spell_id)`.
- Add `quest::IsDisciplineBuff(spell_id)`.
- Add `quest::IsDiseaseCounterSpell(spell_id)`.
- Add `quest::IsDistanceModifierSpell(spell_id)`.
- Add `quest::IsEffectIgnoredInStacking(effect_id)`.
- Add `quest::IsFastHealSpell(spell_id)`.
- Add `quest::IsFearSpell(spell_id)`.
- Add `quest::IsFocusLimit(effect_id)`.
- Add `quest::IsFullDeathSaveSpell(spell_id)`.
- Add `quest::IsGateSpell(spell_id)`.
- Add `quest::IsImprovedDamageSpell(spell_id)`.
- Add `quest::IsImprovedHealingSpell(spell_id)`.
- Add `quest::IsIncreaseDurationSpell(spell_id)`.
- Add `quest::IsIncreaseRangeSpell(spell_id)`.
- Add `quest::IsInstrumentModifierAppliedToSpellEffect(spell_id, effect_id)`.
- Add `quest::IsInvisibleSpell(spell_id)`.
- Add `quest::IsInvulnerabilitySpell(spell_id)`.
- Add `quest::IsLDoNObjectSpell(spell_id)`.
- Add `quest::IsLifetapSpell(spell_id)`.
- Add `quest::IsMagicRuneSpell(spell_id)`.
- Add `quest::IsManaCostReductionSpell(spell_id)`.
- Add `quest::IsManaTapSpell(spell_id)`.
- Add `quest::IsMesmerizeSpell(spell_id)`.
- Add `quest::IsNoDetrimentalSpellAggroSpell(spell_id)`.
- Add `quest::IsPBAENukeSpell(spell_id)`.
- Add `quest::IsPartialDeathSaveSpell(spell_id)`.
- Add `quest::IsPartialResistableSpell(spell_id)`.
- Add `quest::IsPercentalHealSpell(spell_id)`.
- Add `quest::IsPersistDeathSpell(spell_id)`.
- Add `quest::IsPetSpell(spell_id)`.
- Add `quest::IsPoisonCounterSpell(spell_id)`.
- Add `quest::IsPulsingBardSong(spell_id)`.
- Add `quest::IsPureNukeSpell(spell_id)`.
- Add `quest::IsRegularGroupHealSpell(spell_id)`.
- Add `quest::IsRegularSingleTargetHealSpell(spell_id)`.
- Add `quest::IsResistDebuffSpell(spell_id)`.
- Add `quest::IsResistableSpell(spell_id)`.
- Add `quest::IsRestAllowedSpell(spell_id)`.
- Add `quest::IsResurrectionEffects(spell_id)`.
- Add `quest::IsRuneSpell(spell_id)`.
- Add `quest::IsRunning(spell_id)`.
- Add `quest::IsSacrificeSpell(spell_id)`.
- Add `quest::IsSelfConversionSpell(spell_id)`.
- Add `quest::IsShadowStepSpell(spell_id)`.
- Add `quest::IsShortDurationBuff(spell_id)`.
- Add `quest::IsSpellUsableInThisZoneType(spell_id)`.
- Add `quest::IsSpellUsableInThisZoneType(spell_id, zone_type)`.
- Add `quest::IsStackableDOT(spell_id)`.
- Add `quest::IsStunSpell(spell_id)`.
- Add `quest::IsSuccorSpell(spell_id)`.
- Add `quest::IsSummonItemSpell(spell_id)`.
- Add `quest::IsSummonPCSpell(spell_id)`.
- Add `quest::IsSummonPetSpell(spell_id)`.
- Add `quest::IsSummonSkeletonSpell(spell_id)`.
- Add `quest::IsSummonSpell(spell_id)`.
- Add `quest::IsSuspendableSpell(spell_id)`.
- Add `quest::IsTargetRequiredForSpell(spell_id)`.
- Add `quest::IsTargetableAESpell(spell_id)`.
- Add `quest::IsTeleportSpell(spell_id)`.
- Add `quest::IsTranslocateSpell(spell_id)`.
- Add `quest::IsValidSpell(spell_id)`.
- Add `quest::IsVeryFastHealSpell(spell_id)`.
- Add `quest::IsVirusSpell(spell_id)`.

# Lua
- Add `eq.calculate_corruption_counters(spell_id)`.
- Add `eq.calculate_counters(spell_id)`.
- Add `eq.calculate_curse_counters(spell_id)`.
- Add `eq.calculate_disease_counters(spell_id)`.
- Add `eq.calculate_poison_counters(spell_id)`.
- Add `eq.get_spell_effect_description_number(spell_id)`.
- Add `eq.get_spell_effect_index(spell_id, effect_id)`.
- Add `eq.get_spell_furious_bash(spell_id)`.
- Add `eq.get_spell_level(spell_id, class_id)`.
- Add `eq.get_spell_minimum_level(spell_id)`.
- Add `eq.get_spell_nimbus_effect(spell_id)`.
- Add `eq.get_spell_partial_magic_rune_amount(spell_id)`.
- Add `eq.get_spell_partial_magic_rune_reduction(spell_id)`.
- Add `eq.get_spell_partial_melee_rune_amount(spell_id)`.
- Add `eq.get_spell_partial_melee_rune_reduction(spell_id)`.
- Add `eq.get_spell_proc_limit_timer(spell_id)`.
- Add `eq.get_spell_resist_type(spell_id)`.
- Add `eq.get_spell_resurrection_sickness_check(spell_id_one, spell_id_two)`.
- Add `eq.get_spell_target_type(spell_id)`.
- Add `eq.get_spell_trigger_spell_id(spell_id)`.
- Add `eq.get_spell_viral_maximum_spread_time(spell_id)`.
- Add `eq.get_spell_viral_minimum_spread_time(spell_id)`.
- Add `eq.get_spell_viral_spread_range(spell_id)`.
- Add `eq.is_ae_duration_spell(spell_id)`.
- Add `eq.is_ae_nuke_spell(spell_id)`.
- Add `eq.is_ae_rain_nuke_spell(spell_id)`.
- Add `eq.is_alliance_spell(spell_id)`.
- Add `eq.is_bard_only_stack_effect(spell_id)`.
- Add `eq.is_bard_song(spell_id)`.
- Add `eq.is_beneficial_spell(spell_id)`.
- Add `eq.is_blank_spell_effect(spell_id)`.
- Add `eq.is_blind_spell(spell_id)`.
- Add `eq.is_buff_spell(spell_id)`.
- Add `eq.is_cast_not_standing_spell(spell_id)`.
- Add `eq.is_cast_on_fade_duration_spell(spell_id)`.
- Add `eq.is_cast_restricted_spell(spell_id)`.
- Add `eq.is_cast_time_reduction_spell(spell_id)`.
- Add `eq.is_cast_while_invisible_spell(spell_id)`.
- Add `eq.is_charm_spell(spell_id)`.
- Add `eq.is_combat_skill(spell_id)`.
- Add `eq.is_complete_heal_duration_spell(spell_id)`.
- Add `eq.is_complete_heal_spell(spell_id)`.
- Add `eq.is_cure_spell(spell_id)`.
- Add `eq.is_damage_spell(spell_id)`.
- Add `eq.is_death_save_spell(spell_id)`.
- Add `eq.is_debuff_spell(spell_id)`.
- Add `eq.is_detrimental_spell(spell_id)`.
- Add `eq.is_discipline(spell_id)`.
- Add `eq.is_discipline_buff(spell_id)`.
- Add `eq.is_disease_counter_spell(spell_id)`.
- Add `eq.is_distance_modifier_spell(spell_id)`.
- Add `eq.is_effect_ignored_in_stacking(effect_id)`.
- Add `eq.is_effect_in_spell(spell_id, effect_id)`.
- Add `eq.is_fast_heal_spell(spell_id)`.
- Add `eq.is_fear_spell(spell_id)`.
- Add `eq.is_focus_limit(effect_id)`.
- Add `eq.is_full_death_save_spell(spell_id)`.
- Add `eq.is_gate_spell(spell_id)`.
- Add `eq.is_group_complete_heal_spell(spell_id)`.
- Add `eq.is_group_heal_over_time_spell(spell_id)`.
- Add `eq.is_group_only_spell(spell_id)`.
- Add `eq.is_group_spell(spell_id)`.
- Add `eq.is_harmony_spell(spell_id)`.
- Add `eq.is_haste_spell(spell_id)`.
- Add `eq.is_heal_over_time_spell(spell_id)`.
- Add `eq.is_health_spell(spell_id)`.
- Add `eq.is_illusion_spell(spell_id)`.
- Add `eq.is_improved_damage_spell(spell_id)`.
- Add `eq.is_improved_healing_spell(spell_id)`.
- Add `eq.is_increase_duration_spell(spell_id)`.
- Add `eq.is_increase_range_spell(spell_id)`.
- Add `eq.is_instrument_modifier_applied_to_spell_effect(spell_id, effect_id)`.
- Add `eq.is_invisible_spell(spell_id)`.
- Add `eq.is_invulnerability_spell(spell_id)`.
- Add `eq.is_ldon_object_spell(spell_id)`.
- Add `eq.is_lifetap_spell(spell_id)`.
- Add `eq.is_magic_rune_spell(spell_id)`.
- Add `eq.is_mana_cost_reduction_spell(spell_id)`.
- Add `eq.is_mana_tap_spell(spell_id)`.
- Add `eq.is_mesmerize_spell(spell_id)`.
- Add `eq.is_no_detrimental_spell_aggro_spell(spell_id)`.
- Add `eq.is_partial_death_save_spell(spell_id)`.
- Add `eq.is_partial_resistable_spell(spell_id)`.
- Add `eq.is_pbae_nuke_spell(spell_id)`.
- Add `eq.is_percental_heal_spell(spell_id)`.
- Add `eq.is_persist_death_spell(spell_id)`.
- Add `eq.is_pet_spell(spell_id)`.
- Add `eq.is_poison_counter_spell(spell_id)`.
- Add `eq.is_pulsing_bard_song(spell_id)`.
- Add `eq.is_pure_nuke_spell(spell_id)`.
- Add `eq.is_regular_group_heal_spell(spell_id)`.
- Add `eq.is_regular_single_target_heal_spell(spell_id)`.
- Add `eq.is_resist_debuff_spell(spell_id)`.
- Add `eq.is_resistable_spell(spell_id)`.
- Add `eq.is_rest_allowed_spell(spell_id)`.
- Add `eq.is_resurrection_effects(spell_id)`.
- Add `eq.is_rune_spell(spell_id)`.
- Add `eq.is_sacrifice_spell(spell_id)`.
- Add `eq.is_self_conversion_spell(spell_id)`.
- Add `eq.is_shadow_step_spell(spell_id)`.
- Add `eq.is_short_duration_buff(spell_id)`.
- Add `eq.is_spell_usable_in_this_zone_type(spell_id)`.
- Add `eq.is_spell_usable_in_this_zone_type(spell_id, zone_type)`.
- Add `eq.is_stackable_dot(spell_id)`.
- Add `eq.is_stun_spell(spell_id)`.
- Add `eq.is_succor_spell(spell_id)`.
- Add `eq.is_summon_item_spell(spell_id)`.
- Add `eq.is_summon_pc_spell(spell_id)`.
- Add `eq.is_summon_pet_spell(spell_id)`.
- Add `eq.is_summon_skeleton_spell(spell_id)`.
- Add `eq.is_summon_spell(spell_id)`.
- Add `eq.is_suspendable_spell(spell_id)`.
- Add `eq.is_target_required_for_spell(spell_id)`.
- Add `eq.is_targetable_ae_spell(spell_id)`.
- Add `eq.is_teleport_spell(spell_id)`.
- Add `eq.is_tgb_compatible_spell(spell_id)`.
- Add `eq.is_translocate_spell(spell_id)`.
- Add `eq.is_valid_spell(spell_id)`.
- Add `eq.is_very_fast_heal_spell(spell_id)`.
- Add `eq.is_virus_spell(spell_id)`.

# Notes
- A lot of cleanup in the logic and naming of these methods was done.
- Missing GM restricted spells like Guide spells and GM Health buffs were added as defines.
```cpp
#define SPELL_GMHP25K 6817
#define SPELL_GMHP50K 6818
#define SPELL_GMHP100K 6819
#define SPELL_GMHP225K 6820
#define SPELL_GMHP475K 6821
#define SPELL_GMHP925K 6822
#define SPELL_GMHP2M 6823
#define SPELL_GMHP3M 6824
#define SPELL_GMHP5M 39851
#define SPELL_GUIDE_ACTING_ONE 778
#define SPELL_GUIDE_ALLIANCE_ONE 810
#define SPELL_GUIDE_CANCEL_MAGIC_ONE 811
#define SPELL_GUIDE_JOURNEY_ONE 813
#define SPELL_GUIDE_VISION_ONE 814
#define SPELL_GUIDE_HEALTH_ONE 815
#define SPELL_GUIDE_INVULNERABILITY_ONE 816
#define SPELL_GUIDE_BOLT_ONE 817
#define SPELL_GUIDE_MEMORY_BLUR_ONE 818
#define SPELL_GUIDE_ACTING_TWO 1209
#define SPELL_GUIDE_CANCEL_MAGIC_TWO 1211
#define SPELL_GUIDE_JOURNEY_TWO 1212
#define SPELL_GUIDE_VISION_TWO 1213
#define SPELL_GUIDE_HEALTH_TWO 1214
#define SPELL_GUIDE_INVULNERABILITY_TWO 1215
#define SPELL_GUIDE_BOLT_TWO 1216
#define SPELL_GUIDE_MEMORY_BLUR_TWO 1217
#define SPELL_GUIDE_ALLIANCE_TWO 1219
#define SPELL_GUIDE_EVACUATION 3921
#define SPELL_GUIDE_LEVITATION 39852
#define SPELL_GUIDE_SPELL_HASTE 39853
#define SPELL_GUIDE_HASTE 39854
```
- Resurrection effects non-stacking value was added as a define.
```cpp
#define RES_EFFECTS_CANNOT_STACK -1
```
- Death save values were added as defines.
```cpp
#define PARTIAL_DEATH_SAVE 1
#define FULL_DEATH_SAVE 2
```
- Max fast heal casting time and max very fast heal casting time were added as defines.
```cpp
#define MAX_FAST_HEAL_CASTING_TIME 2000
#define MAX_VERY_FAST_HEAL_CASTING_TIME 1000
```
- Good effect values were added as defines.
```cpp
#define DETRIMENTAL_EFFECT 0
#define BENEFICIAL_EFFECT 1
#define BENEFICIAL_EFFECT_GROUP_ONLY 2
```
- `SE_Display` was uncommented so we could use it instead of the magic number `425`.
- `IsEvacSpell(spell_id)` was removed as it was unnecessary since `IsSuccorSpell(spell_id)` checks for `SE_Succor` as well.
- `GetMorphTrigger(spell_id)` was removed as it was unused.
- `GroupOnlySpell(spell_id)` was removed as it was unnecessary since `IsGroupOnlySpell(spell_id)` exists.
- `CanUseSpell(spell_id)` was removed as it was unnecessary since `GetSpellLevel(spell_id, class_id)` exists.
- `BeneficialSpell(spell_id)` was removed as it was unnecessary since `IsBeneficialSpell(spell_id)` exists.