### PR TITLE
[Bug Fix] Correct missed maxlevel reference in exp.cpp

### DIFF
--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -837,7 +837,7 @@ void Client::SetEXP(ExpSource exp_source, uint64 set_exp, uint64 set_aaxp, bool 
 
 	//If were at max level then stop gaining experience if we make it to the cap
 	if (GetLevel() == max_level - 1){
-		uint32 expneeded = GetEXPForLevel(maxlevel);
+		uint32 expneeded = GetEXPForLevel(max_level);
 		if (set_exp > expneeded) {
 			set_exp = expneeded;
 		}


### PR DESCRIPTION
# Description

This was causing characters to de-level when gaining experience and was missed as part of https://github.com/EQEmu/Server/pull/4455

Fixes # (issue)

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Testing

Testing was done on the Vegarlson Asylum server without issues.

Clients tested: 
RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I have made corresponding changes to the documentation (if applicable, if not delete this line)
- [x] I own the changes of my code and take responsibility for the potential issues that occur
- [x] If my changes make database schema changes, I have tested the changes on a local database (attach image). Updated version.h CURRENT_BINARY_DATABASE_VERSION to the new version. (Delete this if not applicable)
