### PR TITLE
[Rule] Allow maximum per kill AA amount

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -815,7 +815,7 @@ RULE_INT(AA, ModernAAScalingAAMinimum, 0, "The minimum number of earned AA befor
 RULE_INT(AA, ModernAAScalingAALimit, 4000, "The number of earned AA when AA experience scaling ends")
 RULE_BOOL(AA, SoundForAAEarned, false, "Play sound when AA point earned")
 RULE_INT(AA, UnusedAAPointCap, -1, "Cap for Unused AA Points.  Default: -1.  NOTE: DO NOT LOWER THIS WITHOUT KNOWING WHAT YOU ARE DOING. MAY RESULT IN PLAYERS LOSING AAs.")
-RULE_INT(AA, MaxAAEXPPerKill, -1, "Maximum AA EXP per Kill (3425214 is about 7%) - Default: 0 will disable the check")
+RULE_INT(AA, MaxAAEXPPerKill, -1, "Maximum AA EXP per Kill (3425214 is about 7%) - Default: -1 will disable the check")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Console)

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -815,7 +815,7 @@ RULE_INT(AA, ModernAAScalingAAMinimum, 0, "The minimum number of earned AA befor
 RULE_INT(AA, ModernAAScalingAALimit, 4000, "The number of earned AA when AA experience scaling ends")
 RULE_BOOL(AA, SoundForAAEarned, false, "Play sound when AA point earned")
 RULE_INT(AA, UnusedAAPointCap, -1, "Cap for Unused AA Points.  Default: -1.  NOTE: DO NOT LOWER THIS WITHOUT KNOWING WHAT YOU ARE DOING. MAY RESULT IN PLAYERS LOSING AAs.")
-RULE_INT(AA, MaxAAExpPerKill, -1, "Maximum AA EXP per Kill (3425214 is about 7%) - Default: 0 will disable the check")
+RULE_INT(AA, MaxAAEXPPerKill, -1, "Maximum AA EXP per Kill (3425214 is about 7%) - Default: 0 will disable the check")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Console)

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -815,6 +815,7 @@ RULE_INT(AA, ModernAAScalingAAMinimum, 0, "The minimum number of earned AA befor
 RULE_INT(AA, ModernAAScalingAALimit, 4000, "The number of earned AA when AA experience scaling ends")
 RULE_BOOL(AA, SoundForAAEarned, false, "Play sound when AA point earned")
 RULE_INT(AA, UnusedAAPointCap, -1, "Cap for Unused AA Points.  Default: -1.  NOTE: DO NOT LOWER THIS WITHOUT KNOWING WHAT YOU ARE DOING. MAY RESULT IN PLAYERS LOSING AAs.")
+RULE_INT(AA, MaxAAExpPerKill, 0, "Maximum AA EXP per Kill (3425214 is about 7%) - Default: 0 will disable the check")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Console)

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -815,7 +815,7 @@ RULE_INT(AA, ModernAAScalingAAMinimum, 0, "The minimum number of earned AA befor
 RULE_INT(AA, ModernAAScalingAALimit, 4000, "The number of earned AA when AA experience scaling ends")
 RULE_BOOL(AA, SoundForAAEarned, false, "Play sound when AA point earned")
 RULE_INT(AA, UnusedAAPointCap, -1, "Cap for Unused AA Points.  Default: -1.  NOTE: DO NOT LOWER THIS WITHOUT KNOWING WHAT YOU ARE DOING. MAY RESULT IN PLAYERS LOSING AAs.")
-RULE_INT(AA, MaxAAExpPerKill, 0, "Maximum AA EXP per Kill (3425214 is about 7%) - Default: 0 will disable the check")
+RULE_INT(AA, MaxAAExpPerKill, -1, "Maximum AA EXP per Kill (3425214 is about 7%) - Default: 0 will disable the check")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Console)

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -531,10 +531,8 @@ void Client::AddEXP(ExpSource exp_source, uint64 in_add_exp, uint8 conlevel, boo
 	}
 
 	// Check for AA XP Cap
-	uint64 aaxp_cap = RuleI(AA, MaxAAExpPerKill);
-
-	if (aaxp_cap >= 0 && aaexp > aaxp_cap) {
-		aaexp = aaxp_cap;
+	if (RuleI(AA, MaxAAEXPPerKill) >= 0 && aaexp > RuleI(AA, MaxAAEXPPerKill)) {
+		aaexp = RuleI(AA, MaxAAEXPPerKill);
 	}
 
 	// Get current AA XP total

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -533,7 +533,7 @@ void Client::AddEXP(ExpSource exp_source, uint64 in_add_exp, uint8 conlevel, boo
 	// Check for AA XP Cap
 	uint64 aaxp_cap = RuleI(AA, MaxAAExpPerKill);
 
-	if (aaxp_cap > 0 && aaexp > aaxp_cap) {
+	if (aaxp_cap >= 0 && aaexp > aaxp_cap) {
 		aaexp = aaxp_cap;
 	}
 

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -530,6 +530,13 @@ void Client::AddEXP(ExpSource exp_source, uint64 in_add_exp, uint8 conlevel, boo
 		aaexp = ScaleAAXPBasedOnCurrentAATotal(GetAAPoints(), aaexp);
 	}
 
+	// Check for AA XP Cap
+	uint64 aaxp_cap = RuleI(AA, MaxAAExpPerKill);
+
+	if (aaxp_cap > 0 && aaexp > aaxp_cap) {
+		aaexp = aaxp_cap;
+	}
+
 	// Get current AA XP total
 	uint32 had_aaexp = GetAAXP();
 


### PR DESCRIPTION
# Description

Allow you to clamp the maximum per kill aa amount awarded.


## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# Testing

Set AA xp to 0 for each kill.

Before Clamping:
![image](https://github.com/EQEmu/Server/assets/5864295/acfa139d-012e-47fb-8e1b-863b51f23f32)

After Clamping:

![image](https://github.com/EQEmu/Server/assets/5864295/43d97f5f-8156-4ed0-b895-5cd7f5779831)
![image](https://github.com/EQEmu/Server/assets/5864295/1da708c7-7d5f-49a7-8ee0-53d09ec34819)



Clients tested: 

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
