### PR TITLE
[Saylink] Fix cases where saylinks were not being cached

### DIFF
--- a/common/say_link.cpp
+++ b/common/say_link.cpp
@@ -376,7 +376,7 @@ std::string EQ::SayLinkEngine::InjectSaylinksIfNotExist(const char *message)
 
 void EQ::SayLinkEngine::LoadCachedSaylinks()
 {
-	auto saylinks = SaylinkRepository::GetWhere(database, "phrase not like '%#%'");
+	auto saylinks = SaylinkRepository::GetWhere(database, "phrase not like '%#% %' and phrase not REGEXP '[0-9]'");
 	LogSaylink("Loaded [{}] saylinks into cache", saylinks.size());
 	g_cached_saylinks = saylinks;
 }
@@ -399,6 +399,7 @@ SaylinkRepository::Saylink EQ::SayLinkEngine::GetOrSaveSaylink(std::string sayli
 
 	// return if found from the database
 	if (!saylinks.empty()) {
+		g_cached_saylinks.emplace_back(saylinks[0]);
 		return saylinks[0];
 	}
 

--- a/common/say_link.cpp
+++ b/common/say_link.cpp
@@ -376,7 +376,7 @@ std::string EQ::SayLinkEngine::InjectSaylinksIfNotExist(const char *message)
 
 void EQ::SayLinkEngine::LoadCachedSaylinks()
 {
-	auto saylinks = SaylinkRepository::GetWhere(database, "phrase not like '%#% %' and phrase not REGEXP '[0-9]'");
+	auto saylinks = SaylinkRepository::GetWhere(database, "phrase not REGEXP BINARY '[A-Z]' and phrase not REGEXP '[0-9]'");
 	LogSaylink("Loaded [{}] saylinks into cache", saylinks.size());
 	g_cached_saylinks = saylinks;
 }


### PR DESCRIPTION
This fixes some scenarios where saylinks were not being cached at all

Noticed during initial use of `#help` (every command is not cached and not cached once found)

Entries looked up from the database were not being added to the cache either once found