### PR TITLE
[Bug Fix] Add Validation to #find, #set, and #show args

### DIFF
--- a/zone/gm_commands/find.cpp
+++ b/zone/gm_commands/find.cpp
@@ -72,7 +72,9 @@ void command_find(Client *c, const Seperator *sep)
 
 				// skip the first arg
 				for (auto i = 1; i <= arguments; i++) {
-					args.emplace_back(sep->arg[i]);
+					if (sep->arg[i]) {
+						args.emplace_back(sep->arg[i]);
+					}
 				}
 
 				// build the rewrite string

--- a/zone/gm_commands/set.cpp
+++ b/zone/gm_commands/set.cpp
@@ -136,7 +136,9 @@ void command_set(Client *c, const Seperator *sep)
 
 				// skip the first arg
 				for (auto i = 1; i <= arguments; i++) {
-					args.emplace_back(sep->arg[i]);
+					if (sep->arg[i]) {
+						args.emplace_back(sep->arg[i]);
+					}
 				}
 
 				// build the rewrite string

--- a/zone/gm_commands/show.cpp
+++ b/zone/gm_commands/show.cpp
@@ -115,7 +115,9 @@ void command_show(Client *c, const Seperator *sep)
 
 				// skip the first arg
 				for (auto i = 1; i <= arguments; i++) {
-					args.emplace_back(sep->arg[i]);
+					if (sep->arg[i]) {
+						args.emplace_back(sep->arg[i]);
+					}
 				}
 
 				// build the rewrite string


### PR DESCRIPTION
# Notes
- We were not validating `sep->arg[i]` so we could possibly be pushing a `nullptr` in.