### PR TITLE
[Bug Fix] Remove line showing ShowBuffs alert on buffs landing

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -1654,10 +1654,6 @@ void EntityList::QueueClientsByTarget(Mob *sender, const EQApplicationPacket *ap
 				if (inspect_buffs) { // if inspect_buffs is true we're sending a mob's buffs to those with the LAA
 					Send = clear_target_window;
 					if (c->GetGM() || RuleB(Spells, AlwaysSendTargetsBuffs)) {
-						if (c->GetGM()) {
-							c->Message(Chat::White, "Your GM flag allows you to always see your targets' buffs.");
-						}
-
 						Send = !clear_target_window;
 					} else if (c->IsRaidGrouped()) {
 						Raid *raid = c->GetRaid();


### PR DESCRIPTION
# Description

If a GM has something targeted and a new buff lands, it gets hit with the alert "Your GM flag allows you to always see your targets' buffs." every time a buff lands. This removes that alert.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Clients tested: 
RoF2
# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
