### PR TITLE
[Performance] Reuse OP_HPUpdate packet memory

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1522,16 +1522,12 @@ void Mob::SendHPUpdate(bool force_update_all)
 				last_hp
 			);
 
-			auto client_packet     = new EQApplicationPacket(OP_HPUpdate, sizeof(SpawnHPUpdate_Struct));
-			auto *hp_packet_client = (SpawnHPUpdate_Struct *) client_packet->pBuffer;
-
-			hp_packet_client->cur_hp   = static_cast<uint32>(CastToClient()->GetHP() - itembonuses.HP);
-			hp_packet_client->spawn_id = GetID();
-			hp_packet_client->max_hp   = CastToClient()->GetMaxHP() - itembonuses.HP;
-
-			CastToClient()->QueuePacket(client_packet);
-
-			safe_delete(client_packet);
+			static EQApplicationPacket p(OP_HPUpdate, sizeof(SpawnHPUpdate_Struct));
+			auto b = (SpawnHPUpdate_Struct*) p.pBuffer;
+			b->cur_hp   = static_cast<uint32>(CastToClient()->GetHP() - itembonuses.HP);
+			b->spawn_id = GetID();
+			b->max_hp   = CastToClient()->GetMaxHP() - itembonuses.HP;
+			CastToClient()->QueuePacket(&p);
 
 			ResetHPUpdateTimer();
 


### PR DESCRIPTION
# Description

This change makes use of static buffers for the creation of packets at the first layer in the network layer when we send packets to clients.

Usually we new up a packet struct, send it and free it immediately. This action in volume is actually quite expensive CPU wise. We can benefit greatly from nailing up memory buffers to an object that gets re-used for any client that invokes the logic, memory does not need to be allocated again, just re-filled and sent.

## Type of change

- [x] Performance improvement

# Testing

Tested in game, damaged self, seemed fine.

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context
- [x] I own the changes of my code and take responsibility for the potential issues that occur
