### PR TITLE
[Databuckets] Nested Databuckets Protections and Improvements

### DIFF
--- a/common/strings.cpp
+++ b/common/strings.cpp
@@ -936,3 +936,11 @@ std::string Strings::Slugify(const std::string& input, const std::string& separa
 
 	return slug;
 }
+
+bool Strings::IsValidJson(const std::string &json)
+{
+	rapidjson::Document    doc;
+	rapidjson::ParseResult result = doc.Parse(json.c_str());
+
+	return result;
+}

--- a/common/strings.h
+++ b/common/strings.h
@@ -45,6 +45,7 @@
 #include <type_traits>
 
 #include <fmt/format.h>
+#include <cereal/external/rapidjson/document.h>
 
 #ifndef _WIN32
 // this doesn't appear to affect linux-based systems..need feedback for _WIN64
@@ -188,6 +189,7 @@ public:
 	}
 
 	static std::string Slugify(const std::string &input, const std::string &separator = "-");
+	static bool IsValidJson(const std::string& json);
 };
 
 const std::string StringFormat(const char *format, ...);

--- a/utils/scripts/build/linux-build.sh
+++ b/utils/scripts/build/linux-build.sh
@@ -56,8 +56,9 @@ echo "# Running shared_memory"
 echo "# Running NPC hand-in tests"
 ./bin/zone tests:npc-handins 2>&1 | tee test_output.log
 ./bin/zone tests:npc-handins-multiquest 2>&1 | tee -a test_output.log
+./bin/zone tests:databuckets 2>&1 | tee -a test_output.log
 
-if grep -E -q "QueryErr|Error" test_output.log; then
+if grep -E -q "QueryErr|Error|FAILED" test_output.log; then
     echo "Error found in test output! Failing build."
     exit 1
 fi

--- a/zone/cli/databuckets.cpp
+++ b/zone/cli/databuckets.cpp
@@ -240,6 +240,12 @@ void ZoneCLI::DataBuckets(int argc, char **argv, argh::parser &cmd, std::string 
 	value = client->GetBucket("deep_nested.level1.level2.level3.level4.level5");
 	RunTest("Deeply Nested Key Retrieval", "final_value", value);
 
+	// Setting a Key with an Expiration
+	client->SetBucket("nested_expire.test.test", "shouldnt_expire", "S1");
+	value = client->GetBucket("nested_expire");
+	std::this_thread::sleep_for(std::chrono::seconds(2));
+	RunTest("Setting a nested key with an expiration protection test", R"({"test":{"test":"shouldnt_expire"}})", value);
+
 	// Delete Deep Nested Key Keeps Parent**
 //	client->DeleteBucket("deep_nested");
 //	client->SetBucket("deep_nested.level1.level2.level3", R"({"key": "value"})");

--- a/zone/cli/databuckets.cpp
+++ b/zone/cli/databuckets.cpp
@@ -61,12 +61,12 @@ void ZoneCLI::DataBuckets(int argc, char **argv, argh::parser &cmd, std::string 
 	RunTest("Nested Key Set/Get", R"({"test1":"value1","test2":"value2"})", value);
 
 	// 🧪 **Test 3: Prevent Overwriting Objects**
-//	client->DeleteBucket("nested");
-//	client->SetBucket("nested.test1", "value1");
-//	client->SetBucket("nested.test2", "value2");
-//	client->SetBucket("nested", "new_value");  // Should be **rejected**
-//	value = client->GetBucket("nested");
-//	RunTest("Prevent Overwriting Objects", R"({"test1":"value1","test2":"value2"})", value);
+	client->DeleteBucket("nested");
+	client->SetBucket("nested.test1.a", "value1");
+	client->SetBucket("nested.test2.a", "value2");
+	client->SetBucket("nested.test2", "new_value");  // Should be **rejected**
+	value = client->GetBucket("nested");
+	RunTest("Prevent Overwriting Objects", R"({"test1":{"a":"value1"},"test2":{"a":"value2"}})", value);
 
 	// 🧪 **Test 4: Deleting a Specific Nested Key**
 	client->DeleteBucket("nested");
@@ -112,12 +112,12 @@ void ZoneCLI::DataBuckets(int argc, char **argv, argh::parser &cmd, std::string 
 	RunTest("Delete Nested Key within JSON", R"({"key1":"value1"})", value);
 
 	// 🧪 **Test 11: Ensure Object Protection on Overwrite Attempt**
-//	client->DeleteBucket("complex");
-//	client->SetBucket("complex.nested.obj1", "data1");
-//	client->SetBucket("complex.nested.obj2", "data2");
-//	client->SetBucket("complex.nested", "overwrite_attempt"); // Should be rejected
-//	value = client->GetBucket("complex.nested");
-//	RunTest("Ensure Object Protection on Overwrite Attempt", R"({"obj1":"data1","obj2":"data2"})", value);
+	client->DeleteBucket("complex");
+	client->SetBucket("complex.nested.obj1", "data1");
+	client->SetBucket("complex.nested.obj2", "data2");
+	client->SetBucket("complex.nested", "overwrite_attempt"); // Should be rejected
+	value = client->GetBucket("complex");
+	RunTest("Ensure Object Protection on Overwrite Attempt", R"({"nested":{"obj1":"data1","obj2":"data2"}})", value);
 
 	// 🧪 **Test 12: Deleting Non-Existent Key Doesn't Break Existing Data**
 	client->DeleteBucket("complex");
@@ -126,6 +126,20 @@ void ZoneCLI::DataBuckets(int argc, char **argv, argh::parser &cmd, std::string 
 	client->DeleteBucket("does_not_exist");  // Should do nothing
 	value = client->GetBucket("complex");
 	RunTest("Deleting Non-Existent Key Doesn't Break Existing Data", R"({"nested":{"obj1":"data1","obj2":"data2"}})", value);
+
+	// 🧪 **Test 13: Get nested key value one level up **
+	client->DeleteBucket("complex");
+	client->SetBucket("complex.nested.obj1", "data1");
+	client->SetBucket("complex.nested.obj2", "data2");
+	value = client->GetBucket("complex.nested");
+	RunTest("Get nested key value", R"({"obj1":"data1","obj2":"data2"})", value);
+
+	// 🧪 **Test 13: Get nested key value deep **
+	client->DeleteBucket("complex");
+	client->SetBucket("complex.nested.obj1", "data1");
+	client->SetBucket("complex.nested.obj2", "data2");
+	value = client->GetBucket("complex.nested.obj2");
+	RunTest("Get nested key value", R"(data2)", value);
 
 	// Cleanup
 	delete client;

--- a/zone/cli/databuckets.cpp
+++ b/zone/cli/databuckets.cpp
@@ -1,0 +1,136 @@
+#include "../../common/http/httplib.h"
+#include "../../common/eqemu_logsys.h"
+#include "../../common/platform.h"
+#include "../zone.h"
+#include "../client.h"
+#include "../../common/net/eqstream.h"
+
+extern Zone *zone;
+
+void RunTest(const std::string &test_name, const std::string &expected, const std::string &actual)
+{
+	if (expected == actual) {
+		std::cout << "[✅] " << test_name << " PASSED\n";
+	} else {
+		std::cerr << "[❌] " << test_name << " FAILED\n";
+		std::cerr << "   📌 Expected: " << expected << "\n";
+		std::cerr << "   ❌ Got:      " << actual << "\n";
+		std::exit(1);
+	}
+}
+
+void ZoneCLI::DataBuckets(int argc, char **argv, argh::parser &cmd, std::string &description)
+{
+	if (cmd[{"-h", "--help"}]) {
+		return;
+	}
+
+	uint32 break_length = 50;
+	int failed_count = 0;
+
+	LogSys.SilenceConsoleLogging();
+
+	// boot shell zone for testing
+	Zone::Bootup(ZoneID("qrg"), 0, false);
+	zone->StopShutdownTimer();
+
+	entity_list.Process();
+	entity_list.MobProcess();
+
+	LogSys.EnableConsoleLogging();
+
+	std::cout << "===========================================\n";
+	std::cout << "Running DataBuckets Tests...\n";
+	std::cout << "===========================================\n\n";
+
+	Client *client = new Client();
+
+	/*** FIXED TEST CASES WITH BUCKET RESET ***/
+
+	// 🧪 **Test 1: Basic Key-Value Storage**
+	client->DeleteBucket("simple_key"); // Reset
+	client->SetBucket("simple_key", "simple_value");
+	std::string value = client->GetBucket("simple_key");
+	RunTest("Basic Key-Value Set/Get", "simple_value", value);
+
+	// 🧪 **Test 2: Nested Key Storage**
+	client->DeleteBucket("nested");
+	client->SetBucket("nested.test1", "value1");
+	client->SetBucket("nested.test2", "value2");
+	value = client->GetBucket("nested");
+	RunTest("Nested Key Set/Get", R"({"test1":"value1","test2":"value2"})", value);
+
+	// 🧪 **Test 3: Prevent Overwriting Objects**
+//	client->DeleteBucket("nested");
+//	client->SetBucket("nested.test1", "value1");
+//	client->SetBucket("nested.test2", "value2");
+//	client->SetBucket("nested", "new_value");  // Should be **rejected**
+//	value = client->GetBucket("nested");
+//	RunTest("Prevent Overwriting Objects", R"({"test1":"value1","test2":"value2"})", value);
+
+	// 🧪 **Test 4: Deleting a Specific Nested Key**
+	client->DeleteBucket("nested");
+	client->SetBucket("nested.test1", "value1");
+	client->SetBucket("nested.test2", "value2");
+	client->DeleteBucket("nested.test1");
+	value = client->GetBucket("nested");
+	RunTest("Delete Nested Key", R"({"test2":"value2"})", value);
+
+	// 🧪 **Test 5: Deleting the Entire Parent Key**
+	client->DeleteBucket("nested");
+	value = client->GetBucket("nested");
+	RunTest("Delete Parent Key", "", value);
+
+	// 🧪 **Test 6: Expiration is Ignored for Nested Keys**
+	client->DeleteBucket("exp_test");
+	client->SetBucket("exp_test.nested", "data", "S20"); // Expiration ignored
+	value = client->GetBucket("exp_test");
+	RunTest("Expiration Ignored for Nested Keys", R"({"nested":"data"})", value);
+
+	// 🧪 **Test 7: Cache Behavior**
+	client->DeleteBucket("cache_test");
+	client->SetBucket("cache_test", "cache_value");
+	value = client->GetBucket("cache_test");
+	RunTest("Cache Read/Write Consistency", "cache_value", value);
+
+	// 🧪 **Test 8: Ensure Deleting Parent Key Clears Cache**
+	client->DeleteBucket("cache_test");
+	value = client->GetBucket("cache_test");
+	RunTest("Cache Clears on Parent Delete", "", value);
+
+	// 🧪 **Test 9: Setting an Entire JSON Object**
+	client->DeleteBucket("full_json");
+	client->SetBucket("full_json", R"({"key1":"value1","key2":{"subkey":"subvalue"}})");
+	value = client->GetBucket("full_json");
+	RunTest("Set and Retrieve Full JSON Structure", R"({"key1":"value1","key2":{"subkey":"subvalue"}})", value);
+
+	// 🧪 **Test 10: Partial Nested Key Deletion within JSON**
+	client->DeleteBucket("full_json");
+	client->SetBucket("full_json", R"({"key1":"value1","key2":{"subkey":"subvalue"}})");
+	client->DeleteBucket("full_json.key2");
+	value = client->GetBucket("full_json");
+	RunTest("Delete Nested Key within JSON", R"({"key1":"value1"})", value);
+
+	// 🧪 **Test 11: Ensure Object Protection on Overwrite Attempt**
+//	client->DeleteBucket("complex");
+//	client->SetBucket("complex.nested.obj1", "data1");
+//	client->SetBucket("complex.nested.obj2", "data2");
+//	client->SetBucket("complex.nested", "overwrite_attempt"); // Should be rejected
+//	value = client->GetBucket("complex.nested");
+//	RunTest("Ensure Object Protection on Overwrite Attempt", R"({"obj1":"data1","obj2":"data2"})", value);
+
+	// 🧪 **Test 12: Deleting Non-Existent Key Doesn't Break Existing Data**
+	client->DeleteBucket("complex");
+	client->SetBucket("complex.nested.obj1", "data1");
+	client->SetBucket("complex.nested.obj2", "data2");
+	client->DeleteBucket("does_not_exist");  // Should do nothing
+	value = client->GetBucket("complex");
+	RunTest("Deleting Non-Existent Key Doesn't Break Existing Data", R"({"nested":{"obj1":"data1","obj2":"data2"}})", value);
+
+	// Cleanup
+	delete client;
+
+	std::cout << "\n===========================================\n";
+	std::cout << "✅ All DataBucket Tests Completed!\n";
+	std::cout << "===========================================\n";
+}

--- a/zone/cli/databuckets.cpp
+++ b/zone/cli/databuckets.cpp
@@ -139,7 +139,66 @@ void ZoneCLI::DataBuckets(int argc, char **argv, argh::parser &cmd, std::string 
 	client->SetBucket("complex.nested.obj1", "data1");
 	client->SetBucket("complex.nested.obj2", "data2");
 	value = client->GetBucket("complex.nested.obj2");
-	RunTest("Get nested key value", R"(data2)", value);
+	RunTest("Get nested key value deep", R"(data2)", value);
+
+	/*** ADDITIONAL TEST CASES ***/
+
+	// 🧪 **Test 1: Retrieve Nested Key from Plain String**
+	client->DeleteBucket("plain_string");
+	client->SetBucket("plain_string", "some_value");
+	value = client->GetBucket("plain_string.nested");
+	RunTest("Retrieve Nested Key from Plain String", "", value);
+
+	// 🧪 **Test 2: Store and Retrieve JSON Array**
+	client->DeleteBucket("json_array");
+	client->SetBucket("json_array", R"(["item1", "item2"])");
+	value = client->GetBucket("json_array");
+	RunTest("Store and Retrieve JSON Array", R"(["item1", "item2"])", value);
+
+//	// 🧪 **Test 3: Prevent Overwriting Array with Object**
+//	client->DeleteBucket("json_array");
+//	client->SetBucket("json_array", R"(["item1", "item2"])");
+//	client->SetBucket("json_array.item", "new_value"); // Should be rejected
+//	value = client->GetBucket("json_array");
+//	RunTest("Prevent Overwriting Array with Object", R"(["item1", "item2"])", value);
+
+	// 🧪 **Test 4: Retrieve Non-Existent Nested Key**
+	client->DeleteBucket("nested_partial");
+	client->SetBucket("nested_partial.level1", R"({"exists": "yes"})");
+	value = client->GetBucket("nested_partial.level1.non_existent");
+	RunTest("Retrieve Non-Existent Nested Key", "", value);
+
+	// 🧪 **Test 5: Overwriting Parent Key Deletes Children**
+	client->DeleteBucket("nested_override");
+	client->SetBucket("nested_override.child", "data");
+	client->SetBucket("nested_override", "new_parent_value"); // Should remove `child`
+	value = client->GetBucket("nested_override");
+	RunTest("Overwriting Parent Key Deletes Children", "new_parent_value", value);
+
+	// 🧪 **Test 6: Store and Retrieve Empty JSON Object**
+	client->DeleteBucket("empty_json");
+	client->SetBucket("empty_json", R"({})");
+	value = client->GetBucket("empty_json");
+	RunTest("Store and Retrieve Empty JSON Object", R"({})", value);
+
+	// 🧪 **Test 7: Store and Retrieve JSON String**
+	client->DeleteBucket("json_string");
+	client->SetBucket("json_string", R"("this is a string")");
+	value = client->GetBucket("json_string");
+	RunTest("Store and Retrieve JSON String", R"("this is a string")", value);
+
+	// 🧪 **Test 8: Deeply Nested Key Retrieval**
+	client->DeleteBucket("deep_nested");
+	client->SetBucket("deep_nested.level1.level2.level3.level4.level5", "final_value");
+	value = client->GetBucket("deep_nested.level1.level2.level3.level4.level5");
+	RunTest("Deeply Nested Key Retrieval", "final_value", value);
+
+	// 🧪 **Test 9: Delete Deep Nested Key Keeps Parent**
+//	client->DeleteBucket("deep_nested");
+//	client->SetBucket("deep_nested.level1.level2.level3", R"({"key": "value"})");
+//	client->DeleteBucket("deep_nested.level1.level2.level3.key");
+//	value = client->GetBucket("deep_nested.level1.level2.level3");
+//	RunTest("Delete Deep Nested Key Keeps Parent", "{}", value);
 
 	std::cout << "\n===========================================\n";
 	std::cout << "✅ All DataBucket Tests Completed!\n";

--- a/zone/cli/databuckets.cpp
+++ b/zone/cli/databuckets.cpp
@@ -141,9 +141,6 @@ void ZoneCLI::DataBuckets(int argc, char **argv, argh::parser &cmd, std::string 
 	value = client->GetBucket("complex.nested.obj2");
 	RunTest("Get nested key value", R"(data2)", value);
 
-	// Cleanup
-	delete client;
-
 	std::cout << "\n===========================================\n";
 	std::cout << "✅ All DataBucket Tests Completed!\n";
 	std::cout << "===========================================\n";

--- a/zone/cli/databuckets.cpp
+++ b/zone/cli/databuckets.cpp
@@ -45,22 +45,71 @@ void ZoneCLI::DataBuckets(int argc, char **argv, argh::parser &cmd, std::string 
 
 	Client *client = new Client();
 
-	/*** FIXED TEST CASES WITH BUCKET RESET ***/
-
-	// 🧪 **Test 1: Basic Key-Value Storage**
-	client->DeleteBucket("simple_key"); // Reset
-	client->SetBucket("simple_key", "simple_value");
-	std::string value = client->GetBucket("simple_key");
+	// Basic Key-Value Set/Get
+	client->DeleteBucket("basic_key");
+	client->SetBucket("basic_key", "simple_value");
+	std::string value = client->GetBucket("basic_key");
 	RunTest("Basic Key-Value Set/Get", "simple_value", value);
 
-	// 🧪 **Test 2: Nested Key Storage**
+	// Overwriting a Key
+	client->SetBucket("basic_key", "new_value");
+	value = client->GetBucket("basic_key");
+	RunTest("Overwriting a Key", "new_value", value);
+
+	// Deleting a Key
+	client->DeleteBucket("basic_key");
+	value = client->GetBucket("basic_key");
+	RunTest("Deleting a Key", "", value);
+
+	// Setting a Key with an Expiration
+	client->SetBucket("expiring_key", "expires_soon", "S1");
+	value = client->GetBucket("expiring_key");
+	RunTest("Setting a Key with an Expiration", "expires_soon", value);
+
+	// Ensure Expired Key is Deleted
+	std::this_thread::sleep_for(std::chrono::seconds(2));
+	value = client->GetBucket("expiring_key");
+	RunTest("Ensure Expired Key is Deleted", "", value);
+
+	// Cache Read/Write Consistency
+	client->SetBucket("cache_key", "cached_value");
+	value = client->GetBucket("cache_key");
+	RunTest("Cache Read/Write Consistency", "cached_value", value);
+
+	// Cache Clears on Key Deletion
+	client->DeleteBucket("cache_key");
+	value = client->GetBucket("cache_key");
+	RunTest("Cache Clears on Key Deletion", "", value);
+
+	// Setting a Full JSON String
+	client->SetBucket("json_key", R"({"key1":"value1","key2":"value2"})");
+	value = client->GetBucket("json_key");
+	RunTest("Setting a Full JSON String", R"({"key1":"value1","key2":"value2"})", value);
+
+	// Overwriting JSON with a Simple String
+	client->SetBucket("json_key", "string_value");
+	value = client->GetBucket("json_key");
+	RunTest("Overwriting JSON with a Simple String", "string_value", value);
+
+	// Deleting Non-Existent Key
+	client->DeleteBucket("non_existent_key");
+	value = client->GetBucket("non_existent_key");
+	RunTest("Deleting Non-Existent Key", "", value);
+
+	// 🧪 **Test: Basic Key-Value Storage**
+	client->DeleteBucket("simple_key"); // Reset
+	client->SetBucket("simple_key", "simple_value");
+	value = client->GetBucket("simple_key");
+	RunTest("Basic Key-Value Set/Get", "simple_value", value);
+
+	// 🧪 **Test: Nested Key Storage**
 	client->DeleteBucket("nested");
 	client->SetBucket("nested.test1", "value1");
 	client->SetBucket("nested.test2", "value2");
 	value = client->GetBucket("nested");
 	RunTest("Nested Key Set/Get", R"({"test1":"value1","test2":"value2"})", value);
 
-	// 🧪 **Test 3: Prevent Overwriting Objects**
+	// 🧪 **Test: Prevent Overwriting Objects**
 	client->DeleteBucket("nested");
 	client->SetBucket("nested.test1.a", "value1");
 	client->SetBucket("nested.test2.a", "value2");
@@ -68,7 +117,7 @@ void ZoneCLI::DataBuckets(int argc, char **argv, argh::parser &cmd, std::string 
 	value = client->GetBucket("nested");
 	RunTest("Prevent Overwriting Objects", R"({"test1":{"a":"value1"},"test2":{"a":"value2"}})", value);
 
-	// 🧪 **Test 4: Deleting a Specific Nested Key**
+	// 🧪 **Test: Deleting a Specific Nested Key**
 	client->DeleteBucket("nested");
 	client->SetBucket("nested.test1", "value1");
 	client->SetBucket("nested.test2", "value2");
@@ -76,42 +125,42 @@ void ZoneCLI::DataBuckets(int argc, char **argv, argh::parser &cmd, std::string 
 	value = client->GetBucket("nested");
 	RunTest("Delete Nested Key", R"({"test2":"value2"})", value);
 
-	// 🧪 **Test 5: Deleting the Entire Parent Key**
+	// 🧪 **Test: Deleting the Entire Parent Key**
 	client->DeleteBucket("nested");
 	value = client->GetBucket("nested");
 	RunTest("Delete Parent Key", "", value);
 
-	// 🧪 **Test 6: Expiration is Ignored for Nested Keys**
+	// 🧪 **Test: Expiration is Ignored for Nested Keys**
 	client->DeleteBucket("exp_test");
 	client->SetBucket("exp_test.nested", "data", "S20"); // Expiration ignored
 	value = client->GetBucket("exp_test");
 	RunTest("Expiration Ignored for Nested Keys", R"({"nested":"data"})", value);
 
-	// 🧪 **Test 7: Cache Behavior**
+	// 🧪 **Test: Cache Behavior**
 	client->DeleteBucket("cache_test");
 	client->SetBucket("cache_test", "cache_value");
 	value = client->GetBucket("cache_test");
 	RunTest("Cache Read/Write Consistency", "cache_value", value);
 
-	// 🧪 **Test 8: Ensure Deleting Parent Key Clears Cache**
+	// 🧪 **Test: Ensure Deleting Parent Key Clears Cache**
 	client->DeleteBucket("cache_test");
 	value = client->GetBucket("cache_test");
 	RunTest("Cache Clears on Parent Delete", "", value);
 
-	// 🧪 **Test 9: Setting an Entire JSON Object**
+	// 🧪 **Test: Setting an Entire JSON Object**
 	client->DeleteBucket("full_json");
 	client->SetBucket("full_json", R"({"key1":"value1","key2":{"subkey":"subvalue"}})");
 	value = client->GetBucket("full_json");
 	RunTest("Set and Retrieve Full JSON Structure", R"({"key1":"value1","key2":{"subkey":"subvalue"}})", value);
 
-	// 🧪 **Test 10: Partial Nested Key Deletion within JSON**
+	// 🧪 **Test: Partial Nested Key Deletion within JSON**
 	client->DeleteBucket("full_json");
 	client->SetBucket("full_json", R"({"key1":"value1","key2":{"subkey":"subvalue"}})");
 	client->DeleteBucket("full_json.key2");
 	value = client->GetBucket("full_json");
 	RunTest("Delete Nested Key within JSON", R"({"key1":"value1"})", value);
 
-	// 🧪 **Test 11: Ensure Object Protection on Overwrite Attempt**
+	// 🧪 **Test: Ensure Object Protection on Overwrite Attempt**
 	client->DeleteBucket("complex");
 	client->SetBucket("complex.nested.obj1", "data1");
 	client->SetBucket("complex.nested.obj2", "data2");
@@ -119,7 +168,7 @@ void ZoneCLI::DataBuckets(int argc, char **argv, argh::parser &cmd, std::string 
 	value = client->GetBucket("complex");
 	RunTest("Ensure Object Protection on Overwrite Attempt", R"({"nested":{"obj1":"data1","obj2":"data2"}})", value);
 
-	// 🧪 **Test 12: Deleting Non-Existent Key Doesn't Break Existing Data**
+	// 🧪 **Test: Deleting Non-Existent Key Doesn't Break Existing Data**
 	client->DeleteBucket("complex");
 	client->SetBucket("complex.nested.obj1", "data1");
 	client->SetBucket("complex.nested.obj2", "data2");
@@ -127,73 +176,71 @@ void ZoneCLI::DataBuckets(int argc, char **argv, argh::parser &cmd, std::string 
 	value = client->GetBucket("complex");
 	RunTest("Deleting Non-Existent Key Doesn't Break Existing Data", R"({"nested":{"obj1":"data1","obj2":"data2"}})", value);
 
-	// 🧪 **Test 13: Get nested key value one level up **
+	// 🧪 **Test: Get nested key value one level up **
 	client->DeleteBucket("complex");
 	client->SetBucket("complex.nested.obj1", "data1");
 	client->SetBucket("complex.nested.obj2", "data2");
 	value = client->GetBucket("complex.nested");
 	RunTest("Get nested key value", R"({"obj1":"data1","obj2":"data2"})", value);
 
-	// 🧪 **Test 13: Get nested key value deep **
+	// 🧪 **Test: Get nested key value deep **
 	client->DeleteBucket("complex");
 	client->SetBucket("complex.nested.obj1", "data1");
 	client->SetBucket("complex.nested.obj2", "data2");
 	value = client->GetBucket("complex.nested.obj2");
 	RunTest("Get nested key value deep", R"(data2)", value);
 
-	/*** ADDITIONAL TEST CASES ***/
-
-	// 🧪 **Test 1: Retrieve Nested Key from Plain String**
+	// 🧪 **Test: Retrieve Nested Key from Plain String**
 	client->DeleteBucket("plain_string");
 	client->SetBucket("plain_string", "some_value");
 	value = client->GetBucket("plain_string.nested");
 	RunTest("Retrieve Nested Key from Plain String", "", value);
 
-	// 🧪 **Test 2: Store and Retrieve JSON Array**
+	// 🧪 **Test: Store and Retrieve JSON Array**
 	client->DeleteBucket("json_array");
 	client->SetBucket("json_array", R"(["item1", "item2"])");
 	value = client->GetBucket("json_array");
 	RunTest("Store and Retrieve JSON Array", R"(["item1", "item2"])", value);
 
-//	// 🧪 **Test 3: Prevent Overwriting Array with Object**
+//	// 🧪 **Test: Prevent Overwriting Array with Object**
 //	client->DeleteBucket("json_array");
 //	client->SetBucket("json_array", R"(["item1", "item2"])");
 //	client->SetBucket("json_array.item", "new_value"); // Should be rejected
 //	value = client->GetBucket("json_array");
 //	RunTest("Prevent Overwriting Array with Object", R"(["item1", "item2"])", value);
 
-	// 🧪 **Test 4: Retrieve Non-Existent Nested Key**
+	// 🧪 **Test: Retrieve Non-Existent Nested Key**
 	client->DeleteBucket("nested_partial");
 	client->SetBucket("nested_partial.level1", R"({"exists": "yes"})");
 	value = client->GetBucket("nested_partial.level1.non_existent");
 	RunTest("Retrieve Non-Existent Nested Key", "", value);
 
-	// 🧪 **Test 5: Overwriting Parent Key Deletes Children**
+	// 🧪 **Test: Overwriting Parent Key Deletes Children**
 	client->DeleteBucket("nested_override");
 	client->SetBucket("nested_override.child", "data");
 	client->SetBucket("nested_override", "new_parent_value"); // Should remove `child`
 	value = client->GetBucket("nested_override");
 	RunTest("Overwriting Parent Key Deletes Children", "new_parent_value", value);
 
-	// 🧪 **Test 6: Store and Retrieve Empty JSON Object**
+	// 🧪 **Test: Store and Retrieve Empty JSON Object**
 	client->DeleteBucket("empty_json");
 	client->SetBucket("empty_json", R"({})");
 	value = client->GetBucket("empty_json");
 	RunTest("Store and Retrieve Empty JSON Object", R"({})", value);
 
-	// 🧪 **Test 7: Store and Retrieve JSON String**
+	// 🧪 **Test: Store and Retrieve JSON String**
 	client->DeleteBucket("json_string");
 	client->SetBucket("json_string", R"("this is a string")");
 	value = client->GetBucket("json_string");
 	RunTest("Store and Retrieve JSON String", R"("this is a string")", value);
 
-	// 🧪 **Test 8: Deeply Nested Key Retrieval**
+	// 🧪 **Test: Deeply Nested Key Retrieval**
 	client->DeleteBucket("deep_nested");
 	client->SetBucket("deep_nested.level1.level2.level3.level4.level5", "final_value");
 	value = client->GetBucket("deep_nested.level1.level2.level3.level4.level5");
 	RunTest("Deeply Nested Key Retrieval", "final_value", value);
 
-	// 🧪 **Test 9: Delete Deep Nested Key Keeps Parent**
+	// 🧪 **Test: Delete Deep Nested Key Keeps Parent**
 //	client->DeleteBucket("deep_nested");
 //	client->SetBucket("deep_nested.level1.level2.level3", R"({"key": "value"})");
 //	client->DeleteBucket("deep_nested.level1.level2.level3.key");

--- a/zone/cli/databuckets.cpp
+++ b/zone/cli/databuckets.cpp
@@ -96,20 +96,20 @@ void ZoneCLI::DataBuckets(int argc, char **argv, argh::parser &cmd, std::string 
 	value = client->GetBucket("non_existent_key");
 	RunTest("Deleting Non-Existent Key", "", value);
 
-	// 🧪 **Test: Basic Key-Value Storage**
+	// Basic Key-Value Storage**
 	client->DeleteBucket("simple_key"); // Reset
 	client->SetBucket("simple_key", "simple_value");
 	value = client->GetBucket("simple_key");
 	RunTest("Basic Key-Value Set/Get", "simple_value", value);
 
-	// 🧪 **Test: Nested Key Storage**
+	// Nested Key Storage**
 	client->DeleteBucket("nested");
 	client->SetBucket("nested.test1", "value1");
 	client->SetBucket("nested.test2", "value2");
 	value = client->GetBucket("nested");
 	RunTest("Nested Key Set/Get", R"({"test1":"value1","test2":"value2"})", value);
 
-	// 🧪 **Test: Prevent Overwriting Objects**
+	// Prevent Overwriting Objects**
 	client->DeleteBucket("nested");
 	client->SetBucket("nested.test1.a", "value1");
 	client->SetBucket("nested.test2.a", "value2");
@@ -117,7 +117,7 @@ void ZoneCLI::DataBuckets(int argc, char **argv, argh::parser &cmd, std::string 
 	value = client->GetBucket("nested");
 	RunTest("Prevent Overwriting Objects", R"({"test1":{"a":"value1"},"test2":{"a":"value2"}})", value);
 
-	// 🧪 **Test: Deleting a Specific Nested Key**
+	// Deleting a Specific Nested Key**
 	client->DeleteBucket("nested");
 	client->SetBucket("nested.test1", "value1");
 	client->SetBucket("nested.test2", "value2");
@@ -125,42 +125,42 @@ void ZoneCLI::DataBuckets(int argc, char **argv, argh::parser &cmd, std::string 
 	value = client->GetBucket("nested");
 	RunTest("Delete Nested Key", R"({"test2":"value2"})", value);
 
-	// 🧪 **Test: Deleting the Entire Parent Key**
+	// Deleting the Entire Parent Key**
 	client->DeleteBucket("nested");
 	value = client->GetBucket("nested");
 	RunTest("Delete Parent Key", "", value);
 
-	// 🧪 **Test: Expiration is Ignored for Nested Keys**
+	// Expiration is Ignored for Nested Keys**
 	client->DeleteBucket("exp_test");
 	client->SetBucket("exp_test.nested", "data", "S20"); // Expiration ignored
 	value = client->GetBucket("exp_test");
 	RunTest("Expiration Ignored for Nested Keys", R"({"nested":"data"})", value);
 
-	// 🧪 **Test: Cache Behavior**
+	// Cache Behavior**
 	client->DeleteBucket("cache_test");
 	client->SetBucket("cache_test", "cache_value");
 	value = client->GetBucket("cache_test");
 	RunTest("Cache Read/Write Consistency", "cache_value", value);
 
-	// 🧪 **Test: Ensure Deleting Parent Key Clears Cache**
+	// Ensure Deleting Parent Key Clears Cache**
 	client->DeleteBucket("cache_test");
 	value = client->GetBucket("cache_test");
 	RunTest("Cache Clears on Parent Delete", "", value);
 
-	// 🧪 **Test: Setting an Entire JSON Object**
+	// Setting an Entire JSON Object**
 	client->DeleteBucket("full_json");
 	client->SetBucket("full_json", R"({"key1":"value1","key2":{"subkey":"subvalue"}})");
 	value = client->GetBucket("full_json");
 	RunTest("Set and Retrieve Full JSON Structure", R"({"key1":"value1","key2":{"subkey":"subvalue"}})", value);
 
-	// 🧪 **Test: Partial Nested Key Deletion within JSON**
+	// Partial Nested Key Deletion within JSON**
 	client->DeleteBucket("full_json");
 	client->SetBucket("full_json", R"({"key1":"value1","key2":{"subkey":"subvalue"}})");
 	client->DeleteBucket("full_json.key2");
 	value = client->GetBucket("full_json");
 	RunTest("Delete Nested Key within JSON", R"({"key1":"value1"})", value);
 
-	// 🧪 **Test: Ensure Object Protection on Overwrite Attempt**
+	// Ensure Object Protection on Overwrite Attempt**
 	client->DeleteBucket("complex");
 	client->SetBucket("complex.nested.obj1", "data1");
 	client->SetBucket("complex.nested.obj2", "data2");
@@ -168,7 +168,7 @@ void ZoneCLI::DataBuckets(int argc, char **argv, argh::parser &cmd, std::string 
 	value = client->GetBucket("complex");
 	RunTest("Ensure Object Protection on Overwrite Attempt", R"({"nested":{"obj1":"data1","obj2":"data2"}})", value);
 
-	// 🧪 **Test: Deleting Non-Existent Key Doesn't Break Existing Data**
+	// Deleting Non-Existent Key Doesn't Break Existing Data**
 	client->DeleteBucket("complex");
 	client->SetBucket("complex.nested.obj1", "data1");
 	client->SetBucket("complex.nested.obj2", "data2");
@@ -176,71 +176,71 @@ void ZoneCLI::DataBuckets(int argc, char **argv, argh::parser &cmd, std::string 
 	value = client->GetBucket("complex");
 	RunTest("Deleting Non-Existent Key Doesn't Break Existing Data", R"({"nested":{"obj1":"data1","obj2":"data2"}})", value);
 
-	// 🧪 **Test: Get nested key value one level up **
+	// Get nested key value one level up **
 	client->DeleteBucket("complex");
 	client->SetBucket("complex.nested.obj1", "data1");
 	client->SetBucket("complex.nested.obj2", "data2");
 	value = client->GetBucket("complex.nested");
 	RunTest("Get nested key value", R"({"obj1":"data1","obj2":"data2"})", value);
 
-	// 🧪 **Test: Get nested key value deep **
+	// Get nested key value deep **
 	client->DeleteBucket("complex");
 	client->SetBucket("complex.nested.obj1", "data1");
 	client->SetBucket("complex.nested.obj2", "data2");
 	value = client->GetBucket("complex.nested.obj2");
 	RunTest("Get nested key value deep", R"(data2)", value);
 
-	// 🧪 **Test: Retrieve Nested Key from Plain String**
+	// Retrieve Nested Key from Plain String**
 	client->DeleteBucket("plain_string");
 	client->SetBucket("plain_string", "some_value");
 	value = client->GetBucket("plain_string.nested");
 	RunTest("Retrieve Nested Key from Plain String", "", value);
 
-	// 🧪 **Test: Store and Retrieve JSON Array**
+	// Store and Retrieve JSON Array**
 	client->DeleteBucket("json_array");
 	client->SetBucket("json_array", R"(["item1", "item2"])");
 	value = client->GetBucket("json_array");
 	RunTest("Store and Retrieve JSON Array", R"(["item1", "item2"])", value);
 
-//	// 🧪 **Test: Prevent Overwriting Array with Object**
+//	// Prevent Overwriting Array with Object**
 //	client->DeleteBucket("json_array");
 //	client->SetBucket("json_array", R"(["item1", "item2"])");
 //	client->SetBucket("json_array.item", "new_value"); // Should be rejected
 //	value = client->GetBucket("json_array");
 //	RunTest("Prevent Overwriting Array with Object", R"(["item1", "item2"])", value);
 
-	// 🧪 **Test: Retrieve Non-Existent Nested Key**
+	// Retrieve Non-Existent Nested Key**
 	client->DeleteBucket("nested_partial");
 	client->SetBucket("nested_partial.level1", R"({"exists": "yes"})");
 	value = client->GetBucket("nested_partial.level1.non_existent");
 	RunTest("Retrieve Non-Existent Nested Key", "", value);
 
-	// 🧪 **Test: Overwriting Parent Key Deletes Children**
+	// Overwriting Parent Key Deletes Children**
 	client->DeleteBucket("nested_override");
 	client->SetBucket("nested_override.child", "data");
 	client->SetBucket("nested_override", "new_parent_value"); // Should remove `child`
 	value = client->GetBucket("nested_override");
 	RunTest("Overwriting Parent Key Deletes Children", "new_parent_value", value);
 
-	// 🧪 **Test: Store and Retrieve Empty JSON Object**
+	// Store and Retrieve Empty JSON Object**
 	client->DeleteBucket("empty_json");
 	client->SetBucket("empty_json", R"({})");
 	value = client->GetBucket("empty_json");
 	RunTest("Store and Retrieve Empty JSON Object", R"({})", value);
 
-	// 🧪 **Test: Store and Retrieve JSON String**
+	// Store and Retrieve JSON String**
 	client->DeleteBucket("json_string");
 	client->SetBucket("json_string", R"("this is a string")");
 	value = client->GetBucket("json_string");
 	RunTest("Store and Retrieve JSON String", R"("this is a string")", value);
 
-	// 🧪 **Test: Deeply Nested Key Retrieval**
+	// Deeply Nested Key Retrieval**
 	client->DeleteBucket("deep_nested");
 	client->SetBucket("deep_nested.level1.level2.level3.level4.level5", "final_value");
 	value = client->GetBucket("deep_nested.level1.level2.level3.level4.level5");
 	RunTest("Deeply Nested Key Retrieval", "final_value", value);
 
-	// 🧪 **Test: Delete Deep Nested Key Keeps Parent**
+	// Delete Deep Nested Key Keeps Parent**
 //	client->DeleteBucket("deep_nested");
 //	client->SetBucket("deep_nested.level1.level2.level3", R"({"key": "value"})");
 //	client->DeleteBucket("deep_nested.level1.level2.level3.key");

--- a/zone/data_bucket.cpp
+++ b/zone/data_bucket.cpp
@@ -27,7 +27,8 @@ void DataBucket::SetData(const std::string &bucket_key, const std::string &bucke
 void DataBucket::SetData(const DataBucketKey &k_)
 {
 	DataBucketKey k = k_; // copy the key so we can modify it
-	if (k.key.find(NESTED_KEY_DELIMITER) != std::string::npos) {
+	bool is_nested = k.key.find(NESTED_KEY_DELIMITER) != std::string::npos;
+	if (is_nested) {
 		k.key = Strings::Split(k.key, NESTED_KEY_DELIMITER).front();
 	}
 
@@ -62,6 +63,10 @@ void DataBucket::SetData(const DataBucketKey &k_)
 		expires_time_unix = static_cast<int64>(std::time(nullptr)) + Strings::ToInt(k.expires);
 		if (isalpha(k.expires[0]) || isalpha(k.expires[k.expires.length() - 1])) {
 			expires_time_unix = static_cast<int64>(std::time(nullptr)) + Strings::TimeToSeconds(k.expires);
+		}
+		if (is_nested) {
+			LogDataBuckets("Nested keys can't expire; set expiration on the parent key");
+			expires_time_unix = 0;
 		}
 	}
 

--- a/zone/data_bucket.cpp
+++ b/zone/data_bucket.cpp
@@ -430,6 +430,21 @@ bool DataBucket::DeleteData(const DataBucketKey &k)
 	// If the JSON object is now empty, delete the top-level key
 	if (json_value.empty()) {
 		LogDataBuckets("Top-level key [{}] is now empty, deleting entire entry", top_level_key);
+
+		// delete cache
+		if (CanCache(k)) {
+			g_data_bucket_cache.erase(
+				std::remove_if(
+					g_data_bucket_cache.begin(),
+					g_data_bucket_cache.end(),
+					[&](DataBucketsRepository::DataBuckets &e) {
+						return CheckBucketMatch(e, top_level_k);
+					}
+				),
+				g_data_bucket_cache.end()
+			);
+		}
+
 		return DataBucketsRepository::DeleteWhere(
 			database,
 			fmt::format("{} `key` = '{}'", DataBucket::GetScopedDbFilters(k), top_level_key)

--- a/zone/data_bucket.cpp
+++ b/zone/data_bucket.cpp
@@ -103,6 +103,8 @@ void DataBucket::SetData(const DataBucketKey &k_)
 
 			if (i == nested_keys.size() - 1) {
 
+				LogDataBucketsDetail("Setting key [{}] key_part [{}]", k.key, key_part);
+
 				// If the key already exists and is an object or array, prevent overwriting to avoid data loss
 				if (current->contains(key_part) &&
 					((*current)[key_part].is_object() || (*current)[key_part].is_array())) {
@@ -164,6 +166,8 @@ DataBucketsRepository::DataBuckets DataBucket::ExtractNestedValue(
 	const std::string &full_key)
 {
 	auto nested_keys = Strings::Split(full_key, NESTED_KEY_DELIMITER);
+	auto top_key = nested_keys.front();
+	nested_keys.erase(nested_keys.begin());
 	json json_value;
 
 	// Check if the JSON is valid

--- a/zone/data_bucket.cpp
+++ b/zone/data_bucket.cpp
@@ -97,6 +97,14 @@ void DataBucket::SetData(const DataBucketKey &k_)
 		for (size_t i = 0; i < nested_keys.size(); ++i) {
 			const std::string &key_part = nested_keys[i];
 			if (i == nested_keys.size() - 1) {
+
+				// If the key already exists and is an object or array, prevent overwriting to avoid data loss
+				if (current->contains(key_part) &&
+					((*current)[key_part].is_object() || (*current)[key_part].is_array())) {
+					LogDataBuckets("Attempted to overwrite an existing object or array at key [{}] - skipping", k_.key);
+					return;
+				}
+
 				// Set the value at the final key
 				(*current)[key_part] = k_.value;
 			} else {

--- a/zone/zone_cli.cpp
+++ b/zone/zone_cli.cpp
@@ -31,12 +31,14 @@ void ZoneCLI::CommandHandler(int argc, char **argv)
 	// Register commands
 	function_map["benchmark:databuckets"] = &ZoneCLI::BenchmarkDatabuckets;
 	function_map["sidecar:serve-http"] = &ZoneCLI::SidecarServeHttp;
+	function_map["tests:databuckets"] = &ZoneCLI::DataBuckets;
 	function_map["tests:npc-handins"] = &ZoneCLI::NpcHandins;
 	function_map["tests:npc-handins-multiquest"] = &ZoneCLI::NpcHandinsMultiQuest;
 
 	EQEmuCommand::HandleMenu(function_map, cmd, argc, argv);
 }
 
+#include "cli/databuckets.cpp"
 #include "cli/benchmark_databuckets.cpp"
 #include "cli/sidecar_serve_http.cpp"
 #include "cli/npc_handins.cpp"

--- a/zone/zone_cli.h
+++ b/zone/zone_cli.h
@@ -11,6 +11,7 @@ public:
 	static bool RanConsoleCommand(int argc, char **argv);
 	static bool RanSidecarCommand(int argc, char **argv);
 	static bool RanTestCommand(int argc, char **argv);
+	static void DataBuckets(int argc, char **argv, argh::parser &cmd, std::string &description);
 	static void NpcHandins(int argc, char **argv, argh::parser &cmd, std::string &description);
 	static void NpcHandinsMultiQuest(int argc, char **argv, argh::parser &cmd, std::string &description);
 };

--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -45,18 +45,11 @@ struct LootStateData {
 	}
 };
 
-inline bool IsValidJson(const std::string& json) {
-	rapidjson::Document doc;
-	rapidjson::ParseResult result = doc.Parse(json.c_str());
-
-	return result;
-}
-
 inline void LoadLootStateData(Zone *zone, NPC *npc, const std::string &loot_data)
 {
 	LootStateData l{};
 
-	if (!IsValidJson(loot_data)) {
+	if (!Strings::IsValidJson(loot_data)) {
 		LogZoneState("Invalid JSON data for NPC [{}]", npc->GetNPCTypeID());
 		return;
 	}
@@ -178,7 +171,7 @@ inline std::string GetLootSerialized(Corpse *c)
 
 inline void LoadNPCEntityVariables(NPC *n, const std::string &entity_variables)
 {
-	if (!IsValidJson(entity_variables)) {
+	if (!Strings::IsValidJson(entity_variables)) {
 		LogZoneState("Invalid JSON data for NPC [{}]", n->GetNPCTypeID());
 		return;
 	}
@@ -203,7 +196,7 @@ inline void LoadNPCEntityVariables(NPC *n, const std::string &entity_variables)
 
 inline void LoadNPCBuffs(NPC *n, const std::string &buffs)
 {
-	if (!IsValidJson(buffs)) {
+	if (!Strings::IsValidJson(buffs)) {
 		LogZoneState("Invalid JSON data for NPC [{}]", n->GetNPCTypeID());
 		return;
 	}


### PR DESCRIPTION
# Description

With the implementation of [[Databuckets] Implement Nested Databuckets #4604](https://github.com/EQEmu/Server/pull/4604) we have seen some user feedback where users (script writers) can on a more rare occasion - accidentally incur data loss. It is extremely important to avoid this even with honest script mistakes.

This PR adds protections as well as implements targeted nested databucket deletion because it didn't exist prior.

**🛡️ Protections**

* ✅ **Accidental Nested Expiration** When a nested databucket set call is made with an expiration, it now gets ignored because it can cause the entire parent to expire and all of the nested keys along with it. This is not desired behavior (Example: SetBucket("key.key1", "value", "S20")
* ✅ **Empty or Invalid JSON** When invalid or empty JSON was passed to a get or set call, we would throw an exception. We've added JSON validation prior to the input being parsed, avoiding this error and preventing unexpected internal server exceptions being thrown inside the serialization library.
* ✅ **Accidental Adjacent Key Overwrite Protection or Object / Array** This prevents accidentally deleting a tree of nested data on accident. The only way to do this intentionally is to issue a nested `DeleteBucket("key.key1)` call.

**🆕 Nested Deletion**

You can now specifically target a nested databucket key for deletion, originally you could only do it by parent key

Example

```perl
sub EVENT_SAY {
    if ($text=~/delete/i) {
        $client->DeleteBucket("test.test2");
    }
}
```

**Before**

```
+----------+------+----------------------------------------------------------------------------------------+---------+------------+--------------+--------+--------+---------+-------------+
| id       | key  | value                                                                                  | expires | account_id | character_id | npc_id | bot_id | zone_id | instance_id |
+----------+------+----------------------------------------------------------------------------------------+---------+------------+--------------+--------+--------+---------+-------------+
| 52451882 | test | {"test1":{"a":"7","b":"1","c":{"f":"1"}},"test2":{"a":"1","b":"1","c":"1"}}  |       0 |          0 |            9 |      0 |      0 |       0 |           0 |
+----------+------+----------------------------------------------------------------------------------------+---------+------------+--------------+--------+--------+---------+-------------+
```
 
**After**

This is a targeted delete of `test.test2`, below we see it and its nested keys removed

```
+----------+------+-----------------------------------------------------+---------+------------+--------------+--------+--------+---------+-------------+
| id       | key  | value                                               | expires | account_id | character_id | npc_id | bot_id | zone_id | instance_id |
+----------+------+-----------------------------------------------------+---------+------------+--------------+--------+--------+---------+-------------+
| 52451882 | test | {"test1":{"a":"7","b":"1","c":{"f":"1"}}}  |       0 |          0 |            9 |      0 |      0 |       0 |           0 |
+----------+------+-----------------------------------------------------+---------+------------+--------------+--------+--------+---------+-------------+
```

**Automated Testing**

Added zone test command `./bin/zone tests:databuckets` that run through a series of tests automatically. Also now ran in our CI pipeline

```
===========================================
Running DataBuckets Tests...
===========================================

[✅] Basic Key-Value Set/Get PASSED
[✅] Overwriting a Key PASSED
[✅] Deleting a Key PASSED
[✅] Setting a Key with an Expiration PASSED
[✅] Ensure Expired Key is Deleted PASSED
[✅] Cache Read/Write Consistency PASSED
[✅] Cache Clears on Key Deletion PASSED
[✅] Setting a Full JSON String PASSED
[✅] Overwriting JSON with a Simple String PASSED
[✅] Deleting Non-Existent Key PASSED
[✅] Basic Key-Value Set/Get PASSED
[✅] Nested Key Set/Get PASSED
[✅] Prevent Overwriting Objects PASSED
[✅] Delete Nested Key PASSED
[✅] Delete Parent Key PASSED
[✅] Expiration Ignored for Nested Keys PASSED
[✅] Cache Read/Write Consistency PASSED
[✅] Cache Clears on Parent Delete PASSED
[✅] Set and Retrieve Full JSON Structure PASSED
[✅] Delete Nested Key within JSON PASSED
[✅] Ensure Object Protection on Overwrite Attempt PASSED
[✅] Deleting Non-Existent Key Doesn't Break Existing Data PASSED
[✅] Get nested key value PASSED
[✅] Get nested key value deep PASSED
[✅] Retrieve Nested Key from Plain String PASSED
[✅] Store and Retrieve JSON Array PASSED
[✅] Retrieve Non-Existent Nested Key PASSED
[✅] Overwriting Parent Key Deletes Children PASSED
[✅] Store and Retrieve Empty JSON Object PASSED
[✅] Store and Retrieve JSON String PASSED
[✅] Deeply Nested Key Retrieval PASSED
[✅] Setting a nested key with an expiration protection test PASSED

===========================================
✅ All DataBucket Tests Completed!
===========================================

```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Testing

## Nested Expiration Protection

```perl
sub EVENT_SAY {
    if ($text=~/nested_expire/i) {
        $client->SetBucket("test.test1.a", "something", "S20");
    }
}
```

Below we reject the expiration update but allow the value to be updated.

```
   Zone |   Debug    | ChannelMessageReceived Client::ChannelMessageReceived() [Channel:8] [message:nested_expire] -- [blackburrow] (Blackburrow) inst_id [0]
  Zone | DataBucket | GetData Getting bucket key [test] bot_id [0] account_id [0] character_id [9] npc_id [0] zone_id [0] instance_id [0] -- [blackburrow] (Blackburrow) inst_id [0]
  Zone | DataBucket | GetData Returning key [test] value [{"test1":{"a":"7","b":"1","c":{"f":"1"}}}] from cache -- [blackburrow] (Blackburrow) inst_id [0]
  Zone | DataBucket | SetData Nested keys can't expire; set expiration on the parent key -- [blackburrow] (Blackburrow) inst_id [0]
```

Data is still in tact

```
mariadb> select * from data_buckets where `key` = 'test';
+----------+------+-------------------------------------------------------------+---------+------------+--------------+--------+--------+---------+-------------+
| id       | key  | value                                                       | expires | account_id | character_id | npc_id | bot_id | zone_id | instance_id |
+----------+------+-------------------------------------------------------------+---------+------------+--------------+--------+--------+---------+-------------+
| 52451884 | test | {"test1":{"a":"something","b":"1","c":{"f":"1"}}}  |       0 |          0 |            9 |      0 |      0 |       0 |           0 |
+----------+------+-------------------------------------------------------------+---------+------------+--------------+--------+--------+---------+-------------+
1 row in set (0.00 sec)
```

## Nested Deletion / Protection Testing

Testing script 

```perl
sub EVENT_SAY {
    if ($text=~/test/i) {
        $client->SetBucket("test.test1.a", 7);
        $client->SetBucket("test.test1.b", 1);
        $client->SetBucket("test.test1.c", 1);
        $client->SetBucket("test.test1.c.f", 1);
        $client->SetBucket("test.test2.a", 1);
        $client->SetBucket("test.test2.b", 1);
        $client->SetBucket("test.test2.c", 1);
    }

    if ($text=~/write/i) {
        $client->SetBucket("test.test1", 1);
        $client->SetBucket("test.test2", 1);
    }

    if ($text=~/whole/i) {
        $client->SetBucket("test", '{"test1":{"a":"7","b":"1","c":{"f":"1"}},"test2":{"a":"1","b":"1","c":"1"}}');
    }

    if ($text=~/delete/i) {
        $client->DeleteBucket("test.test2");
    }

    if ($text=~/nuke/i) {
        $client->DeleteBucket("test");
    }
}
```

/say test

```
mariadb> select * from data_buckets where `key` = 'test';
+----------+------+----------------------------------------------------------------------------------------+---------+------------+--------------+--------+--------+---------+-------------+
| id       | key  | value                                                                                  | expires | account_id | character_id | npc_id | bot_id | zone_id | instance_id |
+----------+------+----------------------------------------------------------------------------------------+---------+------------+--------------+--------+--------+---------+-------------+
| 52451882 | test | {"test1":{"a":"7","b":"1","c":{"f":"1"}},"test2":{"a":"1","b":"1","c":"1"}}  |       0 |          0 |            9 |      0 |      0 |       0 |           0 |
+----------+------+----------------------------------------------------------------------------------------+---------+------------+--------------+--------+--------+---------+-------------+
```
 
/say write

We see below that the source protected accidental deletion of existing object (Need to use DeleteBucket) to explicitly delete.

```
  Zone | DataBucket | GetData Getting bucket key [test] bot_id [0] account_id [0] character_id [9] npc_id [0] zone_id [0] instance_id [0] -- [blackburrow] (Blackburrow) inst_id [0]
  Zone | DataBucket | GetData Returning key [test] value [{"test1":{"a":"7","b":"1","c":{"f":"1"}},"test2":{"a":"1","b":"1","c":"1"}}] from cache -- [blackburrow] (Blackburrow) inst_id [0]
  Zone | DataBucket | SetData Attempted to overwrite an existing object or array at key [test.test1] - skipping -- [blackburrow] (Blackburrow) inst_id [0]
  Zone | DataBucket | GetData Getting bucket key [test] bot_id [0] account_id [0] character_id [9] npc_id [0] zone_id [0] instance_id [0] -- [blackburrow] (Blackburrow) inst_id [0]
  Zone | DataBucket | GetData Returning key [test] value [{"test1":{"a":"7","b":"1","c":{"f":"1"}},"test2":{"a":"1","b":"1","c":"1"}}] from cache -- [blackburrow] (Blackburrow) inst_id [0]
  Zone | DataBucket | SetData Attempted to overwrite an existing object or array at key [test.test2] - skipping -- [blackburrow] (Blackburrow) inst_id [0]
```

We should still see our bucket in-tact (we do)

```
+----------+------+----------------------------------------------------------------------------------------+---------+------------+--------------+--------+--------+---------+-------------+
| id       | key  | value                                                                                  | expires | account_id | character_id | npc_id | bot_id | zone_id | instance_id |
+----------+------+----------------------------------------------------------------------------------------+---------+------------+--------------+--------+--------+---------+-------------+
| 52451882 | test | {"test1":{"a":"7","b":"1","c":{"f":"1"}},"test2":{"a":"1","b":"1","c":"1"}}  |       0 |          0 |            9 |      0 |      0 |       0 |           0 |
+----------+------+----------------------------------------------------------------------------------------+---------+------------+--------------+--------+--------+---------+-------------+
```
 
/say delete

This is a targeted delete of `test.test2`, below we see it and its nested keys removed

```
+----------+------+-----------------------------------------------------+---------+------------+--------------+--------+--------+---------+-------------+
| id       | key  | value                                               | expires | account_id | character_id | npc_id | bot_id | zone_id | instance_id |
+----------+------+-----------------------------------------------------+---------+------------+--------------+--------+--------+---------+-------------+
| 52451882 | test | {"test1":{"a":"7","b":"1","c":{"f":"1"}}}  |       0 |          0 |            9 |      0 |      0 |       0 |           0 |
+----------+------+-----------------------------------------------------+---------+------------+--------------+--------+--------+---------+-------------+
```
 
/say nuke

Below we see the entire key removed from the database and the local cache.

```
mariadb> select * from data_buckets where `key` = 'test';
Empty set
```
 
/say test

Key is re-created again (this tests cache)

```
mariadb> select * from data_buckets where `key` = 'test';
+----------+------+----------------------------------------------------------------------------------------+---------+------------+--------------+--------+--------+---------+-------------+
| id       | key  | value                                                                                  | expires | account_id | character_id | npc_id | bot_id | zone_id | instance_id |
+----------+------+----------------------------------------------------------------------------------------+---------+------------+--------------+--------+--------+---------+-------------+
| 52451883 | test | {"test1":{"a":"7","b":"1","c":{"f":"1"}},"test2":{"a":"1","b":"1","c":"1"}}  |       0 |          0 |            9 |      0 |      0 |       0 |           0 |
+----------+------+----------------------------------------------------------------------------------------+---------+------------+--------------+--------+--------+---------+-------------+
```
 
/say delete 

Deletes `test.test2` again

```
mariadb> select * from data_buckets where `key` = 'test';
+----------+------+-----------------------------------------------------+---------+------------+--------------+--------+--------+---------+-------------+
| id       | key  | value                                               | expires | account_id | character_id | npc_id | bot_id | zone_id | instance_id |
+----------+------+-----------------------------------------------------+---------+------------+--------------+--------+--------+---------+-------------+
| 52451883 | test | {"test1":{"a":"7","b":"1","c":{"f":"1"}}}  |       0 |          0 |            9 |      0 |      0 |       0 |           0 |
+----------+------+-----------------------------------------------------+---------+------------+--------------+--------+--------+---------+-------------+
1 row in set (0.00 sec)
```

Then finally **/say whole**

This tests to see if we can set an entire bucket tree from the parent manually still.

```
mariadb> select * from data_buckets where `key` = 'test';
+----------+------+----------------------------------------------------------------------------------------+---------+------------+--------------+--------+--------+---------+-------------+
| id       | key  | value                                                                                  | expires | account_id | character_id | npc_id | bot_id | zone_id | instance_id |
+----------+------+----------------------------------------------------------------------------------------+---------+------------+--------------+--------+--------+---------+-------------+
| 52451884 | test | {"test1":{"a":"7","b":"1","c":{"f":"1"}},"test2":{"a":"1","b":"1","c":"1"}}  |       0 |          0 |            9 |      0 |      0 |       0 |           0 |
+----------+------+----------------------------------------------------------------------------------------+---------+------------+--------------+--------+--------+---------+-------------+
1 row in set (0.00 sec)
```

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

