### PR TITLE
[Databuckets] Fix issue with expired databuckets not being expired and returned properly

### DIFF
--- a/zone/data_bucket.h
+++ b/zone/data_bucket.h
@@ -34,7 +34,7 @@ public:
 	// scoped bucket methods
 	static void SetData(const DataBucketKey& k);
 	static bool DeleteData(const DataBucketKey& k);
-	static std::string GetData(const DataBucketKey& k);
+	static DataBucketsRepository::DataBuckets GetData(const DataBucketKey& k);
 	static std::string GetDataExpires(const DataBucketKey& k);
 	static std::string GetDataRemaining(const DataBucketKey& k);
 	static std::string CheckBucketKey(const Mob* mob, const DataBucketKey& k);

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -1276,10 +1276,10 @@ uint8 Client::GetCharMaxLevelFromBucket()
 	DataBucketKey k = GetScopedBucketKeys();
 	k.key = "CharMaxLevel";
 
-	auto bucket_value = DataBucket::GetData(k);
-	if (!bucket_value.empty()) {
-		if (Strings::IsNumber(bucket_value)) {
-			return static_cast<uint8>(Strings::ToUnsignedInt(bucket_value));
+	auto b = DataBucket::GetData(k);
+	if (!b.value.empty()) {
+		if (Strings::IsNumber(b.value)) {
+			return static_cast<uint8>(Strings::ToUnsignedInt(b.value));
 		}
 	}
 

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -8062,9 +8062,9 @@ std::string Mob::GetBucket(std::string bucket_name)
 	DataBucketKey k = GetScopedBucketKeys();
 	k.key = bucket_name;
 
-	std::string bucket_value = DataBucket::GetData(k);
-	if (!bucket_value.empty()) {
-		return bucket_value;
+	auto b = DataBucket::GetData(k);
+	if (!b.value.empty()) {
+		return b.value;
 	}
 	return {};
 }

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -5880,14 +5880,14 @@ bool Client::SpellBucketCheck(uint16 spell_id, uint32 character_id) {
 	DataBucketKey k = GetScopedBucketKeys();
 	k.key = spell_bucket_name;
 
-	auto bucket_value = DataBucket::GetData(k);
-	if (!bucket_value.empty()) {
-		if (Strings::IsNumber(bucket_value) && Strings::IsNumber(spell_bucket_value)) {
-			if (Strings::ToInt(bucket_value) >= Strings::ToInt(spell_bucket_value)) {
+	auto b = DataBucket::GetData(k);
+	if (!b.value.empty()) {
+		if (Strings::IsNumber(b.value) && Strings::IsNumber(spell_bucket_value)) {
+			if (Strings::ToInt(b.value) >= Strings::ToInt(spell_bucket_value)) {
 				return true; // If value is greater than or equal to spell bucket value, allow scribing.
 			}
 		} else {
-			if (bucket_value == spell_bucket_value) {
+			if (b.value == spell_bucket_value) {
 				return true; // If value is equal to spell bucket value, allow scribing.
 			}
 		}
@@ -5899,7 +5899,7 @@ bool Client::SpellBucketCheck(uint16 spell_id, uint32 character_id) {
 		spell_bucket_name
 	);
 
-	bucket_value = DataBucket::GetData(old_bucket_name);
+	auto bucket_value = DataBucket::GetData(old_bucket_name);
 	if (!bucket_value.empty()) {
 		if (Strings::IsNumber(bucket_value) && Strings::IsNumber(spell_bucket_value)) {
 			if (Strings::ToInt(bucket_value) >= Strings::ToInt(spell_bucket_value)) {


### PR DESCRIPTION
Fix issue with expired databuckets not being expired and returned properly

**Testing**

```lua
function event_say(e)
    local ldon_request_timer_bucket = ("LDoN_Request-"..e.self:CharacterID());

    if eq.get_data(ldon_request_timer_bucket) ~= "" then
      e.self:DialogueWindow(string.format("{red} You must wait longer before re-requesting an adventure.~"));
      return;
    else
        e.self:DialogueWindow(string.format("{green} YOU CAN REQUEST ONE NOW.~"));
    end
    
    eq.set_data(ldon_request_timer_bucket,"1",tostring(eq.seconds("1m"))); -- 1 minute request cooldown
end
```

Before expired

![image](https://github.com/EQEmu/Server/assets/3319450/42788314-a84b-4e56-b9ef-1c1c8ec0ccdf)

When expired

![image](https://github.com/EQEmu/Server/assets/3319450/8aa03555-6b27-4ec8-961d-3125927a506c)
