### PR TITLE
[Feature] Fix ignore_default on lua mod damage

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -3968,12 +3968,8 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 	int64 lua_ret = 0;
 	bool ignore_default = false;
 	lua_ret = LuaParser::Instance()->CommonDamage(this, attacker, damage, spell_id, static_cast<int>(skill_used), avoidable, buffslot, iBuffTic, static_cast<int>(special), ignore_default);
-	if (lua_ret != 0) {
-		damage = lua_ret;
-	}
-
 	if (ignore_default) {
-		//return lua_ret;
+		damage = lua_ret;
 	}
 #endif
 	// This method is called with skill_used=ABJURE for Damage Shield damage.
@@ -4708,12 +4704,8 @@ void Mob::HealDamage(uint64 amount, Mob* caster, uint16 spell_id)
 	bool ignore_default = false;
 
 	lua_ret = LuaParser::Instance()->HealDamage(this, caster, amount, spell_id, ignore_default);
-	if (lua_ret != 0) {
-		amount = lua_ret;
-	}
-
 	if (ignore_default) {
-		//return lua_ret;
+		amount = lua_ret;
 	}
 #endif
 	int64 maxhp = GetMaxHP();

--- a/zone/lua_mod.cpp
+++ b/zone/lua_mod.cpp
@@ -38,6 +38,8 @@ void LuaMod::Init()
 	m_has_common_outgoing_hit_success = parser_->HasFunction("CommonOutgoingHitSuccess", package_name_);
 	m_has_calc_spell_effect_value_formula = parser_->HasFunction("CalcSpellEffectValue_formula", package_name_);
 	m_has_register_bug = parser_->HasFunction("RegisterBug", package_name_);
+	m_has_common_damage = parser_->HasFunction("CommonDamage", package_name_);
+	m_has_heal_damage = parser_->HasFunction("HealDamage", package_name_);
 }
 
 void PutDamageHitInfo(lua_State *L, luabind::adl::object &e, DamageHitInfo &hit) {


### PR DESCRIPTION
This changes the new lua mods to require ignore_default to be set to true in order for a return value to be applied to the following logic.

Normally, ignore_default returns from a function, but due to how these functions work, that can't be done elegantly so this is the compromise.

I'll update the documentation and make an example accordingly.