### PR TITLE
[Character] Convert Delete/Load/Save of Character Disciplines to Repositories

### DIFF
--- a/common/repositories/base/base_character_disciplines_repository.h
+++ b/common/repositories/base/base_character_disciplines_repository.h
@@ -6,7 +6,7 @@
  * Any modifications to base repositories are to be made by the generator only
  *
  * @generator ./utils/scripts/generators/repository-generator.pl
- * @docs https://eqemu.gitbook.io/server/in-development/developer-area/repositories
+ * @docs https://docs.eqemu.io/developer/repositories
  */
 
 #ifndef EQEMU_BASE_CHARACTER_DISCIPLINES_REPOSITORY_H
@@ -15,6 +15,7 @@
 #include "../../database.h"
 #include "../../strings.h"
 #include <ctime>
+
 
 class BaseCharacterDisciplinesRepository {
 public:
@@ -112,8 +113,9 @@ public:
 	{
 		auto results = db.QueryDatabase(
 			fmt::format(
-				"{} WHERE id = {} LIMIT 1",
+				"{} WHERE {} = {} LIMIT 1",
 				BaseSelect(),
+				PrimaryKey(),
 				character_disciplines_id
 			)
 		);
@@ -338,6 +340,66 @@ public:
 		return (results.Success() && results.begin()[0] ? strtoll(results.begin()[0], nullptr, 10) : 0);
 	}
 
+	static std::string BaseReplace()
+	{
+		return fmt::format(
+			"REPLACE INTO {} ({}) ",
+			TableName(),
+			ColumnsRaw()
+		);
+	}
+
+	static int ReplaceOne(
+		Database& db,
+		const CharacterDisciplines &e
+	)
+	{
+		std::vector<std::string> v;
+
+		v.push_back(std::to_string(e.id));
+		v.push_back(std::to_string(e.slot_id));
+		v.push_back(std::to_string(e.disc_id));
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} VALUES ({})",
+				BaseReplace(),
+				Strings::Implode(",", v)
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
+
+	static int ReplaceMany(
+		Database& db,
+		const std::vector<CharacterDisciplines> &entries
+	)
+	{
+		std::vector<std::string> insert_chunks;
+
+		for (auto &e: entries) {
+			std::vector<std::string> v;
+
+			v.push_back(std::to_string(e.id));
+			v.push_back(std::to_string(e.slot_id));
+			v.push_back(std::to_string(e.disc_id));
+
+			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
+		}
+
+		std::vector<std::string> v;
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} VALUES {}",
+				BaseReplace(),
+				Strings::Implode(",", insert_chunks)
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
 };
 
 #endif //EQEMU_BASE_CHARACTER_DISCIPLINES_REPOSITORY_H

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10744,17 +10744,19 @@ void Client::SaveDisciplines()
 {
 	std::vector<CharacterDisciplinesRepository::CharacterDisciplines> v;
 
-	for (int index = 0; index < MAX_PP_DISCIPLINES; index++) {
-		if (IsValidSpell(m_pp.disciplines.values[index])) {
+	for (int slot_id = 0; slot_id < MAX_PP_DISCIPLINES; slot_id++) {
+		if (IsValidSpell(m_pp.disciplines.values[slot_id])) {
 			auto e = CharacterDisciplinesRepository::NewEntity();
 
 			e.id      = CharacterID();
-			e.slot_id = index;
-			e.disc_id = m_pp.disciplines.values[index];
+			e.slot_id = slot_id;
+			e.disc_id = m_pp.disciplines.values[slot_id];
 
 			v.emplace_back(e);
 		}
 	}
+
+	CharacterDisciplinesRepository::DeleteOne(database, CharacterID());
 
 	if (!v.empty()) {
 		CharacterDisciplinesRepository::ReplaceMany(database, v);

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10756,8 +10756,8 @@ void Client::SaveDisciplines()
 		}
 	}
 
-	if (!l.empty()) {
-		CharacterDisciplinesRepository::ReplaceMany(database, l);
+	if (!v.empty()) {
+		CharacterDisciplinesRepository::ReplaceMany(database, v);
 	}
 }
 

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10742,22 +10742,22 @@ void Client::SaveSpells()
 
 void Client::SaveDisciplines()
 {
-	std::vector<CharacterDisciplinesRepository::CharacterDisciplines> character_discs = {};
+	std::vector<CharacterDisciplinesRepository::CharacterDisciplines> v;
 
 	for (int index = 0; index < MAX_PP_DISCIPLINES; index++) {
 		if (IsValidSpell(m_pp.disciplines.values[index])) {
-			auto discipline = CharacterDisciplinesRepository::NewEntity();
-			discipline.id      = CharacterID();
-			discipline.slot_id = index;
-			discipline.disc_id = m_pp.disciplines.values[index];
-			character_discs.emplace_back(discipline);
+			auto e = CharacterDisciplinesRepository::NewEntity();
+
+			e.id      = CharacterID();
+			e.slot_id = index;
+			e.disc_id = m_pp.disciplines.values[index];
+
+			v.emplace_back(e);
 		}
 	}
 
-	CharacterDisciplinesRepository::DeleteWhere(database, fmt::format("id = {}", CharacterID()));
-
-	if (!character_discs.empty()) {
-		CharacterDisciplinesRepository::InsertMany(database, character_discs);
+	if (!l.empty()) {
+		CharacterDisciplinesRepository::ReplaceMany(database, l);
 	}
 }
 

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10756,8 +10756,6 @@ void Client::SaveDisciplines()
 		}
 	}
 
-	CharacterDisciplinesRepository::DeleteOne(database, CharacterID());
-
 	if (!v.empty()) {
 		CharacterDisciplinesRepository::ReplaceMany(database, v);
 	}

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -690,7 +690,7 @@ bool Client::TrainDiscipline(uint32 itemid) {
 			return false;
 		} else if (m_pp.disciplines.values[r] == 0) {
 			m_pp.disciplines.values[r] = spell_id;
-			database.DeleteCharacterDiscipline(CharacterID(), r, spell_id);
+			database.SaveCharacterDiscipline(CharacterID(), r, spell_id);
 			SendDisciplineUpdate();
 			Message(Chat::White, "You have learned a new discipline!");
 			return true;
@@ -789,7 +789,7 @@ void Client::TrainDiscBySpellID(int32 spell_id)
 	for(i = 0; i < MAX_PP_DISCIPLINES; i++) {
 		if(m_pp.disciplines.values[i] == 0) {
 			m_pp.disciplines.values[i] = spell_id;
-			database.DeleteCharacterDiscipline(CharacterID(), i, spell_id);
+			database.SaveCharacterDiscipline(CharacterID(), i, spell_id);
 			SendDisciplineUpdate();
 			Message(Chat::Yellow, "You have learned a new combat ability!");
 			return;

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -690,7 +690,7 @@ bool Client::TrainDiscipline(uint32 itemid) {
 			return false;
 		} else if (m_pp.disciplines.values[r] == 0) {
 			m_pp.disciplines.values[r] = spell_id;
-			database.SaveCharacterDisc(CharacterID(), r, spell_id);
+			database.DeleteCharacterDiscipline(CharacterID(), r, spell_id);
 			SendDisciplineUpdate();
 			Message(Chat::White, "You have learned a new discipline!");
 			return true;
@@ -789,7 +789,7 @@ void Client::TrainDiscBySpellID(int32 spell_id)
 	for(i = 0; i < MAX_PP_DISCIPLINES; i++) {
 		if(m_pp.disciplines.values[i] == 0) {
 			m_pp.disciplines.values[i] = spell_id;
-			database.SaveCharacterDisc(CharacterID(), i, spell_id);
+			database.DeleteCharacterDiscipline(CharacterID(), i, spell_id);
 			SendDisciplineUpdate();
 			Message(Chat::Yellow, "You have learned a new combat ability!");
 			return;

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -5761,7 +5761,7 @@ void Client::UntrainDisc(int slot, bool update_client, bool defer_save)
 	m_pp.disciplines.values[slot] = 0;
 
 	if (!defer_save) {
-		database.DeleteCharacterDisc(CharacterID(), slot);
+		database.DeleteCharacterDiscipline(CharacterID(), slot);
 	}
 
 	if (update_client) {

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -1023,13 +1023,14 @@ bool ZoneDatabase::SaveCharacterSkill(uint32 character_id, uint32 skill_id, uint
 
 bool ZoneDatabase::SaveCharacterDiscipline(uint32 character_id, uint32 slot_id, uint32 disc_id)
 {
-	auto e = CharacterDisciplinesRepository::NewEntity();
-
-	e.id      = character_id;
-	e.slot_id = slot_id;
-	e.disc_id = disc_id;
-
-	return CharacterDisciplinesRepository::ReplaceOne(*this, e);
+	return CharacterDisciplinesRepository::ReplaceOne(
+		*this,
+		CharacterDisciplinesRepository::CharacterDisciplines{
+			.id = character_id,
+			.slot_id = static_cast<uint16_t>(slot_id),
+			.disc_id = static_cast<uint16_t>(disc_id)
+		}
+	);
 }
 
 void ZoneDatabase::SaveCharacterTribute(Client* c)

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -424,7 +424,7 @@ public:
 
 	bool DeleteCharacterAAs(uint32 character_id);
 	bool DeleteCharacterBandolier(uint32 character_id, uint32 bandolier_id);
-	bool DeleteCharacterDisc(uint32 character_id, uint32 slot_id);
+	bool DeleteCharacterDiscipline(uint32 character_id, uint32 slot_id);
 	bool DeleteCharacterMaterialColor(uint32 character_id);
 	bool DeleteCharacterLeadershipAbilities(uint32 character_id);
 	bool DeleteCharacterMemorizedSpell(uint32 character_id, uint32 slot_id);
@@ -447,7 +447,7 @@ public:
 	bool SaveCharacterBandolier(uint32 character_id, uint8 bandolier_id, uint8 bandolier_slot, uint32 item_id, uint32 icon, const char* bandolier_name);
 	bool SaveCharacterCurrency(uint32 character_id, PlayerProfile_Struct* pp);
 	bool SaveCharacterData(Client* c, PlayerProfile_Struct* pp, ExtendedProfile_Struct* m_epp);
-	bool SaveCharacterDisc(uint32 character_id, uint32 slot_id, uint32 disc_id);
+	bool SaveCharacterDiscipline(uint32 character_id, uint32 slot_id, uint32 disc_id);
 	bool SaveCharacterLanguage(uint32 character_id, uint32 lang_id, uint32 value);
 	bool SaveCharacterLeadershipAbilities(uint32 character_id, PlayerProfile_Struct* pp);
 	bool SaveCharacterMaterialColor(uint32 character_id, uint8 slot_id, uint32 color);


### PR DESCRIPTION
# Notes
- Convert `DeleteCharacterDiscipline` and `SaveCharacterDiscipline` to repositories.
- `LoadCharacterDiscipline` already used repositories, cleaned up the logic.

# Images
## Load
![image](https://github.com/EQEmu/Server/assets/89047260/0f673856-457a-4e0b-8710-544cddb6f4d9)
![image](https://github.com/EQEmu/Server/assets/89047260/8ec8672f-361b-40fa-a1e5-292bfe20dea8)
## Save
![image](https://github.com/EQEmu/Server/assets/89047260/9c0bb7b8-1dd7-4b00-a7c2-68480645517c)
![image](https://github.com/EQEmu/Server/assets/89047260/047336bf-bcd4-4d64-8b55-bdd2ef4b67d3)
## Delete
![image](https://github.com/EQEmu/Server/assets/89047260/867cb246-7910-40ad-b0c8-86dcff66de1f)
![image](https://github.com/EQEmu/Server/assets/89047260/165bc563-4309-43dd-ad10-2c20a177fa26)