### PR TITLE
[Hotfix] Fix crash regression in SendEnterWorld

### DIFF
--- a/world/client.cpp
+++ b/world/client.cpp
@@ -192,7 +192,7 @@ bool Client::CanTradeFVNoDropItem()
 
 void Client::SendEnterWorld(std::string name)
 {
-	const std::string& live_name = database.GetLiveChar(GetAccountID());
+	const std::string live_name = database.GetLiveChar(GetAccountID());
 	if (is_player_zoning) {
 		if(database.GetAccountIDByChar(live_name) != GetAccountID()) {
 			eqs->Close();


### PR DESCRIPTION
From https://github.com/EQEmu/Server/pull/4054

```
 World |   Crash    | print_trace #4  0x000061734d054af3 in Client::SendEnterWorld (this=this@entry=0x61734f2c81d0, name=...) at /home/eqemu/code/world/client.cpp:206 
 World |   Crash    | print_trace #5  0x000061734d05568b in Client::HandleSendLoginInfoPacket (this=this@entry=0x61734f2c81d0, app=app@entry=0x61734f1c86b0) at /home/eqemu/code/world/client.cpp:518 
 World |   Crash    | print_trace #6  0x000061734d05a07e in Client::HandlePacket (this=this@entry=0x61734f2c81d0, app=0x61734f1c86b0) at /home/eqemu/code/world/client.cpp:1105 
 World |   Crash    | print_trace #7  0x000061734d05a754 in Client::Process (this=0x61734f2c81d0) at /home/eqemu/code/world/client.cpp:1197 
 World |   Crash    | print_trace #8  0x000061734d068a1f in ClientList::Process (this=<optimized out>) at /home/eqemu/code/world/clientlist.cpp:64 
 World |   Crash    | print_trace #9  0x000061734d094edc in main::$_11::operator() (this=0x61734f1d3600, t=<optimized out>) at /home/eqemu/code/world/main.cpp:417 
```