### PR TITLE
[Bug Fix] Fix Issue with ClearSpawnTimers()

### DIFF
--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -2649,22 +2649,24 @@ void Zone::ClearSpawnTimers()
 
 	iterator.Reset();
 
-	std::vector<std::string> respawn_ids;
+	std::vector<uint32> respawn_ids;
 
 	while (iterator.MoreElements()) {
-		respawn_ids.emplace_back(std::to_string(iterator.GetData()->GetID()));
+		respawn_ids.emplace_back(iterator.GetData()->spawn2_id);
 
 		iterator.Advance();
 	}
 
-	RespawnTimesRepository::DeleteWhere(
-		database,
-		fmt::format(
-			"`instance_id` = {} AND `id` IN ({})",
-			GetInstanceID(),
-			Strings::Implode(", ", respawn_ids)
-		)
-	);
+	if (!respawn_ids.empty()) {
+		RespawnTimesRepository::DeleteWhere(
+			database,
+			fmt::format(
+				"`instance_id` = {} AND `id` IN ({})",
+				GetInstanceID(),
+				Strings::Join(respawn_ids, ", ")
+			)
+		);
+	}
 }
 
 uint32 Zone::GetSpawnKillCount(uint32 in_spawnid) {


### PR DESCRIPTION
# Notes
- We were using the improper ID for this and not checking if the vector was empty before using.