### PR TITLE
[Factions] Fix issue with npcedit and cached factions

### DIFF
--- a/zone/zone_npc_factions.cpp
+++ b/zone/zone_npc_factions.cpp
@@ -120,6 +120,17 @@ NpcFactionRepository::NpcFaction* Zone::GetNPCFaction(const uint32 npc_faction_i
 		}
 	}
 
+	// Maybe we're being asked to load an npc_faction not yet used in the zone
+	// like from npc_edit to assign it.  Load it if possible and try again.
+
+	LoadNPCFaction(npc_faction_id);
+
+	for (auto& e : m_npc_factions) {
+		if (e.id == npc_faction_id) {
+			return &e;
+		}
+	}
+
 	return nullptr;
 }
 

--- a/zone/zone_npc_factions.cpp
+++ b/zone/zone_npc_factions.cpp
@@ -114,15 +114,7 @@ void Zone::ReloadNPCFactions()
 
 NpcFactionRepository::NpcFaction* Zone::GetNPCFaction(const uint32 npc_faction_id)
 {
-	for (auto& e : m_npc_factions) {
-		if (e.id == npc_faction_id) {
-			return &e;
-		}
-	}
-
 	// Maybe we're being asked to load an npc_faction not yet used in the zone
-	// like from npc_edit to assign it.  Load it if possible and try again.
-
 	LoadNPCFaction(npc_faction_id);
 
 	for (auto& e : m_npc_factions) {


### PR DESCRIPTION
#npcedit faction 1 would fail with the new "cached" factions is the npc_faction_id provided was not a faction loaded with the zone.

This fixes this by forcing the load of the new faction.