### PR TITLE
[Character] Fix character copier due to schema change

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -2279,6 +2279,10 @@ bool Database::CopyCharacter(
 				std::string column = columns[column_index];
 				std::string value  = row[column_index] ? row[column_index] : "null";
 
+				if (table_name == "keyring" && column == "id") {
+					value = "0";
+				}
+
 				if (column == character_id_column_name) {
 					value = new_character_id;
 				}

--- a/common/database.cpp
+++ b/common/database.cpp
@@ -2246,6 +2246,11 @@ bool Database::CopyCharacter(
 	row     = results.begin();
 	std::string new_character_id = row[0];
 
+	std::vector<std::string> tables_to_zero_id = {
+		"keyring",
+		"data_buckets",
+	};
+
 	TransactionBegin();
 	for (const auto &iter : DatabaseSchema::GetCharacterTables()) {
 		std::string table_name               = iter.first;
@@ -2279,7 +2284,7 @@ bool Database::CopyCharacter(
 				std::string column = columns[column_index];
 				std::string value  = row[column_index] ? row[column_index] : "null";
 
-				if (table_name == "keyring" && column == "id") {
+				if (column == "id" && Strings::Contains(tables_to_zero_id, table_name)) {
 					value = "0";
 				}
 
@@ -2330,7 +2335,6 @@ bool Database::CopyCharacter(
 			if (!insert.ErrorMessage().empty()) {
 				TransactionRollback();
 				return false;
-				break;
 			}
 		}
 	}

--- a/common/database_schema.h
+++ b/common/database_schema.h
@@ -71,7 +71,7 @@ namespace DatabaseSchema {
 			{"character_tasks",                "charid"},
 			{"character_tribute",              "character_id"},
 			{"completed_tasks",                "charid"},
-			{"data_buckets",                   "id"},
+			{"data_buckets",                   "character_id"},
 			{"faction_values",                 "char_id"},
 			{"friends",                        "charid"},
 			{"guild_members",                  "char_id"},


### PR DESCRIPTION
Due to schema change in https://github.com/EQEmu/Server/pull/3746 the character copier breaks because it attempts to copy the same auto inc id from the source character. This change sets `id` to `0` so the database engine assigns a new auto inc id for the destination row

![image](https://github.com/EQEmu/Server/assets/3319450/a2711e46-e08a-47e8-a219-b39965380ba3)

**This needs to be actually tested**