### PR TITLE
[Lua] Add SetEXP and SetAAEXP Lua Mods

### DIFF
--- a/common/eq_constants.h
+++ b/common/eq_constants.h
@@ -1131,4 +1131,17 @@ namespace LeadershipAbilitySlot {
 	constexpr uint16 HealthOfTargetsTarget = 14;
 }
 
+enum ExpSource
+{
+	Unknown,
+	Quest,
+	GM,
+	Kill,
+	Death,
+	Resurrection,
+	LDoNChest,
+	Task,
+	Sacrifice
+};
+
 #endif /*COMMON_EQ_CONSTANTS_H*/

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1946,7 +1946,7 @@ bool Client::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::Skil
 			} else {
 				newexp -= exploss;
 			}
-			SetEXP(newexp, GetAAXP());
+			SetEXP(newexp, GetAAXP(), false, ExpSource::Death);
 			//m_epp.perAA = 0;	//reset to no AA exp on death.
 		}
 
@@ -2591,7 +2591,7 @@ bool NPC::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillTy
 
 		if (killer_raid) {
 			if (!is_ldon_treasure && MerchantType == 0) {
-				killer_raid->SplitExp(final_exp, this);
+				killer_raid->SplitExp(final_exp, this, ExpSource::Kill);
 
 				if (
 					killer_mob &&
@@ -2657,7 +2657,7 @@ bool NPC::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillTy
 			}
 		} else if (give_exp_client->IsGrouped() && killer_group) {
 			if (!is_ldon_treasure && MerchantType == 0) {
-				killer_group->SplitExp(final_exp, this);
+				killer_group->SplitExp(final_exp, this, ExpSource::Kill);
 
 				if (
 					killer_mob &&
@@ -2721,7 +2721,7 @@ bool NPC::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillTy
 
 				if (con_level != CON_GRAY) {
 					if (!GetOwner() || (GetOwner() && !GetOwner()->IsClient())) {
-						give_exp_client->AddEXP(final_exp, con_level);
+						give_exp_client->AddEXP(final_exp, con_level, false, ExpSource::Kill);
 
 						if (
 							killer_mob &&

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -3900,7 +3900,7 @@ void Client::Sacrifice(Client *caster)
 	if (GetLevel() >= RuleI(Spells, SacrificeMinLevel) && GetLevel() <= RuleI(Spells, SacrificeMaxLevel)) {
 		int exploss = (int)(GetLevel() * (GetLevel() / 18.0) * 12000);
 		if (exploss < GetEXP()) {
-			SetEXP(GetEXP() - exploss, GetAAXP());
+			SetEXP(GetEXP() - exploss, GetAAXP(), false, ExpSource::Sacrifice);
 			SendLogoutPackets();
 
 			// make our become corpse packet, and queue to ourself before OP_Death.
@@ -5007,15 +5007,15 @@ void Client::HandleLDoNOpen(NPC *target)
 			{
 				if(GetRaid())
 				{
-					GetRaid()->SplitExp(target->GetLevel()*target->GetLevel()*2625/10, target);
+					GetRaid()->SplitExp(target->GetLevel()*target->GetLevel()*2625/10, target, ExpSource::LDoNChest);
 				}
 				else if(GetGroup())
 				{
-					GetGroup()->SplitExp(target->GetLevel()*target->GetLevel()*2625/10, target);
+					GetGroup()->SplitExp(target->GetLevel()*target->GetLevel()*2625/10, target, ExpSource::LDoNChest);
 				}
 				else
 				{
-					AddEXP(target->GetLevel()*target->GetLevel()*2625/10, GetLevelCon(target->GetLevel()));
+					AddEXP(target->GetLevel()*target->GetLevel()*2625/10, GetLevelCon(target->GetLevel()), false, ExpSource::LDoNChest);
 				}
 			}
 			target->Death(this, 0, SPELL_UNKNOWN, EQ::skills::SkillHandtoHand);
@@ -5217,7 +5217,7 @@ void Client::SummonAndRezzAllCorpses()
 	int RezzExp = entity_list.RezzAllCorpsesByCharID(CharacterID());
 
 	if(RezzExp > 0)
-		SetEXP(GetEXP() + RezzExp, GetAAXP(), true);
+		SetEXP(GetEXP() + RezzExp, GetAAXP(), true, ExpSource::Resurrection);
 
 	Message(Chat::Yellow, "All your corpses have been summoned to your feet and have received a 100% resurrection.");
 }
@@ -8276,7 +8276,7 @@ void Client::QuestReward(Mob* target, uint32 copper, uint32 silver, uint32 gold,
 	}
 
 	if (exp > 0) {
-		AddEXP(exp);
+		AddEXP(exp, 0xFF, false, ExpSource::Quest);
 	}
 
 	QueuePacket(outapp, true, Client::CLIENT_CONNECTED);
@@ -8321,7 +8321,7 @@ void Client::QuestReward(Mob* target, const QuestReward_Struct &reward, bool fac
 	}
 
 	if (reward.exp_reward > 0) {
-		AddEXP(reward.exp_reward);
+		AddEXP(reward.exp_reward, 0xFF, false, ExpSource::Quest);
 	}
 
 	QueuePacket(outapp, true, Client::CLIENT_CONNECTED);

--- a/zone/client.h
+++ b/zone/client.h
@@ -629,14 +629,14 @@ public:
 	void SendCrystalCounts();
 
 	uint64 GetExperienceForKill(Mob *against);
-	void AddEXP(uint64 in_add_exp, uint8 conlevel = 0xFF, bool resexp = false);
+	void AddEXP(uint64 in_add_exp, uint8 conlevel = 0xFF, bool resexp = false, ExpSource exp_source = ExpSource::Unknown);
 	uint64 CalcEXP(uint8 conlevel = 0xFF, bool ignore_mods = false);
 	void CalculateNormalizedAAExp(uint64 &add_aaxp, uint8 conlevel, bool resexp);
 	void CalculateStandardAAExp(uint64 &add_aaxp, uint8 conlevel, bool resexp);
 	void CalculateLeadershipExp(uint64 &add_exp, uint8 conlevel);
 	void CalculateExp(uint64 in_add_exp, uint64 &add_exp, uint64 &add_aaxp, uint8 conlevel, bool resexp);
-	void SetEXP(uint64 set_exp, uint64 set_aaxp, bool resexp=false);
-	void AddLevelBasedExp(uint8 exp_percentage, uint8 max_level = 0, bool ignore_mods = false);
+	void SetEXP(uint64 set_exp, uint64 set_aaxp, bool resexp=false, ExpSource source= ExpSource::Unknown);
+	void AddLevelBasedExp(uint8 exp_percentage, uint8 max_level = 0, bool ignore_mods = false, ExpSource exp_source = ExpSource::Unknown);
 	void SetLeadershipEXP(uint64 group_exp, uint64 raid_exp);
 	void AddLeadershipEXP(uint64 group_exp, uint64 raid_exp);
 	void SendLeadershipEXPUpdate();

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -1075,9 +1075,9 @@ void Client::OPRezzAnswer(uint32 Action, uint32 SpellID, uint16 ZoneID, uint16 I
 
 		if(spells[SpellID].base_value[0] < 100 && spells[SpellID].base_value[0] > 0 && PendingRezzXP > 0) {
 				SetEXP(((int)(GetEXP()+((float)((PendingRezzXP / 100) * spells[SpellID].base_value[0])))),
-						GetAAXP(),true);
+						GetAAXP(), true, ExpSource::Resurrection);
 		} else if (spells[SpellID].base_value[0] == 100 && PendingRezzXP > 0) {
-			SetEXP((GetEXP() + PendingRezzXP), GetAAXP(), true);
+			SetEXP((GetEXP() + PendingRezzXP), GetAAXP(), true, ExpSource::Resurrection);
 		}
 
 		//Was sending the packet back to initiate client zone...

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -497,7 +497,7 @@ void Client::CalculateExp(uint64 in_add_exp, uint64 &add_exp, uint64 &add_aaxp, 
 	add_exp = GetEXP() + add_exp;
 }
 
-void Client::AddEXP(uint64 in_add_exp, uint8 conlevel, bool resexp) {
+void Client::AddEXP(uint64 in_add_exp, uint8 conlevel, bool resexp, ExpSource exp_source) {
 	if (!IsEXPEnabled()) {
 		return;
 	}
@@ -569,10 +569,32 @@ void Client::AddEXP(uint64 in_add_exp, uint8 conlevel, bool resexp) {
 	}
 
 	// Now update our character's normal and AA xp
-	SetEXP(exp, aaexp, resexp);
+	SetEXP(exp, aaexp, resexp, exp_source);
 }
 
-void Client::SetEXP(uint64 set_exp, uint64 set_aaxp, bool isrezzexp) {
+void Client::SetEXP(uint64 set_exp, uint64 set_aaxp, bool isrezzexp, ExpSource exp_source) {
+	uint64 current_exp = GetEXP();
+	uint64 current_aa_exp = GetAAXP();
+	uint64 total_current_exp = current_exp + current_aa_exp;
+	uint64 total_add_exp = set_exp + set_aaxp;
+
+#ifdef LUA_EQEMU
+	uint64 lua_ret = 0;
+	bool ignore_default = false;
+	lua_ret = LuaParser::Instance()->SetEXP(this, exp_source, current_exp, set_exp, isrezzexp, ignore_default);
+	if (ignore_default) {
+		set_exp = lua_ret;
+	}
+
+	lua_ret = 0;
+	ignore_default = false;
+	lua_ret = LuaParser::Instance()->SetAAEXP(this, exp_source, current_aa_exp, set_aaxp, isrezzexp, ignore_default);
+	if (ignore_default) {
+		set_aaxp = lua_ret;
+	}
+	total_add_exp = set_exp + set_aaxp;
+#endif
+
 	LogDebug("Attempting to Set Exp for [{}] (XP: [{}], AAXP: [{}], Rez: [{}])", GetCleanName(), set_exp, set_aaxp, isrezzexp ? "true" : "false");
 
 	auto max_AAXP = GetRequiredAAExperience();
@@ -591,10 +613,6 @@ void Client::SetEXP(uint64 set_exp, uint64 set_aaxp, bool isrezzexp) {
 		}
 	}
 
-	uint64 current_exp = GetEXP();
-	uint64 current_aa_exp = GetAAXP();
-	uint64 total_current_exp = current_exp + current_aa_exp;
-	uint64 total_add_exp = set_exp + set_aaxp;
 	if (total_add_exp > total_current_exp) {
 		uint64 exp_gained = set_exp - current_exp;
 		uint64 aa_exp_gained = set_aaxp - current_aa_exp;
@@ -1084,7 +1102,7 @@ uint32 Client::GetEXPForLevel(uint16 check_level)
 	return finalxp;
 }
 
-void Client::AddLevelBasedExp(uint8 exp_percentage, uint8 max_level, bool ignore_mods)
+void Client::AddLevelBasedExp(uint8 exp_percentage, uint8 max_level, bool ignore_mods, ExpSource exp_source)
 {
 	uint64	award;
 	uint64	xp_for_level;
@@ -1113,10 +1131,10 @@ void Client::AddLevelBasedExp(uint8 exp_percentage, uint8 max_level, bool ignore
 	}
 
 	uint64 newexp = GetEXP() + award;
-	SetEXP(newexp, GetAAXP());
+	SetEXP(newexp, GetAAXP(), false, exp_source);
 }
 
-void Group::SplitExp(const uint64 exp, Mob* other) {
+void Group::SplitExp(const uint64 exp, Mob* other, ExpSource exp_source) {
 	if (other->CastToNPC()->MerchantType != 0) {
 		return;
 	}
@@ -1174,13 +1192,13 @@ void Group::SplitExp(const uint64 exp, Mob* other) {
 			if (diff >= max_diff) {
 				const uint64 tmp  = (m->GetLevel() + 3) * (m->GetLevel() + 3) * 75 * 35 / 10;
 				const uint64 tmp2 = group_experience / member_count;
-				m->CastToClient()->AddEXP(tmp < tmp2 ? tmp : tmp2, consider_level);
+				m->CastToClient()->AddEXP(tmp < tmp2 ? tmp : tmp2, consider_level, false, exp_source);
 			}
 		}
 	}
 }
 
-void Raid::SplitExp(const uint64 exp, Mob* other) {
+void Raid::SplitExp(const uint64 exp, Mob* other, ExpSource exp_source) {
 	if (other->CastToNPC()->MerchantType != 0) {
 		return;
 	}
@@ -1225,7 +1243,7 @@ void Raid::SplitExp(const uint64 exp, Mob* other) {
 			if (diff >= max_diff) {
 				const uint64 tmp  = (m.member->GetLevel() + 3) * (m.member->GetLevel() + 3) * 75 * 35 / 10;
 				const uint64 tmp2 = (raid_experience / member_modifier) + 1;
-				m.member->AddEXP(tmp < tmp2 ? tmp : tmp2, consider_level);
+				m.member->AddEXP(tmp < tmp2 ? tmp : tmp2, consider_level, false, exp_source);
 			}
 		}
 	}

--- a/zone/gm_commands/set/aa_exp.cpp
+++ b/zone/gm_commands/set/aa_exp.cpp
@@ -38,7 +38,8 @@ void SetAAEXP(Client *c, const Seperator *sep)
 		t->SetEXP(
 			t->GetEXP(),
 			aa_experience,
-			false
+			false,
+			ExpSource::GM
 		);
 	} else if (is_group) {
 		group_raid_string = "Group ";

--- a/zone/gm_commands/set/exp.cpp
+++ b/zone/gm_commands/set/exp.cpp
@@ -27,12 +27,14 @@ void SetEXP(Client *c, const Seperator *sep)
 	if (is_aa) {
 		t->SetEXP(
 			t->GetEXP(),
-			amount
+			amount,
+			ExpSource::GM
 		);
 	} else if (is_exp) {
 		t->SetEXP(
 			amount,
-			t->GetAAXP()
+			t->GetAAXP(),
+			ExpSource::GM
 		);
 	}
 

--- a/zone/groups.h
+++ b/zone/groups.h
@@ -76,7 +76,7 @@ public:
 	bool	IsGroup()			{ return true; }
 	void	SendGroupJoinOOZ(Mob* NewMember);
 	void	CastGroupSpell(Mob* caster,uint16 spellid);
-	void	SplitExp(const uint64 exp, Mob* other);
+	void	SplitExp(const uint64 exp, Mob* other, ExpSource exp_source);
 	void	GroupMessage(Mob* sender,uint8 language,uint8 lang_skill,const char* message);
 	void	GroupMessageString(Mob* sender, uint32 type, uint32 string_id, const char* message,const char* message2=0,const char* message3=0,const char* message4=0,const char* message5=0,const char* message6=0,const char* message7=0,const char* message8=0,const char* message9=0, uint32 distance = 0);
 	uint32	GetTotalGroupDamage(Mob* other);

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -252,27 +252,27 @@ void Lua_Client::SetDeity(int v) {
 
 void Lua_Client::AddEXP(uint32 add_exp) {
 	Lua_Safe_Call_Void();
-	self->AddEXP(add_exp);
+	self->AddEXP(add_exp, 0xFF, false, ExpSource::Quest);
 }
 
 void Lua_Client::AddEXP(uint32 add_exp, int conlevel) {
 	Lua_Safe_Call_Void();
-	self->AddEXP(add_exp, conlevel);
+	self->AddEXP(add_exp, conlevel, false, ExpSource::Quest);
 }
 
 void Lua_Client::AddEXP(uint32 add_exp, int conlevel, bool resexp) {
 	Lua_Safe_Call_Void();
-	self->AddEXP(add_exp, conlevel, resexp);
+	self->AddEXP(add_exp, conlevel, resexp, ExpSource::Quest);
 }
 
 void Lua_Client::SetEXP(uint64 set_exp, uint64 set_aaxp) {
 	Lua_Safe_Call_Void();
-	self->SetEXP(set_exp, set_aaxp);
+	self->SetEXP(set_exp, set_aaxp, false, ExpSource::Quest);
 }
 
 void Lua_Client::SetEXP(uint64 set_exp, uint64 set_aaxp, bool resexp) {
 	Lua_Safe_Call_Void();
-	self->SetEXP(set_exp, set_aaxp, resexp);
+	self->SetEXP(set_exp, set_aaxp, resexp, ExpSource::Quest);
 }
 
 void Lua_Client::SetBindPoint() {
@@ -1318,17 +1318,17 @@ uint32 Lua_Client::GetIP() {
 
 void Lua_Client::AddLevelBasedExp(int exp_pct) {
 	Lua_Safe_Call_Void();
-	self->AddLevelBasedExp(exp_pct);
+	self->AddLevelBasedExp(exp_pct, 0, false, ExpSource::Quest);
 }
 
 void Lua_Client::AddLevelBasedExp(int exp_pct, int max_level) {
 	Lua_Safe_Call_Void();
-	self->AddLevelBasedExp(exp_pct, max_level);
+	self->AddLevelBasedExp(exp_pct, max_level, false, ExpSource::Quest);
 }
 
 void Lua_Client::AddLevelBasedExp(int exp_pct, int max_level, bool ignore_mods) {
 	Lua_Safe_Call_Void();
-	self->AddLevelBasedExp(exp_pct, max_level, ignore_mods);
+	self->AddLevelBasedExp(exp_pct, max_level, ignore_mods, ExpSource::Quest);
 }
 
 void Lua_Client::IncrementAA(int aa) {

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -7852,4 +7852,21 @@ luabind::scope lua_register_journal_mode() {
 		)];
 }
 
+
+luabind::scope lua_register_exp_source() {
+	return luabind::class_<ExpSource>("ExpSource")
+		.enum_("constants")
+		[(
+			luabind::value("Unknown", static_cast<int>(ExpSource::Unknown)),
+			luabind::value("Quest", static_cast<int>(ExpSource::Quest)),
+			luabind::value("GM", static_cast<int>(ExpSource::GM)),
+			luabind::value("Kill", static_cast<int>(ExpSource::Kill)),
+			luabind::value("Death", static_cast<int>(ExpSource::Death)),
+			luabind::value("Resurrection", static_cast<int>(ExpSource::Resurrection)),
+			luabind::value("LDoNChest", static_cast<int>(ExpSource::LDoNChest)),
+			luabind::value("Task", static_cast<int>(ExpSource::Task)),
+			luabind::value("Sacrifice", static_cast<int>(ExpSource::Sacrifice))
+		)];
+}
+
 #endif

--- a/zone/lua_general.h
+++ b/zone/lua_general.h
@@ -23,6 +23,7 @@ luabind::scope lua_register_ruler();
 luabind::scope lua_register_ruleb();
 luabind::scope lua_register_journal_speakmode();
 luabind::scope lua_register_journal_mode();
+luabind::scope lua_register_exp_source();
 
 #endif
 #endif

--- a/zone/lua_group.cpp
+++ b/zone/lua_group.cpp
@@ -34,7 +34,7 @@ void Lua_Group::CastGroupSpell(Lua_Mob caster, int spell_id) {
 
 void Lua_Group::SplitExp(uint64 exp, Lua_Mob other) {
 	Lua_Safe_Call_Void();
-	self->SplitExp(exp, other);
+	self->SplitExp(exp, other, ExpSource::Quest);
 }
 
 void Lua_Group::GroupMessage(Lua_Mob sender, const char* message) {

--- a/zone/lua_mod.cpp
+++ b/zone/lua_mod.cpp
@@ -38,6 +38,8 @@ void LuaMod::Init()
 	m_has_common_outgoing_hit_success = parser_->HasFunction("CommonOutgoingHitSuccess", package_name_);
 	m_has_calc_spell_effect_value_formula = parser_->HasFunction("CalcSpellEffectValue_formula", package_name_);
 	m_has_register_bug = parser_->HasFunction("RegisterBug", package_name_);
+	m_has_set_exp = parser_->HasFunction("SetEXP", package_name_);
+	m_has_set_aa_exp = parser_->HasFunction("SetAAEXP", package_name_);
 }
 
 void PutDamageHitInfo(lua_State *L, luabind::adl::object &e, DamageHitInfo &hit) {
@@ -862,4 +864,111 @@ void LuaMod::HealDamage(Mob *self, Mob* caster, uint64 value, uint16 spell_id, u
 		lua_pop(L, n);
 	}
 }
+
+void LuaMod::SetEXP(Mob *self, ExpSource exp_source, uint64 current_exp, uint64 set_exp, bool is_rezz_exp, uint64 &return_value, bool &ignore_default)
+{
+	int start = lua_gettop(L);
+
+	try {
+		if (!m_has_set_exp) {
+			return;
+		}
+
+		lua_getfield(L, LUA_REGISTRYINDEX, package_name_.c_str());
+		lua_getfield(L, -1, "SetEXP");
+
+		Lua_Mob l_self(self);
+		luabind::adl::object e = luabind::newtable(L);
+		e["self"] = l_self;
+		e["exp_source"] = exp_source;
+		e["current_exp"] = current_exp;
+		e["set_exp"] = set_exp;
+		e["is_rezz_exp"] = is_rezz_exp;
+
+		e.push(L);
+
+		if (lua_pcall(L, 1, 1, 0)) {
+			std::string error = lua_tostring(L, -1);
+			parser_->AddError(error);
+			lua_pop(L, 2);
+			return;
+		}
+
+		if (lua_type(L, -1) == LUA_TTABLE) {
+			luabind::adl::object ret(luabind::from_stack(L, -1));
+			auto ignore_default_obj = ret["ignore_default"];
+			if (luabind::type(ignore_default_obj) == LUA_TBOOLEAN) {
+				ignore_default = ignore_default || luabind::object_cast<bool>(ignore_default_obj);
+			}
+
+			auto return_value_obj = ret["return_value"];
+			if (luabind::type(return_value_obj) == LUA_TNUMBER) {
+				return_value = luabind::object_cast<int64>(return_value_obj);
+			}
+		}
+	}
+	catch (std::exception &ex) {
+		parser_->AddError(ex.what());
+	}
+
+	int end = lua_gettop(L);
+	int n = end - start;
+	if (n > 0) {
+		lua_pop(L, n);
+	}
+}
+
+void LuaMod::SetAAEXP(Mob *self, ExpSource exp_source, uint64 current_aa_exp, uint64 set_aa_exp, bool is_rezz_exp, uint64 &return_value, bool &ignore_default)
+{
+	int start = lua_gettop(L);
+
+	try {
+		if (!m_has_set_aa_exp) {
+			return;
+		}
+
+		lua_getfield(L, LUA_REGISTRYINDEX, package_name_.c_str());
+		lua_getfield(L, -1, "SetAAExp");
+
+		Lua_Mob l_self(self);
+		luabind::adl::object e = luabind::newtable(L);
+		e["self"] = l_self;
+		e["exp_source"] = exp_source;
+		e["current_aa_exp"] = current_aa_exp;
+		e["set_aa_exp"] = set_aa_exp;
+		e["is_rezz_exp"] = is_rezz_exp;
+
+		e.push(L);
+
+		if (lua_pcall(L, 1, 1, 0)) {
+			std::string error = lua_tostring(L, -1);
+			parser_->AddError(error);
+			lua_pop(L, 2);
+			return;
+		}
+
+		if (lua_type(L, -1) == LUA_TTABLE) {
+			luabind::adl::object ret(luabind::from_stack(L, -1));
+			auto ignore_default_obj = ret["ignore_default"];
+			if (luabind::type(ignore_default_obj) == LUA_TBOOLEAN) {
+				ignore_default = ignore_default || luabind::object_cast<bool>(ignore_default_obj);
+			}
+
+			auto return_value_obj = ret["return_value"];
+			if (luabind::type(return_value_obj) == LUA_TNUMBER) {
+				return_value = luabind::object_cast<int64>(return_value_obj);
+			}
+		}
+	}
+	catch (std::exception &ex) {
+		parser_->AddError(ex.what());
+	}
+
+	int end = lua_gettop(L);
+	int n = end - start;
+	if (n > 0) {
+		lua_pop(L, n);
+	}
+}
+
 #endif

--- a/zone/lua_mod.cpp
+++ b/zone/lua_mod.cpp
@@ -928,7 +928,7 @@ void LuaMod::SetAAEXP(Mob *self, ExpSource exp_source, uint64 current_aa_exp, ui
 		}
 
 		lua_getfield(L, LUA_REGISTRYINDEX, package_name_.c_str());
-		lua_getfield(L, -1, "SetAAExp");
+		lua_getfield(L, -1, "SetAAEXP");
 
 		Lua_Mob l_self(self);
 		luabind::adl::object e = luabind::newtable(L);

--- a/zone/lua_mod.h
+++ b/zone/lua_mod.h
@@ -31,6 +31,8 @@ public:
 	void RegisterBug(Client *self, BaseBugReportsRepository::BugReports bug, bool &ignore_default);
 	void CommonDamage(Mob *self, Mob* attacker, int64 value, uint16 spell_id, int skill_used, bool avoidable, int8 buff_slot, bool buff_tic, int special, int64 &return_value, bool &ignore_default);
 	void HealDamage(Mob *self, Mob* caster, uint64 value, uint16 spell_id, uint64 &return_value, bool &ignore_default);
+	void SetEXP(Mob *self, ExpSource exp_source, uint64 current_exp, uint64 set_exp, bool is_rezz_exp, uint64 &return_value, bool &ignore_default);
+	void SetAAEXP(Mob *self, ExpSource exp_source, uint64 current_aa_exp, uint64 set_aa_exp, bool is_rezz_exp, uint64 &return_value, bool &ignore_default);
 private:
 	LuaParser *parser_;
 	lua_State *L;
@@ -49,4 +51,6 @@ private:
 	bool m_has_register_bug;
 	bool m_has_common_damage;
 	bool m_has_heal_damage;
+	bool m_has_set_exp;
+	bool m_has_set_aa_exp;
 };

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -1312,7 +1312,8 @@ void LuaParser::MapFunctions(lua_State *L) {
 			lua_register_journal_mode(),
 			lua_register_expedition(),
 			lua_register_expedition_lock_messages(),
-			lua_register_buff()
+			lua_register_buff(),
+			lua_register_exp_source()
 		)];
 
 	} catch(std::exception &ex) {
@@ -1617,6 +1618,26 @@ void LuaParser::RegisterBug(Client *self, BaseBugReportsRepository::BugReports b
 		mod.RegisterBug(self, bug, ignore_default);
 	}
 }
+
+
+uint64 LuaParser::SetEXP(Mob *self, ExpSource exp_source, uint64 current_exp, uint64 set_exp, bool is_rezz_exp, bool &ignore_default)
+{
+	uint64 retval = 0;
+	for (auto &mod : mods_) {
+		mod.SetEXP(self, exp_source, current_exp, set_exp, is_rezz_exp, retval, ignore_default);
+	}
+	return retval;
+}
+
+uint64 LuaParser::SetAAEXP(Mob *self, ExpSource exp_source, uint64 current_aa_exp, uint64 set_aa_exp, bool is_rezz_exp, bool &ignore_default)
+{
+	uint64 retval = 0;
+	for (auto &mod : mods_) {
+		mod.SetAAEXP(self, exp_source, current_aa_exp, set_aa_exp, is_rezz_exp, retval, ignore_default);
+	}
+	return retval;
+}
+
 
 int LuaParser::EventBot(
 	QuestEventID evt,

--- a/zone/lua_parser.h
+++ b/zone/lua_parser.h
@@ -201,6 +201,9 @@ public:
 	void RegisterBug(Client *self, BaseBugReportsRepository::BugReports bug, bool &ignore_default);
 	int64 CommonDamage(Mob *self, Mob* attacker, int64 value, uint16 spell_id, int skill_used, bool avoidable, int8 buff_slot, bool buff_tic, int special, bool &ignore_default);
 	uint64 HealDamage(Mob *self, Mob* caster, uint64 value, uint16 spell_id, bool &ignore_default);
+	uint64 SetEXP(Mob *self, ExpSource exp_source, uint64 current_exp, uint64 set_exp, bool is_rezz_exp, bool &ignore_default);
+	uint64 SetAAEXP(Mob *self, ExpSource exp_source, uint64 current_aa_exp, uint64 set_aa_exp, bool is_rezz_exp, bool &ignore_default);
+
 	
 private:
 	LuaParser();

--- a/zone/lua_raid.cpp
+++ b/zone/lua_raid.cpp
@@ -48,7 +48,7 @@ int Lua_Raid::GetGroup(Lua_Client c) {
 
 void Lua_Raid::SplitExp(uint64 exp, Lua_Mob other) {
 	Lua_Safe_Call_Void();
-	self->SplitExp(exp, other);
+	self->SplitExp(exp, other, ExpSource::Quest);
 }
 
 uint32 Lua_Raid::GetTotalRaidDamage(Lua_Mob other) {

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -216,27 +216,27 @@ void Perl_Client_SetDeity(Client* self, uint32 deity_id) // @categories Account 
 
 void Perl_Client_AddEXP(Client* self, uint32 add_exp) // @categories Experience and Level
 {
-	self->AddEXP(add_exp);
+	self->AddEXP(add_exp, 0xFF, false, ExpSource::Quest);
 }
 
 void Perl_Client_AddEXP(Client* self, uint32 add_exp, uint8 conlevel) // @categories Experience and Level
 {
-	self->AddEXP(add_exp, conlevel);
+	self->AddEXP(add_exp, conlevel, false, ExpSource::Quest);
 }
 
 void Perl_Client_AddEXP(Client* self, uint32 add_exp, uint8 conlevel, bool resexp) // @categories Experience and Level
 {
-	self->AddEXP(add_exp, conlevel, resexp);
+	self->AddEXP(add_exp, conlevel, resexp, ExpSource::Quest);
 }
 
 void Perl_Client_SetEXP(Client* self, uint64 set_exp, uint64 set_aaxp) // @categories Experience and Level
 {
-	self->SetEXP(set_exp, set_aaxp);
+	self->SetEXP(set_exp, set_aaxp, false, ExpSource::Quest);
 }
 
 void Perl_Client_SetEXP(Client* self, uint64 set_exp, uint64 set_aaxp, bool resexp) // @categories Experience and Level
 {
-	self->SetEXP(set_exp, set_aaxp, resexp);
+	self->SetEXP(set_exp, set_aaxp, resexp, ExpSource::Quest);
 }
 
 void Perl_Client_SetBindPoint(Client* self) // @categories Account and Character, Stats and Attributes
@@ -1280,17 +1280,17 @@ uint32_t Perl_Client_GetIP(Client* self) // @categories Script Utility
 
 void Perl_Client_AddLevelBasedExp(Client* self, uint8 exp_percentage) // @categories Experience and Level
 {
-	self->AddLevelBasedExp(exp_percentage);
+	self->AddLevelBasedExp(exp_percentage, 0, false, ExpSource::Quest);
 }
 
 void Perl_Client_AddLevelBasedExp(Client* self, uint8 exp_percentage, uint8 max_level) // @categories Experience and Level
 {
-	self->AddLevelBasedExp(exp_percentage, max_level);
+	self->AddLevelBasedExp(exp_percentage, max_level, false, ExpSource::Quest);
 }
 
 void Perl_Client_AddLevelBasedExp(Client* self, uint8 exp_percentage, uint8 max_level, bool ignore_mods) // @categories Experience and Level
 {
-	self->AddLevelBasedExp(exp_percentage, max_level, ignore_mods);
+	self->AddLevelBasedExp(exp_percentage, max_level, ignore_mods, ExpSource::Quest);
 }
 
 void Perl_Client_IncrementAA(Client* self, uint32 aa_skill_id) // @categories Alternative Advancement

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -1280,7 +1280,7 @@ uint32_t Perl_Client_GetIP(Client* self) // @categories Script Utility
 
 void Perl_Client_AddLevelBasedExp(Client* self, uint8 exp_percentage) // @categories Experience and Level
 {
-	self->AddLevelBasedExp(exp_percentage, 0, false, ExpSource::Quest);
+	self->AddLevelBasedExp(exp_percentage, 0xFF, false, ExpSource::Quest);
 }
 
 void Perl_Client_AddLevelBasedExp(Client* self, uint8 exp_percentage, uint8 max_level) // @categories Experience and Level

--- a/zone/perl_groups.cpp
+++ b/zone/perl_groups.cpp
@@ -29,7 +29,7 @@ void Perl_Group_CastGroupSpell(Group* self, Mob* caster, uint16 spell_id) // @ca
 
 void Perl_Group_SplitExp(Group* self, uint32_t exp, Mob* other) // @categories Account and Character, Script Utility, Group
 {
-	self->SplitExp(exp, other);
+	self->SplitExp(exp, other, ExpSource::Quest);
 }
 
 void Perl_Group_GroupMessage(Group* self, Mob* sender, const char* message) // @categories Script Utility, Group

--- a/zone/perl_raids.cpp
+++ b/zone/perl_raids.cpp
@@ -45,7 +45,7 @@ uint32_t Perl_Raid_GetGroup(Raid* self, Client* client) // @categories Group, Ra
 
 void Perl_Raid_SplitExp(Raid* self, uint32 experience, Mob* other) // @categories Experience and Level, Raid
 {
-	self->SplitExp(experience, other);
+	self->SplitExp(experience, other, ExpSource::Quest);
 }
 
 uint32_t Perl_Raid_GetTotalRaidDamage(Raid* self, Mob* other) // @categories Raid

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -1385,7 +1385,7 @@ void QuestManager::changedeity(int deity_id) {
 void QuestManager::exp(int amt) {
 	QuestManagerCurrentQuestVars();
 	if (initiator)
-		initiator->AddEXP(amt);
+		initiator->AddEXP(amt, 0xFF, false, ExpSource::Quest);
 }
 
 void QuestManager::level(int newlevel) {

--- a/zone/raids.h
+++ b/zone/raids.h
@@ -165,7 +165,7 @@ public:
 
 	void	RaidMessageString(Mob* sender, uint32 type, uint32 string_id, const char* message,const char* message2=0,const char* message3=0,const char* message4=0,const char* message5=0,const char* message6=0,const char* message7=0,const char* message8=0,const char* message9=0, uint32 distance = 0);
 	void	CastGroupSpell(Mob* caster,uint16 spellid, uint32 gid);
-	void	SplitExp(const uint64 exp, Mob* other);
+	void	SplitExp(const uint64 exp, Mob* other, ExpSource exp_source);
 	uint32	GetTotalRaidDamage(Mob* other);
 	void	BalanceHP(int32 penalty, uint32 gid, float range = 0, Mob* caster = nullptr, int32 limit = 0);
 	void	BalanceMana(int32 penalty, uint32 gid,  float range = 0, Mob* caster = nullptr, int32 limit = 0);

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -1091,14 +1091,14 @@ void ClientTaskState::RewardTask(Client *c, const TaskInformation *ti, ClientTas
 
 	auto experience_reward = ti->experience_reward;
 	if (experience_reward > 0) {
-		c->AddEXP(experience_reward);
+		c->AddEXP(experience_reward, 0xFF, false, ExpSource::Task);
 	} else if (experience_reward < 0) {
 		uint32 pos_reward = experience_reward * -1;
 		// Minimal Level Based Exp reward Setting is 101 (1% exp at level 1)
 		if (pos_reward > 100 && pos_reward < 25700) {
 			uint8 max_level   = pos_reward / 100;
 			uint8 exp_percent = pos_reward - (max_level * 100);
-			c->AddLevelBasedExp(exp_percent, max_level, RuleB(TaskSystem, ExpRewardsIgnoreLevelBasedEXPMods));
+			c->AddLevelBasedExp(exp_percent, max_level, RuleB(TaskSystem, ExpRewardsIgnoreLevelBasedEXPMods), ExpSource::Task);
 		}
 	}
 


### PR DESCRIPTION
# Description

This adds two new lua hooks, SetEXP and SetAAEXP.

Due to the nature of said functions, I also added a new constant called ExpSource, where each call of said functions pass a context on what source the exp gain or loss comes from. This was important because without it, it was difficult to identify why an EXP change occurred. This also causes this PR to touch a lot of files to add ExpSource context. 

An existing lua mod exists called `GetExperienceForKill`, but it is limited to only kills. This new lua mod allows you to recognize and change EXP from all origins. This granularity was needed for a server vision I had, and I believe this PR will be hugely beneficial for future custom servers as they want to add experience modifications via lua.

The new ExpSources I decided on were:
Unknown, - A fallback default value, so new entries that SetExp have a flag to note it is an unknown origin
Quest, - For any quest provided EXP tweaks
GM, - For when a GM command executs EXP tweaks
Kill, - For when a mob is killed
Death, - For when a client dies
Resurrection, - For when a client gets resurrected
LDoNChest, - For when an LDoN chest rewards exp
Task, - For when a task rewards exp. This is arguably similar to quest and some tasks may give exp via quest
Sacrifice - For when the Sacrifice AA skill is used (possibly necro skill too?), I made this unique since it's a pretty unique mechanic

Fixes # (issue)

No fixes
## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# Testing

This is still ongoing. I created the PR as a draft to allow others give feedback but please do not put this into master until I'm given more time to test it locally.

Clients tested: 

RoF2. Other clients likely won't be affected as this is a server side change.

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [ ] I have made corresponding changes to the documentation (if applicable, if not delete this line)
- [x] I own the changes of my code and take responsibility for the potential issues that occur
