### PR TITLE
[Bug Fix] Fix Untrained Disciplines in Client::SaveDisciplines()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [22.56.1] 9/13/2024
+
+### Fixes
+
+* Fix Untrained Disciplines in Client::SaveDisciplines() ([#4472](https://github.com/EQEmu/Server/pull/4472)) @Kinglykrab 2024-09-13
+* Fix Infinite Loop in Adventure::Finished() ([#4473](https://github.com/EQEmu/Server/pull/4473)) @oddx2k 2024-09-13
+
 ## [22.56.0] 9/12/2024
 
 ### Code

--- a/common/version.h
+++ b/common/version.h
@@ -25,7 +25,7 @@
 
 // Build variables
 // these get injected during the build pipeline
-#define CURRENT_VERSION "22.56.0-dev" // always append -dev to the current version for custom-builds
+#define CURRENT_VERSION "22.56.1-dev" // always append -dev to the current version for custom-builds
 #define LOGIN_VERSION "0.8.0"
 #define COMPILE_DATE    __DATE__
 #define COMPILE_TIME    __TIME__

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eqemu-server",
-  "version": "22.56.0",
+  "version": "22.56.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/EQEmu/Server.git"

--- a/world/adventure.cpp
+++ b/world/adventure.cpp
@@ -287,6 +287,7 @@ void Adventure::Finished(AdventureWinStatus ws)
 		auto character_id = database.GetCharacterID(*iter);
 
 		if (character_id == 0) {
+			++iter;
 			continue;
 		}
 

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -11097,7 +11097,9 @@ void Client::SaveDisciplines()
 {
 	std::vector<CharacterDisciplinesRepository::CharacterDisciplines> v;
 
-	for (int slot_id = 0; slot_id < MAX_PP_DISCIPLINES; slot_id++) {
+	std::vector<std::string> delete_slots;
+
+	for (uint16 slot_id = 0; slot_id < MAX_PP_DISCIPLINES; slot_id++) {
 		if (IsValidSpell(m_pp.disciplines.values[slot_id])) {
 			auto e = CharacterDisciplinesRepository::NewEntity();
 
@@ -11106,7 +11108,19 @@ void Client::SaveDisciplines()
 			e.disc_id = m_pp.disciplines.values[slot_id];
 
 			v.emplace_back(e);
+		} else {
+			delete_slots.emplace_back(std::to_string(slot_id));
 		}
+	}
+
+	if (!delete_slots.empty()) {
+		CharacterDisciplinesRepository::DeleteWhere(
+			database,
+			fmt::format(
+				"`slot_id` IN ({})",
+				Strings::Join(delete_slots, ", ")
+			)
+		);
 	}
 
 	if (!v.empty()) {


### PR DESCRIPTION
# Description
- Fixes an issue introduced in https://github.com/EQEmu/Server/pull/1640 where we are not actually deleting untrained disciplines and only replacing those that have been added/changed.
- Untraining player disciplines using the bulk methods was removing the disciplines visually, but leaving behind the database rows. This caused players' disciplines to reappear on zoning.

## Type of change
- [X] Bug fix

# Testing
## Before using #untraindiscs
![image](https://github.com/user-attachments/assets/632201d1-8d03-4fa8-9f7f-c6cb8f962f63)
![image](https://github.com/user-attachments/assets/de44262f-cd85-43e4-93c2-2e5f5b5e9adf)
## After using #untraindiscs
![image](https://github.com/user-attachments/assets/bf784171-e26a-4565-ac1f-3302a91d7e35)
![image](https://github.com/user-attachments/assets/a6380084-5d6e-4d66-b2b2-48c057b34fa4)

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur