### PR TITLE
[Scaling/Bug Fix] Scaling where min and max damage was bugged

### DIFF
--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -2583,12 +2583,16 @@ void NPC::ModifyNPCStat(const std::string& stat, const std::string& value)
 	}
 	else if (stat_lower == "min_hit") {
 		min_dmg = Strings::ToInt(value);
+		// Clamp max_dmg to be >= min_dmg
+		max_dmg = std::max(min_dmg, max_dmg);
 		base_damage = round((max_dmg - min_dmg) / 1.9);
 		min_damage  = min_dmg - round(base_damage / 10.0);
 		return;
 	}
 	else if (stat_lower == "max_hit") {
 		max_dmg = Strings::ToInt(value);
+		// Clamp min_dmg to be <= max_dmg
+		min_dmg = std::min(min_dmg, max_dmg);
 		base_damage = round((max_dmg - min_dmg) / 1.9);
 		min_damage  = min_dmg - round(base_damage / 10.0);
 		return;

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -2583,30 +2583,12 @@ void NPC::ModifyNPCStat(const std::string& stat, const std::string& value)
 	}
 	else if (stat_lower == "min_hit") {
 		min_dmg = Strings::ToInt(value);
-
-		// TODO: fix DB
-
-		if (min_dmg > max_dmg) {
-			const auto temporary_damage = max_dmg;
-			max_dmg = min_dmg;
-			min_dmg = temporary_damage;
-		}
-
 		base_damage = round((max_dmg - min_dmg) / 1.9);
 		min_damage  = min_dmg - round(base_damage / 10.0);
 		return;
 	}
 	else if (stat_lower == "max_hit") {
 		max_dmg = Strings::ToInt(value);
-
-		// TODO: fix DB
-
-		if (max_dmg < min_dmg) {
-			const auto temporary_damage = min_dmg;
-			min_dmg = max_dmg;
-			max_dmg = temporary_damage;
-		}
-
 		base_damage = round((max_dmg - min_dmg) / 1.9);
 		min_damage  = min_dmg - round(base_damage / 10.0);
 		return;

--- a/zone/npc_scale_manager.cpp
+++ b/zone/npc_scale_manager.cpp
@@ -135,31 +135,24 @@ void NpcScaleManager::ScaleNPC(
 		npc->ModifyNPCStat("phr", std::to_string(scale_data.physical_resist));
 	}
 
-	auto min_damage_set = false;
+	// If either is scaled, both need to be.  The values for base_damage and min_damage will be in flux until
+	// both are complete.
 
-	if (always_scale || npc->GetMinDMG() == 0) {
+	if (always_scale || npc->GetMinDMG() == 0 || npc->GetMaxDMG() == 0) {
 		int64 min_dmg = scale_data.min_dmg;
+		int64 max_dmg = scale_data.max_dmg;
+
 		if (RuleB(Combat, UseNPCDamageClassLevelMods)) {
 			uint32 class_level_damage_mod = GetClassLevelDamageMod(npc->GetLevel(), npc->GetClass());
 			min_dmg = (min_dmg * class_level_damage_mod) / 220;
-
-			LogNPCScaling("ClassLevelDamageMod::min_dmg base: [{}] calc: [{}]", scale_data.min_dmg, min_dmg);
+			max_dmg = (max_dmg * class_level_damage_mod) / 220;
 		}
 
 		npc->ModifyNPCStat("min_hit", std::to_string(min_dmg));
-		min_damage_set = true;
-	}
-
-	if (always_scale || npc->GetMaxDMG() == 0 || min_damage_set) {
-		int64 max_dmg = scale_data.max_dmg;
-		if (RuleB(Combat, UseNPCDamageClassLevelMods)) {
-			uint32 class_level_damage_mod = GetClassLevelDamageMod(npc->GetLevel(), npc->GetClass());
-			max_dmg = (scale_data.max_dmg * class_level_damage_mod) / 220;
-
-			LogNPCScaling("ClassLevelDamageMod::max_dmg base: [{}] calc: [{}]", scale_data.max_dmg, max_dmg);
-		}
-
 		npc->ModifyNPCStat("max_hit", std::to_string(max_dmg));
+
+		LogNPCScaling("ClassLevelDamageMod::min_dmg base: [{}] calc: [{}]", scale_data.min_dmg, min_dmg);
+		LogNPCScaling("ClassLevelDamageMod::max_dmg base: [{}] calc: [{}]", scale_data.max_dmg, max_dmg);
 	}
 
 	if (always_scale || (npc->GetHPRegen() == 0 && is_auto_scaled)) {


### PR DESCRIPTION
This is a refinement of a fix by @Kinglykrab in the following PR:

https://github.com/EQEmu/Server/pull/3351

@Kinglykrab addressed an issue where min_dmg was 0 in db and max_dmg was not.  This caused the npc_scale_manager to only scale the min_dmg side, which can result in the min_dmg being bigger than the max_dmg.

This PR fixes a side effect of that PR wherein when min_dmg and max_dmg are both 0 in the db, setting min_dmg 1st results in min_dmg getting put into max_dmg (due to his attempts to keep max_dmg greater than min_dmg inside of ModifyNPCStat()) at all times.

My belief is that if _either min or max dmg is 0 in the db, both need to be processed.  His earlier PR assures that, so long as min_dmg is 0, but not when min_dmg is non-zero and max_dmg is 0.  Admittedly an unlikely case, but it simplifies the code tremendously to simply scale both if either is 0.

This was discovered because several special attacks like bash and kick (for scaled mobs) were saying the opponent was invulnerable.  This was due to math from the changes to npc.cpp which left min_damage (GetMinDamage()) negative and sometimes that value was -5 (DMG_INVULNERABLE) or -6 (DMG_RUNE).

eqlog_Ebola_Rolath.txt:[Tue Jun 13 15:14:40 2023] A wan ghoul knight tries to bash YOU, but  are INVULNERABLE!
eqlog_Ebola_Rolath.txt:[Tue Jun 13 15:15:12 2023] A wan ghoul knight tries to bash YOU, but  are INVULNERABLE!
eqlog_Ebola_Rolath.txt:[Tue Jun 13 15:49:58 2023] A wan ghoul knight tries to bash YOU, but  are INVULNERABLE!
eqlog_Ebola_Rolath.txt:[Tue Jun 13 16:06:20 2023] A zol ghoul knight tries to bash YOU, but  are INVULNERABLE!