### PR TITLE
[BugFix] Fix a display error regarding a few trader/buyer query errors.

### DIFF
--- a/common/repositories/buyer_buy_lines_repository.h
+++ b/common/repositories/buyer_buy_lines_repository.h
@@ -236,6 +236,10 @@ public:
 				)
 			);
 
+			if (buyers.empty()) {
+				return all_entries;
+			}
+
 			std::vector<std::string> char_ids{};
 			for (auto const &bl : buyers) {
 				char_ids.push_back((std::to_string(bl.char_id)));

--- a/common/repositories/buyer_repository.h
+++ b/common/repositories/buyer_repository.h
@@ -120,6 +120,10 @@ public:
 			}
 
 			DeleteWhere(db, fmt::format("`char_id` = '{}';", char_id));
+			if (buy_line_ids.empty()) {
+				return false;
+			}
+
 			BaseBuyerBuyLinesRepository::DeleteWhere(
 				db,
 				fmt::format("`id` IN({})", Strings::Implode(", ", buy_line_ids))

--- a/common/repositories/trader_repository.h
+++ b/common/repositories/trader_repository.h
@@ -217,6 +217,10 @@ public:
 			delete_ids.push_back(std::to_string(e.id));
 		}
 
+		if (delete_ids.empty()) {
+			return 0;
+		}
+
 		return DeleteWhere(db, fmt::format("`id` IN({})", Strings::Implode(",", delete_ids)));
 	}
 };


### PR DESCRIPTION
# Description

There were a few places where a query error would be displayed when a vector was empty.  This did not impact functionality, though was causing display errors.

Fixes # (issue)
An example was doing a /barter search with 'Local Barters'.  The zone console would record a query error if there were no active buyers in the players zone:
```[QueryErr] Zone [bazaar] MySQL Error (1064) [You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ')' at line 1] Query [SELECT id, buyer_id, char_id, buy_slot_id, item_id, item_qty, item_price, item_icon, item_name FROM buyer_buy_lines WHERE item_name LIKE "%Amulet of Necropotence%" AND **char_id IN ()** ]```

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
Tested against RoF2

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
