### PR TITLE
[Bug Fix] Fix hotzone string error

### DIFF
--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -628,7 +628,7 @@ void Client::SetEXP(uint64 set_exp, uint64 set_aaxp, bool isrezzexp) {
 				if (RuleI(Character, ShowExpValues) > 0) {
 					Message(Chat::Experience, "You have gained %s party experience! %s", exp_amount_message.c_str(), exp_percent_message.c_str());
 				} else if (zone->IsHotzone()) { 
-					MessageString(Chat::Experience, GAIN_GROUPXP_BONUS);
+					Message(Chat::Experience, "You gain party experience (with a bonus)!");
 				} else {
 					MessageString(Chat::Experience, GAIN_GROUPXP);
 				}
@@ -636,7 +636,7 @@ void Client::SetEXP(uint64 set_exp, uint64 set_aaxp, bool isrezzexp) {
 				if (RuleI(Character, ShowExpValues) > 0) {
 					Message(Chat::Experience, "You have gained %s raid experience! %s", exp_amount_message.c_str(), exp_percent_message.c_str());
 				} else if (zone->IsHotzone()) { 
-					MessageString(Chat::Experience, GAIN_RAIDXP_BONUS);
+					Message(Chat::Experience, "You gained raid experience (with a bonus)!");
 				} else {
 					MessageString(Chat::Experience, GAIN_RAIDEXP);
 				}
@@ -644,7 +644,7 @@ void Client::SetEXP(uint64 set_exp, uint64 set_aaxp, bool isrezzexp) {
 				if (RuleI(Character, ShowExpValues) > 0) {
 					Message(Chat::Experience, "You have gained %s experience! %s", exp_amount_message.c_str(), exp_percent_message.c_str());
 				} else if (zone->IsHotzone()) { 
-					MessageString(Chat::Experience, GAIN_XP_BONUS);
+					Message(Chat::Experience, "You gain experience (with a bonus)!");
 				} else {
 					MessageString(Chat::Experience, GAIN_XP);
 				}


### PR DESCRIPTION
The Strings entry was from a newer client. Moved text to a raw message.