### PR TITLE
[Quest API] Export Combat Record to Death Events

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2980,12 +2980,16 @@ bool NPC::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillTy
 
 	if (parse->HasQuestSub(GetNPCTypeID(), EVENT_DEATH_COMPLETE)) {
 		const auto& export_string = fmt::format(
-			"{} {} {} {} {}",
+			"{} {} {} {} {} {} {} {} {}",
 			killer_mob ? killer_mob->GetID() : 0,
 			damage,
 			spell,
 			static_cast<int>(attack_skill),
-			entity_id
+			entity_id,
+			m_combat_record.GetStartTime(),
+			m_combat_record.GetEndTime(),
+			m_combat_record.GetDamageReceived(),
+			m_combat_record.GetHealingReceived()
 		);
 
 		std::vector<std::any> args = { corpse };
@@ -2996,12 +3000,16 @@ bool NPC::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillTy
 	// Zone controller process EVENT_DEATH_ZONE (Death events)
 	if (parse->HasQuestSub(ZONE_CONTROLLER_NPC_ID, EVENT_DEATH_ZONE)) {
 		const auto& export_string = fmt::format(
-			"{} {} {} {} {}",
+			"{} {} {} {} {} {} {} {} {}",
 			killer_mob ? killer_mob->GetID() : 0,
 			damage,
 			spell,
 			static_cast<int>(attack_skill),
-			entity_id
+			entity_id,
+			m_combat_record.GetStartTime(),
+			m_combat_record.GetEndTime(),
+			m_combat_record.GetDamageReceived(),
+			m_combat_record.GetHealingReceived()
 		);
 
 		std::vector<std::any> args = { corpse, this };
@@ -4074,7 +4082,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 			if (IsClient()) {
 				CommonBreakInvisible();
 			}
-			
+
 			damage = ReduceDamage(damage);
 			LogCombat("Melee Damage reduced to [{}]", damage);
 			damage = ReduceAllDamage(damage);

--- a/zone/combat_record.cpp
+++ b/zone/combat_record.cpp
@@ -71,3 +71,23 @@ float CombatRecord::GetHealedReceivedPerSecond() const
 	double time_in_combat = TimeInCombat();
 	return time_in_combat > 0 ? (m_heal_received / time_in_combat) : m_heal_received;
 }
+
+time_t CombatRecord::GetStartTime() const
+{
+	return m_start_time;
+}
+
+time_t CombatRecord::GetEndTime() const
+{
+	return m_end_time;
+}
+
+int64 CombatRecord::GetDamageReceived() const
+{
+	return m_damage_received;
+}
+
+int64 CombatRecord::GetHealingReceived() const
+{
+	return m_heal_received;
+}

--- a/zone/combat_record.h
+++ b/zone/combat_record.h
@@ -14,6 +14,10 @@ public:
 	double TimeInCombat() const;
 	float GetDamageReceivedPerSecond() const;
 	float GetHealedReceivedPerSecond() const;
+	time_t GetStartTime() const;
+	time_t GetEndTime() const;
+	int64 GetDamageReceived() const;
+	int64 GetHealingReceived() const;
 private:
 	std::string m_mob_name;
 	time_t      m_start_time      = 0;

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -2024,6 +2024,13 @@ void PerlembParser::ExportEventVariables(
 			ExportVar(package_name.c_str(), "killer_skill", sep.arg[3]);
 			ExportVar(package_name.c_str(), "killed_entity_id", sep.arg[4]);
 
+			if (sep.arg[5]) {
+				ExportVar(package_name.c_str(), "combat_start_time", sep.arg[5]);
+				ExportVar(package_name.c_str(), "combat_end_time", sep.arg[6]);
+				ExportVar(package_name.c_str(), "damage_received", sep.arg[7]);
+				ExportVar(package_name.c_str(), "healing_received", sep.arg[8]);
+			}
+
 			if (extra_pointers && extra_pointers->size() >= 1) {
 				Corpse* corpse = std::any_cast<Corpse*>(extra_pointers->at(0));
 				if (corpse) {

--- a/zone/lua_parser_events.cpp
+++ b/zone/lua_parser_events.cpp
@@ -321,6 +321,18 @@ void handle_npc_death(
 	lua_pushinteger(L, Strings::ToUnsignedInt(sep.arg[4]));
 	lua_setfield(L, -2, "killed_entity_id");
 
+	lua_pushinteger(L, Strings::ToUnsignedInt(sep.arg[5]));
+	lua_setfield(L, -2, "combat_start_time");
+
+	lua_pushinteger(L, Strings::ToUnsignedInt(sep.arg[6]));
+	lua_setfield(L, -2, "combat_end_time");
+
+	lua_pushinteger(L, Strings::ToBigInt(sep.arg[7]));
+	lua_setfield(L, -2, "damage_received");
+
+	lua_pushinteger(L, Strings::ToBigInt(sep.arg[8]));
+	lua_setfield(L, -2, "healing_received");
+
 	if (extra_pointers && extra_pointers->size() >= 1) {
 		Lua_Corpse l_corpse(std::any_cast<Corpse*>(extra_pointers->at(0)));
 		luabind::adl::object l_corpse_o = luabind::adl::object(L, l_corpse);


### PR DESCRIPTION
# Perl
- Add `$combat_start_time`, `$combat_end_time`, `$damage_received`, and `$healing_received` to death events for NPCs.

# Lua
- Add `e.combat_start_time`, `e.combat_end_time`, `e.damage_received`, and `e.healing_received` to death events for NPCs.

# Notes
- Allows operators to hook in to the combat record logic so they can log the start and end of combat as well as the damage/healing received over the course of the fight or give rewards/loot or balance content based on duration of fights.