### PR TITLE
Added character_instance_safereturns to prevent duplicate keys #4484

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -1860,7 +1860,7 @@ bool Database::CopyCharacter(
 
 	const int64 new_character_id = (CharacterDataRepository::GetMaxId(*this) + 1);
 
-	std::vector<std::string> tables_to_zero_id = { "keyring", "data_buckets" };
+	std::vector<std::string> tables_to_zero_id = { "keyring", "data_buckets", "character_instance_safereturns" };
 
 	TransactionBegin();
 


### PR DESCRIPTION
# Description

Added character_instance_safereturns to prevent a duplicate key issue when using #copycharacter

Fixes # 4484

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

So, I'm kinda bad here. I don't actually know how to test my changes because I am unsure how to compile this code and put it into my akk-stack dev server for testing.

Clients tested: 

# Checklist

- [ ] I have tested my changes... As mentioned above I don't know enough about how to compile this code and then import it into my akk-stack dev server for testing. I hope to figure that out soon.
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur