### PR TITLE
[Fix] Update GuildBank to correctly handle items with charges equal to zero

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -7653,7 +7653,11 @@ void Client::Handle_OP_GuildBank(const EQApplicationPacket *app)
 						log.char_id  = CharacterID();
 						log.guild_id = GuildID();
 						log.item_id  = inst->GetID();
-						log.quantity = inst->GetCharges();
+						log.quantity = 1;
+						if (inst->GetCharges() > 0 || inst->IsStackable() || inst->GetItem()->MaxCharges > 0) {
+							log.quantity = inst->GetCharges();
+						}
+
 						if (inst->IsAugmented()) {
 							auto augs          = inst->GetAugmentIDs();
 							log.aug_slot_one   = augs.at(0);
@@ -7737,7 +7741,11 @@ void Client::Handle_OP_GuildBank(const EQApplicationPacket *app)
 			item.guild_id    = GuildID();
 			item.area        = GuildBankDepositArea;
 			item.item_id     = cursor_item->ID;
-			item.quantity    = cursor_item_inst->GetCharges();
+			item.quantity    = 1;
+			if (cursor_item_inst->GetCharges() > 0 || cursor_item_inst->IsStackable() || cursor_item->MaxCharges > 0) {
+				item.quantity = cursor_item_inst->GetCharges();
+			}
+
 			item.donator     = GetCleanName();
 			item.permissions = GuildBankBankerOnly;
 			if (cursor_item_inst->IsAugmented()) {
@@ -7821,12 +7829,9 @@ void Client::Handle_OP_GuildBank(const EQApplicationPacket *app)
 				break;
 			}
 
-			if (inst->GetCharges() > 0) {
+			gbwis->Quantity = 1;
+			if (inst->GetCharges() > 0 || inst->IsStackable() || inst->GetItem()->MaxCharges > 0) {
 				gbwis->Quantity = inst->GetCharges();
-			}
-
-			if (inst->GetCharges() < 0) {
-				gbwis->Quantity = 1;
 			}
 
 			PushItemOnCursor(*inst.get());


### PR DESCRIPTION
# Description

If the player attempts to deposit an item with zero charges, the item would be incorrectly stored/retrieved from the bank.  This also happened using the #fi command for certain items and then directly depositing in the Guild Bank.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
Tested against several items, 8205 (converted to tradeable - this item does not poof when hitting zero charges), 70208, 8517, 1320.  Also tested the player event logging to ensure proper capture of charges equal zero.

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
