### PR TITLE
[Release] 22.56.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [22.56.3] 9/23/2024
+
+### Fixes
+
+* Fix issue with Client::SaveDisciplines() not specifying character ID ([#4481](https://github.com/EQEmu/Server/pull/4477)) @Kinglykrab 2024-09-23
+
 ## [22.56.2] 9/20/2024
 
 ### Fixes

--- a/common/version.h
+++ b/common/version.h
@@ -25,7 +25,7 @@
 
 // Build variables
 // these get injected during the build pipeline
-#define CURRENT_VERSION "22.56.2-dev" // always append -dev to the current version for custom-builds
+#define CURRENT_VERSION "22.56.3-dev" // always append -dev to the current version for custom-builds
 #define LOGIN_VERSION "0.8.0"
 #define COMPILE_DATE    __DATE__
 #define COMPILE_TIME    __TIME__

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eqemu-server",
-  "version": "22.56.2",
+  "version": "22.56.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/EQEmu/Server.git"

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -11117,7 +11117,8 @@ void Client::SaveDisciplines()
 		CharacterDisciplinesRepository::DeleteWhere(
 			database,
 			fmt::format(
-				"`slot_id` IN ({})",
+				"`id` = {} AND `slot_id` IN ({})",
+				CharacterID(),
 				Strings::Join(delete_slots, ", ")
 			)
 		);


### PR DESCRIPTION
# Description
- [Bug Fix] Fix issue with Client::SaveDisciplines() not specifying character ID
- Testing this on my development server I did not notice this issue because I only had one character online at a time when testing.
- The issue occurs when player X has their disciplines deleted and because we're not specifying a character ID in the query it will also affect characters Y, Z, etc.

## Type of change
- [X] Bug fix

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur