### PR TITLE
[Cleanup] Cleanup Zone Get Methods

### DIFF
--- a/common/zone_store.cpp
+++ b/common/zone_store.cpp
@@ -236,1142 +236,476 @@ ZoneRepository::Zone *ZoneStore::GetZoneWithFallback(uint32 zone_id, int version
 
 glm::vec4 ZoneStore::GetZoneSafeCoordinates(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return glm::vec4(z.safe_x, z.safe_y, z.safe_z, z.safe_heading);
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return glm::vec4(z.safe_x, z.safe_y, z.safe_z, z.safe_heading);
-		}
-	}
-
-	return glm::vec4(0.f);
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? glm::vec4(z->safe_x, z->safe_y, z->safe_z, z->safe_heading) : glm::vec4(0.f);
 }
 
 float ZoneStore::GetZoneGraveyardID(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.graveyard_id;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.graveyard_id;
-		}
-	}
-
-	return 0;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->graveyard_id : 0;
 }
 
 uint8 ZoneStore::GetZoneMinimumLevel(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.min_level;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.min_level;
-		}
-	}
-
-	return 0;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->min_level : 0;
 }
 
 uint8 ZoneStore::GetZoneMaximumLevel(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.max_level;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.max_level;
-		}
-	}
-
-	return UINT8_MAX;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->max_level : UINT8_MAX;
 }
 
 uint8 ZoneStore::GetZoneMinimumStatus(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.min_status;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.min_status;
-		}
-	}
-
-	return 0;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->min_status : 0;
 }
 
 int ZoneStore::GetZoneTimeZone(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.min_status;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.min_status;
-		}
-	}
-
-	return 0;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->timezone : 0;
 }
 
 int ZoneStore::GetZoneMaximumPlayers(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.maxclients;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.maxclients;
-		}
-	}
-
-	return 0;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->maxclients : 0;
 }
 
 uint32 ZoneStore::GetZoneRuleSet(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.ruleset;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.ruleset;
-		}
-	}
-
-	return 0;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->ruleset : 0;
 }
 
 const std::string ZoneStore::GetZoneNote(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.note;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.note;
-		}
-	}
-
-	return "";
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->note : "";
 }
 
 float ZoneStore::GetZoneUnderworld(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.underworld;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.underworld;
-		}
-	}
-
-	return 0.0f;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->underworld : 0.0f;
 }
 
 float ZoneStore::GetZoneMinimumClip(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.minclip;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.minclip;
-		}
-	}
-
-	return DEFAULT_MINIMUM_CLIP;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->minclip : DEFAULT_MINIMUM_CLIP;
 }
 
 float ZoneStore::GetZoneMaximumClip(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.maxclip;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.maxclip;
-		}
-	}
-
-	return DEFAULT_MAXIMUM_CLIP;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->maxclip : DEFAULT_MAXIMUM_CLIP;
 }
 
 float ZoneStore::GetZoneFogMinimumClip(uint32 zone_id, uint8 slot, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			switch (slot) {
-				case FOG_SLOT_ONE:
-					return z.fog_minclip1;
-				case FOG_SLOT_TWO:
-					return z.fog_minclip2;
-				case FOG_SLOT_THREE:
-					return z.fog_minclip3;
-				case FOG_SLOT_FOUR:
-					return z.fog_minclip4;
-				default:
-					return z.fog_minclip;
-			}
-		}
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+
+	if (!z) {
+		return DEFAULT_MINIMUM_CLIP;
 	}
 
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			switch (slot) {
-				case FOG_SLOT_ONE:
-					return z.fog_minclip1;
-				case FOG_SLOT_TWO:
-					return z.fog_minclip2;
-				case FOG_SLOT_THREE:
-					return z.fog_minclip3;
-				case FOG_SLOT_FOUR:
-					return z.fog_minclip4;
-				default:
-					return z.fog_minclip;
-			}
-		}
+	switch (slot) {
+		case FOG_SLOT_ONE:
+			return z->fog_minclip1;
+		case FOG_SLOT_TWO:
+			return z->fog_minclip2;
+		case FOG_SLOT_THREE:
+			return z->fog_minclip3;
+		case FOG_SLOT_FOUR:
+			return z->fog_minclip4;
+		default:
+			return z->fog_minclip;
 	}
-
-	return DEFAULT_MINIMUM_CLIP;
 }
 
 float ZoneStore::GetZoneFogMaximumClip(uint32 zone_id, uint8 slot, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			switch (slot) {
-				case FOG_SLOT_ONE:
-					return z.fog_maxclip1;
-				case FOG_SLOT_TWO:
-					return z.fog_maxclip2;
-				case FOG_SLOT_THREE:
-					return z.fog_maxclip3;
-				case FOG_SLOT_FOUR:
-					return z.fog_maxclip4;
-				default:
-					return z.fog_maxclip;
-			}
-		}
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+
+	if (!z) {
+		return DEFAULT_MAXIMUM_CLIP;
 	}
 
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			switch (slot) {
-				case FOG_SLOT_ONE:
-					return z.fog_maxclip1;
-				case FOG_SLOT_TWO:
-					return z.fog_maxclip2;
-				case FOG_SLOT_THREE:
-					return z.fog_maxclip3;
-				case FOG_SLOT_FOUR:
-					return z.fog_maxclip4;
-				default:
-					return z.fog_maxclip;
-			}
-		}
+	switch (slot) {
+		case FOG_SLOT_ONE:
+			return z->fog_maxclip1;
+		case FOG_SLOT_TWO:
+			return z->fog_maxclip2;
+		case FOG_SLOT_THREE:
+			return z->fog_maxclip3;
+		case FOG_SLOT_FOUR:
+			return z->fog_maxclip4;
+		default:
+			return z->fog_maxclip;
 	}
-
-	return DEFAULT_MAXIMUM_CLIP;
 }
 
 uint8 ZoneStore::GetZoneFogRed(uint32 zone_id, uint8 slot, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			switch (slot) {
-				case FOG_SLOT_ONE:
-					return z.fog_red1;
-				case FOG_SLOT_TWO:
-					return z.fog_red2;
-				case FOG_SLOT_THREE:
-					return z.fog_red3;
-				case FOG_SLOT_FOUR:
-					return z.fog_red4;
-				default:
-					return z.fog_red;
-			}
-		}
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+
+	if (!z) {
+		return 0;
 	}
 
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			switch (slot) {
-				case FOG_SLOT_ONE:
-					return z.fog_red1;
-				case FOG_SLOT_TWO:
-					return z.fog_red2;
-				case FOG_SLOT_THREE:
-					return z.fog_red3;
-				case FOG_SLOT_FOUR:
-					return z.fog_red4;
-				default:
-					return z.fog_red;
-			}
-		}
+	switch (slot) {
+		case FOG_SLOT_ONE:
+			return z->fog_red1;
+		case FOG_SLOT_TWO:
+			return z->fog_red2;
+		case FOG_SLOT_THREE:
+			return z->fog_red3;
+		case FOG_SLOT_FOUR:
+			return z->fog_red4;
+		default:
+			return z->fog_red;
 	}
-
-	return 0;
 }
 
 uint8 ZoneStore::GetZoneFogGreen(uint32 zone_id, uint8 slot, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			switch (slot) {
-				case FOG_SLOT_ONE:
-					return z.fog_green1;
-				case FOG_SLOT_TWO:
-					return z.fog_green2;
-				case FOG_SLOT_THREE:
-					return z.fog_green3;
-				case FOG_SLOT_FOUR:
-					return z.fog_green4;
-				default:
-					return z.fog_green;
-			}
-		}
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+
+	if (!z) {
+		return 0;
 	}
 
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			switch (slot) {
-				case FOG_SLOT_ONE:
-					return z.fog_green1;
-				case FOG_SLOT_TWO:
-					return z.fog_green2;
-				case FOG_SLOT_THREE:
-					return z.fog_green3;
-				case FOG_SLOT_FOUR:
-					return z.fog_green4;
-				default:
-					return z.fog_green;
-			}
-		}
+	switch (slot) {
+		case FOG_SLOT_ONE:
+			return z->fog_green1;
+		case FOG_SLOT_TWO:
+			return z->fog_green2;
+		case FOG_SLOT_THREE:
+			return z->fog_green3;
+		case FOG_SLOT_FOUR:
+			return z->fog_green4;
+		default:
+			return z->fog_green;
 	}
-
-	return 0;
 }
 
 uint8 ZoneStore::GetZoneFogBlue(uint32 zone_id, uint8 slot, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			switch (slot) {
-				case FOG_SLOT_ONE:
-					return z.fog_blue1;
-				case FOG_SLOT_TWO:
-					return z.fog_blue2;
-				case FOG_SLOT_THREE:
-					return z.fog_blue3;
-				case FOG_SLOT_FOUR:
-					return z.fog_blue4;
-				default:
-					return z.fog_blue;
-			}
-		}
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+
+	if (!z) {
+		return 0;
 	}
 
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			switch (slot) {
-				case FOG_SLOT_ONE:
-					return z.fog_blue1;
-				case FOG_SLOT_TWO:
-					return z.fog_blue2;
-				case FOG_SLOT_THREE:
-					return z.fog_blue3;
-				case FOG_SLOT_FOUR:
-					return z.fog_blue4;
-				default:
-					return z.fog_blue;
-			}
-		}
+	switch (slot) {
+		case FOG_SLOT_ONE:
+			return z->fog_blue1;
+		case FOG_SLOT_TWO:
+			return z->fog_blue2;
+		case FOG_SLOT_THREE:
+			return z->fog_blue3;
+		case FOG_SLOT_FOUR:
+			return z->fog_blue4;
+		default:
+			return z->fog_blue;
 	}
-
-	return 0;
 }
 
 uint8 ZoneStore::GetZoneSky(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.sky;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.sky;
-		}
-	}
-
-	return 0;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->sky : 0;
 }
 
 uint8 ZoneStore::GetZoneZType(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.ztype;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.ztype;
-		}
-	}
-
-	return 0;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->ztype : 0;
 }
 
 float ZoneStore::GetZoneExperienceMultiplier(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.zone_exp_multiplier;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.zone_exp_multiplier;
-		}
-	}
-
-	return 1.0f;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->zone_exp_multiplier : 1.0f;
 }
 
 float ZoneStore::GetZoneWalkSpeed(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.walkspeed;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.walkspeed;
-		}
-	}
-
-	return DEFAULT_ZONE_RUNSPEED;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->walkspeed : DEFAULT_ZONE_RUNSPEED;
 }
 
 uint8 ZoneStore::GetZoneTimeType(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.time_type;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.time_type;
-		}
-	}
-
-	return 0;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->time_type : 0;
 }
 
 float ZoneStore::GetZoneFogDensity(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.fog_density;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.fog_density;
-		}
-	}
-
-	return 0.0f;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->fog_density : 0.0f;
 }
 
 const std::string ZoneStore::GetZoneFlagNeeded(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.flag_needed;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.flag_needed;
-		}
-	}
-
-	return "";
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->flag_needed : "";
 }
 
 int8 ZoneStore::GetZoneCanBind(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.canbind;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.canbind;
-		}
-	}
-
-	return 0;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->canbind : 0;
 }
 
 int8 ZoneStore::GetZoneCanCombat(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.cancombat;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.cancombat;
-		}
-	}
-
-	return 0;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->cancombat : 0;
 }
 
 int8 ZoneStore::GetZoneCanLevitate(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.canlevitate;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.canlevitate;
-		}
-	}
-
-	return 0;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->canlevitate : 0;
 }
 
 int8 ZoneStore::GetZoneCastOutdoor(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.castoutdoor;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.castoutdoor;
-		}
-	}
-
-	return 0;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->castoutdoor : 0;
 }
 
 uint8 ZoneStore::GetZoneHotzone(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.hotzone;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.hotzone;
-		}
-	}
-
-	return 0;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->hotzone : 0;
 }
 
 uint8 ZoneStore::GetZoneInstanceType(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.insttype;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.insttype;
-		}
-	}
-
-	return 0;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->insttype : 0;
 }
 
 uint64 ZoneStore::GetZoneShutdownDelay(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.shutdowndelay;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.shutdowndelay;
-		}
-	}
-
-	return DEFAULT_ZONE_SHUTDOWN_DELAY;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->shutdowndelay : DEFAULT_ZONE_SHUTDOWN_DELAY;
 }
 
 int8 ZoneStore::GetZonePEQZone(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.peqzone;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.peqzone;
-		}
-	}
-
-	return 0;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->peqzone : 0;
 }
 
 int8 ZoneStore::GetZoneExpansion(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.expansion;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.expansion;
-		}
-	}
-
-	return 0;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->expansion : 0;
 }
 
 int8 ZoneStore::GetZoneBypassExpansionCheck(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.bypass_expansion_check;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.bypass_expansion_check;
-		}
-	}
-
-	return 0;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->bypass_expansion_check : 0;
 }
 
 uint8 ZoneStore::GetZoneSuspendBuffs(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.suspendbuffs;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.suspendbuffs;
-		}
-	}
-
-	return 0;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->suspendbuffs : 0;
 }
 
 int ZoneStore::GetZoneRainChance(uint32 zone_id, uint8 slot, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			switch (slot) {
-				case RAIN_SLOT_TWO:
-					return z.rain_chance2;
-				case RAIN_SLOT_THREE:
-					return z.rain_chance3;
-				case RAIN_SLOT_FOUR:
-					return z.rain_chance4;
-				case RAIN_SLOT_ONE:
-				default:
-					return z.rain_chance1;
-			}
-		}
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+
+	if (!z) {
+		return 0;
 	}
 
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			switch (slot) {
-				case RAIN_SLOT_TWO:
-					return z.rain_chance2;
-				case RAIN_SLOT_THREE:
-					return z.rain_chance3;
-				case RAIN_SLOT_FOUR:
-					return z.rain_chance4;
-				case RAIN_SLOT_ONE:
-				default:
-					return z.rain_chance1;
-			}
-		}
+	switch (slot) {
+		case RAIN_SLOT_TWO:
+			return z->rain_chance2;
+		case RAIN_SLOT_THREE:
+			return z->rain_chance3;
+		case RAIN_SLOT_FOUR:
+			return z->rain_chance4;
+		case RAIN_SLOT_ONE:
+		default:
+			return z->rain_chance1;
 	}
-
-	return 0;
 }
 
 int ZoneStore::GetZoneRainDuration(uint32 zone_id, uint8 slot, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			switch (slot) {
-				case RAIN_SLOT_TWO:
-					return z.rain_duration2;
-				case RAIN_SLOT_THREE:
-					return z.rain_duration3;
-				case RAIN_SLOT_FOUR:
-					return z.rain_duration4;
-				case RAIN_SLOT_ONE:
-				default:
-					return z.rain_duration1;
-			}
-		}
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+
+	if (!z) {
+		return 0;
 	}
 
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			switch (slot) {
-				case RAIN_SLOT_TWO:
-					return z.rain_duration2;
-				case RAIN_SLOT_THREE:
-					return z.rain_duration3;
-				case RAIN_SLOT_FOUR:
-					return z.rain_duration4;
-				case RAIN_SLOT_ONE:
-				default:
-					return z.rain_duration1;
-			}
-		}
+	switch (slot) {
+		case RAIN_SLOT_TWO:
+			return z->rain_duration2;
+		case RAIN_SLOT_THREE:
+			return z->rain_duration3;
+		case RAIN_SLOT_FOUR:
+			return z->rain_duration4;
+		case RAIN_SLOT_ONE:
+		default:
+			return z->rain_duration1;
 	}
-
-	return 0;
 }
 
 int ZoneStore::GetZoneSnowChance(uint32 zone_id, uint8 slot, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			switch (slot) {
-				case SNOW_SLOT_TWO:
-					return z.snow_chance2;
-				case SNOW_SLOT_THREE:
-					return z.snow_chance3;
-				case SNOW_SLOT_FOUR:
-					return z.snow_chance4;
-				case SNOW_SLOT_ONE:
-				default:
-					return z.snow_chance1;
-			}
-		}
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+
+	if (!z) {
+		return 0;
 	}
 
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			switch (slot) {
-				case SNOW_SLOT_TWO:
-					return z.snow_chance2;
-				case SNOW_SLOT_THREE:
-					return z.snow_chance3;
-				case SNOW_SLOT_FOUR:
-					return z.snow_chance4;
-				case SNOW_SLOT_ONE:
-				default:
-					return z.snow_chance1;
-			}
-		}
+	switch (slot) {
+		case SNOW_SLOT_TWO:
+			return z->snow_chance2;
+		case SNOW_SLOT_THREE:
+			return z->snow_chance3;
+		case SNOW_SLOT_FOUR:
+			return z->snow_chance4;
+		case SNOW_SLOT_ONE:
+		default:
+			return z->snow_chance1;
 	}
-
-	return 0;
 }
 
 int ZoneStore::GetZoneSnowDuration(uint32 zone_id, uint8 slot, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			switch (slot) {
-				case SNOW_SLOT_TWO:
-					return z.snow_duration2;
-				case SNOW_SLOT_THREE:
-					return z.snow_duration3;
-				case SNOW_SLOT_FOUR:
-					return z.snow_duration4;
-				case SNOW_SLOT_ONE:
-				default:
-					return z.snow_duration1;
-			}
-		}
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+
+	if (!z) {
+		return 0;
 	}
 
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			switch (slot) {
-				case SNOW_SLOT_TWO:
-					return z.snow_duration2;
-				case SNOW_SLOT_THREE:
-					return z.snow_duration3;
-				case SNOW_SLOT_FOUR:
-					return z.snow_duration4;
-				case SNOW_SLOT_ONE:
-				default:
-					return z.snow_duration1;
-			}
-		}
+	switch (slot) {
+		case SNOW_SLOT_TWO:
+			return z->snow_duration2;
+		case SNOW_SLOT_THREE:
+			return z->snow_duration3;
+		case SNOW_SLOT_FOUR:
+			return z->snow_duration4;
+		case SNOW_SLOT_ONE:
+		default:
+			return z->snow_duration1;
 	}
-
-	return 0;
 }
 
 float ZoneStore::GetZoneGravity(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.gravity;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.gravity;
-		}
-	}
-
-	return DEFAULT_ZONE_GRAVITY;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->gravity : DEFAULT_ZONE_GRAVITY;
 }
 
 int ZoneStore::GetZoneType(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.type;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.type;
-		}
-	}
-
-	return DEFAULT_ZONE_TYPE;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->type : DEFAULT_ZONE_TYPE;
 }
 
 int8 ZoneStore::GetZoneSkyLock(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.skylock;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.skylock;
-		}
-	}
-
-	return 0;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->skylock : 0;
 }
 
 int ZoneStore::GetZoneFastRegenHP(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.fast_regen_hp;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.fast_regen_hp;
-		}
-	}
-
-	return DEFAULT_ZONE_FAST_REGEN;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->fast_regen_hp : DEFAULT_ZONE_FAST_REGEN;
 }
 
 int ZoneStore::GetZoneFastRegenMana(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.fast_regen_mana;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.fast_regen_mana;
-		}
-	}
-
-	return DEFAULT_ZONE_FAST_REGEN;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->fast_regen_mana : DEFAULT_ZONE_FAST_REGEN;
 }
 
 int ZoneStore::GetZoneFastRegenEndurance(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.fast_regen_endurance;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.fast_regen_endurance;
-		}
-	}
-
-	return DEFAULT_ZONE_FAST_REGEN;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->fast_regen_endurance : DEFAULT_ZONE_FAST_REGEN;
 }
 
 int ZoneStore::GetZoneNPCMaximumAggroDistance(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.npc_max_aggro_dist;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.npc_max_aggro_dist;
-		}
-	}
-
-	return DEFAULT_ZONE_MAX_AGGRO_DISTANCE;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->npc_max_aggro_dist : DEFAULT_ZONE_MAX_AGGRO_DISTANCE;
 }
 
 uint32 ZoneStore::GetZoneMaximumMovementUpdateRange(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.max_movement_update_range;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.max_movement_update_range;
-		}
-	}
-
-	return DEFAULT_ZONE_MAX_MOVEMENT_UPDATE_RANGE;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->max_movement_update_range : DEFAULT_ZONE_MAX_MOVEMENT_UPDATE_RANGE;
 }
 
 int8 ZoneStore::GetZoneMinimumExpansion(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.min_expansion;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.min_expansion;
-		}
-	}
-
-	return DEFAULT_ZONE_MIN_MAX_EXPANSION;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->min_expansion : DEFAULT_ZONE_MIN_MAX_EXPANSION;
 }
 
 int8 ZoneStore::GetZoneMaximumExpansion(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.max_expansion;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.max_expansion;
-		}
-	}
-
-	return DEFAULT_ZONE_MIN_MAX_EXPANSION;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->max_expansion : DEFAULT_ZONE_MIN_MAX_EXPANSION;
 }
 
 const std::string ZoneStore::GetZoneContentFlags(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.content_flags;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.content_flags;
-		}
-	};
-
-	return "";
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->content_flags : "";
 }
 
 const std::string ZoneStore::GetZoneContentFlagsDisabled(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.content_flags_disabled;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.content_flags_disabled;
-		}
-	}
-
-	return "";
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->content_flags_disabled : "";
 }
 
 int ZoneStore::GetZoneUnderworldTeleportIndex(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.underworld_teleport_index;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.underworld_teleport_index;
-		}
-	}
-
-	return 0;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->underworld_teleport_index : 0;
 }
 
 int ZoneStore::GetZoneLavaDamage(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.lava_damage;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.lava_damage;
-		}
-	}
-
-	return 0;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->lava_damage : 0;
 }
 
 int ZoneStore::GetZoneMinimumLavaDamage(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.min_lava_damage;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.min_lava_damage;
-		}
-	}
-
-	return 0;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->min_lava_damage : 0;
 }
 
 uint8 ZoneStore::GetZoneIdleWhenEmpty(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.idle_when_empty;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.idle_when_empty;
-		}
-	}
-
-	return 1;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->idle_when_empty : 1;
 }
 
 uint32 ZoneStore::GetZoneSecondsBeforeIdle(uint32 zone_id, int version)
 {
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == version) {
-			return z.seconds_before_idle;
-		}
-	}
-
-	for (auto &z: m_zones) {
-		if (z.zoneidnumber == zone_id && z.version == 0) {
-			return z.seconds_before_idle;
-		}
-	}
-
-	return 60;
+	const auto& z = GetZoneVersionWithFallback(zone_id, version);
+	return z ? z->seconds_before_idle : 60;
 }


### PR DESCRIPTION
# Notes
- Utilize `GetZoneVersionWithFallback` to shorten methods and reduce duplicate code.