### PR TITLE
[Quest API] Add GetAugmentIDs() to Perl/Lua

### DIFF
--- a/common/item_instance.cpp
+++ b/common/item_instance.cpp
@@ -1801,6 +1801,17 @@ uint32 EQ::ItemInstance::GetItemGuildFavor() const
 	return 0;
 }
 
+std::vector<uint32> EQ::ItemInstance::GetAugmentIDs() const
+{
+	std::vector<uint32> augments;
+
+	for (uint8 slot_id = invaug::SOCKET_BEGIN; slot_id <= invaug::SOCKET_END; slot_id++) {
+		augments.push_back(GetAugment(slot_id) ? GetAugmentItemID(slot_id) : 0);
+	}
+
+	return augments;
+}
+
 //
 // class EvolveInfo
 //

--- a/common/item_instance.h
+++ b/common/item_instance.h
@@ -300,6 +300,7 @@ namespace EQ
 		int GetItemHeroicCorrup(bool augments = false) const;
 		int GetItemHaste(bool augments = false) const;
 		uint32 GetItemGuildFavor() const;
+		std::vector<uint32> GetAugmentIDs() const;
 
 	protected:
 		//////////////////////////

--- a/zone/lua_iteminst.cpp
+++ b/zone/lua_iteminst.cpp
@@ -317,6 +317,26 @@ void Lua_ItemInst::ItemSay(const char* text, uint8 language_id) // @categories I
 	quest_manager.GetInitiator()->ChannelMessageSend(self->GetItem()->Name, 0, ChatChannel_Say, language_id, Language::MaxValue, text);
 }
 
+luabind::object Lua_ItemInst::GetAugmentIDs(lua_State* L)
+{
+	auto lua_table = luabind::newtable(L);
+
+	if (d_) {
+		auto self = reinterpret_cast<NativeType*>(d_);
+
+		const auto& augment_ids = self->GetAugmentIDs();
+
+		int index = 1;
+
+		for (auto augment_id : augment_ids) {
+			lua_table[index] = augment_id;
+			index++;
+		}
+	}
+
+	return lua_table;
+}
+
 luabind::scope lua_register_iteminst() {
 	return luabind::class_<Lua_ItemInst>("ItemInst")
 	.def(luabind::constructor<>())
@@ -331,6 +351,7 @@ luabind::scope lua_register_iteminst() {
 	.def("CountAugmentByID", (int(Lua_ItemInst::*)(uint32))&Lua_ItemInst::CountAugmentByID)
 	.def("DeleteCustomData", (void(Lua_ItemInst::*)(const std::string &))&Lua_ItemInst::DeleteCustomData)
 	.def("GetAugment", (Lua_ItemInst(Lua_ItemInst::*)(int))&Lua_ItemInst::GetAugment)
+	.def("GetAugmentIDs", (luabind::object(Lua_ItemInst::*)(lua_State*))&Lua_ItemInst::GetAugmentIDs)
 	.def("GetAugmentItemID", (uint32(Lua_ItemInst::*)(int))&Lua_ItemInst::GetAugmentItemID)
 	.def("GetAugmentType", (int(Lua_ItemInst::*)(void))&Lua_ItemInst::GetAugmentType)
 	.def("GetCharges", (int(Lua_ItemInst::*)(void))&Lua_ItemInst::GetCharges)

--- a/zone/lua_iteminst.h
+++ b/zone/lua_iteminst.h
@@ -89,6 +89,7 @@ public:
 	std::string GetName();
 	void ItemSay(const char* text);
 	void ItemSay(const char* text, uint8 language_id);
+	luabind::object GetAugmentIDs(lua_State* L);
 
 private:
 	bool cloned_;

--- a/zone/perl_questitem.cpp
+++ b/zone/perl_questitem.cpp
@@ -275,6 +275,20 @@ EQ::ItemData* Perl_QuestItem_GetUnscaledItem(EQ::ItemInstance* self) {
 	return const_cast<EQ::ItemData*>(self->GetUnscaledItem());
 }
 
+perl::array Perl_QuestItem_GetAugmentIDs(EQ::ItemInstance* self)
+{
+	perl::array result;
+
+	const auto& augment_ids = self->GetAugmentIDs();
+
+	for (int i = 0; i < augment_ids.size(); i++) {
+		result.push_back(augment_ids[i]);
+	}
+
+	return result;
+}
+
+
 void perl_register_questitem()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -287,6 +301,7 @@ void perl_register_questitem()
 	package.add("CountAugmentByID", &Perl_QuestItem_CountAugmentByID);
 	package.add("DeleteCustomData", &Perl_QuestItem_DeleteCustomData);
 	package.add("GetAugment", &Perl_QuestItem_GetAugment);
+	package.add("GetAugmentIDs", &Perl_QuestItem_GetAugmentIDs);
 	package.add("GetAugmentItemID", &Perl_QuestItem_GetAugmentItemID);
 	package.add("GetAugmentType", &Perl_QuestItem_GetAugmentType);
 	package.add("GetCharges", &Perl_QuestItem_GetCharges);


### PR DESCRIPTION
# Perl
- Add `$questitem->GetAugmentIDs()`.

# Lua
- Add `iteminst:GetAugmentIDs()`.

# Notes
- Allows operators to get a list of augment IDs from an item instance directly without using the inventory method.