### PR TITLE
[Bug Fix] Change `UnburyCorpse` to use repository methods

### DIFF
--- a/common/repositories/character_corpses_repository.h
+++ b/common/repositories/character_corpses_repository.h
@@ -213,23 +213,23 @@ public:
 		const glm::vec4& position
 	)
 	{
-		auto results = db.QueryDatabase(
-			fmt::format(
-				"UPDATE `{}` SET `is_buried` = 0, `zone_id` = {}, `instance_id` = {}, `x` = {:.2f}, `y` = {:.2f}, `z` = {:.2f}, `heading` = {:.2f}, `time_of_death` = {}, `was_at_graveyard` = 0 WHERE `{}` = {}",
-				TableName(),
-				zone_id,
-				instance_id,
-				position.x,
-				position.y,
-				position.z,
-				position.w,
-				std::time(nullptr),
-				PrimaryKey(),
-				corpse_id
-			)
-		);
+		auto corpse = FindOne(db, corpse_id);
 
-		return results.Success() ? results.RowsAffected() : 0;
+		if (corpse.id == 0) {
+			return 0;
+		}
+
+		corpse.is_buried		= 0;
+		corpse.zone_id			= zone_id;
+		corpse.instance_id		= instance_id;
+		corpse.x				= position.x;
+		corpse.y				= position.y;
+		corpse.z				= position.z;
+		corpse.heading			= position.w;
+		corpse.time_of_death	= time(nullptr);
+		corpse.was_at_graveyard = 0;
+
+		return UpdateOne(db, corpse);
 	}
 };
 


### PR DESCRIPTION
As seen in
```
[QueryErr] Zone [shadowrest] MySQL Error (1292) [Incorrect datetime value: '1709411184' for column peq.character_corpses.time_of_death at row 1] Query [UPDATE character_corpses SET is_buried = 0, zone_id = 187, instance_id = 0, x = -149.34, y = -51.88, z = -10.29, heading = 0.00, time_of_death = 1709411184, was_at_graveyard = 0 WHERE id = 752112]
```

With character corpse updates, `quest::summonburiedplayercorpse()` was using raw input missing unix timestamp changes for `time_of_death`.

![image](https://github.com/EQEmu/Server/assets/3617814/7b95e1e6-a7ee-4e7a-8164-60884be51451)

![image](https://github.com/EQEmu/Server/assets/3617814/443a7dce-288c-4fdc-b759-dc56071480d2)

![image](https://github.com/EQEmu/Server/assets/3617814/e95d9fcb-6d20-4346-86a0-d435b389a463)

![image](https://github.com/EQEmu/Server/assets/3617814/d2889463-4ff9-4b8c-8a8f-42d6527144f1)

