### PR TITLE
[Targeting] /tar <bad target> should not untarget existing target

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -14419,11 +14419,6 @@ void Client::Handle_OP_TargetCommand(const EQApplicationPacket *app)
 		return;
 	}
 
-	if (GetTarget())
-	{
-		GetTarget()->IsTargeted(-1);
-	}
-
 	// Locate and cache new target
 	ClientTarget_Struct* ct = (ClientTarget_Struct*)app->pBuffer;
 	pClientSideTarget = ct->new_target;
@@ -14432,6 +14427,11 @@ void Client::Handle_OP_TargetCommand(const EQApplicationPacket *app)
 		Mob *nt = entity_list.GetMob(ct->new_target);
 		if (nt)
 		{
+			if (GetTarget())
+			{
+				GetTarget()->IsTargeted(-1);
+			}
+
 			SetTarget(nt);
 			bool inspect_buffs = false;
 			// rank 1 gives you ability to see NPC buffs in target window (SoD+)
@@ -14460,21 +14460,7 @@ void Client::Handle_OP_TargetCommand(const EQApplicationPacket *app)
 		}
 		else
 		{
-			SetTarget(nullptr);
-			SetHoTT(0);
-			UpdateXTargetType(TargetsTarget, nullptr);
-
-			Group *g = GetGroup();
-
-			if (g && g->HasRole(this, RoleAssist))
-				g->SetGroupAssistTarget(0);
-
-			if (g && g->HasRole(this, RoleTank))
-				g->SetGroupTankTarget(0);
-
-			if (g && g->HasRole(this, RolePuller))
-				g->SetGroupPullerTarget(0);
-
+			this->MessageString(Chat::Red, DONT_SEE_TARGET);
 			return;
 		}
 	}

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -14460,7 +14460,7 @@ void Client::Handle_OP_TargetCommand(const EQApplicationPacket *app)
 		}
 		else
 		{
-			this->MessageString(Chat::Red, DONT_SEE_TARGET);
+			MessageString(Chat::Red, DONT_SEE_TARGET);
 			return;
 		}
 	}

--- a/zone/string_ids.h
+++ b/zone/string_ids.h
@@ -100,6 +100,7 @@
 #define DUP_LORE					290		//Duplicate lore items are not allowed.
 #define TGB_ON						293		//Target other group buff is *ON*.
 #define TGB_OFF						294		//Target other group buff is *OFF*.
+#define DONT_SEE_TARGET				303		//I don't see anyone by that name around here...
 #define DISARMED_TRAP				305		//You have disarmed the trap.
 #define LDON_SENSE_TRAP1			306		//You do not Sense any traps.
 #define TRADESKILL_NOCOMBINE		334		//You cannot combine these items in this container type!


### PR DESCRIPTION
On live if you have something targetted, and you type /tar Innothule, but Innothule is not around, you get an error message and your current target is unmodifed.

Prior to this patch, if you do this on eqemu, it "looks" like your current target is unchanged, but you no longer get updates.

This change fixes that.  But I have a couple of questions:

1. The code differentiates between AI controlled clients and non-AI controlled clients.  Is not the /tar command unable to be send if you are AI controlled, meaning I could also delete those lines?  If not, perhaps the code I moved down inside non-ai controlled needs to be down in AI controlled as well?  My take is that those lines can be deleted.
2. The ONLY time all of the code after the // HoTT comment executes if its a NON-AI-CONTROLLED successful target.  So I don't believe any of that needs to be changed, since that's the case I fixed.  Just looking for a second set of eyes on that.

