### PR TITLE
[Databuckets] Remove memory reserve from bulk load

### DIFF
--- a/zone/data_bucket.cpp
+++ b/zone/data_bucket.cpp
@@ -428,8 +428,6 @@ void DataBucket::BulkLoadEntities(DataBucketLoadType::Type t, std::vector<uint32
 		return;
 	}
 
-	size_t size_before = g_data_bucket_cache.size();
-
 	LogDataBucketsDetail("cache size before [{}] l size [{}]", g_data_bucket_cache.size(), l.size());
 
 	uint32 added_count = 0;
@@ -439,8 +437,6 @@ void DataBucket::BulkLoadEntities(DataBucketLoadType::Type t, std::vector<uint32
 			added_count++;
 		}
 	}
-
-	g_data_bucket_cache.reserve(g_data_bucket_cache.size() + added_count);
 
 	for (const auto &e: l) {
 		if (!ExistsInCache(e)) {


### PR DESCRIPTION
# Description

This change simply removes a memory reserve which is fine under initial load which is how the server uses it. When this is used from a Quest API repeatedly, this can end up "leaking" memory because of constantly reserving more than what's needed because we don't know for sure if it exists in the cache already at this point.

This change should largely be harmless.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

No testing really needs to be done for this. This is preemptive allocation of memory.

# Checklist

- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur