### PR TITLE
[Crash Fix] Update to location of qGlobals initialization

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -284,6 +284,7 @@ Client::Client(EQStreamInterface *ieqs) : Mob(
 	PendingSacrifice = false;
 	controlling_boat_id = 0;
 	controlled_mob_id = 0;
+	qGlobals = nullptr;
 
 	if (!RuleB(Character, PerCharacterQglobalMaxLevel) && !RuleB(Character, PerCharacterBucketMaxLevel)) {
 		SetClientMaxLevel(0);
@@ -311,7 +312,6 @@ Client::Client(EQStreamInterface *ieqs) : Mob(
 	aa_los_them_mob = nullptr;
 	los_status = false;
 	los_status_facing = false;
-	qGlobals = nullptr;
 	HideCorpseMode = HideCorpseNone;
 	PendingGuildInvitation = false;
 


### PR DESCRIPTION
Error log from Spire id 19626 fingerprint a7bba against 22.45.0

Setting the rule Character:PerCharacterQglobalMaxLevel to true would cause zone.exe to crash on character login.

qGlobals was not being initialized before it was being used in the routine resulting in the nullptr check to fail.
Relocated the initialization to before the routine.
 