### PR TITLE
[Bug Fix] Using %T in channel messages on fresh corpse yields mob, not corpse name.

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2870,17 +2870,17 @@ bool NPC::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillTy
 		entity_list.AddCorpse(corpse, GetID());
 
 		auto out2 = new EQApplicationPacket(OP_MobRename, sizeof(MobRename_Struct));
-        auto data = (MobRename_Struct *)out2->pBuffer;
-        out2->priority = 6;
+		auto data = (MobRename_Struct *)out2->pBuffer;
+		out2->priority = 6;
 
-        strn0cpy(data->old_name, temp_name.c_str(), sizeof(data->old_name));
-        strn0cpy(data->old_name_again, data->old_name, sizeof(data->old_name_again));
-        strn0cpy(data->new_name, corpse->GetCleanName(), sizeof(data->new_name));
-        data->unknown192 = 0;
-        data->unknown196 = 1;
+		strn0cpy(data->old_name, temp_name.c_str(), sizeof(data->old_name));
+		strn0cpy(data->old_name_again, data->old_name, sizeof(data->old_name_again));
+		strn0cpy(data->new_name, corpse->GetCleanName(), sizeof(data->new_name));
+		data->unknown192 = 0;
+		data->unknown196 = 1;
 
-        entity_list.QueueClients(killer_mob, out2, false);
-        safe_delete(out2);
+		entity_list.QueueClients(killer_mob, out2, false);
+		safe_delete(out2);
 
 		entity_list.UnMarkNPC(GetID());
 		entity_list.RemoveNPC(GetID());

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2867,7 +2867,7 @@ bool NPC::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillTy
 		// The client sees NPC corpses as name's_corpse.  The server uses
 		// name`s_corpse so that %T works on corpses (client workaround)
 		// Rename the new corpse on client side.
-		std::string old_name = Strings::Replace(corpse->GetName(), "`", "'");
+		std::string old_name = Strings::Replace(corpse->GetName(), "`s_corpse", "'s_corpse");
 		SendRename(killer_mob, old_name.c_str(), corpse->GetCleanName());
 
 		entity_list.UnMarkNPC(GetID());

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2868,7 +2868,7 @@ bool NPC::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillTy
 		// name`s_corpse so that %T works on corpses (client workaround)
 		// Rename the new corpse on client side.
 		std::string old_name = Strings::Replace(corpse->GetName(), "`s_corpse", "'s_corpse");
-		SendRename(killer_mob, old_name.c_str(), corpse->GetCleanName());
+		SendRename(killer_mob, old_name.c_str(), corpse->GetName());
 
 		entity_list.UnMarkNPC(GetID());
 		entity_list.RemoveNPC(GetID());

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2012,10 +2012,9 @@ bool Client::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::Skil
 			}
 
 			entity_list.AddCorpse(new_corpse, GetID());
+			new_corpse->Spawn();
 			SetID(0);
 
-			//send the become corpse packet to everybody else in the zone.
-			entity_list.QueueClients(this, &app2, true);
 			ApplyIllusionToCorpse(illusion_spell_id, new_corpse);
 			leave_corpse = true;
 		}
@@ -2861,7 +2860,7 @@ bool NPC::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillTy
 
 		entity_list.LimitRemoveNPC(this);
 		entity_list.AddCorpse(corpse, GetID());
-
+		corpse->Spawn();
 		entity_list.UnMarkNPC(GetID());
 		entity_list.RemoveNPC(GetID());
 

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -622,7 +622,7 @@ void Corpse::CalcCorpseName()
 	EntityList::RemoveNumbers(name);
 	char tmp[64];
 	if (m_is_player_corpse) {
-		snprintf(tmp, sizeof(tmp), "'s corpse%d", GetID());
+		snprintf(tmp, sizeof(tmp), "`s corpse%d", GetID());
 	}
 	else {
 		snprintf(tmp, sizeof(tmp), "`s_corpse%d", GetID());

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -622,7 +622,7 @@ void Corpse::CalcCorpseName()
 	EntityList::RemoveNumbers(name);
 	char tmp[64];
 	if (m_is_player_corpse) {
-		snprintf(tmp, sizeof(tmp), "`s corpse%d", GetID());
+		snprintf(tmp, sizeof(tmp), "'s corpse%d", GetID());
 	}
 	else {
 		snprintf(tmp, sizeof(tmp), "`s_corpse%d", GetID());

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1585,6 +1585,22 @@ void Mob::SendHPUpdate(bool force_update_all)
 	}
 }
 
+void Mob::SendRename(Mob *sender, const char* old_name, const char* new_name)
+{
+	auto out2 = new EQApplicationPacket(OP_MobRename, sizeof(MobRename_Struct));
+	auto data = (MobRename_Struct *)out2->pBuffer;
+	out2->priority = 6;
+
+	strn0cpy(data->old_name, old_name, sizeof(data->old_name));
+	strn0cpy(data->old_name_again, old_name, sizeof(data->old_name_again));
+	strn0cpy(data->new_name, new_name, sizeof(data->new_name));
+	data->unknown192 = 0;
+	data->unknown196 = 1;
+
+	entity_list.QueueClients(sender, out2);
+	safe_delete(out2);
+}
+
 void Mob::StopMoving()
 {
 	StopNavigation();
@@ -4312,15 +4328,7 @@ void Mob::TempName(const char *newname)
 	entity_list.MakeNameUnique(temp_name);
 
 	// Send the new name to all clients
-	auto outapp = new EQApplicationPacket(OP_MobRename, sizeof(MobRename_Struct));
-	MobRename_Struct* mr = (MobRename_Struct*) outapp->pBuffer;
-	strn0cpy(mr->old_name, old_name, 64);
-	strn0cpy(mr->old_name_again, old_name, 64);
-	strn0cpy(mr->new_name, temp_name, 64);
-	mr->unknown192 = 0;
-	mr->unknown196 = 1;
-	entity_list.QueueClients(this, outapp);
-	safe_delete(outapp);
+	SendRename(this, old_name, temp_name);
 
 	SetName(temp_name);
 }

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -830,6 +830,7 @@ public:
 	void SendHPUpdate(bool force_update_all = false);
 	virtual void ResetHPUpdateTimer() {}; // does nothing
 	static void SetSpawnLastNameByClass(NewSpawn_Struct* ns);
+	void SendRename(Mob* sender, const char* old_name, const char* new_name);
 
 	//Util
 	static uint32 RandomTimer(int min, int max);


### PR DESCRIPTION
The problem:

Kill a PC or NPC.  Target the corpse.  The client shows the corpse name as xyz's_corpse.  But the result of using %T in channels is just the npc or player name without the ''s corpse' addition.  If you zone out and back in, then %T works as expected.

I broke down testing this to the two different cases:

MOB:

The only way I could make the client honor %T was to do a corpse->Spawn() after we do AddCorpse to the entity list.  AddCorpse ends up setting the new name, but the client doesn't see this without me adding corpse->Spawn().  We do not get (2) corpses, it just seems to fix the (1).  

Concerns:

- If we don't use a backtick in the corpse name, but rather use a tick - the client doesnt fix it. Seems really odd to me.  I tested if it was just a matter of changing any character.  Nothing I did worked other that using a backtick instead of a tick.  Maybe somewhere at some packet levels the tick is getting stripped?


PC:

[ Could not get this to function.  The rename worked but caused multiple side effects on the client.  Not worth it for just displaying correct name in macros. ]

@neckkola credited for the rename fix.  I had uses a spawn packet instead.
