### PR TITLE
[Database] Fix default value for `time_of_death` in `character_corpses`

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -5346,6 +5346,16 @@ CREATE TABLE guild_tributes (
 ) ENGINE=InnoDB;
 )"
 	},
+	ManifestEntry{
+		.version = 9261,
+		.description = "2024_02_11_character_corpses.sql",
+		.check = "SHOW COLUMNS FROM `character_corpses` LIKE 'time_of_death'",
+		.condition = "contains",
+		.match = "0000-00-00 00:00:00",
+		.sql = R"(
+ALTER TABLE `character_corpses` MODIFY COLUMN `time_of_death` datetime NOT NULL NULL DEFAULT CURRENT_TIMESTAMP;
+		)"
+	}
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{
 //		.version = 9228,

--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -5353,7 +5353,7 @@ CREATE TABLE guild_tributes (
 		.condition = "contains",
 		.match = "0000-00-00 00:00:00",
 		.sql = R"(
-ALTER TABLE `character_corpses` MODIFY COLUMN `time_of_death` datetime NOT NULL NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE `character_corpses` MODIFY COLUMN `time_of_death` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP;
 		)"
 	}
 // -- template; copy/paste this when you need to create a new entry

--- a/common/repositories/base/base_character_corpses_repository.h
+++ b/common/repositories/base/base_character_corpses_repository.h
@@ -66,6 +66,10 @@ public:
 		uint32_t    wc_7;
 		uint32_t    wc_8;
 		uint32_t    wc_9;
+		uint32_t    rez_time;
+		uint32_t    gm_exp;
+		uint32_t    killed_by;
+		uint8_t     rezzable;
 	};
 
 	static std::string PrimaryKey()
@@ -123,6 +127,10 @@ public:
 			"wc_7",
 			"wc_8",
 			"wc_9",
+			"rez_time",
+			"gm_exp",
+			"killed_by",
+			"rezzable",
 		};
 	}
 
@@ -176,6 +184,10 @@ public:
 			"wc_7",
 			"wc_8",
 			"wc_9",
+			"rez_time",
+			"gm_exp",
+			"killed_by",
+			"rezzable",
 		};
 	}
 
@@ -263,6 +275,10 @@ public:
 		e.wc_7             = 0;
 		e.wc_8             = 0;
 		e.wc_9             = 0;
+		e.rez_time         = 0;
+		e.gm_exp           = 0;
+		e.killed_by        = 0;
+		e.rezzable         = 0;
 
 		return e;
 	}
@@ -346,6 +362,10 @@ public:
 			e.wc_7             = row[44] ? static_cast<uint32_t>(strtoul(row[44], nullptr, 10)) : 0;
 			e.wc_8             = row[45] ? static_cast<uint32_t>(strtoul(row[45], nullptr, 10)) : 0;
 			e.wc_9             = row[46] ? static_cast<uint32_t>(strtoul(row[46], nullptr, 10)) : 0;
+			e.rez_time         = row[47] ? static_cast<uint32_t>(strtoul(row[47], nullptr, 10)) : 0;
+			e.gm_exp           = row[48] ? static_cast<uint32_t>(strtoul(row[48], nullptr, 10)) : 0;
+			e.killed_by        = row[49] ? static_cast<uint32_t>(strtoul(row[49], nullptr, 10)) : 0;
+			e.rezzable         = row[50] ? static_cast<uint8_t>(strtoul(row[50], nullptr, 10)) : 0;
 
 			return e;
 		}
@@ -425,6 +445,10 @@ public:
 		v.push_back(columns[44] + " = " + std::to_string(e.wc_7));
 		v.push_back(columns[45] + " = " + std::to_string(e.wc_8));
 		v.push_back(columns[46] + " = " + std::to_string(e.wc_9));
+		v.push_back(columns[47] + " = " + std::to_string(e.rez_time));
+		v.push_back(columns[48] + " = " + std::to_string(e.gm_exp));
+		v.push_back(columns[49] + " = " + std::to_string(e.killed_by));
+		v.push_back(columns[50] + " = " + std::to_string(e.rezzable));
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -493,6 +517,10 @@ public:
 		v.push_back(std::to_string(e.wc_7));
 		v.push_back(std::to_string(e.wc_8));
 		v.push_back(std::to_string(e.wc_9));
+		v.push_back(std::to_string(e.rez_time));
+		v.push_back(std::to_string(e.gm_exp));
+		v.push_back(std::to_string(e.killed_by));
+		v.push_back(std::to_string(e.rezzable));
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -569,6 +597,10 @@ public:
 			v.push_back(std::to_string(e.wc_7));
 			v.push_back(std::to_string(e.wc_8));
 			v.push_back(std::to_string(e.wc_9));
+			v.push_back(std::to_string(e.rez_time));
+			v.push_back(std::to_string(e.gm_exp));
+			v.push_back(std::to_string(e.killed_by));
+			v.push_back(std::to_string(e.rezzable));
 
 			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
 		}
@@ -649,6 +681,10 @@ public:
 			e.wc_7             = row[44] ? static_cast<uint32_t>(strtoul(row[44], nullptr, 10)) : 0;
 			e.wc_8             = row[45] ? static_cast<uint32_t>(strtoul(row[45], nullptr, 10)) : 0;
 			e.wc_9             = row[46] ? static_cast<uint32_t>(strtoul(row[46], nullptr, 10)) : 0;
+			e.rez_time         = row[47] ? static_cast<uint32_t>(strtoul(row[47], nullptr, 10)) : 0;
+			e.gm_exp           = row[48] ? static_cast<uint32_t>(strtoul(row[48], nullptr, 10)) : 0;
+			e.killed_by        = row[49] ? static_cast<uint32_t>(strtoul(row[49], nullptr, 10)) : 0;
+			e.rezzable         = row[50] ? static_cast<uint8_t>(strtoul(row[50], nullptr, 10)) : 0;
 
 			all_entries.push_back(e);
 		}
@@ -720,6 +756,10 @@ public:
 			e.wc_7             = row[44] ? static_cast<uint32_t>(strtoul(row[44], nullptr, 10)) : 0;
 			e.wc_8             = row[45] ? static_cast<uint32_t>(strtoul(row[45], nullptr, 10)) : 0;
 			e.wc_9             = row[46] ? static_cast<uint32_t>(strtoul(row[46], nullptr, 10)) : 0;
+			e.rez_time         = row[47] ? static_cast<uint32_t>(strtoul(row[47], nullptr, 10)) : 0;
+			e.gm_exp           = row[48] ? static_cast<uint32_t>(strtoul(row[48], nullptr, 10)) : 0;
+			e.killed_by        = row[49] ? static_cast<uint32_t>(strtoul(row[49], nullptr, 10)) : 0;
+			e.rezzable         = row[50] ? static_cast<uint8_t>(strtoul(row[50], nullptr, 10)) : 0;
 
 			all_entries.push_back(e);
 		}
@@ -841,6 +881,10 @@ public:
 		v.push_back(std::to_string(e.wc_7));
 		v.push_back(std::to_string(e.wc_8));
 		v.push_back(std::to_string(e.wc_9));
+		v.push_back(std::to_string(e.rez_time));
+		v.push_back(std::to_string(e.gm_exp));
+		v.push_back(std::to_string(e.killed_by));
+		v.push_back(std::to_string(e.rezzable));
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -910,6 +954,10 @@ public:
 			v.push_back(std::to_string(e.wc_7));
 			v.push_back(std::to_string(e.wc_8));
 			v.push_back(std::to_string(e.wc_9));
+			v.push_back(std::to_string(e.rez_time));
+			v.push_back(std::to_string(e.gm_exp));
+			v.push_back(std::to_string(e.killed_by));
+			v.push_back(std::to_string(e.rezzable));
 
 			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
 		}

--- a/common/repositories/base/base_character_corpses_repository.h
+++ b/common/repositories/base/base_character_corpses_repository.h
@@ -66,10 +66,6 @@ public:
 		uint32_t    wc_7;
 		uint32_t    wc_8;
 		uint32_t    wc_9;
-		uint32_t    rez_time;
-		uint32_t    gm_exp;
-		uint32_t    killed_by;
-		uint8_t     rezzable;
 	};
 
 	static std::string PrimaryKey()
@@ -127,10 +123,6 @@ public:
 			"wc_7",
 			"wc_8",
 			"wc_9",
-			"rez_time",
-			"gm_exp",
-			"killed_by",
-			"rezzable",
 		};
 	}
 
@@ -184,10 +176,6 @@ public:
 			"wc_7",
 			"wc_8",
 			"wc_9",
-			"rez_time",
-			"gm_exp",
-			"killed_by",
-			"rezzable",
 		};
 	}
 
@@ -237,7 +225,7 @@ public:
 		e.y                = 0;
 		e.z                = 0;
 		e.heading          = 0;
-		e.time_of_death    = 0;
+		e.time_of_death    = std::time(nullptr);
 		e.guild_consent_id = 0;
 		e.is_rezzed        = 0;
 		e.is_buried        = 0;
@@ -275,10 +263,6 @@ public:
 		e.wc_7             = 0;
 		e.wc_8             = 0;
 		e.wc_9             = 0;
-		e.rez_time         = 0;
-		e.gm_exp           = 0;
-		e.killed_by        = 0;
-		e.rezzable         = 0;
 
 		return e;
 	}
@@ -362,10 +346,6 @@ public:
 			e.wc_7             = row[44] ? static_cast<uint32_t>(strtoul(row[44], nullptr, 10)) : 0;
 			e.wc_8             = row[45] ? static_cast<uint32_t>(strtoul(row[45], nullptr, 10)) : 0;
 			e.wc_9             = row[46] ? static_cast<uint32_t>(strtoul(row[46], nullptr, 10)) : 0;
-			e.rez_time         = row[47] ? static_cast<uint32_t>(strtoul(row[47], nullptr, 10)) : 0;
-			e.gm_exp           = row[48] ? static_cast<uint32_t>(strtoul(row[48], nullptr, 10)) : 0;
-			e.killed_by        = row[49] ? static_cast<uint32_t>(strtoul(row[49], nullptr, 10)) : 0;
-			e.rezzable         = row[50] ? static_cast<uint8_t>(strtoul(row[50], nullptr, 10)) : 0;
 
 			return e;
 		}
@@ -445,10 +425,6 @@ public:
 		v.push_back(columns[44] + " = " + std::to_string(e.wc_7));
 		v.push_back(columns[45] + " = " + std::to_string(e.wc_8));
 		v.push_back(columns[46] + " = " + std::to_string(e.wc_9));
-		v.push_back(columns[47] + " = " + std::to_string(e.rez_time));
-		v.push_back(columns[48] + " = " + std::to_string(e.gm_exp));
-		v.push_back(columns[49] + " = " + std::to_string(e.killed_by));
-		v.push_back(columns[50] + " = " + std::to_string(e.rezzable));
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -517,10 +493,6 @@ public:
 		v.push_back(std::to_string(e.wc_7));
 		v.push_back(std::to_string(e.wc_8));
 		v.push_back(std::to_string(e.wc_9));
-		v.push_back(std::to_string(e.rez_time));
-		v.push_back(std::to_string(e.gm_exp));
-		v.push_back(std::to_string(e.killed_by));
-		v.push_back(std::to_string(e.rezzable));
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -597,10 +569,6 @@ public:
 			v.push_back(std::to_string(e.wc_7));
 			v.push_back(std::to_string(e.wc_8));
 			v.push_back(std::to_string(e.wc_9));
-			v.push_back(std::to_string(e.rez_time));
-			v.push_back(std::to_string(e.gm_exp));
-			v.push_back(std::to_string(e.killed_by));
-			v.push_back(std::to_string(e.rezzable));
 
 			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
 		}
@@ -681,10 +649,6 @@ public:
 			e.wc_7             = row[44] ? static_cast<uint32_t>(strtoul(row[44], nullptr, 10)) : 0;
 			e.wc_8             = row[45] ? static_cast<uint32_t>(strtoul(row[45], nullptr, 10)) : 0;
 			e.wc_9             = row[46] ? static_cast<uint32_t>(strtoul(row[46], nullptr, 10)) : 0;
-			e.rez_time         = row[47] ? static_cast<uint32_t>(strtoul(row[47], nullptr, 10)) : 0;
-			e.gm_exp           = row[48] ? static_cast<uint32_t>(strtoul(row[48], nullptr, 10)) : 0;
-			e.killed_by        = row[49] ? static_cast<uint32_t>(strtoul(row[49], nullptr, 10)) : 0;
-			e.rezzable         = row[50] ? static_cast<uint8_t>(strtoul(row[50], nullptr, 10)) : 0;
 
 			all_entries.push_back(e);
 		}
@@ -756,10 +720,6 @@ public:
 			e.wc_7             = row[44] ? static_cast<uint32_t>(strtoul(row[44], nullptr, 10)) : 0;
 			e.wc_8             = row[45] ? static_cast<uint32_t>(strtoul(row[45], nullptr, 10)) : 0;
 			e.wc_9             = row[46] ? static_cast<uint32_t>(strtoul(row[46], nullptr, 10)) : 0;
-			e.rez_time         = row[47] ? static_cast<uint32_t>(strtoul(row[47], nullptr, 10)) : 0;
-			e.gm_exp           = row[48] ? static_cast<uint32_t>(strtoul(row[48], nullptr, 10)) : 0;
-			e.killed_by        = row[49] ? static_cast<uint32_t>(strtoul(row[49], nullptr, 10)) : 0;
-			e.rezzable         = row[50] ? static_cast<uint8_t>(strtoul(row[50], nullptr, 10)) : 0;
 
 			all_entries.push_back(e);
 		}
@@ -881,10 +841,6 @@ public:
 		v.push_back(std::to_string(e.wc_7));
 		v.push_back(std::to_string(e.wc_8));
 		v.push_back(std::to_string(e.wc_9));
-		v.push_back(std::to_string(e.rez_time));
-		v.push_back(std::to_string(e.gm_exp));
-		v.push_back(std::to_string(e.killed_by));
-		v.push_back(std::to_string(e.rezzable));
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -954,10 +910,6 @@ public:
 			v.push_back(std::to_string(e.wc_7));
 			v.push_back(std::to_string(e.wc_8));
 			v.push_back(std::to_string(e.wc_9));
-			v.push_back(std::to_string(e.rez_time));
-			v.push_back(std::to_string(e.gm_exp));
-			v.push_back(std::to_string(e.killed_by));
-			v.push_back(std::to_string(e.rezzable));
 
 			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
 		}

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9260
+#define CURRENT_BINARY_DATABASE_VERSION 9261
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9042
 
 #endif


### PR DESCRIPTION
As before with other cases, default `datetime` can no longer be 0s. Made it default to `CURRENT_TIMESTAMP` as it was originally defined as `NOT NULL`