### PR TITLE
[Fix] Update a few Bazaar RoF2 routines for memory leaks

### DIFF
--- a/common/patches/rof2.cpp
+++ b/common/patches/rof2.cpp
@@ -433,7 +433,9 @@ namespace RoF2
 					VARSTRUCT_ENCODE_TYPE(uint32, eq, i.item_icon);
 					VARSTRUCT_SKIP_TYPE(uint32, eq);
 				}
+
 				dest->QueuePacket(outapp.get());
+				safe_delete(in);
 				break;
 			}
 			default: {
@@ -468,8 +470,8 @@ namespace RoF2
 				}
 
 				auto p_size = 41 * results.size() + name_size + 14;
-				auto buffer = std::make_unique<char[]>(p_size);
-				auto bufptr = buffer.get();
+				auto buffer = new char[p_size];
+				auto bufptr = buffer;
 
 				VARSTRUCT_ENCODE_TYPE(uint32, bufptr, 0);
 				VARSTRUCT_ENCODE_TYPE(uint16, bufptr, results[0].trader_zone_id);
@@ -489,8 +491,9 @@ namespace RoF2
 
 				safe_delete_array(in->pBuffer);
 				in->size    = p_size;
-				in->pBuffer = (uchar *) buffer.get();
+				in->pBuffer = (uchar*)buffer;
 				dest->QueuePacket(in);
+				safe_delete(in);
 
 				break;
 			}
@@ -500,9 +503,9 @@ namespace RoF2
 				break;
 			}
 			case WelcomeMessage: {
-				auto buffer = std::make_unique<char[]>(sizeof(structs::BazaarWelcome_Struct));
+				auto buffer = new char[sizeof(structs::BazaarWelcome_Struct)];
 				auto emu    = (BazaarWelcome_Struct *) in->pBuffer;
-				auto eq     = (structs::BazaarWelcome_Struct *) buffer.get();
+				auto eq     = (structs::BazaarWelcome_Struct *) buffer;
 
 				eq->action         = structs::RoF2BazaarTraderBuyerActions::WelcomeMessage;
 				eq->num_of_traders = emu->traders;
@@ -511,10 +514,11 @@ namespace RoF2
 				safe_delete_array(in->pBuffer);
 				in->SetOpcode(OP_TraderShop);
 				in->size    = sizeof(structs::BazaarWelcome_Struct);
-				in->pBuffer = (uchar *) buffer.get();
+				in->pBuffer = (uchar *)buffer;
 
 				LogTrading("(RoF2) WelcomeMessage action <green>[{}]", action);
 				dest->QueuePacket(in);
+				safe_delete(in);
 
 				break;
 			}
@@ -892,7 +896,9 @@ namespace RoF2
 					VARSTRUCT_ENCODE_TYPE(uint16, eq, b.buyer_zone_instance_id);
 					VARSTRUCT_ENCODE_STRING(eq, b.buyer_name.c_str());
 				}
+
 				dest->QueuePacket(outapp.get());
+				safe_delete(inapp);
 				break;
 			}
 			case Barter_RemoveFromMerchantWindow: {
@@ -963,6 +969,7 @@ namespace RoF2
 				VARSTRUCT_ENCODE_TYPE(uint32, eq, blsi.seller_quantity);
 
 				dest->QueuePacket(outapp.get());
+				safe_delete(inapp);
 				break;
 			}
 			default: {


### PR DESCRIPTION
Memory leak repairs

# Description

There were a few RoF2 Bazaar/Buyer routines which were not deleting the inbound emu packet correctly.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
Tested against valgrind to ensure that the leaks were removed.

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
