### PR TITLE
[Bug Fix] Cleanup zone buckets on instance purge.

### DIFF
--- a/common/database_instances.cpp
+++ b/common/database_instances.cpp
@@ -562,6 +562,7 @@ void Database::PurgeExpiredInstances()
 	DynamicZoneMembersRepository::DeleteByManyInstances(*this, imploded_instance_ids);
 	DynamicZonesRepository::DeleteWhere(*this, fmt::format("instance_id IN ({})", imploded_instance_ids));
 	Spawn2DisabledRepository::DeleteWhere(*this, fmt::format("instance_id IN ({})", imploded_instance_ids));
+	DataBucketsRepository::DeleteWhere(*this, fmt::format("instance_id != 0 and instance_id IN ({})", imploded_instance_ids));
 }
 
 void Database::SetInstanceDuration(uint16 instance_id, uint32 new_duration)


### PR DESCRIPTION
When I tested it I found that the zone-scoped data buckets were persisting after the instance disappeared from the instance_list table due to hitting its expiration time.  Appeared to be due to this bit of missing logic in 'PurgeExpiredInstances'.

Test Steps:

1. Create an instance and set a zone data bucket.
2. Leave the DZ.
3. Update the start_time of the instance in instance_list to some value in the distant past and restart server.

Expected:

Zone data buckets with the same instance id disappear when instance is removed from instance_list.