### PR TITLE
[Bugfix] Fix zone crash when attempting to add a disappearing client to hate list

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -3041,7 +3041,13 @@ void Mob::AddToHateList(Mob* other, int64 hate /*= 0*/, int64 damage /*= 0*/, bo
 	if (!other)
 		return;
 
+	if (other->IsDestroying())
+		return;
+
 	if (other == this)
+		return;
+
+	if (other->IsClient() && (other->CastToClient()->IsZoning() || other->CastToClient()->Connected() == false))
 		return;
 
 	if (other->IsTrap())

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -131,7 +131,8 @@ Mob::Mob(
 	m_scan_close_mobs_timer(6000),
 	m_see_close_mobs_timer(1000),
 	m_mob_check_moving_timer(1000),
-	bot_attack_flag_timer(10000)
+	bot_attack_flag_timer(10000),
+	m_destroying(false)
 {
 	mMovementManager = &MobMovementManager::Get();
 	mMovementManager->AddMob(this);
@@ -531,6 +532,8 @@ Mob::Mob(
 
 Mob::~Mob()
 {
+	m_destroying = true;
+
 	entity_list.RemoveMobFromCloseLists(this);
 	m_close_mobs.clear();
 

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -1510,6 +1510,7 @@ public:
 
 	void ClearDataBucketCache();
 	bool IsGuildmaster() const;
+	bool IsDestroying() const { return m_destroying; }
 
 protected:
 	void CommonDamage(Mob* other, int64 &damage, const uint16 spell_id, const EQ::skills::SkillType attack_skill, bool &avoidable, const int8 buffslot, const bool iBuffTic, eSpecialAttacks specal = eSpecialAttacks::None);
@@ -1932,6 +1933,7 @@ private:
 	EQ::InventoryProfile m_inv;
 	std::shared_ptr<HealRotation> m_target_of_heal_rotation;
 	bool m_manual_follow;
+	bool m_destroying;
 
 	void SetHeroicStrBonuses(StatBonuses* n);
 	void SetHeroicStaBonuses(StatBonuses* n);


### PR DESCRIPTION
# Description

Was toying around with adding a client back to an npc's hatelist whenever it was removed as a way of making a 'tenacious' npc.  I found that when hate was dropped as the result of a zone or disconnect my zone process would crash.

The main culprit is the destructor for Mob is clearing itself from the hatelist, which then via events and scripting adds it back and now the hate list has a bad reference in it and it blows up the next time its processed.

My fix is to prevent adding it back when we detect that its a going away client.  Unfortunately since we're already in a half-destroyed state polymorphic behaviors like IsClient() no longer function properly, hence the need to add the destroying flag.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Tested on vanilla akk-stack with rof2 client.

Added a basic 'default.lua' to whatever zone i was testing in with the following event handler:

```
function event_hate_list(e)
        if not e.joining then
                e.self:AddToHateList(e.other);
        end
end
```

Test cases
- Aggro npc and then leave the zone via #zone command
- Aggro npc and then camp out with GM mode enabled to simulate a disconnect


# Additional Stuff

Here's some stack traces I captured while debugging.  First two are from the crashes.  Last one is me interrogating the client while its being removed from the hate list (before the event is triggered).

```
Thread 1 (Thread 0x7f055913a100 (LWP 757592) "zone"):
#0  0x00005556c9ae1ba0 in ?? ()
#1  0x00005556c3695615 in HateList::WipeHateList (this=0x5556c94a06a0, npc_only=true) at /home/eqemu/code/zone/hate_list.cpp:52
#2  0x00005556c392a850 in Mob::WipeHateList (this=0x5556c9499070, npc_only=true) at /home/eqemu/code/zone/mob.h:813
#3  0x00005556c3938ec5 in Mob::AI_Process (this=0x5556c9499070) at /home/eqemu/code/zone/mob_ai.cpp:1079
#4  0x00005556c39507a0 in NPC::Process (this=0x5556c9499070) at /home/eqemu/code/zone/npc.cpp:889
#5  0x00005556c36552b1 in EntityList::MobProcess (this=0x5556c45a8220 <entity_list>) at /home/eqemu/code/zone/entity.cpp:528
#6  0x00005556c38fc6db in main::$_12::operator() (this=0x5556c8704a20, t=<optimized out>) at /home/eqemu/code/zone/main.cpp:627
#7  std::__invoke_impl<void, main::$_12&, EQ::Timer*> (__f=..., __args=<optimized out>) at /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/invoke.h:61
#8  std::__invoke_r<void, main::$_12&, EQ::Timer*> (__fn=..., __args=<optimized out>) at /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/invoke.h:111
#9  std::_Function_handler<void (EQ::Timer*), main::$_12>::_M_invoke(std::_Any_data const&, EQ::Timer*&&) (__functor=..., __args=<optimized out>) at /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/std_function.h:290
#10 0x00005556c38ff58b in std::function<void (EQ::Timer*)>::operator()(EQ::Timer*) const (this=0x7f0559358cc8 <main_arena+104>, __args=0x7ffe07ae4870) at /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/std_function.h:591
#11 EQ::Timer::Execute (this=0x7f0559358cc0 <main_arena+96>) at /home/eqemu/code/zone/../common/event/timer.h:61
#12 EQ::Timer::Start(unsigned long, bool)::{lambda(uv_timer_s*)#1}::operator()(uv_timer_s*) const (handle=<optimized out>, this=<optimized out>) at /home/eqemu/code/zone/../common/event/timer.h:38
#13 EQ::Timer::Start(unsigned long, bool)::{lambda(uv_timer_s*)#1}::__invoke(uv_timer_s*) (handle=<optimized out>) at /home/eqemu/code/zone/../common/event/timer.h:36
#14 0x00005556c3f4aab6 in uv__run_timers (loop=loop@entry=0x7f05591389f0) at /home/eqemu/code/submodules/libuv/src/timer.c:178
#15 0x00005556c3f4d3e5 in uv_run (loop=0x7f05591389f0, mode=UV_RUN_DEFAULT) at /home/eqemu/code/submodules/libuv/src/unix/core.c:393
#16 0x00005556c38fae52 in EQ::EventLoop::Run (this=0x7f0559358cc0 <main_arena+96>) at /home/eqemu/code/zone/../common/net/../event/event_loop.h:25
#17 main (argc=<optimized out>, argv=0x7ffe07ae4c18) at /home/eqemu/code/zone/main.cpp:657
```

```
#0  0x0000000000000000 in ?? ()
#1  0x00005642dea17c84 in Mob::AI_Process (this=0x5642e28e7110) at /home/eqemu/code/zone/mob_ai.cpp:1098
#2  0x00005642dea2f7a0 in NPC::Process (this=0x5642e28e7110) at /home/eqemu/code/zone/npc.cpp:889
#3  0x00005642de7342b1 in EntityList::MobProcess (this=0x5642df687220 <entity_list>) at /home/eqemu/code/zone/entity.cpp:528
#4  0x00005642de9db6db in main::$_12::operator() (this=0x5642e1b89b30, t=<optimized out>) at /home/eqemu/code/zone/main.cpp:627
#5  std::__invoke_impl<void, main::$_12&, EQ::Timer*> (__f=..., __args=<optimized out>) at /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/invoke.h:61
#6  std::__invoke_r<void, main::$_12&, EQ::Timer*> (__fn=..., __args=<optimized out>) at /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/invoke.h:111
#7  std::_Function_handler<void (EQ::Timer*), main::$_12>::_M_invoke(std::_Any_data const&, EQ::Timer*&&) (__functor=..., __args=<optimized out>) at /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/std_function.h:290
#8  0x00005642de9de58b in std::function<void (EQ::Timer*)>::operator()(EQ::Timer*) const (this=0x5642e2f76f38, __args=0x7fff3b3b2e10) at /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/std_function.h:591
#9  EQ::Timer::Execute (this=0x5642e2f76f30) at /home/eqemu/code/zone/../common/event/timer.h:61
#10 EQ::Timer::Start(unsigned long, bool)::{lambda(uv_timer_s*)#1}::operator()(uv_timer_s*) const (handle=<optimized out>, this=<optimized out>) at /home/eqemu/code/zone/../common/event/timer.h:38
#11 EQ::Timer::Start(unsigned long, bool)::{lambda(uv_timer_s*)#1}::__invoke(uv_timer_s*) (handle=<optimized out>) at /home/eqemu/code/zone/../common/event/timer.h:36
#12 0x00005642df029ab6 in uv__run_timers (loop=loop@entry=0x7f758c4629f0) at /home/eqemu/code/submodules/libuv/src/timer.c:178
#13 0x00005642df02c3e5 in uv_run (loop=0x7f758c4629f0, mode=UV_RUN_DEFAULT) at /home/eqemu/code/submodules/libuv/src/unix/core.c:393
#14 0x00005642de9d9e52 in EQ::EventLoop::Run (this=0x5642e2f76f30) at /home/eqemu/code/zone/../common/net/../event/event_loop.h:25
#15 main (argc=<optimized out>, argv=0x7fff3b3b31b8) at /home/eqemu/code/zone/main.cpp:657
```

"Adventure" is the name of my character.
```
(gdb) print init
$1 = (Mob *) 0x5568929a8a30
(gdb) print init->IsClient()
$2 = false
(gdb) print init->name
$3 = "Adventure", '\000' <repeats 54 times>
(gdb) bt
#0  handle_npc_hate (parse=parse@entry=0x55688e59ff78 <LuaParser::Instance()::inst>, L=L@entry=0x556891462a20, npc=npc@entry=0x556893cee380, init=init@entry=0x5568929a8a30, data="0", extra_data=0, extra_pointers=<optimized out>) at /home/eqemu/code/zone/lua_parser_events.cpp:237
#1  0x000055688d8f697b in LuaParser::_EventNPC (this=0x55688e59ff78 <LuaParser::Instance()::inst>, this@entry=0x38, package_name="encounter_dungeon_finder", evt=evt@entry=EVENT_HATE_LIST, npc=0x556893cee380, npc@entry=0x1e, init=0x5568929a8a30, init@entry=0x626f6c6700000000,
    data="0", extra_data=0, extra_pointers=0x0, l_func=0x556891a44b20) at /home/eqemu/code/zone/lua_parser.cpp:490
#2  0x000055688d8fcf8b in LuaParser::DispatchEventNPC (this=0x55688e59ff78 <LuaParser::Instance()::inst>, evt=<optimized out>, npc=0x5568929a8a30, init=0x7ffc4790e8d0, data=..., extra_data=<optimized out>, extra_pointers=<optimized out>)
    at /home/eqemu/code/zone/lua_parser.cpp:1385
#3  0x000055688db83ceb in QuestParserCollection::DispatchEventNPC (this=this@entry=0x55689009b700, event_id=2437294624, event_id@entry=EVENT_HATE_LIST, npc=npc@entry=0x556893cee380, init=init@entry=0x5568929a8a30, data="0", extra_data=extra_data@entry=0, extra_pointers=0x0)
    at /home/eqemu/code/zone/quest_parser_collection.cpp:1429
#4  0x000055688db83682 in QuestParserCollection::EventNPC (this=0x55689009b700, event_id=EVENT_HATE_LIST, npc=0x556893cee380, init=0x5568929a8a30, data=..., extra_data=0, extra_pointers=0x0) at /home/eqemu/code/zone/quest_parser_collection.cpp:447
#5  0x000055688d6ccefc in HateList::RemoveEntFromHateList (this=0x556893cf59b0, in_entity=0x5568929a8a30) at /home/eqemu/code/zone/hate_list.cpp:279
#6  0x000055688d961837 in Mob::RemoveFromHateList (this=0x556893cee380, mob=0x5568929a8a30) at /home/eqemu/code/zone/mob.cpp:5028
#7  0x000055688d68edc7 in EntityList::RemoveFromTargets (this=<optimized out>, mob=0x5568929a8a30, RemoveFromXTargets=<optimized out>) at /home/eqemu/code/zone/entity.cpp:1546
#8  0x000055688d94a7cc in Mob::~Mob (this=0x5568929a8a30) at /home/eqemu/code/zone/mob.cpp:558
#9  0x000055688d406e64 in Client::~Client (this=0x5568929a8a30) at /home/eqemu/code/zone/client.cpp:851
#10 0x000055688d407ef7 in Client::~Client (this=0x55688e59ff78 <LuaParser::Instance()::inst>) at /home/eqemu/code/zone/client.cpp:726
```