### PR TITLE
[Bug Fix] Fix Case-Sensitive Search in #find skill

### DIFF
--- a/zone/gm_commands/find/skill.cpp
+++ b/zone/gm_commands/find/skill.cpp
@@ -15,15 +15,15 @@ void FindSkill(Client *c, const Seperator *sep)
 			return;
 		}
 
-		const auto& m = EQ::skills::GetSkillTypeMap();
-		const auto& s = m.find(skill_id);
-		if (s != m.end()) {
+		const std::string& skill_name = EQ::skills::GetSkillName(skill_id);
+
+		if (!skill_name.empty()) {
 			c->Message(
 				Chat::White,
 				fmt::format(
 					"Skill {} | {}",
-					s->first,
-					s->second
+					skill_id,
+					skill_name
 				).c_str()
 			);
 		}

--- a/zone/gm_commands/find/skill.cpp
+++ b/zone/gm_commands/find/skill.cpp
@@ -3,43 +3,40 @@
 void FindSkill(Client *c, const Seperator *sep)
 {
 	if (sep->IsNumber(2)) {
-		const auto skill_id = Strings::ToInt(sep->arg[2]);
-		if (EQ::ValueWithin(skill_id, EQ::skills::Skill1HBlunt, EQ::skills::SkillCount)) {
-			for (const auto& s : EQ::skills::GetSkillTypeMap()) {
-				if (skill_id == s.first) {
-					c->Message(
-						Chat::White,
-						fmt::format(
-							"Skill {} | {}",
-							s.first,
-							s.second
-						).c_str()
-					);
-					break;
-				}
-			}
-
+		const auto skill_id = static_cast<EQ::skills::SkillType>(Strings::ToInt(sep->arg[2]));
+		if (!EQ::ValueWithin(skill_id, EQ::skills::Skill1HBlunt, EQ::skills::SkillCount)) {
+			c->Message(
+				Chat::White,
+				fmt::format(
+					"Skill ID {} was not found.",
+					skill_id
+				).c_str()
+			);
 			return;
 		}
 
-		c->Message(
-			Chat::White,
-			fmt::format(
-				"Skill ID {} was not found.",
-				skill_id
-			).c_str()
-		);
+		const auto& m = EQ::skills::GetSkillTypeMap();
+		const auto& s = m.find(skill_id);
+		if (s != m.end()) {
+			c->Message(
+				Chat::White,
+				fmt::format(
+					"Skill {} | {}",
+					s->first,
+					s->second
+				).c_str()
+			);
+		}
 
 		return;
 	}
 
-	const auto& search_criteria = Strings::ToLower(sep->argplus[2]);
+	const std::string& search_criteria = Strings::ToLower(sep->argplus[2]);
 
-	auto found_count = 0;
+	uint32 found_count = 0;
 
 	for (const auto& s : EQ::skills::GetSkillTypeMap()) {
-		const auto& skill_name_lower = Strings::ToLower(s.second);
-		if (!Strings::Contains(skill_name_lower, sep->argplus[2])) {
+		if (!Strings::Contains(Strings::ToLower(s.second), search_criteria)) {
 			continue;
 		}
 


### PR DESCRIPTION
# Description
- Prior to this change using `#find skill` was case-sensitive because I had not used `search_criteria` for the string comparison and was instead using `sep->argplus[2]` as supplied by the GM, causing case sensitivity.

## Type of Change
- [X] Bug fix

# Testing
![image](https://github.com/EQEmu/Server/assets/89047260/5ebe912e-232c-4adf-93f8-4c1a61f6c77a)

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
