### PR TITLE
[Crash] Fix rarer crash in EntityList::MobProcess

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -526,7 +526,7 @@ void EntityList::MobProcess()
 			//	-- the zone is newly empty and we're allowing mobs to settle
 			if (
 				numclients > 0 || zone->quest_idle_override ||
-				(s2 && s2->PathWhenZoneIdle()) ||
+				(mob && s2 && s2->PathWhenZoneIdle()) ||
 				mob_settle_timer->Enabled()
 			) {
 				mob_dead = !mob->Process();


### PR DESCRIPTION
# Description

As observed in roughly 5 windows crashes. This is not guaranteed to fix the crash but it validates the mob pointer before assuming what's nested is available

https://spire.akkadius.com/dev/release/22.50.1?id=23796

- [x] Crash Fix

# Testing

Unable to test. Will need to validate over time with our crash analytics.

# Checklist

- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
