### PR TITLE
[Bug Fix] quest::processmobswhilezoneempty() fix.

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -531,7 +531,6 @@ void EntityList::MobProcess()
 
 			// Perform normal mob processing if any of these are true:
 			//	-- zone is not empty
-			//	-- a quest has turned it on for this zone while zone is idle
 			//	-- the entity's spawn2 point is marked as path_while_zone_idle
 			//	-- the zone is newly empty and we're allowing mobs to settle
 			if (

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -933,9 +933,9 @@ void QuestManager::repopzone() {
 	}
 }
 
-void QuestManager::processmobswhilezoneempty(bool idle_when_empty) {
+void QuestManager::processmobswhilezoneempty(bool turn_on) {
 	if (zone) {
-		zone->SetIdleWhenEmpty(idle_when_empty);
+		zone->SetIdleWhenEmpty(!turn_on);
 	} else {
 		LogQuests(
 			"QuestManager::processmobswhilezoneempty called with nullptr zone. Probably syntax error in quest file"


### PR DESCRIPTION
The recent PR #3891 made a small mistake when changing how QuestManager::processmobswhilezoneempty() works.

Since it now changes the zone's idle while empty, instead of an extra variable, the input needed to be negated to match correct behavior,