### PR TITLE
[Bug Fix] Hero forge armor bug on login and show helm toggle.

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -278,8 +278,6 @@ Client::Client(EQStreamInterface *ieqs) : Mob(
 	if (RuleI(World, PVPMinLevel) > 0 && level >= RuleI(World, PVPMinLevel) && m_pp.pvp == 0) SetPVP(true, false);
 	dynamiczone_removal_timer.Disable();
 
-	heroforge_wearchange_timer.Disable();
-
 	//for good measure:
 	memset(&m_pp, 0, sizeof(m_pp));
 	memset(&m_epp, 0, sizeof(m_epp));

--- a/zone/client.h
+++ b/zone/client.h
@@ -1953,8 +1953,6 @@ private:
 	Timer task_request_timer;
 	Timer pick_lock_timer;
 
-	Timer heroforge_wearchange_timer;
-
 	glm::vec3 m_Proximity;
 	glm::vec4 last_position_before_bulk_update;
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -16011,11 +16011,10 @@ void Client::Handle_OP_WearChange(const EQApplicationPacket *app)
 		return;
 
 	// Hero Forge ID needs to be fixed here as RoF2 appears to send an incorrect value.
-	if (wc->hero_forge_model != 0 && wc->wear_slot_id >= 0 && wc->wear_slot_id < EQ::textures::weaponPrimary)
+	if (wc->wear_slot_id >= 0 && wc->wear_slot_id < EQ::textures::weaponPrimary)
 		wc->hero_forge_model = GetHerosForgeModel(wc->wear_slot_id);
 
-	// we could maybe ignore this and just send our own from moveitem
-	entity_list.QueueClients(this, app, true);
+	entity_list.QueueClients(this, app, false);
 }
 
 void Client::Handle_OP_WhoAllRequest(const EQApplicationPacket *app)

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -758,7 +758,10 @@ void Client::CompleteConnect()
 	entity_list.SendTraders(this);
 
 	Mob *pet = GetPet();
+	SendWearChangeAndLighting(EQ::textures::LastTexture);
+	Mob* pet = GetPet();
 	if (pet) {
+		pet->SendWearChangeAndLighting(EQ::textures::LastTexture);
 		pet->SendPetBuffsToClient();
 	}
 
@@ -950,8 +953,6 @@ void Client::CompleteConnect()
 		worldserver.SendPacket(p);
 		safe_delete(p);
 	}
-
-	heroforge_wearchange_timer.Start(250);
 
 	RecordStats();
 	AutoGrantAAPoints();
@@ -16014,6 +16015,7 @@ void Client::Handle_OP_WearChange(const EQApplicationPacket *app)
 	if (wc->wear_slot_id >= 0 && wc->wear_slot_id < EQ::textures::weaponPrimary)
 		wc->hero_forge_model = GetHerosForgeModel(wc->wear_slot_id);
 
+	// we could maybe ignore this and just send our own from moveitem
 	entity_list.QueueClients(this, app, false);
 }
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -757,7 +757,6 @@ void Client::CompleteConnect()
 
 	entity_list.SendTraders(this);
 
-	Mob *pet = GetPet();
 	SendWearChangeAndLighting(EQ::textures::LastTexture);
 	Mob* pet = GetPet();
 	if (pet) {

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -213,25 +213,6 @@ bool Client::Process() {
 			instalog = true;
 		}
 
-		if (heroforge_wearchange_timer.Check()) {
-			/*
-				This addresses bug where on zone in heroforge models would not be sent to other clients when this was
-				in Client::CompleteConnect(). Sending after a small 250 ms delay after that function resolves the issue.
-				Unclear the underlying reason for this, if a better solution can be found then can move this back.
-			*/
-			if (queue_wearchange_slot >= 0) { //Resend slot from Client::SwapItem if heroforge item is swapped.
-				SendWearChange(static_cast<uint8>(queue_wearchange_slot));
-			}
-			else { //Send from Client::CompleteConnect()
-				SendWearChangeAndLighting(EQ::textures::LastTexture);
-				Mob *pet = GetPet();
-				if (pet) {
-					pet->SendWearChangeAndLighting(EQ::textures::LastTexture);
-				}
-			}
-			heroforge_wearchange_timer.Disable();
-		}
-
 		if (IsStunned() && stunned_timer.Check())
 			Mob::UnStun();
 

--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -2258,10 +2258,6 @@ bool Client::SwapItem(MoveItem_Struct* move_in) {
 	if (dst_slot_id <= EQ::invslot::EQUIPMENT_END) {// on Titanium and ROF2 /showhelm works even if sending helm slot
 		SendWearChange(matslot);
 	}
-	// This is part of a bug fix to ensure heroforge graphics display to other clients in zone.
-	if (queue_wearchange_slot >= 0) {
-		heroforge_wearchange_timer.Start(100);
-	}
 
 	// Step 7: Save change to the database
 	if (src_slot_id == EQ::invslot::slotCursor) {

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -506,8 +506,6 @@ Mob::Mob(
 	use_double_melee_round_dmg_bonus = false;
 	dw_same_delay                    = 0;
 
-	queue_wearchange_slot = -1;
-
 	m_manual_follow = false;
 
 	mob_close_scan_timer.Trigger();

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1668,8 +1668,6 @@ protected:
 	int32 appearance_effects_id[MAX_APPEARANCE_EFFECTS];
 	int32 appearance_effects_slot[MAX_APPEARANCE_EFFECTS];
 
-	int queue_wearchange_slot;
-
 	Timer shield_timer;
 	uint32 m_shield_target_id;
 	uint32 m_shielder_id;

--- a/zone/mob_appearance.cpp
+++ b/zone/mob_appearance.cpp
@@ -399,9 +399,6 @@ void Mob::SendWearChange(uint8 material_slot, Client *one_client)
 
 	w->wear_slot_id = material_slot;
 
-	// Part of a bug fix to ensure heroforge models send to other clients in zone.
-	queue_wearchange_slot = w->hero_forge_model ? material_slot : -1;
-
 	if (!one_client) {
 		entity_list.QueueClients(this, packet);
 	} else {


### PR DESCRIPTION
# Description

1. Other clients witnessing a new client that is wearing Hero Forge armor would not see the armor until a zone or re-equip.
2. A character wearing hero forge armor on head would lose the model when toggling show helm.

HELP!!
**This fix potentially removes the need for the heroforge_wearchange_timer which is set in Client::CompleteConnect().  Changing that timer to be longer also fixes the problem, but was not the root cause.  I would love some expert opinion on if taking that timer out completely is advisable.**

@KayenEQ 

https://github.com/EQEmu/Server/pull/1883

HELP!!

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

Video showing bug [here](http://norrath.no-ip.org/herob4.mp4).
Video showing fix [here](http://norrath.no-ip.org/heroafter.mp4).

Clients tested:  ROF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur

