### PR TITLE
[Bug Fix] Fix Issue With Auto Login

### DIFF
--- a/world/client.cpp
+++ b/world/client.cpp
@@ -205,7 +205,7 @@ void Client::SendEnterWorld(std::string name)
 		LogInfo("Zoning with live_name [{}] account_id [{}]", live_name, GetAccountID());
 	}
 
-	if (RuleB(World, EnableAutoLogin)) {
+	if (!is_player_zoning && RuleB(World, EnableAutoLogin)) {
 		live_name = AccountRepository::GetAutoLoginCharacterNameByAccountID(database, GetAccountID());
 		LogInfo("Attempting to auto login with live_name [{}] account_id [{}]", live_name, GetAccountID());
 	}


### PR DESCRIPTION
# Description
Found this issue when testing #4266 and zoning around.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

Prior to this change, if auto login was enabled it would attempt to use your auto login character name whenever you zoned instead of only when you logged in, this fix makes sure it only happens on login and not every time you zone so that it doesn't kick you to server select.

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur