### PR TITLE
[Quest API] Add IsBoat()/IsControllableBoat() to Perl/Lua

### DIFF
--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -3273,6 +3273,18 @@ bool Lua_Mob::IsDestructibleObject()
 	return self->IsDestructibleObject();
 }
 
+bool Lua_Mob::IsBoat()
+{
+	Lua_Safe_Call_Bool();
+	return self->IsBoat();
+}
+
+bool Lua_Mob::IsControllableBoat()
+{
+	Lua_Safe_Call_Bool();
+	return self->IsControllableBoat();
+}
+
 luabind::scope lua_register_mob() {
 	return luabind::class_<Lua_Mob, Lua_Entity>("Mob")
 	.def(luabind::constructor<>())
@@ -3655,8 +3667,10 @@ luabind::scope lua_register_mob() {
 	.def("IsBeneficialAllowed", (bool(Lua_Mob::*)(Lua_Mob))&Lua_Mob::IsBeneficialAllowed)
 	.def("IsBerserk", &Lua_Mob::IsBerserk)
 	.def("IsBlind", (bool(Lua_Mob::*)(void))&Lua_Mob::IsBlind)
+	.def("IsBoat", &Lua_Mob::IsBoat)
 	.def("IsCasting", &Lua_Mob::IsCasting)
 	.def("IsCharmed", &Lua_Mob::IsCharmed)
+	.def("IsControllableBoat", &Lua_Mob::IsControllableBoat)
 	.def("IsDestructibleObject", &Lua_Mob::IsDestructibleObject)
 	.def("IsEliteMaterialItem", (uint32(Lua_Mob::*)(uint8))&Lua_Mob::IsEliteMaterialItem)
 	.def("IsEngaged", (bool(Lua_Mob::*)(void))&Lua_Mob::IsEngaged)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -578,6 +578,8 @@ public:
 	bool IsPetOwnerClient();
 	bool IsPetOwnerNPC();
 	bool IsDestructibleObject();
+	bool IsBoat();
+	bool IsControllableBoat();
 };
 
 #endif

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -3400,6 +3400,16 @@ bool Perl_Mob_IsDestructibleObject(Mob* self)
 	return self->IsDestructibleObject();
 }
 
+bool Perl_Mob_IsBoat(Mob* self)
+{
+	return self->IsBoat();
+}
+
+bool Perl_Mob_IsControllableBoat(Mob* self)
+{
+	return self->IsControllableBoat();
+}
+
 void perl_register_mob()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3773,10 +3783,12 @@ void perl_register_mob()
 	package.add("IsBeneficialAllowed", &Perl_Mob_IsBeneficialAllowed);
 	package.add("IsBerserk", &Perl_Mob_IsBerserk);
 	package.add("IsBlind", &Perl_Mob_IsBlind);
+	package.add("IsBoat", &Perl_Mob_IsBoat);
 	package.add("IsBot", &Perl_Mob_IsBot);
 	package.add("IsCasting", &Perl_Mob_IsCasting);
 	package.add("IsCharmed", &Perl_Mob_IsCharmed);
 	package.add("IsClient", &Perl_Mob_IsClient);
+	package.add("IsControllableBoat", &Perl_Mob_IsControllableBoat);
 	package.add("IsCorpse", &Perl_Mob_IsCorpse);
 	package.add("IsDestructibleObject", &Perl_Mob_IsDestructibleObject);
 	package.add("IsDoor", &Perl_Mob_IsDoor);


### PR DESCRIPTION
# Perl
- Add `$mob->IsBoat()`.
- Add `$mob->IsControllableBoat()`.

# Lua
- Add `mob:IsBoat()`.
- Add `mob:IsControllableBoat()`.

# Notes
- Allows operators to determine if a mob is a boat or a controllable boat.