### PR TITLE
[Corpses] Corpse searches for items did not search augs

### DIFF
--- a/zone/inventory.cpp
+++ b/zone/inventory.cpp
@@ -4820,6 +4820,11 @@ bool Client::HasItemOnCorpse(uint32 item_id)
 		if (item.item_id == item_id) {
 			return true;
 		}
+		if (item.aug_1 == item_id || item.aug_2 == item_id ||
+			item.aug_3 == item_id || item.aug_4 == item_id ||
+			item.aug_5 == item_id || item.aug_6 == item_id) {
+			return true;
+		}
 	}
 
 	return false;


### PR DESCRIPTION
# Description

I have a section in my global player quest that looks for an item on a player and acts accordingly.  If a player dies, this code was not finding an aug on the corpses causing it to behave incorrectly.

Using this version of hasitem.pl :  https://github.com/ProjectEQ/projecteqquests/blob/master/plugins/check_hasitem.pl#L35

I updated $client->HasItemOnCorpse($item_id) to check for augs on the items on corpses.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

This fixes the issue.  Video of entering zone [before ](http://norrath.no-ip.org/B4Aug.mp4)fix (and item given incorrectly) and [after](http://norrath.no-ip.org/AfterAug.mp4)

Clients tested: RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur

