### PR TITLE
[Combat] Add rule to set stun duration.  Add rule to add stun messages.

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -597,6 +597,8 @@ RULE_INT(Combat, ClassicTripleAttackChanceMonk, 100, "Innate Chance for Monk to 
 RULE_INT(Combat, ClassicTripleAttackChanceBerserker, 100, "Innate Chance for Berserker to Triple Attack after a Double Attack (200 = 20%). DEFAULT: 100")
 RULE_INT(Combat, ClassicTripleAttackChanceRanger, 100, "Innate Chance for Ranger to Triple Attack after a Double Attack (200 = 20%). DEFAULT: 100")
 RULE_INT(Combat, StunChance, 12, "Percent chance that client will be stunned when mob is behind player. DEFAULT: 12")
+RULE_INT(Combat, StunDuration, 2000, "Duration of stuns in ms. DEFAULT: 2000")
+RULE_BOOL(Combat, ClientStunMessage, false, "Client stunning NPC produces message. DEFAULT false")
 RULE_BOOL(Combat, BashTwoHanderUseShoulderAC, false, "Enable to use shoulder AC for bash calculations when two hander is equipped. Unproven if accurate DEFAULT: false")
 RULE_REAL(Combat, BashACBonusDivisor, 25.0, "this divides the AC value contribution to bash damage, lower to increase damage")
 RULE_CATEGORY_END()

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -5467,7 +5467,7 @@ void Mob::TryCriticalHit(Mob *defender, DamageHitInfo &hit, ExtraAttackOptions *
 				// staggers message.
 				if (defender->GetLevel() <= 55 && !defender->GetSpecialAbility(UNSTUNABLE)) {
 					defender->Emote("staggers.");
-					defender->Stun(2000);
+					defender->Stun(RuleI(Combat, StunDuration));
 				}
 				return;
 			}

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -4375,7 +4375,15 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 					if (zone->random.Int(0, 100) >= stun_resist) {
 						// did stun
 						// nothing else to check!
-						Stun(2000); // straight 2 seconds every time
+						Stun(RuleI(Combat, StunDuration));
+						if (RuleB(Combat, ClientStunMessage) && attacker->IsClient()) {
+							if (attacker) {
+							entity_list.MessageClose(this, true, 500, Chat::Emote, "%s is stunned after being bashed by %s.", GetCleanName(), attacker->GetCleanName());
+							}
+							else {
+							entity_list.MessageClose(this, true, 500, Chat::Emote, "%s is stunned by a bash to the head.", GetCleanName());
+							}
+						}
 					}
 					else {
 						// stun resist passed!

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -4378,10 +4378,10 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 						Stun(RuleI(Combat, StunDuration));
 						if (RuleB(Combat, ClientStunMessage) && attacker->IsClient()) {
 							if (attacker) {
-							entity_list.MessageClose(this, true, 500, Chat::Emote, "%s is stunned after being bashed by %s.", GetCleanName(), attacker->GetCleanName());
+								entity_list.MessageClose(this, true, 500, Chat::Emote, "%s is stunned after being bashed by %s.", GetCleanName(), attacker->GetCleanName());
 							}
 							else {
-							entity_list.MessageClose(this, true, 500, Chat::Emote, "%s is stunned by a bash to the head.", GetCleanName());
+								entity_list.MessageClose(this, true, 500, Chat::Emote, "%s is stunned by a bash to the head.", GetCleanName());
 							}
 						}
 					}


### PR DESCRIPTION
# Description

In the past, stun duration for mobs was hard coded to 2 seconds.  This PR allows setting this duration in a rule, and defaults to existing behavior.

In the past, no messages and delivered when a PC stuns a mob.  This PR allows setting a rule to turn on these messages, and defaults to existing behavior.

Part of my effort to eliminate most of my local only merges.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# Testing

Tested with and without the new rules.  Tested various stun lengths to varify rule operates correctly.

Clients tested: RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur

