### PR TITLE
[Fix] Always spawn zone controller first

### DIFF
--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -859,9 +859,9 @@ void NPC::Depop(bool start_spawn_timer) {
 
 bool NPC::SpawnZoneController()
 {
-
-	if (!RuleB(Zone, UseZoneController))
+	if (!RuleB(Zone, UseZoneController)) {
 		return false;
+	}
 
 	auto npc_type = new NPCType;
 	memset(npc_type, 0, sizeof(NPCType));

--- a/zone/spawn2.cpp
+++ b/zone/spawn2.cpp
@@ -498,6 +498,8 @@ bool ZoneDatabase::PopulateZoneSpawnList(uint32 zoneid, LinkedList<Spawn2*> &spa
 		);
 	}
 
+	NPC::SpawnZoneController();
+
 	for (auto &s: spawns) {
 		uint32 spawn_time_left = 0;
 		if (spawn_times.count(s.id) != 0) {
@@ -537,8 +539,6 @@ bool ZoneDatabase::PopulateZoneSpawnList(uint32 zoneid, LinkedList<Spawn2*> &spa
 	}
 
 	LogInfo("Loaded [{}] spawn2 entries", Strings::Commify(l.size()));
-
-	NPC::SpawnZoneController();
 
 	return true;
 }


### PR DESCRIPTION
# Description

This change simply spawns the zone controller earlier than the rest of the mobs. Because we [made mobs spawn instantly](https://github.com/EQEmu/Server/pull/4620), the zone controller is getting spawned after everything else.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

No testing needs to be done for this

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
