### PR TITLE
[Fix] Zone state edge case with 0 hp

### DIFF
--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -336,6 +336,16 @@ inline void LoadNPCState(Zone *zone, NPC *n, ZoneStateSpawnsRepository::ZoneStat
 		n->SetEndurance(s.endurance);
 	}
 
+	// if these are zero for some reason, we need to reset the max hp
+	if (!s.is_corpse) {
+		if (s.hp == 0 || n->GetHP() == 0) {
+			n->SetMaxHP();
+		}
+		if (s.mana == 0 || n->GetMana() == 0) {
+			n->RestoreMana();
+		}
+	}
+
 	if (s.grid) {
 		n->AssignWaypoints(s.grid, s.current_waypoint);
 	}


### PR DESCRIPTION
# Description

This should potentially fix an issue that I've been unable to reproduce in rarer circumstances where NPC's restore with 0 HP. This change sets HP to max if current HP on restore is 0.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

None

# Checklist

- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I have made corresponding changes to the documentation (if applicable, if not delete this line)
- [x] I own the changes of my code and take responsibility for the potential issues that occur

