### PR TITLE
[Config] Fix World TCP Address Configuration Default

### DIFF
--- a/common/eqemu_config.cpp
+++ b/common/eqemu_config.cpp
@@ -94,7 +94,7 @@ void EQEmuConfig::parse_config()
 		auto_database_updates = true;
 	}
 
-	WorldIP      = _root["server"]["world"]["tcp"].get("host", "127.0.0.1").asString();
+	WorldIP      = _root["server"]["world"]["tcp"].get("ip", "127.0.0.1").asString();
 	WorldTCPPort = Strings::ToUnsignedInt(_root["server"]["world"]["tcp"].get("port", "9000").asString());
 
 	TelnetIP      = _root["server"]["world"]["telnet"].get("ip", "127.0.0.1").asString();


### PR DESCRIPTION
# Description

This fixes an issue where World configuration loading was picking the wrong key from the config. As a result, it would default bind to `127.0.0.1` instead of something that is routable beyond the host. For 99.99% of server this is not an issue, but if you need to do horizontal zone sharding you need world TCP to be reachable beyond local host.

https://github.com/Akkadius/eqemu-install-v2/blob/master/eqemu_config_docker.json#L41-L44

```json
{
  "server": {
    "world": {
      "tcp": {
        "ip": "0.0.0.0",
        "port": "9001"
      },
    }
  }
}
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Tested locally and works. Below is an image of two zones from two different servers on Spire. Note the two different zoneserver IP's

![image](https://github.com/user-attachments/assets/ac6a604c-36ee-4565-b671-e2e2c22778e9)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

