### PR TITLE
[Bots] Fix ^oo autodefend from sending bots/pets to invalid haters

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -2346,7 +2346,7 @@ bool Bot::TryAutoDefend(Client* bot_owner, float leash_distance) {
 					}
 
 					auto hater = entity_list.GetMob(hater_iter.spawn_id);
-					if (hater && !hater->IsMezzed() && DistanceSquared(hater->GetPosition(), bot_owner->GetPosition()) <= leash_distance) {
+					if (hater && hater->CastToNPC()->IsOnHatelist(bot_owner) && !hater->IsMezzed() && DistanceSquared(hater->GetPosition(), bot_owner->GetPosition()) <= leash_distance) {
 						// This is roughly equivilent to npc attacking a client pet owner
 						AddToHateList(hater, 1);
 						SetTarget(hater);


### PR DESCRIPTION
Bots and especially their pets could get in a loop where they try to attack an invalid target. This would result in their pets spamming "That is not a legal target" messages.