### PR TITLE
[Expansions] Fix content filter criteria for max_expansions

### DIFF
--- a/common/repositories/criteria/content_filter_criteria.h
+++ b/common/repositories/criteria/content_filter_criteria.h
@@ -27,7 +27,7 @@ namespace ContentFilterCriteria {
 		);
 
 		criteria += fmt::format(
-			" AND ({}max_expansion >= {} OR {}max_expansion = -1)",
+			" AND ({}max_expansion <= {} OR {}max_expansion = -1)",
 			table_prefix,
 			current_expansion_filter_criteria,
 			table_prefix


### PR DESCRIPTION
We should not be loading rows that are **greater** than our current expansion.

This was never caught because no one is doing anything with expansion filtering to the extent we have with ProjectEQ Expansions lately.