### PR TITLE
[Bug Fix] Fix _PutItem having a slot_id of -1 on mobs with no items

### DIFF
--- a/common/inventory_profile.cpp
+++ b/common/inventory_profile.cpp
@@ -1444,7 +1444,7 @@ int16 EQ::InventoryProfile::_PutItem(int16 slot_id, ItemInstance* inst)
 	}
 
 	if (result == INVALID_INDEX) {
-		LogError("InventoryProfile::_PutItem: Invalid slot_id specified ({}) with parent slot id ({})", slot_id, parentSlot);
+		LogError("Invalid slot_id specified ({}) with parent slot id ({})", slot_id, parentSlot);
 		InventoryProfile::MarkDirty(inst); // Slot not found, clean up
 	}
 

--- a/zone/loottables.cpp
+++ b/zone/loottables.cpp
@@ -299,7 +299,7 @@ void NPC::AddLootDrop(
 	uint32 aug6
 )
 {
-	if (item2 == nullptr) {
+	if (!item2) {
 		return;
 	}
 
@@ -363,7 +363,7 @@ void NPC::AddLootDrop(
 
 	bool found = false; // track if we found an empty slot we fit into
 
-	int foundslot = -1; // for multi-slot items
+	int foundslot = INVALID_INDEX; // for multi-slot items
 
 	const auto* inst = database.CreateItem(
 		item2->ID,
@@ -375,6 +375,10 @@ void NPC::AddLootDrop(
 		aug5,
 		aug6
 	);
+
+	if (!inst) {
+		return;
+	}
 
 	if (loot_drop.equip_item > 0) {
 		uint8 eslot = 0xFF;
@@ -524,7 +528,10 @@ void NPC::AddLootDrop(
 	}
 
 	if (itemlist) {
-		GetInv().PutItem(foundslot, *inst);
+		if (foundslot != INVALID_INDEX) {
+			GetInv().PutItem(foundslot, *inst);
+		}
+
 		itemlist->push_back(item);
 	} else {
 		safe_delete(item);


### PR DESCRIPTION
# Notes
- This was causing an insane amount of error logs because we were always using `PutItem`, even with a `slot_id` of `-1`.