### PR TITLE
[Rules] Add rule to toggle pets accepting quest items

### DIFF
--- a/common/item_data.cpp
+++ b/common/item_data.cpp
@@ -230,6 +230,10 @@ bool EQ::ItemData::IsTypeShield() const
 	return (ItemType == item::ItemTypeShield);
 }
 
+bool EQ::ItemData::IsQuestItem() const {
+	return QuestItemFlag;
+}
+
 bool EQ::ItemData::CheckLoreConflict(const ItemData* l_item, const ItemData* r_item)
 {
 	if (!l_item || !r_item)

--- a/common/item_data.h
+++ b/common/item_data.h
@@ -546,6 +546,7 @@ namespace EQ
 		bool IsType1HWeapon() const;
 		bool IsType2HWeapon() const;
 		bool IsTypeShield() const;
+		bool IsQuestItem() const;
 
 		static bool CheckLoreConflict(const ItemData* l_item, const ItemData* r_item);
 		bool CheckLoreConflict(const ItemData* item) const { return CheckLoreConflict(this, item); }

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -256,6 +256,7 @@ RULE_REAL(Pets, AttackCommandRange, 150, "Range at which a pet will respond to a
 RULE_BOOL(Pets, UnTargetableSwarmPet, false, "Setting whether swarm pets should be targetable")
 RULE_REAL(Pets, PetPowerLevelCap, 10, "Maximum number of levels a player pet can go up with pet power")
 RULE_BOOL(Pets, CanTakeNoDrop, false, "Setting whether anyone can give no-drop items to pets")
+RULE_BOOL(Pets, CanTakeQuestItems, true, "Setting whether anyone can give quest items to pets")
 RULE_BOOL(Pets, LivelikeBreakCharmOnInvis, true, "Default: true will break charm on any type of invis (hide/ivu/iva/etc) false will only break if the pet can not see you (ex. you have an undead pet and cast IVU")
 RULE_BOOL(Pets, ClientPetsUseOwnerNameInLastName, true, "Disable this to keep client pet's last names from being owner_name's pet")
 RULE_CATEGORY_END()

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -72,8 +72,9 @@ void Trade::Start(uint32 mob_id, bool initiate_with)
 	// Autostart on other mob?
 	if (initiate_with) {
 		Mob* with = With();
-		if (with)
+		if (with) {
 			with->trade->Start(owner->GetID(), false);
+		}
 	}
 }
 
@@ -774,20 +775,22 @@ void Client::FinishTrade(Mob* tradingWith, bool finalizer, void* event_entry, st
 				}
 
 				const EQ::ItemData* item = inst->GetItem();
-
-				bool isPetAndCanHaveNoDrop = (RuleB(Pets, CanTakeNoDrop) &&
-					_CLIENTPET(tradingWith) &&
-					tradingWith->GetPetType()<=petOther);
+				const bool isPet = _CLIENTPET(tradingWith) && tradingWith->GetPetType()<=petOther;
+				const bool PetsCanTakeQuestItems = RuleB(Pets, CanTakeQuestItems);
+				const bool isPetAndCanHaveNoDrop = (RuleB(Pets, CanTakeNoDrop) &&	isPet);
+				const bool isPetAndCanHaveQuestItems = (PetsCanTakeQuestItems &&	isPet);
 				// if it was not a NO DROP or Attuned item (or if a GM is trading), let the NPC have it
 				if(GetGM() || (inst->IsAttuned() == false &&
-					(item->NoDrop != 0 || isPetAndCanHaveNoDrop))) {
+					(item->NoDrop != 0 || isPetAndCanHaveNoDrop) &&
+					(item->IsQuestItem() == false || isPetAndCanHaveQuestItems))) {
 					// pets need to look inside bags and try to equip items found there
 					if (item->IsClassBag() && item->BagSlots > 0) {
 						for (int16 bslot = EQ::invbag::SLOT_BEGIN; bslot < item->BagSlots; bslot++) {
 							const EQ::ItemInstance* baginst = inst->GetItem(bslot);
 							if (baginst) {
 								const EQ::ItemData* bagitem = baginst->GetItem();
-								if (bagitem && (GetGM() || (bagitem->NoDrop != 0 && baginst->IsAttuned() == false))) {
+								if (bagitem && (GetGM() || (bagitem->NoDrop != 0 && baginst->IsAttuned() == false)  &&
+								((isPet == true && (bagitem->IsQuestItem() == false or PetsCanTakeQuestItems) or isPet == false)))) {
 
 									auto loot_drop_entry = NPC::NewLootDropEntry();
 									loot_drop_entry.equip_item   = 1;
@@ -799,6 +802,11 @@ void Client::FinishTrade(Mob* tradingWith, bool finalizer, void* event_entry, st
 										loot_drop_entry,
 										true
 									);
+								}
+								else if (isPet == true && bagitem->IsQuestItem() == true) {
+									tradingWith->SayString(TRADE_BACK, GetCleanName());
+									PushItemOnCursor(*baginst, true);
+									Message(Chat::Red, "You cannot trade quest items with your pet.");
 								}
 								else if (RuleB(NPC, ReturnNonQuestNoDropItems)) {
 									tradingWith->SayString(TRADE_BACK, GetCleanName());
@@ -818,6 +826,12 @@ void Client::FinishTrade(Mob* tradingWith, bool finalizer, void* event_entry, st
 						new_loot_drop_entry,
 						true
 					);
+				}
+				// Return quest items being traded to player pet when not allowed
+				else if (isPet == true && item->IsQuestItem() == true) {
+					tradingWith->SayString(TRADE_BACK, GetCleanName());
+					PushItemOnCursor(*inst, true);
+					Message(Chat::Red, "You cannot trade quest items with your pet.");
 				}
 				// Return NO DROP and Attuned items being handed into a non-quest NPC if the rule is true
 				else if (RuleB(NPC, ReturnNonQuestNoDropItems)) {

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -3303,7 +3303,8 @@ void ZoneDatabase::SavePetInfo(Client *client)
 
 		// build pet buffs into struct
 		int pet_buff_count = 0;
-		int max_slots = RuleI(Spells, MaxTotalSlotsPET) > 30 ? 30 : RuleI(Spells, MaxTotalSlotsPET);
+		// Guard against setting the maximum pet slots above the client allowed maximum.
+		int max_slots = RuleI(Spells, MaxTotalSlotsPET) > PET_BUFF_COUNT ? PET_BUFF_COUNT : RuleI(Spells, MaxTotalSlotsPET);
 
 		// count pet buffs
 		for (int index = 0; index < max_slots; index++) {

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -3303,7 +3303,7 @@ void ZoneDatabase::SavePetInfo(Client *client)
 
 		// build pet buffs into struct
 		int pet_buff_count = 0;
-		int max_slots = RuleI(Spells, MaxTotalSlotsPET);
+		int max_slots = RuleI(Spells, MaxTotalSlotsPET) > 30 ? 30 : RuleI(Spells, MaxTotalSlotsPET);
 
 		// count pet buffs
 		for (int index = 0; index < max_slots; index++) {


### PR DESCRIPTION
Adds the following rule: Pets:CanTakeQuestItems, default true.

As name suggests, rejects items flagged as "Quest" when traded to a pet.  The main purpose for this rule is to block players accidentally trading quest items to their pet instead of the desired quest NPC. 

Everything works so far in testing, but I want to torture test it some more before i take this out of draft.