### PR TITLE
[Performance] Change skill_cap from vector to map

### DIFF
--- a/common/skill_caps.cpp
+++ b/common/skill_caps.cpp
@@ -40,7 +40,7 @@ uint8 SkillCaps::GetTrainLevel(uint8 class_id, EQ::skills::SkillType skill_id, u
 
 	for (const auto &e: m_skill_caps) {
 		for (uint8 current_level = 1; current_level <= max_level; current_level++) {
-			auto pos = m_skill_caps.find(fmt::format("{}-{}-{}", class_id, level, skill_id));
+			auto pos = m_skill_caps.find(fmt::format("{}-{}-{}", class_id, current_level, skill_id));
 			if (pos != m_skill_caps.end()) {
 				return current_level;
 			}

--- a/common/skill_caps.cpp
+++ b/common/skill_caps.cpp
@@ -13,16 +13,10 @@ SkillCapsRepository::SkillCaps SkillCaps::GetSkillCap(uint8 class_id, EQ::skills
 		return SkillCapsRepository::NewEntity();
 	}
 
-	for (const auto &e: m_skill_caps) {
-		if (
-			e.class_id == class_id &&
-			e.level == level &&
-			static_cast<EQ::skills::SkillType>(e.skill_id) == skill_id
-			) {
-			return e;
-		}
+	auto pos = m_skill_caps.find(fmt::format("{}-{}-{}", class_id, level, skill_id));
+	if (pos != m_skill_caps.end()) {
+		return pos->second;
 	}
-
 	return SkillCapsRepository::NewEntity();
 }
 
@@ -46,11 +40,8 @@ uint8 SkillCaps::GetTrainLevel(uint8 class_id, EQ::skills::SkillType skill_id, u
 
 	for (const auto &e: m_skill_caps) {
 		for (uint8 current_level = 1; current_level <= max_level; current_level++) {
-			if (
-				e.class_id == class_id &&
-				static_cast<EQ::skills::SkillType>(e.skill_id) == skill_id &&
-				e.level == current_level
-				) {
+			auto pos = m_skill_caps.find(fmt::format("{}-{}-{}", class_id, level, skill_id));
+			if (pos != m_skill_caps.end()) {
 				return current_level;
 			}
 		}
@@ -63,7 +54,7 @@ void SkillCaps::LoadSkillCaps()
 {
 	const auto &l = SkillCapsRepository::All(*m_content_database);
 
-	m_skill_caps.reserve(l.size());
+	m_skill_caps.clear();
 
 	for (const auto &e: l) {
 		if (
@@ -74,7 +65,7 @@ void SkillCaps::LoadSkillCaps()
 			continue;
 		}
 
-		m_skill_caps.emplace_back(e);
+		m_skill_caps[fmt::format("{}-{}-{}", e.class_id, e.level, e.skill_id)] = e;
 	}
 
 	LogInfo(

--- a/common/skill_caps.cpp
+++ b/common/skill_caps.cpp
@@ -13,7 +13,8 @@ SkillCapsRepository::SkillCaps SkillCaps::GetSkillCap(uint8 class_id, EQ::skills
 		return SkillCapsRepository::NewEntity();
 	}
 
-	auto pos = m_skill_caps.find(fmt::format("{}-{}-{}", class_id, level, skill_id));
+	uint64_t key = class_id * 1000000 + level * 1000 + static_cast<uint32>(skill_id);
+	auto pos = m_skill_caps.find(key);
 	if (pos != m_skill_caps.end()) {
 		return pos->second;
 	}
@@ -40,7 +41,8 @@ uint8 SkillCaps::GetTrainLevel(uint8 class_id, EQ::skills::SkillType skill_id, u
 
 	for (const auto &e: m_skill_caps) {
 		for (uint8 current_level = 1; current_level <= max_level; current_level++) {
-			auto pos = m_skill_caps.find(fmt::format("{}-{}-{}", class_id, current_level, skill_id));
+			uint64_t key = class_id * 1000000 + level * 1000 + static_cast<uint32>(skill_id);
+			auto pos = m_skill_caps.find(key);
 			if (pos != m_skill_caps.end()) {
 				return current_level;
 			}
@@ -65,7 +67,8 @@ void SkillCaps::LoadSkillCaps()
 			continue;
 		}
 
-		m_skill_caps[fmt::format("{}-{}-{}", e.class_id, e.level, e.skill_id)] = e;
+		uint64_t key = e.class_id * 1000000 + e.level * 1000 + e.skill_id;
+		m_skill_caps[key] = e;
 	}
 
 	LogInfo(

--- a/common/skill_caps.cpp
+++ b/common/skill_caps.cpp
@@ -13,7 +13,7 @@ SkillCapsRepository::SkillCaps SkillCaps::GetSkillCap(uint8 class_id, EQ::skills
 		return SkillCapsRepository::NewEntity();
 	}
 
-	uint64_t key = class_id * 1000000 + level * 1000 + static_cast<uint32>(skill_id);
+	uint64_t key = (class_id * 1000000) + (level * 1000) + static_cast<uint32>(skill_id);
 	auto pos = m_skill_caps.find(key);
 	if (pos != m_skill_caps.end()) {
 		return pos->second;
@@ -41,7 +41,7 @@ uint8 SkillCaps::GetTrainLevel(uint8 class_id, EQ::skills::SkillType skill_id, u
 
 	for (const auto &e: m_skill_caps) {
 		for (uint8 current_level = 1; current_level <= max_level; current_level++) {
-			uint64_t key = class_id * 1000000 + level * 1000 + static_cast<uint32>(skill_id);
+			uint64_t key = (class_id * 1000000) + (level * 1000) + static_cast<uint32>(skill_id);
 			auto pos = m_skill_caps.find(key);
 			if (pos != m_skill_caps.end()) {
 				return current_level;
@@ -67,7 +67,7 @@ void SkillCaps::LoadSkillCaps()
 			continue;
 		}
 
-		uint64_t key = e.class_id * 1000000 + e.level * 1000 + e.skill_id;
+		uint64_t key = (e.class_id * 1000000) + (e.level * 1000) + e.skill_id;
 		m_skill_caps[key] = e;
 	}
 

--- a/common/skill_caps.h
+++ b/common/skill_caps.h
@@ -17,7 +17,7 @@ public:
 	SkillCaps *SetContentDatabase(Database *db);
 private:
 	Database                                    *m_content_database{};
-	std::vector<SkillCapsRepository::SkillCaps> m_skill_caps = {};
+	std::map<std::string, SkillCapsRepository::SkillCaps> m_skill_caps = {};
 };
 
 extern SkillCaps skill_caps;

--- a/common/skill_caps.h
+++ b/common/skill_caps.h
@@ -17,7 +17,7 @@ public:
 	SkillCaps *SetContentDatabase(Database *db);
 private:
 	Database                                    *m_content_database{};
-	std::map<std::string, SkillCapsRepository::SkillCaps> m_skill_caps = {};
+	std::map<uint64, SkillCapsRepository::SkillCaps> m_skill_caps = {};
 };
 
 extern SkillCaps skill_caps;


### PR DESCRIPTION
# Description

Prior CPU load was high on skill caps

Fixes # N/A

## Type of change

Changes a vector to a map

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing
before this fix:
![image](https://github.com/EQEmu/Server/assets/845670/890e9448-c89f-4f92-a77a-eed1d6f704d2)


after this fix:
![image](https://github.com/EQEmu/Server/assets/845670/280381f0-4a46-4f67-b145-91a85f6115da)

message details seen here: https://discord.com/channels/212663220849213441/557677602706423982/1228873494671130684


Clients tested:  RoF2, client shouldn't be applicable, it's a server side fix

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur