### PR TITLE
[Fix} Correct a guild bank dup issue

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -5568,6 +5568,17 @@ ADD COLUMN `is_parcel_merchant` TINYINT(1) UNSIGNED NOT NULL DEFAULT '0' AFTER `
 ALTER TABLE `character_data`
 ADD COLUMN `extra_haste` int(11) NOT NULL DEFAULT 0 AFTER `wis`;
 )"
+	},
+	ManifestEntry{
+		.version = 9276,
+		.description = "2024_05_12_fix_guild_bank_dup_issue.sql",
+		.check = "SHOW COLUMNS FROM `guild_bank` WHERE FIELD = 'qty' AND Type LIKE '%unsigned';",
+		.condition = "not_empty",
+		.match = "",
+		.sql = R"(
+ALTER TABLE `guild_bank`
+	CHANGE COLUMN `qty` `qty` INT(10) NOT NULL DEFAULT '0' AFTER `itemid`;
+)"
 	}
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9275
+#define CURRENT_BINARY_DATABASE_VERSION 9276
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9044
 
 #endif


### PR DESCRIPTION
When depositing an item in the guild bank with an unlimited charge (-1) a db error would occur resulting in a duplication issue. Can test with item id 70208

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
Before (note qty)
![guild_bank_before](https://github.com/EQEmu/Server/assets/65987027/5a789e06-4c15-4834-bcf4-6d58dc4d0db6)

After (note qty)
![guild_bank_after](https://github.com/EQEmu/Server/assets/65987027/3392009c-7b76-42df-b89d-240ae170816e)

https://www.youtube.com/watch?v=xOSWbRp-jho

Clients tested: 
RoF2
UF
Ti

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
- [X] If my changes make database schema changes, I have tested the changes on a local database (attach image). Updated version.h CURRENT_BINARY_DATABASE_VERSION to the new version. (Delete this if not applicable)
