### PR TITLE
[Lua] Add UpdatePersonalFaction Lua Mod

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -7563,13 +7563,13 @@ void Client::SetFactionLevel(
 		faction_before = current_value;
 
 #ifdef LUA_EQEMU
-	int32 lua_ret = 0;
-	bool ignore_default = false;
-	lua_ret = LuaParser::Instance()->UpdatePersonalFaction(this, e.value, e.faction_id, current_value, e.temp, faction_minimum, faction_maximum, ignore_default);
+		int32 lua_ret = 0;
+		bool ignore_default = false;
+		lua_ret = LuaParser::Instance()->UpdatePersonalFaction(this, e.value, e.faction_id, current_value, e.temp, faction_minimum, faction_maximum, ignore_default);
 
-	if (ignore_default) {
-		e.value = lua_ret;
-	}
+		if (ignore_default) {
+			e.value = lua_ret;
+		}
 #endif
 
 		UpdatePersonalFaction(
@@ -7628,13 +7628,13 @@ void Client::SetFactionLevel2(uint32 char_id, int32 faction_id, uint8 char_class
 		faction_before_hit = current_value;
 
 #ifdef LUA_EQEMU
-	int32 lua_ret = 0;
-	bool ignore_default = false;
-	lua_ret = LuaParser::Instance()->UpdatePersonalFaction(this, value, faction_id, current_value, temp, this_faction_min, this_faction_max, ignore_default);
+		int32 lua_ret = 0;
+		bool ignore_default = false;
+		lua_ret = LuaParser::Instance()->UpdatePersonalFaction(this, value, faction_id, current_value, temp, this_faction_min, this_faction_max, ignore_default);
 
-	if (ignore_default) {
-		e.value = lua_ret;
-	}
+		if (ignore_default) {
+			value = lua_ret;
+		}
 #endif
 
 		UpdatePersonalFaction(char_id, value, faction_id, &current_value, temp, this_faction_min, this_faction_max);

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -7562,6 +7562,16 @@ void Client::SetFactionLevel(
 		current_value = GetCharacterFactionLevel(e.faction_id);
 		faction_before = current_value;
 
+#ifdef LUA_EQEMU
+	int32 lua_ret = 0;
+	bool ignore_default = false;
+	lua_ret = LuaParser::Instance()->UpdatePersonalFaction(this, e.value, e.faction_id, current_value, e.temp, faction_minimum, faction_maximum, ignore_default);
+
+	if (ignore_default) {
+		e.value = lua_ret;
+	}
+#endif
+
 		UpdatePersonalFaction(
 			character_id,
 			e.value,
@@ -7616,6 +7626,16 @@ void Client::SetFactionLevel2(uint32 char_id, int32 faction_id, uint8 char_class
 		//Get the faction modifiers
 		current_value = GetCharacterFactionLevel(faction_id);
 		faction_before_hit = current_value;
+
+#ifdef LUA_EQEMU
+	int32 lua_ret = 0;
+	bool ignore_default = false;
+	lua_ret = LuaParser::Instance()->UpdatePersonalFaction(this, e.value, e.faction_id, current_value, e.temp, faction_minimum, faction_maximum, ignore_default);
+
+	if (ignore_default) {
+		e.value = lua_ret;
+	}
+#endif
 
 		UpdatePersonalFaction(char_id, value, faction_id, &current_value, temp, this_faction_min, this_faction_max);
 

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -7630,7 +7630,7 @@ void Client::SetFactionLevel2(uint32 char_id, int32 faction_id, uint8 char_class
 #ifdef LUA_EQEMU
 	int32 lua_ret = 0;
 	bool ignore_default = false;
-	lua_ret = LuaParser::Instance()->UpdatePersonalFaction(this, e.value, e.faction_id, current_value, e.temp, faction_minimum, faction_maximum, ignore_default);
+	lua_ret = LuaParser::Instance()->UpdatePersonalFaction(this, value, faction_id, current_value, temp, this_faction_min, this_faction_max, ignore_default);
 
 	if (ignore_default) {
 		e.value = lua_ret;

--- a/zone/lua_mod.cpp
+++ b/zone/lua_mod.cpp
@@ -37,6 +37,7 @@ void LuaMod::Init()
 	m_has_get_experience_for_kill = parser_->HasFunction("GetExperienceForKill", package_name_);
 	m_has_common_outgoing_hit_success = parser_->HasFunction("CommonOutgoingHitSuccess", package_name_);
 	m_has_calc_spell_effect_value_formula = parser_->HasFunction("CalcSpellEffectValue_formula", package_name_);
+	m_has_update_personal_faction = parser_->HasFunction("UpdatePersonalFaction", package_name_);
 	m_has_register_bug = parser_->HasFunction("RegisterBug", package_name_);
 	m_has_common_damage = parser_->HasFunction("CommonDamage", package_name_);
 	m_has_heal_damage = parser_->HasFunction("HealDamage", package_name_);
@@ -174,6 +175,61 @@ void GetExtraAttackOptions(luabind::adl::object &ret, ExtraAttackOptions *opts) 
 				opts->skilldmgtaken_bonus_flat = luabind::object_cast<int>(skilldmgtaken_bonus_flat);
 			}
 		}
+	}
+}
+
+void LuaMod::UpdatePersonalFaction(Mob *self, int32 npc_value, int32 faction_id, int32 current_value, int32 temp, int32 this_faction_min, int32 this_faction_max, int32 &return_value, bool &ignore_default)
+{
+	int start = lua_gettop(L);
+
+	try {
+		if (!m_has_update_personal_faction) {
+			return;
+		}
+
+		lua_getfield(L, LUA_REGISTRYINDEX, package_name_.c_str());
+		lua_getfield(L, -1, "UpdatePersonalFaction");
+
+		Lua_Mob l_self(self);
+		luabind::adl::object e = luabind::newtable(L);
+		e["self"] = l_self;
+		e["npc_value"] = npc_value;
+		e["faction_id"] = faction_id;
+		e["current_value"] = current_value;
+		e["temp"] = temp;
+		e["this_faction_min"] = this_faction_min;
+		e["this_faction_max"] = this_faction_max;
+
+		e.push(L);
+
+		if (lua_pcall(L, 1, 1, 0)) {
+			std::string error = lua_tostring(L, -1);
+			parser_->AddError(error);
+			lua_pop(L, 2);
+			return;
+		}
+
+		if (lua_type(L, -1) == LUA_TTABLE) {
+			luabind::adl::object ret(luabind::from_stack(L, -1));
+			auto ignore_default_obj = ret["ignore_default"];
+			if (luabind::type(ignore_default_obj) == LUA_TBOOLEAN) {
+				ignore_default = ignore_default || luabind::object_cast<bool>(ignore_default_obj);
+			}
+
+			auto return_value_obj = ret["return_value"];
+			if (luabind::type(return_value_obj) == LUA_TNUMBER) {
+				return_value = luabind::object_cast<int64>(return_value_obj);
+			}
+		}
+	}
+	catch (std::exception &ex) {
+		parser_->AddError(ex.what());
+	}
+
+	int end = lua_gettop(L);
+	int n = end - start;
+	if (n > 0) {
+		lua_pop(L, n);
 	}
 }
 

--- a/zone/lua_mod.h
+++ b/zone/lua_mod.h
@@ -29,6 +29,7 @@ public:
 	void IsImmuneToSpell(Mob *self, Mob* caster, uint16 spell_id, bool &return_value, bool &ignore_default);
 	void GetExperienceForKill(Client *self, Mob *against, uint64 &returnValue, bool &ignoreDefault);
 	void CalcSpellEffectValue_formula(Mob *self, uint32 formula, int64 base_value, int64 max_value, int caster_level, uint16 spell_id, int ticsremaining, int64 &returnValue, bool &ignoreDefault);
+	void UpdatePersonalFaction(Mob *self, int32 npc_value, int32 faction_id, int32 current_value, int32 temp, int32 this_faction_min, int32 this_faction_max, int32 &return_value, bool &ignore_default);
 	void RegisterBug(Client *self, BaseBugReportsRepository::BugReports bug, bool &ignore_default);
 	void CommonDamage(Mob *self, Mob* attacker, int64 value, uint16 spell_id, int skill_used, bool avoidable, int8 buff_slot, bool buff_tic, int special, int64 &return_value, bool &ignore_default);
 	void HealDamage(Mob *self, Mob* caster, uint64 value, uint16 spell_id, uint64 &return_value, bool &ignore_default);
@@ -51,4 +52,5 @@ private:
 	bool m_has_common_damage;
 	bool m_has_heal_damage;
 	bool m_has_is_immune_to_spell;
+	bool m_has_update_personal_faction;
 };

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -1620,6 +1620,15 @@ int64 LuaParser::CalcSpellEffectValue_formula(Mob *self, uint32 formula, int64 b
 	return retval;
 }
 
+int32 LuaParser::UpdatePersonalFaction(Mob *self, int32 npc_value, int32 faction_id, int32 current_value, int32 temp, int32 this_faction_min, int32 this_faction_max, bool &ignore_default)
+{
+	int32 retval = 0;
+	for (auto &mod : mods_) {
+		mod.UpdatePersonalFaction(self, npc_value, faction_id, current_value, temp, this_faction_min, this_faction_max, retval, ignore_default);
+	}
+	return retval;
+}
+
 void LuaParser::RegisterBug(Client *self, BaseBugReportsRepository::BugReports bug, bool &ignore_default)
 {
 	for (auto &mod : mods_) {

--- a/zone/lua_parser.h
+++ b/zone/lua_parser.h
@@ -198,6 +198,7 @@ public:
 	uint32 GetEXPForLevel(Client *self, uint16 level, bool &ignoreDefault);
 	uint64 GetExperienceForKill(Client *self, Mob *against, bool &ignoreDefault);
 	int64 CalcSpellEffectValue_formula(Mob *self, uint32 formula, int64 base_value, int64 max_value, int caster_level, uint16 spell_id, int ticsremaining, bool &ignoreDefault);
+	int32 UpdatePersonalFaction(Mob *self, int32 npc_value, int32 faction_id, int32 current_value, int32 temp, int32 this_faction_min, int32 this_faction_max, bool &ignore_default);
 	void RegisterBug(Client *self, BaseBugReportsRepository::BugReports bug, bool &ignore_default);
 	int64 CommonDamage(Mob *self, Mob* attacker, int64 value, uint16 spell_id, int skill_used, bool avoidable, int8 buff_slot, bool buff_tic, int special, bool &ignore_default);
 	uint64 HealDamage(Mob *self, Mob* caster, uint64 value, uint16 spell_id, bool &ignore_default);


### PR DESCRIPTION
# Description

This introduces a new way to increase faction via lua mods. This allows players to create personalized, custom lua-driven ways to give faction boosts.

Here's an example of a froglok in seb with a 4x positive modifier with debug messages showing math:
![image](https://github.com/EQEmu/Server/assets/845670/87d604fa-abe1-4c2d-b281-aa788feb4425)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Testing

Here's a [sample file](https://gist.github.com/xackery/9d70f4108b441bbeaec46bd43cfec47c) where I have a mighty system to boost exp and faction by a modifier. With what is exposed via this method, it's also possible to fine-tune a specific faction so a player can have it boosted when they achieve something on a server.

No snippet of above, as the sample file should show a decent example of how it works.

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [ ] I have made corresponding changes to the documentation (if applicable, if not delete this line)
- [x] I own the changes of my code and take responsibility for the potential issues that occur
