### PR TITLE
[Zoning] Fix zone routing edge case

### DIFF
--- a/common/content/world_content_service.cpp
+++ b/common/content/world_content_service.cpp
@@ -357,3 +357,13 @@ WorldContentService::FindZoneResult WorldContentService::FindZone(uint32 zone_id
 	return WorldContentService::FindZoneResult{.zone_id = 0};
 }
 
+bool WorldContentService::IsInPublicStaticInstance(uint32 instance_id)
+{
+	for (auto &i: m_zone_instances) {
+		if (i.id == instance_id) {
+			return true;
+		}
+	}
+
+	return false;
+}

--- a/common/content/world_content_service.h
+++ b/common/content/world_content_service.h
@@ -178,6 +178,8 @@ public:
 	};
 
 	FindZoneResult FindZone(uint32 zone_id, uint32 instance_id);
+	bool IsInPublicStaticInstance(uint32 instance_id);
+
 private:
 	int current_expansion{};
 	std::vector<ContentFlagsRepository::ContentFlags> content_flags;

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -755,11 +755,6 @@ void Client::ZonePC(uint32 zoneID, uint32 instance_id, float x, float y, float z
 		pZoneName = strcpy(new char[zd->long_name.length() + 1], zd->long_name.c_str());
 	}
 
-	// If we are zoning to the same zone, we need to use the current instance ID if it is not specified.
-	if (zoneID == zone->GetZoneID() && instance_id == 0) {
-		instance_id = zone->GetInstanceID();
-	}
-
 	auto r = content_service.FindZone(zoneID, instance_id);
 	if (r.zone_id) {
 		zoneID      = r.zone_id;
@@ -776,6 +771,11 @@ void Client::ZonePC(uint32 zoneID, uint32 instance_id, float x, float y, float z
 			ignorerestrictions,
 			static_cast<int>(zm)
 		);
+
+		// If we are zoning to the same zone, we need to use the current instance ID if it is not specified.
+		if (zoneID == zone->GetZoneID() && instance_id == 0) {
+			instance_id = zone->GetInstanceID();
+		}
 	}
 
 	LogInfo(

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -773,7 +773,7 @@ void Client::ZonePC(uint32 zoneID, uint32 instance_id, float x, float y, float z
 		);
 
 		// If we are zoning to the same zone, we need to use the current instance ID if it is not specified.
-		if (zoneID == zone->GetZoneID() && instance_id == 0) {
+		if (content_service.IsInPublicStaticInstance(instance_id) && zoneID == zone->GetZoneID() && instance_id == 0) {
 			instance_id = zone->GetInstanceID();
 		}
 	}


### PR DESCRIPTION
# Description

This change is necessary because certain routing rules only mean for global static instances were happening for any instances and any zone. We now only do same zone instance over-riding logic in global static instances.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

![image](https://github.com/EQEmu/Server/assets/3319450/53e6bf44-6044-4c10-a3bd-d8ef1d3c0778)

Trust tested his edge case on his server

Clients tested: ROF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur