### PR TITLE
[Crash] Resolve crash when assigning empty raid note.

### DIFF
--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -1721,7 +1721,7 @@ bool Raid::LearnMembers()
 	}
 
 	int i = 0;
-	for (auto &e: raid_members) {
+	for (const auto &e: raid_members) {
 		if (e.name.empty()) {
 			continue;
 		}


### PR DESCRIPTION
Regression from #3524. Forming a raid would cause a crash at ```members[i].note = std::string(row[10]);```

Tried multiple resolutions along with @neckkola, however the only way that worked consistently was after switching the method to use Repositories to load in the database.
