### PR TITLE
[Crash] Fix crash where Raid invite could be accepted after forming group with the Raid invitor.

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -12053,6 +12053,11 @@ void Client::Handle_OP_RaidCommand(const EQApplicationPacket* app)
 			{
 				auto player_sending_invite_group = player_sending_invite->GetGroup();
 				Group* group = GetGroup();
+
+				if (group && group == player_sending_invite_group) {
+					break;
+				}
+
 				if (group) //if our target has a group
 				{
 					raid = new Raid(player_sending_invite);

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -12054,8 +12054,10 @@ void Client::Handle_OP_RaidCommand(const EQApplicationPacket* app)
 				auto player_sending_invite_group = player_sending_invite->GetGroup();
 				Group* group = GetGroup();
 
+				/* Prevent scenario where player had joined group with Raid invitor before accepting Raid invite */
 				if (group && group == player_sending_invite_group) {
-					break;
+					player_sending_invite->MessageString(Chat::Red, INVITE_GROUP_LEADER);
+					return;
 				}
 
 				if (group) //if our target has a group

--- a/zone/string_ids.h
+++ b/zone/string_ids.h
@@ -177,6 +177,7 @@
 #define CANNOT_WAKE					555		//%1 tells you, 'I am unable to wake %2, master.'
 #define SUMMONING_CORPSE_ZONE		596		//Summoning %1's corpse(s).
 #define TASK_NOT_RIGHT_LEVEL        615     //You are not at the right level for this task.
+#define INVITE_GROUP_LEADER			679		//To invite another group into yours, please invite the leader of the other group.
 #define PET_HOLD_SET_ON				698		//The pet hold mode has been set to on.
 #define PET_HOLD_SET_OFF			699		//The pet hold mode has been set to off.
 #define PET_FOCUS_SET_ON			700		//The pet focus mode has been set to on.


### PR DESCRIPTION
This fixes a crash described in #3048 

The Raid invitor will be notified when the raid invite fails.

![image](https://github.com/EQEmu/Server/assets/109764533/cb12f8d5-c858-48bb-9145-72ce947af0f6)


