### PR TITLE
[Feature] Add Expansion and Content Flag support to Blocked Spells

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -4958,6 +4958,17 @@ ALTER TABLE `items`
  MODIFY COLUMN `bardeffect`          MEDIUMINT(6)     NOT NULL DEFAULT 0;
 )"
 	},
+	ManifestEntry{
+		.version = 9238,
+		.description = "2023_10_18_tradeskill_add_learned_by_item_id.sql",
+		.check = "SHOW COLUMNS FROM `tradeskill_recipe` LIKE 'learned_by_item_id'",
+		.condition = "empty",
+		.match = "",
+		.sql = R"(
+ALTER TABLE `tradeskill_recipe`
+	ADD COLUMN `learned_by_item_id` int(11) NOT NULL DEFAULT 0 AFTER `must_learn`;
+)"
+	},
 
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{

--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -4969,6 +4969,20 @@ ALTER TABLE `tradeskill_recipe`
 	ADD COLUMN `learned_by_item_id` int(11) NOT NULL DEFAULT 0 AFTER `must_learn`;
 )"
 	},
+	ManifestEntry{
+		.version = 9239,
+		.description = "2023_10_18_blocked_spells_expansions_content_flags.sql",
+		.check = "SHOW COLUMNS FROM `blocked_spells` LIKE 'min_expansion'",
+		.condition = "",
+		.match = "empty",
+		.sql = R"(
+ALTER TABLE `blocked_spells`
+ADD COLUMN `min_expansion` tinyint(4) NOT NULL DEFAULT -1 AFTER `description`,
+ADD COLUMN `max_expansion` tinyint(4) NOT NULL DEFAULT -1 AFTER `min_expansion`,
+ADD COLUMN `content_flags` varchar(100) CHARACTER SET latin1 COLLATE latin1_swedish_ci NULL DEFAULT NULL AFTER `max_expansion`,
+ADD COLUMN `content_flags_disabled` varchar(100) CHARACTER SET latin1 COLLATE latin1_swedish_ci NULL DEFAULT NULL AFTER `content_flags`;
+)"
+	},
 
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9237
+#define CURRENT_BINARY_DATABASE_VERSION 9238
 
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9040
 

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9238
+#define CURRENT_BINARY_DATABASE_VERSION 9239
 
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9040
 

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -2197,12 +2197,21 @@ void Zone::LoadZoneBlockedSpells()
 		if (zone_total_blocked_spells > 0) {
 			blocked_spells = new ZoneSpellsBlocked[zone_total_blocked_spells];
 			if (!content_db.LoadBlockedSpells(zone_total_blocked_spells, blocked_spells, GetZoneID())) {
-				LogError(" Failed to load blocked spells");
+				LogError(
+					"Failed to load blocked spells for {} ({}).",
+					zone_store.GetZoneName(GetZoneID(), true),
+					GetZoneID()
+				);
 				ClearBlockedSpells();
 			}
 		}
 
-		LogInfo("Loaded [{}] blocked spells(s)", Strings::Commify(zone_total_blocked_spells));
+		LogInfo(
+			"Loaded [{}] blocked spells(s) for {} ({}).",
+			Strings::Commify(zone_total_blocked_spells),
+			zone_store.GetZoneName(GetZoneID(), true),
+			GetZoneID()
+		);
 	}
 }
 

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -619,8 +619,8 @@ public:
 	int GetDoorsDBCountPlusOne(std::string zone_short_name, int16 version);
 
 	/* Blocked Spells   */
-	int32	GetBlockedSpellsCount(uint32 zoneid);
-	bool	LoadBlockedSpells(int32 blockedSpellsCount, ZoneSpellsBlocked* into, uint32 zoneid);
+	int64 GetBlockedSpellsCount(uint32 zone_id);
+	bool LoadBlockedSpells(int64 blocked_spells_count, ZoneSpellsBlocked* into, uint32 zone_id);
 
 	/* Traps   */
 	bool	LoadTraps(const char* zonename, int16 version);


### PR DESCRIPTION
# Notes
- Allows operators to filter blocked spells behind expansions or content flags.
- Requested in https://github.com/EQEmu/Server/issues/3582