### PR TITLE
[Rule] Add Rule to Disable Strings::Commify

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -300,6 +300,7 @@ RULE_BOOL(World, EnforceCharacterLimitAtLogin, false, "Enforce the limit for cha
 RULE_BOOL(World, EnableDevTools, true, "Enable or Disable the Developer Tools globally (Most of the time you want this enabled)")
 RULE_BOOL(World, EnableChecksumVerification, false, "Enable or Disable the Checksum Verification for eqgame.exe and spells_us.txt")
 RULE_INT(World, MaximumQuestErrors, 30, "Changes the maximum number of quest errors that can be displayed in #questerrors, default is 30")
+RULE_BOOL(World, DisableNumberCommification, false, "Disables number commification in Strings::Commify and quest methods")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Zone)

--- a/common/strings.cpp
+++ b/common/strings.cpp
@@ -42,6 +42,8 @@
 #include <stdio.h>
 #include <iostream>
 
+#include "rulesys.h"
+
 //Const char based
 #include "strings_legacy.cpp" // legacy c functions
 #include "strings_misc.cpp" // anything non "Strings" scoped
@@ -279,6 +281,10 @@ bool Strings::Contains(std::vector<std::string> container, const std::string& el
 
 std::string Strings::Commify(const std::string &number)
 {
+	if (RuleB(World, DisableNumberCommification)) {
+		return number;
+	}
+
 	std::string temp_string;
 
 	auto string_length = static_cast<int>(number.length());


### PR DESCRIPTION
# Notes
- This is a preference based rule for operators who would prefer their numbers not be commified in places where we have hard-coded commification.