### PR TITLE
[Quest API] Add AreTasksCompleted() to Perl/Lua.

### DIFF
--- a/zone/client.h
+++ b/zone/client.h
@@ -1420,10 +1420,10 @@ public:
 	{
 		return (task_state ? task_state->EnabledTaskCount(task_set_id) : -1);
 	}
-	inline int IsTaskCompleted(int task_id) { return (task_state ? task_state->IsTaskCompleted(task_id) : -1); }
-	inline int AreTasksCompleted(std::vector<int> task_ids)
+	inline bool IsTaskCompleted(int task_id) { return (task_state ? task_state->IsTaskCompleted(task_id) : false); }
+	inline bool AreTasksCompleted(std::vector<int> task_ids)
 	{
-		return (task_state ? task_state->AreTasksCompleted(task_ids) : -1);
+		return (task_state ? task_state->AreTasksCompleted(task_ids) : false);
 	}
 	inline void ShowClientTasks(Client *client) { if (task_state) { task_state->ShowClientTasks(this, client); }}
 	inline void CancelAllTasks() { if (task_state) { task_state->CancelAllTasks(this); }}

--- a/zone/client.h
+++ b/zone/client.h
@@ -1421,6 +1421,10 @@ public:
 		return (task_state ? task_state->EnabledTaskCount(task_set_id) : -1);
 	}
 	inline int IsTaskCompleted(int task_id) { return (task_state ? task_state->IsTaskCompleted(task_id) : -1); }
+	inline int AreTasksCompleted(std::vector<int> task_ids)
+	{
+		return (task_state ? task_state->AreTasksCompleted(task_ids) : -1);
+	}
 	inline void ShowClientTasks(Client *client) { if (task_state) { task_state->ShowClientTasks(this, client); }}
 	inline void CancelAllTasks() { if (task_state) { task_state->CancelAllTasks(this); }}
 	inline int GetActiveTaskCount() { return (task_state ? task_state->GetActiveTaskCount() : 0); }

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -5967,6 +5967,17 @@ bool Perl__send_parcel(perl::reference table_ref)
 	return out;
 }
 
+int Perl__aretaskscompleted(perl::array task_ids)
+{
+	std::vector<int> v;
+
+	for (const auto& e : task_ids) {
+		v.emplace_back(static_cast<int>(e));
+	}
+
+	return quest_manager.aretaskscompleted(v);
+}
+
 void perl_register_quest()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -6290,6 +6301,7 @@ void perl_register_quest()
 	package.add("addloot", (void(*)(int, int))&Perl__addloot);
 	package.add("addloot", (void(*)(int, int, bool))&Perl__addloot);
 	package.add("addskill", &Perl__addskill);
+	package.add("aretaskscompleted", &Perl__aretaskscompleted);
 	package.add("assigntask", (void(*)(int))&Perl__assigntask);
 	package.add("assigntask", (void(*)(int, bool))&Perl__assigntask);
 	package.add("attack", &Perl__attack);

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -1276,7 +1276,7 @@ int Perl__tasktimeleft(int task_id)
 	return quest_manager.tasktimeleft(task_id);
 }
 
-int Perl__istaskcompleted(int task_id)
+bool Perl__istaskcompleted(int task_id)
 {
 	return quest_manager.istaskcompleted(task_id);
 }
@@ -5967,7 +5967,7 @@ bool Perl__send_parcel(perl::reference table_ref)
 	return out;
 }
 
-int Perl__aretaskscompleted(perl::array task_ids)
+bool Perl__aretaskscompleted(perl::array task_ids)
 {
 	std::vector<int> v;
 

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -1409,9 +1409,9 @@ void Lua_Client::FailTask(int task) {
 	self->FailTask(task);
 }
 
-bool Lua_Client::IsTaskCompleted(int task) {
+bool Lua_Client::IsTaskCompleted(int task_id) {
 	Lua_Safe_Call_Bool();
-	return self->IsTaskCompleted(task) != 0;
+	return self->IsTaskCompleted(task_id);
 }
 
 bool Lua_Client::IsTaskActive(int task) {
@@ -3379,12 +3379,12 @@ uint8 Lua_Client::GetSkillTrainLevel(int skill_id)
 	return self->GetSkillTrainLevel(static_cast<EQ::skills::SkillType>(skill_id), self->GetClass());
 }
 
-int Lua_Client::AreTasksCompleted(luabind::object task_ids)
+bool Lua_Client::AreTasksCompleted(luabind::object task_ids)
 {
 	Lua_Safe_Call_Int();
 
 	if (luabind::type(task_ids) != LUA_TTABLE) {
-		return 0;
+		return false;
 	}
 
 	std::vector<int> v;
@@ -3406,7 +3406,7 @@ int Lua_Client::AreTasksCompleted(luabind::object task_ids)
 	}
 
 	if (v.empty()) {
-		return 0;
+		return false;
 	}
 
 	return self->AreTasksCompleted(v);
@@ -3458,7 +3458,7 @@ luabind::scope lua_register_client() {
 	.def("ApplySpellRaid", (void(Lua_Client::*)(int,int,int,bool))&Lua_Client::ApplySpellRaid)
 	.def("ApplySpellRaid", (void(Lua_Client::*)(int,int,int,bool,bool))&Lua_Client::ApplySpellRaid)
 	.def("ApplySpellRaid", (void(Lua_Client::*)(int,int,int,bool,bool,bool))&Lua_Client::ApplySpellRaid)
-	.def("AreTasksCompleted", (int(Lua_Client::*)(luabind::object))&Lua_Client::AreTasksCompleted)
+	.def("AreTasksCompleted", (bool(Lua_Client::*)(luabind::object))&Lua_Client::AreTasksCompleted)
 	.def("AssignTask", (void(Lua_Client::*)(int))&Lua_Client::AssignTask)
 	.def("AssignTask", (void(Lua_Client::*)(int,int))&Lua_Client::AssignTask)
 	.def("AssignTask", (void(Lua_Client::*)(int,int,bool))&Lua_Client::AssignTask)

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3379,6 +3379,39 @@ uint8 Lua_Client::GetSkillTrainLevel(int skill_id)
 	return self->GetSkillTrainLevel(static_cast<EQ::skills::SkillType>(skill_id), self->GetClass());
 }
 
+int Lua_Client::AreTasksCompleted(luabind::object task_ids)
+{
+	Lua_Safe_Call_Int();
+
+	if (luabind::type(task_ids) != LUA_TTABLE) {
+		return 0;
+	}
+
+	std::vector<int> v;
+	int index = 1;
+	while (luabind::type(task_ids[index]) != LUA_TNIL) {
+		auto current_id = task_ids[index];
+		int task_id = 0;
+		if (luabind::type(current_id) != LUA_TNIL) {
+			try {
+				task_id = luabind::object_cast<int>(current_id);
+			} catch(luabind::cast_failed &) {
+			}
+		} else {
+			break;
+		}
+
+		v.push_back(task_id);
+		++index;
+	}
+
+	if (v.empty()) {
+		return 0;
+	}
+
+	return self->AreTasksCompleted(v);
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 	.def(luabind::constructor<>())
@@ -3425,6 +3458,7 @@ luabind::scope lua_register_client() {
 	.def("ApplySpellRaid", (void(Lua_Client::*)(int,int,int,bool))&Lua_Client::ApplySpellRaid)
 	.def("ApplySpellRaid", (void(Lua_Client::*)(int,int,int,bool,bool))&Lua_Client::ApplySpellRaid)
 	.def("ApplySpellRaid", (void(Lua_Client::*)(int,int,int,bool,bool,bool))&Lua_Client::ApplySpellRaid)
+	.def("AreTasksCompleted", (int(Lua_Client::*)(luabind::object))&Lua_Client::AreTasksCompleted)
 	.def("AssignTask", (void(Lua_Client::*)(int))&Lua_Client::AssignTask)
 	.def("AssignTask", (void(Lua_Client::*)(int,int))&Lua_Client::AssignTask)
 	.def("AssignTask", (void(Lua_Client::*)(int,int,bool))&Lua_Client::AssignTask)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -360,7 +360,7 @@ public:
 	void AssignTask(int task_id, int npc_id);
 	void AssignTask(int task_id, int npc_id, bool enforce_level_requirement);
 	void FailTask(int task);
-	bool IsTaskCompleted(int task);
+	bool IsTaskCompleted(int task_id);
 	bool IsTaskActive(int task);
 	bool IsTaskActivityActive(int task, int activity);
 	void LockSharedTask(bool lock);
@@ -577,7 +577,7 @@ public:
 	void CampAllBots(uint8 class_id);
 	bool RemoveAAPoints(uint32 points);
 	bool RemoveAlternateCurrencyValue(uint32 currency_id, uint32 amount);
-	int AreTasksCompleted(luabind::object task_ids);
+	bool AreTasksCompleted(luabind::object task_ids);
 
 	void DialogueWindow(std::string markdown);
 

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -577,6 +577,7 @@ public:
 	void CampAllBots(uint8 class_id);
 	bool RemoveAAPoints(uint32 points);
 	bool RemoveAlternateCurrencyValue(uint32 currency_id, uint32 amount);
+	int AreTasksCompleted(luabind::object task_ids);
 
 	void DialogueWindow(std::string markdown);
 

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -5604,6 +5604,37 @@ uint32 lua_get_zone_uptime()
 	return Timer::GetCurrentTime() / 1000;
 }
 
+int lua_are_tasks_completed(luabind::object task_ids)
+{
+	if (luabind::type(task_ids) != LUA_TTABLE) {
+		return 0;
+	}
+
+	std::vector<int> v;
+	int index = 1;
+	while (luabind::type(task_ids[index]) != LUA_TNIL) {
+		auto current_id = task_ids[index];
+		int task_id = 0;
+		if (luabind::type(current_id) != LUA_TNIL) {
+			try {
+				task_id = luabind::object_cast<int>(current_id);
+			} catch(luabind::cast_failed &) {
+			}
+		} else {
+			break;
+		}
+
+		v.push_back(task_id);
+		++index;
+	}
+
+	if (v.empty()) {
+		return 0;
+	}
+
+	return quest_manager.aretaskscompleted(v);
+}
+
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
 	cur = table[#name]; \
 	if(luabind::type(cur) != LUA_TNIL) { \
@@ -6410,6 +6441,7 @@ luabind::scope lua_register_general() {
 		luabind::def("get_zone_short_name_by_long_name", &lua_get_zone_short_name_by_long_name),
 		luabind::def("send_parcel", &lua_send_parcel),
 		luabind::def("get_zone_uptime", &lua_get_zone_uptime),
+		luabind::def("are_tasks_completed", &lua_are_tasks_completed),
 		/*
 			Cross Zone
 		*/

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -3176,7 +3176,7 @@ uint8 Perl_Client_GetSkillTrainLevel(Client* self, int skill_id)
 	return self->GetSkillTrainLevel(static_cast<EQ::skills::SkillType>(skill_id), self->GetClass());
 }
 
-int Perl_Client_AreTasksCompleted(Client* self, perl::array task_ids)
+bool Perl_Client_AreTasksCompleted(Client* self, perl::array task_ids)
 {
 	std::vector<int> v;
 
@@ -3236,7 +3236,7 @@ void perl_register_client()
 	package.add("ApplySpellRaid", (void(*)(Client*, int, int, int, bool))&Perl_Client_ApplySpellRaid);
 	package.add("ApplySpellRaid", (void(*)(Client*, int, int, int, bool, bool))&Perl_Client_ApplySpellRaid);
 	package.add("ApplySpellRaid", (void(*)(Client*, int, int, int, bool, bool, bool))&Perl_Client_ApplySpellRaid);
-	package.add("AreTasksCompleted", (int(*)(Client*, perl::array))&Perl_Client_AreTasksCompleted);
+	package.add("AreTasksCompleted", (bool(*)(Client*, perl::array))&Perl_Client_AreTasksCompleted);
 	package.add("AssignTask", (void(*)(Client*, int))&Perl_Client_AssignTask);
 	package.add("AssignTask", (void(*)(Client*, int, int))&Perl_Client_AssignTask);
 	package.add("AssignTask", (void(*)(Client*, int, int, bool))&Perl_Client_AssignTask);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -3176,6 +3176,17 @@ uint8 Perl_Client_GetSkillTrainLevel(Client* self, int skill_id)
 	return self->GetSkillTrainLevel(static_cast<EQ::skills::SkillType>(skill_id), self->GetClass());
 }
 
+int Perl_Client_AreTasksCompleted(Client* self, perl::array task_ids)
+{
+	std::vector<int> v;
+
+	for (const auto& e : task_ids) {
+		v.push_back(static_cast<int>(e));
+	}
+
+	return self->AreTasksCompleted(v);
+}
+
 void perl_register_client()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3225,6 +3236,7 @@ void perl_register_client()
 	package.add("ApplySpellRaid", (void(*)(Client*, int, int, int, bool))&Perl_Client_ApplySpellRaid);
 	package.add("ApplySpellRaid", (void(*)(Client*, int, int, int, bool, bool))&Perl_Client_ApplySpellRaid);
 	package.add("ApplySpellRaid", (void(*)(Client*, int, int, int, bool, bool, bool))&Perl_Client_ApplySpellRaid);
+	package.add("AreTasksCompleted", (int(*)(Client*, perl::array))&Perl_Client_AreTasksCompleted);
 	package.add("AssignTask", (void(*)(Client*, int))&Perl_Client_AssignTask);
 	package.add("AssignTask", (void(*)(Client*, int, int))&Perl_Client_AssignTask);
 	package.add("AssignTask", (void(*)(Client*, int, int, bool))&Perl_Client_AssignTask);

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -3251,23 +3251,26 @@ int QuestManager::activespeakactivity(int taskid) {
 	return 0;
 }
 
-int QuestManager::istaskcompleted(int taskid) {
+bool QuestManager::istaskcompleted(int task_id)
+{
 	QuestManagerCurrentQuestVars();
 
-	if(RuleB(TaskSystem, EnableTaskSystem) && initiator)
-		return initiator->IsTaskCompleted(taskid);
+	if (initiator && RuleB(TaskSystem, EnableTaskSystem)) {
+		return initiator->IsTaskCompleted(task_id);
+	}
 
-	return -1;
+	return false;
 }
 
-int QuestManager::aretaskscompleted(const std::vector<int>& task_ids) {
+bool QuestManager::aretaskscompleted(const std::vector<int>& task_ids)
+{
 	QuestManagerCurrentQuestVars();
 
-	if (RuleB(TaskSystem, EnableTaskSystem) && initiator) {
+	if (initiator && RuleB(TaskSystem, EnableTaskSystem)) {
 		return initiator->AreTasksCompleted(task_ids);
 	}
 
-	return -1;
+	return false;
 }
 
 int QuestManager::activetasksinset(int taskset) {

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -3260,6 +3260,16 @@ int QuestManager::istaskcompleted(int taskid) {
 	return -1;
 }
 
+int QuestManager::aretaskscompleted(const std::vector<int>& task_ids) {
+	QuestManagerCurrentQuestVars();
+
+	if (RuleB(TaskSystem, EnableTaskSystem) && initiator) {
+		return initiator->AreTasksCompleted(task_ids);
+	}
+
+	return -1;
+}
+
 int QuestManager::activetasksinset(int taskset) {
 	QuestManagerCurrentQuestVars();
 

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -226,6 +226,7 @@ public:
 	void failtask(int taskid);
 	int tasktimeleft(int taskid);
 	int istaskcompleted(int taskid);
+	int aretaskscompleted(const std::vector<int>& task_ids);
 	int enabledtaskcount(int taskset);
 	int firsttaskinset(int taskset);
 	int lasttaskinset(int taskset);

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -225,8 +225,8 @@ public:
 	void assigntask(int taskid, bool enforce_level_requirement = false);
 	void failtask(int taskid);
 	int tasktimeleft(int taskid);
-	int istaskcompleted(int taskid);
-	int aretaskscompleted(const std::vector<int>& task_ids);
+	bool istaskcompleted(int task_id);
+	bool aretaskscompleted(const std::vector<int>& task_ids);
 	int enabledtaskcount(int taskset);
 	int firsttaskinset(int taskset);
 	int lasttaskinset(int taskset);

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -1599,6 +1599,23 @@ int ClientTaskState::IsTaskCompleted(int task_id)
 	return 0;
 }
 
+int ClientTaskState::AreTasksCompleted(const std::vector<int>& task_ids)
+{
+	if (!(RuleB(TaskSystem, RecordCompletedTasks))) {
+		return -1;
+	}
+
+	int tasks_completed = 1;
+
+	for (const auto& task_id : task_ids) {
+		if (!IsTaskCompleted(task_id)) {
+			tasks_completed = 0;
+		}
+	}
+
+	return tasks_completed;
+}
+
 bool ClientTaskState::TaskOutOfTime(TaskType task_type, int index)
 {
 	// Returns true if the Task in the specified slot has a time limit that has been exceeded.

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -1578,42 +1578,35 @@ int ClientTaskState::TaskTimeLeft(int task_id)
 	return -1;
 }
 
-int ClientTaskState::IsTaskCompleted(int task_id)
+bool ClientTaskState::IsTaskCompleted(int task_id)
 {
-
-	// Returns:	-1 if RecordCompletedTasks is not true
-	//		+1 if the task has been completed
-	//		0 if the task has not been completed
-
-	if (!(RuleB(TaskSystem, RecordCompletedTasks))) {
-		return -1;
+	if (!RuleB(TaskSystem, RecordCompletedTasks)) {
+		return false;
 	}
 
-	for (auto &completed_task : m_completed_tasks) {
-		LogTasks("Comparing completed task [{}] with [{}]", completed_task.task_id, task_id);
-		if (completed_task.task_id == task_id) {
-			return 1;
+	for (const auto& e : m_completed_tasks) {
+		LogTasks("Comparing completed task [{}] with [{}]", e.task_id, task_id);
+		if (e.task_id == task_id) {
+			return true;
 		}
 	}
 
-	return 0;
+	return false;
 }
 
-int ClientTaskState::AreTasksCompleted(const std::vector<int>& task_ids)
+bool ClientTaskState::AreTasksCompleted(const std::vector<int>& task_ids)
 {
-	if (!(RuleB(TaskSystem, RecordCompletedTasks))) {
-		return -1;
+	if (!RuleB(TaskSystem, RecordCompletedTasks)) {
+		return false;
 	}
 
-	int tasks_completed = 1;
-
-	for (const auto& task_id : task_ids) {
-		if (!IsTaskCompleted(task_id)) {
-			tasks_completed = 0;
+	for (const auto& e : task_ids) {
+		if (!IsTaskCompleted(e)) {
+			return false;
 		}
 	}
 
-	return tasks_completed;
+	return true;
 }
 
 bool ClientTaskState::TaskOutOfTime(TaskType task_type, int index)

--- a/zone/task_client_state.h
+++ b/zone/task_client_state.h
@@ -45,8 +45,8 @@ public:
 	void AcceptNewTask(Client *client, int task_id, int npc_type_id, time_t accept_time, bool enforce_level_requirement = false);
 	void FailTask(Client *client, int task_id);
 	int TaskTimeLeft(int task_id);
-	int IsTaskCompleted(int task_id);
-	int AreTasksCompleted(const std::vector<int>& task_ids);
+	bool IsTaskCompleted(int task_id);
+	bool AreTasksCompleted(const std::vector<int>& task_ids);
 	bool IsTaskActive(int task_id);
 	bool IsTaskActivityActive(int task_id, int activity_id);
 	ActivityState GetTaskActivityState(TaskType task_type, int index, int activity_id);

--- a/zone/task_client_state.h
+++ b/zone/task_client_state.h
@@ -46,6 +46,7 @@ public:
 	void FailTask(Client *client, int task_id);
 	int TaskTimeLeft(int task_id);
 	int IsTaskCompleted(int task_id);
+	int AreTasksCompleted(const std::vector<int>& task_ids);
 	bool IsTaskActive(int task_id);
 	bool IsTaskActivityActive(int task_id, int activity_id);
 	ActivityState GetTaskActivityState(TaskType task_type, int index, int activity_id);


### PR DESCRIPTION
# Description
- Adds a method to allow operators to check if multiple tasks are complete without stringing together multiple `IsTaskCompleted` calls.

# Perl
- Add `$client->AreTasksCompleted(task_ids)`.
- Add `quest::aretaskscompleted(task_ids)`.

## Perl Example
```pl
sub EVENT_SAY {
	if ($text=~/#a/i) {
		my @task_ids = (5166, 5745);
		my $are_completed = quest::aretaskscompleted(@task_ids);
		quest::message(315, "Perl: $are_completed");
	}
}
```

## Perl Screenshot
![image](https://github.com/user-attachments/assets/945324a4-443f-4de9-8fb5-9ad149a62618)

# Lua
- Add `client:AreTasksCompleted(task_ids)`.
- Add `eq.are_tasks_completed(task_ids)`.

## Lua Example
```lua
function event_say(e)
	if e.message:findi("#a") then
		local task_ids = { 5166, 5745 }
		local are_completed = eq.are_tasks_completed(task_ids);
		eq.message(315, "Lua: " .. tostring(are_completed))
	end
end
```

## Lua Screenshot
![image](https://github.com/user-attachments/assets/6e712000-7421-4ac8-a695-5af64af709b9)
