### PR TITLE
[Crash] Add validation to RemoveXTarget

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -6994,6 +6994,10 @@ void Client::AddAutoXTarget(Mob *m, bool send)
 
 void Client::RemoveXTarget(Mob *m, bool OnlyAutoSlots)
 {
+	if (!XTargettingAvailable() || !m || !m_activeautohatermgr) {
+		return;
+	}
+
 	m_activeautohatermgr->decrement_count(m);
 	// now we may need to clean up our CurrentTargetNPC entries
 	for (int i = 0; i < GetMaxXTargets(); ++i) {


### PR DESCRIPTION
# Description

Adds validation to RemoveXTarget. Ensures the xtarget manager is valid, ensures the mob to be removed is valid and additionally checks to see if xtargets is even enabled before running the business logic.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Xtarget functionality still works as expecfted.

https://github.com/EQEmu/Server/assets/3319450/12cea7d8-871e-4ce2-ab17-3ccc08e4624a

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
