### PR TITLE
[Messages] Fix multiple errors in spell damage at death.

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1724,7 +1724,7 @@ void Client::Damage(Mob* other, int64 damage, uint16 spell_id, EQ::skills::Skill
 	}
 }
 
-bool Client::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillType attack_skill, KilledByTypes killed_by)
+bool Client::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillType attack_skill, KilledByTypes killed_by, bool iBuffTic)
 {
 	if (!ClientFinishedLoading() || dead) {
 		return false;
@@ -1786,12 +1786,25 @@ bool Client::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::Skil
 	/* Make Death Packet */
 	EQApplicationPacket app(OP_Death, sizeof(Death_Struct));
 	Death_Struct* d = (Death_Struct*)app.pBuffer;
+
+	// Convert last message to color to avoid duplicate damage messages
+	// that occur in these rare cases when this is the death blow.
+	if (IsValidSpell(spell) &&
+		(attack_skill == EQ::skills::SkillTigerClaw ||
+        (IsDamageSpell(spell) && IsDiscipline(spell)) ||
+		!iBuffTic)) {
+			d->attack_skill = DamageTypeSpell;
+			d->spell_id = (iBuffTic) ? UINT32_MAX : spell;
+	}
+	else {
+		d->attack_skill = SkillDamageTypes[attack_skill];
+		d->spell_id = UINT32_MAX;
+	}
+
 	d->spawn_id = GetID();
 	d->killer_id = killer_mob ? killer_mob->GetID() : 0;
 	d->corpseid = GetID();
 	d->bindzoneid = m_pp.binds[0].zone_id;
-	d->spell_id = IsValidSpell(spell) ? spell : 0xffffffff;
-	d->attack_skill = IsValidSpell(spell) ? 0xe7 : attack_skill;
 	d->damage = damage;
 	app.priority = 6;
 	entity_list.QueueClients(this, &app);
@@ -2380,7 +2393,7 @@ void NPC::Damage(Mob* other, int64 damage, uint16 spell_id, EQ::skills::SkillTyp
 	}
 }
 
-bool NPC::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillType attack_skill, KilledByTypes killed_by)
+bool NPC::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillType attack_skill, KilledByTypes killed_by, bool iBuffTic)
 {
 	LogCombat(
 		"Fatal blow dealt by [{}] with [{}] damage, spell [{}], skill [{}]",
@@ -2493,12 +2506,24 @@ bool NPC::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillTy
 	auto app = new EQApplicationPacket(OP_Death, sizeof(Death_Struct));
 
 	auto d = (Death_Struct*) app->pBuffer;
+ 
+	// Convert last message to color to avoid duplicate damage messages
+	// that occur in these rare cases when this is the death blow.
+	if (IsValidSpell(spell) &&
+		(attack_skill == EQ::skills::SkillTigerClaw ||
+        (IsDamageSpell(spell) && IsDiscipline(spell)) ||
+		!iBuffTic)) {
+			d->attack_skill = DamageTypeSpell;
+			d->spell_id = (iBuffTic) ? UINT32_MAX : spell;
+	}
+	else {
+		d->attack_skill = SkillDamageTypes[attack_skill];
+		d->spell_id = UINT32_MAX;
+	}
 
 	d->spawn_id     = GetID();
 	d->killer_id    = killer_mob ? killer_mob->GetID() : 0;
 	d->bindzoneid   = 0;
-	d->spell_id     = UINT32_MAX;
-	d->attack_skill = SkillDamageTypes[attack_skill];
 	d->damage       = damage;
 	d->corpseid		= GetID();
 
@@ -4257,8 +4282,8 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 
 			if (!IsSaved && !TrySpellOnDeath()) {
 				SetHP(-500);
-
-				if (Death(attacker, damage, spell_id, skill_used)) {
+				// killedByType is clarified in Client::Death if we are client.
+				if (Death(attacker, damage, spell_id, skill_used, KilledByTypes::Killed_NPC, iBuffTic)) {
 					return;
 				}
 			}

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1724,7 +1724,7 @@ void Client::Damage(Mob* other, int64 damage, uint16 spell_id, EQ::skills::Skill
 	}
 }
 
-bool Client::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillType attack_skill, KilledByTypes killed_by, bool iBuffTic)
+bool Client::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillType attack_skill, KilledByTypes killed_by, bool is_buff_tic)
 {
 	if (!ClientFinishedLoading() || dead) {
 		return false;
@@ -1792,9 +1792,9 @@ bool Client::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::Skil
 	if (IsValidSpell(spell) &&
 		(attack_skill == EQ::skills::SkillTigerClaw ||
         (IsDamageSpell(spell) && IsDiscipline(spell)) ||
-		!iBuffTic)) {
+		!is_buff_tic)) {
 			d->attack_skill = DamageTypeSpell;
-			d->spell_id = (iBuffTic) ? UINT32_MAX : spell;
+			d->spell_id = (is_buff_tic) ? UINT32_MAX : spell;
 	}
 	else {
 		d->attack_skill = SkillDamageTypes[attack_skill];
@@ -2393,7 +2393,7 @@ void NPC::Damage(Mob* other, int64 damage, uint16 spell_id, EQ::skills::SkillTyp
 	}
 }
 
-bool NPC::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillType attack_skill, KilledByTypes killed_by, bool iBuffTic)
+bool NPC::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillType attack_skill, KilledByTypes killed_by, bool is_buff_tic)
 {
 	LogCombat(
 		"Fatal blow dealt by [{}] with [{}] damage, spell [{}], skill [{}]",
@@ -2512,9 +2512,9 @@ bool NPC::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillTy
 	if (IsValidSpell(spell) &&
 		(attack_skill == EQ::skills::SkillTigerClaw ||
         (IsDamageSpell(spell) && IsDiscipline(spell)) ||
-		!iBuffTic)) {
+		!is_buff_tic)) {
 			d->attack_skill = DamageTypeSpell;
-			d->spell_id = (iBuffTic) ? UINT32_MAX : spell;
+			d->spell_id = (is_buff_tic) ? UINT32_MAX : spell;
 	}
 	else {
 		d->attack_skill = SkillDamageTypes[attack_skill];

--- a/zone/beacon.h
+++ b/zone/beacon.h
@@ -34,7 +34,7 @@ public:
 	~Beacon();
 
 	//abstract virtual function implementations requird by base abstract class
-	virtual bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by = KilledByTypes::Killed_NPC, bool iBuffTic = false) { return true; }
+	virtual bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by = KilledByTypes::Killed_NPC, bool is_buff_tic = false) { return true; }
 	virtual void Damage(Mob* from, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, bool avoidable = true, int8 buffslot = -1, bool iBuffTic = false, eSpecialAttacks special = eSpecialAttacks::None) { return; }
 	virtual bool HasRaid() { return false; }
 	virtual bool HasGroup() { return false; }

--- a/zone/beacon.h
+++ b/zone/beacon.h
@@ -34,7 +34,7 @@ public:
 	~Beacon();
 
 	//abstract virtual function implementations requird by base abstract class
-	virtual bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by = KilledByTypes::Killed_NPC) { return true; }
+	virtual bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by = KilledByTypes::Killed_NPC, bool iBuffTic = false) { return true; }
 	virtual void Damage(Mob* from, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, bool avoidable = true, int8 buffslot = -1, bool iBuffTic = false, eSpecialAttacks special = eSpecialAttacks::None) { return; }
 	virtual bool HasRaid() { return false; }
 	virtual bool HasGroup() { return false; }

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -4341,7 +4341,7 @@ void Bot::PerformTradeWithClient(int16 begin_slot_id, int16 end_slot_id, Client*
 	}
 }
 
-bool Bot::Death(Mob *killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by, bool iBuffTic)
+bool Bot::Death(Mob *killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by, bool is_buff_tic)
 {
 	if (!NPC::Death(killer_mob, damage, spell_id, attack_skill)) {
 		return false;

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -4341,7 +4341,7 @@ void Bot::PerformTradeWithClient(int16 begin_slot_id, int16 end_slot_id, Client*
 	}
 }
 
-bool Bot::Death(Mob *killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by)
+bool Bot::Death(Mob *killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by, bool iBuffTic)
 {
 	if (!NPC::Death(killer_mob, damage, spell_id, attack_skill)) {
 		return false;

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -131,7 +131,7 @@ public:
 	Bot(uint32 botID, uint32 botOwnerCharacterID, uint32 botSpellsID, double totalPlayTime, uint32 lastZoneId, NPCType *npcTypeData, int32 expansion_bitmask);
 
 	//abstract virtual override function implementations requird by base abstract class
-	bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by = KilledByTypes::Killed_NPC) override;
+	bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by = KilledByTypes::Killed_NPC, bool iBuffTic = false) override;
 	void Damage(Mob* from, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, bool avoidable = true, int8 buffslot = -1,
 		bool iBuffTic = false, eSpecialAttacks special = eSpecialAttacks::None) override;
 

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -131,7 +131,7 @@ public:
 	Bot(uint32 botID, uint32 botOwnerCharacterID, uint32 botSpellsID, double totalPlayTime, uint32 lastZoneId, NPCType *npcTypeData, int32 expansion_bitmask);
 
 	//abstract virtual override function implementations requird by base abstract class
-	bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by = KilledByTypes::Killed_NPC, bool iBuffTic = false) override;
+	bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by = KilledByTypes::Killed_NPC, bool is_buff_tic = false) override;
 	void Damage(Mob* from, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, bool avoidable = true, int8 buffslot = -1,
 		bool iBuffTic = false, eSpecialAttacks special = eSpecialAttacks::None) override;
 

--- a/zone/client.h
+++ b/zone/client.h
@@ -261,7 +261,7 @@ public:
 	bool GotoPlayerRaid(const std::string& player_name);
 
 	//abstract virtual function implementations required by base abstract class
-	virtual bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by = KilledByTypes::Killed_NPC);
+	virtual bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by = KilledByTypes::Killed_NPC, bool iBuffTic = false);
 	virtual void Damage(Mob* from, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, bool avoidable = true, int8 buffslot = -1, bool iBuffTic = false, eSpecialAttacks special = eSpecialAttacks::None);
 	virtual bool HasRaid() { return (GetRaid() ? true : false); }
 	virtual bool HasGroup() { return (GetGroup() ? true : false); }

--- a/zone/client.h
+++ b/zone/client.h
@@ -261,7 +261,7 @@ public:
 	bool GotoPlayerRaid(const std::string& player_name);
 
 	//abstract virtual function implementations required by base abstract class
-	virtual bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by = KilledByTypes::Killed_NPC, bool iBuffTic = false);
+	virtual bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by = KilledByTypes::Killed_NPC, bool is_buff_tic = false);
 	virtual void Damage(Mob* from, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, bool avoidable = true, int8 buffslot = -1, bool iBuffTic = false, eSpecialAttacks special = eSpecialAttacks::None);
 	virtual bool HasRaid() { return (GetRaid() ? true : false); }
 	virtual bool HasGroup() { return (GetGroup() ? true : false); }

--- a/zone/corpse.h
+++ b/zone/corpse.h
@@ -69,7 +69,7 @@ public:
 		uint16 spell_id,
 		EQ::skills::SkillType attack_skill,
 		KilledByTypes killed_by = KilledByTypes::Killed_NPC,
-		bool iBuffTic = false
+		bool is_buff_tic = false
 	) { return true; }
 
 	virtual void Damage(

--- a/zone/corpse.h
+++ b/zone/corpse.h
@@ -68,7 +68,8 @@ public:
 		int64 damage,
 		uint16 spell_id,
 		EQ::skills::SkillType attack_skill,
-		KilledByTypes killed_by = KilledByTypes::Killed_NPC
+		KilledByTypes killed_by = KilledByTypes::Killed_NPC,
+		bool iBuffTic = false
 	) { return true; }
 
 	virtual void Damage(

--- a/zone/encounter.h
+++ b/zone/encounter.h
@@ -34,7 +34,7 @@ public:
 	~Encounter();
 
 	//abstract virtual function implementations required by base abstract class
-	virtual bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by = KilledByTypes::Killed_NPC) { return true; }
+	virtual bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by = KilledByTypes::Killed_NPC, bool iBuffTic = false) { return true; }
 	virtual void Damage(Mob* from, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, bool avoidable = true, int8 buffslot = -1, bool iBuffTic = false, eSpecialAttacks special = eSpecialAttacks::None) { return; }
 	bool Attack(Mob* other, int Hand = EQ::invslot::slotPrimary, bool FromRiposte = false, bool IsStrikethrough = false,
 		bool IsFromSpell = false, ExtraAttackOptions *opts = nullptr) override {

--- a/zone/encounter.h
+++ b/zone/encounter.h
@@ -34,7 +34,7 @@ public:
 	~Encounter();
 
 	//abstract virtual function implementations required by base abstract class
-	virtual bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by = KilledByTypes::Killed_NPC, bool iBuffTic = false) { return true; }
+	virtual bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by = KilledByTypes::Killed_NPC, bool is_buff_tic = false) { return true; }
 	virtual void Damage(Mob* from, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, bool avoidable = true, int8 buffslot = -1, bool iBuffTic = false, eSpecialAttacks special = eSpecialAttacks::None) { return; }
 	bool Attack(Mob* other, int Hand = EQ::invslot::slotPrimary, bool FromRiposte = false, bool IsStrikethrough = false,
 		bool IsFromSpell = false, ExtraAttackOptions *opts = nullptr) override {

--- a/zone/merc.cpp
+++ b/zone/merc.cpp
@@ -4070,7 +4070,7 @@ Mob* Merc::GetOwnerOrSelf() {
 	return Result;
 }
 
-bool Merc::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillType attack_skill, uint8 killed_by)
+bool Merc::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillType attack_skill, uint8 killed_by, bool iBuffTic)
 {
 	if (!NPC::Death(killer_mob, damage, spell, attack_skill)) {
 		return false;

--- a/zone/merc.cpp
+++ b/zone/merc.cpp
@@ -4070,7 +4070,7 @@ Mob* Merc::GetOwnerOrSelf() {
 	return Result;
 }
 
-bool Merc::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillType attack_skill, uint8 killed_by, bool iBuffTic)
+bool Merc::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillType attack_skill, uint8 killed_by, bool is_buff_tic)
 {
 	if (!NPC::Death(killer_mob, damage, spell, attack_skill)) {
 		return false;

--- a/zone/merc.h
+++ b/zone/merc.h
@@ -52,7 +52,7 @@ public:
 	virtual ~Merc();
 
 	//abstract virtual function implementations requird by base abstract class
-	virtual bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, uint8 killed_by = 0, bool iBuffTic = false);
+	virtual bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, uint8 killed_by = 0, bool is_buff_tic = false);
 	virtual void Damage(Mob* from, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, bool avoidable = true, int8 buffslot = -1, bool iBuffTic = false, eSpecialAttacks special = eSpecialAttacks::None);
 	virtual bool Attack(Mob* other, int Hand = EQ::invslot::slotPrimary, bool FromRiposte = false, bool IsStrikethrough = false,
 	bool IsFromSpell = false, ExtraAttackOptions *opts = nullptr);

--- a/zone/merc.h
+++ b/zone/merc.h
@@ -52,7 +52,7 @@ public:
 	virtual ~Merc();
 
 	//abstract virtual function implementations requird by base abstract class
-	virtual bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, uint8 killed_by = 0);
+	virtual bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, uint8 killed_by = 0, bool iBuffTic = false);
 	virtual void Damage(Mob* from, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, bool avoidable = true, int8 buffslot = -1, bool iBuffTic = false, eSpecialAttacks special = eSpecialAttacks::None);
 	virtual bool Attack(Mob* other, int Hand = EQ::invslot::slotPrimary, bool FromRiposte = false, bool IsStrikethrough = false,
 	bool IsFromSpell = false, ExtraAttackOptions *opts = nullptr);

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -541,7 +541,7 @@ public:
 	bool CanClassEquipItem(uint32 item_id);
 	bool CanRaceEquipItem(uint32 item_id);
 	bool AffectedBySpellExcludingSlot(int slot, int effect);
-	virtual bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by = KilledByTypes::Killed_NPC) = 0;
+	virtual bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by = KilledByTypes::Killed_NPC, bool iBuffTic = false) = 0;
 	virtual void Damage(Mob* from, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill,
 		bool avoidable = true, int8 buffslot = -1, bool iBuffTic = false, eSpecialAttacks special = eSpecialAttacks::None) = 0;
 	void SetHP(int64 hp);

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -541,7 +541,7 @@ public:
 	bool CanClassEquipItem(uint32 item_id);
 	bool CanRaceEquipItem(uint32 item_id);
 	bool AffectedBySpellExcludingSlot(int slot, int effect);
-	virtual bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by = KilledByTypes::Killed_NPC, bool iBuffTic = false) = 0;
+	virtual bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by = KilledByTypes::Killed_NPC, bool is_buff_tic = false) = 0;
 	virtual void Damage(Mob* from, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill,
 		bool avoidable = true, int8 buffslot = -1, bool iBuffTic = false, eSpecialAttacks special = eSpecialAttacks::None) = 0;
 	void SetHP(int64 hp);

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -130,7 +130,7 @@ public:
 	static NPC * SpawnZonePointNodeNPC(std::string name, const glm::vec4 &position);
 
 	//abstract virtual function implementations requird by base abstract class
-	virtual bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by = KilledByTypes::Killed_NPC);
+	virtual bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by = KilledByTypes::Killed_NPC, bool iBuffTic = false);
 	virtual void Damage(Mob* from, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, bool avoidable = true, int8 buffslot = -1, bool iBuffTic = false, eSpecialAttacks special = eSpecialAttacks::None);
 	bool Attack(Mob* other, int Hand = EQ::invslot::slotPrimary, bool FromRiposte = false, bool IsStrikethrough = false,
 		bool IsFromSpell = false, ExtraAttackOptions *opts = nullptr) override;

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -130,7 +130,7 @@ public:
 	static NPC * SpawnZonePointNodeNPC(std::string name, const glm::vec4 &position);
 
 	//abstract virtual function implementations requird by base abstract class
-	virtual bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by = KilledByTypes::Killed_NPC, bool iBuffTic = false);
+	virtual bool Death(Mob* killer_mob, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, KilledByTypes killed_by = KilledByTypes::Killed_NPC, bool is_buff_tic = false);
 	virtual void Damage(Mob* from, int64 damage, uint16 spell_id, EQ::skills::SkillType attack_skill, bool avoidable = true, int8 buffslot = -1, bool iBuffTic = false, eSpecialAttacks special = eSpecialAttacks::None);
 	bool Attack(Mob* other, int Hand = EQ::invslot::slotPrimary, bool FromRiposte = false, bool IsStrikethrough = false,
 		bool IsFromSpell = false, ExtraAttackOptions *opts = nullptr) override;


### PR DESCRIPTION
# Description

This fixes a few errors in messages that appeared, or were missing at the time of a death to spell damage.

1. If a mob died to a proc (like poison or weapon proc) or to a damagjng discipline, the non-melee damage came out twice.
2. If a mob died to spell damage (non-dot) the color message did not come out.  (xyz has been poisoned, etc)
3. If a mob died to DoT spell damage sometimes the color message _did_ come out on the tic at which the mob died, which is incorrect.


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

Before and after examples:

1 Before:
[Wed Apr 10 09:42:59 2024] Noudess hit a skeletal monk for 117 points of non-melee damage.
[Wed Apr 10 09:42:59 2024] You strike a skeletal monk for 117 points of damage.
[Wed Apr 10 09:42:59 2024] You have slain a skeletal monk!

1 After:
[Wed Apr 10 20:27:05 2024] Noudess hit dry bone skeleton for 117 points of non-melee damage.
[Wed Apr 10 20:27:05 2024] Dry bone skeleton has been poisoned.
[Wed Apr 10 20:27:05 2024] You have slain dry bone skeleton!

2 Before:
[Tue Apr 16 10:34:33 2024] Nowdess hit a skeleton for 81 points of non-melee damage.
[Tue Apr 16 10:34:33 2024] You have slain a skeleton!

2 After:
[Tue Apr 16 10:53:13 2024] Nowdess hit a skeleton for 81 points of non-melee damage.
[Tue Apr 16 10:53:13 2024] A skeleton has been poisoned.
[Tue Apr 16 10:53:13 2024] You have slain a skeleton!

3 Before:
[Tue Apr 16 11:14:18 2024] Nowdess hit Bear for 6 points of non-melee damage.
[Tue Apr 16 11:14:18 2024] Nowdess has defeated Bear in a duel to the death!
[Tue Apr 16 11:14:18 2024] Bear has been poisoned.
[Tue Apr 16 11:14:18 2024] Your Poison Bolt spell has worn off of Bear.
[Tue Apr 16 11:14:18 2024] You have slain Bear!

3 After:
[Tue Apr 16 11:05:20 2024] Nowdess hit a skeleton for 10 points of non-melee damage.
[Tue Apr 16 11:05:20 2024] Your Poison Bolt spell has worn off of a skeleton.
[Tue Apr 16 11:05:20 2024] You have slain a skeleton!

Clients tested: RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur

