### PR TITLE
[Skills] Fix caps out of bounds issue

### DIFF
--- a/client_files/export/main.cpp
+++ b/client_files/export/main.cpp
@@ -32,6 +32,7 @@
 #include "../../common/repositories/skill_caps_repository.h"
 #include "../../common/file.h"
 #include "../../common/events/player_event_logs.h"
+#include "../../common/skill_caps.h"
 
 EQEmuLogSys         LogSys;
 WorldContentService content_service;
@@ -213,17 +214,16 @@ void ExportSkillCaps(SharedDatabase* db)
 		return;
 	}
 
-	const uint8 skill_cap_max_level = (
-		RuleI(Character, SkillCapMaxLevel) > 0 ?
-		RuleI(Character, SkillCapMaxLevel) :
-		RuleI(Character, MaxLevel)
-	);
-
 	for (uint8 class_id = Class::Warrior; class_id <= Class::Berserker; class_id++) {
 		for (uint8 skill_id = EQ::skills::Skill1HBlunt; skill_id <= EQ::skills::Skill2HPiercing; skill_id++) {
 			if (SkillUsable(db, skill_id, class_id)) {
 				uint32 previous_cap = 0;
-				for (uint8 level = 1; level <= skill_cap_max_level; level++) {
+
+				for (
+					uint8 level = 1;
+					level <= SkillCaps::GetSkillCapMaxLevel(class_id, static_cast<EQ::skills::SkillType>(skill_id));
+					level++
+					) {
 					uint32 cap = GetSkill(db, skill_id, class_id, level);
 					if (cap < previous_cap) {
 						cap = previous_cap;

--- a/common/skill_caps.cpp
+++ b/common/skill_caps.cpp
@@ -1,11 +1,30 @@
 #include "skill_caps.h"
 #include "timer.h"
 
+std::map<uint8_t, int32_t> skill_max_level = {};
+
 SkillCaps *SkillCaps::SetContentDatabase(Database *db)
 {
 	m_content_database = db;
 
 	return this;
+}
+
+int32_t SkillCaps::GetSkillCapMaxLevel(uint8 class_id, EQ::skills::SkillType skill_id)
+{
+	const uint32 class_count = Class::PLAYER_CLASS_COUNT;
+	const uint32 skill_count = EQ::skills::HIGHEST_SKILL + 1;
+	if (class_id > class_count || static_cast<uint32>(skill_id) > skill_count) {
+		return 0;
+	}
+
+	const int max_level_key = (class_id * 1000000) + skill_id;
+	auto it = skill_max_level.find(max_level_key);
+	if (it != skill_max_level.end()) {
+		return it->second;
+	}
+
+	return RuleI(Character, MaxLevel);
 }
 
 SkillCapsRepository::SkillCaps SkillCaps::GetSkillCap(uint8 class_id, EQ::skills::SkillType skill_id, uint8 level)
@@ -14,8 +33,18 @@ SkillCapsRepository::SkillCaps SkillCaps::GetSkillCap(uint8 class_id, EQ::skills
 		return SkillCapsRepository::NewEntity();
 	}
 
-	const uint64_t key = (class_id * 1000000) + (level * 1000) + static_cast<uint32>(skill_id);
+	const uint32 class_count = Class::PLAYER_CLASS_COUNT;
+	const uint32 skill_count = EQ::skills::HIGHEST_SKILL + 1;
+	if (class_id > class_count || static_cast<uint32>(skill_id) > skill_count) {
+		return SkillCapsRepository::NewEntity();
+	}
 
+	const uint8 skill_cap_max_level = GetSkillCapMaxLevel(class_id, skill_id);
+	if (level > skill_cap_max_level) {
+		level = skill_cap_max_level;
+	}
+
+	const uint64_t key = (class_id * 1000000) + (level * 1000) + static_cast<uint32>(skill_id);
 	auto pos = m_skill_caps.find(key);
 	if (pos != m_skill_caps.end()) {
 		return pos->second;
@@ -70,6 +99,18 @@ void SkillCaps::LoadSkillCaps()
 
 		const uint64_t key = (e.class_id * 1000000) + (e.level * 1000) + e.skill_id;
 		m_skill_caps[key] = e;
+
+		const int max_level_key = (e.class_id * 1000000) + e.skill_id;
+		auto it = skill_max_level.find(max_level_key);
+		if (it != skill_max_level.end()) {
+			// Key found, update the value if the new level is higher
+			if (e.level > it->second) {
+				it->second = e.level;
+			}
+		} else {
+			// Key not found, insert the new key-value pair
+			skill_max_level[max_level_key] = e.level;
+		}
 	}
 
 	LogInfo(

--- a/common/skill_caps.h
+++ b/common/skill_caps.h
@@ -13,6 +13,7 @@ public:
 	uint8 GetSkillTrainLevel(uint8 class_id, EQ::skills::SkillType skill_id, uint8 level);
 	void LoadSkillCaps();
 	void ReloadSkillCaps();
+	static int32_t GetSkillCapMaxLevel(uint8 class_id, EQ::skills::SkillType skill_id);
 
 	SkillCaps *SetContentDatabase(Database *db);
 private:


### PR DESCRIPTION
# Description

This fixes out of bounds data issues with skill caps where if an NPC or a Clients level is outside of the max defined skill levels defined in the database, we return 0 values as reported by @fryguy503 

This restores logic we had previously https://github.com/EQEmu/Server/blob/e06c7d7735184d6e1807f7aa12aba1b71634de4f/common/shareddb.cpp#L1837-L1865

This also adds logic to cache skill cap max values per class / skill id pair during load.

To get max value, we anchor to max that is available in the database. We always honor what's defined in rules as max.

In the situation Trust had, his skill caps only went to level 70 and his rule max was 75. NPC's were returning 0 above level 70.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Awaiting test confirmation from @fryguy503 

Skills show proper values when beyond defined level of 100, they anchor to 100

![image](https://github.com/EQEmu/Server/assets/3319450/51935ebd-0542-4411-9acb-56e14a0f5d60)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur