### PR TITLE
[Bug Fix] Fix bots/Mercenaries being removed from hatelist

### DIFF
--- a/zone/hate_list.cpp
+++ b/zone/hate_list.cpp
@@ -46,7 +46,14 @@ void HateList::WipeHateList(bool npc_only) {
 	auto iterator = list.begin();
 	while (iterator != list.end()) {
 		Mob *m = (*iterator)->entity_on_hatelist;
-		if (m && (m->IsClient() || (m->IsPet() && m->GetOwner()->IsClient())) && npc_only) {
+		if (
+			m &&
+			(
+				m->IsOfClientBotMerc() ||
+				(m->IsPet() && m->GetOwner() && m->GetOwner()->IsOfClientBotMerc())
+			) &&
+			npc_only
+		) {
 			iterator++;
 		} else {
 			if (m) {
@@ -58,6 +65,7 @@ void HateList::WipeHateList(bool npc_only) {
 					m->CastToClient()->DecrementAggroCount();
 					m->CastToClient()->RemoveXTarget(hate_owner, true);
 				}
+
 				delete (*iterator);
 				iterator = list.erase(iterator);
 			}
@@ -733,7 +741,7 @@ int HateList::AreaRampage(Mob *caster, Mob *target, int count, ExtraAttackOption
 			caster->CombatRange(h->entity_on_hatelist, 1.0, true, opts)) {
 			id_list.push_back(h->entity_on_hatelist->GetID());
 		}
-		
+
 		if (count != -1 && id_list.size() > count) {
 			break;
 		}


### PR DESCRIPTION
# Notes
- https://github.com/EQEmu/Server/pull/3595 caused bots, bot pets, and mercenaries to be removed from hate list because we were only checking for `IsClient()` not `IsOfClientBotMerc()`.
- Resolves an issue mentioned [here](https://discord.com/channels/212663220849213441/1177288302383079534) where NPCs would run past bots/mercenaries to attack the owner.