### PR TITLE
[Cleanup] Remove command_showpetspell in zone/command.h

### DIFF
--- a/zone/command.h
+++ b/zone/command.h
@@ -250,7 +250,6 @@ void command_showbonusstats(Client *c, const Seperator *sep);
 void command_showbuffs(Client *c, const Seperator *sep);
 void command_shownumhits(Client *c, const Seperator *sep);
 void command_shownpcgloballoot(Client *c, const Seperator *sep);
-void command_showpetspell(Client *c, const Seperator *sep);
 void command_showskills(Client *c, const Seperator *sep);
 void command_showspellslist(Client *c, const Seperator *sep);
 void command_showstats(Client *c, const Seperator *sep);


### PR DESCRIPTION
# Notes
- This is unused.