### PR TITLE
[Bots] Remove unnecessary error on SetItemReuse

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -2765,9 +2765,6 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, CastingSlot slot, in
 			CastToBot()->SetItemReuseTimer(item->ID);
 			CastToBot()->SetIsUsingItemClick(false);
 		}
-		else {
-			GetOwner()->Message(Chat::Red, "%s says, 'Failed to set item reuse timer for %s.", GetCleanName());
-		}
 	}
 
 	if (IsNPC()) {


### PR DESCRIPTION
This error is not necessary as it can be triggered when clicked spells have secondary effects that run through the same spell checks for clicked items but aren't actually clicked by the item. Spells that trigger other spell effects and some Bard scaling songs could trigger this after the initial click.