### PR TITLE
[Bug Fix] Add chatchannel_reserved_names to a new manifest

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -4744,6 +4744,22 @@ ADD COLUMN `id` int(11) NOT NULL AUTO_INCREMENT FIRST,
 ADD PRIMARY KEY (`id`);
 )",
 	},
+	ManifestEntry{
+		.version = 9229,
+		.description = "2023_07_04_chatchannel_reserved_names_fix.sql",
+		.check = "SHOW TABLES LIKE 'chatchannel_reserved_names'",
+		.condition = "empty",
+		.match = "",
+		.sql = R"(
+CREATE TABLE `chatchannel_reserved_names`
+(
+`id`   int(11) NOT NULL AUTO_INCREMENT,
+`name` varchar(64) NOT NULL,
+PRIMARY KEY (`id`) USING BTREE,
+UNIQUE KEY `name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+)"
+	},
 
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9228
+#define CURRENT_BINARY_DATABASE_VERSION 9229
 
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9039
 


### PR DESCRIPTION
# Notes
- This should resolve issues where the old query fails because it's adding an already existing column to another table.