### PR TITLE
[Code] Update perlbind to 1.1.0

### DIFF
--- a/libs/perlbind/include/perlbind/scalar.h
+++ b/libs/perlbind/include/perlbind/scalar.h
@@ -251,4 +251,6 @@ private:
   scalar m_value;
 };
 
+using ref = reference;
+
 } // namespace perlbind

--- a/libs/perlbind/include/perlbind/stack_push.h
+++ b/libs/perlbind/include/perlbind/stack_push.h
@@ -28,8 +28,8 @@ struct pusher
     ++m_pushed;
   }
   void push(const std::string& value) { mPUSHp(value.c_str(), value.size()); ++m_pushed; }
-  void push(scalar value) { mPUSHs(value.release()); ++m_pushed; };
-  void push(reference value) { mPUSHs(value.release()); ++m_pushed; };
+  void push(scalar value) { mPUSHs(value.release()); ++m_pushed; }
+  void push(reference value) { mPUSHs(value.release()); ++m_pushed; }
 
   void push(array value)
   {
@@ -38,7 +38,8 @@ struct pusher
     for (int i = 0; i < count; ++i)
     {
       // mortalizes one reference to array element to avoid copying
-      PUSHs(sv_2mortal(SvREFCNT_inc(value[i].sv())));
+      SV** sv = av_fetch(static_cast<AV*>(value), i, true);
+      mPUSHs(SvREFCNT_inc(*sv));
     }
     m_pushed += count;
   }

--- a/libs/perlbind/include/perlbind/stack_read.h
+++ b/libs/perlbind/include/perlbind/stack_read.h
@@ -242,7 +242,7 @@ struct read_as<hash>
   static bool check(PerlInterpreter* my_perl, int i, int ax, int items)
   {
     int remaining = items - i;
-    return remaining > 0 && remaining % 2 == 0 && SvTYPE(ST(i)) == SVt_PV;
+    return remaining > 0 && remaining % 2 == 0 && SvTYPE(ST(i)) < SVt_PVAV;
   }
 
   static hash get(PerlInterpreter* my_perl, int i, int ax, int items)

--- a/libs/perlbind/include/perlbind/version.h
+++ b/libs/perlbind/include/perlbind/version.h
@@ -1,7 +1,7 @@
 #pragma once
 
 constexpr int perlbind_version_major = 1;
-constexpr int perlbind_version_minor = 0;
+constexpr int perlbind_version_minor = 1;
 constexpr int perlbind_version_patch = 0;
 
 constexpr int perlbind_version()


### PR DESCRIPTION
# Description

This makes some minor changes that shouldn't affect functionality

- Adds a perl::ref alias for perl::reference

- Optimizes array return pushes by accessing SV* values directly instead of using operator[] scalar_proxy

- Allows functions with a perl::hash parameter to accept hashes with any scalar key type instead of requiring explicit string keys

  e.g., foo(123 => 1) will now work on functions accepting a perl::hash

# Checklist

- [ ] I have tested my changes
- [ ] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [ ] I have made corresponding changes to the documentation (if applicable, if not delete this line)
- [ ] I own the changes of my code and take responsibility for the potential issues that occur
- [ ] If my changes make database schema changes, I have tested the changes on a local database (attach image). Updated version.h CURRENT_BINARY_DATABASE_VERSION to the new version. (Delete this if not applicable)
