### PR TITLE
[Bug Fix] Limit Pet Taunt Distance

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -269,6 +269,7 @@ RULE_BOOL(Pets, CanTakeNoDrop, false, "Setting whether anyone can give no-drop i
 RULE_BOOL(Pets, CanTakeQuestItems, true, "Setting whether anyone can give quest items to pets")
 RULE_BOOL(Pets, LivelikeBreakCharmOnInvis, true, "Default: true will break charm on any type of invis (hide/ivu/iva/etc) false will only break if the pet can not see you (ex. you have an undead pet and cast IVU")
 RULE_BOOL(Pets, ClientPetsUseOwnerNameInLastName, true, "Disable this to keep client pet's last names from being owner_name's pet")
+RULE_INT(Pets, PetTauntRange, 150, "Range at which a pet will taunt targets.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(GM)

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -1819,7 +1819,8 @@ void NPC::DoClassAttacks(Mob *target) {
 		target->GetBodyType() != BT_Undead &&
 		taunt_time &&
 		type_of_pet &&
-		type_of_pet != petTargetLock
+		type_of_pet != petTargetLock &&
+		DistanceSquared(this->GetPosition(), target->GetPosition()) <= (RuleI(Pets, PetTauntRange)*RuleI(Pets, PetTauntRange))
 	) {
 		GetOwner()->MessageString(Chat::PetResponse, PET_TAUNTING);
 		Taunt(target->CastToNPC(), false);

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -1820,14 +1820,15 @@ void NPC::DoClassAttacks(Mob *target) {
 		taunt_time &&
 		type_of_pet &&
 		type_of_pet != petTargetLock &&
-		DistanceSquared(this->GetPosition(), target->GetPosition()) <= (RuleI(Pets, PetTauntRange)*RuleI(Pets, PetTauntRange))
+		DistanceSquared(GetPosition(), target->GetPosition()) <= (RuleI(Pets, PetTauntRange) * RuleI(Pets, PetTauntRange))
 	) {
 		GetOwner()->MessageString(Chat::PetResponse, PET_TAUNTING);
 		Taunt(target->CastToNPC(), false);
 	}
 
-	if(!ca_time)
+	if(!ca_time) {
 		return;
+	}
 
 	float HasteModifier = GetHaste() * 0.01f;
 


### PR DESCRIPTION
Previously this was not regulated and allowed players to exploit unlimited taunt distance.

Rule Name: PetTauntRange
Rule Default: 150

Calculation is Rule Squared.