### PR TITLE
[Bug Fix] Fix issue with NPC Secondary Textures

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1269,8 +1269,8 @@ void Mob::FillSpawnStruct(NewSpawn_Struct* ns, Mob* ForWho)
 
 	strn0cpy(ns->spawn.lastName, lastname, sizeof(ns->spawn.lastName));
 
-	if (IsPlayerRace(race)) {
-		for (i = 0; i < EQ::textures::weaponPrimary; i++) {
+	for (i = 0; i < EQ::textures::materialCount; i++) {
+		if (IsPlayerRace(race) || i > EQ::textures::armorFeet) {
 			ns->spawn.equipment.Slot[i].Material        = GetEquipmentMaterial(i);
 			ns->spawn.equipment.Slot[i].EliteModel      = IsEliteMaterialItem(i);
 			ns->spawn.equipment.Slot[i].HerosForgeModel = GetHerosForgeModel(i);

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1220,10 +1220,7 @@ void Mob::FillSpawnStruct(NewSpawn_Struct* ns, Mob* ForWho)
 	UpdateActiveLight();
 	ns->spawn.light		= m_Light.Type[EQ::lightsource::LightActive];
 
-	if (IsNPC() && race == ERUDITE)
-		ns->spawn.showhelm = 1;
-	else
-		ns->spawn.showhelm = (helmtexture && helmtexture != 0xFF) ? 1 : 0;
+	ns->spawn.showhelm = (helmtexture && helmtexture != std::numeric_limits<uint8>::max()) ? 1 : 0;
 
 	ns->spawn.invis		= (invisible || hidden) ? 1 : 0;	// TODO: load this before spawning players
 	ns->spawn.NPC		= IsClient() ? 0 : 1;

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1285,7 +1285,12 @@ void Mob::FillSpawnStruct(NewSpawn_Struct* ns, Mob* ForWho)
 
 	if (texture > 0) {
 		for (i = 0; i < 9; i++) {
-			if (i == EQ::textures::weaponPrimary || i == EQ::textures::weaponSecondary || texture == 255) {
+			if (
+				i == EQ::textures::weaponPrimary ||
+				i == EQ::textures::weaponSecondary ||
+				i == EQ::textures::armorHead ||
+				texture == std::numeric_limits<uint8>::max()
+			) {
 				continue;
 			}
 			ns->spawn.equipment.Slot[i].Material = texture;

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1220,7 +1220,7 @@ void Mob::FillSpawnStruct(NewSpawn_Struct* ns, Mob* ForWho)
 	UpdateActiveLight();
 	ns->spawn.light		= m_Light.Type[EQ::lightsource::LightActive];
 
-	ns->spawn.showhelm = (helmtexture && helmtexture != std::numeric_limits<uint8>::max()) ? 1 : 0;
+	ns->spawn.showhelm = helmtexture != std::numeric_limits<uint8>::max() ? 1 : 0;
 
 	ns->spawn.invis		= (invisible || hidden) ? 1 : 0;	// TODO: load this before spawning players
 	ns->spawn.NPC		= IsClient() ? 0 : 1;
@@ -1269,10 +1269,8 @@ void Mob::FillSpawnStruct(NewSpawn_Struct* ns, Mob* ForWho)
 
 	strn0cpy(ns->spawn.lastName, lastname, sizeof(ns->spawn.lastName));
 
-	//for (i = 0; i < _MaterialCount; i++)
-	for (i = 0; i < 9; i++) {
-		// Only Player Races Wear Armor
-		if (IsPlayerRace(race) || i > 6) {
+	if (IsPlayerRace(race)) {
+		for (i = 0; i < EQ::textures::weaponPrimary; i++) {
 			ns->spawn.equipment.Slot[i].Material        = GetEquipmentMaterial(i);
 			ns->spawn.equipment.Slot[i].EliteModel      = IsEliteMaterialItem(i);
 			ns->spawn.equipment.Slot[i].HerosForgeModel = GetHerosForgeModel(i);
@@ -1280,18 +1278,42 @@ void Mob::FillSpawnStruct(NewSpawn_Struct* ns, Mob* ForWho)
 		}
 	}
 
-	if (texture > 0) {
-		for (i = 0; i < 9; i++) {
-			if (
-				i == EQ::textures::weaponPrimary ||
-				i == EQ::textures::weaponSecondary ||
-				i == EQ::textures::armorHead ||
-				texture == std::numeric_limits<uint8>::max()
-			) {
-				continue;
-			}
-			ns->spawn.equipment.Slot[i].Material = texture;
+	for (i = 0; i < EQ::textures::weaponPrimary; i++) {
+		if (texture == std::numeric_limits<uint8>::max()) {
+			continue;
 		}
+
+		if (i == EQ::textures::armorHead && helmtexture != texture) {
+			ns->spawn.equipment.Slot[i].Material = helmtexture;
+			continue;
+		}
+
+		if (i == EQ::textures::armorArms && armtexture != 0) {
+			ns->spawn.equipment.Slot[i].Material = armtexture;
+			continue;
+		}
+
+		if (i == EQ::textures::armorWrist && bracertexture != 0) {
+			ns->spawn.equipment.Slot[i].Material = bracertexture;
+			continue;
+		}
+
+		if (i == EQ::textures::armorHands && handtexture != 0) {
+			ns->spawn.equipment.Slot[i].Material = handtexture;
+			continue;
+		}
+
+		if (i == EQ::textures::armorLegs && legtexture != 0) {
+			ns->spawn.equipment.Slot[i].Material = legtexture;
+			continue;
+		}
+
+		if (i == EQ::textures::armorFeet && feettexture != 0) {
+			ns->spawn.equipment.Slot[i].Material = feettexture;
+			continue;
+		}
+
+		ns->spawn.equipment.Slot[i].Material = texture;
 	}
 
 	memset(ns->spawn.set_to_0xFF, 0xFF, sizeof(ns->spawn.set_to_0xFF));


### PR DESCRIPTION
# Notes
- We were overwriting secondary materials within this secondary loop which caused NPC's materials to show their body texture in some places or no texture for their head if their `showhelm` was not flagged.

# Images
## Before Fix
![image](https://github.com/EQEmu/Server/assets/89047260/67915f62-303a-4741-a778-23bb5c94cd46)
## After Fix
![image](https://github.com/EQEmu/Server/assets/89047260/1dcb75f4-2be8-46c2-b29e-59d8fd9f04c3)
![image](https://github.com/EQEmu/Server/assets/89047260/6943609a-815b-4877-8276-311d78cfa3fc)
