### PR TITLE
[Bug Fix] Fix Luabind Double Class Register

### DIFF
--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -41,6 +41,8 @@ struct MessageTypes { };
 struct Rule { };
 struct Journal_SpeakMode { };
 struct Journal_Mode { };
+struct Zone { };
+struct Language { };
 
 struct lua_registered_event {
 	std::string encounter_name;
@@ -7249,7 +7251,7 @@ luabind::scope lua_register_message_types() {
 }
 
 luabind::scope lua_register_zone_types() {
-	return luabind::class_<MessageTypes>("Zone")
+	return luabind::class_<Zone>("Zone")
 		.enum_("constants")
 		[(
 			luabind::value("qeynos", Zones::QEYNOS),
@@ -7737,7 +7739,7 @@ luabind::scope lua_register_zone_types() {
 }
 
 luabind::scope lua_register_languages() {
-	return luabind::class_<MessageTypes>("Language")
+	return luabind::class_<Language>("Language")
 		.enum_("constants")
 		[(
 			luabind::value("CommonTongue", Language::CommonTongue),

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -41,8 +41,8 @@ struct MessageTypes { };
 struct Rule { };
 struct Journal_SpeakMode { };
 struct Journal_Mode { };
-struct Zone { };
-struct Language { };
+struct ZoneIDs { };
+struct LanguageIDs { };
 
 struct lua_registered_event {
 	std::string encounter_name;
@@ -7251,7 +7251,7 @@ luabind::scope lua_register_message_types() {
 }
 
 luabind::scope lua_register_zone_types() {
-	return luabind::class_<Zone>("Zone")
+	return luabind::class_<ZoneIDs>("Zone")
 		.enum_("constants")
 		[(
 			luabind::value("qeynos", Zones::QEYNOS),
@@ -7739,7 +7739,7 @@ luabind::scope lua_register_zone_types() {
 }
 
 luabind::scope lua_register_languages() {
-	return luabind::class_<Language>("Language")
+	return luabind::class_<LanguageIDs>("Language")
 		.enum_("constants")
 		[(
 			luabind::value("CommonTongue", Language::CommonTongue),


### PR DESCRIPTION
# Notes
- These two methods were registering to the same class as another method, causing an error seen by @neckkola and others.
- Comes from https://github.com/EQEmu/Server/pull/4211.

# Error
```
zone: /home/eqemu/source_jas/libs/luabind/src/class_registry.cpp:151: void luabind::detail::class_registry::add_class(const luabind::type_id&, luabind::detail::class_rep*): Assertion `(m_classes.find(info) == m_classes.end()) && "you are trying to register a class twice"' failed.
```