### PR TITLE
[Quest API] Add GetEXPForLevel() to Perl/Lua

### DIFF
--- a/zone/client.h
+++ b/zone/client.h
@@ -1641,6 +1641,7 @@ public:
 	PlayerEvent::PlayerEvent GetPlayerEvent();
 	void RecordKilledNPCEvent(NPC *n);
 
+	uint32 GetEXPForLevel(uint16 check_level);
 protected:
 	friend class Mob;
 	void CalcEdibleBonuses(StatBonuses* newbon);
@@ -1816,7 +1817,6 @@ private:
 	bool temp_pvp;
 
 	void NPCSpawn(const Seperator* sep);
-	uint32 GetEXPForLevel(uint16 level);
 
 	void SendLogoutPackets();
 	void SendZoneInPackets();

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3054,6 +3054,12 @@ bool Lua_Client::ReloadDataBuckets() {
 	return DataBucket::GetDataBuckets(self);
 }
 
+uint32 Lua_Client::GetEXPForLevel(uint16 check_level)
+{
+	Lua_Safe_Call_Int();
+	return self->GetEXPForLevel(check_level);
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 	.def(luabind::constructor<>())
@@ -3217,6 +3223,7 @@ luabind::scope lua_register_client() {
 	.def("GetDisciplineTimer", (uint32(Lua_Client::*)(uint32))&Lua_Client::GetDisciplineTimer)
 	.def("GetDuelTarget", (int(Lua_Client::*)(void))&Lua_Client::GetDuelTarget)
 	.def("GetEXP", (uint32(Lua_Client::*)(void))&Lua_Client::GetEXP)
+	.def("GetEXPForLevel", (uint32(Lua_Client::*)(uint16))&Lua_Client::GetEXPForLevel)
 	.def("GetEXPModifier", (double(Lua_Client::*)(uint32))&Lua_Client::GetEXPModifier)
 	.def("GetEXPModifier", (double(Lua_Client::*)(uint32,int16))&Lua_Client::GetEXPModifier)
 	.def("GetEbonCrystals", (uint32(Lua_Client::*)(void))&Lua_Client::GetEbonCrystals)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -468,6 +468,7 @@ public:
 	void UseAugmentContainer(int container_slot);
 	bool IsAutoAttackEnabled();
 	bool IsAutoFireEnabled();
+	uint32 GetEXPForLevel(uint16 check_level);
 
 	void ApplySpell(int spell_id);
 	void ApplySpell(int spell_id, int duration);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -2912,6 +2912,11 @@ bool Perl_Client_ReloadDataBuckets(Client* self)
 	return DataBucket::GetDataBuckets(self);
 }
 
+uint32 Perl_Client_GetEXPForLevel(Client* self, uint16 check_level)
+{
+	return self->GetEXPForLevel(check_level);
+}
+
 void perl_register_client()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3075,6 +3080,7 @@ void perl_register_client()
 	package.add("GetDuelTarget", &Perl_Client_GetDuelTarget);
 	package.add("GetEnvironmentDamageModifier", &Perl_Client_GetEnvironmentDamageModifier);
 	package.add("GetEXP", &Perl_Client_GetEXP);
+	package.add("GetEXPForLevel", &Perl_Client_GetEXPForLevel);
 	package.add("GetEXPModifier", (double(*)(Client*, uint32))&Perl_Client_GetEXPModifier);
 	package.add("GetEXPModifier", (double(*)(Client*, uint32, int16))&Perl_Client_GetEXPModifier);
 	package.add("GetEbonCrystals", &Perl_Client_GetEbonCrystals);


### PR DESCRIPTION
# Perl
- Add `$client->GetEXPForLevel(check_level)`.

# Lua
- Add `client:GetEXPForLevel(check_level)`.

# Notes
- This allows operators to see the required experience for a level based on the client provided, this takes race/class modifiers into account as well if enabled.