### PR TITLE
[Performance] Reduce LFGuild Chatter to World

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -261,6 +261,7 @@ RULE_INT(Guild, TributeTime, 600000, "Time in ms for guild tributes.  Default is
 RULE_INT(Guild, TributeTimeRefreshInterval, 180000, "Time in ms to send all guild members a Tribute Time refresh. Default is 3 mins.")
 RULE_INT(Guild, TributePlatConversionRate, 10, "The conversion rate of platinum donations.  Default is 10 guild favor to 1 platinum.")
 RULE_BOOL(Guild, UseCharacterMaxLevelForGuildTributes, true, "Guild Tributes will adhere to Character:MaxLevel.  Default is true.")
+RULE_BOOL(Guild, EnableLFGuild, false, "Enable the LFGuild system (Requires queryserv)")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Skills)

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -882,9 +882,13 @@ void Client::SendZoneInPackets()
 		//SendGuildMembers();
 		SendGuildURL();
 		SendGuildChannel();
-		SendGuildLFGuildStatus();
+		if (RuleB(Guild, EnableLFGuild)) {
+			SendGuildLFGuildStatus();
+		}
 	}
-	SendLFGuildStatus();
+	if (RuleB(Guild, EnableLFGuild)) {
+		SendLFGuildStatus();
+	}
 
 	//No idea why live sends this if even were not in a guild
 	SendGuildMOTD();


### PR DESCRIPTION
# Description

This is a performance adjustment for **World** where 3k players and 1,800 zoneservers showed strain on World. A grand majority of the CPU load (98%) this was shown to be TCP chatter (server to server).

I ran S<->S packet logging in world and found the following data. This change will be one of several found from these results. https://gist.github.com/Akkadius/12b57fadbbe21ea9a46b854c62cc3a65#file-world-s2s-1m-md

For this PR - this targets the following packets and should reduce chatter by upwards of 100% in the case that most servers don't use this feature, don't run queryserv to support it and it creates a lot of packet chatter for almost nothing.

* **ServerOP_QueryServGeneric** (520 packets in a minute - 8.6 packets/s received from zones)

## Type of change

- [x] Optimization

# Testing

Rule disabled, packet doesn't send

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
