### PR TITLE
[Bug Fix] Fix Client::RemoveTitle

### DIFF
--- a/zone/titles.cpp
+++ b/zone/titles.cpp
@@ -343,7 +343,7 @@ void Client::RemoveTitle(int title_set)
 		return;
 	}
 
-	for (const auto& title : TitleManager::GetTitles()) {
+	for (const auto& title : title_manager.GetTitles()) {
 		if (title.titleset == title_set) {
 			if (std::string(m_pp.title) == title.prefix) {
 				SetAATitle("");

--- a/zone/titles.cpp
+++ b/zone/titles.cpp
@@ -19,7 +19,7 @@
 #include "../common/eq_packet_structs.h"
 #include "../common/strings.h"
 #include "../common/misc_functions.h"
-#include "../common/repositories/titles_repository.h"
+#include "../common/repositories/player_titlesets_repository.h"
 
 #include "client.h"
 #include "entity.h"
@@ -343,7 +343,7 @@ void Client::RemoveTitle(int title_set)
 		return;
 	}
 
-	TitlesRepository::DeleteWhere(
+	PlayerTitlesetsRepository::DeleteWhere(
 		database,
 		fmt::format(
 			"`title_set` = {} AND `char_id` = {}",

--- a/zone/titles.cpp
+++ b/zone/titles.cpp
@@ -347,7 +347,9 @@ void Client::RemoveTitle(int title_set)
 		if (title.titleset == title_set) {
 			if (std::string(m_pp.title) == title.prefix) {
 				SetAATitle("");
-			} else if (std::string(m_pp.suffix) == title.suffix) {
+			}
+
+			if (std::string(m_pp.suffix) == title.suffix) {
 				SetTitleSuffix("");
 			}
 

--- a/zone/titles.cpp
+++ b/zone/titles.cpp
@@ -343,6 +343,18 @@ void Client::RemoveTitle(int title_set)
 		return;
 	}
 
+	for (const auto& title : TitleManager::GetTitles()) {
+		if (title.titleset == title_set) {
+			if (std::string(m_pp.title) == title.prefix) {
+				SetAATitle("");
+			} else if (std::string(m_pp.suffix) == title.suffix) {
+				SetTitleSuffix("");
+			}
+
+			break;
+		}
+	}
+
 	PlayerTitlesetsRepository::DeleteWhere(
 		database,
 		fmt::format(

--- a/zone/titles.h
+++ b/zone/titles.h
@@ -57,7 +57,7 @@ public:
 	void CreateNewPlayerTitle(Client *client, std::string title);
 	void CreateNewPlayerSuffix(Client *client, std::string suffix);
 	bool HasTitle(Client* client, uint32 title_id);
-	inline static const std::vector<TitleEntry>& GetTitles() { return titles; }
+	inline const std::vector<TitleEntry>& GetTitles() { return titles; }
 
 protected:
 	std::vector<TitleEntry> titles;

--- a/zone/titles.h
+++ b/zone/titles.h
@@ -57,6 +57,7 @@ public:
 	void CreateNewPlayerTitle(Client *client, std::string title);
 	void CreateNewPlayerSuffix(Client *client, std::string suffix);
 	bool HasTitle(Client* client, uint32 title_id);
+	inline static const std::vector<TitleEntry>& GetTitles() { return titles; }
 
 protected:
 	std::vector<TitleEntry> titles;


### PR DESCRIPTION
# Description
@Valorith described an issue where player titlesets when removed were not being removed from the player. Looking at the code we seem to be using the wrong repository.

## Type of change
- [X] Bug fix

# Checklist
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
