### PR TITLE
[Bots] Remove Alt Combat Functionality

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -694,7 +694,6 @@ RULE_BOOL(Bots, BotGroupXP, false, "Determines whether client gets experience fo
 RULE_BOOL(Bots, BotLevelsWithOwner, false, "Auto-updates spawned bots as owner levels/de-levels (false is original behavior)")
 RULE_INT(Bots, BotCharacterLevel, 0, "If level is greater that value player can spawn bots if BotCharacterLevelEnabled is true")
 RULE_INT(Bots, CasterStopMeleeLevel, 13, "Level at which caster bots stop melee attacks")
-RULE_BOOL(Bots, AllowOwnerOptionAltCombat, true, "When option is enabled, bots will use an auto-/shared-aggro combat model")
 RULE_BOOL(Bots, AllowOwnerOptionAutoDefend, true, "When option is enabled, bots will defend their owner on enemy aggro")
 RULE_REAL(Bots, LeashDistance, 562500.0f, "Distance a bot is allowed to travel from leash owner before being pulled back (squared value)")
 RULE_BOOL(Bots, AllowApplyPoisonCommand, true, "Allows the use of the bot command 'applypoison'")

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -781,12 +781,15 @@ public:
 	Mob* SetFollowMob(Client* leash_owner);
 
 	Mob* GetBotTarget(Client* bot_owner);
-	void AcquireBotTarget(Group* bot_group, Raid* raid, Client* leash_owner, float leash_distance);
-	void SetBotTarget(Client* bot_owner, Raid* raid, Group* bot_group, Client* leash_owner, float lo_distance, float leash_distance, bool bo_alt_combat);
-	void SetLeashOwnerTarget(Client* leash_owner, Client* bot_owner, float lo_distance, float leash_distance);
 	void SetOwnerTarget(Client* bot_owner);
-	void SetBotGroupTarget(const Client* bot_owner, Client* leash_owner, float lo_distance, float leash_distance, Mob* const& bg_member, Mob* bgm_target);
-	bool IsValidTarget(Client* bot_owner, Client* leash_owner, float lo_distance, float leash_distance, bool bo_alt_combat, Mob* tar, float tar_distance);
+	bool IsValidTarget(
+		Client* bot_owner,
+		Client* leash_owner,
+		float lo_distance,
+		float leash_distance,
+		Mob* tar,
+		float tar_distance
+	);
 
 	bool PullingFlagChecks(Client* bot_owner);
 	bool ReturningFlagChecks(Client* bot_owner, float fm_distance);
@@ -879,7 +882,6 @@ private:
 	int32	end_regen;
 
 	Timer m_evade_timer; // can be moved to pTimers at some point
-	Timer m_alt_combat_hate_timer;
 	Timer m_auto_defend_timer;
 	Timer auto_save_timer;
 	bool m_dirtyautohaters;

--- a/zone/bot_commands/owner_option.cpp
+++ b/zone/bot_commands/owner_option.cpp
@@ -45,11 +45,6 @@ void bot_command_owner_option(Client *c, const Seperator *sep)
 						"<td><c \"#888888\">spawn with class-based message</td>"
 						"</tr>"
 						"<tr>"
-						"<td><c \"#CCCCCC\">altcombat</td>"
-						"<td><c \"#00CC00\">enable <c \"#CCCCCC\">| <c \"#00CC00\">disable</td>"
-						"<td><c \"#888888\">use alternate ai combat behavior</td>"
-						"</tr>"
-						"<tr>"
 						"<td></td>"
 						"<td><c \"#00CCCC\">null</td>"
 						"<td><c \"#888888\">(toggles)</td>"
@@ -199,28 +194,6 @@ void bot_command_owner_option(Client *c, const Seperator *sep)
 
 		c->Message(Chat::White, "Bot 'spawn message' is now %s.", argument.c_str());
 	}
-	else if (!owner_option.compare("altcombat")) {
-
-		if (RuleB(Bots, AllowOwnerOptionAltCombat)) {
-
-			if (!argument.compare("enable")) {
-				c->SetBotOption(Client::booAltCombat, true);
-			}
-			else if (!argument.compare("disable")) {
-				c->SetBotOption(Client::booAltCombat, false);
-			}
-			else {
-				c->SetBotOption(Client::booAltCombat, !c->GetBotOption(Client::booAltCombat));
-			}
-
-			database.botdb.SaveOwnerOption(c->CharacterID(), Client::booAltCombat, c->GetBotOption(Client::booAltCombat));
-
-			c->Message(Chat::White, "Bot 'alt combat' is now %s.", (c->GetBotOption(Client::booAltCombat) ? "enabled" : "disabled"));
-		}
-		else {
-			c->Message(Chat::White, "Bot owner option 'altcombat' is not allowed on this server.");
-		}
-	}
 	else if (!owner_option.compare("autodefend")) {
 
 		if (RuleB(Bots, AllowOwnerOptionAutoDefend)) {
@@ -292,7 +265,6 @@ void bot_command_owner_option(Client *c, const Seperator *sep)
 			"<tr>" "<td><c \"#CCCCCC\">statsupdate</td>"    "<td><c \"#00CC00\">{}</td>" "</tr>"
 			"<tr>" "<td><c \"#CCCCCC\">spawnmessage</td>"   "<td><c \"#00CC00\">{}</td>" "</tr>"
 			"<tr>" "<td><c \"#CCCCCC\">spawnmessage</td>"   "<td><c \"#00CC00\">{}</td>" "</tr>"
-			"<tr>" "<td><c \"#CCCCCC\">altcombat</td>"      "<td><c \"#00CC00\">{}</td>" "</tr>"
 			"<tr>" "<td><c \"#CCCCCC\">autodefend</td>"     "<td><c \"#00CC00\">{}</td>" "</tr>"
 			"<tr>" "<td><c \"#CCCCCC\">buffcounter</td>"    "<td><c \"#00CC00\">{}</td>" "</tr>"
 			"<tr>" "<td><c \"#CCCCCC\">monkwumessage</td>"  "<td><c \"#00CC00\">{}</td>" "</tr>"
@@ -301,7 +273,6 @@ void bot_command_owner_option(Client *c, const Seperator *sep)
 			(c->GetBotOption(Client::booStatsUpdate) ? "enabled" : "disabled"),
 			(c->GetBotOption(Client::booSpawnMessageSay) ? "say" : (c->GetBotOption(Client::booSpawnMessageTell) ? "tell" : "silent")),
 			(c->GetBotOption(Client::booSpawnMessageClassSpecific) ? "class" : "default"),
-			(RuleB(Bots, AllowOwnerOptionAltCombat) ? (c->GetBotOption(Client::booAltCombat) ? "enabled" : "disabled") : "restricted"),
 			(RuleB(Bots, AllowOwnerOptionAutoDefend) ? (c->GetBotOption(Client::booAutoDefend) ? "enabled" : "disabled") : "restricted"),
 			(c->GetBotOption(Client::booBuffCounter) ? "enabled" : "disabled"),
 			(c->GetBotOption(Client::booMonkWuMessage) ? "enabled" : "disabled")

--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -1842,7 +1842,7 @@ bool BotDatabase::SaveOwnerOption(const uint32 owner_id, size_t type, const bool
 		Client::booDeathMarquee,
 		Client::booStatsUpdate,
 		Client::booSpawnMessageClassSpecific,
-		Client::booAltCombat,
+		Client::booAltCombat, // Unused
 		Client::booAutoDefend,
 		Client::booBuffCounter,
 		Client::booMonkWuMessage

--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -1842,7 +1842,7 @@ bool BotDatabase::SaveOwnerOption(const uint32 owner_id, size_t type, const bool
 		Client::booDeathMarquee,
 		Client::booStatsUpdate,
 		Client::booSpawnMessageClassSpecific,
-		Client::booAltCombat, // Unused
+		Client::booUnused,
 		Client::booAutoDefend,
 		Client::booBuffCounter,
 		Client::booMonkWuMessage

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -370,7 +370,6 @@ Client::Client(EQStreamInterface *ieqs) : Mob(
 	bot_owner_options[booSpawnMessageSay] = false;
 	bot_owner_options[booSpawnMessageTell] = true;
 	bot_owner_options[booSpawnMessageClassSpecific] = true;
-	bot_owner_options[booAltCombat] = RuleB(Bots, AllowOwnerOptionAltCombat);
 	bot_owner_options[booAutoDefend] = RuleB(Bots, AllowOwnerOptionAutoDefend);
 	bot_owner_options[booBuffCounter] = false;
 	bot_owner_options[booMonkWuMessage] = false;
@@ -537,7 +536,7 @@ void Client::SendZoneInPackets()
 	safe_delete(outapp);
 
 	if (IsInAGuild()) {
-		guild_mgr.UpdateDbMemberOnline(CharacterID(), true); 
+		guild_mgr.UpdateDbMemberOnline(CharacterID(), true);
 		//SendGuildMembers();
 		SendGuildURL();
 		SendGuildChannel();
@@ -747,7 +746,7 @@ bool Client::Save(uint8 iCommitNow) {
 			SetNextInvSnapshot(RuleI(Character, InvSnapshotMinRetryM));
 		}
 	}
-	
+
 	database.SaveCharacterData(this, &m_pp, &m_epp); /* Save Character Data */
 
 	database.SaveCharacterEXPModifier(this);

--- a/zone/client.h
+++ b/zone/client.h
@@ -2076,7 +2076,7 @@ public:
 		booSpawnMessageSay,
 		booSpawnMessageTell,
 		booSpawnMessageClassSpecific,
-		booAltCombat, // Unused
+		booUnused,
 		booAutoDefend,
 		booBuffCounter,
 		booMonkWuMessage,

--- a/zone/client.h
+++ b/zone/client.h
@@ -2076,7 +2076,7 @@ public:
 		booSpawnMessageSay,
 		booSpawnMessageTell,
 		booSpawnMessageClassSpecific,
-		booAltCombat,
+		booAltCombat, // Unused
 		booAutoDefend,
 		booBuffCounter,
 		booMonkWuMessage,


### PR DESCRIPTION
# Notes
- This functionality needlessly complicates bot targeting logic and causes crashes and unintended behavior for players when accidentally enabled or enabled by default.