### PR TITLE
[Bug Fix] Fix Issue with Perl EVENT_PAYLOAD

### DIFF
--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -1736,7 +1736,7 @@ void PerlembParser::ExportEventVariables(
 		case EVENT_PAYLOAD: {
 			Seperator sep(data);
 			ExportVar(package_name.c_str(), "payload_id", sep.arg[0]);
-			ExportVar(package_name.c_str(), "payload_value", sep.arg[1]);
+			ExportVar(package_name.c_str(), "payload_value", sep.argplus[1]);
 			break;
 		}
 


### PR DESCRIPTION
# Description
- Fixes a bug where if you use spaces in the `$payload_value` it is cut off at the first entry before a space.

## Type of change
- [X] Bug fix

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur