### PR TITLE
[Commands] Add #fish Command

### DIFF
--- a/zone/client.h
+++ b/zone/client.h
@@ -1090,7 +1090,7 @@ public:
 	void SetPEQZoneFlag(uint32 zone_id);
 
 	bool CanFish();
-	void GoFish(bool guarantee = false, bool use_no_bait = false);
+	void GoFish(bool guarantee = false, bool use_bait = true);
 	void ForageItem(bool guarantee = false);
 	//Calculate vendor price modifier based on CHA: (reverse==selling)
 	float CalcPriceMod(Mob* other = 0, bool reverse = false);

--- a/zone/client.h
+++ b/zone/client.h
@@ -1090,7 +1090,7 @@ public:
 	void SetPEQZoneFlag(uint32 zone_id);
 
 	bool CanFish();
-	void GoFish();
+	void GoFish(bool guarantee = false, bool use_no_bait = false);
 	void ForageItem(bool guarantee = false);
 	//Calculate vendor price modifier based on CHA: (reverse==selling)
 	float CalcPriceMod(Mob* other = 0, bool reverse = false);

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -131,6 +131,7 @@ int command_init(void)
 		command_add("feature", "Change your or your target's feature's temporarily", AccountStatus::QuestTroupe, command_feature) ||
 		command_add("size", "Change your targets size (alias of #feature size)", AccountStatus::QuestTroupe, command_feature) ||
 		command_add("find", "Search command used to find various things", AccountStatus::Guide, command_find) ||
+		command_add("fish", "Fish for an item", AccountStatus::QuestTroupe, command_fish) ||
 		command_add("fixmob", "[race|gender|texture|helm|face|hair|haircolor|beard|beardcolor|heritage|tattoo|detail] [next|prev] - Manipulate appearance of your target", AccountStatus::QuestTroupe, command_fixmob) ||
 		command_add("flagedit", "Edit zone flags on your target. Use #flagedit help for more info.", AccountStatus::GMAdmin, command_flagedit) ||
 		command_add("forage", "Forage an item", AccountStatus::QuestTroupe, command_forage) ||
@@ -823,6 +824,7 @@ void command_bot(Client *c, const Seperator *sep)
 #include "gm_commands/faction.cpp"
 #include "gm_commands/feature.cpp"
 #include "gm_commands/find.cpp"
+#include "gm_commands/fish.cpp"
 #include "gm_commands/fixmob.cpp"
 #include "gm_commands/flagedit.cpp"
 #include "gm_commands/forage.cpp"

--- a/zone/command.h
+++ b/zone/command.h
@@ -83,6 +83,7 @@ void command_faction(Client *c, const Seperator *sep);
 void command_faction_association(Client *c, const Seperator *sep);
 void command_feature(Client *c, const Seperator *sep);
 void command_find(Client *c, const Seperator *sep);
+void command_fish(Client* c, const Seperator* sep);
 void command_fixmob(Client *c, const Seperator *sep);
 void command_flagedit(Client *c, const Seperator *sep);
 void command_forage(Client* c, const Seperator* sep);

--- a/zone/forage.cpp
+++ b/zone/forage.cpp
@@ -257,7 +257,7 @@ bool Client::CanFish() {
 	return true;
 }
 
-void Client::GoFish()
+void Client::GoFish(bool guarantee, bool use_no_bait)
 {
 
 	//TODO: generate a message if we're already fishing
@@ -306,7 +306,7 @@ void Client::GoFish()
 		fishing_skill = 100+((fishing_skill-100)/2);
 	}
 
-	if (zone->random.Int(0,175) < fishing_skill) {
+	if (guarantee || zone->random.Int(0,175) < fishing_skill) {
 		uint32 food_id = 0;
 
 		//25% chance to fish an item.
@@ -343,8 +343,10 @@ void Client::GoFish()
 			}
 		}
 
-		//consume bait, should we always consume bait on success?
-		DeleteItemInInventory(bslot, 1, true);	//do we need client update?
+		if (!use_no_bait) {
+			//consume bait, should we always consume bait on success?
+			DeleteItemInInventory(bslot, 1, true);    //do we need client update?
+		}
 
 		if(food_id == 0) {
 			int index = zone->random.Int(0, MAX_COMMON_FISH_IDS-1);

--- a/zone/forage.cpp
+++ b/zone/forage.cpp
@@ -257,7 +257,7 @@ bool Client::CanFish() {
 	return true;
 }
 
-void Client::GoFish(bool guarantee, bool use_no_bait)
+void Client::GoFish(bool guarantee, bool use_bait)
 {
 
 	//TODO: generate a message if we're already fishing
@@ -343,7 +343,7 @@ void Client::GoFish(bool guarantee, bool use_no_bait)
 			}
 		}
 
-		if (!use_no_bait) {
+		if (use_bait) {
 			//consume bait, should we always consume bait on success?
 			DeleteItemInInventory(bslot, 1, true);    //do we need client update?
 		}

--- a/zone/gm_commands/fish.cpp
+++ b/zone/gm_commands/fish.cpp
@@ -2,5 +2,5 @@
 
 void command_fish(Client *c, const Seperator *sep)
 {
-	c->GoFish(true, true);
+	c->GoFish(true, false);
 }

--- a/zone/gm_commands/fish.cpp
+++ b/zone/gm_commands/fish.cpp
@@ -1,0 +1,6 @@
+#include "../client.h"
+
+void command_fish(Client *c, const Seperator *sep)
+{
+	c->GoFish(true, true);
+}


### PR DESCRIPTION
# Notes
- Adds `#fish` command.
- Allows operators to simulate fishing to see what they would get, consumes no bait.