### PR TITLE
[Quest API] Add Parcel Sending to Perl/Lua

### DIFF
--- a/common/repositories/character_parcels_repository.h
+++ b/common/repositories/character_parcels_repository.h
@@ -78,6 +78,37 @@ public:
 
 		return all_entries;
 	}
+
+	static int GetNextFreeParcelSlot(Database& db, const uint32 character_id, const uint32 max_slots)
+	{
+		const auto& l = CharacterParcelsRepository::GetWhere(
+			db,
+			fmt::format(
+				"char_id = '{}' ORDER BY slot_id ASC",
+				character_id
+			)
+		);
+
+		if (l.empty()) {
+			return PARCEL_BEGIN_SLOT;
+		}
+
+		for (uint32 i = PARCEL_BEGIN_SLOT; i <= max_slots; i++) {
+			auto it = std::find_if(
+				l.cbegin(),
+				l.cend(),
+				[&](const auto &x) {
+					return x.slot_id == i;
+				}
+			);
+
+			if (it == l.end()) {
+				return i;
+			}
+		}
+
+		return INVALID_INDEX;
+	}
 };
 
 #endif //EQEMU_CHARACTER_PARCELS_REPOSITORY_H

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -5504,6 +5504,78 @@ std::string lua_get_zone_short_name_by_long_name(std::string zone_long_name) {
 	return zone_store.GetZoneShortNameByLongName(zone_long_name);
 }
 
+bool lua_send_parcel(luabind::object lua_table)
+{
+	if (luabind::type(lua_table) != LUA_TTABLE) {
+		return false;
+	}
+
+	if (
+		(luabind::type(lua_table["name"]) == LUA_TNIL && luabind::type(lua_table["character_id"]) == LUA_TNIL) ||
+		luabind::type(lua_table["item_id"]) == LUA_TNIL ||
+		luabind::type(lua_table["quantity"]) == LUA_TNIL
+	) {
+		return false;
+	}
+
+	std::string name         = luabind::type(lua_table["name"]) != LUA_TNIL ? luabind::object_cast<std::string>(lua_table["name"]) : "";
+	uint32      character_id = luabind::type(lua_table["character_id"]) != LUA_TNIL ? luabind::object_cast<uint32>(lua_table["character_id"]) : 0;
+
+	if (character_id) {
+		const std::string& character_name = database.GetCharName(character_id);
+		if (character_name.empty()) {
+			return false;
+		}
+
+		name = character_name;
+	} else {
+		auto v = CharacterParcelsRepository::GetParcelCountAndCharacterName(database, name);
+		if (v.at(0).character_name.empty()) {
+			return false;
+		}
+
+		character_id = v.at(0).char_id;
+	}
+
+	if (!character_id) {
+		return false;
+	}
+
+	const int next_parcel_slot = CharacterParcelsRepository::GetNextFreeParcelSlot(database, character_id, RuleI(Parcel, ParcelMaxItems));
+	if (next_parcel_slot == INVALID_INDEX) {
+		return false;
+	}
+
+	const uint32 item_id         = luabind::object_cast<uint32>(lua_table["item_id"]);
+	const int16  quantity        = luabind::object_cast<int16>(lua_table["quantity"]);
+	const uint32 augment_one     = luabind::type(lua_table["augment_one"]) != LUA_TNIL ? luabind::object_cast<uint32>(lua_table["augment_one"]) : 0;
+	const uint32 augment_two     = luabind::type(lua_table["augment_two"]) != LUA_TNIL ? luabind::object_cast<uint32>(lua_table["augment_two"]) : 0;
+	const uint32 augment_three   = luabind::type(lua_table["augment_three"]) != LUA_TNIL ? luabind::object_cast<uint32>(lua_table["augment_three"]) : 0;
+	const uint32 augment_four    = luabind::type(lua_table["augment_four"]) != LUA_TNIL ? luabind::object_cast<uint32>(lua_table["augment_four"]) : 0;
+	const uint32 augment_five    = luabind::type(lua_table["augment_five"]) != LUA_TNIL ? luabind::object_cast<uint32>(lua_table["augment_five"]) : 0;
+	const uint32 augment_six     = luabind::type(lua_table["augment_six"]) != LUA_TNIL ? luabind::object_cast<uint32>(lua_table["augment_six"]) : 0;
+	const std::string& from_name = luabind::type(lua_table["from_name"]) != LUA_TNIL ? luabind::object_cast<std::string>(lua_table["from_name"]) : std::string();
+	const std::string& note      = luabind::type(lua_table["note"]) != LUA_TNIL ? luabind::object_cast<std::string>(lua_table["note"]) : std::string();
+
+	auto e = CharacterParcelsRepository::NewEntity();
+
+	e.char_id    = character_id;
+	e.item_id    = item_id;
+	e.aug_slot_1 = augment_one;
+	e.aug_slot_2 = augment_two;
+	e.aug_slot_3 = augment_three;
+	e.aug_slot_4 = augment_four;
+	e.aug_slot_5 = augment_five;
+	e.aug_slot_6 = augment_six;
+	e.slot_id    = next_parcel_slot;
+	e.quantity   = quantity;
+	e.from_name  = from_name;
+	e.note       = note;
+	e.sent_date  = std::time(nullptr);
+
+	return CharacterParcelsRepository::InsertOne(database, e).id;
+}
+
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
 	cur = table[#name]; \
 	if(luabind::type(cur) != LUA_TNIL) { \
@@ -6307,6 +6379,7 @@ luabind::scope lua_register_general() {
 		luabind::def("set_auto_login_character_name_by_account_id", &lua_set_auto_login_character_name_by_account_id),
 		luabind::def("get_zone_id_by_long_name", &lua_get_zone_id_by_long_name),
 		luabind::def("get_zone_short_name_by_long_name", &lua_get_zone_short_name_by_long_name),
+		luabind::def("send_parcel", &lua_send_parcel),
 		/*
 			Cross Zone
 		*/


### PR DESCRIPTION
# Description
- This change allows Operators to send Parcels from Perl and Lua.

## Perl
- Add `quest::send_parcel(table)`.

### Perl Example
```pl
sub EVENT_SAY {
    if ($text=~/#a/i) {
        my %table = (
            "character_id" => $client->CharacterID(),
            "item_id" => 1200,
            "quantity" => 1,
            "augment_one" => 49656,
            "augment_two" => 49656,
            "augment_three" => 49656,
            "augment_four" => 49656,
            "augment_five" => 49656,
            "augment_six" => 49656,
            "from_name" => "Perl Test",
        );
        quest::send_parcel(\%table);
    }
}
```

## Lua
- Add `eq.send_parcel(table)`.

### Lua Example
```lua
function event_say(e)
    if e.message:findi("#a") then
        local table = {
            character_id = e.self:CharacterID(),
            item_id = 1200,
            quantity = 1,
            augment_one = 49656,
            augment_two = 49656,
            augment_three = 49656,
            augment_four = 49656,
            augment_five = 49656,
            augment_six = 49656,
            from_name = "Lua Test",
        }
        eq.send_parcel(table)
    end
end
```

## Type of Change
- [X] New feature

# Testing
![image](https://github.com/EQEmu/Server/assets/89047260/b4dd7912-af3c-409f-b231-1aaa64294cb9)

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur