### PR TITLE
[Commands] Add #task complete Command

### DIFF
--- a/zone/client.h
+++ b/zone/client.h
@@ -1274,6 +1274,10 @@ public:
 		}
 		else { return 0; }
 	}
+	inline bool CompleteTask(uint32 task_id)
+	{
+		return task_state ? task_state->CompleteTask(this, task_id) : false;
+	}
 	inline void FailTask(int task_id) { if (task_state) { task_state->FailTask(this, task_id); }}
 	inline int TaskTimeLeft(int task_id) { return (task_state ? task_state->TaskTimeLeft(task_id) : 0); }
 	inline int EnabledTaskCount(int task_set_id)

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -1396,6 +1396,28 @@ void ClientTaskState::ResetTaskActivity(Client *client, int task_id, int activit
 	);
 }
 
+bool ClientTaskState::CompleteTask(Client *c, uint32 task_id)
+{
+	const auto task_data = task_manager->GetTaskData(task_id);
+	if (!task_data) {
+		return false;
+	}
+
+	for (
+		int activity_id = 0;
+		activity_id < task_manager->GetActivityCount(task_id);
+		activity_id++
+	) {
+		c->UpdateTaskActivity(
+			task_id,
+			activity_id,
+			task_data->activity_information[activity_id].goal_count
+		);
+	}
+
+	return true;
+}
+
 void ClientTaskState::ShowClientTaskInfoMessage(ClientTaskInformation *task, Client *c)
 {
 	const auto task_data = task_manager->GetTaskData(task->task_id);
@@ -1565,7 +1587,7 @@ int ClientTaskState::IsTaskCompleted(int task_id)
 	}
 
 	for (auto &completed_task : m_completed_tasks) {
-		LogTasks("Comparing compelted task [{}] with [{}]", completed_task.task_id, task_id);
+		LogTasks("Comparing completed task [{}] with [{}]", completed_task.task_id, task_id);
 		if (completed_task.task_id == task_id) {
 			return 1;
 		}

--- a/zone/task_client_state.h
+++ b/zone/task_client_state.h
@@ -84,6 +84,7 @@ public:
 	bool CanAcceptNewTask(Client* client, int task_id, int npc_entity_id) const;
 	bool HasExploreTask(Client* client) const;
 	void EndSharedTask(Client* client, bool send_fail);
+	bool CompleteTask(Client *c, uint32 task_id);
 
 	inline bool HasFreeTaskSlot() { return m_active_task.task_id == TASKSLOTEMPTY; }
 


### PR DESCRIPTION
# Notes
- `#task complete [Task ID]` allows operators to complete an entire task without updating individual activities.
- Added task names to messages so you know which task you updated, assigned, etc.