### PR TITLE
[CRASH] Fix crash on CentOS when forming a raid with PCs or BOTs

### DIFF
--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -40,7 +40,6 @@ extern WorldServer worldserver;
 Raid::Raid(uint32 raidID)
 : GroupIDConsumer(raidID)
 {
-	memset(members ,0, (sizeof(RaidMember)*MAX_RAID_MEMBERS));
 	memset(&raid_aa, 0, sizeof(RaidLeadershipAA_Struct));
 	memset(group_aa, 0, sizeof(GroupLeadershipAA_Struct) * MAX_RAID_GROUPS);
 	for (auto& gm : group_mentor) {
@@ -66,7 +65,6 @@ Raid::Raid(uint32 raidID)
 Raid::Raid(Client* nLeader)
 : GroupIDConsumer()
 {
-	memset(members ,0, (sizeof(RaidMember)*MAX_RAID_MEMBERS));
 	memset(&raid_aa, 0, sizeof(RaidLeadershipAA_Struct));
 	memset(group_aa, 0, sizeof(GroupLeadershipAA_Struct) * MAX_RAID_GROUPS);
 	for (auto& gm : group_mentor) {
@@ -1705,7 +1703,7 @@ void Raid::SaveRaidMOTD()
 
 bool Raid::LearnMembers()
 {
-	memset(members, 0, (sizeof(RaidMember) * MAX_RAID_MEMBERS));
+	EmptyRaidMembers();
 
 	auto raid_members = RaidMembersRepository::GetWhere(
 			database,
@@ -2974,4 +2972,23 @@ void Raid::SendMarkTargets(Client* c)
 		}
 	}
 	UpdateXtargetMarkedNPC();
+}
+
+void Raid::EmptyRaidMembers() 
+{
+	for (int i = 0; i < MAX_RAID_MEMBERS; i++) {
+		members[i].group_number    = RAID_GROUPLESS;
+		members[i].is_group_leader = 0;
+		members[i].level           = 0;
+		members[i].main_assister   = 0;
+		members[i].main_marker     = 0;
+		members[i]._class          = 0;
+		members[i].is_bot          = false;
+		members[i].is_looter       = false;
+		members[i].is_raid_leader  = false;
+		members[i].is_raid_main_assist_one = false;
+		members[i].member          = nullptr;
+		members[i].note            = '\0';
+		members[i].member_name[0]  = '\0';
+	}
 }

--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -2988,7 +2988,7 @@ void Raid::EmptyRaidMembers()
 		members[i].is_raid_leader  = false;
 		members[i].is_raid_main_assist_one = false;
 		members[i].member          = nullptr;
-		members[i].note            = '\0';
+		members[i].note.clear();
 		members[i].member_name[0]  = '\0';
 	}
 }

--- a/zone/raids.h
+++ b/zone/raids.h
@@ -75,19 +75,19 @@ const uint32 RAID_GROUPLESS = 0xFFFFFFFF;
 #define MAX_NO_RAID_MAIN_MARKERS 3
 
 struct RaidMember{
-	char member_name[64];
-	Client *member;
-	uint32 group_number;
-	uint8 _class;
-	uint8 level;
-	std::string note;
-	bool is_group_leader;
-	bool is_raid_leader;
-	bool is_looter;
-	uint8 main_marker;
-	uint8 main_assister;
-	bool is_bot = false;
-	bool is_raid_main_assist_one = false;
+	char member_name[64]{ 0 };
+	Client* member{ nullptr };
+	uint32 group_number{ RAID_GROUPLESS };
+	uint8 _class{ 0 };
+	uint8 level{ 0 };
+	std::string note{};
+	bool is_group_leader{ false };
+	bool is_raid_leader{ false };
+	bool is_looter{ false };
+	uint8 main_marker{ 0 };
+	uint8 main_assister{ 0 };
+	bool is_bot{ false };
+	bool is_raid_main_assist_one{false};
 };
 
 struct GroupMentor {
@@ -131,6 +131,7 @@ public:
 	void	SetNewRaidLeader(uint32 i);
 	bool    IsAssister(const char* who);
 	bool    IsMarker(const char* who);
+	void    EmptyRaidMembers();
 
 	uint32	GetFreeGroup();
 	uint8	GroupCount(uint32 gid);


### PR DESCRIPTION
A crash condition was being seen in CentOS after the conversion of raid notes from char[] to std::string.  It was not seen in other linux distros or on windows though it appears that it would have eventually been seen.

Issue was duplicated on a new CentOS 7 install and was traced to the memset usage in the raid constructors and LearnMembers as it was overwriting the std::string structure.  

Added default initializers to RaidMember struct as well.

Tested with the CentOS install and on a windows install by forming a raid with a Bot, moving/rearranging groups, attacking and zoning.  Would appreciate others testing as an added layer.  OP of crash is testing in the next few days.

Thanks,
Neckkola