### PR TITLE
[Cleanup] Remove acmod() from zone/merc.h

### DIFF
--- a/zone/merc.h
+++ b/zone/merc.h
@@ -287,7 +287,6 @@ private:
 	int32 CalcAC();
 	int32 GetACMit();
 	int32 GetACAvoid();
-	int32 acmod();
 	int32 CalcATK();
 	//int CalcHaste();
 


### PR DESCRIPTION
# Notes
- This is unused.