### PR TITLE
[Memory Leak] Fix leak in QuestManager::varlink

### DIFF
--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -3449,7 +3449,9 @@ std::string QuestManager::varlink(
 	linker.SetLinkType(EQ::saylink::SayLinkItemInst);
 	linker.SetItemInst(item);
 
-	return linker.GenerateLink();
+	auto link = linker.GenerateLink();
+	safe_delete(item);
+	return link;
 }
 
 std::string QuestManager::getitemcomment(uint32 item_id) {


### PR DESCRIPTION
# Description

Observed on THJ. We never free the newly created item.

**Valgrind**

```cpp
==1479239== 4,988,684 (788,888 direct, 4,199,796 indirect) bytes in 3,181 blocks are definitely lost in loss record 21,758 of 21,758
==1479239==    at 0x4840F2F: operator new(unsigned long) (vg_replace_malloc.c:422)
==1479239==    by 0x1305F76: SharedDatabase::CreateBaseItem(EQ::ItemData const*, short) (shareddb.cpp:1720)
==1479239==    by 0x130B380: SharedDatabase::CreateItem(unsigned int, short, unsigned int, unsigned int, unsigned int, unsigned int, unsigned int, unsigned int, bool, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned int, unsigned int, unsigned int) (shareddb.cpp:1637)
==1479239==    by 0xF22D9E: QuestManager::varlink[abi:cxx11](unsigned int, short, unsigned int, unsigned int, unsigned int, unsigned int, unsigned int, unsigned int, bool) (questmgr.cpp:3390)
==1479239==    by 0x7924C0: Perl__varlink[abi:cxx11](unsigned int) (embparser_api.cpp:4968)
==1479239==    by 0x7E624B: call_func<std::__cxx11::basic_string<char> (*)(unsigned int), std::tuple<unsigned int>, 0> (function.h:116)
==1479239==    by 0x7E624B: apply<std::__cxx11::basic_string<char> (*)(unsigned int), std::tuple<unsigned int> > (function.h:129)
==1479239==    by 0x7E624B: call_impl (function.h:103)
==1479239==    by 0x7E624B: perlbind::detail::function<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > (*)(unsigned int)>::call(perlbind::detail::xsub_stack&) const (function.h:97)
==1479239==    by 0x15068DD: xsub (package.cpp:62)
==1479239==    by 0x4F2A757: Perl_pp_entersub (in /opt/eqemu-perl/lib/5.32.1/x86_64-linux-thread-multi/CORE/libperl.so)
==1479239==    by 0x4F20B95: Perl_runops_standard (in /opt/eqemu-perl/lib/5.32.1/x86_64-linux-thread-multi/CORE/libperl.so)
==1479239==    by 0x4E876CB: Perl_call_sv (in /opt/eqemu-perl/lib/5.32.1/x86_64-linux-thread-multi/CORE/libperl.so)
```

# Testing

![image](https://github.com/user-attachments/assets/5ae5e15b-2bb4-4a3f-952f-3c4310b59c13)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
