### PR TITLE
[Crash] Fix crash in add loot code path

### DIFF
--- a/zone/loot.cpp
+++ b/zone/loot.cpp
@@ -375,6 +375,10 @@ void NPC::AddLootDrop(
 				if (item2->Slots & slots) {
 					if (equipment[i]) {
 						compitem = database.GetItem(equipment[i]);
+						if (!compitem) {
+							continue;
+						}
+
 						if (item2->AC > compitem->AC || (item2->AC == compitem->AC && item2->HP > compitem->HP)) {
 							// item would be an upgrade
 							// check if we're multi-slot, if yes then we have to keep
@@ -385,6 +389,9 @@ void NPC::AddLootDrop(
 							else {
 								// Unequip old item
 								auto *old_item = GetItem(i);
+								if (!old_item) {
+									continue;
+								}
 
 								old_item->equip_slot = EQ::invslot::SLOT_INVALID;
 
@@ -677,7 +684,7 @@ LootItem *NPC::GetItem(int slot_id)
 	end = m_loot_items.end();
 	for (; cur != end; ++cur) {
 		LootItem *item = *cur;
-		if (item->equip_slot == slot_id) {
+		if (item && item->equip_slot == slot_id) {
 			return item;
 		}
 	}


### PR DESCRIPTION
# Description

Not sure exactly what is causing this from zone state but it appears we're not validating valid items in certain code paths during loot assignment. This adds extra validation and appears to have fixed the issue reported.

```
#3  NPC::GetItem (this=0x65130056d4d0, slot_id=17) at /drone/src/zone/loot.cpp:680
#4  NPC::AddLootDrop (this=0x65130056d4d0, item2=0x7829d738d900, loot_drop=..., wear_change=252, augment_one=<optimized out>, augment_two=<optimized out>, augment_three=<optimized out>, augment_four=<optimized out>, augment_five=<optimized out>, augment_six=<optimized out>) at /drone/src/zone/loot.cpp:387
#5  0x00006512c30bc02d in LoadLootStateData (zone=<optimized out>, zone@entry=0x6512fe34d500, npc=0x6512fcfe1820, npc@entry=0x65130056d4d0, loot_data=...) at /drone/src/zone/zone_save_state.cpp:92
#6  0x00006512c30a7f8f in LoadNPCState (zone=0x6512fe34d500, n=n@entry=0x65130056d4d0, s=...) at /drone/src/zone/zone_save_state.cpp:255
#7  0x00006512c309fca7 in Zone::LoadZoneState (this=0x6512fe34d500, spawn_times=..., disabled_spawns=...) at /drone/src/zone/zone_save_state.cpp:391
#8  0x00006512c2f965c0 in ZoneDatabase::PopulateZoneSpawnList (this=<optimized out>, zoneid=<optimized out>, spawn2_list=..., version=0) at /drone/src/zone/spawn2.cpp:508
#9  0x00006512c308c460 in Zone::Init (this=this@entry=0x6512fe34d500, is_static=<optimized out>) at /drone/src/zone/zone.cpp:1206
#10 0x00006512c308b661 in Zone::Bootup (iZoneID=84, iInstanceID=0, is_static=true) at /drone/src/zone/zone.cpp:115
#11 0x00006512c2cb9bc4 in main (argc=2, argv=0x7ffdadb09d48) at /drone/src/zone/main.cpp:512
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Server operator reported says appears fixed

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

