### PR TITLE
[Quest API] Add ClearAccountFlag() and GetAccountFlags() to Perl/Lua

### DIFF
--- a/common/repositories/account_flags_repository.h
+++ b/common/repositories/account_flags_repository.h
@@ -44,7 +44,35 @@ public:
      */
 
 	// Custom extended repository methods here
+	static void ClearFlag(
+		Database& db,
+		AccountFlagsRepository::AccountFlags e
+	) {
+		AccountFlagsRepository::DeleteWhere(
+			database,
+			fmt::format(
+				"p_accid = {} AND p_flag = '{}'",
+				e.p_accid,
+				Strings::Escape(e.p_flag)
+			)
+		);
+	}
 
+	static void ReplaceFlag(
+		Database& db,
+		AccountFlagsRepository::AccountFlags e
+	) {
+		db.QueryDatabase(
+			fmt::format(
+				"REPLACE INTO {} ({}) VALUES ({}, '{}', '{}')",
+				TableName(),
+				ColumnsRaw(),
+				e.p_accid,
+				Strings::Escape(e.p_flag),
+				Strings::Escape(e.p_value)
+			)
+		);
+	}
 };
 
 #endif //EQEMU_ACCOUNT_FLAGS_REPOSITORY_H

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -58,6 +58,7 @@ extern volatile bool RunLoops;
 #include "mob_movement_manager.h"
 #include "cheat_manager.h"
 
+#include "../common/repositories/account_flags_repository.h"
 #include "../common/repositories/bug_reports_repository.h"
 #include "../common/repositories/char_recipe_list_repository.h"
 #include "../common/repositories/character_spells_repository.h"
@@ -7561,36 +7562,57 @@ void Client::SendFactionMessage(int32 tmpvalue, int32 faction_id, int32 faction_
 
 void Client::LoadAccountFlags()
 {
-
 	accountflags.clear();
-	std::string query = StringFormat("SELECT p_flag, p_value "
-									"FROM account_flags WHERE p_accid = '%d'",
-									account_id);
-	auto results = database.QueryDatabase(query);
-	if (!results.Success()) {
+
+	const auto& l = AccountFlagsRepository::GetWhere(database, fmt::format("p_accid = {}", account_id));
+	if (l.empty()) {
 		return;
 	}
 
-	for (auto row = results.begin(); row != results.end(); ++row)
-		accountflags[row[0]] = row[1];
-}
-
-void Client::SetAccountFlag(std::string flag, std::string val) {
-
-	std::string query = StringFormat("REPLACE INTO account_flags (p_accid, p_flag, p_value) "
-									"VALUES( '%d', '%s', '%s')",
-									account_id, flag.c_str(), val.c_str());
-	auto results = database.QueryDatabase(query);
-	if(!results.Success()) {
-		return;
+	for (const auto& e : l) {
+		accountflags[e.p_flag] = e.p_value;
 	}
-
-	accountflags[flag] = val;
 }
 
-std::string Client::GetAccountFlag(std::string flag)
+void Client::ClearAccountFlag(const std::string& flag)
 {
-	return(accountflags[flag]);
+	auto e = AccountFlagsRepository::NewEntity();
+
+	e.p_accid = account_id;
+	e.p_flag  = flag;
+
+	AccountFlagsRepository::ClearFlag(database, e);
+}
+
+void Client::SetAccountFlag(const std::string& flag, const std::string& value)
+{
+	auto e = AccountFlagsRepository::NewEntity();
+
+	e.p_accid = account_id;
+	e.p_flag  = flag;
+	e.p_value = value;
+
+	AccountFlagsRepository::ReplaceFlag(database, e);
+
+	accountflags[flag] = value;
+}
+
+std::string Client::GetAccountFlag(const std::string& flag)
+{
+	return accountflags[flag];
+}
+
+std::vector<std::string> Client::GetAccountFlags()
+{
+	std::vector<std::string> l;
+
+	l.reserve(accountflags.size());
+
+	for (const auto& e : accountflags) {
+		l.emplace_back(e.first);
+	}
+
+	return l;
 }
 
 void Client::TickItemCheck()

--- a/zone/client.h
+++ b/zone/client.h
@@ -1583,8 +1583,10 @@ public:
 	int32 GetActWIS() { return( std::min(GetMaxWIS(), GetWIS()) ); }
 	int32 GetActCHA() { return( std::min(GetMaxCHA(), GetCHA()) ); }
 	void LoadAccountFlags();
-	void SetAccountFlag(std::string flag, std::string val);
-	std::string GetAccountFlag(std::string flag);
+	void ClearAccountFlag(const std::string& flag);
+	void SetAccountFlag(const std::string& flag, const std::string& value);
+	std::string GetAccountFlag(const std::string& flag);
+	std::vector<std::string> GetAccountFlags();
 	void SetGMStatus(int16 new_status);
 	void Consume(const EQ::ItemData *item, uint8 type, int16 slot, bool auto_consume);
 	void PlayMP3(const char* fname);

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -1529,7 +1529,7 @@ luabind::object Lua_Client::GetAccountFlags(lua_State* L) {
 	if (d_) {
 		auto self = reinterpret_cast<NativeType*>(d_);
 		auto l = self->GetAccountFlags();
-		auto i = 1;
+		int i = 1;
 		for (const auto& e : l) {
 			t[i] = e;
 			i++;

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -2851,7 +2851,7 @@ luabind::object Lua_Client::GetPEQZoneFlags(lua_State* L) {
 	if (d_) {
 		auto self = reinterpret_cast<NativeType*>(d_);
 		auto l = self->GetPEQZoneFlags();
-		auto i = 1;
+		int i = 1;
 		for (const auto& f : l) {
 			t[i] = f;
 			i++;
@@ -2866,7 +2866,7 @@ luabind::object Lua_Client::GetZoneFlags(lua_State* L) {
 	if (d_) {
 		auto self = reinterpret_cast<NativeType*>(d_);
 		auto l = self->GetZoneFlags();
-		auto i = 1;
+		int i = 1;
 		for (const auto& f : l) {
 			t[i] = f;
 			i++;

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -1509,14 +1509,34 @@ bool Lua_Client::HasSpellScribed(int spell_id) {
 	return self->HasSpellScribed(spell_id);
 }
 
-void Lua_Client::SetAccountFlag(std::string flag, std::string val) {
+void Lua_Client::ClearAccountFlag(const std::string& flag) {
 	Lua_Safe_Call_Void();
-	self->SetAccountFlag(flag, val);
+	self->ClearAccountFlag(flag);
 }
 
-std::string Lua_Client::GetAccountFlag(std::string flag) {
+void Lua_Client::SetAccountFlag(const std::string& flag, const std::string& value) {
+	Lua_Safe_Call_Void();
+	self->SetAccountFlag(flag, value);
+}
+
+std::string Lua_Client::GetAccountFlag(const std::string& flag) {
 	Lua_Safe_Call_String();
 	return self->GetAccountFlag(flag);
+}
+
+luabind::object Lua_Client::GetAccountFlags(lua_State* L) {
+	auto t = luabind::newtable(L);
+	if (d_) {
+		auto self = reinterpret_cast<NativeType*>(d_);
+		auto l = self->GetAccountFlags();
+		auto i = 1;
+		for (const auto& e : l) {
+			t[i] = e;
+			i++;
+		}
+	}
+
+	return t;
 }
 
 Lua_Group Lua_Client::GetGroup() {
@@ -3136,6 +3156,7 @@ luabind::scope lua_register_client() {
 	.def("CheckIncreaseSkill", (void(Lua_Client::*)(int,Lua_Mob,int))&Lua_Client::CheckIncreaseSkill)
 	.def("CheckSpecializeIncrease", (void(Lua_Client::*)(int))&Lua_Client::CheckSpecializeIncrease)
 	.def("ClearCompassMark",(void(Lua_Client::*)(void))&Lua_Client::ClearCompassMark)
+	.def("ClearAccountFlag", (void(Lua_Client::*)(const std::string&))&Lua_Client::ClearAccountFlag)
 	.def("ClearPEQZoneFlag", (void(Lua_Client::*)(uint32))&Lua_Client::ClearPEQZoneFlag)
 	.def("ClearZoneFlag", (void(Lua_Client::*)(uint32))&Lua_Client::ClearZoneFlag)
 	.def("Connected", (bool(Lua_Client::*)(void))&Lua_Client::Connected)
@@ -3190,7 +3211,8 @@ luabind::scope lua_register_client() {
 	.def("GetAAPoints", (int(Lua_Client::*)(void))&Lua_Client::GetAAPoints)
 	.def("GetAFK", (int(Lua_Client::*)(void))&Lua_Client::GetAFK)
 	.def("GetAccountAge", (int(Lua_Client::*)(void))&Lua_Client::GetAccountAge)
-	.def("GetAccountFlag", (std::string(Lua_Client::*)(std::string))&Lua_Client::GetAccountFlag)
+	.def("GetAccountFlag", (std::string(Lua_Client::*)(const std::string&))&Lua_Client::GetAccountFlag)
+	.def("GetAccountFlags", (luabind::object(Lua_Client::*)(lua_State*))&Lua_Client::GetAccountFlags)
 	.def("GetAggroCount", (int(Lua_Client::*)(void))&Lua_Client::GetAggroCount)
 	.def("GetAllMoney", (uint64(Lua_Client::*)(void))&Lua_Client::GetAllMoney)
 	.def("GetAlternateCurrencyValue", (int(Lua_Client::*)(uint32))&Lua_Client::GetAlternateCurrencyValue)
@@ -3470,8 +3492,7 @@ luabind::scope lua_register_client() {
 	.def("SetAATitle", (void(Lua_Client::*)(std::string))&Lua_Client::SetAATitle)
 	.def("SetAATitle", (void(Lua_Client::*)(std::string,bool))&Lua_Client::SetAATitle)
 	.def("SetAFK", (void(Lua_Client::*)(uint8))&Lua_Client::SetAFK)
-	.def("SetAccountFlag", (void(Lua_Client::*)(std::string,std::string))&Lua_Client::SetAccountFlag)
-	.def("SetAccountFlag", (void(Lua_Client::*)(std::string,std::string))&Lua_Client::SetAccountFlag)
+	.def("SetAccountFlag", (void(Lua_Client::*)(const std::string&,const std::string&))&Lua_Client::SetAccountFlag)
 	.def("SetAlternateCurrencyValue", (void(Lua_Client::*)(uint32,int))&Lua_Client::SetAlternateCurrencyValue)
 	.def("SetAnon", (void(Lua_Client::*)(uint8))&Lua_Client::SetAnon)
 	.def("SetBaseClass", (void(Lua_Client::*)(int))&Lua_Client::SetBaseClass)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -380,8 +380,10 @@ public:
 	int GetAlternateCurrencyValue(uint32 currency);
 	void SendWebLink(const char *site);
 	bool HasSpellScribed(int spell_id);
-	void SetAccountFlag(std::string flag, std::string val);
-	std::string GetAccountFlag(std::string flag);
+	void ClearAccountFlag(const std::string& flag);
+	void SetAccountFlag(const std::string& flag, const std::string& value);
+	std::string GetAccountFlag(const std::string& flag);
+	luabind::object GetAccountFlags(lua_State* L);
 	int GetAccountAge();
 	Lua_Group GetGroup();
 	Lua_Raid GetRaid();

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -2753,7 +2753,7 @@ luabind::object Lua_Mob::GetEntityVariables(lua_State* L) {
 	if (d_) {
 		auto self = reinterpret_cast<NativeType*>(d_);
 		auto l = self->GetEntityVariables();
-		auto i = 1;
+		int i = 1;
 		for (const auto& v : l) {
 			t[i] = v;
 			i++;
@@ -3044,7 +3044,7 @@ luabind::object Lua_Mob::GetBuffSpellIDs(lua_State* L) {
 	if (d_) {
 		auto self = reinterpret_cast<NativeType*>(d_);
 		auto l = self->GetBuffSpellIDs();
-		auto i = 1;
+		int i = 1;
 		for (const auto& v : l) {
 			t[i] = v;
 			i++;

--- a/zone/lua_object.cpp
+++ b/zone/lua_object.cpp
@@ -173,7 +173,7 @@ luabind::object Lua_Object::GetEntityVariables(lua_State* L) {
 	if (d_) {
 		auto self = reinterpret_cast<NativeType*>(d_);
 		auto l = self->GetEntityVariables();
-		auto i = 1;
+		int i = 1;
 		for (const auto& v : l) {
 			t[i] = v;
 			i++;

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -1502,6 +1502,11 @@ bool Perl_Client_HasSpellScribed(Client* self, int spell_id) // @categories Spel
 	return self->HasSpellScribed(spell_id);
 }
 
+void Perl_Client_ClearAccountFlag(Client* self, std::string flag) // @categories Account and Character
+{
+	self->ClearAccountFlag(flag);
+}
+
 void Perl_Client_SetAccountFlag(Client* self, std::string flag, std::string value) // @categories Account and Character
 {
 	self->SetAccountFlag(flag, value);
@@ -1510,6 +1515,21 @@ void Perl_Client_SetAccountFlag(Client* self, std::string flag, std::string valu
 std::string Perl_Client_GetAccountFlag(Client* self, std::string flag) // @categories Account and Character
 {
 	return self->GetAccountFlag(flag);
+}
+
+perl::array Perl_Client_GetAccountFlags(Client* self)
+{
+	perl::array result;
+
+	const auto& l = self->GetAccountFlags();
+
+	result.reserve(l.size());
+
+	for (const auto& e : l) {
+		result.push_back(e);
+	}
+
+	return result;
 }
 
 int Perl_Client_GetHunger(Client* self) // @categories Account and Character, Stats and Attributes
@@ -2994,6 +3014,7 @@ void perl_register_client()
 	package.add("CheckIncreaseSkill", (bool(*)(Client*, int, int))&Perl_Client_CheckIncreaseSkill);
 	package.add("CheckSpecializeIncrease", &Perl_Client_CheckSpecializeIncrease);
 	package.add("ClearCompassMark", &Perl_Client_ClearCompassMark);
+	package.add("ClearAccountFlag", &Perl_Client_ClearAccountFlag);
 	package.add("ClearPEQZoneFlag", &Perl_Client_ClearPEQZoneFlag);
 	package.add("ClearZoneFlag", &Perl_Client_ClearZoneFlag);
 	package.add("Connected", &Perl_Client_Connected);
@@ -3042,6 +3063,7 @@ void perl_register_client()
 	package.add("GetAFK", &Perl_Client_GetAFK);
 	package.add("GetAccountAge", &Perl_Client_GetAccountAge);
 	package.add("GetAccountFlag", &Perl_Client_GetAccountFlag);
+	package.add("GetAccountFlags", &Perl_Client_GetAccountFlags);
 	package.add("GetAggroCount", &Perl_Client_GetAggroCount);
 	package.add("GetAllMoney", &Perl_Client_GetAllMoney);
 	package.add("GetAlternateCurrencyValue", &Perl_Client_GetAlternateCurrencyValue);


### PR DESCRIPTION
# Perl
- Add `$client->ClearAccountFlag(flag)`.
- Add `$client->GetAccountFlags()`.

# Lua
- Add `client:ClearAccountFlag(flag)`.
- Add `client:GetAccountFlags()`.

# Notes
- Made use of repositories and cleaned up existing code.