### PR TITLE
[Telnet] Automatically prune connections

### DIFF
--- a/common/net/console_server_connection.cpp
+++ b/common/net/console_server_connection.cpp
@@ -4,6 +4,7 @@
 #include "../eqemu_logsys.h"
 #include "../servertalk.h"
 #include "../rulesys.h"
+#include "../event/timer.h"
 #include <fmt/format.h>
 
 EQ::Net::ConsoleServerConnection::ConsoleServerConnection(ConsoleServer *parent, std::shared_ptr<TCPConnection> connection)
@@ -21,7 +22,13 @@ EQ::Net::ConsoleServerConnection::ConsoleServerConnection(ConsoleServer *parent,
 	m_connection->OnDisconnect(std::bind(&ConsoleServerConnection::OnDisconnect, this, std::placeholders::_1));
 	m_connection->Start();
 	ClearBuffer();
-	
+
+	m_keepalive = std::make_unique<EQ::Timer>(1000, true, [this](EQ::Timer *t) {
+		EQ::Net::DynamicPacket clear;
+		clear.PutUInt8(0, 0);
+		m_connection->Write((const char*)clear.Data(), clear.Length());
+	});
+
 	auto addr = m_connection->RemoteIP();
 
 	SendLine(fmt::format("Establishing connection from: {0}:{1}", addr, m_connection->RemotePort()));
@@ -85,12 +92,12 @@ void EQ::Net::ConsoleServerConnection::QueueMessage(const std::string &msg)
 	}
 	else {
 		std::string cmd(m_line, m_line + m_cursor);
-		
+
 		size_t len = m_user.length() + 2 + cmd.length();
 		for (size_t i = 0; i < len; ++i) {
 			Send("\x08");
 		}
-		
+
 		if (msg.length() < cmd.length()) {
 			Send(msg);
 			size_t blank_spaces = 2 + cmd.length() - msg.length();
@@ -227,6 +234,8 @@ void EQ::Net::ConsoleServerConnection::OnRead(TCPConnection *c, const unsigned c
 
 void EQ::Net::ConsoleServerConnection::OnDisconnect(TCPConnection *c)
 {
+	LogInfo("Console connection disconnected");
+
 	m_parent->ConnectionDisconnected(this);
 }
 

--- a/common/net/console_server_connection.cpp
+++ b/common/net/console_server_connection.cpp
@@ -24,9 +24,7 @@ EQ::Net::ConsoleServerConnection::ConsoleServerConnection(ConsoleServer *parent,
 	ClearBuffer();
 
 	m_keepalive = std::make_unique<EQ::Timer>(1000, true, [this](EQ::Timer *t) {
-		EQ::Net::DynamicPacket clear;
-		clear.PutUInt8(0, 0);
-		m_connection->Write((const char*)clear.Data(), clear.Length());
+		m_connection->Write("", 0);
 	});
 
 	auto addr = m_connection->RemoteIP();

--- a/common/net/console_server_connection.h
+++ b/common/net/console_server_connection.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "tcp_server.h"
+#include "../event/timer.h"
 #include <memory>
 #include <map>
 
@@ -58,6 +59,7 @@ namespace EQ
 			int m_user_id;
 			int m_admin;
 			bool m_accept_messages;
+			std::unique_ptr<EQ::Timer> m_keepalive;
 
 			size_t m_cursor;
 			char m_line[MaxConsoleLineLength];


### PR DESCRIPTION
# Description

This fixes an issue observed by TAKP community where they had a script telneting to World grabbing statistics, but it did not exit or close gracefully, causing the connection / socket to hang server side eventually resulting in the telnet server to stop working entirely after a period of time (10 days usually).

This PR adds a keepalive at the TCP level which is a pattern we use for a lot of inter-process communication at the server level today, examples -

* World -> Zone
* Zone -> World
* World -> Loginserver
* Loginserver -> World
* etc.

By having a 0 size keepalive packet the server will automatically detect when a connection is no longer available and clean resources up server side.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Below is starting world, and then connecting to telnet locally, seeing world echo a 1 second keepalive timer (debugging).

```
eqemu@83d7385f74ee:~/server$ telnet 0 9000
Trying 0.0.0.0...
Connected to 0.
Escape character is '^]'.
Establishing connection from: 127.0.0.1:42878
Connection established from localhost, assuming admin
>  
 World |    Info    | operator() Keepalive timeout for console connection [127.0.0.1] 
 World |    Info    | operator() Keepalive timeout for console connection [127.0.0.1] 
 World |    Info    | operator() Keepalive timeout for console connection [127.0.0.1] 
 World |    Info    | operator() Keepalive timeout for console connection [127.0.0.1] 
 World |    Info    | operator() Keepalive timeout for console connection [127.0.0.1] 
 World |    Info    | operator() Keepalive timeout for console connection [127.0.0.1] 
 World |    Info    | operator() Keepalive timeout for console connection [127.0.0.1] 
```

In a second shell we validate that sockets / resources are opened up at the OS level

```
telnet    121064                  eqemu    3u     IPv4 19355912       0t0      TCP localhost:42878->localhost:9000 (ESTABLISHED)
eqemu@83d7385f74ee:~$ lsof | grep 9000 | grep EST
world     121046                  eqemu   17u     IPv4 19322874       0t0      TCP localhost:9000->localhost:42878 (ESTABLISHED)
world     121046 121047 world     eqemu   17u     IPv4 19322874       0t0      TCP localhost:9000->localhost:42878 (ESTABLISHED)
world     121046 121048 world     eqemu   17u     IPv4 19322874       0t0      TCP localhost:9000->localhost:42878 (ESTABLISHED)
world     121046 121049 world     eqemu   17u     IPv4 19322874       0t0      TCP localhost:9000->localhost:42878 (ESTABLISHED)
world     121046 121050 world     eqemu   17u     IPv4 19322874       0t0      TCP localhost:9000->localhost:42878 (ESTABLISHED)
telnet    121064                  eqemu    3u     IPv4 19355912       0t0      TCP localhost:42878->localhost:9000 (ESTABLISHED)
```

As soon as we kill the "telnet" client in the second shell we notice that the sockets are cleaned up 

```
eqemu@83d7385f74ee:~$ pkill telnet
eqemu@83d7385f74ee:~$ lsof | grep 9000 | grep EST
eqemu@83d7385f74ee:~$ 
```

And server side we see

```
 World |    Info    | operator() Keepalive timeout for console connection [127.0.0.1] 
Terminated
eqemu@83d7385f74ee:~/server$  World |    Info    | operator() Keepalive timeout for console connection [127.0.0.1] 
 World |    Info    | operator() Keepalive timeout for console connection [] 
 World |    Info    | OnDisconnect Console connection disconnected 

eqemu@83d7385f74ee:~/server$ 
```

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur