### PR TITLE
[Quest API] Add Getter/Setter for Guild Favor to Perl/Lua

### DIFF
--- a/common/guild_base.h
+++ b/common/guild_base.h
@@ -104,12 +104,15 @@ class BaseGuildManager
 		bool    GetGuildBankerStatus(uint32 guild_id, uint32 guild_rank);
 		bool	SetTributeFlag(uint32 charid, bool enabled);
 		bool	SetPublicNote(uint32 charid, std::string public_note);
-		uint32  UpdateDbGuildFavor(uint32 guild_id, uint32 enabled);
 		bool    UpdateDbGuildTributeEnabled(uint32 guild_id, uint32 enabled);
 		bool    UpdateDbMemberTributeEnabled(uint32 guild_id, uint32 char_id, uint32 enabled);
 		bool    UpdateDbTributeTimeRemaining(uint32 guild_id, uint32 enabled);
-		uint32	UpdateDbMemberFavor(uint32 guild_id, uint32 char_id, uint32 favor);
 		bool    UpdateDbMemberOnline(uint32 char_id, bool status);
+
+		uint32 GetGuildMemberFavor(uint32 guild_id, uint32 character_id);
+		void SetGuildMemberFavor(uint32 guild_id, uint32 character_id, uint32 favor);
+		uint32 GetGuildFavor(uint32 guild_id);
+		void SetGuildFavor(uint32 guild_id, uint32 enabled);
 
 		//queries
 		bool	GetCharInfo(const char *char_name, CharGuildInfo &into);

--- a/world/wguild_mgr.cpp
+++ b/world/wguild_mgr.cpp
@@ -261,7 +261,7 @@ void WorldGuildManager::Process()
 			g.second->tribute.favor         -= GetGuildTributeCost(g.first);
 			g.second->tribute.time_remaining = RuleI(Guild, TributeTime);
 			g.second->tribute.timer.Start(RuleI(Guild, TributeTime));
-			guild_mgr.UpdateDbGuildFavor(g.first, g.second->tribute.favor);
+			guild_mgr.SetGuildFavor(g.first, g.second->tribute.favor);
 			guild_mgr.UpdateDbTributeTimeRemaining(g.first, RuleI(Guild, TributeTime));
 			SendGuildTributeFavorAndTimer(g.first, g.second->tribute.favor, g.second->tribute.timer.GetRemainingTime());
 		}

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -1619,7 +1619,7 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 					guild->tribute.timer.Disable();
 				}
 				guild_mgr.UpdateDbGuildTributeEnabled(data->guild_id, data->enabled);
-				guild_mgr.UpdateDbGuildFavor(data->guild_id, data->favor);
+				guild_mgr.SetGuildFavor(data->guild_id, data->favor);
 				guild_mgr.UpdateDbTributeTimeRemaining(data->guild_id, data->time_remaining);
 
 				zoneserver_list.SendPacketToBootedZones(pack);

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -17055,8 +17055,8 @@ void Client::Handle_OP_GuildTributeDonateItem(const EQApplicationPacket *app)
 	auto guild = guild_mgr.GetGuildByGuildID(guild_id);
 	if (guild) {
 		guild->tribute.favor += favor;
-		guild_mgr.UpdateDbGuildFavor(GuildID(), guild->tribute.favor);
-		auto member_favor = guild_mgr.UpdateDbMemberFavor(GuildID(), CharacterID(), favor);
+		guild_mgr.SetGuildFavor(GuildID(), guild->tribute.favor);
+		guild_mgr.SetGuildMemberFavor(GuildID(), CharacterID(), favor);
 
 		if (inst->IsStackable()) {
 			if (inst->GetCharges() < (int32) in->quantity) {
@@ -17086,7 +17086,7 @@ void Client::Handle_OP_GuildTributeDonateItem(const EQApplicationPacket *app)
 		strn0cpy(out->player_name, GetCleanName(), sizeof(out->player_name));
 		out->member_time    = time(nullptr);
 		out->member_enabled = GuildTributeOptIn();
-		out->member_favor   = member_favor;
+		out->member_favor   = favor;
 		worldserver.SendPacket(outapp);
 		safe_delete(outapp)
 
@@ -17109,8 +17109,8 @@ void Client::Handle_OP_GuildTributeDonatePlat(const EQApplicationPacket *app)
 	auto guild = guild_mgr.GetGuildByGuildID(guild_id);
 	if (guild) {
 		guild->tribute.favor += favor;
-		guild_mgr.UpdateDbGuildFavor(GuildID(), guild->tribute.favor);
-		auto member_favor = guild_mgr.UpdateDbMemberFavor(GuildID(), CharacterID(), favor);
+		guild_mgr.SetGuildFavor(GuildID(), guild->tribute.favor);
+		guild_mgr.SetGuildMemberFavor(GuildID(), CharacterID(), favor);
 
 		TakePlatinum(quantity, false);
 		SendGuildTributeDonatePlatReply(in, favor);
@@ -17131,7 +17131,7 @@ void Client::Handle_OP_GuildTributeDonatePlat(const EQApplicationPacket *app)
 		strncpy(out->player_name, GetCleanName(), sizeof(out->player_name));
 		out->member_time    = time(nullptr);
 		out->member_enabled = GuildTributeOptIn();
-		out->member_favor   = member_favor;
+		out->member_favor   = favor;
 		worldserver.SendPacket(outapp);
 		safe_delete(outapp)
 

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -34,6 +34,7 @@
 #include "questmgr.h"
 #include "zone.h"
 #include "data_bucket.h"
+#include "guild_mgr.h"
 
 #include <cctype>
 
@@ -5762,6 +5763,26 @@ std::string Perl__convert_money_to_string(perl::hash table)
 	return Strings::Money(platinum, gold, silver, copper);
 }
 
+uint32 Perl__get_guild_favor(uint32 guild_id)
+{
+	return guild_mgr.GetGuildFavor(guild_id);
+}
+
+void Perl__set_guild_favor(uint32 guild_id, uint32 favor)
+{
+	guild_mgr.SetGuildFavor(guild_id, favor);
+}
+
+uint32 Perl__get_guild_member_favor(uint32 guild_id, uint32 character_id)
+{
+	return guild_mgr.GetGuildMemberFavor(guild_id, character_id);
+}
+
+void Perl__set_guild_member_favor(uint32 guild_id, uint32 character_id, uint32 favor)
+{
+	guild_mgr.SetGuildMemberFavor(guild_id, character_id, favor);
+}
+
 void perl_register_quest()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -6415,6 +6436,8 @@ void perl_register_quest()
 	package.add("get_expedition_lockouts_by_char_id", (perl::reference(*)(uint32))&Perl__get_expedition_lockouts_by_char_id);
 	package.add("get_expedition_lockouts_by_char_id", (perl::reference(*)(uint32, std::string))&Perl__get_expedition_lockouts_by_char_id);
 	package.add("getfactionname", &Perl__getfactionname);
+	package.add("get_guild_favor", &Perl__get_guild_favor);
+	package.add("get_guild_member_favor", &Perl__get_guild_member_favor);
 	package.add("getinventoryslotid", &Perl__getinventoryslotid);
 	package.add("getitemcomment", &Perl__getitemcomment);
 	package.add("getitemlore", &Perl__getitemlore);
@@ -6581,6 +6604,8 @@ void perl_register_quest()
 	package.add("setaaexpmodifierbycharid", (void(*)(uint32, uint32, double, int16))&Perl__setaaexpmodifierbycharid);
 	package.add("set_data", (void(*)(std::string, std::string))&Perl__set_data);
 	package.add("set_data", (void(*)(std::string, std::string, std::string))&Perl__set_data);
+	package.add("set_guild_favor", &Perl__set_guild_favor);
+	package.add("set_guild_member_favor", &Perl__set_guild_member_favor);
 	package.add("set_proximity", (void(*)(float, float, float, float))&Perl__set_proximity);
 	package.add("set_proximity", (void(*)(float, float, float, float, float, float))&Perl__set_proximity);
 	package.add("set_proximity", (void(*)(float, float, float, float, float, float, bool))&Perl__set_proximity);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -11,6 +11,7 @@
 #include "../common/timer.h"
 #include "../common/classes.h"
 #include "../common/rulesys.h"
+#include "guild_mgr.h"
 #include "lua_item.h"
 #include "lua_iteminst.h"
 #include "lua_client.h"
@@ -5406,6 +5407,27 @@ std::string lua_convert_money_to_string(luabind::adl::object table)
 	return Strings::Money(platinum, gold, silver, copper);
 }
 
+uint32 lua_get_guild_favor(uint32 guild_id)
+{
+	return guild_mgr.GetGuildFavor(guild_id);
+}
+
+void lua_set_guild_favor(uint32 guild_id, uint32 favor)
+{
+	guild_mgr.SetGuildFavor(guild_id, favor);
+}
+
+uint32 lua_get_guild_member_favor(uint32 guild_id, uint32 character_id)
+{
+	return guild_mgr.GetGuildMemberFavor(guild_id, character_id);
+}
+
+void lua_set_guild_member_favor(uint32 guild_id, uint32 character_id, uint32 favor)
+{
+	guild_mgr.SetGuildMemberFavor(guild_id, character_id, favor);
+}
+
+
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
 	cur = table[#name]; \
 	if(luabind::type(cur) != LUA_TNIL) { \
@@ -6187,6 +6209,10 @@ luabind::scope lua_register_general() {
 		luabind::def("get_spell_resurrection_sickness_check", &lua_get_spell_resurrection_sickness_check),
 		luabind::def("get_spell_nimbus_effect", &lua_get_spell_nimbus_effect),
 		luabind::def("convert_money_to_string", &lua_convert_money_to_string),
+		luabind::def("get_guild_favor", &lua_get_guild_favor),
+		luabind::def("get_guild_member_favor", &lua_get_guild_member_favor),
+		luabind::def("set_guild_favor", &lua_set_guild_favor),
+		luabind::def("set_guild_member_favor", &lua_set_guild_member_favor),
 		/*
 			Cross Zone
 		*/


### PR DESCRIPTION
# Perl
- Add `quest::get_guild_favor(guild_id)`.
- Add `quest::get_guild_member_favor(guild_id, character_id)`.
- Add `quest::set_guild_favor(guild_id, favor)`.
- Add `quest::set_guild_member_favor(guild_id, character_id, favor)`.

# Lua
- Add `eq.get_guild_favor(guild_id)`.
- Add `eq.get_guild_member_favor(guild_id, character_id)`.
- Add `eq.set_guild_favor(guild_id, favor)`.
- Add `eq.set_guild_member_favor(guild_id, character_id, favor)`.

# Notes
- Allows operators to set guild and guild member favor from a quest script.
- Would be nice to expose a lot more of these methods or a guild object to scripts at some point.