### PR TITLE
[Bug Fix] Escape search string in #find item

### DIFF
--- a/common/repositories/items_repository.h
+++ b/common/repositories/items_repository.h
@@ -53,7 +53,7 @@ public:
 		auto query = fmt::format(
 			"SELECT `id` FROM {} WHERE LOWER(`name`) LIKE '%%{}%%' ORDER BY id ASC",
 			TableName(),
-			search_string
+			Strings::Escape(search_string)
 		);
 
 		if (query_limit >= 1) {


### PR DESCRIPTION
# Notes
- String wasn’t being escaped, so things with `’` in the name causes issues.