### PR TITLE
[Cleanup] Default skill type to Hand to Hand in #npcedit meleetype

### DIFF
--- a/zone/gm_commands/npcedit.cpp
+++ b/zone/gm_commands/npcedit.cpp
@@ -549,7 +549,7 @@ void command_npcedit(Client *c, const Seperator *sep)
 	} else if (!strcasecmp(sep->arg[1], "meleetype")) {
 		if (sep->IsNumber(2)) {
 			auto     primary_type   = Strings::ToUnsignedInt(sep->arg[2]);
-			uint32_t secondary_type = sep->IsNumber(3) ? Strings::ToUnsignedInt(sep->arg[3]) : 0;
+			uint32_t secondary_type = sep->IsNumber(3) ? Strings::ToUnsignedInt(sep->arg[3]) : EQ::skills::SkillHandtoHand;
 
 			auto primary_skill   = EQ::skills::GetSkillName(static_cast<EQ::skills::SkillType>(primary_type));
 			auto secondary_skill = EQ::skills::GetSkillName(static_cast<EQ::skills::SkillType>(secondary_type));


### PR DESCRIPTION
# Notes
- We default to `Hand to Hand (Skill ID 28)` in the database, so we need to default to this in `#npcedit meleetype` in case the operator only sets the first melee type this avoids the NPC hitting with `1H Blunt (Skill ID 0)`.