### PR TITLE
[Commands] Cleanup #petitems Command

### DIFF
--- a/zone/gm_commands/petitems.cpp
+++ b/zone/gm_commands/petitems.cpp
@@ -2,24 +2,65 @@
 
 void command_petitems(Client *c, const Seperator *sep)
 {
-	if (!c->GetPet()) {
-		c->Message(Chat::White, "You must have a pet to use this command.");
+	NPC* t = nullptr;
+
+	if (c->GetPet()) {
+		t = c->GetPet()->CastToNPC();
+	}
+
+	if (c->GetTarget() && c->GetTarget()->IsNPC()) {
+		t = c->GetTarget()->CastToNPC();
+	}
+
+	if (!t || !t->IsPet()) {
+		c->Message(Chat::White, "You must have a pet or target a bot's pet to use this command.");
+		return;
+	}	
+
+	Mob* o = t->GetOwner();
+	if (!o) {
+		c->Message(Chat::White, "Invalid owner for pet.");
 		return;
 	}
 
-	auto pet = c->GetPet()->CastToNPC();
-	auto loot_list = pet->GetLootList();
-	if (!loot_list.empty()) {
-		pet->QueryLoot(c, true);
-		c->Message(
-			Chat::White,
-			fmt::format(
-				"Your pet has {} item{}.",
-				loot_list.size(),
-				loot_list.size() != 1 ? "s" : ""
-			).c_str()
-		);
-	} else {
-		c->Message(Chat::White, "Your pet has no items.");
+	if (
+		o->IsBot() &&
+		o->CastToBot()->GetBotOwnerCharacterID() != c->CharacterID()
+	) {
+		c->Message(Chat::White, "You do not own the targeted pet.");
+		return;
 	}
+
+	if (
+		o->IsClient() &&
+		o->GetID() != c->GetID()
+	) {
+		c->Message(Chat::White, "You do not own the targeted pet.");
+		return;
+	}
+
+	const std::string& pet_owner = (
+		o->IsClient() ?
+		"Your" :
+		fmt::format(
+			"Your bot {}{}",
+			o->GetCleanName(),
+			Strings::EndsWith(o->GetCleanName(), "s") ? "'" : "'s"
+		)
+	);
+
+	const auto& l = t->GetLootList();
+	if (!l.empty()) {
+		t->QueryLoot(c, true);
+	}
+
+	c->Message(
+		Chat::White,
+		fmt::format(
+			"{} pet has {} item{}.",
+			pet_owner,
+			l.size(),
+			l.size() != 1 ? "s" : ""
+		).c_str()
+	);
 }


### PR DESCRIPTION
# Notes
- Adds support to `#petitems` to allow you to target bot's pets to view their items, defaults to your pet if you have one.
- If you have no pet or no bot pet targeted it won't function.