### PR TITLE
[Quests] Reload Quests on Bootup, Init earlier

### DIFF
--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -223,6 +223,11 @@ PerlembParser::~PerlembParser()
 	safe_delete(perl);
 }
 
+void PerlembParser::Init()
+{
+	ReloadQuests();
+}
+
 void PerlembParser::ReloadQuests()
 {
 	try {

--- a/zone/embparser.h
+++ b/zone/embparser.h
@@ -138,6 +138,7 @@ public:
 
 	virtual void AddVar(std::string name, std::string val);
 	virtual std::string GetVar(std::string name);
+	virtual void Init() override;
 	virtual void ReloadQuests();
 	virtual uint32 GetIdentifier() { return 0xf8b05c11; }
 

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -109,6 +109,7 @@ bool Zone::Bootup(uint32 iZoneID, uint32 iInstanceID, bool is_static) {
 	zone = new Zone(iZoneID, iInstanceID, zonename);
 
 	parse->Init();
+	parse->ReloadQuests(true);
 
 	//init the zone, loads all the data, etc
 	if (!zone->Init(is_static)) {

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -108,6 +108,8 @@ bool Zone::Bootup(uint32 iZoneID, uint32 iInstanceID, bool is_static) {
 	numclients = 0;
 	zone = new Zone(iZoneID, iInstanceID, zonename);
 
+	parse->Init();
+
 	//init the zone, loads all the data, etc
 	if (!zone->Init(is_static)) {
 		safe_delete(zone);
@@ -158,7 +160,6 @@ bool Zone::Bootup(uint32 iZoneID, uint32 iInstanceID, bool is_static) {
 	LogInfo("Zone server [{}] listening on port [{}]", zonename, ZoneConfig::get()->ZonePort);
 	LogInfo("Zone bootup type [{}] short_name [{}] zone_id [{}] instance_id [{}]",
 		(is_static) ? "Static" : "Dynamic", zonename, iZoneID, iInstanceID);
-	parse->Init();
 	UpdateWindowTitle(nullptr);
 
 	// Dynamic zones need to Sync here.


### PR DESCRIPTION
# Description

This PR attempts to circle back on the following related PR's

- https://github.com/EQEmu/Server/pull/4225
- https://github.com/EQEmu/Server/pull/3333
- https://github.com/EQEmu/Server/pull/3648
- https://github.com/EQEmu/Server/pull/4149

Perl does not implement the reload interface. We also should initialize / reload earlier in the zone init process because we rely on things being reloaded before we spawn in NPC's and anything else.

A concern is that one time we broke encounters. Another was that we would reload after NPC's had already been spawned, including things like the zone controller. This should consider those cases as well.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Attach images and describe testing done to validate functionality.

**Tested Zone Controller**

```perl
sub EVENT_SPAWN {
    quest::shout("I'm alive");
    quest::debug("zone controller is alive");
}
```

Tested in halas

![image](https://github.com/EQEmu/Server/assets/3319450/59dd39cf-e97e-40ff-9953-a5c8cb1d600d)

Edited the script after the process was already booted from a cold start

```
  Zone |    Info    | LoadLootTables Loaded [13] loottables (0.000070s) 
  Zone |    Info    | PopulateZoneSpawnList Loaded [0] respawn timer(s) 
  Zone |    Info    | PopulateZoneSpawnList Loaded [0] spawn2 entries 
  Zone | Quest Debu | Perl__debug zone controller is alive (after process was booted) 
```

**Tested Encounters**

Edited an encounter spawn event for a zone process that was idle and not booted

After booting

```
  Zone | Quest Debu | lua_debug King spawn -- [riftseekers] (Riftseekers' Sanctum) inst_id [0]
```

Clients tested: ROF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur