### PR TITLE
[Fix] Bazaar Search not working correctly for Iksar, Vashir, Drakkin and Froglok races

### DIFF
--- a/common/bazaar.cpp
+++ b/common/bazaar.cpp
@@ -314,7 +314,7 @@ Bazaar::GetSearchResults(
 			},
 			{
 				.should_check = search.race != 0xFFFFFFFF,
-				.condition = static_cast<bool>(item->Races & GetPlayerRaceBit(search.race))
+				.condition = static_cast<bool>(item->Races & GetPlayerRaceBit(GetRaceIDFromPlayerRaceValue(search.race)))
 			},
 			{
 				.should_check = search.augment != 0,


### PR DESCRIPTION
The Bazaar Search feature by race was not working correctly for iskar, froglok, vahshir and drakkin due to the conversion between player race and server race.  This conversion was not accounted for and has been corrected.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
The following image is a search by race = vahshir for a hammer of scourge which is useable by Vahshir.  Previously, this search would return no items.

![image](https://github.com/EQEmu/Server/assets/65987027/44962f3d-0399-4d9f-b06f-edd39d9958ef)

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
