### PR TITLE
[Bug Fix] Fix issue with subcommand settings not working

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -437,13 +437,13 @@ int command_realdispatch(Client *c, std::string message, bool ignore_status)
 {
 	Seperator sep(message.c_str(), ' ', 10, 100, true); // "three word argument" should be considered 1 arg
 
-	std::string cstr(sep.arg[0] + 1);
+	std::string command(sep.arg[0] + 1);
 
-	if (commandlist.count(cstr) != 1) {
+	if (commandlist.count(command) != 1) {
 		return -2;
 	}
 
-	auto cur = commandlist[cstr];
+	const CommandRecord* current_command = commandlist[command];
 
 	bool is_subcommand            = false;
 	bool can_use_subcommand       = false;
@@ -451,11 +451,11 @@ int command_realdispatch(Client *c, std::string message, bool ignore_status)
 
 	const auto arguments = sep.argnum;
 
-	if (arguments >= 2) {
+	if (arguments) {
 		const std::string& sub_command = sep.arg[1];
 
 		for (const auto &e : command_subsettings) {
-			if (e.sub_command == sub_command) {
+			if (e.parent_command == command && e.sub_command == sub_command) {
 				can_use_subcommand       = c->Admin() >= static_cast<int16>(e.access_level);
 				is_subcommand            = true;
 				found_subcommand_setting = true;
@@ -465,7 +465,7 @@ int command_realdispatch(Client *c, std::string message, bool ignore_status)
 
 		if (!found_subcommand_setting) {
 			for (const auto &e: command_subsettings) {
-				if (e.sub_command == sub_command) {
+				if (e.parent_command == command && e.sub_command == sub_command) {
 					can_use_subcommand = c->Admin() >= static_cast<int16>(e.access_level);
 					is_subcommand      = true;
 					break;
@@ -474,8 +474,21 @@ int command_realdispatch(Client *c, std::string message, bool ignore_status)
 		}
 	}
 
+	c->Message(
+		Chat::White,
+		fmt::format(
+			"{} Argument{} | {} | Is{} Subcommand | Setting {}Found | {} Use Subcommand",
+			arguments,
+			arguments != 1 ? "s" : "",
+			current_command->description,
+			is_subcommand ? "" : " Not",
+			found_subcommand_setting ? "" : "Not ",
+			can_use_subcommand ? "Can" : "Cannot"
+		).c_str()
+	);
+
 	if (!ignore_status) {
-		if (!is_subcommand && c->Admin() < cur->admin) {
+		if (!is_subcommand && c->Admin() < current_command->admin) {
 			c->Message(Chat::White, "Your status is not high enough to use this command.");
 			return -1;
 		}
@@ -497,7 +510,7 @@ int command_realdispatch(Client *c, std::string message, bool ignore_status)
 		QServ->PlayerLogEvent(Player_Log_Issued_Commands, c->CharacterID(), event_desc);
 	}
 
-	if (cur->admin >= COMMANDS_LOGGING_MIN_STATUS) {
+	if (current_command->admin >= COMMANDS_LOGGING_MIN_STATUS) {
 		LogCommands(
 			"[{}] ([{}]) used command: [{}] (target=[{}])",
 			c->GetName(),
@@ -507,8 +520,8 @@ int command_realdispatch(Client *c, std::string message, bool ignore_status)
 		);
 	}
 
-	if (!cur->function) {
-		LogError("Command [{}] has a null function", cstr);
+	if (!current_command->function) {
+		LogError("Command [{}] has a null function", command);
 		return -1;
 	}
 
@@ -525,7 +538,7 @@ int command_realdispatch(Client *c, std::string message, bool ignore_status)
 		RecordPlayerEventLogWithClient(c, PlayerEvent::GM_COMMAND, e);
 	}
 
-	cur->function(c, &sep);	// Dispatch C++ Command
+	current_command->function(c, &sep);	// Dispatch C++ Command
 
 	return 0;
 }

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -474,19 +474,6 @@ int command_realdispatch(Client *c, std::string message, bool ignore_status)
 		}
 	}
 
-	c->Message(
-		Chat::White,
-		fmt::format(
-			"{} Argument{} | {} | Is{} Subcommand | Setting {}Found | {} Use Subcommand",
-			arguments,
-			arguments != 1 ? "s" : "",
-			current_command->description,
-			is_subcommand ? "" : " Not",
-			found_subcommand_setting ? "" : "Not ",
-			can_use_subcommand ? "Can" : "Cannot"
-		).c_str()
-	);
-
 	if (!ignore_status) {
 		if (!is_subcommand && c->Admin() < current_command->admin) {
 			c->Message(Chat::White, "Your status is not high enough to use this command.");


### PR DESCRIPTION
# Notes
- We were checking for `arguments >= 2` when we should just be checking for if there are any arguments and comparing `sep.arg[0]` (the command) and `sep.arg[1]` (the subcommand) to our `command_subsettings` to see if it exists and if we pass the requirements.
- This fix will let operators properly set a subcommand to a lower or higher status level than the parent command.