### PR TITLE
[Bug Fix] Use std::clamp for size

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -4384,17 +4384,15 @@ void Mob::SendWearChangeAndLighting(int8 last_texture) {
 
 void Mob::ChangeSize(float in_size = 0, bool unrestricted)
 {
+	size = std::clamp(in_size, 1.0f, 255.0f);
+
 	if (!unrestricted) {
 		if (IsClient() || petid != 0) {
-			EQ::Clamp(in_size, 3.0f, 15.0f);
+			size = std::clamp(in_size, 3.0f, 15.0f);
 		}
 	}
 
-	EQ::Clamp(in_size, 1.0f, 255.0f);
-
-	size = in_size;
-
-	SendAppearancePacket(AppearanceType::Size, static_cast<uint32>(in_size));
+	SendAppearancePacket(AppearanceType::Size, static_cast<uint32>(size));
 }
 
 Mob* Mob::GetOwnerOrSelf()


### PR DESCRIPTION
Helper template was not deducing float for lower/upper values allowing invalid sizes.
Limit to sane values of 1-255 unrestricted and 3-15 for clients and pets.