### PR TITLE
[Bug Fix] Players could become flagged as a Trader when they were not trading

### DIFF
--- a/common/servertalk.h
+++ b/common/servertalk.h
@@ -1945,6 +1945,7 @@ struct ServerOP_GuildMessage_Struct {
 struct TraderMessaging_Struct {
 	uint32 action;
 	uint32 zone_id;
+	uint32 instance_id;
 	uint32 trader_id;
 	uint32 entity_id;
 	char   trader_name[64];

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -2913,10 +2913,11 @@ void Client::SendBecomeTraderToWorld(Client *trader, BazaarTraderBarterActions a
 	auto outapp = new ServerPacket(ServerOP_TraderMessaging, sizeof(TraderMessaging_Struct));
 	auto data   = (TraderMessaging_Struct *) outapp->pBuffer;
 
-	data->action    = action;
-	data->entity_id = trader->GetID();
-	data->trader_id = trader->CharacterID();
-	data->zone_id   = trader->GetZoneID();
+	data->action      = action;
+	data->entity_id   = trader->GetID();
+	data->trader_id   = trader->CharacterID();
+	data->zone_id     = trader->GetZoneID();
+	data->instance_id = trader->GetInstanceID();
 	strn0cpy(data->trader_name, trader->GetName(), sizeof(data->trader_name));
 
 	worldserver.SendPacket(outapp);

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -3942,7 +3942,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 					c.second->QueuePacket(outapp);
 					safe_delete(outapp);
 				}
-				if (zone && zone->GetZoneID() == Zones::BAZAAR) {
+				if (zone && zone->GetZoneID() == Zones::BAZAAR && in->instance_id == zone->GetInstanceID()) {
 					if (in->action == TraderOn) {
 						c.second->SendBecomeTrader(TraderOn, in->entity_id);
 					}


### PR DESCRIPTION
A player within a bazaar instance could receive an appearance packet flagging them as a trader if they shared an entity_id with an existing trader in another instance.

This was the result of the BecomeTrader routine not being instance aware.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
Issue was reproduceable and repaired.

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur