### PR TITLE
[Quest API] Add Bot Methods to Perl/Lua

### DIFF
--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -2353,10 +2353,6 @@ std::vector<uint32> BotDatabase::GetBotIDsByCharacterID(const uint32 character_i
 		)
 	);
 
-	if (l.empty()) {
-		return v;
-	}
-
 	for (const auto& e : l) {
 		v.push_back(e.bot_id);
 	}

--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -2318,3 +2318,69 @@ bool BotDatabase::SaveBotCasterRange(const uint32 bot_id, const uint32 bot_caste
 
 	return BotDataRepository::UpdateOne(database, e);
 }
+
+const uint8 BotDatabase::GetBotClassByID(const uint32 bot_id)
+{
+	const auto& e = BotDataRepository::FindOne(database, bot_id);
+
+	return e.bot_id ? e.class_ : Class::None;
+}
+
+const uint8 BotDatabase::GetBotGenderByID(const uint32 bot_id)
+{
+	const auto& e = BotDataRepository::FindOne(database, bot_id);
+
+	return e.bot_id ? e.gender : Gender::Neuter;
+}
+
+std::vector<uint32> BotDatabase::GetBotIDsByCharacterID(const uint32 character_id, uint8 class_id)
+{
+	std::vector<uint32> v;
+
+	const auto& l = BotDataRepository::GetWhere(
+		database,
+		fmt::format(
+			"`owner_id` = {}{}",
+			character_id,
+			(
+				class_id ?
+				fmt::format(
+					" AND `class` = {}",
+					class_id
+				) :
+				""
+			)
+		)
+	);
+
+	if (l.empty()) {
+		return v;
+	}
+
+	for (const auto& e : l) {
+		v.push_back(e.bot_id);
+	}
+
+	return v;
+}
+
+const uint8 BotDatabase::GetBotLevelByID(const uint32 bot_id)
+{
+	const auto& e = BotDataRepository::FindOne(database, bot_id);
+
+	return e.bot_id ? e.level : 0;
+}
+
+const std::string& BotDatabase::GetBotNameByID(const uint32 bot_id)
+{
+	const auto& e = BotDataRepository::FindOne(database, bot_id);
+
+	return e.bot_id ? e.name : std::string();
+}
+
+const uint16 BotDatabase::GetBotRaceByID(const uint32 bot_id)
+{
+	const auto& e = BotDataRepository::FindOne(database, bot_id);
+
+	return e.bot_id ? e.race : Race::Doug;
+}

--- a/zone/bot_database.h
+++ b/zone/bot_database.h
@@ -160,6 +160,13 @@ public:
 
 	uint32 GetRaceClassBitmask(uint32 bot_race);
 
+	const uint8 GetBotClassByID(const uint32 bot_id);
+	const uint8 GetBotGenderByID(const uint32 bot_id);
+	std::vector<uint32> GetBotIDsByCharacterID(const uint32 character_id, uint8 class_id = Class::None);
+	const uint8 GetBotLevelByID(const uint32 bot_id);
+	const std::string& GetBotNameByID(const uint32 bot_id);
+	const uint16 GetBotRaceByID(const uint32 bot_id);
+
 	class fail {
 	public:
 		/* fail::Bot functions   */

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -5782,6 +5782,57 @@ std::string Perl__convert_money_to_string(perl::hash table)
 	return Strings::Money(platinum, gold, silver, copper);
 }
 
+uint8 Perl__GetBotClassByID(uint32 bot_id)
+{
+	return database.botdb.GetBotClassByID(bot_id);
+}
+
+uint8 Perl__GetBotGenderByID(uint32 bot_id)
+{
+	return database.botdb.GetBotGenderByID(bot_id);
+}
+
+perl::array Perl__GetBotIDsByCharacterID(uint32 character_id)
+{
+	perl::array result;
+
+	const auto bot_ids = database.botdb.GetBotIDsByCharacterID(character_id);
+
+	for (int i = 0; i < bot_ids.size(); i++) {
+		result.push_back(bot_ids[i]);
+	}
+
+	return result;
+}
+
+perl::array Perl__GetBotIDsByCharacterID(uint32 character_id, uint8 class_id)
+{
+	perl::array result;
+
+	const auto bot_ids = database.botdb.GetBotIDsByCharacterID(character_id, class_id);
+
+	for (int i = 0; i < bot_ids.size(); i++) {
+		result.push_back(bot_ids[i]);
+	}
+
+	return result;
+}
+
+uint8 Perl__GetBotLevelByID(uint32 bot_id)
+{
+	return database.botdb.GetBotLevelByID(bot_id);
+}
+
+std::string Perl__GetBotNameByID(uint32 bot_id)
+{
+	return database.botdb.GetBotNameByID(bot_id);
+}
+
+uint16 Perl__GetBotRaceByID(uint32 bot_id)
+{
+	return database.botdb.GetBotRaceByID(bot_id);
+}
+
 void perl_register_quest()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -5812,6 +5863,13 @@ void perl_register_quest()
 	package.add("FlagInstanceByGroupLeader", &Perl__FlagInstanceByGroupLeader);
 	package.add("FlagInstanceByRaidLeader", &Perl__FlagInstanceByRaidLeader);
 	package.add("FlyMode", &Perl__FlyMode);
+	package.add("GetBotClassByID", &Perl__GetBotClassByID);
+	package.add("GetBotGenderByID", &Perl__GetBotGenderByID);
+	package.add("GetBotIDsByCharacterID", (perl::array(*)(uint32))&Perl__GetBotIDsByCharacterID);
+	package.add("GetBotIDsByCharacterID", (perl::array(*)(uint32, uint8))&Perl__GetBotIDsByCharacterID);
+	package.add("GetBotLevelByID", &Perl__GetBotLevelByID);
+	package.add("GetBotNameByID", &Perl__GetBotNameByID);
+	package.add("GetBotRaceByID", &Perl__GetBotRaceByID);
 	package.add("GetCharactersInInstance", &Perl__GetCharactersInInstance);
 	package.add("GetInstanceID", &Perl__GetInstanceID);
 	package.add("GetInstanceIDByCharID", &Perl__GetInstanceIDByCharID);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -5416,6 +5416,65 @@ void lua_self_cast(uint16 spell_id)
 	quest_manager.selfcast(spell_id);
 }
 
+uint8 lua_get_bot_class_by_id(uint32 bot_id)
+{
+	return database.botdb.GetBotClassByID(bot_id);
+}
+
+uint8 lua_get_bot_gender_by_id(uint32 bot_id)
+{
+	return database.botdb.GetBotGenderByID(bot_id);
+}
+
+luabind::object lua_get_bot_ids_by_character_id(lua_State* L, uint32 character_id)
+{
+	auto lua_table = luabind::newtable(L);
+
+	const auto& l = database.botdb.GetBotIDsByCharacterID(character_id);
+
+	if (!l.empty()) {
+		int index = 1;
+		for (const auto& i : l) {
+			lua_table[index] = i;
+			index++;
+		}
+	}
+
+	return lua_table;
+}
+
+luabind::object lua_get_bot_ids_by_character_id(lua_State* L, uint32 character_id, uint8 class_id)
+{
+	auto lua_table = luabind::newtable(L);
+
+	const auto& l = database.botdb.GetBotIDsByCharacterID(character_id, class_id);
+
+	if (!l.empty()) {
+		int index = 1;
+		for (const auto& i : l) {
+			lua_table[index] = i;
+			index++;
+		}
+	}
+
+	return lua_table;
+}
+
+uint8 lua_get_bot_level_by_id(uint32 bot_id)
+{
+	return database.botdb.GetBotLevelByID(bot_id);
+}
+
+std::string lua_get_bot_name_by_id(uint32 bot_id)
+{
+	return database.botdb.GetBotNameByID(bot_id);
+}
+
+uint16 lua_get_bot_race_by_id(uint32 bot_id)
+{
+	return database.botdb.GetBotRaceByID(bot_id);
+}
+
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
 	cur = table[#name]; \
 	if(luabind::type(cur) != LUA_TNIL) { \
@@ -6199,6 +6258,13 @@ luabind::scope lua_register_general() {
 		luabind::def("convert_money_to_string", &lua_convert_money_to_string),
 		luabind::def("cast_spell", &lua_cast_spell),
 		luabind::def("self_cast", &lua_self_cast),
+		luabind::def("get_bot_class_by_id", &lua_get_bot_class_by_id),
+		luabind::def("get_bot_gender_by_id", &lua_get_bot_gender_by_id),
+		luabind::def("get_bot_ids_by_character_id", (luabind::object(*)(lua_State*, uint32))&lua_get_bot_ids_by_character_id),
+		luabind::def("get_bot_ids_by_character_id", (luabind::object(*)(lua_State*, uint32,uint8))&lua_get_bot_ids_by_character_id),
+		luabind::def("get_bot_level_by_id", &lua_get_bot_level_by_id),
+		luabind::def("get_bot_name_by_id", &lua_get_bot_name_by_id),
+		luabind::def("get_bot_race_by_id", &lua_get_bot_race_by_id),
 		/*
 			Cross Zone
 		*/


### PR DESCRIPTION
# Perl
- Add `quest::GetBotClassByID(bot_id)`.
- Add `quest::GetBotGenderByID(bot_id)`.
- Add `quest::GetBotIDsByCharacterID(character_id)`.
- Add `quest::GetBotIDsByCharacterID(character_id, class_id)`.
- Add `quest::GetBotLevelByID(bot_id)`.
- Add `quest::GetBotNameByID(bot_id)`.
- Add `quest::GetBotRaceByID(bot_id)`.

# Lua
- Add `eq.get_bot_class_by_id(bot_id)`.
- Add `eq.get_bot_gender_by_id(bot_id)`.
- Add `eq.get_bot_ids_by_character_id(character_id)`.
- Add `eq.get_bot_ids_by_character_id(character_id, class_id)`.
- Add `eq.get_bot_level_by_id(bot_id)`.
- Add `eq.get_bot_name_by_id(bot_id)`.
- Add `eq.get_bot_race_by_id(bot_id)`.

# Notes
- Allows operators to get a list of a player's bot IDs, get a bot's class, gender, level, name, and race.