### PR TITLE
[Feature] Add rule to allow /changepetname to function without being enabled by scripts.

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -287,6 +287,7 @@ RULE_BOOL(Pets, LivelikeBreakCharmOnInvis, true, "Default: true will break charm
 RULE_BOOL(Pets, ClientPetsUseOwnerNameInLastName, true, "Disable this to keep client pet's last names from being owner_name's pet")
 RULE_BOOL(Pets, CanTakeNoDrop, false, "Setting whether anyone can give no-drop items to pets")
 RULE_INT(Pets, PetTauntRange, 150, "Range at which a pet will taunt targets.")
+RULE_BOOL(Pets, AlwaysAllowPetRename, false, "Enable this option to allow /changepetname to work without enabling a pet name change via scripts.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(GM)

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -4705,6 +4705,10 @@ void Client::KeyRingList()
 }
 
 bool Client::IsPetNameChangeAllowed() {
+	if (RuleB(Pets, AlwaysAllowPetRename)) {
+		return true;
+	}
+
 	DataBucketKey k = GetScopedBucketKeys();
 	k.key = "PetNameChangesAllowed";
 
@@ -13277,7 +13281,7 @@ std::string Client::SendBotCommandHelpWindow(const BotCommandHelpParams& params)
 	const std::string& header_color = "indian_red";
 	const std::string& description_color = "light_grey";
 	const std::string& description_color_secondary = "dark_orange";
-	const std::string& example_color = "goldenrod";	
+	const std::string& example_color = "goldenrod";
 	const std::string& example_color_secondary = "slate_blue";
 	const std::string& option_color = "light_grey";
 	const std::string& option_color_secondary = "slate_blue";
@@ -13383,7 +13387,7 @@ std::string Client::SplitCommandHelpText(std::vector<std::string> msg, std::stri
 
 							break;
 					}
-					
+
 					if (y == x) {
 						msg_split.emplace_back(msg[i].substr(x, max_length));
 

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -821,7 +821,7 @@ void Client::CompleteConnect()
 			)
 		);
 
-		if (IsPetNameChangeAllowed()) {
+		if (IsPetNameChangeAllowed() && !RuleB(Pets, AlwaysAllowPetRename)) {
 			InvokeChangePetName(false);
 		}
 	}


### PR DESCRIPTION
# Description

Adds `Pets:AlwaysAllowPetRename`. This does what it says on the tin. Not sure how many times to restate the title.

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Enabled the rule and noticed that /changepetname works. Nag box is *not* invoked on login.

Clients tested: 

Only works on ROF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
