### PR TITLE
[Cleanup] Cleanup AddCash() and RemoveCash() NPC Methods

### DIFF
--- a/zone/lua_npc.cpp
+++ b/zone/lua_npc.cpp
@@ -92,7 +92,7 @@ void Lua_NPC::ClearItemList() {
 	self->ClearItemList();
 }
 
-void Lua_NPC::AddCash(int copper, int silver, int gold, int platinum) {
+void Lua_NPC::AddCash(uint32 copper, uint32 silver, uint32 gold, uint32 platinum) {
 	Lua_Safe_Call_Void();
 	self->AddCash(copper, silver, gold, platinum);
 }
@@ -833,7 +833,7 @@ luabind::scope lua_register_npc() {
 	.def("AddAISpell", (void(Lua_NPC::*)(int,int,int,int,int,int))&Lua_NPC::AddAISpell)
 	.def("AddAISpell", (void(Lua_NPC::*)(int,int,int,int,int,int,int,int))&Lua_NPC::AddAISpell)
 	.def("AddAISpellEffect", (void(Lua_NPC::*)(int,int,int,int))&Lua_NPC::AddAISpellEffect)
-	.def("AddCash", (void(Lua_NPC::*)(int,int,int,int))&Lua_NPC::AddCash)
+	.def("AddCash", (void(Lua_NPC::*)(uint32,uint32,uint32,uint32))&Lua_NPC::AddCash)
 	.def("AddItem", (void(Lua_NPC::*)(int,int))&Lua_NPC::AddItem)
 	.def("AddItem", (void(Lua_NPC::*)(int,int,bool))&Lua_NPC::AddItem)
 	.def("AddItem", (void(Lua_NPC::*)(int,int,bool,int))&Lua_NPC::AddItem)

--- a/zone/lua_npc.h
+++ b/zone/lua_npc.h
@@ -45,7 +45,7 @@ public:
 	void RemoveItem(int item_id, int quantity);
 	void RemoveItem(int item_id, int quantity, int slot);
 	void ClearItemList();
-	void AddCash(int copper, int silver, int gold, int platinum);
+	void AddCash(uint32 copper, uint32 silver, uint32 gold, uint32 platinum);
 	void RemoveCash();
 	int CountLoot();
 	int GetLoottableID();

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -820,32 +820,22 @@ uint16 NPC::GetFirstSlotByItemID(uint32 item_id) {
 	return 0;
 }
 
-void NPC::AddCash(uint16 in_copper, uint16 in_silver, uint16 in_gold, uint16 in_platinum) {
-	if(in_copper >= 0)
-		copper = in_copper;
-	else
-		copper = 0;
-
-	if(in_silver >= 0)
-		silver = in_silver;
-	else
-		silver = 0;
-
-	if(in_gold >= 0)
-		gold = in_gold;
-	else
-		gold = 0;
-
-	if(in_platinum >= 0)
-		platinum = in_platinum;
-	else
-		platinum = 0;
+void NPC::AddCash(
+	uint32 in_copper,
+	uint32 in_silver,
+	uint32 in_gold,
+	uint32 in_platinum
+) {
+	copper   = in_copper >= 0 ? in_copper : 0;
+	silver   = in_silver >= 0 ? in_silver : 0;
+	gold     = in_gold >= 0 ? in_gold : 0;
+	platinum = in_platinum >= 0 ? in_platinum : 0;
 }
 
 void NPC::RemoveCash() {
-	copper = 0;
-	silver = 0;
-	gold = 0;
+	copper   = 0;
+	silver   = 0;
+	gold     = 0;
 	platinum = 0;
 }
 

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -213,7 +213,7 @@ public:
 	void	ClearItemList();
 	inline const ItemList &GetItemList() { return itemlist; }
 	ServerLootItem_Struct*	GetItem(int slot_id);
-	void	AddCash(uint16 in_copper, uint16 in_silver, uint16 in_gold, uint16 in_platinum);
+	void	AddCash(uint32 in_copper, uint32 in_silver, uint32 in_gold, uint32 in_platinum);
 	void	RemoveCash();
 	void	QueryLoot(Client* to, bool is_pet_query = false);
 	bool	HasItem(uint32 item_id);

--- a/zone/perl_npc.cpp
+++ b/zone/perl_npc.cpp
@@ -91,7 +91,7 @@ void Perl_NPC_ClearItemList(NPC* self) // @categories Inventory and Items
 	self->ClearItemList();
 }
 
-void Perl_NPC_AddCash(NPC* self, uint16 copper, uint16 silver, uint16 gold, uint16 platinum) // @categories Currency and Points
+void Perl_NPC_AddCash(NPC* self, uint32 copper, uint32 silver, uint32 gold, uint32 platinum) // @categories Currency and Points
 {
 	self->AddCash(copper, silver, gold, platinum);
 }


### PR DESCRIPTION
# Notes
- `AddCash()` was `uint16` in C++/Perl and `int` in Lua, fix these to `uint32`.
- Consolidate logic in `AddCash()`.