### PR TITLE
[Feature] Implement learning recipes from books

### DIFF
--- a/common/repositories/char_recipe_list_repository.h
+++ b/common/repositories/char_recipe_list_repository.h
@@ -59,6 +59,24 @@ public:
 		return NewEntity();
 	}
 
+	// insert with ON DUPLICATE KEY UPDATE to leave rows that exist unchanged
+	static int InsertUpdateMany(Database& db, const std::vector<CharRecipeList>& entries)
+	{
+		std::vector<std::string> values;
+		values.reserve(entries.size());
+
+		for (const auto& e: entries)
+		{
+			values.emplace_back(fmt::format("({},{},{})", e.char_id, e.recipe_id, e.madecount));
+		}
+
+		auto results = db.QueryDatabase(fmt::format(
+			"INSERT INTO {0} (char_id, recipe_id, madecount) VALUES {1} ON DUPLICATE KEY UPDATE {2}={2}",
+			TableName(), fmt::join(values, ","), PrimaryKey()));
+
+		return results.Success() ? results.RowsAffected() : 0;
+	}
+
 };
 
 #endif //EQEMU_CHAR_RECIPE_LIST_REPOSITORY_H

--- a/zone/client.h
+++ b/zone/client.h
@@ -348,6 +348,7 @@ public:
 	int GetRecipeMadeCount(uint32 recipe_id);
 	bool HasRecipeLearned(uint32 recipe_id);
 	bool CanIncreaseTradeskill(EQ::skills::SkillType tradeskill);
+	void ScribeRecipes(uint32_t item_id) const;
 
 	bool GetRevoked() const { return revoked; }
 	void SetRevoked(bool rev) { revoked = rev; }

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4168,10 +4168,11 @@ void Client::Handle_OP_BookButton(const EQApplicationPacket* app)
 	BookButton_Struct* book = reinterpret_cast<BookButton_Struct*>(app->pBuffer);
 
 	const EQ::ItemInstance* const inst = GetInv().GetItem(book->invslot);
-	if (inst && inst->GetItem()->Book)
+	if (inst && inst->GetItem())
 	{
-		// todo: if scribe book learn recipes and delete book from inventory
-		// todo: if cast book use its spell on target and delete book from inventory (unless reusable?)
+		// todo: cast spell button (unknown if anything on live uses this)
+		ScribeRecipes(inst->GetItem()->ID);
+		DeleteItemInInventory(book->invslot, 1, true);
 	}
 
 	EQApplicationPacket outapp(OP_FinishWindow, 0);


### PR DESCRIPTION
This uses the book scribe button to learn recipes in SoF+ clients. For Titanium clients the button is not available so a workaround will need to be added later.

Note live gives no feedback when scribing books (at least those tested).