### PR TITLE
[Database] Drop item_tick if exists tweak in manifest

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -5229,7 +5229,7 @@ ALTER TABLE `merchantlist_temp`
 		.condition = "not_empty",
 		.match = "",
 		.sql = R"(
-DROP TABLE item_tick
+DROP TABLE IF EXISTS item_tick
 )"
 	}
 // -- template; copy/paste this when you need to create a new entry


### PR DESCRIPTION
Should have added this originally, somehow someone didn't have the table and the migration failed

```
 World |  QueryErr  | QueryDatabaseMulti [Unknown table 'peq.item_tick'] (1051) query [DROP TABLE item_tick] 
 World |   Error    | UpdateManifest (#1051) [Unknown table 'peq.item_tick'] 
 World |    Info    | UpdateManifest Required database update failed. This could be a problem 
 World |    Info    | UpdateManifest Would you like to skip this update? [y/n] (Timeout 60s) 
 World |    Info    | UpdateManifest [9255] [2024_01_13_drop_item_tick_deprecated.sql] [error] 
 World |   Error    | UpdateManifest Fatal | Database migration [2024_01_13_drop_item_tick_deprecated.sql] failed to run 
 World |   Error    | UpdateManifest Fatal | Shutting down
```