### PR TITLE
[Rule] Classic Triple Attack

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -555,6 +555,11 @@ RULE_BOOL(Combat, WaterMatchRequiredForAutoFireLoS, true, "Enable/Disable the re
 RULE_INT(Combat, ExtraAllowedKickClassesBitmask, 0, "Bitmask for allowing extra classes beyond Warrior, Ranger, Beastlord, and Berserker to kick, No Extra Classes (0) by default")
 RULE_INT(Combat, MaxProcs, 4, "Adjustable maximum number of procs per round, the hard cap is MAX_PROCS (11). Requires mob repop or client zone when changed")
 RULE_BOOL(Combat, FinishingBlowOnlyWhenFleeing, false, "Enable to only allow Finishing Blow when fleeing (Original Style Finishing Blow)")
+RULE_BOOL(Combat, ClassicTripleAttack, false, "enable to use non-skill based classic triple attack. Originally it was Warrior Only but was expanded, can use the TripleAttackChance to tune the classes out.")
+RULE_INT(Combat, ClassicTripleAttackChanceWarrior, 100, "Innate Chance for Warrior to Triple Attack after a Double Attack (125 = 12.5%). DEFAULT: 100")
+RULE_INT(Combat, ClassicTripleAttackChanceMonk, 100, "Innate Chance for Monk to Triple Attack after a Double Attack (200 = 20%). DEFAULT: 100")
+RULE_INT(Combat, ClassicTripleAttackChanceBerserker, 100, "Innate Chance for Berserker to Triple Attack after a Double Attack (200 = 20%). DEFAULT: 100")
+RULE_INT(Combat, ClassicTripleAttackChanceRanger, 100, "Innate Chance for Ranger to Triple Attack after a Double Attack (200 = 20%). DEFAULT: 100")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(NPC)

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -3727,18 +3727,32 @@ bool Client::CheckTripleAttack()
 	int chance;
 
 	if (RuleB(Combat, ClassicTripleAttack)) {
-		if (IsClient() && (GetLevel() >= 60) && (GetClass() == Class::Warrior)) {
-			chance = RuleI(Combat, ClassicTripleAttackChanceWarrior);
-		}
-		if (IsClient() && (GetLevel() >= 60) && (GetClass() == Class::Monk)) {
-			chance = RuleI(Combat, ClassicTripleAttackChanceMonk);
-		}
-		if (IsClient() && (GetLevel() >= 60) && (GetClass() == Class::Berserker)) {
-			chance = RuleI(Combat, ClassicTripleAttackChanceBerserker);
-		}
-
-		if (IsClient() && (GetLevel() >= 60) && (GetClass() == Class::Ranger)) {
-			chance = RuleI(Combat, ClassicTripleAttackChanceRanger);
+		if (
+			IsClient() &&
+			GetLevel() >= 60 &&
+			(
+				GetClass() == Class::Warrior ||
+				GetClass() == Class::Ranger ||
+				GetClass() == Class::Monk ||
+				GetClass() == Class::Berserker
+			)
+		) {
+			switch (GetClass()) {
+				case Class::Warrior:
+					chance = RuleI(Combat, ClassicTripleAttackChanceWarrior);
+					break;
+				case Class::Ranger:
+					chance = RuleI(Combat, ClassicTripleAttackChanceRanger);
+					break;
+				case Class::Monk:
+					chance = RuleI(Combat, ClassicTripleAttackChanceMonk);
+					break;
+				case Class::Berserker:
+					chance = RuleI(Combat, ClassicTripleAttackChanceBerserker);
+					break;
+				default:
+					break;
+			}
 		}
 	} else {
 		chance = GetSkill(EQ::skills::SkillTripleAttack);
@@ -6346,7 +6360,7 @@ void Client::DoAttackRounds(Mob *target, int hand, bool IsFromSpell)
 
 				if (CheckTripleAttack()) {
 					Attack(target, hand, false, false, IsFromSpell);
-					auto flurry_chance = aabonuses.FlurryChance + spellbonuses.FlurryChance +
+					int flurry_chance = aabonuses.FlurryChance + spellbonuses.FlurryChance +
 							    itembonuses.FlurryChance;
 
 					if (flurry_chance && zone->random.Roll(flurry_chance)) {

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -3724,9 +3724,29 @@ bool Client::CheckDoubleAttack()
 // with varying triple attack skill (1-3% error at least)
 bool Client::CheckTripleAttack()
 {
-	int chance = GetSkill(EQ::skills::SkillTripleAttack);
-	if (chance < 1)
+	int chance;
+
+	if (RuleB(Combat, ClassicTripleAttack)) {
+		if (IsClient() && (GetLevel() >= 60) && (GetClass() == Class::Warrior)) {
+			chance = RuleI(Combat, ClassicTripleAttackChanceWarrior);
+		}
+		if (IsClient() && (GetLevel() >= 60) && (GetClass() == Class::Monk)) {
+			chance = RuleI(Combat, ClassicTripleAttackChanceMonk);
+		}
+		if (IsClient() && (GetLevel() >= 60) && (GetClass() == Class::Berserker)) {
+			chance = RuleI(Combat, ClassicTripleAttackChanceBerserker);
+		}
+
+		if (IsClient() && (GetLevel() >= 60) && (GetClass() == Class::Ranger)) {
+			chance = RuleI(Combat, ClassicTripleAttackChanceRanger);
+		}
+	} else {
+		chance = GetSkill(EQ::skills::SkillTripleAttack);
+	}
+
+	if (chance < 1) {
 		return false;
+	}
 
 	int inc = aabonuses.TripleAttackChance + spellbonuses.TripleAttackChance + itembonuses.TripleAttackChance;
 	chance = static_cast<int>(chance * (1 + inc / 100.0f));
@@ -6320,15 +6340,21 @@ void Client::DoAttackRounds(Mob *target, int hand, bool IsFromSpell)
 
 			// you can only triple from the main hand
 			if (hand == EQ::invslot::slotPrimary && CanThisClassTripleAttack()) {
-				CheckIncreaseSkill(EQ::skills::SkillTripleAttack, target, -10);
+				if (!RuleB(Combat, ClassicTripleAttack)) {
+					CheckIncreaseSkill(EQ::skills::SkillTripleAttack, target, -10);
+				}
+
 				if (CheckTripleAttack()) {
 					Attack(target, hand, false, false, IsFromSpell);
-					auto flurrychance = aabonuses.FlurryChance + spellbonuses.FlurryChance +
+					auto flurry_chance = aabonuses.FlurryChance + spellbonuses.FlurryChance +
 							    itembonuses.FlurryChance;
-					if (flurrychance && zone->random.Roll(flurrychance)) {
+
+					if (flurry_chance && zone->random.Roll(flurry_chance)) {
 						Attack(target, hand, false, false, IsFromSpell);
-						if (zone->random.Roll(flurrychance))
+						
+						if (zone->random.Roll(flurry_chance)) {
 							Attack(target, hand, false, false, IsFromSpell);
+						}
 						MessageString(Chat::NPCFlurry, YOU_FLURRY);
 					}
 				}

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -4539,10 +4539,15 @@ bool Mob::CanThisClassDoubleAttack(void) const
 
 bool Mob::CanThisClassTripleAttack() const
 {
-	if (!IsClient())
+	if (!IsClient()) {
 		return false; // When they added the real triple attack skill, mobs lost the ability to triple
-	else
-		return CastToClient()->HasSkill(EQ::skills::SkillTripleAttack);
+	} else {
+		if (RuleB(Combat, ClassicTripleAttack)) {
+			return (GetLevel() >= 60 && (GetClass() == Class::Warrior || GetClass() == Class::Monk || GetClass() == Class::Berserker || GetClass() == Class::Ranger));
+		} else {
+			return CastToClient()->HasSkill(EQ::skills::SkillTripleAttack);
+		}
+	}
 }
 
 bool Mob::IsWarriorClass(void) const

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -4543,7 +4543,15 @@ bool Mob::CanThisClassTripleAttack() const
 		return false; // When they added the real triple attack skill, mobs lost the ability to triple
 	} else {
 		if (RuleB(Combat, ClassicTripleAttack)) {
-			return (GetLevel() >= 60 && (GetClass() == Class::Warrior || GetClass() == Class::Monk || GetClass() == Class::Berserker || GetClass() == Class::Ranger));
+			return (
+				GetLevel() >= 60 &&
+				(
+					GetClass() == Class::Warrior ||
+					GetClass() == Class::Ranger ||
+					GetClass() == Class::Monk ||
+					GetClass() == Class::Berserker
+				)
+			);
 		} else {
 			return CastToClient()->HasSkill(EQ::skills::SkillTripleAttack);
 		}


### PR DESCRIPTION
Classic Triple attack pre-dates skill based triple attack.

Originally it was only for a few classes but was expanded to Warrior, Monks, Berserkers and finally rangers for Dragons of Norrath. After which it was converted to a skill based feature.

These were innate starting level 60 and had a flat % to trigger.