### PR TITLE
[Commands] Cleanup #shownpcgloballoot and #showzonegloballoot Commands

### DIFF
--- a/zone/global_loot_manager.cpp
+++ b/zone/global_loot_manager.cpp
@@ -2,6 +2,7 @@
 #include "npc.h"
 #include "client.h"
 #include "zone.h"
+#include "dialogue_window.h"
 
 extern Zone *zone;
 
@@ -21,62 +22,77 @@ std::vector<int> GlobalLootManager::GetGlobalLootTables(NPC *mob) const
 	return tables;
 }
 
-void GlobalLootManager::ShowZoneGlobalLoot(Client *to) const
+void GlobalLootManager::ShowZoneGlobalLoot(Client *c) const
 {
-	int table_number = 1;
+	std::string global_loot_table;
+
+	global_loot_table += DialogueWindow::TableRow(
+		fmt::format(
+			"{}{}{}",
+			DialogueWindow::TableCell("ID"),
+			DialogueWindow::TableCell("Table Name"),
+			DialogueWindow::TableCell("Loottable ID")
+		)
+	);
 
 	for (auto &e : m_entries) {
-		to->Message(
-			Chat::White,
+		global_loot_table += DialogueWindow::TableRow(
 			fmt::format(
-				"Table {} | Name: {}",
-				table_number,
-				e.GetDescription()
-			).c_str()
+				"{}{}{}",
+				DialogueWindow::TableCell(Strings::Commify(e.GetID())),
+				DialogueWindow::TableCell(e.GetDescription()),
+				DialogueWindow::TableCell(Strings::Commify(e.GetLootTableID()))
+			)
 		);
-
-		to->Message(
-			Chat::White,
-			fmt::format(
-				"Table {} | Global Table ID: {} Loot Table ID: {}",
-				table_number,
-				e.GetID(),
-				e.GetLootTableID()
-			).c_str()
-		);
-
-		table_number++;
 	}
+
+	global_loot_table = DialogueWindow::Table(global_loot_table);
+
+	c->SendPopupToClient(
+		fmt::format(
+			"Global Loot for {} ({})",
+			zone->GetLongName(),
+			zone->GetZoneID()
+		).c_str(),
+		global_loot_table.c_str()
+	);
 }
 
-void GlobalLootManager::ShowNPCGlobalLoot(Client *to, NPC *who) const
+void GlobalLootManager::ShowNPCGlobalLoot(Client *c, NPC *t) const
 {
-	int table_number = 1;
+	std::string global_loot_table;
+
+	global_loot_table += DialogueWindow::TableRow(
+		fmt::format(
+			"{}{}{}",
+			DialogueWindow::TableCell("ID"),
+			DialogueWindow::TableCell("Table Name"),
+			DialogueWindow::TableCell("Loottable ID")
+		)
+	);
 
 	for (auto &e : m_entries) {
-		if (e.PassesRules(who)) {
-			to->Message(
-				Chat::White,
+		if (e.PassesRules(t)) {
+			global_loot_table += DialogueWindow::TableRow(
 				fmt::format(
-					"Table {} | Name: {}",
-					table_number,
-					e.GetDescription()
-				).c_str()
+					"{}{}{}",
+					DialogueWindow::TableCell(Strings::Commify(e.GetID())),
+					DialogueWindow::TableCell(e.GetDescription()),
+					DialogueWindow::TableCell(Strings::Commify(e.GetLootTableID()))
+				)
 			);
-
-			to->Message(
-				Chat::White,
-				fmt::format(
-					"Table {} | Global Table ID: {} Loot Table ID: {}",
-					table_number,
-					e.GetID(),
-					e.GetLootTableID()
-				).c_str()
-			);
-
-			table_number++;
 		}
 	}
+
+	global_loot_table = DialogueWindow::Table(global_loot_table);
+
+	c->SendPopupToClient(
+		fmt::format(
+			"Global Loot for {}",
+			c->GetTargetDescription(t)
+		).c_str(),
+		global_loot_table.c_str()
+	);
 }
 
 bool GlobalLootEntry::PassesRules(NPC *mob) const

--- a/zone/gm_commands/shownpcgloballoot.cpp
+++ b/zone/gm_commands/shownpcgloballoot.cpp
@@ -7,17 +7,8 @@ void command_shownpcgloballoot(Client *c, const Seperator *sep)
 		return;
 	}
 
-	auto target = c->GetTarget()->CastToNPC();
+	const auto t = c->GetTarget()->CastToNPC();
 
-	c->Message(
-		Chat::White,
-		fmt::format(
-			"Global loot for {} ({}).",
-			target->GetCleanName(),
-			target->GetNPCTypeID()
-		).c_str()
-	);
-
-	zone->ShowNPCGlobalLoot(c, target);
+	zone->ShowNPCGlobalLoot(c, t);
 }
 

--- a/zone/gm_commands/showzonegloballoot.cpp
+++ b/zone/gm_commands/showzonegloballoot.cpp
@@ -2,15 +2,6 @@
 
 void command_showzonegloballoot(Client *c, const Seperator *sep)
 {
-	c->Message(
-		Chat::White,
-		fmt::format(
-			"Global loot for {} ({}).",
-			zone->GetLongName(),
-			zone->GetZoneID()
-		).c_str()
-	);
-
 	zone->ShowZoneGlobalLoot(c);
 }
 

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -177,8 +177,8 @@ public:
 	inline Timer *GetInstanceTimer() { return Instance_Timer; }
 	inline void AddGlobalLootEntry(GlobalLootEntry &in) { return m_global_loot.AddEntry(in); }
 	inline void SetZoneHasCurrentTime(bool time) { zone_has_current_time = time; }
-	inline void ShowNPCGlobalLoot(Client *to, NPC *who) { m_global_loot.ShowNPCGlobalLoot(to, who); }
-	inline void ShowZoneGlobalLoot(Client *to) { m_global_loot.ShowZoneGlobalLoot(to); }
+	inline void ShowNPCGlobalLoot(Client *c, NPC *t) { m_global_loot.ShowNPCGlobalLoot(c, t); }
+	inline void ShowZoneGlobalLoot(Client *c) { m_global_loot.ShowZoneGlobalLoot(c); }
 	int GetZoneTotalBlockedSpells() { return zone_total_blocked_spells; }
 	int SaveTempItem(uint32 merchantid, uint32 npcid, uint32 item, int32 charges, bool sold = false);
 	int32 MobsAggroCount() { return aggroedmobs; }


### PR DESCRIPTION
# Notes
- Cleanup messages and logic.
- Utilize Dialogue Window tables.

# `#shownpcgloballoot`
![image](https://github.com/EQEmu/Server/assets/89047260/f20ca11f-c068-4728-943e-e25f2cdde627)

# `#showzonegloballoot`
![image](https://github.com/EQEmu/Server/assets/89047260/fd3c8b5c-0928-425a-9ed3-fb11cdae4bff)
