### PR TITLE
[GCC] Compatibility fix for GCC 13

### DIFF
--- a/common/serverinfo.h
+++ b/common/serverinfo.h
@@ -19,6 +19,7 @@
 
 #include <string>
 #include <vector>
+#include <stdint.h>
 
 typedef struct eq_cpu_info_s {
 	std::string model;


### PR DESCRIPTION
Fixes ` ‘uint64_t’ does not name a type ` error under GCC 13