### PR TITLE
[Crash Fix] Reverting PR #3877

### DIFF
--- a/queryserv/database.cpp
+++ b/queryserv/database.cpp
@@ -398,6 +398,5 @@ void QSDatabase::GeneralQueryReceive(ServerPacket *pack)
 		LogInfo("[{}]", query.c_str());
 	}
 
-	safe_delete(pack);
 	safe_delete_array(queryBuffer);
 }


### PR DESCRIPTION
Reports of #3877 causing crashes on windows. No reports on Linux, but reverting for safety.