### PR TITLE
[Bug Fix] Corpse Call removing Rez Effects

### DIFF
--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -1034,22 +1034,27 @@ void Client::OPRezzAnswer(uint32 Action, uint32 SpellID, uint16 ZoneID, uint16 I
 				name, (uint16)spells[SpellID].base_value[0],
 				SpellID, ZoneID, InstanceID);
 
+		const bool use_old_resurrection = (
+			RuleB(Character, UseOldRaceRezEffects) &&
+			(
+				GetRace() == Race::Barbarian ||
+				GetRace() == Race::Dwarf ||
+				GetRace() == Race::Troll ||
+				GetRace() == Race::Ogre
+			)
+		);
+
+		const uint16 resurrection_sickness_spell_id = (
+			use_old_resurrection ?
+			RuleI(Character, OldResurrectionSicknessSpellID) :
+			RuleI(Character, ResurrectionSicknessSpellID)
+		);
+
 		int SpellEffectDescNum = GetSpellEffectDescriptionNumber(SpellID);
 		// Rez spells with Rez effects have this DescNum (first is Titanium, second is 6.2 Client)
 		if(RuleB(Character, UseResurrectionSickness) && SpellEffectDescNum == 82 || SpellEffectDescNum == 39067) {
 			SetHP(GetMaxHP() / 5);
 			SetMana(0);
-			int resurrection_sickness_spell_id = (
-				RuleB(Character, UseOldRaceRezEffects) &&
-			    (
-					GetRace() == BARBARIAN ||
-					GetRace() == DWARF ||
-					GetRace() == TROLL ||
-					GetRace() == OGRE
-				) ?
-				RuleI(Character, OldResurrectionSicknessSpellID) :
-				RuleI(Character, ResurrectionSicknessSpellID)
-			);
 
 			if (RuleB(Spells, BuffsFadeOnDeath)) {
 				BuffFadeNonPersistDeath();
@@ -1066,23 +1071,11 @@ void Client::OPRezzAnswer(uint32 Action, uint32 SpellID, uint16 ZoneID, uint16 I
 			RestoreEndurance();
 		} else {
 			if (RuleB(Character, UseResurrectionSickness)) {
-				int resurrection_sickness_spell_id = (
-				RuleB(Character, UseOldRaceRezEffects) &&
-					(
-						GetRace() == BARBARIAN ||
-						GetRace() == DWARF ||
-						GetRace() == TROLL ||
-						GetRace() == OGRE
-					) ?
-					RuleI(Character, OldResurrectionSicknessSpellID) :
-					RuleI(Character, ResurrectionSicknessSpellID)
-				);
-
-				bool has_rez_effects = false;
+				bool has_resurrection_sickness = false;
 
 				for (int slot = 0; slot < GetMaxTotalSlots(); slot++) {
 					if (IsValidSpell(buffs[slot].spellid) && IsResurrectionSicknessSpell(buffs[slot].spellid)){
-						has_rez_effects = true;
+						has_resurrection_sickness = true;
 						break;
 					}
 				}
@@ -1092,7 +1085,7 @@ void Client::OPRezzAnswer(uint32 Action, uint32 SpellID, uint16 ZoneID, uint16 I
 					BuffFadeNonPersistDeath();
 				}
 
-				if (has_rez_effects) {
+				if (has_resurrection_sickness) {
 					SpellOnTarget(resurrection_sickness_spell_id, this);
 				}
 			}


### PR DESCRIPTION
# Description

When calling a corpse, it should not remove rez effects.

Moved logic around, if rez effects do not exist on call, then it will just wipe the buffs, if it does exist it will recast rez effects.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

![image](https://github.com/user-attachments/assets/7a58ad0b-7b0f-468a-bdf6-45d2010426b3)

![image](https://github.com/user-attachments/assets/0715aa97-25cc-4a12-9ae7-13cae50832b4)

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
