### PR TITLE
[Cleanup] Remove GetACAvoid() from zone/merc.h

### DIFF
--- a/zone/merc.h
+++ b/zone/merc.h
@@ -285,7 +285,6 @@ protected:
 private:
 
 	int32 CalcAC();
-	int32 GetACAvoid();
 	int32 CalcATK();
 	//int CalcHaste();
 


### PR DESCRIPTION
# Notes
- This is unused.