### PR TITLE
[MySQL] Fix MySQL Query error formatting

### DIFF
--- a/common/dbcore.cpp
+++ b/common/dbcore.cpp
@@ -138,7 +138,7 @@ MySQLRequestResult DBcore::QueryDatabase(const char *query, uint32 querylen, boo
 		 * Error logging
 		 */
 		if (mysql_errno(mysql) > 0 && query[0] != '\0') {
-			LogMySQLError("[{}] [{}]\n[{}]", mysql_errno(mysql), mysql_error(mysql), query);
+			LogMySQLError("MySQL Error ({}) [{}] Query [{}]", mysql_errno(mysql), mysql_error(mysql), query);
 		}
 
 		return MySQLRequestResult(nullptr, 0, 0, 0, 0, mysql_errno(mysql), errorBuffer);


### PR DESCRIPTION
Ever since our console logging overhaul, the MySQL query error logging has had strange logging. This PR fixes that.

**Before**

![image](https://github.com/EQEmu/Server/assets/3319450/dad6aa1f-bcb5-4bf3-9d9c-e620910a167a)

```
  Zone |  QueryErr  | QueryDatabase [1054] [Unknown column 'can_hear' in 'field [list'
SELECT] guild_id,`rank`,title,can_hear,can_speak,can_invite,can_remove,can_promote,can_demote,can_motd,can_warpeace FROM guild_ranks] 
```

**After**

![image](https://github.com/EQEmu/Server/assets/3319450/1e0e21da-d01d-4e2b-9d5c-66c377784242)

```
  Zone |  QueryErr  | QueryDatabase MySQL Error (1054) [Unknown column 'can_hear' in 'field list'] Query [SELECT guild_id,`rank`,title,can_hear,can_speak,can_invite,can_remove,can_promote,can_demote,can_motd,can_warpeace FROM guild_ranks] 
```

