### PR TITLE
[Tasks] Send active elements in task select packet

### DIFF
--- a/common/tasks.h
+++ b/common/tasks.h
@@ -216,6 +216,8 @@ struct TaskInformation {
 	uint32_t            request_timer_group;
 	uint32_t            request_timer_seconds;
 	ActivityInformation activity_information[MAXACTIVITIESPERTASK];
+	std::vector<int>    selector_ids; // initial active elements for task select window
+	int                 selector_step = std::numeric_limits<int>::max();
 
 	void SerializeSelector(SerializeBuffer& out, EQ::versions::ClientVersion client_version) const
 	{
@@ -232,12 +234,14 @@ struct TaskInformation {
 			out.WriteUInt8(0); // 0: no rewards 1: enables "Reward Preview" button
 		}
 
-		// selector only needs to send the first objective to fill description starting zone
-		out.WriteUInt32(std::min(activity_count, 1)); // number of task objectives
-		if (activity_count > 0)
+		// live only sends the initial active elements to the select window
+		// element index 0 fills the description starting zone
+		// bracket descriptions are appended if all their elements are sent
+		out.WriteUInt32(static_cast<uint32_t>(selector_ids.size())); // element count
+		for (int id : selector_ids)
 		{
-			out.WriteUInt32(0); // objective index
-			activity_information[0].SerializeSelector(out, client_version);
+			out.WriteInt32(id); // element index
+			activity_information[id].SerializeSelector(out, client_version);
 		}
 	}
 };

--- a/zone/task_manager.cpp
+++ b/zone/task_manager.cpp
@@ -238,6 +238,17 @@ bool TaskManager::LoadTasks(int single_task)
 			}
 		}
 
+		// store initial active element ids for select window
+		if (ad->req_activity_id < 0 && ad->step <= task_data->selector_step)
+		{
+			if (ad->step < task_data->selector_step)
+			{
+				task_data->selector_step = ad->step;
+				task_data->selector_ids.clear();
+			}
+			task_data->selector_ids.push_back(activity_id);
+		}
+
 		LogTasksDetail(
 			"(Activity) task_id [{}] activity_id [{}] slot [{}] activity_type [{}] goal_method [{}] goal_count [{}] zones [{}]"
 			" target_name [{}] item_list [{}] skill_list [{}] spell_list [{}] description_override [{}]",


### PR DESCRIPTION
Only the first element was being serialized to show the start zone of tasks. This was resulting in a blank description for tasks that only have element descriptions.

Live sends all initial active elements for the task when sending this packet. Any bracket text with these elements as a requirement will be appended to the description.