### PR TITLE
[Rule] Classic Harm Touch Formula

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -503,6 +503,7 @@ RULE_BOOL(Spells, RequireMnemonicRetention, true, "Enabling will require spell s
 RULE_BOOL(Spells, EvacClearCharmPet, false, "Enable to have evac in zone clear charm from charm pets and detach buffs.")
 RULE_BOOL(Spells, ManaTapsRequireNPCMana, false, "Enabling will require target to have mana to tap. Default off as many npc's are caster class with 0 mana and need fixed.")
 RULE_INT(Spells, HarmTouchCritRatio, 200, "Harmtouch crit bonus, on top of BaseCritRatio")
+RULE_BOOL(Spells, UseClassicHarmTouchDamage, false, "Use pre 2007 Harm Touch calculations - Default: False")
 RULE_BOOL(Spells, UseClassicSpellFocus, false, "Enabling will tell the server to handle random focus damage as classic spell imports lack the limit values.")
 RULE_BOOL(Spells, ManaTapsOnAnyClass, false, "Enabling this will allow you to cast mana taps on any class, this will bypass ManaTapsRequireNPCMana rule.")
 RULE_INT(Spells, HealAmountMessageFilterThreshold, 100, "Lifetaps below this threshold will not have a message sent to the client (Heal will still process) 0 to Disable.")

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -109,7 +109,7 @@ int64 Mob::GetActSpellDamage(uint16 spell_id, int64 value, Mob* target) {
 				}
 
 				//This adds the extra damage from the AA Unholy Touch, 450 per level to the AA Improved Harm TOuch.
-				if (spell_id == SPELL_IMP_HARM_TOUCH && (IsClient() || IsBot())) { //Improved Harm Touch
+				if (spell_id == SPELL_IMP_HARM_TOUCH && IsOfClientBotMerc()) { //Improved Harm Touch
 					value -= GetAA(aaUnholyTouch) * 450; //Unholy Touch
 				}
 			}

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -104,7 +104,7 @@ int64 Mob::GetActSpellDamage(uint16 spell_id, int64 value, Mob* target) {
 
 			if (RuleB(Spells, UseClassicHarmTouchDamage)) {
 				// Need to scale HT damage differently after level 40! It no longer scales by the constant value in the spell file. It scales differently, instead of 10 more damage per level, it does 30 more damage per level. So we multiply the level minus 40 times 20 if they are over level 40.
-				if ((spell_id == SPELL_HARM_TOUCH || spell_id == SPELL_HARM_TOUCH2 || spell_id == SPELL_IMP_HARM_TOUCH ) && GetLevel() > 40) {
+				if (IsHarmTouchSpell(spell_id) && GetLevel() > 40) {
 					value -= (GetLevel() - 40) * 20;
 				}
 
@@ -114,18 +114,18 @@ int64 Mob::GetActSpellDamage(uint16 spell_id, int64 value, Mob* target) {
 				}
 			}
 
-			value += base_value*GetFocusEffect(focusImprovedDamage, spell_id)/100;
-			value += base_value*GetFocusEffect(focusImprovedDamage2, spell_id)/100;
+			value += base_value*GetFocusEffect(focusImprovedDamage, spell_id) / 100;
+			value += base_value*GetFocusEffect(focusImprovedDamage2, spell_id) / 100;
 
-			value += int(base_value*GetFocusEffect(focusFcDamagePctCrit, spell_id)/100)*ratio/100;
-			value += int(base_value*GetFocusEffect(focusFcAmplifyMod, spell_id) / 100)*ratio / 100;
+			value += int(base_value*GetFocusEffect(focusFcDamagePctCrit, spell_id) / 100) * ratio / 100;
+			value += int(base_value*GetFocusEffect(focusFcAmplifyMod, spell_id) / 100) * ratio / 100;
 
 			if (target) {
-				value += int(base_value*target->GetVulnerability(this, spell_id, 0)/100)*ratio/100;
+				value += int(base_value*target->GetVulnerability(this, spell_id, 0) / 100) * ratio / 100;
 				value -= target->GetFcDamageAmtIncoming(this, spell_id);
 			}
 
-			value -= GetFocusEffect(focusFcDamageAmtCrit, spell_id)*ratio/100;
+			value -= GetFocusEffect(focusFcDamageAmtCrit, spell_id) * ratio / 100;
 
 			value -= GetFocusEffect(focusFcDamageAmt, spell_id);
 			value -= GetFocusEffect(focusFcDamageAmt2, spell_id);
@@ -157,30 +157,20 @@ int64 Mob::GetActSpellDamage(uint16 spell_id, int64 value, Mob* target) {
 				MessageString(Chat::SpellCrit, YOU_CRIT_BLAST, itoa(-value));
 			}
 
-			// Need to scale HT damage differently after level 40! It no longer scales by the constant value in the spell file. It scales differently, instead of 10 more damage per level, it does 30 more damage per level. So we multiply the level minus 40 times 20 if they are over level 40.
-			if (IsHarmTouchSpell(spell_id) && GetLevel() > 40) {
-				value -= (GetLevel() - 40) * 20;
-			}
-
-			//This adds the extra damage from the AA Unholy Touch, 450 per level to the AA Improved Harm Touch.
-			if (spell_id == SPELL_IMP_HARM_TOUCH && IsOfClientBot()) { //Improved Harm Touch
-				value -= GetAA(aaUnholyTouch) * 450; //Unholy Touch
-			}
-
 			return value;
 		}
 	}
 	//Non Crtical Hit Calculation pathway
 	value = base_value;
 
-	value += base_value*GetFocusEffect(focusImprovedDamage, spell_id)/100;
-	value += base_value*GetFocusEffect(focusImprovedDamage2, spell_id)/100;
+	value += base_value*GetFocusEffect(focusImprovedDamage, spell_id) / 100;
+	value += base_value*GetFocusEffect(focusImprovedDamage2, spell_id) / 100;
 
-	value += base_value*GetFocusEffect(focusFcDamagePctCrit, spell_id)/100;
-	value += base_value*GetFocusEffect(focusFcAmplifyMod, spell_id)/100;
+	value += base_value*GetFocusEffect(focusFcDamagePctCrit, spell_id) / 100;
+	value += base_value*GetFocusEffect(focusFcAmplifyMod, spell_id) / 100;
 
 	if (target) {
-		value += base_value*target->GetVulnerability(this, spell_id, 0)/100;
+		value += base_value*target->GetVulnerability(this, spell_id, 0) / 100;
 		value -= target->GetFcDamageAmtIncoming(this, spell_id);
 	}
 


### PR DESCRIPTION
# Description

Pre 2007 Harm Touch was handled differently with base harm Touch ( Ability or 2 ranks aa) and Improved Harm Touch AA. It was converted into 10 ranks of Harm Touch -

http://www.tski.co.jp/baldio/patch/20071113.html

It was further refined in 2008 to have a DoT component.

http://www.tski.co.jp/baldio/patch/20080709.html

This rule focuses on the pre 2007 version and allows the damage to properly scale

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# Testing

Before fix:

![image](https://github.com/EQEmu/Server/assets/5864295/0b3c3854-1fa9-4242-9fdc-e33c88539def)

After Fix:

![image](https://github.com/EQEmu/Server/assets/5864295/6939936e-569e-49b9-bbb5-98f203d81611)

Era info:

During Luclin there was a bug that let you spam Harm Touch, Here is a list of some of the crits at that time:

![image](https://github.com/EQEmu/Server/assets/5864295/b99f01a7-7cc0-42b8-80b3-17c226b2cda7)


# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
