### PR TITLE
[Inventory] Add GetInventorySlots() Method

### DIFF
--- a/common/inventory_profile.cpp
+++ b/common/inventory_profile.cpp
@@ -612,9 +612,9 @@ bool EQ::InventoryProfile::HasAugmentEquippedByID(uint32 item_id)
 	return has_equipped;
 }
 
-int EQ::InventoryProfile::CountAugmentEquippedByID(uint32 item_id)
+uint32 EQ::InventoryProfile::CountAugmentEquippedByID(uint32 item_id)
 {
-	int quantity = 0;
+	uint32 quantity = 0;
 	ItemInstance* item = nullptr;
 
 	for (int slot_id = EQ::invslot::EQUIPMENT_BEGIN; slot_id <= EQ::invslot::EQUIPMENT_END; ++slot_id) {
@@ -643,9 +643,9 @@ bool EQ::InventoryProfile::HasItemEquippedByID(uint32 item_id)
 	return has_equipped;
 }
 
-int EQ::InventoryProfile::CountItemEquippedByID(uint32 item_id)
+uint32 EQ::InventoryProfile::CountItemEquippedByID(uint32 item_id)
 {
-	int quantity = 0;
+	uint32 quantity = 0;
 	ItemInstance* item = nullptr;
 
 	for (int slot_id = EQ::invslot::EQUIPMENT_BEGIN; slot_id <= EQ::invslot::EQUIPMENT_END; ++slot_id) {

--- a/common/inventory_profile.h
+++ b/common/inventory_profile.h
@@ -147,13 +147,13 @@ namespace EQ
 		bool HasItemEquippedByID(uint32 item_id);
 
 		// Check how many of a specific item the player has equipped by Item ID
-		int CountItemEquippedByID(uint32 item_id);
+		uint32 CountItemEquippedByID(uint32 item_id);
 
 		// Check if player has a specific augment equipped by Item ID
 		bool HasAugmentEquippedByID(uint32 item_id);
 
 		// Check how many of a specific augment the player has equipped by Item ID
-		int CountAugmentEquippedByID(uint32 item_id);
+		uint32 CountAugmentEquippedByID(uint32 item_id);
 
 		// Get a list of augments from a specific slot ID
 		std::vector<uint32> GetAugmentIDsBySlotID(int16 slot_id);

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10613,11 +10613,7 @@ void Client::RemoveItem(uint32 item_id, uint32 quantity)
 
 		item = GetInv().GetItem(slot_id);
 		if (item && item->GetID() == item_id) {
-			uint32 charges = (
-				item->IsStackable() ?
-				(item->GetCharges() > 0 ? item->GetCharges() : 1) :
-				1
-			);
+			uint32 charges    = item->IsStackable() ? item->GetCharges() : 0;
 			uint32 stack_size = std::max(charges, static_cast<uint32>(1));
 			if ((removed_count + stack_size) <= quantity) {
 				removed_count += stack_size;
@@ -12810,11 +12806,7 @@ void Client::RemoveItemBySerialNumber(uint32 serial_number, uint32 quantity)
 
 		item = GetInv().GetItem(slot_id);
 		if (item && item->GetSerialNumber() == serial_number) {
-			uint32 charges    = (
-				item->IsStackable() ?
-				(item->GetCharges() > 0 ? item->GetCharges() : 1) :
-				1
-			);
+			uint32 charges    = item->IsStackable() ? item->GetCharges() : 0;
 			uint32 stack_size = std::max(charges, static_cast<uint32>(1));
 			if ((removed_count + stack_size) <= quantity) {
 				removed_count += stack_size;

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10461,27 +10461,17 @@ void Client::SendToInstance(std::string instance_type, std::string zone_short_na
 	MovePC(zone_id, instance_id, x, y, z, heading);
 }
 
-int Client::CountItem(uint32 item_id)
+uint32 Client::CountItem(uint32 item_id)
 {
-	int quantity = 0;
+	uint32 quantity = 0;
 	EQ::ItemInstance *item = nullptr;
-	static const int16 slots[][2] = {
-		{ EQ::invslot::POSSESSIONS_BEGIN, EQ::invslot::POSSESSIONS_END },
-		{ EQ::invbag::GENERAL_BAGS_BEGIN, EQ::invbag::GENERAL_BAGS_END },
-		{ EQ::invbag::CURSOR_BAG_BEGIN, EQ::invbag::CURSOR_BAG_END},
-		{ EQ::invslot::BANK_BEGIN, EQ::invslot::BANK_END },
-		{ EQ::invslot::GUILD_TRIBUTE_BEGIN, EQ::invslot::GUILD_TRIBUTE_END },
-		{ EQ::invbag::BANK_BAGS_BEGIN, EQ::invbag::BANK_BAGS_END },
-		{ EQ::invslot::SHARED_BANK_BEGIN, EQ::invslot::SHARED_BANK_END },
-		{ EQ::invbag::SHARED_BANK_BAGS_BEGIN, EQ::invbag::SHARED_BANK_BAGS_END },
-	};
-	const size_t slot_index_count = sizeof(slots) / sizeof(slots[0]);
-	for (int slot_index = 0; slot_index < slot_index_count; ++slot_index) {
-		for (int slot_id = slots[slot_index][0]; slot_id <= slots[slot_index][1]; ++slot_id) {
-			item = GetInv().GetItem(slot_id);
-			if (item && item->GetID() == item_id) {
-				quantity += (item->IsStackable() ? item->GetCharges() : 1);
-			}
+
+	const auto& slot_ids = GetInventorySlots();
+
+	for (const int16& slot_id : slot_ids) {
+		item = GetInv().GetItem(slot_id);
+		if (item && item->GetID() == item_id) {
+			quantity += (item->IsStackable() ? item->GetCharges() : 1);
 		}
 	}
 
@@ -10498,30 +10488,28 @@ void Client::ResetItemCooldown(uint32 item_id)
 	int recast_type = item_d->RecastType;
 	bool found_item = false;
 
-	static const int16 slots[][2] = {
-		{ EQ::invslot::POSSESSIONS_BEGIN, EQ::invslot::POSSESSIONS_END },
-		{ EQ::invbag::GENERAL_BAGS_BEGIN, EQ::invbag::GENERAL_BAGS_END },
-		{ EQ::invbag::CURSOR_BAG_BEGIN, EQ::invbag::CURSOR_BAG_END},
-		{ EQ::invslot::BANK_BEGIN, EQ::invslot::BANK_END },
-		{ EQ::invbag::BANK_BAGS_BEGIN, EQ::invbag::BANK_BAGS_END },
-		{ EQ::invslot::SHARED_BANK_BEGIN, EQ::invslot::SHARED_BANK_END },
-		{ EQ::invbag::SHARED_BANK_BAGS_BEGIN, EQ::invbag::SHARED_BANK_BAGS_END },
-	};
-	const size_t slot_index_count = sizeof(slots) / sizeof(slots[0]);
-	for (int slot_index = 0; slot_index < slot_index_count; ++slot_index) {
-		for (int slot_id = slots[slot_index][0]; slot_id <= slots[slot_index][1]; ++slot_id) {
-			item = GetInv().GetItem(slot_id);
-			if (item) {
-				item_d = item->GetItem();
-				if (item_d && item->GetID() == item_id || (item_d->RecastType != RECAST_TYPE_UNLINKED_ITEM && item_d->RecastType == recast_type)) {
-					item->SetRecastTimestamp(0);
-					DeleteItemRecastTimer(item_d->ID);
-					SendItemPacket(slot_id, item, ItemPacketCharmUpdate);
-					found_item = true;
-				}
+	const auto& slot_ids = GetInventorySlots();
+
+	for (const int16& slot_id : slot_ids) {
+		item = GetInv().GetItem(slot_id);
+		if (item) {
+			item_d = item->GetItem();
+			if (
+				item_d &&
+				item->GetID() == item_id ||
+				(
+					item_d->RecastType != RECAST_TYPE_UNLINKED_ITEM &&
+					item_d->RecastType == recast_type
+				)
+			) {
+				item->SetRecastTimestamp(0);
+				DeleteItemRecastTimer(item_d->ID);
+				SendItemPacket(slot_id, item, ItemPacketCharmUpdate);
+				found_item = true;
 			}
 		}
 	}
+
 	if (!found_item) {
 		DeleteItemRecastTimer(item_id); //We didn't find the item but we still want to remove the timer
 	}
@@ -10556,25 +10544,22 @@ void Client::SetItemCooldown(uint32 item_id, bool use_saved_timer, uint32 in_sec
 		final_time = total_time - current_time;
 	}
 
-	static const int16 slots[][2] = {
-		{ EQ::invslot::POSSESSIONS_BEGIN, EQ::invslot::POSSESSIONS_END },
-		{ EQ::invbag::GENERAL_BAGS_BEGIN, EQ::invbag::GENERAL_BAGS_END },
-		{ EQ::invbag::CURSOR_BAG_BEGIN, EQ::invbag::CURSOR_BAG_END},
-		{ EQ::invslot::BANK_BEGIN, EQ::invslot::BANK_END },
-		{ EQ::invbag::BANK_BAGS_BEGIN, EQ::invbag::BANK_BAGS_END },
-		{ EQ::invslot::SHARED_BANK_BEGIN, EQ::invslot::SHARED_BANK_END },
-		{ EQ::invbag::SHARED_BANK_BAGS_BEGIN, EQ::invbag::SHARED_BANK_BAGS_END },
-	};
-	const size_t slot_index_count = sizeof(slots) / sizeof(slots[0]);
-	for (int slot_index = 0; slot_index < slot_index_count; ++slot_index) {
-		for (int slot_id = slots[slot_index][0]; slot_id <= slots[slot_index][1]; ++slot_id) {
-			item = GetInv().GetItem(slot_id);
-			if (item) {
-				item_d = item->GetItem();
-				if (item_d && item->GetID() == item_id || (item_d->RecastType != RECAST_TYPE_UNLINKED_ITEM && item_d->RecastType == recast_type)) {
-					item->SetRecastTimestamp(total_time);
-					SendItemPacket(slot_id, item, ItemPacketCharmUpdate);
-				}
+	const auto& slot_ids = GetInventorySlots();
+
+	for (const int16& slot_id : slot_ids) {
+		item = GetInv().GetItem(slot_id);
+		if (item) {
+			item_d = item->GetItem();
+			if (
+				item_d &&
+				item->GetID() == item_id ||
+				(
+					item_d->RecastType != RECAST_TYPE_UNLINKED_ITEM &&
+					item_d->RecastType == recast_type
+				)
+			) {
+				item->SetRecastTimestamp(total_time);
+				SendItemPacket(slot_id, item, ItemPacketCharmUpdate);
 			}
 		}
 	}
@@ -10617,38 +10602,31 @@ uint32 Client::GetItemCooldown(uint32 item_id)
 
 void Client::RemoveItem(uint32 item_id, uint32 quantity)
 {
+	uint32 removed_count = 0;
 	EQ::ItemInstance *item = nullptr;
-	static const int16 slots[][2] = {
-		{ EQ::invslot::POSSESSIONS_BEGIN, EQ::invslot::POSSESSIONS_END },
-		{ EQ::invbag::GENERAL_BAGS_BEGIN, EQ::invbag::GENERAL_BAGS_END },
-		{ EQ::invbag::CURSOR_BAG_BEGIN, EQ::invbag::CURSOR_BAG_END},
-		{ EQ::invslot::BANK_BEGIN, EQ::invslot::BANK_END },
-		{ EQ::invslot::GUILD_TRIBUTE_BEGIN, EQ::invslot::GUILD_TRIBUTE_END },
-		{ EQ::invbag::BANK_BAGS_BEGIN, EQ::invbag::BANK_BAGS_END },
-		{ EQ::invslot::SHARED_BANK_BEGIN, EQ::invslot::SHARED_BANK_END },
-		{ EQ::invbag::SHARED_BANK_BAGS_BEGIN, EQ::invbag::SHARED_BANK_BAGS_END },
-	};
-	int16 removed_count = 0;
-	const size_t slot_index_count = sizeof(slots) / sizeof(slots[0]);
-	for (int slot_index = 0; slot_index < slot_index_count; ++slot_index) {
-		for (int slot_id = slots[slot_index][0]; slot_id <= slots[slot_index][1]; ++slot_id) {
-			if (removed_count == quantity) {
-				break;
-			}
 
-			item = GetInv().GetItem(slot_id);
-			if (item && item->GetID() == item_id) {
-				int16 charges = item->IsStackable() ? item->GetCharges() : 0;
-				int16 stack_size = std::max(charges, static_cast<int16>(1));
-				if ((removed_count + stack_size) <= quantity) {
-					removed_count += stack_size;
-					DeleteItemInInventory(slot_id, charges, true);
-				} else {
-					int16 amount_left = (quantity - removed_count);
-					if (amount_left > 0 && stack_size >= amount_left) {
-						removed_count += amount_left;
-						DeleteItemInInventory(slot_id, amount_left, true);
-					}
+	const auto& slot_ids = GetInventorySlots();
+	for (const int16& slot_id : slot_ids) {
+		if (removed_count == quantity) {
+			break;
+		}
+
+		item = GetInv().GetItem(slot_id);
+		if (item && item->GetID() == item_id) {
+			uint32 charges = (
+				item->IsStackable() ?
+				(item->GetCharges() > 0 ? item->GetCharges() : 1) :
+				1
+			);
+			uint32 stack_size = std::max(charges, static_cast<uint32>(1));
+			if ((removed_count + stack_size) <= quantity) {
+				removed_count += stack_size;
+				DeleteItemInInventory(slot_id, charges, true);
+			} else {
+				uint32 amount_left = (quantity - removed_count);
+				if (amount_left > 0 && stack_size >= amount_left) {
+					removed_count += amount_left;
+					DeleteItemInInventory(slot_id, amount_left, true);
 				}
 			}
 		}
@@ -12820,37 +12798,32 @@ uint16 Client::GetSkill(EQ::skills::SkillType skill_id) const
 void Client::RemoveItemBySerialNumber(uint32 serial_number, uint32 quantity)
 {
 	EQ::ItemInstance *item = nullptr;
-	static const int16 slots[][2] = {
-		{ EQ::invslot::POSSESSIONS_BEGIN, EQ::invslot::POSSESSIONS_END },
-		{ EQ::invbag::GENERAL_BAGS_BEGIN, EQ::invbag::GENERAL_BAGS_END },
-		{ EQ::invbag::CURSOR_BAG_BEGIN, EQ::invbag::CURSOR_BAG_END},
-		{ EQ::invslot::BANK_BEGIN, EQ::invslot::BANK_END },
-		{ EQ::invslot::GUILD_TRIBUTE_BEGIN, EQ::invslot::GUILD_TRIBUTE_END },
-		{ EQ::invbag::BANK_BAGS_BEGIN, EQ::invbag::BANK_BAGS_END },
-		{ EQ::invslot::SHARED_BANK_BEGIN, EQ::invslot::SHARED_BANK_END },
-		{ EQ::invbag::SHARED_BANK_BAGS_BEGIN, EQ::invbag::SHARED_BANK_BAGS_END },
-	};
-	int16 removed_count = 0;
-	const size_t slot_index_count = sizeof(slots) / sizeof(slots[0]);
-	for (int slot_index = 0; slot_index < slot_index_count; ++slot_index) {
-		for (int slot_id = slots[slot_index][0]; slot_id <= slots[slot_index][1]; ++slot_id) {
-			if (removed_count == quantity) {
-				break;
-			}
 
-			item = GetInv().GetItem(slot_id);
-			if (item && item->GetSerialNumber() == serial_number) {
-				int16 charges = item->IsStackable() ? item->GetCharges() : 0;
-				int16 stack_size = std::max(charges, static_cast<int16>(1));
-				if ((removed_count + stack_size) <= quantity) {
-					removed_count += stack_size;
-					DeleteItemInInventory(slot_id, charges, true);
-				} else {
-					int16 amount_left = (quantity - removed_count);
-					if (amount_left > 0 && stack_size >= amount_left) {
-						removed_count += amount_left;
-						DeleteItemInInventory(slot_id, amount_left, true);
-					}
+	uint32 removed_count = 0;
+
+	const auto& slot_ids = GetInventorySlots();
+
+	for (const int16& slot_id : slot_ids) {
+		if (removed_count == quantity) {
+			break;
+		}
+
+		item = GetInv().GetItem(slot_id);
+		if (item && item->GetSerialNumber() == serial_number) {
+			uint32 charges    = (
+				item->IsStackable() ?
+				(item->GetCharges() > 0 ? item->GetCharges() : 1) :
+				1
+			);
+			uint32 stack_size = std::max(charges, static_cast<uint32>(1));
+			if ((removed_count + stack_size) <= quantity) {
+				removed_count += stack_size;
+				DeleteItemInInventory(slot_id, charges, true);
+			} else {
+				uint32 amount_left = (quantity - removed_count);
+				if (amount_left > 0 && stack_size >= amount_left) {
+					removed_count += amount_left;
+					DeleteItemInInventory(slot_id, amount_left, true);
 				}
 			}
 		}
@@ -13074,4 +13047,28 @@ void Client::ClientToNpcAggroProcess()
 		}
 		LogAggro("Checking Reverse Aggro (client->npc) scanned_npcs ([{}])", npc_scan_count);
 	}
+}
+
+const std::vector<int16>& Client::GetInventorySlots()
+{
+	static const int16 slots[][2] = {
+		{ EQ::invslot::POSSESSIONS_BEGIN,     EQ::invslot::POSSESSIONS_END },
+		{ EQ::invbag::GENERAL_BAGS_BEGIN,     EQ::invbag::GENERAL_BAGS_END },
+		{ EQ::invbag::CURSOR_BAG_BEGIN,       EQ::invbag::CURSOR_BAG_END },
+		{ EQ::invslot::BANK_BEGIN,            EQ::invslot::BANK_END },
+		{ EQ::invbag::BANK_BAGS_BEGIN,        EQ::invbag::BANK_BAGS_END },
+		{ EQ::invslot::SHARED_BANK_BEGIN,     EQ::invslot::SHARED_BANK_END },
+		{ EQ::invbag::SHARED_BANK_BAGS_BEGIN, EQ::invbag::SHARED_BANK_BAGS_END },
+	};
+
+	std::vector<int16> slot_ids;
+	const size_t       size = sizeof(slots) / sizeof(slots[0]);
+
+	for (uint8 slot_index = 0; slot_index < size; ++slot_index) {
+		for (int16 slot_id = slots[slot_index][0]; slot_id <= slots[slot_index][1]; ++slot_id) {
+			slot_ids.emplace_back(slot_id);
+		}
+	}
+
+	return slot_ids;
 }

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10466,9 +10466,7 @@ uint32 Client::CountItem(uint32 item_id)
 	uint32 quantity = 0;
 	EQ::ItemInstance *item = nullptr;
 
-	const auto& slot_ids = GetInventorySlots();
-
-	for (const int16& slot_id : slot_ids) {
+	for (const int16& slot_id : GetInventorySlots()) {
 		item = GetInv().GetItem(slot_id);
 		if (item && item->GetID() == item_id) {
 			quantity += (item->IsStackable() ? item->GetCharges() : 1);
@@ -10488,9 +10486,7 @@ void Client::ResetItemCooldown(uint32 item_id)
 	int recast_type = item_d->RecastType;
 	bool found_item = false;
 
-	const auto& slot_ids = GetInventorySlots();
-
-	for (const int16& slot_id : slot_ids) {
+	for (const int16& slot_id : GetInventorySlots()) {
 		item = GetInv().GetItem(slot_id);
 		if (item) {
 			item_d = item->GetItem();
@@ -10544,9 +10540,7 @@ void Client::SetItemCooldown(uint32 item_id, bool use_saved_timer, uint32 in_sec
 		final_time = total_time - current_time;
 	}
 
-	const auto& slot_ids = GetInventorySlots();
-
-	for (const int16& slot_id : slot_ids) {
+	for (const int16& slot_id : GetInventorySlots()) {
 		item = GetInv().GetItem(slot_id);
 		if (item) {
 			item_d = item->GetItem();
@@ -10605,8 +10599,7 @@ void Client::RemoveItem(uint32 item_id, uint32 quantity)
 	uint32 removed_count = 0;
 	EQ::ItemInstance *item = nullptr;
 
-	const auto& slot_ids = GetInventorySlots();
-	for (const int16& slot_id : slot_ids) {
+	for (const int16& slot_id : GetInventorySlots()) {
 		if (removed_count == quantity) {
 			break;
 		}
@@ -13043,7 +13036,7 @@ void Client::ClientToNpcAggroProcess()
 
 const std::vector<int16>& Client::GetInventorySlots()
 {
-	static const int16 slots[][2] = {
+	static const std::vector<std::pair<int16, int16>> slots = {
 		{ EQ::invslot::POSSESSIONS_BEGIN,     EQ::invslot::POSSESSIONS_END },
 		{ EQ::invbag::GENERAL_BAGS_BEGIN,     EQ::invbag::GENERAL_BAGS_END },
 		{ EQ::invbag::CURSOR_BAG_BEGIN,       EQ::invbag::CURSOR_BAG_END },
@@ -13053,12 +13046,13 @@ const std::vector<int16>& Client::GetInventorySlots()
 		{ EQ::invbag::SHARED_BANK_BAGS_BEGIN, EQ::invbag::SHARED_BANK_BAGS_END },
 	};
 
-	std::vector<int16> slot_ids;
-	const size_t       size = sizeof(slots) / sizeof(slots[0]);
+	static std::vector<int16> slot_ids;
 
-	for (uint8 slot_index = 0; slot_index < size; ++slot_index) {
-		for (int16 slot_id = slots[slot_index][0]; slot_id <= slots[slot_index][1]; ++slot_id) {
-			slot_ids.emplace_back(slot_id);
+	if (slot_ids.empty()) {
+		for (const auto& [begin, end] : slots) {
+			for (int16 slot_id = begin; slot_id <= end; ++slot_id) {
+				slot_ids.emplace_back(slot_id);
+			}
 		}
 	}
 

--- a/zone/client.h
+++ b/zone/client.h
@@ -467,6 +467,7 @@ public:
 	inline ExtendedProfile_Struct& GetEPP() { return m_epp; }
 	inline EQ::InventoryProfile& GetInv() { return m_inv; }
 	inline const EQ::InventoryProfile& GetInv() const { return m_inv; }
+	const std::vector<int16>& GetInventorySlots();
 	inline PetInfo* GetPetInfo(int pet_info_type) { return pet_info_type == PetInfoType::Suspended ? &m_suspendedminion : &m_petinfo; }
 	inline InspectMessage_Struct& GetInspectMessage() { return m_inspect_message; }
 	inline const InspectMessage_Struct& GetInspectMessage() const { return m_inspect_message; }
@@ -1093,7 +1094,7 @@ public:
 	bool PushItemOnCursor(const EQ::ItemInstance& inst, bool client_update = false);
 	void SendCursorBuffer();
 	void DeleteItemInInventory(int16 slot_id, int16 quantity = 0, bool client_update = false, bool update_db = true);
-	int CountItem(uint32 item_id);
+	uint32 CountItem(uint32 item_id);
 	void ResetItemCooldown(uint32 item_id);
 	void SetItemCooldown(uint32 item_id, bool use_saved_timer = false, uint32 in_seconds = 1);
 	uint32 GetItemCooldown(uint32 item_id);

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -1871,9 +1871,10 @@ bool Corpse::HasItem(uint32 item_id)
 	return false;
 }
 
-uint16 Corpse::CountItem(uint32 item_id)
+uint32 Corpse::CountItem(uint32 item_id)
 {
-	uint16 item_count = 0;
+	uint32 item_count = 0;
+
 	if (!database.GetItem(item_id)) {
 		return item_count;
 	}
@@ -1893,6 +1894,7 @@ uint16 Corpse::CountItem(uint32 item_id)
 			item_count += i->charges > 0 ? i->charges : 1;
 		}
 	}
+
 	return item_count;
 }
 

--- a/zone/corpse.h
+++ b/zone/corpse.h
@@ -196,7 +196,7 @@ public:
 	/* Corpse: Loot */
 	void QueryLoot(Client *to);
 	bool HasItem(uint32 item_id);
-	uint16 CountItem(uint32 item_id);
+	uint32 CountItem(uint32 item_id);
 	uint32 GetItemIDBySlot(uint16 loot_slot);
 	uint16 GetFirstLootSlotByItemID(uint32 item_id);
 	std::vector<int> GetLootList();

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -1446,7 +1446,7 @@ int Perl__collectitems(uint32_t item_id, bool remove_item)
 	return quest_manager.collectitems(item_id, remove_item);
 }
 
-int Perl__countitem(uint32_t item_id)
+uint32 Perl__countitem(uint32_t item_id)
 {
 	return quest_manager.countitem(item_id);
 }

--- a/zone/gm_commands/emptyinventory.cpp
+++ b/zone/gm_commands/emptyinventory.cpp
@@ -2,31 +2,23 @@
 
 void command_emptyinventory(Client *c, const Seperator *sep)
 {
-	auto target = c;
+	Client* t = c;
 	if (c->GetGM() && c->GetTarget() && c->GetTarget()->IsClient()) {
-		target = c->GetTarget()->CastToClient();
+		t = c->GetTarget()->CastToClient();
 	}
 
 	EQ::ItemInstance *item = nullptr;
-	static const int16 slots[][2] = {
-		{ EQ::invslot::POSSESSIONS_BEGIN, EQ::invslot::POSSESSIONS_END },
-		{ EQ::invbag::GENERAL_BAGS_BEGIN, EQ::invbag::GENERAL_BAGS_END },
-		{ EQ::invbag::CURSOR_BAG_BEGIN, EQ::invbag::CURSOR_BAG_END},
-		{ EQ::invslot::BANK_BEGIN, EQ::invslot::BANK_END },
-		{ EQ::invbag::BANK_BAGS_BEGIN, EQ::invbag::BANK_BAGS_END },
-		{ EQ::invslot::SHARED_BANK_BEGIN, EQ::invslot::SHARED_BANK_END },
-		{ EQ::invbag::SHARED_BANK_BAGS_BEGIN, EQ::invbag::SHARED_BANK_BAGS_END },
-	};
-	int removed_count = 0;
-	const size_t size = sizeof(slots) / sizeof(slots[0]);
-	for (int slot_index = 0; slot_index < size; ++slot_index) {
-		for (int slot_id = slots[slot_index][0]; slot_id <= slots[slot_index][1]; ++slot_id) {
-			item = target->GetInv().GetItem(slot_id);
-			if (item) {
-				int stack_size = std::max(static_cast<int>(item->GetCharges()), 1);
-				removed_count += stack_size;
-				target->DeleteItemInInventory(slot_id, 0, true);
-			}
+	uint32 removed_count = 0;
+
+	const auto& slot_ids = t->GetInventorySlots();
+
+	for (const int16& slot_id : slot_ids) {
+		item = t->GetInv().GetItem(slot_id);
+
+		if (item) {
+			uint32 stack_size = std::max(static_cast<uint32>(item->GetCharges()), static_cast<uint32>(1));
+			removed_count += stack_size;
+			t->DeleteItemInInventory(slot_id, 0, true);
 		}
 	}
 
@@ -35,8 +27,8 @@ void command_emptyinventory(Client *c, const Seperator *sep)
 			Chat::White,
 			fmt::format(
 				"{} {} no items to delete.",
-				c->GetTargetDescription(target, TargetDescriptionType::UCYou),
-				c == target ? "have" : "has"
+				c->GetTargetDescription(t, TargetDescriptionType::UCYou),
+				c == t ? "have" : "has"
 			).c_str()
 		);
 		return;
@@ -46,7 +38,7 @@ void command_emptyinventory(Client *c, const Seperator *sep)
 		Chat::White,
 		fmt::format(
 			"Inventory cleared for {}, {} item{} deleted.",
-			c->GetTargetDescription(target),
+			c->GetTargetDescription(t),
 			removed_count,
 			removed_count != 1 ? "s" : ""
 		).c_str()

--- a/zone/gm_commands/emptyinventory.cpp
+++ b/zone/gm_commands/emptyinventory.cpp
@@ -10,9 +10,7 @@ void command_emptyinventory(Client *c, const Seperator *sep)
 	EQ::ItemInstance *item = nullptr;
 	uint32 removed_count = 0;
 
-	const auto& slot_ids = t->GetInventorySlots();
-
-	for (const int16& slot_id : slot_ids) {
+	for (const int16& slot_id : t->GetInventorySlots()) {
 		item = t->GetInv().GetItem(slot_id);
 
 		if (item) {

--- a/zone/loot.cpp
+++ b/zone/loot.cpp
@@ -859,9 +859,9 @@ bool NPC::HasItem(uint32 item_id)
 	return false;
 }
 
-uint16 NPC::CountItem(uint32 item_id)
+uint32 NPC::CountItem(uint32 item_id)
 {
-	uint16 item_count = 0;
+	uint32 item_count = 0;
 	if (!database.GetItem(item_id)) {
 		return item_count;
 	}

--- a/zone/lua_bot.cpp
+++ b/zone/lua_bot.cpp
@@ -274,7 +274,7 @@ void Lua_Bot::SetSpellDurationRaid(int spell_id, int duration, int level, bool a
 	self->SetSpellDuration(spell_id, duration, level, ApplySpellType::Raid, allow_pets, is_raid_group_only);
 }
 
-int Lua_Bot::CountAugmentEquippedByID(uint32 item_id) {
+uint32 Lua_Bot::CountAugmentEquippedByID(uint32 item_id) {
 	Lua_Safe_Call_Int();
 	return self->GetInv().CountAugmentEquippedByID(item_id);
 }
@@ -284,7 +284,7 @@ bool Lua_Bot::HasAugmentEquippedByID(uint32 item_id) {
 	return self->GetInv().HasAugmentEquippedByID(item_id);
 }
 
-int Lua_Bot::CountItemEquippedByID(uint32 item_id) {
+uint32 Lua_Bot::CountItemEquippedByID(uint32 item_id) {
 	Lua_Safe_Call_Int();
 	return self->GetInv().CountItemEquippedByID(item_id);
 }
@@ -701,8 +701,9 @@ luabind::scope lua_register_bot() {
 	.def("ClearItemReuseTimer", (void(Lua_Bot::*)(uint32))&Lua_Bot::ClearItemReuseTimer)
 	.def("ClearSpellRecastTimer", (void(Lua_Bot::*)())&Lua_Bot::ClearSpellRecastTimer)
 	.def("ClearSpellRecastTimer", (void(Lua_Bot::*)(uint16))&Lua_Bot::ClearSpellRecastTimer)
+	.def("CountAugmentEquippedByID", (uint32(Lua_Bot::*)(uint32))&Lua_Bot::CountAugmentEquippedByID)
 	.def("CountBotItem", (uint32(Lua_Bot::*)(uint32))&Lua_Bot::CountBotItem)
-	.def("CountItemEquippedByID", (int(Lua_Bot::*)(uint32))&Lua_Bot::CountItemEquippedByID)
+	.def("CountItemEquippedByID", (uint32(Lua_Bot::*)(uint32))&Lua_Bot::CountItemEquippedByID)
 	.def("DeleteBot", (void(Lua_Bot::*)(void))&Lua_Bot::DeleteBot)
 	.def("DeleteBucket", (void(Lua_Bot::*)(std::string))&Lua_Bot::DeleteBucket)
 	.def("Escape", (void(Lua_Bot::*)(void))&Lua_Bot::Escape)

--- a/zone/lua_bot.h
+++ b/zone/lua_bot.h
@@ -127,8 +127,8 @@ public:
 	void SetSpellRecastTimer(uint16 spell_id);
 	void SetSpellRecastTimer(uint16 spell_id, uint32 reuse_timer);
 
-	int CountAugmentEquippedByID(uint32 item_id);
-	int CountItemEquippedByID(uint32 item_id);
+	uint32 CountAugmentEquippedByID(uint32 item_id);
+	uint32 CountItemEquippedByID(uint32 item_id);
 	bool HasAugmentEquippedByID(uint32 item_id);
 	bool HasItemEquippedByID(uint32 item_id);
 	int GetHealAmount();

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3441,9 +3441,8 @@ luabind::object Lua_Client::GetInventorySlots(lua_State* L) {
 
 	if (d_) {
 		auto self = reinterpret_cast<NativeType*>(d_);
-		const auto& slot_ids = self->GetInventorySlots();
 		int index = 1;
-		for (const int16& slot_id : slot_ids) {
+		for (const int16& slot_id : self->GetInventorySlots()) {
 			lua_table[index] = slot_id;
 			index++;
 		}

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -2287,7 +2287,7 @@ void Lua_Client::SendToInstance(std::string instance_type, std::string zone_shor
 	self->SendToInstance(instance_type, zone_short_name, instance_version, x, y, z, heading, instance_identifier, duration);
 }
 
-int Lua_Client::CountItem(uint32 item_id) {
+uint32 Lua_Client::CountItem(uint32 item_id) {
 	Lua_Safe_Call_Int();
 	return self->CountItem(item_id);
 }
@@ -2480,7 +2480,7 @@ void Lua_Client::AddItem(luabind::object item_table) {
 	);
 }
 
-int Lua_Client::CountAugmentEquippedByID(uint32 item_id) {
+uint32 Lua_Client::CountAugmentEquippedByID(uint32 item_id) {
 	Lua_Safe_Call_Int();
 	return self->GetInv().CountAugmentEquippedByID(item_id);
 }
@@ -2490,7 +2490,7 @@ bool Lua_Client::HasAugmentEquippedByID(uint32 item_id) {
 	return self->GetInv().HasAugmentEquippedByID(item_id);
 }
 
-int Lua_Client::CountItemEquippedByID(uint32 item_id) {
+uint32 Lua_Client::CountItemEquippedByID(uint32 item_id) {
 	Lua_Safe_Call_Int();
 	return self->GetInv().CountItemEquippedByID(item_id);
 }
@@ -3436,6 +3436,22 @@ void Lua_Client::AreaTaunt(float range, int bonus_hate)
 	entity_list.AETaunt(self, range, bonus_hate);
 }
 
+luabind::object Lua_Client::GetInventorySlots(lua_State* L) {
+	auto lua_table = luabind::newtable(L);
+
+	if (d_) {
+		auto self = reinterpret_cast<NativeType*>(d_);
+		const auto& slot_ids = self->GetInventorySlots();
+		int index = 1;
+		for (const int16& slot_id : slot_ids) {
+			lua_table[index] = slot_id;
+			index++;
+		}
+	}
+
+	return lua_table;
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 	.def(luabind::constructor<>())
@@ -3514,9 +3530,9 @@ luabind::scope lua_register_client() {
 	.def("ClearXTargets", (void(Lua_Client::*)(void))&Lua_Client::ClearXTargets)
 	.def("ClearZoneFlag", (void(Lua_Client::*)(uint32))&Lua_Client::ClearZoneFlag)
 	.def("Connected", (bool(Lua_Client::*)(void))&Lua_Client::Connected)
-	.def("CountAugmentEquippedByID", (int(Lua_Client::*)(uint32))&Lua_Client::CountAugmentEquippedByID)
-	.def("CountItem", (int(Lua_Client::*)(uint32))&Lua_Client::CountItem)
-	.def("CountItemEquippedByID", (int(Lua_Client::*)(uint32))&Lua_Client::CountItemEquippedByID)
+	.def("CountAugmentEquippedByID", (uint32(Lua_Client::*)(uint32))&Lua_Client::CountAugmentEquippedByID)
+	.def("CountItem", (uint32(Lua_Client::*)(uint32))&Lua_Client::CountItem)
+	.def("CountItemEquippedByID", (uint32(Lua_Client::*)(uint32))&Lua_Client::CountItemEquippedByID)
 	.def("CreateExpedition", (Lua_Expedition(Lua_Client::*)(luabind::object))&Lua_Client::CreateExpedition)
 	.def("CreateExpedition", (Lua_Expedition(Lua_Client::*)(std::string, uint32, uint32, std::string, uint32, uint32))&Lua_Client::CreateExpedition)
 	.def("CreateExpedition", (Lua_Expedition(Lua_Client::*)(std::string, uint32, uint32, std::string, uint32, uint32, bool))&Lua_Client::CreateExpedition)
@@ -3650,6 +3666,7 @@ luabind::scope lua_register_client() {
 	.def("GetInstrumentMod", (int(Lua_Client::*)(int))&Lua_Client::GetInstrumentMod)
 	.def("GetIntoxication", (int(Lua_Client::*)(void))&Lua_Client::GetIntoxication)
 	.def("GetInventory", (Lua_Inventory(Lua_Client::*)(void))&Lua_Client::GetInventory)
+	.def("GetInventorySlots", (luabind::object(Lua_Client::*)(lua_State* L))&Lua_Client::GetInventorySlots)
 	.def("GetInvulnerableEnvironmentDamage", (bool(Lua_Client::*)(void))&Lua_Client::GetInvulnerableEnvironmentDamage)
 	.def("GetItemIDAt", (int(Lua_Client::*)(int))&Lua_Client::GetItemIDAt)
 	.def("GetItemCooldown", (uint32(Lua_Client::*)(uint32))&Lua_Client::GetItemCooldown)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -441,14 +441,14 @@ public:
 	void Popup(const char* title, const char* text, uint32 popup_id, uint32 negative_id, uint32 button_type, uint32 duration);
 	void Popup(const char* title, const char* text, uint32 popup_id, uint32 negative_id, uint32 button_type, uint32 duration, const char* button_name_one, const char* button_name_two);
 	void Popup(const char* title, const char* text, uint32 popup_id, uint32 negative_id, uint32 button_type, uint32 duration, const char* button_name_one, const char* button_name_two, uint32 sound_controls);
-	int CountItem(uint32 item_id);
+	uint32 CountItem(uint32 item_id);
 	void RemoveItem(uint32 item_id);
 	void RemoveItem(uint32 item_id, uint32 quantity);
 	void SetGMStatus(int new_status);
 	int16 GetGMStatus();
 	void AddItem(luabind::object item_table);
-	int CountAugmentEquippedByID(uint32 item_id);
-	int CountItemEquippedByID(uint32 item_id);
+	uint32 CountAugmentEquippedByID(uint32 item_id);
+	uint32 CountItemEquippedByID(uint32 item_id);
 	bool HasAugmentEquippedByID(uint32 item_id);
 	bool HasItemEquippedByID(uint32 item_id);
 	int GetHealAmount();
@@ -509,6 +509,7 @@ public:
 	void AreaTaunt();
 	void AreaTaunt(float range);
 	void AreaTaunt(float range, int bonus_hate);
+	luabind::object GetInventorySlots(lua_State* L);
 
 	void ApplySpell(int spell_id);
 	void ApplySpell(int spell_id, int duration);

--- a/zone/lua_corpse.cpp
+++ b/zone/lua_corpse.cpp
@@ -177,7 +177,7 @@ bool Lua_Corpse::HasItem(uint32 item_id) {
 	return self->HasItem(item_id);
 }
 
-uint16 Lua_Corpse::CountItem(uint32 item_id) {
+uint32 Lua_Corpse::CountItem(uint32 item_id) {
 	Lua_Safe_Call_Int();
 	return self->CountItem(item_id);
 }
@@ -226,7 +226,7 @@ luabind::scope lua_register_corpse() {
 	.def("AllowMobLoot", (void(Lua_Corpse::*)(Lua_Mob, uint8))&Lua_Corpse::AllowMobLoot)
 	.def("Bury", (void(Lua_Corpse::*)(void))&Lua_Corpse::Bury)
 	.def("CanMobLoot", (bool(Lua_Corpse::*)(int))&Lua_Corpse::CanMobLoot)
-	.def("CountItem", (uint16(Lua_Corpse::*)(uint32))&Lua_Corpse::CountItem)
+	.def("CountItem", (uint32(Lua_Corpse::*)(uint32))&Lua_Corpse::CountItem)
 	.def("CountItems", (uint32(Lua_Corpse::*)(void))&Lua_Corpse::CountItems)
 	.def("Delete", (void(Lua_Corpse::*)(void))&Lua_Corpse::Delete)
 	.def("Depop", (void(Lua_Corpse::*)(void))&Lua_Corpse::Depop)

--- a/zone/lua_corpse.h
+++ b/zone/lua_corpse.h
@@ -62,7 +62,7 @@ public:
 	uint32 GetPlatinum();
 	void AddLooter(Lua_Mob who);
 	bool HasItem(uint32 item_id);
-	uint16 CountItem(uint32 item_id);
+	uint32 CountItem(uint32 item_id);
 	uint32 GetItemIDBySlot(uint16 loot_slot);
 	uint16 GetFirstLootSlotByItemID(uint32 item_id);
 	Lua_Corpse_Loot_List GetLootList(lua_State* L);

--- a/zone/lua_inventory.cpp
+++ b/zone/lua_inventory.cpp
@@ -164,7 +164,7 @@ int Lua_Inventory::GetSlotByItemInst(Lua_ItemInst inst) {
 	return self->GetSlotByItemInst(inst);
 }
 
-int Lua_Inventory::CountAugmentEquippedByID(uint32 item_id) {
+uint32 Lua_Inventory::CountAugmentEquippedByID(uint32 item_id) {
 	Lua_Safe_Call_Int();
 	return self->CountAugmentEquippedByID(item_id);
 }
@@ -174,7 +174,7 @@ bool Lua_Inventory::HasAugmentEquippedByID(uint32 item_id) {
 	return self->HasAugmentEquippedByID(item_id);
 }
 
-int Lua_Inventory::CountItemEquippedByID(uint32 item_id) {
+uint32 Lua_Inventory::CountItemEquippedByID(uint32 item_id) {
 	Lua_Safe_Call_Int();
 	return self->CountItemEquippedByID(item_id);
 }
@@ -208,8 +208,8 @@ luabind::scope lua_register_inventory() {
 	.def("CalcSlotId", (int(Lua_Inventory::*)(int,int))&Lua_Inventory::CalcSlotId)
 	.def("CanItemFitInContainer", (bool(Lua_Inventory::*)(Lua_Item,Lua_Item))&Lua_Inventory::CanItemFitInContainer)
 	.def("CheckNoDrop", (bool(Lua_Inventory::*)(int))&Lua_Inventory::CheckNoDrop)
-	.def("CountAugmentEquippedByID", (int(Lua_Inventory::*)(uint32))&Lua_Inventory::CountAugmentEquippedByID)
-	.def("CountItemEquippedByID", (int(Lua_Inventory::*)(uint32))&Lua_Inventory::CountItemEquippedByID)
+	.def("CountAugmentEquippedByID", (uint32(Lua_Inventory::*)(uint32))&Lua_Inventory::CountAugmentEquippedByID)
+	.def("CountItemEquippedByID", (uint32(Lua_Inventory::*)(uint32))&Lua_Inventory::CountItemEquippedByID)
 	.def("DeleteItem", (bool(Lua_Inventory::*)(int))&Lua_Inventory::DeleteItem)
 	.def("DeleteItem", (bool(Lua_Inventory::*)(int,int))&Lua_Inventory::DeleteItem)
 	.def("FindFreeSlot", (int(Lua_Inventory::*)(bool,bool))&Lua_Inventory::FindFreeSlot)

--- a/zone/lua_inventory.h
+++ b/zone/lua_inventory.h
@@ -43,8 +43,8 @@ public:
 	bool DeleteItem(int slot_id);
 	bool DeleteItem(int slot_id, int quantity);
 	bool CheckNoDrop(int slot_id);
-	int CountAugmentEquippedByID(uint32 item_id);
-	int CountItemEquippedByID(uint32 item_id);
+	uint32 CountAugmentEquippedByID(uint32 item_id);
+	uint32 CountItemEquippedByID(uint32 item_id);
 	Lua_ItemInst PopItem(int slot_id);
 	bool HasAugmentEquippedByID(uint32 item_id);
 	bool HasItemEquippedByID(uint32 item_id);

--- a/zone/lua_npc.cpp
+++ b/zone/lua_npc.cpp
@@ -597,7 +597,7 @@ bool Lua_NPC::HasItem(uint32 item_id)
 	return self->HasItem(item_id);
 }
 
-uint16 Lua_NPC::CountItem(uint32 item_id)
+uint32 Lua_NPC::CountItem(uint32 item_id)
 {
 	Lua_Safe_Call_Int();
 	return self->CountItem(item_id);
@@ -862,7 +862,7 @@ luabind::scope lua_register_npc() {
 	.def("CheckNPCFactionAlly", (int(Lua_NPC::*)(int))&Lua_NPC::CheckNPCFactionAlly)
 	.def("ClearItemList", (void(Lua_NPC::*)(void))&Lua_NPC::ClearLootItems)
 	.def("ClearLastName", (void(Lua_NPC::*)(void))&Lua_NPC::ClearLastName)
-	.def("CountItem", (uint16(Lua_NPC::*)(uint32))&Lua_NPC::CountItem)
+	.def("CountItem", (uint32(Lua_NPC::*)(uint32))&Lua_NPC::CountItem)
 	.def("CountLoot", (int(Lua_NPC::*)(void))&Lua_NPC::CountLoot)
 	.def("DeleteBucket", (void(Lua_NPC::*)(std::string))&Lua_NPC::DeleteBucket)
 	.def("DescribeSpecialAbilities", (void(Lua_NPC::*)(Lua_Client))&Lua_NPC::DescribeSpecialAbilities)

--- a/zone/lua_npc.h
+++ b/zone/lua_npc.h
@@ -146,7 +146,7 @@ public:
 	void ChangeLastName(std::string last_name);
 	void ClearLastName();
 	bool HasItem(uint32 item_id);
-	uint16 CountItem(uint32 item_id);
+	uint32 CountItem(uint32 item_id);
 	uint32 GetLootItemIDBySlot(uint16 loot_slot);
 	uint16 GetFirstLootSlotByItemID(uint32 item_id);
 	float GetHealScale();

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -222,7 +222,7 @@ public:
 	void RemoveLootCash();
 	void QueryLoot(Client *to, bool is_pet_query = false);
 	bool HasItem(uint32 item_id);
-	uint16 CountItem(uint32 item_id);
+	uint32 CountItem(uint32 item_id);
 	uint32 GetLootItemIDBySlot(uint16 loot_slot);
 	uint16 GetFirstLootSlotByItemID(uint32 item_id);
 	std::vector<int> GetLootList();

--- a/zone/perl_bot.cpp
+++ b/zone/perl_bot.cpp
@@ -145,7 +145,7 @@ EQ::ItemInstance* Perl_Bot_GetAugmentAt(Bot* self, int16 slot_id, uint8 augment_
 	return nullptr;
 }
 
-int Perl_Bot_CountAugmentEquippedByID(Bot* self, uint32 item_id)
+uint32 Perl_Bot_CountAugmentEquippedByID(Bot* self, uint32 item_id)
 {
 	return self->GetInv().CountAugmentEquippedByID(item_id);
 }
@@ -155,7 +155,7 @@ bool Perl_Bot_HasAugmentEquippedByID(Bot* self, uint32 item_id)
 	return self->GetInv().HasAugmentEquippedByID(item_id);
 }
 
-int Perl_Bot_CountItemEquippedByID(Bot* self, uint32 item_id)
+uint32 Perl_Bot_CountItemEquippedByID(Bot* self, uint32 item_id)
 {
 	return self->GetInv().CountItemEquippedByID(item_id);
 }
@@ -650,7 +650,7 @@ void perl_register_bot()
 	package.add("ApplySpellRaid", (void(*)(Bot*, int, int, int, bool))&Perl_Bot_ApplySpellRaid);
 	package.add("ApplySpellRaid", (void(*)(Bot*, int, int, int, bool, bool))&Perl_Bot_ApplySpellRaid);
 	package.add("Camp", (void(*)(Bot*))&Perl_Bot_Camp);
-	package.add("Camp", (void(*)(Bot*, bool))&Perl_Bot_Camp);	
+	package.add("Camp", (void(*)(Bot*, bool))&Perl_Bot_Camp);
 	package.add("ClearDisciplineReuseTimer", (void(*)(Bot*))&Perl_Bot_ClearDisciplineReuseTimer);
 	package.add("ClearDisciplineReuseTimer", (void(*)(Bot*, uint16))&Perl_Bot_ClearDisciplineReuseTimer);
 	package.add("ClearItemReuseTimer", (void(*)(Bot*))&Perl_Bot_ClearItemReuseTimer);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -2209,7 +2209,7 @@ void Perl_Client_SendToInstance(Client* self, std::string instance_type, std::st
 	self->SendToInstance(instance_type, zone_short_name, instance_version, x, y, z, heading, instance_identifier, duration);
 }
 
-int Perl_Client_CountItem(Client* self, uint32 item_id)
+uint32 Perl_Client_CountItem(Client* self, uint32 item_id)
 {
 	return self->CountItem(item_id);
 }
@@ -2388,7 +2388,7 @@ void Perl_Client_AddItem(Client* self, perl::reference table_ref)
 		augment_four, augment_five, augment_six, attuned, slot_id);
 }
 
-int Perl_Client_CountAugmentEquippedByID(Client* self, uint32 item_id)
+uint32 Perl_Client_CountAugmentEquippedByID(Client* self, uint32 item_id)
 {
 	return self->GetInv().CountAugmentEquippedByID(item_id);
 }
@@ -2398,7 +2398,7 @@ bool Perl_Client_HasAugmentEquippedByID(Client* self, uint32 item_id)
 	return self->GetInv().HasAugmentEquippedByID(item_id);
 }
 
-int Perl_Client_CountItemEquippedByID(Client* self, uint32 item_id)
+uint32 Perl_Client_CountItemEquippedByID(Client* self, uint32 item_id)
 {
 	return self->GetInv().CountItemEquippedByID(item_id);
 }
@@ -3212,6 +3212,18 @@ Merc* Perl_Client_GetMerc(Client* self)
 	return self->GetMerc();
 }
 
+perl::array Perl_Client_GetInventorySlots(Client* self)
+{
+	perl::array result;
+	const auto& v = self->GetInventorySlots();
+
+	for (int i = 0; i < v.size(); ++i) {
+		result.push_back(v[i]);
+	}
+
+	return result;
+}
+
 void perl_register_client()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3426,6 +3438,7 @@ void perl_register_client()
 	package.add("GetInstanceID", &Perl_Client_GetInstanceID);
 	package.add("GetInstrumentMod", &Perl_Client_GetInstrumentMod);
 	package.add("GetInventory", &Perl_Client_GetInventory);
+	package.add("GetInventorySlots", &Perl_Client_GetInventorySlots);
 	package.add("GetInvulnerableEnvironmentDamage", &Perl_Client_GetInvulnerableEnvironmentDamage);
 	package.add("GetItemAt", &Perl_Client_GetItemAt);
 	package.add("GetItemCooldown", &Perl_Client_GetItemCooldown);

--- a/zone/perl_inventory.cpp
+++ b/zone/perl_inventory.cpp
@@ -150,7 +150,7 @@ bool Perl_Inventory_HasAugmentEquippedByID(EQ::InventoryProfile* self, uint32_t 
 	return self->HasAugmentEquippedByID(item_id);
 }
 
-int Perl_Inventory_CountAugmentEquippedByID(EQ::InventoryProfile* self, uint32_t item_id)
+uint32 Perl_Inventory_CountAugmentEquippedByID(EQ::InventoryProfile* self, uint32_t item_id)
 {
 	return self->CountAugmentEquippedByID(item_id);
 }
@@ -160,7 +160,7 @@ bool Perl_Inventory_HasItemEquippedByID(EQ::InventoryProfile* self, uint32_t ite
 	return self->HasItemEquippedByID(item_id);
 }
 
-int Perl_Inventory_CountItemEquippedByID(EQ::InventoryProfile* self, uint32_t item_id)
+uint32 Perl_Inventory_CountItemEquippedByID(EQ::InventoryProfile* self, uint32_t item_id)
 {
 	return self->CountItemEquippedByID(item_id);
 }

--- a/zone/perl_npc.cpp
+++ b/zone/perl_npc.cpp
@@ -615,7 +615,7 @@ bool Perl_NPC_HasItem(NPC* self, uint32 item_id) // @categories Script Utility
 	return self->HasItem(item_id);
 }
 
-int Perl_NPC_CountItem(NPC* self, uint32 item_id)
+uint32 Perl_NPC_CountItem(NPC* self, uint32 item_id)
 {
 	return self->CountItem(item_id);
 }

--- a/zone/perl_player_corpse.cpp
+++ b/zone/perl_player_corpse.cpp
@@ -161,7 +161,7 @@ bool Perl_Corpse_HasItem(Corpse* self, uint32_t item_id) // @categories Script U
 	return self->HasItem(item_id);
 }
 
-int Perl_Corpse_CountItem(Corpse* self, uint32_t item_id) // @categories Script Utility
+uint32 Perl_Corpse_CountItem(Corpse* self, uint32_t item_id) // @categories Script Utility
 {
 	return self->CountItem(item_id);
 }

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -3343,7 +3343,7 @@ int QuestManager::collectitems(uint32 item_id, bool remove)
 	return quantity;
 }
 
-int QuestManager::countitem(uint32 item_id) {
+uint32 QuestManager::countitem(uint32 item_id) {
 	QuestManagerCurrentQuestVars();
 
 	if (!initiator) {

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -249,7 +249,7 @@ public:
 	int getlevel(uint8 type);
 	int collectitems(uint32 item_id, bool remove);
 	int collectitems_processSlot(int16 slot_id, uint32 item_id, bool remove);
-	int countitem(uint32 item_id);
+	uint32 countitem(uint32 item_id);
 	void removeitem(uint32 item_id, uint32 quantity = 1);
 	std::string getitemcomment(uint32 item_id);
 	std::string getitemlore(uint32 item_id);


### PR DESCRIPTION
# Description
- Add `GetInventorySlots()` method for an easy short hand for inventory slots.

## Perl
- Add `$client->GetInventorySlots()`.

## Lua
- Add `client:GetInventorySlots()`.

## Type of change
- [X] New feature

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur