### PR TITLE
[Tests] Cleanup Hand-in Tests

### DIFF
--- a/zone/cli/databuckets.cpp
+++ b/zone/cli/databuckets.cpp
@@ -40,7 +40,7 @@ void ZoneCLI::DataBuckets(int argc, char **argv, argh::parser &cmd, std::string 
 	LogSys.EnableConsoleLogging();
 
 	std::cout << "===========================================\n";
-	std::cout << "Running DataBuckets Tests...\n";
+	std::cout << "⚙\uFE0F> Running DataBuckets Tests...\n";
 	std::cout << "===========================================\n\n";
 
 	Client *client = new Client();

--- a/zone/cli/npc_handins.cpp
+++ b/zone/cli/npc_handins.cpp
@@ -4,23 +4,82 @@
 #include "../zone.h"
 #include "../client.h"
 #include "../../common/net/eqstream.h"
+#include "../../common/json/json.hpp"
 
 extern Zone *zone;
+using json = nlohmann::json;
+
+struct HandinEntry {
+	std::string            item_id            = "0";
+	uint32                 count              = 0;
+	const EQ::ItemInstance *item              = nullptr;
+	bool                   is_multiquest_item = false; // state
+};
+
+struct HandinMoney {
+	uint32 platinum = 0;
+	uint32 gold     = 0;
+	uint32 silver   = 0;
+	uint32 copper   = 0;
+};
+
+struct Handin {
+	std::vector<HandinEntry> items = {}; // items can be removed from this set as successful handins are made
+	HandinMoney              money = {}; // money can be removed from this set as successful handins are made
+};
+
+struct TestCase {
+	std::string description;
+	Handin      hand_in;
+	Handin      required;
+	Handin      returned;
+	bool        handin_check_result;
+};
+
+void RunTest(const std::string &test_name, bool expected, bool actual)
+{
+	if (expected == actual) {
+		std::cout << "[✅] " << test_name << " PASSED\n";
+	}
+	else {
+		std::cerr << "[❌] " << test_name << " FAILED\n";
+		std::cerr << "   📌 Expected: " << (expected ? "true" : "false") << "\n";
+		std::cerr << "   ❌ Got:      " << (actual ? "true" : "false") << "\n";
+		std::exit(1);
+	}
+}
+
+void RunSerializedTest(const std::string &test_name, const std::string &expected, const std::string &actual)
+{
+	if (expected == actual) {
+		std::cout << "[✅] " << test_name << " PASSED\n";
+	}
+	else {
+		std::cerr << "[❌] " << test_name << " FAILED\n";
+		std::cerr << "   📌 Expected: " << expected << "\n";
+		std::cerr << "   ❌ Got:      " << actual << "\n";
+		std::exit(1);
+	}
+}
+
+std::string SerializeHandin(const std::map<std::string, uint32> &items, const HandinMoney &money)
+{
+	json j;
+	j["items"] = items;
+	j["money"] = {
+		{"platinum", money.platinum},
+		{"gold",     money.gold},
+		{"silver",   money.silver},
+		{"copper",   money.copper}
+	};
+	return j.dump();
+}
 
 void ZoneCLI::NpcHandins(int argc, char **argv, argh::parser &cmd, std::string &description)
 {
 	if (cmd[{"-h", "--help"}]) {
 		return;
 	}
-
-	uint32 break_length = 50;
-	int failed_count = 0;
-
-	RegisterExecutablePlatform(EQEmuExePlatform::ExePlatformZoneSidecar);
-
-	LogInfo("{}", Strings::Repeat("-", break_length));
-	LogInfo("Booting test zone for NPC handins");
-	LogInfo("{}", Strings::Repeat("-", break_length));
 
 	LogSys.SilenceConsoleLogging();
 
@@ -30,9 +89,9 @@ void ZoneCLI::NpcHandins(int argc, char **argv, argh::parser &cmd, std::string &
 	entity_list.Process();
 	entity_list.MobProcess();
 
-	LogInfo("{}", Strings::Repeat("-", break_length));
-	LogInfo("> Done booting test zone");
-	LogInfo("{}", Strings::Repeat("-", break_length));
+	std::cout << "===========================================\n";
+	std::cout << "⚙\uFE0F> Running Hand-in Tests...\n";
+	std::cout << "===========================================\n\n";
 
 	Client *c       = new Client();
 	auto   npc_type = content_db.LoadNPCTypesData(754008);
@@ -45,36 +104,6 @@ void ZoneCLI::NpcHandins(int argc, char **argv, argh::parser &cmd, std::string &
 		);
 
 		entity_list.AddNPC(npc);
-
-		LogInfo("> Spawned NPC [{}]", npc->GetCleanName());
-		LogInfo("> Spawned client [{}]", c->GetCleanName());
-
-		struct HandinEntry {
-			std::string            item_id            = "0";
-			uint32                 count              = 0;
-			const EQ::ItemInstance *item              = nullptr;
-			bool                   is_multiquest_item = false; // state
-		};
-
-		struct HandinMoney {
-			uint32 platinum = 0;
-			uint32 gold     = 0;
-			uint32 silver   = 0;
-			uint32 copper   = 0;
-		};
-
-		struct Handin {
-			std::vector<HandinEntry> items = {}; // items can be removed from this set as successful handins are made
-			HandinMoney              money = {}; // money can be removed from this set as successful handins are made
-		};
-
-		struct TestCase {
-			std::string description = "";
-			Handin      hand_in;
-			Handin      required;
-			Handin      returned;
-			bool        handin_check_result;
-		};
 
 		std::vector<TestCase> test_cases = {
 			TestCase{
@@ -155,7 +184,10 @@ void ZoneCLI::NpcHandins(int argc, char **argv, argh::parser &cmd, std::string &
 					.items = {},
 					.money = {.platinum = 100},
 				},
-				.returned = {},
+				.returned = {
+					.items = {},
+					.money = {.platinum = 1},
+				},
 				.handin_check_result = false,
 			},
 			TestCase{
@@ -168,7 +200,10 @@ void ZoneCLI::NpcHandins(int argc, char **argv, argh::parser &cmd, std::string &
 					.items = {},
 					.money = {.platinum = 100, .gold = 100, .silver = 100, .copper = 100},
 				},
-				.returned = {},
+				.returned = {
+					.items = {},
+					.money = {.platinum = 1, .gold = 1, .silver = 1, .copper = 1},
+				},
 				.handin_check_result = false,
 			},
 			TestCase{
@@ -217,8 +252,11 @@ void ZoneCLI::NpcHandins(int argc, char **argv, argh::parser &cmd, std::string &
 				},
 				.returned = {
 					.items = {
-						HandinEntry{.item_id = "1001", .count = 1},
+						HandinEntry{
+							.item_id = "1001", .count = 0,
+						},
 					},
+					.money = {.platinum = 1},
 				},
 				.handin_check_result = false,
 			},
@@ -304,12 +342,7 @@ void ZoneCLI::NpcHandins(int argc, char **argv, argh::parser &cmd, std::string &
 						HandinEntry{.item_id = "1007", .count = 1},
 						HandinEntry{.item_id = "1007", .count = 1},
 					},
-					.money = {
-						.platinum = 1,
-						.gold    = 666,
-						.silver  = 234,
-						.copper  = 444,
-					},
+					.money = {},
 				},
 				.handin_check_result = true,
 			},
@@ -402,8 +435,8 @@ void ZoneCLI::NpcHandins(int argc, char **argv, argh::parser &cmd, std::string &
 			},
 		};
 
-		std::map<std::string, uint32>         hand_ins;
-		std::map<std::string, uint32>         required;
+		std::map<std::string, uint32>   hand_ins;
+		std::map<std::string, uint32>   required;
 		std::vector<EQ::ItemInstance *> items;
 
 		LogSys.EnableConsoleLogging();
@@ -411,14 +444,12 @@ void ZoneCLI::NpcHandins(int argc, char **argv, argh::parser &cmd, std::string &
 		// turn this on to see debugging output
 		LogSys.log_settings[Logs::NpcHandin].log_to_console = std::getenv("DEBUG") ? 3 : 0;
 
-		LogInfo("{}", Strings::Repeat("-", break_length));
-
-		for (auto &test_case: test_cases) {
+		for (auto &test: test_cases) {
 			hand_ins.clear();
 			required.clear();
 			items.clear();
 
-			for (auto &hand_in: test_case.hand_in.items) {
+			for (auto &hand_in: test.hand_in.items) {
 				auto             item_id = Strings::ToInt(hand_in.item_id);
 				EQ::ItemInstance *inst   = database.CreateItem(item_id);
 				if (inst->IsStackable()) {
@@ -434,71 +465,75 @@ void ZoneCLI::NpcHandins(int argc, char **argv, argh::parser &cmd, std::string &
 			}
 
 			// money
-			if (test_case.hand_in.money.platinum > 0) {
-				hand_ins["platinum"] = test_case.hand_in.money.platinum;
+			if (test.hand_in.money.platinum > 0) {
+				hand_ins["platinum"] = test.hand_in.money.platinum;
 			}
-			if (test_case.hand_in.money.gold > 0) {
-				hand_ins["gold"] = test_case.hand_in.money.gold;
+			if (test.hand_in.money.gold > 0) {
+				hand_ins["gold"] = test.hand_in.money.gold;
 			}
-			if (test_case.hand_in.money.silver > 0) {
-				hand_ins["silver"] = test_case.hand_in.money.silver;
+			if (test.hand_in.money.silver > 0) {
+				hand_ins["silver"] = test.hand_in.money.silver;
 			}
-			if (test_case.hand_in.money.copper > 0) {
-				hand_ins["copper"] = test_case.hand_in.money.copper;
+			if (test.hand_in.money.copper > 0) {
+				hand_ins["copper"] = test.hand_in.money.copper;
 			}
 
-			for (auto &req: test_case.required.items) {
+			for (auto &req: test.required.items) {
 				required[req.item_id] = req.count;
 			}
 
 			// money
-			if (test_case.required.money.platinum > 0) {
-				required["platinum"] = test_case.required.money.platinum;
+			if (test.required.money.platinum > 0) {
+				required["platinum"] = test.required.money.platinum;
 			}
-			if (test_case.required.money.gold > 0) {
-				required["gold"] = test_case.required.money.gold;
+			if (test.required.money.gold > 0) {
+				required["gold"] = test.required.money.gold;
 			}
-			if (test_case.required.money.silver > 0) {
-				required["silver"] = test_case.required.money.silver;
+			if (test.required.money.silver > 0) {
+				required["silver"] = test.required.money.silver;
 			}
-			if (test_case.required.money.copper > 0) {
-				required["copper"] = test_case.required.money.copper;
+			if (test.required.money.copper > 0) {
+				required["copper"] = test.required.money.copper;
 			}
 
 			auto result = npc->CheckHandin(c, hand_ins, required, items);
-			if (result != test_case.handin_check_result) {
-				failed_count++;
-				LogError("FAIL [{}]", test_case.description);
-				// print out the hand-ins
-				LogError("Hand-ins >");
-				for (auto &hand_in: hand_ins) {
-					LogError(" > Item [{}] count [{}]", hand_in.first, hand_in.second);
-				}
-				LogError("Required >");
-				for (auto &req: required) {
-					LogError(" > Item [{}] count [{}]", req.first, req.second);
-				}
-				LogError("Expected [{}] got [{}]", test_case.handin_check_result, result);
-			}
-			else {
-				LogInfo("PASS [{}]", test_case.description);
-			}
+
+			RunTest(test.description, test.handin_check_result, result);
 
 			auto returned = npc->ReturnHandinItems(c);
 
-			// assert that returned items are expected
-			for (auto &item: test_case.returned.items) {
-				auto      found = false;
-				for (auto &ret: returned.items) {
-					if (ret.item_id == item.item_id) {
-						found = true;
-						break;
-					}
-				}
-				if (!found) {
-					LogError("Returned item [{}] not expected", item.item_id);
-				}
+			std::map<std::string, uint32> returned_items;
+			HandinMoney                   returned_money{};
+
+			// Serialize returned items
+			for (const auto &ret: returned.items) {
+//				if (ret.item->IsStackable() && ret.item->GetCharges() != ret.count) {
+//					ret.item->SetCharges(ret.count);
+//				}
+				returned_items[ret.item_id] += ret.count;
 			}
+
+			// Serialize returned money
+			returned_money.platinum = returned.money.platinum;
+			returned_money.gold     = returned.money.gold;
+			returned_money.silver   = returned.money.silver;
+			returned_money.copper   = returned.money.copper;
+
+			// Serialize expected and actual return values for comparison
+			std::map<std::string, uint32> expected_returned_items;
+			for (const auto               &entry: test.returned.items) {
+				expected_returned_items[entry.item_id] += entry.count;
+			}
+
+			std::string expected_serialized = SerializeHandin(
+				expected_returned_items,
+				test.returned.money
+			);
+
+			std::string actual_serialized = SerializeHandin(returned_items, returned_money);
+
+			// Run serialization check test
+			RunSerializedTest(test.description + " (Return Validation)", expected_serialized, actual_serialized);
 
 			npc->ResetHandin();
 
@@ -508,11 +543,7 @@ void ZoneCLI::NpcHandins(int argc, char **argv, argh::parser &cmd, std::string &
 		}
 	}
 
-	if (failed_count > 0) {
-		LogError("Failed [{}] tests", failed_count);
-		std::exit(1);
-	}
-	else {
-		LogInfo("All tests passed");
-	}
+	std::cout << "\n===========================================\n";
+	std::cout << "✅ All NPC Hand-in Tests Completed!\n";
+	std::cout << "===========================================\n";
 }


### PR DESCRIPTION
# Description

This adjusts the automated test coverage for hand-ins to be more uniform with recent testing paradigms and output patterns. It also fixes some test cases.

```
eqemu@ct-eqemu-server:~/server$ n && server && ./bin/zone tests:npc-handins
ninja: no work to do.
===========================================
⚙️> Running Hand-in Tests...
===========================================

[✅] Test basic cloth-cap hand-in PASSED
[✅] Test basic cloth-cap hand-in (Return Validation) PASSED
[✅] Test basic cloth-cap hand-in failure PASSED
[✅] Test basic cloth-cap hand-in failure (Return Validation) PASSED
[✅] Test basic cloth-cap hand-in failure from handing in too many PASSED
[✅] Test basic cloth-cap hand-in failure from handing in too many (Return Validation) PASSED
[✅] Test handing in money PASSED
[✅] Test handing in money (Return Validation) PASSED
[✅] Test handing in money, but not enough PASSED
[✅] Test handing in money, but not enough (Return Validation) PASSED
[✅] Test handing in money, but not enough of any type PASSED
[✅] Test handing in money, but not enough of any type (Return Validation) PASSED
[✅] Test handing in money of all types PASSED
[✅] Test handing in money of all types (Return Validation) PASSED
[✅] Test handing in platinum with items with success PASSED
[✅] Test handing in platinum with items with success (Return Validation) PASSED
[✅] Test handing in platinum with items with failure PASSED
[✅] Test handing in platinum with items with failure (Return Validation) PASSED
[✅] Test returning money and items PASSED
[✅] Test returning money and items (Return Validation) PASSED
[✅] Test returning money PASSED
[✅] Test returning money (Return Validation) PASSED
[✅] Test handing in many items of the same required item PASSED
[✅] Test handing in many items of the same required item (Return Validation) PASSED
[✅] Test handing in item of a stack PASSED
[✅] Test handing in item of a stack (Return Validation) PASSED
[✅] Test handing in item of a stack but not enough PASSED
[✅] Test handing in item of a stack but not enough (Return Validation) PASSED
[✅] Test handing in 4 non-stacking helmets when 4 are required PASSED
[✅] Test handing in 4 non-stacking helmets when 4 are required (Return Validation) PASSED
[✅] Test handing in Soulfire that has 5 charges and have it count as 1 item PASSED
[✅] Test handing in Soulfire that has 5 charges and have it count as 1 item (Return Validation) PASSED

===========================================
✅ All NPC Hand-in Tests Completed!
===========================================

eqemu@ct-eqemu-server:~/server$ n && server && ./bin/zone tests:npc-handins-multiquest
[2/2] Linking CXX executable bin/zone
===========================================
⚙️> Running Hand-in Tests (Multi-Quest)...
===========================================

[✅] Journeyman's Boots PASSED

===========================================
✅ All NPC Hand-in Tests Completed (Multi-Quest)!
===========================================
```

## Type of change

- [x] Test coverage

# Testing

Included in description

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

