### PR TITLE
[Cleanup] Cleanup cross-zone/world-wide OPCode handling

### DIFF
--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -3059,7 +3059,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 			) {
 				switch (s->update_type) {
 					case WWMoveUpdateType_MoveZone:
-						c.second->MoveZone(s->zone_short_name.c_str());
+						c.second->MoveZone(s->zone_short_name);
 						break;
 					case WWMoveUpdateType_MoveZoneInstance:
 						c.second->MoveZoneInstance(s->instance_id);


### PR DESCRIPTION
# Notes
- Cleans up the logic greatly for cross-zone/world-wide methods since we were doing extraneous status checks and needlessly allocating memory for variables.
- `ServerOP_CZSpell` and `ServerOP_WWSpell` are cleaned up in #4002.