### PR TITLE
[Feature] Add Character:DefaultGuildRank Rule

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -66,6 +66,7 @@
 #endif
 
 #include "database.h"
+#include "data_verification.h"
 #include "eq_packet_structs.h"
 #include "extprofile.h"
 #include "strings.h"
@@ -308,14 +309,15 @@ bool Database::ReserveName(uint32 account_id, const std::string& name)
 		return false;
 	}
 
-	const uint32 guild_id = RuleI(Character, DefaultGuild);
+	const uint32 guild_id   = RuleI(Character, DefaultGuild);
+	const uint8  guild_rank = EQ::Clamp(RuleI(Character, DefaultGuildRank), 0, 8);
 	if (guild_id != 0) {
 		if (e.id) {
 			auto g = GuildMembersRepository::NewEntity();
 
 			g.char_id  = e.id;
 			g.guild_id = guild_id;
-			g.rank_    = RuleI(Character, DefaultGuildRank);
+			g.rank_    = guild_rank;
 
 			GuildMembersRepository::InsertOne(*this, g);
 		}

--- a/common/database.cpp
+++ b/common/database.cpp
@@ -308,13 +308,14 @@ bool Database::ReserveName(uint32 account_id, const std::string& name)
 		return false;
 	}
 
-	const int guild_id = RuleI(Character, DefaultGuild);
+	const uint32 guild_id = RuleI(Character, DefaultGuild);
 	if (guild_id != 0) {
 		if (e.id) {
 			auto g = GuildMembersRepository::NewEntity();
 
 			g.char_id  = e.id;
 			g.guild_id = guild_id;
+			g.rank_    = RuleI(Character, DefaultGuildRank);
 
 			GuildMembersRepository::InsertOne(*this, g);
 		}

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -178,7 +178,7 @@ RULE_BOOL(Character, NoSkillsOnHorse, false, "Enabling this will prevent Bind Wo
 RULE_BOOL(Character, UseNoJunkFishing, false, "Disregards junk items when fishing")
 RULE_BOOL(Character, SoftDeletes, true, "When characters are deleted in character select, they are only soft deleted")
 RULE_INT(Character, DefaultGuild, 0, "If not 0, new characters placed into the guild # indicated")
-RULE_INT(Character, DefaultGuildRank, 0, "Default guild rank when Character:DefaultGuild is anon-0 value, default is 0")
+RULE_INT(Character, DefaultGuildRank, 0, "Default guild rank when Character:DefaultGuild is a non-0 value, default is 0")
 RULE_BOOL(Character, ProcessFearedProximity, false, "Processes proximity checks when feared")
 RULE_BOOL(Character, EnableCharacterEXPMods, false, "Enables character zone-based experience modifiers.")
 RULE_BOOL(Character, PVPEnableGuardFactionAssist, true, "Enables faction based assisting against the aggresor in pvp.")

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -178,7 +178,7 @@ RULE_BOOL(Character, NoSkillsOnHorse, false, "Enabling this will prevent Bind Wo
 RULE_BOOL(Character, UseNoJunkFishing, false, "Disregards junk items when fishing")
 RULE_BOOL(Character, SoftDeletes, true, "When characters are deleted in character select, they are only soft deleted")
 RULE_INT(Character, DefaultGuild, 0, "If not 0, new characters placed into the guild # indicated")
-RULE_INT(Character, DefaultGuildRank, 0, "Default guild rank when Character:DefaultGuild is a non-0 value, default is 0")
+RULE_INT(Character, DefaultGuildRank, 8, "Default guild rank when Character:DefaultGuild is a non-0 value, default is 8 (Recruit)")
 RULE_BOOL(Character, ProcessFearedProximity, false, "Processes proximity checks when feared")
 RULE_BOOL(Character, EnableCharacterEXPMods, false, "Enables character zone-based experience modifiers.")
 RULE_BOOL(Character, PVPEnableGuardFactionAssist, true, "Enables faction based assisting against the aggresor in pvp.")

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -178,6 +178,7 @@ RULE_BOOL(Character, NoSkillsOnHorse, false, "Enabling this will prevent Bind Wo
 RULE_BOOL(Character, UseNoJunkFishing, false, "Disregards junk items when fishing")
 RULE_BOOL(Character, SoftDeletes, true, "When characters are deleted in character select, they are only soft deleted")
 RULE_INT(Character, DefaultGuild, 0, "If not 0, new characters placed into the guild # indicated")
+RULE_INT(Character, DefaultGuildRank, 0, "Default guild rank when Character:DefaultGuild is anon-0 value, default is 0")
 RULE_BOOL(Character, ProcessFearedProximity, false, "Processes proximity checks when feared")
 RULE_BOOL(Character, EnableCharacterEXPMods, false, "Enables character zone-based experience modifiers.")
 RULE_BOOL(Character, PVPEnableGuardFactionAssist, true, "Enables faction based assisting against the aggresor in pvp.")


### PR DESCRIPTION
# Description
- Adds `Character:DefaultGuildRank` rule that sets members of the `Character:DefaultGuild` to the rank specified, `0` is the default for the lowest possibly member rank.

## Type of change
- [X] New feature

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur