### PR TITLE
[Performance] Reuse OP_Damage packet memory

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -3415,15 +3415,15 @@ void Mob::DamageShield(Mob* attacker, bool spell_ds) {
 
 		attacker->Damage(this, -DS, spellid, EQ::skills::SkillAbjuration/*hackish*/, false);
 		//we can assume there is a spell now
-		auto outapp = new EQApplicationPacket(OP_Damage, sizeof(CombatDamage_Struct));
-		CombatDamage_Struct* cds = (CombatDamage_Struct*)outapp->pBuffer;
-		cds->target = attacker->GetID();
-		cds->source = GetID();
-		cds->type = spellbonuses.DamageShieldType;
-		cds->spellid = 0x0;
-		cds->damage = DS;
-		entity_list.QueueCloseClients(this, outapp);
-		safe_delete(outapp);
+
+		static EQApplicationPacket p(OP_Damage, sizeof(CombatDamage_Struct));
+		auto                       b = (CombatDamage_Struct *) p.pBuffer;
+		b->target  = attacker->GetID();
+		b->source  = GetID();
+		b->type    = spellbonuses.DamageShieldType;
+		b->spellid = 0x0;
+		b->damage  = DS;
+		entity_list.QueueCloseClients(this, &p);
 	}
 	else if (DS > 0 && !spell_ds) {
 		//we are healing the attacker...
@@ -4540,8 +4540,8 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 
 		//send damage packet...
 	if (!iBuffTic) { //buff ticks do not send damage, instead they just call SendHPUpdate(), which is done above
-		auto outapp = new EQApplicationPacket(OP_Damage, sizeof(CombatDamage_Struct));
-		CombatDamage_Struct* a = (CombatDamage_Struct*)outapp->pBuffer;
+		static EQApplicationPacket p(OP_Damage, sizeof(CombatDamage_Struct));
+		auto                       a = (CombatDamage_Struct *) p.pBuffer;
 		a->target = GetID();
 
 		if (!attacker) {
@@ -4622,7 +4622,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 					if (!FromDamageShield) {
 						entity_list.QueueCloseClients(
 							attacker, /* Sender */
-							outapp, /* packet */
+							&p, /* packet */
 							false, /* Skip Sender */
 							((IsValidSpell(spell_id)) ? RuleI(Range, SpellMessages) : RuleI(Range, DamageMessages)),
 							0, /* don't skip anyone on spell */
@@ -4696,11 +4696,11 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 						filter = FilterMyMisses;
 
 					if (attacker->IsClient()) {
-						attacker->CastToClient()->QueuePacket(outapp, true, CLIENT_CONNECTED, filter);
+						attacker->CastToClient()->QueuePacket(&p, true, CLIENT_CONNECTED, filter);
 					} else {
 						entity_list.QueueCloseClients(
 							attacker, /* Sender */
-							outapp, /* packet */
+							&p, /* packet */
 							false, /* Skip Sender */
 							(
 								IsValidSpell(spell_id) ?
@@ -4755,7 +4755,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 				a->type = DamageTypeSpell;
 				entity_list.QueueCloseClients(
 					this, /* Sender */
-					outapp, /* packet */
+					&p, /* packet */
 					false, /* Skip Sender */
 					range, /* distance packet travels at the speed of sound */
 					0, /* don't skip anyone on spell */
@@ -4766,7 +4766,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 			else {
 				//I dont think any filters apply to damage affecting us
 				if (IsClient()) {
-					CastToClient()->QueuePacket(outapp);
+					CastToClient()->QueuePacket(&p);
 				}
 
 				// Send normal message to observers
@@ -4776,7 +4776,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 				if (!owner || (owner && !owner->IsClient())) {
 					entity_list.QueueCloseClients(
 						this, /* Sender */
-						outapp, /* packet */
+						&p, /* packet */
 						true, /* Skip Sender */
 						range, /* distance packet travels at the speed of sound */
 						(IsValidSpell(spell_id) && skill_used != EQ::skills::SkillTigerClaw) ? 0 : skip,
@@ -4786,8 +4786,6 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 				}
 			}
 		}
-
-		safe_delete(outapp);
 	}
 	else {
 		//else, it is a buff tic...

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -953,9 +953,9 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 						auto action_packet =
 						    new EQApplicationPacket(OP_Action, sizeof(Action_Struct));
 						Action_Struct* action = (Action_Struct*) action_packet->pBuffer;
-						auto message_packet =
-						    new EQApplicationPacket(OP_Damage, sizeof(CombatDamage_Struct));
-						CombatDamage_Struct *cd = (CombatDamage_Struct *)message_packet->pBuffer;
+
+						static EQApplicationPacket p(OP_Damage, sizeof(CombatDamage_Struct));
+						auto                       cd = (CombatDamage_Struct *) p.pBuffer;
 
 						action->target = GetID();
 						action->source = caster ? caster->GetID() : GetID();
@@ -978,16 +978,15 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 							caster->CastToClient()->QueuePacket(action_packet);
 						}
 
-						CastToClient()->QueuePacket(message_packet);
+						CastToClient()->QueuePacket(&p);
 
 						if (caster && caster->IsClient() && caster != this) {
-							caster->CastToClient()->QueuePacket(message_packet);
+							caster->CastToClient()->QueuePacket(&p);
 						}
 
 						CastToClient()->SetBindPoint(spells[spell_id].base_value[i] - 1);
 						Save();
 						safe_delete(action_packet);
-						safe_delete(message_packet);
 					} else {
 						if (!zone->CanBind()) {
 							MessageString(Chat::SpellFailure, CANNOT_BIND);
@@ -1002,9 +1001,9 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 								auto action_packet = new EQApplicationPacket(
 								    OP_Action, sizeof(Action_Struct));
 								Action_Struct* action = (Action_Struct*) action_packet->pBuffer;
-								auto message_packet = new EQApplicationPacket(
-								    OP_Damage, sizeof(CombatDamage_Struct));
-								CombatDamage_Struct *cd = (CombatDamage_Struct *)message_packet->pBuffer;
+
+								static EQApplicationPacket p(OP_Damage, sizeof(CombatDamage_Struct));
+								auto                       cd = (CombatDamage_Struct *) p.pBuffer;
 
 								action->target = GetID();
 								action->source = caster ? caster->GetID() : GetID();
@@ -1027,24 +1026,23 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 									caster->CastToClient()->QueuePacket(action_packet);
 								}
 
-								CastToClient()->QueuePacket(message_packet);
+								CastToClient()->QueuePacket(&p);
 
 								if (caster->IsClient() && caster != this) {
-									caster->CastToClient()->QueuePacket(message_packet);
+									caster->CastToClient()->QueuePacket(&p);
 								}
 
 								CastToClient()->SetBindPoint(spells[spell_id].base_value[i] - 1);
 								Save();
 								safe_delete(action_packet);
-								safe_delete(message_packet);
 							}
 						} else {
 							auto action_packet =
 							    new EQApplicationPacket(OP_Action, sizeof(Action_Struct));
 							Action_Struct* action = (Action_Struct*) action_packet->pBuffer;
-							auto message_packet = new EQApplicationPacket(
-							    OP_Damage, sizeof(CombatDamage_Struct));
-							CombatDamage_Struct *cd = (CombatDamage_Struct *)message_packet->pBuffer;
+
+							static EQApplicationPacket p(OP_Damage, sizeof(CombatDamage_Struct));
+							auto                       cd = (CombatDamage_Struct *) p.pBuffer;
 
 							action->target = GetID();
 							action->source = caster ? caster->GetID() : GetID();
@@ -1067,16 +1065,15 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 								caster->CastToClient()->QueuePacket(action_packet);
 							}
 
-							CastToClient()->QueuePacket(message_packet);
+							CastToClient()->QueuePacket(&p);
 
 							if (caster->IsClient() && caster != this) {
-								caster->CastToClient()->QueuePacket(message_packet);
+								caster->CastToClient()->QueuePacket(&p);
 							}
 
 							CastToClient()->SetBindPoint(spells[spell_id].base_value[i] - 1);
 							Save();
 							safe_delete(action_packet);
-							safe_delete(message_packet);
 						}
 					}
 				}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4564,8 +4564,8 @@ bool Mob::SpellOnTarget(
 		}
 	}
 
-	message_packet = new EQApplicationPacket(OP_Damage, sizeof(CombatDamage_Struct));
-	CombatDamage_Struct *cd = (CombatDamage_Struct *)message_packet->pBuffer;
+	static EQApplicationPacket p(OP_Damage, sizeof(CombatDamage_Struct));
+	auto                       cd = (CombatDamage_Struct *) p.pBuffer;
 	cd->target = action->target;
 	cd->source = action->source;
 	cd->type = action->type;
@@ -4583,7 +4583,7 @@ bool Mob::SpellOnTarget(
 	) {
 		entity_list.QueueCloseClients(
 			spelltar, /* Sender */
-			message_packet, /* Packet */
+			&p, /* Packet */
 			false, /* Ignore Sender */
 			RuleI(Range, SpellMessages),
 			0, /* Skip this mob */
@@ -4593,7 +4593,6 @@ bool Mob::SpellOnTarget(
 	}
 
 	safe_delete(action_packet);
-	safe_delete(message_packet);
 
 	/*
 		Bug: When an HP buff with a heal effect is applied for first time, the heal portion of the effect heals the client and


### PR DESCRIPTION
# Description

This change makes use of static buffers for the creation of packets at the first layer in the network layer when we send packets to clients.

Usually we new up a packet struct, send it and free it immediately. This action in volume is actually quite expensive CPU wise. We can benefit greatly from nailing up memory buffers to an object that gets re-used for any client that invokes the logic, memory does not need to be allocated again, just re-filled and sent.

## Type of change

- [x] Performance improvement

# Testing

Tested in game, beat on some NPC's, etc.

![image](https://github.com/user-attachments/assets/b58b3605-db6e-4118-86b4-9afd80431e2b)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context
- [x] I own the changes of my code and take responsibility for the potential issues that occur
