### PR TITLE
[Quest API] Add Hate Entry Methods to Perl

### DIFF
--- a/zone/lua_hate_list.cpp
+++ b/zone/lua_hate_list.cpp
@@ -37,8 +37,8 @@ void Lua_HateEntry::SetHate(int64 value) {
 	self->stored_hate_amount = value;
 }
 
-int Lua_HateEntry::GetFrenzy() {
-	Lua_Safe_Call_Int();
+bool Lua_HateEntry::GetFrenzy() {
+	Lua_Safe_Call_Bool();
 	return self->is_entity_frenzy;
 }
 

--- a/zone/lua_hate_list.h
+++ b/zone/lua_hate_list.h
@@ -24,7 +24,7 @@ public:
 	void SetDamage(int64 value);
 	int64 GetHate();
 	void SetHate(int64 value);
-	int GetFrenzy();
+	bool GetFrenzy();
 	void SetFrenzy(bool value);
 };
 

--- a/zone/perl_hateentry.cpp
+++ b/zone/perl_hateentry.cpp
@@ -7,9 +7,19 @@
 #include "embperl.h"
 #include "hate_list.h"
 
+int64_t Perl_HateEntry_GetDamage(struct_HateList* self) // @categories Script Utility, Hate and Aggro
+{
+	return self->hatelist_damage;
+}
+
 Mob* Perl_HateEntry_GetEnt(struct_HateList* self) // @categories Script Utility, Hate and Aggro
 {
 	return self->entity_on_hatelist;
+}
+
+bool Perl_HateEntry_GetFrenzy(struct_HateList* self) // @categories Script Utility, Hate and Aggro
+{
+	return self->is_entity_frenzy;
 }
 
 int64_t Perl_HateEntry_GetHate(struct_HateList* self) // @categories Script Utility, Hate and Aggro
@@ -17,9 +27,24 @@ int64_t Perl_HateEntry_GetHate(struct_HateList* self) // @categories Script Util
 	return self->stored_hate_amount;
 }
 
-int64_t Perl_HateEntry_GetDamage(struct_HateList* self) // @categories Script Utility, Hate and Aggro
+void Perl_HateEntry_SetDamage(struct_HateList* self, int64 value) // @categories Script Utility, Hate and Aggro
 {
-	return self->hatelist_damage;
+	self->hatelist_damage = value;
+}
+
+void Perl_HateEntry_SetEnt(struct_HateList* self, Mob* mob) // @categories Script Utility, Hate and Aggro
+{
+	self->entity_on_hatelist = mob;
+}
+
+void Perl_HateEntry_SetFrenzy(struct_HateList* self, bool is_frenzy) // @categories Script Utility, Hate and Aggro
+{
+	self->is_entity_frenzy = is_frenzy;
+}
+
+void Perl_HateEntry_SetHate(struct_HateList* self, int64 value) // @categories Script Utility, Hate and Aggro
+{
+	self->stored_hate_amount = value;
 }
 
 void perl_register_hateentry()
@@ -29,7 +54,12 @@ void perl_register_hateentry()
 	auto package = perl.new_class<struct_HateList>("HateEntry");
 	package.add("GetDamage", &Perl_HateEntry_GetDamage);
 	package.add("GetEnt", &Perl_HateEntry_GetEnt);
+	package.add("GetFrenzy", &Perl_HateEntry_GetFrenzy);
 	package.add("GetHate", &Perl_HateEntry_GetHate);
+	package.add("SetDamage", &Perl_HateEntry_SetDamage);
+	package.add("SetEnt", &Perl_HateEntry_SetEnt);
+	package.add("SetFrenzy", &Perl_HateEntry_SetFrenzy);
+	package.add("SetHate", &Perl_HateEntry_SetHate);
 }
 
 #endif //EMBPERL_XS_CLASSES


### PR DESCRIPTION
# Perl
- Add `$hate_entry->GetFrenzy()`.
- Add `$hate_entry->SetDamage(value)`.
- Add `$hate_entry->SetEnt(mob)`.
- Add `$hate_entry->SetFrenzy(is_frenzy)`.
- Add `$hate_entry->SetHate(value)`.

# Lua
- Convert `hate_entry:GetFrenzy()` to `bool` instead of `int`, as `is_entity_frenzy` is a `bool`.