### PR TITLE
[Lua] Add IsImmuneToSpell Lua Mod

### DIFF
--- a/zone/lua_mod.h
+++ b/zone/lua_mod.h
@@ -26,6 +26,7 @@ public:
 	void TryCriticalHit(Mob *self, Mob *defender, DamageHitInfo &hit, ExtraAttackOptions *opts, bool &ignoreDefault);
 	void GetRequiredAAExperience(Client *self, uint32 &returnValue, bool &ignoreDefault);
 	void GetEXPForLevel(Client *self, uint16 level, uint32 &returnValue, bool &ignoreDefault);
+	void IsImmuneToSpell(Mob *self, Mob* caster, uint16 spell_id, bool &return_value, bool &ignore_default);
 	void GetExperienceForKill(Client *self, Mob *against, uint64 &returnValue, bool &ignoreDefault);
 	void CalcSpellEffectValue_formula(Mob *self, uint32 formula, int64 base_value, int64 max_value, int caster_level, uint16 spell_id, int ticsremaining, int64 &returnValue, bool &ignoreDefault);
 	void RegisterBug(Client *self, BaseBugReportsRepository::BugReports bug, bool &ignore_default);
@@ -49,4 +50,5 @@ private:
 	bool m_has_register_bug;
 	bool m_has_common_damage;
 	bool m_has_heal_damage;
+	bool m_has_is_immune_to_spell;
 };

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -1602,6 +1602,15 @@ uint64 LuaParser::HealDamage(Mob *self, Mob* caster, uint64 value, uint16 spell_
 	return retval;
 }
 
+bool LuaParser::IsImmuneToSpell(Mob *self, Mob *caster, uint16 spell_id, bool &ignore_default)
+{
+	bool retval = false;
+	for (auto &mod : mods_) {
+		mod.IsImmuneToSpell(self, caster, spell_id, retval, ignore_default);
+	}
+	return retval;
+}
+
 int64 LuaParser::CalcSpellEffectValue_formula(Mob *self, uint32 formula, int64 base_value, int64 max_value, int caster_level, uint16 spell_id, int ticsremaining, bool &ignoreDefault)
 {
 	int64 retval = 0;

--- a/zone/lua_parser.h
+++ b/zone/lua_parser.h
@@ -201,6 +201,7 @@ public:
 	void RegisterBug(Client *self, BaseBugReportsRepository::BugReports bug, bool &ignore_default);
 	int64 CommonDamage(Mob *self, Mob* attacker, int64 value, uint16 spell_id, int skill_used, bool avoidable, int8 buff_slot, bool buff_tic, int special, bool &ignore_default);
 	uint64 HealDamage(Mob *self, Mob* caster, uint64 value, uint16 spell_id, bool &ignore_default);
+	bool IsImmuneToSpell(Mob *self, Mob* caster, uint16 spell_id, bool &ignore_default);
 	
 private:
 	LuaParser();

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -84,6 +84,7 @@ Copyright (C) 2001-2002 EQEMu Development Team (http://eqemu.org)
 #include "string_ids.h"
 #include "worldserver.h"
 #include "fastmath.h"
+#include "lua_parser.h"
 
 #include <assert.h>
 #include <algorithm>

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4958,6 +4958,16 @@ bool Mob::IsImmuneToSpell(uint16 spell_id, Mob *caster)
 
 	LogSpells("Checking to see if we are immune to spell [{}] cast by [{}]", spell_id, caster->GetName());
 
+#ifdef LUA_EQEMU
+	bool is_immune = false;
+	bool ignore_default = false;
+	is_immune = LuaParser::Instance()->IsImmuneToSpell(this, caster, spell_id, ignore_default);
+
+	if (ignore_default) {
+		return is_immune;
+	}
+#endif
+
 	if(!IsValidSpell(spell_id))
 		return true;
 


### PR DESCRIPTION
# Description

This introduces a new way to resists spells via lua mods. Originally, I was using  ResistSpellRoll #4241 but this did not let me fully resist all spells the way I desired.

Here's an example of image of overriding dain banish via lua, with a custom message:
![image](https://github.com/EQEmu/Server/assets/845670/6c0f4819-7648-48c1-8ba2-8900a724e96d)

No dependencies are needed.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Testing

Here's a sample file I used for testing on my server: https://gist.github.com/xackery/0255e990225336ba2541c78c5c3883f2
A highlight of this sample:
```lua
---@param e ModIsImmuneToSpell
function IsImmuneToSpell(e)
 --- code here was omitted for summary
for _, v in pairs(banish_spells) do
        if e.spell_id == v and e.self:IsClient() then
            ally:Message(MT.SpellFailure, string.format("%s's %s (Banish) was resisted.", e.caster:GetCleanName(), spell_name))
            e.return_value = true
            e.ignore_default = true
            return e
        end
    end
```

In this case, I created a list of banish spells and if it was cast on the player, a resist message was generated informing the player it was used on them.



Attach images and describe testing done to validate functionality.

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [ ] I have made corresponding changes to the documentation (if applicable, if not delete this line)
- [x] I own the changes of my code and take responsibility for the potential issues that occur
