### PR TITLE
[Revert] Handle routing to instances when using evac/succor (#4297)

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -241,7 +241,6 @@ Client::Client(EQStreamInterface *ieqs) : Mob(
 	runmode = false;
 	linkdead_timer.Disable();
 	zonesummon_id = 0;
-	zonesummon_instance_id = 0;
 	zonesummon_ignorerestrictions = 0;
 	bZoning              = false;
 	m_lock_save_position = false;

--- a/zone/client.h
+++ b/zone/client.h
@@ -1980,7 +1980,6 @@ private:
 
 	glm::vec4 m_ZoneSummonLocation;
 	uint16 zonesummon_id;
-	uint8 zonesummon_instance_id;
 	uint8 zonesummon_ignorerestrictions;
 	ZoneMode zone_mode;
 

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -94,7 +94,6 @@ void Client::Handle_OP_ZoneChange(const EQApplicationPacket *app) {
 			case GMHiddenSummon:
 			case ZoneSolicited: //we told the client to zone somewhere, so we know where they are going.
 				target_zone_id = zonesummon_id;
-				target_instance_id = zonesummon_instance_id;
 				break;
 			case GateToBindPoint:
 			case ZoneToBindPoint:
@@ -127,7 +126,6 @@ void Client::Handle_OP_ZoneChange(const EQApplicationPacket *app) {
 		// WildcardX 27 January 2008
 		if (zone_mode == EvacToSafeCoords && zonesummon_id) {
 			target_zone_id = zonesummon_id;
-			target_instance_id = zonesummon_instance_id;
 		} else {
 			target_zone_id = zc->zoneID;
 		}
@@ -575,7 +573,6 @@ void Client::DoZoneSuccess(ZoneChange_Struct *zc, uint16 zone_id, uint32 instanc
 	zone_mode = ZoneUnsolicited;
 	m_ZoneSummonLocation = glm::vec4();
 	zonesummon_id = 0;
-	zonesummon_instance_id = 0;
 	zonesummon_ignorerestrictions = 0;
 
 	// this simply resets the zone shutdown timer
@@ -962,7 +959,6 @@ void Client::ZonePC(uint32 zoneID, uint32 instance_id, float x, float y, float z
 
 			// we hide the real zoneid we want to evac/succor to here
 			zonesummon_id = zoneID;
-			zonesummon_instance_id = instance_id;
 
 			outapp->priority = 6;
 			FastQueuePacket(&outapp);


### PR DESCRIPTION
# Description

This reverts commit dfd1bfbd493487f40ea96172b5bd854874e8e96d.

This has been causing intermittent issues as it relates to evac within instances. The original issue was conflated with zone routing rules that have also recently been addressed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Tested on Wayfarers

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
