### PR TITLE
Fix infinite loop in mob:StopTimer().

### DIFF
--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -680,7 +680,7 @@ void QuestManager::stoptimer(const std::string& timer_name, Mob* m)
 		return;
 	}
 
-	for (auto e = QTimerList.begin(); e != QTimerList.end();) {
+	for (auto e = QTimerList.begin(); e != QTimerList.end(); ++e) {
 		if (e->mob && e->mob == m) {
 			parse->EventMob(EVENT_TIMER_STOP, m, nullptr, [&]() { return timer_name; });
 


### PR DESCRIPTION
Stumbled across this one when I had a zone spin up to 100% and lock up when I was writing content.
