### PR TITLE
[Crash] Fix Zone deconstructor crashes

### DIFF
--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -1098,20 +1098,21 @@ Zone::Zone(uint32 in_zoneid, uint32 in_instanceid, const char* in_short_name)
 
 Zone::~Zone() {
 	spawn2_list.Clear();
-	safe_delete(zonemap);
-	safe_delete(watermap);
-	safe_delete(pathing);
 	if (worldserver.Connected()) {
 		worldserver.SetZoneData(0);
 	}
-	safe_delete_array(short_name);
-	safe_delete_array(long_name);
-	safe_delete(Weather_Timer);
 	npc_emote_list.clear();
 	zone_point_list.Clear();
 	entity_list.Clear();
+	parse->ReloadQuests();
 	ClearBlockedSpells();
 
+	safe_delete_array(short_name);
+	safe_delete_array(long_name);
+	safe_delete(Weather_Timer);
+	safe_delete(zonemap);
+	safe_delete(watermap);
+	safe_delete(pathing);
 	safe_delete(Instance_Timer);
 	safe_delete(Instance_Shutdown_Timer);
 	safe_delete(Instance_Warning_timer);


### PR DESCRIPTION
# Description

Moves around some desconstructor deletes in the zone deconstructor. 

As observed in fixes like https://github.com/EQEmu/Server/commit/b2d9de8d965d0203c44321d9462050cab78947b9 we've found that when `short_name` was deleted before other things still needed it, it caused crashes in the zone shutdown process. 

https://spire.akkadius.com/dev/release/22.50.1?id=23668

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Harder to test, will validate in our crash analytics over time.

Zone at least shuts down gracefully.

![image](https://github.com/EQEmu/Server/assets/3319450/65487f36-3779-4f96-9090-57d775331bae)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
