### PR TITLE
[Doors] Replace magic # in code with a field in doors table for when door closes.

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -5545,7 +5545,7 @@ ALTER TABLE `character_parcels`
 		.match = "",
 		.sql = R"(
 ALTER TABLE `doors`
-ADD COLUMN `close_timer_ms` smallint(8) DEFAULT 5000 AFTER `is_ldon_door`;
+ADD COLUMN `close_timer_ms` smallint(8) UNSIGNED NOT NULL DEFAULT 5000 AFTER `is_ldon_door`;
 )",
 		.content_schema_update = true
 	}

--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -5536,6 +5536,18 @@ ALTER TABLE `character_parcels`
 	ADD COLUMN `aug_slot_5` INT UNSIGNED NOT NULL DEFAULT '0' AFTER `aug_slot_4`,
 	ADD COLUMN `aug_slot_6` INT UNSIGNED NOT NULL DEFAULT '0' AFTER `aug_slot_5`;
 )"
+	},
+	ManifestEntry{
+		.version = 9273,
+		.description = "2024_04_24_door_close_timer.sql",
+		.check = "SHOW COLUMNS FROM `doors` LIKE 'close_timer'",
+		.condition = "empty",
+		.match = "",
+		.sql = R"(
+ALTER TABLE `doors`
+ADD COLUMN `close_timer_ms` smallint(8) DEFAULT 5000 AFTER `is_ldon_door`;
+)",
+		.content_schema_update = true
 	}
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{

--- a/common/repositories/base/base_doors_repository.h
+++ b/common/repositories/base/base_doors_repository.h
@@ -50,6 +50,7 @@ public:
 		float       buffer;
 		uint32_t    client_version_mask;
 		int16_t     is_ldon_door;
+		int16_t     close_timer_ms;
 		int32_t     dz_switch_id;
 		int8_t      min_expansion;
 		int8_t      max_expansion;
@@ -96,6 +97,7 @@ public:
 			"buffer",
 			"client_version_mask",
 			"is_ldon_door",
+			"close_timer_ms",
 			"dz_switch_id",
 			"min_expansion",
 			"max_expansion",
@@ -138,6 +140,7 @@ public:
 			"buffer",
 			"client_version_mask",
 			"is_ldon_door",
+			"close_timer_ms",
 			"dz_switch_id",
 			"min_expansion",
 			"max_expansion",
@@ -214,6 +217,7 @@ public:
 		e.buffer                 = 0;
 		e.client_version_mask    = 4294967295;
 		e.is_ldon_door           = 0;
+		e.close_timer_ms         = 5000;
 		e.dz_switch_id           = 0;
 		e.min_expansion          = -1;
 		e.max_expansion          = -1;
@@ -286,11 +290,12 @@ public:
 			e.buffer                 = row[28] ? strtof(row[28], nullptr) : 0;
 			e.client_version_mask    = row[29] ? static_cast<uint32_t>(strtoul(row[29], nullptr, 10)) : 4294967295;
 			e.is_ldon_door           = row[30] ? static_cast<int16_t>(atoi(row[30])) : 0;
-			e.dz_switch_id           = row[31] ? static_cast<int32_t>(atoi(row[31])) : 0;
-			e.min_expansion          = row[32] ? static_cast<int8_t>(atoi(row[32])) : -1;
-			e.max_expansion          = row[33] ? static_cast<int8_t>(atoi(row[33])) : -1;
-			e.content_flags          = row[34] ? row[34] : "";
-			e.content_flags_disabled = row[35] ? row[35] : "";
+			e.close_timer_ms         = row[31] ? static_cast<int16_t>(atoi(row[31])) : 5000;
+			e.dz_switch_id           = row[32] ? static_cast<int32_t>(atoi(row[32])) : 0;
+			e.min_expansion          = row[33] ? static_cast<int8_t>(atoi(row[33])) : -1;
+			e.max_expansion          = row[34] ? static_cast<int8_t>(atoi(row[34])) : -1;
+			e.content_flags          = row[35] ? row[35] : "";
+			e.content_flags_disabled = row[36] ? row[36] : "";
 
 			return e;
 		}
@@ -354,11 +359,12 @@ public:
 		v.push_back(columns[28] + " = " + std::to_string(e.buffer));
 		v.push_back(columns[29] + " = " + std::to_string(e.client_version_mask));
 		v.push_back(columns[30] + " = " + std::to_string(e.is_ldon_door));
-		v.push_back(columns[31] + " = " + std::to_string(e.dz_switch_id));
-		v.push_back(columns[32] + " = " + std::to_string(e.min_expansion));
-		v.push_back(columns[33] + " = " + std::to_string(e.max_expansion));
-		v.push_back(columns[34] + " = '" + Strings::Escape(e.content_flags) + "'");
-		v.push_back(columns[35] + " = '" + Strings::Escape(e.content_flags_disabled) + "'");
+		v.push_back(columns[31] + " = " + std::to_string(e.close_timer_ms));
+		v.push_back(columns[32] + " = " + std::to_string(e.dz_switch_id));
+		v.push_back(columns[33] + " = " + std::to_string(e.min_expansion));
+		v.push_back(columns[34] + " = " + std::to_string(e.max_expansion));
+		v.push_back(columns[35] + " = '" + Strings::Escape(e.content_flags) + "'");
+		v.push_back(columns[36] + " = '" + Strings::Escape(e.content_flags_disabled) + "'");
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -411,6 +417,7 @@ public:
 		v.push_back(std::to_string(e.buffer));
 		v.push_back(std::to_string(e.client_version_mask));
 		v.push_back(std::to_string(e.is_ldon_door));
+		v.push_back(std::to_string(e.close_timer_ms));
 		v.push_back(std::to_string(e.dz_switch_id));
 		v.push_back(std::to_string(e.min_expansion));
 		v.push_back(std::to_string(e.max_expansion));
@@ -476,6 +483,7 @@ public:
 			v.push_back(std::to_string(e.buffer));
 			v.push_back(std::to_string(e.client_version_mask));
 			v.push_back(std::to_string(e.is_ldon_door));
+			v.push_back(std::to_string(e.close_timer_ms));
 			v.push_back(std::to_string(e.dz_switch_id));
 			v.push_back(std::to_string(e.min_expansion));
 			v.push_back(std::to_string(e.max_expansion));
@@ -545,11 +553,12 @@ public:
 			e.buffer                 = row[28] ? strtof(row[28], nullptr) : 0;
 			e.client_version_mask    = row[29] ? static_cast<uint32_t>(strtoul(row[29], nullptr, 10)) : 4294967295;
 			e.is_ldon_door           = row[30] ? static_cast<int16_t>(atoi(row[30])) : 0;
-			e.dz_switch_id           = row[31] ? static_cast<int32_t>(atoi(row[31])) : 0;
-			e.min_expansion          = row[32] ? static_cast<int8_t>(atoi(row[32])) : -1;
-			e.max_expansion          = row[33] ? static_cast<int8_t>(atoi(row[33])) : -1;
-			e.content_flags          = row[34] ? row[34] : "";
-			e.content_flags_disabled = row[35] ? row[35] : "";
+			e.close_timer_ms         = row[31] ? static_cast<int16_t>(atoi(row[31])) : 5000;
+			e.dz_switch_id           = row[32] ? static_cast<int32_t>(atoi(row[32])) : 0;
+			e.min_expansion          = row[33] ? static_cast<int8_t>(atoi(row[33])) : -1;
+			e.max_expansion          = row[34] ? static_cast<int8_t>(atoi(row[34])) : -1;
+			e.content_flags          = row[35] ? row[35] : "";
+			e.content_flags_disabled = row[36] ? row[36] : "";
 
 			all_entries.push_back(e);
 		}
@@ -605,11 +614,12 @@ public:
 			e.buffer                 = row[28] ? strtof(row[28], nullptr) : 0;
 			e.client_version_mask    = row[29] ? static_cast<uint32_t>(strtoul(row[29], nullptr, 10)) : 4294967295;
 			e.is_ldon_door           = row[30] ? static_cast<int16_t>(atoi(row[30])) : 0;
-			e.dz_switch_id           = row[31] ? static_cast<int32_t>(atoi(row[31])) : 0;
-			e.min_expansion          = row[32] ? static_cast<int8_t>(atoi(row[32])) : -1;
-			e.max_expansion          = row[33] ? static_cast<int8_t>(atoi(row[33])) : -1;
-			e.content_flags          = row[34] ? row[34] : "";
-			e.content_flags_disabled = row[35] ? row[35] : "";
+			e.close_timer_ms         = row[31] ? static_cast<int16_t>(atoi(row[31])) : 5000;
+			e.dz_switch_id           = row[32] ? static_cast<int32_t>(atoi(row[32])) : 0;
+			e.min_expansion          = row[33] ? static_cast<int8_t>(atoi(row[33])) : -1;
+			e.max_expansion          = row[34] ? static_cast<int8_t>(atoi(row[34])) : -1;
+			e.content_flags          = row[35] ? row[35] : "";
+			e.content_flags_disabled = row[36] ? row[36] : "";
 
 			all_entries.push_back(e);
 		}
@@ -715,6 +725,7 @@ public:
 		v.push_back(std::to_string(e.buffer));
 		v.push_back(std::to_string(e.client_version_mask));
 		v.push_back(std::to_string(e.is_ldon_door));
+		v.push_back(std::to_string(e.close_timer_ms));
 		v.push_back(std::to_string(e.dz_switch_id));
 		v.push_back(std::to_string(e.min_expansion));
 		v.push_back(std::to_string(e.max_expansion));
@@ -773,6 +784,7 @@ public:
 			v.push_back(std::to_string(e.buffer));
 			v.push_back(std::to_string(e.client_version_mask));
 			v.push_back(std::to_string(e.is_ldon_door));
+			v.push_back(std::to_string(e.close_timer_ms));
 			v.push_back(std::to_string(e.dz_switch_id));
 			v.push_back(std::to_string(e.min_expansion));
 			v.push_back(std::to_string(e.max_expansion));

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9272
+#define CURRENT_BINARY_DATABASE_VERSION 9274
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9043
 
 #endif

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9274
+#define CURRENT_BINARY_DATABASE_VERSION 9273
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9043
 
 #endif

--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -43,7 +43,7 @@ extern EntityList  entity_list;
 extern WorldServer worldserver;
 
 Doors::Doors(const DoorsRepository::Doors &door) :
-	m_close_timer(5000),
+	m_close_timer(door.close_timer_ms),
 	m_position(door.pos_x, door.pos_y, door.pos_z, door.heading),
 	m_destination(door.dest_x, door.dest_y, door.dest_z, door.dest_heading)
 {


### PR DESCRIPTION
# Description

Existing code uses a hard coded 5000ms for a timer that tries to match the client in regards to when doors on the client close themselves.  This PR allows each door to have it's own value, as I have found that doors in runnyeye run on 10000ms timer.  Perhaps if we gather enough data in the db over time, as we repair values in the new field in doors, we can draw some conclusions that would allow a more general rule.  But if seems like a small price to pay (one field) to be able to control the server to match client behavior per door.

This PR defaults the database to 5000ms, as per existing behaviour.

![image](https://github.com/EQEmu/Server/assets/8644833/0779a8fc-9677-49f8-8ffb-eb5fb7e93550)


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# Testing

Tested doors wil various values and added a temporary log entry displaying door timer setting.

Clients tested: 

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [ ] I have made corresponding changes to the documentation (if applicable, if not delete this line)
- [X] I own the changes of my code and take responsibility for the potential issues that occur
- [X] If my changes make database schema changes, I have tested the changes on a local database (attach image). Updated version.h CURRENT_BINARY_DATABASE_VERSION to the new version. (Delete this if not applicable)
