### PR TITLE
[Bug Fix] Fix Targeted AOE Max Targets Rule

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -475,7 +475,6 @@ RULE_BOOL(Spells, OldRainTargets, false, "Use old incorrectly implemented maximu
 RULE_REAL(Spells, CallOfTheHeroAggroClearDist, 250.0, "Distance at which CoTH will wipe aggro. To disable and always enable aggro wipe on any distance of CoTH, set to 0.")
 RULE_BOOL(Spells, NPCSpellPush, false, "Enable spell push on NPCs")
 RULE_BOOL(Spells, July242002PetResists, true, "Enable Pets using PCs resist change from July 24 2002")
-RULE_INT(Spells, AOEMaxTargets, 0, "Max number of targets a Targeted AOE spell can cast on. Set to 0 for no limit.")
 RULE_BOOL(Spells, CazicTouchTargetsPetOwner, true, "If True, causes Cazic Touch to swap targets from pet to pet owner if a pet is tanking.")
 RULE_BOOL(Spells, PreventFactionWarOnCharmBreak, false, "Enable spell interupts and dot removal on charm break to prevent faction wars.")
 RULE_BOOL(Spells, AllowDoubleInvis, true, "Allows you to cast invisibility spells on a player that is already invisible, live like behavior.")
@@ -515,6 +514,7 @@ RULE_BOOL(Spells, UseClassicSpellFocus, false, "Enabling will tell the server to
 RULE_BOOL(Spells, ManaTapsOnAnyClass, false, "Enabling this will allow you to cast mana taps on any class, this will bypass ManaTapsRequireNPCMana rule.")
 RULE_INT(Spells, HealAmountMessageFilterThreshold, 100, "Lifetaps below this threshold will not have a message sent to the client (Heal will still process) 0 to Disable.")
 RULE_BOOL(Spells, SnareOverridesSpeedBonuses, false, "Enabling will allow snares to override any speed bonuses the entity may have. Default: False")
+RULE_INT(Spells, TargetedAOEMaxTargets, 4, "Max number of targets a Targeted AOE spell can cast on. Set to 0 for no limit.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Combat)

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -1096,7 +1096,7 @@ void EntityList::AESpell(
 		max_targets = nullptr;
 	}
 
-	int max_targets_allowed = RuleI(Range, AOEMaxTargets); // unlimited
+	int max_targets_allowed = 4;
 	if (max_targets) { // rains pass this in since they need to preserve the count through waves
 		max_targets_allowed = *max_targets;
 	} else if (spells[spell_id].aoe_max_targets) {
@@ -1108,7 +1108,7 @@ void EntityList::AESpell(
 		!IsEffectInSpell(spell_id, SE_Lull) &&
 		!IsEffectInSpell(spell_id, SE_Mez)
 	) {
-		max_targets_allowed = 4;
+		max_targets_allowed = RuleI(Spells, TargetedAOEMaxTargets);
 	}
 
 	int   target_hit_counter = 0;


### PR DESCRIPTION
# Description
- Fixes an issue where we were using the rule improperly, causing spells that should not be limited to be limited instead of only limiting specific spell types.
- We were also using the rule as `Range:AOEMaxTargets` when it was `Spells:AOEMaxTargets`.
- I fixed this by removing the old rule since it does nothing and adding a new one with a default of `0` for unlimited.

## Type of change
- [X] Bug fix

# Testing
![image](https://github.com/user-attachments/assets/d862631f-5e7e-4f7d-9ff8-a64fb517bb47)

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur