### PR TITLE
[Memory Leak] Fix memory leak in Client::Handle_OP_MoveMultipleItems

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -10882,7 +10882,6 @@ void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
 						InterrogateInventory(this, true, false, true, error);
 					}
 				}
-				Message(15, "Deleted");
 				safe_delete(mi);
 			}
 		// This is the swap.

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -10882,6 +10882,8 @@ void Client::Handle_OP_MoveMultipleItems(const EQApplicationPacket *app)
 						InterrogateInventory(this, true, false, true, error);
 					}
 				}
+				Message(15, "Deleted");
+				safe_delete(mi);
 			}
 		// This is the swap.
 		// Client behavior is just to move stacks without combining them


### PR DESCRIPTION
# Description

Observed on THJ, a struct is new'ed and never freed.

**Valgrind**

```cpp
==1479239== 1,860 bytes in 155 blocks are definitely lost in loss record 20,729 of 21,758
==1479239==    at 0x4840F2F: operator new(unsigned long) (vg_replace_malloc.c:422)
==1479239==    by 0x4514BF: Client::Handle_OP_MoveMultipleItems(EQApplicationPacket const*) (client_packet.cpp:11084)
==1479239==    by 0x48F7F3: Client::HandlePacket(EQApplicationPacket const*) (client_packet.cpp:515)
==1479239==    by 0x4D64F1: Client::Process() (client_process.cpp:720)
==1479239==    by 0x8157BB: EntityList::MobProcess() (entity.cpp:532)
==1479239==    by 0xC12E2A: main::{lambda(EQ::Timer*)#1}::operator()(EQ::Timer*) const (main.cpp:613)
==1479239==    by 0xC12F51: __invoke_impl<void, main(int, char**)::<lambda(EQ::Timer*)>&, EQ::Timer*> (invoke.h:61)
==1479239==    by 0xC12F51: __invoke_r<void, main(int, char**)::<lambda(EQ::Timer*)>&, EQ::Timer*> (invoke.h:111)
==1479239==    by 0xC12F51: std::_Function_handler<void (EQ::Timer*), main::{lambda(EQ::Timer*)#1}>::_M_invoke(std::_Any_data const&, EQ::Timer*&&) (std_function.h:290)
==1479239==    by 0xC21D3C: EQ::Timer::Start(unsigned long, bool)::{lambda(uv_timer_s*)#1}::_FUN(uv_timer_s*) (std_function.h:591)
==1479239==    by 0x14D2B3C: uv__run_timers (timer.c:178)
==1479239==    by 0x14D613F: uv_run (core.c:393)
==1479239== 
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

```cpp
Message(15, "Deleted");
safe_delete(mi);
```

![image](https://github.com/user-attachments/assets/bca0c272-100d-406f-a5ac-f9830c588489)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
