### PR TITLE
[Bug Fix] Fix Strings::Commify bug with #mystats

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -2048,8 +2048,8 @@ void Mob::SendStatsWindow(Client* c, bool use_window)
 			case 0: {
 				mod2a_name = "Avoidance";
 				mod2b_name = "Combat Effects";
-				mod2a_cap  = Strings::Commify(RuleI(Character, ItemAvoidanceCap));
-				mod2b_cap  = Strings::Commify(RuleI(Character, ItemCombatEffectsCap));
+				mod2a_cap  = RuleI(Character, ItemAvoidanceCap);
+				mod2b_cap  = RuleI(Character, ItemCombatEffectsCap);
 
 				if (IsBot()) {
 					mod2a = Strings::Commify(CastToBot()->GetAvoidance());
@@ -2068,8 +2068,8 @@ void Mob::SendStatsWindow(Client* c, bool use_window)
 			case 1: {
 				mod2a_name = "Accuracy";
 				mod2b_name = "Strikethrough";
-				mod2a_cap  = Strings::Commify(RuleI(Character, ItemAccuracyCap));
-				mod2b_cap  = Strings::Commify(RuleI(Character, ItemStrikethroughCap));
+				mod2a_cap  = RuleI(Character, ItemAccuracyCap);
+				mod2b_cap  = RuleI(Character, ItemStrikethroughCap);
 
 				if (IsBot()) {
 					mod2a = Strings::Commify(CastToBot()->GetAccuracy());
@@ -2088,8 +2088,8 @@ void Mob::SendStatsWindow(Client* c, bool use_window)
 			case 2: {
 				mod2a_name = "Shielding";
 				mod2b_name = "Spell Shielding";
-				mod2a_cap  = Strings::Commify(RuleI(Character, ItemShieldingCap));
-				mod2b_cap  = Strings::Commify(RuleI(Character, ItemSpellShieldingCap));
+				mod2a_cap  = RuleI(Character, ItemShieldingCap);
+				mod2b_cap  = RuleI(Character, ItemSpellShieldingCap);
 
 				if (IsBot()) {
 					mod2a = Strings::Commify(CastToBot()->GetShielding());
@@ -2109,8 +2109,8 @@ void Mob::SendStatsWindow(Client* c, bool use_window)
 			case 3: {
 				mod2a_name = "Stun Resist";
 				mod2b_name = "DOT Shielding";
-				mod2a_cap  = Strings::Commify(RuleI(Character, ItemStunResistCap));
-				mod2b_cap  = Strings::Commify(RuleI(Character, ItemDoTShieldingCap));
+				mod2a_cap  = RuleI(Character, ItemStunResistCap);
+				mod2b_cap  = RuleI(Character, ItemDoTShieldingCap);
 
 				if (IsBot()) {
 					mod2a = Strings::Commify(CastToBot()->GetStunResist());

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -2052,15 +2052,15 @@ void Mob::SendStatsWindow(Client* c, bool use_window)
 				mod2b_cap  = RuleI(Character, ItemCombatEffectsCap);
 
 				if (IsBot()) {
-					mod2a = Strings::Commify(CastToBot()->GetAvoidance());
+					mod2a = CastToBot()->GetAvoidance();
 				} else if (IsClient()) {
-					mod2a = Strings::Commify(CastToClient()->GetAvoidance());
+					mod2a = CastToClient()->GetAvoidance();
 				}
 
 				if (IsBot()) {
-					mod2b = Strings::Commify(CastToBot()->GetCombatEffects());
+					mod2b = CastToBot()->GetCombatEffects();
 				} else if (IsClient()) {
-					mod2b = Strings::Commify(CastToClient()->GetCombatEffects());
+					mod2b = CastToClient()->GetCombatEffects();
 				}
 
 				break;
@@ -2072,15 +2072,15 @@ void Mob::SendStatsWindow(Client* c, bool use_window)
 				mod2b_cap  = RuleI(Character, ItemStrikethroughCap);
 
 				if (IsBot()) {
-					mod2a = Strings::Commify(CastToBot()->GetAccuracy());
+					mod2a = CastToBot()->GetAccuracy();
 				} else if (IsClient()) {
-					mod2a = Strings::Commify(CastToClient()->GetAccuracy());
+					mod2a = CastToClient()->GetAccuracy();
 				}
 
 				if (IsBot()) {
-					mod2b = Strings::Commify(CastToBot()->GetStrikeThrough());
+					mod2b = CastToBot()->GetStrikeThrough();
 				} else if (IsClient()) {
-					mod2b = Strings::Commify(CastToClient()->GetStrikeThrough());
+					mod2b = CastToClient()->GetStrikeThrough();
 				}
 
 				break;
@@ -2092,16 +2092,16 @@ void Mob::SendStatsWindow(Client* c, bool use_window)
 				mod2b_cap  = RuleI(Character, ItemSpellShieldingCap);
 
 				if (IsBot()) {
-					mod2a = Strings::Commify(CastToBot()->GetShielding());
+					mod2a = CastToBot()->GetShielding();
 				} else if (IsClient()) {
-					mod2a = Strings::Commify(CastToClient()->GetShielding());
+					mod2a = CastToClient()->GetShielding();
 				}
 
 
 				if (IsBot()) {
-					mod2b = Strings::Commify(CastToBot()->GetSpellShield());
+					mod2b = CastToBot()->GetSpellShield();
 				} else if (IsClient()) {
-					mod2b = Strings::Commify(CastToClient()->GetSpellShield());
+					mod2b = CastToClient()->GetSpellShield();
 				}
 
 				break;
@@ -2113,15 +2113,15 @@ void Mob::SendStatsWindow(Client* c, bool use_window)
 				mod2b_cap  = RuleI(Character, ItemDoTShieldingCap);
 
 				if (IsBot()) {
-					mod2a = Strings::Commify(CastToBot()->GetStunResist());
+					mod2a = CastToBot()->GetStunResist();
 				} else if (IsClient()) {
-					mod2a = Strings::Commify(CastToClient()->GetStunResist());
+					mod2a = CastToClient()->GetStunResist();
 				}
 
 				if (IsBot()) {
-					mod2b = Strings::Commify(CastToBot()->GetDoTShield());
+					mod2b = CastToBot()->GetDoTShield();
 				} else if (IsClient()) {
-					mod2b = Strings::Commify(CastToClient()->GetDoTShield());
+					mod2b = CastToClient()->GetDoTShield();
 				}
 
 				break;


### PR DESCRIPTION
When using values larger than 1,000, we were calling commify on a string that already had commas. This resulted in the value 1005 looking like 1,,005.

# Description

Please include a summary of the changes and the related issue (Why is this change necessary). Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Attach images and describe testing done to validate functionality.

Clients tested: 

# Checklist

- [ ] I have tested my changes
- [ ] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [ ] I have made corresponding changes to the documentation (if applicable, if not delete this line)
- [ ] I own the changes of my code and take responsibility for the potential issues that occur
- [ ] If my changes make database schema changes, I have tested the changes on a local database (attach image). Updated version.h CURRENT_BINARY_DATABASE_VERSION to the new version. (Delete this if not applicable)
