### PR TITLE
[Bots] Fix a couple potential crashes with GetNumberNeedingHealedInGroup

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -7687,15 +7687,15 @@ void EntityList::ShowSpawnWindow(Client* client, int Distance, bool NamedOnly) {
 }
 
 uint8 Bot::GetNumberNeedingHealedInGroup(Mob* tar, uint16 spell_type, uint16 spell_id, float range) {
-	if (!tar->IsBot()) {
+	if (!tar) {
 		return 0;
 	}
 
 	uint8 count = 0;
-	auto target_list = tar->IsClient() ? tar->CastToBot()->GatherSpellTargets() : tar->CastToBot()->GetSpellTargetList();
+	auto target_list = tar->IsClient() ? GatherSpellTargets(false, tar) : tar->CastToBot()->GetSpellTargetList();
 
 	for (Mob* m : target_list) {
-		if (tar->CalculateDistance(m) < range && CastChecks(spell_id, m, spell_type, true, IsGroupBotSpellType(spell_type))) {
+		if (m && tar->CalculateDistance(m) < range && CastChecks(spell_id, m, spell_type, true, IsGroupBotSpellType(spell_type))) {
 			++count;
 		}
 	}
@@ -11175,11 +11175,14 @@ bool Bot::GetUltimateSpellTypeHold(uint16 spell_type, Mob* tar) {
 		return GetSpellTypeHold(spell_type);
 	}
 
-	if (tar->IsPet() && tar->GetOwner() && tar->IsPetOwnerBot()) {
-		return tar->GetOwner()->CastToBot()->GetSpellTypeHold(GetPetBotSpellType(spell_type));
-	}
+	Mob* owner = tar->IsPet() ? tar->GetOwner() : nullptr;
+	Bot* bot_owner = (owner && owner->IsBot())
+		? owner->CastToBot()
+		: nullptr;
 
-	return GetSpellTypeHold(spell_type);
+	return bot_owner
+		? bot_owner->GetSpellTypeHold(GetPetBotSpellType(spell_type))
+		: GetSpellTypeHold(spell_type);
 }
 
 void Bot::SetSpellTypePriority(uint16 spell_type, uint8 priority_type, uint16 priority) {

--- a/zone/botspellsai.cpp
+++ b/zone/botspellsai.cpp
@@ -1305,7 +1305,7 @@ BotSpell Bot::GetBestBotSpellForGroupHeal(Bot* caster, Mob* tar, uint16 spell_ty
 
 		for (std::list<BotSpell>::iterator bot_spell_list_itr = bot_spell_list.begin(); bot_spell_list_itr != bot_spell_list.end(); ++bot_spell_list_itr) {
 			// Assuming all the spells have been loaded into this list by level and in descending order
-			if (IsGroupHealOverTimeSpell(bot_spell_list_itr->SpellId)) {
+			if (IsRegularGroupHealSpell(bot_spell_list_itr->SpellId)) {
 				uint16 spell_id = bot_spell_list_itr->SpellId;
 
 				if (!caster->IsCommandedSpell() && caster->IsValidSpellRange(spell_id, tar)) {
@@ -1379,7 +1379,7 @@ BotSpell Bot::GetBestBotSpellForGroupCompleteHeal(Bot* caster, Mob* tar, uint16 
 
 		for (std::list<BotSpell>::iterator bot_spell_list_itr = bot_spell_list.begin(); bot_spell_list_itr != bot_spell_list.end(); ++bot_spell_list_itr) {
 			// Assuming all the spells have been loaded into this list by level and in descending order
-			if (IsGroupHealOverTimeSpell(bot_spell_list_itr->SpellId)) {
+			if (IsGroupCompleteHealSpell(bot_spell_list_itr->SpellId)) {
 				uint16 spell_id = bot_spell_list_itr->SpellId;
 
 				if (!caster->IsCommandedSpell() && caster->IsValidSpellRange(spell_id, tar)) {


### PR DESCRIPTION
# Description

- There was some potential for pointers to be lost during these checks that would result in a crash.
- If a bot or player death happened during these group heal checks there was a chance of a crash.

- Also corrects the grabbing of spells for Group Heals and Group Complete Heals.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

- Tested many scenarios with killing bots and players throughout the heal process and checks catch any death that resulted in - crashes prior.

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
