### PR TITLE
[Fix] Further refinements for instanced bazaar

### DIFF
--- a/common/repositories/trader_repository.h
+++ b/common/repositories/trader_repository.h
@@ -164,37 +164,35 @@ public:
 		return UpdateOne(db, m);
 	}
 
-	static Trader GetItemBySerialNumber(Database &db, uint32 serial_number)
+	static Trader GetItemBySerialNumber(Database &db, uint32 serial_number, uint32 trader_id)
 	{
 		Trader     e{};
 		const auto trader_item = GetWhere(
 			db,
-			fmt::format("`item_sn` = '{}' LIMIT 1", serial_number)
+			fmt::format("`char_id` = '{}' AND `item_sn` = '{}' LIMIT 1", trader_id, serial_number)
 		);
 
 		if (trader_item.empty()) {
 			return e;
 		}
-		else {
-			return trader_item.at(0);
-		}
+
+		return trader_item.at(0);
 	}
 
-	static Trader GetItemBySerialNumber(Database &db, std::string serial_number)
+	static Trader GetItemBySerialNumber(Database &db, std::string serial_number, uint32 trader_id)
 	{
 		Trader     e{};
 		auto       sn          = Strings::ToUnsignedBigInt(serial_number);
 		const auto trader_item = GetWhere(
 			db,
-			fmt::format("`item_sn` = '{}' LIMIT 1", sn)
+			fmt::format("`char_id` = '{}' AND `item_sn` = '{}' LIMIT 1", trader_id, sn)
 		);
 
 		if (trader_item.empty()) {
 			return e;
 		}
-		else {
-			return trader_item.at(0);
-		}
+
+		return trader_item.at(0);
 	}
 
 	static int UpdateActiveTransaction(Database &db, uint32 id, bool status)

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -3235,7 +3235,10 @@ void Client::SendBulkBazaarTraders()
 
 void Client::DoBazaarInspect(const BazaarInspect_Struct &in)
 {
-	auto items = TraderRepository::GetWhere(database, fmt::format("item_sn = {}", in.serial_number));
+	auto items = TraderRepository::GetWhere(
+		database, fmt::format("`char_id` = '{}' AND `item_sn` = '{}'", in.trader_id, in.serial_number)
+	);
+
 	if (items.empty()) {
 		LogInfo("Failed to find item with serial number [{}]", in.serial_number);
 		return;
@@ -3304,7 +3307,7 @@ std::string Client::DetermineMoneyString(uint64 cp)
 void Client::BuyTraderItemOutsideBazaar(TraderBuy_Struct *tbs, const EQApplicationPacket *app)
 {
 	auto in          = (TraderBuy_Struct *) app->pBuffer;
-	auto trader_item = TraderRepository::GetItemBySerialNumber(database, tbs->serial_number);
+	auto trader_item = TraderRepository::GetItemBySerialNumber(database, tbs->serial_number, tbs->trader_id);
 	if (!trader_item.id) {
 		LogTrading("Attempt to purchase an item outside of the Bazaar trader_id <red>[{}] item serial_number "
 				   "<red>[{}] The Traders data was outdated.",


### PR DESCRIPTION
Further testing of instanced bazaar highlighted additional issues when item serial numbers conflicted across zones.  When this happened, it was possible to;
- inspect an item from within the bazaar search window and show the wrong item
- purchase an item via parcel delivery and see the wrong item delivered

This was caused by a few trader queries that were assuming a single bazaar instance and therefore no serial number conflicts.  

The fix updates those queries to be sensitive to this condition and resolve it.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
The issue was reported by THJ, and was reproduceable with a dev environment.
Testing occurred within the dev environment and the issue was resolved.

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
