### PR TITLE
[Quest API] Add IsInAGuild() to Perl/Lua

### DIFF
--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3290,6 +3290,12 @@ int Lua_Client::GetEXPPercentage()
 	return self->GetEXPPercentage();
 }
 
+bool Lua_Client::IsInAGuild()
+{
+	Lua_Safe_Call_Bool();
+	return self->IsInAGuild();
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 	.def(luabind::constructor<>())
@@ -3578,6 +3584,7 @@ luabind::scope lua_register_client() {
 	.def("IsDueling", (bool(Lua_Client::*)(void))&Lua_Client::IsDueling)
 	.def("IsEXPEnabled", (bool(Lua_Client::*)(void))&Lua_Client::IsEXPEnabled)
 	.def("IsGrouped", (bool(Lua_Client::*)(void))&Lua_Client::IsGrouped)
+	.def("IsInAGuild", (bool(Lua_Client::*)(void))&Lua_Client::IsInAGuild)
 	.def("IsLD", (bool(Lua_Client::*)(void))&Lua_Client::IsLD)
 	.def("IsMedding", (bool(Lua_Client::*)(void))&Lua_Client::IsMedding)
 	.def("IsRaidGrouped", (bool(Lua_Client::*)(void))&Lua_Client::IsRaidGrouped)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -495,6 +495,7 @@ public:
 	void ClearXTargets();
 	int GetAAEXPPercentage();
 	int GetEXPPercentage();
+	bool IsInAGuild();
 
 	void ApplySpell(int spell_id);
 	void ApplySpell(int spell_id, int duration);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -3098,6 +3098,11 @@ int Perl_Client_GetEXPPercentage(Client* self)
 	return self->GetEXPPercentage();
 }
 
+bool Perl_Client_IsInAGuild(Client* self)
+{
+	return self->IsInAGuild();
+}
+
 void perl_register_client()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3386,6 +3391,7 @@ void perl_register_client()
 	package.add("IsDueling", &Perl_Client_IsDueling);
 	package.add("IsEXPEnabled", &Perl_Client_IsEXPEnabled);
 	package.add("IsGrouped", &Perl_Client_IsGrouped);
+	package.add("IsInAGuild", &Perl_Client_IsInAGuild);
 	package.add("IsLD", &Perl_Client_IsLD);
 	package.add("IsMedding", &Perl_Client_IsMedding);
 	package.add("IsRaidGrouped", &Perl_Client_IsRaidGrouped);


### PR DESCRIPTION
# Perl
- Add `$client->IsInAGuild()`.

# Lua
- Add `client:IsInAGuild()`.

# Notes
- Allows operators to more accurately tell if a player is in a group.
- `GuildID()` returns `uint32` max value if the player isn't in a guild so conditions using it must check for a value over a certain point, this is just a bool that simplifies that logic.