### PR TITLE
[Spawns] Fixes a rarer issue where spawn2 is not being properly content filtered

### DIFF
--- a/zone/spawn2.cpp
+++ b/zone/spawn2.cpp
@@ -26,6 +26,7 @@
 #include "worldserver.h"
 #include "zone.h"
 #include "zonedb.h"
+#include "../common/repositories/criteria/content_filter_criteria.h"
 
 extern EntityList entity_list;
 extern Zone* zone;
@@ -467,7 +468,7 @@ bool ZoneDatabase::PopulateZoneSpawnList(uint32 zoneid, LinkedList<Spawn2*> &spa
 	LogInfo("Loaded [{}] respawn timer(s)", Strings::Commify(results.RowCount()));
 
 	const char *zone_name = ZoneName(zoneid);
-	std::string query = StringFormat(
+	std::string query = fmt::format(
 		"SELECT "
 		"id, "
 		"spawngroupID, "
@@ -485,7 +486,8 @@ bool ZoneDatabase::PopulateZoneSpawnList(uint32 zoneid, LinkedList<Spawn2*> &spa
 		"animation "
 		"FROM "
 		"spawn2 "
-		"WHERE zone = '%s' AND  (version = %u OR version = -1)",
+		"WHERE TRUE {} AND zone = '{}' AND (version = {} OR version = -1) ",
+		ContentFilterCriteria::apply(),
 		zone_name,
 		version
 	);


### PR DESCRIPTION
Fixes a rarer issue where spawn2 is not being properly content filtered

As observered when @regneq was working on PoK spawns and was splitting the same NPC onto two separate grids and the wrong pathgrid was being loaded 

**Before**

![image](https://github.com/EQEmu/Server/assets/3319450/9d14e785-7785-41f2-a392-2a5cf932be03)

![image](https://github.com/EQEmu/Server/assets/3319450/b99d1e22-68bb-4c77-afa3-3b53555f59e9)

**After**

![image](https://github.com/EQEmu/Server/assets/3319450/580ae75b-649a-4edd-b805-e46d3e6ce452)
