### PR TITLE
[Memory Leak] Fix leaks in Client::Handle_OP_AugmentItem

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -3252,11 +3252,11 @@ void Client::Handle_OP_AugmentItem(const EQApplicationPacket *app)
 				if (!new_aug) { // Shouldn't get the OP code without the augment on the user's cursor, but maybe it's h4x.
 					LogError("AugmentItem OpCode with 'Insert' or 'Swap' action received, but no augment on client's cursor");
 					Message(Chat::Red, "Error: No augment found on cursor for inserting.");
-					return;
+					break;
 				} else {
 					if (!RuleB(Inventory, AllowMultipleOfSameAugment) && tobe_auged->ContainsAugmentByID(new_aug->GetID())) {
 						Message(Chat::Red, "Error: Cannot put multiple of the same augment in an item.");
-						return;
+						break;
 					}
 
 					if (
@@ -3340,7 +3340,7 @@ void Client::Handle_OP_AugmentItem(const EQApplicationPacket *app)
 									in_augment->augment_index
 								).c_str()
 							);
-							return;
+							break;
 						}
 
 						item_one_to_push = tobe_auged->Clone();
@@ -3412,7 +3412,7 @@ void Client::Handle_OP_AugmentItem(const EQApplicationPacket *app)
 					}
 				} else {
 					Message(Chat::Red, "Error: Could not find augmentation to remove at index %i. Aborting.", in_augment->augment_index);
-					return;
+					break;
 				}
 
 				old_aug = tobe_auged->RemoveAugment(in_augment->augment_index);
@@ -3445,7 +3445,7 @@ void Client::Handle_OP_AugmentItem(const EQApplicationPacket *app)
 					if (!PutItemInInventory(EQ::invslot::slotCursor, *item_two_to_push, true)) {
 						LogError("Problem returning augment to player's cursor after safe removal");
 						Message(Chat::Yellow, "Error: Failed to return augment after removal from item!");
-						return;
+						break;
 					}
 				}
 				break;
@@ -3490,7 +3490,7 @@ void Client::Handle_OP_AugmentItem(const EQApplicationPacket *app)
 							in_augment->augment_index
 						).c_str()
 					);
-					return;
+					break;
 				}
 
 				tobe_auged->DeleteAugment(in_augment->augment_index);
@@ -3511,6 +3511,7 @@ void Client::Handle_OP_AugmentItem(const EQApplicationPacket *app)
 				if (material != EQ::textures::materialInvalid) {
 					SendWearChange(material);
 				}
+
 				break;
 			default: // Unknown
 				LogInventory(
@@ -3524,9 +3525,13 @@ void Client::Handle_OP_AugmentItem(const EQApplicationPacket *app)
 				);
 				break;
 		}
+		Message(Chat::White, "We did it captain");
+		safe_delete(item_one_to_push);
+		safe_delete(item_two_to_push);
 	} else {
 		Object::HandleAugmentation(this, in_augment, m_tradeskill_object); // Delegate to tradeskill object to perform combine
 	}
+
 	return;
 }
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -3525,7 +3525,6 @@ void Client::Handle_OP_AugmentItem(const EQApplicationPacket *app)
 				);
 				break;
 		}
-		Message(Chat::White, "We did it captain");
 		safe_delete(item_one_to_push);
 		safe_delete(item_two_to_push);
 	} else {


### PR DESCRIPTION
# Description

Observed on THJ. Up to two items get cloned and never freed. We early `return` in a switch statement instead of `break`, changed to `break`s so all switch statements end up freeing in the same spot.

**Valgrind**

```cpp
==1479239== 145,080 (1,536 direct, 143,544 indirect) bytes in 32 blocks are definitely lost in loss record 21,724 of 21,758
==1479239==    at 0x4840F2F: operator new(unsigned long) (vg_replace_malloc.c:422)
==1479239==    by 0x1296642: allocate (new_allocator.h:137)
==1479239==    by 0x1296642: allocate (allocator.h:188)
==1479239==    by 0x1296642: allocate (alloc_traits.h:464)
==1479239==    by 0x1296642: _M_get_node (stl_tree.h:561)
==1479239==    by 0x1296642: _M_create_node<const std::piecewise_construct_t&, std::tuple<unsigned char const&>, std::tuple<> > (stl_tree.h:611)
==1479239==    by 0x1296642: _Auto_node<const std::piecewise_construct_t&, std::tuple<unsigned char const&>, std::tuple<> > (stl_tree.h:1636)
==1479239==    by 0x1296642: std::_Rb_tree_iterator<std::pair<unsigned char const, EQ::ItemInstance*> > std::_Rb_tree<unsigned char, std::pair<unsigned char const, EQ::ItemInstance*>, std::_Select1st<std::pair<unsigned char const, EQ::ItemInstance*> >, std::less<unsigned char>, std::allocator<std::pair<unsigned char const, EQ::ItemInstance*> > >::_M_emplace_hint_unique<std::piecewise_construct_t const&, std::tuple<unsigned char const&>, std::tuple<> >(std::_Rb_tree_const_iterator<std::pair<unsigned char const, EQ::ItemInstance*> >, std::piecewise_construct_t const&, std::tuple<unsigned char const&>&&, std::tuple<>&&) (stl_tree.h:2461)
==1479239==    by 0x128F89D: operator[] (stl_map.h:511)
==1479239==    by 0x128F89D: EQ::ItemInstance::ItemInstance(EQ::ItemInstance const&) (item_instance.cpp:134)
==1479239==    by 0x128FBE2: EQ::ItemInstance::Clone() const (item_instance.cpp:988)
==1479239==    by 0x483E17: Client::Handle_OP_AugmentItem(EQApplicationPacket const*) (client_packet.cpp:3418)
==1479239==    by 0x48F7F3: Client::HandlePacket(EQApplicationPacket const*) (client_packet.cpp:515)
==1479239==    by 0x4D64F1: Client::Process() (client_process.cpp:720)
==1479239==    by 0x8157BB: EntityList::MobProcess() (entity.cpp:532)
==1479239==    by 0xC12E2A: main::{lambda(EQ::Timer*)#1}::operator()(EQ::Timer*) const (main.cpp:613)
==1479239==    by 0xC12F51: __invoke_impl<void, main(int, char**)::<lambda(EQ::Timer*)>&, EQ::Timer*> (invoke.h:61)
==1479239==    by 0xC12F51: __invoke_r<void, main(int, char**)::<lambda(EQ::Timer*)>&, EQ::Timer*> (invoke.h:111)
==1479239==    by 0xC12F51: std::_Function_handler<void (EQ::Timer*), main::{lambda(EQ::Timer*)#1}>::_M_invoke(std::_Any_data const&, EQ::Timer*&&) (std_function.h:290)
==1479239== 
==1479239== 161,072 (8,928 direct, 152,144 indirect) bytes in 36 blocks are definitely lost in loss record 21,726 of 21,758
==1479239==    at 0x4840F2F: operator new(unsigned long) (vg_replace_malloc.c:422)
==1479239==    by 0x128FBD4: EQ::ItemInstance::Clone() const (item_instance.cpp:988)
==1479239==    by 0x483E17: Client::Handle_OP_AugmentItem(EQApplicationPacket const*) (client_packet.cpp:3418)
==1479239==    by 0x48F7F3: Client::HandlePacket(EQApplicationPacket const*) (client_packet.cpp:515)
==1479239==    by 0x4D64F1: Client::Process() (client_process.cpp:720)
==1479239==    by 0x8157BB: EntityList::MobProcess() (entity.cpp:532)
==1479239==    by 0xC12E2A: main::{lambda(EQ::Timer*)#1}::operator()(EQ::Timer*) const (main.cpp:613)
==1479239==    by 0xC12F51: __invoke_impl<void, main(int, char**)::<lambda(EQ::Timer*)>&, EQ::Timer*> (invoke.h:61)
==1479239==    by 0xC12F51: __invoke_r<void, main(int, char**)::<lambda(EQ::Timer*)>&, EQ::Timer*> (invoke.h:111)
==1479239==    by 0xC12F51: std::_Function_handler<void (EQ::Timer*), main::{lambda(EQ::Timer*)#1}>::_M_invoke(std::_Any_data const&, EQ::Timer*&&) (std_function.h:290)
==1479239==    by 0xC21D3C: EQ::Timer::Start(unsigned long, bool)::{lambda(uv_timer_s*)#1}::_FUN(uv_timer_s*) (std_function.h:591)
==1479239==    by 0x14D2B3C: uv__run_timers (timer.c:178)
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

```cpp
		Message(Chat::White, "We did it captain");
		safe_delete(item_one_to_push);
		safe_delete(item_two_to_push);
```

![image](https://github.com/user-attachments/assets/be9b2eb5-f7a9-471e-8cf1-4ef627cd1909)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

