### PR TITLE
[Feature] Add optional `is_forced` parameter to Zone::Repop

### DIFF
--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -1042,6 +1042,11 @@ void Perl__repopzone()
 	quest_manager.repopzone();
 }
 
+void Perl__repopzone(bool is_force)
+{
+	quest_manager.repopzone(is_force);
+}
+
 void Perl__processmobswhilezoneempty(bool on)
 {
 	quest_manager.processmobswhilezoneempty(on);
@@ -6547,7 +6552,8 @@ void perl_register_quest()
 	package.add("removeldonwin", &Perl__removeldonwin);
 	package.add("removetitle", &Perl__removetitle);
 	package.add("rename", &Perl__rename);
-	package.add("repopzone", &Perl__repopzone);
+	package.add("repopzone", (void(*)(void))&Perl__repopzone);
+	package.add("repopzone", (void(*)(bool))&Perl__repopzone);
 	package.add("resettaskactivity", &Perl__resettaskactivity);
 	package.add("respawn", &Perl__respawn);
 	package.add("resume", &Perl__resume);

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -1042,9 +1042,9 @@ void Perl__repopzone()
 	quest_manager.repopzone();
 }
 
-void Perl__repopzone(bool is_force)
+void Perl__repopzone(bool is_forced)
 {
-	quest_manager.repopzone(is_force);
+	quest_manager.repopzone(is_forced);
 }
 
 void Perl__processmobswhilezoneempty(bool on)

--- a/zone/gm_commands/repop.cpp
+++ b/zone/gm_commands/repop.cpp
@@ -2,13 +2,6 @@
 
 void command_repop(Client *c, const Seperator *sep)
 {
-	const uint16 arguments = sep->argnum;
-	if (!arguments) {
-		c->Message(Chat::White, "Zone depopped, repopping now.");
-		zone->Repop();
-		return;
-	}
-
 	const bool is_forced = !strcasecmp(sep->arg[1], "force");
 
 	c->Message(
@@ -19,6 +12,7 @@ void command_repop(Client *c, const Seperator *sep)
 		).c_str()
 	);
 
+	entity_list.ClearAreas();
 	zone->Repop(is_forced);
 }
 

--- a/zone/gm_commands/repop.cpp
+++ b/zone/gm_commands/repop.cpp
@@ -9,16 +9,16 @@ void command_repop(Client *c, const Seperator *sep)
 		return;
 	}
 
-	const bool is_force = !strcasecmp(sep->arg[1], "force");
+	const bool is_forced = !strcasecmp(sep->arg[1], "force");
 
 	c->Message(
 		Chat::White,
 		fmt::format(
 			"Zone depopped, {}repopping now.",
-			is_force ? "forcefully " : ""
+			is_forced ? "forcefully " : ""
 		).c_str()
 	);
 
-	zone->Repop(is_force);
+	zone->Repop(is_forced);
 }
 

--- a/zone/gm_commands/repop.cpp
+++ b/zone/gm_commands/repop.cpp
@@ -2,7 +2,7 @@
 
 void command_repop(Client *c, const Seperator *sep)
 {
-	const bool is_forced = !strcasecmp(sep->arg[1], "force");
+	const bool is_forced = sep->argnum > 0 ? !strcasecmp(sep->arg[1], "force") : false;
 
 	c->Message(
 		Chat::White,

--- a/zone/gm_commands/repop.cpp
+++ b/zone/gm_commands/repop.cpp
@@ -2,23 +2,23 @@
 
 void command_repop(Client *c, const Seperator *sep)
 {
-	int arguments = sep->argnum;
+	const uint16 arguments = sep->argnum;
 	if (!arguments) {
-		entity_list.ClearAreas();
 		c->Message(Chat::White, "Zone depopped, repopping now.");
 		zone->Repop();
 		return;
 	}
 
-	bool is_force = !strcasecmp(sep->arg[1], "force");
+	const bool is_force = !strcasecmp(sep->arg[1], "force");
 
-	if (is_force) {
-		zone->ClearSpawnTimers();
-		c->Message(Chat::White, "Zone depopped, forcefully repopping now.");
-	} else {
-		c->Message(Chat::White, "Zone depopped, repopping now.");
-	}
+	c->Message(
+		Chat::White,
+		fmt::format(
+			"Zone depopped, {}repopping now.",
+			is_force ? "forcefully " : ""
+		).c_str()
+	);
 
-	zone->Repop();
+	zone->Repop(is_force);
 }
 

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -403,8 +403,8 @@ void lua_repop_zone() {
 	quest_manager.repopzone();
 }
 
-void lua_repop_zone(bool is_force) {
-	quest_manager.repopzone(is_force);
+void lua_repop_zone(bool is_forced) {
+	quest_manager.repopzone(is_forced);
 }
 
 void lua_process_mobs_while_zone_empty(bool on) {

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -403,6 +403,10 @@ void lua_repop_zone() {
 	quest_manager.repopzone();
 }
 
+void lua_repop_zone(bool is_force) {
+	quest_manager.repopzone(is_force);
+}
+
 void lua_process_mobs_while_zone_empty(bool on) {
 	quest_manager.processmobswhilezoneempty(on);
 }
@@ -5634,7 +5638,8 @@ luabind::scope lua_register_general() {
 		luabind::def("depop_all", (void(*)(void))&lua_depop_all),
 		luabind::def("depop_all", (void(*)(int))&lua_depop_all),
 		luabind::def("depop_zone", &lua_depop_zone),
-		luabind::def("repop_zone", &lua_repop_zone),
+		luabind::def("repop_zone", (void(*)(void))&lua_repop_zone),
+		luabind::def("repop_zone", (void(*)(bool))&lua_repop_zone),
 		luabind::def("process_mobs_while_zone_empty", &lua_process_mobs_while_zone_empty),
 		luabind::def("is_disc_tome", &lua_is_disc_tome),
 		luabind::def("get_race_name", (std::string(*)(uint16))&lua_get_race_name),

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -926,11 +926,11 @@ void QuestManager::depopzone(bool StartSpawnTimer) {
 	}
 }
 
-void QuestManager::repopzone() {
-	if(zone) {
-		zone->Repop();
-	}
-	else {
+void QuestManager::repopzone(bool is_force)
+{
+	if (zone) {
+		zone->Repop(is_force);
+	} else {
 		LogQuests("QuestManager::repopzone called with nullptr zone. Probably syntax error in quest file");
 	}
 }

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -926,10 +926,10 @@ void QuestManager::depopzone(bool StartSpawnTimer) {
 	}
 }
 
-void QuestManager::repopzone(bool is_force)
+void QuestManager::repopzone(bool is_forced)
 {
 	if (zone) {
-		zone->Repop(is_force);
+		zone->Repop(is_forced);
 	} else {
 		LogQuests("QuestManager::repopzone called with nullptr zone. Probably syntax error in quest file");
 	}

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -105,7 +105,7 @@ public:
 	void depop_withtimer(int npc_type = 0); // depop NPC and start spawn timer
 	void depopall(int npc_type = 0);
 	void depopzone(bool StartSpawnTimer = true);
-	void repopzone(bool is_force = false);
+	void repopzone(bool is_forced = false);
 	void processmobswhilezoneempty(bool quest_override_on);
 	void settarget(const char *type, int target_id);
 	void follow(int entity_id, int distance);

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -105,7 +105,7 @@ public:
 	void depop_withtimer(int npc_type = 0); // depop NPC and start spawn timer
 	void depopall(int npc_type = 0);
 	void depopzone(bool StartSpawnTimer = true);
-	void repopzone();
+	void repopzone(bool is_force = false);
 	void processmobswhilezoneempty(bool quest_override_on);
 	void settarget(const char *type, int target_id);
 	void follow(int entity_id, int distance);

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -1888,7 +1888,7 @@ void Zone::ClearNPCTypeCache(int id) {
 	}
 }
 
-void Zone::Repop(bool is_force)
+void Zone::Repop(bool is_forced)
 {
 	if (!Depop()) {
 		return;
@@ -1901,7 +1901,7 @@ void Zone::Repop(bool is_force)
 		iterator.RemoveCurrent();
 	}
 
-	if (is_force) {
+	if (is_forced) {
 		ClearSpawnTimers();
 	}
 

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -1888,7 +1888,7 @@ void Zone::ClearNPCTypeCache(int id) {
 	}
 }
 
-void Zone::Repop()
+void Zone::Repop(bool is_force)
 {
 	if (!Depop()) {
 		return;
@@ -1899,6 +1899,10 @@ void Zone::Repop()
 	iterator.Reset();
 	while (iterator.MoreElements()) {
 		iterator.RemoveCurrent();
+	}
+
+	if (is_force) {
+		ClearSpawnTimers();
 	}
 
 	npc_scale_manager->LoadScaleData();

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -303,7 +303,7 @@ public:
 	void ReloadWorld(uint8 global_repop);
 	void RemoveAuth(const char *iCharName, const char *iLSKey);
 	void RemoveAuth(uint32 lsid);
-	void Repop(bool is_force = false);
+	void Repop(bool is_forced = false);
 	void RequestUCSServerStatus();
 	void ResetAuth();
 	void SetDate(uint16 year, uint8 month, uint8 day, uint8 hour, uint8 minute);

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -303,7 +303,7 @@ public:
 	void ReloadWorld(uint8 global_repop);
 	void RemoveAuth(const char *iCharName, const char *iLSKey);
 	void RemoveAuth(uint32 lsid);
-	void Repop();
+	void Repop(bool is_force = false);
 	void RequestUCSServerStatus();
 	void ResetAuth();
 	void SetDate(uint16 year, uint8 month, uint8 day, uint8 hour, uint8 minute);


### PR DESCRIPTION
# Perl
- Add `quest::repopzone(is_forced)`.

# Lua
- Add `eq.repop_zone(is_forced)`.

# Commands
- Cleanup `#repop` to use new parameter in `Zone::Repop`.

# Notes
- Allows operators to forcefully repop a zone without using a second method to clear the respawn timers.