### PR TITLE
[Quest API] Add Zone Uptime Exports to Perl/Lua

### DIFF
--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -1547,16 +1547,17 @@ void PerlembParser::ExportMobVariables(
 void PerlembParser::ExportZoneVariables(std::string& package_name)
 {
 	if (zone) {
-		ExportVar(package_name.c_str(), "zoneid", zone->GetZoneID());
-		ExportVar(package_name.c_str(), "zoneln", zone->GetLongName());
-		ExportVar(package_name.c_str(), "zonesn", zone->GetShortName());
 		ExportVar(package_name.c_str(), "instanceid", zone->GetInstanceID());
 		ExportVar(package_name.c_str(), "instanceversion", zone->GetInstanceVersion());
 		TimeOfDay_Struct eqTime{ };
 		zone->zone_time.GetCurrentEQTimeOfDay(time(0), &eqTime);
 		ExportVar(package_name.c_str(), "zonehour", eqTime.hour - 1);
+		ExportVar(package_name.c_str(), "zoneid", zone->GetZoneID());
+		ExportVar(package_name.c_str(), "zoneln", zone->GetLongName());
 		ExportVar(package_name.c_str(), "zonemin", eqTime.minute);
+		ExportVar(package_name.c_str(), "zonesn", zone->GetShortName());
 		ExportVar(package_name.c_str(), "zonetime", (eqTime.hour - 1) * 100 + eqTime.minute);
+		ExportVar(package_name.c_str(), "zoneuptime", Timer::GetCurrentTime() / 1000);
 		ExportVar(package_name.c_str(), "zoneweather", zone->zone_weather);
 	}
 }

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -5576,6 +5576,11 @@ bool lua_send_parcel(luabind::object lua_table)
 	return CharacterParcelsRepository::InsertOne(database, e).id;
 }
 
+uint32 lua_get_zone_uptime()
+{
+	return Timer::GetCurrentTime() / 1000;
+}
+
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
 	cur = table[#name]; \
 	if(luabind::type(cur) != LUA_TNIL) { \
@@ -6380,6 +6385,7 @@ luabind::scope lua_register_general() {
 		luabind::def("get_zone_id_by_long_name", &lua_get_zone_id_by_long_name),
 		luabind::def("get_zone_short_name_by_long_name", &lua_get_zone_short_name_by_long_name),
 		luabind::def("send_parcel", &lua_send_parcel),
+		luabind::def("get_zone_uptime", &lua_get_zone_uptime),
 		/*
 			Cross Zone
 		*/


### PR DESCRIPTION
# Perl
- Add `$zoneuptime` export, this returns the current zone's uptime in seconds.
- Note: This is exported alongside other variables like `$zoneid` and `$zonesn` in `PerlembParser::ExportZoneVariables` and requires `export_zone` in the `perl_event_export_settings` to be set to `1` for the event you are using this in.

# Lua
- Add `eq.get_zone_uptime()`, this returns the current zone's uptime in seconds.

## Type of Change
- [X] New feature

# Testing
## Perl
![image](https://github.com/EQEmu/Server/assets/89047260/ad127b2c-b8d3-4b6f-9592-6540fb171eee)

## Perl Script
```pl
sub EVENT_SAY {
	if ($text=~/#a/i) {
		my $time = quest::secondstotime($zoneuptime);
		$client->SendGMCommand("#show uptime $_") for (6, 7);
		quest::message(315, "[Perl] Uptime is $time.");
	}
}
```

## Lua
![image](https://github.com/EQEmu/Server/assets/89047260/a13504d0-1590-4f7f-b6f0-27be34293d01)

## Lua Script
```lua
function event_say(e)
	if e.message:findi("#a") then
		local time = eq.seconds_to_time(eq.get_zone_uptime());
		for zone_server_id = 6, 7 do
			e.self:SendGMCommand(string.format("#show uptime %d", zone_server_id))
		end
		
		eq.message(315, string.format("[Lua] Uptime is %s.", time));
	end
end
```

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur