### PR TITLE
[Cleanup] Remove struct TradeEntity from zone/common.h

### DIFF
--- a/zone/common.h
+++ b/zone/common.h
@@ -232,7 +232,6 @@ enum GravityBehavior {
 	LevitateWhileRunning
 };
 
-struct TradeEntity;
 class Trade;
 enum TradeState {
 	TradeNone,


### PR DESCRIPTION
# Notes
- This is unused.