### PR TITLE
[Feature] Lazy Load Bank Contents

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -909,6 +909,7 @@ RULE_BOOL(Inventory, AllowAnyWeaponTransformation, false, "Weapons can use any w
 RULE_BOOL(Inventory, TransformSummonedBags, false, "Transforms summoned bags into disenchanted ones instead of deleting")
 RULE_BOOL(Inventory, AllowMultipleOfSameAugment, false, "Allows multiple of the same augment to be placed in an item via #augmentitem or MQ2, set to true to allow")
 RULE_INT(Inventory, AlternateAugmentationSealer, 53, "Allows RoF+ clients to augment items from a special container type")
+RULE_BOOL(Inventory, LazyLoadBank, false, "Don't load bank during zoning, only when in proximinity to a banker. May increase zone speed and stability")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Client)

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -909,7 +909,7 @@ RULE_BOOL(Inventory, AllowAnyWeaponTransformation, false, "Weapons can use any w
 RULE_BOOL(Inventory, TransformSummonedBags, false, "Transforms summoned bags into disenchanted ones instead of deleting")
 RULE_BOOL(Inventory, AllowMultipleOfSameAugment, false, "Allows multiple of the same augment to be placed in an item via #augmentitem or MQ2, set to true to allow")
 RULE_INT(Inventory, AlternateAugmentationSealer, 53, "Allows RoF+ clients to augment items from a special container type")
-RULE_BOOL(Inventory, LazyLoadBank, false, "Don't load bank during zoning, only when in proximinity to a banker. May increase zone speed and stability")
+RULE_BOOL(Inventory, LazyLoadBank, true, "Don't load bank during zoning, only when in proximinity to a banker. May increase zone speed and stability")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Client)

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -392,7 +392,6 @@ Client::Client(EQStreamInterface *ieqs) : Mob(
 	SetBotPrecombat(false);
 
 	AI_Init();
-
 }
 
 Client::~Client() {

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -185,7 +185,8 @@ Client::Client(EQStreamInterface *ieqs) : Mob(
   position_update_timer(10000),
   consent_throttle_timer(2000),
   tmSitting(0),
-  parcel_timer(RuleI(Parcel, ParcelDeliveryDelay))
+  parcel_timer(RuleI(Parcel, ParcelDeliveryDelay)),
+  lazy_load_bank_check_timer(1000)
 {
 	for (auto client_filter = FilterNone; client_filter < _FilterCount; client_filter = eqFilterType(client_filter + 1)) {
 		SetFilter(client_filter, FilterShow);

--- a/zone/client.h
+++ b/zone/client.h
@@ -2174,7 +2174,7 @@ private:
 	glm::vec3 m_quest_compass;
 	bool m_has_quest_compass = false;
 	std::vector<uint32_t> m_dynamic_zone_ids;
-
+	int sent_inventory;
 
 public:
 	enum BotOwnerOption : size_t {

--- a/zone/client.h
+++ b/zone/client.h
@@ -2177,7 +2177,7 @@ private:
 	glm::vec3 m_quest_compass;
 	bool m_has_quest_compass = false;
 	std::vector<uint32_t> m_dynamic_zone_ids;
-	int sent_inventory;
+	int sent_inventory = 0;
 
 public:
 	enum BotOwnerOption : size_t {

--- a/zone/client.h
+++ b/zone/client.h
@@ -2058,9 +2058,8 @@ private:
 	Timer parcel_timer;	//Used to limit the number of parcels to one every 30 seconds (default).  Changable via rule.
 	Timer lazy_load_bank_check_timer;
 
-	bool m_lazy_load_bank       = false;
-	int  m_lazy_load_sent_slots = 0;
-
+	bool m_lazy_load_bank            = false;
+	int  m_lazy_load_sent_bank_slots = 0;
 
 	glm::vec3 m_Proximity;
 	glm::vec4 last_position_before_bulk_update;

--- a/zone/client.h
+++ b/zone/client.h
@@ -2056,6 +2056,9 @@ private:
 	Timer task_request_timer;
 	Timer pick_lock_timer;
 	Timer parcel_timer;	//Used to limit the number of parcels to one every 30 seconds (default).  Changable via rule.
+	Timer lazy_load_bank_check_timer;
+
+	bool m_lazy_load_bank = false;
 
 	glm::vec3 m_Proximity;
 	glm::vec4 last_position_before_bulk_update;

--- a/zone/client.h
+++ b/zone/client.h
@@ -2058,7 +2058,9 @@ private:
 	Timer parcel_timer;	//Used to limit the number of parcels to one every 30 seconds (default).  Changable via rule.
 	Timer lazy_load_bank_check_timer;
 
-	bool m_lazy_load_bank = false;
+	bool m_lazy_load_bank       = false;
+	int  m_lazy_load_sent_slots = 0;
+
 
 	glm::vec3 m_Proximity;
 	glm::vec4 last_position_before_bulk_update;
@@ -2177,7 +2179,6 @@ private:
 	glm::vec3 m_quest_compass;
 	bool m_has_quest_compass = false;
 	std::vector<uint32_t> m_dynamic_zone_ids;
-	int sent_inventory = 0;
 
 public:
 	enum BotOwnerOption : size_t {

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1202,6 +1202,7 @@ void Client::Handle_Connect_OP_WorldObjectsSent(const EQApplicationPacket *app)
 
 void Client::Handle_Connect_OP_ZoneComplete(const EQApplicationPacket *app)
 {
+	sent_inventory = 0;
 	auto outapp = new EQApplicationPacket(OP_0x0347, 0);
 	QueuePacket(outapp);
 	safe_delete(outapp);

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1202,7 +1202,6 @@ void Client::Handle_Connect_OP_WorldObjectsSent(const EQApplicationPacket *app)
 
 void Client::Handle_Connect_OP_ZoneComplete(const EQApplicationPacket *app)
 {
-	sent_inventory = 0;
 	auto outapp = new EQApplicationPacket(OP_0x0347, 0);
 	QueuePacket(outapp);
 	safe_delete(outapp);

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -289,24 +289,25 @@ bool Client::Process() {
 			entity_list.ScanCloseMobs(close_mobs, this, IsMoving());
 		}
 
-        if (RuleB(Custom, BlockBankItemsOnZone) && Connected()) {
+        if (RuleB(Inventory, LazyLoadBank) && Connected()) {
 			uint32 banker_max_dist = 0;
 			if(sent_inventory <= EQ::invslot::SHARED_BANK_END && entity_list.GetClosestBanker(this, banker_max_dist) && banker_max_dist <= USE_NPC_RANGE2) {
-            const EQ::ItemInstance* inst = nullptr;
+				const EQ::ItemInstance* inst = nullptr;
 
-            // Jump the gaps
-            if (sent_inventory < EQ::invslot::BANK_BEGIN) {
-                sent_inventory = EQ::invslot::BANK_BEGIN;
-            } else if (sent_inventory > EQ::invslot::BANK_END && sent_inventory < EQ::invslot::SHARED_BANK_BEGIN) {
-                sent_inventory = EQ::invslot::SHARED_BANK_BEGIN;
-            } else {
-                sent_inventory++;
-            }
+				// Jump the gaps
+				if (sent_inventory < EQ::invslot::BANK_BEGIN) {
+					sent_inventory = EQ::invslot::BANK_BEGIN;
+				} else if (sent_inventory > EQ::invslot::BANK_END && sent_inventory < EQ::invslot::SHARED_BANK_BEGIN) {
+					sent_inventory = EQ::invslot::SHARED_BANK_BEGIN;
+				} else {
+					sent_inventory++;
+				}
 
-            inst = m_inv[sent_inventory];
-            if (inst) {
-                SendItemPacket(sent_inventory, inst, ItemPacketType::ItemPacketTrade);
-            }
+				inst = m_inv[sent_inventory];
+				if (inst) {
+					SendItemPacket(sent_inventory, inst, ItemPacketType::ItemPacketTrade);
+				}
+			}
         }
 
 		bool may_use_attacks = false;

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -292,29 +292,30 @@ bool Client::Process() {
 		if (RuleB(Inventory, LazyLoadBank)) {
 			// poll once a second to see if we are close to a banker and we haven't loaded the bank yet
 			if (!m_lazy_load_bank && lazy_load_bank_check_timer.Check()) {
-				if (m_lazy_load_sent_slots <= EQ::invslot::SHARED_BANK_END && IsCloseToBanker()) {
+				if (m_lazy_load_sent_bank_slots <= EQ::invslot::SHARED_BANK_END && IsCloseToBanker()) {
 					m_lazy_load_bank = true;
 					lazy_load_bank_check_timer.Disable();
 				}
 			}
 
-			if (m_lazy_load_bank && m_lazy_load_sent_slots <= EQ::invslot::SHARED_BANK_END) {
+			if (m_lazy_load_bank && m_lazy_load_sent_bank_slots <= EQ::invslot::SHARED_BANK_END) {
 				const EQ::ItemInstance *inst = nullptr;
 
 				// Jump the gaps
-				if (m_lazy_load_sent_slots < EQ::invslot::BANK_BEGIN) {
-					m_lazy_load_sent_slots = EQ::invslot::BANK_BEGIN;
+				if (m_lazy_load_sent_bank_slots < EQ::invslot::BANK_BEGIN) {
+					m_lazy_load_sent_bank_slots = EQ::invslot::BANK_BEGIN;
 				}
-				else if (m_lazy_load_sent_slots > EQ::invslot::BANK_END && m_lazy_load_sent_slots < EQ::invslot::SHARED_BANK_BEGIN) {
-					m_lazy_load_sent_slots = EQ::invslot::SHARED_BANK_BEGIN;
+				else if (m_lazy_load_sent_bank_slots > EQ::invslot::BANK_END &&
+						 m_lazy_load_sent_bank_slots < EQ::invslot::SHARED_BANK_BEGIN) {
+					m_lazy_load_sent_bank_slots = EQ::invslot::SHARED_BANK_BEGIN;
 				}
 				else {
-					m_lazy_load_sent_slots++;
+					m_lazy_load_sent_bank_slots++;
 				}
 
-				inst = m_inv[m_lazy_load_sent_slots];
+				inst = m_inv[m_lazy_load_sent_bank_slots];
 				if (inst) {
-					SendItemPacket(m_lazy_load_sent_slots, inst, ItemPacketType::ItemPacketTrade);
+					SendItemPacket(m_lazy_load_sent_bank_slots, inst, ItemPacketType::ItemPacketTrade);
 				}
 			}
 		}

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -292,29 +292,29 @@ bool Client::Process() {
 		if (RuleB(Inventory, LazyLoadBank)) {
 			// poll once a second to see if we are close to a banker and we haven't loaded the bank yet
 			if (!m_lazy_load_bank && lazy_load_bank_check_timer.Check()) {
-				if (sent_inventory <= EQ::invslot::SHARED_BANK_END && IsCloseToBanker()) {
+				if (m_lazy_load_sent_slots <= EQ::invslot::SHARED_BANK_END && IsCloseToBanker()) {
 					m_lazy_load_bank = true;
 					lazy_load_bank_check_timer.Disable();
 				}
 			}
 
-			if (m_lazy_load_bank && sent_inventory <= EQ::invslot::SHARED_BANK_END) {
+			if (m_lazy_load_bank && m_lazy_load_sent_slots <= EQ::invslot::SHARED_BANK_END) {
 				const EQ::ItemInstance *inst = nullptr;
 
 				// Jump the gaps
-				if (sent_inventory < EQ::invslot::BANK_BEGIN) {
-					sent_inventory = EQ::invslot::BANK_BEGIN;
+				if (m_lazy_load_sent_slots < EQ::invslot::BANK_BEGIN) {
+					m_lazy_load_sent_slots = EQ::invslot::BANK_BEGIN;
 				}
-				else if (sent_inventory > EQ::invslot::BANK_END && sent_inventory < EQ::invslot::SHARED_BANK_BEGIN) {
-					sent_inventory = EQ::invslot::SHARED_BANK_BEGIN;
+				else if (m_lazy_load_sent_slots > EQ::invslot::BANK_END && m_lazy_load_sent_slots < EQ::invslot::SHARED_BANK_BEGIN) {
+					m_lazy_load_sent_slots = EQ::invslot::SHARED_BANK_BEGIN;
 				}
 				else {
-					sent_inventory++;
+					m_lazy_load_sent_slots++;
 				}
 
-				inst = m_inv[sent_inventory];
+				inst = m_inv[m_lazy_load_sent_slots];
 				if (inst) {
-					SendItemPacket(sent_inventory, inst, ItemPacketType::ItemPacketTrade);
+					SendItemPacket(m_lazy_load_sent_slots, inst, ItemPacketType::ItemPacketTrade);
 				}
 			}
 		}


### PR DESCRIPTION
# Description

This provides a rule which causes the contents of the Bank to not load until the player is within proximity of a Banker. This has has been observed to dramatically improve zoning times and zoning stability for characters with well-populated banks while using custom code to expand bag sizes, but is likely to produce similar effects with normal bag sizes.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# Testing

This has been in usage on Retribution for approximately two months.

Clients tested: 

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
