### PR TITLE
[Quest API] Add Class/Deity/Race Methods to Perl/Lua

### DIFF
--- a/common/races.cpp
+++ b/common/races.cpp
@@ -1379,7 +1379,7 @@ uint32 GetPlayerRaceValue(uint16 race_id) {
 	}
 }
 
-uint32 GetPlayerRaceBit(uint16 race_id) {
+uint16 GetPlayerRaceBit(uint16 race_id) {
 	switch (race_id) {
 		case HUMAN:
 			return PLAYER_RACE_HUMAN_BIT;

--- a/common/races.h
+++ b/common/races.h
@@ -124,7 +124,7 @@ bool IsPlayerRace(uint16 race_id);
 const std::string GetPlayerRaceAbbreviation(uint16 race_id);
 
 uint32 GetPlayerRaceValue(uint16 race_id);
-uint32 GetPlayerRaceBit(uint16 race_id);
+uint16 GetPlayerRaceBit(uint16 race_id);
 
 uint16 GetRaceIDFromPlayerRaceValue(uint32 player_race_value);
 uint16 GetRaceIDFromPlayerRaceBit(uint32 player_race_bit);

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -5840,6 +5840,21 @@ std::string Perl__silent_saylink(std::string text, std::string link_name)
 	return Saylink::Silent(text, link_name);
 }
 
+uint16 Perl__get_class_bitmask(uint8 class_id)
+{
+	return GetPlayerClassBit(class_id);
+}
+
+uint32 Perl__get_deity_bitmask(uint16 deity_id)
+{
+	return static_cast<uint32>(EQ::deity::GetDeityBitmask(static_cast<EQ::deity::DeityType>(deity_id)));
+}
+
+uint16 Perl__get_race_bitmask(uint16 race_id)
+{
+	return GetPlayerRaceBit(race_id);
+}
+
 void perl_register_quest()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -6486,9 +6501,11 @@ void perl_register_quest()
 	package.add("getconsiderlevelname", &Perl__getconsiderlevelname);
 	package.add("gethexcolorcode", &Perl__gethexcolorcode);
 	package.add("getcurrencyid", &Perl__getcurrencyid);
+	package.add("get_class_bitmask", &Perl__get_class_bitmask);
 	package.add("get_data", &Perl__get_data);
 	package.add("get_data_expires", &Perl__get_data_expires);
 	package.add("get_data_remaining", &Perl__get_data_remaining);
+	package.add("get_deity_bitmask", &Perl__get_deity_bitmask);
 	package.add("get_dz_task_id", &Perl__get_dz_task_id);
 	package.add("getexpmodifierbycharid", (double(*)(uint32, uint32))&Perl__getexpmodifierbycharid);
 	package.add("getexpmodifierbycharid", (double(*)(uint32, uint32, int16))&Perl__getexpmodifierbycharid);
@@ -6521,6 +6538,7 @@ void perl_register_quest()
 	package.add("getgroupidbycharid", &Perl__getgroupidbycharid);
 	package.add("getinventoryslotname", &Perl__getinventoryslotname);
 	package.add("getraididbycharid", &Perl__getraididbycharid);
+	package.add("get_race_bitmask", &Perl__get_race_bitmask);
 	package.add("get_recipe_component_item_ids", &Perl__GetRecipeComponentItemIDs);
 	package.add("get_recipe_container_item_ids", &Perl__GetRecipeContainerItemIDs);
 	package.add("get_recipe_fail_item_ids", &Perl__GetRecipeFailItemIDs);

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -150,12 +150,17 @@ void Lua_Client::SetBaseGender(int v) {
 	self->SetBaseGender(v);
 }
 
-int Lua_Client::GetClassBitmask() {
+uint16 Lua_Client::GetClassBitmask() {
 	Lua_Safe_Call_Int();
 	return GetPlayerClassBit(self->GetClass());
 }
 
-int Lua_Client::GetRaceBitmask() {
+uint32 Lua_Client::GetDeityBitmask() {
+	Lua_Safe_Call_Int();
+	return static_cast<uint32>(EQ::deity::GetDeityBitmask(static_cast<EQ::deity::DeityType>(GetDeity())));
+}
+
+uint16 Lua_Client::GetRaceBitmask() {
 	Lua_Safe_Call_Int();
 	return GetPlayerRaceBit(self->GetBaseRace());
 }
@@ -3507,13 +3512,14 @@ luabind::scope lua_register_client() {
 	.def("GetCarriedPlatinum", (uint32(Lua_Client::*)(void))&Lua_Client::GetCarriedPlatinum)
 	.def("GetCharacterFactionLevel", (int(Lua_Client::*)(int))&Lua_Client::GetCharacterFactionLevel)
 	.def("GetClassAbbreviation", (std::string(Lua_Client::*)(void))&Lua_Client::GetClassAbbreviation)
-	.def("GetClassBitmask", (int(Lua_Client::*)(void))&Lua_Client::GetClassBitmask)
+	.def("GetClassBitmask", (uint16(Lua_Client::*)(void))&Lua_Client::GetClassBitmask)
 	.def("GetClientMaxLevel", (int(Lua_Client::*)(void))&Lua_Client::GetClientMaxLevel)
 	.def("GetClientVersion", (int(Lua_Client::*)(void))&Lua_Client::GetClientVersion)
 	.def("GetClientVersionBit", (uint32(Lua_Client::*)(void))&Lua_Client::GetClientVersionBit)
 	.def("GetCorpseCount", (int64(Lua_Client::*)(void))&Lua_Client::GetCorpseCount)
 	.def("GetCorpseID", (int(Lua_Client::*)(int))&Lua_Client::GetCorpseID)
 	.def("GetCorpseItemAt", (int(Lua_Client::*)(int,int))&Lua_Client::GetCorpseItemAt)
+	.def("GetDeityBitmask", (uint32(Lua_Client::*)(void))&Lua_Client::GetDeityBitmask)
 	.def("GetDiscSlotBySpellID", (int(Lua_Client::*)(int32))&Lua_Client::GetDiscSlotBySpellID)
 	.def("GetDisciplineTimer", (uint32(Lua_Client::*)(uint32))&Lua_Client::GetDisciplineTimer)
 	.def("GetDuelTarget", (int(Lua_Client::*)(void))&Lua_Client::GetDuelTarget)
@@ -3571,7 +3577,7 @@ luabind::scope lua_register_client() {
 	.def("GetNextAvailableSpellBookSlot", (int(Lua_Client::*)(void))&Lua_Client::GetNextAvailableSpellBookSlot)
 	.def("GetPVP", (bool(Lua_Client::*)(void))&Lua_Client::GetPVP)
 	.def("GetPVPPoints", (uint32(Lua_Client::*)(void))&Lua_Client::GetPVPPoints)
-	.def("GetRaceBitmask", (int(Lua_Client::*)(void))&Lua_Client::GetRaceBitmask)
+	.def("GetRaceBitmask", (uint16(Lua_Client::*)(void))&Lua_Client::GetRaceBitmask)
 	.def("GetRadiantCrystals", (uint32(Lua_Client::*)(void))&Lua_Client::GetRadiantCrystals)
 	.def("GetRaid", (Lua_Raid(Lua_Client::*)(void))&Lua_Client::GetRaid)
 	.def("GetRaidOrGroupOrSelf", (luabind::object(Lua_Client::*)(lua_State*))&Lua_Client::GetRaidOrGroupOrSelf)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -57,8 +57,9 @@ public:
 	void SetBaseClass(int v);
 	void SetBaseRace(int v);
 	void SetBaseGender(int v);
-	int GetClassBitmask();
-	int GetRaceBitmask();
+	uint16 GetClassBitmask();
+	uint32 GetDeityBitmask();
+	uint16 GetRaceBitmask();
 	int GetBaseFace();
 	int GetLanguageSkill(int skill_id);
 	int GetLDoNPointsTheme(int theme);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -5474,6 +5474,18 @@ std::string lua_silent_say_link(std::string text, std::string link_name) {
 	return Saylink::Silent(text, link_name);
 }
 
+uint16 lua_get_class_bitmask(uint8 class_id) {
+	return GetPlayerClassBit(class_id);
+}
+
+uint32 lua_get_deity_bitmask(uint16 deity_id) {
+	return static_cast<uint32>(EQ::deity::GetDeityBitmask(static_cast<EQ::deity::DeityType>(deity_id)));
+}
+
+uint16 lua_get_race_bitmask(uint16 race_id) {
+	return GetPlayerRaceBit(race_id);
+}
+
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
 	cur = table[#name]; \
 	if(luabind::type(cur) != LUA_TNIL) { \
@@ -6270,6 +6282,9 @@ luabind::scope lua_register_general() {
 		luabind::def("get_bot_race_by_id", &lua_get_bot_race_by_id),
 		luabind::def("silent_say_link", (std::string(*)(std::string))&lua_silent_say_link),
 		luabind::def("silent_say_link", (std::string(*)(std::string,std::string))&lua_silent_say_link),
+		luabind::def("get_class_bitmask", &lua_get_class_bitmask),
+		luabind::def("get_deity_bitmask", &lua_get_deity_bitmask),
+		luabind::def("get_race_bitmask", &lua_get_race_bitmask),
 		/*
 			Cross Zone
 		*/

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -2007,12 +2007,17 @@ bool Perl_Client_HasDisciplineLearned(Client* self, uint16 spell_id)
 	return self->HasDisciplineLearned(spell_id);
 }
 
-uint32_t Perl_Client_GetClassBitmask(Client* self)
+uint16_t Perl_Client_GetClassBitmask(Client* self)
 {
 	return GetPlayerClassBit(self->GetClass());
 }
 
-uint32_t Perl_Client_GetRaceBitmask(Client* self) // @categories Stats and Attributes
+uint32_t Perl_Client_GetDeityBitmask(Client* self)
+{
+	return static_cast<uint32_t>(EQ::deity::GetDeityBitmask(static_cast<EQ::deity::DeityType>(self->GetDeity())));
+}
+
+uint16_t Perl_Client_GetRaceBitmask(Client* self) // @categories Stats and Attributes
 {
 	return GetPlayerRaceBit(self->GetBaseRace());
 }
@@ -3312,6 +3317,7 @@ void perl_register_client()
 	package.add("GetCorpseID", &Perl_Client_GetCorpseID);
 	package.add("GetCorpseItemAt", &Perl_Client_GetCorpseItemAt);
 	package.add("GetCustomItemData", &Perl_Client_GetCustomItemData);
+	package.add("GetDeityBitmask", &Perl_Client_GetDeityBitmask);
 	package.add("GetDiscSlotBySpellID", &Perl_Client_GetDiscSlotBySpellID);
 	package.add("GetDisciplineTimer", &Perl_Client_GetDisciplineTimer);
 	package.add("GetDuelTarget", &Perl_Client_GetDuelTarget);


### PR DESCRIPTION
# Perl
- Add `$client->GetDeityBitmask()`.
- Add `quest::get_class_bitmask(class_id)`.
- Add `quest::get_deity_bitmask(deity_id)`.
- Add `quest::get_race_bitmask(race_id)`.

# Lua
- Add `client:GetDeityBitmask()`.
- Add `eq.get_class_bitmask(class_id)`.
- Add `eq.get_deity_bitmask(deity_id)`.
- Add `eq.get_race_bitmask(race_id)`.

# Notes
- Allows operators to get the class/deity/race bitmask of a class/deity/race by ID.
- Allows operators to get a client's deity bitmask.