### PR TITLE
[Bug Fix] Fix Bot Creation Issue

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -74,6 +74,7 @@
 #include "repositories/zone_repository.h"
 #include "zone_store.h"
 #include "repositories/merchantlist_temp_repository.h"
+#include "repositories/bot_data_repository.h"
 
 extern Client client;
 
@@ -915,15 +916,31 @@ bool Database::UpdateName(const std::string& old_name, const std::string& new_na
 	return CharacterDataRepository::UpdateOne(*this, e);
 }
 
-bool Database::CheckUsedName(const std::string& name)
+bool Database::IsNameUsed(const std::string& name)
 {
-	return !CharacterDataRepository::GetWhere(
+	if (RuleB(Bots, Enabled)) {
+		const auto& bot_data = BotDataRepository::GetWhere(
+			*this,
+			fmt::format(
+				"`name` = '{}'",
+				Strings::Escape(name)
+			)
+		);
+
+		if (!bot_data.empty()) {
+			return true;
+		}
+	}
+
+	const auto& character_data = CharacterDataRepository::GetWhere(
 		*this,
 		fmt::format(
 			"`name` = '{}'",
 			Strings::Escape(name)
 		)
-	).empty();
+	);
+
+	return !character_data.empty();
 }
 
 uint32 Database::GetServerType()

--- a/common/database.h
+++ b/common/database.h
@@ -115,7 +115,7 @@ public:
 	bool CheckBannedIPs(const std::string& login_ip); //Check incoming connection against banned IP table.
 	bool CheckGMIPs(const std::string& login_ip, uint32 account_id);
 	bool CheckNameFilter(const std::string& name, bool surname = false);
-	bool CheckUsedName(const std::string& name);
+	bool IsNameUsed(const std::string& name);
 
 	uint32 GetAccountIDByChar(const std::string& name, uint32* character_id = 0);
 	uint32 GetAccountIDByChar(uint32 character_id);

--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -184,32 +184,8 @@ bool BotDatabase::QueryNameAvailablity(const std::string& bot_name, bool& availa
 	if (
 		bot_name.empty() ||
 		bot_name.size() > 60 ||
-		!database.CheckUsedName(bot_name)
+		database.IsNameUsed(bot_name)
 	) {
-		return false;
-	}
-
-	const auto& bot_data = BotDataRepository::GetWhere(
-		database,
-		fmt::format(
-			"`name` LIKE '{}' LIMIT 1",
-			bot_name
-		)
-	);
-
-	if (!bot_data.empty()) {
-		return false;
-	}
-
-	const auto& character_data = CharacterDataRepository::GetWhere(
-		database,
-		fmt::format(
-			"`name` LIKE '{}' LIMIT 1",
-			bot_name
-		)
-	);
-
-	if (!character_data.empty()) {
 		return false;
 	}
 

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -2228,8 +2228,8 @@ void Client::ChangeLastName(std::string last_name) {
 bool Client::ChangeFirstName(const char* in_firstname, const char* gmname)
 {
 	// check duplicate name
-	bool usedname = database.CheckUsedName((const char*) in_firstname);
-	if (!usedname) {
+	bool used_name = database.IsNameUsed((const char*) in_firstname);
+	if (used_name) {
 		return false;
 	}
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -6875,7 +6875,7 @@ void Client::Handle_OP_GMNameChange(const EQApplicationPacket *app)
 	Client *c = entity_list.GetClientByName(gmn->oldname);
 	LogInfo("GM([{}]) changeing players name. Old:[{}] New:[{}]", GetName(), gmn->oldname, gmn->newname);
 
-	const bool used_name = database.CheckUsedName(gmn->newname);
+	const bool used_name = database.IsNameUsed(gmn->newname);
 	if (!c) {
 		Message(Chat::Red, fmt::format("{} not found for name change. Operation failed!", gmn->oldname).c_str());
 		return;
@@ -6886,7 +6886,7 @@ void Client::Handle_OP_GMNameChange(const EQApplicationPacket *app)
 		return;
 	}
 
-	if (!used_name) {
+	if (used_name) {
 		Message(Chat::Red, fmt::format("{} is already in use. Operation failed!", gmn->newname).c_str());
 		return;
 	}

--- a/zone/merc.cpp
+++ b/zone/merc.cpp
@@ -4203,7 +4203,7 @@ const char* Merc::GetRandomName(){
 			//name must begin with an upper-case letter.
 			valid = false;
 		}
-		else if (database.CheckUsedName(rndname)) {
+		else if (!database.IsNameUsed(rndname)) {
 			valid = true;
 		}
 		else {


### PR DESCRIPTION
# Description
- Creating bots was failing because we were checking for `false` on `Database::CheckUsedName()` in `BotDatabase::QueryNameAvailability`.
- `Database::CheckUsedName()` is now `Database::IsNameUsed()` and checks for both bots and character name usages, we use this instead in `BotDatabase::QueryNameAvailability` to clean it up considerably.
- We were checking for `false` which was always happening when there were no entries for the supplied name, meaning we were never allowed to create a bot.

# Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
![image](https://github.com/EQEmu/Server/assets/89047260/ad806304-acd3-4ef0-ab8a-fd7ddb494c7c)

# Clients 
- [X] Rain of Fear 2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
