### PR TITLE
[Instances] Add `expire_at` Column

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -7071,6 +7071,20 @@ CREATE INDEX `idx_expire_at` ON `respawn_times` (`expire_at`);
 )",
 		.content_schema_update = false
 	},
+	ManifestEntry{
+		.version = 9321,
+		.description = "2025_03_30_instance_list_add_expire_at.sql",
+		.check = "SHOW COLUMNS FROM `instance_list` LIKE 'expire_at'",
+		.condition = "empty",
+		.match = "",
+		.sql = R"(
+ALTER TABLE `instance_list`
+ADD COLUMN `expire_at` bigint(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `duration`;
+
+CREATE INDEX `idx_expire_at` ON `instance_list` (`expire_at`);
+)",
+		.content_schema_update = false
+	},
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{
 //		.version = 9228,

--- a/common/database_instances.cpp
+++ b/common/database_instances.cpp
@@ -128,6 +128,7 @@ bool Database::CreateInstance(uint16 instance_id, uint32 zone_id, uint32 version
 	e.version = version;
 	e.start_time = std::time(nullptr);
 	e.duration = duration;
+	e.expire_at = e.start_time + duration;
 
 	RespawnTimesRepository::ClearInstanceTimers(*this, e.id);
 	InstanceListRepository::ReplaceOne(*this, e);
@@ -562,7 +563,7 @@ void Database::PurgeExpiredInstances()
 {
 	auto l = InstanceListRepository::GetWhere(
 		*this,
-		"expire_at <= (UNIX_TIMESTAMP()) AND never_expires = 0"
+		"expire_at <= UNIX_TIMESTAMP() AND never_expires = 0"
 	);
 	if (l.empty()) {
 		return;
@@ -598,6 +599,7 @@ void Database::SetInstanceDuration(uint16 instance_id, uint32 new_duration)
 
 	i.start_time = std::time(nullptr);
 	i.duration = new_duration;
+	i.expire_at = i.start_time + i.duration;
 
 	InstanceListRepository::UpdateOne(*this, i);
 }

--- a/common/database_instances.cpp
+++ b/common/database_instances.cpp
@@ -563,7 +563,10 @@ void Database::PurgeExpiredInstances()
 {
 	auto l = InstanceListRepository::GetWhere(
 		*this,
-		"expire_at <= UNIX_TIMESTAMP() AND never_expires = 0"
+		fmt::format(
+			"expire_at <= (UNIX_TIMESTAMP() - {}) AND never_expires = 0",
+			RuleI(Instances, ExpireOffsetTimeSeconds)
+		)
 	);
 	if (l.empty()) {
 		return;

--- a/common/dynamic_zone_base.cpp
+++ b/common/dynamic_zone_base.cpp
@@ -58,6 +58,7 @@ uint32_t DynamicZoneBase::CreateInstance()
 	insert_instance.start_time = static_cast<int>(std::chrono::system_clock::to_time_t(m_start_time));
 	insert_instance.duration = static_cast<int>(m_duration.count());
 	insert_instance.never_expires = m_never_expires;
+	insert_instance.expire_at = insert_instance.start_time + insert_instance.duration;
 
 	auto instance = InstanceListRepository::InsertOne(GetDatabase(), insert_instance);
 	if (instance.id == 0)

--- a/common/repositories/base/base_instance_list_repository.h
+++ b/common/repositories/base/base_instance_list_repository.h
@@ -25,6 +25,7 @@ public:
 		uint8_t     is_global;
 		uint32_t    start_time;
 		uint32_t    duration;
+		uint64_t    expire_at;
 		uint8_t     never_expires;
 		std::string notes;
 	};
@@ -43,6 +44,7 @@ public:
 			"is_global",
 			"start_time",
 			"duration",
+			"expire_at",
 			"never_expires",
 			"notes",
 		};
@@ -57,6 +59,7 @@ public:
 			"is_global",
 			"start_time",
 			"duration",
+			"expire_at",
 			"never_expires",
 			"notes",
 		};
@@ -105,6 +108,7 @@ public:
 		e.is_global     = 0;
 		e.start_time    = 0;
 		e.duration      = 0;
+		e.expire_at     = 0;
 		e.never_expires = 0;
 		e.notes         = "";
 
@@ -149,8 +153,9 @@ public:
 			e.is_global     = row[3] ? static_cast<uint8_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.start_time    = row[4] ? static_cast<uint32_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.duration      = row[5] ? static_cast<uint32_t>(strtoul(row[5], nullptr, 10)) : 0;
-			e.never_expires = row[6] ? static_cast<uint8_t>(strtoul(row[6], nullptr, 10)) : 0;
-			e.notes         = row[7] ? row[7] : "";
+			e.expire_at     = row[6] ? strtoull(row[6], nullptr, 10) : 0;
+			e.never_expires = row[7] ? static_cast<uint8_t>(strtoul(row[7], nullptr, 10)) : 0;
+			e.notes         = row[8] ? row[8] : "";
 
 			return e;
 		}
@@ -189,8 +194,9 @@ public:
 		v.push_back(columns[3] + " = " + std::to_string(e.is_global));
 		v.push_back(columns[4] + " = " + std::to_string(e.start_time));
 		v.push_back(columns[5] + " = " + std::to_string(e.duration));
-		v.push_back(columns[6] + " = " + std::to_string(e.never_expires));
-		v.push_back(columns[7] + " = '" + Strings::Escape(e.notes) + "'");
+		v.push_back(columns[6] + " = " + std::to_string(e.expire_at));
+		v.push_back(columns[7] + " = " + std::to_string(e.never_expires));
+		v.push_back(columns[8] + " = '" + Strings::Escape(e.notes) + "'");
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -218,6 +224,7 @@ public:
 		v.push_back(std::to_string(e.is_global));
 		v.push_back(std::to_string(e.start_time));
 		v.push_back(std::to_string(e.duration));
+		v.push_back(std::to_string(e.expire_at));
 		v.push_back(std::to_string(e.never_expires));
 		v.push_back("'" + Strings::Escape(e.notes) + "'");
 
@@ -255,6 +262,7 @@ public:
 			v.push_back(std::to_string(e.is_global));
 			v.push_back(std::to_string(e.start_time));
 			v.push_back(std::to_string(e.duration));
+			v.push_back(std::to_string(e.expire_at));
 			v.push_back(std::to_string(e.never_expires));
 			v.push_back("'" + Strings::Escape(e.notes) + "'");
 
@@ -296,8 +304,9 @@ public:
 			e.is_global     = row[3] ? static_cast<uint8_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.start_time    = row[4] ? static_cast<uint32_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.duration      = row[5] ? static_cast<uint32_t>(strtoul(row[5], nullptr, 10)) : 0;
-			e.never_expires = row[6] ? static_cast<uint8_t>(strtoul(row[6], nullptr, 10)) : 0;
-			e.notes         = row[7] ? row[7] : "";
+			e.expire_at     = row[6] ? strtoull(row[6], nullptr, 10) : 0;
+			e.never_expires = row[7] ? static_cast<uint8_t>(strtoul(row[7], nullptr, 10)) : 0;
+			e.notes         = row[8] ? row[8] : "";
 
 			all_entries.push_back(e);
 		}
@@ -328,8 +337,9 @@ public:
 			e.is_global     = row[3] ? static_cast<uint8_t>(strtoul(row[3], nullptr, 10)) : 0;
 			e.start_time    = row[4] ? static_cast<uint32_t>(strtoul(row[4], nullptr, 10)) : 0;
 			e.duration      = row[5] ? static_cast<uint32_t>(strtoul(row[5], nullptr, 10)) : 0;
-			e.never_expires = row[6] ? static_cast<uint8_t>(strtoul(row[6], nullptr, 10)) : 0;
-			e.notes         = row[7] ? row[7] : "";
+			e.expire_at     = row[6] ? strtoull(row[6], nullptr, 10) : 0;
+			e.never_expires = row[7] ? static_cast<uint8_t>(strtoul(row[7], nullptr, 10)) : 0;
+			e.notes         = row[8] ? row[8] : "";
 
 			all_entries.push_back(e);
 		}
@@ -410,6 +420,7 @@ public:
 		v.push_back(std::to_string(e.is_global));
 		v.push_back(std::to_string(e.start_time));
 		v.push_back(std::to_string(e.duration));
+		v.push_back(std::to_string(e.expire_at));
 		v.push_back(std::to_string(e.never_expires));
 		v.push_back("'" + Strings::Escape(e.notes) + "'");
 
@@ -440,6 +451,7 @@ public:
 			v.push_back(std::to_string(e.is_global));
 			v.push_back(std::to_string(e.start_time));
 			v.push_back(std::to_string(e.duration));
+			v.push_back(std::to_string(e.expire_at));
 			v.push_back(std::to_string(e.never_expires));
 			v.push_back("'" + Strings::Escape(e.notes) + "'");
 

--- a/common/repositories/instance_list_repository.h
+++ b/common/repositories/instance_list_repository.h
@@ -11,7 +11,7 @@ public:
 	{
 		auto results = db.QueryDatabase(
 			fmt::format(
-				"UPDATE `{}` SET `duration` = {} WHERE `{}` = {}",
+				"UPDATE `{}` SET `duration` = {}, `expire_at` = (`duration` + `start_time`) WHERE `{}` = {}",
 				TableName(),
 				new_duration,
 				PrimaryKey(),

--- a/common/repositories/instance_list_repository.h
+++ b/common/repositories/instance_list_repository.h
@@ -7,44 +7,6 @@
 
 class InstanceListRepository: public BaseInstanceListRepository {
 public:
-
-    /**
-     * This file was auto generated and can be modified and extended upon
-     *
-     * Base repository methods are automatically
-     * generated in the "base" version of this repository. The base repository
-     * is immutable and to be left untouched, while methods in this class
-     * are used as extension methods for more specific persistence-layer
-     * accessors or mutators.
-     *
-     * Base Methods (Subject to be expanded upon in time)
-     *
-     * Note: Not all tables are designed appropriately to fit functionality with all base methods
-     *
-     * InsertOne
-     * UpdateOne
-     * DeleteOne
-     * FindOne
-     * GetWhere(std::string where_filter)
-     * DeleteWhere(std::string where_filter)
-     * InsertMany
-     * All
-     *
-     * Example custom methods in a repository
-     *
-     * InstanceListRepository::GetByZoneAndVersion(int zone_id, int zone_version)
-     * InstanceListRepository::GetWhereNeverExpires()
-     * InstanceListRepository::GetWhereXAndY()
-     * InstanceListRepository::DeleteWhereXAndY()
-     *
-     * Most of the above could be covered by base methods, but if you as a developer
-     * find yourself re-using logic for other parts of the code, its best to just make a
-     * method that can be re-used easily elsewhere especially if it can use a base repository
-     * method and encapsulate filters there
-     */
-
-	// Custom extended repository methods here
-
 	static int UpdateDuration(Database& db, uint16 instance_id, uint32_t new_duration)
 	{
 		auto results = db.QueryDatabase(
@@ -65,7 +27,7 @@ public:
 		auto results = db.QueryDatabase(
 			fmt::format(
 				SQL(
-					SELECT ((start_time + duration) - UNIX_TIMESTAMP()) AS `remaining` FROM `{}`
+					SELECT (`expire_at` - UNIX_TIMESTAMP()) AS `remaining` FROM `{}`
 					WHERE `id` = {}
 				),
 				TableName(),

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -1096,6 +1096,7 @@ RULE_CATEGORY(Instances)
 RULE_INT(Instances, ReservedInstances, 100, "Number of instance IDs which are reserved for globals. This value should not be changed while a server is running")
 RULE_BOOL(Instances, RecycleInstanceIds, true, "Setting whether free instance IDs should be recycled to prevent them from gradually running out at 32k")
 RULE_INT(Instances, GuildHallExpirationDays, 90, "Amount of days before a Guild Hall instance expires")
+RULE_INT(Instances, ExpireOffsetTimeSeconds, 3600, "Amount of seconds to beyond instance expiration time we wait to purge the entry from the database. (Default: 1 Hour)")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Expedition)

--- a/common/servertalk.h
+++ b/common/servertalk.h
@@ -276,6 +276,8 @@
 #define ServerOP_QSSendQuery		0x5000
 #define ServerOP_PlayerEvent 0x5100
 
+#define ServerOP_ZoneInstanceShutdown 0x5200 // unload all data, kick clients, kill process
+
 enum {
 	CZUpdateType_Character,
 	CZUpdateType_Group,

--- a/common/servertalk.h
+++ b/common/servertalk.h
@@ -276,8 +276,6 @@
 #define ServerOP_QSSendQuery		0x5000
 #define ServerOP_PlayerEvent 0x5100
 
-#define ServerOP_ZoneInstanceShutdown 0x5200 // unload all data, kick clients, kill process
-
 enum {
 	CZUpdateType_Character,
 	CZUpdateType_Group,

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9320
+#define CURRENT_BINARY_DATABASE_VERSION 9321
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9054
 
 #endif

--- a/world/dynamic_zone.cpp
+++ b/world/dynamic_zone.cpp
@@ -137,8 +137,11 @@ void DynamicZone::SetSecondsRemaining(uint32_t seconds_remaining)
 		m_expire_time = now + new_remaining;
 		m_duration = std::chrono::duration_cast<std::chrono::seconds>(m_expire_time - m_start_time);
 
-		InstanceListRepository::UpdateDuration(database,
-			GetInstanceID(), static_cast<uint32_t>(m_duration.count()));
+		InstanceListRepository::UpdateDuration(
+			database,
+			GetInstanceID(),
+			static_cast<uint32_t>(m_duration.count())
+		);
 
 		SendZonesDurationUpdate(); // update zone caches and actual instance's timer
 	}

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -3506,6 +3506,7 @@ void QuestManager::UpdateInstanceTimer(uint16 instance_id, uint32 new_duration)
 
 	e.duration   = new_duration;
 	e.start_time = std::time(nullptr);
+	e.expire_at  = e.start_time + e.duration;
 
 	const int updated = InstanceListRepository::UpdateOne(database, e);
 


### PR DESCRIPTION
# Description

* **New Column** This adds an `expire_at` column to `instance_list` table so that we have a finite value to index on. Currently, queries perform full table scans during instance pruning and creates table contention.
* **PurgeExpiredInstances** Instead of offsetting purged instances 1 day after expiration, we now offset by 1 hour to purge instances faster. This is configurable by rule **Instances:ExpireOffsetTimeSeconds**

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Migration testing

```
 World |    Info    | UpdateManifest ---------------------------------------------------------------------- 
 World |    Info    | UpdateManifest Running database migrations. Please wait... 
 World |    Info    | UpdateManifest ---------------------------------------------------------------------- 
 World |    Info    | UpdateManifest [9321] [2025_03_30_instance_list_add_expire_at.sql] [ok] 
 World |    Info    | UpdateManifest ---------------------------------------------------------------------- 
 World |    Info    | CheckDbUpdates Updates ran successfully, setting database version to [9321] from [9320] 
```

Created 1 minute expiration instance

```perl
sub EVENT_SAY {
    if ($text=~/instance/i) {
        my $instance_id = quest::CreateInstance("halas", 0, 60);
        $client->AssignToInstance($instance_id);
        $client->MoveZoneInstance($instance_id);
    }
}
```

Instance expiring

```
 World |    Info    | operator() Purging expired instances 
 World |   Query    | QueryDatabase SELECT id, zone, version, is_global, start_time, duration, expire_at, never_expires, notes FROM instance_list WHERE expire_at <= (UNIX_TIMESTAMP()) AND never_expires = 0 -- (1 row returned) (0.000220s)
 World |   Query    | QueryDatabase DELETE FROM instance_list WHERE id IN (101) -- (1 row affected) (0.010887s)
 World |   Query    | QueryDatabase DELETE FROM instance_list_player WHERE id IN (101) -- (1 row affected) (0.001782s)
 World |   Query    | QueryDatabase DELETE FROM respawn_times WHERE instance_id IN (101) -- (0 rows affected) (0.000073s)
 World |   Query    | QueryDatabase DELETE FROM spawn_condition_values WHERE instance_id IN (101) -- (0 rows affected) (0.000033s)
 World |   Query    | QueryDatabase UPDATE `character_corpses` SET is_buried = 1, instance_id = 0 WHERE instance_id IN (101) -- (0 rows affected) (0.000047s)
 World |   Query    | QueryDatabase DELETE dynamic_zone_members FROM dynamic_zone_members INNER JOIN dynamic_zones ON dynamic_zone_members.dynamic_zone_id = dynamic_zones.id WHERE dynamic_zones.instance_id IN (101) -- (0 rows affected) (0.000053s)
 World |   Query    | QueryDatabase DELETE FROM dynamic_zones WHERE instance_id IN (101) -- (0 rows affected) (0.000025s)
 World |   Query    | QueryDatabase DELETE FROM spawn2_disabled WHERE instance_id IN (101) -- (0 rows affected) (0.000018s)
 World |   Query    | QueryDatabase DELETE FROM data_buckets WHERE instance_id != 0 and instance_id IN (101) -- (0 rows affected) (0.000026s)
 World |   Query    | QueryDatabase DELETE FROM zone_state_spawns WHERE `instance_id` IN (101) -- (82 rows affected) (0.003508s)
 World |   Query    | QueryDatabase DELETE FROM data_buckets WHERE (`expires` < 1743316091 AND `expires` > 0) -- (0 rows affected) (0.000081s)
 World |   Query    | QueryDatabase DELETE FROM character_expedition_lockouts WHERE expire_time <= NOW() -- (0 rows affected) (0.000025s)
 World |   Query    | QueryDatabase DELETE FROM character_task_timers WHERE expire_time <= NOW() -- (0 rows affected) (0.000017s)
```

Updating existing instance duration

```perl
sub EVENT_SAY {
    if ($text=~/instance/i) {
        my $instance_id = quest::CreateInstance("halas", 0, 60);
        $client->AssignToInstance($instance_id);
        $client->MoveZoneInstance($instance_id);
        quest::UpdateInstanceTimer($instance_id, 120);
    }
}
```

![image](https://github.com/user-attachments/assets/ceeb757f-6fd0-4aa7-ad73-5b3a7ff89d17)


# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
- [x] If my changes make database schema changes, I have tested the changes on a local database (attach image). Updated version.h CURRENT_BINARY_DATABASE_VERSION to the new version. (Delete this if not applicable)
