### PR TITLE
[Database] Fix database version checking edge case issue

### DIFF
--- a/common/database/database_update.h
+++ b/common/database/database_update.h
@@ -30,7 +30,7 @@ public:
 	bool HasPendingUpdates();
 private:
 	Database *m_database;
-	static bool CheckVersions(DatabaseVersion v, DatabaseVersion b);
+	static bool CheckVersionsUpToDate(DatabaseVersion v, DatabaseVersion b);
 	void InjectBotsVersionColumn();
 };
 


### PR DESCRIPTION
When a server operator does not have bots enabled, it is possible for `CheckVersions` to improperly return "not up to date" because bots version values can be incorrectly compared.

This fixes an edge case where if bots are **not** enabled - it will always return **up-to-date**