### PR TITLE
[Performance] Re-use OP_Animation packet

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2559,16 +2559,12 @@ bool NPC::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillTy
 	const uint8 killed_level = GetLevel();
 
 	if (GetClass() == Class::LDoNTreasure) { // open chest
-		auto outapp = new EQApplicationPacket(OP_Animation, sizeof(Animation_Struct));
-
-		auto a = (Animation_Struct*) outapp->pBuffer;
-
+		static EQApplicationPacket p(OP_Animation, sizeof(Animation_Struct));
+		auto a = (Animation_Struct*) p.pBuffer;
 		a->spawnid = GetID();
 		a->action  = 0x0F;
 		a->speed   = 10;
-
-		entity_list.QueueCloseClients(this, outapp);
-		safe_delete(outapp);
+		entity_list.QueueCloseClients(this, &p);
 	}
 
 	auto app = new EQApplicationPacket(OP_Death, sizeof(Death_Struct));

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -125,7 +125,7 @@ Mob::Mob(
 	tmHidden(-1),
 	mitigation_ac(0),
 	m_specialattacks(eSpecialAttacks::None),
-	attack_anim_timer(500),
+	attack_anim_timer(100),
 	position_update_melee_push_timer(500),
 	hate_list_cleanup_timer(6000),
 	m_scan_close_mobs_timer(6000),
@@ -3540,24 +3540,21 @@ void Mob::DoAnim(const int animation_id, int animation_speed, bool ackreq, eqFil
 		return;
 	}
 
-	auto outapp = new EQApplicationPacket(OP_Animation, sizeof(Animation_Struct));
-	auto *a  = (Animation_Struct *) outapp->pBuffer;
-
+	static EQApplicationPacket p(OP_Animation, sizeof(Animation_Struct));
+	auto a = (Animation_Struct*) p.pBuffer;
 	a->spawnid = GetID();
 	a->action  = animation_id;
 	a->speed   = animation_speed ? animation_speed : 10;
 
 	entity_list.QueueCloseClients(
 		this, /* Sender */
-		outapp, /* Packet */
+		&p, /* Packet */
 		false, /* Ignore Sender */
 		RuleI(Range, Anims),
 		0, /* Skip this mob */
 		ackreq, /* Packet ACK */
 		filter /* eqFilterType filter */
 	);
-
-	safe_delete(outapp);
 }
 
 void Mob::ShowBuffs(Client* c) {


### PR DESCRIPTION
# Description

This change makes use of static buffers for the creation of packets at the first layer in the network layer when we send packets to clients.

Usually we new up a packet struct, send it and free it immediately. This action in volume is actually quite expensive CPU wise. We can benefit greatly from nailing up memory buffers to an object that gets re-used for any client that invokes the logic, memory does not need to be allocated again, just re-filled and sent.

Also reduced attack animation timer throttle to allow animations to look a little more natural.

## Type of change

- [x] Performance improvement

# Testing

https://github.com/user-attachments/assets/2ed7b115-7bf9-4a9f-b3e3-ad4bd53ed214


# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context
- [x] I own the changes of my code and take responsibility for the potential issues that occur
