### PR TITLE
[Crash] Fix Aura process crash with bots

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -708,6 +708,9 @@ Client::Client(EQStreamInterface *ieqs) : Mob(
 }
 
 Client::~Client() {
+	entity_list.RemoveMobFromCloseLists(this);
+	m_close_mobs.clear();
+
 	if (ClientVersion() == EQ::versions::ClientVersion::RoF2 && RuleB (Parcel, EnableParcelMerchants)) {
 		DoParcelCancel();
 	}

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -531,6 +531,9 @@ Mob::Mob(
 
 Mob::~Mob()
 {
+	entity_list.RemoveMobFromCloseLists(this);
+	m_close_mobs.clear();
+
 	quest_manager.stopalltimers(this);
 
 	mMovementManager->RemoveMob(this);
@@ -570,10 +573,7 @@ Mob::~Mob()
 	entity_list.UnMarkNPC(GetID());
 	UninitializeBuffSlots();
 
-	entity_list.RemoveMobFromCloseLists(this);
 	entity_list.RemoveAuraFromMobs(this);
-
-	m_close_mobs.clear();
 
 	ClearDataBucketCache();
 


### PR DESCRIPTION
# Description

This fixes a crash observed on bot servers where an aura casted on a client would crash the zone when the client leaves the zone. This is because of a dangling pointer of GetCloseList's. 

I've added removal of close lists earlier in deconstructor of both Mob and Client which may actually fix some other extremely rare dangling pointer crashes.

```
C:\Windows\Temp\drone-Dpfa8CgrqAI48tFX\drone\src\zone\client.cpp (1178): Client::QueuePacket 
C:\Windows\Temp\drone-Dpfa8CgrqAI48tFX\drone\src\zone\aura.cpp (705): Aura::ProcessSpawns 
C:\Windows\Temp\drone-Dpfa8CgrqAI48tFX\drone\src\zone\aura.cpp (765): Aura::Process 
C:\Windows\Temp\drone-Dpfa8CgrqAI48tFX\drone\src\zone\entity.cpp (544): EntityList::MobProcess 
C:\Windows\Temp\drone-Dpfa8CgrqAI48tFX\drone\src\zone\main.cpp (628): `main'::`2'::<lambda_1>::operator() 
C:\Windows\Temp\drone-Dpfa8CgrqAI48tFX\drone\src\common\event\timer.h (39): `EQ::Timer::Start'::`8'::<lambda_1>::<lambda_invoker_cdecl> 
C:\Windows\Temp\drone-Dpfa8CgrqAI48tFX\drone\src\submodules\libuv\src\timer.c (178): uv__run_timers 
C:\Windows\Temp\drone-Dpfa8CgrqAI48tFX\drone\src\submodules\libuv\src\win\core.c (605): uv_run 
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Reported fixed in a support thread by a bot server operator

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

