### PR TITLE
[Rule] Classic Invite Requires Target

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -218,6 +218,7 @@ RULE_BOOL(Character, ItemExtraSkillDamageCalcAsPercent, false, "If enabled, appl
 RULE_BOOL(Character, UseForageCommonFood, true, "If enabled, use the common foods specified in the code.")
 RULE_INT(Character, ClearXTargetDelay, 10, "Seconds between uses of the #clearxtargets command (Set to 0 to disable)")
 RULE_BOOL(Character, PreventMountsFromZoning, false, "Enable to prevent mounts from zoning - Prior to December 15, 2004 this is enabled.")
+RULE_BOOL(Character, GroupInvitesRequireTarget, false, "Enable to require players to have invitee on target (Disables /invite name) - Classic Style")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Mercs)

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -7389,7 +7389,7 @@ void Client::Handle_OP_GroupInvite2(const EQApplicationPacket *app)
 		}
 	} else {
 		if (RuleB(Character, GroupInvitesRequireTarget)) {
-			Message(Chat::White, "Invalid target!");
+			Message(Chat::White, "You must target a player first to invite to join your group.");
 		} else {
 			auto pack = new ServerPacket(ServerOP_GroupInvite, sizeof(GroupInvite_Struct));
 			memcpy(pack->pBuffer, gis, sizeof(GroupInvite_Struct));

--- a/zone/string_ids.h
+++ b/zone/string_ids.h
@@ -373,6 +373,7 @@
 #define ALREADY_IN_YOUR_RAID		5077	//%1 is already in your raid.
 #define NOT_IN_YOUR_RAID            5082	//%1 is not in your raid.
 #define GAIN_RAIDEXP				5085	//You gained raid experience!
+#define ALREADY_IN_GRP_RAID			5088	//% 1 rejects your invite because they are in a raid and you are not in theirs, or they are a raid group leader
 #define DUNGEON_SEALED				5141	//The gateway to the dungeon is sealed off to you.  Perhaps you would be able to enter if you needed to adventure there.
 #define ADVENTURE_COMPLETE			5147	//You received %1 points for successfully completing the adventure.
 #define SUCCOR_FAIL					5169	//The portal collapes before you can escape!


### PR DESCRIPTION
Default is false, when enabled, group invites will require a hard target to invite.

`/invite charname` will no longer function when enabled.