### PR TITLE
[Rule] Snare Override Movement Bonus

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -506,7 +506,7 @@ RULE_INT(Spells, HarmTouchCritRatio, 200, "Harmtouch crit bonus, on top of BaseC
 RULE_BOOL(Spells, UseClassicSpellFocus, false, "Enabling will tell the server to handle random focus damage as classic spell imports lack the limit values.")
 RULE_BOOL(Spells, ManaTapsOnAnyClass, false, "Enabling this will allow you to cast mana taps on any class, this will bypass ManaTapsRequireNPCMana rule.")
 RULE_INT(Spells, HealAmountMessageFilterThreshold, 100, "Lifetaps below this threshold will not have a message sent to the client (Heal will still process) 0 to Disable.")
-RULE_BOOL(Spells, AllowSnareEffectsOverrideBonus, false, "Enabling will allow snares to override any speed bonuses the entity may have. Default: False")
+RULE_BOOL(Spells, SnareOverridesSpeedBonuses, false, "Enabling will allow snares to override any speed bonuses the entity may have. Default: False")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Combat)

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -506,6 +506,7 @@ RULE_INT(Spells, HarmTouchCritRatio, 200, "Harmtouch crit bonus, on top of BaseC
 RULE_BOOL(Spells, UseClassicSpellFocus, false, "Enabling will tell the server to handle random focus damage as classic spell imports lack the limit values.")
 RULE_BOOL(Spells, ManaTapsOnAnyClass, false, "Enabling this will allow you to cast mana taps on any class, this will bypass ManaTapsRequireNPCMana rule.")
 RULE_INT(Spells, HealAmountMessageFilterThreshold, 100, "Lifetaps below this threshold will not have a message sent to the client (Heal will still process) 0 to Disable.")
+RULE_BOOL(Spells, AllowSnareEffectsOverrideBonus, false, "Enabling will allow snares to override any speed bonuses the entity may have. Default: False")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Combat)

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -2438,6 +2438,10 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 			case SE_CastingLevel2:
 			{
 				new_bonus->effective_casting_level += effect_value;
+
+				if (RuleB(Spells, AllowSnareEffectsOverrideBonus) && effect_value < 0) {
+					new_bonus->movementspeed = effect_value;
+				}
 				break;
 			}
 

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -2439,7 +2439,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 			{
 				new_bonus->effective_casting_level += effect_value;
 
-				if (RuleB(Spells, AllowSnareEffectsOverrideBonus) && effect_value < 0) {
+				if (RuleB(Spells, SnareOverridesSpeedBonuses) && effect_value < 0) {
 					new_bonus->movementspeed = effect_value;
 				}
 				break;


### PR DESCRIPTION
# Description

This rule allows snare to override any movement bonuses.

RULE_BOOL(Spells, AllowSnareEffectsOverrideBonus, false, "Enabling will allow snares to override any speed bonuses the entity may have. Default: False")

Default: False

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
