### PR TITLE
[Combat] Disarm was not dropping item to ground due to bug

### DIFF
--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -1997,7 +1997,7 @@ void NPC::Disarm(Client* client, int chance) {
 		if (zone->random.Int(0, 1000) <= chance) {
 			weapon = database.GetItem(equipment[eslot]);
 			if (weapon) {
-				if (!weapon->Magic && weapon->NoDrop == 255) {
+				if (!weapon->Magic && weapon->NoDrop != 0) {
 					int16 charges = -1;
 					ItemList::iterator cur, end;
 					cur = itemlist.begin();


### PR DESCRIPTION
The disarm ability should remove the equipped weapon and drop it to the ground so long as it is non-magical and not no-drop.

The code was testing no-drop against the value 255. 

Most of the db I have seen use the values of 0 (not droppable) and 1 (droppable).

This caused those servers (afaik all servers) to not do this part of the code correctly.