### PR TITLE
[Bug Fix] Fix Bot::CheckDataBucket to work with Owner Buckets.

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -8170,6 +8170,7 @@ bool Bot::CheckDataBucket(std::string bucket_name, const std::string& bucket_val
 		if (b.value.empty() && GetBotOwner()) {
 			// fetch from owner
 			k = GetBotOwner()->GetScopedBucketKeys();
+			k.key = bucket_name;
 
 			b = DataBucket::GetData(k);
 			if (b.value.empty()) {


### PR DESCRIPTION
Fixed regression from #3498, Bot::CheckDataBucket was not properly checking owner buckets as ```k.key``` was not being set after ```k = GetBotOwner()->GetScopedBucketKeys();```.