### PR TITLE
[Quests] Fix issue with Lua encounters loading in certain circumstances

### DIFF
--- a/zone/quest_parser_collection.cpp
+++ b/zone/quest_parser_collection.cpp
@@ -116,7 +116,7 @@ bool QuestParserCollection::HasQuestSub(uint32 npc_id, QuestEventID event_id)
 
 bool QuestParserCollection::NPCHasEncounterSub(uint32 npc_id, QuestEventID event_id)
 {
-	return HasEncounterSub(event_id, fmt::format("npc_{}", npc_id)) || HasEncounterSub(event_id, "npc_-1");
+	return HasEncounterSub(event_id, fmt::format("npc_{}", npc_id)) || HasEncounterSub(event_id, "npc_" + ENCOUNTER_NO_ENTITY_ID);
 }
 
 bool QuestParserCollection::HasQuestSubLocal(uint32 npc_id, QuestEventID event_id)
@@ -228,7 +228,8 @@ bool QuestParserCollection::PlayerHasQuestSubGlobal(QuestEventID event_id)
 
 bool QuestParserCollection::SpellHasEncounterSub(uint32 spell_id, QuestEventID event_id)
 {
-	return HasEncounterSub(event_id, fmt::format("spell_{}", spell_id)) || HasEncounterSub(event_id, "spell_-1");
+	return HasEncounterSub(event_id, fmt::format("spell_{}", spell_id)) ||
+		   HasEncounterSub(event_id, "spell_" + ENCOUNTER_NO_ENTITY_ID);
 }
 
 bool QuestParserCollection::SpellHasQuestSub(uint32 spell_id, QuestEventID event_id)
@@ -260,10 +261,11 @@ bool QuestParserCollection::SpellHasQuestSub(uint32 spell_id, QuestEventID event
 	return false;
 }
 
-bool QuestParserCollection::ItemHasEncounterSub(EQ::ItemInstance* inst, QuestEventID event_id)
+bool QuestParserCollection::ItemHasEncounterSub(EQ::ItemInstance *inst, QuestEventID event_id)
 {
 	if (inst) {
-		return HasEncounterSub(event_id, fmt::format("item_{}", inst->GetID())) || HasEncounterSub(event_id, "item_-1");
+		return HasEncounterSub(event_id, fmt::format("item_{}", inst->GetID())) ||
+			   HasEncounterSub(event_id, "item_" + ENCOUNTER_NO_ENTITY_ID);
 	}
 
 	return false;

--- a/zone/quest_parser_collection.cpp
+++ b/zone/quest_parser_collection.cpp
@@ -35,7 +35,7 @@
 // this represents the object not being loaded yet
 // eq.register_npc_event(Event.death_complete, -1, AllDeath);
 // eq.register_npc_event(Event.say, -1, All_Say);
-std::string ENCOUNTER_NO_ENTITY_ID = "-1";
+const std::string ENCOUNTER_NO_ENTITY_ID = "-1";
 
 extern Zone* zone;
 extern void MapOpcodes();

--- a/zone/quest_parser_collection.cpp
+++ b/zone/quest_parser_collection.cpp
@@ -116,13 +116,7 @@ bool QuestParserCollection::HasQuestSub(uint32 npc_id, QuestEventID event_id)
 
 bool QuestParserCollection::NPCHasEncounterSub(uint32 npc_id, QuestEventID event_id)
 {
-	return HasEncounterSub(
-		event_id,
-		fmt::format(
-			"npc_{}",
-			npc_id
-		)
-	);
+	return HasEncounterSub(event_id, fmt::format("npc_{}", npc_id)) || HasEncounterSub(event_id, "npc_-1");
 }
 
 bool QuestParserCollection::HasQuestSubLocal(uint32 npc_id, QuestEventID event_id)
@@ -234,13 +228,7 @@ bool QuestParserCollection::PlayerHasQuestSubGlobal(QuestEventID event_id)
 
 bool QuestParserCollection::SpellHasEncounterSub(uint32 spell_id, QuestEventID event_id)
 {
-	return HasEncounterSub(
-		event_id,
-		fmt::format(
-			"spell_{}",
-			spell_id
-		)
-	);
+	return HasEncounterSub(event_id, fmt::format("spell_{}", spell_id)) || HasEncounterSub(event_id, "spell_-1");
 }
 
 bool QuestParserCollection::SpellHasQuestSub(uint32 spell_id, QuestEventID event_id)
@@ -275,13 +263,7 @@ bool QuestParserCollection::SpellHasQuestSub(uint32 spell_id, QuestEventID event
 bool QuestParserCollection::ItemHasEncounterSub(EQ::ItemInstance* inst, QuestEventID event_id)
 {
 	if (inst) {
-		return HasEncounterSub(
-			event_id,
-			fmt::format(
-				"item_{}",
-				inst->GetID()
-			)
-		);
+		return return HasEncounterSub(event_id, fmt::format("item_{}", inst->GetID())) || HasEncounterSub(event_id, "item_-1");
 	}
 
 	return false;

--- a/zone/quest_parser_collection.cpp
+++ b/zone/quest_parser_collection.cpp
@@ -32,7 +32,7 @@
 #include <stdio.h>
 
 // an encounter can register events before the object is loaded
-// this represents the object not being loaded yet
+// examples
 // eq.register_npc_event(Event.death_complete, -1, AllDeath);
 // eq.register_npc_event(Event.say, -1, All_Say);
 const std::string ENCOUNTER_NO_ENTITY_ID = "-1";

--- a/zone/quest_parser_collection.cpp
+++ b/zone/quest_parser_collection.cpp
@@ -263,7 +263,7 @@ bool QuestParserCollection::SpellHasQuestSub(uint32 spell_id, QuestEventID event
 bool QuestParserCollection::ItemHasEncounterSub(EQ::ItemInstance* inst, QuestEventID event_id)
 {
 	if (inst) {
-		return return HasEncounterSub(event_id, fmt::format("item_{}", inst->GetID())) || HasEncounterSub(event_id, "item_-1");
+		return HasEncounterSub(event_id, fmt::format("item_{}", inst->GetID())) || HasEncounterSub(event_id, "item_-1");
 	}
 
 	return false;

--- a/zone/quest_parser_collection.cpp
+++ b/zone/quest_parser_collection.cpp
@@ -31,6 +31,12 @@
 
 #include <stdio.h>
 
+// an encounter can register events before the object is loaded
+// this represents the object not being loaded yet
+// eq.register_npc_event(Event.death_complete, -1, AllDeath);
+// eq.register_npc_event(Event.say, -1, All_Say);
+std::string ENCOUNTER_NO_ENTITY_ID = "-1";
+
 extern Zone* zone;
 extern void MapOpcodes();
 

--- a/zone/quest_parser_collection.h
+++ b/zone/quest_parser_collection.h
@@ -42,12 +42,6 @@
 #define QuestFailedToLoad 0xFFFFFFFF
 #define QuestUnloaded 0x00
 
-// an encounter can register events before the object is loaded
-// this represents the object not being loaded yet
-// eq.register_npc_event(Event.death_complete, -1, AllDeath);
-// eq.register_npc_event(Event.say, -1, All_Say);
-std::string ENCOUNTER_NO_ENTITY_ID = "-1";
-
 extern const ZoneConfig *Config;
 class Client;
 class Mob;

--- a/zone/quest_parser_collection.h
+++ b/zone/quest_parser_collection.h
@@ -42,6 +42,12 @@
 #define QuestFailedToLoad 0xFFFFFFFF
 #define QuestUnloaded 0x00
 
+// an encounter can register events before the object is loaded
+// this represents the object not being loaded yet
+// eq.register_npc_event(Event.death_complete, -1, AllDeath);
+// eq.register_npc_event(Event.say, -1, All_Say);
+std::string ENCOUNTER_NO_ENTITY_ID = "-1";
+
 extern const ZoneConfig *Config;
 class Client;
 class Mob;


### PR DESCRIPTION
# Description

This fixes an issue with encounters loading properly in certain circumstances. When events get registered, we may not have an entity loaded at the time of registration which can keep things from being fully loaded. This is related to other fixes that have occurred recently to fix other quest related issues.

We load quests earlier now because we need to load quests before NPC's are spawned. This is to ensure the latest quests are loaded and available and also ensures that quests are loaded and available prior to all NPC's being spawned.

Code credit to @hgtw 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

@fryguy503 can attach is related testing

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
