### PR TITLE
[Bug Fix] Fixes to zone idle while empty changes.

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -491,41 +491,32 @@ void EntityList::MobProcess()
 				old_client_count > 0 &&
 				zone->GetSecondsBeforeIdle() > 0
 			) {
-				if (!zone->IsIdle()) {
-					LogInfo(
-						"Zone will go into an idle state after [{}] second{}.",
-						zone->GetSecondsBeforeIdle(),
-						zone->GetSecondsBeforeIdle() != 1 ? "s" : ""
-					);
-				}
-
+				LogInfo(
+					"Zone will go into an idle state after [{}] second{}.",
+					zone->GetSecondsBeforeIdle(),
+					zone->GetSecondsBeforeIdle() != 1 ? "s" : ""
+				);
 				mob_settle_timer->Start(zone->GetSecondsBeforeIdle() * 1000);
 			}
 
-			old_client_count = numclients;
-
 			if (numclients == 0 && mob_settle_timer->Check()) {
-				if (!zone->IsIdle()) {
-					LogInfo(
-						"Zone has gone idle after [{}] second{}.",
-						zone->GetSecondsBeforeIdle(),
-						zone->GetSecondsBeforeIdle() != 1 ? "s" : ""
-					);
-
-					zone->SetIsIdle(true);
-				}
+				LogInfo(
+					"Zone has gone idle after [{}] second{}.",
+					zone->GetSecondsBeforeIdle(),
+					zone->GetSecondsBeforeIdle() != 1 ? "s" : ""
+				);
+				mob_settle_timer->Disable();
 			}
 
 			// Disable settle timer if someone zones into empty zone
 			if (numclients > 0 || mob_settle_timer->Check()) {
-				if (zone->IsIdle()) {
-					LogInfo("Zone is no longer idle.");
-
-					zone->SetIsIdle(false);
+				if (mob_settle_timer->Enabled()) {
+					LogInfo("Zone is no longer scheduled to go idle.");
+					mob_settle_timer->Disable();
 				}
-
-				mob_settle_timer->Disable();
 			}
+
+			old_client_count = numclients;
 
 			Spawn2* s2 = mob->CastToNPC()->respawn2;
 

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -3259,13 +3259,3 @@ void Zone::SetSecondsBeforeIdle(uint32 seconds_before_idle)
 {
 	Zone::m_seconds_before_idle = seconds_before_idle;
 }
-
-bool Zone::IsIdle() const
-{
-	return m_is_idle;
-}
-
-void Zone::SetIsIdle(bool m_is_idle)
-{
-	Zone::m_is_idle = m_is_idle;
-}

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -105,8 +105,6 @@ public:
 	AA::Ability *GetAlternateAdvancementAbilityByRank(int rank_id);
 	AA::Rank *GetAlternateAdvancementRank(int rank_id);
 	bool is_zone_time_localized;
-	bool IsIdle() const;
-	void SetIsIdle(bool m_is_idle);
 	bool IsIdleWhenEmpty() const;
 	void SetIdleWhenEmpty(bool idle_when_empty);
 	uint32 GetSecondsBeforeIdle() const;
@@ -443,7 +441,6 @@ private:
 	uint32    m_last_ucss_update;
 	bool      m_idle_when_empty;
 	uint32    m_seconds_before_idle;
-	bool      m_is_idle;
 
 	GlobalLootManager                   m_global_loot;
 	LinkedList<ZoneClientAuth_Struct *> client_auth_list;


### PR DESCRIPTION
This PR resolves an issue where zones would stay active after an idle timer expired.  This was an unintended side effect of PR [3891](https://github.com/EQEmu/Server/pull/3891).

Changes as follows:

- Removed IsIdle() flag as it was only used to keep messages from spamming.  I found problems where this variable was in the wrong state, rather than fixing it, I just removed it and made sure messages didn't spam using available data.
- The mob_settle_timer was not being disabled after is expired.  Since the status of this timer (enabled) is used to decide if we process mobs, it needed to be disabled after it expired.  This led to zones stayign active forever - even  after the timeout.


One note.  Quests that use processmobswhilezoneempty() used to be able to assume that they could turn the zone back off.  If anyone else uses this quest function, those quests will need to check/save the idle status of the zone before mucking with it, then restore it.  This wasn't needed before PT 3891 because zones were always idle when empty.  If people want, I'll do a second PR making the quest override a separate value, so it doesnt mess with the zone one.
