### PR TITLE
[Groups] Fix AmIMainAssist incorrectly checking for MainTankName

### DIFF
--- a/zone/groups.cpp
+++ b/zone/groups.cpp
@@ -2419,7 +2419,7 @@ bool Group::AmIMainAssist(const char *mob_name)
 	if (!mob_name)
 		return false;
 
-	return !((bool)MainTankName.compare(mob_name));
+	return !((bool)MainAssistName.compare(mob_name));
 }
 
 bool Group::AmIPuller(const char *mob_name)


### PR DESCRIPTION
# Description

Currently unused but AmIMainAssist was checking for MainTank rather than MainAssist


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Clients tested: 

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
