### PR TITLE
[Cleanup] Remove Extraneous Time Type in ShowZoneData

### DIFF
--- a/zone/gm_commands/show/zone_data.cpp
+++ b/zone/gm_commands/show/zone_data.cpp
@@ -82,11 +82,6 @@ void ShowZoneData(Client *c, const Seperator *sep)
 	);
 
 	popup_table += DialogueWindow::TableRow(
-		DialogueWindow::TableCell("Time Type") +
-		DialogueWindow::TableCell(std::to_string(zone->newzone_data.time_type))
-	);
-
-	popup_table += DialogueWindow::TableRow(
 		DialogueWindow::TableCell("Experience Multiplier") +
 		DialogueWindow::TableCell(
 			fmt::format(


### PR DESCRIPTION
# Description
- Removes extra Time Type listing, no testing needed.
