### PR TITLE
[Bug Fix] Fix potential trader crash when serialized item not found

### DIFF
--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -318,6 +318,7 @@ std::unique_ptr<EQ::ItemInstance> ZoneDatabase::LoadSingleTraderItem(uint32 char
 
 	if (results.empty()) {
 		LogTrading("Could not find item serial number {} for character id {}", serial_number, char_id);
+		return nullptr;
 	}
 
 	int item_id = results.at(0).item_id;


### PR DESCRIPTION
# Description

As seen [here](https://spire.akkadius.com/dev/release/22.52.0?id=24563), if a serialized item is not found for the character, we did not return a `nullptr`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing



Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur