### PR TITLE
[Guilds] Clean up `GUILD_RANK_NONE` references

### DIFF
--- a/common/guild_base.cpp
+++ b/common/guild_base.cpp
@@ -881,7 +881,7 @@ static void ProcessGuildMember(MySQLRequestRow row, CharGuildInfo &into)
 	if (into.guild_id == 0) {
 		into.guild_id = GUILD_NONE;
 	}
-	if (into.rank > GUILD_MAX_RANK) {
+	if (into.rank > GUILD_MAX_RANK + 1) {
 		into.rank = GUILD_RANK_NONE;
 	}
 }

--- a/common/guilds.h
+++ b/common/guilds.h
@@ -35,7 +35,7 @@
 #define GUILD_MEMBER_TI	    0
 #define GUILD_OFFICER_TI    1
 #define GUILD_LEADER_TI     2
-#define GUILD_RANK_NONE (GUILD_MAX_RANK+1)
+#define GUILD_RANK_NONE_TI (GUILD_MAX_RANK + 1)
 
 //defines for standard ranks base on RoF2 definitions
 #define GUILD_RANK_NONE      0

--- a/common/patches/titanium.cpp
+++ b/common/patches/titanium.cpp
@@ -692,6 +692,10 @@ namespace Titanium
 				eq->rank = GUILD_LEADER_TI;
 				break;
 			}
+			default: {
+				eq->rank = GUILD_RANK_NONE_TI;
+				break;
+			}
 		}
 
 		memcpy(eq->member_name, emu->member_name, sizeof(eq->member_name));
@@ -1417,6 +1421,7 @@ namespace Titanium
 				break;
 			}
 			default: {
+				eq->guildrank = GUILD_RANK_NONE_TI;
 				break;
 			}
 		}

--- a/common/patches/uf.cpp
+++ b/common/patches/uf.cpp
@@ -1155,6 +1155,7 @@ namespace UF
 						break;
 					}
 					default: {
+						emu_e->rank = GUILD_RANK_NONE_TI;
 						break;
 					}
 				}
@@ -1256,6 +1257,10 @@ namespace UF
 				eq->rank_ = GUILD_LEADER_TI;
 				break;
 			}
+			default: {
+				eq->rank_ = GUILD_RANK_NONE_TI;
+				break;
+			}
 		}
 		OUT(zone_id)
 		OUT(last_on)
@@ -1289,6 +1294,10 @@ namespace UF
 			}
 			case GUILD_LEADER: {
 				eq->rank_ = GUILD_LEADER_TI;
+				break;
+			}
+			default: {
+				eq->rank_ = GUILD_RANK_NONE_TI;
 				break;
 			}
 		}
@@ -1970,6 +1979,7 @@ namespace UF
 				break;
 			}
 			default: {
+				emu->guildrank = GUILD_RANK_NONE_TI;
 				break;
 			}
 		}
@@ -2503,6 +2513,10 @@ namespace UF
 						eq->parameter = GUILD_LEADER_TI;
 						break;
 					}
+					default: {
+						eq->parameter = GUILD_RANK_NONE_TI;
+						break;
+					}
 				}
 				break;
 			}
@@ -2545,6 +2559,7 @@ namespace UF
 				break;
 			}
 			default: {
+				emu->rank = GUILD_RANK_NONE_TI;
 				break;
 			}
 		}
@@ -3163,6 +3178,7 @@ namespace UF
 						break;
 					}
 					default: {
+						emu->guildrank = GUILD_RANK_NONE_TI;
 						break;
 					}
 				}

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -8163,6 +8163,10 @@ void Client::Handle_OP_GuildInvite(const EQApplicationPacket *app)
 				rank = GUILD_LEADER;
 				break;
 			}
+			default: {
+				rank = GUILD_RANK_NONE;
+				break;
+			}
 		}
 	}
 
@@ -8562,6 +8566,10 @@ void Client::Handle_OP_GuildPromote(const EQApplicationPacket *app)
 				}
 				case GUILD_LEADER_TI: {
 					rank = GUILD_LEADER;
+					break;
+				}
+				default: {
+					rank = GUILD_RANK_NONE;
 					break;
 				}
 			}

--- a/zone/guild_mgr.cpp
+++ b/zone/guild_mgr.cpp
@@ -1640,6 +1640,7 @@ uint8* ZoneGuildManager::MakeGuildMembers(uint32 guild_id, const char* prefix_na
 					break;
 				}
 				default: {
+					ci->rank = GUILD_RANK_NONE_TI;
 					break;
 				}
 			}


### PR DESCRIPTION
Should be exhaustive for guild rank values
Cleans up redefinition of `GUILD_RANK_NONE` by including `GUILD_RANK_NONE_TI`
Fixes #4057