### PR TITLE
[Cleanup] Cleanup #show currencies Command

### DIFF
--- a/common/eq_constants.h
+++ b/common/eq_constants.h
@@ -1059,4 +1059,20 @@ enum SpellTimeRestrictions
 	Night
 };
 
+enum MoneyTypes
+{
+	Copper,
+	Silver,
+	Gold,
+	Platinum
+};
+
+enum MoneySubtypes
+{
+	Personal,
+	Bank,
+	Cursor,
+	SharedBank // Platinum Only
+};
+
 #endif /*COMMON_EQ_CONSTANTS_H*/

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -2262,10 +2262,10 @@ void Client::QuestReadBook(const char* text, uint8 type) {
 
 uint32 Client::GetCarriedPlatinum() {
 	return (
-		GetMoney(3, 0) +
-		(GetMoney(2, 0) / 10) +
-		(GetMoney(1, 0) / 100) +
-		(GetMoney(0, 0) / 1000)
+		GetMoney(MoneyTypes::Platinum, MoneySubtypes::Personal) +
+		(GetMoney(MoneyTypes::Gold, MoneySubtypes::Personal) / 10) +
+		(GetMoney(MoneyTypes::Silver, MoneySubtypes::Personal) / 100) +
+		(GetMoney(MoneyTypes::Copper, MoneySubtypes::Personal) / 1000)
 	);
 }
 
@@ -8119,16 +8119,17 @@ void Client::SendHPUpdateMarquee(){
 
 uint32 Client::GetMoney(uint8 type, uint8 subtype) {
 	uint32 value = 0;
+
 	switch (type) {
-		case 0: {
+		case MoneyTypes::Copper: {
 			switch (subtype) {
-				case 0:
+				case MoneySubtypes::Personal:
 					value = static_cast<uint32>(m_pp.copper);
 					break;
-				case 1:
+				case MoneySubtypes::Bank:
 					value = static_cast<uint32>(m_pp.copper_bank);
 					break;
-				case 2:
+				case MoneySubtypes::Cursor:
 					value = static_cast<uint32>(m_pp.copper_cursor);
 					break;
 				default:
@@ -8136,15 +8137,15 @@ uint32 Client::GetMoney(uint8 type, uint8 subtype) {
 			}
 			break;
 		}
-		case 1: {
+		case MoneyTypes::Silver: {
 			switch (subtype) {
-				case 0:
+				case MoneySubtypes::Personal:
 					value = static_cast<uint32>(m_pp.silver);
 					break;
-				case 1:
+				case MoneySubtypes::Bank:
 					value = static_cast<uint32>(m_pp.silver_bank);
 					break;
-				case 2:
+				case MoneySubtypes::Cursor:
 					value = static_cast<uint32>(m_pp.silver_cursor);
 					break;
 				default:
@@ -8152,15 +8153,15 @@ uint32 Client::GetMoney(uint8 type, uint8 subtype) {
 			}
 			break;
 		}
-		case 2: {
+		case MoneyTypes::Gold: {
 			switch (subtype) {
-				case 0:
+				case MoneySubtypes::Personal:
 					value = static_cast<uint32>(m_pp.gold);
 					break;
-				case 1:
+				case MoneySubtypes::Bank:
 					value = static_cast<uint32>(m_pp.gold_bank);
 					break;
-				case 2:
+				case MoneySubtypes::Cursor:
 					value = static_cast<uint32>(m_pp.gold_cursor);
 					break;
 				default:
@@ -8168,18 +8169,18 @@ uint32 Client::GetMoney(uint8 type, uint8 subtype) {
 			}
 			break;
 		}
-		case 3: {
+		case MoneyTypes::Platinum: {
 			switch (subtype) {
-				case 0:
+				case MoneySubtypes::Personal:
 					value = static_cast<uint32>(m_pp.platinum);
 					break;
-				case 1:
+				case MoneySubtypes::Bank:
 					value = static_cast<uint32>(m_pp.platinum_bank);
 					break;
-				case 2:
+				case MoneySubtypes::Cursor:
 					value = static_cast<uint32>(m_pp.platinum_cursor);
 					break;
-				case 3:
+				case MoneySubtypes::SharedBank:
 					value = static_cast<uint32>(m_pp.platinum_shared);
 					break;
 				default:
@@ -8190,6 +8191,7 @@ uint32 Client::GetMoney(uint8 type, uint8 subtype) {
 		default:
 			break;
 	}
+
 	return value;
 }
 

--- a/zone/gm_commands/show/currencies.cpp
+++ b/zone/gm_commands/show/currencies.cpp
@@ -3,7 +3,7 @@
 
 void ShowCurrencies(Client *c, const Seperator *sep)
 {
-	Client* t = c;
+	Client *t = c;
 	if (c->GetTarget() && c->GetTarget()->IsClient()) {
 		t = c->GetTarget()->CastToClient();
 	}

--- a/zone/gm_commands/show/currencies.cpp
+++ b/zone/gm_commands/show/currencies.cpp
@@ -3,34 +3,34 @@
 
 void ShowCurrencies(Client *c, const Seperator *sep)
 {
-	auto t = c;
+	Client* t = c;
 	if (c->GetTarget() && c->GetTarget()->IsClient()) {
 		t = c->GetTarget()->CastToClient();
 	}
 
-	const uint32 platinum = (
-		t->GetMoney(3, 0) +
-		t->GetMoney(3, 1) +
-		t->GetMoney(3, 2) +
-		t->GetMoney(3, 3)
+	const uint64 platinum = (
+		t->GetMoney(MoneyTypes::Platinum, MoneySubtypes::Personal) +
+		t->GetMoney(MoneyTypes::Platinum, MoneySubtypes::Bank) +
+		t->GetMoney(MoneyTypes::Platinum, MoneySubtypes::Cursor) +
+		t->GetMoney(MoneyTypes::Platinum, MoneySubtypes::SharedBank)
 	);
 
-	const uint32 gold = (
-		t->GetMoney(2, 0) +
-		t->GetMoney(2, 1) +
-		t->GetMoney(2, 2)
+	const uint64 gold = (
+		t->GetMoney(MoneyTypes::Gold, MoneySubtypes::Personal) +
+		t->GetMoney(MoneyTypes::Gold, MoneySubtypes::Bank) +
+		t->GetMoney(MoneyTypes::Gold, MoneySubtypes::Cursor)
 	);
 
-	const uint32 silver = (
-		t->GetMoney(1, 0) +
-		t->GetMoney(1, 1) +
-		t->GetMoney(1, 2)
+	const uint64 silver = (
+		t->GetMoney(MoneyTypes::Silver, MoneySubtypes::Personal) +
+		t->GetMoney(MoneyTypes::Silver, MoneySubtypes::Bank) +
+		t->GetMoney(MoneyTypes::Silver, MoneySubtypes::Cursor)
 	);
 
-	const uint32 copper = (
-		t->GetMoney(0, 0) +
-		t->GetMoney(0, 1) +
-		t->GetMoney(0, 2)
+	const uint64 copper = (
+		t->GetMoney(MoneyTypes::Copper, MoneySubtypes::Personal) +
+		t->GetMoney(MoneyTypes::Copper, MoneySubtypes::Bank) +
+		t->GetMoney(MoneyTypes::Copper, MoneySubtypes::Cursor)
 	);
 
 	std::string currency_table;
@@ -51,6 +51,16 @@ void ShowCurrencies(Client *c, const Seperator *sep)
 		currency_table += DialogueWindow::TableRow(
 			DialogueWindow::TableCell("Money") +
 			DialogueWindow::TableCell(Strings::Money(platinum, gold, silver, copper))
+		);
+
+		has_currency = true;
+	}
+
+	const int aa_points = t->GetAAPoints();
+	if (aa_points) {
+		currency_table += DialogueWindow::TableRow(
+			DialogueWindow::TableCell("AA Points") +
+			DialogueWindow::TableCell(Strings::Commify(aa_points))
 		);
 
 		has_currency = true;
@@ -79,9 +89,9 @@ void ShowCurrencies(Client *c, const Seperator *sep)
 	for (const auto& a : zone->AlternateCurrencies) {
 		const uint32 currency_value = t->GetAlternateCurrencyValue(a.id);
 		if (currency_value) {
-			const auto* d = database.GetItem(a.item_id);
+			const auto *item = database.GetItem(a.item_id);
 			currency_table += DialogueWindow::TableRow(
-				DialogueWindow::TableCell(d->Name) +
+				DialogueWindow::TableCell(item->Name) +
 				DialogueWindow::TableCell(Strings::Commify(currency_value))
 			);
 

--- a/zone/gm_commands/show/currencies.cpp
+++ b/zone/gm_commands/show/currencies.cpp
@@ -56,16 +56,6 @@ void ShowCurrencies(Client *c, const Seperator *sep)
 		has_currency = true;
 	}
 
-	const int aa_points = t->GetAAPoints();
-	if (aa_points) {
-		currency_table += DialogueWindow::TableRow(
-			DialogueWindow::TableCell("AA Points") +
-			DialogueWindow::TableCell(Strings::Commify(aa_points))
-		);
-
-		has_currency = true;
-	}
-
 	const uint32 ebon_crystals = t->GetEbonCrystals();
 	if (ebon_crystals) {
 		currency_table += DialogueWindow::TableRow(


### PR DESCRIPTION
# Notes
- Cleans up messages.
- Adds an enum for `MoneyTypes` and `MoneySubtypes` so we're not using magic numbers for `GetMoney` anymore.
- Converts money amounts to `uint64`.