### PR TITLE
[Messages] Fix bug where DoT messages stop coming out when mob dies.

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -4677,9 +4677,9 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 	else {
 		//else, it is a buff tic...
 		// So we can see our dot dmg like live shows it.
-		if (IsValidSpell(spell_id) && damage > 0 && attacker && attacker != this && !attacker->IsCorpse()) {
+		if (IsValidSpell(spell_id) && damage > 0 && attacker && attacker != this) {
 			//might filter on (attack_skill>200 && attack_skill<250), but I dont think we need it
-			if (attacker->IsClient()) {
+			if (!attacker->IsCorpse() && attacker->IsClient()) {
 				attacker->FilteredMessageString(attacker, Chat::DotDamage,
 					FilterDOT, YOUR_HIT_DOT, GetCleanName(), itoa(damage),
 					spells[spell_id].name);


### PR DESCRIPTION
# Description

My old PR #2289 accidentally removed messages for DoTs that are cast by NPCs on PCs after the NPC dies.

On live:

![image](https://github.com/EQEmu/Server/assets/8644833/b7a5dd66-e186-480e-bae7-0a1b3d1a4ab9)

We now match this.

Additionally I created an issue #4248 because its always been true on live that DoTs live past the corpse.  That change on eqemu is larger in scale and I think should be separate from this PR.  On live, the damage still occurs and looks like this:

![image](https://github.com/EQEmu/Server/assets/8644833/549b07cb-1fd5-45a5-896a-7ef47bdea47a)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

Killed a mob after getting DoTTed and made sure damage was getting done and we got the messages again.

Clients tested: RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur

