### PR TITLE
[Bug Fix] Fix for sending money via Parcel, then changing your mind

### DIFF
--- a/zone/parcels.cpp
+++ b/zone/parcels.cpp
@@ -278,6 +278,19 @@ void Client::DoParcelSend(const Parcel_Struct *parcel_in)
 		return;
 	}
 
+	if (parcel_in->money_flag && parcel_in->item_slot != INVALID_INDEX) {
+		Message(
+			Chat::Yellow,
+			fmt::format(
+				"{} tells you, 'I am confused!  Do you want to send money or an item?'",
+				merchant->GetCleanName()
+			).c_str()
+		);
+		DoParcelCancel();
+		SendParcelAck();
+		return;
+	}
+
 	auto num_of_parcels = GetParcelCount();
 	if (num_of_parcels >= RuleI(Parcel, ParcelMaxItems)) {
 		SendParcelIconStatus();


### PR DESCRIPTION
If you attempt to send money via a parcel, then change your mind and replace the money with an item, the money would still be sent, in error.  The item would be returned to inventory.

The fix monitors for this situation and cancels the parcel send, returning the money and item to the player's inventory.
A message is also sent to the player informing them to 'try again'.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
The bug was reproduceable and tested ok.

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
