### PR TITLE
[Commands] Add #itemsearch alias to #find aliases

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -391,6 +391,7 @@ int command_init(void)
 				"findspell",
 				"findtask",
 				"findzone",
+				"itemsearch"
 			}
 		},
 	};


### PR DESCRIPTION
# Notes
- `#itemsearch` did not exist in this alias list.