### PR TITLE
[Cleanup] Remove Extra Skill in EQ::skills::GetExtraDamageSkills()

### DIFF
--- a/common/skills.cpp
+++ b/common/skills.cpp
@@ -249,7 +249,6 @@ const std::vector<EQ::skills::SkillType>& EQ::skills::GetExtraDamageSkills()
 		EQ::skills::SkillFlyingKick,
 		EQ::skills::SkillKick,
 		EQ::skills::SkillRoundKick,
-		EQ::skills::SkillRoundKick,
 		EQ::skills::SkillTigerClaw,
 		EQ::skills::SkillFrenzy
 	};


### PR DESCRIPTION
# Description
- Removes an extra `EQ::skills::SkillRoundKick` in `EQ::skills::GetExtraDamageSkills()` that is unnecessary.
- This does not cause any issues, but if this is ever used for anything else that may loop these, it could cause issues.