### PR TITLE
Return key in validate external login web api call

### DIFF
--- a/loginserver/account_management.h
+++ b/loginserver/account_management.h
@@ -2,6 +2,7 @@
 #define EQEMU_ACCOUNT_MANAGEMENT_H
 
 #include "iostream"
+#include <tuple>
 #include "../common/types.h"
 
 class AccountManagement {
@@ -65,7 +66,7 @@ public:
 	 * @param in_account_password
 	 * @return
 	 */
-	static uint32 CheckExternalLoginserverUserCredentials(
+	static std::tuple<uint32, std::string> CheckExternalLoginserverUserCredentials(
 		const std::string &in_account_username,
 		const std::string &in_account_password
 	);

--- a/loginserver/client.cpp
+++ b/loginserver/client.cpp
@@ -346,7 +346,7 @@ void Client::AttemptLoginAccountCreation(
 		}
 
 
-		uint32 account_id = AccountManagement::CheckExternalLoginserverUserCredentials(
+		auto [account_id, _] = AccountManagement::CheckExternalLoginserverUserCredentials(
 			user,
 			pass
 		);

--- a/loginserver/loginserver_command_handler.cpp
+++ b/loginserver/loginserver_command_handler.cpp
@@ -247,7 +247,7 @@ namespace LoginserverCommandHandler {
 
 		EQEmuCommand::ValidateCmdInput(arguments, options, cmd, argc, argv);
 
-		auto res = AccountManagement::CheckExternalLoginserverUserCredentials(
+		auto [res, _] = AccountManagement::CheckExternalLoginserverUserCredentials(
 			cmd(2).str(),
 			cmd(3).str()
 		);

--- a/loginserver/loginserver_webserver.cpp
+++ b/loginserver/loginserver_webserver.cpp
@@ -280,7 +280,7 @@ namespace LoginserverWebserver {
 					return;
 				}
 
-				uint32 account_id = AccountManagement::CheckExternalLoginserverUserCredentials(
+				auto [account_id, key] = AccountManagement::CheckExternalLoginserverUserCredentials(
 					username,
 					password
 				);
@@ -288,6 +288,7 @@ namespace LoginserverWebserver {
 				if (account_id > 0) {
 					response["message"]            = "Credentials valid!";
 					response["data"]["account_id"] = account_id;
+					response["data"]["key"] = key;
 				}
 				else {
 					response["error"] = "Credentials invalid!";


### PR DESCRIPTION
In order to make a handshake with a world server we would need to provide the lsid and key--the login web api can provide this to bypass the need to connect with (web)sockets from a client's perspective.