### PR TITLE
[Databuckets] Add Zone Scoped Databuckets

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -6847,10 +6847,8 @@ RENAME TABLE `expedition_lockouts` TO `dynamic_zone_lockouts`;
 		.sql = R"(
 -- ✅ Drop old indexes
 DROP INDEX IF EXISTS `keys` ON `data_buckets`;
-DROP INDEX IF EXISTS `idx_character_expires` ON `data_buckets`;
 DROP INDEX IF EXISTS `idx_npc_expires` ON `data_buckets`;
 DROP INDEX IF EXISTS `idx_bot_expires` ON `data_buckets`;
-DROP INDEX IF EXISTS `idx_account_id_key` ON `data_buckets`;
 
 -- Add zone_id, instance_id
 ALTER TABLE `data_buckets`
@@ -6867,6 +6865,9 @@ ALTER TABLE `data_buckets`
 
 -- ✅ Create optimized unique index with `key` first
 CREATE UNIQUE INDEX `keys` ON data_buckets (`key`, character_id, npc_id, bot_id, account_id, zone_id, instance_id);
+
+-- ✅ Create indexes for just instance_id (instance deletion)
+CREATE INDEX idx_instance_id ON data_buckets (instance_id);
 )",
 		.content_schema_update = false
 	},

--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -6852,9 +6852,6 @@ DROP INDEX IF EXISTS `idx_npc_expires` ON `data_buckets`;
 DROP INDEX IF EXISTS `idx_bot_expires` ON `data_buckets`;
 DROP INDEX IF EXISTS `idx_account_id_key` ON `data_buckets`;
 
--- ✅ Create optimized unique index with `key` first
-CREATE UNIQUE INDEX `keys` ON data_buckets (`key`, character_id, npc_id, bot_id, account_id, zone_id, instance_id);
-
 -- Add zone_id, instance_id
 ALTER TABLE `data_buckets`
 	MODIFY COLUMN `npc_id` int(11) NOT NULL DEFAULT 0 AFTER `character_id`,
@@ -6867,6 +6864,9 @@ ALTER TABLE `data_buckets`
 	MODIFY COLUMN `character_id` bigint(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `account_id`,
 	MODIFY COLUMN `npc_id` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `character_id`,
 	MODIFY COLUMN `bot_id` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `npc_id`;
+
+-- ✅ Create optimized unique index with `key` first
+CREATE UNIQUE INDEX `keys` ON data_buckets (`key`, character_id, npc_id, bot_id, account_id, zone_id, instance_id);
 )",
 		.content_schema_update = false
 	},

--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -6838,6 +6838,38 @@ DROP TABLE `expeditions`;
 RENAME TABLE `expedition_lockouts` TO `dynamic_zone_lockouts`;
 )"
 	},
+	ManifestEntry{
+		.version = 9306,
+		.description = "2025_02_16_data_buckets_zone_id_instance_id.sql",
+		.check       = "SHOW COLUMNS FROM `data_buckets` LIKE 'zone_id'",
+		.condition   = "empty",
+		.match = "",
+		.sql = R"(
+-- ✅ Drop old indexes
+DROP INDEX IF EXISTS `keys` ON `data_buckets`;
+DROP INDEX IF EXISTS `idx_character_expires` ON `data_buckets`;
+DROP INDEX IF EXISTS `idx_npc_expires` ON `data_buckets`;
+DROP INDEX IF EXISTS `idx_bot_expires` ON `data_buckets`;
+DROP INDEX IF EXISTS `idx_account_id_key` ON `data_buckets`;
+
+-- ✅ Create optimized unique index with `key` first
+CREATE UNIQUE INDEX `keys` ON data_buckets (`key`, character_id, npc_id, bot_id, account_id, zone_id, instance_id);
+
+-- Add zone_id, instance_id
+ALTER TABLE `data_buckets`
+	MODIFY COLUMN `npc_id` int(11) NOT NULL DEFAULT 0 AFTER `character_id`,
+	MODIFY COLUMN `bot_id` int(11) NOT NULL DEFAULT 0 AFTER `npc_id`,
+	ADD COLUMN `zone_id` smallint(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `bot_id`,
+	ADD COLUMN `instance_id` smallint(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `zone_id`;
+
+ALTER TABLE `data_buckets`
+	MODIFY COLUMN `account_id` bigint(11) UNSIGNED NULL DEFAULT 0 AFTER `expires`,
+	MODIFY COLUMN `character_id` bigint(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `account_id`,
+	MODIFY COLUMN `npc_id` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `character_id`,
+	MODIFY COLUMN `bot_id` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `npc_id`;
+)",
+		.content_schema_update = false
+	},
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{
 //		.version = 9228,

--- a/common/database_instances.cpp
+++ b/common/database_instances.cpp
@@ -30,7 +30,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include "../common/repositories/respawn_times_repository.h"
 #include "../common/repositories/spawn_condition_values_repository.h"
 #include "repositories/spawn2_disabled_repository.h"
-
+#include "repositories/data_buckets_repository.h"
 
 #include "database.h"
 
@@ -479,6 +479,7 @@ void Database::DeleteInstance(uint16 instance_id)
 	DynamicZoneMembersRepository::DeleteByInstance(*this, instance_id);
 	DynamicZonesRepository::DeleteWhere(*this, fmt::format("instance_id = {}", instance_id));
 	CharacterCorpsesRepository::BuryInstance(*this, instance_id);
+	DataBucketsRepository::DeleteWhere(*this, fmt::format("instance_id = {}", instance_id));
 }
 
 void Database::FlagInstanceByGroupLeader(uint32 zone_id, int16 version, uint32 character_id, uint32 group_id)

--- a/common/repositories/base/base_data_buckets_repository.h
+++ b/common/repositories/base/base_data_buckets_repository.h
@@ -23,10 +23,12 @@ public:
 		std::string key_;
 		std::string value;
 		uint32_t    expires;
-		int64_t     account_id;
-		int64_t     character_id;
-		int64_t     npc_id;
-		int64_t     bot_id;
+		uint64_t    account_id;
+		uint64_t    character_id;
+		uint32_t    npc_id;
+		uint32_t    bot_id;
+		uint16_t    zone_id;
+		uint16_t    instance_id;
 
 		// cereal
 		template<class Archive>
@@ -40,7 +42,9 @@ public:
 				CEREAL_NVP(account_id),
 				CEREAL_NVP(character_id),
 				CEREAL_NVP(npc_id),
-				CEREAL_NVP(bot_id)
+				CEREAL_NVP(bot_id),
+				CEREAL_NVP(zone_id),
+				CEREAL_NVP(instance_id)
 			);
 		}
 	};
@@ -61,6 +65,8 @@ public:
 			"character_id",
 			"npc_id",
 			"bot_id",
+			"zone_id",
+			"instance_id",
 		};
 	}
 
@@ -75,6 +81,8 @@ public:
 			"character_id",
 			"npc_id",
 			"bot_id",
+			"zone_id",
+			"instance_id",
 		};
 	}
 
@@ -123,6 +131,8 @@ public:
 		e.character_id = 0;
 		e.npc_id       = 0;
 		e.bot_id       = 0;
+		e.zone_id      = 0;
+		e.instance_id  = 0;
 
 		return e;
 	}
@@ -163,10 +173,12 @@ public:
 			e.key_         = row[1] ? row[1] : "";
 			e.value        = row[2] ? row[2] : "";
 			e.expires      = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
-			e.account_id   = row[4] ? strtoll(row[4], nullptr, 10) : 0;
-			e.character_id = row[5] ? strtoll(row[5], nullptr, 10) : 0;
-			e.npc_id       = row[6] ? strtoll(row[6], nullptr, 10) : 0;
-			e.bot_id       = row[7] ? strtoll(row[7], nullptr, 10) : 0;
+			e.account_id   = row[4] ? strtoull(row[4], nullptr, 10) : 0;
+			e.character_id = row[5] ? strtoull(row[5], nullptr, 10) : 0;
+			e.npc_id       = row[6] ? static_cast<uint32_t>(strtoul(row[6], nullptr, 10)) : 0;
+			e.bot_id       = row[7] ? static_cast<uint32_t>(strtoul(row[7], nullptr, 10)) : 0;
+			e.zone_id      = row[8] ? static_cast<uint16_t>(strtoul(row[8], nullptr, 10)) : 0;
+			e.instance_id  = row[9] ? static_cast<uint16_t>(strtoul(row[9], nullptr, 10)) : 0;
 
 			return e;
 		}
@@ -207,6 +219,8 @@ public:
 		v.push_back(columns[5] + " = " + std::to_string(e.character_id));
 		v.push_back(columns[6] + " = " + std::to_string(e.npc_id));
 		v.push_back(columns[7] + " = " + std::to_string(e.bot_id));
+		v.push_back(columns[8] + " = " + std::to_string(e.zone_id));
+		v.push_back(columns[9] + " = " + std::to_string(e.instance_id));
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -236,6 +250,8 @@ public:
 		v.push_back(std::to_string(e.character_id));
 		v.push_back(std::to_string(e.npc_id));
 		v.push_back(std::to_string(e.bot_id));
+		v.push_back(std::to_string(e.zone_id));
+		v.push_back(std::to_string(e.instance_id));
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -273,6 +289,8 @@ public:
 			v.push_back(std::to_string(e.character_id));
 			v.push_back(std::to_string(e.npc_id));
 			v.push_back(std::to_string(e.bot_id));
+			v.push_back(std::to_string(e.zone_id));
+			v.push_back(std::to_string(e.instance_id));
 
 			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
 		}
@@ -310,10 +328,12 @@ public:
 			e.key_         = row[1] ? row[1] : "";
 			e.value        = row[2] ? row[2] : "";
 			e.expires      = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
-			e.account_id   = row[4] ? strtoll(row[4], nullptr, 10) : 0;
-			e.character_id = row[5] ? strtoll(row[5], nullptr, 10) : 0;
-			e.npc_id       = row[6] ? strtoll(row[6], nullptr, 10) : 0;
-			e.bot_id       = row[7] ? strtoll(row[7], nullptr, 10) : 0;
+			e.account_id   = row[4] ? strtoull(row[4], nullptr, 10) : 0;
+			e.character_id = row[5] ? strtoull(row[5], nullptr, 10) : 0;
+			e.npc_id       = row[6] ? static_cast<uint32_t>(strtoul(row[6], nullptr, 10)) : 0;
+			e.bot_id       = row[7] ? static_cast<uint32_t>(strtoul(row[7], nullptr, 10)) : 0;
+			e.zone_id      = row[8] ? static_cast<uint16_t>(strtoul(row[8], nullptr, 10)) : 0;
+			e.instance_id  = row[9] ? static_cast<uint16_t>(strtoul(row[9], nullptr, 10)) : 0;
 
 			all_entries.push_back(e);
 		}
@@ -342,10 +362,12 @@ public:
 			e.key_         = row[1] ? row[1] : "";
 			e.value        = row[2] ? row[2] : "";
 			e.expires      = row[3] ? static_cast<uint32_t>(strtoul(row[3], nullptr, 10)) : 0;
-			e.account_id   = row[4] ? strtoll(row[4], nullptr, 10) : 0;
-			e.character_id = row[5] ? strtoll(row[5], nullptr, 10) : 0;
-			e.npc_id       = row[6] ? strtoll(row[6], nullptr, 10) : 0;
-			e.bot_id       = row[7] ? strtoll(row[7], nullptr, 10) : 0;
+			e.account_id   = row[4] ? strtoull(row[4], nullptr, 10) : 0;
+			e.character_id = row[5] ? strtoull(row[5], nullptr, 10) : 0;
+			e.npc_id       = row[6] ? static_cast<uint32_t>(strtoul(row[6], nullptr, 10)) : 0;
+			e.bot_id       = row[7] ? static_cast<uint32_t>(strtoul(row[7], nullptr, 10)) : 0;
+			e.zone_id      = row[8] ? static_cast<uint16_t>(strtoul(row[8], nullptr, 10)) : 0;
+			e.instance_id  = row[9] ? static_cast<uint16_t>(strtoul(row[9], nullptr, 10)) : 0;
 
 			all_entries.push_back(e);
 		}
@@ -428,6 +450,8 @@ public:
 		v.push_back(std::to_string(e.character_id));
 		v.push_back(std::to_string(e.npc_id));
 		v.push_back(std::to_string(e.bot_id));
+		v.push_back(std::to_string(e.zone_id));
+		v.push_back(std::to_string(e.instance_id));
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -458,6 +482,8 @@ public:
 			v.push_back(std::to_string(e.character_id));
 			v.push_back(std::to_string(e.npc_id));
 			v.push_back(std::to_string(e.bot_id));
+			v.push_back(std::to_string(e.zone_id));
+			v.push_back(std::to_string(e.instance_id));
 
 			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
 		}

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9305
+#define CURRENT_BINARY_DATABASE_VERSION 9306
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9054
 
 #endif

--- a/zone/cli/benchmark_databuckets.cpp
+++ b/zone/cli/benchmark_databuckets.cpp
@@ -1,0 +1,277 @@
+#include <chrono>
+#include <iostream>
+#include <random>
+#include "../../common/http/httplib.h"
+#include "../../common/eqemu_logsys.h"
+#include "../sidecar_api/sidecar_api.h"
+#include "../../common/platform.h"
+#include "../data_bucket.h"
+#include "../zonedb.h"
+#include "../../common/repositories/data_buckets_repository.h"
+
+void RunBenchmarkCycle(uint64_t target_rows)
+{
+	const size_t      OPERATIONS_PER_TEST = 5000;
+	const std::string test_key_prefix     = "test_key_";
+
+	std::cout << Strings::Repeat("-", 70) << "\n";
+	std::cout << "📊 Running Benchmark at " << Strings::Commify(target_rows) << " Rows...\n";
+	std::cout << Strings::Repeat("-", 70) << "\n";
+
+	// 🧹 **Purge `test_key_*` Keys Before Each Run**
+	std::cout << "🧹 Purging test keys (`test_key_*`)...\n";
+	auto purge_start = std::chrono::high_resolution_clock::now();
+	DataBucketsRepository::DeleteWhere(database, "`key` LIKE '" + test_key_prefix + "%'");
+	auto                          purge_end  = std::chrono::high_resolution_clock::now();
+	std::chrono::duration<double> purge_time = purge_end - purge_start;
+	std::cout << "✅ Purged test keys in " << purge_time.count() << " seconds.\n";
+
+	// 📊 **Ensure the Table Contains At Least `target_rows`**
+	auto     populate_start = std::chrono::high_resolution_clock::now();
+	uint64_t current_count  = DataBucketsRepository::Count(database);
+	if (current_count < target_rows) {
+		std::cout << "📌 Populating table to " << Strings::Commify(target_rows) << " rows...\n";
+		std::mt19937                       rng(std::random_device{}());
+		std::uniform_int_distribution<int> entity_type(1, 5);
+		std::uniform_int_distribution<int> id_dist(1, 1000000);
+		std::uniform_int_distribution<int> expiry_dist(0, 86400 * 30);  // Expiry up to 30 days
+
+		while (current_count < target_rows) {
+			std::vector<DataBucketsRepository::DataBuckets> batch;
+			for (size_t                                     i = 0; i < 100000; ++i) {
+				if (i > target_rows - current_count) {
+					break;
+				}
+
+				int         entity_choice = entity_type(rng);
+				int         entity_id     = id_dist(rng);
+				std::string key           = "test_key_" + std::to_string(current_count + i);
+				std::string value         = "value_" + std::to_string(current_count + i);
+				int         expires       = static_cast<int>(std::time(nullptr)) + expiry_dist(rng);
+
+				DataBucketsRepository::DataBuckets e{};
+				e.key_         = key;
+				e.value        = value;
+				e.expires      = expires;
+				e.account_id   = (entity_choice == 1) ? entity_id : 0;
+				e.character_id = (entity_choice == 2) ? entity_id : 0;
+				e.npc_id       = (entity_choice == 3) ? entity_id : 0;
+				e.bot_id       = (entity_choice == 4) ? entity_id : 0;
+				e.zone_id      = (entity_choice == 5) ? entity_id : 0;
+				e.instance_id  = (entity_choice == 5) ? entity_id : 0;
+
+				batch.emplace_back(e);
+			}
+			DataBucketsRepository::InsertMany(database, batch);
+			current_count += batch.size();
+		}
+	}
+	else {
+		std::cout << "✅ Table already has " << current_count << " rows, proceeding with benchmark.\n";
+	}
+
+	auto                          populate_end  = std::chrono::high_resolution_clock::now();
+	std::chrono::duration<double> populate_time = populate_end - populate_start;
+	std::cout << "✅ Populated table in " << populate_time.count() << " seconds.\n";
+
+	std::mt19937                       rng(std::random_device{}());
+	std::uniform_int_distribution<int> id_dist(1, 1000);
+
+	// 🚀 **Measure Insert Performance**
+	std::vector<DataBucketKey> inserted_keys = {};
+	auto                       insert_start  = std::chrono::high_resolution_clock::now();
+	for (size_t                i             = 0; i < OPERATIONS_PER_TEST; ++i) {
+		std::string key     = test_key_prefix + std::to_string(current_count + i);
+		std::string value   = "value_" + std::to_string(current_count + i);
+		int         expires = static_cast<int>(std::time(nullptr)) + 3600;
+
+		DataBucketKey e{
+			.key = key,
+			.value = value,
+			.expires = std::to_string(expires),
+			.account_id = 0,
+			.character_id = 0,
+			.npc_id = 0,
+			.bot_id = 0
+		};
+
+		// randomly set account_id, character_id, npc_id, or bot_id
+		switch (i % 4) {
+			case 0:
+				e.account_id = id_dist(rng);
+				break;
+			case 1:
+				e.character_id = id_dist(rng);
+				break;
+			case 2:
+				e.npc_id = id_dist(rng);
+				break;
+			case 3:
+				e.bot_id = id_dist(rng);
+				break;
+			case 4:
+				int entity_choice = id_dist(rng);
+				e.zone_id = entity_choice;
+				e.instance_id = entity_choice;
+				break;
+		}
+
+		DataBucket::SetData(e);
+
+		inserted_keys.emplace_back(e);
+	}
+	auto                          insert_end  = std::chrono::high_resolution_clock::now();
+	std::chrono::duration<double> insert_time = insert_end - insert_start;
+	std::cout << "✅ Completed " << Strings::Commify(OPERATIONS_PER_TEST) << " inserts in " << insert_time.count()
+			  << " seconds. (Individual Insert Performance)\n";
+
+	// ✏️ **Measure Update Performance Using DataBucket**
+	auto      update_start = std::chrono::high_resolution_clock::now();
+	for (auto &key: inserted_keys) {
+		// 🔍 Retrieve existing bucket using scoped `GetData`
+		auto e = DataBucket::GetData(key);
+		if (e.id > 0) {
+			// create a new key object with the updated values
+			DataBucketKey bucket_entry_key{
+				.key = e.key_,
+				.value = "some_new_value",
+				.expires = std::to_string(e.expires),
+				.account_id = e.account_id,
+				.character_id = e.character_id,
+				.npc_id = e.npc_id,
+				.bot_id = e.bot_id,
+				.zone_id = e.zone_id,
+				.instance_id = e.instance_id
+			};
+
+			// 🔄 Update using DataBucket class
+			DataBucket::SetData(bucket_entry_key);
+		}
+	}
+	auto                          update_end  = std::chrono::high_resolution_clock::now();
+	std::chrono::duration<double> update_time = update_end - update_start;
+	std::cout << "✅ Completed " << Strings::Commify(OPERATIONS_PER_TEST) << " updates in " << update_time.count()
+			  << " seconds. (Scoped Update Performance)\n";
+
+
+	// 🔍 **Measure Cached Read Performance**
+	auto        read_cached_start = std::chrono::high_resolution_clock::now();
+	for (size_t i                 = 0; i < OPERATIONS_PER_TEST; ++i) {
+		std::string   key = test_key_prefix + std::to_string(current_count + i);
+		DataBucketKey k{
+			.key = key,
+			.account_id = 0,
+			.character_id = 0,
+			.npc_id = 0,
+			.bot_id = 0,
+			.zone_id = 0,
+			.instance_id = 0
+		};
+
+		// randomly set account_id, character_id, npc_id, or bot_id
+		switch (i % 4) {
+			case 0:
+				k.account_id = id_dist(rng);
+				break;
+			case 1:
+				k.character_id = id_dist(rng);
+				break;
+			case 2:
+				k.npc_id = id_dist(rng);
+				break;
+			case 3:
+				k.bot_id = id_dist(rng);
+				break;
+			case 4:
+				int entity_choice = id_dist(rng);
+				k.zone_id = entity_choice;
+				k.instance_id = entity_choice;
+		}
+
+		DataBucket::GetData(key);
+	}
+	auto                          read_cached_end  = std::chrono::high_resolution_clock::now();
+	std::chrono::duration<double> read_cached_time = read_cached_end - read_cached_start;
+	std::cout << "✅ Completed " << Strings::Commify(OPERATIONS_PER_TEST) << " cached reads in "
+			  << read_cached_time.count() << " seconds. (DataBucket::GetData)\n";
+
+	// 🔍 **Measure Non-Cached Read Performance (Direct Query)**
+	auto                          read_uncached_start = std::chrono::high_resolution_clock::now();
+	for (size_t                   i                   = 0; i < OPERATIONS_PER_TEST; ++i) {
+		std::string key = test_key_prefix + std::to_string(current_count + i);
+		DataBucketsRepository::GetWhere(database, "`key` = '" + key + "'");
+	}
+	auto                          read_uncached_end   = std::chrono::high_resolution_clock::now();
+	std::chrono::duration<double> read_uncached_time  = read_uncached_end - read_uncached_start;
+	std::cout << "✅ Completed " << Strings::Commify(OPERATIONS_PER_TEST) << " non-cached reads in "
+			  << read_uncached_time.count() << " seconds. (DataBucketsRepository::GetWhere)\n";
+
+	// 🗑️ **Measure Delete Performance**
+	auto        delete_start = std::chrono::high_resolution_clock::now();
+	for (size_t i            = 0; i < OPERATIONS_PER_TEST; ++i) {
+		std::string key = test_key_prefix + std::to_string(current_count + i);
+
+		DataBucketKey k{
+			.key = key,
+			.account_id = 0,
+			.character_id = 0,
+			.npc_id = 0,
+			.bot_id = 0,
+			.zone_id = 0,
+			.instance_id = 0
+		};
+
+		// randomly set account_id, character_id, npc_id, or bot_id
+		switch (i % 4) {
+			case 0:
+				k.account_id = id_dist(rng);
+				break;
+			case 1:
+				k.character_id = id_dist(rng);
+				break;
+			case 2:
+				k.npc_id = id_dist(rng);
+				break;
+			case 3:
+				k.bot_id = id_dist(rng);
+				break;
+			case 4:
+				int entity_choice = id_dist(rng);
+				k.zone_id = entity_choice;
+				k.instance_id = entity_choice;
+		}
+
+		DataBucket::DeleteData(k);
+	}
+	auto                          delete_end  = std::chrono::high_resolution_clock::now();
+	std::chrono::duration<double> delete_time = delete_end - delete_start;
+	std::cout << "✅ Completed " << Strings::Commify(OPERATIONS_PER_TEST) << " deletes in " << delete_time.count()
+			  << " seconds.\n";
+}
+
+void ZoneCLI::BenchmarkDatabuckets(int argc, char **argv, argh::parser &cmd, std::string &description)
+{
+	description = "Benchmark individual reads/writes/deletes in data_buckets at different table sizes.";
+
+	if (cmd[{"-h", "--help"}]) {
+		std::cout << "Usage: BenchmarkDatabuckets\n";
+		return;
+	}
+
+	if (std::getenv("DEBUG")) {
+		LogSys.SetDatabase(&database)->LoadLogDatabaseSettings();
+	}
+
+	auto start_time = std::chrono::high_resolution_clock::now();
+
+	std::vector<uint64_t> benchmark_sizes = {10000, 100000, 1000000};
+
+	for (auto size: benchmark_sizes) {
+		RunBenchmarkCycle(size);
+	}
+
+	// 🚀 **Total Benchmark Time**
+	auto                          end_time      = std::chrono::high_resolution_clock::now();
+	std::chrono::duration<double> total_elapsed = end_time - start_time;
+	std::cout << "\n🚀 Total Benchmark Time: " << total_elapsed.count() << " seconds\n";
+}

--- a/zone/data_bucket.cpp
+++ b/zone/data_bucket.cpp
@@ -15,7 +15,7 @@ std::vector<DataBucketsRepository::DataBuckets> g_data_bucket_cache = {};
 
 void DataBucket::SetData(const std::string &bucket_key, const std::string &bucket_value, std::string expires_time)
 {
-	thread_local auto k = DataBucketKey{
+	auto k = DataBucketKey{
 		.key = bucket_key,
 		.value = bucket_value,
 		.expires = expires_time,
@@ -26,13 +26,13 @@ void DataBucket::SetData(const std::string &bucket_key, const std::string &bucke
 
 void DataBucket::SetData(const DataBucketKey &k_)
 {
-	thread_local DataBucketKey k = k_; // copy the key so we can modify it
+	DataBucketKey k = k_; // copy the key so we can modify it
 	if (k.key.find(NESTED_KEY_DELIMITER) != std::string::npos) {
 		k.key = Strings::Split(k.key, NESTED_KEY_DELIMITER).front();
 	}
 
-	thread_local auto b = DataBucketsRepository::NewEntity();
-	thread_local auto r = GetData(k, true);
+	auto b = DataBucketsRepository::NewEntity();
+	auto r = GetData(k, true);
 	// if we have an entry, use it
 	if (r.id > 0) {
 		b = r;
@@ -178,7 +178,7 @@ DataBucketsRepository::DataBuckets DataBucket::ExtractNestedValue(
 // the only place we should be ignoring the misses cache is on the initial read during SetData
 DataBucketsRepository::DataBuckets DataBucket::GetData(const DataBucketKey &k_, bool ignore_misses_cache)
 {
-	thread_local DataBucketKey k = k_; // Copy the key so we can modify it
+	DataBucketKey k = k_; // Copy the key so we can modify it
 
 	bool is_nested_key = k.key.find(NESTED_KEY_DELIMITER) != std::string::npos;
 
@@ -268,7 +268,7 @@ DataBucketsRepository::DataBuckets DataBucket::GetData(const DataBucketKey &k_, 
 		return DataBucketsRepository::NewEntity();
 	}
 
-	thread_local auto bucket = r.front();
+	auto bucket = r.front();
 
 	// If the entry has expired, delete it
 	if (bucket.expires > 0 && bucket.expires < static_cast<long long>(std::time(nullptr))) {
@@ -311,8 +311,7 @@ std::string DataBucket::GetDataRemaining(const std::string &bucket_key)
 
 bool DataBucket::DeleteData(const std::string &bucket_key)
 {
-	thread_local auto k = DataBucketKey{.key = bucket_key};
-	return DeleteData(k);
+	return DeleteData(DataBucketKey{.key = bucket_key});
 }
 
 // GetDataBuckets bulk loads all data buckets for a mob

--- a/zone/data_bucket.cpp
+++ b/zone/data_bucket.cpp
@@ -15,7 +15,7 @@ std::vector<DataBucketsRepository::DataBuckets> g_data_bucket_cache = {};
 
 void DataBucket::SetData(const std::string &bucket_key, const std::string &bucket_value, std::string expires_time)
 {
-	auto k = DataBucketKey{
+	thread_local auto k = DataBucketKey{
 		.key = bucket_key,
 		.value = bucket_value,
 		.expires = expires_time,
@@ -26,13 +26,13 @@ void DataBucket::SetData(const std::string &bucket_key, const std::string &bucke
 
 void DataBucket::SetData(const DataBucketKey &k_)
 {
-	DataBucketKey k = k_; // copy the key so we can modify it
+	thread_local DataBucketKey k = k_; // copy the key so we can modify it
 	if (k.key.find(NESTED_KEY_DELIMITER) != std::string::npos) {
 		k.key = Strings::Split(k.key, NESTED_KEY_DELIMITER).front();
 	}
 
-	auto b = DataBucketsRepository::NewEntity();
-	auto r = GetData(k, true);
+	thread_local auto b = DataBucketsRepository::NewEntity();
+	thread_local auto r = GetData(k, true);
 	// if we have an entry, use it
 	if (r.id > 0) {
 		b = r;
@@ -178,7 +178,7 @@ DataBucketsRepository::DataBuckets DataBucket::ExtractNestedValue(
 // the only place we should be ignoring the misses cache is on the initial read during SetData
 DataBucketsRepository::DataBuckets DataBucket::GetData(const DataBucketKey &k_, bool ignore_misses_cache)
 {
-	DataBucketKey k = k_; // Copy the key so we can modify it
+	thread_local DataBucketKey k = k_; // Copy the key so we can modify it
 
 	bool is_nested_key = k.key.find(NESTED_KEY_DELIMITER) != std::string::npos;
 
@@ -268,7 +268,7 @@ DataBucketsRepository::DataBuckets DataBucket::GetData(const DataBucketKey &k_, 
 		return DataBucketsRepository::NewEntity();
 	}
 
-	auto bucket = r.front();
+	thread_local auto bucket = r.front();
 
 	// If the entry has expired, delete it
 	if (bucket.expires > 0 && bucket.expires < static_cast<long long>(std::time(nullptr))) {
@@ -311,7 +311,8 @@ std::string DataBucket::GetDataRemaining(const std::string &bucket_key)
 
 bool DataBucket::DeleteData(const std::string &bucket_key)
 {
-	return DeleteData(DataBucketKey{.key = bucket_key});
+	thread_local auto k = DataBucketKey{.key = bucket_key};
+	return DeleteData(k);
 }
 
 // GetDataBuckets bulk loads all data buckets for a mob

--- a/zone/data_bucket.cpp
+++ b/zone/data_bucket.cpp
@@ -617,10 +617,7 @@ void DataBucket::DeleteCachedBuckets(DataBucketLoadType::Type type, uint32 id, u
 					(type == DataBucketLoadType::Bot && e.bot_id == id) ||
 					(type == DataBucketLoadType::Account && e.account_id == id) ||
 					(type == DataBucketLoadType::Client && e.character_id == id) ||
-					(type == DataBucketLoadType::Zone &&
-					 e.zone_id == id &&
-					 e.instance_id == secondary_id
-					)
+					(type == DataBucketLoadType::Zone && e.zone_id == id && e.instance_id == secondary_id)
 				);
 			}
 		),

--- a/zone/data_bucket.h
+++ b/zone/data_bucket.h
@@ -12,10 +12,12 @@ struct DataBucketKey {
 	std::string key;
 	std::string value;
 	std::string expires;
-	int64_t     account_id = 0;
-	int64_t     character_id = 0;
-	int64_t     npc_id = 0;
-	int64_t     bot_id = 0;
+	uint64_t    account_id   = 0;
+	uint64_t    character_id = 0;
+	uint32_t    npc_id       = 0;
+	uint32_t    bot_id       = 0;
+	uint16_t    zone_id      = 0;
+	uint16_t    instance_id  = 0;
 };
 
 namespace DataBucketLoadType {
@@ -23,6 +25,7 @@ namespace DataBucketLoadType {
 		Bot,
 		Account,
 		Client,
+		Zone,
 		MaxType
 	};
 
@@ -30,6 +33,7 @@ namespace DataBucketLoadType {
 		"Bot",
 		"Account",
 		"Client",
+		"Zone"
 	};
 }
 
@@ -56,12 +60,14 @@ public:
 	static bool CheckBucketMatch(const DataBucketsRepository::DataBuckets &dbe, const DataBucketKey &k);
 	static bool ExistsInCache(const DataBucketsRepository::DataBuckets &entry);
 
+	static void LoadZoneCache(uint16 zone_id, uint16 instance_id);
 	static void BulkLoadEntitiesToCache(DataBucketLoadType::Type t, std::vector<uint32> ids);
-	static void DeleteCachedBuckets(DataBucketLoadType::Type type, uint32 id);
+	static void DeleteCachedBuckets(DataBucketLoadType::Type type, uint32 id, uint32 secondary_id = 0);
 
 	static void DeleteFromMissesCache(DataBucketsRepository::DataBuckets e);
 	static void ClearCache();
 	static void DeleteFromCache(uint64 id, DataBucketLoadType::Type type);
+	static void DeleteZoneFromCache(uint16 zone_id, uint16 instance_id, DataBucketLoadType::Type type);
 	static bool CanCache(const DataBucketKey &key);
 	static DataBucketsRepository::DataBuckets
 	ExtractNestedValue(const DataBucketsRepository::DataBuckets &bucket, const std::string &full_key);

--- a/zone/lua_zone.cpp
+++ b/zone/lua_zone.cpp
@@ -685,6 +685,42 @@ void Lua_Zone::ShowZoneGlobalLoot(Lua_Client c)
 	self->ShowZoneGlobalLoot(c);
 }
 
+void Lua_Zone::SetBucket(const std::string& bucket_name, const std::string& bucket_value)
+{
+	Lua_Safe_Call_Void();
+	self->SetBucket(bucket_name, bucket_value);
+}
+
+void Lua_Zone::SetBucket(const std::string& bucket_name, const std::string& bucket_value, const std::string& expiration)
+{
+	Lua_Safe_Call_Void();
+	self->SetBucket(bucket_name, bucket_value, expiration);
+}
+
+void Lua_Zone::DeleteBucket(const std::string& bucket_name)
+{
+	Lua_Safe_Call_Void();
+	self->DeleteBucket(bucket_name);
+}
+
+std::string Lua_Zone::GetBucket(const std::string& bucket_name)
+{
+	Lua_Safe_Call_String();
+	return self->GetBucket(bucket_name);
+}
+
+std::string Lua_Zone::GetBucketExpires(const std::string& bucket_name)
+{
+	Lua_Safe_Call_String();
+	return self->GetBucketExpires(bucket_name);
+}
+
+std::string Lua_Zone::GetBucketRemaining(const std::string& bucket_name)
+{
+	Lua_Safe_Call_String();
+	return self->GetBucketRemaining(bucket_name);
+}
+
 luabind::scope lua_register_zone() {
 	return luabind::class_<Lua_Zone>("Zone")
 	.def(luabind::constructor<>())
@@ -695,11 +731,15 @@ luabind::scope lua_register_zone() {
 	.def("CanDoCombat", &Lua_Zone::CanDoCombat)
 	.def("CanLevitate", &Lua_Zone::CanLevitate)
 	.def("ClearSpawnTimers", &Lua_Zone::ClearSpawnTimers)
+	.def("DeleteBucket", (void(Lua_Zone::*)(const std::string&))&Lua_Zone::DeleteBucket)
 	.def("Depop", (void(Lua_Zone::*)(void))&Lua_Zone::Depop)
 	.def("Depop", (void(Lua_Zone::*)(bool))&Lua_Zone::Depop)
 	.def("Despawn", &Lua_Zone::Despawn)
 	.def("GetAAEXPModifier", &Lua_Zone::GetAAEXPModifier)
 	.def("GetAAEXPModifierByCharacterID", &Lua_Zone::GetAAEXPModifierByCharacterID)
+	.def("GetBucket", (std::string(Lua_Zone::*)(const std::string&))&Lua_Zone::GetBucket)
+	.def("GetBucketExpires", (std::string(Lua_Zone::*)(const std::string&))&Lua_Zone::GetBucketExpires)
+	.def("GetBucketRemaining", (std::string(Lua_Zone::*)(const std::string&))&Lua_Zone::GetBucketRemaining)
 	.def("GetContentFlags", &Lua_Zone::GetContentFlags)
 	.def("GetContentFlagsDisabled", &Lua_Zone::GetContentFlagsDisabled)
 	.def("GetExperienceMultiplier", &Lua_Zone::GetExperienceMultiplier)
@@ -795,6 +835,8 @@ luabind::scope lua_register_zone() {
 	.def("Repop", (void(Lua_Zone::*)(bool))&Lua_Zone::Repop)
 	.def("SetAAEXPModifier", &Lua_Zone::SetAAEXPModifier)
 	.def("SetAAEXPModifierByCharacterID", &Lua_Zone::SetAAEXPModifierByCharacterID)
+	.def("SetBucket", (void(Lua_Zone::*)(const std::string&,const std::string&))&Lua_Zone::SetBucket)
+	.def("SetBucket", (void(Lua_Zone::*)(const std::string&,const std::string&,const std::string&))&Lua_Zone::SetBucket)
 	.def("SetEXPModifier", &Lua_Zone::SetEXPModifier)
 	.def("SetEXPModifierByCharacterID", &Lua_Zone::SetEXPModifierByCharacterID)
 	.def("SetInstanceTimer", &Lua_Zone::SetInstanceTimer)

--- a/zone/lua_zone.h
+++ b/zone/lua_zone.h
@@ -141,6 +141,14 @@ public:
 	void SetIsHotzone(bool is_hotzone);
 	void ShowZoneGlobalLoot(Lua_Client c);
 
+	// data buckets
+	void SetBucket(const std::string& bucket_name, const std::string& bucket_value);
+	void SetBucket(const std::string& bucket_name, const std::string& bucket_value, const std::string& expiration = "");
+	void DeleteBucket(const std::string& bucket_name);
+	std::string GetBucket(const std::string& bucket_name);
+	std::string GetBucketExpires(const std::string& bucket_name);
+	std::string GetBucketRemaining(const std::string& bucket_name);
+
 };
 
 #endif

--- a/zone/perl_zone.cpp
+++ b/zone/perl_zone.cpp
@@ -526,6 +526,36 @@ void Perl_Zone_ShowZoneGlobalLoot(Zone* self, Client* c)
 	self->ShowZoneGlobalLoot(c);
 }
 
+void Perl_Zone_SetBucket(Zone* self, const std::string bucket_name, const std::string bucket_value)
+{
+	self->SetBucket(bucket_name, bucket_value);
+}
+
+void Perl_Zone_SetBucket(Zone* self, const std::string bucket_name, const std::string bucket_value, const std::string expiration)
+{
+	self->SetBucket(bucket_name, bucket_value, expiration);
+}
+
+void Perl_Zone_DeleteBucket(Zone* self, const std::string bucket_name)
+{
+	self->DeleteBucket(bucket_name);
+}
+
+std::string Perl_Zone_GetBucket(Zone* self, const std::string bucket_name)
+{
+	return self->GetBucket(bucket_name);
+}
+
+std::string Perl_Zone_GetBucketExpires(Zone* self, const std::string bucket_name)
+{
+	return self->GetBucketExpires(bucket_name);
+}
+
+std::string Perl_Zone_GetBucketRemaining(Zone* self, const std::string bucket_name)
+{
+	return self->GetBucketRemaining(bucket_name);
+}
+
 void perl_register_zone()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -538,11 +568,15 @@ void perl_register_zone()
 	package.add("CanDoCombat", &Perl_Zone_CanDoCombat);
 	package.add("CanLevitate", &Perl_Zone_CanLevitate);
 	package.add("ClearSpawnTimers", &Perl_Zone_ClearSpawnTimers);
+	package.add("DeleteBucket", &Perl_Zone_DeleteBucket);
 	package.add("Depop", (void(*)(Zone*))&Perl_Zone_Depop);
 	package.add("Depop", (void(*)(Zone*, bool))&Perl_Zone_Depop);
 	package.add("Despawn", &Perl_Zone_Despawn);
 	package.add("GetAAEXPModifier", &Perl_Zone_GetAAEXPModifier);
 	package.add("GetAAEXPModifierByCharacterID", &Perl_Zone_GetAAEXPModifierByCharacterID);
+	package.add("GetBucket", &Perl_Zone_GetBucket);
+	package.add("GetBucketExpires", &Perl_Zone_GetBucketExpires);
+	package.add("GetBucketRemaining", &Perl_Zone_GetBucketRemaining);
 	package.add("GetContentFlags", &Perl_Zone_GetContentFlags);
 	package.add("GetContentFlagsDisabled", &Perl_Zone_GetContentFlagsDisabled);
 	package.add("GetExperienceMultiplier", &Perl_Zone_GetExperienceMultiplier);
@@ -638,6 +672,8 @@ void perl_register_zone()
 	package.add("Repop", (void(*)(Zone*, bool))&Perl_Zone_Repop);
 	package.add("SetAAEXPModifier", &Perl_Zone_SetAAEXPModifier);
 	package.add("SetAAEXPModifierByCharacterID", &Perl_Zone_SetAAEXPModifierByCharacterID);
+	package.add("SetBucket", (void(*)(Zone*, const std::string, const std::string))&Perl_Zone_SetBucket);
+	package.add("SetBucket", (void(*)(Zone*, const std::string, const std::string, const std::string))&Perl_Zone_SetBucket);
 	package.add("SetEXPModifier", &Perl_Zone_SetEXPModifier);
 	package.add("SetEXPModifierByCharacterID", &Perl_Zone_SetEXPModifierByCharacterID);
 	package.add("SetInstanceTimer", &Perl_Zone_SetInstanceTimer);

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -172,6 +172,8 @@ bool Zone::Bootup(uint32 iZoneID, uint32 iInstanceID, bool is_static) {
 	zone->RequestUCSServerStatus();
 	zone->StartShutdownTimer();
 
+	DataBucket::LoadZoneCache(iZoneID, iInstanceID);
+
 	/*
 	 * Set Logging
 	 */
@@ -931,6 +933,8 @@ void Zone::Shutdown(bool quiet)
 	entity_list.ClearAreas();
 	parse->ReloadQuests(true);
 	UpdateWindowTitle(nullptr);
+
+	DataBucket::DeleteCachedBuckets(DataBucketLoadType::Zone, zone->GetZoneID(), zone->GetInstanceID());
 
 	LogSys.CloseFileLogs();
 
@@ -3185,6 +3189,58 @@ bool Zone::DoesAlternateCurrencyExist(uint32 currency_id)
 			return c.id == currency_id;
 		}
 	);
+}
+
+std::string Zone::GetBucket(const std::string& bucket_name)
+{
+	DataBucketKey k = {};
+	k.zone_id     = zoneid;
+	k.instance_id = instanceid;
+	k.key         = bucket_name;
+
+	return DataBucket::GetData(k).value;
+}
+
+void Zone::SetBucket(const std::string& bucket_name, const std::string& bucket_value, const std::string& expiration)
+{
+	DataBucketKey k = {};
+	k.zone_id     = zoneid;
+	k.instance_id = instanceid;
+	k.key         = bucket_name;
+	k.expires     = expiration;
+	k.value       = bucket_value;
+
+	DataBucket::SetData(k);
+}
+
+void Zone::DeleteBucket(const std::string& bucket_name)
+{
+	DataBucketKey k = {};
+	k.zone_id     = zoneid;
+	k.instance_id = instanceid;
+	k.key         = bucket_name;
+
+	DataBucket::DeleteData(k);
+}
+
+std::string Zone::GetBucketExpires(const std::string& bucket_name)
+{
+	DataBucketKey k = {};
+	k.zone_id     = zoneid;
+	k.instance_id = instanceid;
+	k.key         = bucket_name;
+
+	return DataBucket::GetDataExpires(k);
+}
+
+std::string Zone::GetBucketRemaining(const std::string& bucket_name)
+{
+	DataBucketKey k = {};
+	k.zone_id     = zoneid;
+	k.instance_id = instanceid;
+	k.key         = bucket_name;
+
+	return DataBucket::GetDataRemaining(k);
 }
 
 #include "zone_loot.cpp"

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -879,6 +879,8 @@ void Zone::Shutdown(bool quiet)
 		return;
 	}
 
+	DataBucket::DeleteCachedBuckets(DataBucketLoadType::Zone, zone->GetZoneID(), zone->GetInstanceID());
+
 	entity_list.StopMobAI();
 
 	std::map<uint32, NPCType *>::iterator itr;
@@ -933,8 +935,6 @@ void Zone::Shutdown(bool quiet)
 	entity_list.ClearAreas();
 	parse->ReloadQuests(true);
 	UpdateWindowTitle(nullptr);
-
-	DataBucket::DeleteCachedBuckets(DataBucketLoadType::Zone, zone->GetZoneID(), zone->GetInstanceID());
 
 	LogSys.CloseFileLogs();
 

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -451,6 +451,12 @@ public:
 	void LoadBaseData();
 	void ReloadBaseData();
 
+	// data buckets
+	std::string GetBucket(const std::string& bucket_name);
+	void SetBucket(const std::string& bucket_name, const std::string& bucket_value, const std::string& expiration = "");
+	void DeleteBucket(const std::string& bucket_name);
+	std::string GetBucketExpires(const std::string& bucket_name);
+	std::string GetBucketRemaining(const std::string& bucket_name);
 
 private:
 	bool      allow_mercs;

--- a/zone/zone_cli.cpp
+++ b/zone/zone_cli.cpp
@@ -29,6 +29,7 @@ void ZoneCLI::CommandHandler(int argc, char **argv)
 	auto function_map = EQEmuCommand::function_map;
 
 	// Register commands
+	function_map["benchmark:databuckets"] = &ZoneCLI::BenchmarkDatabuckets;
 	function_map["sidecar:serve-http"] = &ZoneCLI::SidecarServeHttp;
 	function_map["tests:npc-handins"] = &ZoneCLI::NpcHandins;
 	function_map["tests:npc-handins-multiquest"] = &ZoneCLI::NpcHandinsMultiQuest;
@@ -36,6 +37,7 @@ void ZoneCLI::CommandHandler(int argc, char **argv)
 	EQEmuCommand::HandleMenu(function_map, cmd, argc, argv);
 }
 
+#include "cli/benchmark_databuckets.cpp"
 #include "cli/sidecar_serve_http.cpp"
 #include "cli/npc_handins.cpp"
 #include "cli/npc_handins_multiquest.cpp"

--- a/zone/zone_cli.h
+++ b/zone/zone_cli.h
@@ -6,6 +6,7 @@
 class ZoneCLI {
 public:
 	static void CommandHandler(int argc, char **argv);
+	static void BenchmarkDatabuckets(int argc, char **argv, argh::parser &cmd, std::string &description);
 	static void SidecarServeHttp(int argc, char **argv, argh::parser &cmd, std::string &description);
 	static bool RanConsoleCommand(int argc, char **argv);
 	static bool RanSidecarCommand(int argc, char **argv);


### PR DESCRIPTION
# Description

Adds support for Zone Scoped Databuckets.

Every bucket uses **two** keys **zone_id and instance_id**

Also thanks to @Kinglykrab for adding [zone scoped Quest API support](https://github.com/EQEmu/Server/pull/4662) in support to this PR. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing

```perl
sub EVENT_SAY {
    # set 3 variations
    if ($text=~/set/i) {
        $zone->SetBucket("example", "1");
        $zone->SetBucket("example2", "1");
        $zone->SetBucket("example3", "1", "1S");   
    }

    # one expires, we delete the second, the first should be the only one to return a value
    if ($text=~/get/i) {
        $zone->DeleteBucket("example2");
        $client->Message(15, "example1 " . $zone->GetBucket("example"));
        $client->Message(15, "example2 " . $zone->GetBucket("example2") . " (Should be deleted)");
        $client->Message(15, "example3 " . $zone->GetBucket("example3") . " (Should be expired)");
    }
}
```

![image](https://github.com/user-attachments/assets/5911e8b0-c551-441d-8398-b157e115024d)

```lua
function event_say(e)
    local zone = eq.get_zone()

    -- Setting zone buckets
    if e.message:findi("set") then
        zone:SetBucket("example", "1")
        zone:SetBucket("example2", "1")
        zone:SetBucket("example3", "1", "1S")   
    end

    -- Getting zone buckets
    if e.message:findi("get") then
        zone:DeleteBucket("example2")
        e.self:Message(15, "example1 " .. zone:GetBucket("example") .. " (should exist)")
        e.self:Message(15, "example2 " .. zone:GetBucket("example2") .. " (should be deleted)")
        e.self:Message(15, "example3 " .. zone:GetBucket("example3") .. " (should be expired)")
    end
end
```

![image](https://github.com/user-attachments/assets/53974f25-42a4-48a4-b698-a7cf1f105dba)

**SQL Results**

```
mariadb> select * from data_buckets where zone_id = 159 and `key` not like 'test_key%';
+----------+---------+-------+---------+------------+--------------+--------+--------+---------+-------------+
| id       | key     | value | expires | account_id | character_id | npc_id | bot_id | zone_id | instance_id |
+----------+---------+-------+---------+------------+--------------+--------+--------+---------+-------------+
| 41306869 | example | 1     |       0 |          0 |            0 |      0 |      0 |     159 |           0 |
+----------+---------+-------+---------+------------+--------------+--------+--------+---------+-------------+
1 row in set (0.28 sec)
```

Associated server logs

```
   Zone |   Debug    | ChannelMessageReceived Client::ChannelMessageReceived() [Channel:8] [message:set] -- [sseru] (Sanctus Seru) inst_id [0]
  Zone |   Query    | QueryDatabase UPDATE data_buckets SET `key` = 'example', value = '1', expires = 0, account_id = 0, character_id = 0, npc_id = 0, bot_id = 0, zone_id = 159, instance_id = 0 WHERE id = 41306869 -- (1 row affected) (0.000223s)-- [sseru] (Sanctus Seru) inst_id [0]
  Zone |   Query    | QueryDatabase UPDATE data_buckets SET `key` = 'example', value = '1', expires = 0, account_id = 0, character_id = 0, npc_id = 0, bot_id = 0, zone_id = 159, instance_id = 0 WHERE id = 41306869 -- (1 row affected) (0.000052s)-- [sseru] (Sanctus Seru) inst_id [0]
  Zone |   Query    | QueryDatabase UPDATE data_buckets SET `key` = 'example', value = '1', expires = 0, account_id = 0, character_id = 0, npc_id = 0, bot_id = 0, zone_id = 159, instance_id = 0 WHERE id = 41306869 -- (1 row affected) (0.000118s)-- [sseru] (Sanctus Seru) inst_id [0]
  Zone |   Debug    | HandleStuckBehavior Handle stuck behavior for a_Guardian_of_the_Arx006 at (733.75, -1212.25, 63.75) with movement_mode 0 -- [sseru] (Sanctus Seru) inst_id [0]
  Zone |   Debug    | ChannelMessageReceived Client::ChannelMessageReceived() [Channel:8] [message:get] -- [sseru] (Sanctus Seru) inst_id [0]
  Zone | DataBucket | DeleteData Deleting bucket key [example2] bot_id [0] account_id [0] character_id [0] npc_id [0] bot_id [0] zone_id [159] instance_id [0] cache size before [5] after [4] -- [sseru] (Sanctus Seru) inst_id [0]
  Zone |   Query    | QueryDatabase DELETE FROM data_buckets WHERE character_id = 0 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 159 AND instance_id = 0 AND `key` = 'example2' -- (0 rows affected) (0.000345s)-- [sseru] (Sanctus Seru) inst_id [0]
  Zone | DataBucket | GetData Getting bucket key [example] bot_id [0] account_id [0] character_id [0] npc_id [0] zone_id [159] instance_id [0] -- [sseru] (Sanctus Seru) inst_id [0]
  Zone | DataBucket | GetData Returning key [example] value [1] from cache -- [sseru] (Sanctus Seru) inst_id [0]
  Zone | DataBucket | GetData Getting bucket key [example2] bot_id [0] account_id [0] character_id [0] npc_id [0] zone_id [159] instance_id [0] -- [sseru] (Sanctus Seru) inst_id [0]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 0 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 159 AND instance_id = 0 AND `key` = 'example2' LIMIT 1 -- (0 rows returned) (0.000036s)-- [sseru] (Sanctus Seru) inst_id [0]
  Zone | DataBucket | GetData Key [example2] not found in database, adding to cache as a miss account_id [0] character_id [0] npc_id [0] bot_id [0] zone_id [159] instance_id [0] cache size before [4] after [5] -- [sseru] (Sanctus Seru) inst_id [0]
  Zone | DataBucket | GetData Getting bucket key [example3] bot_id [0] account_id [0] character_id [0] npc_id [0] zone_id [159] instance_id [0] -- [sseru] (Sanctus Seru) inst_id [0]
  Zone | DataBucket | GetData Returning key [example3] value [] from cache -- [sseru] (Sanctus Seru) inst_id [0]
```

**Zone Cache Load (Zone Boot)**

```
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE zone_id = 159 AND instance_id = 0 AND (`expires` > 1739759173 OR `expires` = 0) -- (1 row returned) (0.279438s)-- [sseru] (Sanctus Seru) inst_id [0]
  Zone | DataBucket | LoadZoneCache cache size before [0] l size [1] -- [sseru] (Sanctus Seru) inst_id [0]
  Zone | DataBucket | LoadZoneCache bucket id [41306869] bucket key [example] bucket value [1] -- [sseru] (Sanctus Seru) inst_id [0]
  Zone | DataBucket | LoadZoneCache cache size after [1] -- [sseru] (Sanctus Seru) inst_id [0]
  Zone | DataBucket | LoadZoneCache Loaded [1] zone keys new cache size is [1] -- [sseru] (Sanctus Seru) inst_id [0]
```

**Zone Cache Delete (Shutdown)**

```
  Zone |    Info    | HandleMessage Zone shutdown by Akka. -- [sseru] (Sanctus Seru) inst_id [0]
  Zone | DataBucket | DeleteCachedBuckets LoadType [Zone] id [159] cache size before [3] after [2] -- [sseru] (Sanctus Seru) inst_id [0]
```

**Instance Testing**

```perl
sub EVENT_SAY {
   
    if ($text=~/instance/i) {
        my $instance_id = quest::CreateInstance("halas", 0, 30000000);
        $client->AssignToInstance($instance_id);
        $client->MovePCInstance(29, $instance_id, 0, 0, 0, 0);
    }

    if ($text=~/destroy/i) {
        quest::DestroyInstance($client->GetInstanceID());
    }

    # set 3 variations
    if ($text=~/set/i) {
        $zone->SetBucket("example", "1");
        $zone->SetBucket("example2", "1");
        $zone->SetBucket("example3", "1", "1S");   
    }

    # one expires, we delete the second, the first should be the only one to return a value
    if ($text=~/get/i) {
        $zone->DeleteBucket("example2");
        $client->Message(15, "example1 " . $zone->GetBucket("example"));
        $client->Message(15, "example2 " . $zone->GetBucket("example2") . " (Should be deleted)");
        $client->Message(15, "example3 " . $zone->GetBucket("example3") . " (Should be expired)");
    }
}
```

![image](https://github.com/user-attachments/assets/7b4b330e-f196-4093-8dbf-ed0f51b35cb8)

```
mariadb> select * from data_buckets where zone_id = 29 and `key` not like 'test_key%';
+----------+---------+-------+---------+------------+--------------+--------+--------+---------+-------------+
| id       | key     | value | expires | account_id | character_id | npc_id | bot_id | zone_id | instance_id |
+----------+---------+-------+---------+------------+--------------+--------+--------+---------+-------------+
| 42416855 | example | 1     |       0 |          0 |            0 |      0 |      0 |      29 |         111 |
+----------+---------+-------+---------+------------+--------------+--------+--------+---------+-------------+
1 row in set (0.00 sec)
```

After destroy

```
mariadb> select * from data_buckets where zone_id = 29 and `key` not like 'test_key%';
Empty set
```

**Performance Benchmarks**

Also wrote benchmarks command `./bin/zone benchmark:databuckets` that helped me understand the impact of continually adding and overloading keys to the table. There is virtually no overhead as long as the indexes are covered properly.

https://gist.github.com/Akkadius/5da8c70c4c280df467ea1ac06e0748e9#file-result-6-md

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
- [x] If my changes make database schema changes, I have tested the changes on a local database (attach image). Updated version.h CURRENT_BINARY_DATABASE_VERSION to the new version. (Delete this if not applicable)
