### PR TITLE
[Client Mod] Adds a hacked fast camp rule for GMs.

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -230,6 +230,7 @@ RULE_BOOL(Character, PlayerTradingLoreFeedback, true, "If enabled, during a play
 RULE_INT(Character, MendAlwaysSucceedValue, 199, "Value at which mend will always succeed its skill check. Default: 199")
 RULE_BOOL(Character, SneakAlwaysSucceedOver100, false, "When sneak skill is over 100, always succeed sneak/hide. Default: false")
 RULE_INT(Character, BandolierSwapDelay, 0, "Bandolier swap delay in milliseconds, default is 0")
+RULE_BOOL(Character, EnableHackedFastCampForGM, false, "Enables hacked fast camp for GM clients, if the GM doesn't have a hacked client they'll camp like normal")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Mercs)

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -4251,7 +4251,14 @@ void Client::Handle_OP_Camp(const EQApplicationPacket *app)
 
 	if (GetGM())
 	{
-		OnDisconnect(true);
+		if (RuleB(Character, EnableHackedFastCampForGM))
+		{
+			camp_timer.Start(100, true);
+		}
+		else {
+			OnDisconnect(true);
+		}
+		
 		return;
 	}
 


### PR DESCRIPTION
# Description

Adds a rule that disables the GM "disconnect" on /camp.  This allows you to use a hacked client either through injection or actually modifying the eqgame.exe.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing

Tested locally with a hacked client, it should also be testable on a normal client in which case it would take the full 30s to logout on a GM.

Clients tested: RoF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
