### PR TITLE
[Quest API] Add spell cast methods to Lua

### DIFF
--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -313,12 +313,12 @@ int Perl__getinventoryslotid(std::string identifier)
 	return result;
 }
 
-void Perl__castspell(int spell_id, int target_id)
+void Perl__castspell(uint16 spell_id, uint16 target_id)
 {
 	quest_manager.castspell(spell_id, target_id);
 }
 
-void Perl__selfcast(int spell_id)
+void Perl__selfcast(uint16 spell_id)
 {
 	quest_manager.selfcast(spell_id);
 }

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -5406,6 +5406,16 @@ std::string lua_convert_money_to_string(luabind::adl::object table)
 	return Strings::Money(platinum, gold, silver, copper);
 }
 
+void lua_cast_spell(uint16 spell_id, uint16 target_id)
+{
+	quest_manager.castspell(spell_id, target_id);
+}
+
+void lua_self_cast(uint16 spell_id)
+{
+	quest_manager.selfcast(spell_id);
+}
+
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
 	cur = table[#name]; \
 	if(luabind::type(cur) != LUA_TNIL) { \
@@ -6187,6 +6197,8 @@ luabind::scope lua_register_general() {
 		luabind::def("get_spell_resurrection_sickness_check", &lua_get_spell_resurrection_sickness_check),
 		luabind::def("get_spell_nimbus_effect", &lua_get_spell_nimbus_effect),
 		luabind::def("convert_money_to_string", &lua_convert_money_to_string),
+		luabind::def("cast_spell", &lua_cast_spell),
+		luabind::def("self_cast", &lua_self_cast),
 		/*
 			Cross Zone
 		*/

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -396,19 +396,39 @@ void QuestManager::incstat(int stat, int value) {
 		initiator->IncStats(stat, value);
 }
 
-void QuestManager::castspell(int spell_id, int target_id) {
+void QuestManager::castspell(uint16 spell_id, uint16 target_id)
+{
 	QuestManagerCurrentQuestVars();
+
 	if (owner) {
-		Mob *tgt = entity_list.GetMob(target_id);
-		if(tgt != nullptr)
-			owner->SpellFinished(spell_id, tgt, EQ::spells::CastingSlot::Item, 0, -1, spells[spell_id].resist_difficulty);
+		Mob* t = entity_list.GetMob(target_id);
+		if (t) {
+			owner->SpellFinished(
+				spell_id,
+				t,
+				EQ::spells::CastingSlot::Item,
+				0,
+				-1,
+				spells[spell_id].resist_difficulty
+			);
+		}
 	}
 }
 
-void QuestManager::selfcast(int spell_id) {
+void QuestManager::selfcast(uint16 spell_id)
+{
 	QuestManagerCurrentQuestVars();
-	if (initiator)
-		initiator->SpellFinished(spell_id, initiator, EQ::spells::CastingSlot::Item, 0, -1, spells[spell_id].resist_difficulty);
+
+	if (initiator) {
+		initiator->SpellFinished(
+			spell_id,
+			initiator,
+			EQ::spells::CastingSlot::Item,
+			0,
+			-1,
+			spells[spell_id].resist_difficulty
+		);
+	}
 }
 
 void QuestManager::addloot(

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -75,8 +75,8 @@ public:
 	void disable_spawn2(uint32 spawn2_id);
 	void setstat(int stat, int value);
 	void incstat(int stat, int value);
-	void castspell(int spell_id, int target_id);
-	void selfcast(int spell_id);
+	void castspell(uint16 spell_id, uint16 target_id);
+	void selfcast(uint16 spell_id);
 	void addloot(int item_id, int charges = 0, bool equipitem = true, int aug1 = 0, int aug2 = 0, int aug3 = 0, int aug4 = 0, int aug5 = 0, int aug6 = 0);
 	void Zone(const char *zone_name);
 	void ZoneGroup(const char *zone_name);


### PR DESCRIPTION
# Notes
- Add `eq.cast_spell(spell_id, target_id)` and `eq.self_cast(spell_id)` to Lua.
- Lua did not have `quest::castspell(spell_id, target_id)` or `quest::selfcast(spell_id)` equivalents, so this adds them.