### PR TITLE
[Quest API] Add Several Door Methods to Perl/Lua

### DIFF
--- a/zone/doors.h
+++ b/zone/doors.h
@@ -60,6 +60,12 @@ public:
 	void SetPosition(const glm::vec4 &position);
 	void SetSize(uint16 size);
 	void ToggleState(Mob *sender);
+	inline std::string GetDestinationZoneName() { return m_destination_zone_name; }
+	inline int GetDestinationInstanceID() { return m_destination_instance_id; }
+	inline float GetDestinationX() { return m_destination.x; }
+	inline float GetDestinationY() { return m_destination.y; }
+	inline float GetDestinationZ() { return m_destination.z; }
+	inline float GetDestinationHeading() { return m_destination.w; }
 
 	float GetX();
 	float GetY();

--- a/zone/lua_door.cpp
+++ b/zone/lua_door.cpp
@@ -180,6 +180,96 @@ uint32 Lua_Door::GetID() {
 	return self->GetID();
 }
 
+uint8 Lua_Door::GetTriggerDoorID() {
+	Lua_Safe_Call_Int();
+	return self->GetTriggerDoorID();
+}
+
+uint8 Lua_Door::GetTriggerType() {
+	Lua_Safe_Call_Int();
+	return self->GetTriggerType();
+}
+
+bool Lua_Door::IsLDoNDoor() {
+	Lua_Safe_Call_Bool();
+	return self->IsLDoNDoor();
+}
+
+uint32 Lua_Door::GetClientVersionMask() {
+	Lua_Safe_Call_Int();
+	return self->GetClientVersionMask();
+}
+
+int Lua_Door::GetDoorParam() {
+	Lua_Safe_Call_Int();
+	return self->GetDoorParam();
+}
+
+bool Lua_Door::HasDestinationZone() {
+	Lua_Safe_Call_Bool();
+	return self->HasDestinationZone();
+}
+
+bool Lua_Door::IsDestinationZoneSame() {
+	Lua_Safe_Call_Bool();
+	return self->IsDestinationZoneSame();
+}
+
+bool Lua_Door::IsDoorBlacklisted() {
+	Lua_Safe_Call_Bool();
+	return self->IsDoorBlacklisted();
+}
+
+std::string Lua_Door::GetDestinationZoneName() {
+	Lua_Safe_Call_String();
+	return self->GetDestinationZoneName();
+}
+
+int Lua_Door::GetDestinationInstanceID() {
+	Lua_Safe_Call_Int();
+	return self->GetDestinationInstanceID();
+}
+
+float Lua_Door::GetDestinationX() {
+	Lua_Safe_Call_Real();
+	return self->GetDestinationX();
+}
+
+float Lua_Door::GetDestinationY() {
+	Lua_Safe_Call_Real();
+	return self->GetDestinationY();
+}
+
+float Lua_Door::GetDestinationZ() {
+	Lua_Safe_Call_Real();
+	return self->GetDestinationZ();
+}
+
+float Lua_Door::GetDestinationHeading() {
+	Lua_Safe_Call_Real();
+	return self->GetDestinationHeading();
+}
+
+int Lua_Door::GetDzSwitchID() {
+	Lua_Safe_Call_Int();
+	return self->GetDzSwitchID();
+}
+
+int Lua_Door::GetInvertState() {
+	Lua_Safe_Call_Int();
+	return self->GetInvertState();
+}
+
+void Lua_Door::SetInvertState(int invert_state) {
+	Lua_Safe_Call_Void();
+	self->SetInvertState(invert_state);
+}
+
+uint32 Lua_Door::GetGuildID() {
+	Lua_Safe_Call_Int();
+	return self->GetGuildID();
+}
+
 luabind::scope lua_register_door() {
 	return luabind::class_<Lua_Door, Lua_Entity>("Door")
 	.def(luabind::constructor<>())
@@ -191,24 +281,42 @@ luabind::scope lua_register_door() {
 	.def("ForceOpen", (void(Lua_Door::*)(Lua_Mob))&Lua_Door::ForceOpen)
 	.def("ForceOpen", (void(Lua_Door::*)(Lua_Mob,bool))&Lua_Door::ForceOpen)
 	.def("GetDisableTimer", (bool(Lua_Door::*)(void))&Lua_Door::GetDisableTimer)
+	.def("GetClientVersionMask", (uint32(Lua_Door::*)(void))&Lua_Door::GetClientVersionMask)
+	.def("GetDestinationHeading", (float(Lua_Door::*)(void))&Lua_Door::GetDestinationHeading)
+	.def("GetDestinationInstanceID", (int(Lua_Door::*)(void))&Lua_Door::GetDestinationInstanceID)
+	.def("GetDestinationX", (float(Lua_Door::*)(void))&Lua_Door::GetDestinationX)
+	.def("GetDestinationY", (float(Lua_Door::*)(void))&Lua_Door::GetDestinationY)
+	.def("GetDestinationZ", (float(Lua_Door::*)(void))&Lua_Door::GetDestinationZ)
+	.def("GetDestinationZoneName", (std::string(Lua_Door::*)(void))&Lua_Door::GetDestinationZoneName)
 	.def("GetDoorDBID", (uint32(Lua_Door::*)(void))&Lua_Door::GetDoorDBID)
 	.def("GetDoorID", (uint32(Lua_Door::*)(void))&Lua_Door::GetDoorID)
 	.def("GetDoorName", (const char*(Lua_Door::*)(void))&Lua_Door::GetDoorName)
+	.def("GetDoorParam", (int(Lua_Door::*)(void))&Lua_Door::GetDoorParam)
+	.def("GetDzSwitchID", (int(Lua_Door::*)(void))&Lua_Door::GetDzSwitchID)
+	.def("GetGuildID", (uint32(Lua_Door::*)(void))&Lua_Door::GetGuildID)
 	.def("GetHeading", (float(Lua_Door::*)(void))&Lua_Door::GetHeading)
 	.def("GetID", (uint32(Lua_Door::*)(void))&Lua_Door::GetID)
 	.def("GetIncline", (uint32(Lua_Door::*)(void))&Lua_Door::GetIncline)
+	.def("GetInvertState", (int(Lua_Door::*)(void))&Lua_Door::GetInvertState)
 	.def("GetKeyItem", (uint32(Lua_Door::*)(void))&Lua_Door::GetKeyItem)
 	.def("GetLockPick", (uint32(Lua_Door::*)(void))&Lua_Door::GetLockPick)
 	.def("GetNoKeyring", (int(Lua_Door::*)(void))&Lua_Door::GetNoKeyring)
 	.def("GetOpenType", (uint32(Lua_Door::*)(void))&Lua_Door::GetOpenType)
 	.def("GetSize", (uint32(Lua_Door::*)(void))&Lua_Door::GetSize)
+	.def("GetTriggerDoorID", (uint8(Lua_Door::*)(void))&Lua_Door::GetTriggerDoorID)
+	.def("GetTriggerType", (uint8(Lua_Door::*)(void))&Lua_Door::GetTriggerType)
 	.def("GetX", (float(Lua_Door::*)(void))&Lua_Door::GetX)
 	.def("GetY", (float(Lua_Door::*)(void))&Lua_Door::GetY)
 	.def("GetZ", (float(Lua_Door::*)(void))&Lua_Door::GetZ)
+	.def("HasDestinationZone", (bool(Lua_Door::*)(void))&Lua_Door::HasDestinationZone)
+	.def("IsDestinationZoneSame", (bool(Lua_Door::*)(void))&Lua_Door::IsDestinationZoneSame)
+	.def("IsDoorBlacklisted", (bool(Lua_Door::*)(void))&Lua_Door::IsDoorBlacklisted)
+	.def("IsLDoNDoor", (bool(Lua_Door::*)(void))&Lua_Door::IsLDoNDoor)
 	.def("SetDisableTimer", (void(Lua_Door::*)(bool))&Lua_Door::SetDisableTimer)
 	.def("SetDoorName", (void(Lua_Door::*)(const char*))&Lua_Door::SetDoorName)
 	.def("SetHeading", (void(Lua_Door::*)(float))&Lua_Door::SetHeading)
 	.def("SetIncline", (void(Lua_Door::*)(uint32))&Lua_Door::SetIncline)
+	.def("SetInvertState", (void(Lua_Door::*)(int))&Lua_Door::SetInvertState)
 	.def("SetKeyItem", (void(Lua_Door::*)(uint32))&Lua_Door::SetKeyItem)
 	.def("SetLocation", (void(Lua_Door::*)(float,float,float))&Lua_Door::SetLocation)
 	.def("SetLockPick", (void(Lua_Door::*)(uint32))&Lua_Door::SetLockPick)

--- a/zone/lua_door.h
+++ b/zone/lua_door.h
@@ -63,6 +63,24 @@ public:
 	void ForceClose(Lua_Mob sender);
 	void ForceClose(Lua_Mob sender, bool alt_mode);
 	uint32 GetID();
+	uint8 GetTriggerDoorID();
+	uint8 GetTriggerType();
+	bool IsLDoNDoor();
+	uint32 GetClientVersionMask();
+	int GetDoorParam();
+	bool HasDestinationZone();
+	bool IsDestinationZoneSame();
+	bool IsDoorBlacklisted();
+	std::string GetDestinationZoneName();
+	int GetDestinationInstanceID();
+	float GetDestinationX();
+	float GetDestinationY();
+	float GetDestinationZ();
+	float GetDestinationHeading();
+	int GetDzSwitchID();
+	int GetInvertState();
+	void SetInvertState(int invert_state);
+	uint32 GetGuildID();
 };
 
 #endif

--- a/zone/perl_doors.cpp
+++ b/zone/perl_doors.cpp
@@ -179,6 +179,96 @@ void Perl_Doors_SetDisableTimer(Doors* self, bool disable_timer)
 	self->SetDisableTimer(disable_timer);
 }
 
+uint8 Perl_Doors_GetTriggerDoorID(Doors* self)
+{
+	return self->GetTriggerDoorID();
+}
+
+uint8 Perl_Doors_GetTriggerType(Doors* self)
+{
+	return self->GetTriggerType();
+}
+
+bool Perl_Doors_IsLDoNDoor(Doors* self)
+{
+	return self->IsLDoNDoor();
+}
+
+uint32 Perl_Doors_GetClientVersionMask(Doors* self)
+{
+	return self->GetClientVersionMask();
+}
+
+int Perl_Doors_GetDoorParam(Doors* self)
+{
+	return self->GetDoorParam();
+}
+
+bool Perl_Doors_HasDestinationZone(Doors* self)
+{
+	return self->HasDestinationZone();
+}
+
+bool Perl_Doors_IsDestinationZoneSame(Doors* self)
+{
+	return self->IsDestinationZoneSame();
+}
+
+bool Perl_Doors_IsDoorBlacklisted(Doors* self)
+{
+	return self->IsDoorBlacklisted();
+}
+
+std::string Perl_Doors_GetDestinationZoneName(Doors* self)
+{
+	return self->GetDestinationZoneName();
+}
+
+int Perl_Doors_GetDestinationInstanceID(Doors* self)
+{
+	return self->GetDestinationInstanceID();
+}
+
+float Perl_Doors_GetDestinationX(Doors* self)
+{
+	return self->GetDestinationX();
+}
+
+float Perl_Doors_GetDestinationY(Doors* self)
+{
+	return self->GetDestinationY();
+}
+
+float Perl_Doors_GetDestinationZ(Doors* self)
+{
+	return self->GetDestinationZ();
+}
+
+float Perl_Doors_GetDestinationHeading(Doors* self)
+{
+	return self->GetDestinationHeading();
+}
+
+int Perl_Doors_GetDzSwitchID(Doors* self)
+{
+	return self->GetDzSwitchID();
+}
+
+int Perl_Doors_GetInvertState(Doors* self)
+{
+	return self->GetInvertState();
+}
+
+void Perl_Doors_SetInvertState(Doors* self, int invert_state)
+{
+	self->SetInvertState(invert_state);
+}
+
+uint32 Perl_Doors_GetGuildID(Doors* self)
+{
+	return self->GetGuildID();
+}
+
 void perl_register_doors()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -189,24 +279,42 @@ void perl_register_doors()
 	package.add("ForceClose", (void(*)(Doors*, Mob*, bool))&Perl_Doors_ForceClose);
 	package.add("ForceOpen", (void(*)(Doors*, Mob*))&Perl_Doors_ForceOpen);
 	package.add("ForceOpen", (void(*)(Doors*, Mob*, bool))&Perl_Doors_ForceOpen);
+	package.add("GetClientVersionMask", &Perl_Doors_GetClientVersionMask);
+	package.add("GetDestinationHeading", &Perl_Doors_GetDestinationHeading);
+	package.add("GetDestinationInstanceID", &Perl_Doors_GetDestinationInstanceID);
+	package.add("GetDestinationX", &Perl_Doors_GetDestinationX);
+	package.add("GetDestinationY", &Perl_Doors_GetDestinationY);
+	package.add("GetDestinationZ", &Perl_Doors_GetDestinationZ);
+	package.add("GetDestinationZoneName", &Perl_Doors_GetDestinationZoneName);
 	package.add("GetDisableTimer", &Perl_Doors_GetDisableTimer);
 	package.add("GetDoorDBID", &Perl_Doors_GetDoorDBID);
 	package.add("GetDoorID", &Perl_Doors_GetDoorID);
+	package.add("GetDoorParam", &Perl_Doors_GetDoorParam);
+	package.add("GetDzSwitchID", &Perl_Doors_GetDzSwitchID);
+	package.add("GetGuildID", &Perl_Doors_GetGuildID);
 	package.add("GetHeading", &Perl_Doors_GetHeading);
 	package.add("GetID", &Perl_Doors_GetID);
 	package.add("GetIncline", &Perl_Doors_GetIncline);
+	package.add("GetInvertState", &Perl_Doors_GetInvertState);
 	package.add("GetKeyItem", &Perl_Doors_GetKeyItem);
 	package.add("GetLockPick", &Perl_Doors_GetLockPick);
 	package.add("GetModelName", &Perl_Doors_GetModelName);
 	package.add("GetNoKeyring", &Perl_Doors_GetNoKeyring);
 	package.add("GetOpenType", &Perl_Doors_GetOpenType);
 	package.add("GetSize", &Perl_Doors_GetSize);
+	package.add("GetTriggerDoorID", &Perl_Doors_GetTriggerDoorID);
+	package.add("GetTriggerType", &Perl_Doors_GetTriggerType);
 	package.add("GetX", &Perl_Doors_GetX);
 	package.add("GetY", &Perl_Doors_GetY);
 	package.add("GetZ", &Perl_Doors_GetZ);
+	package.add("HasDestinationZone", &Perl_Doors_HasDestinationZone);
+	package.add("IsDestinationZoneSame", &Perl_Doors_IsDestinationZoneSame);
+	package.add("IsDoorBlacklisted", &Perl_Doors_IsDoorBlacklisted);
+	package.add("IsLDoNDoor", &Perl_Doors_IsLDoNDoor);
 	package.add("SetDisableTimer", &Perl_Doors_SetDisableTimer);
 	package.add("SetHeading", &Perl_Doors_SetHeading);
 	package.add("SetIncline", &Perl_Doors_SetIncline);
+	package.add("SetInvertState", &Perl_Doors_SetInvertState);
 	package.add("SetKeyItem", &Perl_Doors_SetKeyItem);
 	package.add("SetLocation", &Perl_Doors_SetLocation);
 	package.add("SetLockPick", &Perl_Doors_SetLockPick);


### PR DESCRIPTION
# Perl
- Add `$door->GetClientVersionMask()`.
- Add `$door->GetDestinationHeading()`.
- Add `$door->GetDestinationInstanceID()`.
- Add `$door->GetDestinationX()`.
- Add `$door->GetDestinationY()`.
- Add `$door->GetDestinationZ()`.
- Add `$door->GetDestinationZoneName()`.
- Add `$door->GetDoorParam()`.
- Add `$door->GetDzSwitchID()`.
- Add `$door->GetGuildID()`.
- Add `$door->GetInvertState()`.
- Add `$door->GetTriggerDoorID()`.
- Add `$door->GetTriggerType()`.
- Add `$door->HasDestinationZone()`.
- Add `$door->IsDestinationZoneSame()`.
- Add `$door->IsDoorBlacklisted()`.
- Add `$door->IsLDoNDoor()`.
- Add `$door->SetInvertState(invert_state)`.

# Lua
- Add `door:GetClientVersionMask()`.
- Add `door:GetDestinationHeading()`.
- Add `door:GetDestinationInstanceID()`.
- Add `door:GetDestinationX()`.
- Add `door:GetDestinationY()`.
- Add `door:GetDestinationZ()`.
- Add `door:GetDestinationZoneName()`.
- Add `door:GetDoorParam()`.
- Add `door:GetDzSwitchID()`.
- Add `door:GetGuildID()`.
- Add `door:GetInvertState()`.
- Add `door:GetTriggerDoorID()`.
- Add `door:GetTriggerType()`.
- Add `door:HasDestinationZone()`.
- Add `door:IsDestinationZoneSame()`.
- Add `door:IsDoorBlacklisted()`.
- Add `door:IsLDoNDoor()`.
- Add `door:SetInvertState(invert_state)`.