### PR TITLE
[Rule] RequireMnemonicRetention for Spells 9-12 Rule

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -473,6 +473,7 @@ RULE_BOOL(Spells, UseLegacyFizzleCode, false, "Enable will turn on the legacy fi
 RULE_BOOL(Spells, LegacyManaburn, false, "Enable to have the legacy manaburn system from 2003 and earlier.")
 RULE_BOOL(Spells, EvacClearAggroInSameZone, false, "Enable to clear aggro on clients when evacing in same zone.")
 RULE_BOOL(Spells, CharmAggroOverLevel, false, "Enabling this rule will cause Charm casts over level to show resisted and cause aggro. Early EQ style.")
+RULE_BOOL(Spells, RequireMnemonicRetention, false, "Enabling will require spell slots 9-12 to have the appropriate Mnemonic Retention AA learned.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Combat)

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -474,6 +474,7 @@ RULE_BOOL(Spells, LegacyManaburn, false, "Enable to have the legacy manaburn sys
 RULE_BOOL(Spells, EvacClearAggroInSameZone, false, "Enable to clear aggro on clients when evacing in same zone.")
 RULE_BOOL(Spells, CharmAggroOverLevel, false, "Enabling this rule will cause Charm casts over level to show resisted and cause aggro. Early EQ style.")
 RULE_BOOL(Spells, RequireMnemonicRetention, false, "Enabling will require spell slots 9-12 to have the appropriate Mnemonic Retention AA learned.")
+RULE_BOOL(Spells, RequireMnemonicRetention, True, "Enabling will require spell slots 9-12 to have the appropriate Mnemonic Retention AA learned.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Combat)

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -475,6 +475,7 @@ RULE_BOOL(Spells, EvacClearAggroInSameZone, false, "Enable to clear aggro on cli
 RULE_BOOL(Spells, CharmAggroOverLevel, false, "Enabling this rule will cause Charm casts over level to show resisted and cause aggro. Early EQ style.")
 RULE_BOOL(Spells, RequireMnemonicRetention, false, "Enabling will require spell slots 9-12 to have the appropriate Mnemonic Retention AA learned.")
 RULE_BOOL(Spells, RequireMnemonicRetention, True, "Enabling will require spell slots 9-12 to have the appropriate Mnemonic Retention AA learned.")
+RULE_BOOL(Spells, RequireMnemonicRetention, true, "Enabling will require spell slots 9-12 to have the appropriate Mnemonic Retention AA learned.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Combat)

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -473,8 +473,6 @@ RULE_BOOL(Spells, UseLegacyFizzleCode, false, "Enable will turn on the legacy fi
 RULE_BOOL(Spells, LegacyManaburn, false, "Enable to have the legacy manaburn system from 2003 and earlier.")
 RULE_BOOL(Spells, EvacClearAggroInSameZone, false, "Enable to clear aggro on clients when evacing in same zone.")
 RULE_BOOL(Spells, CharmAggroOverLevel, false, "Enabling this rule will cause Charm casts over level to show resisted and cause aggro. Early EQ style.")
-RULE_BOOL(Spells, RequireMnemonicRetention, false, "Enabling will require spell slots 9-12 to have the appropriate Mnemonic Retention AA learned.")
-RULE_BOOL(Spells, RequireMnemonicRetention, True, "Enabling will require spell slots 9-12 to have the appropriate Mnemonic Retention AA learned.")
 RULE_BOOL(Spells, RequireMnemonicRetention, true, "Enabling will require spell slots 9-12 to have the appropriate Mnemonic Retention AA learned.")
 RULE_CATEGORY_END()
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4329,6 +4329,27 @@ void Client::Handle_OP_CastSpell(const EQApplicationPacket *app)
 	LogSpells("OP CastSpell: slot [{}] spell [{}] target [{}] inv [{}]", castspell->slot, castspell->spell_id, castspell->target_id, (unsigned long)castspell->inventoryslot);
 	CastingSlot slot = static_cast<CastingSlot>(castspell->slot);
 
+	if (RuleB(Spells, RequireMnemonicRetention)) {
+		// casting from slot 9, 10, 11 or 12, we disable cause not classic.
+		if (castspell->slot == 8 && GetAA(aaMnemonicRetention) < 1) {
+			InterruptSpell(castspell->spell_id);
+			Message(Chat::Red, "You do not have the required AA to use this spell slot.");
+			return;
+		} else if(castspell->slot == 9 && GetAA(aaMnemonicRetention) < 2) {
+			InterruptSpell(castspell->spell_id);
+			Message(Chat::Red, "You do not have the required AA to use this spell slot.");
+			return;
+		} else if(castspell->slot == 10 && GetAA(aaMnemonicRetention) < 3) {
+			InterruptSpell(castspell->spell_id);
+			Message(Chat::Red, "You do not have the required AA to use this spell slot.");
+			return;
+		} else if(castspell->slot == 11 && GetAA(aaMnemonicRetention) < 4) {
+			InterruptSpell(castspell->spell_id);
+			Message(Chat::Red, "You do not have the required AA to use this spell slot.");
+			return;
+		}
+	}
+
 	/* Memorized Spell */
 	if (m_pp.mem_spells[castspell->slot] && m_pp.mem_spells[castspell->slot] == castspell->spell_id) {
 		uint16 spell_to_cast = 0;

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4329,25 +4329,10 @@ void Client::Handle_OP_CastSpell(const EQApplicationPacket *app)
 	LogSpells("OP CastSpell: slot [{}] spell [{}] target [{}] inv [{}]", castspell->slot, castspell->spell_id, castspell->target_id, (unsigned long)castspell->inventoryslot);
 	CastingSlot slot = static_cast<CastingSlot>(castspell->slot);
 
-	if (RuleB(Spells, RequireMnemonicRetention)) {
-		// casting from slot 9, 10, 11 or 12, we disable cause not classic.
-		if (castspell->slot == 8 && GetAA(aaMnemonicRetention) < 1) {
-			InterruptSpell(castspell->spell_id);
-			Message(Chat::Red, "You do not have the required AA to use this spell slot.");
-			return;
-		} else if(castspell->slot == 9 && GetAA(aaMnemonicRetention) < 2) {
-			InterruptSpell(castspell->spell_id);
-			Message(Chat::Red, "You do not have the required AA to use this spell slot.");
-			return;
-		} else if(castspell->slot == 10 && GetAA(aaMnemonicRetention) < 3) {
-			InterruptSpell(castspell->spell_id);
-			Message(Chat::Red, "You do not have the required AA to use this spell slot.");
-			return;
-		} else if(castspell->slot == 11 && GetAA(aaMnemonicRetention) < 4) {
-			InterruptSpell(castspell->spell_id);
-			Message(Chat::Red, "You do not have the required AA to use this spell slot.");
-			return;
-		}
+	if (EQ::ValueWithin(castspell->slot, 8, 11) && GetAA(aaMnemonicRetention) < (castspell->slot - 7)) {
+		InterruptSpell(castspell->spell_id);
+		Message(Chat::Red, "You do not have the required AA to use this spell slot.");
+		return;
 	}
 
 	/* Memorized Spell */

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4329,10 +4329,12 @@ void Client::Handle_OP_CastSpell(const EQApplicationPacket *app)
 	LogSpells("OP CastSpell: slot [{}] spell [{}] target [{}] inv [{}]", castspell->slot, castspell->spell_id, castspell->target_id, (unsigned long)castspell->inventoryslot);
 	CastingSlot slot = static_cast<CastingSlot>(castspell->slot);
 
-	if (EQ::ValueWithin(castspell->slot, 8, 11) && GetAA(aaMnemonicRetention) < (castspell->slot - 7)) {
-		InterruptSpell(castspell->spell_id);
-		Message(Chat::Red, "You do not have the required AA to use this spell slot.");
-		return;
+	if (RuleB(Spells, RequireMnemonicRetention)) {
+		if (EQ::ValueWithin(castspell->slot, 8, 11) && GetAA(aaMnemonicRetention) < (castspell->slot - 7)) {
+			InterruptSpell(castspell->spell_id);
+			Message(Chat::Red, "You do not have the required AA to use this spell slot.");
+			return;
+		}
 	}
 
 	/* Memorized Spell */


### PR DESCRIPTION
Rule is default true.

Enabling will require clients to have the required ranks of Mnemonic Retention in order to cast.

This is a stopgap as on live, the buttons are not even available to use. This will mimic the functionality but denying the cast.