### PR TITLE
[CLI] Console menu validation fixes

### DIFF
--- a/common/cli/eqemu_command_handler.cpp
+++ b/common/cli/eqemu_command_handler.cpp
@@ -77,7 +77,7 @@ namespace EQEmuCommand {
 			index++;
 		}
 
-		if (!arguments_filled || argc == 2 || cmd[{"-h", "--help"}]) {
+		if (!arguments_filled || (argc == 2 && !cmd[{"-h", "--help"}]) || (argc == 3 && cmd[{"-h", "--help"}])) {
 			std::string arguments_string;
 			for (auto &arg : arguments) {
 				arguments_string += " " + arg;

--- a/world/cli/database_dump.cpp
+++ b/world/cli/database_dump.cpp
@@ -23,11 +23,11 @@ void WorldserverCLI::DatabaseDump(int argc, char **argv, argh::parser &cmd, std:
 		"--compress"
 	};
 
+	EQEmuCommand::ValidateCmdInput(arguments, options, cmd, argc, argv);
+
 	if (cmd[{"-h", "--help"}]) {
 		return;
 	}
-
-	EQEmuCommand::ValidateCmdInput(arguments, options, cmd, argc, argv);
 
 	auto s        = new DatabaseDumpService();
 	bool dump_all = cmd[{"-a", "--all"}];


### PR DESCRIPTION
Related to work in https://github.com/EQEmu/Server/pull/2857

Currently in `database:dump` when you run help, the root CLI menu `--help` takes over and shows the command menu instead of printing the help for the command itself.

**Before**

```
eqemu@332a3650bfe4:~/server$ ./bin/world database:dump --help

> EQEmulator [World] CLI Menu

character
  character:copy-character     Copies a character into a destination account
database
  database:dump                Dumps server database tables
  database:schema              Displays server database schema
  database:set-account-status  Sets account status by account name
  database:version             Shows database version
world
  world:version                Shows server version
```

**After**

```
eqemu@332a3650bfe4:~/server$ ./bin/world database:dump --help

Command

database:dump

Options

  --all
  --content-tables
  --login-tables
  --player-tables
  --bot-tables
  --merc-tables
  --state-tables
  --system-tables
  --query-serv-tables
  --table-structure-only
  --table-lock
  --dump-path=
  --dump-output-to-console
  --drop-table-syntax-only
  --compress
```