### PR TITLE
[Bug Fix] Fix Bot Cloning

### DIFF
--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -1788,7 +1788,8 @@ bool BotDatabase::CreateCloneBotInventory(const uint32 bot_id, const uint32 clon
 	}
 
 	for (auto& e : l) {
-		e.bot_id = clone_id;
+		e.inventories_index = 0;
+		e.bot_id            = clone_id;
 	}
 
 	return BotInventoriesRepository::InsertMany(database, l);


### PR DESCRIPTION
# Notes
- We were not setting `inventories_index` to `0` so it was trying to use the pre-existing unique identifier, causing the query to fail.