### PR TITLE
[Crash] Fix crash when map name is null

### DIFF
--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -1140,6 +1140,11 @@ bool Zone::Init(bool is_static) {
 		}
 	}
 
+	if (!map_name) {
+		LogError("No map name found for zone [{}]", GetShortName());
+		return false;
+	}
+
 	zonemap  = Map::LoadMapFile(map_name);
 	watermap = WaterMap::LoadWaterMapfile(map_name);
 	pathing  = IPathfinder::Load(map_name);


### PR DESCRIPTION
# Description

As observed in 11 crashes. Adds simple validation and failure to boot if not set.

https://spire.akkadius.com/dev/release/22.49.1?id=22207

- [x] Crash Fix

# Testing

Do not have a reliable testing scenario.

# Checklist

- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
