### PR TITLE
[Spawn2] Spawn condition value should default spawn_conditions value

### DIFF
--- a/zone/spawn2.cpp
+++ b/zone/spawn2.cpp
@@ -966,8 +966,14 @@ bool SpawnConditionManager::LoadSpawnConditions(const char* zone_name, uint32 in
 			StrictCheck = true;
 
 		//If event is disabled, or we failed the strict check, set initial spawn_condition to default startup value from spawn_conditions.
-		if(!cevent.enabled || !StrictCheck)
-			SetCondition(zone->GetShortName(), zone->GetInstanceID(),cevent.condition_id,spawn_conditions[cevent.condition_id].value);
+		if(!cevent.enabled || !StrictCheck) {
+			SetCondition(
+					zone->GetShortName(),
+					zone->GetInstanceID(),
+					cevent.condition_id,
+					spawn_conditions[cevent.condition_id].value
+			);
+		}
 
 		if(!cevent.enabled)
             continue;

--- a/zone/spawn2.cpp
+++ b/zone/spawn2.cpp
@@ -845,7 +845,7 @@ bool SpawnConditionManager::LoadDBEvent(uint32 event_id, SpawnEvent &event, std:
     std::string timeAsString;
     EQTime::ToString(&event.next, timeAsString);
 
-  LogSpawns("(LoadDBEvent) Loaded [{}] spawn event [{}] on condition [{}] with period [{}], action [{}], argument [{}], strict [{}]. Will trigger at [{}]", event.enabled? "enabled": "disabled", event.id, event.condition_id, event.period, event.action, event.argument, event.strict, timeAsString.c_str());
+  LogSpawns("(LoadDBEvent) Loaded [{}] spawn event [{}] on condition [{}] with period [{}] action [{}] argument [{}] strict [{}]. Will trigger at [{}]", event.enabled? "enabled": "disabled", event.id, event.condition_id, event.period, event.action, event.argument, event.strict, timeAsString.c_str());
 
 	return true;
 }
@@ -931,7 +931,7 @@ bool SpawnConditionManager::LoadSpawnConditions(const char* zone_name, uint32 in
 		spawn_events.push_back(event);
 
 		LogSpawns(
-			"(LoadSpawnConditions) Loaded [{}] spawn event [{}] on condition [{}] with period [{}], action [{}], argument [{}], strict [{}]",
+			"(LoadSpawnConditions) Loaded [{}] spawn event [{}] on condition [{}] with period [{}] action [{}] argument [{}] strict [{}]",
 			event.enabled ? "enabled" : "disabled",
 			event.id,
 			event.condition_id,
@@ -965,9 +965,9 @@ bool SpawnConditionManager::LoadSpawnConditions(const char* zone_name, uint32 in
 			cevent.next.year == tod.year)
 			StrictCheck = true;
 
-		//If event is disabled, or we failed the strict check, set initial spawn_condition to 0.
+		//If event is disabled, or we failed the strict check, set initial spawn_condition to default startup value from spawn_conditions.
 		if(!cevent.enabled || !StrictCheck)
-			SetCondition(zone->GetShortName(), zone->GetInstanceID(),cevent.condition_id,0);
+			SetCondition(zone->GetShortName(), zone->GetInstanceID(),cevent.condition_id,spawn_conditions[cevent.condition_id].value);
 
 		if(!cevent.enabled)
             continue;
@@ -1053,7 +1053,7 @@ void SpawnConditionManager::SetCondition(const char *zone_short, uint32 instance
 		SpawnCondition &cond = condi->second;
 
 		if(cond.value == new_value) {
-			LogSpawns("Condition update received from world for [{}] with value [{}], which is what we already have", condition_id, new_value);
+			LogSpawns("Condition update received from world for [{}] with value [{}] which is what we already have", condition_id, new_value);
 			return;
 		}
 
@@ -1080,7 +1080,7 @@ void SpawnConditionManager::SetCondition(const char *zone_short, uint32 instance
 		SpawnCondition &cond = condi->second;
 
 		if(cond.value == new_value) {
-			LogSpawns("Local Condition update requested for [{}] with value [{}], which is what we already have", condition_id, new_value);
+			LogSpawns("Local Condition update requested for [{}] with value [{}] which is what we already have", condition_id, new_value);
 			return;
 		}
 


### PR DESCRIPTION
The spawn_conditions table has a default value for the condition.  This was not used at bootup.

I have zones where spawn2 locations have the same condition, but what spawns depends on the value 1, 2, 3 etc.

These spots are spawning with a bootup value of 0 instead of what was in the spawn_conditions table.

Yes, they fix themselves as either spawn_events or quests update the condition, but the bootup value should not always be 0.

I fixed the LogSpawn lines because the commas were confusing the formatting engine and ended up inside the [].