### PR TITLE
[Quest API] Add GrantAllAAPoints() to Perl/Lua and Modify #grantaa

### DIFF
--- a/zone/client.h
+++ b/zone/client.h
@@ -906,7 +906,7 @@ public:
 	int GetSpentAA() { return m_pp.aapoints_spent; }
 	uint32 GetRequiredAAExperience();
 	void AutoGrantAAPoints();
-	void GrantAllAAPoints();
+	void GrantAllAAPoints(uint8 unlock_level = 0);
 	bool HasAlreadyPurchasedRank(AA::Rank* rank);
 
 	bool SendGMCommand(std::string message, bool ignore_status = false);

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -137,7 +137,7 @@ int command_init(void)
 		command_add("givemoney", "[Platinum] [Gold] [Silver] [Copper] - Gives specified amount of money to you or your player target", AccountStatus::GMMgmt, command_givemoney) ||
 		command_add("gmzone", "[Zone ID|Zone Short Name] [Version] [Instance Identifier] - Zones to a private GM instance (Version defaults to 0 and Instance Identifier defaults to 'gmzone' if not used)", AccountStatus::GMAdmin, command_gmzone) ||
 		command_add("goto", "[playername] or [x y z] [h] - Teleport to the provided coordinates or to your target", AccountStatus::Steward, command_goto) ||
-		command_add("grantaa", "Grants a player all available AA points for their level.", AccountStatus::GMMgmt, command_grantaa) ||
+		command_add("grantaa", "[level] - Grants a player all available AA points up the specified level, all AAs are granted if no level is specified.", AccountStatus::GMMgmt, command_grantaa) ||
 		command_add("grid", "[add/delete] [grid_num] [wandertype] [pausetype] - Create/delete a wandering grid", AccountStatus::GMAreas, command_grid) ||
 		command_add("guild", "Guild manipulation commands. Use argument help for more info.", AccountStatus::Steward, command_guild) ||
 		command_add("help", "[Search Criteria] - List available commands and their description, specify partial command as argument to search", AccountStatus::Player, command_help) ||

--- a/zone/gm_commands/grantaa.cpp
+++ b/zone/gm_commands/grantaa.cpp
@@ -7,14 +7,24 @@ void command_grantaa(Client *c, const Seperator *sep)
 		return;
 	}
 
+	const uint8 unlock_level = sep->IsNumber(1) ? static_cast<uint8>(Strings::ToUnsignedInt(sep->arg[1])) : 0;
+
 	auto t = c->GetTarget()->CastToClient();
-	t->GrantAllAAPoints();
+	t->GrantAllAAPoints(unlock_level);
 
 	c->Message(
 		Chat::White,
 		fmt::format(
-			"Successfully granted all Alternate Advancements for {}.",
-			c->GetTargetDescription(t)
+			"Successfully granted all Alternate Advancements for {}{}.",
+			c->GetTargetDescription(t),
+			(
+				unlock_level ?
+				fmt::format(
+					" up to level {}",
+					unlock_level
+				) :
+				""
+			)
 		).c_str()
 	);
 }

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3164,6 +3164,18 @@ void Lua_Client::SetBucket(std::string bucket_name, std::string bucket_value, st
 	self->SetBucket(bucket_name, bucket_value, expiration);
 }
 
+void Lua_Client::GrantAllAAPoints()
+{
+	Lua_Safe_Call_Void();
+	self->GrantAllAAPoints();
+}
+
+void Lua_Client::GrantAllAAPoints(uint8 unlock_level)
+{
+	Lua_Safe_Call_Void();
+	self->GrantAllAAPoints(unlock_level);
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 	.def(luabind::constructor<>())
@@ -3414,6 +3426,8 @@ luabind::scope lua_register_client() {
 	.def("GetPEQZoneFlags", (luabind::object(Lua_Client::*)(lua_State*))&Lua_Client::GetPEQZoneFlags)
 	.def("GetZoneFlags", (luabind::object(Lua_Client::*)(lua_State*))&Lua_Client::GetZoneFlags)
 	.def("GoFish", (void(Lua_Client::*)(void))&Lua_Client::GoFish)
+	.def("GrantAllAAPoints", (void(Lua_Client::*)(void))&Lua_Client::GrantAllAAPoints)
+	.def("GrantAllAAPoints", (void(Lua_Client::*)(uint8))&Lua_Client::GrantAllAAPoints)
 	.def("GrantAlternateAdvancementAbility", (bool(Lua_Client::*)(int, int))&Lua_Client::GrantAlternateAdvancementAbility)
 	.def("GrantAlternateAdvancementAbility", (bool(Lua_Client::*)(int, int, bool))&Lua_Client::GrantAlternateAdvancementAbility)
 	.def("GuildID", (uint32(Lua_Client::*)(void))&Lua_Client::GuildID)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -480,6 +480,8 @@ public:
 	std::string GetBucketRemaining(std::string bucket_name);
 	void SetBucket(std::string bucket_name, std::string bucket_value);
 	void SetBucket(std::string bucket_name, std::string bucket_value, std::string expiration);
+	void GrantAllAAPoints();
+	void GrantAllAAPoints(uint8 unlock_level);
 
 	void ApplySpell(int spell_id);
 	void ApplySpell(int spell_id, int duration);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -2982,6 +2982,16 @@ void Perl_Client_SetLDoNPoints(Client* self, uint32 theme_id, uint32 points)
 	self->SetLDoNPoints(theme_id, points);
 }
 
+void Perl_Client_GrantAllAAPoints(Client* self)
+{
+	self->GrantAllAAPoints();
+}
+
+void Perl_Client_GrantAllAAPoints(Client* self, uint8 unlock_level)
+{
+	self->GrantAllAAPoints(unlock_level);
+}
+
 void perl_register_client()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3232,6 +3242,8 @@ void perl_register_client()
 	package.add("GetPEQZoneFlags", &Perl_Client_GetPEQZoneFlags);
 	package.add("GetZoneFlags", &Perl_Client_GetZoneFlags);
 	package.add("GoFish", &Perl_Client_GoFish);
+	package.add("GrantAllAAPoints", (void(*)(Client*))&Perl_Client_GrantAllAAPoints);
+	package.add("GrantAllAAPoints", (void(*)(Client*, uint8))&Perl_Client_GrantAllAAPoints);
 	package.add("GrantAlternateAdvancementAbility", (bool(*)(Client*, int, int))&Perl_Client_GrantAlternateAdvancementAbility);
 	package.add("GrantAlternateAdvancementAbility", (bool(*)(Client*, int, int, bool))&Perl_Client_GrantAlternateAdvancementAbility);
 	package.add("GuildID", &Perl_Client_GuildID);


### PR DESCRIPTION
# Command
- Add optional `level` argument to `#grantaa` so you can grant AAs up the specified level.

# Perl
- Add `$client->GrantAllAAPoints()`.
- Add `$client->GrantAllAAPoints(unlock_level)`.

# Lua
- Add `client:GrantAllAAPoints()`.
- Add `client:GrantAllAAPoints(unlock_level)`.

# Notes
- Grants all AA abilities up to client's current level or a specified level.