### PR TITLE
[Performance] Improve Character Select DB Performance

### DIFF
--- a/world/worlddb.h
+++ b/world/worlddb.h
@@ -20,6 +20,8 @@
 
 #include "../common/shareddb.h"
 #include "../common/eq_packet.h"
+#include "../common/repositories/inventory_repository.h"
+#include "../common/repositories/character_data_repository.h"
 
 struct PlayerProfile_Struct;
 struct CharCreate_Struct;
@@ -43,7 +45,11 @@ private:
 	void SetTitaniumDefaultStartZone(PlayerProfile_Struct* in_pp, CharCreate_Struct* in_cc);
 	void SetSoFDefaultStartZone(PlayerProfile_Struct* in_pp, CharCreate_Struct* in_cc);
 
-	bool GetCharSelInventory(uint32 account_id, char* name, EQ::InventoryProfile* inv);
+	bool GetCharSelInventory(
+		const std::vector<InventoryRepository::Inventory> &inventories,
+		const CharacterDataRepository::CharacterData &character,
+		EQ::InventoryProfile *inv
+	);
 };
 
 extern WorldDatabase database;


### PR DESCRIPTION
# Description

This is a performance adjustment for **World** where on THJ at 3,600 players and 2,000 zoneservers we observe more of the stress points of world. This cuts down on query volume dramatically.

When you have 12 characters, you can produce over 100 queries just by hitting character select. The same amount of queries get produced when you delete or create a character while in character select. Most of these queries are from queries inside of a loop. Instead, we bulk load as much as we can at once.

[Example](https://gist.github.com/Akkadius/34e0639c5f27871cee16b0355874d89d) of World queries before when someone would hit character select

**Bulk Loading**

* We fetch all character rows at once
* We fetch all inventory rows for all characters at once
* We fetch all binds for all characters at once
* We fetch all inventory material colors at once
* We no longer do an extra query to get character id by name since we already have it

## Type of change

- [x] Optimization

# Testing

* Character creation, character goes to the expected bind
* Character deletion, character gets soft deleted and shown as expected
* Character inventory shows as expected
* Character inventory material colors shows as expected

![image](https://github.com/user-attachments/assets/91752636-5ff0-45ee-8e25-de43da8f2c84)

![image](https://github.com/user-attachments/assets/c37a13c2-1f85-45d3-9fe6-6c2e8dba59b4)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

