### PR TITLE
[Bug Fix] Bazaar two edge case issues resolved

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -2731,6 +2731,14 @@ void Client::Handle_OP_AltCurrencyReclaim(const EQApplicationPacket *app)
 		return;
 	}
 
+	if (IsTrader()) {
+		TraderEndTrader();
+	}
+
+	if (IsBuyer()) {
+		ToggleBuyerMode(false);
+	}
+
 	/* Item to Currency Storage */
 	if (reclaim->reclaim_flag == 1) {
 		uint32 removed = NukeItem(item_id, invWhereWorn | invWherePersonal | invWhereCursor);

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -3497,7 +3497,7 @@ void Client::BuyTraderItemOutsideBazaar(TraderBuy_Struct *tbs, const EQApplicati
 	ps.item_slot = parcel_out.slot_id;
 	strn0cpy(ps.send_to, GetCleanName(), sizeof(ps.send_to));
 
-	if (trader_item.item_charges <= static_cast<int32>(tbs->quantity)) {
+	if (trader_item.item_charges <= static_cast<int32>(tbs->quantity) || !buy_item->IsStackable()) {
 		TraderRepository::DeleteOne(database, trader_item.id);
 	} else {
 		TraderRepository::UpdateQuantity(


### PR DESCRIPTION
This update resolves two bazaar issues that have been recently reported.

- If parcel delivery is used to purchase an item, and the seller has several of the same items, that have various charges, the item would not be removed from the db.  This allowed for incorrect purchases.

- If a player 'reclaims' an alt currency item that they also have for sale on their active trader,  the item would remain for sale even though it had been reclaimed.  This impacted custom alt currency items that were no trade.

Fixes # (issue)
Issue was reported by THJ.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
Tested with RoF2 using item id 14172 5 Dose Potion of Wolves Blood x3 and 14730 Circlet of Shadow.

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
