### PR TITLE
[Bug Fix] Fix crash when checking Bot Group/Raid membership

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -3336,7 +3336,7 @@ bool Bot::Spawn(Client* botCharacterOwner) {
 
 		if (auto raid = entity_list.GetRaidByBotName(GetName())) {
 			// Safety Check to confirm we have a valid raid
-			if (!raid->IsRaidMember(GetBotOwner()->GetName())) {
+			if (!raid->IsRaidMember(GetBotOwner()->GetCleanName())) {
 				Bot::RemoveBotFromRaid(this);
 			} else {
 				SetRaidGrouped(true);
@@ -3346,7 +3346,7 @@ bool Bot::Spawn(Client* botCharacterOwner) {
 		}
 		else if (auto group = entity_list.GetGroupByMobName(GetName())) {
 			// Safety Check to confirm we have a valid group
-			if (!group->IsGroupMember(GetBotOwner()->GetName())) {
+			if (!group->IsGroupMember(GetBotOwner()->GetCleanName())) {
 				Bot::RemoveBotFromGroup(this, group);
 			} else {
 				SetGrouped(true);

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -3336,7 +3336,8 @@ bool Bot::Spawn(Client* botCharacterOwner) {
 
 		if (auto raid = entity_list.GetRaidByBotName(GetName())) {
 			// Safety Check to confirm we have a valid raid
-			if (!raid->IsRaidMember(GetBotOwner()->GetCleanName())) {
+			auto owner = GetBotOwner();
+			if (owner && !raid->IsRaidMember(owner->GetCleanName())) {
 				Bot::RemoveBotFromRaid(this);
 			} else {
 				SetRaidGrouped(true);
@@ -3346,7 +3347,8 @@ bool Bot::Spawn(Client* botCharacterOwner) {
 		}
 		else if (auto group = entity_list.GetGroupByMobName(GetName())) {
 			// Safety Check to confirm we have a valid group
-			if (!group->IsGroupMember(GetBotOwner()->GetCleanName())) {
+			auto owner = GetBotOwner();
+			if (owner && !group->IsGroupMember(owner->GetCleanName())) {
 				Bot::RemoveBotFromGroup(this, group);
 			} else {
 				SetGrouped(true);


### PR DESCRIPTION
Change to use CleanName.

[crash_sleeper_version_2_inst_id_11115_port_7020_2611722.log](https://github.com/EQEmu/Server/files/13058476/crash_sleeper_version_2_inst_id_11115_port_7020_2611722.log)
