### PR TITLE
[Feature] Exempt a zone from IP-limit checks.

### DIFF
--- a/common/rulesys.h
+++ b/common/rulesys.h
@@ -23,6 +23,7 @@
 * - RuleI(category, rule) -> fetch an integer rule's value
 * - RuleR(category, rule) -> fetch a real (float) rule's value
 * - RuleB(category, rule) -> fetch a boolean/flag rule's value
+* - RuleS(category, rule) -> fetch a string rule's value
 *
 */
 
@@ -35,6 +36,8 @@
     RuleManager::Instance()->GetRealRule( RuleManager::Real__##rule_name )
 #define RuleB(category_name, rule_name) \
     RuleManager::Instance()->GetBoolRule( RuleManager::Bool__##rule_name )
+#define RuleS(category_name, rule_name) \
+    RuleManager::Instance()->GetStringRule( RuleManager::String__##rule_name )
 
 
 #include <vector>
@@ -82,6 +85,17 @@ public:
 	static const int BoolRuleCount = static_cast<int>(_BoolRuleCount);
 
 	typedef enum {
+#define RULE_STRING(category_name, rule_name, default_value, notes) \
+        String__##rule_name,
+
+#include "ruletypes.h"
+
+		_StringRuleCount
+	} StringType;
+
+	static const int StringRuleCount = static_cast<int>(_StringRuleCount);
+
+	typedef enum {
 #define RULE_CATEGORY(category_name) \
         Category__##category_name,
 
@@ -99,45 +113,49 @@ public:
 	static const IntType      InvalidInt      = _IntRuleCount;
 	static const RealType     InvalidReal     = _RealRuleCount;
 	static const BoolType     InvalidBool     = _BoolRuleCount;
+	static const StringType   InvalidString   = _StringRuleCount;
 	static const CategoryType InvalidCategory = _CatCount;
 
-	static const uint32 RulesCount = IntRuleCount + RealRuleCount + BoolRuleCount;
+	static const uint32 RulesCount = IntRuleCount + RealRuleCount + BoolRuleCount + StringRuleCount;
 
 	//fetch routines, you should generally use the Rule* macros instead of this
 	int GetIntRule(IntType t) const;
 	float GetRealRule(RealType t) const;
 	bool GetBoolRule(BoolType t) const;
+	std::string GetStringRule(StringType t) const;
 
 	//management routines
 	static std::string GetRuleName(IntType t) { return s_RuleInfo[static_cast<int>(t)].name; }
 	static std::string GetRuleName(RealType t) { return s_RuleInfo[static_cast<int>(t) + IntRuleCount].name; }
 	static std::string GetRuleName(BoolType t) { return s_RuleInfo[static_cast<int>(t) + IntRuleCount + RealRuleCount].name; }
-	static const std::string &GetRuleNotes(IntType t) { return s_RuleInfo[static_cast<int>(t)].notes; }
-	static const std::string &GetRuleNotes(RealType t) { return s_RuleInfo[static_cast<int>(t) + IntRuleCount].notes; }
-	static const std::string &GetRuleNotes(BoolType t) { return s_RuleInfo[static_cast<int>(t) + IntRuleCount + RealRuleCount].notes; }
+	static std::string GetRuleName(StringType t) { return s_RuleInfo[static_cast<int>(t) + IntRuleCount + RealRuleCount + StringRuleCount].name; }
+	static const std::string& GetRuleNotes(IntType t) { return s_RuleInfo[static_cast<int>(t)].notes; }
+	static const std::string& GetRuleNotes(RealType t) { return s_RuleInfo[static_cast<int>(t) + IntRuleCount].notes; }
+	static const std::string& GetRuleNotes(BoolType t) { return s_RuleInfo[static_cast<int>(t) + IntRuleCount + RealRuleCount].notes; }
+	static const std::string& GetRuleNotes(StringType t) { return s_RuleInfo[static_cast<int>(t) + IntRuleCount + RealRuleCount + StringRuleCount].notes; }
 	static uint32 CountRules() { return RulesCount; }
-	static CategoryType FindCategory(const std::string &category_name);
-	bool ListRules(const std::string &category_name, std::vector <std::string> &l);
-	bool ListCategories(std::vector <std::string> &l);
-	bool GetRule(const std::string &rule_name, std::string &rule_value);
+	static CategoryType FindCategory(const std::string& category_name);
+	bool ListRules(const std::string& category_name, std::vector<std::string>& l);
+	bool ListCategories(std::vector<std::string>& l);
+	bool GetRule(const std::string& rule_name, std::string& rule_value);
 	bool SetRule(
-		const std::string &rule_name,
-		const std::string &rule_value,
-		Database *db = nullptr,
+		const std::string& rule_name,
+		const std::string& rule_value,
+		Database* db = nullptr,
 		bool db_save = false,
 		bool reload = false
 	);
 
 	int GetActiveRulesetID() const { return m_activeRuleset; }
 	std::string GetActiveRuleset() const { return m_activeName; }
-	static bool ListRulesets(Database *db, std::map<int, std::string> &l);
+	static bool ListRulesets(Database* db, std::map<int, std::string>& l);
 
 	void ResetRules(bool reload = false);
-	bool LoadRules(Database *db, const std::string &rule_set_name, bool reload = false);
-	void SaveRules(Database *db, const std::string &rule_set_name);
-	bool UpdateInjectedRules(Database *db, const std::string &rule_set_name, bool quiet_update = false);
-	bool UpdateOrphanedRules(Database *db, bool quiet_update = false);
-	bool RestoreRuleNotes(Database *db);
+	bool LoadRules(Database* db, const std::string& rule_set_name, bool reload = false);
+	void SaveRules(Database* db, const std::string& rule_set_name);
+	bool UpdateInjectedRules(Database* db, const std::string& rule_set_name, bool quiet_update = false);
+	bool UpdateOrphanedRules(Database* db, bool quiet_update = false);
+	bool RestoreRuleNotes(Database* db);
 
 private:
 	RuleManager();
@@ -147,21 +165,23 @@ private:
 	int         m_activeRuleset;
 	std::string m_activeName;
 
-	int    m_RuleIntValues[IntRuleCount];
-	float  m_RuleRealValues[RealRuleCount];
-	uint32 m_RuleBoolValues[BoolRuleCount];
+	int         m_RuleIntValues[IntRuleCount];
+	float       m_RuleRealValues[RealRuleCount];
+	uint32      m_RuleBoolValues[BoolRuleCount];
+	std::string m_RuleStringValues[StringRuleCount];
 
 	typedef enum {
 		IntRule,
 		RealRule,
-		BoolRule
+		BoolRule,
+		StringRule
 	} RuleType;
 
-	static bool _FindRule(const std::string &rule_name, RuleType &type_into, uint16 &index_into);
+	static bool _FindRule(const std::string& rule_name, RuleType& type_into, uint16& index_into);
 	static std::string _GetRuleName(RuleType type, uint16 index);
-	static const std::string &_GetRuleNotes(RuleType type, uint16 index);
-	static int _FindOrCreateRuleset(Database *db, const std::string &rule_set_name);
-	void _SaveRule(Database *db, RuleType type, uint16 index);
+	static const std::string& _GetRuleNotes(RuleType type, uint16 index);
+	static int _FindOrCreateRuleset(Database* db, const std::string& rule_set_name);
+	void _SaveRule(Database* db, RuleType type, uint16 index);
 
 	static const char* s_categoryNames[];
 	typedef struct {

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -324,6 +324,7 @@ RULE_INT(World, MaximumQuestErrors, 30, "Changes the maximum number of quest err
 RULE_INT(World, BootHour, 0, "Sets the in-game hour world will set when it first boots. 0-24 are valid options, where 0 disables this rule")
 RULE_BOOL(World, UseItemLinksForKeyRing, false, "Uses item links for Key Ring Listing instead of item name")
 RULE_BOOL(World, UseOldShadowKnightClassExport, true, "Disable to have Shadowknight show as Shadow Knight (live-like)")
+RULE_INT(World, IPExemptionZone, 0, "Set to zone ID to ignore for the purposes of IP Limits. Set to 0 to disable.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Zone)

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -327,7 +327,7 @@ RULE_INT(World, MaximumQuestErrors, 30, "Changes the maximum number of quest err
 RULE_INT(World, BootHour, 0, "Sets the in-game hour world will set when it first boots. 0-24 are valid options, where 0 disables this rule")
 RULE_BOOL(World, UseItemLinksForKeyRing, false, "Uses item links for Key Ring Listing instead of item name")
 RULE_BOOL(World, UseOldShadowKnightClassExport, true, "Disable to have Shadowknight show as Shadow Knight (live-like)")
-RULE_INT(World, IPExemptionZone, 0, "Set to zone ID to ignore for the purposes of IP Limits. Set to 0 to disable.")
+RULE_STRING(World, IPExemptionZones, "", "Comma-delimited list of zones to exclude from IP-limit checks. Empty string to disable.")
 RULE_STRING(World, MOTD, "", "Server MOTD sent on login, change from empty to have this be used instead of variables table 'motd' value")
 RULE_CATEGORY_END()
 

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -28,6 +28,9 @@
 #ifndef RULE_BOOL
 #define RULE_BOOL(cat, rule, default_value, notes)
 #endif
+#ifndef RULE_STRING
+#define RULE_STRING(cat, rule, default_value, notes)
+#endif
 #ifndef RULE_CATEGORY_END
 #define RULE_CATEGORY_END()
 #endif
@@ -325,6 +328,7 @@ RULE_INT(World, BootHour, 0, "Sets the in-game hour world will set when it first
 RULE_BOOL(World, UseItemLinksForKeyRing, false, "Uses item links for Key Ring Listing instead of item name")
 RULE_BOOL(World, UseOldShadowKnightClassExport, true, "Disable to have Shadowknight show as Shadow Knight (live-like)")
 RULE_INT(World, IPExemptionZone, 0, "Set to zone ID to ignore for the purposes of IP Limits. Set to 0 to disable.")
+RULE_STRING(World, MOTD, "", "Server MOTD sent on login, change from empty to have this be used instead of variables table 'motd' value")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Zone)
@@ -951,4 +955,5 @@ RULE_CATEGORY_END()
 #undef RULE_INT
 #undef RULE_REAL
 #undef RULE_BOOL
+#undef RULE_STRING
 #undef RULE_CATEGORY_END

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -647,7 +647,7 @@ bool Client::HandleGenerateRandomNamePacket(const EQApplicationPacket *app) {
 		if (database.CheckNameFilter(newName)) {
 			std::string query = StringFormat("SELECT `name` FROM `character_data` WHERE `name` = '%s'", newName);
 			auto res = database.QueryDatabase(query);
-			if (res.Success() && res.RowCount() == 0) {				
+			if (res.Success() && res.RowCount() == 0) {
 				unique = true;
 			}
 		}
@@ -887,14 +887,19 @@ bool Client::HandleEnterWorldPacket(const EQApplicationPacket *app) {
 	}
 
 	auto outapp = new EQApplicationPacket(OP_MOTD);
-	std::string motd_message;
-	if (database.GetVariable("MOTD", motd_message)) {
-		outapp->size = motd_message.length() + 1;
+	std::string motd = RuleS(World, MOTD);
+	if (!motd.empty()) {
+		outapp->size    = motd.length() + 1;
 		outapp->pBuffer = new uchar[outapp->size];
 		memset(outapp->pBuffer, 0, outapp->size);
-		strcpy((char*)outapp->pBuffer, motd_message.c_str());
+		strcpy((char*) outapp->pBuffer, motd.c_str());
+	} else if (database.GetVariable("MOTD", motd)) {
+		outapp->size    = motd.length() + 1;
+		outapp->pBuffer = new uchar[outapp->size];
+		memset(outapp->pBuffer, 0, outapp->size);
+		strcpy((char*) outapp->pBuffer, motd.c_str());
 	} else { // Null Message of the Day. :)
-		outapp->size = 1;
+		outapp->size    = 1;
 		outapp->pBuffer = new uchar[outapp->size];
 		outapp->pBuffer[0] = 0;
 	}

--- a/world/clientlist.cpp
+++ b/world/clientlist.cpp
@@ -98,17 +98,13 @@ void ClientList::GetCLEIP(uint32 in_ip) {
 		cle = iterator.GetData();
 
 		if (RuleS(World, IPExemptionZones)) {
-			std::string IPExemptZones = RuleS(World, IPExemptionZones);
-			std::vector<std::string> zones;
-			std::stringstream ss(IPExemptZones);
-			std::string temp;
-			while (getline(ss, temp, ',')) {
-				zones.push_back(temp);
-			}
-			
-			if (std::find(zones.begin(), zones.end(), std::to_string(cle->zone())) != zones.end()) {
-				iterator.Advance();
-				continue;
+			const auto zones = Strings::Split(RuleS(World, IPExemptionZones), ",");
+
+			for (const auto &z : zones) {
+				if (Strings::ToUnsignedInt(z) == cle->zone()) {
+					iterator.Advance();
+					continue;
+				}
 			}	
 		}
 

--- a/world/clientlist.cpp
+++ b/world/clientlist.cpp
@@ -96,16 +96,13 @@ void ClientList::GetCLEIP(uint32 in_ip) {
 
 	while (iterator.MoreElements()) {
 		cle = iterator.GetData();
-
-		if (RuleS(World, IPExemptionZones)) {
-			const auto zones = Strings::Split(RuleS(World, IPExemptionZones), ",");
-
-			for (const auto &z : zones) {
-				if (Strings::ToUnsignedInt(z) == cle->zone()) {
-					iterator.Advance();
-					continue;
-				}
-			}	
+		
+		const auto zones = Strings::Split(RuleS(World, IPExemptionZones), ",");
+		for (const auto &z : zones) {
+			if (Strings::ToUnsignedInt(z) == cle->zone()) {
+				iterator.Advance();
+				continue;
+			}
 		}
 
 		if (

--- a/world/clientlist.cpp
+++ b/world/clientlist.cpp
@@ -106,7 +106,7 @@ void ClientList::GetCLEIP(uint32 in_ip) {
 				zones.push_back(temp);
 			}
 			
-			if (std::find(zones.begin(), zones.end(), zoneStr) != zones.end()) {
+			if (std::find(zones.begin(), zones.end(), std::to_string(cle->zone())) != zones.end()) {
 				iterator.Advance();
 				continue;
 			}	

--- a/world/clientlist.cpp
+++ b/world/clientlist.cpp
@@ -97,8 +97,8 @@ void ClientList::GetCLEIP(uint32 in_ip) {
 	while (iterator.MoreElements()) {
 		cle = iterator.GetData();
 
-		if (RuleS(World, IPExemptionZone)) {
-			std::string IPExemptZones = RuleS(World, IPExemptionZone);
+		if (RuleS(World, IPExemptionZones)) {
+			std::string IPExemptZones = RuleS(World, IPExemptionZones);
 			std::vector<std::string> zones;
 			std::stringstream ss(IPExemptZones);
 			std::string temp;

--- a/world/clientlist.cpp
+++ b/world/clientlist.cpp
@@ -97,9 +97,19 @@ void ClientList::GetCLEIP(uint32 in_ip) {
 	while (iterator.MoreElements()) {
 		cle = iterator.GetData();
 
-		if (RuleI(World, IPExemptionZone) > 0 && cle->zone() == RuleI(World, IPExemptionZone)) {
-			iterator.Advance();
-			continue;
+		if (RuleS(World, IPExemptionZone)) {
+			std::string IPExemptZones = RuleS(World, IPExemptionZone);
+			std::vector<std::string> zones;
+			std::stringstream ss(IPExemptZones);
+			std::string temp;
+			while (getline(ss, temp, ',')) {
+				zones.push_back(temp);
+			}
+			
+			if (std::find(zones.begin(), zones.end(), zoneStr) != zones.end()) {
+				iterator.Advance();
+				continue;
+			}	
 		}
 
 		if (

--- a/world/clientlist.cpp
+++ b/world/clientlist.cpp
@@ -96,6 +96,12 @@ void ClientList::GetCLEIP(uint32 in_ip) {
 
 	while (iterator.MoreElements()) {
 		cle = iterator.GetData();
+
+		if (RuleI(World, IPExemptionZone) > 0 && cle->zone() == RuleI(World, IPExemptionZone)) {
+			iterator.Advance();
+			continue;
+		}
+
 		if (
 			cle->GetIP() == in_ip &&
 			(

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -1100,7 +1100,7 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 			}
 
 			auto smotd = (ServerMotd_Struct*) pack->pBuffer;
-			database.SetVariable("MOTD", smotd->motd);
+			RuleManager::Instance()->SetRule("MOTD", smotd->motd, &database, true, true);
 			zoneserver_list.SendPacket(pack);
 			break;
 		}

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -7248,7 +7248,7 @@ luabind::scope lua_register_rules_const() {
 #define RULE_BOOL(cat, rule, default_value, notes) \
 		luabind::value(#rule, RuleManager::Bool__##rule),
 #include "../common/ruletypes.h"
-		luabind::value("_BoolRuleCount", RuleManager::_BoolRuleCount)
+		luabind::value("_BoolRuleCount", RuleManager::_BoolRuleCount),
 #undef RULE_BOOL
 #define RULE_STRING(cat, rule, default_value, notes) \
 		luabind::value(#rule, RuleManager::String__##rule),

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -5653,6 +5653,10 @@ bool get_ruleb(int rule) {
 	return RuleManager::Instance()->GetBoolRule((RuleManager::BoolType)rule);
 }
 
+std::string get_rules(int rule) {
+	return RuleManager::Instance()->GetStringRule((RuleManager::StringType)rule);
+}
+
 luabind::scope lua_register_general() {
 	return luabind::namespace_("eq")
 	[(
@@ -7245,6 +7249,12 @@ luabind::scope lua_register_rules_const() {
 		luabind::value(#rule, RuleManager::Bool__##rule),
 #include "../common/ruletypes.h"
 		luabind::value("_BoolRuleCount", RuleManager::_BoolRuleCount)
+#undef RULE_BOOL
+#define RULE_STRING(cat, rule, default_value, notes) \
+		luabind::value(#rule, RuleManager::String__##rule),
+#include "../common/ruletypes.h"
+		luabind::value("_StringRuleCount", RuleManager::_StringRuleCount)
+#undef RULE_STRING
 	)];
 }
 
@@ -7266,6 +7276,13 @@ luabind::scope lua_register_ruleb() {
 	return luabind::namespace_("RuleB")
 		[
 			luabind::def("Get", &get_ruleb)
+		];
+}
+
+luabind::scope lua_register_rules() {
+	return luabind::namespace_("RuleS")
+		[
+			luabind::def("Get", &get_rules)
 		];
 }
 


### PR DESCRIPTION
Allows server operators to select a zone to be skipped for checking IP limits. An example use-case would be to allow the Bazaar to be populated by traders without needing to build a scripted IP-exemption infrastructure.