### PR TITLE
[Network] Prune / disconnect TCP connections gracefully

### DIFF
--- a/common/net/tcp_connection.cpp
+++ b/common/net/tcp_connection.cpp
@@ -80,6 +80,8 @@ void EQ::Net::TCPConnection::Start() {
 			}
 		}
 		else if (nread == UV_EOF) {
+			connection->Disconnect();
+
 			if (buf->base) {
 				delete[] buf->base;
 			}

--- a/loginserver/world_server.cpp
+++ b/loginserver/world_server.cpp
@@ -51,12 +51,6 @@ WorldServer::WorldServer(std::shared_ptr<EQ::Net::ServertalkServerConnection> wo
 		ServerOP_LSAccountUpdate,
 		std::bind(&WorldServer::ProcessLSAccountUpdate, this, std::placeholders::_1, std::placeholders::_2)
 	);
-
-	m_keepalive = std::make_unique<EQ::Timer>(
-		1000,
-		true,
-		std::bind(&WorldServer::OnKeepAlive, this, std::placeholders::_1)
-	);
 }
 
 WorldServer::~WorldServer() = default;
@@ -1305,12 +1299,6 @@ const std::string &WorldServer::GetProtocol() const
 const std::string &WorldServer::GetVersion() const
 {
 	return m_version;
-}
-
-void WorldServer::OnKeepAlive(EQ::Timer *t)
-{
-	ServerPacket pack(ServerOP_KeepAlive, 0);
-	m_connection->SendPacket(&pack);
 }
 
 void WorldServer::FormatWorldServerName(char *name, int8 server_list_type)

--- a/loginserver/world_server.h
+++ b/loginserver/world_server.h
@@ -187,13 +187,6 @@ private:
 	bool         m_is_server_logged_in;
 	bool         m_is_server_trusted;
 
-	/**
-	 * Keepalive
-	 * @param t
-	 */
-	void OnKeepAlive(EQ::Timer *t);
-	std::unique_ptr<EQ::Timer> m_keepalive;
-
 	static void FormatWorldServerName(char *name, int8 server_list_type);
 };
 

--- a/world/login_server.cpp
+++ b/world/login_server.cpp
@@ -595,11 +595,6 @@ bool LoginServer::Connect()
 		);
 	}
 
-	m_keepalive = std::make_unique<EQ::Timer>(
-		1000,
-		true,
-		std::bind(&LoginServer::OnKeepAlive, this, std::placeholders::_1));
-
 	return true;
 }
 
@@ -716,8 +711,3 @@ void LoginServer::SendAccountUpdate(ServerPacket *pack)
 	}
 }
 
-void LoginServer::OnKeepAlive(EQ::Timer *t)
-{
-	ServerPacket pack(ServerOP_KeepAlive, 0);
-	SendPacket(&pack);
-}

--- a/world/login_server.h
+++ b/world/login_server.h
@@ -50,7 +50,6 @@ private:
 	void ProcessLSRemoteAddr(uint16_t opcode, EQ::Net::Packet &p);
 	void ProcessLSAccountUpdate(uint16_t opcode, EQ::Net::Packet &p);
 
-	void OnKeepAlive(EQ::Timer *t);
 	std::unique_ptr<EQ::Timer> m_keepalive;
 
 	std::unique_ptr<EQ::Net::ServertalkClient>       m_client;

--- a/world/queryserv.cpp
+++ b/world/queryserv.cpp
@@ -22,7 +22,6 @@ void QueryServConnection::AddConnection(std::shared_ptr<EQ::Net::ServertalkServe
 	connection->OnMessage(ServerOP_QueryServGeneric, std::bind(&QueryServConnection::HandleGenericMessage, this, std::placeholders::_1, std::placeholders::_2));
 	connection->OnMessage(ServerOP_LFGuildUpdate, std::bind(&QueryServConnection::HandleLFGuildUpdateMessage, this, std::placeholders::_1, std::placeholders::_2));
 	m_streams.emplace(std::make_pair(connection->GetUUID(), connection));
-	m_keepalive = std::make_unique<EQ::Timer>(1000, true, std::bind(&QueryServConnection::OnKeepAlive, this, std::placeholders::_1));
 }
 
 void QueryServConnection::RemoveConnection(std::shared_ptr<EQ::Net::ServertalkServerConnection> connection)
@@ -54,8 +53,3 @@ bool QueryServConnection::SendPacket(ServerPacket* pack)
 	return true;
 }
 
-void QueryServConnection::OnKeepAlive(EQ::Timer *t)
-{
-	ServerPacket pack(ServerOP_KeepAlive, 0);
-	SendPacket(&pack);
-}

--- a/world/queryserv.h
+++ b/world/queryserv.h
@@ -15,7 +15,6 @@ public:
 	void HandleGenericMessage(uint16_t opcode, EQ::Net::Packet &p);
 	void HandleLFGuildUpdateMessage(uint16_t opcode, EQ::Net::Packet &p);
 	bool SendPacket(ServerPacket* pack);
-	void OnKeepAlive(EQ::Timer *t);
 private:
 	std::map<std::string, std::shared_ptr<EQ::Net::ServertalkServerConnection>> m_streams;
 	std::unique_ptr<EQ::Timer> m_keepalive;

--- a/world/ucs.cpp
+++ b/world/ucs.cpp
@@ -31,8 +31,6 @@ void UCSConnection::SetConnection(std::shared_ptr<EQ::Net::ServertalkServerConne
 			)
 		);
 	}
-
-	m_keepalive = std::make_unique<EQ::Timer>(1000, true, std::bind(&UCSConnection::OnKeepAlive, this, std::placeholders::_1));
 }
 
 const std::shared_ptr<EQ::Net::ServertalkServerConnection> &UCSConnection::GetConnection() const
@@ -91,14 +89,4 @@ void UCSConnection::SendMessage(const char *From, const char *Message)
 
 	SendPacket(pack);
 	safe_delete(pack);
-}
-
-void UCSConnection::OnKeepAlive(EQ::Timer *t)
-{
-	if (!connection) {
-		return;
-	}
-
-	ServerPacket pack(ServerOP_KeepAlive, 0);
-	connection->SendPacket(&pack);
 }

--- a/world/ucs.h
+++ b/world/ucs.h
@@ -23,11 +23,6 @@ private:
 	inline std::string GetIP() const { return (connection && connection->Handle()) ? connection->Handle()->RemoteIP() : 0; }
 	std::shared_ptr<EQ::Net::ServertalkServerConnection> connection;
 
-	/**
-	 * Keepalive
-	 */
-	std::unique_ptr<EQ::Timer> m_keepalive;
-	void OnKeepAlive(EQ::Timer *t);
 };
 
 #endif /*UCS_H_*/

--- a/world/zonelist.cpp
+++ b/world/zonelist.cpp
@@ -42,7 +42,6 @@ ZSList::ZSList()
 	memset(pLockedZones, 0, sizeof(pLockedZones));
 
 	m_tick = std::make_unique<EQ::Timer>(5000, true, std::bind(&ZSList::OnTick, this, std::placeholders::_1));
-	m_keepalive = std::make_unique<EQ::Timer>(1000, true, std::bind(&ZSList::OnKeepAlive, this, std::placeholders::_1));
 }
 
 ZSList::~ZSList() {
@@ -844,13 +843,6 @@ void ZSList::OnTick(EQ::Timer *t)
 	}
 
 	web_interface.SendEvent(out);
-}
-
-void ZSList::OnKeepAlive(EQ::Timer *t)
-{
-	for (auto &zone : zone_server_list) {
-		zone->SendKeepAlive();
-	}
 }
 
 const std::list<std::unique_ptr<ZoneServer>> &ZSList::getZoneServerList() const

--- a/world/zonelist.h
+++ b/world/zonelist.h
@@ -72,7 +72,6 @@ public:
 
 private:
 	void OnTick(EQ::Timer *t);
-	void OnKeepAlive(EQ::Timer *t);
 	uint32 NextID;
 	uint16	pLockedZones[MaxLockedZones];
 	uint32 CurGroupID;

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -91,8 +91,6 @@ void WorldServer::Connect()
 	});
 
 	m_connection->OnMessage(std::bind(&WorldServer::HandleMessage, this, std::placeholders::_1, std::placeholders::_2));
-
-	m_keepalive = std::make_unique<EQ::Timer>(1000, true, std::bind(&WorldServer::OnKeepAlive, this, std::placeholders::_1));
 }
 
 bool WorldServer::SendPacket(ServerPacket *pack)
@@ -4688,12 +4686,6 @@ void WorldServer::RequestTellQueue(const char *who)
 	SendPacket(pack);
 	safe_delete(pack);
 	return;
-}
-
-void WorldServer::OnKeepAlive(EQ::Timer *t)
-{
-	ServerPacket pack(ServerOP_KeepAlive, 0);
-	SendPacket(&pack);
 }
 
 ZoneEventScheduler *WorldServer::GetScheduler() const

--- a/zone/worldserver.h
+++ b/zone/worldserver.h
@@ -73,8 +73,6 @@ private:
 	uint32 cur_groupid;
 	uint32 last_groupid;
 
-	void OnKeepAlive(EQ::Timer *t);
-
 	std::unique_ptr<EQ::Net::ServertalkClient> m_connection;
 	std::unique_ptr<EQ::Timer> m_keepalive;
 


### PR DESCRIPTION
# Description

This fixes an issue with our server TCP connections not closing gracefully. In the past we've used empty packet keepalives inter-process to have the server prune the connections immediately. 

This PR should also significantly reduce keepalive load / chatter with servers with large amounts of processes.

Thanks to solar from Tak for code pairing on related issue https://github.com/EQEmu/Server/pull/4573

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

This is after killing 3 zone processes and below we see World disconnect the zoneserver on `UV_EOF` - we would see similarly for any other Server -> Server connection or Server -> Client that uses this connection class (Console, Websocket)

```
eqemu@83d7385f74ee:~/server$ pkill zone
  Zone |    Info    | Shutdown Shutting down... 
  Zone |    Info    | Shutdown Shutting down... 
  Zone |    Info    | Shutdown Shutting down... 
eqemu@83d7385f74ee:~/server$   Zone |    Info    | main Proper zone shutdown complete. 
  Zone |    Info    | main Proper zone shutdown complete. 
  Zone |    Info    | main Proper zone shutdown complete. 
 World |    Info    | operator() UV_EOF - Closing connection 
 World |    Info    | operator() Removed Zone Server connection from [85e3a0f1-4e45-4ae8-9dd6-69e7b8a83546] total zone_count [2] 
 World |    Info    | operator() UV_EOF - Closing connection 
 World |    Info    | operator() Removed Zone Server connection from [6146795f-f0b9-4e56-93a1-8c6535cc75b7] total zone_count [1] 
 World |    Info    | operator() UV_EOF - Closing connection 
 World |    Info    | operator() Removed Zone Server connection from [71d4c857-36a2-44e5-b8ad-24c0dca6b7cb] total zone_count [0] 
```

Inverse where we kill World and all zones close their connection to World

```
eqemu@83d7385f74ee:~/server$ pkill world
 World |    Info    | CatchSignal Caught signal [15] 
eqemu@83d7385f74ee:~/server$  World |    Info    | main World main loop completed 
 World |    Info    | main Shutting down zone connections (if any) 
 World |    Info    | main Zone (TCP) listener stopped 
 World |    Info    | main Signaling HTTP service to stop 
  Zone |    Info    | operator() UV_EOF - Closing connection 
  Zone |    Info    | operator() UV_EOF - Closing connection 
  Zone |    Info    | operator() UV_EOF - Closing connection 
```

Similar test with UCS

```
eqemu@83d7385f74ee:~/code/build$ pkill ucs
   UCS |    Info    | CatchSignal Caught signal [15] 
eqemu@83d7385f74ee:~/code/build$    UCS |    Info    | Shutdown Shutting down... 
 World |    Info    | operator() UV_EOF - Closing connection 
 World |    Info    | operator() Connection lost from UCS Server [f0c765cc-aa85-4162-8156-58c731e4809b] 
 World |    Info    | operator() Removing currently active UCS connection 
```

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
