### PR TITLE
[Skill Caps] Further improvements

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -83,6 +83,7 @@ SET(common_sources
     shared_tasks.cpp
     shareddb.cpp
     skills.cpp
+    skill_caps.cpp
     spdat.cpp
     strings.cpp
     struct_strategy.cpp
@@ -492,7 +493,7 @@ SET(repositories
     repositories/zone_repository.h
     repositories/zone_points_repository.h
 
-    )
+)
 
 SET(common_headers
     additive_lagged_fibonacci_engine.h
@@ -592,7 +593,7 @@ SET(common_headers
     ptimer.h
     queue.h
     races.h
-	raid.h
+    raid.h
     random.h
     rdtsc.h
     rulesys.h
@@ -606,6 +607,7 @@ SET(common_headers
     shared_tasks.h
     shareddb.h
     skills.h
+    skill_caps.h
     spdat.h
     strings.h
     struct_strategy.h
@@ -681,13 +683,13 @@ SOURCE_GROUP(Event FILES
     event/event_loop.h
     event/timer.h
     event/task.h
-    )
+)
 
 SOURCE_GROUP(Json FILES
     json/json.h
     json/jsoncpp.cpp
     json/json-forwards.h
-    )
+)
 
 SOURCE_GROUP(Net FILES
     net/console_server.cpp
@@ -724,7 +726,7 @@ SOURCE_GROUP(Net FILES
     net/websocket_server.h
     net/websocket_server_connection.cpp
     net/websocket_server_connection.h
-    )
+)
 
 SOURCE_GROUP(Patches FILES
     patches/patches.h
@@ -768,12 +770,12 @@ SOURCE_GROUP(Patches FILES
     patches/titanium_limits.cpp
     patches/uf.cpp
     patches/uf_limits.cpp
-    )
+)
 
 SOURCE_GROUP(StackWalker FILES
     StackWalker/StackWalker.h
     StackWalker/StackWalker.cpp
-    )
+)
 
 SOURCE_GROUP(Util FILES
     util/memory_stream.h
@@ -781,7 +783,7 @@ SOURCE_GROUP(Util FILES
     util/directory.h
     util/uuid.cpp
     util/uuid.h
-    )
+)
 
 INCLUDE_DIRECTORIES(Patches SocketLib StackWalker)
 
@@ -794,6 +796,6 @@ ENDIF (UNIX)
 
 IF (WIN32 AND EQEMU_BUILD_PCH)
     TARGET_PRECOMPILE_HEADERS(common PRIVATE pch/pch.h)
-ENDIF()
+ENDIF ()
 
 SET(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)

--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -1914,24 +1914,3 @@ void SharedDatabase::SetSharedSpellsCount(uint32 shared_spells_count)
 {
 	SharedDatabase::m_shared_spells_count = shared_spells_count;
 }
-
-uint16 SharedDatabase::GetSkillCap(uint8 class_id, EQ::skills::SkillType skill_id, uint8 level)
-{
-	const auto& l = SkillCapsRepository::GetWhere(
-		*this,
-		fmt::format(
-			"`class_id` = {} AND `skill_id` = {} AND `level` = {} LIMIT 1",
-			class_id,
-			static_cast<uint16>(skill_id),
-			level
-		)
-	);
-
-	if (l.empty()) {
-		return 0;
-	}
-
-	const auto& e = l.front();
-
-	return e.cap;
-}

--- a/common/shareddb.h
+++ b/common/shareddb.h
@@ -160,8 +160,6 @@ public:
 	uint32 GetSharedItemsCount() { return m_shared_items_count; }
 	uint32 GetItemsCount();
 
-	uint16 GetSkillCap(uint8 class_id, EQ::skills::SkillType skill_id, uint8 level);
-
 	/**
 	 * spells
 	 */

--- a/common/skill_caps.cpp
+++ b/common/skill_caps.cpp
@@ -1,17 +1,24 @@
-#include "zone.h"
+#include "skill_caps.h"
 
-SkillCapsRepository::SkillCaps Zone::GetSkillCap(uint8 class_id, EQ::skills::SkillType skill_id, uint8 level)
+SkillCaps *SkillCaps::SetContentDatabase(Database *db)
+{
+	m_content_database = db;
+
+	return this;
+}
+
+SkillCapsRepository::SkillCaps SkillCaps::GetSkillCap(uint8 class_id, EQ::skills::SkillType skill_id, uint8 level)
 {
 	if (!IsPlayerClass(class_id)) {
 		return SkillCapsRepository::NewEntity();
 	}
 
-	for (const auto& e : m_skill_caps) {
+	for (const auto &e: m_skill_caps) {
 		if (
 			e.class_id == class_id &&
 			e.level == level &&
 			static_cast<EQ::skills::SkillType>(e.skill_id) == skill_id
-		) {
+			) {
 			return e;
 		}
 	}
@@ -19,31 +26,31 @@ SkillCapsRepository::SkillCaps Zone::GetSkillCap(uint8 class_id, EQ::skills::Ski
 	return SkillCapsRepository::NewEntity();
 }
 
-uint8 Zone::GetTrainLevel(uint8 class_id, EQ::skills::SkillType skill_id, uint8 level)
+uint8 SkillCaps::GetTrainLevel(uint8 class_id, EQ::skills::SkillType skill_id, uint8 level)
 {
 	if (
 		!IsPlayerClass(class_id) ||
 		class_id > Class::PLAYER_CLASS_COUNT ||
 		static_cast<uint32>(skill_id) > (EQ::skills::HIGHEST_SKILL + 1)
-	) {
+		) {
 		return 0;
 	}
 
 	const uint8 skill_cap_max_level = (
 		RuleI(Character, SkillCapMaxLevel) > 0 ?
-		RuleI(Character, SkillCapMaxLevel) :
-		RuleI(Character, MaxLevel)
+			RuleI(Character, SkillCapMaxLevel) :
+			RuleI(Character, MaxLevel)
 	);
 
 	const uint8 max_level = level > skill_cap_max_level ? level : skill_cap_max_level;
 
-	for (const auto& e : m_skill_caps) {
+	for (const auto &e: m_skill_caps) {
 		for (uint8 current_level = 1; current_level <= max_level; current_level++) {
 			if (
 				e.class_id == class_id &&
 				static_cast<EQ::skills::SkillType>(e.skill_id) == skill_id &&
 				e.level == current_level
-			) {
+				) {
 				return current_level;
 			}
 		}
@@ -52,18 +59,18 @@ uint8 Zone::GetTrainLevel(uint8 class_id, EQ::skills::SkillType skill_id, uint8 
 	return 0;
 }
 
-void Zone::LoadSkillCaps()
+void SkillCaps::LoadSkillCaps()
 {
-	const auto& l = SkillCapsRepository::All(content_db);
+	const auto &l = SkillCapsRepository::All(*m_content_database);
 
 	m_skill_caps.reserve(l.size());
 
-	for (const auto& e : l) {
+	for (const auto &e: l) {
 		if (
 			e.level < 1 ||
 			!IsPlayerClass(e.class_id) ||
 			static_cast<EQ::skills::SkillType>(e.skill_id) >= EQ::skills::SkillCount
-		) {
+			) {
 			continue;
 		}
 
@@ -77,7 +84,7 @@ void Zone::LoadSkillCaps()
 	);
 }
 
-void Zone::ReloadSkillCaps()
+void SkillCaps::ReloadSkillCaps()
 {
 	ClearSkillCaps();
 	LoadSkillCaps();

--- a/common/skill_caps.h
+++ b/common/skill_caps.h
@@ -1,0 +1,26 @@
+#ifndef CODE_SKILL_CAPS_H
+#define CODE_SKILL_CAPS_H
+
+#include "repositories/skill_caps_repository.h"
+#include "types.h"
+#include "classes.h"
+#include "skills.h"
+
+class SkillCaps {
+public:
+	inline void ClearSkillCaps() { m_skill_caps.clear(); }
+	SkillCapsRepository::SkillCaps GetSkillCap(uint8 class_id, EQ::skills::SkillType skill_id, uint8 level);
+	uint8 GetTrainLevel(uint8 class_id, EQ::skills::SkillType skill_id, uint8 level);
+	void LoadSkillCaps();
+	void ReloadSkillCaps();
+
+	SkillCaps *SetContentDatabase(Database *db);
+private:
+	Database                                    *m_content_database{};
+	std::vector<SkillCapsRepository::SkillCaps> m_skill_caps = {};
+};
+
+extern SkillCaps skill_caps;
+
+
+#endif //CODE_SKILL_CAPS_H

--- a/common/skills.cpp
+++ b/common/skills.cpp
@@ -18,9 +18,9 @@
 */
 
 #include "skills.h"
+#include "classes.h"
 
 #include <string.h>
-
 
 bool EQ::skills::IsTradeskill(SkillType skill)
 {

--- a/common/skills.h
+++ b/common/skills.h
@@ -26,7 +26,6 @@
 #include <map>
 #include <vector>
 
-
 namespace EQ
 {
 	namespace skills {

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -55,6 +55,7 @@
 #include "../common/content/world_content_service.h"
 #include "../common/repositories/group_id_repository.h"
 #include "../common/repositories/character_data_repository.h"
+#include "../common/skill_caps.h"
 
 #include <iostream>
 #include <iomanip>
@@ -2133,7 +2134,7 @@ void Client::SetClassStartingSkills(PlayerProfile_Struct *pp)
 				i == EQ::skills::SkillAlcoholTolerance || i == EQ::skills::SkillBindWound)
 				continue;
 
-			pp->skills[i] = content_db.GetSkillCap(pp->class_, (EQ::skills::SkillType)i, 1);
+			pp->skills[i] = skill_caps.GetSkillCap(pp->class_, (EQ::skills::SkillType)i, 1).cap;
 		}
 	}
 

--- a/world/main.cpp
+++ b/world/main.cpp
@@ -86,8 +86,9 @@
 #include "world_boot.h"
 #include "../common/path_manager.h"
 #include "../common/events/player_event_logs.h"
+#include "../common/skill_caps.h"
 
-
+SkillCaps           skill_caps;
 ZoneStore           zone_store;
 ClientList          client_list;
 GroupLFPList        LFPGroupList;
@@ -192,6 +193,8 @@ int main(int argc, char **argv)
 		->SetContentDatabase(&content_db)
 		->SetExpansionContext()
 		->ReloadContentFlags();
+
+	skill_caps.SetContentDatabase(&content_db)->LoadSkillCaps();
 
 	std::unique_ptr<EQ::Net::ServertalkServer> server_connection;
 	server_connection = std::make_unique<EQ::Net::ServertalkServer>();

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -49,6 +49,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include "../common/patches/patches.h"
 #include "../zone/data_bucket.h"
 #include "../common/repositories/guild_tributes_repository.h"
+#include "../common/skill_caps.h"
 
 extern ClientList client_list;
 extern GroupLFPList LFPGroupList;
@@ -1411,7 +1412,6 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 		case ServerOP_ReloadNPCEmotes:
 		case ServerOP_ReloadObjects:
 		case ServerOP_ReloadPerlExportSettings:
-		case ServerOP_ReloadSkillCaps:
 		case ServerOP_ReloadStaticZoneData:
 		case ServerOP_ReloadTitles:
 		case ServerOP_ReloadTraps:
@@ -1435,6 +1435,11 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 		case ServerOP_WWTaskUpdate:
 		case ServerOP_ZonePlayer: {
 			zoneserver_list.SendPacket(pack);
+			break;
+		}
+		case ServerOP_ReloadSkillCaps: {
+			zoneserver_list.SendPacket(pack);
+			skill_caps.ReloadSkillCaps();
 			break;
 		}
 		case ServerOP_ReloadRules: {

--- a/zone/CMakeLists.txt
+++ b/zone/CMakeLists.txt
@@ -166,7 +166,6 @@ SET(zone_sources
     zone_event_scheduler.cpp
     zone_npc_factions.cpp
     zone_reload.cpp
-    zone_skill_caps.cpp
     zoning.cpp
 )
 

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -27,6 +27,7 @@
 #include "../common/repositories/bot_starting_items_repository.h"
 #include "../common/data_verification.h"
 #include "../common/repositories/criteria/content_filter_criteria.h"
+#include "../common/skill_caps.h"
 
 // This constructor is used during the bot create command
 Bot::Bot(NPCType *npcTypeData, Client* botOwner) : NPC(npcTypeData, nullptr, glm::vec4(), Ground, false), rest_timer(1), ping_timer(1) {
@@ -1171,7 +1172,7 @@ uint16 Bot::GetPrimarySkillValue() {
 }
 
 uint16 Bot::MaxSkill(EQ::skills::SkillType skillid, uint16 class_, uint16 level) const {
-	return(content_db.GetSkillCap(class_, skillid, level));
+	return skill_caps.GetSkillCap(class_, skillid, level).cap;
 }
 
 uint32 Bot::GetTotalATK() {
@@ -6758,7 +6759,7 @@ void Bot::CalcBotStats(bool showtext) {
 		SetLevel(GetBotOwner()->GetLevel());
 
 	for (int sindex = 0; sindex <= EQ::skills::HIGHEST_SKILL; ++sindex) {
-		skills[sindex] = content_db.GetSkillCap(GetClass(), (EQ::skills::SkillType)sindex, GetLevel());
+		skills[sindex] = skill_caps.GetSkillCap(GetClass(), (EQ::skills::SkillType)sindex, GetLevel()).cap;
 	}
 
 	taunt_timer.Start(1000);

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -73,6 +73,7 @@ extern volatile bool RunLoops;
 #include "../common/events/player_event_logs.h"
 #include "dialogue_window.h"
 #include "../common/zone_store.h"
+#include "../common/skill_caps.h"
 
 
 extern QueryServ* QServ;
@@ -2771,7 +2772,7 @@ bool Client::CanHaveSkill(EQ::skills::SkillType skill_id) const
 		skill_id = EQ::skills::Skill2HPiercing;
 	}
 
-	return zone->GetSkillCap(GetClass(), skill_id, RuleI(Character, MaxLevel)).cap > 0;
+	return skill_caps.GetSkillCap(GetClass(), skill_id, RuleI(Character, MaxLevel)).cap > 0;
 }
 
 uint16 Client::MaxSkill(EQ::skills::SkillType skill_id, uint8 class_id, uint8 level) const
@@ -2784,7 +2785,7 @@ uint16 Client::MaxSkill(EQ::skills::SkillType skill_id, uint8 class_id, uint8 le
 		skill_id = EQ::skills::Skill2HPiercing;
 	}
 
-	return(content_db.GetSkillCap(class_id, skill_id, level));
+	return skill_caps.GetSkillCap(class_id, skill_id, level).cap;
 }
 
 uint8 Client::SkillTrainLevel(EQ::skills::SkillType skill_id, uint8 class_id)
@@ -2797,7 +2798,7 @@ uint8 Client::SkillTrainLevel(EQ::skills::SkillType skill_id, uint8 class_id)
 		skill_id = EQ::skills::Skill2HPiercing;
 	}
 
-	return zone->GetTrainLevel(class_id, skill_id, RuleI(Character, MaxLevel));
+	return skill_caps.GetTrainLevel(class_id, skill_id, RuleI(Character, MaxLevel));
 }
 
 uint16 Client::GetMaxSkillAfterSpecializationRules(EQ::skills::SkillType skillid, uint16 maxSkill)
@@ -11795,7 +11796,7 @@ void Client::MaxSkills()
 		auto current_skill_value = (
 			EQ::skills::IsSpecializedSkill(s.first) ?
 			MAX_SPECIALIZED_SKILL :
-			content_db.GetSkillCap(GetClass(), s.first, GetLevel())
+			skill_caps.GetSkillCap(GetClass(), s.first, GetLevel()).cap
 		);
 
 		if (GetSkill(s.first) < current_skill_value) {

--- a/zone/main.cpp
+++ b/zone/main.cpp
@@ -86,6 +86,7 @@ extern volatile bool is_zone_loaded;
 #include "../common/events/player_event_logs.h"
 #include "../common/path_manager.h"
 #include "../common/database/database_update.h"
+#include "../common/skill_caps.h"
 #include "zone_event_scheduler.h"
 #include "zone_cli.h"
 
@@ -108,6 +109,7 @@ WorldContentService   content_service;
 PathManager           path;
 PlayerEventLogs       player_event_logs;
 DatabaseUpdate        database_update;
+SkillCaps             skill_caps;
 
 const SPDat_Spell_Struct* spells;
 int32 SPDAT_RECORDS = -1;
@@ -306,6 +308,8 @@ int main(int argc, char **argv)
 		->StartFileLogs();
 
 	player_event_logs.SetDatabase(&database)->Init();
+
+	skill_caps.SetContentDatabase(&content_db)->LoadSkillCaps();
 
 	const auto c = EQEmuConfig::get();
 	if (c->auto_database_updates) {

--- a/zone/merc.cpp
+++ b/zone/merc.cpp
@@ -8,6 +8,7 @@
 
 #include "zone.h"
 #include "string_ids.h"
+#include "../common/skill_caps.h"
 
 extern volatile bool is_zone_loaded;
 
@@ -65,7 +66,7 @@ Merc::Merc(const NPCType* d, float x, float y, float z, float heading)
 
 	int r;
 	for (r = 0; r <= EQ::skills::HIGHEST_SKILL; r++) {
-		skills[r] = content_db.GetSkillCap(GetClass(), (EQ::skills::SkillType)r, GetLevel());
+		skills[r] = skill_caps.GetSkillCap(GetClass(), (EQ::skills::SkillType)r, GetLevel()).cap;
 	}
 
 	size = d->size;
@@ -770,16 +771,16 @@ void Merc::CalcRestState() {
 }
 
 bool Merc::HasSkill(EQ::skills::SkillType skill_id) const {
-	return((GetSkill(skill_id) > 0) && CanHaveSkill(skill_id));
+	return ((GetSkill(skill_id) > 0) && CanHaveSkill(skill_id));
 }
 
 bool Merc::CanHaveSkill(EQ::skills::SkillType skill_id) const {
-	return(content_db.GetSkillCap(GetClass(), skill_id, RuleI(Character, MaxLevel)) > 0);
+	return skill_caps.GetSkillCap(GetClass(), skill_id, RuleI(Character, MaxLevel)).cap > 0;
 	//if you don't have it by max level, then odds are you never will?
 }
 
 uint16 Merc::MaxSkill(EQ::skills::SkillType skillid, uint16 class_, uint16 level) const {
-	return(content_db.GetSkillCap(class_, skillid, level));
+	return skill_caps.GetSkillCap(class_, skillid, level).cap;
 }
 
 void Merc::FillSpawnStruct(NewSpawn_Struct* ns, Mob* ForWho) {

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -48,6 +48,7 @@
 #include "npc_scale_manager.h"
 
 #include "bot.h"
+#include "../common/skill_caps.h"
 
 #include <stdio.h>
 #include <string>
@@ -363,7 +364,7 @@ NPC::NPC(const NPCType *npc_type_data, Spawn2 *in_respawn, const glm::vec4 &posi
 	//give NPCs skill values...
 	int r;
 	for (r = 0; r <= EQ::skills::HIGHEST_SKILL; r++) {
-		skills[r] = content_db.GetSkillCap(GetClass(), (EQ::skills::SkillType)r, moblevel);
+		skills[r] = skill_caps.GetSkillCap(GetClass(), (EQ::skills::SkillType)r, moblevel).cap;
 	}
 	// some overrides -- really we need to be able to set skills for mobs in the DB
 	// There are some known low level SHM/BST pets that do not follow this, which supports
@@ -3437,7 +3438,7 @@ void NPC::RecalculateSkills()
 {
   	int r;
 	for (r = 0; r <= EQ::skills::HIGHEST_SKILL; r++) {
-		skills[r] = content_db.GetSkillCap(GetClass(), (EQ::skills::SkillType)r, level);
+		skills[r] = skill_caps.GetSkillCap(GetClass(), (EQ::skills::SkillType)r, level).cap;
 	}
 
 	// some overrides -- really we need to be able to set skills for mobs in the DB

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -59,6 +59,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include "../common/events/player_event_logs.h"
 #include "../common/repositories/guild_tributes_repository.h"
 #include "../common/patches/patches.h"
+#include "../common/skill_caps.h"
 
 extern EntityList entity_list;
 extern Zone* zone;
@@ -2101,7 +2102,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 	{
 		if (zone && zone->IsLoaded()) {
 			zone->SendReloadMessage("Skill Caps");
-			zone->ReloadSkillCaps();
+			skill_caps.ReloadSkillCaps();
 		}
 
 		break;

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -1185,8 +1185,6 @@ bool Zone::Init(bool is_static) {
 
 	LoadBaseData();
 
-	LoadSkillCaps();
-
 	//Load merchant data
 	LoadMerchants();
 

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -453,12 +453,6 @@ public:
 	void LoadBaseData();
 	void ReloadBaseData();
 
-	// Skill Caps
-	inline void ClearSkillCaps() { m_skill_caps.clear(); }
-	SkillCapsRepository::SkillCaps GetSkillCap(uint8 class_id, EQ::skills::SkillType skill_id, uint8 level);
-	uint8 GetTrainLevel(uint8 class_id, EQ::skills::SkillType skill_id, uint8 level);
-	void LoadSkillCaps();
-	void ReloadSkillCaps();
 
 private:
 	bool      allow_mercs;
@@ -523,9 +517,6 @@ private:
 
 	// Base Data
 	std::vector<BaseDataRepository::BaseData> m_base_data = { };
-
-	// Skill Caps
-	std::vector<SkillCapsRepository::SkillCaps> m_skill_caps = { };
 };
 
 #endif


### PR DESCRIPTION
This further improves upon https://github.com/EQEmu/Server/pull/4069

We were generating tens of thousands of queries still for fetching skill caps. Not everything was happening entirely in memory. We are now.

**Changes**

* Create a `SkillCaps` class that can be used globally to pull skill cap references in both **world** and **zone**
* The `SkillCaps` class is in **common** so it can be used by both **world** and **zone**
* All references to skill caps now happen purely in memory using the functions that @Kinglykrab created, they are just now living in the shared `SkillCaps` class

**Testing**

Skills seem to be working

```
 World |    Info    | LoadSkillCaps Loaded [58359] Skill Cap Entries
  Zone |    Info    | LoadSkillCaps Loaded [58359] Skill Cap Entries 
```

![image](https://github.com/EQEmu/Server/assets/3319450/0c3a6e12-d8a1-4346-a052-02b987d41971)

Additional testing will need to be done