### PR TITLE
[Crash] Validate item in SE_SummonItemIntoBag

### DIFF
--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -1243,6 +1243,11 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 			case SE_SummonItemIntoBag:
 			{
 				const EQ::ItemData *item = database.GetItem(spell.base_value[i]);
+				if (!item) {
+					Message(Chat::Red, "Unable to summon item %d. Item not found.", spell.base_value[i]);
+					break;
+				}
+
 #ifdef SPELL_EFFECT_SPAM
 				const char *itemname = item ? item->Name : "*Unknown Item*";
 				snprintf(effect_desc, _EDLEN, "Summon Item In Bag: %s (id %d)", itemname, spell.base_value[i]);


### PR DESCRIPTION
# Description

Fixes https://spire.akkadius.com/dev/release/23.0.1?id=214519

```
#0  0x00007fe976e68bd7 in __GI___wait4 (pid=34677, stat_loc=0x0, options=0, usage=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:30
#1  0x000056097a4ae16b in print_trace () at /drone/src/common/crash.cpp:281
#2  <signal handler called>
#3  Mob::SpellEffect (this=0x5609b88495d0, caster=0x5609b88495d0, spell_id=<optimized out>, partial=100, level_override=<optimized out>, reflect_effectiveness=0, duration_override=<optimized out>, disable_buff_overwrite=<optimized out>) at /drone/src/zone/spell_effects.cpp:1264
#4  0x000056097a3019fd in Mob::SpellOnTarget (this=0x5609b88495d0, spell_id=<optimized out>, spelltar=0x5609b88495d0, reflect_effectiveness=8, use_resist_adjust=20, resist_adjust=<optimized out>, isproc=<optimized out>, level_override=-1, duration_override=0, disable_buff_overwrite=<optimized out>) at /drone/src/zone/spells.cpp:4598
#5  0x000056097a2f7ca8 in Mob::SpellFinished (this=this@entry=0x5609b88495d0, spell_id=<optimized out>, spell_target=0x7fe96b8a9e64, spell_target@entry=0x5609b7bf9dd0, slot=slot@entry=EQ::spells::CastingSlot::Item, mana_used=<optimized out>, mana_used@entry=0, inventory_slot=<optimized out>, inventory_slot@entry=5615, resist_adjust=<optimized out>, isproc=<optimized out>, level_override=<optimized out>, timer=<optimized out>, timer_duration=<optimized out>, from_casted_spell=<optimized out>, aa_id=<optimized out>) at /drone/src/zone/spells.cpp:2603
#6  0x000056097a2ef730 in Mob::CastedSpellFinished (this=this@entry=0x5609b88495d0, spell_id=<optimized out>, target_id=<optimized out>, slot=EQ::spells::CastingSlot::Item, mana_used=8, inventory_slot=5615, resist_adjust=0) at /drone/src/zone/spells.cpp:1757
#7  0x000056097a2edec7 in Mob::SpellProcess (this=0x5609b88495d0) at /drone/src/zone/spells.cpp:134
#8  0x0000560979a5913d in Client::Process (this=0x5609b88495d0) at /drone/src/zone/client_process.cpp:517
#9  0x0000560979cac9dc in EntityList::MobProcess (this=0x56097b2cf480 <entity_list>) at /drone/src/zone/entity.cpp:528
#10 0x0000560979fdc39a in main::$_12::operator() (this=0x5609b8188f20, t=<optimized out>) at /drone/src/zone/main.cpp:627
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)