### PR TITLE
[Bug Fix] Shared Tasks - group_id.charid is now group_id.character_id

### DIFF
--- a/common/shared_tasks.cpp
+++ b/common/shared_tasks.cpp
@@ -60,7 +60,7 @@ SharedTaskRequest SharedTask::GetRequestCharacters(Database &db, uint32_t reques
 	request.group_type = SharedTaskRequestGroupType::Group;
 	auto characters = CharacterDataRepository::GetWhere(
 		db, fmt::format(
-			"id IN (select charid from group_id where group_id = (select group_id from group_id where charid = {}))",
+			"id IN (select character_id from group_id where group_id = (select group_id from group_id where character_id = {}))",
 			requested_character_id
 		)
 	);


### PR DESCRIPTION
## BugFix

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I have tested my changes
- [x] I own the changes of my code take responsibilities for the potential issues that occur

# Description

Bugfix for shared_tasks.cpp where group_id.charid is now group_id.character_id


