### PR TITLE
[Bug Fix] Fix Lua Crash with Spell Blocked Event

### DIFF
--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -183,7 +183,7 @@ const char *LuaEvents[_LargestEventID] = {
 	"event_entity_variable_delete",
 	"event_entity_variable_set",
 	"event_entity_variable_update",
-	"event_aa_loss"
+	"event_aa_loss",
 	"event_spell_blocked"
 };
 


### PR DESCRIPTION
# Description
- A Lua crash was occurring because there was no indication the `event_spell_blocked` line existed, so when attempting to get the event's name by its ID it was failing per @KayenEQ's log.
- Occurred when resolving merge conflicts in the [original pull request](https://github.com/EQEmu/Server/pull/4217/files#diff-7787e019afff2b04f164b280dc133f7dbecfcb156effd8c7ef0ebab7e2eb70cbR187).

# Log
```
[04-01-2024 14:08:10] [Zone] [Crash] C:\git-eqemulator\Server\zone\lua_parser.cpp (881): LuaParser::GlobalPlayerHasQuestSub 
[04-01-2024 14:08:10] [Zone] [Crash] C:\git-eqemulator\Server\zone\quest_parser_collection.cpp (229): QuestParserCollection::PlayerHasQuestSubGlobal 
[04-01-2024 14:08:10] [Zone] [Crash] C:\git-eqemulator\Server\zone\quest_parser_collection.cpp (185): QuestParserCollection::PlayerHasQuestSub 
[04-01-2024 14:08:10] [Zone] [Crash] C:\git-eqemulator\Server\zone\spells.cpp (3579): Mob::AddBuff 
[04-01-2024 14:08:10] [Zone] [Crash] C:\git-eqemulator\Server\zone\spell_effects.cpp (125): Mob::SpellEffect 
[04-01-2024 14:08:10] [Zone] [Crash] C:\git-eqemulator\Server\zone\spells.cpp (4526): Mob::SpellOnTarget 
[04-01-2024 14:08:10] [Zone] [Crash] C:\git-eqemulator\Server\zone\spells.cpp (2591): Mob::SpellFinished 
[04-01-2024 14:08:10] [Zone] [Crash] C:\git-eqemulator\Server\zone\spells.cpp (1743): Mob::CastedSpellFinished 
[04-01-2024 14:08:10] [Zone] [Crash] C:\git-eqemulator\Server\zone\spells.cpp (134): Mob::SpellProcess 
[04-01-2024 14:08:10] [Zone] [Crash] C:\git-eqemulator\Server\zone\client_process.cpp (500): Client::Process 
[04-01-2024 14:08:10] [Zone] [Crash] C:\git-eqemulator\Server\zone\entity.cpp (544): EntityList::MobProcess
```

# Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
@KayenEQ confirmed he no longer crashes with this fix implemented.

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
