### PR TITLE
[Bug Fix] Fix Character EXP Modifiers Default

### DIFF
--- a/common/repositories/character_exp_modifiers_repository.h
+++ b/common/repositories/character_exp_modifiers_repository.h
@@ -74,9 +74,11 @@ public:
 			};
 		}
 
+		const auto& m = l.front();
+
 		return EXPModifier{
-			.aa_modifier = l[0].aa_modifier,
-			.exp_modifier = l[0].exp_modifier
+			.aa_modifier = m.aa_modifier,
+			.exp_modifier = m.exp_modifier
 		};
 	}
 

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -3165,6 +3165,11 @@ void Zone::ClearEXPModifier(Client* c)
 	exp_modifiers.erase(c->CharacterID());
 }
 
+void Zone::ClearEXPModifierByCharacterID(const uint32 character_id)
+{
+	exp_modifiers.erase(character_id);
+}
+
 float Zone::GetAAEXPModifier(Client* c)
 {
 	const auto& l = exp_modifiers.find(c->CharacterID());
@@ -3177,9 +3182,33 @@ float Zone::GetAAEXPModifier(Client* c)
 	return v.aa_modifier;
 }
 
+float Zone::GetAAEXPModifierByCharacterID(const uint32 character_id)
+{
+	const auto& l = exp_modifiers.find(character_id);
+	if (l == exp_modifiers.end()) {
+		return 1.0f;
+	}
+
+	const auto& v = l->second;
+
+	return v.aa_modifier;
+}
+
 float Zone::GetEXPModifier(Client* c)
 {
 	const auto& l = exp_modifiers.find(c->CharacterID());
+	if (l == exp_modifiers.end()) {
+		return 1.0f;
+	}
+
+	const auto& v = l->second;
+
+	return v.exp_modifier;
+}
+
+float Zone::GetEXPModifierByCharacterID(const uint32 character_id)
+{
+	const auto& l = exp_modifiers.find(character_id);
 	if (l == exp_modifiers.end()) {
 		return 1.0f;
 	}
@@ -3209,6 +3238,26 @@ void Zone::SetAAEXPModifier(Client* c, float aa_modifier)
 	);
 }
 
+void Zone::SetAAEXPModifierByCharacterID(const uint32 character_id, float aa_modifier)
+{
+	auto l = exp_modifiers.find(character_id);
+	if (l == exp_modifiers.end()) {
+		return;
+	}
+
+	auto& m = l->second;
+
+	m.aa_modifier = aa_modifier;
+
+	CharacterExpModifiersRepository::SetEXPModifier(
+		database,
+		character_id,
+		GetZoneID(),
+		GetInstanceVersion(),
+		m
+	);
+}
+
 void Zone::SetEXPModifier(Client* c, float exp_modifier)
 {
 	auto l = exp_modifiers.find(c->CharacterID());
@@ -3223,6 +3272,26 @@ void Zone::SetEXPModifier(Client* c, float exp_modifier)
 	CharacterExpModifiersRepository::SetEXPModifier(
 		database,
 		c->CharacterID(),
+		GetZoneID(),
+		GetInstanceVersion(),
+		m
+	);
+}
+
+void Zone::SetEXPModifierByCharacterID(const uint32 character_id, float exp_modifier)
+{
+	auto l = exp_modifiers.find(character_id);
+	if (l == exp_modifiers.end()) {
+		return;
+	}
+
+	auto& m = l->second;
+
+	m.exp_modifier = exp_modifier;
+
+	CharacterExpModifiersRepository::SetEXPModifier(
+		database,
+		character_id,
 		GetZoneID(),
 		GetInstanceVersion(),
 		m

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -269,10 +269,15 @@ public:
 	void SendReloadMessage(std::string reload_type);
 
 	void ClearEXPModifier(Client* c);
+	void ClearEXPModifierByCharacterID(const uint32 character_id);
 	float GetAAEXPModifier(Client* c);
+	float GetAAEXPModifierByCharacterID(const uint32 character_id);
 	float GetEXPModifier(Client* c);
+	float GetEXPModifierByCharacterID(const uint32 character_id);
 	void SetAAEXPModifier(Client* c, float aa_modifier);
+	void SetAAEXPModifierByCharacterID(const uint32 character_id, float aa_modifier);
 	void SetEXPModifier(Client* c, float exp_modifier);
+	void SetEXPModifierByCharacterID(const uint32 character_id, float exp_modifier);
 
 	void AddAggroMob() { aggroedmobs++; }
 	void AddAuth(ServerZoneIncomingClient_Struct *szic);

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -4270,7 +4270,7 @@ void ZoneDatabase::SetAAEXPModifierByCharID(
 		instance_version,
 		EXPModifier{
 			.aa_modifier = aa_modifier,
-			.exp_modifier = -1.0f
+			.exp_modifier = zone->GetEXPModifierByCharacterID(character_id)
 		}
 	);
 }
@@ -4288,7 +4288,7 @@ void ZoneDatabase::SetEXPModifierByCharID(
 		zone_id,
 		instance_version,
 		EXPModifier{
-			.aa_modifier = -1.0f,
+			.aa_modifier = zone->GetAAEXPModifierByCharacterID(character_id),
 			.exp_modifier = exp_modifier
 		}
 	);


### PR DESCRIPTION
# Notes
- The `-1.0f` was causing these modifiers to be set to `0.0` and when people would enable them they would get no experience.
- We now use the zone based grabbed methods when setting which will default to a value of `1.0f` if there is not a value found.