### PR TITLE
[AAs] Convert Loading of AAs to Repositories

### DIFF
--- a/common/repositories/base/base_aa_ability_repository.h
+++ b/common/repositories/base/base_aa_ability_repository.h
@@ -16,6 +16,7 @@
 #include "../../strings.h"
 #include <ctime>
 
+
 class BaseAaAbilityRepository {
 public:
 	struct AaAbility {

--- a/common/repositories/base/base_aa_rank_effects_repository.h
+++ b/common/repositories/base/base_aa_rank_effects_repository.h
@@ -16,6 +16,7 @@
 #include "../../strings.h"
 #include <ctime>
 
+
 class BaseAaRankEffectsRepository {
 public:
 	struct AaRankEffects {

--- a/common/repositories/base/base_aa_rank_prereqs_repository.h
+++ b/common/repositories/base/base_aa_rank_prereqs_repository.h
@@ -16,6 +16,7 @@
 #include "../../strings.h"
 #include <ctime>
 
+
 class BaseAaRankPrereqsRepository {
 public:
 	struct AaRankPrereqs {

--- a/common/repositories/base/base_aa_ranks_repository.h
+++ b/common/repositories/base/base_aa_ranks_repository.h
@@ -16,6 +16,7 @@
 #include "../../strings.h"
 #include <ctime>
 
+
 class BaseAaRanksRepository {
 public:
 	struct AaRanks {

--- a/zone/aa.cpp
+++ b/zone/aa.cpp
@@ -1898,7 +1898,7 @@ bool ZoneDatabase::LoadAlternateAdvancementAbilities(
 			continue;
 		}
 
-		if (ranks.count(e.rank_id)) {
+		if (ranks.count(e.rank_id) > 0) {
 			AA::Rank* r = ranks[e.rank_id].get();
 			r->effects.push_back(f);
 		}


### PR DESCRIPTION
# Notes
- Convert `LoadAlternateAdvancementAbilities()` to repositories.
- Regenerate repositories since a column was added to `aa_ability`.

# Images
## Load
![image](https://github.com/EQEmu/Server/assets/89047260/3de90823-36fc-46f1-926e-18ec9c6037cf)
