### PR TITLE
[Crash] Check mob pointer before trying to remove it

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -2675,6 +2675,10 @@ void EntityList::RemoveAllMobs()
 {
 	auto it = mob_list.begin();
 	while (it != mob_list.end()) {
+		if (!it->second) {
+			++it;
+			continue;
+		}
 		safe_delete(it->second);
 		free_ids.push(it->first);
 		it = mob_list.erase(it);
@@ -2812,6 +2816,9 @@ bool EntityList::RemoveMob(uint16 delete_id)
 
 	auto it = mob_list.find(delete_id);
 	if (it != mob_list.end()) {
+		if (!it->second) {
+			return false;
+		}
 		if (npc_list.count(delete_id)) {
 			entity_list.RemoveNPC(delete_id);
 		}


### PR DESCRIPTION
# Description

This attempts to check a pointer before trying to do book keeping. We are observing a crashing during zone shutdown during `RemoveAllMobs` that is unclear the exact source of the trigger

Attempts to fix crash fingerprint `10444` which has over 100 occurrences at this point https://spire.akkadius.com/dev/release/22.48.0?id=20718

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Had 3 zones shutdown that trigger `RemoveAllMobs`

![image](https://github.com/EQEmu/Server/assets/3319450/92cdd4aa-dbbd-4cca-894f-4bf7bc4bcbc2)

![image](https://github.com/EQEmu/Server/assets/3319450/c3b643b0-8ebb-4020-960b-b950634425b6)

![image](https://github.com/EQEmu/Server/assets/3319450/244b21b7-6720-4212-90bd-59b4271b168e)

 - [x] Currently running and baking on PEQ. Seems to have helped the crashes.
 - [x] This should be tested and baked on a server with players such as PEQ to confirm it doesn't create other issues

Clients tested: ROF2

# Checklist

- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I have tested my changes
- [x] I have made corresponding changes to the documentation
- [x] I own the changes of my code and take responsibility for the potential issues that occur

