### PR TITLE
[Bug Fix] Fix #parcels add subcommand

### DIFF
--- a/zone/gm_commands/parcels.cpp
+++ b/zone/gm_commands/parcels.cpp
@@ -163,7 +163,7 @@ void command_parcels(Client *c, const Seperator *sep)
 				return;
 			}
 
-			CharacterParcelsRepository::CharacterParcels parcel_out;
+			auto parcel_out = CharacterParcelsRepository::NewEntity();
 			parcel_out.from_name = c->GetName();
 			parcel_out.note      = note;
 			parcel_out.sent_date = time(nullptr);
@@ -241,7 +241,7 @@ void command_parcels(Client *c, const Seperator *sep)
 					? inst->GetItem()->MaxCharges : (int16) quantity;
 			}
 
-			CharacterParcelsRepository::CharacterParcels parcel_out;
+			auto parcel_out = CharacterParcelsRepository::NewEntity();
 			parcel_out.from_name = c->GetName();
 			parcel_out.note      = note.empty() ? "" : note;
 			parcel_out.sent_date = time(nullptr);


### PR DESCRIPTION
# Description
A report from WFH of items sent using the #parcels add gm command having their LORE attribute changed unexpectedly. 
 The cause was that the parcel object was not be initialized fully resulting in the possibility of incorrect data being written for the uninitialized members.

Fixes # (issue)
A report from @fryguy503 (WFH).

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
This has been tested on WFH and confirmed that the issue was resolved.

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
