### PR TITLE
[Loot] Consolidate filtering logic

### DIFF
--- a/zone/zone_loot.cpp
+++ b/zone/zone_loot.cpp
@@ -211,6 +211,21 @@ LoottableRepository::Loottable *Zone::GetLootTable(const uint32 loottable_id)
 {
 	for (auto &e: m_loottables) {
 		if (e.id == loottable_id) {
+			if (!content_service.DoesPassContentFiltering(
+				ContentFlags{
+					.min_expansion = e.min_expansion,
+					.max_expansion = e.max_expansion,
+					.content_flags = e.content_flags,
+					.content_flags_disabled = e.content_flags_disabled
+				}
+			)) {
+				LogLootDetail(
+					"Loot table [{}] does not pass content filtering",
+					loottable_id
+				);
+				continue;
+			}
+
 			return &e;
 		}
 	}
@@ -234,6 +249,21 @@ LootdropRepository::Lootdrop Zone::GetLootdrop(const uint32 lootdrop_id) const
 {
 	for (const auto &e: m_lootdrops) {
 		if (e.id == lootdrop_id) {
+			if (!content_service.DoesPassContentFiltering(
+				ContentFlags{
+					.min_expansion = e.min_expansion,
+					.max_expansion = e.max_expansion,
+					.content_flags = e.content_flags,
+					.content_flags_disabled = e.content_flags_disabled
+				}
+			)) {
+				LogLootDetail(
+					"Lootdrop table [{}] does not pass content filtering",
+					lootdrop_id
+				);
+				continue;
+			}
+
 			return e;
 		}
 	}
@@ -246,6 +276,23 @@ std::vector<LootdropEntriesRepository::LootdropEntries> Zone::GetLootdropEntries
 	std::vector<LootdropEntriesRepository::LootdropEntries> entries = {};
 	for (const auto &e: m_lootdrop_entries) {
 		if (e.lootdrop_id == lootdrop_id) {
+			if (!content_service.DoesPassContentFiltering(
+				ContentFlags{
+					.min_expansion = e.min_expansion,
+					.max_expansion = e.max_expansion,
+					.content_flags = e.content_flags,
+					.content_flags_disabled = e.content_flags_disabled
+				}
+			)) {
+				LogLoot(
+					"Lootdrop [{}] Item [{}] ({}) does not pass content filtering",
+					lootdrop_id,
+					e.item_id,
+					database.GetItem(e.item_id) ? database.GetItem(e.item_id)->Name : "Unknown"
+				);
+				continue;
+			}
+
 			entries.emplace_back(e);
 		}
 	}

--- a/zone/zone_loot.cpp
+++ b/zone/zone_loot.cpp
@@ -284,7 +284,7 @@ std::vector<LootdropEntriesRepository::LootdropEntries> Zone::GetLootdropEntries
 					.content_flags_disabled = e.content_flags_disabled
 				}
 			)) {
-				LogLoot(
+				LogLootDetail(
 					"Lootdrop [{}] Item [{}] ({}) does not pass content filtering",
 					lootdrop_id,
 					e.item_id,


### PR DESCRIPTION
# Description

This was brought up during some questions Robregen had while implementing some loot filtering scenarios. It caused some edge cases and inconsistencies. 

This PR consolidates filtering logic to the core getters rather than sprinkling filtering logic in the edges of our code. This also ensures filtering applies consistency in the consumers of these getters, such as the loot simulator command and web api.

This fixes minor observations and consistencies in drop chance percentages as well that have been observed.

Robregen: Fixed an issue with loot entry content filtering would often count the item being filtered out as part of the chances.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

![image](https://github.com/EQEmu/Server/assets/3319450/d66e4ca0-7156-4b54-abb0-106979dbd2be)

![image](https://github.com/EQEmu/Server/assets/3319450/cb67385a-9192-4062-afd9-c3c93ae61b11)

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
