### PR TITLE
[Bots] Fix invalid races from being created

### DIFF
--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -8884,7 +8884,7 @@ uint32 helper_bot_create(Client *bot_owner, std::string bot_name, uint8 bot_clas
 		return bot_id;
 	}
 
-	if (!Bot::IsValidRaceClassCombo(bot_race, bot_class) && IsPlayerRace(bot_race)) {
+	if (!Bot::IsValidRaceClassCombo(bot_race, bot_class)) {
 		const std::string bot_race_name = GetRaceIDName(bot_race);
 		const std::string bot_class_name = GetClassIDName(bot_class);
 		const auto view_saylink = Saylink::Silent(


### PR DESCRIPTION
Previously this check allowed bots of invalid races to be created. If a race was neither a valid combination or a valid player race, it would pass the check and allow bots of any race to be created.

**^create 1 123 0** could create a Male Innoruuk Warrior

_I can modify this if needed to allow the IsPlayerRace check to remain, although I feel if players modify their creation table to allow non-player races, they should be allowed to create them even if it causes items to not be usable_