### PR TITLE
[Database] Wrap PurgeExpiredInstances in a Transaction

### DIFF
--- a/common/database_instances.cpp
+++ b/common/database_instances.cpp
@@ -579,6 +579,7 @@ void Database::PurgeExpiredInstances()
 
 	const auto ids = Strings::Implode(",", instance_ids);
 
+	TransactionBegin();
 	InstanceListRepository::DeleteWhere(*this, fmt::format("id IN ({})", ids));
 	InstanceListPlayerRepository::DeleteWhere(*this, fmt::format("id IN ({})", ids));
 	RespawnTimesRepository::DeleteWhere(*this, fmt::format("instance_id IN ({})", ids));
@@ -591,6 +592,9 @@ void Database::PurgeExpiredInstances()
 	if (RuleB(Zone, StateSavingOnShutdown)) {
 		ZoneStateSpawnsRepository::DeleteWhere(*this, fmt::format("`instance_id` IN ({})", ids));
 	}
+	TransactionCommit();
+
+	LogInfo("Purged [{}] expired instances", l.size());
 }
 
 void Database::SetInstanceDuration(uint16 instance_id, uint32 new_duration)


### PR DESCRIPTION
# Description

This simply wraps all of the instance deletions in a transaction. This will speed up query execution because we aren't making individual round trips.

No need to specifically handle rollback in simple deletes.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing

Purge on world boot example

```
 World |    Info    | PurgeExpiredInstances Purged [1] expired instances 
```

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
