### PR TITLE
[Bug Fix] Negative Aggro Fix

### DIFF
--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -653,8 +653,14 @@ int Mob::MonkSpecialAttack(Mob *other, uint8 unchecked_type)
 	}
 
 	int32 ht = 0;
-	if (max_dmg > 0)
+	if (max_dmg > 0) {
 		ht = max_dmg;
+	}
+
+	// aggro should never be negative else it does massive aggro
+	if (ht < 0)	{
+		ht = 0;
+	}
 
 	DoSpecialAttackDamage(other, skill_type, max_dmg, min_dmg, ht, reuse);
 


### PR DESCRIPTION
If aggro goes negative, it resets the counter from the max value, so having a negative aggro will give massive aggro.  This was happening with bane attacks from monk special abilities being set to -5 damage so they don't hit, and since aggro was set to the same, instant aggro from monks on bane mobs.  Set all monk special attacks to generate 0 aggro if it is less than 0.