### PR TITLE
[Hotfix] Fix forage returning first result from table

### DIFF
--- a/zone/forage.cpp
+++ b/zone/forage.cpp
@@ -89,7 +89,7 @@ uint32 ZoneDatabase::LoadForage(uint32 zone_id, uint8 skill_level)
 		}
 
 		forage_items[count]   = e.Itemid;
-		forage_chances[count] = e.chance;
+		forage_chances[count] = e.chance + current_chance;
 
 		current_chance = forage_chances[count];
 


### PR DESCRIPTION
Forage was not properly incrementing the total chance of items when more than one was found and would result in the final chance roll being based off the last item found rather than the total. This would cause the first item returned to be chosen in most cases when the chances are the same in the table.