### PR TITLE
[Quest API] Add GMMove Overloads to Perl/Lua

### DIFF
--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -285,6 +285,11 @@ void Lua_Mob::GMMove(double x, double y, double z, double heading) {
 	self->GMMove(static_cast<float>(x), static_cast<float>(y), static_cast<float>(z), static_cast<float>(heading));
 }
 
+void Lua_Mob::GMMove(double x, double y, double z, double heading, bool save_guard_spot) {
+	Lua_Safe_Call_Void();
+	self->GMMove(static_cast<float>(x), static_cast<float>(y), static_cast<float>(z), static_cast<float>(heading), save_guard_spot);
+}
+
 void Lua_Mob::TryMoveAlong(float distance, float angle) {
 	Lua_Safe_Call_Void();
 	self->TryMoveAlong(distance, angle);
@@ -3350,6 +3355,7 @@ luabind::scope lua_register_mob() {
 	.def("FindType", (bool(Lua_Mob::*)(int,bool,int))&Lua_Mob::FindType)
 	.def("GMMove", (void(Lua_Mob::*)(double,double,double))&Lua_Mob::GMMove)
 	.def("GMMove", (void(Lua_Mob::*)(double,double,double,double))&Lua_Mob::GMMove)
+	.def("GMMove", (void(Lua_Mob::*)(double,double,double,double,bool))&Lua_Mob::GMMove)
 	.def("GetAA", (int(Lua_Mob::*)(int))&Lua_Mob::GetAA)
 	.def("GetAABonuses", &Lua_Mob::GetAABonuses)
 	.def("GetAAByAAID", (int(Lua_Mob::*)(int))&Lua_Mob::GetAAByAAID)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -80,6 +80,7 @@ public:
 	bool RandomizeFeatures(bool send_illusion, bool save_variables);
 	void GMMove(double x, double y, double z);
 	void GMMove(double x, double y, double z, double heading);
+	void GMMove(double x, double y, double z, double heading, bool save_guard_spot);
 	void TryMoveAlong(float distance, float heading);
 	void TryMoveAlong(float distance, float heading, bool send);
 	bool HasProcs();

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -326,6 +326,11 @@ void Perl_Mob_GMMove(Mob* self, float x, float y, float z, float heading) // @ca
 	self->GMMove(x, y, z, heading);
 }
 
+void Perl_Mob_GMMove(Mob* self, float x, float y, float z, float heading, bool save_guard_spot) // @categories Script Utility
+{
+	self->GMMove(x, y, z, heading, save_guard_spot);
+}
+
 bool Perl_Mob_HasProcs(Mob* self) // @categories Stats and Attributes
 {
 	return self->HasProcs();
@@ -3469,6 +3474,7 @@ void perl_register_mob()
 	package.add("FindType", (bool(*)(Mob*, uint16_t, bool, uint16_t))&Perl_Mob_FindType);
 	package.add("GMMove", (void(*)(Mob*, float, float, float))&Perl_Mob_GMMove);
 	package.add("GMMove", (void(*)(Mob*, float, float, float, float))&Perl_Mob_GMMove);
+	package.add("GMMove", (void(*)(Mob*, float, float, float, float, bool))&Perl_Mob_GMMove);
 	package.add("Gate", &Perl_Mob_Gate);
 	package.add("GetAA", &Perl_Mob_GetAA);
 	package.add("GetAABonuses", &Perl_Mob_GetAABonuses);


### PR DESCRIPTION
# Perl
- Add `$mob->GMMove(x, y, z, heading, save_guard_spot)`.

# Lua
- Add `mob:GMMove(x, y, z, heading, save_guard_spot)`.

# Notes
- Operators weren't able to disable saving guard spots, so moving with `GMMove` meant NPCs stayed where they were moved.