### PR TITLE
[Commands] Cleanup #appearance Command

### DIFF
--- a/common/emu_constants.cpp
+++ b/common/emu_constants.cpp
@@ -582,7 +582,7 @@ std::string EQ::constants::GetEmoteTypeName(uint8 emote_type)
 
 const std::map<uint32, std::string>& EQ::constants::GetAppearanceTypeMap()
 {
-	static const std::map<uint32, std::string> animation_type_map = {
+	static const std::map<uint32, std::string> appearance_type_map = {
 		{ AppearanceType::Die, "Die" },
 		{ AppearanceType::WhoLevel, "Who Level" },
 		{ AppearanceType::MaxHealth, "Max Health" },
@@ -627,7 +627,7 @@ const std::map<uint32, std::string>& EQ::constants::GetAppearanceTypeMap()
 		{ AppearanceType::OfflineMode, "Offline Mode" }
 	};
 
-	return animation_type_map;
+	return appearance_type_map;
 }
 
 std::string EQ::constants::GetAppearanceTypeName(uint32 appearance_type)

--- a/common/emu_constants.cpp
+++ b/common/emu_constants.cpp
@@ -509,7 +509,6 @@ std::string EQ::constants::GetObjectTypeName(int object_type)
 {
 	if (!EQ::ValueWithin(object_type, ObjectTypes::SmallBag, ObjectTypes::NoDeposit)) {
 		return std::string();
-
 	}
 
 	return EQ::constants::GetObjectTypeMap().find(object_type)->second;
@@ -579,4 +578,64 @@ std::string EQ::constants::GetEmoteTypeName(uint8 emote_type)
 	}
 
 	return EQ::constants::GetEmoteTypeMap().find(emote_type)->second;
+}
+
+const std::map<uint32, std::string>& EQ::constants::GetAppearanceTypeMap()
+{
+	static const std::map<uint32, std::string> animation_type_map = {
+		{ AppearanceType::Die, "Die" },
+		{ AppearanceType::WhoLevel, "Who Level" },
+		{ AppearanceType::MaxHealth, "Max Health" },
+		{ AppearanceType::Invisibility, "Invisibility" },
+		{ AppearanceType::PVP, "PVP" },
+		{ AppearanceType::Light, "Light" },
+		{ AppearanceType::Animation, "Animation" },
+		{ AppearanceType::Sneak, "Sneak" },
+		{ AppearanceType::SpawnID, "Spawn ID" },
+		{ AppearanceType::Health, "Health" },
+		{ AppearanceType::Linkdead, "Linkdead" },
+		{ AppearanceType::FlyMode, "Fly Mode" },
+		{ AppearanceType::GM, "GM" },
+		{ AppearanceType::Anonymous, "Anonymous" },
+		{ AppearanceType::GuildID, "Guild ID" },
+		{ AppearanceType::GuildRank, "Guild Rank" },
+		{ AppearanceType::AFK, "AFK" },
+		{ AppearanceType::Pet, "Pet" },
+		{ AppearanceType::Summoned, "Summoned" },
+		{ AppearanceType::Split, "Split" },
+		{ AppearanceType::Size, "Size" },
+		{ AppearanceType::SetType, "Set Type" },
+		{ AppearanceType::NPCName, "NPCName" },
+		{ AppearanceType::AARank, "AARank" },
+		{ AppearanceType::CancelSneakHide, "Cancel Sneak Hide" },
+		{ AppearanceType::AreaHealthRegen, "Area Health Regeneration" },
+		{ AppearanceType::AreaManaRegen, "Area Mana Regeneration" },
+		{ AppearanceType::AreaEnduranceRegen, "Area Endurance Regeneration" },
+		{ AppearanceType::FreezeBeneficialBuffs, "Freeze Beneficial Buffs" },
+		{ AppearanceType::NPCTintIndex, "NPC Tint Index" },
+		{ AppearanceType::GroupAutoConsent, "Group Auto Consent" },
+		{ AppearanceType::RaidAutoConsent, "Raid Auto Consent" },
+		{ AppearanceType::GuildAutoConsent, "Guild Auto Consent" },
+		{ AppearanceType::ShowHelm, "Show Helm" },
+		{ AppearanceType::DamageState, "Damage State" },
+		{ AppearanceType::EQPlayers, "EQ Players" },
+		{ AppearanceType::FindBits, "Find Bits" },
+		{ AppearanceType::TextureType, "Texture Type" },
+		{ AppearanceType::FacePick, "Face Pick" },
+		{ AppearanceType::AntiCheat, "Anti Cheat" },
+		{ AppearanceType::GuildShow, "Guild Show" },
+		{ AppearanceType::OfflineMode, "Offline Mode" }
+	};
+
+	return animation_type_map;
+}
+
+std::string EQ::constants::GetAppearanceTypeName(uint32 appearance_type)
+{
+	const auto& a = EQ::constants::GetAppearanceTypeMap().find(appearance_type);
+	if (a != EQ::constants::GetAppearanceTypeMap().end()) {
+		return a->second;
+	}
+
+	return std::string();
 }

--- a/common/emu_constants.h
+++ b/common/emu_constants.h
@@ -397,6 +397,9 @@ namespace EQ
 		extern const std::map<uint8, std::string>& GetEmoteTypeMap();
 		std::string GetEmoteTypeName(uint8 emote_type);
 
+		extern const std::map<uint32, std::string>& GetAppearanceTypeMap();
+		std::string GetAppearanceTypeName(uint32 animation_type);
+
 		const int STANCE_TYPE_FIRST = stancePassive;
 		const int STANCE_TYPE_LAST = stanceBurnAE;
 		const int STANCE_TYPE_COUNT = stanceBurnAE;

--- a/common/eq_constants.h
+++ b/common/eq_constants.h
@@ -23,61 +23,59 @@
 #include "skills.h"
 #include "types.h"
 
+namespace AppearanceType {
+	constexpr uint32 Die                   = 0; // Causes the client to keel over and zone to bind point (default action)
+	constexpr uint32 WhoLevel              = 1; // Level that shows up on /who
+	constexpr uint32 MaxHealth             = 2;
+	constexpr uint32 Invisibility          = 3; // 0 = Visible, 1 = Invisible
+	constexpr uint32 PVP                   = 4; // 0 = Non-PVP, 1 = PVP
+	constexpr uint32 Light                 = 5; // Light type emitted by player (lightstone, shiny shield)
+	constexpr uint32 Animation             = 14; // 100 = Standing, 102 = Freeze, 105 = Looting, 110 = Sitting, 111 = Crouching, 115 = Lying
+	constexpr uint32 Sneak                 = 15; // 0 = Normal, 1 = Sneaking
+	constexpr uint32 SpawnID               = 16; // Server -> Client, sets player spawn ID
+	constexpr uint32 Health                = 17; // Client->Server, my HP has changed (like regen tic)
+	constexpr uint32 Linkdead              = 18; // 0 = Normal, 1 = Linkdead
+	constexpr uint32 FlyMode               = 19; // 0 = Off, 1 = Flying, 2 = Levitating, 3 = Water, 4 = Floating, 5 = Levitating while Running
+	constexpr uint32 GM                    = 20; // 0 = Non-GM, 1 = GM
+	constexpr uint32 Anonymous             = 21; // 0 = Non-Anonymous, 1 = Anonymous, 2 = Roleplaying
+	constexpr uint32 GuildID               = 22;
+	constexpr uint32 GuildRank             = 23;
+	constexpr uint32 AFK                   = 24; // 0 = Non-AFK, 1 = AFK
+	constexpr uint32 Pet                   = 25; // Parameter is Entity ID of owner, or 0 for when charm breaks
+	constexpr uint32 Summoned              = 27;
+	constexpr uint32 Split                 = 28; // 0 = No Split, 1 = Auto Split
+	constexpr uint32 Size                  = 29; // Spawn's Size
+	constexpr uint32 SetType               = 30; // 0 = PC, 1 = NPC, 2 = Corpse
+	constexpr uint32 NPCName               = 31; // Change PC name color to NPC name color
+	constexpr uint32 AARank                = 32; // AA Rank Title ID, title in /who?
+	constexpr uint32 CancelSneakHide       = 33; // Turns off Hide and Sneak
+	constexpr uint32 AreaHealthRegen       = 35; // Guild Hall Regeneration Pool sets to value * 0.001
+	constexpr uint32 AreaManaRegen         = 36; // Guild Hall Regeneration Pool sets to value * 0.001
+	constexpr uint32 AreaEnduranceRegen    = 37; // Guild Hall Regeneration Pool sets to value * 0.001
+	constexpr uint32 FreezeBeneficialBuffs = 38; // Freezes beneficial buff timers for PCs
+	constexpr uint32 NPCTintIndex          = 39;
+	constexpr uint32 GroupAutoConsent      = 40; // Auto Consent Group
+	constexpr uint32 RaidAutoConsent       = 41; // Auto Consent Raid
+	constexpr uint32 GuildAutoConsent      = 42; // Auto Consent Guild
+	constexpr uint32 ShowHelm              = 43; // 0 = Hide, 1 = Show
+	constexpr uint32 DamageState           = 44; // The damage state of a destructible object (0 through 10) plays sound IDs, most only have 2 or 4 states though
+	constexpr uint32 EQPlayers             = 45; // EQ Players Update
+	constexpr uint32 FindBits              = 46; // Set Find Bits?
+	constexpr uint32 TextureType           = 48; // Texture Type?
+	constexpr uint32 FacePick              = 49; // Turns off face pick window?
+	constexpr uint32 AntiCheat             = 51; // Sent by the client randomly telling the server how long since last action has occurred
+	constexpr uint32 GuildShow             = 52;
+	constexpr uint32 OfflineMode           = 53; // Offline Mode
+}
 
-//SpawnAppearance types: (compared two clients for server-originating types: SoF & RoF2)
-#define AT_Die 0			// this causes the client to keel over and zone to bind point (default action)
-#define AT_WhoLevel 1		// the level that shows up on /who
-#define AT_HPMax 2			// idk
-#define AT_Invis 3			// 0 = visible, 1 = invisible
-#define AT_PVP 4			// 0 = blue, 1 = pvp (red)
-#define AT_Light 5			// light type emitted by player (lightstone, shiny shield)
-#define AT_Anim 14			// 100=standing, 110=sitting, 111=ducking, 115=feigned, 105=looting
-#define AT_Sneak 15			// 0 = normal, 1 = sneaking
-#define AT_SpawnID 16		// server to client, sets player spawn id
-#define AT_HP 17			// Client->Server, my HP has changed (like regen tic)
-#define AT_Linkdead 18		// 0 = normal, 1 = linkdead
-#define AT_Levitate 19		// 0=off, 1=flymode, 2=levitate max 5, see GravityBehavior enum
-#define AT_GM 20			// 0 = normal, 1 = GM - all odd numbers seem to make it GM
-#define AT_Anon 21			// 0 = normal, 1 = anon, 2 = roleplay
-#define AT_GuildID 22
-#define AT_GuildRank 23		// 0=member, 1=officer, 2=leader
-#define AT_AFK 24			// 0 = normal, 1 = afk
-#define AT_Pet 25			// Param is EntityID of owner, or 0 for when charm breaks
-#define AT_Summoned 27		// Unsure
-#define AT_Split 28			// 0 = normal, 1 = autosplit on (not showing in SoF+) (client-to-server only)
-#define AT_Size 29			// spawn's size (present: SoF, absent: RoF2)
-#define AT_SetType 30		// 0 = PC, 1 = NPC, 2 <= = corpse
-#define AT_NPCName 31		// change PC's name's color to NPC color 0 = normal, 1 = npc name, Trader on RoF2?
-#define AT_AARank 32		// AA Rank Title ID thingy, does is this the title in /who?
-#define AT_CancelSneakHide 33	// Turns off Hide and Sneak
-//#define AT_34 34			// unknown (present: SoF, absent: RoF2)
-#define AT_AreaHPRegen 35	// guild hall regen pool sets to value * 0.001
-#define AT_AreaManaRegen 36	// guild hall regen pool sets to value * 0.001
-#define AT_AreaEndRegen 37	// guild hall regen pool sets to value * 0.001
-#define AT_FreezeBuffs 38	// Freezes beneficial buff timers
-#define AT_NpcTintIndex 39	// not 100% sure
-#define AT_GroupConsent 40	// auto consent group
-#define AT_RaidConsent 41	// auto consent raid
-#define AT_GuildConsent 42	// auto consent guild
-#define AT_ShowHelm 43		// 0 = hide graphic, 1 = show graphic
-#define AT_DamageState 44	// The damage state of a destructible object (0 through 10) plays soundids most only have 2 or 4 states though
-#define AT_EQPlayers 45		// /eqplayersupdate
-#define AT_FindBits 46		// set FindBits, whatever those are!
-#define AT_TextureType 48	// TextureType
-#define AT_FacePick 49		// Turns off face pick window? maybe ...
-#define AT_AntiCheat 51		// sent by the client randomly telling the server how long since last action has occured
-#define AT_GuildShow 52		// this is what MQ2 call sit, not sure
-#define AT_Offline 53		// Offline mode
-
-//#define AT_Trader 300		// Bazaar Trader Mode (not present in SoF or RoF2)
-
-// animations for AT_Anim
-#define ANIM_FREEZE	    102
-#define	ANIM_STAND		0x64
-#define	ANIM_SIT		0x6e
-#define	ANIM_CROUCH		0x6f
-#define	ANIM_DEATH		0x73
-#define ANIM_LOOT		0x69
+namespace Animation {
+	constexpr uint32 Standing  = 100;
+	constexpr uint32 Freeze    = 102;
+	constexpr uint32 Looting   = 105;
+	constexpr uint32 Sitting   = 110;
+	constexpr uint32 Crouching = 111;
+	constexpr uint32 Lying     = 115;
+}
 
 constexpr int16 RECAST_TYPE_UNLINKED_ITEM = -1;
 

--- a/common/patches/rof.cpp
+++ b/common/patches/rof.cpp
@@ -2621,7 +2621,7 @@ namespace RoF
 		general->parameter = RaidCommandAcceptInvite;
 		strn0cpy(general->leader_name, emu->leader_name, sizeof(emu->leader_name));
 		strn0cpy(general->player_name, emu->leader_name, sizeof(emu->leader_name));
-		
+
 		dest->FastQueuePacket(&outapp);
 
 		safe_delete(inapp);
@@ -3165,7 +3165,7 @@ namespace RoF
 
 		SpawnAppearance_Struct *sas = (SpawnAppearance_Struct *)emu_buffer;
 
-		if (sas->type != AT_Size)
+		if (sas->type != AppearanceType::Size)
 		{
 			dest->FastQueuePacket(&in, ack_req);
 			return;

--- a/common/patches/rof2.cpp
+++ b/common/patches/rof2.cpp
@@ -3218,7 +3218,7 @@ namespace RoF2
 
 		SpawnAppearance_Struct *sas = (SpawnAppearance_Struct *)emu_buffer;
 
-		if (sas->type != AT_Size)
+		if (sas->type != AppearanceType::Size)
 		{
 			dest->FastQueuePacket(&in, ack_req);
 			return;

--- a/common/patches/uf.cpp
+++ b/common/patches/uf.cpp
@@ -2339,7 +2339,7 @@ namespace UF
 
 		SpawnAppearance_Struct *sas = (SpawnAppearance_Struct *)emu_buffer;
 
-		if (sas->type != AT_Size)
+		if (sas->type != AppearanceType::Size)
 		{
 			dest->FastQueuePacket(&in, ack_req);
 			return;

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -3911,11 +3911,11 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 
 		if (IsClient() && CastToClient()->sneaking) {
 			CastToClient()->sneaking = false;
-			SendAppearancePacket(AT_Sneak, 0);
+			SendAppearancePacket(AppearanceType::Sneak, 0);
 		}
 		if (attacker && attacker->IsClient() && attacker->CastToClient()->sneaking) {
 			attacker->CastToClient()->sneaking = false;
-			attacker->SendAppearancePacket(AT_Sneak, 0);
+			attacker->SendAppearancePacket(AppearanceType::Sneak, 0);
 		}
 
 		//final damage has been determined.

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -325,30 +325,30 @@ Bot::Bot(
 
 					switch (spell.base_value[x1]) {
 					case OGRE:
-						SendAppearancePacket(AT_Size, 9);
+						SendAppearancePacket(AppearanceType::Size, 9);
 						break;
 					case TROLL:
-						SendAppearancePacket(AT_Size, 8);
+						SendAppearancePacket(AppearanceType::Size, 8);
 						break;
 					case VAHSHIR:
 					case BARBARIAN:
-						SendAppearancePacket(AT_Size, 7);
+						SendAppearancePacket(AppearanceType::Size, 7);
 						break;
 					case HALF_ELF:
 					case WOOD_ELF:
 					case DARK_ELF:
 					case FROGLOK:
-						SendAppearancePacket(AT_Size, 5);
+						SendAppearancePacket(AppearanceType::Size, 5);
 						break;
 					case DWARF:
-						SendAppearancePacket(AT_Size, 4);
+						SendAppearancePacket(AppearanceType::Size, 4);
 						break;
 					case HALFLING:
 					case GNOME:
-						SendAppearancePacket(AT_Size, 3);
+						SendAppearancePacket(AppearanceType::Size, 3);
 						break;
 					default:
-						SendAppearancePacket(AT_Size, 6);
+						SendAppearancePacket(AppearanceType::Size, 6);
 						break;
 					}
 					break;
@@ -372,18 +372,18 @@ Bot::Bot(
 				case SE_Invisibility:
 				{
 					invisible = true;
-					SendAppearancePacket(AT_Invis, 1);
+					SendAppearancePacket(AppearanceType::Invisibility, 1);
 					break;
 				}
 				case SE_Levitate:
 				{
 					if (!zone->CanLevitate())
 					{
-							SendAppearancePacket(AT_Levitate, 0);
+							SendAppearancePacket(AppearanceType::FlyMode, 0);
 							BuffFadeByEffect(SE_Levitate);
 					}
 					else {
-						SendAppearancePacket(AT_Levitate, 2);
+						SendAppearancePacket(AppearanceType::FlyMode, 2);
 					}
 					break;
 				}
@@ -3674,7 +3674,7 @@ void Bot::LevelBotWithClient(Client* c, uint8 new_level, bool send_appearance) {
 				}
 
 				e->SendHPUpdate();
-				e->SendAppearancePacket(AT_WhoLevel, new_level, true, true); // who level change
+				e->SendAppearancePacket(AppearanceType::WhoLevel, new_level, true, true); // who level change
 				e->AI_AddBotSpells(e->GetBotSpellID());
 			}
 		}
@@ -3706,7 +3706,7 @@ void Bot::BotAddEquipItem(uint16 slot_id, uint32 item_id) {
 
 		UpdateEquipmentLight();
 		if (UpdateActiveLight() && GetID()) { // temp hack fix
-			SendAppearancePacket(AT_Light, GetActiveLightType());
+			SendAppearancePacket(AppearanceType::Light, GetActiveLightType());
 		}
 	}
 }
@@ -3726,7 +3726,7 @@ void Bot::BotRemoveEquipItem(uint16 slot_id)
 
 	UpdateEquipmentLight();
 	if (UpdateActiveLight()) {
-		SendAppearancePacket(AT_Light, GetActiveLightType());
+		SendAppearancePacket(AppearanceType::Light, GetActiveLightType());
 	}
 }
 

--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -7594,7 +7594,7 @@ void bot_subcommand_bot_toggle_helm(Client *c, const Seperator *sep)
 			EQApplicationPacket* outapp = new EQApplicationPacket(OP_SpawnAppearance, sizeof(SpawnAppearance_Struct));
 			SpawnAppearance_Struct* saptr = (SpawnAppearance_Struct*)outapp->pBuffer;
 			saptr->spawn_id = bot_iter->GetID();
-			saptr->type = AT_ShowHelm;
+			saptr->type = AppearanceType::ShowHelm;
 			saptr->parameter = bot_iter->GetShowHelm();
 
 			entity_list.QueueClients(bot_iter, outapp);
@@ -7667,7 +7667,7 @@ void bot_subcommand_bot_toggle_helm(Client *c, const Seperator *sep)
 	[10-16-2015 :: 22:15:40] [Packet :: Server -> Client (Dump)] [OP_SpawnAppearance - 0x01d1] [Size: 10]
 	0: A2 02 2B 00 00 00 00 00 - showhelm = false
 
-	*** Bot did not update using the OP_SpawnAppearance packet with AT_ShowHelm appearance type ***
+	*** Bot did not update using the OP_SpawnAppearance packet with AppearanceType::ShowHelm appearance type ***
 	*/
 }
 
@@ -7694,7 +7694,7 @@ void bot_subcommand_bot_update(Client *c, const Seperator *sep)
 
 		bot_iter->SetPetChooser(false);
 		bot_iter->CalcBotStats(c->GetBotOption(Client::booStatsUpdate));
-		bot_iter->SendAppearancePacket(AT_WhoLevel, bot_iter->GetLevel(), true, true);
+		bot_iter->SendAppearancePacket(AppearanceType::WhoLevel, bot_iter->GetLevel(), true, true);
 		++bot_count;
 	}
 

--- a/zone/cheat_manager.cpp
+++ b/zone/cheat_manager.cpp
@@ -349,10 +349,10 @@ void CheatManager::ProcessMovementHistory(const EQApplicationPacket *app)
 
 void CheatManager::ProcessSpawnApperance(uint16 spawn_id, uint16 type, uint32 parameter)
 {
-	if (type == AT_Anim && parameter == ANIM_SIT) {
+	if (type == AppearanceType::Animation && parameter == Animation::Sitting) {
 		m_time_since_last_memorization = Timer::GetCurrentTime();
 	}
-	else if (spawn_id == 0 && type == AT_AntiCheat) {
+	else if (spawn_id == 0 && type == AppearanceType::AntiCheat) {
 		m_time_since_last_action = parameter;
 	}
 }

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -483,7 +483,7 @@ void Client::SendZoneInPackets()
 	// Spawn Appearance Packet
 	auto outapp = new EQApplicationPacket(OP_SpawnAppearance, sizeof(SpawnAppearance_Struct));
 	SpawnAppearance_Struct* sa = (SpawnAppearance_Struct*)outapp->pBuffer;
-	sa->type = AT_SpawnID;			// Is 0x10 used to set the player id?
+	sa->type = AppearanceType::SpawnID;			// Is 0x10 used to set the player id?
 	sa->parameter = GetID();	// Four bytes for this parameter...
 	outapp->priority = 6;
 	QueuePacket(outapp);
@@ -498,7 +498,7 @@ void Client::SendZoneInPackets()
 	safe_delete(outapp);
 	SetSpawned();
 	if (GetPVP(false))	//force a PVP update until we fix the spawn struct
-		SendAppearancePacket(AT_PVP, GetPVP(false), true, false);
+		SendAppearancePacket(AppearanceType::PVP, GetPVP(false), true, false);
 
 	//Send AA Exp packet:
 	if (GetLevel() >= 51)
@@ -2221,7 +2221,7 @@ void Client::SetGM(bool toggle) {
 			m_pp.gm ? "now" : "no longer"
 		).c_str()
 	);
-	SendAppearancePacket(AT_GM, m_pp.gm);
+	SendAppearancePacket(AppearanceType::GM, m_pp.gm);
 	Save();
 	UpdateWho();
 }
@@ -2839,7 +2839,7 @@ void Client::SetPVP(bool toggle, bool message) {
 		}
 	}
 
-	SendAppearancePacket(AT_PVP, GetPVP());
+	SendAppearancePacket(AppearanceType::PVP, GetPVP());
 	Save();
 }
 
@@ -3607,7 +3607,7 @@ void Client::LinkDead()
 
 //	save_timer.Start(2500);
 	linkdead_timer.Start(RuleI(Zone,ClientLinkdeadMS));
-	SendAppearancePacket(AT_Linkdead, 1);
+	SendAppearancePacket(AppearanceType::Linkdead, 1);
 	client_state = CLIENT_LINKDEAD;
 	AI_Start(CLIENT_LD_TIMEOUT);
 }
@@ -3750,7 +3750,7 @@ void Client::EnteringMessages(Client* client)
 				).c_str()
 			);
 
-			client->SendAppearancePacket(AT_Anim, ANIM_FREEZE);
+			client->SendAppearancePacket(AppearanceType::Animation, Animation::Freeze);
 		}
 	}
 }
@@ -8565,37 +8565,37 @@ bool Client::CanMedOnHorse()
 void Client::EnableAreaHPRegen(int value)
 {
 	AreaHPRegen = value * 0.001f;
-	SendAppearancePacket(AT_AreaHPRegen, value, false);
+	SendAppearancePacket(AppearanceType::AreaHealthRegen, value, false);
 }
 
 void Client::DisableAreaHPRegen()
 {
 	AreaHPRegen = 1.0f;
-	SendAppearancePacket(AT_AreaHPRegen, 1000, false);
+	SendAppearancePacket(AppearanceType::AreaHealthRegen, 1000, false);
 }
 
 void Client::EnableAreaManaRegen(int value)
 {
 	AreaManaRegen = value * 0.001f;
-	SendAppearancePacket(AT_AreaManaRegen, value, false);
+	SendAppearancePacket(AppearanceType::AreaManaRegen, value, false);
 }
 
 void Client::DisableAreaManaRegen()
 {
 	AreaManaRegen = 1.0f;
-	SendAppearancePacket(AT_AreaManaRegen, 1000, false);
+	SendAppearancePacket(AppearanceType::AreaManaRegen, 1000, false);
 }
 
 void Client::EnableAreaEndRegen(int value)
 {
 	AreaEndRegen = value * 0.001f;
-	SendAppearancePacket(AT_AreaEndRegen, value, false);
+	SendAppearancePacket(AppearanceType::AreaEnduranceRegen, value, false);
 }
 
 void Client::DisableAreaEndRegen()
 {
 	AreaEndRegen = 1.0f;
-	SendAppearancePacket(AT_AreaEndRegen, 1000, false);
+	SendAppearancePacket(AppearanceType::AreaEnduranceRegen, 1000, false);
 }
 
 void Client::EnableAreaRegens(int value)
@@ -10011,7 +10011,7 @@ void Client::SetAnon(uint8 anon_flag) {
 	auto outapp = new EQApplicationPacket(OP_SpawnAppearance, sizeof(SpawnAppearance_Struct));
 	SpawnAppearance_Struct* spawn_appearance = (SpawnAppearance_Struct*)outapp->pBuffer;
 	spawn_appearance->spawn_id = GetID();
-	spawn_appearance->type = AT_Anon;
+	spawn_appearance->type = AppearanceType::Anonymous;
 	spawn_appearance->parameter = anon_flag;
 	entity_list.QueueClients(this, outapp);
 	Save();
@@ -10024,7 +10024,7 @@ void Client::SetAFK(uint8 afk_flag) {
 	auto outapp = new EQApplicationPacket(OP_SpawnAppearance, sizeof(SpawnAppearance_Struct));
 	SpawnAppearance_Struct* spawn_appearance = (SpawnAppearance_Struct*)outapp->pBuffer;
 	spawn_appearance->spawn_id = GetID();
-	spawn_appearance->type = AT_AFK;
+	spawn_appearance->type = AppearanceType::AFK;
 	spawn_appearance->parameter = afk_flag;
 	entity_list.QueueClients(this, outapp);
 	safe_delete(outapp);

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -547,8 +547,8 @@ void Client::CompleteConnect()
 			default: { break; }				// GUILD_NONE
 			}
 		}
-		SendAppearancePacket(AT_GuildID, GuildID(), false);
-		SendAppearancePacket(AT_GuildRank, rank, false);
+		SendAppearancePacket(AppearanceType::GuildID, GuildID(), false);
+		SendAppearancePacket(AppearanceType::GuildRank, rank, false);
 	}
 
 	// moved to dbload and translators since we iterate there also .. keep m_pp values whatever they are when they get here
@@ -703,7 +703,7 @@ void Client::CompleteConnect()
 			case SE_Invisibility2:
 			case SE_Invisibility:
 			{
-				SendAppearancePacket(AT_Invis, Invisibility::Invisible);
+				SendAppearancePacket(AppearanceType::Invisibility, Invisibility::Invisible);
 				break;
 			}
 			case SE_Levitate:
@@ -712,17 +712,17 @@ void Client::CompleteConnect()
 				{
 					if (!GetGM())
 					{
-						SendAppearancePacket(AT_Levitate, 0);
+						SendAppearancePacket(AppearanceType::FlyMode, 0);
 						BuffFadeByEffect(SE_Levitate);
 						Message(Chat::Red, "You can't levitate in this zone.");
 					}
 				}
 				else {
 					if (spell.limit_value[x1] == 1) {
-						SendAppearancePacket(AT_Levitate, EQ::constants::GravityBehavior::LevitateWhileRunning, true, true);
+						SendAppearancePacket(AppearanceType::FlyMode, EQ::constants::GravityBehavior::LevitateWhileRunning, true, true);
 					}
 					else {
-						SendAppearancePacket(AT_Levitate, EQ::constants::GravityBehavior::Levitating, true, true);
+						SendAppearancePacket(AppearanceType::FlyMode, EQ::constants::GravityBehavior::Levitating, true, true);
 					}
 				}
 				break;
@@ -747,7 +747,7 @@ void Client::CompleteConnect()
 		}
 	}
 
-	/* Sends appearances for all mobs not doing anim_stand aka sitting, looting, playing dead */
+	/* Sends appearances for all mobs not doing Animation::Standing aka sitting, looting, playing dead */
 	entity_list.SendZoneAppearance(this);
 	/* Sends the Nimbus particle effects (up to 3) for any mob using them */
 	entity_list.SendNimbusEffects(this);
@@ -1316,7 +1316,7 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 	/* If GM, not trackable */
 	if (gm_hide_me) { trackable = false; }
 	if (gminvul) { invulnerable = true; }
-	if (flymode > 0) { SendAppearancePacket(AT_Levitate, flymode); }
+	if (flymode > 0) { SendAppearancePacket(AppearanceType::FlyMode, flymode); }
 	/* Set Con State for Reporting */
 	conn_state = PlayerProfileLoaded;
 
@@ -6481,7 +6481,7 @@ void Client::Handle_OP_GMBecomeNPC(const EQApplicationPacket *app)
 			t->SetGM(false);
 		}
 
-		m->SendAppearancePacket(AT_NPCName, 1, true);
+		m->SendAppearancePacket(AppearanceType::NPCName, 1, true);
 		t->SetBecomeNPC(true);
 		t->SetBecomeNPCLevel(b->maxlevel);
 		m->MessageString(Chat::White, TOGGLE_OFF);
@@ -10842,7 +10842,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 				// Set Sit button to unpressed - send stand anim/end hpregen
 				mypet->SetFeigned(false);
 				SetPetCommandState(PET_BUTTON_SIT, 0);
-				mypet->SendAppearancePacket(AT_Anim, ANIM_STAND);
+				mypet->SendAppearancePacket(AppearanceType::Animation, Animation::Standing);
 
 				mypet->SayString(this, Chat::PetResponse, PET_GUARDINGLIFE);
 				mypet->SetPetOrder(SPO_Guard);
@@ -10867,7 +10867,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 
 			// fix GUI sit button to be unpressed - send stand anim/end hpregen
 			SetPetCommandState(PET_BUTTON_SIT, 0);
-			mypet->SendAppearancePacket(AT_Anim, ANIM_STAND);
+			mypet->SendAppearancePacket(AppearanceType::Animation, Animation::Standing);
 
 			if (mypet->IsPetStop()) {
 				mypet->SetPetStop(false);
@@ -10915,7 +10915,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 
 			// Set Sit button to unpressed - send stand anim/end hpregen
 			SetPetCommandState(PET_BUTTON_SIT, 0);
-			mypet->SendAppearancePacket(AT_Anim, ANIM_STAND);
+			mypet->SendAppearancePacket(AppearanceType::Animation, Animation::Standing);
 
 			if (mypet->IsPetStop()) {
 				mypet->SetPetStop(false);
@@ -10933,7 +10933,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 				mypet->SetFeigned(false);
 				mypet->SayString(this, Chat::PetResponse, PET_SIT_STRING);
 				mypet->SetPetOrder(SPO_Follow);
-				mypet->SendAppearancePacket(AT_Anim, ANIM_STAND);
+				mypet->SendAppearancePacket(AppearanceType::Animation, Animation::Standing);
 			}
 			else
 			{
@@ -10943,7 +10943,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 				mypet->SetRunAnimSpeed(0);
 				if (!mypet->UseBardSpellLogic())	//maybe we can have a bard pet
 					mypet->InterruptSpell(); //No cast 4 u. //i guess the pet should start casting
-				mypet->SendAppearancePacket(AT_Anim, ANIM_SIT);
+				mypet->SendAppearancePacket(AppearanceType::Animation, Animation::Sitting);
 			}
 		}
 		break;
@@ -10956,7 +10956,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			mypet->SayString(this, Chat::PetResponse, PET_SIT_STRING);
 			SetPetCommandState(PET_BUTTON_SIT, 0);
 			mypet->SetPetOrder(SPO_Follow);
-			mypet->SendAppearancePacket(AT_Anim, ANIM_STAND);
+			mypet->SendAppearancePacket(AppearanceType::Animation, Animation::Standing);
 		}
 		break;
 	}
@@ -10971,7 +10971,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			mypet->SetRunAnimSpeed(0);
 			if (!mypet->UseBardSpellLogic())	//maybe we can have a bard pet
 				mypet->InterruptSpell(); //No cast 4 u. //i guess the pet should start casting
-			mypet->SendAppearancePacket(AT_Anim, ANIM_SIT);
+			mypet->SendAppearancePacket(AppearanceType::Animation, Animation::Sitting);
 		}
 		break;
 	}
@@ -11176,7 +11176,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 				mypet->SetPetOrder(SPO_FeignDeath);
 				mypet->SetRunAnimSpeed(0);
 				mypet->StopNavigation();
-				mypet->SendAppearancePacket(AT_Anim, ANIM_DEATH);
+				mypet->SendAppearancePacket(AppearanceType::Animation, Animation::Lying);
 				mypet->SetFeigned(true);
 				mypet->SetTarget(nullptr);
 				if (!mypet->UseBardSpellLogic()) {
@@ -14247,14 +14247,14 @@ void Client::Handle_OP_SpawnAppearance(const EQApplicationPacket *app)
 	if (sa->spawn_id != GetID())
 		return;
 
-	if (sa->type == AT_Invis) {
+	if (sa->type == AppearanceType::Invisibility) {
 		if (sa->parameter != 0)
 		{
 			if (!HasSkill(EQ::skills::SkillHide) && GetSkill(EQ::skills::SkillHide) == 0)
 			{
 				if (ClientVersion() < EQ::versions::ClientVersion::SoF)
 				{
-					auto message = fmt::format("Player sent OP_SpawnAppearance with AT_Invis [{}]", sa->parameter);
+					auto message = fmt::format("Player sent OP_SpawnAppearance with AppearanceType::Invisibility [{}]", sa->parameter);
 					RecordPlayerEventLog(PlayerEvent::POSSIBLE_HACK, PlayerEvent::PossibleHackEvent{.message = message});
 				}
 			}
@@ -14266,18 +14266,18 @@ void Client::Handle_OP_SpawnAppearance(const EQApplicationPacket *app)
 		entity_list.QueueClients(this, app, true);
 		return;
 	}
-	else if (sa->type == AT_Anim) {
+	else if (sa->type == AppearanceType::Animation) {
 		if (IsAIControlled())
 			return;
 
-		if (sa->parameter == ANIM_STAND) {
+		if (sa->parameter == Animation::Standing) {
 			SetAppearance(eaStanding);
 			playeraction = 0;
 			SetFeigned(false);
 			BindWound(this, false, true);
 			camp_timer.Disable();
 		}
-		else if (sa->parameter == ANIM_SIT) {
+		else if (sa->parameter == Animation::Sitting) {
 			SetAppearance(eaSitting);
 			playeraction = 1;
 			if (!UseBardSpellLogic())
@@ -14287,19 +14287,19 @@ void Client::Handle_OP_SpawnAppearance(const EQApplicationPacket *app)
 			tmSitting = Timer::GetCurrentTime();
 			BuffFadeBySitModifier();
 		}
-		else if (sa->parameter == ANIM_CROUCH) {
+		else if (sa->parameter == Animation::Crouching) {
 			if (!UseBardSpellLogic())
 				InterruptSpell();
 			SetAppearance(eaCrouching);
 			playeraction = 2;
 			SetFeigned(false);
 		}
-		else if (sa->parameter == ANIM_DEATH) { // feign death too
+		else if (sa->parameter == Animation::Lying) { // feign death too
 			SetAppearance(eaDead);
 			playeraction = 3;
 			InterruptSpell();
 		}
-		else if (sa->parameter == ANIM_LOOT) {
+		else if (sa->parameter == Animation::Looting) {
 			SetAppearance(eaLooting);
 			playeraction = 4;
 			SetFeigned(false);
@@ -14312,7 +14312,7 @@ void Client::Handle_OP_SpawnAppearance(const EQApplicationPacket *app)
 
 		entity_list.QueueClients(this, app, true);
 	}
-	else if (sa->type == AT_Anon) {
+	else if (sa->type == AppearanceType::Anonymous) {
 		if (!anon_toggle_timer.Check()) {
 			return;
 		}
@@ -14334,19 +14334,19 @@ void Client::Handle_OP_SpawnAppearance(const EQApplicationPacket *app)
 		entity_list.QueueClients(this, app, true);
 		UpdateWho();
 	}
-	else if ((sa->type == AT_HP) && (dead == 0)) {
+	else if ((sa->type == AppearanceType::Health) && (dead == 0)) {
 		return;
 	}
-	else if (sa->type == AT_AFK) {
+	else if (sa->type == AppearanceType::AFK) {
 		if (afk_toggle_timer.Check()) {
 			AFK = (sa->parameter == 1);
 			entity_list.QueueClients(this, app, true);
 		}
 	}
-	else if (sa->type == AT_Split) {
+	else if (sa->type == AppearanceType::Split) {
 		m_pp.autosplit = (sa->parameter == 1);
 	}
-	else if (sa->type == AT_Sneak) {
+	else if (sa->type == AppearanceType::Sneak) {
 		if (sneaking == 0)
 			return;
 
@@ -14354,7 +14354,7 @@ void Client::Handle_OP_SpawnAppearance(const EQApplicationPacket *app)
 		{
 			if (!HasSkill(EQ::skills::SkillSneak))
 			{
-				auto message = fmt::format("Player sent OP_SpawnAppearance with AT_Sneak [{}]", sa->parameter);
+				auto message = fmt::format("Player sent OP_SpawnAppearance with AppearanceType::Sneak [{}]", sa->parameter);
 				RecordPlayerEventLog(PlayerEvent::POSSIBLE_HACK, PlayerEvent::PossibleHackEvent{.message = message});
 			}
 			return;
@@ -14362,38 +14362,38 @@ void Client::Handle_OP_SpawnAppearance(const EQApplicationPacket *app)
 		sneaking = 0;
 		entity_list.QueueClients(this, app, true);
 	}
-	else if (sa->type == AT_Size)
+	else if (sa->type == AppearanceType::Size)
 	{
-		auto message = fmt::format("Player sent OP_SpawnAppearance with AT_Size [{}]", sa->parameter);
+		auto message = fmt::format("Player sent OP_SpawnAppearance with AppearanceType::Size [{}]", sa->parameter);
 		RecordPlayerEventLog(PlayerEvent::POSSIBLE_HACK, PlayerEvent::PossibleHackEvent{.message = message});
 	}
-	else if (sa->type == AT_Light)	// client emitting light (lightstone, shiny shield)
+	else if (sa->type == AppearanceType::Light)	// client emitting light (lightstone, shiny shield)
 	{
 		//don't do anything with this
 	}
-	else if (sa->type == AT_Levitate)
+	else if (sa->type == AppearanceType::FlyMode)
 	{
 		// don't do anything with this, we tell the client when it's
 		// levitating, not the other way around
 	}
-	else if (sa->type == AT_ShowHelm)
+	else if (sa->type == AppearanceType::ShowHelm)
 	{
 		if (helm_toggle_timer.Check()) {
 			m_pp.showhelm = (sa->parameter == 1);
 			entity_list.QueueClients(this, app, true);
 		}
 	}
-	else if (sa->type == AT_GroupConsent)
+	else if (sa->type == AppearanceType::GroupAutoConsent)
 	{
 		m_pp.groupAutoconsent = (sa->parameter == 1);
 		ConsentCorpses("Group", (sa->parameter != 1));
 	}
-	else if (sa->type == AT_RaidConsent)
+	else if (sa->type == AppearanceType::RaidAutoConsent)
 	{
 		m_pp.raidAutoconsent = (sa->parameter == 1);
 		ConsentCorpses("Raid", (sa->parameter != 1));
 	}
-	else if (sa->type == AT_GuildConsent)
+	else if (sa->type == AppearanceType::GuildAutoConsent)
 	{
 		m_pp.guildAutoconsent = (sa->parameter == 1);
 		ConsentCorpses("Guild", (sa->parameter != 1));

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -572,7 +572,7 @@ bool Client::Process() {
 			linkdead_timer.Start(RuleI(Zone, ClientLinkdeadMS));
 			client_state = CLIENT_LINKDEAD;
 			AI_Start(CLIENT_LD_TIMEOUT);
-			SendAppearancePacket(AT_Linkdead, 1);
+			SendAppearancePacket(AppearanceType::Linkdead, 1);
 
 			SetDynamicZoneMemberStatus(DynamicZoneMemberStatus::LinkDead);
 		}
@@ -1184,10 +1184,10 @@ void Client::CancelSneakHide()
 	if (hidden || improved_hidden) {
 		auto app = new EQApplicationPacket(OP_CancelSneakHide, 0);
 		FastQueuePacket(&app);
-		// SoF and Tit send back a OP_SpawnAppearance turning off AT_Invis
+		// SoF and Tit send back a OP_SpawnAppearance turning off AppearanceType::Invisibility
 		// so we need to handle our sneaking flag only
 		// The later clients send back a OP_Hide (this has a size but data is 0)
-		// as well as OP_SpawnAppearance with AT_Invis and one with AT_Sneak
+		// as well as OP_SpawnAppearance with AppearanceType::Invisibility and one with AppearanceType::Sneak
 		// So we don't have to handle any of those flags
 		if (ClientVersionBit() & EQ::versions::maskSoFAndEarlier)
 			sneaking = false;

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -927,7 +927,7 @@ void Corpse::RemoveItem(ServerLootItem_Struct* item_data)
 
 		UpdateEquipmentLight();
 		if (UpdateActiveLight())
-			SendAppearancePacket(AT_Light, GetActiveLightType());
+			SendAppearancePacket(AppearanceType::Light, GetActiveLightType());
 
 		safe_delete(sitem);
 		return;

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -1411,7 +1411,7 @@ void EntityList::SendZonePVPUpdates(Client *to)
 	while (it != client_list.end()) {
 		Client *c = it->second;
 		if(c->GetPVP())
-			c->SendAppearancePacket(AT_PVP, c->GetPVP(), true, false, to);
+			c->SendAppearancePacket(AppearanceType::PVP, c->GetPVP(), true, false, to);
 		++it;
 	}
 }
@@ -4704,10 +4704,10 @@ void EntityList::SendZoneAppearance(Client *c)
 				continue;
 			}
 			if (cur->GetAppearance() != eaStanding) {
-				cur->SendAppearancePacket(AT_Anim, cur->GetAppearanceValue(cur->GetAppearance()), false, true, c);
+				cur->SendAppearancePacket(AppearanceType::Animation, cur->GetAppearanceValue(cur->GetAppearance()), false, true, c);
 			}
 			if (cur->GetSize() != cur->GetBaseSize()) {
-				cur->SendAppearancePacket(AT_Size, (uint32) cur->GetSize(), false, true, c);
+				cur->SendAppearancePacket(AppearanceType::Size, (uint32) cur->GetSize(), false, true, c);
 			}
 		}
 		++it;

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -950,7 +950,7 @@ void Client::SetLevel(uint8 set_level, bool command)
 
 	QueuePacket(outapp);
 	safe_delete(outapp);
-	SendAppearancePacket(AT_WhoLevel, set_level); // who level change
+	SendAppearancePacket(AppearanceType::WhoLevel, set_level); // who level change
 
 	LogInfo("Setting Level for [{}] to [{}]", GetName(), set_level);
 

--- a/zone/gm_commands/acceptrules.cpp
+++ b/zone/gm_commands/acceptrules.cpp
@@ -8,6 +8,6 @@ void command_acceptrules(Client *c, const Seperator *sep)
 	}
 
 	database.SetAgreementFlag(c->AccountID());
-	c->SendAppearancePacket(AT_Anim, ANIM_STAND);
+	c->SendAppearancePacket(AppearanceType::Animation, Animation::Standing);
 	c->Message(Chat::White, "It is recorded you have agreed to the rules.");
 }

--- a/zone/gm_commands/appearance.cpp
+++ b/zone/gm_commands/appearance.cpp
@@ -2,25 +2,43 @@
 
 void command_appearance(Client *c, const Seperator *sep)
 {
-	Mob *t = c->CastToMob();
+	const int arguments = sep->argnum;
+	if (!arguments || !sep->IsNumber(1) || !sep->IsNumber(2)) {
+		c->Message(Chat::White, "Usage: #appearance [Type] [Value]");
+		c->Message(Chat::White, "Note: Types are as follows:");
 
-	// sends any appearance packet
-	// Dev debug command, for appearance types
-	if (sep->arg[2][0] == 0) {
-		c->Message(Chat::White, "Usage: #appearance type value");
-	}
-	else {
-		if ((c->GetTarget())) {
-			t = c->GetTarget();
+		for (const auto& a : EQ::constants::GetAppearanceTypeMap()) {
+			c->Message(
+				Chat::White,
+				fmt::format(
+					"Appearance Type {} | {}",
+					a.first,
+					a.second
+				).c_str()
+			);
 		}
-		t->SendAppearancePacket(Strings::ToInt(sep->arg[1]), Strings::ToInt(sep->arg[2]));
-		c->Message(
-			Chat::White,
-			"Sending appearance packet: target=%s, type=%s, value=%s",
-			t->GetName(),
-			sep->arg[1],
-			sep->arg[2]
-		);
-	}
-}
 
+		return;
+	}
+
+	Mob *t = c;
+	if (c->GetTarget()) {
+		t = c->GetTarget();
+	}
+
+	const uint32 type  = Strings::ToUnsignedInt(sep->arg[1]);
+	const uint32 value = Strings::ToUnsignedInt(sep->arg[2]);
+
+	t->SendAppearancePacket(type, value);
+
+	c->Message(
+		Chat::White,
+		fmt::format(
+			"Appearance Sent to {} | Type: {} ({}) Value: {}",
+			c->GetTargetDescription(t, TargetDescriptionType::UCSelf),
+			EQ::constants::GetAppearanceTypeName(type),
+			type,
+			value
+		).c_str()
+	);
+}

--- a/zone/gm_commands/set/flymode.cpp
+++ b/zone/gm_commands/set/flymode.cpp
@@ -51,7 +51,7 @@ void SetFlymode(Client *c, const Seperator *sep)
 	}
 
 	t->SetFlyMode(static_cast<GravityBehavior>(flymode_id));
-	t->SendAppearancePacket(AT_Levitate, flymode_id);
+	t->SendAppearancePacket(AppearanceType::FlyMode, flymode_id);
 
 	const uint32 account = c->AccountID();
 

--- a/zone/gm_commands/set/frozen.cpp
+++ b/zone/gm_commands/set/frozen.cpp
@@ -21,7 +21,7 @@ void SetFrozen(Client *c, const Seperator *sep)
 		return;
 	}
 
-	t->SendAppearancePacket(AT_Anim, is_frozen ? ANIM_FREEZE : ANIM_STAND);
+	t->SendAppearancePacket(AppearanceType::Animation, is_frozen ? Animation::Freeze : Animation::Standing);
 
 	c->Message(
 		Chat::White,

--- a/zone/gm_commands/set/god_mode.cpp
+++ b/zone/gm_commands/set/god_mode.cpp
@@ -26,7 +26,7 @@ void SetGodMode(Client *c, const Seperator *sep)
 	}
 
 	c->SetInvul(god_mode);
-	c->SendAppearancePacket(AT_Levitate, god_mode);
+	c->SendAppearancePacket(AppearanceType::FlyMode, god_mode);
 	c->SetHideMe(god_mode);
 
 	c->Message(

--- a/zone/guild.cpp
+++ b/zone/guild.cpp
@@ -146,12 +146,12 @@ void Client::SendGuildRanks()
 void Client::SendGuildSpawnAppearance() {
 	if (!IsInAGuild()) {
 		// clear guildtag
-		SendAppearancePacket(AT_GuildID, GUILD_NONE);
+		SendAppearancePacket(AppearanceType::GuildID, GUILD_NONE);
 		LogGuilds("Sending spawn appearance for no guild tag");
 	} else {
 		uint8 rank = guild_mgr.GetDisplayedRank(GuildID(), GuildRank(), CharacterID());
 		LogGuilds("Sending spawn appearance for guild [{}] at rank [{}]", GuildID(), rank);
-		SendAppearancePacket(AT_GuildID, GuildID());
+		SendAppearancePacket(AppearanceType::GuildID, GuildID());
 		if (ClientVersion() >= EQ::versions::ClientVersion::RoF)
 		{
 			switch (rank) {
@@ -161,7 +161,7 @@ void Client::SendGuildSpawnAppearance() {
 				default: { break; }				// GUILD_NONE
 			}
 		}
-		SendAppearancePacket(AT_GuildRank, rank);
+		SendAppearancePacket(AppearanceType::GuildRank, rank);
 	}
 	UpdateWho();
 }
@@ -372,8 +372,8 @@ void EntityList::SendGuildJoin(GuildJoin_Struct* gj){
 			return false;
 		// clear guildtag
 		guild_id = GUILD_NONE;
-		SendAppearancePacket(AT_GuildID, GUILD_NONE);
-		SendAppearancePacket(AT_GuildRank, GUILD_RANK_NONE);
+		SendAppearancePacket(AppearanceType::GuildID, GUILD_NONE);
+		SendAppearancePacket(AppearanceType::GuildRank, GUILD_RANK_NONE);
 		UpdateWho();
 		return true;
 	} else {
@@ -382,9 +382,9 @@ void EntityList::SendGuildJoin(GuildJoin_Struct* gj){
 		guildrank = in_rank;
 		if (guild_id != in_guild_id) {
 			guild_id = in_guild_id;
-			SendAppearancePacket(AT_GuildID, in_guild_id);
+			SendAppearancePacket(AppearanceType::GuildID, in_guild_id);
 		}
-		SendAppearancePacket(AT_GuildRank, in_rank);
+		SendAppearancePacket(AppearanceType::GuildRank, in_rank);
 		UpdateWho();
 		return true;
 	}

--- a/zone/loottables.cpp
+++ b/zone/loottables.cpp
@@ -248,7 +248,7 @@ void ZoneDatabase::AddLootDropToNPC(NPC *npc, uint32 lootdrop_id, ItemList *item
 	npc->UpdateEquipmentLight();
 	// no wearchange associated with this function..so, this should not be needed
 	//if (npc->UpdateActiveLightValue())
-	//	npc->SendAppearancePacket(AT_Light, npc->GetActiveLightValue());
+	//	npc->SendAppearancePacket(AppearanceType::Light, npc->GetActiveLightValue());
 }
 
 bool NPC::MeetsLootDropLevelRequirements(LootDropEntries_Struct loot_drop, bool verbose)
@@ -558,7 +558,7 @@ void NPC::AddLootDrop(
 	UpdateEquipmentLight();
 
 	if (UpdateActiveLight()) {
-		SendAppearancePacket(AT_Light, GetActiveLightType());
+		SendAppearancePacket(AppearanceType::Light, GetActiveLightType());
 	}
 }
 

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -1458,12 +1458,12 @@ void Lua_Client::AssignToInstance(int instance_id) {
 
 void Lua_Client::Freeze() {
 	Lua_Safe_Call_Void();
-	self->SendAppearancePacket(AT_Anim, ANIM_FREEZE);
+	self->SendAppearancePacket(AppearanceType::Animation, Animation::Freeze);
 }
 
 void Lua_Client::UnFreeze() {
 	Lua_Safe_Call_Void();
-	self->SendAppearancePacket(AT_Anim, ANIM_STAND);
+	self->SendAppearancePacket(AppearanceType::Animation, Animation::Standing);
 }
 
 uint32 Lua_Client::GetAggroCount() {

--- a/zone/merc.cpp
+++ b/zone/merc.cpp
@@ -4626,7 +4626,7 @@ void Merc::UpdateMercAppearance() {
 	}
 
 	if (UpdateActiveLight())
-		SendAppearancePacket(AT_Light, GetActiveLightType());
+		SendAppearancePacket(AppearanceType::Light, GetActiveLightType());
 }
 
 void Merc::UpdateEquipmentLight()
@@ -5653,7 +5653,7 @@ void Client::UpdateMercLevel() {
 	if (merc)
 	{
 		merc->UpdateMercStats(this, false);
-		merc->SendAppearancePacket(AT_WhoLevel, GetLevel(), true, true);
+		merc->SendAppearancePacket(AppearanceType::WhoLevel, GetLevel(), true, true);
 	}
 }
 

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -567,9 +567,8 @@ Mob::~Mob()
 	LeaveHealRotationTargetPool();
 }
 
-uint32 Mob::GetAppearanceValue(EmuAppearance iAppearance) {
-	switch (iAppearance) {
-		// 0 standing, 1 sitting, 2 ducking, 3 lieing down, 4 looting
+uint32 Mob::GetAppearanceValue(EmuAppearance in_appearance) {
+	switch (in_appearance) {
 		case eaStanding: {
 			return Animation::Standing;
 		}
@@ -585,11 +584,12 @@ uint32 Mob::GetAppearanceValue(EmuAppearance iAppearance) {
 		case eaLooting: {
 			return Animation::Looting;
 		}
-		//to shup up compiler:
-		case _eaMaxAppearance:
+		case _eaMaxAppearance: {
 			break;
+		}
 	}
-	return(Animation::Standing);
+
+	return Animation::Standing;
 }
 
 
@@ -4352,15 +4352,17 @@ const int64& Mob::SetMana(int64 amount)
 }
 
 
-void Mob::SetAppearance(EmuAppearance app, bool iIgnoreSelf) {
+void Mob::SetAppearance(EmuAppearance app, bool ignore_self) {
 	if (_appearance == app) {
 		return;
 	}
 
 	_appearance = app;
-	SendAppearancePacket(AppearanceType::Animation, GetAppearanceValue(app), true, iIgnoreSelf);
+
+	SendAppearancePacket(AppearanceType::Animation, GetAppearanceValue(app), true, ignore_self);
+
 	if (IsClient() && IsAIControlled()) {
-		SendAppearancePacket(AppearanceType::Animation, Animation::Freeze, false, false);
+		SendAppearancePacket(AppearanceType::Animation, Animation::Freeze, false);
 	}
 }
 

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1021,9 +1021,9 @@ public:
 	void SetFlurryChance(uint8 value) { SetSpecialAbilityParam(SPECATK_FLURRY, 0, value); }
 	uint8 GetFlurryChance() { return GetSpecialAbilityParam(SPECATK_FLURRY, 0); }
 
-	static uint32 GetAppearanceValue(EmuAppearance iAppearance);
+	static uint32 GetAppearanceValue(EmuAppearance in_appearance);
 	void SendAppearancePacket(uint32 type, uint32 value, bool whole_zone = true, bool ignore_self = false, Client* target = nullptr);
-	void SetAppearance(EmuAppearance app, bool iIgnoreSelf = true);
+	void SetAppearance(EmuAppearance app, bool ignore_self = true);
 	inline EmuAppearance GetAppearance() const { return _appearance; }
 	inline const int GetAnimation() const { return animation; }
 	inline void SetAnimation(int a) { animation = a; }

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1022,7 +1022,7 @@ public:
 	uint8 GetFlurryChance() { return GetSpecialAbilityParam(SPECATK_FLURRY, 0); }
 
 	static uint32 GetAppearanceValue(EmuAppearance iAppearance);
-	void SendAppearancePacket(uint32 type, uint32 value, bool WholeZone = true, bool iIgnoreSelf = false, Client *specific_target=nullptr);
+	void SendAppearancePacket(uint32 type, uint32 value, bool whole_zone = true, bool ignore_self = false, Client* target = nullptr);
 	void SetAppearance(EmuAppearance app, bool iIgnoreSelf = true);
 	inline EmuAppearance GetAppearance() const { return _appearance; }
 	inline const int GetAnimation() const { return animation; }

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -472,8 +472,8 @@ void Client::AI_Start(uint32 iMoveDelay) {
 		return;
 
 	pClientSideTarget = GetTarget() ? GetTarget()->GetID() : 0;
-	SendAppearancePacket(AT_Anim, ANIM_FREEZE);	// this freezes the client
-	SendAppearancePacket(AT_Linkdead, 1); // Sending LD packet so *LD* appears by the player name when charmed/feared -Kasai
+	SendAppearancePacket(AppearanceType::Animation, Animation::Freeze);	// this freezes the client
+	SendAppearancePacket(AppearanceType::Linkdead, 1); // Sending LD packet so *LD* appears by the player name when charmed/feared -Kasai
 	SetAttackTimer();
 	SetFeigned(false);
 }
@@ -537,8 +537,8 @@ void Client::AI_Stop() {
 	safe_delete(app);
 
 	SetTarget(entity_list.GetMob(pClientSideTarget));
-	SendAppearancePacket(AT_Anim, GetAppearanceValue(GetAppearance()));
-	SendAppearancePacket(AT_Linkdead, 0); // Removing LD packet so *LD* no longer appears by the player name when charmed/feared -Kasai
+	SendAppearancePacket(AppearanceType::Animation, GetAppearanceValue(GetAppearance()));
+	SendAppearancePacket(AppearanceType::Linkdead, 0); // Removing LD packet so *LD* no longer appears by the player name when charmed/feared -Kasai
 	if (!auto_attack) {
 		attack_timer.Disable();
 		attack_dw_timer.Disable();

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -602,14 +602,14 @@ void NPC::RemoveItem(uint32 item_id, uint16 quantity, uint16 slot) {
 		if (item->item_id == item_id && slot <= 0 && quantity <= 0) {
 			itemlist.erase(cur);
 			UpdateEquipmentLight();
-			if (UpdateActiveLight()) { SendAppearancePacket(AT_Light, GetActiveLightType()); }
+			if (UpdateActiveLight()) { SendAppearancePacket(AppearanceType::Light, GetActiveLightType()); }
 			return;
 		}
 		else if (item->item_id == item_id && item->equip_slot == slot && quantity >= 1) {
 			if (item->charges <= quantity) {
 				itemlist.erase(cur);
 				UpdateEquipmentLight();
-				if (UpdateActiveLight()) { SendAppearancePacket(AT_Light, GetActiveLightType()); }
+				if (UpdateActiveLight()) { SendAppearancePacket(AppearanceType::Light, GetActiveLightType()); }
 			}
 			else {
 				item->charges -= quantity;
@@ -655,7 +655,7 @@ void NPC::CheckTrivialMinMaxLevelDrop(Mob *killer)
 
 	UpdateEquipmentLight();
 	if (UpdateActiveLight()) {
-		SendAppearancePacket(AT_Light, GetActiveLightType());
+		SendAppearancePacket(AppearanceType::Light, GetActiveLightType());
 	}
 }
 
@@ -671,7 +671,7 @@ void NPC::ClearItemList() {
 
 	UpdateEquipmentLight();
 	if (UpdateActiveLight())
-		SendAppearancePacket(AT_Light, GetActiveLightType());
+		SendAppearancePacket(AppearanceType::Light, GetActiveLightType());
 }
 
 void NPC::QueryLoot(Client* to, bool is_pet_query)
@@ -2439,7 +2439,7 @@ void NPC::SetLevel(uint8 in_level, bool command)
 	if(in_level > level)
 		SendLevelAppearance();
 	level = in_level;
-	SendAppearancePacket(AT_WhoLevel, in_level);
+	SendAppearancePacket(AppearanceType::WhoLevel, in_level);
 }
 
 void NPC::ModifyNPCStat(const std::string& stat, const std::string& value)

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -1440,12 +1440,12 @@ void Perl_Client_RemoveFromInstance(Client* self, uint16 instance_id) // @catego
 
 void Perl_Client_Freeze(Client* self)
 {
-	self->SendAppearancePacket(AT_Anim, ANIM_FREEZE);
+	self->SendAppearancePacket(AppearanceType::Animation, Animation::Freeze);
 }
 
 void Perl_Client_UnFreeze(Client* self)
 {
-	self->SendAppearancePacket(AT_Anim, ANIM_STAND);
+	self->SendAppearancePacket(AppearanceType::Animation, Animation::Standing);
 }
 
 uint32 Perl_Client_GetAggroCount(Client* self) // @categories Script Utility, Hate and Aggro

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -2322,7 +2322,7 @@ void Perl_Mob_SetDeltas(Mob* self, float delta_x, float delta_y, float delta_z, 
 
 void Perl_Mob_SetLD(Mob* self, bool value) // @categories Script Utility
 {
-	self->SendAppearancePacket(AT_Linkdead, value);
+	self->SendAppearancePacket(AppearanceType::Linkdead, value);
 }
 
 void Perl_Mob_SetTargetable(Mob* self, bool on) // @categories Stats and Attributes

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -3538,12 +3538,12 @@ void QuestManager::FlyMode(GravityBehavior flymode)
 	QuestManagerCurrentQuestVars();
 	if(initiator)
 	{
-		initiator->SendAppearancePacket(AT_Levitate, static_cast<int>(flymode));
+		initiator->SendAppearancePacket(AppearanceType::FlyMode, static_cast<int>(flymode));
 		initiator->SetFlyMode(flymode);
 	}
 	else if(owner)
 	{
-		owner->SendAppearancePacket(AT_Levitate, static_cast<int>(flymode));
+		owner->SendAppearancePacket(AppearanceType::FlyMode, static_cast<int>(flymode));
 		owner->SetFlyMode(flymode);
 	}
 }

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -810,7 +810,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					entity_list.QueueClients(this, app);
 					safe_delete(app);
 					SendPetBuffsToClient();
-					SendAppearancePacket(AT_Pet, caster->GetID(), true, true);
+					SendAppearancePacket(AppearanceType::Pet, caster->GetID(), true, true);
 				}
 
 				if (IsClient())
@@ -1435,10 +1435,10 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				//this sends the levitate packet to everybody else
 				//who does not otherwise receive the buff packet.
 				if (spells[spell_id].limit_value[i] == 1) {
-					SendAppearancePacket(AT_Levitate, EQ::constants::GravityBehavior::LevitateWhileRunning, true, true);
+					SendAppearancePacket(AppearanceType::FlyMode, EQ::constants::GravityBehavior::LevitateWhileRunning, true, true);
 				}
 				else {
-					SendAppearancePacket(AT_Levitate, EQ::constants::GravityBehavior::Levitating, true, true);
+					SendAppearancePacket(AppearanceType::FlyMode, EQ::constants::GravityBehavior::Levitating, true, true);
 				}
 				break;
 			}
@@ -1482,7 +1482,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 								.texture = caster->GetTarget()->GetTexture(),
 							}
 						);
-						caster->SendAppearancePacket(AT_Size, static_cast<uint32>(caster->GetTarget()->GetSize()));
+						caster->SendAppearancePacket(AppearanceType::Size, static_cast<uint32>(caster->GetTarget()->GetSize()));
 
 						for (int x = EQ::textures::textureBegin; x <= EQ::textures::LastTintableTexture; x++)
 							caster->SendWearChange(x);
@@ -4278,7 +4278,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 			{
 				SendIllusionPacket(AppearanceStruct{});
 				// The GetSize below works because the above setting race to zero sets size back.
-				SendAppearancePacket(AT_Size, GetSize());
+				SendAppearancePacket(AppearanceType::Size, GetSize());
 
 				for (int x = EQ::textures::textureBegin; x <= EQ::textures::LastTintableTexture; x++) {
 					SendWearChange(x);
@@ -4290,7 +4290,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 			case SE_Levitate:
 			{
 				if (!AffectedBySpellExcludingSlot(slot, SE_Levitate))
-					SendAppearancePacket(AT_Levitate, 0);
+					SendAppearancePacket(AppearanceType::FlyMode, 0);
 				break;
 			}
 
@@ -4337,7 +4337,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 
 			case SE_Mez:
 			{
-				SendAppearancePacket(AT_Anim, ANIM_STAND);	// unfreeze
+				SendAppearancePacket(AppearanceType::Animation, Animation::Standing);	// unfreeze
 				mezzed = false;
 				break;
 			}
@@ -4350,7 +4350,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 					CastToNPC()->ModifyStatsOnCharm(true);
 				}
 
-				SendAppearancePacket(AT_Pet, 0, true, true);
+				SendAppearancePacket(AppearanceType::Pet, 0, true, true);
 				Mob* owner = GetOwner();
 				SetOwnerID(0);
 				SetPetType(petNone);
@@ -4437,7 +4437,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 							SetSpecialAbility(IMMUNE_AGGRO, 0);
 						}
 					}
-					SendAppearancePacket(AT_Anim, ANIM_STAND);
+					SendAppearancePacket(AppearanceType::Animation, Animation::Standing);
 				}
 				if(owner && owner->IsClient())
 				{
@@ -10335,7 +10335,7 @@ void Mob::ApplySpellEffectIllusion(int32 spell_id, Mob *caster, int buffslot, in
 			SetFaceAppearance(f);
 		}
 
-		SendAppearancePacket(AT_Size, race_size);
+		SendAppearancePacket(AppearanceType::Size, race_size);
 	}
 
 	for (int x = EQ::textures::textureBegin; x <= EQ::textures::LastTintableTexture; x++) {


### PR DESCRIPTION
# Notes
- Cleanup messages and logic.
- Cleanup appearance type constants to use a namespace with constexpr instead.
- Cleanup animation constants to use a namespace with constexpr instead.

## Usage Menu
![image](https://github.com/EQEmu/Server/assets/89047260/70e5e301-20bd-49dd-98b5-9b09904e050e)

## Usage
![image](https://github.com/EQEmu/Server/assets/89047260/bffffed8-ce2e-421d-b771-478adba2d7ef)
![image](https://github.com/EQEmu/Server/assets/89047260/d7ece0ce-f48e-48c0-91ce-cb6972b61b38)
