### PR TITLE
[Bug Fix] Fix Mob::CalculateDistance(mob) Typo

### DIFF
--- a/zone/waypoints.cpp
+++ b/zone/waypoints.cpp
@@ -606,8 +606,8 @@ float Mob::CalculateDistance(float x, float y, float z) {
 float Mob::CalculateDistance(Mob* mob) {
 	return sqrtf(
 		((m_Position.x - mob->GetX()) * (m_Position.x - mob->GetX())) +
-		((m_Position.y - mob->GetX()) * (m_Position.y - mob->GetY())) +
-		((m_Position.z - mob->GetX()) * (m_Position.z - mob->GetZ()))
+		((m_Position.y - mob->GetY()) * (m_Position.y - mob->GetY())) +
+		((m_Position.z - mob->GetZ()) * (m_Position.z - mob->GetZ()))
 	);
 }
 


### PR DESCRIPTION
# Notes
- Was using `GetX()` for all parts of the calculation, meaning it would produce incorrect values.
- Part of [this](https://github.com/EQEmu/Server/pull/3455/files#diff-94a8e3b04f001e4f74ce2da8404cbce7653146d963a3b93be6536505035ce96dR602-R607).