### PR TITLE
[Bug Fix] Raid Targets should not be Blindable as this will break all spell casting AI.

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -610,7 +610,7 @@ RULE_BOOL(Combat, UseMobStaticOffenseSkill, false, "Toggle to enabled the use of
 RULE_BOOL(Combat, UseEnhancedMobStaticWeaponSkill, false, "Toggle to enabled the use of an enhanced (slightly higher hit rate) static weapon skill for Mobs.  DEFAULT: false")
 RULE_INT(Combat, PCAttackPowerScaling, 100, "Applies scaling to PC Attack Power (75 = 75%).  DEFAULT: 100 to not adjust existing Servers")
 RULE_INT(Combat, PCAccuracyAvoidanceMod2Scale, 100, "Scale Factor for PC Accuracy and Avoidance (Mod2, found on items).  Found a value of 100 to make both too strong (75 = x0.75).  DEFAULT: 100 to not adjust existing Servers")
-RULE_CATEGORY_END()
+RULE_BOOL(Combat, AllowRaidTargetBlind, false, "Toggle to allow raid targets to be blinded, default is false (Live-like)")
 
 RULE_CATEGORY(NPC)
 RULE_INT(NPC, MinorNPCCorpseDecayTime, 450000, "NPC corpse decay time, if NPC below level 55 (milliseconds)")
@@ -734,7 +734,7 @@ RULE_BOOL(Bots, BotHealOnLevel, false, "Setting whether a bot should heal comple
 RULE_INT(Bots, AutosaveIntervalSeconds, 300, "Number of seconds after which a timer is triggered which stores the bot data. The value 0 means no periodic automatic saving.")
 RULE_BOOL(Bots, CazicTouchBotsOwner, true, "Default True. Cazic Touch/DT will hit bot owner rather than bot.")
 RULE_INT(Bots, BotsClickItemsMinLvl, 1, "Minimum level for bots to be able to use ^clickitem. Default 1.")
-RULE_BOOL(Bots, BotsCanClickItems, true, "Enabled the ability for bots to click items they have equipped. Default TRUE")
+RULE_BOOL(Bots, BotsCanClickItems, true, "Enables the ability for bots to click items they have equipped. Default TRUE")
 RULE_BOOL(Bots, CanClickMageEpicV1, true, "Whether or not bots are allowed to click Mage Epic 1.0. Default TRUE")
 RULE_CATEGORY_END()
 

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -3356,10 +3356,10 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 
 			case SE_Blind:
-				if (IsRaidTarget()) {
-					// do not blind raid targtets
+				if (RuleB(Combat, AllowRaidTargetBlind) && IsRaidTarget()) { // do not blind raid targets
 					break;
 				}
+
 				new_bonus->IsBlind = true;
 				break;
 

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -3356,6 +3356,10 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 
 			case SE_Blind:
+				if (IsRaidTarget()) {
+					// do not blind raid targtets
+					break;
+				}
 				new_bonus->IsBlind = true;
 				break;
 


### PR DESCRIPTION
# Description

Raid Targets should not be Blindable as this will break all spell casting AI.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur