### PR TITLE
[Messages] Swarm pet normal damage messages were missing

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -4226,7 +4226,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 		//this was done to simplify the code here (since we can only effectively skip one mob on queue)
 		eqFilterType filter;
 		Mob* skip = attacker;
-		if (attacker && attacker->GetOwnerID()) {
+		if (attacker && attacker->GetOwner()) {
 			//attacker is a pet, let pet owners see their pet's damage
 			Mob* owner = attacker->GetOwner();
 			if (owner && owner->IsClient()) {


### PR DESCRIPTION
In a previous PR: https://github.com/EQEmu/Server/pull/3551 I fixed a problem where proc messages for some situations were lost.  In the process, I moved all pet messages to the same spot in the code, so they could all be handled correctly using the correct filters.

That spot, was using GetOwnerID() instead of GetOwner() to tell if an npc was a pet.  For some reason Swarm pets do not have an OwnerID.  

This PR only fixes the messaging issue by using GetOwner() in this one spot, to make sure swarm pet messages are not missed.

If swarm pets should have a OwnerID() I leave that to someone with more knowledge of swarms.