### PR TITLE
[Bugfix] Shutdown zone instances when they are purged from instance_list.

### DIFF
--- a/common/database.h
+++ b/common/database.h
@@ -159,7 +159,7 @@ public:
 	void FlagInstanceByGroupLeader(uint32 zone_id, int16 version, uint32 character_id, uint32 group_id);
 	void FlagInstanceByRaidLeader(uint32 zone_id, int16 version, uint32 character_id, uint32 raid_id);
 	void GetCharactersInInstance(uint16 instance_id, std::list<uint32>& character_ids);
-	void PurgeExpiredInstances();
+	std::vector<int32_t> PurgeExpiredInstances();
 	void SetInstanceDuration(uint16 instance_id, uint32 new_duration);
 	void CleanupInstanceCorpses();
 

--- a/world/main.cpp
+++ b/world/main.cpp
@@ -453,7 +453,14 @@ int main(int argc, char **argv)
 		}
 
 		if (PurgeInstanceTimer.Check()) {
-			database.PurgeExpiredInstances();
+			std::vector<int32_t> purged = database.PurgeExpiredInstances();
+			for(int32_t instance_id : purged) {
+				ZoneServer *zs = zoneserver_list.FindByInstanceID(instance_id);
+				if (zs != 0) {
+					zs->Shutdown("instance_purge");
+				}
+			}
+
 			database.PurgeAllDeletedDataBuckets();
 			CharacterExpeditionLockoutsRepository::DeleteWhere(database, "expire_time <= NOW()");
 			CharacterTaskTimersRepository::DeleteWhere(database, "expire_time <= NOW()");

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -1830,6 +1830,26 @@ void ZoneServer::TriggerBootup(uint32 in_zone_id, uint32 in_instance_id, const c
 	LSBootUpdate(in_zone_id, in_instance_id);
 }
 
+void ZoneServer::Shutdown(const char* reason) {
+	auto pack = new ServerPacket;
+	pack->opcode  = ServerOP_ZoneShutdown;
+	pack->size    = sizeof(ServerZoneStateChange_Struct);
+	pack->pBuffer = new uchar[pack->size];
+	memset(pack->pBuffer, 0, sizeof(ServerZoneStateChange_Struct));
+
+	auto *s = (ServerZoneStateChange_Struct *) pack->pBuffer;
+	s->zone_id     = GetZoneID();
+	s->instance_id = GetInstanceID();
+
+	if (reason) {
+		strn0cpy(s->admin_name, reason, sizeof(s->admin_name));
+	}
+
+	SendPacket(pack);
+
+	delete pack;
+}
+
 void ZoneServer::IncomingClient(Client* client) {
 	is_booting_up = true;
 	auto pack = new ServerPacket(ServerOP_ZoneIncClient, sizeof(ServerZoneIncomingClient_Struct));

--- a/world/zoneserver.h
+++ b/world/zoneserver.h
@@ -43,6 +43,7 @@ public:
 	bool		SetZone(uint32 in_zone_id, uint32 in_instance_id = 0, bool in_is_static_zone = false);
 	void		TriggerBootup(uint32 in_zone_id = 0, uint32 in_instance_id = 0, const char* admin_name = 0, bool is_static_zone = false);
 	void		Disconnect() { auto handle = tcpc->Handle(); if (handle) { handle->Disconnect(); } }
+	void            Shutdown(const char* reason = 0);
 	void		IncomingClient(Client* client);
 	void		LSBootUpdate(uint32 zone_id, uint32 instance_id = 0, bool startup = false);
 	void		LSSleepUpdate(uint32 zone_id);


### PR DESCRIPTION
This may be more of a conversation starter than an actual solution.  Not entirely convinced this is the best approach (nor am I certain I did it right).

# Description

A change was made downstream that removed the 24 hour buffer on purging old instances from the instance_list table.  This combined with other settings like DynamicZone:EmptyShutdownDelaySeconds and the zone shutdown delay value can result in a scenario where the instance is purged from instance_list while the zone process is still running.

When this happens if a player were to then start a new instance and get that same instance id and attempt to zone in they will be connected to that existing process.  This may result in odd behaviors like zoning into the wrong zone, or the zone they zone into is in an odd state.

HOWEVER

There's a lot of factors that goes into this that really restricts the chances for this to happen.  As long as the current EQEmu source retains the 24 hour buffer in common/database_instances.cpp this problem effectively doesnt exist by default unless someone tweaks zone shutdown delays to some value > 24 hours.  Secondly, the calculation for purging the instance ids is:

start time + EmptyShutdownDelaySeconds + time player spent in dz + 24 hours (or 0 if on THJ).

So the issue can be further mitigated through things like increasing the EmptyShutdownDelaySeconds or by ensuring zone shutdown delays are below that value or by the fact the players will likely spend 10+ mins in an instance on average.

The only reason I even noticed this was because I had EmptyShutdownDelaySeconds set to 1 from testing zone-state saving and my zone shutdown delays are still quite high from the default PEQ database snapshot.

# Testing

akk-stack + RoF2 client

Test Steps
- Spun up DZ
- Zoned in
- Left
- Quit DZ

Reproduction
- Wait for instance to drop from instance_list, observe that the zone process is still running according to spire.
- Request a new DZ, preferrably for a different zone than the first
- Observe that zoning into the new DZ takes you to the old zone and not the one you requested.

Fixed
- Wait for instance to drop from instance_list, observe that the zone process immediately disappears with it

![image](https://github.com/user-attachments/assets/229e8fa9-9c1e-43fb-8c67-857f566dcc79)

# Concerns

My outstanding concerns is that at scale on something like THJ there would still be a large enough window for players to end up trying to connect to that zone process that is in the process of shutting down.  I'm not sure what the resulting behavior will be in that case as its a bit hard to test.