### PR TITLE
[Bug Fix] Fix AddCrystals() in Perl/Lua

### DIFF
--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -1214,25 +1214,23 @@ void Lua_Client::AddPVPPoints(uint32 points) {
 	self->AddPVPPoints(points);
 }
 
-void Lua_Client::AddCrystals(uint32 radiant, uint32 ebon) {
+void Lua_Client::AddCrystals(uint32 radiant_count, uint32 ebon_count) {
 	Lua_Safe_Call_Void();
 
-	if (ebon != 0) {
-		if (ebon > 0) {
-			self->AddEbonCrystals(ebon);
-			return;
+	if (ebon_count != 0) {
+		if (ebon_count > 0) {
+			self->AddEbonCrystals(ebon_count);
+		} else {
+			self->RemoveEbonCrystals(ebon_count);
 		}
-
-		self->RemoveEbonCrystals(ebon);
 	}
 
-	if (radiant != 0) {
-		if (radiant > 0) {
-			self->AddRadiantCrystals(radiant);
-			return;
+	if (radiant_count != 0) {
+		if (radiant_count > 0) {
+			self->AddRadiantCrystals(radiant_count);
+		} else {
+			self->RemoveRadiantCrystals(radiant_count);
 		}
-
-		self->RemoveRadiantCrystals(radiant);
 	}
 }
 

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -316,7 +316,7 @@ public:
 	void KeyRingAdd(uint32 item);
 	bool KeyRingCheck(uint32 item);
 	void AddPVPPoints(uint32 points);
-	void AddCrystals(uint32 radiant, uint32 ebon);
+	void AddCrystals(uint32 radiant_count, uint32 ebon_count);
 	void SetEbonCrystals(uint32 value);
 	void SetRadiantCrystals(uint32 value);
 	uint32 GetPVPPoints();

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -1162,19 +1162,17 @@ void Perl_Client_AddCrystals(Client* self, uint32 radiant_count, uint32 ebon_cou
 	if (ebon_count != 0) {
 		if (ebon_count > 0) {
 			self->AddEbonCrystals(ebon_count);
-			return;
+		} else {
+			self->RemoveEbonCrystals(ebon_count);
 		}
-
-		self->RemoveEbonCrystals(ebon_count);
 	}
 
 	if (radiant_count != 0) {
 		if (radiant_count > 0) {
 			self->AddRadiantCrystals(radiant_count);
-			return;
+		} else {
+			self->RemoveRadiantCrystals(radiant_count);
 		}
-
-		self->RemoveRadiantCrystals(radiant_count);
 	}
 }
 


### PR DESCRIPTION
# Description
- Fixes an issue where when using `AddCrystals`, if you were to provide a greater than `0` amount of Ebon Crystals the method would return early regardless of the supplied Radiant Crystals amount.

## Type of change
- [X] Bug fix

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur