### PR TITLE
[Quest API] Implement eq.handin() and quest::handin()

### DIFF
--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -5973,6 +5973,28 @@ void Perl__SpawnGrid(uint32 npc_id, float x, float y, float z, float heading, fl
 	quest_manager.SpawnGrid(npc_id, glm::vec4(x, y, z, heading), spacing, spawn_count);
 }
 
+bool Perl__handin(perl::reference handin_ref)
+{
+	perl::hash handin = handin_ref;
+
+	std::map<std::string, uint32> handin_map;
+
+	for (auto e: handin) {
+		if (!e.first) {
+			continue;
+		}
+
+		if (Strings::EqualFold(e.first, "0")) {
+			continue;
+		}
+
+		const uint32 count = static_cast<uint32>(handin.at(e.first));
+		handin_map[e.first] = count;
+	}
+
+	return quest_manager.handin(handin_map);
+}
+
 void perl_register_quest()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -6698,6 +6720,7 @@ void perl_register_quest()
 	package.add("gmsay", (void(*)(const char*, int, bool))&Perl__gmsay);
 	package.add("gmsay", (void(*)(const char*, int, bool, int))&Perl__gmsay);
 	package.add("gmsay", (void(*)(const char*, int, bool, int, int))&Perl__gmsay);
+	package.add("handin", &Perl__handin);
 	package.add("has_zone_flag", &Perl__has_zone_flag);
 	package.add("hasrecipelearned", &Perl__hasrecipelearned);
 	package.add("hastimer", &Perl__hastimer);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -5642,6 +5642,31 @@ Lua_Zone lua_get_zone()
 	return Lua_Zone(zone);
 }
 
+bool lua_handin(luabind::adl::object handin_table)
+{
+	std::map<std::string, uint32> handin_map;
+
+	for (luabind::iterator i(handin_table), end; i != end; i++) {
+		std::string key;
+		if (luabind::type(i.key()) == LUA_TSTRING) {
+			key = luabind::object_cast<std::string>(i.key());
+		}
+		else if (luabind::type(i.key()) == LUA_TNUMBER) {
+			key = fmt::format("{}", luabind::object_cast<int>(i.key()));
+		}
+		else {
+			LogError("Handin key type [{}] not supported", luabind::type(i.key()));
+		}
+
+		if (!key.empty()) {
+			handin_map[key] = luabind::object_cast<uint32>(handin_table[i.key()]);
+			LogNpcHandinDetail("Handin key [{}] value [{}]", key, handin_map[key]);
+		}
+	}
+
+	return quest_manager.handin(handin_map);
+}
+
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
 	cur = table[#name]; \
 	if(luabind::type(cur) != LUA_TNIL) { \
@@ -6450,6 +6475,7 @@ luabind::scope lua_register_general() {
 		luabind::def("spawn_circle", &lua_spawn_circle),
 		luabind::def("spawn_grid", &lua_spawn_grid),
 		luabind::def("get_zone", &lua_get_zone),
+		luabind::def("handin", &lua_handin),
 		/*
 			Cross Zone
 		*/

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -4351,6 +4351,10 @@ bool NPC::CheckHandin(
 		h = m_hand_in;
 	}
 
+	if (IsMultiQuestEnabled()) {
+		LogNpcHandin("{} Multi-Quest hand-in enabled", log_handin_prefix);
+	}
+
 	std::vector<std::pair<const std::map<std::string, uint32>&, Handin&>> datasets = {};
 
 	// if we've already started the hand-in process, we don't want to re-process the hand-in data
@@ -4432,7 +4436,7 @@ bool NPC::CheckHandin(
 
 	// multi-quest
 	if (IsMultiQuestEnabled()) {
-		for (auto &h_item: h.items) {
+		for (auto &h_item: m_hand_in.items) {
 			for (const auto &r_item: r.items) {
 				if (h_item.item_id == r_item.item_id && h_item.count == r_item.count) {
 					h_item.is_multiquest_item = true;
@@ -4777,7 +4781,11 @@ NPC::Handin NPC::ReturnHandinItems(Client *c)
 					}
 
 					c->PushItemOnCursor(*i.item, true);
-					LogNpcHandin("Hand-in failed, returning item [{}]", i.item->GetItem()->Name);
+					LogNpcHandin(
+						"Hand-in failed, returning item [{}] i.is_multiquest_item [{}]",
+						i.item->GetItem()->Name,
+						i.is_multiquest_item
+					);
 
 					returned_handin = true;
 					return true; // Mark this item for removal

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -4606,3 +4606,18 @@ void QuestManager::SpawnGrid(uint32 npc_id, glm::vec4 position, float spacing, u
 		}
 	}
 }
+
+bool QuestManager::handin(std::map<std::string, uint32> required) {
+	QuestManagerCurrentQuestVars();
+	if (!owner || !initiator) {
+		LogQuests("QuestManager::handin called with nullptr owner. Probably syntax error in quest file");
+		return false;
+	}
+
+	if (owner && !owner->IsNPC()) {
+		LogQuests("QuestManager::handin called with non-NPC owner. Probably syntax error in quest file");
+		return false;
+	}
+
+	return owner->CastToNPC()->CheckHandin(initiator, {}, required, {});
+}

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -376,6 +376,7 @@ public:
 	bool botquest();
 	bool createBot(const char *name, const char *lastname, uint8 level, uint16 race, uint8 botclass, uint8 gender);
 
+	bool handin(std::map<std::string, uint32> required);
 
 private:
 	std::stack<running_quest> quests_running_;


### PR DESCRIPTION
# Description

This PR polishes off the https://github.com/EQEmu/Server/pull/4593 arc by giving source-native dead-simple Quest API calls to use for **all** hand-ins.

## Perl

* quest::handin(requirement_hash);

**Example**

```perl
sub EVENT_ITEM {
	if (quest::handin({1001 => 1, "platinum" => 100})) {
		quest::say("Thanks for the cap and the platinum!");
	}
} 
```

## Lua

* eq.handin(requirement_hash);

```lua
function event_trade(e)
	if (eq.handin({[1001] = 1, platinum = 100})) then
		e.self:Say("Thanks for the cloth cap and platinum!");
	end
end
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing

![image](https://github.com/user-attachments/assets/39151c93-9aab-470b-a2aa-8f153ff0b332)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I have made corresponding changes to the documentation (if applicable, if not delete this line)
- [x] I own the changes of my code and take responsibility for the potential issues that occur
