### PR TITLE
[Bug Fix] Fix Bot/Character ID Overlap in Groups

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -1282,41 +1282,6 @@ void Database::AddReport(std::string who, std::string against, std::string lines
 	safe_delete_array(escape_str);
 }
 
-void Database::SetGroupID(
-	const std::string& name,
-	uint32 group_id,
-	uint32 character_id,
-	uint32 bot_id,
-	bool is_merc
-)
-{
-	if (!group_id) {
-		const int deleted = GroupIdRepository::DeleteWhere(
-			*this,
-			fmt::format(
-				"`character_id` = {} AND `bot_id` = {} AND `name` = '{}' AND `is_merc` = {}",
-				character_id,
-				bot_id,
-				name,
-				is_merc ? 1 : 0
-			)
-		);
-
-		return;
-	}
-
-	GroupIdRepository::ReplaceOne(
-		*this,
-		GroupIdRepository::GroupId{
-			.group_id = group_id,
-			.character_id = character_id,
-			.bot_id = bot_id,
-			.name = name,
-			.is_merc = static_cast<uint8_t>(is_merc ? 1 : 0)
-		}
-	);
-}
-
 void Database::ClearAllGroups(void)
 {
 	std::string query("DELETE FROM `group_id`");

--- a/common/database.cpp
+++ b/common/database.cpp
@@ -35,6 +35,8 @@
 #include "../common/repositories/character_languages_repository.h"
 #include "../common/repositories/character_leadership_abilities_repository.h"
 #include "../common/repositories/character_skills_repository.h"
+#include "../common/repositories/group_id_repository.h"
+#include "../common/repositories/group_leaders_repository.h"
 
 // Disgrace: for windows compile
 #ifdef _WINDOWS
@@ -1280,22 +1282,39 @@ void Database::AddReport(std::string who, std::string against, std::string lines
 	safe_delete_array(escape_str);
 }
 
-void Database::SetGroupID(const char* name, uint32 id, uint32 charid, uint32 ismerc) {
-	std::string query;
-	if (id == 0) {
-		// removing from group
-		query = StringFormat("delete from group_id where charid=%i and name='%s' and ismerc=%i",charid, name, ismerc);
-		auto results = QueryDatabase(query);
-
-		if (!results.Success())
-			LogError("Error deleting character from group id: {}", results.ErrorMessage().c_str());
+void Database::SetGroupID(
+	const std::string& name,
+	uint32 group_id,
+	uint32 character_id,
+	uint32 bot_id,
+	bool is_merc
+)
+{
+	if (!group_id) {
+		const int deleted = GroupIdRepository::DeleteWhere(
+			*this,
+			fmt::format(
+				"`character_id` = {} AND `bot_id` = {} AND `name` = '{}' AND `is_merc` = {}",
+				character_id,
+				bot_id,
+				name,
+				is_merc ? 1 : 0
+			)
+		);
 
 		return;
 	}
 
-	/* Add to the Group */
-	query = StringFormat("REPLACE INTO  `group_id` SET `charid` = %i, `groupid` = %i, `name` = '%s', `ismerc` = '%i'", charid, id, name, ismerc);
-	QueryDatabase(query);
+	GroupIdRepository::ReplaceOne(
+		*this,
+		GroupIdRepository::GroupId{
+			.group_id = group_id,
+			.character_id = character_id,
+			.bot_id = bot_id,
+			.name = name,
+			.is_merc = static_cast<uint8_t>(is_merc ? 1 : 0)
+		}
+	);
 }
 
 void Database::ClearAllGroups(void)
@@ -1305,71 +1324,65 @@ void Database::ClearAllGroups(void)
 	return;
 }
 
-void Database::ClearGroup(uint32 gid) {
-	ClearGroupLeader(gid);
+void Database::ClearGroup(uint32 group_id) {
+	ClearGroupLeader(group_id);
 
-	if(gid == 0)
-	{
+	if (!group_id) {
 		//clear all groups
 		ClearAllGroups();
 		return;
 	}
 
 	//clear a specific group
-	std::string query = StringFormat("delete from group_id where groupid = %lu", (unsigned long)gid);
-	QueryDatabase(query);
-}
-
-uint32 Database::GetGroupID(const char* name){
-	std::string query = StringFormat("SELECT groupid from group_id where name='%s'", name);
-	auto results = QueryDatabase(query);
-
-	if (!results.Success()) {
-		return 0;
-	}
-
-	if (results.RowCount() == 0)
-	{
-		// Commenting this out until logging levels can prevent this from going to console
-		//LogDebug(, "Character not in a group: [{}]", name);
-		return 0;
-	}
-
-	auto row = results.begin();
-
-	return Strings::ToUnsignedInt(row[0]);
-}
-
-std::string Database::GetGroupLeaderForLogin(std::string character_name) {
-	uint32 group_id = 0;
-
-	auto query = fmt::format(
-		"SELECT `groupid` FROM `group_id` WHERE `name` = '{}'",
-		character_name
+	GroupIdRepository::DeleteWhere(
+		*this,
+		fmt::format(
+			"`group_id` = {}",
+			group_id
+		)
 	);
-	auto results = QueryDatabase(query);
+}
 
-	if (results.Success() && results.RowCount()) {
-		auto row = results.begin();
-		group_id = Strings::ToUnsignedInt(row[0]);
+uint32 Database::GetGroupID(const std::string& name)
+{
+	const auto& l = GroupIdRepository::GetWhere(
+		*this,
+		fmt::format(
+			"`name` = '{}'",
+			Strings::Escape(name)
+		)
+	);
+
+	if (l.empty()) {
+		return 0;
 	}
 
-	if (!group_id) {
+	auto e = l.front();
+
+	return e.group_id;
+}
+
+std::string Database::GetGroupLeaderForLogin(const std::string& character_name)
+{
+	const auto& g = GroupIdRepository::GetWhere(
+		*this,
+		fmt::format(
+			"`name` = '{}'",
+			Strings::Escape(character_name)
+		)
+	);
+
+	if (g.empty()) {
 		return std::string();
 	}
 
-	query = fmt::format(
-		"SELECT `leadername` FROM `group_leaders` WHERE `gid` = {} LIMIT 1",
-		group_id
-	);
-	results = QueryDatabase(query);
+	auto group = g.front();
 
-	if (results.Success() && results.RowCount()) {
-		auto row = results.begin();
-		return row[0];
-	}
+	const uint32 group_id = group.group_id;
 
-	return std::string();
+	const auto& e = GroupLeadersRepository::FindOne(*this, group_id);
+
+	return e.gid ? e.leadername : std::string();
 }
 
 void Database::SetGroupLeaderName(uint32 gid, const char* name) {

--- a/common/database.h
+++ b/common/database.h
@@ -202,16 +202,16 @@ public:
 
 	/* Groups */
 
-	std::string GetGroupLeaderForLogin(std::string character_name);
+	std::string GetGroupLeaderForLogin(const std::string& character_name);
 	char* GetGroupLeadershipInfo(uint32 gid, char* leaderbuf, char* maintank = nullptr, char* assist = nullptr, char* puller = nullptr, char *marknpc = nullptr, char *mentoree = nullptr, int *mentor_percent = nullptr, GroupLeadershipAA_Struct* GLAA = nullptr);
 
 	std::string GetGroupLeaderName(uint32 group_id);
 
-	uint32	GetGroupID(const char* name);
+	uint32	GetGroupID(const std::string& name);
 
-	void	ClearGroup(uint32 gid = 0);
+	void	ClearGroup(uint32 group_id = 0);
 	void	ClearGroupLeader(uint32 gid = 0);
-	void	SetGroupID(const char* name, uint32 id, uint32 charid, uint32 ismerc = false);
+	void	SetGroupID(const std::string& name, uint32 group_id, uint32 character_id, uint32 bot_id = 0, bool is_merc = false);
 	void	SetGroupLeaderName(uint32 gid, const char* name);
 
 	/* Raids */

--- a/common/database.h
+++ b/common/database.h
@@ -211,7 +211,6 @@ public:
 
 	void	ClearGroup(uint32 group_id = 0);
 	void	ClearGroupLeader(uint32 gid = 0);
-	void	SetGroupID(const std::string& name, uint32 group_id, uint32 character_id, uint32 bot_id = 0, bool is_merc = false);
 	void	SetGroupLeaderName(uint32 gid, const char* name);
 
 	/* Raids */

--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -5442,13 +5442,15 @@ MODIFY COLUMN `rule_value` text CHARACTER SET latin1 COLLATE latin1_swedish_ci N
 		.match = "",
 		.sql = R"(
 ALTER TABLE `group_id`
-CHANGE COLUMN `groupid` `group_id` int(11) UNSIGNED NOT NULL FIRST,
-CHANGE COLUMN `charid` `character_id` int(11) UNSIGNED NOT NULL AFTER `group_id`,
-CHANGE COLUMN `ismerc` `is_merc` tinyint(1) UNSIGNED NOT NULL DEFAULT 0 AFTER `name`,
-ADD COLUMN `bot_id` int(11) UNSIGNED NOT NULL AFTER `character_id`,
-MODIFY COLUMN `name` varchar(64) NOT NULL DEFAULT 0 AFTER `character_id`,
+CHANGE COLUMN `groupid` `group_id` int(11) UNSIGNED NOT NULL DEFAULT 0 FIRST,
+CHANGE COLUMN `charid` `character_id` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `group_id`,
+CHANGE COLUMN `ismerc` `merc_id` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `name`,
+ADD COLUMN `bot_id` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `character_id`,
+MODIFY COLUMN `name` varchar(64) NOT NULL DEFAULT '' AFTER `character_id`,
 DROP PRIMARY KEY,
-ADD PRIMARY KEY (`group_id`, `character_id`, `bot_id`, `is_merc`) USING BTREE;
+ADD PRIMARY KEY (`group_id`, `character_id`, `bot_id`, `merc_id`) USING BTREE;
+ALTER TABLE `group_id`
+MODIFY COLUMN `character_id` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `name`;
 )"
 	}
 // -- template; copy/paste this when you need to create a new entry

--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -5433,6 +5433,23 @@ ADD PRIMARY KEY (`id`);
 ALTER TABLE `rule_values`
 MODIFY COLUMN `rule_value` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NULL DEFAULT NULL AFTER `rule_name`;
 		)"
+	},
+	ManifestEntry{
+		.version = 9267,
+		.description = "2024_02_18_group_id_bot_id.sql",
+		.check = "SHOW COLUMNS FROM `group_id` LIKE 'bot_id'",
+		.condition = "empty",
+		.match = "",
+		.sql = R"(
+ALTER TABLE `group_id`
+CHANGE COLUMN `groupid` `group_id` int(11) UNSIGNED NOT NULL FIRST,
+CHANGE COLUMN `charid` `character_id` int(11) UNSIGNED NOT NULL AFTER `group_id`,
+CHANGE COLUMN `ismerc` `is_merc` tinyint(1) UNSIGNED NOT NULL DEFAULT 0 AFTER `name`,
+ADD COLUMN `bot_id` int(11) UNSIGNED NOT NULL AFTER `character_id`,
+MODIFY COLUMN `name` varchar(64) NOT NULL DEFAULT 0 AFTER `character_id`,
+DROP PRIMARY KEY,
+ADD PRIMARY KEY (`group_id`, `character_id`, `bot_id`, `is_merc`) USING BTREE;
+)"
 	}
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{

--- a/common/database_instances.cpp
+++ b/common/database_instances.cpp
@@ -421,20 +421,25 @@ void Database::AssignGroupToInstance(uint32 group_id, uint32 instance_id)
 	auto zone_id = GetInstanceZoneID(instance_id);
 	auto version = GetInstanceVersion(instance_id);
 
-	auto l = GroupIdRepository::GetWhere(
+	const auto& l = GroupIdRepository::GetWhere(
 		*this,
 		fmt::format(
-			"groupid = {}",
+			"`group_id` = {}",
 			group_id
 		)
 	);
+
 	if (l.empty()) {
 		return;
 	}
 
 	for (const auto& e : l) {
-		if (!GetInstanceID(zone_id, e.charid, version)) {
-			AddClientToInstance(instance_id, e.charid);
+		if (!e.character_id) {
+			continue;
+		}
+
+		if (!GetInstanceID(zone_id, e.character_id, version)) {
+			AddClientToInstance(instance_id, e.character_id);
 		}
 	}
 }

--- a/common/repositories/base/base_group_id_repository.h
+++ b/common/repositories/base/base_group_id_repository.h
@@ -20,10 +20,10 @@ class BaseGroupIdRepository {
 public:
 	struct GroupId {
 		uint32_t    group_id;
+		std::string name;
 		uint32_t    character_id;
 		uint32_t    bot_id;
-		std::string name;
-		uint8_t     is_merc;
+		uint32_t    merc_id;
 	};
 
 	static std::string PrimaryKey()
@@ -35,10 +35,10 @@ public:
 	{
 		return {
 			"group_id",
+			"name",
 			"character_id",
 			"bot_id",
-			"name",
-			"is_merc",
+			"merc_id",
 		};
 	}
 
@@ -46,10 +46,10 @@ public:
 	{
 		return {
 			"group_id",
+			"name",
 			"character_id",
 			"bot_id",
-			"name",
-			"is_merc",
+			"merc_id",
 		};
 	}
 
@@ -91,10 +91,10 @@ public:
 		GroupId e{};
 
 		e.group_id     = 0;
+		e.name         = "";
 		e.character_id = 0;
 		e.bot_id       = 0;
-		e.name         = "";
-		e.is_merc      = 0;
+		e.merc_id      = 0;
 
 		return e;
 	}
@@ -132,10 +132,10 @@ public:
 			GroupId e{};
 
 			e.group_id     = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
-			e.character_id = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
-			e.bot_id       = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
-			e.name         = row[3] ? row[3] : "";
-			e.is_merc      = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
+			e.name         = row[1] ? row[1] : "";
+			e.character_id = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.bot_id       = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
+			e.merc_id      = row[4] ? static_cast<uint32_t>(strtoul(row[4], nullptr, 10)) : 0;
 
 			return e;
 		}
@@ -170,10 +170,10 @@ public:
 		auto columns = Columns();
 
 		v.push_back(columns[0] + " = " + std::to_string(e.group_id));
-		v.push_back(columns[1] + " = " + std::to_string(e.character_id));
-		v.push_back(columns[2] + " = " + std::to_string(e.bot_id));
-		v.push_back(columns[3] + " = '" + Strings::Escape(e.name) + "'");
-		v.push_back(columns[4] + " = " + std::to_string(e.is_merc));
+		v.push_back(columns[1] + " = '" + Strings::Escape(e.name) + "'");
+		v.push_back(columns[2] + " = " + std::to_string(e.character_id));
+		v.push_back(columns[3] + " = " + std::to_string(e.bot_id));
+		v.push_back(columns[4] + " = " + std::to_string(e.merc_id));
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -196,10 +196,10 @@ public:
 		std::vector<std::string> v;
 
 		v.push_back(std::to_string(e.group_id));
+		v.push_back("'" + Strings::Escape(e.name) + "'");
 		v.push_back(std::to_string(e.character_id));
 		v.push_back(std::to_string(e.bot_id));
-		v.push_back("'" + Strings::Escape(e.name) + "'");
-		v.push_back(std::to_string(e.is_merc));
+		v.push_back(std::to_string(e.merc_id));
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -230,10 +230,10 @@ public:
 			std::vector<std::string> v;
 
 			v.push_back(std::to_string(e.group_id));
+			v.push_back("'" + Strings::Escape(e.name) + "'");
 			v.push_back(std::to_string(e.character_id));
 			v.push_back(std::to_string(e.bot_id));
-			v.push_back("'" + Strings::Escape(e.name) + "'");
-			v.push_back(std::to_string(e.is_merc));
+			v.push_back(std::to_string(e.merc_id));
 
 			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
 		}
@@ -268,10 +268,10 @@ public:
 			GroupId e{};
 
 			e.group_id     = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
-			e.character_id = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
-			e.bot_id       = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
-			e.name         = row[3] ? row[3] : "";
-			e.is_merc      = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
+			e.name         = row[1] ? row[1] : "";
+			e.character_id = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.bot_id       = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
+			e.merc_id      = row[4] ? static_cast<uint32_t>(strtoul(row[4], nullptr, 10)) : 0;
 
 			all_entries.push_back(e);
 		}
@@ -297,10 +297,10 @@ public:
 			GroupId e{};
 
 			e.group_id     = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
-			e.character_id = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
-			e.bot_id       = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
-			e.name         = row[3] ? row[3] : "";
-			e.is_merc      = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
+			e.name         = row[1] ? row[1] : "";
+			e.character_id = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.bot_id       = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
+			e.merc_id      = row[4] ? static_cast<uint32_t>(strtoul(row[4], nullptr, 10)) : 0;
 
 			all_entries.push_back(e);
 		}
@@ -376,10 +376,10 @@ public:
 		std::vector<std::string> v;
 
 		v.push_back(std::to_string(e.group_id));
+		v.push_back("'" + Strings::Escape(e.name) + "'");
 		v.push_back(std::to_string(e.character_id));
 		v.push_back(std::to_string(e.bot_id));
-		v.push_back("'" + Strings::Escape(e.name) + "'");
-		v.push_back(std::to_string(e.is_merc));
+		v.push_back(std::to_string(e.merc_id));
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -403,10 +403,10 @@ public:
 			std::vector<std::string> v;
 
 			v.push_back(std::to_string(e.group_id));
+			v.push_back("'" + Strings::Escape(e.name) + "'");
 			v.push_back(std::to_string(e.character_id));
 			v.push_back(std::to_string(e.bot_id));
-			v.push_back("'" + Strings::Escape(e.name) + "'");
-			v.push_back(std::to_string(e.is_merc));
+			v.push_back(std::to_string(e.merc_id));
 
 			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
 		}

--- a/common/repositories/base/base_group_id_repository.h
+++ b/common/repositories/base/base_group_id_repository.h
@@ -93,7 +93,7 @@ public:
 		e.group_id     = 0;
 		e.character_id = 0;
 		e.bot_id       = 0;
-		e.name         = "0";
+		e.name         = "";
 		e.is_merc      = 0;
 
 		return e;
@@ -134,7 +134,7 @@ public:
 			e.group_id     = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.character_id = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
 			e.bot_id       = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
-			e.name         = row[3] ? row[3] : "0";
+			e.name         = row[3] ? row[3] : "";
 			e.is_merc      = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
 
 			return e;
@@ -270,7 +270,7 @@ public:
 			e.group_id     = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.character_id = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
 			e.bot_id       = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
-			e.name         = row[3] ? row[3] : "0";
+			e.name         = row[3] ? row[3] : "";
 			e.is_merc      = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
 
 			all_entries.push_back(e);
@@ -299,7 +299,7 @@ public:
 			e.group_id     = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.character_id = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
 			e.bot_id       = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
-			e.name         = row[3] ? row[3] : "0";
+			e.name         = row[3] ? row[3] : "";
 			e.is_merc      = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
 
 			all_entries.push_back(e);

--- a/common/repositories/base/base_group_id_repository.h
+++ b/common/repositories/base/base_group_id_repository.h
@@ -19,34 +19,37 @@
 class BaseGroupIdRepository {
 public:
 	struct GroupId {
-		int32_t     groupid;
-		int32_t     charid;
+		uint32_t    group_id;
+		uint32_t    character_id;
+		uint32_t    bot_id;
 		std::string name;
-		int8_t      ismerc;
+		uint8_t     is_merc;
 	};
 
 	static std::string PrimaryKey()
 	{
-		return std::string("groupid");
+		return std::string("group_id");
 	}
 
 	static std::vector<std::string> Columns()
 	{
 		return {
-			"groupid",
-			"charid",
+			"group_id",
+			"character_id",
+			"bot_id",
 			"name",
-			"ismerc",
+			"is_merc",
 		};
 	}
 
 	static std::vector<std::string> SelectColumns()
 	{
 		return {
-			"groupid",
-			"charid",
+			"group_id",
+			"character_id",
+			"bot_id",
 			"name",
-			"ismerc",
+			"is_merc",
 		};
 	}
 
@@ -87,10 +90,11 @@ public:
 	{
 		GroupId e{};
 
-		e.groupid = 0;
-		e.charid  = 0;
-		e.name    = "";
-		e.ismerc  = 0;
+		e.group_id     = 0;
+		e.character_id = 0;
+		e.bot_id       = 0;
+		e.name         = "0";
+		e.is_merc      = 0;
 
 		return e;
 	}
@@ -101,7 +105,7 @@ public:
 	)
 	{
 		for (auto &group_id : group_ids) {
-			if (group_id.groupid == group_id_id) {
+			if (group_id.group_id == group_id_id) {
 				return group_id;
 			}
 		}
@@ -127,10 +131,11 @@ public:
 		if (results.RowCount() == 1) {
 			GroupId e{};
 
-			e.groupid = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
-			e.charid  = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
-			e.name    = row[2] ? row[2] : "";
-			e.ismerc  = row[3] ? static_cast<int8_t>(atoi(row[3])) : 0;
+			e.group_id     = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
+			e.character_id = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
+			e.bot_id       = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.name         = row[3] ? row[3] : "0";
+			e.is_merc      = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
 
 			return e;
 		}
@@ -164,10 +169,11 @@ public:
 
 		auto columns = Columns();
 
-		v.push_back(columns[0] + " = " + std::to_string(e.groupid));
-		v.push_back(columns[1] + " = " + std::to_string(e.charid));
-		v.push_back(columns[2] + " = '" + Strings::Escape(e.name) + "'");
-		v.push_back(columns[3] + " = " + std::to_string(e.ismerc));
+		v.push_back(columns[0] + " = " + std::to_string(e.group_id));
+		v.push_back(columns[1] + " = " + std::to_string(e.character_id));
+		v.push_back(columns[2] + " = " + std::to_string(e.bot_id));
+		v.push_back(columns[3] + " = '" + Strings::Escape(e.name) + "'");
+		v.push_back(columns[4] + " = " + std::to_string(e.is_merc));
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -175,7 +181,7 @@ public:
 				TableName(),
 				Strings::Implode(", ", v),
 				PrimaryKey(),
-				e.groupid
+				e.group_id
 			)
 		);
 
@@ -189,10 +195,11 @@ public:
 	{
 		std::vector<std::string> v;
 
-		v.push_back(std::to_string(e.groupid));
-		v.push_back(std::to_string(e.charid));
+		v.push_back(std::to_string(e.group_id));
+		v.push_back(std::to_string(e.character_id));
+		v.push_back(std::to_string(e.bot_id));
 		v.push_back("'" + Strings::Escape(e.name) + "'");
-		v.push_back(std::to_string(e.ismerc));
+		v.push_back(std::to_string(e.is_merc));
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -203,7 +210,7 @@ public:
 		);
 
 		if (results.Success()) {
-			e.groupid = results.LastInsertedID();
+			e.group_id = results.LastInsertedID();
 			return e;
 		}
 
@@ -222,10 +229,11 @@ public:
 		for (auto &e: entries) {
 			std::vector<std::string> v;
 
-			v.push_back(std::to_string(e.groupid));
-			v.push_back(std::to_string(e.charid));
+			v.push_back(std::to_string(e.group_id));
+			v.push_back(std::to_string(e.character_id));
+			v.push_back(std::to_string(e.bot_id));
 			v.push_back("'" + Strings::Escape(e.name) + "'");
-			v.push_back(std::to_string(e.ismerc));
+			v.push_back(std::to_string(e.is_merc));
 
 			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
 		}
@@ -259,10 +267,11 @@ public:
 		for (auto row = results.begin(); row != results.end(); ++row) {
 			GroupId e{};
 
-			e.groupid = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
-			e.charid  = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
-			e.name    = row[2] ? row[2] : "";
-			e.ismerc  = row[3] ? static_cast<int8_t>(atoi(row[3])) : 0;
+			e.group_id     = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
+			e.character_id = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
+			e.bot_id       = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.name         = row[3] ? row[3] : "0";
+			e.is_merc      = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
 
 			all_entries.push_back(e);
 		}
@@ -287,10 +296,11 @@ public:
 		for (auto row = results.begin(); row != results.end(); ++row) {
 			GroupId e{};
 
-			e.groupid = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
-			e.charid  = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
-			e.name    = row[2] ? row[2] : "";
-			e.ismerc  = row[3] ? static_cast<int8_t>(atoi(row[3])) : 0;
+			e.group_id     = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
+			e.character_id = row[1] ? static_cast<uint32_t>(strtoul(row[1], nullptr, 10)) : 0;
+			e.bot_id       = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
+			e.name         = row[3] ? row[3] : "0";
+			e.is_merc      = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
 
 			all_entries.push_back(e);
 		}
@@ -365,10 +375,11 @@ public:
 	{
 		std::vector<std::string> v;
 
-		v.push_back(std::to_string(e.groupid));
-		v.push_back(std::to_string(e.charid));
+		v.push_back(std::to_string(e.group_id));
+		v.push_back(std::to_string(e.character_id));
+		v.push_back(std::to_string(e.bot_id));
 		v.push_back("'" + Strings::Escape(e.name) + "'");
-		v.push_back(std::to_string(e.ismerc));
+		v.push_back(std::to_string(e.is_merc));
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -391,10 +402,11 @@ public:
 		for (auto &e: entries) {
 			std::vector<std::string> v;
 
-			v.push_back(std::to_string(e.groupid));
-			v.push_back(std::to_string(e.charid));
+			v.push_back(std::to_string(e.group_id));
+			v.push_back(std::to_string(e.character_id));
+			v.push_back(std::to_string(e.bot_id));
 			v.push_back("'" + Strings::Escape(e.name) + "'");
-			v.push_back(std::to_string(e.ismerc));
+			v.push_back(std::to_string(e.is_merc));
 
 			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
 		}

--- a/common/repositories/base/base_group_leaders_repository.h
+++ b/common/repositories/base/base_group_leaders_repository.h
@@ -105,7 +105,7 @@ public:
 		e.gid            = 0;
 		e.leadername     = "";
 		e.marknpc        = "";
-		e.leadershipaa   = 0;
+		e.leadershipaa   = "";
 		e.maintank       = "";
 		e.assist         = "";
 		e.puller         = "";
@@ -150,7 +150,7 @@ public:
 			e.gid            = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
 			e.leadername     = row[1] ? row[1] : "";
 			e.marknpc        = row[2] ? row[2] : "";
-			e.leadershipaa   = row[3] ? row[3] : 0;
+			e.leadershipaa   = row[3] ? row[3] : "";
 			e.maintank       = row[4] ? row[4] : "";
 			e.assist         = row[5] ? row[5] : "";
 			e.puller         = row[6] ? row[6] : "";
@@ -302,7 +302,7 @@ public:
 			e.gid            = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
 			e.leadername     = row[1] ? row[1] : "";
 			e.marknpc        = row[2] ? row[2] : "";
-			e.leadershipaa   = row[3] ? row[3] : 0;
+			e.leadershipaa   = row[3] ? row[3] : "";
 			e.maintank       = row[4] ? row[4] : "";
 			e.assist         = row[5] ? row[5] : "";
 			e.puller         = row[6] ? row[6] : "";
@@ -335,7 +335,7 @@ public:
 			e.gid            = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
 			e.leadername     = row[1] ? row[1] : "";
 			e.marknpc        = row[2] ? row[2] : "";
-			e.leadershipaa   = row[3] ? row[3] : 0;
+			e.leadershipaa   = row[3] ? row[3] : "";
 			e.maintank       = row[4] ? row[4] : "";
 			e.assist         = row[5] ? row[5] : "";
 			e.puller         = row[6] ? row[6] : "";

--- a/common/shared_tasks.cpp
+++ b/common/shared_tasks.cpp
@@ -60,7 +60,7 @@ SharedTaskRequest SharedTask::GetRequestCharacters(Database &db, uint32_t reques
 	request.group_type = SharedTaskRequestGroupType::Group;
 	auto characters = CharacterDataRepository::GetWhere(
 		db, fmt::format(
-			"id IN (select charid from group_id where groupid = (select groupid from group_id where charid = {}))",
+			"id IN (select charid from group_id where group_id = (select group_id from group_id where charid = {}))",
 			requested_character_id
 		)
 	);

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9266
+#define CURRENT_BINARY_DATABASE_VERSION 9267
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9043
 
 #endif

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -53,6 +53,7 @@
 #include "../common/repositories/inventory_repository.h"
 #include "../common/events/player_event_logs.h"
 #include "../common/content/world_content_service.h"
+#include "../common/repositories/group_id_repository.h"
 
 #include <iostream>
 #include <iomanip>
@@ -881,7 +882,14 @@ bool Client::HandleEnterWorldPacket(const EQApplicationPacket *app) {
 	}
 
 	if(!is_player_zoning) {
-		database.SetGroupID(char_name, 0, charid);
+		GroupIdRepository::DeleteWhere(
+			database,
+			fmt::format(
+				"`character_id` = {} AND `name` = '{}'",
+				charid,
+				Strings::Escape(char_name)
+			)
+		);
 		database.SetLoginFlags(charid, false, false, 1);
 	} else {
 		auto group_id = database.GetGroupID(char_name);

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -3343,7 +3343,7 @@ void Bot::LoadAndSpawnAllZonedBots(Client* bot_owner) {
 					}
 
 					if (bot_spawn_limit >= 0 && spawned_bots_count >= bot_spawn_limit) {
-						database.SetGroupID(b->GetCleanName(), 0, 0, b->GetBotID());
+						Group::RemoveFromGroup(b);
 						g->UpdatePlayer(bot_owner);
 						continue;
 					}
@@ -3355,7 +3355,7 @@ void Bot::LoadAndSpawnAllZonedBots(Client* bot_owner) {
 						bot_spawn_limit_class >= 0 &&
 						spawned_bot_count_class >= bot_spawn_limit_class
 					) {
-						database.SetGroupID(b->GetCleanName(), 0, 0, b->GetBotID());
+						Group::RemoveFromGroup(b);
 						g->UpdatePlayer(bot_owner);
 						continue;
 					}
@@ -3375,7 +3375,7 @@ void Bot::LoadAndSpawnAllZonedBots(Client* bot_owner) {
 					}
 
 					if (!bot_owner->HasGroup()) {
-						database.SetGroupID(b->GetCleanName(), 0, 0, b->GetBotID());
+						Group::RemoveFromGroup(b);
 					}
 				}
 			}
@@ -3646,7 +3646,7 @@ bool Bot::RemoveBotFromGroup(Bot* bot, Group* group) {
 				group->members[i]->SetFollowID(0);
 			}
 			group->DisbandGroup();
-			database.SetGroupID(bot->GetCleanName(), 0, 0, bot->GetBotID());
+			Group::RemoveFromGroup(bot);
 		}
 		Result = true;
 	}
@@ -6600,14 +6600,14 @@ void Bot::ProcessBotGroupInvite(Client* c, std::string const& botName) {
 					entity_list.AddGroup(g);
 					database.SetGroupLeaderName(g->GetID(), c->GetName());
 					g->SaveGroupLeaderAA();
-					database.SetGroupID(c->GetName(), g->GetID(), c->CharacterID());
-					database.SetGroupID(invitedBot->GetCleanName(), g->GetID(), 0, invitedBot->GetBotID());
+					g->AddToGroup(c);
+					g->AddToGroup(invitedBot);
 				} else {
 					delete g;
 				}
 			} else {
 				if (AddBotToGroup(invitedBot, c->GetGroup())) {
-					database.SetGroupID(invitedBot->GetCleanName(), c->GetGroup()->GetID(), 0, invitedBot->GetBotID());
+					c->GetGroup()->AddToGroup(invitedBot);
 				}
 			}
 		} else if (invitedBot->HasGroup()) {

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -3343,7 +3343,7 @@ void Bot::LoadAndSpawnAllZonedBots(Client* bot_owner) {
 					}
 
 					if (bot_spawn_limit >= 0 && spawned_bots_count >= bot_spawn_limit) {
-						database.SetGroupID(b->GetCleanName(), 0, b->GetBotID());
+						database.SetGroupID(b->GetCleanName(), 0, 0, b->GetBotID());
 						g->UpdatePlayer(bot_owner);
 						continue;
 					}
@@ -3355,7 +3355,7 @@ void Bot::LoadAndSpawnAllZonedBots(Client* bot_owner) {
 						bot_spawn_limit_class >= 0 &&
 						spawned_bot_count_class >= bot_spawn_limit_class
 					) {
-						database.SetGroupID(b->GetCleanName(), 0, b->GetBotID());
+						database.SetGroupID(b->GetCleanName(), 0, 0, b->GetBotID());
 						g->UpdatePlayer(bot_owner);
 						continue;
 					}
@@ -3375,7 +3375,7 @@ void Bot::LoadAndSpawnAllZonedBots(Client* bot_owner) {
 					}
 
 					if (!bot_owner->HasGroup()) {
-						database.SetGroupID(b->GetCleanName(), 0, b->GetBotID());
+						database.SetGroupID(b->GetCleanName(), 0, 0, b->GetBotID());
 					}
 				}
 			}
@@ -3632,7 +3632,7 @@ bool Bot::RemoveBotFromGroup(Bot* bot, Group* group) {
 			bot->SetFollowID(0);
 			if (group->DelMember(bot)) {
 				group->DelMemberOOZ(bot->GetName());
-				database.SetGroupID(bot->GetCleanName(), 0, bot->GetBotID());
+				Group::RemoveFromGroup(bot);
 				if (group->GroupCount() < 2) {
 					group->DisbandGroup();
 				}
@@ -3646,7 +3646,7 @@ bool Bot::RemoveBotFromGroup(Bot* bot, Group* group) {
 				group->members[i]->SetFollowID(0);
 			}
 			group->DisbandGroup();
-			database.SetGroupID(bot->GetCleanName(), 0, bot->GetBotID());
+			database.SetGroupID(bot->GetCleanName(), 0, 0, bot->GetBotID());
 		}
 		Result = true;
 	}
@@ -6601,13 +6601,13 @@ void Bot::ProcessBotGroupInvite(Client* c, std::string const& botName) {
 					database.SetGroupLeaderName(g->GetID(), c->GetName());
 					g->SaveGroupLeaderAA();
 					database.SetGroupID(c->GetName(), g->GetID(), c->CharacterID());
-					database.SetGroupID(invitedBot->GetCleanName(), g->GetID(), invitedBot->GetBotID());
+					database.SetGroupID(invitedBot->GetCleanName(), g->GetID(), 0, invitedBot->GetBotID());
 				} else {
 					delete g;
 				}
 			} else {
 				if (AddBotToGroup(invitedBot, c->GetGroup())) {
-					database.SetGroupID(invitedBot->GetCleanName(), c->GetGroup()->GetID(), invitedBot->GetBotID());
+					database.SetGroupID(invitedBot->GetCleanName(), c->GetGroup()->GetID(), 0, invitedBot->GetBotID());
 				}
 			}
 		} else if (invitedBot->HasGroup()) {

--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -1922,18 +1922,14 @@ bool BotDatabase::LoadGroupedBotsByGroupID(const uint32 owner_id, const uint32 g
 	const auto& l = GroupIdRepository::GetWhere(
 		database,
 		fmt::format(
-			"`groupid` = {} AND `name` IN (SELECT `name` FROM `bot_data` WHERE `owner_id` = {})",
+			"`group_id` = {} AND `bot_id` != 0 AND `name` IN (SELECT `name` FROM `bot_data` WHERE `owner_id` = {})",
 			group_id,
 			owner_id
 		)
 	);
 
-	if (l.empty()) {
-		return true;
-	}
-
 	for (const auto& e : l) {
-		group_list.push_back(e.charid);
+		group_list.emplace_back(e.bot_id);
 	}
 
 	return true;

--- a/zone/bot_raid.cpp
+++ b/zone/bot_raid.cpp
@@ -98,7 +98,7 @@ void Raid::HandleBotGroupDisband(uint32 owner, uint32 gid)
 			auto r_group_members = GetRaidGroupMembers(GetGroup(b->GetName()));
 			auto g = new Group(b);
 			entity_list.AddGroup(g);
-			database.SetGroupID(b->GetCleanName(), g->GetID(), b->GetBotID());
+			database.SetGroupID(b->GetCleanName(), g->GetID(), 0, b->GetBotID());
 			database.SetGroupLeaderName(g->GetID(), b->GetName());
 
 			for (auto m: r_group_members) {

--- a/zone/bot_raid.cpp
+++ b/zone/bot_raid.cpp
@@ -98,7 +98,7 @@ void Raid::HandleBotGroupDisband(uint32 owner, uint32 gid)
 			auto r_group_members = GetRaidGroupMembers(GetGroup(b->GetName()));
 			auto g = new Group(b);
 			entity_list.AddGroup(g);
-			database.SetGroupID(b->GetCleanName(), g->GetID(), 0, b->GetBotID());
+			g->AddToGroup(b);
 			database.SetGroupLeaderName(g->GetID(), b->GetName());
 
 			for (auto m: r_group_members) {

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -4442,7 +4442,7 @@ bool Client::GroupFollow(Client* inviter) {
 			}
 
 			//now we have a group id, can set inviter's id
-			database.SetGroupID(inviter->GetName(), group->GetID(), inviter->CharacterID(), false);
+			database.SetGroupID(inviter->GetName(), group->GetID(), inviter->CharacterID());
 			database.SetGroupLeaderName(group->GetID(), inviter->GetName());
 			group->UpdateGroupAAs();
 

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -4442,7 +4442,7 @@ bool Client::GroupFollow(Client* inviter) {
 			}
 
 			//now we have a group id, can set inviter's id
-			database.SetGroupID(inviter->GetName(), group->GetID(), inviter->CharacterID());
+			group->AddToGroup(inviter);
 			database.SetGroupLeaderName(group->GetID(), inviter->GetName());
 			group->UpdateGroupAAs();
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1531,7 +1531,7 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 		}	//else, somebody from our group is already here...
 
 		if (!group)
-			database.SetGroupID(GetName(), 0, CharacterID(), false);	//cannot re-establish group, kill it
+			database.SetGroupID(GetName(), 0, CharacterID());	//cannot re-establish group, kill it
 
 	}
 	else {	//no group id
@@ -7189,7 +7189,7 @@ void Client::Handle_OP_GroupCancelInvite(const EQApplicationPacket *app)
 
 	if (!GetMerc())
 	{
-		database.SetGroupID(GetName(), 0, CharacterID(), false);
+		database.SetGroupID(GetName(), 0, CharacterID());
 	}
 	return;
 }

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1530,8 +1530,9 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 			}
 		}	//else, somebody from our group is already here...
 
-		if (!group)
-			database.SetGroupID(GetName(), 0, CharacterID());	//cannot re-establish group, kill it
+		if (!group) { //cannot re-establish group, kill it
+			Group::RemoveFromGroup(this);
+		}
 
 	}
 	else {	//no group id
@@ -7189,7 +7190,7 @@ void Client::Handle_OP_GroupCancelInvite(const EQApplicationPacket *app)
 
 	if (!GetMerc())
 	{
-		database.SetGroupID(GetName(), 0, CharacterID());
+		Group::RemoveFromGroup(this);
 	}
 	return;
 }

--- a/zone/groups.h
+++ b/zone/groups.h
@@ -52,6 +52,13 @@ public:
 	Group(uint32 gid);
 	~Group();
 
+	struct AddToGroupRequest {
+		Mob* mob = nullptr;
+		// Only used cross-zone, otherwise use Mob* mob
+		std::string member_name  = std::string();
+		uint32      character_id = 0;
+	};
+
 	bool	AddMember(Mob* new_member, std::string new_member_name = std::string(), uint32 character_id = 0, bool is_merc = false);
 	void	AddMember(const std::string& new_member_name);
 	void	SendUpdate(uint32 type,Mob* member);
@@ -145,6 +152,9 @@ public:
 	void	SetDirtyAutoHaters();
 	inline XTargetAutoHaters *GetXTargetAutoMgr() { return &m_autohatermgr; }
 	void	JoinRaidXTarget(Raid *raid, bool first = false);
+	void	AddToGroup(AddToGroupRequest r);
+	void	AddToGroup(Mob* m);
+	static void	RemoveFromGroup(Mob* m);
 
 	void SetGroupMentor(int percent, char *name);
 	void ClearGroupMentor();

--- a/zone/groups.h
+++ b/zone/groups.h
@@ -52,8 +52,8 @@ public:
 	Group(uint32 gid);
 	~Group();
 
-	bool	AddMember(Mob* newmember, const char* NewMemberName = nullptr, uint32 CharacterID = 0, bool ismerc = false);
-	void	AddMember(const char* NewMemberName);
+	bool	AddMember(Mob* new_member, std::string new_member_name = std::string(), uint32 character_id = 0, bool is_merc = false);
+	void	AddMember(const std::string& new_member_name);
 	void	SendUpdate(uint32 type,Mob* member);
 	void	SendLeadershipAAUpdate();
 	void	SendWorldGroup(uint32 zone_id,Mob* zoningmember);

--- a/zone/merc.cpp
+++ b/zone/merc.cpp
@@ -5377,7 +5377,7 @@ bool Merc::RemoveMercFromGroup(Merc* merc, Group* group) {
 				{
 					if(merc->GetMercenaryCharacterID() != 0)
 					{
-						database.SetGroupID(merc->GetName(), 0, merc->GetMercenaryCharacterID(), true);
+						Group::RemoveFromGroup(merc);
 					}
 				}
 			}
@@ -5462,7 +5462,7 @@ bool Merc::MercJoinClientGroup() {
 
 			if (AddMercToGroup(this, g))
 			{
-				database.SetGroupID(mercOwner->GetName(), g->GetID(), mercOwner->CharacterID());
+				g->AddToGroup(mercOwner);
 				database.SetGroupLeaderName(g->GetID(), mercOwner->GetName());
 				database.RefreshGroupFromDB(mercOwner);
 				g->SaveGroupLeaderAA();

--- a/zone/merc.cpp
+++ b/zone/merc.cpp
@@ -5462,7 +5462,7 @@ bool Merc::MercJoinClientGroup() {
 
 			if (AddMercToGroup(this, g))
 			{
-				database.SetGroupID(mercOwner->GetName(), g->GetID(), mercOwner->CharacterID(), false);
+				database.SetGroupID(mercOwner->GetName(), g->GetID(), mercOwner->CharacterID());
 				database.SetGroupLeaderName(g->GetID(), mercOwner->GetName());
 				database.RefreshGroupFromDB(mercOwner);
 				g->SaveGroupLeaderAA();

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -1092,7 +1092,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 					break;
 				}
 
-				database.SetGroupID(Inviter->GetName(), group->GetID(), Inviter->CastToClient()->CharacterID(), false);
+				database.SetGroupID(Inviter->GetName(), group->GetID(), Inviter->CastToClient()->CharacterID());
 				database.SetGroupLeaderName(group->GetID(), Inviter->GetName());
 				group->UpdateGroupAAs();
 
@@ -1194,7 +1194,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 			{
 				if (client->GetMerc())
 					database.SetGroupID(client->GetMerc()->GetCleanName(), 0, client->CharacterID(), true);
-				database.SetGroupID(client->GetName(), 0, client->CharacterID(), false);	//cannot re-establish group, kill it
+				database.SetGroupID(client->GetName(), 0, client->CharacterID());	//cannot re-establish group, kill it
 			}
 
 		}

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -1092,7 +1092,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 					break;
 				}
 
-				database.SetGroupID(Inviter->GetName(), group->GetID(), Inviter->CastToClient()->CharacterID());
+				group->AddToGroup(Inviter);
 				database.SetGroupLeaderName(group->GetID(), Inviter->GetName());
 				group->UpdateGroupAAs();
 
@@ -1192,9 +1192,11 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 				group->UpdatePlayer(client);
 			else
 			{
-				if (client->GetMerc())
-					database.SetGroupID(client->GetMerc()->GetCleanName(), 0, client->CharacterID(), true);
-				database.SetGroupID(client->GetName(), 0, client->CharacterID());	//cannot re-establish group, kill it
+				if (client->GetMerc()) {
+					Group::RemoveFromGroup(client->GetMerc());
+				}
+
+				Group::RemoveFromGroup(client);	//cannot re-establish group, kill it
 			}
 
 		}

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -2649,7 +2649,7 @@ void ZoneDatabase::RefreshGroupFromDB(Client *client){
 	int index = 0;
 
 	auto query = fmt::format(
-		"SELECT name FROM group_id WHERE groupid = {}",
+		"SELECT name FROM group_id WHERE group_id = {}",
 		group->GetID()
 	);
 	auto results = QueryDatabase(query);


### PR DESCRIPTION
# Notes
- Attempt to fix bot/character ID overlap in groups keeping bots with the same unique identifier as players from not spawning on zone.
- Adds `bot_id` to `group_id` to differentiate bots from characters and hopefully alleviate this issue.