### PR TITLE
[Fix] Fix issue with mob scanning when trying to use EVENT_SPAWN

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -674,6 +674,8 @@ void EntityList::AddNPC(NPC *npc, bool send_spawn_packet, bool dont_queue)
 	npc_list.emplace(std::pair<uint16, NPC *>(npc->GetID(), npc));
 	mob_list.emplace(std::pair<uint16, Mob *>(npc->GetID(), npc));
 
+	entity_list.ScanCloseMobs(npc->close_mobs, npc, true);
+
 	if (parse->HasQuestSub(npc->GetNPCTypeID(), EVENT_SPAWN)) {
 		parse->EventNPC(EVENT_SPAWN, npc, nullptr, "", 0);
 	}
@@ -712,8 +714,6 @@ void EntityList::AddNPC(NPC *npc, bool send_spawn_packet, bool dont_queue)
 	}
 
 	npc->SendPositionToClients();
-
-	entity_list.ScanCloseMobs(npc->close_mobs, npc, true);
 
 	if (parse->HasQuestSub(ZONE_CONTROLLER_NPC_ID, EVENT_SPAWN_ZONE)) {
 		npc->DispatchZoneControllerEvent(EVENT_SPAWN_ZONE, npc, "", 0, nullptr);


### PR DESCRIPTION
This wasn't an issue until recently when Quest API entries were exposed that add the ability to read the close mob list.

The close mob list is not scanned until after `EVENT_SPAWN` this moves scanning before EVENT_SPAWN so script callers can rely on the information being there.