### PR TITLE
[Bug Fix] Correct incorrectly calculated stat caps with Heroic Stats

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -318,13 +318,13 @@ void Mob::AddItemBonuses(const EQ::ItemInstance* inst, StatBonuses* b, bool is_a
 	b->HeroicWIS += CalcItemBonus(item->HeroicWis);
 	b->HeroicCHA += CalcItemBonus(item->HeroicCha);
 
-	b->STRCapMod += item->HeroicSTR;
-	b->STACapMod += item->HeroicSTA;
-	b->DEXCapMod += item->HeroicDEX;
-	b->AGICapMod += item->HeroicAGI;
-	b->INTCapMod += item->HeroicINT;
-	b->WISCapMod += item->HeroicWIS;
-	b->CHACapMod += item->HeroicCHA;
+	b->STRCapMod += item->HeroicStr;
+	b->STACapMod += item->HeroicSta;
+	b->DEXCapMod += item->HeroicDex;
+	b->AGICapMod += item->HeroicAgi;
+	b->INTCapMod += item->HeroicInt;
+	b->WISCapMod += item->HeroicWis;
+	b->CHACapMod += item->HeroicCha;
 
 	b->MR += CalcItemBonus(item->MR + item->HeroicMR);
 	b->FR += CalcItemBonus(item->FR + item->HeroicFR);
@@ -345,7 +345,7 @@ void Mob::AddItemBonuses(const EQ::ItemInstance* inst, StatBonuses* b, bool is_a
 	b->CRCapMod += item->HeroicCR;
 	b->PRCapMod += item->HeroicPR;
 	b->DRCapMod += item->HeroicDR;
-	b->CorrupCapMod += item->HeroicCorrup;
+	b->CorrupCapMod += item->HeroicSVCorrup;
 
 	b->HPRegen += CalcItemBonus(item->Regen);
 	b->ManaRegen += CalcItemBonus(item->ManaRegen);

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -318,13 +318,13 @@ void Mob::AddItemBonuses(const EQ::ItemInstance* inst, StatBonuses* b, bool is_a
 	b->HeroicWIS += CalcItemBonus(item->HeroicWis);
 	b->HeroicCHA += CalcItemBonus(item->HeroicCha);
 
-	b->STRCapMod += b->HeroicSTR;
-	b->STACapMod += b->HeroicSTA;
-	b->DEXCapMod += b->HeroicDEX;
-	b->AGICapMod += b->HeroicAGI;
-	b->INTCapMod += b->HeroicINT;
-	b->WISCapMod += b->HeroicWIS;
-	b->CHACapMod += b->HeroicCHA;
+	b->STRCapMod += item->HeroicSTR;
+	b->STACapMod += item->HeroicSTA;
+	b->DEXCapMod += item->HeroicDEX;
+	b->AGICapMod += item->HeroicAGI;
+	b->INTCapMod += item->HeroicINT;
+	b->WISCapMod += item->HeroicWIS;
+	b->CHACapMod += item->HeroicCHA;
 
 	b->MR += CalcItemBonus(item->MR + item->HeroicMR);
 	b->FR += CalcItemBonus(item->FR + item->HeroicFR);
@@ -340,12 +340,12 @@ void Mob::AddItemBonuses(const EQ::ItemInstance* inst, StatBonuses* b, bool is_a
 	b->HeroicDR += CalcItemBonus(item->HeroicDR);
 	b->HeroicCorrup += CalcItemBonus(item->HeroicSVCorrup);
 
-	b->MRCapMod += b->HeroicMR;
-	b->FRCapMod += b->HeroicFR;
-	b->CRCapMod += b->HeroicCR;
-	b->PRCapMod += b->HeroicPR;
-	b->DRCapMod += b->HeroicDR;
-	b->CorrupCapMod += b->HeroicCorrup;
+	b->MRCapMod += item->HeroicMR;
+	b->FRCapMod += item->HeroicFR;
+	b->CRCapMod += item->HeroicCR;
+	b->PRCapMod += item->HeroicPR;
+	b->DRCapMod += item->HeroicDR;
+	b->CorrupCapMod += item->HeroicCorrup;
 
 	b->HPRegen += CalcItemBonus(item->Regen);
 	b->ManaRegen += CalcItemBonus(item->ManaRegen);


### PR DESCRIPTION
# Description

Fixes effectively infinite stat caps when any gear with a heroic stat is equipped.

Draft while I verify no other outstanding issues here.

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

I literally can't take screenshots today.

Issue is very apparent from commits.

Clients tested: 
ROF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur