### PR TITLE
[Bug Fix] Add check for underscores in botcreate command

### DIFF
--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -5512,7 +5512,8 @@ void bot_subcommand_bot_create(Client *c, const Seperator *sep)
 
 	std::string bot_name = sep->arg[1];
 	bot_name = Strings::UcFirst(bot_name);
-	if (bot_name.find('_') != std::string::npos) {
+
+	if (String::Contains(bot_name, "_")) {
 		c->Message(Chat::White, "Bot name cannot contain underscores!");
 		return;
 	}

--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -5513,7 +5513,7 @@ void bot_subcommand_bot_create(Client *c, const Seperator *sep)
 	std::string bot_name = sep->arg[1];
 	bot_name = Strings::UcFirst(bot_name);
 
-	if (String::Contains(bot_name, "_")) {
+	if (Strings::Contains(bot_name, "_")) {
 		c->Message(Chat::White, "Bot name cannot contain underscores!");
 		return;
 	}

--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -5512,6 +5512,11 @@ void bot_subcommand_bot_create(Client *c, const Seperator *sep)
 
 	std::string bot_name = sep->arg[1];
 	bot_name = Strings::UcFirst(bot_name);
+	if (bot_name.find('_') != std::string::npos) {
+		c->Message(Chat::White, "Bot name cannot contain underscores!");
+		return;
+	}
+	
 	if (arguments < 2 || !sep->IsNumber(2)) {
 		c->Message(Chat::White, "Invalid class!");
 		return;


### PR DESCRIPTION
### NOTES
Check for underscores in bot names as the server will replace with a space and add to the database. The bot can't be deleted/summoned or changed except by editing the database.

Other symbols seem to be properly ignored (they are just deleted, like # or *). I added a simple check to prevent names with _'s. 

### Steps to Recreate
**Command:** ^botcreate Tuday_bot_healer 1 1 1

![image](https://github.com/EQEmu/Server/assets/27604078/76a9f690-e15e-4ac9-b5e3-eda59a54ff3f)

The server replaces _'s with spaces and adds the bot. Here is an example:

![image](https://github.com/EQEmu/Server/assets/27604078/881b3a42-9357-4792-96b8-15d6e32bc044)

You can no longer delete/summon/alter the bot in anyway without editing SQL.

### Example after adding check

![image](https://github.com/EQEmu/Server/assets/27604078/1831a0c4-7970-411a-bd28-4496677069c6)

