### PR TITLE
[Bug Fix] ModernAAScalingEnabled() Calculation Error

### DIFF
--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -527,7 +527,7 @@ void Client::AddEXP(ExpSource exp_source, uint64 in_add_exp, uint8 conlevel, boo
 	// Are we also doing linear AA acceleration?
 	if (RuleB(AA, ModernAAScalingEnabled) && aaexp > 0)
 	{
-		aaexp = ScaleAAXPBasedOnCurrentAATotal(GetAAPoints(), aaexp);
+		aaexp = ScaleAAXPBasedOnCurrentAATotal(GetSpentAA() + GetAAPoints(), aaexp);
 	}
 
 	// Check for AA XP Cap


### PR DESCRIPTION
Description
This PR fixes an issue where the AA experience scaling only considered unspent AAs, leading to incorrect scaling. The old implementation based the scaling on unspent AAs, meaning if a player had 2000 spent AAs and 1 unspent AA, the scaling would incorrectly be based only on the 1 unspent AA instead of the total of 2001 AAs.

Here’s a log output of the issue before the fix, from the custom code inside the ModernAAScalingEnabled function:

```
[Wed Sep 11 14:10:19 2024] [AA] [ScaleAAXPBasedOnCurrentAATotal] AA Experience Calculation: add_aaxp = 660796, Base Bonus = 256.000000, Half-Life = 64.000000, Minimum Bonus = 1.000000, Earned AA = 1, Calculated Bonus = 253.242371
```
The custom logic looks like this:

```
uint64 totalWithExpMod = add_aaxp;
if (RuleB(AA, EnableLogrithmicClasslessAABonus)) {
    float base_bonus = RuleR(AA, InitialLogrithmicClasslessAABonus);
    float half_life = RuleR(AA, HalfLifeLogrithmicClasslessAABonus);
    float min_bon = RuleR(AA, MinimumLogrithmicClasslessAABonus);
    float bonus_expon = earnedAA / half_life;

    float bonus = base_bonus * std::pow(0.5, bonus_expon);
    Log(Logs::General, Logs::AA, 
        "AA Experience Calculation: add_aaxp = %d, Base Bonus = %f, Half-Life = %f, Minimum Bonus = %f, Earned AA = %d, Calculated Bonus = %f", 
        add_aaxp, base_bonus, half_life, min_bon, earnedAA, bonus);
    
    if (bonus < min_bon) bonus = min_bon;

    totalWithExpMod = (uint64)(totalWithExpMod * bonus);
}
```
After the fix, the experience calculation properly considers the total number of AAs (spent + unspent). The updated log is as follows:

```
[Wed Sep 11 14:30:11 2024] [AA] [ScaleAAXPBasedOnCurrentAATotal] AA Experience Calculation: add_aaxp = 660796, Base Bonus = 256.000000, Half-Life = 64.000000, Minimum Bonus = 1.000000, Earned AA = 6245, Calculated Bonus =1.000000
```
This log reflects the intended behavior, where AA scaling is based on the total number of AAs.

Motivation
The bugfix ensures the correct scaling of AA experience by taking into account both spent and unspent AAs. Without this change, the AA experience calculation would disproportionately favor players with very few unspent AAs.

Type of change
 Bug fix (non-breaking change that resolves an incorrect behavior)
Related Issues
Fixes # (issue link, if available)

Testing
Please include any test information and evidence, including logs or screenshots that validate the correct behavior after this fix.

Clients tested:
 Describe client environments or versions tested.
Logs:
Please attach or describe any relevant logs that verify the correct functionality of the fix.

Checklist
 I have tested my changes.
 I have performed a self-review of my code, ensuring variable and function names are clear and comments are used appropriately.
 I have updated relevant documentation (if applicable).
 I accept full responsibility for the impact of my changes.
 If applicable, I have tested the database changes locally and updated version.h to reflect the new CURRENT_BINARY_DATABASE_VERSION.