### PR TITLE
[Bug Fix] Fix EVENT_COMBAT on NPC Death

### DIFF
--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -1815,12 +1815,18 @@ void Mob::AI_Event_NoLongerEngaged() {
 	StopNavigation();
 	ClearRampage();
 
-	parse->EventBotMercNPC(EVENT_COMBAT, this, nullptr, [&]() { return "0"; });
-
 	if (IsNPC()) {
 		SetPrimaryAggro(false);
 		SetAssistAggro(false);
-		if (CastToNPC()->GetCombatEvent() && GetHP() > 0) {
+		if (
+			CastToNPC()->GetCombatEvent() &&
+			GetHP() > 0 &&
+			entity_list.GetNPCByID(GetID())
+		) {
+			if (parse->HasQuestSub(GetNPCTypeID(), EVENT_COMBAT)) {
+				parse->EventNPC(EVENT_COMBAT, CastToNPC(), nullptr, "0", 0);
+			}
+
 			const uint32 emote_id = CastToNPC()->GetEmoteID();
 			if (emote_id) {
 				CastToNPC()->DoNPCEmote(EQ::constants::EmoteEventTypes::LeaveCombat, emote_id);
@@ -1829,6 +1835,8 @@ void Mob::AI_Event_NoLongerEngaged() {
 			m_combat_record.Stop();
 			CastToNPC()->SetCombatEvent(false);
 		}
+	} else {
+		parse->EventBotMerc(EVENT_COMBAT, this, nullptr, [&]() { return "0"; });
 	}
 }
 


### PR DESCRIPTION
# Description
- Fixes a bug where `EVENT_COMBAT` fired with `EVENT_DEATH_COMPLETE` because we were not confirming the NPC was still on the entity list before firing the event.
- Bug was introduced in [this](https://github.com/EQEmu/Server/pull/4500/files).

## Type of change
- [X] Bug fix

# Testing
## Before
![image](https://github.com/user-attachments/assets/f4b109d7-091b-43b2-b0fe-64c966037f1b)
## After
![image](https://github.com/user-attachments/assets/f7f8485d-d040-42ca-9a6c-9b4860004a45)

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur