### PR TITLE
[Bug Fix] Allow Items in ROF2 to Stack to 32,767

### DIFF
--- a/common/patches/rof2.cpp
+++ b/common/patches/rof2.cpp
@@ -6358,9 +6358,19 @@ namespace RoF2
 		//sprintf(hdr.unknown000, "06e0002Y1W00");
 		strn0cpy(hdr.unknown000, fmt::format("{:016}\0", inst->GetSerialNumber()).c_str(),sizeof(hdr.unknown000));
 
-		hdr.stacksize =
-			item->ID == PARCEL_MONEY_ITEM_ID ? inst->GetPrice() : (inst->IsStackable() ? ((inst->GetCharges() > 1000)
-				? 0xFFFFFFFF : inst->GetCharges()) : 1);
+		hdr.stacksize = (
+			item->ID == PARCEL_MONEY_ITEM_ID ?
+			inst->GetPrice() :
+			(
+				inst->IsStackable() ?
+				(
+					inst->GetCharges() > std::numeric_limits<int16>::max() ?
+					std::numeric_limits<uint32>::max() :
+					inst->GetCharges()
+				) :
+				1
+			)
+		);
 		hdr.unknown004 = 0;
 
 		structs::InventorySlot_Struct slot_id{};

--- a/common/patches/rof2.cpp
+++ b/common/patches/rof2.cpp
@@ -6358,19 +6358,18 @@ namespace RoF2
 		//sprintf(hdr.unknown000, "06e0002Y1W00");
 		strn0cpy(hdr.unknown000, fmt::format("{:016}\0", inst->GetSerialNumber()).c_str(),sizeof(hdr.unknown000));
 
-		hdr.stacksize = (
-			item->ID == PARCEL_MONEY_ITEM_ID ?
-			inst->GetPrice() :
-			(
-				inst->IsStackable() ?
-				(
-					inst->GetCharges() > std::numeric_limits<int16>::max() ?
-					std::numeric_limits<uint32>::max() :
-					inst->GetCharges()
-				) :
-				1
-			)
-		);
+		hdr.stacksize = 1;
+
+		if (item->ID == PARCEL_MONEY_ITEM_ID) {
+			hdr.stacksize = inst->GetPrice();
+		} else if (inst->IsStackable()) {
+			if (inst->GetCharges() > std::numeric_limits<int16>::max()) {
+				hdr.stacksize = std::numeric_limits<uint32>::max();
+			} else {
+				hdr.stacksize = inst->GetCharges();
+			}
+		}
+
 		hdr.unknown004 = 0;
 
 		structs::InventorySlot_Struct slot_id{};


### PR DESCRIPTION
# Description
- ROF2 actually allows items to stack to 32,767 instead of just to 1,000

## Type of change
- [X] New feature

# Testing
![image](https://github.com/user-attachments/assets/fed88a00-0f1d-4aec-b886-e08e956f44f9)

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur