### PR TITLE
[Crash] Fix CanUseAlternateAdvancementRank crash

### DIFF
--- a/zone/aa.cpp
+++ b/zone/aa.cpp
@@ -1576,6 +1576,10 @@ bool Mob::SetAA(uint32 rank_id, uint32 new_value, uint32 charges) {
 
 
 bool Mob::CanUseAlternateAdvancementRank(AA::Rank *rank) {
+	if (!rank) {
+		return false;
+	}
+
 	AA::Ability *ability = rank->base_ability;
 
 	if(!ability)


### PR DESCRIPTION
As observed in http://spire.akkadius.com/dev/release/22.26.2?id=11674