### PR TITLE
[Quest API] Add GetMobTypeIdentifier() to Perl/Lua

### DIFF
--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -3133,6 +3133,12 @@ bool Lua_Mob::IsTemporaryPet()
 	return self->IsTempPet();
 }
 
+uint32 Lua_Mob::GetMobTypeIdentifier()
+{
+	Lua_Safe_Call_Int();
+	return self->GetMobTypeIdentifier();
+}
+
 luabind::scope lua_register_mob() {
 	return luabind::class_<Lua_Mob, Lua_Entity>("Mob")
 	.def(luabind::constructor<>())
@@ -3429,6 +3435,7 @@ luabind::scope lua_register_mob() {
 	.def("GetMeleeDamageMod_SE", &Lua_Mob::GetMeleeDamageMod_SE)
 	.def("GetMeleeMinDamageMod_SE", &Lua_Mob::GetMeleeMinDamageMod_SE)
 	.def("GetMeleeMitigation", (int32(Lua_Mob::*)(void))&Lua_Mob::GetMeleeMitigation)
+	.def("GetMobTypeIdentifier", (uint32(Lua_Mob::*)(void))&Lua_Mob::GetMobTypeIdentifier)
 	.def("GetModSkillDmgTaken", (int(Lua_Mob::*)(int))&Lua_Mob::GetModSkillDmgTaken)
 	.def("GetModVulnerability", (int(Lua_Mob::*)(int))&Lua_Mob::GetModVulnerability)
 	.def("GetNPCTypeID", &Lua_Mob::GetNPCTypeID)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -557,6 +557,7 @@ public:
 	std::string GetClassPlural();
 	std::string GetRacePlural();
 	bool IsTemporaryPet();
+	uint32 GetMobTypeIdentifier();
 };
 
 #endif

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -3113,6 +3113,11 @@ std::string Perl_Mob_GetClassPlural(Mob* self)
 	return self->GetClassPlural();
 }
 
+uint32 Perl_Mob_GetMobTypeIdentifier(Mob* self)
+{
+	return self->GetMobTypeIdentifier();
+}
+
 std::string Perl_Mob_GetRacePlural(Mob* self)
 {
 	return self->GetRacePlural();
@@ -3399,6 +3404,7 @@ void perl_register_mob()
 	package.add("GetMaxSTR", &Perl_Mob_GetMaxSTR);
 	package.add("GetMaxWIS", &Perl_Mob_GetMaxWIS);
 	package.add("GetMeleeMitigation", &Perl_Mob_GetMeleeMitigation);
+	package.add("GetMobTypeIdentifier", &Perl_Mob_GetMobTypeIdentifier);
 	package.add("GetModSkillDmgTaken", &Perl_Mob_GetModSkillDmgTaken);
 	package.add("GetModVulnerability", &Perl_Mob_GetModVulnerability);
 	package.add("GetNPCTypeID", &Perl_Mob_GetNPCTypeID);


### PR DESCRIPTION
# Perl
- Add `$mob->GetMobTypeIdentifier()`.

# Lua
- Add `mob:GetMobTypeIdentifier()`.

# Notes
- Gets unique identifier independent of mob type.