### PR TITLE
[Bug Fix] Disable Hide/Improved Hide on Trap damage

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -6287,6 +6287,7 @@ void Client::Handle_OP_EnvDamage(const EQApplicationPacket *app)
 
 		if (ed->dmgtype == EQ::constants::EnvironmentalDamage::Trap) {
 			BreakInvisibleSpells();
+			CancelSneakHide();
 		}
 	}
 


### PR DESCRIPTION
# Notes
- Further fixes an issue where traps don't drop hide/invisible.