### PR TITLE
[Rules] Rule to disable Common Forage Items

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -215,6 +215,7 @@ RULE_BOOL(Character, EnableRaidEXPModifier, true, "Enable or disable the raid ex
 RULE_BOOL(Character, EnableRaidMemberEXPModifier, true, "Enable or disable the raid experience modifier based on members in raid, default is true")
 RULE_BOOL(Character, LeaveCursorMoneyOnCorpse, false, "Enable or disable leaving cursor money on player corpses")
 RULE_BOOL(Character, ItemExtraSkillDamageCalcAsPercent, false, "If enabled, apply Item Extra Skill Damage as Percentage-based modifiers")
+RULE_BOOL(Character, UseForageCommonFood, true, "If enabled, use the common foods specified in the code.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Mercs)

--- a/zone/forage.cpp
+++ b/zone/forage.cpp
@@ -456,7 +456,7 @@ void Client::ForageItem(bool guarantee) {
 		}
 
 		//not an else in case theres no DB food
-		if (foragedfood == 0) {
+		if (foragedfood == 0 && RuleB(Character, UseForageCommonFood)) {
 			uint8 index = 0;
 			index = zone->random.Int(0, MAX_COMMON_FOOD_IDS-1);
 			foragedfood = common_food_ids[index];


### PR DESCRIPTION
# Notes
- Adds a rule to disabled using common_food_ids from the list in forage.cpp.  currently set to enabled.