### PR TITLE
[Feature] Add Parcel notification for online players when using the Quest API

### DIFF
--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -34,6 +34,7 @@
 #include "questmgr.h"
 #include "zone.h"
 #include "data_bucket.h"
+#include "../common/events/player_event_logs.h"
 
 #include <cctype>
 
@@ -5946,7 +5947,22 @@ bool Perl__send_parcel(perl::reference table_ref)
 	e.note       = note;
 	e.sent_date  = std::time(nullptr);
 
-	return CharacterParcelsRepository::InsertOne(database, e).id;
+	auto out = CharacterParcelsRepository::InsertOne(database, e).id;
+	if (out) {
+		Parcel_Struct ps{};
+		ps.item_slot = e.slot_id;
+		strn0cpy(ps.send_to, name.c_str(), sizeof(ps.send_to));
+
+		std::unique_ptr<ServerPacket> out(new ServerPacket(ServerOP_ParcelDelivery, sizeof(Parcel_Struct)));
+		auto                          data = (Parcel_Struct *) out->pBuffer;
+
+		data->item_slot = ps.item_slot;
+		strn0cpy(data->send_to, ps.send_to, sizeof(data->send_to));
+
+		worldserver.SendPacket(out.get());
+	}
+
+	return out;
 }
 
 void perl_register_quest()

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -35,11 +35,13 @@
 #include "zone.h"
 #include "data_bucket.h"
 #include "../common/events/player_event_logs.h"
+#include "worldserver.h"
 
 #include <cctype>
 
 extern Zone      *zone;
 extern QueryServ *QServ;
+extern WorldServer worldserver;
 
 #ifdef EMBPERL_XS_CLASSES
 
@@ -5953,13 +5955,13 @@ bool Perl__send_parcel(perl::reference table_ref)
 		ps.item_slot = e.slot_id;
 		strn0cpy(ps.send_to, name.c_str(), sizeof(ps.send_to));
 
-		std::unique_ptr<ServerPacket> out(new ServerPacket(ServerOP_ParcelDelivery, sizeof(Parcel_Struct)));
-		auto                          data = (Parcel_Struct *) out->pBuffer;
+		std::unique_ptr<ServerPacket> server_packet(new ServerPacket(ServerOP_ParcelDelivery, sizeof(Parcel_Struct)));
+		auto                          data = (Parcel_Struct *) server_packet->pBuffer;
 
 		data->item_slot = ps.item_slot;
 		strn0cpy(data->send_to, ps.send_to, sizeof(data->send_to));
 
-		worldserver.SendPacket(out.get());
+		worldserver.SendPacket(server_packet.get());
 	}
 
 	return out;

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -27,6 +27,7 @@
 #include "expedition.h"
 #include "dialogue_window.h"
 #include "../common/events/player_event_logs.h"
+#include "worldserver.h"
 
 struct Events { };
 struct Factions { };
@@ -57,6 +58,8 @@ extern std::map<std::string, Encounter *> lua_encounters;
 
 extern void MapOpcodes();
 extern void ClearMappedOpcode(EmuOpcode op);
+
+extern WorldServer worldserver;
 
 void unregister_event(std::string package_name, std::string name, int evt);
 
@@ -5584,13 +5587,13 @@ bool lua_send_parcel(luabind::object lua_table)
 		ps.item_slot = e.slot_id;
 		strn0cpy(ps.send_to, name.c_str(), sizeof(ps.send_to));
 
-		std::unique_ptr<ServerPacket> out(new ServerPacket(ServerOP_ParcelDelivery, sizeof(Parcel_Struct)));
-		auto                          data = (Parcel_Struct *) out->pBuffer;
+		std::unique_ptr<ServerPacket> server_packet(new ServerPacket(ServerOP_ParcelDelivery, sizeof(Parcel_Struct)));
+		auto                          data = (Parcel_Struct *) server_packet->pBuffer;
 
 		data->item_slot = ps.item_slot;
 		strn0cpy(data->send_to, ps.send_to, sizeof(data->send_to));
 
-		worldserver.SendPacket(out.get());
+		worldserver.SendPacket(server_packet.get());
 	}
 
 	return out;


### PR DESCRIPTION
# Description

When using the quest api (lua/perl) send_parcel, the receiving player will be notified if online via the notification message and the icon in the player window.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# Testing
https://www.youtube.com/watch?v=DQbCFrsPj6w

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
