### PR TITLE
[Auras] Clear all character auras on save

### DIFF
--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -3087,7 +3087,13 @@ void ZoneDatabase::LoadBuffs(Client *client)
 
 void ZoneDatabase::SaveAuras(Client *c)
 {
-	CharacterAurasRepository::DeleteOne(database, c->CharacterID());
+	CharacterAurasRepository::DeleteWhere(
+		database,
+		fmt::format(
+			"`id` = {}",
+			c->CharacterID()
+		)
+	);
 
 	std::vector<CharacterAurasRepository::CharacterAuras> v;
 


### PR DESCRIPTION
Certain classes can have multiple auras - code may not support this yet. When saving character auras, we should clear all auras for the character.

https://forums.daybreakgames.com/eq/index.php?threads/auras.289675/
https://everquest.fanra.info/wiki/Auras

![EQ000000](https://github.com/EQEmu/Server/assets/3617814/66d509d7-bb14-4e0b-98b9-4e8bafce8306)
![EQ000001](https://github.com/EQEmu/Server/assets/3617814/224bf8ba-5d12-4598-9b76-c551a046262f)
![EQ000002](https://github.com/EQEmu/Server/assets/3617814/7014965a-6120-46ff-9b68-1b57b1db4031)
