### PR TITLE
[Performance] Significantly Improve Client Network Resends

### DIFF
--- a/common/net/daybreak_connection.cpp
+++ b/common/net/daybreak_connection.cpp
@@ -1117,10 +1117,7 @@ void EQ::Net::DaybreakConnection::ProcessResend(int stream)
 	auto s = &m_streams[stream];
 
 	// Get a reference resend delay (assume first packet represents the typical case)
-	size_t reference_resend_delay = 0;
 	if (!s->sent_packets.empty()) {
-		reference_resend_delay = s->sent_packets.begin()->second.resend_delay;
-
 		// Check if the first packet has timed out
 		auto time_since_first_sent = std::chrono::duration_cast<std::chrono::milliseconds>(now - s->sent_packets.begin()->second.first_sent).count();
 		if (time_since_first_sent >= m_owner->m_options.resend_timeout) {

--- a/common/net/daybreak_connection.cpp
+++ b/common/net/daybreak_connection.cpp
@@ -44,12 +44,7 @@ void EQ::Net::DaybreakConnectionManager::Attach(uv_loop_t *loop)
 			DaybreakConnectionManager *c = (DaybreakConnectionManager*)handle->data;
 			c->UpdateDataBudget();
 			c->Process();
-			auto now = Clock::now();
-			if (std::chrono::duration_cast<std::chrono::milliseconds>(now - c->m_last_resend_check).count() > c->m_resend_check_interval) {
-				c->ProcessResend();
-				c->m_last_resend_check = now;
-				return;
-			}
+			c->ProcessResend();
 		}, update_rate, update_rate);
 
 		uv_udp_init(loop, &m_socket);
@@ -1119,16 +1114,53 @@ void EQ::Net::DaybreakConnection::ProcessResend(int stream)
 	// Get a reference resend delay (assume first packet represents the typical case)
 	if (!s->sent_packets.empty()) {
 		// Check if the first packet has timed out
-		auto time_since_first_sent = std::chrono::duration_cast<std::chrono::milliseconds>(now - s->sent_packets.begin()->second.first_sent).count();
+		auto &first_packet = s->sent_packets.begin()->second;
+		auto time_since_first_sent = std::chrono::duration_cast<std::chrono::milliseconds>(now - first_packet.first_sent).count();
+
+		// make sure that the first_packet in the list first_sent time is within the resend_delay and now
+		// if it is not, then we need to resend all packets in the list
+		if (time_since_first_sent <= first_packet.resend_delay && !m_acked_since_last_resend) {
+			LogNetcodeDetail(
+				"Not resending packets for stream [{}] time since first sent [{}] resend delay [{}] m_acked_since_last_resend [{}]",
+				stream,
+				time_since_first_sent,
+				first_packet.resend_delay,
+				m_acked_since_last_resend
+			);
+			return;
+		}
+
 		if (time_since_first_sent >= m_owner->m_options.resend_timeout) {
 			Close();
 			return;
 		}
 	}
 
+	if (LogSys.IsLogEnabled(Logs::Detail, Logs::Netcode)) {
+		size_t    total_size = 0;
+		for (auto &e: s->sent_packets) {
+			total_size += e.second.packet.Length();
+		}
+
+		LogNetcodeDetail(
+			"Resending packets for stream [{}] packet count [{}] total packet size [{}] m_acked_since_last_resend [{}]",
+			stream,
+			s->sent_packets.size(),
+			total_size,
+			m_acked_since_last_resend
+		);
+	}
+
 	for (auto &e: s->sent_packets) {
 		if (m_resend_packets_sent >= MAX_CLIENT_RECV_PACKETS_PER_WINDOW ||
 			m_resend_bytes_sent >= MAX_CLIENT_RECV_BYTES_PER_WINDOW) {
+			LogNetcodeDetail(
+				"Stopping resend because we hit thresholds m_resend_packets_sent [{}] max [{}] m_resend_bytes_sent [{}] max [{}]",
+				m_resend_packets_sent,
+				MAX_CLIENT_RECV_PACKETS_PER_WINDOW,
+				m_resend_bytes_sent,
+				MAX_CLIENT_RECV_BYTES_PER_WINDOW
+			);
 			break;
 		}
 
@@ -1160,6 +1192,8 @@ void EQ::Net::DaybreakConnection::ProcessResend(int stream)
 			m_owner->m_options.resend_delay_max
 		);
 	}
+
+	m_acked_since_last_resend = false;
 }
 
 void EQ::Net::DaybreakConnection::Ack(int stream, uint16_t seq)
@@ -1180,6 +1214,7 @@ void EQ::Net::DaybreakConnection::Ack(int stream, uint16_t seq)
 			m_rolling_ping = (m_rolling_ping * 2 + round_time) / 3;
 
 			iter = s->sent_packets.erase(iter);
+			m_acked_since_last_resend = true;
 		}
 		else {
 			++iter;

--- a/common/net/daybreak_connection.h
+++ b/common/net/daybreak_connection.h
@@ -181,6 +181,10 @@ namespace EQ
 			Timestamp m_close_time;
 			double m_outgoing_budget;
 
+			// resend tracking
+			size_t m_resend_packets_sent = 0;
+			size_t m_resend_bytes_sent = 0;
+
 			struct DaybreakSentPacket
 			{
 				DynamicPacket packet;
@@ -317,6 +321,10 @@ namespace EQ
 		private:
 			void Attach(uv_loop_t *loop);
 			void Detach();
+
+			// resend
+			Timestamp m_last_resend_check;
+			int m_resend_check_interval = 50;
 
 			EQ::Random m_rand;
 			uv_timer_t m_timer;

--- a/common/net/daybreak_connection.h
+++ b/common/net/daybreak_connection.h
@@ -184,6 +184,7 @@ namespace EQ
 			// resend tracking
 			size_t m_resend_packets_sent = 0;
 			size_t m_resend_bytes_sent = 0;
+			bool m_acked_since_last_resend = false;
 
 			struct DaybreakSentPacket
 			{
@@ -321,10 +322,6 @@ namespace EQ
 		private:
 			void Attach(uv_loop_t *loop);
 			void Detach();
-
-			// resend
-			Timestamp m_last_resend_check;
-			int m_resend_check_interval = 50;
 
 			EQ::Random m_rand;
 			uv_timer_t m_timer;


### PR DESCRIPTION
### Description

This PR addresses several client network issues reported by players, aiming to significantly improve connection reliability and speed. These changes mitigate common disconnect scenarios, especially during high-stress network events, such as heavy raid traffic or zoning with large inventories.

---

### Player-Perceived Issues

While these improvements greatly enhance connection stability, it’s important to note that extreme cases (e.g., very poor connections) may still face limitations due to factors outside the server's control.

Common issues addressed:
- Players disconnect during heavy network traffic (e.g., raid burns).
- Players experience "random" disconnects while zoning.
- Players with poor connections disconnecting while doing seemingly nothing.
- Players with poor connections disconnecting while trying to enter world with large inventories.

---

### Root Cause Analysis

These issues are deeply rooted in network-layer behavior. When either the server or client connection falls behind, packets are queued for resending. This process introduces several challenges:

#### Resend Storms
A typical scenario involves a player zoning in with a large inventory on a limited bandwidth connection. The server queues a massive number of packets for transmission (e.g., up to **1MB pre-compression**). If the client cannot keep up:
- The server aggressively resends packets every 16ms (~62.5 times per second).
- This can result in a compressed data load of 18.75MB/s, overwhelming the client and causing disconnects.
- Players with large inventories or poor connections are particularly affected, often entering a perpetual resend state that exacerbates disconnect issues.

---

### Solutions

The following changes are implemented to resolve these issues:

1. **Resend Window Optimization**
   - Limit resend attempts to a maximum of **300 packets or 140KB of data per window** (based on observed client processing capabilities).
   - Significantly reduces expensive server memory allocation and network bandwidth usage.

2. **Reduced Resend Frequency**
   - Resend checks are now performed every 50ms instead of 16ms, decreasing the rate of packet resends.

3. **Targeted Resend Checks**
   - Resend attempts now prioritize the first overdue packet, rather than iterating through all queued packets.

4. **Early Exit on Empty Queues**
   - Resend processing halts immediately when no packets remain in the queue, preventing unnecessary overhead.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement

# Testing

Stress testing bags. A client with 36 x 100 slot bags with 100 items each = (3600 items) would take upwards of 30-40 seconds to load if not more if not entirely disconnect originally. With these changes the client loads in about 5-6 seconds.

![image](https://github.com/user-attachments/assets/3bb6fd0f-b67d-4923-b995-116bb244ed73)

https://github.com/user-attachments/assets/42211213-09e2-45d2-b065-dad848819d66

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

