### PR TITLE
[Database] Extend dumper CLI utility to export static instance data

### DIFF
--- a/common/database/database_dump_service.cpp
+++ b/common/database/database_dump_service.cpp
@@ -279,6 +279,11 @@ void DatabaseDumpService::DatabaseDump()
 		}
 	}
 
+	if (IsDumpStaticInstanceData()) {
+		tables_to_dump += "instance_list";
+		options += " --no-create-info --where=\"instance_list.is_global > 0 and instance_list.never_expires > 0\"";
+	}
+
 	if (!dump_descriptor.empty()) {
 		SetDumpFileName(GetDumpFileName() + dump_descriptor);
 	}
@@ -605,4 +610,14 @@ void DatabaseDumpService::RemoveCredentialsFile()
 	if (File::Exists(CREDENTIALS_FILE)) {
 		std::filesystem::remove(CREDENTIALS_FILE);
 	}
+}
+
+bool DatabaseDumpService::IsDumpStaticInstanceData()
+{
+	return dump_static_instance_data;
+}
+
+void DatabaseDumpService::SetDumpStaticInstanceData(bool b)
+{
+	dump_static_instance_data = b;
 }

--- a/common/database/database_dump_service.h
+++ b/common/database/database_dump_service.h
@@ -58,6 +58,9 @@ public:
 	bool IsDumpMercTables() const;
 	void SetDumpMercTables(bool dump_bot_tables);
 
+	void SetDumpStaticInstanceData(bool b);
+	bool IsDumpStaticInstanceData();
+
 private:
 	bool        dump_all_tables             = false;
 	bool        dump_state_tables           = false;
@@ -73,6 +76,8 @@ private:
 	bool        dump_drop_table_syntax_only = false;
 	bool        dump_bot_tables             = false;
 	bool        dump_merc_tables            = false;
+	bool        dump_static_instance_data   = false;
+
 	std::string dump_path;
 	std::string dump_file_name;
 

--- a/utils/sql/peq-dump/peq-dump.sh
+++ b/utils/sql/peq-dump/peq-dump.sh
@@ -45,7 +45,7 @@ bash -c "${world_bin} database:dump --login-tables --table-structure-only --dump
 bash -c "${world_bin} database:dump --player-tables --table-structure-only --dump-output-to-console | sed 's/ AUTO_INCREMENT=[0-9]*\b//g' > ${dump_path}create_tables_player.sql"
 bash -c "${world_bin} database:dump --state-tables --table-structure-only --dump-output-to-console | sed 's/ AUTO_INCREMENT=[0-9]*\b//g' > ${dump_path}create_tables_state.sql"
 bash -c "${world_bin} database:dump --static-instance-data --dump-output-to-console > ${dump_path}create_tables_state.sql"
-bash -c "${world_bin} database:dump --query-serv-tables --table-structure-only --dump-output-to-console | sed 's/ AUTO_INCREMENT=[0-9]*\b//g' > ${dump_path}create_tables_queryserv.sql"
+bash -c "${world_bin} database:dump --query-serv-tables --table-structure-only --dump-output-to-console | sed 's/ AUTO_INCREMENT=[0-9]*\b//g' >> ${dump_path}create_tables_queryserv.sql"
 
 # with content
 bash -c "${world_bin} database:dump --content-tables --dump-output-to-console > ${dump_path}create_tables_content.sql"

--- a/utils/sql/peq-dump/peq-dump.sh
+++ b/utils/sql/peq-dump/peq-dump.sh
@@ -44,7 +44,7 @@ echo "Generating [create_*] table exports..."
 bash -c "${world_bin} database:dump --login-tables --table-structure-only --dump-output-to-console | sed 's/ AUTO_INCREMENT=[0-9]*\b//g' > ${dump_path}create_tables_login.sql"
 bash -c "${world_bin} database:dump --player-tables --table-structure-only --dump-output-to-console | sed 's/ AUTO_INCREMENT=[0-9]*\b//g' > ${dump_path}create_tables_player.sql"
 bash -c "${world_bin} database:dump --state-tables --table-structure-only --dump-output-to-console | sed 's/ AUTO_INCREMENT=[0-9]*\b//g' > ${dump_path}create_tables_state.sql"
-echo 'REPLACE INTO `instance_list` VALUES (1,25,1,1,0,0,1),(2,25,2,1,0,0,1),(3,151,1,1,0,0,1),(4,114,1,1,0,0,1),(5,344,1,1,0,0,1),(6,202,0,1,0,0,1);' >> "${dump_path}create_tables_state.sql"
+bash -c "${world_bin} database:dump --static-instance-data --dump-output-to-console > ${dump_path}create_tables_state.sql"
 bash -c "${world_bin} database:dump --query-serv-tables --table-structure-only --dump-output-to-console | sed 's/ AUTO_INCREMENT=[0-9]*\b//g' > ${dump_path}create_tables_queryserv.sql"
 
 # with content

--- a/utils/sql/peq-dump/peq-dump.sh
+++ b/utils/sql/peq-dump/peq-dump.sh
@@ -44,8 +44,8 @@ echo "Generating [create_*] table exports..."
 bash -c "${world_bin} database:dump --login-tables --table-structure-only --dump-output-to-console | sed 's/ AUTO_INCREMENT=[0-9]*\b//g' > ${dump_path}create_tables_login.sql"
 bash -c "${world_bin} database:dump --player-tables --table-structure-only --dump-output-to-console | sed 's/ AUTO_INCREMENT=[0-9]*\b//g' > ${dump_path}create_tables_player.sql"
 bash -c "${world_bin} database:dump --state-tables --table-structure-only --dump-output-to-console | sed 's/ AUTO_INCREMENT=[0-9]*\b//g' > ${dump_path}create_tables_state.sql"
-bash -c "${world_bin} database:dump --static-instance-data --dump-output-to-console > ${dump_path}create_tables_state.sql"
-bash -c "${world_bin} database:dump --query-serv-tables --table-structure-only --dump-output-to-console | sed 's/ AUTO_INCREMENT=[0-9]*\b//g' >> ${dump_path}create_tables_queryserv.sql"
+bash -c "${world_bin} database:dump --static-instance-data --dump-output-to-console >> ${dump_path}create_tables_state.sql"
+bash -c "${world_bin} database:dump --query-serv-tables --table-structure-only --dump-output-to-console | sed 's/ AUTO_INCREMENT=[0-9]*\b//g' > ${dump_path}create_tables_queryserv.sql"
 
 # with content
 bash -c "${world_bin} database:dump --content-tables --dump-output-to-console > ${dump_path}create_tables_content.sql"

--- a/world/cli/database_dump.cpp
+++ b/world/cli/database_dump.cpp
@@ -15,6 +15,7 @@ void WorldserverCLI::DatabaseDump(int argc, char **argv, argh::parser &cmd, std:
 		"--state-tables",
 		"--system-tables",
 		"--query-serv-tables",
+		"--static-instance-data",
 		"--table-structure-only",
 		"--table-lock",
 		"--dump-path=",
@@ -51,6 +52,7 @@ void WorldserverCLI::DatabaseDump(int argc, char **argv, argh::parser &cmd, std:
 	s->SetDumpWithCompression(cmd[{"--compress"}]);
 	s->SetDumpOutputToConsole(cmd[{"--dump-output-to-console"}]);
 	s->SetDumpDropTableSyntaxOnly(cmd[{"--drop-table-syntax-only"}]);
+	s->SetDumpStaticInstanceData(cmd[{"--static-instance-data"}]);
 
 	s->DatabaseDump();
 }


### PR DESCRIPTION
This solves for an issue where `instance_list` is classified as a state table, yet we hold some semblance of content data in it because some zones are classified as "static global instances" which never expire and are used for v1/v2 zone expansion switches.

We only export static data after the structure of the table was already created.

**Example Output**

```
./bin/world database:dump --static-instance-data --dump-output-to-console
```

```sql
-- MariaDB dump 10.19  Distrib 10.5.18-MariaDB, for debian-linux-gnu (x86_64)
--
-- Host: mariadb    Database: peq
-- ------------------------------------------------------
-- Server version	10.5.4-MariaDB-1:10.5.4+maria~focal

/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
/*!40101 SET NAMES utf8 */;
/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
/*!40103 SET TIME_ZONE='+00:00' */;
/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;

--
-- Dumping data for table `instance_list`
--
-- WHERE:  instance_list.is_global > 0 and instance_list.never_expires > 0

LOCK TABLES `instance_list` WRITE;
/*!40000 ALTER TABLE `instance_list` DISABLE KEYS */;
INSERT INTO `instance_list` VALUES (1,25,1,1,0,0,1,'Nektulos DoDH'),(2,25,2,1,0,0,1,'Nektulos Unused'),(3,151,1,1,0,0,1,'Classic Bazaar'),(4,114,1,1,0,0,1,'Skyshrine Sleeper ?'),(5,344,1,1,0,0,1,'Guild Lobby Unused'),(6,202,0,1,0,0,1,'Plane of Knowledge Unused'),(40,25,1,1,0,0,1,'');
/*!40000 ALTER TABLE `instance_list` ENABLE KEYS */;
UNLOCK TABLES;
/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;

/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;

-- Dump completed on 2023-08-20 15:30:14
```

**PEQ Dumper Script**

Also updated to reflect the dumper change