### PR TITLE
[Quest API] Add GetAAEXPPercentage() and GetEXPPercentage() to Perl/Lua

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -12004,3 +12004,23 @@ void Client::SetEXPModifier(uint32 zone_id, float exp_modifier, int16 instance_v
 
 	database.LoadCharacterEXPModifier(this);
 }
+
+float Client::GetAAEXPPercentage()
+{
+	const float current = GetAAXP();
+	const float max     = GetRequiredAAExperience();
+
+	const float percentage = ((current / max) * 100);
+
+	return std::round(percentage * 100) / 100;
+}
+
+float Client::GetEXPPercentage()
+{
+	const float current = GetEXP() - GetEXPForLevel(GetLevel());
+	const float max     = GetEXPForLevel(GetLevel() + 1) - GetEXPForLevel(GetLevel());
+
+	const float percentage = ((current / max) * 100);
+
+	return std::round(percentage * 100) / 100;
+}

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -12005,22 +12005,26 @@ void Client::SetEXPModifier(uint32 zone_id, float exp_modifier, int16 instance_v
 	database.LoadCharacterEXPModifier(this);
 }
 
-float Client::GetAAEXPPercentage()
+uint8 Client::GetAAEXPPercentage()
 {
 	const float current = GetAAXP();
 	const float max     = GetRequiredAAExperience();
 
-	const float percentage = ((current / max) * 100);
+	const float percentage = ((current / max) * 100.0f);
 
-	return std::round(percentage * 100) / 100;
+	return std::round(percentage);
 }
 
-float Client::GetEXPPercentage()
+uint8 Client::GetEXPPercentage()
 {
 	const float current = GetEXP() - GetEXPForLevel(GetLevel());
 	const float max     = GetEXPForLevel(GetLevel() + 1) - GetEXPForLevel(GetLevel());
 
-	const float percentage = ((current / max) * 100);
+	if (max == 0.0f) {
+		return 0;
+	}
 
-	return std::round(percentage * 100) / 100;
+	const float percentage = ((current / max) * 100.0f);
+
+	return std::round(percentage);
 }

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -12005,26 +12005,24 @@ void Client::SetEXPModifier(uint32 zone_id, float exp_modifier, int16 instance_v
 	database.LoadCharacterEXPModifier(this);
 }
 
-uint8 Client::GetAAEXPPercentage()
+int Client::GetAAEXPPercentage()
 {
-	const float current = GetAAXP();
-	const float max     = GetRequiredAAExperience();
+	int scaled = static_cast<int>(330.0f * static_cast<float>(GetAAXP()) / GetRequiredAAExperience());
 
-	const float percentage = ((current / max) * 100.0f);
-
-	return std::round(percentage);
+	return static_cast<int>(std::round(scaled * 100.0 / 330.0));
 }
 
-uint8 Client::GetEXPPercentage()
+int Client::GetEXPPercentage()
 {
-	const float current = GetEXP() - GetEXPForLevel(GetLevel());
-	const float max     = GetEXPForLevel(GetLevel() + 1) - GetEXPForLevel(GetLevel());
+	float    norm = 0.0f;
+	uint32_t min  = GetEXPForLevel(GetLevel());
+	uint32_t max  = GetEXPForLevel(GetLevel() + 1);
 
-	if (max == 0.0f) {
-		return 0;
+	if (min != max) {
+		norm = static_cast<float>(GetEXP() - min) / (max - min);
 	}
 
-	const float percentage = ((current / max) * 100.0f);
+	int scaled = static_cast<int>(330.0f * norm); // scale and truncate
 
-	return std::round(percentage);
+	return static_cast<int>(std::round(scaled * 100.0 / 330.0)); // unscaled pct
 }

--- a/zone/client.h
+++ b/zone/client.h
@@ -960,6 +960,9 @@ public:
 	void SetTitleSuffix(std::string suffix);
 	void MemorizeSpell(uint32 slot, uint32 spell_id, uint32 scribing, uint32 reduction = 0);
 
+	float GetAAEXPPercentage();
+	float GetEXPPercentage();
+
 	// Item methods
 	void UseAugmentContainer(int container_slot);
 	void EVENT_ITEM_ScriptStopReturn();

--- a/zone/client.h
+++ b/zone/client.h
@@ -960,8 +960,8 @@ public:
 	void SetTitleSuffix(std::string suffix);
 	void MemorizeSpell(uint32 slot, uint32 spell_id, uint32 scribing, uint32 reduction = 0);
 
-	uint8 GetAAEXPPercentage();
-	uint8 GetEXPPercentage();
+	int GetAAEXPPercentage();
+	int GetEXPPercentage();
 
 	// Item methods
 	void UseAugmentContainer(int container_slot);

--- a/zone/client.h
+++ b/zone/client.h
@@ -960,8 +960,8 @@ public:
 	void SetTitleSuffix(std::string suffix);
 	void MemorizeSpell(uint32 slot, uint32 spell_id, uint32 scribing, uint32 reduction = 0);
 
-	float GetAAEXPPercentage();
-	float GetEXPPercentage();
+	uint8 GetAAEXPPercentage();
+	uint8 GetEXPPercentage();
 
 	// Item methods
 	void UseAugmentContainer(int container_slot);

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3278,6 +3278,18 @@ void Lua_Client::ClearXTargets()
 	self->ClearXTargets();
 }
 
+uint8 Lua_Client::GetAAEXPPercentage()
+{
+	Lua_Safe_Call_Int();
+	return self->GetAAEXPPercentage();
+}
+
+uint8 Lua_Client::GetEXPPercentage()
+{
+	Lua_Safe_Call_Int();
+	return self->GetEXPPercentage();
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 	.def(luabind::constructor<>())
@@ -3400,6 +3412,7 @@ luabind::scope lua_register_client() {
 	.def("GetAAEXPModifier", (float(Lua_Client::*)(void))&Lua_Client::GetAAEXPModifier)
 	.def("GetAAEXPModifier", (float(Lua_Client::*)(uint32))&Lua_Client::GetAAEXPModifier)
 	.def("GetAAEXPModifier", (float(Lua_Client::*)(uint32,int16))&Lua_Client::GetAAEXPModifier)
+	.def("GetAAEXPPercentage", (uint8(Lua_Client::*)(void))&Lua_Client::GetAAEXPPercentage)
 	.def("GetAAExp", (uint32(Lua_Client::*)(void))&Lua_Client::GetAAExp)
 	.def("GetAAPercent", (uint32(Lua_Client::*)(void))&Lua_Client::GetAAPercent)
 	.def("GetAAPoints", (int(Lua_Client::*)(void))&Lua_Client::GetAAPoints)
@@ -3459,6 +3472,7 @@ luabind::scope lua_register_client() {
 	.def("GetEXPModifier", (float(Lua_Client::*)(void))&Lua_Client::GetEXPModifier)
 	.def("GetEXPModifier", (float(Lua_Client::*)(uint32))&Lua_Client::GetEXPModifier)
 	.def("GetEXPModifier", (float(Lua_Client::*)(uint32,int16))&Lua_Client::GetEXPModifier)
+	.def("GetEXPPercentage", (uint8(Lua_Client::*)(void))&Lua_Client::GetEXPPercentage)
 	.def("GetEbonCrystals", (uint32(Lua_Client::*)(void))&Lua_Client::GetEbonCrystals)
 	.def("GetEndurance", (int(Lua_Client::*)(void))&Lua_Client::GetEndurance)
 	.def("GetEndurancePercent", (int(Lua_Client::*)(void))&Lua_Client::GetEndurancePercent)

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3278,13 +3278,13 @@ void Lua_Client::ClearXTargets()
 	self->ClearXTargets();
 }
 
-uint8 Lua_Client::GetAAEXPPercentage()
+int Lua_Client::GetAAEXPPercentage()
 {
 	Lua_Safe_Call_Int();
 	return self->GetAAEXPPercentage();
 }
 
-uint8 Lua_Client::GetEXPPercentage()
+int Lua_Client::GetEXPPercentage()
 {
 	Lua_Safe_Call_Int();
 	return self->GetEXPPercentage();
@@ -3412,7 +3412,7 @@ luabind::scope lua_register_client() {
 	.def("GetAAEXPModifier", (float(Lua_Client::*)(void))&Lua_Client::GetAAEXPModifier)
 	.def("GetAAEXPModifier", (float(Lua_Client::*)(uint32))&Lua_Client::GetAAEXPModifier)
 	.def("GetAAEXPModifier", (float(Lua_Client::*)(uint32,int16))&Lua_Client::GetAAEXPModifier)
-	.def("GetAAEXPPercentage", (uint8(Lua_Client::*)(void))&Lua_Client::GetAAEXPPercentage)
+	.def("GetAAEXPPercentage", (int(Lua_Client::*)(void))&Lua_Client::GetAAEXPPercentage)
 	.def("GetAAExp", (uint32(Lua_Client::*)(void))&Lua_Client::GetAAExp)
 	.def("GetAAPercent", (uint32(Lua_Client::*)(void))&Lua_Client::GetAAPercent)
 	.def("GetAAPoints", (int(Lua_Client::*)(void))&Lua_Client::GetAAPoints)
@@ -3472,7 +3472,7 @@ luabind::scope lua_register_client() {
 	.def("GetEXPModifier", (float(Lua_Client::*)(void))&Lua_Client::GetEXPModifier)
 	.def("GetEXPModifier", (float(Lua_Client::*)(uint32))&Lua_Client::GetEXPModifier)
 	.def("GetEXPModifier", (float(Lua_Client::*)(uint32,int16))&Lua_Client::GetEXPModifier)
-	.def("GetEXPPercentage", (uint8(Lua_Client::*)(void))&Lua_Client::GetEXPPercentage)
+	.def("GetEXPPercentage", (int(Lua_Client::*)(void))&Lua_Client::GetEXPPercentage)
 	.def("GetEbonCrystals", (uint32(Lua_Client::*)(void))&Lua_Client::GetEbonCrystals)
 	.def("GetEndurance", (int(Lua_Client::*)(void))&Lua_Client::GetEndurance)
 	.def("GetEndurancePercent", (int(Lua_Client::*)(void))&Lua_Client::GetEndurancePercent)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -493,6 +493,8 @@ public:
 	void SummonItemIntoInventory(luabind::object item_table);
 	bool HasItemOnCorpse(uint32 item_id);
 	void ClearXTargets();
+	uint8 GetAAEXPPercentage();
+	uint8 GetEXPPercentage();
 
 	void ApplySpell(int spell_id);
 	void ApplySpell(int spell_id, int duration);

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -493,8 +493,8 @@ public:
 	void SummonItemIntoInventory(luabind::object item_table);
 	bool HasItemOnCorpse(uint32 item_id);
 	void ClearXTargets();
-	uint8 GetAAEXPPercentage();
-	uint8 GetEXPPercentage();
+	int GetAAEXPPercentage();
+	int GetEXPPercentage();
 
 	void ApplySpell(int spell_id);
 	void ApplySpell(int spell_id, int duration);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -3088,6 +3088,16 @@ void Perl_Client_ClearXTargets(Client* self)
 	self->ClearXTargets();
 }
 
+float Perl_Client_GetAAEXPPercentage(Client* self)
+{
+	return self->GetAAEXPPercentage();
+}
+
+float Perl_Client_GetEXPPercentage(Client* self)
+{
+	return self->GetEXPPercentage();
+}
+
 void perl_register_client()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3204,6 +3214,7 @@ void perl_register_client()
 	package.add("GetAAEXPModifier", (float(*)(Client*))&Perl_Client_GetAAEXPModifier);
 	package.add("GetAAEXPModifier", (float(*)(Client*, uint32))&Perl_Client_GetAAEXPModifier);
 	package.add("GetAAEXPModifier", (float(*)(Client*, uint32, int16))&Perl_Client_GetAAEXPModifier);
+	package.add("GetAAEXPPercentage", &Perl_Client_GetAAEXPPercentage);
 	package.add("GetAAExp", &Perl_Client_GetAAExp);
 	package.add("GetAALevel", &Perl_Client_GetAALevel);
 	package.add("GetAAPercent", &Perl_Client_GetAAPercent);
@@ -3265,6 +3276,7 @@ void perl_register_client()
 	package.add("GetEXPModifier", (float(*)(Client*))&Perl_Client_GetEXPModifier);
 	package.add("GetEXPModifier", (float(*)(Client*, uint32))&Perl_Client_GetEXPModifier);
 	package.add("GetEXPModifier", (float(*)(Client*, uint32, int16))&Perl_Client_GetEXPModifier);
+	package.add("GetEXPPercentage", &Perl_Client_GetEXPPercentage);
 	package.add("GetEbonCrystals", &Perl_Client_GetEbonCrystals);
 	package.add("GetEndurance", &Perl_Client_GetEndurance);
 	package.add("GetEnduranceRatio", &Perl_Client_GetEnduranceRatio);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -3088,12 +3088,12 @@ void Perl_Client_ClearXTargets(Client* self)
 	self->ClearXTargets();
 }
 
-uint8 Perl_Client_GetAAEXPPercentage(Client* self)
+int Perl_Client_GetAAEXPPercentage(Client* self)
 {
 	return self->GetAAEXPPercentage();
 }
 
-uint8 Perl_Client_GetEXPPercentage(Client* self)
+int Perl_Client_GetEXPPercentage(Client* self)
 {
 	return self->GetEXPPercentage();
 }

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -3088,12 +3088,12 @@ void Perl_Client_ClearXTargets(Client* self)
 	self->ClearXTargets();
 }
 
-float Perl_Client_GetAAEXPPercentage(Client* self)
+uint8 Perl_Client_GetAAEXPPercentage(Client* self)
 {
 	return self->GetAAEXPPercentage();
 }
 
-float Perl_Client_GetEXPPercentage(Client* self)
+uint8 Perl_Client_GetEXPPercentage(Client* self)
 {
 	return self->GetEXPPercentage();
 }


### PR DESCRIPTION
# Perl
- Add `$client->GetAAEXPPercentage()`.
- Add `$client->GetEXPPercentage()`.

# Lua
- Add `client:GetAAEXPPercentage()`.
- Add `client:GetEXPPercentage()`.

# Notes
- Allows operators to get current AA or regular experience percentages.
- Math is verified by @hgtw to match what the client does so we're not +/- 1%.