### PR TITLE
[Bug Fix] Added additional crash checks to zone and world guild_mgr

### DIFF
--- a/world/wguild_mgr.cpp
+++ b/world/wguild_mgr.cpp
@@ -369,6 +369,10 @@ bool WorldGuildManager::LoadTributes()
 bool WorldGuildManager::RefreshGuild(uint32 guild_id)
 {
 	auto temp_guild = GetGuildByGuildID(guild_id);
+	if (!temp_guild) {
+		return false;
+	}
+
 	BaseGuildManager::GuildInfo temp_guild_detail;
 
 	if (temp_guild) {
@@ -389,6 +393,11 @@ bool WorldGuildManager::RefreshGuild(uint32 guild_id)
 	LogGuilds("Found guild id [{}].  Loading details.....", db_guild.id);
 	_CreateGuild(db_guild.id, db_guild.name, db_guild.leader, db_guild.minstatus, db_guild.motd, db_guild.motd_setter, db_guild.channel, db_guild.url, db_guild.favor);
 	auto guild = GetGuildByGuildID(guild_id);
+	if (!guild) {
+		LogError("Error refreshing guild id {}", guild_id);
+		return false;
+	}
+
 	auto where_filter = fmt::format("guild_id = '{}'", guild_id);
 	auto guild_ranks = GuildRanksRepository::GetWhere(*m_db, where_filter);
 	for (auto const& r : guild_ranks) {


### PR DESCRIPTION
This should resolve a few reported crash scenarios on spire fingerprint cb586.

Added additional crash checks when a guild lookup fails in both world and zone guild managers.
Also moved a few lookup routines to GetGuildByGuildID function instead of using m_guilds.find.


