### PR TITLE
[Bug Fix] Fix #setlevel Allowing Skills Above Max

### DIFF
--- a/zone/gm_commands/set/level.cpp
+++ b/zone/gm_commands/set/level.cpp
@@ -25,6 +25,13 @@ void SetLevel(Client *c, const Seperator *sep)
 	t->SetLevel(level, true);
 
 	if (t->IsClient()) {
+		for (const auto& s : EQ::skills::GetSkillTypeMap()) {
+			const uint16 max_skill_value = t->CastToClient()->MaxSkill(s.first);
+			if (t->GetSkill(s.first) > max_skill_value) {
+				t->CastToClient()->SetSkill(s.first, max_skill_value);
+			}
+		}
+
 		t->CastToClient()->SendLevelAppearance();
 
 		if (RuleB(Bots, Enabled) && RuleB(Bots, BotLevelsWithOwner)) {


### PR DESCRIPTION
# Description
- Fixes an issue described in https://github.com/EQEmu/Server/issues/4300 that happens when setting a player to a level lower than they were before with skills higher than they're allowed to have or skills they should not have access to at their new level, such as Dual Wield, Triple Attack, etc.

## Type of change
- [X] Bug fix

# Testing
[Screencast from 07-22-2024 07:13:13 AM.webm](https://github.com/user-attachments/assets/29d83c3c-65a3-4050-b9a7-1b7af139eaac)

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur