### PR TITLE
[Quest API] Add Caster ID Parameter to FindBuff in Perl/Lua

### DIFF
--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -315,9 +315,14 @@ void Lua_Mob::SetInvisible(int state) {
 	self->SetInvisible(state);
 }
 
-bool Lua_Mob::FindBuff(int spell_id) {
+bool Lua_Mob::FindBuff(uint16 spell_id) {
 	Lua_Safe_Call_Bool();
 	return self->FindBuff(spell_id);
+}
+
+bool Lua_Mob::FindBuff(uint16 spell_id, uint16 caster_id) {
+	Lua_Safe_Call_Bool();
+	return self->FindBuff(spell_id, caster_id);
 }
 
 uint16 Lua_Mob::FindBuffBySlot(int slot) {
@@ -3313,7 +3318,8 @@ luabind::scope lua_register_mob() {
 	.def("Emote", &Lua_Mob::Emote)
 	.def("EntityVariableExists", &Lua_Mob::EntityVariableExists)
 	.def("FaceTarget", (void(Lua_Mob::*)(Lua_Mob))&Lua_Mob::FaceTarget)
-	.def("FindBuff", &Lua_Mob::FindBuff)
+	.def("FindBuff", (bool(Lua_Mob::*)(uint16))&Lua_Mob::FindBuff)
+	.def("FindBuff", (bool(Lua_Mob::*)(uint16,uint16))&Lua_Mob::FindBuff)
 	.def("FindBuffBySlot", (uint16(Lua_Mob::*)(int))&Lua_Mob::FindBuffBySlot)
 	.def("FindGroundZ", (double(Lua_Mob::*)(double,double))&Lua_Mob::FindGroundZ)
 	.def("FindGroundZ", (double(Lua_Mob::*)(double,double,double))&Lua_Mob::FindGroundZ)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -90,7 +90,8 @@ public:
 	uint8 GetInvisibleUndeadLevel();
 	void SetSeeInvisibleLevel(uint8 invisible_level);
 	void SetSeeInvisibleUndeadLevel(uint8 invisible_level);
-	bool FindBuff(int spell_id);
+	bool FindBuff(uint16 spell_id);
+	bool FindBuff(uint16 spell_id, uint16 caster_id);
 	uint16 FindBuffBySlot(int slot);
 	uint32 BuffCount();
 	uint32 BuffCount(bool is_beneficial);

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -464,7 +464,7 @@ public:
 	void DamageShield(Mob* other, bool spell_ds = false);
 	int32 RuneAbsorb(int64 damage, uint16 type);
 	std::vector<uint16> GetBuffSpellIDs();
-	bool FindBuff(uint16 spell_id);
+	bool FindBuff(uint16 spell_id, uint16 caster_id = 0);
 	uint16 FindBuffBySlot(int slot);
 	uint32 BuffCount(bool is_beneficial = true, bool is_detrimental = true);
 	bool FindType(uint16 type, bool bOffensive = false, uint16 threshold = 100);

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -362,6 +362,11 @@ bool Perl_Mob_FindBuff(Mob* self, uint16 spell_id) // @categories Spells and Dis
 	return self->FindBuff(spell_id);
 }
 
+bool Perl_Mob_FindBuff(Mob* self, uint16 spell_id, uint16 caster_id) // @categories Spells and Disciplines, Script Utility
+{
+	return self->FindBuff(spell_id, caster_id);
+}
+
 int Perl_Mob_FindBuffBySlot(Mob* self, int slot) // @categories Spells and Disciplines, Script Utility
 {
 	return self->FindBuffBySlot(slot);
@@ -3559,7 +3564,8 @@ void perl_register_mob()
 	package.add("EntityVariableExists", &Perl_Mob_EntityVariableExists);
 	package.add("FaceTarget", (void(*)(Mob*))&Perl_Mob_FaceTarget);
 	package.add("FaceTarget", (void(*)(Mob*, Mob*))&Perl_Mob_FaceTarget);
-	package.add("FindBuff", &Perl_Mob_FindBuff);
+	package.add("FindBuff", (bool(*)(Mob*, uint16))&Perl_Mob_FindBuff);
+	package.add("FindBuff", (bool(*)(Mob*, uint16, uint16))&Perl_Mob_FindBuff);
 	package.add("FindBuffBySlot", &Perl_Mob_FindBuffBySlot);
 	package.add("FindGroundZ", (float(*)(Mob*, float, float))&Perl_Mob_FindGroundZ);
 	package.add("FindGroundZ", (float(*)(Mob*, float, float, float))&Perl_Mob_FindGroundZ);

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4402,14 +4402,20 @@ std::vector<uint16> Mob::GetBuffSpellIDs()
 	return l;
 }
 
-bool Mob::FindBuff(uint16 spell_id)
+bool Mob::FindBuff(uint16 spell_id, uint16 caster_id)
 {
-	uint32 buff_count = GetMaxTotalSlots();
+	const int buff_count = GetMaxTotalSlots();
 	for (int buff_slot = 0; buff_slot < buff_count; buff_slot++) {
-		auto current_spell_id = buffs[buff_slot].spellid;
+		const uint16 current_spell_id = buffs[buff_slot].spellid;
 		if (
-			IsValidSpell(current_spell_id) &&
-			current_spell_id == spell_id
+			(
+				IsValidSpell(current_spell_id) &&
+				current_spell_id == spell_id
+			) &&
+			(
+				!caster_id ||
+				buffs[buff_slot].casterid == caster_id
+			)
 		) {
 			return true;
 		}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4408,10 +4408,8 @@ bool Mob::FindBuff(uint16 spell_id, uint16 caster_id)
 	for (int buff_slot = 0; buff_slot < buff_count; buff_slot++) {
 		const uint16 current_spell_id = buffs[buff_slot].spellid;
 		if (
-			(
-				IsValidSpell(current_spell_id) &&
-				current_spell_id == spell_id
-			) &&
+			IsValidSpell(current_spell_id) &&
+			current_spell_id == spell_id &&
 			(
 				!caster_id ||
 				buffs[buff_slot].casterid == caster_id


### PR DESCRIPTION
# Perl
- Add `$mob->FindBuff(spell_id, caster_id)`.

# Lua
- Add `mob:FindBuff(spell_id, caster_id)`.

# Notes
- Allows operators to check if the spell ID is cast by a specific entity ID.
- We don't use `Mob*` reference here since the mob may have died, left zone, etc.