### PR TITLE
[Performance] Add several database indexes

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -7056,7 +7056,6 @@ ALTER TABLE character_tribute ADD INDEX idx_character_id (character_id);
 )",
 		.content_schema_update = false
 	},
-
 	ManifestEntry{
 		.version = 9320,
 		.description = "2025_03_29_data_buckets_expires_index.sql",

--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -6914,7 +6914,7 @@ CREATE TABLE `zone_state_spawns` (
 	},
 	ManifestEntry{
 		.version = 9308,
-		.description = "2025_add_multivalue_support_to_evolving_subtype.sql",
+		.description = "2025_03_29_add_multivalue_support_to_evolving_subtype.sql",
 		.check = "SHOW COLUMNS FROM `items_evolving_details` LIKE 'sub_type'",
 		.condition = "missing",
 		.match = "varchar(200)",
@@ -6986,7 +6986,6 @@ ALTER TABLE data_buckets ADD INDEX idx_bot_expires (bot_id, expires);
 		.match = "idx_zone_instance",
 		.sql = R"(
 ALTER TABLE zone_state_spawns ADD INDEX idx_zone_instance (zone_id, instance_id);
-ALTER TABLE zone_state_spawns ADD INDEX idx_instance_id (instance_id);
 )",
 	.content_schema_update = false
 	},

--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -7001,6 +7001,74 @@ TRUNCATE TABLE zone_state_spawns;
 )",
 		.content_schema_update = false
 	},
+	ManifestEntry{
+		.version = 9315,
+		.description = "2025_03_29_character_tribute_index.sql",
+		.check = "SHOW INDEX FROM character_tribute",
+		.condition = "missing",
+		.match = "idx_character_id",
+		.sql = R"(
+ALTER TABLE character_tribute ADD INDEX idx_character_id (character_id);
+)",
+		.content_schema_update = false
+	},
+	ManifestEntry{
+		.version = 9316,
+		.description = "2025_03_29_player_titlesets_index.sql",
+		.check = "SHOW INDEX FROM player_titlesets",
+		.condition = "missing",
+		.match = "idx_char_id",
+		.sql = R"(
+ALTER TABLE player_titlesets ADD INDEX idx_char_id (char_id);
+)",
+		.content_schema_update = false
+	},
+	ManifestEntry{
+		.version = 9317,
+		.description = "2025_03_29_respawn_times_instance_index.sql",
+		.check = "SHOW INDEX FROM respawn_times",
+		.condition = "missing",
+		.match = "idx_instance_id",
+		.sql = R"(
+ALTER TABLE respawn_times ADD INDEX idx_instance_id (instance_id);
+)",
+		.content_schema_update = false
+	},
+	ManifestEntry{
+		.version = 9318,
+		.description = "2025_03_29_zone_state_spawns_instance_index.sql",
+		.check = "SHOW INDEX FROM zone_state_spawns",
+		.condition = "missing",
+		.match = "idx_instance_id",
+		.sql = R"(
+ALTER TABLE zone_state_spawns ADD INDEX idx_instance_id (instance_id);
+)",
+		.content_schema_update = false
+	},
+	ManifestEntry{
+		.version = 9319,
+		.description = "2025_03_29_character_tribute_character_id_index.sql",
+		.check = "SHOW INDEX FROM character_tribute",
+		.condition = "missing",
+		.match = "idx_character_id",
+		.sql = R"(
+ALTER TABLE character_tribute ADD INDEX idx_character_id (character_id);
+)",
+		.content_schema_update = false
+	},
+
+	ManifestEntry{
+		.version = 9320,
+		.description = "2025_03_29_data_buckets_expires_index.sql",
+		.check = "SHOW INDEX FROM data_buckets",
+		.condition = "missing",
+		.match = "idx_expires",
+		.sql = R"(
+CREATE INDEX idx_expires ON data_buckets (expires);
+)",
+		.content_schema_update = false
+	},
+
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{
 //		.version = 9228,

--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -6792,7 +6792,7 @@ UPDATE `character_corpse_items` SET `equip_slot` = ((`equip_slot` - 341) + 5810)
 	},
 	ManifestEntry{
 		.version     = 9304,
-		.description = "2024_12_01_2024_update_guild_bank",
+		.description = "2024_12_01_update_guild_bank",
 		.check       = "SHOW COLUMNS FROM `guild_bank` LIKE 'augment_one_id'",
 		.condition   = "empty",
 		.match       = "",
@@ -7046,17 +7046,6 @@ ALTER TABLE zone_state_spawns ADD INDEX idx_instance_id (instance_id);
 	},
 	ManifestEntry{
 		.version = 9319,
-		.description = "2025_03_29_character_tribute_character_id_index.sql",
-		.check = "SHOW INDEX FROM character_tribute",
-		.condition = "missing",
-		.match = "idx_character_id",
-		.sql = R"(
-ALTER TABLE character_tribute ADD INDEX idx_character_id (character_id);
-)",
-		.content_schema_update = false
-	},
-	ManifestEntry{
-		.version = 9320,
 		.description = "2025_03_29_data_buckets_expires_index.sql",
 		.check = "SHOW INDEX FROM data_buckets",
 		.condition = "missing",

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9314
+#define CURRENT_BINARY_DATABASE_VERSION 9320
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9054
 
 #endif

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9320
+#define CURRENT_BINARY_DATABASE_VERSION 9319
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9054
 
 #endif


### PR DESCRIPTION
# Description

These indexes are the result of monitoring THJ at 4,200 players / 2k zoneservers and finding table / database contention or slow queries in various places.

These database manifest entries will add the indexes if you don't have them already.

## Type of change

- [x] Performance

# Testing

```
 World |    Info    | CheckVersionsUpToDate ---------------------------------------------------------------------- 
 World |    Info    | CheckVersionsUpToDate   Server | database [9315] binary [9320] checking updates 
 World |    Info    | CheckVersionsUpToDate   Config | [server.auto_database_updates] [true] 
 World |    Info    | CheckVersionsUpToDate ---------------------------------------------------------------------- 
 World |    Info    | UpdateManifest [9316]  [missing] | [2025_03_29_player_titlesets_index.sql] 
 World |    Info    | UpdateManifest [9317]  [missing] | [2025_03_29_respawn_times_instance_index.sql] 
 World |    Info    | UpdateManifest [9318]       [ok] | [2025_03_29_zone_state_spawns_instance_index.sql] 
 World |    Info    | UpdateManifest [9319]  [missing] | [2025_03_29_character_tribute_character_id_index.sql] 
 World |    Info    | UpdateManifest [9320]  [missing] | [2025_03_29_data_buckets_expires_index.sql] 
 World |    Info    | UpdateManifest ---------------------------------------------------------------------- 
 World |    Info    | UpdateManifest Automatically backing up database before applying updates 
 World |    Info    | UpdateManifest ---------------------------------------------------------------------- 
 World |    Info    | DatabaseDump MySQL installed [mysql  Ver 15.1 Distrib 10.11.6-MariaDB, for debian-linux-gnu (x86_64) using  EditLine wrapper] 
 World |    Info    | DatabaseDump Database [peq] Host [mariadb] Username [eqemu] 
 World |    Info    | DatabaseDump Backing up database [mysqldump --defaults-extra-file=login.my.cnf peq --allow-keywords --extended-insert --max-allowed-packet=1G --net-buffer-length=32704 --skip-lock-tables   > backups/peq-2025-03-29.sql] 
 World |    Info    | DatabaseDump This can take a few minutes depending on the size of your database 
 World |    Info    | DatabaseDump LOADING... PLEASE WAIT... 
 Login |   Debug    | ProcessLSStatus World Server Status Update Received | Server [|T| Akkas Test Bed (LDL)] Status [0] Players [0] Zones [4] 
 World |    Info    | DatabaseDump Database dump created at [backups/peq-2025-03-29.sql] 
 World |    Info    | DatabaseDump Compression requested. Compressing dump [backups/peq-2025-03-29.sql] 
 Login |   Debug    | ProcessLSStatus World Server Status Update Received | Server [|T| Akkas Test Bed (LDL)] Status [0] Players [0] Zones [4] 
 World |    Info    | DatabaseDump Compressed dump created at [backups/peq-2025-03-29.tar.gz] 
 World |    Info    | UpdateManifest ---------------------------------------------------------------------- 
 World |    Info    | UpdateManifest Running database migrations. Please wait... 
 World |    Info    | UpdateManifest ---------------------------------------------------------------------- 
 World |    Info    | UpdateManifest [9316] [2025_03_29_player_titlesets_index.sql] [ok] 
 World |    Info    | UpdateManifest [9317] [2025_03_29_respawn_times_instance_index.sql] [ok] 
 World |    Info    | UpdateManifest [9319] [2025_03_29_character_tribute_character_id_index.sql] [ok] 
 World |    Info    | UpdateManifest [9320] [2025_03_29_data_buckets_expires_index.sql] [ok] 
 World |    Info    | UpdateManifest ---------------------------------------------------------------------- 
 World |    Info    | CheckDbUpdates Updates ran successfully, setting database version to [9320] from [9315] 
```

After setting the version back, after running updates, everything comes back "Ok"

```
eqemu@ct-eqemu-server:~/server$ ./bin/world database:updates
 World |    Info    | CheckVersionsUpToDate ---------------------------------------------------------------------- 
 World |    Info    | CheckVersionsUpToDate   Server | database [9314] binary [9320] checking updates 
 World |    Info    | CheckVersionsUpToDate   Config | [server.auto_database_updates] [true] 
 World |    Info    | CheckVersionsUpToDate ---------------------------------------------------------------------- 
 World |    Info    | UpdateManifest [9315]       [ok] | [2025_03_29_character_tribute_index.sql] 
 World |    Info    | UpdateManifest [9316]       [ok] | [2025_03_29_player_titlesets_index.sql] 
 World |    Info    | UpdateManifest [9317]       [ok] | [2025_03_29_respawn_times_instance_index.sql] 
 World |    Info    | UpdateManifest [9318]       [ok] | [2025_03_29_zone_state_spawns_instance_index.sql] 
 World |    Info    | UpdateManifest [9319]       [ok] | [2025_03_29_character_tribute_character_id_index.sql] 
 World |    Info    | UpdateManifest [9320]       [ok] | [2025_03_29_data_buckets_expires_index.sql] 
 World |    Info    | UpdateManifest ---------------------------------------------------------------------- 
 World |    Info    | UpdateManifest ---------------------------------------------------------------------- 
 World |    Info    | CheckDbUpdates Updates ran successfully, setting database version to [9320] from [9314] 
```

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
- [x] If my changes make database schema changes, I have tested the changes on a local database (attach image). Updated version.h CURRENT_BINARY_DATABASE_VERSION to the new version. (Delete this if not applicable)
