### PR TITLE
[Spells] Normal Group Spells (non-raid) landed twice on caster

### DIFF
--- a/zone/groups.cpp
+++ b/zone/groups.cpp
@@ -793,7 +793,6 @@ bool Group::DelMember(Mob* oldmember, bool ignoresender)
 	return true;
 }
 
-// does the caster + group
 void Group::CastGroupSpell(Mob* caster, uint16 spell_id) {
 	uint32 z;
 	float range, distance;
@@ -806,8 +805,6 @@ void Group::CastGroupSpell(Mob* caster, uint16 spell_id) {
 
 	float range2 = range*range;
 	float min_range2 = spells[spell_id].min_range * spells[spell_id].min_range;
-
-//	caster->SpellOnTarget(spell_id, caster);
 
 	for(z=0; z < MAX_GROUP_MEMBERS; z++)
 	{

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -2669,7 +2669,7 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, CastingSlot slot, in
 					Group *target_group = entity_list.GetGroupByMob(spell_target);
 					if (target_group) {
 						target_group->CastGroupSpell(this, spell_id);
-						if (GetClass() != Class::Bard) {
+						if (target_group != GetGroup() && GetClass() != Class::Bard) {
 							SpellOnTarget(spell_id, this);
 						}
 					}


### PR DESCRIPTION
# Description

When casting group buffs (in a non-raid situation) the spell was being cast twice on the original caster.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

Before this fix, casting a spell like Pack Chloroplast or Group Resist magic landed on caster twice:

https://cdn.discordapp.com/attachments/736008216906825858/1224719140967944344/image.png?ex=661e8395&is=660c0e95&hm=191e4a949c1bec0404688f911619dda8a16ae7b690898092d39b7bf0dde4e6c4&

I tested after the fix.  I also went in and made sure this did not impact raids or non-grouped cases.   I also found and deleted a comment in Groups::CastGroupSpell() that was incorrect, and removed a line commented out long ago.

Clients tested: RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur

