### PR TITLE
[Feature] Add `is_parcel_merchant` to #npcedit

### DIFF
--- a/zone/gm_commands/npcedit.cpp
+++ b/zone/gm_commands/npcedit.cpp
@@ -1579,6 +1579,24 @@ void command_npcedit(Client *c, const Seperator *sep)
 			);
 			return;
 		}
+	} else if (!strcasecmp(sep->arg[1], "is_parcel_merchant")) {
+		if (sep->IsNumber(2)) {
+			const bool is_parcel_merchant = static_cast<uint8_t>(Strings::ToUnsignedInt(sep->arg[2]));
+
+			n.is_parcel_merchant = is_parcel_merchant;
+
+			d = fmt::format(
+				"{} will {} be a Parcel Merchant.",
+				npc_id_string,
+				is_parcel_merchant ? "now" : "no longer"
+			);
+		} else {
+			c->Message(
+				Chat::White,
+				"Usage: #npcedit is_parcel_merchant [Flag] - Sets an NPC's Parcel Merchant Flag [0 = False, 1 = True]"
+			);
+			return;
+		}
 	} else if (!strcasecmp(sep->arg[1], "setanimation")) {
 		if (sep->IsNumber(2)) {
 			auto animation_id   = Strings::ToUnsignedInt(sep->arg[2]);
@@ -1791,6 +1809,7 @@ void SendNPCEditSubCommands(Client *c)
 	c->Message(Chat::White, "Usage: #npcedit heroic_strikethrough [Heroic Strikethrough] - Sets an NPC's Heroic Strikethrough");
 	c->Message(Chat::White, "Usage: #npcedit faction_amount [Faction Amount] - Sets an NPC's Faction Amount");
 	c->Message(Chat::White, "Usage: #npcedit keeps_sold_items [Flag] - Sets an NPC's Keeps Sold Items Flag [0 = False, 1 = True]");
+	c->Message(Chat::White, "Usage: #npcedit is_parcel_merchant [Flag] - Sets an NPC's Parcel Merchant Flag [0 = False, 1 = True]");
 	c->Message(Chat::White, "Usage: #npcedit setanimation [Animation ID] - Sets an NPC's Animation on Spawn (Stored in spawn2 table)");
 	c->Message(Chat::White, "Usage: #npcedit respawntime [Respawn Time] - Sets an NPC's Respawn Timer in Seconds (Stored in spawn2 table)");
 	c->Message(Chat::White, "Usage: #npcedit set_grid [Grid ID] - Sets an NPC's Grid ID");


### PR DESCRIPTION
# Description
- Adds the ability to edit an NPC's `is_parcel_merchant` flag with `#npcedit is_parcel_merchant`.

## Type of Change
- [X] New feature

# Testing
![image](https://github.com/EQEmu/Server/assets/89047260/12700b4d-575e-40b7-a1f5-2acc8ba1cc60)
![image](https://github.com/EQEmu/Server/assets/89047260/c5b5f1b2-bdd5-4797-8cae-f9f2ec066f8d)

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
