### PR TITLE
[Hotfix] [Bots] Fix for potential crash of DS damage on death

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -4485,7 +4485,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 						if (attacker->IsBot()) {
 							Mob* owner = attacker->GetOwner();
 
-							if (owner->CastToClient()->GetFilter(FilterDamageShields) != FilterHide) {
+							if (owner && owner->CastToClient()->GetFilter(FilterDamageShields) != FilterHide) {
 								owner->MessageString(
 									Chat::DamageShield,
 									OTHER_HIT_NONMELEE,


### PR DESCRIPTION
On the unfortunate timing of a bot or owner dying when the bot deals damage due to a DS and the owner pointer is no longer valid.