### PR TITLE
[Bug Fix] Fix Auto Login Issue

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -986,7 +986,7 @@ bool Database::UpdateLiveChar(const std::string& name, uint32 account_id)
 	return AccountRepository::UpdateOne(*this, e);
 }
 
-const std::string& Database::GetLiveChar(uint32 account_id)
+const std::string Database::GetLiveChar(uint32 account_id)
 {
 	auto e = AccountRepository::FindOne(*this, account_id);
 

--- a/common/database.h
+++ b/common/database.h
@@ -166,7 +166,7 @@ public:
 	bool GetAdventureStats(uint32 character_id, AdventureStats_Struct* as);
 
 	/* Account Related */
-	const std::string& GetLiveChar(uint32 account_id);
+	const std::string GetLiveChar(uint32 account_id);
 	bool SetAccountStatus(const std::string& account_name, int16 status);
 	bool SetLocalPassword(uint32 account_id, const std::string& password);
 	bool UpdateLiveChar(const std::string& name, uint32 account_id);

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -193,8 +193,9 @@ bool Client::CanTradeFVNoDropItem()
 
 void Client::SendEnterWorld(std::string name)
 {
-	const std::string live_name = database.GetLiveChar(GetAccountID());
+	std::string live_name {};
 	if (is_player_zoning) {
+		live_name = database.GetLiveChar(GetAccountID());
 		if(database.GetAccountIDByChar(live_name) != GetAccountID()) {
 			eqs->Close();
 			return;


### PR DESCRIPTION
# Notes
- We were setting `live_name` value regardless of if we were zoning, causing us to automatically log in to the last character we'd logged in to before.
- Thanks @neckkola for this.