### PR TITLE
[Quest API] Add DisableRespawnTimers to Perl and Lua

### DIFF
--- a/zone/lua_zone.cpp
+++ b/zone/lua_zone.cpp
@@ -67,6 +67,12 @@ void Lua_Zone::Despawn(uint32 spawngroup_id)
 	self->Despawn(spawngroup_id);
 }
 
+void Lua_Zone:DisableRespawnTimers()
+{
+	Lua_Safe_Call_Void();
+	self->DisableRespawnTimers();
+}
+
 float Lua_Zone::GetAAEXPModifier(Lua_Client c)
 {
 	Lua_Safe_Call_Real();
@@ -735,6 +741,7 @@ luabind::scope lua_register_zone() {
 	.def("Depop", (void(Lua_Zone::*)(void))&Lua_Zone::Depop)
 	.def("Depop", (void(Lua_Zone::*)(bool))&Lua_Zone::Depop)
 	.def("Despawn", &Lua_Zone::Despawn)
+	.def("DisableRespawnTimers", &Lua_Zone::DisableRespawnTimers)
 	.def("GetAAEXPModifier", &Lua_Zone::GetAAEXPModifier)
 	.def("GetAAEXPModifierByCharacterID", &Lua_Zone::GetAAEXPModifierByCharacterID)
 	.def("GetBucket", (std::string(Lua_Zone::*)(const std::string&))&Lua_Zone::GetBucket)

--- a/zone/lua_zone.cpp
+++ b/zone/lua_zone.cpp
@@ -67,7 +67,7 @@ void Lua_Zone::Despawn(uint32 spawngroup_id)
 	self->Despawn(spawngroup_id);
 }
 
-void Lua_Zone:DisableRespawnTimers()
+void Lua_Zone::DisableRespawnTimers()
 {
 	Lua_Safe_Call_Void();
 	self->DisableRespawnTimers();

--- a/zone/lua_zone.h
+++ b/zone/lua_zone.h
@@ -37,6 +37,7 @@ public:
 	void Depop();
 	void Depop(bool start_spawn_timers);
 	void Despawn(uint32 spawngroup_id);
+	void DisableRespawnTimers();
 	float GetAAEXPModifier(Lua_Client c);
 	float GetAAEXPModifierByCharacterID(uint32 character_id);
 	std::string GetContentFlags();

--- a/zone/perl_zone.cpp
+++ b/zone/perl_zone.cpp
@@ -56,6 +56,11 @@ void Perl_Zone_Despawn(Zone* self, uint32 spawngroup_id)
 	self->Despawn(spawngroup_id);
 }
 
+void Perl_Zone_DisableRespawnTimers(Zone* self)
+{
+	self->DisableRespawnTimers();
+}
+
 float Perl_Zone_GetAAEXPModifier(Zone* self, Client* c)
 {
 	return self->GetAAEXPModifier(c);
@@ -572,6 +577,7 @@ void perl_register_zone()
 	package.add("Depop", (void(*)(Zone*))&Perl_Zone_Depop);
 	package.add("Depop", (void(*)(Zone*, bool))&Perl_Zone_Depop);
 	package.add("Despawn", &Perl_Zone_Despawn);
+	package.add("DisableRespawnTimers", &Perl_Zone_DisableRespawnTimers);
 	package.add("GetAAEXPModifier", &Perl_Zone_GetAAEXPModifier);
 	package.add("GetAAEXPModifierByCharacterID", &Perl_Zone_GetAAEXPModifierByCharacterID);
 	package.add("GetBucket", &Perl_Zone_GetBucket);

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -3190,4 +3190,16 @@ std::string Zone::GetBucketRemaining(const std::string& bucket_name)
 	return DataBucket::GetDataRemaining(k);
 }
 
+void Zone::DisableRespawnTimers()
+{
+	LinkedListIterator<Spawn2*> e(spawn2_list);
+
+	e.Reset();
+
+	while (e.MoreElements()) {
+		e.GetData()->Disable();
+		e.Advance();
+	}
+}
+
 #include "zone_loot.cpp"

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -3197,7 +3197,7 @@ void Zone::DisableRespawnTimers()
 	e.Reset();
 
 	while (e.MoreElements()) {
-		e.GetData()->Disable();
+		e.GetData()->SetRespawnTimer(std::numeric_limits<uint32_t>::max());
 		e.Advance();
 	}
 }

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -154,6 +154,7 @@ public:
 	bool Process();
 	bool SaveZoneCFG();
 	bool DoesAlternateCurrencyExist(uint32 currency_id);
+	void DisableRespawnTimers();
 
 	char *adv_data;
 


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue (Why is this change necessary). Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing

```perl
sub EVENT_SAY {
    if ($text=~/test/i) {
       $zone->DisableRespawnTimers();
    }

    if ($text=~/verify/i) {
        foreach my $e ($entity_list->GetSpawnList()) {
            $client->Message(15, "Respawn timer " . $e->GetRespawnTimer());
        }
    }
}
```

![image](https://github.com/user-attachments/assets/0dee16f9-a135-401d-ba90-6b225ad7e149)


# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur