### PR TITLE
[Cleanup] Remove GateAllClients() from zone/entity.cpp and zone/entity.h

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -5171,17 +5171,6 @@ uint32 EntityList::CheckNPCsClose(Mob *center)
 	return count;
 }
 
-void EntityList::GateAllClients()
-{
-	auto it = client_list.begin();
-	while (it != client_list.end()) {
-		Client *c = it->second;
-		if (c)
-			c->GoToBind();
-		++it;
-	}
-}
-
 void EntityList::SignalAllClients(int signal_id)
 {
 	for (const auto& c : client_list) {

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -518,7 +518,6 @@ public:
 	void	ZoneWho(Client *c, Who_All_Struct* Who);
 	void	UnMarkNPC(uint16 ID);
 
-	void	GateAllClients();
 	void	SignalAllClients(int signal_id);
 	void	UpdateQGlobal(uint32 qid, QGlobal newGlobal);
 	void	DeleteQGlobal(std::string name, uint32 npcID, uint32 charID, uint32 zoneID);


### PR DESCRIPTION
# Notes
- This is unused.