### PR TITLE
[Cleanup] Remove unused methods

### DIFF
--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -2931,25 +2931,6 @@ DBnpcspells_Struct *ZoneDatabase::GetNPCSpells(uint32 npc_spells_id)
 	return nullptr;
 }
 
-uint32 ZoneDatabase::GetMaxNPCSpellsID() {
-
-	std::string query = "SELECT max(id) from npc_spells";
-	auto results = QueryDatabase(query);
-	if (!results.Success()) {
-		return 0;
-	}
-
-    if (results.RowCount() != 1)
-        return 0;
-
-    auto row = results.begin();
-
-    if (!row[0])
-        return 0;
-
-    return Strings::ToInt(row[0]);
-}
-
 DBnpcspellseffects_Struct *ZoneDatabase::GetNPCSpellsEffects(uint32 iDBSpellsEffectsID)
 {
 	if (iDBSpellsEffectsID == 0)

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -561,9 +561,6 @@ public:
 	bool		GetPoweredPetEntry(const std::string& pet_type, int16 pet_power, PetRecord* r);
 	bool		GetBasePetItems(int32 equipmentset, uint32 *items);
 	BeastlordPetData::PetStruct GetBeastlordPetData(uint16 race_id);
-	void		AddLootTableToNPC(NPC* npc, uint32 loottable_id, ItemList* itemlist, uint32* copper, uint32* silver, uint32* gold, uint32* plat);
-	void		AddLootDropToNPC(NPC* npc, uint32 lootdrop_id, ItemList* item_list, uint8 droplimit, uint8 mindrop);
-	uint32		GetMaxNPCSpellsID();
 	uint32		GetMaxNPCSpellsEffectsID();
 	bool GetAuraEntry(uint16 spell_id, AuraRecord &record);
 	void LoadGlobalLoot();


### PR DESCRIPTION
# Description
- Removes `GetMaxNPCSpellsID()`, `AddLootTableToNPC()`, and `AddLootDropToNPC()` from `zone/mob_ai.cpp` and `zone/zonedb.h` as they are all unused.