### PR TITLE
[Feature] Rule: UseLiveBlockedMessage Bard Spam

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3529,7 +3529,9 @@ int Mob::AddBuff(Mob *caster, uint16 spell_id, int duration, int32 level_overrid
 				LogSpells("Adding buff [{}] failed: stacking prevented by spell [{}] in slot [{}] with caster level [{}]",
 						spell_id, curbuf.spellid, buffslot, curbuf.casterlevel);
 				if (caster && caster->IsClient() && RuleB(Client, UseLiveBlockedMessage)) {
-					caster->Message(Chat::Red, "Your %s did not take hold on %s. (Blocked by %s.)", spells[spell_id].name, GetName(), spells[curbuf.spellid].name);
+					if (caster->GetClass() != Class::Bard) {
+						caster->Message(Chat::Red, "Your %s did not take hold on %s. (Blocked by %s.)", spells[spell_id].name, GetName(), spells[curbuf.spellid].name);
+					}
 				}
 				return -1;
 			}


### PR DESCRIPTION
When using `UseLiveBlockedMessage` rule, bard will get massively spammed when doing aoe songs that are blocked. Not sure it is resonable to try and filter out all stacking messages from songs, but rather just block bards as a whole. I can not think of many cases where bards care of songs land or not when using this rule.