### PR TITLE
[Rules] Add DOT and HOT Rules

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -458,6 +458,8 @@ RULE_INT(Spells, WizardCritMinimumRandomRatio, 20, "The minimum value for the ra
 RULE_INT(Spells, WizardCritMaximumRandomRatio, 70, "The maximum value for the random range which Wizards and Caster DPS Mercs innately have for spell crit ratio. Set to 70 for vanilla values.")
 RULE_INT(Spells, DefensiveProcPenaltyLevelGap, 6, "Defensive Proc Penalty Level Gap where procs start losing their proc rate at RuleR(Spells, DefensiveProcPenaltyModifier)% per level difference")
 RULE_REAL(Spells, DefensiveProcPenaltyLevelGapModifier, 10.0f, "Defensive Proc Penalty Level Gap Modifier where procs start losing their proc rate at defined % after RuleI(Spells, DefensiveProcLevelGap) level difference")
+RULE_BOOL(Spells, DOTBonusDamageSplitOverDuration, true, "Disable to have Damage Over Time total bonus damage added to each tick instead of divided across duration")
+RULE_BOOL(Spells, HOTBonusHealingSplitOverDuration, true, "Disable to have Heal Over Time total bonus healing added to each tick instead of divided across duration")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Combat)

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -528,11 +528,10 @@ int64 Mob::GetActSpellHealing(uint16 spell_id, int64 value, Mob* target, bool fr
 				const int duration = CalcBuffDuration(this, target, spell_id);
 				if (duration > 0) {
 					extra_heal /= duration;
+					value += extra_heal;
 				}
 			}
 		}
-
-		value += extra_heal;
 
 		value *= critical_modifier;
 	}

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -285,10 +285,13 @@ int64 Mob::GetActDoTDamage(uint16 spell_id, int64 value, Mob* target, bool from_
 			extra_dmg += GetSkillDmgAmt(spells[spell_id].skill) * ratio / 100;
 		}
 
-		if (extra_dmg) {
-			int duration = CalcBuffDuration(this, target, spell_id);
-			if (duration > 0)
-				extra_dmg /= duration;
+		if (RuleB(Spells, DOTBonusDamageSplitOverDuration)) {
+			if (extra_dmg) {
+				const int duration = CalcBuffDuration(this, target, spell_id);
+				if (duration > 0) {
+					extra_dmg /= duration;
+				}
+			}
 		}
 
 		value -= extra_dmg;
@@ -328,10 +331,13 @@ int64 Mob::GetActDoTDamage(uint16 spell_id, int64 value, Mob* target, bool from_
 			extra_dmg += GetSkillDmgAmt(spells[spell_id].skill);
 		}
 
-		if (extra_dmg) {
-			int duration = CalcBuffDuration(this, target, spell_id);
-			if (duration > 0)
-				extra_dmg /= duration;
+		if (RuleB(Spells, DOTBonusDamageSplitOverDuration)) {
+			if (extra_dmg) {
+				const int duration = CalcBuffDuration(this, target, spell_id);
+				if (duration > 0) {
+					extra_dmg /= duration;
+				}
+			}
 		}
 
 		value -= extra_dmg;
@@ -517,11 +523,13 @@ int64 Mob::GetActSpellHealing(uint16 spell_id, int64 value, Mob* target, bool fr
 			}
 		}
 
-		if (extra_heal) {
-			int duration = CalcBuffDuration(this, target, spell_id);
-			if (duration > 0) {
-				extra_heal /= duration;
-				value += extra_heal;
+		if (RuleB(Spells, HOTBonusHealingSplitOverDuration)) {
+			if (extra_heal) {
+				const int duration = CalcBuffDuration(this, target, spell_id);
+				if (duration > 0) {
+					extra_heal /= duration;
+					value += extra_heal;
+				}
 			}
 		}
 

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -528,10 +528,11 @@ int64 Mob::GetActSpellHealing(uint16 spell_id, int64 value, Mob* target, bool fr
 				const int duration = CalcBuffDuration(this, target, spell_id);
 				if (duration > 0) {
 					extra_heal /= duration;
-					value += extra_heal;
 				}
 			}
 		}
+
+		value += extra_heal;
 
 		value *= critical_modifier;
 	}


### PR DESCRIPTION
# Notes
- Add `Spells:DOTDamageBonusSplitOverDuration` rule.
- Allows operators to disable the DOT bonus damage being split over duration and instead adds the full amount every tic.
- Add `Spells:HOTBonusHealingSplitOverDuration` rule.
- Allows operators to disable the HOT bonus healing being split over duration and instead adds the full amount every tic.