### PR TITLE
[NPC Spells] Fixed an issue where the repository spell adj value was overriding the spell difficulty default value

### DIFF
--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -2787,10 +2787,11 @@ void NPC::AISpellsList(Client *c)
 			c->Message(
 				Chat::White,
 				fmt::format(
-					"Spell {} | Priority: {} Recast Delay: {}",
+					"Spell {} | Priority: {} Recast Delay: {} Resist Difficulty: {}",
 					spell_slot,
 					ai_spell.priority,
-					ai_spell.recast_delay
+					ai_spell.recast_delay,
+					ai_spell.resist_adjust
 				).c_str()
 			);
 
@@ -2912,11 +2913,8 @@ DBnpcspells_Struct *ZoneDatabase::GetNPCSpells(uint32 npc_spells_id)
 				se.priority = 1;
 			}
 
-			if (e.resist_adjust) {
-				se.resist_adjust = e.resist_adjust;
-			}
-			else if (IsValidSpell(e.id)) {
-				se.resist_adjust = spells[e.id].resist_difficulty;
+			if (IsValidSpell(e.id)) {
+				se.resist_adjust = spells[e.spellid].resist_difficulty;
 			}
 
 			ss.entries.push_back(se);

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -2913,7 +2913,10 @@ DBnpcspells_Struct *ZoneDatabase::GetNPCSpells(uint32 npc_spells_id)
 				se.priority = 1;
 			}
 
-			if (IsValidSpell(e.id)) {
+			if (e.resist_adjust) {
+				se.resist_adjust = e.resist_adjust;
+			}
+			else if (IsValidSpell(e.spellid)) {
 				se.resist_adjust = spells[e.spellid].resist_difficulty;
 			}
 


### PR DESCRIPTION
# Description

the recent commit with npc_spells_entries to add content filtering was setting the repository resist_adj value to 0 overriding the default value of spell resist difficulty.    Also added resist adj to show spells_list to see the what the resist value is.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)


# Testing

before the fix:
 ![image](https://github.com/EQEmu/Server/assets/3778417/e76dfa47-4093-4a77-8938-738378189a4d)

after this fix:
![image](https://github.com/EQEmu/Server/assets/3778417/f465ca88-47f4-4056-877b-d78f780b89fc)

Clients tested: 
RoF2
# Checklist

- [x ] I have tested my changes
- [x ] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I have made corresponding changes to the documentation (if applicable, if not delete this line)
- [x] I own the changes of my code and take responsibility for the potential issues that occur
- [ ] If my changes make database schema changes, I have tested the changes on a local database (attach image). Updated version.h CURRENT_BINARY_DATABASE_VERSION to the new version. (Delete this if not applicable)
