### PR TITLE
[Fixes for PR # 3999

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -8304,7 +8304,7 @@ void Client::RewardFaction(int faction_id, int amount)
 	};
 
 	for (uint16 slot_id = 0; slot_id < faction_ids.size(); slot_id++) {
-		if (faction_ids[slot_id] > 0 && faction_modifiers[slot_id] > 0.0f) {
+		if (faction_ids[slot_id] > 0) {
 			SetFactionLevel2(
 				CharacterID(),
 				faction_ids[slot_id],

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -7387,14 +7387,14 @@ FACTION_VALUE Client::GetFactionLevel(uint32 char_id, uint32 npc_id, uint32 p_ra
 //Sets the characters faction standing with the specified NPC.
 void Client::SetFactionLevel(
 	uint32 character_id,
-	uint32 faction_id,
+	uint32 npc_faction_id,
 	uint8 class_id,
 	uint8 race_id,
 	uint8 deity_id,
 	bool is_quest
 )
 {
-	auto l = zone->GetNPCFactionEntries(faction_id);
+	auto l = zone->GetNPCFactionEntries(npc_faction_id);
 
 	if (l.empty()) {
 		return;

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -8264,17 +8264,17 @@ void Client::RewardFaction(int faction_id, int amount)
 		f->mod_10
 	};
 
-	std::vector<int> temporary_values = {
-		static_cast<int>(faction_modifiers[0] * amount),
-		static_cast<int>(faction_modifiers[1] * amount),
-		static_cast<int>(faction_modifiers[2] * amount),
-		static_cast<int>(faction_modifiers[3] * amount),
-		static_cast<int>(faction_modifiers[4] * amount),
-		static_cast<int>(faction_modifiers[5] * amount),
-		static_cast<int>(faction_modifiers[6] * amount),
-		static_cast<int>(faction_modifiers[7] * amount),
-		static_cast<int>(faction_modifiers[8] * amount),
-		static_cast<int>(faction_modifiers[9] * amount)
+	std::vector<float> temporary_values = {
+		static_cast<float>(faction_modifiers[0] * amount),
+		static_cast<float>(faction_modifiers[1] * amount),
+		static_cast<float>(faction_modifiers[2] * amount),
+		static_cast<float>(faction_modifiers[3] * amount),
+		static_cast<float>(faction_modifiers[4] * amount),
+		static_cast<float>(faction_modifiers[5] * amount),
+		static_cast<float>(faction_modifiers[6] * amount),
+		static_cast<float>(faction_modifiers[7] * amount),
+		static_cast<float>(faction_modifiers[8] * amount),
+		static_cast<float>(faction_modifiers[9] * amount)
 	};
 
 	std::vector<int> signs = {
@@ -8291,16 +8291,16 @@ void Client::RewardFaction(int faction_id, int amount)
 	};
 
 	std::vector<int> new_values = {
-		std::max(1, static_cast<int>(std::abs(temporary_values[0])) * signs[0]),
-		std::max(1, static_cast<int>(std::abs(temporary_values[1])) * signs[1]),
-		std::max(1, static_cast<int>(std::abs(temporary_values[2])) * signs[2]),
-		std::max(1, static_cast<int>(std::abs(temporary_values[3])) * signs[3]),
-		std::max(1, static_cast<int>(std::abs(temporary_values[4])) * signs[4]),
-		std::max(1, static_cast<int>(std::abs(temporary_values[5])) * signs[5]),
-		std::max(1, static_cast<int>(std::abs(temporary_values[6])) * signs[6]),
-		std::max(1, static_cast<int>(std::abs(temporary_values[7])) * signs[7]),
-		std::max(1, static_cast<int>(std::abs(temporary_values[8])) * signs[8]),
-		std::max(1, static_cast<int>(std::abs(temporary_values[9])) * signs[9])
+		std::max(1, static_cast<int>(std::abs(temporary_values[0]))) * signs[0],
+		std::max(1, static_cast<int>(std::abs(temporary_values[1]))) * signs[1],
+		std::max(1, static_cast<int>(std::abs(temporary_values[2]))) * signs[2],
+		std::max(1, static_cast<int>(std::abs(temporary_values[3]))) * signs[3],
+		std::max(1, static_cast<int>(std::abs(temporary_values[4]))) * signs[4],
+		std::max(1, static_cast<int>(std::abs(temporary_values[5]))) * signs[5],
+		std::max(1, static_cast<int>(std::abs(temporary_values[6]))) * signs[6],
+		std::max(1, static_cast<int>(std::abs(temporary_values[7]))) * signs[7],
+		std::max(1, static_cast<int>(std::abs(temporary_values[8]))) * signs[8],
+		std::max(1, static_cast<int>(std::abs(temporary_values[9]))) * signs[9]
 	};
 
 	for (uint16 slot_id = 0; slot_id < faction_ids.size(); slot_id++) {

--- a/zone/client.h
+++ b/zone/client.h
@@ -699,7 +699,7 @@ public:
 	void SendFactionMessage(int32 tmpvalue, int32 faction_id, int32 faction_before_hit, int32 totalvalue, uint8 temp,  int32 this_faction_min, int32 this_faction_max);
 
 	void UpdatePersonalFaction(int32 char_id, int32 npc_value, int32 faction_id, int32 *current_value, int32 temp, int32 this_faction_min, int32 this_faction_max);
-	void SetFactionLevel(uint32 char_id, uint32 npc_id, uint8 char_class, uint8 char_race, uint8 char_deity, bool quest = false);
+	void SetFactionLevel(uint32 char_id, uint32 npc_faction_id, uint8 char_class, uint8 char_race, uint8 char_deity, bool quest = false);
 	void SetFactionLevel2(uint32 char_id, int32 faction_id, uint8 char_class, uint8 char_race, uint8 char_deity, int32 value, uint8 temp);
 	int32 GetRawItemAC();
 

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -390,9 +390,9 @@ int Lua_Client::GetFactionLevel(uint32 char_id, uint32 npc_id, uint32 race, uint
 	return static_cast<int>(self->GetFactionLevel(char_id, npc_id, race, class_, deity, faction, npc));
 }
 
-void Lua_Client::SetFactionLevel(uint32 char_id, uint32 npc_id, int char_class, int char_race, int char_deity) {
+void Lua_Client::SetFactionLevel(uint32 char_id, uint32 npc_faction_id, int char_class, int char_race, int char_deity) {
 	Lua_Safe_Call_Void();
-	self->SetFactionLevel(char_id, npc_id, char_class, char_race, char_deity);
+	self->SetFactionLevel(char_id, npc_faction_id, char_class, char_race, char_deity);
 }
 
 void Lua_Client::SetFactionLevel2(uint32 char_id, int faction_id, int char_class, int char_race, int char_deity, int value, int temp) {

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -145,7 +145,7 @@ public:
 	bool TeleportRaidToPlayerByName(std::string player_name);
 	void ChangeLastName(std::string last_name);
 	int GetFactionLevel(uint32 char_id, uint32 npc_id, uint32 race, uint32 class_, uint32 deity, uint32 faction, Lua_NPC npc);
-	void SetFactionLevel(uint32 char_id, uint32 npc__faction_id, int char_class, int char_race, int char_deity);
+	void SetFactionLevel(uint32 char_id, uint32 npc_faction_id, int char_class, int char_race, int char_deity);
 	void SetFactionLevel2(uint32 char_id, int faction_id, int char_class, int char_race, int char_deity, int value, int temp);
 	void RewardFaction(int id, int amount);
 	int GetRawItemAC();

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -145,7 +145,7 @@ public:
 	bool TeleportRaidToPlayerByName(std::string player_name);
 	void ChangeLastName(std::string last_name);
 	int GetFactionLevel(uint32 char_id, uint32 npc_id, uint32 race, uint32 class_, uint32 deity, uint32 faction, Lua_NPC npc);
-	void SetFactionLevel(uint32 char_id, uint32 npc_id, int char_class, int char_race, int char_deity);
+	void SetFactionLevel(uint32 char_id, uint32 npc__faction_id, int char_class, int char_race, int char_deity);
 	void SetFactionLevel2(uint32 char_id, int faction_id, int char_class, int char_race, int char_deity, int value, int temp);
 	void RewardFaction(int id, int amount);
 	int GetRawItemAC();

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -2775,13 +2775,13 @@ void Mob::ShowStats(Client* c)
 
 		// Faction
 		if (t->GetNPCFactionID()) {
-			const std::string& faction_name = content_db.GetFactionName(t->GetNPCFactionID());
+			const std::string& faction_name = content_db.GetFactionName(t->GetPrimaryFaction());
 			c->Message(
 				Chat::White,
 				fmt::format(
 					"Faction: {} ({})",
 					faction_name,
-					t->GetNPCFactionID()
+					t->GetPrimaryFaction();	
 				).c_str()
 			);
 		}

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -2781,7 +2781,7 @@ void Mob::ShowStats(Client* c)
 				fmt::format(
 					"Faction: {} ({})",
 					faction_name,
-					t->GetPrimaryFaction();	
+					t->GetPrimaryFaction()
 				).c_str()
 			);
 		}

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -344,9 +344,9 @@ int Perl_Client_GetFactionLevel(Client* self, uint32 char_id, uint32 npc_id, uin
 	return self->GetFactionLevel(char_id, npc_id, race_id, class_id, deity_id, faction_id, tnpc);
 }
 
-void Perl_Client_SetFactionLevel(Client* self, uint32 char_id, uint32 npc_id, uint8 char_class, uint8 char_race, uint8 char_deity) // @categories Faction
+void Perl_Client_SetFactionLevel(Client* self, uint32 char_id, uint32 npc_faction_id, uint8 char_class, uint8 char_race, uint8 char_deity) // @categories Faction
 {
-	self->SetFactionLevel(char_id, npc_id, char_class, char_race, char_deity);
+	self->SetFactionLevel(char_id, npc_faction_id, char_class, char_race, char_deity);
 }
 
 void Perl_Client_SetFactionLevel2(Client* self, uint32 char_id, int32 faction_id, uint8 char_class, uint8 char_race, uint8 char_deity, int32 value) // @categories Faction

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -1439,6 +1439,7 @@ void QuestManager::rewardfaction(int faction_id, int faction_value) {
 	QuestManagerCurrentQuestVars();
 	if (initiator) {
 		if (faction_id != 0 && faction_value != 0) {
+			zone->LoadFactionAssociation(faction_id);
 			initiator->RewardFaction(faction_id, faction_value);
 		}
 	}

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -1057,6 +1057,7 @@ void ClientTaskState::RewardTask(Client *c, const TaskInformation *ti, ClientTas
 
 	// just use normal NPC faction ID stuff
 	if (ti->faction_reward && ti->faction_amount == 0) {
+		zone->LoadNPCFaction(ti->faction_reward);
 		c->SetFactionLevel(
 			c->CharacterID(),
 			ti->faction_reward,
@@ -1065,6 +1066,7 @@ void ClientTaskState::RewardTask(Client *c, const TaskInformation *ti, ClientTas
 			c->GetDeity()
 		);
 	} else if (ti->faction_reward != 0 && ti->faction_amount != 0) {
+		// faction_reward is a faction ID
 		c->RewardFaction(
 			ti->faction_reward,
 			ti->faction_amount

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -1067,6 +1067,7 @@ void ClientTaskState::RewardTask(Client *c, const TaskInformation *ti, ClientTas
 		);
 	} else if (ti->faction_reward != 0 && ti->faction_amount != 0) {
 		// faction_reward is a faction ID
+		zone->LoadFactionAssociation(ti->faction_reward);
 		c->RewardFaction(
 			ti->faction_reward,
 			ti->faction_amount

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -1,4 +1,4 @@
-/*		EQEMU: Everquest Server Emulator
+/*	EQEMU: Everquest Server Emulator
 Copyright (C) 2001-2016 EQEMu Development Team (http://eqemu.org)
 
 This program is free software; you can redistribute it and/or modify

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -1,4 +1,4 @@
-eloeloau: Everquest Server Emulator
+/*		EQEMU: Everquest Server Emulator
 Copyright (C) 2001-2016 EQEMu Development Team (http://eqemu.org)
 
 This program is free software; you can redistribute it and/or modify

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -1,4 +1,4 @@
-/*	EQEMU: Everquest Server Emulator
+/*	EQEMu: Everquest Server Emulator
 Copyright (C) 2001-2016 EQEMu Development Team (http://eqemu.org)
 
 This program is free software; you can redistribute it and/or modify

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -1,4 +1,4 @@
-/*	EQEMu: Everquest Server Emulator
+eloeloau: Everquest Server Emulator
 Copyright (C) 2001-2016 EQEMu Development Team (http://eqemu.org)
 
 This program is free software; you can redistribute it and/or modify
@@ -1993,6 +1993,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 	{
 		if (zone && zone->IsLoaded()) {
 			zone->SendReloadMessage("Factions");
+			content_db.LoadFactionData();
 			zone->ReloadNPCFactions();
 			zone->ReloadFactionAssociations();
 		}

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -417,7 +417,7 @@ public:
 	NpcFactionRepository::NpcFaction* GetNPCFaction(const uint32 npc_faction_id);
 	std::vector<NpcFactionEntriesRepository::NpcFactionEntries> GetNPCFactionEntries(const uint32 npc_faction_id) const;
 
-	void LoadFactionAssociation(const uint32 faction_id);
+	void LoadFactionAssociation(const uint32 npc_faction_id);
 	void LoadFactionAssociations(const std::vector<uint32>& npc_faction_ids);
 	void ClearFactionAssociations();
 	void ReloadFactionAssociations();

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -418,7 +418,7 @@ public:
 	std::vector<NpcFactionEntriesRepository::NpcFactionEntries> GetNPCFactionEntries(const uint32 npc_faction_id) const;
 
 	void LoadFactionAssociation(const uint32 faction_id);
-	void LoadFactionAssociations(const std::vector<uint32>& faction_ids);
+	void LoadFactionAssociations(const std::vector<uint32>& npc_faction_ids);
 	void ClearFactionAssociations();
 	void ReloadFactionAssociations();
 	FactionAssociationRepository::FactionAssociation* GetFactionAssociation(const uint32 faction_id);

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -410,8 +410,8 @@ public:
 
 	void ReloadContentFlags();
 
-	void LoadNPCFaction(const uint32 faction_id);
-	void LoadNPCFactions(const std::vector<uint32>& faction_ids);
+	void LoadNPCFaction(const uint32 npc_faction_id);
+	void LoadNPCFactions(const std::vector<uint32>& npc_faction_ids);
 	void ClearNPCFactions();
 	void ReloadNPCFactions();
 	NpcFactionRepository::NpcFaction* GetNPCFaction(const uint32 npc_faction_id);

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -419,6 +419,8 @@ public:
 
 	void LoadNPCFactionAssociation(const uint32 npc_faction_id);
 	void LoadNPCFactionAssociations(const std::vector<uint32>& npc_faction_ids);
+	void LoadFactionAssociation(const uint32 faction_id);
+	void LoadFactionAssociations(const std::vector<uint32>& faction_ids);
 	void ClearFactionAssociations();
 	void ReloadFactionAssociations();
 	FactionAssociationRepository::FactionAssociation* GetFactionAssociation(const uint32 faction_id);

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -414,8 +414,8 @@ public:
 	void LoadNPCFactions(const std::vector<uint32>& faction_ids);
 	void ClearNPCFactions();
 	void ReloadNPCFactions();
-	NpcFactionRepository::NpcFaction* GetNPCFaction(const uint32 faction_id);
-	std::vector<NpcFactionEntriesRepository::NpcFactionEntries> GetNPCFactionEntries(const uint32 faction_id) const;
+	NpcFactionRepository::NpcFaction* GetNPCFaction(const uint32 npc_faction_id);
+	std::vector<NpcFactionEntriesRepository::NpcFactionEntries> GetNPCFactionEntries(const uint32 npc_faction_id) const;
 
 	void LoadFactionAssociation(const uint32 faction_id);
 	void LoadFactionAssociations(const std::vector<uint32>& faction_ids);

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -417,8 +417,8 @@ public:
 	NpcFactionRepository::NpcFaction* GetNPCFaction(const uint32 npc_faction_id);
 	std::vector<NpcFactionEntriesRepository::NpcFactionEntries> GetNPCFactionEntries(const uint32 npc_faction_id) const;
 
-	void LoadFactionAssociation(const uint32 npc_faction_id);
-	void LoadFactionAssociations(const std::vector<uint32>& npc_faction_ids);
+	void LoadNPCFactionAssociation(const uint32 npc_faction_id);
+	void LoadNPCFactionAssociations(const std::vector<uint32>& npc_faction_ids);
 	void ClearFactionAssociations();
 	void ReloadFactionAssociations();
 	FactionAssociationRepository::FactionAssociation* GetFactionAssociation(const uint32 faction_id);

--- a/zone/zone_npc_factions.cpp
+++ b/zone/zone_npc_factions.cpp
@@ -119,10 +119,10 @@ void Zone::ReloadNPCFactions()
 	LoadNPCFactions(faction_ids);
 }
 
-NpcFactionRepository::NpcFaction* Zone::GetNPCFaction(const uint32 faction_id)
+NpcFactionRepository::NpcFaction* Zone::GetNPCFaction(const uint32 npc_faction_id)
 {
 	for (auto& e : m_npc_factions) {
-		if (e.primaryfaction == faction_id) {
+		if (e.id == npc_faction_id) {
 			return &e;
 		}
 	}
@@ -130,7 +130,7 @@ NpcFactionRepository::NpcFaction* Zone::GetNPCFaction(const uint32 faction_id)
 	return nullptr;
 }
 
-std::vector<NpcFactionEntriesRepository::NpcFactionEntries> Zone::GetNPCFactionEntries(const uint32 faction_id) const
+std::vector<NpcFactionEntriesRepository::NpcFactionEntries> Zone::GetNPCFactionEntries(const uint32 npc_faction_id) const
 {
 	std::vector<NpcFactionEntriesRepository::NpcFactionEntries> npc_faction_entries = { };
 
@@ -138,7 +138,7 @@ std::vector<NpcFactionEntriesRepository::NpcFactionEntries> Zone::GetNPCFactionE
 
 	for (auto e : m_npc_faction_entries) {
 		if (
-			e.npc_faction_id == faction_id &&
+			e.npc_faction_id == npc_faction_id &&
 			std::find(
 				faction_ids.begin(),
 				faction_ids.end(),

--- a/zone/zone_npc_factions.cpp
+++ b/zone/zone_npc_factions.cpp
@@ -146,7 +146,7 @@ std::vector<NpcFactionEntriesRepository::NpcFactionEntries> Zone::GetNPCFactionE
 	return npc_faction_entries;
 }
 
-void Zone::LoadFactionAssociations(const std::vector<uint32>& npc_faction_ids)
+void Zone::LoadNPCFactionAssociations(const std::vector<uint32>& npc_faction_ids)
 {
 	LogFaction(
 		"Load Associations for NPC Faction IDs [{}]",
@@ -256,13 +256,13 @@ void Zone::LoadFactionAssociations(const std::vector<uint32>& npc_faction_ids)
 			LogFaction("Loaded [{}] Faction Associations.", num_associations);
 	}
 
-void Zone::LoadFactionAssociation(const uint32 npc_faction_id)
+void Zone::LoadNPCFactionAssociation(const uint32 npc_faction_id)
 	{
 		if (!npc_faction_id) {
 			return;
 		}
 
-		LoadFactionAssociations({ npc_faction_id });
+		LoadNPCFactionAssociations({ npc_faction_id });
 	}
 
 void Zone::ClearFactionAssociations()
@@ -291,7 +291,7 @@ void Zone::ReloadFactionAssociations()
 		}
 
 		LogFaction("Reloading Faction Associations");
-		LoadFactionAssociations(npc_faction_ids);
+		LoadNPCFactionAssociations(npc_faction_ids);
 	}
 
 FactionAssociationRepository::FactionAssociation* Zone::GetFactionAssociation(const uint32 faction_id)

--- a/zone/zone_npc_factions.cpp
+++ b/zone/zone_npc_factions.cpp
@@ -168,7 +168,7 @@ void Zone::LoadNPCFactionAssociations(const std::vector<uint32>& npc_faction_ids
 					if (a.id == f.primaryfaction) {
 						found = true;
 						LogError("Association [{}] already loaded", a.id);
-					break;
+						break;
 					}
 				}
 
@@ -181,9 +181,23 @@ void Zone::LoadNPCFactionAssociations(const std::vector<uint32>& npc_faction_ids
 
 	if (faction_ids.empty()) {
 		LogFactionDetail("No New Faction Associations to load.");
+	}
+	else {
+		LoadFactionAssociations(faction_ids);
+	}
+}
+
+void Zone::LoadNPCFactionAssociation(const uint32 npc_faction_id)
+{
+	if (!npc_faction_id) {
 		return;
 	}
 
+	LoadNPCFactionAssociations({ npc_faction_id });
+}
+
+void Zone::LoadFactionAssociations(const std::vector<uint32>& faction_ids)
+{
 	LogFaction(
 		"These are the primary faction IDs [{}]",
 		Strings::Join(faction_ids, ", ")
@@ -205,102 +219,59 @@ void Zone::LoadNPCFactionAssociations(const std::vector<uint32>& npc_faction_ids
 		return;
 	}
 
-	uint32 num_associations= 0;
-
 	for (const auto& e : faction_associations) {
-			if (e.id_1) {
-				num_associations++;
-				LogFaction("Association [{}] -> [{}]", e.id_1, e.mod_1);
-			}
-			if (e.id_2) {
-				num_associations++;
-				LogFaction("Association [{}] -> [{}]", e.id_2, e.mod_2);
-			}
-			if (e.id_3) {
-				num_associations++;
-				LogFaction("Association [{}] -> [{}]", e.id_3, e.mod_3);
-			}
-			if (e.id_4) {
-				num_associations++;
-				LogFaction("Association [{}] -> [{}]", e.id_4, e.mod_4);
-			}
-			if (e.id_5) {
-				num_associations++;
-				LogFaction("Association [{}] -> [{}]", e.id_5, e.mod_5);
-			}
-			if (e.id_6) {
-				num_associations++;
-				LogFaction("Association [{}] -> [{}]", e.id_6, e.mod_6);
-			}
-			if (e.id_7) {
-				num_associations++;
-				LogFaction("Association [{}] -> [{}]", e.id_7, e.mod_7);
-			}
-			if (e.id_8) {
-				num_associations++;
-				LogFaction("Association [{}] -> [{}]", e.id_8, e.mod_8);
-			}
-			if (e.id_9) {
-				num_associations++;
-				LogFaction("Association [{}] -> [{}]", e.id_9, e.mod_9);
-			}
-			if (e.id_10) {
-				num_associations++;
-				LogFaction("Association [{}] -> [{}]", e.id_10, e.mod_10);
-			}
-
 			m_faction_associations.emplace_back(e);
 		}
 
-	if (num_associations)
-			LogFaction("Loaded [{}] Faction Associations.", num_associations);
+	LogFaction("Loaded [{}] Faction Associations.", faction_associations.size());
+}
+
+void Zone::LoadFactionAssociation(const uint32 faction_id)
+{
+	if (!faction_id) {
+		return;
 	}
 
-void Zone::LoadNPCFactionAssociation(const uint32 npc_faction_id)
-	{
-		if (!npc_faction_id) {
-			return;
-		}
+	LoadFactionAssociations({ faction_id });
+}
 
-		LoadNPCFactionAssociations({ npc_faction_id });
-	}
 
 void Zone::ClearFactionAssociations()
-	{
-		m_faction_associations.clear();
-	}
+{
+	m_faction_associations.clear();
+}
 
 void Zone::ReloadFactionAssociations()
-	{
-		ClearFactionAssociations();
+{
+	ClearFactionAssociations();
 
-		std::vector<uint32> npc_faction_ids = { };
+	std::vector<uint32> npc_faction_ids = { };
 
-		for (const auto& n : entity_list.GetNPCList()) {
-			if (n.second->GetNPCFactionID() != 0) {
-				if (
-					std::find(
-						npc_faction_ids.begin(),
-						npc_faction_ids.end(),
-						n.second->GetNPCFactionID()
-					) == npc_faction_ids.end()
-				) {
-					npc_faction_ids.emplace_back(n.second->GetNPCFactionID());
-				}
+	for (const auto& n : entity_list.GetNPCList()) {
+		if (n.second->GetNPCFactionID() != 0) {
+			if (
+				std::find(
+					npc_faction_ids.begin(),
+					npc_faction_ids.end(),
+					n.second->GetNPCFactionID()
+				) == npc_faction_ids.end()
+			) {
+				npc_faction_ids.emplace_back(n.second->GetNPCFactionID());
 			}
 		}
-
-		LogFaction("Reloading Faction Associations");
-		LoadNPCFactionAssociations(npc_faction_ids);
 	}
 
+	LogFaction("Reloading Faction Associations");
+	LoadNPCFactionAssociations(npc_faction_ids);
+}
+
 FactionAssociationRepository::FactionAssociation* Zone::GetFactionAssociation(const uint32 faction_id)
-	{
-		for (auto& e : m_faction_associations) {
-			if (e.id == faction_id) {
-				return &e;
-			}
+{
+	for (auto& e : m_faction_associations) {
+		if (e.id == faction_id) {
+			return &e;
 		}
+	}
 
 	return nullptr;
 }

--- a/zone/zone_npc_factions.cpp
+++ b/zone/zone_npc_factions.cpp
@@ -21,7 +21,7 @@ void Zone::LoadNPCFactions(const std::vector<uint32> &npc_faction_ids)
 	std::vector<uint32> new_npc_faction_ids = { };
 
 	for (const auto& e : npc_faction_ids) {
-		bool found=0;
+		bool found = false;
 
 		for (const auto& nf : m_npc_factions) {
 			found = (nf.id == e);
@@ -162,11 +162,11 @@ void Zone::LoadNPCFactionAssociations(const std::vector<uint32>& npc_faction_ids
 
 	for (const auto& e : npc_faction_ids) {
 		for (const auto& f : m_npc_factions) {
-			bool found=false;
+			bool found = false;
 			if (e == f.id && f.primaryfaction > 0) {
-				for (auto a : m_faction_associations) {
+				for (const auto& a : m_faction_associations) {
 					if (a.id == f.primaryfaction) {
-						found=true;
+						found = true;
 						LogError("Association [{}] already loaded", a.id);
 					break;
 					}

--- a/zone/zone_npc_factions.cpp
+++ b/zone/zone_npc_factions.cpp
@@ -59,21 +59,10 @@ void Zone::LoadNPCFactions(const std::vector<uint32> &npc_faction_ids)
 	);
 
 	for (const auto& e : npc_factions) {
-		bool has_faction = false;
+		m_npc_factions.emplace_back(e);
 
-		for (const auto& f : m_npc_factions) {
-			if (e.primaryfaction == f.primaryfaction) {
-				has_faction = true;
-				break;
-			}
-		}
-
-		if (!has_faction) {
-			m_npc_factions.emplace_back(e);
-
-			for (const auto& f : npc_faction_entries) {
-				m_npc_faction_entries.emplace_back(f);
-			}
+		for (const auto& f : npc_faction_entries) {
+			m_npc_faction_entries.emplace_back(f);
 		}
 	}
 
@@ -267,7 +256,7 @@ void Zone::LoadFactionAssociations(const std::vector<uint32>& npc_faction_ids)
 			LogFaction("Loaded [{}] Faction Associations.", num_associations);
 	}
 
-	void Zone::LoadFactionAssociation(const uint32 npc_faction_id)
+void Zone::LoadFactionAssociation(const uint32 npc_faction_id)
 	{
 		if (!npc_faction_id) {
 			return;
@@ -276,12 +265,12 @@ void Zone::LoadFactionAssociations(const std::vector<uint32>& npc_faction_ids)
 		LoadFactionAssociations({ npc_faction_id });
 	}
 
-	void Zone::ClearFactionAssociations()
+void Zone::ClearFactionAssociations()
 	{
 		m_faction_associations.clear();
 	}
 
-	void Zone::ReloadFactionAssociations()
+void Zone::ReloadFactionAssociations()
 	{
 		ClearFactionAssociations();
 
@@ -305,7 +294,7 @@ void Zone::LoadFactionAssociations(const std::vector<uint32>& npc_faction_ids)
 		LoadFactionAssociations(npc_faction_ids);
 	}
 
-	FactionAssociationRepository::FactionAssociation* Zone::GetFactionAssociation(const uint32 faction_id)
+FactionAssociationRepository::FactionAssociation* Zone::GetFactionAssociation(const uint32 faction_id)
 	{
 		for (auto& e : m_faction_associations) {
 			if (e.id == faction_id) {

--- a/zone/zone_npc_factions.cpp
+++ b/zone/zone_npc_factions.cpp
@@ -64,14 +64,14 @@ void Zone::LoadNPCFactions(const std::vector<uint32> &npc_faction_ids)
 	}
 }
 
-void Zone::LoadNPCFaction(const uint32 faction_id)
+void Zone::LoadNPCFaction(const uint32 npc_faction_id)
 {
-	if (!faction_id) {
+	if (!npc_faction_id) {
 		return;
 	}
 
-	LogFaction("LoadNPCFaction for [{}]", faction_id);
-	LoadNPCFactions({ faction_id });
+	LogFaction("LoadNPCFaction for [{}]", npc_faction_id);
+	LoadNPCFactions({ npc_faction_id });
 }
 
 void Zone::ClearNPCFactions()
@@ -86,23 +86,23 @@ void Zone::ReloadNPCFactions()
 
 	ClearNPCFactions();
 
-	std::vector<uint32> faction_ids = { };
+	std::vector<uint32> npc_faction_ids = { };
 
 	for (const auto& n : entity_list.GetNPCList()) {
 		if (n.second->GetNPCFactionID() != 0) {
 			if (
 				std::find(
-					faction_ids.begin(),
-					faction_ids.end(),
+					npc_faction_ids.begin(),
+					npc_faction_ids.end(),
 					n.second->GetNPCFactionID()
-				) == faction_ids.end()
+				) == npc_faction_ids.end()
 			) {
-				faction_ids.emplace_back(n.second->GetNPCFactionID());
+				npc_faction_ids.emplace_back(n.second->GetNPCFactionID());
 			}
 		}
 	}
 
-	LoadNPCFactions(faction_ids);
+	LoadNPCFactions(npc_faction_ids);
 }
 
 NpcFactionRepository::NpcFaction* Zone::GetNPCFaction(const uint32 npc_faction_id)

--- a/zone/zone_npc_factions.cpp
+++ b/zone/zone_npc_factions.cpp
@@ -167,7 +167,7 @@ void Zone::LoadNPCFactionAssociations(const std::vector<uint32>& npc_faction_ids
 				for (const auto& a : m_faction_associations) {
 					if (a.id == f.primaryfaction) {
 						found = true;
-						LogError("Association [{}] already loaded", a.id);
+						LogFaction("Association [{}] already loaded", a.id);
 						break;
 					}
 				}

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -1853,7 +1853,6 @@ const NPCType *ZoneDatabase::LoadNPCTypesData(uint32 npc_type_id, bool bulk_load
 					t->npc_faction_id
 				) == npc_faction_ids.end()
 			) {
-				LogFaction("Loading npc_faction ID [{}]", t->npc_faction_id);
 				npc_faction_ids.emplace_back(t->npc_faction_id);
 			}
 		}

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -1982,7 +1982,7 @@ const NPCType *ZoneDatabase::LoadNPCTypesData(uint32 npc_type_id, bool bulk_load
 
 	if (!npc_faction_ids.empty()) {
 		zone->LoadNPCFactions(npc_faction_ids);
-		zone->LoadFactionAssociations(npc_faction_ids);
+		zone->LoadNPCFactionAssociations(npc_faction_ids);
 	}
 
 	return npc;

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -1746,7 +1746,7 @@ const NPCType *ZoneDatabase::LoadNPCTypesData(uint32 npc_type_id, bool bulk_load
 	}
 
 	std::vector<uint32> npc_ids;
-	std::vector<uint32> faction_ids;
+	std::vector<uint32> npc_faction_ids;
 
 	for (NpcTypesRepository::NpcTypes &n : NpcTypesRepository::GetWhere((Database &) content_db, filter)) {
 		NPCType *t;
@@ -1848,12 +1848,13 @@ const NPCType *ZoneDatabase::LoadNPCTypesData(uint32 npc_type_id, bool bulk_load
 		if (t->npc_faction_id > 0) {
 			if (
 				std::find(
-					faction_ids.begin(),
-					faction_ids.end(),
+					npc_faction_ids.begin(),
+					npc_faction_ids.end(),
 					t->npc_faction_id
-				) == faction_ids.end()
+				) == npc_faction_ids.end()
 			) {
-				faction_ids.emplace_back(t->npc_faction_id);
+				LogFaction("Loading npc_faction ID [{}]", t->npc_faction_id);
+				npc_faction_ids.emplace_back(t->npc_faction_id);
 			}
 		}
 
@@ -1979,8 +1980,10 @@ const NPCType *ZoneDatabase::LoadNPCTypesData(uint32 npc_type_id, bool bulk_load
 
 	DataBucket::BulkLoadEntities(DataBucketLoadType::NPC, npc_ids);
 
-	zone->LoadNPCFactions(faction_ids);
-	zone->LoadFactionAssociations(faction_ids);
+	if (bulk_load) {
+		zone->LoadNPCFactions(npc_faction_ids);
+		zone->LoadFactionAssociations(npc_faction_ids);
+	}
 
 	return npc;
 }

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -1980,7 +1980,7 @@ const NPCType *ZoneDatabase::LoadNPCTypesData(uint32 npc_type_id, bool bulk_load
 
 	DataBucket::BulkLoadEntities(DataBucketLoadType::NPC, npc_ids);
 
-	if (bulk_load) {
+	if (!npc_faction_ids.empty()) {
 		zone->LoadNPCFactions(npc_faction_ids);
 		zone->LoadFactionAssociations(npc_faction_ids);
 	}

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -3467,13 +3467,18 @@ bool ZoneDatabase::GetFactionName(int32 faction_id, char* name, uint32 buflen) {
 
 std::string ZoneDatabase::GetFactionName(int32 faction_id)
 {
-	const auto& e = NpcFactionRepository::FindOne(*this, faction_id);
-
-	if (!e.id) {
-		return std::string();
+	std::string faction_name;
+	if (
+		faction_id <= 0 ||
+		 faction_id > static_cast<int>(max_faction) ||
+		 !faction_array[faction_id]
+	) {
+		return faction_name;
 	}
 
-	return e.name;
+	faction_name = faction_array[faction_id]->name;
+
+	return faction_name;
 }
 
 //o--------------------------------------------------------------
@@ -3621,33 +3626,33 @@ bool ZoneDatabase::LoadFactionData()
 }
 
 bool ZoneDatabase::GetFactionIDsForNPC(
-	uint32 faction_id,
+	uint32 npc_faction_id,
 	std::list<NpcFactionEntriesRepository::NpcFactionEntries> *faction_list,
 	int32* primary_faction
 )
 {
-	if (faction_id <= 0) {
+	if (npc_faction_id <= 0) {
 		faction_list->clear();
 
 		if (primary_faction) {
-			*primary_faction = faction_id;
+			*primary_faction = npc_faction_id;
 		}
 
 		return true;
 	}
 
-	const auto& f = zone->GetNPCFaction(faction_id);
-	if (!f) {
+	const auto& npcf = zone->GetNPCFaction(npc_faction_id);
+	if (!npcf) {
 		return false;
 	}
 
-	const auto& l = zone->GetNPCFactionEntries(faction_id);
+	const auto& l = zone->GetNPCFactionEntries(npc_faction_id);
 	if (l.empty()) {
 		return false;
 	}
 
 	if (primary_faction) {
-		*primary_faction = f->primaryfaction;
+		*primary_faction = npcf->primaryfaction;
 	}
 
 	faction_list->clear();

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -3643,13 +3643,11 @@ bool ZoneDatabase::GetFactionIDsForNPC(
 
 	const auto& npcf = zone->GetNPCFaction(npc_faction_id);
 	if (!npcf) {
+		LogError("No NPC faction entry for [{}]", npc_faction_id);
 		return false;
 	}
 
 	const auto& l = zone->GetNPCFactionEntries(npc_faction_id);
-	if (l.empty()) {
-		return false;
-	}
 
 	if (primary_faction) {
 		*primary_faction = npcf->primaryfaction;

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -511,7 +511,7 @@ public:
 	bool		GetFactionData(FactionMods* fd, uint32 class_mod, uint32 race_mod, uint32 deity_mod, int32 faction_id); //needed for factions Dec, 16 2001
 	bool		GetFactionName(int faction_id, char* name, uint32 buflen); // needed for factions Dec, 16 2001
 	std::string GetFactionName(int faction_id);
-	bool		GetFactionIDsForNPC(uint32 faction_id, std::list<NpcFactionEntriesRepository::NpcFactionEntries>* faction_list, int32* primary_faction = 0); // improve faction handling
+	bool		GetFactionIDsForNPC(uint32 npc_faction_id, std::list<NpcFactionEntriesRepository::NpcFactionEntries>* faction_list, int32* primary_faction = 0); // improve faction handling
 	bool		SetCharacterFactionLevel(uint32 char_id, int32 faction_id, int32 value, uint8 temp, faction_map &val_list); // needed for factions Dec, 16 2001
 	bool		LoadFactionData();
 	inline uint32 GetMaxFaction() { return max_faction; }


### PR DESCRIPTION
These are the naming changes I proposed to use correct naming for:

npc_faction_id - an ID that is an umbrella ID indexing into behavior, hits, primary faction, etc.
faction_id - an id that indexes an actual in game faction like Guards of Qeynos

Also restoring ShowStats to show in game faction, not the umbrella name.

Also I believe NpcFactionRepository::NpcFaction* Zone::GetNPCFaction(const uint32 npc_faction_id) was retrieving the incorrect entry based on naming confustion.  We're passing in an npc_faction_id and expecting back the umbrella data.  The comparison to primary_faction_id implies that the npc_faction_id we got in was a faction.

Restored std::string ZoneDatabase::GetFactionName(int32 faction_id) back to returning information about a faction, rather than an npc_faction_id.

Also added code to load the actual in game factions in addition to the umbralla data to the OP_Reload functionality,

I still need help understanding the GetNPCFactionEntries  code.
