### PR TITLE
[Spells] SAP69 TotalHP can be used in Worn Slot, Fixes/Updates to Max HP related variables.

### DIFF
--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1003,7 +1003,6 @@ typedef enum {
 #define SE_AETaunt						206	// implemented
 #define SE_FleshToBone					207	// implemented
 //#define SE_PurgePoison				208	// not used
-//#define SE_PurgePoison				208	// not used
 #define SE_DispelBeneficial				209 // implemented, @Dispel, removes only beneficial effects on a target, base: pct chance (950=95%), limit: none, max: none
 #define SE_PetShield					210	// implmented, @ShieldAbility, allows pet to 'shield' owner for 50 pct of damage taken for a duration, base: Time multiplier 1=12 seconds, 2=24 ect, limit: mitigation on pet owner override (not on live), max: mitigation on pet overide (not on live)
 #define SE_AEMelee						211	// implemented TO DO: Implement to allow NPC use (client only atm).

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1003,6 +1003,7 @@ typedef enum {
 #define SE_AETaunt						206	// implemented
 #define SE_FleshToBone					207	// implemented
 //#define SE_PurgePoison				208	// not used
+//#define SE_PurgePoison				208	// not used
 #define SE_DispelBeneficial				209 // implemented, @Dispel, removes only beneficial effects on a target, base: pct chance (950=95%), limit: none, max: none
 #define SE_PetShield					210	// implmented, @ShieldAbility, allows pet to 'shield' owner for 50 pct of damage taken for a duration, base: Time multiplier 1=12 seconds, 2=24 ect, limit: mitigation on pet owner override (not on live), max: mitigation on pet overide (not on live)
 #define SE_AEMelee						211	// implemented TO DO: Implement to allow NPC use (client only atm).

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -938,7 +938,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 		case SE_IncreaseRange:
 			break;
 		case SE_MaxHPChange:
-			newbon->MaxHP += base_value;
+			newbon->PercentMaxHPChange += base_value;
 			break;
 		case SE_Packrat:
 			newbon->Packrat += base_value;
@@ -997,7 +997,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			newbon->BuffSlotIncrease += base_value;
 			break;
 		case SE_TotalHP:
-			newbon->HP += base_value;
+			newbon->FlatMaxHPChange += base_value;
 			break;
 		case SE_StunResist:
 			newbon->StunResist += base_value;
@@ -2237,7 +2237,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 
 			case SE_TotalHP:
 			{
-				new_bonus->HP += effect_value;
+				new_bonus->FlatMaxHPChange += effect_value;
 				break;
 			}
 
@@ -2919,7 +2919,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 			}
 
 			case SE_MaxHPChange:
-				new_bonus->MaxHPChange += effect_value;
+				new_bonus->PercentMaxHPChange += effect_value;
 				break;
 
 			case SE_EndurancePool:
@@ -4515,9 +4515,9 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 					break;
 
 				case SE_TotalHP:
-					if (negate_spellbonus) { spellbonuses.HP = effect_value; }
-					if (negate_aabonus) { aabonuses.HP = effect_value; }
-					if (negate_itembonus) { itembonuses.HP = effect_value; }
+					if (negate_spellbonus) { spellbonuses.FlatMaxHPChange = effect_value; }
+					if (negate_aabonus) { aabonuses.FlatMaxHPChange = effect_value; }
+					if (negate_itembonus) { itembonuses.FlatMaxHPChange = effect_value; }
 					break;
 
 				case SE_ManaRegen_v2:
@@ -4999,10 +4999,9 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 				}
 
 				case SE_MaxHPChange:
-					if (negate_spellbonus) { spellbonuses.MaxHPChange = effect_value; }
-					if (negate_aabonus) { aabonuses.MaxHPChange = effect_value; }
-					if (negate_aabonus) { aabonuses.MaxHP = effect_value; }
-					if (negate_itembonus) { itembonuses.MaxHPChange = effect_value; }
+					if (negate_spellbonus) { spellbonuses.PercentMaxHPChange = effect_value; }
+					if (negate_aabonus) { aabonuses.PercentMaxHPChange = effect_value; }
+					if (negate_itembonus) { itembonuses.PercentMaxHPChange = effect_value; }
 					break;
 
 				case SE_EndurancePool:

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -6235,9 +6235,9 @@ int64 Bot::CalcMaxHP() {
 	uint32 nd = 10000;
 	bot_hp += (GenerateBaseHitPoints() + itembonuses.HP);
 	bot_hp += itembonuses.heroic_max_hp;
-	nd += aabonuses.MaxHP + spellbonuses.MaxHPChange + itembonuses.MaxHPChange;
+	nd += aabonuses.PercentMaxHPChange + spellbonuses.PercentMaxHPChange + itembonuses.PercentMaxHPChange;
 	bot_hp = ((float)bot_hp * (float)nd / (float)10000);
-	bot_hp += (spellbonuses.HP + aabonuses.HP);
+	bot_hp += (spellbonuses.FlatMaxHPChange + aabonuses.FlatMaxHPChange + itembonuses.FlatMaxHPChange);
 	bot_hp += GroupLeadershipAAHealthEnhancement();
 	max_hp = bot_hp;
 	if (current_hp > max_hp)

--- a/zone/client_mods.cpp
+++ b/zone/client_mods.cpp
@@ -325,9 +325,7 @@ int64 Client::CalcMaxHP()
 	
 	nd += aabonuses.PercentMaxHPChange + spellbonuses.PercentMaxHPChange + itembonuses.PercentMaxHPChange;	//Natural Durability, Physical Enhancement, Planar Durability
 	max_hp = (float)max_hp * (float)nd / (float)10000; //this is to fix the HP-above-495k issue
-	
 	max_hp += spellbonuses.FlatMaxHPChange + aabonuses.FlatMaxHPChange + itembonuses.FlatMaxHPChange;
-	Shout("Get item bonus %i [item Worn %i] spell bonus %i [ max %i]", itembonuses.HP, itembonuses.FlatMaxHPChange, spellbonuses.FlatMaxHPChange, max_hp);
 
 	max_hp += GroupLeadershipAAHealthEnhancement();
 	if (current_hp > max_hp) {

--- a/zone/client_mods.cpp
+++ b/zone/client_mods.cpp
@@ -323,9 +323,11 @@ int64 Client::CalcMaxHP()
 	//to apply it to (basehp + itemhp).. I will oblige to the client's whims over
 	//the aa description
 	
-	nd += aabonuses.MaxHP + spellbonuses.MaxHPChange + itembonuses.MaxHPChange;	//Natural Durability, Physical Enhancement, Planar Durability (MaxHP and MaxHPChange are SPA214)
+	nd += aabonuses.PercentMaxHPChange + spellbonuses.PercentMaxHPChange + itembonuses.PercentMaxHPChange;	//Natural Durability, Physical Enhancement, Planar Durability
 	max_hp = (float)max_hp * (float)nd / (float)10000; //this is to fix the HP-above-495k issue
-	max_hp += spellbonuses.HP + aabonuses.HP;
+	
+	max_hp += spellbonuses.FlatMaxHPChange + aabonuses.FlatMaxHPChange + itembonuses.FlatMaxHPChange;
+	Shout("Get item bonus %i [item Worn %i] spell bonus %i [ max %i]", itembonuses.HP, itembonuses.FlatMaxHPChange, spellbonuses.FlatMaxHPChange, max_hp);
 
 	max_hp += GroupLeadershipAAHealthEnhancement();
 	if (current_hp > max_hp) {

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -16773,7 +16773,7 @@ void Client::RecordStats()
 	r.level                    = GetLevel();
 	r.class_                   = GetBaseClass();
 	r.race                     = GetBaseRace();
-	r.hp                       = GetMaxHP() - GetSpellBonuses().HP;
+	r.hp                       = GetMaxHP() - GetSpellBonuses().FlatMaxHPChange;
 	r.mana                     = GetMaxMana() - GetSpellBonuses().Mana;
 	r.endurance                = GetMaxEndurance() - GetSpellBonuses().Endurance;
 	r.ac                       = GetDisplayAC() - GetSpellBonuses().AC;

--- a/zone/common.h
+++ b/zone/common.h
@@ -412,7 +412,7 @@ struct StatBonuses {
 	int32	MeleeLifetap;						//i
 	int32	Vampirism;							//i
 	int32	HealRate;							// Spell effect that influences effectiveness of heals
-	int64	PercentMaxHPChange;					// percent change in hit points (aabonuses use variable MaxHP)
+	int64	PercentMaxHPChange;					// base: Max HP change by percentage value from spell effect/item worn effect/aa
 	int16	SkillDmgTaken[EQ::skills::HIGHEST_SKILL + 2];		// All Skills + -1
 	int32	HealAmt;							// Item Effect
 	int32	SpellDmg;							// Item Effect
@@ -512,7 +512,7 @@ struct StatBonuses {
 	uint8	invisibility_verse_undead;			// IVU level
 	uint8	invisibility_verse_animal;			// IVA level
 	int32	ShieldTargetSpa[2];                 // [0] base = % mitigation amount, [1] buff slot
-	int64	FlatMaxHPChange;					// base: Max HP change flat value from spell effect
+	int64	FlatMaxHPChange;					// base: Max HP change by a flat amount value from spell effect/item worn effect/aa
 
 	// AAs
 	int32	TrapCircumvention;					// reduce chance to trigger a trap.

--- a/zone/common.h
+++ b/zone/common.h
@@ -287,7 +287,6 @@ struct StatBonuses {
 	int32	AC;
 	int64	HP;
 	int64	HPRegen;
-	int64	MaxHP; //same bonus as MaxHPChange when applied to spells and item bonuses
 	int64	ManaRegen;
 	int64	EnduranceRegen;
 	int64	Mana;
@@ -413,7 +412,7 @@ struct StatBonuses {
 	int32	MeleeLifetap;						//i
 	int32	Vampirism;							//i
 	int32	HealRate;							// Spell effect that influences effectiveness of heals
-	int32	MaxHPChange;						// percent change in hit points (aabonuses use variable MaxHP)
+	int64	PercentMaxHPChange;					// percent change in hit points (aabonuses use variable MaxHP)
 	int16	SkillDmgTaken[EQ::skills::HIGHEST_SKILL + 2];		// All Skills + -1
 	int32	HealAmt;							// Item Effect
 	int32	SpellDmg;							// Item Effect
@@ -513,6 +512,7 @@ struct StatBonuses {
 	uint8	invisibility_verse_undead;			// IVU level
 	uint8	invisibility_verse_animal;			// IVA level
 	int32	ShieldTargetSpa[2];                 // [0] base = % mitigation amount, [1] buff slot
+	int64	FlatMaxHPChange;					// base: Max HP change flat value from spell effect
 
 	// AAs
 	int32	TrapCircumvention;					// reduce chance to trigger a trap.

--- a/zone/lua_stat_bonuses.cpp
+++ b/zone/lua_stat_bonuses.cpp
@@ -16,6 +16,11 @@ int64 Lua_StatBonuses::GetHP() const {
 	return self->HP;
 }
 
+int64 Lua_StatBonuses::GetFlatMaxHPChange() const {
+	Lua_Safe_Call_Int();
+	return self->FlatMaxHPChange;
+}
+
 int64 Lua_StatBonuses::GetHPRegen() const {
 	Lua_Safe_Call_Int();
 	return self->HPRegen;
@@ -23,7 +28,7 @@ int64 Lua_StatBonuses::GetHPRegen() const {
 
 int64 Lua_StatBonuses::GetMaxHP() const {
 	Lua_Safe_Call_Int();
-	return self->MaxHP;
+	return self->PercentMaxHPChange;
 }
 
 int64 Lua_StatBonuses::GetManaRegen() const {
@@ -608,7 +613,7 @@ int32 Lua_StatBonuses::GetHealRate() const {
 
 int32 Lua_StatBonuses::GetMaxHPChange() const {
 	Lua_Safe_Call_Int();
-	return self->MaxHPChange;
+	return self->PercentMaxHPChange;
 }
 
 int32 Lua_StatBonuses::GetHealAmt() const {
@@ -1381,6 +1386,7 @@ luabind::scope lua_register_stat_bonuses() {
 	.def("FeignedCastOnChance", &Lua_StatBonuses::GetFeignedCastOnChance)
 	.def("FinishingBlow", &Lua_StatBonuses::GetFinishingBlow)
 	.def("FinishingBlowLvl", &Lua_StatBonuses::GetFinishingBlowLvl)
+	.def("FlatMaxHPChange", &Lua_StatBonuses::GetFlatMaxHPChange)
 	.def("FlurryChance", &Lua_StatBonuses::GetFlurryChance)
 	.def("FocusEffects", &Lua_StatBonuses::GetFocusEffects)
 	.def("FocusEffectsWorn", &Lua_StatBonuses::GetFocusEffectsWorn)

--- a/zone/lua_stat_bonuses.h
+++ b/zone/lua_stat_bonuses.h
@@ -27,6 +27,7 @@ public:
 
 	int32 GetAC() const;
 	int64 GetHP() const;
+	int64 GetFlatMaxHPChange() const;
 	int64 GetHPRegen() const;
 	int64 GetMaxHP() const;
 	int64 GetManaRegen() const;

--- a/zone/merc.cpp
+++ b/zone/merc.cpp
@@ -461,10 +461,10 @@ int64 Merc::CalcMaxHP() {
 	//but the actual effect sent on live causes the client
 	//to apply it to (basehp + itemhp).. I will oblige to the client's whims over
 	//the aa description
-	nd += aabonuses.MaxHP + spellbonuses.MaxHPChange + itembonuses.MaxHPChange;  //Natural Durability, Physical Enhancement, Planar Durability
+	nd += aabonuses.PercentMaxHPChange + spellbonuses.PercentMaxHPChange + itembonuses.PercentMaxHPChange;  //Natural Durability, Physical Enhancement, Planar Durability
 
 	max_hp = (float)max_hp * (float)nd / (float)10000; //this is to fix the HP-above-495k issue
-	max_hp += spellbonuses.HP + aabonuses.HP;
+	max_hp += spellbonuses.FlatMaxHPChange + aabonuses.FlatMaxHPChange + itembonuses.FlatMaxHPChange;
 
 	max_hp += GroupLeadershipAAHealthEnhancement();
 

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -968,8 +968,8 @@ int64 Mob::CalcMaxHP() {
 int64 Mob::GetItemHPBonuses() {
 	int64 item_hp = 0;
 	item_hp = itembonuses.HP;
+	item_hp += item_hp * ((itembonuses.PercentMaxHPChange + spellbonuses.FlatMaxHPChange + aabonuses.FlatMaxHPChange) / 10000.0f);
 	item_hp += itembonuses.FlatMaxHPChange;
-	item_hp += item_hp * itembonuses.PercentMaxHPChange / 10000;
 	return item_hp;
 }
 

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -958,8 +958,9 @@ int64 Mob::CalcMaxMana()
 }
 
 int64 Mob::CalcMaxHP() {
-	max_hp = (base_hp + itembonuses.HP + spellbonuses.HP);
-	max_hp += max_hp * ((aabonuses.MaxHPChange + spellbonuses.MaxHPChange + itembonuses.MaxHPChange) / 10000.0f);
+	max_hp = (base_hp + itembonuses.HP);
+	max_hp += max_hp * ((aabonuses.PercentMaxHPChange + spellbonuses.PercentMaxHPChange + itembonuses.PercentMaxHPChange) / 10000.0f);
+	max_hp += spellbonuses.FlatMaxHPChange + itembonuses.FlatMaxHPChange + aabonuses.FlatMaxHPChange;
 
 	return max_hp;
 }
@@ -967,14 +968,15 @@ int64 Mob::CalcMaxHP() {
 int64 Mob::GetItemHPBonuses() {
 	int64 item_hp = 0;
 	item_hp = itembonuses.HP;
-	item_hp += item_hp * itembonuses.MaxHPChange / 10000;
+	item_hp = itembonuses.FlatMaxHPChange;
+	item_hp += item_hp * itembonuses.PercentMaxHPChange / 10000;
 	return item_hp;
 }
 
 int64 Mob::GetSpellHPBonuses() {
 	int64 spell_hp = 0;
-	spell_hp = spellbonuses.HP;
-	spell_hp += spell_hp * spellbonuses.MaxHPChange / 10000;
+	spell_hp = spellbonuses.FlatMaxHPChange;
+	spell_hp += spell_hp * spellbonuses.PercentMaxHPChange / 10000;
 	return spell_hp;
 }
 

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -969,7 +969,6 @@ int64 Mob::GetItemHPBonuses() {
 	int64 item_hp = 0;
 	item_hp = itembonuses.HP;
 	item_hp += item_hp * ((itembonuses.PercentMaxHPChange + spellbonuses.FlatMaxHPChange + aabonuses.FlatMaxHPChange) / 10000.0f);
-	item_hp += itembonuses.FlatMaxHPChange;
 	return item_hp;
 }
 

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -968,15 +968,15 @@ int64 Mob::CalcMaxHP() {
 int64 Mob::GetItemHPBonuses() {
 	int64 item_hp = 0;
 	item_hp = itembonuses.HP;
-	item_hp = itembonuses.FlatMaxHPChange;
+	item_hp += itembonuses.FlatMaxHPChange;
 	item_hp += item_hp * itembonuses.PercentMaxHPChange / 10000;
 	return item_hp;
 }
 
 int64 Mob::GetSpellHPBonuses() {
 	int64 spell_hp = 0;
-	spell_hp = spellbonuses.FlatMaxHPChange;
 	spell_hp += spell_hp * spellbonuses.PercentMaxHPChange / 10000;
+	spell_hp = spellbonuses.FlatMaxHPChange;
 	return spell_hp;
 }
 

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -975,8 +975,7 @@ int64 Mob::GetItemHPBonuses() {
 
 int64 Mob::GetSpellHPBonuses() {
 	int64 spell_hp = 0;
-	spell_hp += spell_hp * spellbonuses.PercentMaxHPChange / 10000;
-	spell_hp = spellbonuses.FlatMaxHPChange;
+	spell_hp += spellbonuses.FlatMaxHPChange;
 	return spell_hp;
 }
 

--- a/zone/perl_stat_bonuses.cpp
+++ b/zone/perl_stat_bonuses.cpp
@@ -16,6 +16,11 @@ int64 Perl_StatBonuses_GetHP(StatBonuses* self)
 	return self->HP;
 }
 
+int64 Perl_StatBonuses_GetFlatMaxHPChange(StatBonuses* self)
+{
+	return self->FlatMaxHPChange;
+}
+
 int64 Perl_StatBonuses_GetHPRegen(StatBonuses* self)
 {
 	return self->HPRegen;
@@ -23,7 +28,7 @@ int64 Perl_StatBonuses_GetHPRegen(StatBonuses* self)
 
 int64 Perl_StatBonuses_GetMaxHP(StatBonuses* self)
 {
-	return self->MaxHP;
+	return self->PercentMaxHPChange;
 }
 
 int64 Perl_StatBonuses_GetManaRegen(StatBonuses* self)
@@ -608,7 +613,7 @@ int32 Perl_StatBonuses_GetHealRate(StatBonuses* self)
 
 int32 Perl_StatBonuses_GetMaxHPChange(StatBonuses* self)
 {
-	return self->MaxHPChange;
+	return self->PercentMaxHPChange;
 }
 
 int32 Perl_StatBonuses_GetHealAmt(StatBonuses* self)
@@ -1532,6 +1537,7 @@ void perl_register_stat_bonuses()
 	package.add("GetStringedModifier", &Perl_StatBonuses_GetStringedModifier);
 	package.add("GetStunBashChance", &Perl_StatBonuses_GetStunBashChance);
 	package.add("GetStunResist", &Perl_StatBonuses_GetStunResist);
+	package.add("GetFlatMaxHPChange", &Perl_StatBonuses_GetFlatMaxHPChange);
 	package.add("GetTradeSkillMastery", &Perl_StatBonuses_GetTradeSkillMastery);
 	package.add("GetTriggerMeleeThreshold", &Perl_StatBonuses_GetTriggerMeleeThreshold);
 	package.add("GetTriggerOnValueAmount", &Perl_StatBonuses_GetTriggerOnValueAmount);


### PR DESCRIPTION
# Description

Added functionality to SPA 69 TotalHP (increases Max HP by a flat amount) to be able to be used as a Worn Effect. For example you could place spell 'Virtue' on an item in the worn effect and get a flat amount of hit points. This has utility because unlike regular item obtained hit points, hit points gained from SPA69 are not modified by bonuses from effects like AA Natural Durability (SPA214 which increase max HP by percent).

Source code changes were made to the variable names used to describe spell effect derived Max HP bonuses. We had multiple bonus variables doing the same thing, and were using same variable for Item hit points as spell effect hit points. Beyond being confusing. This would cause certain effects like the one that negates bonuses to remove item derived hit points instead of just spell/AA/worn effect derived. HP bonuses from spell effects now use their own consistent variables.

**Potential breaking change for quest functions in PERL/LUA using $stat_bonuses->GetHP()**
Prior to this update using these would return $item_bonuses as total HP from items, $spell_bonuses as HP from SPA69 buffs, and $aa_bonuses from SPA69 AAs. After this update, it will only return total HP from items.

Added new function, $stat_bonuses->GetFlatMaxTotalHP()
$spell_bonuses as HP from SPA69 buffs, and $aa_bonuses as HP from SPA69 AAs and $item_bonuses from SPA69 worn effects

To regain same functionality as having $stat_bonuses->GetHP() get the same total HP as before use
total_hp = $item_bonuses->GetHP() + $aa_bonuses->GetFlatMaxTotalHP() + $spell_bonuses->GetFlatMaxTotalHP()

Fixes # (issue)
SPA 69 could not be used as a worn effect
Mixed variable usage for Max HP made other effects that check for specific bonuses not work correctly.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) **(PERL/LUA CHANGE ABOVE)**

# Testing

Attach images and describe testing done to validate functionality.
![Screenshot (12)](https://github.com/EQEmu/Server/assets/6178028/50067280-f0b4-4529-a363-0b34ec1dd2a7)
![Screenshot (13)](https://github.com/EQEmu/Server/assets/6178028/917752ca-267e-4892-aa82-e0cadde50c12)

Clients tested: ROF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I have made corresponding changes to the documentation (if applicable, if not delete this line)
- [x] I own the changes of my code and take responsibility for the potential issues that occur

