### PR TITLE
[Rules] Fix EvolvingItems:PercentOfRaidExperience Description

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -1161,7 +1161,7 @@ RULE_CATEGORY_END()
 RULE_CATEGORY(EvolvingItems)
 RULE_REAL(EvolvingItems, PercentOfSoloExperience, 0.1, "Percentage of solo experience allocated to evolving items that require experience.")
 RULE_REAL(EvolvingItems, PercentOfGroupExperience, 0.1, "Percentage of group experience allocated to evolving items that require experience.")
-RULE_REAL(EvolvingItems, PercentOfRaidExperience, 0.1, "Percentage of solo experience allocated to evolving items that require experience.")
+RULE_REAL(EvolvingItems, PercentOfRaidExperience, 0.1, "Percentage of raid experience allocated to evolving items that require experience.")
 RULE_INT(EvolvingItems, DelayUponEquipping, 30000, "Delay in ms before an evolving item will earn rewards after equipping.  Default is 30000ms or 30s.")
 RULE_CATEGORY_END()
 


### PR DESCRIPTION
- Fixes an issue where the description was inaccurate, described [here](https://discord.com/channels/212663220849213441/557677602706423982/1347293634453835899).