### PR TITLE
[Fix] Fix Instance Creation Race Condition

### DIFF
--- a/common/database.h
+++ b/common/database.h
@@ -141,6 +141,7 @@ public:
 	bool CheckInstanceExpired(uint16 instance_id);
 	bool CreateInstance(uint16 instance_id, uint32 zone_id, uint32 version, uint32 duration);
 	bool GetUnusedInstanceID(uint16& instance_id);
+	bool TryGetUnusedInstanceID(uint16& instance_id);
 	bool IsGlobalInstance(uint16 instance_id);
 	bool RemoveClientFromInstance(uint16 instance_id, uint32 char_id);
 	bool RemoveClientsFromInstance(uint16 instance_id);

--- a/common/database_instances.cpp
+++ b/common/database_instances.cpp
@@ -151,6 +151,7 @@ bool Database::GetUnusedInstanceID(uint16 &instance_id)
 		}
 	}
 
+	instance_id = 0;
 	return false;
 }
 

--- a/common/database_instances.cpp
+++ b/common/database_instances.cpp
@@ -137,9 +137,17 @@ bool Database::CreateInstance(uint16 instance_id, uint32 zone_id, uint32 version
 bool Database::GetUnusedInstanceID(uint16 &instance_id)
 {
 	// attempt to get an unused instance id
-	for (int i = 0; i < 10; i++) {
-		if (TryGetUnusedInstanceID(instance_id)) {
-			return true;
+	for (int a = 0; a < 10; a++) {
+		uint16 attempted_id = 0;
+		if (TryGetUnusedInstanceID(attempted_id)) {
+			auto i = InstanceListRepository::NewEntity();
+			i.id    = attempted_id;
+			i.notes = "Prefetching";
+			auto n = InstanceListRepository::InsertOne(database, i);
+			if (n.id > 0) {
+				instance_id = n.id;
+				return true;
+			}
 		}
 	}
 

--- a/common/database_instances.cpp
+++ b/common/database_instances.cpp
@@ -143,7 +143,7 @@ bool Database::GetUnusedInstanceID(uint16 &instance_id)
 			auto i = InstanceListRepository::NewEntity();
 			i.id    = attempted_id;
 			i.notes = "Prefetching";
-			auto n = InstanceListRepository::InsertOne(database, i);
+			auto n = InstanceListRepository::InsertOne(*this, i);
 			if (n.id > 0) {
 				instance_id = n.id;
 				return true;

--- a/common/database_instances.cpp
+++ b/common/database_instances.cpp
@@ -131,7 +131,7 @@ bool Database::CreateInstance(uint16 instance_id, uint32 zone_id, uint32 version
 
 	RespawnTimesRepository::ClearInstanceTimers(*this, e.id);
 	InstanceListRepository::ReplaceOne(*this, e);
-	return e.id;
+	return instance_id > 0 && e.id;
 }
 
 bool Database::GetUnusedInstanceID(uint16 &instance_id)

--- a/common/database_instances.cpp
+++ b/common/database_instances.cpp
@@ -130,123 +130,94 @@ bool Database::CreateInstance(uint16 instance_id, uint32 zone_id, uint32 version
 	e.duration = duration;
 
 	RespawnTimesRepository::ClearInstanceTimers(*this, e.id);
-
-	return InstanceListRepository::InsertOne(*this, e).id;
+	InstanceListRepository::ReplaceOne(*this, e);
+	return e.id;
 }
 
 bool Database::GetUnusedInstanceID(uint16 &instance_id)
 {
-	uint32 max_reserved_instance_id = RuleI(Instances, ReservedInstances);
-	uint32 max_instance_id          = 32000;
+	const uint32 max_reserved_instance_id = RuleI(Instances, ReservedInstances);
+	const uint32 max_instance_id = 32000;
 
-	// sanity check reserved
 	if (max_reserved_instance_id >= max_instance_id) {
 		instance_id = 0;
 		return false;
 	}
 
-	// recycle instances
-	if (RuleB(Instances, RecycleInstanceIds)) {
+	for (int attempt = 0; attempt < 10; ++attempt) {
+		uint32 proposed_id = 0;
 
-		//query to get first unused id above reserved
-		auto query = fmt::format(
-			SQL(
-				SELECT id
-				FROM instance_list
-				WHERE id = {};
-			),
-			max_reserved_instance_id + 1
-		);
+		if (RuleB(Instances, RecycleInstanceIds)) {
+			// Try to find a gap in used IDs
+			auto query = fmt::format(
+				SQL(
+					SELECT MIN(i.id + 1) AS next_available
+					FROM instance_list i
+					LEFT JOIN instance_list i2 ON i.id + 1 = i2.id
+					WHERE i.id >= {}
+					AND i2.id IS NULL;
+				),
+				max_reserved_instance_id
+			);
 
-		auto results = QueryDatabase(query);
+			auto results = QueryDatabase(query);
 
-		// could not successfully query - bail out
-		if (!results.Success()) {
-			instance_id = 0;
-			return false;
+			if (!results.Success() || results.RowCount() == 0) {
+				continue; // try again
+			}
+
+			auto row = results.begin();
+			if (!row[0]) {
+				continue; // no result, try again
+			}
+
+			proposed_id = Strings::ToInt(row[0]);
+		}
+		else {
+			// Get next max available ID
+			auto query = fmt::format(
+				"SELECT IFNULL(MAX(id), {}) + 1 FROM instance_list WHERE id > {}",
+				max_reserved_instance_id,
+				max_reserved_instance_id
+			);
+
+			auto results = QueryDatabase(query);
+
+			if (!results.Success() || results.RowCount() == 0) {
+				continue; // try again
+			}
+
+			auto row = results.begin();
+			if (!row[0]) {
+				proposed_id = max_reserved_instance_id + 1;
+			} else {
+				proposed_id = Strings::ToInt(row[0]);
+			}
 		}
 
-		// first id is available
-		if (results.RowCount() == 0) {
-			instance_id = max_reserved_instance_id + 1;
+		if (proposed_id <= max_reserved_instance_id || proposed_id > max_instance_id) {
+			continue; // try again
+		}
+
+		// Try to reserve the ID
+		auto e = InstanceListRepository::NewEntity();
+		e.id         = proposed_id;
+		e.zone       = 0; // placeholder values
+		e.version    = 0;
+		e.start_time = std::time(nullptr);
+		e.duration   = 1;
+
+		auto inserted = InstanceListRepository::InsertOne(*this, e);
+
+		if (inserted.id != 0) {
+			instance_id = inserted.id;
 			return true;
 		}
 
-		// now look for next available above reserved
-		query = fmt::format(
-			SQL(
-				SELECT MIN(i.id + 1) AS next_available
-				FROM instance_list i
-				LEFT JOIN instance_list i2 ON i.id + 1 = i2.id
-				WHERE i.id >= {}
-				AND i2.id IS NULL;
-			),
-			max_reserved_instance_id
-		);
-
-		results = QueryDatabase(query);
-
-		// could not successfully query - bail out
-		if (!results.Success()) {
-			instance_id = 0;
-			return false;
-		}
-
-		// did not retrieve any rows - bail out
-		if (results.RowCount() == 0) {
-			instance_id = 0;
-			return false;
-		}
-
-		auto row = results.begin();
-
-		// check that id is within limits
-		if (row[0] && Strings::ToInt(row[0]) <= max_instance_id) {
-			instance_id = Strings::ToInt(row[0]);
-			return true;
-		}
-
-		// no available instance ids
-		instance_id = 0;
-		return false;
+		// Insert failed (likely race), try again
 	}
 
-	// get max unused id above reserved
-	auto query = fmt::format(
-		"SELECT IFNULL(MAX(id), {}) + 1 FROM instance_list WHERE id > {}",
-		max_reserved_instance_id,
-		max_reserved_instance_id
-	);
-
-	auto results = QueryDatabase(query);
-
-	// could not successfully query - bail out
-	if (!results.Success()) {
-		instance_id = 0;
-		return false;
-	}
-
-	// did not retrieve any rows - bail out
-	if (results.RowCount() == 0) {
-		instance_id = 0;
-		return false;
-	}
-
-	auto row = results.begin();
-
-	// no instances currently used
-	if (!row[0]) {
-		instance_id = max_reserved_instance_id + 1;
-		return true;
-	}
-
-	// check that id is within limits
-	if (Strings::ToInt(row[0]) <= max_instance_id) {
-		instance_id = Strings::ToInt(row[0]);
-		return true;
-	}
-
-	// no available instance ids
+	// All attempts failed
 	instance_id = 0;
 	return false;
 }


### PR DESCRIPTION
# Description

This fixes a rarer race condition on larger servers where many zone processes can fight and race for the same instance id during creation. It can happen quite often depending on instance creation volume.

This PR modifies instance creation to first make sure we can insert a blank row reserving the row and ID first with a placeholder before returning out and passing it to **CreateInstance** which will actually write the zone_id / instance_id / expiration details afterwards.

**Example Error**

```
[QueryErr] Zone [hohonorb] MySQL Error (1062) [Duplicate entry '4248' for key 'PRIMARY'] Query [INSERT INTO instance_list (id, zone, version, is_global, start_time, duration, never_expires, notes)  VALUES (4248,220,255,0,1742758058,604800,0,'')]
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Tested with a GM instance **#gmzone halas 0** 

![image](https://github.com/user-attachments/assets/e3ea7670-6799-4bd2-9d92-9f04eb52bca7)

Query trace of what occurs now

```
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 0 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = 'halas-ffffff-0-instance' LIMIT 1 -- (0 rows returned) (0.000355s)-- [halas] (Halas) inst_id [116]
  Zone |   Query    | QueryDatabase SELECT id FROM instance_list WHERE id = 101; -- (1 row returned) (0.000272s)-- [halas] (Halas) inst_id [116]
  Zone |   Query    | QueryDatabase SELECT MIN(i.id + 1) AS next_available FROM instance_list i LEFT JOIN instance_list i2 ON i.id + 1 = i2.id WHERE i.id >= 100 AND i2.id IS NULL; -- (1 row returned) (0.000340s)-- [halas] (Halas) inst_id [116]
  Zone |   Query    | QueryDatabase INSERT INTO instance_list (id, zone, version, is_global, start_time, duration, never_expires, notes)  VALUES (117,0,0,0,0,0,0,'Prefetching') -- (1 row affected) (0.011106s)-- [halas] (Halas) inst_id [116]
  Zone |   Query    | QueryDatabase REPLACE INTO instance_list (id, zone, version, is_global, start_time, duration, never_expires, notes)  VALUES (117,29,0,0,1743280369,100000000,0,'') -- (2 rows affected) (0.002079s)-- [halas] (Halas) inst_id [116]
  Zone |   Query    | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE  character_id = 0 AND account_id = 0 AND npc_id = 0 AND bot_id = 0 AND zone_id = 0 AND instance_id = 0 AND `key` = 'halas-ffffff-0-instance' LIMIT 1 -- (0 rows returned) (0.000060s)-- [halas] (Halas) inst_id [116]
  Zone |   Query    | QueryDatabase INSERT INTO data_buckets (id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id)  VALUES (0,'halas-ffffff-0-instance','117',0,0,0,0,0,0,0) -- (1 row affected) (0.003343s)-- [halas] (Halas) inst_id [116]
```

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

