### PR TITLE
[Bug Fix] Fix an error causing Endurance Regen to not be applied by items.

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -349,7 +349,7 @@ void Mob::AddItemBonuses(const EQ::ItemInstance* inst, StatBonuses* b, bool is_a
 
 	b->HPRegen += CalcItemBonus(item->Regen);
 	b->ManaRegen += CalcItemBonus(item->ManaRegen);
-	b->ManaRegen += CalcItemBonus(item->EnduranceRegen);
+	b->EnduranceRegen= CalcItemBonus(item->EnduranceRegen);
 
 	// These have rule-configured caps.
 	b->ATK              = CalcCappedItemBonus(b->ATK, item->Attack, RuleI(Character, ItemATKCap) + itembonuses.ItemATKCap + spellbonuses.ItemATKCap + aabonuses.ItemATKCap);

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -349,7 +349,7 @@ void Mob::AddItemBonuses(const EQ::ItemInstance* inst, StatBonuses* b, bool is_a
 
 	b->HPRegen += CalcItemBonus(item->Regen);
 	b->ManaRegen += CalcItemBonus(item->ManaRegen);
-	b->EnduranceRegen= CalcItemBonus(item->EnduranceRegen);
+	b->EnduranceRegen += CalcItemBonus(item->EnduranceRegen);
 
 	// These have rule-configured caps.
 	b->ATK              = CalcCappedItemBonus(b->ATK, item->Attack, RuleI(Character, ItemATKCap) + itembonuses.ItemATKCap + spellbonuses.ItemATKCap + aabonuses.ItemATKCap);


### PR DESCRIPTION
# Description

Typo assigned Endurance Regen as Mana Regen, this fixes that error.

## Type of change

Please delete options that are not relevant.

- [C] Bug fix (non-breaking change which fixes an issue)

# Testing

No testing has been performed. This change is of trivial complexity.

Clients tested: 
N/A

# Checklist

- [ ] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
