### PR TITLE
[Cleanup] Fix casing in corpse money and decay time.

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -5224,12 +5224,12 @@ void Client::Handle_OP_ConsiderCorpse(const EQApplicationPacket *app)
 
 	uint32 decay_time = t->GetDecayTime();
 	if (decay_time) {
-		auto time_string = Strings::SecondsToTime(decay_time, true);
+		const std::string& time_string = Strings::SecondsToTime(decay_time, true);
 		Message(
 			Chat::NPCQuestSay,
 			fmt::format(
 				"This corpse will decay in {}.",
-				time_string
+				Strings::ToLower(time_string)
 			).c_str()
 		);
 

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -1207,7 +1207,7 @@ void Corpse::MakeLootRequestPackets(Client* client, const EQApplicationPacket* a
 			client->Message(
 				Chat::Yellow,
 				fmt::format(
-					"This corpse Contains {}.",
+					"This corpse contains {}.",
 					Strings::Money(
 						GetPlatinum(),
 						GetGold(),
@@ -1217,7 +1217,7 @@ void Corpse::MakeLootRequestPackets(Client* client, const EQApplicationPacket* a
 				).c_str()
 			);
 		} else {
-			client->Message(Chat::Yellow, "This corpse Contains no money.");
+			client->Message(Chat::Yellow, "This corpse contains no money.");
 		}
 
 		auto outapp = new EQApplicationPacket(OP_MoneyOnCorpse, sizeof(moneyOnCorpseStruct));


### PR DESCRIPTION
# Notes
- These were uppercase and should be lowercase.