### PR TITLE
[Bug Fix] Fix Issue with Removed #setfaction Command

### DIFF
--- a/common/repositories/command_subsettings_repository.h
+++ b/common/repositories/command_subsettings_repository.h
@@ -85,7 +85,6 @@ public:
 			{.parent_command = "set", .sub_command = "endurance", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "setendurance"},
 			{.parent_command = "set", .sub_command = "endurance_full", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "endurance"},
 			{.parent_command = "set", .sub_command = "exp", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "setxp|setexp"},
-			{.parent_command = "set", .sub_command = "faction", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "setfaction"},
 			{.parent_command = "set", .sub_command = "flymode", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "flymode"},
 			{.parent_command = "set", .sub_command = "freeze", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "freeze|unfreeze"},
 			{.parent_command = "set", .sub_command = "gender", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "gender"},


### PR DESCRIPTION
- Resolves https://github.com/EQEmu/Server/issues/4440, this was not removed from `common/repositories/command_subsettings_repository.h`, causing this subcommand to still show up in peoples' database, leading them to believe this command still exists.