### PR TITLE
[Bug Fix] Correctly limit max targets of PBAOE

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -515,6 +515,8 @@ RULE_BOOL(Spells, ManaTapsOnAnyClass, false, "Enabling this will allow you to ca
 RULE_INT(Spells, HealAmountMessageFilterThreshold, 100, "Lifetaps below this threshold will not have a message sent to the client (Heal will still process) 0 to Disable.")
 RULE_BOOL(Spells, SnareOverridesSpeedBonuses, false, "Enabling will allow snares to override any speed bonuses the entity may have. Default: False")
 RULE_INT(Spells, TargetedAOEMaxTargets, 4, "Max number of targets a Targeted AOE spell can cast on. Set to 0 for no limit.")
+RULE_INT(Spells, PointBlankAOEMaxTargets, 0, "Max number of targets a Point-Blank AOE spell can cast on. Set to 0 for no limit.")
+RULE_INT(Spells, DefaultAOEMaxTargets, 0, "Max number of targets that an AOE spell which does not meet other descriptions can cast on. Set to 0 for no limit.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Combat)

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -1096,7 +1096,7 @@ void EntityList::AESpell(
 		max_targets = nullptr;
 	}
 
-	int max_targets_allowed = 4;
+	int max_targets_allowed = RuleI(Spells, DefaultAOEMaxTargets);;
 	if (max_targets) { // rains pass this in since they need to preserve the count through waves
 		max_targets_allowed = *max_targets;
 	} else if (spells[spell_id].aoe_max_targets) {
@@ -1109,7 +1109,15 @@ void EntityList::AESpell(
 		!IsEffectInSpell(spell_id, SE_Mez)
 	) {
 		max_targets_allowed = RuleI(Spells, TargetedAOEMaxTargets);
+	} else if (
+		IsPBAENukeSpell(spell_id) &&
+		IsDetrimentalSpell &&
+		!is_npc
+	) {
+		max_targets_allowed = RuleI(Spells, PointBlankAOEMaxTargets);
 	}
+
+	RuleI(Spells, PointBlankAOEMaxTargets)
 
 	int   target_hit_counter = 0;
 	float distance_to_target = 0;


### PR DESCRIPTION
# Description

The recent commit allowing for adjustment of maximum targets for Targeted AoE effects also imposed a limit of 4 targets on PBAoE. This commit provides a configuration for Maximum PBAoE targets, as well as a 'Default' maximum targets for any other type of PBAoE not captured by other rules or per-spell configurations.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing



Clients tested: 

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
