### PR TITLE
[Bug Fix] Fix Crash with null Argument in #modifynpcstat

### DIFF
--- a/zone/gm_commands/modifynpcstat.cpp
+++ b/zone/gm_commands/modifynpcstat.cpp
@@ -16,8 +16,15 @@ void command_modifynpcstat(Client *c, const Seperator *sep)
 
 	auto target = c->GetTarget()->CastToNPC();
 
-	std::string stat = sep->arg[1];
-	std::string value = sep->arg[2] ? sep->arg[2] : "";
+	const std::string& stat = sep->arg[1] ? sep->arg[1] : "";
+
+	if (stat.empty()) {
+		c->Message(Chat::White, "Usage: #modifynpcstat [Stat] [Value]");
+		ListModifyNPCStatMap(c);
+		return;
+	}
+
+	const std::string& value = sep->arg[2] ? sep->arg[2] : "";
 
 	auto stat_description = GetModifyNPCStatDescription(stat);
 	if (!stat_description.length()) {

--- a/zone/gm_commands/modifynpcstat.cpp
+++ b/zone/gm_commands/modifynpcstat.cpp
@@ -16,17 +16,10 @@ void command_modifynpcstat(Client *c, const Seperator *sep)
 
 	auto target = c->GetTarget()->CastToNPC();
 
-	const std::string& stat = sep->arg[1] ? sep->arg[1] : "";
-
-	if (stat.empty()) {
-		c->Message(Chat::White, "Usage: #modifynpcstat [Stat] [Value]");
-		ListModifyNPCStatMap(c);
-		return;
-	}
-
+	const std::string& stat  = sep->arg[1] ? sep->arg[1] : "";
 	const std::string& value = sep->arg[2] ? sep->arg[2] : "";
 
-	if (value.empty()) {
+	if (stat.empty() || value.empty()) {
 		c->Message(Chat::White, "Usage: #modifynpcstat [Stat] [Value]");
 		ListModifyNPCStatMap(c);
 		return;

--- a/zone/gm_commands/modifynpcstat.cpp
+++ b/zone/gm_commands/modifynpcstat.cpp
@@ -26,6 +26,12 @@ void command_modifynpcstat(Client *c, const Seperator *sep)
 
 	const std::string& value = sep->arg[2] ? sep->arg[2] : "";
 
+	if (value.empty()) {
+		c->Message(Chat::White, "Usage: #modifynpcstat [Stat] [Value]");
+		ListModifyNPCStatMap(c);
+		return;
+	}
+
 	auto stat_description = GetModifyNPCStatDescription(stat);
 	if (!stat_description.length()) {
 		c->Message(


### PR DESCRIPTION
# Description
- Using `#modifynpcstat` with a space afterwards (`#modifynpcstat `) was causing a crash due to it being used with a null value.
- Mentioned [here](https://discord.com/channels/212663220849213441/557677602706423982/1243683157975498882).

## Type of Change
- [X] Bug fix

# Testing
![image](https://github.com/EQEmu/Server/assets/89047260/453bf93c-d7e9-4912-8225-e6effa92756b)

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur