### PR TITLE
[Fix] Fix non-error in player_event_logs

### DIFF
--- a/common/events/player_event_logs.cpp
+++ b/common/events/player_event_logs.cpp
@@ -402,7 +402,7 @@ void PlayerEventLogs::ProcessBatchQueue()
 				r.event_data = "{}"; // Clear event data
 			}
 			else {
-				LogError("Non-Implemented ETL routing [{}]", r.event_type_id);
+				LogPlayerEventsDetail("Non-Implemented ETL routing [{}]", r.event_type_id);
 			}
 		}
 	}


### PR DESCRIPTION
# Description

This fixes an issue where we were emitting a non-actionable error about an unimplemented ETL type. This should be more along the lines of player event debug logging.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

No testing done (not really needed)

# Checklist

- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
