### PR TITLE
[Crash] Fix Rarer World Crash with Player Event Thread Processor

### DIFF
--- a/queryserv/queryserv.cpp
+++ b/queryserv/queryserv.cpp
@@ -177,7 +177,7 @@ int main()
 		}
 
 		if (player_event_process_timer.Check()) {
-			std::jthread player_event_thread(&PlayerEventLogs::Process, &player_event_logs);
+			player_event_logs.Process();
 		}
 	};
 

--- a/world/main.cpp
+++ b/world/main.cpp
@@ -387,7 +387,9 @@ int main(int argc, char **argv)
 
 	auto event_log_processor = std::jthread([](const std::stop_token& stoken) {
 		while (!stoken.stop_requested()) {
-			player_event_logs.Process();
+			if (!RuleB(Logging, PlayerEventsQSProcess)) {
+				player_event_logs.Process();
+			}
 			std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 		}
 	});

--- a/world/main.cpp
+++ b/world/main.cpp
@@ -381,10 +381,16 @@ int main(int argc, char **argv)
 		}
 	);
 
-	Timer player_event_process_timer(1000);
 	if (player_event_logs.LoadDatabaseConnection()) {
 		player_event_logs.Init();
 	}
+
+	auto event_log_processor = std::jthread([](const std::stop_token& stoken) {
+		while (!stoken.stop_requested()) {
+			player_event_logs.Process();
+			std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+		}
+	});
 
 	auto loop_fn = [&](EQ::Timer* t) {
 		Timer::SetCurrentTime();
@@ -448,10 +454,6 @@ int main(int argc, char **argv)
 			}
 		}
 
-		if (player_event_process_timer.Check()) {
-			std::jthread event_thread(&PlayerEventLogs::Process, &player_event_logs);
-		}
-
 		if (PurgeInstanceTimer.Check()) {
 			database.PurgeExpiredInstances();
 			database.PurgeAllDeletedDataBuckets();
@@ -501,6 +503,8 @@ int main(int argc, char **argv)
 	process_timer.Start(32, true);
 
 	EQ::EventLoop::Get().Run();
+
+	event_log_processor.request_stop();
 
 	LogInfo("World main loop completed");
 	LogInfo("Shutting down zone connections (if any)");


### PR DESCRIPTION
# Description

This should fix a rarer crash in the player event thread processor. Needs to be tested and verified

```
03-22-2025 22:53:27 | World | Crash | [New LWP 765275]
03-22-2025 22:53:27 | World | Crash | [New LWP 765276]
03-22-2025 22:53:27 | World | Crash | [New LWP 765277]
03-22-2025 22:53:27 | World | Crash | [New LWP 765278]
03-22-2025 22:53:27 | World | Crash | [New LWP 786056]
03-22-2025 22:53:27 | World | Crash | [Thread debugging using libthread_db enabled]
03-22-2025 22:53:27 | World | Crash | Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
03-22-2025 22:53:27 | World | Crash | __futex_abstimed_wait_common64 (private=128, cancel=true, abstime=0x0, op=265, expected=786056, futex_word=0x7fc48885d990) at ./nptl/futex-internal.c:57
03-22-2025 22:53:27 | World | Crash | [Current thread is 1 (Thread 0x7fc48a9c0ec0 (LWP 765255))]
03-22-2025 22:53:27 | World | Crash | #0  __futex_abstimed_wait_common64 (private=128, cancel=true, abstime=0x0, op=265, expected=786056, futex_word=0x7fc48885d990) at ./nptl/futex-internal.c:57
03-22-2025 22:53:27 | World | Crash | #1  __futex_abstimed_wait_common (futex_word=futex_word@entry=0x7fc48885d990, expected=786056, clockid=clockid@entry=0, abstime=abstime@entry=0x0, private=private@entry=128, cancel=cancel@entry=true) at ./nptl/futex-internal.c:87
03-22-2025 22:53:27 | World | Crash | #2  0x00007fc48aa86efb in __GI___futex_abstimed_wait_cancelable64 (futex_word=futex_word@entry=0x7fc48885d990, expected=, clockid=clockid@entry=0, abstime=abstime@entry=0x0, private=private@entry=128) at ./nptl/futex-internal.c:139
03-22-2025 22:53:27 | World | Crash | #3  0x00007fc48aa8bc23 in __pthread_clockjoin_ex (threadid=140482080790208, thread_return=0x0, clockid=0, abstime=0x0, block=) at ./nptl/pthread_join_common.c:102
03-22-2025 22:53:27 | World | Crash | #4  0x00005602db8c99b7 in std::thread::join() ()
03-22-2025 22:53:27 | World | Crash | #5  0x00005602db19f5f8 in std::jthread::join (this=0x7fff40665070) at /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/thread:170
03-22-2025 22:53:27 | World | Crash | #6  std::jthread::~jthread (this=this@entry=0x7fff40665070) at /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/thread:140
03-22-2025 22:53:27 | World | Crash | #7  0x00005602db19dc75 in main::$_11::operator() (this=0x5602dda3f3f0, t=) at /drone/src/world/main.cpp:453
03-22-2025 22:53:27 | World | Crash | #8  std::__invoke_impl (__f=..., __args=) at /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/invoke.h:61
03-22-2025 22:53:27 | World | Crash | #9  std::__invoke_r (__fn=..., __args=) at /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/invoke.h:111
03-22-2025 22:53:27 | World | Crash | #10 std::_Function_handler::_M_invoke(std::_Any_data const&, EQ::Timer*&&) (__functor=..., __args=) at /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/std_function.h:290
03-22-2025 22:53:27 | World | Crash | #11 0x00005602db168709 in std::function::operator()(EQ::Timer*) const (this=0xfffffffffffffe08, __args=0x7fff40665480) at /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/std_function.h:591
03-22-2025 22:53:27 | World | Crash | #12 EQ::Timer::Execute (this=0xfffffffffffffe00) at /drone/src/world/../common/net/../event/timer.h:61
03-22-2025 22:53:27 | World | Crash | #13 EQ::Timer::Start(unsigned long, bool)::{lambda(uv_timer_s*)#1}::operator()(uv_timer_s*) const (handle=, this=) at /drone/src/world/../common/net/../event/timer.h:38
03-22-2025 22:53:27 | World | Crash | #14 EQ::Timer::Start(unsigned long, bool)::{lambda(uv_timer_s*)#1}::__invoke(uv_timer_s*) (handle=) at /drone/src/world/../common/net/../event/timer.h:36
03-22-2025 22:53:27 | World | Crash | #15 0x00005602db59c5a6 in uv__run_timers (loop=loop@entry=0x7fc48a9bf7a0) at /drone/src/submodules/libuv/src/timer.c:178
03-22-2025 22:53:27 | World | Crash | #16 0x00005602db59ea15 in uv_run (loop=0x7fc48a9bf7a0, mode=UV_RUN_DEFAULT) at /drone/src/submodules/libuv/src/unix/core.c:393
03-22-2025 22:53:27 | World | Crash | #17 0x00005602db1992cc in EQ::EventLoop::Run (this=0xfffffffffffffe00) at /drone/src/world/../common/event/event_loop.h:25
03-22-2025 22:53:27 | World | Crash | #18 main (argc=, argv=) at /drone/src/world/main.cpp:503
03-22-2025 22:53:27 | World | Crash | [Inferior 1 (process 765255) detached]
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

No testing, unable to reproduce.

Tested that events ingest properly as expected in World.

```
 World | PlayerEven | ProcessBatchQueue Processing batch player event log queue of [14] took [0.013965053] 
```

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

