### PR TITLE
[Rule] Separate Tradeskill Max Train from Research.

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -244,7 +244,8 @@ RULE_INT(Guild, PlayerCreationRequiredTime, 0, "Time needed online on the accoun
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Skills)
-RULE_INT(Skills, MaxTrainTradeskills, 21, "Highest level for trading skills that can be learnt by the trainer")
+RULE_INT(Skills, MaxTrainTradeskills, 21, "Highest level for trade skills that can be learnt by the trainer")
+RULE_INT(Skills, MaxTrainResearch, 21, "Highest level for training research from a GM.")
 RULE_BOOL(Skills, UseLimitTradeskillSearchSkillDiff, true, "Enables the limit for the maximum difference between trivial and skill for recipe searches and favorites")
 RULE_BOOL(Skills, TrivialTradeskillCombinesNoFail, false, "Enable to make all trivial tradeskill combines unable to fail")
 RULE_INT(Skills, MaxTradeskillSearchSkillDiff, 50, "The maximum difference in skill between the trivial of an item and the skill of the player if the trivial is higher than the skill. Recipes that have not been learnt or made at least once via the Experiment mode will be removed from searches based on this criteria.")

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -244,7 +244,7 @@ RULE_INT(Guild, PlayerCreationRequiredTime, 0, "Time needed online on the accoun
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Skills)
-RULE_INT(Skills, MaxTrainTradeskills, 21, "Highest level for trade skills that can be learnt by the trainer")
+RULE_INT(Skills, MaxTrainTradeskills, 21, "Highest level for trade skills that can be taught by the trainer")
 RULE_INT(Skills, MaxTrainResearch, 21, "Highest level for training research from a GM.")
 RULE_BOOL(Skills, UseLimitTradeskillSearchSkillDiff, true, "Enables the limit for the maximum difference between trivial and skill for recipe searches and favorites")
 RULE_BOOL(Skills, TrivialTradeskillCombinesNoFail, false, "Enable to make all trivial tradeskill combines unable to fail")

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -1713,7 +1713,6 @@ void Client::OPGMTrainSkill(const EQApplicationPacket *app)
 			case EQ::skills::SkillBrewing:
 			case EQ::skills::SkillMakePoison:
 			case EQ::skills::SkillTinkering:
-			case EQ::skills::SkillResearch:
 			case EQ::skills::SkillAlchemy:
 			case EQ::skills::SkillBaking:
 			case EQ::skills::SkillTailoring:
@@ -1722,6 +1721,13 @@ void Client::OPGMTrainSkill(const EQApplicationPacket *app)
 			case EQ::skills::SkillJewelryMaking:
 			case EQ::skills::SkillPottery:
 				if(skilllevel >= RuleI(Skills, MaxTrainTradeskills)) {
+					MessageString(Chat::Red, MORE_SKILLED_THAN_I, pTrainer->GetCleanName());
+					SetSkill(skill, skilllevel);
+					return;
+				}
+				break;
+			case EQ::skills::SkillResearch:
+				if(skilllevel >= RuleI(Skills, MaxTrainResearch)) {
 					MessageString(Chat::Red, MORE_SKILLED_THAN_I, pTrainer->GetCleanName());
 					SetSkill(skill, skilllevel);
 					return;


### PR DESCRIPTION
Different eras had different rules on the max gm trainable skill for Research.