### PR TITLE
[Quest API] Add missing Item Methods to Perl/Lua.

### DIFF
--- a/common/languages.h
+++ b/common/languages.h
@@ -48,5 +48,7 @@
 #define LANG_HADAL			26
 #define LANG_UNKNOWN	27
 
+#define MAX_LANGUAGE_SKILL 100
+
 #endif
 

--- a/zone/lua_iteminst.cpp
+++ b/zone/lua_iteminst.cpp
@@ -3,6 +3,7 @@
 #include <luabind/luabind.hpp>
 #include <luabind/object.hpp>
 
+#include "../common/languages.h"
 #include "masterentity.h"
 #include "lua_iteminst.h"
 #include "lua_item.h"
@@ -55,12 +56,12 @@ bool Lua_ItemInst::IsStackable() {
 	return self->IsStackable();
 }
 
-bool Lua_ItemInst::IsEquipable(int race, int class_) {
+bool Lua_ItemInst::IsEquipable(uint16 race_bitmask, uint16 class_bitmask) {
 	Lua_Safe_Call_Bool();
-	return self->IsEquipable(race, class_);
+	return self->IsEquipable(race_bitmask, class_bitmask);
 }
 
-bool Lua_ItemInst::IsEquipable(int slot_id) {
+bool Lua_ItemInst::IsEquipable(int16 slot_id) {
 	Lua_Safe_Call_Bool();
 	return self->IsEquipable(slot_id);
 }
@@ -80,9 +81,9 @@ bool Lua_ItemInst::IsExpendable() {
 	return self->IsExpendable();
 }
 
-Lua_ItemInst Lua_ItemInst::GetItem(int slot) {
+Lua_ItemInst Lua_ItemInst::GetItem(uint8 slot_id) {
 	Lua_Safe_Call_Class(Lua_ItemInst);
-	return Lua_ItemInst(self->GetItem(slot));
+	return Lua_ItemInst(self->GetItem(slot_id));
 }
 
 Lua_Item Lua_ItemInst::GetItem() {
@@ -90,29 +91,29 @@ Lua_Item Lua_ItemInst::GetItem() {
 	return Lua_Item(self->GetItem());
 }
 
-Lua_Item Lua_ItemInst::GetUnscaledItem(int slot) {
+Lua_Item Lua_ItemInst::GetUnscaledItem() {
 	Lua_Safe_Call_Class(Lua_Item);
 	return self->GetUnscaledItem();
 }
 
-uint32 Lua_ItemInst::GetItemID(int slot) {
+uint32 Lua_ItemInst::GetItemID(uint8 slot_id) {
 	Lua_Safe_Call_Int();
-	return self->GetItemID(slot);
+	return self->GetItemID(slot_id);
 }
 
-int Lua_ItemInst::GetTotalItemCount() {
+uint8 Lua_ItemInst::GetTotalItemCount() {
 	Lua_Safe_Call_Int();
 	return self->GetTotalItemCount();
 }
 
-Lua_ItemInst Lua_ItemInst::GetAugment(int slot) {
+Lua_ItemInst Lua_ItemInst::GetAugment(uint8 slot_id) {
 	Lua_Safe_Call_Class(Lua_ItemInst);
-	return self->GetAugment(slot);
+	return self->GetAugment(slot_id);
 }
 
-uint32 Lua_ItemInst::GetAugmentItemID(int slot) {
+uint32 Lua_ItemInst::GetAugmentItemID(uint8 slot_id) {
 	Lua_Safe_Call_Int();
-	return self->GetAugmentItemID(slot);
+	return self->GetAugmentItemID(slot_id);
 }
 
 bool Lua_ItemInst::IsAugmented() {
@@ -240,12 +241,12 @@ void Lua_ItemInst::AddExp(uint32 exp) {
 	self->AddExp(exp);
 }
 
-int Lua_ItemInst::GetMaxEvolveLvl() {
+int8 Lua_ItemInst::GetMaxEvolveLvl() {
 	Lua_Safe_Call_Int();
 	return self->GetMaxEvolveLvl();
 }
 
-uint32 Lua_ItemInst::GetKillsNeeded(int current_level) {
+uint32 Lua_ItemInst::GetKillsNeeded(uint8 current_level) {
 	Lua_Safe_Call_Int();
 	return self->GetKillsNeeded(current_level);
 }
@@ -290,6 +291,23 @@ int Lua_ItemInst::RemoveTaskDeliveredItems() {
 	return self->RemoveTaskDeliveredItems();
 }
 
+std::string Lua_ItemInst::GetName() {
+	Lua_Safe_Call_String();
+	return self->GetItem()->Name;
+}
+
+void Lua_ItemInst::ItemSay(const char* text) // @categories Inventory and Items
+{
+	Lua_Safe_Call_Void();
+	quest_manager.GetInitiator()->ChannelMessageSend(self->GetItem()->Name, 0, ChatChannel_Say, LANG_COMMON_TONGUE, MAX_LANGUAGE_SKILL, text);
+}
+
+void Lua_ItemInst::ItemSay(const char* text, uint8 language_id) // @categories Inventory and Items
+{
+	Lua_Safe_Call_Void();
+	quest_manager.GetInitiator()->ChannelMessageSend(self->GetItem()->Name, 0, ChatChannel_Say, language_id, MAX_LANGUAGE_SKILL, text);
+}
+
 luabind::scope lua_register_iteminst() {
 	return luabind::class_<Lua_ItemInst>("ItemInst")
 	.def(luabind::constructor<>())
@@ -313,26 +331,31 @@ luabind::scope lua_register_iteminst() {
 	.def("GetExp", (uint32(Lua_ItemInst::*)(void))&Lua_ItemInst::GetExp)
 	.def("GetID", (uint32(Lua_ItemInst::*)(void))&Lua_ItemInst::GetID)
 	.def("GetItem", (Lua_Item(Lua_ItemInst::*)(void))&Lua_ItemInst::GetItem)
-	.def("GetItem", (Lua_ItemInst(Lua_ItemInst::*)(int))&Lua_ItemInst::GetItem)
+	.def("GetItem", (Lua_ItemInst(Lua_ItemInst::*)(uint8))&Lua_ItemInst::GetItem)
 	.def("GetItemID", (uint32(Lua_ItemInst::*)(int))&Lua_ItemInst::GetItemID)
 	.def("GetItemScriptID", (uint32(Lua_ItemInst::*)(void))&Lua_ItemInst::GetItemScriptID)
 	.def("GetKillsNeeded", (uint32(Lua_ItemInst::*)(int))&Lua_ItemInst::GetKillsNeeded)
 	.def("GetMaxEvolveLvl", (int(Lua_ItemInst::*)(void))&Lua_ItemInst::GetMaxEvolveLvl)
+	.def("GetName", (std::string(Lua_ItemInst::*)(void))&Lua_ItemInst::GetName)
 	.def("GetPrice", (uint32(Lua_ItemInst::*)(void))&Lua_ItemInst::GetPrice)
 	.def("GetTaskDeliveredCount", &Lua_ItemInst::GetTaskDeliveredCount)
-	.def("GetTotalItemCount", (int(Lua_ItemInst::*)(void))&Lua_ItemInst::GetTotalItemCount)
+	.def("GetTotalItemCount", (uint8(Lua_ItemInst::*)(void))&Lua_ItemInst::GetTotalItemCount)
 	.def("GetUnscaledItem", (Lua_ItemInst(Lua_ItemInst::*)(int))&Lua_ItemInst::GetUnscaledItem)
 	.def("IsAmmo", (bool(Lua_ItemInst::*)(void))&Lua_ItemInst::IsAmmo)
+	.def("IsAttuned", (bool(Lua_ItemInst::*)(void))&Lua_ItemInst::IsInstNoDrop)
 	.def("IsAugmentable", (bool(Lua_ItemInst::*)(void))&Lua_ItemInst::IsAugmentable)
 	.def("IsAugmented", (bool(Lua_ItemInst::*)(void))&Lua_ItemInst::IsAugmented)
-	.def("IsEquipable", (bool(Lua_ItemInst::*)(int))&Lua_ItemInst::IsEquipable)
-	.def("IsEquipable", (bool(Lua_ItemInst::*)(int,int))&Lua_ItemInst::IsEquipable)
+	.def("IsEquipable", (bool(Lua_ItemInst::*)(int16))&Lua_ItemInst::IsEquipable)
+	.def("IsEquipable", (bool(Lua_ItemInst::*)(uint16,uint16))&Lua_ItemInst::IsEquipable)
 	.def("IsExpendable", (bool(Lua_ItemInst::*)(void))&Lua_ItemInst::IsExpendable)
 	.def("IsInstNoDrop", (bool(Lua_ItemInst::*)(void))&Lua_ItemInst::IsInstNoDrop)
 	.def("IsStackable", (bool(Lua_ItemInst::*)(void))&Lua_ItemInst::IsStackable)
 	.def("IsType", (bool(Lua_ItemInst::*)(int))&Lua_ItemInst::IsType)
 	.def("IsWeapon", (bool(Lua_ItemInst::*)(void))&Lua_ItemInst::IsWeapon)
+	.def("ItemSay", (void(Lua_ItemInst::*)(const char*))&Lua_ItemInst::ItemSay)
+	.def("ItemSay", (void(Lua_ItemInst::*)(const char*, uint8))&Lua_ItemInst::ItemSay)
 	.def("RemoveTaskDeliveredItems", &Lua_ItemInst::RemoveTaskDeliveredItems)
+	.def("SetAttuned", (void(Lua_ItemInst::*)(bool))&Lua_ItemInst::SetInstNoDrop)
 	.def("SetCharges", (void(Lua_ItemInst::*)(int))&Lua_ItemInst::SetCharges)
 	.def("SetColor", (void(Lua_ItemInst::*)(uint32))&Lua_ItemInst::SetColor)
 	.def("SetCustomData", (void(Lua_ItemInst::*)(const std::string&,bool))&Lua_ItemInst::SetCustomData)

--- a/zone/lua_iteminst.h
+++ b/zone/lua_iteminst.h
@@ -37,19 +37,18 @@ public:
 
 	bool IsType(int item_class);
 	bool IsStackable();
-	bool IsEquipable(int race, int class_);
-	bool IsEquipable(int slot_id);
+	bool IsEquipable(uint16 race_bitmask, uint16 class_bitmask);
+	bool IsEquipable(int16 slot_id);
 	bool IsAugmentable();
 	int GetAugmentType();
 	bool IsExpendable();
-	Lua_ItemInst GetItem(int slot);
+	Lua_ItemInst GetItem(uint8 slot_id);
 	Lua_Item GetItem();
-	void SetItem(Lua_Item item);
-	Lua_Item GetUnscaledItem(int slot);
-	uint32 GetItemID(int slot);
-	int GetTotalItemCount();
-	Lua_ItemInst GetAugment(int slot);
-	uint32 GetAugmentItemID(int slot);
+	Lua_Item GetUnscaledItem();
+	uint32 GetItemID(uint8 slot_id);
+	uint8 GetTotalItemCount();
+	Lua_ItemInst GetAugment(uint8 slot_id);
+	uint32 GetAugmentItemID(uint8 slot_id);
 	bool IsAugmented();
 	bool IsWeapon();
 	bool IsAmmo();
@@ -75,8 +74,8 @@ public:
 	uint32 GetExp();
 	void SetExp(uint32 exp);
 	void AddExp(uint32 exp);
-	int GetMaxEvolveLvl();
-	uint32 GetKillsNeeded(int current_level);
+	int8 GetMaxEvolveLvl();
+	uint32 GetKillsNeeded(uint8 current_level);
 	Lua_ItemInst Clone();
 	void SetTimer(std::string name, uint32 time);
 	void StopTimer(std::string name);
@@ -85,6 +84,10 @@ public:
 	int CountAugmentByID(uint32 item_id);
 	int GetTaskDeliveredCount();
 	int RemoveTaskDeliveredItems();
+	std::string GetName();
+	bool IsAttuned();
+	void ItemSay(const char* text);
+	void ItemSay(const char* text, uint8 language_id);
 
 private:
 	bool cloned_;

--- a/zone/perl_questitem.cpp
+++ b/zone/perl_questitem.cpp
@@ -1,4 +1,5 @@
 #include "../common/features.h"
+#include "../common/languages.h"
 #include "client.h"
 
 #ifdef EMBPERL_XS_CLASSES
@@ -20,12 +21,12 @@ void Perl_QuestItem_SetScale(EQ::ItemInstance* self, float scale_multiplier) // 
 
 void Perl_QuestItem_ItemSay(EQ::ItemInstance* self, const char* text) // @categories Inventory and Items
 {
-	quest_manager.GetInitiator()->ChannelMessageSend(self->GetItem()->Name, 0, 8, 0, 100, text);
+	quest_manager.GetInitiator()->ChannelMessageSend(self->GetItem()->Name, 0, ChatChannel_Say, LANG_COMMON_TONGUE, MAX_LANGUAGE_SKILL, text);
 }
 
-void Perl_QuestItem_ItemSay(EQ::ItemInstance* self, const char* text, int language_id) // @categories Inventory and Items
+void Perl_QuestItem_ItemSay(EQ::ItemInstance* self, const char* text, uint8 language_id) // @categories Inventory and Items
 {
-	quest_manager.GetInitiator()->ChannelMessageSend(self->GetItem()->Name, 0, 8, language_id, 100, text);
+	quest_manager.GetInitiator()->ChannelMessageSend(self->GetItem()->Name, 0, ChatChannel_Say, language_id, MAX_LANGUAGE_SKILL, text);
 }
 
 bool Perl_QuestItem_IsType(EQ::ItemInstance* self, int type) // @categories Inventory and Items
@@ -43,7 +44,7 @@ int Perl_QuestItem_GetCharges(EQ::ItemInstance* self) // @categories Inventory a
 	return self->GetCharges();
 }
 
-EQ::ItemInstance* Perl_QuestItem_GetAugment(EQ::ItemInstance* self, int slot_id) // @categories Inventory and Items
+EQ::ItemInstance* Perl_QuestItem_GetAugment(EQ::ItemInstance* self, uint8 slot_id) // @categories Inventory and Items
 {
 	return self->GetAugment(slot_id);
 }
@@ -83,26 +84,218 @@ int Perl_QuestItem_RemoveTaskDeliveredItems(EQ::ItemInstance* self)
 	return self->RemoveTaskDeliveredItems();
 }
 
+void Perl_QuestItem_AddEXP(EQ::ItemInstance* self, uint32 exp)
+{
+	self->AddExp(exp);
+}
+
+void Perl_QuestItem_ClearTimers(EQ::ItemInstance* self)
+{
+	self->ClearTimers();
+}
+
+EQ::ItemInstance* Perl_QuestItem_Clone(EQ::ItemInstance* self)
+{
+	return self->Clone();
+}
+
+void Perl_QuestItem_DeleteCustomData(EQ::ItemInstance* self, std::string identifier)
+{
+	self->DeleteCustomData(identifier);
+}
+
+uint32 Perl_QuestItem_GetAugmentItemID(EQ::ItemInstance* self, uint8 slot_id)
+{
+	return self->GetAugmentItemID(slot_id);
+}
+
+int Perl_QuestItem_GetAugmentType(EQ::ItemInstance* self)
+{
+	return self->GetAugmentType();
+}
+
+uint32 Perl_QuestItem_GetColor(EQ::ItemInstance* self)
+{
+	return self->GetColor();
+}
+
+std::string Perl_QuestItem_GetCustomData(EQ::ItemInstance* self, std::string identifier)
+{
+	return self->GetCustomData(identifier);
+}
+
+std::string Perl_QuestItem_GetCustomDataString(EQ::ItemInstance* self)
+{
+	return self->GetCustomDataString();
+}
+
+uint32 Perl_QuestItem_GetEXP(EQ::ItemInstance* self)
+{
+	return self->GetExp();
+}
+
+EQ::ItemInstance* Perl_QuestItem_GetItem(EQ::ItemInstance* self, uint8 slot_id)
+{
+	return self->GetItem(slot_id);
+}
+
+uint32 Perl_QuestItem_GetItemID(EQ::ItemInstance* self, uint8 slot_id)
+{
+	return self->GetItemID(slot_id);
+}
+
+uint32 Perl_QuestItem_GetItemScriptID(EQ::ItemInstance* self)
+{
+	return self->GetItemScriptID();
+}
+
+uint32 Perl_QuestItem_GetKillsNeeded(EQ::ItemInstance* self, uint8 current_level)
+{
+	return self->GetKillsNeeded(current_level);
+}
+
+int8 Perl_QuestItem_GetMaxEvolveLevel(EQ::ItemInstance* self)
+{
+	return self->GetMaxEvolveLvl();
+}
+
+uint32 Perl_QuestItem_GetPrice(EQ::ItemInstance* self)
+{
+	return self->GetPrice();
+}
+
+uint8 Perl_QuestItem_GetTotalItemCount(EQ::ItemInstance* self)
+{
+	return self->GetTotalItemCount();
+}
+
+bool Perl_QuestItem_IsAmmo(EQ::ItemInstance* self)
+{
+	return self->IsAmmo();
+}
+
+bool Perl_QuestItem_IsAugmentable(EQ::ItemInstance* self)
+{
+	return self->IsAugmentable();
+}
+
+bool Perl_QuestItem_IsAugmented(EQ::ItemInstance* self)
+{
+	return self->IsAugmented();
+}
+
+bool Perl_QuestItem_IsEquipable(EQ::ItemInstance* self, int16 slot_id)
+{
+	return self->IsEquipable(slot_id);
+}
+
+bool Perl_QuestItem_IsEquipable(EQ::ItemInstance* self, uint16 race_bitmask, uint16 class_bitmask)
+{
+	return self->IsEquipable(race_bitmask, class_bitmask);
+}
+
+bool Perl_QuestItem_IsExpendable(EQ::ItemInstance* self)
+{
+	return self->IsExpendable();
+}
+
+bool Perl_QuestItem_IsWeapon(EQ::ItemInstance* self)
+{
+	return self->IsWeapon();
+}
+
+void Perl_QuestItem_SetAttuned(EQ::ItemInstance* self, bool is_attuned)
+{
+	self->SetAttuned(is_attuned);
+}
+
+void Perl_QuestItem_SetColor(EQ::ItemInstance* self, uint32 color)
+{
+	self->SetColor(color);
+}
+
+void Perl_QuestItem_SetEXP(EQ::ItemInstance* self, uint32 exp)
+{
+	self->SetExp(exp);
+}
+
+void Perl_QuestItem_SetPrice(EQ::ItemInstance* self, uint32 price)
+{
+	self->SetPrice(price);
+}
+
+void Perl_QuestItem_SetScaling(EQ::ItemInstance* self, bool is_scaling)
+{
+	self->SetScaling(is_scaling);
+}
+
+void Perl_QuestItem_SetTimer(EQ::ItemInstance* self, std::string timer_name, uint32 timer)
+{
+	self->SetTimer(timer_name, timer);
+}
+
+void Perl_QuestItem_StopTimer(EQ::ItemInstance* self, std::string timer_name)
+{
+	self->StopTimer(timer_name);
+}
+
 void perl_register_questitem()
 {
 	perl::interpreter perl(PERL_GET_THX);
 
 	auto package = perl.new_class<EQ::ItemInstance>("QuestItem");
+	package.add("AddEXP", &Perl_QuestItem_AddEXP);
+	package.add("ClearTimers", &Perl_QuestItem_ClearTimers);
+	package.add("Clone", &Perl_QuestItem_Clone);
 	package.add("ContainsAugmentByID", &Perl_QuestItem_ContainsAugmentByID);
 	package.add("CountAugmentByID", &Perl_QuestItem_CountAugmentByID);
+	package.add("DeleteCustomData", &Perl_QuestItem_DeleteCustomData);
 	package.add("GetAugment", &Perl_QuestItem_GetAugment);
+	package.add("GetAugmentItemID", &Perl_QuestItem_GetAugmentItemID);
+	package.add("GetAugmentType", &Perl_QuestItem_GetAugmentType);
 	package.add("GetCharges", &Perl_QuestItem_GetCharges);
+	package.add("GetColor", &Perl_QuestItem_GetColor);
+	package.add("GetCustomData", &Perl_QuestItem_GetCustomData);
+	package.add("GetCustomDataString", &Perl_QuestItem_GetCustomDataString);
+	package.add("GetEXP", &Perl_QuestItem_GetEXP);
 	package.add("GetID", &Perl_QuestItem_GetID);
+	package.add("GetItem", &Perl_QuestItem_GetItem);
+	package.add("GetItemID", &Perl_QuestItem_GetItemID);
+	package.add("GetItemScriptID", &Perl_QuestItem_GetItemScriptID);
+	package.add("GetKillsNeeded", &Perl_QuestItem_GetKillsNeeded);
+	package.add("GetMaxEvolveLevel", &Perl_QuestItem_GetMaxEvolveLevel);
 	package.add("GetName", &Perl_QuestItem_GetName);
+	package.add("GetPrice", &Perl_QuestItem_GetPrice);
 	package.add("GetTaskDeliveredCount", &Perl_QuestItem_GetTaskDeliveredCount);
+	package.add("GetTotalItemCount", &Perl_QuestItem_GetTotalItemCount);
+	package.add("IsAmmo", &Perl_QuestItem_IsAmmo);
 	package.add("IsAttuned", &Perl_QuestItem_IsAttuned);
+	package.add("IsAugmentable", &Perl_QuestItem_IsAugmentable);
+	package.add("IsAugmented", &Perl_QuestItem_IsAugmented);
+	package.add("IsEquipable", (bool(*)(EQ::ItemInstance*, int16))&Perl_QuestItem_IsEquipable);
+	package.add("IsEquipable", (bool(*)(EQ::ItemInstance*, uint16, uint16))&Perl_QuestItem_IsEquipable);
+	package.add("IsExpendable", &Perl_QuestItem_IsExpendable);
+	package.add("IsInstanceNoDrop", &Perl_QuestItem_IsAttuned);
 	package.add("IsStackable", &Perl_QuestItem_IsStackable);
 	package.add("IsType", &Perl_QuestItem_IsType);
+	package.add("IsWeapon", &Perl_QuestItem_IsWeapon);
 	package.add("ItemSay", (void(*)(EQ::ItemInstance*, const char*))&Perl_QuestItem_ItemSay);
-	package.add("ItemSay", (void(*)(EQ::ItemInstance*, const char*, int))&Perl_QuestItem_ItemSay);
+	package.add("ItemSay", (void(*)(EQ::ItemInstance*, const char*, uint8))&Perl_QuestItem_ItemSay);
 	package.add("RemoveTaskDeliveredItems", &Perl_QuestItem_RemoveTaskDeliveredItems);
+	package.add("SetAttuned", &Perl_QuestItem_SetAttuned);
 	package.add("SetCharges", &Perl_QuestItem_SetCharges);
+	package.add("SetColor", &Perl_QuestItem_SetColor);
+	package.add("SetCustomData", (void(*)(EQ::ItemInstance*, std::string, bool))&Perl_QuestItem_SetColor);
+	package.add("SetCustomData", (void(*)(EQ::ItemInstance*, std::string, float))&Perl_QuestItem_SetColor);
+	package.add("SetCustomData", (void(*)(EQ::ItemInstance*, std::string, int))&Perl_QuestItem_SetColor);
+	package.add("SetCustomData", (void(*)(EQ::ItemInstance*, std::string, std::string))&Perl_QuestItem_SetColor);
+	package.add("SetEXP", &Perl_QuestItem_SetEXP);
+	package.add("SetInstanceNoDrop", &Perl_QuestItem_SetAttuned);
+	package.add("SetPrice", &Perl_QuestItem_SetPrice);
 	package.add("SetScale", &Perl_QuestItem_SetScale);
+	package.add("SetScaling", &Perl_QuestItem_SetScaling);
+	package.add("SetTimer", &Perl_QuestItem_SetTimer);
+	package.add("StopTimer", &Perl_QuestItem_StopTimer);
 }
 
 #endif //EMBPERL_XS_CLASSES


### PR DESCRIPTION
# Perl
- Add `$questitem->AddEXP(exp)`.
- Add `$questitem->ClearTimers()`.
- Add `$questitem->Clone()`.
- Add `$questitem->DeleteCustomData(identifier)`.
- Add `$questitem->GetAugmentItemID(slot_id)`.
- Add `$questitem->GetAugmentType()`.
- Add `$questitem->GetColor()`.
- Add `$questitem->GetCustomData(identifier)`.
- Add `$questitem->GetCustomDataString()`.
- Add `$questitem->GetEXP()`.
- Add `$questitem->GetItem(slot_id)`.
- Add `$questitem->GetItemID(slot_id)`.
- Add `$questitem->GetItemScriptID()`.
- Add `$questitem->GetKillsNeeded()`.
- Add `$questitem->GetMaxEvolveLevel()`.
- Add `$questitem->GetPrice()`.
- Add `$questitem->GetTotalItemCount()`.
- Add `$questitem->IsAmmo()`.
- Add `$questitem->IsAugmentable()`.
- Add `$questitem->IsAugmented()`.
- Add `$questitem->IsEquipable(slot_id)`.
- Add `$questitem->IsEquipable(race_bitmask, class_bitmask)`.
- Add `$questitem->IsExpendable()`.
- Add `$questitem->IsInstanceNoDrop()`.
- Add `$questitem->IsWeapon()`.
- Add `$questitem->SetAttuned(is_attuned)`.
- Add `$questitem->SetColor(color)`.
- Add `$questitem->SetCustomData(identifier, bool_value)`.
- Add `$questitem->SetCustomData(identifier, float_value)`.
- Add `$questitem->SetCustomData(identifier, int_value)`.
- Add `$questitem->SetCustomData(identifier, string_value)`.
- Add `$questitem->SetEXP(exp)`.
- Add `$questitem->SetInstanceNoDrop(is_attuned)`.
- Add `$questitem->SetPrice(price)`.
- Add `$questitem->SetScaling(is_scaling)`.
- Add `$questitem->SetTimer(timer_name, timer)`.
- Add `$questitem->StopTimer(timer_name)`.

# Lua
- Add `iteminst:GetName()`.
- Add `iteminst:IsAttuned()`.
- Add `iteminst:ItemSay(text)`.
- Add `iteminst:ItemSay(text, language_id)`.
- Add `iteminst:SetAttuned(is_attuned)`.

# Notes
- Cleaned up return types and parameter types that were mismatched.
- Removed `SetItem` from Lua as it wasn't used.
- Removed unused parameter in `GetUnscaledItem` in Lua.
- I plan to add Perl ItemData support after this makes its way in, so the missing methods like the `GetItem` overload will be added then.