### PR TITLE
[Bug Fix] Fix 'Teleport Doors' from being blocked by GM flag

### DIFF
--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -542,7 +542,7 @@ void Doors::HandleClick(Client *sender, uint8 trigger)
 	if (EQ::ValueWithin(m_open_type, 57, 58) && HasDestinationZone()) {
 		bool has_key_required = (required_key_item && required_key_item == player_key);
 
-		if (sender->GetGM() && has_key_required) {
+		if (sender->GetGM() && !has_key_required) {
 			has_key_required = true;
 			sender->Message(Chat::White, "Your GM flag allows you to open this door without a key.");
 		}

--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -543,7 +543,7 @@ void Doors::HandleClick(Client *sender, uint8 trigger)
 		bool has_key_required = (required_key_item && required_key_item == player_key);
 
 		if (sender->GetGM() && has_key_required) {
-			has_key_required = false;
+			has_key_required = true;
 			sender->Message(Chat::White, "Your GM flag allows you to open this door without a key.");
 		}
 


### PR DESCRIPTION

# Description

GM flag causes teleport doors to always act as if you do not have the key, instead of acting as if you do have the key

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

This is a trivial fix

Clients tested: 

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur

