### PR TITLE
[Bug Fix] Add safety check to SummonAllCharacterCorpses

### DIFF
--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -3988,7 +3988,9 @@ bool ZoneDatabase::SummonAllCharacterCorpses(
 		}
 	}
 
-	CharacterCorpsesRepository::ReplaceMany(*this, l);
+	if (!l.empty()) {
+		CharacterCorpsesRepository::ReplaceMany(*this, l);
+	}
 
 	return corpse_count > 0;
 }


### PR DESCRIPTION
Should prevent an empty vector from being passed to the repository.