### PR TITLE
[Quest API] Add Silent Saylink Methods to Perl/Lua

### DIFF
--- a/common/say_link.cpp
+++ b/common/say_link.cpp
@@ -348,7 +348,7 @@ std::string EQ::SayLinkEngine::InjectSaylinksIfNotExist(const char *message)
 			if (ch != startpos)
 			{
 				std::string str(startpos, ch - startpos);
-				new_message += EQ::SayLinkEngine::GenerateQuestSaylink(str, false, str);
+				new_message += Saylink::Create(str);
 			}
 			in_bracket_state = false;
 		}
@@ -417,11 +417,12 @@ SaylinkRepository::Saylink EQ::SayLinkEngine::GetOrSaveSaylink(std::string sayli
 	return {};
 }
 
-std::string Saylink::Create(const std::string &saylink_text, bool silent, const std::string &link_name)
+std::string Saylink::Create(const std::string& saylink_text, bool silent, const std::string& link_name)
 {
 	return EQ::SayLinkEngine::GenerateQuestSaylink(saylink_text, silent, (link_name.empty() ? saylink_text : link_name));
 }
 
-std::string Saylink::Silent(const std::string &saylink_text, const std::string &link_name) {
+std::string Saylink::Silent(const std::string& saylink_text, const std::string& link_name)
+{
 	return EQ::SayLinkEngine::GenerateQuestSaylink(saylink_text, true, (link_name.empty() ? saylink_text : link_name));
 }

--- a/common/say_link.h
+++ b/common/say_link.h
@@ -130,7 +130,7 @@ namespace EQ
 
 class Saylink {
 public:
-	static std::string Create(const std::string &saylink_text, bool silent, const std::string &link_name = "");
+	static std::string Create(const std::string &saylink_text, bool silent = false, const std::string &link_name = "");
 	static std::string Silent(const std::string &saylink_text, const std::string &link_name = "");
 };
 

--- a/zone/dialogue_window.cpp
+++ b/zone/dialogue_window.cpp
@@ -334,7 +334,7 @@ void DialogueWindow::Render(Client *c, std::string markdown)
 	if (responses.size() > 1) {
 		for (auto &r: responses) {
 			bracket_responses.emplace_back(
-				fmt::format("[{}]", Saylink::Create(r, false))
+				fmt::format("[{}]", Saylink::Create(r))
 			);
 		}
 	}

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -1654,20 +1654,19 @@ void Perl__FlagInstanceByRaidLeader(uint32 zone, uint16 version)
 	quest_manager.FlagInstanceByRaidLeader(zone, version);
 }
 
-std::string Perl__saylink(const char* text)
+std::string Perl__saylink(std::string text)
 {
-	// const cast is safe since, target api doesn't modify it
-	return quest_manager.saylink(const_cast<char*>(text), false, text);
+	return Saylink::Create(text);
 }
 
-std::string Perl__saylink(const char* text, bool silent)
+std::string Perl__saylink(std::string text, bool silent)
 {
-	return quest_manager.saylink(const_cast<char*>(text), silent, text);
+	return Saylink::Create(text, silent);
 }
 
-std::string Perl__saylink(const char* text, bool silent, const char* link_name)
+std::string Perl__saylink(std::string text, bool silent, std::string link_name)
 {
-	return quest_manager.saylink(const_cast<char*>(text), silent, link_name);
+	return Saylink::Create(text, silent, link_name);
 }
 
 std::string Perl__getcharnamebyid(uint32 char_id)
@@ -5833,6 +5832,16 @@ uint16 Perl__GetBotRaceByID(uint32 bot_id)
 	return database.botdb.GetBotRaceByID(bot_id);
 }
 
+std::string Perl__silent_saylink(std::string text)
+{
+	return Saylink::Silent(text);
+}
+
+std::string Perl__silent_saylink(std::string text, std::string link_name)
+{
+	return Saylink::Silent(text, link_name);
+}
+
 void perl_register_quest()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -6644,9 +6653,9 @@ void perl_register_quest()
 	package.add("say", (void(*)(const char*, uint8, int))&Perl__say);
 	package.add("say", (void(*)(const char*, uint8, int, int))&Perl__say);
 	package.add("say", (void(*)(const char*, uint8, int, int, int))&Perl__say);
-	package.add("saylink", (std::string(*)(const char*))&Perl__saylink);
-	package.add("saylink", (std::string(*)(const char*, bool))&Perl__saylink);
-	package.add("saylink", (std::string(*)(const char*, bool, const char*))&Perl__saylink);
+	package.add("saylink", (std::string(*)(std::string))&Perl__saylink);
+	package.add("saylink", (std::string(*)(std::string, bool))&Perl__saylink);
+	package.add("saylink", (std::string(*)(std::string, bool, std::string))&Perl__saylink);
 	package.add("scribespells", (int(*)(int))&Perl__scribespells);
 	package.add("scribespells", (int(*)(int, int))&Perl__scribespells);
 	package.add("secondstotime", &Perl__secondstotime);
@@ -6698,6 +6707,8 @@ void perl_register_quest()
 	package.add("signal", (void(*)(int, int))&Perl__signal);
 	package.add("signalwith", (void(*)(int, int))&Perl__signalwith);
 	package.add("signalwith", (void(*)(int, int, int))&Perl__signalwith);
+	package.add("silent_saylink", (std::string(*)(std::string))&Perl__silent_saylink);
+	package.add("silent_saylink", (std::string(*)(std::string, std::string))&Perl__silent_saylink);
 	package.add("snow", &Perl__snow);
 	package.add("spawn", &Perl__spawn);
 	package.add("spawn2", &Perl__spawn2);

--- a/zone/gm_commands/logs.cpp
+++ b/zone/gm_commands/logs.cpp
@@ -82,7 +82,7 @@ void command_logs(Client *c, const Seperator *sep)
 				}
 
 				gmsay.emplace_back(
-					EQ::SayLinkEngine::GenerateQuestSaylink(
+					Saylink::Create(
 						fmt::format("#logs set gmsay {} {}", index, i), false, std::to_string(i)
 					)
 				);
@@ -96,7 +96,7 @@ void command_logs(Client *c, const Seperator *sep)
 				}
 
 				file.emplace_back(
-					EQ::SayLinkEngine::GenerateQuestSaylink(
+					Saylink::Create(
 						fmt::format("#logs set file {} {}", index, i), false, std::to_string(i)
 					)
 				);
@@ -110,7 +110,7 @@ void command_logs(Client *c, const Seperator *sep)
 				}
 
 				console.emplace_back(
-					EQ::SayLinkEngine::GenerateQuestSaylink(
+					Saylink::Create(
 						fmt::format("#logs set console {} {}", index, i), false, std::to_string(i)
 					)
 				);
@@ -124,7 +124,7 @@ void command_logs(Client *c, const Seperator *sep)
 				}
 
 				discord.emplace_back(
-					EQ::SayLinkEngine::GenerateQuestSaylink(
+					Saylink::Create(
 						fmt::format("#logs set discord {} {}", index, i), false, std::to_string(i)
 					)
 				);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -894,25 +894,16 @@ std::string lua_get_item_name(uint32 item_id) {
 	return quest_manager.getitemname(item_id);
 }
 
-std::string lua_say_link(const char *phrase, bool silent, const char *link_name) {
-	char text[256] = { 0 };
-	strncpy(text, phrase, 255);
-
-	return quest_manager.saylink(text, silent, link_name);
+std::string lua_say_link(std::string  text) {
+	return Saylink::Create(text);
 }
 
-std::string lua_say_link(const char *phrase, bool silent) {
-	char text[256] = { 0 };
-	strncpy(text, phrase, 255);
-
-	return quest_manager.saylink(text, silent, text);
+std::string lua_say_link(std::string text, bool silent) {
+	return Saylink::Create(text, silent, text);
 }
 
-std::string lua_say_link(const char *phrase) {
-	char text[256] = { 0 };
-	strncpy(text, phrase, 255);
-
-	return quest_manager.saylink(text, false, text);
+std::string lua_say_link(std::string text, bool silent, std::string link_name) {
+	return Saylink::Create(text, silent, link_name);
 }
 
 void lua_set_rule(std::string rule_name, std::string rule_value) {
@@ -5475,6 +5466,14 @@ uint16 lua_get_bot_race_by_id(uint32 bot_id)
 	return database.botdb.GetBotRaceByID(bot_id);
 }
 
+std::string lua_silent_say_link(std::string text) {
+	return Saylink::Silent(text);
+}
+
+std::string lua_silent_say_link(std::string text, std::string link_name) {
+	return Saylink::Silent(text, link_name);
+}
+
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
 	cur = table[#name]; \
 	if(luabind::type(cur) != LUA_TNIL) { \
@@ -5828,9 +5827,9 @@ luabind::scope lua_register_general() {
 		luabind::def("get_item_comment", (std::string(*)(uint32))&lua_get_item_comment),
 		luabind::def("get_item_lore", (std::string(*)(uint32))&lua_get_item_lore),
 		luabind::def("get_item_name", (std::string(*)(uint32))&lua_get_item_name),
-		luabind::def("say_link", (std::string(*)(const char*,bool,const char*))&lua_say_link),
-		luabind::def("say_link", (std::string(*)(const char*,bool))&lua_say_link),
-		luabind::def("say_link", (std::string(*)(const char*))&lua_say_link),
+		luabind::def("say_link", (std::string(*)(std::string))&lua_say_link),
+		luabind::def("say_link", (std::string(*)(std::string,bool))&lua_say_link),
+		luabind::def("say_link", (std::string(*)(std::string,bool,std::string))&lua_say_link),
 		luabind::def("set_rule", (void(*)(std::string, std::string))&lua_set_rule),
 		luabind::def("get_rule", (std::string(*)(std::string))&lua_get_rule),
 		luabind::def("get_data", (std::string(*)(std::string))&lua_get_data),
@@ -6269,6 +6268,8 @@ luabind::scope lua_register_general() {
 		luabind::def("get_bot_level_by_id", &lua_get_bot_level_by_id),
 		luabind::def("get_bot_name_by_id", &lua_get_bot_name_by_id),
 		luabind::def("get_bot_race_by_id", &lua_get_bot_race_by_id),
+		luabind::def("silent_say_link", (std::string(*)(std::string))&lua_silent_say_link),
+		luabind::def("silent_say_link", (std::string(*)(std::string,std::string))&lua_silent_say_link),
 		/*
 			Cross Zone
 		*/

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -3869,13 +3869,6 @@ void QuestManager::FlagInstanceByRaidLeader(uint32 zone, int16 version)
 	}
 }
 
-std::string QuestManager::saylink(char *saylink_text, bool silent, const char *link_name)
-{
-	QuestManagerCurrentQuestVars();
-
-	return Saylink::Create(saylink_text, silent, link_name);
-}
-
 std::string QuestManager::getcharnamebyid(uint32 char_id) {
 	std::string res;
 	if (char_id > 0) {

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -285,7 +285,6 @@ public:
 	void FlagInstanceByGroupLeader(uint32 zone, int16 version);
 	void FlagInstanceByRaidLeader(uint32 zone, int16 version);
 	std::string varlink(uint32 item_id, int16 charges = 0, uint32 aug1 = 0, uint32 aug2 = 0, uint32 aug3 = 0, uint32 aug4 = 0, uint32 aug5 = 0, uint32 aug6 = 0, bool attuned = false);
-	std::string saylink(char *saylink_text, bool silent, const char *link_name);
 	std::string getcharnamebyid(uint32 char_id);
 	uint32 getcharidbyname(const char* name);
 	std::string getclassname(uint8 class_id, uint8 level = 0);


### PR DESCRIPTION
# Perl
- Add `quest::silent_saylink(text)`.
- Add `quest::silent_saylink(text, link_name)`.

# Lua
- Add `eq.silent_say_link(text)`.
- Add `eq.silent_say_link(text, link_name)`.

# Notes
- Allows operators to more easily use silent saylinks without an optional silent parameter in the traditional saylink methods.
- Sets `silent` parameter default to `false` so we do not need to pass `false` when we are not using a silent saylink.
- Changes all places that used `EQ::SayLinkEngine::GenerateQuestSaylink` to `Saylink::Create` where possible.
- Removed `questmgr` method that is no longer necessary.
- Cleaned up Lua methods to use the strings directly instead of building one out.