### PR TITLE
[Crash] Fix reload concurrency crash when ran from Spire

### DIFF
--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -4500,13 +4500,6 @@ void WorldServer::QueueReload(ServerReload::Request r)
 	m_reload_mutex.lock();
 	int64_t reload_at = r.reload_at_unix - std::time(nullptr);
 
-	// If the reload is set to happen now, process it immediately versus queuing it
-	if (reload_at <= 0) {
-		ProcessReload(r);
-		m_reload_mutex.unlock();
-		return;
-	}
-
 	LogInfo(
 		"Queuing reload for [{}] ({}) to reload in [{}]",
 		ServerReload::GetName(r.type),


### PR DESCRIPTION
# Description

This fixes a concurrency crash during reload that races to mutate objects in the main thread when reload is called from the networking thread. This change removes the immediate reload in some cases so reloads are always queued and always process in the main thread.

Fixes crash https://spire.akkadius.com/dev/release/23.0.2?id=214933 (60 occurrences) 

```
C:\Windows\Temp\drone-hj5VEr5bfcU1gHs6\drone\src\zone\zone.cpp (1859): Zone::Depop 
C:\Windows\Temp\drone-hj5VEr5bfcU1gHs6\drone\src\zone\zone.cpp (1901): Zone::Repop 
C:\Windows\Temp\drone-hj5VEr5bfcU1gHs6\drone\src\zone\worldserver.cpp (4674): WorldServer::ProcessReload 
C:\Windows\Temp\drone-hj5VEr5bfcU1gHs6\drone\src\zone\worldserver.cpp (97): WorldServer::Process 
C:\Windows\Temp\drone-hj5VEr5bfcU1gHs6\drone\src\common\event\timer.h (39): `EQ::Timer::Start'::`8'::<lambda_1>::<lambda_invoker_cdecl> 
C:\Windows\Temp\drone-hj5VEr5bfcU1gHs6\drone\src\submodules\libuv\src\timer.c (178): uv__run_timers 
C:\Windows\Temp\drone-hj5VEr5bfcU1gHs6\drone\src\submodules\libuv\src\win\core.c (605): uv_run 
C:\Windows\Temp\drone-hj5VEr5bfcU1gHs6\drone\src\zone\main.cpp (659): main 
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Tested reloading World from Spire which previously crashed. Crashes no longer.

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

