### PR TITLE
[Fix] Add Bazaar BulkSendTrader Limit for RoF2

### DIFF
--- a/common/eq_limits.cpp
+++ b/common/eq_limits.cpp
@@ -47,6 +47,7 @@ static const EQ::constants::LookupEntry constants_static_lookup_entries[EQ::vers
 		ClientUnknown::constants::EXPANSION_BIT,
 		ClientUnknown::constants::EXPANSIONS_MASK,
 		ClientUnknown::INULL,
+		ClientUnknown::INULL,
 		ClientUnknown::INULL
 	),
 	/*[ClientVersion::Client62] =*/
@@ -54,6 +55,7 @@ static const EQ::constants::LookupEntry constants_static_lookup_entries[EQ::vers
 		Client62::constants::EXPANSION,
 		Client62::constants::EXPANSION_BIT,
 		Client62::constants::EXPANSIONS_MASK,
+		Client62::INULL,
 		Client62::INULL,
 		Client62::INULL
 	),
@@ -63,7 +65,8 @@ static const EQ::constants::LookupEntry constants_static_lookup_entries[EQ::vers
 		Titanium::constants::EXPANSION_BIT,
 		Titanium::constants::EXPANSIONS_MASK,
 		Titanium::constants::CHARACTER_CREATION_LIMIT,
-		Titanium::constants::SAY_LINK_BODY_SIZE
+		Titanium::constants::SAY_LINK_BODY_SIZE,
+		Titanium::INULL
 	),
 	/*[ClientVersion::SoF] =*/
 	EQ::constants::LookupEntry(
@@ -71,7 +74,8 @@ static const EQ::constants::LookupEntry constants_static_lookup_entries[EQ::vers
 		SoF::constants::EXPANSION_BIT,
 		SoF::constants::EXPANSIONS_MASK,
 		SoF::constants::CHARACTER_CREATION_LIMIT,
-		SoF::constants::SAY_LINK_BODY_SIZE
+		SoF::constants::SAY_LINK_BODY_SIZE,
+		SoF::INULL
 	),
 	/*[ClientVersion::SoD] =*/
 	EQ::constants::LookupEntry(
@@ -79,7 +83,8 @@ static const EQ::constants::LookupEntry constants_static_lookup_entries[EQ::vers
 		SoD::constants::EXPANSION_BIT,
 		SoD::constants::EXPANSIONS_MASK,
 		SoD::constants::CHARACTER_CREATION_LIMIT,
-		SoD::constants::SAY_LINK_BODY_SIZE
+		SoD::constants::SAY_LINK_BODY_SIZE,
+		SoD::INULL
 	),
 	/*[ClientVersion::UF] =*/
 	EQ::constants::LookupEntry(
@@ -87,7 +92,8 @@ static const EQ::constants::LookupEntry constants_static_lookup_entries[EQ::vers
 		UF::constants::EXPANSION_BIT,
 		UF::constants::EXPANSIONS_MASK,
 		UF::constants::CHARACTER_CREATION_LIMIT,
-		UF::constants::SAY_LINK_BODY_SIZE
+		UF::constants::SAY_LINK_BODY_SIZE,
+		UF::INULL
 	),
 	/*[ClientVersion::RoF] =*/
 	EQ::constants::LookupEntry(
@@ -95,7 +101,8 @@ static const EQ::constants::LookupEntry constants_static_lookup_entries[EQ::vers
 		RoF::constants::EXPANSION_BIT,
 		RoF::constants::EXPANSIONS_MASK,
 		RoF::constants::CHARACTER_CREATION_LIMIT,
-		RoF::constants::SAY_LINK_BODY_SIZE
+		RoF::constants::SAY_LINK_BODY_SIZE,
+		RoF::INULL
 	),
 	/*[ClientVersion::RoF2] =*/
 	EQ::constants::LookupEntry(
@@ -103,7 +110,8 @@ static const EQ::constants::LookupEntry constants_static_lookup_entries[EQ::vers
 		RoF2::constants::EXPANSION_BIT,
 		RoF2::constants::EXPANSIONS_MASK,
 		RoF2::constants::CHARACTER_CREATION_LIMIT,
-		RoF2::constants::SAY_LINK_BODY_SIZE
+		RoF2::constants::SAY_LINK_BODY_SIZE,
+		RoF2::constants::MAX_BAZAAR_TRADERS
 	)
 };
 

--- a/common/eq_limits.h
+++ b/common/eq_limits.h
@@ -42,6 +42,7 @@ namespace EQ
 			uint32 ExpansionsMask;
 			int16 CharacterCreationLimit;
 			size_t SayLinkBodySize;
+			uint32 BazaarTraderLimit;
 			
 			LookupEntry(const LookupEntry *lookup_entry) { }
 			LookupEntry(
@@ -49,13 +50,15 @@ namespace EQ
 				uint32 ExpansionBit,
 				uint32 ExpansionsMask,
 				int16 CharacterCreationLimit,
-				size_t SayLinkBodySize
+				size_t SayLinkBodySize,
+				uint32 BazaarTraderLimit
 			) :
 				Expansion(Expansion),
 				ExpansionBit(ExpansionBit),
 				ExpansionsMask(ExpansionsMask),
 				CharacterCreationLimit(CharacterCreationLimit),
-				SayLinkBodySize(SayLinkBodySize)
+				SayLinkBodySize(SayLinkBodySize),
+				BazaarTraderLimit(BazaarTraderLimit)
 			{ }
 		};
 

--- a/common/patches/rof2_limits.h
+++ b/common/patches/rof2_limits.h
@@ -272,6 +272,7 @@ namespace RoF2
 
 		const size_t SAY_LINK_BODY_SIZE = 56;
 		const uint32 MAX_GUILD_ID       = 50000;
+		const uint32 MAX_BAZAAR_TRADERS = 600;
 
 	} /*constants*/
 

--- a/common/patches/titanium_limits.h
+++ b/common/patches/titanium_limits.h
@@ -286,8 +286,8 @@ namespace Titanium
 
 		const size_t CHARACTER_CREATION_LIMIT = 8; // Hard-coded in client - DO NOT ALTER
 
-		const size_t SAY_LINK_BODY_SIZE = 45;
-		const uint32 MAX_GUILD_ID       = 1500;
+		const size_t SAY_LINK_BODY_SIZE       = 45;
+		const uint32 MAX_GUILD_ID             = 1500;
 
 	} /*constants*/
 

--- a/common/repositories/trader_repository.h
+++ b/common/repositories/trader_repository.h
@@ -40,15 +40,18 @@ public:
 		int32 char_zone_instance_id
 	);
 
-	static BulkTraders_Struct GetDistinctTraders(Database &db)
+	static BulkTraders_Struct GetDistinctTraders(Database &db, uint32 char_zone_instance_id, uint32 max_results)
 	{
 		BulkTraders_Struct                  all_entries{};
 		std::vector<DistinctTraders_Struct> distinct_traders;
 
-		auto results = db.QueryDatabase(
+		auto results = db.QueryDatabase(fmt::format(
 			"SELECT DISTINCT(t.char_id), t.char_zone_id, t.char_zone_instance_id, t.char_entity_id, c.name "
 			"FROM trader AS t "
-			"JOIN character_data AS c ON t.char_id = c.id;"
+			"JOIN character_data AS c ON t.char_id = c.id "
+			"ORDER BY t.char_zone_instance_id = {} DESC LIMIT {};",
+			char_zone_instance_id,
+			max_results)
 		);
 
 		distinct_traders.reserve(results.RowCount());

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -3219,7 +3219,12 @@ void Client::SendBulkBazaarTraders()
 		return;
 	}
 
-	auto  results = TraderRepository::GetDistinctTraders(database);
+	auto results = TraderRepository::GetDistinctTraders(
+		database,
+		GetInstanceID(),
+		EQ::constants::StaticLookup(ClientVersion())->BazaarTraderLimit
+	);
+
 	auto  p_size  = 4 + 12 * results.count + results.name_length;
 	auto  buffer  = std::make_unique<char[]>(p_size);
 	memset(buffer.get(), 0, p_size);


### PR DESCRIPTION
# Description

RoF2 has a client limit of 600 traders.  Currently, this is not checked server side and therefore if there are more than 600 traders (reached with THJ large player base), the client would crash upon receiving the BulkSendTrader list packet.

This packet populates the bazaar search window dropdown list of traders and is required for the window to function.

With this fix, I have created a constant for RoF2 for this limitation allow for this to be easily modified as newer clients are added.  This will allow the server operator to have more than 600 traders, and limit the packet to 600 max.  The client allows for 'all traders' (the 600 limit) and 'local traders' (the players current zone).  I have therefore created the packet to include all the traders from the players local zone and then augment to the 600 max with traders from outside the local zone.  This will allow players to search 'up to' 600 traders, and always have access to the local traders (which on THJ is set to 200).

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# Testing
This was tested with a trader table of 1000 traders, with 12 in instance 34 and the remaining 988 in instance 35.  The client was able to login without crashing, zone without crashing and retrieve 12 traders with local trader searching, and 600 for all traders, which included the 12.

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
