### PR TITLE
[Bug Fix] Parcel purchase of bazaar items with unlimited charges

### DIFF
--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -3495,7 +3495,7 @@ void Client::BuyTraderItemOutsideBazaar(TraderBuy_Struct *tbs, const EQApplicati
 	ps.item_slot = parcel_out.slot_id;
 	strn0cpy(ps.send_to, GetCleanName(), sizeof(ps.send_to));
 
-	if (trader_item.item_charges == tbs->quantity) {
+	if (trader_item.item_charges <= static_cast<int32>(tbs->quantity)) {
 		TraderRepository::DeleteOne(database, trader_item.id);
 	} else {
 		TraderRepository::UpdateQuantity(


### PR DESCRIPTION
A bug was reported and confirmed regarding purchasing a bazaar item via parcel delivery when the item had unlimited charges. 
The item would not be removed from the db correctly, resulting in incorrect behaviour.  

The problem was not seen when purchasing directly from a vendor.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
This fix has been running in two environments for several weeks and confirmed fixed.

Clients tested: 
RoF2
# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
