### PR TITLE
[Backups] Move world database:dump to use MySQL credentials file

### DIFF
--- a/common/database/database_dump_service.h
+++ b/common/database/database_dump_service.h
@@ -93,6 +93,8 @@ private:
 	std::string GetSetDumpPath();
 	std::string GetQueryServTables();
 	void RemoveSqlBackup();
+	void BuildCredentialsFile();
+	void RemoveCredentialsFile();
 };
 
 


### PR DESCRIPTION
This PR moves the `DatabaseDumpService` to use a credentials file instead of passing credentials on the command line.

This is done by temporarily creating a temporary credentials file before the command is executed and then is cleaned up after the dump is created. The reason for this is that `mysqldump` or invocations of `mysql` on the command line will echo warnings of 

```
mysqldump: [Warning] Using a password on the command line interface can be insecure.
```

This warning gets in the dump files and will halt execution of the dump entirely. This warning is produced on later versions of MySQL.

**File Creation and Deletion**

Below is a `cat` during invocation and immediately after.

```
eqemu@332a3650bfe4:~/server$ cat login.my.cnf
[mysqldump]
user=eqemu
password=xxx
host=mariadb
port=3306
default-character-set=utf8
eqemu@332a3650bfe4:~/server$ cat login.my.cnf
cat: login.my.cnf: No such file or directory
```

**Testing**

Testing done to validate everything works as expected still. Ran a backup, checked lines, size and ensured we didn't have a warning message emitted.

```
eqemu@332a3650bfe4:~/server$ ./bin/world database:dump --all
 World |    Info    | DatabaseDump MySQL installed [mysql  Ver 15.1 Distrib 10.5.18-MariaDB, for debian-linux-gnu (x86_64) using  EditLine wrapper] 
 World |    Info    | DatabaseDump Database [peq] Host [mariadb] Username [eqemu] 
 World |    Info    | DatabaseDump Database dump created at [backups/peq-2023-06-17.sql] 
eqemu@332a3650bfe4:~/server$ cat backups/peq-2023-06-17.sql | wc -l
17322
eqemu@332a3650bfe4:~/server$ ls -lsh ./backups/peq-2023-06-17.sql 
257M -rw-r--r-- 1 eqemu eqemu 257M Jun 17 16:56 ./backups/peq-2023-06-17.sql
eqemu@332a3650bfe4:~/server$ cat ./backups/peq-2023-06-17.sql | grep mysqldump
```