### PR TITLE
[Bug Fix] Stop DOSing ourselves with OP_WearChange

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -16035,7 +16035,8 @@ void Client::Handle_OP_WearChange(const EQApplicationPacket *app)
 		wc->hero_forge_model = GetHerosForgeModel(wc->wear_slot_id);
 
 	// we could maybe ignore this and just send our own from moveitem
-	entity_list.QueueClients(this, app, false);
+	// We probably need to skip this entirely when it is send as an ack, but not sure how to ID that.
+	entity_list.QueueClients(this, app, true);
 }
 
 void Client::Handle_OP_WhoAllRequest(const EQApplicationPacket *app)

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -14757,10 +14757,6 @@ void Client::Handle_OP_SpawnAppearance(const EQApplicationPacket *app)
 			playeraction = 4;
 			SetFeigned(false);
 		}
-		else if (sa->parameter == Animation::Freeze) {
-			// Client seems to expect an ack here
-			SendAppearancePacket(AppearanceType::Animation, Animation::Freeze);
-		}
 
 		else {
 			LogError("Client [{}] :: unknown appearance [{}]", name, (int)sa->parameter);

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -14757,6 +14757,10 @@ void Client::Handle_OP_SpawnAppearance(const EQApplicationPacket *app)
 			playeraction = 4;
 			SetFeigned(false);
 		}
+		else if (sa->parameter == Animation::Freeze) {
+			// Client seems to expect an ack here
+			SendAppearancePacket(AppearanceType::Animation, Animation::Freeze);
+		}
 
 		else {
 			LogError("Client [{}] :: unknown appearance [{}]", name, (int)sa->parameter);


### PR DESCRIPTION
# Description

This modifies `Handle_OP_WearChange` to skip sending the packet back to the sender. The client appears to echo this packet back to us under this circumstance, which generates a packet storm which significantly impacts client performance. This manifests as increased rate of random disconnects under many circumstances.

I'm opening this as a draft because there may be a better way to handle this; I'm not certain that we should be spraying this to all clients in the Handler method at all, but I don't understand either the purpose of this packet or the intended architecture here well enough to make that call, and would like the input from more experienced contributors.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Prior to implementing this change, it could be observed that any populated zone would be absolutely inundated with OP_WearChange C->S AND S->C traffic (The entire client chat buffer would fill with either filter of this traffic, occuluding ANY other output). After this change, that amount of traffic is much more reasonable.

Clients tested: 
ROF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
