### PR TITLE
[Quest API] Add DeleteBot() to Perl/Lua

### DIFF
--- a/zone/lua_bot.cpp
+++ b/zone/lua_bot.cpp
@@ -659,6 +659,11 @@ void Lua_Bot::SetBucket(std::string bucket_name, std::string bucket_value, std::
 	self->SetBucket(bucket_name, bucket_value, expiration);
 }
 
+void Lua_Bot::DeleteBot() {
+	Lua_Safe_Call_Void();
+	self->DeleteBot();
+}
+
 luabind::scope lua_register_bot() {
 	return luabind::class_<Lua_Bot, Lua_Mob>("Bot")
 	.def(luabind::constructor<>())
@@ -698,6 +703,7 @@ luabind::scope lua_register_bot() {
 	.def("ClearSpellRecastTimer", (void(Lua_Bot::*)(uint16))&Lua_Bot::ClearSpellRecastTimer)
 	.def("CountBotItem", (uint32(Lua_Bot::*)(uint32))&Lua_Bot::CountBotItem)
 	.def("CountItemEquippedByID", (int(Lua_Bot::*)(uint32))&Lua_Bot::CountItemEquippedByID)
+	.def("DeleteBot", (void(Lua_Bot::*)(void))&Lua_Bot::DeleteBot)
 	.def("DeleteBucket", (void(Lua_Bot::*)(std::string))&Lua_Bot::DeleteBucket)
 	.def("Escape", (void(Lua_Bot::*)(void))&Lua_Bot::Escape)
 	.def("Fling", (void(Lua_Bot::*)(float,float,float))&Lua_Bot::Fling)

--- a/zone/lua_bot.h
+++ b/zone/lua_bot.h
@@ -60,6 +60,7 @@ public:
 	uint32 GetBotID();
 	void Camp();
 	void Camp(bool save_to_database);
+	void DeleteBot();
 	Lua_ItemInst GetAugmentAt(int16 slot_id, uint8 augment_index);
 	int GetAugmentIDAt(int16 slot_id, uint8 augment_index);
 	luabind::object GetAugmentIDsBySlotID(lua_State* L, int16 slot_id) const;

--- a/zone/perl_bot.cpp
+++ b/zone/perl_bot.cpp
@@ -615,6 +615,11 @@ std::string Perl_Bot_GetRaceAbbreviation(Bot* self)
 	return GetPlayerRaceAbbreviation(self->GetBaseRace());
 }
 
+void Perl_Bot_DeleteBot(Bot* self) // @categories Script Utility
+{
+	self->DeleteBot();
+}
+
 void perl_register_bot()
 {
 	perl::interpreter state(PERL_GET_THX);
@@ -655,6 +660,7 @@ void perl_register_bot()
 	package.add("CountAugmentEquippedByID", &Perl_Bot_CountAugmentEquippedByID);
 	package.add("CountBotItem", &Perl_Bot_CountBotItem);
 	package.add("CountItemEquippedByID", &Perl_Bot_CountItemEquippedByID);
+	package.add("DeleteBot", (void(*)(Bot*)) &Perl_Bot_DeleteBot);
 	package.add("Escape", &Perl_Bot_Escape);
 	package.add("Fling", (void(*)(Bot*, float, float, float))&Perl_Bot_Fling);
 	package.add("Fling", (void(*)(Bot*, float, float, float, bool))&Perl_Bot_Fling);


### PR DESCRIPTION
### Perl
- Add $bot->DeleteBot().
```
sub EVENT_SAY {
	if ($text =~/#deletebot/i && $client->Admin() >= 100) {
		my @bot_list = $entity_list->GetBotList();

		foreach $ent (@bot_list) {
			if ($ent) {
				quest::shout("Deleting " . $ent->GetCleanName());
				$ent->DeleteBot();
				$ent->Camp(0);
			}
		}
	}
}
```
### Lua
- Add bot:DeleteBot().
```
function event_say(e)
	if(e.message:findi("#deletebot")) then
		local bot_list = eq.get_entity_list():GetBotList();

		for ent in bot_list.entries do
			if (ent) then
				e.self:Message(7,"Deleting " .. ent:GetCleanName() .. "");
				ent:DeleteBot();
				ent:Camp(false);
			end
		end
	end
end
```
### Notes
- Allows operators to delete bots.