### PR TITLE
[Bug Fix] Fix for random disconnects when a large number of guild members zone or disconnect

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -215,6 +215,7 @@ Client::Client(EQStreamInterface *ieqs) : Mob(
 	guild_id = GUILD_NONE;
 	guildrank = 0;
 	guild_tribute_opt_in = 0;
+	SetGuildListDirty(false);
 	GuildBanker = false;
 	memset(lskey, 0, sizeof(lskey));
 	strcpy(account_name, "");
@@ -410,8 +411,12 @@ Client::~Client() {
 		zone->ClearEXPModifier(this);
 	}
 
-	if(IsInAGuild())
-		guild_mgr.SendGuildMemberUpdateToWorld(GetName(), GuildID(), 0, time(nullptr));
+	if (!IsZoning()) {
+		if(IsInAGuild()) {
+			guild_mgr.UpdateDbMemberOnline(CharacterID(), false);
+			guild_mgr.SendGuildMemberUpdateToWorld(GetName(), GuildID(), 0, time(nullptr));
+		}
+	}
 
 	Mob* horse = entity_list.GetMob(CastToClient()->GetHorseId());
 	if (horse)

--- a/zone/client.h
+++ b/zone/client.h
@@ -739,6 +739,7 @@ public:
 	void GoToDeath();
 	inline const int32 GetInstanceID() const { return zone->GetInstanceID(); }
 	void SetZoning(bool in) { bZoning = in; }
+	bool IsZoning() { return bZoning; }
 
 	void ShowSpells(Client* c, ShowSpellType show_spell_type);
 


### PR DESCRIPTION
# Description

Reports from multiple servers indicate that when a large number of guild members zone, or /ex to disconnect, some guild members will go linkdead and disconnect.  Reports from both PEQ and EZ

It appears that the zone process is becoming overwhelmed with packet processing regarding sending guild member status (zone, time, etc).  When an impacted client de-guilds, the problem is no longer experienced.

# Fix

The destructor for Client was sending a guild member status packet with a zone_id = 0 to indicate that the client was offline.  This packet would then be sent to all zone servers to notify guild players.  This was originally established to notify clients when a player logged.  However, if the client was simply zoning, the packet was still sent, even though the CompleteConnect function would immediately send another packet to indicate the new zone of the player.  

Therefore, the destructor packet was modified to only be sent when the player is not zoning.  This reduces the packet load by 50%, a significant reduction for large guilds.  

I also confirmed that the db update for online status is occurring as designed and should not be an issue. (first logon, and a disconnect).

I believe that this will resolve the random nature of this issue.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
I monitored packets being sent when a guild member is logged in, and another guild member zones.  When zoning, player A would receive 2 packets, one with a zone id of 0, another with the proper zone id.  With the fix, player A receives a single packet with the updated zone id.

I logged clients into the arena, bazaar and crescent reach and monitored packets and the guild window to ensure it continues to function as expected.

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
