### PR TITLE
[Fix] Update the shard bazaar search feature

### DIFF
--- a/common/bazaar.cpp
+++ b/common/bazaar.cpp
@@ -373,9 +373,12 @@ Bazaar::GetSearchResults(
 
 		LogTradingDetail("Found item [{}] meeting search criteria.", r.item_name);
 		if (RuleB(Bazaar, UseAlternateBazaarSearch)) {
-			if (convert || (r.trader_zone_id == Zones::BAZAAR && r.trader_zone_instance_id != char_zone_instance_id)) {
+			if (convert ||
+				char_zone_id != Zones::BAZAAR ||
+				(char_zone_id == Zones::BAZAAR && r.trader_zone_instance_id != char_zone_instance_id)
+				) {
 				r.trader_id = TraderRepository::TRADER_CONVERT_ID + r.trader_zone_instance_id;
-			}
+				}
 		}
 
 		all_entries.push_back(r);


### PR DESCRIPTION
# Description
Resolve an issue that searches in Shard 1 would not appear when the player was in an open world zone.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
This has been deployed in THJ for several days.  Reports indicate the problem is resolved.

Clients tested: 
RoF2/THJ

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
