### PR TITLE
[Bug Fix] Revert 2df7d19

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -4102,8 +4102,9 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 			TryTriggerThreshHold(damage, SE_TriggerSpellThreshold, attacker);
 		}
 
-		if (IsClient()) {
-			//CommonBreakInvisible();
+		if (IsClient() && CastToClient()->sneaking) {
+			CastToClient()->sneaking = false;
+			SendAppearancePacket(AppearanceType::Sneak, 0);
 		}
 
 		if (attacker && attacker->IsClient() && attacker->CastToClient()->sneaking) {

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -4103,7 +4103,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 		}
 
 		if (IsClient()) {
-			CommonBreakInvisible();
+			//CommonBreakInvisible();
 		}
 
 		if (attacker && attacker->IsClient() && attacker->CastToClient()->sneaking) {

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -4071,6 +4071,10 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 
 		//see if any runes want to reduce this damage
 		if (!IsValidSpell(spell_id)) {
+			if (IsClient()) {
+				CommonBreakInvisible();
+			}
+			
 			damage = ReduceDamage(damage);
 			LogCombat("Melee Damage reduced to [{}]", damage);
 			damage = ReduceAllDamage(damage);


### PR DESCRIPTION
The original change breaks lich-type spells as seen in #4098. Per comment on original change, also don't see where Runes come into play.

Current behavior immediately after casting invis:
![image](https://github.com/EQEmu/Server/assets/3617814/0ef27689-098c-4b9d-9c30-f0a0127e6901)

Reverted behavior:
![image](https://github.com/EQEmu/Server/assets/3617814/364f873c-83b9-450d-86c8-8a68db2b2ba0)
