### PR TITLE
[Crash] Fix player events reload when out of bounds

### DIFF
--- a/common/events/player_event_logs.cpp
+++ b/common/events/player_event_logs.cpp
@@ -642,6 +642,10 @@ void PlayerEventLogs::ProcessRetentionTruncation()
 void PlayerEventLogs::ReloadSettings()
 {
 	for (auto &e: PlayerEventLogSettingsRepository::All(*m_database)) {
+		if (e.id >= PlayerEvent::MAX || e.id < 0) {
+			continue;
+		}
+
 		m_settings[e.id] = e;
 	}
 }


### PR DESCRIPTION
# Description

As observed in 14 crashes, player event database table has ID's that are out of bounds of what is actually in code.

https://spire.akkadius.com/dev/release/22.49.1?id=23845

- [x] Crash Fix

# Testing

Tested by setting an ID out of bounds an issuing a reload.

# Checklist

- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
