### PR TITLE
[Cleanup] Remove GetGroupByBot(), GetRaidByMob(), and GetRaidByLeaderName() from zone/entity.cpp and zone/entity.h

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -2165,21 +2165,6 @@ Group *EntityList::GetGroupByClient(Client *client)
 	return nullptr;
 }
 
-Raid *EntityList::GetRaidByLeaderName(const char *leader)
-{
-	std::list<Raid *>::iterator iterator;
-
-	iterator = raid_list.begin();
-
-	while (iterator != raid_list.end()) {
-		if ((*iterator)->GetLeader() && strcmp((*iterator)->GetLeader()->GetName(), leader) == 0) {
-			return *iterator;
-		}
-		++iterator;
-	}
-	return nullptr;
-}
-
 Raid *EntityList::GetRaidByID(uint32 id)
 {
 	std::list<Raid *>::iterator iterator;
@@ -2255,26 +2240,6 @@ Raid* EntityList::GetRaidByBot(const Bot* bot)
 				return r;
 			}
 		}
-	}
-	return nullptr;
-}
-
-
-Raid *EntityList::GetRaidByMob(Mob *mob)
-{
-	std::list<Raid *>::iterator iterator;
-
-	iterator = raid_list.begin();
-
-	while (iterator != raid_list.end()) {
-		for(int x = 0; x < MAX_RAID_MEMBERS; x++) {
-			// TODO: Implement support for Mob objects in Raid class
-			/*if((*iterator)->members[x].member){
-				if((*iterator)->members[x].member == mob)
-					return *iterator;
-			}*/
-		}
-		++iterator;
 	}
 	return nullptr;
 }

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -194,15 +194,12 @@ public:
 	Mob* GetRandomMob(const glm::vec3& location = glm::vec3(0.f), float distance = 0, Mob* exclude_mob = nullptr);
 	Group* GetGroupByMob(Mob* mob);
 	Group* GetGroupByMobName(const char* name);
-	Group* GetGroupByBot(Bot* bot);
 	bool IsInSameGroupOrRaidGroup(Client *client1, Client *client2);
 	Group *GetGroupByClient(Client* client);
 	Group *GetGroupByID(uint32 id);
 	Group *GetGroupByLeaderName(const char* leader);
-	Raid *GetRaidByMob(Mob* mob);
 	Raid *GetRaidByClient(Client* client);
 	Raid *GetRaidByID(uint32 id);
-	Raid *GetRaidByLeaderName(const char *leader);
 	Raid* GetRaidByBotName(const char* name);
 	Raid* GetRaidByBot(const Bot* bot);
 


### PR DESCRIPTION
# Notes
- These are unused.