### PR TITLE
[Memory Leak] Change raw pointer to unique_ptr to avoid potential leak in dbg stream

### DIFF
--- a/common/net/daybreak_connection.cpp
+++ b/common/net/daybreak_connection.cpp
@@ -500,10 +500,9 @@ void EQ::Net::DaybreakConnection::ProcessQueue()
 				break;
 			}
 
-			auto packet = iter->second;
+			auto &packet = iter->second;
 			stream->packet_queue.erase(iter);
 			ProcessDecodedPacket(*packet);
-			delete packet;
 		}
 	}
 }
@@ -513,9 +512,8 @@ void EQ::Net::DaybreakConnection::RemoveFromQueue(int stream, uint16_t seq)
 	auto s = &m_streams[stream];
 	auto iter = s->packet_queue.find(seq);
 	if (iter != s->packet_queue.end()) {
-		auto packet = iter->second;
+		auto &packet = iter->second;
 		s->packet_queue.erase(iter);
-		delete packet;
 	}
 }
 
@@ -527,7 +525,7 @@ void EQ::Net::DaybreakConnection::AddToQueue(int stream, uint16_t seq, const Pac
 		DynamicPacket *out = new DynamicPacket();
 		out->PutPacket(0, p);
 
-		s->packet_queue.emplace(std::make_pair(seq, out));
+		s->packet_queue.emplace(std::make_pair(seq, std::unique_ptr<Packet>(out)));
 	}
 }
 

--- a/common/net/daybreak_connection.h
+++ b/common/net/daybreak_connection.h
@@ -201,7 +201,7 @@ namespace EQ
 
 				uint16_t sequence_in;
 				uint16_t sequence_out;
-				std::map<uint16_t, Packet*> packet_queue;
+				std::map<uint16_t, std::unique_ptr<Packet>> packet_queue;
 
 				DynamicPacket fragment_packet;
 				uint32_t fragment_current_bytes;


### PR DESCRIPTION
# Description

Akk brought this potential leak to my attention.  Basically what can happen is if you disconnect in the middle of receiving a big packet from the server the parts of the packet that have arrived will be put in a queue that isn't cleared when the connection is terminated.

**Valgrind**

```cpp
==1682562== 72,011 (64,448 direct, 7,563 indirect) bytes in 152 blocks are definitely lost in loss record 24,115 of 24,262
==1682562==    at 0x4843F93: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1682562==    by 0x15C3B91: EQ::Net::DaybreakConnection::AddToQueue(int, unsigned short, EQ::Net::Packet const&) (common/net/daybreak_connection.cpp:527)
==1682562==    by 0x15C36CA: EQ::Net::DaybreakConnection::ProcessDecodedPacket(EQ::Net::Packet const&) (common/net/daybreak_connection.cpp:0)
==1682562==    by 0x15C3567: EQ::Net::DaybreakConnection::ProcessDecodedPacket(EQ::Net::Packet const&) (common/net/daybreak_connection.cpp:558)
==1682562==    by 0x15BFF57: EQ::Net::DaybreakConnection::ProcessPacket(EQ::Net::Packet&) (common/net/daybreak_connection.cpp:464)
==1682562==    by 0x15BEF89: EQ::Net::DaybreakConnectionManager::ProcessPacket(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, char const*, unsigned long) (common/net/daybreak_connection.cpp:224)
==1682562==    by 0x15C532A: operator() (common/net/daybreak_connection.cpp:72)
==1682562==    by 0x15C532A: EQ::Net::DaybreakConnectionManager::Attach(uv_loop_s*)::$_2::__invoke(uv_udp_s*, long, uv_buf_t const*, sockaddr const*, unsigned int) (common/net/daybreak_connection.cpp:62)
==1682562==    by 0x15E5501: uv__udp_recvmsg (submodules/libuv/src/unix/udp.c:0)
==1682562==    by 0x15E5501: uv__udp_io (submodules/libuv/src/unix/udp.c:178)
==1682562==    by 0x15E8827: uv__io_poll (submodules/libuv/src/unix/epoll.c:374)
==1682562==    by 0x15DC597: uv_run (submodules/libuv/src/unix/core.c:406)
==1682562== 
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing
Clients tested: RoF2.

Note: it's a little difficult to test since it's hard to actually force this with a real client.  It just sometimes happens based on network conditions and such.  I've tested that the netcode still functions as normal in basic operation.

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
