### PR TITLE
[Filesystem] Path Manager Improvements

### DIFF
--- a/common/eqemu_logsys.cpp
+++ b/common/eqemu_logsys.cpp
@@ -25,6 +25,8 @@
 #include "repositories/discord_webhooks_repository.h"
 #include "repositories/logsys_categories_repository.h"
 #include "termcolor/rang.hpp"
+#include "path_manager.h"
+#include "file.h"
 
 #include <iostream>
 #include <string>
@@ -531,6 +533,11 @@ void EQEmuLogSys::CloseFileLogs()
 void EQEmuLogSys::StartFileLogs(const std::string &log_name)
 {
 	EQEmuLogSys::CloseFileLogs();
+
+	if (!File::Exists(path.GetLogPath())) {
+		LogInfo("Logs directory not found, creating [{}]", path.GetLogPath());
+		File::Makedir(path.GetLogPath());
+	}
 
 	/**
 	 * When loading settings, we must have been given a reason in category based logging to output to a file in order to even create or open one...

--- a/common/path_manager.cpp
+++ b/common/path_manager.cpp
@@ -5,16 +5,8 @@
 #include "strings.h"
 
 #include <filesystem>
+
 namespace fs = std::filesystem;
-
-inline std::string striptrailingslash(const std::string &file_path)
-{
-	if (file_path.back() == '/' || file_path.back() == '\\') {
-		return file_path.substr(0, file_path.length() - 1);
-	}
-
-	return file_path;
-}
 
 void PathManager::LoadPaths()
 {
@@ -36,8 +28,8 @@ void PathManager::LoadPaths()
 
 	auto resolve_path = [&](const std::string& dir, const std::vector<std::string>& fallback_dirs = {}) -> std::string {
 		// relative
-		if (File::Exists(fs::path{m_server_path + "/" + dir}.string())) {
-			return fs::relative(fs::path{m_server_path + "/" + dir}).lexically_normal().string();
+		if (File::Exists((fs::path{m_server_path} / dir).string())) {
+			return fs::relative(fs::path{m_server_path} / dir).lexically_normal().string();
 		}
 
 		// absolute
@@ -47,8 +39,8 @@ void PathManager::LoadPaths()
 
 		// fallback search options if specified
 		for (const auto& fallback : fallback_dirs) {
-			if (File::Exists(fs::path{m_server_path + "/" + fallback}.string())) {
-				return fs::relative(fs::path{m_server_path + "/" + fallback}).lexically_normal().string();
+			if (File::Exists((fs::path{m_server_path} / fallback).string())) {
+				return fs::relative(fs::path{m_server_path} / fallback).lexically_normal().string();
 			}
 		}
 

--- a/common/path_manager.cpp
+++ b/common/path_manager.cpp
@@ -34,7 +34,7 @@ void PathManager::LoadPaths()
 
 	const auto c = EQEmuConfig::get();
 
-	auto resolve_path = [&](const std::string& dir, const std::vector<std::string>& fallbackDirs = {}) -> std::string {
+	auto resolve_path = [&](const std::string& dir, const std::vector<std::string>& fallback_dirs = {}) -> std::string {
 		// relative
 		if (File::Exists(fs::path{m_server_path + "/" + dir}.string())) {
 			return fs::relative(fs::path{m_server_path + "/" + dir}).lexically_normal().string();
@@ -46,13 +46,13 @@ void PathManager::LoadPaths()
 		}
 
 		// fallback search options if specified
-		for (const auto& fallback : fallbackDirs) {
+		for (const auto& fallback : fallback_dirs) {
 			if (File::Exists(fs::path{m_server_path + "/" + fallback}.string())) {
 				return fs::relative(fs::path{m_server_path + "/" + fallback}).lexically_normal().string();
 			}
 		}
 
-		// if all else fails, just set it to th	e config value
+		// if all else fails, just set it to the config value
 		return dir;
 	};
 

--- a/common/path_manager.cpp
+++ b/common/path_manager.cpp
@@ -20,16 +20,12 @@ void PathManager::LoadPaths()
 {
 	m_server_path = File::FindEqemuConfigPath();
 
-	if (!m_server_path.empty()) {
-		std::filesystem::current_path(m_server_path);
-	}
-
 	if (m_server_path.empty()) {
 		LogInfo("Failed to load server path");
 		return;
 	}
 
-	LogInfo("server [{}]", m_server_path);
+	std::filesystem::current_path(m_server_path);
 
 	if (!EQEmuConfig::LoadConfig()) {
 		LogError("Failed to load eqemu config");
@@ -38,66 +34,64 @@ void PathManager::LoadPaths()
 
 	const auto c = EQEmuConfig::get();
 
-	// maps
-	if (File::Exists(fs::path{m_server_path + "/" + c->MapDir}.string())) {
-		m_maps_path = fs::relative(fs::path{m_server_path + "/" + c->MapDir}).string();
-	}
-	else if (File::Exists(fs::path{m_server_path + "/maps"}.string())) {
-		m_maps_path = fs::relative(fs::path{m_server_path + "/maps"}).string();
-	}
-	else if (File::Exists(fs::path{m_server_path + "/Maps"}.string())) {
-		m_maps_path = fs::relative(fs::path{m_server_path + "/Maps"}).string();
-	}
+	auto resolve_path = [&](const std::string& dir, const std::vector<std::string>& fallbackDirs = {}) -> std::string {
+		// relative
+		if (File::Exists(fs::path{m_server_path + "/" + dir}.string())) {
+			return fs::relative(fs::path{m_server_path + "/" + dir}).lexically_normal().string();
+		}
 
-	// quests
-	if (File::Exists(fs::path{m_server_path + "/" + c->QuestDir}.string())) {
-		m_quests_path = fs::relative(fs::path{m_server_path + "/" + c->QuestDir}).string();
-	}
+		// absolute
+		if (File::Exists(fs::path{dir}.string())) {
+			return fs::absolute(fs::path{dir}).string();
+		}
 
-	// plugins
-	if (File::Exists(fs::path{m_server_path + "/" + c->PluginDir}.string())) {
-		m_plugins_path = fs::relative(fs::path{m_server_path + "/" + c->PluginDir}).string();
-	}
+		// fallback search options if specified
+		for (const auto& fallback : fallbackDirs) {
+			if (File::Exists(fs::path{m_server_path + "/" + fallback}.string())) {
+				return fs::relative(fs::path{m_server_path + "/" + fallback}).lexically_normal().string();
+			}
+		}
 
-	// lua_modules
-	if (File::Exists(fs::path{m_server_path + "/" + c->LuaModuleDir}.string())) {
-		m_lua_modules_path = fs::relative(fs::path{m_server_path + "/" + c->LuaModuleDir}).string();
-	}
+		// if all else fails, just set it to th	e config value
+		return dir;
+	};
 
-	// lua mods
-	if (File::Exists(fs::path{ m_server_path + "/mods" }.string())) {
-		m_lua_mods_path = fs::relative(fs::path{ m_server_path + "/mods" }).string();
-	}
+	m_maps_path          = resolve_path(c->MapDir, {"maps", "Maps"});
+	m_quests_path        = resolve_path(c->QuestDir);
+	m_plugins_path       = resolve_path(c->PluginDir);
+	m_lua_modules_path   = resolve_path(c->LuaModuleDir);
+	m_lua_mods_path      = resolve_path("mods");
+	m_patch_path         = resolve_path(c->PatchDir);
+	m_opcode_path        = resolve_path(c->OpcodeDir);
+	m_shared_memory_path = resolve_path(c->SharedMemDir);
+	m_log_path           = resolve_path(c->LogDir, {"logs"});
 
-	// patches
-	if (File::Exists(fs::path{m_server_path + "/" + c->PatchDir}.string())) {
-		m_patch_path = fs::relative(fs::path{m_server_path + "/" + c->PatchDir}).string();
-	}
+	// Log all paths in a loop
+	std::vector<std::pair<std::string, std::string>> paths = {
+		{"server", m_server_path},
+		{"logs", m_log_path},
+		{"lua mods", m_lua_mods_path},
+		{"lua_modules", m_lua_modules_path},
+		{"maps", m_maps_path},
+		{"patches", m_patch_path},
+		{"opcode", m_opcode_path},
+		{"plugins", m_plugins_path},
+		{"quests", m_quests_path},
+		{"shared_memory", m_shared_memory_path}
+	};
 
-	// patches
-	if (File::Exists(fs::path{ m_server_path + "/" + c->OpcodeDir }.string())) {
-		m_opcode_path = fs::relative(fs::path{ m_server_path + "/" + c->OpcodeDir }).string();
-	}
+	constexpr int name_width   = 15;
+	constexpr int path_width   = 0;
+	constexpr int break_length = 70;
 
-	// shared_memory_path
-	if (File::Exists(fs::path{m_server_path + "/" + c->SharedMemDir}.string())) {
-		m_shared_memory_path = fs::relative(fs::path{ m_server_path + "/" + c->SharedMemDir }).string();
+	std::cout << std::endl;
+	LogInfo("{}", Strings::Repeat("-", break_length));
+	for (const auto& [name, in_path] : paths) {
+		if (!in_path.empty()) {
+			LogInfo("{:>{}} > [{:<{}}]", name, name_width, in_path, path_width);
+		}
 	}
-
-	// logging path
-	if (File::Exists(fs::path{m_server_path + "/" + c->LogDir}.string())) {
-		m_log_path = fs::relative(fs::path{m_server_path + "/" + c->LogDir}).string();
-	}
-
-	LogInfo("logs path [{}]", m_log_path);
-	LogInfo("lua mods path [{}]", m_lua_mods_path);
-	LogInfo("lua_modules path [{}]", m_lua_modules_path);
-	LogInfo("maps path [{}]", m_maps_path);
-	LogInfo("patches path [{}]", m_patch_path);
-	LogInfo("opcode path [{}]", m_opcode_path);
-	LogInfo("plugins path [{}]", m_plugins_path);
-	LogInfo("quests path [{}]", m_quests_path);
-	LogInfo("shared_memory path [{}]", m_shared_memory_path);
+	LogInfo("{}", Strings::Repeat("-", break_length));
 }
 
 const std::string &PathManager::GetServerPath() const


### PR DESCRIPTION
# Description

This surfaced from some issues Brainiac was running into when trying to set his server up a certain way and aims to resolve the following scenarios

* Allow for absolute paths to be set by any config parameter
* Make the path resolution logic more resilient to allowing multiple scenarios to exist. Absolute, relative and fallbacks. 
* Create logging directory if it does not exist

Brainiac wants to be able to set absolute paths for most things, our current limited relative-only path loading falls short of being able to do that.

```json
"directories": {
 "maps": "D:\\eqemu-server\\maps",
 "quests": "D:\\eqemu-server\\quests",
 "plugins": "D:\\eqemu-server\\plugins",
 "lua_modules": "D:\\eqemu-server\\lua_modules",
 "patches": "D:\\eqemu-server",
 "opcodes": "D:\\eqemu-server",
 "shared_memory": "D:\\eqemu-server\\shared",
 "logs": "D:\\eqemu-server\\logs"
}
```

**Current Loading Hierarchy**

* Check relative first (what we use for most things today)
* Check absolute second
* Check fallback dirs (eg. Maps, maps - case sensitivity on Linux)
* Use the config value directly if none of the above checks find an existing directory

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Testing

Tested by setting `logs` to a custom absolute path directory

```json
"directories": {
  "logs": "/tmp/eq-logs",
  "patches": "assets/patches/",
  "opcodes": "assets/opcodes/"
}
```

Paths being loaded

```
  Zone |    Info    | LoadPaths ---------------------------------------------------------------------- 
  Zone |    Info    | LoadPaths          server > [/home/eqemu/server] 
  Zone |    Info    | LoadPaths            logs > [/tmp/eq-logs] 
  Zone |    Info    | LoadPaths        lua mods > [mods] 
  Zone |    Info    | LoadPaths     lua_modules > [quests/lua_modules] 
  Zone |    Info    | LoadPaths            maps > [maps] 
  Zone |    Info    | LoadPaths         patches > [assets/patches] 
  Zone |    Info    | LoadPaths          opcode > [assets/opcodes] 
  Zone |    Info    | LoadPaths         plugins > [quests/plugins] 
  Zone |    Info    | LoadPaths          quests > [quests] 
  Zone |    Info    | LoadPaths   shared_memory > [shared] 
  Zone |    Info    | LoadPaths ---------------------------------------------------------------------- 
```

Creating log directory if does not exist

```
  Zone |    Info    | StartFileLogs Logs directory not found, creating [/tmp/eq-logs] 
  Zone |    Info    | StartFileLogs Starting File Log [/tmp/eq-logs/zone/zone_5448.log] 
```

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
