### PR TITLE
[Rule] Bash Two Hander use shoulders

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -564,6 +564,8 @@ RULE_INT(Combat, ClassicTripleAttackChanceMonk, 100, "Innate Chance for Monk to 
 RULE_INT(Combat, ClassicTripleAttackChanceBerserker, 100, "Innate Chance for Berserker to Triple Attack after a Double Attack (200 = 20%). DEFAULT: 100")
 RULE_INT(Combat, ClassicTripleAttackChanceRanger, 100, "Innate Chance for Ranger to Triple Attack after a Double Attack (200 = 20%). DEFAULT: 100")
 RULE_INT(Combat, StunChance, 12, "Percent chance that client will be stunned when mob is behind player. DEFAULT: 12")
+RULE_BOOL(Combat, BashTwoHanderUseShoulderAC, false, "Enable to use shoulder AC for bash calculations when two hander is equipped. Unproven if accurate DEFAULT: false")
+RULE_REAL(Combat, BashACBonusDivisor, 25.0, "this divides the AC value contribution to bash damage, lower to increase damage")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(NPC)

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -137,12 +137,16 @@ int Mob::GetBaseSkillDamage(EQ::skills::SkillType skill, Mob *target)
 				if (HasShieldEquipped()) {
 					inst = CastToClient()->GetInv().GetItem(EQ::invslot::slotSecondary);
 				} else if (HasTwoHanderEquipped()) {
-					inst = CastToClient()->GetInv().GetItem(EQ::invslot::slotPrimary);
+					if (RuleB(Combat, BashTwoHanderUseShoulderAC)) {
+						inst = CastToClient()->GetInv().GetItem(EQ::invslot::slotShoulders);
+					} else {
+						inst = CastToClient()->GetInv().GetItem(EQ::invslot::slotPrimary);
+					}
 				}
 			}
 
 			if (inst) {
-				ac_bonus = inst->GetItemArmorClass(true) / 25.0f;
+				ac_bonus = inst->GetItemArmorClass(true) / RuleR(Combat, BashACBonusDivisor);
 			} else {
 				return 0;
 			} // return 0 in cases where we don't have an item


### PR DESCRIPTION
Rule: BashTwoHanderUseShoulderAC
Default: False

Allows server operators to choose if they want two handed bash to utilize the shoulder armor or not.

Rule: BashACBonusDivisor
Default: 25.0

Allows adjustment for bash AC value contributions. Lower to increase damage.