### PR TITLE
[Feature] Add Rule for dealing with augments when an item evolves

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -1163,6 +1163,7 @@ RULE_REAL(EvolvingItems, PercentOfSoloExperience, 0.1, "Percentage of solo exper
 RULE_REAL(EvolvingItems, PercentOfGroupExperience, 0.1, "Percentage of group experience allocated to evolving items that require experience.")
 RULE_REAL(EvolvingItems, PercentOfRaidExperience, 0.1, "Percentage of solo experience allocated to evolving items that require experience.")
 RULE_INT(EvolvingItems, DelayUponEquipping, 30000, "Delay in ms before an evolving item will earn rewards after equipping.  Default is 30000ms or 30s.")
+RULE_BOOL(EvolvingItems, DestroyAugmentsOnEvolve, false, "If this is enabled, any augments in an item will be destroyed when the item evolves. Otherwise, send augments to the player via the parcel system (requires that the Parcel System be enabled).")
 RULE_CATEGORY_END()
 
 #undef RULE_CATEGORY

--- a/zone/client.h
+++ b/zone/client.h
@@ -404,6 +404,7 @@ public:
 	void LoadParcels();
 	std::map<uint32, CharacterParcelsRepository::CharacterParcels> GetParcels() { return m_parcels; }
 	int32 FindNextFreeParcelSlot(uint32 char_id);
+	int32 FindNextFreeParcelSlotUsingMemory();
 	void SendParcelIconStatus();
 
 	void SendBecomeTraderToWorld(Client *trader, BazaarTraderBarterActions action);
@@ -1900,7 +1901,7 @@ public:
 	void SendEvolvingPacket(int8 action, const CharacterEvolvingItemsRepository::CharacterEvolvingItems &item);
 	void DoEvolveItemToggle(const EQApplicationPacket* app);
 	void DoEvolveItemDisplayFinalResult(const EQApplicationPacket* app);
-	bool DoEvolveCheckProgression(const EQ::ItemInstance &inst);
+	bool DoEvolveCheckProgression(EQ::ItemInstance &inst);
 	void SendEvolveXPWindowDetails(const EQApplicationPacket* app);
 	void DoEvolveTransferXP(const EQApplicationPacket* app);
 	void SendEvolveXPTransferWindow();

--- a/zone/parcels.cpp
+++ b/zone/parcels.cpp
@@ -888,6 +888,22 @@ void Client::AddParcel(CharacterParcelsRepository::CharacterParcels &parcel)
 			"Unable to send parcel at this time.  Please try again later."
 		);
 		SendParcelAck();
-		return;
 	}
+}
+
+int32 Client::FindNextFreeParcelSlotUsingMemory()
+{
+	auto const results = GetParcels();
+
+	if (results.empty()) {
+		return PARCEL_BEGIN_SLOT;
+	}
+
+	for (uint32 i = PARCEL_BEGIN_SLOT; i <= RuleI(Parcel, ParcelMaxItems); i++) {
+		if (!results.contains(i)) {
+			return i;
+		}
+	}
+
+	return INVALID_INDEX;
 }


### PR DESCRIPTION
# Description

Current logic destroys augments if an augmented item evolves.  Community asked for a QoL rule to allow augments to be removed and sent via the parcel system, instead of destroying them.

This feature update creates a rule to EvolvingItems, DestroyAugmentsOnEvolve with a default value of false.  This rule controls the behaviour.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# Testing
Tested with item 89550 augmented with 39384.

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I have made corresponding changes to the documentation (if applicable, if not delete this line)
- [X] I own the changes of my code and take responsibility for the potential issues that occur