### PR TITLE
[Bug Fix] Update bot naming check and add more explanation

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -1273,8 +1273,11 @@ bool Bot::IsValidName(std::string& name)
 	if (!isupper(name[0]))
 		return false;
 
-	for (int i = 1; i < name.length(); ++i) {
-		if ((!RuleB(Bots, AllowCamelCaseNames) && !islower(name[i])) && name[i] != '_') {
+	for (char c : name.substr(1)) {
+		if (!RuleB(Bots, AllowCamelCaseNames) && !islower(c)) {
+			return false;
+		}
+		if (isdigit(c) || ispunct(c)) {
 			return false;
 		}
 	}

--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -5501,11 +5501,6 @@ void bot_subcommand_bot_create(Client *c, const Seperator *sep)
 	std::string bot_name = sep->arg[1];
 	bot_name = Strings::UcFirst(bot_name);
 
-	if (Strings::Contains(bot_name, "_")) {
-		c->Message(Chat::White, "Bot name cannot contain underscores!");
-		return;
-	}
-
 	if (arguments < 2 || !sep->IsNumber(2)) {
 		c->Message(Chat::White, "Invalid class!");
 		return;
@@ -8858,7 +8853,7 @@ uint32 helper_bot_create(Client *bot_owner, std::string bot_name, uint8 bot_clas
 		bot_owner->Message(
 			Chat::White,
 			fmt::format(
-				"'{}' is an invalid name. You may only use characters 'A-Z', 'a-z' and '_'.",
+				"'{}' is an invalid name. You may only use characters 'A-Z' or 'a-z'.",
 				bot_name
 			).c_str()
 		);

--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -8853,8 +8853,8 @@ uint32 helper_bot_create(Client *bot_owner, std::string bot_name, uint8 bot_clas
 		bot_owner->Message(
 			Chat::White,
 			fmt::format(
-				"'{}' is an invalid name. You may only use characters 'A-Z' or 'a-z'.",
-				bot_name
+				"'{}' is an invalid name. You may only use characters 'A-Z' or 'a-z'. Mixed case {} allowed.",
+				bot_name, RuleB(Bots, AllowCamelCaseNames) ? "is" : "is not"
 			).c_str()
 		);
 		return bot_id;


### PR DESCRIPTION
### NOTES

- Refactor previous fix #3458 to prevent _'s to leverage the existing "IsValidName" bot method.
- Add more explanation to error message depending on server rule on CamelCase bot names
- Add detection for numbers which would get removed and duplicate bot names created

