### PR TITLE
[Bug Fix] Make restored entity variables available in spawn events.

### DIFF
--- a/zone/npc.h
+++ b/zone/npc.h
@@ -607,6 +607,7 @@ public:
 	inline uint32_t SetCorpseDecayTime(uint32_t decay_time) { return m_corpse_decay_time = decay_time; }
 	inline void SetResumedFromZoneSuspend(bool state = true) { m_resumed_from_zone_suspend = state; }
 	inline bool IsResumedFromZoneSuspend() { return m_resumed_from_zone_suspend; }
+	void LoadEntityVariables(const std::string &entity_variables);
 
 	inline void LoadBuffsFromState(std::vector<Buffs_Struct> in_buffs) {
 		int i = 0;

--- a/zone/spawn2.cpp
+++ b/zone/spawn2.cpp
@@ -280,6 +280,11 @@ bool Spawn2::Process() {
 		npc->SetResumedFromZoneSuspend(m_resumed_from_zone_suspend);
 		m_resumed_from_zone_suspend = false;
 
+		if (!m_saved_entity_variables.empty()) {
+			npc->LoadEntityVariables(m_saved_entity_variables);
+			m_saved_entity_variables = "";
+		}
+
 		npc->AddLootTable();
 		if (npc->DropsGlobalLoot()) {
 			npc->CheckGlobalLootTables();

--- a/zone/spawn2.h
+++ b/zone/spawn2.h
@@ -77,6 +77,7 @@ public:
 	inline NPC *GetNPC() const { return npcthis; }
 	inline bool IsResumedFromZoneSuspend() const { return m_resumed_from_zone_suspend; }
 	inline void SetResumedFromZoneSuspend(bool resumed) { m_resumed_from_zone_suspend = resumed; }
+	inline void SetSavedEntityVariables(std::string entity_variables) { m_saved_entity_variables = entity_variables; }
 
 protected:
 	friend class Zone;
@@ -104,6 +105,7 @@ private:
 	bool IsDespawned;
 	uint32  killcount;
 	bool m_resumed_from_zone_suspend = false;
+	std::string m_saved_entity_variables = "";
 };
 
 class SpawnCondition {

--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -204,7 +204,7 @@ inline std::string GetLootSerialized(Corpse *c)
 	return "";
 }
 
-inline void LoadNPCEntityVariables(NPC *n, const std::string &entity_variables)
+void NPC::LoadEntityVariables(const std::string &entity_variables)
 {
 	if (!RuleB(Zone, StateSaveEntityVariables)) {
 		return;
@@ -215,7 +215,7 @@ inline void LoadNPCEntityVariables(NPC *n, const std::string &entity_variables)
 	}
 
 	if (!Strings::IsValidJson(entity_variables)) {
-		LogZoneState("Invalid JSON data for NPC [{}]", n->GetNPCTypeID());
+		LogZoneState("Invalid JSON data for NPC [{}]", this->GetNPCTypeID());
 		return;
 	}
 
@@ -228,12 +228,12 @@ inline void LoadNPCEntityVariables(NPC *n, const std::string &entity_variables)
 		}
 	}
 	catch (const std::exception &e) {
-		LogZoneState("Failed to load entity variables for NPC [{}] [{}]", n->GetNPCTypeID(), e.what());
+		LogZoneState("Failed to load entity variables for NPC [{}] [{}]", this->GetNPCTypeID(), e.what());
 		return;
 	}
 
 	for (const auto &[key, value]: deserialized_map) {
-		n->SetEntityVariable(key, value);
+		this->SetEntityVariable(key, value);
 	}
 }
 
@@ -329,7 +329,6 @@ inline void LoadNPCState(Zone *zone, NPC *n, ZoneStateSpawnsRepository::ZoneStat
 	n->SetResumedFromZoneSuspend(false);
 	LoadLootStateData(zone, n, s.loot_data);
 	n->SetResumedFromZoneSuspend(true);
-	LoadNPCEntityVariables(n, s.entity_variables);
 	LoadNPCBuffs(n, s.buffs);
 
 	if (s.is_corpse) {
@@ -475,6 +474,7 @@ bool Zone::LoadZoneState(
 		if (spawn_time_left == 0) {
 			new_spawn->SetCurrentNPCID(s.npc_id);
 			new_spawn->SetResumedFromZoneSuspend(true);
+			new_spawn->SetSavedEntityVariables(s.entity_variables);
 		}
 
 		spawn2_list.Insert(new_spawn);


### PR DESCRIPTION
# Description

Was running into an issue with scripts where the spawn events were triggering before the entity variables had loaded in from state.  This put me into a kind of catch-22 situation where I was struggling to find a solution with script logic.

In one case I could check the resume state of the npc and opt to not do anything knowing that the variables would populate later, but then any logic that might also need to be run based on the state of those variables couldn't because I didn't have them yet.

On the other hand if i just treated it like a normal spawn and did typical setup logic the entity variables would then overwrite the new values and then the npc would be in an inconsistent mixed-state.

This change stores the serialized entity variables in the spawn2 object to be deserialized into the npc after its created but before the events start firing off.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Basic akk-stack and rof2 client.

Tested with a basic default.lua script:

```
function event_spawn(e)
        if e.self:IsResumedFromZoneSuspend() then
                eq.debug("from suspend");
                eq.debug(e.self:GetEntityVariable("test"));
                e.self:SetEntityVariable("fromsuspend", e.self:GetEntityVariable("test"));
        else
                eq.debug("normal spawn");
                e.self:SetEntityVariable("test", "testvalue");
        end
end
```

And verifying with #entityvariable commands and console output that the entity variables were available as expected for restored spawns.

![image](https://github.com/user-attachments/assets/ec23073c-2d13-487f-8e0f-c6eb2dd97146)

![image](https://github.com/user-attachments/assets/4a248db0-b328-4dd0-9816-85a6a8b11637)
