### PR TITLE
[Fix] Regression in World SendEmoteMessageRaw

### DIFF
--- a/world/zonelist.cpp
+++ b/world/zonelist.cpp
@@ -912,8 +912,9 @@ bool ZSList::SendPacketToZonesWithGuild(uint32 guild_id, ServerPacket* pack)
 
 bool ZSList::SendPacketToZonesWithGMs(ServerPacket* pack)
 {
+	auto servers = client_list.GetZoneServersWithGMs();
 	for (auto const &z: zone_server_list) {
-		for (auto const &server_id: client_list.GetZoneServersWithGMs()) {
+		for (auto const &server_id: servers) {
 			if (z->GetID() == server_id && z->GetZoneID() > 0) {
 				z->SendPacket(pack);
 			}


### PR DESCRIPTION
# Description

Fix regression caused by https://github.com/EQEmu/Server/pull/4818 that otherwise originally makes significant performance gains, unintentionally caused worse pain by iterating over the entire CLE list for every zoneserver. Not only is that not great at scale, it compounds with global reload messages.

**Quick math scenario** 

* 2000 zone servers, 3,000 players
* Global reload messages (2,000) (Message for each zone)

2,000 (zone servers) x 3,000 (players) x 2000 (messages) = 12,000,000,000 (trillion iterations)

Fix by calculating the zoneservers with GM's once, not 2,000 times (for each zone server).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Tested doing a global reload

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

