### PR TITLE
[Rules] Add ClientPetsUserOwnerNameInLastName rule

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -256,6 +256,7 @@ RULE_BOOL(Pets, UnTargetableSwarmPet, false, "Setting whether swarm pets should 
 RULE_REAL(Pets, PetPowerLevelCap, 10, "Maximum number of levels a player pet can go up with pet power")
 RULE_BOOL(Pets, CanTakeNoDrop, false, "Setting whether anyone can give no-drop items to pets")
 RULE_BOOL(Pets, LivelikeBreakCharmOnInvis, true, "Default: true will break charm on any type of invis (hide/ivu/iva/etc) false will only break if the pet can not see you (ex. you have an undead pet and cast IVU")
+RULE_BOOL(Pets, ClientPetsUseOwnerNameInLastName, true, "Disable this to keep client pet's last names from being owner_name's pet")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(GM)

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -2412,74 +2412,67 @@ void NPC::FillSpawnStruct(NewSpawn_Struct* ns, Mob* ForWho)
 void NPC::PetOnSpawn(NewSpawn_Struct* ns)
 {
 	//Basic settings to make sure swarm pets work properly.
-	Mob *swarmOwner = nullptr;
-	if  (GetSwarmOwner())
-	{
-		swarmOwner = entity_list.GetMobID(GetSwarmOwner());
+	Mob *swarm_owner = nullptr;
+	if (GetSwarmOwner()) {
+		swarm_owner = entity_list.GetMobID(GetSwarmOwner());
 	}
 
-	if  (swarmOwner != nullptr)
-	{
-		if(swarmOwner->IsClient())
-		{
+	if (swarm_owner) {
+		if (swarm_owner->IsClient()) {
 			SetPetOwnerClient(true); //Simple flag to determine if pet belongs to a client
 			SetAllowBeneficial(true);//Allow temp pets to receive buffs and heals if owner is client.
 			//This will allow CLIENT swarm pets NOT to be targeted with F8.
-			ns->spawn.targetable_with_hotkey = 0;
-			no_target_hotkey = 1;
-		}
-		else
-		{
+			ns->spawn.targetable_with_hotkey = false;
+			no_target_hotkey = true;
+		} else {
 			//NPC cast swarm pets should still be targetable with F8.
-			ns->spawn.targetable_with_hotkey = 1;
-			no_target_hotkey = 0;
+			ns->spawn.targetable_with_hotkey = true;
+			no_target_hotkey = false;
 		}
 
 		SetTempPet(true); //Simple mob flag for checking if temp pet
-		swarmOwner->SetTempPetsActive(true); //Necessary fail safe flag set if mob ever had a swarm pet to ensure they are removed.
-		swarmOwner->SetTempPetCount(swarmOwner->GetTempPetCount() + 1);
+		swarm_owner->SetTempPetsActive(true); //Necessary fail safe flag set if mob ever had a swarm pet to ensure they are removed.
+		swarm_owner->SetTempPetCount(swarm_owner->GetTempPetCount() + 1);
 
 		//Not recommended if using above (However, this will work better on older clients).
-		if (RuleB(Pets, UnTargetableSwarmPet))
-		{
-			ns->spawn.bodytype = 11;
-			if(!IsCharmed() && swarmOwner->IsClient()) {
-				std::string tmp_lastname = swarmOwner->GetName();
-				tmp_lastname += "'s Pet";
-				if (tmp_lastname.size() < sizeof(ns->spawn.lastName))
-					strn0cpy(ns->spawn.lastName, tmp_lastname.c_str(), sizeof(ns->spawn.lastName));
+		if (RuleB(Pets, UnTargetableSwarmPet)) {
+			ns->spawn.bodytype = BT_NoTarget;
+		}
+
+		if (
+			!IsCharmed() &&
+			swarm_owner->IsClient() &&
+			RuleB(Pets, ClientPetsUseOwnerNameInLastName)
+		) {
+			const auto &tmp_lastname = fmt::format("{}'s Pet", swarm_owner->GetName());
+			if (tmp_lastname.size() < sizeof(ns->spawn.lastName)) {
+				strn0cpy(ns->spawn.lastName, tmp_lastname.c_str(), sizeof(ns->spawn.lastName));
 			}
 		}
 
-		if (swarmOwner->IsNPC()) {
+		if (swarm_owner->IsNPC()) {
 			SetPetOwnerNPC(true);
 		}
-	}
-	else if(GetOwnerID())
-	{
+	} else if (GetOwnerID()) {
 		ns->spawn.is_pet = 1;
-		if (!IsCharmed())
-		{
-			Client *client = entity_list.GetClientByID(GetOwnerID());
-			if(client)
-			{
+
+		if (!IsCharmed()) {
+			const auto c = entity_list.GetClientByID(GetOwnerID());
+			if (c) {
 				SetPetOwnerClient(true);
-				std::string tmp_lastname = client->GetName();
-				tmp_lastname += "'s Pet";
-				if (tmp_lastname.size() < sizeof(ns->spawn.lastName))
-					strn0cpy(ns->spawn.lastName, tmp_lastname.c_str(), sizeof(ns->spawn.lastName));
-			}
-			else
-			{
-				if (entity_list.GetNPCByID(GetOwnerID()))
-				{
+				if (RuleB(Pets, ClientPetsUseOwnerNameInLastName)) {
+					const auto &tmp_lastname = fmt::format("{}'s Pet", c->GetName());
+					if (tmp_lastname.size() < sizeof(ns->spawn.lastName)) {
+						strn0cpy(ns->spawn.lastName, tmp_lastname.c_str(), sizeof(ns->spawn.lastName));
+					}
+				}
+			} else {
+				if (entity_list.GetNPCByID(GetOwnerID())) {
 					SetPetOwnerNPC(true);
 				}
 			}
 		}
-	}
-	else
-	{
+	} else {
 		ns->spawn.is_pet = 0;
 	}
 }

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -2444,7 +2444,7 @@ void NPC::PetOnSpawn(NewSpawn_Struct* ns)
 			swarm_owner->IsClient() &&
 			RuleB(Pets, ClientPetsUseOwnerNameInLastName)
 		) {
-			const auto &tmp_lastname = fmt::format("{}'s Pet", swarm_owner->GetName());
+			const auto& tmp_lastname = fmt::format("{}'s Pet", swarm_owner->GetName());
 			if (tmp_lastname.size() < sizeof(ns->spawn.lastName)) {
 				strn0cpy(ns->spawn.lastName, tmp_lastname.c_str(), sizeof(ns->spawn.lastName));
 			}
@@ -2461,7 +2461,7 @@ void NPC::PetOnSpawn(NewSpawn_Struct* ns)
 			if (c) {
 				SetPetOwnerClient(true);
 				if (RuleB(Pets, ClientPetsUseOwnerNameInLastName)) {
-					const auto &tmp_lastname = fmt::format("{}'s Pet", c->GetName());
+					const auto& tmp_lastname = fmt::format("{}'s Pet", c->GetName());
 					if (tmp_lastname.size() < sizeof(ns->spawn.lastName)) {
 						strn0cpy(ns->spawn.lastName, tmp_lastname.c_str(), sizeof(ns->spawn.lastName));
 					}


### PR DESCRIPTION
# Notes
- This rule defaults to `true` and maintains `Kinglykrab's Pet` as my pet's last name, disabling allows you to manually modify the last name or have pets with no last name.

# Image
![image](https://github.com/EQEmu/Server/assets/89047260/d39161c5-e91d-4f7a-a55c-3f712ffff7e8)