### PR TITLE
[Bug Fix] Fix for players having empty bazaar window dropdown list, even though trader is tagged as a trader.

### DIFF
--- a/common/patches/rof2.cpp
+++ b/common/patches/rof2.cpp
@@ -542,8 +542,8 @@ namespace RoF2
 				LogTrading(
 					"(RoF2) AddTraderToBazaarWindow action <green>[{}] trader_id <green>[{}] entity_id <green>[{}] zone_id <green>[{}]",
 					eq->action,
-					eq->entity_id,
 					eq->trader_id,
+					eq->entity_id,
 					eq->zone_id
 				);
 				dest->FastQueuePacket(&outapp);

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -1128,6 +1128,7 @@ void Client::TraderStartTrader(const EQApplicationPacket *app)
 		return;
 	}
 
+	TraderRepository::DeleteWhere(database, fmt::format("`char_id` = '{}';", CharacterID()));
 	TraderRepository::ReplaceMany(database, trader_items);
 	safe_delete(inv);
 

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -1049,6 +1049,10 @@ void Client::TraderStartTrader(const EQApplicationPacket *app)
 
 	//Check inventory for no-trade items
 	for (auto const &i: inv->serial_number) {
+		if (i <= 0) {
+			continue;
+		}
+
 		auto inst = FindTraderItemBySerialNumber(i);
 		if (inst) {
 			if (inst->GetItem() && inst->GetItem()->NoDrop == 0) {
@@ -1067,7 +1071,16 @@ void Client::TraderStartTrader(const EQApplicationPacket *app)
 	}
 
 	for (uint32 i = 0; i < max_items; i++) {
+		if (inv->serial_number[i] <= 0) {
+			continue;
+		}
+
 		auto inst = FindTraderItemBySerialNumber(inv->serial_number[i]);
+		if (!inst) {
+			trade_items_valid = false;
+			break;
+		}
+
 		auto it   = std::find(std::begin(in->serial_number), std::end(in->serial_number), inv->serial_number[i]);
 		if (inst && it != std::end(in->serial_number)) {
 			inst->SetPrice(in->item_cost[i]);
@@ -1106,13 +1119,10 @@ void Client::TraderStartTrader(const EQApplicationPacket *app)
 			trade_items_valid = false;
 			continue;
 		}
-		else if (!in->serial_number[i]) {
-			break;
-		}
 	}
 
 	if (!trade_items_valid) {
-		Message(Chat::Red, "You are not able to become a trader at this time.");
+		Message(Chat::Red, "You are not able to become a trader at this time.  Invalid item found.");
 		TraderEndTrader();
 		safe_delete(inv);
 		return;

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -1194,13 +1194,6 @@ bool Zone::Init(bool is_static) {
 	LoadZoneObjects();
 	LoadZoneDoors();
 	LoadZoneBlockedSpells();
-
-	//clear trader items if we are loading the bazaar
-	if (strncasecmp(short_name, "bazaar", 6) == 0) {
-		TraderRepository::Truncate(database);
-		database.DeleteBuyLines(0);
-	}
-
 	LoadVeteranRewards();
 	LoadAlternateCurrencies();
 	LoadNPCEmotes(&npc_emote_list);


### PR DESCRIPTION
# Description

Some players have reported that the bazaar window dropdown is empty and the Welcome button displays 0 traders even though there are players with Trader Mode On and with the Trader name above their head.  https://discordapp.com/channels/212663220849213441/1247473480019218514

After further monitoring, it was found that the issue was the logic to clear the trader table when the bazaar zone loaded.  There were circumstances where another bazaar instance would load, thereby removing the trader table entries and therefore resulting in the observed behaviour.  This was confirmed on June 10, 2024.  To resolve this issue, I have removed the table clear and instead delete that player's trader entries when starting trader mode.

Also, in monitoring PEQ, there were occurrences where the start trader routine logic was allowing trader mode to start, with invalid items (items that could not be found on the player).  Instead of recognizing this and alerting the player and ending Trader mode, it would allow trader mode to be enabled.  This is also fixed in this patch.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
Tested with RoF2 to ensure that trader mode ON continues to function.  

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
