### PR TITLE
[Cleanup] Avoid unnecessary copies in database functions

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -139,7 +139,7 @@ uint32 Database::CheckLogin(
 		return 0;
 	}
 
-	auto e = l.front();
+	auto& e = l.front();
 
 	if (status) {
 		*status = e.status;
@@ -260,7 +260,7 @@ bool Database::SetAccountStatus(const std::string& account_name, int16 status)
 		return false;
 	}
 
-	auto e = l.front();
+	auto& e = l.front();
 
 	e.status = status;
 
@@ -327,7 +327,7 @@ bool Database::DeleteCharacter(const std::string& name)
 		return false;
 	}
 
-	auto e = l.front();
+	auto& e = l.front();
 
 	if (!e.id) {
 		return false;
@@ -565,7 +565,7 @@ uint32 Database::GetCharacterID(const std::string& name)
 		return 0;
 	}
 
-	auto e = l.front();
+	auto& e = l.front();
 
 	return e.id;
 }
@@ -584,7 +584,7 @@ uint32 Database::GetAccountIDByChar(const std::string& name, uint32* character_i
 		return 0;
 	}
 
-	auto e = l.front();
+	auto& e = l.front();
 
 	if (character_id) {
 		*character_id = e.id;
@@ -619,7 +619,7 @@ uint32 Database::GetAccountIDByName(const std::string& account_name, const std::
 		return 0;
 	}
 
-	auto e = l.front();
+	auto& e = l.front();
 
 	if (status) {
 		*status = e.status;
@@ -747,7 +747,7 @@ bool Database::SetVariable(const std::string& name, const std::string& value)
 		return false;
 	}
 
-	auto variable = l.front();
+	auto& variable = l.front();
 
 	variable.value = value;
 
@@ -874,7 +874,7 @@ uint32 Database::GetAccountIDFromLSID(
 		return 0;
 	}
 
-	auto e = l.front();
+	auto& e = l.front();
 
 	if (in_account_name) {
 		strcpy(in_account_name, e.name.c_str());
@@ -908,7 +908,7 @@ bool Database::UpdateName(const std::string& old_name, const std::string& new_na
 		return false;
 	}
 
-	auto e = l.front();
+	auto& e = l.front();
 
 	e.name = new_name;
 
@@ -934,7 +934,7 @@ uint32 Database::GetServerType()
 		return 0;
 	}
 
-	auto e = l.front();
+	auto& e = l.front();
 
 	return Strings::ToUnsignedInt(e.value);
 }
@@ -964,7 +964,7 @@ bool Database::MoveCharacterToZone(const std::string& name, uint32 zone_id)
 		return false;
 	}
 
-	auto e = l.front();
+	auto& e = l.front();
 
 	e.zone_id = zone_id;
 
@@ -1080,7 +1080,7 @@ uint32 Database::GetGroupID(const std::string& name)
 		return 0;
 	}
 
-	auto e = l.front();
+	auto& e = l.front();
 
 	return e.group_id;
 }
@@ -1099,7 +1099,7 @@ std::string Database::GetGroupLeaderForLogin(const std::string& character_name)
 		return std::string();
 	}
 
-	auto group = g.front();
+	auto& group = g.front();
 
 	const uint32 group_id = group.group_id;
 
@@ -1144,7 +1144,7 @@ std::string Database::GetGroupLeaderName(uint32 group_id)
 		return std::string();
 	}
 
-	auto row = results.begin();
+	auto& row = results.begin();
 
 	return row[0];
 }
@@ -1328,7 +1328,7 @@ uint32 Database::GetRaidID(const std::string& name)
 		return 0;
 	}
 
-	auto e = l.front();
+	auto& e = l.front();
 
 	return e.raidid;
 }
@@ -1405,7 +1405,7 @@ void Database::GetGroupLeadershipInfo(
 		return;
 	}
 
-	auto row = results.begin();
+	auto& row = results.begin();
 
 	if (maintank) {
 		strcpy(maintank, row[0]);
@@ -1477,7 +1477,7 @@ void Database::GetRaidLeadershipInfo(
 		return;
 	}
 
-	auto row = results.begin();
+	auto& row = results.begin();
 
 	if (maintank) {
 		strcpy(maintank, row[0]);
@@ -1651,7 +1651,7 @@ struct TimeOfDay_Struct Database::LoadTime(time_t& realtime)
 		return t;
 	}
 
-	auto row = results.begin();
+	auto& row = results.begin();
 
 	uint8  hour      = Strings::ToUnsignedInt(row[1]);
 	time_t realtime_ = Strings::ToBigInt(row[5]);
@@ -1703,14 +1703,14 @@ int Database::GetIPExemption(const std::string& account_ip)
 		return RuleI(World, MaxClientsPerIP);
 	}
 
-	auto e = l.front();
+	auto& e = l.front();
 
 	return e.exemption_amount;
 }
 
 void Database::SetIPExemption(const std::string& account_ip, int exemption_amount)
 {
-	const auto& l = IpExemptionsRepository::GetWhere(
+	auto l = IpExemptionsRepository::GetWhere(
 		*this,
 		fmt::format(
 			"`exemption_ip` = '{}'",
@@ -1729,7 +1729,7 @@ void Database::SetIPExemption(const std::string& account_ip, int exemption_amoun
 		return;
 	}
 
-	auto e = l.front();
+	auto& e = l.front();
 
 	e.exemption_amount = exemption_amount;
 
@@ -1751,7 +1751,7 @@ int Database::GetInstanceID(uint32 character_id, uint32 zone_id)
 		return 0;
 	}
 
-	auto e = l.front();
+	auto& e = l.front();
 
 	return e.id;
 }
@@ -1775,7 +1775,7 @@ bool Database::CopyCharacter(
 		return false;
 	}
 
-	auto character = characters.front();
+	auto& character = characters.front();
 
 	const uint32 source_character_id = character.id;
 
@@ -1792,7 +1792,7 @@ bool Database::CopyCharacter(
 		return false;
 	}
 
-	auto account = accounts.front();
+	auto& account = accounts.front();
 
 	const int destination_account_id = account.id;
 


### PR DESCRIPTION
Since `auto` doesn't deduce references, these will most likely create copies having unintended results.