### PR TITLE
[Linux] Add symbols to release builds

### DIFF
--- a/utils/scripts/build/linux-build.sh
+++ b/utils/scripts/build/linux-build.sh
@@ -9,7 +9,17 @@ git submodule init && git submodule update
 
 perl utils/scripts/build/tag-version.pl
 
-mkdir -p build && cd build && cmake -DEQEMU_BUILD_TESTS=ON -DEQEMU_BUILD_STATIC=ON -DEQEMU_BUILD_LOGIN=ON -DEQEMU_BUILD_LUA=ON  -DEQEMU_BUILD_PERL=ON -DCMAKE_CXX_FLAGS_RELWITHDEBINFO:STRING="-Os" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -G 'Unix Makefiles' .. && make -j$((`nproc`-4))
+mkdir -p build && cd build && \
+  cmake -DEQEMU_BUILD_TESTS=ON \
+      -DEQEMU_BUILD_STATIC=ON \
+      -DEQEMU_BUILD_LOGIN=ON \
+      -DEQEMU_BUILD_LUA=ON \
+      -DEQEMU_BUILD_PERL=ON \
+      -DCMAKE_CXX_FLAGS:STRING="-O2 -g" \
+      -DCMAKE_CXX_FLAGS_RELWITHDEBINFO:STRING="-O2 -g" \
+      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+      -G 'Unix Makefiles' \
+      .. && make -j$((`nproc`-4))
 
 curl https://raw.githubusercontent.com/Akkadius/eqemu-install-v2/master/eqemu_config.json --output eqemu_config.json
 ./bin/tests

--- a/utils/scripts/build/linux-build.sh
+++ b/utils/scripts/build/linux-build.sh
@@ -15,8 +15,8 @@ mkdir -p build && cd build && \
       -DEQEMU_BUILD_LOGIN=ON \
       -DEQEMU_BUILD_LUA=ON \
       -DEQEMU_BUILD_PERL=ON \
-      -DCMAKE_CXX_FLAGS:STRING="-O2 -g" \
-      -DCMAKE_CXX_FLAGS_RELWITHDEBINFO:STRING="-O2 -g" \
+      -DCMAKE_CXX_FLAGS:STRING="-O1 -g" \
+      -DCMAKE_CXX_FLAGS_RELWITHDEBINFO:STRING="-O1 -g" \
       -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       -G 'Unix Makefiles' \
       .. && make -j$((`nproc`-4))


### PR DESCRIPTION
As seen in Linux release build, we are missing symbols http://spire.akkadius.com/dev/release/22.30.2?id=13725

We still want the binaries to be optimized as well