### PR TITLE
[Commands] Cleanup #resetaa Command

### DIFF
--- a/zone/aa.cpp
+++ b/zone/aa.cpp
@@ -518,7 +518,7 @@ void Mob::WakeTheDead(uint16 spell_id, Corpse *corpse_to_use, Mob *tar, uint32 d
 
 void Client::ResetAA()
 {
-	SendClearAA();
+	SendClearPlayerAA();
 	RefundAA();
 
 	memset(&m_pp.aa_array[0], 0, sizeof(AA_Array) * MAX_PP_AA_ARRAY);
@@ -540,6 +540,13 @@ void Client::ResetAA()
 		++slot_id;
 	}
 
+	database.DeleteCharacterAAs(CharacterID());
+}
+
+void Client::ResetLeadershipAA()
+{
+	SendClearLeadershipAA();
+
 	for (int slot_id = 0; slot_id < _maxLeaderAA; ++slot_id) {
 		m_pp.leader_abilities.ranks[slot_id] = 0;
 	}
@@ -549,14 +556,7 @@ void Client::ResetAA()
 	m_pp.group_leadership_exp    = 0;
 	m_pp.raid_leadership_exp     = 0;
 
-	database.DeleteCharacterAAs(CharacterID());
 	database.DeleteCharacterLeadershipAbilities(CharacterID());
-}
-
-void Client::SendClearAA()
-{
-	SendClearLeadershipAA();
-	SendClearPlayerAA();
 }
 
 void Client::SendClearPlayerAA()
@@ -2178,7 +2178,8 @@ void Client::AutoGrantAAPoints() {
 		}
 	}
 
-	SendClearAA();
+	SendClearLeadershipAA();
+	SendClearPlayerAA();
 	SendAlternateAdvancementTable();
 	SendAlternateAdvancementPoints();
 	SendAlternateAdvancementStats();
@@ -2211,7 +2212,8 @@ void Client::GrantAllAAPoints(uint8 unlock_level)
 	}
 
 	SaveAA();
-	SendClearAA();
+	SendClearLeadershipAA();
+	SendClearPlayerAA();
 	SendAlternateAdvancementTable();
 	SendAlternateAdvancementPoints();
 	SendAlternateAdvancementStats();

--- a/zone/client.h
+++ b/zone/client.h
@@ -1009,8 +1009,8 @@ public:
 
 	//old AA methods that we still use
 	void ResetAA();
+	void ResetLeadershipAA();
 	void RefundAA();
-	void SendClearAA();
 	void SendClearLeadershipAA();
 	void SendClearPlayerAA();
 	inline uint32 GetAAXP() const { return m_pp.expAA; }

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -197,7 +197,7 @@ int command_init(void)
 		command_add("rl", "Reloads logs (alias of #reload logs).", AccountStatus::GMMgmt, command_reload) ||
 		command_add("removeitem", "[Item ID] [Amount] - Removes the specified Item ID by Amount from you or your player target's inventory (Amount defaults to 1 if not used)", AccountStatus::GMAdmin, command_removeitem) ||
 		command_add("repop", "[Force] - Repop the zone with optional force repop", AccountStatus::GMAdmin, command_repop) ||
-		command_add("resetaa", "Resets a Player's AA in their profile and refunds spent AA's to unspent, may disconnect player.", AccountStatus::GMMgmt, command_resetaa) ||
+		command_add("resetaa", "[aa|leadership] - Resets a player's AAs or Leadership AAs and refunds spent AAs (not Leadership AAs) to unspent, may disconnect player.", AccountStatus::GMMgmt, command_resetaa) ||
 		command_add("resetaa_timer", "[All|Timer ID] - Command to reset AA cooldown timers for you or your player target.", AccountStatus::GMMgmt, command_resetaa_timer) ||
 		command_add("resetdisc_timer", "[All|Timer ID] - Command to reset discipline timers.", AccountStatus::GMMgmt, command_resetdisc_timer) ||
 		command_add("revoke", "[Character Name] [0|1] - Revokes or unrevokes a player's ability to talk in OOC by name (0 = Unrevoke, 1 = Revoke)", AccountStatus::GMMgmt, command_revoke) ||

--- a/zone/gm_commands/resetaa.cpp
+++ b/zone/gm_commands/resetaa.cpp
@@ -7,13 +7,30 @@ void command_resetaa(Client *c, const Seperator *sep)
 		return;
 	}
 
-	auto t = c->GetTarget()->CastToClient();
-	t->ResetAA();
+	const uint16 arguments = sep->argnum;
+
+	const bool is_aa         = !strcasecmp(sep->arg[1], "aa");
+	const bool is_leadership = !strcasecmp(sep->arg[1], "leadership");
+
+	if (!is_aa && !is_leadership) {
+		c->Message(Chat::White, "Usage: #resetaa aa - Resets and refunds a player's AAs");
+		c->Message(Chat::White, "Usage: #resetaa leadership - Resets a player's Leadership AAs");
+		return;
+	}
+
+	Client* t = c->GetTarget()->CastToClient();
+
+	if (is_aa) {
+		t->ResetAA();
+	} else if (is_leadership) {
+		t->ResetLeadershipAA();
+	}
 
 	c->Message(
 		Chat::White,
 		fmt::format(
-			"Successfully reset all Alternate Advancements for {}.",
+			"Successfully reset all{} AAs for {}.",
+			is_aa ? "" : " Leadership",
 			c->GetTargetDescription(t)
 		).c_str()
 	);

--- a/zone/gm_commands/resetaa.cpp
+++ b/zone/gm_commands/resetaa.cpp
@@ -2,23 +2,20 @@
 
 void command_resetaa(Client *c, const Seperator *sep)
 {
-	if (!c->GetTarget() || !c->GetTarget()->IsClient()) {
-		c->Message(Chat::White, "You must target a player to use this command.");
-		return;
+	Client* t = c;
+	if (c->GetTarget() && c->GetTarget()->IsClient()) {
+		t = c->GetTarget()->CastToClient();
 	}
 
-	const uint16 arguments = sep->argnum;
+	const uint16 arguments     = sep->argnum;
+	const bool   is_aa         = !strcasecmp(sep->arg[1], "aa");
+	const bool   is_leadership = !strcasecmp(sep->arg[1], "leadership");
 
-	const bool is_aa         = !strcasecmp(sep->arg[1], "aa");
-	const bool is_leadership = !strcasecmp(sep->arg[1], "leadership");
-
-	if (!is_aa && !is_leadership) {
+	if (!arguments || (!is_aa && !is_leadership)) {
 		c->Message(Chat::White, "Usage: #resetaa aa - Resets and refunds a player's AAs");
 		c->Message(Chat::White, "Usage: #resetaa leadership - Resets a player's Leadership AAs");
 		return;
 	}
-
-	Client* t = c->GetTarget()->CastToClient();
 
 	if (is_aa) {
 		t->ResetAA();

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3369,6 +3369,12 @@ void Lua_Client::DescribeSpecialAbilities(Lua_NPC n)
 	n.DescribeSpecialAbilities(self);
 }
 
+void Lua_Client::ResetLeadershipAA()
+{
+	Lua_Safe_Call_Void();
+	self->ResetLeadershipAA();
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 	.def(luabind::constructor<>())
@@ -3751,11 +3757,13 @@ luabind::scope lua_register_client() {
 	.def("RemoveAllExpeditionLockouts", (void(Lua_Client::*)(std::string))&Lua_Client::RemoveAllExpeditionLockouts)
 	.def("RemoveAllExpeditionLockouts", (void(Lua_Client::*)(void))&Lua_Client::RemoveAllExpeditionLockouts)
 	.def("RemoveAlternateCurrencyValue", (bool(Lua_Client::*)(uint32,uint32))&Lua_Client::RemoveAlternateCurrencyValue)
+	.def("RemoveEbonCrystals", (void(Lua_Client::*)(uint32))&Lua_Client::RemoveEbonCrystals)
 	.def("RemoveExpeditionLockout", (void(Lua_Client::*)(std::string, std::string))&Lua_Client::RemoveExpeditionLockout)
 	.def("RemoveItem", (void(Lua_Client::*)(uint32))&Lua_Client::RemoveItem)
 	.def("RemoveItem", (void(Lua_Client::*)(uint32,uint32))&Lua_Client::RemoveItem)
 	.def("RemoveLDoNLoss", (void(Lua_Client::*)(uint32))&Lua_Client::RemoveLDoNLoss)
 	.def("RemoveLDoNWin", (void(Lua_Client::*)(uint32))&Lua_Client::RemoveLDoNWin)
+	.def("RemoveRadiantCrystals", (void(Lua_Client::*)(uint32))&Lua_Client::RemoveRadiantCrystals)
 	.def("ResetAA", (void(Lua_Client::*)(void))&Lua_Client::ResetAA)
 	.def("ResetAllDisciplineTimers", (void(Lua_Client::*)(void))&Lua_Client::ResetAllDisciplineTimers)
 	.def("ResetAllCastbarCooldowns", (void(Lua_Client::*)(void))&Lua_Client::ResetAllCastbarCooldowns)
@@ -3763,9 +3771,8 @@ luabind::scope lua_register_client() {
 	.def("ResetCastbarCooldownBySlot", (void(Lua_Client::*)(int))&Lua_Client::ResetCastbarCooldownBySlot)
 	.def("ResetCastbarCooldownBySpellID", (void(Lua_Client::*)(uint32))&Lua_Client::ResetCastbarCooldownBySpellID)
 	.def("ResetDisciplineTimer", (void(Lua_Client::*)(uint32))&Lua_Client::ResetDisciplineTimer)
-	.def("RemoveEbonCrystals", (void(Lua_Client::*)(uint32))&Lua_Client::RemoveEbonCrystals)
 	.def("ResetItemCooldown", (void(Lua_Client::*)(uint32))&Lua_Client::ResetItemCooldown)
-	.def("RemoveRadiantCrystals", (void(Lua_Client::*)(uint32))&Lua_Client::RemoveRadiantCrystals)
+	.def("ResetLeadershipAA", (void(Lua_Client::*)(void))&Lua_Client::ResetLeadershipAA)
 	.def("ResetTrade", (void(Lua_Client::*)(void))&Lua_Client::ResetTrade)
 	.def("RewardFaction", (void(Lua_Client::*)(int,int))&Lua_Client::RewardFaction)
 	.def("Save", (void(Lua_Client::*)(int))&Lua_Client::Save)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -503,6 +503,7 @@ public:
 	bool SetAutoLoginCharacterName();
 	bool SetAutoLoginCharacterName(std::string character_name);
 	void DescribeSpecialAbilities(Lua_NPC n);
+	void ResetLeadershipAA();
 
 	void ApplySpell(int spell_id);
 	void ApplySpell(int spell_id, int duration);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -3168,6 +3168,11 @@ void Perl_Client_DescribeSpecialAbilities(Client* self, NPC* n)
 	n->DescribeSpecialAbilities(self);
 }
 
+void Perl_Client_ResetLeadershipAA(Client* self)
+{
+	self->ResetLeadershipAA();
+}
+
 void perl_register_client()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3561,6 +3566,7 @@ void perl_register_client()
 	package.add("ResetCastbarCooldownBySpellID", &Perl_Client_ResetCastbarCooldownBySpellID);
 	package.add("ResetDisciplineTimer", &Perl_Client_ResetDisciplineTimer);
 	package.add("ResetItemCooldown", &Perl_Client_ResetItemCooldown);
+	package.add("ResetLeadershipAA", &Perl_Client_ResetLeadershipAA);
 	package.add("ResetTrade", &Perl_Client_ResetTrade);
 	package.add("Save", &Perl_Client_Save);
 	package.add("ScribeSpell", (void(*)(Client*, uint16, int))&Perl_Client_ScribeSpell);


### PR DESCRIPTION
# Description

Tossica reported Leadership AAs being reset and not refunded to the players when using `#resetaa`, causing players to lose their progress on these and require manual intervention to fix. Thread is [here](https://discord.com/channels/212663220849213441/1238107050173534269).

## Type of Change
- [X] Bug fix

# Testing
![image](https://github.com/EQEmu/Server/assets/89047260/640d6c67-f56a-4f5d-b22f-9aa63ad0b125)

## Perl
- Add `$client->ResetLeadershipAA()`.

### Perl Image
![image](https://github.com/EQEmu/Server/assets/89047260/1ccadd73-b5ca-48e3-b419-fa06c2490f86)

### Perl Example
```pl
sub EVENT_SAY {
	if ($text=~/#a/i) {
		quest::message(315, "Perl attempting to reset Leadership AAs.");
		$client->ResetLeadershipAA();
		quest::message(315, "Perl attempted to reset Leadership AAs.");
	}
}
```

## Lua
- Add `client:ResetLeadershipAA()`.

### Lua Image
![image](https://github.com/EQEmu/Server/assets/89047260/bd2cc917-493c-4cc9-8607-e10947a17d47)


### Lua Example
```lua
function event_say(e)
	if e.message:findi("#b") then
		eq.message(315, "Lua attempting to reset Leadership AA.")
		e.self:ResetLeadershipAA()
		eq.message(315, "Lua attempted to reset Leadership AA.")
	end
end
```

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur