### PR TITLE
[Quest API] Add Restore Methods for Health, Mana, and Endurance to Perl/Lua

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1687,13 +1687,6 @@ bool Mob::Attack(Mob* other, int Hand, bool bRiposte, bool IsStrikethrough, bool
 	}
 }
 
-//used by complete heal and #heal
-void Mob::Heal()
-{
-	SetMaxHP();
-	SendHPUpdate();
-}
-
 void Client::Damage(Mob* other, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, bool avoidable, int8 buffslot, bool iBuffTic, eSpecialAttacks special)
 {
 	if (dead || IsCorpse())

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -1064,9 +1064,9 @@ void Client::OPRezzAnswer(uint32 Action, uint32 SpellID, uint16 ZoneID, uint16 I
 			);
 			SpellOnTarget(resurrection_sickness_spell_id, this);
 		} else if (SpellID == SPELL_DIVINE_REZ) {
-			SetHP(GetMaxHP());
-			SetMana(GetMaxMana());
-			SetEndurance(GetMaxEndurance());
+			RestoreHealth();
+			RestoreMana();
+			RestoreEndurance();
 		} else {
 			SetHP(GetMaxHP() / 20);
 			SetMana(GetMaxMana() / 20);
@@ -2177,9 +2177,9 @@ void Client::HandleRespawnFromHover(uint32 Option)
 			FastQueuePacket(&outapp);
 
 			CalcBonuses();
-			SetHP(GetMaxHP());
-			SetMana(GetMaxMana());
-			SetEndurance(GetMaxEndurance());
+			RestoreHealth();
+			RestoreMana();
+			RestoreEndurance();
 
 			m_Position.x = chosen->x;
 			m_Position.y = chosen->y;

--- a/zone/gm_commands/set/hp_full.cpp
+++ b/zone/gm_commands/set/hp_full.cpp
@@ -7,7 +7,7 @@ void SetHPFull(Client *c, const Seperator *sep)
 		t = c->GetTarget();
 	}
 
-	t->Heal();
+	t->RestoreHealth();
 
 	c->Message(
 		Chat::White,

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -216,11 +216,6 @@ void Lua_Mob::ThrowingAttack(Lua_Mob other) {
 	self->ThrowingAttack(other);
 }
 
-void Lua_Mob::Heal() {
-	Lua_Safe_Call_Void();
-	self->Heal();
-}
-
 void Lua_Mob::HealDamage(uint64 amount) {
 	Lua_Safe_Call_Void();
 	self->HealDamage(amount);
@@ -3304,12 +3299,13 @@ std::string Lua_Mob::GetDeityName()
 	return EQ::deity::GetDeityName(static_cast<EQ::deity::DeityType>(self->GetDeity()));
 }
 
-luabind::object Lua_Mob::GetBuffs(lua_State* L) {
+luabind::object Lua_Mob::GetBuffs(lua_State* L)
+{
 	auto t = luabind::newtable(L);
 	if (d_) {
-		auto self = reinterpret_cast<NativeType*>(d_);
-		auto l    = self->GetBuffs();
-		int  i    = 1;
+		auto     self    = reinterpret_cast<NativeType *>(d_);
+		auto     l       = self->GetBuffs();
+		int      i       = 1;
 		for (int slot_id = 0; slot_id < self->GetMaxBuffSlots(); slot_id++) {
 			t[i] = Lua_Buff(&l[slot_id]);
 			i++;
@@ -3317,6 +3313,24 @@ luabind::object Lua_Mob::GetBuffs(lua_State* L) {
 	}
 
 	return t;
+}
+
+void Lua_Mob::RestoreEndurance()
+{
+	Lua_Safe_Call_Void();
+	self->RestoreEndurance();
+}
+
+void Lua_Mob::RestoreHealth()
+{
+	Lua_Safe_Call_Void();
+	self->RestoreHealth();
+}
+
+void Lua_Mob::RestoreMana()
+{
+	Lua_Safe_Call_Void();
+	self->RestoreMana();
 }
 
 luabind::scope lua_register_mob() {
@@ -3691,7 +3705,7 @@ luabind::scope lua_register_mob() {
 	.def("HasTimer", &Lua_Mob::HasTimer)
 	.def("HasTwoHandBluntEquipped", (bool(Lua_Mob::*)(void))&Lua_Mob::HasTwoHandBluntEquipped)
 	.def("HasTwoHanderEquipped", (bool(Lua_Mob::*)(void))&Lua_Mob::HasTwoHanderEquipped)
-	.def("Heal", &Lua_Mob::Heal)
+	.def("Heal", &Lua_Mob::RestoreHealth)
 	.def("HealDamage", (void(Lua_Mob::*)(uint64))&Lua_Mob::HealDamage)
 	.def("HealDamage", (void(Lua_Mob::*)(uint64,Lua_Mob))&Lua_Mob::HealDamage)
 	.def("InterruptSpell", (void(Lua_Mob::*)(int))&Lua_Mob::InterruptSpell)
@@ -3771,6 +3785,9 @@ luabind::scope lua_register_mob() {
 	.def("ResistSpell", (double(Lua_Mob::*)(int,int,Lua_Mob,bool))&Lua_Mob::ResistSpell)
 	.def("ResistSpell", (double(Lua_Mob::*)(int,int,Lua_Mob,bool,int))&Lua_Mob::ResistSpell)
 	.def("ResistSpell", (double(Lua_Mob::*)(int,int,Lua_Mob,bool,int,bool))&Lua_Mob::ResistSpell)
+	.def("RestoreEndurance", &Lua_Mob::RestoreEndurance)
+	.def("RestoreHealth", &Lua_Mob::RestoreHealth)
+	.def("RestoreMana", &Lua_Mob::RestoreMana)
 	.def("ResumeTimer", &Lua_Mob::ResumeTimer)
 	.def("RunTo", (void(Lua_Mob::*)(double, double, double))&Lua_Mob::RunTo)
 	.def("Say", (void(Lua_Mob::*)(const char*))& Lua_Mob::Say)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -63,7 +63,6 @@ public:
 	void Damage(Lua_Mob from, int64 damage, int spell_id, int attack_skill, bool avoidable, int buffslot, bool buff_tic);
 	void RangedAttack(Lua_Mob other);
 	void ThrowingAttack(Lua_Mob other);
-	void Heal();
 	void HealDamage(uint64 amount);
 	void HealDamage(uint64 amount, Lua_Mob other);
 	uint32 GetLevelCon(int other);
@@ -584,6 +583,9 @@ public:
 	bool IsAlwaysAggro();
 	std::string GetDeityName();
 	luabind::object GetBuffs(lua_State* L);
+	void RestoreEndurance();
+	void RestoreHealth();
+	void RestoreMana();
 };
 
 #endif

--- a/zone/merc.cpp
+++ b/zone/merc.cpp
@@ -73,9 +73,9 @@ Merc::Merc(const NPCType* d, float x, float y, float z, float heading)
 
 	// Class should use npc constructor to set light properties
 
-	SetHP(GetMaxHP());
-	SetMana(GetMaxMana());
-	SetEndurance(GetMaxEndurance());
+	RestoreHealth();
+	RestoreMana();
+	RestoreEndurance();
 
 	AI_Start();
 }
@@ -5289,9 +5289,9 @@ bool Merc::Unsuspend(bool setMaxStats) {
 		{
 			if(setMaxStats)
 			{
-				SetHP(GetMaxHP());
-				SetMana(GetMaxMana());
-				SetEndurance(GetMaxEndurance());
+				RestoreHealth();
+				RestoreMana();
+				RestoreEndurance();
 			}
 
 			//check for sufficient funds and remove them last

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -546,7 +546,6 @@ public:
 		bool avoidable = true, int8 buffslot = -1, bool iBuffTic = false, eSpecialAttacks special = eSpecialAttacks::None) = 0;
 	void SetHP(int64 hp);
 	inline void SetOOCRegen(int64 new_ooc_regen) { ooc_regen = new_ooc_regen; }
-	virtual void Heal();
 	virtual void HealDamage(uint64 ammount, Mob* caster = nullptr, uint16 spell_id = SPELL_UNKNOWN);
 	virtual void SetMaxHP() { current_hp = max_hp; }
 	virtual inline uint16 GetBaseRace() const { return base_race; }
@@ -1335,6 +1334,10 @@ public:
 
 	inline virtual bool IsBlockedBuff(int32 SpellID) { return false; }
 	inline virtual bool IsBlockedPetBuff(int32 SpellID) { return false; }
+
+	inline void RestoreEndurance() { SetEndurance(GetMaxEndurance()); };
+	inline void RestoreHealth() { SetMaxHP(); SendHPUpdate(); };
+	inline void RestoreMana() { SetMana(GetMaxMana()); };
 
 	std::string GetGlobal(const char *varname);
 	void SetGlobal(const char *varname, const char *newvalue, int options, const char *duration, Mob *other = nullptr);

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1337,7 +1337,7 @@ public:
 
 	inline void RestoreEndurance() { SetEndurance(GetMaxEndurance()); }
 	inline void RestoreHealth() { SetMaxHP(); SendHPUpdate(); }
-	inline void RestoreMana() { SetMana(GetMaxMana()); };
+	inline void RestoreMana() { SetMana(GetMaxMana()); }
 
 	std::string GetGlobal(const char *varname);
 	void SetGlobal(const char *varname, const char *newvalue, int options, const char *duration, Mob *other = nullptr);

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1335,8 +1335,8 @@ public:
 	inline virtual bool IsBlockedBuff(int32 SpellID) { return false; }
 	inline virtual bool IsBlockedPetBuff(int32 SpellID) { return false; }
 
-	inline void RestoreEndurance() { SetEndurance(GetMaxEndurance()); };
-	inline void RestoreHealth() { SetMaxHP(); SendHPUpdate(); };
+	inline void RestoreEndurance() { SetEndurance(GetMaxEndurance()); }
+	inline void RestoreHealth() { SetMaxHP(); SendHPUpdate(); }
 	inline void RestoreMana() { SetMana(GetMaxMana()); };
 
 	std::string GetGlobal(const char *varname);

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -1136,7 +1136,7 @@ void Mob::AI_Process() {
 
 			if (DistanceSquaredNoZ(m_Position, npcSpawnPoint) > leash_range) {
 				GMMove(npcSpawnPoint.x, npcSpawnPoint.y, npcSpawnPoint.z, npcSpawnPoint.w);
-				SetHP(GetMaxHP());
+				RestoreHealth();
 				BuffFadeAll();
 				WipeHateList();
 				return;

--- a/zone/mob_movement_manager.cpp
+++ b/zone/mob_movement_manager.cpp
@@ -605,7 +605,7 @@ public:
 
 		mob->BuffFadeAll();
 		mob->WipeHateList();
-		mob->Heal();
+		mob->RestoreHealth();
 
 		return false;
 	}

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -246,7 +246,7 @@ NPC::NPC(const NPCType *npc_type_data, Spawn2 *in_respawn, const glm::vec4 &posi
 	charm_atk              = npc_type_data->charm_atk;
 
 	CalcMaxMana();
-	SetMana(GetMaxMana());
+	RestoreMana();
 
 	MerchantType          = npc_type_data->merchanttype;
 	merchant_open         = (
@@ -448,7 +448,7 @@ NPC::NPC(const NPCType *npc_type_data, Spawn2 *in_respawn, const glm::vec4 &posi
 
 	npc_scale_manager->ScaleNPC(this);
 
-	SetMana(GetMaxMana());
+	RestoreMana();
 
 	if (GetBodyType() == BT_Animal && !RuleB(NPC, AnimalsOpenDoors)) {
 		m_can_open_doors = false;

--- a/zone/npc_scale_manager.cpp
+++ b/zone/npc_scale_manager.cpp
@@ -64,7 +64,7 @@ void NpcScaleManager::ScaleNPC(
 
 	if (always_scale || npc->GetMaxHP() == 0) {
 		npc->ModifyNPCStat("max_hp", std::to_string(scale_data.hp));
-		npc->Heal();
+		npc->RestoreHealth();
 	}
 
 	if (always_scale || npc->GetAccuracyRating() == 0) {

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -256,11 +256,6 @@ void Perl_Mob_ThrowingAttack(Mob* self, Mob* other) // @categories Skills and Re
 	self->ThrowingAttack(other);
 }
 
-void Perl_Mob_Heal(Mob* self)// @categories Script Utility
-{
-	self->Heal();
-}
-
 void Perl_Mob_HealDamage(Mob* self, int64_t amount)  // @categories Script Utility
 {
 	self->HealDamage(amount);
@@ -3429,13 +3424,28 @@ perl::array Perl_Mob_GetBuffs(Mob* self)
 {
 	perl::array result;
 
-	const auto& buffs = self->GetBuffs();
+	const auto &buffs = self->GetBuffs();
 
 	for (int slot_id = 0; slot_id < self->GetMaxBuffSlots(); slot_id++) {
 		result.push_back(&buffs[slot_id]);
 	}
 
 	return result;
+}
+
+void Perl_Mob_RestoreEndurance(Mob* self)
+{
+	self->RestoreEndurance();
+}
+
+void Perl_Mob_RestoreHealth(Mob* self)
+{
+	self->RestoreHealth();
+}
+
+void Perl_Mob_RestoreMana(Mob* self)
+{
+	self->RestoreMana();
 }
 
 void perl_register_mob()
@@ -3799,7 +3809,7 @@ void perl_register_mob()
 	package.add("HasTwoHandBluntEquipped", &Perl_Mob_HasTwoHandBluntEquipped);
 	package.add("HasTwoHanderEquipped", &Perl_Mob_HasTwoHanderEquipped);
 	package.add("HateSummon", &Perl_Mob_HateSummon);
-	package.add("Heal", &Perl_Mob_Heal);
+	package.add("Heal", &Perl_Mob_RestoreHealth);
 	package.add("HealDamage", (void(*)(Mob*, int64_t))&Perl_Mob_HealDamage);
 	package.add("HealDamage", (void(*)(Mob*, int64_t, Mob*))&Perl_Mob_HealDamage);
 	package.add("InterruptSpell", (void(*)(Mob*))&Perl_Mob_InterruptSpell);
@@ -3900,6 +3910,9 @@ void perl_register_mob()
 	package.add("RemoveNimbusEffect", &Perl_Mob_RemoveNimbusEffect);
 	package.add("RemovePet", &Perl_Mob_RemovePet);
 	package.add("ResistSpell", &Perl_Mob_ResistSpell);
+	package.add("RestoreEndurance", &Perl_Mob_RestoreEndurance);
+	package.add("RestoreHealth", &Perl_Mob_RestoreHealth);
+	package.add("RestoreMana", &Perl_Mob_RestoreMana);
 	package.add("ResumeTimer", &Perl_Mob_ResumeTimer);
 	package.add("RogueAssassinate", &Perl_Mob_RogueAssassinate);
 	package.add("RunTo", &Perl_Mob_RunTo);


### PR DESCRIPTION
# Perl
- Add `$mob->RestoreEndurance()`.
- Add `$mob->RestoreHealth()`.
- Add `$mob->RestoreMana()`.

# Lua
- Add `mob:RestoreEndurance()`.
- Add `mob:RestoreHealth()`.
- Add `mob:RestoreMana()`.

# Notes
- Allows operators to easily restore a mob to full health, mana, or endurance.
- `RestoreHealth` is just a more verbosely named `Heal`.
- Convert spots in source to use these short hands instead of directly using `SetEndurance(GetMaxEndurance())`, `SetHP(GetMaxHP())`, or `SetMana(GetMaxMana())`.