### PR TITLE
[Bots] Add BotHealOnLevel to fully heal/mana on level.

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -649,6 +649,7 @@ RULE_BOOL(Bots, ResurrectionSickness, true, "Use Resurrection Sickness based on 
 RULE_INT(Bots, OldResurrectionSicknessSpell, 757, "757 is Default Old Resurrection Sickness Spell")
 RULE_INT(Bots, ResurrectionSicknessSpell, 756, "756 is Default Resurrection Sickness Spell")
 RULE_BOOL(Bots, AllowPickpocketCommand, true, "Allows the use of the bot command 'pickpocket'")
+RULE_BOOL(Bots, BotHealOnLevel, false, "Setting whether a bot should heal completely when leveling. Default FALSE.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Chat)

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -3634,12 +3634,27 @@ void Bot::LevelBotWithClient(Client* client, uint8 level, bool sendlvlapp) {
 
 		for (auto biter = blist.begin(); biter != blist.end(); ++biter) {
 			Bot* bot = *biter;
+
 			if (bot && (bot->GetLevel() != client->GetLevel())) {
 				bot->SetPetChooser(false); // not sure what this does, but was in bot 'update' code
 				bot->CalcBotStats(client->GetBotOption(Client::booStatsUpdate));
-				if (sendlvlapp)
+
+				if (sendlvlapp) {
 					bot->SendLevelAppearance();
+				}
 				// modified from Client::SetLevel()
+				if (!RuleB(Bots, BotHealOnLevel)) {
+					int mhp = bot->CalcMaxHP();
+					if (bot->GetHP() > mhp) {
+						bot->SetHP(mhp);
+					}
+				}
+				else {
+					bot->SetHP(bot->CalcMaxHP());
+					bot->SetMana(bot->CalcMaxMana());
+				}
+
+				bot->SendHPUpdate();
 				bot->SendAppearancePacket(AT_WhoLevel, level, true, true); // who level change
 			}
 		}


### PR DESCRIPTION
Adds the rule ***Bots, BotHealOnLevel***, default false, to control whether or not bots will gain full health and mana when their owner levels.