### PR TITLE
[Database] Increase max spawngroup name from 50 to 200

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -5231,6 +5231,17 @@ ALTER TABLE `merchantlist_temp`
 		.sql = R"(
 DROP TABLE IF EXISTS item_tick
 )"
+	},
+	ManifestEntry{
+		.version = 9256,
+		.description = "2024_01_16_increase_spawngroup_size.sql",
+		.check = "SHOW COLUMNS FROM `spawngroup` LIKE 'name'",
+		.condition = "contains",
+		.match = "varchar(50)",
+		.sql = R"(
+ALTER TABLE `spawngroup`
+MODIFY COLUMN `name` varchar(200) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL DEFAULT '' AFTER `id`;
+)"
 	}
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9255
+#define CURRENT_BINARY_DATABASE_VERSION 9256
 
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9041
 


### PR DESCRIPTION
This field is needlessly restrictive on name length