### PR TITLE
[Bug Fix] Fix Tradeskill Queries

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -15661,7 +15661,7 @@ void Client::Handle_OP_TradeSkillRecipeInspect(const EQApplicationPacket* app)
 	auto s = (TradeSkillRecipeInspect_Struct*) app->pBuffer;
 
 	const auto& v = TradeskillRecipeEntriesRepository::GetWhere(
-		database,
+		content_db,
 		fmt::format(
 			"`recipe_id` = {} AND `componentcount` = 0 AND `successcount` > 0 LIMIT 1",
 			s->recipe_id

--- a/zone/gm_commands/find/recipe.cpp
+++ b/zone/gm_commands/find/recipe.cpp
@@ -10,7 +10,7 @@ void FindRecipe(Client *c, const Seperator *sep)
 		const auto recipe_id = static_cast<uint16>(Strings::ToUnsignedInt(sep->arg[2]));
 
 		const auto& l = TradeskillRecipeRepository::GetWhere(
-			database,
+			content_db,
 			fmt::format("id = {}", recipe_id)
 		);
 
@@ -56,7 +56,7 @@ void FindRecipe(Client *c, const Seperator *sep)
 	auto found_count = 0;
 
 	const auto& l = TradeskillRecipeRepository::GetWhere(
-		database,
+		content_db,
 		fmt::format(
 			"LOWER(`name`) LIKE '%%{}%%' ORDER BY `id` ASC",
 			search_criteria

--- a/zone/gm_commands/show/recipe.cpp
+++ b/zone/gm_commands/show/recipe.cpp
@@ -13,12 +13,12 @@ void ShowRecipe(Client *c, const Seperator *sep)
 	const uint16 recipe_id = static_cast<uint16>(Strings::ToUnsignedInt(sep->arg[2]));
 
 	const auto& re = TradeskillRecipeEntriesRepository::GetWhere(
-		database,
+		content_db,
 		fmt::format("recipe_id = {} ORDER BY id ASC", recipe_id)
 	);
 
 	const auto& r = TradeskillRecipeRepository::GetWhere(
-		database,
+		content_db,
 		fmt::format("id = {}", recipe_id)
 	);
 

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -4430,7 +4430,7 @@ int QuestManager::GetRecipeMadeCount(uint32 recipe_id) {
 
 std::string QuestManager::GetRecipeName(uint32 recipe_id) {
 	auto r = TradeskillRecipeRepository::GetWhere(
-		database,
+		content_db,
 		fmt::format("id = {}", recipe_id)
 	);
 


### PR DESCRIPTION
# Description
- These queries were not using `content_db`, causing them to fail on servers that use multi-tenancy.

## Type of change
- [X] Bug fix

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur