### PR TITLE
[Bug] Pets should not ignore Z axis

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -10766,7 +10766,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 		}
 
 		if ((mypet->GetPetType() == petAnimation && aabonuses.PetCommands[PetCommand]) || mypet->GetPetType() != petAnimation) {
-			if (target != this && DistanceSquaredNoZ(mypet->GetPosition(), target->GetPosition()) <= (RuleR(Pets, AttackCommandRange)*RuleR(Pets, AttackCommandRange))) {
+			if (target != this && DistanceSquared(mypet->GetPosition(), target->GetPosition()) <= (RuleR(Pets, AttackCommandRange)*RuleR(Pets, AttackCommandRange))) {
 				mypet->SetFeigned(false);
 				if (mypet->IsPetStop()) {
 					mypet->SetPetStop(false);


### PR DESCRIPTION
Ignoring the Z axis allows you to attack mobs on target from wildly inappropriate Z distances.

Example you can pull mobs to the cy in bothunder from the towers you are under when many 1000's of units away by Z only.