### PR TITLE
[Fix] #rq and #reload quest alias

### DIFF
--- a/common/server_reload_types.h
+++ b/common/server_reload_types.h
@@ -67,7 +67,7 @@ namespace ServerReload {
 		"Objects",
 		"Opcodes",
 		"Perl Event Export Settings",
-		"Quests",
+		"Quest",
 		"Quests With Timer (Resets timer events)",
 		"Rules",
 		"Skill Caps",

--- a/zone/gm_commands/reload.cpp
+++ b/zone/gm_commands/reload.cpp
@@ -1,3 +1,11 @@
+#include <string>
+#include "../client.h"
+#include "../../common/strings.h"
+#include "../../common/server_reload_types.h"
+#include "../worldserver.h"
+
+extern WorldServer worldserver;
+
 void command_reload(Client *c, const Seperator *sep)
 {
 	std::string command   = sep->arg[0] ? sep->arg[0] : "";


### PR DESCRIPTION
# Description

This is a follow up minor-regression to https://github.com/EQEmu/Server/pull/4689 where #rq does not fire because the commands are getting mapped to `#reload quests` (plural) from the automatic slugging. This fixes it to be `#reload quest` and the `#rq` alias redirects properly as well.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

![image](https://github.com/user-attachments/assets/224e38fb-2a07-409b-8624-90de8036d227)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
