### PR TITLE
Update tasks in all zones if invalid zone set

### DIFF
--- a/common/tasks.h
+++ b/common/tasks.h
@@ -83,7 +83,8 @@ struct ActivityInformation {
 		if (zone_ids.empty()) {
 			return true;
 		}
-		bool found_zone = std::find(zone_ids.begin(), zone_ids.end(), zone_id) != zone_ids.end();
+		bool found_zone = std::any_of(zone_ids.begin(), zone_ids.end(),
+			[zone_id](int id) { return id <= 0 || id == zone_id; });
 
 		return found_zone && (zone_version == version || zone_version == -1);
 	}
@@ -100,7 +101,7 @@ struct ActivityInformation {
 			out.WriteInt32(activity_type == TaskActivityType::GiveCash ? 1 : goal_count);
 			out.WriteLengthString(skill_list); // used in SkillOn objective type string, "-1" for none
 			out.WriteLengthString(spell_list); // used in CastOn objective type string, "0" for none
-			out.WriteString(zones);            // used in objective zone column and task select "begins in" (may have multiple, "0" for "unknown zone", empty for "ALL")
+			out.WriteString(zones);            // used in ui zone columns and task select "begins in" (may have multiple, invalid id for "Unknown Zone", empty for "ALL")
 		}
 		else
 		{
@@ -114,7 +115,7 @@ struct ActivityInformation {
 		out.WriteString(description_override);
 
 		if (client_version >= EQ::versions::ClientVersion::RoF) {
-			out.WriteString(zones); // serialized again after description (seems unused)
+			out.WriteString(zones); // target zone version internal id (unused client side)
 		}
 	}
 


### PR DESCRIPTION
This allows task elements to update in any zone when it has an invalid zone id <= 0. This has the same effect as leaving the zones field empty except "Unknown Zone" instead of "ALL" will be shown in task windows.

Note that Titanium shows "ALL" for a zone id of 0 despite it being an invalid zone id. This could be manipulated server side to match newer clients but there isn't much benefit since any other invalid zone id below 0 can be used to do the same.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I have made corresponding changes to the documentation (if applicable, if not delete this line)
- [x] I own the changes of my code and take responsibility for the potential issues that occur
- [x] If my changes make database schema changes, I have tested the changes on a local database (attach image). Updated version.h CURRENT_BINARY_DATABASE_VERSION to the new version. (Delete this if not applicable)
