### PR TITLE
[Bug Fix] Missing e.time_of_death on creation of character_corpses

### DIFF
--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -3791,6 +3791,7 @@ uint32 ZoneDatabase::SaveCharacterCorpse(
 	e.z                = position.z;
 	e.heading          = position.w;
 	e.guild_consent_id = guild_consent_id;
+	e.time_of_death    = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
 	e.is_locked        = corpse.locked;
 	e.exp              = corpse.exp;
 	e.size             = corpse.size;


### PR DESCRIPTION
Prior this was handled in the query, with the move to repositories it is expected for the data to be populated in the structure.