### PR TITLE
[Pets] Convert Load of Pets Beastlord Data to Repositories

### DIFF
--- a/common/repositories/base/base_pets_beastlord_data_repository.h
+++ b/common/repositories/base/base_pets_beastlord_data_repository.h
@@ -19,13 +19,13 @@
 class BasePetsBeastlordDataRepository {
 public:
 	struct PetsBeastlordData {
-		uint32_t    player_race;
-		uint32_t    pet_race;
-		uint8_t     texture;
-		uint8_t     helm_texture;
-		uint8_t     gender;
-		std::string size_modifier;
-		uint8_t     face;
+		uint32_t player_race;
+		uint32_t pet_race;
+		uint8_t  texture;
+		uint8_t  helm_texture;
+		uint8_t  gender;
+		float    size_modifier;
+		uint8_t  face;
 	};
 
 	static std::string PrimaryKey()

--- a/utils/scripts/generators/repository-generator.pl
+++ b/utils/scripts/generators/repository-generator.pl
@@ -570,7 +570,7 @@ sub translate_mysql_data_type_to_c
             $struct_data_type = 'float';
         }
         elsif ($mysql_data_type =~ /double/i) {
-            $struct_data_type = 'float';
+            $struct_data_type = 'double';
         }
     }
     elsif ($mysql_data_type =~ /bigint/) {

--- a/utils/scripts/generators/repository-generator.pl
+++ b/utils/scripts/generators/repository-generator.pl
@@ -566,6 +566,12 @@ sub translate_mysql_data_type_to_c
         elsif ($mysql_data_type =~ /int/) {
             $struct_data_type = 'uint32_t';
         }
+        elsif ($mysql_data_type =~ /float|decimal/i) {
+            $struct_data_type = 'float';
+        }
+        elsif ($mysql_data_type =~ /double/i) {
+            $struct_data_type = 'float';
+        }
     }
     elsif ($mysql_data_type =~ /bigint/) {
         $struct_data_type = 'int64_t';

--- a/zone/pets.cpp
+++ b/zone/pets.cpp
@@ -21,6 +21,7 @@
 #include "../common/strings.h"
 
 #include "../common/repositories/pets_repository.h"
+#include "../common/repositories/pets_beastlord_data_repository.h"
 
 #include "entity.h"
 #include "client.h"
@@ -196,15 +197,18 @@ void Mob::MakePoweredPet(uint16 spell_id, const char* pettype, int16 petpower,
 	}
 
 	// Beastlord Pets
-	if(record.petnaming == 2) {
+	if (record.petnaming == 2) {
 		uint16 race_id = GetBaseRace();
-		auto beastlord_pet_data = content_db.GetBeastlordPetData(race_id);
-		npc_type->race = beastlord_pet_data.race_id;
-		npc_type->texture = beastlord_pet_data.texture;
-		npc_type->helmtexture = beastlord_pet_data.helm_texture;
-		npc_type->gender = beastlord_pet_data.gender;
-		npc_type->size *= beastlord_pet_data.size_modifier;
-		npc_type->luclinface = beastlord_pet_data.face;
+
+		auto d = content_db.GetBeastlordPetData(race_id);
+
+		npc_type->race        = d.race_id;
+		npc_type->texture     = d.texture;
+		npc_type->helmtexture = d.helm_texture;
+		npc_type->gender      = d.gender;
+		npc_type->luclinface  = d.face;
+
+		npc_type->size *= d.size_modifier;
 	}
 
 	// handle monster summoning pet appearance
@@ -655,27 +659,20 @@ bool Pet::CheckSpellLevelRestriction(Mob *caster, uint16 spell_id)
 }
 
 BeastlordPetData::PetStruct ZoneDatabase::GetBeastlordPetData(uint16 race_id) {
-	BeastlordPetData::PetStruct beastlord_pet_data;
-	std::string query = fmt::format(
-		SQL(
-			SELECT
-			`pet_race`, `texture`, `helm_texture`, `gender`, `size_modifier`, `face`
-			FROM `pets_beastlord_data`
-			WHERE `player_race` = {}
-		),
-		race_id
-	);
-	auto results = QueryDatabase(query);
-	if (!results.Success() || results.RowCount() != 1) {
-		return beastlord_pet_data;
+	BeastlordPetData::PetStruct d;
+
+	const auto& e = PetsBeastlordDataRepository::FindOne(*this, race_id);
+
+	if (!e.player_race) {
+		return d;
 	}
 
-	auto row = results.begin();
-	beastlord_pet_data.race_id = Strings::ToInt(row[0]);
-	beastlord_pet_data.texture = Strings::ToInt(row[1]);
-	beastlord_pet_data.helm_texture = Strings::ToInt(row[2]);
-	beastlord_pet_data.gender = Strings::ToInt(row[3]);
-	beastlord_pet_data.size_modifier = Strings::ToFloat(row[4]);
-	beastlord_pet_data.face = Strings::ToInt(row[5]);
-	return beastlord_pet_data;
+	d.race_id       = e.pet_race;
+	d.texture       = e.texture;
+	d.helm_texture  = e.helm_texture;
+	d.gender        = e.gender;
+	d.size_modifier = e.size_modifier;
+	d.face          = e.face;
+
+	return d;
 }

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -15,8 +15,6 @@
 
 #include "bot_database.h"
 
-#define WOLF 42
-
 class Client;
 class Corpse;
 class Merc;
@@ -337,12 +335,12 @@ struct CharacterCorpseEntry
 
 namespace BeastlordPetData {
 	struct PetStruct {
-		uint16 race_id = WOLF;
-		uint8 texture = 0;
-		uint8 helm_texture = 0;
-		uint8 gender = Gender::Neuter;
-		float size_modifier = 1.0f;
-		uint8 face = 0;
+		uint16 race_id       = Race::Wolf;
+		uint8  texture       = 0;
+		uint8  helm_texture  = 0;
+		uint8  gender        = Gender::Neuter;
+		float  size_modifier = 1.0f;
+		uint8  face          = 0;
 	};
 }
 


### PR DESCRIPTION
# Notes
- Convert `GetBeastlordPetData()` to repositories.
- Add support for `unsigned` versions of `float`, `double`, and `decimal`, without this we defaulted to `std::string`, such as with `pets_beastlord_data`.