### PR TITLE
[Bug Fix] Fix reusing timers

### DIFF
--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -380,12 +380,12 @@ void Perl__settimer(std::string timer_name, uint32 seconds)
 
 void Perl__settimer(std::string timer_name, uint32 seconds, Mob* m)
 {
-	quest_manager.settimer(timer_name, seconds);
+	quest_manager.settimer(timer_name, seconds, m);
 }
 
 void Perl__settimer(std::string timer_name, uint32 seconds, EQ::ItemInstance* inst)
 {
-	quest_manager.settimer(timer_name, seconds);
+	quest_manager.settimerMS(timer_name, seconds * 1000, inst);
 }
 
 void Perl__settimerMS(std::string timer_name, uint32 milliseconds)
@@ -6693,9 +6693,9 @@ void perl_register_quest()
 	package.add("settarget", &Perl__settarget);
 	package.add("settime", (void(*)(int, int))&Perl__settime);
 	package.add("settime", (void(*)(int, int, bool))&Perl__settime);
-	package.add("settimer", (void(*)(std::string, uint32))&Perl__settimer),
-	package.add("settimer", (void(*)(std::string, uint32, EQ::ItemInstance*))&Perl__settimer),
-	package.add("settimer", (void(*)(std::string, uint32, Mob*))&Perl__settimer),
+	package.add("settimer", (void(*)(std::string, uint32))&Perl__settimer);
+	package.add("settimer", (void(*)(std::string, uint32, EQ::ItemInstance*))&Perl__settimer);
+	package.add("settimer", (void(*)(std::string, uint32, Mob*))&Perl__settimer);
 	package.add("settimerMS", (void(*)(std::string, uint32))&Perl__settimerMS);
 	package.add("settimerMS", (void(*)(std::string, uint32, EQ::ItemInstance*))&Perl__settimerMS);
 	package.add("settimerMS", (void(*)(std::string, uint32, Mob*))&Perl__settimerMS);

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -537,9 +537,8 @@ void QuestManager::settimer(const std::string& timer_name, uint32 seconds, Mob* 
 	);
 
 	if (!QTimerList.empty()) {
-		for (auto e : QTimerList) {
+		for (auto& e : QTimerList) {
 			if (e.mob && e.mob == mob && e.name == timer_name) {
-				e.Timer_.Enable();
 				e.Timer_.Start(seconds * 1000, false);
 
 				if (has_start_event) {
@@ -613,9 +612,8 @@ void QuestManager::settimerMS(const std::string& timer_name, uint32 milliseconds
 	}
 
 	if (!QTimerList.empty()) {
-		for (auto e : QTimerList) {
+		for (auto& e : QTimerList) {
 			if (e.mob && e.mob == owner && e.name == timer_name) {
-				e.Timer_.Enable();
 				e.Timer_.Start(milliseconds, false);
 
 				if (has_start_event) {
@@ -678,9 +676,8 @@ void QuestManager::settimerMS(const std::string& timer_name, uint32 milliseconds
 	);
 
 	if (!QTimerList.empty()) {
-		for (auto e : QTimerList) {
+		for (auto& e : QTimerList) {
 			if (e.mob && e.mob == m && e.name == timer_name) {
-				e.Timer_.Enable();
 				e.Timer_.Start(milliseconds, false);
 
 				if (has_start_event) {


### PR DESCRIPTION
Fixes regression from #4099 where timers that were reused were not getting changed with their updated times

Using test script:
```
my $t = 10;

sub EVENT_TIMER {
  quest::say("Timer triggered.");
  $t = $t + 5;
  if ($t == 45) {
    quest::say("Stopping timer.");
    quest::stoptimer("trigger");
  }
  else {
    quest::say("Setting timer to $t seconds.");
    quest::settimer("trigger", $t);
  }
}

sub EVENT_SPAWN {
  quest::say("Setting initial timer for $t seconds.");
  quest::settimer("trigger", $t);
}
```
```
[Fri Mar 22 21:47:04 2024] a training dummy says 'Setting initial timer for 10 seconds.'
[Fri Mar 22 21:47:14 2024] a training dummy says 'Timer triggered.'
[Fri Mar 22 21:47:14 2024] a training dummy says 'Setting timer to 15 seconds.'
[Fri Mar 22 21:47:29 2024] a training dummy says 'Timer triggered.'
[Fri Mar 22 21:47:29 2024] a training dummy says 'Setting timer to 20 seconds.'
[Fri Mar 22 21:47:49 2024] a training dummy says 'Timer triggered.'
[Fri Mar 22 21:47:49 2024] a training dummy says 'Setting timer to 25 seconds.'
[Fri Mar 22 21:48:14 2024] a training dummy says 'Timer triggered.'
[Fri Mar 22 21:48:14 2024] a training dummy says 'Setting timer to 30 seconds.'
[Fri Mar 22 21:48:44 2024] a training dummy says 'Timer triggered.'
[Fri Mar 22 21:48:44 2024] a training dummy says 'Setting timer to 35 seconds.'
[Fri Mar 22 21:49:19 2024] a training dummy says 'Timer triggered.'
[Fri Mar 22 21:49:19 2024] a training dummy says 'Setting timer to 40 seconds.'
[Fri Mar 22 21:49:59 2024] a training dummy says 'Timer triggered.'
[Fri Mar 22 21:49:59 2024] a training dummy says 'Stopping timer.'
```
