### PR TITLE
[Cleanup] Remove queryserv dump flag

### DIFF
--- a/common/database/database_dump_service.h
+++ b/common/database/database_dump_service.h
@@ -65,7 +65,6 @@ private:
 	bool        dump_system_tables          = false;
 	bool        dump_content_tables         = false;
 	bool        dump_player_tables          = false;
-	bool        dump_query_server_tables    = false;
 	bool        dump_login_server_tables    = false;
 	bool        dump_with_no_data           = false;
 	bool        dump_table_lock             = false;


### PR DESCRIPTION
# Description
Since queryserv tables are deprecated, there is no longer a need to use this flag

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
Compiles with unused flag

Clients tested: N/A

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur