### PR TITLE
[Cleanup] Mask GM Show Buff message behind EntityVariable

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -793,7 +793,7 @@ void Client::CompleteConnect()
 		parse->EventPlayer(EVENT_ENTER_ZONE, this, "", 0);
 	}
 
-	DeleteEntityVariable("see_buffs_flag");
+	DeleteEntityVariable(SEE_BUFFS_FLAG);
 
 	// the way that the client deals with positions during the initial spawn struct
 	// is subtly different from how it deals with getting a position update

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -793,6 +793,8 @@ void Client::CompleteConnect()
 		parse->EventPlayer(EVENT_ENTER_ZONE, this, "", 0);
 	}
 
+	DeleteEntityVariable("see_buffs_flag");
+
 	// the way that the client deals with positions during the initial spawn struct
 	// is subtly different from how it deals with getting a position update
 	// if a mob is slightly in the wall or slightly clipping a floor they will be

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -1655,9 +1655,9 @@ void EntityList::QueueClientsByTarget(Mob *sender, const EQApplicationPacket *ap
 					Send = clear_target_window;
 					if (c->GetGM() || RuleB(Spells, AlwaysSendTargetsBuffs)) {
 						if (c->GetGM()) {
-							if (!c->EntityVariableExists("see_buffs_flag")) {
+							if (!c->EntityVariableExists(SEE_BUFFS_FLAG)) {
 								c->Message(Chat::White, "Your GM flag allows you to always see your targets' buffs.");
-								c->SetEntityVariable("see_buffs_flag", "1");
+								c->SetEntityVariable(SEE_BUFFS_FLAG, "1");
 							}
 						}
 

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -1655,7 +1655,10 @@ void EntityList::QueueClientsByTarget(Mob *sender, const EQApplicationPacket *ap
 					Send = clear_target_window;
 					if (c->GetGM() || RuleB(Spells, AlwaysSendTargetsBuffs)) {
 						if (c->GetGM()) {
-							c->Message(Chat::White, "Your GM flag allows you to always see your targets' buffs.");
+							if (!c->EntityVariableExists("see_buffs_flag")) {
+								c->Message(Chat::White, "Your GM flag allows you to always see your targets' buffs.");
+								c->SetEntityVariable("see_buffs_flag", "1");
+							}
 						}
 
 						Send = !clear_target_window;

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -60,6 +60,8 @@ class Bot;
 
 extern EntityList entity_list;
 
+constexpr std::string SEE_BUFFS_FLAG = "see_buffs_flag";
+
 class Entity
 {
 public:

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -60,7 +60,7 @@ class Bot;
 
 extern EntityList entity_list;
 
-constexpr std::string SEE_BUFFS_FLAG = "see_buffs_flag";
+constexpr const char* SEE_BUFFS_FLAG = "see_buffs_flag";
 
 class Entity
 {


### PR DESCRIPTION
# Description

Removes the spam of "Your GM flag allows you to always see your targets' buffs." for GMs every time a buff lands on a target.

It will now lock to an Entity Variable and only show once per zone.

# Testing

Zoned multiple times and allows multiple spells to landed on targeted NPCs and verified it only displays once per zone and resets each zone.

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
