### PR TITLE
[Bug Fix] Bots will now load AAs properly when spawned.

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -119,7 +119,15 @@ Bot::Bot(NPCType *npcTypeData, Client* botOwner) : NPC(npcTypeData, nullptr, glm
 }
 
 // This constructor is used when the bot is loaded out of the database
-Bot::Bot(uint32 botID, uint32 botOwnerCharacterID, uint32 botSpellsID, double totalPlayTime, uint32 lastZoneId, NPCType *npcTypeData, int32 expansion_bitmask)
+Bot::Bot(
+		uint32 botID,
+		uint32 botOwnerCharacterID,
+		uint32 botSpellsID,
+		double totalPlayTime,
+		uint32 lastZoneId,
+		NPCType *npcTypeData,
+		int32 expansion_bitmask
+	)
 	: NPC(npcTypeData, nullptr, glm::vec4(), Ground, false), rest_timer(1), ping_timer(1)
 {
 	GiveNPCTypeData(npcTypeData);

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -120,14 +120,14 @@ Bot::Bot(NPCType *npcTypeData, Client* botOwner) : NPC(npcTypeData, nullptr, glm
 
 // This constructor is used when the bot is loaded out of the database
 Bot::Bot(
-		uint32 botID,
-		uint32 botOwnerCharacterID,
-		uint32 botSpellsID,
-		double totalPlayTime,
-		uint32 lastZoneId,
-		NPCType *npcTypeData,
-		int32 expansion_bitmask
-	)
+	uint32 botID,
+	uint32 botOwnerCharacterID,
+	uint32 botSpellsID,
+	double totalPlayTime,
+	uint32 lastZoneId,
+	NPCType *npcTypeData,
+	int32 expansion_bitmask
+)
 	: NPC(npcTypeData, nullptr, glm::vec4(), Ground, false), rest_timer(1), ping_timer(1)
 {
 	GiveNPCTypeData(npcTypeData);

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -161,7 +161,7 @@ Bot::Bot(uint32 botID, uint32 botOwnerCharacterID, uint32 botSpellsID, double to
 	RestRegenHP = 0;
 	RestRegenMana = 0;
 	RestRegenEndurance = 0;
-    m_expansion_bitmask = expansion_bitmask;
+	m_expansion_bitmask = expansion_bitmask;
 	SetBotID(botID);
 	SetBotSpellID(botSpellsID);
 	SetSpawnStatus(false);

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -119,7 +119,7 @@ Bot::Bot(NPCType *npcTypeData, Client* botOwner) : NPC(npcTypeData, nullptr, glm
 }
 
 // This constructor is used when the bot is loaded out of the database
-Bot::Bot(uint32 botID, uint32 botOwnerCharacterID, uint32 botSpellsID, double totalPlayTime, uint32 lastZoneId, NPCType *npcTypeData)
+Bot::Bot(uint32 botID, uint32 botOwnerCharacterID, uint32 botSpellsID, double totalPlayTime, uint32 lastZoneId, NPCType *npcTypeData, int32 expansion_bitmask)
 	: NPC(npcTypeData, nullptr, glm::vec4(), Ground, false), rest_timer(1), ping_timer(1)
 {
 	GiveNPCTypeData(npcTypeData);
@@ -161,6 +161,7 @@ Bot::Bot(uint32 botID, uint32 botOwnerCharacterID, uint32 botSpellsID, double to
 	RestRegenHP = 0;
 	RestRegenMana = 0;
 	RestRegenEndurance = 0;
+    m_expansion_bitmask = expansion_bitmask;
 	SetBotID(botID);
 	SetBotSpellID(botSpellsID);
 	SetSpawnStatus(false);

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -130,7 +130,7 @@ public:
 
 	// Class Constructors
 	Bot(NPCType *npcTypeData, Client* botOwner);
-	Bot(uint32 botID, uint32 botOwnerCharacterID, uint32 botSpellsID, double totalPlayTime, uint32 lastZoneId, NPCType *npcTypeData);
+	Bot(uint32 botID, uint32 botOwnerCharacterID, uint32 botSpellsID, double totalPlayTime, uint32 lastZoneId, NPCType *npcTypeData, int32 expansion_bitmask);
 
 	//abstract virtual override function implementations requird by base abstract class
 	bool Death(Mob* killerMob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill) override;

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -130,7 +130,8 @@ public:
 
 	// Class Constructors
 	Bot(NPCType *npcTypeData, Client* botOwner);
-	Bot(uint32 botID, uint32 botOwnerCharacterID, uint32 botSpellsID, double totalPlayTime, uint32 lastZoneId, NPCType *npcTypeData, int32 expansion_bitmask);
+	Bot(uint32 botID, uint32 botOwnerCharacterID, uint32 botSpellsID,
+		double totalPlayTime, uint32 lastZoneId, NPCType *npcTypeData, int32 expansion_bitmask);
 
 	//abstract virtual override function implementations requird by base abstract class
 	bool Death(Mob* killerMob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill) override;

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -130,8 +130,7 @@ public:
 
 	// Class Constructors
 	Bot(NPCType *npcTypeData, Client* botOwner);
-	Bot(uint32 botID, uint32 botOwnerCharacterID, uint32 botSpellsID,
-		double totalPlayTime, uint32 lastZoneId, NPCType *npcTypeData, int32 expansion_bitmask);
+	Bot(uint32 botID, uint32 botOwnerCharacterID, uint32 botSpellsID, double totalPlayTime, uint32 lastZoneId, NPCType *npcTypeData, int32 expansion_bitmask);
 
 	//abstract virtual override function implementations requird by base abstract class
 	bool Death(Mob* killerMob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill) override;

--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -459,14 +459,14 @@ bool BotDatabase::LoadBot(const uint32 bot_id, Bot*& loaded_bot)
 	safe_delete(d);
 
 	loaded_bot = new Bot(
-                bot_id,
-                l.owner_id,
-                l.spells_id,
-                l.time_spawned,
-                l.zone_id,
-                t,
-                l.expansion_bitmask
-            );
+        bot_id,
+        l.owner_id,
+        l.spells_id,
+        l.time_spawned,
+        l.zone_id,
+        t,
+        l.expansion_bitmask
+    );
 
 	if (loaded_bot) {
 		loaded_bot->SetSurname(l.last_name);

--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -459,12 +459,12 @@ bool BotDatabase::LoadBot(const uint32 bot_id, Bot*& loaded_bot)
 	safe_delete(d);
 
 	loaded_bot = new Bot(
-			bot_id,
-			l.owner_id,
-			l.spells_id,
-			l.time_spawned,
-			l.zone_id,
-			t,
+            bot_id,
+            l.owner_id,
+            l.spells_id,
+            l.time_spawned,
+            l.zone_id,
+            t,
             l.expansion_bitmask);
 
 	if (loaded_bot) {

--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -459,14 +459,14 @@ bool BotDatabase::LoadBot(const uint32 bot_id, Bot*& loaded_bot)
 	safe_delete(d);
 
 	loaded_bot = new Bot(
-        bot_id,
-        l.owner_id,
-        l.spells_id,
-        l.time_spawned,
-        l.zone_id,
-        t,
-        l.expansion_bitmask
-    );
+            bot_id,
+            l.owner_id,
+            l.spells_id,
+            l.time_spawned,
+            l.zone_id,
+            t,
+            l.expansion_bitmask
+        );
 
 	if (loaded_bot) {
 		loaded_bot->SetSurname(l.last_name);

--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -459,13 +459,14 @@ bool BotDatabase::LoadBot(const uint32 bot_id, Bot*& loaded_bot)
 	safe_delete(d);
 
 	loaded_bot = new Bot(
-            bot_id,
-            l.owner_id,
-            l.spells_id,
-            l.time_spawned,
-            l.zone_id,
-            t,
-            l.expansion_bitmask);
+                bot_id,
+                l.owner_id,
+                l.spells_id,
+                l.time_spawned,
+                l.zone_id,
+                t,
+                l.expansion_bitmask
+            );
 
 	if (loaded_bot) {
 		loaded_bot->SetSurname(l.last_name);

--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -459,13 +459,13 @@ bool BotDatabase::LoadBot(const uint32 bot_id, Bot*& loaded_bot)
 	safe_delete(d);
 
 	loaded_bot = new Bot(
-		bot_id,
-		l.owner_id,
-		l.spells_id,
-		l.time_spawned,
-		l.zone_id,
-		t
-	);
+			bot_id,
+			l.owner_id,
+			l.spells_id,
+			l.time_spawned,
+			l.zone_id,
+			t,
+            l.expansion_bitmask);
 
 	if (loaded_bot) {
 		loaded_bot->SetSurname(l.last_name);
@@ -478,8 +478,6 @@ bool BotDatabase::LoadBot(const uint32 bot_id, Bot*& loaded_bot)
 		loaded_bot->SetFollowDistance(bfd);
 
 		loaded_bot->SetStopMeleeLevel(l.stop_melee_level);
-
-		loaded_bot->SetExpansionBitmask(l.expansion_bitmask, false);
 
 		loaded_bot->SetBotEnforceSpellSetting((l.enforce_spell_settings ? true : false));
 

--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -459,14 +459,14 @@ bool BotDatabase::LoadBot(const uint32 bot_id, Bot*& loaded_bot)
 	safe_delete(d);
 
 	loaded_bot = new Bot(
-            bot_id,
-            l.owner_id,
-            l.spells_id,
-            l.time_spawned,
-            l.zone_id,
-            t,
-            l.expansion_bitmask
-        );
+		bot_id,
+		l.owner_id,
+		l.spells_id,
+		l.time_spawned,
+		l.zone_id,
+		t,
+		l.expansion_bitmask
+	);
 
 	if (loaded_bot) {
 		loaded_bot->SetSurname(l.last_name);


### PR DESCRIPTION
Bots were not loading AA's properly on Spawn due to ```m_expansion_bitmask``` being set after the Bot constructor was called.




