### PR TITLE
[HotFix] Clearing target window on CHARM wear off had a side effect

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -1361,7 +1361,7 @@ void EntityList::SendZoneSpawnsBulk(Client *client)
 				(spawn->IsClient() && (spawn->GetRace() == MINOR_ILL_OBJ || spawn->GetRace() == TREE))
 			);
 
-			if (false) {
+			if (is_delayed_packet) {
 				app = new EQApplicationPacket;
 				spawn->CreateSpawnPacket(app);
 				client->QueuePacket(app, true, Client::CLIENT_CONNECTED);

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -1361,7 +1361,7 @@ void EntityList::SendZoneSpawnsBulk(Client *client)
 				(spawn->IsClient() && (spawn->GetRace() == MINOR_ILL_OBJ || spawn->GetRace() == TREE))
 			);
 
-			if (is_delayed_packet) {
+			if (false) {
 				app = new EQApplicationPacket;
 				spawn->CreateSpawnPacket(app);
 				client->QueuePacket(app, true, Client::CLIENT_CONNECTED);
@@ -1611,7 +1611,7 @@ void EntityList::QueueClientsByTarget(Mob *sender, const EQApplicationPacket *ap
 
 		TargetsTarget = Target->GetTarget();
 
-		bool Send = clear_target_window;
+		bool Send = false;
 
 		if (c == SkipThisMob)
 			continue;
@@ -1623,6 +1623,7 @@ void EntityList::QueueClientsByTarget(Mob *sender, const EQApplicationPacket *ap
 		if (c != sender) {
 			if (Target == sender) {
 				if (inspect_buffs) { // if inspect_buffs is true we're sending a mob's buffs to those with the LAA
+					Send = clear_target_window;
 					if (c->GetGM() || RuleB(Spells, AlwaysSendTargetsBuffs)) {
 						Send = !clear_target_window;
 					} else if (c->IsRaidGrouped()) {


### PR DESCRIPTION
Previous changes to QueueClientsByTarget to allow for clearing the target window of clients who have a charmed mob targetted at the time charm wears off had a bug where it could also clear a client target window that had something else targetted.

The use of the new flag clear_target_window needed to be limited in scope to when inspect_buffs is true.