### PR TITLE
[Bug Fix] Client:SetBucket Overload Incorrectly Named

### DIFF
--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3679,7 +3679,7 @@ luabind::scope lua_register_client() {
 	.def("SetBotSpawnLimit", (void(Lua_Client::*)(int))&Lua_Client::SetBotSpawnLimit)
 	.def("SetBotSpawnLimit", (void(Lua_Client::*)(int,uint8))&Lua_Client::SetBotSpawnLimit)
 	.def("SetBucket", (void(Lua_Client::*)(std::string,std::string))&Lua_Client::SetBucket)
-	.def("SetBucketExpires", (void(Lua_Client::*)(std::string,std::string,std::string))&Lua_Client::SetBucket)
+	.def("SetBucket", (void(Lua_Client::*)(std::string,std::string,std::string))&Lua_Client::SetBucket)
 	.def("SetClientMaxLevel", (void(Lua_Client::*)(int))&Lua_Client::SetClientMaxLevel)
 	.def("SetConsumption", (void(Lua_Client::*)(int, int))&Lua_Client::SetConsumption)
 	.def("SetDeity", (void(Lua_Client::*)(int))&Lua_Client::SetDeity)


### PR DESCRIPTION
There was an issue with Client:SetBucket when attempting to use an expiration date. Looks like a lua def was mistakenly named SetBucketExpires.