### PR TITLE
[Performance] Improvements to ScanCloseMobs logic

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -1578,7 +1578,10 @@ bool Bot::Process()
 		return false;
 	}
 
-	ScanCloseMobProcess();
+	if (m_scan_close_mobs_timer.Check()) {
+		entity_list.ScanCloseMobs(this);
+	}
+
 	SpellProcess();
 
 	if (tic_timer.Check()) {

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -5013,7 +5013,11 @@ void Client::Handle_OP_ClientUpdate(const EQApplicationPacket *app) {
 	SetMoving(!(cy == m_Position.y && cx == m_Position.x));
 
 	CheckClientToNpcAggroTimer();
-	CheckScanCloseMobsMovingTimer();
+
+	if (m_mob_check_moving_timer.Check()) {
+		CheckScanCloseMobsMovingTimer();
+	}
+
 	CheckSendBulkClientPositionUpdate();
 
 	int32 new_animation = ppu->animation;

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -281,7 +281,9 @@ bool Client::Process() {
 			}
 		}
 
-		ScanCloseMobProcess();
+		if (m_scan_close_mobs_timer.Check()) {
+			entity_list.ScanCloseMobs(this);
+		}
 
 		if (RuleB(Inventory, LazyLoadBank)) {
 			// poll once a second to see if we are close to a banker and we haven't loaded the bank yet

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -2957,9 +2957,10 @@ void EntityList::ScanCloseMobs(Mob *scanning_mob)
 
 		float distance = DistanceSquared(scanning_mob->GetPosition(), mob->GetPosition());
 		if (distance <= scan_range || mob->GetAggroRange() >= scan_range) {
-			// Avoid duplicates in mob->m_close_mobs by using emplace directly
+			// add ourselves to other mobs close list
 			mob->m_close_mobs.emplace(scanning_mob->GetID(), scanning_mob);
 
+			// add to self, so we can keep track of who is close to us
 			scanning_mob->m_close_mobs.emplace(std::pair<uint16, Mob *>(mob->GetID(), mob));
 		}
 	}

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -2957,28 +2957,15 @@ void EntityList::ScanCloseMobs(Mob *scanning_mob)
 
 		float distance = DistanceSquared(scanning_mob->GetPosition(), mob->GetPosition());
 		if (distance <= scan_range || mob->GetAggroRange() >= scan_range) {
+			// Avoid duplicates in mob->m_close_mobs by using emplace directly
+			mob->m_close_mobs.emplace(scanning_mob->GetID(), scanning_mob);
+
 			scanning_mob->m_close_mobs.emplace(std::pair<uint16, Mob *>(mob->GetID(), mob));
-
-			// add self to other mobs close list
-			if (scanning_mob->GetID() > 0) {
-				bool has_mob = false;
-
-				for (auto &cm: mob->m_close_mobs) {
-					if (scanning_mob->GetID() == cm.first) {
-						has_mob = true;
-						break;
-					}
-				}
-
-				if (!has_mob) {
-					mob->m_close_mobs.insert(std::pair<uint16, Mob *>(scanning_mob->GetID(), scanning_mob));
-				}
-			}
 		}
 	}
 
-	LogAIScanCloseDetail(
-		"[{}] Scanning Close List | list_size [{}] moving [{}]",
+	LogAIScanClose(
+		"[{}] Scanning close list > list_size [{}] moving [{}]",
 		scanning_mob->GetCleanName(),
 		scanning_mob->m_close_mobs.size(),
 		scanning_mob->IsMoving() ? "true" : "false"

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -8586,16 +8586,16 @@ const uint16 scan_close_mobs_timer_idle   = 60000; // 60 seconds
 
 void Mob::CheckScanCloseMobsMovingTimer()
 {
-	LogAIScanCloseDetail(
-		"Mob [{}] {}moving, scan timer [{}]",
-		GetCleanName(),
-		IsMoving() ? "" : "NOT ",
-		m_scan_close_mobs_timer.GetRemainingTime()
-	);
-
 	// If the moving timer triggers, lets see if we are moving or idle to restart the appropriate
 	// dynamic timer
 	if (m_mob_check_moving_timer.Check()) {
+		LogAIScanCloseDetail(
+			"Mob [{}] {}moving, scan timer [{}]",
+			GetCleanName(),
+			IsMoving() ? "" : "NOT ",
+			m_scan_close_mobs_timer.GetRemainingTime()
+		);
+
 		// If the mob is still moving, restart the moving timer
 		if (moving) {
 			if (m_scan_close_mobs_timer.GetRemainingTime() > scan_close_mobs_timer_moving) {

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -8584,40 +8584,30 @@ bool Mob::HasBotAttackFlag(Mob* tar) {
 const uint16 scan_close_mobs_timer_moving = 6000; // 6 seconds
 const uint16 scan_close_mobs_timer_idle   = 60000; // 60 seconds
 
+// If the moving timer triggers, lets see if we are moving or idle to restart the appropriate dynamic timer
 void Mob::CheckScanCloseMobsMovingTimer()
 {
-	// If the moving timer triggers, lets see if we are moving or idle to restart the appropriate
-	// dynamic timer
-	if (m_mob_check_moving_timer.Check()) {
-		LogAIScanCloseDetail(
-			"Mob [{}] {}moving, scan timer [{}]",
-			GetCleanName(),
-			IsMoving() ? "" : "NOT ",
-			m_scan_close_mobs_timer.GetRemainingTime()
-		);
+	LogAIScanCloseDetail(
+		"Mob [{}] {}moving, scan timer [{}]",
+		GetCleanName(),
+		IsMoving() ? "" : "NOT ",
+		m_scan_close_mobs_timer.GetRemainingTime()
+	);
 
-		// If the mob is still moving, restart the moving timer
-		if (moving) {
-			if (m_scan_close_mobs_timer.GetRemainingTime() > scan_close_mobs_timer_moving) {
-				LogAIScanCloseDetail("Mob [{}] Restarting with moving timer", GetCleanName());
-				m_scan_close_mobs_timer.Disable();
-				m_scan_close_mobs_timer.Start(scan_close_mobs_timer_moving);
-				m_scan_close_mobs_timer.Trigger();
-			}
-		}
-		// If the mob is not moving, restart the idle timer
-		else if (m_scan_close_mobs_timer.GetDuration() == scan_close_mobs_timer_moving) {
-			LogAIScanCloseDetail("Mob [{}] Restarting with idle timer", GetCleanName());
+	// If the mob is still moving, restart the moving timer
+	if (moving) {
+		if (m_scan_close_mobs_timer.GetRemainingTime() > scan_close_mobs_timer_moving) {
+			LogAIScanCloseDetail("Mob [{}] Restarting with moving timer", GetCleanName());
 			m_scan_close_mobs_timer.Disable();
-			m_scan_close_mobs_timer.Start(scan_close_mobs_timer_idle);
+			m_scan_close_mobs_timer.Start(scan_close_mobs_timer_moving);
+			m_scan_close_mobs_timer.Trigger();
 		}
 	}
-}
-
-void Mob::ScanCloseMobProcess()
-{
-	if (m_scan_close_mobs_timer.Check()) {
-		entity_list.ScanCloseMobs(this);
+		// If the mob is not moving, restart the idle timer
+	else if (m_scan_close_mobs_timer.GetDuration() == scan_close_mobs_timer_moving) {
+		LogAIScanCloseDetail("Mob [{}] Restarting with idle timer", GetCleanName());
+		m_scan_close_mobs_timer.Disable();
+		m_scan_close_mobs_timer.Start(scan_close_mobs_timer_idle);
 	}
 }
 

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1488,7 +1488,6 @@ public:
 
 	bool IsCloseToBanker();
 
-	void ScanCloseMobProcess();
 	std::unordered_map<uint16, Mob *> &GetCloseMobList(float distance = 0.0f);
 	void CheckScanCloseMobsMovingTimer();
 

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -601,8 +601,13 @@ bool NPC::Process()
 		DepopSwarmPets();
 	}
 
-	ScanCloseMobProcess();
-	CheckScanCloseMobsMovingTimer();
+	if (m_scan_close_mobs_timer.Check()) {
+		entity_list.ScanCloseMobs(this);
+	}
+
+	if (m_mob_check_moving_timer.Check()) {
+		CheckScanCloseMobsMovingTimer();
+	}
 
 	if (hp_regen_per_second > 0 && hp_regen_per_second_timer.Check()) {
 		if (GetHP() < GetMaxHP()) {


### PR DESCRIPTION
# Description

This adds a few improvements to ScanCloseMobs

* Improvements to logging, normal logging should not be so chatty
* Instead of looping we just lean into the function of a map by doing a direct insert which should definitely save on cycles
* Instead of having "Process" functions, we move the timer checks one level up in the stack to avoid branching which will make a substantial difference in unnecessary branching in zones with many entities
* We keep a reserved bank of memory for the map instead of rapidly allocating / de-allocating memory. The mob will now simply re-use the same allocated memory regardless if the list shrinks, heavily saving on cycles and memory thrashing

## Type of change

- [x] Improvement

# Testing

Tested going in and out of other NPC's scan range, functions as expected.

![image](https://github.com/user-attachments/assets/bc571db3-3168-47ff-b54c-1d6103aff6e3)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
