### PR TITLE
[Character] Convert Delete/Save of Character Memmed Spells to Repositories

### DIFF
--- a/common/repositories/base/base_character_memmed_spells_repository.h
+++ b/common/repositories/base/base_character_memmed_spells_repository.h
@@ -6,7 +6,7 @@
  * Any modifications to base repositories are to be made by the generator only
  *
  * @generator ./utils/scripts/generators/repository-generator.pl
- * @docs https://eqemu.gitbook.io/server/in-development/developer-area/repositories
+ * @docs https://docs.eqemu.io/developer/repositories
  */
 
 #ifndef EQEMU_BASE_CHARACTER_MEMMED_SPELLS_REPOSITORY_H
@@ -15,6 +15,7 @@
 #include "../../database.h"
 #include "../../strings.h"
 #include <ctime>
+
 
 class BaseCharacterMemmedSpellsRepository {
 public:
@@ -112,8 +113,9 @@ public:
 	{
 		auto results = db.QueryDatabase(
 			fmt::format(
-				"{} WHERE id = {} LIMIT 1",
+				"{} WHERE {} = {} LIMIT 1",
 				BaseSelect(),
+				PrimaryKey(),
 				character_memmed_spells_id
 			)
 		);
@@ -338,6 +340,66 @@ public:
 		return (results.Success() && results.begin()[0] ? strtoll(results.begin()[0], nullptr, 10) : 0);
 	}
 
+	static std::string BaseReplace()
+	{
+		return fmt::format(
+			"REPLACE INTO {} ({}) ",
+			TableName(),
+			ColumnsRaw()
+		);
+	}
+
+	static int ReplaceOne(
+		Database& db,
+		const CharacterMemmedSpells &e
+	)
+	{
+		std::vector<std::string> v;
+
+		v.push_back(std::to_string(e.id));
+		v.push_back(std::to_string(e.slot_id));
+		v.push_back(std::to_string(e.spell_id));
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} VALUES ({})",
+				BaseReplace(),
+				Strings::Implode(",", v)
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
+
+	static int ReplaceMany(
+		Database& db,
+		const std::vector<CharacterMemmedSpells> &entries
+	)
+	{
+		std::vector<std::string> insert_chunks;
+
+		for (auto &e: entries) {
+			std::vector<std::string> v;
+
+			v.push_back(std::to_string(e.id));
+			v.push_back(std::to_string(e.slot_id));
+			v.push_back(std::to_string(e.spell_id));
+
+			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
+		}
+
+		std::vector<std::string> v;
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} VALUES {}",
+				BaseReplace(),
+				Strings::Implode(",", insert_chunks)
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
 };
 
 #endif //EQEMU_BASE_CHARACTER_MEMMED_SPELLS_REPOSITORY_H

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -5602,7 +5602,7 @@ void Client::UnmemSpell(int slot, bool update_client)
 
 	LogSpells("Spell [{}] forgotten from slot [{}]", m_pp.mem_spells[slot], slot);
 
-	database.DeleteCharacterMemorizedSpell(CharacterID(), m_pp.mem_spells[slot], slot);
+	database.DeleteCharacterMemorizedSpell(CharacterID(), slot);
 
 	if (update_client) {
 		MemorizeSpell(slot, m_pp.mem_spells[slot], memSpellForget);

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -1280,11 +1280,7 @@ bool ZoneDatabase::SaveCharacterMemorizedSpell(uint32 character_id, uint32 spell
 
 	const int replaced = CharacterMemmedSpellsRepository::ReplaceOne(*this, e);
 
-	if (!replaced) {
-		return false;
-	}
-
-	return true;
+	return replaced;
 }
 
 bool ZoneDatabase::SaveCharacterSpell(uint32 character_id, uint32 spell_id, uint32 slot_id){

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -1272,15 +1272,14 @@ bool ZoneDatabase::SaveCharacterMemorizedSpell(uint32 character_id, uint32 spell
 		return false;
 	}
 
-	auto e = CharacterMemmedSpellsRepository::NewEntity();
-
-	e.id       = character_id;
-	e.slot_id  = slot_id;
-	e.spell_id = spell_id;
-
-	const int replaced = CharacterMemmedSpellsRepository::ReplaceOne(*this, e);
-
-	return replaced;
+	return CharacterMemmedSpellsRepository::ReplaceOne(
+		*this,
+		CharacterMemmedSpellsRepository::CharacterMemmedSpells{
+			.id = character_id,
+			.slot_id = static_cast<uint16_t>(slot_id),
+			.spell_id = static_cast<uint16_t>(spell_id)
+		}
+	);
 }
 
 bool ZoneDatabase::SaveCharacterSpell(uint32 character_id, uint32 spell_id, uint32 slot_id){
@@ -1326,7 +1325,7 @@ bool ZoneDatabase::DeleteCharacterMaterialColor(uint32 character_id)
 
 bool ZoneDatabase::DeleteCharacterMemorizedSpell(uint32 character_id, uint32 slot_id)
 {
-	const int deleted = CharacterMemmedSpellsRepository::DeleteWhere(
+	return CharacterMemmedSpellsRepository::DeleteWhere(
 		*this,
 		fmt::format(
 			"`id` = {} AND `slot_id` = {}",
@@ -1334,12 +1333,6 @@ bool ZoneDatabase::DeleteCharacterMemorizedSpell(uint32 character_id, uint32 slo
 			slot_id
 		)
 	);
-
-	if (!deleted) {
-		return false;
-	}
-
-	return true;
 }
 
 bool ZoneDatabase::NoRentExpired(const char* name){

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -427,7 +427,7 @@ public:
 	bool DeleteCharacterDisc(uint32 character_id, uint32 slot_id);
 	bool DeleteCharacterMaterialColor(uint32 character_id);
 	bool DeleteCharacterLeadershipAbilities(uint32 character_id);
-	bool DeleteCharacterMemorizedSpell(uint32 character_id, uint32 spell_id, uint32 slot_id);
+	bool DeleteCharacterMemorizedSpell(uint32 character_id, uint32 slot_id);
 	bool DeleteCharacterSpell(uint32 character_id, uint32 spell_id, uint32 slot_id);
 
 	bool LoadCharacterBandolier(uint32 character_id, PlayerProfile_Struct* pp);


### PR DESCRIPTION
# Notes
- Converts `DeleteCharacterMemorizedSpell` and `LoadCharacterMemmedSpells` to repositories.

# Images
## Memmed
![image](https://github.com/EQEmu/Server/assets/89047260/4ad3497a-43cc-40a5-b1d7-4050d4bb453b)
![image](https://github.com/EQEmu/Server/assets/89047260/ee555759-1a4b-43c4-87c4-adb0c1f84fe2)

## Unmemmed
![image](https://github.com/EQEmu/Server/assets/89047260/2a84ffd4-3ac0-420c-ab9b-b9e387b4cb99)
![image](https://github.com/EQEmu/Server/assets/89047260/68f706d7-a10b-445c-8e57-32a4f189a0ac)
