### PR TITLE
[Bots] Fix timers loading on spawn and zone

### DIFF
--- a/zone/bot_database.cpp
+++ b/zone/bot_database.cpp
@@ -828,7 +828,7 @@ bool BotDatabase::LoadTimers(Bot* b)
 	BotTimer_Struct t{ };
 
 	for (const auto& e : l) {
-		if (t.timer_value < (Timer::GetCurrentTime() + t.recast_time)) {
+		if (e.timer_value < (Timer::GetCurrentTime() + e.recast_time)) {
 			t.timer_id    = e.timer_id;
 			t.timer_value = e.timer_value;
 			t.recast_time = e.recast_time;


### PR DESCRIPTION
# Description

Timers were not properly checking their expiration time on spawn and load and could cause invalid timers to load if the server was restarted resulting in improper lockouts.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Zoning, spawning, server restarts.

Clients tested: 

RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
