### PR TITLE
[Quest API] Add NPC List Filter Methods to Perl/Lua

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -5938,15 +5938,17 @@ void EntityList::DamageArea(
 	}
 }
 
-std::vector<NPC*> EntityList::GetNPCsByNPCIDs(std::vector<uint32> npc_ids)
+std::vector<NPC*> EntityList::GetFilteredNPCList(std::vector<uint32> npc_ids, bool is_exclude)
 {
 	std::vector<NPC*> v;
 
 	for (const auto& e : GetNPCList()) {
-		if (
-			e.second &&
-			std::find(npc_ids.begin(), npc_ids.end(), e.second->GetNPCTypeID()) != npc_ids.end()
-		) {
+		const auto& n = std::find(npc_ids.begin(), npc_ids.end(), e.second->GetNPCTypeID());
+		if (e.second) {
+			if (is_exclude && n != npc_ids.end()) {
+				continue;
+			}
+
 			v.emplace_back(e.second);
 		}
 	}

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -5944,8 +5944,13 @@ std::vector<NPC*> EntityList::GetFilteredNPCList(std::vector<uint32> npc_ids, bo
 
 	for (const auto& e : GetNPCList()) {
 		const auto& n = std::find(npc_ids.begin(), npc_ids.end(), e.second->GetNPCTypeID());
+		const bool is_found = n != npc_ids.end();
 		if (e.second) {
-			if (is_exclude && n != npc_ids.end()) {
+			if (is_exclude && is_found) {
+				continue;
+			}
+
+			if (!is_exclude && !is_found) {
 				continue;
 			}
 

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -5937,3 +5937,19 @@ void EntityList::DamageArea(
 		}
 	}
 }
+
+std::vector<NPC*> EntityList::GetNPCsByNPCIDs(std::vector<uint32> npc_ids)
+{
+	std::vector<NPC*> v;
+
+	for (const auto& e : GetNPCList()) {
+		if (
+			e.second &&
+			std::find(npc_ids.begin(), npc_ids.end(), e.second->GetNPCTypeID()) != npc_ids.end()
+		) {
+			v.emplace_back(e.second);
+		}
+	}
+
+	return v;
+}

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -5938,19 +5938,32 @@ void EntityList::DamageArea(
 	}
 }
 
-std::vector<NPC*> EntityList::GetFilteredNPCList(std::vector<uint32> npc_ids, bool is_exclude)
+std::vector<NPC*> EntityList::GetNPCsByIDs(std::vector<uint32> npc_ids)
 {
 	std::vector<NPC*> v;
 
 	for (const auto& e : GetNPCList()) {
 		const auto& n = std::find(npc_ids.begin(), npc_ids.end(), e.second->GetNPCTypeID());
-		const bool is_found = n != npc_ids.end();
 		if (e.second) {
-			if (is_exclude && is_found) {
+			if (n != npc_ids.end()) {
 				continue;
 			}
 
-			if (!is_exclude && !is_found) {
+			v.emplace_back(e.second);
+		}
+	}
+
+	return v;
+}
+
+std::vector<NPC*> EntityList::GetExcludedNPCsByIDs(std::vector<uint32> npc_ids)
+{
+	std::vector<NPC*> v;
+
+	for (const auto& e : GetNPCList()) {
+		const auto& n = std::find(npc_ids.begin(), npc_ids.end(), e.second->GetNPCTypeID());
+		if (e.second) {
+			if (n == npc_ids.end()) {
 				continue;
 			}
 

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -560,7 +560,7 @@ public:
 
 	std::unordered_map<uint16, Mob *> &GetCloseMobList(Mob *mob, float distance = 0.0f);
 
-	std::vector<NPC*> GetNPCsByNPCIDs(std::vector<uint32> npc_ids);
+	std::vector<NPC*> GetFilteredNPCList(std::vector<uint32> npc_ids, bool is_exclude = false);
 
 	void	DepopAll(int NPCTypeID, bool StartSpawnTimer = true);
 

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -560,6 +560,8 @@ public:
 
 	std::unordered_map<uint16, Mob *> &GetCloseMobList(Mob *mob, float distance = 0.0f);
 
+	std::vector<NPC*> GetNPCsByNPCIDs(std::vector<uint32> npc_ids);
+
 	void	DepopAll(int NPCTypeID, bool StartSpawnTimer = true);
 
 	uint16 GetFreeID();

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -560,7 +560,8 @@ public:
 
 	std::unordered_map<uint16, Mob *> &GetCloseMobList(Mob *mob, float distance = 0.0f);
 
-	std::vector<NPC*> GetFilteredNPCList(std::vector<uint32> npc_ids, bool is_exclude = false);
+	std::vector<NPC*> GetNPCsByIDs(std::vector<uint32> npc_ids);
+	std::vector<NPC*> GetExcludedNPCsByIDs(std::vector<uint32> npc_ids);
 
 	void	DepopAll(int NPCTypeID, bool StartSpawnTimer = true);
 

--- a/zone/lua_entity_list.cpp
+++ b/zone/lua_entity_list.cpp
@@ -784,7 +784,7 @@ Lua_NPC_List Lua_EntityList::GetNPCsByExcludedIDs(luabind::adl::object table)
 			index++;
 		}
 
-		const auto& l = self->GetFilteredNPCList(ids, true);
+		const auto& l = self->GetExcludedNPCsByIDs(ids);
 
 		for (const auto& e : l) {
 			ret.entries.emplace_back(Lua_NPC(e));
@@ -814,7 +814,7 @@ Lua_NPC_List Lua_EntityList::GetNPCsByIDs(luabind::adl::object table)
 			index++;
 		}
 
-		const auto& l = self->GetFilteredNPCList(ids);
+		const auto& l = self->GetNPCsByIDs(ids);
 
 		for (const auto& e : l) {
 			ret.entries.emplace_back(Lua_NPC(e));

--- a/zone/lua_entity_list.cpp
+++ b/zone/lua_entity_list.cpp
@@ -764,6 +764,36 @@ void Lua_EntityList::MassGroupBuff(Lua_Mob caster, Lua_Mob center, uint16 spell_
 	self->MassGroupBuff(caster, center, spell_id, affect_caster);
 }
 
+Lua_NPC_List Lua_EntityList::GetNPCsByNPCIDs(luabind::adl::object table)
+{
+	Lua_Safe_Call_Class(Lua_NPC_List);
+	Lua_NPC_List ret;
+
+	if (luabind::type(table) != LUA_TTABLE) {
+		return ret;
+	}
+
+	if (d_) {
+		auto self = reinterpret_cast<NativeType*>(d_);
+
+		std::vector<uint32> ids;
+
+		int index = 1;
+		while (luabind::type(table[index]) != LUA_TNIL) {
+			ids.emplace_back(luabind::object_cast<uint32>(table[index]));
+			index++;
+		}
+
+		const auto& l = self->GetNPCsByNPCIDs(ids);
+
+		for (const auto& e : l) {
+			ret.entries.emplace_back(Lua_NPC(e));
+		}
+	}
+
+	return ret;
+}
+
 luabind::scope lua_register_entity_list() {
 	return luabind::class_<Lua_EntityList>("EntityList")
 	.def(luabind::constructor<>())
@@ -829,6 +859,7 @@ luabind::scope lua_register_entity_list() {
 	.def("GetNPCByNPCTypeID", (Lua_NPC(Lua_EntityList::*)(int))&Lua_EntityList::GetNPCByNPCTypeID)
 	.def("GetNPCBySpawnID", (Lua_NPC(Lua_EntityList::*)(int))&Lua_EntityList::GetNPCBySpawnID)
 	.def("GetNPCList", (Lua_NPC_List(Lua_EntityList::*)(void))&Lua_EntityList::GetNPCList)
+	.def("GetNPCsByNPCIDs", (Lua_NPC_List(Lua_EntityList::*)(luabind::adl::object))&Lua_EntityList::GetNPCsByNPCIDs)
 	.def("GetObjectByDBID", (Lua_Object(Lua_EntityList::*)(uint32))&Lua_EntityList::GetObjectByDBID)
 	.def("GetObjectByID", (Lua_Object(Lua_EntityList::*)(int))&Lua_EntityList::GetObjectByID)
 	.def("GetObjectList", (Lua_Object_List(Lua_EntityList::*)(void))&Lua_EntityList::GetObjectList)

--- a/zone/lua_entity_list.h
+++ b/zone/lua_entity_list.h
@@ -156,7 +156,8 @@ public:
 	void AreaTaunt(Lua_Client caster, float range, int bonus_hate);
 	void MassGroupBuff(Lua_Mob caster, Lua_Mob center, uint16 spell_id);
 	void MassGroupBuff(Lua_Mob caster, Lua_Mob center, uint16 spell_id, bool affect_caster);
-	Lua_NPC_List GetNPCsByNPCIDs(luabind::adl::object npc_ids);
+	Lua_NPC_List GetNPCsByIDs(luabind::adl::object npc_ids);
+	Lua_NPC_List GetNPCsByExcludedIDs(luabind::adl::object npc_ids);
 };
 
 #endif

--- a/zone/lua_entity_list.h
+++ b/zone/lua_entity_list.h
@@ -156,7 +156,7 @@ public:
 	void AreaTaunt(Lua_Client caster, float range, int bonus_hate);
 	void MassGroupBuff(Lua_Mob caster, Lua_Mob center, uint16 spell_id);
 	void MassGroupBuff(Lua_Mob caster, Lua_Mob center, uint16 spell_id, bool affect_caster);
-
+	Lua_NPC_List GetNPCsByNPCIDs(luabind::adl::object npc_ids);
 };
 
 #endif

--- a/zone/perl_entity.cpp
+++ b/zone/perl_entity.cpp
@@ -747,7 +747,7 @@ perl::array Perl_EntityList_GetNPCsByExcludedIDs(EntityList* self, perl::array n
 		ids.emplace_back(npc_ids[i]);
 	}
 
-	const auto& l = self->GetFilteredNPCList(ids, true);
+	const auto& l = self->GetExcludedNPCsByIDs(ids);
 
 	perl::array npcs;
 
@@ -766,7 +766,7 @@ perl::array Perl_EntityList_GetNPCsByIDs(EntityList* self, perl::array npc_ids)
 		ids.emplace_back(npc_ids[i]);
 	}
 
-	const auto& l = self->GetFilteredNPCList(ids);
+	const auto& l = self->GetNPCsByIDs(ids);
 
 	perl::array npcs;
 

--- a/zone/perl_entity.cpp
+++ b/zone/perl_entity.cpp
@@ -739,6 +739,25 @@ void Perl_EntityList_MassGroupBuff(EntityList* self, Mob* caster, Mob* center, u
 	self->MassGroupBuff(caster, center, spell_id, affect_caster);
 }
 
+perl::array Perl_EntityList_GetNPCsByNPCIDs(EntityList* self, perl::array npc_ids)
+{
+	std::vector<uint32> ids;
+
+	for (int i = 0; i < npc_ids.size(); i++) {
+		ids.emplace_back(npc_ids[i]);
+	}
+
+	const auto& l = self->GetNPCsByNPCIDs(ids);
+
+	perl::array npcs;
+
+	for (const auto& e : l) {
+		npcs.push_back(e);
+	}
+
+	return npcs;
+}
+
 void perl_register_entitylist()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -804,6 +823,7 @@ void perl_register_entitylist()
 	package.add("GetNPCByNPCTypeID", &Perl_EntityList_GetNPCByNPCTypeID);
 	package.add("GetNPCBySpawnID", &Perl_EntityList_GetNPCBySpawnID);
 	package.add("GetNPCList", &Perl_EntityList_GetNPCList);
+	package.add("GetNPCsByNPCIDs", &Perl_EntityList_GetNPCsByNPCIDs);
 	package.add("GetObjectByDBID", &Perl_EntityList_GetObjectByDBID);
 	package.add("GetObjectByID", &Perl_EntityList_GetObjectByID);
 	package.add("GetObjectList", &Perl_EntityList_GetObjectList);

--- a/zone/perl_entity.cpp
+++ b/zone/perl_entity.cpp
@@ -739,7 +739,7 @@ void Perl_EntityList_MassGroupBuff(EntityList* self, Mob* caster, Mob* center, u
 	self->MassGroupBuff(caster, center, spell_id, affect_caster);
 }
 
-perl::array Perl_EntityList_GetNPCsByNPCIDs(EntityList* self, perl::array npc_ids)
+perl::array Perl_EntityList_GetNPCsByExcludedIDs(EntityList* self, perl::array npc_ids)
 {
 	std::vector<uint32> ids;
 
@@ -747,7 +747,26 @@ perl::array Perl_EntityList_GetNPCsByNPCIDs(EntityList* self, perl::array npc_id
 		ids.emplace_back(npc_ids[i]);
 	}
 
-	const auto& l = self->GetNPCsByNPCIDs(ids);
+	const auto& l = self->GetFilteredNPCList(ids, true);
+
+	perl::array npcs;
+
+	for (const auto& e : l) {
+		npcs.push_back(e);
+	}
+
+	return npcs;
+}
+
+perl::array Perl_EntityList_GetNPCsByIDs(EntityList* self, perl::array npc_ids)
+{
+	std::vector<uint32> ids;
+
+	for (int i = 0; i < npc_ids.size(); i++) {
+		ids.emplace_back(npc_ids[i]);
+	}
+
+	const auto& l = self->GetFilteredNPCList(ids);
 
 	perl::array npcs;
 
@@ -823,7 +842,8 @@ void perl_register_entitylist()
 	package.add("GetNPCByNPCTypeID", &Perl_EntityList_GetNPCByNPCTypeID);
 	package.add("GetNPCBySpawnID", &Perl_EntityList_GetNPCBySpawnID);
 	package.add("GetNPCList", &Perl_EntityList_GetNPCList);
-	package.add("GetNPCsByNPCIDs", &Perl_EntityList_GetNPCsByNPCIDs);
+	package.add("GetNPCsByExcludedIDs", &Perl_EntityList_GetNPCsByExcludedIDs);
+	package.add("GetNPCsByIDs", &Perl_EntityList_GetNPCsByIDs);
 	package.add("GetObjectByDBID", &Perl_EntityList_GetObjectByDBID);
 	package.add("GetObjectByID", &Perl_EntityList_GetObjectByID);
 	package.add("GetObjectList", &Perl_EntityList_GetObjectList);


### PR DESCRIPTION
# Description
- Adds methods to Perl and Lua to allow operators to get a list of NPCs based on a list of NPC IDs without looping the entity list to do so.

# Perl
- Add `$entity_list->GetNPCsByExcludedIDs(npc_ids)`.
- Add `$entity_list->GetNPCsByIDs(npc_ids)`.

## Perl Example
```pl
sub EVENT_SAY {
	if ($text=~/#a/i) {
		my @npc_ids = (189013, 189014, 189453);
		my @npcs = $entity_list->GetNPCsByIDs(@npc_ids);
		my @excluded = $entity_list->GetNPCsByExcludedIDs(@npc_ids);

		foreach my $npc (@npcs) {
			my $entity_id = $npc->GetID();
			$npc->Shout("[Perl] I am included! ID $entity_id");
		}

		foreach my $npc (@excluded) {
			my $entity_id = $npc->GetID();
			$npc->Shout("[Perl] I am not excluded! ID $entity_id");
		}
	}
}
```

## Perl Testing
![image](https://github.com/user-attachments/assets/e27898a6-f19f-4ee9-a59a-793d431b0981)

# Lua
- Add `eq.get_entity_list():GetNPCsByExcludedIDs(npc_ids)`.
- Add `eq.get_entity_list():GetNPCsByIDs(npc_ids)`.

## Lua Example
```lua
function event_say(e)
	if e.message:findi("#b") then
		local npc_ids = { 189013, 189014, 189453 }
		local excluded = eq.get_entity_list():GetNPCsByExcludedIDs(npc_ids)
		local npcs = eq.get_entity_list():GetNPCsByIDs(npc_ids)

		for n in npcs.entries do
			local entity_id = n:GetID()
			n:Shout("[Lua] I am included! ID " .. tostring(entity_id))
		end

		for n in excluded.entries do
			local entity_id = n:GetID()
			n:Shout("[Lua] I am not excluded! ID " .. tostring(entity_id))
		end
	end
end
```

## Lua Testing
![Uploading image.png…]()