### PR TITLE
[CLI] Add --skip-backup to world database:updates

### DIFF
--- a/common/database/database_update.cpp
+++ b/common/database/database_update.cpp
@@ -169,7 +169,10 @@ bool DatabaseUpdate::UpdateManifest(
 		LogSys.EnableMySQLErrorLogs();
 		LogInfo("{}", Strings::Repeat("-", BREAK_LENGTH));
 
-		if (!missing_migrations.empty()) {
+		if (!missing_migrations.empty() && m_skip_backup) {
+			LogInfo("Skipping database backup");
+		}
+		else if (!missing_migrations.empty()) {
 			LogInfo("Automatically backing up database before applying updates");
 			LogInfo("{}", Strings::Repeat("-", BREAK_LENGTH));
 			auto s = DatabaseDumpService();
@@ -267,6 +270,13 @@ DatabaseUpdate *DatabaseUpdate::SetDatabase(Database *db)
 DatabaseUpdate *DatabaseUpdate::SetContentDatabase(Database *db)
 {
 	m_content_database = db;
+
+	return this;
+}
+
+DatabaseUpdate *DatabaseUpdate::SetSkipBackup(bool skip)
+{
+	m_skip_backup = skip;
 
 	return this;
 }

--- a/common/database/database_update.h
+++ b/common/database/database_update.h
@@ -29,12 +29,15 @@ public:
 
 	DatabaseUpdate *SetDatabase(Database *db);
 	DatabaseUpdate *SetContentDatabase(Database *db);
+	DatabaseUpdate *SetSkipBackup(bool skip);
 	bool HasPendingUpdates();
 private:
+	bool m_skip_backup = false;
 	Database *m_database;
 	Database *m_content_database;
 	static bool CheckVersionsUpToDate(DatabaseVersion v, DatabaseVersion b);
 	void InjectBotsVersionColumn();
+
 };
 
 #endif //EQEMU_DATABASE_UPDATE_H

--- a/world/cli/database_dump.cpp
+++ b/world/cli/database_dump.cpp
@@ -24,11 +24,11 @@ void WorldserverCLI::DatabaseDump(int argc, char **argv, argh::parser &cmd, std:
 		"--compress"
 	};
 
-	EQEmuCommand::ValidateCmdInput(arguments, options, cmd, argc, argv);
-
 	if (cmd[{"-h", "--help"}]) {
 		return;
 	}
+
+	EQEmuCommand::ValidateCmdInput(arguments, options, cmd, argc, argv);
 
 	auto s        = new DatabaseDumpService();
 	bool dump_all = cmd[{"-a", "--all"}];

--- a/world/cli/database_updates.cpp
+++ b/world/cli/database_updates.cpp
@@ -4,12 +4,17 @@ void WorldserverCLI::DatabaseUpdates(int argc, char **argv, argh::parser &cmd, s
 {
 	description = "Runs database updates manually";
 
+	std::vector<std::string> options   = {
+		"--skip-backup",
+	};
+
 	if (cmd[{"-h", "--help"}]) {
 		return;
 	}
 
 	DatabaseUpdate update;
 	update.SetDatabase(&database)
+		->SetSkipBackup(cmd[{"--skip-backup"}] )
 		->SetContentDatabase(&content_db)
 		->CheckDbUpdates();
 }


### PR DESCRIPTION
# Description

This is related to some work of sourcing our database and running database migrations in our CI pipeline. I want to skip backups in the CI pipeline so I've added an option to do so

```
./bin/world database:updates --skip-backup
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing

Without backup

![image](https://github.com/user-attachments/assets/297e8f29-667c-4460-9792-298f799378e8)

Default, with backup

![image](https://github.com/user-attachments/assets/e5f1d8ae-df95-4ee1-879c-4eddf09efd51)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
