### PR TITLE
[Perl] Reload perl quests on zone bootup

### DIFF
--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -205,6 +205,11 @@ PerlembParser::~PerlembParser()
 	safe_delete(perl);
 }
 
+void PerlembParser::Init()
+{
+	ReloadQuests();
+}
+
 void PerlembParser::ReloadQuests()
 {
 	try {

--- a/zone/embparser.h
+++ b/zone/embparser.h
@@ -133,6 +133,7 @@ public:
 
 	virtual void AddVar(std::string name, std::string val);
 	virtual std::string GetVar(std::string name);
+	virtual void Init() override;
 	virtual void ReloadQuests();
 	virtual uint32 GetIdentifier() { return 0xf8b05c11; }
 


### PR DESCRIPTION
Perl wasn't implementing quest interface's Init which is called by Zone::Bootup. This should fix zone's that were in standby not using the latest version of perl plugin scripts.

This needs tested to make sure it doesn't break something. This doesn't touch lua but I'm not sure why https://github.com/EQEmu/Server/pull/3333/files would have broken encounters since lua parser already implements Init and calls ReloadQuests after zone init.