### PR TITLE
[Bug Fix] Fix RemoveAlternateCurrencyValue not updating Client

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -6787,6 +6787,8 @@ bool Client::RemoveAlternateCurrencyValue(uint32 currency_id, uint32 amount)
 
 	alternate_currency[currency_id] = new_amount;
 
+	SendAlternateCurrencyValue(currency_id);
+
 	if (parse->PlayerHasQuestSub(EVENT_ALT_CURRENCY_LOSS)) {
 		const std::string &export_string = fmt::format(
 			"{} {} {}",

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -6786,7 +6786,7 @@ bool Client::RemoveAlternateCurrencyValue(uint32 currency_id, uint32 amount)
 	const uint32 new_amount = (current_amount - amount);
 
 	alternate_currency[currency_id] = new_amount;
-
+	database.UpdateAltCurrencyValue(CharacterID(), currency_id, new_amount);
 	SendAlternateCurrencyValue(currency_id);
 
 	if (parse->PlayerHasQuestSub(EVENT_ALT_CURRENCY_LOSS)) {


### PR DESCRIPTION
# Description
- Resolves an issue where the alternate currency that was removed was not being properly updated visually.
- Mentioned [here](https://discord.com/channels/212663220849213441/1241485859262300373).

## Type of Change
- [X] Bug fix

# Testing
[Video](https://github.com/EQEmu/Server/assets/89047260/6a565fa6-7076-4cb9-b65a-41d4d0216fee)

## Perl Script
```pl
sub EVENT_SAY {
	if ($text=~/#a/i) {
		$client->SetAlternateCurrencyValue(10, 1000);
	} elsif ($text=~/#b/i) {
		if ($client->RemoveAlternateCurrencyValue(10, 1000)) {
			quest::message(315, "Successfully removed 1,000 currency.");
		}
	}
}
```

## Lua Script
```lua
  function event_say(e)
	if e.messsage:findi("#a") then
		e.self:SetAlternateCurrencyValue(10, 1000);
	elseif e.messsage:findi("#b") then
		if e.self:RemoveAlternateCurrencyValue(10, 1000) then
			eq.message(315, "Successfully removed 1,000 currency.");
		end
	end
end
```

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur