### PR TITLE
[Fix] Repair a LoadNPCEmote MemoryLeak

### DIFF
--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -1100,7 +1100,12 @@ Zone::~Zone() {
 	if (worldserver.Connected()) {
 		worldserver.SetZoneData(0);
 	}
+
+	for (auto &e: npc_emote_list) {
+		safe_delete(e);
+	}
 	npc_emote_list.clear();
+
 	zone_point_list.Clear();
 	entity_list.Clear();
 	parse->ReloadQuests();
@@ -1257,7 +1262,6 @@ void Zone::ReloadStaticData() {
 
 	LoadVeteranRewards();
 	LoadAlternateCurrencies();
-	npc_emote_list.clear();
 	LoadNPCEmotes(&npc_emote_list);
 
 	//load the zone config file.
@@ -2575,6 +2579,10 @@ void Zone::DoAdventureActions()
 
 void Zone::LoadNPCEmotes(std::vector<NPC_Emote_Struct*>* v)
 {
+	for (auto &e: *v) {
+		safe_delete(e);
+	}
+
 	v->clear();
 
 	const auto& l = NpcEmotesRepository::All(content_db);


### PR DESCRIPTION
# Description

Two issues were identified.

1. When a zone was shutdown, the npc_emote_list was cleared, however its contents were established with the 'new' keyword.  The entries were not deleted before the clear.
2. When reloading the NPCEmoteList, for example using #reload npc_emotes, the list was cleared, without the delete.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
Validated the memory leak and resolution with Valgrind.

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
