### PR TITLE
[Logging] Fix logging crash when % are sent through query logs

### DIFF
--- a/common/eqemu_logsys.cpp
+++ b/common/eqemu_logsys.cpp
@@ -446,6 +446,8 @@ void EQEmuLogSys::Out(
 	// remove this when we remove all legacy logs
 	bool ignore_log_legacy_format = (
 		log_category == Logs::Netcode ||
+		log_category == Logs::MySQLQuery ||
+		log_category == Logs::MySQLError ||
 		log_category == Logs::PacketServerClient ||
 		log_category == Logs::PacketClientServer ||
 		log_category == Logs::PacketServerToServer


### PR DESCRIPTION
As seen here http://spire.akkadius.com/dev/release/22.16.0?id=5229

We eventually need to get rid of all legacy logging that does not use `vStringFormat` formatting. If a string is passed with a `%` it can be interpreted as a `printf` code http://personal.ee.surrey.ac.uk/Personal/R.Bowden/C/printf.html