### PR TITLE
[Quest API] Add Hatelist Count Methods to Perl/Lua

### DIFF
--- a/zone/hate_list.cpp
+++ b/zone/hate_list.cpp
@@ -683,7 +683,33 @@ int64 HateList::GetEntHateAmount(Mob *in_entity, bool damage)
 }
 
 bool HateList::IsHateListEmpty() {
-	return(list.size() == 0);
+	return list.empty();
+}
+
+uint32 HateList::GetHateListCount(HateListCountType count_type)
+{
+	if (count_type == HateListCountType::All) {
+		return list.size();
+	}
+
+	uint32 count = 0;
+
+	for (const auto& e : list) {
+		Mob* m = e->entity_on_hatelist;
+
+		if (
+			m &&
+			(
+				(count_type == HateListCountType::Bot && m->IsBot()) ||
+				(count_type == HateListCountType::Client && m->IsClient()) ||
+				(count_type == HateListCountType::NPC && m->IsNPC())
+			)
+		) {
+			count++;
+		}
+	}
+
+	return count;
 }
 
 void HateList::PrintHateListToClient(Client *c)

--- a/zone/hate_list.h
+++ b/zone/hate_list.h
@@ -36,6 +36,13 @@ struct struct_HateList {
 	uint32 last_modified; // we need to remove this if it gets higher than 10 mins
 };
 
+enum class HateListCountType {
+	Bot    = 0,
+	Client = 1,
+	NPC    = 2,
+	All    = 3,
+};
+
 class HateList {
 public:
 	HateList();
@@ -51,6 +58,7 @@ public:
 	bool IsEntOnHateList(Mob* m);
 	bool IsHateListEmpty();
 	bool RemoveEntFromHateList(Mob *ent);
+	uint32 GetHateListCount(HateListCountType count_type = HateListCountType::All);
 
 	int AreaRampage(Mob *caster, Mob *target, int count, ExtraAttackOptions *opts);
 	int GetSummonedPetCountOnHateList();

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -3201,6 +3201,30 @@ uint32 Lua_Mob::GetMobTypeIdentifier()
 	return self->GetMobTypeIdentifier();
 }
 
+uint32 Lua_Mob::GetHateListCount()
+{
+	Lua_Safe_Call_Int();
+	return self->GetHateListCount();
+}
+
+uint32 Lua_Mob::GetHateListBotCount()
+{
+	Lua_Safe_Call_Int();
+	return self->GetHateListCount(HateListCountType::Bot);
+}
+
+uint32 Lua_Mob::GetHateListClientCount()
+{
+	Lua_Safe_Call_Int();
+	return self->GetHateListCount(HateListCountType::Client);
+}
+
+uint32 Lua_Mob::GetHateListNPCCount()
+{
+	Lua_Safe_Call_Int();
+	return self->GetHateListCount(HateListCountType::NPC);
+}
+
 luabind::scope lua_register_mob() {
 	return luabind::class_<Lua_Mob, Lua_Entity>("Mob")
 	.def(luabind::constructor<>())
@@ -3460,12 +3484,16 @@ luabind::scope lua_register_mob() {
 	.def("GetHateList", &Lua_Mob::GetHateList)
 	.def("GetHateListBots", (Lua_HateList(Lua_Mob::*)(void))&Lua_Mob::GetHateListBots)
 	.def("GetHateListBots", (Lua_HateList(Lua_Mob::*)(uint32))&Lua_Mob::GetHateListBots)
+	.def("GetHateListBotCount", &Lua_Mob::GetHateListBotCount)
 	.def("GetHateListClients", (Lua_HateList(Lua_Mob::*)(void))&Lua_Mob::GetHateListClients)
 	.def("GetHateListClients", (Lua_HateList(Lua_Mob::*)(uint32))&Lua_Mob::GetHateListClients)
+	.def("GetHateListClientCount", &Lua_Mob::GetHateListClientCount)
 	.def("GetHateListNPCs", (Lua_HateList(Lua_Mob::*)(void))&Lua_Mob::GetHateListNPCs)
 	.def("GetHateListNPCs", (Lua_HateList(Lua_Mob::*)(uint32))&Lua_Mob::GetHateListNPCs)
+	.def("GetHateListNPCCount", &Lua_Mob::GetHateListNPCCount)
 	.def("GetHateListByDistance", (Lua_HateList(Lua_Mob::*)(void))&Lua_Mob::GetHateListByDistance)
 	.def("GetHateListByDistance", (Lua_HateList(Lua_Mob::*)(uint32))&Lua_Mob::GetHateListByDistance)
+	.def("GetHateListCount", &Lua_Mob::GetHateListCount)
 	.def("GetHateRandom", (Lua_Mob(Lua_Mob::*)(void))&Lua_Mob::GetHateRandom)
 	.def("GetHateRandomBot", (Lua_Bot(Lua_Mob::*)(void))&Lua_Mob::GetHateRandomBot)
 	.def("GetHateRandomClient", (Lua_Client(Lua_Mob::*)(void))&Lua_Mob::GetHateRandomClient)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -566,6 +566,10 @@ public:
 	std::string GetRacePlural();
 	bool IsTemporaryPet();
 	uint32 GetMobTypeIdentifier();
+	uint32 GetHateListCount();
+	uint32 GetHateListBotCount();
+	uint32 GetHateListClientCount();
+	uint32 GetHateListNPCCount();
 };
 
 #endif

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -769,6 +769,7 @@ public:
 	Client* GetHateClosestClient(bool skip_mezzed = false) { return hate_list.GetClosestEntOnHateList(this, skip_mezzed, EntityFilterType::Clients)->CastToClient(); }
 	NPC* GetHateClosestNPC(bool skip_mezzed = false) { return hate_list.GetClosestEntOnHateList(this, skip_mezzed, EntityFilterType::NPCs)->CastToNPC(); }
 	bool IsEngaged() { return(!hate_list.IsHateListEmpty()); }
+	inline uint32 GetHateListCount(HateListCountType count_type = HateListCountType::All) { return hate_list.GetHateListCount(count_type); }
 	bool HasPrimaryAggro() { return PrimaryAggro; }
 	bool HasAssistAggro() { return AssistAggro; }
 	void SetPrimaryAggro(bool value) { PrimaryAggro = value; if (value) AssistAggro = false; }

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -3340,6 +3340,26 @@ std::string Perl_Mob_GetRacePlural(Mob* self)
 	return self->GetRacePlural();
 }
 
+uint32 Perl_Mob_GetHateListCount(Mob* self)
+{
+	return self->GetHateListCount();
+}
+
+uint32 Perl_Mob_GetHateListBotCount(Mob* self)
+{
+	return self->GetHateListCount(HateListCountType::Bot);
+}
+
+uint32 Perl_Mob_GetHateListClientCount(Mob* self)
+{
+	return self->GetHateListCount(HateListCountType::Client);
+}
+
+uint32 Perl_Mob_GetHateListNPCCount(Mob* self)
+{
+	return self->GetHateListCount(HateListCountType::NPC);
+}
+
 void perl_register_mob()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3585,12 +3605,16 @@ void perl_register_mob()
 	package.add("GetHateList", &Perl_Mob_GetHateList);
 	package.add("GetHateListBots", (perl::array(*)(Mob*))&Perl_Mob_GetHateListBots);
 	package.add("GetHateListBots", (perl::array(*)(Mob*, uint32))&Perl_Mob_GetHateListBots);
+	package.add("GetHateListBotCount", &Perl_Mob_GetHateListBotCount);
 	package.add("GetHateListClients", (perl::array(*)(Mob*))&Perl_Mob_GetHateListClients);
 	package.add("GetHateListClients", (perl::array(*)(Mob*, uint32))&Perl_Mob_GetHateListClients);
+	package.add("GetHateListClientCount", &Perl_Mob_GetHateListClientCount);
 	package.add("GetHateListNPCs", (perl::array(*)(Mob*))&Perl_Mob_GetHateListNPCs);
 	package.add("GetHateListNPCs", (perl::array(*)(Mob*, uint32))&Perl_Mob_GetHateListNPCs);
+	package.add("GetHateListNPCCount", &Perl_Mob_GetHateListNPCCount);
 	package.add("GetHateListByDistance", (perl::array(*)(Mob*))&Perl_Mob_GetHateListByDistance);
 	package.add("GetHateListByDistance", (perl::array(*)(Mob*, uint32))&Perl_Mob_GetHateListByDistance);
+	package.add("GetHateListCount", &Perl_Mob_GetHateListCount);
 	package.add("GetHateRandom", &Perl_Mob_GetHateRandom);
 	package.add("GetHateRandomBot", &Perl_Mob_GetHateRandomBot);
 	package.add("GetHateRandomClient", &Perl_Mob_GetHateRandomClient);


### PR DESCRIPTION
# Perl
- Add `$mob->GetHateListCount()`.
- Add `$mob->GetHateListBotCount()`.
- Add `$mob->GetHateListClientCount()`.
- Add `$mob->GetHateListNPCCount()`.

# Lua
- Add `mob:GetHateListCount()`.
- Add `mob:GetHateListBotCount()`.
- Add `mob:GetHateListClientCount()`.
- Add `mob:GetHateListNPCCount()`.

# Perl Example Script
```pl
sub EVENT_SAY {
	if ($text=~/#a/i) {
		my $h = $client->GetTarget() ? $client->GetTarget()->GetHateListCount() : 0;
		my $b = $client->GetTarget() ? $client->GetTarget()->GetHateListBotCount() : 0;
		my $c = $client->GetTarget() ? $client->GetTarget()->GetHateListClientCount() : 0;
		my $n = $client->GetTarget() ? $client->GetTarget()->GetHateListNPCCount() : 0;
		quest::message(315, "H: $h B: $b C: $c N: $n");
	}
}
```

# Image
![image](https://github.com/EQEmu/Server/assets/89047260/e78cd854-c384-4729-ab85-cf6c6381c924)

# Notes
- Allows operators to more easily get a total entity count of a Mob's hate list, can do an overall count, or specifically bots, clients, or NPCs.