### PR TITLE
[Bug Fix] Fix Bot Spell Entries IDs Capping at 32,767

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -5718,6 +5718,17 @@ COLLATE='latin1_swedish_ci'
 ENGINE=InnoDB
 AUTO_INCREMENT=1;
 )"
+	},
+	ManifestEntry{
+		.version = 9282,
+		.description = "2024_08_05_bot_spells_entries_unsigned_spell_id.sql",
+		.check = "SHOW COLUMNS FROM `bot_spells_entries` LIKE 'spellid'",
+		.condition = "empty",
+		.match = "",
+		.sql = R"(
+ALTER TABLE `bot_spells_entries`
+CHANGE COLUMN `spellid` `spell_id` smallint(5) UNSIGNED NOT NULL DEFAULT 0 AFTER `npc_spells_id`;
+)"
 	}
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{

--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -5718,17 +5718,6 @@ COLLATE='latin1_swedish_ci'
 ENGINE=InnoDB
 AUTO_INCREMENT=1;
 )"
-	},
-	ManifestEntry{
-		.version = 9282,
-		.description = "2024_08_05_bot_spells_entries_unsigned_spell_id.sql",
-		.check = "SHOW COLUMNS FROM `bot_spells_entries` LIKE 'spellid'",
-		.condition = "empty",
-		.match = "",
-		.sql = R"(
-ALTER TABLE `bot_spells_entries`
-CHANGE COLUMN `spellid` `spell_id` smallint(5) UNSIGNED NOT NULL DEFAULT 0 AFTER `npc_spells_id`;
-)"
 	}
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{

--- a/common/database/database_update_manifest_bots.cpp
+++ b/common/database/database_update_manifest_bots.cpp
@@ -151,6 +151,17 @@ ADD COLUMN `augment_six` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `augment_five
 ALTER TABLE `bot_data`
 ADD COLUMN `extra_haste` mediumint(8) NOT NULL DEFAULT 0 AFTER `wis`;
 )"
+	},
+	ManifestEntry{
+		.version = 9045,
+		.description = "2024_08_05_bot_spells_entries_unsigned_spell_id.sql",
+		.check = "SHOW COLUMNS FROM `bot_spells_entries` LIKE 'spell_id'",
+		.condition = "empty",
+		.match = "",
+		.sql = R"(
+ALTER TABLE `bot_spells_entries`
+CHANGE COLUMN `spellid` `spell_id` smallint(5) UNSIGNED NOT NULL DEFAULT 0 AFTER `npc_spells_id`;
+)"
 	}
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{

--- a/common/repositories/base/base_bot_spells_entries_repository.h
+++ b/common/repositories/base/base_bot_spells_entries_repository.h
@@ -21,7 +21,7 @@ public:
 	struct BotSpellsEntries {
 		uint32_t    id;
 		int32_t     npc_spells_id;
-		int16_t     spellid;
+		uint16_t    spell_id;
 		uint32_t    type;
 		uint8_t     minlevel;
 		uint8_t     maxlevel;
@@ -46,7 +46,7 @@ public:
 		return {
 			"id",
 			"npc_spells_id",
-			"spellid",
+			"spell_id",
 			"type",
 			"minlevel",
 			"maxlevel",
@@ -67,7 +67,7 @@ public:
 		return {
 			"id",
 			"npc_spells_id",
-			"spellid",
+			"spell_id",
 			"type",
 			"minlevel",
 			"maxlevel",
@@ -122,7 +122,7 @@ public:
 
 		e.id                = 0;
 		e.npc_spells_id     = 0;
-		e.spellid           = 0;
+		e.spell_id          = 0;
 		e.type              = 0;
 		e.minlevel          = 0;
 		e.maxlevel          = 255;
@@ -173,7 +173,7 @@ public:
 
 			e.id                = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.npc_spells_id     = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
-			e.spellid           = row[2] ? static_cast<int16_t>(atoi(row[2])) : 0;
+			e.spell_id          = row[2] ? static_cast<uint16_t>(strtoul(row[2], nullptr, 10)) : 0;
 			e.type              = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.minlevel          = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.maxlevel          = row[5] ? static_cast<uint8_t>(strtoul(row[5], nullptr, 10)) : 255;
@@ -220,7 +220,7 @@ public:
 		auto columns = Columns();
 
 		v.push_back(columns[1] + " = " + std::to_string(e.npc_spells_id));
-		v.push_back(columns[2] + " = " + std::to_string(e.spellid));
+		v.push_back(columns[2] + " = " + std::to_string(e.spell_id));
 		v.push_back(columns[3] + " = " + std::to_string(e.type));
 		v.push_back(columns[4] + " = " + std::to_string(e.minlevel));
 		v.push_back(columns[5] + " = " + std::to_string(e.maxlevel));
@@ -256,7 +256,7 @@ public:
 
 		v.push_back(std::to_string(e.id));
 		v.push_back(std::to_string(e.npc_spells_id));
-		v.push_back(std::to_string(e.spellid));
+		v.push_back(std::to_string(e.spell_id));
 		v.push_back(std::to_string(e.type));
 		v.push_back(std::to_string(e.minlevel));
 		v.push_back(std::to_string(e.maxlevel));
@@ -300,7 +300,7 @@ public:
 
 			v.push_back(std::to_string(e.id));
 			v.push_back(std::to_string(e.npc_spells_id));
-			v.push_back(std::to_string(e.spellid));
+			v.push_back(std::to_string(e.spell_id));
 			v.push_back(std::to_string(e.type));
 			v.push_back(std::to_string(e.minlevel));
 			v.push_back(std::to_string(e.maxlevel));
@@ -348,7 +348,7 @@ public:
 
 			e.id                = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.npc_spells_id     = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
-			e.spellid           = row[2] ? static_cast<int16_t>(atoi(row[2])) : 0;
+			e.spell_id          = row[2] ? static_cast<uint16_t>(strtoul(row[2], nullptr, 10)) : 0;
 			e.type              = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.minlevel          = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.maxlevel          = row[5] ? static_cast<uint8_t>(strtoul(row[5], nullptr, 10)) : 255;
@@ -387,7 +387,7 @@ public:
 
 			e.id                = row[0] ? static_cast<uint32_t>(strtoul(row[0], nullptr, 10)) : 0;
 			e.npc_spells_id     = row[1] ? static_cast<int32_t>(atoi(row[1])) : 0;
-			e.spellid           = row[2] ? static_cast<int16_t>(atoi(row[2])) : 0;
+			e.spell_id          = row[2] ? static_cast<uint16_t>(strtoul(row[2], nullptr, 10)) : 0;
 			e.type              = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.minlevel          = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.maxlevel          = row[5] ? static_cast<uint8_t>(strtoul(row[5], nullptr, 10)) : 255;
@@ -476,7 +476,7 @@ public:
 
 		v.push_back(std::to_string(e.id));
 		v.push_back(std::to_string(e.npc_spells_id));
-		v.push_back(std::to_string(e.spellid));
+		v.push_back(std::to_string(e.spell_id));
 		v.push_back(std::to_string(e.type));
 		v.push_back(std::to_string(e.minlevel));
 		v.push_back(std::to_string(e.maxlevel));
@@ -513,7 +513,7 @@ public:
 
 			v.push_back(std::to_string(e.id));
 			v.push_back(std::to_string(e.npc_spells_id));
-			v.push_back(std::to_string(e.spellid));
+			v.push_back(std::to_string(e.spell_id));
 			v.push_back(std::to_string(e.type));
 			v.push_back(std::to_string(e.minlevel));
 			v.push_back(std::to_string(e.maxlevel));

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9281
+#define CURRENT_BINARY_DATABASE_VERSION 9282
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9044
 
 #endif

--- a/common/version.h
+++ b/common/version.h
@@ -42,8 +42,8 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9282
-#define CURRENT_BINARY_BOTS_DATABASE_VERSION 9044
+#define CURRENT_BINARY_DATABASE_VERSION 9281
+#define CURRENT_BINARY_BOTS_DATABASE_VERSION 9045
 
 #endif
 

--- a/zone/botspellsai.cpp
+++ b/zone/botspellsai.cpp
@@ -3324,18 +3324,19 @@ DBbotspells_Struct* ZoneDatabase::GetBotSpells(uint32 bot_spell_id)
 		if (!bse.empty()) {
 			for (const auto& e : bse) {
 				DBbotspells_entries_Struct entry;
-				entry.spellid = e.spellid;
-				entry.type = e.type;
-				entry.minlevel = e.minlevel;
-				entry.maxlevel = e.maxlevel;
-				entry.manacost = e.manacost;
-				entry.recast_delay = e.recast_delay;
-				entry.priority = e.priority;
-				entry.min_hp = e.min_hp;
-				entry.max_hp = e.max_hp;
-				entry.resist_adjust = e.resist_adjust;
-				entry.bucket_name = e.bucket_name;
-				entry.bucket_value = e.bucket_value;
+
+				entry.spellid           = e.spell_id;
+				entry.type              = e.type;
+				entry.minlevel          = e.minlevel;
+				entry.maxlevel          = e.maxlevel;
+				entry.manacost          = e.manacost;
+				entry.recast_delay      = e.recast_delay;
+				entry.priority          = e.priority;
+				entry.min_hp            = e.min_hp;
+				entry.max_hp            = e.max_hp;
+				entry.resist_adjust     = e.resist_adjust;
+				entry.bucket_name       = e.bucket_name;
+				entry.bucket_value      = e.bucket_value;
 				entry.bucket_comparison = e.bucket_comparison;
 
 				// some spell types don't make much since to be priority 0, so fix that
@@ -3345,8 +3346,8 @@ DBbotspells_Struct* ZoneDatabase::GetBotSpells(uint32 bot_spell_id)
 
 				if (e.resist_adjust) {
 					entry.resist_adjust = e.resist_adjust;
-				} else if (IsValidSpell(e.spellid)) {
-					entry.resist_adjust = spells[e.spellid].resist_difficulty;
+				} else if (IsValidSpell(e.spell_id)) {
+					entry.resist_adjust = spells[e.spell_id].resist_difficulty;
 				}
 
 				spell_set.entries.push_back(entry);


### PR DESCRIPTION
# Description
- Spell IDs for bots were limited to `32,767` because the field wasn't `unsigned`.

## Type of change
- [X] Bug fix

# Testing
![image](https://github.com/user-attachments/assets/55b3fe0a-e947-4551-a737-d372495de3b7)

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur