### PR TITLE
[Crash] Fix Exception Crash issue in PlayerEventLogs::ProcessBatchQueue

### DIFF
--- a/common/events/player_event_logs.cpp
+++ b/common/events/player_event_logs.cpp
@@ -81,7 +81,7 @@ void PlayerEventLogs::Init()
 	if (!settings_to_insert.empty()) {
 		PlayerEventLogSettingsRepository::ReplaceMany(*m_database, settings_to_insert);
 	}
-	
+
 	bool processing_in_world = !RuleB(Logging, PlayerEventsQSProcess) && IsWorld();
 	bool processing_in_qs    = RuleB(Logging, PlayerEventsQSProcess) && IsQueryServ();
 
@@ -181,9 +181,17 @@ void PlayerEventLogs::ProcessBatchQueue()
 
 	// Helper to deserialize event data
 	auto Deserialize = [](const std::string &data, auto &out) {
-		std::stringstream        ss(data);
-		cereal::JSONInputArchive ar(ss);
-		out.serialize(ar);
+		if (!Strings::IsValidJson(data)) {
+			return;
+		}
+
+		// cpp exceptions are terrible, don't ever use them
+		try {
+			std::stringstream        ss(data);
+			cereal::JSONInputArchive ar(ss);
+			out.serialize(ar);
+		}
+		catch (const std::exception &e) {}
 	};
 
 	// Helper to assign ETL table ID


### PR DESCRIPTION
# Description

Fixes a rarer exception crash issue in PlayerEventLogs::ProcessBatchQueue that is caused from malformed JSON.

We now defensively check if the string is valid JSON before parsing and now try/catch around the offending code that would throw the exception to begin with.

Appeared on PEQ but was not an obvious crash at all. The crash looks like main thread is hanging and the "lock" happens on another thread which is the player event log processor thread.

**Crash Report | Server [[PEQ] The Grand Creation | Dragons of Norrath] File [crash_world_901147.log]** **Chunk** [1]
```bash
[New LWP 901148]
[New LWP 901149]
[New LWP 901150]
[New LWP 901151]
[New LWP 901152]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
0x00007f1217d50ea6 in epoll_wait (epfd=3, events=events@entry=0x7ffc43b292c0, maxevents=maxevents@entry=1024, timeout=timeout@entry=16) at ../sysdeps/unix/sysv/linux/epoll_wait.c:30
[Current thread is 1 (Thread 0x7f1217c246c0 (LWP 901147))]
#0  0x00007f1217d50ea6 in epoll_wait (epfd=3, events=events@entry=0x7ffc43b292c0, maxevents=maxevents@entry=1024, timeout=timeout@entry=16) at ../sysdeps/unix/sysv/linux/epoll_wait.c:30
#1  0x000055df64518b74 in uv__io_poll (loop=loop@entry=0x7f1217c017c8, timeout=<optimized out>) at /home/eqemu/code/submodules/libuv/src/unix/epoll.c:236
#2  0x000055df6450bca5 in uv_run (loop=0x7f1217c017c8, mode=UV_RUN_DEFAULT) at /home/eqemu/code/submodules/libuv/src/unix/core.c:406
#3  0x000055df640884ae in EQ::EventLoop::Run (this=<optimized out>) at /home/eqemu/code/world/../common/event/event_loop.h:25
#4  main (argc=<optimized out>, argv=<optimized out>) at /home/eqemu/code/world/main.cpp:507
[Inferior 1 (process 901147) detached]

```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Not able to test. It will bake on PEQ

# Checklist

- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
