### PR TITLE
[Bug Fix] Fix possible crash with #npcedit weapon

### DIFF
--- a/zone/gm_commands/npcedit.cpp
+++ b/zone/gm_commands/npcedit.cpp
@@ -530,14 +530,14 @@ void command_npcedit(Client *c, const Seperator *sep)
 	} else if (!strcasecmp(sep->arg[1], "weapon")) {
 		if (sep->IsNumber(2)) {
 			auto     primary_model   = Strings::ToUnsignedInt(sep->arg[2]);
-			uint32_t secondary_model = sep->arg[3] && sep->IsNumber(3) ? Strings::ToUnsignedInt(sep->arg[3]) : 0;
+			uint32_t secondary_model = sep->IsNumber(3) ? Strings::ToUnsignedInt(sep->arg[3]) : 0;
 			n.d_melee_texture1 = primary_model;
 			n.d_melee_texture2 = secondary_model;
 			d = fmt::format(
 				"{} will have Model {} set to their Primary and Model {} set to their Secondary on repop.",
 				npc_id_string,
-				Strings::Commify(sep->arg[2]),
-				sep->arg[3] && sep->IsNumber(3) ? Strings::Commify(sep->arg[3]) : 0
+				Strings::Commify(primary_model),
+				Strings::Commify(secondary_model)
 			);
 		} else {
 			c->Message(


### PR DESCRIPTION
# Notes
- Using `#npcedit weapon` without the secondary model had a chance to crash the zone you were in, i.e `#npcedit weapon 1`.

# Crash Logs
```txt
[06-18-2023 16:26:55] [Zone] [Crash] [New LWP 802548]
[06-18-2023 16:26:55] [Zone] [Crash] [New LWP 802549]
[06-18-2023 16:26:55] [Zone] [Crash] [New LWP 802550]
[06-18-2023 16:26:55] [Zone] [Crash] [New LWP 802551]
[06-18-2023 16:26:55] [Zone] [Crash] [Thread debugging using libthread_db enabled]
[06-18-2023 16:26:55] [Zone] [Crash] Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
[06-18-2023 16:26:55] [Zone] [Crash] 0x00007f22b2b14207 in __GI___wait4 (pid=819104, stat_loc=0x0, options=0, usage=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:27
[06-18-2023 16:26:55] [Zone] [Crash] [Current thread is 1 (Thread 0x7f22b29eab00 (LWP 802540))]
[06-18-2023 16:26:55] [Zone] [Crash] #0  0x00007f22b2b14207 in __GI___wait4 (pid=819104, stat_loc=0x0, options=0, usage=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:27
[06-18-2023 16:26:55] [Zone] [Crash] #1  0x000055e4451b6b6e in print_trace () at /home/eqemu/code/common/crash.cpp:281
[06-18-2023 16:26:55] [Zone] [Crash] #2  <signal handler called>
[06-18-2023 16:26:55] [Zone] [Crash] #3  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
[06-18-2023 16:26:55] [Zone] [Crash] #4  0x00007f22b2a6e537 in __GI_abort () at abort.c:79
[06-18-2023 16:26:55] [Zone] [Crash] #5  0x00007f22b2e067ec in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
[06-18-2023 16:26:55] [Zone] [Crash] #6  0x00007f22b2e11966 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
[06-18-2023 16:26:55] [Zone] [Crash] #7  0x00007f22b2e119d1 in std::terminate() () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
[06-18-2023 16:26:55] [Zone] [Crash] #8  0x00007f22b2e11c65 in __cxa_throw () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
[06-18-2023 16:26:55] [Zone] [Crash] #9  0x00007f22b2e08faa in std::__throw_logic_error(char const*) () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
[06-18-2023 16:26:55] [Zone] [Crash] #10 0x000055e444216b48 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*> (this=0x7fff9bd06620, __beg=0x0, __end=0xffffffffffffffff <error: Cannot access memory at address 0xffffffffffffffff>) at /usr/include/c++/10/bits/basic_string.tcc:212
[06-18-2023 16:26:55] [Zone] [Crash] #11 0x000055e44420dd09 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct_aux<char const*> (this=0x7fff9bd06620, __beg=0x0, __end=0xffffffffffffffff <error: Cannot access memory at address 0xffffffffffffffff>) at /usr/include/c++/10/bits/basic_string.h:247
[06-18-2023 16:26:55] [Zone] [Crash] #12 0x000055e444203977 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*> (this=0x7fff9bd06620, __beg=0x0, __end=0xffffffffffffffff <error: Cannot access memory at address 0xffffffffffffffff>) at /usr/include/c++/10/bits/basic_string.h:266
[06-18-2023 16:26:55] [Zone] [Crash] #13 0x000055e4441f93ef in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string<std::allocator<char> > (this=0x7fff9bd06620, __s=0x0, __a=...) at /usr/include/c++/10/bits/basic_string.h:527
[06-18-2023 16:26:55] [Zone] [Crash] #14 0x000055e4445469df in command_npcedit (c=0x55e448292480, sep=0x7fff9bd09a20) at /home/eqemu/code/zone/gm_commands/npcedit.cpp:540
[06-18-2023 16:26:55] [Zone] [Crash] #15 0x000055e4444e2039 in command_realdispatch (c=0x55e448292480, message="#npcedit weapon 1", ignore_status=false) at /home/eqemu/code/zone/command.cpp:602
[06-18-2023 16:26:55] [Zone] [Crash] #16 0x000055e4443b03d3 in Client::ChannelMessageReceived (this=0x55e448292480, chan_num=8 '\b', language=0 '\000', lang_skill=100 'd', orig_message=0x55e44a69e314 "#npcedit weapon 1", targetname=0x55e44a69e280 "a_willowisp000", is_silent=false) at /home/eqemu/code/zone/client.cpp:1122
[06-18-2023 16:26:55] [Zone] [Crash] #17 0x000055e444454597 in Client::Handle_OP_ChannelMessage (this=0x55e448292480, app=0x55e449156a70) at /home/eqemu/code/zone/client_packet.cpp:4478
[06-18-2023 16:26:55] [Zone] [Crash] #18 0x000055e44443c5d2 in Client::HandlePacket (this=0x55e448292480, app=0x55e449156a70) at /home/eqemu/code/zone/client_packet.cpp:495
[06-18-2023 16:26:55] [Zone] [Crash] #19 0x000055e4444b7add in Client::Process (this=0x55e448292480) at /home/eqemu/code/zone/client_process.cpp:587
[06-18-2023 16:26:55] [Zone] [Crash] #20 0x000055e44472df12 in EntityList::MobProcess (this=0x55e445df07c0 <entity_list>) at /home/eqemu/code/zone/entity.cpp:510
[06-18-2023 16:26:55] [Zone] [Crash] #21 0x000055e444c149b0 in operator() (__closure=0x55e448dc9170, t=0x7fff9bd0c4a0) at /home/eqemu/code/zone/main.cpp:562
[06-18-2023 16:26:55] [Zone] [Crash] #22 0x000055e444c19fd2 in std::__invoke_impl<void, main(int, char**)::<lambda(EQ::Timer*)>&, EQ::Timer*>(std::__invoke_other, struct {...} &) (__f=...) at /usr/include/c++/10/bits/invoke.h:60
[06-18-2023 16:26:55] [Zone] [Crash] #23 0x000055e444c19da1 in std::__invoke_r<void, main(int, char**)::<lambda(EQ::Timer*)>&, EQ::Timer*>(struct {...} &) (__fn=...) at /usr/include/c++/10/bits/invoke.h:110
[06-18-2023 16:26:55] [Zone] [Crash] #24 0x000055e444c19ac8 in std::_Function_handler<void(EQ::Timer*), main(int, char**)::<lambda(EQ::Timer*)> >::_M_invoke(const std::_Any_data &, EQ::Timer *&&) (__functor=..., __args#0=@0x7fff9bd0bea0: 0x7fff9bd0c4a0) at /usr/include/c++/10/bits/std_function.h:291
[06-18-2023 16:26:55] [Zone] [Crash] #25 0x000055e444c1f4c5 in std::function<void (EQ::Timer*)>::operator()(EQ::Timer*) const (this=0x7fff9bd0c4a8, __args#0=0x7fff9bd0c4a0) at /usr/include/c++/10/bits/std_function.h:622
[06-18-2023 16:26:55] [Zone] [Crash] #26 0x000055e444c1d265 in EQ::Timer::Execute (this=0x7fff9bd0c4a0) at /home/eqemu/code/zone/../common/net/../event/timer.h:61
[06-18-2023 16:26:55] [Zone] [Crash] #27 0x000055e444c1d023 in EQ::Timer::Start(unsigned long, bool)::{lambda(uv_timer_s*)#1}::operator()(uv_timer_s*) const (__closure=0x0, handle=0x55e44832b570) at /home/eqemu/code/zone/../common/net/../event/timer.h:38
[06-18-2023 16:26:55] [Zone] [Crash] #28 0x000055e444c1d043 in EQ::Timer::Start(unsigned long, bool)::{lambda(uv_timer_s*)#1}::_FUN(uv_timer_s*) () at /home/eqemu/code/zone/../common/net/../event/timer.h:39
[06-18-2023 16:26:55] [Zone] [Crash] #29 0x000055e4454afb5d in uv__run_timers (loop=loop@entry=0x7f22b29ea7a8) at /home/eqemu/code/submodules/libuv/src/timer.c:178
[06-18-2023 16:26:55] [Zone] [Crash] #30 0x000055e4454b3182 in uv_run (loop=0x7f22b29ea7a8, mode=UV_RUN_DEFAULT) at /home/eqemu/code/submodules/libuv/src/unix/core.c:393
[06-18-2023 16:26:55] [Zone] [Crash] #31 0x000055e444c1ceeb in EQ::EventLoop::Run (this=0x7f22b29ea7a8) at /home/eqemu/code/zone/../common/net/../event/event_loop.h:25
[06-18-2023 16:26:55] [Zone] [Crash] #32 0x000055e444c18b6e in main (argc=1, argv=0x7fff9bd0d568) at /home/eqemu/code/zone/main.cpp:591
[06-18-2023 16:26:55] [Zone] [Crash] [Inferior 1 (process 802540) detached]
```

```txt
[06-18-2023 16:29:51] [Zone] [Crash] [New LWP 819434]
[06-18-2023 16:29:51] [Zone] [Crash] [New LWP 819436]
[06-18-2023 16:29:51] [Zone] [Crash] [New LWP 819438]
[06-18-2023 16:29:51] [Zone] [Crash] [New LWP 819440]
[06-18-2023 16:29:51] [Zone] [Crash] [Thread debugging using libthread_db enabled]
[06-18-2023 16:29:51] [Zone] [Crash] Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
[06-18-2023 16:29:51] [Zone] [Crash] 0x00007f489d185207 in __GI___wait4 (pid=819646, stat_loc=0x0, options=0, usage=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:27
[06-18-2023 16:29:51] [Zone] [Crash] [Current thread is 1 (Thread 0x7f489d05bb00 (LWP 819417))]
[06-18-2023 16:29:51] [Zone] [Crash] #0  0x00007f489d185207 in __GI___wait4 (pid=819646, stat_loc=0x0, options=0, usage=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:27
[06-18-2023 16:29:51] [Zone] [Crash] #1  0x000055d58e442b6e in print_trace () at /home/eqemu/code/common/crash.cpp:281
[06-18-2023 16:29:51] [Zone] [Crash] #2  <signal handler called>
[06-18-2023 16:29:51] [Zone] [Crash] #3  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
[06-18-2023 16:29:51] [Zone] [Crash] #4  0x00007f489d0df537 in __GI_abort () at abort.c:79
[06-18-2023 16:29:51] [Zone] [Crash] #5  0x00007f489d4777ec in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
[06-18-2023 16:29:51] [Zone] [Crash] #6  0x00007f489d482966 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
[06-18-2023 16:29:51] [Zone] [Crash] #7  0x00007f489d4829d1 in std::terminate() () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
[06-18-2023 16:29:51] [Zone] [Crash] #8  0x00007f489d482c65 in __cxa_throw () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
[06-18-2023 16:29:51] [Zone] [Crash] #9  0x00007f489d479faa in std::__throw_logic_error(char const*) () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
[06-18-2023 16:29:51] [Zone] [Crash] #10 0x000055d58d4a2b48 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*> (this=0x7ffdbbca2500, __beg=0x0, __end=0xffffffffffffffff <error: Cannot access memory at address 0xffffffffffffffff>) at /usr/include/c++/10/bits/basic_string.tcc:212
[06-18-2023 16:29:51] [Zone] [Crash] #11 0x000055d58d499d09 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct_aux<char const*> (this=0x7ffdbbca2500, __beg=0x0, __end=0xffffffffffffffff <error: Cannot access memory at address 0xffffffffffffffff>) at /usr/include/c++/10/bits/basic_string.h:247
[06-18-2023 16:29:51] [Zone] [Crash] #12 0x000055d58d48f977 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*> (this=0x7ffdbbca2500, __beg=0x0, __end=0xffffffffffffffff <error: Cannot access memory at address 0xffffffffffffffff>) at /usr/include/c++/10/bits/basic_string.h:266
[06-18-2023 16:29:51] [Zone] [Crash] #13 0x000055d58d4853ef in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string<std::allocator<char> > (this=0x7ffdbbca2500, __s=0x0, __a=...) at /usr/include/c++/10/bits/basic_string.h:527
[06-18-2023 16:29:51] [Zone] [Crash] #14 0x000055d58d7d29df in command_npcedit (c=0x55d59219f080, sep=0x7ffdbbca5900) at /home/eqemu/code/zone/gm_commands/npcedit.cpp:540
[06-18-2023 16:29:51] [Zone] [Crash] #15 0x000055d58d76e039 in command_realdispatch (c=0x55d59219f080, message="#npcedit weapon 1", ignore_status=false) at /home/eqemu/code/zone/command.cpp:602
[06-18-2023 16:29:51] [Zone] [Crash] #16 0x000055d58d63c3d3 in Client::ChannelMessageReceived (this=0x55d59219f080, chan_num=8 '\b', language=0 '\000', lang_skill=100 'd', orig_message=0x55d591b59b44 "#npcedit weapon 1", targetname=0x55d591b59ab0 "a_whiskered_bat002", is_silent=false) at /home/eqemu/code/zone/client.cpp:1122
[06-18-2023 16:29:51] [Zone] [Crash] #17 0x000055d58d6e0597 in Client::Handle_OP_ChannelMessage (this=0x55d59219f080, app=0x55d592711c60) at /home/eqemu/code/zone/client_packet.cpp:4478
[06-18-2023 16:29:51] [Zone] [Crash] #18 0x000055d58d6c85d2 in Client::HandlePacket (this=0x55d59219f080, app=0x55d592711c60) at /home/eqemu/code/zone/client_packet.cpp:495
[06-18-2023 16:29:51] [Zone] [Crash] #19 0x000055d58d743add in Client::Process (this=0x55d59219f080) at /home/eqemu/code/zone/client_process.cpp:587
[06-18-2023 16:29:51] [Zone] [Crash] #20 0x000055d58d9b9f12 in EntityList::MobProcess (this=0x55d58f07c7c0 <entity_list>) at /home/eqemu/code/zone/entity.cpp:510
[06-18-2023 16:29:51] [Zone] [Crash] #21 0x000055d58dea09b0 in operator() (__closure=0x55d591a07f10, t=0x7ffdbbca8380) at /home/eqemu/code/zone/main.cpp:562
[06-18-2023 16:29:51] [Zone] [Crash] #22 0x000055d58dea5fd2 in std::__invoke_impl<void, main(int, char**)::<lambda(EQ::Timer*)>&, EQ::Timer*>(std::__invoke_other, struct {...} &) (__f=...) at /usr/include/c++/10/bits/invoke.h:60
[06-18-2023 16:29:51] [Zone] [Crash] #23 0x000055d58dea5da1 in std::__invoke_r<void, main(int, char**)::<lambda(EQ::Timer*)>&, EQ::Timer*>(struct {...} &) (__fn=...) at /usr/include/c++/10/bits/invoke.h:110
[06-18-2023 16:29:51] [Zone] [Crash] #24 0x000055d58dea5ac8 in std::_Function_handler<void(EQ::Timer*), main(int, char**)::<lambda(EQ::Timer*)> >::_M_invoke(const std::_Any_data &, EQ::Timer *&&) (__functor=..., __args#0=@0x7ffdbbca7d80: 0x7ffdbbca8380) at /usr/include/c++/10/bits/std_function.h:291
[06-18-2023 16:29:51] [Zone] [Crash] #25 0x000055d58deab4c5 in std::function<void (EQ::Timer*)>::operator()(EQ::Timer*) const (this=0x7ffdbbca8388, __args#0=0x7ffdbbca8380) at /usr/include/c++/10/bits/std_function.h:622
[06-18-2023 16:29:51] [Zone] [Crash] #26 0x000055d58dea9265 in EQ::Timer::Execute (this=0x7ffdbbca8380) at /home/eqemu/code/zone/../common/net/../event/timer.h:61
[06-18-2023 16:29:51] [Zone] [Crash] #27 0x000055d58dea9023 in EQ::Timer::Start(unsigned long, bool)::{lambda(uv_timer_s*)#1}::operator()(uv_timer_s*) const (__closure=0x0, handle=0x55d590f6a610) at /home/eqemu/code/zone/../common/net/../event/timer.h:38
[06-18-2023 16:29:51] [Zone] [Crash] #28 0x000055d58dea9043 in EQ::Timer::Start(unsigned long, bool)::{lambda(uv_timer_s*)#1}::_FUN(uv_timer_s*) () at /home/eqemu/code/zone/../common/net/../event/timer.h:39
[06-18-2023 16:29:51] [Zone] [Crash] #29 0x000055d58e73bb5d in uv__run_timers (loop=loop@entry=0x7f489d05b7a8) at /home/eqemu/code/submodules/libuv/src/timer.c:178
[06-18-2023 16:29:51] [Zone] [Crash] #30 0x000055d58e73f182 in uv_run (loop=0x7f489d05b7a8, mode=UV_RUN_DEFAULT) at /home/eqemu/code/submodules/libuv/src/unix/core.c:393
[06-18-2023 16:29:51] [Zone] [Crash] #31 0x000055d58dea8eeb in EQ::EventLoop::Run (this=0x7f489d05b7a8) at /home/eqemu/code/zone/../common/net/../event/event_loop.h:25
[06-18-2023 16:29:51] [Zone] [Crash] #32 0x000055d58dea4b6e in main (argc=1, argv=0x7ffdbbca9448) at /home/eqemu/code/zone/main.cpp:591
[06-18-2023 16:29:51] [Zone] [Crash] [Inferior 1 (process 819417) detached]
```