### PR TITLE
[Rule] Classic Tracking Skillups

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -257,6 +257,7 @@ RULE_BOOL(Skills, SelfLanguageLearning, true, "Enabling self-learning of languag
 RULE_BOOL(Skills, RequireTomeHandin, false, "Disable click-to-learn and force hand in to Guild Master")
 RULE_INT(Skills, TradeSkillClamp, 0, "Legacy tradeskills would clamp at 252 regardless of item modifiers and skill combination. DEFAULT: 0 will bypass clamp. Legacy value 252")
 RULE_BOOL(Skills, UseAltSinisterStrikeFormula, false, "Enabling will utilize a formula derived from 2004 monkey business post which makes the AA actually worth something.")
+RULE_BOOL(SKills, TrackingAutoRefreshSkillUps, true, "Disable to prevent tracking auto-refresh from giving skill-ups. Classic Style")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Pets)

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -257,7 +257,7 @@ RULE_BOOL(Skills, SelfLanguageLearning, true, "Enabling self-learning of languag
 RULE_BOOL(Skills, RequireTomeHandin, false, "Disable click-to-learn and force hand in to Guild Master")
 RULE_INT(Skills, TradeSkillClamp, 0, "Legacy tradeskills would clamp at 252 regardless of item modifiers and skill combination. DEFAULT: 0 will bypass clamp. Legacy value 252")
 RULE_BOOL(Skills, UseAltSinisterStrikeFormula, false, "Enabling will utilize a formula derived from 2004 monkey business post which makes the AA actually worth something.")
-RULE_BOOL(SKills, TrackingAutoRefreshSkillUps, true, "Disable to prevent tracking auto-refresh from giving skill-ups. Classic Style")
+RULE_BOOL(Skills, TrackingAutoRefreshSkillUps, true, "Disable to prevent tracking auto-refresh from giving skill-ups. Classic Style")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Pets)

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4895,7 +4895,7 @@ void Client::Handle_OP_ClientUpdate(const EQApplicationPacket *app) {
 	/* Update internal state */
 	m_Delta = glm::vec4(ppu->delta_x, ppu->delta_y, ppu->delta_z, EQ10toFloat(ppu->delta_heading));
 
-	if (IsTracking() && ((m_Position.x != cx) || (m_Position.y != cy))) {
+	if (RuleB(Skills, TrackingAutoRefreshSkillUps) && IsTracking() && ((m_Position.x != cx) || (m_Position.y != cy))) {
 		if (zone->random.Real(0, 100) < 70)//should be good
 			CheckIncreaseSkill(EQ::skills::SkillTracking, nullptr, -20);
 	}


### PR DESCRIPTION
Rule: TrackingAutoRefreshSkillUps
Default: True

Disable rule to prevent skillups from happening on auto refresh of tracking window.