### PR TITLE
[Quest API] Adjust GetCloseMobList calls internally

### DIFF
--- a/zone/lua_entity_list.cpp
+++ b/zone/lua_entity_list.cpp
@@ -641,9 +641,7 @@ Lua_Mob_List Lua_EntityList::GetCloseMobList(Lua_Mob mob) {
 	Lua_Mob_List ret;
 
 	const auto& l = self->GetCloseMobList(mob);
-
 	ret.entries.reserve(l.size());
-
 	for (const auto& e : l) {
 		ret.entries.emplace_back(Lua_Mob(e.second));
 	}
@@ -657,13 +655,9 @@ Lua_Mob_List Lua_EntityList::GetCloseMobList(Lua_Mob mob, float distance) {
 	Lua_Mob_List ret;
 
 	const auto& l = self->GetCloseMobList(mob);
-
 	ret.entries.reserve(l.size());
-
 	for (const auto& e : l) {
-		if (mob.CalculateDistance(e.second) <= distance) {
-			ret.entries.emplace_back(Lua_Mob(e.second));
-		}
+		ret.entries.emplace_back(Lua_Mob(e.second));
 	}
 
 	return ret;
@@ -674,18 +668,12 @@ Lua_Mob_List Lua_EntityList::GetCloseMobList(Lua_Mob mob, float distance, bool i
 
 	Lua_Mob_List ret;
 
-	const auto& l = self->GetCloseMobList(mob);
-
-	ret.entries.reserve(l.size());
-
-	for (const auto& e : l) {
+	for (const auto& e : self->GetCloseMobList(mob)) {
 		if (ignore_self && e.second == mob) {
 			continue;
 		}
 
-		if (mob.CalculateDistance(e.second) <= distance) {
-			ret.entries.emplace_back(Lua_Mob(e.second));
-		}
+		ret.entries.emplace_back(Lua_Mob(e.second));
 	}
 
 	return ret;

--- a/zone/lua_entity_list.cpp
+++ b/zone/lua_entity_list.cpp
@@ -651,13 +651,12 @@ Lua_Mob_List Lua_EntityList::GetCloseMobList(Lua_Mob mob) {
 
 Lua_Mob_List Lua_EntityList::GetCloseMobList(Lua_Mob mob, float distance) {
 	Lua_Safe_Call_Class(Lua_Mob_List);
-
 	Lua_Mob_List ret;
 
-	const auto& l = self->GetCloseMobList(mob);
-	ret.entries.reserve(l.size());
-	for (const auto& e : l) {
-		ret.entries.emplace_back(Lua_Mob(e.second));
+	for (const auto& e : self->GetCloseMobList(mob)) {
+		if (mob.CalculateDistance(e.second) <= distance) {
+			ret.entries.emplace_back(Lua_Mob(e.second));
+		}
 	}
 
 	return ret;
@@ -673,7 +672,9 @@ Lua_Mob_List Lua_EntityList::GetCloseMobList(Lua_Mob mob, float distance, bool i
 			continue;
 		}
 
-		ret.entries.emplace_back(Lua_Mob(e.second));
+		if (mob.CalculateDistance(e.second) <= distance) {
+			ret.entries.emplace_back(Lua_Mob(e.second));
+		}
 	}
 
 	return ret;

--- a/zone/perl_entity.cpp
+++ b/zone/perl_entity.cpp
@@ -631,9 +631,7 @@ perl::array Perl_EntityList_GetCloseMobList(EntityList* self, Mob* mob, float di
 	perl::array result;
 
 	const auto& l = self->GetCloseMobList(mob, distance);
-
 	result.reserve(l.size());
-
 	for (const auto& e : l) {
 		if (mob->CalculateDistance(e.second) <= distance) {
 			result.push_back(e.second);
@@ -646,19 +644,12 @@ perl::array Perl_EntityList_GetCloseMobList(EntityList* self, Mob* mob, float di
 perl::array Perl_EntityList_GetCloseMobList(EntityList* self, Mob* mob, float distance, bool ignore_self)
 {
 	perl::array result;
-
-	const auto& l = self->GetCloseMobList(mob, distance);
-
-	result.reserve(l.size());
-
-	for (const auto& e : l) {
+	for (const auto& e : self->GetCloseMobList(mob, distance)) {
 		if (ignore_self && e.second == mob) {
 			continue;
 		}
 
-		if (mob->CalculateDistance(e.second) <= distance) {
-			result.push_back(e.second);
-		}
+		result.push_back(e.second);
 	}
 
 	return result;

--- a/zone/perl_entity.cpp
+++ b/zone/perl_entity.cpp
@@ -614,11 +614,8 @@ Bot* Perl_EntityList_GetRandomBot(EntityList* self, float x, float y, float z, f
 perl::array Perl_EntityList_GetCloseMobList(EntityList* self, Mob* mob)
 {
 	perl::array result;
-
 	const auto& l = self->GetCloseMobList(mob);
-
 	result.reserve(l.size());
-
 	for (const auto& e : l) {
 		result.push_back(e.second);
 	}
@@ -629,10 +626,7 @@ perl::array Perl_EntityList_GetCloseMobList(EntityList* self, Mob* mob)
 perl::array Perl_EntityList_GetCloseMobList(EntityList* self, Mob* mob, float distance)
 {
 	perl::array result;
-
-	const auto& l = self->GetCloseMobList(mob, distance);
-	result.reserve(l.size());
-	for (const auto& e : l) {
+	for (const auto& e : self->GetCloseMobList(mob, distance)) {
 		if (mob->CalculateDistance(e.second) <= distance) {
 			result.push_back(e.second);
 		}
@@ -649,7 +643,9 @@ perl::array Perl_EntityList_GetCloseMobList(EntityList* self, Mob* mob, float di
 			continue;
 		}
 
-		result.push_back(e.second);
+		if (mob->CalculateDistance(e.second) <= distance) {
+			result.push_back(e.second);
+		}
 	}
 
 	return result;


### PR DESCRIPTION
This PR does a few minor but performance impacting changes

* We shouldn't reserve on the container when we don't know for certain whether or not we end up filtering ourself in the list, we end up returning blank values to the user in the Quest API results. You can double loop but the juice is not worth the squeeze performance wise - I measured this very recently. 
* Also - we are even further filtering based on the distance passed in by the user which further filters down the close list that is compiled from 600 units