### PR TITLE
[Rule] Classic Tradeskill Skill Clamp

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -254,6 +254,7 @@ RULE_BOOL(Skills, TrainSenseHeading, false, "Switch whether SenseHeading is trai
 RULE_INT(Skills, SenseHeadingStartValue, 200, "Start value of sense heading skill")
 RULE_BOOL(Skills, SelfLanguageLearning, true, "Enabling self-learning of languages")
 RULE_BOOL(Skills, RequireTomeHandin, false, "Disable click-to-learn and force hand in to Guild Master")
+RULE_INT(Skills, TradeSkillClamp, 0, "Legacy tradeskills would clamp at 252 regardless of item modifiers and skill combination. DEFAULT: 0 will bypass clamp. Legacy value 252")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Pets)

--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -952,10 +952,16 @@ void Client::SendTradeskillDetails(uint32 recipe_id) {
 
 //returns true on success
 bool Client::TradeskillExecute(DBTradeskillRecipe_Struct *spec) {
-	if(spec == nullptr)
-		return(false);
+	if (!spec) {
+		return false;
+	}
 
 	uint16 user_skill = GetSkill(spec->tradeskill);
+
+	if (RuleI(Skills, TradeSkillClamp) != 0 && user_skill > RuleI(Skills, TradeSkillClamp)) {
+		user_skill = RuleI(Skills, TradeSkillClamp);
+	}
+
 	float chance = 0.0;
 	float skillup_modifier = 0.0;
 	int16 thirdstat = 0;


### PR DESCRIPTION
Legacy Tradeskills had a 252 clamp regardless of modifier and skill.

Default to 0 to bypass clamp