### PR TITLE
[Bots] Enable auto-saving of bots.

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -651,6 +651,7 @@ RULE_INT(Bots, OldResurrectionSicknessSpell, 757, "757 is Default Old Resurrecti
 RULE_INT(Bots, ResurrectionSicknessSpell, 756, "756 is Default Resurrection Sickness Spell")
 RULE_BOOL(Bots, AllowPickpocketCommand, true, "Allows the use of the bot command 'pickpocket'")
 RULE_BOOL(Bots, BotHealOnLevel, false, "Setting whether a bot should heal completely when leveling. Default FALSE.")
+RULE_INT(Bots, AutosaveIntervalSeconds, 300, "Number of seconds after which a timer is triggered which stores the bot data. The value 0 means no periodic automatic saving.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Chat)

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -1736,6 +1736,17 @@ bool Bot::Process()
 		}
 	}
 
+	if (auto_save_timer.Check()) {
+		clock_t t = std::clock(); /* Function timer start */
+		Save();
+		LogDebug(
+			"ZoneDatabase::SaveBotData [{}], done Took [{}] seconds",
+			GetBotID(),
+			((float)(std::clock() - t)) / CLOCKS_PER_SEC
+		);
+		auto_save_timer.Start(RuleI(Bots, AutosaveIntervalSeconds) * 1000);
+	}
+
 	if (IsStunned() || IsMezzed()) {
 		return true;
 	}
@@ -3321,6 +3332,7 @@ bool Bot::Spawn(Client* botCharacterOwner) {
 		LoadPet();
 		SentPositionPacket(0.0f, 0.0f, 0.0f, 0.0f, 0);
 		ping_timer.Start(8000);
+		auto_save_timer.Start(RuleI(Bots, AutosaveIntervalSeconds) * 1000);
 		// there is something askew with spawn struct appearance fields...
 		// I re-enabled this until I can sort it out
 		const auto& m = GetBotItemSlots();

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -866,6 +866,7 @@ private:
 	Timer m_evade_timer; // can be moved to pTimers at some point
 	Timer m_alt_combat_hate_timer;
 	Timer m_auto_defend_timer;
+	Timer auto_save_timer;
 	bool m_dirtyautohaters;
 	bool m_guard_flag;
 	bool m_hold_flag;


### PR DESCRIPTION
Adds the rule **Bots, AutosaveIntervalSeconds** to control the frequency of the autosave of bots. Currently they only fully save on camp/zone.