### PR TITLE
[Bug Fix] client_max_level allow leveling to end of level

### DIFF
--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -607,10 +607,10 @@ void Client::SetEXP(ExpSource exp_source, uint64 set_exp, uint64 set_aaxp, bool 
 		Message(Chat::Red, "Error in Client::SetEXP. EXP not set.");
 		return; // Must be invalid class/race
 	}
+
 	uint32 i = 0;
 	uint32 membercount = 0;
-	if(GetGroup())
-	{
+	if(GetGroup()) {
 		for (i = 0; i < MAX_GROUP_MEMBERS; i++) {
 			if (GetGroup()->members[i] != nullptr) {
 				membercount++;
@@ -627,25 +627,29 @@ void Client::SetEXP(ExpSource exp_source, uint64 set_exp, uint64 set_aaxp, bool 
 		if (RuleI(Character, ShowExpValues) >= 1) {
 			if (exp_gained > 0 && aa_exp_gained > 0) {
 				exp_amount_message = fmt::format("({}) ({})", exp_gained, aa_exp_gained);
-			}
-			else if (exp_gained > 0) {
+			} else if (exp_gained > 0) {
 				exp_amount_message = fmt::format("({})", exp_gained);
-			}
-			else {
+			} else {
 				exp_amount_message = fmt::format("({}) AA", aa_exp_gained);
 			}
 		}
 
 		std::string exp_percent_message = "";
 		if (RuleI(Character, ShowExpValues) >= 2) {
-			if (exp_gained > 0 && aa_exp_gained > 0) exp_percent_message = StringFormat("(%.3f%%, %.3f%%AA)", exp_percent, aa_exp_percent);
-			else if (exp_gained > 0) exp_percent_message = StringFormat("(%.3f%%)", exp_percent);
-			else exp_percent_message = StringFormat("(%.3f%%AA)", aa_exp_percent);
+			if (exp_gained > 0 && aa_exp_gained > 0) {
+				exp_percent_message = StringFormat("(%.3f%%, %.3f%%AA)", exp_percent, aa_exp_percent);
+			} else if (exp_gained > 0) {
+				exp_percent_message = StringFormat("(%.3f%%)", exp_percent);
+			} else {
+				exp_percent_message = StringFormat("(%.3f%%AA)", aa_exp_percent);
+			}
 		}
 		if (isrezzexp) {
-			if (RuleI(Character, ShowExpValues) > 0)
+			if (RuleI(Character, ShowExpValues) > 0) {
 				Message(Chat::Experience, "You regain %s experience from resurrection. %s", exp_amount_message.c_str(), exp_percent_message.c_str());
-			else MessageString(Chat::Experience, REZ_REGAIN);
+			} else {
+				MessageString(Chat::Experience, REZ_REGAIN);
+			}
 		} else {
 			if (membercount > 1) {
 				if (RuleI(Character, ShowExpValues) > 0) {
@@ -673,14 +677,17 @@ void Client::SetEXP(ExpSource exp_source, uint64 set_exp, uint64 set_aaxp, bool 
 				}
 			}
 		}
-	}
-	else if(total_add_exp < total_current_exp){ //only loss message if you lose exp, no message if you gained/lost nothing.
+	} else if(total_add_exp < total_current_exp) { //only loss message if you lose exp, no message if you gained/lost nothing.
 		uint64 exp_lost = current_exp - set_exp;
 		float exp_percent = (float)((float)exp_lost / (float)(GetEXPForLevel(GetLevel() + 1) - GetEXPForLevel(GetLevel())))*(float)100;
 
-		if (RuleI(Character, ShowExpValues) == 1 && exp_lost > 0) Message(Chat::Yellow, "You have lost %i experience.", exp_lost);
-		else if (RuleI(Character, ShowExpValues) == 2 && exp_lost > 0) Message(Chat::Yellow, "You have lost %i experience. (%.3f%%)", exp_lost, exp_percent);
-		else Message(Chat::Yellow, "You have lost experience.");
+		if (RuleI(Character, ShowExpValues) == 1 && exp_lost > 0) {
+			Message(Chat::Yellow, "You have lost %i experience.", exp_lost);
+		} else if (RuleI(Character, ShowExpValues) == 2 && exp_lost > 0) {
+			Message(Chat::Yellow, "You have lost %i experience. (%.3f%%)", exp_lost, exp_percent);
+		} else {
+			Message(Chat::Yellow, "You have lost experience.");
+		}
 	}
 
 	//check_level represents the level we should be when we have
@@ -698,8 +705,9 @@ void Client::SetEXP(ExpSource exp_source, uint64 set_exp, uint64 set_aaxp, bool 
 		}
 		level_count++;
 
-		if(GetMercenaryID())
+		if (GetMercenaryID()) {
 			UpdateMercLevel();
+		}
 	}
 	//see if we lost any levels
 	while (set_exp < GetEXPForLevel(check_level-1)) {
@@ -709,8 +717,9 @@ void Client::SetEXP(ExpSource exp_source, uint64 set_exp, uint64 set_aaxp, bool 
 			break;
 		}
 		level_increase = false;
-		if(GetMercenaryID())
+		if (GetMercenaryID()) {
 			UpdateMercLevel();
+		}
 	}
 	check_level--;
 
@@ -747,12 +756,14 @@ void Client::SetEXP(ExpSource exp_source, uint64 set_exp, uint64 set_aaxp, bool 
 		//Message(Chat::Yellow, "You have gained %d skill points!!", m_pp.aapoints - last_unspentAA);
 		char val1[20] = { 0 };
 		char val2[20] = { 0 };
-		if (gained == 1 && m_pp.aapoints == 1)
+
+		if (gained == 1 && m_pp.aapoints == 1) {
 			MessageString(Chat::Experience, GAIN_SINGLE_AA_SINGLE_AA, ConvertArray(m_pp.aapoints, val1)); //You have gained an ability point!  You now have %1 ability point.
-		else if (gained == 1 && m_pp.aapoints > 1)
+		} else if (gained == 1 && m_pp.aapoints > 1) {
 			MessageString(Chat::Experience, GAIN_SINGLE_AA_MULTI_AA, ConvertArray(m_pp.aapoints, val1)); //You have gained an ability point!  You now have %1 ability points.
-		else
+		} else {
 			MessageString(Chat::Experience, GAIN_MULTI_AA_MULTI_AA, ConvertArray(gained, val1), ConvertArray(m_pp.aapoints, val2)); //You have gained %1 ability point(s)!  You now have %2 ability point(s).
+		}
 
 		if (RuleB(AA, SoundForAAEarned)) {
 			SendSound();
@@ -765,7 +776,7 @@ void Client::SetEXP(ExpSource exp_source, uint64 set_exp, uint64 set_aaxp, bool 
 		RecordPlayerEventLog(PlayerEvent::AA_GAIN, PlayerEvent::AAGainedEvent{gained});
 
 		/* QS: PlayerLogAARate */
-		if (RuleB(QueryServ, PlayerLogAARate)){
+		if (RuleB(QueryServ, PlayerLogAARate)) {
 			int add_points = (m_pp.aapoints - last_unspentAA);
 			std::string query = StringFormat("INSERT INTO `qs_player_aa_rate_hourly` (char_id, aa_count, hour_time) VALUES (%i, %i, UNIX_TIMESTAMP() - MOD(UNIX_TIMESTAMP(), 3600)) ON DUPLICATE KEY UPDATE `aa_count` = `aa_count` + %i", CharacterID(), add_points, add_points);
 			QServ->SendQuery(query.c_str());
@@ -774,47 +785,44 @@ void Client::SetEXP(ExpSource exp_source, uint64 set_exp, uint64 set_aaxp, bool 
 		//Message(Chat::Yellow, "You now have %d skill points available to spend.", m_pp.aapoints);
 	}
 
-	uint8 maxlevel = RuleI(Character, MaxExpLevel) + 1;
+	uint8 max_level = RuleI(Character, MaxExpLevel) + 1;
 
-	if(maxlevel <= 1)
-		maxlevel = RuleI(Character, MaxLevel) + 1;
-
-	if(check_level > maxlevel) {
-		check_level = maxlevel;
-
-		if(RuleB(Character, KeepLevelOverMax)) {
-			set_exp = GetEXPForLevel(GetLevel()+1);
-		}
-		else {
-			set_exp = GetEXPForLevel(maxlevel);
-		}
+	if (max_level <= 1) {
+		max_level = RuleI(Character, MaxLevel) + 1;
 	}
 
 	auto client_max_level = GetClientMaxLevel();
 	if (client_max_level) {
-		if (GetLevel() >= client_max_level) {
-			auto exp_needed = GetEXPForLevel(client_max_level);
-			if (set_exp > exp_needed) {
-				set_exp = exp_needed;
-			}
+		max_level = client_max_level + 1;
+	}
+
+	if (check_level > max_level) {
+		check_level = max_level;
+
+		if (RuleB(Character, KeepLevelOverMax)) {
+			set_exp = GetEXPForLevel(GetLevel()+1);
+		} else {
+			set_exp = GetEXPForLevel(max_level);
 		}
 	}
 
-	if ((GetLevel() != check_level) && !(check_level >= maxlevel)) {
+	if ((GetLevel() != check_level) && !(check_level >= max_level)) {
 		char val1[20]={0};
-		if (level_increase)
-		{
-			if (level_count == 1)
+		if (level_increase) {
+			if (level_count == 1) {
 				MessageString(Chat::Experience, GAIN_LEVEL, ConvertArray(check_level, val1));
-			else
+			} else {
 				Message(Chat::Yellow, "Welcome to level %i!", check_level);
+			}
 
 			if (check_level == RuleI(Character, DeathItemLossLevel) &&
-			    m_ClientVersionBit & EQ::versions::maskUFAndEarlier)
+			    m_ClientVersionBit & EQ::versions::maskUFAndEarlier) {
 				MessageString(Chat::Yellow, CORPSE_ITEM_LOST);
+				}
 
-			if (check_level == RuleI(Character, DeathExpLossLevel))
+			if (check_level == RuleI(Character, DeathExpLossLevel)) {
 				MessageString(Chat::Yellow, CORPSE_EXP_LOST);
+			}
 		}
 
 		uint8 myoldlevel = GetLevel();
@@ -828,9 +836,9 @@ void Client::SetEXP(ExpSource exp_source, uint64 set_exp, uint64 set_aaxp, bool 
 	}
 
 	//If were at max level then stop gaining experience if we make it to the cap
-	if(GetLevel() == maxlevel - 1){
+	if (GetLevel() == max_level - 1){
 		uint32 expneeded = GetEXPForLevel(maxlevel);
-		if(set_exp > expneeded) {
+		if (set_exp > expneeded) {
 			set_exp = expneeded;
 		}
 	}


### PR DESCRIPTION
# Description

When using a method that leverages client_max_level (e.g. Max Level by bucket / qglobal / quest API) it would stop xp at 0% into the level rather than maximum xp for the level.

This could pose an issue where: If you had a max level of 65 via a databucket and a raid zone required level 65, one death would de-level them and potentially prevent them from entering the zone.

I reorganized the code to leverage the existing max_level logic which allows max xp in the max level.

I also cleaned up the overall functions formating (Mostly brackets and implied if statements).

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

![image](https://github.com/user-attachments/assets/216cfeaf-9b10-4a51-823f-8e02e3d1c481)
![image](https://github.com/user-attachments/assets/f717e614-7ebb-4bb5-b534-688d42f623a4)
![image](https://github.com/user-attachments/assets/96c4f78d-40e9-4673-a6ec-9c62498ce851)

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
