### PR TITLE
[Faction] Alliance line is only allowed 1 faction change at a time.

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -515,6 +515,7 @@ Mob::Mob(
 
 	is_boat = IsBoat();
 
+	current_alliance_faction = -1;
 }
 
 Mob::~Mob()
@@ -7126,24 +7127,10 @@ int8 Mob::GetDecayEffectValue(uint16 spell_id, uint16 spelleffect) {
 	return effect_value;
 }
 
-// Faction Mods for Alliance type spells
+// Faction Mods for Alliance type spells (only 1 ever active)
 void Mob::AddFactionBonus(uint32 pFactionID,int32 bonus) {
-	std::map <uint32, int32> :: const_iterator faction_bonus;
-	typedef std::pair <uint32, int32> NewFactionBonus;
-
-	faction_bonus = faction_bonuses.find(pFactionID);
-	if(faction_bonus == faction_bonuses.end())
-	{
-		faction_bonuses.emplace(NewFactionBonus(pFactionID,bonus));
-	}
-	else
-	{
-		if(faction_bonus->second<bonus)
-		{
-			faction_bonuses.erase(pFactionID);
-			faction_bonuses.emplace(NewFactionBonus(pFactionID,bonus));
-		}
-	}
+	current_alliance_faction = pFactionID;
+	current_alliance_mod = bonus;
 }
 
 // Faction Mods from items
@@ -7167,11 +7154,9 @@ void Mob::AddItemFactionBonus(uint32 pFactionID,int32 bonus) {
 }
 
 int32 Mob::GetFactionBonus(uint32 pFactionID) {
-	std::map <uint32, int32> :: const_iterator faction_bonus;
-	faction_bonus = faction_bonuses.find(pFactionID);
-	if(faction_bonus != faction_bonuses.end())
+	if(current_alliance_faction == pFactionID)
 	{
-		return (*faction_bonus).second;
+		return current_alliance_mod;
 	}
 	return 0;
 }

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1774,8 +1774,9 @@ protected:
 	uint32 time_until_can_move;
 	HateList hate_list;
 	std::set<uint32> feign_memory_list;
-	// This is to keep track of mobs we cast faction mod spells on
-	std::map<uint32,int32> faction_bonuses; // Primary FactionID, Bonus
+	// This is to keep track of the current (one only) faction mod (alliance)
+	uint32 current_alliance_faction;
+	int32 current_alliance_mod;
 	void AddFactionBonus(uint32 pFactionID,int32 bonus);
 	int32 GetFactionBonus(uint32 pFactionID);
 	// This is to keep track of item faction modifiers


### PR DESCRIPTION
The alliance line of faction spells can only impact (1) faction at a time.  The existing code allows an infinate #.

This video shows on live how it works:

https://github.com/EQEmu/Server/assets/8644833/9977a8ba-caf8-4e79-bff4-28ffeb874ad1

Looking at my local DB and projecteq, there are only 6 spells that use SE_AddFaction and they are all the alliance line, or a guide version of it.

If someone has added a custom SE_AddFaction to there server, and wants it stick, regardless of the alliance line, we'd need something further.  But as it stands, this is much siumpler, and more accurate.