### PR TITLE
[Bug Fix] GLAA fix after database.cpp updates

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -1178,7 +1178,7 @@ char* Database::GetGroupLeadershipInfo(
 	GroupLeadershipAA_Struct* GLAA
 )
 {
-	const auto& e = GroupLeadersRepository::GetGroupLeaderFix(*this, group_id);
+	auto e = GroupLeadersRepository::FindOne(*this, group_id);
 
 	if (!e.gid) {
 		if (leaderbuf) {
@@ -1239,8 +1239,10 @@ char* Database::GetGroupLeadershipInfo(
 	if (mentor_percent) {
 		*mentor_percent = e.mentor_percent;
 	}
-
-	memcpy(GLAA, &e.leadershipaa, sizeof(GroupLeadershipAA_Struct));
+	if(GLAA && e.leadershipaa.length() == sizeof(GroupLeadershipAA_Struct)) {
+		Decode(e.leadershipaa);
+		memcpy(GLAA, e.leadershipaa.data(), sizeof(GroupLeadershipAA_Struct));
+	}
 
 	return leaderbuf;
 }
@@ -2026,3 +2028,17 @@ void Database::SourceSqlFromUrl(const std::string& url)
 		LogError("URI parser error [{}]", iae.what());
 	}
 }
+
+void Database::Encode(std::string &in)
+{
+	for(int i = 0; i < in.length(); i++) {
+		in.at(i) += char('0');
+	}
+};
+
+void Database::Decode(std::string &in)
+{
+	for(int i = 0; i < in.length(); i++) {
+		in.at(i) -= char('0');
+	}
+};

--- a/common/database.cpp
+++ b/common/database.cpp
@@ -1125,27 +1125,13 @@ std::string Database::GetGroupLeaderForLogin(const std::string& character_name)
 	return e.gid ? e.leadername : std::string();
 }
 
-void Database::SetGroupLeaderName(uint32 group_id, const std::string& name)
+void Database::SetGroupLeaderName(uint32 group_id, const std::string &name)
 {
-	auto e = GroupLeadersRepository::FindOne(*this, group_id);
+    GroupLeadersRepository::GroupLeaders e {};
+    e.gid        = group_id;
+    e.leadername = name;
 
-	e.leadername = name;
-
-	if (e.gid) {
-		GroupLeadersRepository::UpdateOne(*this, e);
-		return;
-	}
-
-	e.gid            = group_id;
-	e.marknpc        = std::string();
-	e.leadershipaa   = std::string();
-	e.maintank       = std::string();
-	e.assist         = std::string();
-	e.puller         = std::string();
-	e.mentoree       = std::string();
-	e.mentor_percent = 0;
-
-	GroupLeadersRepository::InsertOne(*this, e);
+    GroupLeadersRepository::ReplaceOne(*this, e);
 }
 
 std::string Database::GetGroupLeaderName(uint32 group_id)

--- a/common/database.h
+++ b/common/database.h
@@ -267,6 +267,8 @@ public:
 
 	void SourceDatabaseTableFromUrl(const std::string& table_name, const std::string& url);
 	void SourceSqlFromUrl(const std::string& url);
+	void Encode(std::string &in);
+	void Decode(std::string &in);
 
 private:
 	Mutex           Mvarcache;

--- a/common/repositories/base/base_group_leaders_repository.h
+++ b/common/repositories/base/base_group_leaders_repository.h
@@ -192,7 +192,7 @@ public:
 		v.push_back(columns[0] + " = " + std::to_string(e.gid));
 		v.push_back(columns[1] + " = '" + Strings::Escape(e.leadername) + "'");
 		v.push_back(columns[2] + " = '" + Strings::Escape(e.marknpc) + "'");
-		v.push_back(columns[3] + " = '" + Strings::Escape(e.leadershipaa) + "'");
+		v.push_back(columns[3] + " = '" + e.leadershipaa + "'");
 		v.push_back(columns[4] + " = '" + Strings::Escape(e.maintank) + "'");
 		v.push_back(columns[5] + " = '" + Strings::Escape(e.assist) + "'");
 		v.push_back(columns[6] + " = '" + Strings::Escape(e.puller) + "'");
@@ -222,7 +222,7 @@ public:
 		v.push_back(std::to_string(e.gid));
 		v.push_back("'" + Strings::Escape(e.leadername) + "'");
 		v.push_back("'" + Strings::Escape(e.marknpc) + "'");
-		v.push_back("'" + Strings::Escape(e.leadershipaa) + "'");
+		v.push_back("'" + e.leadershipaa + "'");
 		v.push_back("'" + Strings::Escape(e.maintank) + "'");
 		v.push_back("'" + Strings::Escape(e.assist) + "'");
 		v.push_back("'" + Strings::Escape(e.puller) + "'");
@@ -260,7 +260,7 @@ public:
 			v.push_back(std::to_string(e.gid));
 			v.push_back("'" + Strings::Escape(e.leadername) + "'");
 			v.push_back("'" + Strings::Escape(e.marknpc) + "'");
-			v.push_back("'" + Strings::Escape(e.leadershipaa) + "'");
+			v.push_back("'" + e.leadershipaa + "'");
 			v.push_back("'" + Strings::Escape(e.maintank) + "'");
 			v.push_back("'" + Strings::Escape(e.assist) + "'");
 			v.push_back("'" + Strings::Escape(e.puller) + "'");
@@ -418,7 +418,7 @@ public:
 		v.push_back(std::to_string(e.gid));
 		v.push_back("'" + Strings::Escape(e.leadername) + "'");
 		v.push_back("'" + Strings::Escape(e.marknpc) + "'");
-		v.push_back("'" + Strings::Escape(e.leadershipaa) + "'");
+		v.push_back("'" + e.leadershipaa + "'");
 		v.push_back("'" + Strings::Escape(e.maintank) + "'");
 		v.push_back("'" + Strings::Escape(e.assist) + "'");
 		v.push_back("'" + Strings::Escape(e.puller) + "'");
@@ -449,7 +449,7 @@ public:
 			v.push_back(std::to_string(e.gid));
 			v.push_back("'" + Strings::Escape(e.leadername) + "'");
 			v.push_back("'" + Strings::Escape(e.marknpc) + "'");
-			v.push_back("'" + Strings::Escape(e.leadershipaa) + "'");
+			v.push_back("'" + e.leadershipaa + "'");
 			v.push_back("'" + Strings::Escape(e.maintank) + "'");
 			v.push_back("'" + Strings::Escape(e.assist) + "'");
 			v.push_back("'" + Strings::Escape(e.puller) + "'");

--- a/common/repositories/group_leaders_repository.h
+++ b/common/repositories/group_leaders_repository.h
@@ -7,6 +7,18 @@
 
 class GroupLeadersRepository: public BaseGroupLeadersRepository {
 public:
+	struct GroupLeadersFix
+	{
+		int32_t     gid;
+		std::string leadername;
+		std::string marknpc;
+		char leadershipaa[sizeof(GroupLeadershipAA_Struct)];
+		std::string maintank;
+		std::string assist;
+		std::string puller;
+		std::string mentoree;
+		int32_t     mentor_percent;
+	};
 
     /**
      * This file was auto generated and can be modified and extended upon
@@ -53,6 +65,44 @@ public:
 			)
 		);
 	}
+
+	static GroupLeadersFix GetGroupLeaderFix(
+		Database &db,
+		int group_leaders_id
+	)
+	{
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} WHERE {} = {} LIMIT 1",
+				BaseSelect(),
+				PrimaryKey(),
+				group_leaders_id
+			)
+		);
+
+		GroupLeadersFix tmp{};
+
+		auto            row = results.begin();
+        if (results.RowCount() == 1) {
+            GroupLeadersFix e{};
+
+            e.gid        = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
+            e.leadername = row[1] ? row[1] : "";
+            e.marknpc    = row[2] ? row[2] : "";
+            if (results.LengthOfColumn(3) == sizeof(GroupLeadershipAA_Struct)) {
+                memcpy(e.leadershipaa, row[3], sizeof(e.leadershipaa));
+            }
+            e.maintank       = row[4] ? row[4] : "";
+            e.assist         = row[5] ? row[5] : "";
+            e.puller         = row[6] ? row[6] : "";
+            e.mentoree       = row[7] ? row[7] : "";
+            e.mentor_percent = row[8] ? static_cast<int32_t>(atoi(row[8])) : 0;
+
+            return e;
+        }
+
+        return tmp;
+    }
 };
 
 #endif //EQEMU_GROUP_LEADERS_REPOSITORY_H

--- a/common/repositories/group_leaders_repository.h
+++ b/common/repositories/group_leaders_repository.h
@@ -52,6 +52,20 @@ public:
 			)
 		);
 	}
+
+	static int UpdateLeadershipAA(Database &db, std::string &aa, uint32 group_id)
+	{
+		const auto group_leader = GetWhere(db, fmt::format("gid = '{}' LIMIT 1", group_id));
+		if(group_leader.empty()) {
+			return 0;
+		}
+
+		db.Encode(aa);
+		auto m = group_leader[0];
+		m.leadershipaa = aa;
+
+		return UpdateOne(db, m);
+	}
 };
 
 #endif //EQEMU_GROUP_LEADERS_REPOSITORY_H

--- a/common/repositories/group_leaders_repository.h
+++ b/common/repositories/group_leaders_repository.h
@@ -7,19 +7,6 @@
 
 class GroupLeadersRepository: public BaseGroupLeadersRepository {
 public:
-	struct GroupLeadersFix
-	{
-		int32_t     gid;
-		std::string leadername;
-		std::string marknpc;
-		char leadershipaa[sizeof(GroupLeadershipAA_Struct)];
-		std::string maintank;
-		std::string assist;
-		std::string puller;
-		std::string mentoree;
-		int32_t     mentor_percent;
-	};
-
     /**
      * This file was auto generated and can be modified and extended upon
      *
@@ -65,44 +52,6 @@ public:
 			)
 		);
 	}
-
-	static GroupLeadersFix GetGroupLeaderFix(
-		Database &db,
-		int group_leaders_id
-	)
-	{
-		auto results = db.QueryDatabase(
-			fmt::format(
-				"{} WHERE {} = {} LIMIT 1",
-				BaseSelect(),
-				PrimaryKey(),
-				group_leaders_id
-			)
-		);
-
-		GroupLeadersFix tmp{};
-
-		auto            row = results.begin();
-        if (results.RowCount() == 1) {
-            GroupLeadersFix e{};
-
-            e.gid        = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
-            e.leadername = row[1] ? row[1] : "";
-            e.marknpc    = row[2] ? row[2] : "";
-            if (results.LengthOfColumn(3) == sizeof(GroupLeadershipAA_Struct)) {
-                memcpy(e.leadershipaa, row[3], sizeof(e.leadershipaa));
-            }
-            e.maintank       = row[4] ? row[4] : "";
-            e.assist         = row[5] ? row[5] : "";
-            e.puller         = row[6] ? row[6] : "";
-            e.mentoree       = row[7] ? row[7] : "";
-            e.mentor_percent = row[8] ? static_cast<int32_t>(atoi(row[8])) : 0;
-
-            return e;
-        }
-
-        return tmp;
-    }
 };
 
 #endif //EQEMU_GROUP_LEADERS_REPOSITORY_H

--- a/utils/scripts/generators/repository-generator.pl
+++ b/utils/scripts/generators/repository-generator.pl
@@ -260,6 +260,9 @@ foreach my $table_to_generate (@tables) {
         elsif ((trim($column_default) eq "" || $column_default eq "NULL") && $column_type =~ /text|varchar/i) {
             $default_value = '""';
         }
+        elsif ((trim($column_default) eq "" || $column_default eq "NULL") && $column_type =~ /blob/i) {
+            $default_value = '""';
+        }
 
         # for datetime values that set default value all zeroed out
         if ($default_value =~ /0000-00-00 00:00:00/i) {
@@ -296,6 +299,9 @@ foreach my $table_to_generate (@tables) {
             elsif ($data_type =~ /datetime|timestamp/) {
                 $query_value = sprintf('FROM_UNIXTIME(" + (e.%s > 0 ? std::to_string(e.%s) : "null") + ")");', $column_name_formatted, $column_name_formatted);
             }
+            elsif ($data_type =~ /blob/) {
+                $query_value = sprintf('\'" + e.%s + "\'");', $column_name_formatted);
+            }
 
             $update_one_entries .= sprintf(
                 "\t\t" . 'v.push_back(columns[%s] + " = %s' . "\n",
@@ -311,6 +317,9 @@ foreach my $table_to_generate (@tables) {
         }
         elsif ($data_type =~ /datetime|timestamp/) {
             $value = sprintf('"FROM_UNIXTIME(" + (e.%s > 0 ? std::to_string(e.%s) : "null") + ")"', $column_name_formatted, $column_name_formatted);
+        }
+        elsif ($data_type =~ /blob/) {
+            $value = sprintf("\"'\" + e.%s + \"'\"", $column_name_formatted);
         }
 
         $insert_one_entries  .= sprintf("\t\tv.push_back(%s);\n", $value);

--- a/zone/groups.cpp
+++ b/zone/groups.cpp
@@ -24,6 +24,8 @@
 #include "string_ids.h"
 #include "../common/events/player_event_logs.h"
 #include "../common/repositories/group_id_repository.h"
+#include "../common/repositories/group_leaders_repository.h"
+
 
 extern EntityList entity_list;
 extern WorldServer worldserver;
@@ -2103,20 +2105,15 @@ void Group::UnDelegateMarkNPC(const char *OldNPCMarkerName)
 
 void Group::SaveGroupLeaderAA()
 {
-	// Stores the Group Leaders Leadership AA data from the Player Profile as a blob in the group_leaders table.
-	// This is done so that group members not in the same zone as the Leader still have access to this information.
+    // Stores the Group Leaders Leadership AA data from the Player Profile as a blob in the group_leaders table.
+    // This is done so that group members not in the same zone as the Leader still have access to this information.
 
-	std::string aa((char *)&LeaderAbilities, sizeof(GroupLeadershipAA_Struct));
-	database.Encode(aa);
-	std::string query = fmt::format(
-		"UPDATE group_leaders SET leadershipaa = '{}' WHERE gid = '{}' LIMIT 1;",
-		aa,
-		GetID()
-	);
-	auto results = database.QueryDatabase(query);
-	if (!results.Success())
-		LogError("Unable to store LeadershipAA: [{}]\n", results.ErrorMessage().c_str());
+    std::string aa((char *) &LeaderAbilities, sizeof(GroupLeadershipAA_Struct));
+    auto        results = GroupLeadersRepository::UpdateLeadershipAA(database, aa, GetID());
 
+	if (!results) {
+        LogError("Unable to store GroupLeadershipAA for group_id: [{}]", GetID());
+    }
 }
 
 void Group::UnMarkNPC(uint16 ID)

--- a/zone/groups.cpp
+++ b/zone/groups.cpp
@@ -2105,14 +2105,15 @@ void Group::SaveGroupLeaderAA()
 {
 	// Stores the Group Leaders Leadership AA data from the Player Profile as a blob in the group_leaders table.
 	// This is done so that group members not in the same zone as the Leader still have access to this information.
-	auto queryBuffer = new char[sizeof(GroupLeadershipAA_Struct) * 2 + 1];
-	database.DoEscapeString(queryBuffer, (char *)&LeaderAbilities, sizeof(GroupLeadershipAA_Struct));
 
-	std::string query = "UPDATE group_leaders SET leadershipaa = '";
-	query += queryBuffer;
-	query +=  StringFormat("' WHERE gid = %i LIMIT 1", GetID());
-	safe_delete_array(queryBuffer);
-    auto results = database.QueryDatabase(query);
+	std::string aa((char *)&LeaderAbilities, sizeof(GroupLeadershipAA_Struct));
+	database.Encode(aa);
+	std::string query = fmt::format(
+		"UPDATE group_leaders SET leadershipaa = '{}' WHERE gid = '{}' LIMIT 1;",
+		aa,
+		GetID()
+	);
+	auto results = database.QueryDatabase(query);
 	if (!results.Success())
 		LogError("Unable to store LeadershipAA: [{}]\n", results.ErrorMessage().c_str());
 


### PR DESCRIPTION
# Description

Group LeadershipAA was not being sent to clients correctly after the database.cpp updates and changes to use the repo pattern.  Issue was traced to saving the leadership aa data to the group_leaders table.  The repo was converting to a std::string and was truncating at the first 0x00, creating the issue.

Solution:
Create an encode/decode function within Database to add char('0') to the values, mirroring the builtin behavior of the RoF2 client in various places.  Therefore, the the repo treats it correctly.  Also, rewrote the save routine to also use the repo and this functionality.  There are no db changes required, the existing blob datatype remains unchanged.

## Type of change
Bug fix.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
https://1drv.ms/v/s!AupA3qRrvt-1oc42Wt8qUfnKWbuOkw

Clients tested: 
The solution was tested with RoF2 and UF client. 

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
