### PR TITLE
[Bots] Add ScanCloseMobs support to fix AEs

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -1669,7 +1669,7 @@ bool Bot::Process()
 			mob_close_scan_timer.GetDuration()
 		);
 
-		entity_list.ScanCloseClientMobs(close_mobs, this);
+		entity_list.ScanCloseMobs(close_mobs, this, IsMoving());
 	}
 
 	SpellProcess();


### PR DESCRIPTION
Previously bots were only scanning for nearby clients so any AE spells or procs didn't have mobs to hit.

This changes that to scan for mobs instead of clients so their close entity list supports AEs with mobs to hit.