### PR TITLE
[Crash] Fix filesystem crash / exception in DatabaseDumpService::RemoveCredentialsFile()

### DIFF
--- a/common/database/database_dump_service.cpp
+++ b/common/database/database_dump_service.cpp
@@ -596,7 +596,12 @@ void DatabaseDumpService::BuildCredentialsFile()
 void DatabaseDumpService::RemoveCredentialsFile()
 {
 	if (File::Exists(CREDENTIALS_FILE)) {
-		std::filesystem::remove(CREDENTIALS_FILE);
+		try {
+			std::filesystem::remove(CREDENTIALS_FILE);
+		}
+		catch (std::exception &e) {
+			LogError("std::filesystem::remove err [{}]", e.what());
+		}
 	}
 }
 


### PR DESCRIPTION
# Description

This catches an exception thrown and seen in this crash https://spire.akkadius.com/dev/release/23.0.2?id=214916

```
C:\Windows\Temp\drone-hj5VEr5bfcU1gHs6\drone\src\common\database\database_dump_service.cpp (599): DatabaseDumpService::RemoveCredentialsFile 
C:\Windows\Temp\drone-hj5VEr5bfcU1gHs6\drone\src\common\database\database_dump_service.cpp (389): DatabaseDumpService::DatabaseDump 
C:\Windows\Temp\drone-hj5VEr5bfcU1gHs6\drone\src\common\database\database_update.cpp (187): DatabaseUpdate::UpdateManifest 
C:\Windows\Temp\drone-hj5VEr5bfcU1gHs6\drone\src\common\database\database_update.cpp (53): DatabaseUpdate::CheckDbUpdates 
C:\Windows\Temp\drone-hj5VEr5bfcU1gHs6\drone\src\world\world_boot.cpp (246): WorldBoot::DatabaseLoadRoutines 
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
