### PR TITLE
[Networking] Fix "port in use" error

### DIFF
--- a/common/ip_util.cpp
+++ b/common/ip_util.cpp
@@ -303,6 +303,14 @@ bool IpUtil::IsPortInUse(const std::string& ip, int port) {
 		return true; // Assume in use on failure
 	}
 
+#ifdef _WIN32
+	int opt = 1;
+	setsockopt(sock, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, (char*)&opt, sizeof(opt)); // Windows-specific
+#else
+	int opt = 1;
+	setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)); // Linux/macOS
+#endif
+
 	sockaddr_in addr{};
 	addr.sin_family = AF_INET;
 	addr.sin_port = htons(port);


### PR DESCRIPTION
# Description

This modifies the `IpUtil::IsPortInUse` to be more lax on being able to reuse a recently closed port.

What would happen before is that even if you just freshly killed a **world** process it would error with "port in use" for upwards of 30 seconds which is annoying to operators.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

- Boot world, no problem
- Boot second world,  "World port [9001] already in use" (Expected)
- Kill world, immediately boot world, no error (Expected)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur