### PR TITLE
[Pathing] Improvements to roambox logic, pathing

### DIFF
--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -1074,10 +1074,12 @@ void Mob::AI_Process() {
 			bool is_moving = IsMoving() && !(IsRooted() || IsStunned() || IsMezzed());
 			auto t         = GetTarget();
 			if (is_moving && t) {
-				float self_z   = GetZ() - GetZOffset();
-				float target_z = t->GetPosition().z - t->GetZOffset();
-				if (DistanceNoZ(GetPosition(), t->GetPosition()) < 75 &&
-					std::abs(self_z - target_z) >= 25 && !CheckLosFN(t)) {
+				float self_z            = GetZ() - GetZOffset();
+				float target_z          = t->GetPosition().z - t->GetZOffset();
+				bool  can_path_to       = CastToNPC()->CanPathTo(t->GetX(), t->GetY(), t->GetZ());
+				bool  within_distance   = DistanceNoZ(GetPosition(), t->GetPosition()) < 75;
+				bool  within_z_distance = std::abs(self_z - target_z) >= 25;
+				if (within_distance && within_z_distance && !can_path_to) {
 					float new_z = FindDestGroundZ(t->GetPosition());
 					GMMove(t->GetPosition().x, t->GetPosition().y, new_z + GetZOffset(), t->GetPosition().w, false);
 					FaceTarget(t);

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -3956,7 +3956,6 @@ bool NPC::CanPathTo(float x, float y, float z)
 	opts.offset      = GetZOffset();
 	opts.flags       = PathingNotDisabled ^ PathingZoneLine;
 
-	//This is probably pointless since the nav mesh tool currently sets zonelines to disabled anyway
 	auto partial = false;
 	auto stuck   = false;
 	auto route   = zone->pathing->FindPath(
@@ -3967,5 +3966,5 @@ bool NPC::CanPathTo(float x, float y, float z)
 		opts
 	);
 
-	return route.size();
+	return !route.empty();
 }

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -3825,9 +3825,14 @@ void NPC::HandleRoambox()
 			auto requested_y = EQ::Clamp((GetY() + move_y), m_roambox.min_y, m_roambox.max_y);
 			auto requested_z = GetGroundZ(requested_x, requested_y);
 
+			if (std::abs(requested_z - GetZ()) > 100) {
+				LogNPCRoamBox("[{}] | Failed to find reasonable ground [{}]", GetCleanName(), i);
+				continue;
+			}
+
 			std::vector<float> heights = {0, 250, -250};
 			for (auto &h: heights) {
-				if (CheckLosFN(requested_x, requested_y, requested_z + h, GetSize())) {
+				if (CanPathTo(requested_x, requested_y, requested_z + h)) {
 					LogNPCRoamBox("[{}] Found line of sight to path attempt [{}] at height [{}]", GetCleanName(), i, h);
 					can_path = true;
 					break;
@@ -3941,4 +3946,26 @@ void NPC::SetTaunting(bool is_taunting) {
 	if (IsPet() && IsPetOwnerClient()) {
 		GetOwner()->CastToClient()->SetPetCommandState(PET_BUTTON_TAUNT, is_taunting);
 	}
+}
+
+bool NPC::CanPathTo(float x, float y, float z)
+{
+	PathfinderOptions opts;
+	opts.smooth_path = true;
+	opts.step_size   = RuleR(Pathing, NavmeshStepSize);
+	opts.offset      = GetZOffset();
+	opts.flags       = PathingNotDisabled ^ PathingZoneLine;
+
+	//This is probably pointless since the nav mesh tool currently sets zonelines to disabled anyway
+	auto partial = false;
+	auto stuck   = false;
+	auto route   = zone->pathing->FindPath(
+		glm::vec3(GetX(), GetY(), GetZ()),
+		glm::vec3(x, y, z),
+		partial,
+		stuck,
+		opts
+	);
+
+	return route.size();
 }

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -3956,8 +3956,8 @@ bool NPC::CanPathTo(float x, float y, float z)
 	opts.offset      = GetZOffset();
 	opts.flags       = PathingNotDisabled ^ PathingZoneLine;
 
-	auto partial = false;
-	auto stuck   = false;
+	bool partial = false;
+	bool stuck   = false;
 	auto route   = zone->pathing->FindPath(
 		glm::vec3(GetX(), GetY(), GetZ()),
 		glm::vec3(x, y, z),

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -541,6 +541,8 @@ public:
 
 	static LootDropEntries_Struct NewLootDropEntry();
 
+	bool CanPathTo(float x, float y, float z);
+
 protected:
 
 	void HandleRoambox();

--- a/zone/waypoints.cpp
+++ b/zone/waypoints.cpp
@@ -846,8 +846,15 @@ void Mob::FixZ(int32 z_find_offset /*= 5*/, bool fix_client_z /*= false*/) {
 	glm::vec3 current_loc(m_Position);
 	float new_z = GetFixedZ(current_loc, z_find_offset);
 
-	if (new_z == m_Position.z)
+	// reject z if it is too far from the current z
+	if (std::abs(new_z - m_Position.z) > 100) {
 		return;
+	}
+
+	// reject if it's the same as the current z
+	if (new_z == m_Position.z) {
+		return;
+	}
 
 	if ((new_z > -2000) && new_z != BEST_Z_INVALID) {
 		if (RuleB(Map, MobZVisualDebug)) {


### PR DESCRIPTION
This PR improves pathing

* Roambox logic when path finding will now reject random paths that result in a z difference of 100 units or more. This prevents mobs from choosing to climb mountains like a goat looking entirely unnatural. This will allow mobs to choose more sane pathing decisions.
* Roambox logic no longer relies on line of sight for path finding, it uses the navmesh data to determine if the path is findable, if the path can not be routed to, it will return and attempt another path (there are 10 attempts to find a path in one roambox path finding cycle)
* Should resolve an issue where if an NPC gets drug out of its roambox and it no longer chooses to route back to the roambox because it no longer has line of sight
* Z-Clipping correction now uses navigation mesh path finding to determine clipping instead of only using LOS
* FixZ now rejects new z's dramatically different from their current (over 100 units) this is because sometimes you can have bad geometry in zones that produced bad map data and you can suddenly find a ground Z significantly lower than where the NPC actually is. This is another issue that can lead to clipping

### Tests

Testing for NPC's going out of bounds

![image](https://github.com/EQEmu/Server/assets/3319450/9c773967-9c83-459b-94a5-04456bb691b1)

Testing to ensure NPC's don't bunch when in a hole (even distribution)

![image](https://github.com/EQEmu/Server/assets/3319450/214742dc-5360-4d5c-af3a-fe1197c9d9b8)

![image](https://github.com/EQEmu/Server/assets/3319450/8e24f855-878d-481d-a548-4c2e11d5dc5d)

![image](https://github.com/EQEmu/Server/assets/3319450/70d8ccd8-2e4f-4541-855c-ce1d56866b4f)

Testing to ensure NPC's don't climb steep hills

![image](https://github.com/EQEmu/Server/assets/3319450/cfaeebd6-a618-48e9-ae4c-04ec9b31a351)
