### PR TITLE
[Quest API] Add convert_money_to_string() to Perl/Lua

### DIFF
--- a/common/strings.cpp
+++ b/common/strings.cpp
@@ -370,7 +370,8 @@ std::string Strings::NumberToWords(unsigned long long int n)
 
 	return res;
 }
-std::string Strings::Money(uint32 platinum, uint32 gold, uint32 silver, uint32 copper)
+
+std::string Strings::Money(uint64 platinum, uint64 gold, uint64 silver, uint64 copper)
 {
 	std::string money_string = "Unknown";
 	if (copper && silver && gold && platinum) { // CSGP

--- a/common/strings.h
+++ b/common/strings.h
@@ -114,7 +114,7 @@ public:
 	static std::string Join(const std::vector<std::string> &ar, const std::string &delim);
 	static std::string Join(const std::vector<uint32_t> &ar, const std::string &delim);
 	static std::string MillisecondsToTime(int duration);
-	static std::string Money(uint32 platinum, uint32 gold = 0, uint32 silver = 0, uint32 copper = 0);
+	static std::string Money(uint64 platinum, uint64 gold = 0, uint64 silver = 0, uint64 copper = 0);
 	static std::string NumberToWords(unsigned long long int n);
 	static std::string Repeat(std::string s, int n);
 	static std::string Replace(std::string subject, const std::string &search, const std::string &replace);

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -5325,6 +5325,25 @@ void Perl__send_channel_message(Client* from, const char* to, uint8 channel_numb
 	quest_manager.SendChannelMessage(from, to, channel_number, guild_id, language_id, language_skill, message);
 }
 
+std::string Perl__convert_money_to_string(perl::hash table)
+{
+	uint64 platinum = table.exists("platinum") ? static_cast<uint64>(table["platinum"]) : 0;
+	uint64 gold     = table.exists("gold") ? static_cast<uint64>(table["gold"]) : 0;
+	uint64 silver   = table.exists("silver") ? static_cast<uint64>(table["silver"]) : 0;
+	uint64 copper   = table.exists("copper") ? static_cast<uint64>(table["copper"]) : 0;
+
+	if (
+		!copper &&
+		!silver &&
+		!gold &&
+		!platinum
+	) {
+		return std::string();
+	}
+
+	return Strings::Money(platinum, gold, silver, copper);
+}
+
 void perl_register_quest()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -5649,6 +5668,7 @@ void perl_register_quest()
 	package.add("collectitems", &Perl__collectitems);
 	package.add("commify", &Perl__commify);
 	package.add("completedtasksinset", &Perl__completedtasksinset);
+	package.add("convert_money_to_string", &Perl__convert_money_to_string);
 	package.add("countitem", &Perl__countitem);
 	package.add("countspawnednpcs", &Perl__countspawnednpcs);
 	package.add("createdoor", (uint16(*)(const char*, float, float, float, float))&Perl__CreateDoor);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -5019,7 +5019,7 @@ int lua_get_spell_nimbus_effect(uint16 spell_id)
 
 std::string lua_convert_money_to_string(luabind::adl::object table)
 {
-	if(luabind::type(table) != LUA_TTABLE) {
+	if (luabind::type(table) != LUA_TTABLE) {
 		return std::string();
 	}
 
@@ -5037,7 +5037,7 @@ std::string lua_convert_money_to_string(luabind::adl::object table)
 		return std::string();
 	}
 
-	return Strings::Money(platinum, gold, silver, copper);;
+	return Strings::Money(platinum, gold, silver, copper);
 }
 
 #define LuaCreateNPCParse(name, c_type, default_value) do { \

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -5017,6 +5017,29 @@ int lua_get_spell_nimbus_effect(uint16 spell_id)
 	return GetSpellNimbusEffect(spell_id);
 }
 
+std::string lua_convert_money_to_string(luabind::adl::object table)
+{
+	if(luabind::type(table) != LUA_TTABLE) {
+		return std::string();
+	}
+
+	uint64 platinum = luabind::type(table["platinum"]) != LUA_TNIL ? luabind::object_cast<uint64>(table["platinum"]) : 0;
+	uint64 gold     = luabind::type(table["gold"]) != LUA_TNIL ? luabind::object_cast<uint64>(table["gold"]) : 0;
+	uint64 silver   = luabind::type(table["silver"]) != LUA_TNIL ? luabind::object_cast<uint64>(table["silver"]) : 0;
+	uint64 copper   = luabind::type(table["copper"]) != LUA_TNIL ? luabind::object_cast<uint64>(table["copper"]) : 0;
+
+	if (
+		!copper &&
+		!silver &&
+		!gold &&
+		!platinum
+	) {
+		return std::string();
+	}
+
+	return Strings::Money(platinum, gold, silver, copper);;
+}
+
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
 	cur = table[#name]; \
 	if(luabind::type(cur) != LUA_TNIL) { \
@@ -5790,6 +5813,7 @@ luabind::scope lua_register_general() {
 		luabind::def("calculate_counters", &lua_calculate_counters),
 		luabind::def("get_spell_resurrection_sickness_check", &lua_get_spell_resurrection_sickness_check),
 		luabind::def("get_spell_nimbus_effect", &lua_get_spell_nimbus_effect),
+		luabind::def("convert_money_to_string", &lua_convert_money_to_string),
 		/*
 			Cross Zone
 		*/


### PR DESCRIPTION
# Perl
- Add `quest::convert_money_to_string(money_hash)`.

# Lua
- Add `eq.convert_money_to_string(money_table)`.

# Notes
- Allows operators to convert money in to a readable string using `Strings::Money`.

# Examples

## Perl
```pl
sub EVENT_SAY {
	if ($text=~/#a/i) {
		my %money_data = (
			"platinum" => 3123,
			"gold" => 5692,
			"copper" => 9
		);
		quest::message(315, quest::convert_money_to_string(%money_data));
	}
}
```

## Lua
```lua
function event_say(e)
	if e.message:find("#a") then
		local money_data = {
			gold = 12,
			silver = 523904,
			copper = 3
		}
		eq.message(315, "Lua: " .. eq.convert_money_to_string(money_data))
	end
end
```