### PR TITLE
[Fix] AllowFVNoDrop Flag trades

### DIFF
--- a/common/item_instance.cpp
+++ b/common/item_instance.cpp
@@ -906,24 +906,32 @@ bool EQ::ItemInstance::IsSlotAllowed(int16 slot_id) const {
 
 bool EQ::ItemInstance::IsDroppable(bool recurse) const
 {
-	if (!m_item)
+	if (!m_item) {
 		return false;
+	}
 	/*if (m_ornamentidfile) // not implemented
 		return false;*/
-	if (m_attuned)
+	if (m_attuned) {
 		return false;
-	/*if (m_item->FVNoDrop != 0) // not implemented
-		return false;*/
-	if (m_item->NoDrop == 0)
+	}
+
+	if (RuleI(World, FVNoDropFlag) == FVNoDropFlagRule::Enabled && m_item->FVNoDrop == 0) {
+		return true;
+	}
+
+	if (m_item->NoDrop == 0) {
 		return false;
+	}
 
 	if (recurse) {
-		for (auto iter : m_contents) {
-			if (!iter.second)
+		for (auto iter: m_contents) {
+			if (!iter.second) {
 				continue;
+			}
 
-			if (!iter.second->IsDroppable(recurse))
+			if (!iter.second->IsDroppable(recurse)) {
 				return false;
+			}
 		}
 	}
 


### PR DESCRIPTION
# Description
It was reported that when the rule FVNoDrop was true, direct player to player trades would result in a cancellation and a message indicating "Hacking activity detected in trade transaction."
https://discordapp.com/channels/212663220849213441/1353885055956680754

This was reproduceable by enabling the flag, then trying to trade a normally no drop item, though tradeable FV flag. (item id = 5112).

The fix is behind the rule, so should not impact none FVNoDrop functionality.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
Tested with item id 5112.  With FVNoDrop rule true, before this item would not complete a trade.  Post, the trade worked as expected.

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
