### PR TITLE
[Spawn2] Fix edge case with instances not copying disabled spawn state

### DIFF
--- a/common/database_instances.cpp
+++ b/common/database_instances.cpp
@@ -30,7 +30,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include "../common/repositories/respawn_times_repository.h"
 #include "../common/repositories/spawn_condition_values_repository.h"
 #include "repositories/spawn2_disabled_repository.h"
-
+#include "zone_store.h"
 
 #include "database.h"
 
@@ -46,7 +46,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #else
 #include "unix.h"
 #include "../zone/zonedb.h"
-#include "zone_store.h"
 #include <netinet/in.h>
 #include <sys/time.h>
 #endif


### PR DESCRIPTION
This fixes an issue where disabled spawns are not being inherited from the base of the zone that is being cloned (instanced). 

I'm not in love with copying data for this but it seems like the cleanest way to approach this problem currently.

Expeditions unfortunately create their own instance so there's a copy of this code in two places but this will resolve the issue for now and is a bit more of a pressing issue to get a hotfix out for.

See thread: http://www.projecteq.net/forums/index.php?threads/anguish-spawns-bugged.17734/

Validated fixed in an Anguish expedition

On creation

```sql
  Zone |   Query    | QueryDatabase SELECT id, spawn2_id, instance_id, disabled FROM spawn2_disabled WHERE spawn2_id IN (select id from spawn2 where LOWER(zone) = 'anguish' and version = 0) and instance_id = 0 -- (32 rows returned) (0.000765s)-- [wallofslaughter] (Wall of Slaughter) inst_id [0]
  Zone |   Query    | QueryDatabase INSERT INTO spawn2_disabled (id, spawn2_id, instance_id, disabled)  VALUES (0,54521,31,1),(0,54522,31,1),(0,54523,31,1),(0,54524,31,1),(0,54525,31,1),(0,54660,31,1),(0,54661,31,1),(0,54662,31,1),(0,54663,31,1),(0,54664,31,1),(0,54669,31,1),(0,54722,31,1),(0,54723,31,1),(0,54724,31,1),(0,54725,31,1),(0,54726,31,1),(0,54727,31,1),(0,54728,31,1),(0,54784,31,1),(0,54788,31,1),(0,54790,31,1),(0,54791,31,1),(0,54792,31,1),(0,54797,31,1),(0,54798,31,1),(0,54809,31,1),(0,54818,31,1),(0,54819,31,1),(0,54826,31,1),(0,54844,31,1),(0,54862,31,1),(0,54863,31,1) -- (32 rows affected) (0.004219s)-- [wallofslaughter] (Wall of Slaughter) inst_id [0]
```

You can a little later in the logs see the zone properly targeting the state data for the newly created instance

```sql
  Zone |   Query    | QueryDatabase SELECT id, spawn2_id, instance_id, disabled FROM spawn2_disabled WHERE spawn2_id = 54535 and instance_id = 31 -- (1 row returned) (0.000276s)-- [anguish] (Anguish, the Fallen Palace) inst_id [31]
  Zone |   Query    | QueryDatabase UPDATE spawn2_disabled SET spawn2_id = 54535, instance_id = 31, disabled = 0 WHERE id = 1025 -- (1 row affected) (0.000266s)-- [anguish] (Anguish, the Fallen Palace) inst_id [31]
  Zone |   Query    | QueryDatabase SELECT id, spawn2_id, instance_id, disabled FROM spawn2_disabled WHERE spawn2_id = 54536 and instance_id = 31 -- (1 row returned) (0.000058s)-- [anguish] (Anguish, the Fallen Palace) inst_id [31]
  Zone |   Query    | QueryDatabase UPDATE spawn2_disabled SET spawn2_id = 54536, instance_id = 31, disabled = 0 WHERE id = 1026 -- (1 row affected) (0.000026s)-- [anguish] (Anguish, the Fallen Palace) inst_id [31]
  Zone |   Query    | QueryDatabase SELECT id, spawn2_id, instance_id, disabled FROM spawn2_disabled WHERE spawn2_id = 54537 and instance_id = 31 -- (1 row returned) (0.000031s)-- [anguish] (Anguish, the Fallen Palace) inst_id [31]
  Zone |   Query    | QueryDatabase UPDATE spawn2_disabled SET spawn2_id = 54537, instance_id = 31, disabled = 0 WHERE id = 1027 -- (1 row affected) (0.000020s)-- [anguish] (Anguish, the Fallen Palace) inst_id [31]
  Zone |   Query    | QueryDatabase SELECT id, spawn2_id, instance_id, disabled FROM spawn2_disabled WHERE spawn2_id = 54538 and instance_id = 31 -- (1 row returned) (0.000031s)-- [anguish] (Anguish, the Fallen Palace) inst_id [31]
  Zone |   Query    | QueryDatabase UPDATE spawn2_disabled SET spawn2_id = 54538, instance_id = 31, disabled = 0 WHERE id = 1028 -- (1 row affected) (0.000018s)-- [anguish] (Anguish, the Fallen Palace) inst_id [31]
  Zone |   Query    | QueryDatabase SELECT id, spawn2_id, instance_id, disabled FROM spawn2_disabled WHERE spawn2_id = 54539 and instance_id = 31 -- (1 row returned) (0.000027s)-- [anguish] (Anguish, the Fallen Palace) inst_id [31]
  Zone |   Query    | QueryDatabase UPDATE spawn2_disabled SET spawn2_id = 54539, instance_id = 31, disabled = 0 WHERE id = 1029 -- (1 row affected) (0.000024s)-- [anguish] (Anguish, the Fallen Palace) inst_id [31]
```