### PR TITLE
[Quest API] Add SetLDoNPoints() to Perl/Lua

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -1558,7 +1558,13 @@ void Client::SetLDoNPoints(uint32 theme_id, uint32 points)
 		}
 	}
 
-	m_pp.ldon_points_available += points;
+	m_pp.ldon_points_available = (
+		m_pp.ldon_points_guk +
+		m_pp.ldon_points_mir +
+		m_pp.ldon_points_mmc +
+		m_pp.ldon_points_ruj +
+		m_pp.ldon_points_tak
+	);
 
 	auto outapp = new EQApplicationPacket(OP_AdventurePointsUpdate, sizeof(AdventurePoints_Update_Struct));
 

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3092,6 +3092,12 @@ std::string Lua_Client::GetRaceAbbreviation()
 	return GetPlayerRaceAbbreviation(self->GetBaseRace());
 }
 
+void Lua_Client::SetLDoNPoints(uint32 theme_id, uint32 points)
+{
+	Lua_Safe_Call_Void();
+	self->SetLDoNPoints(theme_id, points);
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 	.def(luabind::constructor<>())
@@ -3536,6 +3542,7 @@ luabind::scope lua_register_client() {
 	.def("SetIPExemption", (void(Lua_Client::*)(int))&Lua_Client::SetIPExemption)
 	.def("SetItemCooldown", (void(Lua_Client::*)(uint32,uint32))&Lua_Client::SetItemCooldown)
 	.def("SetLanguageSkill", (void(Lua_Client::*)(int,int))&Lua_Client::SetLanguageSkill)
+	.def("SetLDoNPoints", (void(Lua_Client::*)(uint32,uint32))&Lua_Client::SetLDoNPoints)
 	.def("SetMaterial", (void(Lua_Client::*)(int,uint32))&Lua_Client::SetMaterial)
 	.def("SetPEQZoneFlag", (void(Lua_Client::*)(uint32))&Lua_Client::SetPEQZoneFlag)
 	.def("SetPVP", (void(Lua_Client::*)(bool))&Lua_Client::SetPVP)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -473,6 +473,7 @@ public:
 	uint32 GetEXPForLevel(uint16 check_level);
 	std::string GetClassAbbreviation();
 	std::string GetRaceAbbreviation();
+	void SetLDoNPoints(uint32 theme_id, uint32 points);
 
 	void ApplySpell(int spell_id);
 	void ApplySpell(int spell_id, int duration);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -2947,6 +2947,11 @@ std::string Perl_Client_GetRaceAbbreviation(Client* self)
 	return GetPlayerRaceAbbreviation(self->GetBaseRace());
 }
 
+void Perl_Client_SetLDoNPoints(Client* self, uint32 theme_id, uint32 points)
+{
+	self->SetLDoNPoints(theme_id, points);
+}
+
 void perl_register_client()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3394,6 +3399,7 @@ void perl_register_client()
 	package.add("SetInvulnerableEnvironmentDamage", &Perl_Client_SetInvulnerableEnvironmentDamage);
 	package.add("SetItemCooldown", &Perl_Client_SetItemCooldown);
 	package.add("SetLanguageSkill", &Perl_Client_SetLanguageSkill);
+	package.add("SetLDoNPoints", &Perl_Client_SetLDoNPoints);
 	package.add("SetMaterial", &Perl_Client_SetMaterial);
 	package.add("SetPEQZoneFlag", &Perl_Client_SetPEQZoneFlag);
 	package.add("SetPVP", &Perl_Client_SetPVP);


### PR DESCRIPTION
# Perl
- Add `$client->SetLDoNPoints(theme_id, points)`.

# Lua
- Add `client:SetLDoNPoints(theme_id, points)`.

# Notes
- Allows operators to directly set LDoN Points.