### PR TITLE
[Performance] Move Discipline Loading to Client::CompleteConnect()

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1346,6 +1346,10 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 		m_pp.ldon_losses_tak = as.failure.tak;
 	}
 
+	for (int slot_id = 0; slot_id < MAX_PP_DISCIPLINES; slot_id++) {
+		m_pp.disciplines.values[slot_id] = 0;
+	}
+
 	/* Set item material tint */
 	for (int i = EQ::textures::textureBegin; i <= EQ::textures::LastTexture; i++)
 	{

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -934,6 +934,7 @@ void Client::CompleteConnect()
 	}
 
 	database.LoadAuras(this); // this ends up spawning them so probably safer to load this later (here)
+	database.LoadCharacterDisciplines(CharacterID(), &m_pp);
 
 	entity_list.RefreshClientXTargets(this);
 
@@ -1318,7 +1319,6 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 	database.LoadCharacterInspectMessage(cid, &m_inspect_message); /* Load Character Inspect Message */
 	database.LoadCharacterSpellBook(cid, &m_pp); /* Load Character Spell Book */
 	database.LoadCharacterMemmedSpells(cid, &m_pp);  /* Load Character Memorized Spells */
-	database.LoadCharacterDisciplines(cid, &m_pp); /* Load Character Disciplines */
 	database.LoadCharacterLanguages(cid, &m_pp); /* Load Character Languages */
 	database.LoadCharacterLeadershipAbilities(cid, &m_pp); /* Load Character Leadership AA's */
 	database.LoadCharacterTribute(this); /* Load CharacterTribute */

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -934,7 +934,7 @@ void Client::CompleteConnect()
 	}
 
 	database.LoadAuras(this); // this ends up spawning them so probably safer to load this later (here)
-	database.LoadCharacterDisciplines(CharacterID(), &m_pp);
+	database.LoadCharacterDisciplines(this);
 
 	entity_list.RefreshClientXTargets(this);
 
@@ -1344,10 +1344,6 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 		m_pp.ldon_losses_mmc = as.failure.mmc;
 		m_pp.ldon_losses_ruj = as.failure.ruj;
 		m_pp.ldon_losses_tak = as.failure.tak;
-	}
-
-	for (int slot_id = 0; slot_id < MAX_PP_DISCIPLINES; slot_id++) {
-		m_pp.disciplines.values[slot_id] = 0;
 	}
 
 	/* Set item material tint */

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -671,8 +671,8 @@ bool ZoneDatabase::LoadCharacterLeadershipAbilities(uint32 character_id, PlayerP
 	return true;
 }
 
-bool ZoneDatabase::LoadCharacterDisciplines(uint32 character_id, PlayerProfile_Struct* pp){
-
+bool ZoneDatabase::LoadCharacterDisciplines(uint32 character_id, PlayerProfile_Struct* pp)
+{
 	const auto& l = CharacterDisciplinesRepository::GetWhere(
 		database, fmt::format(
 			"`id` = {} ORDER BY `slot_id`",
@@ -684,7 +684,7 @@ bool ZoneDatabase::LoadCharacterDisciplines(uint32 character_id, PlayerProfile_S
 		return false;
 	}
 
-	for (int slot_id = 0; slot_id < MAX_PP_DISCIPLINES; slot_id++) { // Initialize Disciplines
+	for (int slot_id = 0; slot_id < MAX_PP_DISCIPLINES; slot_id++) {
 		pp->disciplines.values[slot_id] = 0;
 	}
 

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -671,12 +671,16 @@ bool ZoneDatabase::LoadCharacterLeadershipAbilities(uint32 character_id, PlayerP
 	return true;
 }
 
-bool ZoneDatabase::LoadCharacterDisciplines(uint32 character_id, PlayerProfile_Struct* pp)
+bool ZoneDatabase::LoadCharacterDisciplines(Client* c)
 {
+	if (!c) {
+		return false;
+	}
+
 	const auto& l = CharacterDisciplinesRepository::GetWhere(
 		database, fmt::format(
 			"`id` = {} ORDER BY `slot_id`",
-			character_id
+			c->CharacterID()
 		)
 	);
 
@@ -684,11 +688,17 @@ bool ZoneDatabase::LoadCharacterDisciplines(uint32 character_id, PlayerProfile_S
 		return false;
 	}
 
+	for (int slot_id = 0; slot_id < MAX_PP_DISCIPLINES; slot_id++) {
+		c->GetPP().disciplines.values[slot_id] = 0;
+	}
+
 	for (const auto& e : l) {
 		if (IsValidSpell(e.disc_id) && e.slot_id < MAX_PP_DISCIPLINES) {
-			pp->disciplines.values[e.slot_id] = e.disc_id;
+			c->GetPP().disciplines.values[e.slot_id] = e.disc_id;
 		}
 	}
+
+	c->SendDisciplineUpdate();
 
 	return true;
 }

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -684,10 +684,6 @@ bool ZoneDatabase::LoadCharacterDisciplines(uint32 character_id, PlayerProfile_S
 		return false;
 	}
 
-	for (int slot_id = 0; slot_id < MAX_PP_DISCIPLINES; slot_id++) {
-		pp->disciplines.values[slot_id] = 0;
-	}
-
 	for (const auto& e : l) {
 		if (IsValidSpell(e.disc_id) && e.slot_id < MAX_PP_DISCIPLINES) {
 			pp->disciplines.values[e.slot_id] = e.disc_id;

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -436,7 +436,7 @@ public:
 	bool LoadCharacterBindPoint(uint32 character_id, PlayerProfile_Struct* pp);
 	bool LoadCharacterCurrency(uint32 character_id, PlayerProfile_Struct* pp);
 	bool LoadCharacterData(uint32 character_id, PlayerProfile_Struct* pp, ExtendedProfile_Struct* m_epp);
-	bool LoadCharacterDisciplines(uint32 character_id, PlayerProfile_Struct* pp);
+	bool LoadCharacterDisciplines(Client* c);
 	bool LoadCharacterFactionValues(uint32 character_id, faction_map & val_list);
 	bool LoadCharacterLanguages(uint32 character_id, PlayerProfile_Struct* pp);
 	bool LoadCharacterLeadershipAbilities(uint32 character_id, PlayerProfile_Struct* pp);


### PR DESCRIPTION
# Description
- This moves discipline loading to `Client::CompleteConnect()` to remove some of the data loaded in `Handle_OP_ZoneEntry`.
- The idea here is reducing the amount of data loading mid-zoning will reduce the amount of crashes we will see on zoning.

## Type of change
- [X] New feature

# Testing
[Screencast from 09-09-2024 07:17:40 PM.webm](https://github.com/user-attachments/assets/7d098bc0-a5fd-4431-941e-8ce0712f7c94)

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur