### PR TITLE
[Zone] Zone Routing Improvements

### DIFF
--- a/common/content/world_content_service.cpp
+++ b/common/content/world_content_service.cpp
@@ -303,7 +303,7 @@ WorldContentService * WorldContentService::LoadStaticGlobalZoneInstances()
 {
 	m_zone_instances = InstanceListRepository::GetWhere(*GetDatabase(), fmt::format("never_expires = 1 AND is_global = 1"));
 
-	LogInfo("Loaded [{}] zone_instances", m_zones.size());
+	LogInfo("Loaded [{}] zone_instances", m_zone_instances.size());
 
 	return this;
 }

--- a/common/content/world_content_service.h
+++ b/common/content/world_content_service.h
@@ -170,6 +170,14 @@ public:
 	void SetContentFlag(const std::string &content_flag_name, bool enabled);
 
 	void HandleZoneRoutingMiddleware(ZoneChange_Struct *zc);
+
+	struct FindZoneResult {
+		uint32                               zone_id = 0;
+		InstanceListRepository::InstanceList instance;
+		ZoneRepository::Zone                 zone;
+	};
+
+	FindZoneResult FindZone(uint32 zone_id, uint32 instance_id);
 private:
 	int current_expansion{};
 	std::vector<ContentFlagsRepository::ContentFlags> content_flags;

--- a/common/content/world_content_service.h
+++ b/common/content/world_content_service.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include "../repositories/content_flags_repository.h"
 #include "../repositories/zone_repository.h"
+#include "../repositories/instance_list_repository.h"
 
 class Database;
 
@@ -169,7 +170,6 @@ public:
 	void SetContentFlag(const std::string &content_flag_name, bool enabled);
 
 	void HandleZoneRoutingMiddleware(ZoneChange_Struct *zc);
-	WorldContentService * SetContentZones(const std::vector<ZoneRepository::Zone>& zones);
 private:
 	int current_expansion{};
 	std::vector<ContentFlagsRepository::ContentFlags> content_flags;
@@ -180,6 +180,9 @@ private:
 
 	// holds a record of the zone table from the database
 	std::vector<ZoneRepository::Zone> m_zones = {};
+	WorldContentService *LoadStaticGlobalZoneInstances();
+	std::vector<InstanceListRepository::InstanceList> m_zone_instances;
+	WorldContentService * LoadZones();
 };
 
 extern WorldContentService content_service;

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -52,6 +52,7 @@
 #include "../common/repositories/player_event_logs_repository.h"
 #include "../common/repositories/inventory_repository.h"
 #include "../common/events/player_event_logs.h"
+#include "../common/content/world_content_service.h"
 
 #include <iostream>
 #include <iomanip>
@@ -769,6 +770,12 @@ bool Client::HandleEnterWorldPacket(const EQApplicationPacket *app) {
 		LogInfo("Could not get CharInfo for [{}]", char_name);
 		eqs->Close();
 		return true;
+	}
+
+	auto r = content_service.FindZone(zone_id, instance_id);
+	if (r.zone_id && r.instance.id != instance_id) {
+		LogInfo("Zone [{}] has been remapped to instance_id [{}] from instance_id [{}]", r.zone.short_name, r.instance.id, instance_id);
+		instance_id = r.instance.id;
 	}
 
 	// Make sure this account owns this character

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -774,7 +774,13 @@ bool Client::HandleEnterWorldPacket(const EQApplicationPacket *app) {
 
 	auto r = content_service.FindZone(zone_id, instance_id);
 	if (r.zone_id && r.instance.id != instance_id) {
-		LogInfo("Zone [{}] has been remapped to instance_id [{}] from instance_id [{}]", r.zone.short_name, r.instance.id, instance_id);
+		LogInfo(
+			"Zone [{}] has been remapped to instance_id [{}] from instance_id [{}] for client [{}]",
+			r.zone.short_name,
+			r.instance.id,
+			instance_id,
+			char_name
+		);
 		instance_id = r.instance.id;
 	}
 

--- a/world/eqemu_api_world_data_service.cpp
+++ b/world/eqemu_api_world_data_service.cpp
@@ -142,6 +142,7 @@ std::vector<Reload> reload_types = {
 	Reload{.command = "base_data", .opcode = ServerOP_ReloadBaseData, .desc = "Base Data"},
 	Reload{.command = "blocked_spells", .opcode = ServerOP_ReloadBlockedSpells, .desc = "Blocked Spells"},
 	Reload{.command = "commands", .opcode = ServerOP_ReloadCommands, .desc = "Commands"},
+	Reload{.command = "content_flags", .opcode = ServerOP_ReloadContentFlags, .desc = "Content Flags"},
 	Reload{.command = "data_buckets_cache", .opcode = ServerOP_ReloadDataBucketsCache, .desc = "Data Buckets Cache"},
 	Reload{.command = "doors", .opcode = ServerOP_ReloadDoors, .desc = "Doors"},
 	Reload{.command = "dztemplates", .opcode = ServerOP_ReloadDzTemplates, .desc = "Dynamic Zone Templates"},

--- a/world/main.cpp
+++ b/world/main.cpp
@@ -188,6 +188,11 @@ int main(int argc, char **argv)
 		RegisterConsoleFunctions(console);
 	}
 
+	content_service.SetDatabase(&database)
+		->SetContentDatabase(&content_db)
+		->SetExpansionContext()
+		->ReloadContentFlags();
+
 	std::unique_ptr<EQ::Net::ServertalkServer> server_connection;
 	server_connection = std::make_unique<EQ::Net::ServertalkServer>();
 

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -6285,7 +6285,17 @@ void Client::SendZonePoints()
 			zp->zpe[i].z = data->target_z;
 			zp->zpe[i].heading = data->target_heading;
 			zp->zpe[i].zoneid = data->target_zone_id;
-			zp->zpe[i].zoneinstance = data->target_zone_instance;
+
+			// if the target zone is the same as the current zone, use the instance of the current zone
+			// if we don't use the same instance_id that the client was sent, the client will forcefully
+			// issue a zone change request when they should be simply moving to a different point in the same zone
+			// because the client will think the zone point target is different from the current instance
+			auto target_instance = data->target_zone_instance;
+			if (data->target_zone_id == zone->GetZoneID() && data->target_zone_instance == 0) {
+				target_instance = zone->GetInstanceID();
+			}
+
+			zp->zpe[i].zoneinstance = target_instance;
 			i++;
 		}
 		iterator.Advance();

--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -73,6 +73,15 @@ Doors::Doors(const DoorsRepository::Doors &door) :
 	m_door_param              = door.door_param;
 	m_size                    = door.size;
 	m_invert_state            = door.invert_state;
+
+	// if the target zone is the same as the current zone, use the instance of the current zone
+	// if we don't use the same instance_id that the client was sent, the client will forcefully
+	// issue a zone change request when they should be simply moving to a different point in the same zone
+	// because the client will think the zone point target is different from the current instance
+	if (door.dest_zone == zone->GetShortName() && m_destination_instance_id == 0) {
+		m_destination_instance_id = zone->GetInstanceID();
+	}
+
 	m_destination_instance_id = door.dest_instance;
 	m_is_ldon_door            = door.is_ldon_door;
 	m_dz_switch_id            = door.dz_switch_id;

--- a/zone/main.cpp
+++ b/zone/main.cpp
@@ -403,7 +403,6 @@ int main(int argc, char **argv)
 
 	content_service.SetDatabase(&database)
 		->SetContentDatabase(&content_db)
-		->SetContentZones(zone_store.GetZones())
 		->SetExpansionContext()
 		->ReloadContentFlags();
 

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -760,31 +760,22 @@ void Client::ZonePC(uint32 zoneID, uint32 instance_id, float x, float y, float z
 		instance_id = zone->GetInstanceID();
 	}
 
-	// used for v1/v2 zone routing
-	if (instance_id == 0) {
-		// we do this to reuse the middleware routing logic
-		auto zc = new ZoneChange_Struct{
-			.char_name = "",
-			.zoneID = static_cast<uint16>(zoneID),
-			.instanceID = static_cast<uint16>(instance_id),
-		};
-		content_service.HandleZoneRoutingMiddleware(zc);
-		if (zc->instanceID > 0) {
-			LogZoning(
-				"Client caught HandleZoneRoutingMiddleware [{}] zone_id [{}] instance_id [{}] x [{}] y [{}] z [{}] heading [{}] ignorerestrictions [{}] zone_mode [{}]",
-				GetCleanName(),
-				zoneID,
-				zc->instanceID,
-				x,
-				y,
-				z,
-				heading,
-				ignorerestrictions,
-				static_cast<int>(zm)
-			);
-			instance_id = zc->instanceID;
-		}
-		safe_delete(zc);
+	auto r = content_service.FindZone(zoneID, instance_id);
+	if (r.zone_id) {
+		zoneID      = r.zone_id;
+		instance_id = r.instance.id;
+		LogZoning(
+			"Client caught HandleZoneRoutingMiddleware [{}] zone_id [{}] instance_id [{}] x [{}] y [{}] z [{}] heading [{}] ignorerestrictions [{}] zone_mode [{}]",
+			GetCleanName(),
+			zoneID,
+			instance_id,
+			x,
+			y,
+			z,
+			heading,
+			ignorerestrictions,
+			static_cast<int>(zm)
+		);
 	}
 
 	LogInfo(

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -405,11 +405,23 @@ void Client::SendZoneCancel(ZoneChange_Struct *zc) {
 		zc->success
 	);
 
-	strcpy(zc2->char_name, zc->char_name);
+	strn0cpy(zc2->char_name, zc->char_name, 64);
 	zc2->zoneID = zone->GetZoneID();
 	zc2->success = 1;
-	outapp->priority = 6;
-	FastQueuePacket(&outapp);
+	zc2->instanceID = zone->GetInstanceID();
+
+	// this fixes an issue where when we do a zone cancel what often ends up happening is we are sending
+	// the client the wrong coordinates to zone back to. Often times it is the x,y,z of the destination zone
+	// because we saved the destination x,y,z on the client profile before we rejected the zone request.
+	// we're using rewind location because it should be where the client relatively was before we rejected the zone request.
+	// it also prevents the client from getting caught up in a zone loop because if we sent them exactly back to where they
+	// originated the request we could end up in a situation where the client is caught in a zone loop.
+	m_Position.x = m_RewindLocation.x;
+	m_Position.y = m_RewindLocation.y;
+	m_Position.z = m_RewindLocation.z;
+	zc2->x       = m_Position.x;
+	zc2->y       = m_Position.y;
+	zc2->z       = m_Position.z;
 
 	LogZoning(
 		"(zc2) Client [{}] char_name [{}] zoning to [{}] ({}) cancelled instance_id [{}] x [{}] y [{}] z [{}] zone_reason [{}] success [{}]",
@@ -424,6 +436,9 @@ void Client::SendZoneCancel(ZoneChange_Struct *zc) {
 		zc2->zone_reason,
 		zc2->success
 	);
+
+	outapp->priority = 6;
+	FastQueuePacket(&outapp);
 
 	//reset to unsolicited.
 	zone_mode = ZoneUnsolicited;
@@ -740,10 +755,43 @@ void Client::ZonePC(uint32 zoneID, uint32 instance_id, float x, float y, float z
 		pZoneName = strcpy(new char[zd->long_name.length() + 1], zd->long_name.c_str());
 	}
 
+	// If we are zoning to the same zone, we need to use the current instance ID if it is not specified.
+	if (zoneID == zone->GetZoneID() && instance_id == 0) {
+		instance_id = zone->GetInstanceID();
+	}
+
+	// used for v1/v2 zone routing
+	if (instance_id == 0) {
+		// we do this to reuse the middleware routing logic
+		auto zc = new ZoneChange_Struct{
+			.char_name = "",
+			.zoneID = static_cast<uint16>(zoneID),
+			.instanceID = static_cast<uint16>(instance_id),
+		};
+		content_service.HandleZoneRoutingMiddleware(zc);
+		if (zc->instanceID > 0) {
+			LogZoning(
+				"Client caught HandleZoneRoutingMiddleware [{}] zone_id [{}] instance_id [{}] x [{}] y [{}] z [{}] heading [{}] ignorerestrictions [{}] zone_mode [{}]",
+				GetCleanName(),
+				zoneID,
+				zc->instanceID,
+				x,
+				y,
+				z,
+				heading,
+				ignorerestrictions,
+				static_cast<int>(zm)
+			);
+			instance_id = zc->instanceID;
+		}
+		safe_delete(zc);
+	}
+
 	LogInfo(
-		"Client [{}] zone_id [{}] x [{}] y [{}] z [{}] heading [{}] ignorerestrictions [{}] zone_mode [{}]",
+		"Client [{}] zone_id [{}] instance_id [{}] x [{}] y [{}] z [{}] heading [{}] ignorerestrictions [{}] zone_mode [{}]",
 		GetCleanName(),
 		zoneID,
+		instance_id,
 		x,
 		y,
 		z,
@@ -867,9 +915,8 @@ void Client::ZonePC(uint32 zoneID, uint32 instance_id, float x, float y, float z
 			outapp->priority = 6;
 			FastQueuePacket(&outapp);
 		}
-		else if(zm == ZoneSolicited || zm == ZoneToSafeCoords) {
-			auto outapp =
-			    new EQApplicationPacket(OP_RequestClientZoneChange, sizeof(RequestClientZoneChange_Struct));
+		else if (zm == ZoneSolicited || zm == ZoneToSafeCoords) {
+			auto outapp = new EQApplicationPacket(OP_RequestClientZoneChange, sizeof(RequestClientZoneChange_Struct));
 			RequestClientZoneChange_Struct* gmg = (RequestClientZoneChange_Struct*) outapp->pBuffer;
 
 			gmg->zone_id = zoneID;
@@ -879,6 +926,17 @@ void Client::ZonePC(uint32 zoneID, uint32 instance_id, float x, float y, float z
 			gmg->heading = heading;
 			gmg->instance_id = instance_id;
 			gmg->type = 0x01;				//an observed value, not sure of meaning
+
+			LogZoning(
+				"Player [{}] has requested zoning to zone_id [{}] instance_id [{}] x [{}] y [{}] z [{}] heading [{}]",
+				GetCleanName(),
+				zoneID,
+				instance_id,
+				x,
+				y,
+				z,
+				heading
+			);
 
 			outapp->priority = 6;
 			FastQueuePacket(&outapp);


### PR DESCRIPTION
This is a critical PR that needs to get out to fix some various edge cases in zone routing logic that expands on recent breakthroughs with https://github.com/EQEmu/Server/pull/4084 expansion efforts.

**Changes**

* Fixed an issue where when entering a version of a zone that is no longer applicable due to the server era changing while the server was offline by routing clients to the proper version from character select
* Zone routing logic now happens purely in memory, including static global instance data to refrain from database hits
* Zone and Instance data gets reloaded when content flags get reloaded
* Fixed an issue where any calls to ZonePC would trigger zone requests when making calls to same zone requests in an "instanced" regular version of a zone, instead it issues an intra-zone move as expected. This is things like `#zone`, `quest::movepc`, etc.
* Fixed an issue where DZ safe return would return to the version `0` zone regardless of era contextual routing. This now takes era contextual routing into consideration through changes in ZonePC
* Added `content_flags` to the ReloadAPI that Spire uses
* Fixed an issue where `zone_points` were sending `instance_id` `0` for clients that were initiating same-zone and intra-zone movements. A portal zone point with `target_instance_id` of `0` would cause the client to trigger a zone request, this no longer occurs and the client simply moves intra-zone as expected.
* Fixed an issue where `doors` were sending `instance_id` of `0` for clients that were initiating same-zone and intra-zone movements. This would cause the client to trigger a zone request because the `instance_id` does not match what the client thinks its versus the desired behavior of an intra-zone move as expected.
* Fixed an issue where if a client got a `ZoneCancel` trigger for any reason, that sometimes the client would drop from the sky because location coordinates from the new zone were saved on the character, then being loaded in the original zone that they were kicked back to. Instead, we are using the rewind position to kick the player back to when zone cancels occur.

**Testing**

Entering zone from character select when the character was camped in a version of the zone that is no longer part of the server's current era / expansion settings, routes the player to the era-current version of the zone.

```
 World |    Info    | FindZone Attempting to route player to zone [griegsend] (163) version [1] long_name [Grieg's End] 
 World |    Info    | FindZone Routed player to instance [9] of zone [griegsend] (163) version [1] long_name [Grieg's End] notes [Griegsend V2 - LDON - Aug 26 2003] 
 World |    Info    | HandleEnterWorldPacket Zone [griegsend] has been remapped to instance_id [9] from instance_id [0] for client [Akkadius] 
 World |    Info    | EnterWorld Attempting autobootup of [griegsend] [(163:9)] 
```

Era-contextual zone routing works per normal.

Nektulos to Lavastorm (Dragons of Norrath)

![image](https://github.com/EQEmu/Server/assets/3319450/f9732f4b-8c44-4bbf-8eb2-7be1cdae3ab4)

![image](https://github.com/EQEmu/Server/assets/3319450/1d65cd1d-3c69-4c5e-8ba6-92aa76b5a635)

Issue where teleport pads would initiate a zone request when in an "instanced" public version of a zone (Griegs version 1)

https://github.com/EQEmu/Server/assets/3319450/c28934a5-7cf6-47e4-a839-a8326899f9c0

