### PR TITLE
[Zone] Make zone controller less likely to be visible, immune to all forms of combat

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -2914,7 +2914,7 @@ void EntityList::ScanCloseMobs(Mob *scanning_mob)
 		return;
 	}
 
-	if (scanning_mob->GetID() <= 0) {
+	if (scanning_mob->GetID() <= 0 || scanning_mob->IsZoneController()) {
 		return;
 	}
 
@@ -2933,7 +2933,7 @@ void EntityList::ScanCloseMobs(Mob *scanning_mob)
 	for (auto &e : mob_list) {
 		auto mob = e.second;
 
-		if (mob && mob->GetID() <= 0) {
+		if (mob && (mob->GetID() <= 0 || mob->IsZoneController())) {
 			continue;
 		}
 

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1453,7 +1453,7 @@ void Mob::FillSpawnStruct(NewSpawn_Struct* ns, Mob* ForWho)
 		ns->spawn.flymode = 0;
 	}
 
-	if (IsNPC() && GetNPCTypeID() == ZONE_CONTROLLER_NPC_ID) {
+	if (IsZoneController()) {
 		ns->spawn.invis = 255; // gm invis
 	}
 
@@ -8351,7 +8351,7 @@ int Mob::DispatchZoneControllerEvent(
 		RuleB(Zone, UseZoneController) &&
 		(
 			!IsNPC() ||
-			(IsNPC() && GetNPCTypeID() != ZONE_CONTROLLER_NPC_ID)
+			(IsNPC() && !IsZoneController())
 		)
 	) {
 		auto controller = entity_list.GetNPCByNPCTypeID(ZONE_CONTROLLER_NPC_ID);

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1453,6 +1453,10 @@ void Mob::FillSpawnStruct(NewSpawn_Struct* ns, Mob* ForWho)
 		ns->spawn.flymode = 0;
 	}
 
+	if (IsNPC() && GetNPCTypeID() == ZONE_CONTROLLER_NPC_ID) {
+		ns->spawn.invis = 255; // gm invis
+	}
+
 	if (RuleB(Character, AllowCrossClassTrainers) && ForWho) {
 		if (ns->spawn.class_ >= Class::WarriorGM && ns->spawn.class_ <= Class::BerserkerGM) {
 			int trainer_class = Class::WarriorGM + (ForWho->GetClass() - 1);

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -671,6 +671,7 @@ public:
 		((static_cast<float>(current_mana) / max_mana) * 100); }
 	virtual int64 CalcMaxMana();
 	uint32 GetNPCTypeID() const { return npctype_id; }
+	inline bool IsZoneController() const { return npctype_id == ZONE_CONTROLLER_NPC_ID; }
 	void SetNPCTypeID(uint32 npctypeid) { npctype_id = npctypeid; }
 	inline const glm::vec4& GetPosition() const { return m_Position; }
 	inline void SetPosition(const float x, const float y, const float z) { m_Position.x = x; m_Position.y = y; m_Position.z = z; }

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -941,13 +941,14 @@ bool NPC::SpawnZoneController()
 
 	npc_type->findable  = 0;
 	npc_type->trackable = 0;
+	npc_type->untargetable = 1;
 
-	strcpy(npc_type->special_abilities, "12,1^13,1^14,1^15,1^16,1^17,1^19,1^22,1^24,1^25,1^28,1^31,1^35,1^39,1^42,1");
+	strcpy(npc_type->special_abilities, "1,1,3000,50^12,1^14,1^16,1^18,1^19,1^20,1^21,1^22,1^23,1^24,1^25,1^26,1^32,1^33,1^35,1^46,1^47,1^48,1^49,1^50,1^52,1^53,1^54,1^55,1^56,1^57,1");
 
 	glm::vec4 point;
-	point.x = 3000;
-	point.y = 1000;
-	point.z = 500;
+	point.x = 30000;
+	point.y = 10000;
+	point.z = -10000;
 
 	auto npc = new NPC(npc_type, nullptr, point, GravityBehavior::Flying);
 	npc->GiveNPCTypeData(npc_type);


### PR DESCRIPTION
# Description

This should make the zone controller less likely to be found visible (0,0,0), sets it to untargetable as well as GM invis. Set all immune / no-combat special abilities as well

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Tested in game, seems to work 

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
