### PR TITLE
[Bug Fix] Aegolism Spell line stacking

### DIFF
--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -2349,7 +2349,7 @@ bool IsAegolismSpell(uint16 spell_id) {
 		}
 	}
 
-	if (has_max_hp == true && has_current_hp == true && has_ac == true) {
+	if (has_max_hp && has_current_hp && has_ac) {
 		return 1;
 	}
 	return 0;
@@ -2358,19 +2358,22 @@ bool IsAegolismSpell(uint16 spell_id) {
 
 bool AegolismStackingIsSymbolSpell(uint16 spell_id) {
 	
+	/*
+		This is hardcoded to be specific to the type of HP buffs that are removed if a mob has an Aegolism buff.
+	*/
+
 	if (!IsValidSpell(spell_id)) {
 		return 0;
 	}
 
 	bool has_max_hp = false;
 	bool has_current_hp = false;
-	bool fail = false;
 
 	for (int i = 0; i < EFFECT_COUNT; ++i) {
 
 		if ((i < 2 && spells[spell_id].effect_id[i] != SE_CHA) ||
 			i > 3 && spells[spell_id].effect_id[i] != SE_Blank) {
-			fail = true;
+			return 0;;
 		}
 
 		if (i == 2 && spells[spell_id].effect_id[i] == SE_TotalHP) {
@@ -2382,7 +2385,7 @@ bool AegolismStackingIsSymbolSpell(uint16 spell_id) {
 		}
 	}
 
-	if (has_max_hp == true && has_current_hp == true && fail == false) {
+	if (has_max_hp && has_current_hp) {
 		return 1;
 	}
 
@@ -2390,19 +2393,20 @@ bool AegolismStackingIsSymbolSpell(uint16 spell_id) {
 }
 
 bool AegolismStackingIsArmorClassSpell(uint16 spell_id) {
-
+	/*
+		This is hardcoded to be specific to the type of AC buffs that are removed if a mob has an Aegolism buff.
+	*/
 	if (!IsValidSpell(spell_id)) {
 		return 0;
 	}
 
 	bool has_ac = false;
-	bool fail = false;
 
 	for (int i = 0; i < EFFECT_COUNT; ++i) {
 
 		if ((i < 3 && spells[spell_id].effect_id[i] != SE_CHA) ||
 			i > 3 && spells[spell_id].effect_id[i] != SE_Blank) {
-			fail = true;
+			return 0;
 		}
 
 		if (i == 3 && spells[spell_id].effect_id[i] == SE_ArmorClass) {
@@ -2410,7 +2414,7 @@ bool AegolismStackingIsArmorClassSpell(uint16 spell_id) {
 		}
 	}
 
-	if (has_ac == true && fail == false) {
+	if (has_ac) {
 		return 1;
 	}
 

--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -2315,3 +2315,104 @@ bool IsCastNotStandingSpell(uint16 spell_id) {
 	*/
 	return spells[spell_id].cast_not_standing;
 }
+
+bool IsAegolismSpell(uint16 spell_id) {
+
+	if (!IsValidSpell(spell_id)) {
+		return 0;
+	}
+
+	bool has_max_hp = false;
+	bool has_current_hp = false;
+	bool has_ac = false;
+
+	for (int i = 0; i < EFFECT_COUNT; ++i) {
+
+		if (i == 0 && spells[spell_id].effect_id[i] != SE_StackingCommand_Block) {
+			return 0;
+		}
+
+		if (i == 1 && spells[spell_id].effect_id[i] == SE_TotalHP) {
+			has_max_hp = true;
+		}
+
+		if (i == 2 && spells[spell_id].effect_id[i] == SE_CurrentHPOnce) {
+			has_current_hp = true;
+		}
+
+		if (i == 3 && spells[spell_id].effect_id[i] == SE_ArmorClass) {
+			has_ac = true;
+		}
+
+		if (i == 4 && spells[spell_id].effect_id[i] != SE_StackingCommand_Overwrite) {
+			return 0;
+		}
+	}
+
+	if (has_max_hp == true && has_current_hp == true && has_ac == true) {
+		return 1;
+	}
+	return 0;
+}
+
+
+bool AegolismStackingIsSymbolSpell(uint16 spell_id) {
+	
+	if (!IsValidSpell(spell_id)) {
+		return 0;
+	}
+
+	bool has_max_hp = false;
+	bool has_current_hp = false;
+	bool fail = false;
+
+	for (int i = 0; i < EFFECT_COUNT; ++i) {
+
+		if ((i < 2 && spells[spell_id].effect_id[i] != SE_CHA) ||
+			i > 3 && spells[spell_id].effect_id[i] != SE_Blank) {
+			fail = true;
+		}
+
+		if (i == 2 && spells[spell_id].effect_id[i] == SE_TotalHP) {
+			has_max_hp = true;
+		}
+
+		if (i == 3 && spells[spell_id].effect_id[i] == SE_CurrentHPOnce) {
+			has_current_hp = true;
+		}
+	}
+
+	if (has_max_hp == true && has_current_hp == true && fail == false) {
+		return 1;
+	}
+
+	return 0;
+}
+
+bool AegolismStackingIsArmorClassSpell(uint16 spell_id) {
+
+	if (!IsValidSpell(spell_id)) {
+		return 0;
+	}
+
+	bool has_ac = false;
+	bool fail = false;
+
+	for (int i = 0; i < EFFECT_COUNT; ++i) {
+
+		if ((i < 3 && spells[spell_id].effect_id[i] != SE_CHA) ||
+			i > 3 && spells[spell_id].effect_id[i] != SE_Blank) {
+			fail = true;
+		}
+
+		if (i == 3 && spells[spell_id].effect_id[i] == SE_ArmorClass) {
+			has_ac = true;
+		}
+	}
+
+	if (has_ac == true && fail == false) {
+		return 1;
+	}
+
+	return 0;
+}

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1624,5 +1624,8 @@ bool IsSpellUsableInThisZoneType(uint16 spell_id, uint8 zone_type);
 const char *GetSpellName(uint16 spell_id);
 int GetSpellStatValue(uint16 spell_id, const char* stat_identifier, uint8 slot = 0);
 bool IsCastRestrictedSpell(uint16 spell_id);
+bool IsAegolismSpell(uint16 spell_id);
+bool AegolismStackingIsSymbolSpell(uint16 spell_id);
+bool AegolismStackingIsArmorClassSpell(uint16 spell_id);
 
 #endif

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3743,6 +3743,18 @@ int Mob::AddBuff(Mob *caster, uint16 spell_id, int duration, int32 level_overrid
 		}
 	}
 
+	//remove associated buffs for certain live spell lines
+	if (IsAegolismSpell(spell_id)) {
+		int buff_count = GetMaxBuffSlots();
+		for (int slot = 0; slot < buff_count; slot++) {
+			if (IsValidSpell(buffs[slot].spellid)) {
+				if (AegolismStackingIsSymbolSpell(buffs[slot].spellid) || AegolismStackingIsArmorClassSpell(buffs[slot].spellid)) {
+					BuffFadeBySlot(slot);
+				}
+			}
+		}
+	}
+
 	buffs[emptyslot].spellid = spell_id;
 	buffs[emptyslot].casterlevel = caster_level;
 	if (caster && !caster->IsAura()) // maybe some other things we don't want to ...


### PR DESCRIPTION
Issue: 

Buff stacking issue regarding Aegolism spell line. On live Aeoglism type spells should override and remove all present cleric type AC, symbol and heorism buffs.  Currently depending on how buffs are ordered Aeoglism could override just one of these buffs and not remove the others. Now it will always remove associated buffs.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Attach images and describe testing done to validate functionality.

Clients tested: 

# Checklist

- [x ] I have tested my changes
- [x ] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [ ] I have made corresponding changes to the documentation (if applicable, if not delete this line)
- [ ] I own the changes of my code and take responsibility for the potential issues that occur
- [ ] If my changes make database schema changes, I have tested the changes on a local database (attach image). Updated version.h CURRENT_BINARY_DATABASE_VERSION to the new version. (Delete this if not applicable)
