### PR TITLE
[Fix] Fix guild creation to propagate across zones

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -7937,6 +7937,7 @@ void Client::Handle_OP_GuildCreate(const EQApplicationPacket *app)
 	SetGuildID(new_guild_id);
 	SendGuildList();
 	guild_mgr.MemberAdd(new_guild_id, CharacterID(), GetLevel(), GetClass(), GUILD_LEADER, GetZoneID(), GetName());
+	guild_mgr.SendGuildRefresh(new_guild_id, true, true, true, true);
 	guild_mgr.SendToWorldSendGuildList();
 	SendGuildSpawnAppearance();
 

--- a/zone/guild_mgr.h
+++ b/zone/guild_mgr.h
@@ -83,9 +83,9 @@ public:
 	void SendRankName(uint32 guild_id, uint32 rank, std::string rank_name);
 	void SendAllRankNames(uint32 guild_id, uint32 char_id);
 	BaseGuildManager::GuildInfo* GetGuildByGuildID(uint32 guild_id);
+	virtual void SendGuildRefresh(uint32 guild_id, bool name, bool motd, bool rank, bool relation);
 
 protected:
-	virtual void SendGuildRefresh(uint32 guild_id, bool name, bool motd, bool rank, bool relation);
 	virtual void SendCharRefresh(uint32 old_guild_id, uint32 guild_id, uint32 charid);
 	virtual void SendRankUpdate(uint32 CharID);
 	virtual void SendGuildDelete(uint32 guild_id);


### PR DESCRIPTION
# Description

When a new guild is created, it is not automatically propagated across booted zones.  This creates issues with permissions showing as empty, guild tags as <>, etc.  If the guild channel or guild url is updated, it would force the propagation.

This fix will force the propagation upon guild creation to ensure all booted zones have the details for the new guild.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
Tested on multi instances of a zone.

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur