### PR TITLE
[Quest API] Add GetNPCAggro() and SetNPCAggro() to Perl/Lua

### DIFF
--- a/zone/aggro.cpp
+++ b/zone/aggro.cpp
@@ -46,7 +46,7 @@ void EntityList::DescribeAggro(Client *to_who, NPC *from_who, float d, bool verb
 	);
 
 	bool is_engaged = from_who->IsEngaged();
-	bool will_aggro_npcs = from_who->WillAggroNPCs();
+	bool will_aggro_npcs = from_who->GetNPCAggro();
 	if (is_engaged) {
 		Mob *top = from_who->GetHateTop();
 		to_who->Message(

--- a/zone/api_service.cpp
+++ b/zone/api_service.cpp
@@ -245,7 +245,7 @@ Json::Value ApiGetNpcListDetail(EQ::Net::WebsocketServerConnection *connection, 
 		row["swarm_owner"]     = npc->GetSwarmOwner();
 		row["swarm_target"]    = npc->GetSwarmTarget();
 		row["waypoint_max"]    = npc->GetWaypointMax();
-		row["will_aggro_npcs"] = npc->WillAggroNPCs();
+		row["will_aggro_npcs"] = npc->GetNPCAggro();
 
 		response.append(row);
 	}

--- a/zone/api_service.cpp
+++ b/zone/api_service.cpp
@@ -245,7 +245,7 @@ Json::Value ApiGetNpcListDetail(EQ::Net::WebsocketServerConnection *connection, 
 		row["swarm_owner"]     = npc->GetSwarmOwner();
 		row["swarm_target"]    = npc->GetSwarmTarget();
 		row["waypoint_max"]    = npc->GetWaypointMax();
-		row["will_aggro_npcs"] = npc->GetNPCAggro();
+		row["npc_aggro"]       = npc->GetNPCAggro();
 
 		response.append(row);
 	}

--- a/zone/lua_npc.cpp
+++ b/zone/lua_npc.cpp
@@ -813,6 +813,18 @@ void Lua_NPC::SetBucket(std::string bucket_name, std::string bucket_value, std::
 	self->SetBucket(bucket_name, bucket_value, expiration);
 }
 
+bool Lua_NPC::GetNPCAggro()
+{
+	Lua_Safe_Call_Bool();
+	return self->GetNPCAggro();
+}
+
+void Lua_NPC::SetNPCAggro(bool in_npc_aggro)
+{
+	Lua_Safe_Call_Void();
+	self->SetNPCAggro(in_npc_aggro);
+}
+
 luabind::scope lua_register_npc() {
 	return luabind::class_<Lua_NPC, Lua_Mob>("NPC")
 	.def(luabind::constructor<>())
@@ -872,6 +884,7 @@ luabind::scope lua_register_npc() {
 	.def("GetLDoNLockedSkill", (uint16(Lua_NPC::*)(void))&Lua_NPC::GetLDoNLockedSkill)
 	.def("GetLDoNTrapType", (uint8(Lua_NPC::*)(void))&Lua_NPC::GetLDoNTrapType)
 	.def("GetLDoNTrapSpellID", (uint16(Lua_NPC::*)(void))&Lua_NPC::GetLDoNTrapSpellID)
+	.def("GetNPCAggro", (bool(Lua_NPC::*)(void))&Lua_NPC::GetNPCAggro)
 	.def("GetNPCFactionID", (int(Lua_NPC::*)(void))&Lua_NPC::GetNPCFactionID)
 	.def("GetNPCHate", (int64(Lua_NPC::*)(Lua_Mob))&Lua_NPC::GetNPCHate)
 	.def("GetNPCSpellsID", (int(Lua_NPC::*)(void))&Lua_NPC::GetNPCSpellsID)
@@ -949,6 +962,7 @@ luabind::scope lua_register_npc() {
 	.def("SetLDoNTrapDetected", (void(Lua_NPC::*)(bool))&Lua_NPC::SetLDoNTrapDetected)
 	.def("SetLDoNTrapSpellID", (void(Lua_NPC::*)(uint16))&Lua_NPC::SetLDoNTrapSpellID)
 	.def("SetLDoNTrapType", (void(Lua_NPC::*)(uint8))&Lua_NPC::SetLDoNTrapType)
+	.def("SetNPCAggro", (void(Lua_NPC::*)(bool))&Lua_NPC::SetNPCAggro)
 	.def("SetNPCFactionID", (void(Lua_NPC::*)(int))&Lua_NPC::SetNPCFactionID)
 	.def("SetPetSpellID", (void(Lua_NPC::*)(int))&Lua_NPC::SetPetSpellID)
 	.def("SetPlatinum", (void(Lua_NPC::*)(uint32))&Lua_NPC::SetPlatinum)

--- a/zone/lua_npc.h
+++ b/zone/lua_npc.h
@@ -182,6 +182,8 @@ public:
 	std::string GetBucketRemaining(std::string bucket_name);
 	void SetBucket(std::string bucket_name, std::string bucket_value);
 	void SetBucket(std::string bucket_name, std::string bucket_value, std::string expiration);
+	bool GetNPCAggro();
+	void SetNPCAggro(bool in_npc_aggro);
 };
 
 #endif

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -448,7 +448,7 @@ void Mob::AI_Start(uint32 iMoveDelay) {
 		hate_list_cleanup_timer.Disable();
 	}
 
-	if (CastToNPC()->WillAggroNPCs())
+	if (CastToNPC()->GetNPCAggro())
 		AI_scan_area_timer = std::make_unique<Timer>(RandomTimer(RuleI(NPC, NPCToNPCAggroTimerMin), RuleI(NPC, NPCToNPCAggroTimerMax)));
 
 	AI_check_signal_timer = std::make_unique<Timer>(AI_check_signal_timer_delay);
@@ -1066,7 +1066,7 @@ void Mob::AI_Process() {
 					IsNPC() &&
 					!CastToNPC()->GetSwarmInfo() &&
 					(!IsPet() || (HasOwner() && GetOwner()->IsNPC())) &&
-					!CastToNPC()->WillAggroNPCs()
+					!CastToNPC()->GetNPCAggro()
 				) {
 					WipeHateList(true); // wipe NPCs from hate list to prevent faction war
 				}
@@ -1386,7 +1386,7 @@ void Mob::AI_Process() {
 				StopNavigation();
 			}
 		}
-		else if (zone->CanDoCombat() && CastToNPC()->WillAggroNPCs() && AI_scan_area_timer->Check()) {
+		else if (zone->CanDoCombat() && CastToNPC()->GetNPCAggro() && AI_scan_area_timer->Check()) {
 
 			/**
 			 * NPC to NPC aggro (npc_aggro flag set)

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -394,7 +394,8 @@ public:
 	int		GetNumMercs() { return static_cast<int>(mercDataList.size()); };
 	int		GetNumMercs( uint32 expansion );
 
-	inline bool WillAggroNPCs() const { return(npc_aggro); }
+	inline bool GetNPCAggro() const { return npc_aggro; }
+	inline void SetNPCAggro(bool in_npc_aggro) { npc_aggro = in_npc_aggro; }
 
 	inline void GiveNPCTypeData(NPCType *ours) { NPCTypedata_ours = ours; }
 	inline const uint32 GetNPCSpellsID()	const { return npc_spells_id; }

--- a/zone/perl_npc.cpp
+++ b/zone/perl_npc.cpp
@@ -775,6 +775,17 @@ bool Perl_NPC_HasSpecialAbilities(NPC* self) // @categories Script Utility
 	return self->HasSpecialAbilities();
 }
 
+bool Perl_NPC_GetNPCAggro(NPC* self) // @categories Script Utility
+{
+	return self->GetNPCAggro();
+}
+
+void Perl_NPC_SetNPCAggro(NPC* self, bool in_npc_aggro) // @categories Script Utility
+{
+	self->SetNPCAggro(in_npc_aggro);
+}
+
+
 void perl_register_npc()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -836,6 +847,7 @@ void perl_register_npc()
 	package.add("GetMaxDamage", &Perl_NPC_GetMaxDamage);
 	package.add("GetMaxWp", &Perl_NPC_GetMaxWp);
 	package.add("GetMinDMG", &Perl_NPC_GetMinDMG);
+	package.add("GetNPCAggro", &Perl_NPC_GetNPCAggro);
 	package.add("GetNPCFactionID", &Perl_NPC_GetNPCFactionID);
 	package.add("GetNPCHate", &Perl_NPC_GetNPCHate);
 	package.add("GetNPCSpellsID", &Perl_NPC_GetNPCSpellsID);
@@ -911,6 +923,7 @@ void perl_register_npc()
 	package.add("SetLDoNTrapDetected", &Perl_NPC_SetLDoNTrapDetected);
 	package.add("SetLDoNTrapSpellID", &Perl_NPC_SetLDoNTrapSpellID);
 	package.add("SetLDoNTrapType", &Perl_NPC_SetLDoNTrapType);
+	package.add("SetNPCAggro", &Perl_NPC_SetNPCAggro);
 	package.add("SetGold", &Perl_NPC_SetGold);
 	package.add("SetGrid", &Perl_NPC_SetGrid);
 	package.add("SetNPCFactionID", &Perl_NPC_SetNPCFactionID);


### PR DESCRIPTION
# Perl
- Add `$npc->GetNPCAggro()`.
- Add `$npc->SetNPCAggro(in_npc_aggro)`.

# Lua
- Add `npc:GetNPCAggro()`.
- Add `npc:SetNPCAggro(in_npc_aggro)`.

# Notes
- Allows operators to enable or disable an NPC's NPC aggro capability dynamically.