### PR TITLE
[Database] When database version is greater than binary, we are up to date

### DIFF
--- a/common/database/database_update.cpp
+++ b/common/database/database_update.cpp
@@ -274,9 +274,9 @@ bool DatabaseUpdate::CheckVersionsUpToDate(DatabaseVersion v, DatabaseVersion b)
 	LogInfo("{}", Strings::Repeat("-", BREAK_LENGTH));
 
 	// server database version is required
-	bool server_up_to_date = v.server_database_version == b.server_database_version;
+	bool server_up_to_date = v.server_database_version >= b.server_database_version;
 	// bots database version is optional, if not enabled then it is always up-to-date
-	bool bots_up_to_date   = RuleB(Bots, Enabled) ? v.bots_database_version == b.bots_database_version : true;
+	bool bots_up_to_date   = RuleB(Bots, Enabled) ? v.bots_database_version >= b.bots_database_version : true;
 
 	return server_up_to_date && bots_up_to_date;
 }


### PR DESCRIPTION
This fixes a much rarer issue where you may have a database that is considered more up to date than the binaries you are running, zone will not boot because it expects the version to be **exactly the same** instead of **greater than** and terminates.

**Example**

```
  Zone |    Info    | LoadPaths server [/home/eqemu/server] 
  Zone |    Info    | LoadPaths logs path [logs] 
  Zone |    Info    | LoadPaths lua mods path [] 
  Zone |    Info    | LoadPaths lua_modules path [quests/lua_modules] 
  Zone |    Info    | LoadPaths maps path [maps] 
  Zone |    Info    | LoadPaths patches path [assets/patches] 
  Zone |    Info    | LoadPaths plugins path [quests/plugins] 
  Zone |    Info    | LoadPaths quests path [quests] 
  Zone |    Info    | LoadPaths shared_memory path [shared] 
  Zone |    Info    | main Loading server configuration 
  Zone |    Info    | main Connecting to MySQL 
  Zone |    Info    | Connect Connected to database [default] [peq] @ [mariadb:3306] 
  Zone |    Info    | LoadRules Loaded [722] rules(s) in rule_set [default] id [1] 
  Zone |    Info    | LoadLogDatabaseSettings Loaded [73] log categories 
  Zone |    Info    | StartFileLogs Starting File Log [logs/zone/zone_8397.log] 
  Zone |    Info    | CheckVersionsUpToDate ---------------------------------------------------------------------- 
  Zone |    Info    | CheckVersionsUpToDate   Server | database [9248] binary [9246] checking updates 
  Zone |    Info    | CheckVersionsUpToDate   Config | [server.auto_database_updates] [true] 
  Zone |    Info    | CheckVersionsUpToDate ---------------------------------------------------------------------- 
  Zone |  Warning   | main Database is not up to date [world] needs to be ran to apply updates, shutting down in 5 seconds 
```