### PR TITLE
[Bug Fix] Minor adjustment to formula calc position to fix modifier bug.

### DIFF
--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -1194,6 +1194,8 @@ void Raid::SplitExp(const uint64 exp, Mob* other) {
 		member_modifier = member_count;
 	}
 
+	raid_experience = static_cast<uint64>(static_cast<float>(raid_experience) * RuleR(Character, FinalRaidExpMultiplier));
+
 	for (const auto& m : members) {
 		if (m.member && !m.is_bot) {
 			const int32 diff     = m.member->GetLevel() - highest_level;
@@ -1210,8 +1212,6 @@ void Raid::SplitExp(const uint64 exp, Mob* other) {
 			}
 		}
 	}
-
-	raid_experience = static_cast<uint64>(static_cast<float>(raid_experience) *	RuleR(Character, FinalRaidExpMultiplier));
 }
 
 void Client::SetLeadershipEXP(uint64 group_exp, uint64 raid_exp) {

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -1184,6 +1184,8 @@ void Raid::SplitExp(const uint64 exp, Mob* other) {
 		raid_experience = static_cast<uint64>(static_cast<float>(raid_experience) *	(1.0f - RuleR(Character, RaidExpMultiplier)));
 	}
 
+	raid_experience = static_cast<uint64>(static_cast<float>(raid_experience) * RuleR(Character, FinalRaidExpMultiplier));
+
 	const auto consider_level = Mob::GetLevelCon(highest_level, other->GetLevel());
 	if (consider_level == CON_GRAY) {
 		return;
@@ -1193,8 +1195,6 @@ void Raid::SplitExp(const uint64 exp, Mob* other) {
 	if (RuleB(Character, EnableRaidMemberEXPModifier)) {
 		member_modifier = member_count;
 	}
-
-	raid_experience = static_cast<uint64>(static_cast<float>(raid_experience) * RuleR(Character, FinalRaidExpMultiplier));
 
 	for (const auto& m : members) {
 		if (m.member && !m.is_bot) {


### PR DESCRIPTION
This PR fixes a bug introduced in #3554 which would cause the final raid exp modifier to not apply correctly due to it being calculated too late in the code path.