### PR TITLE
[Bug Fix] Fix Entity ID on death with #castspell

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -5068,7 +5068,7 @@ const char *Mob::GetCleanName()
 	return clean_name;
 }
 
-std::string Mob::GetTargetDescription(Mob* target, uint8 description_type)
+std::string Mob::GetTargetDescription(Mob* target, uint8 description_type, uint16 entity_id_override)
 {
 	std::string self_return = "yourself";
 
@@ -5119,7 +5119,7 @@ std::string Mob::GetTargetDescription(Mob* target, uint8 description_type)
 			fmt::format(
 				"{} ({})",
 				target->GetCleanName(),
-				target->GetID()
+				entity_id_override ? entity_id_override : target->GetID()
 			)
 		)
 	);

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -586,7 +586,7 @@ public:
 	virtual void SetName(const char *new_name = nullptr) { new_name ? strn0cpy(name, new_name, 64) :
 		strn0cpy(name, GetName(), 64); return; };
 	inline Mob* GetTarget() const { return target; }
-	std::string GetTargetDescription(Mob* target, uint8 description_type = TargetDescriptionType::LCSelf);
+	std::string GetTargetDescription(Mob* target, uint8 description_type = TargetDescriptionType::LCSelf, uint16 entity_id_override = 0);
 	virtual void SetTarget(Mob* mob);
 	inline bool HasTargetReflection() const { return (target && target != this && target->target == this); }
 	virtual inline float GetHPRatio() const { return max_hp == 0 ? 0 : ((float) current_hp / max_hp * 100); }


### PR DESCRIPTION
# Notes
- Entities killed by a spell with #cast were not reporting their pre-death entity ID properly.
- Added an `entity_id_override` to `GetTargetDescription()` and added a pre-defined entity ID variable to the cast command so we can message the proper pre-death entity ID.