### PR TITLE
[Cleanup] Remove GetACMit() from zone/merc.h

### DIFF
--- a/zone/merc.h
+++ b/zone/merc.h
@@ -285,7 +285,6 @@ protected:
 private:
 
 	int32 CalcAC();
-	int32 GetACMit();
 	int32 GetACAvoid();
 	int32 acmod();
 	int32 CalcATK();


### PR DESCRIPTION
# Notes
- This is unused.