### PR TITLE
[Rule] Remove hard coded initial aggro in favor or an adjustable Rule

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -664,6 +664,8 @@ RULE_BOOL(Aggro, NPCAggroMaxDistanceEnabled, true, "If enabled, NPC's will drop 
 RULE_BOOL(Aggro, AggroPlayerPets, false, "If enabled, NPCs will aggro player pets")
 RULE_BOOL(Aggro, UndeadAlwaysAggro, true, "should undead always aggro?")
 RULE_INT(Aggro, BardAggroCap, 40, "per song bard aggro cap.")
+RULE_INT(Aggro, InitialAggroBonus, 100, "Initial Aggro Bonus, Default: 100")
+RULE_INT(Aggro, InitialPetAggroBonus, 100, "Initial Pet Aggro Bonus, Default 100")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(TaskSystem)

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -3090,12 +3090,10 @@ void Mob::AddToHateList(Mob* other, int64 hate /*= 0*/, int64 damage /*= 0*/, bo
 		}
 		hate = ((hate * (hatemod)) / 100);
 	} else {
-		if (this->IsCharmed()){
+		if (IsCharmed()){
 			hate += RuleI(Aggro, InitialPetAggroBonus);
-			LogCombat("InitialPetAggroBonus: [{}]", RuleI(Aggro, InitialPetAggroBonus));
 		} else {
 			hate += RuleI(Aggro, InitialAggroBonus);
-			LogCombat("InitialAggroBonus: [{}]", RuleI(Aggro, InitialAggroBonus));
 		}
 	}
 

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -3085,12 +3085,18 @@ void Mob::AddToHateList(Mob* other, int64 hate /*= 0*/, int64 damage /*= 0*/, bo
 		// Spell Casting Subtlety etc
 		int64 hatemod = 100 + other->spellbonuses.hatemod + other->itembonuses.hatemod + other->aabonuses.hatemod;
 
-		if (hatemod < 1)
+		if (hatemod < 1) {
 			hatemod = 1;
+		}
 		hate = ((hate * (hatemod)) / 100);
-	}
-	else {
-		hate += 100; // 100 bonus initial aggro
+	} else {
+		if (this->IsCharmed()){
+			hate += RuleI(Aggro, InitialPetAggroBonus);
+			LogCombat("InitialPetAggroBonus: [{}]", RuleI(Aggro, InitialPetAggroBonus));
+		} else {
+			hate += RuleI(Aggro, InitialAggroBonus);
+			LogCombat("InitialAggroBonus: [{}]", RuleI(Aggro, InitialAggroBonus));
+		}
 	}
 
 	// Pet that is /pet hold on will not add to their hate list if they're not engaged


### PR DESCRIPTION
# Description

This removes the hard coded hate += 100; in favor or a rule seperated for charmed pet initial aggro and everything else. This will allow server ops to tune the initial aggro bonus on the fly.


## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
