### PR TITLE
[Bug Fix] Increase Precision in CheckDoubleAttack

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -3726,7 +3726,8 @@ bool Client::CheckDoubleAttack()
 		chance = (float(bonus_give_double_attack + bonus_double_attack) / 100.0f);
 	}
 
-	LogCombatDetail("skill = [{}] - bonus_give_double_attack = [{}] - bonus_double_attack = [{}] - chance = [{}]",
+	LogCombatDetail(
+		"skill [{}] bonus_give_double_attack [{}] bonus_double_attack [{}] chance [{}]",
 		skill,
 		bonus_give_double_attack,
 		bonus_double_attack,

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -3726,7 +3726,7 @@ bool Client::CheckDoubleAttack()
 		chance = (float(bonus_give_double_attack + bonus_double_attack) / 100.0f);
 	}
 
-	LogCombatDetail("DA Skill = [{}] - GiveDoubleAttack = [{}] - DoubleAttackChance = [{}] - Final Double Attack Chance = [{}]",
+	LogCombatDetail("skill = [{}] - bonus_give_double_attack = [{}] - bonus_double_attack = [{}] - chance = [{}]",
 		skill,
 		bonus_give_double_attack,
 		bonus_double_attack,


### PR DESCRIPTION
On DA Checks where class was a non skill based DA Attacker (Bard or BST with granted DA) The DA check was too steep and should not have been dividing by 500 but rather 100. Also adjusted logic percision to use floats so loss of data does not occur.