### PR TITLE
[Quests] Fix Lua encounter double register

### DIFF
--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -1172,7 +1172,6 @@ bool Zone::Init(bool is_static) {
 
 	// make sure that anything that needs to be loaded prior to scripts is loaded before here
 	// this is to ensure that the scripts have access to the data they need
-	parse->Init();
 	parse->ReloadQuests(true);
 
 	spawn_conditions.LoadSpawnConditions(short_name, instanceid);


### PR DESCRIPTION
# Description

This fixes a scenario where Lua encounters get registered / fired twice during zone initialization. There's no need to call `parse->Init()` when `parse->ReloadQuests()` does largely the same functionality.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Awaiting @fryguy503 to do hands on testing

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
