### PR TITLE
[Bots] Add attack flag when told to attack

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -2978,7 +2978,7 @@ void Bot::SetOwnerTarget(Client* bot_owner) {
 	if (NOT_HOLDING && NOT_PASSIVE) {
 
 		auto attack_target = bot_owner->GetTarget();
-		if (attack_target) {
+		if (attack_target && HasBotAttackFlag(attack_target)) {
 
 			InterruptSpell();
 			WipeHateList();

--- a/zone/bot_commands/attack.cpp
+++ b/zone/bot_commands/attack.cpp
@@ -35,6 +35,11 @@ void bot_command_attack(Client *c, const Seperator *sep)
 		return;
 	}
 
+	if (!c->HasBotAttackFlag(target_mob)) {
+		target_mob->SetBotAttackFlag(c->CharacterID());
+		target_mob->bot_attack_flag_timer.Start(10000);
+	}
+
 	size_t attacker_count = 0;
 	Bot *first_attacker = nullptr;
 	sbl.remove(nullptr);

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -129,7 +129,8 @@ Mob::Mob(
 	position_update_melee_push_timer(500),
 	hate_list_cleanup_timer(6000),
 	mob_close_scan_timer(6000),
-	mob_check_moving_timer(1000)
+	mob_check_moving_timer(1000),
+	bot_attack_flag_timer(10000)
 {
 	mMovementManager = &MobMovementManager::Get();
 	mMovementManager->AddMob(this);
@@ -399,6 +400,10 @@ Mob::Mob(
 	pet_owner_client  = false;
 	pet_owner_npc     = false;
 	pet_targetlock_id = 0;
+
+	//bot attack flag
+	bot_attack_flags.clear();
+	bot_attack_flag_timer.Disable();
 
 	attacked_count = 0;
 	mezzed         = false;
@@ -8617,6 +8622,26 @@ bool Mob::IsCloseToBanker()
 	for (auto &e: entity_list.GetCloseMobList(this)) {
 		auto mob = e.second;
 		if (mob && mob->IsNPC() && mob->GetClass() == Class::Banker) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool Mob::HasBotAttackFlag(Mob* tar) {
+	if (!tar) {
+		return false;
+	}
+
+	std::vector<uint32> l = tar->GetBotAttackFlags();
+
+	for (uint32 e : l) {
+		if (IsBot() && e == CastToBot()->GetBotOwnerCharacterID()) {
+			return true;
+		}
+
+		if (IsClient() && e == CastToClient()->CharacterID()) {
 			return true;
 		}
 	}

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -205,6 +205,9 @@ public:
 	Timer                             mob_close_scan_timer;
 	Timer                             mob_check_moving_timer;
 
+	// Bot attack flag
+	Timer bot_attack_flag_timer;
+
 	//Somewhat sorted: needs documenting!
 
 	//Attack
@@ -1102,6 +1105,11 @@ public:
 	bool invulnerable;
 	bool qglobal;
 
+	inline std::vector<uint32> GetBotAttackFlags() { return bot_attack_flags; }
+	inline void SetBotAttackFlag(uint32 value) { bot_attack_flags.push_back(value); }
+	inline void ClearBotAttackFlags() { bot_attack_flags.clear(); }
+	bool HasBotAttackFlag(Mob* tar);
+
 	virtual void SetAttackTimer();
 	inline void SetInvul(bool invul) { invulnerable=invul; }
 	inline bool GetInvul(void) { return invulnerable; }
@@ -1862,6 +1870,9 @@ protected:
 	bool pet_owner_client; // Flags pets as belonging to a Client
 	bool pet_owner_npc;    // Flags pets as belonging to an NPC
 	uint32 pet_targetlock_id;
+
+	//bot attack flags
+	std::vector<uint32> bot_attack_flags;
 
 	glm::vec3 m_TargetRing;
 

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -799,6 +799,11 @@ bool NPC::Process()
 		}
 	}
 
+	if (bot_attack_flag_timer.Check()) {
+		bot_attack_flag_timer.Disable();
+		ClearBotAttackFlags();
+	}
+
 	AI_Process();
 
 	return true;


### PR DESCRIPTION
# Description

This adds a flag to mobs that are told to attack by their owner to prevent unintended attacks.

Previously, if you were to send your bots to attack a target and then switch targets: before casters land their spell or if melee hasn't engaged before the target switch, they could switch to your new target and attack.

This adds a flag upon attack and bots will only attack flagged targets.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing
<b>Before change, can send attack then switch targets and they will attack new target.</b>
[Before](https://github.com/user-attachments/assets/5a4dcb8f-a31e-41ea-bf95-cbf5f94a630d)
----
<b>After change, can send attack then switch targets and they will attack the initial target.</b>
[After](https://github.com/user-attachments/assets/d0e6078f-b07d-4f68-ae44-f336eae383bc)
----
Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
