### PR TITLE
[Bug Fix] Fix Mercenary Encounter Crash

### DIFF
--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -90,8 +90,6 @@ void QuestManager::Process() {
 	while (cur != end) {
 		if (cur->Timer_.Enabled() && cur->Timer_.Check()) {
 			if (cur->mob) {
-				parse->EventMob(EVENT_TIMER, cur->mob, nullptr, [&]() { return cur->name; }, 0);
-
 				if (cur->mob->IsEncounter()) {
 					parse->EventEncounter(
 						EVENT_TIMER,
@@ -100,6 +98,8 @@ void QuestManager::Process() {
 						0,
 						nullptr
 					);
+				} else {
+					parse->EventMob(EVENT_TIMER, cur->mob, nullptr, [&]() { return cur->name; }, 0);
 				}
 
 				//we MUST reset our iterator since the quest could have removed/added any


### PR DESCRIPTION
# Description
- @hgtw noted you cannot use `cur` after the event call and we would need to conditionally perform either the `Encounter` event of the `Mob` event.

## Type of change
- [X] Bug fix

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur