### PR TITLE
[Database] Move pets query to content database

### DIFF
--- a/zone/pets.cpp
+++ b/zone/pets.cpp
@@ -383,7 +383,7 @@ bool ZoneDatabase::GetPetEntry(const std::string& pet_type, PetRecord *p)
 bool ZoneDatabase::GetPoweredPetEntry(const std::string& pet_type, int16 pet_power, PetRecord* r)
 {
 	const auto& l = PetsRepository::GetWhere(
-		*this,
+		content_db,
 		fmt::format(
 			"`type` = '{}' AND `petpower` <= {} ORDER BY `petpower` DESC LIMIT 1",
 			pet_type,
@@ -395,7 +395,7 @@ bool ZoneDatabase::GetPoweredPetEntry(const std::string& pet_type, int16 pet_pow
 		return false;
 	}
 
-	auto e = l.front();
+	auto &e = l.front();
 
 	r->npc_type     = e.npcID;
 	r->temporary    = e.temp;


### PR DESCRIPTION
# Description

Pull powered pet entries from content database.

As seen on PEQ:
```05-02-2024 22:19:33 | Zone | QueryErr | MySQL Error (1146) [Table 'peq.pets' doesn't exist] Query [SELECT id, type, petpower, npcID, temp, petcontrol, petnaming, monsterflag, equipmentset FROM pets WHERE `type` = 'SwarmPetDG3' AND `petpower` <= 0 ORDER BY `petpower` DESC LIMIT 1]```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

![image](https://github.com/EQEmu/Server/assets/3617814/3a0080a2-d981-4651-be7d-b671789574f7)

![image](https://github.com/EQEmu/Server/assets/3617814/6f372cf0-ed8f-4cd1-81f9-9225cbac3be6)

Clients tested: RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
