### PR TITLE
[Fix] Clear GuildOnlineStatus on world boot

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -2089,3 +2089,8 @@ void Database::PurgeCharacterParcels()
 		RuleI(Parcel, ParcelPruneDelay)
 	);
 }
+
+void Database::ClearGuildOnlineStatus()
+{
+	GuildMembersRepository::ClearOnlineStatus(*this);
+}

--- a/common/database.h
+++ b/common/database.h
@@ -243,6 +243,7 @@ public:
 	void SetRaidGroupLeaderInfo(uint32 group_id, uint32 raid_id);
 
 	void PurgeAllDeletedDataBuckets();
+	void ClearGuildOnlineStatus();
 
 
 	/* Database Variables */

--- a/common/repositories/guild_members_repository.h
+++ b/common/repositories/guild_members_repository.h
@@ -190,6 +190,17 @@ public:
 
 		return UpdateOne(db, m);
 	}
+
+	static void ClearOnlineStatus(Database &db)
+	{
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"UPDATE {} SET `online` = 0 "
+				"WHERE `online` = 1;",
+				TableName()
+			)
+		);
+	}
 };
 
 #endif //EQEMU_GUILD_MEMBERS_REPOSITORY_H

--- a/world/cliententry.cpp
+++ b/world/cliententry.cpp
@@ -138,7 +138,7 @@ void ClientListEntry::SetOnline(CLE_Status iOnline)
 		"Online status [{}] ({}) status [{}] ({})",
 		AccountName(),
 		AccountID(),
-		CLEStatusString[CLE_Status::Online],
+		CLEStatusString[iOnline],
 		static_cast<int>(iOnline)
 	);
 

--- a/world/world_boot.cpp
+++ b/world/world_boot.cpp
@@ -284,6 +284,8 @@ bool WorldBoot::DatabaseLoadRoutines(int argc, char **argv)
 	database.ClearRaid();
 	database.ClearRaidDetails();
 	database.ClearRaidLeader();
+	LogInfo("Clearing guild online status");
+	database.ClearGuildOnlineStatus();
 	LogInfo("Clearing inventory snapshots");
 	database.ClearInvSnapshots();
 	LogInfo("Loading items");


### PR DESCRIPTION
There have been a few reports of guild online status showing incorrectly in the guild mgmt window.  More specifically the guild mgmt window shows a player online when they are in fact off-line.

This update will ensure that guild online status is forced to 'offline' when world boots and assist with resolving this situation.

Also, the update to iOnline is to correct the english version to be displayed, which appears to be the original intent.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
Booted world and noted that the guild_members table was updated to set online status to 0.

Clients tested: 
N/A

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
