### PR TITLE
[Bug] FindBestZ selecting false zone floor as bestz - Results in roambox failures

### DIFF
--- a/zone/map.cpp
+++ b/zone/map.cpp
@@ -31,12 +31,14 @@ Map::~Map() {
 }
 
 float Map::FindBestZ(glm::vec3 &start, glm::vec3 *result) const {
-	if (!imp)
+	if (!imp) {
 		return BEST_Z_INVALID;
+	}
 
 	glm::vec3 tmp;
-	if(!result)
+	if (!result) {
 		result = &tmp;
+	}
 
 	start.z += RuleI(Map, FindBestZHeightAdjust);
 	glm::vec3 from(start.x, start.y, start.z);
@@ -45,16 +47,22 @@ float Map::FindBestZ(glm::vec3 &start, glm::vec3 *result) const {
 	bool hit = false;
 
 	hit = imp->rm->raycast((const RmReal*)&from, (const RmReal*)&to, (RmReal*)result, nullptr, &hit_distance);
-	if(hit) {
+	if (hit && zone->newzone_data.underworld != 0.0f && result->z < zone->newzone_data.underworld) {
+		hit = false;
+	}
+
+	if (hit) {
 		return result->z;
 	}
 
 	// Find nearest Z above us
-
 	to.z = -BEST_Z_INVALID;
 	hit = imp->rm->raycast((const RmReal*)&from, (const RmReal*)&to, (RmReal*)result, nullptr, &hit_distance);
-	if (hit)
-	{
+	if (zone->newzone_data.max_z != 0.0f && result->z > zone->newzone_data.max_z) {
+		hit = false;
+	}
+
+	if (hit) {
 		return result->z;
 	}
 


### PR DESCRIPTION
# Description

Added underworld checks per the EQMac project. Thank you TAKP for being a wonderful source of resolutions to issues that you have tackled over the last 10 years.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

Prior:

Mobs on roamboxes would bunch up in dips/holes/lowspots in some olderzones.
![image](https://github.com/user-attachments/assets/0bf38d41-8f25-4a80-b472-b6c4de09b630)

In these cases, it was due to a below world requested_z from the false zone floor in the map file (In this example its -198 is the false floor)

![image](https://github.com/user-attachments/assets/8d7cf104-b246-4082-be28-24ee3e0b8c22)


Post:

Same location after 20 minutes, normally filling with "stuck" mobs:

![image](https://github.com/user-attachments/assets/baaf3857-ad1a-41cc-b49d-bc4c5d46615c)

snippet showing the requested_z no longer being the -198 consistently

![image](https://github.com/user-attachments/assets/a30db5fb-1a9c-4736-bab3-c58ff39b21a9)

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur