### PR TITLE
[Performance] Reduce UpdateWho S2S Chatter to World

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -379,6 +379,7 @@ RULE_BOOL(Zone, StateSaveEntityVariables, true, "Set to true if you want buffs t
 RULE_BOOL(Zone, StateSaveBuffs, true, "Set to true if you want buffs to be saved on shutdown")
 RULE_INT(Zone, StateSaveClearDays, 7, "Clears state save data older than this many days")
 RULE_BOOL(Zone, StateSavingOnShutdown, true, "Set to true if you want zones to save state on shutdown (npcs, corpses, loot, entity variables, buffs etc.)")
+RULE_INT(Zone, UpdateWhoTimer, 120, "Seconds between updates to /who list, CLE stale timer")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Map)

--- a/zone/main.cpp
+++ b/zone/main.cpp
@@ -500,6 +500,8 @@ int main(int argc, char **argv)
 	}
 
 	Timer InterserverTimer(INTERSERVER_TIMER); // does MySQL pings and auto-reconnect
+	Timer UpdateWhoTimer(2 * 60 * 1000); // updates who list every 2 minutes
+
 #ifdef EQPROFILE
 #ifdef PROFILE_DUMP_TIME
 	Timer profile_dump_timer(PROFILE_DUMP_TIME * 1000);
@@ -647,7 +649,9 @@ int main(int argc, char **argv)
 			InterserverTimer.Start();
 			database.ping();
 			content_db.ping();
-			entity_list.UpdateWho();
+			if (UpdateWhoTimer.Check()) {
+				entity_list.UpdateWho();
+			}
 		}
 	};
 

--- a/zone/main.cpp
+++ b/zone/main.cpp
@@ -500,7 +500,7 @@ int main(int argc, char **argv)
 	}
 
 	Timer InterserverTimer(INTERSERVER_TIMER); // does MySQL pings and auto-reconnect
-	Timer UpdateWhoTimer(2 * 60 * 1000); // updates who list every 2 minutes
+	Timer UpdateWhoTimer(RuleI(Zone, UpdateWhoTimer) * 1000); // updates who list every 2 minutes
 
 #ifdef EQPROFILE
 #ifdef PROFILE_DUMP_TIME
@@ -650,6 +650,7 @@ int main(int argc, char **argv)
 			database.ping();
 			content_db.ping();
 			if (UpdateWhoTimer.Check()) {
+				UpdateWhoTimer.SetTimer(RuleI(Zone, UpdateWhoTimer) * 1000); // in-case it was changed
 				entity_list.UpdateWho();
 			}
 		}


### PR DESCRIPTION
# Description

This is a performance adjustment for **World** where 3k players and 1,800 zoneservers showed strain on World. A grand majority of the CPU load (98%) this was shown to be TCP chatter (server to server).

I ran S<->S packet logging in world and found the following data. This change will be one of several found from these results. https://gist.github.com/Akkadius/12b57fadbbe21ea9a46b854c62cc3a65#file-world-s2s-1m-md

For this PR - this targets the following packets and should reduce chatter by upwards of 90% give or take.

* **ServerOP_ClientListKA** (10,652 packets in a minute, 177 packets/s received from zones)
* **ServerOP_ClientList** (1,388 23 packets/s received from zones)

Today we send every 10 seconds from zone an update packet to World to update /who data and also simply set a "stale" bool which gets checked every 10 seconds World side to then mark a clients connection as stale after up to 3.3 minutes of inactivity. There's no reason for this to be so frequent and we can pull this back quite a bit.

## Type of change

- [x] Optimization

# Testing

**Before**

```
> who
Players on server:
  * GM-Impossible * [90 Imperator] Akka (Barbarian) zone: kael AccID: 12 AccName: test LSID: 5 Status: 255
1 players online
```

**After**

After a brief period of force killing my game client, world finds the player / account as stale.

```
 Login |   Debug    | ProcessLSStatus World Server Status Update Received | Server [|T| Akkas Test Bed (LDL)] Status [1] Players [1] Zones [3] 
  Zone |    Info    | Process Client linkdead: Akka -- [kael] (Kael Drakkel) inst_id [0]
 World | Client Log | SetOnline Online status [test] (12) status [Offline] (1) 
  Zone |   Debug    | SaveCharacterData ZoneDatabase::SaveCharacterData [9,] done Took [0.000116] seconds -- [kael] (Kael Drakkel) inst_id [0]
  Zone |    Info    | MobProcess Zone will go into an idle state after [600] seconds. -- [kael] (Kael Drakkel) inst_id [0]
```

```
who
Players on server:
0 players online
```

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
