### PR TITLE
[Bug Fix] [Quest API] Fix getraididbycharid and getgroupidbycharid

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -1629,16 +1629,29 @@ uint32 Database::GetGuildIDByCharID(uint32 character_id)
 
 uint32 Database::GetGroupIDByCharID(uint32 character_id)
 {
-	const auto& e = GroupIdRepository::FindOne(*this, character_id);
+	const auto& e = GroupIdRepository::GetWhere(
+		*this,
+		fmt::format(
+			"`character_id` = {}",
+			character_id
+		)
+	);
 
-	return e.character_id ? e.group_id : 0;
+	return e.size() == 1 ? e.front().group_id : 0;
 }
 
 uint32 Database::GetRaidIDByCharID(uint32 character_id)
 {
-	const auto& e = RaidMembersRepository::FindOne(*this, character_id);
 
-	return e.charid ? e.raidid : 0;
+	const auto& e = RaidMembersRepository::GetWhere(
+		*this,
+		fmt::format(
+			"`charid` = {}",
+			character_id
+		)
+	);
+
+	return e.size() == 1 ? e.front().raidid : 0;
 }
 
 int64 Database::CountInvSnapshots()


### PR DESCRIPTION
# Description
getgroupidbycharid and getraididbychairid were testing against the wrong columns and always returning 0.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Testing
```
sub EVENT_SAY {
	if ($text =~/groupcheck/i) {
		quest::shout("Group ID for [" . $client->GetCleanName() . "] is [#" . quest::getgroupidbycharid($client->CharacterID()) . "]");
	}
	
	if ($text =~/raidcheck/i) {
		quest::shout("Raid ID for [" . $client->GetCleanName() . "] is [#" . quest::getraididbycharid($client->CharacterID()) . "]");
	}
}
```
![Screenshot_20240716-125829](https://github.com/user-attachments/assets/356dbe9a-24e7-472a-ab04-703e6b754b2e)

Clients tested: 
RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur