### PR TITLE
[Bug Fix] Block mounts from zoning to no mount zones

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -679,7 +679,7 @@ void Client::CompleteConnect()
 				break;
 			}
 			case SE_SummonHorse: {
-				if (RuleB(Character, PreventMountsFromZoning)) {
+				if (RuleB(Character, PreventMountsFromZoning) || !zone->CanCastOutdoor()) {
 					BuffFadeByEffect(SE_SummonHorse);
 				} else {
 					SummonHorse(buffs[j1].spellid);


### PR DESCRIPTION
# Description

Then mounts are allowed to zone (RuleB Character, PreventMountsFromZoning) is not enabled, it will check if the destination zone allows mounts and remove the mount if true.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

Zoned into Netherbian with a mount and it was removed, zoned from nexus to PoK and the mount stayed. With PreventMountsFromZoning rule, mount is always removed.

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
