### PR TITLE
[Bots] Fix bots learning spells on level

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -3641,6 +3641,7 @@ void Bot::LevelBotWithClient(Client* client, uint8 level, bool sendlvlapp) {
 					bot->SendLevelAppearance();
 				// modified from Client::SetLevel()
 				bot->SendAppearancePacket(AT_WhoLevel, level, true, true); // who level change
+				bot->AI_AddBotSpells(bot->GetBotSpellID());
 			}
 		}
 


### PR DESCRIPTION
Previously bots would need to be zoned or camped/spawned to begin using new spells for their level.