### PR TITLE
[Repop] Make #repop instant

### DIFF
--- a/zone/spawn2.cpp
+++ b/zone/spawn2.cpp
@@ -533,6 +533,7 @@ bool ZoneDatabase::PopulateZoneSpawnList(uint32 zoneid, LinkedList<Spawn2*> &spa
 		);
 
 		spawn2_list.Insert(new_spawn);
+		new_spawn->Process();
 	}
 
 	LogInfo("Loaded [{}] spawn2 entries", Strings::Commify(l.size()));


### PR DESCRIPTION
# Description

This fixes a minor issue noticed when issuing a #repop - the "spawn2" timer loop waits up to a second to process spawning NPC's. This change makes the process trigger immediate on repop.

## Type of change

- [x] Improvement

# Testing

https://github.com/user-attachments/assets/6b8983f7-2c14-4715-adc8-a9348dde2415

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
