### PR TITLE
[Databuckets] Implement Nested Databuckets

### DIFF
--- a/zone/data_bucket.cpp
+++ b/zone/data_bucket.cpp
@@ -248,7 +248,7 @@ DataBucketsRepository::DataBuckets DataBucket::GetData(const DataBucketKey &k_, 
 			);
 
 			LogDataBuckets(
-				"Key [{}] not found in database, adding to cache as a miss account_id [{}] character_id [{}], npc_id [{}], bot_id [{}], cache size before [{}], after [{}]",
+				"Key [{}] not found in database, adding to cache as a miss account_id [{}] character_id [{}] npc_id [{}] bot_id [{}] cache size before [{}] after [{}]",
 				k.key,
 				k.account_id,
 				k.character_id,

--- a/zone/data_bucket.cpp
+++ b/zone/data_bucket.cpp
@@ -178,8 +178,9 @@ DataBucketsRepository::DataBuckets DataBucket::ExtractNestedValue(
 // the only place we should be ignoring the misses cache is on the initial read during SetData
 DataBucketsRepository::DataBuckets DataBucket::GetData(const DataBucketKey &k_, bool ignore_misses_cache)
 {
-	DataBucketKey k             = k_; // Copy the key so we can modify it
-	bool          is_nested_key = k.key.find('.') != std::string::npos;
+	DataBucketKey k = k_; // Copy the key so we can modify it
+
+	bool is_nested_key = k.key.find('.') != std::string::npos;
 
 	// Extract the top-level key for nested keys
 	if (is_nested_key) {

--- a/zone/data_bucket.cpp
+++ b/zone/data_bucket.cpp
@@ -176,8 +176,6 @@ DataBucketsRepository::DataBuckets DataBucket::ExtractNestedValue(
 	return result;
 }
 
-
-
 // GetData fetches bucket data from the database or cache if it exists
 // if the bucket doesn't exist, it will be added to the cache as a miss
 // if ignore_misses_cache is true, the bucket will not be added to the cache as a miss

--- a/zone/data_bucket.h
+++ b/zone/data_bucket.h
@@ -45,7 +45,7 @@ public:
 	static bool GetDataBuckets(Mob *mob);
 
 	// scoped bucket methods
-	static void SetData(const DataBucketKey &k);
+	static void SetData(const DataBucketKey &k_);
 	static bool DeleteData(const DataBucketKey &k);
 	static DataBucketsRepository::DataBuckets GetData(const DataBucketKey &k, bool ignore_misses_cache = false);
 	static std::string GetDataExpires(const DataBucketKey &k);

--- a/zone/data_bucket.h
+++ b/zone/data_bucket.h
@@ -63,6 +63,8 @@ public:
 	static void ClearCache();
 	static void DeleteFromCache(uint64 id, DataBucketLoadType::Type type);
 	static bool CanCache(const DataBucketKey &key);
+	static DataBucketsRepository::DataBuckets
+	ExtractNestedValue(const DataBucketsRepository::DataBuckets &bucket, const std::string &full_key);
 };
 
 #endif //EQEMU_DATABUCKET_H

--- a/zone/data_bucket.h
+++ b/zone/data_bucket.h
@@ -47,7 +47,7 @@ public:
 	// scoped bucket methods
 	static void SetData(const DataBucketKey &k_);
 	static bool DeleteData(const DataBucketKey &k);
-	static DataBucketsRepository::DataBuckets GetData(const DataBucketKey &k, bool ignore_misses_cache = false);
+	static DataBucketsRepository::DataBuckets GetData(const DataBucketKey &k_, bool ignore_misses_cache = false);
 	static std::string GetDataExpires(const DataBucketKey &k);
 	static std::string GetDataRemaining(const DataBucketKey &k);
 	static std::string GetScopedDbFilters(const DataBucketKey &k);


### PR DESCRIPTION
# Description

This feature allows operators to use nested keys in their databuckets delimited by `.` which allows you to hold much more data about one `key`. For example to hold progression keys, you might want one `progression` key with many arbitrarily nested keys.

**Example**

This is an example of some expansion flagging that @fryguy503 was using.

```perl
sub EVENT_SAY {
    my %flag_template = (
        OG => { # Unlocks Expansion 1
            Naggy      => 0,
            Vox        => 0,
            TM_Task    => 0,
            Art_Task   => 0,
        },
        RoK => { # Unlocks Expansion 2
            Trakanon   => 0,
            Gorenaire  => 0,
            Severilous => 0,
            Talendor   => 0,
            TM_Task    => 0,
            Art_Task   => 0,
        },
        SoV => { # Unlocks Expansion 3
            Yelinak    => 0,
            Wuoshi     => 0,
            Klandicar  => 0,
            Zlandicar  => 0,
            TM_Task    => 0,
            Art_Task   => 0,
        },
        SoL => { # Unlocks Expansion 4-6
            THO        => 0,
            TIC        => 0,
            EMP        => 0,
            TM_Task    => 0,
            Art_Task   => 0,
        },
        PoP => { # Unlocks Expansion 7
            Agnarr     => 0,
            TM_Task    => 0,
            Art_Task   => 0,
        },
        GoD => { # Unlocks Expansion 8
            Cynosure   => 0,
            TM_Task    => 0,
            Art_Task   => 0,
        },
        OoW => { # Unlocks Expansion 9
            MPG        => 0,
            TM_Task    => 0,
            Art_Task   => 0,
        },
        DoN => { # Unlocks Expansion 10
            Yar        => 0,
            TM_Task    => 0,
            Art_Task   => 0,
        },
        DoDH => { # Unlocks Expansion 11
            Sendai     => 0,
            TM_Task    => 0,
            Art_Task   => 0,
        },
        PoR => { # Unlocks Expansion 12
            SZ         => 0,
            TM_Task    => 0,
            Art_Task   => 0,
        },
    );

    if ($text=~/set_nested/i) {
        foreach my $expansion (keys %flag_template) {
            foreach my $key (keys %{$flag_template{$expansion}}) {
                my $bucket_key = "progression.$expansion.$key";
                my $value = 1;
                $client->SetBucket($bucket_key, $value);
                $client->Message(15, "Set $bucket_key to $value");
            }
        }
    }

    # Get and print all nested buckets
    if ($text=~/get_nested/i) {
        foreach my $expansion (keys %flag_template) {
            foreach my $key (keys %{$flag_template{$expansion}}) {
                my $bucket_key = "progression.$expansion.$key";
                my $value = $client->GetBucket($bucket_key);
                $client->Message(15, "$bucket_key = $value");
            }
        }

        $client->Message(15, "Entire progression bucket: " . $client->GetBucket("progression"));
    }
}
```

Yields

```json
{
  "progression": {
    "DoDH": {
      "Art_Task": "1",
      "Sendai": "1",
      "TM_Task": "1"
    },
    "DoN": {
      "Art_Task": "1",
      "TM_Task": "1",
      "Yar": "1"
    },
    "GoD": {
      "Art_Task": "1",
      "Cynosure": "1",
      "TM_Task": "1"
    },
    "OG": {
      "Art_Task": "1",
      "Naggy": "1",
      "TM_Task": "1",
      "Vox": "1"
    },
    "OoW": {
      "Art_Task": "1",
      "MPG": "1",
      "TM_Task": "1"
    },
    "PoP": {
      "Agnarr": "1",
      "Art_Task": "1",
      "TM_Task": "1"
    },
    "PoR": {
      "Art_Task": "1",
      "SZ": "1",
      "TM_Task": "1"
    },
    "RoK": {
      "Art_Task": "1",
      "Gorenaire": "1",
      "Severilous": "1",
      "TM_Task": "1",
      "Talendor": "1",
      "Trakanon": "1"
    },
    "SoL": {
      "Art_Task": "1",
      "EMP": "1",
      "THO": "1",
      "TIC": "1",
      "TM_Task": "1"
    },
    "SoV": {
      "Art_Task": "1",
      "Klandicar": "1",
      "TM_Task": "1",
      "Wuoshi": "1",
      "Yelinak": "1",
      "Zlandicar": "1"
    },
    "classic": {
      "nagafen_killed": "1",
      "vox_killed": "1"
    },
    "don": {
      "good": {
        "step1": "done",
        "step2": "done"
      }
    }
  }
}
```

![image](https://github.com/user-attachments/assets/a34c0d8d-bb54-4f41-9291-2b808517ff69)

**Test Fetching / Setting Entire JSON Blob**

```perl
$client->SetBucket("progression", $client->GetBucket("progression"));
```

Get

```
  Zone | DataBucket | GetData Returning key [progression] value [{"progression":{"DoDH":{"Art_Task":"1","Sendai":"1","TM_Task":"1"},"DoN":{"Art_Task":"1","TM_Task":"1","Yar":"1"},"GoD":{"Art_Task":"1","Cynosure":"1","TM_Task":"1"},"OG":{"Art_Task":"1","Naggy":"1","TM_Task":"1","Vox":"1"},"OoW":{"Art_Task":"1","MPG":"1","TM_Task":"1"},"PoP":{"Agnarr":"1","Art_Task":"1","TM_Task":"1"},"PoR":{"Art_Task":"1","SZ":"1","TM_Task":"1"},"RoK":{"Art_Task":"1","Gorenaire":"1","Severilous":"1","TM_Task":"1","Talendor":"1","Trakanon":"1"},"SoL":{"Art_Task":"1","EMP":"1","THO":"1","TIC":"1","TM_Task":"1"},"SoV":{"Art_Task":"1","Klandicar":"1","TM_Task":"1","Wuoshi":"1","Yelinak":"1","Zlandicar":"1"},"classic":{"nagafen_killed":"1","vox_killed":"1"},"don":{"good":{"step1":"done","step2":"done"}}}}] from cache
```

Set

```
  Zone |   Query    | QueryDatabase UPDATE data_buckets SET `key` = 'progression', value = '{\"progression\":{\"DoDH\":{\"Art_Task\":\"1\",\"Sendai\":\"1\",\"TM_Task\":\"1\"},\"DoN\":{\"Art_Task\":\"1\",\"TM_Task\":\"1\",\"Yar\":\"1\"},\"GoD\":{\"Art_Task\":\"1\",\"Cynosure\":\"1\",\"TM_Task\":\"1\"},\"OG\":{\"Art_Task\":\"1\",\"Naggy\":\"1\",\"TM_Task\":\"1\",\"Vox\":\"1\"},\"OoW\":{\"Art_Task\":\"1\",\"MPG\":\"1\",\"TM_Task\":\"1\"},\"PoP\":{\"Agnarr\":\"1\",\"Art_Task\":\"1\",\"TM_Task\":\"1\"},\"PoR\":{\"Art_Task\":\"1\",\"SZ\":\"1\",\"TM_Task\":\"1\"},\"RoK\":{\"Art_Task\":\"1\",\"Gorenaire\":\"1\",\"Severilous\":\"1\",\"TM_Task\":\"1\",\"Talendor\":\"1\",\"Trakanon\":\"1\"},\"SoL\":{\"Art_Task\":\"1\",\"EMP\":\"1\",\"THO\":\"1\",\"TIC\":\"1\",\"TM_Task\":\"1\"},\"SoV\":{\"Art_Task\":\"1\",\"Klandicar\":\"1\",\"TM_Task\":\"1\",\"Wuoshi\":\"1\",\"Yelinak\":\"1\",\"Zlandicar\":\"1\"},\"classic\":{\"nagafen_killed\":\"1\",\"vox_killed\":\"1\"},\"don\":{\"good\":{\"step1\":\"done\",\"step2\":\"done\"}}}}', expires = 0, account_id = 0, character_id = 1, npc_id = 0, bot_id = 0 WHERE id = 23 -- (1 row affected) (0.000029s)-- [poknowledge] (The Plane of Knowledge) inst_id [0]
```

### Testing Normal Databuckets (Non-Nested)

```perl
sub EVENT_SAY {
    # set 3 variations
    if ($text=~/set_account/i) {
        $client->SetAccountBucket("example", "1");
        $client->SetAccountBucket("example2", "1");
        $client->SetAccountBucket("example3", "1", "1S");   
    }

    # one expires, we delete the second, the first should be the only one to return a value
    if ($text=~/get_account/i) {
        $client->DeleteAccountBucket("example2");
        $client->Message(15, "example1 " . $client->GetAccountBucket("example"));
        $client->Message(15, "example2 " . $client->GetAccountBucket("example2"));
        $client->Message(15, "example3 " . $client->GetAccountBucket("example3"));
    }
}
```

get_account

```
  Zone | DataBucket | GetData Getting bucket key [example] bot_id [0] account_id [1] character_id [0] npc_id [0] -- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone | DataBucket | GetData Returning key [example] value [1] from cache -- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone |   Query    | QueryDatabase UPDATE data_buckets SET `key` = 'example', value = '1', expires = 0, account_id = 1, character_id = 0, npc_id = 0, bot_id = 0 WHERE id = 24 -- (1 row affected) (0.000212s)-- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone | DataBucket | GetData Getting bucket key [example2] bot_id [0] account_id [1] character_id [0] npc_id [0] -- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone | DataBucket | GetData Returning key [example2] value [] from cache -- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone |   Query    | QueryDatabase INSERT INTO data_buckets (id, `key`, value, expires, account_id, character_id, npc_id, bot_id)  VALUES (0,'example2','1',0,1,0,0,0) -- (1 row affected) (0.011036s)-- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone | DataBucket | DeleteFromMissesCache Deleted bucket misses from cache where key [example2] size before [8] after [7] -- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone | DataBucket | GetData Getting bucket key [example3] bot_id [0] account_id [1] character_id [0] npc_id [0] -- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id FROM data_buckets WHERE  character_id = 0 AND account_id = 1 AND npc_id = 0 AND bot_id = 0 AND `key` = 'example3' LIMIT 1 -- (0 rows returned) (0.000156s)-- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone |   Query    | QueryDatabase INSERT INTO data_buckets (id, `key`, value, expires, account_id, character_id, npc_id, bot_id)  VALUES (0,'example3','1',1737498446,1,0,0,0) -- (1 row affected) (0.001821s)-- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone | DataBucket | DeleteFromMissesCache Deleted bucket misses from cache where key [example3] size before [8] after [8] -- [poknowledge] (The Plane of Knowledge) inst_id [0]
```

set_account

```
  Zone | DataBucket | DeleteData Deleting bucket key [example2] bot_id [0] account_id [1] character_id [0] npc_id [0] cache size before [9] after [8] -- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone |   Query    | QueryDatabase DELETE FROM data_buckets WHERE character_id = 0 AND account_id = 1 AND npc_id = 0 AND bot_id = 0 AND `key` = 'example2' -- (1 row affected) (0.010921s)-- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone | DataBucket | GetData Getting bucket key [example] bot_id [0] account_id [1] character_id [0] npc_id [0] -- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone | DataBucket | GetData Returning key [example] value [1] from cache -- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone | DataBucket | GetData Getting bucket key [example2] bot_id [0] account_id [1] character_id [0] npc_id [0] -- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id FROM data_buckets WHERE  character_id = 0 AND account_id = 1 AND npc_id = 0 AND bot_id = 0 AND `key` = 'example2' LIMIT 1 -- (0 rows returned) (0.000143s)-- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone | DataBucket | GetData Key [example2] not found in database, adding to cache as a miss account_id [1] character_id [0,] npc_id [0,] bot_id [0,] cache size before [8,] after [9] -- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone | DataBucket | GetData Getting bucket key [example3] bot_id [0] account_id [1] character_id [0] npc_id [0] -- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone | DataBucket | GetData Attempted to read expired key [example3] removing from cache -- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone | DataBucket | DeleteData Deleting bucket key [example3] bot_id [0] account_id [1] character_id [0] npc_id [0] cache size before [9] after [8] -- [poknowledge] (The Plane of Knowledge) inst_id [0]
  Zone |   Query    | QueryDatabase DELETE FROM data_buckets WHERE character_id = 0 AND account_id = 1 AND npc_id = 0 AND bot_id = 0 AND `key` = 'example3' -- (1 row affected) (0.001962s)-- [poknowledge] (The Plane of Knowledge) inst_id [0]
```

![image](https://github.com/user-attachments/assets/98f6381b-278a-4935-bc75-29f3e07ebf6c)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
