### PR TITLE
[Objects] Remove "No objects to load for zone" error message

### DIFF
--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -182,10 +182,6 @@ bool Zone::LoadZoneObjects()
 			ContentFilterCriteria::apply()
 		)
 	);
-	if (l.empty()) {
-		LogWarning("No Objects to load for Zone [{}] Version [{}]", zoneid, instanceversion);
-		return false;
-	}
 
 	for (const auto &e : l) {
 		if (e.type == ObjectTypes::StaticLocked) {


### PR DESCRIPTION
When you boot a zone that has zero objects, we throw a warning and an error which neither are informative or helpful during normal **Info** channel loading mechanisms. We already print `Loaded [{}] world objects` which is informative whether that count is 0 or non-zero. This PR removes the error / warning message.

**Example**

![image](https://github.com/EQEmu/Server/assets/3319450/6b43232f-58b4-4582-b1e9-102eeab67f2d)
