### PR TITLE
[Logs] Improve Crash Log Defaults

### DIFF
--- a/common/crash.cpp
+++ b/common/crash.cpp
@@ -294,6 +294,8 @@ void print_trace()
 		SendCrashReport(crash_report);
 	}
 
+	LogSys.CloseFileLogs();
+
 	exit(1);
 }
 

--- a/common/eqemu_logsys.cpp
+++ b/common/eqemu_logsys.cpp
@@ -85,6 +85,7 @@ EQEmuLogSys *EQEmuLogSys::LoadLogSettingsDefaults()
 	 * Set Defaults
 	 */
 	log_settings[Logs::Crash].log_to_console                = static_cast<uint8>(Logs::General);
+	log_settings[Logs::Crash].log_to_file                   = static_cast<uint8>(Logs::General);
 	log_settings[Logs::MySQLError].log_to_console           = static_cast<uint8>(Logs::General);
 	log_settings[Logs::NPCScaling].log_to_gmsay             = static_cast<uint8>(Logs::General);
 	log_settings[Logs::HotReload].log_to_gmsay              = static_cast<uint8>(Logs::General);


### PR DESCRIPTION
# Description

This improves defaults for crash logs by setting file to on by default and flushing the log file buffer during a crash.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

![image](https://github.com/user-attachments/assets/9438436a-efdc-47be-bba5-318fda64577f)

![image](https://github.com/user-attachments/assets/98009756-abe6-421c-8b30-f17724a7214b)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

