### PR TITLE
[Quest API] Add Zone Methods to Perl/Lua

### DIFF
--- a/common/zone_store.cpp
+++ b/common/zone_store.cpp
@@ -162,6 +162,32 @@ std::string ZoneStore::GetZoneLongName(uint32 zone_id)
 	return {};
 }
 
+std::string ZoneStore::GetZoneShortNameByLongName(const std::string& zone_long_name)
+{
+	for (const auto& z : m_zones) {
+		if (z.long_name == zone_long_name) {
+			return z.short_name;
+		}
+	}
+
+	LogInfo("Failed to get zone short name by zone_long_name [{}]", zone_long_name);
+
+	return {};
+}
+
+uint32 ZoneStore::GetZoneIDByLongName(const std::string& zone_long_name)
+{
+	for (const auto& z : m_zones) {
+		if (z.long_name == zone_long_name) {
+			return z.zoneidnumber;
+		}
+	}
+
+	LogInfo("Failed to get zone ID by zone_long_name [{}]", zone_long_name);
+
+	return {};
+}
+
 /**
  * @param zone_id
  * @param version

--- a/common/zone_store.cpp
+++ b/common/zone_store.cpp
@@ -185,7 +185,7 @@ uint32 ZoneStore::GetZoneIDByLongName(const std::string& zone_long_name)
 
 	LogInfo("Failed to get zone ID by zone_long_name [{}]", zone_long_name);
 
-	return {};
+	return 0;
 }
 
 /**

--- a/common/zone_store.h
+++ b/common/zone_store.h
@@ -42,6 +42,8 @@ public:
 	uint32 GetZoneID(std::string zone_name);
 	std::string GetZoneName(uint32 zone_id);
 	std::string GetZoneLongName(uint32 zone_id);
+	std::string GetZoneShortNameByLongName(const std::string& zone_long_name);
+	uint32 GetZoneIDByLongName(const std::string& zone_long_name);
 	const char *GetZoneName(uint32 zone_id, bool error_unknown = false);
 	const char *GetZoneLongName(uint32 zone_id, bool error_unknown = false);
 	ZoneRepository::Zone *GetZoneWithFallback(uint32 zone_id, int version = 0);

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -5865,6 +5865,16 @@ bool Perl__SetAutoLoginCharacterNameByAccountID(uint32 account_id, std::string c
 	return quest_manager.SetAutoLoginCharacterNameByAccountID(account_id, character_name);
 }
 
+uint32 Perl__GetZoneIDByLongName(std::string zone_long_name)
+{
+	return zone_store.GetZoneIDByLongName(zone_long_name);
+}
+
+std::string Perl__GetZoneShortNameByLongName(std::string zone_long_name)
+{
+	return zone_store.GetZoneShortNameByLongName(zone_long_name);
+}
+
 void perl_register_quest()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -5951,6 +5961,7 @@ void perl_register_quest()
 	package.add("GetZoneInstanceType", (uint8(*)(uint32))&Perl__GetZoneInstanceType);
 	package.add("GetZoneInstanceType", (uint8(*)(uint32, int))&Perl__GetZoneInstanceType);
 	package.add("GetZoneID", &Perl__GetZoneID);
+	package.add("GetZoneIDByLongName", (uint32(*)(std::string))&Perl__GetZoneIDByLongName);
 	package.add("GetZoneExpansion", (int8(*)(uint32))&Perl__GetZoneExpansion);
 	package.add("GetZoneExpansion", (int8(*)(uint32, int))&Perl__GetZoneExpansion);
 	package.add("GetZoneExperienceMultiplier", (float(*)(uint32))&Perl__GetZoneExperienceMultiplier);
@@ -6030,6 +6041,8 @@ void perl_register_quest()
 	package.add("GetZoneSafeZ", (float(*)(uint32, int))&Perl__GetZoneSafeZ);
 	package.add("GetZoneSecondsBeforeIdle", (uint32(*)(uint32))&Perl__GetZoneSecondsBeforeIdle);
 	package.add("GetZoneSecondsBeforeIdle", (uint32(*)(uint32, int))&Perl__GetZoneSecondsBeforeIdle);
+	package.add("GetZoneShortName", (std::string(*)(uint32))&Perl__GetZoneShortName);
+	package.add("GetZoneShortNameByLongName", (std::string(*)(std::string))&Perl__GetZoneShortNameByLongName);
 	package.add("GetZoneShutdownDelay", (uint64(*)(uint32))&Perl__GetZoneShutdownDelay);
 	package.add("GetZoneShutdownDelay", (uint64(*)(uint32, int))&Perl__GetZoneShutdownDelay);
 	package.add("GetZoneSky", (uint8(*)(uint32))&Perl__GetZoneSky);
@@ -6046,7 +6059,6 @@ void perl_register_quest()
 	package.add("GetZoneSuspendBuffs", (uint8(*)(uint32, int))&Perl__GetZoneSuspendBuffs);
 	package.add("GetZoneZType", (uint8(*)(uint32))&Perl__GetZoneZType);
 	package.add("GetZoneZType", (uint8(*)(uint32, int))&Perl__GetZoneZType);
-	package.add("GetZoneShortName", &Perl__GetZoneShortName);
 	package.add("GetZoneTimeType", (uint8(*)(uint32))&Perl__GetZoneTimeType);
 	package.add("GetZoneTimeType", (uint8(*)(uint32, int))&Perl__GetZoneTimeType);
 	package.add("GetZoneTimeZone", (int(*)(uint32))&Perl__GetZoneTimeZone);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -5496,6 +5496,14 @@ bool lua_set_auto_login_character_name_by_account_id(uint32 account_id, std::str
 	return quest_manager.SetAutoLoginCharacterNameByAccountID(account_id, character_name);
 }
 
+uint32 lua_get_zone_id_by_long_name(std::string zone_long_name) {
+	return zone_store.GetZoneIDByLongName(zone_long_name);
+}
+
+std::string lua_get_zone_short_name_by_long_name(std::string zone_long_name) {
+	return zone_store.GetZoneShortNameByLongName(zone_long_name);
+}
+
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
 	cur = table[#name]; \
 	if(luabind::type(cur) != LUA_TNIL) { \
@@ -6297,6 +6305,8 @@ luabind::scope lua_register_general() {
 		luabind::def("get_race_bitmask", &lua_get_race_bitmask),
 		luabind::def("get_auto_login_character_name_by_account_id", &lua_get_auto_login_character_name_by_account_id),
 		luabind::def("set_auto_login_character_name_by_account_id", &lua_set_auto_login_character_name_by_account_id),
+		luabind::def("get_zone_id_by_long_name", &lua_get_zone_id_by_long_name),
+		luabind::def("get_zone_short_name_by_long_name", &lua_get_zone_short_name_by_long_name),
 		/*
 			Cross Zone
 		*/


### PR DESCRIPTION
# Description
- Adds new methods for getting zone ID and zone short name by zone long name.

## Perl
- Adds `quest::GetZoneIDByLongName(zone_long_name)`.
- Adds `quest::GetZoneShortNameByLongName(zone_long_name)`.

## Lua
- Adds `eq.get_zone_id_by_long_name(zone_long_name)`.
- Adds `eq.get_zone_short_name_by_long_name(zone_long_name)`.

## Type of Change
- [X] New feature (non-breaking change which adds functionality)

# Testing
## Perl
### Script
```pl
sub EVENT_SAY {
	if ($text=~/#a/i) {
		my $zone_id = quest::GetZoneIDByLongName("South Qeynos");
		my $zone_short_name = quest::GetZoneShortNameByLongName("South Qeynos");
		quest::message(315, "Perl | ID [$zone_id] Short Name [$zone_short_name]");
	}
}
```

## Lua
### Script
```lua
function event_say(e)
	if e.message:findi("#a") then
		local zone_id = eq.get_zone_id_by_long_name("South Qeynos");
		local zone_short_name = eq.get_zone_short_name_by_long_name("South Qeynos");
		eq.message(315, string.format("Lua | ID [%s] Short Name [%s]", tostring(zone_id), zone_short_name))
	end
end
```

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur