### PR TITLE
[Logging] Fixed statements that logged incorrect data

### DIFF
--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -623,13 +623,13 @@ void Doors::ForceOpen(Mob *sender, bool alt_mode)
 	if (!alt_mode) { // original function
 		if (!m_is_open) {
 			if (!m_disable_timer) {
-				LogDoorsDetail("door_id [{}] starting timer", md->doorid);
+				LogDoorsDetail("door_id [{}] starting timer", m_door_id);
 				m_close_timer.Start();
 			}
 			m_is_open = true;
 		}
 		else {
-			LogDoorsDetail("door_id [{}] disable timer", md->doorid);
+			LogDoorsDetail("door_id [{}] disable timer", m_door_id);
 			m_close_timer.Disable();
 			if (!m_disable_timer) {
 				m_is_open = false;
@@ -638,7 +638,7 @@ void Doors::ForceOpen(Mob *sender, bool alt_mode)
 	}
 	else { // alternative function
 		if (!m_disable_timer) {
-			LogDoorsDetail("door_id [{}] alt starting timer", md->doorid);
+			LogDoorsDetail("door_id [{}] alt starting timer", m_door_id);
 			m_close_timer.Start();
 		}
 		m_is_open = true;


### PR DESCRIPTION
Due to the data types in the client packet, door_id was not being logged correctly.  Replaced the value from the packet with the simple m_door_id.

The old code displayed a seemingly random value for the same door, I assume because of casting.