### PR TITLE
[Feature] Add Zone Reload Quests

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -359,6 +359,7 @@ RULE_INT(Zone, FishingChance, 399, "Chance of fishing from zone table vs global 
 RULE_BOOL(Zone, AllowCrossZoneSpellsOnBots, false, "Set to true to allow cross zone spells (cast/remove) to affect bots")
 RULE_BOOL(Zone, AllowCrossZoneSpellsOnMercs, false, "Set to true to allow cross zone spells (cast/remove) to affect mercenaries")
 RULE_BOOL(Zone, AllowCrossZoneSpellsOnPets, false, "Set to true to allow cross zone spells (cast/remove) to affect pets")
+RULE_BOOL(Zone, QuestsReloadOnBootup, false, "Reloads all quests when a non-static zone boots up")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Map)

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -144,6 +144,11 @@ bool Zone::Bootup(uint32 iZoneID, uint32 iInstanceID, bool is_static) {
 		}
 	}
 
+	if (!is_static && RuleB(Zone, QuestsReloadOnBootup)) {
+		LogInfo("Reloading quests");
+		parse->ReloadQuests(RuleB(HotReload, QuestsResetTimersWithReload));
+	}
+
 	is_zone_loaded = true;
 
 	worldserver.SetZoneData(iZoneID, iInstanceID);


### PR DESCRIPTION
I noticed that when a sleeping zone starts up, it was not reloading quests as I expected.

Since I wasn't sure if this was an intended effect, I put the behavior I desired behind a rule.

This rule, when enabled, will reload quests any time a zone goes through the bootup function and is not set to static.

This repairs a symptom I was experiencing where global quests that were changed while a zone was sleeping, and a `#reload world` is called, would still retain the old global quest data it had during initial zone init.

