### PR TITLE
[Tasks] Extend IsTaskCompleted to also be aware of shared task completion

### DIFF
--- a/zone/client.h
+++ b/zone/client.h
@@ -75,6 +75,7 @@ namespace EQ
 #include "../common/repositories/character_evolving_items_repository.h"
 
 #include "bot_structs.h"
+#include "../common/repositories/completed_shared_tasks_repository.h"
 
 #ifdef _WINDOWS
 	// since windows defines these within windef.h (which windows.h include)
@@ -1289,6 +1290,19 @@ public:
 	void SendSpellTypePrompts(bool commanded_types = false, bool client_only_types = false);
 
 	// Task System Methods
+	inline void LoadClientSharedCompletedTasks()
+	{
+		m_completed_shared_tasks = CompletedSharedTasksRepository::GetWhere(
+			database,
+			fmt::format(
+				"character_id = {} GROUP BY task_id",
+				CharacterID()
+			)
+		);
+	};
+	inline std::vector<CompletedSharedTasksRepository::CompletedSharedTasks> GetCompletedSharedTasks() const {
+		return m_completed_shared_tasks;
+	};
 	void LoadClientTaskState();
 	void RemoveClientTaskState();
 	void SendTaskActivityComplete(int task_id, int activity_id, int task_index, TaskType task_type, int task_incomplete=1);
@@ -1459,7 +1473,10 @@ public:
 	{
 		return (task_state ? task_state->EnabledTaskCount(task_set_id) : -1);
 	}
-	inline bool IsTaskCompleted(int task_id) { return (task_state ? task_state->IsTaskCompleted(task_id) : false); }
+	inline bool IsTaskCompleted(int task_id)
+	{
+		return (task_state ? task_state->IsTaskCompleted(task_id, this) : false);
+	}
 	inline bool AreTasksCompleted(std::vector<int> task_ids)
 	{
 		return (task_state ? task_state->AreTasksCompleted(task_ids) : false);
@@ -2289,6 +2306,8 @@ private:
 	glm::vec3 m_quest_compass;
 	bool m_has_quest_compass = false;
 	std::vector<uint32_t> m_dynamic_zone_ids;
+
+	std::vector<CompletedSharedTasksRepository::CompletedSharedTasks> m_completed_shared_tasks;
 
 public:
 	enum BotOwnerOption : size_t {

--- a/zone/client.h
+++ b/zone/client.h
@@ -1293,7 +1293,7 @@ public:
 	{
 		std::string query = fmt::format(R"(
 			SELECT
-			cst.task_id,
+			cst.task_id
 			FROM completed_shared_task_members cstm
 			JOIN completed_shared_tasks cst ON cstm.shared_task_id = cst.id
 			WHERE cstm.character_id = {}

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -1578,7 +1578,7 @@ bool ClientTaskState::IsTaskCompleted(int task_id, Client *c)
 
 	if (c) {
 		for (auto &e: c->GetCompletedSharedTasks()) {
-			if (e.task_id == task_id) {
+			if (e == task_id) {
 				return true;
 			}
 		}

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -952,6 +952,8 @@ int ClientTaskState::IncrementDoneCount(
 
 				client->CancelTask(task_index, task_data->type);
 			}
+
+			client->LoadClientSharedCompletedTasks();
 		}
 	}
 	else {
@@ -1561,7 +1563,7 @@ int ClientTaskState::TaskTimeLeft(int task_id)
 	return -1;
 }
 
-bool ClientTaskState::IsTaskCompleted(int task_id)
+bool ClientTaskState::IsTaskCompleted(int task_id, Client *c)
 {
 	if (!RuleB(TaskSystem, RecordCompletedTasks)) {
 		return false;
@@ -1571,6 +1573,14 @@ bool ClientTaskState::IsTaskCompleted(int task_id)
 		LogTasks("Comparing completed task [{}] with [{}]", e.task_id, task_id);
 		if (e.task_id == task_id) {
 			return true;
+		}
+	}
+
+	if (c) {
+		for (auto &e: c->GetCompletedSharedTasks()) {
+			if (e.task_id == task_id) {
+				return true;
+			}
 		}
 	}
 

--- a/zone/task_client_state.h
+++ b/zone/task_client_state.h
@@ -45,7 +45,7 @@ public:
 	void AcceptNewTask(Client *client, int task_id, int npc_type_id, time_t accept_time, bool enforce_level_requirement = false);
 	void FailTask(Client *client, int task_id);
 	int TaskTimeLeft(int task_id);
-	bool IsTaskCompleted(int task_id);
+	bool IsTaskCompleted(int task_id, Client *c = nullptr);
 	bool AreTasksCompleted(const std::vector<int>& task_ids);
 	bool IsTaskActive(int task_id);
 	bool IsTaskActivityActive(int task_id, int activity_id);

--- a/zone/tasks.cpp
+++ b/zone/tasks.cpp
@@ -15,8 +15,9 @@ extern QueryServ *QServ;
 void Client::LoadClientTaskState()
 {
 	if (RuleB(TaskSystem, EnableTaskSystem) && task_manager) {
-		safe_delete(task_state);
+		LoadClientSharedCompletedTasks();
 
+		safe_delete(task_state);
 		task_state = new ClientTaskState();
 		if (!task_manager->LoadClientState(this, task_state)) {
 			safe_delete(task_state);


### PR DESCRIPTION
# Description

This PR extends IsTaskCompleted (And quest calls) to be aware of completed shared tasks.

This is pre-requisite to some Depths of Darkhollow work @fryguy503 is doing.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing

I need Trust to test the following -

- [x] Test IsTaskCompleted returning true for a shared task
- [x] Test IsTaskCompleted returns true immediately after shared task completion (race condition checking)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

