### PR TITLE
[Quest API] Add Archetype Methods to Perl/Lua

### DIFF
--- a/zone/botspellsai.cpp
+++ b/zone/botspellsai.cpp
@@ -591,7 +591,7 @@ bool Bot::BotCastCombatBuff(Mob* tar, uint8 botLevel, uint8 botClass) {
 			//Only check archetype if spell is not a group spell
 			//Hybrids get all buffs
 				switch (tar->GetArchetype()) {
-					case ARCHETYPE_CASTER:
+					case Archetype::Caster:
 						//TODO: probably more caster specific spell effects in here
 						if (
 							(
@@ -606,7 +606,7 @@ bool Bot::BotCastCombatBuff(Mob* tar, uint8 botLevel, uint8 botClass) {
 							continue;
 						}
 						break;
-					case ARCHETYPE_MELEE:
+					case Archetype::Melee:
 						if (
 							(
 								IsEffectInSpell(s.SpellId, SE_IncreaseSpellHaste) ||
@@ -899,7 +899,7 @@ bool Bot::BotCastBuff(Mob* tar, uint8 botLevel, uint8 botClass) {
 
 			switch (tar->GetArchetype())
 			{
-				case ARCHETYPE_CASTER:
+				case Archetype::Caster:
 					//TODO: probably more caster specific spell effects in here
 					if (IsEffectInSpell(s.SpellId, SE_AttackSpeed) || IsEffectInSpell(s.SpellId, SE_ATK) ||
 						IsEffectInSpell(s.SpellId, SE_STR) || IsEffectInSpell(s.SpellId, SE_ReverseDS))
@@ -907,7 +907,7 @@ bool Bot::BotCastBuff(Mob* tar, uint8 botLevel, uint8 botClass) {
 						continue;
 					}
 					break;
-				case ARCHETYPE_MELEE:
+				case Archetype::Melee:
 					if (IsEffectInSpell(s.SpellId, SE_IncreaseSpellHaste) || IsEffectInSpell(s.SpellId, SE_ManaPool) ||
 						IsEffectInSpell(s.SpellId, SE_CastingLevel) || IsEffectInSpell(s.SpellId, SE_ManaRegen_v2) ||
 						IsEffectInSpell(s.SpellId, SE_CurrentMana))

--- a/zone/common.h
+++ b/zone/common.h
@@ -19,9 +19,11 @@
 #define HEAD_POSITION 0.9f	//ratio of GetSize() where NPCs see from
 #define SEE_POSITION 0.5f	//ratio of GetSize() where NPCs try to see for LOS
 
-#define ARCHETYPE_HYBRID	1
-#define ARCHETYPE_CASTER	2
-#define ARCHETYPE_MELEE		3
+namespace Archetype {
+	constexpr uint8 Hybrid = 1;
+	constexpr uint8 Caster = 2;
+	constexpr uint8 Melee  = 3;
+};
 
 #define CON_GREEN		2
 #define CON_LIGHTBLUE	18

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -3333,6 +3333,30 @@ void Lua_Mob::RestoreMana()
 	self->RestoreMana();
 }
 
+std::string Lua_Mob::GetArchetypeName()
+{
+	Lua_Safe_Call_String();
+	return self->GetArchetypeName();
+}
+
+bool Lua_Mob::IsIntelligenceCasterClass()
+{
+	Lua_Safe_Call_Bool();
+	return self->IsIntelligenceCasterClass();
+}
+
+bool Lua_Mob::IsPureMeleeClass()
+{
+	Lua_Safe_Call_Bool();
+	return self->IsPureMeleeClass();
+}
+
+bool Lua_Mob::IsWisdomCasterClass()
+{
+	Lua_Safe_Call_Bool();
+	return self->IsWisdomCasterClass();
+}
+
 luabind::scope lua_register_mob() {
 	return luabind::class_<Lua_Mob, Lua_Entity>("Mob")
 	.def(luabind::constructor<>())
@@ -3524,6 +3548,7 @@ luabind::scope lua_register_mob() {
 	.def("GetAggroRange", (float(Lua_Mob::*)(void))&Lua_Mob::GetAggroRange)
 	.def("GetAllowBeneficial", (bool(Lua_Mob::*)(void))&Lua_Mob::GetAllowBeneficial)
 	.def("GetAppearance", (uint32(Lua_Mob::*)(void))&Lua_Mob::GetAppearance)
+	.def("GetArchetypeName", &Lua_Mob::GetArchetypeName)
 	.def("GetAssistRange", (float(Lua_Mob::*)(void))&Lua_Mob::GetAssistRange)
 	.def("GetBaseGender", &Lua_Mob::GetBaseGender)
 	.def("GetBaseRace", &Lua_Mob::GetBaseRace)
@@ -3732,6 +3757,7 @@ luabind::scope lua_register_mob() {
 	.def("IsFindable", (bool(Lua_Mob::*)(void))&Lua_Mob::IsFindable)
 	.def("IsHorse", &Lua_Mob::IsHorse)
 	.def("IsImmuneToSpell", (bool(Lua_Mob::*)(int,Lua_Mob))&Lua_Mob::IsImmuneToSpell)
+	.def("IsIntelligenceCasterClass", &Lua_Mob::IsIntelligenceCasterClass)
 	.def("IsInvisible", (bool(Lua_Mob::*)(Lua_Mob))&Lua_Mob::IsInvisible)
 	.def("IsInvisible", (bool(Lua_Mob::*)(void))&Lua_Mob::IsInvisible)
 	.def("IsMeleeDisabled", (bool(Lua_Mob::*)(void))&Lua_Mob::IsMeleeDisabled)
@@ -3742,6 +3768,7 @@ luabind::scope lua_register_mob() {
 	.def("IsPetOwnerBot", &Lua_Mob::IsPetOwnerBot)
 	.def("IsPetOwnerClient", &Lua_Mob::IsPetOwnerClient)
 	.def("IsPetOwnerNPC", &Lua_Mob::IsPetOwnerNPC)
+	.def("IsPureMeleeClass", &Lua_Mob::IsPureMeleeClass)
 	.def("IsRoamer", (bool(Lua_Mob::*)(void))&Lua_Mob::IsRoamer)
 	.def("IsRooted", (bool(Lua_Mob::*)(void))&Lua_Mob::IsRooted)
 	.def("IsRunning", (bool(Lua_Mob::*)(void))&Lua_Mob::IsRunning)
@@ -3753,6 +3780,7 @@ luabind::scope lua_register_mob() {
 	.def("IsTemporaryPet", &Lua_Mob::IsTemporaryPet)
 	.def("IsTrackable", (bool(Lua_Mob::*)(void))&Lua_Mob::IsTrackable)
 	.def("IsWarriorClass", &Lua_Mob::IsWarriorClass)
+	.def("IsWisdomCasterClass", &Lua_Mob::IsWisdomCasterClass)
 	.def("Kill", (void(Lua_Mob::*)(void))&Lua_Mob::Kill)
 	.def("Mesmerize", (void(Lua_Mob::*)(void))&Lua_Mob::Mesmerize)
 	.def("Message", &Lua_Mob::Message)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -586,6 +586,10 @@ public:
 	void RestoreEndurance();
 	void RestoreHealth();
 	void RestoreMana();
+	std::string GetArchetypeName();
+	bool IsIntelligenceCasterClass();
+	bool IsPureMeleeClass();
+	bool IsWisdomCasterClass();
 };
 
 #endif

--- a/zone/merc.cpp
+++ b/zone/merc.cpp
@@ -489,23 +489,12 @@ int64 Merc::CalcBaseHP()
 
 int64 Merc::CalcMaxMana()
 {
-	switch(GetCasterClass())
-	{
-	case 'I':
-	case 'W': {
+	if (IsIntelligenceCasterClass() || IsWisdomCasterClass()) {
 		max_mana = (CalcBaseMana() + itembonuses.Mana + spellbonuses.Mana + GroupLeadershipAAManaEnhancement());
-		break;
-			  }
-	case 'N': {
+	} else {
 		max_mana = 0;
-		break;
-			  }
-	default: {
-		LogDebug("Invalid Class [{}] in CalcMaxMana", GetCasterClass());
-		max_mana = 0;
-		break;
-			 }
 	}
+
 	if (max_mana < 0) {
 		max_mana = 0;
 	}
@@ -565,12 +554,13 @@ int64 Merc::CalcManaRegen()
 		regen = mana_regen + spellbonuses.ManaRegen + itembonuses.ManaRegen;
 	}
 
-	if(GetCasterClass() == 'I')
+	if (IsIntelligenceCasterClass()) {
 		regen += (itembonuses.HeroicINT / 25);
-	else if(GetCasterClass() == 'W')
+	} else if (IsWisdomCasterClass()) {
 		regen += (itembonuses.HeroicWIS / 25);
-	else
+	} else {
 		regen = 0;
+	}
 
 	//AAs
 	regen += aabonuses.ManaRegen;
@@ -581,14 +571,11 @@ int64 Merc::CalcManaRegen()
 int64 Merc::CalcManaRegenCap()
 {
 	int64 cap = RuleI(Character, ItemManaRegenCap) + aabonuses.ItemManaRegenCap;
-	switch(GetCasterClass())
-	{
-	case 'I':
+
+	if (IsIntelligenceCasterClass()) {
 		cap += (itembonuses.HeroicINT / 25);
-		break;
-	case 'W':
+	} else if (IsWisdomCasterClass()) {
 		cap += (itembonuses.HeroicWIS / 25);
-		break;
 	}
 
 	return (cap * RuleI(Character, ManaRegenMultiplier) / 100);
@@ -1166,7 +1153,7 @@ void Merc::AI_Process() {
 						float newX = 0;
 						float newY = 0;
 						float newZ = 0;
-						if (PlotPositionAroundTarget(GetTarget(), newX, newY, newZ, false) && GetArchetype() != ARCHETYPE_CASTER) {
+						if (PlotPositionAroundTarget(GetTarget(), newX, newY, newZ, false) && GetArchetype() != Archetype::Caster) {
 							RunTo(newX, newY, newZ);
 							return;
 						}
@@ -1314,7 +1301,7 @@ void Merc::AI_Process() {
 			if(AI_EngagedCastCheck()) {
 				MercMeditate(false);
 			}
-			else if(GetArchetype() == ARCHETYPE_CASTER)
+			else if(GetArchetype() == Archetype::Caster)
 				MercMeditate(true);
 		}
 	}
@@ -1337,7 +1324,7 @@ void Merc::AI_Process() {
 			//TODO: Implement passive stances.
 			//if(GetStance() != MercStancePassive) {
 			if(!AI_IdleCastCheck() && !IsCasting()) {
-				if(GetArchetype() == ARCHETYPE_CASTER) {
+				if(GetArchetype() == Archetype::Caster) {
 					MercMeditate(true);
 				}
 			}
@@ -1792,7 +1779,7 @@ bool Merc::AICastSpell(int8 iChance, uint32 iSpellTypes) {
 										if( !IsImmuneToSpell(selectedMercSpell.spellid, this)
 											&& (CanBuffStack(selectedMercSpell.spellid, mercLevel, true) >= 0)) {
 
-												if( GetArchetype() == ARCHETYPE_MELEE && IsEffectInSpell(selectedMercSpell.spellid, SE_IncreaseSpellHaste)) {
+												if( GetArchetype() == Archetype::Melee && IsEffectInSpell(selectedMercSpell.spellid, SE_IncreaseSpellHaste)) {
 													continue;
 												}
 
@@ -1819,7 +1806,7 @@ bool Merc::AICastSpell(int8 iChance, uint32 iSpellTypes) {
 												if( !tar->IsImmuneToSpell(selectedMercSpell.spellid, this)
 													&& (tar->CanBuffStack(selectedMercSpell.spellid, mercLevel, true) >= 0)) {
 
-														if( tar->GetArchetype() == ARCHETYPE_MELEE && IsEffectInSpell(selectedMercSpell.spellid, SE_IncreaseSpellHaste)) {
+														if( tar->GetArchetype() == Archetype::Melee && IsEffectInSpell(selectedMercSpell.spellid, SE_IncreaseSpellHaste)) {
 															continue;
 														}
 

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -940,19 +940,16 @@ int Mob::_GetFearSpeed() const {
 	return speed_mod;
 }
 
-int64 Mob::CalcMaxMana() {
-	switch (GetCasterClass()) {
-		case 'I':
-			max_mana = (((GetINT()/2)+1) * GetLevel()) + spellbonuses.Mana + itembonuses.Mana;
-			break;
-		case 'W':
-			max_mana = (((GetWIS()/2)+1) * GetLevel()) + spellbonuses.Mana + itembonuses.Mana;
-			break;
-		case 'N':
-		default:
-			max_mana = 0;
-			break;
+int64 Mob::CalcMaxMana()
+{
+	if (IsIntelligenceCasterClass()) {
+		max_mana = (((GetINT() / 2) + 1) * GetLevel()) + spellbonuses.Mana + itembonuses.Mana;
+	} else if (IsWisdomCasterClass()) {
+		max_mana = (((GetWIS() / 2) + 1) * GetLevel()) + spellbonuses.Mana + itembonuses.Mana;
+	} else {
+		max_mana = 0;
 	}
+
 	if (max_mana < 0) {
 		max_mana = 0;
 	}
@@ -981,90 +978,155 @@ int64 Mob::GetSpellHPBonuses() {
 	return spell_hp;
 }
 
-char Mob::GetCasterClass() const {
-	switch(class_)
-	{
-	case Class::Cleric:
-	case Class::Paladin:
-	case Class::Ranger:
-	case Class::Druid:
-	case Class::Shaman:
-	case Class::Beastlord:
-	case Class::ClericGM:
-	case Class::PaladinGM:
-	case Class::RangerGM:
-	case Class::DruidGM:
-	case Class::ShamanGM:
-	case Class::BeastlordGM:
-		return 'W';
-		break;
-
-	case Class::ShadowKnight:
-	case Class::Bard:
-	case Class::Necromancer:
-	case Class::Wizard:
-	case Class::Magician:
-	case Class::Enchanter:
-	case Class::ShadowKnightGM:
-	case Class::BardGM:
-	case Class::NecromancerGM:
-	case Class::WizardGM:
-	case Class::MagicianGM:
-	case Class::EnchanterGM:
-		return 'I';
-		break;
-
-	default:
-		return 'N';
-		break;
+bool Mob::IsIntelligenceCasterClass() const
+{
+	switch (GetClass()) {
+		case Class::ShadowKnight:
+		case Class::Bard:
+		case Class::Necromancer:
+		case Class::Wizard:
+		case Class::Magician:
+		case Class::Enchanter:
+		case Class::ShadowKnightGM:
+		case Class::BardGM:
+		case Class::NecromancerGM:
+		case Class::WizardGM:
+		case Class::MagicianGM:
+		case Class::EnchanterGM:
+			return true;
 	}
+
+	return false;
 }
 
-uint8 Mob::GetArchetype() const {
-	switch(class_)
-	{
-	case Class::Paladin:
-	case Class::Ranger:
-	case Class::ShadowKnight:
-	case Class::Bard:
-	case Class::Beastlord:
-	case Class::PaladinGM:
-	case Class::RangerGM:
-	case Class::ShadowKnightGM:
-	case Class::BardGM:
-	case Class::BeastlordGM:
-		return ARCHETYPE_HYBRID;
-		break;
-	case Class::Cleric:
-	case Class::Druid:
-	case Class::Shaman:
-	case Class::Necromancer:
-	case Class::Wizard:
-	case Class::Magician:
-	case Class::Enchanter:
-	case Class::ClericGM:
-	case Class::DruidGM:
-	case Class::ShamanGM:
-	case Class::NecromancerGM:
-	case Class::WizardGM:
-	case Class::MagicianGM:
-	case Class::EnchanterGM:
-		return ARCHETYPE_CASTER;
-		break;
-	case Class::Warrior:
-	case Class::Monk:
-	case Class::Rogue:
-	case Class::Berserker:
-	case Class::WarriorGM:
-	case Class::MonkGM:
-	case Class::RogueGM:
-	case Class::BerserkerGM:
-		return ARCHETYPE_MELEE;
-		break;
-	default:
-		return ARCHETYPE_HYBRID;
-		break;
+bool Mob::IsPureMeleeClass() const
+{
+	switch (GetClass()) {
+		case Class::Warrior:
+		case Class::Monk:
+		case Class::Rogue:
+		case Class::Berserker:
+		case Class::WarriorGM:
+		case Class::MonkGM:
+		case Class::RogueGM:
+		case Class::BerserkerGM:
+			return true;
+		default:
+			break;
 	}
+
+	return false;
+}
+
+bool Mob::IsWarriorClass() const
+{
+	switch (GetClass()) {
+		case Class::Warrior:
+		case Class::WarriorGM:
+		case Class::Rogue:
+		case Class::RogueGM:
+		case Class::Monk:
+		case Class::MonkGM:
+		case Class::Paladin:
+		case Class::PaladinGM:
+		case Class::ShadowKnight:
+		case Class::ShadowKnightGM:
+		case Class::Ranger:
+		case Class::RangerGM:
+		case Class::Beastlord:
+		case Class::BeastlordGM:
+		case Class::Berserker:
+		case Class::BerserkerGM:
+		case Class::Bard:
+		case Class::BardGM:
+			return true;
+		default:
+			break;
+	}
+
+	return false;
+}
+
+bool Mob::IsWisdomCasterClass() const
+{
+	switch (GetClass()) {
+		case Class::Cleric:
+		case Class::Paladin:
+		case Class::Ranger:
+		case Class::Druid:
+		case Class::Shaman:
+		case Class::Beastlord:
+		case Class::ClericGM:
+		case Class::PaladinGM:
+		case Class::RangerGM:
+		case Class::DruidGM:
+		case Class::ShamanGM:
+		case Class::BeastlordGM:
+			return true;
+	}
+
+	return false;
+}
+
+uint8 Mob::GetArchetype() const
+{
+	switch (GetClass()) {
+		case Class::Paladin:
+		case Class::Ranger:
+		case Class::ShadowKnight:
+		case Class::Bard:
+		case Class::Beastlord:
+		case Class::PaladinGM:
+		case Class::RangerGM:
+		case Class::ShadowKnightGM:
+		case Class::BardGM:
+		case Class::BeastlordGM:
+			return Archetype::Hybrid;
+		case Class::Cleric:
+		case Class::Druid:
+		case Class::Shaman:
+		case Class::Necromancer:
+		case Class::Wizard:
+		case Class::Magician:
+		case Class::Enchanter:
+		case Class::ClericGM:
+		case Class::DruidGM:
+		case Class::ShamanGM:
+		case Class::NecromancerGM:
+		case Class::WizardGM:
+		case Class::MagicianGM:
+		case Class::EnchanterGM:
+			return Archetype::Caster;
+		case Class::Warrior:
+		case Class::Monk:
+		case Class::Rogue:
+		case Class::Berserker:
+		case Class::WarriorGM:
+		case Class::MonkGM:
+		case Class::RogueGM:
+		case Class::BerserkerGM:
+			return Archetype::Melee;
+		default:
+			break;
+	}
+
+	return Archetype::Hybrid;
+}
+
+const std::string& Mob::GetArchetypeName()
+{
+	switch (GetArchetype()) {
+		case Archetype::Hybrid:
+			return "Hybrid";
+		case Archetype::Caster:
+			return "Caster";
+		case Archetype::Melee:
+			return "Melee";
+		default:
+			break;
+	}
+
+	return "Hybrid";
 }
 
 void Mob::SetSpawnLastNameByClass(NewSpawn_Struct* ns)
@@ -4584,39 +4646,6 @@ bool Mob::CanThisClassTripleAttack() const
 			return CastToClient()->HasSkill(EQ::skills::SkillTripleAttack);
 		}
 	}
-}
-
-bool Mob::IsWarriorClass(void) const
-{
-	switch(GetClass())
-	{
-	case Class::Warrior:
-	case Class::WarriorGM:
-	case Class::Rogue:
-	case Class::RogueGM:
-	case Class::Monk:
-	case Class::MonkGM:
-	case Class::Paladin:
-	case Class::PaladinGM:
-	case Class::ShadowKnight:
-	case Class::ShadowKnightGM:
-	case Class::Ranger:
-	case Class::RangerGM:
-	case Class::Beastlord:
-	case Class::BeastlordGM:
-	case Class::Berserker:
-	case Class::BerserkerGM:
-	case Class::Bard:
-	case Class::BardGM:
-		{
-			return true;
-		}
-	default:
-		{
-			return false;
-		}
-	}
-
 }
 
 bool Mob::CanThisClassParry(void) const

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1022,23 +1022,23 @@ bool Mob::IsWarriorClass() const
 {
 	switch (GetClass()) {
 		case Class::Warrior:
-		case Class::WarriorGM:
-		case Class::Rogue:
-		case Class::RogueGM:
-		case Class::Monk:
-		case Class::MonkGM:
 		case Class::Paladin:
-		case Class::PaladinGM:
-		case Class::ShadowKnight:
-		case Class::ShadowKnightGM:
 		case Class::Ranger:
-		case Class::RangerGM:
-		case Class::Beastlord:
-		case Class::BeastlordGM:
-		case Class::Berserker:
-		case Class::BerserkerGM:
+		case Class::ShadowKnight:
+		case Class::Monk:
 		case Class::Bard:
+		case Class::Rogue:
+		case Class::Beastlord:
+		case Class::Berserker:
+		case Class::WarriorGM:
+		case Class::PaladinGM:
+		case Class::RangerGM:
+		case Class::ShadowKnightGM:
+		case Class::MonkGM:
 		case Class::BardGM:
+		case Class::RogueGM:
+		case Class::BeastlordGM:
+		case Class::BerserkerGM:
 			return true;
 		default:
 			break;

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -838,8 +838,11 @@ public:
 	virtual void MakePet(uint16 spell_id, const char* pettype, const char *petname = nullptr);
 	virtual void MakePoweredPet(uint16 spell_id, const char* pettype, int16 petpower, const char *petname = nullptr, float in_size = 0.0f);
 	bool IsWarriorClass() const;
-	char GetCasterClass() const;
+	bool IsIntelligenceCasterClass() const;
+	bool IsPureMeleeClass() const;
+	bool IsWisdomCasterClass() const;
 	uint8 GetArchetype() const;
+	const std::string& GetArchetypeName();
 	void SetZone(uint32 zone_id, uint32 instance_id);
 	void SendStatsWindow(Client* c, bool use_window);
 	void ShowStats(Client* client);

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -2756,35 +2756,28 @@ void NPC::SetSwarmTarget(int target_id)
 int64 NPC::CalcMaxMana()
 {
 	if (npc_mana == 0) {
-		switch (GetCasterClass()) {
-			case 'I':
-				max_mana = (((GetINT() / 2) + 1) * GetLevel()) + spellbonuses.Mana + itembonuses.Mana;
-				break;
-			case 'W':
-				max_mana = (((GetWIS() / 2) + 1) * GetLevel()) + spellbonuses.Mana + itembonuses.Mana;
-				break;
-			default:
-				max_mana = 0;
-				break;
+		if (IsIntelligenceCasterClass()) {
+			max_mana = (((GetINT() / 2) + 1) * GetLevel()) + spellbonuses.Mana + itembonuses.Mana;
+		} else if (IsWisdomCasterClass()) {
+			max_mana = (((GetWIS() / 2) + 1) * GetLevel()) + spellbonuses.Mana + itembonuses.Mana;
+		} else {
+			max_mana = 0;
 		}
+
 		if (max_mana < 0) {
 			max_mana = 0;
 		}
 
 		return max_mana;
-	}
-	else {
-		switch (GetCasterClass()) {
-			case 'I':
-				max_mana = npc_mana + spellbonuses.Mana + itembonuses.Mana;
-				break;
-			case 'W':
-				max_mana = npc_mana + spellbonuses.Mana + itembonuses.Mana;
-				break;
-			default:
-				max_mana = 0;
-				break;
+	} else {
+		if (IsIntelligenceCasterClass()) {
+			max_mana = npc_mana + spellbonuses.Mana + itembonuses.Mana;
+		} else if (IsWisdomCasterClass()) {
+			max_mana = npc_mana + spellbonuses.Mana + itembonuses.Mana;
+		} else {
+			max_mana = 0;
 		}
+
 		if (max_mana < 0) {
 			max_mana = 0;
 		}

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -3448,6 +3448,26 @@ void Perl_Mob_RestoreMana(Mob* self)
 	self->RestoreMana();
 }
 
+std::string Perl_Mob_GetArchetypeName(Mob* self)
+{
+	return self->GetArchetypeName();
+}
+
+bool Perl_Mob_IsIntelligenceCasterClass(Mob* self)
+{
+	return self->IsIntelligenceCasterClass();
+}
+
+bool Perl_Mob_IsPureMeleeClass(Mob* self)
+{
+	return self->IsPureMeleeClass();
+}
+
+bool Perl_Mob_IsWisdomCasterClass(Mob* self)
+{
+	return self->IsWisdomCasterClass();
+}
+
 void perl_register_mob()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3620,6 +3640,7 @@ void perl_register_mob()
 	package.add("GetAggroRange", &Perl_Mob_GetAggroRange);
 	package.add("GetAllowBeneficial", &Perl_Mob_GetAllowBeneficial);
 	package.add("GetAppearance", &Perl_Mob_GetAppearance);
+	package.add("GetArchetypeName", &Perl_Mob_GetArchetypeName);
 	package.add("GetArmorTint", &Perl_Mob_GetArmorTint);
 	package.add("GetAssistRange", &Perl_Mob_GetAssistRange);
 	package.add("GetBaseGender", &Perl_Mob_GetBaseGender);
@@ -3843,6 +3864,7 @@ void perl_register_mob()
 	package.add("IsFindable", &Perl_Mob_IsFindable);
 	package.add("IsHorse", &Perl_Mob_IsHorse);
 	package.add("IsImmuneToSpell", &Perl_Mob_IsImmuneToSpell);
+	package.add("IsIntelligenceCasterClass", &Perl_Mob_IsIntelligenceCasterClass);
 	package.add("IsInvisible", (bool(*)(Mob*))&Perl_Mob_IsInvisible);
 	package.add("IsInvisible", (bool(*)(Mob*, Mob*))&Perl_Mob_IsInvisible);
 	package.add("IsMeleeDisabled", &Perl_Mob_IsMeleeDisabled);
@@ -3861,6 +3883,7 @@ void perl_register_mob()
 	package.add("IsPetOwnerClient", &Perl_Mob_IsPetOwnerClient);
 	package.add("IsPetOwnerNPC", &Perl_Mob_IsPetOwnerNPC);
 	package.add("IsPlayerCorpse", &Perl_Mob_IsPlayerCorpse);
+	package.add("IsPureMeleeClass", &Perl_Mob_IsPureMeleeClass);
 	package.add("IsRoamer", &Perl_Mob_IsRoamer);
 	package.add("IsRooted", &Perl_Mob_IsRooted);
 	package.add("IsRunning", &Perl_Mob_IsRunning);
@@ -3873,6 +3896,7 @@ void perl_register_mob()
 	package.add("IsTrackable", &Perl_Mob_IsTrackable);
 	package.add("IsTrap", &Perl_Mob_IsTrap);
 	package.add("IsWarriorClass", &Perl_Mob_IsWarriorClass);
+	package.add("IsWisdomCasterClass", &Perl_Mob_IsWisdomCasterClass);
 	package.add("Kill", &Perl_Mob_Kill);
 	package.add("MakePet", (void(*)(Mob*, uint16, const char*))&Perl_Mob_MakePet);
 	package.add("MakePet", (void(*)(Mob*, uint16, const char*, const char*))&Perl_Mob_MakePet);

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -456,7 +456,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				if(GetClass() == Class::Bard)
 					break;
 				if(IsManaTapSpell(spell_id)) {
-					if(GetCasterClass() != 'N') {
+					if (!IsPureMeleeClass()) {
 #ifdef SPELL_EFFECT_SPAM
 						snprintf(effect_desc, _EDLEN, "Current Mana: %+i", effect_value);
 #endif
@@ -578,12 +578,12 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 									GetPet()->BuffFadeByEffect(SE_Charm);
 								}
 							}
-							
+
 							CastToClient()->MovePC(zone->GetZoneID(), zone->GetInstanceID(), x, y, z, heading, 0, EvacToSafeCoords);
 						} else {
 							GMMove(x, y, z, heading);
 						}
-						
+
 						if (RuleB(Spells, EvacClearAggroInSameZone)) {
 							entity_list.ClearAggro(this);
 						}
@@ -1058,7 +1058,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 							cd->hit_heading = action->hit_heading;
 
 							CastToClient()->QueuePacket(action_packet);
-							
+
 							if (caster->IsClient() && caster != this) {
 								caster->CastToClient()->QueuePacket(action_packet);
 							}
@@ -1068,7 +1068,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 							if (caster->IsClient() && caster != this) {
 								caster->CastToClient()->QueuePacket(message_packet);
 							}
-							
+
 							CastToClient()->SetBindPoint(spells[spell_id].base_value[i] - 1);
 							Save();
 							safe_delete(action_packet);
@@ -1105,7 +1105,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					}
 					break;
 				}
-				
+
 				DispelMagic(caster, spell_id, effect_value);
 				break;
 			}
@@ -7369,7 +7369,7 @@ bool Mob::PassLimitClass(uint32 Classes_, uint16 Class_)
 	return false;
 }
 
-void Mob::DispelMagic(Mob* caster, uint16 spell_id, int effect_value) 
+void Mob::DispelMagic(Mob* caster, uint16 spell_id, int effect_value)
 {
 	for (int slot = 0; slot < GetMaxTotalSlots(); slot++) {
 		if (

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -224,8 +224,12 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 	if(GetTarget() && IsManaTapSpell(spell_id)) {
 		// If melee, block if ManaTapsOnAnyClass rule is false
 		// if caster, block if ManaTapsRequireNPCMana and no mana
-		bool melee_block = !RuleB(Spells, ManaTapsOnAnyClass);
-		bool caster_block = (GetTarget()->GetCasterClass() != 'N' && RuleB(Spells, ManaTapsRequireNPCMana) &&  GetTarget()->GetMana() == 0);
+		bool melee_block  = !RuleB(Spells, ManaTapsOnAnyClass);
+		bool caster_block = (
+			!GetTarget()->IsPureMeleeClass() &&
+			RuleB(Spells, ManaTapsRequireNPCMana) &&
+			GetTarget()->GetMana() == 0
+		);
 		if (melee_block || caster_block) {
 			InterruptSpell(TARGET_NO_MANA, 0x121, spell_id);
 			return false;
@@ -1105,10 +1109,10 @@ bool Client::CheckFizzle(uint16 spell_id)
 		// CALCULATE EFFECTIVE CASTING STAT VALUE
 		float prime_stat_reduction = 0.0f;
 
-		if (GetCasterClass() == 'W') {
-			prime_stat_reduction = (GetWIS() - 75) / 10.0;
-		} else if (GetCasterClass() == 'I') {
+		if (IsIntelligenceCasterClass()) {
 			prime_stat_reduction = (GetINT() - 75) / 10.0;
+		} else if (IsWisdomCasterClass()) {
+			prime_stat_reduction = (GetWIS() - 75) / 10.0;
 		}
 
 		// BARDS ARE SPECIAL - they add both CHA and DEX mods to get casting rates similar to full casters without spec skill
@@ -1183,10 +1187,10 @@ bool Client::CheckFizzle(uint16 spell_id)
 	// if you have high int/wis you fizzle less, you fizzle more if you are stupid
 	if (GetClass() == Class::Bard) {
 		diff -= (GetCHA() - 110) / 20.0;
-	} else if (GetCasterClass() == 'W') {
-		diff -= (GetWIS() - 125) / 20.0;
-	} else if (GetCasterClass() == 'I') {
+	} else if (IsIntelligenceCasterClass()) {
 		diff -= (GetINT() - 125) / 20.0;
+	} else if (IsWisdomCasterClass()) {
+		diff -= (GetWIS() - 125) / 20.0;
 	}
 
 	// base fizzlechance is lets say 5%, we can make it lower for AA skills or whatever


### PR DESCRIPTION
# Perl
- Add `$mob->GetArchetypeName()`.
- Add `$mob->IsIntelligenceCasterClass()`.
- Add `$mob->IsPureMeleeClass()`.
- Add `$mob->IsWisdomCasterClass()`.

# Lua
- Add `mob:GetArchetypeName()`.
- Add `mob:IsIntelligenceCasterClass()`.
- Add `mob:IsPureMeleeClass()`.
- Add `mob:IsWisdomCasterClass()`.

# Notes
- Allows operators to use mob archetypes to perform different operations.
- Add a namespace for archetypes instead of constants.
- Utilize `IsIntelligenceCasterClass()`, `IsPureMeleeClass()`, and `IsWisdomCasterClass()` where necessary.