### PR TITLE
[Bug Fix] Attune Augments when Equipped

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -3285,6 +3285,10 @@ void Client::Handle_OP_AugmentItem(const EQApplicationPacket *app)
 							}
 						}
 
+						if (new_aug->GetItem()->Attuneable) {
+							new_aug->SetAttuned(true);
+						}
+
 						tobe_auged->PutAugment(in_augment->augment_index, *new_aug);
 						tobe_auged->UpdateOrnamentationInfo();
 


### PR DESCRIPTION
# Description

Attune Augments when Equipped. If you attempt to augment an with an attuneable augment, the game natively asks you to confirm. Now it will properly flag the item as no drop even after removal.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

Pre Augmenting:
![image](https://github.com/user-attachments/assets/b0fefd2f-72bd-471d-9b93-8a38d33a9345)

Post Augmenting:
![image](https://github.com/user-attachments/assets/0ad89f52-dfd8-42e0-adaf-426c63568430)

Augment Removed with Distiller showing its still no-drop:
![image](https://github.com/user-attachments/assets/e0139ffd-0c2d-4983-a580-455704a70b65)


Clients tested: RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
