### PR TITLE
[Feature] Add Rule to Limit Task Update Messages

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -715,7 +715,7 @@ RULE_BOOL(TaskSystem, ExpRewardsIgnoreLevelBasedEXPMods, false, "Rewarding Level
 RULE_INT(TaskSystem, SharedTasksWorldProcessRate, 6000, "Timer interval (milliseconds) that shared tasks are processed in world")
 RULE_INT(TaskSystem, SharedTasksTerminateTimerMS, 120000, "Delay (milliseconds) until a shared task is terminated if requirements are no longer met after member removal (default: 2 minutes)")
 RULE_BOOL(TaskSystem, UpdateOneElementPerTask, true, "If true (live-like) task updates only increment the first matching activity. If false all matching elements will be incremented.")
-RULE_BOOL(TaskSystem, OneMessagePerUpdate, false, "If true, sends only one update message regardless of update count (keeps #task update from spamming 100s/1,000s of messages for large activity counts)")
+RULE_INT(TaskSystem, MaxUpdateMessages, 50, "Maximum update messages for non-GiveCash activity types in IncrementDoneCount")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Range)

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -715,6 +715,7 @@ RULE_BOOL(TaskSystem, ExpRewardsIgnoreLevelBasedEXPMods, false, "Rewarding Level
 RULE_INT(TaskSystem, SharedTasksWorldProcessRate, 6000, "Timer interval (milliseconds) that shared tasks are processed in world")
 RULE_INT(TaskSystem, SharedTasksTerminateTimerMS, 120000, "Delay (milliseconds) until a shared task is terminated if requirements are no longer met after member removal (default: 2 minutes)")
 RULE_BOOL(TaskSystem, UpdateOneElementPerTask, true, "If true (live-like) task updates only increment the first matching activity. If false all matching elements will be incremented.")
+RULE_BOOL(TaskSystem, OneMessagePerUpdate, false, "If true, sends only one update message regardless of update count (keeps #task update from spamming 100s/1,000s of messages for large activity counts)")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Range)

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -869,14 +869,12 @@ int ClientTaskState::IncrementDoneCount(
 	if (task_data->type != TaskType::Shared) {
 		// live messages for each increment of non-shared tasks
 		auto activity_type = task_data->activity_information[activity_id].activity_type;
-		int msg_count = (
-			(
-				RuleB(TaskSystem, OneMessagePerUpdate) ||
-				activity_type == TaskActivityType::GiveCash
-			) ?
-			1 :
-			count
-		);
+		int msg_count = 1;
+
+		if (activity_type != TaskActivityType::GiveCash) {
+			msg_count = std::min(count, RuleI(TaskSystem, MaxUpdateMessages));
+		}
+
 		for (int i = 0; i < msg_count; ++i) {
 			client->MessageString(Chat::DefaultText, TASK_UPDATED, task_data->title.c_str());
 		}

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -872,7 +872,7 @@ int ClientTaskState::IncrementDoneCount(
 		int msg_count = (
 			(
 				RuleB(TaskSystem, OneMessagePerUpdate) ||
-				activity_type == TaskActivityType::GiveCash\
+				activity_type == TaskActivityType::GiveCash
 			) ?
 			1 :
 			count

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -869,7 +869,14 @@ int ClientTaskState::IncrementDoneCount(
 	if (task_data->type != TaskType::Shared) {
 		// live messages for each increment of non-shared tasks
 		auto activity_type = task_data->activity_information[activity_id].activity_type;
-		int msg_count = activity_type == TaskActivityType::GiveCash ? 1 : count;
+		int msg_count = (
+			(
+				RuleB(Tasks, OneMessagePerUpdate) ||
+				activity_type == TaskActivityType::GiveCash\
+			) ?
+			1 :
+			count
+		);
 		for (int i = 0; i < msg_count; ++i) {
 			client->MessageString(Chat::DefaultText, TASK_UPDATED, task_data->title.c_str());
 		}

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -871,7 +871,7 @@ int ClientTaskState::IncrementDoneCount(
 		auto activity_type = task_data->activity_information[activity_id].activity_type;
 		int msg_count = (
 			(
-				RuleB(Tasks, OneMessagePerUpdate) ||
+				RuleB(TaskSystem, OneMessagePerUpdate) ||
 				activity_type == TaskActivityType::GiveCash\
 			) ?
 			1 :


### PR DESCRIPTION
# Description
- Adds a rule `TaskSystem:MaxUpdateMessages` that allows operators to limit sending a message for every `1` count.
- Issue was that if you have a task that requires 500/1,000/10,000/50,000 or whatever large number if you use `#task update task_id activity_id count` and the `count` is a large number it will send 500/1,000/10,000/50,000 messages, possibly causing your character to disconnect to character select.

## Type of change
- [X] New feature

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur