### PR TITLE
[Bug Fix] Personal tributes for bard items were not applying correctly

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -183,13 +183,19 @@ void Mob::CalcItemBonuses(StatBonuses* b) {
 	}
 
 	if (IsOfClientBot()) {
-		for (i = EQ::invslot::TRIBUTE_BEGIN; i <= EQ::invslot::TRIBUTE_END; i++) {
-			const EQ::ItemInstance* inst = m_inv[i];
-			if (!inst) {
-				continue;
-			}
+		if (CastToClient()->GetPP().tribute_active) {
+			for (auto const &t: CastToClient()->GetPP().tributes) {
+				auto item_id = CastToClient()->LookupTributeItemID(t.tribute, t.tier);
+				if (item_id) {
+					const EQ::ItemInstance *inst = database.CreateItem(item_id);
+					if (!inst) {
+						continue;
+					}
 
-			AddItemBonuses(inst, b, false, true);
+					AddItemBonuses(inst, b, false, true);
+					safe_delete(inst);
+				}
+			}
 		}
 	}
 

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -182,7 +182,7 @@ void Mob::CalcItemBonuses(StatBonuses* b) {
 		SetDualWeaponsEquipped(true);
 	}
 
-	if (IsOfClientBot()) {
+	if (IsClient()) {
 		if (CastToClient()->GetPP().tribute_active) {
 			for (auto const &t: CastToClient()->GetPP().tributes) {
 				auto item_id = CastToClient()->LookupTributeItemID(t.tribute, t.tier);

--- a/zone/client.h
+++ b/zone/client.h
@@ -70,6 +70,7 @@ namespace EQ
 #include "../common/data_verification.h"
 #include "../common/repositories/character_parcels_repository.h"
 #include "../common/repositories/trader_repository.h"
+#include "../common/guild_base.h"
 
 #ifdef _WINDOWS
 	// since windows defines these within windef.h (which windows.h include)
@@ -967,6 +968,8 @@ public:
 	void ChangeTributeSettings(TributeInfo_Struct *t);
 	void SendTributeTimer();
 	void ToggleTribute(bool enabled);
+	std::map<uint32, TributeData> GetTributeList();
+	uint32 LookupTributeItemID(uint32 tribute_id, uint32 tier);
 	void SendPathPacket(const std::vector<FindPerson_Point> &path);
 
 	inline PTimerList &GetPTimers() { return(p_timers); }

--- a/zone/tribute.cpp
+++ b/zone/tribute.cpp
@@ -48,7 +48,7 @@ but I dont see a point to that right now, so I dont do it.
 
 */
 extern WorldServer worldserver;
-std::map<uint32, TributeData> tribute_list;
+std::map<uint32, TributeData> tribute_list{};
 
 void Client::ToggleTribute(bool enabled) {
 	if(enabled) {
@@ -620,6 +620,26 @@ void Client::SendGuildTributeDonatePlatReply(GuildTributeDonatePlatRequest_Struc
 	QueuePacket(outapp);
 	safe_delete(outapp)
 
+}
+
+std::map<uint32, TributeData> Client::GetTributeList() {
+	return tribute_list;
+}
+
+uint32 Client::LookupTributeItemID(uint32 tribute_id, uint32 tier)
+{
+	if (!tribute_id && !tier) {
+		return 0;
+	}
+
+	if (tribute_list.contains(tribute_id)) {
+		auto tribute = tribute_list.find(tribute_id);
+		auto item_id = tribute->second.tiers[tier].tribute_item_id;
+		if (!item_id) {
+			return 0;
+		}
+		return item_id;
+	}
 }
 
 /*


### PR DESCRIPTION
# Description

It was reported that the person tribute 'Harmony of Drums/Winds/etc' were not applying their modifications correctly. I was able to reproduce. This fix should resolve the issue.  The previous PR created a BoT issue (seems BoTs do not use personal tributes) which caused issues.  

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
https://www.youtube.com/watch?v=qscETMzr7Hs

Clients tested:
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
