### PR TITLE
[Crash Fix] Character Creation Class/Race out of Range.

### DIFF
--- a/world/client.cpp
+++ b/world/client.cpp
@@ -539,12 +539,12 @@ bool Client::HandleNameApprovalPacket(const EQApplicationPacket *app)
 	uchar clas = app->pBuffer[68];
 
 	if (!IsPlayerRace(race)) {
-		LogInfo("Client::HandleNameApprovalPacket Race was less then zero or over 255");
+		LogInfo("Invalid Race ID.");
 		return false;
 	}
 
-	if (if (!EQ::ValueWithin(class, Class::Warrior, Class::Berserker))) {
-		LogInfo("Client::HandleNameApprovalPacket Class was less then zero or over 255");
+	if (!EQ::ValueWithin(class, Class::Warrior, Class::Berserker))) {
+		LogInfo("Invalid Class ID.");
 		return false;
 	}
 	

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -538,12 +538,12 @@ bool Client::HandleNameApprovalPacket(const EQApplicationPacket *app)
 	uchar race = app->pBuffer[64];
 	uchar clas = app->pBuffer[68];
 
-	if (race < 0 || race > 255) {
+	if (!IsPlayerRace(race)) {
 		LogInfo("Client::HandleNameApprovalPacket Race was less then zero or over 255");
 		return false;
 	}
 
-	if (clas < 0 || clas > 255) {
+	if (if (!EQ::ValueWithin(class, Class::Warrior, Class::Berserker))) {
 		LogInfo("Client::HandleNameApprovalPacket Class was less then zero or over 255");
 		return false;
 	}

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -538,6 +538,16 @@ bool Client::HandleNameApprovalPacket(const EQApplicationPacket *app)
 	uchar race = app->pBuffer[64];
 	uchar clas = app->pBuffer[68];
 
+	if (race < 0 || race > 255) {
+		LogInfo("Client::HandleNameApprovalPacket Race was less then zero or over 255");
+		return false;
+	}
+
+	if (clas < 0 || clas > 255) {
+		LogInfo("Client::HandleNameApprovalPacket Class was less then zero or over 255");
+		return false;
+	}
+	
 	LogInfo("Name approval request. Name=[{}], race=[{}], class=[{}]", char_name, GetRaceIDName(race), GetClassIDName(clas));
 
 	EQApplicationPacket *outapp;

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -35,6 +35,7 @@
 #include "../common/random.h"
 #include "../common/shareddb.h"
 #include "../common/opcodemgr.h"
+#include "../common/data_verification.h"
 
 #include "client.h"
 #include "worlddb.h"
@@ -535,20 +536,21 @@ bool Client::HandleNameApprovalPacket(const EQApplicationPacket *app)
 	}
 
 	auto length = snprintf(char_name, 64, "%s", (char*)app->pBuffer);
-	uchar race = app->pBuffer[64];
-	uchar clas = app->pBuffer[68];
 
-	if (!IsPlayerRace(race)) {
+	uchar race_selection  = app->pBuffer[64];
+	uchar class_selection = app->pBuffer[68];
+
+	if (!IsPlayerRace(race_selection)) {
 		LogInfo("Invalid Race ID.");
 		return false;
 	}
 
-	if (!EQ::ValueWithin(class, Class::Warrior, Class::Berserker))) {
+	if (!EQ::ValueWithin(class_selection, Class::Warrior, Class::Berserker)) {
 		LogInfo("Invalid Class ID.");
 		return false;
 	}
 	
-	LogInfo("Name approval request. Name=[{}], race=[{}], class=[{}]", char_name, GetRaceIDName(race), GetClassIDName(clas));
+	LogInfo("Name approval request. Name=[{}], race_selection=[{}], class=[{}]", char_name, GetRaceIDName(race_selection), GetClassIDName(class_selection));
 
 	EQApplicationPacket *outapp;
 	outapp = new EQApplicationPacket;


### PR DESCRIPTION
Known bug to crash the world server from character creation.

You can send a packet with a manual race or class entry below 0 or above 255 will cause world crash.