### PR TITLE
[Bug Fix] Fixes Issue 4257 - Double Taunt Message

### DIFF
--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -2282,8 +2282,6 @@ void Mob::Taunt(NPC *who, bool always_succeed, int chance_bonus, bool from_spell
 		if (who->CanTalk()) {
 			who->SayString(SUCCESSFUL_TAUNT, GetCleanName());
 		}
-
-		MessageString(Chat::Skills, TAUNT_SUCCESS, who->GetCleanName());
 	} else {
 		MessageString(Chat::Skills, FAILED_TAUNT);
 	}


### PR DESCRIPTION
# Description

The client appears to generate its own taunt message, so I removed the additional server side generated message.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

![image](https://github.com/EQEmu/Server/assets/5864295/b1d106a2-a9c8-4425-a077-4dfbdbbd1769)


Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [ ] I have made corresponding changes to the documentation (if applicable, if not delete this line)
- [x] I own the changes of my code and take responsibility for the potential issues that occur
