### PR TITLE
[Bug Fix] Resolve a client crash when logging in or zoning.

### DIFF
--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -3936,7 +3936,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 					out->trader_id        = in->trader_id;
 					strn0cpy(out->trader_name, in->trader_name, sizeof(out->trader_name));
 
-					c.second->QueuePacket(outapp);
+					c.second->QueuePacket(outapp, true, Mob::CLIENT_CONNECTED);
 					safe_delete(outapp);
 				}
 				if (zone && zone->GetZoneID() == Zones::BAZAAR && in->instance_id == zone->GetInstanceID()) {


### PR DESCRIPTION
# Description

In certain circumstances, a client would crash when logging in or when zoning.

The issue was caused by the client receiving a OP_BecomeTrader packet before the client was fully initialized.
  
More specifically, each time a player activates/deactivates trader mode, OP_BecomeTrader is sent to all other clients to inform them, allow for various bazaar/buyer/barter functionality to work properly.  This packet was sent regardless of the connection state of the client as the default for Client::QueuePacket is Mob::CLIENT_CONNECTINGALL.  Limiting the packet to Mob::CLIENT::CONNECTED resolves the issue.

In server environments with low trader traffic, the issue would likely not be seen.

Fixes # (issue)
Random client crashes experienced in RoF2.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
This has been reproduced in test environments, and has been tested within THJ for a few weeks.  The issue is resolved.

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
