### PR TITLE
[Cleanup] Remove unused code in emu_constants.h

### DIFF
--- a/common/emu_constants.h
+++ b/common/emu_constants.h
@@ -438,9 +438,6 @@ namespace EQ
 		extern const std::map<int8, std::string>& GetFlyModeMap();
 		std::string GetFlyModeName(int8 flymode_id);
 
-		extern const std::map<uint8, std::string>& GetAccountStatusMap();
-		std::string GetAccountStatusName(uint8 account_status);
-
 		extern const std::map<uint8, std::string>& GetConsiderLevelMap();
 		std::string GetConsiderLevelName(uint8 consider_level);
 


### PR DESCRIPTION
# Description
- Remove unused code that was missed as a result of resolving merge conflicts and this being left behind.