### PR TITLE
[Bug Fix] Prox aggro for frustrated and undead.

### DIFF
--- a/zone/aggro.cpp
+++ b/zone/aggro.cpp
@@ -452,8 +452,13 @@ bool Mob::CheckWillAggro(Mob *mob) {
 		return false;
 	}
 
-	// Don't aggro new clients if we are already engaged unless SpecialAbility::ProximityAggro is set
-	if (IsEngaged() && (!GetSpecialAbility(SpecialAbility::ProximityAggro) || (GetSpecialAbility(SpecialAbility::ProximityAggro) && !CombatRange(mob)))) {
+	// Don't aggro new clients if we are already engaged unless PROX_AGGRO is set
+	// Frustrated mobs (all rooted up with no one to kill)
+	// will engage without PROX_AGGRO ability if someone new is close now.
+
+	bool is_frustrated = (IsRooted() && !CombatRange(target));
+
+	if (!is_frustrated && IsEngaged() && (!GetSpecialAbility(SpecialAbility::ProximityAggro) && GetBodyType() != BodyType::Undead || (GetSpecialAbility(SpecialAbility::ProximityAggro) && !CombatRange(mob)))) {
 		LogAggro(
 			"[{}] is in combat, and does not have prox_aggro, or does and is out of combat range with [{}]",
 			GetName(),

--- a/zone/aggro.cpp
+++ b/zone/aggro.cpp
@@ -456,9 +456,22 @@ bool Mob::CheckWillAggro(Mob *mob) {
 	// Frustrated mobs (all rooted up with no one to kill)
 	// will engage without PROX_AGGRO ability if someone new is close now.
 
-	bool is_frustrated = (IsRooted() && !CombatRange(target));
+	const bool is_frustrated = IsRooted() && !CombatRange(target);
 
-	if (!is_frustrated && IsEngaged() && (!GetSpecialAbility(SpecialAbility::ProximityAggro) && GetBodyType() != BodyType::Undead || (GetSpecialAbility(SpecialAbility::ProximityAggro) && !CombatRange(mob)))) {
+	if (
+		!is_frustrated &&
+		IsEngaged() &&
+		(
+			(
+				!GetSpecialAbility(SpecialAbility::ProximityAggro) &&
+				GetBodyType() != BodyType::Undead
+			) ||
+			(
+				GetSpecialAbility(SpecialAbility::ProximityAggro) &&
+				!CombatRange(mob)
+			)
+		)
+	) {
 		LogAggro(
 			"[{}] is in combat, and does not have prox_aggro, or does and is out of combat range with [{}]",
 			GetName(),


### PR DESCRIPTION
# Description

If mob is frustrated (Rooted and has no one to kill or is undead will add prox aggro to hate list.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
