### PR TITLE
[Crash] Fix world repop crash

### DIFF
--- a/world/zonelist.cpp
+++ b/world/zonelist.cpp
@@ -894,7 +894,8 @@ void ZSList::SendServerReload(ServerReload::Type type, uchar *packet)
 		ServerReload::Type::Commands,
 		ServerReload::Type::PerlExportSettings,
 		ServerReload::Type::DataBucketsCache,
-		ServerReload::Type::WorldRepop
+		ServerReload::Type::WorldRepop,
+		ServerReload::Type::WorldWithRespawn
 	};
 
 	// Set requires_zone_booted flag before executing reload logic

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -4661,16 +4661,20 @@ void WorldServer::ProcessReload(const ServerReload::Request& request)
 			break;
 
 		case ServerReload::Type::WorldRepop:
-			entity_list.ClearAreas();
 			parse->ReloadQuests();
-			zone->Repop();
+			if (zone && zone->IsLoaded()) {
+				entity_list.ClearAreas();
+				zone->Repop();
+			}
 			break;
 
 		case ServerReload::Type::WorldWithRespawn:
-			entity_list.ClearAreas();
 			parse->ReloadQuests();
-			zone->Repop();
-			zone->ClearSpawnTimers();
+			if (zone && zone->IsLoaded()) {
+				entity_list.ClearAreas();
+				zone->Repop();
+				zone->ClearSpawnTimers();
+			}
 			break;
 
 		case ServerReload::Type::ZonePoints:


### PR DESCRIPTION
# Description

This fixes a crash with world repop where if a zone is not booted, it attempts to repop on a zone that is not loaded. Because this is a hybrid reload where some things can get reloaded while the zone isn't booted, we still need to check if zone is loaded to issue repops.

```
#0  0x00007faa46d94bd7 in __GI___wait4 (pid=26554, stat_loc=0x0, options=0, usage=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:30
#1  0x0000563dc7bf665b in print_trace () at /drone/src/common/crash.cpp:281
#2  <signal handler called>
#3  0x0000563dc81f1cb6 in std::_Rb_tree_rebalance_for_erase(std::_Rb_tree_node_base*, std::_Rb_tree_node_base&) ()
#4  0x0000563dc7aeeb63 in std::_Rb_tree<unsigned int, std::pair<unsigned int const, NPCType*>, std::_Select1st<std::pair<unsigned int const, NPCType*> >, std::less<unsigned int>, std::allocator<std::pair<unsigned int const, NPCType*> > >::_M_erase_aux (__position=..., this=<optimized out>) at /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/stl_tree.h:2492
#5  std::_Rb_tree<unsigned int, std::pair<unsigned int const, NPCType*>, std::_Select1st<std::pair<unsigned int const, NPCType*> >, std::less<unsigned int>, std::allocator<std::pair<unsigned int const, NPCType*> > >::erase[abi:cxx11](std::_Rb_tree_iterator<std::pair<unsigned int const, NPCType*> >) (__position=..., this=<optimized out>) at /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/stl_tree.h:1209
#6  std::map<unsigned int, NPCType*, std::less<unsigned int>, std::allocator<std::pair<unsigned int const, NPCType*> > >::erase[abi:cxx11](std::_Rb_tree_iterator<std::pair<unsigned int const, NPCType*> >) (__position=..., this=<optimized out>) at /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/stl_map.h:1086
#7  Zone::Depop (this=<optimized out>, StartSpawnTimer=<optimized out>) at /drone/src/zone/zone.cpp:1875
#8  0x0000563dc7aeedb9 in Zone::Repop (this=0x0, is_forced=false) at /drone/src/zone/zone.cpp:1913
#9  0x0000563dc7acc514 in WorldServer::ProcessReload (this=<optimized out>, request=...) at /drone/src/zone/worldserver.cpp:4672
#10 0x0000563dc7acbbb9 in WorldServer::Process (this=<optimized out>) at /drone/src/zone/worldserver.cpp:96
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Reload works per normal

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
