### PR TITLE
[Bug Fix] Fix Account Flags Loading

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -343,7 +343,6 @@ Client::Client(EQStreamInterface *ieqs) : Mob(
 	XTargetAutoAddHaters = true;
 	m_autohatermgr.SetOwner(this, nullptr, nullptr);
 	m_activeautohatermgr = &m_autohatermgr;
-	LoadAccountFlags();
 
 	initial_respawn_selection = 0;
 	alternate_currency_loaded = false;

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -538,6 +538,7 @@ void Client::CompleteConnect()
 	EnteringMessages(this);
 	LoadPEQZoneFlags();
 	LoadZoneFlags();
+	LoadAccountFlags();
 
 	/* Sets GM Flag if needed & Sends Petition Queue */
 	UpdateAdmin(false);


### PR DESCRIPTION
# Description
- Account flags were getting an invalid account ID where they were loading prior so they were not properly loading.
- Mentioned [here](https://discord.com/channels/212663220849213441/1223795897809240145/1224113875822317710) by @JasXSL.

# Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
![image](https://github.com/EQEmu/Server/assets/89047260/49fa8bd7-d641-4047-b282-c9c69ca559c2)

# Perl Script
```pl
sub EVENT_SAY {
	if ($text=~/#a/i) {
		my @flags = $client->GetAccountFlags();
		my $flag_number = 1;
		if (!exists $flags[0]) {
			quest::message(315, "You do not have any flags.");
			return;
		}

		foreach my $flag (@flags) {
			my $flag_value = $client->GetAccountFlag($flag);
			quest::message(315, "$flag_number. $flag | $flag_value");
			$flag_number++;
		}
	}
}
```

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
