### PR TITLE
[Crash Fix] Guard against Spells:MaxTotalSlotsPET being set above client allowed maximum.

### DIFF
--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -3303,7 +3303,8 @@ void ZoneDatabase::SavePetInfo(Client *client)
 
 		// build pet buffs into struct
 		int pet_buff_count = 0;
-		int max_slots = RuleI(Spells, MaxTotalSlotsPET) > 30 ? 30 : RuleI(Spells, MaxTotalSlotsPET);
+		// Guard against setting the maximum pet slots above the client allowed maximum.
+		int max_slots = RuleI(Spells, MaxTotalSlotsPET) > PET_BUFF_COUNT ? PET_BUFF_COUNT : RuleI(Spells, MaxTotalSlotsPET);
 
 		// count pet buffs
 		for (int index = 0; index < max_slots; index++) {

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -3303,7 +3303,7 @@ void ZoneDatabase::SavePetInfo(Client *client)
 
 		// build pet buffs into struct
 		int pet_buff_count = 0;
-		int max_slots = RuleI(Spells, MaxTotalSlotsPET);
+		int max_slots = RuleI(Spells, MaxTotalSlotsPET) > 30 ? 30 : RuleI(Spells, MaxTotalSlotsPET);
 
 		// count pet buffs
 		for (int index = 0; index < max_slots; index++) {


### PR DESCRIPTION
Currently, setting Spells:MaxTotalSlotsPET above the client allowed maximum of 30 will cause the server to crash and could also cause database corruption. This caps the rule at 30.

Still doing some testing on this.