### PR TITLE
[Instances] Refine id selection

### DIFF
--- a/common/database_instances.cpp
+++ b/common/database_instances.cpp
@@ -139,50 +139,105 @@ bool Database::GetUnusedInstanceID(uint16 &instance_id)
 		return false;
 	}
 
-	// initial query - get max unused id above reserved
-	auto query = fmt::format(
-		"SELECT IFNULL(MAX(id), {}) + 1 FROM instance_list WHERE id > {}",
-		max_reserved_instance_id,
-		max_reserved_instance_id
-	);
-
-	// recycle instances - change query to get first unused id above reserved
+	// recycle instances
 	if (RuleB(Instances, RecycleInstanceIds)) {
+		
+		//query to get first unused id above reserved
+		auto query = fmt::format(
+			SQL(
+				SELECT id
+				FROM instance_list
+				WHERE id = {};
+			),
+			max_reserved_instance_id + 1
+		);
+
+		auto results = QueryDatabase(query);
+
+		// could not successfully query - bail out
+		if (!results.Success()) {
+			instance_id = 0;
+			return false;
+		}
+
+		// first id is available
+		if (results.RowCount() == 0) {
+			instance_id = max_reserved_instance_id + 1;
+			return true;
+		}
+
+		// now look for next available above reserved
 		query = fmt::format(
 			SQL(
 				SELECT MIN(i.id + 1) AS next_available
 				FROM instance_list i
 				LEFT JOIN instance_list i2 ON i.id + 1 = i2.id
-				WHERE i.id > {}
+				WHERE i.id >= {}
 				AND i2.id IS NULL;
 			),
-			RuleI(Instances, ReservedInstances)
+			max_reserved_instance_id
 		);
-	}
 
-	auto results = QueryDatabase(query);
+		results = QueryDatabase(query);
 
-	// could not successfully query - bail out
-	if (!results.Success()) {
-		instance_id = 0;
-		return false;
-	}
+		// could not successfully query - bail out
+		if (!results.Success()) {
+			instance_id = 0;
+			return false;
+		}
 
-	// no instances running - assign first id above reserved
-	if (results.RowCount() == 0) {
-		instance_id = max_reserved_instance_id + 1;
-		return true;
-	}
+		// did not retrieve any rows - bail out
+		if (results.RowCount() == 0) {
+			instance_id = 0;
+			return false;
+		}
 
-	for (auto row : results) {
+		auto row = results.begin();
+
 		// check that id is within limits
-		if (row[0] && Strings::ToInt(row[0]) <= max_instance_id) {
+		if (Strings::ToInt(row[0]) <= max_instance_id) {
 			instance_id = Strings::ToInt(row[0]);
 			return true;
 		}
 	}
+	else {
+		// get max unused id above reserved
+		auto query = fmt::format(
+			"SELECT IFNULL(MAX(id), {}) + 1 FROM instance_list WHERE id > {}",
+			max_reserved_instance_id,
+			max_reserved_instance_id
+		);
 
-	// unhandled situation - should not reach here
+		auto results = QueryDatabase(query);
+
+		// could not successfully query - bail out
+		if (!results.Success()) {
+			instance_id = 0;
+			return false;
+		}
+
+		// did not retrieve any rows - bail out
+		if (results.RowCount() == 0) {
+			instance_id = 0;
+			return false;
+		}
+
+		auto row = results.begin();
+
+		// no instances currently used
+		if (row[0] == NULL) {
+			instance_id = max_reserved_instance_id + 1;
+			return true;
+		}
+
+		// check that id is within limits
+		if (Strings::ToInt(row[0]) <= max_instance_id) {
+			instance_id = Strings::ToInt(row[0]);
+			return true;
+		}
+	}
+	
+	// no available instance ids
 	instance_id = 0;
 	return false;
 }


### PR DESCRIPTION
Since the IDs start above the minimum, we needed to check if the first slot was available.

Recycle IDs with a gap at max reserved:
```
+----+------+---------+-----------+------------+-----------+---------------+
| id | zone | version | is_global | start_time | duration  | never_expires |
+----+------+---------+-----------+------------+-----------+---------------+
|  1 |   25 |       1 |         1 |          0 |         0 |             1 |
|  2 |   25 |       2 |         1 |          0 |         0 |             1 |
|  3 |  151 |       1 |         1 |          0 |         0 |             1 |
|  4 |  114 |       1 |         1 |          0 |         0 |             1 |
|  5 |  344 |       1 |         1 |          0 |         0 |             1 |
|  6 |  202 |       0 |         1 |          0 |         0 |             1 |
|  7 |  202 |       0 |         0 | 1692588190 | 100000000 |             0 |
|  8 |   77 |       0 |         0 | 1692588252 | 100000000 |             0 |
|  9 |  188 |       0 |         0 | 1692588369 | 100000000 |             0 |
| 10 |  279 |       0 |         0 | 1692589421 | 100000000 |             0 |
| 11 |   77 |       1 |         0 | 1692590051 | 100000000 |             0 |
| 12 |  152 |       0 |         0 | 1692590404 |     10000 |             0 |
| 34 |  204 |       0 |         0 | 1692592749 |        10 |             0 |
| 35 |  152 |       0 |         0 | 1692592760 |        10 |             0 |
| 36 |  154 |       0 |         0 | 1692592804 |        10 |             0 |
| 37 |  152 |       0 |         0 | 1692592863 |        10 |             0 |
| 38 |  204 |       0 |         0 | 1692592952 |        10 |             0 |
+----+------+---------+-----------+------------+-----------+---------------+
17 rows in set (0.001 sec)
```
![image](https://github.com/EQEmu/Server/assets/3617814/fccd62b5-c120-437c-98d5-44806ce0835c)

```
+----+------+---------+-----------+------------+-----------+---------------+
| id | zone | version | is_global | start_time | duration  | never_expires |
+----+------+---------+-----------+------------+-----------+---------------+
|  1 |   25 |       1 |         1 |          0 |         0 |             1 |
|  2 |   25 |       2 |         1 |          0 |         0 |             1 |
|  3 |  151 |       1 |         1 |          0 |         0 |             1 |
|  4 |  114 |       1 |         1 |          0 |         0 |             1 |
|  5 |  344 |       1 |         1 |          0 |         0 |             1 |
|  6 |  202 |       0 |         1 |          0 |         0 |             1 |
|  7 |  202 |       0 |         0 | 1692588190 | 100000000 |             0 |
|  8 |   77 |       0 |         0 | 1692588252 | 100000000 |             0 |
|  9 |  188 |       0 |         0 | 1692588369 | 100000000 |             0 |
| 10 |  279 |       0 |         0 | 1692589421 | 100000000 |             0 |
| 11 |   77 |       1 |         0 | 1692590051 | 100000000 |             0 |
| 12 |  152 |       0 |         0 | 1692590404 |     10000 |             0 |
| 31 |   77 |       0 |         0 | 1692618125 |       100 |             0 |
| 32 |  279 |       0 |         0 | 1692618159 |       100 |             0 |
| 33 |  109 |       0 |         0 | 1692618179 |       100 |             0 |
| 34 |  204 |       0 |         0 | 1692592749 |        10 |             0 |
| 35 |  152 |       0 |         0 | 1692592760 |        10 |             0 |
| 36 |  154 |       0 |         0 | 1692592804 |        10 |             0 |
| 37 |  152 |       0 |         0 | 1692592863 |        10 |             0 |
| 38 |  204 |       0 |         0 | 1692592952 |        10 |             0 |
| 39 |    1 |       0 |         0 | 1692618188 |       100 |             0 |
+----+------+---------+-----------+------------+-----------+---------------+
21 rows in set (0.001 sec)
```
![image](https://github.com/EQEmu/Server/assets/3617814/363b1fd2-4d56-4950-923a-b708c5778628)

```
MariaDB [peq]> delete from instance_list where id=31;
Query OK, 1 row affected (0.009 sec)

MariaDB [peq]> delete from instance_list where id=33;
Query OK, 1 row affected (0.010 sec)

MariaDB [peq]> select * from instance_list;
+----+------+---------+-----------+------------+-----------+---------------+
| id | zone | version | is_global | start_time | duration  | never_expires |
+----+------+---------+-----------+------------+-----------+---------------+
|  1 |   25 |       1 |         1 |          0 |         0 |             1 |
|  2 |   25 |       2 |         1 |          0 |         0 |             1 |
|  3 |  151 |       1 |         1 |          0 |         0 |             1 |
|  4 |  114 |       1 |         1 |          0 |         0 |             1 |
|  5 |  344 |       1 |         1 |          0 |         0 |             1 |
|  6 |  202 |       0 |         1 |          0 |         0 |             1 |
|  7 |  202 |       0 |         0 | 1692588190 | 100000000 |             0 |
|  8 |   77 |       0 |         0 | 1692588252 | 100000000 |             0 |
|  9 |  188 |       0 |         0 | 1692588369 | 100000000 |             0 |
| 10 |  279 |       0 |         0 | 1692589421 | 100000000 |             0 |
| 11 |   77 |       1 |         0 | 1692590051 | 100000000 |             0 |
| 12 |  152 |       0 |         0 | 1692590404 |     10000 |             0 |
| 32 |  279 |       0 |         0 | 1692618159 |       100 |             0 |
| 34 |  204 |       0 |         0 | 1692592749 |        10 |             0 |
| 35 |  152 |       0 |         0 | 1692592760 |        10 |             0 |
| 36 |  154 |       0 |         0 | 1692592804 |        10 |             0 |
| 37 |  152 |       0 |         0 | 1692592863 |        10 |             0 |
| 38 |  204 |       0 |         0 | 1692592952 |        10 |             0 |
| 39 |    1 |       0 |         0 | 1692618188 |       100 |             0 |
+----+------+---------+-----------+------------+-----------+---------------+
19 rows in set (0.001 sec)
```
```
MariaDB [peq]> select * from instance_list;
+----+------+---------+-----------+------------+-----------+---------------+
| id | zone | version | is_global | start_time | duration  | never_expires |
+----+------+---------+-----------+------------+-----------+---------------+
|  1 |   25 |       1 |         1 |          0 |         0 |             1 |
|  2 |   25 |       2 |         1 |          0 |         0 |             1 |
|  3 |  151 |       1 |         1 |          0 |         0 |             1 |
|  4 |  114 |       1 |         1 |          0 |         0 |             1 |
|  5 |  344 |       1 |         1 |          0 |         0 |             1 |
|  6 |  202 |       0 |         1 |          0 |         0 |             1 |
|  7 |  202 |       0 |         0 | 1692588190 | 100000000 |             0 |
|  8 |   77 |       0 |         0 | 1692588252 | 100000000 |             0 |
|  9 |  188 |       0 |         0 | 1692588369 | 100000000 |             0 |
| 10 |  279 |       0 |         0 | 1692589421 | 100000000 |             0 |
| 11 |   77 |       1 |         0 | 1692590051 | 100000000 |             0 |
| 12 |  152 |       0 |         0 | 1692590404 |     10000 |             0 |
| 31 |   25 |       0 |         0 | 1692618881 |        50 |             0 |
| 32 |  279 |       0 |         0 | 1692618159 |       100 |             0 |
| 33 |   42 |       0 |         0 | 1692618894 |        50 |             0 |
| 34 |  204 |       0 |         0 | 1692592749 |        10 |             0 |
| 35 |  152 |       0 |         0 | 1692592760 |        10 |             0 |
| 36 |  154 |       0 |         0 | 1692592804 |        10 |             0 |
| 37 |  152 |       0 |         0 | 1692592863 |        10 |             0 |
| 38 |  204 |       0 |         0 | 1692592952 |        10 |             0 |
| 39 |    1 |       0 |         0 | 1692618188 |       100 |             0 |
| 40 |   43 |       0 |         0 | 1692618899 |        50 |             0 |
+----+------+---------+-----------+------------+-----------+---------------+
22 rows in set (0.001 sec)
```