### PR TITLE
[Mobs] Remove entity type checks from ScanCloseMobs

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -2954,11 +2954,6 @@ void EntityList::ScanCloseMobs(
 
 	for (auto &e : mob_list) {
 		auto mob = e.second;
-
-		if (!mob->IsNPC() && !mob->IsClient() && !mob->IsBot() && !mob->IsMerc()) {
-			continue;
-		}
-
 		if (mob->GetID() <= 0) {
 			continue;
 		}


### PR DESCRIPTION
# Description

This removes unnecessary restriction and filtering from ScanCloseMobs as there are may mobs that are beyond just the ones we're filtering for in this loop. There's no reason to restrict for other types of mobs, such as but not limited to `Beacon` `Corpse` `Encounter` etc.

Fixes potential crash issues (Yet to be seen)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Testing was done via basic scanning functions in game, it is a critical core part of how the server functions and all existing functionality was maintained.

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
