### PR TITLE
[Quest API] Add Mob/Entity type check methods to Perl/Lua

### DIFF
--- a/zone/lua_entity.cpp
+++ b/zone/lua_entity.cpp
@@ -78,6 +78,21 @@ bool Lua_Entity::IsBot() {
 	return self->IsBot();
 }
 
+bool Lua_Entity::IsAura() {
+	Lua_Safe_Call_Bool();
+	return self->IsAura();
+}
+
+bool Lua_Entity::IsOfClientBot() {
+	Lua_Safe_Call_Bool();
+	return self->IsOfClientBot();
+}
+
+bool Lua_Entity::IsOfClientBotMerc() {
+	Lua_Safe_Call_Bool();
+	return self->IsOfClientBotMerc();
+}
+
 int Lua_Entity::GetID() {
 	Lua_Safe_Call_Bool();
 	return self->GetID();
@@ -138,6 +153,7 @@ luabind::scope lua_register_entity() {
 	.def("CastToNPC", &Lua_Entity::CastToNPC)
 	.def("CastToObject", &Lua_Entity::CastToObject)
 	.def("GetID", &Lua_Entity::GetID)
+	.def("IsAura", &Lua_Entity::IsAura)
 	.def("IsBeacon", &Lua_Entity::IsBeacon)
 	.def("IsBot", &Lua_Entity::IsBot)
 	.def("IsClient", &Lua_Entity::IsClient)
@@ -149,7 +165,10 @@ luabind::scope lua_register_entity() {
 	.def("IsNPC", &Lua_Entity::IsNPC)
 	.def("IsNPCCorpse", &Lua_Entity::IsNPCCorpse)
 	.def("IsObject", &Lua_Entity::IsObject)
+	.def("IsOfClientBot", &Lua_Entity::IsOfClientBot)
+	.def("IsOfClientBotMerc", &Lua_Entity::IsOfClientBotMerc)
 	.def("IsPlayerCorpse", &Lua_Entity::IsPlayerCorpse)
+	.def("IsTemporaryPet", &Lua_Entity::IsTemporaryPet)
 	.def("IsTrap", &Lua_Entity::IsTrap);
 }
 

--- a/zone/lua_entity.cpp
+++ b/zone/lua_entity.cpp
@@ -168,7 +168,6 @@ luabind::scope lua_register_entity() {
 	.def("IsOfClientBot", &Lua_Entity::IsOfClientBot)
 	.def("IsOfClientBotMerc", &Lua_Entity::IsOfClientBotMerc)
 	.def("IsPlayerCorpse", &Lua_Entity::IsPlayerCorpse)
-	.def("IsTemporaryPet", &Lua_Entity::IsTemporaryPet)
 	.def("IsTrap", &Lua_Entity::IsTrap);
 }
 

--- a/zone/lua_entity.h
+++ b/zone/lua_entity.h
@@ -47,6 +47,9 @@ public:
 	bool IsBeacon();
 	bool IsEncounter();
 	bool IsBot();
+	bool IsAura();
+	bool IsOfClientBot();
+	bool IsOfClientBotMerc();
 	int GetID();
 
 	Lua_Client CastToClient();

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -3524,6 +3524,7 @@ luabind::scope lua_register_mob() {
 	.def("IsStunned", (bool(Lua_Mob::*)(void))&Lua_Mob::IsStunned)
 	.def("IsTargetable", (bool(Lua_Mob::*)(void))&Lua_Mob::IsTargetable)
 	.def("IsTargeted", &Lua_Mob::IsTargeted)
+	.def("IsTemporaryPet", &Lua_Mob::IsTemporaryPet)
 	.def("IsTrackable", (bool(Lua_Mob::*)(void))&Lua_Mob::IsTrackable)
 	.def("IsWarriorClass", &Lua_Mob::IsWarriorClass)
 	.def("Kill", (void(Lua_Mob::*)(void))&Lua_Mob::Kill)

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -3127,6 +3127,12 @@ std::string Lua_Mob::GetRacePlural()
 	return self->GetRacePlural();
 }
 
+bool Lua_Mob::IsTemporaryPet()
+{
+	Lua_Safe_Call_Bool();
+	return self->IsTempPet();
+}
+
 luabind::scope lua_register_mob() {
 	return luabind::class_<Lua_Mob, Lua_Entity>("Mob")
 	.def(luabind::constructor<>())

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -556,6 +556,7 @@ public:
 	Lua_Mob_List GetCloseMobList(float distance, bool ignore_self);
 	std::string GetClassPlural();
 	std::string GetRacePlural();
+	bool IsTemporaryPet();
 };
 
 #endif

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -21,14 +21,14 @@ bool Perl_Mob_IsNPC(Mob* self) // @categories Script Utility
 	return self->IsNPC();
 }
 
-bool Perl_Mob_IsBot(Mob* self) // @categories Script Utility
-{
-	return self->IsBot();
-}
-
 bool Perl_Mob_IsMob(Mob* self) // @categories Script Utility
 {
 	return self->IsMob();
+}
+
+bool Perl_Mob_IsMerc(Mob* self) // @categories Script Utility
+{
+	return self->IsMerc();
 }
 
 bool Perl_Mob_IsCorpse(Mob* self) // @categories Script Utility, Corpse
@@ -64,6 +64,36 @@ bool Perl_Mob_IsTrap(Mob* self) // @categories Script Utility
 bool Perl_Mob_IsBeacon(Mob* self) // @categories Script Utility
 {
 	return self->IsBeacon();
+}
+
+bool Perl_Mob_IsEncounter(Mob* self) // @categories Script Utility
+{
+	return self->IsEncounter();
+}
+
+bool Perl_Mob_IsBot(Mob* self) // @categories Script Utility
+{
+	return self->IsBot();
+}
+
+bool Perl_Mob_IsAura(Mob* self) // @categories Script Utility
+{
+	return self->IsAura();
+}
+
+bool Perl_Mob_IsOfClientBot(Mob* self) // @categories Script Utility
+{
+	return self->IsOfClientBot();
+}
+
+bool Perl_Mob_IsOfClientBotMerc(Mob* self) // @categories Script Utility
+{
+	return self->IsOfClientBotMerc();
+}
+
+bool Perl_Mob_IsTemporaryPet(Mob* self) // @categories Script Utility
+{
+	return self->IsTempPet();
 }
 
 Client* Perl_Mob_CastToClient(Mob* self) // @categories Account and Character, Script Utility
@@ -3443,6 +3473,7 @@ void perl_register_mob()
 	package.add("IsAmnesiad", &Perl_Mob_IsAmnesiad);
 	package.add("IsAttackAllowed", (bool(*)(Mob*, Mob*))&Perl_Mob_IsAttackAllowed);
 	package.add("IsAttackAllowed", (bool(*)(Mob*, Mob*, bool))&Perl_Mob_IsAttackAllowed);
+	package.add("IsAura", &Perl_Mob_IsAura);
 	package.add("IsBeacon", &Perl_Mob_IsBeacon);
 	package.add("IsBeneficialAllowed", &Perl_Mob_IsBeneficialAllowed);
 	package.add("IsBerserk", &Perl_Mob_IsBerserk);
@@ -3453,6 +3484,7 @@ void perl_register_mob()
 	package.add("IsCorpse", &Perl_Mob_IsCorpse);
 	package.add("IsDoor", &Perl_Mob_IsDoor);
 	package.add("IsEliteMaterialItem", &Perl_Mob_IsEliteMaterialItem);
+	package.add("IsEncounter", &Perl_Mob_IsEncounter);
 	package.add("IsEngaged", &Perl_Mob_IsEngaged);
 	package.add("IsEnraged", &Perl_Mob_IsEnraged);
 	package.add("IsFeared", &Perl_Mob_IsFeared);
@@ -3462,12 +3494,15 @@ void perl_register_mob()
 	package.add("IsInvisible", (bool(*)(Mob*))&Perl_Mob_IsInvisible);
 	package.add("IsInvisible", (bool(*)(Mob*, Mob*))&Perl_Mob_IsInvisible);
 	package.add("IsMeleeDisabled", &Perl_Mob_IsMeleeDisabled);
+	package.add("IsMerc", &Perl_Mob_IsMerc);
 	package.add("IsMezzed", &Perl_Mob_IsMezzed);
 	package.add("IsMob", &Perl_Mob_IsMob);
 	package.add("IsMoving", &Perl_Mob_IsMoving);
 	package.add("IsNPC", &Perl_Mob_IsNPC);
 	package.add("IsNPCCorpse", &Perl_Mob_IsNPCCorpse);
 	package.add("IsObject", &Perl_Mob_IsObject);
+	package.add("IsOfClientBot", &Perl_Mob_IsOfClientBot);
+	package.add("IsOfClientBotMerc", &Perl_Mob_IsOfClientBotMerc);
 	package.add("IsPausedTimer", &Perl_Mob_IsPausedTimer);
 	package.add("IsPet", &Perl_Mob_IsPet);
 	package.add("IsPlayerCorpse", &Perl_Mob_IsPlayerCorpse);
@@ -3478,6 +3513,7 @@ void perl_register_mob()
 	package.add("IsStunned", &Perl_Mob_IsStunned);
 	package.add("IsTargetable", &Perl_Mob_IsTargetable);
 	package.add("IsTargeted", &Perl_Mob_IsTargeted);
+	package.add("IsTemporaryPet", &Perl_Mob_IsTemporaryPet);
 	package.add("IsTrackable", &Perl_Mob_IsTrackable);
 	package.add("IsTrap", &Perl_Mob_IsTrap);
 	package.add("IsWarriorClass", &Perl_Mob_IsWarriorClass);


### PR DESCRIPTION
# Perl
- Add `$mob->IsAura()`.
- Add `$mob->IsEncounter()`.
- Add `$mob->IsMerc()`.
- Add `$mob->IsOfClientBot()`.
- Add `$mob->IsOfClientBotMerc()`.
- Add `$mob->IsTemporaryPet()`.

# Lua
- Add `entity:IsAura()`.
- Add `entity:IsOfClientBot()`.
- Add `entity:IsOfClientBotMerc()`.
- Add `mob:IsTemporaryPet()`.