### PR TITLE
[Bug Fix] Bard Caster Level Fixes

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -6241,7 +6241,12 @@ bool Mob::UseBardSpellLogic(uint16 spell_id, int slot)
 
 int Mob::GetCasterLevel(uint16 spell_id) {
 	int level = GetLevel();
-	level += itembonuses.effective_casting_level + spellbonuses.effective_casting_level + aabonuses.effective_casting_level;
+	if (GetClass() == Class::Bard) {
+		// Bards receive effective casting level increases to resists/effect. They don't receive benefit from spells like intellectual superiority, however.
+		level += itembonuses.effective_casting_level + aabonuses.effective_casting_level;
+	} else {
+		level += itembonuses.effective_casting_level + spellbonuses.effective_casting_level + aabonuses.effective_casting_level;
+	}
 	LogSpells("Determined effective casting level [{}]+[{}]+[{}]=[{}]", GetLevel(), spellbonuses.effective_casting_level, itembonuses.effective_casting_level, level);
 	return std::max(1, level);
 }


### PR DESCRIPTION
Bards do not gain benefits from spells like Intellectual Superiority