### PR TITLE
[Rule] Add Rule for restricting client versions to world server

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -339,6 +339,7 @@ RULE_STRING(World, MOTD, "", "Server MOTD sent on login, change from empty to ha
 RULE_STRING(World, Rules, "", "Server Rules, change from empty to have this be used instead of variables table 'rules' value, lines are pipe (|) separated, example: A|B|C")
 RULE_BOOL(World, EnableAutoLogin, false, "Enables or disables auto login of characters, allowing people to log characters in directly from loginserver to ingame")
 RULE_BOOL(World, EnablePVPRegions, true, "Enables or disables PVP Regions automatically setting your PVP flag")
+RULE_STRING(World, SupportedClients, "", "Comma-delimited list of clients to restrict to. Supported values are Titanium | SoF | SoD | UF | RoF | RoF2. Example: Titanium,RoF2")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Zone)

--- a/world/client.h
+++ b/world/client.h
@@ -121,7 +121,6 @@ private:
 	bool CanTradeFVNoDropItem();
 	void RecordPossibleHack(const std::string& message);
 	void SendUnsupportedClientPacket(const std::string& message);
-
 };
 
 bool CheckCharCreateInfoSoF(CharCreate_Struct *cc);

--- a/world/client.h
+++ b/world/client.h
@@ -120,6 +120,8 @@ private:
 	EQStreamInterface* eqs;
 	bool CanTradeFVNoDropItem();
 	void RecordPossibleHack(const std::string& message);
+	void SendUnsupportedClientPacket(const std::string& message);
+
 };
 
 bool CheckCharCreateInfoSoF(CharCreate_Struct *cc);


### PR DESCRIPTION
# Description

It's a common scenario for custom servers to implicitly restrict clients they support for various reasons (mainly supporting custom files/content which locks them into a certain version). Currently there's nothing preventing users from logging into that server from another client, resulting in a mismatch in expected behavior for what the server is trying to achieve. Since indications and functionality from a custom file perspective can only be presented or applied if the correct version and patch is installed for a custom server, it's a cart before the horse situation where the user won't know they're using the wrong client until there is undefined behavior.

This change adds a new rule option to restrict clients to a comma-separated list (default empty string, which is no restriction, i.e. no changes until someone opts in to use this). If the client's version doesn't fit into the list, they're presented with a dummy character on char select with no option to create another characters or log in but present the list of supported clients.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# Testing

Attach images and describe testing done to validate functionality.
Validated between two clients. I set the rule value to Titanium,Underfoot. Here is the result logging in with RoF2 and attempt to log in via button:

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/ed327172-54e8-4c4e-a6c7-8f5edb743874">

And with the same rule logging in with Titanium:

<img width="1510" alt="image" src="https://github.com/user-attachments/assets/f102e78a-1096-4ee4-b81d-037f0901a94c">

Changing the rule to RoF2 and logging in with Titanium:

<img width="1508" alt="image" src="https://github.com/user-attachments/assets/2cd964b2-d1b1-4c28-9622-7d6ce8ae327e">

Clients tested: 
RoF2
Titanium

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [ ] I have made corresponding changes to the documentation (if applicable, if not delete this line) -- Makes sense to update documentation after PRs are approved?
- [X] I own the changes of my code and take responsibility for the potential issues that occur
