### PR TITLE
[Databuckets] Add Account Scoped Databuckets

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -6301,7 +6301,24 @@ ALTER TABLE zone DROP COLUMN IF EXISTS npc_update_range;
 ALTER TABLE zone DROP COLUMN IF EXISTS max_movement_update_range;
 ALTER TABLE `zone` ADD COLUMN `client_update_range` int(11) NOT NULL DEFAULT 600 AFTER `npc_max_aggro_dist`;
 )",
-		.content_schema_update = true
+		.content_schema_update = true,
+	},
+	ManifestEntry{
+		.version = 9292,
+		.description = "2025_01_21_data_buckets_account_id",
+		.check       = "SHOW COLUMNS FROM `data_buckets` LIKE 'account_id'",
+		.condition   = "empty",
+		.match = "",
+		.sql = R"(
+ALTER TABLE `data_buckets`
+ADD COLUMN `account_id` bigint(11) NULL DEFAULT 0 AFTER `expires`,
+DROP INDEX `keys`,
+ADD UNIQUE INDEX `keys` (`key`, `character_id`, `npc_id`, `bot_id`, `account_id`) USING BTREE;
+
+-- Add the INDEX for character_id and key
+ALTER TABLE `data_buckets` ADD KEY `idx_account_id_key` (`account_id`, `key`);
+)",
+		.content_schema_update = false
 	},
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{

--- a/common/repositories/base/base_data_buckets_repository.h
+++ b/common/repositories/base/base_data_buckets_repository.h
@@ -23,6 +23,7 @@ public:
 		std::string key_;
 		std::string value;
 		uint32_t    expires;
+		int64_t     account_id;
 		int64_t     character_id;
 		int64_t     npc_id;
 		int64_t     bot_id;
@@ -36,6 +37,7 @@ public:
 				CEREAL_NVP(key_),
 				CEREAL_NVP(value),
 				CEREAL_NVP(expires),
+				CEREAL_NVP(account_id),
 				CEREAL_NVP(character_id),
 				CEREAL_NVP(npc_id),
 				CEREAL_NVP(bot_id)
@@ -55,6 +57,7 @@ public:
 			"`key`",
 			"value",
 			"expires",
+			"account_id",
 			"character_id",
 			"npc_id",
 			"bot_id",
@@ -68,6 +71,7 @@ public:
 			"`key`",
 			"value",
 			"expires",
+			"account_id",
 			"character_id",
 			"npc_id",
 			"bot_id",
@@ -115,6 +119,7 @@ public:
 		e.key_         = "";
 		e.value        = "";
 		e.expires      = 0;
+		e.account_id   = 0;
 		e.character_id = 0;
 		e.npc_id       = 0;
 		e.bot_id       = 0;
@@ -158,9 +163,10 @@ public:
 			e.key_         = row[1] ? row[1] : "";
 			e.value        = row[2] ? row[2] : "";
 			e.expires      = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
-			e.character_id = row[4] ? strtoll(row[4], nullptr, 10) : 0;
-			e.npc_id       = row[5] ? strtoll(row[5], nullptr, 10) : 0;
-			e.bot_id       = row[6] ? strtoll(row[6], nullptr, 10) : 0;
+			e.account_id   = row[4] ? strtoll(row[4], nullptr, 10) : 0;
+			e.character_id = row[5] ? strtoll(row[5], nullptr, 10) : 0;
+			e.npc_id       = row[6] ? strtoll(row[6], nullptr, 10) : 0;
+			e.bot_id       = row[7] ? strtoll(row[7], nullptr, 10) : 0;
 
 			return e;
 		}
@@ -197,9 +203,10 @@ public:
 		v.push_back(columns[1] + " = '" + Strings::Escape(e.key_) + "'");
 		v.push_back(columns[2] + " = '" + Strings::Escape(e.value) + "'");
 		v.push_back(columns[3] + " = " + std::to_string(e.expires));
-		v.push_back(columns[4] + " = " + std::to_string(e.character_id));
-		v.push_back(columns[5] + " = " + std::to_string(e.npc_id));
-		v.push_back(columns[6] + " = " + std::to_string(e.bot_id));
+		v.push_back(columns[4] + " = " + std::to_string(e.account_id));
+		v.push_back(columns[5] + " = " + std::to_string(e.character_id));
+		v.push_back(columns[6] + " = " + std::to_string(e.npc_id));
+		v.push_back(columns[7] + " = " + std::to_string(e.bot_id));
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -225,6 +232,7 @@ public:
 		v.push_back("'" + Strings::Escape(e.key_) + "'");
 		v.push_back("'" + Strings::Escape(e.value) + "'");
 		v.push_back(std::to_string(e.expires));
+		v.push_back(std::to_string(e.account_id));
 		v.push_back(std::to_string(e.character_id));
 		v.push_back(std::to_string(e.npc_id));
 		v.push_back(std::to_string(e.bot_id));
@@ -261,6 +269,7 @@ public:
 			v.push_back("'" + Strings::Escape(e.key_) + "'");
 			v.push_back("'" + Strings::Escape(e.value) + "'");
 			v.push_back(std::to_string(e.expires));
+			v.push_back(std::to_string(e.account_id));
 			v.push_back(std::to_string(e.character_id));
 			v.push_back(std::to_string(e.npc_id));
 			v.push_back(std::to_string(e.bot_id));
@@ -301,9 +310,10 @@ public:
 			e.key_         = row[1] ? row[1] : "";
 			e.value        = row[2] ? row[2] : "";
 			e.expires      = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
-			e.character_id = row[4] ? strtoll(row[4], nullptr, 10) : 0;
-			e.npc_id       = row[5] ? strtoll(row[5], nullptr, 10) : 0;
-			e.bot_id       = row[6] ? strtoll(row[6], nullptr, 10) : 0;
+			e.account_id   = row[4] ? strtoll(row[4], nullptr, 10) : 0;
+			e.character_id = row[5] ? strtoll(row[5], nullptr, 10) : 0;
+			e.npc_id       = row[6] ? strtoll(row[6], nullptr, 10) : 0;
+			e.bot_id       = row[7] ? strtoll(row[7], nullptr, 10) : 0;
 
 			all_entries.push_back(e);
 		}
@@ -332,9 +342,10 @@ public:
 			e.key_         = row[1] ? row[1] : "";
 			e.value        = row[2] ? row[2] : "";
 			e.expires      = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
-			e.character_id = row[4] ? strtoll(row[4], nullptr, 10) : 0;
-			e.npc_id       = row[5] ? strtoll(row[5], nullptr, 10) : 0;
-			e.bot_id       = row[6] ? strtoll(row[6], nullptr, 10) : 0;
+			e.account_id   = row[4] ? strtoll(row[4], nullptr, 10) : 0;
+			e.character_id = row[5] ? strtoll(row[5], nullptr, 10) : 0;
+			e.npc_id       = row[6] ? strtoll(row[6], nullptr, 10) : 0;
+			e.bot_id       = row[7] ? strtoll(row[7], nullptr, 10) : 0;
 
 			all_entries.push_back(e);
 		}
@@ -413,6 +424,7 @@ public:
 		v.push_back("'" + Strings::Escape(e.key_) + "'");
 		v.push_back("'" + Strings::Escape(e.value) + "'");
 		v.push_back(std::to_string(e.expires));
+		v.push_back(std::to_string(e.account_id));
 		v.push_back(std::to_string(e.character_id));
 		v.push_back(std::to_string(e.npc_id));
 		v.push_back(std::to_string(e.bot_id));
@@ -442,6 +454,7 @@ public:
 			v.push_back("'" + Strings::Escape(e.key_) + "'");
 			v.push_back("'" + Strings::Escape(e.value) + "'");
 			v.push_back(std::to_string(e.expires));
+			v.push_back(std::to_string(e.account_id));
 			v.push_back(std::to_string(e.character_id));
 			v.push_back(std::to_string(e.npc_id));
 			v.push_back(std::to_string(e.bot_id));

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -402,6 +402,7 @@ Client::~Client() {
 
 	mMovementManager->RemoveClient(this);
 
+	DataBucket::DeleteCachedBuckets(DataBucketLoadType::Account, AccountID());
 	DataBucket::DeleteCachedBuckets(DataBucketLoadType::Client, CharacterID());
 
 	if (RuleB(Bots, Enabled)) {
@@ -13172,10 +13173,57 @@ void Client::BroadcastPositionUpdate()
 
 	Group *g = GetGroup();
 	if (g) {
-		for (auto & m : g->members) {
+		for (auto &m: g->members) {
 			if (m && m->IsClient() && m != this) {
 				m->CastToClient()->QueuePacket(&outapp);
 			}
 		}
 	}
+}
+
+std::string Client::GetAccountBucket(std::string bucket_name)
+{
+	DataBucketKey k = {};
+	k.account_id   = AccountID();
+	k.key          = bucket_name;
+
+	return DataBucket::GetData(k).value;
+}
+
+void Client::SetAccountBucket(std::string bucket_name, std::string bucket_value, std::string expiration)
+{
+	DataBucketKey k = {};
+	k.account_id   = AccountID();
+	k.key          = bucket_name;
+	k.expires      = expiration;
+	k.value        = bucket_value;
+
+	DataBucket::SetData(k);
+}
+
+void Client::DeleteAccountBucket(std::string bucket_name)
+{
+	DataBucketKey k = {};
+	k.account_id   = AccountID();
+	k.key          = bucket_name;
+
+	DataBucket::DeleteData(k);
+}
+
+std::string Client::GetAccountBucketExpires(std::string bucket_name)
+{
+	DataBucketKey k = {};
+	k.account_id   = AccountID();
+	k.key          = bucket_name;
+
+	return DataBucket::GetDataExpires(k);
+}
+
+std::string Client::GetAccountBucketRemaining(std::string bucket_name)
+{
+	DataBucketKey k = {};
+	k.account_id   = AccountID();
+	k.key          = bucket_name;
+
+	return DataBucket::GetDataRemaining(k);
 }

--- a/zone/client.h
+++ b/zone/client.h
@@ -1829,6 +1829,13 @@ public:
 	void SendEvolveXPTransferWindow();
 	void SendEvolveTransferResults(const EQ::ItemInstance &inst_from, const EQ::ItemInstance &inst_to, const EQ::ItemInstance &inst_from_new, const EQ::ItemInstance &inst_to_new, const uint32 compatibility, const uint32 max_transfer_level);
 
+	// Account buckets
+	std::string GetAccountBucket(std::string bucket_name);
+	void SetAccountBucket(std::string bucket_name, std::string bucket_value, std::string expiration = "");
+	void DeleteAccountBucket(std::string bucket_name);
+	std::string GetAccountBucketExpires(std::string bucket_name);
+	std::string GetAccountBucketRemaining(std::string bucket_name);
+
 protected:
 	friend class Mob;
 	void CalcEdibleBonuses(StatBonuses* newbon);

--- a/zone/data_bucket.h
+++ b/zone/data_bucket.h
@@ -12,20 +12,23 @@ struct DataBucketKey {
 	std::string key;
 	std::string value;
 	std::string expires;
-	int64_t     character_id;
-	int64_t     npc_id;
-	int64_t     bot_id;
+	int64_t     account_id = 0;
+	int64_t     character_id = 0;
+	int64_t     npc_id = 0;
+	int64_t     bot_id = 0;
 };
 
 namespace DataBucketLoadType {
 	enum Type : uint8 {
 		Bot,
+		Account,
 		Client,
 		MaxType
 	};
 
 	static const std::string Name[Type::MaxType] = {
 		"Bot",
+		"Account",
 		"Client",
 	};
 }

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3464,6 +3464,36 @@ void Lua_Client::SetAAEXPPercentage(uint8 percentage)
 	self->SetAAEXPPercentage(percentage);
 }
 
+void Lua_Client::SetAccountBucket(std::string bucket_name, std::string bucket_value, std::string expiration)
+{
+	Lua_Safe_Call_Void();
+	self->SetAccountBucket(bucket_name, bucket_value, expiration);
+}
+
+void Lua_Client::DeleteAccountBucket(std::string bucket_name)
+{
+	Lua_Safe_Call_Void();
+	self->DeleteAccountBucket(bucket_name);
+}
+
+std::string Lua_Client::GetAccountBucket(std::string bucket_name)
+{
+	Lua_Safe_Call_String();
+	return self->GetAccountBucket(bucket_name);
+}
+
+std::string Lua_Client::GetAccountBucketExpires(std::string bucket_name)
+{
+	Lua_Safe_Call_String();
+	return self->GetAccountBucketExpires(bucket_name);
+}
+
+std::string Lua_Client::GetAccountBucketRemaining(std::string bucket_name)
+{
+	Lua_Safe_Call_String();
+	return self->GetAccountBucketRemaining(bucket_name);
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 	.def(luabind::constructor<>())
@@ -3552,6 +3582,7 @@ luabind::scope lua_register_client() {
 	.def("CreateTaskDynamicZone", &Lua_Client::CreateTaskDynamicZone)
 	.def("DecreaseByID", (bool(Lua_Client::*)(uint32,int))&Lua_Client::DecreaseByID)
 	.def("DescribeSpecialAbilities", (void(Lua_Client::*)(Lua_NPC))&Lua_Client::DescribeSpecialAbilities)
+	.def("DeleteAccountBucket", (void(Lua_Client::*)(std::string))&Lua_Client::DeleteAccountBucket)
 	.def("DeleteBucket", (void(Lua_Client::*)(std::string))&Lua_Client::DeleteBucket)
 	.def("DeleteItemInInventory", (void(Lua_Client::*)(int,int))&Lua_Client::DeleteItemInInventory)
 	.def("DeleteItemInInventory", (void(Lua_Client::*)(int,int,bool))&Lua_Client::DeleteItemInInventory)
@@ -3630,6 +3661,9 @@ luabind::scope lua_register_client() {
 	.def("GetBotRequiredLevel", (int(Lua_Client::*)(uint8))&Lua_Client::GetBotRequiredLevel)
 	.def("GetBotSpawnLimit", (int(Lua_Client::*)(void))&Lua_Client::GetBotSpawnLimit)
 	.def("GetBotSpawnLimit", (int(Lua_Client::*)(uint8))&Lua_Client::GetBotSpawnLimit)
+	.def("GetAccountBucket", (std::string(Lua_Client::*)(std::string))&Lua_Client::GetAccountBucket)
+	.def("GetAccountBucketExpires", (std::string(Lua_Client::*)(std::string))&Lua_Client::GetAccountBucketExpires)
+	.def("GetAccountBucketRemaining", (std::string(Lua_Client::*)(std::string))&Lua_Client::GetAccountBucketRemaining)
 	.def("GetBucket", (std::string(Lua_Client::*)(std::string))&Lua_Client::GetBucket)
 	.def("GetBucketExpires", (std::string(Lua_Client::*)(std::string))&Lua_Client::GetBucketExpires)
 	.def("GetBucketRemaining", (std::string(Lua_Client::*)(std::string))&Lua_Client::GetBucketRemaining)
@@ -3922,6 +3956,8 @@ luabind::scope lua_register_client() {
 	.def("SetBotRequiredLevel", (void(Lua_Client::*)(int,uint8))&Lua_Client::SetBotRequiredLevel)
 	.def("SetBotSpawnLimit", (void(Lua_Client::*)(int))&Lua_Client::SetBotSpawnLimit)
 	.def("SetBotSpawnLimit", (void(Lua_Client::*)(int,uint8))&Lua_Client::SetBotSpawnLimit)
+	.def("SetAccountBucket", (void(Lua_Client::*)(std::string,std::string))&Lua_Client::SetAccountBucket)
+	.def("SetAccountBucket", (void(Lua_Client::*)(std::string,std::string,std::string))&Lua_Client::SetAccountBucket)
 	.def("SetBucket", (void(Lua_Client::*)(std::string,std::string))&Lua_Client::SetBucket)
 	.def("SetBucket", (void(Lua_Client::*)(std::string,std::string,std::string))&Lua_Client::SetBucket)
 	.def("SetClientMaxLevel", (void(Lua_Client::*)(int))&Lua_Client::SetClientMaxLevel)

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3464,6 +3464,12 @@ void Lua_Client::SetAAEXPPercentage(uint8 percentage)
 	self->SetAAEXPPercentage(percentage);
 }
 
+void Lua_Client::SetAccountBucket(std::string bucket_name, std::string bucket_value)
+{
+	Lua_Safe_Call_Void();
+	self->SetAccountBucket(bucket_name, bucket_value);
+}
+
 void Lua_Client::SetAccountBucket(std::string bucket_name, std::string bucket_value, std::string expiration)
 {
 	Lua_Safe_Call_Void();

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -513,6 +513,7 @@ public:
 	void SetAAEXPPercentage(uint8 percentage);
 
 	// account data buckets
+	void SetAccountBucket(std::string bucket_name, std::string bucket_value);
 	void SetAccountBucket(std::string bucket_name, std::string bucket_value, std::string expiration = "");
 	void DeleteAccountBucket(std::string bucket_name);
 	std::string GetAccountBucket(std::string bucket_name);

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -512,6 +512,13 @@ public:
 	luabind::object GetInventorySlots(lua_State* L);
 	void SetAAEXPPercentage(uint8 percentage);
 
+	// account data buckets
+	void SetAccountBucket(std::string bucket_name, std::string bucket_value, std::string expiration = "");
+	void DeleteAccountBucket(std::string bucket_name);
+	std::string GetAccountBucket(std::string bucket_name);
+	std::string GetAccountBucketExpires(std::string bucket_name);
+	std::string GetAccountBucketRemaining(std::string bucket_name);
+
 	void ApplySpell(int spell_id);
 	void ApplySpell(int spell_id, int duration);
 	void ApplySpell(int spell_id, int duration, int level);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -3234,6 +3234,11 @@ void Perl_Client_SetAAEXPPercentage(Client* self, uint8 percentage)
 	self->SetAAEXPPercentage(percentage);
 }
 
+void Perl_Client_SetAccountBucket(Client* self, std::string bucket_name, std::string bucket_value)
+{
+	self->SetAccountBucket(bucket_name, bucket_value);
+}
+
 void Perl_Client_SetAccountBucket(Client* self, std::string bucket_name, std::string bucket_value, std::string expiration = "")
 {
 	self->SetAccountBucket(bucket_name, bucket_value, expiration);
@@ -3697,7 +3702,8 @@ void perl_register_client()
 	package.add("SetAATitle", (void(*)(Client*, std::string, bool))&Perl_Client_SetAATitle);
 	package.add("SetAFK", &Perl_Client_SetAFK);
 	package.add("SetAccountFlag", &Perl_Client_SetAccountFlag);
-	package.add("SetAccountBucket", &Perl_Client_SetAccountBucket);
+	package.add("SetAccountBucket", (void(*)(Client*, std::string, std::string))&Perl_Client_SetAccountBucket);
+	package.add("SetAccountBucket", (void(*)(Client*, std::string, std::string, std::string))&Perl_Client_SetAccountBucket);
 	package.add("SetAlternateCurrencyValue", &Perl_Client_SetAlternateCurrencyValue);
 	package.add("SetAnon", &Perl_Client_SetAnon);
 	package.add("SetAutoLoginCharacterName", (bool(*)(Client*))&Perl_Client_SetAutoLoginCharacterName);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -3234,6 +3234,31 @@ void Perl_Client_SetAAEXPPercentage(Client* self, uint8 percentage)
 	self->SetAAEXPPercentage(percentage);
 }
 
+void Perl_Client_SetAccountBucket(Client* self, std::string bucket_name, std::string bucket_value, std::string expiration = "")
+{
+	self->SetAccountBucket(bucket_name, bucket_value, expiration);
+}
+
+void Perl_Client_DeleteAccountBucket(Client* self, std::string bucket_name)
+{
+	self->DeleteAccountBucket(bucket_name);
+}
+
+std::string Perl_Client_GetAccountBucket(Client* self, std::string bucket_name)
+{
+	return self->GetAccountBucket(bucket_name);
+}
+
+std::string Perl_Client_GetAccountBucketExpires(Client* self, std::string bucket_name)
+{
+	return self->GetAccountBucketExpires(bucket_name);
+}
+
+std::string Perl_Client_GetAccountBucketRemaining(Client* self, std::string bucket_name)
+{
+	return self->GetAccountBucketRemaining(bucket_name);
+}
+
 void perl_register_client()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3325,6 +3350,7 @@ void perl_register_client()
 	package.add("CreateTaskDynamicZone", &Perl_Client_CreateTaskDynamicZone);
 	package.add("DecreaseByID", &Perl_Client_DecreaseByID);
 	package.add("DescribeSpecialAbilities", &Perl_Client_DescribeSpecialAbilities);
+	package.add("DeleteAccountBucket", &Perl_Client_DeleteAccountBucket);
 	package.add("DeleteItemInInventory", (void(*)(Client*, int16))&Perl_Client_DeleteItemInInventory);
 	package.add("DeleteItemInInventory", (void(*)(Client*, int16, int16))&Perl_Client_DeleteItemInInventory);
 	package.add("DeleteItemInInventory", (void(*)(Client*, int16, int16, bool))&Perl_Client_DeleteItemInInventory);
@@ -3362,6 +3388,9 @@ void perl_register_client()
 	package.add("GetAAPoints", &Perl_Client_GetAAPoints);
 	package.add("GetAFK", &Perl_Client_GetAFK);
 	package.add("GetAccountAge", &Perl_Client_GetAccountAge);
+	package.add("GetAccountBucket", &Perl_Client_GetAccountBucket);
+	package.add("GetAccountBucketExpires", &Perl_Client_GetAccountBucketExpires);
+	package.add("GetGetAccountBucketRemaining", &Perl_Client_GetAccountBucketRemaining);
 	package.add("GetAccountFlag", &Perl_Client_GetAccountFlag);
 	package.add("GetAccountFlags", &Perl_Client_GetAccountFlags);
 	package.add("GetAggroCount", &Perl_Client_GetAggroCount);
@@ -3668,6 +3697,7 @@ void perl_register_client()
 	package.add("SetAATitle", (void(*)(Client*, std::string, bool))&Perl_Client_SetAATitle);
 	package.add("SetAFK", &Perl_Client_SetAFK);
 	package.add("SetAccountFlag", &Perl_Client_SetAccountFlag);
+	package.add("SetAccountBucket", &Perl_Client_SetAccountBucket);
 	package.add("SetAlternateCurrencyValue", &Perl_Client_SetAlternateCurrencyValue);
 	package.add("SetAnon", &Perl_Client_SetAnon);
 	package.add("SetAutoLoginCharacterName", (bool(*)(Client*))&Perl_Client_SetAutoLoginCharacterName);


### PR DESCRIPTION
# Description

Adds support for Account Scoped Databuckets

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing

In the below example, one (example3) should expire in a second, example2 should be deleted and only example1 should return a value

```perl
sub EVENT_SAY
    # set 3 variations
    if ($text=~/set_account/i) {
        $client->SetAccountBucket("example", "1");
        $client->SetAccountBucket("example2", "1");
        $client->SetAccountBucket("example3", "1", "1S");   
    }

    # one expires, we delete the second, the first should be the only one to return a value
    if ($text=~/get_account/i) {
        $client->DeleteAccountBucket("example2");
        $client->Message(15, "example1 " . $client->GetAccountBucket("example"));
        $client->Message(15, "example2 " . $client->GetAccountBucket("example2"));
        $client->Message(15, "example3 " . $client->GetAccountBucket("example3"));
    }
}
```
![image](https://github.com/user-attachments/assets/abf8c5cd-2317-450d-9b73-2ad3790a3276)

Similar test conducted in Lua

![image](https://github.com/user-attachments/assets/7cd2a927-aeab-434e-ae67-afab8c16e8bd)

```lua
function event_say(e)
    -- Setting account buckets
    if e.message:findi("set_account") then
        e.self:SetAccountBucket("example", "1")
        e.self:SetAccountBucket("example2", "1")
        e.self:SetAccountBucket("example3", "1", "1S")   
    end

    -- Getting account buckets
    if e.message:findi("get_account") then
        e.self:DeleteAccountBucket("example2")
        e.self:Message(15, "example1 " .. e.self:GetAccountBucket("example"))
        e.self:Message(15, "example2 " .. e.self:GetAccountBucket("example2"))
        e.self:Message(15, "example3 " .. e.self:GetAccountBucket("example3"))
    end
end
```

```
mariadb> SELECT * FROM `data_buckets` WHERE `key` = 'example' LIMIT 0,1000;
+----+---------+-------+---------+------------+--------------+--------+--------+
| id | key     | value | expires | account_id | character_id | npc_id | bot_id |
+----+---------+-------+---------+------------+--------------+--------+--------+
| 24 | example | 1     |       0 |          1 |            0 |      0 |      0 |
+----+---------+-------+---------+------------+--------------+--------+--------+
1 row in set (0.00 sec)
```

**Caching**

When client loads into zone

Account scoped

```
  Zone | DataBucket | BulkLoadEntitiesToCache cache size before [0] l size [1] -- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone | DataBucket | BulkLoadEntitiesToCache bucket id [24] bucket key [example] bucket value [1] -- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone | DataBucket | BulkLoadEntitiesToCache cache size after [1] -- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone | DataBucket | BulkLoadEntitiesToCache Bulk Loaded ids [1] column [account_id] new cache size is [1] -- [poknowledge] (The Plane of Knowledge) inst_id [0]
```

Character scoped

```
  Zone | DataBucket | BulkLoadEntitiesToCache cache size before [1] l size [6] -- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone | DataBucket | BulkLoadEntitiesToCache bucket id [2] bucket key [test_key] bucket value [something] -- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone | DataBucket | BulkLoadEntitiesToCache bucket id [23] bucket key [progression] bucket value [{"progression":{"classic":{"nagafen_killed":"1","vox_killed":"1"},"don":{"good":{"step1":"done","step2":"done"}}}}] -- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone | DataBucket | BulkLoadEntitiesToCache bucket id [28] bucket key [progression.don.good.step1] bucket value [done] -- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone | DataBucket | BulkLoadEntitiesToCache bucket id [29] bucket key [progression.don.good.step2] bucket value [done] -- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone | DataBucket | BulkLoadEntitiesToCache bucket id [30] bucket key [progression.classic.nagafen_killed] bucket value [1] -- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone | DataBucket | BulkLoadEntitiesToCache bucket id [31] bucket key [progression.classic.vox_killed] bucket value [1] -- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone | DataBucket | BulkLoadEntitiesToCache cache size after [7] -- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone | DataBucket | BulkLoadEntitiesToCache Bulk Loaded ids [1] column [character_id] new cache size is [7] -- [poknowledge] (The Plane of Knowledge) inst_id [0]
```

**Character leaves zone**

Expected to see no buckets in cache

```
  Zone | DataBucket | DeleteCachedBuckets LoadType [Account] id [1] cache size before [7] after [6] -- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone | DataBucket | DeleteCachedBuckets LoadType [Client] id [1] cache size before [6] after [0] -- [poknowledge] (The Plane of Knowledge) inst_id [0]
```

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
- [x] If my changes make database schema changes, I have tested the changes on a local database (attach image). Updated version.h CURRENT_BINARY_DATABASE_VERSION to the new version. (Delete this if not applicable)
