### PR TITLE
[Player Events] Bulk replace settings on boot

### DIFF
--- a/common/repositories/base/base_player_event_log_settings_repository.h
+++ b/common/repositories/base/base_player_event_log_settings_repository.h
@@ -6,7 +6,7 @@
  * Any modifications to base repositories are to be made by the generator only
  *
  * @generator ./utils/scripts/generators/repository-generator.pl
- * @docs https://eqemu.gitbook.io/server/in-development/developer-area/repositories
+ * @docs https://docs.eqemu.io/developer/repositories
  */
 
 #ifndef EQEMU_BASE_PLAYER_EVENT_LOG_SETTINGS_REPOSITORY_H
@@ -15,6 +15,7 @@
 #include "../../database.h"
 #include "../../strings.h"
 #include <ctime>
+
 
 class BasePlayerEventLogSettingsRepository {
 public:
@@ -359,6 +360,70 @@ public:
 		return (results.Success() && results.begin()[0] ? strtoll(results.begin()[0], nullptr, 10) : 0);
 	}
 
+	static std::string BaseReplace()
+	{
+		return fmt::format(
+			"REPLACE INTO {} ({}) ",
+			TableName(),
+			ColumnsRaw()
+		);
+	}
+
+	static int ReplaceOne(
+		Database& db,
+		const PlayerEventLogSettings &e
+	)
+	{
+		std::vector<std::string> v;
+
+		v.push_back(std::to_string(e.id));
+		v.push_back("'" + Strings::Escape(e.event_name) + "'");
+		v.push_back(std::to_string(e.event_enabled));
+		v.push_back(std::to_string(e.retention_days));
+		v.push_back(std::to_string(e.discord_webhook_id));
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} VALUES ({})",
+				BaseReplace(),
+				Strings::Implode(",", v)
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
+
+	static int ReplaceMany(
+		Database& db,
+		const std::vector<PlayerEventLogSettings> &entries
+	)
+	{
+		std::vector<std::string> insert_chunks;
+
+		for (auto &e: entries) {
+			std::vector<std::string> v;
+
+			v.push_back(std::to_string(e.id));
+			v.push_back("'" + Strings::Escape(e.event_name) + "'");
+			v.push_back(std::to_string(e.event_enabled));
+			v.push_back(std::to_string(e.retention_days));
+			v.push_back(std::to_string(e.discord_webhook_id));
+
+			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
+		}
+
+		std::vector<std::string> v;
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} VALUES {}",
+				BaseReplace(),
+				Strings::Implode(",", insert_chunks)
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
 };
 
 #endif //EQEMU_BASE_PLAYER_EVENT_LOG_SETTINGS_REPOSITORY_H

--- a/common/repositories/base/base_player_event_logs_repository.h
+++ b/common/repositories/base/base_player_event_logs_repository.h
@@ -6,7 +6,7 @@
  * Any modifications to base repositories are to be made by the generator only
  *
  * @generator ./utils/scripts/generators/repository-generator.pl
- * @docs https://eqemu.gitbook.io/server/in-development/developer-area/repositories
+ * @docs https://docs.eqemu.io/developer/repositories
  */
 
 #ifndef EQEMU_BASE_PLAYER_EVENT_LOGS_REPOSITORY_H
@@ -240,8 +240,8 @@ public:
 		v.push_back(columns[7] + " = " + std::to_string(e.z));
 		v.push_back(columns[8] + " = " + std::to_string(e.heading));
 		v.push_back(columns[9] + " = " + std::to_string(e.event_type_id));
-		v.push_back(columns[10] + " = '" + db.Escape(e.event_type_name) + "'");
-		v.push_back(columns[11] + " = '" + db.Escape(e.event_data) + "'");
+		v.push_back(columns[10] + " = '" + Strings::Escape(e.event_type_name) + "'");
+		v.push_back(columns[11] + " = '" + Strings::Escape(e.event_data) + "'");
 		v.push_back(columns[12] + " = FROM_UNIXTIME(" + (e.created_at > 0 ? std::to_string(e.created_at) : "null") + ")");
 
 		auto results = db.QueryDatabase(
@@ -274,8 +274,8 @@ public:
 		v.push_back(std::to_string(e.z));
 		v.push_back(std::to_string(e.heading));
 		v.push_back(std::to_string(e.event_type_id));
-		v.push_back("'" + db.Escape(e.event_type_name) + "'");
-		v.push_back("'" + db.Escape(e.event_data) + "'");
+		v.push_back("'" + Strings::Escape(e.event_type_name) + "'");
+		v.push_back("'" + Strings::Escape(e.event_data) + "'");
 		v.push_back("FROM_UNIXTIME(" + (e.created_at > 0 ? std::to_string(e.created_at) : "null") + ")");
 
 		auto results = db.QueryDatabase(
@@ -316,8 +316,8 @@ public:
 			v.push_back(std::to_string(e.z));
 			v.push_back(std::to_string(e.heading));
 			v.push_back(std::to_string(e.event_type_id));
-			v.push_back("'" + db.Escape(e.event_type_name) + "'");
-			v.push_back("'" + db.Escape(e.event_data) + "'");
+			v.push_back("'" + Strings::Escape(e.event_type_name) + "'");
+			v.push_back("'" + Strings::Escape(e.event_data) + "'");
 			v.push_back("FROM_UNIXTIME(" + (e.created_at > 0 ? std::to_string(e.created_at) : "null") + ")");
 
 			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
@@ -460,6 +460,86 @@ public:
 		return (results.Success() && results.begin()[0] ? strtoll(results.begin()[0], nullptr, 10) : 0);
 	}
 
+	static std::string BaseReplace()
+	{
+		return fmt::format(
+			"REPLACE INTO {} ({}) ",
+			TableName(),
+			ColumnsRaw()
+		);
+	}
+
+	static int ReplaceOne(
+		Database& db,
+		const PlayerEventLogs &e
+	)
+	{
+		std::vector<std::string> v;
+
+		v.push_back(std::to_string(e.id));
+		v.push_back(std::to_string(e.account_id));
+		v.push_back(std::to_string(e.character_id));
+		v.push_back(std::to_string(e.zone_id));
+		v.push_back(std::to_string(e.instance_id));
+		v.push_back(std::to_string(e.x));
+		v.push_back(std::to_string(e.y));
+		v.push_back(std::to_string(e.z));
+		v.push_back(std::to_string(e.heading));
+		v.push_back(std::to_string(e.event_type_id));
+		v.push_back("'" + Strings::Escape(e.event_type_name) + "'");
+		v.push_back("'" + Strings::Escape(e.event_data) + "'");
+		v.push_back("FROM_UNIXTIME(" + (e.created_at > 0 ? std::to_string(e.created_at) : "null") + ")");
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} VALUES ({})",
+				BaseReplace(),
+				Strings::Implode(",", v)
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
+
+	static int ReplaceMany(
+		Database& db,
+		const std::vector<PlayerEventLogs> &entries
+	)
+	{
+		std::vector<std::string> insert_chunks;
+
+		for (auto &e: entries) {
+			std::vector<std::string> v;
+
+			v.push_back(std::to_string(e.id));
+			v.push_back(std::to_string(e.account_id));
+			v.push_back(std::to_string(e.character_id));
+			v.push_back(std::to_string(e.zone_id));
+			v.push_back(std::to_string(e.instance_id));
+			v.push_back(std::to_string(e.x));
+			v.push_back(std::to_string(e.y));
+			v.push_back(std::to_string(e.z));
+			v.push_back(std::to_string(e.heading));
+			v.push_back(std::to_string(e.event_type_id));
+			v.push_back("'" + Strings::Escape(e.event_type_name) + "'");
+			v.push_back("'" + Strings::Escape(e.event_data) + "'");
+			v.push_back("FROM_UNIXTIME(" + (e.created_at > 0 ? std::to_string(e.created_at) : "null") + ")");
+
+			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
+		}
+
+		std::vector<std::string> v;
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} VALUES {}",
+				BaseReplace(),
+				Strings::Implode(",", insert_chunks)
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
 };
 
 #endif //EQEMU_BASE_PLAYER_EVENT_LOGS_REPOSITORY_H


### PR DESCRIPTION
This fixes an issue where on initial installation of an emulator server, we can see an error because multiple processes detect that they don't have event settings and then inject them on bootup simultaneously. Under most current circumstances of server, this is never a problem. This presents a scenario where the first process succeeds but then the rest throw errors thinking they don't have the events in the database and try to insert them themselves. By doing a `ReplaceMany` we solve two things

1) We no longer throw errors when two process initialize the same settings. 
2) Less database calls during initialization by doing bulk insertion

**Problem**

![image](https://github.com/EQEmu/Server/assets/3319450/a626dd8c-30a2-488c-a52f-bd64200c4b40)

**Testing**

```
 World |    Info    | Init [New] PlayerEvent [GM Command] (1) 
 World |    Info    | Init [New] PlayerEvent [Zoning] (2) 
 World |    Info    | Init [New] PlayerEvent [AA Gain] (3) 
 World |    Info    | Init [New] PlayerEvent [AA Purchase] (4) 
 World |    Info    | Init [New] PlayerEvent [Forage Success] (5) 
 World |    Info    | Init [New] PlayerEvent [Forage Failure] (6) 
 World |    Info    | Init [New] PlayerEvent [Fish Success] (7) 
 World |    Info    | Init [New] PlayerEvent [Fish Failure] (8) 
 World |    Info    | Init [New] PlayerEvent [Item Destroy] (9) 
 World |    Info    | Init [New] PlayerEvent [Went Online] (10) 
 World |    Info    | Init [New] PlayerEvent [Went Offline] (11) 
 World |    Info    | Init [New] PlayerEvent [Level Gain] (12) 
 World |    Info    | Init [New] PlayerEvent [Level Loss] (13) 
 World |    Info    | Init [New] PlayerEvent [Loot Item] (14) 
 World |    Info    | Init [New] PlayerEvent [Merchant Purchase] (15) 
 World |    Info    | Init [New] PlayerEvent [Merchant Sell] (16) 
 World |    Info    | Init [New] PlayerEvent [Groundspawn Pickup] (21) 
 World |    Info    | Init [New] PlayerEvent [NPC Handin] (22) 
 World |    Info    | Init [New] PlayerEvent [Skill Up] (23) 
 World |    Info    | Init [New] PlayerEvent [Task Accept] (24) 
 World |    Info    | Init [New] PlayerEvent [Task Update] (25) 
 World |    Info    | Init [New] PlayerEvent [Task Complete] (26) 
 World |    Info    | Init [New] PlayerEvent [Trade] (27) 
 World |    Info    | Init [New] PlayerEvent [Say] (29) 
 World |    Info    | Init [New] PlayerEvent [Rez Accepted] (30) 
 World |    Info    | Init [New] PlayerEvent [Death] (31) 
 World |    Info    | Init [New] PlayerEvent [Combine Failure] (32) 
 World |    Info    | Init [New] PlayerEvent [Combine Success] (33) 
 World |    Info    | Init [New] PlayerEvent [Dropped Item] (34) 
 World |    Info    | Init [New] PlayerEvent [Split Money] (35) 
 World |    Info    | Init [New] PlayerEvent [Trader Purchase] (38) 
 World |    Info    | Init [New] PlayerEvent [Trader Sell] (39) 
 World |    Info    | Init [New] PlayerEvent [Discover Item] (42) 
 World |    Info    | Init [New] PlayerEvent [Possible Hack] (43) 
 World |    Info    | Init [New] PlayerEvent [Killed NPC] (44) 
 World |    Info    | Init [New] PlayerEvent [Killed Named NPC] (45) 
 World |    Info    | Init [New] PlayerEvent [Killed Raid NPC] (46) 
 World |    Info    | Init [New] PlayerEvent [Item Creation] (47) 
 World |   Query    | QueryDatabase REPLACE INTO player_event_log_settings (id, event_name, event_enabled, retention_days, discord_webhook_id)  VALUES (1,'GM Command',1,7,0),(2,'Zoning',1,7,0),(3,'AA Gain',1,7,0),(4,'AA Purchase',1,7,0),(5,'Forage Success',0,7,0),(6,'Forage Failure',0,7,0),(7,'Fish Success',0,7,0),(8,'Fish Failure',0,7,0),(9,'Item Destroy',1,7,0),(10,'Went Online',0,7,0),(11,'Went Offline',0,7,0),(12,'Level Gain',1,7,0),(13,'Level Loss',1,7,0),(14,'Loot Item',1,7,0),(15,'Merchant Purchase',1,7,0),(16,'Merchant Sell',1,7,0),(21,'Groundspawn Pickup',1,7,0),(22,'NPC Handin',1,7,0),(23,'Skill Up',0,7,0),(24,'Task Accept',1,7,0),(25,'Task Update',1,7,0),(26,'Task Complete',1,7,0),(27,'Trade',1,7,0),(29,'Say',0,7,0),(30,'Rez Accepted',1,7,0),(31,'Death',1,7,0),(32,'Combine Failure',1,7,0),(33,'Combine Success',1,7,0),(34,'Dropped Item',1,7,0),(35,'Split Money',1,7,0),(38,'Trader Purchase',1,7,0),(39,'Trader Sell',1,7,0),(42,'Discover Item',1,7,0),(43,'Possible Hack',1,7,0),(44,'Killed NPC',0,7,0),(45,'Killed Named NPC',1,7,0),(46,'Killed Raid NPC',1,7,0),(47,'Item Creation',1,7,0) -- (38 rows affected) (0.001938s)
```