### PR TITLE
[Bug Fix] Radiant/Ebon Crystals should only extract to 1000

### DIFF
--- a/common/eq_packet_structs.h
+++ b/common/eq_packet_structs.h
@@ -130,6 +130,11 @@ enum CrystalReclaimTypes
 	Radiant = 4,
 };
 
+namespace ItemStackSizeConstraint {
+	constexpr int16 Minimum = 1;
+	constexpr int16 Maximum = 1000;
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -5595,8 +5595,13 @@ void Client::Handle_OP_CrystalCreate(const EQApplicationPacket *app)
 	}
 
 	// Prevent the client from creating more than they have.
-	const uint32 amount  = EQ::ClampUpper(quantity, current_quantity);
+	uint32 amount  = EQ::ClampUpper(quantity, current_quantity);
 	const uint32 item_id = is_radiant ? RuleI(Zone, RadiantCrystalItemID) : RuleI(Zone, EbonCrystalItemID);
+
+	// Prevent pulling more than 1000 out at a time
+	if (amount > 1000) {
+		amount = 1000;
+	}
 
 	const bool success = SummonItem(item_id, amount);
 	if (!success) {


### PR DESCRIPTION
Creating a stack larger than 1000 can cause potential dupe issues further down the stream if other tasks are performed on the stack.