### PR TITLE
[Cleanup] Cleanup Account Status Code

### DIFF
--- a/common/emu_constants.cpp
+++ b/common/emu_constants.cpp
@@ -206,62 +206,6 @@ std::string EQ::constants::GetFlyModeName(int8 flymode_id)
 	return EQ::constants::GetFlyModeMap().find(flymode_id)->second;
 }
 
-const std::map<bodyType, std::string>& EQ::constants::GetBodyTypeMap()
-{
-	static const std::map<bodyType, std::string> bodytype_map = {
-		{ BT_Humanoid, "Humanoid" },
-		{ BT_Lycanthrope, "Lycanthrope" },
-		{ BT_Undead, "Undead" },
-		{ BT_Giant, "Giant" },
-		{ BT_Construct, "Construct" },
-		{ BT_Extraplanar, "Extraplanar" },
-		{ BT_Magical, "Magical" },
-		{ BT_SummonedUndead, "Summoned Undead" },
-		{ BT_RaidGiant, "Raid Giant" },
-		{ BT_RaidColdain, "Raid Coldain" },
-		{ BT_NoTarget, "Untargetable" },
-		{ BT_Vampire, "Vampire" },
-		{ BT_Atenha_Ra, "Aten Ha Ra" },
-		{ BT_Greater_Akheva, "Greater Akheva" },
-		{ BT_Khati_Sha, "Khati Sha" },
-		{ BT_Seru, "Seru" },
-		{ BT_Grieg_Veneficus, "Grieg Veneficus" },
-		{ BT_Draz_Nurakk, "Draz Nurakk" },
-		{ BT_Zek, "Zek" },
-		{ BT_Luggald, "Luggald" },
-		{ BT_Animal, "Animal" },
-		{ BT_Insect, "Insect" },
-		{ BT_Monster, "Monster" },
-		{ BT_Summoned, "Summoned" },
-		{ BT_Plant, "Plant" },
-		{ BT_Dragon, "Dragon" },
-		{ BT_Summoned2, "Summoned 2" },
-		{ BT_Summoned3, "Summoned 3" },
-		{ BT_Dragon2, "Dragon 2" },
-		{ BT_VeliousDragon, "Velious Dragon" },
-		{ BT_Familiar, "Familiar" },
-		{ BT_Dragon3, "Dragon 3" },
-		{ BT_Boxes, "Boxes" },
-		{ BT_Muramite, "Muramite" },
-		{ BT_NoTarget2, "Untargetable 2" },
-		{ BT_SwarmPet, "Swarm Pet" },
-		{ BT_MonsterSummon, "Monster Summon" },
-		{ BT_InvisMan, "Invisible Man" },
-		{ BT_Special, "Special" },
-	};
-
-	return bodytype_map;
-}
-
-std::string EQ::constants::GetBodyTypeName(bodyType bodytype_id)
-{
-	if (EQ::constants::GetBodyTypeMap().find(bodytype_id) != EQ::constants::GetBodyTypeMap().end()) {
-		return EQ::constants::GetBodyTypeMap().find(bodytype_id)->second;
-	}
-
-	return std::string();
-}
-
 const std::map<uint8, std::string>& EQ::constants::GetConsiderLevelMap()
 {
 	static const std::map<uint8, std::string> consider_level_map = {

--- a/common/emu_constants.cpp
+++ b/common/emu_constants.cpp
@@ -206,41 +206,57 @@ std::string EQ::constants::GetFlyModeName(int8 flymode_id)
 	return EQ::constants::GetFlyModeMap().find(flymode_id)->second;
 }
 
-const std::map<uint8, std::string>& EQ::constants::GetAccountStatusMap()
+const std::map<bodyType, std::string>& EQ::constants::GetBodyTypeMap()
 {
-	static const std::map<uint8, std::string> account_status_map = {
-		{ AccountStatus::Player, "Player" },
-		{ AccountStatus::Steward, "Steward" },
-		{ AccountStatus::ApprenticeGuide, "Apprentice Guide" },
-		{ AccountStatus::Guide, "Guide" },
-		{ AccountStatus::QuestTroupe, "Quest Troupe" },
-		{ AccountStatus::SeniorGuide, "Senior Guide" },
-		{ AccountStatus::GMTester, "GM Tester" },
-		{ AccountStatus::EQSupport, "EQ Support" },
-		{ AccountStatus::GMStaff, "GM Staff" },
-		{ AccountStatus::GMAdmin, "GM Admin" },
-		{ AccountStatus::GMLeadAdmin, "GM Lead Admin" },
-		{ AccountStatus::QuestMaster, "Quest Master" },
-		{ AccountStatus::GMAreas, "GM Areas" },
-		{ AccountStatus::GMCoder, "GM Coder" },
-		{ AccountStatus::GMMgmt, "GM Mgmt" },
-		{ AccountStatus::GMImpossible, "GM Impossible" },
-		{ AccountStatus::Max, "GM Max" }
+	static const std::map<bodyType, std::string> bodytype_map = {
+		{ BT_Humanoid, "Humanoid" },
+		{ BT_Lycanthrope, "Lycanthrope" },
+		{ BT_Undead, "Undead" },
+		{ BT_Giant, "Giant" },
+		{ BT_Construct, "Construct" },
+		{ BT_Extraplanar, "Extraplanar" },
+		{ BT_Magical, "Magical" },
+		{ BT_SummonedUndead, "Summoned Undead" },
+		{ BT_RaidGiant, "Raid Giant" },
+		{ BT_RaidColdain, "Raid Coldain" },
+		{ BT_NoTarget, "Untargetable" },
+		{ BT_Vampire, "Vampire" },
+		{ BT_Atenha_Ra, "Aten Ha Ra" },
+		{ BT_Greater_Akheva, "Greater Akheva" },
+		{ BT_Khati_Sha, "Khati Sha" },
+		{ BT_Seru, "Seru" },
+		{ BT_Grieg_Veneficus, "Grieg Veneficus" },
+		{ BT_Draz_Nurakk, "Draz Nurakk" },
+		{ BT_Zek, "Zek" },
+		{ BT_Luggald, "Luggald" },
+		{ BT_Animal, "Animal" },
+		{ BT_Insect, "Insect" },
+		{ BT_Monster, "Monster" },
+		{ BT_Summoned, "Summoned" },
+		{ BT_Plant, "Plant" },
+		{ BT_Dragon, "Dragon" },
+		{ BT_Summoned2, "Summoned 2" },
+		{ BT_Summoned3, "Summoned 3" },
+		{ BT_Dragon2, "Dragon 2" },
+		{ BT_VeliousDragon, "Velious Dragon" },
+		{ BT_Familiar, "Familiar" },
+		{ BT_Dragon3, "Dragon 3" },
+		{ BT_Boxes, "Boxes" },
+		{ BT_Muramite, "Muramite" },
+		{ BT_NoTarget2, "Untargetable 2" },
+		{ BT_SwarmPet, "Swarm Pet" },
+		{ BT_MonsterSummon, "Monster Summon" },
+		{ BT_InvisMan, "Invisible Man" },
+		{ BT_Special, "Special" },
 	};
 
-	return account_status_map;
+	return bodytype_map;
 }
 
-std::string EQ::constants::GetAccountStatusName(uint8 account_status)
+std::string EQ::constants::GetBodyTypeName(bodyType bodytype_id)
 {
-	for (
-		auto status_level = EQ::constants::GetAccountStatusMap().rbegin();
-		status_level != EQ::constants::GetAccountStatusMap().rend();
-		++status_level
-	) {
-		if (account_status >= status_level->first) {
-			return status_level->second;
-		}
+	if (EQ::constants::GetBodyTypeMap().find(bodytype_id) != EQ::constants::GetBodyTypeMap().end()) {
+		return EQ::constants::GetBodyTypeMap().find(bodytype_id)->second;
 	}
 
 	return std::string();
@@ -571,6 +587,21 @@ std::string EQ::constants::GetConsiderColorName(uint32 consider_color)
 {
 	const auto& c = EQ::constants::GetConsiderColorMap().find(consider_color);
 	return c != EQ::constants::GetConsiderColorMap().end() ? c->second : std::string();
+}
+
+std::string AccountStatus::GetName(uint8 account_status)
+{
+	for (
+		auto e = account_status_names.rbegin();
+		e != account_status_names.rend();
+		++e
+	) {
+		if (account_status >= e->first) {
+			return e->second;
+		}
+	}
+
+	return "UNKNOWN ACCOUNT STATUS";
 }
 
 std::string ComparisonType::GetName(uint8 type)

--- a/common/emu_constants.h
+++ b/common/emu_constants.h
@@ -26,6 +26,48 @@
 
 #include <string.h>
 
+namespace AccountStatus {
+	constexpr uint8 Player          = 0;
+	constexpr uint8 Steward         = 10;
+	constexpr uint8 ApprenticeGuide = 20;
+	constexpr uint8 Guide           = 50;
+	constexpr uint8 QuestTroupe     = 80;
+	constexpr uint8 SeniorGuide     = 81;
+	constexpr uint8 GMTester        = 85;
+	constexpr uint8 EQSupport       = 90;
+	constexpr uint8 GMStaff         = 95;
+	constexpr uint8 GMAdmin         = 100;
+	constexpr uint8 GMLeadAdmin     = 150;
+	constexpr uint8 QuestMaster     = 160;
+	constexpr uint8 GMAreas         = 170;
+	constexpr uint8 GMCoder         = 180;
+	constexpr uint8 GMMgmt          = 200;
+	constexpr uint8 GMImpossible    = 250;
+	constexpr uint8 Max             = 255;
+
+	std::string GetName(uint8 account_status);
+}
+
+static std::map<uint8, std::string> account_status_names = {
+	{ AccountStatus::Player,          "Player" },
+	{ AccountStatus::Steward,         "Steward" },
+	{ AccountStatus::ApprenticeGuide, "Apprentice Guide" },
+	{ AccountStatus::Guide,           "Guide" },
+	{ AccountStatus::QuestTroupe,     "Quest Troupe" },
+	{ AccountStatus::SeniorGuide,     "Senior Guide" },
+	{ AccountStatus::GMTester,        "GM Tester" },
+	{ AccountStatus::EQSupport,       "EQ Support" },
+	{ AccountStatus::GMStaff,         "GM Staff" },
+	{ AccountStatus::GMAdmin,         "GM Admin" },
+	{ AccountStatus::GMLeadAdmin,     "GM Lead Admin" },
+	{ AccountStatus::QuestMaster,     "Quest Master" },
+	{ AccountStatus::GMAreas,         "GM Areas" },
+	{ AccountStatus::GMCoder,         "GM Coder" },
+	{ AccountStatus::GMMgmt,          "GM Mgmt" },
+	{ AccountStatus::GMImpossible,    "GM Impossible" },
+	{ AccountStatus::Max,             "GM Max" }
+};
+
 namespace ComparisonType {
 	constexpr uint8 Equal          = 0;
 	constexpr uint8 NotEqual       = 1;
@@ -52,9 +94,8 @@ static std::map<uint8, std::string> comparison_types = {
 	{ ComparisonType::Any,            "Any" },
 	{ ComparisonType::NotAny,         "Not Any" },
 	{ ComparisonType::Between,        "Between" },
-	{ ComparisonType::NotBetween,     "Not Between" },
+	{ ComparisonType::NotBetween,     "Not Between" }
 };
-
 
 // local definitions are the result of using hybrid-client or server-only values and methods
 namespace EQ
@@ -507,26 +548,6 @@ enum ServerLockType : int {
 	List,
 	Lock,
 	Unlock
-};
-
-enum AccountStatus : uint8 {
-	Player = 0,
-	Steward = 10,
-	ApprenticeGuide = 20,
-	Guide = 50,
-	QuestTroupe = 80,
-	SeniorGuide = 81,
-	GMTester = 85,
-	EQSupport = 90,
-	GMStaff = 95,
-	GMAdmin = 100,
-	GMLeadAdmin = 150,
-	QuestMaster = 160,
-	GMAreas = 170,
-	GMCoder = 180,
-	GMMgmt = 200,
-	GMImpossible = 250,
-	Max = 255
 };
 
 enum Invisibility : uint8 {

--- a/common/emu_constants.h
+++ b/common/emu_constants.h
@@ -94,7 +94,7 @@ static std::map<uint8, std::string> comparison_types = {
 	{ ComparisonType::Any,            "Any" },
 	{ ComparisonType::NotAny,         "Not Any" },
 	{ ComparisonType::Between,        "Between" },
-	{ ComparisonType::NotBetween,     "Not Between" }
+	{ ComparisonType::NotBetween,     "Not Between" },
 };
 
 // local definitions are the result of using hybrid-client or server-only values and methods

--- a/zone/gm_commands/show/who.cpp
+++ b/zone/gm_commands/show/who.cpp
@@ -174,7 +174,7 @@ void ShowWho(Client *c, const Seperator *sep)
 			account_status ?
 			fmt::format(
 				"* {} * ",
-				EQ::constants::GetAccountStatusName(account_status)
+				AccountStatus::GetName(account_status)
 			) :
 			""
 		);


### PR DESCRIPTION
# Description
- Introduces a `AccountStatus` namespace for object types instead of an enum like we had before.

## Type of Change
- [X] New feature

# Testing
![image](https://github.com/EQEmu/Server/assets/89047260/3c702837-b9e4-4070-aec5-73de2d8e5882)

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur