### PR TITLE
[Bugfix] Fix missing timer_name check on Mob::StopTimer

### DIFF
--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -699,7 +699,7 @@ void QuestManager::stoptimer(const std::string& timer_name, Mob* m)
 	}
 
 	for (auto e = QTimerList.begin(); e != QTimerList.end(); ++e) {
-		if (e->mob && e->mob == m) {
+		if (e->mob && e->mob == m && e->name == timer_name) {
 			parse->EventMob(EVENT_TIMER_STOP, m, nullptr, [&]() { return timer_name; });
 
 			QTimerList.erase(e);


### PR DESCRIPTION
# Description

Noticed some timer events going missing, tracked it down to this bit of logic nuking timers it wasn't supposed to.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

```
function event_timer(e)                                                                                                                                                                                                                                                                           eq.debug(e.timer);
        if e.timer == "blah" then
                e.self:StopTimer("blah");
                e.self:SetTimer("blah", 1);
        end
end

function event_spawn(e)
        eq.debug("spawn");
        e.self:SetTimer("blah", 1);
        e.self:SetTimer("blah2", 5);
end
```

Before:
Second timer never triggers
![image](https://github.com/user-attachments/assets/65f0bd3f-ce1d-476f-99b6-c4c281a158f5)

After:
Second timer triggers at expected intervals
![image](https://github.com/user-attachments/assets/665ca660-5be0-42ce-b152-1338103b72a0)


Clients tested: 

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
