### PR TITLE
[Loot] Add content filtering to lootdrop_entries

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -5492,7 +5492,8 @@ ALTER TABLE `lootdrop_entries` ADD `min_expansion` tinyint(4) NOT NULL DEFAULT -
 ALTER TABLE `lootdrop_entries` ADD `max_expansion` tinyint(4) NOT NULL DEFAULT -1;
 ALTER TABLE `lootdrop_entries` ADD `content_flags` varchar(100) NULL;
 ALTER TABLE `lootdrop_entries` ADD `content_flags_disabled` varchar(100) NULL;
-)"
+)",
+		.content_schema_update = true
 	}
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{

--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -5480,6 +5480,19 @@ ADD INDEX `level_skill_cap`(`skill_id`, `class_id`, `level`, `cap`);
 ALTER TABLE `account`
 ADD COLUMN `auto_login_charname` varchar(64) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL DEFAULT '' AFTER `charname`;
 )"
+	},
+	ManifestEntry{
+		.version = 9269,
+		.description = "2024_04_31_content_flagging_lootdrop_entries.sql",
+		.check = "SHOW COLUMNS FROM `lootdrop_entries` LIKE 'content_flags'",
+		.condition = "empty",
+		.match = "",
+		.sql = R"(
+ALTER TABLE `lootdrop_entries` ADD `min_expansion` tinyint(4) NOT NULL DEFAULT -1;
+ALTER TABLE `lootdrop_entries` ADD `max_expansion` tinyint(4) NOT NULL DEFAULT -1;
+ALTER TABLE `lootdrop_entries` ADD `content_flags` varchar(100) NULL;
+ALTER TABLE `lootdrop_entries` ADD `content_flags_disabled` varchar(100) NULL;
+)"
 	}
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{

--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -5482,7 +5482,7 @@ ADD COLUMN `auto_login_charname` varchar(64) CHARACTER SET latin1 COLLATE latin1
 )"
 	},
 	ManifestEntry{
-		.version = 9269,
+		.version = 9270,
 		.description = "2024_04_31_content_flagging_lootdrop_entries.sql",
 		.check = "SHOW COLUMNS FROM `lootdrop_entries` LIKE 'content_flags'",
 		.condition = "empty",

--- a/common/repositories/base/base_lootdrop_entries_repository.h
+++ b/common/repositories/base/base_lootdrop_entries_repository.h
@@ -19,17 +19,21 @@
 class BaseLootdropEntriesRepository {
 public:
 	struct LootdropEntries {
-		uint32_t lootdrop_id;
-		int32_t  item_id;
-		uint16_t item_charges;
-		uint8_t  equip_item;
-		float    chance;
-		float    disabled_chance;
-		uint16_t trivial_min_level;
-		uint16_t trivial_max_level;
-		uint8_t  multiplier;
-		uint16_t npc_min_level;
-		uint16_t npc_max_level;
+		uint32_t    lootdrop_id;
+		int32_t     item_id;
+		uint16_t    item_charges;
+		uint8_t     equip_item;
+		float       chance;
+		float       disabled_chance;
+		uint16_t    trivial_min_level;
+		uint16_t    trivial_max_level;
+		uint8_t     multiplier;
+		uint16_t    npc_min_level;
+		uint16_t    npc_max_level;
+		int8_t      min_expansion;
+		int8_t      max_expansion;
+		std::string content_flags;
+		std::string content_flags_disabled;
 	};
 
 	static std::string PrimaryKey()
@@ -51,6 +55,10 @@ public:
 			"multiplier",
 			"npc_min_level",
 			"npc_max_level",
+			"min_expansion",
+			"max_expansion",
+			"content_flags",
+			"content_flags_disabled",
 		};
 	}
 
@@ -68,6 +76,10 @@ public:
 			"multiplier",
 			"npc_min_level",
 			"npc_max_level",
+			"min_expansion",
+			"max_expansion",
+			"content_flags",
+			"content_flags_disabled",
 		};
 	}
 
@@ -108,17 +120,21 @@ public:
 	{
 		LootdropEntries e{};
 
-		e.lootdrop_id       = 0;
-		e.item_id           = 0;
-		e.item_charges      = 1;
-		e.equip_item        = 0;
-		e.chance            = 1;
-		e.disabled_chance   = 0;
-		e.trivial_min_level = 0;
-		e.trivial_max_level = 0;
-		e.multiplier        = 1;
-		e.npc_min_level     = 0;
-		e.npc_max_level     = 0;
+		e.lootdrop_id            = 0;
+		e.item_id                = 0;
+		e.item_charges           = 1;
+		e.equip_item             = 0;
+		e.chance                 = 1;
+		e.disabled_chance        = 0;
+		e.trivial_min_level      = 0;
+		e.trivial_max_level      = 0;
+		e.multiplier             = 1;
+		e.npc_min_level          = 0;
+		e.npc_max_level          = 0;
+		e.min_expansion          = -1;
+		e.max_expansion          = -1;
+		e.content_flags          = "";
+		e.content_flags_disabled = "";
 
 		return e;
 	}
@@ -155,17 +171,21 @@ public:
 		if (results.RowCount() == 1) {
 			LootdropEntries e{};
 
-			e.lootdrop_id       = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
-			e.item_id           = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
-			e.item_charges      = row[2] ? static_cast<uint16_t>(strtoul(row[2], nullptr, 10)) : 1;
-			e.equip_item        = row[3] ? static_cast<uint8_t>(strtoul(row[3], nullptr, 10)) : 0;
-			e.chance            = row[4] ? strtof(row[4], nullptr) : 1;
-			e.disabled_chance   = row[5] ? strtof(row[5], nullptr) : 0;
-			e.trivial_min_level = row[6] ? static_cast<uint16_t>(strtoul(row[6], nullptr, 10)) : 0;
-			e.trivial_max_level = row[7] ? static_cast<uint16_t>(strtoul(row[7], nullptr, 10)) : 0;
-			e.multiplier        = row[8] ? static_cast<uint8_t>(strtoul(row[8], nullptr, 10)) : 1;
-			e.npc_min_level     = row[9] ? static_cast<uint16_t>(strtoul(row[9], nullptr, 10)) : 0;
-			e.npc_max_level     = row[10] ? static_cast<uint16_t>(strtoul(row[10], nullptr, 10)) : 0;
+			e.lootdrop_id            = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
+			e.item_id                = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
+			e.item_charges           = row[2] ? static_cast<uint16_t>(strtoul(row[2], nullptr, 10)) : 1;
+			e.equip_item             = row[3] ? static_cast<uint8_t>(strtoul(row[3], nullptr, 10)) : 0;
+			e.chance                 = row[4] ? strtof(row[4], nullptr) : 1;
+			e.disabled_chance        = row[5] ? strtof(row[5], nullptr) : 0;
+			e.trivial_min_level      = row[6] ? static_cast<uint16_t>(strtoul(row[6], nullptr, 10)) : 0;
+			e.trivial_max_level      = row[7] ? static_cast<uint16_t>(strtoul(row[7], nullptr, 10)) : 0;
+			e.multiplier             = row[8] ? static_cast<uint8_t>(strtoul(row[8], nullptr, 10)) : 1;
+			e.npc_min_level          = row[9] ? static_cast<uint16_t>(strtoul(row[9], nullptr, 10)) : 0;
+			e.npc_max_level          = row[10] ? static_cast<uint16_t>(strtoul(row[10], nullptr, 10)) : 0;
+			e.min_expansion          = row[11] ? static_cast<int8_t>(atoi(row[11])) : -1;
+			e.max_expansion          = row[12] ? static_cast<int8_t>(atoi(row[12])) : -1;
+			e.content_flags          = row[13] ? row[13] : "";
+			e.content_flags_disabled = row[14] ? row[14] : "";
 
 			return e;
 		}
@@ -210,6 +230,10 @@ public:
 		v.push_back(columns[8] + " = " + std::to_string(e.multiplier));
 		v.push_back(columns[9] + " = " + std::to_string(e.npc_min_level));
 		v.push_back(columns[10] + " = " + std::to_string(e.npc_max_level));
+		v.push_back(columns[11] + " = " + std::to_string(e.min_expansion));
+		v.push_back(columns[12] + " = " + std::to_string(e.max_expansion));
+		v.push_back(columns[13] + " = '" + Strings::Escape(e.content_flags) + "'");
+		v.push_back(columns[14] + " = '" + Strings::Escape(e.content_flags_disabled) + "'");
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -242,6 +266,10 @@ public:
 		v.push_back(std::to_string(e.multiplier));
 		v.push_back(std::to_string(e.npc_min_level));
 		v.push_back(std::to_string(e.npc_max_level));
+		v.push_back(std::to_string(e.min_expansion));
+		v.push_back(std::to_string(e.max_expansion));
+		v.push_back("'" + Strings::Escape(e.content_flags) + "'");
+		v.push_back("'" + Strings::Escape(e.content_flags_disabled) + "'");
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -282,6 +310,10 @@ public:
 			v.push_back(std::to_string(e.multiplier));
 			v.push_back(std::to_string(e.npc_min_level));
 			v.push_back(std::to_string(e.npc_max_level));
+			v.push_back(std::to_string(e.min_expansion));
+			v.push_back(std::to_string(e.max_expansion));
+			v.push_back("'" + Strings::Escape(e.content_flags) + "'");
+			v.push_back("'" + Strings::Escape(e.content_flags_disabled) + "'");
 
 			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
 		}
@@ -315,17 +347,21 @@ public:
 		for (auto row = results.begin(); row != results.end(); ++row) {
 			LootdropEntries e{};
 
-			e.lootdrop_id       = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
-			e.item_id           = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
-			e.item_charges      = row[2] ? static_cast<uint16_t>(strtoul(row[2], nullptr, 10)) : 1;
-			e.equip_item        = row[3] ? static_cast<uint8_t>(strtoul(row[3], nullptr, 10)) : 0;
-			e.chance            = row[4] ? strtof(row[4], nullptr) : 1;
-			e.disabled_chance   = row[5] ? strtof(row[5], nullptr) : 0;
-			e.trivial_min_level = row[6] ? static_cast<uint16_t>(strtoul(row[6], nullptr, 10)) : 0;
-			e.trivial_max_level = row[7] ? static_cast<uint16_t>(strtoul(row[7], nullptr, 10)) : 0;
-			e.multiplier        = row[8] ? static_cast<uint8_t>(strtoul(row[8], nullptr, 10)) : 1;
-			e.npc_min_level     = row[9] ? static_cast<uint16_t>(strtoul(row[9], nullptr, 10)) : 0;
-			e.npc_max_level     = row[10] ? static_cast<uint16_t>(strtoul(row[10], nullptr, 10)) : 0;
+			e.lootdrop_id            = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
+			e.item_id                = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
+			e.item_charges           = row[2] ? static_cast<uint16_t>(strtoul(row[2], nullptr, 10)) : 1;
+			e.equip_item             = row[3] ? static_cast<uint8_t>(strtoul(row[3], nullptr, 10)) : 0;
+			e.chance                 = row[4] ? strtof(row[4], nullptr) : 1;
+			e.disabled_chance        = row[5] ? strtof(row[5], nullptr) : 0;
+			e.trivial_min_level      = row[6] ? static_cast<uint16_t>(strtoul(row[6], nullptr, 10)) : 0;
+			e.trivial_max_level      = row[7] ? static_cast<uint16_t>(strtoul(row[7], nullptr, 10)) : 0;
+			e.multiplier             = row[8] ? static_cast<uint8_t>(strtoul(row[8], nullptr, 10)) : 1;
+			e.npc_min_level          = row[9] ? static_cast<uint16_t>(strtoul(row[9], nullptr, 10)) : 0;
+			e.npc_max_level          = row[10] ? static_cast<uint16_t>(strtoul(row[10], nullptr, 10)) : 0;
+			e.min_expansion          = row[11] ? static_cast<int8_t>(atoi(row[11])) : -1;
+			e.max_expansion          = row[12] ? static_cast<int8_t>(atoi(row[12])) : -1;
+			e.content_flags          = row[13] ? row[13] : "";
+			e.content_flags_disabled = row[14] ? row[14] : "";
 
 			all_entries.push_back(e);
 		}
@@ -350,17 +386,21 @@ public:
 		for (auto row = results.begin(); row != results.end(); ++row) {
 			LootdropEntries e{};
 
-			e.lootdrop_id       = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
-			e.item_id           = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
-			e.item_charges      = row[2] ? static_cast<uint16_t>(strtoul(row[2], nullptr, 10)) : 1;
-			e.equip_item        = row[3] ? static_cast<uint8_t>(strtoul(row[3], nullptr, 10)) : 0;
-			e.chance            = row[4] ? strtof(row[4], nullptr) : 1;
-			e.disabled_chance   = row[5] ? strtof(row[5], nullptr) : 0;
-			e.trivial_min_level = row[6] ? static_cast<uint16_t>(strtoul(row[6], nullptr, 10)) : 0;
-			e.trivial_max_level = row[7] ? static_cast<uint16_t>(strtoul(row[7], nullptr, 10)) : 0;
-			e.multiplier        = row[8] ? static_cast<uint8_t>(strtoul(row[8], nullptr, 10)) : 1;
-			e.npc_min_level     = row[9] ? static_cast<uint16_t>(strtoul(row[9], nullptr, 10)) : 0;
-			e.npc_max_level     = row[10] ? static_cast<uint16_t>(strtoul(row[10], nullptr, 10)) : 0;
+			e.lootdrop_id            = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
+			e.item_id                = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
+			e.item_charges           = row[2] ? static_cast<uint16_t>(strtoul(row[2], nullptr, 10)) : 1;
+			e.equip_item             = row[3] ? static_cast<uint8_t>(strtoul(row[3], nullptr, 10)) : 0;
+			e.chance                 = row[4] ? strtof(row[4], nullptr) : 1;
+			e.disabled_chance        = row[5] ? strtof(row[5], nullptr) : 0;
+			e.trivial_min_level      = row[6] ? static_cast<uint16_t>(strtoul(row[6], nullptr, 10)) : 0;
+			e.trivial_max_level      = row[7] ? static_cast<uint16_t>(strtoul(row[7], nullptr, 10)) : 0;
+			e.multiplier             = row[8] ? static_cast<uint8_t>(strtoul(row[8], nullptr, 10)) : 1;
+			e.npc_min_level          = row[9] ? static_cast<uint16_t>(strtoul(row[9], nullptr, 10)) : 0;
+			e.npc_max_level          = row[10] ? static_cast<uint16_t>(strtoul(row[10], nullptr, 10)) : 0;
+			e.min_expansion          = row[11] ? static_cast<int8_t>(atoi(row[11])) : -1;
+			e.max_expansion          = row[12] ? static_cast<int8_t>(atoi(row[12])) : -1;
+			e.content_flags          = row[13] ? row[13] : "";
+			e.content_flags_disabled = row[14] ? row[14] : "";
 
 			all_entries.push_back(e);
 		}
@@ -446,6 +486,10 @@ public:
 		v.push_back(std::to_string(e.multiplier));
 		v.push_back(std::to_string(e.npc_min_level));
 		v.push_back(std::to_string(e.npc_max_level));
+		v.push_back(std::to_string(e.min_expansion));
+		v.push_back(std::to_string(e.max_expansion));
+		v.push_back("'" + Strings::Escape(e.content_flags) + "'");
+		v.push_back("'" + Strings::Escape(e.content_flags_disabled) + "'");
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -479,6 +523,10 @@ public:
 			v.push_back(std::to_string(e.multiplier));
 			v.push_back(std::to_string(e.npc_min_level));
 			v.push_back(std::to_string(e.npc_max_level));
+			v.push_back(std::to_string(e.min_expansion));
+			v.push_back(std::to_string(e.max_expansion));
+			v.push_back("'" + Strings::Escape(e.content_flags) + "'");
+			v.push_back("'" + Strings::Escape(e.content_flags_disabled) + "'");
 
 			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
 		}

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9269
+#define CURRENT_BINARY_DATABASE_VERSION 9270
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9043
 
 #endif

--- a/zone/loot.cpp
+++ b/zone/loot.cpp
@@ -215,7 +215,6 @@ void NPC::AddLootDropTable(uint32 lootdrop_id, uint8 drop_limit, uint8 min_drop)
 		if (drops < min_drop || roll_table_chance_bypass || (float) zone->random.Real(0.0, 1.0) >= no_loot_prob) {
 			float           roll = (float) zone->random.Real(0.0, roll_t);
 			for (const auto &e: le) {
-				// content flagging
 				if (!content_service.DoesPassContentFiltering(
 					ContentFlags{
 						.min_expansion = e.min_expansion,

--- a/zone/loot.cpp
+++ b/zone/loot.cpp
@@ -150,6 +150,25 @@ void NPC::AddLootDropTable(uint32 lootdrop_id, uint8 drop_limit, uint8 min_drop)
 				e.chance,
 				e.multiplier
 			);
+
+			if (!content_service.DoesPassContentFiltering(
+				ContentFlags{
+					.min_expansion = e.min_expansion,
+					.max_expansion = e.max_expansion,
+					.content_flags = e.content_flags,
+					.content_flags_disabled = e.content_flags_disabled
+				}
+			)) {
+				LogLoot(
+					"-- NPC [{}] Lootdrop [{}] Item [{}] ({}) does not pass content filtering",
+					GetCleanName(),
+					lootdrop_id,
+					e.item_id,
+					database.GetItem(e.item_id)->Name
+				);
+				continue;
+			}
+
 			for (int j = 0; j < e.multiplier; ++j) {
 				if (zone->random.Real(0.0, 100.0) <= e.chance && MeetsLootDropLevelRequirements(e, true)) {
 					const EQ::ItemData *database_item = database.GetItem(e.item_id);

--- a/zone/loot.cpp
+++ b/zone/loot.cpp
@@ -22,7 +22,7 @@ void NPC::AddLootTable(uint32 loottable_id, bool is_global)
 	if (!npctype_id) {
 		return;
 	}
-	
+
 	if (!is_global) {
 		m_loot_copper   = 0;
 		m_loot_silver   = 0;
@@ -215,6 +215,25 @@ void NPC::AddLootDropTable(uint32 lootdrop_id, uint8 drop_limit, uint8 min_drop)
 		if (drops < min_drop || roll_table_chance_bypass || (float) zone->random.Real(0.0, 1.0) >= no_loot_prob) {
 			float           roll = (float) zone->random.Real(0.0, roll_t);
 			for (const auto &e: le) {
+				// content flagging
+				if (!content_service.DoesPassContentFiltering(
+					ContentFlags{
+						.min_expansion = e.min_expansion,
+						.max_expansion = e.max_expansion,
+						.content_flags = e.content_flags,
+						.content_flags_disabled = e.content_flags_disabled
+					}
+				)) {
+					LogLoot(
+						"-- NPC [{}] Lootdrop [{}] Item [{}] ({}) does not pass content filtering",
+						GetCleanName(),
+						lootdrop_id,
+						e.item_id,
+						database.GetItem(e.item_id)->Name
+					);
+					continue;
+				}
+
 				const auto *db_item = database.GetItem(e.item_id);
 				if (db_item) {
 					// if it doesn't meet the requirements do nothing

--- a/zone/loot.cpp
+++ b/zone/loot.cpp
@@ -145,7 +145,7 @@ void NPC::AddLootDropTable(uint32 lootdrop_id, uint8 drop_limit, uint8 min_drop)
 				"-- NPC [{}] Lootdrop [{}] Item [{}] ({}_ Chance [{}] Multiplier [{}]",
 				GetCleanName(),
 				lootdrop_id,
-				database.GetItem(e.item_id)->Name,
+				database.GetItem(e.item_id) ? database.GetItem(e.item_id)->Name : "Unknown",
 				e.item_id,
 				e.chance,
 				e.multiplier
@@ -164,7 +164,7 @@ void NPC::AddLootDropTable(uint32 lootdrop_id, uint8 drop_limit, uint8 min_drop)
 					GetCleanName(),
 					lootdrop_id,
 					e.item_id,
-					database.GetItem(e.item_id)->Name
+					database.GetItem(e.item_id) ? database.GetItem(e.item_id)->Name : "Unknown"
 				);
 				continue;
 			}
@@ -247,7 +247,7 @@ void NPC::AddLootDropTable(uint32 lootdrop_id, uint8 drop_limit, uint8 min_drop)
 						GetCleanName(),
 						lootdrop_id,
 						e.item_id,
-						database.GetItem(e.item_id)->Name
+						database.GetItem(e.item_id) ? database.GetItem(e.item_id)->Name : "Unknown"
 					);
 					continue;
 				}


### PR DESCRIPTION
# Description

This PR is at the request of @regneq and Elroz from TAK. The need to do content filtering at the loot drop entry level reduces complexity of having to split loot tables and loot drops to filter things at the entry level.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing

**Example Lootdrop Entries**

Added "Highblade of the Wyvern Lord" at the end of an existing table

```
select * from lootdrop_entries where lootdrop_id = 138047;
+-------------+---------+--------------+------------+--------+-----------------+-------------------+-------------------+------------+---------------+---------------+---------------+---------------+---------------+------------------------+
| lootdrop_id | item_id | item_charges | equip_item | chance | disabled_chance | trivial_min_level | trivial_max_level | multiplier | npc_min_level | npc_max_level | min_expansion | max_expansion | content_flags | content_flags_disabled |
+-------------+---------+--------------+------------+--------+-----------------+-------------------+-------------------+------------+---------------+---------------+---------------+---------------+---------------+------------------------+
|      138047 |   13025 |            1 |          0 | 29.323 |               0 |                 0 |                 0 |          2 |             0 |             0 |            -1 |            -1 | NULL          | NULL                   |
|      138047 |   13915 |            1 |          0 | 10.553 |               0 |                 0 |                 0 |          2 |             0 |             0 |            -1 |            -1 | NULL          | NULL                   |
|      138047 |   19630 |            1 |          0 | 26.512 |               0 |                 0 |                 0 |          1 |             0 |             0 |            -1 |            -1 | NULL          | NULL                   |
|      138047 |   27392 |            1 |          0 |  4.616 |               0 |                 0 |                 0 |          2 |             0 |             0 |            -1 |            -1 | NULL          | NULL                   |
|      138047 |   27405 |            1 |          0 |  8.208 |               0 |                 0 |                 0 |          2 |             0 |             0 |            -1 |            -1 | NULL          | NULL                   |
|      138047 |   27409 |            1 |          0 |  4.467 |               0 |                 0 |                 0 |          2 |             0 |             0 |            -1 |            -1 | NULL          | NULL                   |
|      138047 |   27421 |            1 |          0 |  2.094 |               0 |                 0 |                 0 |          2 |             0 |             0 |            -1 |            -1 | NULL          | NULL                   |
|      138047 |   27423 |            1 |          0 |  2.168 |               0 |                 0 |                 0 |          2 |             0 |             0 |            -1 |            -1 | NULL          | NULL                   |
|      138047 |   27424 |            1 |          0 |  2.187 |               0 |                 0 |                 0 |          2 |             0 |             0 |            -1 |            -1 | NULL          | NULL                   |
|      138047 |   27427 |            1 |          0 |  2.029 |               0 |                 0 |                 0 |          2 |             0 |             0 |            -1 |            -1 | NULL          | NULL                   |
|      138047 |   34211 |            1 |          0 | 10.236 |               0 |                 0 |                 0 |          2 |             0 |             0 |            -1 |            -1 | NULL          | NULL                   |
|      138047 |   34239 |            1 |          0 |  3.694 |               0 |                 0 |                 0 |          2 |             0 |             0 |            -1 |            -1 | NULL          | NULL                   |
|      138047 |   35085 |            1 |          0 |  2.224 |               0 |                 0 |                 0 |          2 |             0 |             0 |            -1 |            -1 | NULL          | NULL                   |
|      138047 |   35088 |            1 |          0 |  2.447 |               0 |                 0 |                 0 |          2 |             0 |             0 |            -1 |            -1 | NULL          | NULL                   |
|      138047 |  102649 |            1 |          1 |    100 |               0 |                 0 |                 0 |          1 |             0 |             0 |             0 |             4 | NULL          | NULL                   |
+-------------+---------+--------------+------------+--------+-----------------+-------------------+-------------------+------------+---------------+---------------+---------------+---------------+---------------+------------------------+
15 rows in set (0.00 sec)
```

Current expansion (9 Dragons of Norrath) - Loot drop does not drop (Expected)

![image](https://github.com/EQEmu/Server/assets/3319450/4bfdcc79-1a0b-46e3-936b-3908176b0ac1)

Current expansion (3 Luclin) - Loot drop drops as expected

![image](https://github.com/EQEmu/Server/assets/3319450/f462c231-cce5-41a4-ba8c-d8fb55caa728)

Clients tested: RoF2

# Checklist:

- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I have tested my changes
- [x] I have made corresponding changes to the documentation
- [x] I own the changes of my code and take responsibility for the potential issues that occur

