### PR TITLE
[Database] Proper default for `droptime` from `object_contents`

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -5355,6 +5355,16 @@ CREATE TABLE guild_tributes (
 		.sql = R"(
 ALTER TABLE `character_corpses` MODIFY COLUMN `time_of_death` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP;
 		)"
+	},
+	ManifestEntry{
+		.version = 9262,
+		.description = "2024_02_11_object_contents.sql",
+		.check = "SHOW COLUMNS FROM `object_contents` LIKE 'droptime'",
+		.condition = "contains",
+		.match = "0000-00-00 00:00:00",
+		.sql = R"(
+ALTER TABLE `character_corpses` MODIFY COLUMN `droptime` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP;
+		)"
 	}
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{

--- a/common/repositories/base/base_object_contents_repository.h
+++ b/common/repositories/base/base_object_contents_repository.h
@@ -116,7 +116,7 @@ public:
 		e.bagidx   = 0;
 		e.itemid   = 0;
 		e.charges  = 0;
-		e.droptime = 0;
+		e.droptime = std::time(nullptr);
 		e.augslot1 = 0;
 		e.augslot2 = 0;
 		e.augslot3 = 0;

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9261
+#define CURRENT_BINARY_DATABASE_VERSION 9262
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9042
 
 #endif


### PR DESCRIPTION
Looks like this is the last default datetime entry outside of `trader_audit`