### PR TITLE
[Database] Modify `updated` column in `items` table with proper default.

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -5029,8 +5029,8 @@ ALTER TABLE `spawnentry`
 ADD COLUMN `min_time` smallint(4) NOT NULL DEFAULT 0 AFTER `condition_value_filter`,
 ADD COLUMN `max_time` smallint(4) NOT NULL DEFAULT 0 AFTER `min_time`;
 )"
-  },
-  ManifestEntry{
+	},
+	ManifestEntry{
 		.version = 9243,
 		.description = "2023_11_27_starting_items_revamp.sql",
 		.check = "SHOW COLUMNS FROM `starting_items` LIKE 'race_list'",
@@ -5083,8 +5083,18 @@ INSERT INTO
 DROP TABLE `starting_items`;
 RENAME TABLE `starting_items_new` TO `starting_items`;
 )"
-
+	},
+	ManifestEntry{
+		.version = 9244,
+		.description = "2023_11_30_items_table_schema.sql",
+		.check = "SHOW COLUMNS FROM `items` LIKE 'updated'",
+		.condition = "contains",
+		.match = "NULL",
+		.sql = R"(
+ALTER TABLE `items` MODIFY COLUMN `updated` datetime NULL DEFAULT NULL;
+		)"
 	}
+
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{
 //		.version = 9228,

--- a/common/repositories/base/base_items_repository.h
+++ b/common/repositories/base/base_items_repository.h
@@ -75,7 +75,7 @@ public:
 		int32_t     damageshield;
 		int32_t     deity;
 		int32_t     delay;
-		int32_t     augdistiller;
+		uint32_t    augdistiller;
 		int32_t     dotshielding;
 		int32_t     dr;
 		int32_t     clicktype;
@@ -227,7 +227,7 @@ public:
 		int32_t     focusunk5;
 		std::string focusunk6;
 		int32_t     focusunk7;
-		int32_t     scrollunk1;
+		uint32_t    scrollunk1;
 		int32_t     scrollunk2;
 		int32_t     scrollunk3;
 		int32_t     scrollunk4;
@@ -266,10 +266,10 @@ public:
 		std::string created;
 		int16_t     elitematerial;
 		int16_t     ldonsellbackrate;
-		int16_t     scriptfileid;
+		int32_t     scriptfileid;
 		int16_t     expendablearrow;
-		int16_t     powersourcecapacity;
-		int16_t     bardeffect;
+		int32_t     powersourcecapacity;
+		int32_t     bardeffect;
 		int16_t     bardeffecttype;
 		int16_t     bardlevel2;
 		int16_t     bardlevel;
@@ -1307,7 +1307,7 @@ public:
 			e.damageshield        = static_cast<int32_t>(atoi(row[52]));
 			e.deity               = static_cast<int32_t>(atoi(row[53]));
 			e.delay               = static_cast<int32_t>(atoi(row[54]));
-			e.augdistiller        = static_cast<int32_t>(atoi(row[55]));
+			e.augdistiller        = static_cast<uint32_t>(strtoul(row[55], nullptr, 10));
 			e.dotshielding        = static_cast<int32_t>(atoi(row[56]));
 			e.dr                  = static_cast<int32_t>(atoi(row[57]));
 			e.clicktype           = static_cast<int32_t>(atoi(row[58]));
@@ -1459,7 +1459,7 @@ public:
 			e.focusunk5           = static_cast<int32_t>(atoi(row[204]));
 			e.focusunk6           = row[205] ? row[205] : "";
 			e.focusunk7           = static_cast<int32_t>(atoi(row[206]));
-			e.scrollunk1          = static_cast<int32_t>(atoi(row[207]));
+			e.scrollunk1          = static_cast<uint32_t>(strtoul(row[207], nullptr, 10));
 			e.scrollunk2          = static_cast<int32_t>(atoi(row[208]));
 			e.scrollunk3          = static_cast<int32_t>(atoi(row[209]));
 			e.scrollunk4          = static_cast<int32_t>(atoi(row[210]));
@@ -1498,10 +1498,10 @@ public:
 			e.created             = row[243] ? row[243] : "";
 			e.elitematerial       = static_cast<int16_t>(atoi(row[244]));
 			e.ldonsellbackrate    = static_cast<int16_t>(atoi(row[245]));
-			e.scriptfileid        = static_cast<int16_t>(atoi(row[246]));
+			e.scriptfileid        = static_cast<int32_t>(atoi(row[246]));
 			e.expendablearrow     = static_cast<int16_t>(atoi(row[247]));
-			e.powersourcecapacity = static_cast<int16_t>(atoi(row[248]));
-			e.bardeffect          = static_cast<int16_t>(atoi(row[249]));
+			e.powersourcecapacity = static_cast<int32_t>(atoi(row[248]));
+			e.bardeffect          = static_cast<int32_t>(atoi(row[249]));
 			e.bardeffecttype      = static_cast<int16_t>(atoi(row[250]));
 			e.bardlevel2          = static_cast<int16_t>(atoi(row[251]));
 			e.bardlevel           = static_cast<int16_t>(atoi(row[252]));
@@ -2563,7 +2563,7 @@ public:
 			e.damageshield        = static_cast<int32_t>(atoi(row[52]));
 			e.deity               = static_cast<int32_t>(atoi(row[53]));
 			e.delay               = static_cast<int32_t>(atoi(row[54]));
-			e.augdistiller        = static_cast<int32_t>(atoi(row[55]));
+			e.augdistiller        = static_cast<uint32_t>(strtoul(row[55], nullptr, 10));
 			e.dotshielding        = static_cast<int32_t>(atoi(row[56]));
 			e.dr                  = static_cast<int32_t>(atoi(row[57]));
 			e.clicktype           = static_cast<int32_t>(atoi(row[58]));
@@ -2715,7 +2715,7 @@ public:
 			e.focusunk5           = static_cast<int32_t>(atoi(row[204]));
 			e.focusunk6           = row[205] ? row[205] : "";
 			e.focusunk7           = static_cast<int32_t>(atoi(row[206]));
-			e.scrollunk1          = static_cast<int32_t>(atoi(row[207]));
+			e.scrollunk1          = static_cast<uint32_t>(strtoul(row[207], nullptr, 10));
 			e.scrollunk2          = static_cast<int32_t>(atoi(row[208]));
 			e.scrollunk3          = static_cast<int32_t>(atoi(row[209]));
 			e.scrollunk4          = static_cast<int32_t>(atoi(row[210]));
@@ -2754,10 +2754,10 @@ public:
 			e.created             = row[243] ? row[243] : "";
 			e.elitematerial       = static_cast<int16_t>(atoi(row[244]));
 			e.ldonsellbackrate    = static_cast<int16_t>(atoi(row[245]));
-			e.scriptfileid        = static_cast<int16_t>(atoi(row[246]));
+			e.scriptfileid        = static_cast<int32_t>(atoi(row[246]));
 			e.expendablearrow     = static_cast<int16_t>(atoi(row[247]));
-			e.powersourcecapacity = static_cast<int16_t>(atoi(row[248]));
-			e.bardeffect          = static_cast<int16_t>(atoi(row[249]));
+			e.powersourcecapacity = static_cast<int32_t>(atoi(row[248]));
+			e.bardeffect          = static_cast<int32_t>(atoi(row[249]));
 			e.bardeffecttype      = static_cast<int16_t>(atoi(row[250]));
 			e.bardlevel2          = static_cast<int16_t>(atoi(row[251]));
 			e.bardlevel           = static_cast<int16_t>(atoi(row[252]));
@@ -2872,7 +2872,7 @@ public:
 			e.damageshield        = static_cast<int32_t>(atoi(row[52]));
 			e.deity               = static_cast<int32_t>(atoi(row[53]));
 			e.delay               = static_cast<int32_t>(atoi(row[54]));
-			e.augdistiller        = static_cast<int32_t>(atoi(row[55]));
+			e.augdistiller        = static_cast<uint32_t>(strtoul(row[55], nullptr, 10));
 			e.dotshielding        = static_cast<int32_t>(atoi(row[56]));
 			e.dr                  = static_cast<int32_t>(atoi(row[57]));
 			e.clicktype           = static_cast<int32_t>(atoi(row[58]));
@@ -3024,7 +3024,7 @@ public:
 			e.focusunk5           = static_cast<int32_t>(atoi(row[204]));
 			e.focusunk6           = row[205] ? row[205] : "";
 			e.focusunk7           = static_cast<int32_t>(atoi(row[206]));
-			e.scrollunk1          = static_cast<int32_t>(atoi(row[207]));
+			e.scrollunk1          = static_cast<uint32_t>(strtoul(row[207], nullptr, 10));
 			e.scrollunk2          = static_cast<int32_t>(atoi(row[208]));
 			e.scrollunk3          = static_cast<int32_t>(atoi(row[209]));
 			e.scrollunk4          = static_cast<int32_t>(atoi(row[210]));
@@ -3063,10 +3063,10 @@ public:
 			e.created             = row[243] ? row[243] : "";
 			e.elitematerial       = static_cast<int16_t>(atoi(row[244]));
 			e.ldonsellbackrate    = static_cast<int16_t>(atoi(row[245]));
-			e.scriptfileid        = static_cast<int16_t>(atoi(row[246]));
+			e.scriptfileid        = static_cast<int32_t>(atoi(row[246]));
 			e.expendablearrow     = static_cast<int16_t>(atoi(row[247]));
-			e.powersourcecapacity = static_cast<int16_t>(atoi(row[248]));
-			e.bardeffect          = static_cast<int16_t>(atoi(row[249]));
+			e.powersourcecapacity = static_cast<int32_t>(atoi(row[248]));
+			e.bardeffect          = static_cast<int32_t>(atoi(row[249]));
 			e.bardeffecttype      = static_cast<int16_t>(atoi(row[250]));
 			e.bardlevel2          = static_cast<int16_t>(atoi(row[251]));
 			e.bardlevel           = static_cast<int16_t>(atoi(row[252]));

--- a/common/repositories/items_repository.h
+++ b/common/repositories/items_repository.h
@@ -44,35 +44,7 @@ public:
      */
 
 	// Custom extended repository methods here
-	static std::vector<int32> GetItemIDsBySearchCriteria(
-		Database& db,
-		std::string search_string,
-		int query_limit = 0
-	)
-	{
-		auto query = fmt::format(
-			"SELECT `id` FROM {} WHERE LOWER(`name`) LIKE '%%{}%%' ORDER BY id ASC",
-			TableName(),
-			Strings::Escape(search_string)
-		);
 
-		if (query_limit >= 1) {
-			query += fmt::format(" LIMIT {}", query_limit);
-		}
-
-		std::vector<int32> item_id_list;
-
-		auto results = db.QueryDatabase(query);
-		if (!results.Success() || !results.RowCount()) {
-			return item_id_list;
-		}
-
-		for (auto row : results) {
-			item_id_list.emplace_back(Strings::ToInt(row[0]));
-		}
-
-		return item_id_list;
-	}
 };
 
 #endif //EQEMU_ITEMS_REPOSITORY_H

--- a/common/repositories/items_repository.h
+++ b/common/repositories/items_repository.h
@@ -44,7 +44,35 @@ public:
      */
 
 	// Custom extended repository methods here
+	static std::vector<int32> GetItemIDsBySearchCriteria(
+		Database& db,
+		std::string search_string,
+		int query_limit = 0
+	)
+	{
+		auto query = fmt::format(
+			"SELECT `id` FROM {} WHERE LOWER(`name`) LIKE '%%{}%%' ORDER BY id ASC",
+			TableName(),
+			Strings::Escape(search_string)
+		);
 
+		if (query_limit >= 1) {
+			query += fmt::format(" LIMIT {}", query_limit);
+		}
+
+		std::vector<int32> item_id_list;
+
+		auto results = db.QueryDatabase(query);
+		if (!results.Success() || !results.RowCount()) {
+			return item_id_list;
+		}
+
+		for (auto row : results) {
+			item_id_list.emplace_back(Strings::ToInt(row[0]));
+		}
+
+		return item_id_list;
+	}
 };
 
 #endif //EQEMU_ITEMS_REPOSITORY_H

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9243
+#define CURRENT_BINARY_DATABASE_VERSION 9244
 
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9040
 


### PR DESCRIPTION
From https://mariadb.com/kb/en/datetime/, `datetime` can be ZERO_DATE (`0000-00-00` with no time component) or between `1000-01-01 00:00:00.000000` and `9999-12-31 23:59:59.999999`. Currently, `updated` is the only datetime field that is `NOT NULL` and improperly defaulted to `0000-00-00 00:00:00`. This change matches existing structures of the other `datetime` columns.