### PR TITLE
[Logs] Reclassify unhelpful Info message

### DIFF
--- a/common/events/player_event_logs.cpp
+++ b/common/events/player_event_logs.cpp
@@ -611,7 +611,7 @@ void PlayerEventLogs::Process()
 
 void PlayerEventLogs::ProcessRetentionTruncation()
 {
-	LogInfo("Running truncation");
+	LogPlayerEvents("Running truncation");
 
 	for (int i = PlayerEvent::GM_COMMAND; i != PlayerEvent::MAX; i++) {
 		if (m_settings[i].retention_days > 0) {


### PR DESCRIPTION
After a period of time the world console can be filled with the following messages which aren't necessarily helpful unless you're a developer debugging timing, in which you can use player event logging to debug that part of the code.

As a server operator you are otherwise told when and how many events were truncated and those events on show when any events were actually truncated.

**Example Message**

```
 World |    Info    | ProcessRetentionTruncation Running truncation
 World |    Info    | ProcessRetentionTruncation Running truncation
 World |    Info    | ProcessRetentionTruncation Running truncation
 World |    Info    | ProcessRetentionTruncation Running truncation
 World |    Info    | ProcessRetentionTruncation Running truncation
 World |    Info    | ProcessRetentionTruncation Running truncation
 World |    Info    | ProcessRetentionTruncation Running truncation
 World |    Info    | ProcessRetentionTruncation Running truncation
 World |    Info    | ProcessRetentionTruncation Running truncation
 World |    Info    | ProcessRetentionTruncation Running truncation
 World |    Info    | ProcessRetentionTruncation Running truncation
 World |    Info    | ProcessRetentionTruncation Running truncation
 World |    Info    | ProcessRetentionTruncation Running truncation
 World |    Info    | ProcessRetentionTruncation Running truncation
```