### PR TITLE
[Performance] Reuse ClientUpdate packet memory

### DIFF
--- a/zone/aura.cpp
+++ b/zone/aura.cpp
@@ -735,21 +735,22 @@ bool Aura::Process()
 
 	if (movement_type == AuraMovement::Follow && GetPosition() != owner->GetPosition() && movement_timer.Check()) {
 		m_Position = owner->GetPosition();
-		auto app = new EQApplicationPacket(OP_ClientUpdate, sizeof(PlayerPositionUpdateServer_Struct));
-		auto spu = (PlayerPositionUpdateServer_Struct *) app->pBuffer;
+
+		static EQApplicationPacket packet(OP_ClientUpdate, sizeof(PlayerPositionUpdateServer_Struct));
+		auto                       spu = (PlayerPositionUpdateServer_Struct *) packet.pBuffer;
+
 		MakeSpawnUpdate(spu);
 		auto it = spawned_for.begin();
 		while (it != spawned_for.end()) {
 			auto client = entity_list.GetClientByID(*it);
 			if (client) {
-				client->QueuePacket(app);
+				client->QueuePacket(&packet);
 				++it;
 			}
 			else {
 				it = spawned_for.erase(it);
 			}
 		}
-		safe_delete(app);
 	}
 	// TODO: waypoints?
 

--- a/zone/mob_movement_manager.cpp
+++ b/zone/mob_movement_manager.cpp
@@ -824,8 +824,8 @@ void MobMovementManager::SendCommandToClients(
 		return;
 	}
 
-	EQApplicationPacket outapp(OP_ClientUpdate, sizeof(PlayerPositionUpdateServer_Struct));
-	auto                *spu = (PlayerPositionUpdateServer_Struct *) outapp.pBuffer;
+	static EQApplicationPacket p(OP_ClientUpdate, sizeof(PlayerPositionUpdateServer_Struct));
+	auto                       *spu = (PlayerPositionUpdateServer_Struct *) p.pBuffer;
 
 	FillCommandStruct(spu, mob, delta_x, delta_y, delta_z, delta_heading, anim);
 
@@ -862,7 +862,7 @@ void MobMovementManager::SendCommandToClients(
 				}
 			}
 
-			c->QueuePacket(&outapp, false);
+			c->QueuePacket(&p, false);
 			c->m_last_seen_mob_position[mob->GetID()] = mob->GetPosition();
 		}
 	}
@@ -924,7 +924,7 @@ void MobMovementManager::SendCommandToClients(
 					}
 				}
 
-				c->QueuePacket(&outapp, false);
+				c->QueuePacket(&p, false);
 				c->m_last_seen_mob_position[mob->GetID()] = mob->GetPosition();
 			}
 		}

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -3824,13 +3824,12 @@ int NPC::GetRolledItemCount(uint32 item_id)
 
 void NPC::SendPositionToClients()
 {
-	auto      p  = new EQApplicationPacket(OP_ClientUpdate, sizeof(PlayerPositionUpdateServer_Struct));
-	auto      *s = (PlayerPositionUpdateServer_Struct *) p->pBuffer;
+	static EQApplicationPacket p(OP_ClientUpdate, sizeof(PlayerPositionUpdateServer_Struct));
+	auto      *s = (PlayerPositionUpdateServer_Struct *) p.pBuffer;
 	for (auto &c: entity_list.GetClientList()) {
 		MakeSpawnUpdate(s);
-		c.second->QueuePacket(p, false);
+		c.second->QueuePacket(&p, false);
 	}
-	safe_delete(p);
 }
 
 void NPC::HandleRoambox()


### PR DESCRIPTION
# Description

This change makes use of static buffers for the creation of packets at the first layer in the network layer when we send packets to clients.

Usually we new up a packet struct, send it and free it immediately. This action in volume is actually quite expensive CPU wise. We can benefit greatly from nailing up memory buffers to an object that gets re-used for any client that invokes the logic, memory does not need to be allocated again, just re-filled and sent.

## Type of change

- [x] Performance improvement

# Testing

Tested in game, watching NPC's path, everything behaved as normal.

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context
- [x] I own the changes of my code and take responsibility for the potential issues that occur
