### PR TITLE
[Bug Fix] Add "IgnoreLevelBasedHasteCaps" rule to GetHaste() to fix showstats

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -5315,7 +5315,7 @@ int Mob::GetHaste()
 		h += spellbonuses.hastetype2 > 10 ? 10 : spellbonuses.hastetype2;
 
 	// 26+ no cap, 1-25 10
-	if (level > 25) // 26+
+	if (level > 25 || (IsClient() && RuleB(Character, IgnoreLevelBasedHasteCaps))) // 26+
 		h += itembonuses.haste;
 	else // 1-25
 		h += itembonuses.haste > 10 ? 10 : itembonuses.haste;
@@ -5337,7 +5337,7 @@ int Mob::GetHaste()
 		h = cap;
 
 	// 51+ 25 (despite there being higher spells...), 1-50 10
-	if (level > 50) { // 51+
+	if (level > 50 || (IsClient() && RuleB(Character, IgnoreLevelBasedHasteCaps))) { // 51+
 		cap = RuleI(Character, Hastev3Cap);
 		if (spellbonuses.hastetype3 > cap) {
 			h += cap;


### PR DESCRIPTION
I PR'd this rule a while back but only modified the CalcHaste function in client_mods.cpp. It wasn't until recently I discovered that #mystats/#showstats was displaying incorrect haste values. After making a thread in discord about it Nite pointed out that showstats uses GetHaste in mob.cpp to calculate haste to display and suggested we should probably update GetHaste to incorporate this rule. This seems to work as expected and I'm getting proper haste display in #showstats as of now. I made sure to include IsClient() checks as Nite suggested since this function is also used by mobs.