### PR TITLE
[Bug Fix] Fix Default Value in `rule_values` table

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -5431,7 +5431,7 @@ ADD PRIMARY KEY (`id`);
 		.match = "varchar(30)",
 		.sql = R"(
 ALTER TABLE `rule_values`
-MODIFY COLUMN `rule_value` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL DEFAULT '' AFTER `rule_name`;
+MODIFY COLUMN `rule_value` text CHARACTER SET latin1 COLLATE latin1_swedish_ci NULL DEFAULT NULL AFTER `rule_name`;
 		)"
 	}
 // -- template; copy/paste this when you need to create a new entry


### PR DESCRIPTION
# Notes
- Some versions of SQL do not allow a default value for text fields.