### PR TITLE
[Bots] Fix crash related to GetTempSpellType()

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -106,6 +106,7 @@ Bot::Bot(NPCType *npcTypeData, Client* botOwner) : NPC(npcTypeData, nullptr, glm
 
 	LoadDefaultBotSettings();
 	SetCastedSpellType(UINT16_MAX);
+	SetTempSpellType(UINT16_MAX);
 	SetCommandedSpell(false);
 	SetPullingSpell(false);
 
@@ -189,6 +190,7 @@ Bot::Bot(
 	SetSpawnStatus(false);
 	SetBotCharmer(false);
 	SetCastedSpellType(UINT16_MAX);
+	SetTempSpellType(UINT16_MAX);
 	SetCommandedSpell(false);
 	SetPullingSpell(false);
 
@@ -3669,10 +3671,6 @@ bool Bot::Spawn(Client* botCharacterOwner) {
 			}
 		}
 
-		if (IsBotRanged()) {
-			ChangeBotRangedWeapons(true);
-		}
-
 		if (auto raid = entity_list.GetRaidByBotName(GetName())) {
 			// Safety Check to confirm we have a valid raid
 			auto owner = GetBotOwner();
@@ -3704,6 +3702,10 @@ bool Bot::Spawn(Client* botCharacterOwner) {
 		if (RuleB(Bots, RunSpellTypeChecksOnSpawn)) {
 			OwnerMessage("Running SpellType checks. There may be some spells that are mislabeled as incorrect. Use this as a loose guideline.");
 			CheckBotSpells(); //This runs through a serious of checks and outputs any spells that are set to the wrong spell type in the database
+		}
+
+		if (IsBotRanged()) {
+			ChangeBotRangedWeapons(true);
 		}
 
 		return true;

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -1218,7 +1218,7 @@ private:
 	std::vector<Mob*> _group_spell_target_list;
 	Raid* _storedRaid;
 	bool _verifiedRaid;
-	uint16 _tempSpellType;
+	uint16 _tempSpellType; // this is used to check the spell type being cast against ^spellannouncecasts status
 
 	// Private "base stats" Members
 	int32 _baseMR;


### PR DESCRIPTION
# Description

_tempSpellType was not getting defined during bot spawn process which could lead to a potential crash in RaidGroupSay.

Auto archery toggle was what triggered the crash as it announces their status on spawn.

Also moved this toggle for Rangers further down the proccess line.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Macrod repeated logins and camps, would crash at random with ^bottoggleranged on.
No crash after 35 cycles with ^bottoggleranged off.

After over 75 cycles with ^bottoggleranged on, no crashes.

```
[Wed Feb 05 23:29:14 2025] Outrider saved.
[Wed Feb 05 23:29:14 2025] Outrider says 'My blades are sheathed'
[Wed Feb 05 23:29:14 2025] Outriderr saved.
[Wed Feb 05 23:29:14 2025] [Crash] [windows_exception_handler] EXCEPTION_ACCESS_VIOLATION
```

https://github.com/EQEmu/Server/blob/5cebc42f89ff358adad6d5c9eed38dffee685c51/zone/bot.cpp#L3672-L3674

https://github.com/EQEmu/Server/blob/5cebc42f89ff358adad6d5c9eed38dffee685c51/zone/bot.cpp#L7908

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur