### PR TITLE
[Hotfix] [Spells] Fix ST_GroupNoPets and ST_GroupClientAndPet

### DIFF
--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -822,9 +822,7 @@ bool IsGroupSpell(uint16 spell_id)
 	return (
 		spell.target_type == ST_AEBard ||
 		spell.target_type == ST_Group ||
-		spell.target_type == ST_GroupTeleport ||
-		spell.target_type == ST_GroupNoPets ||
-		spell.target_type == ST_GroupClientAndPet
+		spell.target_type == ST_GroupTeleport
 	);
 }
 


### PR DESCRIPTION
# Description

- This was requiring TGB to be on to cast on others.
- Result of a change made to IsGroupSpell(} check.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

- Validated not working without TGB prior.
- Working with and without after.

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur