### PR TITLE
Push discpline messages under melee->disciplines

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -4435,9 +4435,12 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 
 			// If an "innate" spell, change to spell type to
 			// produce a spell message.  Send to everyone.
-			// This fixes issues with npc-procs like 1002 and 918 which
-			// need to spit out extra spell color.
-			if (IsValidSpell(spell_id) && skill_used == EQ::skills::SkillTigerClaw) {
+			// This fixes issues with npc-procs like 1002 and 918 and
+			// damage based disciplines which need to spit out extra spell color.
+			if (IsValidSpell(spell_id) && 
+				(skill_used == EQ::skills::SkillTigerClaw ||
+				(IsDamageSpell(spell_id) && IsDiscipline(spell_id)))
+				) {
 				a->type = DamageTypeSpell;
 				entity_list.QueueCloseClients(
 					this, /* Sender */

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3819,6 +3819,8 @@ bool Mob::SpellOnTarget(
 
 		entity_list.QueueCloseClients(this, outapp, false,
 			RuleI(Range, SpellMessages), 0, true, FilterNone);
+
+		safe_delete(outapp);
 	}
 
 	// Actual cast action - this causes the caster animation and the particles

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3805,24 +3805,6 @@ bool Mob::SpellOnTarget(
 
 	LogSpells("Casting spell [{}] on [{}] with effective caster level [{}]", spell_id, spelltar->GetName(), caster_level);
 
-	if (IsOfClientBotMerc() && (IsDiscipline(spell_id) || spells[spell_id].is_discipline)) {
-		auto outapp = new EQApplicationPacket(OP_Damage, sizeof(CombatDamage_Struct));
-		CombatDamage_Struct* a = (CombatDamage_Struct*)outapp->pBuffer;
-		a->target = spelltar->GetID();
-		a->source = GetID();
-		a->type = DamageTypeSpell;
-		a->damage = 0; // dont know it here
-		a->spellid = spell_id;
-		a->special = 0;
-		a->hit_heading = this->GetHeading();
-		a->force = 0;
-
-		entity_list.QueueCloseClients(this, outapp, false,
-			RuleI(Range, SpellMessages), 0, true, FilterNone);
-
-		safe_delete(outapp);
-	}
-
 	// Actual cast action - this causes the caster animation and the particles
 	// around the target
 	// we do this first, that way we get the particles even if the spell


### PR DESCRIPTION
To be able to move these messages from chat window to chat window, we need to send an actually packet with spell id.

All disciplines should:

- show in chat windows under melee->disciplines
- color changes in client done under special abilities