### PR TITLE
[Bug Fix] Add rank to repository generator

### DIFF
--- a/utils/scripts/generators/repository-generator.pl
+++ b/utils/scripts/generators/repository-generator.pl
@@ -599,7 +599,8 @@ sub get_reserved_cpp_variable_names
         "class",
         "int",
         "key",
-        "range"
+        "range",
+	"rank"
     );
 }
 


### PR DESCRIPTION
# Notes
- This allows `rank` column to be used properly.