### PR TITLE
[Commands] Cleanup #shutdown Command

### DIFF
--- a/zone/gm_commands/shutdown.cpp
+++ b/zone/gm_commands/shutdown.cpp
@@ -3,6 +3,22 @@
 
 void command_shutdown(Client *c, const Seperator *sep)
 {
-	CatchSignal(2);
-}
+	const int arguments = sep->argnum;
+	if (!arguments) {
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"Using this command will shut down your current zone. Please {} this is what you want to do.",
+				Saylink::Silent("#shutdown confirm", "confirm")
+			).c_str()
+		);
+		return;
+	}
 
+	const bool is_confirm = !strcasecmp(sep->arg[1], "confirm");
+
+	if (is_confirm) {
+		c->Message(Chat::White, "Shutting down your current zone.");
+		CatchSignal(2);
+	}
+}


### PR DESCRIPTION
# Notes
- Cleanup messages and logic.
- Add a confirmation so operators don't accidentally shutdown the zone they're in thinking this is `#worldshutdown` instead.

## Confirmation Message
![image](https://github.com/EQEmu/Server/assets/89047260/9d6f743d-d268-45ff-b562-8ef15080d592)

## Confirmation Sent
![image](https://github.com/EQEmu/Server/assets/89047260/f63416b4-41cd-4a51-98cd-be6a3acdec58)
