### PR TITLE
[File] Fix File::Exists(file_name) to be resilient to Chinese characters

### DIFF
--- a/common/file.cpp
+++ b/common/file.cpp
@@ -48,7 +48,7 @@ namespace fs = std::filesystem;
 bool File::Exists(const std::string &name)
 {
 	// fs::exists(fs::path{name}) does not work for Chinese characters in windows
-	FILE *f = fopen(fs::path{name}.c_str(), "r");
+	FILE *f = fopen(fs::path{name}.string().c_str(), "r");
 	if (f) {
 		fclose(f);
 		return true;

--- a/common/file.cpp
+++ b/common/file.cpp
@@ -48,6 +48,7 @@ namespace fs = std::filesystem;
  */
 bool File::Exists(const std::string &name)
 {
+	std::cout << "Checking if file exists [" << name << "]" << std::endl;
 	// fs::exists(fs::path{name}) does not work for Chinese characters in windows
 	struct stat sb{};
 	if (stat(fs::path{name}.string().c_str(), &sb) == 0) {

--- a/common/file.cpp
+++ b/common/file.cpp
@@ -42,15 +42,9 @@
 
 namespace fs = std::filesystem;
 
-/**
- * @param name
- * @return
- */
+
 bool File::Exists(const std::string &name)
 {
-	std::cout << "Checking if file exists [" << name << "]" << std::endl;
-//	std::cout << "Checking if file exists 2 [" << fs::path{name}.string() << "]" << std::endl;
-	// fs::exists(fs::path{name}) does not work for Chinese characters in windows
 	struct stat sb{};
 	if (stat(name.c_str(), &sb) == 0) {
 		return true;
@@ -59,9 +53,6 @@ bool File::Exists(const std::string &name)
 	return false;
 }
 
-/**
- * @param directory_name
- */
 void File::Makedir(const std::string &directory_name)
 {
 	try {

--- a/common/file.cpp
+++ b/common/file.cpp
@@ -48,7 +48,7 @@ namespace fs = std::filesystem;
 bool File::Exists(const std::string &name)
 {
 	// fs::exists(fs::path{name}) does not work for Chinese characters in windows
-	FILE *f = fopen(name.c_str(), "r");
+	FILE *f = fopen(fs::path{name}.c_str(), "r");
 	if (f) {
 		fclose(f);
 		return true;

--- a/common/file.cpp
+++ b/common/file.cpp
@@ -52,7 +52,7 @@ bool File::Exists(const std::string &name)
 	std::cout << "Checking if file exists 2 [" << fs::path{name}.string() << "]" << std::endl;
 	// fs::exists(fs::path{name}) does not work for Chinese characters in windows
 	struct stat sb{};
-	if (stat(fs::path{name}.string().c_str(), &sb) == 0) {
+	if (stat(name.c_str(), &sb) == 0) {
 		return true;
 	}
 

--- a/common/file.cpp
+++ b/common/file.cpp
@@ -49,7 +49,7 @@ namespace fs = std::filesystem;
 bool File::Exists(const std::string &name)
 {
 	std::cout << "Checking if file exists [" << name << "]" << std::endl;
-	std::cout << "Checking if file exists 2 [" << fs::path{name}.string() << "]" << std::endl;
+//	std::cout << "Checking if file exists 2 [" << fs::path{name}.string() << "]" << std::endl;
 	// fs::exists(fs::path{name}) does not work for Chinese characters in windows
 	struct stat sb{};
 	if (stat(name.c_str(), &sb) == 0) {

--- a/common/file.cpp
+++ b/common/file.cpp
@@ -38,6 +38,7 @@
 #include <fmt/format.h>
 #include <filesystem>
 #include <iostream>
+#include <sys/stat.h>
 
 namespace fs = std::filesystem;
 
@@ -48,11 +49,12 @@ namespace fs = std::filesystem;
 bool File::Exists(const std::string &name)
 {
 	// fs::exists(fs::path{name}) does not work for Chinese characters in windows
-	FILE *f = fopen(fs::path{name}.string().c_str(), "r");
-	if (f) {
-		fclose(f);
+	struct stat sb{};
+	if (stat(fs::path{name}.string().c_str(), &sb) == 0) {
 		return true;
 	}
+
+	return false;
 }
 
 /**

--- a/common/file.cpp
+++ b/common/file.cpp
@@ -49,6 +49,7 @@ namespace fs = std::filesystem;
 bool File::Exists(const std::string &name)
 {
 	std::cout << "Checking if file exists [" << name << "]" << std::endl;
+	std::cout << "Checking if file exists 2 [" << fs::path{name}.string() << "]" << std::endl;
 	// fs::exists(fs::path{name}) does not work for Chinese characters in windows
 	struct stat sb{};
 	if (stat(fs::path{name}.string().c_str(), &sb) == 0) {

--- a/common/file.cpp
+++ b/common/file.cpp
@@ -47,7 +47,12 @@ namespace fs = std::filesystem;
  */
 bool File::Exists(const std::string &name)
 {
-	return fs::exists(fs::path{name});
+	// fs::exists(fs::path{name}) does not work for Chinese characters in windows
+	FILE *f = fopen(name.c_str(), "r");
+	if (f) {
+		fclose(f);
+		return true;
+	}
 }
 
 /**


### PR DESCRIPTION
**std::filesystem** has a low level issue with Chinese characters. It is crashing zone processes when a quest script has Chinese characters in the file name. This PR replaces our underlying `File::Exists` method for checking file existence that is more friendly to universal character sets.

```
[02-10-2024 23:24:58] [Zone] [Crash] C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.38.33130\include\system_error (731): std::_Throw_system_error_from_std_win_error 
[02-10-2024 23:24:58] [Zone] [Crash] C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.38.33130\include\filesystem (47): std::filesystem::_Convert_narrow_to_wide 
[02-10-2024 23:24:58] [Zone] [Crash] C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.38.33130\include\filesystem (201): std::filesystem::_Convert_stringoid_to_wide<std::filesystem::_Normal_conversion> 
[02-10-2024 23:24:58] [Zone] [Crash] C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.38.33130\include\filesystem (282): std::filesystem::_Convert_Source_to_wide<std::basic_string<char,std::char_traits<char>,std::allocator<char> >,std::filesystem::_Normal_conversion> 
[02-10-2024 23:24:58] [Zone] [Crash] D:\1_GIT-EQEmu\Server\common\file.cpp (53): File::Exists 
[02-10-2024 23:24:58] [Zone] [Crash] D:\1_GIT-EQEmu\Server\zone\quest_parser_collection.cpp (852): QuestParserCollection::GetQIByNPCQuest 
[02-10-2024 23:24:58] [Zone] [Crash] D:\1_GIT-EQEmu\Server\zone\quest_parser_collection.cpp (141): QuestParserCollection::HasQuestSubLocal 
[02-10-2024 23:24:58] [Zone] [Crash] D:\1_GIT-EQEmu\Server\zone\quest_parser_collection.cpp (110): QuestParserCollection::HasQuestSub 
```