### PR TITLE
[Rule] Allow servers to adjust the filtering threshold for heals from damage (e.g. Mark of Kings).

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -505,6 +505,7 @@ RULE_BOOL(Spells, ManaTapsRequireNPCMana, false, "Enabling will require target t
 RULE_INT(Spells, HarmTouchCritRatio, 200, "Harmtouch crit bonus, on top of BaseCritRatio")
 RULE_BOOL(Spells, UseClassicSpellFocus, false, "Enabling will tell the server to handle random focus damage as classic spell imports lack the limit values.")
 RULE_BOOL(Spells, ManaTapsOnAnyClass, false, "Enabling this will allow you to cast mana taps on any class, this will bypass ManaTapsRequireNPCMana rule.")
+RULE_INT(Spells, HealAmountMessageFilterThreshold, 100, "Lifetaps below this threshold will not have a message sent to the client (Heal will still process) 0 to Disable.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Combat)

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -4762,7 +4762,7 @@ void Mob::HealDamage(uint64 amount, Mob* caster, uint16 spell_id)
 	else
 		acthealed = amount;
 
-	if (acthealed > 100) {
+	if (acthealed > RuleI(Spells, HealAmountMessageFilterThreshold)) {
 		if (caster) {
 			if (IsBuffSpell(spell_id)) { // hots
 				// message to caster


### PR DESCRIPTION
# Description

[Rule] Allow servers to adjust the filtering threshold for heals from damage (e.g. Mark of Kings).

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# Testing

Simple rule change to allow adjustment of hardcoded value.

Clients tested: 

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
