### PR TITLE
[Fix] Add client packets to questmanager:setguild

### DIFF
--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -754,7 +754,7 @@ void Perl__setsky(uint8 new_sky)
 
 void Perl__setguild(uint32_t guild_id, uint8_t guild_rank_id)
 {
-	quest_manager.setguild(guild_id, guild_rank_id);
+	quest_manager.SetGuild(guild_id, guild_rank_id);
 }
 
 void Perl__createguild(const char* guild_name, const char* leader_name)

--- a/zone/gm_commands/guild.cpp
+++ b/zone/gm_commands/guild.cpp
@@ -91,6 +91,8 @@ void command_guild(Client* c, const Seperator* sep)
 			else {
 				auto guild_name = sep->argplus[3];
 				auto guild_id = guild_mgr.CreateGuild(sep->argplus[3], leader_id);
+				auto leader = entity_list.GetClientByCharID(leader_id);
+
 
 				LogGuilds(
 					"[{}]: Creating guild [{}] with leader [{}] with GM command. It was given id [{}]",
@@ -115,7 +117,7 @@ void command_guild(Client* c, const Seperator* sep)
 						).c_str()
 					);
 
-					if (!guild_mgr.SetGuild(leader_id, guild_id, GUILD_LEADER)) {
+					if (!guild_mgr.SetGuild(leader, guild_id, GUILD_LEADER)) {
 						c->Message(
 							Chat::White,
 							fmt::format(
@@ -268,6 +270,7 @@ void command_guild(Client* c, const Seperator* sep)
 				database.GetCharacterID(sep->arg[2])
 				);
 			auto character_name = database.GetCharNameByID(character_id);
+			auto client = entity_list.GetClientByCharID(character_id);
 			if (!character_id || character_name.empty()) {
 				c->Message(
 					Chat::White,
@@ -305,14 +308,14 @@ void command_guild(Client* c, const Seperator* sep)
 						"{} ({}) has {} put into {} ({}).",
 						character_name,
 						character_id,
-						guild_mgr.SetGuild(character_id, guild_id, GUILD_MEMBER) ? "been" : "failed to be",
+						guild_mgr.SetGuild(client, guild_id, GUILD_MEMBER) ? "been" : "failed to be",
 						guild_mgr.GetGuildNameByID(guild_id),
 						guild_id
 					).c_str()
 				);
 			}
 			else {
-				guild_mgr.SetGuild(character_id, GUILD_NONE, 0);
+				guild_mgr.SetGuild(client, GUILD_NONE, 0);
 				c->Message(
 					Chat::White,
 					fmt::format(

--- a/zone/guild_mgr.h
+++ b/zone/guild_mgr.h
@@ -72,6 +72,7 @@ public:
 	void ListGuilds(Client *c, uint32 guild_id = 0) const;
 	void DescribeGuild(Client *c, uint32 guild_id) const;
 	bool IsActionABankAction(GuildAction action);
+	bool SetGuild(Client *client, uint32 guild_id, uint8 rank);
 
 	uint8 *MakeGuildMembers(uint32 guild_id, const char* prefix_name, uint32& length);
 	void  SendToWorldMemberLevelUpdate(uint32 guild_id, uint32 level, std::string player_name);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -468,7 +468,7 @@ void lua_set_sky(int sky) {
 }
 
 void lua_set_guild(int guild_id, int rank) {
-	quest_manager.setguild(guild_id, rank);
+	quest_manager.SetGuild(guild_id, rank);
 }
 
 void lua_create_guild(const char *name, const char *leader) {

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -1623,10 +1623,10 @@ void QuestManager::setsky(uint8 new_sky) {
 	safe_delete(outapp);
 }
 
-void QuestManager::setguild(uint32 new_guild_id, uint8 new_rank) {
+void QuestManager::SetGuild(uint32 new_guild_id, uint8 new_rank) {
 	QuestManagerCurrentQuestVars();
 	if (initiator) {
-		guild_mgr.SetGuild(initiator->CharacterID(), new_guild_id, new_rank);
+		guild_mgr.SetGuild(initiator, new_guild_id, new_rank);
 	}
 }
 
@@ -1681,7 +1681,7 @@ void QuestManager::CreateGuild(const char *guild_name, const char *leader) {
 					gid
 				).c_str()
 			);
-			if (!guild_mgr.SetGuild(character_id, gid, GUILD_LEADER)) {
+			if (!guild_mgr.SetGuild(initiator, gid, GUILD_LEADER)) {
 				worldserver.SendEmoteMessage(
 					0,
 					0,

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -152,7 +152,7 @@ public:
 	void faction(int faction_id, int faction_value, int temp);
 	void rewardfaction(int faction_id, int faction_value);
 	void setsky(uint8 new_sky);
-	void setguild(uint32 new_guild_id, uint8 new_rank);
+	void SetGuild(uint32 new_guild_id, uint8 new_rank);
 	void CreateGuild(const char *guild_name, const char *leader);
 	void settime(uint8 new_hour, uint8 new_min, bool update_world = true);
 	void itemlink(int item_id);


### PR DESCRIPTION
# Description

The questmanager:setguild was not configured to send client packets after setting the Guild ID.  This functionality has been added as follows:
- If the player is already in a guild, it removes them, notifies their old guild appropriately, adds them to the new guild and also notifies the new guild appropriately.
- If the player is not already in a guild, it adds them to the new guild and notifies the new guild appropriately.
- If the rank is 0, it defaults to 8 (Guild Recruit)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
https://www.youtube.com/watch?v=pQzB3Scz9gs

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
