### PR TITLE
[Messages] Remove duplicate message on tracking begin

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -11090,8 +11090,6 @@ void Client::SetTrackingID(uint32 entity_id)
 	}
 
 	TrackingID = entity_id;
-
-	MessageString(Chat::Skills, TRACKING_BEGIN, m->GetCleanName());
 }
 
 int Client::GetRecipeMadeCount(uint32 recipe_id)


### PR DESCRIPTION
When you click on a target and hit "tracking", the you begin to track <target> message is coming out twice.

Removing this from the server results in one and only one message on both Titanium and RoF2.  

Any reason not to merge this?  Other test I should do?