### PR TITLE
[Bug Fix] Update FreeGuildID Routine

### DIFF
--- a/common/guild_base.cpp
+++ b/common/guild_base.cpp
@@ -342,41 +342,14 @@ bool BaseGuildManager::_StoreGuildDB(uint32 guild_id)
 	return true;
 }
 
-uint32 BaseGuildManager::_GetFreeGuildID()
-{
-	GuildsRepository::DeleteWhere(*m_db, "`name` = ''");
-
-	GuildsRepository::Guilds out;
-	out.id          = 0;
-	out.leader      = 0;
-	out.minstatus   = 0;
-	out.tribute     = 0;
-	out.name        = "";
-	out.motd        = "";
-	out.motd_setter = "";
-	out.url         = "";
-	out.channel     = "";
-	auto last_insert_id = GuildsRepository::InsertOne(*m_db, out);
-	if (last_insert_id.id > 0) {
-		LogGuilds("Located a free guild ID [{}] in the database", last_insert_id.id);
-		return last_insert_id.id;
-	}
-
-	LogGuilds("Unable to find a free guild ID in the database");
-	return GUILD_NONE;
-}
-
 uint32 BaseGuildManager::CreateGuild(std::string name, uint32 leader_char_id)
 {
-	uint32 guild_id = UpdateDbCreateGuild(name, leader_char_id);
-	if (guild_id == GUILD_NONE) {
-		return (GUILD_NONE);
-	}
-	//RefreshGuild(guild_id);
-	//SendGuildRefresh(guild_id, true, false, false, false);
-	//SendCharRefresh(GUILD_NONE, guild_id, leader_char_id);
+    uint32 guild_id = UpdateDbCreateGuild(name, leader_char_id);
+    if (guild_id == GUILD_NONE) {
+        return (GUILD_NONE);
+    }
 
-	return guild_id;
+    return guild_id;
 }
 
 bool BaseGuildManager::DeleteGuild(uint32 guild_id)
@@ -539,8 +512,8 @@ bool BaseGuildManager::SetPublicNote(uint32 charid, std::string public_note)
 
 uint32 BaseGuildManager::UpdateDbCreateGuild(std::string name, uint32 leader)
 {
-	auto new_id = _GetFreeGuildID();
-	if (new_id == GUILD_NONE) {
+	auto new_id = GuildsRepository::GetMaxId(*m_db) + 1;
+	if (!new_id) {
 		return GUILD_NONE;
 	}
 

--- a/common/guild_base.h
+++ b/common/guild_base.h
@@ -208,7 +208,6 @@ class BaseGuildManager
 
 		bool _StoreGuildDB(uint32 guild_id);
 		GuildInfo* _CreateGuild(uint32 guild_id, std::string guild_name, uint32 leader_char_id, uint8 minstatus, std::string guild_motd, std::string motd_setter, std::string Channel, std::string URL, uint32 favour);
-		uint32 _GetFreeGuildID();
         GuildsRepository::Guilds CreateGuildRepoFromGuildInfo(uint32 guild_id, BaseGuildManager::GuildInfo& in);
 };
 #endif /*GUILD_BASE_H_*/


### PR DESCRIPTION
This update migrates the routine to determine a free guild id to the repository function GetMaxId.  This should resolve the case of query errors in some environments when creating a guild.

It also cleans up the now unused function for this purpose.
