### PR TITLE
[Fix] Repair a memory leak in GuildsList

### DIFF
--- a/common/patches/rof2.cpp
+++ b/common/patches/rof2.cpp
@@ -1845,11 +1845,11 @@ namespace RoF2
 			}
 		}
 
-		auto outapp     = new EQApplicationPacket(OP_GuildsList);
-		outapp->size    = packet_size;
-		outapp->pBuffer = buffer;
+		safe_delete_array(in->pBuffer);
 
-		dest->FastQueuePacket(&outapp);
+		in->pBuffer = buffer;
+		in->size    = packet_size;
+		dest->FastQueuePacket(&in);
 	}
 
 	ENCODE(OP_GuildTributeDonateItem)


### PR DESCRIPTION
# Description

When the guildslist was encoded for RoF2, the inbound pBuffer was not being deleted correctly, resulting in a memory leak. 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
Validated the memory leak and the resolution with Valgrind

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
