### PR TITLE
[Crash] Fixes a crash when the faction_list db table is empty.

### DIFF
--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -3472,6 +3472,9 @@ bool ZoneDatabase::LoadFactionData()
 	}
 
     auto& fmr_row = faction_max_results.begin();
+	if (fmr_row[0] == nullptr) {
+		return false;
+	}
 
 	max_faction = Strings::ToUnsignedInt(fmr_row[0]);
 	faction_array = new Faction *[max_faction + 1];


### PR DESCRIPTION
# Description

If you have no data in the faction_list table then zone server will crash on startup because the query for max # of rows returns null instead of zero when there's no entries in the table. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

I've tested before and after the change.  It no longer crashes.

Clients tested: 

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
