### PR TITLE
[Trading] Fix part 3 of Issue 932.

### DIFF
--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -757,8 +757,22 @@ void Client::FinishTrade(Mob* tradingWith, bool finalizer, void* event_entry, st
 			}
 		}
 
-		// todo: rule or npc field to auto return normal items also
-		if (!quest_npc)
+		// Regardless of quest or non-quest NPC - No in combat trade completion
+		// is allowed.
+		if (tradingWith->CheckAggro(this))
+		{
+			for (EQ::ItemInstance* inst : items) {
+				if (!inst || !inst->GetItem()) {
+					continue;
+				}
+
+				tradingWith->SayString(TRADE_BACK, GetCleanName());
+				PushItemOnCursor(*inst, true);
+			}
+		}
+		// Only enforce trade rules if the NPC doesn't have an EVENT_TRADE
+		// subroutine.  That overrides all.
+		else if (!quest_npc)
 		{
 			for (EQ::ItemInstance* inst : items) {
 				if (!inst || !inst->GetItem()) {


### PR DESCRIPTION
This fixes part 3 of issue [932](https://github.com/EQEmu/Server/issues/932).

Part 2 is already fixed.

Part 1 is a feature to me.  So unless anyone cares that the mob turns toward you when you do a task turn in, I'd be all for closing issue 932.  If not, this PR stands on its own strength.

The previous [attempt ](https://github.com/EQEmu/Server/pull/3585)at fixing this did not work properly and the review was never replied to.