### PR TITLE
[Fix] Bazaar Search window not working in a DZ

### DIFF
--- a/common/repositories/trader_repository.h
+++ b/common/repositories/trader_repository.h
@@ -54,17 +54,31 @@ public:
 	{
 		BulkTraders_Struct                  all_entries{};
 		std::vector<DistinctTraders_Struct> distinct_traders;
+		MySQLRequestResult                  results;
 
-		auto results = db.QueryDatabase(fmt::format(
-			"SELECT DISTINCT(t.char_id), t.char_zone_id, t.char_zone_instance_id, t.char_entity_id, c.name "
-			"FROM trader AS t "
-			"JOIN character_data AS c ON t.char_id = c.id "
-			"WHERE t.char_zone_instance_id = {} "
-			"ORDER BY t.char_zone_instance_id ASC "
-			"LIMIT {}",
-			char_zone_instance_id,
-			max_results)
-		);
+		if (RuleB(Bazaar, UseAlternateBazaarSearch)) {
+			results = db.QueryDatabase(fmt::format(
+				"SELECT DISTINCT(t.char_id), t.char_zone_id, t.char_zone_instance_id, t.char_entity_id, c.name "
+				"FROM trader AS t "
+				"JOIN character_data AS c ON t.char_id = c.id "
+				"WHERE t.char_zone_instance_id = {} "
+				"ORDER BY t.char_zone_instance_id ASC "
+				"LIMIT {}",
+				char_zone_instance_id,
+				max_results)
+			);
+		}
+		else {
+			results = db.QueryDatabase(fmt::format(
+				"SELECT DISTINCT(t.char_id), t.char_zone_id, t.char_zone_instance_id, t.char_entity_id, c.name "
+				"FROM trader AS t "
+				"JOIN character_data AS c ON t.char_id = c.id "
+				"ORDER BY t.char_zone_instance_id ASC "
+				"LIMIT {}",
+				char_zone_instance_id,
+				max_results)
+			);
+		}
 
 		distinct_traders.reserve(results.RowCount());
 

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -2739,8 +2739,6 @@ void Client::SendBulkBazaarTraders()
 
 	SetTraderCount(results.count);
 
-	SetTraderCount(results.count);
-
 	auto  p_size  = 4 + 12 * results.count + results.name_length;
 	auto  buffer  = std::make_unique<char[]>(p_size);
 	memset(buffer.get(), 0, p_size);


### PR DESCRIPTION
# Description
When the Bazaar:UseAlternateBazaarSearch was set to false, the bazaar window would not function when within a DZ.  The window would function if not in a DZ, or if the rule was true.

Also removed a redundant line.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
Tested with a player in fhalls LDON

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
