### PR TITLE
[Bug Fix] Swimming rules adjustment and racial

### DIFF
--- a/world/client.cpp
+++ b/world/client.cpp
@@ -1691,14 +1691,15 @@ bool Client::OPCharCreate(char *name, CharCreate_Struct *cc)
 	pp.hunger_level = 6000;
 	pp.thirst_level = 6000;
 
+	/* Set default skills for everybody */
+	pp.skills[EQ::skills::SkillSwimming] = RuleI(Skills, SwimmingStartValue);
+	pp.skills[EQ::skills::SkillSenseHeading] = RuleI(Skills, SenseHeadingStartValue);
+
 	/* Set Racial and Class specific language and skills */
 	SetRacialLanguages(&pp);
 	SetRaceStartingSkills(&pp);
 	SetClassStartingSkills(&pp);
 	SetClassLanguages(&pp);
-
-	pp.skills[EQ::skills::SkillSwimming] = RuleI(Skills, SwimmingStartValue);
-	pp.skills[EQ::skills::SkillSenseHeading] = RuleI(Skills, SenseHeadingStartValue);
 
 //	strcpy(pp.servername, WorldConfig::get()->ShortName.c_str());
 
@@ -2143,7 +2144,9 @@ void Client::SetRaceStartingSkills( PlayerProfile_Struct *pp )
 		}
 	case FROGLOK:
 		{
-			pp->skills[EQ::skills::SkillSwimming] = 125;
+			if (RuleI(Skills, SwimmingStartValue) > 125) {
+				pp->skills[EQ::skills::SkillSwimming] = 125;
+			}
 			break;
 		}
 	case GNOME:
@@ -2160,7 +2163,9 @@ void Client::SetRaceStartingSkills( PlayerProfile_Struct *pp )
 	case IKSAR:
 		{
 			pp->skills[EQ::skills::SkillForage] = 50;
-			pp->skills[EQ::skills::SkillSwimming] = 100;
+			if (RuleI(Skills, SwimmingStartValue) > 100) {
+				pp->skills[EQ::skills::SkillSwimming] = 100;
+			}
 			break;
 		}
 	case WOOD_ELF:

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -2144,7 +2144,7 @@ void Client::SetRaceStartingSkills( PlayerProfile_Struct *pp )
 		}
 	case FROGLOK:
 		{
-			if (RuleI(Skills, SwimmingStartValue) > 125) {
+			if (RuleI(Skills, SwimmingStartValue) < 125) {
 				pp->skills[EQ::skills::SkillSwimming] = 125;
 			}
 			break;
@@ -2163,7 +2163,7 @@ void Client::SetRaceStartingSkills( PlayerProfile_Struct *pp )
 	case IKSAR:
 		{
 			pp->skills[EQ::skills::SkillForage] = 50;
-			if (RuleI(Skills, SwimmingStartValue) > 100) {
+			if (RuleI(Skills, SwimmingStartValue) < 100) {
 				pp->skills[EQ::skills::SkillSwimming] = 100;
 			}
 			break;


### PR DESCRIPTION
We need to set all character default swiming prior to working through racials. Added racial check so if starting rule is over the racial default it will not over-ride the starting rule.