### PR TITLE
[Bug Fix] Fix Beastlord Warder Size Modifier

### DIFF
--- a/common/repositories/base/base_pets_beastlord_data_repository.h
+++ b/common/repositories/base/base_pets_beastlord_data_repository.h
@@ -144,7 +144,7 @@ public:
 			e.texture       = row[2] ? static_cast<uint8_t>(strtoul(row[2], nullptr, 10)) : 0;
 			e.helm_texture  = row[3] ? static_cast<uint8_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.gender        = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 2;
-			e.size_modifier = row[5] ? (strtof(row[5], nullptr) > 0.0f ? strtof(row[5], nullptr) : 1.0f) : 1;
+			e.size_modifier = row[5] ? (strtof(row[5], nullptr) > 0.0f ? strtof(row[5], nullptr) : 1) : 1;
 			e.face          = row[6] ? static_cast<uint8_t>(strtoul(row[6], nullptr, 10)) : 0;
 
 			return e;
@@ -288,7 +288,7 @@ public:
 			e.texture       = row[2] ? static_cast<uint8_t>(strtoul(row[2], nullptr, 10)) : 0;
 			e.helm_texture  = row[3] ? static_cast<uint8_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.gender        = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 2;
-			e.size_modifier = row[5] ? (strtof(row[5], nullptr) > 0.0f ? strtof(row[5], nullptr) : 1.0f) : 1;
+			e.size_modifier = row[5] ? (strtof(row[5], nullptr) > 0.0f ? strtof(row[5], nullptr) : 1) : 1;
 			e.face          = row[6] ? static_cast<uint8_t>(strtoul(row[6], nullptr, 10)) : 0;
 
 			all_entries.push_back(e);
@@ -319,7 +319,7 @@ public:
 			e.texture       = row[2] ? static_cast<uint8_t>(strtoul(row[2], nullptr, 10)) : 0;
 			e.helm_texture  = row[3] ? static_cast<uint8_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.gender        = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 2;
-			e.size_modifier = row[5] ? (strtof(row[5], nullptr) > 0.0f ? strtof(row[5], nullptr) : 1.0f) : 1;
+			e.size_modifier = row[5] ? (strtof(row[5], nullptr) > 0.0f ? strtof(row[5], nullptr) : 1) : 1;
 			e.face          = row[6] ? static_cast<uint8_t>(strtoul(row[6], nullptr, 10)) : 0;
 
 			all_entries.push_back(e);

--- a/common/repositories/base/base_pets_beastlord_data_repository.h
+++ b/common/repositories/base/base_pets_beastlord_data_repository.h
@@ -144,6 +144,7 @@ public:
 			e.texture       = row[2] ? static_cast<uint8_t>(strtoul(row[2], nullptr, 10)) : 0;
 			e.helm_texture  = row[3] ? static_cast<uint8_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.gender        = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 2;
+			e.size_modifier = row[5] ? (strtof(row[5], nullptr) > 0.0f ? strtof(row[5], nullptr) : 1.0f) : 1;
 			e.face          = row[6] ? static_cast<uint8_t>(strtoul(row[6], nullptr, 10)) : 0;
 
 			return e;
@@ -287,6 +288,7 @@ public:
 			e.texture       = row[2] ? static_cast<uint8_t>(strtoul(row[2], nullptr, 10)) : 0;
 			e.helm_texture  = row[3] ? static_cast<uint8_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.gender        = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 2;
+			e.size_modifier = row[5] ? (strtof(row[5], nullptr) > 0.0f ? strtof(row[5], nullptr) : 1.0f) : 1;
 			e.face          = row[6] ? static_cast<uint8_t>(strtoul(row[6], nullptr, 10)) : 0;
 
 			all_entries.push_back(e);
@@ -317,6 +319,7 @@ public:
 			e.texture       = row[2] ? static_cast<uint8_t>(strtoul(row[2], nullptr, 10)) : 0;
 			e.helm_texture  = row[3] ? static_cast<uint8_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.gender        = row[4] ? static_cast<uint8_t>(strtoul(row[4], nullptr, 10)) : 2;
+			e.size_modifier = row[5] ? (strtof(row[5], nullptr) > 0.0f ? strtof(row[5], nullptr) : 1.0f) : 1;
 			e.face          = row[6] ? static_cast<uint8_t>(strtoul(row[6], nullptr, 10)) : 0;
 
 			all_entries.push_back(e);

--- a/utils/scripts/generators/repository-generator.pl
+++ b/utils/scripts/generators/repository-generator.pl
@@ -335,6 +335,10 @@ foreach my $table_to_generate (@tables) {
                 $all_entries      .= sprintf("\t\t\te.%-${longest_column_length}s = row[%s] ? static_cast<%s>(strtoul(row[%s], nullptr, 10)) : %s;\n", $column_name_formatted, $index, $struct_data_type, $index, $default_value);
                 $find_one_entries .= sprintf("\t\t\te.%-${longest_column_length}s = row[%s] ? static_cast<%s>(strtoul(row[%s], nullptr, 10)) : %s;\n", $column_name_formatted, $index, $struct_data_type, $index, $default_value);
             }
+			elsif ($data_type =~ /float|decimal/) {
+				$all_entries      .= sprintf("\t\t\te.%-${longest_column_length}s = row[%s] ? (strtof(row[%s], nullptr) > 0.0f ? strtof(row[%s], nullptr) : 1.0f) : %s;\n", $column_name_formatted, $index, $index, $index, $default_value);
+				$find_one_entries .= sprintf("\t\t\te.%-${longest_column_length}s = row[%s] ? (strtof(row[%s], nullptr) > 0.0f ? strtof(row[%s], nullptr) : 1.0f) : %s;\n", $column_name_formatted, $index, $index, $index, $default_value);
+			}
         }
         elsif ($data_type =~ /bigint/) {
             $all_entries      .= sprintf("\t\t\te.%-${longest_column_length}s = row[%s] ? strtoll(row[%s], nullptr, 10) : %s;\n", $column_name_formatted, $index, $index, $default_value);

--- a/utils/scripts/generators/repository-generator.pl
+++ b/utils/scripts/generators/repository-generator.pl
@@ -336,8 +336,8 @@ foreach my $table_to_generate (@tables) {
                 $find_one_entries .= sprintf("\t\t\te.%-${longest_column_length}s = row[%s] ? static_cast<%s>(strtoul(row[%s], nullptr, 10)) : %s;\n", $column_name_formatted, $index, $struct_data_type, $index, $default_value);
             }
 			elsif ($data_type =~ /float|decimal/) {
-				$all_entries      .= sprintf("\t\t\te.%-${longest_column_length}s = row[%s] ? (strtof(row[%s], nullptr) > 0.0f ? strtof(row[%s], nullptr) : 1.0f) : %s;\n", $column_name_formatted, $index, $index, $index, $default_value);
-				$find_one_entries .= sprintf("\t\t\te.%-${longest_column_length}s = row[%s] ? (strtof(row[%s], nullptr) > 0.0f ? strtof(row[%s], nullptr) : 1.0f) : %s;\n", $column_name_formatted, $index, $index, $index, $default_value);
+				$all_entries      .= sprintf("\t\t\te.%-${longest_column_length}s = row[%s] ? (strtof(row[%s], nullptr) > 0.0f ? strtof(row[%s], nullptr) : %s) : %s;\n", $column_name_formatted, $index, $index, $index, $default_value, $default_value);
+				$find_one_entries .= sprintf("\t\t\te.%-${longest_column_length}s = row[%s] ? (strtof(row[%s], nullptr) > 0.0f ? strtof(row[%s], nullptr) : %s) : %s;\n", $column_name_formatted, $index, $index, $index, $default_value, $default_value);
 			}
         }
         elsif ($data_type =~ /bigint/) {

--- a/utils/scripts/generators/repository-generator.pl
+++ b/utils/scripts/generators/repository-generator.pl
@@ -335,10 +335,10 @@ foreach my $table_to_generate (@tables) {
                 $all_entries      .= sprintf("\t\t\te.%-${longest_column_length}s = row[%s] ? static_cast<%s>(strtoul(row[%s], nullptr, 10)) : %s;\n", $column_name_formatted, $index, $struct_data_type, $index, $default_value);
                 $find_one_entries .= sprintf("\t\t\te.%-${longest_column_length}s = row[%s] ? static_cast<%s>(strtoul(row[%s], nullptr, 10)) : %s;\n", $column_name_formatted, $index, $struct_data_type, $index, $default_value);
             }
-			elsif ($data_type =~ /float|decimal/) {
-				$all_entries      .= sprintf("\t\t\te.%-${longest_column_length}s = row[%s] ? (strtof(row[%s], nullptr) > 0.0f ? strtof(row[%s], nullptr) : %s) : %s;\n", $column_name_formatted, $index, $index, $index, $default_value, $default_value);
-				$find_one_entries .= sprintf("\t\t\te.%-${longest_column_length}s = row[%s] ? (strtof(row[%s], nullptr) > 0.0f ? strtof(row[%s], nullptr) : %s) : %s;\n", $column_name_formatted, $index, $index, $index, $default_value, $default_value);
-			}
+            elsif ($data_type =~ /float|decimal/) {
+                $all_entries      .= sprintf("\t\t\te.%-${longest_column_length}s = row[%s] ? (strtof(row[%s], nullptr) > 0.0f ? strtof(row[%s], nullptr) : %s) : %s;\n", $column_name_formatted, $index, $index, $index, $default_value, $default_value);
+                $find_one_entries .= sprintf("\t\t\te.%-${longest_column_length}s = row[%s] ? (strtof(row[%s], nullptr) > 0.0f ? strtof(row[%s], nullptr) : %s) : %s;\n", $column_name_formatted, $index, $index, $index, $default_value, $default_value);
+            }
         }
         elsif ($data_type =~ /bigint/) {
             $all_entries      .= sprintf("\t\t\te.%-${longest_column_length}s = row[%s] ? strtoll(row[%s], nullptr, 10) : %s;\n", $column_name_formatted, $index, $index, $default_value);


### PR DESCRIPTION
# Description
- `repository-generator.pl` was not handling the `unsigned float` data type at all, causing it to default to a value of `0.0f`, this caused the `size_modifier` column of `pets_beastlord_data` to have no function.
- Resolves https://github.com/EQEmu/Server/issues/4664.
## Type of change
- [X] Bug fix

# Testing
## Modifier of 0.5
![image](https://github.com/user-attachments/assets/41e76f7d-3bcf-4f7d-b61b-e85ebbc45800)
## Modifier of 1.0
![image](https://github.com/user-attachments/assets/c43eda32-6283-4a67-9a8d-324e209b6e32)
## Modifier of 2.0
![image](https://github.com/user-attachments/assets/2ffa1b55-729c-4afe-bc65-c231d512223c)

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur