### PR TITLE
[Bug Fix] Cleanup NPC Mana Tap Logic

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -495,6 +495,7 @@ RULE_BOOL(Spells, EvacClearCharmPet, false, "Enable to have evac in zone clear c
 RULE_BOOL(Spells, ManaTapsRequireNPCMana, false, "Enabling will require target to have mana to tap. Default off as many npc's are caster class with 0 mana and need fixed.")
 RULE_INT(Spells, HarmTouchCritRatio, 200, "Harmtouch crit bonus, on top of BaseCritRatio")
 RULE_BOOL(Spells, UseClassicSpellFocus, false, "Enabling will tell the server to handle random focus damage as classic spell imports lack the limit values.")
+RULE_BOOL(Spells, ManaTapsOnAnyClass, false, "Enabling this will allow you to cast mana taps on any class, this will bypass ManaTapsRequireNPCMana rule.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Combat)

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -221,9 +221,12 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 		BuffFadeByEffect(SE_NegateIfCombat);
 	}
 
-	// check to see if target is a caster mob before performing a mana tap
 	if(GetTarget() && IsManaTapSpell(spell_id)) {
-		if (!RuleB(Spells, ManaTapsOnAnyClass) && GetTarget()->GetCasterClass() != 'N' && RuleB(Spells, ManaTapsRequireNPCMana) &&  GetTarget()->GetMana() == 0) {
+		// If melee, block if ManaTapsOnAnyClass rule is false
+		// if caster, block if ManaTapsRequireNPCMana and no mana
+		bool melee_block = !RuleB(Spells, ManaTapsOnAnyClass);
+		bool caster_block = (GetTarget()->GetCasterClass() != 'N' && RuleB(Spells, ManaTapsRequireNPCMana) &&  GetTarget()->GetMana() == 0);
+		if (melee_block || caster_block) {
 			InterruptSpell(TARGET_NO_MANA, 0x121, spell_id);
 			return false;
 		}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -223,7 +223,7 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 
 	// check to see if target is a caster mob before performing a mana tap
 	if(GetTarget() && IsManaTapSpell(spell_id)) {
-		if (RuleB(Spells, ManaTapsRequireNPCMana) &&  GetTarget()->GetMana() == 0) {
+		if (!RuleB(Spells, ManaTapsOnAnyClass) && GetTarget()->GetCasterClass() != 'N' && RuleB(Spells, ManaTapsRequireNPCMana) &&  GetTarget()->GetMana() == 0) {
 			InterruptSpell(TARGET_NO_MANA, 0x121, spell_id);
 			return false;
 		}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -223,16 +223,7 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 
 	// check to see if target is a caster mob before performing a mana tap
 	if(GetTarget() && IsManaTapSpell(spell_id)) {
-		if (
-			GetTarget()->GetCasterClass() == 'N' &&
-			(
-				!RuleB(Spells, ManaTapsRequireNPCMana) ||
-				(
-					RuleB(Spells, ManaTapsRequireNPCMana) &&
-					GetTarget()->GetMana() == 0
-				)
-			)
-		) {
+		if (RuleB(Spells, ManaTapsRequireNPCMana) &&  GetTarget()->GetMana() == 0) {
 			InterruptSpell(TARGET_NO_MANA, 0x121, spell_id);
 			return false;
 		}


### PR DESCRIPTION
Previous soultion could not block melee targets unless requiremana rule was off.  

This coding allows both rules to operate independantly.