### PR TITLE
[Lua Mod] Fix issue with SetAAEXP and SetEXP firing when uninitialized

### DIFF
--- a/zone/lua_mod.cpp
+++ b/zone/lua_mod.cpp
@@ -42,6 +42,8 @@ void LuaMod::Init()
 	m_has_common_damage = parser_->HasFunction("CommonDamage", package_name_);
 	m_has_heal_damage = parser_->HasFunction("HealDamage", package_name_);
 	m_has_is_immune_to_spell = parser_->HasFunction("IsImmuneToSpell", package_name_);
+	m_has_set_aa_exp = parser_->HasFunction("SetAAEXP", package_name_);
+	m_has_set_exp = parser_->HasFunction("SetEXP", package_name_);
 }
 
 void PutDamageHitInfo(lua_State *L, luabind::adl::object &e, DamageHitInfo &hit) {


### PR DESCRIPTION
# Description

Fixes an issue with https://github.com/EQEmu/Server/pull/4292 where the lua mods were firing regardless of being defined or not because we are not initializing the member variables that determine the mods are defined so the bool was being evaluated as truthful at source runtime.

This was spamming EZ's quest error logging with thousands of error logs per minute.

This is only reproducible when you are running at least one Lua mod, could be entirely unrelated to these mod functions. Does not show when no mods are loaded.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

**Before**

![image](https://github.com/EQEmu/Server/assets/3319450/4518260e-e793-4b51-bb41-ab520bc07855)

**After**

![image](https://github.com/EQEmu/Server/assets/3319450/98a8f36a-ba6e-48d7-bee2-ea6e100941e0)

Clients tested: 

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
