### PR TITLE
[Crash] Potential crash fix in scan close mobs

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -2231,7 +2231,7 @@ Raid* EntityList::GetRaidByBotName(const char* name)
 			}
 		}
 	}
-	
+
 	return nullptr;
 }
 
@@ -2933,7 +2933,7 @@ void EntityList::ScanCloseMobs(Mob *scanning_mob)
 	for (auto &e : mob_list) {
 		auto mob = e.second;
 
-		if (mob->GetID() <= 0) {
+		if (mob && mob->GetID() <= 0) {
 			continue;
 		}
 


### PR DESCRIPTION
# Description

Does a simple mob pointer check where we observe a crash

```
C:\Windows\Temp\drone-Dpfa8CgrqAI48tFX\drone\src\zone\entity.cpp (2944): EntityList::ScanCloseMobs 
C:\Windows\Temp\drone-Dpfa8CgrqAI48tFX\drone\src\zone\npc.cpp (615): NPC::Process 
C:\Windows\Temp\drone-Dpfa8CgrqAI48tFX\drone\src\zone\entity.cpp (544): EntityList::MobProcess 
C:\Windows\Temp\drone-Dpfa8CgrqAI48tFX\drone\src\zone\main.cpp (628): `main'::`2'::<lambda_1>::operator() 
C:\Windows\Temp\drone-Dpfa8CgrqAI48tFX\drone\src\common\event\timer.h (39): `EQ::Timer::Start'::`8'::<lambda_1>::<lambda_invoker_cdecl> 
C:\Windows\Temp\drone-Dpfa8CgrqAI48tFX\drone\src\submodules\libuv\src\timer.c (178): uv__run_timers 
C:\Windows\Temp\drone-Dpfa8CgrqAI48tFX\drone\src\submodules\libuv\src\win\core.c (605): uv_run 
C:\Windows\Temp\drone-Dpfa8CgrqAI48tFX\drone\src\zone\main.cpp (659): main 
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Unable to test 

# Checklist

- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

