### PR TITLE
[Cleanup] UCS Member Count

### DIFF
--- a/ucs/chatchannel.cpp
+++ b/ucs/chatchannel.cpp
@@ -408,7 +408,7 @@ void ChatChannel::SendChannelMembers(Client *c) {
 
 	if(!c) return;
 
-	char CountString[10];
+	char CountString[12];
 
 	sprintf(CountString, "(%i)", MemberCount(c->GetAccountStatus()));
 

--- a/ucs/chatchannel.cpp
+++ b/ucs/chatchannel.cpp
@@ -177,7 +177,7 @@ void ChatChannelList::SendAllChannels(Client *c) {
 
 	std::string Message;
 
-	char CountString[12];
+	char CountString[13];
 
 	while(iterator.MoreElements()) {
 
@@ -408,7 +408,7 @@ void ChatChannel::SendChannelMembers(Client *c) {
 
 	if(!c) return;
 
-	char CountString[12];
+	char CountString[13];
 
 	sprintf(CountString, "(%i)", MemberCount(c->GetAccountStatus()));
 

--- a/ucs/chatchannel.cpp
+++ b/ucs/chatchannel.cpp
@@ -177,7 +177,7 @@ void ChatChannelList::SendAllChannels(Client *c) {
 
 	std::string Message;
 
-	char CountString[10];
+	char CountString[12];
 
 	while(iterator.MoreElements()) {
 


### PR DESCRIPTION
# Description

Fix an edge case in linux (windows is more forgiving) where if we had enough members in a chat channel, the channel count will buffer overflow the string. For example, using INT_MAX, "(" + "2147483647" + ")" + "\0" = 13 vice the 10 allocated crashes ucs.

```sh
/home/eqemu/source/ucs/chatchannel.cpp: In member function ‘void ChatChannelList::SendAllChannels(Client*)’:
/home/eqemu/source/ucs/chatchannel.cpp:196:40: warning: ‘%i’ directive writing between 1 and 10 bytes into a region of size 9 [-Wformat-overflow=]
  196 |                 sprintf(CountString, "(%i)", CurrentChannel->MemberCount(c->GetAccountStatus()));
      |                                        ^~
/home/eqemu/source/ucs/chatchannel.cpp:196:38: note: directive argument in the range [0, 2147483647]
  196 |                 sprintf(CountString, "(%i)", CurrentChannel->MemberCount(c->GetAccountStatus()));
      |                                      ^~~~~~
```
```sh
/home/eqemu/source/ucs/chatchannel.cpp: In member function ‘void ChatChannel::SendChannelMembers(Client*)’:
/home/eqemu/source/ucs/chatchannel.cpp:413:32: warning: ‘%i’ directive writing between 1 and 10 bytes into a region of size 9 [-Wformat-overflow=]
  413 |         sprintf(CountString, "(%i)", MemberCount(c->GetAccountStatus()));
      |                                ^~
/home/eqemu/source/ucs/chatchannel.cpp:413:30: note: directive argument in the range [0, 2147483647]
  413 |         sprintf(CountString, "(%i)", MemberCount(c->GetAccountStatus()));
      |                              ^~~~~~
```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
Before change using the example above, ucs crashed with a buffer overflow. Using the same test case after the fix, outputs what is expected.

![image](https://github.com/user-attachments/assets/03ca2392-bfc1-42b4-9cd1-4ee8d2c48a86)

Clients tested: RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur