### PR TITLE
[Fix] Player event ordering merge fix

### DIFF
--- a/common/events/player_events.h
+++ b/common/events/player_events.h
@@ -132,8 +132,7 @@ namespace PlayerEvent {
 		"Parcel Prune Routine",
 		"Barter Transaction",
 		"Player Speech",
-		"Evolve Item Update"
-		"Barter Transaction",
+		"Evolve Item Update",
 		"Guild Bank Item Deposit",
 		"Guild Bank Item Withdrawal",
 		"Guild Bank Move From Deposit Area to Bank Area"


### PR DESCRIPTION
# Description

This is a small regression from a poor merge. This fixes the player event constants to line up properly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

No testing

# Checklist

- [ ] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
