### PR TITLE
[Fix] And check for simultaneous direct vendor and parcel Trader/Buyer Purchase

### DIFF
--- a/zone/client.h
+++ b/zone/client.h
@@ -443,6 +443,8 @@ public:
 	int64 ValidateBuyLineCost(std::map<uint32, BuylineItemDetails_Struct>& item_map);
 	bool DoBarterBuyerChecks(BuyerLineSellItem_Struct& sell_line);
 	bool DoBarterSellerChecks(BuyerLineSellItem_Struct& sell_line);
+	void CancelBuyerTradeWindow();
+	void CancelTraderTradeWindow();
 
 	void FillSpawnStruct(NewSpawn_Struct* ns, Mob* ForWho);
 	bool ShouldISpawnFor(Client *c) { return !GMHideMe(c) && !IsHoveringForRespawn(); }

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -15463,7 +15463,7 @@ void Client::Handle_OP_TraderBuy(const EQApplicationPacket *app)
 			);
 			Message(
 				Chat::Yellow,
-				"Direct inventory delivey is not yet implemented.  Please visit the vendor directly or purchase via parcel delivery."
+				"Direct inventory delivery is not yet implemented.  Please visit the vendor directly or purchase via parcel delivery."
 			);
 			in->method     = BazaarByDirectToInventory;
 			in->sub_action = Failed;

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -1894,6 +1894,13 @@ void Client::SellToBuyer(const EQApplicationPacket *app)
 					break;
 				}
 
+				if (sell_line.purchase_method == BarterInBazaar && buyer->IsThereACustomer()) {
+					auto customer = entity_list.GetClientByID(buyer->GetCustomerID());
+					if (customer) {
+						customer->CancelBuyerTradeWindow();
+					}
+				}
+
 				if (!DoBarterBuyerChecks(sell_line)) {
 					return;
 				};
@@ -3824,4 +3831,19 @@ bool Client::DoBarterSellerChecks(BuyerLineSellItem_Struct &sell_line)
 	}
 
 	return true;
+}
+
+void Client::CancelBuyerTradeWindow()
+{
+	auto end_session = new EQApplicationPacket(OP_Barter, sizeof(BuyerRemoveItemFromMerchantWindow_Struct));
+	auto data        = reinterpret_cast<BuyerRemoveItemFromMerchantWindow_Struct *>(end_session->pBuffer);
+	data->action     = Barter_BuyerInspectBegin;
+
+	FastQueuePacket(&end_session);
+}
+
+void Client::CancelTraderTradeWindow()
+{
+	auto end_session = new EQApplicationPacket(OP_ShopEnd);
+	FastQueuePacket(&end_session);
 }

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -3786,6 +3786,13 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 				return;
 			}
 
+			if (trader_pc->IsThereACustomer()) {
+				auto customer = entity_list.GetClientByID(trader_pc->GetCustomerID());
+				if (customer) {
+					customer->CancelTraderTradeWindow();
+				}
+			}
+
 			auto item_sn = Strings::ToUnsignedBigInt(in->trader_buy_struct.serial_number);
 			auto outapp  = std::make_unique<EQApplicationPacket>(OP_Trader, sizeof(TraderBuy_Struct));
 			auto data    = (TraderBuy_Struct *) outapp->pBuffer;
@@ -3980,6 +3987,12 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 						in->sub_action = Barter_BuyerCouldNotBeFound;
 						worldserver.SendPacket(pack);
 						return;
+					}
+					if (buyer->IsThereACustomer()) {
+						auto customer = entity_list.GetClientByID(buyer->GetCustomerID());
+						if (customer) {
+							customer->CancelBuyerTradeWindow();
+						}
 					}
 
 					BuyerLineSellItem_Struct sell_line{};


### PR DESCRIPTION
# Description

This fix will close a direct vendor window when a player is browsing either a Trader or a Buyer if another player makes a purchase from the Trader/Buyer via parcel delivery.

## Type of change
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
Tested against several instances of bazaar with a direct vendor and another player both within and external to the bazaar instance.

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
