### PR TITLE
[Logs] Change pathing log messages from `Error` to `Pathing`.

### DIFF
--- a/zone/waypoints.cpp
+++ b/zone/waypoints.cpp
@@ -157,7 +157,7 @@ void NPC::ResumeWandering()
 		}
 		else
 		{
-			LogError("NPC not paused - can't resume wandering: [{}]", (unsigned long)GetNPCTypeID());
+			LogPathing("NPC not paused - can't resume wandering: [{}]", (unsigned long)GetNPCTypeID());
 			return;
 		}
 
@@ -173,7 +173,7 @@ void NPC::ResumeWandering()
 	}
 	else
 	{
-		LogError("NPC not on grid - can't resume wandering: [{}]", (unsigned long)GetNPCTypeID());
+		LogPathing("NPC not on grid - can't resume wandering: [{}]", (unsigned long)GetNPCTypeID());
 	}
 	return;
 }
@@ -195,7 +195,7 @@ void NPC::PauseWandering(int pausetime)
 		}
 	}
 	else {
-		LogError("NPC not on grid - can't pause wandering: [{}]", (unsigned long)GetNPCTypeID());
+		LogPathing("NPC not on grid - can't pause wandering: [{}]", (unsigned long)GetNPCTypeID());
 	}
 	return;
 }


### PR DESCRIPTION
Call to `Pause` and `Resume` wandering happen with quest subs and shouldn't be considered errors.