### PR TITLE
[Combat Messages] Fix issue where pet proc damage was not showing up

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -4225,6 +4225,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 		//Note: if players can become pets, they will not receive damage messages of their own
 		//this was done to simplify the code here (since we can only effectively skip one mob on queue)
 		eqFilterType filter;
+		Mob* skip = attacker;
 		if (attacker && attacker->GetOwnerID()) {
 			//attacker is a pet, let pet owners see their pet's damage
 			Mob* owner = attacker->GetOwner();
@@ -4259,6 +4260,8 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 							);
 				}
 			}
+			
+			skip = owner;
 		}
 		else {
 			//attacker is not a pet, send to the attacker
@@ -4366,7 +4369,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 						outapp, /* packet */
 						true, /* Skip Sender */
 						range, /* distance packet travels at the speed of sound */
-						0,
+						(IsValidSpell(spell_id) && skill_used != EQ::skills::SkillTigerClaw) ? 0 : skip,
 						true, /* Packet ACK */
 						filter /* eqFilterType filter */
 						);

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -4260,7 +4260,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 							);
 				}
 			}
-			
+
 			skip = owner;
 		}
 		else {


### PR DESCRIPTION
@Kinglykrab reported a problem from his server where some pet damage from spells was being missed by observers.

While I think pet damage isn't seen by others on live, as there is no others-pet-filters, this was always a part of eqemu and many parsers used it.

The bug came from my PR back in 2022: https://github.com/EQEmu/Server/pull/2170/files

That PR removed many duplicate messages and added missing color messages, but omitted the ones this PR fixes.

New output as seen by owner of pet that is procing:

[Fri Aug 18 14:11:03 2023] Bristlebanes Warder begins to cast a spell. (Spirit of Scorpion Strike)
[Fri Aug 18 14:11:03 2023] Bristlebanes Warder strikes Kizdean Gix for 92 points of damage.
[Fri Aug 18 14:11:03 2023] Kizdean Gix spasms as the spirit of a scorpion rips through their body .

New output as seen by close observers:

[Fri Aug 18 14:11:09 2023] Bristlebanes Warder begins to cast a spell. (Spirit of Scorpion Strike)
[Fri Aug 18 14:11:09 2023] Bristlebanes Warder strikes Kizdean Gix for 92 points of damage.
[Fri Aug 18 14:11:09 2023] Kizdean Gix spasms as the spirit of a scorpion rips through their body .

This PR also puts the pet damage under the correct filter if you are the pet owner.  if you're not the pet owner, you're just gonna get the messages just like all the other pet messages.

I'd suggest long term maybe we need a rule to turn off others pet messages, but that's outside the scope of this fix.

@Kinglykrab Maybe you can have your guy do some testing before we merge this?  We tried to test it well, testing various situations, but only have like 2 hours of testing in.  Your call.