### PR TITLE
[Command] Add #show zone_variables

### DIFF
--- a/zone/gm_commands/show.cpp
+++ b/zone/gm_commands/show.cpp
@@ -49,6 +49,7 @@
 #include "show/zone_loot.cpp"
 #include "show/zone_points.cpp"
 #include "show/zone_status.cpp"
+#include "show/zone_variables.cpp"
 
 void command_show(Client *c, const Seperator *sep)
 {
@@ -110,6 +111,7 @@ void command_show(Client *c, const Seperator *sep)
 		Cmd{.cmd = "zone_loot", .u = "zone_loot", .fn = ShowZoneLoot, .a = {"#viewzoneloot"}},
 		Cmd{.cmd = "zone_points", .u = "zone_points", .fn = ShowZonePoints, .a = {"#showzonepoints"}},
 		Cmd{.cmd = "zone_status", .u = "zone_status", .fn = ShowZoneStatus, .a = {"#zonestatus"}},
+		Cmd{.cmd = "zone_variables", .u = "zone_variables", .fn = ShowZoneVariables},
 	};
 
 	// Check for arguments

--- a/zone/gm_commands/show/zone_variables.cpp
+++ b/zone/gm_commands/show/zone_variables.cpp
@@ -1,0 +1,16 @@
+#include "../../client.h"
+#include "../../zone.h"
+
+extern Zone* zone;
+
+void ShowZoneVariables(Client *c, const Seperator *sep)
+{
+	if (!zone->GetVariables().empty()) {
+		c->Message(Chat::White, "Zone Variables:");
+		for (auto &key: zone->GetVariables()) {
+			c->Message(Chat::White, fmt::format("{}: {}", key, zone->GetVariable(key)).c_str());
+		}
+	} else {
+		c->Message(Chat::White, "No zone variables set.");
+	}
+}


### PR DESCRIPTION
# Description

With the recent introduction of [zone variables](https://github.com/EQEmu/Server/pull/4768) (similar to entity variables) it has been asked to expose a command to show these for debugging purposes.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing

```perl
sub EVENT_SAY {
    if ($text=~/varset/i) {
        $zone->SetVariable("test1", "val1");
        $zone->SetVariable("test2", "val2");
        $zone->SetVariable("test3", "val3");
    }
}
```

![image](https://github.com/user-attachments/assets/f44e1117-5011-4bae-80ea-642b736eed7e)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

