### PR TITLE
[Bug Fix] Fix Proximity Say

### DIFF
--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -2338,6 +2338,10 @@ void QuestManager::set_proximity_range(float x_range, float y_range, float z_ran
 	n->proximity->max_z         = n->GetZ() + z_range;
 	n->proximity->say           = enable_say;
 	n->proximity->proximity_set = true;
+
+	if (enable_say) {
+		HaveProximitySays = enable_say;
+	}
 }
 
 void QuestManager::set_proximity(float min_x, float max_x, float min_y, float max_y, float min_z, float max_z, bool enable_say)
@@ -2359,6 +2363,10 @@ void QuestManager::set_proximity(float min_x, float max_x, float min_y, float ma
 	n->proximity->max_z         = max_z;
 	n->proximity->say           = enable_say;
 	n->proximity->proximity_set = true;
+
+	if (enable_say) {
+		HaveProximitySays = enable_say;
+	}
 }
 
 void QuestManager::clear_proximity() {


### PR DESCRIPTION
# Notes
- Without setting `HaveProximitySays` to `true` along with `n->proximity->say` NPCs will not respond to proximity say stuff.
- Prior to this we were required to enable say in `quest;:set_proximity` or `quest::set_proximity_range` then use `quest::enable_proximity_say` as well.