### PR TITLE
[Character] Convert Delete/Load/Save of Character Bandolier to Repositories

### DIFF
--- a/common/repositories/base/base_character_bandolier_repository.h
+++ b/common/repositories/base/base_character_bandolier_repository.h
@@ -6,7 +6,7 @@
  * Any modifications to base repositories are to be made by the generator only
  *
  * @generator ./utils/scripts/generators/repository-generator.pl
- * @docs https://eqemu.gitbook.io/server/in-development/developer-area/repositories
+ * @docs https://docs.eqemu.io/developer/repositories
  */
 
 #ifndef EQEMU_BASE_CHARACTER_BANDOLIER_REPOSITORY_H
@@ -15,6 +15,7 @@
 #include "../../database.h"
 #include "../../strings.h"
 #include <ctime>
+
 
 class BaseCharacterBandolierRepository {
 public:
@@ -124,8 +125,9 @@ public:
 	{
 		auto results = db.QueryDatabase(
 			fmt::format(
-				"{} WHERE id = {} LIMIT 1",
+				"{} WHERE {} = {} LIMIT 1",
 				BaseSelect(),
+				PrimaryKey(),
 				character_bandolier_id
 			)
 		);
@@ -368,6 +370,72 @@ public:
 		return (results.Success() && results.begin()[0] ? strtoll(results.begin()[0], nullptr, 10) : 0);
 	}
 
+	static std::string BaseReplace()
+	{
+		return fmt::format(
+			"REPLACE INTO {} ({}) ",
+			TableName(),
+			ColumnsRaw()
+		);
+	}
+
+	static int ReplaceOne(
+		Database& db,
+		const CharacterBandolier &e
+	)
+	{
+		std::vector<std::string> v;
+
+		v.push_back(std::to_string(e.id));
+		v.push_back(std::to_string(e.bandolier_id));
+		v.push_back(std::to_string(e.bandolier_slot));
+		v.push_back(std::to_string(e.item_id));
+		v.push_back(std::to_string(e.icon));
+		v.push_back("'" + Strings::Escape(e.bandolier_name) + "'");
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} VALUES ({})",
+				BaseReplace(),
+				Strings::Implode(",", v)
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
+
+	static int ReplaceMany(
+		Database& db,
+		const std::vector<CharacterBandolier> &entries
+	)
+	{
+		std::vector<std::string> insert_chunks;
+
+		for (auto &e: entries) {
+			std::vector<std::string> v;
+
+			v.push_back(std::to_string(e.id));
+			v.push_back(std::to_string(e.bandolier_id));
+			v.push_back(std::to_string(e.bandolier_slot));
+			v.push_back(std::to_string(e.item_id));
+			v.push_back(std::to_string(e.icon));
+			v.push_back("'" + Strings::Escape(e.bandolier_name) + "'");
+
+			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
+		}
+
+		std::vector<std::string> v;
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} VALUES {}",
+				BaseReplace(),
+				Strings::Implode(",", insert_chunks)
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
 };
 
 #endif //EQEMU_BASE_CHARACTER_BANDOLIER_REPOSITORY_H

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -918,14 +918,7 @@ bool ZoneDatabase::LoadCharacterBandolier(uint32 character_id, PlayerProfile_Str
 	return true;
 }
 
-```cpp
-namespace DeathSave {
-	constexpr uint32 HP300  = 1;
-	constexpr uint32 HP8000 = 2;
-}
-```
-
-	void ZoneDatabase::LoadCharacterTribute(Client* c){
+void ZoneDatabase::LoadCharacterTribute(Client* c){
 	const auto& l = CharacterTributeRepository::GetWhere(database, fmt::format("character_id = {}", c->CharacterID()));
 
 	for (auto& t : c->GetPP().tributes) {

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -911,12 +911,21 @@ bool ZoneDatabase::LoadCharacterBandolier(uint32 character_id, PlayerProfile_Str
 
 			pp->bandoliers[e.bandolier_id].Items[e.bandolier_slot].Name[0] = '\0';
 		}
+
+		strncpy(pp->bandoliers[e.bandolier_id].Name, e.bandolier_name, 32);
 	}
 
 	return true;
 }
 
-void ZoneDatabase::LoadCharacterTribute(Client* c){
+```cpp
+namespace DeathSave {
+	constexpr uint32 HP300  = 1;
+	constexpr uint32 HP8000 = 2;
+}
+```
+
+	void ZoneDatabase::LoadCharacterTribute(Client* c){
 	const auto& l = CharacterTributeRepository::GetWhere(database, fmt::format("character_id = {}", c->CharacterID()));
 
 	for (auto& t : c->GetPP().tributes) {

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -900,9 +900,10 @@ bool ZoneDatabase::LoadCharacterBandolier(uint32 character_id, PlayerProfile_Str
 			pp->bandoliers[e.bandolier_id].Items[e.bandolier_slot].ID   = item_data->ID;
 			pp->bandoliers[e.bandolier_id].Items[e.bandolier_slot].Icon = e.icon;
 
-			strcpy(
+			strncpy(
 				pp->bandoliers[e.bandolier_id].Items[e.bandolier_slot].Name,
-				item_data->Name
+				item_data->Name,
+				64
 			);
 		} else {
 			pp->bandoliers[e.bandolier_id].Items[e.bandolier_slot].ID   = 0;

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -900,17 +900,15 @@ bool ZoneDatabase::LoadCharacterBandolier(uint32 character_id, PlayerProfile_Str
 			pp->bandoliers[e.bandolier_id].Items[e.bandolier_slot].ID   = item_data->ID;
 			pp->bandoliers[e.bandolier_id].Items[e.bandolier_slot].Icon = e.icon;
 
-			strn0cpy(
+			strcpy(
 				pp->bandoliers[e.bandolier_id].Items[e.bandolier_slot].Name,
-				item_data->Name,
-				sizeof(pp->bandoliers[e.bandolier_id].Items[e.bandolier_slot].Name)
+				item_data->Name
 			);
 		} else {
 			pp->bandoliers[e.bandolier_id].Items[e.bandolier_slot].ID   = 0;
 			pp->bandoliers[e.bandolier_id].Items[e.bandolier_slot].Icon = 0;
 
 			pp->bandoliers[e.bandolier_id].Items[e.bandolier_slot].Name[0] = '\0';
-
 		}
 	}
 
@@ -1079,19 +1077,17 @@ bool ZoneDatabase::SaveCharacterBandolier(
 	const char* bandolier_name
 )
 {
-	auto e = CharacterBandolierRepository::NewEntity();
-
-	e.id             = character_id;
-	e.bandolier_id   = bandolier_id;
-	e.bandolier_slot = bandolier_slot;
-	e.item_id        = item_id;
-	e.icon           = icon;
-	e.bandolier_name = Strings::Escape(bandolier_name);
-
-	const int replaced = CharacterBandolierRepository::ReplaceOne(*this, e);
-
-	LogDebug("ZoneDatabase::SaveCharacterBandolier for character ID: [{}], bandolier_id: [{}], bandolier_slot: [{}] item_id: [{}], icon:[{}] band_name:[{}]  done", character_id, bandolier_id, bandolier_slot, item_id, icon, bandolier_name);
-	return replaced;
+	return CharacterBandolierRepository::ReplaceOne(
+		*this,
+		CharacterBandolierRepository::CharacterBandolier{
+			.id = character_id,
+			.bandolier_id = bandolier_id,
+			.bandolier_slot = bandolier_slot,
+			.item_id = item_id,
+			.icon = icon,
+			.bandolier_name = bandolier_name
+		}
+	);
 }
 
 bool ZoneDatabase::SaveCharacterPotionBelt(uint32 character_id, uint8 potion_id, uint32 item_id, uint32 icon)
@@ -1360,7 +1356,7 @@ bool ZoneDatabase::DeleteCharacterDisc(uint32 character_id, uint32 slot_id){
 
 bool ZoneDatabase::DeleteCharacterBandolier(uint32 character_id, uint32 bandolier_id)
 {
-	const int deleted = CharacterBandolierRepository::DeleteWhere(
+	return CharacterBandolierRepository::DeleteWhere(
 		*this,
 		fmt::format(
 			"`id` = {} AND `bandolier_id` = {}",
@@ -1368,8 +1364,6 @@ bool ZoneDatabase::DeleteCharacterBandolier(uint32 character_id, uint32 bandolie
 			bandolier_id
 		)
 	);
-
-	return deleted;
 }
 
 bool ZoneDatabase::DeleteCharacterLeadershipAbilities(uint32 character_id)

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -912,7 +912,7 @@ bool ZoneDatabase::LoadCharacterBandolier(uint32 character_id, PlayerProfile_Str
 			pp->bandoliers[e.bandolier_id].Items[e.bandolier_slot].Name[0] = '\0';
 		}
 
-		strncpy(pp->bandoliers[e.bandolier_id].Name, e.bandolier_name, 32);
+		strncpy(pp->bandoliers[e.bandolier_id].Name, e.bandolier_name.c_str(), 32);
 	}
 
 	return true;

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -30,6 +30,7 @@
 #include "../common/repositories/character_spells_repository.h"
 #include "../common/repositories/character_skills_repository.h"
 #include "../common/repositories/character_potionbelt_repository.h"
+#include "../common/repositories/character_bandolier_repository.h"
 
 #include <ctime>
 #include <iostream>
@@ -873,38 +874,46 @@ bool ZoneDatabase::LoadCharacterMaterialColor(uint32 character_id, PlayerProfile
 
 bool ZoneDatabase::LoadCharacterBandolier(uint32 character_id, PlayerProfile_Struct* pp)
 {
-	std::string query = StringFormat("SELECT `bandolier_id`, `bandolier_slot`, `item_id`, `icon`, `bandolier_name` FROM `character_bandolier` WHERE `id` = %u LIMIT %u",
-		character_id, EQ::profile::BANDOLIERS_SIZE);
-	auto results = database.QueryDatabase(query); int i = 0; int r = 0; int si = 0;
-	for (i = 0; i < EQ::profile::BANDOLIERS_SIZE; i++) {
+	const auto& l = CharacterBandolierRepository::GetWhere(
+		database,
+		fmt::format(
+			"`id` = {} LIMIT {}",
+			character_id,
+			EQ::profile::BANDOLIERS_SIZE
+		)
+	);
+
+	for (int i = 0; i < EQ::profile::BANDOLIERS_SIZE; i++) {
 		pp->bandoliers[i].Name[0] = '\0';
+
 		for (int si = 0; si < EQ::profile::BANDOLIER_ITEM_COUNT; si++) {
-			pp->bandoliers[i].Items[si].ID = 0;
+			pp->bandoliers[i].Items[si].ID   = 0;
 			pp->bandoliers[i].Items[si].Icon = 0;
+
 			pp->bandoliers[i].Items[si].Name[0] = '\0';
 		}
 	}
 
-	for (auto& row = results.begin(); row != results.end(); ++row) {
-		r = 0;
-		i = Strings::ToInt(row[r]); /* Bandolier ID */ r++;
-		si = Strings::ToInt(row[r]); /* Bandolier Slot */ r++;
-
-		const EQ::ItemData* item_data = database.GetItem(Strings::ToInt(row[r]));
+	for (const auto& e : l) {
+		const auto* item_data = database.GetItem(e.item_id);
 		if (item_data) {
-			pp->bandoliers[i].Items[si].ID = item_data->ID; r++;
-			pp->bandoliers[i].Items[si].Icon = Strings::ToInt(row[r]); r++; // Must use db value in case an Ornamentation is assigned
-			strncpy(pp->bandoliers[i].Items[si].Name, item_data->Name, 64);
-		}
-		else {
-			pp->bandoliers[i].Items[si].ID = 0; r++;
-			pp->bandoliers[i].Items[si].Icon = 0; r++;
-			pp->bandoliers[i].Items[si].Name[0] = '\0';
-		}
-		strcpy(pp->bandoliers[i].Name, row[r]);  r++;
+			pp->bandoliers[e.bandolier_id].Items[e.bandolier_slot].ID   = item_data->ID;
+			pp->bandoliers[e.bandolier_id].Items[e.bandolier_slot].Icon = e.icon;
 
-		si++; // What is this for!?
+			strn0cpy(
+				pp->bandoliers[e.bandolier_id].Items[e.bandolier_slot].Name,
+				item_data->Name,
+				sizeof(pp->bandoliers[e.bandolier_id].Items[e.bandolier_slot].Name)
+			);
+		} else {
+			pp->bandoliers[e.bandolier_id].Items[e.bandolier_slot].ID   = 0;
+			pp->bandoliers[e.bandolier_id].Items[e.bandolier_slot].Icon = 0;
+
+			pp->bandoliers[e.bandolier_id].Items[e.bandolier_slot].Name[0] = '\0';
+
+		}
 	}
+
 	return true;
 }
 
@@ -1061,14 +1070,28 @@ void ZoneDatabase::SaveCharacterTribute(Client* c)
 	}
 }
 
-bool ZoneDatabase::SaveCharacterBandolier(uint32 character_id, uint8 bandolier_id, uint8 bandolier_slot, uint32 item_id, uint32 icon, const char* bandolier_name)
+bool ZoneDatabase::SaveCharacterBandolier(
+	uint32 character_id,
+	uint8 bandolier_id,
+	uint8 bandolier_slot,
+	uint32 item_id,
+	uint32 icon,
+	const char* bandolier_name
+)
 {
-	char bandolier_name_esc[64];
-	DoEscapeString(bandolier_name_esc, bandolier_name, strlen(bandolier_name));
-	std::string query = StringFormat("REPLACE INTO `character_bandolier` (id, bandolier_id, bandolier_slot, item_id, icon, bandolier_name) VALUES (%u, %u, %u, %u, %u,'%s')", character_id, bandolier_id, bandolier_slot, item_id, icon, bandolier_name_esc);
-	auto results = QueryDatabase(query);
+	auto e = CharacterBandolierRepository::NewEntity();
+
+	e.id             = character_id;
+	e.bandolier_id   = bandolier_id;
+	e.bandolier_slot = bandolier_slot;
+	e.item_id        = item_id;
+	e.icon           = icon;
+	e.bandolier_name = Strings::Escape(bandolier_name);
+
+	const int replaced = CharacterBandolierRepository::ReplaceOne(*this, e);
+
 	LogDebug("ZoneDatabase::SaveCharacterBandolier for character ID: [{}], bandolier_id: [{}], bandolier_slot: [{}] item_id: [{}], icon:[{}] band_name:[{}]  done", character_id, bandolier_id, bandolier_slot, item_id, icon, bandolier_name);
-	return true;
+	return replaced;
 }
 
 bool ZoneDatabase::SaveCharacterPotionBelt(uint32 character_id, uint8 potion_id, uint32 item_id, uint32 icon)
@@ -1335,10 +1358,18 @@ bool ZoneDatabase::DeleteCharacterDisc(uint32 character_id, uint32 slot_id){
 	return true;
 }
 
-bool ZoneDatabase::DeleteCharacterBandolier(uint32 character_id, uint32 band_id){
-	std::string query = StringFormat("DELETE FROM `character_bandolier` WHERE `bandolier_id` = %u AND `id` = %u", band_id, character_id);
-	QueryDatabase(query);
-	return true;
+bool ZoneDatabase::DeleteCharacterBandolier(uint32 character_id, uint32 bandolier_id)
+{
+	const int deleted = CharacterBandolierRepository::DeleteWhere(
+		*this,
+		fmt::format(
+			"`id` = {} AND `bandolier_id` = {}",
+			character_id,
+			bandolier_id
+		)
+	);
+
+	return deleted;
 }
 
 bool ZoneDatabase::DeleteCharacterLeadershipAbilities(uint32 character_id)

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -423,7 +423,7 @@ public:
 	void DeleteItemRecast(uint32 char_id, uint32 recast_type);
 
 	bool DeleteCharacterAAs(uint32 character_id);
-	bool DeleteCharacterBandolier(uint32 character_id, uint32 band_id);
+	bool DeleteCharacterBandolier(uint32 character_id, uint32 bandolier_id);
 	bool DeleteCharacterDisc(uint32 character_id, uint32 slot_id);
 	bool DeleteCharacterMaterialColor(uint32 character_id);
 	bool DeleteCharacterLeadershipAbilities(uint32 character_id);


### PR DESCRIPTION
# Notes
- Converts `DeleteCharacterBandolier`, `LoadCharacterBandolier`, and `SaveCharacterBandolier` to repositories.

# Images
## Load
![image](https://github.com/EQEmu/Server/assets/89047260/0cacea6c-009a-4f27-b5a2-83f99c0f4ff8)
![image](https://github.com/EQEmu/Server/assets/89047260/826702de-7243-46a6-9a6f-26c1192a57af)
## Save
![image](https://github.com/EQEmu/Server/assets/89047260/dcedcdec-417a-4756-9548-f68c266eaac2)
![image](https://github.com/EQEmu/Server/assets/89047260/4465114c-7a8d-4f5e-b473-81f143136754)
## Delete
![image](https://github.com/EQEmu/Server/assets/89047260/6b0091ac-d0a9-4a48-96a1-1e28f131491f)
![image](https://github.com/EQEmu/Server/assets/89047260/2238ec54-810a-4ad8-9cb0-b9088f6e05bc)
