### PR TITLE
[Crash Fix] Groundspawn memory corruption

### DIFF
--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -355,9 +355,7 @@ bool Zone::IsSpecialBindLocation(const glm::vec4& location)
 
 //this also just loads into entity_list, not really into zone
 bool Zone::LoadGroundSpawns() {
-	GroundSpawns g;
-
-	memset(&g, 0, sizeof(g));
+	GroundSpawns g{};
 
 	content_db.LoadGroundSpawns(zoneid, GetInstanceVersion(), &g);
 


### PR DESCRIPTION
I noticed a crash situation with groundspawns.  The struct uses std::string for the object name, and the memset was overwriting the std::string object which would allow for memory corruption.  The result is the name being corrupted, reading erroneous memory locations

I was able to reproduce in my environment zoning into Ak'Aanon.

I removed the memset and used the {} initializer instead to correct the issue.
