### PR TITLE
[Fix] Update trader add/remove packets to limits for RoF2

### DIFF
--- a/zone/client.h
+++ b/zone/client.h
@@ -1128,6 +1128,10 @@ public:
 	void SetTrader(bool status) { trader = status; }
 	uint16 GetTraderID() { return trader_id; }
 	void SetTraderID(uint16 id) { trader_id = id; }
+	void SetNoOfTraders(uint32 no) { m_no_traders = no; }
+	uint32 GetNoOfTraders() { return m_no_traders; }
+	void IncrementNoOfTraders() { m_no_traders += 1; }
+	void DecrementNoOfTraders() { m_no_traders > 0 ? m_no_traders -= 1 : m_no_traders = 0; }
 
 	eqFilterMode GetFilter(eqFilterType filter_id) const { return ClientFilters[filter_id]; }
 	void SetFilter(eqFilterType filter_id, eqFilterMode filter_mode) { ClientFilters[filter_id] = filter_mode; }
@@ -1946,6 +1950,7 @@ private:
 	uint8 firstlogon;
 	uint32 mercid; // current merc
 	uint8 mercSlot; // selected merc slot
+	uint32                                                         m_no_traders{};
 	uint32                                                         m_buyer_id;
 	uint32                                                         m_barter_time;
 	int32                                                          m_parcel_platinum;

--- a/zone/client.h
+++ b/zone/client.h
@@ -1128,10 +1128,10 @@ public:
 	void SetTrader(bool status) { trader = status; }
 	uint16 GetTraderID() { return trader_id; }
 	void SetTraderID(uint16 id) { trader_id = id; }
-	void SetNoOfTraders(uint32 no) { m_no_traders = no; }
-	uint32 GetNoOfTraders() { return m_no_traders; }
-	void IncrementNoOfTraders() { m_no_traders += 1; }
-	void DecrementNoOfTraders() { m_no_traders > 0 ? m_no_traders -= 1 : m_no_traders = 0; }
+	void SetTraderCount(uint32 no) { m_trader_count = no; }
+	uint32 GetTraderCount() { return m_trader_count; }
+	void IncrementTraderCount() { m_trader_count += 1; }
+	void DecrementTraderCount() { m_trader_count > 0 ? m_trader_count -= 1 : m_trader_count = 0; }
 
 	eqFilterMode GetFilter(eqFilterType filter_id) const { return ClientFilters[filter_id]; }
 	void SetFilter(eqFilterType filter_id, eqFilterMode filter_mode) { ClientFilters[filter_id] = filter_mode; }
@@ -1950,7 +1950,7 @@ private:
 	uint8 firstlogon;
 	uint32 mercid; // current merc
 	uint8 mercSlot; // selected merc slot
-	uint32                                                         m_no_traders{};
+	uint32                                                         m_trader_count{};
 	uint32                                                         m_buyer_id;
 	uint32                                                         m_barter_time;
 	int32                                                          m_parcel_platinum;

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -3225,6 +3225,8 @@ void Client::SendBulkBazaarTraders()
 		EQ::constants::StaticLookup(ClientVersion())->BazaarTraderLimit
 	);
 
+	SetNoOfTraders(results.count);
+
 	auto  p_size  = 4 + 12 * results.count + results.name_length;
 	auto  buffer  = std::make_unique<char[]>(p_size);
 	memset(buffer.get(), 0, p_size);

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -3225,7 +3225,7 @@ void Client::SendBulkBazaarTraders()
 		EQ::constants::StaticLookup(ClientVersion())->BazaarTraderLimit
 	);
 
-	SetNoOfTraders(results.count);
+	SetTraderCount(results.count);
 
 	auto  p_size  = 4 + 12 * results.count + results.name_length;
 	auto  buffer  = std::make_unique<char[]>(p_size);

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -3924,9 +3924,9 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 					switch (in->action) {
 						case TraderOn: {
 							out->action = AddTraderToBazaarWindow;
-							if (c.second->GetNoOfTraders() <
+							if (c.second->GetTraderCount() <
 								EQ::constants::StaticLookup(c.second->ClientVersion())->BazaarTraderLimit) {
-									c.second->IncrementNoOfTraders();
+									c.second->IncrementTraderCount();
 									c.second->QueuePacket(outapp, true, Mob::CLIENT_CONNECTED);
 							}
 
@@ -3934,7 +3934,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 						}
 						case TraderOff: {
 							out->action = RemoveTraderFromBazaarWindow;
-							c.second->DecrementNoOfTraders();
+							c.second->DecrementTraderCount();
 							c.second->QueuePacket(outapp, true, Mob::CLIENT_CONNECTED);
 							break;
 						}

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -3912,21 +3912,8 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 			auto            in = (TraderMessaging_Struct *) pack->pBuffer;
 			for (auto const &c: entity_list.GetClientList()) {
 				if (c.second->ClientVersion() >= EQ::versions::ClientVersion::RoF2) {
-					auto outapp    = new EQApplicationPacket(OP_BecomeTrader, sizeof(BecomeTrader_Struct));
-					auto out       = (BecomeTrader_Struct *) outapp->pBuffer;
-					switch (in->action) {
-						case TraderOn: {
-							out->action = AddTraderToBazaarWindow;
-							break;
-						}
-						case TraderOff: {
-							out->action = RemoveTraderFromBazaarWindow;
-							break;
-						}
-						default: {
-							out->action = 0;
-						}
-					}
+					auto outapp           = new EQApplicationPacket(OP_BecomeTrader, sizeof(BecomeTrader_Struct));
+					auto out              = (BecomeTrader_Struct *) outapp->pBuffer;
 
 					out->entity_id        = in->entity_id;
 					out->zone_id          = in->zone_id;
@@ -3934,7 +3921,29 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 					out->trader_id        = in->trader_id;
 					strn0cpy(out->trader_name, in->trader_name, sizeof(out->trader_name));
 
-					c.second->QueuePacket(outapp, true, Mob::CLIENT_CONNECTED);
+					switch (in->action) {
+						case TraderOn: {
+							out->action = AddTraderToBazaarWindow;
+							if (c.second->GetNoOfTraders() <
+								EQ::constants::StaticLookup(c.second->ClientVersion())->BazaarTraderLimit) {
+									c.second->IncrementNoOfTraders();
+									c.second->QueuePacket(outapp, true, Mob::CLIENT_CONNECTED);
+							}
+
+							break;
+						}
+						case TraderOff: {
+							out->action = RemoveTraderFromBazaarWindow;
+							c.second->DecrementNoOfTraders();
+							c.second->QueuePacket(outapp, true, Mob::CLIENT_CONNECTED);
+							break;
+						}
+						default: {
+							out->action = 0;
+							c.second->QueuePacket(outapp, true, Mob::CLIENT_CONNECTED);
+						}
+					}
+
 					safe_delete(outapp);
 				}
 				if (zone && zone->GetZoneID() == Zones::BAZAAR && in->instance_id == zone->GetInstanceID()) {


### PR DESCRIPTION
# Description

As previously noted, the RoF2 limit for the number of traders is 600.  If there are already 600 traders within the client and a new trader is enabled, the 601st would crash the client.

This fix tracks that condition and does not send the packet.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
Tested with a client that had 600 traders, and then enabled a new trader.  Prior the client would crash.  Post, the client would not crash.

Clients tested: 
RoF2 against linux and windows builds

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
