### PR TITLE
[Feature] Hot Zone Bonus XP Notice

### DIFF
--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -625,19 +625,29 @@ void Client::SetEXP(uint64 set_exp, uint64 set_aaxp, bool isrezzexp) {
 			else MessageString(Chat::Experience, REZ_REGAIN);
 		} else {
 			if (membercount > 1) {
-				if (RuleI(Character, ShowExpValues) > 0)
+				if (RuleI(Character, ShowExpValues) > 0) {
 					Message(Chat::Experience, "You have gained %s party experience! %s", exp_amount_message.c_str(), exp_percent_message.c_str());
-				else MessageString(Chat::Experience, GAIN_GROUPXP);
-			}
-			else if (IsRaidGrouped()) {
-				if (RuleI(Character, ShowExpValues) > 0)
+				} else if (zone->IsHotzone()) { 
+					MessageString(Chat::Experience, GAIN_GROUPXP_BONUS);
+				} else {
+					MessageString(Chat::Experience, GAIN_GROUPXP);
+				}
+			} else if (IsRaidGrouped()) {
+				if (RuleI(Character, ShowExpValues) > 0) {
 					Message(Chat::Experience, "You have gained %s raid experience! %s", exp_amount_message.c_str(), exp_percent_message.c_str());
-				else MessageString(Chat::Experience, GAIN_RAIDEXP);
-			}
-			else {
-				if (RuleI(Character, ShowExpValues) > 0)
+				} else if (zone->IsHotzone()) { 
+					MessageString(Chat::Experience, GAIN_RAIDXP_BONUS);
+				} else {
+					MessageString(Chat::Experience, GAIN_RAIDEXP);
+				}
+			} else {
+				if (RuleI(Character, ShowExpValues) > 0) {
 					Message(Chat::Experience, "You have gained %s experience! %s", exp_amount_message.c_str(), exp_percent_message.c_str());
-				else MessageString(Chat::Experience, GAIN_XP);
+				} else if (zone->IsHotzone()) { 
+					MessageString(Chat::Experience, GAIN_XP_BONUS);
+				} else {
+					MessageString(Chat::Experience, GAIN_XP);
+				}
 			}
 		}
 	}

--- a/zone/string_ids.h
+++ b/zone/string_ids.h
@@ -483,6 +483,10 @@
 #define NO_CAST_OUT_OF_COMBAT		9191	//You can not cast this spell while out of combat.
 #define NO_ABILITY_IN_COMBAT		9192	//You can not use this ability while in combat.
 #define NO_ABILITY_OUT_OF_COMBAT	9194	//You can not use this ability while out of combat.
+#define GAIN_GROUPXP_BONUS			9298	//You gain party experience (with a bonus)!
+#define GAIN_GROUPXP_PENALTY		9301	//You gain party experience (with a penalty)!
+#define GAIN_RAIDXP_BONUS			9302	//You gained raid experience (with a bonus)!
+#define GAIN_RAIDXP_PENALTY			9303	//You gained raid experience (with a penalty)!
 #define LESSER_SPELL_VERSION        11004   //%1 is a lesser version of %2 and cannot be scribed
 #define AE_RAMPAGE					11015	//%1 goes on a WILD RAMPAGE!
 #define GROUP_IS_FULL				12000	//You cannot join that group, it is full.
@@ -562,6 +566,8 @@
 #define TOGGLE_OFF					13173	//Asking server to turn OFF all incoming tells for you.
 #define DUEL_INPROGRESS				13251	//You have already accepted a duel with someone else cowardly dog.
 #define OTHER_HIT_DOT				13327	//%1 has taken %2 damage from %3 by %4.
+#define GAIN_XP_BONUS				14541	//You gain experience (with a bonus)!
+#define GAIN_XP_PENALTY				14542	//You gain experience (with a penalty)!
 #define GENERIC_MISS				15041	//%1 missed %2
 
 #endif


### PR DESCRIPTION
When in Hotzones, a bonus XP notice will let players know the hotzone is enabled.