### PR TITLE
[Bug Fix] Fix trader mode

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -77,6 +77,7 @@
 #include "zone_store.h"
 #include "repositories/merchantlist_temp_repository.h"
 #include "repositories/bot_data_repository.h"
+#include "repositories/trader_repository.h"
 
 extern Client client;
 
@@ -2103,4 +2104,9 @@ void Database::PurgeCharacterParcels()
 void Database::ClearGuildOnlineStatus()
 {
 	GuildMembersRepository::ClearOnlineStatus(*this);
+}
+
+void Database::ClearTraderDetails()
+{
+	TraderRepository::Truncate(*this);
 }

--- a/common/database.h
+++ b/common/database.h
@@ -244,6 +244,7 @@ public:
 
 	void PurgeAllDeletedDataBuckets();
 	void ClearGuildOnlineStatus();
+	void ClearTraderDetails();
 
 
 	/* Database Variables */

--- a/world/world_boot.cpp
+++ b/world/world_boot.cpp
@@ -289,6 +289,8 @@ bool WorldBoot::DatabaseLoadRoutines(int argc, char **argv)
 	LogInfo("Clearing inventory snapshots");
 	database.ClearInvSnapshots();
 	LogInfo("Loading items");
+	LogInfo("Clearing trader table details");
+	database.ClearTraderDetails();
 
 	if (!content_db.LoadItems(hotfix_name)) {
 		LogError("Error: Could not load item data. But ignoring");

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -41,7 +41,7 @@ extern QueryServ* QServ;
 
 // The maximum amount of a single bazaar/barter transaction expressed in copper.
 // Equivalent to 2 Million plat
-auto constexpr MAX_TRANSACTION_VALUE = 2000000000;
+constexpr auto MAX_TRANSACTION_VALUE = 2000000000;
 // ##########################################
 // Trade implementation
 // ##########################################

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -41,7 +41,7 @@ extern QueryServ* QServ;
 
 // The maximum amount of a single bazaar/barter transaction expressed in copper.
 // Equivalent to 2 Million plat
-#define MAX_TRANSACTION_VALUE 2000000000
+auto constexpr MAX_TRANSACTION_VALUE = 2000000000;
 // ##########################################
 // Trade implementation
 // ##########################################
@@ -1048,12 +1048,12 @@ void Client::TraderStartTrader(const EQApplicationPacket *app)
 	std::vector<TraderRepository::Trader> trader_items{};
 
 	//Check inventory for no-trade items
-	for (auto const &i: inv->serial_number) {
-		if (i <= 0) {
+	for (auto i = 0; i < max_items; i++) {
+		if (inv->items[i] == 0 || inv->serial_number[i] == 0) {
 			continue;
 		}
 
-		auto inst = FindTraderItemBySerialNumber(i);
+		auto inst = FindTraderItemBySerialNumber(inv->serial_number[i]);
 		if (inst) {
 			if (inst->GetItem() && inst->GetItem()->NoDrop == 0) {
 				Message(
@@ -1320,7 +1320,7 @@ GetItems_Struct *Client::GetTraderItems()
 {
 	const EQ::ItemInstance *item   = nullptr;
 	int16                  slot_id = INVALID_INDEX;
-	auto                   gis     = new GetItems_Struct;
+	auto                   gis     = new GetItems_Struct{0};
 	uint8                  ndx     = 0;
 
 	for (int16 i = EQ::invslot::GENERAL_BEGIN; i <= EQ::invslot::GENERAL_END; i++) {
@@ -1338,7 +1338,7 @@ GetItems_Struct *Client::GetTraderItems()
 				item    = GetInv().GetItem(slot_id);
 
 				if (item) {
-					gis->items[ndx]         = item->GetItem()->ID;
+					gis->items[ndx]         = item->GetID();
 					gis->serial_number[ndx] = item->GetSerialNumber();
 					gis->charges[ndx]       = item->GetCharges() == 0 ? 1 : item->GetCharges();
 					ndx++;
@@ -2044,7 +2044,7 @@ void Client::SendBazaarResults(
 	int    Count           = 0;
 	uint32 StatValue       = 0;
 
-	for (auto row = results.begin(); row != results.end(); ++row) {
+	for (auto &row = results.begin(); row != results.end(); ++row) {
 		VARSTRUCT_ENCODE_TYPE(uint32, bufptr, Action);
 		Count = Strings::ToInt(row[0]);
 		VARSTRUCT_ENCODE_TYPE(uint32, bufptr, Count);
@@ -2304,7 +2304,7 @@ void Client::SendBuyerResults(char* searchString, uint32 searchID) {
     uint32 lastCharID = 0;
 	Client *buyer = nullptr;
 
-	for (auto row = results.begin(); row != results.end(); ++row) {
+	for (auto &row = results.begin(); row != results.end(); ++row) {
         char itemName[64];
 
         uint32 charID = Strings::ToInt(row[0]);
@@ -2407,7 +2407,7 @@ void Client::ShowBuyLines(const EQApplicationPacket *app) {
     if (!results.Success() || results.RowCount() == 0)
         return;
 
-    for (auto row = results.begin(); row != results.end(); ++row) {
+    for (auto &row = results.begin(); row != results.end(); ++row) {
         char ItemName[64];
         uint32 BuySlot = Strings::ToInt(row[1]);
         uint32 ItemID = Strings::ToInt(row[2]);
@@ -3309,7 +3309,7 @@ void Client::DoBazaarInspect(const BazaarInspect_Struct &in)
 		return;
 	}
 
-	auto item = items.front();
+	auto &item = items.front();
 
 	std::unique_ptr<EQ::ItemInstance> inst(
 		database.CreateItem(


### PR DESCRIPTION
# Description

With latest changes, we are unable to start in trader mode because it can't find valid items to trade due to serialized items. We were iterating through slots based on the first serial number instead of the number of allowed bazaar slots. We also weren't initializing the item struct causing the search function to falsely identify items and serial numbers. Finally, forced a trader table truncate on startup to ensure an empty table in the event of a server crash or unclean shutdown which could leave invalid data in the table.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing
Starting trader mode:
![image](https://github.com/EQEmu/Server/assets/3617814/c25c0eec-4ff1-49b3-adde-105b7b8a1632)

Stopping/starting trader mode, removing item from trade, and changing prices:
![image](https://github.com/EQEmu/Server/assets/3617814/67213f50-1224-4cec-9bcb-d28a7edd83ed)

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur