### PR TITLE
[Cleanup] Update link for legacy EQEmu loginserver account setup

### DIFF
--- a/world/login_server.cpp
+++ b/world/login_server.cpp
@@ -286,7 +286,7 @@ void LoginServer::ProcessLSFatalError(uint16_t opcode, EQ::Net::Packet &p)
 	if (error.find("Worldserver Account / Password INVALID") != std::string::npos) {
 		reason = "Usually this indicates you do not have a valid [account] and [password] (worldserver) account associated with your loginserver configuration. ";
 		if (fmt::format("{}", m_loginserver_address).find("login.eqemulator.net") != std::string::npos) {
-			reason += "For Legacy EQEmulator connections, you need to register your server @ http://www.eqemulator.org/account/?LS";
+			reason += "For Legacy EQEmulator connections, you need to register your server @ https://www.eqemulator.org/index.php?pageid=ws_mgmt";
 		}
 	}
 


### PR DESCRIPTION
# Description

When connecting to the legacy EQEmu loginserver, an error is displayed with wrong username/password:
`World | Info | ProcessLSFatalError Login server [login.eqemulator.net:5998] responded with fatal error [Worldserver Account / Password INVALID.��U] Usually this indicates you do not have a valid [account] and [password] (worldserver) account associated with your loginserver configuration. For Legacy EQEmulator connections, you need to register your server @ http://www.eqemulator.org/account/?LS`

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

None. Basic text change

Clients tested: N/A

# Checklist

- [ ] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur