### PR TITLE
[Cleanup] Reference type in `GetRaidLeaderName`

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -1333,7 +1333,7 @@ uint32 Database::GetRaidID(const std::string& name)
 	return e.raidid;
 }
 
-const std::string& Database::GetRaidLeaderName(uint32 raid_id)
+const std::string Database::GetRaidLeaderName(uint32 raid_id)
 {
 	const auto& l = RaidMembersRepository::GetWhere(
 		*this,
@@ -1348,7 +1348,7 @@ const std::string& Database::GetRaidLeaderName(uint32 raid_id)
 		return "UNKNOWN";
 	}
 
-	auto e = l.front();
+	auto& e = l.front();
 
 	return e.name;
 }

--- a/common/database.h
+++ b/common/database.h
@@ -216,7 +216,7 @@ public:
 	void SetGroupLeaderName(uint32 group_id, const std::string& name);
 
 	/* Raids */
-	const std::string& GetRaidLeaderName(uint32 raid_id);
+	const std::string GetRaidLeaderName(uint32 raid_id);
 	uint32 GetRaidID(const std::string& name);
 	void ClearRaid(uint32 raid_id = 0);
 	void ClearRaidDetails(uint32 raid_id = 0);


### PR DESCRIPTION
Minor cleanup from #4054