### PR TITLE
[Logging] Force Info category to be always on in file/console logs

### DIFF
--- a/common/eqemu_logsys.cpp
+++ b/common/eqemu_logsys.cpp
@@ -701,6 +701,8 @@ EQEmuLogSys *EQEmuLogSys::LoadLogDatabaseSettings()
 	log_settings[Logs::Crash].log_to_console = static_cast<uint8>(Logs::General);
 	log_settings[Logs::Crash].log_to_gmsay   = static_cast<uint8>(Logs::General);
 	log_settings[Logs::Crash].log_to_file    = static_cast<uint8>(Logs::General);
+	log_settings[Logs::Info].log_to_file     = static_cast<uint8>(Logs::General);
+	log_settings[Logs::Info].log_to_console  = static_cast<uint8>(Logs::General);
 
 	return this;
 }


### PR DESCRIPTION
Users can accidentally disable this category not realizing it and it disables what is considered standard informational logging to the operation of a server.