### PR TITLE
[Commands] Extend #devtools Functionality

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -9338,6 +9338,7 @@ void Client::ShowDevToolsMenu()
 	std::string menu_reload_eight;
 	std::string menu_reload_nine;
 	std::string menu_toggle;
+	std::string window_toggle;
 
 	/**
 	 * Search entity commands
@@ -9403,9 +9404,14 @@ void Client::ShowDevToolsMenu()
 	/**
 	 * Show window status
 	 */
-	menu_toggle = Saylink::Silent("#devtools enable", "Enable");
+	menu_toggle = Saylink::Silent("#devtools menu enable", "Enable");
 	if (IsDevToolsEnabled()) {
-		menu_toggle = Saylink::Silent("#devtools disable", "Disable");
+		menu_toggle = Saylink::Silent("#devtools menu disable", "Disable");
+	}
+
+	window_toggle = Saylink::Silent("#devtools window enable", "Enable");
+	if (GetDisplayMobInfoWindow()) {
+		window_toggle = Saylink::Silent("#devtools window disable", "Disable");
 	}
 
 	/**
@@ -9426,8 +9432,16 @@ void Client::ShowDevToolsMenu()
 	Message(
 		Chat::White,
 		fmt::format(
-			"Toggle | {}",
+			"Toggle Menu | {}",
 			menu_toggle
+		).c_str()
+	);
+
+	Message(
+		Chat::White,
+		fmt::format(
+			"Toggle Window | {}",
+			window_toggle
 		).c_str()
 	);
 

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -112,7 +112,7 @@ int command_init(void)
 		command_add("delpetition", "[petition number] - Delete a petition", AccountStatus::ApprenticeGuide, command_delpetition) ||
 		command_add("depop", "[Start Spawn Timer] - Depop your NPC target and optionally start their spawn timer (false by default)", AccountStatus::Guide, command_depop) ||
 		command_add("depopzone", "[Start Spawn Timers] - Depop the zone and optionally start spawn timers (false by default)", AccountStatus::GMAdmin, command_depopzone) ||
-		command_add("devtools", "[Enable|Disable] - Manages Developer Tools (send no parameter for menu)", AccountStatus::GMMgmt, command_devtools) ||
+		command_add("devtools", "[menu|window] [enable|disable] - Manages Developer Tools (send no parameter for menu)", AccountStatus::GMMgmt, command_devtools) ||
 		command_add("disablerecipe", "[Recipe ID] - Disables a Recipe", AccountStatus::QuestTroupe, command_disablerecipe) ||
 		command_add("disarmtrap", "Analog for ldon disarm trap for the newer clients since we still don't have it working.", AccountStatus::QuestTroupe, command_disarmtrap) ||
 		command_add("door", "Door editing command", AccountStatus::QuestTroupe, command_door) ||

--- a/zone/gm_commands/devtools.cpp
+++ b/zone/gm_commands/devtools.cpp
@@ -3,11 +3,19 @@
 
 void command_devtools(Client *c, const Seperator *sep)
 {
-	bool is_disable = !strcasecmp(sep->arg[1], "disable");
-	bool is_enable = !strcasecmp(sep->arg[1], "enable");
+	const uint16 arguments = sep->argnum;
+	if (arguments != 2) {
+		c->ShowDevToolsMenu();
+		return;
+	}
 
-	if (is_disable || is_enable) {
-		c->SetDevToolsEnabled(is_enable);
+	const std::string& type = sep->arg[1];
+	const bool toggle = Strings::ToBool(sep->arg[2]);
+
+	if (Strings::EqualFold(type, "menu")) {
+		c->SetDevToolsEnabled(toggle);
+	} else if (Strings::EqualFold(type, "window")) {
+		c->SetDisplayMobInfoWindow(toggle);
 	}
 
 	c->ShowDevToolsMenu();


### PR DESCRIPTION
# Description
- Extends `#devtools` to now require 2 parameters, first being `menu` or `window` and the second being your toggle for them.
- This resolves https://github.com/EQEmu/Server/issues/4307 by adding a way to toggle the window back on if you snooze it and would like it back without zoning.

## Type of change
- [x] New feature

# Testing
[Screencast from 07-22-2024 07:49:59 AM.webm](https://github.com/user-attachments/assets/b087dedd-256a-4b97-98be-32c76f7341ee)

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur