### PR TITLE
[Quest API] Add GetClassAbbreviation() and GetRaceAbbreviation() to Perl/Lua

### DIFF
--- a/common/classes.cpp
+++ b/common/classes.cpp
@@ -755,7 +755,7 @@ uint8 ClassArmorType(uint8 class_id)
 const std::string GetPlayerClassAbbreviation(uint8 class_id)
 {
 	if (!EQ::ValueWithin(class_id, WARRIOR, BERSERKER)) {
-		return std::string();
+		return std::string("UNK");
 	}
 
 	switch (class_id) {
@@ -793,7 +793,7 @@ const std::string GetPlayerClassAbbreviation(uint8 class_id)
 			return "BER";
 	}
 
-	return std::string();
+	return std::string("UNK");
 }
 
 bool IsPlayerClass(uint8 class_id) {

--- a/common/races.cpp
+++ b/common/races.cpp
@@ -2249,7 +2249,7 @@ const char* GetGenderName(uint32 gender_id) {
 const std::string GetPlayerRaceAbbreviation(uint16 race_id)
 {
 	if (!IsPlayerRace(race_id)) {
-		return std::string();
+		return std::string("UNK");
 	}
 
 	switch (race_id) {
@@ -2287,7 +2287,7 @@ const std::string GetPlayerRaceAbbreviation(uint16 race_id)
 			return "DRK";
 	}
 
-	return std::string();
+	return std::string("UNK");
 }
 
 bool IsPlayerRace(uint16 race_id) {

--- a/zone/lua_bot.cpp
+++ b/zone/lua_bot.cpp
@@ -494,6 +494,16 @@ void Lua_Bot::AddItem(const luabind::object& item_table) {
 	}
 }
 
+std::string Lua_Bot::GetClassAbbreviation() {
+	Lua_Safe_Call_String();
+	return GetPlayerClassAbbreviation(self->GetClass());
+}
+
+std::string Lua_Bot::GetRaceAbbreviation() {
+	Lua_Safe_Call_String();
+	return GetPlayerRaceAbbreviation(self->GetBaseRace());
+}
+
 luabind::scope lua_register_bot() {
 	return luabind::class_<Lua_Bot, Lua_Mob>("Bot")
 	.def(luabind::constructor<>())
@@ -541,6 +551,7 @@ luabind::scope lua_register_bot() {
 	.def("GetBotID", (uint32(Lua_Bot::*)(void))&Lua_Bot::GetBotID)
 	.def("GetBotItem", (Lua_ItemInst(Lua_Bot::*)(uint16))&Lua_Bot::GetBotItem)
 	.def("GetBotItemIDBySlot", (uint32(Lua_Bot::*)(uint16))&Lua_Bot::GetBotItemIDBySlot)
+	.def("GetClassAbbreviation", (std::string(Lua_Bot::*)(void))&Lua_Bot::GetClassAbbreviation)
 	.def("GetExpansionBitmask", (int(Lua_Bot::*)(void))&Lua_Bot::GetExpansionBitmask)
 	.def("GetGroup", (Lua_Group(Lua_Bot::*)(void))&Lua_Bot::GetGroup)
 	.def("GetHealAmount", (int(Lua_Bot::*)(void))&Lua_Bot::GetHealAmount)
@@ -548,6 +559,7 @@ luabind::scope lua_register_bot() {
 	.def("GetItemAt", (Lua_ItemInst(Lua_Bot::*)(int16))&Lua_Bot::GetItemAt)
 	.def("GetItemIDAt", (int(Lua_Bot::*)(int16))&Lua_Bot::GetItemIDAt)
 	.def("GetOwner", (Lua_Mob(Lua_Bot::*)(void))&Lua_Bot::GetOwner)
+	.def("GetRaceAbbreviation", (std::string(Lua_Bot::*)(void))&Lua_Bot::GetRaceAbbreviation)
 	.def("GetRawItemAC", (int(Lua_Bot::*)(void))&Lua_Bot::GetRawItemAC)
 	.def("GetSpellDamage", (int(Lua_Bot::*)(void))&Lua_Bot::GetSpellDamage)
 	.def("HasAugmentEquippedByID", (bool(Lua_Bot::*)(uint32))&Lua_Bot::HasAugmentEquippedByID)

--- a/zone/lua_bot.h
+++ b/zone/lua_bot.h
@@ -1,3 +1,4 @@
+\
 #ifndef EQEMU_LUA_BOT_H
 #define EQEMU_LUA_BOT_H
 #ifdef LUA_EQEMU
@@ -65,6 +66,8 @@ public:
 	Lua_ItemInst GetItemAt(int16 slot_id);
 	int GetItemIDAt(int16 slot_id);
 	void SendSpellAnim(uint16 target_id, uint16 spell_id);
+	std::string GetClassAbbreviation();
+	std::string GetRaceAbbreviation();
 
 	void ApplySpell(int spell_id);
 	void ApplySpell(int spell_id, int duration);

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3060,6 +3060,18 @@ uint32 Lua_Client::GetEXPForLevel(uint16 check_level)
 	return self->GetEXPForLevel(check_level);
 }
 
+std::string Lua_Client::GetClassAbbreviation()
+{
+	Lua_Safe_Call_String();
+	return GetPlayerClassAbbreviation(self->GetBaseClass());
+}
+
+std::string Lua_Client::GetRaceAbbreviation()
+{
+	Lua_Safe_Call_String();
+	return GetPlayerRaceAbbreviation(self->GetBaseRace());
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 	.def(luabind::constructor<>())
@@ -3212,6 +3224,7 @@ luabind::scope lua_register_client() {
 	.def("GetCarriedMoney", (uint64(Lua_Client::*)(void))&Lua_Client::GetCarriedMoney)
 	.def("GetCarriedPlatinum", (uint32(Lua_Client::*)(void))&Lua_Client::GetCarriedPlatinum)
 	.def("GetCharacterFactionLevel", (int(Lua_Client::*)(int))&Lua_Client::GetCharacterFactionLevel)
+	.def("GetClassAbbreviation", (std::string(Lua_Client::*)(void))&Lua_Client::GetClassAbbreviation)
 	.def("GetClassBitmask", (int(Lua_Client::*)(void))&Lua_Client::GetClassBitmask)
 	.def("GetClientMaxLevel", (int(Lua_Client::*)(void))&Lua_Client::GetClientMaxLevel)
 	.def("GetClientVersion", (int(Lua_Client::*)(void))&Lua_Client::GetClientVersion)
@@ -3278,6 +3291,7 @@ luabind::scope lua_register_client() {
 	.def("GetRadiantCrystals", (uint32(Lua_Client::*)(void))&Lua_Client::GetRadiantCrystals)
 	.def("GetRaid", (Lua_Raid(Lua_Client::*)(void))&Lua_Client::GetRaid)
 	.def("GetRaidPoints", (uint32(Lua_Client::*)(void))&Lua_Client::GetRaidPoints)
+	.def("GetRaceAbbreviation", (std::string(Lua_Client::*)(void))&Lua_Client::GetRaceAbbreviation)
 	.def("GetRawItemAC", (int(Lua_Client::*)(void))&Lua_Client::GetRawItemAC)
 	.def("GetRawSkill", (int(Lua_Client::*)(int))&Lua_Client::GetRawSkill)
 	.def("GetRecipeMadeCount", (int(Lua_Client::*)(uint32))&Lua_Client::GetRecipeMadeCount)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -469,6 +469,8 @@ public:
 	bool IsAutoAttackEnabled();
 	bool IsAutoFireEnabled();
 	uint32 GetEXPForLevel(uint16 check_level);
+	std::string GetClassAbbreviation();
+	std::string GetRaceAbbreviation();
 
 	void ApplySpell(int spell_id);
 	void ApplySpell(int spell_id, int duration);

--- a/zone/perl_bot.cpp
+++ b/zone/perl_bot.cpp
@@ -445,6 +445,16 @@ void Perl_Bot_AddItem(Bot *self, perl::reference table_ref)
 	}
 }
 
+std::string Perl_Bot_GetClassAbbreviation(Bot* self)
+{
+	return GetPlayerClassAbbreviation(self->GetClass());
+}
+
+std::string Perl_Bot_GetRaceAbbreviation(Bot* self)
+{
+	return GetPlayerRaceAbbreviation(self->GetBaseRace());
+}
+
 void perl_register_bot()
 {
 	perl::interpreter state(PERL_GET_THX);
@@ -492,6 +502,7 @@ void perl_register_bot()
 	package.add("GetBotID", &Perl_Bot_GetBotID);
 	package.add("GetBotItem", &Perl_Bot_GetBotItem);
 	package.add("GetBotItemIDBySlot", &Perl_Bot_GetBotItemIDBySlot);
+	package.add("GetClassAbbreviation", &Perl_Bot_GetClassAbbreviation);
 	package.add("GetExpansionBitmask", &Perl_Bot_GetExpansionBitmask);
 	package.add("GetGroup", &Perl_Bot_GetGroup);
 	package.add("GetHealAmount", &Perl_Bot_GetHealAmount);
@@ -499,6 +510,7 @@ void perl_register_bot()
 	package.add("GetItemAt", &Perl_Bot_GetItemAt);
 	package.add("GetItemIDAt", &Perl_Bot_GetItemIDAt);
 	package.add("GetOwner", &Perl_Bot_GetOwner);
+	package.add("GetRaceAbbreviation", &Perl_Bot_GetRaceAbbreviation);
 	package.add("GetRawItemAC", &Perl_Bot_GetRawItemAC);
 	package.add("GetSpellDamage", &Perl_Bot_GetSpellDamage);
 	package.add("HasAugmentEquippedByID", &Perl_Bot_HasAugmentEquippedByID);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -2917,6 +2917,16 @@ uint32 Perl_Client_GetEXPForLevel(Client* self, uint16 check_level)
 	return self->GetEXPForLevel(check_level);
 }
 
+std::string Perl_Client_GetClassAbbreviation(Client* self)
+{
+	return GetPlayerClassAbbreviation(self->GetBaseClass());
+}
+
+std::string Perl_Client_GetRaceAbbreviation(Client* self)
+{
+	return GetPlayerRaceAbbreviation(self->GetBaseRace());
+}
+
 void perl_register_client()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3067,6 +3077,7 @@ void perl_register_client()
 	package.add("GetCarriedMoney", &Perl_Client_GetCarriedMoney);
 	package.add("GetCarriedPlatinum", &Perl_Client_GetCarriedPlatinum);
 	package.add("GetCharacterFactionLevel", &Perl_Client_GetCharacterFactionLevel);
+	package.add("GetClassAbbreviation", &Perl_Client_GetClassAbbreviation);
 	package.add("GetClassBitmask", &Perl_Client_GetClassBitmask);
 	package.add("GetClientMaxLevel", &Perl_Client_GetClientMaxLevel);
 	package.add("GetClientVersion", &Perl_Client_GetClientVersion);
@@ -3133,6 +3144,7 @@ void perl_register_client()
 	package.add("GetMoney", &Perl_Client_GetMoney);
 	package.add("GetPVP", &Perl_Client_GetPVP);
 	package.add("GetPVPPoints", &Perl_Client_GetPVPPoints);
+	package.add("GetRaceAbbreviation", &Perl_Client_GetRaceAbbreviation);
 	package.add("GetRaceBitmask", &Perl_Client_GetRaceBitmask);
 	package.add("GetRadiantCrystals", &Perl_Client_GetRadiantCrystals);
 	package.add("GetRaid", &Perl_Client_GetRaid);


### PR DESCRIPTION
# Perl
- Add `$bot->GetClassAbbreviation()`.
- Add `$bot->GetRaceAbbreviation()`.
- Add `$client->GetClassAbbreviation()`.
- Add `$client->GetRaceAbbreviation()`.

# Lua
- Add `bot:GetClassAbbreviation()`.
- Add `bot:GetRaceAbbreviation()`.
- Add `client:GetClassAbbreviation()`.
- Add `client:GetRaceAbbreviation()`.

# Notes
- Allows operators to easily get a player race/class abbreviation, example being `Warrior` as `WAR`.