### PR TITLE
[Bots] Enable Bot Commands Only if Rule Enabled

### DIFF
--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -40,7 +40,7 @@ extern FastMath g_Math;
 void CatchSignal(int sig_num);
 
 
-int                                                           command_count; // how many commands we have
+int command_count; // how many commands we have
 
 // this is the pointer to the dispatch function, updated once
 // init has been performed to point at the real function
@@ -96,7 +96,7 @@ int command_init(void)
 		command_add("augmentitem", "Force augments an item. Must have the augment item window open.", AccountStatus::GMImpossible, command_augmentitem) ||
 		command_add("ban", "[Character Name] [Reason] - Ban by character name", AccountStatus::GMLeadAdmin, command_ban) ||
 		command_add("bugs", "[Close|Delete|Review|Search|View] - Handles player bug reports", AccountStatus::QuestTroupe, command_bugs) ||
-		command_add("bot", "Type \"#bot help\" or \"^help\" to the see the list of available commands for bots.", AccountStatus::Player, command_bot) ||
+		(RuleB(Bots, Enabled) && command_add("bot", "Type \"#bot help\" or \"^help\" to the see the list of available commands for bots.", AccountStatus::Player, command_bot)) ||
 		command_add("camerashake", "[Duration (Milliseconds)] [Intensity (1-10)] - Shakes the camera on everyone's screen globally.", AccountStatus::QuestTroupe, command_camerashake) ||
 		command_add("castspell", "[Spell ID] [Instant (0 = False, 1 = True, Default is 1 if Unused)] - Cast a spell", AccountStatus::Guide, command_castspell) ||
 		command_add("chat", "[Channel ID] [Message] - Send a channel message to all zones", AccountStatus::GMMgmt, command_chat) ||


### PR DESCRIPTION
# Description
- Disables the `#bot` command if the server does not have the `Bots:Enabled` rule set to `true`.
- This keeps servers that do not use bots from showing this command in `#help`.

## Type of change
- [X] Bug fix

# Testing
![image](https://github.com/user-attachments/assets/41f655a2-25d2-4888-8dc5-db2afee3077b)

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur