### PR TITLE
[Feature] Implement Move Multiple Items

### DIFF
--- a/common/emu_constants.h
+++ b/common/emu_constants.h
@@ -146,7 +146,7 @@ namespace EQ
 			inventoryPersonal = 0,
 			inventoryBank = 1,
 			inventorySharedBank = 2
-		}
+		};
 
 	} // namespace invtype
 

--- a/common/emu_constants.h
+++ b/common/emu_constants.h
@@ -142,12 +142,6 @@ namespace EQ
 		int16 GetInvTypeSize(int16 inv_type);
 		using RoF2::invtype::GetInvTypeName;
 
-		enum MoveMultiType: int16 {
-			inventoryPersonal = 0,
-			inventoryBank = 1,
-			inventorySharedBank = 2
-		};
-
 	} // namespace invtype
 
 	namespace DevTools {

--- a/common/emu_constants.h
+++ b/common/emu_constants.h
@@ -142,6 +142,12 @@ namespace EQ
 		int16 GetInvTypeSize(int16 inv_type);
 		using RoF2::invtype::GetInvTypeName;
 
+		enum MoveMultiType: int16 {
+			inventoryPersonal = 0,
+			inventoryBank = 1,
+			inventorySharedBank = 2
+		}
+
 	} // namespace invtype
 
 	namespace DevTools {

--- a/common/eq_packet_structs.h
+++ b/common/eq_packet_structs.h
@@ -1620,6 +1620,32 @@ struct MoveItem_Struct
 /*0012*/
 };
 
+// New for RoF2 - Size: 12
+struct InventorySlot_Struct
+{
+/*000*/	int16	Type;		// Worn and Normal inventory = 0, Bank = 1, Shared Bank = 2, Delete Item = -1
+/*002*/	int16	Unknown02;
+/*004*/	int16	Slot;
+/*006*/	int16	SubIndex;
+/*008*/	int16	AugIndex;	// Guessing - Seen 0xffff
+/*010*/	int16	Unknown01;	// Normally 0 - Seen 13262 when deleting an item, but didn't match item ID
+/*012*/
+};
+
+struct MultiMoveItemSub_Struct
+{
+/*0000*/ InventorySlot_Struct	from_slot;
+/*0012*/ InventorySlot_Struct	to_slot;
+/*0024*/ uint32			number_in_stack;
+/*0028*/ uint8			unknown[8];
+};
+
+struct MultiMoveItem_Struct
+{
+/*0000*/ uint32	count;
+/*0004*/ MultiMoveItemSub_Struct moves[0];
+};
+
 // both MoveItem_Struct/DeleteItem_Struct server structures will be changing to a structure-based slot format..this will
 // be used for handling SoF/SoD/etc... time stamps sent using the MoveItem_Struct format. (nothing will be done with this
 // info at the moment..but, it is forwarded on to the server for handling/future use)

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -10915,7 +10915,7 @@ void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
 {
 	// This packet is only sent from the client if we ctrl click items in inventory
 	if (m_ClientVersionBit & EQ::versions::maskRoF2AndLater) {
-		
+
 		if (!CharacterID()) {
 			LinkDead();
 			return;
@@ -10931,7 +10931,7 @@ void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
 			LinkDead();
 			return; // Packet size does not match expected size
 		}
-			
+
 		const auto from_parent = multi_move->moves[0].from_slot.Slot;
 		const auto to_parent   = multi_move->moves[0].to_slot.Slot;
 
@@ -10952,14 +10952,14 @@ void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
 		if (left_click) {
 			for (int i = 0; i < multi_move->count; i++) {
 				MoveItem_Struct* mi = new MoveItem_Struct();
-				mi->from_slot 	= multi_move->moves[i].from_slot.SubIndex == -1 ? multi_move->moves[i].from_slot.Slot : m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot, multi_move->moves[i].from_slot.SubIndex);									
+				mi->from_slot 	= multi_move->moves[i].from_slot.SubIndex == -1 ? multi_move->moves[i].from_slot.Slot : m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot, multi_move->moves[i].from_slot.SubIndex);
 				mi->to_slot = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot, multi_move->moves[i].to_slot.SubIndex);
-				
+
 				if (multi_move->moves[i].to_slot.Type == EQ::invtype::inventoryBank) { // Target is bank inventory
 					mi->to_slot = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot + EQ::invslot::BANK_BEGIN, multi_move->moves[i].to_slot.SubIndex);
 				} else if (multi_move->moves[i].to_slot.Type == EQ::invtype::inventorySharedBank) { // Target is shared bank inventory
 					mi->to_slot = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot + EQ::invslot::SHARED_BANK_BEGIN, multi_move->moves[i].to_slot.SubIndex);
-				}				
+				}
 
 				// This sends '1' as the stack count for unstackable items, which our titanium-era SwapItem blows up
 				if (m_inv.GetItem(mi->from_slot)->IsStackable()) {
@@ -10970,7 +10970,7 @@ void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
 
 				if (!SwapItem(mi) && IsValidSlot(mi->from_slot) && IsValidSlot(mi->to_slot)) {
 					bool error = false;
-					SwapItemResync(mi);					
+					SwapItemResync(mi);
 					InterrogateInventory(this, false, true, false, error, false);
 					if (error)
 						InterrogateInventory(this, true, false, true, error);
@@ -10978,7 +10978,7 @@ void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
 			}
 		// This is the swap.
 		// Client behavior is just to move stacks without combining them
-		} else {			
+		} else {
 			struct MoveInfo {
 				EQ::ItemInstance* item;
 				uint16 to_slot;
@@ -11003,11 +11003,11 @@ void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
 					to_slot = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot + EQ::invslot::SHARED_BANK_BEGIN, multi_move->moves[i].to_slot.SubIndex);
 				}
 
-				// Probably need some error checking here, but I wasn't able to produce any error states on purpose.				
+				// Probably need some error checking here, but I wasn't able to produce any error states on purpose.
 				MoveInfo move;
 				move.item = m_inv.PopItem(from_slot); // Don't delete the instance here
 				move.to_slot = to_slot;
-				if (move.item) {				
+				if (move.item) {
 					items.push_back(move);
 				}
 			}
@@ -11016,7 +11016,7 @@ void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
 				PutItemInInventory(move.to_slot, *move.item); // This saves inventory too
 			}
 		}
-		
+
 	} else {
 		LinkDead(); // This packet should not be sent by an older client
 		return;
@@ -15616,19 +15616,7 @@ void Client::Handle_OP_Trader(const EQApplicationPacket *app)
 	//
 	// SoF sends 1 or more unhandled OP_Trader packets of size 96 when a trade has completed.
 	// I don't know what they are for (yet), but it doesn't seem to matter that we ignore them.
-
-
-	uint32 max_items = 80;
-
-	/*
-	if (GetClientVersion() >= EQClientRoF)
-	max_items = 200;
-	*/
-
-	//Show Items
-	if (app->size == sizeof(Trader_ShowItems_Struct))
-	{
-		Trader_ShowItems_Struct* sis = (Trader_ShowItems_Struct*)app->pBuffer;
+	auto action = *(uint32 *)app->pBuffer;
 
 	switch (action) {
 		case TraderOff: {

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -368,6 +368,7 @@ void MapOpcodes()
 	ConnectedOpcodes[OP_Save] = &Client::Handle_OP_Save;
 	ConnectedOpcodes[OP_SaveOnZoneReq] = &Client::Handle_OP_SaveOnZoneReq;
 	ConnectedOpcodes[OP_SelectTribute] = &Client::Handle_OP_SelectTribute;
+	ConnectedOpcodes[OP_Checksum] = &Client::Handle_OP_Checksum;
 
 	// Use or Ignore sense heading based on rule.
 	bool train = RuleB(Skills, TrainSenseHeading);
@@ -529,6 +530,10 @@ int Client::HandlePacket(const EQApplicationPacket *app)
 // Finish client connecting state
 void Client::CompleteConnect()
 {
+
+	if (RuleB(Custom, MulticlassingEnabled)) {
+		m_pp.classes = Strings::ToInt(GetBucket("GestaltClasses"), GetPlayerClassBit(m_pp.class_));
+	}
 
 	UpdateWho();
 	client_state = CLIENT_CONNECTED;
@@ -973,6 +978,12 @@ void Client::CompleteConnect()
 	RecordStats();
 	AutoGrantAAPoints();
 
+	if (RuleB(Custom, ServerAuthStats)) {
+		SendEdgeStatBulkUpdate();
+		database.LoadCharacterDisciplines(character_id, &m_pp); /* Load Character Disciplines */
+		SendDisciplineUpdate();
+	}
+
 	// enforce some rules..
 	if (!CanEnterZone()) {
 		LogInfo("Kicking character [{}] from zone, not allowed here (missing requirements)", GetCleanName());
@@ -1323,7 +1334,11 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 	database.LoadCharacterInspectMessage(cid, &m_inspect_message); /* Load Character Inspect Message */
 	database.LoadCharacterSpellBook(cid, &m_pp); /* Load Character Spell Book */
 	database.LoadCharacterMemmedSpells(cid, &m_pp);  /* Load Character Memorized Spells */
-	database.LoadCharacterDisciplines(cid, &m_pp); /* Load Character Disciplines */
+	
+	if (!RuleB(Custom, ServerAuthStats)) {
+		database.LoadCharacterDisciplines(cid, &m_pp); /* Load Character Disciplines */
+	}
+	
 	database.LoadCharacterLanguages(cid, &m_pp); /* Load Character Languages */
 	database.LoadCharacterLeadershipAbilities(cid, &m_pp); /* Load Character Leadership AA's */
 	database.LoadCharacterTribute(this); /* Load CharacterTribute */
@@ -3029,8 +3044,7 @@ void Client::Handle_OP_ApplyPoison(const EQApplicationPacket *app)
 
 	bool IsPoison = (poison && poison->ItemType == EQ::item::ItemTypePoison);
 
-	if (IsPoison && GetClass() == Class::Rogue) {
-
+	if (IsPoison && (GetClassesBits() & GetPlayerClassBit(Class::Rogue))) {
 		// Live always checks for skillup, even when poison is too high
 		CheckIncreaseSkill(EQ::skills::SkillApplyPoison, nullptr, 10);
 
@@ -4323,12 +4337,18 @@ void Client::Handle_OP_Camp(const EQApplicationPacket *app)
 
 	if (IsLFP())
 		worldserver.StopLFP(CharacterID());
-
+	
 	if (GetGM())
 	{
 		OnDisconnect(true);
 		return;
 	}
+
+	if (zone->GetZoneID() == Zones::BAZAAR) {
+		camp_timer.Start(5000, true);
+		return;
+	}
+
 	camp_timer.Start(29000, true);
 	return;
 }
@@ -4563,7 +4583,7 @@ void Client::Handle_OP_CastSpell(const EQApplicationPacket *app)
 	else if (slot == CastingSlot::Ability) {
 		uint16 spell_to_cast = 0;
 
-		if (castspell->spell_id == SPELL_LAY_ON_HANDS && GetClass() == Class::Paladin) {
+		if (castspell->spell_id == SPELL_LAY_ON_HANDS && (GetClassesBits() & GetPlayerClassBit(Class::Paladin))) {
 			if (!p_timers.Expired(&database, pTimerLayHands)) {
 				Message(Chat::Red, "Ability recovery time not yet met.");
 				InterruptSpell(castspell->spell_id);
@@ -4571,9 +4591,7 @@ void Client::Handle_OP_CastSpell(const EQApplicationPacket *app)
 			}
 			spell_to_cast = SPELL_LAY_ON_HANDS;
 			p_timers.Start(pTimerLayHands, LayOnHandsReuseTime);
-		}
-		else if ((castspell->spell_id == SPELL_HARM_TOUCH
-			|| castspell->spell_id == SPELL_HARM_TOUCH2) && GetClass() == Class::ShadowKnight) {
+		} else if ((castspell->spell_id == SPELL_HARM_TOUCH || castspell->spell_id == SPELL_HARM_TOUCH2) && (GetClassesBits() & GetPlayerClassBit(Class::ShadowKnight))) {
 			if (!p_timers.Expired(&database, pTimerHarmTouch)) {
 				Message(Chat::Red, "Ability recovery time not yet met.");
 				InterruptSpell(castspell->spell_id);
@@ -8977,7 +8995,7 @@ void Client::Handle_OP_Hide(const EQApplicationPacket *app)
 			hidden = true;
 		tmHidden = Timer::GetCurrentTime();
 	}
-	if (GetClass() == Class::Rogue) {
+	if (GetClassesBits() & GetPlayerClassBit(Class::Rogue)) {
 		auto outapp = new EQApplicationPacket(OP_SimpleMessage, sizeof(SimpleMessage_Struct));
 		SimpleMessage_Struct *msg = (SimpleMessage_Struct *)outapp->pBuffer;
 		msg->color = 0x010E;
@@ -9526,7 +9544,7 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 				Bards on live can click items while casting spell gems, it stops that song cast and replaces it with item click cast.
 				Can not click while casting other items.
 			*/
-			if (GetClass() == Class::Bard && IsCasting() && casting_spell_slot < CastingSlot::MaxGems)
+			if (GetClass() == Class::Bard && IsCasting() && casting_spell_slot < CastingSlot::MaxGems && !RuleB(Custom, MulticlassingEnabled))
 			{
 				is_casting_bard_song = true;
 			}
@@ -9692,10 +9710,13 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 						if (!IsCastWhileInvisibleSpell(item->Click.Effect)) {
 							CommonBreakInvisible(); // client can't do this for us :(
 						}
-						if (GetClass() == Class::Bard){
+						
+						
+						if (GetClass() == Class::Bard && !(RuleB(Custom, MulticlassingEnabled))) {
 							DoBardCastingFromItemClick(is_casting_bard_song, item->CastTime, item->Click.Effect, target_id, CastingSlot::Item, slot_id, item->RecastType, item->RecastDelay);
 						}
-						else {
+
+						else {						
 							CastSpell(item->Click.Effect, target_id, CastingSlot::Item, item->CastTime, 0, 0, slot_id);
 						}
 					} else {
@@ -9763,10 +9784,12 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 					if (i == 0) {
 						if (!IsCastWhileInvisibleSpell(augitem->Click.Effect)) {
 							CommonBreakInvisible(); // client can't do this for us :(
+						}						
+						
+						if (GetClass() == Class::Bard && !(RuleB(Custom, MulticlassingEnabled))) {
+							DoBardCastingFromItemClick(is_casting_bard_song, item->CastTime, item->Click.Effect, target_id, CastingSlot::Item, slot_id, item->RecastType, item->RecastDelay);
 						}
-						if (GetClass() == Class::Bard) {
-							DoBardCastingFromItemClick(is_casting_bard_song, augitem->CastTime, augitem->Click.Effect, target_id, CastingSlot::Item, slot_id, augitem->RecastType, augitem->RecastDelay);
-						}
+
 						else {
 							CastSpell(augitem->Click.Effect, target_id, CastingSlot::Item, augitem->CastTime, 0, 0, slot_id);
 						}
@@ -9784,7 +9807,7 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 			}
 			else
 			{
-				if (ClientVersion() >= EQ::versions::ClientVersion::SoD && !inst->IsEquipable(GetBaseRace(), GetClass()))
+				if (ClientVersion() >= EQ::versions::ClientVersion::SoD && !inst->IsEquipable(GetBaseRace(), CastToClient()->GetClassesBits()))
 				{
 					if (item->ItemType != EQ::item::ItemTypeFood && item->ItemType != EQ::item::ItemTypeDrink && item->ItemType != EQ::item::ItemTypeAlcohol)
 					{
@@ -10381,7 +10404,10 @@ void Client::Handle_OP_ManaChange(const EQApplicationPacket *app)
 	if (app->size == 0) {
 		// i think thats the sign to stop the songs
 		if (IsBardSong(casting_spell_id) || HasActiveSong()) {
-			InterruptSpell(SONG_ENDS, 0x121); //Live doesn't send song end message anymore (~Kayen 1/26/22)
+			auto tt = spells[bardsong].target_type;
+			if (tt == ST_AECaster || tt == ST_Target || tt == ST_AETarget || !HasActiveSong()) {
+				InterruptSpell(SONG_ENDS, 0x121); //Live doesn't send song end message anymore (~Kayen 1/26/22)
+			}
 		}
 		else {
 			InterruptSpell(INTERRUPT_SPELL, 0x121);
@@ -10855,8 +10881,10 @@ void Client::Handle_OP_MoveItem(const EQApplicationPacket *app)
 		return;
 	}
 
+	
 	MoveItem_Struct* mi = (MoveItem_Struct*)app->pBuffer;
-	if (spellend_timer.Enabled() && casting_spell_id && !IsBardSong(casting_spell_id))
+	/*
+	if (spellend_timer.Enabled() && casting_spell_id && !(GetClassesBits() & GetPlayerClassBit(Class::Bard)));
 	{
 		if (mi->from_slot != mi->to_slot && (mi->from_slot <= EQ::invslot::GENERAL_END || mi->from_slot > 39) && IsValidSlot(mi->from_slot) && IsValidSlot(mi->to_slot))
 		{
@@ -10873,6 +10901,7 @@ void Client::Handle_OP_MoveItem(const EQApplicationPacket *app)
 			return;
 		}
 	}
+	*/
 
 	// Illegal bagslot usage checks. Currently, user only receives a message if this check is triggered.
 	bool mi_hack = false;
@@ -10914,8 +10943,7 @@ void Client::Handle_OP_MoveItem(const EQApplicationPacket *app)
 void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
 {
 	// This packet is only sent from the client if we ctrl click items in inventory
-	if (m_ClientVersionBit & EQ::versions::maskRoF2AndLater) {
-		LogDebug("OP_MoveMultipleItems Triggered");
+	if (m_ClientVersionBit & EQ::versions::maskRoF2AndLater) {		
 		if (!CharacterID()) {
 			LinkDead();
 			return;
@@ -10996,7 +11024,6 @@ void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
 				} else if (multi_move->moves[i].to_slot.Type == 2) { // Target is shared bank inventory
 					to_slot = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot + EQ::invslot::SHARED_BANK_BEGIN, multi_move->moves[i].to_slot.SubIndex);
 				}
-
 
 				// Probably need some error checking here, but I wasn't able to produce any error states on purpose.				
 				MoveInfo move;
@@ -11346,16 +11373,19 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 	}
 	case PET_TAUNT: {
 		if ((mypet->GetPetType() == petAnimation && aabonuses.PetCommands[PetCommand]) || mypet->GetPetType() != petAnimation) {
-			if (mypet->CastToNPC()->IsTaunting())
-			{
-				MessageString(Chat::PetResponse, PET_NO_TAUNT);
-				mypet->CastToNPC()->SetTaunting(false);
+			bool taunt_status = mypet->CastToNPC()->IsTaunting();			
+			if (RuleB(Custom, TauntTogglesPetTanking)) {
+				if (!taunt_status) {
+					mypet->SetSpecialAbility(25, 0);
+					mypet->SetSpecialAbility(41, 1);
+				} else {					
+					mypet->SetSpecialAbility(25, 1);
+					mypet->SetSpecialAbility(41, 0);
+					entity_list.RemoveFromTargets(mypet);
+				}
 			}
-			else
-			{
-				MessageString(Chat::PetResponse, PET_DO_TAUNT);
-				mypet->CastToNPC()->SetTaunting(true);
-			}
+			mypet->CastToNPC()->SetTaunting(!taunt_status);
+			MessageString(Chat::PetResponse, !taunt_status ? PET_DO_TAUNT : PET_NO_TAUNT);			
 		}
 		break;
 	}
@@ -14768,7 +14798,7 @@ void Client::Handle_OP_Sneak(const EQApplicationPacket *app)
 	sa_out->parameter = sneaking;
 	QueuePacket(outapp);
 	safe_delete(outapp);
-	if (GetClass() == Class::Rogue) {
+	if (GetClassesBits() & GetPlayerClassBit(Class::Rogue)) {
 		outapp = new EQApplicationPacket(OP_SimpleMessage, 12);
 		SimpleMessage_Struct *msg = (SimpleMessage_Struct *)outapp->pBuffer;
 		msg->color = 0x010E;
@@ -16144,6 +16174,18 @@ void Client::Handle_OP_WhoAllRequest(const EQApplicationPacket *app)
 		entity_list.ZoneWho(this, whoall);
 	else
 		WhoAll(whoall);
+	return;
+}
+
+void Client::Handle_OP_Checksum(const EQApplicationPacket *app)
+{
+	if (app->size != sizeof(SimpleChecksum_Struct*)){
+		LogDebug("Recieved invalid checksum packet");
+	}
+
+	SimpleChecksum_Struct* checksum = (SimpleChecksum_Struct*)app->pBuffer;
+
+	LogDebug("Got Checksum Struct: %d", checksum->checksum);
 	return;
 }
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -10915,15 +10915,18 @@ void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
 {
 	if (m_ClientVersionBit & EQ::versions::maskRoF2AndLater) {		
 		if (!CharacterID()) {
+			LinkDead();
 			return;
 		}
 
 		if (app->size < sizeof(MultiMoveItem_Struct)) {
+			LinkDead();
 			return; // Not enough data to be a valid packet
 		}
 
 		const MultiMoveItem_Struct* multi_move = reinterpret_cast<const MultiMoveItem_Struct*>(app->pBuffer);
 		if (app->size != sizeof(MultiMoveItem_Struct) + sizeof(MultiMoveItemSub_Struct) * multi_move->count) {
+			LinkDead();
 			return; // Packet size does not match expected size
 		}
 			
@@ -10956,6 +10959,7 @@ void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
 		
 	} else {
 		LinkDead(); // This packet should not be sent by an older client
+		return;
 	}
 }
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -10941,7 +10941,7 @@ void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
 
 		// We need to check if this is a swap or just an addition (left click or right click)
 		// Check if any component of this transaction is coming from anywhere other than the cursor
-		int left_click = true;
+		bool left_click = true;
 		for (int i = 0; i < multi_move->count; i++) {
 			if (multi_move->moves[i].from_slot.Slot != EQ::invslot::slotCursor) {
 				left_click = false;

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -10990,16 +10990,16 @@ void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
 			for (int i = 0; i < multi_move->count; i++) {
 				// These are always bags, so we don't need to worry about raw items in slotCursor
 				int16 from_slot   = m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot, multi_move->moves[i].from_slot.SubIndex);
-				if (multi_move->moves[i].from_slot.Type == EQ::invtype::inventoryBank) { // Target is bank inventory
+				if (multi_move->moves[i].from_slot.Type == EQ::invtype::typeBank) { // Target is bank inventory
 					from_slot = m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot + EQ::invslot::BANK_BEGIN, multi_move->moves[i].from_slot.SubIndex);
-				} else if (multi_move->moves[i].from_slot.Type == EQ::invtype::inventorySharedBank) { // Target is shared bank inventory
+				} else if (multi_move->moves[i].from_slot.Type == EQ::invtype::typeSharedBank) { // Target is shared bank inventory
 					from_slot = m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot + EQ::invslot::SHARED_BANK_BEGIN, multi_move->moves[i].from_slot.SubIndex);
 				}
 
 				int16 to_slot   = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot, multi_move->moves[i].to_slot.SubIndex);
-				if (multi_move->moves[i].to_slot.Type == EQ::invtype::inventoryBank) { // Target is bank inventory
+				if (multi_move->moves[i].to_slot.Type == EQ::invtype::typeBank) { // Target is bank inventory
 					to_slot = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot + EQ::invslot::BANK_BEGIN, multi_move->moves[i].to_slot.SubIndex);
-				} else if (multi_move->moves[i].to_slot.Type == EQ::invtype::inventorySharedBank) { // Target is shared bank inventory
+				} else if (multi_move->moves[i].to_slot.Type == EQ::invtype::typeSharedBank) { // Target is shared bank inventory
 					to_slot = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot + EQ::invslot::SHARED_BANK_BEGIN, multi_move->moves[i].to_slot.SubIndex);
 				}
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -10954,9 +10954,9 @@ void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
 				mi->from_slot 	= multi_move->moves[i].from_slot.SubIndex == -1 ? multi_move->moves[i].from_slot.Slot : m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot, multi_move->moves[i].from_slot.SubIndex);
 				mi->to_slot = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot, multi_move->moves[i].to_slot.SubIndex);
 
-				if (multi_move->moves[i].to_slot.Type == EQ::invtype::inventoryBank) { // Target is bank inventory
+				if (multi_move->moves[i].to_slot.Type == EQ::invtype::typeBank) { // Target is bank inventory
 					mi->to_slot = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot + EQ::invslot::BANK_BEGIN, multi_move->moves[i].to_slot.SubIndex);
-				} else if (multi_move->moves[i].to_slot.Type == EQ::invtype::inventorySharedBank) { // Target is shared bank inventory
+				} else if (multi_move->moves[i].to_slot.Type == EQ::invtype::typeSharedBank) { // Target is shared bank inventory
 					mi->to_slot = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot + EQ::invslot::SHARED_BANK_BEGIN, multi_move->moves[i].to_slot.SubIndex);
 				}
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -10989,7 +10989,7 @@ void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
 
 			for (int i = 0; i < multi_move->count; i++) {
 				// These are always bags, so we don't need to worry about raw items in slotCursor
-				int16 from_slot   = m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot, multi_move->moves[i].from_slot.SubIndex);
+				uint16 from_slot   = m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot, multi_move->moves[i].from_slot.SubIndex);
 				if (multi_move->moves[i].from_slot.Type == EQ::invtype::typeBank) { // Target is bank inventory
 					from_slot = m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot + EQ::invslot::BANK_BEGIN, multi_move->moves[i].from_slot.SubIndex);
 				} else if (multi_move->moves[i].from_slot.Type == EQ::invtype::typeSharedBank) { // Target is shared bank inventory

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -10943,7 +10943,8 @@ void Client::Handle_OP_MoveItem(const EQApplicationPacket *app)
 void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
 {
 	// This packet is only sent from the client if we ctrl click items in inventory
-	if (m_ClientVersionBit & EQ::versions::maskRoF2AndLater) {		
+	if (m_ClientVersionBit & EQ::versions::maskRoF2AndLater) {
+		
 		if (!CharacterID()) {
 			LinkDead();
 			return;
@@ -11016,9 +11017,15 @@ void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
     		items.reserve(multi_move->count);
 
 			for (int i = 0; i < multi_move->count; i++) {
-				auto from_slot = multi_move->moves[i].from_slot.SubIndex == -1 ? multi_move->moves[i].from_slot.Slot : m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot, multi_move->moves[i].from_slot.SubIndex);
-				auto to_slot   = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot, multi_move->moves[i].to_slot.SubIndex);
+				// These are always bags, so we don't need to worry about raw items in slotCursor
+				auto from_slot   = m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot, multi_move->moves[i].from_slot.SubIndex);
+				if (multi_move->moves[i].from_slot.Type == 1) { // Target is bank inventory
+					from_slot = m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot + EQ::invslot::BANK_BEGIN, multi_move->moves[i].from_slot.SubIndex);
+				} else if (multi_move->moves[i].from_slot.Type == 2) { // Target is shared bank inventory
+					from_slot = m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot + EQ::invslot::SHARED_BANK_BEGIN, multi_move->moves[i].from_slot.SubIndex);
+				}
 
+				auto to_slot   = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot, multi_move->moves[i].to_slot.SubIndex);
 				if (multi_move->moves[i].to_slot.Type == 1) { // Target is bank inventory
 					to_slot = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot + EQ::invslot::BANK_BEGIN, multi_move->moves[i].to_slot.SubIndex);
 				} else if (multi_move->moves[i].to_slot.Type == 2) { // Target is shared bank inventory

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -10996,7 +10996,7 @@ void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
 					from_slot = m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot + EQ::invslot::SHARED_BANK_BEGIN, multi_move->moves[i].from_slot.SubIndex);
 				}
 
-				int16 to_slot   = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot, multi_move->moves[i].to_slot.SubIndex);
+				uint16 to_slot   = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot, multi_move->moves[i].to_slot.SubIndex);
 				if (multi_move->moves[i].to_slot.Type == EQ::invtype::typeBank) { // Target is bank inventory
 					to_slot = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot + EQ::invslot::BANK_BEGIN, multi_move->moves[i].to_slot.SubIndex);
 				} else if (multi_move->moves[i].to_slot.Type == EQ::invtype::typeSharedBank) { // Target is shared bank inventory

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -10915,7 +10915,7 @@ void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
 {
 	// This packet is only sent from the client if we ctrl click items in inventory
 	if (m_ClientVersionBit & EQ::versions::maskRoF2AndLater) {
-		LogDebug("OP_MoveMultipleItems Triggered");
+		
 		if (!CharacterID()) {
 			LinkDead();
 			return;
@@ -10988,15 +10988,20 @@ void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
     		items.reserve(multi_move->count);
 
 			for (int i = 0; i < multi_move->count; i++) {
-				auto from_slot = multi_move->moves[i].from_slot.SubIndex == -1 ? multi_move->moves[i].from_slot.Slot : m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot, multi_move->moves[i].from_slot.SubIndex);
-				auto to_slot   = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot, multi_move->moves[i].to_slot.SubIndex);
+				// These are always bags, so we don't need to worry about raw items in slotCursor
+				auto from_slot   = m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot, multi_move->moves[i].from_slot.SubIndex);
+				if (multi_move->moves[i].from_slot.Type == 1) { // Target is bank inventory
+					from_slot = m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot + EQ::invslot::BANK_BEGIN, multi_move->moves[i].from_slot.SubIndex);
+				} else if (multi_move->moves[i].from_slot.Type == 2) { // Target is shared bank inventory
+					from_slot = m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot + EQ::invslot::SHARED_BANK_BEGIN, multi_move->moves[i].from_slot.SubIndex);
+				}
 
+				auto to_slot   = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot, multi_move->moves[i].to_slot.SubIndex);
 				if (multi_move->moves[i].to_slot.Type == 1) { // Target is bank inventory
 					to_slot = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot + EQ::invslot::BANK_BEGIN, multi_move->moves[i].to_slot.SubIndex);
 				} else if (multi_move->moves[i].to_slot.Type == 2) { // Target is shared bank inventory
 					to_slot = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot + EQ::invslot::SHARED_BANK_BEGIN, multi_move->moves[i].to_slot.SubIndex);
 				}
-
 
 				// Probably need some error checking here, but I wasn't able to produce any error states on purpose.				
 				MoveInfo move;

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -10943,8 +10943,7 @@ void Client::Handle_OP_MoveItem(const EQApplicationPacket *app)
 void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
 {
 	// This packet is only sent from the client if we ctrl click items in inventory
-	if (m_ClientVersionBit & EQ::versions::maskRoF2AndLater) {
-		
+	if (m_ClientVersionBit & EQ::versions::maskRoF2AndLater) {		
 		if (!CharacterID()) {
 			LinkDead();
 			return;
@@ -11017,15 +11016,9 @@ void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
     		items.reserve(multi_move->count);
 
 			for (int i = 0; i < multi_move->count; i++) {
-				// These are always bags, so we don't need to worry about raw items in slotCursor
-				auto from_slot   = m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot, multi_move->moves[i].from_slot.SubIndex);
-				if (multi_move->moves[i].from_slot.Type == 1) { // Target is bank inventory
-					from_slot = m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot + EQ::invslot::BANK_BEGIN, multi_move->moves[i].from_slot.SubIndex);
-				} else if (multi_move->moves[i].from_slot.Type == 2) { // Target is shared bank inventory
-					from_slot = m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot + EQ::invslot::SHARED_BANK_BEGIN, multi_move->moves[i].from_slot.SubIndex);
-				}
-
+				auto from_slot = multi_move->moves[i].from_slot.SubIndex == -1 ? multi_move->moves[i].from_slot.Slot : m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot, multi_move->moves[i].from_slot.SubIndex);
 				auto to_slot   = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot, multi_move->moves[i].to_slot.SubIndex);
+
 				if (multi_move->moves[i].to_slot.Type == 1) { // Target is bank inventory
 					to_slot = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot + EQ::invslot::BANK_BEGIN, multi_move->moves[i].to_slot.SubIndex);
 				} else if (multi_move->moves[i].to_slot.Type == 2) { // Target is shared bank inventory

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -10955,9 +10955,9 @@ void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
 				mi->from_slot 	= multi_move->moves[i].from_slot.SubIndex == -1 ? multi_move->moves[i].from_slot.Slot : m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot, multi_move->moves[i].from_slot.SubIndex);									
 				mi->to_slot = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot, multi_move->moves[i].to_slot.SubIndex);
 				
-				if (multi_move->moves[i].to_slot.Type == 1) { // Target is bank inventory
+				if (multi_move->moves[i].to_slot.Type == EQ::invtype::inventoryBank) { // Target is bank inventory
 					mi->to_slot = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot + EQ::invslot::BANK_BEGIN, multi_move->moves[i].to_slot.SubIndex);
-				} else if (multi_move->moves[i].to_slot.Type == 2) { // Target is shared bank inventory
+				} else if (multi_move->moves[i].to_slot.Type == EQ::invtype::inventorySharedBank) { // Target is shared bank inventory
 					mi->to_slot = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot + EQ::invslot::SHARED_BANK_BEGIN, multi_move->moves[i].to_slot.SubIndex);
 				}				
 
@@ -10990,16 +10990,16 @@ void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
 			for (int i = 0; i < multi_move->count; i++) {
 				// These are always bags, so we don't need to worry about raw items in slotCursor
 				auto from_slot   = m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot, multi_move->moves[i].from_slot.SubIndex);
-				if (multi_move->moves[i].from_slot.Type == 1) { // Target is bank inventory
+				if (multi_move->moves[i].from_slot.Type == EQ::invtype::inventoryBank) { // Target is bank inventory
 					from_slot = m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot + EQ::invslot::BANK_BEGIN, multi_move->moves[i].from_slot.SubIndex);
-				} else if (multi_move->moves[i].from_slot.Type == 2) { // Target is shared bank inventory
+				} else if (multi_move->moves[i].from_slot.Type == EQ::invtype::inventorySharedBank) { // Target is shared bank inventory
 					from_slot = m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot + EQ::invslot::SHARED_BANK_BEGIN, multi_move->moves[i].from_slot.SubIndex);
 				}
 
 				auto to_slot   = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot, multi_move->moves[i].to_slot.SubIndex);
-				if (multi_move->moves[i].to_slot.Type == 1) { // Target is bank inventory
+				if (multi_move->moves[i].to_slot.Type == EQ::invtype::inventoryBank) { // Target is bank inventory
 					to_slot = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot + EQ::invslot::BANK_BEGIN, multi_move->moves[i].to_slot.SubIndex);
-				} else if (multi_move->moves[i].to_slot.Type == 2) { // Target is shared bank inventory
+				} else if (multi_move->moves[i].to_slot.Type == EQ::invtype::inventorySharedBank) { // Target is shared bank inventory
 					to_slot = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot + EQ::invslot::SHARED_BANK_BEGIN, multi_move->moves[i].to_slot.SubIndex);
 				}
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -10913,7 +10913,9 @@ void Client::Handle_OP_MoveItem(const EQApplicationPacket *app)
 
 void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
 {
-	if (m_ClientVersionBit & EQ::versions::maskRoF2AndLater) {		
+	// This packet is only sent from the client if we ctrl click items in inventory
+	if (m_ClientVersionBit & EQ::versions::maskRoF2AndLater) {
+		LogDebug("OP_MoveMultipleItems Triggered");
 		if (!CharacterID()) {
 			LinkDead();
 			return;
@@ -10930,34 +10932,85 @@ void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
 			return; // Packet size does not match expected size
 		}
 			
-		const auto from_bag = multi_move->moves[0].from_slot.Slot;
-		const auto to_bag   = multi_move->moves[0].to_slot.Slot;		
+		const auto from_parent = multi_move->moves[0].from_slot.Slot;
+		const auto to_parent   = multi_move->moves[0].to_slot.Slot;
 
-		// This is checked by the client, but can't hurt to check here too.
-		if (m_inv.GetItem(from_bag)->IsClassBag() && m_inv.GetItem(to_bag)->IsClassBag()) {
+		// CTRL + left click drops an item into a bag without opening it.
+		// This can be a bag, in which case it tries to fill the target bag with the contents of the bag on the cursor
+		// CTRL + right click swaps the contents of two bags if a bag is on your cursor and you ctrl-right click on another bag.
+
+		// We need to check if this is a swap or just an addition (left click or right click)
+		// Check if any component of this transaction is coming from anywhere other than the cursor
+		int left_click = true;
+		for (int i = 0; i < multi_move->count; i++) {
+			if (multi_move->moves[i].from_slot.Slot != EQ::invslot::slotCursor) {
+				left_click = false;
+			}
+		}
+
+		// This is a left click which is purely additive. This should always be cursor object or cursor bag contents into general\bank\whatever bag
+		if (left_click) {
 			for (int i = 0; i < multi_move->count; i++) {
 				MoveItem_Struct* mi = new MoveItem_Struct();
-				mi->from_slot = m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot, multi_move->moves[i].from_slot.SubIndex);
-				mi->to_slot   = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot, multi_move->moves[i].to_slot.SubIndex);
-				mi->number_in_stack = 0; // This is always 0 in MoveItem_Struct unless we are combining stacks, which this never tries to do.
+				mi->from_slot 	= multi_move->moves[i].from_slot.SubIndex == -1 ? multi_move->moves[i].from_slot.Slot : m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot, multi_move->moves[i].from_slot.SubIndex);									
+				mi->to_slot = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot, multi_move->moves[i].to_slot.SubIndex);
+				
+				if (multi_move->moves[i].to_slot.Type == 1) { // Target is bank inventory
+					mi->to_slot = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot + EQ::invslot::BANK_BEGIN, multi_move->moves[i].to_slot.SubIndex);
+				} else if (multi_move->moves[i].to_slot.Type == 2) { // Target is shared bank inventory
+					mi->to_slot = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot + EQ::invslot::SHARED_BANK_BEGIN, multi_move->moves[i].to_slot.SubIndex);
+				}				
 
-				LogInventory("Swapping slot [{}] to slot [{}]",mi->from_slot,mi->to_slot);
+				// This sends '1' as the stack count for unstackable items, which our titanium-era SwapItem blows up
+				if (m_inv.GetItem(mi->from_slot)->IsStackable()) {
+					mi->number_in_stack = multi_move->moves[i].number_in_stack;
+				} else {
+					mi->number_in_stack = 0;
+				}
 
 				if (!SwapItem(mi) && IsValidSlot(mi->from_slot) && IsValidSlot(mi->to_slot)) {
-					SwapItemResync(mi);
-
 					bool error = false;
+					SwapItemResync(mi);					
 					InterrogateInventory(this, false, true, false, error, false);
 					if (error)
 						InterrogateInventory(this, true, false, true, error);
 				}
-
-				safe_delete(mi);
 			}
-			return;
-		} else {
-			LogDebug("ERROR: At least one of the items being swapped was not a bag.");
-		}	
+		// This is the swap.
+		// Client behavior is just to move stacks without combining them
+		} else {			
+			struct MoveInfo {
+				EQ::ItemInstance* item;
+				uint16 to_slot;
+			};
+
+			std::vector<MoveInfo> items;
+    		items.reserve(multi_move->count);
+
+			for (int i = 0; i < multi_move->count; i++) {
+				auto from_slot = multi_move->moves[i].from_slot.SubIndex == -1 ? multi_move->moves[i].from_slot.Slot : m_inv.CalcSlotId(multi_move->moves[i].from_slot.Slot, multi_move->moves[i].from_slot.SubIndex);
+				auto to_slot   = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot, multi_move->moves[i].to_slot.SubIndex);
+
+				if (multi_move->moves[i].to_slot.Type == 1) { // Target is bank inventory
+					to_slot = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot + EQ::invslot::BANK_BEGIN, multi_move->moves[i].to_slot.SubIndex);
+				} else if (multi_move->moves[i].to_slot.Type == 2) { // Target is shared bank inventory
+					to_slot = m_inv.CalcSlotId(multi_move->moves[i].to_slot.Slot + EQ::invslot::SHARED_BANK_BEGIN, multi_move->moves[i].to_slot.SubIndex);
+				}
+
+
+				// Probably need some error checking here, but I wasn't able to produce any error states on purpose.				
+				MoveInfo move;
+				move.item = m_inv.PopItem(from_slot); // Don't delete the instance here
+				move.to_slot = to_slot;
+				if (move.item) {				
+					items.push_back(move);
+				}
+			}
+
+			for (const MoveInfo& move : items) {
+				PutItemInInventory(move.to_slot, *move.item); // This saves inventory too
+			}
+		}
 		
 	} else {
 		LinkDead(); // This packet should not be sent by an older client


### PR DESCRIPTION
# Description

This implements ctrl-click movement of bag contents for ROF+ clients.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# Testing

There are three behaviors that are introduced here;
* CTRL + left click -> drops an item into a bag without opening it.
* CTRL + left click -> adds the contents of a bag (on cursor) into another bag without opening it
* CTRL + right click -> swaps the contents of two bags if a bag is on your cursor and you ctrl-right click on another bag.

I don't know how to attach images to demonstrate this.

I would furthermore like some assistance testing this.

Clients tested: 
* ROF2

# Checklist

- [x] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [ ] I have made corresponding changes to the documentation (if applicable, if not delete this line)
- [X] I own the changes of my code and take responsibility for the potential issues that occur
