### PR TITLE
[Performance] Reduce Adventure S2S Chatter to World

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -73,6 +73,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include "../common/repositories/character_stats_record_repository.h"
 #include "dialogue_window.h"
 #include "../common/rulesys.h"
+#include "../common/repositories/adventure_members_repository.h"
 
 extern QueryServ* QServ;
 extern Zone* zone;
@@ -913,11 +914,14 @@ void Client::CompleteConnect()
 
 	SendDynamicZoneUpdates();
 
-	/** Request adventure info **/
-	auto pack = new ServerPacket(ServerOP_AdventureDataRequest, 64);
-	strcpy((char*)pack->pBuffer, GetName());
-	worldserver.SendPacket(pack);
-	delete pack;
+	// Request adventure info
+	auto members = AdventureMembersRepository::GetWhere(database, fmt::format("charid = {}", CharacterID()));
+	if (!members.empty()) {
+		auto pack = new ServerPacket(ServerOP_AdventureDataRequest, 64);
+		strcpy((char*)pack->pBuffer, GetName());
+		worldserver.SendPacket(pack);
+		delete pack;
+	}
 
 	if (IsClient() && CastToClient()->ClientVersionBit() & EQ::versions::maskUFAndLater) {
 		EQApplicationPacket *outapp = MakeBuffsPacket(false);


### PR DESCRIPTION
# Description

This is a performance adjustment for **World** where 3k players and 1,800 zoneservers showed strain on World. A grand majority of the CPU load (98%) this was shown to be TCP chatter (server to server).

I ran S<->S packet logging in world and found the following data. This change will be one of several found from these results. https://gist.github.com/Akkadius/12b57fadbbe21ea9a46b854c62cc3a65#file-world-s2s-1m-md

For this PR - this targets the following packets and should reduce chatter by upwards of 100% in the case that most players are not in adventures in most servers.

* **ServerOP_AdventureDataRequest** (361 packets in a minute - 6 packets/s received from zones)
* **ServerOP_AdventureZoneData** (41 packets a minute - 7 packets/s received from zones)

## Type of change

- [x] Optimization

# Testing

Loaded into a zone, no query errors, no packet sent

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
