### PR TITLE
[Bug Fix] MariaDB 10.5.x error with parcel function GetParcelCountAndCharacterName

### DIFF
--- a/common/repositories/character_parcels_repository.h
+++ b/common/repositories/character_parcels_repository.h
@@ -58,7 +58,7 @@ public:
 		auto results = db.QueryDatabase(
 			fmt::format(
 				"SELECT c.name, COUNT(p.id), c.id FROM character_data c "
-				"JOIN character_parcels p ON p.char_id = c.id "
+				"LEFT JOIN character_parcels p ON p.char_id = c.id "
 				"WHERE c.name = '{}' "
 				"LIMIT 1",
 				character_name)


### PR DESCRIPTION
# Description

As experienced by N0ctnrl, parcel merchants and the #parcel add command would respond that the player could not be found, even when the player name was correct.  The problem was traced to the query within the  GetParcelCountAndCharacterName function returning incorrect results.  It was further traced to mariadb 10.5.22 as the problem was not seen on 10.4.13 or 10.10.3. The problem was reproduced on 10.5.24.

Fixes # (issue)
Updated the query with the keyword LEFT to establish the JOIN.  Mariadb 10.5.22 and 10.5.24 then functioned properly.  This was retested with 10.4.13 and 10.10.3 without issue.

## Type of change
Bug fix

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
The result was tested against 10.4.13, 10.5.24 and 10.10.3.  N0ctnrl also tested with their install of 10.5.22 and reported that the problem was fixed.

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
