### PR TITLE
[Bug Fix] Client not updating HP bar when an HP Buff with a Heal is applied.

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4645,7 +4645,7 @@ bool Mob::SpellOnTarget(
 		However due to server thinking your healed, you are unable to correct it by healing.
 		Solution: You need to resend the HP update after buff completed and action packet resent.
 	*/
-	if (IsEffectInSpell(spell_id, SE_TotalHP) && (IsEffectInSpell(spell_id, SE_CurrentHPOnce) || IsEffectInSpell(spell_id, SE_CurrentHP))) {
+	if ((IsEffectInSpell(spell_id, SE_TotalHP) || IsEffectInSpell(spell_id, SE_MaxHPChange)) && (IsEffectInSpell(spell_id, SE_CurrentHPOnce) || IsEffectInSpell(spell_id, SE_CurrentHP))) {
 		SendHPUpdate(true);
 	}
 

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4639,6 +4639,16 @@ bool Mob::SpellOnTarget(
 	safe_delete(action_packet);
 	safe_delete(message_packet);
 
+	/*
+		Bug: When an HP buff with a heal effect is applied for first time, the heal portion of the effect heals the client and
+		updates HPs currently server side, but client side the HP bar does not register it as a heal thus you display as less than full HP.
+		However due to server thinking your healed, you are unable to correct it by healing.
+		Solution: You need to resend the HP update after buff completed and action packet resent.
+	*/
+	if (IsEffectInSpell(spell_id, SE_TotalHP) && (IsEffectInSpell(spell_id, SE_CurrentHPOnce) || IsEffectInSpell(spell_id, SE_CurrentHP))) {
+		SendHPUpdate(true);
+	}
+
 	LogSpells("Cast of [{}] by [{}] on [{}] complete successfully", spell_id, GetName(), spelltar->GetName());
 
 	return true;


### PR DESCRIPTION
Came across this bug while trying to fix another bug...

Bug: When an HP buff with a heal effect is applied for first time (example Virtue), the heal portion of the effect heals the client and updates HPs correctly server side, but client side the HP bar does not register it as a heal thus you display as less than full HP. However, due to server thinking your healed, you are unable to correct it by healing yourself.
		
Solution: We need to resend the HP update again after buff completed and action packet resent.

This is currently coded to apply to spell effects SPA 69 (Total HP) and SPA 214 (Max HP Change) that have instant healing components SPA 0 or SPA 79. Possible that this may need to be expanded on in the future.