### PR TITLE
[Cleanup] Remove Evade() from zone/entity.cpp and zone/entity.h

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -3601,24 +3601,6 @@ void EntityList::HalveAggro(Mob *who)
 	}
 }
 
-void EntityList::Evade(Mob *who)
-{
-	uint32 flatval = who->GetLevel() * 13;
-	int amt = 0;
-	auto it = npc_list.begin();
-	while (it != npc_list.end()) {
-		if (it->second->CastToNPC()->CheckAggro(who)) {
-			amt = it->second->CastToNPC()->GetHateAmount(who);
-			amt -= flatval;
-			if (amt > 0)
-				it->second->CastToNPC()->SetHateAmountOnEnt(who, amt);
-			else
-				it->second->CastToNPC()->SetHateAmountOnEnt(who, 0);
-		}
-		++it;
-	}
-}
-
 //removes "targ" from all hate lists, including feigned, in the zone
 void EntityList::ClearAggro(Mob* targ)
 {

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -472,7 +472,6 @@ public:
 	void	WriteEntityIDs();
 	void	HalveAggro(Mob* who);
 	void	DoubleAggro(Mob* who);
-	void	Evade(Mob *who);
 	void	UpdateHoTT(Mob* target);
 
 	void	Process();


### PR DESCRIPTION
# Notes
- This is unused.