### PR TITLE
[Fix] Repair levers opening the Evolving XP Transfer Window

### DIFF
--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -612,7 +612,7 @@ void Doors::HandleClick(Client *sender, uint8 trigger)
 		}
 	}
 
-	if (GetOpenType() == 40 && GetZone(GetDoorZone(),0)) {
+	if (GetOpenType() == 40 && sender->GetZoneID() == Zones::CORATHUS) {
 		sender->SendEvolveXPTransferWindow();
 	}
 }


### PR DESCRIPTION
# Description

Levers outside of Corathus were causing the Evolving Item XP Transfer Window to open, in error.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
Tested by clicking a level in Nadox, no issue.  Clicking on the correct lever in Corathus opened the window.

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
