### PR TITLE
[Quest API] Add HasItemOnCorpse() to Perl/Lua

### DIFF
--- a/zone/client.h
+++ b/zone/client.h
@@ -988,6 +988,7 @@ public:
 	void IncStats(uint8 type,int16 increase_val);
 	void DropItem(int16 slot_id, bool recurse = true);
 	void DropItemQS(EQ::ItemInstance* inst, bool pickup);
+	bool HasItemOnCorpse(uint32 item_id);
 
 	bool IsAugmentRestricted(uint8 item_type, uint32 augment_restriction);
 

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -4789,3 +4789,31 @@ void Client::SummonItemIntoInventory(
 		slot_id
 	);
 }
+
+bool Client::HasItemOnCorpse(uint32 item_id)
+{
+	const uint32 corpse_count = GetCorpseCount();
+	if (!corpse_count) {
+		return EQ::invslot::SLOT_INVALID;
+	}
+
+	for (int i = 0; i < corpse_count; i++) {
+		const uint32 corpse_id = GetCorpseID(i);
+
+		for (int16 slot_id = EQ::invslot::POSSESSIONS_BEGIN; slot_id < EQ::invslot::POSSESSIONS_END; slot_id++) {
+			const uint32 current_item_id = GetCorpseItemAt(corpse_id, slot_id);
+			if (current_item_id && current_item_id == item_id) {
+				return true;
+			}
+		}
+
+		for (int16 slot_id = EQ::invbag::GENERAL_BAGS_BEGIN; slot_id < EQ::invbag::GENERAL_BAGS_END; slot_id++) {
+			const uint32 current_item_id = GetCorpseItemAt(corpse_id, slot_id);
+			if (current_item_id && current_item_id == item_id) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3246,6 +3246,12 @@ void Lua_Client::SummonItemIntoInventory(luabind::object item_table) {
 	);
 }
 
+bool Lua_Client::HasItemOnCorpse(uint32 item_id)
+{
+	Lua_Safe_Call_Bool();
+	return self->HasItemOnCorpse(item_id);
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 	.def(luabind::constructor<>())
@@ -3508,6 +3514,7 @@ luabind::scope lua_register_client() {
 	.def("HasDisciplineLearned", (bool(Lua_Client::*)(uint16))&Lua_Client::HasDisciplineLearned)
 	.def("HasExpeditionLockout", (bool(Lua_Client::*)(std::string, std::string))&Lua_Client::HasExpeditionLockout)
 	.def("HasItemEquippedByID", (bool(Lua_Client::*)(uint32))&Lua_Client::HasItemEquippedByID)
+	.def("HasItemOnCorpse", (bool(Lua_Client::*)(uint32))&Lua_Client::HasItemOnCorpse)
 	.def("HasPEQZoneFlag", (bool(Lua_Client::*)(uint32))&Lua_Client::HasPEQZoneFlag)
 	.def("HasRecipeLearned", (bool(Lua_Client::*)(uint32))&Lua_Client::HasRecipeLearned)
 	.def("HasSkill", (bool(Lua_Client::*)(int))&Lua_Client::HasSkill)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -487,6 +487,7 @@ public:
 	void RemoveEbonCrystals(uint32 amount);
 	void RemoveRadiantCrystals(uint32 amount);
 	void SummonItemIntoInventory(luabind::object item_table);
+	bool HasItemOnCorpse(uint32 item_id);
 
 	void ApplySpell(int spell_id);
 	void ApplySpell(int spell_id, int duration);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -3058,6 +3058,11 @@ void Perl_Client_SummonItemIntoInventory(Client* self, perl::reference table_ref
 	);
 }
 
+bool Perl_Client_HasItemOnCorpse(Client* self, uint32 item_id)
+{
+	return self->HasItemOnCorpse(item_id);
+}
+
 void perl_register_client()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3320,6 +3325,7 @@ void perl_register_client()
 	package.add("HasDisciplineLearned", &Perl_Client_HasDisciplineLearned);
 	package.add("HasExpeditionLockout", &Perl_Client_HasExpeditionLockout);
 	package.add("HasItemEquippedByID", &Perl_Client_HasItemEquippedByID);
+	package.add("HasItemOnCorpse", &Perl_Client_HasItemOnCorpse);
 	package.add("HasPEQZoneFlag", &Perl_Client_HasPEQZoneFlag);
 	package.add("HasRecipeLearned", &Perl_Client_HasRecipeLearned);
 	package.add("HasSkill", &Perl_Client_HasSkill);

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -4123,15 +4123,16 @@ uint32 ZoneDatabase::GetCharacterCorpseID(uint32 char_id, uint8 corpse) {
 		return 0;
 }
 
-uint32 ZoneDatabase::GetCharacterCorpseItemAt(uint32 corpse_id, uint16 slotid) {
-	Corpse* tmp = LoadCharacterCorpse(corpse_id);
-	uint32 itemid = 0;
+uint32 ZoneDatabase::GetCharacterCorpseItemAt(uint32 corpse_id, uint16 slot_id) {
+	Corpse* c = LoadCharacterCorpse(corpse_id);
+	uint32 item_id = 0;
 
-	if (tmp) {
-		itemid = tmp->GetWornItem(slotid);
-		tmp->DepopPlayerCorpse();
+	if (c) {
+		item_id = c->GetWornItem(slot_id);
+		c->DepopPlayerCorpse();
 	}
-	return itemid;
+
+	return item_id;
 }
 
 bool ZoneDatabase::LoadCharacterCorpseData(uint32 corpse_id, CharacterCorpseEntry& corpse){

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -498,7 +498,7 @@ public:
 	uint32		GetFirstCorpseID(uint32 char_id);
 	uint32		GetCharacterCorpseCount(uint32 char_id);
 	uint32		GetCharacterCorpseID(uint32 char_id, uint8 corpse);
-	uint32		GetCharacterCorpseItemAt(uint32 corpse_id, uint16 slotid);
+	uint32		GetCharacterCorpseItemAt(uint32 corpse_id, uint16 slot_id);
 	uint32		GetPlayerCorpseTimeLeft(uint8 corpse, uint8 type);
 	void        SendCharacterCorpseToNonInstance(uint32 corpse_db_id);
 


### PR DESCRIPTION
# Perl
- Add `$client->HasItemOnCorpse(item_id)`.

# Lua
- Add `client:HasItemOnCorpse(item_id)`.

# Notes
- Allows operators to see if a player has an item on any of their corpses.
- May need to address having to allocate and deallocate memory for every corpse that could possibly exist for a player.