### PR TITLE
[Zone] State Save Improvements

### DIFF
--- a/common/database_instances.cpp
+++ b/common/database_instances.cpp
@@ -31,7 +31,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include "../common/repositories/spawn_condition_values_repository.h"
 #include "repositories/spawn2_disabled_repository.h"
 #include "repositories/data_buckets_repository.h"
-
+#include "repositories/zone_state_spawns_repository.h"
 #include "database.h"
 
 #include <iomanip>
@@ -480,6 +480,9 @@ void Database::DeleteInstance(uint16 instance_id)
 	DynamicZonesRepository::DeleteWhere(*this, fmt::format("instance_id = {}", instance_id));
 	CharacterCorpsesRepository::BuryInstance(*this, instance_id);
 	DataBucketsRepository::DeleteWhere(*this, fmt::format("instance_id = {}", instance_id));
+	if (RuleB(Zone, StateSavingOnShutdown)) {
+		ZoneStateSpawnsRepository::DeleteWhere(database, fmt::format("`instance_id` = {}", instance_id));
+	}
 }
 
 void Database::FlagInstanceByGroupLeader(uint32 zone_id, int16 version, uint32 character_id, uint32 group_id)
@@ -563,6 +566,9 @@ void Database::PurgeExpiredInstances()
 	DynamicZonesRepository::DeleteWhere(*this, fmt::format("instance_id IN ({})", imploded_instance_ids));
 	Spawn2DisabledRepository::DeleteWhere(*this, fmt::format("instance_id IN ({})", imploded_instance_ids));
 	DataBucketsRepository::DeleteWhere(*this, fmt::format("instance_id != 0 and instance_id IN ({})", imploded_instance_ids));
+	if (RuleB(Zone, StateSavingOnShutdown)) {
+		ZoneStateSpawnsRepository::DeleteWhere(database, fmt::format("`instance_id` IN ({})", imploded_instance_ids));
+	}
 }
 
 void Database::SetInstanceDuration(uint16 instance_id, uint32 new_duration)

--- a/common/database_instances.cpp
+++ b/common/database_instances.cpp
@@ -481,7 +481,7 @@ void Database::DeleteInstance(uint16 instance_id)
 	CharacterCorpsesRepository::BuryInstance(*this, instance_id);
 	DataBucketsRepository::DeleteWhere(*this, fmt::format("instance_id = {}", instance_id));
 	if (RuleB(Zone, StateSavingOnShutdown)) {
-		ZoneStateSpawnsRepository::DeleteWhere(database, fmt::format("`instance_id` = {}", instance_id));
+		ZoneStateSpawnsRepository::DeleteWhere(*this, fmt::format("`instance_id` = {}", instance_id));
 	}
 }
 
@@ -567,7 +567,7 @@ void Database::PurgeExpiredInstances()
 	Spawn2DisabledRepository::DeleteWhere(*this, fmt::format("instance_id IN ({})", imploded_instance_ids));
 	DataBucketsRepository::DeleteWhere(*this, fmt::format("instance_id != 0 and instance_id IN ({})", imploded_instance_ids));
 	if (RuleB(Zone, StateSavingOnShutdown)) {
-		ZoneStateSpawnsRepository::DeleteWhere(database, fmt::format("`instance_id` IN ({})", imploded_instance_ids));
+		ZoneStateSpawnsRepository::DeleteWhere(*this, fmt::format("`instance_id` IN ({})", imploded_instance_ids));
 	}
 }
 

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -374,6 +374,8 @@ RULE_BOOL(Zone, AllowCrossZoneSpellsOnBots, false, "Set to true to allow cross z
 RULE_BOOL(Zone, AllowCrossZoneSpellsOnMercs, false, "Set to true to allow cross zone spells (cast/remove) to affect mercenaries")
 RULE_BOOL(Zone, AllowCrossZoneSpellsOnPets, false, "Set to true to allow cross zone spells (cast/remove) to affect pets")
 RULE_BOOL(Zone, ZoneShardQuestMenuOnly, false, "Set to true if you only want quests to show the zone shard menu")
+RULE_BOOL(Zone, StateSaveEntityVariables, true, "Set to true if you want buffs to be saved on shutdown")
+RULE_BOOL(Zone, StateSaveBuffs, true, "Set to true if you want buffs to be saved on shutdown")
 RULE_BOOL(Zone, StateSavingOnShutdown, true, "Set to true if you want zones to save state on shutdown (npcs, corpses, loot, entity variables, buffs etc.)")
 RULE_CATEGORY_END()
 

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -608,6 +608,33 @@ public:
 	inline void SetResumedFromZoneSuspend(bool state = true) { m_resumed_from_zone_suspend = state; }
 	inline bool IsResumedFromZoneSuspend() { return m_resumed_from_zone_suspend; }
 
+	inline void LoadBuffsFromState(std::vector<Buffs_Struct> in_buffs) {
+		int i = 0;
+		for (auto &b: in_buffs) {
+			buffs[i].spellid     = b.spellid;
+			buffs[i].casterlevel = b.casterlevel;
+			buffs[i].casterid    = b.casterid;
+			strncpy(buffs[i].caster_name, b.caster_name, 64);
+			buffs[i].ticsremaining     = b.ticsremaining;
+			buffs[i].counters          = b.counters;
+			buffs[i].hit_number        = b.hit_number;
+			buffs[i].melee_rune        = b.melee_rune;
+			buffs[i].magic_rune        = b.magic_rune;
+			buffs[i].dot_rune          = b.dot_rune;
+			buffs[i].caston_x          = b.caston_x;
+			buffs[i].caston_y          = b.caston_y;
+			buffs[i].caston_z          = b.caston_z;
+			buffs[i].ExtraDIChance     = b.ExtraDIChance;
+			buffs[i].RootBreakChance   = b.RootBreakChance;
+			buffs[i].instrument_mod    = b.instrument_mod;
+			buffs[i].virus_spread_time = b.virus_spread_time;
+			buffs[i].persistant_buff   = b.persistant_buff;
+			buffs[i].client            = b.client;
+			buffs[i].UpdateClient      = b.UpdateClient;
+			i++;
+		}
+	}
+
 protected:
 
 	void HandleRoambox();

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -633,6 +633,7 @@ public:
 			buffs[i].UpdateClient      = b.UpdateClient;
 			i++;
 		}
+		CalcBonuses();
 	}
 
 protected:

--- a/zone/spawn2.cpp
+++ b/zone/spawn2.cpp
@@ -202,7 +202,7 @@ bool Spawn2::Process() {
 		if (RuleB(Zone, StateSavingOnShutdown) && currentnpcid && currentnpcid > 0) {
 			npcid = currentnpcid;
 		} else {
-			spawn_group->GetNPCType(condition_value);
+			npcid = spawn_group->GetNPCType(condition_value);
 		}
 
 		if (npcid == 0) {

--- a/zone/spawn2.cpp
+++ b/zone/spawn2.cpp
@@ -198,7 +198,13 @@ bool Spawn2::Process() {
 		}
 
 		//have the spawn group pick an NPC for us
-		uint32 npcid = currentnpcid && currentnpcid > 0 ? currentnpcid : spawn_group->GetNPCType(condition_value);
+		uint32 npcid = 0;
+		if (RuleB(Zone, StateSavingOnShutdown) && currentnpcid && currentnpcid > 0) {
+			npcid = currentnpcid;
+		} else {
+			spawn_group->GetNPCType(condition_value);
+		}
+
 		if (npcid == 0) {
 			LogSpawns("Spawn2 [{}]: Spawn group [{}] did not yeild an NPC! not spawning", spawn2_id, spawngroup_id_);
 

--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -353,7 +353,7 @@ bool Zone::LoadZoneState(
 			(bool) s.path_when_zone_idle,
 			s.condition_id,
 			s.condition_min_value,
-			spawn_enabled,
+			(s.enabled && spawn_enabled),
 			(EmuAppearance) s.anim
 		);
 

--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -171,6 +171,10 @@ inline std::string GetLootSerialized(Corpse *c)
 
 inline void LoadNPCEntityVariables(NPC *n, const std::string &entity_variables)
 {
+	if (!RuleB(Zone, StateSaveEntityVariables)) {
+		return;
+	}
+
 	if (!Strings::IsValidJson(entity_variables)) {
 		LogZoneState("Invalid JSON data for NPC [{}]", n->GetNPCTypeID());
 		return;
@@ -196,6 +200,10 @@ inline void LoadNPCEntityVariables(NPC *n, const std::string &entity_variables)
 
 inline void LoadNPCBuffs(NPC *n, const std::string &buffs)
 {
+	if (!RuleB(Zone, StateSaveBuffs)) {
+		return;
+	}
+
 	if (!Strings::IsValidJson(buffs)) {
 		LogZoneState("Invalid JSON data for NPC [{}]", n->GetNPCTypeID());
 		return;
@@ -214,10 +222,7 @@ inline void LoadNPCBuffs(NPC *n, const std::string &buffs)
 		return;
 	}
 
-	for (const auto &b: valid_buffs) {
-		// int AddBuff(Mob *caster, const uint16 spell_id, int duration = 0, int32 level_override = -1, bool disable_buff_overwrite = false);
-		n->AddBuff(n, b.spellid, b.ticsremaining, b.casterlevel, false);
-	}
+	n->LoadBuffsFromState(valid_buffs);
 }
 
 inline std::vector<uint32_t> GetLootdropIds(const std::vector<ZoneStateSpawnsRepository::ZoneStateSpawns> &spawn_states)
@@ -225,7 +230,8 @@ inline std::vector<uint32_t> GetLootdropIds(const std::vector<ZoneStateSpawnsRep
 	LogInfo("Loading lootdrop ids for zone state spawns");
 
 	std::vector<uint32_t> lootdrop_ids;
-	for (auto             &s: spawn_states) {
+
+	for (auto &s: spawn_states) {
 		if (s.loot_data.empty()) {
 			continue;
 		}
@@ -415,7 +421,8 @@ inline void SaveNPCState(NPC *n, ZoneStateSpawnsRepository::ZoneStateSpawns &s)
 {
 	// entity variables
 	std::map<std::string, std::string> variables;
-	for (const auto                    &k: n->GetEntityVariables()) {
+
+	for (const auto &k: n->GetEntityVariables()) {
 		variables[k] = n->GetEntityVariable(k);
 	}
 
@@ -503,7 +510,7 @@ void Zone::SaveZoneState()
 		s.created_at          = std::time(nullptr);
 
 		auto n = sp->GetNPC();
-		if (n) {
+		if (n && entity_list.GetNPCByID(n->GetID())) {
 			SaveNPCState(n, s);
 		}
 


### PR DESCRIPTION
# Description

This fixes a few observed issues after roll-out

* **Rule** Added **Zone:StateSaveEntityVariables** (true) to allow operators to flip this off if necessary
* **Rule** Added **Zone:StateSaveBuffs** (true) to allow operators to flip this off if necessary
* **Buffs**  Change how buffs are loaded from saved state. We are directly hydrating the entire struct and all of its fields versus going through **AddBuff**
* **Buffs** Run a CalcBonuses after we load buffs from state
* **Spawn2** During Spawn process we check to see if rule **Zone:StateSavingOnShutdown** is set before trying to pull `currentnpcid` which is mainly used during state restore
* **Spawn2** Validate the NPC pointer against the NPC list during **SaveNPC** state during the spawn2 loop. We've found that spawn2 has some dangling pointers and can't be trusted solely because of how Spawn2 does book keeping
* **Spawn2** Also make sure that we load the Spawn2 "enabled" field from the state table row
* **Instances** Make sure that we purge zone state data when instances are destroyed

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Tested changes to buff loading, works fine

![image](https://github.com/user-attachments/assets/72f626b2-e24c-4a6d-b5b7-f6d07a3397c2)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
