### PR TITLE
[Quest API] Add GetNPCSpellsEffectsID() to Perl/Lua

### DIFF
--- a/zone/lua_npc.cpp
+++ b/zone/lua_npc.cpp
@@ -378,7 +378,7 @@ bool Lua_NPC::GetFollowCanRun() {
 	return self->GetFollowCanRun();
 }
 
-int Lua_NPC::GetNPCSpellsID() {
+uint32 Lua_NPC::GetNPCSpellsID() {
 	Lua_Safe_Call_Int();
 	return self->GetNPCSpellsID();
 }
@@ -825,6 +825,12 @@ void Lua_NPC::SetNPCAggro(bool in_npc_aggro)
 	self->SetNPCAggro(in_npc_aggro);
 }
 
+uint32 Lua_NPC::GetNPCSpellsEffectsID()
+{
+	Lua_Safe_Call_Int();
+	return self->GetNPCSpellsEffectsID();
+}
+
 luabind::scope lua_register_npc() {
 	return luabind::class_<Lua_NPC, Lua_Mob>("NPC")
 	.def(luabind::constructor<>())
@@ -887,8 +893,8 @@ luabind::scope lua_register_npc() {
 	.def("GetNPCAggro", (bool(Lua_NPC::*)(void))&Lua_NPC::GetNPCAggro)
 	.def("GetNPCFactionID", (int(Lua_NPC::*)(void))&Lua_NPC::GetNPCFactionID)
 	.def("GetNPCHate", (int64(Lua_NPC::*)(Lua_Mob))&Lua_NPC::GetNPCHate)
-	.def("GetNPCSpellsID", (int(Lua_NPC::*)(void))&Lua_NPC::GetNPCSpellsID)
-	.def("GetNPCSpellsID", (int(Lua_NPC::*)(void))&Lua_NPC::GetNPCSpellsID)
+	.def("GetNPCSpellsEffectsID", (uint32(Lua_NPC::*)(void))&Lua_NPC::GetNPCSpellsEffectsID)
+	.def("GetNPCSpellsID", (uint32(Lua_NPC::*)(void))&Lua_NPC::GetNPCSpellsID)
 	.def("GetNPCStat", (float(Lua_NPC::*)(std::string))&Lua_NPC::GetNPCStat)
 	.def("GetPetSpellID", (int(Lua_NPC::*)(void))&Lua_NPC::GetPetSpellID)
 	.def("GetPlatinum", (uint32(Lua_NPC::*)(void))&Lua_NPC::GetPlatinum)

--- a/zone/lua_npc.h
+++ b/zone/lua_npc.h
@@ -102,7 +102,7 @@ public:
 	int GetFollowID();
 	int GetFollowDistance();
 	bool GetFollowCanRun();
-	int GetNPCSpellsID();
+	uint32 GetNPCSpellsID();
 	int GetSpawnPointID();
 	float GetSpawnPointX();
 	float GetSpawnPointY();
@@ -184,6 +184,7 @@ public:
 	void SetBucket(std::string bucket_name, std::string bucket_value, std::string expiration);
 	bool GetNPCAggro();
 	void SetNPCAggro(bool in_npc_aggro);
+	uint32 GetNPCSpellsEffectsID();
 };
 
 #endif

--- a/zone/perl_npc.cpp
+++ b/zone/perl_npc.cpp
@@ -786,6 +786,11 @@ void Perl_NPC_SetNPCAggro(NPC* self, bool in_npc_aggro) // @categories Script Ut
 	self->SetNPCAggro(in_npc_aggro);
 }
 
+uint32 Perl_NPC_GetNPCSpellsEffectsID(NPC* self)
+{
+	return self->GetNPCSpellsEffectsID();
+}
+
 
 void perl_register_npc()
 {
@@ -851,6 +856,7 @@ void perl_register_npc()
 	package.add("GetNPCAggro", &Perl_NPC_GetNPCAggro);
 	package.add("GetNPCFactionID", &Perl_NPC_GetNPCFactionID);
 	package.add("GetNPCHate", &Perl_NPC_GetNPCHate);
+	package.add("GetNPCSpellsEffectsID", &Perl_NPC_GetNPCSpellsEffectsID);
 	package.add("GetNPCSpellsID", &Perl_NPC_GetNPCSpellsID);
 	package.add("GetNPCStat", &Perl_NPC_GetNPCStat);
 	package.add("GetPetSpellID", &Perl_NPC_GetPetSpellID);


### PR DESCRIPTION
# Perl
- Add `$npc->GetNPCSpellsEffectsID()`.

# Lua
- Add `npc:GetNPCSpellsEffectsID()`.

# Notes
- Allows operator's to get an NPC's spell effects ID.