### PR TITLE
[Parser] Cleanup Spire Parsing for crosszonemoveplayerbyguildid

### DIFF
--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -3634,14 +3634,7 @@ void Perl__crosszonemoveplayerbyguildid(uint32 guild_id, std::string zone_short_
 	);
 }
 
-void Perl__crosszonemoveplayerbyguildid(
-	uint32 guild_id,
-	std::string zone_short_name,
-	float x,
-	float y,
-	float z,
-	float heading
-)
+void Perl__crosszonemoveplayerbyguildid(uint32 guild_id, std::string zone_short_name, float x, float y, float z, float heading)
 {
 	quest_manager.CrossZoneMove(
 		CZMove_Struct{


### PR DESCRIPTION
# Notes
- This formatting was causing Spire not to pick up the parameters.