### PR TITLE
[Crash] Fix zone crash caused by NPC::MoveTo

### DIFF
--- a/zone/waypoints.cpp
+++ b/zone/waypoints.cpp
@@ -206,6 +206,9 @@ void NPC::PauseWandering(int pausetime)
 
 void NPC::MoveTo(const glm::vec4 &position, bool saveguardspot)
 {    // makes mob walk to specified location
+	if (!AI_walking_timer) {
+		return;
+	}
 	if (IsNPC() && GetGrid() != 0) {    // he is on a grid
 		if (GetGrid() < 0) {    // currently stopped by a quest command
 			SetGrid(0 - GetGrid());    // get him moving again


### PR DESCRIPTION
# Description

Scripts owned by another mob can call `MoveTo` after a mob has died, but before it has been removed from entity list, causing a npc when the NPC's walk timer is dereferenced. 

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

I have not been able to reproduce this race condition on demand in local testing, it has occurred sporadically with a very high population server (THJ).

Clients tested: 

# Checklist

- [ ] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur

