### PR TITLE
[Bug Fix] An Update to Xtarget to exclude Bot owned Temp/Swarm Pets

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -6775,7 +6775,7 @@ void Client::UpdateClientXTarget(Client *c)
 // IT IS NOT SAFE TO CALL THIS IF IT'S NOT INITIAL AGGRO
 void Client::AddAutoXTarget(Mob *m, bool send)
 {
-	if (m->IsBot() || (m->IsPet() && m->IsPetOwnerBot()) || (m->IsTempPet() && IsPetOwnerBot()) {
+	if (m->IsBot() || (m->IsPet() && m->IsPetOwnerBot()) || (m->IsTempPet() && IsPetOwnerBot())) {
 		return;
 	}
 

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -6775,7 +6775,7 @@ void Client::UpdateClientXTarget(Client *c)
 // IT IS NOT SAFE TO CALL THIS IF IT'S NOT INITIAL AGGRO
 void Client::AddAutoXTarget(Mob *m, bool send)
 {
-	if (m->IsBot() || (m->IsPet() && m->IsPetOwnerBot()) || (m->IsTempPet() && IsPetOwnerBot())) {
+	if (m->IsBot() || ((m->IsPet() || m->IsTempPet()) && m->IsPetOwnerBot())) {
 		return;
 	}
 

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -6775,7 +6775,7 @@ void Client::UpdateClientXTarget(Client *c)
 // IT IS NOT SAFE TO CALL THIS IF IT'S NOT INITIAL AGGRO
 void Client::AddAutoXTarget(Mob *m, bool send)
 {
-	if (m->IsBot() || (m->IsPet() && m->IsPetOwnerBot())) {
+	if (m->IsBot() || (m->IsPet() && m->IsPetOwnerBot()) || (m->IsTempPet() && IsPetOwnerBot()) {
 		return;
 	}
 


### PR DESCRIPTION
Adds an additional check to ensure bot owned temp pets/swarm pets are excluded on Xtarget list. 
We've tested this on Karana. Working great in numerous fights over the last 12 hours.