### PR TITLE
[Bots] bot command resist spell list fix

### DIFF
--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -404,38 +404,38 @@ public:
 
 						for (int i = EffectIDFirst; i <= EffectIDLast; ++i) {
 							int effect_index = EFFECTIDTOINDEX(i);
-							if (spells[spell_id].base_value[effect_index] <= 0)
+							if (spells[spell_id].max_value[effect_index] <= 0)
 								continue;
 
 							switch (spells[spell_id].effect_id[effect_index]) {
 								case SE_ResistFire:
 									entry_prototype->SafeCastToResistance()->resist_value[RESISTANCEIDTOINDEX(
-										BCEnum::RT_Fire)] += spells[spell_id].base_value[effect_index];
+										BCEnum::RT_Fire)] += spells[spell_id].max_value[effect_index];
 									break;
 								case SE_ResistCold:
 									entry_prototype->SafeCastToResistance()->resist_value[RESISTANCEIDTOINDEX(
-										BCEnum::RT_Cold)] += spells[spell_id].base_value[effect_index];
+										BCEnum::RT_Cold)] += spells[spell_id].max_value[effect_index];
 									break;
 								case SE_ResistPoison:
 									entry_prototype->SafeCastToResistance()->resist_value[RESISTANCEIDTOINDEX(
-										BCEnum::RT_Poison)] += spells[spell_id].base_value[effect_index];
+										BCEnum::RT_Poison)] += spells[spell_id].max_value[effect_index];
 									break;
 								case SE_ResistDisease:
 									entry_prototype->SafeCastToResistance()->resist_value[RESISTANCEIDTOINDEX(
-										BCEnum::RT_Disease)] += spells[spell_id].base_value[effect_index];
+										BCEnum::RT_Disease)] += spells[spell_id].max_value[effect_index];
 									break;
 								case SE_ResistMagic:
 									entry_prototype->SafeCastToResistance()->resist_value[RESISTANCEIDTOINDEX(
-										BCEnum::RT_Magic)] += spells[spell_id].base_value[effect_index];
+										BCEnum::RT_Magic)] += spells[spell_id].max_value[effect_index];
 									break;
 								case SE_ResistCorruption:
 									entry_prototype->SafeCastToResistance()->resist_value[RESISTANCEIDTOINDEX(
-										BCEnum::RT_Corruption)] += spells[spell_id].base_value[effect_index];
+										BCEnum::RT_Corruption)] += spells[spell_id].max_value[effect_index];
 									break;
 								default:
 									continue;
 							}
-							entry_prototype->SafeCastToResistance()->resist_total += spells[spell_id].base_value[effect_index];
+							entry_prototype->SafeCastToResistance()->resist_total += spells[spell_id].max_value[effect_index];
 							valid_spell = true;
 						}
 						if (!valid_spell) {


### PR DESCRIPTION
Bots were not casting the highest level spell with ^resist. Base_value was being used to compare resist spells, but this is typically the same value for all resist spells. This fix should be easier than calculating the caster bots level adjusted "resist_total".