### PR TITLE
[Commands] Adjust #kill/#list Commands

### DIFF
--- a/zone/gm_commands/kill.cpp
+++ b/zone/gm_commands/kill.cpp
@@ -2,27 +2,40 @@
 
 void command_kill(Client *c, const Seperator *sep)
 {
-	auto target = c->GetTarget();
-	if (!target) {
-		c->Message(Chat::White, "You must have a target to use this command.");
+	if (!sep->IsNumber(1) && !c->GetTarget()) {
+		c->Message(Chat::White, "#kill - Kills your target");
+		c->Message(Chat::White, "#kill [entity_id] - Kills the entity ID you provided");
 		return;
 	}
 
-	if (
-		!target->IsClient() ||
-		target->CastToClient()->Admin() <= c->Admin()
-	) {
-		if (c != target) {
+	Mob* t = nullptr;
+	uint16 entity_id = 0;
+
+	if (sep->IsNumber(1)) {
+		entity_id = static_cast<uint16>(Strings::ToUnsignedInt(sep->arg[1]));
+		t         = entity_list.GetMob(entity_id);
+	} else {
+		t = c->GetTarget();
+	}
+
+	if (!t) {
+		c->Message(Chat::White, "You must have a target or supply an entity ID to use this command.");
+		return;
+	}
+
+	if (!t->IsClient() || t->CastToClient()->Admin() <= c->Admin()) {
+		if (c != t) {
 			c->Message(
 				Chat::White,
 				fmt::format(
-					"Killing {}.",
-					c->GetTargetDescription(target)
+					"Killing {}{}.",
+					c->GetTargetDescription(t),
+					entity_id ? " by entity id" : ""
 				).c_str()
 			);
 		}
 
-		target->Kill();
+		t->Kill();
 	}
 }
 

--- a/zone/gm_commands/list.cpp
+++ b/zone/gm_commands/list.cpp
@@ -12,13 +12,16 @@ struct UniqueEntity {
 
 void command_list(Client *c, const Seperator *sep)
 {
-	const int arguments = sep->argnum;
+	const uint16 arguments = sep->argnum;
 	if (!arguments) {
-		c->Message(Chat::White, "Usage: #list [corpses|doors|npcs|objects|players] [search]");
+		c->Message(Chat::White, "Usage: #list [bots|corpses|doors|npcs|objects|players] [search]");
 		c->Message(Chat::White, "Example: #list npcs (Blank for all)");
 		return;
 	}
 
+	const bool can_kill = c->Admin() >= GetCommandStatus("kill");
+
+	const bool is_bots    = !strcasecmp(sep->arg[1], "bots");
 	const bool is_corpses = !strcasecmp(sep->arg[1], "corpses");
 	const bool is_doors   = !strcasecmp(sep->arg[1], "doors");
 	const bool is_npcs    = !strcasecmp(sep->arg[1], "npcs");
@@ -26,13 +29,14 @@ void command_list(Client *c, const Seperator *sep)
 	const bool is_players = !strcasecmp(sep->arg[1], "players");
 
 	if (
+		!is_bots &&
 		!is_corpses &&
 		!is_doors &&
 		!is_npcs &&
 		!is_objects &&
 		!is_players
 	) {
-		c->Message(Chat::White, "Usage: #list [npcs|players|corpses|doors|objects] [search]");
+		c->Message(Chat::White, "Usage: #list [bots|corpses|doors|npcs|objects|players] [search]");
 		c->Message(Chat::White, "Example: #list npcs (Blank for all)");
 		return;
 	}
@@ -40,20 +44,23 @@ void command_list(Client *c, const Seperator *sep)
 	std::string search_type;
 	std::string unique_type;
 
-	if (is_corpses) {
-		search_type = "corpse";
+	if (is_bots) {
+		search_type = "bots";
+		unique_type = "Bot ID";
+	} else if (is_corpses) {
+		search_type = "corpses";
 		unique_type = "Corpse ID";
 	} else if (is_doors) {
-		search_type = "door";
+		search_type = "doors";
 		unique_type = "Door ID";
 	} else if (is_npcs) {
-		search_type = "NPC";
+		search_type = "NPCs";
 		unique_type = "NPC ID";
 	} else if (is_objects) {
-		search_type = "object";
+		search_type = "objects";
 		unique_type = "Object ID";
 	} else if (is_players) {
-		search_type = "player";
+		search_type = "players";
 		unique_type = "Character ID";
 	}
 
@@ -64,16 +71,38 @@ void command_list(Client *c, const Seperator *sep)
 
 	std::vector<UniqueEntity> unique_entities;
 
-	if (is_corpses) {
-		const auto &l = entity_list.GetCorpseList();
+	if (is_bots) {
+		const auto& l = entity_list.GetBotList();
 
-		for (const auto &e : l) {
-			Corpse *entity = e.second;
+		for (const auto& e: l) {
+			entity_count++;
+
+			const std::string& entity_name = Strings::ToLower(e->GetName());
+			if (!search_string.empty() && !Strings::Contains(entity_name, search_string)) {
+				continue;
+			}
+
+			unique_entities.emplace_back(
+				UniqueEntity{
+					.entity_id = e->GetID(),
+					.entity_name = e->GetName(),
+					.unique_id = e->GetBotID(),
+					.position = e->GetPosition()
+				}
+			);
+
+			found_count++;
+		}
+	} else if (is_corpses) {
+		const auto& l = entity_list.GetCorpseList();
+
+		for (const auto& e: l) {
+			Corpse* entity = e.second;
 
 			entity_count++;
 
-			const std::string &entity_name = Strings::ToLower(entity->GetName());
-			if (!search_string.empty() && entity_name.find(search_string) == std::string::npos) {
+			const std::string& entity_name = Strings::ToLower(entity->GetName());
+			if (!search_string.empty() && !Strings::Contains(entity_name, search_string)) {
 				continue;
 			}
 
@@ -89,15 +118,15 @@ void command_list(Client *c, const Seperator *sep)
 			found_count++;
 		}
 	} else if (is_doors) {
-		const auto &l = entity_list.GetDoorsList();
+		const auto& l = entity_list.GetDoorsList();
 
-		for (const auto &e : l) {
-			Doors *entity = e.second;
+		for (const auto& e: l) {
+			Doors* entity = e.second;
 
 			entity_count++;
 
-			const std::string &entity_name = Strings::ToLower(entity->GetDoorName());
-			if (!search_string.empty() && entity_name.find(search_string) == std::string::npos) {
+			const std::string& entity_name = Strings::ToLower(entity->GetDoorName());
+			if (!search_string.empty() && !Strings::Contains(entity_name, search_string)) {
 				continue;
 			}
 
@@ -113,18 +142,18 @@ void command_list(Client *c, const Seperator *sep)
 			found_count++;
 		}
 	} else if (is_npcs) {
-		const auto &l = entity_list.GetMobList();
+		const auto& l = entity_list.GetMobList();
 
-		for (const auto &e : l) {
-			Mob *entity = e.second;
+		for (const auto& e: l) {
+			Mob* entity = e.second;
 			if (!entity->IsNPC()) {
 				continue;
 			}
 
 			entity_count++;
 
-			const std::string &entity_name = Strings::ToLower(entity->GetName());
-			if (!search_string.empty() && entity_name.find(search_string) == std::string::npos) {
+			const std::string& entity_name = Strings::ToLower(entity->GetName());
+			if (!search_string.empty() && !Strings::Contains(entity_name, search_string)) {
 				continue;
 			}
 
@@ -140,15 +169,15 @@ void command_list(Client *c, const Seperator *sep)
 			found_count++;
 		}
 	} else if (is_objects) {
-		const auto &l = entity_list.GetObjectList();
+		const auto& l = entity_list.GetObjectList();
 
-		for (const auto &e : l) {
-			Object *entity = e.second;
+		for (const auto& e: l) {
+			Object* entity = e.second;
 
 			entity_count++;
 
-			const std::string &entity_name = Strings::ToLower(entity->GetModelName());
-			if (!search_string.empty() && entity_name.find(search_string) == std::string::npos) {
+			const std::string& entity_name = Strings::ToLower(entity->GetModelName());
+			if (!search_string.empty() && !Strings::Contains(entity_name, search_string)) {
 				continue;
 			}
 
@@ -164,15 +193,15 @@ void command_list(Client *c, const Seperator *sep)
 			found_count++;
 		}
 	} else if (is_players) {
-		const auto &l = entity_list.GetClientList();
+		const auto& l = entity_list.GetClientList();
 
-		for (const auto &e : l) {
-			Client *entity = e.second;
+		for (const auto& e: l) {
+			Client* entity = e.second;
 
 			entity_count++;
 
-			const std::string &entity_name = Strings::ToLower(entity->GetName());
-			if (!search_string.empty() && entity_name.find(search_string) == std::string::npos) {
+			const std::string& entity_name = Strings::ToLower(entity->GetName());
+			if (!search_string.empty() && !Strings::Contains(entity_name, search_string)) {
 				continue;
 			}
 
@@ -197,27 +226,31 @@ void command_list(Client *c, const Seperator *sep)
 				search_type,
 				(
 					!search_string.empty() ?
-					fmt::format(
-						" matching '{}'",
-						search_string
-					) :
-					""
+						fmt::format(
+							" matching '{}'",
+							search_string
+						) :
+						""
 				)
 			).c_str()
 		);
 		return;
 	}
 
-	std::sort(unique_entities.begin(), unique_entities.end(), [](UniqueEntity a, UniqueEntity b) {
-		if (a.entity_id && b.entity_id) {
-			return a.entity_id < b.entity_id;
-		} else {
-			return a.unique_id < b.unique_id;
+	std::sort(
+		unique_entities.begin(),
+		unique_entities.end(),
+		[](UniqueEntity a, UniqueEntity b) {
+			if (a.entity_id && b.entity_id) {
+				return a.entity_id < b.entity_id;
+			} else {
+				return a.unique_id < b.unique_id;
+			}
 		}
-	});
+	);
 
 	for (const auto& e : unique_entities) {
-		const std::string &saylink = Saylink::Silent(
+		const std::string& saylink = Saylink::Silent(
 			fmt::format(
 				"#goto {:.2f} {:.2f} {:.2f}",
 				e.position.x,
@@ -230,7 +263,7 @@ void command_list(Client *c, const Seperator *sep)
 		c->Message(
 			Chat::White,
 			fmt::format(
-				"| {}{}{} | {} |",
+				"| {}{}{} | {} |{}",
 				saylink,
 				(
 					e.entity_id ?
@@ -249,7 +282,21 @@ void command_list(Client *c, const Seperator *sep)
 					) :
 					""
 				),
-				e.entity_name
+				e.entity_name,
+				(
+					(can_kill && (is_bots || is_npcs || is_players)) ?
+					fmt::format(
+						" {} |",
+						Saylink::Silent(
+							fmt::format(
+								"#kill {}",
+								e.entity_id
+							),
+							"Kill"
+						)
+					) :
+					""
+				)
 			).c_str()
 		);
 	}


### PR DESCRIPTION
# Description
- Adds the ability to use `#kill` with a supplied entity ID, i.e. `#kill 123`.
- Adds bot support to the `#list` command and adds `#kill` saylinks to the `#list` data if the client can use the `#kill` command.

## Type of Change
- [X] New feature (non-breaking change which adds functionality)

# Testing
![image](https://github.com/EQEmu/Server/assets/89047260/24b277a6-176a-423f-9607-32e2fb454db1)
![image](https://github.com/EQEmu/Server/assets/89047260/7bae3e09-0d95-40e0-ab35-ecda31092399)

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur