### PR TITLE
[Bug Fix] Fix Group Leadership

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -1114,9 +1114,8 @@ void Database::SetGroupLeaderName(uint32 group_id, const std::string& name)
 
 	e.leadername = name;
 
-	const int updated_leader = GroupLeadersRepository::UpdateOne(*this, e);
-
-	if (!updated_leader) {
+	if (e.gid) {
+		GroupLeadersRepository::UpdateOne(*this, e);
 		return;
 	}
 
@@ -1130,7 +1129,7 @@ void Database::SetGroupLeaderName(uint32 group_id, const std::string& name)
 	e.mentoree       = std::string();
 	e.mentor_percent = 0;
 
-	GroupLeadersRepository::UpdateOne(*this, e);
+	GroupLeadersRepository::InsertOne(*this, e);
 }
 
 std::string Database::GetGroupLeaderName(uint32 group_id)

--- a/common/database.cpp
+++ b/common/database.cpp
@@ -1120,7 +1120,6 @@ void Database::SetGroupLeaderName(uint32 group_id, const std::string& name)
 	}
 
 	e.gid            = group_id;
-	e.leadername     = name;
 	e.marknpc        = std::string();
 	e.leadershipaa   = std::string();
 	e.maintank       = std::string();


### PR DESCRIPTION
# Notes
- We were not sending anything to `group_leaders` table if we did not already have an existing row.

# Video
- In this video I invite two characters to a group, leader privileges still work and so does my invite button even after they both join.
[Video](https://github.com/EQEmu/Server/assets/89047260/948c3d9a-4023-4a0b-91de-a92ec191d078)
