### PR TITLE
[Bug Fix] Verifying mail keys when none exist

### DIFF
--- a/ucs/database.cpp
+++ b/ucs/database.cpp
@@ -156,6 +156,11 @@ bool UCSDatabase::VerifyMailKey(const std::string& characterName, int IPAddress,
 		return false;
 	}
 
+	if (results.RowCount() == 0) {
+		LogInfo("No mailkeys found for [{}].", characterName.c_str());
+		return false;
+	}
+	
 	auto row = results.begin();
 
 	// The key is the client's IP address (expressed as 8 hex digits) and an 8 hex digit random string generated


### PR DESCRIPTION
No need to verify mail key when none exist.

As seen in http://spire.akkadius.com/dev/release/22.28.0?id=12069