### PR TITLE
[Feature] Add a rule for spells to bypass stacking rules

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -528,6 +528,7 @@ RULE_INT(Spells, TargetedAOEMaxTargets, 4, "Max number of targets a Targeted AOE
 RULE_INT(Spells, PointBlankAOEMaxTargets, 0, "Max number of targets a Point-Blank AOE spell can cast on. Set to 0 for no limit.")
 RULE_INT(Spells, DefaultAOEMaxTargets, 0, "Max number of targets that an AOE spell which does not meet other descriptions can cast on. Set to 0 for no limit.")
 RULE_BOOL(Spells, AllowFocusOnSkillDamageSpells, false, "Allow focus effects 185, 459, and 482 to enhance SkillAttack spell effect 193")
+RULE_STRING(Spells, AlwaysStackSpells, "", "Comma-Seperated list of spell IDs to always stack with every other spell, except themselves.")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Combat)

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3135,13 +3135,13 @@ int Mob::CheckStackConflict(uint16 spellid1, int caster_level1, uint16 spellid2,
 		}
 	}
 
-	const std::string& always_stack_str = RuleS(Spells, AlwaysStackSpells);
-	if (spellid1 != spellid2 && !always_stack_str.empty()) {
-		const auto& v = Strings::Split(always_stack_str, ",");
-		if (std::find(v.begin(), v.end(), std::to_string(spellid1)) != v.end()) {
+	const std::string& always_stack_spells = RuleS(Spells, AlwaysStackSpells);
+	if (spellid1 != spellid2 && !always_stack_spells.empty()) {
+		const auto& v = Strings::Split(always_stack_spells, ",");
+		if (Strings::Contains(v, std::to_string(spellid1))) {
 			return 0;
 		}
-		if (std::find(v.begin(), v.end(), std::to_string(spellid2)) != v.end()) {
+		if (Strings::Contains(v, std::to_string(spellid2))) {
 			return 0;
 		}
 	}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3135,6 +3135,17 @@ int Mob::CheckStackConflict(uint16 spellid1, int caster_level1, uint16 spellid2,
 		}
 	}
 
+	const std::string& always_stack_str = RuleS(Spells, AlwaysStackSpells);
+	if (spellid1 != spellid2 && !always_stack_str.empty()) {
+		const auto& v = Strings::Split(always_stack_str, ",");
+		if (std::find(v.begin(), v.end(), std::to_string(spellid1)) != v.end()) {
+			return 0;
+		}
+		if (std::find(v.begin(), v.end(), std::to_string(spellid2)) != v.end()) {
+			return 0;
+		}
+	}
+
 	/*
 	One of these is a bard song and one isn't and they're both beneficial so they should stack.
 	*/


### PR DESCRIPTION
# Description

Adds `Spells:AlwaysStackSpells` to allow for a comma-separated list of SpellIDs which will always stack with every other spell, excluding themselves. 

- [X] New feature (non-breaking change which adds functionality)

# Testing
Case 1:
 -> Added 3467 (Virtue) to list, along with 3 other arbitrary IDs
 -> Cast Temperance (3692) and Virtue.
 -> Observed stacking.
 -> Tested each cast order of these two spells
 -> Cast Aegolism (1447)
 -> Observe stacks with Virtue, overwrites Temperance

Case 2:
 -> Added 3467 (Virtue) to list, along with 3 other arbitrary ID 
 -> Cast Protection of Cabbage, then Virtue
 -> Observe stacking
 -> Removed Virtue, Removed 3467 from rule list
 -> Cast Virtue, observed no stack.

Clients tested: 
ROF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
