### PR TITLE
[Bug Fix] spawn_conditions map was being emptied by mistake

### DIFF
--- a/zone/spawn2.cpp
+++ b/zone/spawn2.cpp
@@ -915,8 +915,6 @@ bool SpawnConditionManager::LoadSpawnConditions(const std::string& zone_short_na
 		)
 	);
 
-	spawn_conditions.clear();
-
 	for (const auto& e : condition_values) {
 		auto i = spawn_conditions.find(e.id);
 		if (i != spawn_conditions.end()) {


### PR DESCRIPTION
PR #[4014 ](https://github.com/EQEmu/Server/pull/4014/files) has an issue where the spawn_conditons map was being cleared right after it was filled.

Any attempt to fetch spawn conditions was failing due to an empty map.