### PR TITLE
[Zoning] Additional logs for zoning under instance checks

### DIFF
--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -166,6 +166,7 @@ void Client::Handle_OP_ZoneChange(const EQApplicationPacket *app) {
 					target_instance_id
 				).c_str()
 			);
+			LogZoning("Client [{}] Invalid zone instance request to zone id [{}]", GetCleanName(), target_zone_id);
 			SendZoneCancel(zc);
 			return;
 		}
@@ -179,6 +180,7 @@ void Client::Handle_OP_ZoneChange(const EQApplicationPacket *app) {
 					target_zone_id
 				).c_str()
 			);
+			LogZoning("Client [{}] Invalid zone instance request to zone id [{}]", GetCleanName(), target_zone_id);
 			SendZoneCancel(zc);
 			return;
 		}


### PR DESCRIPTION
This adds logging in cases where we validate instance checks. The client doesn't actually get these messages when we send a zone cancel and can be hard to pin down what is happening if you are getting rejected.