### PR TITLE
[Bots] Add IsInRaidOrGroup checks to ^attack and ^pull

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -12380,6 +12380,23 @@ bool Bot::BotPassiveCheck() {
 	return false;
 }
 
+bool Bot::ValidStateCheck(Mob* other, bool same_raid_group) {
+	if (
+		GetBotStance() == Stance::Passive ||
+		GetHoldFlag() ||
+		GetAppearance() == eaDead ||
+		IsFeared() ||
+		IsSilenced() ||
+		IsAmnesiad() ||
+		GetHP() < 0 ||
+		!IsInGroupOrRaid(other, same_raid_group)
+	) {
+		return false;
+	}
+
+	return true;
+}
+
 bool Bot::IsValidSpellTypeSubType(uint16 spell_type, uint16 sub_type, uint16 spell_id) {
 	if (sub_type == UINT16_MAX) {
 		return true;

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -526,6 +526,7 @@ public:
 	void DoAttackRounds(Mob* target, int hand);
 
 	bool BotPassiveCheck();
+	bool ValidStateCheck(Mob* other, bool same_raid_group = false);
 	Raid* GetStoredRaid() { return _storedRaid; }
 	void SetStoredRaid(Raid* stored_raid) { _storedRaid = stored_raid; }
 	bool GetVerifiedRaid() { return _verifiedRaid; }

--- a/zone/bot_commands/attack.cpp
+++ b/zone/bot_commands/attack.cpp
@@ -54,34 +54,33 @@ void bot_command_attack(Client *c, const Seperator *sep)
 	Bot *first_attacker = nullptr;
 	sbl.erase(std::remove(sbl.begin(), sbl.end(), nullptr), sbl.end());
 	for (auto bot_iter : sbl) {
-
-		if (bot_iter->GetAppearance() != eaDead && bot_iter->GetBotStance() != Stance::Passive) {
-
-			if (!first_attacker) {
-				first_attacker = bot_iter;
-			}
-			++attacker_count;
-
-			bot_iter->SetAttackFlag();
+		if (!bot_iter->ValidStateCheck(c)) {
+			continue;
 		}
+
+		if (!first_attacker) {
+			first_attacker = bot_iter;
+		}
+
+		++attacker_count;
+
+		bot_iter->SetAttackFlag();
 	}
 
-	if (attacker_count == 1 && first_attacker) {
-		c->Message(
-			Chat::Green,
-			fmt::format(
-				"Attacking {}.",
-				target_mob->GetCleanName()
-			).c_str()
-		);
-	} else {
-		c->Message(
-			Chat::Green,
-			fmt::format(
-				"{} of your bots are attacking {}.",
-				sbl.size(),
-				target_mob->GetCleanName()
-			).c_str()
-		);
+	if (first_attacker) {
+		std::string message;
+
+		if (attacker_count == 1) {
+			message = fmt::format("Attacking {}.", target_mob->GetCleanName());
+		} else {
+			message = fmt::format("{} of your bots are attacking {}.", sbl.size(), target_mob->GetCleanName());
+		}
+
+		c->Message(Chat::Green, message.c_str());
 	}
+	else {
+		c->Message(Chat::Yellow,fmt::format("None of your bots are capable of attacking {}.", target_mob->GetCleanName()).c_str());
+	}
+
+	return;
 }

--- a/zone/bot_commands/cast.cpp
+++ b/zone/bot_commands/cast.cpp
@@ -477,11 +477,7 @@ void bot_command_cast(Client* c, const Seperator* sep)
 	Bot* first_found = nullptr;
 
 	for (auto bot_iter : sbl) {
-		if (!bot_iter->IsInGroupOrRaid(c)) {
-			continue;
-		}
-
-		if (bot_iter->GetBotStance() == Stance::Passive || bot_iter->GetHoldFlag() || bot_iter->GetAppearance() == eaDead || bot_iter->IsFeared() || bot_iter->IsSilenced() || bot_iter->IsAmnesiad() || bot_iter->GetHP() < 0) {
+		if (!bot_iter->ValidStateCheck(c)) {
 			continue;
 		}
 

--- a/zone/bot_commands/depart.cpp
+++ b/zone/bot_commands/depart.cpp
@@ -141,11 +141,7 @@ void bot_command_depart(Client* c, const Seperator* sep)
 	std::map<std::string, std::pair<uint8_t, uint8_t>> list_zones;
 
 	for (auto bot_iter : sbl) {
-		if (!bot_iter->IsInGroupOrRaid(tar, !single)) {
-			continue;
-		}
-
-		if (bot_iter->GetBotStance() == Stance::Passive || bot_iter->GetHoldFlag() || bot_iter->GetAppearance() == eaDead || bot_iter->IsFeared() || bot_iter->IsSilenced() || bot_iter->IsAmnesiad() || bot_iter->GetHP() < 0) {
+		if (!bot_iter->ValidStateCheck(c)) {
 			continue;
 		}
 

--- a/zone/bot_commands/discipline.cpp
+++ b/zone/bot_commands/discipline.cpp
@@ -125,11 +125,7 @@ void bot_command_discipline(Client* c, const Seperator* sep)
 	Bot* first_found = nullptr;
 
 	for (auto bot_iter : sbl) {
-		if (!bot_iter->IsInGroupOrRaid(c)) {
-			continue;
-		}
-
-		if (bot_iter->GetBotStance() == Stance::Passive || bot_iter->GetHoldFlag() || bot_iter->GetAppearance() == eaDead || bot_iter->IsFeared() || bot_iter->IsSilenced() || bot_iter->IsAmnesiad() || bot_iter->GetHP() < 0) {
+		if (!bot_iter->ValidStateCheck(c)) {
 			continue;
 		}
 

--- a/zone/bot_commands/pull.cpp
+++ b/zone/bot_commands/pull.cpp
@@ -63,7 +63,7 @@ void bot_command_pull(Client *c, const Seperator *sep)
 	Bot* bot_puller = nullptr;
 
 	for (auto bot_iter : sbl) {
-		if (bot_iter->GetAppearance() == eaDead || bot_iter->GetBotStance() == Stance::Passive) {
+		if (!bot_iter->ValidStateCheck(c)) {
 			continue;
 		}
 


### PR DESCRIPTION
# Description

- Adds IsInRaidOrGroup checks to these commands to prevent attempts at sending bots that wouldn't actually follow the command anyway as they would be checked further down the bot process anyway.
- This does not change actual functionality, just properly informs the owner and avoids unnecessary checks further down the line.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

- Same functionality. Proper message output if a bot doesn't pass the check instead of generic no bots available error.

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
