### PR TITLE
[Bug Fix] Add RULE_STRING to RuleManager::ResetRules

### DIFF
--- a/common/rulesys.cpp
+++ b/common/rulesys.cpp
@@ -190,7 +190,7 @@ void RuleManager::ResetRules(bool reload) {
 	#define RULE_BOOL(category_name, rule_name, default_value, notes) \
 		m_RuleBoolValues[ Bool__##rule_name ] = default_value;
 	#define RULE_STRING(category_name, rule_name, default_value, notes) \
-		m_RuleStringValues[ Bool__##rule_name ] = default_value;
+		m_RuleStringValues[ String__##rule_name ] = default_value;
 	#include "ruletypes.h"
 
 	// restore these rules to their pre-reset values

--- a/common/rulesys.cpp
+++ b/common/rulesys.cpp
@@ -189,6 +189,8 @@ void RuleManager::ResetRules(bool reload) {
 		m_RuleRealValues[ Real__##rule_name ] = default_value;
 	#define RULE_BOOL(category_name, rule_name, default_value, notes) \
 		m_RuleBoolValues[ Bool__##rule_name ] = default_value;
+	#define RULE_STRING(category_name, rule_name, default_value, notes) \
+		m_RuleStringValues[ Bool__##rule_name ] = default_value;
 	#include "ruletypes.h"
 
 	// restore these rules to their pre-reset values


### PR DESCRIPTION
# Description
- Add missing `RULE_STRING` definition to `RuleManager::ResetRules`.

## Type of change
- [X] Bug fix