### PR TITLE
[Bug Fix] Client 'Hitch Bug' Fix due to large guild membership

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -860,7 +860,7 @@ void Client::CompleteConnect()
 	if (IsInAGuild()) {
 		if (firstlogon == 1) {
 			guild_mgr.UpdateDbMemberOnline(CharacterID(), true);
-			guild_mgr.SendToWorldSendGuildMembersList(GuildID());
+			SendGuildMembersList();
 		}
 
 		guild_mgr.SendGuildMemberUpdateToWorld(GetName(), GuildID(), zone->GetZoneID(), time(nullptr));

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -179,7 +179,7 @@ bool Client::Process() {
 			}
 			if (IsInAGuild()) {
 				guild_mgr.UpdateDbMemberOnline(CharacterID(), false);
-				guild_mgr.SendToWorldSendGuildMembersList(GuildID());
+				guild_mgr.SendGuildMemberUpdateToWorld(GetName(), GuildID(), 0, time(nullptr));
 			}
 
 			SetDynamicZoneMemberStatus(DynamicZoneMemberStatus::Offline);
@@ -202,7 +202,7 @@ bool Client::Process() {
 			Save();
 			if (IsInAGuild()) {
 				guild_mgr.UpdateDbMemberOnline(CharacterID(), false);
-				guild_mgr.SendToWorldSendGuildMembersList(GuildID());
+				guild_mgr.SendGuildMemberUpdateToWorld(GetName(), GuildID(), 0, time(nullptr));
 			}
 
 			if (GetMerc())
@@ -578,7 +578,7 @@ bool Client::Process() {
 			}
 			if (IsInAGuild()) {
 				guild_mgr.UpdateDbMemberOnline(CharacterID(), false);
-				guild_mgr.SendToWorldSendGuildMembersList(GuildID());
+				guild_mgr.SendGuildMemberUpdateToWorld(GetName(), GuildID(), 0, time(nullptr));
 			}
 
 			return false;


### PR DESCRIPTION
When the guild membership was large (1k+) the client would studder for half a sec when a guild member would login or logout.  This was reproduceable with a guild size of 2k members though the floor would be client dependent most likely.  I did not work out the lower limit though some operators noticed it above 1k guild members.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
I tested with a guild membership of 2000, with Player A running in the Arena while Player B from the same guild logged in and logged out.  The result is that Player A would 'hitch' or 'pause' for a brief moment.  It was very noticeable.
Post the change, the hitch was no longer present.

This also been running several days within WFH without any side effects.

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
