### PR TITLE
[Fix] Prevent zone from loading ETL ID's on bootup

### DIFF
--- a/common/events/player_event_logs.cpp
+++ b/common/events/player_event_logs.cpp
@@ -81,14 +81,13 @@ void PlayerEventLogs::Init()
 	if (!settings_to_insert.empty()) {
 		PlayerEventLogSettingsRepository::ReplaceMany(*m_database, settings_to_insert);
 	}
-
-	LoadEtlIds();
-
+	
 	bool processing_in_world = !RuleB(Logging, PlayerEventsQSProcess) && IsWorld();
 	bool processing_in_qs    = RuleB(Logging, PlayerEventsQSProcess) && IsQueryServ();
 
 	// on initial boot process truncation
 	if (processing_in_world || processing_in_qs) {
+		LoadEtlIds();
 		ProcessRetentionTruncation();
 	}
 }


### PR DESCRIPTION
# Description

This fixes a minor issue as a result of https://github.com/EQEmu/Server/pull/4542 that is loading ETL ID's for zones during player event logging initialization. ETL ID's should only be loading for the events ingester processor (either world or queryserv)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

No testing

# Checklist

- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur