### PR TITLE
[Bug Fix] Fix `character_exp_modifiers` Default Values

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -5747,6 +5747,18 @@ ALTER TABLE `inventory`
 ALTER TABLE `inventory_snapshots`
 	ADD COLUMN `guid` BIGINT UNSIGNED NULL DEFAULT '0' AFTER `ornament_hero_model`;
 )"
+	},
+	ManifestEntry{
+		.version = 9284,
+		.description = "2024_10_08_character_exp_modifiers_default.sql",
+		.check = "SHOW CREATE TABLE `character_exp_modifiers`",
+		.condition = "contains",
+		.match = "`exp_modifier` float NOT NULL,",
+		.sql = R"(
+ALTER TABLE `character_exp_modifiers`
+MODIFY COLUMN `aa_modifier` float NOT NULL DEFAULT 1.0 AFTER `instance_version`,
+MODIFY COLUMN `exp_modifier` float NOT NULL DEFAULT 1.0 AFTER `aa_modifier`;
+)"
 	}
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9283
+#define CURRENT_BINARY_DATABASE_VERSION 9284
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9045
 
 #endif


### PR DESCRIPTION
# Description
- Adds a default value to the `aa_modifier` and `exp_modifier` of `1.0` so values are not initialized with no value, causing no experience to be gained when values are added improperly.

## Type of change
- [X] Bug fix

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur