### PR TITLE
[Illusions] RandomizeFeatures erased texture.

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -3586,10 +3586,17 @@ void Mob::SendIllusionPacket(const AppearanceStruct& a)
 	gender           = new_gender;
 	hairstyle        = new_hair;
 	haircolor        = new_hair_color;
-	helmtexture      = new_helmet_texture;
 	race             = new_race;
 	size             = new_size;
-	texture          = new_texture;
+
+	// These two should not be modified in base data - it kills db texture
+	// when illusion is only for RandomizeFeatures...
+	if (new_helmet_texture != UINT8_MAX) {
+		helmtexture      = new_helmet_texture;
+	}
+	if (new_texture != UINT8_MAX) {
+		texture          = new_texture;
+	}
 
 	auto outapp = new EQApplicationPacket(OP_Illusion, sizeof(Illusion_Struct));
 	auto is     = (Illusion_Struct *) outapp->pBuffer;


### PR DESCRIPTION
This PR re-fixes the issue I fixed in this [PR](https://github.com/EQEmu/Server/pull/3376).

It was rebroken as a result of many fixes put in via this [PR](https://github.com/EQEmu/Server/pull/3520).

The problem is that when using RandomizeFeatures (which does not alter texure), textture gets set back to 0xFF.

I reapplied my fix to the new code and it once again works properly.

To see bug: spawn an npc wth a custom texture (like 12).
Use RandomizeFeatures.
Texture is lost.

This fixes it by not saving the texture if it was not supplied as a value other that 0xFF.