### PR TITLE
[Cleanup] Cleanup Bucket Comparison Code

### DIFF
--- a/common/emu_constants.cpp
+++ b/common/emu_constants.cpp
@@ -736,3 +736,13 @@ std::string EQ::constants::GetConsiderColorName(uint32 consider_color)
 	const auto& c = EQ::constants::GetConsiderColorMap().find(consider_color);
 	return c != EQ::constants::GetConsiderColorMap().end() ? c->second : std::string();
 }
+
+const std::string& ComparisonType::GetName(uint8 type)
+{
+	return IsValid(type) ? comparison_types[type] : "UNKNOWN COMPARISON TYPE";
+}
+
+bool ComparisonType::IsValid(uint8 type)
+{
+	return comparison_types.find(type) != comparison_types.end();
+}

--- a/common/emu_constants.cpp
+++ b/common/emu_constants.cpp
@@ -737,7 +737,7 @@ std::string EQ::constants::GetConsiderColorName(uint32 consider_color)
 	return c != EQ::constants::GetConsiderColorMap().end() ? c->second : std::string();
 }
 
-const std::string& ComparisonType::GetName(uint8 type)
+std::string ComparisonType::GetName(uint8 type)
 {
 	return IsValid(type) ? comparison_types[type] : "UNKNOWN COMPARISON TYPE";
 }

--- a/common/emu_constants.h
+++ b/common/emu_constants.h
@@ -26,6 +26,35 @@
 
 #include <string.h>
 
+namespace ComparisonType {
+	constexpr uint8 Equal          = 0;
+	constexpr uint8 NotEqual       = 1;
+	constexpr uint8 GreaterOrEqual = 2;
+	constexpr uint8 LesserOrEqual  = 3;
+	constexpr uint8 Greater        = 4;
+	constexpr uint8 Lesser         = 5;
+	constexpr uint8 Any            = 6;
+	constexpr uint8 NotAny         = 7;
+	constexpr uint8 Between        = 8;
+	constexpr uint8 NotBetween     = 9;
+
+	const std::string& GetName(uint8 type);
+	bool IsValid(uint8 type);
+}
+
+static std::map<uint8, std::string> comparison_types = {
+	{ ComparisonType::Equal,          "Equal" },
+	{ ComparisonType::NotEqual,       "Not Equal" },
+	{ ComparisonType::GreaterOrEqual, "Greater or Equal" },
+	{ ComparisonType::LesserOrEqual,  "Lesser or Equal" },
+	{ ComparisonType::Greater,        "Greater" },
+	{ ComparisonType::Lesser,         "Lesser" },
+	{ ComparisonType::Any,            "Any" },
+	{ ComparisonType::NotAny,         "Not Any" },
+	{ ComparisonType::Between,        "Between" },
+	{ ComparisonType::NotBetween,     "Not Between" },
+};
+
 
 // local definitions are the result of using hybrid-client or server-only values and methods
 namespace EQ
@@ -586,19 +615,6 @@ enum ReloadWorld : uint8 {
 	NoRepop = 0,
 	Repop,
 	ForceRepop
-};
-
-enum BucketComparison : uint8 {
-	BucketEqualTo = 0,
-	BucketNotEqualTo,
-	BucketGreaterThanOrEqualTo,
-	BucketLesserThanOrEqualTo,
-	BucketGreaterThan,
-	BucketLesserThan,
-	BucketIsAny,
-	BucketIsNotAny,
-	BucketIsBetween,
-	BucketIsNotBetween
 };
 
 enum class EntityFilterType {

--- a/common/emu_constants.h
+++ b/common/emu_constants.h
@@ -38,7 +38,7 @@ namespace ComparisonType {
 	constexpr uint8 Between        = 8;
 	constexpr uint8 NotBetween     = 9;
 
-	const std::string& GetName(uint8 type);
+	std::string GetName(uint8 type);
 	bool IsValid(uint8 type);
 }
 

--- a/common/repositories/command_subsettings_repository.h
+++ b/common/repositories/command_subsettings_repository.h
@@ -51,6 +51,7 @@ public:
 			{.parent_command = "find", .sub_command = "aa", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "findaa"},
 			{.parent_command = "find", .sub_command = "character", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "findcharacter"},
 			{.parent_command = "find", .sub_command = "class", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "findclass"},
+			{.parent_command = "find", .sub_command = "comparison_type", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "findcomparisontype"},
 			{.parent_command = "find", .sub_command = "currency", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "findcurrency"},
 			{.parent_command = "find", .sub_command = "deity", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "finddeity"},
 			{.parent_command = "find", .sub_command = "emote", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "findemote"},

--- a/zone/gm_commands/find.cpp
+++ b/zone/gm_commands/find.cpp
@@ -2,6 +2,7 @@
 #include "find/aa.cpp"
 #include "find/character.cpp"
 #include "find/class.cpp"
+#include "find/comparison_type.cpp"
 #include "find/currency.cpp"
 #include "find/deity.cpp"
 #include "find/emote.cpp"
@@ -32,6 +33,7 @@ void command_find(Client *c, const Seperator *sep)
 		Cmd{.cmd = "aa", .u = "aa [Search Criteria]", .fn = FindAA, .a = {"#findaa"}},
 		Cmd{.cmd = "character", .u = "character [Search Criteria]", .fn = FindCharacter, .a = {"#findcharacter"}},
 		Cmd{.cmd = "class", .u = "class [Search Criteria]", .fn = FindClass, .a = {"#findclass"}},
+		Cmd{.cmd = "comparison_type", .u = "comparison_type [Search Criteria]", .fn = FindComparisonType, .a = {"#findcomparisontype"}},
 		Cmd{.cmd = "currency", .u = "currency [Search Criteria]", .fn = FindCurrency, .a = {"#findcurrency"}},
 		Cmd{.cmd = "deity", .u = "deity [Search Criteria]", .fn = FindDeity, .a = {"#finddeity"}},
 		Cmd{.cmd = "emote", .u = "emote [Search Criteria]", .fn = FindEmote, .a = {"#findemote"}},

--- a/zone/gm_commands/find/comparison_type.cpp
+++ b/zone/gm_commands/find/comparison_type.cpp
@@ -1,0 +1,63 @@
+#include "../../client.h"
+
+void FindComparisonType(Client *c, const Seperator *sep)
+{
+	if (sep->IsNumber(2)) {
+		const uint8 type = static_cast<uint8>(Strings::ToUnsignedInt(sep->arg[2]));
+		const std::string& type_name = ComparisonType::GetName(type);
+		if (Strings::EqualFold(type_name, "UNKNOWN COMPARISON TYPE")) {
+			c->Message(
+				Chat::White,
+				fmt::format(
+					"Comparison Type {} does not exist.",
+					type
+				).c_str()
+			);
+
+			return;
+		}
+
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"Comparison Type {} | {}",
+				type,
+				type_name
+			).c_str()
+		);
+
+		return;
+	}
+
+	const std::string& search_criteria = Strings::ToLower(sep->argplus[2]);
+
+	uint32 found_count = 0;
+
+	for (const auto& e : comparison_types) {
+		const std::string& type_name_lower = Strings::ToLower(e.second);
+		if (!Strings::Contains(type_name_lower, search_criteria)) {
+			continue;
+		}
+
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"Comparison Type {} | {}",
+				e.first,
+				e.second
+			).c_str()
+		);
+
+		found_count++;
+	}
+
+	c->Message(
+		Chat::White,
+		fmt::format(
+			"{} Comparison Type{} found matching '{}'.",
+			found_count,
+			found_count != 1 ? "s" : "",
+			sep->argplus[2]
+		).c_str()
+	);
+}

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -334,7 +334,7 @@ public:
 	bool IsQuestHotReloadQueued() const;
 	void SetQuestHotReloadQueued(bool in_quest_hot_reload_queued);
 
-	bool CompareDataBucket(uint8 bucket_comparison, const std::string& bucket_value, const std::string& player_value);
+	bool CompareDataBucket(uint8 comparison_type, const std::string& bucket, const std::string& value);
 
 	WaterMap *watermap;
 	ZonePoint *GetClosestZonePoint(const glm::vec3 &location, uint32 to, Client *client, float max_distance = 40000.0f);


### PR DESCRIPTION
# Description
- Introduces a `ComparisonType` namespace for bucket comparisons instead of an enum like we had before.
- Cleans up a lot of the logic in finding a comparison type, checking for a valid comparison type, etc.
- Adds `#find comparison_type` subcommand.

## Type of Change
- [X] New feature

# Testing
![image](https://github.com/EQEmu/Server/assets/89047260/19c1bfdc-b4c1-4d6e-894f-60522d342e35)

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur