### PR TITLE
[Database] Consolidate Starting Items Table

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -5019,17 +5019,72 @@ ALTER TABLE `spawn2` DROP COLUMN `enabled`;
 )"
 	},
 	ManifestEntry{
-	  .version = 9242,
-	  .description = "2023_11_7_mintime_maxtime_spawnentry.sql",
-	  .check = "SHOW COLUMNS FROM `spawnentry` LIKE 'min_time'",
-	  .condition = "empty",
-	  .match = "",
-	  .sql = R"(
+		.version = 9242,
+		.description = "2023_11_7_mintime_maxtime_spawnentry.sql",
+		.check = "SHOW COLUMNS FROM `spawnentry` LIKE 'min_time'",
+		.condition = "empty",
+		.match = "",
+		.sql = R"(
 ALTER TABLE `spawnentry`
 ADD COLUMN `min_time` smallint(4) NOT NULL DEFAULT 0 AFTER `condition_value_filter`,
 ADD COLUMN `max_time` smallint(4) NOT NULL DEFAULT 0 AFTER `min_time`;
 )"
   },
+  ManifestEntry{
+		.version = 9243,
+		.description = "2023_11_27_starting_items_revamp.sql",
+		.check = "SHOW COLUMNS FROM `starting_items` LIKE 'race_list'",
+		.condition = "empty",
+		.match = "",
+		.sql = R"(
+CREATE TABLE `starting_items_backup_9243` LIKE `starting_items`;
+INSERT INTO `starting_items_backup_9243` SELECT * FROM `starting_items`;
+
+CREATE TABLE `starting_items_new`  (
+  `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `race_list` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NULL DEFAULT NULL,
+  `class_list` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NULL DEFAULT NULL,
+  `deity_list` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NULL DEFAULT NULL,
+  `zone_id_list` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NULL DEFAULT NULL,
+  `item_id` int(11) UNSIGNED NOT NULL DEFAULT 0,
+  `item_charges` tinyint(3) UNSIGNED NOT NULL DEFAULT 1,
+  `gm` mediumint(3) UNSIGNED NOT NULL DEFAULT 0,
+  `slot` mediumint(9) NOT NULL DEFAULT -1,
+  `min_expansion` tinyint(4) NOT NULL DEFAULT -1,
+  `max_expansion` tinyint(4) NOT NULL DEFAULT -1,
+  `content_flags` varchar(100) NULL,
+  `content_flags_disabled` varchar(100) NULL,
+  PRIMARY KEY (`id`)
+);
+
+INSERT INTO
+`starting_items_new`
+(
+	SELECT
+		0 AS `id`,
+		GROUP_CONCAT(DISTINCT `class` ORDER BY class ASC SEPARATOR '|') AS `class_list`,
+		GROUP_CONCAT(DISTINCT `race` ORDER BY race ASC SEPARATOR '|') AS `race_list`,
+		GROUP_CONCAT(DISTINCT `deityid` ORDER BY deityid ASC SEPARATOR '|') AS `deity_list`,
+		GROUP_CONCAT(DISTINCT `zoneid` ORDER BY zoneid ASC SEPARATOR '|') AS `zone_list`,
+		`itemid`,
+		`item_charges`,
+		`gm`,
+		`slot`,
+		`min_expansion`,
+		`max_expansion`,
+		`content_flags`,
+		`content_flags_disabled `
+	FROM
+		`starting_items`
+	GROUP BY
+		`itemid`
+);
+
+DROP TABLE `starting_items`;
+RENAME TABLE `starting_items_new` TO `starting_items`;
+)"
+
+	}
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{
 //		.version = 9228,

--- a/common/repositories/base/base_starting_items_repository.h
+++ b/common/repositories/base/base_starting_items_repository.h
@@ -16,17 +16,18 @@
 #include "../../strings.h"
 #include <ctime>
 
+
 class BaseStartingItemsRepository {
 public:
 	struct StartingItems {
 		uint32_t    id;
-		int32_t     race;
-		int32_t     class_;
-		int32_t     deityid;
-		int32_t     zoneid;
-		int32_t     itemid;
+		std::string race_list;
+		std::string class_list;
+		std::string deity_list;
+		std::string zone_id_list;
+		uint32_t    item_id;
 		uint8_t     item_charges;
-		int8_t      gm;
+		uint8_t     gm;
 		int32_t     slot;
 		int8_t      min_expansion;
 		int8_t      max_expansion;
@@ -43,11 +44,11 @@ public:
 	{
 		return {
 			"id",
-			"race",
-			"`class`",
-			"deityid",
-			"zoneid",
-			"itemid",
+			"race_list",
+			"class_list",
+			"deity_list",
+			"zone_id_list",
+			"item_id",
 			"item_charges",
 			"gm",
 			"slot",
@@ -62,11 +63,11 @@ public:
 	{
 		return {
 			"id",
-			"race",
-			"`class`",
-			"deityid",
-			"zoneid",
-			"itemid",
+			"race_list",
+			"class_list",
+			"deity_list",
+			"zone_id_list",
+			"item_id",
 			"item_charges",
 			"gm",
 			"slot",
@@ -115,11 +116,11 @@ public:
 		StartingItems e{};
 
 		e.id                     = 0;
-		e.race                   = 0;
-		e.class_                 = 0;
-		e.deityid                = 0;
-		e.zoneid                 = 0;
-		e.itemid                 = 0;
+		e.race_list              = "";
+		e.class_list             = "";
+		e.deity_list             = "";
+		e.zone_id_list           = "";
+		e.item_id                = 0;
 		e.item_charges           = 1;
 		e.gm                     = 0;
 		e.slot                   = -1;
@@ -152,8 +153,9 @@ public:
 	{
 		auto results = db.QueryDatabase(
 			fmt::format(
-				"{} WHERE id = {} LIMIT 1",
+				"{} WHERE {} = {} LIMIT 1",
 				BaseSelect(),
+				PrimaryKey(),
 				starting_items_id
 			)
 		);
@@ -163,13 +165,13 @@ public:
 			StartingItems e{};
 
 			e.id                     = static_cast<uint32_t>(strtoul(row[0], nullptr, 10));
-			e.race                   = static_cast<int32_t>(atoi(row[1]));
-			e.class_                 = static_cast<int32_t>(atoi(row[2]));
-			e.deityid                = static_cast<int32_t>(atoi(row[3]));
-			e.zoneid                 = static_cast<int32_t>(atoi(row[4]));
-			e.itemid                 = static_cast<int32_t>(atoi(row[5]));
+			e.race_list              = row[1] ? row[1] : "";
+			e.class_list             = row[2] ? row[2] : "";
+			e.deity_list             = row[3] ? row[3] : "";
+			e.zone_id_list           = row[4] ? row[4] : "";
+			e.item_id                = static_cast<uint32_t>(strtoul(row[5], nullptr, 10));
 			e.item_charges           = static_cast<uint8_t>(strtoul(row[6], nullptr, 10));
-			e.gm                     = static_cast<int8_t>(atoi(row[7]));
+			e.gm                     = static_cast<uint8_t>(strtoul(row[7], nullptr, 10));
 			e.slot                   = static_cast<int32_t>(atoi(row[8]));
 			e.min_expansion          = static_cast<int8_t>(atoi(row[9]));
 			e.max_expansion          = static_cast<int8_t>(atoi(row[10]));
@@ -208,11 +210,11 @@ public:
 
 		auto columns = Columns();
 
-		v.push_back(columns[1] + " = " + std::to_string(e.race));
-		v.push_back(columns[2] + " = " + std::to_string(e.class_));
-		v.push_back(columns[3] + " = " + std::to_string(e.deityid));
-		v.push_back(columns[4] + " = " + std::to_string(e.zoneid));
-		v.push_back(columns[5] + " = " + std::to_string(e.itemid));
+		v.push_back(columns[1] + " = '" + Strings::Escape(e.race_list) + "'");
+		v.push_back(columns[2] + " = '" + Strings::Escape(e.class_list) + "'");
+		v.push_back(columns[3] + " = '" + Strings::Escape(e.deity_list) + "'");
+		v.push_back(columns[4] + " = '" + Strings::Escape(e.zone_id_list) + "'");
+		v.push_back(columns[5] + " = " + std::to_string(e.item_id));
 		v.push_back(columns[6] + " = " + std::to_string(e.item_charges));
 		v.push_back(columns[7] + " = " + std::to_string(e.gm));
 		v.push_back(columns[8] + " = " + std::to_string(e.slot));
@@ -242,11 +244,11 @@ public:
 		std::vector<std::string> v;
 
 		v.push_back(std::to_string(e.id));
-		v.push_back(std::to_string(e.race));
-		v.push_back(std::to_string(e.class_));
-		v.push_back(std::to_string(e.deityid));
-		v.push_back(std::to_string(e.zoneid));
-		v.push_back(std::to_string(e.itemid));
+		v.push_back("'" + Strings::Escape(e.race_list) + "'");
+		v.push_back("'" + Strings::Escape(e.class_list) + "'");
+		v.push_back("'" + Strings::Escape(e.deity_list) + "'");
+		v.push_back("'" + Strings::Escape(e.zone_id_list) + "'");
+		v.push_back(std::to_string(e.item_id));
 		v.push_back(std::to_string(e.item_charges));
 		v.push_back(std::to_string(e.gm));
 		v.push_back(std::to_string(e.slot));
@@ -284,11 +286,11 @@ public:
 			std::vector<std::string> v;
 
 			v.push_back(std::to_string(e.id));
-			v.push_back(std::to_string(e.race));
-			v.push_back(std::to_string(e.class_));
-			v.push_back(std::to_string(e.deityid));
-			v.push_back(std::to_string(e.zoneid));
-			v.push_back(std::to_string(e.itemid));
+			v.push_back("'" + Strings::Escape(e.race_list) + "'");
+			v.push_back("'" + Strings::Escape(e.class_list) + "'");
+			v.push_back("'" + Strings::Escape(e.deity_list) + "'");
+			v.push_back("'" + Strings::Escape(e.zone_id_list) + "'");
+			v.push_back(std::to_string(e.item_id));
 			v.push_back(std::to_string(e.item_charges));
 			v.push_back(std::to_string(e.gm));
 			v.push_back(std::to_string(e.slot));
@@ -330,13 +332,13 @@ public:
 			StartingItems e{};
 
 			e.id                     = static_cast<uint32_t>(strtoul(row[0], nullptr, 10));
-			e.race                   = static_cast<int32_t>(atoi(row[1]));
-			e.class_                 = static_cast<int32_t>(atoi(row[2]));
-			e.deityid                = static_cast<int32_t>(atoi(row[3]));
-			e.zoneid                 = static_cast<int32_t>(atoi(row[4]));
-			e.itemid                 = static_cast<int32_t>(atoi(row[5]));
+			e.race_list              = row[1] ? row[1] : "";
+			e.class_list             = row[2] ? row[2] : "";
+			e.deity_list             = row[3] ? row[3] : "";
+			e.zone_id_list           = row[4] ? row[4] : "";
+			e.item_id                = static_cast<uint32_t>(strtoul(row[5], nullptr, 10));
 			e.item_charges           = static_cast<uint8_t>(strtoul(row[6], nullptr, 10));
-			e.gm                     = static_cast<int8_t>(atoi(row[7]));
+			e.gm                     = static_cast<uint8_t>(strtoul(row[7], nullptr, 10));
 			e.slot                   = static_cast<int32_t>(atoi(row[8]));
 			e.min_expansion          = static_cast<int8_t>(atoi(row[9]));
 			e.max_expansion          = static_cast<int8_t>(atoi(row[10]));
@@ -367,13 +369,13 @@ public:
 			StartingItems e{};
 
 			e.id                     = static_cast<uint32_t>(strtoul(row[0], nullptr, 10));
-			e.race                   = static_cast<int32_t>(atoi(row[1]));
-			e.class_                 = static_cast<int32_t>(atoi(row[2]));
-			e.deityid                = static_cast<int32_t>(atoi(row[3]));
-			e.zoneid                 = static_cast<int32_t>(atoi(row[4]));
-			e.itemid                 = static_cast<int32_t>(atoi(row[5]));
+			e.race_list              = row[1] ? row[1] : "";
+			e.class_list             = row[2] ? row[2] : "";
+			e.deity_list             = row[3] ? row[3] : "";
+			e.zone_id_list           = row[4] ? row[4] : "";
+			e.item_id                = static_cast<uint32_t>(strtoul(row[5], nullptr, 10));
 			e.item_charges           = static_cast<uint8_t>(strtoul(row[6], nullptr, 10));
-			e.gm                     = static_cast<int8_t>(atoi(row[7]));
+			e.gm                     = static_cast<uint8_t>(strtoul(row[7], nullptr, 10));
 			e.slot                   = static_cast<int32_t>(atoi(row[8]));
 			e.min_expansion          = static_cast<int8_t>(atoi(row[9]));
 			e.max_expansion          = static_cast<int8_t>(atoi(row[10]));

--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -500,10 +500,6 @@ bool SharedDatabase::SetStartingItems(
 			}
 		}
 
-		if (e.gm > admin_level) {
-			continue;
-		}
-
 		v.emplace_back(e);
 	}
 

--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -500,6 +500,10 @@ bool SharedDatabase::SetStartingItems(
 			}
 		}
 
+		if (e.gm > admin_level) {
+			continue;
+		}
+
 		v.emplace_back(e);
 	}
 

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9242
+#define CURRENT_BINARY_DATABASE_VERSION 9243
 
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9040
 


### PR DESCRIPTION
# Notes
- Convert `class`, `deityid`, `race`, and `zoneid` columns to `|` separated columns.
- Consolidates up to 15 rows per item down to a singular row.
- Allows ease of use for operators.
- Entire process is automated and creates a backup of pre-existing table.