### PR TITLE
[Quest API] Add GetConsiderColor() to Perl/Lua

### DIFF
--- a/common/emu_constants.cpp
+++ b/common/emu_constants.cpp
@@ -714,3 +714,25 @@ std::string EQ::constants::GetSpecialAbilityName(uint32 ability_id)
 
 	return std::string();
 }
+
+const std::map<uint32, std::string>& EQ::constants::GetConsiderColorMap()
+{
+	static const std::map<uint32, std::string> consider_color_map = {
+		{ ConsiderColor::Green,         "Green" },
+		{ ConsiderColor::DarkBlue,      "Dark Blue" },
+		{ ConsiderColor::Gray,          "Gray" },
+		{ ConsiderColor::White,         "White" },
+		{ ConsiderColor::Red,           "Red" },
+		{ ConsiderColor::Yellow,        "Yellow" },
+		{ ConsiderColor::LightBlue,     "Light Blue" },
+		{ ConsiderColor::WhiteTitanium, "White" },
+	};
+
+	return consider_color_map;
+}
+
+std::string EQ::constants::GetConsiderColorName(uint32 consider_color)
+{
+	const auto& c = EQ::constants::GetConsiderColorMap().find(consider_color);
+	return c != EQ::constants::GetConsiderColorMap().end() ? c->second : std::string();
+}

--- a/common/emu_constants.h
+++ b/common/emu_constants.h
@@ -404,6 +404,9 @@ namespace EQ
 		extern const std::map<uint32, std::string>& GetSpecialAbilityMap();
 		std::string GetSpecialAbilityName(uint32 ability_id);
 
+		extern const std::map<uint32, std::string>& GetConsiderColorMap();
+		std::string GetConsiderColorName(uint32 consider_color);
+
 		const int STANCE_TYPE_FIRST = stancePassive;
 		const int STANCE_TYPE_LAST = stanceBurnAE;
 		const int STANCE_TYPE_COUNT = stanceBurnAE;
@@ -557,6 +560,17 @@ enum ConsiderLevel : uint8 {
 	Dubiously,
 	Threateningly,
 	Scowls
+};
+
+namespace ConsiderColor {
+	constexpr uint32 Green         = 2;
+	constexpr uint32 DarkBlue      = 4;
+	constexpr uint32 Gray          = 6;
+	constexpr uint32 White         = 10;
+	constexpr uint32 Red           = 13;
+	constexpr uint32 Yellow        = 15;
+	constexpr uint32 LightBlue     = 18;
+	constexpr uint32 WhiteTitanium = 20;
 };
 
 enum TargetDescriptionType : uint8 {

--- a/zone/aggro.cpp
+++ b/zone/aggro.cpp
@@ -221,7 +221,7 @@ void NPC::DescribeAggro(Client *to_who, Mob *mob, bool verbose) {
 	if (RuleB(Aggro, UseLevelAggro)) {
 		if (
 			GetLevel() < RuleI(Aggro, MinAggroLevel) &&
-			mob->GetLevelCon(GetLevel()) == CON_GRAY &&
+			mob->GetLevelCon(GetLevel()) == ConsiderColor::Gray &&
 			GetBodyType() != BT_Undead &&
 			!AlwaysAggro()
 		) {
@@ -237,7 +237,7 @@ void NPC::DescribeAggro(Client *to_who, Mob *mob, bool verbose) {
 	} else {
 		if (
 			GetINT() > RuleI(Aggro, IntAggroThreshold) &&
-			mob->GetLevelCon(GetLevel()) == CON_GRAY &&
+			mob->GetLevelCon(GetLevel()) == ConsiderColor::Gray &&
 			!AlwaysAggro()
 		) {
 			to_who->Message(
@@ -502,7 +502,7 @@ bool Mob::CheckWillAggro(Mob *mob) {
 				mob->IsClient() &&
 				mob->CastToClient()->IsSitting()
 			) ||
-			mob->GetLevelCon(GetLevel()) != CON_GRAY
+			mob->GetLevelCon(GetLevel()) != ConsiderColor::Gray
 		) &&
 		(
 			faction_value == FACTION_SCOWLS ||
@@ -531,7 +531,7 @@ bool Mob::CheckWillAggro(Mob *mob) {
 					mob->IsClient() &&
 					mob->CastToClient()->IsSitting()
 				) ||
-				mob->GetLevelCon(GetLevel()) != CON_GRAY
+				mob->GetLevelCon(GetLevel()) != ConsiderColor::Gray
 			) &&
 			(
 				faction_value == FACTION_SCOWLS	||
@@ -586,7 +586,7 @@ int EntityList::GetHatedCount(Mob *attacker, Mob *exclude, bool inc_gray_con)
 			continue;
 		}
 
-		if (!inc_gray_con && attacker->GetLevelCon(mob->GetLevel()) == CON_GRAY) {
+		if (!inc_gray_con && attacker->GetLevelCon(mob->GetLevel()) == ConsiderColor::Gray) {
 			continue;
 		}
 

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2720,7 +2720,7 @@ bool NPC::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillTy
 			if (!is_ldon_treasure && !MerchantType) {
 				const uint32 con_level = give_exp->GetLevelCon(GetLevel());
 
-				if (con_level != CON_GRAY) {
+				if (con_level != ConsiderColor::Gray) {
 					if (!GetOwner() || (GetOwner() && !GetOwner()->IsClient())) {
 						give_exp_client->AddEXP(final_exp, con_level);
 
@@ -6322,10 +6322,10 @@ void Mob::CommonOutgoingHitSuccess(Mob* defender, DamageHitInfo &hit, ExtraAttac
 		bool use_shield_ability = true;
 		//If defender is being shielded by an ability AND has a shield spell effect buff use highest mitigation value.
 		if ((defender->GetShieldTargetMitigation() && defender->spellbonuses.ShieldTargetSpa[SBIndex::SHIELD_TARGET_MITIGATION_PERCENT]) &&
-			 (defender->spellbonuses.ShieldTargetSpa[SBIndex::SHIELD_TARGET_MITIGATION_PERCENT] >= defender->GetShieldTargetMitigation())){ 
+			 (defender->spellbonuses.ShieldTargetSpa[SBIndex::SHIELD_TARGET_MITIGATION_PERCENT] >= defender->GetShieldTargetMitigation())){
 				bool use_shield_ability = false;
 		}
-	
+
 		//use targeted /shield ability values
 		if (defender->GetShielderID() && use_shield_ability) {
 			DoShieldDamageOnShielder(defender, hit.damage_done, hit.skill);
@@ -6387,14 +6387,14 @@ void Mob::DoShieldDamageOnShielderSpellEffect(Mob* shield_target, int64 hit_dama
 	}
 	/*
 		SPA 463 SE_SHIELD_TARGET
-		
-		Live description: "Shields your target, taking a percentage of their damage". 
+
+		Live description: "Shields your target, taking a percentage of their damage".
 		Only example spell on live is an NPC who uses it during a raid event "Laurion's Song" expansion. SPA 54492 'Guardian Stance' Described as 100% Melee Shielding
-		
+
 		Example of mechanic. Base value = 70. Caster puts buff on target. Each melee hit Buff Target takes 70% less damage, Buff Caster receives 30% of the melee damage.
 		Added mechanic to cause buff to fade if target or caster are seperated by a distance greater than the casting range of the spell. This allows similiar mechanics
 		to the /shield ability, without a range removal mechanic it would be too easy to abuse if put on a player spell. *can not confirm live does this currently
-		
+
 		Can not be cast on self.
 	*/
 

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -7366,23 +7366,23 @@ void EntityList::ShowSpawnWindow(Client* client, int Distance, bool NamedOnly) {
 
 					LastCon = CurrentCon;
 					switch(CurrentCon) {
-						case CON_GREEN: {
+						case ConsiderColor::Green: {
 							WindowText += "<c \"#00FF00\">";
 							break;
 						}
-						case CON_LIGHTBLUE: {
+						case ConsiderColor::LightBlue: {
 							WindowText += "<c \"#8080FF\">";
 							break;
 						}
-						case CON_BLUE: {
+						case ConsiderColor::DarkBlue: {
 							WindowText += "<c \"#2020FF\">";
 							break;
 						}
-						case CON_YELLOW: {
+						case ConsiderColor::Yellow: {
 							WindowText += "<c \"#FFFF00\">";
 							break;
 						}
-						case CON_RED: {
+						case ConsiderColor::Red: {
 							WindowText += "<c \"#FF0000\">";
 							break;
 						}

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -2660,7 +2660,7 @@ bool Client::CheckIncreaseSkill(EQ::skills::SkillType skillid, Mob *against_who,
 			against_who->GetSpecialAbility(IMMUNE_AGGRO) ||
 			against_who->GetSpecialAbility(IMMUNE_AGGRO_CLIENT) ||
 			against_who->IsClient() ||
-			GetLevelCon(against_who->GetLevel()) == CON_GRAY
+			GetLevelCon(against_who->GetLevel()) == ConsiderColor::Gray
 		) {
 			return false;
 		}

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -5189,10 +5189,10 @@ void Client::Handle_OP_Consider(const EQApplicationPacket *app)
 	con->level = GetLevelCon(t->GetLevel());
 
 	if (ClientVersion() <= EQ::versions::ClientVersion::Titanium) {
-		if (con->level == CON_GRAY) {
-			con->level = CON_GREEN;
-		} else if (con->level == CON_WHITE) {
-			con->level = CON_WHITE_TITANIUM;
+		if (con->level == ConsiderColor::Gray) {
+			con->level = ConsiderColor::Green;
+		} else if (con->level == ConsiderColor::White) {
+			con->level = ConsiderColor::WhiteTitanium;
 		}
 	}
 
@@ -5233,26 +5233,26 @@ void Client::Handle_OP_Consider(const EQApplicationPacket *app)
 	if (t->IsRaidTarget()) {
 		uint32 color = 0;
 		switch (con->level) {
-			case CON_GREEN:
+			case ConsiderColor::Green:
 				color = 2;
 				break;
-			case CON_LIGHTBLUE:
+			case ConsiderColor::LightBlue:
 				color = 10;
 				break;
-			case CON_BLUE:
+			case ConsiderColor::DarkBlue:
 				color = 4;
 				break;
-			case CON_WHITE_TITANIUM:
-			case CON_WHITE:
+			case ConsiderColor::WhiteTitanium:
+			case ConsiderColor::White:
 				color = 10;
 				break;
-			case CON_YELLOW:
+			case ConsiderColor::Yellow:
 				color = 15;
 				break;
-			case CON_RED:
+			case ConsiderColor::Red:
 				color = 13;
 				break;
-			case CON_GRAY:
+			case ConsiderColor::Gray:
 				color = 6;
 				break;
 		}

--- a/zone/common.h
+++ b/zone/common.h
@@ -25,15 +25,6 @@ namespace Archetype {
 	constexpr uint8 Melee  = 3;
 };
 
-#define CON_GREEN		2
-#define CON_LIGHTBLUE	18
-#define CON_BLUE		4
-#define CON_WHITE		10
-#define CON_WHITE_TITANIUM		20
-#define CON_YELLOW		15
-#define CON_RED			13
-#define CON_GRAY		6
-
 #define DMG_BLOCKED		-1
 #define DMG_PARRIED		-2
 #define DMG_RIPOSTED		-3

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -146,25 +146,25 @@ uint64 Client::CalcEXP(uint8 consider_level, bool ignore_modifiers) {
 	if (RuleB(Character,UseXPConScaling)) {
 		if (consider_level != 0xFF) {
 			switch (consider_level) {
-				case CON_GRAY:
+				case ConsiderColor::Gray:
 					in_add_exp = 0;
 					return 0;
-				case CON_GREEN:
+				case ConsiderColor::Green:
 					in_add_exp = in_add_exp * RuleI(Character, GreenModifier) / 100;
 					break;
-				case CON_LIGHTBLUE:
+				case ConsiderColor::LightBlue:
 					in_add_exp = in_add_exp * RuleI(Character, LightBlueModifier) / 100;
 					break;
-				case CON_BLUE:
+				case ConsiderColor::DarkBlue:
 					in_add_exp = in_add_exp * RuleI(Character, BlueModifier) / 100;
 					break;
-				case CON_WHITE:
+				case ConsiderColor::White:
 					in_add_exp = in_add_exp * RuleI(Character, WhiteModifier) / 100;
 					break;
-				case CON_YELLOW:
+				case ConsiderColor::Yellow:
 					in_add_exp = in_add_exp * RuleI(Character, YellowModifier) / 100;
 					break;
-				case CON_RED:
+				case ConsiderColor::Red:
 					in_add_exp = in_add_exp * RuleI(Character, RedModifier) / 100;
 					break;
 			}
@@ -222,22 +222,22 @@ float static GetConLevelModifierPercent(uint8 conlevel)
 {
 	switch (conlevel)
 	{
-	case CON_GREEN:
+	case ConsiderColor::Green:
 		return (float)RuleI(Character, GreenModifier) / 100;
 		break;
-	case CON_LIGHTBLUE:
+	case ConsiderColor::LightBlue:
 		return (float)RuleI(Character, LightBlueModifier) / 100;
 		break;
-	case CON_BLUE:
+	case ConsiderColor::DarkBlue:
 		return (float)RuleI(Character, BlueModifier) / 100;
 		break;
-	case CON_WHITE:
+	case ConsiderColor::White:
 		return (float)RuleI(Character, WhiteModifier) / 100;
 		break;
-	case CON_YELLOW:
+	case ConsiderColor::Yellow:
 		return (float)RuleI(Character, YellowModifier) / 100;
 		break;
-	case CON_RED:
+	case ConsiderColor::Red:
 		return (float)RuleI(Character, RedModifier) / 100;
 		break;
 	default:
@@ -249,7 +249,7 @@ void Client::CalculateNormalizedAAExp(uint64 &add_aaxp, uint8 conlevel, bool res
 {
 	// Functionally this is the same as having the case in the switch, but this is
 	// cleaner to read.
-	if (CON_GRAY == conlevel || resexp)
+	if (ConsiderColor::Gray == conlevel || resexp)
 	{
 		add_aaxp = 0;
 		return;
@@ -325,7 +325,7 @@ void Client::CalculateStandardAAExp(uint64 &add_aaxp, uint8 conlevel, bool resex
 
 void Client::CalculateLeadershipExp(uint64 &add_exp, uint8 conlevel)
 {
-	if (IsLeadershipEXPOn() && (conlevel == CON_BLUE || conlevel == CON_WHITE || conlevel == CON_YELLOW || conlevel == CON_RED))
+	if (IsLeadershipEXPOn() && (conlevel == ConsiderColor::DarkBlue || conlevel == ConsiderColor::White || conlevel == ConsiderColor::Yellow || conlevel == ConsiderColor::Red))
 	{
 		add_exp = static_cast<uint64>(static_cast<float>(add_exp) * 0.8f);
 
@@ -627,7 +627,7 @@ void Client::SetEXP(uint64 set_exp, uint64 set_aaxp, bool isrezzexp) {
 			if (membercount > 1) {
 				if (RuleI(Character, ShowExpValues) > 0) {
 					Message(Chat::Experience, "You have gained %s party experience! %s", exp_amount_message.c_str(), exp_percent_message.c_str());
-				} else if (zone->IsHotzone()) { 
+				} else if (zone->IsHotzone()) {
 					Message(Chat::Experience, "You gain party experience (with a bonus)!");
 				} else {
 					MessageString(Chat::Experience, GAIN_GROUPXP);
@@ -635,7 +635,7 @@ void Client::SetEXP(uint64 set_exp, uint64 set_aaxp, bool isrezzexp) {
 			} else if (IsRaidGrouped()) {
 				if (RuleI(Character, ShowExpValues) > 0) {
 					Message(Chat::Experience, "You have gained %s raid experience! %s", exp_amount_message.c_str(), exp_percent_message.c_str());
-				} else if (zone->IsHotzone()) { 
+				} else if (zone->IsHotzone()) {
 					Message(Chat::Experience, "You gained raid experience (with a bonus)!");
 				} else {
 					MessageString(Chat::Experience, GAIN_RAIDEXP);
@@ -643,7 +643,7 @@ void Client::SetEXP(uint64 set_exp, uint64 set_aaxp, bool isrezzexp) {
 			} else {
 				if (RuleI(Character, ShowExpValues) > 0) {
 					Message(Chat::Experience, "You have gained %s experience! %s", exp_amount_message.c_str(), exp_percent_message.c_str());
-				} else if (zone->IsHotzone()) { 
+				} else if (zone->IsHotzone()) {
 					Message(Chat::Experience, "You gain experience (with a bonus)!");
 				} else {
 					MessageString(Chat::Experience, GAIN_XP);
@@ -1158,7 +1158,7 @@ void Group::SplitExp(const uint64 exp, Mob* other) {
 	}
 
 	const uint8 consider_level = Mob::GetLevelCon(highest_level, other->GetLevel());
-	if (consider_level == CON_GRAY) {
+	if (consider_level == ConsiderColor::Gray) {
 		return;
 	}
 
@@ -1204,7 +1204,7 @@ void Raid::SplitExp(const uint64 exp, Mob* other) {
 	raid_experience = static_cast<uint64>(static_cast<float>(raid_experience) * RuleR(Character, FinalRaidExpMultiplier));
 
 	const auto consider_level = Mob::GetLevelCon(highest_level, other->GetLevel());
-	if (consider_level == CON_GRAY) {
+	if (consider_level == ConsiderColor::Gray) {
 		return;
 	}
 

--- a/zone/fearpath.cpp
+++ b/zone/fearpath.cpp
@@ -71,7 +71,7 @@ void Mob::CheckFlee()
 	}
 
 	// If no special flee_percent check for Gray or Other con rates
-	if (GetLevelCon(hate_top->GetLevel(), GetLevel()) == CON_GRAY && flee_ratio == 0 && RuleB(Combat, FleeGray) &&
+	if (GetLevelCon(hate_top->GetLevel(), GetLevel()) == ConsiderColor::Gray && flee_ratio == 0 && RuleB(Combat, FleeGray) &&
 		GetLevel() <= RuleI(Combat, FleeGrayMaxLevel)) {
 		flee_ratio = RuleI(Combat, FleeGrayHPRatio);
 		LogFlee("Mob [{}] using combat flee gray hp_ratio [{}] flee_ratio [{}]", GetCleanName(), hp_ratio, flee_ratio);
@@ -110,16 +110,16 @@ void Mob::CheckFlee()
 	int    flee_chance;
 	switch (con) {
 		//these values are not 100% researched
-		case CON_GRAY:
+		case ConsiderColor::Gray:
 			flee_chance = 100;
 			break;
-		case CON_GREEN:
+		case ConsiderColor::Green:
 			flee_chance = 90;
 			break;
-		case CON_LIGHTBLUE:
+		case ConsiderColor::LightBlue:
 			flee_chance = 90;
 			break;
-		case CON_BLUE:
+		case ConsiderColor::DarkBlue:
 			flee_chance = 80;
 			break;
 		default:
@@ -175,7 +175,7 @@ void Mob::ProcessFlee()
 	Mob *hate_top = GetHateTop();
 
 	// If no special flee_percent check for Gray or Other con rates
-	if(hate_top != nullptr && GetLevelCon(hate_top->GetLevel(), GetLevel()) == CON_GRAY && fleeratio == 0 && RuleB(Combat, FleeGray)) {
+	if(hate_top != nullptr && GetLevelCon(hate_top->GetLevel(), GetLevel()) == ConsiderColor::Gray && fleeratio == 0 && RuleB(Combat, FleeGray)) {
 		fleeratio = RuleI(Combat, FleeGrayHPRatio);
 	} else if(fleeratio == 0) {
 		fleeratio = RuleI(Combat, FleeHPRatio );

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -3357,6 +3357,18 @@ bool Lua_Mob::IsWisdomCasterClass()
 	return self->IsWisdomCasterClass();
 }
 
+std::string Lua_Mob::GetConsiderColor(Lua_Mob other)
+{
+	Lua_Safe_Call_String();
+	return EQ::constants::GetConsiderColorName(self->GetLevelCon(other.GetLevel()));
+}
+
+std::string Lua_Mob::GetConsiderColor(uint8 other_level)
+{
+	Lua_Safe_Call_String();
+	return EQ::constants::GetConsiderColorName(self->GetLevelCon(other_level));
+}
+
 luabind::scope lua_register_mob() {
 	return luabind::class_<Lua_Mob, Lua_Entity>("Mob")
 	.def(luabind::constructor<>())
@@ -3576,6 +3588,8 @@ luabind::scope lua_register_mob() {
 	.def("GetCloseMobList", (Lua_Mob_List(Lua_Mob::*)(void))&Lua_Mob::GetCloseMobList)
 	.def("GetCloseMobList", (Lua_Mob_List(Lua_Mob::*)(float))&Lua_Mob::GetCloseMobList)
 	.def("GetCloseMobList", (Lua_Mob_List(Lua_Mob::*)(float,bool))&Lua_Mob::GetCloseMobList)
+	.def("GetConsiderColor", (std::string(Lua_Mob::*)(Lua_Mob))&Lua_Mob::GetConsiderColor)
+	.def("GetConsiderColor", (std::string(Lua_Mob::*)(uint8))&Lua_Mob::GetConsiderColor)
 	.def("GetCorruption", &Lua_Mob::GetCorruption)
 	.def("GetDEX", &Lua_Mob::GetDEX)
 	.def("GetDR", &Lua_Mob::GetDR)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -590,6 +590,8 @@ public:
 	bool IsIntelligenceCasterClass();
 	bool IsPureMeleeClass();
 	bool IsWisdomCasterClass();
+	std::string GetConsiderColor(Lua_Mob other);
+	std::string GetConsiderColor(uint8 other_level);
 };
 
 #endif

--- a/zone/merc.cpp
+++ b/zone/merc.cpp
@@ -3794,37 +3794,37 @@ bool Merc::CheckConfidence() {
 		switch(CurrentCon) {
 
 
-					case CON_GRAY: {
+					case ConsiderColor::Gray: {
 						ConRating = 0;
 						break;
 					}
 
-					case CON_GREEN: {
+					case ConsiderColor::Green: {
 						ConRating = 0.1;
 						break;
 									}
 
-					case CON_LIGHTBLUE: {
+					case ConsiderColor::LightBlue: {
 						ConRating = 0.2;
 						break;
 										}
 
-					case CON_BLUE: {
+					case ConsiderColor::DarkBlue: {
 						ConRating = 0.6;
 						break;
 								   }
 
-					case CON_WHITE: {
+					case ConsiderColor::White: {
 						ConRating = 1.0;
 						break;
 									}
 
-					case CON_YELLOW: {
+					case ConsiderColor::Yellow: {
 						ConRating = 1.2;
 						break;
 									 }
 
-					case CON_RED: {
+					case ConsiderColor::Red: {
 						ConRating = 1.5;
 						break;
 								  }

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -2187,162 +2187,162 @@ uint32 Mob::GetLevelCon(uint8 mylevel, uint8 iOtherLevel) {
 		int16 diff = iOtherLevel - mylevel;
 
 		if (diff == 0)
-			return CON_WHITE;
+			return ConsiderColor::White;
 		else if (diff >= 1 && diff <= 2)
-			return CON_YELLOW;
+			return ConsiderColor::Yellow;
 		else if (diff >= 3)
-			return CON_RED;
+			return ConsiderColor::Red;
 
 		if (mylevel <= 8)
 		{
 			if (diff <= -4)
-				conlevel = CON_GRAY;
+				conlevel = ConsiderColor::Gray;
 			else
-				conlevel = CON_BLUE;
+				conlevel = ConsiderColor::DarkBlue;
 		}
 		else if (mylevel <= 9)
 		{
 			if (diff <= -6)
-				conlevel = CON_GRAY;
+				conlevel = ConsiderColor::Gray;
 			else if (diff <= -4)
-				conlevel = CON_LIGHTBLUE;
+				conlevel = ConsiderColor::LightBlue;
 			else
-				conlevel = CON_BLUE;
+				conlevel = ConsiderColor::DarkBlue;
 		}
 		else if (mylevel <= 13)
 		{
 			if (diff <= -7)
-				conlevel = CON_GRAY;
+				conlevel = ConsiderColor::Gray;
 			else if (diff <= -5)
-				conlevel = CON_LIGHTBLUE;
+				conlevel = ConsiderColor::LightBlue;
 			else
-				conlevel = CON_BLUE;
+				conlevel = ConsiderColor::DarkBlue;
 		}
 		else if (mylevel <= 15)
 		{
 			if (diff <= -7)
-				conlevel = CON_GRAY;
+				conlevel = ConsiderColor::Gray;
 			else if (diff <= -5)
-				conlevel = CON_LIGHTBLUE;
+				conlevel = ConsiderColor::LightBlue;
 			else
-				conlevel = CON_BLUE;
+				conlevel = ConsiderColor::DarkBlue;
 		}
 		else if (mylevel <= 17)
 		{
 			if (diff <= -8)
-				conlevel = CON_GRAY;
+				conlevel = ConsiderColor::Gray;
 			else if (diff <= -6)
-				conlevel = CON_LIGHTBLUE;
+				conlevel = ConsiderColor::LightBlue;
 			else
-				conlevel = CON_BLUE;
+				conlevel = ConsiderColor::DarkBlue;
 		}
 		else if (mylevel <= 21)
 		{
 			if (diff <= -9)
-				conlevel = CON_GRAY;
+				conlevel = ConsiderColor::Gray;
 			else if (diff <= -7)
-				conlevel = CON_LIGHTBLUE;
+				conlevel = ConsiderColor::LightBlue;
 			else
-				conlevel = CON_BLUE;
+				conlevel = ConsiderColor::DarkBlue;
 		}
 		else if (mylevel <= 25)
 		{
 			if (diff <= -10)
-				conlevel = CON_GRAY;
+				conlevel = ConsiderColor::Gray;
 			else if (diff <= -8)
-				conlevel = CON_LIGHTBLUE;
+				conlevel = ConsiderColor::LightBlue;
 			else
-				conlevel = CON_BLUE;
+				conlevel = ConsiderColor::DarkBlue;
 		}
 		else if (mylevel <= 29)
 		{
 			if (diff <= -11)
-				conlevel = CON_GRAY;
+				conlevel = ConsiderColor::Gray;
 			else if (diff <= -9)
-				conlevel = CON_LIGHTBLUE;
+				conlevel = ConsiderColor::LightBlue;
 			else
-				conlevel = CON_BLUE;
+				conlevel = ConsiderColor::DarkBlue;
 		}
 		else if (mylevel <= 31)
 		{
 			if (diff <= -12)
-				conlevel = CON_GRAY;
+				conlevel = ConsiderColor::Gray;
 			else if (diff <= -9)
-				conlevel = CON_LIGHTBLUE;
+				conlevel = ConsiderColor::LightBlue;
 			else
-				conlevel = CON_BLUE;
+				conlevel = ConsiderColor::DarkBlue;
 		}
 		else if (mylevel <= 33)
 		{
 			if (diff <= -13)
-				conlevel = CON_GRAY;
+				conlevel = ConsiderColor::Gray;
 			else if (diff <= -10)
-				conlevel = CON_LIGHTBLUE;
+				conlevel = ConsiderColor::LightBlue;
 			else
-				conlevel = CON_BLUE;
+				conlevel = ConsiderColor::DarkBlue;
 		}
 		else if (mylevel <= 37)
 		{
 			if (diff <= -14)
-				conlevel = CON_GRAY;
+				conlevel = ConsiderColor::Gray;
 			else if (diff <= -11)
-				conlevel = CON_LIGHTBLUE;
+				conlevel = ConsiderColor::LightBlue;
 			else
-				conlevel = CON_BLUE;
+				conlevel = ConsiderColor::DarkBlue;
 		}
 		else if (mylevel <= 41)
 		{
 			if (diff <= -16)
-				conlevel = CON_GRAY;
+				conlevel = ConsiderColor::Gray;
 			else if (diff <= -12)
-				conlevel = CON_LIGHTBLUE;
+				conlevel = ConsiderColor::LightBlue;
 			else
-				conlevel = CON_BLUE;
+				conlevel = ConsiderColor::DarkBlue;
 		}
 		else if (mylevel <= 45)
 		{
 			if (diff <= -17)
-				conlevel = CON_GRAY;
+				conlevel = ConsiderColor::Gray;
 			else if (diff <= -13)
-				conlevel = CON_LIGHTBLUE;
+				conlevel = ConsiderColor::LightBlue;
 			else
-				conlevel = CON_BLUE;
+				conlevel = ConsiderColor::DarkBlue;
 		}
 		else if (mylevel <= 49)
 		{
 			if (diff <= -18)
-				conlevel = CON_GRAY;
+				conlevel = ConsiderColor::Gray;
 			else if (diff <= -14)
-				conlevel = CON_LIGHTBLUE;
+				conlevel = ConsiderColor::LightBlue;
 			else
-				conlevel = CON_BLUE;
+				conlevel = ConsiderColor::DarkBlue;
 		}
 		else if (mylevel <= 53)
 		{
 			if (diff <= -19)
-				conlevel = CON_GRAY;
+				conlevel = ConsiderColor::Gray;
 			else if (diff <= -15)
-				conlevel = CON_LIGHTBLUE;
+				conlevel = ConsiderColor::LightBlue;
 			else
-				conlevel = CON_BLUE;
+				conlevel = ConsiderColor::DarkBlue;
 		}
 		else if (mylevel <= 55)
 		{
 			if (diff <= -20)
-				conlevel = CON_GRAY;
+				conlevel = ConsiderColor::Gray;
 			else if (diff <= -15)
-				conlevel = CON_LIGHTBLUE;
+				conlevel = ConsiderColor::LightBlue;
 			else
-				conlevel = CON_BLUE;
+				conlevel = ConsiderColor::DarkBlue;
 		}
 		else
 		{
 			if (diff <= -21)
-				conlevel = CON_GRAY;
+				conlevel = ConsiderColor::Gray;
 			else if (diff <= -16)
-				conlevel = CON_LIGHTBLUE;
+				conlevel = ConsiderColor::LightBlue;
 			else
-				conlevel = CON_BLUE;
+				conlevel = ConsiderColor::DarkBlue;
 		}
 	}
 	else
@@ -2352,42 +2352,42 @@ uint32 Mob::GetLevelCon(uint8 mylevel, uint8 iOtherLevel) {
 		uint32 conGreenLvl = mylevel - (int32)((mylevel + 7) / 4);
 
 		if (diff == 0)
-			return CON_WHITE;
+			return ConsiderColor::White;
 		else if (diff >= 1 && diff <= 3)
-			return CON_YELLOW;
+			return ConsiderColor::Yellow;
 		else if (diff >= 4)
-			return CON_RED;
+			return ConsiderColor::Red;
 
 		if (mylevel <= 15)
 		{
 			if (diff <= -6)
-				conlevel = CON_GRAY;
+				conlevel = ConsiderColor::Gray;
 			else
-				conlevel = CON_BLUE;
+				conlevel = ConsiderColor::DarkBlue;
 		}
 		else
 			if (mylevel <= 20)
 			{
 				if (iOtherLevel <= conGrayLvl)
-					conlevel = CON_GRAY;
+					conlevel = ConsiderColor::Gray;
 				else
 					if (iOtherLevel <= conGreenLvl)
-						conlevel = CON_GREEN;
+						conlevel = ConsiderColor::Green;
 					else
-						conlevel = CON_BLUE;
+						conlevel = ConsiderColor::DarkBlue;
 			}
 			else
 			{
 				if (iOtherLevel <= conGrayLvl)
-					conlevel = CON_GRAY;
+					conlevel = ConsiderColor::Gray;
 				else
 					if (iOtherLevel <= conGreenLvl)
-						conlevel = CON_GREEN;
+						conlevel = ConsiderColor::Green;
 					else
 						if (diff <= -6)
-							conlevel = CON_LIGHTBLUE;
+							conlevel = ConsiderColor::LightBlue;
 						else
-							conlevel = CON_BLUE;
+							conlevel = ConsiderColor::DarkBlue;
 			}
 	}
 	return conlevel;

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -3403,7 +3403,7 @@ void NPC::AIYellForHelp(Mob *sender, Mob *attacker)
 			 * if they are in range, make sure we are not green...
 			 * then jump in if they are our friend
 			 */
-			if (mob->GetLevel() >= 50 || mob->AlwaysAggro() || attacker->GetLevelCon(mob->GetLevel()) != CON_GRAY) {
+			if (mob->GetLevel() >= 50 || mob->AlwaysAggro() || attacker->GetLevelCon(mob->GetLevel()) != ConsiderColor::Gray) {
 				if (mob->GetPrimaryFaction() == sender->CastToNPC()->GetPrimaryFaction()) {
 					const auto f = zone->GetNPCFaction(mob->CastToNPC()->GetNPCFactionID());
 					if (f) {

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -3468,6 +3468,16 @@ bool Perl_Mob_IsWisdomCasterClass(Mob* self)
 	return self->IsWisdomCasterClass();
 }
 
+std::string Perl_Mob_GetConsiderColor(Mob* self, Mob* other)
+{
+	return EQ::constants::GetConsiderColorName(self->GetLevelCon(other->GetLevel()));
+}
+
+std::string Perl_Mob_GetConsiderColor(Mob* self, uint8 other_level)
+{
+	return EQ::constants::GetConsiderColorName(self->GetLevelCon(other_level));
+}
+
 void perl_register_mob()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3670,6 +3680,8 @@ void perl_register_mob()
 	package.add("GetCloseMobList", (perl::array(*)(Mob*))&Perl_Mob_GetCloseMobList);
 	package.add("GetCloseMobList", (perl::array(*)(Mob*, float))&Perl_Mob_GetCloseMobList);
 	package.add("GetCloseMobList", (perl::array(*)(Mob*, float, bool))&Perl_Mob_GetCloseMobList);
+	package.add("GetConsiderColor", (std::string(*)(Mob*, Mob*))&Perl_Mob_GetConsiderColor);
+	package.add("GetConsiderColor", (std::string(*)(Mob*, uint8))&Perl_Mob_GetConsiderColor);
 	package.add("GetCorruption", &Perl_Mob_GetCorruption);
 	package.add("GetDefaultRaceSize", (float(*)(Mob*))&Perl_Mob_GetDefaultRaceSize);
 	package.add("GetDefaultRaceSize", (float(*)(Mob*, int))&Perl_Mob_GetDefaultRaceSize);


### PR DESCRIPTION
# Description
- Allows operators to get the consider color's name based on the level or Mob provided.

## Perl
- Add `$mob->GetConsiderColor(other)`.
- Add `$mob->GetConsiderColor(other_level)`.

## Lua
- Add `mob:GetConsiderColor(other)`.
- Add `mob:GetConsiderColor(other_level)`.

## Notes

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# Testing
![image](https://github.com/EQEmu/Server/assets/89047260/57e1b98d-c54c-4d25-9e27-dd818b698f7f)
![image](https://github.com/EQEmu/Server/assets/89047260/faba3e5f-8f6a-4128-8718-f03a0ceed068)

## Example Script (Perl)
```pl
sub EVENT_SAY {
	if ($text=~/#a/i && $client->GetTarget()) {
		my $consider_color = $client->GetConsiderColor($client->GetTarget());
		quest::message(315, $consider_color);
	} elsif ($text=~/#b/i) {
		my $random_level = quest::ChooseRandom(1..255);
		my $consider_color = $client->GetConsiderColor($random_level);
		quest::message(315, "A level $random_level is $consider_color to you.");
	}
}
```

## Example Script (Lua)
```lua
function event_say(e)
	if e.message:findi("#a") and e.self:GetTarget() then
		local consider_color = e.self:GetConsiderColor(e.self:GetTarget())
		eq.message(315, tostring(consider_color))
	elseif e.message:findi("#b") then
		local random_level = math.random(255)
		local consider_color = e.self:GetConsiderColor(random_level)
		eq.message(315, string.format("A level %s is %s to you.", tostring(random_level), tostring(consider_color)))
	end
end
```

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur