### PR TITLE
[Bug Fix] Hotfix command without hotfix name

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -665,7 +665,7 @@ void command_hotfix(Client *c, const Seperator *sep)
 				hotfix_command = fmt::format("\"{}\" -hotfix={}", shared_memory_path, hotfix_name);
 			}
 			else {
-				hotfix_command = fmt::format("\"{}\"", shared_memory_path, hotfix_name);
+				hotfix_command = fmt::format("\"{}\"", shared_memory_path);
 			}
 
 			LogInfo("Running hotfix command [{}]", hotfix_command);


### PR DESCRIPTION
If no hotfix name is provided, the hotfix command won't need the empty string.

Seen in http://spire.akkadius.com/dev/release/22.28.0?id=13585