### PR TITLE
[Cleanup] Remove _ClearWaypints() from zone/npc.h

### DIFF
--- a/zone/npc.h
+++ b/zone/npc.h
@@ -637,7 +637,6 @@ protected:
 
 	//waypoint crap:
 	std::vector<wplist> Waypoints;
-	void _ClearWaypints();
 	int max_wp;
 	int save_wp;
 	glm::vec4 m_GuardPoint;


### PR DESCRIPTION
# Notes
- This is unused.