### PR TITLE
[DynamicZones] Bulk request dz member statuses on zone boot

### DIFF
--- a/common/servertalk.h
+++ b/common/servertalk.h
@@ -196,6 +196,7 @@
 #define ServerOP_DzSaveInvite                 0x0466
 #define ServerOP_DzRequestInvite              0x0467
 #define ServerOP_DzMakeLeader                 0x0468
+#define ServerOP_DzGetBulkMemberStatuses      0x0469
 
 #define ServerOP_LSInfo				0x1000
 #define ServerOP_LSStatus			0x1001
@@ -1553,6 +1554,13 @@ struct ServerDzMemberStatuses_Struct {
 	uint32 dz_id;
 	uint32 count;
 	ServerDzMemberStatusEntry_Struct entries[0];
+};
+
+struct ServerDzCerealData_Struct {
+	uint16_t zone_id;
+	uint16_t inst_id;
+	uint32_t cereal_size;
+	char     cereal_data[1];
 };
 
 struct ServerDzMovePC_Struct {

--- a/world/dynamic_zone_manager.h
+++ b/world/dynamic_zone_manager.h
@@ -30,6 +30,8 @@ public:
 	std::unordered_map<uint32_t, std::unique_ptr<DynamicZone>> dynamic_zone_cache;
 
 private:
+	void SendBulkMemberStatuses(uint32_t zone_id, uint16_t inst_id);
+
 	Timer m_process_throttle_timer{};
 	std::unordered_map<uint32_t, DynamicZoneTemplatesRepository::DynamicZoneTemplates> m_dz_templates;
 };

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -1480,6 +1480,7 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 		case ServerOP_DzSwapMembers:
 		case ServerOP_DzRemoveAllMembers:
 		case ServerOP_DzGetMemberStatuses:
+		case ServerOP_DzGetBulkMemberStatuses:
 		case ServerOP_DzSetSecondsRemaining:
 		case ServerOP_DzSetCompass:
 		case ServerOP_DzSetSafeReturn:

--- a/zone/dynamic_zone.h
+++ b/zone/dynamic_zone.h
@@ -92,13 +92,13 @@ public:
 	void SendMemberNameToZoneMembers(const std::string& char_name, bool remove);
 	void SendMemberStatusToZoneMembers(const DynamicZoneMember& member);
 	void SetLocked(bool lock, bool update_db = false, DzLockMsg lock_msg = DzLockMsg::None, uint32_t color = Chat::Yellow);
-	void UpdateMembers();
 
 	std::string GetLootEvent(uint32_t id, DzLootEvent::Type type) const;
 	void SetLootEvent(uint32_t id, const std::string& event, DzLootEvent::Type type);
 
 private:
 	static void StartAllClientRemovalTimers();
+	static void RequestMemberStatuses();
 
 	uint16_t GetCurrentInstanceID() const override;
 	uint16_t GetCurrentZoneID() const override;
@@ -125,6 +125,7 @@ private:
 	void SendWorldPlayerInvite(const std::string& inviter, const std::string& swap_name, const std::string& add_name, bool pending = false);
 	void SetUpdatedDuration(uint32_t seconds);
 	void TryAddClient(Client* add_client, const std::string& inviter, const std::string& swap_name, Client* leader = nullptr);
+	void UpdateMembers();
 
 	std::unique_ptr<EQApplicationPacket> CreateExpireWarningPacket(uint32_t minutes_remaining);
 	std::unique_ptr<EQApplicationPacket> CreateInfoPacket(bool clear = false);

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -3410,6 +3410,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 	case ServerOP_DzRemoveAllMembers:
 	case ServerOP_DzDurationUpdate:
 	case ServerOP_DzGetMemberStatuses:
+	case ServerOP_DzGetBulkMemberStatuses:
 	case ServerOP_DzSetCompass:
 	case ServerOP_DzSetSafeReturn:
 	case ServerOP_DzSetZoneIn:


### PR DESCRIPTION
When dynamic zones are cached on zone boot each dz requests member statuses from world separately. This causes a lot of network traffic between world and booted zones when there are a lot of active dzs.

This changes it to make a single request to world on zone boot and a single bulk reply back.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I have made corresponding changes to the documentation (if applicable, if not delete this line)
- [x] I own the changes of my code and take responsibility for the potential issues that occur
- [x] If my changes make database schema changes, I have tested the changes on a local database (attach image). Updated version.h CURRENT_BINARY_DATABASE_VERSION to the new version. (Delete this if not applicable)
