### PR TITLE
[Bug Fix] Master of Disguise should apply to illusions casted by others.

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -2964,7 +2964,6 @@ int Mob::CalcBuffDuration(Mob *caster, Mob *target, uint16 spell_id, int32 caste
 
 	int res = CalcBuffDuration_formula(castlevel, formula, duration);
 	if (
-		caster == target &&
 		(
 			target->aabonuses.IllusionPersistence ||
 			target->spellbonuses.IllusionPersistence ||


### PR DESCRIPTION
# Description

Many era comments outline how Master of Disguise would apply to Project Illusion spells on you:

https://thesafehouse.org/forums/forum/everquest-wing/main-lounge/14249-new-aa-master-of-disguise/page4

https://thesafehouse.org/forums/forum/everquest-wing/training-studios/18143-master-of-disguise-broken

```
Im not a big fan of wolf form, but having a 1200 min NDT is pretty nice  I also agree its great to shrink on a raid once and not have to worry about it. 7 aa is a little steep imho, but with a name change and some frog potions, I may reapply to my guild as the servers only froggy rogue /cackle.
```

```
share form of the great wolf gave a 1500min timer.
```

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

Enchanter Projecting illusion on a bard without Master of Disguise:

![image](https://github.com/user-attachments/assets/733cfd2b-60ed-4ece-8d0c-f4ccd1865453)

Enchanter Projecting illusion on a bard with Master of Disguise:

![image](https://github.com/user-attachments/assets/2f98c6b6-233a-46ea-9d15-7214ae8086ee)


Clients tested:  RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur