### PR TITLE
[Bug Fix] Fix issue with #hotfix

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -741,7 +741,7 @@ bool Database::SetVariable(const std::string& name, const std::string& value)
 	auto l = VariablesRepository::GetWhere(
 		*this,
 		fmt::format(
-			"`name` = '{}'",
+			"`varname` = '{}'",
 			Strings::Escape(name)
 		)
 	);


### PR DESCRIPTION
# Description
- Fixes issue where `VariablesRepository::GetWhere` was using `name` instead of `varname` for the column name in its query.
- Mentioned [here](https://discord.com/channels/212663220849213441/1241190274567508178) by Celtic Trinity Studios.

## Type of Change
- [X] Bug fix

# Testing
![image](https://github.com/EQEmu/Server/assets/89047260/d1fdcb6d-b4dd-4182-8edb-b2912b9ebd68)

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur