### PR TITLE
[Performance] Store Player Title Sets in Client Memory

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -1100,6 +1100,7 @@ bool Client::Save(uint8 iCommitNow) {
 	database.SaveCharacterData(this, &m_pp, &m_epp); /* Save Character Data */
 
 	database.SaveCharacterEXPModifier(this);
+	database.SaveCharacterTitleSets(this);
 
 	if (RuleB(Bots, Enabled)) {
 		database.botdb.SaveBotSettings(this);

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -1100,7 +1100,6 @@ bool Client::Save(uint8 iCommitNow) {
 	database.SaveCharacterData(this, &m_pp, &m_epp); /* Save Character Data */
 
 	database.SaveCharacterEXPModifier(this);
-	database.SaveCharacterTitleSets(this);
 
 	if (RuleB(Bots, Enabled)) {
 		database.botdb.SaveBotSettings(this);

--- a/zone/client.h
+++ b/zone/client.h
@@ -1253,7 +1253,9 @@ public:
 	void ResetAllCastbarCooldowns();
 	void ResetCastbarCooldownBySpellID(uint32 spell_id);
 
+	void AddTitle(PlayerTitlesetsRepository::PlayerTitlesets e) { m_player_title_sets.emplace_back(e); }
 	bool CheckTitle(int titleset);
+	const std::vector<PlayerTitlesetsRepository::PlayerTitlesets>& GetTitles() { return m_player_title_sets; };
 	void EnableTitle(int titleset);
 	void RemoveTitle(int titleset);
 
@@ -2255,6 +2257,7 @@ private:
 	bool m_exp_enabled;
 
 	std::vector<EXPModifier> m_exp_modifiers;
+	std::vector<PlayerTitlesetsRepository::PlayerTitlesets> m_player_title_sets;
 
 	//Anti Spam Stuff
 	Timer *KarmaUpdateTimer;

--- a/zone/client.h
+++ b/zone/client.h
@@ -73,6 +73,7 @@ namespace EQ
 #include "../common/guild_base.h"
 #include "../common/repositories/buyer_buy_lines_repository.h"
 #include "../common/repositories/character_evolving_items_repository.h"
+#include "../common/repositories/player_titlesets_repository.h"
 
 #include "bot_structs.h"
 

--- a/zone/client.h
+++ b/zone/client.h
@@ -1253,11 +1253,10 @@ public:
 	void ResetAllCastbarCooldowns();
 	void ResetCastbarCooldownBySpellID(uint32 spell_id);
 
-	void AddTitle(PlayerTitlesetsRepository::PlayerTitlesets e, bool insert = true);
-	bool CheckTitle(int titleset);
+	bool CheckTitle(int title_set);
+	void EnableTitle(int title_set, bool insert = true);
 	const std::vector<PlayerTitlesetsRepository::PlayerTitlesets>& GetTitles() { return m_player_title_sets; };
-	void EnableTitle(int titleset);
-	void RemoveTitle(int titleset);
+	void RemoveTitle(int title_set);
 
 	void EnteringMessages(Client* client);
 	void SendRules();

--- a/zone/client.h
+++ b/zone/client.h
@@ -1253,7 +1253,7 @@ public:
 	void ResetAllCastbarCooldowns();
 	void ResetCastbarCooldownBySpellID(uint32 spell_id);
 
-	void AddTitle(PlayerTitlesetsRepository::PlayerTitlesets e);
+	void AddTitle(PlayerTitlesetsRepository::PlayerTitlesets e, bool insert);
 	bool CheckTitle(int titleset);
 	const std::vector<PlayerTitlesetsRepository::PlayerTitlesets>& GetTitles() { return m_player_title_sets; };
 	void EnableTitle(int titleset);

--- a/zone/client.h
+++ b/zone/client.h
@@ -1253,7 +1253,7 @@ public:
 	void ResetAllCastbarCooldowns();
 	void ResetCastbarCooldownBySpellID(uint32 spell_id);
 
-	void AddTitle(PlayerTitlesetsRepository::PlayerTitlesets e) { m_player_title_sets.emplace_back(e); }
+	void AddTitle(PlayerTitlesetsRepository::PlayerTitlesets e);
 	bool CheckTitle(int titleset);
 	const std::vector<PlayerTitlesetsRepository::PlayerTitlesets>& GetTitles() { return m_player_title_sets; };
 	void EnableTitle(int titleset);

--- a/zone/client.h
+++ b/zone/client.h
@@ -1253,7 +1253,7 @@ public:
 	void ResetAllCastbarCooldowns();
 	void ResetCastbarCooldownBySpellID(uint32 spell_id);
 
-	void AddTitle(PlayerTitlesetsRepository::PlayerTitlesets e, bool insert);
+	void AddTitle(PlayerTitlesetsRepository::PlayerTitlesets e, bool insert = true);
 	bool CheckTitle(int titleset);
 	const std::vector<PlayerTitlesetsRepository::PlayerTitlesets>& GetTitles() { return m_player_title_sets; };
 	void EnableTitle(int titleset);

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1350,6 +1350,7 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 	database.LoadCharacterLeadershipAbilities(cid, &m_pp); /* Load Character Leadership AA's */
 	database.LoadCharacterTribute(this); /* Load CharacterTribute */
 	database.LoadCharacterEXPModifier(this); /* Load Character EXP Modifier */
+	database.LoadCharacterTitleSets(this);
 
 	// this pattern is strange
 	// this is remnants of the old way of doing things

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1350,7 +1350,7 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 	database.LoadCharacterLeadershipAbilities(cid, &m_pp); /* Load Character Leadership AA's */
 	database.LoadCharacterTribute(this); /* Load CharacterTribute */
 	database.LoadCharacterEXPModifier(this); /* Load Character EXP Modifier */
-	database.LoadCharacterTitleSets(this);
+	database.LoadCharacterTitleSets(this); /* Load Character Title Sets */
 
 	// this pattern is strange
 	// this is remnants of the old way of doing things

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -1094,8 +1094,8 @@ int lua_faction_value() {
 	return quest_manager.FactionValue();
 }
 
-void lua_check_title(uint32 title_set) {
-	quest_manager.checktitle(title_set);
+bool lua_check_title(uint32 title_set) {
+	return quest_manager.checktitle(title_set);
 }
 
 void lua_enable_title(uint32 title_set) {

--- a/zone/titles.cpp
+++ b/zone/titles.cpp
@@ -326,6 +326,13 @@ void Client::EnableTitle(int title_set)
 	}
 
 	m_player_title_sets.emplace_back(e);
+	database.SaveCharacterTitleSets(this);
+}
+
+void Client::AddTitle(PlayerTitlesetsRepository::PlayerTitlesets e)
+{
+	m_player_title_sets.emplace_back(e);
+	database.SaveCharacterTitleSets(this);
 }
 
 bool Client::CheckTitle(int title_set)

--- a/zone/titles.cpp
+++ b/zone/titles.cpp
@@ -328,14 +328,16 @@ void Client::EnableTitle(int title_set)
 	m_player_title_sets.emplace_back(e);
 }
 
-void Client::AddTitle(PlayerTitlesetsRepository::PlayerTitlesets e)
+void Client::AddTitle(PlayerTitlesetsRepository::PlayerTitlesets e, bool insert)
 {
 	m_player_title_sets.emplace_back(e);
 
-	e = PlayerTitlesetsRepository::InsertOne(database, e);
-	if (!e.id) {
-		LogError("Error in AddTitle query for titleset [{}] and charid [{}]", e.title_set, CharacterID());
-		return;
+	if (insert) {
+		e = PlayerTitlesetsRepository::InsertOne(database, e);
+		if (!e.id) {
+			LogError("Error in AddTitle query for titleset [{}] and charid [{}]", e.title_set, CharacterID());
+			return;
+		}
 	}
 }
 

--- a/zone/titles.cpp
+++ b/zone/titles.cpp
@@ -308,7 +308,7 @@ void Client::SetTitleSuffix(std::string suffix)
 	safe_delete(outapp);
 }
 
-void Client::EnableTitle(int title_set)
+void Client::EnableTitle(int title_set, bool insert)
 {
 	if (CheckTitle(title_set)) {
 		return;
@@ -319,26 +319,15 @@ void Client::EnableTitle(int title_set)
 	e.char_id   = CharacterID();
 	e.title_set = title_set;
 
-	e = PlayerTitlesetsRepository::InsertOne(database, e);
-	if (!e.id) {
-		LogError("Error in EnableTitle query for titleset [{}] and charid [{}]", title_set, CharacterID());
-		return;
-	}
-
-	m_player_title_sets.emplace_back(e);
-}
-
-void Client::AddTitle(PlayerTitlesetsRepository::PlayerTitlesets e, bool insert)
-{
-	m_player_title_sets.emplace_back(e);
-
 	if (insert) {
 		e = PlayerTitlesetsRepository::InsertOne(database, e);
 		if (!e.id) {
-			LogError("Error in AddTitle query for titleset [{}] and charid [{}]", e.title_set, CharacterID());
+			LogError("Error in EnableTitle query for titleset [{}] and charid [{}]", title_set, CharacterID());
 			return;
 		}
 	}
+
+	m_player_title_sets.emplace_back(e);
 }
 
 bool Client::CheckTitle(int title_set)

--- a/zone/titles.cpp
+++ b/zone/titles.cpp
@@ -325,12 +325,12 @@ void Client::EnableTitle(int title_set)
 		return;
 	}
 
-	zone->player_title_sets[CharacterID()].emplace_back(e);
+	m_player_title_sets.emplace_back(e);
 }
 
 bool Client::CheckTitle(int title_set)
 {
-	for (const auto& e : zone->player_title_sets[CharacterID()]) {
+	for (const auto& e : m_player_title_sets) {
 		if (e.title_set == title_set) {
 			return true;
 		}
@@ -359,7 +359,7 @@ void Client::RemoveTitle(int title_set)
 		}
 	}
 
-	auto& titles = zone->player_title_sets[CharacterID()];
+	auto& titles = m_player_title_sets;
 	for (auto e = titles.begin(); e != titles.end(); e++) {
 		if (e->title_set == title_set) {
 			titles.erase(e);

--- a/zone/titles.cpp
+++ b/zone/titles.cpp
@@ -326,13 +326,17 @@ void Client::EnableTitle(int title_set)
 	}
 
 	m_player_title_sets.emplace_back(e);
-	database.SaveCharacterTitleSets(this);
 }
 
 void Client::AddTitle(PlayerTitlesetsRepository::PlayerTitlesets e)
 {
 	m_player_title_sets.emplace_back(e);
-	database.SaveCharacterTitleSets(this);
+
+	e = PlayerTitlesetsRepository::InsertOne(database, e);
+	if (!e.id) {
+		LogError("Error in AddTitle query for titleset [{}] and charid [{}]", e.title_set, CharacterID());
+		return;
+	}
 }
 
 bool Client::CheckTitle(int title_set)

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -49,6 +49,7 @@
 #include "../common/repositories/skill_caps_repository.h"
 #include "../common/repositories/zone_state_spawns_repository.h"
 #include "../common/repositories/spawn2_disabled_repository.h"
+#include "../common/repositories/player_titlesets_repository.h"
 
 struct EXPModifier
 {
@@ -248,6 +249,8 @@ public:
 	std::unordered_map<uint32, DynamicZoneTemplatesRepository::DynamicZoneTemplates> dz_template_cache;
 
 	std::unordered_map<uint32, EXPModifier> exp_modifiers;
+
+	std::unordered_map<uint32, std::vector<PlayerTitlesetsRepository::PlayerTitlesets>> player_title_sets;
 
 	std::vector<uint32> discovered_items;
 

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -250,8 +250,6 @@ public:
 
 	std::unordered_map<uint32, EXPModifier> exp_modifiers;
 
-	std::unordered_map<uint32, std::vector<PlayerTitlesetsRepository::PlayerTitlesets>> player_title_sets;
-
 	std::vector<uint32> discovered_items;
 
 	std::map<std::string, std::string> m_zone_variables;

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -4271,3 +4271,37 @@ void ZoneDatabase::SaveCharacterEXPModifier(Client* c)
 		}
 	);
 }
+
+void ZoneDatabase::LoadCharacterTitleSets(Client* c)
+{
+	if (!zone || !c) {
+		return;
+	}
+
+	const auto& l = PlayerTitlesetsRepository::GetWhere(
+		*this,
+		fmt::format(
+			"`char_id` = {}",
+			c->CharacterID()
+		)
+	);
+
+	if (l.empty()) {
+		return;
+	}
+
+	const uint32 character_id = c->CharacterID();
+
+	for (const auto& e : l) {
+		zone->player_title_sets[character_id].emplace_back(e);
+	}
+}
+
+void ZoneDatabase::SaveCharacterTitleSets(Client* c)
+{
+	if (!zone) {
+		return;
+	}
+
+	PlayerTitlesetsRepository::ReplaceMany(*this, zone->player_title_sets[c->CharacterID()]);
+}

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -4299,7 +4299,7 @@ void ZoneDatabase::LoadCharacterTitleSets(Client* c)
 
 void ZoneDatabase::SaveCharacterTitleSets(Client* c)
 {
-	if (!zone || !c) {
+	if (!zone || !c || c->GetTitles().empty()) {
 		return;
 	}
 

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -4293,7 +4293,7 @@ void ZoneDatabase::LoadCharacterTitleSets(Client* c)
 	const uint32 character_id = c->CharacterID();
 
 	for (const auto& e : l) {
-		c->AddTitle(e);
+		c->AddTitle(e, false);
 	}
 }
 

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -4293,15 +4293,6 @@ void ZoneDatabase::LoadCharacterTitleSets(Client* c)
 	const uint32 character_id = c->CharacterID();
 
 	for (const auto& e : l) {
-		c->AddTitle(e, false);
+		c->EnableTitle(e.title_set, false);
 	}
-}
-
-void ZoneDatabase::SaveCharacterTitleSets(Client* c)
-{
-	if (!zone || !c || c->GetTitles().empty()) {
-		return;
-	}
-
-	PlayerTitlesetsRepository::ReplaceMany(*this, c->GetTitles());
 }

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -4293,15 +4293,15 @@ void ZoneDatabase::LoadCharacterTitleSets(Client* c)
 	const uint32 character_id = c->CharacterID();
 
 	for (const auto& e : l) {
-		zone->player_title_sets[character_id].emplace_back(e);
+		c->AddTitle(e);
 	}
 }
 
 void ZoneDatabase::SaveCharacterTitleSets(Client* c)
 {
-	if (!zone) {
+	if (!zone || !c) {
 		return;
 	}
 
-	PlayerTitlesetsRepository::ReplaceMany(*this, zone->player_title_sets[c->CharacterID()]);
+	PlayerTitlesetsRepository::ReplaceMany(*this, c->GetTitles());
 }

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -466,7 +466,6 @@ public:
 
 	/* Player Title Sets */
 	void LoadCharacterTitleSets(Client* c);
-	void SaveCharacterTitleSets(Client *c);
 
 	float GetAAEXPModifierByCharID(uint32 character_id, uint32 zone_id, int16 instance_version = -1);
 	float GetEXPModifierByCharID(uint32 character_id, uint32 zone_id, int16 instance_version = -1);

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -464,6 +464,10 @@ public:
 	void LoadCharacterEXPModifier(Client* c);
 	void SaveCharacterEXPModifier(Client *c);
 
+	/* Player Title Sets */
+	void LoadCharacterTitleSets(Client* c);
+	void SaveCharacterTitleSets(Client *c);
+
 	float GetAAEXPModifierByCharID(uint32 character_id, uint32 zone_id, int16 instance_version = -1);
 	float GetEXPModifierByCharID(uint32 character_id, uint32 zone_id, int16 instance_version = -1);
 	void SetAAEXPModifierByCharID(uint32 character_id, uint32 zone_id, float aa_modifier, int16 instance_version = -1);


### PR DESCRIPTION
# Description
- Stores player title sets in client memory, loading them when a player zones in, instead of having an individual query per title.
- Testing shows no queries being ran, but server is aware the player has the proper title sets.

## Type of change
- [X] New feature

# Testing
![image](https://github.com/user-attachments/assets/4ccef7ea-0a67-4cd7-8adc-e8658d9c8303)
![image](https://github.com/user-attachments/assets/6b7ca1d4-9d45-4cf5-8613-cd987b514b05)
![image](https://github.com/user-attachments/assets/dbe4e9b8-630d-4708-b3cf-1199a809190e)

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur