### PR TITLE
[Bug Fix] Zero out currentnpcid whenever spawn is reset.

### DIFF
--- a/zone/spawn2.cpp
+++ b/zone/spawn2.cpp
@@ -356,6 +356,7 @@ void Spawn2::LoadGrid(int start_wp) {
 void Spawn2::Reset() {
 	timer.Start(resetTimer());
 	npcthis = nullptr;
+	currentnpcid = 0;
 	LogSpawns("Spawn2 [{}]: Spawn reset, repop in [{}] ms", spawn2_id, timer.GetRemainingTime());
 }
 
@@ -363,6 +364,7 @@ void Spawn2::Depop() {
 	timer.Disable();
 	LogSpawns("Spawn2 [{}]: Spawn reset, repop disabled", spawn2_id);
 	npcthis = nullptr;
+	currentnpcid = 0;
 }
 
 void Spawn2::Repop(uint32 delay) {
@@ -374,6 +376,7 @@ void Spawn2::Repop(uint32 delay) {
 		timer.Start(delay);
 	}
 	npcthis = nullptr;
+	currentnpcid = 0;
 }
 
 void Spawn2::ForceDespawn()
@@ -392,12 +395,14 @@ void Spawn2::ForceDespawn()
 				npcthis->Depop(true);
 				IsDespawned = true;
 				npcthis = nullptr;
+				currentnpcid = 0;
 				return;
 			}
 			else
 			{
 				npcthis->Depop(false);
 				npcthis = nullptr;
+				currentnpcid = 0;
 			}
 		}
 	}
@@ -429,6 +434,7 @@ void Spawn2::DeathReset(bool realdeath)
 
 	//zero out our NPC since he is now gone
 	npcthis = nullptr;
+	currentnpcid = 0;
 
 	if(realdeath) { killcount++; }
 
@@ -643,6 +649,7 @@ void Spawn2::SpawnConditionChanged(const SpawnCondition &c, int16 old_value) {
 			LogSpawns("Spawn2 [{}]: Our npcthis is currently not null. The zone thinks it is [{}]. Forcing a depop", spawn2_id, npcthis->GetName());
 			npcthis->Depop(false);	//remove the current mob
 			npcthis = nullptr;
+			currentnpcid = 0;
 		}
 		if(new_state) { // only get repawn timer remaining when the SpawnCondition is enabled.
 			timer_remaining = database.GetSpawnTimeLeft(spawn2_id,zone->GetInstanceID());


### PR DESCRIPTION
# Description

Spawns are retaining this value between respawns which prevents them from choosing a different npc to spawn each time.  I basically went through and just zero'd out this value whenever 'npcthis' gets set to nullptr.

### Test Cases
- Full zone repop: NPC's respawn are randomized
- #depop 1: A random npc is chosen on respawn
- #kill: Random npc is chosen on respawn
- #damage 10000: Random npc is chosen on respawn
- State save/reload: NPC types are properly preserved.
