### PR TITLE
[Cleanup] Convert Event Parses to Single Line

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1550,15 +1550,15 @@ void Mob::DoAttack(Mob *other, DamageHitInfo &hit, ExtraAttackOptions *opts, boo
 			hit.damage_done = 0;
 		}
 
-		std::function<std::string()> f = [&]() {
-			return fmt::format(
-				"{} {}",
-				hit.skill,
-				GetSkill(hit.skill)
-			);
-		};
-
-		parse->EventBotMerc(EVENT_USE_SKILL, this, nullptr, f);
+		parse->EventBotMerc(EVENT_USE_SKILL, this, nullptr,
+			[&]() {
+				return fmt::format(
+					"{} {}",
+					hit.skill,
+					GetSkill(hit.skill)
+				);
+			}
+		);
 	}
 }
 
@@ -3075,22 +3075,23 @@ bool NPC::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillTy
 
 	std::vector<std::any> args = { corpse };
 
-	std::function<std::string()> f = [&]() {
-		return fmt::format(
-			"{} {} {} {} {} {} {} {} {}",
-			killer_mob ? killer_mob->GetID() : 0,
-			damage,
-			spell,
-			static_cast<int>(attack_skill),
-			entity_id,
-			m_combat_record.GetStartTime(),
-			m_combat_record.GetEndTime(),
-			m_combat_record.GetDamageReceived(),
-			m_combat_record.GetHealingReceived()
-		);
-	};
-
-	parse->EventMercNPC(EVENT_DEATH_COMPLETE, this, owner_or_self, f, 0, &args);
+	parse->EventMercNPC(EVENT_DEATH_COMPLETE, this, owner_or_self,
+		[&]() {
+			return fmt::format(
+				"{} {} {} {} {} {} {} {} {}",
+				killer_mob ? killer_mob->GetID() : 0,
+				damage,
+				spell,
+				static_cast<int>(attack_skill),
+				entity_id,
+				m_combat_record.GetStartTime(),
+				m_combat_record.GetEndTime(),
+				m_combat_record.GetDamageReceived(),
+				m_combat_record.GetHealingReceived()
+			);
+		},
+		0, &args
+	);
 
 	// Zone controller process EVENT_DEATH_ZONE (Death events)
 	if (parse->HasQuestSub(ZONE_CONTROLLER_NPC_ID, EVENT_DEATH_ZONE)) {
@@ -4258,10 +4259,32 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 		if (attacker) {
 			args = { this };
 
-			std::function<std::string()> f = [&]() {
+			parse->EventMob(EVENT_DAMAGE_GIVEN, attacker, this,
+				[&]() {
+					return fmt::format(
+						"{} {} {} {} {} {} {} {} {}",
+						GetID(),
+						damage,
+						spell_id,
+						static_cast<int>(skill_used),
+						FromDamageShield ? 1 : 0,
+						avoidable ? 1 : 0,
+						buffslot,
+						iBuffTic ? 1 : 0,
+						static_cast<int>(special)
+					);
+				},
+				0, &args
+			);
+		}
+
+		args = { attacker };
+
+		damage_override = parse->EventMob(EVENT_DAMAGE_TAKEN, this, attacker,
+			[&]() {
 				return fmt::format(
 					"{} {} {} {} {} {} {} {} {}",
-					GetID(),
+					attacker ? attacker->GetID() : 0,
 					damage,
 					spell_id,
 					static_cast<int>(skill_used),
@@ -4271,29 +4294,9 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 					iBuffTic ? 1 : 0,
 					static_cast<int>(special)
 				);
-			};
-
-			parse->EventMob(EVENT_DAMAGE_GIVEN, attacker, this, f, 0, &args);
-		}
-
-		args = { attacker };
-
-		std::function<std::string()> f = [&]() {
-			return fmt::format(
-				"{} {} {} {} {} {} {} {} {}",
-				attacker ? attacker->GetID() : 0,
-				damage,
-				spell_id,
-				static_cast<int>(skill_used),
-				FromDamageShield ? 1 : 0,
-				avoidable ? 1 : 0,
-				buffslot,
-				iBuffTic ? 1 : 0,
-				static_cast<int>(special)
-			);
-		};
-
-		damage_override = parse->EventMob(EVENT_DAMAGE_TAKEN, this, attacker, f, 0, &args);
+			},
+			0, &args
+		);
 
 		if (damage_override > 0) {
 			damage = damage_override;

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -4192,14 +4192,7 @@ void Bot::PerformTradeWithClient(int16 begin_slot_id, int16 end_slot_id, Client*
 
 				std::vector<std::any> args = { return_iterator.return_item_instance };
 
-				parse->EventBot(
-					EVENT_UNEQUIP_ITEM_BOT,
-					this,
-					nullptr,
-					export_string,
-					return_iterator.return_item_instance->GetID(),
-					&args
-				);
+				parse->EventBot(EVENT_UNEQUIP_ITEM_BOT, this, nullptr, export_string, return_iterator.return_item_instance->GetID(), &args);
 			}
 
 			if (return_instance) {
@@ -4264,14 +4257,7 @@ void Bot::PerformTradeWithClient(int16 begin_slot_id, int16 end_slot_id, Client*
 
 			std::vector<std::any> args = { trade_iterator.trade_item_instance };
 
-			parse->EventBot(
-				EVENT_EQUIP_ITEM_BOT,
-				this,
-				nullptr,
-				export_string,
-				trade_iterator.trade_item_instance->GetID(),
-				&args
-			);
+			parse->EventBot(EVENT_EQUIP_ITEM_BOT, this, nullptr, export_string, trade_iterator.trade_item_instance->GetID(), &args);
 		}
 
 		trade_iterator.trade_item_instance = nullptr; // actual deletion occurs in client delete below

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -3251,30 +3251,14 @@ void Client::Handle_OP_AugmentItem(const EQApplicationPacket *app)
 							args.push_back(old_aug);
 
 							if (parse->ItemHasQuestSub(tobe_auged, EVENT_UNAUGMENT_ITEM)) {
-								parse->EventItem(
-									EVENT_UNAUGMENT_ITEM,
-									this,
-									tobe_auged,
-									nullptr,
-									"",
-									in_augment->augment_index,
-									&args
-								);
+								parse->EventItem(EVENT_UNAUGMENT_ITEM, this, tobe_auged, nullptr, "", in_augment->augment_index, &args);
 							}
 
 							args.assign(1, tobe_auged);
 							args.push_back(false);
 
 							if (parse->ItemHasQuestSub(old_aug, EVENT_AUGMENT_REMOVE)) {
-								parse->EventItem(
-									EVENT_AUGMENT_REMOVE,
-									this,
-									old_aug,
-									nullptr,
-									"",
-									in_augment->augment_index,
-									&args
-								);
+								parse->EventItem(EVENT_AUGMENT_REMOVE, this, old_aug, nullptr, "", in_augment->augment_index, &args);
 							}
 
 							if (parse->PlayerHasQuestSub(EVENT_AUGMENT_REMOVE_CLIENT)) {
@@ -3306,29 +3290,13 @@ void Client::Handle_OP_AugmentItem(const EQApplicationPacket *app)
 							args.push_back(aug);
 
 							if (parse->ItemHasQuestSub(tobe_auged, EVENT_AUGMENT_ITEM)) {
-								parse->EventItem(
-									EVENT_AUGMENT_ITEM,
-									this,
-									tobe_auged,
-									nullptr,
-									"",
-									in_augment->augment_index,
-									&args
-								);
+								parse->EventItem(EVENT_AUGMENT_ITEM, this, tobe_auged, nullptr, "", in_augment->augment_index, &args);
 							}
 
 							args.assign(1, tobe_auged);
 
 							if (parse->ItemHasQuestSub(aug, EVENT_AUGMENT_INSERT)) {
-								parse->EventItem(
-									EVENT_AUGMENT_INSERT,
-									this,
-									aug,
-									nullptr,
-									"",
-									in_augment->augment_index,
-									&args
-								);
+								parse->EventItem(EVENT_AUGMENT_INSERT, this, aug, nullptr, "", in_augment->augment_index, &args);
 							}
 
 							args.push_back(aug);
@@ -3398,30 +3366,14 @@ void Client::Handle_OP_AugmentItem(const EQApplicationPacket *app)
 					args.push_back(aug);
 
 					if (parse->ItemHasQuestSub(tobe_auged, EVENT_UNAUGMENT_ITEM)) {
-						parse->EventItem(
-							EVENT_UNAUGMENT_ITEM,
-							this,
-							tobe_auged,
-							nullptr,
-							"",
-							in_augment->augment_index,
-							&args
-						);
+						parse->EventItem(EVENT_UNAUGMENT_ITEM, this, tobe_auged, nullptr, "", in_augment->augment_index, &args);
 					}
 
 					args.assign(1, tobe_auged);
 					args.push_back(false);
 
 					if (parse->ItemHasQuestSub(aug, EVENT_AUGMENT_REMOVE)) {
-						parse->EventItem(
-							EVENT_AUGMENT_REMOVE,
-							this,
-							aug,
-							nullptr,
-							"",
-							in_augment->augment_index,
-							&args
-						);
+						parse->EventItem(EVENT_AUGMENT_REMOVE, this, aug, nullptr, "", in_augment->augment_index, &args);
 					}
 
 					args.push_back(aug);
@@ -3486,30 +3438,14 @@ void Client::Handle_OP_AugmentItem(const EQApplicationPacket *app)
 					args.push_back(aug);
 
 					if (parse->ItemHasQuestSub(tobe_auged, EVENT_UNAUGMENT_ITEM)) {
-						parse->EventItem(
-							EVENT_UNAUGMENT_ITEM,
-							this,
-							tobe_auged,
-							nullptr,
-							"",
-							in_augment->augment_index,
-							&args
-						);
+						parse->EventItem(EVENT_UNAUGMENT_ITEM, this, tobe_auged, nullptr, "", in_augment->augment_index, &args);
 					}
 
 					args.assign(1, tobe_auged);
 					args.push_back(true);
 
 					if (parse->ItemHasQuestSub(aug, EVENT_AUGMENT_REMOVE)) {
-						parse->EventItem(
-							EVENT_AUGMENT_REMOVE,
-							this,
-							aug,
-							nullptr,
-							"",
-							in_augment->augment_index,
-							&args
-						);
+						parse->EventItem(EVENT_AUGMENT_REMOVE, this, aug, nullptr, "", in_augment->augment_index, &args);
 					}
 
 					args.push_back(aug);
@@ -4479,14 +4415,7 @@ void Client::Handle_OP_CastSpell(const EQApplicationPacket *app)
 							int i = 0;
 
 							if (parse->ItemHasQuestSub(p_inst, EVENT_ITEM_CLICK_CAST)) {
-								i = parse->EventItem(
-									EVENT_ITEM_CLICK_CAST,
-									this,
-									p_inst,
-									nullptr,
-									"",
-									castspell->inventoryslot
-								);
+								i = parse->EventItem(EVENT_ITEM_CLICK_CAST, this, p_inst, nullptr, "", castspell->inventoryslot);
 							}
 
 							if (parse->PlayerHasQuestSub(EVENT_ITEM_CLICK_CAST_CLIENT)) {
@@ -4518,14 +4447,7 @@ void Client::Handle_OP_CastSpell(const EQApplicationPacket *app)
 						int i = 0;
 
 						if (parse->ItemHasQuestSub(p_inst, EVENT_ITEM_CLICK_CAST)) {
-							i = parse->EventItem(
-								EVENT_ITEM_CLICK_CAST,
-								this,
-								p_inst,
-								nullptr,
-								"",
-								castspell->inventoryslot
-							);
+							i = parse->EventItem(EVENT_ITEM_CLICK_CAST, this, p_inst, nullptr, "", castspell->inventoryslot);
 						}
 
 						if (parse->PlayerHasQuestSub(EVENT_ITEM_CLICK_CAST_CLIENT)) {
@@ -9591,14 +9513,7 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 					int i = 0;
 
 					if (parse->ItemHasQuestSub(p_inst, EVENT_ITEM_CLICK_CAST)) {
-						i = parse->EventItem(
-							EVENT_ITEM_CLICK_CAST,
-							this,
-							p_inst,
-							nullptr,
-							"",
-							slot_id
-						);
+						i = parse->EventItem(EVENT_ITEM_CLICK_CAST, this, p_inst, nullptr, "", slot_id);
 					}
 
 					if (parse->PlayerHasQuestSub(EVENT_ITEM_CLICK_CAST_CLIENT)) {
@@ -9662,14 +9577,7 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 					int i = 0;
 
 					if (parse->ItemHasQuestSub(p_inst, EVENT_ITEM_CLICK_CAST)) {
-						i = parse->EventItem(
-							EVENT_ITEM_CLICK_CAST,
-							this,
-							clickaug,
-							nullptr,
-							"",
-							slot_id
-						);
+						i = parse->EventItem(EVENT_ITEM_CLICK_CAST, this, clickaug, nullptr, "", slot_id);
 					}
 
 					if (parse->PlayerHasQuestSub(EVENT_ITEM_CLICK_CAST_CLIENT)) {

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -1817,25 +1817,13 @@ void EntityList::DuelMessage(Mob *winner, Mob *loser, bool flee)
 		if (parse->PlayerHasQuestSub(EVENT_DUEL_WIN)) {
 			std::vector<std::any> args = { winner, loser };
 
-			parse->EventPlayer(
-				EVENT_DUEL_WIN,
-				winner->CastToClient(),
-				loser->GetName(),
-				loser->CastToClient()->CharacterID(),
-				&args
-			);
+			parse->EventPlayer(EVENT_DUEL_WIN, winner->CastToClient(), loser->GetName(), loser->CastToClient()->CharacterID(), &args);
 		}
 
 		if (parse->PlayerHasQuestSub(EVENT_DUEL_LOSE)) {
 			std::vector<std::any> args = { winner, loser };
 
-			parse->EventPlayer(
-				EVENT_DUEL_LOSE,
-				loser->CastToClient(),
-				winner->GetName(),
-				winner->CastToClient()->CharacterID(),
-				&args
-			);
+			parse->EventPlayer(EVENT_DUEL_LOSE, loser->CastToClient(), winner->GetName(), winner->CastToClient()->CharacterID(), &args);
 		}
 	}
 

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -5325,14 +5325,7 @@ void Mob::ExecWeaponProc(const EQ::ItemInstance* inst, uint16 spell_id, Mob* on,
 		//It should be safe as we don't have any truly const EQ::ItemInstance floating around anywhere.
 		//So we'll live with it for now
 		if (parse->ItemHasQuestSub(const_cast<EQ::ItemInstance*>(inst), EVENT_WEAPON_PROC)) {
-			int i = parse->EventItem(
-				EVENT_WEAPON_PROC,
-				CastToClient(),
-				const_cast<EQ::ItemInstance*>(inst),
-				on,
-				"",
-				spell_id
-			);
+			int i = parse->EventItem(EVENT_WEAPON_PROC, CastToClient(), const_cast<EQ::ItemInstance*>(inst), on, "", spell_id);
 
 			if (i != 0) {
 				return;

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -91,13 +91,7 @@ void QuestManager::Process() {
 		if (cur->Timer_.Enabled() && cur->Timer_.Check()) {
 			if (cur->mob) {
 				if (cur->mob->IsEncounter()) {
-					parse->EventEncounter(
-						EVENT_TIMER,
-						cur->mob->CastToEncounter()->GetEncounterName(),
-						cur->name,
-						0,
-						nullptr
-					);
+					parse->EventEncounter(EVENT_TIMER, cur->mob->CastToEncounter()->GetEncounterName(), cur->name, 0, nullptr);
 				} else {
 					parse->EventMob(EVENT_TIMER, cur->mob, nullptr, [&]() { return cur->name; }, 0);
 				}
@@ -661,14 +655,7 @@ void QuestManager::stoptimer(const std::string& timer_name)
 
 	for (auto e = QTimerList.begin(); e != QTimerList.end(); ++e) {
 		if (e->mob && e->mob == owner && e->name == timer_name) {
-			parse->EventMob(
-				EVENT_TIMER_STOP,
-				owner,
-				nullptr,
-				[&]() {
-					return timer_name;
-				}
-			);
+			parse->EventMob(EVENT_TIMER_STOP, owner, nullptr, [&]() { return timer_name; });
 
 			QTimerList.erase(e);
 			break;
@@ -695,14 +682,7 @@ void QuestManager::stoptimer(const std::string& timer_name, Mob* m)
 
 	for (auto e = QTimerList.begin(); e != QTimerList.end();) {
 		if (e->mob && e->mob == m) {
-			parse->EventMob(
-				EVENT_TIMER_STOP,
-				m,
-				nullptr,
-				[&]() {
-					return timer_name;
-				}
-			);
+			parse->EventMob(EVENT_TIMER_STOP, m, nullptr, [&]() { return timer_name; });
 
 			QTimerList.erase(e);
 			break;
@@ -743,14 +723,7 @@ void QuestManager::stopalltimers()
 
 	for (auto e = QTimerList.begin(); e != QTimerList.end();) {
 		if (e->mob && e->mob == owner) {
-			parse->EventMob(
-				EVENT_TIMER_STOP,
-				owner,
-				nullptr,
-				[&]() {
-					return e->name;
-				}
-			);
+			parse->EventMob(EVENT_TIMER_STOP, owner, nullptr, [&]() { return e->name; });
 
 			e = QTimerList.erase(e);
 		} else {
@@ -792,14 +765,7 @@ void QuestManager::stopalltimers(Mob* m)
 
 	for (auto e = QTimerList.begin(); e != QTimerList.end();) {
 		if (e->mob && e->mob == m) {
-			parse->EventMob(
-				EVENT_TIMER_STOP,
-				m,
-				nullptr,
-				[&]() {
-					return e->name;
-				}
-			);
+			parse->EventMob(EVENT_TIMER_STOP, m, nullptr, [&]() { return e->name; });
 
 			e = QTimerList.erase(e);
 		} else {
@@ -853,18 +819,15 @@ void QuestManager::pausetimer(const std::string& timer_name, Mob* m)
 		}
 	);
 
-	parse->EventMob(
-		EVENT_TIMER_PAUSE,
-		mob,
-		nullptr,
-		[&]() {
-			return fmt::format(
-				"{} {}",
-				timer_name,
-				milliseconds
-			);
-		}
-	);
+	std::function<std::string()> f = [&]() {
+		return fmt::format(
+			"{} {}",
+			timer_name,
+			milliseconds
+		);
+	};
+
+	parse->EventMob(EVENT_TIMER_PAUSE, mob, nullptr, f);
 
 	LogQuests("Pausing timer [{}] for [{}] with [{}] ms remaining", timer_name, owner->GetName(), milliseconds);
 }

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -819,15 +819,13 @@ void QuestManager::pausetimer(const std::string& timer_name, Mob* m)
 		}
 	);
 
-	std::function<std::string()> f = [&]() {
+	parse->EventMob(EVENT_TIMER_PAUSE, mob, nullptr, [&]() {
 		return fmt::format(
 			"{} {}",
 			timer_name,
 			milliseconds
 		);
-	};
-
-	parse->EventMob(EVENT_TIMER_PAUSE, mob, nullptr, f);
+	});
 
 	LogQuests("Pausing timer [{}] for [{}] with [{}] ms remaining", timer_name, owner->GetName(), milliseconds);
 }

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3953,8 +3953,6 @@ bool Mob::SpellOnTarget(
 
 	std::vector<std::any> args = { spelltar };
 
-	std::function<std::string()> f = ;
-
 	parse->EventMob(EVENT_CAST_ON, spelltar, this,
 		[&]() {
 			return fmt::format(

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -254,24 +254,19 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 		}
 	}
 
+	std::function<std::string()> f = [&]() {
+		return fmt::format(
+			"{} {} {} {}",
+			spell_id,
+			GetID(),
+			GetCasterLevel(spell_id),
+			target_id
+		);
+	};
+
 	Mob* spell_target = entity_list.GetMobID(target_id);
 	std::vector<std::any> args = { spell_target };
-	int return_value = parse->EventMob(
-		EVENT_CAST_BEGIN,
-		this,
-		nullptr,
-		[&]() {
-			return fmt::format(
-				"{} {} {} {}",
-				spell_id,
-				GetID(),
-				GetCasterLevel(spell_id),
-				target_id
-			);
-		},
-		0,
-		&args
-	);
+	int return_value = parse->EventMob(EVENT_CAST_BEGIN, this, nullptr, f, 0, &args);
 
 	if (IsClient() && return_value != 0) {
 		if (IsDiscipline(spell_id)) {
@@ -1804,22 +1799,17 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 
 	std::vector<std::any> args = { spell_target };
 
-	parse->EventMob(
-		EVENT_CAST,
-		this,
-		nullptr,
-		[&]() {
-			return fmt::format(
-				"{} {} {} {}",
-				spell_id,
-				GetID(),
-				GetCasterLevel(spell_id),
-				target_id
-			);
-		},
-		0,
-		&args
-	);
+	std::function<std::string()> f = [&]() {
+		return fmt::format(
+			"{} {} {} {}",
+			spell_id,
+			GetID(),
+			GetCasterLevel(spell_id),
+			target_id
+		);
+	};
+
+	parse->EventMob(EVENT_CAST, this, nullptr, f, 0, &args);
 
 	if(bard_song_mode)
 	{
@@ -3965,22 +3955,17 @@ bool Mob::SpellOnTarget(
 
 	std::vector<std::any> args = { spelltar };
 
-	parse->EventMob(
-		EVENT_CAST_ON,
-		spelltar,
-		this,
-		[&]() {
-			return fmt::format(
-				"{} {} {} {}",
-				spell_id,
-				GetID(),
-				caster_level,
-				target_id
-			);
-		},
-		0,
-		&args
-	);
+	std::function<std::string()> f = [&]() {
+		return fmt::format(
+			"{} {} {} {}",
+			spell_id,
+			GetID(),
+			caster_level,
+			target_id
+		);
+	};
+
+	parse->EventMob(EVENT_CAST_ON, spelltar, this, f, 0, &args);
 
 	if (!DoCastingChecksOnTarget(false, spell_id, spelltar)) {
 		safe_delete(action_packet);

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -1797,7 +1797,7 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 
 	std::vector<std::any> args = { spell_target };
 
-	std::function<std::string()> f = [&]() {
+	parse->EventMob(EVENT_CAST, this, nullptr, [&]() {
 		return fmt::format(
 			"{} {} {} {}",
 			spell_id,
@@ -1805,9 +1805,7 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 			GetCasterLevel(spell_id),
 			target_id
 		);
-	};
-
-	parse->EventMob(EVENT_CAST, this, nullptr, f, 0, &args);
+	}, 0, &args);
 
 	if(bard_song_mode)
 	{


### PR DESCRIPTION
# Description
- This will allow Spire to properly parse these events, due to them being on multiple lines Spire was not parsing them so they did not show up in the events dropdown.

## Type of change
- [X] Bug fix

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur