### PR TITLE
[Performance] Improve SkillCaps::GetTrainLevel() Efficiency

### DIFF
--- a/common/skill_caps.cpp
+++ b/common/skill_caps.cpp
@@ -1,4 +1,5 @@
 #include "skill_caps.h"
+#include "timer.h"
 
 SkillCaps *SkillCaps::SetContentDatabase(Database *db)
 {
@@ -13,7 +14,8 @@ SkillCapsRepository::SkillCaps SkillCaps::GetSkillCap(uint8 class_id, EQ::skills
 		return SkillCapsRepository::NewEntity();
 	}
 
-	uint64_t key = (class_id * 1000000) + (level * 1000) + static_cast<uint32>(skill_id);
+	const uint64_t key = (class_id * 1000000) + (level * 1000) + static_cast<uint32>(skill_id);
+
 	auto pos = m_skill_caps.find(key);
 	if (pos != m_skill_caps.end()) {
 		return pos->second;
@@ -22,7 +24,7 @@ SkillCapsRepository::SkillCaps SkillCaps::GetSkillCap(uint8 class_id, EQ::skills
 	return SkillCapsRepository::NewEntity();
 }
 
-uint8 SkillCaps::GetTrainLevel(uint8 class_id, EQ::skills::SkillType skill_id, uint8 level)
+uint8 SkillCaps::GetSkillTrainLevel(uint8 class_id, EQ::skills::SkillType skill_id, uint8 level)
 {
 	if (
 		!IsPlayerClass(class_id) ||
@@ -38,10 +40,10 @@ uint8 SkillCaps::GetTrainLevel(uint8 class_id, EQ::skills::SkillType skill_id, u
 		RuleI(Character, MaxLevel)
 	);
 
-	const uint8 max_level = level > skill_cap_max_level ? level : skill_cap_max_level;
+	const uint8    max_level = level > skill_cap_max_level ? level : skill_cap_max_level;
+	const uint64_t key       = (class_id * 1000000) + (level * 1000) + static_cast<uint32>(skill_id);
 
 	for (uint8 current_level = 1; current_level <= max_level; current_level++) {
-		uint64_t key = (class_id * 1000000) + (level * 1000) + static_cast<uint32>(skill_id);
 		auto pos = m_skill_caps.find(key);
 		if (pos != m_skill_caps.end()) {
 			return current_level;
@@ -53,11 +55,11 @@ uint8 SkillCaps::GetTrainLevel(uint8 class_id, EQ::skills::SkillType skill_id, u
 
 void SkillCaps::LoadSkillCaps()
 {
-	const auto &l = SkillCapsRepository::All(*m_content_database);
+	const auto& l = SkillCapsRepository::All(*m_content_database);
 
 	m_skill_caps.clear();
 
-	for (const auto &e: l) {
+	for (const auto& e: l) {
 		if (
 			e.level < 1 ||
 			!IsPlayerClass(e.class_id) ||
@@ -66,7 +68,7 @@ void SkillCaps::LoadSkillCaps()
 			continue;
 		}
 
-		uint64_t key = (e.class_id * 1000000) + (e.level * 1000) + e.skill_id;
+		const uint64_t key = (e.class_id * 1000000) + (e.level * 1000) + e.skill_id;
 		m_skill_caps[key] = e;
 	}
 

--- a/common/skill_caps.cpp
+++ b/common/skill_caps.cpp
@@ -18,6 +18,7 @@ SkillCapsRepository::SkillCaps SkillCaps::GetSkillCap(uint8 class_id, EQ::skills
 	if (pos != m_skill_caps.end()) {
 		return pos->second;
 	}
+
 	return SkillCapsRepository::NewEntity();
 }
 
@@ -27,25 +28,23 @@ uint8 SkillCaps::GetTrainLevel(uint8 class_id, EQ::skills::SkillType skill_id, u
 		!IsPlayerClass(class_id) ||
 		class_id > Class::PLAYER_CLASS_COUNT ||
 		static_cast<uint32>(skill_id) > (EQ::skills::HIGHEST_SKILL + 1)
-		) {
+	) {
 		return 0;
 	}
 
 	const uint8 skill_cap_max_level = (
 		RuleI(Character, SkillCapMaxLevel) > 0 ?
-			RuleI(Character, SkillCapMaxLevel) :
-			RuleI(Character, MaxLevel)
+		RuleI(Character, SkillCapMaxLevel) :
+		RuleI(Character, MaxLevel)
 	);
 
 	const uint8 max_level = level > skill_cap_max_level ? level : skill_cap_max_level;
 
-	for (const auto &e: m_skill_caps) {
-		for (uint8 current_level = 1; current_level <= max_level; current_level++) {
-			uint64_t key = (class_id * 1000000) + (level * 1000) + static_cast<uint32>(skill_id);
-			auto pos = m_skill_caps.find(key);
-			if (pos != m_skill_caps.end()) {
-				return current_level;
-			}
+	for (uint8 current_level = 1; current_level <= max_level; current_level++) {
+		uint64_t key = (class_id * 1000000) + (level * 1000) + static_cast<uint32>(skill_id);
+		auto pos = m_skill_caps.find(key);
+		if (pos != m_skill_caps.end()) {
+			return current_level;
 		}
 	}
 
@@ -63,7 +62,7 @@ void SkillCaps::LoadSkillCaps()
 			e.level < 1 ||
 			!IsPlayerClass(e.class_id) ||
 			static_cast<EQ::skills::SkillType>(e.skill_id) >= EQ::skills::SkillCount
-			) {
+		) {
 			continue;
 		}
 

--- a/common/skill_caps.h
+++ b/common/skill_caps.h
@@ -10,7 +10,7 @@ class SkillCaps {
 public:
 	inline void ClearSkillCaps() { m_skill_caps.clear(); }
 	SkillCapsRepository::SkillCaps GetSkillCap(uint8 class_id, EQ::skills::SkillType skill_id, uint8 level);
-	uint8 GetTrainLevel(uint8 class_id, EQ::skills::SkillType skill_id, uint8 level);
+	uint8 GetSkillTrainLevel(uint8 class_id, EQ::skills::SkillType skill_id, uint8 level);
 	void LoadSkillCaps();
 	void ReloadSkillCaps();
 

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -2803,7 +2803,7 @@ uint16 Client::MaxSkill(EQ::skills::SkillType skill_id, uint8 class_id, uint8 le
 	return skill_caps.GetSkillCap(class_id, skill_id, level).cap;
 }
 
-uint8 Client::SkillTrainLevel(EQ::skills::SkillType skill_id, uint8 class_id)
+uint8 Client::GetSkillTrainLevel(EQ::skills::SkillType skill_id, uint8 class_id)
 {
 	if (
 		ClientVersion() < EQ::versions::ClientVersion::RoF2 &&
@@ -2813,7 +2813,7 @@ uint8 Client::SkillTrainLevel(EQ::skills::SkillType skill_id, uint8 class_id)
 		skill_id = EQ::skills::Skill2HPiercing;
 	}
 
-	return skill_caps.GetTrainLevel(class_id, skill_id, RuleI(Character, MaxLevel));
+	return skill_caps.GetSkillTrainLevel(class_id, skill_id, RuleI(Character, MaxLevel));
 }
 
 uint16 Client::GetMaxSkillAfterSpecializationRules(EQ::skills::SkillType skillid, uint16 maxSkill)

--- a/zone/client.h
+++ b/zone/client.h
@@ -866,7 +866,7 @@ public:
 
 	uint16 MaxSkill(EQ::skills::SkillType skill_id, uint8 class_id, uint8 level) const;
 	inline uint16 MaxSkill(EQ::skills::SkillType skill_id) const { return MaxSkill(skill_id, GetClass(), GetLevel()); }
-	uint8 SkillTrainLevel(EQ::skills::SkillType skill_id, uint8 class_id);
+	uint8 GetSkillTrainLevel(EQ::skills::SkillType skill_id, uint8 class_id);
 	void MaxSkills();
 
 	void SendTradeskillSearchResults(const std::string &query, unsigned long objtype, unsigned long someid);

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -1718,7 +1718,7 @@ void Client::OPGMTrainSkill(const EQApplicationPacket *app)
 
 		if (skilllevel == 0) {
 			//this is a new skill..
-			uint16 t_level = SkillTrainLevel(skill, GetClass());
+			uint16 t_level = GetSkillTrainLevel(skill, GetClass());
 
 			if (t_level == 0) {
 				LogSkills("Tried to train a new skill [{}] which is invalid for this race/class.", skill);

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3375,6 +3375,12 @@ void Lua_Client::ResetLeadershipAA()
 	self->ResetLeadershipAA();
 }
 
+uint8 Lua_Client::GetSkillTrainLevel(int skill_id)
+{
+	Lua_Safe_Call_Int();
+	return self->GetSkillTrainLevel(static_cast<EQ::skills::SkillType>(skill_id), self->GetClass());
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 	.def(luabind::constructor<>())
@@ -3624,6 +3630,7 @@ luabind::scope lua_register_client() {
 	.def("GetScribeableSpells", (luabind::object(Lua_Client::*)(lua_State* L,uint8,uint8))&Lua_Client::GetScribeableSpells)
 	.def("GetScribedSpells", (luabind::object(Lua_Client::*)(lua_State* L))&Lua_Client::GetScribedSpells)
 	.def("GetSkillPoints", (int(Lua_Client::*)(void))&Lua_Client::GetSkillPoints)
+	.def("GetSkillTrainLevel", (uint8(Lua_Client::*)(int))&Lua_Client::GetSkillTrainLevel)
 	.def("GetSpellDamage", (int(Lua_Client::*)(void))&Lua_Client::GetSpellDamage)
 	.def("GetSpellIDByBookSlot", (uint32(Lua_Client::*)(int))&Lua_Client::GetSpellIDByBookSlot)
 	.def("GetSpentAA", (int(Lua_Client::*)(void))&Lua_Client::GetSpentAA)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -504,6 +504,7 @@ public:
 	bool SetAutoLoginCharacterName(std::string character_name);
 	void DescribeSpecialAbilities(Lua_NPC n);
 	void ResetLeadershipAA();
+	uint8 GetSkillTrainLevel(int skill_id);
 
 	void ApplySpell(int spell_id);
 	void ApplySpell(int spell_id, int duration);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -3173,6 +3173,11 @@ void Perl_Client_ResetLeadershipAA(Client* self)
 	self->ResetLeadershipAA();
 }
 
+uint8 Perl_Client_GetSkillTrainLevel(Client* self, int skill_id)
+{
+	return self->GetSkillTrainLevel(static_cast<EQ::skills::SkillType>(skill_id), self->GetClass());
+}
+
 void perl_register_client()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3431,6 +3436,7 @@ void perl_register_client()
 	package.add("GetTaskActivityDoneCount", &Perl_Client_GetTaskActivityDoneCount);
 	package.add("GetThirst", &Perl_Client_GetThirst);
 	package.add("GetTotalSecondsPlayed", &Perl_Client_GetTotalSecondsPlayed);
+	package.add("GetSkillTrainLevel", &Perl_Client_GetSkillTrainLevel);
 	package.add("GetWeight", &Perl_Client_GetWeight);
 	package.add("GetPEQZoneFlags", &Perl_Client_GetPEQZoneFlags);
 	package.add("GetZoneFlags", &Perl_Client_GetZoneFlags);


### PR DESCRIPTION
# Description
- Being we're using `.find` with an integer-based keying, the outer loop is unnecessary now.
- The loop initially existed prior to the integer-based keying and was not removed, as a result of this we are needlessly looping `m_skill_caps` and performing extra `.find` calls.

# Perl
- Add `$client->GetSkillTrainLevel(skill_id)`.

## Perl Script
```pl
sub EVENT_SAY {
	if ($text=~/#a/i) {
		foreach my $skill_id (1, 2) {
			my $skill_name = quest::getskillname($skill_id);
			my $train_level = $client->GetSkillTrainLevel($skill_id);
			quest::message(315, "$skill_name ($skill_id) trains at level $train_level.");
		}
	}
}
```

# Lua
- Add `client:GetSkillTrainLevel(skill_id)`.

## Lua Script
```lua
function event_say(e)
	if e.message:findi("#a") then
		for skill_id = 1, 2 do
			local skill_name = eq.get_skill_name(skill_id);
			local train_level = e.self:GetSkillTrainLevel(skill_id);
			eq.message(315, string.format("%s (%d) trains at level %d.", skill_name, skill_id, train_level));
		end
	end
end
```

# Before Benchmark
![image](https://github.com/EQEmu/Server/assets/89047260/fd6e88c9-698e-48f3-994a-453734f665e4)

# After Benchmark
![image](https://github.com/EQEmu/Server/assets/89047260/d6299cb7-55f6-4209-a957-409b1ba405e7)

## Type of Change
- [X] Bug fix

# Checklist
- [X] I own the changes of my code and take responsibility for the potential issues that occur