### PR TITLE
[Merchants] Change database structure for merchant slots

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -5198,6 +5198,29 @@ ADD COLUMN `idle_when_empty` tinyint(1) UNSIGNED NOT NULL DEFAULT 1 AFTER `min_l
 ADD COLUMN `seconds_before_idle` int(11) UNSIGNED NOT NULL DEFAULT 60 AFTER `idle_when_empty`;
 )",
 		.content_schema_update = true
+	},
+	ManifestEntry{
+		.version = 9253,
+		.description = "2024_01_13_merchantlist_slot.sql",
+		.check = "SHOW COLUMNS FROM `merchantlist` LIKE 'slot'",
+		.condition = "missing",
+		.match = "unsigned",
+		.sql = R"(
+ALTER TABLE `merchantlist`
+	MODIFY COLUMN `slot` int(11) UNSIGNED NOT NULL DEFAULT 0
+)",
+		.content_schema_update = true
+	},
+	ManifestEntry{
+		.version = 9254,
+		.description = "2024_01_13_merchantlist_temp_slot.sql",
+		.check = "SHOW COLUMNS FROM `merchantlist_temp` LIKE 'slot'",
+		.condition = "contains",
+		.match = "tinyint",
+		.sql = R"(
+ALTER TABLE `merchantlist_temp`
+	MODIFY COLUMN `slot` int(11) UNSIGNED NOT NULL DEFAULT 0
+)"
 	}
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{

--- a/common/repositories/base/base_merchantlist_repository.h
+++ b/common/repositories/base/base_merchantlist_repository.h
@@ -20,7 +20,7 @@ class BaseMerchantlistRepository {
 public:
 	struct Merchantlist {
 		int32_t     merchantid;
-		int32_t     slot;
+		uint32_t    slot;
 		int32_t     item;
 		int16_t     faction_required;
 		uint8_t     level_required;
@@ -179,21 +179,21 @@ public:
 		if (results.RowCount() == 1) {
 			Merchantlist e{};
 
-			e.merchantid             = static_cast<int32_t>(atoi(row[0]));
-			e.slot                   = static_cast<int32_t>(atoi(row[1]));
-			e.item                   = static_cast<int32_t>(atoi(row[2]));
-			e.faction_required       = static_cast<int16_t>(atoi(row[3]));
+			e.merchantid             = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
+			e.slot                   = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
+			e.item                   = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
+			e.faction_required       = row[3] ? static_cast<int16_t>(atoi(row[3])) : -100;
 			e.level_required         = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.min_status             = row[5] ? static_cast<uint8_t>(strtoul(row[5], nullptr, 10)) : 0;
 			e.max_status             = row[6] ? static_cast<uint8_t>(strtoul(row[6], nullptr, 10)) : 255;
 			e.alt_currency_cost      = row[7] ? static_cast<uint16_t>(strtoul(row[7], nullptr, 10)) : 0;
-			e.classes_required       = static_cast<int32_t>(atoi(row[8]));
-			e.probability            = static_cast<int32_t>(atoi(row[9]));
+			e.classes_required       = row[8] ? static_cast<int32_t>(atoi(row[8])) : 65535;
+			e.probability            = row[9] ? static_cast<int32_t>(atoi(row[9])) : 100;
 			e.bucket_name            = row[10] ? row[10] : "";
 			e.bucket_value           = row[11] ? row[11] : "";
 			e.bucket_comparison      = row[12] ? static_cast<uint8_t>(strtoul(row[12], nullptr, 10)) : 0;
-			e.min_expansion          = static_cast<int8_t>(atoi(row[13]));
-			e.max_expansion          = static_cast<int8_t>(atoi(row[14]));
+			e.min_expansion          = row[13] ? static_cast<int8_t>(atoi(row[13])) : -1;
+			e.max_expansion          = row[14] ? static_cast<int8_t>(atoi(row[14])) : -1;
 			e.content_flags          = row[15] ? row[15] : "";
 			e.content_flags_disabled = row[16] ? row[16] : "";
 
@@ -363,21 +363,21 @@ public:
 		for (auto row = results.begin(); row != results.end(); ++row) {
 			Merchantlist e{};
 
-			e.merchantid             = static_cast<int32_t>(atoi(row[0]));
-			e.slot                   = static_cast<int32_t>(atoi(row[1]));
-			e.item                   = static_cast<int32_t>(atoi(row[2]));
-			e.faction_required       = static_cast<int16_t>(atoi(row[3]));
+			e.merchantid             = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
+			e.slot                   = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
+			e.item                   = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
+			e.faction_required       = row[3] ? static_cast<int16_t>(atoi(row[3])) : -100;
 			e.level_required         = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.min_status             = row[5] ? static_cast<uint8_t>(strtoul(row[5], nullptr, 10)) : 0;
 			e.max_status             = row[6] ? static_cast<uint8_t>(strtoul(row[6], nullptr, 10)) : 255;
 			e.alt_currency_cost      = row[7] ? static_cast<uint16_t>(strtoul(row[7], nullptr, 10)) : 0;
-			e.classes_required       = static_cast<int32_t>(atoi(row[8]));
-			e.probability            = static_cast<int32_t>(atoi(row[9]));
+			e.classes_required       = row[8] ? static_cast<int32_t>(atoi(row[8])) : 65535;
+			e.probability            = row[9] ? static_cast<int32_t>(atoi(row[9])) : 100;
 			e.bucket_name            = row[10] ? row[10] : "";
 			e.bucket_value           = row[11] ? row[11] : "";
 			e.bucket_comparison      = row[12] ? static_cast<uint8_t>(strtoul(row[12], nullptr, 10)) : 0;
-			e.min_expansion          = static_cast<int8_t>(atoi(row[13]));
-			e.max_expansion          = static_cast<int8_t>(atoi(row[14]));
+			e.min_expansion          = row[13] ? static_cast<int8_t>(atoi(row[13])) : -1;
+			e.max_expansion          = row[14] ? static_cast<int8_t>(atoi(row[14])) : -1;
 			e.content_flags          = row[15] ? row[15] : "";
 			e.content_flags_disabled = row[16] ? row[16] : "";
 
@@ -404,21 +404,21 @@ public:
 		for (auto row = results.begin(); row != results.end(); ++row) {
 			Merchantlist e{};
 
-			e.merchantid             = static_cast<int32_t>(atoi(row[0]));
-			e.slot                   = static_cast<int32_t>(atoi(row[1]));
-			e.item                   = static_cast<int32_t>(atoi(row[2]));
-			e.faction_required       = static_cast<int16_t>(atoi(row[3]));
+			e.merchantid             = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
+			e.slot                   = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
+			e.item                   = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
+			e.faction_required       = row[3] ? static_cast<int16_t>(atoi(row[3])) : -100;
 			e.level_required         = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.min_status             = row[5] ? static_cast<uint8_t>(strtoul(row[5], nullptr, 10)) : 0;
 			e.max_status             = row[6] ? static_cast<uint8_t>(strtoul(row[6], nullptr, 10)) : 255;
 			e.alt_currency_cost      = row[7] ? static_cast<uint16_t>(strtoul(row[7], nullptr, 10)) : 0;
-			e.classes_required       = static_cast<int32_t>(atoi(row[8]));
-			e.probability            = static_cast<int32_t>(atoi(row[9]));
+			e.classes_required       = row[8] ? static_cast<int32_t>(atoi(row[8])) : 65535;
+			e.probability            = row[9] ? static_cast<int32_t>(atoi(row[9])) : 100;
 			e.bucket_name            = row[10] ? row[10] : "";
 			e.bucket_value           = row[11] ? row[11] : "";
 			e.bucket_comparison      = row[12] ? static_cast<uint8_t>(strtoul(row[12], nullptr, 10)) : 0;
-			e.min_expansion          = static_cast<int8_t>(atoi(row[13]));
-			e.max_expansion          = static_cast<int8_t>(atoi(row[14]));
+			e.min_expansion          = row[13] ? static_cast<int8_t>(atoi(row[13])) : -1;
+			e.max_expansion          = row[14] ? static_cast<int8_t>(atoi(row[14])) : -1;
 			e.content_flags          = row[15] ? row[15] : "";
 			e.content_flags_disabled = row[16] ? row[16] : "";
 

--- a/common/repositories/base/base_merchantlist_temp_repository.h
+++ b/common/repositories/base/base_merchantlist_temp_repository.h
@@ -16,12 +16,11 @@
 #include "../../strings.h"
 #include <ctime>
 
-
 class BaseMerchantlistTempRepository {
 public:
 	struct MerchantlistTemp {
 		uint32_t npcid;
-		uint8_t  slot;
+		uint32_t slot;
 		int32_t  zone_id;
 		int32_t  instance_id;
 		uint32_t itemid;
@@ -137,9 +136,9 @@ public:
 			MerchantlistTemp e{};
 
 			e.npcid       = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
-			e.slot        = row[1] ? static_cast<uint8_t>(strtoul(row[1], nullptr, 10)) : 0;
-			e.zone_id     = static_cast<int32_t>(atoi(row[2]));
-			e.instance_id = static_cast<int32_t>(atoi(row[3]));
+			e.slot        = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
+			e.zone_id     = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
+			e.instance_id = row[3] ? static_cast<int32_t>(atoi(row[3])) : 0;
 			e.itemid      = row[4] ? static_cast<uint32_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.charges     = row[5] ? static_cast<uint32_t>(strtoul(row[5], nullptr, 10)) : 1;
 
@@ -277,9 +276,9 @@ public:
 			MerchantlistTemp e{};
 
 			e.npcid       = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
-			e.slot        = row[1] ? static_cast<uint8_t>(strtoul(row[1], nullptr, 10)) : 0;
-			e.zone_id     = static_cast<int32_t>(atoi(row[2]));
-			e.instance_id = static_cast<int32_t>(atoi(row[3]));
+			e.slot        = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
+			e.zone_id     = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
+			e.instance_id = row[3] ? static_cast<int32_t>(atoi(row[3])) : 0;
 			e.itemid      = row[4] ? static_cast<uint32_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.charges     = row[5] ? static_cast<uint32_t>(strtoul(row[5], nullptr, 10)) : 1;
 
@@ -307,9 +306,9 @@ public:
 			MerchantlistTemp e{};
 
 			e.npcid       = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
-			e.slot        = row[1] ? static_cast<uint8_t>(strtoul(row[1], nullptr, 10)) : 0;
-			e.zone_id     = static_cast<int32_t>(atoi(row[2]));
-			e.instance_id = static_cast<int32_t>(atoi(row[3]));
+			e.slot        = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
+			e.zone_id     = row[2] ? static_cast<int32_t>(atoi(row[2])) : 0;
+			e.instance_id = row[3] ? static_cast<int32_t>(atoi(row[3])) : 0;
 			e.itemid      = row[4] ? static_cast<uint32_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.charges     = row[5] ? static_cast<uint32_t>(strtoul(row[5], nullptr, 10)) : 1;
 

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9252
+#define CURRENT_BINARY_DATABASE_VERSION 9254
 
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9041
 


### PR DESCRIPTION
The `slot` field should be unsigned int. The temp slot is currently limited to 127. The client will limit the visible slots. Fixes selling to merchants with inventory >127 as seen in:
```[**QueryErr**] **Zone** [**poknowledge**] MySQL Error (1264) [Out of range value for column 'slot' at row 1] Query [REPLACE INTO merchantlist_temp (npcid, slot, zone_id, instance_id, itemid, charges) VALUES(202173, 311, 202, 0, 26708, 1)]```

![image](https://github.com/EQEmu/Server/assets/3617814/ac23e3c3-00c2-4b50-8798-b53e141ee059)

![image](https://github.com/EQEmu/Server/assets/3617814/e1d656ce-7d9e-4aed-9935-fea43833e7d5)

