### PR TITLE
[Spells] SPA148 stacking fix

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3211,8 +3211,16 @@ int Mob::CheckStackConflict(uint16 spellid1, int caster_level1, uint16 spellid2,
 
 					if (sp2_value < blocked_below_value)
 					{
-						LogSpells("Blocking spell because sp2_Value < blocked_below_value");
-						return -1;		//blocked
+						if (IsDetrimentalSpell(spellid2))
+						{
+							//Live fixed this in 2018 to allow detrimental spells to bypass being blocked by SPA 148
+							LogSpells("Detrimental spell [{}] ([{}]) avoids being blocked.", sp2.name, spellid2);
+						}
+						else
+						{
+							LogSpells("Blocking spell because sp2_Value < blocked_below_value");
+							return -1;		//blocked
+						}
 					}
 				} else {
 					LogSpells("[{}] ([{}]) blocks effect [{}] on slot [{}] below [{}], but we do not have that effect on that slot. Ignored",


### PR DESCRIPTION
Update to SPA148 which acts to block spells buffs that are of lesser value than the current buff for specific effect slots. This effect was preventing detrimental debuffs from being applied that were using same effect slot. This bug affected a very small amount of spell interactions and was fixed on live in 2018.  Example being Vishmitars Corruption (6642) being blocked by SteelOak Skin (5352)

 I confirmed the behavior on live myself. The detrimental buff  if in conflict should now be applied instead of blocked.