### PR TITLE
[Logs] Convert Loot Messages to Error Logs

### DIFF
--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -811,7 +811,7 @@ void Client::ZonePC(uint32 zoneID, uint32 instance_id, float x, float y, float z
 			Entity* entity = entity_list.GetID(entity_id_being_looted);
 			if (entity == 0)
 			{
-				Message(Chat::Red, "Error: OP_EndLootRequest: Corpse not found (ent = 0)");
+				LogError("OP_EndLootRequest: Corpse with id of {} not found for {}.", entity_id_being_looted, GetCleanName());
 				if (ClientVersion() >= EQ::versions::ClientVersion::SoD)
 					Corpse::SendEndLootErrorPacket(this);
 				else
@@ -819,7 +819,7 @@ void Client::ZonePC(uint32 zoneID, uint32 instance_id, float x, float y, float z
 			}
 			else if (!entity->IsCorpse())
 			{
-				Message(Chat::Red, "Error: OP_EndLootRequest: Corpse not found (!entity->IsCorpse())");
+				LogError("OP_EndLootRequest: Entity with id of {} was not corpse for {}.", entity_id_being_looted, GetCleanName());
 				Corpse::SendLootReqErrorPacket(this);
 			}
 			else


### PR DESCRIPTION
# Notes
- These messages were sending to users and not being logged.
- `Message(Chat::Red, "Error: OP_EndLootRequest: Corpse not found (ent = 0)");` sends often when corpse expires right as you try to loot, so it makes the user think there's a true error.