### PR TITLE
[Bug Fix] Fix Client::SendEnterWorld Bug

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -986,7 +986,7 @@ bool Database::UpdateLiveChar(const std::string& name, uint32 account_id)
 	return AccountRepository::UpdateOne(*this, e);
 }
 
-const std::string& Database::GetLiveChar(uint32 account_id)
+std::string Database::GetLiveChar(uint32 account_id)
 {
 	auto e = AccountRepository::FindOne(*this, account_id);
 

--- a/common/database.h
+++ b/common/database.h
@@ -166,7 +166,7 @@ public:
 	bool GetAdventureStats(uint32 character_id, AdventureStats_Struct* as);
 
 	/* Account Related */
-	const std::string& GetLiveChar(uint32 account_id);
+	std::string GetLiveChar(uint32 account_id);
 	bool SetAccountStatus(const std::string& account_name, int16 status);
 	bool SetLocalPassword(uint32 account_id, const std::string& password);
 	bool UpdateLiveChar(const std::string& name, uint32 account_id);

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -193,9 +193,8 @@ bool Client::CanTradeFVNoDropItem()
 
 void Client::SendEnterWorld(std::string name)
 {
-	const std::string live_name = database.GetLiveChar(GetAccountID());
 	if (is_player_zoning) {
-		if(database.GetAccountIDByChar(live_name) != GetAccountID()) {
+		if (database.GetAccountIDByChar(name) != GetAccountID()) {
 			eqs->Close();
 			return;
 		} else {
@@ -203,8 +202,8 @@ void Client::SendEnterWorld(std::string name)
 		}
 	}
 
-	auto outapp = new EQApplicationPacket(OP_EnterWorld, live_name.length() + 1);
-	memcpy(outapp->pBuffer, live_name.c_str(), live_name.length() + 1);
+	auto outapp = new EQApplicationPacket(OP_EnterWorld, name.length() + 1);
+	memcpy(outapp->pBuffer, name.c_str(), name.length() + 1);
 	QueuePacket(outapp);
 	safe_delete(outapp);
 }


### PR DESCRIPTION
# Notes
- `Client::SendEnterWorld` was automatically logging in the player from server select to the last character they had played, to get to a different character they had to log off with /camp then choose another character.