### PR TITLE
[Bug Fix] Fix Group ID 0 in Group::SaveGroupLeaderAA()

### DIFF
--- a/zone/groups.cpp
+++ b/zone/groups.cpp
@@ -2117,15 +2117,20 @@ void Group::UnDelegateMarkNPC(const char *OldNPCMarkerName)
 
 void Group::SaveGroupLeaderAA()
 {
-    // Stores the Group Leaders Leadership AA data from the Player Profile as a blob in the group_leaders table.
-    // This is done so that group members not in the same zone as the Leader still have access to this information.
+	const uint32 group_id = GetID();
 
-    std::string aa((char *) &LeaderAbilities, sizeof(GroupLeadershipAA_Struct));
-    auto        results = GroupLeadersRepository::UpdateLeadershipAA(database, aa, GetID());
+	if (!group_id) {
+		return;
+	}
 
-	if (!results) {
-        LogError("Unable to store GroupLeadershipAA for group_id: [{}]", GetID());
-    }
+	// Stores the Group Leaders Leadership AA data from the Player Profile as a blob in the group_leaders table.
+	// This is done so that group members not in the same zone as the Leader still have access to this information.
+
+	std::string aa((char*) &LeaderAbilities, sizeof(GroupLeadershipAA_Struct));
+
+	if (!GroupLeadersRepository::UpdateLeadershipAA(database, aa, group_id)) {
+		LogError("Unable to store GroupLeadershipAA for group_id: [{}]", group_id);
+	}
 }
 
 void Group::UnMarkNPC(uint16 ID)


### PR DESCRIPTION
# Description
- Halts the saving of group leadership AAs if the group ID is `0`.

## Type of change
- [X Bug fix

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur