### PR TITLE
[Rule] Added MeleeMitigation Level Difference Roll Adjusted for level diffs

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -521,6 +521,8 @@ RULE_BOOL(Combat, NPCCanCrit, false, "Setting whether an NPC can land critical h
 RULE_BOOL(Combat, UseIntervalAC, true, "Switch whether bonuses, armour class, multipliers, classes and caps should be considered in the calculation of damage values")
 RULE_INT(Combat, PetAttackMagicLevel, 10, "Level at which pets can cause magic damage, no longer used")
 RULE_INT(Combat, NPCAttackMagicLevel, 10, "Level at which NPC and pets can cause magic damage")
+RULE_INT(Combat, LevelDifferenceRollCheck, -1, "Level Difference to enable LeverDifferenceRollBonus for MeleeMitigation - Default: -1 is disabled, 20 is common")
+RULE_REAL(Combat, LevelDifferenceRollBonus, 0.5, "Roll Bonus/Detrement if using LevelDifferenceRollCheck")
 RULE_BOOL(Combat, EnableFearPathing, true, "Setting whether to use pathing during fear")
 RULE_BOOL(Combat, FleeGray, true, "If true FleeGrayHPRatio will be used")
 RULE_INT(Combat, FleeGrayHPRatio, 50, "HP percentage when a Gray NPC begins to flee")

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1043,18 +1043,22 @@ void Mob::MeleeMitigation(Mob *attacker, DamageHitInfo &hit, ExtraAttackOptions 
 	auto roll = RollD20(hit.offense, mitigation);
 
 	// Add bonus to roll if level difference is sufficient
-	int level_diff = attacker->GetLevel() - GetLevel();
-	int level_diff_roll_check = RuleI(Combat, LevelDifferenceRollCheck);
+	const int level_diff            = attacker->GetLevel() - GetLevel();
+	const int level_diff_roll_check = RuleI(Combat, LevelDifferenceRollCheck);
 
-	if (level_diff_roll_check >= 0 && level_diff > level_diff_roll_check) {
-		roll += RuleR(Combat, LevelDifferenceRollBonus);
-		if (roll > 2.0) {
-			roll = 2.0;
-		}
-	} else if (level_diff_roll_check >= 0 && level_diff < (-level_diff_roll_check)) {
-		roll -= RuleR(Combat, LevelDifferenceRollBonus);
-		if (roll < 0.1) {
-			roll = 0.1;
+	if (level_diff_roll_check >= 0) {
+		if (level_diff > level_diff_roll_check) {
+			roll += RuleR(Combat, LevelDifferenceRollBonus);
+
+			if (roll > 2.0f) {
+				roll = 2.0f;
+			}
+		} else if (level_diff < (-level_diff_roll_check)) {
+			roll -= RuleR(Combat, LevelDifferenceRollBonus);
+
+			if (roll < 0.1f) {
+				roll = 0.1f;
+			}
 		}
 	}
 
@@ -2525,7 +2529,7 @@ bool NPC::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillTy
 	auto app = new EQApplicationPacket(OP_Death, sizeof(Death_Struct));
 
 	auto d = (Death_Struct*) app->pBuffer;
- 
+
 	// Convert last message to color to avoid duplicate damage messages
 	// that occur in these rare cases when this is the death blow.
 	if (IsValidSpell(spell) &&

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1042,6 +1042,20 @@ void Mob::MeleeMitigation(Mob *attacker, DamageHitInfo &hit, ExtraAttackOptions 
 
 	auto roll = RollD20(hit.offense, mitigation);
 
+	// Add bonus to roll if level difference is sufficient
+	signed lvldiff = attacker->GetLevel() - this->GetLevel();
+	if (RuleI(Combat, LevelDifferenceRollCheck) >= 0 && lvldiff > RuleI(Combat, LevelDifferenceRollCheck)) {
+		roll += RuleR(Combat, LevelDifferenceRollBonus);
+		if (roll > 2.0) {
+			roll = 2.0;
+		}
+	} else if (RuleI(Combat, LevelDifferenceRollCheck) >= 0 && lvldiff < (-RuleI(Combat, LevelDifferenceRollCheck))) {
+		roll -= RuleR(Combat, LevelDifferenceRollBonus);
+		if (roll < 0.1) {
+			roll = 0.1;
+		}
+	}
+
 	// +0.5 for rounding, min to 1 dmg
 	hit.damage_done = std::max(static_cast<int>(roll * static_cast<double>(hit.base_damage) + 0.5), 1);
 

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1043,13 +1043,15 @@ void Mob::MeleeMitigation(Mob *attacker, DamageHitInfo &hit, ExtraAttackOptions 
 	auto roll = RollD20(hit.offense, mitigation);
 
 	// Add bonus to roll if level difference is sufficient
-	signed lvldiff = attacker->GetLevel() - this->GetLevel();
-	if (RuleI(Combat, LevelDifferenceRollCheck) >= 0 && lvldiff > RuleI(Combat, LevelDifferenceRollCheck)) {
+	int level_diff = attacker->GetLevel() - GetLevel();
+	int level_diff_roll_check = RuleI(Combat, LevelDifferenceRollCheck);
+
+	if (level_diff_roll_check >= 0 && level_diff > level_diff_roll_check) {
 		roll += RuleR(Combat, LevelDifferenceRollBonus);
 		if (roll > 2.0) {
 			roll = 2.0;
 		}
-	} else if (RuleI(Combat, LevelDifferenceRollCheck) >= 0 && lvldiff < (-RuleI(Combat, LevelDifferenceRollCheck))) {
+	} else if (level_diff_roll_check >= 0 && level_diff < (-level_diff_roll_check)) {
 		roll -= RuleR(Combat, LevelDifferenceRollBonus);
 		if (roll < 0.1) {
 			roll = 0.1;

--- a/zone/tune.cpp
+++ b/zone/tune.cpp
@@ -1012,6 +1012,26 @@ void Mob::TuneMeleeMitigation(Mob *attacker, DamageHitInfo &hit, int ac_override
 
 	auto roll = RollD20(hit.offense, mitigation);
 
+	// Add bonus to roll if level difference is sufficient
+	const int level_diff            = attacker->GetLevel() - GetLevel();
+	const int level_diff_roll_check = RuleI(Combat, LevelDifferenceRollCheck);
+
+	if (level_diff_roll_check >= 0) {
+		if (level_diff > level_diff_roll_check) {
+			roll += RuleR(Combat, LevelDifferenceRollBonus);
+
+			if (roll > 2.0f) {
+				roll = 2.0f;
+			}
+		} else if (level_diff < (-level_diff_roll_check)) {
+			roll -= RuleR(Combat, LevelDifferenceRollBonus);
+
+			if (roll < 0.1f) {
+				roll = 0.1f;
+			}
+		}
+	}
+
 	// +0.5 for rounding, min to 1 dmg
 	hit.damage_done = std::max(static_cast<int>(roll * static_cast<double>(hit.base_damage) + 0.5), 1);
 }


### PR DESCRIPTION
# Description

This patch allows server ops to adjust the MeleeMitigation of NPC's based on the level difference and tune the amount adjusted. This will give greater diffs an advantage/disadvantage based on the values. -1 value should disabled and not change any current functionality.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
