### PR TITLE
[Bug] Prevent Resurrection Spells from being resisted

### DIFF
--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -431,7 +431,7 @@ bool IsCharmSpell(uint16 spell_id)
 	return IsEffectInSpell(spell_id, SE_Charm);
 }
 
-bool IsResurrectionSpell(uint16 spell_id) {
+bool IsResurrectionSicknessSpell(uint16 spell_id) {
 	return (
 		spell_id == SPELL_RESURRECTION_SICKNESS ||
 		spell_id == SPELL_RESURRECTION_SICKNESS2 ||

--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -431,7 +431,7 @@ bool IsCharmSpell(uint16 spell_id)
 	return IsEffectInSpell(spell_id, SE_Charm);
 }
 
-bool IsRessurectionSpell(uint16 spell_id) {
+bool IsResurrectionSpell(uint16 spell_id) {
 	return (
 		spell_id == SPELL_RESURRECTION_SICKNESS ||
 		spell_id == SPELL_RESURRECTION_SICKNESS2 ||

--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -431,6 +431,16 @@ bool IsCharmSpell(uint16 spell_id)
 	return IsEffectInSpell(spell_id, SE_Charm);
 }
 
+bool IsRessurectionSpell(uint16 spell_id) {
+	return (
+		spell_id == SPELL_RESURRECTION_SICKNESS ||
+		spell_id == SPELL_RESURRECTION_SICKNESS2 ||
+		spell_id == SPELL_RESURRECTION_SICKNESS3 ||
+		spell_id == SPELL_RESURRECTION_SICKNESS4 ||
+		spell_id == SPELL_REVIVAL_SICKNESS
+	);
+}
+
 bool IsBlindSpell(uint16 spell_id)
 {
 	return IsEffectInSpell(spell_id, SE_Blind);

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1522,7 +1522,7 @@ bool IsSummonPetSpell(uint16 spell_id);
 bool IsSummonPCSpell(uint16 spell_id);
 bool IsPetSpell(uint16 spell_id);
 bool IsCharmSpell(uint16 spell_id);
-bool IsRessurectionSpell(uint16 spell_id);
+bool IsResurrectionSpell(uint16 spell_id);
 bool IsBlindSpell(uint16 spell_id);
 bool IsHealthSpell(uint16 spell_id);
 bool IsCastTimeReductionSpell(uint16 spell_id);

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1522,6 +1522,7 @@ bool IsSummonPetSpell(uint16 spell_id);
 bool IsSummonPCSpell(uint16 spell_id);
 bool IsPetSpell(uint16 spell_id);
 bool IsCharmSpell(uint16 spell_id);
+bool IsRessurectionSpell(uint16 spell_id);
 bool IsBlindSpell(uint16 spell_id);
 bool IsHealthSpell(uint16 spell_id);
 bool IsCastTimeReductionSpell(uint16 spell_id);

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1522,7 +1522,7 @@ bool IsSummonPetSpell(uint16 spell_id);
 bool IsSummonPCSpell(uint16 spell_id);
 bool IsPetSpell(uint16 spell_id);
 bool IsCharmSpell(uint16 spell_id);
-bool IsResurrectionSpell(uint16 spell_id);
+bool IsResurrectionSicknessSpell(uint16 spell_id);
 bool IsBlindSpell(uint16 spell_id);
 bool IsHealthSpell(uint16 spell_id);
 bool IsCastTimeReductionSpell(uint16 spell_id);

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -5324,7 +5324,7 @@ float Mob::ResistSpell(uint8 resist_type, uint16 spell_id, Mob *caster, bool use
 
 		// Check for Chance to Resist Spell bonuses (ie Sanctification Discipline)
 		int resist_bonuses = CalcResistChanceBonus();
-		if (resist_bonuses && zone->random.Roll(resist_bonuses) && !IsResurrectionSpell(spell_id)) {
+		if (resist_bonuses && zone->random.Roll(resist_bonuses) && !IsResurrectionSicknessSpell(spell_id)) {
 			LogSpells("Resisted spell in sanctification, had [{}] chance to resist", resist_bonuses);
 			return 0;
 		}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -5324,7 +5324,7 @@ float Mob::ResistSpell(uint8 resist_type, uint16 spell_id, Mob *caster, bool use
 
 		// Check for Chance to Resist Spell bonuses (ie Sanctification Discipline)
 		int resist_bonuses = CalcResistChanceBonus();
-		if (resist_bonuses && zone->random.Roll(resist_bonuses) && !IsRessurectionSpell(spell_id)) {
+		if (resist_bonuses && zone->random.Roll(resist_bonuses) && !IsResurrectionSpell(spell_id)) {
 			LogSpells("Resisted spell in sanctification, had [{}] chance to resist", resist_bonuses);
 			return 0;
 		}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -5315,19 +5315,16 @@ float Mob::ResistSpell(uint8 resist_type, uint16 spell_id, Mob *caster, bool use
 		}
 	}
 
-	if (!CharmTick){
-
+	if (!CharmTick) {
 		//Check for Spell Effect specific resistance chances (ie AA Mental Fortitude)
 		int se_resist_bonuses = GetSpellEffectResistChance(spell_id);
-		if(se_resist_bonuses && zone->random.Roll(se_resist_bonuses))
-		{
+		if (se_resist_bonuses && zone->random.Roll(se_resist_bonuses)) {
 			return 0;
 		}
 
 		// Check for Chance to Resist Spell bonuses (ie Sanctification Discipline)
 		int resist_bonuses = CalcResistChanceBonus();
-		if(resist_bonuses && zone->random.Roll(resist_bonuses))
-		{
+		if (resist_bonuses && zone->random.Roll(resist_bonuses) && !IsRessurectionSpell(spell_id)) {
 			LogSpells("Resisted spell in sanctification, had [{}] chance to resist", resist_bonuses);
 			return 0;
 		}


### PR DESCRIPTION
# Description

Added IsResurrectionSicknessSpell(uint16 spell_id) to assist with checking on a spell is a Resurrection spell.

This was noticed when Dragons of Norrath launched and the Tier 5 Progression AA provided SPA 180 2% SE_ResistSpellChance

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
