### PR TITLE
[Bug Fix] Fix Mercenaries Buffs/Zoning Issues

### DIFF
--- a/zone/merc.cpp
+++ b/zone/merc.cpp
@@ -5575,20 +5575,17 @@ Merc* Client::GetMerc() {
 	return (tmp);
 }
 
-uint8 Client::GetNumberOfMercenaries() {
+uint8 Client::GetNumberOfMercenaries()
+{
+	uint8 count = 0;
 
-	uint8 numMercs = 0;
-
-	for(int i=0; i<MAXMERCS; i++)
-	{
-		if(m_mercinfo[i].mercid != 0)
-		{
-			numMercs++;
+	for (int slot_id = 0; slot_id < MAXMERCS; slot_id++) {
+		if (m_mercinfo[slot_id].mercid != 0) {
+			count++;
 		}
 	}
-	Log(Logs::General, Logs::Mercenaries, "GetNumberOfMercenaries Number: %i for %s.", numMercs, GetName());
 
-	return numMercs;
+	return count;
 }
 
 void Merc::SetMercData( uint32 template_id ) {
@@ -5738,17 +5735,17 @@ void NPC::LoadMercenaryTypes()
 	);
 
 	auto results = database.QueryDatabase(query);
-	if (!results.Success()) {
+	if (!results.Success() || !results.RowCount()) {
 		return;
 	}
 
-	for (auto row = results.begin(); row != results.end(); ++row) {
-		MercType t;
-
-		t.Type          = Strings::ToInt(row[0]);
-		t.ClientVersion = Strings::ToInt(row[1]);
-
-		mercTypeList.push_back(t);
+	for (auto row : results) {
+		mercTypeList.push_back(
+			MercType{
+				.Type = Strings::ToUnsignedInt(row[0]),
+				.ClientVersion = Strings::ToUnsignedInt(row[1])
+			}
+		);
 	}
 }
 
@@ -5772,21 +5769,21 @@ void NPC::LoadMercenaries()
 	);
 
 	auto results = database.QueryDatabase(query);
-	if (!results.Success()) {
+	if (!results.Success() || !results.RowCount()) {
 		return;
 	}
 
-	for (auto row = results.begin(); row != results.end(); ++row) {
-		MercData t;
-
-		t.MercTemplateID = Strings::ToInt(row[0]);
-		t.MercType       = Strings::ToInt(row[1]);
-		t.MercSubType    = Strings::ToInt(row[2]);
-		t.CostFormula    = Strings::ToInt(row[3]);
-		t.ClientVersion  = Strings::ToInt(row[4]);
-		t.NPCID          = Strings::ToInt(row[5]);
-
-		mercDataList.push_back(t);
+	for (auto row : results) {
+		mercDataList.push_back(
+			MercData{
+				.MercTemplateID = Strings::ToUnsignedInt(row[0]),
+				.MercType = Strings::ToUnsignedInt(row[1]),
+				.MercSubType = Strings::ToUnsignedInt(row[2]),
+				.CostFormula = Strings::ToUnsignedInt(row[3]),
+				.ClientVersion = Strings::ToUnsignedInt(row[4]),
+				.NPCID = Strings::ToUnsignedInt(row[5])
+			}
+		);
 	}
 }
 

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -2295,7 +2295,7 @@ bool ZoneDatabase::SaveMercenary(Merc* m)
 		auto e = MercsRepository::NewEntity();
 
 		e.OwnerCharacterID = m->GetMercenaryCharacterID();
-		e.Slot             = c->GetNumberOfMercenaries();
+		e.Slot             = (c->GetNumberOfMercenaries() - 1);
 		e.Name             = m->GetCleanName();
 		e.TemplateID       = m->GetMercenaryTemplateID();
 		e.SuspendedTime    = c->GetMercInfo().SuspendedTime;
@@ -2336,7 +2336,7 @@ bool ZoneDatabase::SaveMercenary(Merc* m)
 	auto e = MercsRepository::FindOne(*this, m->GetMercenaryID());
 
 	e.OwnerCharacterID = m->GetMercenaryCharacterID();
-	e.Slot             = c->GetNumberOfMercenaries();
+	e.Slot             = (c->GetNumberOfMercenaries() - 1);
 	e.Name             = m->GetCleanName();
 	e.TemplateID       = m->GetMercenaryTemplateID();
 	e.SuspendedTime    = c->GetMercInfo().SuspendedTime;
@@ -2416,7 +2416,9 @@ void ZoneDatabase::SaveMercenaryBuffs(Merc* m)
 		v.emplace_back(e);
 	}
 
-	MercBuffsRepository::InsertMany(*this, v);
+	if (!v.empty()) {
+		MercBuffsRepository::InsertMany(*this, v);
+	}
 }
 
 void ZoneDatabase::LoadMercenaryBuffs(Merc* m)


### PR DESCRIPTION
# Notes
- Mercenaries were disappearing on zoning because they were saving to slot `1` and being loaded from slot `0`.
- Mercenaries were not displaying properly in group window because of this as well.
- Mercenary buffs were saving even when they did not have any buffs.