### PR TITLE
[Fix] Update exp routine for evolving items

### DIFF
--- a/zone/client_evolving_items.cpp
+++ b/zone/client_evolving_items.cpp
@@ -128,6 +128,7 @@ void Client::ProcessEvolvingItem(const uint64 exp, const Mob *mob)
 					evolve_amount = exp * RuleR(EvolvingItems, PercentOfSoloExperience) / 100;
 				}
 
+				inst->SetEvolveAddToCurrentAmount(evolve_amount);
 				inst->CalculateEvolveProgression();
 
 				auto e = CharacterEvolvingItemsRepository::SetCurrentAmountAndProgression(


### PR DESCRIPTION
# Description

A bug report indicated that the exp evolving items type/subtype was not working correctly.  This was reproduceable.

After investigation, I had obviously deleted a line in the routine as this was originally working.  :-(

Either way, all fixed.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
Tested in PoI.

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
