### PR TITLE
[Bug Fix] Fix issue with killed mob coordinates

### DIFF
--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -2064,9 +2064,14 @@ void PerlembParser::ExportEventVariables(
 				Corpse* corpse = std::any_cast<Corpse*>(extra_pointers->at(0));
 				if (corpse) {
 					ExportVar(package_name.c_str(), "killed_corpse_id", corpse->GetID());
+					ExportVar(package_name.c_str(), "killed_x", corpse->GetX());
+					ExportVar(package_name.c_str(), "killed_y", corpse->GetY());
+					ExportVar(package_name.c_str(), "killed_z", corpse->GetZ());
+					ExportVar(package_name.c_str(), "killed_h", corpse->GetHeading());
 				}
 			}
 
+			// EVENT_DEATH_ZONE only
 			if (extra_pointers && extra_pointers->size() >= 2) {
 				NPC* killed = std::any_cast<NPC*>(extra_pointers->at(1));
 				if (killed) {
@@ -2076,10 +2081,6 @@ void PerlembParser::ExportEventVariables(
 						killed->IsBot() ? killed->CastToBot()->GetBotID() : 0
 					);
 					ExportVar(package_name.c_str(), "killed_npc_id", killed->IsNPC() ? killed->GetNPCTypeID() : 0);
-					ExportVar(package_name.c_str(), "killed_x", killed->GetX());
-					ExportVar(package_name.c_str(), "killed_y", killed->GetY());
-					ExportVar(package_name.c_str(), "killed_z", killed->GetZ());
-					ExportVar(package_name.c_str(), "killed_h", killed->GetHeading());
 				}
 			}
 			break;


### PR DESCRIPTION
# Description
- Fixes a bug where `$killed_x`, `$killed_y`, `$killed_z`, and `$killed_h` were undefined because they were `EVENT_DEATH_ZONE` only.
- Fixed by moving to where corpse is used for `$killed_corpse_id`.

# Testing
## Script
```pl
sub EVENT_DEATH_COMPLETE {
	quest::debug("killer_id " . $killer_id);
	quest::debug("killer_damage " . $killer_damage);
	quest::debug("killer_spell " . $killer_spell);
	quest::debug("killer_skill " . $killer_skill);
	quest::debug("killed_entity_id " . $killed_entity_id);
	quest::debug("combat_start_time " . $combat_start_time);
	quest::debug("combat_end_time " . $combat_end_time);
	quest::debug("damage_received " . $damage_received);
	quest::debug("healing_received " . $healing_received);
	quest::debug("killed_corpse_id " . $killed_corpse_id);
	quest::debug("killed_x " . $killed_x);
	quest::debug("killed_y " . $killed_y);
	quest::debug("killed_z " . $killed_z);
	quest::debug("killed_h " . $killed_h);
}
```

## Screenshot
![image](https://github.com/user-attachments/assets/3a0723fb-e745-44f7-b564-1d18edfa37de)
