### PR TITLE
[Fix] Fix for mult-instanced bazaar zones

### DIFF
--- a/common/eq_packet_structs.h
+++ b/common/eq_packet_structs.h
@@ -3221,6 +3221,7 @@ struct BuyerMessaging_Struct {
 	char   item_name[64];
 	uint32 slot;
 	uint32 seller_quantity;
+	uint32 purchase_method; // 0 direct merchant, 1 via /barter window
 };
 
 struct BuyerAddBuyertoBarterWindow_Struct {

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -1755,7 +1755,11 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 				return;
 			}
 
-			zoneserver_list.SendPacket(Zones::BAZAAR, pack);
+			auto trader = client_list.FindCLEByCharacterID(in->trader_buy_struct.trader_id);
+			if (trader) {
+				zoneserver_list.SendPacket(trader->zone(), trader->instance(), pack);
+			}
+
 			break;
 		}
 		case ServerOP_BuyerMessaging: {

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -1779,12 +1779,20 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 					break;
 				}
 				case Barter_SellItem: {
-					zoneserver_list.SendPacket(Zones::BAZAAR, pack);
+					auto buyer = client_list.FindCharacter(in->buyer_name);
+					if (buyer) {
+						zoneserver_list.SendPacket(buyer->zone(), buyer->instance(), pack);
+					}
+
 					break;
 				}
 				case Barter_FailedTransaction:
 				case Barter_BuyerTransactionComplete: {
-					zoneserver_list.SendPacket(in->zone_id, pack);
+					auto seller = client_list.FindCharacter(in->seller_name);
+					if (seller) {
+						zoneserver_list.SendPacket(seller->zone(), seller->instance(), pack);
+					}
+
 					break;
 				}
 				default:

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -2606,6 +2606,7 @@ void Client::SellToBuyer(const EQApplicationPacket *app)
 				data->zone_id          = GetZoneID();
 				data->slot             = sell_line.slot;
 				data->seller_quantity  = sell_line.seller_quantity;
+				data->purchase_method  = sell_line.purchase_method;
 				strn0cpy(data->item_name, sell_line.item_name, sizeof(data->item_name));
 				strn0cpy(data->buyer_name, sell_line.buyer_name.c_str(), sizeof(data->buyer_name));
 				strn0cpy(data->seller_name, GetCleanName(), sizeof(data->seller_name));
@@ -4250,6 +4251,14 @@ bool Client::DoBarterSellerChecks(BuyerLineSellItem_Struct &sell_line)
 						 sell_line.item_name
 		);
 		Message(Chat::Red, "The item that you are trying to sell is augmented. Please remove augments first");
+	}
+
+	if (sell_item && !sell_item->IsDroppable()) {
+		seller_error = true;
+		LogTradingDetail("Seller item <red>[{}] is non-tradeable therefore cannot be sold.",
+						 sell_line.item_name
+		);
+		Message(Chat::Red, "The item that you are trying to sell is non-tradeable and therefore cannot be sold.");
 	}
 
 	if (seller_error) {

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -4044,6 +4044,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 					sell_line.buyer_name      = in->buyer_name;
 					sell_line.seller_quantity = in->seller_quantity;
 					sell_line.slot            = in->slot;
+					sell_line.purchase_method = in->purchase_method;
 					strn0cpy(sell_line.item_name, in->item_name, sizeof(sell_line.item_name));
 
 					uint64 total_cost = (uint64) sell_line.item_cost * (uint64) sell_line.seller_quantity;


### PR DESCRIPTION
# Description

With the introduction of zone shards/multi instancing of the bazaar, certain features (namely parcel delivery of purchasing) were not working correctly.  This was due to the inter zone communication for 'out of bazaar' purchases.  The previous system would send the inter zone comms to the first instance of the bazaar, which may or may not be the one holding the player.  This fix sends the inter zone comms to the correct instance. 

Further, a bug was reported with attuned items.  This was also fixed.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
I have tested along with THJ.

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
