### PR TITLE
[Rules] Add rules for requiring custom files from client

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -342,6 +342,7 @@ RULE_BOOL(World, EnablePVPRegions, true, "Enables or disables PVP Regions automa
 RULE_STRING(World, SupportedClients, "", "Comma-delimited list of clients to restrict to. Supported values are Titanium | SoF | SoD | UF | RoF | RoF2. Example: Titanium,RoF2")
 RULE_STRING(World, CustomFilesKey, "", "Enable if the server requires custom files and sends a key to validate. Empty string to disable. Example: eqcustom_v1")
 RULE_STRING(World, CustomFilesUrl, "github.com/knervous/eqnexus/releases", "URL to display at character select if client is missing custom files")
+RULE_INT(World, CustomFilesAdminLevel, 20, "Admin level at which custom file key is not required when CustomFilesKey is specified")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Zone)

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -341,7 +341,7 @@ RULE_BOOL(World, EnableAutoLogin, false, "Enables or disables auto login of char
 RULE_BOOL(World, EnablePVPRegions, true, "Enables or disables PVP Regions automatically setting your PVP flag")
 RULE_STRING(World, SupportedClients, "", "Comma-delimited list of clients to restrict to. Supported values are Titanium | SoF | SoD | UF | RoF | RoF2. Example: Titanium,RoF2")
 RULE_STRING(World, CustomFilesKey, "", "Enable if the server requires custom files and sends a key to validate. Empty string to disable. Example: eqcustom_v1")
-RULE_STRING(World, CustomFilesUrl, "https://github.com/knervous/eqnexus/releases", "URL to display at character select if client is missing custom files")
+RULE_STRING(World, CustomFilesUrl, "github.com/knervous/eqnexus/releases", "URL to display at character select if client is missing custom files")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Zone)

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -340,6 +340,8 @@ RULE_STRING(World, Rules, "", "Server Rules, change from empty to have this be u
 RULE_BOOL(World, EnableAutoLogin, false, "Enables or disables auto login of characters, allowing people to log characters in directly from loginserver to ingame")
 RULE_BOOL(World, EnablePVPRegions, true, "Enables or disables PVP Regions automatically setting your PVP flag")
 RULE_STRING(World, SupportedClients, "", "Comma-delimited list of clients to restrict to. Supported values are Titanium | SoF | SoD | UF | RoF | RoF2. Example: Titanium,RoF2")
+RULE_STRING(World, CustomFilesKey, "", "Enable if the server requires custom files and sends a key to validate. Empty string to disable. Example: eqcustom_v1")
+RULE_STRING(World, CustomFilesUrl, "https://github.com/knervous/eqnexus/releases", "URL to display at character select if client is missing custom files")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Zone)

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -545,8 +545,8 @@ bool Client::HandleSendLoginInfoPacket(const EQApplicationPacket *app)
 			if (!skip_char_info && !custom_files_key.empty()) {
 				// Modified clients can utilize this unused block in login_info to send custom payloads on login
 				// which indicates they are using custom client files with the correct version, based on key payload.
-				const auto server_name = std::string(reinterpret_cast<char*>(login_info->unknown064));
-				if (custom_files_key != server_name) {
+				const auto client_key = std::string(reinterpret_cast<char*>(login_info->unknown064));
+				if (custom_files_key != client_key) {
 					std::string message = fmt::format("Missing Files [{}]", RuleS(World, CustomFilesUrl) );
 					SendUnsupportedClientPacket(message);
 					skip_char_info = true;

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -542,7 +542,7 @@ bool Client::HandleSendLoginInfoPacket(const EQApplicationPacket *app)
 				}
 			}
 			const auto& custom_files_key = RuleS(World, CustomFilesKey);
-			if (!skip_char_info && !custom_files_key.empty()) {
+			if (!skip_char_info && !custom_files_key.empty() && cle->Admin() < AccountStatus::ApprenticeGuide) {
 				// Modified clients can utilize this unused block in login_info to send custom payloads on login
 				// which indicates they are using custom client files with the correct version, based on key payload.
 				const auto client_key = std::string(reinterpret_cast<char*>(login_info->unknown064));

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -542,7 +542,7 @@ bool Client::HandleSendLoginInfoPacket(const EQApplicationPacket *app)
 				}
 			}
 			const auto& custom_files_key = RuleS(World, CustomFilesKey);
-			if (!skip_char_info && !custom_files_key.empty() && cle->Admin() < AccountStatus::ApprenticeGuide) {
+			if (!skip_char_info && !custom_files_key.empty() && cle->Admin() < RuleI(World, CustomFilesAdminLevel)) {
 				// Modified clients can utilize this unused block in login_info to send custom payloads on login
 				// which indicates they are using custom client files with the correct version, based on key payload.
 				const auto client_key = std::string(reinterpret_cast<char*>(login_info->unknown064));

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -541,6 +541,17 @@ bool Client::HandleSendLoginInfoPacket(const EQApplicationPacket *app)
 					skip_char_info = true;
 				}
 			}
+			const auto& custom_files_key = RuleS(World, CustomFilesKey);
+			if (!skip_char_info && !custom_files_key.empty()) {
+				// Modified clients can utilize this unused block in login_info to send custom payloads on login
+				// which indicates they are using custom client files with the correct version, based on key payload.
+				const auto server_name = std::string(reinterpret_cast<char*>(login_info->unknown064));
+				if (custom_files_key != server_name) {
+					std::string message = fmt::format("Missing Files [{}]", RuleS(World, CustomFilesUrl) );
+					SendUnsupportedClientPacket(message);
+					skip_char_info = true;
+				}
+			}
 
 			if (!skip_char_info) {
 				SendExpansionInfo();


### PR DESCRIPTION
# Description

These rules are for custom servers that require custom files, giving them an option to lock out players that don't have them installed while presenting a URL to download those files and get up to date. This prevents stale patch files and undefined behavior for clients logging in without the appropriate server files.

Here is an example of a custom client binary sending a custom payload:

https://github.com/knervous/eqnexus/blob/main/core/server_options.ixx

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Example of what client sees when logging into a custom server without the correct custom files.

![image](https://github.com/user-attachments/assets/c7fc2054-03ba-4854-9b94-cf5025680a30)


Clients tested: RoF2, Titanium

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
