### PR TITLE
[Fix] Fix issue with getting an unset nested databucket

### DIFF
--- a/zone/data_bucket.cpp
+++ b/zone/data_bucket.cpp
@@ -212,7 +212,7 @@ DataBucketsRepository::DataBuckets DataBucket::GetData(const DataBucketKey &k_, 
 
 				LogDataBuckets("Returning key [{}] value [{}] from cache", e.key_, e.value);
 
-				if (is_nested_key) {
+				if (is_nested_key && !k_.key.empty()) {
 					return ExtractNestedValue(e, k_.key);
 				}
 
@@ -292,7 +292,7 @@ DataBucketsRepository::DataBuckets DataBucket::GetData(const DataBucketKey &k_, 
 	}
 
 	// Handle nested key extraction
-	if (is_nested_key) {
+	if (is_nested_key && !k_.key.empty()) {
 		return ExtractNestedValue(bucket, k_.key);
 	}
 


### PR DESCRIPTION
# Description

Fixes an issue with getting a nested databucket that is initially unset

Original reported error

![image](https://github.com/user-attachments/assets/6c6845c8-14b1-4b06-81d6-4430ff65b064)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Have not been able to reproduce

# Checklist

- [ ] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
