### PR TITLE
[Urgent Patch] Update database_update_manifest.cpp

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -5540,7 +5540,7 @@ ALTER TABLE `character_parcels`
 	ManifestEntry{
 		.version = 9273,
 		.description = "2024_04_24_door_close_timer.sql",
-		.check = "SHOW COLUMNS FROM `doors` LIKE 'close_timer'",
+		.check = "SHOW COLUMNS FROM `doors` LIKE 'close_timer_ms'",
 		.condition = "empty",
 		.match = "",
 		.sql = R"(


### PR DESCRIPTION
Manifest check for field used incorrect name.

# Description

Well, I tested adding the field, but not what happens when you try twice and your check is incorrect.  This needs to be merged to prevent a manifest error.  Now runs correctly even if you already have the field.

![image](https://github.com/EQEmu/Server/assets/8644833/ddb3d7b4-4b99-4ffe-825e-f1d604d1543e)


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

Ran db update multiple times after adjusting db version to retest.

Clients tested: ROF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
- [X] If my changes make database schema changes, I have tested the changes on a local database (attach image). Updated version.h CURRENT_BINARY_DATABASE_VERSION to the new version. (Delete this if not applicable)
