### PR TITLE
[Fix] Zone State Entity Variable Load Pre-Spawn

### DIFF
--- a/zone/spawn2.cpp
+++ b/zone/spawn2.cpp
@@ -277,6 +277,12 @@ bool Spawn2::Process() {
 
 		npcthis = npc;
 
+		if (!m_entity_variables.empty()) {
+			for (auto &var : m_entity_variables) {
+				npc->SetEntityVariable(var.first, var.second);
+			}
+		}
+
 		npc->SetResumedFromZoneSuspend(m_resumed_from_zone_suspend);
 		m_resumed_from_zone_suspend = false;
 

--- a/zone/spawn2.cpp
+++ b/zone/spawn2.cpp
@@ -281,6 +281,7 @@ bool Spawn2::Process() {
 			for (auto &var : m_entity_variables) {
 				npc->SetEntityVariable(var.first, var.second);
 			}
+			m_entity_variables = {};
 		}
 
 		npc->SetResumedFromZoneSuspend(m_resumed_from_zone_suspend);

--- a/zone/spawn2.h
+++ b/zone/spawn2.h
@@ -77,6 +77,7 @@ public:
 	inline NPC *GetNPC() const { return npcthis; }
 	inline bool IsResumedFromZoneSuspend() const { return m_resumed_from_zone_suspend; }
 	inline void SetResumedFromZoneSuspend(bool resumed) { m_resumed_from_zone_suspend = resumed; }
+	inline void SetEntityVariables(std::map<std::string, std::string> vars) { m_entity_variables = vars; }
 
 protected:
 	friend class Zone;
@@ -104,6 +105,7 @@ private:
 	bool IsDespawned;
 	uint32  killcount;
 	bool m_resumed_from_zone_suspend = false;
+	std::map<std::string, std::string> m_entity_variables = {};
 };
 
 class SpawnCondition {

--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -356,8 +356,6 @@ inline void LoadNPCState(Zone *zone, NPC *n, ZoneStateSpawnsRepository::ZoneStat
 		}
 	}
 
-	n->SetPosition(s.x, s.y, s.z);
-	n->SetHeading(s.heading);
 	n->SetResumedFromZoneSuspend(true);
 }
 

--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -523,7 +523,7 @@ bool Zone::LoadZoneState(
 			npc->SetQueuedToCorpse();
 		}
 
-		LoadNPCEntityVariables(n, s.entity_variables);
+		LoadNPCEntityVariables(npc, s.entity_variables);
 
 		entity_list.AddNPC(npc, true, true);
 

--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -523,6 +523,8 @@ bool Zone::LoadZoneState(
 			npc->SetQueuedToCorpse();
 		}
 
+		LoadNPCEntityVariables(n, s.entity_variables);
+
 		entity_list.AddNPC(npc, true, true);
 
 		LoadNPCState(zone, npc, s);

--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -204,6 +204,33 @@ inline std::string GetLootSerialized(Corpse *c)
 	return "";
 }
 
+inline std::map<std::string, std::string> GetVariablesDeserialized(const std::string &entity_variables)
+{
+	std::map<std::string, std::string> deserialized_map;
+
+	if (entity_variables.empty()) {
+		return deserialized_map;
+	}
+
+	if (!Strings::IsValidJson(entity_variables)) {
+		LogZoneState("Invalid JSON data for entity variables");
+		return deserialized_map;
+	}
+
+	try {
+		std::stringstream ss;
+		{
+			ss << entity_variables;
+			cereal::JSONInputArchive ar(ss);
+			ar(deserialized_map);
+		}
+	} catch (const std::exception &e) {
+		LogZoneState("Failed to load entity variables [{}]", e.what());
+	}
+
+	return deserialized_map;
+}
+
 inline void LoadNPCEntityVariables(NPC *n, const std::string &entity_variables)
 {
 	if (!RuleB(Zone, StateSaveEntityVariables)) {
@@ -214,25 +241,7 @@ inline void LoadNPCEntityVariables(NPC *n, const std::string &entity_variables)
 		return;
 	}
 
-	if (!Strings::IsValidJson(entity_variables)) {
-		LogZoneState("Invalid JSON data for NPC [{}]", n->GetNPCTypeID());
-		return;
-	}
-
-	std::map<std::string, std::string> deserialized_map;
-	try {
-		std::istringstream is(entity_variables);
-		{
-			cereal::JSONInputArchive archive(is);
-			archive(deserialized_map);
-		}
-	}
-	catch (const std::exception &e) {
-		LogZoneState("Failed to load entity variables for NPC [{}] [{}]", n->GetNPCTypeID(), e.what());
-		return;
-	}
-
-	for (const auto &[key, value]: deserialized_map) {
+	for (const auto &[key, value]: GetVariablesDeserialized(entity_variables)) {
 		n->SetEntityVariable(key, value);
 	}
 }
@@ -343,6 +352,8 @@ inline void LoadNPCState(Zone *zone, NPC *n, ZoneStateSpawnsRepository::ZoneStat
 		}
 	}
 
+	n->SetPosition(s.x, s.y, s.z);
+	n->SetHeading(s.heading);
 	n->SetResumedFromZoneSuspend(true);
 }
 
@@ -475,6 +486,7 @@ bool Zone::LoadZoneState(
 		if (spawn_time_left == 0) {
 			new_spawn->SetCurrentNPCID(s.npc_id);
 			new_spawn->SetResumedFromZoneSuspend(true);
+			new_spawn->SetEntityVariables(GetVariablesDeserialized(s.entity_variables));
 		}
 
 		spawn2_list.Insert(new_spawn);

--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -319,6 +319,11 @@ inline std::vector<uint32_t> GetLootdropIds(const std::vector<ZoneStateSpawnsRep
 	return lootdrop_ids;
 }
 
+inline void LoadNPCStatePreSpawn(Zone *zone, NPC *n, ZoneStateSpawnsRepository::ZoneStateSpawns &s)
+{
+	LoadNPCEntityVariables(n, s.entity_variables);
+}
+
 inline void LoadNPCState(Zone *zone, NPC *n, ZoneStateSpawnsRepository::ZoneStateSpawns &s)
 {
 	if (s.hp > 0) {
@@ -338,7 +343,6 @@ inline void LoadNPCState(Zone *zone, NPC *n, ZoneStateSpawnsRepository::ZoneStat
 	n->SetResumedFromZoneSuspend(false);
 	LoadLootStateData(zone, n, s.loot_data);
 	n->SetResumedFromZoneSuspend(true);
-	LoadNPCEntityVariables(n, s.entity_variables);
 	LoadNPCBuffs(n, s.buffs);
 
 	if (s.is_corpse) {
@@ -523,7 +527,7 @@ bool Zone::LoadZoneState(
 			npc->SetQueuedToCorpse();
 		}
 
-		LoadNPCEntityVariables(npc, s.entity_variables);
+		LoadNPCStatePreSpawn(zone, npc, s);
 
 		entity_list.AddNPC(npc, true, true);
 
@@ -578,7 +582,7 @@ inline void SaveNPCState(NPC *n, ZoneStateSpawnsRepository::ZoneStateSpawns &s)
 	auto buffs = n->GetBuffs();
 	if (buffs) {
 		std::vector<Buffs_Struct> valid_buffs;
-		for (int index = 0; index < n->GetMaxBuffSlots(); index++) {
+		for (int                  index = 0; index < n->GetMaxBuffSlots(); index++) {
 			if (buffs[index].spellid != 0 && buffs[index].spellid != 65535) {
 				valid_buffs.push_back(buffs[index]);
 			}


### PR DESCRIPTION
# Description

This fixes another rare edge case with zone state restore where entity variables are not present during an EVENT_SPAWN, they are restored shortly after. This fixes that and loads them prior to the NPC being added to the NPC list and firing quest events.

Originally reported by @zimp-wow in https://github.com/EQEmu/Server/pull/4783

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Tested basic functionality

![image](https://github.com/user-attachments/assets/fac0e1c9-7029-43d0-97b1-e5c6add33405)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

