### PR TITLE
[Memory Leak] Fix leak in BuyTraderItemOutsideBazaar

### DIFF
--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -3602,7 +3602,7 @@ void Client::BuyTraderItemOutsideBazaar(TraderBuy_Struct *tbs, const EQApplicati
 	out_data->id                      = trader_item.id;
 	strn0cpy(out_data->trader_buy_struct.buyer_name, GetCleanName(), sizeof(out_data->trader_buy_struct.buyer_name));
 
-	worldserver.SendPacket(out_server.release());
+	worldserver.SendPacket(out_server.get());
 }
 
 void Client::SetBuyerWelcomeMessage(const char *welcome_message)


### PR DESCRIPTION
# Description

Observed on THJ. `.release()` frees ownership of the pointer from the unique_ptr and it never gets freed

**Valgrind**

```cpp
==1479239== 58,320 (6,480 direct, 51,840 indirect) bytes in 162 blocks are definitely lost in loss record 21,680 of 21,758
==1479239==    at 0x4840F2F: operator new(unsigned long) (vg_replace_malloc.c:422)
==1479239==    by 0x1065CF9: std::__detail::_MakeUniq<ServerPacket>::__single_object std::make_unique<ServerPacket, int, unsigned long>(int&&, unsigned long&&) (unique_ptr.h:1065)
==1479239==    by 0x10540A8: Client::BuyTraderItemOutsideBazaar(TraderBuy_Struct*, EQApplicationPacket const*) (trading.cpp:3557)
==1479239==    by 0x47C006: Client::Handle_OP_TraderBuy(EQApplicationPacket const*) (client_packet.cpp:16114)
==1479239==    by 0x48F7F3: Client::HandlePacket(EQApplicationPacket const*) (client_packet.cpp:515)
==1479239==    by 0x4D64F1: Client::Process() (client_process.cpp:720)
==1479239==    by 0x8157BB: EntityList::MobProcess() (entity.cpp:532)
==1479239==    by 0xC12E2A: main::{lambda(EQ::Timer*)#1}::operator()(EQ::Timer*) const (main.cpp:613)
==1479239==    by 0xC12F51: __invoke_impl<void, main(int, char**)::<lambda(EQ::Timer*)>&, EQ::Timer*> (invoke.h:61)
==1479239==    by 0xC12F51: __invoke_r<void, main(int, char**)::<lambda(EQ::Timer*)>&, EQ::Timer*> (invoke.h:111)
==1479239==    by 0xC12F51: std::_Function_handler<void (EQ::Timer*), main::{lambda(EQ::Timer*)#1}>::_M_invoke(std::_Any_data const&, EQ::Timer*&&) (std_function.h:290)
==1479239==    by 0xC21D3C: EQ::Timer::Start(unsigned long, bool)::{lambda(uv_timer_s*)#1}::_FUN(uv_timer_s*) (std_function.h:591)
==1479239== 
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Ran through the action to validate functionality wasn't broken.

![image](https://github.com/user-attachments/assets/0ed7cdb4-2e8e-4be3-8e89-0f101cd4a916)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
