### PR TITLE
[Quests] Use separate variable for quest idle override.

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -525,7 +525,7 @@ void EntityList::MobProcess()
 			//	-- the entity's spawn2 point is marked as path_while_zone_idle
 			//	-- the zone is newly empty and we're allowing mobs to settle
 			if (
-				numclients > 0 ||
+				numclients > 0 || quest_idle_override ||
 				(s2 && s2->PathWhenZoneIdle()) ||
 				mob_settle_timer->Enabled()
 			) {

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -525,7 +525,7 @@ void EntityList::MobProcess()
 			//	-- the entity's spawn2 point is marked as path_while_zone_idle
 			//	-- the zone is newly empty and we're allowing mobs to settle
 			if (
-				numclients > 0 || quest_idle_override ||
+				numclients > 0 || zone->quest_idle_override ||
 				(s2 && s2->PathWhenZoneIdle()) ||
 				mob_settle_timer->Enabled()
 			) {

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -934,9 +934,9 @@ void QuestManager::repopzone() {
 	}
 }
 
-void QuestManager::processmobswhilezoneempty(bool turn_on) {
+void QuestManager::processmobswhilezoneempty(bool on) {
 	if (zone) {
-		zone->SetIdleWhenEmpty(!turn_on);
+		zone->quest_idle_override = on;
 	} else {
 		LogQuests(
 			"QuestManager::processmobswhilezoneempty called with nullptr zone. Probably syntax error in quest file"

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -106,7 +106,7 @@ public:
 	void depopall(int npc_type = 0);
 	void depopzone(bool StartSpawnTimer = true);
 	void repopzone();
-	void processmobswhilezoneempty(bool idle_when_empty);
+	void processmobswhilezoneempty(bool quest_override_on);
 	void settarget(const char *type, int target_id);
 	void follow(int entity_id, int distance);
 	void sfollow();

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -974,6 +974,7 @@ Zone::Zone(uint32 in_zoneid, uint32 in_instanceid, const char* in_short_name)
 	default_ruleset = 0;
 
 	is_zone_time_localized = false;
+	quest_idle_override = false;
 
 	loglevelvar = 0;
 	merchantvar = 0;

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -105,6 +105,7 @@ public:
 	AA::Ability *GetAlternateAdvancementAbilityByRank(int rank_id);
 	AA::Rank *GetAlternateAdvancementRank(int rank_id);
 	bool is_zone_time_localized;
+	bool quest_idle_override;
 	bool IsIdleWhenEmpty() const;
 	void SetIdleWhenEmpty(bool idle_when_empty);
 	uint32 GetSecondsBeforeIdle() const;


### PR DESCRIPTION
Using a separate variable to indicate a quest(s) wants to change an idle zone to active temporarily.  Using a separate variable allows quests to not have to worry about a zones setting for IdleWhileEmpty, in regards to restoring the state later.  It also allows future instrumentation to know why a zone is idle or active.