### PR TITLE
[Quest API] Add GetSpawn() to Perl and Lua

### DIFF
--- a/zone/lua_npc.cpp
+++ b/zone/lua_npc.cpp
@@ -9,6 +9,7 @@
 #include "lua_client.h"
 #include "lua_item.h"
 #include "lua_iteminst.h"
+#include "lua_spawn.h"
 
 struct Lua_NPC_Loot_List {
 	std::vector<uint32> entries;
@@ -932,6 +933,12 @@ void Lua_NPC::ReturnHandinItems(Lua_Client c)
 	self->ReturnHandinItems(c);
 }
 
+Lua_Spawn Lua_NPC::GetSpawn(lua_State* L)
+{
+	Lua_Safe_Call_Class(Lua_Spawn);
+	return Lua_Spawn(self->GetSpawn());
+}
+
 luabind::scope lua_register_npc() {
 	return luabind::class_<Lua_NPC, Lua_Mob>("NPC")
 	.def(luabind::constructor<>())
@@ -1009,6 +1016,7 @@ luabind::scope lua_register_npc() {
 	.def("GetSilver", (uint32(Lua_NPC::*)(void))&Lua_NPC::GetSilver)
 	.def("GetSlowMitigation", (int(Lua_NPC::*)(void))&Lua_NPC::GetSlowMitigation)
 	.def("GetSp2", (uint32(Lua_NPC::*)(void))&Lua_NPC::GetSp2)
+	.def("GetSpawn", (Lua_Spawn(Lua_NPC::*)(void))&Lua_NPC::GetSpawn)
 	.def("GetSpawnKillCount", (int(Lua_NPC::*)(void))&Lua_NPC::GetSpawnKillCount)
 	.def("GetSpawnPointH", (float(Lua_NPC::*)(void))&Lua_NPC::GetSpawnPointH)
 	.def("GetSpawnPointID", (int(Lua_NPC::*)(void))&Lua_NPC::GetSpawnPointID)

--- a/zone/lua_npc.h
+++ b/zone/lua_npc.h
@@ -10,6 +10,7 @@ class Lua_NPC;
 class Lua_Client;
 struct Lua_NPC_Loot_List;
 class Lua_Inventory;
+class Lua_Spawn;
 
 namespace luabind {
 	struct scope;
@@ -196,6 +197,7 @@ public:
 		luabind::adl::object items_table
 	);
 	void ReturnHandinItems(Lua_Client c);
+	Lua_Spawn GetSpawn(lua_State* L);
 };
 
 #endif

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -4905,24 +4905,3 @@ void NPC::ResetMultiQuest() {
 
 	m_hand_in = {};
 }
-
-Spawn2* NPC::GetSpawn()
-{
-	if (!zone || !zone->IsLoaded()) {
-		return nullptr;
-	}
-
-	LinkedListIterator<Spawn2*> iterator(zone->spawn2_list);
-
-	iterator.Reset();
-
-	while (iterator.MoreElements()) {
-		if (iterator.GetData()->GetID() == GetSpawnPointID()) {
-			return iterator.GetData();
-		}
-
-		iterator.Advance();
-	}
-
-	return nullptr;
-}

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -2751,10 +2751,7 @@ void NPC::LevelScale() {
 
 uint32 NPC::GetSpawnPointID() const
 {
-	if (respawn2) {
-		return respawn2->GetID();
-	}
-	return 0;
+	return respawn2 ? respawn2->GetID() : 0;
 }
 
 void NPC::NPCSlotTexture(uint8 slot, uint32 texture)
@@ -4907,4 +4904,25 @@ void NPC::ResetMultiQuest() {
 	}
 
 	m_hand_in = {};
+}
+
+Spawn2* NPC::GetSpawn()
+{
+	if (!zone || !zone->IsLoaded()) {
+		return nullptr;
+	}
+
+	LinkedListIterator<Spawn2*> iterator(zone->spawn2_list);
+
+	iterator.Reset();
+
+	while (iterator.MoreElements()) {
+		if (iterator.GetData()->GetID() == GetSpawnPointID()) {
+			return iterator.GetData();
+		}
+
+		iterator.Advance();
+	}
+
+	return nullptr;
 }

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -248,7 +248,7 @@ public:
 
 	uint16 GetWaypointMax() const { return wp_m; }
 	int32 GetGrid() const { return grid; }
-	Spawn2* GetSpawn();
+	Spawn2* GetSpawn() { return respawn2 ? respawn2 : nullptr; };
 	uint32 GetSpawnGroupId() const { return spawn_group_id; }
 	uint32 GetSpawnPointID() const;
 

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -248,7 +248,7 @@ public:
 
 	uint16 GetWaypointMax() const { return wp_m; }
 	int32 GetGrid() const { return grid; }
-	Spawn2* GetSpawn() { return respawn2 ? respawn2 : nullptr; };
+	Spawn2* GetSpawn() { return respawn2 ? respawn2 : nullptr; }
 	uint32 GetSpawnGroupId() const { return spawn_group_id; }
 	uint32 GetSpawnPointID() const;
 

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -248,6 +248,7 @@ public:
 
 	uint16 GetWaypointMax() const { return wp_m; }
 	int32 GetGrid() const { return grid; }
+	Spawn2* GetSpawn();
 	uint32 GetSpawnGroupId() const { return spawn_group_id; }
 	uint32 GetSpawnPointID() const;
 

--- a/zone/perl_npc.cpp
+++ b/zone/perl_npc.cpp
@@ -875,6 +875,11 @@ void Perl_NPC_ReturnHandinItems(NPC *self, Client* c)
 	self->ReturnHandinItems(c);
 }
 
+Spawn2* Perl_NPC_GetSpawn(NPC* self)
+{
+	return self->GetSpawn();
+}
+
 void perl_register_npc()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -953,6 +958,7 @@ void perl_register_npc()
 	package.add("GetSilver", &Perl_NPC_GetSilver);
 	package.add("GetSlowMitigation", &Perl_NPC_GetSlowMitigation);
 	package.add("GetSp2", &Perl_NPC_GetSp2);
+	package.add("GetSpawn", &Perl_NPC_GetSpawn);
 	package.add("GetSpawnKillCount", &Perl_NPC_GetSpawnKillCount);
 	package.add("GetSpawnPointH", &Perl_NPC_GetSpawnPointH);
 	package.add("GetSpawnPointID", &Perl_NPC_GetSpawnPointID);


### PR DESCRIPTION
# Description
- Adds a direct NPC method for grabbing the NPC's spawn reference.

## Perl
- Add `$npc->GetSpawn()`
### Image
![image](https://github.com/user-attachments/assets/dcfc8515-b031-4fd5-a449-15fab60e7dab)
### Example
```pl
sub EVENT_SAY {
    if ($text=~/Hail/i) {
        my $spawn = $npc->GetSpawn();
        my $npc_id = $spawn->GetCurrentNPCID();
        quest::message(315, "[Perl] Spawn NPC ID: $npc_id");
    }
}
```
## Lua
- Add `npc:GetSpawn()`
### Image
![image](https://github.com/user-attachments/assets/fc008ceb-b422-4792-bbc8-679c2678c7db)
### Example
```lua
function event_say(e)
    if e.message:findi("hail") then
        local spawn = e.self:GetSpawn()
        local npc_id = spawn:CurrentNPCID()
        eq.message(
            MT.Chat1Echo,
            string.format(
                "[Lua] Spawn NPC ID: %d",
                npc_id
            )
        )
    end
end
```

## Type of change
- [X] New feature

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur