### PR TITLE
[Cleanup] Remove command_unlock from zone/command.h

### DIFF
--- a/zone/command.h
+++ b/zone/command.h
@@ -282,7 +282,6 @@ void command_trapinfo(Client *c, const Seperator *sep);
 void command_tune(Client *c, const Seperator *sep);
 void command_undye(Client *c, const Seperator *sep);
 void command_unfreeze(Client *c, const Seperator *sep);
-void command_unlock(Client *c, const Seperator *sep);
 void command_unmemspell(Client *c, const Seperator *sep);
 void command_unmemspells(Client *c, const Seperator *sep);
 void command_unscribespell(Client *c, const Seperator *sep);


### PR DESCRIPTION
# Notes
- This is unused.