### PR TITLE
[Crash] Bot member zoned crash fix

### DIFF
--- a/zone/groups.cpp
+++ b/zone/groups.cpp
@@ -555,8 +555,13 @@ void Group::MemberZoned(Mob* removemob) {
 
 	//should NOT clear the name, it is used for world communication.
 	for (auto & m : members) {
-		if (m && (m == removemob || (m->IsBot() && m->CastToBot()->GetBotOwner() == removemob))) {
-			m = nullptr;
+		if (m) {
+			if (m->IsBot() && m->CastToBot()->GetBotOwner() && m->CastToBot()->GetBotOwner() == removemob) {
+				m = nullptr;
+			}
+			else if (m == removemob) {
+				m = nullptr;
+			}
 		}
 	}
 


### PR DESCRIPTION
As observed in http://spire.akkadius.com/dev/release/22.26.2?id=11616

Does not look like we validate the bot owner exists trying to compare a potential null pointer. Not guaranteed to fix this.