### PR TITLE
[Cleanup] Control flow defaults missed in recent bot updates

### DIFF
--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -10599,6 +10599,8 @@ BotSpell Bot::GetSpellByHealType(uint16 spell_type, Mob* tar) {
 			return GetBestBotSpellForHealOverTime(this, tar, spell_type);
 		case BotSpellTypes::GroupHoTHeals:
 			return GetBestBotSpellForGroupHealOverTime(this, tar, spell_type);
+		default:
+			return BotSpell(); // Return an empty BotSpell if no valid spell type is found
 	}
 }
 
@@ -10650,7 +10652,7 @@ int Bot::GetDefaultSetting(uint16 setting_category, uint16 setting_type, uint8 s
 		case BotSettingCategories::SpellTypeAnnounceCast:
 			return GetDefaultSpellTypeAnnounceCast(setting_type, stance);
 		default:
-			break;
+			return 0; // Default return value for unrecognized categories
 	}
 }
 
@@ -10689,7 +10691,7 @@ int Bot::GetSetting(uint16 setting_category, uint16 setting_type) {
 		case BotSettingCategories::SpellTypeAnnounceCast:
 			return GetSpellTypeAnnounceCast(setting_type);
 		default:
-			break;
+			return 0; // Default return value for unrecognized categories
 	}
 }
 

--- a/zone/client_bot.cpp
+++ b/zone/client_bot.cpp
@@ -256,6 +256,8 @@ int Client::GetDefaultBotSettings(uint8 setting_type, uint16 bot_setting) {
 			return GetDefaultSpellTypeMinThreshold(bot_setting);
 		case BotSettingCategories::SpellMaxThreshold:
 			return GetDefaultSpellTypeMaxThreshold(bot_setting);
+		default:
+			return 0; // default return for any unsupported setting type
 	}
 }
 
@@ -269,6 +271,8 @@ int Client::GetBotSetting(uint8 setting_type, uint16 bot_setting) {
 			return GetSpellTypeMinThreshold(bot_setting);
 		case BotSettingCategories::SpellMaxThreshold:
 			return GetSpellTypeMaxThreshold(bot_setting);
+		default:
+			return 0; // default return for any unsupported setting type
 	}
 }
 


### PR DESCRIPTION
# Missed switch defaults in some recent bot changes

bot.cpp:
```sh
/home/eqemu/source/zone/bot.cpp: In member function ‘BotSpell Bot::GetSpellByHealType(uint16, Mob*)’:
/home/eqemu/source/zone/bot.cpp:10603:1: warning: control reaches end of non-void function [-Wreturn-type]
10603 | }
      | ^
/home/eqemu/source/zone/bot.cpp: In member function ‘int Bot::GetDefaultSetting(uint16, uint16, uint8)’:
/home/eqemu/source/zone/bot.cpp:10655:1: warning: control reaches end of non-void function [-Wreturn-type]
10655 |      | ^
/home/eqemu/source/zone/bot.cpp: In member function ‘int Bot::GetSetting(uint16, uint16)’:
/home/eqemu/source/zone/bot.cpp:10694:1: warning: control reaches end of non-void function [-Wreturn-type]
10694 | }
      | ^
```

client_bot.cpp:
```sh
/home/eqemu/source/zone/client_bot.cpp: In member function ‘int Client::GetDefaultBotSettings(uint8, uint16)’:
/home/eqemu/source/zone/client_bot.cpp:260:1: warning: control reaches end of non-void function [-Wreturn-type]
  260 | }
      | ^
/home/eqemu/source/zone/client_bot.cpp: In member function ‘int Client::GetBotSetting(uint8, uint16)’:
/home/eqemu/source/zone/client_bot.cpp:273:1: warning: control reaches end of non-void function [-Wreturn-type]
  273 | }
      | ^
```
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

Could use testing. Compiles fine.

Clients tested: N/A

# Checklist

- [ ] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur