### PR TITLE
[Bug Fix] Fix an edge case with augmented items inside parceled containers

### DIFF
--- a/zone/parcels.cpp
+++ b/zone/parcels.cpp
@@ -406,9 +406,8 @@ void Client::DoParcelSend(const Parcel_Struct *parcel_in)
 
 			std::vector<CharacterParcelsContainersRepository::CharacterParcelsContainers> all_entries{};
 			if (inst->IsNoneEmptyContainer()) {
-				CharacterParcelsContainersRepository::CharacterParcelsContainers cpc{};
-
 				for (auto const &kv: *inst->GetContents()) {
+					CharacterParcelsContainersRepository::CharacterParcelsContainers cpc{};
 					cpc.parcels_id = result.id;
 					cpc.slot_id    = kv.first;
 					cpc.item_id    = kv.second->GetID();


### PR DESCRIPTION
# Description

A bug was reported when sending containers within the parcel system.

There is an edge case that would cause augments to be incorrect when retrieving a container, if the container had a mix of augmented and non-augmented items.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
The bug was reproduceable and then passed the edge case testing.

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
