### PR TITLE
[Bug Fix] Apply Race & Class restrictions to Auto-Combines

### DIFF
--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -625,6 +625,41 @@ void Object::HandleAutoCombine(Client* user, const RecipeAutoCombine_Struct* rac
 		return;
 	}
 
+	if (spec.tradeskill == EQ::skills::SkillAlchemy) {
+		if (!user->GetClass() == Class::Shaman) {
+			user->Message(Chat::Red, "This tradeskill can only be performed by a shaman.");
+			auto outapp = new EQApplicationPacket(OP_TradeSkillCombine, 0);
+			user->QueuePacket(outapp);
+			safe_delete(outapp);
+			return;
+		}
+		else if (user->GetLevel() < MIN_LEVEL_ALCHEMY) {
+			user->Message(Chat::Red, "You cannot perform alchemy until you reach level %i.", MIN_LEVEL_ALCHEMY);
+			auto outapp = new EQApplicationPacket(OP_TradeSkillCombine, 0);
+			user->QueuePacket(outapp);
+			safe_delete(outapp);
+			return;
+		}
+	}
+	else if (spec.tradeskill == EQ::skills::SkillTinkering) {
+		if (user->GetRace() != GNOME) {
+			user->Message(Chat::Red, "Only gnomes can tinker.");
+			auto outapp = new EQApplicationPacket(OP_TradeSkillCombine, 0);
+			user->QueuePacket(outapp);
+			safe_delete(outapp);
+			return;
+		}
+	}
+	else if (spec.tradeskill == EQ::skills::SkillMakePoison) {
+		if (!user->GetClass() == Class::Rogue) {
+			user->Message(Chat::Red, "Only rogues can mix poisons.");
+			auto outapp = new EQApplicationPacket(OP_TradeSkillCombine, 0);
+			user->QueuePacket(outapp);
+			safe_delete(outapp);
+			return;
+		}
+	}
+
     //pull the list of components
 	const auto query = fmt::format("SELECT item_id, componentcount "
                                     "FROM tradeskill_recipe_entries "


### PR DESCRIPTION
# Description

Copy & Paste from `HandleCombine()` to `HandleAutoCombine()` to account for client mods which spawn autocombine window for restricted tradeskills.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

Attach images and describe testing done to validate functionality.
![image](https://github.com/user-attachments/assets/ab6fa5f1-ff0a-4fc9-af47-2e5e9497ba0c)

Clients tested:  ROF2 w/ client mods

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
