### PR TITLE
[Bug Fix] GetBotNameByID Temporary Reference Warning

### DIFF
--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -2367,7 +2367,7 @@ const uint8 BotDatabase::GetBotLevelByID(const uint32 bot_id)
 	return e.bot_id ? e.level : 0;
 }
 
-const std::string& BotDatabase::GetBotNameByID(const uint32 bot_id)
+const std::string BotDatabase::GetBotNameByID(const uint32 bot_id)
 {
 	const auto& e = BotDataRepository::FindOne(database, bot_id);
 

--- a/zone/bot_database.h
+++ b/zone/bot_database.h
@@ -164,7 +164,7 @@ public:
 	const uint8 GetBotGenderByID(const uint32 bot_id);
 	std::vector<uint32> GetBotIDsByCharacterID(const uint32 character_id, uint8 class_id = Class::None);
 	const uint8 GetBotLevelByID(const uint32 bot_id);
-	const std::string& GetBotNameByID(const uint32 bot_id);
+	const std::string GetBotNameByID(const uint32 bot_id);
 	const uint16 GetBotRaceByID(const uint32 bot_id);
 
 	class fail {


### PR DESCRIPTION
# Notes
- We were getting a warning for returning `std::string()` from this method as it's a temporary reference.
- Change from `const std::string&` to `const std::string` to avoid this.
```
/home/eqemu/source/zone/bot_database.cpp: In member function ‘const std::string& BotDatabase::GetBotNameByID(uint32)’:
/home/eqemu/source/zone/bot_database.cpp:2374:25: warning: returning reference to temporary [-Wreturn-local-addr]
 2374 |         return e.bot_id ? e.name : std::string();
```