### PR TITLE
[Bug Fix] Fix Spawns Not Parsing Quest on Zone Bootup

### DIFF
--- a/zone/quest_parser_collection.cpp
+++ b/zone/quest_parser_collection.cpp
@@ -805,7 +805,7 @@ int QuestParserCollection::EventBotGlobal(
 
 QuestInterface* QuestParserCollection::GetQIByNPCQuest(uint32 npc_id, std::string& filename)
 {
-	if (!zone || !zone->IsLoaded()) {
+	if (!zone) {
 		return nullptr;
 	}
 
@@ -871,7 +871,7 @@ QuestInterface* QuestParserCollection::GetQIByNPCQuest(uint32 npc_id, std::strin
 
 QuestInterface* QuestParserCollection::GetQIByPlayerQuest(std::string& filename)
 {
-	if (!zone || !zone->IsLoaded()) {
+	if (!zone) {
 		return nullptr;
 	}
 
@@ -922,7 +922,7 @@ QuestInterface* QuestParserCollection::GetQIByPlayerQuest(std::string& filename)
 
 QuestInterface* QuestParserCollection::GetQIByGlobalNPCQuest(std::string& filename)
 {
-	if (!zone || !zone->IsLoaded()) {
+	if (!zone) {
 		return nullptr;
 	}
 
@@ -947,7 +947,7 @@ QuestInterface* QuestParserCollection::GetQIByGlobalNPCQuest(std::string& filena
 
 QuestInterface* QuestParserCollection::GetQIByGlobalPlayerQuest(std::string& filename)
 {
-	if (!zone || !zone->IsLoaded()) {
+	if (!zone) {
 		return nullptr;
 	}
 
@@ -971,7 +971,7 @@ QuestInterface* QuestParserCollection::GetQIByGlobalPlayerQuest(std::string& fil
 
 QuestInterface* QuestParserCollection::GetQIBySpellQuest(uint32 spell_id, std::string& filename)
 {
-	if (!zone || !zone->IsLoaded()) {
+	if (!zone) {
 		return nullptr;
 	}
 
@@ -1023,7 +1023,7 @@ QuestInterface* QuestParserCollection::GetQIBySpellQuest(uint32 spell_id, std::s
 
 QuestInterface* QuestParserCollection::GetQIByItemQuest(std::string item_script, std::string& filename)
 {
-	if (!zone || !zone->IsLoaded()) {
+	if (!zone) {
 		return nullptr;
 	}
 
@@ -1075,7 +1075,7 @@ QuestInterface* QuestParserCollection::GetQIByItemQuest(std::string item_script,
 
 QuestInterface* QuestParserCollection::GetQIByEncounterQuest(std::string encounter_name, std::string& filename)
 {
-	if (!zone || !zone->IsLoaded()) {
+	if (!zone) {
 		return nullptr;
 	}
 
@@ -1125,7 +1125,7 @@ QuestInterface* QuestParserCollection::GetQIByEncounterQuest(std::string encount
 
 QuestInterface* QuestParserCollection::GetQIByBotQuest(std::string& filename)
 {
-	if (!zone || !zone->IsLoaded()) {
+	if (!zone) {
 		return nullptr;
 	}
 
@@ -1176,7 +1176,7 @@ QuestInterface* QuestParserCollection::GetQIByBotQuest(std::string& filename)
 
 QuestInterface* QuestParserCollection::GetQIByGlobalBotQuest(std::string& filename)
 {
-	if (!zone || !zone->IsLoaded()) {
+	if (!zone) {
 		return nullptr;
 	}
 

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -158,6 +158,8 @@ bool Zone::Bootup(uint32 iZoneID, uint32 iInstanceID, bool is_static) {
 	LogInfo("Zone bootup type [{}] short_name [{}] zone_id [{}] instance_id [{}]",
 		(is_static) ? "Static" : "Dynamic", zonename, iZoneID, iInstanceID);
 	parse->Init();
+	parse->ReloadQuests();
+	zone->Repop();
 	UpdateWindowTitle(nullptr);
 
 	// Dynamic zones need to Sync here.

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -158,8 +158,6 @@ bool Zone::Bootup(uint32 iZoneID, uint32 iInstanceID, bool is_static) {
 	LogInfo("Zone bootup type [{}] short_name [{}] zone_id [{}] instance_id [{}]",
 		(is_static) ? "Static" : "Dynamic", zonename, iZoneID, iInstanceID);
 	parse->Init();
-	parse->ReloadQuests();
-	zone->Repop();
 	UpdateWindowTitle(nullptr);
 
 	// Dynamic zones need to Sync here.


### PR DESCRIPTION
# Notes
- Spawns were not parsing quests on initial zone bootup, causing stuff that relied on this to not work.