### PR TITLE
[Commands] #guild set CharName 0 did not remove char from guild.

### DIFF
--- a/zone/gm_commands/guild.cpp
+++ b/zone/gm_commands/guild.cpp
@@ -329,7 +329,7 @@ void command_guild(Client *c, const Seperator *sep)
 					).c_str()
 				);
 			} else {
-				guild_mgr.SetGuild(char_id, GUILD_NONE, 0);
+				guild_mgr.SetGuild(character_id, GUILD_NONE, 0);
 				c->Message(
 					Chat::White,
 					fmt::format(

--- a/zone/gm_commands/guild.cpp
+++ b/zone/gm_commands/guild.cpp
@@ -329,6 +329,7 @@ void command_guild(Client *c, const Seperator *sep)
 					).c_str()
 				);
 			} else {
+				guild_mgr.SetGuild(char_id, GUILD_NONE, 0);
 				c->Message(
 					Chat::White,
 					fmt::format(


### PR DESCRIPTION
Seems like it just spews a message.

Using #guild set Bobo 0 does not remove Bobo from the guild he is in.

It does now.

Poor Bobo.