### PR TITLE
[Cleanup] Remove WriteEntityIDs() from zone/entity.cpp and zone/entity.h

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -3524,15 +3524,6 @@ void EntityList::ClearClientPetitionQueue()
 	return;
 }
 
-void EntityList::WriteEntityIDs()
-{
-	auto it = mob_list.begin();
-	while (it != mob_list.end()) {
-		std::cout << "ID: " << it->first << "  Name: " << it->second->GetName() << std::endl;
-		++it;
-	}
-}
-
 BulkZoneSpawnPacket::BulkZoneSpawnPacket(Client *iSendTo, uint32 iMaxSpawnsPerPacket)
 {
 	data = nullptr;

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -469,7 +469,6 @@ public:
 	uint32	DeleteNPCCorpses();
 	uint32	DeletePlayerCorpses();
 	void	CorpseFix(Client* c);
-	void	WriteEntityIDs();
 	void	HalveAggro(Mob* who);
 	void	DoubleAggro(Mob* who);
 	void	Evade(Mob *who);


### PR DESCRIPTION
# Notes
- This is unused.