### PR TITLE
[Feature] Add Defensive Proc Rules for Level Gap Penalty

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -454,6 +454,8 @@ RULE_INT(Spells, ResurrectionEffectBlock, 2, "0 = allow overwrites/rule disabled
 RULE_BOOL(Spells, WaterMatchRequiredForLoS, true, "Enable/Disable the requirement of both the attacker/victim being both in or out of water for spells LoS to pass.")
 RULE_INT(Spells, WizardCritMinimumRandomRatio, 20, "The minimum value for the random range which Wizards and Caster DPS Mercs innately have for spell crit ratio. Set to 20 for vanilla values.")
 RULE_INT(Spells, WizardCritMaximumRandomRatio, 70, "The maximum value for the random range which Wizards and Caster DPS Mercs innately have for spell crit ratio. Set to 70 for vanilla values.")
+RULE_INT(Spells, DefensiveProcPenaltyLevelGap, 6, "Defensive Proc Penalty Level Gap where procs start losing their proc rate at RuleR(Spells, DefensiveProcPenaltyModifier)% per level difference")
+RULE_REAL(Spells, DefensiveProcPenaltyLevelGapModifier, 10.0f, "Defensive Proc Penalty Level Gap Modifier where procs start losing their proc rate at defined % after RuleI(Spells, DefensiveProcLevelGap) level difference")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Combat)


### PR DESCRIPTION
# Notes
- Allows operators to modify the level gap penalty and level gap required for the penalty for defensive procs' level gap penalty.
- Setting `Spells:DefensiveProcPenaltyLevelGap` to `-1` will disable the penalty.