### PR TITLE
[Fix] Instance DZ Creation

### DIFF
--- a/common/dynamic_zone_base.cpp
+++ b/common/dynamic_zone_base.cpp
@@ -67,7 +67,7 @@ uint32_t DynamicZoneBase::CreateInstance()
 		return 0;
 	}
 
-	m_instance_id = instance.id;
+	m_instance_id = unused_instance_id;
 
 	return m_instance_id;
 }

--- a/common/dynamic_zone_base.cpp
+++ b/common/dynamic_zone_base.cpp
@@ -60,8 +60,8 @@ uint32_t DynamicZoneBase::CreateInstance()
 	insert_instance.never_expires = m_never_expires;
 	insert_instance.expire_at = insert_instance.start_time + insert_instance.duration;
 
-	auto instance = InstanceListRepository::InsertOne(GetDatabase(), insert_instance);
-	if (instance.id == 0)
+	auto instance = InstanceListRepository::ReplaceOne(GetDatabase(), insert_instance);
+	if (!instance)
 	{
 		LogDynamicZones("Failed to create instance [{}] for zone [{}]", unused_instance_id, m_zone_id);
 		return 0;


### PR DESCRIPTION
# Description

Fixes instance DZ creation since DZ's create instances outside of the rest of the pipeline. This [PR](https://github.com/EQEmu/Server/pull/4803) changes how we fetch ID's. We make sure we can insert a row first and than we replace it later instead of trying to insert after.

## Type of change

- [x] Regression fix 

# Testing

Catapultam — 4:45 PM
this successfully generated an instance

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

