### PR TITLE
[Fix] Repair a memory leak in #summonitem

### DIFF
--- a/zone/gm_commands/summonitem.cpp
+++ b/zone/gm_commands/summonitem.cpp
@@ -132,4 +132,6 @@ void command_summonitem(Client *c, const Seperator *sep)
 			item_link
 		).c_str()
 	);
+
+	safe_delete(new_item);
 }


### PR DESCRIPTION
# Description

Include a delete within the summon item command to resolve a memory leak.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
Tested by summoning an item and noting that the memory leak was no longer reported.

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
