### PR TITLE
[Quest API] Add Pet Owner Methods to Perl/Lua

### DIFF
--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -3249,6 +3249,24 @@ bool Lua_Mob::IsTargetLockPet()
 	return self->IsTargetLockPet();
 }
 
+bool Lua_Mob::IsPetOwnerBot()
+{
+	Lua_Safe_Call_Bool();
+	return self->IsPetOwnerBot();
+}
+
+bool Lua_Mob::IsPetOwnerClient()
+{
+	Lua_Safe_Call_Bool();
+	return self->IsPetOwnerClient();
+}
+
+bool Lua_Mob::IsPetOwnerNPC()
+{
+	Lua_Safe_Call_Bool();
+	return self->IsPetOwnerNPC();
+}
+
 luabind::scope lua_register_mob() {
 	return luabind::class_<Lua_Mob, Lua_Entity>("Mob")
 	.def(luabind::constructor<>())
@@ -3648,6 +3666,9 @@ luabind::scope lua_register_mob() {
 	.def("IsMoving", &Lua_Mob::IsMoving)
 	.def("IsPausedTimer", &Lua_Mob::IsPausedTimer)
 	.def("IsPet", (bool(Lua_Mob::*)(void))&Lua_Mob::IsPet)
+	.def("IsPetOwnerBot", &Lua_Mob::IsPetOwnerBot)
+	.def("IsPetOwnerClient", &Lua_Mob::IsPetOwnerClient)
+	.def("IsPetOwnerNPC", &Lua_Mob::IsPetOwnerNPC)
 	.def("IsRoamer", (bool(Lua_Mob::*)(void))&Lua_Mob::IsRoamer)
 	.def("IsRooted", (bool(Lua_Mob::*)(void))&Lua_Mob::IsRooted)
 	.def("IsRunning", (bool(Lua_Mob::*)(void))&Lua_Mob::IsRunning)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -574,6 +574,9 @@ public:
 	bool IsCharmed();
 	bool IsFamiliar();
 	bool IsTargetLockPet();
+	bool IsPetOwnerBot();
+	bool IsPetOwnerClient();
+	bool IsPetOwnerNPC();
 };
 
 #endif

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -392,6 +392,7 @@ Mob::Mob(
 	pet_stop          = false;
 	pet_regroup       = false;
 	_IsTempPet        = false;
+	pet_owner_bot     = false;
 	pet_owner_client  = false;
 	pet_owner_npc     = false;
 	pet_targetlock_id = 0;

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1076,10 +1076,12 @@ public:
 	inline int16 GetTempPetCount() const { return count_TempPet; }
 	inline void SetTempPetCount(int16 i) { count_TempPet = i; }
 	bool HasPetAffinity() { if (aabonuses.GivePetGroupTarget || itembonuses.GivePetGroupTarget || spellbonuses.GivePetGroupTarget) return true; return false; }
+	inline bool IsPetOwnerBot() const { return pet_owner_bot; }
+	inline void SetPetOwnerBot(bool b) { pet_owner_bot = b; }
 	inline bool IsPetOwnerClient() const { return pet_owner_client; }
-	inline void SetPetOwnerClient(bool value) { pet_owner_client = value; }
+	inline void SetPetOwnerClient(bool b) { pet_owner_client = b; }
 	inline bool IsPetOwnerNPC() const { return pet_owner_npc; }
-	inline void SetPetOwnerNPC(bool value) { pet_owner_npc = value; }
+	inline void SetPetOwnerNPC(bool b) { pet_owner_npc = b; }
 	inline bool IsTempPet() const { return _IsTempPet; }
 	inline void SetTempPet(bool value) { _IsTempPet = value; }
 	inline bool IsHorse() { return is_horse; }
@@ -1838,8 +1840,9 @@ protected:
 	bool hasTempPet;
 	bool _IsTempPet;
 	int16 count_TempPet;
-	bool pet_owner_client; //Flags regular and pets as belonging to a client
-	bool pet_owner_npc;    //Flags regular and pets as belonging to a npc
+	bool pet_owner_bot;    // Flags pets as belonging to a Bot
+	bool pet_owner_client; // Flags pets as belonging to a Client
+	bool pet_owner_npc;    // Flags pets as belonging to an NPC
 	uint32 pet_targetlock_id;
 
 	glm::vec3 m_TargetRing;

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -2162,7 +2162,9 @@ void NPC::PetOnSpawn(NewSpawn_Struct* ns)
 			}
 		}
 
-		if (swarm_owner->IsNPC()) {
+		if (swarm_owner->IsBot()) {
+			SetPetOwnerBot(true);
+		} else if (swarm_owner->IsNPC()) {
 			SetPetOwnerNPC(true);
 		}
 	} else if (GetOwnerID()) {
@@ -2179,8 +2181,13 @@ void NPC::PetOnSpawn(NewSpawn_Struct* ns)
 					}
 				}
 			} else {
-				if (entity_list.GetNPCByID(GetOwnerID())) {
-					SetPetOwnerNPC(true);
+				Mob* owner = entity_list.GetMob(GetOwnerID());
+				if (owner) {
+					if (owner->IsBot()) {
+						SetPetOwnerBot(true);
+					} else if (entity_list.GetNPCByID(GetOwnerID())) {
+						SetPetOwnerNPC(true);
+					}
 				}
 			}
 		}

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -2185,7 +2185,7 @@ void NPC::PetOnSpawn(NewSpawn_Struct* ns)
 				if (owner) {
 					if (owner->IsBot()) {
 						SetPetOwnerBot(true);
-					} else if (entity_list.GetNPCByID(GetOwnerID())) {
+					} else if (owner->IsNPC()) {
 						SetPetOwnerNPC(true);
 					}
 				}

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -3380,6 +3380,21 @@ bool Perl_Mob_IsTargetLockPet(Mob* self)
 	return self->IsTargetLockPet();
 }
 
+bool Perl_Mob_IsPetOwnerBot(Mob* self)
+{
+	return self->IsPetOwnerBot();
+}
+
+bool Perl_Mob_IsPetOwnerClient(Mob* self)
+{
+	return self->IsPetOwnerClient();
+}
+
+bool Perl_Mob_IsPetOwnerNPC(Mob* self)
+{
+	return self->IsPetOwnerNPC();
+}
+
 void perl_register_mob()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3782,6 +3797,9 @@ void perl_register_mob()
 	package.add("IsOfClientBotMerc", &Perl_Mob_IsOfClientBotMerc);
 	package.add("IsPausedTimer", &Perl_Mob_IsPausedTimer);
 	package.add("IsPet", &Perl_Mob_IsPet);
+	package.add("IsPetOwnerBot", &Perl_Mob_IsPetOwnerBot);
+	package.add("IsPetOwnerClient", &Perl_Mob_IsPetOwnerClient);
+	package.add("IsPetOwnerNPC", &Perl_Mob_IsPetOwnerNPC);
 	package.add("IsPlayerCorpse", &Perl_Mob_IsPlayerCorpse);
 	package.add("IsRoamer", &Perl_Mob_IsRoamer);
 	package.add("IsRooted", &Perl_Mob_IsRooted);


### PR DESCRIPTION
# Perl
- Add `$mob->IsPetOwnerBot()`.
- Add `$mob->IsPetOwnerClient()`.
- Add `$mob->IsPetOwnerNPC()`.

# Lua
- Add `mob:IsPetOwnerBot()`.
- Add `mob:IsPetOwnerClient()`.
- Add `mob:IsPetOwnerNPC()`.

# Notes
- Allows operators to use these short hands instead of doing a `GetOwner() && GetOwner()->IsClient()`.