### PR TITLE
[Database] Remove force_interactive from big bag updates

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -6417,7 +6417,7 @@ ADD COLUMN `guid` bigint(20) UNSIGNED NOT NULL DEFAULT 0 AFTER `ornament_hero_mo
 ADD PRIMARY KEY (`account_id`, `slot_id`);
 )",
 		.content_schema_update = false,
-		.force_interactive = true
+		.force_interactive = false
 	},
 	ManifestEntry{
 		.version = 9298,
@@ -6481,7 +6481,7 @@ UPDATE `sharedbank` SET `slot_id` = ((`slot_id` - 2531) + 11010) WHERE `slot_id`
 UPDATE `sharedbank` SET `slot_id` = ((`slot_id` - 2541) + 11210) WHERE `slot_id` BETWEEN 2541 AND 2550; -- Shared Bank Bag 2
 )",
 		.content_schema_update = false,
-		.force_interactive = true
+		.force_interactive = false
 	},
 	ManifestEntry{
 		.version = 9299,


### PR DESCRIPTION
# Description

This removes force_interactive from big bags update. The intention was to heed caution to those who took this update but it is currently causing way more hang ups than what it is currently worth. We can re-introduce this later as needed but right now it's causing installers to hang, causing Spire to not run updates because Spire doesn't run interactively. These things can be made to work better to work with force interactive but it hasn't been current priority with the sheer volume of everything we've had going on with this last release. This will remove friction for users.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
