### PR TITLE
[Bug Fix] Fix can_riposte parameter in DoMeleeSkillAttackDmg

### DIFF
--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1121,7 +1121,7 @@ public:
 
 	void DoSpecialAttackDamage(Mob *who, EQ::skills::SkillType skill, int base_damage, int min_damage = 0, int32 hate_override = -1, int ReuseTime = 10);
 	void DoThrowingAttackDmg(Mob* other, const EQ::ItemInstance* RangeWeapon = nullptr, const EQ::ItemData* AmmoItem = nullptr, int32 weapon_damage = 0, int16 chance_mod = 0, int16 focus = 0, int ReuseTime = 0, uint32 range_id = 0, int AmmoSlot = 0, float speed = 4.0f, bool DisableProcs = false);
-	void DoMeleeSkillAttackDmg(Mob* other, int32 weapon_damage, EQ::skills::SkillType skillinuse, int16 chance_mod = 0, int16 focus = 0, bool CanRiposte = false, int ReuseTime = 0);
+	void DoMeleeSkillAttackDmg(Mob* other, int32 weapon_damage, EQ::skills::SkillType skillinuse, int16 chance_mod = 0, int16 focus = 0, bool can_riposte = false, int ReuseTime = 0);
 	void DoArcheryAttackDmg(Mob* other, const EQ::ItemInstance* RangeWeapon = nullptr, const EQ::ItemInstance* Ammo = nullptr, int32 weapon_damage = 0, int16 chance_mod = 0, int16 focus = 0, int ReuseTime = 0, uint32 range_id = 0, uint32 ammo_id = 0, const EQ::ItemData *AmmoItem = nullptr, int AmmoSlot = 0, float speed = 4.0f, bool DisableProcs = false);
 	bool TryProjectileAttack(Mob* other, const EQ::ItemData *item, EQ::skills::SkillType skillInUse, uint64 weapon_dmg, const EQ::ItemInstance* RangeWeapon, const EQ::ItemInstance* Ammo, int AmmoSlot, float speed, bool DisableProcs = false);
 	void ProjectileAttack();

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -2385,7 +2385,7 @@ int Mob::TryAssassinate(Mob *defender, EQ::skills::SkillType skillInUse)
 }
 
 void Mob::DoMeleeSkillAttackDmg(Mob *other, int32 weapon_damage, EQ::skills::SkillType skillinuse, int16 chance_mod,
-				int16 focus, bool CanRiposte, int ReuseTime)
+				int16 focus, bool can_riposte, int ReuseTime)
 {
 	if (!CanDoSpecialAttack(other)) {
 		return;
@@ -2425,15 +2425,14 @@ void Mob::DoMeleeSkillAttackDmg(Mob *other, int32 weapon_damage, EQ::skills::Ski
 		}
 
 		DamageHitInfo my_hit {};
-		my_hit.base_damage = weapon_damage;
-		my_hit.min_damage = 0;
-		my_hit.damage_done = 1;
 
-		my_hit.skill = skillinuse;
-		my_hit.offense = offense(my_hit.skill);
-		my_hit.tohit = GetTotalToHit(my_hit.skill, chance_mod);
-		// slot range exclude ripe etc ...
-		my_hit.hand = CanRiposte ? EQ::invslot::slotRange : EQ::invslot::slotPrimary;
+		my_hit.base_damage = weapon_damage;
+		my_hit.min_damage  = 0;
+		my_hit.damage_done = 1;
+		my_hit.skill       = skillinuse;
+		my_hit.offense     = offense(my_hit.skill);
+		my_hit.tohit       = GetTotalToHit(my_hit.skill, chance_mod);
+		my_hit.hand        = can_riposte ? EQ::invslot::slotPrimary : EQ::invslot::slotRange;
 
 		if (IsNPC()) {
 			my_hit.min_damage = CastToNPC()->GetMinDamage();


### PR DESCRIPTION
# Note
- `can_riposte` logic was reverse, setting to `true` caused the attack to not be able to be riposted, the opposite of the intended functionality.