### PR TITLE
[Zone] Zone State Improvements Part 3

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -6990,6 +6990,17 @@ ALTER TABLE zone_state_spawns ADD INDEX idx_instance_id (instance_id);
 )",
 	.content_schema_update = false
 	},
+	ManifestEntry{
+		.version = 9314,
+		.description = "2025_03_12_zone_state_spawns_one_time_truncate.sql",
+		.check = "SELECT * FROM db_version WHERE version >= 9314",
+		.condition = "empty",
+		.match = "",
+		.sql = R"(
+TRUNCATE TABLE zone_state_spawns;
+)",
+		.content_schema_update = false
+	},
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{
 //		.version = 9228,

--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -6980,7 +6980,7 @@ ALTER TABLE data_buckets ADD INDEX idx_bot_expires (bot_id, expires);
 	},
 	ManifestEntry{
 		.version = 9313,
-		.description = "2025_03_11_data_bucket_indexes.sql",
+		.description = "2025_03_11_zone_state_spawns.sql",
 		.check = "SHOW INDEX FROM zone_state_spawns",
 		.condition = "missing",
 		.match = "idx_zone_instance",

--- a/common/repositories/zone_state_spawns_repository.h
+++ b/common/repositories/zone_state_spawns_repository.h
@@ -5,7 +5,7 @@
 #include "../strings.h"
 #include "base/base_zone_state_spawns_repository.h"
 
-class ZoneStateSpawnsRepository: public BaseZoneStateSpawnsRepository {
+class ZoneStateSpawnsRepository : public BaseZoneStateSpawnsRepository {
 public:
 	// Custom extended repository methods here
 	static void PurgeInvalidZoneStates(Database &database)
@@ -33,10 +33,10 @@ HAVING COUNT(*) = SUM(
 		}
 
 		for (auto row: results) {
-			uint32 zone_id     = std::stoul(row[0]);
+			uint32 zone_id = std::stoul(row[0]);
 			uint32 instance_id = std::stoul(row[1]);
 
-			ZoneStateSpawnsRepository::DeleteWhere(
+			int rows = ZoneStateSpawnsRepository::DeleteWhere(
 				database,
 				fmt::format(
 					"`zone_id` = {} AND `instance_id` = {}",
@@ -45,7 +45,36 @@ HAVING COUNT(*) = SUM(
 				)
 			);
 
-			LogInfo("Purged invalid zone state data for zone [{}] instance [{}]", zone_id, instance_id);
+			LogInfo(
+				"Purged invalid zone state data for zone [{}] instance [{}] rows [{}]",
+				zone_id,
+				instance_id,
+				Strings::Commify(rows)
+			);
+		}
+	}
+
+	static void PurgeOldZoneStates(Database &database)
+	{
+		int days = RuleI(Zone, StateSaveClearDays);
+
+		std::string query = fmt::format(
+			"DELETE FROM zone_state_spawns WHERE created_at < NOW() - INTERVAL {} DAY",
+			days
+		);
+
+		auto results = database.QueryDatabase(query);
+		if (!results.Success()) {
+			LogError("Failed to purge old zone state data older than {} days.", days);
+			return;
+		}
+
+		if (results.RowsAffected() > 0) {
+			LogInfo(
+				"Purged old zone state data older than days [{}] rows [{}]",
+				days,
+				Strings::Commify(results.RowsAffected())
+			);
 		}
 	}
 

--- a/common/repositories/zone_state_spawns_repository.h
+++ b/common/repositories/zone_state_spawns_repository.h
@@ -7,25 +7,24 @@
 
 class ZoneStateSpawnsRepository : public BaseZoneStateSpawnsRepository {
 public:
-	// Custom extended repository methods here
 	static void PurgeInvalidZoneStates(Database &database)
 	{
 		std::string query = R"(
-SELECT zone_id, instance_id
-FROM zone_state_spawns
-GROUP BY zone_id, instance_id
-HAVING COUNT(*) = SUM(
-    CASE
-        WHEN hp = 0
-         AND mana = 0
-         AND endurance = 0
-         AND (loot_data IS NULL OR loot_data = '')
-         AND (entity_variables IS NULL OR entity_variables = '')
-         AND (buffs IS NULL OR buffs = '')
-        THEN 1 ELSE 0
-    END
-);
-)";
+			SELECT zone_id, instance_id
+			FROM zone_state_spawns
+			GROUP BY zone_id, instance_id
+			HAVING COUNT(*) = SUM(
+				CASE
+					WHEN hp = 0
+					 AND mana = 0
+					 AND endurance = 0
+					 AND (loot_data IS NULL OR loot_data = '')
+					 AND (entity_variables IS NULL OR entity_variables = '')
+					 AND (buffs IS NULL OR buffs = '')
+					THEN 1 ELSE 0
+				END
+			);
+		)";
 
 		auto results = database.QueryDatabase(query);
 		if (!results.Success()) {

--- a/common/repositories/zone_state_spawns_repository.h
+++ b/common/repositories/zone_state_spawns_repository.h
@@ -8,6 +8,46 @@
 class ZoneStateSpawnsRepository: public BaseZoneStateSpawnsRepository {
 public:
 	// Custom extended repository methods here
+	static void PurgeInvalidZoneStates(Database &database)
+	{
+		std::string query = R"(
+SELECT zone_id, instance_id
+FROM zone_state_spawns
+GROUP BY zone_id, instance_id
+HAVING COUNT(*) = SUM(
+    CASE
+        WHEN hp = 0
+         AND mana = 0
+         AND endurance = 0
+         AND (loot_data IS NULL OR loot_data = '')
+         AND (entity_variables IS NULL OR entity_variables = '')
+         AND (buffs IS NULL OR buffs = '')
+        THEN 1 ELSE 0
+    END
+);
+)";
+
+		auto results = database.QueryDatabase(query);
+		if (!results.Success()) {
+			return;
+		}
+
+		for (auto row: results) {
+			uint32 zone_id     = std::stoul(row[0]);
+			uint32 instance_id = std::stoul(row[1]);
+
+			ZoneStateSpawnsRepository::DeleteWhere(
+				database,
+				fmt::format(
+					"`zone_id` = {} AND `instance_id` = {}",
+					zone_id,
+					instance_id
+				)
+			);
+
+			LogInfo("Purged invalid zone state data for zone [{}] instance [{}]", zone_id, instance_id);
+		}
+	}
 
 };
 

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -376,6 +376,7 @@ RULE_BOOL(Zone, AllowCrossZoneSpellsOnPets, false, "Set to true to allow cross z
 RULE_BOOL(Zone, ZoneShardQuestMenuOnly, false, "Set to true if you only want quests to show the zone shard menu")
 RULE_BOOL(Zone, StateSaveEntityVariables, true, "Set to true if you want buffs to be saved on shutdown")
 RULE_BOOL(Zone, StateSaveBuffs, true, "Set to true if you want buffs to be saved on shutdown")
+RULE_INT(Zone, StateSaveClearDays, 7, "Clears state save data older than this many days")
 RULE_BOOL(Zone, StateSavingOnShutdown, true, "Set to true if you want zones to save state on shutdown (npcs, corpses, loot, entity variables, buffs etc.)")
 RULE_CATEGORY_END()
 

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9313
+#define CURRENT_BINARY_DATABASE_VERSION 9314
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9054
 
 #endif

--- a/world/world_boot.cpp
+++ b/world/world_boot.cpp
@@ -413,7 +413,10 @@ bool WorldBoot::DatabaseLoadRoutines(int argc, char **argv)
 	LogInfo("Cleaning up instance corpses");
 	database.CleanupInstanceCorpses();
 
-	ZoneStateSpawnsRepository::PurgeInvalidZoneStates(database);
+	if (RuleB(Zone, StateSavingOnShutdown)) {
+		ZoneStateSpawnsRepository::PurgeInvalidZoneStates(database);
+		ZoneStateSpawnsRepository::PurgeOldZoneStates(database);
+	}
 
 	return true;
 }

--- a/world/world_boot.cpp
+++ b/world/world_boot.cpp
@@ -27,6 +27,7 @@
 #include "../common/zone_store.h"
 #include "../common/path_manager.h"
 #include "../common/database/database_update.h"
+#include "../common/repositories/zone_state_spawns_repository.h"
 
 extern ZSList      zoneserver_list;
 extern WorldConfig Config;
@@ -411,6 +412,8 @@ bool WorldBoot::DatabaseLoadRoutines(int argc, char **argv)
 
 	LogInfo("Cleaning up instance corpses");
 	database.CleanupInstanceCorpses();
+
+	ZoneStateSpawnsRepository::PurgeInvalidZoneStates(database);
 
 	return true;
 }

--- a/zone/loot.cpp
+++ b/zone/loot.cpp
@@ -23,6 +23,11 @@ void NPC::AddLootTable(uint32 loottable_id, bool is_global)
 		return;
 	}
 
+	if (m_resumed_from_zone_suspend) {
+		LogZoneState("NPC [{}] is resuming from zone suspend, skipping", GetCleanName());
+		return;
+	}
+
 	if (!is_global) {
 		m_loot_copper   = 0;
 		m_loot_silver   = 0;
@@ -277,7 +282,7 @@ void NPC::AddLootDrop(
 )
 {
 	if (m_resumed_from_zone_suspend) {
-		LogZoneState("NPC [{}] is resuming from zone suspend, skipping AddItem", GetCleanName());
+		LogZoneState("NPC [{}] is resuming from zone suspend, skipping", GetCleanName());
 		return;
 	}
 

--- a/zone/mob_info.cpp
+++ b/zone/mob_info.cpp
@@ -626,6 +626,9 @@ inline void NPCCommandsMenu(Client* client, NPC* npc)
 
 	if (npc->GetLoottableID() > 0) {
 		menu_commands += "[" + Saylink::Silent("#npcloot show", "Loot") + "] ";
+		if (npc) {
+			menu_commands += fmt::format(" Item(s) ({}) ", npc->GetLootItems().size());
+		}
 	}
 
 	if (npc->IsProximitySet()) {

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -134,7 +134,7 @@ NPC::NPC(const NPCType *npc_type_data, Spawn2 *in_respawn, const glm::vec4 &posi
 	  swarm_timer(100),
 	  m_corpse_queue_timer(1000),
 	  m_corpse_queue_shutoff_timer(30000),
-	  m_resumed_from_zone_suspend_shutoff_timer(5000),
+	  m_resumed_from_zone_suspend_shutoff_timer(10000),
 	  classattack_timer(1000),
 	  monkattack_timer(1000),
 	  knightattack_timer(1000),

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -134,7 +134,7 @@ NPC::NPC(const NPCType *npc_type_data, Spawn2 *in_respawn, const glm::vec4 &posi
 	  swarm_timer(100),
 	  m_corpse_queue_timer(1000),
 	  m_corpse_queue_shutoff_timer(30000),
-	  m_resumed_from_zone_suspend_shutoff_timer(30000),
+	  m_resumed_from_zone_suspend_shutoff_timer(5000),
 	  classattack_timer(1000),
 	  monkattack_timer(1000),
 	  knightattack_timer(1000),

--- a/zone/quest_parser_collection.cpp
+++ b/zone/quest_parser_collection.cpp
@@ -435,10 +435,8 @@ int QuestParserCollection::EventNPC(
 	std::vector<std::any>* extra_pointers
 )
 {
-	if (npc->IsResumedFromZoneSuspend()) {
-		if (event_id == EVENT_DEATH_COMPLETE || event_id == EVENT_DEATH) {
-			return 0;
-		}
+	if (npc->IsResumedFromZoneSuspend() && npc->IsQueuedForCorpse()) {
+		return 0;
 	}
 
 	const int local_return   = EventNPCLocal(event_id, npc, init, data, extra_data, extra_pointers);

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -208,6 +208,15 @@ void QuestManager::write(const char *file, const char *str) {
 }
 
 Mob* QuestManager::spawn2(int npc_id, int grid, int unused, const glm::vec4& position) {
+	QuestManagerCurrentQuestVars();
+	if (owner && owner->IsNPC()) {
+		auto n = owner->CastToNPC();
+		if (n->IsResumedFromZoneSuspend()) {
+			LogZoneState("NPC [{}] is resuming from zone suspend, skipping quest call", n->GetCleanName());
+			return nullptr;
+		}
+	}
+
 	const NPCType* t = 0;
 	if (t = content_db.LoadNPCTypesData(npc_id)) {
 		auto npc = new NPC(t, nullptr, position, GravityBehavior::Water);
@@ -228,6 +237,15 @@ Mob* QuestManager::spawn2(int npc_id, int grid, int unused, const glm::vec4& pos
 }
 
 Mob* QuestManager::unique_spawn(int npc_type, int grid, int unused, const glm::vec4& position) {
+	QuestManagerCurrentQuestVars();
+	if (owner && owner->IsNPC()) {
+		auto n = owner->CastToNPC();
+		if (n->IsResumedFromZoneSuspend()) {
+			LogZoneState("NPC [{}] is resuming from zone suspend, skipping quest call", n->GetCleanName());
+			return nullptr;
+		}
+	}
+
 	Mob *other = entity_list.GetMobByNpcTypeID(npc_type);
 	if(other != nullptr) {
 		return other;

--- a/zone/spawn2.cpp
+++ b/zone/spawn2.cpp
@@ -277,6 +277,8 @@ bool Spawn2::Process() {
 
 		npcthis = npc;
 
+		npc->SetResumedFromZoneSuspend(IsResumedFromZoneSuspend());
+
 		npc->AddLootTable();
 		if (npc->DropsGlobalLoot()) {
 			npc->CheckGlobalLootTables();

--- a/zone/spawn2.cpp
+++ b/zone/spawn2.cpp
@@ -277,7 +277,8 @@ bool Spawn2::Process() {
 
 		npcthis = npc;
 
-		npc->SetResumedFromZoneSuspend(IsResumedFromZoneSuspend());
+		npc->SetResumedFromZoneSuspend(m_resumed_from_zone_suspend);
+		m_resumed_from_zone_suspend = false;
 
 		npc->AddLootTable();
 		if (npc->DropsGlobalLoot()) {

--- a/zone/spawn2.h
+++ b/zone/spawn2.h
@@ -75,6 +75,8 @@ public:
 	int16 GetConditionMinValue() const { return condition_min_value; }
 	int16 GetAnimation () { return anim; }
 	inline NPC *GetNPC() const { return npcthis; }
+	inline bool IsResumedFromZoneSuspend() const { return m_resumed_from_zone_suspend; }
+	inline void SetResumedFromZoneSuspend(bool resumed) { m_resumed_from_zone_suspend = resumed; }
 
 protected:
 	friend class Zone;
@@ -101,6 +103,7 @@ private:
 	EmuAppearance anim;
 	bool IsDespawned;
 	uint32  killcount;
+	bool m_resumed_from_zone_suspend = false;
 };
 
 class SpawnCondition {

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -887,7 +887,10 @@ void Zone::Shutdown(bool quiet)
 		c.second->WorldKick();
 	}
 
-	if (RuleB(Zone, StateSavingOnShutdown)) {
+	bool does_zone_have_entities =
+			 zone->IsLoaded() &&
+			 (!entity_list.GetNPCList().empty() || !entity_list.GetCorpseList().empty());
+	if (RuleB(Zone, StateSavingOnShutdown) && does_zone_have_entities) {
 		SaveZoneState();
 	}
 

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -888,7 +888,7 @@ void Zone::Shutdown(bool quiet)
 	}
 
 	bool does_zone_have_entities =
-			 zone->IsLoaded() &&
+			 zone && zone->IsLoaded() &&
 			 (!entity_list.GetNPCList().empty() || !entity_list.GetCorpseList().empty());
 	if (RuleB(Zone, StateSavingOnShutdown) && does_zone_have_entities) {
 		SaveZoneState();

--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -643,6 +643,19 @@ void Zone::SaveZoneState()
 		)
 	);
 
+	int good_spawns = 0;
+	for (auto &s: spawns) {
+		if (s.hp == 0 && s.mana == 0 && s.endurance == 0 && s.loot_data.empty() && s.entity_variables.empty() && s.buffs.empty()) {
+			continue;
+		}
+		good_spawns++;
+	}
+
+	if (!good_spawns) {
+		LogZoneState("All data was found to be invalid, potentially zone was saved before it had a chance to fully boot");
+		return;
+	}
+
 	ZoneStateSpawnsRepository::InsertMany(database, spawns);
 
 	LogInfo("Saved [{}] zone state spawns", Strings::Commify(spawns.size()));

--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -236,6 +236,10 @@ inline std::vector<uint32_t> GetLootdropIds(const std::vector<ZoneStateSpawnsRep
 			continue;
 		}
 
+		if (!Strings::IsValidJson(s.loot_data)) {
+			continue;
+		}
+
 		LootStateData l{};
 		try {
 			std::stringstream ss;

--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -497,6 +497,11 @@ bool Zone::LoadZoneState(
 
 		npc->SetResumedFromZoneSuspend(true);
 
+		// tag as corpse before we add to entity list to prevent quest triggers
+		if (s.is_corpse) {
+			npc->SetQueuedToCorpse();
+		}
+
 		entity_list.AddNPC(npc, true, true);
 
 		LoadNPCState(zone, npc, s);

--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -80,7 +80,7 @@ inline void LoadLootStateData(Zone *zone, NPC *npc, const std::string &loot_data
 
 		// dynamically added via AddItem
 		if (e.lootdrop_id == 0) {
-			npc->AddItem(e.item_id, e.charges);
+			npc->AddItem(e.item_id, e.charges, true);
 			continue;
 		}
 

--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -384,7 +384,7 @@ bool Zone::LoadZoneState(
 	auto spawn_states = ZoneStateSpawnsRepository::GetWhere(
 		database,
 		fmt::format(
-			"zone_id = {} AND instance_id = {}",
+			"zone_id = {} AND instance_id = {} ORDER BY spawn2_id",
 			zoneid,
 			zone->GetInstanceID()
 		)

--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -96,6 +96,11 @@ inline void LoadLootStateData(Zone *zone, NPC *npc, const std::string &loot_data
 		return;
 	}
 
+	// reset
+	npc->RemoveLootCash();
+	npc->ClearLootItems();
+
+	// add loot
 	npc->AddLootCash(l.copper, l.silver, l.gold, l.platinum);
 
 	for (auto &e: l.entries) {
@@ -470,9 +475,7 @@ bool Zone::LoadZoneState(
 		new_spawn->Process();
 		auto n = new_spawn->GetNPC();
 		if (n) {
-			if (s.grid > 0) {
-				n->AssignWaypoints(s.grid, s.current_waypoint);
-			}
+			LoadNPCState(zone, n, s);
 		}
 	}
 

--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -356,6 +356,10 @@ bool Zone::LoadZoneState(
 
 	LogInfo("Loading zone state spawns for zone [{}] spawns [{}]", GetShortName(), spawn_states.size());
 
+	if (spawn_states.empty()) {
+		return false;
+	}
+
 	std::vector<uint32_t> lootdrop_ids = GetLootdropIds(spawn_states);
 	zone->LoadLootDrops(lootdrop_ids);
 

--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -643,15 +643,16 @@ void Zone::SaveZoneState()
 		)
 	);
 
-	int good_spawns = 0;
+	bool found_valid_spawn = false;
 	for (auto &s: spawns) {
 		if (s.hp == 0 && s.mana == 0 && s.endurance == 0 && s.loot_data.empty() && s.entity_variables.empty() && s.buffs.empty()) {
 			continue;
 		}
-		good_spawns++;
+		found_valid_spawn = true;
+		break;
 	}
 
-	if (!good_spawns) {
+	if (!found_valid_spawn) {
 		LogZoneState("All data was found to be invalid, potentially zone was saved before it had a chance to fully boot");
 		return;
 	}

--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -67,7 +67,15 @@ inline void LoadLootStateData(Zone *zone, NPC *npc, const std::string &loot_data
 {
 	LootStateData l{};
 
+	// in the event that should never happen, we roll loot from the NPC's table
 	if (loot_data.empty()) {
+		LogZoneState("No loot state data found for NPC [{}], re-rolling", npc->GetNPCTypeID());
+		npc->ClearLootItems();
+		npc->AddLootTable();
+		if (npc->DropsGlobalLoot()) {
+			npc->CheckGlobalLootTables();
+		}
+
 		return;
 	}
 
@@ -462,7 +470,6 @@ bool Zone::LoadZoneState(
 		new_spawn->Process();
 		auto n = new_spawn->GetNPC();
 		if (n) {
-			n->ClearLootItems();
 			if (s.grid > 0) {
 				n->AssignWaypoints(s.grid, s.current_waypoint);
 			}

--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -49,6 +49,10 @@ inline void LoadLootStateData(Zone *zone, NPC *npc, const std::string &loot_data
 {
 	LootStateData l{};
 
+	if (loot_data.empty()) {
+		return;
+	}
+
 	if (!Strings::IsValidJson(loot_data)) {
 		LogZoneState("Invalid JSON data for NPC [{}]", npc->GetNPCTypeID());
 		return;
@@ -175,6 +179,10 @@ inline void LoadNPCEntityVariables(NPC *n, const std::string &entity_variables)
 		return;
 	}
 
+	if (entity_variables.empty()) {
+		return;
+	}
+
 	if (!Strings::IsValidJson(entity_variables)) {
 		LogZoneState("Invalid JSON data for NPC [{}]", n->GetNPCTypeID());
 		return;
@@ -201,6 +209,10 @@ inline void LoadNPCEntityVariables(NPC *n, const std::string &entity_variables)
 inline void LoadNPCBuffs(NPC *n, const std::string &buffs)
 {
 	if (!RuleB(Zone, StateSaveBuffs)) {
+		return;
+	}
+
+	if (buffs.empty()) {
 		return;
 	}
 

--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -307,7 +307,9 @@ inline void LoadNPCState(Zone *zone, NPC *n, ZoneStateSpawnsRepository::ZoneStat
 		n->AssignWaypoints(s.grid, s.current_waypoint);
 	}
 
+	n->SetResumedFromZoneSuspend(false);
 	LoadLootStateData(zone, n, s.loot_data);
+	n->SetResumedFromZoneSuspend(true);
 	LoadNPCEntityVariables(n, s.entity_variables);
 	LoadNPCBuffs(n, s.buffs);
 
@@ -453,6 +455,7 @@ bool Zone::LoadZoneState(
 
 		if (spawn_time_left == 0) {
 			new_spawn->SetCurrentNPCID(s.npc_id);
+			new_spawn->SetResumedFromZoneSuspend(true);
 		}
 
 		spawn2_list.Insert(new_spawn);
@@ -484,6 +487,8 @@ bool Zone::LoadZoneState(
 			glm::vec4(s.x, s.y, s.z, s.heading),
 			GravityBehavior::Water
 		);
+
+		npc->SetResumedFromZoneSuspend(true);
 
 		entity_list.AddNPC(npc, true, true);
 


### PR DESCRIPTION
# Description

This PR is yet another continued series of fixes as a result of rolling this out and observing in large scale production (THJ) with 3k players and 1,400 zoneservers.

**Data Validation**  
  - Add checks to **Zone::Shutdown** to ensure we have active NPCs or Corpses before saving zone state. Prevents saving invalid state data from an incomplete zone load.  
  - Adds **bool IsZoneStateValid(std::vector<zonestatespawnsrepository::ZoneStateSpawns> &spawns)** to validate spawn state on both loading and saving of a zone to reject bad data.  

**Cleanup**  
  - Adds **ZoneStateSpawnsRepository::PurgeInvalidZoneStates(database);** on world bootup to purge existing invalid zones.  
  - Adds **ZoneStateSpawnsRepository::PurgeOldZoneStates(database);** - which will purge zones older than the defined rule **Zone:StateSaveClearDays (7)**.  

**One Time Purge**  
  - Because of the fixes in this PR, we do a one-time truncation of the state table to clean up bad data from the quest spawn protection issue.  

**Weapon Appearance**  
  - Ensures that when an item is added via script to an NPC's loot table, it is visually equippable on state restore.  

**Safety**  
  - Ensures buffs exist before attempting to serialize, save, or load them.  
  - Block **quest::spawn2** and **quest::unique_spawn** from running within 10 seconds of spawn state being restored.  
  - Restored corpses no longer trigger quest events.  

**Loading**  
  - If no state data exists, return early to avoid processing invalid zone states.  
  - Fix an issue when a zone spins down NPC's were previously killed and enough time elapsed during the spin down time that the NPC had fully spawned by the time it was spun back up, no loot was being applied.  

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

When booting a zone with invalid data, we detect the invalid state, delete the invalid state in the DB and boot up as normal

```
  Zone | ZoneState  | LoadZoneState Invalid zone state data for zone [sebilis] 
```

When loading world we check the entire spawn states table for bad zone data

```
 World |    Info    | PurgeInvalidZoneStates Purged invalid zone state data for zone [89] instance [0] 
```

When loading world we check for zone state older than defined rule Zone:

```
 World |    Info    | PurgeOldZoneStates Purged old zone state data older than days [7] rows [331] 
```

When calling **spawn2** or **unique_spawn** from EVENT_SPAWN after restoring from state save. We don't want spawn2 to trigger again, but we may not want to entirely block spawn2 from triggering.

```lua
function event_spawn(e)
    eq.spawn2(89184, 0, 0, -434, -2222, -139, 489);
end
```

```
  Zone | ZoneState  | spawn2 NPC [Tolapumj] is resuming from zone suspend, skipping quest call 
```

**Before**

(2 spawns)

![image](https://github.com/user-attachments/assets/de63e8bc-c744-44dc-ba81-bc3b035b1027)

**After**

(1 spawn) - intended result

![image](https://github.com/user-attachments/assets/a88455fe-2338-4895-ad79-08e1bf4a920d)

**This also works for encounters (tested)**

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
