### PR TITLE
[Bug Fix] When refreshing buffs, attempt to use the same buffslot if the buff still exists.

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3672,6 +3672,10 @@ int Mob::AddBuff(Mob *caster, uint16 spell_id, int duration, int32 level_overrid
 				);
 
 				// If this is the first buff it would override, use its slot
+				if (!will_overwrite && !IsDisciplineBuff(spell_id)) {
+					emptyslot = buffslot;
+				}
+				
 				will_overwrite = true;
 				overwrite_slots.push_back(buffslot);
 			} else if (ret == 2) {


### PR DESCRIPTION
# Description

When refreshing buffs, attempt to use the same buffslot if the buff still exists.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
