### PR TITLE
[Crash] Database SetMutex crash fix

### DIFF
--- a/common/dbcore.cpp
+++ b/common/dbcore.cpp
@@ -302,7 +302,9 @@ std::string DBcore::Escape(const std::string& s)
 
 void DBcore::SetMutex(Mutex *mutex)
 {
-	safe_delete(m_mutex);
+	if (m_mutex && m_mutex != mutex) {
+		safe_delete(m_mutex);
+	}
 
 	DBcore::m_mutex = mutex;
 }


### PR DESCRIPTION
# Description

This fixes a crash observed in our crash analytics. I'm not sure how this is suddenly being raised after all of this time but I'm adding a little extra logic that doesn't delete the mutex if the same pointer as the one being held locally, we also check to see if its not null.

```
#0  0x00007d146e7e6bd7 in __GI___wait4 (pid=312, stat_loc=0x0, options=0, usage=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:30
#1  0x00005b6b3b672afb in print_trace () at /drone/src/common/crash.cpp:281
#2  <signal handler called>
#3  __pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at ./nptl/pthread_kill.c:44
#4  0x00007d146e79df1f in __pthread_kill_internal (signo=6, threadid=<optimized out>) at ./nptl/pthread_kill.c:78
#5  0x00007d146e74efb2 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#6  0x00007d146e739472 in __GI_abort () at ./stdlib/abort.c:79
#7  0x00007d146e792430 in __libc_message (action=action@entry=do_abort, fmt=fmt@entry=0x7d146e8ac459 "%s\n") at ../sysdeps/posix/libc_fatal.c:155
#8  0x00007d146e7a783a in malloc_printerr (str=str@entry=0x7d146e8af098 "free(): double free detected in tcache 2") at ./malloc/malloc.c:5660
#9  0x00007d146e7a9ac6 in _int_free (av=0x7d146e8e5c60 <main_arena>, p=0x5b6b76c6c1d0, have_lock=have_lock@entry=0) at ./malloc/malloc.c:4469
#10 0x00007d146e7abf1f in __GI___libc_free (mem=<optimized out>) at ./malloc/malloc.c:3385
#11 0x00005b6b3b6ebc04 in DBcore::SetMutex (this=0x5b6b3c0643d0 <content_db+8>, mutex=0x5b6b76c6c1e0) at /drone/src/common/dbcore.cpp:305
#12 0x00005b6b3b626556 in WorldBoot::LoadDatabaseConnections () at /drone/src/world/world_boot.cpp:169
#13 0x00005b6b3b5c0f13 in main (argc=2, argv=0x7fff25999948) at /drone/src/world/main.cpp:172
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Processes seem to boot fine per normal

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

