### PR TITLE
[Performance] Send Smarter Emote Packets

### DIFF
--- a/world/clientlist.cpp
+++ b/world/clientlist.cpp
@@ -1886,3 +1886,36 @@ std::vector<uint32_t> ClientList::GetGuildZoneServers(uint32 guild_id)
 
 	return zone_server_ids;
 }
+
+std::vector<uint32_t> ClientList::GetZoneServersWithGMs()
+{
+	std::vector<uint32_t>                 zone_server_ids;
+	std::unordered_set<uint32_t>          seen_ids;
+	LinkedListIterator<ClientListEntry *> iterator(clientlist);
+
+	iterator.Reset();
+	while (iterator.MoreElements()) {
+		ClientListEntry *cle = iterator.GetData();
+
+		if (cle->Online() != CLE_Status::InZone) {
+			iterator.Advance();
+			continue;
+		}
+
+		if (!cle->Server()) {
+			iterator.Advance();
+			continue;
+		}
+
+		if (cle->Admin() > 0) {
+			uint32_t id = cle->Server()->GetID();
+			if (seen_ids.insert(id).second) {
+				zone_server_ids.emplace_back(id);
+			}
+		}
+
+		iterator.Advance();
+	}
+
+	return zone_server_ids;
+}

--- a/world/clientlist.h
+++ b/world/clientlist.h
@@ -61,6 +61,7 @@ public:
 	void	CLEKeepAlive(uint32 numupdates, uint32* wid);
 	void	CLEAdd(uint32 login_server_id, const char* login_server_name, const char* login_name, const char* login_key, int16 world_admin = AccountStatus::Player, uint32 ip_address = 0, uint8 is_local=0);
 	std::vector<uint32_t> GetGuildZoneServers(uint32 guild_id);
+	std::vector<uint32_t> GetZoneServersWithGMs();
 	void	UpdateClientGuild(uint32 char_id, uint32 guild_id);
 	bool    IsAccountInGame(uint32 iLSID);
 

--- a/world/zonelist.h
+++ b/world/zonelist.h
@@ -30,6 +30,7 @@ public:
 	bool SendPacket(uint32 zoneid, ServerPacket *pack);
 	bool SendPacket(uint32 zoneid, uint16 instanceid, ServerPacket *pack);
 	bool SendPacketToZonesWithGuild(uint32 guild_id, ServerPacket *pack);
+	bool SendPacketToZonesWithGMs(ServerPacket *pack);
 	bool SendPacketToBootedZones(ServerPacket* pack);
 	bool SetLockedZone(uint16 iZoneID, bool iLock);
 

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -571,7 +571,13 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 						);
 					}
 				}
-				zoneserver_list.SendPacket(pack);
+				if (scm->guilddbid > 0) {
+					zoneserver_list.SendPacketToZonesWithGuild(scm->guilddbid, pack);
+				} else if (scm->chan_num == ChatChannel_GMSAY) {
+					zoneserver_list.SendPacketToZonesWithGMs(pack);
+				} else {
+					zoneserver_list.SendPacket(pack);
+				}
 			}
 
 			break;


### PR DESCRIPTION
# Description

This PR routes packets smarter for emote / guild / gmsay messages.

If we take for example - 2,000 zoneservers and we issue a global reload of logs, for each zone we send GM (emote) messages indicating that the zone has reloaded logs. For each zone that this is sent, it sends it to **every** other zone. This results in n x n packets. In this case 2,000 x 2,000 = 4,000,000 (4 million) packets. The resulting changes in this PR selectively look for zoneservers where GM's are logged in and only sends the packets there.

Similarly for Guilds, we only send guild messages where guild members are.

This PR should dramatically reduce packet sending from world.

## Type of change

- [x] Optimization

# Testing

* Tested /gmsay (also quest::gmsay)
* Tested /gu (works)
* Tested logging reloads, targeting only zones with GM's

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

