### PR TITLE
[Rules] Implement double and triple attack for ranged attacks

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -657,6 +657,7 @@ RULE_INT(Combat, KickBaseDamage, 3, "Kick base damage, default is 3")
 RULE_INT(Combat, RoundKickBaseDamage, 5, "Round Kick base damage, default is 5")
 RULE_INT(Combat, ThrowingBaseDamage, 0, "Throwing base damage, default is 0")
 RULE_INT(Combat, TigerClawBaseDamage, 4, "Tiger Claw base damage, default is 4")
+RULE_BOOL(Combat, RangedDoubleAndTripleAttack, false, "Ranged attacks will be able to utilize double and triple attack")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(NPC)

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -354,7 +354,7 @@ bool Client::Process() {
 			}
 		}
 
-		if (AutoFireEnabled() && may_use_attacks) {
+		if (AutoFireEnabled()) {
 			if (GetTarget() == this) {
 				MessageString(Chat::TooFarAway, TRY_ATTACKING_SOMEONE);
 				auto_fire = false;

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -354,12 +354,12 @@ bool Client::Process() {
 			}
 		}
 
-		if (AutoFireEnabled()) {
+		if (AutoFireEnabled() && may_use_attacks) {
 			if (GetTarget() == this) {
 				MessageString(Chat::TooFarAway, TRY_ATTACKING_SOMEONE);
 				auto_fire = false;
 			}
-			EQ::ItemInstance *ranged = GetInv().GetItem(EQ::invslot::slotRange);
+			EQ::ItemInstance* ranged = GetInv().GetItem(EQ::invslot::slotRange);
 			if (ranged) {
 				if (ranged->GetItem() && ranged->GetItem()->ItemType == EQ::item::ItemTypeBow) {
 					if (ranged_timer.Check(false)) {
@@ -367,33 +367,58 @@ bool Client::Process() {
 							if (GetTarget()->InFrontMob(this, GetTarget()->GetX(), GetTarget()->GetY())) {
 								if (CheckLosFN(GetTarget()) && CheckWaterAutoFireLoS(GetTarget())) {
 									//client has built in los check, but auto fire does not.. done last.
-									if (RangedAttack(GetTarget()) && CheckDoubleRangedAttack()) {
-										RangedAttack(GetTarget(), true);
+									if (RangedAttack(GetTarget()) && (CheckDoubleRangedAttack() || (RuleB(Custom, RangedDoubleAndTripleAttack) && CanThisClassDoubleAttack() && CheckDoubleAttack()))) {
+										if (RangedAttack(GetTarget(), true) && RuleB(Custom, RangedDoubleAndTripleAttack) && CanThisClassTripleAttack() && CheckTripleAttack()) {
+											RangedAttack(GetTarget(), true);
+										}
 									}
-								} else {
+									if (RuleB(Custom, DoubleAttackSkillRanged) && CanThisClassDoubleAttack()) {
+										CheckIncreaseSkill(EQ::skills::SkillDoubleAttack, GetTarget());
+									}
+									if (RuleB(Custom, DoubleAttackSkillRanged) && CanThisClassTripleAttack()) {
+										CheckIncreaseSkill(EQ::skills::SkillTripleAttack, GetTarget());
+									}
+								}
+								else {
 									ranged_timer.Start();
 								}
-							} else {
+							}
+							else {
 								ranged_timer.Start();
 							}
-						} else {
+						}
+						else {
 							ranged_timer.Start();
 						}
 					}
-				} else if (ranged->GetItem() && (ranged->GetItem()->ItemType == EQ::item::ItemTypeLargeThrowing || ranged->GetItem()->ItemType == EQ::item::ItemTypeSmallThrowing)) {
+				}
+				else if (ranged->GetItem() && (ranged->GetItem()->ItemType == EQ::item::ItemTypeLargeThrowing || ranged->GetItem()->ItemType == EQ::item::ItemTypeSmallThrowing)) {
 					if (ranged_timer.Check(false)) {
 						if (GetTarget() && (GetTarget()->IsNPC() || GetTarget()->IsClient()) && IsAttackAllowed(GetTarget())) {
 							if (GetTarget()->InFrontMob(this, GetTarget()->GetX(), GetTarget()->GetY())) {
 								if (CheckLosFN(GetTarget()) && CheckWaterAutoFireLoS(GetTarget())) {
 									//client has built in los check, but auto fire does not.. done last.
-									ThrowingAttack(GetTarget());
-								} else {
+									if (ThrowingAttack(GetTarget()) && (CheckDoubleRangedAttack() || (RuleB(Custom, RangedDoubleAndTripleAttack) && CanThisClassDoubleAttack() && CheckDoubleAttack()))) {
+										if (ThrowingAttack(GetTarget(), true) && RuleB(Custom, RangedDoubleAndTripleAttack) && CanThisClassTripleAttack() && CheckTripleAttack()) {
+											ThrowingAttack(GetTarget(), true);
+										}
+									}
+									if (RuleB(Custom, DoubleAttackSkillRanged) && CanThisClassDoubleAttack()) {
+										CheckIncreaseSkill(EQ::skills::SkillDoubleAttack, GetTarget());
+									}
+									if (RuleB(Custom, DoubleAttackSkillRanged) && CanThisClassTripleAttack()) {
+										CheckIncreaseSkill(EQ::skills::SkillTripleAttack, GetTarget());
+									}
+								}
+								else {
 									ranged_timer.Start();
 								}
-							} else {
+							}
+							else {
 								ranged_timer.Start();
 							}
-						} else {
+						}
+						else {
 							ranged_timer.Start();
 						}
 					}

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -367,29 +367,23 @@ bool Client::Process() {
 							if (GetTarget()->InFrontMob(this, GetTarget()->GetX(), GetTarget()->GetY())) {
 								if (CheckLosFN(GetTarget()) && CheckWaterAutoFireLoS(GetTarget())) {
 									//client has built in los check, but auto fire does not.. done last.
-									if (RangedAttack(GetTarget()) && (CheckDoubleRangedAttack() || (RuleB(Custom, RangedDoubleAndTripleAttack) && CanThisClassDoubleAttack() && CheckDoubleAttack()))) {
-										if (RangedAttack(GetTarget(), true) && RuleB(Custom, RangedDoubleAndTripleAttack) && CanThisClassTripleAttack() && CheckTripleAttack()) {
-											RangedAttack(GetTarget(), true);
-										}
+									RangedAttack(GetTarget());
+									if (CheckDoubleRangedAttack() || (RuleB(Combat, RangedDoubleAndTripleAttack) && CanThisClassDoubleAttack() && CheckDoubleAttack())) {
+										RangedAttack(GetTarget(), true);
 									}
-									if (RuleB(Custom, DoubleAttackSkillRanged) && CanThisClassDoubleAttack()) {
+									if (RuleB(Combat, RangedDoubleAndTripleAttack) && CanThisClassTripleAttack() && CheckTripleAttack()) {
+										RangedAttack(GetTarget(), true);
+									}
+									if (RuleB(Combat, RangedDoubleAndTripleAttack) && CanThisClassDoubleAttack()) {
 										CheckIncreaseSkill(EQ::skills::SkillDoubleAttack, GetTarget());
 									}
-									if (RuleB(Custom, DoubleAttackSkillRanged) && CanThisClassTripleAttack()) {
+									if (RuleB(Combat, RangedDoubleAndTripleAttack) && CanThisClassTripleAttack()) {
 										CheckIncreaseSkill(EQ::skills::SkillTripleAttack, GetTarget());
 									}
 								}
-								else {
-									ranged_timer.Start();
-								}
-							}
-							else {
-								ranged_timer.Start();
 							}
 						}
-						else {
-							ranged_timer.Start();
-						}
+						ranged_timer.Start();
 					}
 				}
 				else if (ranged->GetItem() && (ranged->GetItem()->ItemType == EQ::item::ItemTypeLargeThrowing || ranged->GetItem()->ItemType == EQ::item::ItemTypeSmallThrowing)) {
@@ -398,29 +392,23 @@ bool Client::Process() {
 							if (GetTarget()->InFrontMob(this, GetTarget()->GetX(), GetTarget()->GetY())) {
 								if (CheckLosFN(GetTarget()) && CheckWaterAutoFireLoS(GetTarget())) {
 									//client has built in los check, but auto fire does not.. done last.
-									if (ThrowingAttack(GetTarget()) && (CheckDoubleRangedAttack() || (RuleB(Custom, RangedDoubleAndTripleAttack) && CanThisClassDoubleAttack() && CheckDoubleAttack()))) {
-										if (ThrowingAttack(GetTarget(), true) && RuleB(Custom, RangedDoubleAndTripleAttack) && CanThisClassTripleAttack() && CheckTripleAttack()) {
-											ThrowingAttack(GetTarget(), true);
-										}
+									ThrowingAttack(GetTarget());
+									if (CheckDoubleRangedAttack() || (RuleB(Combat, RangedDoubleAndTripleAttack) && CanThisClassDoubleAttack() && CheckDoubleAttack())) {
+										ThrowingAttack(GetTarget(), true);
 									}
-									if (RuleB(Custom, DoubleAttackSkillRanged) && CanThisClassDoubleAttack()) {
+									if (RuleB(Combat, RangedDoubleAndTripleAttack) && CanThisClassTripleAttack() && CheckTripleAttack()) {
+										ThrowingAttack(GetTarget(), true);
+									}
+									if (RuleB(Combat, RangedDoubleAndTripleAttack) && CanThisClassDoubleAttack()) {
 										CheckIncreaseSkill(EQ::skills::SkillDoubleAttack, GetTarget());
 									}
-									if (RuleB(Custom, DoubleAttackSkillRanged) && CanThisClassTripleAttack()) {
+									if (RuleB(Combat, RangedDoubleAndTripleAttack) && CanThisClassTripleAttack()) {
 										CheckIncreaseSkill(EQ::skills::SkillTripleAttack, GetTarget());
 									}
 								}
-								else {
-									ranged_timer.Start();
-								}
-							}
-							else {
-								ranged_timer.Start();
 							}
 						}
-						else {
-							ranged_timer.Start();
-						}
+						ranged_timer.Start();
 					}
 				}
 			}

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -395,14 +395,10 @@ bool Client::Process() {
 									ThrowingAttack(GetTarget());
 									if (CheckDoubleRangedAttack() || (RuleB(Combat, RangedDoubleAndTripleAttack) && CanThisClassDoubleAttack() && CheckDoubleAttack())) {
 										ThrowingAttack(GetTarget(), true);
+										CheckIncreaseSkill(EQ::skills::SkillDoubleAttack, GetTarget());
 									}
 									if (RuleB(Combat, RangedDoubleAndTripleAttack) && CanThisClassTripleAttack() && CheckTripleAttack()) {
 										ThrowingAttack(GetTarget(), true);
-									}
-									if (RuleB(Combat, RangedDoubleAndTripleAttack) && CanThisClassDoubleAttack()) {
-										CheckIncreaseSkill(EQ::skills::SkillDoubleAttack, GetTarget());
-									}
-									if (RuleB(Combat, RangedDoubleAndTripleAttack) && CanThisClassTripleAttack()) {
 										CheckIncreaseSkill(EQ::skills::SkillTripleAttack, GetTarget());
 									}
 								}

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -370,14 +370,10 @@ bool Client::Process() {
 									RangedAttack(GetTarget());
 									if (CheckDoubleRangedAttack() || (RuleB(Combat, RangedDoubleAndTripleAttack) && CanThisClassDoubleAttack() && CheckDoubleAttack())) {
 										RangedAttack(GetTarget(), true);
+										CheckIncreaseSkill(EQ::skills::SkillDoubleAttack, GetTarget());
 									}
 									if (RuleB(Combat, RangedDoubleAndTripleAttack) && CanThisClassTripleAttack() && CheckTripleAttack()) {
 										RangedAttack(GetTarget(), true);
-									}
-									if (RuleB(Combat, RangedDoubleAndTripleAttack) && CanThisClassDoubleAttack()) {
-										CheckIncreaseSkill(EQ::skills::SkillDoubleAttack, GetTarget());
-									}
-									if (RuleB(Combat, RangedDoubleAndTripleAttack) && CanThisClassTripleAttack()) {
 										CheckIncreaseSkill(EQ::skills::SkillTripleAttack, GetTarget());
 									}
 								}


### PR DESCRIPTION
# Description

Adds a rule to allow ranged attacks to utilize Double Attack and Triple Attack. This rule is false by default.

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur