### PR TITLE
[Quest API] Add Support for NPC ID and NPC Name Specificity

### DIFF
--- a/zone/quest_parser_collection.cpp
+++ b/zone/quest_parser_collection.cpp
@@ -939,7 +939,7 @@ QuestInterface* QuestParserCollection::GetQIByNPCQuest(uint32 npc_id, std::strin
 
 	Strings::FindReplace(npc_name, "`", "-");
 
-	const std::string& npc_name_and_id = fmt::format(
+	const std::string& npc_id_and_name = fmt::format(
 		"{} ({})",
 		npc_name,
 		npc_id
@@ -967,13 +967,13 @@ QuestInterface* QuestParserCollection::GetQIByNPCQuest(uint32 npc_id, std::strin
 	std::vector<std::string> file_names = {
 		fmt::format("{}/{}", zone_versioned_path, npc_id), // Local versioned by NPC ID
 		fmt::format("{}/{}", zone_versioned_path, npc_name), // Local versioned by NPC Name
-		fmt::format("{}/{}", zone_versioned_path, npc_name_and_id), // Local versioned by NPC ID and NPC Name
+		fmt::format("{}/{}", zone_versioned_path, npc_id_and_name), // Local versioned by NPC ID and NPC Name
 		fmt::format("{}/{}", zone_path, npc_id), // Local by NPC ID
 		fmt::format("{}/{}", zone_path, npc_name), // Local by NPC Name
-		fmt::format("{}/{}", zone_path, npc_name_and_id), // Local by NPC ID and NPC Name
+		fmt::format("{}/{}", zone_path, npc_id_and_name), // Local by NPC ID and NPC Name
 		fmt::format("{}/{}", global_path, npc_id), // Global by NPC ID
 		fmt::format("{}/{}", global_path, npc_name), // Global by NPC ID
-		fmt::format("{}/{}", global_path, npc_name_and_id), // Global by NPC ID and NPC Name
+		fmt::format("{}/{}", global_path, npc_id_and_name), // Global by NPC ID and NPC Name
 		fmt::format("{}/default", zone_versioned_path), // Zone Versioned Default
 		fmt::format("{}/default", zone_path), // Zone Default
 		fmt::format("{}/default", global_path), // Global Default

--- a/zone/quest_parser_collection.cpp
+++ b/zone/quest_parser_collection.cpp
@@ -939,6 +939,12 @@ QuestInterface* QuestParserCollection::GetQIByNPCQuest(uint32 npc_id, std::strin
 
 	Strings::FindReplace(npc_name, "`", "-");
 
+	const std::string& npc_name_and_id = fmt::format(
+		"{} ({})",
+		npc_name,
+		npc_id
+	);
+
 	const std::string& global_path = fmt::format(
 		"{}/{}",
 		path.GetQuestsPath(),
@@ -959,13 +965,16 @@ QuestInterface* QuestParserCollection::GetQIByNPCQuest(uint32 npc_id, std::strin
 	);
 
 	std::vector<std::string> file_names = {
-		fmt::format("{}/{}", zone_versioned_path, npc_id), // Local versioned by NPC ID ./quests/zone/v0/10.ext
-		fmt::format("{}/{}", zone_versioned_path, npc_name), // Local versioned by NPC Name ./quests/zone/v0/npc.ext
+		fmt::format("{}/{}", zone_versioned_path, npc_id), // Local versioned by NPC ID
+		fmt::format("{}/{}", zone_versioned_path, npc_name), // Local versioned by NPC Name
+		fmt::format("{}/{}", zone_versioned_path, npc_name_and_id), // Local versioned by NPC ID and NPC Name
 		fmt::format("{}/{}", zone_path, npc_id), // Local by NPC ID
 		fmt::format("{}/{}", zone_path, npc_name), // Local by NPC Name
+		fmt::format("{}/{}", zone_path, npc_name_and_id), // Local by NPC ID and NPC Name
 		fmt::format("{}/{}", global_path, npc_id), // Global by NPC ID
 		fmt::format("{}/{}", global_path, npc_name), // Global by NPC ID
-		fmt::format("{}/default", zone_versioned_path), // Zone Default ./quests/zone/v0/default.ext
+		fmt::format("{}/{}", global_path, npc_name_and_id), // Global by NPC ID and NPC Name
+		fmt::format("{}/default", zone_versioned_path), // Zone Versioned Default
 		fmt::format("{}/default", zone_path), // Zone Default
 		fmt::format("{}/default", global_path), // Global Default
 	};

--- a/zone/quest_parser_collection.cpp
+++ b/zone/quest_parser_collection.cpp
@@ -965,16 +965,16 @@ QuestInterface* QuestParserCollection::GetQIByNPCQuest(uint32 npc_id, std::strin
 	);
 
 	std::vector<std::string> file_names = {
-		fmt::format("{}/{}", zone_versioned_path, npc_id), // Local versioned by NPC ID
-		fmt::format("{}/{}", zone_versioned_path, npc_name), // Local versioned by NPC Name
-		fmt::format("{}/{}", zone_versioned_path, npc_id_and_name), // Local versioned by NPC ID and NPC Name
+		fmt::format("{}/{}", zone_versioned_path, npc_id), // Local versioned by NPC ID (./quests/zone/v0/10.ext)
+		fmt::format("{}/{}", zone_versioned_path, npc_name), // Local versioned by NPC Name (./quests/zone/v0/name.ext)
+		fmt::format("{}/{}", zone_versioned_path, npc_id_and_name), // Local versioned by NPC ID and NPC Name (./quests/zone/v0/10_name.ext)
 		fmt::format("{}/{}", zone_path, npc_id), // Local by NPC ID
 		fmt::format("{}/{}", zone_path, npc_name), // Local by NPC Name
 		fmt::format("{}/{}", zone_path, npc_id_and_name), // Local by NPC ID and NPC Name
 		fmt::format("{}/{}", global_path, npc_id), // Global by NPC ID
 		fmt::format("{}/{}", global_path, npc_name), // Global by NPC ID
 		fmt::format("{}/{}", global_path, npc_id_and_name), // Global by NPC ID and NPC Name
-		fmt::format("{}/default", zone_versioned_path), // Zone Versioned Default
+		fmt::format("{}/default", zone_versioned_path), // Zone Versioned Default (./quests/zone/v0/default.ext)
 		fmt::format("{}/default", zone_path), // Zone Default
 		fmt::format("{}/default", global_path), // Global Default
 	};

--- a/zone/quest_parser_collection.cpp
+++ b/zone/quest_parser_collection.cpp
@@ -940,7 +940,7 @@ QuestInterface* QuestParserCollection::GetQIByNPCQuest(uint32 npc_id, std::strin
 	Strings::FindReplace(npc_name, "`", "-");
 
 	const std::string& npc_id_and_name = fmt::format(
-		"{}_({})",
+		"{}_{}",
 		npc_name,
 		npc_id
 	);

--- a/zone/quest_parser_collection.cpp
+++ b/zone/quest_parser_collection.cpp
@@ -940,7 +940,7 @@ QuestInterface* QuestParserCollection::GetQIByNPCQuest(uint32 npc_id, std::strin
 	Strings::FindReplace(npc_name, "`", "-");
 
 	const std::string& npc_id_and_name = fmt::format(
-		"{} ({})",
+		"{}_({})",
 		npc_name,
 		npc_id
 	);


### PR DESCRIPTION
# Description
- Allows operators to name scripts like `Bob_123.pl` or `Bob_456.pl` so you can have multiple NPCs under the same name and still have ID specificity without needing to know the NPC ID to find the file.

## Type of change
- [X] New feature

## Testing
![image](https://github.com/user-attachments/assets/bdc6fa4b-7fdc-46ec-9571-c35132035824)
### Test_2001021.pl
```pl
sub EVENT_SAY {
	if ($text=~/Hail/i) {
		quest::whisper("I love you, $name!");
	}
}
```
### Test_2001022.pl
```pl
sub EVENT_SAY {
	if ($text=~/Hail/i) {
		quest::whisper("I hate you, $name!");
	}
}
```

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur