### PR TITLE
[Bug Fix] Fix Swarm Pets Requiring NPC Aggros Flag

### DIFF
--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -1062,10 +1062,15 @@ void Mob::AI_Process() {
 			SetTarget(hate_list.GetClosestEntOnHateList(this));
 		else {
 			if (AI_target_check_timer->Check()) {
-				if (IsNPC() && (!IsPet() || (HasOwner() && GetOwner()->IsNPC())) && !CastToNPC()->WillAggroNPCs()) {
+				if (
+					IsNPC() &&
+					!CastToNPC()->GetSwarmInfo() &&
+					(!IsPet() || (HasOwner() && GetOwner()->IsNPC())) &&
+					!CastToNPC()->WillAggroNPCs()
+				) {
 					WipeHateList(true); // wipe NPCs from hate list to prevent faction war
 				}
-				
+
 				if (IsFocused()) {
 					if (!target) {
 						SetTarget(hate_list.GetEntWithMostHateOnList(this));
@@ -1293,7 +1298,7 @@ void Mob::AI_Process() {
 							if (cur > 0) {
 								opts.range_percent = cur;
 							}
-							
+
 							AreaRampage(&opts);
 							specialed = true;
 						}


### PR DESCRIPTION
# Notes
- https://github.com/EQEmu/Server/pull/3595 made swarm pets require the `npc_aggro` flag to be set to attack.