### PR TITLE
[Bots] Add "silent" option to ^spawn and mute raid spawn

### DIFF
--- a/zone/bot_commands/bot.cpp
+++ b/zone/bot_commands/bot.cpp
@@ -857,7 +857,7 @@ void bot_command_spawn(Client *c, const Seperator *sep)
 		c->Message(
 			Chat::White,
 			fmt::format(
-				"Usage: {} [bot_name]",
+				"Usage: {} [bot_name] [optional: silent]",
 				sep->arg[0]
 			).c_str()
 		);
@@ -1045,9 +1045,17 @@ void bot_command_spawn(Client *c, const Seperator *sep)
 		message_index = VALIDATECLASSID(my_bot->GetClass());
 	}
 
-	if (c->GetBotOption(Client::booSpawnMessageSay)) {
+	std::string silent_confirm = sep->arg[2];
+	bool silentTell = false;
+
+	if (!silent_confirm.compare("silent")) {
+		silentTell = true;
+	}
+
+	if (!silentTell && c->GetBotOption(Client::booSpawnMessageSay)) {
 		Bot::BotGroupSay(my_bot, bot_spawn_message[message_index].c_str());
-	} else if (c->GetBotOption(Client::booSpawnMessageTell)) {
+	}
+	else if (!silentTell && c->GetBotOption(Client::booSpawnMessageTell)) {
 		my_bot->OwnerMessage(bot_spawn_message[message_index]);
 	}
 }

--- a/zone/bot_raid.cpp
+++ b/zone/bot_raid.cpp
@@ -312,10 +312,12 @@ void Client::SpawnRaidBotsOnConnect(Raid* raid) {
 	for (const auto& m: r_members) {
 		if (strlen(m.member_name) != 0) {
 
-			for (const auto& b: bots_list) {
+			for (const auto& b : bots_list) {
 				if (strcmp(m.member_name, b.bot_name) == 0) {
 					std::string buffer = "^spawn ";
 					buffer.append(m.member_name);
+					std::string silent = " silent";
+					buffer.append(silent);
 					bot_command_real_dispatch(this, buffer.c_str());
 					auto bot = entity_list.GetBotByBotName(m.member_name);
 


### PR DESCRIPTION
# Description

When zoning or forming a raid, bots would spam their spawn message. They will now be muted.

Adds an optional argument "silent" to the `^spawn` command. This will bypass `^oo spawnmessage` settings and not send a spawn message. Example: `^spawn Warbot silent`

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Testing

Attach images and describe testing done to validate functionality.

Clients tested: 
RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
