### PR TITLE
[Bug Fix] Fix Using Bind Wound Above 70% Health

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -3220,9 +3220,7 @@ bool Client::BindWound(Mob *bindmob, bool start, bool fail)
 							else if (GetSkill(EQ::skills::SkillBindWound) >= 12)
 								bindhps = GetSkill(EQ::skills::SkillBindWound) / 4; // 4:1 skill-to-hp ratio
 
-							int bonus_hp_percent = 0;
-							if (percent_base >= 70)
-								bonus_hp_percent = spellbonuses.BindWound + itembonuses.BindWound + aabonuses.BindWound;
+							int bonus_hp_percent = spellbonuses.BindWound + itembonuses.BindWound + aabonuses.BindWound;
 
 							bindhps += (bindhps * bonus_hp_percent) / 100;
 

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -3233,9 +3233,9 @@ bool Client::BindWound(Mob *bindmob, bool start, bool fail)
 							bindmob->SendHPUpdate();
 						}
 						else {
-							Message(Chat::Yellow, "You cannot bind wounds above %d%% hitpoints", max_percent);
+							Message(Chat::Yellow, "You cannot bind wounds above %d%% hitpoints.", max_percent);
 							if (bindmob != this && bindmob->IsClient())
-								bindmob->CastToClient()->Message(Chat::Yellow, "You cannot have your wounds bound above %d%% hitpoints", max_percent);
+								bindmob->CastToClient()->Message(Chat::Yellow, "You cannot have your wounds bound above %d%% hitpoints.", max_percent);
 						}
 					}
 				}

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -3199,9 +3199,7 @@ bool Client::BindWound(Mob *bindmob, bool start, bool fail)
 								percent_base = 70;
 						}
 
-						int percent_bonus = 0;
-						if (percent_base >= 70)
-							percent_bonus = spellbonuses.MaxBindWound + itembonuses.MaxBindWound + aabonuses.MaxBindWound;
+						int percent_bonus = spellbonuses.MaxBindWound + itembonuses.MaxBindWound + aabonuses.MaxBindWound;
 
 						int max_percent = percent_base + percent_bonus;
 						if (max_percent < 0)


### PR DESCRIPTION
# Description
- Resolves https://github.com/EQEmu/Server/issues/4312.
- Based on patch notes [here](https://everquest.allakhazam.com/history/patches-2004-1.html).
```
HP Regen
- All characters should now regenerate HP faster when sitting. The longer you sit, the faster you regenerate!
- You will not receive increased regen while under the effects of a DOT or while feigned.
- You can now bandage yourself up to 70% of your HP. Folks with the appropriate AA abilities can bandage above 70%.
- You can now bandage while sitting.
```
Note: I added the periods to the messages shown in the below screenshots after they were done, but they will are there in the final code.

## Type of Change
- [X] Bug fix

# Testing with First Aid AA Rank 3 (+30% Bind Wound)
## Cleric
![image](https://github.com/EQEmu/Server/assets/89047260/98abcd20-605f-4b8a-be83-68c7e8841bef)
## Warrior
![image](https://github.com/EQEmu/Server/assets/89047260/9c38a56b-44c9-489d-80d7-2bc9d0a200b7)

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur