### PR TITLE
[Feature] Instance version customization (zone_config.json)

### DIFF
--- a/common/zone_store.cpp
+++ b/common/zone_store.cpp
@@ -195,6 +195,8 @@ uint32 ZoneStore::GetZoneIDByLongName(const std::string& zone_long_name)
  */
 ZoneRepository::Zone *ZoneStore::GetZone(uint32 zone_id, int version)
 {
+	version = GetVersionAlias(zone_id, version);
+
 	for (auto &z: m_zones) {
 		if (z.zoneidnumber == zone_id && z.version == version) {
 			return &z;
@@ -242,6 +244,8 @@ const std::vector<ZoneRepository::Zone> &ZoneStore::GetZones() const
 // gets zone data by using explicit version and falling back to version 0 if not found
 ZoneRepository::Zone *ZoneStore::GetZoneWithFallback(uint32 zone_id, int version)
 {
+	version = GetVersionAlias(zone_id, version);
+
 	for (auto &z: m_zones) {
 		if (z.zoneidnumber == zone_id && z.version == version) {
 			return &z;
@@ -728,4 +732,22 @@ uint32 ZoneStore::GetZoneSecondsBeforeIdle(uint32 zone_id, int version)
 {
 	const auto& z = GetZoneVersionWithFallback(zone_id, version);
 	return z ? z->seconds_before_idle : 60;
+}
+
+void ZoneStore::RegisterVersionAlias(uint32 zone_id, int old_version, int new_version)
+{
+	if (!m_zone_alt_versions.contains(zone_id)) {
+		m_zone_alt_versions[zone_id] = std::map<int, int>();
+	}
+
+	m_zone_alt_versions[zone_id][old_version] = new_version;
+}
+
+int ZoneStore::GetVersionAlias(uint32 zone_id, int old_version)
+{
+	if (m_zone_alt_versions.contains(zone_id) && m_zone_alt_versions[zone_id].contains(old_version)) {
+		return m_zone_alt_versions[zone_id][old_version];
+	}
+
+	return old_version;
 }

--- a/common/zone_store.h
+++ b/common/zone_store.h
@@ -34,6 +34,8 @@ public:
 	const std::vector<ZoneRepository::Zone> &GetZones() const;
 
 	void LoadZones(Database &db);
+	void RegisterVersionAlias(uint32 zone_id, int old_version, int new_version);
+	int GetVersionAlias(uint32 zone_id, int old_version);
 
 	ZoneRepository::Zone *GetZone(uint32 zone_id, int version = 0);
 	ZoneRepository::Zone *GetZone(const char *in_zone_name);
@@ -106,6 +108,7 @@ public:
 
 private:
 	std::vector<ZoneRepository::Zone> m_zones;
+	std::map<uint32, std::map<int, int>> m_zone_alt_versions;
 };
 
 extern ZoneStore zone_store;

--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -778,6 +778,9 @@ int ZoneDatabase::GetDoorsDBCountPlusOne(std::string zone_short_name, int16 vers
 
 std::vector<DoorsRepository::Doors> ZoneDatabase::LoadDoors(const std::string &zone_name, int16 version)
 {
+	auto quest_config = zone->GetQuestConfig();
+	version = quest_config->template_version;
+
 	auto door_entries = DoorsRepository::GetWhere(
 		*this, fmt::format(
 			"zone = '{}' AND (version = {} OR version = -1) {} ORDER BY doorid ASC",

--- a/zone/quest_parser_collection.h
+++ b/zone/quest_parser_collection.h
@@ -72,6 +72,7 @@ public:
 	bool ItemHasQuestSub(EQ::ItemInstance* inst, QuestEventID event_id);
 	bool BotHasQuestSub(QuestEventID event_id);
 	bool MercHasQuestSub(QuestEventID event_id);
+	QuestZoneConfig::Config LoadZoneConfig(uint32 version, const char * short_name);
 
 	int EventNPC(
 		QuestEventID event_id,

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -220,9 +220,14 @@ Mob* QuestManager::spawn2(int npc_id, int grid, int unused, const glm::vec4& pos
 	const NPCType* t = 0;
 	if (t = content_db.LoadNPCTypesData(npc_id)) {
 		auto npc = new NPC(t, nullptr, position, GravityBehavior::Water);
-		npc->AddLootTable();
-		if (npc->DropsGlobalLoot()) {
-			npc->CheckGlobalLootTables();
+
+		if(zone->GetQuestConfig()->disable_private_loot == false) {
+			npc->AddLootTable();
+		}
+		if(zone->GetQuestConfig()->disable_global_loot == false) {
+			if (npc->DropsGlobalLoot()) {
+				npc->CheckGlobalLootTables();
+			}
 		}
 
 		entity_list.AddNPC(npc, true, true);
@@ -255,9 +260,16 @@ Mob* QuestManager::unique_spawn(int npc_type, int grid, int unused, const glm::v
 	if (tmp = content_db.LoadNPCTypesData(npc_type))
 	{
 		auto npc = new NPC(tmp, nullptr, position, GravityBehavior::Water);
-		npc->AddLootTable();
-		if (npc->DropsGlobalLoot())
-			npc->CheckGlobalLootTables();
+
+		if(zone->GetQuestConfig()->disable_private_loot == false) {
+			npc->AddLootTable();
+		}
+		if(zone->GetQuestConfig()->disable_global_loot == false) {
+			if (npc->DropsGlobalLoot()) {
+				npc->CheckGlobalLootTables();
+			}
+		}
+
 		entity_list.AddNPC(npc,true,true);
 		if(grid > 0)
 		{
@@ -337,10 +349,16 @@ Mob *QuestManager::spawn_from_spawn2(uint32 spawn2_id)
 		auto npc = new NPC(tmp, found_spawn, position, GravityBehavior::Water);
 
 		found_spawn->SetNPCPointer(npc);
-		npc->AddLootTable();
-		if (npc->DropsGlobalLoot()) {
-			npc->CheckGlobalLootTables();
+
+		if(zone->GetQuestConfig()->disable_private_loot == false) {
+			npc->AddLootTable();
 		}
+		if(zone->GetQuestConfig()->disable_global_loot == false) {
+			if (npc->DropsGlobalLoot()) {
+				npc->CheckGlobalLootTables();
+			}
+		}
+
 		npc->SetSpawnGroupId(found_spawn->SpawnGroupID());
 		entity_list.AddNPC(npc);
 		entity_list.LimitAddNPC(npc);
@@ -2085,9 +2103,16 @@ void QuestManager::respawn(int npcTypeID, int grid) {
 	if ((npcType = content_db.LoadNPCTypesData(npcTypeID)))
 	{
 		owner = new NPC(npcType, nullptr, owner->GetPosition(), GravityBehavior::Water);
-		owner->CastToNPC()->AddLootTable();
-		if (owner->CastToNPC()->DropsGlobalLoot())
-			owner->CastToNPC()->CheckGlobalLootTables();
+
+		if(zone->GetQuestConfig()->disable_private_loot == false) {
+			owner->CastToNPC()->AddLootTable();
+		}
+		if(zone->GetQuestConfig()->disable_global_loot == false) {
+			if (owner->CastToNPC()->DropsGlobalLoot()) {
+				owner->CastToNPC()->CheckGlobalLootTables();
+			}
+		}
+
 		entity_list.AddNPC(owner->CastToNPC(),true,true);
 		if(grid > 0)
 			owner->CastToNPC()->AssignWaypoints(grid);
@@ -4569,10 +4594,13 @@ void QuestManager::SpawnCircle(uint32 npc_id, glm::vec4 position, float radius, 
 
 		n->FixZ();
 
-		n->AddLootTable();
-
-		if (n->DropsGlobalLoot()) {
-			n->CheckGlobalLootTables();
+		if(zone->GetQuestConfig()->disable_private_loot == false) {
+			n->AddLootTable();
+		}
+		if(zone->GetQuestConfig()->disable_global_loot == false) {
+			if (n->DropsGlobalLoot()) {
+				n->CheckGlobalLootTables();
+			}
 		}
 
 		entity_list.AddNPC(n, true, true);
@@ -4612,10 +4640,13 @@ void QuestManager::SpawnGrid(uint32 npc_id, glm::vec4 position, float spacing, u
 
 			n->FixZ();
 
-			n->AddLootTable();
-
-			if (n->DropsGlobalLoot()) {
-				n->CheckGlobalLootTables();
+			if(zone->GetQuestConfig()->disable_private_loot == false) {
+				n->AddLootTable();
+			}
+			if(zone->GetQuestConfig()->disable_global_loot == false) {
+				if (n->DropsGlobalLoot()) {
+					n->CheckGlobalLootTables();
+				}
 			}
 
 			entity_list.AddNPC(n, true, true);

--- a/zone/spawn2.h
+++ b/zone/spawn2.h
@@ -33,7 +33,7 @@ public:
 		float x, float y, float z, float heading,
 		uint32 respawn, uint32 variance,
 		uint32 timeleft = 0, uint32 grid = 0, bool in_path_when_zone_idle=false,
-		uint16 cond_id = SC_AlwaysEnabled, int16 min_value = 0, bool in_enabled = true, EmuAppearance anim = eaStanding);
+		uint16 cond_id = SC_AlwaysEnabled, int16 min_value = 0, bool in_enabled = true, EmuAppearance anim = eaStanding, bool in_disable_private_loot=false, bool in_disable_global_loot=false);
 	~Spawn2();
 
 	void	LoadGrid(int start_wp = 0);
@@ -81,6 +81,8 @@ public:
 	inline void SetResumedNPCID(uint32 npc_id) { m_resumed_npc_id = npc_id; }
 	inline void SetStoredLocation(const glm::vec4& loc) { m_stored_location = loc; }
 
+	bool    PrivateLootEnabled() const { return !disable_private_loot; }
+	bool    GlobalLootEnabled() const { return !disable_global_loot; }
 protected:
 	friend class Zone;
 	Timer	timer;
@@ -110,6 +112,8 @@ private:
 	uint32 m_resumed_npc_id = 0;
 	std::map<std::string, std::string> m_entity_variables = {};
 	glm::vec4 m_stored_location = {0, 0, -1000, 0}; // use -1000 to indicate unset/zero-state
+	bool    disable_private_loot;
+	bool    disable_global_loot;
 };
 
 class SpawnCondition {

--- a/zone/spawngroup.cpp
+++ b/zone/spawngroup.cpp
@@ -165,6 +165,9 @@ void SpawnGroupList::ClearSpawnGroups()
 
 bool ZoneDatabase::LoadSpawnGroups(const char *zone_name, uint16 version, SpawnGroupList *spawn_group_list)
 {
+	auto quest_config = zone->GetQuestConfig();
+	version = quest_config->template_version;
+
 	std::string query = fmt::format(
 		SQL(
 			SELECT

--- a/zone/trap.cpp
+++ b/zone/trap.cpp
@@ -171,9 +171,14 @@ void Trap::Trigger(Mob* trigger)
 					auto randomOffset = glm::vec4(zone->random.Int(-5, 5),zone->random.Int(-5, 5),zone->random.Int(-5, 5), zone->random.Int(0, 249));
 					auto spawnPosition = randomOffset + glm::vec4(m_Position, 0.0f);
 					auto new_npc = new NPC(tmp, nullptr, spawnPosition, GravityBehavior::Flying);
-					new_npc->AddLootTable();
-					if (new_npc->DropsGlobalLoot())
-						new_npc->CheckGlobalLootTables();
+					if(zone->GetQuestConfig()->disable_private_loot == false) {
+						new_npc->AddLootTable();
+					}
+					if(zone->GetQuestConfig()->disable_global_loot == false) {
+						if (new_npc->DropsGlobalLoot()) {
+							new_npc->CheckGlobalLootTables();
+						}
+					}
 					entity_list.AddNPC(new_npc);
 					new_npc->AddToHateList(trigger,1);
 				}
@@ -196,9 +201,14 @@ void Trap::Trigger(Mob* trigger)
 					auto randomOffset = glm::vec4(zone->random.Int(-2, 2), zone->random.Int(-2, 2), zone->random.Int(-2, 2), zone->random.Int(0, 249));
 					auto spawnPosition = randomOffset + glm::vec4(m_Position, 0.0f);
 					auto new_npc = new NPC(tmp, nullptr, spawnPosition, GravityBehavior::Flying);
-					new_npc->AddLootTable();
-					if (new_npc->DropsGlobalLoot())
-						new_npc->CheckGlobalLootTables();
+					if(zone->GetQuestConfig()->disable_private_loot == false) {
+						new_npc->AddLootTable();
+					}
+					if(zone->GetQuestConfig()->disable_global_loot == false) {
+						if (new_npc->DropsGlobalLoot()) {
+							new_npc->CheckGlobalLootTables();
+						}
+					}
 					entity_list.AddNPC(new_npc);
 					new_npc->AddToHateList(trigger,1);
 				}
@@ -452,6 +462,9 @@ void EntityList::ClearTrapPointers()
 
 bool ZoneDatabase::LoadTraps(const std::string& zone_short_name, int16 instance_version)
 {
+	auto quest_config = zone->GetQuestConfig();
+	instance_version = quest_config->template_version;
+
 	const auto& l = TrapsRepository::GetWhere(
 		*this,
 		fmt::format(

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -36,6 +36,7 @@
 #include "pathfinder_interface.h"
 #include "global_loot_manager.h"
 #include "queryserv.h"
+#include "zone_config.h"
 #include "../common/discord/discord.h"
 #include "../common/repositories/dynamic_zone_templates_repository.h"
 #include "../common/repositories/npc_faction_repository.h"
@@ -485,6 +486,8 @@ public:
 	static void ClearZoneState(uint32 zone_id, uint32 instance_id);
 	void ReloadMaps();
 
+	QuestZoneConfig::Config *GetQuestConfig() { return &quest_config; };
+
 private:
 	bool      allow_mercs;
 	bool      can_bind;
@@ -535,6 +538,7 @@ private:
 	Timer                               initgrids_timer;
 	Timer                               qglobal_purge_timer;
 	ZoneSpellsBlocked                   *blocked_spells;
+	QuestZoneConfig::Config             quest_config;
 
 	// Factions
 	std::vector<NpcFactionRepository::NpcFaction>                 m_npc_factions         = { };

--- a/zone/zone_config.h
+++ b/zone/zone_config.h
@@ -19,6 +19,7 @@
 #define __ZoneConfig_H
 
 #include "../common/eqemu_config.h"
+#include "../common/json/json.hpp"
 
 class ZoneConfig : public EQEmuConfig {
 	public:
@@ -59,5 +60,22 @@ class ZoneConfig : public EQEmuConfig {
 
 	void Dump() const;
 };
+
+namespace QuestZoneConfig {
+	struct Config {
+		std::string description = "";
+		int template_version = 0;
+		bool disable_respawns = false;
+		int max_respawn_seconds = 0;
+		int default_respawn_seconds = 0;
+		bool disable_global_loot = false;
+		bool disable_private_loot = false;
+	};
+
+	Config Default(uint32 instance_version);
+
+	// https://github.com/nlohmann/json?tab=readme-ov-file#basic-usage
+	NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Config, description, template_version, disable_respawns, max_respawn_seconds, default_respawn_seconds, disable_global_loot, disable_private_loot)
+}
 
 #endif

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -1667,6 +1667,10 @@ const NPCType *ZoneDatabase::LoadNPCTypesData(uint32 npc_type_id, bool bulk_load
 
 	std::string filter = fmt::format("id = {}", npc_type_id);
 
+	auto version = zone->GetInstanceVersion();
+	auto quest_config = zone->GetQuestConfig();
+	version = quest_config->template_version;
+
 	if (bulk_load) {
 		LogDebug("Performing bulk NPC Types load");
 
@@ -1679,7 +1683,7 @@ const NPCType *ZoneDatabase::LoadNPCTypesData(uint32 npc_type_id, bool bulk_load
 				)
 			),
 			zone->GetShortName(),
-			zone->GetInstanceVersion()
+			version
 		);
 	}
 


### PR DESCRIPTION
# Description

This is a rework of a downstream feature that allows servers to spawn instance versions with custom behaviors.   An example of this being the Respawning/Non-Respawning instances seen on THJ.

With this change content creators can add support for a new instance version by simply dropping in a 'zone_config.json' file in the appropriate location:

```
quests/zone_name/v###/zone_config.json
quests/global/v###/zone_config.json
quests/zone_name/zone_config.json
quests/global/zone_config.json
```

An example of the zone_config.json is:

```
{
    "description": "",
    "template_version": 0,
    "disable_respawns": false,
    "max_respawn_seconds": 0,
    "disable_private_loot": false,
    "disable_global_loot": false
}
```

### template_version

By default versioned instances use that version number to lookup information in the database pertaining to spawning enemies, traps, doors, etc.  This field allows a versioned instance to override this behavior and use the data from another version instead.  This is usually set to '0' to force versioned instances to load the same data as the open world zone.

### disable_respawns

Changes the default respawn timer of npcs to some high value

### max_respawn_seconds

Prevents spawning of npcs that have a respawn value >= this setting.

### disable_private_loot/disable_global_loot

Disable loot tables for new spawns

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Testing

Akk-stack and RoF2 client

## Check open world for regressions

-Spawns/doors/traps are present
![image](https://github.com/user-attachments/assets/c580a903-b858-4fa7-bd93-8c684dd72227)

-Enemies spawning with loot
![image](https://github.com/user-attachments/assets/5e179251-9c0a-4041-8f45-e13a75572b09)

-Respawn times normal
![image](https://github.com/user-attachments/assets/8c48a617-f73d-4f5b-9016-24131a300241)

## Testing zone_config.json

-Checking zone_config.json not present
Same results as template_version 255 below.

-Verifying template_version behavior
Value: 255
![image](https://github.com/user-attachments/assets/6b7b383c-6153-4f0f-a5f9-69504529f0ca)

Value: 0
![image](https://github.com/user-attachments/assets/1b946cfe-8d36-4af0-b5de-f4f33bce80d6)

-Verifying 'disable_respawns: true'
![image](https://github.com/user-attachments/assets/68b30e5d-7814-4375-a6d0-c19e460f2c75)

-Verifying 'max_respawn_seconds: 0'
![image](https://github.com/user-attachments/assets/909593f4-0655-45ef-b094-fa29f5d33714)

-Verifying 'max_respawn_seconds: 7200'
Spawn disabled

-Verifying 'disable_private_loot:false'
![image](https://github.com/user-attachments/assets/af9de9c1-c51b-41b5-9b18-7a7592276961)

-Verifying 'disable_private_loot: true'
![image](https://github.com/user-attachments/assets/1f10c0e8-cc06-49c2-bde7-a3064d525f35)
No reports of loot being added to enemies

-Verifying 'disable_global_loot: false'
![image](https://github.com/user-attachments/assets/d7333382-4fac-4469-9009-1845ef9bb9df)

-Verifying 'disable_global_loot: true'
No global loot observed after 10 repop cycles.

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
