### PR TITLE
[Bugfix] Prevent depops from blocking new spawns.

### DIFF
--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -3159,6 +3159,13 @@ void EntityList::Depop(bool StartSpawnTimer)
 				UpdateFindableNPCState(pnpc, true);
 			}
 
+			// Depop below will eventually remove this npc from the entity list
+			// but that can happen AFTER we've already tried to spawn its replacement.
+			// So go ahead and remove it from the limits so it doesn't count.
+			if (npc_limit_list.count(pnpc->GetID())) {
+				npc_limit_list.erase(pnpc->GetID());
+			}
+
 			pnpc->WipeHateList();
 			pnpc->Depop(StartSpawnTimer);
 		}


### PR DESCRIPTION
# Description

Was goofing around with potimeb and noticed that #repops and quest hot reloads were resulting in situations where the zone_status/zone_emote npcs were not spawned.

Digging into the problem showed that we were calling Depop on the NPC and then continuing with the rest of our reload logic.  The reload logic would then fail to spawn the replacement because spawn_limit was configured and the Depop had not yet been processed (which is what is responsible for removing the npc from the limit_list in entity.cpp).

This change goes ahead and removes the npc from the limit_list to prevent it from counting against the spawn_limit while it is still being processed for the depop.

Now normally in this scenario the respawn timer would start for the spawn but in the case of Non-Respawning instances on THJ this would be some high value and never actually happen.  This makes the behavior a bit easier to observe because on a normal zone process the npc would eventually show back up depending on its natural respawn timer, further muddying the water.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Latest master branch with rof2 client.

#repop without change
![image](https://github.com/user-attachments/assets/5132413f-3b5f-4dd3-ac9a-9e2517051872)

#repop with change
![image](https://github.com/user-attachments/assets/a0ea1423-8bfe-4ded-a33b-84c8f70d76ca)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
