### PR TITLE
[Database] Make it clearer to users that a database backup is occurring

### DIFF
--- a/common/database/database_dump_service.cpp
+++ b/common/database/database_dump_service.cpp
@@ -322,6 +322,10 @@ void DatabaseDumpService::DatabaseDump()
 			pipe_file
 		);
 
+		LogInfo("Backing up database [{}]", execute_command);
+		LogInfo("This can take a few minutes depending on the size of your database");
+		LogInfo("LOADING... PLEASE WAIT...");
+
 		BuildCredentialsFile();
 		std::string execution_result = Process::execute(execute_command);
 		if (!execution_result.empty() && IsDumpOutputToConsole()) {


### PR DESCRIPTION
It was reported in https://github.com/EQEmu/Server/issues/3731 that user feedback is not super obvious during the automatic database backup routine when we apply schema updates. This PR adds some messaging right before execution of the `mysqldump` command.

**New Messages**

```
 World |    Info    | DatabaseDump Backing up database [mysqldump --defaults-extra-file=login.my.cnf peq --allow-keywords --extended-insert --max-allowed-packet=1G --net-buffer-length=32704 --skip-lock-tables   > backups/peq-2023-12-15.sql] 
 World |    Info    | DatabaseDump This can take a few minutes depending on the size of your database 
 World |    Info    | DatabaseDump LOADING... PLEASE WAIT... 
```

**Testing**

```
 World |    Info    | LoadRules Loaded [721] rules(s) in rule_set [default] id [1] 
 World |    Info    | CheckVersionsUpToDate ---------------------------------------------------------------------- 
 World |    Info    | CheckVersionsUpToDate   Server | database [9247] binary [9248] checking updates 
 World |    Info    | CheckVersionsUpToDate   Config | [server.auto_database_updates] [true] 
 World |    Info    | CheckVersionsUpToDate ---------------------------------------------------------------------- 
 World |    Info    | UpdateManifest [9248]  [missing] | [some_new_migration.sql] 
 World |    Info    | UpdateManifest ---------------------------------------------------------------------- 
 World |    Info    | UpdateManifest Automatically backing up database before applying updates 
 World |    Info    | UpdateManifest ---------------------------------------------------------------------- 
 World |    Info    | DatabaseDump MySQL installed [mysql  Ver 15.1 Distrib 10.11.4-MariaDB, for debian-linux-gnu (x86_64) using  EditLine wrapper] 
 World |    Info    | DatabaseDump Database [peq] Host [mariadb] Username [eqemu] 
 World |    Info    | DatabaseDump Backing up database [mysqldump --defaults-extra-file=login.my.cnf peq --allow-keywords --extended-insert --max-allowed-packet=1G --net-buffer-length=32704 --skip-lock-tables   > backups/peq-2023-12-15.sql] 
 World |    Info    | DatabaseDump This can take a few minutes depending on the size of your database 
 World |    Info    | DatabaseDump LOADING... PLEASE WAIT... 
```