### PR TITLE
[Quests] Hot Reload Changes

### DIFF
--- a/world/console.cpp
+++ b/world/console.cpp
@@ -918,6 +918,8 @@ void ConsoleReloadWorld(
 	safe_delete(pack);
 }
 
+auto debounceReload = std::chrono::system_clock::now();
+
 /**
  * @param connection
  * @param command
@@ -933,6 +935,14 @@ void ConsoleReloadZoneQuests(
 		connection->SendLine("[zone_short_name] required as argument");
 		return;
 	}
+
+	// if now is within 1 second, return
+	if (std::chrono::system_clock::now() - debounceReload < std::chrono::seconds(1)) {
+		debounceReload = std::chrono::system_clock::now();
+		return;
+	}
+
+	debounceReload = std::chrono::system_clock::now();
 
 	std::string zone_short_name = args[0];
 

--- a/world/console.cpp
+++ b/world/console.cpp
@@ -918,7 +918,7 @@ void ConsoleReloadWorld(
 	safe_delete(pack);
 }
 
-auto debounceReload = std::chrono::system_clock::now();
+auto debounce_reload = std::chrono::system_clock::now();
 
 /**
  * @param connection
@@ -937,12 +937,12 @@ void ConsoleReloadZoneQuests(
 	}
 
 	// if now is within 1 second, return
-	if (std::chrono::system_clock::now() - debounceReload < std::chrono::seconds(1)) {
-		debounceReload = std::chrono::system_clock::now();
+	if (std::chrono::system_clock::now() - debounce_reload < std::chrono::seconds(1)) {
+		debounce_reload = std::chrono::system_clock::now();
 		return;
 	}
 
-	debounceReload = std::chrono::system_clock::now();
+	debounce_reload = std::chrono::system_clock::now();
 
 	std::string zone_short_name = args[0];
 

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -3550,18 +3550,18 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 			zone->SetQuestHotReloadQueued(true);
 		} else if (request_zone_short_name == "all") {
 			std::string reload_quest_saylink = Saylink::Silent("#reload quest", "Locally");
-			std::string reload_world_saylink = Saylink::Silent("#reload world", "Globally");
-			worldserver.SendEmoteMessage(
-				0,
-				0,
-				AccountStatus::ApprenticeGuide,
-				Chat::Yellow,
-				fmt::format(
+			std::string reload_world_saylink = Saylink::Silent("#reload world 1", "Globally");
+			for (const auto& [client_id, client] : entity_list.GetClientList()) {
+				if (client->Admin() < AccountStatus::ApprenticeGuide) {
+					continue;
+				}
+
+				client->Message(Chat::Yellow, fmt::format(
 					"A quest, plugin, or global script has changed. Reload: [{}] [{}]",
 					reload_quest_saylink,
 					reload_world_saylink
-				).c_str()
-			);
+				).c_str());
+			}
 		}
 		break;
 	}


### PR DESCRIPTION
# Description

This PR addresses a few minor issues with quest hot reloading that were found when porting hot reloading over to Spire natively away from Occulus itself.

**Fixes**

* An issue where if global auto reload was turned off, you'd see as many messages to reload as there were zones
* An issue where double messaging can be queued and sent, we use debouncing for this now

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

**Problem before**

We see as many messages as we do zones booted

![image](https://github.com/EQEmu/Server/assets/3319450/83089ca4-32fe-46ac-a6d0-d17e79a9d638)

**After**

One line, as expected

![image](https://github.com/EQEmu/Server/assets/3319450/e158586b-f799-466a-9e7d-5c2ccb80d3e2)


# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
