### PR TITLE
[Feature] Add profiler flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,13 @@ IF (EQEMU_BUILD_STATIC)
 	ENDIF ()
 ENDIF (EQEMU_BUILD_STATIC)
 
+
+# Requires libgoogle-perftools-dev google-perftools packages for linux (debian)
+IF(EQEMU_ADD_PROFILER)
+	SET(CMAKE_EXE_LINKER_FLAGS "-Wl,--no-as-needed,-lprofiler,--as-needed")
+ENDIF(EQEMU_ADD_PROFILER)
+
+
 IF(MSVC)
 	ADD_DEFINITIONS(-D_CRT_SECURE_NO_WARNINGS)
 	ADD_DEFINITIONS(-DNOMINMAX)


### PR DESCRIPTION
# Description

This adds a new flag option, EQEMU_ADD_PROFILER.
When enabled, this allows you to use google-perftools to get heap and other info.

I'll add another PR with usages, but this change alone, due to it not being enabled by default, should have no side effects. I also added comments on enabling it on linux. I am unsure the steps for windows support, it may be worth adding that context as well in a comment/documentation.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# Testing

Attach images and describe testing done to validate functionality.

Clients tested: N/A, RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [ ] I have made corresponding changes to the documentation (if applicable, if not delete this line)
- [x] I own the changes of my code and take responsibility for the potential issues that occur