### PR TITLE
[Bug Fix] Fix Swarm Pet Damage Messages

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -4593,10 +4593,10 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 		//this was done to simplify the code here (since we can only effectively skip one mob on queue)
 		eqFilterType filter;
 		Mob* skip = attacker;
-		if (attacker && attacker->IsPet() && !attacker->IsBot()) {
+		Mob* owner = attacker ? attacker->GetOwner() : nullptr;
+		if (attacker && owner && !attacker->IsBot()) {
 			//attacker is a pet, let pet owners see their pet's damage
-			Mob* owner = attacker->GetOwner();
-			if (owner && owner->IsClient()) {
+			if (owner->IsClient()) {
 				if (FromDamageShield && damage > 0) {
 					//special crap for spell damage, looks hackish to me
 					char val1[20] = { 0 };


### PR DESCRIPTION
# Description
- Fixes an issue where swarm pets were not properly sending damage messages due to `IsPet()` being used instead of `GetOwner()`.

## Type of Change
- [X] Bug fix

# Testing
- Confirmed fixed and tested by @noudess.

# Checklist
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur