### PR TITLE
[Memory Leak] Fix leak in NPC::RemoveItem

### DIFF
--- a/zone/loot.cpp
+++ b/zone/loot.cpp
@@ -687,6 +687,8 @@ void NPC::RemoveItem(uint32 item_id, uint16 quantity, uint16 slot)
 		LootItem *item = *cur;
 		if (item->item_id == item_id && slot <= 0 && quantity <= 0) {
 			m_loot_items.erase(cur);
+			Say("Deleting item %d from NPC %s", item_id, GetName());
+			safe_delete(item);
 			UpdateEquipmentLight();
 			if (UpdateActiveLight()) { SendAppearancePacket(AppearanceType::Light, GetActiveLightType()); }
 			return;
@@ -694,6 +696,8 @@ void NPC::RemoveItem(uint32 item_id, uint16 quantity, uint16 slot)
 		else if (item->item_id == item_id && item->equip_slot == slot && quantity >= 1) {
 			if (item->charges <= quantity) {
 				m_loot_items.erase(cur);
+				Say("Deleting item %d from NPC %s", item_id, GetName());
+				safe_delete(item);
 				UpdateEquipmentLight();
 				if (UpdateActiveLight()) { SendAppearancePacket(AppearanceType::Light, GetActiveLightType()); }
 			}

--- a/zone/loot.cpp
+++ b/zone/loot.cpp
@@ -687,7 +687,6 @@ void NPC::RemoveItem(uint32 item_id, uint16 quantity, uint16 slot)
 		LootItem *item = *cur;
 		if (item->item_id == item_id && slot <= 0 && quantity <= 0) {
 			m_loot_items.erase(cur);
-			Say("Deleting item %d from NPC %s", item_id, GetName());
 			safe_delete(item);
 			UpdateEquipmentLight();
 			if (UpdateActiveLight()) { SendAppearancePacket(AppearanceType::Light, GetActiveLightType()); }
@@ -696,7 +695,6 @@ void NPC::RemoveItem(uint32 item_id, uint16 quantity, uint16 slot)
 		else if (item->item_id == item_id && item->equip_slot == slot && quantity >= 1) {
 			if (item->charges <= quantity) {
 				m_loot_items.erase(cur);
-				Say("Deleting item %d from NPC %s", item_id, GetName());
 				safe_delete(item);
 				UpdateEquipmentLight();
 				if (UpdateActiveLight()) { SendAppearancePacket(AppearanceType::Light, GetActiveLightType()); }


### PR DESCRIPTION
# Description

Observed on THJ. When an item is added to an NPC, we free on deconstructor but there are paths where we don't fully clean up (Such as removing). THJ has a pet code inventory sync function that constantly adds and removes items from the pet to "sync" and it adds up significantly.

**Valgrind**

```cpp
==1479239== 2,657,664 bytes in 27,684 blocks are definitely lost in loss record 21,755 of 21,758
==1479239==    at 0x4840F2F: operator new(unsigned long) (vg_replace_malloc.c:422)
==1479239==    by 0x8CB1CF: NPC::AddLootDropFixed(EQ::ItemData const*, BaseLootdropEntriesRepository::LootdropEntries, bool, unsigned int, unsigned int, unsigned int, unsigned int, unsigned int, unsigned int) (loot.cpp:324)
==1479239==    by 0x8CC690: NPC::AddItemFixed(unsigned int, unsigned short, bool, unsigned int, unsigned int, unsigned int, unsigned int, unsigned int, unsigned int) (loot.cpp:679)
==1479239==    by 0x415A74: Client::DoPetBagResync(int) (client.cpp:14000)
==1479239==    by 0x8BFDA5: Client::SwapItem(MoveItem_Struct*) (inventory.cpp:2652)
==1479239==    by 0x45E4A1: Client::Handle_OP_MoveItem(EQApplicationPacket const*) (client_packet.cpp:11033)
==1479239==    by 0x48F7F3: Client::HandlePacket(EQApplicationPacket const*) (client_packet.cpp:515)
==1479239==    by 0x4D64F1: Client::Process() (client_process.cpp:720)
==1479239==    by 0x8157BB: EntityList::MobProcess() (entity.cpp:532)
==1479239==    by 0xC12E2A: main::{lambda(EQ::Timer*)#1}::operator()(EQ::Timer*) const (main.cpp:613)
```

# Testing

![image](https://github.com/user-attachments/assets/fc1c8e7e-50c8-4f08-921b-bb3f925af18e)

```perl
sub EVENT_SAY {
    if ($text=~/test/i) {
        $client->GetTarget()->CastToNPC()->AddItem(5042);
        $client->GetTarget()->CastToNPC()->RemoveItem(5042);
        $client->GetTarget()->CastToNPC()->RemoveItem(5042);
        $client->GetTarget()->CastToNPC()->RemoveItem(5042);
        $client->GetTarget()->CastToNPC()->RemoveItem(5042);
    }
}
```

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
