### PR TITLE
[Data Buckets] Implement scoped data buckets

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -4806,6 +4806,27 @@ UNIQUE INDEX `command`(`parent_command`, `sub_command`)
 )
 )"
 	},
+	ManifestEntry{
+		.version = 9233,
+		.description = "2023_07_16_scoped_data_buckets.sql",
+		.check = "SHOW TABLES LIKE 'command_subsettings'",
+		.condition = "empty",
+		.match = "",
+		.sql = R"(
+
+ALTER TABLE `data_buckets`
+ADD COLUMN `character_id` bigint(11) NOT NULL DEFAULT 0 AFTER `expires`,
+ADD COLUMN `npc_id` bigint(11) NOT NULL DEFAULT 0 AFTER `character_id`,
+ADD COLUMN `bot_id` bigint(11) NOT NULL DEFAULT 0 AFTER `npc_id`,
+DROP INDEX `key_index`,
+ADD UNIQUE INDEX `keys`(`key`,`character_id`,`npc_id`,`bot_id`)
+
+UPDATE data_buckets SET character_id = SUBSTRING_INDEX(SUBSTRING_INDEX( `key`, '-', 2 ), '-', -1), `key` = SUBSTR(SUBSTRING_INDEX(`key`, SUBSTRING_INDEX( `key`, '-', 2 ), -1), 2) WHERE `key` LIKE 'character-%';
+UPDATE data_buckets SET npc_id = SUBSTRING_INDEX(SUBSTRING_INDEX( `key`, '-', 2 ), '-', -1), `key` = SUBSTR(SUBSTRING_INDEX(`key`, SUBSTRING_INDEX( `key`, '-', 2 ), -1), 2) WHERE `key` LIKE 'npc-%';
+UPDATE data_buckets SET bot_id = SUBSTRING_INDEX(SUBSTRING_INDEX( `key`, '-', 2 ), '-', -1), `key` = SUBSTR(SUBSTRING_INDEX(`key`, SUBSTRING_INDEX( `key`, '-', 2 ), -1), 2) WHERE `key` LIKE 'bot-%';
+
+)"
+	},
 
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{

--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -4819,7 +4819,7 @@ ADD COLUMN `character_id` bigint(11) NOT NULL DEFAULT 0 AFTER `expires`,
 ADD COLUMN `npc_id` bigint(11) NOT NULL DEFAULT 0 AFTER `character_id`,
 ADD COLUMN `bot_id` bigint(11) NOT NULL DEFAULT 0 AFTER `npc_id`,
 DROP INDEX `key_index`,
-ADD UNIQUE INDEX `keys`(`key`,`character_id`,`npc_id`,`bot_id`)
+ADD UNIQUE INDEX `keys`(`key`,`character_id`,`npc_id`,`bot_id`);
 
 UPDATE data_buckets SET character_id = SUBSTRING_INDEX(SUBSTRING_INDEX( `key`, '-', 2 ), '-', -1), `key` = SUBSTR(SUBSTRING_INDEX(`key`, SUBSTRING_INDEX( `key`, '-', 2 ), -1), 2) WHERE `key` LIKE 'character-%';
 UPDATE data_buckets SET npc_id = SUBSTRING_INDEX(SUBSTRING_INDEX( `key`, '-', 2 ), '-', -1), `key` = SUBSTR(SUBSTRING_INDEX(`key`, SUBSTRING_INDEX( `key`, '-', 2 ), -1), 2) WHERE `key` LIKE 'npc-%';

--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -4809,7 +4809,7 @@ UNIQUE INDEX `command`(`parent_command`, `sub_command`)
 	ManifestEntry{
 		.version = 9233,
 		.description = "2023_07_16_scoped_data_buckets.sql",
-		.check = "SHOW TABLES LIKE 'command_subsettings'",
+		.check = "SHOW COLUMNS FROM `data_buckets` LIKE 'character_id'",
 		.condition = "empty",
 		.match = "",
 		.sql = R"(

--- a/common/repositories/base/base_data_buckets_repository.h
+++ b/common/repositories/base/base_data_buckets_repository.h
@@ -24,6 +24,9 @@ public:
 		std::string key_;
 		std::string value;
 		uint32_t    expires;
+		int64_t     character_id;
+		int64_t     npc_id;
+		int64_t     bot_id;
 	};
 
 	static std::string PrimaryKey()
@@ -38,6 +41,9 @@ public:
 			"`key`",
 			"value",
 			"expires",
+			"character_id",
+			"npc_id",
+			"bot_id",
 		};
 	}
 
@@ -48,6 +54,9 @@ public:
 			"`key`",
 			"value",
 			"expires",
+			"character_id",
+			"npc_id",
+			"bot_id",
 		};
 	}
 
@@ -88,10 +97,13 @@ public:
 	{
 		DataBuckets e{};
 
-		e.id      = 0;
-		e.key_    = "";
-		e.value   = "";
-		e.expires = 0;
+		e.id           = 0;
+		e.key_         = "";
+		e.value        = "";
+		e.expires      = 0;
+		e.character_id = 0;
+		e.npc_id       = 0;
+		e.bot_id       = 0;
 
 		return e;
 	}
@@ -128,10 +140,13 @@ public:
 		if (results.RowCount() == 1) {
 			DataBuckets e{};
 
-			e.id      = strtoull(row[0], nullptr, 10);
-			e.key_    = row[1] ? row[1] : "";
-			e.value   = row[2] ? row[2] : "";
-			e.expires = static_cast<uint32_t>(strtoul(row[3], nullptr, 10));
+			e.id           = strtoull(row[0], nullptr, 10);
+			e.key_         = row[1] ? row[1] : "";
+			e.value        = row[2] ? row[2] : "";
+			e.expires      = static_cast<uint32_t>(strtoul(row[3], nullptr, 10));
+			e.character_id = strtoll(row[4], nullptr, 10);
+			e.npc_id       = strtoll(row[5], nullptr, 10);
+			e.bot_id       = strtoll(row[6], nullptr, 10);
 
 			return e;
 		}
@@ -168,6 +183,9 @@ public:
 		v.push_back(columns[1] + " = '" + Strings::Escape(e.key_) + "'");
 		v.push_back(columns[2] + " = '" + Strings::Escape(e.value) + "'");
 		v.push_back(columns[3] + " = " + std::to_string(e.expires));
+		v.push_back(columns[4] + " = " + std::to_string(e.character_id));
+		v.push_back(columns[5] + " = " + std::to_string(e.npc_id));
+		v.push_back(columns[6] + " = " + std::to_string(e.bot_id));
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -193,6 +211,9 @@ public:
 		v.push_back("'" + Strings::Escape(e.key_) + "'");
 		v.push_back("'" + Strings::Escape(e.value) + "'");
 		v.push_back(std::to_string(e.expires));
+		v.push_back(std::to_string(e.character_id));
+		v.push_back(std::to_string(e.npc_id));
+		v.push_back(std::to_string(e.bot_id));
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -226,6 +247,9 @@ public:
 			v.push_back("'" + Strings::Escape(e.key_) + "'");
 			v.push_back("'" + Strings::Escape(e.value) + "'");
 			v.push_back(std::to_string(e.expires));
+			v.push_back(std::to_string(e.character_id));
+			v.push_back(std::to_string(e.npc_id));
+			v.push_back(std::to_string(e.bot_id));
 
 			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
 		}
@@ -259,10 +283,13 @@ public:
 		for (auto row = results.begin(); row != results.end(); ++row) {
 			DataBuckets e{};
 
-			e.id      = strtoull(row[0], nullptr, 10);
-			e.key_    = row[1] ? row[1] : "";
-			e.value   = row[2] ? row[2] : "";
-			e.expires = static_cast<uint32_t>(strtoul(row[3], nullptr, 10));
+			e.id           = strtoull(row[0], nullptr, 10);
+			e.key_         = row[1] ? row[1] : "";
+			e.value        = row[2] ? row[2] : "";
+			e.expires      = static_cast<uint32_t>(strtoul(row[3], nullptr, 10));
+			e.character_id = strtoll(row[4], nullptr, 10);
+			e.npc_id       = strtoll(row[5], nullptr, 10);
+			e.bot_id       = strtoll(row[6], nullptr, 10);
 
 			all_entries.push_back(e);
 		}
@@ -287,10 +314,13 @@ public:
 		for (auto row = results.begin(); row != results.end(); ++row) {
 			DataBuckets e{};
 
-			e.id      = strtoull(row[0], nullptr, 10);
-			e.key_    = row[1] ? row[1] : "";
-			e.value   = row[2] ? row[2] : "";
-			e.expires = static_cast<uint32_t>(strtoul(row[3], nullptr, 10));
+			e.id           = strtoull(row[0], nullptr, 10);
+			e.key_         = row[1] ? row[1] : "";
+			e.value        = row[2] ? row[2] : "";
+			e.expires      = static_cast<uint32_t>(strtoul(row[3], nullptr, 10));
+			e.character_id = strtoll(row[4], nullptr, 10);
+			e.npc_id       = strtoll(row[5], nullptr, 10);
+			e.bot_id       = strtoll(row[6], nullptr, 10);
 
 			all_entries.push_back(e);
 		}

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9232
+#define CURRENT_BINARY_DATABASE_VERSION 9233
 
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9039
 

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -6033,14 +6033,10 @@ float Mob::CheckHeroicBonusesDataBuckets(std::string bucket_name)
 {
 	std::string bucket_value;
 	if (!bucket_name.empty()) {
-		const auto full_name = fmt::format(
-			"{}-{}",
-			GetBucketKey(),
-			bucket_name
-		);
-
+		DataBucketKey k = GetScopedBucketKeys();
+		k.key = bucket_name;
 		if (IsOfClientBot()) {
-			bucket_value = DataBucket::CheckBucketKey(this, full_name);
+			bucket_value = DataBucket::CheckBucketKey(this, k);
 		}
 
 		if (bucket_value.empty() || !Strings::IsNumber(bucket_value)) {

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -8193,21 +8193,16 @@ void Bot::OwnerMessage(const std::string& message)
 bool Bot::CheckDataBucket(std::string bucket_name, const std::string& bucket_value, uint8 bucket_comparison)
 {
 	if (!bucket_name.empty() && !bucket_value.empty()) {
-		auto full_name = fmt::format(
-			"{}-{}",
-			GetBucketKey(),
-			bucket_name
-		);
+		// try to fetch from bot first
+		DataBucketKey k = GetScopedBucketKeys();
+		k.key = bucket_name;
 
-		auto player_value = DataBucket::CheckBucketKey(this, full_name);
+		auto player_value = DataBucket::CheckBucketKey(this, k);
 		if (player_value.empty() && GetBotOwner()) {
-			full_name = fmt::format(
-				"{}-{}",
-				GetBotOwner()->GetBucketKey(),
-				bucket_name
-			);
+			// fetch from owner
+			k = GetBotOwner()->GetScopedBucketKeys();
 
-			player_value = DataBucket::CheckBucketKey(GetBotOwner(), full_name);
+			player_value = DataBucket::CheckBucketKey(GetBotOwner(), k);
 			if (player_value.empty()) {
 				return false;
 			}

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -853,13 +853,11 @@ void Client::BulkSendMerchantInventory(int merchant_id, int npcid) {
 		auto bucket_name = ml.bucket_name;
 		auto const& bucket_value = ml.bucket_value;
 		if (!bucket_name.empty() && !bucket_value.empty()) {
-			auto full_name = fmt::format(
-				"{}-{}",
-				GetBucketKey(),
-				bucket_name
-			);
 
-			auto const& player_value = DataBucket::CheckBucketKey(this, full_name);
+			DataBucketKey k = GetScopedBucketKeys();
+			k.key = bucket_name;
+
+			auto const& player_value = DataBucket::CheckBucketKey(this, k);
 			if (player_value.empty()) {
 				continue;
 			}

--- a/zone/data_bucket.cpp
+++ b/zone/data_bucket.cpp
@@ -19,7 +19,7 @@ void DataBucket::SetData(const std::string &bucket_key, const std::string &bucke
 	DataBucket::SetData(k);
 }
 
-void DataBucket::SetData(const DataBucketKey& k)
+void DataBucket::SetData(const DataBucketKey &k)
 {
 	auto r = DataBucketsRepository::GetWhere(
 		database,
@@ -66,7 +66,7 @@ std::string DataBucket::GetData(const std::string &bucket_key)
 	return GetData(k);
 }
 
-std::string DataBucket::GetData(const DataBucketKey& k)
+std::string DataBucket::GetData(const DataBucketKey &k)
 {
 	auto r = DataBucketsRepository::GetWhere(
 		database,
@@ -109,7 +109,7 @@ bool DataBucket::DeleteData(const std::string &bucket_key)
 bool DataBucket::GetDataBuckets(Mob *mob)
 {
 	DataBucketKey k = mob->GetScopedBucketKeys();
-	auto l = BaseDataBucketsRepository::GetWhere(
+	auto          l = BaseDataBucketsRepository::GetWhere(
 		database,
 		fmt::format(
 			"{} (`expires` > {} OR `expires` = 0)",
@@ -138,7 +138,7 @@ bool DataBucket::GetDataBuckets(Mob *mob)
 	return true;
 }
 
-std::string DataBucket::CheckBucketKey(const Mob *mob, const DataBucketKey& k)
+std::string DataBucket::CheckBucketKey(const Mob *mob, const DataBucketKey &k)
 {
 	std::string     bucket_value;
 	for (const auto &d: mob->m_data_bucket_cache) {
@@ -150,7 +150,7 @@ std::string DataBucket::CheckBucketKey(const Mob *mob, const DataBucketKey& k)
 	return bucket_value;
 }
 
-bool DataBucket::DeleteData(const DataBucketKey& k)
+bool DataBucket::DeleteData(const DataBucketKey &k)
 {
 	return DataBucketsRepository::DeleteWhere(
 		database,
@@ -162,7 +162,7 @@ bool DataBucket::DeleteData(const DataBucketKey& k)
 	);
 }
 
-std::string DataBucket::GetDataExpires(const DataBucketKey& k)
+std::string DataBucket::GetDataExpires(const DataBucketKey &k)
 {
 	auto r = DataBucketsRepository::GetWhere(
 		database,
@@ -180,7 +180,7 @@ std::string DataBucket::GetDataExpires(const DataBucketKey& k)
 	return fmt::format("{}", r[0].expires);
 }
 
-std::string DataBucket::GetDataRemaining(const DataBucketKey& k)
+std::string DataBucket::GetDataRemaining(const DataBucketKey &k)
 {
 	auto r = DataBucketsRepository::GetWhere(
 		database,
@@ -198,7 +198,7 @@ std::string DataBucket::GetDataRemaining(const DataBucketKey& k)
 	return fmt::format("{}", r[0].expires - (long long) std::time(nullptr));
 }
 
-std::string DataBucket::GetScopedDbFilters(const DataBucketKey& k)
+std::string DataBucket::GetScopedDbFilters(const DataBucketKey &k)
 {
 	std::vector<std::string> query = {};
 	if (k.character_id > 0) {
@@ -211,5 +211,9 @@ std::string DataBucket::GetScopedDbFilters(const DataBucketKey& k)
 		query.emplace_back(fmt::format("bot_id = {}", k.bot_id));
 	}
 
-	return Strings::Join(query, " AND ") + " AND ";
+	return fmt::format(
+		"{} {}",
+		Strings::Join(query, " AND "),
+		!query.empty() ? "AND" : ""
+	);
 }

--- a/zone/data_bucket.cpp
+++ b/zone/data_bucket.cpp
@@ -211,7 +211,7 @@ std::string DataBucket::GetScopedDbFilters(const DataBucketKey& k)
 		query.emplace_back(fmt::format("bot_id = {}", k.bot_id));
 	}
 
-	return Strings::Join(query, " AND ");
+	return Strings::Join(query, " AND ") + " AND ";
 }
 
 

--- a/zone/data_bucket.cpp
+++ b/zone/data_bucket.cpp
@@ -213,6 +213,3 @@ std::string DataBucket::GetScopedDbFilters(const DataBucketKey& k)
 
 	return Strings::Join(query, " AND ") + " AND ";
 }
-
-
-

--- a/zone/data_bucket.cpp
+++ b/zone/data_bucket.cpp
@@ -1,173 +1,120 @@
 #include "data_bucket.h"
 #include "zonedb.h"
+#include "mob.h"
 #include <ctime>
 #include <cctype>
+#include "../common/repositories/data_buckets_repository.h"
 
-/**
- * Persists data via bucket_name as key
- * @param bucket_key
- * @param bucket_value
- * @param expires_time
- */
-void DataBucket::SetData(const std::string& bucket_key, const std::string& bucket_value, std::string expires_time) {
-	uint64 bucket_id = DataBucket::DoesBucketExist(bucket_key);
+void DataBucket::SetData(const std::string &bucket_key, const std::string &bucket_value, std::string expires_time)
+{
+	auto k = DataBucketKey{
+		.key = bucket_key,
+		.value = bucket_value,
+		.expires = expires_time,
+		.character_id = 0,
+		.npc_id = 0,
+		.bot_id = 0
+	};
 
-	std::string query;
+	DataBucket::SetData(k);
+}
+
+void DataBucket::SetData(const DataBucketKey& k)
+{
+	auto r = DataBucketsRepository::GetWhere(
+		database,
+		fmt::format(
+			"`key` = '{}' AND (`expires` > {} OR `expires` = 0) LIMIT 1",
+			Strings::Escape(k.key),
+			(long long) std::time(nullptr)
+		)
+	);
+
+	// if we have an entry, use it
+	auto b = DataBucketsRepository::NewEntity();
+	if (!r.empty()) {
+		b = r[0];
+	}
+
+	uint64    bucket_id         = b.id;
 	long long expires_time_unix = 0;
 
-	if (!expires_time.empty()) {
-		if (isalpha(expires_time[0]) || isalpha(expires_time[expires_time.length() - 1])) {
-			expires_time_unix = (long long) std::time(nullptr) + Strings::TimeToSeconds(expires_time);
-		} else {
-			expires_time_unix = (long long) std::time(nullptr) + Strings::ToInt(expires_time);
+	if (!k.expires.empty()) {
+		expires_time_unix = (long long) std::time(nullptr) + Strings::ToInt(k.expires);
+		if (isalpha(k.expires[0]) || isalpha(k.expires[k.expires.length() - 1])) {
+			expires_time_unix = (long long) std::time(nullptr) + Strings::TimeToSeconds(k.expires);
 		}
 	}
 
 	if (bucket_id > 0) {
-		std::string update_expired_time;
-		if (expires_time_unix > 0) {
-			update_expired_time = StringFormat(", `expires` = %lld ", expires_time_unix);
-		}
-
-		query = StringFormat(
-				"UPDATE `data_buckets` SET `value` = '%s' %s WHERE `id` = %i",
-				Strings::Escape(bucket_value).c_str(),
-				Strings::Escape(update_expired_time).c_str(),
-				bucket_id
-		);
+		b.expires = expires_time_unix;
+		b.value   = k.value;
+		DataBucketsRepository::UpdateOne(database, b);
 	}
 	else {
-		query = StringFormat(
-				"INSERT INTO `data_buckets` (`key`, `value`, `expires`) VALUES ('%s', '%s', '%lld')",
-				Strings::Escape(bucket_key).c_str(),
-				Strings::Escape(bucket_value).c_str(),
-				expires_time_unix
-		);
+		b.expires = expires_time_unix;
+		b.key_    = k.key;
+		b.value   = k.value;
+		DataBucketsRepository::InsertOne(database, b);
 	}
-
-	database.QueryDatabase(query);
 }
 
-/**
- * Retrieves data via bucket_name as key
- * @param bucket_key
- * @return
- */
-std::string DataBucket::GetData(const std::string& bucket_key) {
-	std::string query = StringFormat(
-			"SELECT `value` from `data_buckets` WHERE `key` = '%s' AND (`expires` > %lld OR `expires` = 0)  LIMIT 1",
-			bucket_key.c_str(),
-			(long long) std::time(nullptr)
-	);
-
-	auto results = database.QueryDatabase(query);
-	if (!results.Success()) {
-		return std::string();
-	}
-
-	if (results.RowCount() != 1)
-		return std::string();
-
-	auto row = results.begin();
-
-	return std::string(row[0]);
-}
-
-/**
- * Retrieves data expires time via bucket_name as key
- * @param bucket_key
- * @return
- */
-std::string DataBucket::GetDataExpires(const std::string& bucket_key) {
-	std::string query = StringFormat(
-			"SELECT `expires` from `data_buckets` WHERE `key` = '%s' AND (`expires` > %lld OR `expires` = 0)  LIMIT 1",
-			bucket_key.c_str(),
-			(long long) std::time(nullptr)
-	);
-
-	auto results = database.QueryDatabase(query);
-	if (!results.Success()) {
-		return std::string();
-	}
-
-	if (results.RowCount() != 1)
-		return std::string();
-
-	auto row = results.begin();
-
-	return std::string(row[0]);
-}
-
-std::string DataBucket::GetDataRemaining(const std::string& bucket_key) {
-	if (DataBucket::GetDataExpires(bucket_key).empty()) {
-		return "0";
-	}
-	std::string query = fmt::format(
-		"SELECT (`expires` - UNIX_TIMESTAMP()) AS `remaining` from `data_buckets` WHERE `key` = '{}' AND (`expires` > {} OR `expires` = 0) LIMIT 1",
-		bucket_key.c_str(),
-		(long long) std::time(nullptr)
-	);
-
-	auto results = database.QueryDatabase(query);
-	if (!results.Success()) {
-		return std::string();
-	}
-
-	if (results.RowCount() != 1)
-		return std::string();
-
-	auto row = results.begin();
-
-	return std::string(row[0]);
-}
-
-/**
- * Checks for bucket existence by bucket_name key
- * @param bucket_key
- * @return
- */
-uint64 DataBucket::DoesBucketExist(const std::string& bucket_key) {
-	std::string query = StringFormat(
-			"SELECT `id` from `data_buckets` WHERE `key` = '%s' AND (`expires` > %lld OR `expires` = 0) LIMIT 1",
-			Strings::Escape(bucket_key).c_str(),
-			(long long) std::time(nullptr)
-	);
-
-	auto results = database.QueryDatabase(query);
-	if (!results.Success()) {
-		return 0;
-	}
-
-	auto row = results.begin();
-	if (results.RowCount() != 1)
-		return 0;
-
-	return Strings::ToUnsignedBigInt(row[0]);
-}
-
-/**
- * Deletes data bucket by key
- * @param bucket_key
- * @return
- */
-bool DataBucket::DeleteData(const std::string& bucket_key) {
-	std::string query = StringFormat(
-			"DELETE FROM `data_buckets` WHERE `key` = '%s'",
-			Strings::Escape(bucket_key).c_str()
-	);
-
-	auto results = database.QueryDatabase(query);
-
-	return results.Success();
-}
-
-bool DataBucket::GetDataBuckets(Mob* mob)
+std::string DataBucket::GetData(const std::string &bucket_key)
 {
+	DataBucketKey k = {};
+	k.key = bucket_key;
+	return GetData(k);
+}
+
+std::string DataBucket::GetData(const DataBucketKey& k)
+{
+	auto r = DataBucketsRepository::GetWhere(
+		database,
+		fmt::format(
+			"`key` = '{}' AND (`expires` > {} OR `expires` = 0) LIMIT 1",
+			k.key,
+			(long long) std::time(nullptr)
+		)
+	);
+
+	if (r.empty()) {
+		return {};
+	}
+
+	return r[0].value;
+}
+
+std::string DataBucket::GetDataExpires(const std::string &bucket_key)
+{
+	DataBucketKey k = {};
+	k.key = bucket_key;
+
+	return GetDataExpires(k);
+}
+
+std::string DataBucket::GetDataRemaining(const std::string &bucket_key)
+{
+	DataBucketKey k = {};
+	k.key = bucket_key;
+	return GetDataRemaining(k);
+}
+
+bool DataBucket::DeleteData(const std::string &bucket_key)
+{
+	DataBucketKey r = {};
+	r.key = bucket_key;
+	return DeleteData(r);
+}
+
+bool DataBucket::GetDataBuckets(Mob *mob)
+{
+	DataBucketKey k = mob->GetScopedBucketKeys();
 	auto l = BaseDataBucketsRepository::GetWhere(
 		database,
 		fmt::format(
-			"`key` LIKE '{}-%'",
-			Strings::Escape(mob->GetBucketKey())
+			"{} (`expires` > {} OR `expires` = 0)",
+			DataBucket::GetScopedDbFilters(k),
+			(long long) std::time(nullptr)
 		)
 	);
 
@@ -179,10 +126,10 @@ bool DataBucket::GetDataBuckets(Mob* mob)
 
 	DataBucketCache d;
 
-	for (const auto& e : l) {
-		d.bucket_id = e.id;
-		d.bucket_key = e.key_;
-		d.bucket_value = e.value;
+	for (const auto &e: l) {
+		d.bucket_id      = e.id;
+		d.bucket_key     = e.key_;
+		d.bucket_value   = e.value;
 		d.bucket_expires = e.expires;
 
 		mob->m_data_bucket_cache.emplace_back(d);
@@ -191,15 +138,81 @@ bool DataBucket::GetDataBuckets(Mob* mob)
 	return true;
 }
 
-std::string DataBucket::CheckBucketKey(const Mob* mob, std::string_view full_name)
+std::string DataBucket::CheckBucketKey(const Mob *mob, const DataBucketKey& k)
 {
-	std::string bucket_value;
-	for (const auto &d : mob->m_data_bucket_cache) {
-		if (d.bucket_key == full_name) {
+	std::string     bucket_value;
+	for (const auto &d: mob->m_data_bucket_cache) {
+		if (d.bucket_key == k.key) {
 			bucket_value = d.bucket_value;
 			break;
 		}
 	}
 	return bucket_value;
 }
+
+bool DataBucket::DeleteData(const DataBucketKey& k)
+{
+	return DataBucketsRepository::DeleteWhere(
+		database,
+		fmt::format(
+			"{} `key` = '{}'",
+			DataBucket::GetScopedDbFilters(k),
+			k.key
+		)
+	);
+}
+
+std::string DataBucket::GetDataExpires(const DataBucketKey& k)
+{
+	auto r = DataBucketsRepository::GetWhere(
+		database,
+		fmt::format(
+			"`key` = '{}' AND (`expires` > {} OR `expires` = 0) LIMIT 1",
+			k.key,
+			(long long) std::time(nullptr)
+		)
+	);
+
+	if (r.empty()) {
+		return {};
+	}
+
+	return fmt::format("{}", r[0].expires);
+}
+
+std::string DataBucket::GetDataRemaining(const DataBucketKey& k)
+{
+	auto r = DataBucketsRepository::GetWhere(
+		database,
+		fmt::format(
+			"`key` = '{}' AND (`expires` > {} OR `expires` = 0) LIMIT 1",
+			k.key,
+			(long long) std::time(nullptr)
+		)
+	);
+
+	if (r.empty()) {
+		return "0";
+	}
+
+	return fmt::format("{}", r[0].expires - (long long) std::time(nullptr));
+}
+
+std::string DataBucket::GetScopedDbFilters(const DataBucketKey& k)
+{
+	std::vector<std::string> query = {};
+	if (k.character_id > 0) {
+		query.emplace_back(fmt::format("character_id = {}", k.character_id));
+	}
+	else if (k.npc_id > 0) {
+		query.emplace_back(fmt::format("npc_id = {}", k.npc_id));
+	}
+	else if (k.bot_id > 0) {
+		query.emplace_back(fmt::format("bot_id = {}", k.bot_id));
+	}
+
+	return Strings::Join(query, " AND ");
+}
+
+
 

--- a/zone/data_bucket.cpp
+++ b/zone/data_bucket.cpp
@@ -24,7 +24,8 @@ void DataBucket::SetData(const DataBucketKey &k)
 	auto r = DataBucketsRepository::GetWhere(
 		database,
 		fmt::format(
-			"`key` = '{}' AND (`expires` > {} OR `expires` = 0) LIMIT 1",
+			"{} `key` = '{}' AND (`expires` > {} OR `expires` = 0) LIMIT 1",
+			DataBucket::GetScopedDbFilters(k),
 			Strings::Escape(k.key),
 			(long long) std::time(nullptr)
 		)
@@ -71,7 +72,8 @@ std::string DataBucket::GetData(const DataBucketKey &k)
 	auto r = DataBucketsRepository::GetWhere(
 		database,
 		fmt::format(
-			"`key` = '{}' AND (`expires` > {} OR `expires` = 0) LIMIT 1",
+			"{} `key` = '{}' AND (`expires` > {} OR `expires` = 0) LIMIT 1",
+			DataBucket::GetScopedDbFilters(k),
 			k.key,
 			(long long) std::time(nullptr)
 		)
@@ -167,7 +169,8 @@ std::string DataBucket::GetDataExpires(const DataBucketKey &k)
 	auto r = DataBucketsRepository::GetWhere(
 		database,
 		fmt::format(
-			"`key` = '{}' AND (`expires` > {} OR `expires` = 0) LIMIT 1",
+			"{} `key` = '{}' AND (`expires` > {} OR `expires` = 0) LIMIT 1",
+			DataBucket::GetScopedDbFilters(k),
 			k.key,
 			(long long) std::time(nullptr)
 		)
@@ -185,7 +188,8 @@ std::string DataBucket::GetDataRemaining(const DataBucketKey &k)
 	auto r = DataBucketsRepository::GetWhere(
 		database,
 		fmt::format(
-			"`key` = '{}' AND (`expires` > {} OR `expires` = 0) LIMIT 1",
+			"{} `key` = '{}' AND (`expires` > {} OR `expires` = 0) LIMIT 1",
+			DataBucket::GetScopedDbFilters(k),
 			k.key,
 			(long long) std::time(nullptr)
 		)

--- a/zone/data_bucket.cpp
+++ b/zone/data_bucket.cpp
@@ -37,6 +37,14 @@ void DataBucket::SetData(const DataBucketKey &k)
 		b = r[0];
 	}
 
+	if (k.character_id > 0) {
+		b.character_id = k.character_id;
+	} else if (k.npc_id > 0) {
+		b.npc_id = k.npc_id;
+	} else if (k.bot_id > 0) {
+		b.bot_id = k.bot_id;
+	}
+
 	uint64    bucket_id         = b.id;
 	long long expires_time_unix = 0;
 

--- a/zone/data_bucket.h
+++ b/zone/data_bucket.h
@@ -22,7 +22,7 @@ struct DataBucketKey {
 
 class DataBucket {
 public:
-	// non-scoped bucket methods
+	// non-scoped bucket methods (for global buckets)
 	static void SetData(const std::string& bucket_key, const std::string& bucket_value, std::string expires_time = "");
 	static bool DeleteData(const std::string& bucket_key);
 	static std::string GetData(const std::string& bucket_key);

--- a/zone/data_bucket.h
+++ b/zone/data_bucket.h
@@ -10,18 +10,35 @@
 #include "../common/repositories/data_buckets_repository.h"
 #include "mob.h"
 
+
+struct DataBucketKey {
+	std::string key;
+	std::string value;
+	std::string expires;
+	int64_t     character_id;
+	int64_t     npc_id;
+	int64_t     bot_id;
+};
+
 class DataBucket {
 public:
+	// non-scoped bucket methods
 	static void SetData(const std::string& bucket_key, const std::string& bucket_value, std::string expires_time = "");
 	static bool DeleteData(const std::string& bucket_key);
 	static std::string GetData(const std::string& bucket_key);
 	static std::string GetDataExpires(const std::string& bucket_key);
 	static std::string GetDataRemaining(const std::string& bucket_key);
-	static bool GetDataBuckets(Mob* mob);
-	static std::string CheckBucketKey(const Mob* mob, std::string_view full_name);
 
-private:
-	static uint64 DoesBucketExist(const std::string& bucket_key);
+	static bool GetDataBuckets(Mob* mob);
+
+	// scoped bucket methods
+	static void SetData(const DataBucketKey& k);
+	static bool DeleteData(const DataBucketKey& k);
+	static std::string GetData(const DataBucketKey& k);
+	static std::string GetDataExpires(const DataBucketKey& k);
+	static std::string GetDataRemaining(const DataBucketKey& k);
+	static std::string CheckBucketKey(const Mob* mob, const DataBucketKey& k);
+	static std::string GetScopedDbFilters(const DataBucketKey& k);
 };
 
 #endif //EQEMU_DATABUCKET_H

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -1273,24 +1273,10 @@ uint8 Client::GetCharMaxLevelFromQGlobal() {
 
 uint8 Client::GetCharMaxLevelFromBucket()
 {
-	auto new_bucket_name = fmt::format(
-		"{}-CharMaxLevel",
-		GetBucketKey()
-	);
+	DataBucketKey k = GetScopedBucketKeys();
+	k.key = "CharMaxLevel";
 
-	auto bucket_value = DataBucket::GetData(new_bucket_name);
-	if (!bucket_value.empty()) {
-		if (Strings::IsNumber(bucket_value)) {
-			return static_cast<uint8>(Strings::ToUnsignedInt(bucket_value));
-		}
-	}
-
-	auto old_bucket_name = fmt::format(
-		"{}-CharMaxLevel",
-		CharacterID()
-	);
-
-	bucket_value = DataBucket::GetData(old_bucket_name);
+	auto bucket_value = DataBucket::GetData(k);
 	if (!bucket_value.empty()) {
 		if (Strings::IsNumber(bucket_value)) {
 			return static_cast<uint8>(Strings::ToUnsignedInt(bucket_value));

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -2353,7 +2353,7 @@ std::string Lua_Mob::GetBucketExpires(std::string bucket_name)
 std::string Lua_Mob::GetBucketKey()
 {
 	Lua_Safe_Call_String();
-	return self->GetBucketKey();
+	return {};
 }
 
 std::string Lua_Mob::GetBucketRemaining(std::string bucket_name)

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -69,6 +69,7 @@ enum class eSpecialAttacks : int {
 	ChaoticStab
 };
 
+class DataBucketKey;
 class Mob : public Entity {
 public:
 	enum CLIENT_CONN_STATUS { CLIENT_CONNECTING, CLIENT_CONNECTED, CLIENT_LINKDEAD,
@@ -1413,7 +1414,6 @@ public:
 	void DeleteBucket(std::string bucket_name);
 	std::string GetBucket(std::string bucket_name);
 	std::string GetBucketExpires(std::string bucket_name);
-	std::string GetBucketKey();
 	std::string GetBucketRemaining(std::string bucket_name);
 	void SetBucket(std::string bucket_name, std::string bucket_value, std::string expiration = "");
 
@@ -1442,6 +1442,8 @@ public:
 	void DrawDebugCoordinateNode(std::string node_name, const glm::vec4 vec);
 
 	void CalcHeroicBonuses(StatBonuses* newbon);
+
+	DataBucketKey GetScopedBucketKeys();
 
 protected:
 	void CommonDamage(Mob* other, int64 &damage, const uint16 spell_id, const EQ::skills::SkillType attack_skill, bool &avoidable, const int8 buffslot, const bool iBuffTic, eSpecialAttacks specal = eSpecialAttacks::None);

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -2420,7 +2420,7 @@ std::string Perl_Mob_GetBucketExpires(Mob* self, std::string bucket_name) // @ca
 
 std::string Perl_Mob_GetBucketKey(Mob* self) // @categories Script Utility
 {
-	return self->GetBucketKey();
+	return {};
 }
 
 std::string Perl_Mob_GetBucketRemaining(Mob* self, std::string bucket_name) // @categories Script Utility

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -5877,13 +5877,10 @@ bool Client::SpellBucketCheck(uint16 spell_id, uint32 character_id) {
 		return true; // If the entry in the spell_buckets table has nothing set for the qglobal name, allow scribing.
 	}
 
-	auto new_bucket_name = fmt::format(
-		"{}-{}",
-		GetBucketKey(),
-		spell_bucket_name
-	);
+	DataBucketKey k = GetScopedBucketKeys();
+	k.key = spell_bucket_name;
 
-	auto bucket_value = DataBucket::GetData(new_bucket_name);
+	auto bucket_value = DataBucket::GetData(k);
 	if (!bucket_value.empty()) {
 		if (Strings::IsNumber(bucket_value) && Strings::IsNumber(spell_bucket_value)) {
 			if (Strings::ToInt(bucket_value) >= Strings::ToInt(spell_bucket_value)) {


### PR DESCRIPTION
## What

This PR implements scoped data buckets

This means that for common primitives such as `character` `npc` or `bot` that use data-buckets that we represent them as their own columns within the data model and have a unique constraints applied against them.

For example, Quest API methods that use `mob:SetData(name, value)` will automatically scope the `key` to the entity under the hood without an operator needing to additionally add nested keying.

This PR also is pre-cursor to other work, such as distributed data bucket caching and other features.

**This PR still needs to be tested in its entirety**

## Goal(s)

* Allow for easier manipulation of `data_buckets` as it relates to a mechanism for storing character progress and flags to copy a character, migrate a character's flags and easily select what flags are unique to a specific player
* Maintain the simplicity of using data buckets
* Allow EQEmu Server developers and operators alike to maintain a simple way to manage flagging on a per-entity basis
* This will allow the creation of a simplified flagging interface for characters so they can be a common language across servers and Quest API's 

## Current

Right now, data-buckets are arbitrary k/v pairs, which should be the case when using a k/v store and this mostly works without issue, you can store things as arbitrary k/v and key however you wish. 

```
describe data_buckets;
+---------+---------------------+------+-----+---------+----------------+
| Field   | Type                | Null | Key | Default | Extra          |
+---------+---------------------+------+-----+---------+----------------+
| id      | bigint(11) unsigned | NO   | PRI | NULL    | auto_increment |
| key     | varchar(100)        | YES  | MUL | NULL    |                |
| value   | text                | YES  |     | NULL    |                |
| expires | int(11) unsigned    | YES  |     | 0       |                |
+---------+---------------------+------+-----+---------+----------------+
4 rows in set (0.07 sec)
```

## Challenge

The part where this breaks down is when you want to easily query what flags or buckets that are tied to a specific entity, unless you have a consistent keying convention that all servers use, it is difficult to understand what is tied to a character.

In the source we prepend identifiers, but unless you are going through the quest abstraction of using `Mob::SetBucket` your values may or may not be tied to that entity. Some servers use their own set of prefixes or sometimes even suffixes to append uniqueness to their keys and does not allow for simplicity of the API.

We need a way to scope this, still keep pairs arbitrary but can be specific to at least a character.

```cpp
std::string Mob::GetBucketKey() {  
	if (IsClient()) {  
		return fmt::format("character-{}", CastToClient()->CharacterID());  
	} else if (IsNPC()) {  
		return fmt::format("npc-{}", GetNPCTypeID());  
	} else if (IsBot()) {  
		return fmt::format("bot-{}", CastToBot()->GetBotID());  
	}  
	return std::string();  
}
```

## Solution: Scoped Columns

We can add columns that scope to the player, but it will need to change how we query the data. 

Instead of just having the key be the absolute unique component, it will need to extend to each scoped entity, in this case `character_id`, `npc_id` and `bot_id`. 

### Schema

If we were to implement the equivalent `character_id` `npc_id` `bot_id` scoped entries the schema would resemble the following

```sql
ALTER TABLE `data_buckets` 
ADD COLUMN `character_id` bigint(11) NOT NULL DEFAULT 0 AFTER `expires`,
ADD COLUMN `npc_id` bigint(11) NOT NULL DEFAULT 0 AFTER `character_id`,
ADD COLUMN `bot_id` bigint(11) NOT NULL DEFAULT 0 AFTER `npc_id`,
DROP INDEX `key_index`,
ADD UNIQUE INDEX `keys`(`key`,`character_id`,`npc_id`,`bot_id`)
```

We drop the old `key_index` which **only** enforced uniqueness on the `key` column, we need to extend this uniqueness to other types.

### Testing Schema

If we were to test this schema it would end up looking something like

![Pasted image 20230715232849](https://github.com/EQEmu/Server/assets/3319450/2b01c3b7-0f17-4d9b-a422-779db42cc08c)

We're using `something` as a key and we have a unique entry globally `character_id` and `npc_id` are 0 while we have entries that are scoped to a specific `character_id` and a `npc_id` separately. 

The moment we try to add a 4th entry that is then the same as a record previously added for the same `npc_id` we get:

![Pasted image 20230715232953](https://github.com/EQEmu/Server/assets/3319450/741bb610-df31-469a-9786-65d03216c8fe)

Similar test applies when we add the `bot_id` field, we can add a `key` that is unique to that `bot_id` without issue while existing with the other flags.

![Pasted image 20230715233140](https://github.com/EQEmu/Server/assets/3319450/f4f5f669-2b19-4164-b4cf-2af28c9e5dba)

## Migration

We'd need to have a means to migrate from the existing code-level abstraction of how flags are defined per-character or per-npc in this case. We could do so while doing a select using the code format that is listed in the code above. This would result in a one-time migration of flags and while that is done, code changes would also have to be made in the current abstractions to add a scope to what column is being selected and written to during the `Get` and `Set` operations of the Quest API

### Conversion example query

Below we show `character_id` being pulled out of the original format we had in the code.

We also pull out `bucket_name` similarly.

```sql
SELECT
	`key`,
	SUBSTRING_INDEX(SUBSTRING_INDEX( `key`, '-', 2 ), '-', -1) as character_id,
	SUBSTR(SUBSTRING_INDEX(`key`, SUBSTRING_INDEX( `key`, '-', 2 ), -1), 2) as bucket_name
FROM
	data_buckets 
WHERE
	`key` LIKE 'character-%';
```

![Pasted image 20230716034423](https://github.com/EQEmu/Server/assets/3319450/e7808142-6849-41a4-8ea1-130af8a47e46)

We want to see the bucket name containing the character prefix and the ID get removed from the bucket name itself and exploded onto the new scoped column

![Pasted image 20230716034440](https://github.com/EQEmu/Server/assets/3319450/a734077f-b527-4a4c-b654-31a60fb729b3)

### Final Conversion

```sql
UPDATE data_buckets SET character_id = SUBSTRING_INDEX(SUBSTRING_INDEX( `key`, '-', 2 ), '-', -1), `key` = SUBSTR(SUBSTRING_INDEX(`key`, SUBSTRING_INDEX( `key`, '-', 2 ), -1), 2) WHERE `key` LIKE 'character-%';
UPDATE data_buckets SET npc_id = SUBSTRING_INDEX(SUBSTRING_INDEX( `key`, '-', 2 ), '-', -1), `key` = SUBSTR(SUBSTRING_INDEX(`key`, SUBSTRING_INDEX( `key`, '-', 2 ), -1), 2) WHERE `key` LIKE 'npc-%';
UPDATE data_buckets SET bot_id = SUBSTRING_INDEX(SUBSTRING_INDEX( `key`, '-', 2 ), '-', -1), `key` = SUBSTR(SUBSTRING_INDEX(`key`, SUBSTRING_INDEX( `key`, '-', 2 ), -1), 2) WHERE `key` LIKE 'bot-%';
```