### PR TITLE
[Fix] Validate Character ID on Adventure Awards

### DIFF
--- a/world/adventure.cpp
+++ b/world/adventure.cpp
@@ -282,88 +282,77 @@ void Adventure::IncrementAssassinationCount()
 void Adventure::Finished(AdventureWinStatus ws)
 {
 	auto iter = players.begin();
-	while(iter != players.end())
-	{
+	while (iter != players.end()) {
 		ClientListEntry *current = client_list.FindCharacter((*iter).c_str());
-		if(current)
-		{
-			if(current->Online() == CLE_Status::InZone)
-			{
+		auto character_id = database.GetCharacterID(*iter);
+
+		if (character_id == 0) {
+			continue;
+		}
+
+		if (current) {
+			if (current->Online() == CLE_Status::InZone) {
 				//We can send our packets only.
-				auto pack =
-				    new ServerPacket(ServerOP_AdventureFinish, sizeof(ServerAdventureFinish_Struct));
+				auto pack = new ServerPacket(ServerOP_AdventureFinish, sizeof(ServerAdventureFinish_Struct));
 				ServerAdventureFinish_Struct *af = (ServerAdventureFinish_Struct*)pack->pBuffer;
 				strcpy(af->player, (*iter).c_str());
 				af->theme = GetTemplate()->theme;
-				if(ws == AWS_Win)
-				{
+				if (ws == AWS_Win) {
 					af->win = true;
 					af->points = GetTemplate()->win_points;
 				}
-				else if(ws == AWS_SecondPlace)
-				{
+				else if (ws == AWS_SecondPlace) {
 					af->win = true;
 					af->points = GetTemplate()->lose_points;
 				}
-				else
-				{
+				else {
 					af->win = false;
 					af->points = 0;
 				}
-
 				zoneserver_list.SendPacket(current->zone(), current->instance(), pack);
-				database.UpdateAdventureStatsEntry(database.GetCharacterID((*iter)), GetTemplate()->theme, (ws != AWS_Lose) ? true : false);
+				database.UpdateAdventureStatsEntry(character_id, GetTemplate()->theme, (ws != AWS_Lose) ? true : false);
 				delete pack;
 			}
-			else
-			{
+			else {
 				AdventureFinishEvent afe;
 				afe.name = (*iter);
-				if(ws == AWS_Win)
-				{
+				if (ws == AWS_Win) {
 					afe.theme = GetTemplate()->theme;
 					afe.points = GetTemplate()->win_points;
 					afe.win = true;
 				}
-				else if(ws == AWS_SecondPlace)
-				{
+				else if (ws == AWS_SecondPlace) {
 					afe.theme = GetTemplate()->theme;
 					afe.points = GetTemplate()->lose_points;
 					afe.win = true;
 				}
-				else
-				{
+				else {
 					afe.win = false;
 					afe.points = 0;
 				}
 				adventure_manager.AddFinishedEvent(afe);
-				database.UpdateAdventureStatsEntry(database.GetCharacterID((*iter)), GetTemplate()->theme, (ws != AWS_Lose) ? true : false);
+				database.UpdateAdventureStatsEntry(character_id, GetTemplate()->theme, (ws != AWS_Lose) ? true : false);
 			}
 		}
-		else
-		{
+		else {
 			AdventureFinishEvent afe;
 			afe.name = (*iter);
-			if(ws == AWS_Win)
-			{
+			if (ws == AWS_Win) {
 				afe.theme = GetTemplate()->theme;
 				afe.points = GetTemplate()->win_points;
 				afe.win = true;
 			}
-			else if(ws == AWS_SecondPlace)
-			{
+			else if (ws == AWS_SecondPlace) {
 				afe.theme = GetTemplate()->theme;
 				afe.points = GetTemplate()->lose_points;
 				afe.win = true;
 			}
-			else
-			{
+			else {
 				afe.win = false;
 				afe.points = 0;
 			}
 			adventure_manager.AddFinishedEvent(afe);
-
-			database.UpdateAdventureStatsEntry(database.GetCharacterID((*iter)), GetTemplate()->theme, (ws != AWS_Lose) ? true : false);
+			database.UpdateAdventureStatsEntry(character_id, GetTemplate()->theme, (ws != AWS_Lose) ? true : false);
 		}
 		++iter;
 	}


### PR DESCRIPTION
# Description

As reported by @titanium-forever [on Discord](https://discord.com/channels/212663220849213441/1245124955226640384/1245132433846833274), the server will attempt to award adventure points to bots (Character ID of 0).

![adventure](https://github.com/EQEmu/Server/assets/3617814/237d766e-cb69-4e70-a320-0ad555d94e8a)

This update validates the character id before attempting to update.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Needs testing on server with bots.

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur