### PR TITLE
[Opcodes] Fix opcode reloading

### DIFF
--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -1367,6 +1367,7 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 		}
 		case ServerOP_ReloadOpcodes: {
 			ReloadAllPatches();
+			zoneserver_list.SendPacket(pack);
 			break;
 		}
 		case ServerOP_CZDialogueWindow:

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -58,6 +58,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include "bot_command.h"
 #include "../common/events/player_event_logs.h"
 #include "../common/repositories/guild_tributes_repository.h"
+#include "../common/patches/patches.h"
 
 extern EntityList entity_list;
 extern Zone* zone;
@@ -1976,6 +1977,12 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 			zone->LoadAlternateAdvancement();
 			entity_list.SendAlternateAdvancementStats();
 		}
+		break;
+	}
+	case ServerOP_ReloadOpcodes:
+	{
+		zone->SendReloadMessage("Opcodes");
+		ReloadAllPatches();
 		break;
 	}
 	case ServerOP_ReloadAlternateCurrencies:


### PR DESCRIPTION
Opcodes would only reload for world, this propagates to zones

**Testing**

![image](https://github.com/EQEmu/Server/assets/3319450/800a94c7-1df3-40f3-9a63-5700ce7262ac)

![image](https://github.com/EQEmu/Server/assets/3319450/d91954e4-7680-46a9-a6bf-c8cdd06b316e)
