### PR TITLE
[Charm] Fix to update target windows on charm on/off

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -1595,7 +1595,7 @@ void EntityList::RefreshClientXTargets(Client *c)
 }
 
 void EntityList::QueueClientsByTarget(Mob *sender, const EQApplicationPacket *app,
-		bool iSendToSender, Mob *SkipThisMob, bool ackreq, bool HoTT, uint32 ClientVersionBits, bool inspect_buffs, bool clear)
+		bool iSendToSender, Mob *SkipThisMob, bool ackreq, bool HoTT, uint32 ClientVersionBits, bool inspect_buffs, bool clear_target_window)
 {
 	auto it = client_list.begin();
 	while (it != client_list.end()) {
@@ -1611,7 +1611,7 @@ void EntityList::QueueClientsByTarget(Mob *sender, const EQApplicationPacket *ap
 
 		TargetsTarget = Target->GetTarget();
 
-		bool Send = clear;
+		bool Send = clear_target_window;
 
 		if (c == SkipThisMob)
 			continue;
@@ -1624,21 +1624,21 @@ void EntityList::QueueClientsByTarget(Mob *sender, const EQApplicationPacket *ap
 			if (Target == sender) {
 				if (inspect_buffs) { // if inspect_buffs is true we're sending a mob's buffs to those with the LAA
 					if (c->GetGM() || RuleB(Spells, AlwaysSendTargetsBuffs)) {
-						Send = !clear;
+						Send = !clear_target_window;
 					} else if (c->IsRaidGrouped()) {
 						Raid *raid = c->GetRaid();
 						if (raid) {
 							uint32 gid = raid->GetGroup(c);
 							if (gid < MAX_RAID_GROUPS && raid->GroupCount(gid) >= 3) {
 								if (raid->GetLeadershipAA(groupAAInspectBuffs, gid))
-									Send = !clear;
+									Send = !clear_target_window;
 							}
 						}
 					} else {
 						Group *group = c->GetGroup();
 						if (group && group->GroupCount() >= 3) {
 							if (group->GetLeadershipAA(groupAAInspectBuffs)) {
-								Send = !clear;
+								Send = !clear_target_window;
 							}
 						}
 					}

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -1361,7 +1361,7 @@ void EntityList::SendZoneSpawnsBulk(Client *client)
 				(spawn->IsClient() && (spawn->GetRace() == MINOR_ILL_OBJ || spawn->GetRace() == TREE))
 			);
 
-			if (false) {
+			if (is_delayed_packet) {
 				app = new EQApplicationPacket;
 				spawn->CreateSpawnPacket(app);
 				client->QueuePacket(app, true, Client::CLIENT_CONNECTED);

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -1629,7 +1629,7 @@ void EntityList::QueueClientsByTarget(Mob *sender, const EQApplicationPacket *ap
 						Raid *raid = c->GetRaid();
 						if (raid) {
 							uint32 gid = raid->GetGroup(c);
-							if (gid <= 11 && raid->GroupCount(gid) >= 3) {
+							if (gid < MAX_RAID_GROUPS && raid->GroupCount(gid) >= 3) {
 								if (raid->GetLeadershipAA(groupAAInspectBuffs, gid))
 									Send = !clear;
 							}

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -413,7 +413,7 @@ public:
 	void	QueueClientsStatus(Mob* sender, const EQApplicationPacket* app, bool ignore_sender = false, uint8 minstatus = AccountStatus::Player, uint8 maxstatus = AccountStatus::Player);
 	void	QueueClientsGuild(Mob* sender, const EQApplicationPacket* app, bool ignore_sender = false, uint32 guildeqid = 0);
 	void	QueueClientsGuildBankItemUpdate(const GuildBankItemUpdate_Struct *gbius, uint32 GuildID);
-	void	QueueClientsByTarget(Mob* sender, const EQApplicationPacket* app, bool iSendToSender = true, Mob* SkipThisMob = 0, bool ackreq = true, bool HoTT = true, uint32 ClientVersionBits = 0xFFFFFFFF, bool inspect_buffs = false, bool clear  = false);
+	void	QueueClientsByTarget(Mob* sender, const EQApplicationPacket* app, bool iSendToSender = true, Mob* SkipThisMob = 0, bool ackreq = true, bool HoTT = true, uint32 ClientVersionBits = 0xFFFFFFFF, bool inspect_buffs = false, bool clear_target_window  = false);
 
 	void	QueueClientsByXTarget(Mob* sender, const EQApplicationPacket* app, bool iSendToSender = true, EQ::versions::ClientVersionBitmask client_version_bits = EQ::versions::ClientVersionBitmask::maskAllClients);
 	void	QueueToGroupsForNPCHealthAA(Mob* sender, const EQApplicationPacket* app);

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -413,8 +413,7 @@ public:
 	void	QueueClientsStatus(Mob* sender, const EQApplicationPacket* app, bool ignore_sender = false, uint8 minstatus = AccountStatus::Player, uint8 maxstatus = AccountStatus::Player);
 	void	QueueClientsGuild(Mob* sender, const EQApplicationPacket* app, bool ignore_sender = false, uint32 guildeqid = 0);
 	void	QueueClientsGuildBankItemUpdate(const GuildBankItemUpdate_Struct *gbius, uint32 GuildID);
-	void	QueueClientsByTarget(Mob* sender, const EQApplicationPacket* app, bool iSendToSender = true, Mob* SkipThisMob = 0, bool ackreq = true,
-						bool HoTT = true, uint32 ClientVersionBits = 0xFFFFFFFF, bool inspect_buffs = false);
+	void	QueueClientsByTarget(Mob* sender, const EQApplicationPacket* app, bool iSendToSender = true, Mob* SkipThisMob = 0, bool ackreq = true, bool HoTT = true, uint32 ClientVersionBits = 0xFFFFFFFF, bool inspect_buffs = false, bool clear  = false);
 
 	void	QueueClientsByXTarget(Mob* sender, const EQApplicationPacket* app, bool iSendToSender = true, EQ::versions::ClientVersionBitmask client_version_bits = EQ::versions::ClientVersionBitmask::maskAllClients);
 	void	QueueToGroupsForNPCHealthAA(Mob* sender, const EQApplicationPacket* app);

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -457,7 +457,7 @@ public:
 	virtual uint32 GetLastBuffSlot(bool disc, bool song);
 	virtual void InitializeBuffSlots() { buffs = nullptr; }
 	virtual void UninitializeBuffSlots() { }
-	EQApplicationPacket *MakeBuffsPacket(bool for_target = true);
+	EQApplicationPacket *MakeBuffsPacket(bool for_target = true, bool clear = false);
 	void SendBuffsToClient(Client *c);
 	inline Buffs_Struct* GetBuffs() { return buffs; }
 	void DoGravityEffect();

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -457,7 +457,7 @@ public:
 	virtual uint32 GetLastBuffSlot(bool disc, bool song);
 	virtual void InitializeBuffSlots() { buffs = nullptr; }
 	virtual void UninitializeBuffSlots() { }
-	EQApplicationPacket *MakeBuffsPacket(bool for_target = true, bool clear = false);
+	EQApplicationPacket *MakeBuffsPacket(bool for_target = true, bool clear_buffs = false);
 	void SendBuffsToClient(Client *c);
 	inline Buffs_Struct* GetBuffs() { return buffs; }
 	void DoGravityEffect();

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -799,6 +799,12 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 
 				SetPetType(petCharmed);
 
+				// This was done in AddBuff, but we were not a pet yet, so
+				// the target windows didn't get updated.
+				EQApplicationPacket *outapp = MakeBuffsPacket();
+				entity_list.QueueClientsByTarget(this, outapp, false, nullptr, true, false, EQ::versions::maskSoDAndLater);
+				safe_delete(outapp);
+
 				if(caster->IsClient()){
 					auto app = new EQApplicationPacket(OP_Charm, sizeof(Charm_Struct));
 					Charm_Struct *ps = (Charm_Struct*)app->pBuffer;
@@ -4355,6 +4361,15 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 				{
 					owner->SetPet(0);
 				}
+
+				// Any client that has a previous charmed pet targetted shouldo
+				// no longer see the buffs on the old pet.
+				// QueueClientsByTarget preserves GM and leadership cases.
+
+				EQApplicationPacket *outapp = MakeBuffsPacket(true, true);
+
+				entity_list.QueueClientsByTarget(this, outapp, false, nullptr, true, false, EQ::versions::maskSoDAndLater, true, true);
+
 				if (IsAIControlled())
 				{
 					//Remove damage over time effects on charmed pet and those applied by charmed pet.

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -6265,19 +6265,15 @@ EQApplicationPacket *Mob::MakeBuffsPacket(bool for_target, bool clear)
 
 	// for self we want all buffs, for target, we want to skip song window buffs
 	// since NPCs and pets don't have a song window, we still see it for them :P
-	if (for_target)
-	{
+	if (for_target) {
 		buff_count = (clear) ? 0 : GetMaxBuffSlots();
 	}
-	else
-	{
+	else {
 		buff_count = GetMaxTotalSlots();
 	}
 
-	for(int i = 0; i < buff_count; ++i)
-	{
-		if (IsValidSpell(buffs[i].spellid))
-		{
+	for(int i = 0; i < buff_count; ++i) {
+		if (IsValidSpell(buffs[i].spellid)) {
 			++count;
 		}
 	}
@@ -6285,12 +6281,10 @@ EQApplicationPacket *Mob::MakeBuffsPacket(bool for_target, bool clear)
 	EQApplicationPacket* outapp = nullptr;
 
 	//Create it for a targeting window, else create it for a create buff packet.
-	if(for_target)
-	{
+	if(for_target) {
 		outapp = new EQApplicationPacket(OP_TargetBuffs, sizeof(BuffIcon_Struct) + sizeof(BuffIconEntry_Struct) * count);
 	}
-	else
-	{
+	else {
 		outapp = new EQApplicationPacket(OP_BuffCreate, sizeof(BuffIcon_Struct) + sizeof(BuffIconEntry_Struct) * count);
 	}
 	BuffIcon_Struct *buff = (BuffIcon_Struct*)outapp->pBuffer;
@@ -6307,10 +6301,8 @@ EQApplicationPacket *Mob::MakeBuffsPacket(bool for_target, bool clear)
 
 	buff->name_lengths = 0; // hacky shit
 	uint32 index = 0;
-	for(int i = 0; i < buff_count; ++i)
-	{
-		if (IsValidSpell(buffs[i].spellid))
-		{
+	for(int i = 0; i < buff_count; ++i) {
+		if (IsValidSpell(buffs[i].spellid)) {
 			buff->entries[index].buff_slot = i;
 			buff->entries[index].spell_id = buffs[i].spellid;
 			buff->entries[index].tics_remaining = buffs[i].ticsremaining;

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -6258,12 +6258,22 @@ void Mob::SendBuffsToClient(Client *c)
 	}
 }
 
-EQApplicationPacket *Mob::MakeBuffsPacket(bool for_target)
+EQApplicationPacket *Mob::MakeBuffsPacket(bool for_target, bool clear)
 {
 	uint32 count = 0;
+	uint32 buff_count;
+
 	// for self we want all buffs, for target, we want to skip song window buffs
 	// since NPCs and pets don't have a song window, we still see it for them :P
-	uint32 buff_count = for_target ? GetMaxBuffSlots() : GetMaxTotalSlots();
+	if (for_target)
+	{
+		buff_count = (clear) ? 0 : GetMaxBuffSlots();
+	}
+	else
+	{
+		buff_count = GetMaxTotalSlots();
+	}
+
 	for(int i = 0; i < buff_count; ++i)
 	{
 		if (IsValidSpell(buffs[i].spellid))

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -6258,7 +6258,7 @@ void Mob::SendBuffsToClient(Client *c)
 	}
 }
 
-EQApplicationPacket *Mob::MakeBuffsPacket(bool for_target, bool clear)
+EQApplicationPacket *Mob::MakeBuffsPacket(bool for_target, bool clear_buffs)
 {
 	uint32 count = 0;
 	uint32 buff_count;
@@ -6266,7 +6266,7 @@ EQApplicationPacket *Mob::MakeBuffsPacket(bool for_target, bool clear)
 	// for self we want all buffs, for target, we want to skip song window buffs
 	// since NPCs and pets don't have a song window, we still see it for them :P
 	if (for_target) {
-		buff_count = (clear) ? 0 : GetMaxBuffSlots();
+		buff_count = (clear_buffs) ? 0 : GetMaxBuffSlots();
 	}
 	else {
 		buff_count = GetMaxTotalSlots();


### PR DESCRIPTION
On classic servers that do not use the rule AlwaysSendTargetsBuffs, we can only see a charmed pet's buffs if we manually retarget after the charm.  These buffs also remain displayed (including the charm) after charm breaks unless we re-target.  This is a bug.

This PR fixes this issue by updating all client target windows when a mob they have targeted is charmed.  It also clears all the buffs from that clients sight when the charm drops (unless client is a GM, AlwaysSendTargetsBuffs is set, or the groupAAInspectBuffsis in play).
