### PR TITLE
[Fix] Repair a EQEMUConfig Memory Leak

### DIFF
--- a/common/eqemu_config.h
+++ b/common/eqemu_config.h
@@ -137,9 +137,9 @@ class EQEmuConfig
 		{
 
 		}
-		virtual ~EQEmuConfig() {}
 
 	public:
+		virtual ~EQEmuConfig() {}
 
 		// Produce a const singleton
 		static const EQEmuConfig *get()

--- a/zone/zone_config.h
+++ b/zone/zone_config.h
@@ -43,11 +43,13 @@ class ZoneConfig : public EQEmuConfig {
 	}
 
 	// Load the config
-	static bool LoadConfig(const std::string& path = "") {
-		if (_zone_config != nullptr)
-			delete _zone_config;
-		_zone_config=new ZoneConfig;
-		_config=_zone_config;
+	static bool LoadConfig(const std::string &path = "")
+	{
+		safe_delete(_zone_config);
+		safe_delete(_config);
+
+		_zone_config = new ZoneConfig;
+		_config      = _zone_config;
 
 		return _config->parseFile(path);
 	}


### PR DESCRIPTION
# Description

The process for a zone initialization is that; _config was being initialized then _zone_config was being initialized.  
Both were initialized with the 'new' keyword.
Once _zone_config was initialized, it was then copied to _config, without first deleting _config.  This lead to a memory leak.

This fix deletes _config prior to the copy.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
Memory leak and resolution validated with Valgrind

Clients tested: 
Tested with RoF2 with a zone login, spawn an npc, and a camp.

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur