### PR TITLE
[Logging] Logging improvements, console silencing, terminal coloring

### DIFF
--- a/common/database/database_dump_service.cpp
+++ b/common/database/database_dump_service.cpp
@@ -309,6 +309,8 @@ void DatabaseDumpService::DatabaseDump()
 		if (tables_to_dump.empty()) {
 			std::cerr << "No tables were specified" << std::endl;
 		}
+
+		return;
 	}
 	else {
 		const auto execute_command = fmt::format(
@@ -325,7 +327,7 @@ void DatabaseDumpService::DatabaseDump()
 		}
 	}
 
-	LogSys.EnableConsoleLogging();
+	LogSys.LoadLogSettingsDefaults();
 
 	if (!pipe_file.empty()) {
 		std::string file = fmt::format("{}.sql", GetDumpFileNameWithPath());
@@ -353,7 +355,7 @@ void DatabaseDumpService::DatabaseDump()
 
 	if (IsDumpWithCompression() && !IsDumpOutputToConsole()) {
 		if (HasCompressionBinary()) {
-			LogInfo("Compression requested... Compressing dump [{}.sql]", GetDumpFileNameWithPath());
+			LogInfo("Compression requested. Compressing dump [{}.sql]", GetDumpFileNameWithPath());
 
 			if (IsTarAvailable()) {
 				Process::execute(

--- a/common/eqemu_logsys.cpp
+++ b/common/eqemu_logsys.cpp
@@ -104,9 +104,9 @@ EQEmuLogSys *EQEmuLogSys::LoadLogSettingsDefaults()
 	/**
 	 * RFC 5424
 	 */
-	log_settings[Logs::Error].log_to_console     = static_cast<uint8>(Logs::General);
-	log_settings[Logs::Warning].log_to_console   = static_cast<uint8>(Logs::General);
-	log_settings[Logs::Info].log_to_console      = static_cast<uint8>(Logs::General);
+	log_settings[Logs::Error].log_to_console   = static_cast<uint8>(Logs::General);
+	log_settings[Logs::Warning].log_to_console = static_cast<uint8>(Logs::General);
+	log_settings[Logs::Info].log_to_console    = static_cast<uint8>(Logs::General);
 
 	/**
 	 * Set Category enabled status on defaults
@@ -219,7 +219,7 @@ void EQEmuLogSys::ProcessConsoleMessage(
 	int line
 )
 {
-	bool is_error = (
+	bool is_error   = (
 		log_category == Logs::LogCategory::Error ||
 		log_category == Logs::LogCategory::MySQLError ||
 		log_category == Logs::LogCategory::Crash ||
@@ -261,7 +261,7 @@ void EQEmuLogSys::ProcessConsoleMessage(
 	}
 
 	if (log_category == Logs::LogCategory::MySQLQuery) {
-		auto        s     = Strings::Split(message, "--");
+		auto s = Strings::Split(message, "--");
 		if (s.size() > 1) {
 			std::string query = Strings::Trim(s[0]);
 			std::string meta  = Strings::Trim(s[1]);
@@ -297,19 +297,76 @@ void EQEmuLogSys::ProcessConsoleMessage(
 					}
 				}
 
-				if (!is_upper) {
-					(!is_error ? std::cout : std::cerr)
-						<< rang::fgB::gray
-						<< "["
-						<< rang::style::bold
-						<< rang::fgB::yellow
-						<< e
-						<< rang::fgB::gray
-						<< "] "
-						;
+				// color matching in []
+				// ex: [<red>variable] would produce [variable] with red inside brackets
+				std::map<std::string, rang::fgB> colors = {
+					{"<black>",   rang::fgB::black},
+					{"<green>",   rang::fgB::green},
+					{"<yellow>",  rang::fgB::yellow},
+					{"<blue>",    rang::fgB::blue},
+					{"<magenta>", rang::fgB::magenta},
+					{"<cyan>",    rang::fgB::cyan},
+					{"<gray>",    rang::fgB::gray},
+					{"<red>",     rang::fgB::red},
+				};
+
+				bool      match_color = false;
+				for (auto &c: colors) {
+					if (Strings::Contains(e, c.first)) {
+						e = Strings::Replace(e, c.first, "");
+						(!is_error ? std::cout : std::cerr)
+							<< rang::fgB::gray
+							<< "["
+							<< rang::style::bold
+							<< c.second
+							<< e
+							<< rang::style::reset
+							<< rang::fgB::gray
+							<< "] ";
+						match_color = true;
+					}
 				}
-				else {
-					(!is_error ? std::cout : std::cerr) << rang::fgB::gray << "[" << e << "] ";
+
+				// string match to colors
+				std::map<std::string, rang::fgB> matches = {
+					{"missing", rang::fgB::red},
+					{"error",   rang::fgB::red},
+					{"ok",      rang::fgB::green},
+				};
+
+				for (auto &c: matches) {
+					if (Strings::Contains(e, c.first)) {
+						(!is_error ? std::cout : std::cerr)
+							<< rang::fgB::gray
+							<< "["
+							<< rang::style::bold
+							<< c.second
+							<< e
+							<< rang::style::reset
+							<< rang::fgB::gray
+							<< "] ";
+						match_color = true;
+					}
+				}
+
+				// if we don't match a color in either the string matching or
+				// the color tag matching, we default to yellow inside brackets
+				// if uppercase, does not get colored
+				if (!match_color) {
+					if (!is_upper) {
+						(!is_error ? std::cout : std::cerr)
+							<< rang::fgB::gray
+							<< "["
+							<< rang::style::bold
+							<< rang::fgB::yellow
+							<< e
+							<< rang::style::reset
+							<< rang::fgB::gray
+							<< "] ";
+					}
+					else {
+						(!is_error ? std::cout : std::cerr) << rang::fgB::gray << "[" << e << "] ";
+					}
 				}
 			}
 			else {
@@ -523,6 +580,8 @@ void EQEmuLogSys::StartFileLogs(const std::string &log_name)
  */
 void EQEmuLogSys::SilenceConsoleLogging()
 {
+	std::copy(std::begin(log_settings), std::end(log_settings), std::begin(pre_silence_settings));
+
 	for (int log_index = Logs::AA; log_index != Logs::MaxCategoryID; log_index++) {
 		log_settings[log_index].log_to_console      = 0;
 		log_settings[log_index].is_category_enabled = 0;
@@ -536,10 +595,7 @@ void EQEmuLogSys::SilenceConsoleLogging()
  */
 void EQEmuLogSys::EnableConsoleLogging()
 {
-	for (int log_index = Logs::AA; log_index != Logs::MaxCategoryID; log_index++) {
-		log_settings[log_index].log_to_console      = Logs::General;
-		log_settings[log_index].is_category_enabled = 1;
-	}
+	std::copy(std::begin(pre_silence_settings), std::end(pre_silence_settings), std::begin(log_settings));
 }
 
 EQEmuLogSys *EQEmuLogSys::LoadLogDatabaseSettings()
@@ -741,3 +797,16 @@ EQEmuLogSys *EQEmuLogSys::SetLogPath(const std::string &log_path)
 	return this;
 }
 
+void EQEmuLogSys::DisableMySQLErrorLogs()
+{
+	log_settings[Logs::MySQLError].log_to_file    = 0;
+	log_settings[Logs::MySQLError].log_to_console = 0;
+	log_settings[Logs::MySQLError].log_to_gmsay   = 0;
+}
+
+void EQEmuLogSys::EnableMySQLErrorLogs()
+{
+	log_settings[Logs::MySQLError].log_to_file    = 1;
+	log_settings[Logs::MySQLError].log_to_console = 1;
+	log_settings[Logs::MySQLError].log_to_gmsay   = 1;
+}

--- a/common/eqemu_logsys.h
+++ b/common/eqemu_logsys.h
@@ -324,6 +324,9 @@ public:
 	*/
 	LogSettings log_settings[Logs::LogCategory::MaxCategoryID]{};
 
+	// temporary bucket to re-load after silencing
+	LogSettings pre_silence_settings[Logs::LogCategory::MaxCategoryID]{};
+
 	struct LogEnabled {
 		bool log_to_file_enabled;
 		bool log_to_console_enabled;
@@ -373,6 +376,9 @@ public:
 
 	[[nodiscard]] const std::string &GetLogPath() const;
 	EQEmuLogSys * SetLogPath(const std::string &log_path);
+
+	void DisableMySQLErrorLogs();
+	void EnableMySQLErrorLogs();
 
 private:
 


### PR DESCRIPTION
Related to work in https://github.com/EQEmu/Server/pull/2857

* Add methods `EnableMySQLErrorLogs` and `DisableMySQLErrorLogs` when we want to use them during database migrations
* Keeps a copy of `pre_silenced` log settings so enabling console logging restores what was loaded from the database prior to silencing during CLI execution
* Returns `DatabaseDumpService` early when no tables are specified when `--drop-table-syntax-only` flag is set
* Reloads log settings from the database after a dump
* Colors console messages as red when bracket content matches `missing` or `error
* Colors console messages as green when bracket content matches `ok`
* Color matching `[<red>variable] would produce [variable] with red inside brackets`
