### PR TITLE
[Quest API] Add Buff Support to Perl/Lua

### DIFF
--- a/zone/CMakeLists.txt
+++ b/zone/CMakeLists.txt
@@ -51,6 +51,7 @@ SET(zone_sources
     loot.cpp
     lua_bot.cpp
     lua_bit.cpp
+    lua_buff.cpp
     lua_corpse.cpp
     lua_client.cpp
     lua_door.cpp
@@ -105,6 +106,7 @@ SET(zone_sources
     pathfinder_null.cpp
     pathing.cpp
     perl_bot.cpp
+    perl_buff.cpp
     perl_client.cpp
     perl_doors.cpp
     perl_entity.cpp
@@ -207,6 +209,7 @@ SET(zone_headers
     horse.h
     lua_bot.h
     lua_bit.h
+    lua_buff.h
     lua_client.h
     lua_corpse.h
     lua_door.h

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -56,6 +56,7 @@ void perl_register_doors();
 void perl_register_expedition();
 void perl_register_expedition_lock_messages();
 void perl_register_bot();
+void perl_register_buff();
 #endif // EMBPERL_XS_CLASSES
 #endif // EMBPERL_XS
 
@@ -1175,6 +1176,7 @@ void PerlembParser::MapFunctions()
 	perl_register_expedition();
 	perl_register_expedition_lock_messages();
 	perl_register_bot();
+	perl_register_buff();
 #endif // EMBPERL_XS_CLASSES
 }
 

--- a/zone/lua_buff.cpp
+++ b/zone/lua_buff.cpp
@@ -151,9 +151,4 @@ luabind::scope lua_register_buff() {
 	.def("SendsClientUpdate", &Lua_Buff::SendsClientUpdate);
 }
 
-luabind::scope lua_register_buffs() {
-	return luabind::class_<Lua_Buffs>("Buffs")
-		.def_readwrite("entries", &Lua_Buffs::entries, luabind::return_stl_iterator);
-}
-
 #endif

--- a/zone/lua_buff.cpp
+++ b/zone/lua_buff.cpp
@@ -6,7 +6,7 @@
 
 #include "lua_buff.h"
 
-uint8 Lua_Buff::GetCasterID()
+uint16 Lua_Buff::GetCasterID()
 {
 	Lua_Safe_Call_Int();
 	return self->casterid;

--- a/zone/lua_buff.cpp
+++ b/zone/lua_buff.cpp
@@ -1,0 +1,159 @@
+#ifdef LUA_EQEMU
+
+#include "lua.hpp"
+#include <luabind/luabind.hpp>
+#include <luabind/iterator_policy.hpp>
+
+#include "lua_buff.h"
+
+uint8 Lua_Buff::GetCasterID()
+{
+	Lua_Safe_Call_Int();
+	return self->casterid;
+}
+
+uint8 Lua_Buff::GetCasterLevel()
+{
+	Lua_Safe_Call_Int();
+	return self->casterlevel;
+}
+
+std::string Lua_Buff::GetCasterName()
+{
+	Lua_Safe_Call_String();
+	return self->caster_name;
+}
+
+int Lua_Buff::GetCastOnX()
+{
+	Lua_Safe_Call_Int();
+	return self->caston_x;
+}
+
+int Lua_Buff::GetCastOnY()
+{
+	Lua_Safe_Call_Int();
+	return self->caston_y;
+}
+
+int Lua_Buff::GetCastOnZ()
+{
+	Lua_Safe_Call_Int();
+	return self->caston_z;
+}
+
+uint32 Lua_Buff::GetCounters()
+{
+	Lua_Safe_Call_Int();
+	return self->counters;
+}
+
+uint32 Lua_Buff::GetDOTRune()
+{
+	Lua_Safe_Call_Int();
+	return self->dot_rune;
+}
+
+int Lua_Buff::GetExtraDIChance()
+{
+	Lua_Safe_Call_Int();
+	return self->ExtraDIChance;
+}
+
+uint32 Lua_Buff::GetInstrumentModifier()
+{
+	Lua_Safe_Call_Int();
+	return self->instrument_mod;
+}
+
+uint32 Lua_Buff::GetMagicRune()
+{
+	Lua_Safe_Call_Int();
+	return self->magic_rune;
+}
+
+uint32 Lua_Buff::GetMeleeRune()
+{
+	Lua_Safe_Call_Int();
+	return self->melee_rune;
+}
+
+uint32 Lua_Buff::GetNumberOfHits()
+{
+	Lua_Safe_Call_Int();
+	return self->hit_number;
+}
+
+int16 Lua_Buff::GetRootBreakChance()
+{
+	Lua_Safe_Call_Int();
+	return self->RootBreakChance;
+}
+
+uint16 Lua_Buff::GetSpellID()
+{
+	Lua_Safe_Call_Int();
+	return self->spellid;
+}
+
+int Lua_Buff::GetTicsRemaining()
+{
+	Lua_Safe_Call_Int();
+	return self->ticsremaining;
+}
+
+int Lua_Buff::GetVirusSpreadTime()
+{
+	Lua_Safe_Call_Int();
+	return self->virus_spread_time;
+}
+
+bool Lua_Buff::IsCasterClient()
+{
+	Lua_Safe_Call_Bool();
+	return self->client;
+}
+
+bool Lua_Buff::IsPersistentBuff()
+{
+	Lua_Safe_Call_Bool();
+	return self->persistant_buff;
+}
+
+bool Lua_Buff::SendsClientUpdate()
+{
+	Lua_Safe_Call_Bool();
+	return self->UpdateClient;
+}
+
+luabind::scope lua_register_buff() {
+	return luabind::class_<Lua_Buff>("Buff")
+	.def(luabind::constructor<>())
+	.def("GetCasterID", &Lua_Buff::GetCasterID)
+	.def("GetCasterLevel", &Lua_Buff::GetCasterLevel)
+	.def("GetCasterName", &Lua_Buff::GetCasterName)
+	.def("GetCastOnX", &Lua_Buff::GetCastOnX)
+	.def("GetCastOnY", &Lua_Buff::GetCastOnY)
+	.def("GetCastOnZ", &Lua_Buff::GetCastOnZ)
+	.def("GetCounters", &Lua_Buff::GetCounters)
+	.def("GetDOTRune", &Lua_Buff::GetDOTRune)
+	.def("GetExtraDIChance", &Lua_Buff::GetExtraDIChance)
+	.def("GetInstrumentModifier", &Lua_Buff::GetInstrumentModifier)
+	.def("GetMagicRune", &Lua_Buff::GetMagicRune)
+	.def("GetMeleeRune", &Lua_Buff::GetMeleeRune)
+	.def("GetNumberOfHits", &Lua_Buff::GetNumberOfHits)
+	.def("GetRootBreakChance", &Lua_Buff::GetRootBreakChance)
+	.def("GetSpellID", &Lua_Buff::GetSpellID)
+	.def("GetTicsRemaining", &Lua_Buff::GetTicsRemaining)
+	.def("GetVirusSpreadTime", &Lua_Buff::GetVirusSpreadTime)
+	.def("IsCasterClient", &Lua_Buff::IsCasterClient)
+	.def("IsPersistentBuff", &Lua_Buff::IsPersistentBuff)
+	.def("SendsClientUpdate", &Lua_Buff::SendsClientUpdate);
+}
+
+luabind::scope lua_register_buffs() {
+	return luabind::class_<Lua_Buffs>("Buffs")
+		.def_readwrite("entries", &Lua_Buffs::entries, luabind::return_stl_iterator);
+}
+
+#endif

--- a/zone/lua_buff.h
+++ b/zone/lua_buff.h
@@ -12,7 +12,6 @@ namespace luabind {
 }
 
 luabind::scope lua_register_buff();
-luabind::scope lua_register_buffs();
 
 class Lua_Buff : public Lua_Ptr<const Buffs_Struct>
 {

--- a/zone/lua_buff.h
+++ b/zone/lua_buff.h
@@ -26,7 +26,7 @@ public:
 		return reinterpret_cast<const Buffs_Struct*>(GetLuaPtrData());
 	}
 
-	uint8 GetCasterID();
+	uint16 GetCasterID();
 	uint8 GetCasterLevel();
 	std::string GetCasterName();
 	int GetCastOnX();

--- a/zone/lua_buff.h
+++ b/zone/lua_buff.h
@@ -48,10 +48,5 @@ public:
 	bool SendsClientUpdate();
 };
 
-struct Lua_Buffs
-{
-	std::vector<Lua_Buff> entries;
-};
-
 #endif
 #endif

--- a/zone/lua_buff.h
+++ b/zone/lua_buff.h
@@ -1,0 +1,57 @@
+#ifndef EQEMU_LUA_BUFF_H
+#define EQEMU_LUA_BUFF_H
+#ifdef LUA_EQEMU
+
+#include "common.h"
+#include "lua_ptr.h"
+
+struct Buffs_Struct;
+
+namespace luabind {
+	struct scope;
+}
+
+luabind::scope lua_register_buff();
+luabind::scope lua_register_buffs();
+
+class Lua_Buff : public Lua_Ptr<const Buffs_Struct>
+{
+	typedef const Buffs_Struct NativeType;
+public:
+	Lua_Buff() : Lua_Ptr(nullptr) { }
+	Lua_Buff(const Buffs_Struct *d) : Lua_Ptr(d) { }
+	virtual ~Lua_Buff() { }
+
+	operator const Buffs_Struct*() {
+		return reinterpret_cast<const Buffs_Struct*>(GetLuaPtrData());
+	}
+
+	uint8 GetCasterID();
+	uint8 GetCasterLevel();
+	std::string GetCasterName();
+	int GetCastOnX();
+	int GetCastOnY();
+	int GetCastOnZ();
+	uint32 GetCounters();
+	uint32 GetDOTRune();
+	int GetExtraDIChance();
+	uint32 GetInstrumentModifier();
+	uint32 GetMagicRune();
+	uint32 GetMeleeRune();
+	uint32 GetNumberOfHits();
+	int16 GetRootBreakChance();
+	uint16 GetSpellID();
+	int GetTicsRemaining();
+	int GetVirusSpreadTime();
+	bool IsCasterClient();
+	bool IsPersistentBuff();
+	bool SendsClientUpdate();
+};
+
+struct Lua_Buffs
+{
+	std::vector<Lua_Buff> entries;
+};
+
+#endif
+#endif

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -3,18 +3,19 @@
 #include "lua.hpp"
 #include <luabind/luabind.hpp>
 
-#include "client.h"
-#include "npc.h"
 #include "bot.h"
+#include "client.h"
+#include "dialogue_window.h"
 #include "lua_bot.h"
+#include "lua_buff.h"
+#include "lua_client.h"
+#include "lua_hate_list.h"
 #include "lua_item.h"
 #include "lua_iteminst.h"
 #include "lua_mob.h"
 #include "lua_npc.h"
-#include "lua_hate_list.h"
-#include "lua_client.h"
 #include "lua_stat_bonuses.h"
-#include "dialogue_window.h"
+#include "npc.h"
 
 struct SpecialAbilities { };
 
@@ -3303,6 +3304,20 @@ std::string Lua_Mob::GetDeityName()
 	return EQ::deity::GetDeityName(static_cast<EQ::deity::DeityType>(self->GetDeity()));
 }
 
+Lua_Buffs Lua_Mob::GetBuffs() {
+	Lua_Safe_Call_Class(Lua_Buffs);
+	Lua_Buffs ret;
+
+	const auto& buffs = self->GetBuffs();
+
+	for (int slot_id = 0; slot_id < self->GetMaxBuffSlots(); slot_id++) {
+		Lua_Buff e(&buffs[slot_id]);
+		ret.entries.push_back(e);
+	}
+
+	return ret;
+}
+
 luabind::scope lua_register_mob() {
 	return luabind::class_<Lua_Mob, Lua_Entity>("Mob")
 	.def(luabind::constructor<>())
@@ -3505,6 +3520,7 @@ luabind::scope lua_register_mob() {
 	.def("GetBucketExpires", (std::string(Lua_Mob::*)(std::string))&Lua_Mob::GetBucketExpires)
 	.def("GetBucketKey", (std::string(Lua_Mob::*)(void))&Lua_Mob::GetBucketKey)
 	.def("GetBucketRemaining", (std::string(Lua_Mob::*)(std::string))&Lua_Mob::GetBucketRemaining)
+	.def("GetBuffs", &Lua_Mob::GetBuffs)
 	.def("GetBuffSlotFromType", &Lua_Mob::GetBuffSlotFromType)
 	.def("GetBuffSpellIDs", &Lua_Mob::GetBuffSpellIDs)
 	.def("GetBuffStatValueBySlot", (void(Lua_Mob::*)(uint8, const char*))& Lua_Mob::GetBuffStatValueBySlot)

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -3304,18 +3304,19 @@ std::string Lua_Mob::GetDeityName()
 	return EQ::deity::GetDeityName(static_cast<EQ::deity::DeityType>(self->GetDeity()));
 }
 
-Lua_Buffs Lua_Mob::GetBuffs() {
-	Lua_Safe_Call_Class(Lua_Buffs);
-	Lua_Buffs ret;
-
-	const auto& buffs = self->GetBuffs();
-
-	for (int slot_id = 0; slot_id < self->GetMaxBuffSlots(); slot_id++) {
-		Lua_Buff e(&buffs[slot_id]);
-		ret.entries.push_back(e);
+luabind::object Lua_Mob::GetBuffs(lua_State* L) {
+	auto t = luabind::newtable(L);
+	if (d_) {
+		auto self = reinterpret_cast<NativeType*>(d_);
+		auto l    = self->GetBuffs();
+		int  i    = 1;
+		for (int slot_id = 0; slot_id < self->GetMaxBuffSlots(); slot_id++) {
+			t[i] = l[slot_id];
+			i++;
+		}
 	}
 
-	return ret;
+	return t;
 }
 
 luabind::scope lua_register_mob() {

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -13,6 +13,7 @@ class Lua_Bot;
 class Lua_NPC;
 class Lua_Client;
 struct Lua_Mob_List;
+struct Lua_Buffs;
 
 namespace luabind {
 	struct scope;
@@ -583,6 +584,7 @@ public:
 	int GetHeroicStrikethrough();
 	bool IsAlwaysAggro();
 	std::string GetDeityName();
+	Lua_Buffs GetBuffs();
 };
 
 #endif

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -13,7 +13,6 @@ class Lua_Bot;
 class Lua_NPC;
 class Lua_Client;
 struct Lua_Mob_List;
-struct Lua_Buffs;
 
 namespace luabind {
 	struct scope;
@@ -584,7 +583,7 @@ public:
 	int GetHeroicStrikethrough();
 	bool IsAlwaysAggro();
 	std::string GetDeityName();
-	Lua_Buffs GetBuffs();
+	luabind::object GetBuffs(lua_State* L);
 };
 
 #endif

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -1306,8 +1306,7 @@ void LuaParser::MapFunctions(lua_State *L) {
 			lua_register_journal_mode(),
 			lua_register_expedition(),
 			lua_register_expedition_lock_messages(),
-			lua_register_buff(),
-			lua_register_buffs()
+			lua_register_buff()
 		)];
 
 	} catch(std::exception &ex) {

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -16,31 +16,31 @@
 #include "zone.h"
 #include "zone_config.h"
 
-#include "lua_parser.h"
 #include "lua_bit.h"
+#include "lua_bot.h"
+#include "lua_buff.h"
+#include "lua_client.h"
+#include "lua_corpse.h"
+#include "lua_door.h"
+#include "lua_encounter.h"
 #include "lua_entity.h"
+#include "lua_entity_list.h"
 #include "lua_expedition.h"
+#include "lua_general.h"
+#include "lua_group.h"
+#include "lua_hate_list.h"
+#include "lua_inventory.h"
 #include "lua_item.h"
 #include "lua_iteminst.h"
 #include "lua_mob.h"
-#include "lua_hate_list.h"
-#include "lua_client.h"
-#include "lua_inventory.h"
 #include "lua_npc.h"
-#include "lua_spell.h"
-#include "lua_entity_list.h"
-#include "lua_group.h"
-#include "lua_raid.h"
-#include "lua_corpse.h"
 #include "lua_object.h"
-#include "lua_door.h"
-#include "lua_spawn.h"
 #include "lua_packet.h"
-#include "lua_general.h"
-#include "lua_encounter.h"
+#include "lua_parser.h"
+#include "lua_raid.h"
+#include "lua_spawn.h"
+#include "lua_spell.h"
 #include "lua_stat_bonuses.h"
-
-#include "lua_bot.h"
 
 const char *LuaEvents[_LargestEventID] = {
 	"event_say",
@@ -1305,7 +1305,9 @@ void LuaParser::MapFunctions(lua_State *L) {
 			lua_register_journal_speakmode(),
 			lua_register_journal_mode(),
 			lua_register_expedition(),
-			lua_register_expedition_lock_messages()
+			lua_register_expedition_lock_messages(),
+			lua_register_buff(),
+			lua_register_buffs()
 		)];
 
 	} catch(std::exception &ex) {

--- a/zone/perl_buff.cpp
+++ b/zone/perl_buff.cpp
@@ -1,0 +1,134 @@
+#include "../common/features.h"
+#ifdef EMBPERL_XS_CLASSES
+#include "../common/global_define.h"
+#include "embperl.h"
+#include "common.h"
+
+uint8 Perl_Buff_GetCasterID(Buffs_Struct* self)
+{
+	return self->casterid;
+}
+
+uint8 Perl_Buff_GetCasterLevel(Buffs_Struct* self)
+{
+	return self->casterlevel;
+}
+
+std::string Perl_Buff_GetCasterName(Buffs_Struct* self)
+{
+	return self->caster_name;
+}
+
+int Perl_Buff_GetCastOnX(Buffs_Struct* self)
+{
+	return self->caston_x;
+}
+
+int Perl_Buff_GetCastOnY(Buffs_Struct* self)
+{
+	return self->caston_y;
+}
+
+int Perl_Buff_GetCastOnZ(Buffs_Struct* self)
+{
+	return self->caston_z;
+}
+
+uint32 Perl_Buff_GetCounters(Buffs_Struct* self)
+{
+	return self->counters;
+}
+
+uint32 Perl_Buff_GetDOTRune(Buffs_Struct* self)
+{
+	return self->dot_rune;
+}
+
+int Perl_Buff_GetExtraDIChance(Buffs_Struct* self)
+{
+	return self->ExtraDIChance;
+}
+
+uint32 Perl_Buff_GetInstrumentModifier(Buffs_Struct* self)
+{
+	return self->instrument_mod;
+}
+
+uint32 Perl_Buff_GetMagicRune(Buffs_Struct* self)
+{
+	return self->magic_rune;
+}
+
+uint32 Perl_Buff_GetMeleeRune(Buffs_Struct* self)
+{
+	return self->melee_rune;
+}
+
+uint32 Perl_Buff_GetNumberOfHits(Buffs_Struct* self)
+{
+	return self->hit_number;
+}
+
+int16 Perl_Buff_GetRootBreakChance(Buffs_Struct* self)
+{
+	return self->RootBreakChance;
+}
+
+uint16 Perl_Buff_GetSpellID(Buffs_Struct* self)
+{
+	return self->spellid;
+}
+
+int Perl_Buff_GetTicsRemaining(Buffs_Struct* self)
+{
+	return self->ticsremaining;
+}
+
+int Perl_Buff_GetVirusSpreadTime(Buffs_Struct* self)
+{
+	return self->virus_spread_time;
+}
+
+bool Perl_Buff_IsCasterClient(Buffs_Struct* self)
+{
+	return self->client;
+}
+
+bool Perl_Buff_IsPersistentBuff(Buffs_Struct* self)
+{
+	return self->persistant_buff;
+}
+
+bool Perl_Buff_SendsClientUpdate(Buffs_Struct* self)
+{
+	return self->UpdateClient;
+}
+
+void perl_register_buff()
+{
+	perl::interpreter state(PERL_GET_THX);
+
+	auto package = state.new_class<Buffs_Struct>("Buff");
+	package.add("GetCasterID", &Perl_Buff_GetCasterID);
+	package.add("GetCasterLevel", &Perl_Buff_GetCasterLevel);
+	package.add("GetCasterName", &Perl_Buff_GetCasterName);
+	package.add("GetCastOnX", &Perl_Buff_GetCastOnX);
+	package.add("GetCastOnY", &Perl_Buff_GetCastOnY);
+	package.add("GetCastOnZ", &Perl_Buff_GetCastOnZ);
+	package.add("GetCounters", &Perl_Buff_GetCounters);
+	package.add("GetDOTRune", &Perl_Buff_GetDOTRune);
+	package.add("GetExtraDIChance", &Perl_Buff_GetExtraDIChance);
+	package.add("GetInstrumentModifier", &Perl_Buff_GetInstrumentModifier);
+	package.add("GetMagicRune", &Perl_Buff_GetMagicRune);
+	package.add("GetMeleeRune", &Perl_Buff_GetMeleeRune);
+	package.add("GetNumberOfHits", &Perl_Buff_GetNumberOfHits);
+	package.add("GetRootBreakChance", &Perl_Buff_GetRootBreakChance);
+	package.add("GetSpellID", &Perl_Buff_GetSpellID);
+	package.add("GetTicsRemaining", &Perl_Buff_GetTicsRemaining);
+	package.add("GetVirusSpreadTime", &Perl_Buff_GetVirusSpreadTime);
+	package.add("IsCasterClient", &Perl_Buff_IsCasterClient);
+	package.add("IsPersistentBuff", &Perl_Buff_IsPersistentBuff);
+	package.add("SendsClientUpdate", &Perl_Buff_SendsClientUpdate);
+}
+
+#endif //EMBPERL_XS_CLASSES

--- a/zone/perl_buff.cpp
+++ b/zone/perl_buff.cpp
@@ -4,7 +4,7 @@
 #include "embperl.h"
 #include "common.h"
 
-uint8 Perl_Buff_GetCasterID(Buffs_Struct* self)
+uint16 Perl_Buff_GetCasterID(Buffs_Struct* self)
 {
 	return self->casterid;
 }

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -3425,6 +3425,19 @@ std::string Perl_Mob_GetDeityName(Mob* self)
 	return EQ::deity::GetDeityName(static_cast<EQ::deity::DeityType>(self->GetDeity()));
 }
 
+perl::array Perl_Mob_GetBuffs(Mob* self)
+{
+	perl::array result;
+
+	const auto& buffs = self->GetBuffs();
+
+	for (int slot_id = 0; slot_id < self->GetMaxBuffSlots(); slot_id++) {
+		result.push_back(&buffs[slot_id]);
+	}
+
+	return result;
+}
+
 void perl_register_mob()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3610,6 +3623,7 @@ void perl_register_mob()
 	package.add("GetBucketExpires", &Perl_Mob_GetBucketExpires);
 	package.add("GetBucketKey", &Perl_Mob_GetBucketKey);
 	package.add("GetBucketRemaining", &Perl_Mob_GetBucketRemaining);
+	package.add("GetBuffs", &Perl_Mob_GetBuffs);
 	package.add("GetBuffSlotFromType", &Perl_Mob_GetBuffSlotFromType);
 	package.add("GetBuffSpellIDs", &Perl_Mob_GetBuffSpellIDs);
 	package.add("GetBuffStatValueBySpell", &Perl_Mob_GetBuffStatValueBySpell);


### PR DESCRIPTION
# Perl
- Add `$buff->GetCasterID()`.
- Add `$buff->GetCasterLevel()`.
- Add `$buff->GetCasterName()`.
- Add `$buff->GetCastOnX()`.
- Add `$buff->GetCastOnY()`.
- Add `$buff->GetCastOnZ()`.
- Add `$buff->GetCounters()`.
- Add `$buff->GetDOTRune()`.
- Add `$buff->GetExtraDIChance()`.
- Add `$buff->GetInstrumentModi()`.
- Add `$buff->GetMagicRune()`.
- Add `$buff->GetMeleeRune()`.
- Add `$buff->GetNumberOfHits()`.
- Add `$buff->GetRootBreakChanc()`.
- Add `$buff->GetSpellID()`.
- Add `$buff->GetTicsRemaining()`.
- Add `$buff->GetVirusSpreadTim()`.
- Add `$buff->IsCasterClient()`.
- Add `$buff->IsPersistentBuff()`.
- Add `$buff->SendsClientUpdate()`.

# Lua
- Add `buff:GetCasterID()`.
- Add `buff:GetCasterLevel()`.
- Add `buff:GetCasterName()`.
- Add `buff:GetCastOnX()`.
- Add `buff:GetCastOnY()`.
- Add `buff:GetCastOnZ()`.
- Add `buff:GetCounters()`.
- Add `buff:GetDOTRune()`.
- Add `buff:GetExtraDIChance()`.
- Add `buff:GetInstrumentModi()`.
- Add `buff:GetMagicRune()`.
- Add `buff:GetMeleeRune()`.
- Add `buff:GetNumberOfHits()`.
- Add `buff:GetRootBreakChanc()`.
- Add `buff:GetSpellID()`.
- Add `buff:GetTicsRemaining()`.
- Add `buff:GetVirusSpreadTim()`.
- Add `buff:IsCasterClient()`.
- Add `buff:IsPersistentBuff()`.
- Add `buff:SendsClientUpdate()`.

# Notes
- Adds support for `Buffs_Struct` to Perl/Lua.
- Allows operators to read a buff's buff data directly to determine caster, melee rune, etc.