### PR TITLE
[Quest API] Add Potion Belt Methods

### DIFF
--- a/zone/client.h
+++ b/zone/client.h
@@ -1832,9 +1832,28 @@ public:
 
 	Raid *p_raid_instance;
 
-	uint32 GetPotionBeltItemIcon(uint8 slot_id);
-	uint32 GetPotionBeltItemID(uint8 slot_id);
-	std::string GetPotionBeltItemName(uint8 slot_id);
+	inline uint32 GetPotionBeltItemIcon(uint8 slot_id)
+	{
+		return EQ::ValueWithin(
+			slot_id,
+			0,
+			EQ::profile::POTION_BELT_SIZE
+		) ? m_pp.potionbelt.Items[slot_id].Icon : 0;
+	};
+
+	inline uint32 GetPotionBeltItemID(uint8 slot_id)
+	{
+		return EQ::ValueWithin(slot_id, 0, EQ::profile::POTION_BELT_SIZE) ? m_pp.potionbelt.Items[slot_id].ID : 0;
+	};
+	
+	inline std::string GetPotionBeltItemName(uint8 slot_id)
+	{
+		return EQ::ValueWithin(
+			slot_id,
+			0,
+			EQ::profile::POTION_BELT_SIZE
+		) ? m_pp.potionbelt.Items[slot_id].Name : 0;
+	};
 
 	void ShowDevToolsMenu();
 	CheatManager cheat_manager;

--- a/zone/client.h
+++ b/zone/client.h
@@ -1834,7 +1834,7 @@ public:
 
 	inline uint32 GetPotionBeltItemIcon(uint8 slot_id) { return EQ::ValueWithin(slot_id, 0, EQ::profile::POTION_BELT_SIZE) ? m_pp.potionbelt.Items[slot_id].Icon : 0; };
 	inline uint32 GetPotionBeltItemID(uint8 slot_id) { return EQ::ValueWithin(slot_id, 0, EQ::profile::POTION_BELT_SIZE) ? m_pp.potionbelt.Items[slot_id].ID : 0; };
-	inline std::string GetPotionBeltItemName(uint8 slot_id) { return EQ::ValueWithin(slot_id, 0, EQ::profile::POTION_BELT_SIZE) ? m_pp.potionbelt.Items[slot_id].Name : 0; };
+	inline std::string GetPotionBeltItemName(uint8 slot_id) { return EQ::ValueWithin(slot_id, 0, EQ::profile::POTION_BELT_SIZE) ? m_pp.potionbelt.Items[slot_id].Name : std::string(); };
 
 	void ShowDevToolsMenu();
 	CheatManager cheat_manager;

--- a/zone/client.h
+++ b/zone/client.h
@@ -1832,9 +1832,9 @@ public:
 
 	Raid *p_raid_instance;
 
-	inline uint32 GetPotionBeltItemIcon(uint8 slot_id) { return EQ::ValueWithin(slot_id, 0, EQ::profile::POTION_BELT_SIZE) ? m_pp.potionbelt.Items[slot_id].Icon : 0; };
-	inline uint32 GetPotionBeltItemID(uint8 slot_id) { return EQ::ValueWithin(slot_id, 0, EQ::profile::POTION_BELT_SIZE) ? m_pp.potionbelt.Items[slot_id].ID : 0; };
-	inline std::string GetPotionBeltItemName(uint8 slot_id) { return EQ::ValueWithin(slot_id, 0, EQ::profile::POTION_BELT_SIZE) ? m_pp.potionbelt.Items[slot_id].Name : std::string(); };
+	uint32 GetPotionBeltItemIcon(uint8 slot_id);
+	uint32 GetPotionBeltItemID(uint8 slot_id);
+	std::string GetPotionBeltItemName(uint8 slot_id);
 
 	void ShowDevToolsMenu();
 	CheatManager cheat_manager;

--- a/zone/client.h
+++ b/zone/client.h
@@ -1832,6 +1832,10 @@ public:
 
 	Raid *p_raid_instance;
 
+	inline uint32 GetPotionBeltItemIcon(uint8 slot_id) { return EQ::ValueWithin(slot_id, 0, EQ::profile::POTION_BELT_SIZE) ? m_pp.potionbelt.Items[slot_id].Icon : 0; };
+	inline uint32 GetPotionBeltItemID(uint8 slot_id) { return EQ::ValueWithin(slot_id, 0, EQ::profile::POTION_BELT_SIZE) ? m_pp.potionbelt.Items[slot_id].ID : 0; };
+	inline std::string GetPotionBeltItemName(uint8 slot_id) { return EQ::ValueWithin(slot_id, 0, EQ::profile::POTION_BELT_SIZE) ? m_pp.potionbelt.Items[slot_id].Name : 0; };
+
 	void ShowDevToolsMenu();
 	CheatManager cheat_manager;
 

--- a/zone/client.h
+++ b/zone/client.h
@@ -1837,13 +1837,13 @@ public:
 		return EQ::ValueWithin(
 			slot_id,
 			0,
-			EQ::profile::POTION_BELT_SIZE
+			EQ::profile::POTION_BELT_SIZE - 1
 		) ? m_pp.potionbelt.Items[slot_id].Icon : 0;
 	};
 
 	inline uint32 GetPotionBeltItemID(uint8 slot_id)
 	{
-		return EQ::ValueWithin(slot_id, 0, EQ::profile::POTION_BELT_SIZE) ? m_pp.potionbelt.Items[slot_id].ID : 0;
+		return EQ::ValueWithin(slot_id, 0, EQ::profile::POTION_BELT_SIZE - 1) ? m_pp.potionbelt.Items[slot_id].ID : 0;
 	};
 	
 	inline std::string GetPotionBeltItemName(uint8 slot_id)
@@ -1851,7 +1851,7 @@ public:
 		return EQ::ValueWithin(
 			slot_id,
 			0,
-			EQ::profile::POTION_BELT_SIZE
+			EQ::profile::POTION_BELT_SIZE - 1
 		) ? m_pp.potionbelt.Items[slot_id].Name : 0;
 	};
 

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3530,6 +3530,24 @@ std::string Lua_Client::GetBandolierItemName(uint8 bandolier_slot, uint8 slot_id
 	return self->GetBandolierItemName(bandolier_slot, slot_id);
 }
 
+uint32 Lua_Client::GetPotionBeltItemIcon(uint8 slot_id)
+{
+	Lua_Safe_Call_Int();
+	return self->GetPotionBeltItemIcon(slot_id);
+}
+
+uint32 Lua_Client::GetPotionBeltItemID(uint8 slot_id)
+{
+	Lua_Safe_Call_Int();
+	return self->GetPotionBeltItemID(slot_id);
+}
+
+std::string Lua_Client::GetPotionBeltItemName(uint8 slot_id)
+{
+	Lua_Safe_Call_String();
+	return self->GetPotionBeltItemName(slot_id);
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 	.def(luabind::constructor<>())
@@ -3776,6 +3794,9 @@ luabind::scope lua_register_client() {
 	.def("GetNextAvailableDisciplineSlot", (int(Lua_Client::*)(void))&Lua_Client::GetNextAvailableDisciplineSlot)
 	.def("GetNextAvailableSpellBookSlot", (int(Lua_Client::*)(int))&Lua_Client::GetNextAvailableSpellBookSlot)
 	.def("GetNextAvailableSpellBookSlot", (int(Lua_Client::*)(void))&Lua_Client::GetNextAvailableSpellBookSlot)
+	.def("GetPotionBeltItemIcon", (uint32(Lua_Client::*)(uint8))&Lua_Client::GetPotionBeltItemIcon)
+	.def("GetPotionBeltItemID", (uint32(Lua_Client::*)(uint8))&Lua_Client::GetPotionBeltItemID)
+	.def("GetPotionBeltItemName", (std::string(Lua_Client::*)(uint8))&Lua_Client::GetPotionBeltItemName)
 	.def("GetPVP", (bool(Lua_Client::*)(void))&Lua_Client::GetPVP)
 	.def("GetPVPPoints", (uint32(Lua_Client::*)(void))&Lua_Client::GetPVPPoints)
 	.def("GetRaceBitmask", (uint16(Lua_Client::*)(void))&Lua_Client::GetRaceBitmask)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -515,6 +515,9 @@ public:
 	uint32 GetBandolierItemIcon(uint8 bandolier_slot, uint8 slot_id);
 	uint32 GetBandolierItemID(uint8 bandolier_slot, uint8 slot_id);
 	std::string GetBandolierItemName(uint8 bandolier_slot, uint8 slot_id);
+	uint32 GetPotionBeltItemIcon(uint8 slot_id);
+	uint32 GetPotionBeltItemID(uint8 slot_id);
+	std::string GetPotionBeltItemName(uint8 slot_id);
 
 	// account data buckets
 	void SetAccountBucket(std::string bucket_name, std::string bucket_value);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -3289,6 +3289,21 @@ std::string Perl_Client_GetBandolierItemName(Client* self, uint8 bandolier_slot,
 	return self->GetBandolierItemName(bandolier_slot, slot_id);
 }
 
+uint32 Perl_Client_GetPotionBeltItemIcon(Client* self, uint8 slot_id)
+{
+	return self->GetPotionBeltItemIcon(slot_id);
+}
+
+uint32 Perl_Client_GetPotionBeltItemID(Client* self, uint8 slot_id)
+{
+	return self->GetPotionBeltItemID(slot_id);
+}
+
+std::string Perl_Client_GetPotionBeltItemName(Client* self, uint8 slot_id)
+{
+	return self->GetPotionBeltItemName(slot_id);
+}
+
 void perl_register_client()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3534,6 +3549,9 @@ void perl_register_client()
 	package.add("GetMemmedSpells", &Perl_Client_GetMemmedSpells);
 	package.add("GetModCharacterFactionLevel", &Perl_Client_GetModCharacterFactionLevel);
 	package.add("GetMoney", &Perl_Client_GetMoney);
+	package.add("GetPotionBeltItemIcon", &Perl_Client_GetPotionBeltItemIcon);
+	package.add("GetPotionBeltItemID", &Perl_Client_GetPotionBeltItemID);
+	package.add("GetPotionBeltItemName", &Perl_Client_GetPotionBeltItemName);
 	package.add("GetPVP", &Perl_Client_GetPVP);
 	package.add("GetPVPPoints", &Perl_Client_GetPVPPoints);
 	package.add("GetRaceAbbreviation", &Perl_Client_GetRaceAbbreviation);


### PR DESCRIPTION
# Description
- Adds Potion Belt methods to Perl and Lua.

## Type of change
- [X] New feature

# Perl
- Add `$client->GetPotionBeltItemIcon(slot_id)`
- Add `$client->GetPotionBeltItemID(slot_id)`
- Add `$client->GetPotionBeltItemName(slot_id)`

## Testing
![image](https://github.com/user-attachments/assets/a16e239e-6768-44ba-9fb3-c0faeb26e46c)
## Example
```pl
sub EVENT_SAY {
	if ($text=~/#a/i) {
		for (my $slot_id = 0; $slot_id < 5; $slot_id++) {
			my $item_icon = $client->GetPotionBeltItemIcon($slot_id);
			my $item_id = $client->GetPotionBeltItemID($slot_id);
			my $item_name = $client->GetPotionBeltItemName($slot_id);
			quest::message(315, "[Perl] Slot: $slot_id Icon: $item_icon ID: $item_id Name: $item_name");
		}
	}
}
```

# Lua
- Add `client:GetPotionBeltItemIcon(slot_id)`
- Add `client:GetPotionBeltItemID(slot_id)`
- Add `client:GetPotionBeltItemName(slot_id)`

## Testing
![image](https://github.com/user-attachments/assets/5a4527b8-da4f-43fb-8edf-353887fbd961)
## Example
```lua
function event_say(e)
	if e.message:findi("#a") then
		for slot_id = 0, 4 do
			local item_icon = e.self:GetPotionBeltItemIcon(slot_id)
			local item_id = e.self:GetPotionBeltItemID(slot_id)
			local item_name = e.self:GetPotionBeltItemName(slot_id)

			eq.message(315, string.format("[Lua] Slot: %d Icon: %d ID: %d Name: %s", slot_id, item_icon, item_id, item_name))
		end
	end
end
```

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur