### PR TITLE
[Bug Fix] Changing Group Leader Invalidated GetLeaderName()

### DIFF
--- a/zone/groups.cpp
+++ b/zone/groups.cpp
@@ -2510,3 +2510,9 @@ bool Group::IsLeader(const char* name) {
 
 	return false;
 }
+
+std::string Group::GetGroupLeaderName(uint32 group_id) {
+	char leader_name_buffer[64] = { 0 };
+	database.GetGroupLeadershipInfo(group_id, leader_name_buffer);
+	return std::string(leader_name_buffer);
+}

--- a/zone/groups.h
+++ b/zone/groups.h
@@ -76,7 +76,7 @@ public:
 	void	SplitMoney(uint32 copper, uint32 silver, uint32 gold, uint32 platinum, Client *splitter = nullptr);
 	inline	void SetLeader(Mob* c){ leader = c; };
 	inline	Mob* GetLeader() { return leader; };
-	const char*	GetLeaderName() { return membername[0]; };
+	const char*	GetLeaderName() { return GetGroupLeaderName(GetID()).c_str(); };
 	void	SendHPManaEndPacketsTo(Mob* newmember);
 	void	SendHPPacketsFrom(Mob* member);
 	void	SendManaPacketFrom(Mob* member);
@@ -177,6 +177,8 @@ private:
 	int mentor_percent;
 
 	XTargetAutoHaters m_autohatermgr;
+
+	std::string GetGroupLeaderName(uint32 group_id);
 };
 
 #endif


### PR DESCRIPTION
# Notes
- Utilizes fixes posted in https://github.com/EQEmu/Server/issues/3706 to resolve https://github.com/EQEmu/Server/issues/368.
- Changing group leader caused issues because we assumed `member[0]` was always leader.