### PR TITLE
[UCS] Merge mailserver and chatserver configs into UCS.

### DIFF
--- a/common/eqemu_config.cpp
+++ b/common/eqemu_config.cpp
@@ -114,10 +114,10 @@ void EQEmuConfig::parse_config()
 	/**
 	 * UCS
 	 */
-	ChatHost = _root["server"]["chatserver"].get("host", "eqchat.eqemulator.net").asString();
-	ChatPort = Strings::ToUnsignedInt(_root["server"]["chatserver"].get("port", "7778").asString());
-	MailHost = _root["server"]["mailserver"].get("host", "eqmail.eqemulator.net").asString();
-	MailPort = Strings::ToUnsignedInt(_root["server"]["mailserver"].get("port", "7778").asString());
+	ChatHost = _root["server"]["ucs"].get("host", "eqchat.eqemulator.net").asString();
+	ChatPort = Strings::ToUnsignedInt(_root["server"]["ucs"].get("port", "7778").asString());
+	MailHost = _root["server"]["ucs"].get("host", "eqmail.eqemulator.net").asString();
+	MailPort = Strings::ToUnsignedInt(_root["server"]["ucs"].get("port", "7778").asString());
 
 	/**
 	 * Database

--- a/common/eqemu_config.h
+++ b/common/eqemu_config.h
@@ -62,11 +62,9 @@ class EQEmuConfig
 		std::string SharedKey;
 		bool DisableConfigChecks;
 
-		// From <chatserver/>
+		// From <ucs/>
 		std::string ChatHost;
 		uint16 ChatPort;
-
-		// From <mailserver/>
 		std::string MailHost;
 		uint16 MailPort;
 

--- a/world/world_boot.cpp
+++ b/world/world_boot.cpp
@@ -635,12 +635,12 @@ void WorldBoot::CheckForPossibleConfigurationIssues()
 		LogWarning("Docs [https://docs.eqemu.io/server/installation/configure-your-eqemu_config/#mailserver]");
 		LogWarning("");
 		LogWarning(
-			"[server.world.address] value [{}] [server.chatserver.host] [{}]",
+			"[server.world.address] value [{}] [server.ucs.host] [{}]",
 			config_address,
 			c->ChatHost
 		);
 		LogWarning(
-			"[server.world.address] value [{}] [server.mailserver.host] [{}]",
+			"[server.world.address] value [{}] [server.ucs.host] [{}]",
 			config_address,
 			c->MailHost
 		);


### PR DESCRIPTION
Fixes #700.
Requires manual adjustment of existing config files as identified below.
Old config:
```
          "mailserver" : {
               "host" : "localhost",
               "port" : "7778"
          },
          "chatserver" : {
               "host" : "localhost",
               "port" : "7778"
          },
```
New config:
```
          "ucs" : {
               "host" : "localhost",
               "port" : "7778"
          },
```

Coordination:
- [ ] Occulus
- [ ] Spire
- [ ] Akk-stack
- [x] EQEmu Docs
- [x] TalkEQ
- [x] Installer Template