### PR TITLE
[Character] Convert Delete/Load/Save of Character Leadership Abilities to Repositories

### DIFF
--- a/common/repositories/base/base_character_leadership_abilities_repository.h
+++ b/common/repositories/base/base_character_leadership_abilities_repository.h
@@ -6,7 +6,7 @@
  * Any modifications to base repositories are to be made by the generator only
  *
  * @generator ./utils/scripts/generators/repository-generator.pl
- * @docs https://eqemu.gitbook.io/server/in-development/developer-area/repositories
+ * @docs https://docs.eqemu.io/developer/repositories
  */
 
 #ifndef EQEMU_BASE_CHARACTER_LEADERSHIP_ABILITIES_REPOSITORY_H
@@ -15,6 +15,7 @@
 #include "../../database.h"
 #include "../../strings.h"
 #include <ctime>
+
 
 class BaseCharacterLeadershipAbilitiesRepository {
 public:
@@ -112,8 +113,9 @@ public:
 	{
 		auto results = db.QueryDatabase(
 			fmt::format(
-				"{} WHERE id = {} LIMIT 1",
+				"{} WHERE {} = {} LIMIT 1",
 				BaseSelect(),
+				PrimaryKey(),
 				character_leadership_abilities_id
 			)
 		);
@@ -338,6 +340,66 @@ public:
 		return (results.Success() && results.begin()[0] ? strtoll(results.begin()[0], nullptr, 10) : 0);
 	}
 
+	static std::string BaseReplace()
+	{
+		return fmt::format(
+			"REPLACE INTO {} ({}) ",
+			TableName(),
+			ColumnsRaw()
+		);
+	}
+
+	static int ReplaceOne(
+		Database& db,
+		const CharacterLeadershipAbilities &e
+	)
+	{
+		std::vector<std::string> v;
+
+		v.push_back(std::to_string(e.id));
+		v.push_back(std::to_string(e.slot));
+		v.push_back(std::to_string(e.rank));
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} VALUES ({})",
+				BaseReplace(),
+				Strings::Implode(",", v)
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
+
+	static int ReplaceMany(
+		Database& db,
+		const std::vector<CharacterLeadershipAbilities> &entries
+	)
+	{
+		std::vector<std::string> insert_chunks;
+
+		for (auto &e: entries) {
+			std::vector<std::string> v;
+
+			v.push_back(std::to_string(e.id));
+			v.push_back(std::to_string(e.slot));
+			v.push_back(std::to_string(e.rank));
+
+			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
+		}
+
+		std::vector<std::string> v;
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} VALUES {}",
+				BaseReplace(),
+				Strings::Implode(",", insert_chunks)
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
 };
 
 #endif //EQEMU_BASE_CHARACTER_LEADERSHIP_ABILITIES_REPOSITORY_H

--- a/zone/aa.cpp
+++ b/zone/aa.cpp
@@ -541,7 +541,7 @@ void Client::ResetAA() {
 	m_pp.raid_leadership_exp = 0;
 
 	database.DeleteCharacterAAs(CharacterID());
-	database.DeleteCharacterLeadershipAAs(CharacterID());
+	database.DeleteCharacterLeadershipAbilities(CharacterID());
 }
 
 void Client::SendClearAA()

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -4599,7 +4599,7 @@ void Client::ClearGroupAAs() {
 	m_pp.raid_leadership_exp = 0;
 
 	Save();
-	database.SaveCharacterLeadershipAA(CharacterID(), &m_pp);
+	database.SaveCharacterLeadershipAbilities(CharacterID(), &m_pp);
 }
 
 void Client::UpdateGroupAAs(int32 points, uint32 type) {

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1277,7 +1277,7 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 	database.LoadCharacterMemmedSpells(cid, &m_pp);  /* Load Character Memorized Spells */
 	database.LoadCharacterDisciplines(cid, &m_pp); /* Load Character Disciplines */
 	database.LoadCharacterLanguages(cid, &m_pp); /* Load Character Languages */
-	database.LoadCharacterLeadershipAA(cid, &m_pp); /* Load Character Leadership AA's */
+	database.LoadCharacterLeadershipAbilities(cid, &m_pp); /* Load Character Leadership AA's */
 	database.LoadCharacterTribute(this); /* Load CharacterTribute */
 
 	// this pattern is strange
@@ -11680,7 +11680,7 @@ void Client::Handle_OP_PurchaseLeadershipAA(const EQApplicationPacket *app)
 		m_pp.raid_leadership_points -= cost;
 		m_pp.leader_abilities.ranks[aaid]++;
 
-		database.SaveCharacterLeadershipAA(CharacterID(), &m_pp);
+		database.SaveCharacterLeadershipAbilities(CharacterID(), &m_pp);
 	}
 	else {
 		//it is a group ability.
@@ -11693,7 +11693,7 @@ void Client::Handle_OP_PurchaseLeadershipAA(const EQApplicationPacket *app)
 		m_pp.group_leadership_points -= cost;
 		m_pp.leader_abilities.ranks[aaid]++;
 
-		database.SaveCharacterLeadershipAA(CharacterID(), &m_pp);
+		database.SaveCharacterLeadershipAbilities(CharacterID(), &m_pp);
 	}
 
 	//success, send them an update

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -22,6 +22,7 @@
 #include "../common/repositories/character_buffs_repository.h"
 #include "../common/repositories/criteria/content_filter_criteria.h"
 #include "../common/repositories/spawn2_disabled_repository.h"
+#include "../common/repositories/character_leadership_abilities_repository.h"
 
 #include <ctime>
 #include <iostream>
@@ -827,13 +828,20 @@ bool ZoneDatabase::LoadCharacterLanguages(uint32 character_id, PlayerProfile_Str
 	return true;
 }
 
-bool ZoneDatabase::LoadCharacterLeadershipAA(uint32 character_id, PlayerProfile_Struct* pp){
-	std::string query = StringFormat("SELECT slot, `rank` FROM character_leadership_abilities WHERE `id` = %u", character_id);
-	auto results = database.QueryDatabase(query); uint32 slot = 0;
-	for (auto& row = results.begin(); row != results.end(); ++row) {
-		slot = Strings::ToInt(row[0]);
-		pp->leader_abilities.ranks[slot] = Strings::ToInt(row[1]);
+bool ZoneDatabase::LoadCharacterLeadershipAbilities(uint32 character_id, PlayerProfile_Struct* pp)
+{
+	const auto& l = CharacterLeadershipAbilitiesRepository::GetWhere(
+		database,
+		fmt::format(
+			"`id` = {}",
+			character_id
+		)
+	);
+
+	for (const auto& e : l) {
+		pp->leader_abilities.ranks[e.slot] = e.rank;
 	}
+
 	return true;
 }
 
@@ -1126,19 +1134,23 @@ bool ZoneDatabase::SaveCharacterPotionBelt(uint32 character_id, uint8 potion_id,
 	return true;
 }
 
-bool ZoneDatabase::SaveCharacterLeadershipAA(uint32 character_id, PlayerProfile_Struct* pp){
-	uint8 first_entry = 0; std::string query = "";
-	for (int i = 0; i < MAX_LEADERSHIP_AA_ARRAY; i++){
-		if (pp->leader_abilities.ranks[i] > 0){
-			if (first_entry != 1){
-				query = StringFormat("REPLACE INTO `character_leadership_abilities` (id, slot, `rank`) VALUES (%i, %u, %u)", character_id, i, pp->leader_abilities.ranks[i]);
-				first_entry = 1;
-			}
-			query = query + StringFormat(", (%i, %u, %u)", character_id, i, pp->leader_abilities.ranks[i]);
+bool ZoneDatabase::SaveCharacterLeadershipAbilities(uint32 character_id, PlayerProfile_Struct* pp)
+{
+	std::vector<CharacterLeadershipAbilitiesRepository::CharacterLeadershipAbilities> v;
+
+	auto e = CharacterLeadershipAbilitiesRepository::NewEntity();
+
+	for (int slot_id = 0; slot_id < MAX_LEADERSHIP_AA_ARRAY; slot_id++) {
+		if (pp->leader_abilities.ranks[slot_id] > 0) {
+			e.id   = character_id;
+			e.slot = slot_id;
+			e.rank = pp->leader_abilities.ranks[slot_id];
+
+			v.emplace_back(e);
 		}
 	}
-	auto results = QueryDatabase(query);
-	return true;
+
+	return CharacterLeadershipAbilitiesRepository::ReplaceMany(*this, v);
 }
 
 bool ZoneDatabase::SaveCharacterData(
@@ -1541,10 +1553,9 @@ bool ZoneDatabase::DeleteCharacterBandolier(uint32 character_id, uint32 band_id)
 	return true;
 }
 
-bool ZoneDatabase::DeleteCharacterLeadershipAAs(uint32 character_id){
-	std::string query = StringFormat("DELETE FROM `character_leadership_abilities` WHERE `id` = %u", character_id);
-	QueryDatabase(query);
-	return true;
+bool ZoneDatabase::DeleteCharacterLeadershipAbilities(uint32 character_id)
+{
+	return CharacterLeadershipAbilitiesRepository::DeleteOne(*this, character_id);
 }
 
 bool ZoneDatabase::DeleteCharacterAAs(uint32 character_id){

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -426,7 +426,7 @@ public:
 	bool DeleteCharacterBandolier(uint32 character_id, uint32 band_id);
 	bool DeleteCharacterDisc(uint32 character_id, uint32 slot_id);
 	bool DeleteCharacterDye(uint32 character_id);
-	bool DeleteCharacterLeadershipAAs(uint32 character_id);
+	bool DeleteCharacterLeadershipAbilities(uint32 character_id);
 	bool DeleteCharacterMemorizedSpell(uint32 character_id, uint32 spell_id, uint32 slot_id);
 	bool DeleteCharacterSpell(uint32 character_id, uint32 spell_id, uint32 slot_id);
 
@@ -437,7 +437,7 @@ public:
 	bool LoadCharacterDisciplines(uint32 character_id, PlayerProfile_Struct* pp);
 	bool LoadCharacterFactionValues(uint32 character_id, faction_map & val_list);
 	bool LoadCharacterLanguages(uint32 character_id, PlayerProfile_Struct* pp);
-	bool LoadCharacterLeadershipAA(uint32 character_id, PlayerProfile_Struct* pp);
+	bool LoadCharacterLeadershipAbilities(uint32 character_id, PlayerProfile_Struct* pp);
 	bool LoadCharacterMaterialColor(uint32 character_id, PlayerProfile_Struct* pp);
 	bool LoadCharacterMemmedSpells(uint32 character_id, PlayerProfile_Struct* pp);
 	bool LoadCharacterPotions(uint32 character_id, PlayerProfile_Struct* pp);
@@ -450,7 +450,7 @@ public:
 	bool SaveCharacterData(Client* c, PlayerProfile_Struct* pp, ExtendedProfile_Struct* m_epp);
 	bool SaveCharacterDisc(uint32 character_id, uint32 slot_id, uint32 disc_id);
 	bool SaveCharacterLanguage(uint32 character_id, uint32 lang_id, uint32 value);
-	bool SaveCharacterLeadershipAA(uint32 character_id, PlayerProfile_Struct* pp);
+	bool SaveCharacterLeadershipAbilities(uint32 character_id, PlayerProfile_Struct* pp);
 	bool SaveCharacterMaterialColor(uint32 character_id, uint32 slot_id, uint32 color);
 	bool SaveCharacterMemorizedSpell(uint32 character_id, uint32 spell_id, uint32 slot_id);
 	bool SaveCharacterPotionBelt(uint32 character_id, uint8 potion_id, uint32 item_id, uint32 icon);


### PR DESCRIPTION
# Notes
- Converts `DeleteCharacterLeadershipAbilities`, `LoadCharacterLeadershipAbilities`, and `SaveCharacterLeadershipAbilities` to repositories.

# Images
## Load
![image](https://github.com/EQEmu/Server/assets/89047260/a6164684-5ee2-4657-ba03-7fa9c46f2c58)
![image](https://github.com/EQEmu/Server/assets/89047260/3d518b05-e8b0-4592-be5f-1518adc3aef8)
## Save
![image](https://github.com/EQEmu/Server/assets/89047260/56103da5-e18c-411b-95fd-64cda1f80138)
![image](https://github.com/EQEmu/Server/assets/89047260/5d7953d5-f5d2-45d5-93ed-3484b94cfbd0)
## Delete
![image](https://github.com/EQEmu/Server/assets/89047260/59ad3cd6-d6e4-4fbc-906a-d11fb98fb339)
![image](https://github.com/EQEmu/Server/assets/89047260/45fb1aa7-ea43-4f37-81e5-5ca86bb4b58b)