### PR TITLE
[Bug Fix] Fix EVENT_KILLED_MERIT firing before NPC removal

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2972,45 +2972,12 @@ bool NPC::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillTy
 	m_combat_record.Stop();
 
 	if (give_exp_client && !IsCorpse()) {
-		if (give_exp_client->IsRaidGrouped()) {
-			Raid* r = entity_list.GetRaidByClient(give_exp_client);
-
-			if (r) {
-				for (const auto& m: r->members) {
-					if (m.is_bot) {
-						continue;
-					}
-
-					if (m.member) {
-						m.member->RecordKilledNPCEvent(this);
-
-						if (parse->HasQuestSub(GetNPCTypeID(), EVENT_KILLED_MERIT)) {
-							parse->EventNPC(EVENT_KILLED_MERIT, this, m.member, "killed", 0);
-						}
-					}
-				}
-			}
-		} else if (give_exp_client->IsGrouped()) {
-			Group* g = entity_list.GetGroupByClient(give_exp_client);
-
-			if (g) {
-				for (const auto& m : g->members) {
-					if (m && m->IsClient()) {
-						Client* c = m->CastToClient();
-
-						c->RecordKilledNPCEvent(this);
-
-						if (parse->HasQuestSub(GetNPCTypeID(), EVENT_KILLED_MERIT)) {
-							parse->EventNPC(EVENT_KILLED_MERIT, this, c, "killed", 0);
-						}
-					}
-				}
-			}
-		} else {
-			give_exp_client->RecordKilledNPCEvent(this);
+		const auto& v = give_exp_client->GetRaidOrGroupOrSelf(true);
+		for (const auto& m : v) {
+			m->CastToClient()->RecordKilledNPCEvent(this);
 
 			if (parse->HasQuestSub(GetNPCTypeID(), EVENT_KILLED_MERIT)) {
-				parse->EventNPC(EVENT_KILLED_MERIT, this, give_exp_client, "killed", 0);
+				parse->EventNPC(EVENT_KILLED_MERIT, this, m, "killed", 0);
 			}
 		}
 	}

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -12330,7 +12330,7 @@ std::vector<Mob*> Client::GetRaidOrGroupOrSelf(bool clients_only)
 
 		if (r) {
 			for (const auto& m : r->members) {
-				if (m.member && (!clients_only || !m.is_bot)) {
+				if (m.member && (!m.is_bot || !clients_only)) {
 					v.emplace_back(m.member);
 				}
 			}
@@ -12340,7 +12340,7 @@ std::vector<Mob*> Client::GetRaidOrGroupOrSelf(bool clients_only)
 
 		if (g) {
 			for (const auto& m : g->members) {
-				if (m && (!clients_only || !m->IsBot())) {
+				if (m && (m->IsClient() || !clients_only)) {
 					v.emplace_back(m);
 				}
 			}

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -12320,3 +12320,34 @@ int Client::GetEXPPercentage()
 
 	return static_cast<int>(std::round(scaled * 100.0 / 330.0)); // unscaled pct
 }
+
+std::vector<Mob*> Client::GetRaidOrGroupOrSelf(bool clients_only)
+{
+	std::vector<Mob*> v;
+
+	if (IsRaidGrouped()) {
+		Raid* r = GetRaid();
+
+		if (r) {
+			for (const auto& m : r->members) {
+				if (m.member && (!clients_only || !m.is_bot)) {
+					v.emplace_back(m.member);
+				}
+			}
+		}
+	} else if (IsGrouped()) {
+		Group* g = GetGroup();
+
+		if (g) {
+			for (const auto& m : g->members) {
+				if (m && (!clients_only || !m->IsBot())) {
+					v.emplace_back(m);
+				}
+			}
+		}
+	} else {
+		v.emplace_back(this);
+	}
+
+	return v;
+}

--- a/zone/client.h
+++ b/zone/client.h
@@ -272,6 +272,8 @@ public:
 	int GetQuiverHaste(int delay);
 	void DoAttackRounds(Mob *target, int hand, bool IsFromSpell = false);
 
+	std::vector<Mob*> GetRaidOrGroupOrSelf(bool client_only = false);
+
 	void AI_Init();
 	void AI_Start(uint32 iMoveDelay = 0);
 	void AI_Stop();

--- a/zone/client.h
+++ b/zone/client.h
@@ -272,7 +272,7 @@ public:
 	int GetQuiverHaste(int delay);
 	void DoAttackRounds(Mob *target, int hand, bool IsFromSpell = false);
 
-	std::vector<Mob*> GetRaidOrGroupOrSelf(bool client_only = false);
+	std::vector<Mob*> GetRaidOrGroupOrSelf(bool clients_only = false);
 
 	void AI_Init();
 	void AI_Start(uint32 iMoveDelay = 0);

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3316,7 +3316,7 @@ luabind::object Lua_Client::GetRaidOrGroupOrSelf(lua_State* L)
 		auto l = self->GetRaidOrGroupOrSelf();
 		int i = 1;
 		for (const auto& e : l) {
-			t[i] = e;
+			t[i] = Lua_Mob(e);
 			i++;
 		}
 	}
@@ -3332,7 +3332,7 @@ luabind::object Lua_Client::GetRaidOrGroupOrSelf(lua_State* L, bool clients_only
 		auto l = self->GetRaidOrGroupOrSelf(clients_only);
 		int i = 1;
 		for (const auto& e : l) {
-			t[i] = e;
+			t[i] = Lua_Mob(e);
 			i++;
 		}
 	}

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3308,7 +3308,7 @@ bool Lua_Client::RemoveAlternateCurrencyValue(uint32 currency_id, uint32 amount)
 	return self->RemoveAlternateCurrencyValue(currency_id, amount);
 }
 
-luabind::object Lua_Client::GetRaidOrGroupOrSelf()
+luabind::object Lua_Client::GetRaidOrGroupOrSelf(lua_State* L)
 {
 	auto t = luabind::newtable(L);
 	if (d_) {
@@ -3324,7 +3324,7 @@ luabind::object Lua_Client::GetRaidOrGroupOrSelf()
 	return t;
 }
 
-luabind::object Lua_Client::GetRaidOrGroupOrSelf(bool clients_only)
+luabind::object Lua_Client::GetRaidOrGroupOrSelf(lua_State* L, bool clients_only)
 {
 	auto t = luabind::newtable(L);
 	if (d_) {
@@ -3574,8 +3574,8 @@ luabind::scope lua_register_client() {
 	.def("GetRaceBitmask", (int(Lua_Client::*)(void))&Lua_Client::GetRaceBitmask)
 	.def("GetRadiantCrystals", (uint32(Lua_Client::*)(void))&Lua_Client::GetRadiantCrystals)
 	.def("GetRaid", (Lua_Raid(Lua_Client::*)(void))&Lua_Client::GetRaid)
-	.def("GetRaidOrGroupOrSelf", (luabind::object(Lua_Client::*)(void))&Lua_Client::GetRaidOrGroupOrSelf)
-	.def("GetRaidOrGroupOrSelf", (luabind::object(Lua_Client::*)(bool))&Lua_Client::GetRaidOrGroupOrSelf)
+	.def("GetRaidOrGroupOrSelf", (luabind::object(Lua_Client::*)(lua_State*))&Lua_Client::GetRaidOrGroupOrSelf)
+	.def("GetRaidOrGroupOrSelf", (luabind::object(Lua_Client::*)(lua_State*,bool))&Lua_Client::GetRaidOrGroupOrSelf)
 	.def("GetRaidPoints", (uint32(Lua_Client::*)(void))&Lua_Client::GetRaidPoints)
 	.def("GetRaceAbbreviation", (std::string(Lua_Client::*)(void))&Lua_Client::GetRaceAbbreviation)
 	.def("GetRawItemAC", (int(Lua_Client::*)(void))&Lua_Client::GetRawItemAC)

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -20,10 +20,6 @@
 
 struct InventoryWhere { };
 
-struct Lua_Mob_List {
-	std::vector<Lua_Mob> entries;
-};
-
 void Lua_Client::SendSound() {
 	Lua_Safe_Call_Void();
 	self->SendSound();
@@ -3312,38 +3308,36 @@ bool Lua_Client::RemoveAlternateCurrencyValue(uint32 currency_id, uint32 amount)
 	return self->RemoveAlternateCurrencyValue(currency_id, amount);
 }
 
-Lua_Mob_List Lua_Client::GetRaidOrGroupOrSelf()
+luabind::object Lua_Client::GetRaidOrGroupOrSelf()
 {
-	Lua_Safe_Call_Class(Lua_Mob_List);
-
-	Lua_Mob_List ret;
-
-	const auto& l = self->GetRaidOrGroupOrSelf();
-
-	ret.entries.reserve(l.size());
-
-	for (const auto& e : l) {
-		ret.entries.emplace_back(Lua_Mob(e));
+	auto t = luabind::newtable(L);
+	if (d_) {
+		auto self = reinterpret_cast<NativeType*>(d_);
+		auto l = self->GetRaidOrGroupOrSelf();
+		int i = 1;
+		for (const auto& e : l) {
+			t[i] = e;
+			i++;
+		}
 	}
 
-	return ret;
+	return t;
 }
 
-Lua_Mob_List Lua_Client::GetRaidOrGroupOrSelf(bool clients_only)
+luabind::object Lua_Client::GetRaidOrGroupOrSelf(bool clients_only)
 {
-	Lua_Safe_Call_Class(Lua_Mob_List);
-
-	Lua_Mob_List ret;
-
-	const auto& l = self->GetRaidOrGroupOrSelf(clients_only);
-
-	ret.entries.reserve(l.size());
-
-	for (const auto& e : l) {
-		ret.entries.emplace_back(Lua_Mob(e));
+	auto t = luabind::newtable(L);
+	if (d_) {
+		auto self = reinterpret_cast<NativeType*>(d_);
+		auto l = self->GetRaidOrGroupOrSelf(clients_only);
+		int i = 1;
+		for (const auto& e : l) {
+			t[i] = e;
+			i++;
+		}
 	}
 
-	return ret;
+	return t;
 }
 
 luabind::scope lua_register_client() {
@@ -3580,8 +3574,8 @@ luabind::scope lua_register_client() {
 	.def("GetRaceBitmask", (int(Lua_Client::*)(void))&Lua_Client::GetRaceBitmask)
 	.def("GetRadiantCrystals", (uint32(Lua_Client::*)(void))&Lua_Client::GetRadiantCrystals)
 	.def("GetRaid", (Lua_Raid(Lua_Client::*)(void))&Lua_Client::GetRaid)
-	.def("GetRaidOrGroupOrSelf", (Lua_Mob_List(Lua_Client::*)(void))&Lua_Client::GetRaidOrGroupOrSelf)
-	.def("GetRaidOrGroupOrSelf", (Lua_Mob_List(Lua_Client::*)(bool))&Lua_Client::GetRaidOrGroupOrSelf)
+	.def("GetRaidOrGroupOrSelf", (luabind::object(Lua_Client::*)(void))&Lua_Client::GetRaidOrGroupOrSelf)
+	.def("GetRaidOrGroupOrSelf", (luabind::object(Lua_Client::*)(bool))&Lua_Client::GetRaidOrGroupOrSelf)
 	.def("GetRaidPoints", (uint32(Lua_Client::*)(void))&Lua_Client::GetRaidPoints)
 	.def("GetRaceAbbreviation", (std::string(Lua_Client::*)(void))&Lua_Client::GetRaceAbbreviation)
 	.def("GetRawItemAC", (int(Lua_Client::*)(void))&Lua_Client::GetRawItemAC)

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -20,6 +20,10 @@
 
 struct InventoryWhere { };
 
+struct Lua_Mob_List {
+	std::vector<Lua_Mob> entries;
+};
+
 void Lua_Client::SendSound() {
 	Lua_Safe_Call_Void();
 	self->SendSound();
@@ -3308,6 +3312,40 @@ bool Lua_Client::RemoveAlternateCurrencyValue(uint32 currency_id, uint32 amount)
 	return self->RemoveAlternateCurrencyValue(currency_id, amount);
 }
 
+Lua_Mob_List Lua_Client::GetRaidOrGroupOrSelf()
+{
+	Lua_Safe_Call_Class(Lua_Mob_List);
+
+	Lua_Mob_List ret;
+
+	const auto& l = self->GetRaidOrGroupOrSelf();
+
+	ret.entries.reserve(l.size());
+
+	for (const auto& e : l) {
+		ret.entries.emplace_back(Lua_Mob(e));
+	}
+
+	return ret;
+}
+
+Lua_Mob_List Lua_Client::GetRaidOrGroupOrSelf(bool clients_only)
+{
+	Lua_Safe_Call_Class(Lua_Mob_List);
+
+	Lua_Mob_List ret;
+
+	const auto& l = self->GetRaidOrGroupOrSelf(clients_only);
+
+	ret.entries.reserve(l.size());
+
+	for (const auto& e : l) {
+		ret.entries.emplace_back(Lua_Mob(e));
+	}
+
+	return ret;
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 	.def(luabind::constructor<>())
@@ -3542,6 +3580,8 @@ luabind::scope lua_register_client() {
 	.def("GetRaceBitmask", (int(Lua_Client::*)(void))&Lua_Client::GetRaceBitmask)
 	.def("GetRadiantCrystals", (uint32(Lua_Client::*)(void))&Lua_Client::GetRadiantCrystals)
 	.def("GetRaid", (Lua_Raid(Lua_Client::*)(void))&Lua_Client::GetRaid)
+	.def("GetRaidOrGroupOrSelf", (Lua_Mob_List(Lua_Client::*)(void))&Lua_Client::GetRaidOrGroupOrSelf)
+	.def("GetRaidOrGroupOrSelf", (Lua_Mob_List(Lua_Client::*)(bool))&Lua_Client::GetRaidOrGroupOrSelf)
 	.def("GetRaidPoints", (uint32(Lua_Client::*)(void))&Lua_Client::GetRaidPoints)
 	.def("GetRaceAbbreviation", (std::string(Lua_Client::*)(void))&Lua_Client::GetRaceAbbreviation)
 	.def("GetRawItemAC", (int(Lua_Client::*)(void))&Lua_Client::GetRawItemAC)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -496,8 +496,8 @@ public:
 	int GetAAEXPPercentage();
 	int GetEXPPercentage();
 	bool IsInAGuild();
-	luabind::object GetRaidOrGroupOrSelf();
-	luabind::object GetRaidOrGroupOrSelf(bool clients_only);
+	luabind::object GetRaidOrGroupOrSelf(lua_State* L);
+	luabind::object GetRaidOrGroupOrSelf(lua_State* L, bool clients_only);
 
 	void ApplySpell(int spell_id);
 	void ApplySpell(int spell_id, int duration);

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -10,6 +10,7 @@ class Lua_Group;
 class Lua_Raid;
 class Lua_Inventory;
 class Lua_Packet;
+struct Lua_Mob_List;
 
 namespace luabind {
 	struct scope;
@@ -496,6 +497,8 @@ public:
 	int GetAAEXPPercentage();
 	int GetEXPPercentage();
 	bool IsInAGuild();
+	Lua_Mob_List GetRaidOrGroupOrSelf();
+	Lua_Mob_List GetRaidOrGroupOrSelf(bool clients_only);
 
 	void ApplySpell(int spell_id);
 	void ApplySpell(int spell_id, int duration);

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -10,7 +10,6 @@ class Lua_Group;
 class Lua_Raid;
 class Lua_Inventory;
 class Lua_Packet;
-struct Lua_Mob_List;
 
 namespace luabind {
 	struct scope;
@@ -497,8 +496,8 @@ public:
 	int GetAAEXPPercentage();
 	int GetEXPPercentage();
 	bool IsInAGuild();
-	Lua_Mob_List GetRaidOrGroupOrSelf();
-	Lua_Mob_List GetRaidOrGroupOrSelf(bool clients_only);
+	luabind::object GetRaidOrGroupOrSelf();
+	luabind::object GetRaidOrGroupOrSelf(bool clients_only);
 
 	void ApplySpell(int spell_id);
 	void ApplySpell(int spell_id, int duration);

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -3311,7 +3311,7 @@ luabind::object Lua_Mob::GetBuffs(lua_State* L) {
 		auto l    = self->GetBuffs();
 		int  i    = 1;
 		for (int slot_id = 0; slot_id < self->GetMaxBuffSlots(); slot_id++) {
-			t[i] = l[slot_id];
+			t[i] = Lua_Buff(&l[slot_id]);
 			i++;
 		}
 	}

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -3113,6 +3113,36 @@ bool Perl_Client_RemoveAlternateCurrencyValue(Client* self, uint32 currency_id, 
 	return self->RemoveAlternateCurrencyValue(currency_id, amount);
 }
 
+perl::array Perl_Client_GetRaidOrGroupOrSelf(Client* self)
+{
+	perl::array result;
+
+	const auto& l = self->GetRaidOrGroupOrSelf();
+
+	result.reserve(l.size());
+
+	for (const auto& e : l) {
+		result.push_back(e);
+	}
+
+	return result;
+}
+
+perl::array Perl_Client_GetRaidOrGroupOrSelf(Client* self, bool clients_only)
+{
+	perl::array result;
+
+	const auto& l = self->GetRaidOrGroupOrSelf(clients_only);
+
+	result.reserve(l.size());
+
+	for (const auto& e : l) {
+		result.push_back(e);
+	}
+
+	return result;
+}
+
 void perl_register_client()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3346,6 +3376,8 @@ void perl_register_client()
 	package.add("GetRaceBitmask", &Perl_Client_GetRaceBitmask);
 	package.add("GetRadiantCrystals", &Perl_Client_GetRadiantCrystals);
 	package.add("GetRaid", &Perl_Client_GetRaid);
+	package.add("GetRaidOrGroupOrSelf", (perl::array(*)(Client*))&Perl_Client_GetRaidOrGroupOrSelf);
+	package.add("GetRaidOrGroupOrSelf", (perl::array(*)(Client*, bool))&Perl_Client_GetRaidOrGroupOrSelf);
 	package.add("GetRaidPoints", &Perl_Client_GetRaidPoints);
 	package.add("GetRawItemAC", &Perl_Client_GetRawItemAC);
 	package.add("GetRawSkill", &Perl_Client_GetRawSkill);


### PR DESCRIPTION
# Perl
- Add `$client->GetGroupOrRaidOrSelf()`.
- Add `$client->GetGroupOrRaidOrSelf(clients_only)`.

# Lua
- Add `client:GetGroupOrRaidOrSelf()`.
- Add `client:GetGroupOrRaidOrSelf(clients_only)`.

# Notes
- NPCs were parsing this event too early and anything that checked if they were still alive in `EVENT_KILLED_MERIT` would show them still alive because of this.

# Image
![image](https://github.com/EQEmu/Server/assets/89047260/accc9ff8-32b8-4e47-b8ae-82231f41c479)
