### PR TITLE
[Performance] Reuse OP_PlayerStateAdd packet memory

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -7717,28 +7717,26 @@ bool Mob::CanRaceEquipItem(uint32 item_id)
 
 void Mob::SendAddPlayerState(PlayerState new_state)
 {
-	auto app = new EQApplicationPacket(OP_PlayerStateAdd, sizeof(PlayerState_Struct));
-	auto ps = (PlayerState_Struct *)app->pBuffer;
+	static EQApplicationPacket p(OP_PlayerStateAdd, sizeof(PlayerState_Struct));
+	auto                       b = (PlayerState_Struct *) p.pBuffer;
 
-	ps->spawn_id = GetID();
-	ps->state = static_cast<uint32>(new_state);
+	b->spawn_id = GetID();
+	b->state    = static_cast<uint32>(new_state);
 
-	AddPlayerState(ps->state);
-	entity_list.QueueClients(nullptr, app);
-	safe_delete(app);
+	AddPlayerState(b->state);
+	entity_list.QueueClients(nullptr, &p);
 }
 
 void Mob::SendRemovePlayerState(PlayerState old_state)
 {
-	auto app = new EQApplicationPacket(OP_PlayerStateRemove, sizeof(PlayerState_Struct));
-	auto ps = (PlayerState_Struct *)app->pBuffer;
+	static EQApplicationPacket p(OP_PlayerStateRemove, sizeof(PlayerState_Struct));
+	auto                       b = (PlayerState_Struct *) p.pBuffer;
 
-	ps->spawn_id = GetID();
-	ps->state = static_cast<uint32>(old_state);
+	b->spawn_id = GetID();
+	b->state    = static_cast<uint32>(old_state);
 
-	RemovePlayerState(ps->state);
-	entity_list.QueueClients(nullptr, app);
-	safe_delete(app);
+	RemovePlayerState(b->state);
+	entity_list.QueueClients(nullptr, &p);
 }
 
 int32 Mob::GetMeleeMitigation() {


### PR DESCRIPTION
# Description

This change makes use of static buffers for the creation of packets at the first layer in the network layer when we send packets to clients.

Usually we new up a packet struct, send it and free it immediately. This action in volume is actually quite expensive CPU wise. We can benefit greatly from nailing up memory buffers to an object that gets re-used for any client that invokes the logic, memory does not need to be allocated again, just re-filled and sent.

## Type of change

- [x] Performance improvement

# Testing

Tested in game, aggro'ed zone, state changes appeared to function as normal.

![image](https://github.com/user-attachments/assets/a328b923-048d-43fa-bb9f-4e98eaef3948)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context
- [x] I own the changes of my code and take responsibility for the potential issues that occur
