### PR TITLE
[Fix] Globally Reloading Quests when not loaded

### DIFF
--- a/world/zonelist.cpp
+++ b/world/zonelist.cpp
@@ -910,6 +910,8 @@ void ZSList::SendServerReload(ServerReload::Type type, uchar *packet)
 		ServerReload::Type::Commands,
 		ServerReload::Type::PerlExportSettings,
 		ServerReload::Type::DataBucketsCache,
+		ServerReload::Type::Quests,
+		ServerReload::Type::QuestsTimerReset,
 		ServerReload::Type::WorldRepop,
 		ServerReload::Type::WorldWithRespawn
 	};


### PR DESCRIPTION
# Description

This fixes a reported issue where the `Quests` and `QuestsTimerReset` reload types would require the zone to be booted in order to issue the reload.

This now reloads quests in zones that aren't booted yet.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

![image](https://github.com/user-attachments/assets/67b21c37-0e5c-423c-8f8a-7297b970a43d)

```
 World |    Info    | SendServerReload Sending reload to all zones for type [Quest] 
  Zone |    Info    | QueueReload Queuing reload for [Quest] (21) to reload in [1 Second] 
  Zone |    Info    | QueueReload Queuing reload for [Quest] (21) to reload in [1 Second] 
  Zone |    Info    | QueueReload Queuing reload for [Quest] (21) to reload in [1 Second] -- [halas] (Halas) inst_id [120]
  Zone |    Info    | QueueReload Queuing reload for [Quest] (21) to reload in [1 Second] 
  Zone |    Info    | QueueReload Queuing reload for [Quest] (21) to reload in [1 Second] 
  Zone |    Info    | QueueReload Queuing reload for [Quest] (21) to reload in [1 Second] 
  Zone |    Info    | QueueReload Queuing reload for [Quest] (21) to reload in [1 Second] 
  Zone |    Info    | ProcessReload Reloading [Quest] (21) zone booted required [false] 
  Zone |    Info    | MapOpcodes Mapped [640] client opcode handlers 
  Zone |    Info    | ProcessReload Reloaded [Quest] (21) 
  Zone |    Info    | ProcessReload Reloading [Quest] (21) zone booted required [false] 
  Zone |    Info    | MapOpcodes Mapped [640] client opcode handlers 
  Zone |    Info    | ProcessReload Reloaded [Quest] (21) 
  Zone |    Info    | ProcessReload Reloading [Quest] (21) zone booted required [false] 
  Zone |    Info    | MapOpcodes Mapped [640] client opcode handlers 
  Zone |    Info    | ProcessReload Reloaded [Quest] (21) 
  Zone |    Info    | ProcessReload Reloading [Quest] (21) zone booted required [false] 
  Zone |    Info    | MapOpcodes Mapped [640] client opcode handlers 
  Zone |    Info    | ProcessReload Reloaded [Quest] (21) 
  Zone |    Info    | ProcessReload Reloading [Quest] (21) zone booted required [false] 
  Zone |    Info    | MapOpcodes Mapped [640] client opcode handlers 
  Zone |    Info    | ProcessReload Reloaded [Quest] (21) 
  Zone |    Info    | ProcessReload Reloading [Quest] (21) zone booted required [false] -- [halas] (Halas) inst_id [120]
  Zone |    Info    | MapOpcodes Mapped [640] client opcode handlers -- [halas] (Halas) inst_id [120]
  Zone |    Info    | ProcessReload Reloaded [Quest] (21) -- [halas] (Halas) inst_id [120]
  Zone |    Info    | ProcessReload Reloading [Quest] (21) zone booted required [false] 
  Zone |    Info    | MapOpcodes Mapped [640] client opcode handlers 
  Zone |    Info    | ProcessReload Reloaded [Quest] (21) 
```

```
World |    Info    | SendServerReload Sending reload to all zones for type [Quests With Timer (Resets timer events)] 
  Zone |    Info    | QueueReload Queuing reload for [Quests With Timer (Resets timer events)] (22) to reload in [1 Second] -- [halas] (Halas) inst_id [120]
  Zone |    Info    | QueueReload Queuing reload for [Quests With Timer (Resets timer events)] (22) to reload in [1 Second] 
  Zone |    Info    | QueueReload Queuing reload for [Quests With Timer (Resets timer events)] (22) to reload in [1 Second] 
  Zone |    Info    | QueueReload Queuing reload for [Quests With Timer (Resets timer events)] (22) to reload in [1 Second] 
  Zone |    Info    | QueueReload Queuing reload for [Quests With Timer (Resets timer events)] (22) to reload in [1 Second] 
  Zone |    Info    | QueueReload Queuing reload for [Quests With Timer (Resets timer events)] (22) to reload in [1 Second] 
  Zone |    Info    | QueueReload Queuing reload for [Quests With Timer (Resets timer events)] (22) to reload in [1 Second] 
  Zone |    Info    | ProcessReload Reloading [Quests With Timer (Resets timer events)] (22) zone booted required [false] 
  Zone |    Info    | MapOpcodes Mapped [640] client opcode handlers 
  Zone |    Info    | ProcessReload Reloaded [Quests With Timer (Resets timer events)] (22) 
  Zone |    Info    | ProcessReload Reloading [Quests With Timer (Resets timer events)] (22) zone booted required [false] 
  Zone |    Info    | MapOpcodes Mapped [640] client opcode handlers 
  Zone |    Info    | ProcessReload Reloaded [Quests With Timer (Resets timer events)] (22) 
  Zone |    Info    | ProcessReload Reloading [Quests With Timer (Resets timer events)] (22) zone booted required [false] 
  Zone |    Info    | MapOpcodes Mapped [640] client opcode handlers 
  Zone |    Info    | ProcessReload Reloaded [Quests With Timer (Resets timer events)] (22) 
  Zone |    Info    | ProcessReload Reloading [Quests With Timer (Resets timer events)] (22) zone booted required [false] 
  Zone |    Info    | MapOpcodes Mapped [640] client opcode handlers 
  Zone |    Info    | ProcessReload Reloaded [Quests With Timer (Resets timer events)] (22) 
  Zone |    Info    | ProcessReload Reloading [Quests With Timer (Resets timer events)] (22) zone booted required [false] 
  Zone |    Info    | MapOpcodes Mapped [640] client opcode handlers 
  Zone |    Info    | ProcessReload Reloaded [Quests With Timer (Resets timer events)] (22) 
  Zone |    Info    | ProcessReload Reloading [Quests With Timer (Resets timer events)] (22) zone booted required [false] -- [halas] (Halas) inst_id [120]
  Zone |    Info    | MapOpcodes Mapped [640] client opcode handlers -- [halas] (Halas) inst_id [120]
  Zone |    Info    | ProcessReload Reloaded [Quests With Timer (Resets timer events)] (22) -- [halas] (Halas) inst_id [120]
  Zone |    Info    | ProcessReload Reloading [Quests With Timer (Resets timer events)] (22) zone booted required [false] 
  Zone |    Info    | MapOpcodes Mapped [640] client opcode handlers 
  Zone |    Info    | ProcessReload Reloaded [Quests With Timer (Resets timer events)] (22) 
```

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
