### PR TITLE
[Crash] Fix crash when client pointer does not exist during #hotfix

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -691,7 +691,7 @@ void command_hotfix(Client *c, const Seperator *sep)
 			}
 			worldserver.SendPacket(&pack);
 
-			if (c) { c->Message(Chat::White, "Hotfix applied"); }
+			worldserver.SendEmoteMessage(0, 0, AccountStatus::ApprenticeGuide, Chat::Yellow, "Hotfix applied");
 		}
 	);
 


### PR DESCRIPTION
As seen in http://spire.akkadius.com/dev/release/22.28.0?id=13588

Using the client pointer may not necessarily be thread safe, safer to just broadcast a GM message to the world