### PR TITLE
[Quest API] Add IsAlwaysAggro() to Perl/Lua

### DIFF
--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -3291,6 +3291,12 @@ int Lua_Mob::GetHeroicStrikethrough()
 	return self->GetHeroicStrikethrough();
 }
 
+bool Lua_Mob::IsAlwaysAggro()
+{
+	Lua_Safe_Call_Bool();
+	return self->AlwaysAggro();
+}
+
 luabind::scope lua_register_mob() {
 	return luabind::class_<Lua_Mob, Lua_Entity>("Mob")
 	.def(luabind::constructor<>())
@@ -3667,6 +3673,7 @@ luabind::scope lua_register_mob() {
 	.def("InterruptSpell", (void(Lua_Mob::*)(int))&Lua_Mob::InterruptSpell)
 	.def("InterruptSpell", (void(Lua_Mob::*)(void))&Lua_Mob::InterruptSpell)
 	.def("IsAIControlled", (bool(Lua_Mob::*)(void))&Lua_Mob::IsAIControlled)
+	.def("IsAlwaysAggro", &Lua_Mob::IsAlwaysAggro)
 	.def("IsAmnesiad", (bool(Lua_Mob::*)(void))&Lua_Mob::IsAmnesiad)
 	.def("IsAnimation", &Lua_Mob::IsAnimation)
 	.def("IsAttackAllowed", (bool(Lua_Mob::*)(Lua_Mob))&Lua_Mob::IsAttackAllowed)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -581,6 +581,7 @@ public:
 	bool IsBoat();
 	bool IsControllableBoat();
 	int GetHeroicStrikethrough();
+	bool IsAlwaysAggro();
 };
 
 #endif

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -3415,6 +3415,11 @@ int Perl_Mob_GetHeroicStrikethrough(Mob* self)
 	return self->GetHeroicStrikethrough();
 }
 
+bool Perl_Mob_IsAlwaysAggro(Mob* self)
+{
+	return self->AlwaysAggro();
+}
+
 void perl_register_mob()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3780,6 +3785,7 @@ void perl_register_mob()
 	package.add("InterruptSpell", (void(*)(Mob*))&Perl_Mob_InterruptSpell);
 	package.add("InterruptSpell", (void(*)(Mob*, uint16))&Perl_Mob_InterruptSpell);
 	package.add("IsAIControlled", &Perl_Mob_IsAIControlled);
+	package.add("IsAlwaysAggro", &Perl_Mob_IsAlwaysAggro);
 	package.add("IsAmnesiad", &Perl_Mob_IsAmnesiad);
 	package.add("IsAnimation", &Perl_Mob_IsAnimation);
 	package.add("IsAttackAllowed", (bool(*)(Mob*, Mob*))&Perl_Mob_IsAttackAllowed);


### PR DESCRIPTION
# Perl
- Add `$mob->IsAlwaysAggro()`.

# Lua
- Add `mob:IsAlwaysAggro()`.

# Notes
- Allows operators to determine if a mob is set to always aggro.