### PR TITLE
[Inventory] Fix cursor bag saving to invalid slot_ids

### DIFF
--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -222,6 +222,10 @@ bool SharedDatabase::SaveCursor(
 		if (!SaveInventory(char_id, inst, use_slot)) {
 			return false;
 		}
+
+		if (i == EQ::invslot::slotCursor) {
+			i = EQ::invbag::CURSOR_BAG_BEGIN;
+		}
 	}
 
 	return true;


### PR DESCRIPTION
# Description
### Before change resulted in errors:
![Before table](https://github.com/user-attachments/assets/756c0716-aa30-4129-9a18-14b4b71ba87f)
```
[Zone] [Error] [inventory_profile.cpp::_PutItem:1466] Invalid slot_id specified (34) with parent slot id (-1)
[Zone] [Error] [shareddb.cpp::GetInventory:878] Warning: Invalid slot_id for item in inventory for character_id [1] item_id [13078] slot_id [34]
[Zone] [Error] [inventory_profile.cpp::_PutItem:1466] Invalid slot_id specified (35) with parent slot id (-1)
[Zone] [Error] [shareddb.cpp::GetInventory:878] Warning: Invalid slot_id for item in inventory for character_id [1] item_id [13078] slot_id [35]
[Zone] [Error] [inventory_profile.cpp::_PutItem:1466] Invalid slot_id specified (36) with parent slot id (-1)
[Zone] [Error] [shareddb.cpp::GetInventory:878] Warning: Invalid slot_id for item in inventory for character_id [1] item_id [13078] slot_id [36]
[Zone] [Error] [inventory_profile.cpp::_PutItem:1466] Invalid slot_id specified (37) with parent slot id (-1)
[Zone] [Error] [shareddb.cpp::GetInventory:878] Warning: Invalid slot_id for item in inventory for character_id [1] item_id [13078] slot_id [37]
[Zone] [Error] [inventory_profile.cpp::_PutItem:1466] Invalid slot_id specified (38) with parent slot id (-1)
[Zone] [Error] [shareddb.cpp::GetInventory:878] Warning: Invalid slot_id for item in inventory for character_id [1] item_id [13078] slot_id [38]
[Zone] [Error] [inventory_profile.cpp::_PutItem:1466] Invalid slot_id specified (39) with parent slot id (-1)
[Zone] [Error] [shareddb.cpp::GetInventory:878] Warning: Invalid slot_id for item in inventory for character_id [1] item_id [13078] slot_id [39]
[Zone] [Error] [inventory_profile.cpp::_PutItem:1466] Invalid slot_id specified (40) with parent slot id (-1)
[Zone] [Error] [shareddb.cpp::GetInventory:878] Warning: Invalid slot_id for item in inventory for character_id [1] item_id [13078] slot_id [40]
[Zone] [Error] [inventory_profile.cpp::_PutItem:1466] Invalid slot_id specified (41) with parent slot id (-1)
[Zone] [Error] [shareddb.cpp::GetInventory:878] Warning: Invalid slot_id for item in inventory for character_id [1] item_id [13078] slot_id [41]
[Zone] [Error] [inventory_profile.cpp::_PutItem:1466] Invalid slot_id specified (42) with parent slot id (-1)
[Zone] [Error] [shareddb.cpp::GetInventory:878] Warning: Invalid slot_id for item in inventory for character_id [1] item_id [13078] slot_id [42]
[Zone] [Error] [inventory_profile.cpp::_PutItem:1466] Invalid slot_id specified (43) with parent slot id (-1)
[Zone] [Error] [shareddb.cpp::GetInventory:878] Warning: Invalid slot_id for item in inventory for character_id [1] item_id [13078] slot_id [43]
[Zone] [Error] [inventory_profile.cpp::_PutItem:1466] Invalid slot_id specified (44) with parent slot id (-1)
[Zone] [Error] [shareddb.cpp::GetInventory:878] Warning: Invalid slot_id for item in inventory for character_id [1] item_id [13078] slot_id [44]
[Zone] [Error] [inventory_profile.cpp::_PutItem:1466] Invalid slot_id specified (45) with parent slot id (-1)
[Zone] [Error] [shareddb.cpp::GetInventory:878] Warning: Invalid slot_id for item in inventory for character_id [1] item_id [13078] slot_id [45]
[Zone] [Error] [inventory_profile.cpp::_PutItem:1466] Invalid slot_id specified (46) with parent slot id (-1)
[Zone] [Error] [shareddb.cpp::GetInventory:878] Warning: Invalid slot_id for item in inventory for character_id [1] item_id [13078] slot_id [46]
[Zone] [Error] [inventory_profile.cpp::_PutItem:1466] Invalid slot_id specified (47) with parent slot id (-1)
[Zone] [Error] [shareddb.cpp::GetInventory:878] Warning: Invalid slot_id for item in inventory for character_id [1] item_id [13078] slot_id [47]
[Zone] [Error] [inventory_profile.cpp::_PutItem:1466] Invalid slot_id specified (48) with parent slot id (-1)
[Zone] [Error] [shareddb.cpp::GetInventory:878] Warning: Invalid slot_id for item in inventory for character_id [1] item_id [13078] slot_id [48]
[Zone] [Error] [inventory_profile.cpp::_PutItem:1466] Invalid slot_id specified (49) with parent slot id (-1)
[Zone] [Error] [shareddb.cpp::GetInventory:878] Warning: Invalid slot_id for item in inventory for character_id [1] item_id [13078] slot_id [49]
[Zone] [Error] [inventory_profile.cpp::_PutItem:1466] Invalid slot_id specified (50) with parent slot id (-1)
[Zone] [Error] [shareddb.cpp::GetInventory:878] Warning: Invalid slot_id for item in inventory for character_id [1] item_id [13078] slot_id [50]
[Zone] [Error] [inventory_profile.cpp::_PutItem:1466] Invalid slot_id specified (51) with parent slot id (-1)
[Zone] [Error] [shareddb.cpp::GetInventory:878] Warning: Invalid slot_id for item in inventory for character_id [1] item_id [13078] slot_id [51]
[Zone] [Error] [inventory_profile.cpp::_PutItem:1466] Invalid slot_id specified (52) with parent slot id (-1)
[Zone] [Error] [shareddb.cpp::GetInventory:878] Warning: Invalid slot_id for item in inventory for character_id [1] item_id [13078] slot_id [52]
```

### After change:
**No errors.**
![After table](https://github.com/user-attachments/assets/c0b58d49-7ee7-4972-991f-1066de1641ec)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# Testing

https://github.com/EQEmu/Server/blob/49917bfb1348391983f8c5e91a77e1dffd2726d6/common/shareddb.cpp#L856

Summoning 20 and (accidentally) 19 stacks of Summoned Bread (Spell #55) before and after change.

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
