### PR TITLE
[Code] Fix build with older C++ libraries

### DIFF
--- a/common/mysql_stmt.cpp
+++ b/common/mysql_stmt.cpp
@@ -415,12 +415,26 @@ static uint64_t MakeBits(std::span<const uint8_t> data)
 }
 
 template <typename T>
+concept has_from_chars = requires (const char* first, const char* last, T value)
+{
+	std::from_chars(first, last, value);
+};
+
+template <typename T>
 static T FromString(std::string_view sv)
 {
 	if constexpr (std::is_same_v<T, bool>)
 	{
 		// return false for empty (zero-length) strings
 		return !sv.empty();
+	}
+	else if constexpr (std::is_same_v<T, float> && !has_from_chars<T>)
+	{
+		return std::strtof(std::string(sv).c_str(), nullptr);
+	}
+	else if constexpr (std::is_same_v<T, double> && !has_from_chars<T>)
+	{
+		return std::strtod(std::string(sv).c_str(), nullptr);
 	}
 	else
 	{


### PR DESCRIPTION
This adds a compile time concept to determine if from_chars has floating-point support and uses fallbacks if not.

This is a C++17 feature but support for floats was only added to libstdc++ with GCC 11.1 and LLVM libc++ in 20.0 (unreleased).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I have made corresponding changes to the documentation (if applicable, if not delete this line)
- [x] I own the changes of my code and take responsibility for the potential issues that occur
- [x] If my changes make database schema changes, I have tested the changes on a local database (attach image). Updated version.h CURRENT_BINARY_DATABASE_VERSION to the new version. (Delete this if not applicable)
