### PR TITLE
[Bug Fix] Fix ScaleNPC() in Perl

### DIFF
--- a/zone/lua_npc.cpp
+++ b/zone/lua_npc.cpp
@@ -758,7 +758,7 @@ void Lua_NPC::SetLDoNTrapDetected(bool is_detected) {
 void Lua_NPC::ScaleNPC(uint8 npc_level)
 {
 	Lua_Safe_Call_Void();
-	self->ScaleNPC(npc_level);
+	self->ScaleNPC(npc_level, true);
 }
 
 void Lua_NPC::ScaleNPC(uint8 npc_level, bool override_special_abilities)

--- a/zone/perl_npc.cpp
+++ b/zone/perl_npc.cpp
@@ -758,12 +758,12 @@ void Perl_NPC_SetLDoNTrapDetected(NPC* self, bool is_detected)
 
 void Perl_NPC_ScaleNPC(NPC* self, uint8 npc_level)
 {
-	return self->ScaleNPC(npc_level);
+	self->ScaleNPC(npc_level, true);
 }
 
 void Perl_NPC_ScaleNPC(NPC* self, uint8 npc_level, bool override_special_abilities)
 {
-	return self->ScaleNPC(npc_level, override_special_abilities);
+	self->ScaleNPC(npc_level, true, override_special_abilities);
 }
 
 bool Perl_NPC_IsUnderwaterOnly(NPC* self) // @categories Script Utility


### PR DESCRIPTION
# Notes
- We were not passing `override_special_abilities` in the right parameter slot.
- Default `always_scale` to `true` when using the Perl/Lua method.