### PR TITLE
[Crash Fix] Fix Possible Crash in HateList::Find

### DIFF
--- a/zone/hate_list.cpp
+++ b/zone/hate_list.cpp
@@ -80,15 +80,18 @@ bool HateList::IsEntOnHateList(Mob *mob)
 	return false;
 }
 
-struct_HateList *HateList::Find(Mob *in_entity)
+struct_HateList* HateList::Find(Mob* m)
 {
-	auto iterator = list.begin();
-	while (iterator != list.end())
-	{
-		if ((*iterator)->entity_on_hatelist == in_entity)
-			return (*iterator);
-		++iterator;
+	if (!m) {
+		return nullptr;
 	}
+
+	for (auto* e : list) {
+		if (e->entity_on_hatelist && e->entity_on_hatelist == m) {
+			return e;
+		}
+	}
+
 	return nullptr;
 }
 

--- a/zone/hate_list.h
+++ b/zone/hate_list.h
@@ -89,7 +89,7 @@ public:
 
 
 protected:
-	struct_HateList *Find(Mob *ent);
+	struct_HateList* Find(Mob* m);
 private:
 	std::list<struct_HateList *> list;
 	Mob                          *hate_owner;


### PR DESCRIPTION
# Notes
- We were not doing any pointer validation, so we were causing crashes in some cases.
- Example: http://spire.akkadius.com/dev/release/22.43.2?id=19163