### PR TITLE
[Pets] Disallow effect of alliance line when cast on pets.

### DIFF
--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -710,7 +710,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				snprintf(effect_desc, _EDLEN, "Faction Mod: %+i", effect_value);
 #endif
 				// EverHood
-				if(caster && GetPrimaryFaction()>0) {
+				if(caster && !IsPet() && GetPrimaryFaction()>0) {
 					caster->AddFactionBonus(GetPrimaryFaction(),effect_value);
 				}
 				break;

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -706,11 +706,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 
 			case SE_AddFaction:
 			{
-#ifdef SPELL_EFFECT_SPAM
-				snprintf(effect_desc, _EDLEN, "Faction Mod: %+i", effect_value);
-#endif
-				// EverHood
-				if(caster && !IsPet() && GetPrimaryFaction()>0) {
+				if (caster && !IsPet() && GetPrimaryFaction() > 0) {
 					caster->AddFactionBonus(GetPrimaryFaction(),effect_value);
 				}
 				break;


### PR DESCRIPTION
This closes a small exploit wherein casting the alliance line of spells on a charmed pet impacted all NPCs of that pet's original faction within the zone.

Casting alliance on a charmed pet on live has no observable impact whatsoever.