### PR TITLE
[Bots] Fix AA ranks to account for level

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -1265,7 +1265,7 @@ void Bot::LoadAAs() {
 		}
 
 		while(current) {
-			if (!CanUseAlternateAdvancementRank(current)) {
+			if (current->level_req > GetLevel() || !CanUseAlternateAdvancementRank(current)) {
 				current = nullptr;
 			} else {
 				current = current->next;


### PR DESCRIPTION
# Description

Previously level requirement was only being checked on the initial rank of an AA. If passed, bots would gain all ranks for that AA regardless of level, this will now check for the level requirement for each rank before granting the AA

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Checked multiple AAs and values granted by level. Prior to change the bonus was always the max rank, after change the bonus matches the bot's level

Clients tested: 

RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
