### PR TITLE
[Quest API] Add Buff Fade Methods to Perl/Lua

### DIFF
--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -3470,6 +3470,12 @@ void Lua_Mob::BuffFadeNonPersistDeath()
 	self->BuffFadeNonPersistDeath();
 }
 
+void Lua_Mob::BuffFadeSongs()
+{
+	Lua_Safe_Call_Void();
+	self->BuffFadeSongs();
+}
+
 luabind::scope lua_register_mob() {
 	return luabind::class_<Lua_Mob, Lua_Entity>("Mob")
 	.def(luabind::constructor<>())
@@ -3516,6 +3522,7 @@ luabind::scope lua_register_mob() {
 	.def("BuffFadeDetrimental", (void(Lua_Mob::*)(void))&Lua_Mob::BuffFadeDetrimental)
 	.def("BuffFadeDetrimentalByCaster", (void(Lua_Mob::*)(Lua_Mob))&Lua_Mob::BuffFadeDetrimentalByCaster)
 	.def("BuffFadeNonPersistDeath", (void(Lua_Mob::*)(void))&Lua_Mob::BuffFadeNonPersistDeath)
+	.def("BuffFadeSongs", (void(Lua_Mob::*)(void))&Lua_Mob::BuffFadeSongs)
 	.def("CalculateDistance", (float(Lua_Mob::*)(double,double,double))&Lua_Mob::CalculateDistance)
 	.def("CalculateDistance", (float(Lua_Mob::*)(Lua_Mob))&Lua_Mob::CalculateDistance)
 	.def("CalculateHeadingToTarget", (double(Lua_Mob::*)(double,double))&Lua_Mob::CalculateHeadingToTarget)

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -3446,6 +3446,30 @@ void Lua_Mob::MassGroupBuff(Lua_Mob center, uint16 spell_id, bool affect_caster)
 	entity_list.MassGroupBuff(self, center, spell_id, affect_caster);
 }
 
+void Lua_Mob::BuffFadeBeneficial()
+{
+	Lua_Safe_Call_Void();
+	self->BuffFadeBeneficial();
+}
+
+void Lua_Mob::BuffFadeDetrimental()
+{
+	Lua_Safe_Call_Void();
+	self->BuffFadeDetrimental();
+}
+
+void Lua_Mob::BuffFadeDetrimentalByCaster(Lua_Mob caster)
+{
+	Lua_Safe_Call_Void();
+	self->BuffFadeDetrimentalByCaster(caster);
+}
+
+void Lua_Mob::BuffFadeNonPersistDeath()
+{
+	Lua_Safe_Call_Void();
+	self->BuffFadeNonPersistDeath();
+}
+
 luabind::scope lua_register_mob() {
 	return luabind::class_<Lua_Mob, Lua_Entity>("Mob")
 	.def(luabind::constructor<>())
@@ -3483,11 +3507,15 @@ luabind::scope lua_register_mob() {
 	.def("BuffCount", (uint32(Lua_Mob::*)(bool))&Lua_Mob::BuffCount)
 	.def("BuffCount", (uint32(Lua_Mob::*)(bool,bool))&Lua_Mob::BuffCount)
 	.def("BuffFadeAll", (void(Lua_Mob::*)(void))&Lua_Mob::BuffFadeAll)
+	.def("BuffFadeBeneficial", (void(Lua_Mob::*)(void))&Lua_Mob::BuffFadeBeneficial)
 	.def("BuffFadeByEffect", (void(Lua_Mob::*)(int))&Lua_Mob::BuffFadeByEffect)
 	.def("BuffFadeByEffect", (void(Lua_Mob::*)(int,int))&Lua_Mob::BuffFadeByEffect)
 	.def("BuffFadeBySlot", (void(Lua_Mob::*)(int))&Lua_Mob::BuffFadeBySlot)
 	.def("BuffFadeBySlot", (void(Lua_Mob::*)(int,bool))&Lua_Mob::BuffFadeBySlot)
 	.def("BuffFadeBySpellID", (void(Lua_Mob::*)(int))&Lua_Mob::BuffFadeBySpellID)
+	.def("BuffFadeDetrimental", (void(Lua_Mob::*)(void))&Lua_Mob::BuffFadeDetrimental)
+	.def("BuffFadeDetrimentalByCaster", (void(Lua_Mob::*)(Lua_Mob))&Lua_Mob::BuffFadeDetrimentalByCaster)
+	.def("BuffFadeNonPersistDeath", (void(Lua_Mob::*)(void))&Lua_Mob::BuffFadeNonPersistDeath)
 	.def("CalculateDistance", (float(Lua_Mob::*)(double,double,double))&Lua_Mob::CalculateDistance)
 	.def("CalculateDistance", (float(Lua_Mob::*)(Lua_Mob))&Lua_Mob::CalculateDistance)
 	.def("CalculateHeadingToTarget", (double(Lua_Mob::*)(double,double))&Lua_Mob::CalculateHeadingToTarget)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -605,6 +605,10 @@ public:
 	void AreaSpell(Lua_Mob center, uint16 spell_id, bool affect_caster, int16 resist_adjust, int max_targets);
 	void MassGroupBuff(Lua_Mob center, uint16 spell_id);
 	void MassGroupBuff(Lua_Mob center, uint16 spell_id, bool affect_caster);
+	void BuffFadeBeneficial();
+	void BuffFadeDetrimental();
+	void BuffFadeDetrimentalByCaster(Lua_Mob caster);
+	void BuffFadeNonPersistDeath();
 };
 
 #endif

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -609,6 +609,7 @@ public:
 	void BuffFadeDetrimental();
 	void BuffFadeDetrimentalByCaster(Lua_Mob caster);
 	void BuffFadeNonPersistDeath();
+	void BuffFadeSongs();
 };
 
 #endif

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -447,6 +447,7 @@ public:
 	void BuffFadeBySlot(int slot, bool iRecalcBonuses = true);
 	void BuffFadeDetrimentalByCaster(Mob *caster);
 	void BuffFadeBySitModifier();
+	void BuffFadeSongs();
 	void BuffDetachCaster(Mob *caster);
 	bool IsAffectedByBuffByGlobalGroup(GlobalGroup group);
 	void BuffModifyDurationBySpellID(uint16 spell_id, int32 newDuration);

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -3563,6 +3563,11 @@ void Perl_Mob_BuffFadeNonPersistDeath(Mob* self)
 	self->BuffFadeNonPersistDeath();
 }
 
+void Perl_Mob_BuffFadeSongs(Mob* self)
+{
+	self->BuffFadeSongs();
+}
+
 void perl_register_mob()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3607,6 +3612,7 @@ void perl_register_mob()
 	package.add("BuffFadeDetrimental", &Perl_Mob_BuffFadeDetrimental);
 	package.add("BuffFadeDetrimentalByCaster", &Perl_Mob_BuffFadeDetrimentalByCaster);
 	package.add("BuffFadeNonPersistDeath", &Perl_Mob_BuffFadeNonPersistDeath);
+	package.add("BuffFadeSongs", &Perl_Mob_BuffFadeSongs);
 	package.add("CalculateDistance", (float(*)(Mob*, float, float, float))&Perl_Mob_CalculateDistance);
 	package.add("CalculateDistance", (float(*)(Mob*, Mob*))&Perl_Mob_CalculateDistance);
 	package.add("CalculateHeadingToTarget", &Perl_Mob_CalculateHeadingToTarget);

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -3543,6 +3543,26 @@ void Perl_Mob_MassGroupBuff(Mob* self, Mob* center, uint16 spell_id, bool affect
 	entity_list.MassGroupBuff(self, center, spell_id, affect_caster);
 }
 
+void Perl_Mob_BuffFadeBeneficial(Mob* self)
+{
+	self->BuffFadeBeneficial();
+}
+
+void Perl_Mob_BuffFadeDetrimental(Mob* self)
+{
+	self->BuffFadeDetrimental();
+}
+
+void Perl_Mob_BuffFadeDetrimentalByCaster(Mob* self, Mob* caster)
+{
+	self->BuffFadeDetrimentalByCaster(caster);
+}
+
+void Perl_Mob_BuffFadeNonPersistDeath(Mob* self)
+{
+	self->BuffFadeNonPersistDeath();
+}
+
 void perl_register_mob()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3578,11 +3598,15 @@ void perl_register_mob()
 	package.add("BuffCount", (uint32(*)(Mob*, bool))&Perl_Mob_BuffCount);
 	package.add("BuffCount", (uint32(*)(Mob*, bool, bool))&Perl_Mob_BuffCount);
 	package.add("BuffFadeAll", &Perl_Mob_BuffFadeAll);
+	package.add("BuffFadeBeneficial", &Perl_Mob_BuffFadeBeneficial);
 	package.add("BuffFadeByEffect", (void(*)(Mob*, int))&Perl_Mob_BuffFadeByEffect);
 	package.add("BuffFadeByEffect", (void(*)(Mob*, int, int))&Perl_Mob_BuffFadeByEffect);
 	package.add("BuffFadeBySlot", (void(*)(Mob*, int))&Perl_Mob_BuffFadeBySlot);
 	package.add("BuffFadeBySlot", (void(*)(Mob*, int, bool))&Perl_Mob_BuffFadeBySlot);
 	package.add("BuffFadeBySpellID", &Perl_Mob_BuffFadeBySpellID);
+	package.add("BuffFadeDetrimental", &Perl_Mob_BuffFadeDetrimental);
+	package.add("BuffFadeDetrimentalByCaster", &Perl_Mob_BuffFadeDetrimentalByCaster);
+	package.add("BuffFadeNonPersistDeath", &Perl_Mob_BuffFadeNonPersistDeath);
 	package.add("CalculateDistance", (float(*)(Mob*, float, float, float))&Perl_Mob_CalculateDistance);
 	package.add("CalculateDistance", (float(*)(Mob*, Mob*))&Perl_Mob_CalculateDistance);
 	package.add("CalculateHeadingToTarget", &Perl_Mob_CalculateHeadingToTarget);

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4984,6 +4984,23 @@ void Mob::BuffFadeByEffect(int effect_id, int slot_to_skip)
 	}
 }
 
+void Mob::BuffFadeSongs() {
+	bool recalc_bonus = false;
+	int  buff_count   = GetMaxTotalSlots();
+
+	for (int buff_slot = 0; buff_slot < buff_count; buff_slot++) {
+		const uint16 current_spell_id = buffs[buff_slot].spellid;
+		if (IsBardSong(current_spell_id)) {
+			BuffFadeBySlot(buff_slot, false);
+			recalc_bonus = true;
+		}
+	}
+
+	if (recalc_bonus) {
+		CalcBonuses();
+	}
+}
+
 bool Mob::IsAffectedByBuffByGlobalGroup(GlobalGroup group)
 {
 	int buff_count = GetMaxTotalSlots();


### PR DESCRIPTION
# Description
- Adds buff fade methods to Perl and Lua that were not previously exposed.

# Perl
- Add `$client->BuffFadeBeneficial()`.
- Add `$client->BuffFadeDetrimental()`.
- Add `$client->BuffFadeDetrimentalByCaster(caster)`.
- Add `$client->BuffFadeNonPersistDeath()`.
- Add `$client->BuffFadeSongs()`.

# Lua
- Add `client:BuffFadeBeneficial()`.
- Add `client:BuffFadeDetrimental()`.
- Add `client:BuffFadeDetrimentalByCaster(caster)`.
- Add `client:BuffFadeNonPersistDeath()`.
- Add `client:BuffFadeSongs()`.