### PR TITLE
[Bug Fix] SPA214 SE_MaxHPChange calculation errors corrected.

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -5001,6 +5001,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 				case SE_MaxHPChange:
 					if (negate_spellbonus) { spellbonuses.MaxHPChange = effect_value; }
 					if (negate_aabonus) { aabonuses.MaxHPChange = effect_value; }
+					if (negate_aabonus) { aabonuses.MaxHP = effect_value; }
 					if (negate_itembonus) { itembonuses.MaxHPChange = effect_value; }
 					break;
 

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -6235,11 +6235,10 @@ int64 Bot::CalcMaxHP() {
 	uint32 nd = 10000;
 	bot_hp += (GenerateBaseHitPoints() + itembonuses.HP);
 	bot_hp += itembonuses.heroic_max_hp;
-	nd += aabonuses.MaxHP;
+	nd += aabonuses.MaxHP + spellbonuses.MaxHPChange + itembonuses.MaxHPChange;
 	bot_hp = ((float)bot_hp * (float)nd / (float)10000);
 	bot_hp += (spellbonuses.HP + aabonuses.HP);
 	bot_hp += GroupLeadershipAAHealthEnhancement();
-	bot_hp += (bot_hp * ((spellbonuses.MaxHPChange + itembonuses.MaxHPChange) / 10000.0f));
 	max_hp = bot_hp;
 	if (current_hp > max_hp)
 		current_hp = max_hp;

--- a/zone/client_mods.cpp
+++ b/zone/client_mods.cpp
@@ -323,7 +323,7 @@ int64 Client::CalcMaxHP()
 	//to apply it to (basehp + itemhp).. I will oblige to the client's whims over
 	//the aa description
 	
-	nd += aabonuses.MaxHP + spellbonuses.MaxHPChange + itembonuses.MaxHPChange;	//Natural Durability, Physical Enhancement, Planar Durability
+	nd += aabonuses.MaxHP + spellbonuses.MaxHPChange + itembonuses.MaxHPChange;	//Natural Durability, Physical Enhancement, Planar Durability (MaxHP and MaxHPChange are SPA214)
 	max_hp = (float)max_hp * (float)nd / (float)10000; //this is to fix the HP-above-495k issue
 	max_hp += spellbonuses.HP + aabonuses.HP;
 

--- a/zone/client_mods.cpp
+++ b/zone/client_mods.cpp
@@ -322,11 +322,12 @@ int64 Client::CalcMaxHP()
 	//but the actual effect sent on live causes the client
 	//to apply it to (basehp + itemhp).. I will oblige to the client's whims over
 	//the aa description
-	nd += aabonuses.MaxHP;	//Natural Durability, Physical Enhancement, Planar Durability
+	
+	nd += aabonuses.MaxHP + spellbonuses.MaxHPChange + itembonuses.MaxHPChange;	//Natural Durability, Physical Enhancement, Planar Durability
 	max_hp = (float)max_hp * (float)nd / (float)10000; //this is to fix the HP-above-495k issue
 	max_hp += spellbonuses.HP + aabonuses.HP;
+
 	max_hp += GroupLeadershipAAHealthEnhancement();
-	max_hp += max_hp * ((spellbonuses.MaxHPChange + itembonuses.MaxHPChange) / 10000.0f);
 	if (current_hp > max_hp) {
 		current_hp = max_hp;
 	}

--- a/zone/common.h
+++ b/zone/common.h
@@ -287,7 +287,7 @@ struct StatBonuses {
 	int32	AC;
 	int64	HP;
 	int64	HPRegen;
-	int64	MaxHP;
+	int64	MaxHP; //same bonus as MaxHPChange when applied to spells and item bonuses
 	int64	ManaRegen;
 	int64	EnduranceRegen;
 	int64	Mana;
@@ -413,7 +413,7 @@ struct StatBonuses {
 	int32	MeleeLifetap;						//i
 	int32	Vampirism;							//i
 	int32	HealRate;							// Spell effect that influences effectiveness of heals
-	int32	MaxHPChange;						// Spell Effect
+	int32	MaxHPChange;						// percent change in hit points (aabonuses use variable MaxHP)
 	int16	SkillDmgTaken[EQ::skills::HIGHEST_SKILL + 2];		// All Skills + -1
 	int32	HealAmt;							// Item Effect
 	int32	SpellDmg;							// Item Effect

--- a/zone/merc.cpp
+++ b/zone/merc.cpp
@@ -461,14 +461,12 @@ int64 Merc::CalcMaxHP() {
 	//but the actual effect sent on live causes the client
 	//to apply it to (basehp + itemhp).. I will oblige to the client's whims over
 	//the aa description
-	nd += aabonuses.MaxHP;  //Natural Durability, Physical Enhancement, Planar Durability
+	nd += aabonuses.MaxHP + spellbonuses.MaxHPChange + itembonuses.MaxHPChange;  //Natural Durability, Physical Enhancement, Planar Durability
 
 	max_hp = (float)max_hp * (float)nd / (float)10000; //this is to fix the HP-above-495k issue
 	max_hp += spellbonuses.HP + aabonuses.HP;
 
 	max_hp += GroupLeadershipAAHealthEnhancement();
-
-	max_hp += max_hp * ((spellbonuses.MaxHPChange + itembonuses.MaxHPChange) / 10000.0f);
 
 	if (current_hp > max_hp)
 		current_hp = max_hp;

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4645,7 +4645,7 @@ bool Mob::SpellOnTarget(
 		However due to server thinking your healed, you are unable to correct it by healing.
 		Solution: You need to resend the HP update after buff completed and action packet resent.
 	*/
-	if (IsEffectInSpell(spell_id, SE_TotalHP) && (IsEffectInSpell(spell_id, SE_CurrentHPOnce) || IsEffectInSpell(spell_id, SE_CurrentHP))) {
+	if ((IsEffectInSpell(spell_id, SE_TotalHP) || IsEffectInSpell(spell_id, SE_MaxHPChange)) && (IsEffectInSpell(spell_id, SE_CurrentHPOnce) || IsEffectInSpell(spell_id, SE_CurrentHP))) {
 		SendHPUpdate(true);
 	}
 

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4641,7 +4641,7 @@ bool Mob::SpellOnTarget(
 
 	/*
 		Bug: When an HP buff with a heal effect is applied for first time, the heal portion of the effect heals the client and
-		updates HPs currently server side, but client side the HP bar does not register it as a heal thus you display as less than full HP.
+		updates HPs correctly server side, but client side the HP bar does not register it as a heal thus you display as less than full HP.
 		However due to server thinking your healed, you are unable to correct it by healing.
 		Solution: You need to resend the HP update after buff completed and action packet resent.
 	*/

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4639,16 +4639,6 @@ bool Mob::SpellOnTarget(
 	safe_delete(action_packet);
 	safe_delete(message_packet);
 
-	/*
-		Bug: When an HP buff with a heal effect is applied for first time, the heal portion of the effect heals the client and
-		updates HPs correctly server side, but client side the HP bar does not register it as a heal thus you display as less than full HP.
-		However due to server thinking your healed, you are unable to correct it by healing.
-		Solution: You need to resend the HP update after buff completed and action packet resent.
-	*/
-	if ((IsEffectInSpell(spell_id, SE_TotalHP) || IsEffectInSpell(spell_id, SE_MaxHPChange)) && (IsEffectInSpell(spell_id, SE_CurrentHPOnce) || IsEffectInSpell(spell_id, SE_CurrentHP))) {
-		SendHPUpdate(true);
-	}
-
 	LogSpells("Cast of [{}] by [{}] on [{}] complete successfully", spell_id, GetName(), spelltar->GetName());
 
 	return true;

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4639,6 +4639,16 @@ bool Mob::SpellOnTarget(
 	safe_delete(action_packet);
 	safe_delete(message_packet);
 
+	/*
+		Bug: When an HP buff with a heal effect is applied for first time, the heal portion of the effect heals the client and
+		updates HPs currently server side, but client side the HP bar does not register it as a heal thus you display as less than full HP.
+		However due to server thinking your healed, you are unable to correct it by healing.
+		Solution: You need to resend the HP update after buff completed and action packet resent.
+	*/
+	if (IsEffectInSpell(spell_id, SE_TotalHP) && (IsEffectInSpell(spell_id, SE_CurrentHPOnce) || IsEffectInSpell(spell_id, SE_CurrentHP))) {
+		SendHPUpdate(true);
+	}
+
 	LogSpells("Cast of [{}] by [{}] on [{}] complete successfully", spell_id, GetName(), spelltar->GetName());
 
 	return true;


### PR DESCRIPTION
Bug: SPA 214 which changes hit points by percentage was not displaying correctly on the client. This was causing differences between client displayed hit points and server calculations.

Solution: The formula we were using to apply the spell and item bonuses using SPA 214 to client max hit points was incorrect. It should not have been applying it after the AA version (Natural Durability) and after Spell HP buffs (Ie. Virtue). The correct calculation was it should be applied at the same time as the AA version.

Client and server now display the same values within 5 hps of each other.

Fixed for Bots and Mercs as well.