### PR TITLE
[Bug Fix] Fix Issue with Bot Dual Wield

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1504,7 +1504,7 @@ bool Mob::Attack(Mob* other, int Hand, bool bRiposte, bool IsStrikethrough, bool
 	}
 
 	if (Hand == EQ::invslot::slotSecondary) {
-		weapon = (IsClient()) ? GetInv().GetItem(EQ::invslot::slotSecondary) : CastToBot()->GetBotItem(EQ::invslot::slotPrimary);
+		weapon = (IsClient()) ? GetInv().GetItem(EQ::invslot::slotSecondary) : CastToBot()->GetBotItem(EQ::invslot::slotSecondary);
 		OffHandAtk(true);
 	}
 	else {


### PR DESCRIPTION
# Notes
- Bots were using primary weapons even for dual wield attacks so they were never attacking with their secondary even when they should be.
- Introduced last year here: https://github.com/EQEmu/Server/pull/2756
