### PR TITLE
[Commands] Add #show aas Command

### DIFF
--- a/common/repositories/command_subsettings_repository.h
+++ b/common/repositories/command_subsettings_repository.h
@@ -120,6 +120,7 @@ public:
 			{.parent_command = "set", .sub_command = "title_suffix", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "titlesuffix"},
 			{.parent_command = "set", .sub_command = "weather", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "weather"},
 			{.parent_command = "set", .sub_command = "zone", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "zclip|zcolor|zheader|zonelock|zsafecoords|zsky|zunderworld"},
+			{.parent_command = "show", .sub_command = "aas", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "showaas"},
 			{.parent_command = "show", .sub_command = "aa_points", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "showaapoints|showaapts"},
 			{.parent_command = "show", .sub_command = "aggro", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "aggro"},
 			{.parent_command = "show", .sub_command = "buffs", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "showbuffs"},

--- a/zone/client.h
+++ b/zone/client.h
@@ -908,6 +908,7 @@ public:
 	void AutoGrantAAPoints();
 	void GrantAllAAPoints(uint8 unlock_level = 0);
 	bool HasAlreadyPurchasedRank(AA::Rank* rank);
+	void ListPurchasedAAs(Client *to, std::string search_criteria = std::string());
 
 	bool SendGMCommand(std::string message, bool ignore_status = false);
 

--- a/zone/gm_commands/show.cpp
+++ b/zone/gm_commands/show.cpp
@@ -1,4 +1,5 @@
 #include "../client.h"
+#include "show/aas.cpp"
 #include "show/aa_points.cpp"
 #include "show/aggro.cpp"
 #include "show/buffs.cpp"
@@ -56,6 +57,7 @@ void command_show(Client *c, const Seperator *sep)
 	};
 
 	std::vector<Cmd> commands = {
+		Cmd{.cmd = "aas", .u = "aas", .fn = ShowAAs, .a = {"#showaas"}},
 		Cmd{.cmd = "aa_points", .u = "aa_points", .fn = ShowAAPoints, .a = {"#showaapoints", "#showaapts"}},
 		Cmd{.cmd = "aggro", .u = "aggro [Distance] [-v] (-v is verbose Faction Information)", .fn = ShowAggro, .a = {"#aggro"}},
 		Cmd{.cmd = "buffs", .u = "buffs", .fn = ShowBuffs, .a = {"#showbuffs"}},

--- a/zone/gm_commands/show/aas.cpp
+++ b/zone/gm_commands/show/aas.cpp
@@ -1,0 +1,13 @@
+#include "../../client.h"
+
+void ShowAAs(Client *c, const Seperator *sep)
+{
+	Client *t = c;
+	if (c->GetTarget() && c->GetTarget()->IsClient()) {
+		t = c->GetTarget()->CastToClient();
+	}
+
+	const std::string& search_criteria = sep->argnum >= 2 ? sep->argplus[2] : std::string();
+
+	t->ListPurchasedAAs(c, search_criteria);
+}


### PR DESCRIPTION
# Notes
- Allows operators to view AAs a player has purchased from ingame and their ranks.

# Image
![image](https://github.com/EQEmu/Server/assets/89047260/27c577b1-c585-4b53-8f28-2f21232e1cd8)