### PR TITLE
[Corpse] Fix /corpse command regression from #3727

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -6879,12 +6879,6 @@ void Client::Handle_OP_GMSummon(const EQApplicationPacket *app)
 		return;
 	}
 
-	if (!GetGM()) {
-		Message(Chat::Red, "Your account has been reported for hacking.");
-		RecordPlayerEventLog(PlayerEvent::POSSIBLE_HACK, PlayerEvent::PossibleHackEvent{.message = "Used /summon"});
-		return;
-	}
-
 	OPGMSummon(app);
 	return;
 }


### PR DESCRIPTION
This fixes a regression in PR #3727 that while provided a lot of good changes, regressed a functionality in `/corpse` where a function labeled `GM` is actually used by `non-gm` characters during the `/corpse` command and were getting a message that they will be reported for hacking.

**Before**

![image](https://github.com/EQEmu/Server/assets/3319450/60d7ddde-32a5-43a9-b88c-13285fae81d9)

**After**

![image](https://github.com/EQEmu/Server/assets/3319450/0a08ffb9-fdfe-4bcb-84b7-d216cc48faf9)
