### PR TITLE
[Bug Fix] Add Missing Lua Registers

### DIFF
--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -6772,7 +6772,6 @@ luabind::scope lua_register_random() {
 		)];
 }
 
-
 luabind::scope lua_register_events() {
 	return luabind::class_<Events>("Event")
 		.enum_("constants")
@@ -8007,7 +8006,6 @@ luabind::scope lua_register_journal_mode() {
 			luabind::value("Log2", static_cast<int>(Journal::Mode::Log2))
 		)];
 }
-
 
 luabind::scope lua_register_exp_source() {
 	return luabind::class_<ExpSource>("ExpSource")

--- a/zone/lua_general.h
+++ b/zone/lua_general.h
@@ -21,8 +21,10 @@ luabind::scope lua_register_rules_const();
 luabind::scope lua_register_rulei();
 luabind::scope lua_register_ruler();
 luabind::scope lua_register_ruleb();
+luabind::scope lua_register_rules();
 luabind::scope lua_register_journal_speakmode();
 luabind::scope lua_register_journal_mode();
+luabind::scope lua_register_exp_source();
 
 #endif
 #endif

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -1312,11 +1312,13 @@ void LuaParser::MapFunctions(lua_State *L) {
 			lua_register_rulei(),
 			lua_register_ruler(),
 			lua_register_ruleb(),
+			lua_register_rules(),
 			lua_register_journal_speakmode(),
 			lua_register_journal_mode(),
 			lua_register_expedition(),
 			lua_register_expedition_lock_messages(),
-			lua_register_buff()
+			lua_register_buff(),
+			lua_register_exp_source()
 		)];
 
 	} catch(std::exception &ex) {


### PR DESCRIPTION
# Description
- These registers were missing from `LuaParser::MapFunctions` and `lua_general.h`, meaning they did not function.

## Type of change
- [X] Bug fix

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur