### PR TITLE
[Fix] Zone State Variables Load First

### DIFF
--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -355,7 +355,7 @@ inline void LoadNPCState(Zone *zone, NPC *n, ZoneStateSpawnsRepository::ZoneStat
 			n->Depop();
 		}
 	}
-	
+
 	n->SetPosition(s.x, s.y, s.z);
 	n->SetHeading(s.heading);
 	n->SetResumedFromZoneSuspend(true);
@@ -443,12 +443,16 @@ bool Zone::LoadZoneState(
 	zone->initgrids_timer.Trigger();
 	zone->Process();
 
+	// load zone variables first
 	for (auto &s: spawn_states) {
 		if (s.is_zone) {
 			LoadZoneVariables(zone, s.entity_variables);
-			continue;
+			break;
 		}
+	}
 
+	// spawn2
+	for (auto &s: spawn_states) {
 		if (s.spawngroup_id == 0 || s.is_corpse || s.is_zone) {
 			continue;
 		}


### PR DESCRIPTION
# Description

Fixes an issue where on state restore zone variables are not available first when scripts need them.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

No testing, yolo

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

