### PR TITLE
[Cleanup] Remove CHECK_LOS_STEP from zone/common.h

### DIFF
--- a/zone/common.h
+++ b/zone/common.h
@@ -20,7 +20,6 @@
 //LOS Parameters:
 #define HEAD_POSITION 0.9f	//ratio of GetSize() where NPCs see from
 #define SEE_POSITION 0.5f	//ratio of GetSize() where NPCs try to see for LOS
-#define CHECK_LOS_STEP 1.0f
 
 #define ARCHETYPE_HYBRID	1
 #define ARCHETYPE_CASTER	2


### PR DESCRIPTION
# Notes
- This is unused.