### PR TITLE
[Bug Fix] Fix improper condition in Water LOS checks

### DIFF
--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -2413,7 +2413,7 @@ bool Client::CheckWaterAutoFireLoS(Mob* m)
 	}
 
 	return (
-		zone->watermap->InLiquid(GetPosition()) &&
+		zone->watermap->InLiquid(GetPosition()) ==
 		zone->watermap->InLiquid(m->GetPosition())
 	);
 }

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -7111,7 +7111,7 @@ bool Mob::CheckWaterLoS(Mob* m)
 	}
 
 	return (
-		zone->watermap->InLiquid(GetPosition()) &&
+		zone->watermap->InLiquid(GetPosition()) ==
 		zone->watermap->InLiquid(m->GetPosition())
 	);
 }


### PR DESCRIPTION
# Notes
- Oversight on my part, should've been `==`, not `&&`.