### PR TITLE
[Bots] Move BotGetSpellsByType to cache

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -12631,12 +12631,20 @@ void Bot::CleanBotBlockedBuffs()
 	}
 }
 
-std::vector<BotSpells_wIndex> Bot::BotGetSpellsByType(uint16 spell_type) {
-	if (AIBot_spells_by_type[spell_type].empty()) {
-		spell_type = GetParentSpellType(spell_type);
+const std::vector<BotSpells_wIndex>& Bot::BotGetSpellsByType(uint16 spell_type) const {
+	auto it = AIBot_spells_by_type.find(spell_type);
+
+	if (it == AIBot_spells_by_type.end() || it->second.empty()) {
+		it = AIBot_spells_by_type.find(GetParentSpellType(spell_type));
+
+		if (it == AIBot_spells_by_type.end()) {
+			static const std::vector<BotSpells_wIndex> empty;
+
+			return empty;
+		}
 	}
 
-	return AIBot_spells_by_type[spell_type];
+	return it->second;
 }
 
 void Bot::AssignBotSpellsToTypes(std::vector<BotSpells>& AIBot_spells, std::unordered_map<uint16, std::vector<BotSpells_wIndex>>& AIBot_spells_by_type) {

--- a/zone/bot.h
+++ b/zone/bot.h
@@ -305,7 +305,7 @@ public:
 	uint16 BotGetSpells(int spellslot) { return AIBot_spells[spellslot].spellid; }
 	uint32 BotGetSpellType(int spellslot) { return AIBot_spells[spellslot].type; }
 	uint16 BotGetSpellPriority(int spellslot) { return AIBot_spells[spellslot].priority; }
-	std::vector<BotSpells_wIndex> BotGetSpellsByType(uint16 spell_type);
+	const std::vector<BotSpells_wIndex>& BotGetSpellsByType(uint16 spell_type) const;
 	float GetProcChances(float ProcBonus, uint16 hand) override;
 	int GetHandToHandDamage(void) override;
 	bool TryFinishingBlow(Mob *defender, int64 &damage) override;
@@ -669,7 +669,7 @@ public:
 	void MapSpellTypeLevels();
 	const std::map<int32_t, std::map<int32_t, BotSpellTypesByClass>>& GetCommandedSpellTypesMinLevels() { return commanded_spells_min_level; }
 	std::list<BotSpellTypeOrder> GetSpellTypesPrioritized(uint8 priority_type);
-	uint16 GetParentSpellType(uint16 spell_type);
+	static uint16 GetParentSpellType(uint16 spell_type);
 	bool IsValidSpellTypeBySpellID(uint16 spell_type, uint16 spell_id);
 	inline uint16 GetCastedSpellType() const { return _castedSpellType; }
 	void SetCastedSpellType(uint16 spell_type);

--- a/zone/bot_commands/discipline.cpp
+++ b/zone/bot_commands/discipline.cpp
@@ -134,14 +134,7 @@ void bot_command_discipline(Client* c, const Seperator* sep)
 		}
 
 		if (spell_id == UINT16_MAX) { // Aggressive/Defensive type
-			std::vector<BotSpells_wIndex> bot_spell_list;
-
-			if (aggressive) {
-				bot_spell_list = bot_iter->BotGetSpellsByType(BotSpellTypes::DiscAggressive);
-			}
-			else if (defensive) {
-				bot_spell_list = bot_iter->BotGetSpellsByType(BotSpellTypes::DiscDefensive);
-			}
+			const std::vector<BotSpells_wIndex>& bot_spell_list = bot_iter->BotGetSpellsByType(aggressive ? BotSpellTypes::DiscAggressive : BotSpellTypes::DiscDefensive);
 
 			for (int i = bot_spell_list.size() - 1; i >= 0; i--) {
 				if (!IsValidSpell(bot_spell_list[i].spellid)) {

--- a/zone/botspellsai.cpp
+++ b/zone/botspellsai.cpp
@@ -912,7 +912,7 @@ std::list<BotSpell> Bot::GetBotSpellsForSpellEffect(Bot* caster, uint16 spell_ty
 	}
 
 	if (caster->AI_HasSpells()) {
-		std::vector<BotSpells_wIndex> bot_spell_list = caster->BotGetSpellsByType(spell_type);
+		const std::vector<BotSpells_wIndex>& bot_spell_list = caster->BotGetSpellsByType(spell_type);
 
 		for (int i = bot_spell_list.size() - 1; i >= 0; i--) {
 			if (!IsValidSpellAndLoS(bot_spell_list[i].spellid, caster->HasLoS())) {
@@ -921,7 +921,7 @@ std::list<BotSpell> Bot::GetBotSpellsForSpellEffect(Bot* caster, uint16 spell_ty
 
 			if (
 				caster->CheckSpellRecastTimer(bot_spell_list[i].spellid) &&
-				(bot_spell_list[i].type == spell_type || bot_spell_list[i].type == caster->GetParentSpellType(spell_type)) &&
+				(bot_spell_list[i].type == spell_type || bot_spell_list[i].type == GetParentSpellType(spell_type)) &&
 				caster->IsValidSpellTypeBySpellID(spell_type, bot_spell_list[i].spellid) &&
 				(IsEffectInSpell(bot_spell_list[i].spellid, spell_effect) || GetSpellTriggerSpellID(bot_spell_list[i].spellid, spell_effect))
 			) {
@@ -950,7 +950,7 @@ std::list<BotSpell> Bot::GetBotSpellsForSpellEffectAndTargetType(Bot* caster, ui
 	}
 
 	if (caster->AI_HasSpells()) {
-		std::vector<BotSpells_wIndex> bot_spell_list = caster->BotGetSpellsByType(spell_type);
+		const std::vector<BotSpells_wIndex>& bot_spell_list = caster->BotGetSpellsByType(spell_type);
 
 		for (int i = bot_spell_list.size() - 1; i >= 0; i--) {
 			if (!IsValidSpellAndLoS(bot_spell_list[i].spellid, caster->HasLoS())) {
@@ -959,7 +959,7 @@ std::list<BotSpell> Bot::GetBotSpellsForSpellEffectAndTargetType(Bot* caster, ui
 
 			if (
 				caster->CheckSpellRecastTimer(bot_spell_list[i].spellid) &&
-				(bot_spell_list[i].type == spell_type || bot_spell_list[i].type == caster->GetParentSpellType(spell_type)) &&
+				(bot_spell_list[i].type == spell_type || bot_spell_list[i].type == GetParentSpellType(spell_type)) &&
 				caster->IsValidSpellTypeBySpellID(spell_type, bot_spell_list[i].spellid) &&
 				(
 					IsEffectInSpell(bot_spell_list[i].spellid, spell_effect) ||
@@ -991,7 +991,7 @@ std::list<BotSpell> Bot::GetBotSpellsBySpellType(Bot* caster, uint16 spell_type)
 	}
 
 	if (caster->AI_HasSpells()) {
-		std::vector<BotSpells_wIndex> bot_spell_list = caster->BotGetSpellsByType(spell_type);
+		const std::vector<BotSpells_wIndex>& bot_spell_list = caster->BotGetSpellsByType(spell_type);
 
 		for (int i = bot_spell_list.size() - 1; i >= 0; i--) {
 			if (!IsValidSpellAndLoS(bot_spell_list[i].spellid, caster->HasLoS())) {
@@ -1000,7 +1000,7 @@ std::list<BotSpell> Bot::GetBotSpellsBySpellType(Bot* caster, uint16 spell_type)
 
 			if (
 				caster->CheckSpellRecastTimer(bot_spell_list[i].spellid) &&
-				(bot_spell_list[i].type == spell_type || bot_spell_list[i].type == caster->GetParentSpellType(spell_type)) &&
+				(bot_spell_list[i].type == spell_type || bot_spell_list[i].type == GetParentSpellType(spell_type)) &&
 				caster->IsValidSpellTypeBySpellID(spell_type, bot_spell_list[i].spellid)
 			) {
 				BotSpell bot_spell;
@@ -1020,7 +1020,7 @@ std::vector<BotSpell_wPriority> Bot::GetPrioritizedBotSpellsBySpellType(Bot* cas
 	std::vector<BotSpell_wPriority> result;
 
 	if (caster && caster->AI_HasSpells()) {
-		std::vector<BotSpells_wIndex> bot_spell_list = caster->BotGetSpellsByType(spell_type);
+		const std::vector<BotSpells_wIndex>& bot_spell_list = caster->BotGetSpellsByType(spell_type);
 
 		for (int i = bot_spell_list.size() - 1; i >= 0; i--) {
 			if (!IsValidSpellAndLoS(bot_spell_list[i].spellid, caster->HasLoS())) {
@@ -1035,7 +1035,7 @@ std::vector<BotSpell_wPriority> Bot::GetPrioritizedBotSpellsBySpellType(Bot* cas
 
 			if (
 				caster->CheckSpellRecastTimer(bot_spell_list[i].spellid) &&
-				(bot_spell_list[i].type == spell_type || bot_spell_list[i].type == caster->GetParentSpellType(spell_type)) &&
+				(bot_spell_list[i].type == spell_type || bot_spell_list[i].type == GetParentSpellType(spell_type)) &&
 				caster->IsValidSpellTypeBySpellID(spell_type, bot_spell_list[i].spellid)
 			) {
 				if (
@@ -1109,7 +1109,7 @@ BotSpell Bot::GetFirstBotSpellBySpellType(Bot* caster, uint16 spell_type) {
 	result.ManaCost = 0;
 
 	if (caster && caster->AI_HasSpells()) {
-		std::vector<BotSpells_wIndex> bot_spell_list = caster->BotGetSpellsByType(spell_type);
+		const std::vector<BotSpells_wIndex>& bot_spell_list = caster->BotGetSpellsByType(spell_type);
 
 		for (int i = bot_spell_list.size() - 1; i >= 0; i--) {
 			if (!IsValidSpellAndLoS(bot_spell_list[i].spellid, caster->HasLoS())) {
@@ -1118,7 +1118,7 @@ BotSpell Bot::GetFirstBotSpellBySpellType(Bot* caster, uint16 spell_type) {
 
 			if (
 				caster->CheckSpellRecastTimer(bot_spell_list[i].spellid) &&
-				(bot_spell_list[i].type == spell_type || bot_spell_list[i].type == caster->GetParentSpellType(spell_type)) &&
+				(bot_spell_list[i].type == spell_type || bot_spell_list[i].type == GetParentSpellType(spell_type)) &&
 				caster->IsValidSpellTypeBySpellID(spell_type, bot_spell_list[i].spellid)
 			) {
 				result.SpellId = bot_spell_list[i].spellid;
@@ -1217,14 +1217,14 @@ BotSpell Bot::GetBestBotSpellForPercentageHeal(Bot* caster, Mob* tar, uint16 spe
 	result.ManaCost = 0;
 
 	if (caster && caster->AI_HasSpells()) {
-		std::vector<BotSpells_wIndex> bot_spell_list = caster->BotGetSpellsByType(spell_type);
+		const std::vector<BotSpells_wIndex>& bot_spell_list = caster->BotGetSpellsByType(spell_type);
 		for (int i = bot_spell_list.size() - 1; i >= 0; i--) {
 			if (!IsValidSpell(bot_spell_list[i].spellid)) {
 				continue;
 			}
 
 			if (
-				(bot_spell_list[i].type == spell_type || bot_spell_list[i].type == caster->GetParentSpellType(spell_type)) &&
+				(bot_spell_list[i].type == spell_type || bot_spell_list[i].type == GetParentSpellType(spell_type)) &&
 				caster->IsValidSpellTypeBySpellID(spell_type, bot_spell_list[i].spellid) &&
 				IsCompleteHealSpell(bot_spell_list[i].spellid) &&
 				caster->CastChecks(bot_spell_list[i].spellid, tar, spell_type)
@@ -1925,7 +1925,7 @@ BotSpell Bot::GetDebuffBotSpell(Bot* caster, Mob *tar, uint16 spell_type) {
 		return result;
 
 	if (caster->AI_HasSpells()) {
-		std::vector<BotSpells_wIndex> bot_spell_list = caster->BotGetSpellsByType(spell_type);
+		const std::vector<BotSpells_wIndex>& bot_spell_list = caster->BotGetSpellsByType(spell_type);
 
 		for (int i = bot_spell_list.size() - 1; i >= 0; i--) {
 			if (!IsValidSpellAndLoS(bot_spell_list[i].spellid, caster->HasLoS())) {
@@ -1971,7 +1971,7 @@ BotSpell Bot::GetBestBotSpellForResistDebuff(Bot* caster, Mob *tar, uint16 spell
 	bool needs_disease_resist_debuff = (tar->GetDR() + level_mod) > 100;
 
 	if (caster->AI_HasSpells()) {
-		std::vector<BotSpells_wIndex> bot_spell_list = caster->BotGetSpellsByType(spell_type);
+		const std::vector<BotSpells_wIndex>& bot_spell_list = caster->BotGetSpellsByType(spell_type);
 
 		for (int i = bot_spell_list.size() - 1; i >= 0; i--) {
 			if (!IsValidSpellAndLoS(bot_spell_list[i].spellid, caster->HasLoS())) {


### PR DESCRIPTION
# Description

- Previously this method had a performance impact by constantly passing and copying the vectors for the lists.
- It is now moved to cache to avoid, debugging performance impact has been virtually removed.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

- Verified grabbing of lists by bots to ensure proper spells and list types are returned.
- Ensured parent and sub types are returned properly when needed.

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
