### PR TITLE
[Bug Fix] Limit Player Taunt Distance

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -259,6 +259,7 @@ RULE_BOOL(Skills, RequireTomeHandin, false, "Disable click-to-learn and force ha
 RULE_INT(Skills, TradeSkillClamp, 0, "Legacy tradeskills would clamp at 252 regardless of item modifiers and skill combination. DEFAULT: 0 will bypass clamp. Legacy value 252")
 RULE_BOOL(Skills, UseAltSinisterStrikeFormula, false, "Enabling will utilize a formula derived from 2004 monkey business post which makes the AA actually worth something.")
 RULE_BOOL(Skills, TrackingAutoRefreshSkillUps, true, "Disable to prevent tracking auto-refresh from giving skill-ups. Classic Style")
+RULE_INT(Skills, MaximumTauntDistance, 150, "Maximum player taunt distance.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Pets)

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -14905,6 +14905,11 @@ void Client::Handle_OP_Taunt(const EQApplicationPacket *app)
 		return;
 	}
 
+	if (DistanceSquared(this->GetPosition(), GetTarget()->GetPosition()) > (RuleI(Skills, MaximumTauntDistance) * (RuleI(Skills, MaximumTauntDistance)))) {
+		MessageString(Chat::TooFarAway, TAUNT_TOO_FAR);
+		return;
+	}
+
 	Taunt(GetTarget()->CastToNPC(), false);
 	return;
 }

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -14905,7 +14905,7 @@ void Client::Handle_OP_Taunt(const EQApplicationPacket *app)
 		return;
 	}
 
-	if (DistanceSquared(this->GetPosition(), GetTarget()->GetPosition()) > (RuleI(Skills, MaximumTauntDistance) * (RuleI(Skills, MaximumTauntDistance)))) {
+	if (DistanceSquared(GetPosition(), GetTarget()->GetPosition()) > (RuleI(Skills, MaximumTauntDistance) * (RuleI(Skills, MaximumTauntDistance)))) {
 		MessageString(Chat::TooFarAway, TAUNT_TOO_FAR);
 		return;
 	}

--- a/zone/string_ids.h
+++ b/zone/string_ids.h
@@ -125,7 +125,8 @@
 #define FAIL_DISARM_DETECTED_TRAP	370		//You fail to disarm the detected trap.
 #define LOOT_LORE_ERROR				371		//You cannot loot this Lore Item. You already have one.
 #define PICK_LORE					379		//You cannot pick up a lore item you already possess.
-#define POISON_TOO_HIGH				382		// This poison is too high level for you to apply.
+#define POISON_TOO_HIGH				382		//This poison is too high level for you to apply.
+#define TAUNT_TOO_FAR				386		//You are too far away from your target to taunt.
 #define CORPSE_TOO_FAR				389		//The corpse is too far away to summon.
 #define CONSENT_DENIED				390		//You do not have consent to summon that corpse.
 #define DISCIPLINE_RDY				393		//You are ready to use a new discipline now.


### PR DESCRIPTION
Previously this was not regulated on the server side and allowed players to exploit situations where the client did not enforce Z distance checks.

Rule Name: MaximumTauntDistance
Rule Default: 150

Calculation is Rule Squared