### PR TITLE
[Cleanup] Use explicit conversions for enum formatting

### DIFF
--- a/common/bodytypes.h
+++ b/common/bodytypes.h
@@ -64,4 +64,6 @@ typedef enum {
 } bodyType;
 /* bodytypes above 64 make the mob not show up */
 
+constexpr int format_as(bodyType type) { return static_cast<int>(type); }
+
 #endif

--- a/common/deity.h
+++ b/common/deity.h
@@ -71,6 +71,8 @@ namespace EQ
 			bit_DeityAll           = UINT32_MAX
 		};
 
+		constexpr int format_as(DeityType type) { return static_cast<int>(type); }
+
 		extern DeityTypeBit GetDeityBitmask(DeityType deity_type);
 		extern std::string GetDeityName(DeityType deity_type);
 		extern const std::map<DeityType, std::string>& GetDeityMap();

--- a/common/emu_opcodes.h
+++ b/common/emu_opcodes.h
@@ -45,6 +45,7 @@ typedef enum { //EQEmu internal opcodes list
 	_maxEmuOpcode
 } EmuOpcode;
 
+constexpr int format_as(EmuOpcode opcode) { return static_cast<int>(opcode); }
 extern const char *OpcodeNames[_maxEmuOpcode+1];
 
 #endif

--- a/common/guilds.h
+++ b/common/guilds.h
@@ -81,5 +81,6 @@ typedef enum {
 	GUILD_ACTION_MEMBERS_DEMOTE_SELF                  = 30,
 } GuildAction;
 
+constexpr int format_as(GuildAction action) { return static_cast<int>(action); }
 
 #endif

--- a/common/patches/rof2_limits.h
+++ b/common/patches/rof2_limits.h
@@ -158,6 +158,7 @@ namespace RoF2
 				slotCursor
 			};
 
+			constexpr int16 format_as(InventorySlots slot) { return static_cast<int16>(slot); }
 		} // namespace enum_
 		using namespace enum_;
 

--- a/common/skills.h
+++ b/common/skills.h
@@ -162,6 +162,8 @@ namespace EQ
 	// server profile does not reflect this yet..so, prefixed with 'PACKET_'
 #define PACKET_SKILL_ARRAY_SIZE 100
 
+		constexpr int format_as(SkillType skill) { return static_cast<int>(skill); }
+
 		bool IsTradeskill(SkillType skill);
 		bool IsSpecializedSkill(SkillType skill);
 		float GetSkillMeleePushForce(SkillType skill);

--- a/common/tasks.h
+++ b/common/tasks.h
@@ -252,6 +252,8 @@ typedef enum {
 	ActivityCompleted = 2
 }                  ActivityState;
 
+constexpr int format_as(ActivityState state) { return static_cast<int>(state); }
+
 struct ClientActivityInformation {
 	int           activity_id;
 	int           done_count;

--- a/common/textures.h
+++ b/common/textures.h
@@ -54,6 +54,8 @@ namespace EQ
 			tintInvalid = textureInvalid
 		};
 
+		constexpr int format_as(TextureSlot slot) { return static_cast<int>(slot); }
+
 		const int8 LastTexture = weaponSecondary;
 		const int8 LastTintableTexture = tintFeet;
 

--- a/world/cliententry.cpp
+++ b/world/cliententry.cpp
@@ -139,7 +139,7 @@ void ClientListEntry::SetOnline(CLE_Status iOnline)
 		AccountName(),
 		AccountID(),
 		CLEStatusString[CLE_Status::Online],
-		iOnline
+		static_cast<int>(iOnline)
 	);
 
 	if (iOnline >= CLE_Status::Online && pOnline < CLE_Status::Online) {

--- a/world/clientlist.cpp
+++ b/world/clientlist.cpp
@@ -280,7 +280,7 @@ void ClientList::SendCLEList(const int16& admin, const char* to, WorldTCPConnect
 				fmt::format_to(std::back_inserter(out), fmt::runtime(newline));
 			}
 			fmt::format_to(std::back_inserter(out), "ID: {}  Acc# {}  AccName: {}  IP: {}", cle->GetID(), cle->AccountID(), cle->AccountName(), inet_ntoa(in));
-			fmt::format_to(std::back_inserter(out), "{}  Stale: {}  Online: {}  Admin: {}", newline, cle->GetStaleCounter(), cle->Online(), cle->Admin());
+			fmt::format_to(std::back_inserter(out), "{}  Stale: {}  Online: {}  Admin: {}", newline, cle->GetStaleCounter(), static_cast<int>(cle->Online()), cle->Admin());
 			if (cle->LSID())
 				fmt::format_to(std::back_inserter(out), "{}  LSID: {}  LSName: {}  WorldAdmin: {}", newline, cle->LSID(), cle->LSName(), cle->WorldAdmin());
 			if (cle->CharID())

--- a/zone/aggro.cpp
+++ b/zone/aggro.cpp
@@ -343,7 +343,7 @@ void NPC::DescribeAggro(Client *to_who, Mob *mob, bool verbose) {
 				"{} does not have low enough faction, their Faction Level is {} ({}).",
 				to_who->GetTargetDescription(mob),
 				FactionValueToString(faction_value),
-				faction_value
+				static_cast<int>(faction_value)
 			).c_str()
 		);
 		return;
@@ -556,7 +556,7 @@ bool Mob::CheckWillAggro(Mob *mob) {
 	LogAggro("Is In zone?:[{}]\n", mob->InZone());
 	LogAggro("Dist^2: [{}]\n", distance_squared);
 	LogAggro("Range^2: [{}]\n", aggro_range_squared);
-	LogAggro("Faction: [{}]\n", faction_value);
+	LogAggro("Faction: [{}]\n", static_cast<int>(faction_value));
 	LogAggro("AlwaysAggroFlag: [{}]\n", AlwaysAggro());
 	LogAggro("Int: [{}]\n", GetINT());
 	LogAggro("Con: [{}]\n", GetLevelCon(mob->GetLevel()));

--- a/zone/bot_commands/bot.cpp
+++ b/zone/bot_commands/bot.cpp
@@ -1107,7 +1107,7 @@ void bot_command_stance(Client *c, const Seperator *sep)
 			fmt::format(
 				"My current stance is {} ({}).",
 				EQ::constants::GetStanceName(bot_iter->GetBotStance()),
-				bot_iter->GetBotStance()
+				static_cast<int>(bot_iter->GetBotStance())
 			).c_str()
 		);
 	}

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -6955,7 +6955,7 @@ void Client::ShowXTargets(Client *c)
 			fmt::format(
 				"xtarget slot [{}] type [{}] ID [{}] name [{}]",
 				i,
-				XTargets[i].Type,
+				static_cast<int>(XTargets[i].Type),
 				XTargets[i].ID,
 				strlen(XTargets[i].Name) ? XTargets[i].Name : "No Name"
 			).c_str()

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -516,7 +516,7 @@ int Client::HandlePacket(const EQApplicationPacket *app)
 	case CLIENT_LINKDEAD:
 		break;
 	default:
-		LogDebug("Unknown client_state: [{}]\n", client_state);
+		LogDebug("Unknown client_state: [{}]\n", static_cast<int>(client_state));
 		break;
 	}
 
@@ -16342,7 +16342,7 @@ void Client::Handle_OP_XTargetRequest(const EQApplicationPacket *app)
 	}
 
 	default:
-		LogDebug("Unhandled XTarget Type [{}]", Type);
+		LogDebug("Unhandled XTarget Type [{}]", static_cast<int>(Type));
 		break;
 	}
 

--- a/zone/data_bucket.cpp
+++ b/zone/data_bucket.cpp
@@ -410,7 +410,7 @@ void DataBucket::BulkLoadEntities(DataBucketLoadType::Type t, std::vector<uint32
 			column = "npc_id";
 			break;
 		default:
-			LogError("Incorrect LoadType [{}]", t);
+			LogError("Incorrect LoadType [{}]", static_cast<int>(t));
 			break;
 	}
 
@@ -546,7 +546,7 @@ void DataBucket::HandleWorldMessage(ServerPacket *p)
 		n.e.id,
 		n.e.key_,
 		n.e.value,
-		n.update_action
+		static_cast<int>(n.update_action)
 	);
 
 	// delete

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -2521,7 +2521,7 @@ void Mob::SendStatsWindow(Client* c, bool use_window)
 				CastToClient()->GetPVP() ? "Yes" : "No",
 				CastToClient()->GetGM() ? "On" : "Off",
 				EQ::constants::GetFlyModeName(static_cast<uint8>(flymode)),
-				flymode,
+				static_cast<int>(flymode),
 				CastToClient()->GetGMSpeed() ? "On" : "Off",
 				CastToClient()->GetHideMe() ? "On" : "Off",
 				CastToClient()->GetGMInvul() ? "On" : "Off",

--- a/zone/mob_movement_manager.cpp
+++ b/zone/mob_movement_manager.cpp
@@ -1487,7 +1487,7 @@ void MobMovementManager::PushEvadeCombat(MobMovementEntry &mob_movement_entry)
  */
 void MobMovementManager::HandleStuckBehavior(Mob *who, float x, float y, float z, MobMovementMode mob_movement_mode)
 {
-	LogDebug("Handle stuck behavior for {0} at ({1}, {2}, {3}) with movement_mode {4}", who->GetName(), x, y, z, mob_movement_mode);
+	LogDebug("Handle stuck behavior for {0} at ({1}, {2}, {3}) with movement_mode {4}", who->GetName(), x, y, z, static_cast<int>(mob_movement_mode));
 
 	auto sb = who->GetStuckBehavior();
 	MobStuckBehavior behavior = RunToTarget;

--- a/zone/spawn2.h
+++ b/zone/spawn2.h
@@ -169,4 +169,7 @@ protected:
 	TimeOfDay_Struct next_event;
 };
 
+constexpr int format_as(SpawnCondition::OnChange val) { return static_cast<int>(val); }
+constexpr int format_as(SpawnEvent::Action val) { return static_cast<int>(val); }
+
 #endif

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -407,7 +407,7 @@ bool Mob::DoCastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 			spell.target_type == ST_Beam
 		) && target_id == 0
 	) {
-		LogSpells("Spell [{}] auto-targeted the caster. Group? [{}], target type [{}]", spell_id, IsGroupSpell(spell_id), spell.target_type);
+		LogSpells("Spell [{}] auto-targeted the caster. Group? [{}], target type [{}]", spell_id, IsGroupSpell(spell_id), static_cast<int>(spell.target_type));
 		target_id = GetID();
 	}
 
@@ -2383,7 +2383,7 @@ bool Mob::DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_ce
 
 		default:
 		{
-			LogSpells("I dont know Target Type: [{}]  Spell: ([{}]) [{}]", spells[spell_id].target_type, spell_id, spells[spell_id].name);
+			LogSpells("I dont know Target Type: [{}]  Spell: ([{}]) [{}]", static_cast<int>(spells[spell_id].target_type), spell_id, spells[spell_id].name);
 			Message(0, "I dont know Target Type: %d   Spell: (%d) %s", spells[spell_id].target_type, spell_id, spells[spell_id].name);
 			CastAction = CastActUnknown;
 			break;
@@ -2461,7 +2461,7 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, CastingSlot slot, in
 		}
 	}
 
-	LogSpells("Spell [{}]: target type [{}], target [{}], AE center [{}]", spell_id, CastAction, spell_target?spell_target->GetName():"NONE", ae_center?ae_center->GetName():"NONE");
+	LogSpells("Spell [{}]: target type [{}], target [{}], AE center [{}]", spell_id, static_cast<int>(CastAction), spell_target?spell_target->GetName():"NONE", ae_center?ae_center->GetName():"NONE");
 
 	// if a spell has the AEDuration flag, it becomes an AE on target
 	// spell that's recast every 2500 msec for AEDuration msec.

--- a/zone/task_manager.cpp
+++ b/zone/task_manager.cpp
@@ -256,7 +256,7 @@ bool TaskManager::LoadTasks(int single_task)
 			activity_id,
 			task_data->activity_count,
 			static_cast<int32_t>(ad->activity_type),
-			ad->goal_method,
+			static_cast<int32_t>(ad->goal_method),
 			ad->goal_count,
 			ad->zones.c_str(),
 			ad->target_name.c_str(),

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -746,7 +746,7 @@ void Client::ZonePC(uint32 zoneID, uint32 instance_id, float x, float y, float z
 		z,
 		heading,
 		ignorerestrictions,
-		zm
+		static_cast<int>(zm)
 	);
 
 	cheat_manager.SetExemptStatus(Port, true);


### PR DESCRIPTION
This is prep for updating to fmt 10 which removed implicit conversions for enums.