### PR TITLE
[Bug Fix] Fix Lua Zone ID Exports

### DIFF
--- a/zone/lua_zone.cpp
+++ b/zone/lua_zone.cpp
@@ -728,7 +728,7 @@ std::string Lua_Zone::GetBucketRemaining(const std::string& bucket_name)
 }
 
 luabind::scope lua_register_zone() {
-	return luabind::class_<Lua_Zone>("Zone")
+	return luabind::class_<Lua_Zone>("Zones")
 	.def(luabind::constructor<>())
 	.def("BuffTimersSuspended", &Lua_Zone::BuffTimersSuspended)
 	.def("BypassesExpansionCheck", &Lua_Zone::BypassesExpansionCheck)


### PR DESCRIPTION
# Description
- Fixes an issue where zone IDs were exported under the `Zone` class and so were zone methods, causing them to conflict.
- I resolved this by changed the zone methods to use `Zones` so we do not break any existing scripts using these constants.

## Type of change
- [X] Bug fix

# Testing
## Image
![image](https://github.com/user-attachments/assets/ff6ff97e-3797-4155-8704-d6d0d72a46e0)
## Example Script
```lua
function event_say(e)
	if e.message:findi("hail") then
		e.other:Message(MT.Yellow, "Attempting to send zone ID")
		e.other:Message(MT.Yellow, tostring(Zone.qeynos))
		e.other:Message(MT.Yellow, "Attempted to send zone ID")
	end
end
```

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur