### PR TITLE
[Fix] GMMove Update Edge Case With Clients

### DIFF
--- a/zone/mob_movement_manager.cpp
+++ b/zone/mob_movement_manager.cpp
@@ -852,7 +852,7 @@ void MobMovementManager::SendCommandToClients(
 			}
 
 			if (c->m_last_seen_mob_position.contains(mob->GetID())) {
-				if (c->m_last_seen_mob_position[mob->GetID()] == mob->GetPosition() && anim == 0) {
+				if (c->m_last_seen_mob_position[mob->GetID()] == mob->GetPosition() && anim == 0 && mob != c) {
 					LogPositionUpdate(
 						"Mob [{}] has already been sent to client [{}] at this position, skipping",
 						mob->GetCleanName(),
@@ -914,7 +914,7 @@ void MobMovementManager::SendCommandToClients(
 				}
 
 				if (c->m_last_seen_mob_position.contains(mob->GetID())) {
-					if (c->m_last_seen_mob_position[mob->GetID()] == mob->GetPosition() && anim == 0) {
+					if (c->m_last_seen_mob_position[mob->GetID()] == mob->GetPosition() && anim == 0 && mob != c) {
 						LogPositionUpdate(
 							"Mob [{}] has already been sent to client [{}] at this position, skipping",
 							mob->GetCleanName(),

--- a/zone/mob_movement_manager.cpp
+++ b/zone/mob_movement_manager.cpp
@@ -851,8 +851,8 @@ void MobMovementManager::SendCommandToClients(
 				_impl->Stats.TotalSentPosition++;
 			}
 
-			if (c->m_last_seen_mob_position.contains(mob->GetID())) {
-				if (c->m_last_seen_mob_position[mob->GetID()] == mob->GetPosition() && anim == 0 && mob != c) {
+			if (!mob->IsClient() && c->m_last_seen_mob_position.contains(mob->GetID())) {
+				if (c->m_last_seen_mob_position[mob->GetID()] == mob->GetPosition() && anim == 0) {
 					LogPositionUpdate(
 						"Mob [{}] has already been sent to client [{}] at this position, skipping",
 						mob->GetCleanName(),
@@ -913,8 +913,8 @@ void MobMovementManager::SendCommandToClients(
 					_impl->Stats.TotalSentPosition++;
 				}
 
-				if (c->m_last_seen_mob_position.contains(mob->GetID())) {
-					if (c->m_last_seen_mob_position[mob->GetID()] == mob->GetPosition() && anim == 0 && mob != c) {
+				if (!mob->IsClient() && c->m_last_seen_mob_position.contains(mob->GetID())) {
+					if (c->m_last_seen_mob_position[mob->GetID()] == mob->GetPosition() && anim == 0) {
 						LogPositionUpdate(
 							"Mob [{}] has already been sent to client [{}] at this position, skipping",
 							mob->GetCleanName(),


### PR DESCRIPTION
# Description

This fixes a rarer edge case regression caused from large optimizations made in https://github.com/EQEmu/Server/pull/4602 where the client is unable to update its last position to itself because normal ClientUpdates don't propogate the last_seen_position bucket position.

This update excludes clients entirely from the caching as its meant mainly for NPC's

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Tested script to 0,0,0 in Halas, client updates after initial move 

```perl
sub EVENT_SAY {
    if ($text=~/test/i) {
        $client->Message(15, "Moving");
        $client->GMMove(0, 0, 0);
    }
}
```

NPC skipping still works as intended

![image](https://github.com/user-attachments/assets/ef338b62-bf0e-4e1c-809e-131fac20a9db)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
