### PR TITLE
[Bug] Escape item name in trader audit.

### DIFF
--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -1462,7 +1462,7 @@ static void BazaarAuditTrail(const char *seller, const char *buyer, const char *
 	std::string query = StringFormat("INSERT INTO `trader_audit` "
                                     "(`time`, `seller`, `buyer`, `itemname`, `quantity`, `totalcost`, `trantype`) "
                                     "VALUES (NOW(), '%s', '%s', '%s', %i, %i, %i)",
-                                    seller, buyer, itemName, quantity, totalCost, tranType);
+                                    seller, buyer, Strings::Escape(itemName).c_str(), quantity, totalCost, tranType);
 	database.QueryDatabase(query);
 }
 

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -1459,10 +1459,17 @@ void Client::TradeRequestFailed(const EQApplicationPacket* app) {
 
 static void BazaarAuditTrail(const char *seller, const char *buyer, const char *itemName, int quantity, int totalCost, int tranType) {
 
-	std::string query = StringFormat("INSERT INTO `trader_audit` "
-                                    "(`time`, `seller`, `buyer`, `itemname`, `quantity`, `totalcost`, `trantype`) "
-                                    "VALUES (NOW(), '%s', '%s', '%s', %i, %i, %i)",
-                                    seller, buyer, Strings::Escape(itemName).c_str(), quantity, totalCost, tranType);
+	const std::string& query = fmt::format(
+		"INSERT INTO `trader_audit` "
+        	"(`time`, `seller`, `buyer`, `itemname`, `quantity`, `totalcost`, `trantype`) "
+		"VALUES (NOW(), '{}', '{}', '{}', {}, {}, {})",
+		seller,
+		buyer,
+		Strings::Escape(itemName),
+		quantity,
+		totalCost,
+		tranType
+	);
 	database.QueryDatabase(query);
 }
 


### PR DESCRIPTION
Quick fix to escape the item names in Trader Audit.