### PR TITLE
[NPC Spells] Fix an issue where procs wouldn't fire if no spell entries in list

### DIFF
--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -2894,10 +2894,6 @@ DBnpcspells_Struct *ZoneDatabase::GetNPCSpells(uint32 npc_spells_id)
 			)
 		);
 
-		if (entries.empty()) {
-			return nullptr;
-		}
-
 		for (auto &e: entries) {
 			DBnpcspells_entries_Struct se{};
 


### PR DESCRIPTION
# Description

This fixes an issue as reported by @regneq that if an NPC does not have any spells in their list, we don't load the spell set at all preventing the NPC from firing procs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

**Before**

![image](https://github.com/EQEmu/Server/assets/3319450/71704770-e005-46ff-bb75-84d935b45e30)

![image](https://github.com/EQEmu/Server/assets/3319450/0eb8608f-5cb6-42eb-9205-f051d4716020)

**After**

![image](https://github.com/EQEmu/Server/assets/3319450/6941cbc0-d98c-4a11-aa66-2c45f5ffa373)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
