### PR TITLE
[Bug Fix] Searching in the bazaar was not honoring the minimum cost

### DIFF
--- a/common/bazaar.cpp
+++ b/common/bazaar.cpp
@@ -47,7 +47,7 @@ Bazaar::GetSearchResults(
 		search_criteria_trader.append(fmt::format(" AND trader.char_id = {}", search.trader_id));
 	}
 	if (search.min_cost != 0) {
-		search_criteria_trader.append(fmt::format(" AND trader.item_cost >= {}", search.min_cost));
+		search_criteria_trader.append(fmt::format(" AND trader.item_cost >= {}", search.min_cost * 1000));
 	}
 	if (search.max_cost != 0) {
 		search_criteria_trader.append(fmt::format(" AND trader.item_cost <= {}", (uint64) search.max_cost * 1000));


### PR DESCRIPTION
# Description

If a player searched in the bazaar the returned results would not honor the minimum cost field.  This was due to the client using platinum only and my code was not adjusting the min cost correctly.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
![image](https://github.com/user-attachments/assets/c0259eb6-d807-43d8-ac70-e5b4e92c78e5)

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
