### PR TITLE
[Bug Fix] Fix Empty Groups When Removing Bots

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -3630,7 +3630,7 @@ bool Bot::RemoveBotFromGroup(Bot* bot, Group* group) {
 			if (group->DelMember(bot)) {
 				group->DelMemberOOZ(bot->GetName());
 				database.SetGroupID(bot->GetCleanName(), 0, bot->GetBotID());
-				if (group->GroupCount() < 1) {
+				if (group->GroupCount() < 2) {
 					group->DisbandGroup();
 				}
 			}


### PR DESCRIPTION
# Notes
- We were checking for the incorrect value, meaning you could end up in an empty group.