### PR TITLE
[Bots] Fix helper_send_usage_required_bots to support sub spell types

### DIFF
--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -808,7 +808,16 @@ void helper_send_usage_required_bots(Client *bot_owner, uint16 spell_type)
 
 	for (int i = Class::Warrior; i <= Class::Berserker; ++i) {
 		auto spell_type_itr = spell_map.find(spell_type);
-		auto class_itr = spell_type_itr->second.find(i);
+
+		if (spell_type_itr == spell_map.end() || spell_type_itr->second.empty()) {
+			spell_type_itr = spell_map.find(GetParentSpellType(spell_type));
+
+			if (spell_type_itr == spell_map.end()) {
+				static const std::vector<BotSpells_wIndex> empty;
+
+				return;
+			}
+		}
 		const auto& spell_info = class_itr->second;
 			
 		if (spell_info.min_level < UINT8_MAX) {


### PR DESCRIPTION
# Description

- Adds sub spell type support to the helper that displays what level classes need to be to use said spell type.
- Previously it was only checking the parent list.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

- Verified spell lists and proper returns for classes and levels for parent and sub spell types.

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
