### PR TITLE
[Hot Fix] Add bool return to fix Client::RemoveAAPoints

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -11502,6 +11502,8 @@ bool Client::RemoveAAPoints(uint32 points)
 	}
 
 	SendAlternateAdvancementStats();
+
+	return true;
 }
 
 void Client::AddAAPoints(uint32 points)


### PR DESCRIPTION
# Notes
- Was missing the `return true;` at the bottom.