### PR TITLE
[Database] Set multi statements off when returning early

### DIFF
--- a/common/dbcore.cpp
+++ b/common/dbcore.cpp
@@ -365,6 +365,8 @@ MySQLRequestResult DBcore::QueryDatabaseMulti(const std::string &query)
 				mysql_free_result(res);
 			}
 
+			SetMultiStatementsOff();
+
 			return r;
 		}
 	}
@@ -417,6 +419,8 @@ MySQLRequestResult DBcore::QueryDatabaseMulti(const std::string &query)
 			std::string error_message = mysql_error(mysql);
 			r.SetErrorMessage(error_message);
 			r.SetErrorNumber(mysql_errno(mysql));
+
+			SetMultiStatementsOff();
 
 			// we handle errors elsewhere
 			return r;


### PR DESCRIPTION
When we run a multi-statement query, sometimes we return early and don't quite get to the end of the function to turn multi-statements back off