### PR TITLE
[Crash] World CLI validation

### DIFF
--- a/common/path_manager.cpp
+++ b/common/path_manager.cpp
@@ -76,6 +76,7 @@ void PathManager::LoadPaths()
 	constexpr int path_width   = 0;
 	constexpr int break_length = 70;
 
+	LogInfo("Loading server paths");
 	LogInfo("{}", Strings::Repeat("-", break_length));
 	for (const auto& [name, in_path] : paths) {
 		if (!in_path.empty()) {

--- a/common/path_manager.cpp
+++ b/common/path_manager.cpp
@@ -76,7 +76,6 @@ void PathManager::LoadPaths()
 	constexpr int path_width   = 0;
 	constexpr int break_length = 70;
 
-	std::cout << std::endl;
 	LogInfo("{}", Strings::Repeat("-", break_length));
 	for (const auto& [name, in_path] : paths) {
 		if (!in_path.empty()) {

--- a/world/world_boot.cpp
+++ b/world/world_boot.cpp
@@ -101,6 +101,12 @@ bool WorldBoot::HandleCommandInput(int argc, char **argv)
 		}
 	}
 
+	std::string arg1 = argv[1];
+	if (argc >= 2 && !Strings::Contains(arg1, ":")) {
+		std::cout << "Invalid command, use --help to see available commands" << std::endl;
+		return true;
+	}
+
 	return false;
 }
 

--- a/world/world_boot.cpp
+++ b/world/world_boot.cpp
@@ -101,7 +101,8 @@ bool WorldBoot::HandleCommandInput(int argc, char **argv)
 		}
 	}
 
-	std::string arg1 = argv[1];
+	// check if we ran a valid command, this whole CLI handler needs to be improved at a later time
+	std::string arg1 = argc >= 2 ? argv[1] : "";
 	if (argc >= 2 && !Strings::Contains(arg1, ":")) {
 		std::cout << "Invalid command, use --help to see available commands" << std::endl;
 		return true;


### PR DESCRIPTION
# Description

Our CLI handler is a bit crude and needs some love. Previously it would crash if an invalid command is passed and would leave a user confused as to what went wrong.

This adds validation to inform the user of an invalid command input.

Fixes https://spire.akkadius.com/dev/release/23.0.2?id=214168

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

```bash
eqemu@ct-eqemu-server:~/server$ ./bin/world s -f -f
Invalid command, use --help to see available commands
eqemu@ct-eqemu-server:~/server$ ./bin/world s      
Invalid command, use --help to see available commands
eqemu@ct-eqemu-server:~/server$ ./bin/world database:schema
{
  "bot_tables" : 
  [
    "bot_blocked_buffs",
...
```

```
eqemu@ct-eqemu-server:~/server$ ./bin/world --help                  

> EQEmulator [World] CLI Menu

bots
  bots:disable                 Disables bots and drops tables
  bots:enable                  Bootstraps bot tables and enables bots
character
  character:copy-character     Copies a character into a destination account
database
  database:dump                Dumps server database tables
  database:schema              Displays server database schema
  database:set-account-status  Sets account status by account name
  database:updates             Runs database updates manually
  database:version             Shows database version
etl
  etl:settings                 Displays server player event logs that are etl enabled
mercs
  mercs:disable                Disables mercenaries
  mercs:enable                 Enables mercenaries
world
  world:version                Shows server version
```

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

