### PR TITLE
[Fix] Item Handins to Pets

### DIFF
--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -4272,11 +4272,13 @@ bool NPC::CanPetTakeItem(const EQ::ItemInstance *inst)
 		return false;
 	}
 
-	if (!IsPetOwnerClient()) {
+	if (!IsPetOwnerClient() && !IsCharmedPet()) {
 		return false;
 	}
 
-	const bool can_take_nodrop         = RuleB(Pets, CanTakeNoDrop) || inst->GetItem()->NoDrop != 0;
+	const bool can_take_nodrop = (RuleB(Pets, CanTakeNoDrop) || inst->GetItem()->NoDrop != 0)
+								 || inst->GetItem()->NoRent == 0;
+
 	const bool is_charmed_with_attuned = IsCharmed() && inst->IsAttuned();
 
 	auto o = GetOwner() && GetOwner()->IsClient() ? GetOwner()->CastToClient() : nullptr;
@@ -4297,7 +4299,7 @@ bool NPC::CanPetTakeItem(const EQ::ItemInstance *inst)
 	for (const auto &c : checks) {
 		if (c.condition) {
 			if (o) {
-				o->Message(Chat::PetResponse, c.message.c_str());
+				o->Message(Chat::PetResponse, fmt::format("[{}] says '{}'", GetCleanName(), c.message).c_str());
 			}
 			return false;
 		}

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -4299,7 +4299,7 @@ bool NPC::CanPetTakeItem(const EQ::ItemInstance *inst)
 	for (const auto &c : checks) {
 		if (c.condition) {
 			if (o) {
-				o->Message(Chat::PetResponse, fmt::format("[{}] says '{}'", GetCleanName(), c.message).c_str());
+				o->Message(Chat::PetResponse, fmt::format("{} says '{}'", GetCleanName(), c.message).c_str());
 			}
 			return false;
 		}

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -549,10 +549,10 @@ void Client::FinishTrade(Mob* tradingWith, bool finalizer, void* event_entry, st
 					}
 				}
 
-				auto               with  = tradingWith->CastToNPC();
-				const EQ::ItemData *item = inst->GetItem();
-
-				if (with->IsPetOwnerClient() && with->CanPetTakeItem(inst)) {
+				auto               with   = tradingWith->CastToNPC();
+				const EQ::ItemData *item  = inst->GetItem();
+				const bool         is_pet = with->IsPetOwnerClient() || with->IsCharmedPet();
+				if (is_pet && with->CanPetTakeItem(inst)) {
 					// pets need to look inside bags and try to equip items found there
 					if (item->IsClassBag() && item->BagSlots > 0) {
 						// if an item inside the bag can't be given to the pet, keep the bag


### PR DESCRIPTION
# Description

This fixes a few edge cases found with the new hand-in system in pets

* Fix an issue where the return message from pets was not including the pets name fully
* Fix an issue where pets could not receive no rent items
* Fix an issue where a player could not hand in items to charmed pets

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Handing in an item the pet can't use message

![image](https://github.com/user-attachments/assets/30a17fa3-24cd-4694-9d2f-fcad807266c8)

Charmed pet hand-in

![image](https://github.com/user-attachments/assets/bc25645d-9e9f-4ecc-82c7-57fc00b77c14)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
