### PR TITLE
[Databuckets] Improvements to distributed cache, reload commands

### DIFF
--- a/common/servertalk.h
+++ b/common/servertalk.h
@@ -249,6 +249,7 @@
 #define ServerOP_ReloadZonePoints 0x4122
 #define ServerOP_ReloadDzTemplates 0x4123
 #define ServerOP_ReloadZoneData 0x4124
+#define ServerOP_ReloadDataBucketsCache 0x4125
 
 #define ServerOP_CZDialogueWindow 0x4500
 #define ServerOP_CZLDoNUpdate 0x4501

--- a/world/eqemu_api_world_data_service.cpp
+++ b/world/eqemu_api_world_data_service.cpp
@@ -138,6 +138,7 @@ std::vector<Reload> reload_types = {
 	Reload{.command = "alternate_currencies", .opcode = ServerOP_ReloadAlternateCurrencies, .desc = "Alternate Currencies"},
 	Reload{.command = "blocked_spells", .opcode = ServerOP_ReloadBlockedSpells, .desc = "Blocked Spells"},
 	Reload{.command = "commands", .opcode = ServerOP_ReloadCommands, .desc = "Commands"},
+	Reload{.command = "data_buckets_cache", .opcode = ServerOP_ReloadDataBucketsCache, .desc = "Data Buckets Cache"},
 	Reload{.command = "doors", .opcode = ServerOP_ReloadDoors, .desc = "Doors"},
 	Reload{.command = "dztemplates", .opcode = ServerOP_ReloadDzTemplates, .desc = "Dynamic Zone Templates"},
 	Reload{.command = "ground_spawns", .opcode = ServerOP_ReloadGroundSpawns, .desc = "Ground Spawns"},

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -1343,6 +1343,7 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 		case ServerOP_ReloadBlockedSpells:
 		case ServerOP_ReloadCommands:
 		case ServerOP_ReloadDoors:
+		case ServerOP_ReloadDataBucketsCache:
 		case ServerOP_ReloadGroundSpawns:
 		case ServerOP_ReloadLevelEXPMods:
 		case ServerOP_ReloadMerchants:

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -8883,7 +8883,8 @@ void Client::ShowDevToolsMenu()
 	menu_reload_two += Saylink::Silent("#reload commands", "Commands");
 	menu_reload_two += " | " + Saylink::Silent("#reload content_flags", "Content Flags");
 
-	menu_reload_three += Saylink::Silent("#reload doors", "Doors");
+	menu_reload_three += Saylink::Silent("#reload data_buckets_cache", "Databuckets");
+	menu_reload_three += " | " + Saylink::Silent("#reload doors", "Doors");
 	menu_reload_three += " | " + Saylink::Silent("#reload ground_spawns", "Ground Spawns");
 
 	menu_reload_four += Saylink::Silent("#reload logs", "Level Based Experience Modifiers");
@@ -10834,6 +10835,16 @@ void Client::SendReloadCommandMessages() {
 		fmt::format(
 			"Usage: {} - Reloads Doors globally",
 			doors_link
+		).c_str()
+	);
+
+	auto data_buckets_link = Saylink::Silent("#reload data_buckets_cache");
+
+	Message(
+		Chat::White,
+		fmt::format(
+			"Usage: {} - Reloads data buckets cache globally",
+			data_buckets_link
 		).c_str()
 	);
 

--- a/zone/data_bucket.h
+++ b/zone/data_bucket.h
@@ -88,6 +88,7 @@ public:
 	static bool SendDataBucketCacheUpdate(const DataBucketCacheEntry &e);
 	static void HandleWorldMessage(ServerPacket *p);
 	static void DeleteFromMissesCache(DataBucketsRepository::DataBuckets e);
+	static void ClearCache();
 };
 
 #endif //EQEMU_DATABUCKET_H

--- a/zone/gm_commands/reload.cpp
+++ b/zone/gm_commands/reload.cpp
@@ -18,6 +18,7 @@ void command_reload(Client *c, const Seperator *sep)
 	bool is_blocked_spells       = !strcasecmp(sep->arg[1], "blocked_spells");
 	bool is_commands             = !strcasecmp(sep->arg[1], "commands");
 	bool is_content_flags        = !strcasecmp(sep->arg[1], "content_flags");
+	bool is_data_buckets         = !strcasecmp(sep->arg[1], "data_buckets_cache");
 	bool is_doors                = !strcasecmp(sep->arg[1], "doors");
 	bool is_dztemplates          = !strcasecmp(sep->arg[1], "dztemplates");
 	bool is_ground_spawns        = !strcasecmp(sep->arg[1], "ground_spawns");
@@ -46,6 +47,7 @@ void command_reload(Client *c, const Seperator *sep)
 		!is_blocked_spells &&
 		!is_commands &&
 		!is_content_flags &&
+		!is_data_buckets &&
 		!is_doors &&
 		!is_dztemplates &&
 		!is_ground_spawns &&
@@ -92,6 +94,9 @@ void command_reload(Client *c, const Seperator *sep)
 	} else if (is_doors) {
 		c->Message(Chat::White, "Attempting to reload Doors globally.");
 		pack = new ServerPacket(ServerOP_ReloadDoors, 0);
+	} else if (is_data_buckets) {
+		c->Message(Chat::White, "Attempting to flush data buckets cache globally.");
+		pack = new ServerPacket(ServerOP_ReloadDataBucketsCache, 0);
 	} else if (is_dztemplates) {
 		c->Message(Chat::White, "Attempting to reload Dynamic Zone Templates globally.");
 		pack = new ServerPacket(ServerOP_ReloadDzTemplates, 0);

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -2004,6 +2004,12 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 		RuleManager::Instance()->LoadRules(&database, RuleManager::Instance()->GetActiveRuleset(), true);
 		break;
 	}
+	case ServerOP_ReloadDataBucketsCache:
+	{
+		zone->SendReloadMessage("Data buckets cache");
+		DataBucket::ClearCache();
+		break;
+	}
 	case ServerOP_ReloadDoors:
 	case ServerOP_ReloadGroundSpawns:
 	case ServerOP_ReloadObjects:


### PR DESCRIPTION
This PR

* Fixes an issue where misses cache isn't properly getting cleared in certain circumstances
* Fixes an issue where updates could be potentially discarded early
* Adds command #reload data_buckets_cache to the reload menu to clear the cache

![image](https://github.com/EQEmu/Server/assets/3319450/7ad9e9cd-ca78-4c3c-8709-28acf845522f)
