### PR TITLE
[Rules] Add rules for cross-zone/world-wide casts to affect Bots/Mercenaries/Pets

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -315,6 +315,9 @@ RULE_INT(World, MaximumQuestErrors, 30, "Changes the maximum number of quest err
 RULE_INT(World, BootHour, 0, "Sets the in-game hour world will set when it first boots. 0-24 are valid options, where 0 disables this rule")
 RULE_BOOL(World, UseItemLinksForKeyRing, false, "Uses item links for Key Ring Listing instead of item name")
 RULE_BOOL(World, UseOldShadowKnightClassExport, true, "Disable to have Shadowknight show as Shadow Knight (live-like)")
+RULE_BOOL(World, AllowWorldWideSpellsOnBots, false, "Set to true to allow world wide spells (cast/remove) to affect bots")
+RULE_BOOL(World, AllowWorldWideSpellsOnMercs, false, "Set to true to allow world wide spells (cast/remove) to affect mercenaries")
+RULE_BOOL(World, AllowWorldWideSpellsOnPets, false, "Set to true to allow world wide spells (cast/remove) to affect pets")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Zone)
@@ -340,6 +343,9 @@ RULE_INT(Zone, GlobalLootMultiplier, 1, "Sets Global Loot drop multiplier for da
 RULE_BOOL(Zone, KillProcessOnDynamicShutdown, true, "When process has booted a zone and has hit its zone shut down timer, it will hard kill the process to free memory back to the OS")
 RULE_INT(Zone, SpawnEventMin, 3, "When strict is set in spawn_events, specifies the max EQ minutes into the trigger hour a spawn_event will fire. Going below 3 may cause the spawn_event to not fire.")
 RULE_INT(Zone, ForageChance, 25, "Chance of foraging from zone table vs global table")
+RULE_BOOL(Zone, AllowCrossZoneSpellsOnBots, false, "Set to true to allow cross zone spells (cast/remove) to affect bots")
+RULE_BOOL(Zone, AllowCrossZoneSpellsOnMercs, false, "Set to true to allow cross zone spells (cast/remove) to affect mercenaries")
+RULE_BOOL(Zone, AllowCrossZoneSpellsOnPets, false, "Set to true to allow cross zone spells (cast/remove) to affect pets")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Map)

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -315,9 +315,6 @@ RULE_INT(World, MaximumQuestErrors, 30, "Changes the maximum number of quest err
 RULE_INT(World, BootHour, 0, "Sets the in-game hour world will set when it first boots. 0-24 are valid options, where 0 disables this rule")
 RULE_BOOL(World, UseItemLinksForKeyRing, false, "Uses item links for Key Ring Listing instead of item name")
 RULE_BOOL(World, UseOldShadowKnightClassExport, true, "Disable to have Shadowknight show as Shadow Knight (live-like)")
-RULE_BOOL(World, AllowWorldWideSpellsOnBots, false, "Set to true to allow world wide spells (cast/remove) to affect bots")
-RULE_BOOL(World, AllowWorldWideSpellsOnMercs, false, "Set to true to allow world wide spells (cast/remove) to affect mercenaries")
-RULE_BOOL(World, AllowWorldWideSpellsOnPets, false, "Set to true to allow world wide spells (cast/remove) to affect pets")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Zone)

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -2749,13 +2749,13 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 							}
 						}
 
-						if (RuleB(World, AllowWorldWideSpellsOnMercs)) {
+						if (RuleB(Zone, AllowCrossZoneSpellsOnMercs)) {
 							if (c->GetMerc()) {
 								c->GetMerc()->ApplySpellBuff(s->spell_id);
 							}
 						}
 
-						if (RuleB(World, AllowWorldWideSpellsOnPets)) {
+						if (RuleB(Zone, AllowCrossZoneSpellsOnPets)) {
 							if (c->HasPet()) {
 								c->GetPet()->ApplySpellBuff(s->spell_id);
 							}
@@ -2771,13 +2771,13 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 							}
 						}
 
-						if (RuleB(World, AllowWorldWideSpellsOnMercs)) {
+						if (RuleB(Zone, AllowCrossZoneSpellsOnMercs)) {
 							if (c->GetMerc()) {
 								c->GetMerc()->BuffFadeBySpellID(s->spell_id);
 							}
 						}
 
-						if (RuleB(World, AllowWorldWideSpellsOnPets)) {
+						if (RuleB(Zone, AllowCrossZoneSpellsOnPets)) {
 							if (c->HasPet()) {
 								c->GetPet()->BuffFadeBySpellID(s->spell_id);
 							}
@@ -2802,7 +2802,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 							case CZSpellUpdateSubtype_Cast:
 								m->ApplySpellBuff(s->spell_id);
 
-								if (RuleB(World, AllowWorldWideSpellsOnPets)) {
+								if (RuleB(Zone, AllowCrossZoneSpellsOnPets)) {
 									if (m->HasPet()) {
 										m->GetPet()->ApplySpellBuff(s->spell_id);
 									}
@@ -2812,7 +2812,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 							case CZSpellUpdateSubtype_Remove:
 								m->BuffFadeBySpellID(s->spell_id);
 
-								if (RuleB(World, AllowWorldWideSpellsOnPets)) {
+								if (RuleB(Zone, AllowCrossZoneSpellsOnPets)) {
 									if (m->HasPet()) {
 										m->GetPet()->BuffFadeBySpellID(s->spell_id);
 									}
@@ -2839,7 +2839,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 							case CZSpellUpdateSubtype_Cast:
 								m.member->ApplySpellBuff(s->spell_id);
 
-								if (RuleB(World, AllowWorldWideSpellsOnPets)) {
+								if (RuleB(Zone, AllowCrossZoneSpellsOnPets)) {
 									if (m.member->HasPet()) {
 										m.member->GetPet()->ApplySpellBuff(s->spell_id);
 									}
@@ -2849,7 +2849,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 							case CZSpellUpdateSubtype_Remove:
 								m.member->BuffFadeBySpellID(s->spell_id);
 
-								if (RuleB(World, AllowWorldWideSpellsOnPets)) {
+								if (RuleB(Zone, AllowCrossZoneSpellsOnPets)) {
 									if (m.member->HasPet()) {
 										m.member->GetPet()->BuffFadeBySpellID(s->spell_id);
 									}
@@ -2873,13 +2873,13 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 								}
 							}
 
-							if (RuleB(World, AllowWorldWideSpellsOnMercs)) {
+							if (RuleB(Zone, AllowCrossZoneSpellsOnMercs)) {
 								if (c.second->GetMerc()) {
 									c.second->GetMerc()->ApplySpellBuff(s->spell_id);
 								}
 							}
 
-							if (RuleB(World, AllowWorldWideSpellsOnPets)) {
+							if (RuleB(Zone, AllowCrossZoneSpellsOnPets)) {
 								if (c.second->HasPet()) {
 									c.second->GetPet()->ApplySpellBuff(s->spell_id);
 								}
@@ -2895,13 +2895,13 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 								}
 							}
 
-							if (RuleB(World, AllowWorldWideSpellsOnMercs)) {
+							if (RuleB(Zone, AllowCrossZoneSpellsOnMercs)) {
 								if (c.second->GetMerc()) {
 									c.second->GetMerc()->BuffFadeBySpellID(s->spell_id);
 								}
 							}
 
-							if (RuleB(World, AllowWorldWideSpellsOnPets)) {
+							if (RuleB(Zone, AllowCrossZoneSpellsOnPets)) {
 								if (c.second->HasPet()) {
 									c.second->GetPet()->BuffFadeBySpellID(s->spell_id);
 								}
@@ -2924,13 +2924,13 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 								}
 							}
 
-							if (RuleB(World, AllowWorldWideSpellsOnMercs)) {
+							if (RuleB(Zone, AllowCrossZoneSpellsOnMercs)) {
 								if (c.second->GetMerc()) {
 									c.second->GetMerc()->ApplySpellBuff(s->spell_id);
 								}
 							}
 
-							if (RuleB(World, AllowWorldWideSpellsOnPets)) {
+							if (RuleB(Zone, AllowCrossZoneSpellsOnPets)) {
 								if (c.second->HasPet()) {
 									c.second->GetPet()->ApplySpellBuff(s->spell_id);
 								}
@@ -2946,13 +2946,13 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 								}
 							}
 
-							if (RuleB(World, AllowWorldWideSpellsOnMercs)) {
+							if (RuleB(Zone, AllowCrossZoneSpellsOnMercs)) {
 								if (c.second->GetMerc()) {
 									c.second->GetMerc()->BuffFadeBySpellID(s->spell_id);
 								}
 							}
 
-							if (RuleB(World, AllowWorldWideSpellsOnPets)) {
+							if (RuleB(Zone, AllowCrossZoneSpellsOnPets)) {
 								if (c.second->HasPet()) {
 									c.second->GetPet()->BuffFadeBySpellID(s->spell_id);
 								}
@@ -2975,13 +2975,13 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 							}
 						}
 
-						if (RuleB(World, AllowWorldWideSpellsOnMercs)) {
+						if (RuleB(Zone, AllowCrossZoneSpellsOnMercs)) {
 							if (c->GetMerc()) {
 								c->GetMerc()->ApplySpellBuff(s->spell_id);
 							}
 						}
 
-						if (RuleB(World, AllowWorldWideSpellsOnPets)) {
+						if (RuleB(Zone, AllowCrossZoneSpellsOnPets)) {
 							if (c->HasPet()) {
 								c->GetPet()->ApplySpellBuff(s->spell_id);
 							}
@@ -2997,13 +2997,13 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 							}
 						}
 
-						if (RuleB(World, AllowWorldWideSpellsOnMercs)) {
+						if (RuleB(Zone, AllowCrossZoneSpellsOnMercs)) {
 							if (c->GetMerc()) {
 								c->GetMerc()->BuffFadeBySpellID(s->spell_id);
 							}
 						}
 
-						if (RuleB(World, AllowWorldWideSpellsOnPets)) {
+						if (RuleB(Zone, AllowCrossZoneSpellsOnPets)) {
 							if (c->HasPet()) {
 								c->GetPet()->BuffFadeBySpellID(s->spell_id);
 							}
@@ -3375,19 +3375,19 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 				if (s->update_type == WWSpellUpdateType_Cast) {
 					c.second->ApplySpellBuff(s->spell_id);
 
-					if (RuleB(World, AllowWorldWideSpellsOnBots)) {
+					if (RuleB(Zone, AllowCrossZoneSpellsOnBots)) {
 						for (const auto& b : entity_list.GetBotListByCharacterID(c.second->CharacterID())) {
 							b->ApplySpellBuff(s->spell_id);
 						}
 					}
 
-					if (RuleB(World, AllowWorldWideSpellsOnMercs)) {
+					if (RuleB(Zone, AllowCrossZoneSpellsOnMercs)) {
 						if (c.second->GetMerc()) {
 							c.second->GetMerc()->ApplySpellBuff(s->spell_id);
 						}
 					}
 
-					if (RuleB(World, AllowWorldWideSpellsOnPets)) {
+					if (RuleB(Zone, AllowCrossZoneSpellsOnPets)) {
 						if (c.second->HasPet()) {
 							c.second->GetPet()->ApplySpellBuff(s->spell_id);
 						}
@@ -3395,19 +3395,19 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 				} else if (s->update_type == WWSpellUpdateType_Remove) {
 					c.second->BuffFadeBySpellID(s->spell_id);
 
-					if (RuleB(World, AllowWorldWideSpellsOnBots)) {
+					if (RuleB(Zone, AllowCrossZoneSpellsOnBots)) {
 						for (const auto& b : entity_list.GetBotListByCharacterID(c.second->CharacterID())) {
 							b->BuffFadeBySpellID(s->spell_id);
 						}
 					}
 
-					if (RuleB(World, AllowWorldWideSpellsOnMercs)) {
+					if (RuleB(Zone, AllowCrossZoneSpellsOnMercs)) {
 						if (c.second->GetMerc()) {
 							c.second->GetMerc()->BuffFadeBySpellID(s->spell_id);
 						}
 					}
 
-					if (RuleB(World, AllowWorldWideSpellsOnPets)) {
+					if (RuleB(Zone, AllowCrossZoneSpellsOnPets)) {
 						if (c.second->HasPet()) {
 							c.second->GetPet()->BuffFadeBySpellID(s->spell_id);
 						}


### PR DESCRIPTION
# Notes
- These rules allow operators to have cross-zone/world-wide casts/removals of spells affect bots, mercenaries, and/or pets.
- Adds `Zone:AllowCrossZoneSpellsOnBots`.
- Adds `Zone:AllowCrossZoneSpellsOnMercs`.
- Adds `Zone:AllowCrossZoneSpellsOnPets`.