### PR TITLE
[Feature] Add SE_IncreaseArchery and rules to tune archery

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -590,6 +590,8 @@ RULE_BOOL(Combat, BackstabIgnoresElemental, false, "Enable or disable Elemental 
 RULE_BOOL(Combat, BackstabIgnoresBane, false, "Enable or disable Bane weapon damage affecting backstab damage, false by default.")
 RULE_INT(Combat, DoubleBackstabLevelRequirement, 55, "Level requirement to enable double backstab attempts. The default is 55.")
 RULE_BOOL(Combat, SummonMeleeRange, true, "Enable or disable summoning of a player when already in melee range of the summoner.")
+RULE_REAL(Combat, ArcheryHitPenalty, 0, "Archery has a hit penalty to try to help balance it with the plethora of long term +hit modifiers for it - Default: 0")
+RULE_REAL(Combat, ArcheryBaseDamageBonus, 1, "Percentage modifier to base archery Damage 0.5=50% base damage, 1=100%,2=200% - Default: 1")
 RULE_BOOL(Combat, WaterMatchRequiredForAutoFireLoS, true, "Enable/Disable the requirement of both the attacker/victim being both in or out of water for AutoFire LoS to pass.")
 RULE_INT(Combat, ExtraAllowedKickClassesBitmask, 0, "Bitmask for allowing extra classes beyond Warrior, Ranger, Beastlord, and Berserker to kick, No Extra Classes (0) by default")
 RULE_INT(Combat, MaxProcs, 4, "Adjustable maximum number of procs per round, the hard cap is MAX_PROCS (11). Requires mob repop or client zone when changed")

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -904,7 +904,7 @@ typedef enum {
 #define SE_AlterNPCLevel				107	// implemented - not used on live
 #define SE_Familiar						108	// implemented
 #define SE_SummonItemIntoBag			109	// implemented - summons stuff into container
-//#define SE_IncreaseArchery			110	// not used
+#define SE_IncreaseArchery				110	// implemented
 #define SE_ResistAll					111	// implemented - Note: Physical Resists are not modified by this effect.
 #define SE_CastingLevel					112	// implemented
 #define	SE_SummonHorse					113	// implemented

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -225,9 +225,9 @@ int Mob::GetTotalToHit(EQ::skills::SkillType skill, int chance_mod)
 		aabonuses.HitChanceEffect[skill] +
 		spellbonuses.HitChanceEffect[skill];
 
-	if(skill == EQ::skills::SkillArchery) 	{
-		hit_bonus += spellbonuses.increasearchery + aabonuses.increasearchery + itembonuses.increasearchery;
-		hit_bonus -= hit_bonus*RuleR(Combat, ArcheryHitPenalty);
+	if (skill == EQ::skills::SkillArchery) {
+		hit_bonus += spellbonuses.increase_archery + aabonuses.increase_archery + itembonuses.increase_archery;
+		hit_bonus -= hit_bonus * RuleR(Combat, ArcheryHitPenalty);
 	}
 
 	accuracy = (accuracy * (100 + hit_bonus)) / 100;

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -225,6 +225,11 @@ int Mob::GetTotalToHit(EQ::skills::SkillType skill, int chance_mod)
 		aabonuses.HitChanceEffect[skill] +
 		spellbonuses.HitChanceEffect[skill];
 
+	if(skill == EQ::skills::SkillArchery) 	{
+		hit_bonus += spellbonuses.increasearchery + aabonuses.increasearchery + itembonuses.increasearchery;
+		hit_bonus -= hit_bonus*RuleR(Combat, ArcheryHitPenalty);
+	}
+
 	accuracy = (accuracy * (100 + hit_bonus)) / 100;
 
 	// TODO: April 2003 added an archery/throwing PVP accuracy penalty while moving, should be in here some where,
@@ -6323,6 +6328,9 @@ void Mob::CommonOutgoingHitSuccess(Mob* defender, DamageHitInfo &hit, ExtraAttac
 				MessageString(Chat::MeleeCrit, BOW_DOUBLE_DAMAGE);
 			}
 		}
+
+		//Scale Factor for Archery Damage Tuning
+		hit.damage_done *= RuleR(Combat, ArcheryBaseDamageBonus);
 	}
 
 	int extra_mincap = 0;

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -2235,6 +2235,12 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
+			case SE_IncreaseArchery:
+			{
+				new_bonus->increasearchery += effect_value;
+				break;
+			}
+			
 			case SE_TotalHP:
 			{
 				new_bonus->FlatMaxHPChange += effect_value;
@@ -4531,6 +4537,12 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 					if (negate_spellbonus) { spellbonuses.inhibitmelee = effect_value; }
 					if (negate_aabonus) { aabonuses.inhibitmelee = effect_value; }
 					if (negate_itembonus) { itembonuses.inhibitmelee = effect_value; }
+					break;
+
+				case SE_IncreaseArchery:
+					if (negate_spellbonus) { spellbonuses.increasearchery = effect_value; }
+					if (negate_aabonus) { aabonuses.increasearchery = effect_value; }
+					if (negate_itembonus) { itembonuses.increasearchery = effect_value; }
 					break;
 
 				case SE_TotalHP:

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -2237,10 +2237,10 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 
 			case SE_IncreaseArchery:
 			{
-				new_bonus->increasearchery += effect_value;
+				new_bonus->increase_archery += effect_value;
 				break;
 			}
-			
+
 			case SE_TotalHP:
 			{
 				new_bonus->FlatMaxHPChange += effect_value;
@@ -4540,9 +4540,9 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 					break;
 
 				case SE_IncreaseArchery:
-					if (negate_spellbonus) { spellbonuses.increasearchery = effect_value; }
-					if (negate_aabonus) { aabonuses.increasearchery = effect_value; }
-					if (negate_itembonus) { itembonuses.increasearchery = effect_value; }
+					if (negate_spellbonus) { spellbonuses.increase_archery = effect_value; }
+					if (negate_aabonus) { aabonuses.increase_archery = effect_value; }
+					if (negate_itembonus) { itembonuses.increase_archery = effect_value; }
 					break;
 
 				case SE_TotalHP:

--- a/zone/common.h
+++ b/zone/common.h
@@ -336,6 +336,7 @@ struct StatBonuses {
 	int32	hastetype2;
 	int32	hastetype3;
 	int32	inhibitmelee;
+	int32	increasearchery;
 	float	AggroRange;							// when calculate just replace original value with this
 	float	AssistRange;
 	int32	skillmod[EQ::skills::HIGHEST_SKILL + 1];

--- a/zone/common.h
+++ b/zone/common.h
@@ -336,7 +336,7 @@ struct StatBonuses {
 	int32	hastetype2;
 	int32	hastetype3;
 	int32	inhibitmelee;
-	int32	increasearchery;
+	int32	increase_archery;
 	float	AggroRange;							// when calculate just replace original value with this
 	float	AssistRange;
 	int32	skillmod[EQ::skills::HIGHEST_SKILL + 1];

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -3341,6 +3341,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 			case SE_SkillProcAttempt:
 			case SE_SkillProcSuccess:
 			case SE_SpellResistReduction:
+			case SE_IncreaseArchery:
 			case SE_Duration_HP_Pct:
 			case SE_Duration_Mana_Pct:
 			case SE_Duration_Endurance_Pct:

--- a/zone/tune.cpp
+++ b/zone/tune.cpp
@@ -1305,6 +1305,11 @@ int64 Mob::TuneGetTotalToHit(EQ::skills::SkillType skill, int chance_mod, int ac
 		aabonuses.HitChanceEffect[skill] +
 		spellbonuses.HitChanceEffect[skill];
 
+	if (skill == EQ::skills::SkillArchery) {
+		hit_bonus += spellbonuses.increase_archery + aabonuses.increase_archery + itembonuses.increase_archery;
+		hit_bonus -= hit_bonus * RuleR(Combat, ArcheryHitPenalty);
+	}
+	
 	accuracy = (accuracy * (100 + hit_bonus)) / 100;
 	return accuracy;
 }


### PR DESCRIPTION
# Description

- Added SE_IncreaseArchery
- Added Rules to tune archery:

RULE_REAL(Combat, ArcheryHitPenalty, 0, "Archery has a hit penalty to try to help balance it with the plethora of long term +hit modifiers for it - Default: 0")
RULE_REAL(Combat, ArcheryBaseDamageBonus, 1, "Percentage modifier to base archery Damage 0.5=50% base damage, 1=100%,2=200% - Default: 1")

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
