### PR TITLE
[Feature] Add Comment to Item Data/Quest API

### DIFF
--- a/common/item_data.h
+++ b/common/item_data.h
@@ -356,6 +356,7 @@ namespace EQ
 	struct ItemData {
 		// Non packet based fields
 		uint8	MinStatus {};
+		char	Comment[255] {};
 
 		// Packet based fields
 		uint8	ItemClass {};		// Item Type: 0=common, 1=container, 2=book

--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -51,7 +51,9 @@ namespace ItemField
 #define F(x) x,
 #include "item_fieldlist.h"
 #undef F
-		updated
+		updated,
+		minstatus,
+		comment,
 	};
 }
 
@@ -965,7 +967,7 @@ void SharedDatabase::LoadItems(void *data, uint32 size, int32 items, uint32 max_
 #define F(x) "`"#x"`,"
 #include "item_fieldlist.h"
 #undef F
-		"updated FROM items ORDER BY id";
+		"updated, minstatus, comment FROM items ORDER BY id";
 	auto results = QueryDatabase(query);
 	if (!results.Success()) {
 		return;
@@ -977,9 +979,13 @@ void SharedDatabase::LoadItems(void *data, uint32 size, int32 items, uint32 max_
 		// Unique Identifier
 		item.ID = Strings::ToUnsignedInt(row[ItemField::id]);
 
-		// Name and Lore
+		// Minimum Status
+		item.MinStatus = static_cast<uint8>(Strings::ToUnsignedInt(row[ItemField::minstatus]));
+
+		// Name, Lore, and Comment
 		strn0cpy(item.Name, row[ItemField::name], sizeof(item.Name));
 		strn0cpy(item.Lore, row[ItemField::lore], sizeof(item.Lore));
+		strn0cpy(item.Comment, row[ItemField::comment], sizeof(item.Comment));
 
 		// Flags
 		item.ArtifactFlag = Strings::ToBool(row[ItemField::artifactflag]);

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -5870,8 +5870,8 @@ void perl_register_quest()
 	package.add("GetZoneFogRed", (uint8(*)(uint32))&Perl__GetZoneFogRed);
 	package.add("GetZoneFogRed", (uint8(*)(uint32, uint8))&Perl__GetZoneFogRed);
 	package.add("GetZoneFogRed", (uint8(*)(uint32, uint8, int))&Perl__GetZoneFogRed);
-	package.add("GetZoneGravity", (float(*)(uint32))&Perl__GetZoneGravity);
-	package.add("GetZoneGravity", (float(*)(uint32, int))&Perl__GetZoneGravity);
+	package.add("GetZoneGravity", (float(*)(uint32))&Perl__GetZoneMaximumClip);
+	package.add("GetZoneGravity", (float(*)(uint32, int))&Perl__GetZoneMaximumClip);
 	package.add("GetZoneMaximumClip", (float(*)(uint32))&Perl__GetZoneMaximumClip);
 	package.add("GetZoneMaximumClip", (float(*)(uint32, int))&Perl__GetZoneMaximumClip);
 	package.add("GetZoneMaximumExpansion", (int8(*)(uint32))&Perl__GetZoneMaximumExpansion);

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -1433,6 +1433,16 @@ void Perl__removeitem(uint32_t item_id, int quantity)
 	quest_manager.removeitem(item_id, quantity);
 }
 
+std::string Perl__getitemcomment(uint32 item_id)
+{
+	return quest_manager.getitemcomment(item_id);
+}
+
+std::string Perl__getitemlore(uint32 item_id)
+{
+	return quest_manager.getitemlore(item_id);
+}
+
 std::string Perl__getitemname(uint32 item_id)
 {
 	return quest_manager.getitemname(item_id);
@@ -5860,8 +5870,8 @@ void perl_register_quest()
 	package.add("GetZoneFogRed", (uint8(*)(uint32))&Perl__GetZoneFogRed);
 	package.add("GetZoneFogRed", (uint8(*)(uint32, uint8))&Perl__GetZoneFogRed);
 	package.add("GetZoneFogRed", (uint8(*)(uint32, uint8, int))&Perl__GetZoneFogRed);
-	package.add("GetZoneGravity", (float(*)(uint32))&Perl__GetZoneMaximumClip);
-	package.add("GetZoneGravity", (float(*)(uint32, int))&Perl__GetZoneMaximumClip);
+	package.add("GetZoneGravity", (float(*)(uint32))&Perl__GetZoneGravity);
+	package.add("GetZoneGravity", (float(*)(uint32, int))&Perl__GetZoneGravity);
 	package.add("GetZoneMaximumClip", (float(*)(uint32))&Perl__GetZoneMaximumClip);
 	package.add("GetZoneMaximumClip", (float(*)(uint32, int))&Perl__GetZoneMaximumClip);
 	package.add("GetZoneMaximumExpansion", (int8(*)(uint32))&Perl__GetZoneMaximumExpansion);
@@ -6404,6 +6414,8 @@ void perl_register_quest()
 	package.add("get_expedition_lockouts_by_char_id", (perl::reference(*)(uint32, std::string))&Perl__get_expedition_lockouts_by_char_id);
 	package.add("getfactionname", &Perl__getfactionname);
 	package.add("getinventoryslotid", &Perl__getinventoryslotid);
+	package.add("getitemcomment", &Perl__getitemcomment);
+	package.add("getitemlore", &Perl__getitemlore);
 	package.add("getitemname", &Perl__getitemname);
 	package.add("getitemstat", &Perl__getitemstat);
 	package.add("getlanguagename", &Perl__getlanguagename);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -349,7 +349,6 @@ void lua_stop_all_timers(Lua_Encounter enc) {
 
 void lua_pause_timer(const char *timer) {
 	quest_manager.pausetimer(timer);
-
 }
 
 void lua_resume_timer(const char *timer) {
@@ -877,6 +876,14 @@ void lua_merchant_set_item(uint32 npc_id, uint32 item_id, uint32 quantity) {
 
 int lua_merchant_count_item(uint32 npc_id, uint32 item_id) {
 	return quest_manager.MerchantCountItem(npc_id, item_id);
+}
+
+std::string lua_get_item_comment(uint32 item_id) {
+	return quest_manager.getitemcomment(item_id);
+}
+
+std::string lua_get_item_lore(uint32 item_id) {
+	return quest_manager.getitemlore(item_id);
 }
 
 std::string lua_get_item_name(uint32 item_id) {
@@ -5720,6 +5727,8 @@ luabind::scope lua_register_general() {
 		luabind::def("item_link", (std::string(*)(uint32,int16,uint32,uint32,uint32,uint32,uint32))&lua_item_link),
 		luabind::def("item_link", (std::string(*)(uint32,int16,uint32,uint32,uint32,uint32,uint32,uint32))&lua_item_link),
 		luabind::def("item_link", (std::string(*)(uint32,int16,uint32,uint32,uint32,uint32,uint32,uint32,bool))&lua_item_link),
+		luabind::def("get_item_comment", (std::string(*)(uint32))&lua_get_item_comment),
+		luabind::def("get_item_lore", (std::string(*)(uint32))&lua_get_item_lore),
 		luabind::def("get_item_name", (std::string(*)(uint32))&lua_get_item_name),
 		luabind::def("say_link", (std::string(*)(const char*,bool,const char*))&lua_say_link),
 		luabind::def("say_link", (std::string(*)(const char*,bool))&lua_say_link),

--- a/zone/lua_item.cpp
+++ b/zone/lua_item.cpp
@@ -30,6 +30,11 @@ const char *Lua_Item::GetLore() {
 	return self->Lore;
 }
 
+const char *Lua_Item::GetComment() {
+	Lua_Safe_Call_String();
+	return self->Comment;
+}
+
 const char *Lua_Item::GetIDFile() {
 	Lua_Safe_Call_String();
 	return self->IDFile;
@@ -957,6 +962,7 @@ luabind::scope lua_register_item() {
 	.def("Click_Type", &Lua_Item::GetClick_Type)
 	.def("Color", &Lua_Item::GetColor)
 	.def("CombatEffects", &Lua_Item::GetCombatEffects)
+	.def("Comment", &Lua_Item::GetComment)
 	.def("DR", &Lua_Item::GetDR)
 	.def("DSMitigation", &Lua_Item::GetDSMitigation)
 	.def("Damage", &Lua_Item::GetDamage)

--- a/zone/lua_item.h
+++ b/zone/lua_item.h
@@ -32,6 +32,7 @@ public:
 	int GetItemClass();
 	const char *GetName();
 	const char *GetLore();
+	const char *GetComment();
 	const char *GetIDFile();
 	uint32 GetID();
 	int GetWeight();

--- a/zone/perl_questitem_data.cpp
+++ b/zone/perl_questitem_data.cpp
@@ -26,6 +26,11 @@ const char* Perl_QuestItemData_GetLore(EQ::ItemData* self)
 	return self->Lore;
 }
 
+const char* Perl_QuestItem_GetComment(EQ::ItemData* self)
+{
+	return self->Comment;
+}
+
 const char* Perl_QuestItemData_GetIDFile(EQ::ItemData* self)
 {
 	return self->IDFile;
@@ -949,6 +954,7 @@ void perl_register_questitem_data()
 	package.add("GetClickType", &Perl_QuestItemData_GetClickType);
 	package.add("GetColor", &Perl_QuestItemData_GetColor);
 	package.add("GetCombatEffects", &Perl_QuestItemData_GetCombatEffects);
+	package.add("GetComment", &Perl_QuestItem_GetComment);
 	package.add("GetCorruption", &Perl_QuestItemData_GetCorruption);
 	package.add("GetDR", &Perl_QuestItemData_GetDR);
 	package.add("GetDSMitigation", &Perl_QuestItemData_GetDSMitigation);

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -3195,8 +3195,29 @@ std::string QuestManager::varlink(
 
 	return linker.GenerateLink();
 }
+
+std::string QuestManager::getitemcomment(uint32 item_id) {
+	const auto* item_data = database.GetItem(item_id);
+	if (!item_data) {
+		return "INVALID ITEM ID IN GETITEMCOMMENT";
+	}
+
+	std::string item_comment = item_data->Comment;
+	return item_comment;
+}
+
+std::string QuestManager::getitemlore(uint32 item_id) {
+	const auto* item_data = database.GetItem(item_id);
+	if (!item_data) {
+		return "INVALID ITEM ID IN GETITEMLORE";
+	}
+
+	std::string item_lore = item_data->Lore;
+	return item_lore;
+}
+
 std::string QuestManager::getitemname(uint32 item_id) {
-	const EQ::ItemData* item_data = database.GetItem(item_id);
+	const auto* item_data = database.GetItem(item_id);
 	if (!item_data) {
 		return "INVALID ITEM ID IN GETITEMNAME";
 	}

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -250,6 +250,8 @@ public:
 	int collectitems_processSlot(int16 slot_id, uint32 item_id, bool remove);
 	int countitem(uint32 item_id);
 	void removeitem(uint32 item_id, uint32 quantity = 1);
+	std::string getitemcomment(uint32 item_id);
+	std::string getitemlore(uint32 item_id);
 	std::string getitemname(uint32 item_id);
 	void enabletitle(int titleset);
 	bool checktitle(int titlecheck);


### PR DESCRIPTION
# Perl
- Add `quest::getitemcomment(item_id)`.
- Add `quest::getitemlore(item_id)`.
- Add `$questitemdata->GetComment()`.

# Lua
- Add `eq.get_item_comment(item_id)`.
- Add `eq.get_item_lore(item_id)`.
- Add `item:Comment()`.

# Notes
- Added the ability for operators to pull these fields from item data without a database hit.
- Fixed a bug in `embparser_api.cpp` where `GetZoneGravity` was connected to the wrong methods.