### PR TITLE
[Rules] Classic Spell Data SPA Calc variability

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -481,6 +481,7 @@ RULE_BOOL(Spells, RequireMnemonicRetention, true, "Enabling will require spell s
 RULE_BOOL(Spells, EvacClearCharmPet, false, "Enable to have evac in zone clear charm from charm pets and detach buffs.")
 RULE_BOOL(Spells, ManaTapsRequireNPCMana, false, "Enabling will require target to have mana to tap. Default off as many npc's are caster class with 0 mana and need fixed.")
 RULE_INT(Spells, HarmTouchCritRatio, 200, "Harmtouch crit bonus, on top of BaseCritRatio")
+RULE_BOOL(Spells, UseClassicSpellFocus, false, "Enabling will tell the server to handle random focus damage as classic spell imports lack the limit values.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Combat)

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -5892,16 +5892,19 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 
 			// handle effects
 			case SE_ImprovedDamage:
-				if (type == focusImprovedDamage) {
-					value = GetFocusRandomEffectivenessValue(focus_spell.base_value[i], focus_spell.limit_value[i], best_focus);
-				}
-				break;
-
 			case SE_ImprovedDamage2:
-				if (type == focusImprovedDamage2) {
-					value = GetFocusRandomEffectivenessValue(focus_spell.base_value[i], focus_spell.limit_value[i], best_focus);
+				if (!RuleB(Spells, UseClassicSpellFocus)) {
+					if (type == focusImprovedDamage || type == focusImprovedDamage2) {
+						value = GetFocusRandomEffectivenessValue(focus_spell.base_value[i], focus_spell.limit_value[i], best_focus);
+					}
+					break;
+				} else {
+					if (best_focus) {
+						value = focus_spell.base_value[i];
+					} else {
+						value = zone->random.Int(1, focus_spell.base_value[i]);
+					}
 				}
-				break;
 
 			case SE_Fc_Amplify_Mod:
 				if (type == focusFcAmplifyMod && focus_spell.base_value[i] > value) {
@@ -5910,16 +5913,19 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				break;
 
 			case SE_ImprovedHeal:
-				if (type == focusImprovedHeal) {
-					value = GetFocusRandomEffectivenessValue(focus_spell.base_value[i], focus_spell.limit_value[i], best_focus);
-				}
-				break;
-
 			case SE_ReduceManaCost:
-				if (type == focusManaCost) {
-					value = GetFocusRandomEffectivenessValue(focus_spell.base_value[i], focus_spell.limit_value[i], best_focus);
+				if (!RuleB(Spells, UseClassicSpellFocus)) {
+					if (type == focusImprovedHeal || type == focusManaCost) {
+						value = GetFocusRandomEffectivenessValue(focus_spell.base_value[i], focus_spell.limit_value[i], best_focus);
+					}
+					break;
+				} else {
+					if (best_focus) {
+						value = focus_spell.base_value[i];
+					} else {
+						value = zone->random.Int(1, focus_spell.base_value[i]);
+					}
 				}
-				break;
 
 			case SE_IncreaseSpellHaste:
 				if (type == focusSpellHaste && focus_spell.base_value[i] > value) {
@@ -5967,10 +5973,16 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				break;
 
 			case SE_ReduceReagentCost:
-				if (type == focusReagentCost) {
-					value = GetFocusRandomEffectivenessValue(focus_spell.base_value[i], focus_spell.limit_value[i], best_focus);
+				if (!RuleB(Spells, UseClassicSpellFocus)) {
+					if (type == focusReagentCost) {
+						value = GetFocusRandomEffectivenessValue(focus_spell.base_value[i], focus_spell.limit_value[i], best_focus);
+					}
+					break;
+				} else {
+					if (type == focusReagentCost && focus_spell.base_value[i] > value) {
+						value = focus_spell.base_value[i];
+					}
 				}
-				break;
 
 			case SE_PetPowerIncrease:
 				if (type == focusPetPower && focus_spell.base_value[i] > value) {
@@ -5991,10 +6003,20 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				break;
 
 			case SE_SpellHateMod:
-				if (type == focusSpellHateMod) {
-					value = GetFocusRandomEffectivenessValue(focus_spell.base_value[i], focus_spell.limit_value[i], best_focus);
+				if (!RuleB(Spells, UseClassicSpellFocus)) {
+					if (type == focusSpellHateMod) {
+						value = GetFocusRandomEffectivenessValue(focus_spell.base_value[i], focus_spell.limit_value[i], best_focus);
+					}
+					break;
+				} else {
+					if (type == focusSpellHateMod) {
+						if (best_focus) {
+							value = focus_spell.base_value[i];
+						} else {
+							value = zone->random.Int(1, focus_spell.base_value[i]);
+						}
+					}
 				}
-				break;
 
 			case SE_ReduceReuseTimer:
 				if (type == focusReduceRecastTime) {

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -5919,13 +5919,14 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 						value = GetFocusRandomEffectivenessValue(focus_spell.base_value[i], focus_spell.limit_value[i], best_focus);
 					}
 					break;
-				} else {
-					if (best_focus) {
-						value = focus_spell.base_value[i];
-					} else {
-						value = zone->random.Int(1, focus_spell.base_value[i]);
-					}
 				}
+
+				if (best_focus) {
+					value = focus_spell.base_value[i];
+				} else {
+					value = zone->random.Int(1, focus_spell.base_value[i]);
+				}
+				break;
 
 			case SE_IncreaseSpellHaste:
 				if (type == focusSpellHaste && focus_spell.base_value[i] > value) {
@@ -5978,11 +5979,12 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 						value = GetFocusRandomEffectivenessValue(focus_spell.base_value[i], focus_spell.limit_value[i], best_focus);
 					}
 					break;
-				} else {
-					if (type == focusReagentCost && focus_spell.base_value[i] > value) {
-						value = focus_spell.base_value[i];
-					}
 				}
+
+				if (type == focusReagentCost && focus_spell.base_value[i] > value) {
+					value = focus_spell.base_value[i];
+				}
+				break;
 
 			case SE_PetPowerIncrease:
 				if (type == focusPetPower && focus_spell.base_value[i] > value) {
@@ -6008,15 +6010,16 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 						value = GetFocusRandomEffectivenessValue(focus_spell.base_value[i], focus_spell.limit_value[i], best_focus);
 					}
 					break;
-				} else {
-					if (type == focusSpellHateMod) {
-						if (best_focus) {
-							value = focus_spell.base_value[i];
-						} else {
-							value = zone->random.Int(1, focus_spell.base_value[i]);
-						}
+				}
+
+				if (type == focusSpellHateMod) {
+					if (best_focus) {
+						value = focus_spell.base_value[i];
+					} else {
+						value = zone->random.Int(1, focus_spell.base_value[i]);
 					}
 				}
+				break;
 
 			case SE_ReduceReuseTimer:
 				if (type == focusReduceRecastTime) {


### PR DESCRIPTION
When  using lucy imports of older more classic data, they lack the limit values which provides Focus Random Effectiveness.

Example:

Bazu Plauge (6472) went from a 40 limit to 0 limit on the 2006 lucy import.

Lucy does have limit value data, but it appears the affected SPAs sony handled in source vs in spell data.