### PR TITLE
[Quest API] Add GetHeroicStrikethrough() to Perl/Lua

### DIFF
--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -3285,6 +3285,12 @@ bool Lua_Mob::IsControllableBoat()
 	return self->IsControllableBoat();
 }
 
+int Lua_Mob::GetHeroicStrikethrough()
+{
+	Lua_Safe_Call_Int();
+	return self->GetHeroicStrikethrough();
+}
+
 luabind::scope lua_register_mob() {
 	return luabind::class_<Lua_Mob, Lua_Entity>("Mob")
 	.def(luabind::constructor<>())
@@ -3564,6 +3570,7 @@ luabind::scope lua_register_mob() {
 	.def("GetHateTopNPC", (Lua_NPC(Lua_Mob::*)(void))&Lua_Mob::GetHateTopNPC)
 	.def("GetHeading", &Lua_Mob::GetHeading)
 	.def("GetHelmTexture", &Lua_Mob::GetHelmTexture)
+	.def("GetHeroicStrikethrough", &Lua_Mob::GetHeroicStrikethrough)
 	.def("GetHerosForgeModel", (int32(Lua_Mob::*)(uint8))&Lua_Mob::GetHerosForgeModel)
 	.def("GetINT", &Lua_Mob::GetINT)
 	.def("GetInvisibleLevel", (uint8(Lua_Mob::*)(void))&Lua_Mob::GetInvisibleLevel)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -580,6 +580,7 @@ public:
 	bool IsDestructibleObject();
 	bool IsBoat();
 	bool IsControllableBoat();
+	int GetHeroicStrikethrough();
 };
 
 #endif

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -3410,6 +3410,11 @@ bool Perl_Mob_IsControllableBoat(Mob* self)
 	return self->IsControllableBoat();
 }
 
+int Perl_Mob_GetHeroicStrikethrough(Mob* self)
+{
+	return self->GetHeroicStrikethrough();
+}
+
 void perl_register_mob()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3675,6 +3680,7 @@ void perl_register_mob()
 	package.add("GetHateTopNPC", &Perl_Mob_GetHateTopNPC);
 	package.add("GetHeading", &Perl_Mob_GetHeading);
 	package.add("GetHelmTexture", &Perl_Mob_GetHelmTexture);
+	package.add("GetHeroicStrikethrough", &Perl_Mob_GetHeroicStrikethrough);
 	package.add("GetHerosForgeModel", &Perl_Mob_GetHerosForgeModel);
 	package.add("GetID", &Perl_Mob_GetID);
 	package.add("GetINT", &Perl_Mob_GetINT);


### PR DESCRIPTION
# Perl
- Add `$mob->GetHeroicStrikethrough()`.

# Lua
- Add `mob:GetHeroicStrikethrough()`.

# Notes
- Allows operators to get a mob's Heroic Strikethrough.