### PR TITLE
[Performance] Have World Send Smarter Guild Updates

### DIFF
--- a/world/clientlist.cpp
+++ b/world/clientlist.cpp
@@ -1850,3 +1850,39 @@ std::map<uint32, ClientListEntry *> ClientList::GetGuildClientsWithTributeOptIn(
 	}
 	return guild_members;
 }
+
+#include <unordered_set>
+
+std::vector<uint32_t> ClientList::GetGuildZoneServers(uint32 guild_id)
+{
+	std::vector<uint32_t>        zone_server_ids;
+	std::unordered_set<uint32_t> seen_ids;
+
+	LinkedListIterator<ClientListEntry *> iterator(clientlist);
+
+	iterator.Reset();
+	while (iterator.MoreElements()) {
+		ClientListEntry *cle = iterator.GetData();
+
+		if (cle->Online() != CLE_Status::InZone) {
+			iterator.Advance();
+			continue;
+		}
+
+		if (!cle->Server()) {
+			iterator.Advance();
+			continue;
+		}
+
+		if (cle->GuildID() == guild_id) {
+			uint32_t id = cle->Server()->GetID();
+			if (seen_ids.insert(id).second) {
+				zone_server_ids.emplace_back(id);
+			}
+		}
+
+		iterator.Advance();
+	}
+
+	return zone_server_ids;
+}

--- a/world/clientlist.h
+++ b/world/clientlist.h
@@ -60,6 +60,7 @@ public:
 	void	CLCheckStale();
 	void	CLEKeepAlive(uint32 numupdates, uint32* wid);
 	void	CLEAdd(uint32 login_server_id, const char* login_server_name, const char* login_name, const char* login_key, int16 world_admin = AccountStatus::Player, uint32 ip_address = 0, uint8 is_local=0);
+	std::vector<uint32_t> GetGuildZoneServers(uint32 guild_id);
 	void	UpdateClientGuild(uint32 char_id, uint32 guild_id);
 	bool    IsAccountInGame(uint32 iLSID);
 

--- a/world/wguild_mgr.cpp
+++ b/world/wguild_mgr.cpp
@@ -85,14 +85,13 @@ void WorldGuildManager::ProcessZonePacket(ServerPacket *pack) {
 		ServerGuildRefresh_Struct *s = (ServerGuildRefresh_Struct *) pack->pBuffer;
 		LogGuilds("Received and broadcasting guild refresh for [{}], changes: name=[{}], motd=[{}], rank=d, relation=[{}]", s->guild_id, s->name_change, s->motd_change, s->rank_change, s->relation_change);
 
-		//broadcast this packet to all zones.
-		zoneserver_list.SendPacketToZonesWithGuild(s->guild_id, pack);
-
 		//preform a local refresh.
 		if(!RefreshGuild(s->guild_id)) {
-			LogGuilds("Unable to preform local refresh on guild [{}]", s->guild_id);
-			//can we do anything?
+			BaseGuildManager::RefreshGuild(s->guild_id);
 		}
+
+		//broadcast this packet to all zones.
+		zoneserver_list.SendPacketToZonesWithGuild(s->guild_id, pack);
 
 		break;
 	}
@@ -230,7 +229,6 @@ void WorldGuildManager::ProcessZonePacket(ServerPacket *pack) {
 	case ServerOP_GuildChannel:
 	case ServerOP_GuildURL:
 	case ServerOP_GuildMemberRemove:
-	case ServerOP_GuildSendGuildList:
 	case ServerOP_GuildMembersList:
 	{
 		auto in = (ServerOP_GuildMessage_Struct *) pack->pBuffer;
@@ -248,6 +246,12 @@ void WorldGuildManager::ProcessZonePacket(ServerPacket *pack) {
         zoneserver_list.SendPacketToZonesWithGuild(in->guild_id, pack);
         break;
     }
+	case ServerOP_GuildSendGuildList: {
+		auto in = (ServerOP_GuildMessage_Struct *) pack->pBuffer;
+		zoneserver_list.SendPacketToBootedZones(pack);
+		break;
+	}
+
 	default:
 		LogGuilds("Unknown packet {:#04x} received from zone??", pack->opcode);
 		break;

--- a/world/wguild_mgr.cpp
+++ b/world/wguild_mgr.cpp
@@ -50,7 +50,7 @@ void WorldGuildManager::SendGuildRefresh(uint32 guild_id, bool name, bool motd, 
 	s->motd_change = motd;
 	s->rank_change = rank;
 	s->relation_change = relation;
-	zoneserver_list.SendPacket(pack);
+	zoneserver_list.SendPacketToZonesWithGuild(guild_id, pack);
 	safe_delete(pack);
 }
 
@@ -61,7 +61,7 @@ void WorldGuildManager::SendCharRefresh(uint32 old_guild_id, uint32 guild_id, ui
 	s->guild_id = guild_id;
 	s->old_guild_id = old_guild_id;
 	s->char_id = charid;
-	zoneserver_list.SendPacket(pack);
+	zoneserver_list.SendPacketToZonesWithGuild(guild_id, pack);
 	safe_delete(pack);
 }
 
@@ -70,7 +70,7 @@ void WorldGuildManager::SendGuildDelete(uint32 guild_id) {
 	auto pack = new ServerPacket(ServerOP_DeleteGuild, sizeof(ServerGuildID_Struct));
 	ServerGuildID_Struct *s = (ServerGuildID_Struct *) pack->pBuffer;
 	s->guild_id = guild_id;
-	zoneserver_list.SendPacket(pack);
+	zoneserver_list.SendPacketToZonesWithGuild(guild_id, pack);
 	safe_delete(pack);
 }
 
@@ -86,7 +86,7 @@ void WorldGuildManager::ProcessZonePacket(ServerPacket *pack) {
 		LogGuilds("Received and broadcasting guild refresh for [{}], changes: name=[{}], motd=[{}], rank=d, relation=[{}]", s->guild_id, s->name_change, s->motd_change, s->rank_change, s->relation_change);
 
 		//broadcast this packet to all zones.
-		zoneserver_list.SendPacket(pack);
+		zoneserver_list.SendPacketToZonesWithGuild(s->guild_id, pack);
 
 		//preform a local refresh.
 		if(!RefreshGuild(s->guild_id)) {
@@ -108,7 +108,7 @@ void WorldGuildManager::ProcessZonePacket(ServerPacket *pack) {
 
 		//broadcast this update to any zone with a member in this guild.
 		//because im sick of this not working, sending it to all zones, just spends a bit more bandwidth.
-		zoneserver_list.SendPacket(pack);
+		zoneserver_list.SendPacketToZonesWithGuild(s->guild_id, pack);
 
 		break;
 	}
@@ -147,7 +147,7 @@ void WorldGuildManager::ProcessZonePacket(ServerPacket *pack) {
 		auto s = (ServerGuildID_Struct *)pack->pBuffer;
 		RefreshGuild(s->guild_id);
 
-		zoneserver_list.SendPacket(pack);
+		zoneserver_list.SendPacketToZonesWithGuild(s->guild_id, pack);
 		break;
 	}
 	case ServerOP_GuildPermissionUpdate:
@@ -179,7 +179,7 @@ void WorldGuildManager::ProcessZonePacket(ServerPacket *pack) {
 				sg->function_value
 			);
 
-			zoneserver_list.SendPacketToBootedZones(pack);
+			zoneserver_list.SendPacketToZonesWithGuild(sg->guild_id, pack);
 		}
 		else {
 			LogError("World Received ServerOP_GuildPermissionUpdate for guild [{}] function id {} with value of {} but guild could not be found.",
@@ -213,7 +213,7 @@ void WorldGuildManager::ProcessZonePacket(ServerPacket *pack) {
 				rnc->rank,
 				rnc->rank_name
 			);
-			zoneserver_list.SendPacketToBootedZones(pack);
+			zoneserver_list.SendPacketToZonesWithGuild(rnc->guild_id, pack);
 		}
 		else {
 			LogError("World Received ServerOP_GuildRankNameChange from zone for guild [{}] rank id {} with new name of {} but could not find guild.",
@@ -233,10 +233,11 @@ void WorldGuildManager::ProcessZonePacket(ServerPacket *pack) {
 	case ServerOP_GuildSendGuildList:
 	case ServerOP_GuildMembersList:
 	{
-		zoneserver_list.SendPacketToBootedZones(pack);
+		auto in = (ServerOP_GuildMessage_Struct *) pack->pBuffer;
+		zoneserver_list.SendPacketToZonesWithGuild(in->guild_id, pack);
 		break;
 	}
-    case ServerOP_GuildMemberAdd: 
+    case ServerOP_GuildMemberAdd:
 	{
         auto in    = (ServerOP_GuildMessage_Struct *)pack->pBuffer;
         auto guild = GetGuildByGuildID(in->guild_id);
@@ -244,7 +245,7 @@ void WorldGuildManager::ProcessZonePacket(ServerPacket *pack) {
             BaseGuildManager::RefreshGuild(in->guild_id);
         }
 
-        zoneserver_list.SendPacketToBootedZones(pack);
+        zoneserver_list.SendPacketToZonesWithGuild(in->guild_id, pack);
         break;
     }
 	default:
@@ -451,6 +452,6 @@ void WorldGuildManager::SendGuildTributeFavorAndTimer(uint32 guild_id, uint32 fa
 	data->tribute_timer = time;
 	data->trophy_timer  = 0;
 
-	zoneserver_list.SendPacketToBootedZones(sp);
+	zoneserver_list.SendPacketToZonesWithGuild(guild_id, sp);
 	safe_delete(sp)
 }

--- a/world/zonelist.cpp
+++ b/world/zonelist.cpp
@@ -36,11 +36,13 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include "shared_task_manager.h"
 #include "dynamic_zone_manager.h"
 #include "ucs.h"
+#include "clientlist.h"
 
 extern uint32 numzones;
 extern EQ::Random emu_random;
 extern WebInterfaceList web_interface;
 extern SharedTaskManager shared_task_manager;
+extern ClientList client_list;
 volatile bool UCSServerAvailable_ = false;
 void CatchSignal(int sig_num);
 
@@ -865,6 +867,20 @@ bool ZSList::SendPacketToBootedZones(ServerPacket* pack)
 		auto r = z.get();
 		if (r && r->GetZoneID() > 0) {
 			r->SendPacket(pack);
+		}
+	}
+
+	return true;
+}
+
+bool ZSList::SendPacketToZonesWithGuild(uint32 guild_id, ServerPacket* pack)
+{
+	auto servers = client_list.GetGuildZoneServers(guild_id);
+	for (auto const& z : zone_server_list) {
+		for (auto const& server_id : servers) {
+			if (z->GetID() == server_id && z->GetZoneID() > 0) {
+				z->SendPacket(pack);
+			}
 		}
 	}
 

--- a/world/zonelist.h
+++ b/world/zonelist.h
@@ -29,6 +29,7 @@ public:
 	bool SendPacket(ServerPacket *pack);
 	bool SendPacket(uint32 zoneid, ServerPacket *pack);
 	bool SendPacket(uint32 zoneid, uint16 instanceid, ServerPacket *pack);
+	bool SendPacketToZonesWithGuild(uint32 guild_id, ServerPacket *pack);
 	bool SendPacketToBootedZones(ServerPacket* pack);
 	bool SetLockedZone(uint16 iZoneID, bool iLock);
 

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -1510,7 +1510,7 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 
 				guild->tribute.timer.Disable();
 
-				zoneserver_list.SendPacketToBootedZones(pack);
+				zoneserver_list.SendPacketToZonesWithGuild(data->guild_id, pack);
 			}
 			break;
 		}
@@ -1553,7 +1553,7 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 				guild_mgr.UpdateDbGuildFavor(data->guild_id, data->favor);
 				guild_mgr.UpdateDbTributeTimeRemaining(data->guild_id, data->time_remaining);
 
-				zoneserver_list.SendPacketToBootedZones(pack);
+				zoneserver_list.SendPacketToZonesWithGuild(data->guild_id, pack);
 			}
 			break;
 		}
@@ -1587,7 +1587,7 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 				data->time_remaining      = in->time_remaining;
 				strn0cpy(data->player_name, in->player_name, sizeof(data->player_name));
 
-				zoneserver_list.SendPacketToBootedZones(out);
+				zoneserver_list.SendPacketToZonesWithGuild(in->guild_id, out);
 				safe_delete(out);
 			}
 			break;
@@ -1610,7 +1610,7 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 				out->tribute_id_2_tier = guild->tribute.id_2_tier;
 				out->time_remaining    = guild_mgr.GetGuildTributeTimeRemaining(in->guild_id);
 
-				zoneserver_list.SendPacketToBootedZones(sp);
+				zoneserver_list.SendPacketToZonesWithGuild(in->guild_id, sp);
 				safe_delete(sp);
 			}
 
@@ -1630,7 +1630,7 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 				out->tribute_timer = guild_mgr.GetGuildTributeTimeRemaining(in->guild_id);
 				out->trophy_timer  = 0;
 
-				zoneserver_list.SendPacketToBootedZones(sp);
+				zoneserver_list.SendPacketToZonesWithGuild(in->guild_id, sp);
 				safe_delete(sp);
 			}
 
@@ -1654,7 +1654,7 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 				out->member_time    = in->member_time;
 				strn0cpy(out->player_name, in->player_name, sizeof(out->player_name));
 
-				zoneserver_list.SendPacketToBootedZones(sp);
+				zoneserver_list.SendPacketToZonesWithGuild(out->guild_id, sp);
 				safe_delete(sp)
 			}
 			break;

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -8149,7 +8149,7 @@ void Client::Handle_OP_GuildInvite(const EQApplicationPacket *app)
 	if (!invitee) {
 		Message(
 			Chat::Red,
-			"Prospective guild member %s must be in zone to preform guild operations on them.",
+			"Prospective guild member %s must be in zone to perform guild operations on them.",
 			gc->othername
 		);
 		return;

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -7980,7 +7980,7 @@ void Client::Handle_OP_GuildCreate(const EQApplicationPacket *app)
 	}
 
 	SetGuildID(new_guild_id);
-	SendGuildList();
+	UpdateWho();
 	guild_mgr.MemberAdd(new_guild_id, CharacterID(), GetLevel(), GetClass(), GUILD_LEADER, GetZoneID(), GetName());
 	guild_mgr.SendGuildRefresh(new_guild_id, true, true, true, true);
 	guild_mgr.SendToWorldSendGuildList();

--- a/zone/guild.cpp
+++ b/zone/guild.cpp
@@ -195,7 +195,7 @@ void Client::SendGuildList()
 
 	std::stringstream           ss;
 	cereal::BinaryOutputArchive ar(ss);
-	ar(guilds_list);
+	{ ar(guilds_list); }
 
 	uint32 packet_size = ss.str().length();
 


### PR DESCRIPTION
# Description

This is a performance adjustment for **World** where 3k players and 1,800 zoneservers showed strain on World. A grand majority of the CPU load (98%) this was shown to be TCP chatter (server to server).

I ran S<->S packet logging in world and found the following data. This change will be one of several found from these results. https://gist.github.com/Akkadius/12b57fadbbe21ea9a46b854c62cc3a65#file-world-s2s-1m-md

---

For this PR, this addresses a lot of places where we blast packets to all zoneservers regardless if the zone needs it or not. This is not free especially at the scale of THJ. World is absolutely getting crushed having to allocate memory to send packets to X zoneservers (in this case lets say 1,800) when only say a dozen care about the packet at all.

We need to be smarter about how we relay packets because it adds up tremendously

## Type of change

- [x] Optimization

# Testing

Tested basic guild updates, create guild, zoning, adding, deleting

I added debugging in my packet sending function which only grabs zone server's that have clients with the interested Guild ID attached.

```
Zone 1
Zone 2
Sending packet to zone server_id 1
Sending packet to zone server_id 2
Zone 1
Zone 2
Sending packet to zone server_id 1
Sending packet to zone server_id 2
```

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
