### PR TITLE
[Cleanup] Add GMFind_Struct to packet structures

### DIFF
--- a/common/eq_packet_structs.h
+++ b/common/eq_packet_structs.h
@@ -1794,14 +1794,14 @@ struct GMSummon_Struct {
 };
 
 struct GMFind_Struct {
-char	charname[64];
-char	gmname[64];
-uint32	success;
-uint32	zoneID;
-float	x;
-float	y;
-float	z;
-uint32	unknown2;
+	char	charname[64];
+	char	gmname[64];
+	uint32	success;
+	uint32	zoneID;
+	float	x;
+	float	y;
+	float	z;
+	uint32	unknown2;
 };
 
 struct GMGoto_Struct { // x,y is swapped as compared to summon and makes sense as own packet

--- a/common/eq_packet_structs.h
+++ b/common/eq_packet_structs.h
@@ -1793,6 +1793,17 @@ struct GMSummon_Struct {
 /*104*/	uint32	unknown2; // E0 E0 56 00
 };
 
+struct GMFind_Struct {
+/*  0*/	char	charname[64];
+/* 30*/	char	gmname[64];
+/* 60*/	uint32	success;
+/* 61*/	uint32	zoneID;
+/*92*/	float	x;
+/*96*/	float	y;
+/*100*/	float	z;
+/*104*/	uint32	unknown2; // E0 E0 56 00
+};
+
 struct GMGoto_Struct { // x,y is swapped as compared to summon and makes sense as own packet
 /*  0*/ char	charname[64];
 

--- a/common/eq_packet_structs.h
+++ b/common/eq_packet_structs.h
@@ -1794,14 +1794,14 @@ struct GMSummon_Struct {
 };
 
 struct GMFind_Struct {
-/*  0*/	char	charname[64];
-/* 30*/	char	gmname[64];
-/* 60*/	uint32	success;
-/* 61*/	uint32	zoneID;
-/*92*/	float	x;
-/*96*/	float	y;
-/*100*/	float	z;
-/*104*/	uint32	unknown2; // E0 E0 56 00
+char	charname[64];
+char	gmname[64];
+uint32	success;
+uint32	zoneID;
+float	x;
+float	y;
+float	z;
+uint32	unknown2;
 };
 
 struct GMGoto_Struct { // x,y is swapped as compared to summon and makes sense as own packet

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -6471,27 +6471,28 @@ void Client::Handle_OP_GMFind(const EQApplicationPacket *app)
 		RecordPlayerEventLog(PlayerEvent::POSSIBLE_HACK, PlayerEvent::PossibleHackEvent{.message = "Used /find"});
 		return;
 	}
-	if (app->size != sizeof(GMSummon_Struct)) {
-		LogError("Wrong size: OP_GMFind, size=[{}], expected [{}]", app->size, sizeof(GMSummon_Struct));
+
+	if (app->size != sizeof(GMFind_Struct)) {
+		LogError("Wrong size: OP_GMFind, size=[{}], expected [{}]", app->size, sizeof(GMFind_Struct));
 		return;
 	}
+
 	//Break down incoming
-	GMSummon_Struct* request = (GMSummon_Struct*)app->pBuffer;
+	auto* request = (GMFind_Struct*) app->pBuffer;
 	//Create a new outgoing
-	auto outapp = new EQApplicationPacket(OP_GMFind, sizeof(GMSummon_Struct));
-	GMSummon_Struct* foundplayer = (GMSummon_Struct*)outapp->pBuffer;
+	auto outapp = new EQApplicationPacket(OP_GMFind, sizeof(GMFind_Struct));
+	auto* foundplayer = (GMFind_Struct*) outapp->pBuffer;
 	//Copy the constants
 	strcpy(foundplayer->charname, request->charname);
 	strcpy(foundplayer->gmname, request->gmname);
 	//Check if the NPC exits intrazone...
-	Mob* gt = entity_list.GetMob(request->charname);
-	if (gt != 0) {
+	auto* gt = entity_list.GetMob(request->charname);
+	if (gt) {
 		foundplayer->success = 1;
-		foundplayer->x = (int32)gt->GetX();
-		foundplayer->y = (int32)gt->GetY();
-
-		foundplayer->z = (int32)gt->GetZ();
-		foundplayer->zoneID = zone->GetZoneID();
+		foundplayer->x       = gt->GetX();
+		foundplayer->y       = gt->GetY();
+		foundplayer->z       = gt->GetZ();
+		foundplayer->zoneID  = zone->GetZoneID();
 	}
 	//Send the packet...
 	FastQueuePacket(&outapp);


### PR DESCRIPTION
# Notes
- X and Y were swapped in GMSummon_Struct so it displayed XYZ incorrectly in /find, adding its own struct fixes this.