### PR TITLE
[Feature] Allow assigning Helm Texture independently of Body Texture for Horses

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -6938,6 +6938,18 @@ CREATE TABLE `character_pet_name` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 )",
 	},
+	ManifestEntry{
+		.version = 9310,
+		.description = "2025_03_7_expand_horse_def.sql",
+		.check = "SHOW COLUMNS FROM `horses` LIKE `helmtexture",
+		.condition = "missing",
+		.match = "TINYINT(2)",
+		.sql = R"(
+ALTER TABLE `horses`
+	ADD COLUMN `helmtexture` TINYINT(2) NOT NULL DEFAULT -1 AFTER `texture`;
+)",
+		.content_schema_update = true
+	},
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{
 //		.version = 9228,

--- a/common/repositories/base/base_horses_repository.h
+++ b/common/repositories/base/base_horses_repository.h
@@ -24,6 +24,7 @@ public:
 		int16_t     race;
 		int8_t      gender;
 		int8_t      texture;
+		int8_t      helmtexture;
 		float       mountspeed;
 		std::string notes;
 	};
@@ -41,6 +42,7 @@ public:
 			"race",
 			"gender",
 			"texture",
+			"helmtexture",
 			"mountspeed",
 			"notes",
 		};
@@ -54,6 +56,7 @@ public:
 			"race",
 			"gender",
 			"texture",
+			"helmtexture",
 			"mountspeed",
 			"notes",
 		};
@@ -96,13 +99,14 @@ public:
 	{
 		Horses e{};
 
-		e.id         = 0;
-		e.filename   = "";
-		e.race       = 216;
-		e.gender     = 0;
-		e.texture    = 0;
-		e.mountspeed = 0.75;
-		e.notes      = "Notes";
+		e.id          = 0;
+		e.filename    = "";
+		e.race        = 216;
+		e.gender      = 0;
+		e.texture     = 0;
+		e.helmtexture = -1;
+		e.mountspeed  = 0.75;
+		e.notes       = "Notes";
 
 		return e;
 	}
@@ -139,13 +143,14 @@ public:
 		if (results.RowCount() == 1) {
 			Horses e{};
 
-			e.id         = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
-			e.filename   = row[1] ? row[1] : "";
-			e.race       = row[2] ? static_cast<int16_t>(atoi(row[2])) : 216;
-			e.gender     = row[3] ? static_cast<int8_t>(atoi(row[3])) : 0;
-			e.texture    = row[4] ? static_cast<int8_t>(atoi(row[4])) : 0;
-			e.mountspeed = row[5] ? strtof(row[5], nullptr) : 0.75;
-			e.notes      = row[6] ? row[6] : "Notes";
+			e.id          = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
+			e.filename    = row[1] ? row[1] : "";
+			e.race        = row[2] ? static_cast<int16_t>(atoi(row[2])) : 216;
+			e.gender      = row[3] ? static_cast<int8_t>(atoi(row[3])) : 0;
+			e.texture     = row[4] ? static_cast<int8_t>(atoi(row[4])) : 0;
+			e.helmtexture = row[5] ? static_cast<int8_t>(atoi(row[5])) : -1;
+			e.mountspeed  = row[6] ? strtof(row[6], nullptr) : 0.75;
+			e.notes       = row[7] ? row[7] : "Notes";
 
 			return e;
 		}
@@ -183,8 +188,9 @@ public:
 		v.push_back(columns[2] + " = " + std::to_string(e.race));
 		v.push_back(columns[3] + " = " + std::to_string(e.gender));
 		v.push_back(columns[4] + " = " + std::to_string(e.texture));
-		v.push_back(columns[5] + " = " + std::to_string(e.mountspeed));
-		v.push_back(columns[6] + " = '" + Strings::Escape(e.notes) + "'");
+		v.push_back(columns[5] + " = " + std::to_string(e.helmtexture));
+		v.push_back(columns[6] + " = " + std::to_string(e.mountspeed));
+		v.push_back(columns[7] + " = '" + Strings::Escape(e.notes) + "'");
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -211,6 +217,7 @@ public:
 		v.push_back(std::to_string(e.race));
 		v.push_back(std::to_string(e.gender));
 		v.push_back(std::to_string(e.texture));
+		v.push_back(std::to_string(e.helmtexture));
 		v.push_back(std::to_string(e.mountspeed));
 		v.push_back("'" + Strings::Escape(e.notes) + "'");
 
@@ -247,6 +254,7 @@ public:
 			v.push_back(std::to_string(e.race));
 			v.push_back(std::to_string(e.gender));
 			v.push_back(std::to_string(e.texture));
+			v.push_back(std::to_string(e.helmtexture));
 			v.push_back(std::to_string(e.mountspeed));
 			v.push_back("'" + Strings::Escape(e.notes) + "'");
 
@@ -282,13 +290,14 @@ public:
 		for (auto row = results.begin(); row != results.end(); ++row) {
 			Horses e{};
 
-			e.id         = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
-			e.filename   = row[1] ? row[1] : "";
-			e.race       = row[2] ? static_cast<int16_t>(atoi(row[2])) : 216;
-			e.gender     = row[3] ? static_cast<int8_t>(atoi(row[3])) : 0;
-			e.texture    = row[4] ? static_cast<int8_t>(atoi(row[4])) : 0;
-			e.mountspeed = row[5] ? strtof(row[5], nullptr) : 0.75;
-			e.notes      = row[6] ? row[6] : "Notes";
+			e.id          = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
+			e.filename    = row[1] ? row[1] : "";
+			e.race        = row[2] ? static_cast<int16_t>(atoi(row[2])) : 216;
+			e.gender      = row[3] ? static_cast<int8_t>(atoi(row[3])) : 0;
+			e.texture     = row[4] ? static_cast<int8_t>(atoi(row[4])) : 0;
+			e.helmtexture = row[5] ? static_cast<int8_t>(atoi(row[5])) : -1;
+			e.mountspeed  = row[6] ? strtof(row[6], nullptr) : 0.75;
+			e.notes       = row[7] ? row[7] : "Notes";
 
 			all_entries.push_back(e);
 		}
@@ -313,13 +322,14 @@ public:
 		for (auto row = results.begin(); row != results.end(); ++row) {
 			Horses e{};
 
-			e.id         = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
-			e.filename   = row[1] ? row[1] : "";
-			e.race       = row[2] ? static_cast<int16_t>(atoi(row[2])) : 216;
-			e.gender     = row[3] ? static_cast<int8_t>(atoi(row[3])) : 0;
-			e.texture    = row[4] ? static_cast<int8_t>(atoi(row[4])) : 0;
-			e.mountspeed = row[5] ? strtof(row[5], nullptr) : 0.75;
-			e.notes      = row[6] ? row[6] : "Notes";
+			e.id          = row[0] ? static_cast<int32_t>(atoi(row[0])) : 0;
+			e.filename    = row[1] ? row[1] : "";
+			e.race        = row[2] ? static_cast<int16_t>(atoi(row[2])) : 216;
+			e.gender      = row[3] ? static_cast<int8_t>(atoi(row[3])) : 0;
+			e.texture     = row[4] ? static_cast<int8_t>(atoi(row[4])) : 0;
+			e.helmtexture = row[5] ? static_cast<int8_t>(atoi(row[5])) : -1;
+			e.mountspeed  = row[6] ? strtof(row[6], nullptr) : 0.75;
+			e.notes       = row[7] ? row[7] : "Notes";
 
 			all_entries.push_back(e);
 		}
@@ -399,6 +409,7 @@ public:
 		v.push_back(std::to_string(e.race));
 		v.push_back(std::to_string(e.gender));
 		v.push_back(std::to_string(e.texture));
+		v.push_back(std::to_string(e.helmtexture));
 		v.push_back(std::to_string(e.mountspeed));
 		v.push_back("'" + Strings::Escape(e.notes) + "'");
 
@@ -428,6 +439,7 @@ public:
 			v.push_back(std::to_string(e.race));
 			v.push_back(std::to_string(e.gender));
 			v.push_back(std::to_string(e.texture));
+			v.push_back(std::to_string(e.helmtexture));
 			v.push_back(std::to_string(e.mountspeed));
 			v.push_back("'" + Strings::Escape(e.notes) + "'");
 

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9309
+#define CURRENT_BINARY_DATABASE_VERSION 9310
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9054
 
 #endif

--- a/zone/horse.cpp
+++ b/zone/horse.cpp
@@ -108,7 +108,7 @@ const NPCType *Horse::BuildHorseType(uint16 spell_id)
 	n->npc_id       = 0;
 	n->loottable_id = 0;
 	n->texture      = e.texture;
-	n->helmtexture  = e.texture;
+	n->helmtexture  = e.helmtexture == -1 ? e.texture : e.helmtexture;
 	n->runspeed     = e.mountspeed;
 	n->light        = 0;
 	n->STR          = 75;


### PR DESCRIPTION
# Description

This does what it says on the tin, useful for some mount models which use helm texture for 'accessories'. Default value of -1 for the new DB field uses texture as helmtexture (current behavior, so non-breaking)

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# Testing

Migration:
![image](https://github.com/user-attachments/assets/2aa3899d-12f2-4fe0-899e-503e3aff39eb)

Result:
![image](https://github.com/user-attachments/assets/9fc5fea2-db20-47f3-9482-1a44c5ad034c)

Clients tested: 

RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
- [X] If my changes make database schema changes, I have tested the changes on a local database (attach image). Updated version.h CURRENT_BINARY_DATABASE_VERSION to the new version.
