### PR TITLE
[Fix] Repair an incorrect safe_delete call memory leak.

### DIFF
--- a/common/patches/rof2.cpp
+++ b/common/patches/rof2.cpp
@@ -487,7 +487,7 @@ namespace RoF2
 					VARSTRUCT_ENCODE_TYPE(uint32, bufptr, i.item_stat);                          //itemstat
 				}
 
-				safe_delete(in->pBuffer);
+				safe_delete_array(in->pBuffer);
 				in->size    = p_size;
 				in->pBuffer = (uchar *) buffer.get();
 				dest->QueuePacket(in);
@@ -508,7 +508,7 @@ namespace RoF2
 				eq->num_of_traders = emu->traders;
 				eq->num_of_items   = emu->items;
 
-				safe_delete(in->pBuffer);
+				safe_delete_array(in->pBuffer);
 				in->SetOpcode(OP_TraderShop);
 				in->size    = sizeof(structs::BazaarWelcome_Struct);
 				in->pBuffer = (uchar *) buffer.get();


### PR DESCRIPTION
# Description

Correct two incorrect safe_delete statements that should be safe_delete_array.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
Tested to ensure that the deletes were correct, no issues seen.

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
