### PR TITLE
[Zone Instances] Handle routing to instances when using evac/succor

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -240,6 +240,7 @@ Client::Client(EQStreamInterface *ieqs) : Mob(
 	runmode = false;
 	linkdead_timer.Disable();
 	zonesummon_id = 0;
+	zonesummon_instance_id = 0;
 	zonesummon_ignorerestrictions = 0;
 	bZoning              = false;
 	m_lock_save_position = false;

--- a/zone/client.h
+++ b/zone/client.h
@@ -1951,6 +1951,7 @@ private:
 
 	glm::vec4 m_ZoneSummonLocation;
 	uint16 zonesummon_id;
+	uint8 zonesummon_instance_id;
 	uint8 zonesummon_ignorerestrictions;
 	ZoneMode zone_mode;
 

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -94,6 +94,7 @@ void Client::Handle_OP_ZoneChange(const EQApplicationPacket *app) {
 			case GMHiddenSummon:
 			case ZoneSolicited: //we told the client to zone somewhere, so we know where they are going.
 				target_zone_id = zonesummon_id;
+				target_instance_id = zonesummon_instance_id;
 				break;
 			case GateToBindPoint:
 			case ZoneToBindPoint:
@@ -126,6 +127,7 @@ void Client::Handle_OP_ZoneChange(const EQApplicationPacket *app) {
 		// WildcardX 27 January 2008
 		if (zone_mode == EvacToSafeCoords && zonesummon_id) {
 			target_zone_id = zonesummon_id;
+			target_instance_id = zonesummon_instance_id;
 		} else {
 			target_zone_id = zc->zoneID;
 		}
@@ -573,6 +575,7 @@ void Client::DoZoneSuccess(ZoneChange_Struct *zc, uint16 zone_id, uint32 instanc
 	zone_mode = ZoneUnsolicited;
 	m_ZoneSummonLocation = glm::vec4();
 	zonesummon_id = 0;
+	zonesummon_instance_id = 0;
 	zonesummon_ignorerestrictions = 0;
 
 	// this simply resets the zone shutdown timer
@@ -959,6 +962,7 @@ void Client::ZonePC(uint32 zoneID, uint32 instance_id, float x, float y, float z
 
 			// we hide the real zoneid we want to evac/succor to here
 			zonesummon_id = zoneID;
+			zonesummon_instance_id = instance_id;
 
 			outapp->priority = 6;
 			FastQueuePacket(&outapp);


### PR DESCRIPTION
# Description

When using evac/succor spells, the client doesn't properly zone, so we have to trick the client by zoning into a valid zone. Currently we use South Qeynos (1) or North Qeynos (2).

```
			// if we are in the same zone we want to evac to, client will not send OP_ZoneChange back to do an actual
			// zoning of the client, so we have to send a viable zoneid that the client *could* zone to to make it believe
			// we are leaving the zone, even though we are not. We have to do this because we are missing the correct op code
			// and struct that should be used for evac/succor.
			// 213 is Plane of War
			// 76 is orignial Plane of Hate
			// WildcardX 27 January 2008. Tested this for 6.2 and Titanium clients.

			if (GetZoneID() == 1) {
				gmg->zone_id = 2;
			} else {
				gmg->zone_id = 1;
			}
```

Unfortunately, that messes with routing to instances since those zones won't have the same instance ids. This change tucks away the instance id along with the zone id to use once the zone instruction is issued for evac.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

Load into Lavastorm, then Evac:
```
[Sat May 04 13:04:17 2024] ------------------------------------------------
[Sat May 04 13:04:17 2024] Current Expansion | Dragons of Norrath (9)
[Sat May 04 13:04:17 2024] Current Zone | [lavastorm] (The Lavastorm Mountains) version [1] instance_id [5] min/max expansion (9/99) content_flags []
[Sat May 04 13:04:17 2024] ------------------------------------------------
[Sat May 04 13:04:40 2024] Your Fabled Earring of Unseen Horrors shimmers briefly.
[Sat May 04 13:04:40 2024] You begin casting Levant. (Levant)
[Sat May 04 13:04:44 2024] Your Zealot's Spiked Bracer pulses with light as your vision sharpens.
[Sat May 04 13:04:44 2024] LOADING, PLEASE WAIT...
[Sat May 04 13:04:49 2024] ------------------------------------------------
[Sat May 04 13:04:49 2024] Current Expansion | Dragons of Norrath (9)
[Sat May 04 13:04:49 2024] Current Zone | [lavastorm] (The Lavastorm Mountains) version [1] instance_id [5] min/max expansion (9/99) content_flags []
[Sat May 04 13:04:49 2024] ------------------------------------------------
```

Run to Nektulos, then evac:
```
[Sat May 04 13:05:36 2024] LOADING, PLEASE WAIT...
[Sat May 04 13:05:40 2024] You have entered The Nektulos Forest.
[Sat May 04 13:06:24 2024] ------------------------------------------------
[Sat May 04 13:06:24 2024] Current Expansion | Dragons of Norrath (9)
[Sat May 04 13:06:24 2024] Current Zone | [nektulos] (The Nektulos Forest) version [0] instance_id [0] min/max expansion (-1/9) content_flags []
[Sat May 04 13:06:24 2024] ------------------------------------------------
[Sat May 04 13:07:04 2024] You begin casting Levant. (Levant)
[Sat May 04 13:07:07 2024] Your Zealot's Spiked Bracer pulses with light as your vision sharpens.
[Sat May 04 13:07:08 2024] LOADING, PLEASE WAIT...
[Sat May 04 13:07:11 2024] You have entered The Nektulos Forest.
[Sat May 04 13:07:12 2024] ------------------------------------------------
[Sat May 04 13:07:12 2024] Current Expansion | Dragons of Norrath (9)
[Sat May 04 13:07:12 2024] Current Zone | [nektulos] (The Nektulos Forest) version [0] instance_id [0] min/max expansion (-1/9) content_flags []
[Sat May 04 13:07:12 2024] ------------------------------------------------
```

Run to East Commons:
```
[Sat May 04 13:07:48 2024] LOADING, PLEASE WAIT...
[Sat May 04 13:07:51 2024] You have entered East Commonlands.
[Sat May 04 13:07:52 2024] ------------------------------------------------
[Sat May 04 13:07:52 2024] Current Expansion | Dragons of Norrath (9)
[Sat May 04 13:07:52 2024] Current Zone | [ecommons] (East Commonlands) version [0] instance_id [0] min/max expansion (-1/-1) content_flags []
```
#zone to West Wastes:
```
[Sat May 04 13:08:15 2024] You say, '#zone westwastes'
[Sat May 04 13:08:16 2024] LOADING, PLEASE WAIT...
[Sat May 04 13:08:20 2024] You have entered The Western Wastes.
[Sat May 04 13:08:21 2024] ------------------------------------------------
[Sat May 04 13:08:21 2024] Current Expansion | Dragons of Norrath (9)
[Sat May 04 13:08:21 2024] Current Zone | [westwastes] (The Western Wastes) version [0] instance_id [0] min/max expansion (-1/-1) content_flags []
[Sat May 04 13:08:21 2024] ------------------------------------------------
```

Run to Sirens, evac in Sirens:
```
[Sat May 04 13:08:35 2024] LOADING, PLEASE WAIT...
[Sat May 04 13:08:38 2024] You have entered Siren's Grotto.
[Sat May 04 13:08:39 2024] ------------------------------------------------
[Sat May 04 13:08:39 2024] Current Expansion | Dragons of Norrath (9)
[Sat May 04 13:08:39 2024] Current Zone | [sirens] (Siren's Grotto) version [1] instance_id [11] min/max expansion (6/99) content_flags []
[Sat May 04 13:08:39 2024] ------------------------------------------------
[Sat May 04 13:08:45 2024] Your Fabled Earring of Unseen Horrors shimmers briefly.
[Sat May 04 13:08:45 2024] You begin casting Levant. (Levant)
[Sat May 04 13:08:48 2024] Your Zealot's Spiked Bracer pulses with light as your vision sharpens.
[Sat May 04 13:08:49 2024] LOADING, PLEASE WAIT...
[Sat May 04 13:08:51 2024] You have entered Siren's Grotto.
[Sat May 04 13:08:52 2024] ------------------------------------------------
[Sat May 04 13:08:52 2024] Current Expansion | Dragons of Norrath (9)
[Sat May 04 13:08:52 2024] Current Zone | [sirens] (Siren's Grotto) version [1] instance_id [11] min/max expansion (6/99) content_flags []
[Sat May 04 13:08:52 2024] ------------------------------------------------
```

Clients tested: RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur