### PR TITLE
[Perl] Linux /opt/eqemu-perl checks when using release binaries

### DIFF
--- a/zone/main.cpp
+++ b/zone/main.cpp
@@ -446,6 +446,21 @@ int main(int argc, char **argv)
 	auto perl_parser = new PerlembParser();
 	parse->RegisterQuestInterface(perl_parser, "pl");
 
+#ifdef __linux__
+	std::string current_version = CURRENT_VERSION;
+	// running release binaries
+	if (!Strings::Contains(current_version, "-dev")) {
+		if (!fs::exists("/opt/eqemu-perl")) {
+			LogError("You are running release binaries without having the required eqemu version of perl compiled and installed on this system present at /opt/eqemu-perl");
+			LogError("If you are running an old Linux install, you need to install the required perl version from the eqemu-perl");
+			LogError("Instructions can be referenced at https://github.com/Akkadius/akk-stack/blob/master/containers/eqemu-server/Dockerfile#L92-L106");
+			LogError("Press any key to continue");
+			getchar();
+		}
+		return 0;
+	}
+#endif
+
 	/* Load Perl Event Export Settings */
 	parse->LoadPerlEventExportSettings(parse->perl_event_export_settings);
 


### PR DESCRIPTION
# Description

We've seen hundreds of crashes of folks using release binaries with old Linux installs and using system Perl. Release binaries are compiled against a very specific version of Perl and not using that can cause weird issues and corruption in the stack.

This PR adds a check to defend from crashes but also instruct users of the exact problem with a remediation path.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

![image](https://github.com/EQEmu/Server/assets/3319450/c6533611-d441-4fec-9e4b-6bc8aaa5231b)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
