### PR TITLE
[CMake] Update minimum version of CMake

### DIFF
--- a/client_files/CMakeLists.txt
+++ b/client_files/CMakeLists.txt
@@ -1,4 +1,4 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 3.2)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 add_subdirectory(import)
 add_subdirectory(export)


### PR DESCRIPTION
```
CMake Deprecation Warning at client_files/CMakeLists.txt:1 (CMAKE_MINIMUM_REQUIRED):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```