### PR TITLE
[Feature] Focus Skill Attack Spells

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -518,6 +518,7 @@ RULE_BOOL(Spells, SnareOverridesSpeedBonuses, false, "Enabling will allow snares
 RULE_INT(Spells, TargetedAOEMaxTargets, 4, "Max number of targets a Targeted AOE spell can cast on. Set to 0 for no limit.")
 RULE_INT(Spells, PointBlankAOEMaxTargets, 0, "Max number of targets a Point-Blank AOE spell can cast on. Set to 0 for no limit.")
 RULE_INT(Spells, DefaultAOEMaxTargets, 0, "Max number of targets that an AOE spell which does not meet other descriptions can cast on. Set to 0 for no limit.")
+RULE_BOOL(Spells, AllowFocusOnSkillDamageSpells, false, "Allow focus effects 185, 459, and 482 to enhance SkillAttack spell effect 193")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Combat)

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -2419,7 +2419,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				int16 dmg_mod = ((RuleB(Spells, AllowFocusOnSkillDamageSpells)) ? caster->GetMeleeDamageMod_SE(spells[spell_id].skill) : 0);
 
 				switch(spells[spell_id].skill) {
-				case EQ::skills::SkillThrowing:					
+				case EQ::skills::SkillThrowing:
 					caster->DoThrowingAttackDmg(this, nullptr, nullptr, spells[spell_id].base_value[i],spells[spell_id].limit_value[i], dmg_mod, ReuseTime, 0, 0, 4.0f, true);
 					break;
 				case EQ::skills::SkillArchery:

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -2416,15 +2416,17 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					break;
 				}
 
+				int16 dmg_mod = ((RuleB(Spells, AllowFocusOnSkillDamageSpells)) ? caster->GetMeleeDamageMod_SE(spells[spell_id].skill) : 0);
+
 				switch(spells[spell_id].skill) {
-				case EQ::skills::SkillThrowing:
-					caster->DoThrowingAttackDmg(this, nullptr, nullptr, spells[spell_id].base_value[i],spells[spell_id].limit_value[i], 0, ReuseTime, 0, 0, 4.0f, true);
+				case EQ::skills::SkillThrowing:					
+					caster->DoThrowingAttackDmg(this, nullptr, nullptr, spells[spell_id].base_value[i],spells[spell_id].limit_value[i], dmg_mod, ReuseTime, 0, 0, 4.0f, true);
 					break;
 				case EQ::skills::SkillArchery:
-					caster->DoArcheryAttackDmg(this, nullptr, nullptr, spells[spell_id].base_value[i],spells[spell_id].limit_value[i], 0, ReuseTime, 0, 0, nullptr, 0, 4.0f, true);
+					caster->DoArcheryAttackDmg(this, nullptr, nullptr, spells[spell_id].base_value[i],spells[spell_id].limit_value[i], dmg_mod, ReuseTime, 0, 0, nullptr, 0, 4.0f, true);
 					break;
 				default:
-					caster->DoMeleeSkillAttackDmg(this, spells[spell_id].base_value[i], spells[spell_id].skill, spells[spell_id].limit_value[i], 0, false, ReuseTime);
+					caster->DoMeleeSkillAttackDmg(this, spells[spell_id].base_value[i], spells[spell_id].skill, spells[spell_id].limit_value[i], dmg_mod, false, ReuseTime);
 					break;
 				}
 				break;

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -2416,18 +2416,18 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					break;
 				}
 
-				int16 dmg_mod = ((RuleB(Spells, AllowFocusOnSkillDamageSpells)) ? caster->GetMeleeDamageMod_SE(spells[spell_id].skill) : 0);
+				int16 focus = RuleB(Spells, AllowFocusOnSkillDamageSpells) ? caster->GetMeleeDamageMod_SE(spells[spell_id].skill) : 0;
 
 				switch(spells[spell_id].skill) {
-				case EQ::skills::SkillThrowing:
-					caster->DoThrowingAttackDmg(this, nullptr, nullptr, spells[spell_id].base_value[i],spells[spell_id].limit_value[i], dmg_mod, ReuseTime, 0, 0, 4.0f, true);
-					break;
-				case EQ::skills::SkillArchery:
-					caster->DoArcheryAttackDmg(this, nullptr, nullptr, spells[spell_id].base_value[i],spells[spell_id].limit_value[i], dmg_mod, ReuseTime, 0, 0, nullptr, 0, 4.0f, true);
-					break;
-				default:
-					caster->DoMeleeSkillAttackDmg(this, spells[spell_id].base_value[i], spells[spell_id].skill, spells[spell_id].limit_value[i], dmg_mod, false, ReuseTime);
-					break;
+					case EQ::skills::SkillThrowing:
+						caster->DoThrowingAttackDmg(this, nullptr, nullptr, spells[spell_id].base_value[i],spells[spell_id].limit_value[i], focus, ReuseTime, 0, 0, 4.0f, true);
+						break;
+					case EQ::skills::SkillArchery:
+						caster->DoArcheryAttackDmg(this, nullptr, nullptr, spells[spell_id].base_value[i],spells[spell_id].limit_value[i], focus, ReuseTime, 0, 0, nullptr, 0, 4.0f, true);
+						break;
+					default:
+						caster->DoMeleeSkillAttackDmg(this, spells[spell_id].base_value[i], spells[spell_id].skill, spells[spell_id].limit_value[i], focus, false, ReuseTime);
+						break;
 				}
 				break;
 			}


### PR DESCRIPTION
# Description

* Currently, focus mods defaults to 0 when processing spell effect 193.
* The default value for this rule is false.
* When false, the rule will retain the current default behavior.
* When true, the aforementioned focus effects will allow focus effects (185, 459, and 482) to modify spell effect 193.

# Example  

Currently, Ancient: Chaos Strike does not modify the damage dealt by the spell, Battery.
If this new rule, Spells:AllowFocusOnSkillDamageSpells, is set to true, Ancient: Chaos Strike WILL modify the damage dealt by the spell, Battery.

Fixes # (issue)

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# Testing

Attach images and describe testing done to validate functionality.

Clients tested: 

ROF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur