### PR TITLE
[Feature] Add Augments to Starting Items for Bots/Players

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -5408,7 +5408,8 @@ ADD COLUMN `augment_three` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `augment_tw
 ADD COLUMN `augment_four` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `augment_three`,
 ADD COLUMN `augment_five` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `augment_four`,
 ADD COLUMN `augment_six` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `augment_five`;
-		)"
+		)",
+		.content_schema_update = true
 	}
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{

--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -5393,6 +5393,22 @@ MODIFY COLUMN `safe_z` float NOT NULL DEFAULT 0 AFTER `safe_y`,
 MODIFY COLUMN `safe_heading` float NOT NULL DEFAULT 0 AFTER `safe_z`;
 		)",
 		.content_schema_update = true
+	},
+	ManifestEntry{
+		.version = 9264,
+		.description = "2024_02_18_starting_items_augments.sql",
+		.check = "SHOW COLUMNS FROM `starting_items` LIKE 'augment_one'",
+		.condition = "empty",
+		.match = "",
+		.sql = R"(
+ALTER TABLE `starting_items`
+ADD COLUMN `augment_one` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `item_charges`,
+ADD COLUMN `augment_two` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `augment_one`,
+ADD COLUMN `augment_three` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `augment_two`,
+ADD COLUMN `augment_four` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `augment_three`,
+ADD COLUMN `augment_five` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `augment_four`,
+ADD COLUMN `augment_six` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `augment_five`;
+		)"
 	}
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{

--- a/common/database/database_update_manifest_bots.cpp
+++ b/common/database/database_update_manifest_bots.cpp
@@ -124,6 +124,22 @@ ALTER TABLE `bot_pet_buffs` DROP FOREIGN KEY `FK_bot_pet_buffs_1`;
 ALTER TABLE `bot_pet_inventories` DROP FOREIGN KEY `FK_bot_pet_inventories_1`;
 ALTER TABLE `bot_stances` DROP FOREIGN KEY `FK_bot_stances_1`;
 )"
+	},
+	ManifestEntry{
+		.version = 9043,
+		.description = "2024_02_18_bot_starting_items_augments.sql",
+		.check = "SHOW COLUMNS FROM `bot_starting_items` LIKE 'augment_one'",
+		.condition = "empty",
+		.match = "",
+		.sql = R"(
+ALTER TABLE `bot_starting_items`
+ADD COLUMN `augment_one` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `item_charges`,
+ADD COLUMN `augment_two` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `augment_one`,
+ADD COLUMN `augment_three` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `augment_two`,
+ADD COLUMN `augment_four` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `augment_three`,
+ADD COLUMN `augment_five` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `augment_four`,
+ADD COLUMN `augment_six` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `augment_five`;
+)"
 	}
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{

--- a/common/repositories/base/base_bot_starting_items_repository.h
+++ b/common/repositories/base/base_bot_starting_items_repository.h
@@ -24,6 +24,12 @@ public:
 		uint32_t    classes;
 		uint32_t    item_id;
 		uint8_t     item_charges;
+		uint32_t    augment_one;
+		uint32_t    augment_two;
+		uint32_t    augment_three;
+		uint32_t    augment_four;
+		uint32_t    augment_five;
+		uint32_t    augment_six;
 		uint8_t     min_status;
 		int32_t     slot_id;
 		int8_t      min_expansion;
@@ -45,6 +51,12 @@ public:
 			"classes",
 			"item_id",
 			"item_charges",
+			"augment_one",
+			"augment_two",
+			"augment_three",
+			"augment_four",
+			"augment_five",
+			"augment_six",
 			"min_status",
 			"slot_id",
 			"min_expansion",
@@ -62,6 +74,12 @@ public:
 			"classes",
 			"item_id",
 			"item_charges",
+			"augment_one",
+			"augment_two",
+			"augment_three",
+			"augment_four",
+			"augment_five",
+			"augment_six",
 			"min_status",
 			"slot_id",
 			"min_expansion",
@@ -113,6 +131,12 @@ public:
 		e.classes                = 0;
 		e.item_id                = 0;
 		e.item_charges           = 1;
+		e.augment_one            = 0;
+		e.augment_two            = 0;
+		e.augment_three          = 0;
+		e.augment_four           = 0;
+		e.augment_five           = 0;
+		e.augment_six            = 0;
 		e.min_status             = 0;
 		e.slot_id                = -1;
 		e.min_expansion          = -1;
@@ -160,12 +184,18 @@ public:
 			e.classes                = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
 			e.item_id                = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.item_charges           = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 1;
-			e.min_status             = row[5] ? static_cast<uint8_t>(strtoul(row[5], nullptr, 10)) : 0;
-			e.slot_id                = row[6] ? static_cast<int32_t>(atoi(row[6])) : -1;
-			e.min_expansion          = row[7] ? static_cast<int8_t>(atoi(row[7])) : -1;
-			e.max_expansion          = row[8] ? static_cast<int8_t>(atoi(row[8])) : -1;
-			e.content_flags          = row[9] ? row[9] : "";
-			e.content_flags_disabled = row[10] ? row[10] : "";
+			e.augment_one            = row[5] ? static_cast<uint32_t>(strtoul(row[5], nullptr, 10)) : 0;
+			e.augment_two            = row[6] ? static_cast<uint32_t>(strtoul(row[6], nullptr, 10)) : 0;
+			e.augment_three          = row[7] ? static_cast<uint32_t>(strtoul(row[7], nullptr, 10)) : 0;
+			e.augment_four           = row[8] ? static_cast<uint32_t>(strtoul(row[8], nullptr, 10)) : 0;
+			e.augment_five           = row[9] ? static_cast<uint32_t>(strtoul(row[9], nullptr, 10)) : 0;
+			e.augment_six            = row[10] ? static_cast<uint32_t>(strtoul(row[10], nullptr, 10)) : 0;
+			e.min_status             = row[11] ? static_cast<uint8_t>(strtoul(row[11], nullptr, 10)) : 0;
+			e.slot_id                = row[12] ? static_cast<int32_t>(atoi(row[12])) : -1;
+			e.min_expansion          = row[13] ? static_cast<int8_t>(atoi(row[13])) : -1;
+			e.max_expansion          = row[14] ? static_cast<int8_t>(atoi(row[14])) : -1;
+			e.content_flags          = row[15] ? row[15] : "";
+			e.content_flags_disabled = row[16] ? row[16] : "";
 
 			return e;
 		}
@@ -203,12 +233,18 @@ public:
 		v.push_back(columns[2] + " = " + std::to_string(e.classes));
 		v.push_back(columns[3] + " = " + std::to_string(e.item_id));
 		v.push_back(columns[4] + " = " + std::to_string(e.item_charges));
-		v.push_back(columns[5] + " = " + std::to_string(e.min_status));
-		v.push_back(columns[6] + " = " + std::to_string(e.slot_id));
-		v.push_back(columns[7] + " = " + std::to_string(e.min_expansion));
-		v.push_back(columns[8] + " = " + std::to_string(e.max_expansion));
-		v.push_back(columns[9] + " = '" + Strings::Escape(e.content_flags) + "'");
-		v.push_back(columns[10] + " = '" + Strings::Escape(e.content_flags_disabled) + "'");
+		v.push_back(columns[5] + " = " + std::to_string(e.augment_one));
+		v.push_back(columns[6] + " = " + std::to_string(e.augment_two));
+		v.push_back(columns[7] + " = " + std::to_string(e.augment_three));
+		v.push_back(columns[8] + " = " + std::to_string(e.augment_four));
+		v.push_back(columns[9] + " = " + std::to_string(e.augment_five));
+		v.push_back(columns[10] + " = " + std::to_string(e.augment_six));
+		v.push_back(columns[11] + " = " + std::to_string(e.min_status));
+		v.push_back(columns[12] + " = " + std::to_string(e.slot_id));
+		v.push_back(columns[13] + " = " + std::to_string(e.min_expansion));
+		v.push_back(columns[14] + " = " + std::to_string(e.max_expansion));
+		v.push_back(columns[15] + " = '" + Strings::Escape(e.content_flags) + "'");
+		v.push_back(columns[16] + " = '" + Strings::Escape(e.content_flags_disabled) + "'");
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -235,6 +271,12 @@ public:
 		v.push_back(std::to_string(e.classes));
 		v.push_back(std::to_string(e.item_id));
 		v.push_back(std::to_string(e.item_charges));
+		v.push_back(std::to_string(e.augment_one));
+		v.push_back(std::to_string(e.augment_two));
+		v.push_back(std::to_string(e.augment_three));
+		v.push_back(std::to_string(e.augment_four));
+		v.push_back(std::to_string(e.augment_five));
+		v.push_back(std::to_string(e.augment_six));
 		v.push_back(std::to_string(e.min_status));
 		v.push_back(std::to_string(e.slot_id));
 		v.push_back(std::to_string(e.min_expansion));
@@ -275,6 +317,12 @@ public:
 			v.push_back(std::to_string(e.classes));
 			v.push_back(std::to_string(e.item_id));
 			v.push_back(std::to_string(e.item_charges));
+			v.push_back(std::to_string(e.augment_one));
+			v.push_back(std::to_string(e.augment_two));
+			v.push_back(std::to_string(e.augment_three));
+			v.push_back(std::to_string(e.augment_four));
+			v.push_back(std::to_string(e.augment_five));
+			v.push_back(std::to_string(e.augment_six));
 			v.push_back(std::to_string(e.min_status));
 			v.push_back(std::to_string(e.slot_id));
 			v.push_back(std::to_string(e.min_expansion));
@@ -319,12 +367,18 @@ public:
 			e.classes                = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
 			e.item_id                = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.item_charges           = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 1;
-			e.min_status             = row[5] ? static_cast<uint8_t>(strtoul(row[5], nullptr, 10)) : 0;
-			e.slot_id                = row[6] ? static_cast<int32_t>(atoi(row[6])) : -1;
-			e.min_expansion          = row[7] ? static_cast<int8_t>(atoi(row[7])) : -1;
-			e.max_expansion          = row[8] ? static_cast<int8_t>(atoi(row[8])) : -1;
-			e.content_flags          = row[9] ? row[9] : "";
-			e.content_flags_disabled = row[10] ? row[10] : "";
+			e.augment_one            = row[5] ? static_cast<uint32_t>(strtoul(row[5], nullptr, 10)) : 0;
+			e.augment_two            = row[6] ? static_cast<uint32_t>(strtoul(row[6], nullptr, 10)) : 0;
+			e.augment_three          = row[7] ? static_cast<uint32_t>(strtoul(row[7], nullptr, 10)) : 0;
+			e.augment_four           = row[8] ? static_cast<uint32_t>(strtoul(row[8], nullptr, 10)) : 0;
+			e.augment_five           = row[9] ? static_cast<uint32_t>(strtoul(row[9], nullptr, 10)) : 0;
+			e.augment_six            = row[10] ? static_cast<uint32_t>(strtoul(row[10], nullptr, 10)) : 0;
+			e.min_status             = row[11] ? static_cast<uint8_t>(strtoul(row[11], nullptr, 10)) : 0;
+			e.slot_id                = row[12] ? static_cast<int32_t>(atoi(row[12])) : -1;
+			e.min_expansion          = row[13] ? static_cast<int8_t>(atoi(row[13])) : -1;
+			e.max_expansion          = row[14] ? static_cast<int8_t>(atoi(row[14])) : -1;
+			e.content_flags          = row[15] ? row[15] : "";
+			e.content_flags_disabled = row[16] ? row[16] : "";
 
 			all_entries.push_back(e);
 		}
@@ -354,12 +408,18 @@ public:
 			e.classes                = row[2] ? static_cast<uint32_t>(strtoul(row[2], nullptr, 10)) : 0;
 			e.item_id                = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.item_charges           = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 1;
-			e.min_status             = row[5] ? static_cast<uint8_t>(strtoul(row[5], nullptr, 10)) : 0;
-			e.slot_id                = row[6] ? static_cast<int32_t>(atoi(row[6])) : -1;
-			e.min_expansion          = row[7] ? static_cast<int8_t>(atoi(row[7])) : -1;
-			e.max_expansion          = row[8] ? static_cast<int8_t>(atoi(row[8])) : -1;
-			e.content_flags          = row[9] ? row[9] : "";
-			e.content_flags_disabled = row[10] ? row[10] : "";
+			e.augment_one            = row[5] ? static_cast<uint32_t>(strtoul(row[5], nullptr, 10)) : 0;
+			e.augment_two            = row[6] ? static_cast<uint32_t>(strtoul(row[6], nullptr, 10)) : 0;
+			e.augment_three          = row[7] ? static_cast<uint32_t>(strtoul(row[7], nullptr, 10)) : 0;
+			e.augment_four           = row[8] ? static_cast<uint32_t>(strtoul(row[8], nullptr, 10)) : 0;
+			e.augment_five           = row[9] ? static_cast<uint32_t>(strtoul(row[9], nullptr, 10)) : 0;
+			e.augment_six            = row[10] ? static_cast<uint32_t>(strtoul(row[10], nullptr, 10)) : 0;
+			e.min_status             = row[11] ? static_cast<uint8_t>(strtoul(row[11], nullptr, 10)) : 0;
+			e.slot_id                = row[12] ? static_cast<int32_t>(atoi(row[12])) : -1;
+			e.min_expansion          = row[13] ? static_cast<int8_t>(atoi(row[13])) : -1;
+			e.max_expansion          = row[14] ? static_cast<int8_t>(atoi(row[14])) : -1;
+			e.content_flags          = row[15] ? row[15] : "";
+			e.content_flags_disabled = row[16] ? row[16] : "";
 
 			all_entries.push_back(e);
 		}
@@ -439,6 +499,12 @@ public:
 		v.push_back(std::to_string(e.classes));
 		v.push_back(std::to_string(e.item_id));
 		v.push_back(std::to_string(e.item_charges));
+		v.push_back(std::to_string(e.augment_one));
+		v.push_back(std::to_string(e.augment_two));
+		v.push_back(std::to_string(e.augment_three));
+		v.push_back(std::to_string(e.augment_four));
+		v.push_back(std::to_string(e.augment_five));
+		v.push_back(std::to_string(e.augment_six));
 		v.push_back(std::to_string(e.min_status));
 		v.push_back(std::to_string(e.slot_id));
 		v.push_back(std::to_string(e.min_expansion));
@@ -472,6 +538,12 @@ public:
 			v.push_back(std::to_string(e.classes));
 			v.push_back(std::to_string(e.item_id));
 			v.push_back(std::to_string(e.item_charges));
+			v.push_back(std::to_string(e.augment_one));
+			v.push_back(std::to_string(e.augment_two));
+			v.push_back(std::to_string(e.augment_three));
+			v.push_back(std::to_string(e.augment_four));
+			v.push_back(std::to_string(e.augment_five));
+			v.push_back(std::to_string(e.augment_six));
 			v.push_back(std::to_string(e.min_status));
 			v.push_back(std::to_string(e.slot_id));
 			v.push_back(std::to_string(e.min_expansion));

--- a/common/repositories/base/base_starting_items_repository.h
+++ b/common/repositories/base/base_starting_items_repository.h
@@ -26,6 +26,12 @@ public:
 		std::string zone_id_list;
 		uint32_t    item_id;
 		uint8_t     item_charges;
+		uint32_t    augment_one;
+		uint32_t    augment_two;
+		uint32_t    augment_three;
+		uint32_t    augment_four;
+		uint32_t    augment_five;
+		uint32_t    augment_six;
 		int32_t     status;
 		int32_t     inventory_slot;
 		int8_t      min_expansion;
@@ -49,6 +55,12 @@ public:
 			"zone_id_list",
 			"item_id",
 			"item_charges",
+			"augment_one",
+			"augment_two",
+			"augment_three",
+			"augment_four",
+			"augment_five",
+			"augment_six",
 			"status",
 			"inventory_slot",
 			"min_expansion",
@@ -68,6 +80,12 @@ public:
 			"zone_id_list",
 			"item_id",
 			"item_charges",
+			"augment_one",
+			"augment_two",
+			"augment_three",
+			"augment_four",
+			"augment_five",
+			"augment_six",
 			"status",
 			"inventory_slot",
 			"min_expansion",
@@ -121,6 +139,12 @@ public:
 		e.zone_id_list           = "";
 		e.item_id                = 0;
 		e.item_charges           = 1;
+		e.augment_one            = 0;
+		e.augment_two            = 0;
+		e.augment_three          = 0;
+		e.augment_four           = 0;
+		e.augment_five           = 0;
+		e.augment_six            = 0;
 		e.status                 = 0;
 		e.inventory_slot         = -1;
 		e.min_expansion          = -1;
@@ -170,12 +194,18 @@ public:
 			e.zone_id_list           = row[4] ? row[4] : "";
 			e.item_id                = row[5] ? static_cast<uint32_t>(strtoul(row[5], nullptr, 10)) : 0;
 			e.item_charges           = row[6] ? static_cast<uint8_t>(strtoul(row[6], nullptr, 10)) : 1;
-			e.status                 = row[7] ? static_cast<int32_t>(atoi(row[7])) : 0;
-			e.inventory_slot         = row[8] ? static_cast<int32_t>(atoi(row[8])) : -1;
-			e.min_expansion          = row[9] ? static_cast<int8_t>(atoi(row[9])) : -1;
-			e.max_expansion          = row[10] ? static_cast<int8_t>(atoi(row[10])) : -1;
-			e.content_flags          = row[11] ? row[11] : "";
-			e.content_flags_disabled = row[12] ? row[12] : "";
+			e.augment_one            = row[7] ? static_cast<uint32_t>(strtoul(row[7], nullptr, 10)) : 0;
+			e.augment_two            = row[8] ? static_cast<uint32_t>(strtoul(row[8], nullptr, 10)) : 0;
+			e.augment_three          = row[9] ? static_cast<uint32_t>(strtoul(row[9], nullptr, 10)) : 0;
+			e.augment_four           = row[10] ? static_cast<uint32_t>(strtoul(row[10], nullptr, 10)) : 0;
+			e.augment_five           = row[11] ? static_cast<uint32_t>(strtoul(row[11], nullptr, 10)) : 0;
+			e.augment_six            = row[12] ? static_cast<uint32_t>(strtoul(row[12], nullptr, 10)) : 0;
+			e.status                 = row[13] ? static_cast<int32_t>(atoi(row[13])) : 0;
+			e.inventory_slot         = row[14] ? static_cast<int32_t>(atoi(row[14])) : -1;
+			e.min_expansion          = row[15] ? static_cast<int8_t>(atoi(row[15])) : -1;
+			e.max_expansion          = row[16] ? static_cast<int8_t>(atoi(row[16])) : -1;
+			e.content_flags          = row[17] ? row[17] : "";
+			e.content_flags_disabled = row[18] ? row[18] : "";
 
 			return e;
 		}
@@ -215,12 +245,18 @@ public:
 		v.push_back(columns[4] + " = '" + Strings::Escape(e.zone_id_list) + "'");
 		v.push_back(columns[5] + " = " + std::to_string(e.item_id));
 		v.push_back(columns[6] + " = " + std::to_string(e.item_charges));
-		v.push_back(columns[7] + " = " + std::to_string(e.status));
-		v.push_back(columns[8] + " = " + std::to_string(e.inventory_slot));
-		v.push_back(columns[9] + " = " + std::to_string(e.min_expansion));
-		v.push_back(columns[10] + " = " + std::to_string(e.max_expansion));
-		v.push_back(columns[11] + " = '" + Strings::Escape(e.content_flags) + "'");
-		v.push_back(columns[12] + " = '" + Strings::Escape(e.content_flags_disabled) + "'");
+		v.push_back(columns[7] + " = " + std::to_string(e.augment_one));
+		v.push_back(columns[8] + " = " + std::to_string(e.augment_two));
+		v.push_back(columns[9] + " = " + std::to_string(e.augment_three));
+		v.push_back(columns[10] + " = " + std::to_string(e.augment_four));
+		v.push_back(columns[11] + " = " + std::to_string(e.augment_five));
+		v.push_back(columns[12] + " = " + std::to_string(e.augment_six));
+		v.push_back(columns[13] + " = " + std::to_string(e.status));
+		v.push_back(columns[14] + " = " + std::to_string(e.inventory_slot));
+		v.push_back(columns[15] + " = " + std::to_string(e.min_expansion));
+		v.push_back(columns[16] + " = " + std::to_string(e.max_expansion));
+		v.push_back(columns[17] + " = '" + Strings::Escape(e.content_flags) + "'");
+		v.push_back(columns[18] + " = '" + Strings::Escape(e.content_flags_disabled) + "'");
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -249,6 +285,12 @@ public:
 		v.push_back("'" + Strings::Escape(e.zone_id_list) + "'");
 		v.push_back(std::to_string(e.item_id));
 		v.push_back(std::to_string(e.item_charges));
+		v.push_back(std::to_string(e.augment_one));
+		v.push_back(std::to_string(e.augment_two));
+		v.push_back(std::to_string(e.augment_three));
+		v.push_back(std::to_string(e.augment_four));
+		v.push_back(std::to_string(e.augment_five));
+		v.push_back(std::to_string(e.augment_six));
 		v.push_back(std::to_string(e.status));
 		v.push_back(std::to_string(e.inventory_slot));
 		v.push_back(std::to_string(e.min_expansion));
@@ -291,6 +333,12 @@ public:
 			v.push_back("'" + Strings::Escape(e.zone_id_list) + "'");
 			v.push_back(std::to_string(e.item_id));
 			v.push_back(std::to_string(e.item_charges));
+			v.push_back(std::to_string(e.augment_one));
+			v.push_back(std::to_string(e.augment_two));
+			v.push_back(std::to_string(e.augment_three));
+			v.push_back(std::to_string(e.augment_four));
+			v.push_back(std::to_string(e.augment_five));
+			v.push_back(std::to_string(e.augment_six));
 			v.push_back(std::to_string(e.status));
 			v.push_back(std::to_string(e.inventory_slot));
 			v.push_back(std::to_string(e.min_expansion));
@@ -337,12 +385,18 @@ public:
 			e.zone_id_list           = row[4] ? row[4] : "";
 			e.item_id                = row[5] ? static_cast<uint32_t>(strtoul(row[5], nullptr, 10)) : 0;
 			e.item_charges           = row[6] ? static_cast<uint8_t>(strtoul(row[6], nullptr, 10)) : 1;
-			e.status                 = row[7] ? static_cast<int32_t>(atoi(row[7])) : 0;
-			e.inventory_slot         = row[8] ? static_cast<int32_t>(atoi(row[8])) : -1;
-			e.min_expansion          = row[9] ? static_cast<int8_t>(atoi(row[9])) : -1;
-			e.max_expansion          = row[10] ? static_cast<int8_t>(atoi(row[10])) : -1;
-			e.content_flags          = row[11] ? row[11] : "";
-			e.content_flags_disabled = row[12] ? row[12] : "";
+			e.augment_one            = row[7] ? static_cast<uint32_t>(strtoul(row[7], nullptr, 10)) : 0;
+			e.augment_two            = row[8] ? static_cast<uint32_t>(strtoul(row[8], nullptr, 10)) : 0;
+			e.augment_three          = row[9] ? static_cast<uint32_t>(strtoul(row[9], nullptr, 10)) : 0;
+			e.augment_four           = row[10] ? static_cast<uint32_t>(strtoul(row[10], nullptr, 10)) : 0;
+			e.augment_five           = row[11] ? static_cast<uint32_t>(strtoul(row[11], nullptr, 10)) : 0;
+			e.augment_six            = row[12] ? static_cast<uint32_t>(strtoul(row[12], nullptr, 10)) : 0;
+			e.status                 = row[13] ? static_cast<int32_t>(atoi(row[13])) : 0;
+			e.inventory_slot         = row[14] ? static_cast<int32_t>(atoi(row[14])) : -1;
+			e.min_expansion          = row[15] ? static_cast<int8_t>(atoi(row[15])) : -1;
+			e.max_expansion          = row[16] ? static_cast<int8_t>(atoi(row[16])) : -1;
+			e.content_flags          = row[17] ? row[17] : "";
+			e.content_flags_disabled = row[18] ? row[18] : "";
 
 			all_entries.push_back(e);
 		}
@@ -374,12 +428,18 @@ public:
 			e.zone_id_list           = row[4] ? row[4] : "";
 			e.item_id                = row[5] ? static_cast<uint32_t>(strtoul(row[5], nullptr, 10)) : 0;
 			e.item_charges           = row[6] ? static_cast<uint8_t>(strtoul(row[6], nullptr, 10)) : 1;
-			e.status                 = row[7] ? static_cast<int32_t>(atoi(row[7])) : 0;
-			e.inventory_slot         = row[8] ? static_cast<int32_t>(atoi(row[8])) : -1;
-			e.min_expansion          = row[9] ? static_cast<int8_t>(atoi(row[9])) : -1;
-			e.max_expansion          = row[10] ? static_cast<int8_t>(atoi(row[10])) : -1;
-			e.content_flags          = row[11] ? row[11] : "";
-			e.content_flags_disabled = row[12] ? row[12] : "";
+			e.augment_one            = row[7] ? static_cast<uint32_t>(strtoul(row[7], nullptr, 10)) : 0;
+			e.augment_two            = row[8] ? static_cast<uint32_t>(strtoul(row[8], nullptr, 10)) : 0;
+			e.augment_three          = row[9] ? static_cast<uint32_t>(strtoul(row[9], nullptr, 10)) : 0;
+			e.augment_four           = row[10] ? static_cast<uint32_t>(strtoul(row[10], nullptr, 10)) : 0;
+			e.augment_five           = row[11] ? static_cast<uint32_t>(strtoul(row[11], nullptr, 10)) : 0;
+			e.augment_six            = row[12] ? static_cast<uint32_t>(strtoul(row[12], nullptr, 10)) : 0;
+			e.status                 = row[13] ? static_cast<int32_t>(atoi(row[13])) : 0;
+			e.inventory_slot         = row[14] ? static_cast<int32_t>(atoi(row[14])) : -1;
+			e.min_expansion          = row[15] ? static_cast<int8_t>(atoi(row[15])) : -1;
+			e.max_expansion          = row[16] ? static_cast<int8_t>(atoi(row[16])) : -1;
+			e.content_flags          = row[17] ? row[17] : "";
+			e.content_flags_disabled = row[18] ? row[18] : "";
 
 			all_entries.push_back(e);
 		}
@@ -461,6 +521,12 @@ public:
 		v.push_back("'" + Strings::Escape(e.zone_id_list) + "'");
 		v.push_back(std::to_string(e.item_id));
 		v.push_back(std::to_string(e.item_charges));
+		v.push_back(std::to_string(e.augment_one));
+		v.push_back(std::to_string(e.augment_two));
+		v.push_back(std::to_string(e.augment_three));
+		v.push_back(std::to_string(e.augment_four));
+		v.push_back(std::to_string(e.augment_five));
+		v.push_back(std::to_string(e.augment_six));
 		v.push_back(std::to_string(e.status));
 		v.push_back(std::to_string(e.inventory_slot));
 		v.push_back(std::to_string(e.min_expansion));
@@ -496,6 +562,12 @@ public:
 			v.push_back("'" + Strings::Escape(e.zone_id_list) + "'");
 			v.push_back(std::to_string(e.item_id));
 			v.push_back(std::to_string(e.item_charges));
+			v.push_back(std::to_string(e.augment_one));
+			v.push_back(std::to_string(e.augment_two));
+			v.push_back(std::to_string(e.augment_three));
+			v.push_back(std::to_string(e.augment_four));
+			v.push_back(std::to_string(e.augment_five));
+			v.push_back(std::to_string(e.augment_six));
 			v.push_back(std::to_string(e.status));
 			v.push_back(std::to_string(e.inventory_slot));
 			v.push_back(std::to_string(e.min_expansion));

--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -461,7 +461,13 @@ bool SharedDatabase::SetStartingItems(
 {
 	const EQ::ItemData *item_data;
 
-	const auto &l = StartingItemsRepository::All(*this);
+	const auto& l = StartingItemsRepository::GetWhere(
+		*this,
+		fmt::format(
+			"TRUE {}",
+			ContentFilterCriteria::apply()
+		)
+	);
 
 	if (l.empty()) {
 		return false;
@@ -515,7 +521,16 @@ bool SharedDatabase::SetStartingItems(
 			continue;
 		}
 
-		const auto *inst = CreateBaseItem(item_data, item_charges);
+		const auto* inst = CreateItem(
+			item_data,
+			item_charges,
+			e.augment_one,
+			e.augment_two,
+			e.augment_three,
+			e.augment_four,
+			e.augment_five,
+			e.augment_six
+		);
 
 		if (slot < EQ::invslot::slotCharm) {
 			slot = inv->FindFreeSlot(false, false);

--- a/common/version.h
+++ b/common/version.h
@@ -42,8 +42,8 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9263
-#define CURRENT_BINARY_BOTS_DATABASE_VERSION 9042
+#define CURRENT_BINARY_DATABASE_VERSION 9264
+#define CURRENT_BINARY_BOTS_DATABASE_VERSION 9043
 
 #endif
 

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -2319,10 +2319,16 @@ bool Client::StoreCharacter(
 	for (int16 slot_id = EQ::invslot::EQUIPMENT_BEGIN; slot_id <= EQ::invbag::BANK_BAGS_END;) {
 		const auto inst = p_inventory_profile->GetItem(slot_id);
 		if (inst) {
-			e.slotid  = slot_id;
-			e.itemid  = inst->GetItem()->ID;
-			e.charges = inst->GetCharges();
-			e.color   = inst->GetColor();
+			e.slotid   = slot_id;
+			e.itemid   = inst->GetItem()->ID;
+			e.charges  = inst->GetCharges();
+			e.color    = inst->GetColor();
+			e.augslot1 = inst->GetAugmentItemID(EQ::invaug::SOCKET_BEGIN);
+			e.augslot2 = inst->GetAugmentItemID(EQ::invaug::SOCKET_BEGIN + 1);
+			e.augslot3 = inst->GetAugmentItemID(EQ::invaug::SOCKET_BEGIN + 2);
+			e.augslot4 = inst->GetAugmentItemID(EQ::invaug::SOCKET_BEGIN + 3);
+			e.augslot5 = inst->GetAugmentItemID(EQ::invaug::SOCKET_BEGIN + 4);
+			e.augslot6 = inst->GetAugmentItemID(EQ::invaug::SOCKET_END);
 
 			v.emplace_back(e);
 		}
@@ -2369,7 +2375,7 @@ void Client::RecordPossibleHack(const std::string& message)
 	}
 }
 
-void Client::SendGuildTributeFavorAndTimer(uint32 favor, uint32 time_remaining) 
+void Client::SendGuildTributeFavorAndTimer(uint32 favor, uint32 time_remaining)
 {
 	auto cle = GetCLE();
 	if (!cle) {

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -8527,10 +8527,17 @@ void Bot::AddBotStartingItems(uint16 race_id, uint8 class_id)
 			(CanRaceEquipItem(e.item_id) || RuleB(Bots, AllowBotEquipAnyRaceGear))
 		) {
 			auto i = BotInventoriesRepository::NewEntity();
+
 			i.bot_id       = GetBotID();
 			i.slot_id      = e.slot_id;
 			i.item_id      = e.item_id;
 			i.inst_charges = e.item_charges;
+			i.augment_1    = e.augment_one;
+			i.augment_2    = e.augment_two;
+			i.augment_3    = e.augment_three;
+			i.augment_4    = e.augment_four;
+			i.augment_5    = e.augment_five;
+			i.augment_6    = e.augment_six;
 
 			v.emplace_back(i);
 		}


### PR DESCRIPTION
# Notes
- Adds support for augments to `bot_starting_items` and `starting_items`.
- Will allow operators to kit bots/players out with augmented gear from the start if they so choose.

# Bot
![image](https://github.com/EQEmu/Server/assets/89047260/72c233c0-a7c1-4f73-a9a4-9e4eda8a2458)
![image](https://github.com/EQEmu/Server/assets/89047260/0877b238-69bd-43e0-9c77-ad0a3e2d978b)

# Client
![image](https://github.com/EQEmu/Server/assets/89047260/5439e8fe-6572-4711-9e58-f72ad0abc445)
![image](https://github.com/EQEmu/Server/assets/89047260/100b3132-b47d-450f-b7c3-d787dbb84425)
