### PR TITLE
[Bots] Adjust Bot Movement Speed

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -651,7 +651,7 @@ NPCType *Bot::FillNPCTypeStruct(
 	n->current_hp = hp;
 	n->max_hp = hp;
 	n->size = size;
-	n->runspeed = 0.7f;
+	n->runspeed = 1.25f;
 	n->gender = gender;
 	n->race = botRace;
 	n->class_ = botClass;
@@ -2227,10 +2227,10 @@ void Bot::AI_Process()
 // OK TO IDLE
 
 		// Ok to idle
-		if (TryIdleChecks(fm_distance)) {
+		if (TryNonCombatMovementChecks(bot_owner, follow_mob, Goal)) {
 			return;
 		}
-		if (TryNonCombatMovementChecks(bot_owner, follow_mob, Goal)) {
+		if (TryIdleChecks(fm_distance)) {
 			return;
 		}
 		if (TryBardMovementCasts()) {
@@ -2263,23 +2263,11 @@ bool Bot::TryNonCombatMovementChecks(Client* bot_owner, const Mob* follow_mob, g
 		if ((!bot_owner->GetBotPulling() || PULLING_BOT) && (destination_distance > GetFollowDistance())) {
 
 			if (!IsRooted()) {
-
 				if (rest_timer.Enabled()) {
 					rest_timer.Disable();
 				}
 
-				bool running = true;
-
-				if (destination_distance < GetFollowDistance() + BOT_FOLLOW_DISTANCE_WALK) {
-					running = false;
-				}
-
-				if (running) {
-					RunTo(Goal.x, Goal.y, Goal.z);
-				}
-				else {
-					WalkTo(Goal.x, Goal.y, Goal.z);
-				}
+				RunTo(Goal.x, Goal.y, Goal.z);
 
 				return true;
 			}

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -39,7 +39,6 @@
 
 constexpr uint32 BOT_FOLLOW_DISTANCE_DEFAULT = 184; // as DSq value (~13.565 units)
 constexpr uint32 BOT_FOLLOW_DISTANCE_DEFAULT_MAX = 2500; // as DSq value (50 units)
-constexpr uint32 BOT_FOLLOW_DISTANCE_WALK = 1000; // as DSq value (~31.623 units)
 
 constexpr uint32 BOT_KEEP_ALIVE_INTERVAL = 5000; // 5 seconds
 


### PR DESCRIPTION
# Notes
- Bots were having a hard time keeping up with players.
- Part of this was due to using walk until a certain distance.
- Another part was their ctor only having `0.7f` run speed versus our Mob sanity check of `1.25f`.
- We check movement stuff now before idle checks so bots are more likely to start moving earlier.