### PR TITLE
[Scripts] Fix zone data load ordering issue

### DIFF
--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -1157,9 +1157,17 @@ bool Zone::Init(bool is_static) {
 	DynamicZone::CacheAllFromDatabase();
 	Expedition::CacheAllFromDatabase();
 
+	content_db.LoadGlobalLoot();
+
 	npc_scale_manager->LoadScaleData();
 
 	LoadGrids();
+
+	if (RuleB(Zone, LevelBasedEXPMods)) {
+		LoadLevelEXPMods();
+	}
+
+	RespawnTimesRepository::ClearExpiredRespawnTimers(database);
 
 	// make sure that anything that needs to be loaded prior to scripts is loaded before here
 	// this is to ensure that the scripts have access to the data they need
@@ -1182,12 +1190,8 @@ bool Zone::Init(bool is_static) {
 
 	LogInfo("Loading adventure flavor text");
 	LoadAdventureFlavor();
-
 	LoadGroundSpawns();
 	LoadZoneObjects();
-
-	RespawnTimesRepository::ClearExpiredRespawnTimers(database);
-
 	LoadZoneDoors();
 	LoadZoneBlockedSpells();
 
@@ -1200,27 +1204,15 @@ bool Zone::Init(bool is_static) {
 	LoadVeteranRewards();
 	LoadAlternateCurrencies();
 	LoadNPCEmotes(&npc_emote_list);
-
 	LoadAlternateAdvancement();
-
-	content_db.LoadGlobalLoot();
-
 	LoadBaseData();
-
-	//Load merchant data
 	LoadMerchants();
-
-	//Load temporary merchant data
 	LoadTempMerchantData();
 
 	// Merc data
 	if (RuleB(Mercs, AllowMercs)) {
 		LoadMercenaryTemplates();
 		LoadMercenarySpells();
-	}
-
-	if (RuleB(Zone, LevelBasedEXPMods)) {
-		LoadLevelEXPMods();
 	}
 
 	petition_list.ClearPetitions();

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -108,9 +108,6 @@ bool Zone::Bootup(uint32 iZoneID, uint32 iInstanceID, bool is_static) {
 	numclients = 0;
 	zone = new Zone(iZoneID, iInstanceID, zonename);
 
-	parse->Init();
-	parse->ReloadQuests(true);
-
 	//init the zone, loads all the data, etc
 	if (!zone->Init(is_static)) {
 		safe_delete(zone);
@@ -1150,6 +1147,13 @@ bool Zone::Init(bool is_static) {
 	watermap = WaterMap::LoadWaterMapfile(map_name);
 	pathing  = IPathfinder::Load(map_name);
 
+	LoadDynamicZoneTemplates();
+	DynamicZone::CacheAllFromDatabase();
+	Expedition::CacheAllFromDatabase();
+
+	parse->Init();
+	parse->ReloadQuests(true);
+
 	spawn_conditions.LoadSpawnConditions(short_name, instanceid);
 
 	content_db.LoadStaticZonePoints(&zone_point_list, short_name, GetInstanceVersion());
@@ -1211,11 +1215,6 @@ bool Zone::Init(bool is_static) {
 
 	petition_list.ClearPetitions();
 	petition_list.ReadDatabase();
-
-	LoadDynamicZoneTemplates();
-
-	DynamicZone::CacheAllFromDatabase();
-	Expedition::CacheAllFromDatabase();
 
 	guild_mgr.LoadGuilds();
 

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -1147,10 +1147,22 @@ bool Zone::Init(bool is_static) {
 	watermap = WaterMap::LoadWaterMapfile(map_name);
 	pathing  = IPathfinder::Load(map_name);
 
+	LogInfo("Loading timezone data");
+	zone_time.setEQTimeZone(content_db.GetZoneTimezone(zoneid, GetInstanceVersion()));
+
+	LoadLDoNTraps();
+	LoadLDoNTrapEntries();
+
 	LoadDynamicZoneTemplates();
 	DynamicZone::CacheAllFromDatabase();
 	Expedition::CacheAllFromDatabase();
 
+	npc_scale_manager->LoadScaleData();
+
+	LoadGrids();
+
+	// make sure that anything that needs to be loaded prior to scripts is loaded before here
+	// this is to ensure that the scripts have access to the data they need
 	parse->Init();
 	parse->ReloadQuests(true);
 
@@ -1185,8 +1197,6 @@ bool Zone::Init(bool is_static) {
 		database.DeleteBuyLines(0);
 	}
 
-	LoadLDoNTraps();
-	LoadLDoNTrapEntries();
 	LoadVeteranRewards();
 	LoadAlternateCurrencies();
 	LoadNPCEmotes(&npc_emote_list);
@@ -1218,14 +1228,7 @@ bool Zone::Init(bool is_static) {
 
 	guild_mgr.LoadGuilds();
 
-	LogInfo("Loading timezone data");
-	zone_time.setEQTimeZone(content_db.GetZoneTimezone(zoneid, GetInstanceVersion()));
-
 	LogInfo("Zone booted successfully zone_id [{}] time_offset [{}]", zoneid, zone_time.getEQTimeZone());
-
-	LoadGrids();
-
-	npc_scale_manager->LoadScaleData();
 
 	// logging origination information
 	LogSys.origination_info.zone_short_name = zone->short_name;


### PR DESCRIPTION
# Description

This is to adjust some behavior change caused from https://github.com/EQEmu/Server/pull/4298

The script reload change is not necessarily an issue by itself but the order in which it is called causes issues with scripts depend on some of those things being initialized such as dynamic zones.

This attempts to move some load ordering around. Still needs testing

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Scripts still load properly prior to zone bootup

```perl
sub EVENT_SPAWN {
    quest::settimerMS("test", 10);
}

sub EVENT_TIMER {
    quest::say("Trigger");
}
```

![image](https://github.com/EQEmu/Server/assets/3319450/1c0730ac-d56a-4a78-9d29-5987d3e65534)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
