### PR TITLE
[Bug Fix] /who all displays incorrect guild name. /who works fine

### DIFF
--- a/world/wguild_mgr.cpp
+++ b/world/wguild_mgr.cpp
@@ -230,13 +230,23 @@ void WorldGuildManager::ProcessZonePacket(ServerPacket *pack) {
 	case ServerOP_GuildChannel:
 	case ServerOP_GuildURL:
 	case ServerOP_GuildMemberRemove:
-	case ServerOP_GuildMemberAdd:
 	case ServerOP_GuildSendGuildList:
 	case ServerOP_GuildMembersList:
 	{
 		zoneserver_list.SendPacketToBootedZones(pack);
 		break;
 	}
+    case ServerOP_GuildMemberAdd: 
+	{
+        auto in    = (ServerOP_GuildMessage_Struct *)pack->pBuffer;
+        auto guild = GetGuildByGuildID(in->guild_id);
+        if (!guild) {
+            BaseGuildManager::RefreshGuild(in->guild_id);
+        }
+
+        zoneserver_list.SendPacketToBootedZones(pack);
+        break;
+    }
 	default:
 		LogGuilds("Unknown packet {:#04x} received from zone??", pack->opcode);
 		break;


### PR DESCRIPTION
If you create a guild and immediately do a /who all, the guild tag in the displayed info is 'Invalid Guild' instead of the actual guild name.  A /who displays the correct guild tag.

Issue: The guild creation routine is not updating world memory immediately.  It does update when a permission is changed, a guild rank name is changed, or the player zones.
