### PR TITLE
[Character] Convert Delete/Load/Save of Character Spells to Repositories

### DIFF
--- a/common/repositories/base/base_character_spells_repository.h
+++ b/common/repositories/base/base_character_spells_repository.h
@@ -6,7 +6,7 @@
  * Any modifications to base repositories are to be made by the generator only
  *
  * @generator ./utils/scripts/generators/repository-generator.pl
- * @docs https://eqemu.gitbook.io/server/in-development/developer-area/repositories
+ * @docs https://docs.eqemu.io/developer/repositories
  */
 
 #ifndef EQEMU_BASE_CHARACTER_SPELLS_REPOSITORY_H
@@ -15,6 +15,7 @@
 #include "../../database.h"
 #include "../../strings.h"
 #include <ctime>
+
 
 class BaseCharacterSpellsRepository {
 public:
@@ -112,8 +113,9 @@ public:
 	{
 		auto results = db.QueryDatabase(
 			fmt::format(
-				"{} WHERE id = {} LIMIT 1",
+				"{} WHERE {} = {} LIMIT 1",
 				BaseSelect(),
+				PrimaryKey(),
 				character_spells_id
 			)
 		);
@@ -337,6 +339,66 @@ public:
 		return (results.Success() && results.begin()[0] ? strtoll(results.begin()[0], nullptr, 10) : 0);
 	}
 
+	static std::string BaseReplace()
+	{
+		return fmt::format(
+			"REPLACE INTO {} ({}) ",
+			TableName(),
+			ColumnsRaw()
+		);
+	}
+
+	static int ReplaceOne(
+		Database& db,
+		const CharacterSpells &e
+	)
+	{
+		std::vector<std::string> v;
+
+		v.push_back(std::to_string(e.id));
+		v.push_back(std::to_string(e.slot_id));
+		v.push_back(std::to_string(e.spell_id));
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} VALUES ({})",
+				BaseReplace(),
+				Strings::Implode(",", v)
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
+
+	static int ReplaceMany(
+		Database& db,
+		const std::vector<CharacterSpells> &entries
+	)
+	{
+		std::vector<std::string> insert_chunks;
+
+		for (auto &e: entries) {
+			std::vector<std::string> v;
+
+			v.push_back(std::to_string(e.id));
+			v.push_back(std::to_string(e.slot_id));
+			v.push_back(std::to_string(e.spell_id));
+
+			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
+		}
+
+		std::vector<std::string> v;
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} VALUES {}",
+				BaseReplace(),
+				Strings::Implode(",", insert_chunks)
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
 };
 
 #endif //EQEMU_BASE_CHARACTER_SPELLS_REPOSITORY_H

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -5771,7 +5771,7 @@ void Client::Handle_OP_DeleteSpell(const EQApplicationPacket *app)
 
 	if (m_pp.spell_book[dss->spell_slot] != SPELLBOOK_UNKNOWN) {
 		m_pp.spell_book[dss->spell_slot] = SPELLBOOK_UNKNOWN;
-		database.DeleteCharacterSpell(CharacterID(), m_pp.spell_book[dss->spell_slot], dss->spell_slot);
+		database.DeleteCharacterSpell(CharacterID(), dss->spell_slot);
 		dss->success = 1;
 	}
 	else
@@ -14550,10 +14550,10 @@ void Client::Handle_OP_SwapSpell(const EQApplicationPacket *app)
 
 	/* Save Spell Swaps */
 	if (!database.SaveCharacterSpell(CharacterID(), m_pp.spell_book[swapspell->from_slot], swapspell->from_slot)) {
-		database.DeleteCharacterSpell(CharacterID(), m_pp.spell_book[swapspell->from_slot], swapspell->from_slot);
+		database.DeleteCharacterSpell(CharacterID(), swapspell->from_slot);
 	}
 	if (!database.SaveCharacterSpell(CharacterID(), swapspelltemp, swapspell->to_slot)) {
-		database.DeleteCharacterSpell(CharacterID(), swapspelltemp, swapspell->to_slot);
+		database.DeleteCharacterSpell(CharacterID(), swapspell->to_slot);
 	}
 
 	QueuePacket(app);

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -5707,7 +5707,7 @@ void Client::UnscribeSpell(int slot, bool update_client, bool defer_save)
 	LogSpells("Spell [{}] erased from spell book slot [{}]", m_pp.spell_book[slot], slot);
 
 	if (!defer_save) {
-		database.DeleteCharacterSpell(CharacterID(), m_pp.spell_book[slot], slot);
+		database.DeleteCharacterSpell(CharacterID(), slot);
 	}
 
 	if (update_client && slot < EQ::spells::DynamicLookup(ClientVersion(), GetGM())->SpellbookSize) {

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -1287,20 +1287,19 @@ bool ZoneDatabase::SaveCharacterSpell(uint32 character_id, uint32 spell_id, uint
 		return false;
 	}
 
-	auto e = CharacterSpellsRepository::NewEntity();
-
-	e.id       = character_id;
-	e.slot_id  = slot_id;
-	e.spell_id = spell_id;
-
-	const int replaced = CharacterSpellsRepository::ReplaceOne(*this, e);
-
-	return replaced;
+	return CharacterSpellsRepository::ReplaceOne(
+		*this,
+		CharacterSpellsRepository::CharacterSpells{
+			.id = character_id,
+			.slot_id = static_cast<uint16_t>(slot_id),
+			.spell_id = static_cast<uint16_t>(spell_id)
+		}
+	);
 }
 
 bool ZoneDatabase::DeleteCharacterSpell(uint32 character_id, uint32 slot_id)
 {
-	const int deleted = CharacterSpellsRepository::DeleteWhere(
+	return CharacterSpellsRepository::DeleteWhere(
 		*this,
 		fmt::format(
 			"`id` = {} AND `slot_id` = {}",
@@ -1308,8 +1307,6 @@ bool ZoneDatabase::DeleteCharacterSpell(uint32 character_id, uint32 slot_id)
 			slot_id
 		)
 	);
-
-	return deleted;
 }
 
 bool ZoneDatabase::DeleteCharacterDisc(uint32 character_id, uint32 slot_id){

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -428,7 +428,7 @@ public:
 	bool DeleteCharacterMaterialColor(uint32 character_id);
 	bool DeleteCharacterLeadershipAbilities(uint32 character_id);
 	bool DeleteCharacterMemorizedSpell(uint32 character_id, uint32 slot_id);
-	bool DeleteCharacterSpell(uint32 character_id, uint32 spell_id, uint32 slot_id);
+	bool DeleteCharacterSpell(uint32 character_id, uint32 slot_id);
 
 	bool LoadCharacterBandolier(uint32 character_id, PlayerProfile_Struct* pp);
 	bool LoadCharacterBindPoint(uint32 character_id, PlayerProfile_Struct* pp);


### PR DESCRIPTION
# Notes
- Converts `DeleteCharacterSpell`, `LoadCharacterSpellBook`, and `SaveCharacterSpell` to repositories.

# Images
## Load
![image](https://github.com/EQEmu/Server/assets/89047260/d7eefaf4-4196-4a58-be1f-0c16c32b3f7f)
![image](https://github.com/EQEmu/Server/assets/89047260/6c0123e4-9122-4344-bdf1-1ef8c5c4b77d)

## Delete
![image](https://github.com/EQEmu/Server/assets/89047260/f625fec8-818a-43bf-925a-d682d7a8313a)
![image](https://github.com/EQEmu/Server/assets/89047260/2d533bf1-e0d0-4f88-b21f-f51976988f16)

## Save
![image](https://github.com/EQEmu/Server/assets/89047260/0a3e84aa-cffa-4570-8696-fe084b2c9bdf)
![image](https://github.com/EQEmu/Server/assets/89047260/b15f8a43-61e0-44c7-9289-a94a4d82e1da)
