### PR TITLE
[Bug Fix] Fix Corpses "Disappearing"

### DIFF
--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -991,9 +991,11 @@ bool Corpse::Process()
 	}
 
 	if (m_corpse_graveyard_timer.Check()) {
-		MovePlayerCorpseToGraveyard();
-		m_corpse_graveyard_timer.Disable();
-		return false;
+		if (MovePlayerCorpseToGraveyard()) {
+			m_corpse_graveyard_timer.Disable();
+			return false;
+		}
+		return true; // If the corpse was not moved, continue the corpse in the process rather than put in limbo
 	}
 
 	// Player is offline. If rez timer is enabled, disable it and save corpse.


### PR DESCRIPTION
# Description
This fixes corpses "disappearing" by fixing the graveyard check. Prior to the corpse overhaul (#3938), moving corpses to graveyards was assumed successful and automatically removed from the process. Even in non-graveyard zones, it was attempting to move the corpse to the graveyard and removing them from the process.

Note: Opened a separate issue for the graveyard timer handling. See #4276.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing
Post-graveyard timer in PoK (non-graveyard zone). Corpse remains.
![image](https://github.com/EQEmu/Server/assets/3617814/c54f9777-586d-43fb-9216-c7ef465b232b)

Pre-graveyard move in PoD (graveyard zone).
![image](https://github.com/EQEmu/Server/assets/3617814/60e2c168-866d-4e4e-a64b-9ac369993eba)

Post-graveyard move in PoD. Corpse moved to graveyard.
![image](https://github.com/EQEmu/Server/assets/3617814/8263f458-5fbe-43c2-96a8-e74497417d69)
![image](https://github.com/EQEmu/Server/assets/3617814/d1c40169-6b7f-49d5-af28-83b611a3b0e8)

Second graveyard timer cycle in PoD. Corpse remains. Note: Location move and rez timer reset tied to other issue mentioned above.
![image](https://github.com/EQEmu/Server/assets/3617814/dce41fd7-0bae-46d1-83db-d404f93fa802)

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur