### PR TITLE
[GM Commands] Fix formatting of wpinfo output.

### DIFF
--- a/zone/waypoints.cpp
+++ b/zone/waypoints.cpp
@@ -113,7 +113,7 @@ void NPC::DisplayWaypointInfo(Client *client) {
 				(
 					current_waypoint.pause ?
 					fmt::format(
-						"{} ({})",
+						" {} ({})",
 						Strings::SecondsToTime(current_waypoint.pause),
 						current_waypoint.pause
 					) :


### PR DESCRIPTION
#wpinfo output was missing a space on lines that included a delay.

![Capture](https://github.com/EQEmu/Server/assets/8644833/878f2643-417d-48c5-9c85-a7706bc55a7c)
