### PR TITLE
[Quest API] Add Area-Based Quest Methods to Perl/Lua

### DIFF
--- a/common/emu_constants.h
+++ b/common/emu_constants.h
@@ -751,4 +751,9 @@ static std::map<uint32, std::string> stance_names = {
 	{ Stance::AEBurn,     "AE Burn" }
 };
 
+namespace PCNPCOnlyFlagType {
+	constexpr int PC  = 1;
+	constexpr int NPC = 2;
+}
+
 #endif /*COMMON_EMU_CONSTANTS_H*/

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -436,23 +436,24 @@ public:
 	void	QueueToGroupsForNPCHealthAA(Mob* sender, const EQApplicationPacket* app);
 
 	void AEAttack(
-		Mob *attacker,
+		Mob* attacker,
 		float distance,
-		int Hand = EQ::invslot::slotPrimary,
-		int count = 0,
+		int16 slot_id = EQ::invslot::slotPrimary,
+		int hit_count = 0,
 		bool is_from_spell = false,
 		int attack_rounds = 1
 	);
-	void AETaunt(Client *caster, float range = 0, int32 bonus_hate = 0);
+	void AETaunt(Client* caster, float range = 0, int bonus_hate = 0);
 	void AESpell(
-		Mob *caster,
-		Mob *center,
+		Mob* caster,
+		Mob* center,
 		uint16 spell_id,
 		bool affect_caster = true,
 		int16 resist_adjust = 0,
-		int *max_targets = nullptr
+		int* max_targets = nullptr,
+		bool is_scripted = false
 	);
-	void MassGroupBuff(Mob *caster, Mob *center, uint16 spell_id, bool affect_caster = true);
+	void MassGroupBuff(Mob* caster, Mob* center, uint16 spell_id, bool affect_caster = true);
 
 	//trap stuff
 	Mob*	GetTrapTrigger(Trap* trap);

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3484,18 +3484,6 @@ void Lua_Client::AreaTaunt(float range, int bonus_hate)
 	entity_list.AETaunt(self, range, bonus_hate);
 }
 
-void Lua_Client::MassGroupBuff(Lua_Mob center, uint16 spell_id)
-{
-	Lua_Safe_Call_Void();
-	entity_list.MassGroupBuff(self, center, spell_id);
-}
-
-void Lua_Client::MassGroupBuff(Lua_Mob center, uint16 spell_id, bool affect_caster)
-{
-	Lua_Safe_Call_Void();
-	entity_list.MassGroupBuff(self, center, spell_id, affect_caster);
-}
-
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 	.def(luabind::constructor<>())
@@ -3826,8 +3814,6 @@ luabind::scope lua_register_client() {
 	.def("Marquee", (void(Lua_Client::*)(uint32, std::string))&Lua_Client::SendMarqueeMessage)
 	.def("Marquee", (void(Lua_Client::*)(uint32, std::string, uint32))&Lua_Client::SendMarqueeMessage)
 	.def("Marquee", (void(Lua_Client::*)(uint32, uint32, uint32, uint32, uint32, std::string))&Lua_Client::SendMarqueeMessage)
-	.def("MassGroupBuff", (void(Lua_Client::*)(Lua_Mob, uint16))&Lua_Client::MassGroupBuff)
-	.def("MassGroupBuff", (void(Lua_Client::*)(Lua_Mob, uint16, bool))&Lua_Client::MassGroupBuff)
 	.def("MaxSkill", (int(Lua_Client::*)(int))&Lua_Client::MaxSkill)
 	.def("MaxSkills", (void(Lua_Client::*)(void))&Lua_Client::MaxSkills)
 	.def("MemSpell", (void(Lua_Client::*)(int,int))&Lua_Client::MemSpell)

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3412,6 +3412,90 @@ bool Lua_Client::AreTasksCompleted(luabind::object task_ids)
 	return self->AreTasksCompleted(v);
 }
 
+void Lua_Client::AreaAttack(float distance)
+{
+	Lua_Safe_Call_Void();
+	entity_list.AEAttack(self, distance);
+}
+
+void Lua_Client::AreaAttack(float distance, int16 slot_id)
+{
+	Lua_Safe_Call_Void();
+	entity_list.AEAttack(self, distance, slot_id);
+}
+
+void Lua_Client::AreaAttack(float distance, int16 slot_id, int count)
+{
+	Lua_Safe_Call_Void();
+	entity_list.AEAttack(self, distance, slot_id, count);
+}
+
+void Lua_Client::AreaAttack(float distance, int16 slot_id, int count, bool is_from_spell)
+{
+	Lua_Safe_Call_Void();
+	entity_list.AEAttack(self, distance, slot_id, count, is_from_spell);
+}
+
+void Lua_Client::AreaAttack(float distance, int16 slot_id, int count, bool is_from_spell, int attack_rounds)
+{
+	Lua_Safe_Call_Void();
+	entity_list.AEAttack(self, distance, slot_id, count, is_from_spell, attack_rounds);
+}
+
+void Lua_Client::AreaSpell(Lua_Mob center, uint16 spell_id)
+{
+	Lua_Safe_Call_Void();
+	entity_list.AESpell(self, center, spell_id);
+}
+
+void Lua_Client::AreaSpell(Lua_Mob center, uint16 spell_id, bool affect_caster)
+{
+	Lua_Safe_Call_Void();
+	entity_list.AESpell(self, center, spell_id, affect_caster);
+}
+
+void Lua_Client::AreaSpell(Lua_Mob center, uint16 spell_id, bool affect_caster, int16 resist_adjust)
+{
+	Lua_Safe_Call_Void();
+	entity_list.AESpell(self, center, spell_id, affect_caster, resist_adjust);
+}
+
+void Lua_Client::AreaSpell(Lua_Mob center, uint16 spell_id, bool affect_caster, int16 resist_adjust, int max_targets)
+{
+	Lua_Safe_Call_Void();
+	entity_list.AESpell(self, center, spell_id, affect_caster, resist_adjust, &max_targets);
+}
+
+void Lua_Client::AreaTaunt()
+{
+	Lua_Safe_Call_Void();
+	entity_list.AETaunt(self);
+}
+
+void Lua_Client::AreaTaunt(float range)
+{
+	Lua_Safe_Call_Void();
+	entity_list.AETaunt(self, range);
+}
+
+void Lua_Client::AreaTaunt(float range, int bonus_hate)
+{
+	Lua_Safe_Call_Void();
+	entity_list.AETaunt(self, range, bonus_hate);
+}
+
+void Lua_Client::MassGroupBuff(Lua_Mob center, uint16 spell_id)
+{
+	Lua_Safe_Call_Void();
+	entity_list.MassGroupBuff(self, center, spell_id);
+}
+
+void Lua_Client::MassGroupBuff(Lua_Mob center, uint16 spell_id, bool affect_caster)
+{
+	Lua_Safe_Call_Void();
+	entity_list.MassGroupBuff(self, center, spell_id, affect_caster);
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 	.def(luabind::constructor<>())
@@ -3459,6 +3543,18 @@ luabind::scope lua_register_client() {
 	.def("ApplySpellRaid", (void(Lua_Client::*)(int,int,int,bool,bool))&Lua_Client::ApplySpellRaid)
 	.def("ApplySpellRaid", (void(Lua_Client::*)(int,int,int,bool,bool,bool))&Lua_Client::ApplySpellRaid)
 	.def("AreTasksCompleted", (bool(Lua_Client::*)(luabind::object))&Lua_Client::AreTasksCompleted)
+	.def("AreaAttack", (void(Lua_Client::*)(float))&Lua_Client::AreaAttack)
+	.def("AreaAttack", (void(Lua_Client::*)(float, int16))&Lua_Client::AreaAttack)
+	.def("AreaAttack", (void(Lua_Client::*)(float, int16, int))&Lua_Client::AreaAttack)
+	.def("AreaAttack", (void(Lua_Client::*)(float, int16, int, bool))&Lua_Client::AreaAttack)
+	.def("AreaAttack", (void(Lua_Client::*)(float, int16, int, bool, int))&Lua_Client::AreaAttack)
+	.def("AreaSpell", (void(Lua_Client::*)(Lua_Mob, uint16))&Lua_Client::AreaSpell)
+	.def("AreaSpell", (void(Lua_Client::*)(Lua_Mob, uint16, bool))&Lua_Client::AreaSpell)
+	.def("AreaSpell", (void(Lua_Client::*)(Lua_Mob, uint16, bool, int16))&Lua_Client::AreaSpell)
+	.def("AreaSpell", (void(Lua_Client::*)(Lua_Mob, uint16, bool, int16, int))&Lua_Client::AreaSpell)
+	.def("AreaTaunt", (void(Lua_Client::*)(void))&Lua_Client::AreaTaunt)
+	.def("AreaTaunt", (void(Lua_Client::*)(float))&Lua_Client::AreaTaunt)
+	.def("AreaTaunt", (void(Lua_Client::*)(float, int))&Lua_Client::AreaTaunt)
 	.def("AssignTask", (void(Lua_Client::*)(int))&Lua_Client::AssignTask)
 	.def("AssignTask", (void(Lua_Client::*)(int,int))&Lua_Client::AssignTask)
 	.def("AssignTask", (void(Lua_Client::*)(int,int,bool))&Lua_Client::AssignTask)
@@ -3730,6 +3826,8 @@ luabind::scope lua_register_client() {
 	.def("Marquee", (void(Lua_Client::*)(uint32, std::string))&Lua_Client::SendMarqueeMessage)
 	.def("Marquee", (void(Lua_Client::*)(uint32, std::string, uint32))&Lua_Client::SendMarqueeMessage)
 	.def("Marquee", (void(Lua_Client::*)(uint32, uint32, uint32, uint32, uint32, std::string))&Lua_Client::SendMarqueeMessage)
+	.def("MassGroupBuff", (void(Lua_Client::*)(Lua_Mob, uint16))&Lua_Client::MassGroupBuff)
+	.def("MassGroupBuff", (void(Lua_Client::*)(Lua_Mob, uint16, bool))&Lua_Client::MassGroupBuff)
 	.def("MaxSkill", (int(Lua_Client::*)(int))&Lua_Client::MaxSkill)
 	.def("MaxSkills", (void(Lua_Client::*)(void))&Lua_Client::MaxSkills)
 	.def("MemSpell", (void(Lua_Client::*)(int,int))&Lua_Client::MemSpell)

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3412,60 +3412,6 @@ bool Lua_Client::AreTasksCompleted(luabind::object task_ids)
 	return self->AreTasksCompleted(v);
 }
 
-void Lua_Client::AreaAttack(float distance)
-{
-	Lua_Safe_Call_Void();
-	entity_list.AEAttack(self, distance);
-}
-
-void Lua_Client::AreaAttack(float distance, int16 slot_id)
-{
-	Lua_Safe_Call_Void();
-	entity_list.AEAttack(self, distance, slot_id);
-}
-
-void Lua_Client::AreaAttack(float distance, int16 slot_id, int count)
-{
-	Lua_Safe_Call_Void();
-	entity_list.AEAttack(self, distance, slot_id, count);
-}
-
-void Lua_Client::AreaAttack(float distance, int16 slot_id, int count, bool is_from_spell)
-{
-	Lua_Safe_Call_Void();
-	entity_list.AEAttack(self, distance, slot_id, count, is_from_spell);
-}
-
-void Lua_Client::AreaAttack(float distance, int16 slot_id, int count, bool is_from_spell, int attack_rounds)
-{
-	Lua_Safe_Call_Void();
-	entity_list.AEAttack(self, distance, slot_id, count, is_from_spell, attack_rounds);
-}
-
-void Lua_Client::AreaSpell(Lua_Mob center, uint16 spell_id)
-{
-	Lua_Safe_Call_Void();
-	entity_list.AESpell(self, center, spell_id);
-}
-
-void Lua_Client::AreaSpell(Lua_Mob center, uint16 spell_id, bool affect_caster)
-{
-	Lua_Safe_Call_Void();
-	entity_list.AESpell(self, center, spell_id, affect_caster);
-}
-
-void Lua_Client::AreaSpell(Lua_Mob center, uint16 spell_id, bool affect_caster, int16 resist_adjust)
-{
-	Lua_Safe_Call_Void();
-	entity_list.AESpell(self, center, spell_id, affect_caster, resist_adjust);
-}
-
-void Lua_Client::AreaSpell(Lua_Mob center, uint16 spell_id, bool affect_caster, int16 resist_adjust, int max_targets)
-{
-	Lua_Safe_Call_Void();
-	entity_list.AESpell(self, center, spell_id, affect_caster, resist_adjust, &max_targets);
-}
-
 void Lua_Client::AreaTaunt()
 {
 	Lua_Safe_Call_Void();
@@ -3531,15 +3477,6 @@ luabind::scope lua_register_client() {
 	.def("ApplySpellRaid", (void(Lua_Client::*)(int,int,int,bool,bool))&Lua_Client::ApplySpellRaid)
 	.def("ApplySpellRaid", (void(Lua_Client::*)(int,int,int,bool,bool,bool))&Lua_Client::ApplySpellRaid)
 	.def("AreTasksCompleted", (bool(Lua_Client::*)(luabind::object))&Lua_Client::AreTasksCompleted)
-	.def("AreaAttack", (void(Lua_Client::*)(float))&Lua_Client::AreaAttack)
-	.def("AreaAttack", (void(Lua_Client::*)(float, int16))&Lua_Client::AreaAttack)
-	.def("AreaAttack", (void(Lua_Client::*)(float, int16, int))&Lua_Client::AreaAttack)
-	.def("AreaAttack", (void(Lua_Client::*)(float, int16, int, bool))&Lua_Client::AreaAttack)
-	.def("AreaAttack", (void(Lua_Client::*)(float, int16, int, bool, int))&Lua_Client::AreaAttack)
-	.def("AreaSpell", (void(Lua_Client::*)(Lua_Mob, uint16))&Lua_Client::AreaSpell)
-	.def("AreaSpell", (void(Lua_Client::*)(Lua_Mob, uint16, bool))&Lua_Client::AreaSpell)
-	.def("AreaSpell", (void(Lua_Client::*)(Lua_Mob, uint16, bool, int16))&Lua_Client::AreaSpell)
-	.def("AreaSpell", (void(Lua_Client::*)(Lua_Mob, uint16, bool, int16, int))&Lua_Client::AreaSpell)
 	.def("AreaTaunt", (void(Lua_Client::*)(void))&Lua_Client::AreaTaunt)
 	.def("AreaTaunt", (void(Lua_Client::*)(float))&Lua_Client::AreaTaunt)
 	.def("AreaTaunt", (void(Lua_Client::*)(float, int))&Lua_Client::AreaTaunt)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -505,20 +505,9 @@ public:
 	void DescribeSpecialAbilities(Lua_NPC n);
 	void ResetLeadershipAA();
 	uint8 GetSkillTrainLevel(int skill_id);
-	void AreaAttack(float distance);
-	void AreaAttack(float distance, int16 slot_id);
-	void AreaAttack(float distance, int16 slot_id, int count);
-	void AreaAttack(float distance, int16 slot_id, int count, bool is_from_spell);
-	void AreaAttack(float distance, int16 slot_id, int count, bool is_from_spell, int attack_rounds);
-	void AreaSpell(Lua_Mob center, uint16 spell_id);
-	void AreaSpell(Lua_Mob center, uint16 spell_id, bool affect_caster);
-	void AreaSpell(Lua_Mob center, uint16 spell_id, bool affect_caster, int16 resist_adjust);
-	void AreaSpell(Lua_Mob center, uint16 spell_id, bool affect_caster, int16 resist_adjust, int max_targets);
 	void AreaTaunt();
 	void AreaTaunt(float range);
 	void AreaTaunt(float range, int bonus_hate);
-	void MassGroupBuff(Lua_Mob center, uint16 spell_id);
-	void MassGroupBuff(Lua_Mob center, uint16 spell_id, bool affect_caster);
 
 	void ApplySpell(int spell_id);
 	void ApplySpell(int spell_id, int duration);

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -505,6 +505,20 @@ public:
 	void DescribeSpecialAbilities(Lua_NPC n);
 	void ResetLeadershipAA();
 	uint8 GetSkillTrainLevel(int skill_id);
+	void AreaAttack(float distance);
+	void AreaAttack(float distance, int16 slot_id);
+	void AreaAttack(float distance, int16 slot_id, int count);
+	void AreaAttack(float distance, int16 slot_id, int count, bool is_from_spell);
+	void AreaAttack(float distance, int16 slot_id, int count, bool is_from_spell, int attack_rounds);
+	void AreaSpell(Lua_Mob center, uint16 spell_id);
+	void AreaSpell(Lua_Mob center, uint16 spell_id, bool affect_caster);
+	void AreaSpell(Lua_Mob center, uint16 spell_id, bool affect_caster, int16 resist_adjust);
+	void AreaSpell(Lua_Mob center, uint16 spell_id, bool affect_caster, int16 resist_adjust, int max_targets);
+	void AreaTaunt();
+	void AreaTaunt(float range);
+	void AreaTaunt(float range, int bonus_hate);
+	void MassGroupBuff(Lua_Mob center, uint16 spell_id);
+	void MassGroupBuff(Lua_Mob center, uint16 spell_id, bool affect_caster);
 
 	void ApplySpell(int spell_id);
 	void ApplySpell(int spell_id, int duration);

--- a/zone/lua_entity_list.cpp
+++ b/zone/lua_entity_list.cpp
@@ -680,11 +680,107 @@ Lua_Mob_List Lua_EntityList::GetCloseMobList(Lua_Mob mob, float distance, bool i
 	return ret;
 }
 
+void Lua_EntityList::AreaAttack(Lua_Mob attacker, float distance)
+{
+	Lua_Safe_Call_Void();
+	self->AEAttack(attacker, distance);
+}
+
+void Lua_EntityList::AreaAttack(Lua_Mob attacker, float distance, int16 slot_id)
+{
+	Lua_Safe_Call_Void();
+	self->AEAttack(attacker, distance, slot_id);
+}
+
+void Lua_EntityList::AreaAttack(Lua_Mob attacker, float distance, int16 slot_id, int count)
+{
+	Lua_Safe_Call_Void();
+	self->AEAttack(attacker, distance, slot_id, count);
+}
+
+void Lua_EntityList::AreaAttack(Lua_Mob attacker, float distance, int16 slot_id, int count, bool is_from_spell)
+{
+	Lua_Safe_Call_Void();
+	self->AEAttack(attacker, distance, slot_id, count, is_from_spell);
+}
+
+void Lua_EntityList::AreaAttack(Lua_Mob attacker, float distance, int16 slot_id, int count, bool is_from_spell, int attack_rounds)
+{
+	Lua_Safe_Call_Void();
+	self->AEAttack(attacker, distance, slot_id, count, is_from_spell, attack_rounds);
+}
+
+void Lua_EntityList::AreaSpell(Lua_Mob caster, Lua_Mob center, uint16 spell_id)
+{
+	Lua_Safe_Call_Void();
+	self->AESpell(caster, center, spell_id);
+}
+
+void Lua_EntityList::AreaSpell(Lua_Mob caster, Lua_Mob center, uint16 spell_id, bool affect_caster)
+{
+	Lua_Safe_Call_Void();
+	self->AESpell(caster, center, spell_id, affect_caster);
+}
+
+void Lua_EntityList::AreaSpell(Lua_Mob caster, Lua_Mob center, uint16 spell_id, bool affect_caster, int16 resist_adjust)
+{
+	Lua_Safe_Call_Void();
+	self->AESpell(caster, center, spell_id, affect_caster, resist_adjust);
+}
+
+void Lua_EntityList::AreaSpell(Lua_Mob caster, Lua_Mob center, uint16 spell_id, bool affect_caster, int16 resist_adjust, int max_targets)
+{
+	Lua_Safe_Call_Void();
+	self->AESpell(caster, center, spell_id, affect_caster, resist_adjust, &max_targets);
+}
+
+void Lua_EntityList::AreaTaunt(Lua_Client caster)
+{
+	Lua_Safe_Call_Void();
+	self->AETaunt(caster);
+}
+
+void Lua_EntityList::AreaTaunt(Lua_Client caster, float range)
+{
+	Lua_Safe_Call_Void();
+	self->AETaunt(caster, range);
+}
+
+void Lua_EntityList::AreaTaunt(Lua_Client caster, float range, int bonus_hate)
+{
+	Lua_Safe_Call_Void();
+	self->AETaunt(caster, range, bonus_hate);
+}
+
+void Lua_EntityList::MassGroupBuff(Lua_Mob caster, Lua_Mob center, uint16 spell_id)
+{
+	Lua_Safe_Call_Void();
+	self->MassGroupBuff(caster, center, spell_id);
+}
+
+void Lua_EntityList::MassGroupBuff(Lua_Mob caster, Lua_Mob center, uint16 spell_id, bool affect_caster)
+{
+	Lua_Safe_Call_Void();
+	self->MassGroupBuff(caster, center, spell_id, affect_caster);
+}
+
 luabind::scope lua_register_entity_list() {
 	return luabind::class_<Lua_EntityList>("EntityList")
 	.def(luabind::constructor<>())
 	.property("null", &Lua_EntityList::Null)
 	.property("valid", &Lua_EntityList::Valid)
+	.def("AreaAttack", (void(Lua_EntityList::*)(Lua_Mob, float))&Lua_EntityList::AreaAttack)
+	.def("AreaAttack", (void(Lua_EntityList::*)(Lua_Mob, float, int16))&Lua_EntityList::AreaAttack)
+	.def("AreaAttack", (void(Lua_EntityList::*)(Lua_Mob, float, int16, int))&Lua_EntityList::AreaAttack)
+	.def("AreaAttack", (void(Lua_EntityList::*)(Lua_Mob, float, int16, int, bool))&Lua_EntityList::AreaAttack)
+	.def("AreaAttack", (void(Lua_EntityList::*)(Lua_Mob, float, int16, int, bool, int))&Lua_EntityList::AreaAttack)
+	.def("AreaSpell", (void(Lua_EntityList::*)(Lua_Mob, Lua_Mob, uint16))&Lua_EntityList::AreaSpell)
+	.def("AreaSpell", (void(Lua_EntityList::*)(Lua_Mob, Lua_Mob, uint16, bool))&Lua_EntityList::AreaSpell)
+	.def("AreaSpell", (void(Lua_EntityList::*)(Lua_Mob, Lua_Mob, uint16, bool, int16))&Lua_EntityList::AreaSpell)
+	.def("AreaSpell", (void(Lua_EntityList::*)(Lua_Mob, Lua_Mob, uint16, bool, int16, int))&Lua_EntityList::AreaSpell)
+	.def("AreaTaunt", (void(Lua_EntityList::*)(Lua_Client))&Lua_EntityList::AreaTaunt)
+	.def("AreaTaunt", (void(Lua_EntityList::*)(Lua_Client, float))&Lua_EntityList::AreaTaunt)
+	.def("AreaTaunt", (void(Lua_EntityList::*)(Lua_Client, float, int))&Lua_EntityList::AreaTaunt)
 	.def("CanAddHateForMob", (bool(Lua_EntityList::*)(Lua_Mob))&Lua_EntityList::CanAddHateForMob)
 	.def("ChannelMessage", (void(Lua_EntityList::*)(Lua_Mob, int, uint8, const char*))&Lua_EntityList::ChannelMessage)
 	.def("ClearClientPetitionQueue", (void(Lua_EntityList::*)(void))&Lua_EntityList::ClearClientPetitionQueue)
@@ -759,6 +855,8 @@ luabind::scope lua_register_entity_list() {
 	.def("Marquee", (void(Lua_EntityList::*)(uint32, std::string))&Lua_EntityList::Marquee)
 	.def("Marquee", (void(Lua_EntityList::*)(uint32, std::string, uint32))&Lua_EntityList::Marquee)
 	.def("Marquee", (void(Lua_EntityList::*)(uint32, uint32, uint32, uint32, uint32, std::string))&Lua_EntityList::Marquee)
+	.def("MassGroupBuff", (void(Lua_EntityList::*)(Lua_Mob, Lua_Mob, uint16))&Lua_EntityList::MassGroupBuff)
+	.def("MassGroupBuff", (void(Lua_EntityList::*)(Lua_Mob, Lua_Mob, uint16, bool))&Lua_EntityList::MassGroupBuff)
 	.def("Message", (void(Lua_EntityList::*)(uint32, uint32, const char*))&Lua_EntityList::Message)
 	.def("MessageClose", (void(Lua_EntityList::*)(Lua_Mob, bool, float, uint32, const char*))&Lua_EntityList::MessageClose)
 	.def("MessageGroup", (void(Lua_EntityList::*)(Lua_Mob, bool, uint32, const char*))&Lua_EntityList::MessageGroup)

--- a/zone/lua_entity_list.h
+++ b/zone/lua_entity_list.h
@@ -142,6 +142,21 @@ public:
 	Lua_Mob_List GetCloseMobList(Lua_Mob mob);
 	Lua_Mob_List GetCloseMobList(Lua_Mob mob, float distance);
 	Lua_Mob_List GetCloseMobList(Lua_Mob mob, float distance, bool ignore_self);
+	void AreaAttack(Lua_Mob attacker, float distance);
+	void AreaAttack(Lua_Mob attacker, float distance, int16 slot_id);
+	void AreaAttack(Lua_Mob attacker, float distance, int16 slot_id, int count);
+	void AreaAttack(Lua_Mob attacker, float distance, int16 slot_id, int count, bool is_from_spell);
+	void AreaAttack(Lua_Mob attacker, float distance, int16 slot_id, int count, bool is_from_spell, int attack_rounds);
+	void AreaSpell(Lua_Mob caster, Lua_Mob center, uint16 spell_id);
+	void AreaSpell(Lua_Mob caster, Lua_Mob center, uint16 spell_id, bool affect_caster);
+	void AreaSpell(Lua_Mob caster, Lua_Mob center, uint16 spell_id, bool affect_caster, int16 resist_adjust);
+	void AreaSpell(Lua_Mob caster, Lua_Mob center, uint16 spell_id, bool affect_caster, int16 resist_adjust, int max_targets);
+	void AreaTaunt(Lua_Client caster);
+	void AreaTaunt(Lua_Client caster, float range);
+	void AreaTaunt(Lua_Client caster, float range, int bonus_hate);
+	void MassGroupBuff(Lua_Mob caster, Lua_Mob center, uint16 spell_id);
+	void MassGroupBuff(Lua_Mob caster, Lua_Mob center, uint16 spell_id, bool affect_caster);
+
 };
 
 #endif

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -3380,6 +3380,72 @@ int Lua_Mob::GetExtraHaste()
 	return self->GetExtraHaste();
 }
 
+void Lua_Mob::AreaAttack(float distance)
+{
+	Lua_Safe_Call_Void();
+	entity_list.AEAttack(self, distance);
+}
+
+void Lua_Mob::AreaAttack(float distance, int16 slot_id)
+{
+	Lua_Safe_Call_Void();
+	entity_list.AEAttack(self, distance, slot_id);
+}
+
+void Lua_Mob::AreaAttack(float distance, int16 slot_id, int count)
+{
+	Lua_Safe_Call_Void();
+	entity_list.AEAttack(self, distance, slot_id, count);
+}
+
+void Lua_Mob::AreaAttack(float distance, int16 slot_id, int count, bool is_from_spell)
+{
+	Lua_Safe_Call_Void();
+	entity_list.AEAttack(self, distance, slot_id, count, is_from_spell);
+}
+
+void Lua_Mob::AreaAttack(float distance, int16 slot_id, int count, bool is_from_spell, int attack_rounds)
+{
+	Lua_Safe_Call_Void();
+	entity_list.AEAttack(self, distance, slot_id, count, is_from_spell, attack_rounds);
+}
+
+void Lua_Mob::AreaSpell(Lua_Mob center, uint16 spell_id)
+{
+	Lua_Safe_Call_Void();
+	entity_list.AESpell(self, center, spell_id);
+}
+
+void Lua_Mob::AreaSpell(Lua_Mob center, uint16 spell_id, bool affect_caster)
+{
+	Lua_Safe_Call_Void();
+	entity_list.AESpell(self, center, spell_id, affect_caster);
+}
+
+void Lua_Mob::AreaSpell(Lua_Mob center, uint16 spell_id, bool affect_caster, int16 resist_adjust)
+{
+	Lua_Safe_Call_Void();
+	entity_list.AESpell(self, center, spell_id, affect_caster, resist_adjust);
+}
+
+void Lua_Mob::AreaSpell(Lua_Mob center, uint16 spell_id, bool affect_caster, int16 resist_adjust, int max_targets)
+{
+	Lua_Safe_Call_Void();
+	entity_list.AESpell(self, center, spell_id, affect_caster, resist_adjust, &max_targets);
+}
+
+void Lua_Mob::MassGroupBuff(Lua_Mob center, uint16 spell_id)
+{
+	Lua_Safe_Call_Void();
+	entity_list.MassGroupBuff(self, center, spell_id);
+}
+
+void Lua_Mob::MassGroupBuff(Lua_Mob center, uint16 spell_id, bool affect_caster)
+{
+	Lua_Safe_Call_Void();
+	entity_list.MassGroupBuff(self, center, spell_id, affect_caster);
+}
+
 luabind::scope lua_register_mob() {
 	return luabind::class_<Lua_Mob, Lua_Entity>("Mob")
 	.def(luabind::constructor<>())
@@ -3393,6 +3459,15 @@ luabind::scope lua_register_mob() {
 	.def("ApplySpellBuff", (void(Lua_Mob::*)(int))&Lua_Mob::ApplySpellBuff)
 	.def("ApplySpellBuff", (void(Lua_Mob::*)(int,int))&Lua_Mob::ApplySpellBuff)
 	.def("ApplySpellBuff", (void(Lua_Mob::*)(int,int,int))&Lua_Mob::ApplySpellBuff)
+	.def("AreaAttack", (void(Lua_Mob::*)(float))&Lua_Mob::AreaAttack)
+	.def("AreaAttack", (void(Lua_Mob::*)(float, int16))&Lua_Mob::AreaAttack)
+	.def("AreaAttack", (void(Lua_Mob::*)(float, int16, int))&Lua_Mob::AreaAttack)
+	.def("AreaAttack", (void(Lua_Mob::*)(float, int16, int, bool))&Lua_Mob::AreaAttack)
+	.def("AreaAttack", (void(Lua_Mob::*)(float, int16, int, bool, int))&Lua_Mob::AreaAttack)
+	.def("AreaSpell", (void(Lua_Mob::*)(Lua_Mob, uint16))&Lua_Mob::AreaSpell)
+	.def("AreaSpell", (void(Lua_Mob::*)(Lua_Mob, uint16, bool))&Lua_Mob::AreaSpell)
+	.def("AreaSpell", (void(Lua_Mob::*)(Lua_Mob, uint16, bool, int16))&Lua_Mob::AreaSpell)
+	.def("AreaSpell", (void(Lua_Mob::*)(Lua_Mob, uint16, bool, int16, int))&Lua_Mob::AreaSpell)
 	.def("Attack", (bool(Lua_Mob::*)(Lua_Mob))&Lua_Mob::Attack)
 	.def("Attack", (bool(Lua_Mob::*)(Lua_Mob,int))&Lua_Mob::Attack)
 	.def("Attack", (bool(Lua_Mob::*)(Lua_Mob,int,bool))&Lua_Mob::Attack)
@@ -3808,6 +3883,8 @@ luabind::scope lua_register_mob() {
 	.def("IsWarriorClass", &Lua_Mob::IsWarriorClass)
 	.def("IsWisdomCasterClass", &Lua_Mob::IsWisdomCasterClass)
 	.def("Kill", (void(Lua_Mob::*)(void))&Lua_Mob::Kill)
+	.def("MassGroupBuff", (void(Lua_Mob::*)(Lua_Mob, uint16))&Lua_Mob::MassGroupBuff)
+	.def("MassGroupBuff", (void(Lua_Mob::*)(Lua_Mob, uint16, bool))&Lua_Mob::MassGroupBuff)
 	.def("Mesmerize", (void(Lua_Mob::*)(void))&Lua_Mob::Mesmerize)
 	.def("Message", &Lua_Mob::Message)
 	.def("MessageString", &Lua_Mob::MessageString)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -594,6 +594,17 @@ public:
 	int GetExtraHaste();
 	void SetExtraHaste(int haste);
 	void SetExtraHaste(int haste, bool need_to_save);
+	void AreaAttack(float distance);
+	void AreaAttack(float distance, int16 slot_id);
+	void AreaAttack(float distance, int16 slot_id, int count);
+	void AreaAttack(float distance, int16 slot_id, int count, bool is_from_spell);
+	void AreaAttack(float distance, int16 slot_id, int count, bool is_from_spell, int attack_rounds);
+	void AreaSpell(Lua_Mob center, uint16 spell_id);
+	void AreaSpell(Lua_Mob center, uint16 spell_id, bool affect_caster);
+	void AreaSpell(Lua_Mob center, uint16 spell_id, bool affect_caster, int16 resist_adjust);
+	void AreaSpell(Lua_Mob center, uint16 spell_id, bool affect_caster, int16 resist_adjust, int max_targets);
+	void MassGroupBuff(Lua_Mob center, uint16 spell_id);
+	void MassGroupBuff(Lua_Mob center, uint16 spell_id, bool affect_caster);
 };
 
 #endif

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -3247,16 +3247,6 @@ void Perl_Client_AreaTaunt(Client* self, float range, int bonus_hate)
 	entity_list.AETaunt(self, range, bonus_hate);
 }
 
-void Perl_Client_MassGroupBuff(Client* self, Mob* center, uint16 spell_id)
-{
-	entity_list.MassGroupBuff(self, center, spell_id);
-}
-
-void Perl_Client_MassGroupBuff(Client* self, Mob* center, uint16 spell_id, bool affect_caster)
-{
-	entity_list.MassGroupBuff(self, center, spell_id, affect_caster);
-}
-
 void perl_register_client()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3586,8 +3576,6 @@ void perl_register_client()
 	package.add("Marquee", (void(*)(Client*, uint32, std::string))&Perl_Client_SendMarqueeMessage);
 	package.add("Marquee", (void(*)(Client*, uint32, std::string, uint32))&Perl_Client_SendMarqueeMessage);
 	package.add("Marquee", (void(*)(Client*, uint32, uint32, uint32, uint32, uint32, std::string))&Perl_Client_SendMarqueeMessage);
-	package.add("MassGroupBuff", (void(*)(Client*, Mob*, uint16))&Perl_Client_MassGroupBuff);
-	package.add("MassGroupBuff", (void(*)(Client*, Mob*, uint16, bool))&Perl_Client_MassGroupBuff);
 	package.add("MaxSkill", (int(*)(Client*, uint16))&Perl_Client_MaxSkill);
 	package.add("MaxSkill", (int(*)(Client*, uint16, uint16))&Perl_Client_MaxSkill);
 	package.add("MaxSkill", (int(*)(Client*, uint16, uint16, uint16))&Perl_Client_MaxSkill);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -3187,6 +3187,76 @@ bool Perl_Client_AreTasksCompleted(Client* self, perl::array task_ids)
 	return self->AreTasksCompleted(v);
 }
 
+void Perl_Client_AreaAttack(Client* self, float distance)
+{
+	entity_list.AEAttack(self, distance);
+}
+
+void Perl_Client_AreaAttack(Client* self, float distance, int16 slot_id)
+{
+	entity_list.AEAttack(self, distance, slot_id);
+}
+
+void Perl_Client_AreaAttack(Client* self, float distance, int16 slot_id, int count)
+{
+	entity_list.AEAttack(self, distance, slot_id, count);
+}
+
+void Perl_Client_AreaAttack(Client* self, float distance, int16 slot_id, int count, bool is_from_spell)
+{
+	entity_list.AEAttack(self, distance, slot_id, count, is_from_spell);
+}
+
+void Perl_Client_AreaAttack(Client* self, float distance, int16 slot_id, int count, bool is_from_spell, int attack_rounds)
+{
+	entity_list.AEAttack(self, distance, slot_id, count, is_from_spell, attack_rounds);
+}
+
+void Perl_Client_AreaSpell(Client* self, Mob* center, uint16 spell_id)
+{
+	entity_list.AESpell(self, center, spell_id, true, 0, nullptr, true);
+}
+
+void Perl_Client_AreaSpell(Client* self, Mob* center, uint16 spell_id, bool affect_caster)
+{
+	entity_list.AESpell(self, center, spell_id, affect_caster, 0, nullptr, true);
+}
+
+void Perl_Client_AreaSpell(Client* self, Mob* center, uint16 spell_id, bool affect_caster, int16 resist_adjust)
+{
+	entity_list.AESpell(self, center, spell_id, affect_caster, resist_adjust, nullptr, true);
+}
+
+void Perl_Client_AreaSpell(Client* self, Mob* center, uint16 spell_id, bool affect_caster, int16 resist_adjust, int max_targets)
+{
+	entity_list.AESpell(self, center, spell_id, affect_caster, resist_adjust, &max_targets, true);
+}
+
+void Perl_Client_AreaTaunt(Client* self)
+{
+	entity_list.AETaunt(self);
+}
+
+void Perl_Client_AreaTaunt(Client* self, float range)
+{
+	entity_list.AETaunt(self, range);
+}
+
+void Perl_Client_AreaTaunt(Client* self, float range, int bonus_hate)
+{
+	entity_list.AETaunt(self, range, bonus_hate);
+}
+
+void Perl_Client_MassGroupBuff(Client* self, Mob* center, uint16 spell_id)
+{
+	entity_list.MassGroupBuff(self, center, spell_id);
+}
+
+void Perl_Client_MassGroupBuff(Client* self, Mob* center, uint16 spell_id, bool affect_caster)
+{
+	entity_list.MassGroupBuff(self, center, spell_id, affect_caster);
+}
+
 void perl_register_client()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3237,6 +3307,18 @@ void perl_register_client()
 	package.add("ApplySpellRaid", (void(*)(Client*, int, int, int, bool, bool))&Perl_Client_ApplySpellRaid);
 	package.add("ApplySpellRaid", (void(*)(Client*, int, int, int, bool, bool, bool))&Perl_Client_ApplySpellRaid);
 	package.add("AreTasksCompleted", (bool(*)(Client*, perl::array))&Perl_Client_AreTasksCompleted);
+	package.add("AreaAttack", (void(*)(Client*, float))&Perl_Client_AreaAttack);
+	package.add("AreaAttack", (void(*)(Client*, float, int16))&Perl_Client_AreaAttack);
+	package.add("AreaAttack", (void(*)(Client*, float, int16, int))&Perl_Client_AreaAttack);
+	package.add("AreaAttack", (void(*)(Client*, float, int16, int, bool))&Perl_Client_AreaAttack);
+	package.add("AreaAttack", (void(*)(Client*, float, int16, int, bool, int))&Perl_Client_AreaAttack);
+	package.add("AreaSpell", (void(*)(Client*, Mob*, uint16))&Perl_Client_AreaSpell);
+	package.add("AreaSpell", (void(*)(Client*, Mob*, uint16, bool))&Perl_Client_AreaSpell);
+	package.add("AreaSpell", (void(*)(Client*, Mob*, uint16, bool, int16))&Perl_Client_AreaSpell);
+	package.add("AreaSpell", (void(*)(Client*, Mob*, uint16, bool, int16, int))&Perl_Client_AreaSpell);
+	package.add("AreaTaunt", (void(*)(Client*))&Perl_Client_AreaTaunt);
+	package.add("AreaTaunt", (void(*)(Client*, float))&Perl_Client_AreaTaunt);
+	package.add("AreaTaunt", (void(*)(Client*, float, int))&Perl_Client_AreaTaunt);
 	package.add("AssignTask", (void(*)(Client*, int))&Perl_Client_AssignTask);
 	package.add("AssignTask", (void(*)(Client*, int, int))&Perl_Client_AssignTask);
 	package.add("AssignTask", (void(*)(Client*, int, int, bool))&Perl_Client_AssignTask);
@@ -3504,6 +3586,8 @@ void perl_register_client()
 	package.add("Marquee", (void(*)(Client*, uint32, std::string))&Perl_Client_SendMarqueeMessage);
 	package.add("Marquee", (void(*)(Client*, uint32, std::string, uint32))&Perl_Client_SendMarqueeMessage);
 	package.add("Marquee", (void(*)(Client*, uint32, uint32, uint32, uint32, uint32, std::string))&Perl_Client_SendMarqueeMessage);
+	package.add("MassGroupBuff", (void(*)(Client*, Mob*, uint16))&Perl_Client_MassGroupBuff);
+	package.add("MassGroupBuff", (void(*)(Client*, Mob*, uint16, bool))&Perl_Client_MassGroupBuff);
 	package.add("MaxSkill", (int(*)(Client*, uint16))&Perl_Client_MaxSkill);
 	package.add("MaxSkill", (int(*)(Client*, uint16, uint16))&Perl_Client_MaxSkill);
 	package.add("MaxSkill", (int(*)(Client*, uint16, uint16, uint16))&Perl_Client_MaxSkill);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -3187,51 +3187,6 @@ bool Perl_Client_AreTasksCompleted(Client* self, perl::array task_ids)
 	return self->AreTasksCompleted(v);
 }
 
-void Perl_Client_AreaAttack(Client* self, float distance)
-{
-	entity_list.AEAttack(self, distance);
-}
-
-void Perl_Client_AreaAttack(Client* self, float distance, int16 slot_id)
-{
-	entity_list.AEAttack(self, distance, slot_id);
-}
-
-void Perl_Client_AreaAttack(Client* self, float distance, int16 slot_id, int count)
-{
-	entity_list.AEAttack(self, distance, slot_id, count);
-}
-
-void Perl_Client_AreaAttack(Client* self, float distance, int16 slot_id, int count, bool is_from_spell)
-{
-	entity_list.AEAttack(self, distance, slot_id, count, is_from_spell);
-}
-
-void Perl_Client_AreaAttack(Client* self, float distance, int16 slot_id, int count, bool is_from_spell, int attack_rounds)
-{
-	entity_list.AEAttack(self, distance, slot_id, count, is_from_spell, attack_rounds);
-}
-
-void Perl_Client_AreaSpell(Client* self, Mob* center, uint16 spell_id)
-{
-	entity_list.AESpell(self, center, spell_id, true, 0, nullptr, true);
-}
-
-void Perl_Client_AreaSpell(Client* self, Mob* center, uint16 spell_id, bool affect_caster)
-{
-	entity_list.AESpell(self, center, spell_id, affect_caster, 0, nullptr, true);
-}
-
-void Perl_Client_AreaSpell(Client* self, Mob* center, uint16 spell_id, bool affect_caster, int16 resist_adjust)
-{
-	entity_list.AESpell(self, center, spell_id, affect_caster, resist_adjust, nullptr, true);
-}
-
-void Perl_Client_AreaSpell(Client* self, Mob* center, uint16 spell_id, bool affect_caster, int16 resist_adjust, int max_targets)
-{
-	entity_list.AESpell(self, center, spell_id, affect_caster, resist_adjust, &max_targets, true);
-}
-
 void Perl_Client_AreaTaunt(Client* self)
 {
 	entity_list.AETaunt(self);
@@ -3297,15 +3252,6 @@ void perl_register_client()
 	package.add("ApplySpellRaid", (void(*)(Client*, int, int, int, bool, bool))&Perl_Client_ApplySpellRaid);
 	package.add("ApplySpellRaid", (void(*)(Client*, int, int, int, bool, bool, bool))&Perl_Client_ApplySpellRaid);
 	package.add("AreTasksCompleted", (bool(*)(Client*, perl::array))&Perl_Client_AreTasksCompleted);
-	package.add("AreaAttack", (void(*)(Client*, float))&Perl_Client_AreaAttack);
-	package.add("AreaAttack", (void(*)(Client*, float, int16))&Perl_Client_AreaAttack);
-	package.add("AreaAttack", (void(*)(Client*, float, int16, int))&Perl_Client_AreaAttack);
-	package.add("AreaAttack", (void(*)(Client*, float, int16, int, bool))&Perl_Client_AreaAttack);
-	package.add("AreaAttack", (void(*)(Client*, float, int16, int, bool, int))&Perl_Client_AreaAttack);
-	package.add("AreaSpell", (void(*)(Client*, Mob*, uint16))&Perl_Client_AreaSpell);
-	package.add("AreaSpell", (void(*)(Client*, Mob*, uint16, bool))&Perl_Client_AreaSpell);
-	package.add("AreaSpell", (void(*)(Client*, Mob*, uint16, bool, int16))&Perl_Client_AreaSpell);
-	package.add("AreaSpell", (void(*)(Client*, Mob*, uint16, bool, int16, int))&Perl_Client_AreaSpell);
 	package.add("AreaTaunt", (void(*)(Client*))&Perl_Client_AreaTaunt);
 	package.add("AreaTaunt", (void(*)(Client*, float))&Perl_Client_AreaTaunt);
 	package.add("AreaTaunt", (void(*)(Client*, float, int))&Perl_Client_AreaTaunt);

--- a/zone/perl_entity.cpp
+++ b/zone/perl_entity.cpp
@@ -669,11 +669,93 @@ perl::array Perl_EntityList_GetSpawnList(EntityList* self) {
 	return ret;
 }
 
+void Perl_EntityList_AreaAttack(EntityList* self, Mob* attacker, float distance)
+{
+	self->AEAttack(attacker, distance);
+}
+
+void Perl_EntityList_AreaAttack(EntityList* self, Mob* attacker, float distance, int16 slot_id)
+{
+	self->AEAttack(attacker, distance, slot_id);
+}
+
+void Perl_EntityList_AreaAttack(EntityList* self, Mob* attacker, float distance, int16 slot_id, int count)
+{
+	self->AEAttack(attacker, distance, slot_id, count);
+}
+
+void Perl_EntityList_AreaAttack(EntityList* self, Mob* attacker, float distance, int16 slot_id, int count, bool is_from_spell)
+{
+	self->AEAttack(attacker, distance, slot_id, count, is_from_spell);
+}
+
+void Perl_EntityList_AreaAttack(EntityList* self, Mob* attacker, float distance, int16 slot_id, int count, bool is_from_spell, int attack_rounds)
+{
+	self->AEAttack(attacker, distance, slot_id, count, is_from_spell, attack_rounds);
+}
+
+void Perl_EntityList_AreaSpell(EntityList* self, Mob* caster, Mob* center, uint16 spell_id)
+{
+	self->AESpell(caster, center, spell_id);
+}
+
+void Perl_EntityList_AreaSpell(EntityList* self, Mob* caster, Mob* center, uint16 spell_id, bool affect_caster)
+{
+	self->AESpell(caster, center, spell_id, affect_caster);
+}
+
+void Perl_EntityList_AreaSpell(EntityList* self, Mob* caster, Mob* center, uint16 spell_id, bool affect_caster, int16 resist_adjust)
+{
+	self->AESpell(caster, center, spell_id, affect_caster, resist_adjust);
+}
+
+void Perl_EntityList_AreaSpell(EntityList* self, Mob* caster, Mob* center, uint16 spell_id, bool affect_caster, int16 resist_adjust, int max_targets)
+{
+	self->AESpell(caster, center, spell_id, affect_caster, resist_adjust, &max_targets);
+}
+
+void Perl_EntityList_AreaTaunt(EntityList* self, Client* caster)
+{
+	self->AETaunt(caster);
+}
+
+void Perl_EntityList_AreaTaunt(EntityList* self, Client* caster, float range)
+{
+	self->AETaunt(caster, range);
+}
+
+void Perl_EntityList_AreaTaunt(EntityList* self, Client* caster, float range, int bonus_hate)
+{
+	self->AETaunt(caster, range, bonus_hate);
+}
+
+void Perl_EntityList_MassGroupBuff(EntityList* self, Mob* caster, Mob* center, uint16 spell_id)
+{
+	self->MassGroupBuff(caster, center, spell_id);
+}
+
+void Perl_EntityList_MassGroupBuff(EntityList* self, Mob* caster, Mob* center, uint16 spell_id, bool affect_caster)
+{
+	self->MassGroupBuff(caster, center, spell_id, affect_caster);
+}
+
 void perl_register_entitylist()
 {
 	perl::interpreter perl(PERL_GET_THX);
 
 	auto package = perl.new_class<EntityList>("EntityList");
+	package.add("AreaAttack", (void(*)(EntityList*, Mob*, float))&Perl_EntityList_AreaAttack);
+	package.add("AreaAttack", (void(*)(EntityList*, Mob*, float, int16))&Perl_EntityList_AreaAttack);
+	package.add("AreaAttack", (void(*)(EntityList*, Mob*, float, int16, int))&Perl_EntityList_AreaAttack);
+	package.add("AreaAttack", (void(*)(EntityList*, Mob*, float, int16, int, bool))&Perl_EntityList_AreaAttack);
+	package.add("AreaAttack", (void(*)(EntityList*, Mob*, float, int16, int, bool, int))&Perl_EntityList_AreaAttack);
+	package.add("AreaSpell", (void(*)(EntityList*, Mob*, Mob*, uint16))&Perl_EntityList_AreaSpell);
+	package.add("AreaSpell", (void(*)(EntityList*, Mob*, Mob*, uint16, bool))&Perl_EntityList_AreaSpell);
+	package.add("AreaSpell", (void(*)(EntityList*, Mob*, Mob*, uint16, bool, int16))&Perl_EntityList_AreaSpell);
+	package.add("AreaSpell", (void(*)(EntityList*, Mob*, Mob*, uint16, bool, int16, int))&Perl_EntityList_AreaSpell);
+	package.add("AreaTaunt", (void(*)(EntityList*, Client*))&Perl_EntityList_AreaTaunt);
+	package.add("AreaTaunt", (void(*)(EntityList*, Client*, float))&Perl_EntityList_AreaTaunt);
+	package.add("AreaTaunt", (void(*)(EntityList*, Client*, float, int))&Perl_EntityList_AreaTaunt);
 	package.add("CanAddHateForMob", &Perl_EntityList_CanAddHateForMob);
 	package.add("Clear", &Perl_EntityList_Clear);
 	package.add("ClearClientPetitionQueue", &Perl_EntityList_ClearClientPetitionQueue);
@@ -747,6 +829,8 @@ void perl_register_entitylist()
 	package.add("Marquee", (void(*)(EntityList*, uint32, std::string))&Perl_EntityList_Marquee);
 	package.add("Marquee", (void(*)(EntityList*, uint32, std::string, uint32))&Perl_EntityList_Marquee);
 	package.add("Marquee", (void(*)(EntityList*, uint32, uint32, uint32, uint32, uint32, std::string))&Perl_EntityList_Marquee);
+	package.add("MassGroupBuff", (void(*)(EntityList*, Mob*, Mob*, uint16))&Perl_EntityList_MassGroupBuff);
+	package.add("MassGroupBuff", (void(*)(EntityList*, Mob*, Mob*, uint16, bool))&Perl_EntityList_MassGroupBuff);
 	package.add("Message", &Perl_EntityList_Message);
 	package.add("MessageClose", &Perl_EntityList_MessageClose);
 	package.add("MessageGroup", &Perl_EntityList_MessageGroup);

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -3488,6 +3488,61 @@ std::string Perl_Mob_GetConsiderColor(Mob* self, uint8 other_level)
 	return EQ::constants::GetConsiderColorName(self->GetLevelCon(other_level));
 }
 
+void Perl_Mob_AreaAttack(Mob* self, float distance)
+{
+	entity_list.AEAttack(self, distance);
+}
+
+void Perl_Mob_AreaAttack(Mob* self, float distance, int16 slot_id)
+{
+	entity_list.AEAttack(self, distance, slot_id);
+}
+
+void Perl_Mob_AreaAttack(Mob* self, float distance, int16 slot_id, int count)
+{
+	entity_list.AEAttack(self, distance, slot_id, count);
+}
+
+void Perl_Mob_AreaAttack(Mob* self, float distance, int16 slot_id, int count, bool is_from_spell)
+{
+	entity_list.AEAttack(self, distance, slot_id, count, is_from_spell);
+}
+
+void Perl_Mob_AreaAttack(Mob* self, float distance, int16 slot_id, int count, bool is_from_spell, int attack_rounds)
+{
+	entity_list.AEAttack(self, distance, slot_id, count, is_from_spell, attack_rounds);
+}
+
+void Perl_Mob_AreaSpell(Mob* self, Mob* center, uint16 spell_id)
+{
+	entity_list.AESpell(self, center, spell_id, true, 0, nullptr, true);
+}
+
+void Perl_Mob_AreaSpell(Mob* self, Mob* center, uint16 spell_id, bool affect_caster)
+{
+	entity_list.AESpell(self, center, spell_id, affect_caster, 0, nullptr, true);
+}
+
+void Perl_Mob_AreaSpell(Mob* self, Mob* center, uint16 spell_id, bool affect_caster, int16 resist_adjust)
+{
+	entity_list.AESpell(self, center, spell_id, affect_caster, resist_adjust, nullptr, true);
+}
+
+void Perl_Mob_AreaSpell(Mob* self, Mob* center, uint16 spell_id, bool affect_caster, int16 resist_adjust, int max_targets)
+{
+	entity_list.AESpell(self, center, spell_id, affect_caster, resist_adjust, &max_targets, true);
+}
+
+void Perl_Mob_MassGroupBuff(Mob* self, Mob* center, uint16 spell_id)
+{
+	entity_list.MassGroupBuff(self, center, spell_id);
+}
+
+void Perl_Mob_MassGroupBuff(Mob* self, Mob* center, uint16 spell_id, bool affect_caster)
+{
+	entity_list.MassGroupBuff(self, center, spell_id, affect_caster);
+}
+
 void perl_register_mob()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3504,6 +3559,15 @@ void perl_register_mob()
 	package.add("ApplySpellBuff", (void(*)(Mob*, int))&Perl_Mob_ApplySpellBuff);
 	package.add("ApplySpellBuff", (void(*)(Mob*, int, int))&Perl_Mob_ApplySpellBuff);
 	package.add("ApplySpellBuff", (void(*)(Mob*, int, int, int))&Perl_Mob_ApplySpellBuff);
+	package.add("AreaAttack", (void(*)(Mob*, float))&Perl_Mob_AreaAttack);
+	package.add("AreaAttack", (void(*)(Mob*, float, int16))&Perl_Mob_AreaAttack);
+	package.add("AreaAttack", (void(*)(Mob*, float, int16, int))&Perl_Mob_AreaAttack);
+	package.add("AreaAttack", (void(*)(Mob*, float, int16, int, bool))&Perl_Mob_AreaAttack);
+	package.add("AreaAttack", (void(*)(Mob*, float, int16, int, bool, int))&Perl_Mob_AreaAttack);
+	package.add("AreaSpell", (void(*)(Mob*, Mob*, uint16))&Perl_Mob_AreaSpell);
+	package.add("AreaSpell", (void(*)(Mob*, Mob*, uint16, bool))&Perl_Mob_AreaSpell);
+	package.add("AreaSpell", (void(*)(Mob*, Mob*, uint16, bool, int16))&Perl_Mob_AreaSpell);
+	package.add("AreaSpell", (void(*)(Mob*, Mob*, uint16, bool, int16, int))&Perl_Mob_AreaSpell);
 	package.add("Attack", (bool(*)(Mob*, Mob*))&Perl_Mob_Attack);
 	package.add("Attack", (bool(*)(Mob*, Mob*, int))&Perl_Mob_Attack);
 	package.add("Attack", (bool(*)(Mob*, Mob*, int, bool))&Perl_Mob_Attack);
@@ -3928,6 +3992,8 @@ void perl_register_mob()
 	package.add("MakeTempPet", (void(*)(Mob*, uint16, const char*, uint32))&Perl_Mob_MakeTempPet);
 	package.add("MakeTempPet", (void(*)(Mob*, uint16, const char*, uint32, Mob*))&Perl_Mob_MakeTempPet);
 	package.add("MakeTempPet", (void(*)(Mob*, uint16, const char*, uint32, Mob*, bool))&Perl_Mob_MakeTempPet);
+	package.add("MassGroupBuff", (void(*)(Mob*, Mob*, uint16))&Perl_Mob_MassGroupBuff);
+	package.add("MassGroupBuff", (void(*)(Mob*, Mob*, uint16, bool))&Perl_Mob_MassGroupBuff);
 	package.add("Mesmerize", &Perl_Mob_Mesmerize);
 	package.add("Message", &Perl_Mob_Message);
 	package.add("Message_StringID", (void(*)(Mob*, uint32, uint32))&Perl_Mob_Message_StringID);

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -886,13 +886,13 @@ bool Mob::DoCastingChecksOnTarget(bool check_on_casting, int32 spell_id, Mob *sp
 	*/
 	if (!ignore_on_casting) {
 		if (spells[spell_id].pcnpc_only_flag && spells[spell_id].target_type != ST_AETargetHateList && spells[spell_id].target_type != ST_HateList) {
-			if (spells[spell_id].pcnpc_only_flag == 1 && !spell_target->IsClient() && !spell_target->IsMerc() && !spell_target->IsBot()) {
+			if (spells[spell_id].pcnpc_only_flag == PCNPCOnlyFlagType::PC && !spell_target->IsClient() && !spell_target->IsMerc() && !spell_target->IsBot()) {
 				if (check_on_casting) {
 					Message(Chat::SpellFailure, "This spell only works on other PCs");
 				}
 				return false;
 			}
-			else if (spells[spell_id].pcnpc_only_flag == 2 && (spell_target->IsClient() || spell_target->IsMerc() || spell_target->IsBot())) {
+			else if (spells[spell_id].pcnpc_only_flag == PCNPCOnlyFlagType::NPC && (spell_target->IsClient() || spell_target->IsMerc() || spell_target->IsBot())) {
 				if (check_on_casting) {
 					Message(Chat::SpellFailure, "This spell only works on NPCs.");
 				}
@@ -3947,12 +3947,12 @@ bool Mob::SpellOnTarget(
 		spells[spell_id].target_type != ST_HateList
 	) {
 		if (
-			spells[spell_id].pcnpc_only_flag == 1 &&
+			spells[spell_id].pcnpc_only_flag == PCNPCOnlyFlagType::PC &&
 			!spelltar->IsOfClientBotMerc()
 		) {
 			return false;
 		} else if (
-			spells[spell_id].pcnpc_only_flag == 2 &&
+			spells[spell_id].pcnpc_only_flag == PCNPCOnlyFlagType::NPC &&
 			(
 				spelltar->IsOfClientBotMerc()
 			)


### PR DESCRIPTION
# Description
- Adds several area based quest methods to Perl and Lua, allowing operators to more easily perform area attacks, area spells, area taunts, and mass group buffs.

# Perl
- Add `$client->AreaTaunt()`.
- Add `$client->AreaTaunt(range)`.
- Add `$client->AreaTaunt(range, bonus_hate)`.
- Add `$entity_list->AreaAttack(attacker, distance)`.
- Add `$entity_list->AreaAttack(attacker, distance, slot_id)`.
- Add `$entity_list->AreaAttack(attacker, distance, slot_id, count)`.
- Add `$entity_list->AreaAttack(attacker, distance, slot_id, count, is_from_spell)`.
- Add `$entity_list->AreaAttack(attacker, distance, slot_id, count, is_from_spell, attack_rounds)`.
- Add `$entity_list->AreaSpell(caster, center, spell_id)`.
- Add `$entity_list->AreaSpell(caster, center, spell_id, affect_caster)`.
- Add `$entity_list->AreaSpell(caster, center, spell_id, affect_caster, resist_adjust)`.
- Add `$entity_list->AreaSpell(caster, center, spell_id, affect_caster, resist_adjust, max_targets)`.
- Add `$entity_list->AreaTaunt(caster)`.
- Add `$entity_list->AreaTaunt(caster, range)`.
- Add `$entity_list->AreaTaunt(caster, range, bonus_hate)`.
- Add `$entity_list->MassGroupBuff(caster, center, spell_id)`.
- Add `$entity_list->MassGroupBuff(caster, center, spell_id, affect_caster)`.
- Add `$mob->AreaAttack(distance)`.
- Add `$mob->AreaAttack(distance, slot_id)`.
- Add `$mob->AreaAttack(distance, slot_id, count)`.
- Add `$mob->AreaAttack(distance, slot_id, count, is_from_spell)`.
- Add `$mob->AreaAttack(distance, slot_id, count, is_from_spell, attack_rounds)`.
- Add `$mob->AreaSpell(center, spell_id)`.
- Add `$mob->AreaSpell(center, spell_id, affect_caster)`.
- Add `$mob->AreaSpell(center, spell_id, affect_caster, resist_adjust)`.
- Add `$mob->AreaSpell(center, spell_id, affect_caster, resist_adjust, max_targets)`.
- Add `$mob->MassGroupBuff(center, spell_id)`.
- Add `$mob->MassGroupBuff(center, spell_id, affect_caster)`.

# Lua
- Add `client:AreaTaunt()`.
- Add `client:AreaTaunt(range)`.
- Add `client:AreaTaunt(range, bonus_hate)`.
- Add `mob:AreaAttack(distance)`.
- Add `mob:AreaAttack(distance, slot_id)`.
- Add `mob:AreaAttack(distance, slot_id, count)`.
- Add `mob:AreaAttack(distance, slot_id, count, is_from_spell)`.
- Add `mob:AreaAttack(distance, slot_id, count, is_from_spell, attack_rounds)`.
- Add `mob:AreaSpell(center, spell_id)`.
- Add `mob:AreaSpell(center, spell_id, affect_caster)`.
- Add `mob:AreaSpell(center, spell_id, affect_caster, resist_adjust)`.
- Add `mob:AreaSpell(center, spell_id, affect_caster, resist_adjust, max_targets)`.
- Add `mob:MassGroupBuff(center, spell_id)`.
- Add `mob:MassGroupBuff(center, spell_id, affect_caster)`.
- Add `eq.get_entity_list():AreaAttack(attacker, distance)`.
- Add `eq.get_entity_list():AreaAttack(attacker, distance, slot_id)`.
- Add `eq.get_entity_list():AreaAttack(attacker, distance, slot_id, count)`.
- Add `eq.get_entity_list():AreaAttack(attacker, distance, slot_id, count, is_from_spell)`.
- Add `eq.get_entity_list():AreaAttack(attacker, distance, slot_id, count, is_from_spell, attack_rounds)`.
- Add `eq.get_entity_list():AreaSpell(caster, center, spell_id)`.
- Add `eq.get_entity_list():AreaSpell(caster, center, spell_id, affect_caster)`.
- Add `eq.get_entity_list():AreaSpell(caster, center, spell_id, affect_caster, resist_adjust)`.
- Add `eq.get_entity_list():AreaSpell(caster, center, spell_id, affect_caster, resist_adjust, max_targets)`.
- Add `eq.get_entity_list():AreaTaunt(caster)`.
- Add `eq.get_entity_list():AreaTaunt(caster, range)`.
- Add `eq.get_entity_list():AreaTaunt(caster, range, bonus_hate)`.
- Add `eq.get_entity_list():MassGroupBuff(caster, center, spell_id)`.
- Add `eq.get_entity_list():MassGroupBuff(caster, center, spell_id, affect_caster)`.