### PR TITLE
[Logs] Fix log in BaseGuildManager::IsGuildLeader()

### DIFF
--- a/common/guild_base.cpp
+++ b/common/guild_base.cpp
@@ -1090,7 +1090,7 @@ bool BaseGuildManager::IsGuildLeader(uint32 guild_id, uint32 char_id) const
 		LogGuilds("Check leader for char [{}]: invalid guild", char_id);
 		return (false);    //invalid guild
 	}
-	LogGuilds("Check leader for guild [{}]\, char [{}]\: leader id=[{}]", guild_id, char_id, res->second->leader);
+	LogGuilds("Check leader for guild [{}], char [{}]: leader id=[{}]", guild_id, char_id, res->second->leader);
 	return (char_id == res->second->leader);
 }
 


### PR DESCRIPTION
Looks like typos created invalid escapes