### PR TITLE
[Fix] Add the bazaar search limit to query

### DIFF
--- a/common/bazaar.cpp
+++ b/common/bazaar.cpp
@@ -279,7 +279,8 @@ Bazaar::GetSearchResults(
 		trader_items_ids,
 		std::string(search.item_name),
 		field_criteria_items,
-		where_criteria_items
+		where_criteria_items,
+		search.max_results
 	);
 
 	if (item_results.empty()) {


### PR DESCRIPTION
# Description
The Bazaar search window has a query limit 'max results'.  This was applied to the result set.

There is an opportunity to apply directly to the query to limit the query itself.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
Tested with a trader and watching the query results.

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
