### PR TITLE
[Quest API] Add Item Link Methods to Perl/Lua

### DIFF
--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -4940,6 +4940,11 @@ void Perl__set_proximity_range(float x_range, float y_range, float z_range, bool
 	quest_manager.set_proximity_range(x_range, y_range, z_range, enable_say);
 }
 
+std::string Perl__varlink(EQ::ItemInstance* inst)
+{
+	return quest_manager.varlink(inst);
+}
+
 std::string Perl__varlink(uint32 item_id)
 {
 	return quest_manager.varlink(item_id);
@@ -6856,6 +6861,7 @@ void perl_register_quest()
 	package.add("updatetaskactivity", (void(*)(int, int, int))&Perl__updatetaskactivity);
 	package.add("updatetaskactivity", (void(*)(int, int, int, bool))&Perl__updatetaskactivity);
 	package.add("UpdateZoneHeader", &Perl__UpdateZoneHeader);
+	package.add("varlink", (std::string(*)(EQ::ItemInstance*))&Perl__varlink);
 	package.add("varlink", (std::string(*)(uint32))&Perl__varlink);
 	package.add("varlink", (std::string(*)(uint32, int16))&Perl__varlink);
 	package.add("varlink", (std::string(*)(uint32, int16, uint32))&Perl__varlink);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -3991,6 +3991,10 @@ void lua_do_anim(int animation_id, int animation_speed, bool ackreq, int filter)
 	quest_manager.doanim(animation_id, animation_speed, ackreq, static_cast<eqFilterType>(filter));
 }
 
+std::string lua_item_link(Lua_ItemInst inst) {
+	return quest_manager.varlink(inst);
+}
+
 std::string lua_item_link(uint32 item_id) {
 	return quest_manager.varlink(item_id);
 }
@@ -5922,6 +5926,7 @@ luabind::scope lua_register_general() {
 		luabind::def("merchant_set_item", (void(*)(uint32,uint32))&lua_merchant_set_item),
 		luabind::def("merchant_set_item", (void(*)(uint32,uint32,uint32))&lua_merchant_set_item),
 		luabind::def("merchant_count_item", &lua_merchant_count_item),
+		luabind::def("item_link", (std::string(*)(Lua_ItemInst))&lua_item_link),
 		luabind::def("item_link", (std::string(*)(uint32))&lua_item_link),
 		luabind::def("item_link", (std::string(*)(uint32,int16))&lua_item_link),
 		luabind::def("item_link", (std::string(*)(uint32,int16,uint32))&lua_item_link),

--- a/zone/lua_iteminst.cpp
+++ b/zone/lua_iteminst.cpp
@@ -337,6 +337,17 @@ luabind::object Lua_ItemInst::GetAugmentIDs(lua_State* L)
 	return lua_table;
 }
 
+std::string Lua_ItemInst::GetItemLink()
+{
+	Lua_Safe_Call_String();
+
+	EQ::SayLinkEngine linker;
+	linker.SetLinkType(EQ::saylink::SayLinkItemInst);
+	linker.SetItemInst(self);
+
+	return linker.GenerateLink();
+}
+
 luabind::scope lua_register_iteminst() {
 	return luabind::class_<Lua_ItemInst>("ItemInst")
 	.def(luabind::constructor<>())
@@ -363,6 +374,7 @@ luabind::scope lua_register_iteminst() {
 	.def("GetItem", (Lua_Item(Lua_ItemInst::*)(void))&Lua_ItemInst::GetItem)
 	.def("GetItem", (Lua_ItemInst(Lua_ItemInst::*)(uint8))&Lua_ItemInst::GetItem)
 	.def("GetItemID", (uint32(Lua_ItemInst::*)(int))&Lua_ItemInst::GetItemID)
+	.def("GetItemLink", (std::string(Lua_ItemInst::*)(void))&Lua_ItemInst::GetItemLink)
 	.def("GetItemScriptID", (uint32(Lua_ItemInst::*)(void))&Lua_ItemInst::GetItemScriptID)
 	.def("GetKillsNeeded", (uint32(Lua_ItemInst::*)(int))&Lua_ItemInst::GetKillsNeeded)
 	.def("GetMaxEvolveLvl", (int(Lua_ItemInst::*)(void))&Lua_ItemInst::GetMaxEvolveLvl)

--- a/zone/lua_iteminst.h
+++ b/zone/lua_iteminst.h
@@ -90,6 +90,7 @@ public:
 	void ItemSay(const char* text);
 	void ItemSay(const char* text, uint8 language_id);
 	luabind::object GetAugmentIDs(lua_State* L);
+	std::string GetItemLink();
 
 private:
 	bool cloned_;

--- a/zone/perl_questitem.cpp
+++ b/zone/perl_questitem.cpp
@@ -288,6 +288,15 @@ perl::array Perl_QuestItem_GetAugmentIDs(EQ::ItemInstance* self)
 	return result;
 }
 
+std::string Perl_QuestItem_GetItemLink(EQ::ItemInstance* self)
+{
+	EQ::SayLinkEngine linker;
+	linker.SetLinkType(EQ::saylink::SayLinkItemInst);
+	linker.SetItemInst(self);
+
+	return linker.GenerateLink();
+}
+
 
 void perl_register_questitem()
 {
@@ -313,6 +322,7 @@ void perl_register_questitem()
 	package.add("GetItem", (EQ::ItemData*(*)(EQ::ItemInstance*))&Perl_QuestItem_GetItem);
 	package.add("GetItem", (EQ::ItemInstance*(*)(EQ::ItemInstance*, uint8))&Perl_QuestItem_GetItem);
 	package.add("GetItemID", &Perl_QuestItem_GetItemID);
+	package.add("GetItemLink", &Perl_QuestItem_GetItemLink);
 	package.add("GetItemScriptID", &Perl_QuestItem_GetItemScriptID);
 	package.add("GetKillsNeeded", &Perl_QuestItem_GetKillsNeeded);
 	package.add("GetMaxEvolveLevel", &Perl_QuestItem_GetMaxEvolveLevel);

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -3574,6 +3574,21 @@ uint32 QuestManager::MerchantCountItem(uint32 NPCid, uint32 itemid) {
 	return Quant;	// return the quantity of itemid (0 if it was never found)
 }
 
+std::string QuestManager::varlink(EQ::ItemInstance* inst)
+{
+	QuestManagerCurrentQuestVars();
+
+	if (!inst) {
+		return "INVALID ITEM INSTANCE IN VARLINK";
+	}
+
+	EQ::SayLinkEngine linker;
+	linker.SetLinkType(EQ::saylink::SayLinkItemInst);
+	linker.SetItemInst(inst);
+
+	return linker.GenerateLink();
+}
+
 // Item Link for use in Variables - "my $example_link = quest::varlink(item_id);"
 std::string QuestManager::varlink(
 	uint32 item_id,

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -284,6 +284,7 @@ public:
 	void MovePCInstance(int zone_id, int instance_id, const glm::vec4& position);
 	void FlagInstanceByGroupLeader(uint32 zone, int16 version);
 	void FlagInstanceByRaidLeader(uint32 zone, int16 version);
+	std::string varlink(EQ::ItemInstance* inst);
 	std::string varlink(uint32 item_id, int16 charges = 0, uint32 aug1 = 0, uint32 aug2 = 0, uint32 aug3 = 0, uint32 aug4 = 0, uint32 aug5 = 0, uint32 aug6 = 0, bool attuned = false);
 	std::string getcharnamebyid(uint32 char_id);
 	uint32 getcharidbyname(const char* name);


### PR DESCRIPTION
# Description
- Adds two new item link methods to Perl and Lua.
- Allows operators to use an `EQ::ItemInstance*` to get an item's varlink without having to use item IDs, augment IDs, etc.

# Perl
- Add `quest::varlink(item_instance)`.
- Add `$questitem->GetItemLink()`.

## Perl Image
![image](https://github.com/EQEmu/Server/assets/89047260/61558222-3bf6-402f-987b-b287ca7a2f09)

## Perl Script
```pl
sub EVENT_SAY {
	if ($text=~/#a/i) {
		my $inventory = $client->GetInventory();
		my $primary_slot_id = quest::getinventoryslotid("primary");
		my $item = $inventory->GetItem($primary_slot_id);
		if ($item) {
			my $item_link_object = $item->GetItemLink();
			my $item_link_quest = quest::varlink($item);
			quest::message(315, "Perl | O [$item_link_object] Q [$item_link_quest]");
		}
	}
}
```

# Lua
- Add `eq.item_link(item_instance)`.
- Add `item_inst:GetItemLink()`.

## Lua Image
![image](https://github.com/EQEmu/Server/assets/89047260/452e4923-a3bf-4aa4-9b2d-5451d5684971)

## Lua Script
```lua
function event_say(e)
	if e.message:findi("#a") then
		local inventory = e.self:GetInventory()
		local item = inventory:GetItem(Slot.Primary)
		if item.valid then
			local item_link_object = item:GetItemLink()
			local item_link_quest = eq.item_link(item)
			eq.message(315, string.format("Lua | O [%s] Q [%s]", item_link_object, item_link_quest))
		end
	end
end
```

## Type of Change
- [X] New feature

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur