### PR TITLE
[Loginserver] Automatifc Opcode File Creation

### DIFF
--- a/common/eqemu_config.cpp
+++ b/common/eqemu_config.cpp
@@ -171,6 +171,7 @@ void EQEmuConfig::parse_config()
 	PluginDir    = _root["server"]["directories"].get("plugins", "plugins/").asString();
 	LuaModuleDir = _root["server"]["directories"].get("lua_modules", "lua_modules/").asString();
 	PatchDir     = _root["server"]["directories"].get("patches", "./").asString();
+	OpcodeDir    = _root["server"]["directories"].get("opcodes", "./").asString();
 	SharedMemDir = _root["server"]["directories"].get("shared_memory", "shared/").asString();
 	LogDir       = _root["server"]["directories"].get("logs", "logs/").asString();
 

--- a/common/eqemu_config.h
+++ b/common/eqemu_config.h
@@ -95,6 +95,7 @@ class EQEmuConfig
 		std::string PluginDir;
 		std::string LuaModuleDir;
 		std::string PatchDir;
+		std::string OpcodeDir;
 		std::string SharedMemDir;
 		std::string LogDir;
 

--- a/common/path_manager.cpp
+++ b/common/path_manager.cpp
@@ -74,6 +74,11 @@ void PathManager::LoadPaths()
 		m_patch_path = fs::relative(fs::path{m_server_path + "/" + c->PatchDir}).string();
 	}
 
+	// patches
+	if (File::Exists(fs::path{ m_server_path + "/" + c->OpcodeDir }.string())) {
+		m_opcode_path = fs::relative(fs::path{ m_server_path + "/" + c->OpcodeDir }).string();
+	}
+
 	// shared_memory_path
 	if (File::Exists(fs::path{m_server_path + "/" + c->SharedMemDir}.string())) {
 		m_shared_memory_path = fs::relative(fs::path{ m_server_path + "/" + c->SharedMemDir }).string();
@@ -89,6 +94,7 @@ void PathManager::LoadPaths()
 	LogInfo("lua_modules path [{}]", m_lua_modules_path);
 	LogInfo("maps path [{}]", m_maps_path);
 	LogInfo("patches path [{}]", m_patch_path);
+	LogInfo("opcode path [{}]", m_opcode_path);
 	LogInfo("plugins path [{}]", m_plugins_path);
 	LogInfo("quests path [{}]", m_quests_path);
 	LogInfo("shared_memory path [{}]", m_shared_memory_path);
@@ -127,6 +133,11 @@ const std::string &PathManager::GetLogPath() const
 const std::string &PathManager::GetPatchPath() const
 {
 	return m_patch_path;
+}
+
+const std::string &PathManager::GetOpcodePath() const
+{
+	return m_opcode_path;
 }
 
 const std::string &PathManager::GetLuaModulesPath() const

--- a/common/path_manager.h
+++ b/common/path_manager.h
@@ -13,6 +13,7 @@ public:
 	[[nodiscard]] const std::string &GetLuaModulesPath() const;
 	[[nodiscard]] const std::string &GetMapsPath() const;
 	[[nodiscard]] const std::string &GetPatchPath() const;
+	[[nodiscard]] const std::string &GetOpcodePath() const;
 	[[nodiscard]] const std::string &GetPluginsPath() const;
 	[[nodiscard]] const std::string &GetQuestsPath() const;
 	[[nodiscard]] const std::string &GetServerPath() const;
@@ -24,6 +25,7 @@ private:
 	std::string m_lua_modules_path;
 	std::string m_maps_path;
 	std::string m_patch_path;
+	std::string m_opcode_path;
 	std::string m_plugins_path;
 	std::string m_quests_path;
 	std::string m_server_path;

--- a/loginserver/client_manager.cpp
+++ b/loginserver/client_manager.cpp
@@ -92,12 +92,8 @@ ClientManager::ClientManager()
 
 	std::string opcodes_path = fmt::format(
 		"{}/{}",
-		path.GetServerPath(),
-		server.config.GetVariableString(
-			"client_configuration",
-			"titanium_opcodes",
-			"login_opcodes.conf"
-		)
+		path.GetOpcodePath(),
+		"login_opcodes.conf"
 	);
 
 	CheckTitaniumOpcodeFile(opcodes_path);
@@ -133,12 +129,8 @@ ClientManager::ClientManager()
 
 	opcodes_path = fmt::format(
 		"{}/{}",
-		path.GetServerPath(),
-		server.config.GetVariableString(
-			"client_configuration",
-			"sod_opcodes",
-			"login_opcodes.conf"
-		)
+		path.GetOpcodePath(),
+		"login_opcodes_sod.conf"
 	);
 
 	CheckSoDOpcodeFile(opcodes_path);
@@ -175,12 +167,8 @@ ClientManager::ClientManager()
 
 	opcodes_path = fmt::format(
 		"{}/{}",
-		path.GetServerPath(),
-		server.config.GetVariableString(
-			"client_configuration",
-			"larion_opcodes",
-			"login_opcodes.conf"
-		)
+		path.GetOpcodePath(),
+		"login_opcodes_larion.conf"
 	);
 
 	CheckLarionOpcodeFile(opcodes_path);

--- a/loginserver/client_manager.cpp
+++ b/loginserver/client_manager.cpp
@@ -7,6 +7,79 @@ extern bool        run_server;
 #include "../common/eqemu_logsys.h"
 #include "../common/misc.h"
 #include "../common/path_manager.h"
+#include "../common/file.h"
+
+void CheckTitaniumOpcodeFile(const std::string &path) {
+	if (File::Exists(path)) {
+		return;
+	}
+
+	auto f = fopen(path.c_str(), "w");
+	if (f) {
+		fprintf(f, "#EQEmu Public Login Server OPCodes\n");
+		fprintf(f, "OP_SessionReady=0x0001\n");
+		fprintf(f, "OP_Login=0x0002\n");
+		fprintf(f, "OP_ServerListRequest=0x0004\n");
+		fprintf(f, "OP_PlayEverquestRequest=0x000d\n");
+		fprintf(f, "OP_PlayEverquestResponse=0x0021\n");
+		fprintf(f, "OP_ChatMessage=0x0016\n");
+		fprintf(f, "OP_LoginAccepted=0x0017\n");
+		fprintf(f, "OP_ServerListResponse=0x0018\n");
+		fprintf(f, "OP_Poll=0x0029\n");
+		fprintf(f, "OP_EnterChat=0x000f\n");
+		fprintf(f, "OP_PollResponse=0x0011\n");
+		fclose(f);
+	}
+}
+
+void CheckSoDOpcodeFile(const std::string& path) {
+	if (File::Exists(path)) {
+		return;
+	}
+
+	auto f = fopen(path.c_str(), "w");
+	if (f) {
+		fprintf(f, "#EQEmu Public Login Server OPCodes\n");
+		fprintf(f, "OP_SessionReady=0x0001\n");
+		fprintf(f, "OP_Login=0x0002\n");
+		fprintf(f, "OP_ServerListRequest=0x0004\n");
+		fprintf(f, "OP_PlayEverquestRequest=0x000d\n");
+		fprintf(f, "OP_PlayEverquestResponse=0x0022\n");
+		fprintf(f, "OP_ChatMessage=0x0017\n");
+		fprintf(f, "OP_LoginAccepted=0x0018\n");
+		fprintf(f, "OP_ServerListResponse=0x0019\n");
+		fprintf(f, "OP_Poll=0x0029\n");
+		fprintf(f, "OP_LoginExpansionPacketData=0x0031\n");
+		fprintf(f, "OP_EnterChat=0x000f\n");
+		fprintf(f, "OP_PollResponse=0x0011\n");
+		fclose(f);
+	}
+}
+
+void CheckLarionOpcodeFile(const std::string& path) {
+	if (File::Exists(path)) {
+		return;
+	}
+
+	auto f = fopen(path.c_str(), "w");
+	if (f) {
+		fprintf(f, "#EQEmu Public Login Server OPCodes\n");
+		fprintf(f, "OP_SessionReady=0x0001\n");
+		fprintf(f, "OP_Login=0x0002\n");
+		fprintf(f, "OP_ServerListRequest=0x0004\n");
+		fprintf(f, "OP_PlayEverquestRequest=0x000d\n");
+		fprintf(f, "OP_PlayEverquestResponse=0x0022\n");
+		fprintf(f, "OP_ChatMessage=0x0017\n");
+		fprintf(f, "OP_LoginAccepted=0x0018\n");
+		fprintf(f, "OP_ServerListResponse=0x0019\n");
+		fprintf(f, "OP_Poll=0x0029\n");
+		fprintf(f, "OP_EnterChat=0x000f\n");
+		fprintf(f, "OP_PollResponse=0x0011\n");
+		fprintf(f, "OP_SystemFingerprint=0x0016\n");
+		fprintf(f, "OP_ExpansionList=0x0030\n");
+		fclose(f);
+	}
+}
 
 ClientManager::ClientManager()
 {
@@ -26,6 +99,8 @@ ClientManager::ClientManager()
 			"login_opcodes.conf"
 		)
 	);
+
+	CheckTitaniumOpcodeFile(opcodes_path);
 
 	if (!titanium_ops->LoadOpcodes(opcodes_path.c_str())) {
 		LogError(
@@ -66,6 +141,8 @@ ClientManager::ClientManager()
 		)
 	);
 
+	CheckSoDOpcodeFile(opcodes_path);
+
 	if (!sod_ops->LoadOpcodes(opcodes_path.c_str())) {
 		LogError(
 			"ClientManager fatal error: couldn't load opcodes for SoD file {0}",
@@ -105,6 +182,8 @@ ClientManager::ClientManager()
 			"login_opcodes.conf"
 		)
 	);
+
+	CheckLarionOpcodeFile(opcodes_path);
 
 	if (!larion_ops->LoadOpcodes(opcodes_path.c_str())) {
 		LogError(


### PR DESCRIPTION
# Description

- Login will auto create opcode files if they don't exist for loading.
- Login will now use the path manager for this config.

Hopefully this will reduce support requests related to the larion work ongoing.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

Not really a bug fix but more a QoL fix to reduce support requests.

# Testing

Tested by deleting login_opcodes.conf, login_opcodes_sod.conf and login_opcodes_larion.conf from my assets/opcodes folder.  Rerunning login auto-created copies that contained the same contents.

Clients tested:  This is not an issue that affected clients but instead server startup.

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

