### PR TITLE
Akkadius/zone routing algorithm improvements

### DIFF
--- a/common/content/world_content_service.h
+++ b/common/content/world_content_service.h
@@ -160,6 +160,7 @@ public:
 	WorldContentService * SetExpansionContext();
 
 	bool DoesPassContentFiltering(const ContentFlags& f);
+	bool DoesZonePassContentFiltering(const ZoneRepository::Zone& z);
 
 	WorldContentService * SetDatabase(Database *database);
 	Database *GetDatabase() const;
@@ -177,7 +178,7 @@ public:
 		ZoneRepository::Zone                 zone;
 	};
 
-	FindZoneResult FindZone(uint32 zone_id, uint32 instance_id);
+	FindZoneResult FindZone(uint32 zone, uint32 instance_id);
 	bool IsInPublicStaticInstance(uint32 instance_id);
 
 private:
@@ -189,9 +190,8 @@ private:
 	Database *m_content_database;
 
 	// holds a record of the zone table from the database
-	std::vector<ZoneRepository::Zone> m_zones = {};
 	WorldContentService *LoadStaticGlobalZoneInstances();
-	std::vector<InstanceListRepository::InstanceList> m_zone_instances;
+	std::vector<InstanceListRepository::InstanceList> m_zone_static_instances;
 	WorldContentService * LoadZones();
 };
 

--- a/common/content/world_content_service.h
+++ b/common/content/world_content_service.h
@@ -178,7 +178,7 @@ public:
 		ZoneRepository::Zone                 zone;
 	};
 
-	FindZoneResult FindZone(uint32 zone, uint32 instance_id);
+	FindZoneResult FindZone(uint32 zone_id, uint32 instance_id);
 	bool IsInPublicStaticInstance(uint32 instance_id);
 
 private:

--- a/common/content/world_content_service.h
+++ b/common/content/world_content_service.h
@@ -192,7 +192,6 @@ private:
 	// holds a record of the zone table from the database
 	WorldContentService *LoadStaticGlobalZoneInstances();
 	std::vector<InstanceListRepository::InstanceList> m_zone_static_instances;
-	WorldContentService * LoadZones();
 };
 
 extern WorldContentService content_service;


### PR DESCRIPTION
# Description

This PR is necessary to fix a few reported extreme edge cases. It simplifies the routing logic quite a bit. This logic has otherwise been battle tested for a few months now with little to no issues.

* Using #zoneinstance to a public static instance and being able to not zone
* Rare chance that the wrong zone data gets matched with an instance route
* We no longer route players when they matched a zone but didn't match an instance, this is something that should be handled by the rest of the code and normally be returned as zone_id 0 so zoning can continue as normal. This also created the possibility that the wrong zone data could be used in the route.

The code now ensures that if the zone in question is an instance, that we match explicitly the instance_id when we are iterating through public static instances. Before, there was a rare chance that the wrong instance could be matched if multiples of the same were in the database.

```cpp
WorldContentService::FindZoneResult WorldContentService::FindZone(uint32 zone_id, uint32 instance_id)
{
	for (const auto &z: zone_store.GetZones()) {
		for (auto &i: m_zone_static_instances) {
			if (
				z.zoneidnumber == zone_id &&
				DoesZonePassContentFiltering(z) &&
				i.zone == zone_id &&
				i.version == z.version) {

				if (instance_id > 0 && i.id != instance_id) {
					continue;
				}

				LogInfo(
					"Routed player to public static instance [{}] of zone [{}] ({}) version [{}] long_name [{}] notes [{}]",
					i.id,
					z.short_name,
					z.zoneidnumber,
					z.version,
					z.long_name,
					i.notes
				);

				return WorldContentService::FindZoneResult{
					.zone_id = static_cast<uint32>(z.zoneidnumber),
					.instance = i,
					.zone = z
				};
			}
		}
	}

	return WorldContentService::FindZoneResult{.zone_id = 0};
}
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Tested zoning locally

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
