### PR TITLE
[Quest API] Add SetAAEXPPercentage to Perl/Lua

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -13106,3 +13106,19 @@ void Client::ShowZoneShardMenu()
 		number++;
 	}
 }
+
+void Client::SetAAEXPPercentage(uint8 percentage)
+{
+	const uint32 before_percentage = m_epp.perAA;
+
+	if (before_percentage > 0 && percentage == 0) {
+		MessageString(Chat::White, AA_OFF);
+	} else if (before_percentage == 0 && percentage > 0) {
+		MessageString(Chat::White, AA_ON);
+	}
+
+	m_epp.perAA = EQ::Clamp(static_cast<int>(percentage), 0, 100);
+
+	SendAlternateAdvancementStats();
+	SendAlternateAdvancementTable();
+}

--- a/zone/client.h
+++ b/zone/client.h
@@ -692,6 +692,8 @@ public:
 	void SetAAEXPModifier(uint32 zone_id, float aa_modifier, int16 instance_version = -1);
 	void SetEXPModifier(uint32 zone_id, float exp_modifier, int16 instance_version = -1);
 
+	void SetAAEXPPercentage(uint8 percentage);
+
 	bool UpdateLDoNPoints(uint32 theme_id, int points);
 	void SetLDoNPoints(uint32 theme_id, uint32 points);
 	void SetPVPPoints(uint32 Points) { m_pp.PVPCurrentPoints = Points; }

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1864,8 +1864,9 @@ void Client::Handle_OP_AAAction(const EQApplicationPacket *app)
 		PurchaseAlternateAdvancementRank(action->ability);
 	}
 	else if (action->action == aaActionDisableEXP) { //Turn Off AA Exp
-		if (m_epp.perAA > 0)
+		if (m_epp.perAA > 0) {
 			MessageString(Chat::White, AA_OFF);
+		}
 
 		m_epp.perAA = 0;
 		SendAlternateAdvancementStats();

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3458,6 +3458,12 @@ void Lua_Client::ShowZoneShardMenu()
 	self->ShowZoneShardMenu();
 }
 
+void Lua_Client::SetAAEXPPercentage(uint8 percentage)
+{
+	Lua_Safe_Call_Void();
+	self->SetAAEXPPercentage(percentage);
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 	.def(luabind::constructor<>())
@@ -3890,6 +3896,7 @@ luabind::scope lua_register_client() {
 	.def("SetAAEXPModifier", (void(Lua_Client::*)(float))&Lua_Client::SetAAEXPModifier)
 	.def("SetAAEXPModifier", (void(Lua_Client::*)(uint32,float))&Lua_Client::SetAAEXPModifier)
 	.def("SetAAEXPModifier", (void(Lua_Client::*)(uint32,float,int16))&Lua_Client::SetAAEXPModifier)
+	.def("SetAAEXPPercentage", (void(Lua_Client::*)(uint8))&Lua_Client::SetAAEXPPercentage)
 	.def("SetAAPoints", (void(Lua_Client::*)(int))&Lua_Client::SetAAPoints)
 	.def("SetAATitle", (void(Lua_Client::*)(std::string))&Lua_Client::SetAATitle)
 	.def("SetAATitle", (void(Lua_Client::*)(std::string,bool))&Lua_Client::SetAATitle)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -510,6 +510,7 @@ public:
 	void AreaTaunt(float range);
 	void AreaTaunt(float range, int bonus_hate);
 	luabind::object GetInventorySlots(lua_State* L);
+	void SetAAEXPPercentage(uint8 percentage);
 
 	void ApplySpell(int spell_id);
 	void ApplySpell(int spell_id, int duration);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -3229,6 +3229,11 @@ perl::array Perl_Client_GetInventorySlots(Client* self)
 	return result;
 }
 
+void Perl_Client_SetAAEXPPercentage(Client* self, uint8 percentage)
+{
+	self->SetAAEXPPercentage(percentage);
+}
+
 void perl_register_client()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3657,6 +3662,7 @@ void perl_register_client()
 	package.add("SetAAEXPModifier", (void(*)(Client*, float))&Perl_Client_SetAAEXPModifier);
 	package.add("SetAAEXPModifier", (void(*)(Client*, uint32, float))&Perl_Client_SetAAEXPModifier);
 	package.add("SetAAEXPModifier", (void(*)(Client*, uint32, float, int16))&Perl_Client_SetAAEXPModifier);
+	package.add("SetAAEXPPercentage", &Perl_Client_SetAAEXPPercentage);
 	package.add("SetAAPoints", &Perl_Client_SetAAPoints);
 	package.add("SetAATitle", (void(*)(Client*, std::string))&Perl_Client_SetAATitle);
 	package.add("SetAATitle", (void(*)(Client*, std::string, bool))&Perl_Client_SetAATitle);


### PR DESCRIPTION
# Description
- Adds a way to set the AA Experience percentage via quest scripts.
- Note: Client will automatically disable AA Experience percentage if the client is below level 51 and you do not have a custom DLL to otherwise allow this functionality below level 51.

# Perl
- Add `$client->SetAAEXPPercentage(percentage)`.

# Lua
- Add `client:SetAAEXPPercentage(percentage)`.

## Type of change
- [X] New feature

# Testing
![image](https://github.com/user-attachments/assets/c76c648e-fa12-4130-a3e4-38e34eb36ec2)
![image](https://github.com/user-attachments/assets/dfa5a947-4634-40c6-8099-bcd0041d6bdf)

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur