### PR TITLE
[Character] Convert Load/Update of Character Alternate Currencies to Repositories

### DIFF
--- a/common/eq_constants.h
+++ b/common/eq_constants.h
@@ -727,6 +727,11 @@ namespace BuffEffectType {
 	constexpr uint8 InverseBuff = 4;
 }
 
+namespace AlternateCurrencyMode {
+	constexpr uint32 Update   = 7;
+	constexpr uint32 Populate = 8;
+}
+
 typedef enum {
 	FilterNone = 0,
 	FilterGuildChat = 1,		//0=hide, 1=show

--- a/common/eq_packet_structs.h
+++ b/common/eq_packet_structs.h
@@ -5134,8 +5134,6 @@ struct GroupMakeLeader_Struct
 //ex for a blank crowns window you would send:
 //999999|1|999999|0
 //any items come after in much the same way adventure merchant items do except there is no theme included
-#define ALT_CURRENCY_OP_POPULATE 8
-#define ALT_CURRENCY_OP_UPDATE 7
 
 //Server -> Client
 //Populates the initial Alternate Currency Window

--- a/common/patches/rof.cpp
+++ b/common/patches/rof.cpp
@@ -202,7 +202,7 @@ namespace RoF
 		unsigned char *emu_buffer = in->pBuffer;
 		uint32 opcode = *((uint32*)emu_buffer);
 
-		if (opcode == 8) {
+		if (opcode == AlternateCurrencyMode::Populate) {
 			AltCurrencyPopulate_Struct *populate = (AltCurrencyPopulate_Struct*)emu_buffer;
 
 			auto outapp = new EQApplicationPacket(

--- a/common/patches/rof2.cpp
+++ b/common/patches/rof2.cpp
@@ -274,7 +274,7 @@ namespace RoF2
 		unsigned char *emu_buffer = in->pBuffer;
 		uint32 opcode = *((uint32*)emu_buffer);
 
-		if (opcode == 8) {
+		if (opcode == AlternateCurrencyMode::Populate) {
 			AltCurrencyPopulate_Struct *populate = (AltCurrencyPopulate_Struct*)emu_buffer;
 
 			auto outapp = new EQApplicationPacket(

--- a/common/patches/uf.cpp
+++ b/common/patches/uf.cpp
@@ -195,7 +195,7 @@ namespace UF
 		unsigned char *emu_buffer = in->pBuffer;
 		uint32 opcode = *((uint32*)emu_buffer);
 
-		if (opcode == 8) {
+		if (opcode == AlternateCurrencyMode::Populate) {
 			AltCurrencyPopulate_Struct *populate = (AltCurrencyPopulate_Struct*)emu_buffer;
 
 			auto outapp = new EQApplicationPacket(

--- a/common/repositories/base/base_character_alt_currency_repository.h
+++ b/common/repositories/base/base_character_alt_currency_repository.h
@@ -6,7 +6,7 @@
  * Any modifications to base repositories are to be made by the generator only
  *
  * @generator ./utils/scripts/generators/repository-generator.pl
- * @docs https://eqemu.gitbook.io/server/in-development/developer-area/repositories
+ * @docs https://docs.eqemu.io/developer/repositories
  */
 
 #ifndef EQEMU_BASE_CHARACTER_ALT_CURRENCY_REPOSITORY_H
@@ -15,6 +15,7 @@
 #include "../../database.h"
 #include "../../strings.h"
 #include <ctime>
+
 
 class BaseCharacterAltCurrencyRepository {
 public:
@@ -112,8 +113,9 @@ public:
 	{
 		auto results = db.QueryDatabase(
 			fmt::format(
-				"{} WHERE id = {} LIMIT 1",
+				"{} WHERE {} = {} LIMIT 1",
 				BaseSelect(),
+				PrimaryKey(),
 				character_alt_currency_id
 			)
 		);
@@ -338,6 +340,66 @@ public:
 		return (results.Success() && results.begin()[0] ? strtoll(results.begin()[0], nullptr, 10) : 0);
 	}
 
+	static std::string BaseReplace()
+	{
+		return fmt::format(
+			"REPLACE INTO {} ({}) ",
+			TableName(),
+			ColumnsRaw()
+		);
+	}
+
+	static int ReplaceOne(
+		Database& db,
+		const CharacterAltCurrency &e
+	)
+	{
+		std::vector<std::string> v;
+
+		v.push_back(std::to_string(e.char_id));
+		v.push_back(std::to_string(e.currency_id));
+		v.push_back(std::to_string(e.amount));
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} VALUES ({})",
+				BaseReplace(),
+				Strings::Implode(",", v)
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
+
+	static int ReplaceMany(
+		Database& db,
+		const std::vector<CharacterAltCurrency> &entries
+	)
+	{
+		std::vector<std::string> insert_chunks;
+
+		for (auto &e: entries) {
+			std::vector<std::string> v;
+
+			v.push_back(std::to_string(e.char_id));
+			v.push_back(std::to_string(e.currency_id));
+			v.push_back(std::to_string(e.amount));
+
+			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
+		}
+
+		std::vector<std::string> v;
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} VALUES {}",
+				BaseReplace(),
+				Strings::Implode(",", insert_chunks)
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
 };
 
 #endif //EQEMU_BASE_CHARACTER_ALT_CURRENCY_REPOSITORY_H


### PR DESCRIPTION
# Notes
- Convert `LoadAltCurrencyValues` and `UpdateAltCurrencyValue` to repositories.
- Cleanup some other code and logic as well.
- Add `AlternateCurrencyMode` namespace for `AltCurrencyPopulate_Struct` opcode magic numbers.

# Images
## Load
![image](https://github.com/EQEmu/Server/assets/89047260/d0850ad7-104b-4eab-9eb6-3d0d32ec0f54)
![image](https://github.com/EQEmu/Server/assets/89047260/f78272c1-cb1b-4914-9de6-dc0e90a4af1c)
## Update
![image](https://github.com/EQEmu/Server/assets/89047260/0f7ad469-dafc-42ff-a843-73a06794ff24)
![image](https://github.com/EQEmu/Server/assets/89047260/33409ab7-f1a4-4b2f-81e9-925f6774fca5)
