### PR TITLE
[Quest API] Add GrantAllAAPoints() Overload To Perl/Lua

### DIFF
--- a/zone/aa.cpp
+++ b/zone/aa.cpp
@@ -2185,13 +2185,17 @@ void Client::AutoGrantAAPoints() {
 	SendAlternateAdvancementStats();
 }
 
-void Client::GrantAllAAPoints(uint8 unlock_level)
+void Client::GrantAllAAPoints(uint8 unlock_level, bool skip_grant_only)
 {
 	//iterate through every AA
 	for (auto& aa : zone->aa_abilities) {
 		AA::Ability* ability = aa.second.get();
 
 		if (ability->charges > 0) {
+			continue;
+		}
+
+		if (ability->grant_only && skip_grant_only) {
 			continue;
 		}
 

--- a/zone/client.h
+++ b/zone/client.h
@@ -1025,7 +1025,7 @@ public:
 	int GetSpentAA() { return m_pp.aapoints_spent; }
 	uint32 GetRequiredAAExperience();
 	void AutoGrantAAPoints();
-	void GrantAllAAPoints(uint8 unlock_level = 0);
+	void GrantAllAAPoints(uint8 unlock_level = 0, bool skip_grant_only = false);
 	bool HasAlreadyPurchasedRank(AA::Rank* rank);
 	void ListPurchasedAAs(Client *to, std::string search_criteria = std::string());
 

--- a/zone/gm_commands/grantaa.cpp
+++ b/zone/gm_commands/grantaa.cpp
@@ -7,15 +7,16 @@ void command_grantaa(Client *c, const Seperator *sep)
 		return;
 	}
 
-	const uint8 unlock_level = sep->IsNumber(1) ? static_cast<uint8>(Strings::ToUnsignedInt(sep->arg[1])) : 0;
+	const uint8 unlock_level    = sep->IsNumber(1) ? static_cast<uint8>(Strings::ToUnsignedInt(sep->arg[1])) : 0;
+	const bool  skip_grant_only = sep->IsNumber(2) ? Strings::ToBool(sep->arg[2]) : false;
 
 	auto t = c->GetTarget()->CastToClient();
-	t->GrantAllAAPoints(unlock_level);
+	t->GrantAllAAPoints(unlock_level, skip_grant_only);
 
 	c->Message(
 		Chat::White,
 		fmt::format(
-			"Successfully granted all Alternate Advancements for {}{}.",
+			"Successfully granted all Alternate Advancements for {}{}{}.",
 			c->GetTargetDescription(t),
 			(
 				unlock_level ?
@@ -24,7 +25,8 @@ void command_grantaa(Client *c, const Seperator *sep)
 					unlock_level
 				) :
 				""
-			)
+			),
+			skip_grant_only ? "except for grant only AAs" : ""
 		).c_str()
 	);
 }

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3216,6 +3216,12 @@ void Lua_Client::GrantAllAAPoints(uint8 unlock_level)
 	self->GrantAllAAPoints(unlock_level);
 }
 
+void Lua_Client::GrantAllAAPoints(uint8 unlock_level, bool skip_grant_only)
+{
+	Lua_Safe_Call_Void();
+	self->GrantAllAAPoints(unlock_level, skip_grant_only);
+}
+
 void Lua_Client::AddEbonCrystals(uint32 amount)
 {
 	Lua_Safe_Call_Void();
@@ -3699,6 +3705,7 @@ luabind::scope lua_register_client() {
 	.def("GoFish", (void(Lua_Client::*)(void))&Lua_Client::GoFish)
 	.def("GrantAllAAPoints", (void(Lua_Client::*)(void))&Lua_Client::GrantAllAAPoints)
 	.def("GrantAllAAPoints", (void(Lua_Client::*)(uint8))&Lua_Client::GrantAllAAPoints)
+	.def("GrantAllAAPoints", (void(Lua_Client::*)(uint8,bool))&Lua_Client::GrantAllAAPoints)
 	.def("GrantAlternateAdvancementAbility", (bool(Lua_Client::*)(int, int))&Lua_Client::GrantAlternateAdvancementAbility)
 	.def("GrantAlternateAdvancementAbility", (bool(Lua_Client::*)(int, int, bool))&Lua_Client::GrantAlternateAdvancementAbility)
 	.def("GuildID", (uint32(Lua_Client::*)(void))&Lua_Client::GuildID)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -487,6 +487,7 @@ public:
 	void SetBucket(std::string bucket_name, std::string bucket_value, std::string expiration);
 	void GrantAllAAPoints();
 	void GrantAllAAPoints(uint8 unlock_level);
+	void GrantAllAAPoints(uint8 unlock_level, bool skip_grant_only);
 	void AddEbonCrystals(uint32 amount);
 	void AddRadiantCrystals(uint32 amount);
 	void RemoveEbonCrystals(uint32 amount);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -3031,6 +3031,11 @@ void Perl_Client_GrantAllAAPoints(Client* self, uint8 unlock_level)
 	self->GrantAllAAPoints(unlock_level);
 }
 
+void Perl_Client_GrantAllAAPoints(Client* self, uint8 unlock_level, bool skip_grant_only)
+{
+	self->GrantAllAAPoints(unlock_level, skip_grant_only);
+}
+
 void Perl_Client_AddEbonCrystals(Client* self, uint32 amount)
 {
 	self->AddEbonCrystals(amount);
@@ -3471,6 +3476,7 @@ void perl_register_client()
 	package.add("GoFish", &Perl_Client_GoFish);
 	package.add("GrantAllAAPoints", (void(*)(Client*))&Perl_Client_GrantAllAAPoints);
 	package.add("GrantAllAAPoints", (void(*)(Client*, uint8))&Perl_Client_GrantAllAAPoints);
+	package.add("GrantAllAAPoints", (void(*)(Client*, uint8, bool))&Perl_Client_GrantAllAAPoints);
 	package.add("GrantAlternateAdvancementAbility", (bool(*)(Client*, int, int))&Perl_Client_GrantAlternateAdvancementAbility);
 	package.add("GrantAlternateAdvancementAbility", (bool(*)(Client*, int, int, bool))&Perl_Client_GrantAlternateAdvancementAbility);
 	package.add("GuildID", &Perl_Client_GuildID);


### PR DESCRIPTION
# Perl
- Add `$client->GrantAllAAPoints(unlock_level, skip_grant_only)`.

# Lua
- Add `client:GrantAllAAPoints(unlock_level, skip_grant_only)`.

# Description
- Allows operators to skip grant only AAs when granting AAs via `#grantaas` or the quest methods.

## Type of change
- [X] New feature

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur