### PR TITLE
[Cleanup] Remove struct DynamicZoneSafeReturn from zone/entity.h

### DIFF
--- a/zone/entity.h
+++ b/zone/entity.h
@@ -50,7 +50,6 @@ class Raid;
 class Spawn2;
 class Trap;
 
-struct DynamicZoneSafeReturn;
 struct GuildBankItemUpdate_Struct;
 struct NewSpawn_Struct;
 struct QGlobal;


### PR DESCRIPTION
# Notes
- This is unused.