### PR TITLE
[Fix] Add trader/buyer cleanup actions

### DIFF
--- a/common/repositories/buyer_repository.h
+++ b/common/repositories/buyer_repository.h
@@ -106,13 +106,8 @@ public:
 				return false;
 			}
 
-			auto buy_lines = BaseBuyerBuyLinesRepository::GetWhere(
-				db,
-				fmt::format("`buyer_id` = '{}'", buyer.front().id)
-			);
-			if (buy_lines.empty()) {
-				return false;
-			}
+			auto buy_lines =
+				BaseBuyerBuyLinesRepository::GetWhere(db, fmt::format("`buyer_id` = '{}'", buyer.front().id));
 
 			std::vector<std::string> buy_line_ids{};
 			for (auto const &bl: buy_lines) {
@@ -121,20 +116,61 @@ public:
 
 			DeleteWhere(db, fmt::format("`char_id` = '{}';", char_id));
 			if (buy_line_ids.empty()) {
-				return false;
+				return true;
 			}
 
 			BaseBuyerBuyLinesRepository::DeleteWhere(
-				db,
-				fmt::format("`id` IN({})", Strings::Implode(", ", buy_line_ids))
+				db, fmt::format("`id` IN({})", Strings::Implode(", ", buy_line_ids))
 			);
 			BaseBuyerTradeItemsRepository::DeleteWhere(
-				db,
-				fmt::format(
-					"`buyer_buy_lines_id` IN({})",
-					Strings::Implode(", ", buy_line_ids))
+				db, fmt::format("`buyer_buy_lines_id` IN({})", Strings::Implode(", ", buy_line_ids))
 			);
 		}
+
+		return true;
+	}
+
+	static bool DeleteBuyers(Database &db, uint32 char_zone_id, uint32 char_zone_instance_id)
+	{
+		auto buyers = GetWhere(
+			db,
+			fmt::format(
+				"`char_zone_id` = '{}' AND `char_zone_instance_id` = '{}'", char_zone_id, char_zone_instance_id)
+		);
+		if (buyers.empty()) {
+			return false;
+		}
+
+		std::vector<std::string> buyer_ids{};
+		std::vector<std::string> buy_line_ids{};
+
+		for (auto const &b: buyers) {
+			buyer_ids.push_back(std::to_string(b.id));
+		}
+
+		auto buy_lines = BaseBuyerBuyLinesRepository::GetWhere(
+			db, fmt::format("`buyer_id` IN({})", Strings::Implode(", ", buyer_ids))
+		);
+
+		if (!buy_lines.empty()) {
+			for (auto const &bl: buy_lines) {
+				buy_line_ids.push_back(std::to_string(bl.id));
+			}
+		}
+
+		DeleteWhere(db, fmt::format("`id` IN({});", Strings::Implode(", ", buyer_ids)));
+		if (buy_line_ids.empty()) {
+			return true;
+		}
+
+		BaseBuyerBuyLinesRepository::DeleteWhere(
+			db,
+			fmt::format("`id` IN({})", Strings::Implode(", ", buy_line_ids))
+		);
+		BaseBuyerTradeItemsRepository::DeleteWhere(
+			db,
+			fmt::format("`buyer_buy_lines_id` IN({})", Strings::Implode(", ", buy_line_ids))
+		);
 
 		return true;
 	}

--- a/common/repositories/buyer_repository.h
+++ b/common/repositories/buyer_repository.h
@@ -107,7 +107,7 @@ public:
 			}
 
 			auto buy_lines =
-				BaseBuyerBuyLinesRepository::GetWhere(db, fmt::format("`buyer_id` = '{}'", buyer.front().id));
+				BaseBuyerBuyLinesRepository::GetWhere(db, fmt::format("`buyer_id` = {}", buyer.front().id));
 
 			std::vector<std::string> buy_line_ids{};
 			for (auto const &bl: buy_lines) {
@@ -135,7 +135,8 @@ public:
 		auto buyers = GetWhere(
 			db,
 			fmt::format(
-				"`char_zone_id` = '{}' AND `char_zone_instance_id` = '{}'", char_zone_id, char_zone_instance_id)
+				"`char_zone_id` = {} AND `char_zone_instance_id` = {}", char_zone_id, char_zone_instance_id
+			)
 		);
 		if (buyers.empty()) {
 			return false;

--- a/world/zonelist.cpp
+++ b/world/zonelist.cpp
@@ -85,18 +85,8 @@ void ZSList::Remove(const std::string &uuid)
 	auto iter = zone_server_list.begin();
 	while (iter != zone_server_list.end()) {
 		if ((*iter)->GetUUID().compare(uuid) == 0) {
-			auto port        = (*iter)->GetCPort();
-			auto zone_id     = (*iter)->GetZoneID();
-			auto instance_id = (*iter)->GetInstanceID();
-			if (zone_id == Zones::BAZAAR) {
-				TraderRepository::DeleteWhere(
-					database,
-					fmt::format("`char_zone_id` = '{}' AND `char_zone_instance_id` = '{}'", zone_id, instance_id)
-				);
-				BuyerRepository::DeleteBuyers(database, zone_id, instance_id);
-
-				LogTradingDetail("Removed trader abd buyer entries for Zone ID {} and Instance ID {}", zone_id, instance_id);
-			}
+			auto port = (*iter)->GetCPort();
+			(*iter)->CheckToClearTraderAndBuyerTables();
 
 			zone_server_list.erase(iter);
 

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -50,6 +50,8 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include "../common/repositories/guild_tributes_repository.h"
 #include "../common/skill_caps.h"
 #include "../common/server_reload_types.h"
+#include "../common/repositories/trader_repository.h"
+#include "../common/repositories/buyer_repository.h"
 
 extern ClientList client_list;
 extern GroupLFPList LFPGroupList;
@@ -1859,4 +1861,20 @@ void ZoneServer::IncomingClient(Client* client) {
 	strn0cpy(s->lskey, client->GetLSKey(), sizeof(s->lskey));
 	SendPacket(pack);
 	delete pack;
+}
+
+void ZoneServer::CheckToClearTraderAndBuyerTables()
+{
+	if (GetZoneID() == Zones::BAZAAR) {
+		TraderRepository::DeleteWhere(
+			database,
+			fmt::format("`char_zone_id` = {} AND `char_zone_instance_id` = {}", GetZoneID(), GetInstanceID()
+			)
+		);
+		BuyerRepository::DeleteBuyers(database, GetZoneID(), GetInstanceID());
+
+		LogTradingDetail(
+			"Removed trader and buyer entries for Zone ID [{}] and Instance ID [{}]", GetZoneID(), GetInstanceID()
+		);
+	}
 }

--- a/world/zoneserver.h
+++ b/world/zoneserver.h
@@ -54,6 +54,7 @@ public:
 	inline const char*	GetZoneName() const	{ return zone_name; }
 	inline const char*	GetZoneLongName() const	{ return long_name; }
 	inline std::string  GetCurrentVersion() const { return CURRENT_VERSION; }
+	void                CheckToClearTraderAndBuyerTables();
 	inline std::string  GetCompileDate() const { return COMPILE_DATE; }
 	const char*			GetCompileTime() const{ return compiled; }
 	void				SetCompile(char* in_compile){ strcpy(compiled,in_compile); }

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -808,6 +808,13 @@ void Client::CompleteConnect()
 
 	/* This sub event is for if a player logs in for the first time since entering world. */
 	if (firstlogon == 1) {
+		TraderRepository::DeleteWhere(database, fmt::format("`char_id` = '{}'", CharacterID()));
+		BuyerRepository::DeleteBuyer(database, CharacterID());
+		LogTradingDetail(
+			"Removed trader abd buyer entries for Character ID {} on first logon to ensure table consistency.",
+			CharacterID()
+		);
+
 		RecordPlayerEventLog(PlayerEvent::WENT_ONLINE, PlayerEvent::EmptyEvent{});
 
 		if (parse->PlayerHasQuestSub(EVENT_CONNECT)) {
@@ -15567,7 +15574,9 @@ void Client::Handle_OP_TraderShop(const EQApplicationPacket *app)
 	switch (in->Code) {
 		case ClickTrader: {
 			LogTrading("Handle_OP_TraderShop case ClickTrader [{}]", in->Code);
-			auto outapp        = std::make_unique<EQApplicationPacket>(OP_TraderShop, sizeof(TraderClick_Struct));
+			auto outapp =
+				std::make_unique<EQApplicationPacket>(OP_TraderShop, static_cast<uint32>(sizeof(TraderClick_Struct))
+			);
 			auto data          = (TraderClick_Struct *) outapp->pBuffer;
 			auto trader_client = entity_list.GetClientByID(in->TraderID);
 

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -505,6 +505,22 @@ void EntityList::MobProcess()
 					zone->GetSecondsBeforeIdle(),
 					zone->GetSecondsBeforeIdle() != 1 ? "s" : ""
 				);
+
+				TraderRepository::DeleteWhere(
+					database,
+					fmt::format(
+						"`char_zone_id` = '{}' AND `char_zone_instance_id` = '{}'",
+						zone->GetZoneID(),
+						zone->GetInstanceID())
+				);
+				BuyerRepository::DeleteBuyers(database, zone->GetZoneID(), zone->GetInstanceID());
+
+				LogTradingDetail(
+					"Removed trader abd buyer entries for Zone ID {} and Instance ID {}",
+					zone->GetZoneID(),
+					zone->GetInstanceID()
+				);
+
 				mob_settle_timer->Disable();
 			}
 
@@ -2334,7 +2350,10 @@ void EntityList::QueueClientsGuild(const EQApplicationPacket *app, uint32 guild_
 
 void EntityList::QueueClientsGuildBankItemUpdate(GuildBankItemUpdate_Struct *gbius, uint32 guild_id)
 {
-	auto outapp = std::make_unique<EQApplicationPacket>(OP_GuildBank, sizeof(GuildBankItemUpdate_Struct));
+	auto outapp = std::make_unique<EQApplicationPacket>(
+		OP_GuildBank,
+		static_cast<uint32>(sizeof(GuildBankItemUpdate_Struct))
+	);
 	auto data   = reinterpret_cast<GuildBankItemUpdate_Struct *>(outapp->pBuffer);
 
 	memcpy(data, gbius, sizeof(GuildBankItemUpdate_Struct));

--- a/zone/entity.h
+++ b/zone/entity.h
@@ -581,6 +581,7 @@ public:
 	void SendMerchantEnd(Mob* merchant);
 	void SendMerchantInventory(Mob* m, int32 slot_id = -1, bool is_delete = false);
 	void RestoreCorpse(NPC* npc, uint32_t decay_time);
+	void CheckToClearTraderAndBuyerTables();
 
 protected:
 	friend class Zone;

--- a/zone/tasks.cpp
+++ b/zone/tasks.cpp
@@ -150,7 +150,7 @@ void Client::StartTaskRequestCooldownTimer()
 	uint32_t milliseconds = RuleI(TaskSystem, RequestCooldownTimerSeconds) * 1000;
 	task_request_timer.Start(milliseconds);
 
-	auto outapp = std::make_unique<EQApplicationPacket>(OP_TaskRequestTimer, sizeof(uint32_t));
+	auto outapp = std::make_unique<EQApplicationPacket>(OP_TaskRequestTimer, static_cast<uint32>(sizeof(uint32_t)));
 	outapp->WriteUInt32(milliseconds);
 	QueuePacket(outapp.get());
 }

--- a/zone/tasks.cpp
+++ b/zone/tasks.cpp
@@ -150,7 +150,7 @@ void Client::StartTaskRequestCooldownTimer()
 	uint32_t milliseconds = RuleI(TaskSystem, RequestCooldownTimerSeconds) * 1000;
 	task_request_timer.Start(milliseconds);
 
-	auto outapp = std::make_unique<EQApplicationPacket>(OP_TaskRequestTimer, static_cast<uint32>(sizeof(uint32_t)));
+	auto outapp = std::make_unique<EQApplicationPacket>(OP_TaskRequestTimer, sizeof(uint32_t));
 	outapp->WriteUInt32(milliseconds);
 	QueuePacket(outapp.get());
 }

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -1351,12 +1351,12 @@ void Client::BuyTraderItem(TraderBuy_Struct *tbs, Client *Trader, const EQApplic
 		return;
 	}
 
-	auto in                          = (TraderBuy_Struct *) app->pBuffer;
-	auto outapp                      = std::make_unique<EQApplicationPacket>(OP_Trader, sizeof(TraderBuy_Struct));
-	auto outtbs                      = (TraderBuy_Struct *) outapp->pBuffer;
-	outtbs->item_id                  = tbs->item_id;
+	auto outapp     = std::make_unique<EQApplicationPacket>(OP_Trader, static_cast<uint32>(sizeof(TraderBuy_Struct)));
+	auto outtbs     = (TraderBuy_Struct *) outapp->pBuffer;
+	outtbs->item_id = tbs->item_id;
+
 	const EQ::ItemInstance *buy_item = nullptr;
-	uint32 item_id                   = 0;
+	uint32                  item_id  = 0;
 
 	if (ClientVersion() >= EQ::versions::ClientVersion::RoF) {
 		tbs->item_id = Strings::ToUnsignedBigInt(tbs->serial_number);
@@ -1558,7 +1558,10 @@ void Client::BuyTraderItem(TraderBuy_Struct *tbs, Client *Trader, const EQApplic
 void Client::SendBazaarWelcome()
 {
 	const auto results = TraderRepository::GetWelcomeData(database);
-	auto       outapp  = std::make_unique<EQApplicationPacket>(OP_BazaarSearch, sizeof(BazaarWelcome_Struct));
+	auto       outapp  = std::make_unique<EQApplicationPacket>(
+		OP_BazaarSearch,
+		static_cast<uint32>(sizeof(BazaarWelcome_Struct))
+		);
 	auto       data    = (BazaarWelcome_Struct *) outapp->pBuffer;
 
 	data->action  = BazaarWelcome;
@@ -1798,7 +1801,10 @@ void Client::SendBuyerResults(BarterSearchRequest_Struct& bsr)
 
 		{ ar(results); }
 
-		auto packet = std::make_unique<EQApplicationPacket>(OP_BuyerItems, ss.str().length() + sizeof(BuyerGeneric_Struct));
+		auto packet = std::make_unique<EQApplicationPacket>(
+			OP_BuyerItems,
+			static_cast<uint32>(ss.str().length()) + static_cast<uint32>(sizeof(BuyerGeneric_Struct))
+		);
 		auto emu    = (BuyerGeneric_Struct *) packet->pBuffer;
 
 		emu->action = Barter_BuyerSearch;
@@ -1851,7 +1857,10 @@ void Client::ShowBuyLines(const EQApplicationPacket *app)
 
 			{ ar(l); }
 
-			auto packet = std::make_unique<EQApplicationPacket>(OP_BuyerItems, ss.str().length() + sizeof(BuyerGeneric_Struct));
+			auto packet = std::make_unique<EQApplicationPacket>(
+				OP_BuyerItems,
+				static_cast<uint32>(ss.str().length()) + static_cast<uint32>(sizeof(BuyerGeneric_Struct))
+			);
 			auto emu    = (BuyerGeneric_Struct *) packet->pBuffer;
 
 			emu->action = Barter_BuyerInspectBegin;
@@ -2075,7 +2084,7 @@ void Client::SellToBuyer(const EQApplicationPacket *app)
 
 				auto server_packet = std::make_unique<ServerPacket>(
 					ServerOP_BuyerMessaging,
-					sizeof(BuyerMessaging_Struct)
+					static_cast<uint32>(sizeof(BuyerMessaging_Struct))
 				);
 
 				auto data = (BuyerMessaging_Struct *) server_packet->pBuffer;
@@ -2123,7 +2132,10 @@ void Client::SendBuyerPacket(Client* Buyer) {
 
 void Client::ToggleBuyerMode(bool status)
 {
-	auto outapp = std::make_unique<EQApplicationPacket>(OP_Barter, sizeof(BuyerSetAppearance_Struct));
+	auto outapp = std::make_unique<EQApplicationPacket>(
+		OP_Barter,
+		static_cast<uint32>(sizeof(BuyerSetAppearance_Struct))
+	);
 	auto data   = (BuyerSetAppearance_Struct *) outapp->pBuffer;
 
 	data->action    = Barter_BuyerAppearance;
@@ -2319,8 +2331,7 @@ void Client::ModifyBuyLine(const EQApplicationPacket *app)
 
 			auto packet = std::make_unique<EQApplicationPacket>(
 				OP_BuyerItems,
-				ss_customer.str().length() +
-				sizeof(BuyerGeneric_Struct)
+				static_cast<uint32>(ss_customer.str().length()) + static_cast<uint32>(sizeof(BuyerGeneric_Struct))
 			);
 			auto emu    = (BuyerGeneric_Struct *) packet->pBuffer;
 
@@ -2815,7 +2826,10 @@ void Client::DoBazaarInspect(BazaarInspect_Struct &in)
 
 void Client::SendBazaarDeliveryCosts()
 {
-	auto outapp = std::make_unique<EQApplicationPacket>(OP_BazaarSearch, sizeof(BazaarDeliveryCost_Struct));
+	auto outapp = std::make_unique<EQApplicationPacket>(
+		OP_BazaarSearch,
+		static_cast<uint32>(sizeof(BazaarDeliveryCost_Struct))
+	);
 	auto data   = (BazaarDeliveryCost_Struct *) outapp->pBuffer;
 
 	data->action                = DeliveryCostUpdate;
@@ -3076,7 +3090,9 @@ void Client::BuyTraderItemOutsideBazaar(TraderBuy_Struct *tbs, const EQApplicati
 		BazaarAuditTrail(tbs->seller_name, GetName(), buy_item->GetItem()->Name, tbs->quantity, tbs->price, 0);
 	}
 
-	auto out_server = std::make_unique<ServerPacket>(ServerOP_BazaarPurchase, sizeof(BazaarPurchaseMessaging_Struct));
+	auto out_server = std::make_unique<ServerPacket>(
+		ServerOP_BazaarPurchase, static_cast<uint32>(sizeof(BazaarPurchaseMessaging_Struct))
+	);
 	auto out_data   = (BazaarPurchaseMessaging_Struct *) out_server->pBuffer;
 
 	out_data->trader_buy_struct       = *tbs;
@@ -3113,7 +3129,7 @@ void Client::SendBuyerGreeting(uint32 buyer_id)
 
 void Client::SendSellerBrowsing(const std::string &browser)
 {
-	auto outapp = std::make_unique<EQApplicationPacket>(OP_Barter, sizeof(BuyerBrowsing_Struct));
+	auto outapp = std::make_unique<EQApplicationPacket>(OP_Barter, static_cast<uint32>(sizeof(BuyerBrowsing_Struct)));
 	auto eq     = (BuyerBrowsing_Struct *) outapp->pBuffer;
 
 	eq->action = Barter_SellerBrowsing;
@@ -3311,7 +3327,7 @@ void Client::SendWindowUpdatesToSellerAndBuyer(BuyerLineSellItem_Struct &blsi)
 	if (blsi.item_quantity - blsi.seller_quantity <= 0) {
 		auto outapp = std::make_unique<EQApplicationPacket>(
 			OP_BuyerItems,
-			sizeof(BuyerRemoveItemFromMerchantWindow_Struct)
+			static_cast<uint32>(sizeof(BuyerRemoveItemFromMerchantWindow_Struct))
 		);
 		auto data   = (BuyerRemoveItemFromMerchantWindow_Struct *) outapp->pBuffer;
 
@@ -3401,7 +3417,7 @@ void Client::SendBuyerToBarterWindow(Client *buyer, uint32 action)
 {
 	auto server_packet = std::make_unique<ServerPacket>(
 		ServerOP_BuyerMessaging,
-		sizeof(BuyerMessaging_Struct)
+		static_cast<uint32>(sizeof(BuyerMessaging_Struct))
 	);
 	auto data          = (BuyerMessaging_Struct *) server_packet->pBuffer;
 
@@ -3422,7 +3438,10 @@ void Client::SendBulkBazaarBuyers()
 		return;
 	}
 
-	auto outapp = std::make_unique<EQApplicationPacket>(OP_Barter, sizeof(BuyerAddBuyertoBarterWindow_Struct));
+	auto outapp = std::make_unique<EQApplicationPacket>(
+		OP_Barter,
+		static_cast<uint32>(sizeof(BuyerAddBuyertoBarterWindow_Struct))
+	);
 	auto emu    = (BuyerAddBuyertoBarterWindow_Struct *) outapp->pBuffer;
 
 	for (auto const &b: results) {
@@ -3665,11 +3684,11 @@ bool Client::ValidateBuyLineItems(std::map<uint32, BuylineItemDetails_Struct> &i
 
 int64 Client::ValidateBuyLineCost(std::map<uint32, BuylineItemDetails_Struct> &item_map)
 {
-	int64 proposed_total_cost = std::accumulate(
+	uint64 proposed_total_cost = std::accumulate(
 		item_map.cbegin(),
 		item_map.cend(),
-		0,
-		[](auto prev_sum, const std::pair<uint32, BuylineItemDetails_Struct> &x) {
+		static_cast<uint64>(0),
+		[](uint64 prev_sum, const std::pair<uint32, BuylineItemDetails_Struct> &x) {
 			return prev_sum + x.second.item_cost;
 		}
 	);

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -1557,18 +1557,15 @@ void Client::BuyTraderItem(TraderBuy_Struct *tbs, Client *Trader, const EQApplic
 
 void Client::SendBazaarWelcome()
 {
-	const auto results = TraderRepository::GetWelcomeData(database);
-	auto       outapp  = std::make_unique<EQApplicationPacket>(
-		OP_BazaarSearch,
-		static_cast<uint32>(sizeof(BazaarWelcome_Struct))
-		);
-	auto       data    = (BazaarWelcome_Struct *) outapp->pBuffer;
+	const auto          results = TraderRepository::GetWelcomeData(database);
+	EQApplicationPacket outapp(OP_BazaarSearch, static_cast<uint32>(sizeof(BazaarWelcome_Struct)));
+	auto                data = (BazaarWelcome_Struct *) outapp.pBuffer;
 
-	data->action  = BazaarWelcome;
-	data->traders = results.count_of_traders;
-	data->items   = results.count_of_items;
+	data->action             = BazaarWelcome;
+	data->traders            = results.count_of_traders;
+	data->items              = results.count_of_items;
 
-	QueuePacket(outapp.get());
+	QueuePacket(&outapp);
 }
 
 void Client::SendBarterWelcome()

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -3794,7 +3794,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 			}
 
 			auto item_sn = Strings::ToUnsignedBigInt(in->trader_buy_struct.serial_number);
-			auto outapp  = std::make_unique<EQApplicationPacket>(OP_Trader, sizeof(TraderBuy_Struct));
+			auto outapp  = std::make_unique<EQApplicationPacket>(OP_Trader, static_cast<uint32>(sizeof(TraderBuy_Struct)));
 			auto data    = (TraderBuy_Struct *) outapp->pBuffer;
 
 			memcpy(data, &in->trader_buy_struct, sizeof(TraderBuy_Struct));
@@ -3841,7 +3841,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 				case Barter_AddToBarterWindow: {
 					auto outapp = std::make_unique<EQApplicationPacket>(
 						OP_Barter,
-						sizeof(BuyerAddBuyertoBarterWindow_Struct)
+						static_cast<uint32>(sizeof(BuyerAddBuyertoBarterWindow_Struct))
 					);
 					auto emu    = (BuyerAddBuyertoBarterWindow_Struct *) outapp->pBuffer;
 
@@ -3858,7 +3858,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 				case Barter_RemoveFromBarterWindow: {
 					auto outapp = std::make_unique<EQApplicationPacket>(
 						OP_Barter,
-						sizeof(BuyerRemoveBuyerFromBarterWindow_Struct)
+						static_cast<uint32>(sizeof(BuyerRemoveBuyerFromBarterWindow_Struct))
 					);
 					auto emu    = (BuyerRemoveBuyerFromBarterWindow_Struct *) outapp->pBuffer;
 

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -677,8 +677,19 @@ void Client::MoveZoneInstanceRaid(uint16 instance_id, const glm::vec4 &location)
 
 void Client::ProcessMovePC(uint32 zoneID, uint32 instance_id, float x, float y, float z, float heading, uint8 ignorerestrictions, ZoneMode zm)
 {
-	// From what I have read, dragged corpses should stay with the player for Intra-zone summons etc, but we can implement that later.
+	// From what I have read, dragged corpses should stay with the player for Intra-zone summons etc, but we can
+	// implement that later.
 	ClearDraggedCorpses();
+
+	// Added to ensure that if a player is moved (ported, gmmove, etc) and they are an active trader or buyer, they will
+	// be removed from future transactions.
+	if(IsTrader()) {
+		TraderEndTrader();
+	}
+
+	if(IsBuyer()) {
+		ToggleBuyerMode(false);
+	}
 
 	if(zoneID == 0)
 		zoneID = zone->GetZoneID();

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -683,11 +683,11 @@ void Client::ProcessMovePC(uint32 zoneID, uint32 instance_id, float x, float y, 
 
 	// Added to ensure that if a player is moved (ported, gmmove, etc) and they are an active trader or buyer, they will
 	// be removed from future transactions.
-	if(IsTrader()) {
+	if (IsTrader()) {
 		TraderEndTrader();
 	}
 
-	if(IsBuyer()) {
+	if (IsBuyer()) {
 		ToggleBuyerMode(false);
 	}
 


### PR DESCRIPTION
Cleanup several compiler warnings

# Description

There have been some reports of trader/buyer tables with erroneous entries when a bazaar instance crashes, or an active trader 
is ported.  In reviewing, several updates have been added to protect from various scenarios.

Add trader/buyer db cleanup for
- on zone idle
- on client first login
- when world drops a zone connection
- in Client::ProcessMovePC

Also made a few compiler warning updates.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
Tested with various combos of db entires and zone idle, crash, client crash, etc

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
