### PR TITLE
[Feature] Break Trader if moved

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4889,7 +4889,7 @@ void Client::Handle_OP_ClientUpdate(const EQApplicationPacket *app) {
 
 	if (cy != m_Position.y || cx != m_Position.x) {
 		// End trader mode if we move
-		if(Trader) {
+		if (Trader) {
 			Trader_EndTrader();
 		}
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4887,8 +4887,13 @@ void Client::Handle_OP_ClientUpdate(const EQApplicationPacket *app) {
 			CheckIncreaseSkill(EQ::skills::SkillTracking, nullptr, -20);
 	}
 
-	/* Break Hide if moving without sneaking and set rewind timer if moved */
 	if (cy != m_Position.y || cx != m_Position.x) {
+		// End trader mode if we move
+		if(Trader) {
+			Trader_EndTrader();
+		}
+
+		/* Break Hide if moving without sneaking and set rewind timer if moved */
 		if ((hidden || improved_hidden) && !sneaking) {
 			hidden = false;
 			improved_hidden = false;


### PR DESCRIPTION
If the player moves while in trader mode, it will end the mode, this prevents traders from moving outside of the trader area after entering trader mode.