### PR TITLE
[Bug Fix] Fix AA Reset Error Message

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -934,6 +934,10 @@ void Client::ReportConnectingState() {
 
 bool Client::SaveAA()
 {
+	if (aa_ranks.empty()) {
+		return true;
+	}
+
 	std::vector<CharacterAlternateAbilitiesRepository::CharacterAlternateAbilities> v;
 
 	uint32 aa_points_spent = 0;
@@ -965,7 +969,7 @@ bool Client::SaveAA()
 
 	m_pp.aapoints_spent = aa_points_spent + m_epp.expended_aa;
 
-	return !v.empty() ? CharacterAlternateAbilitiesRepository::ReplaceMany(database, v) : true;
+	return CharacterAlternateAbilitiesRepository::ReplaceMany(database, v);
 }
 
 void Client::RemoveExpendedAA(int aa_id)

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -934,10 +934,6 @@ void Client::ReportConnectingState() {
 
 bool Client::SaveAA()
 {
-	if (aa_ranks.empty()) {
-		return true;
-	}
-
 	std::vector<CharacterAlternateAbilitiesRepository::CharacterAlternateAbilities> v;
 
 	uint32 aa_points_spent = 0;
@@ -968,6 +964,10 @@ bool Client::SaveAA()
 	}
 
 	m_pp.aapoints_spent = aa_points_spent + m_epp.expended_aa;
+
+	if (v.empty()) {
+		return true;
+	}
 
 	return CharacterAlternateAbilitiesRepository::ReplaceMany(database, v);
 }

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -965,7 +965,7 @@ bool Client::SaveAA()
 
 	m_pp.aapoints_spent = aa_points_spent + m_epp.expended_aa;
 
-	return CharacterAlternateAbilitiesRepository::ReplaceMany(database, v);
+	return !v.empty() ? CharacterAlternateAbilitiesRepository::ReplaceMany(database, v) : true;
 }
 
 void Client::RemoveExpendedAA(int aa_id)


### PR DESCRIPTION
# Description
- Fixes an issue where the source attempts to save no AAs to the table in `Client::SaveAA()` once AAs are reset via `Client::ResetAA()`.
![image](https://github.com/user-attachments/assets/5a8ac105-a7c7-4268-b05b-609f752bdfe5)

## Type of change
- [X] Bug fix

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur