### PR TITLE
[Fix] Zone State Spawn2 Location Restore

### DIFF
--- a/zone/spawn2.cpp
+++ b/zone/spawn2.cpp
@@ -277,7 +277,13 @@ bool Spawn2::Process() {
 			}
 		}
 
-		NPC *npc = new NPC(tmp, this, glm::vec4(x, y, z, heading), GravityBehavior::Water);
+		// zone state restore
+		if (m_stored_location != glm::vec4(0, 0, -1000, 0)) {
+			loc = m_stored_location;
+			m_stored_location = glm::vec4(0, 0, -1000, 0);
+		}
+
+		NPC *npc = new NPC(tmp, this, loc, GravityBehavior::Water);
 
 		npcthis = npc;
 

--- a/zone/spawn2.h
+++ b/zone/spawn2.h
@@ -79,6 +79,7 @@ public:
 	inline void SetResumedFromZoneSuspend(bool resumed) { m_resumed_from_zone_suspend = resumed; }
 	inline void SetEntityVariables(std::map<std::string, std::string> vars) { m_entity_variables = vars; }
 	inline void SetResumedNPCID(uint32 npc_id) { m_resumed_npc_id = npc_id; }
+	inline void SetStoredLocation(const glm::vec4& loc) { m_stored_location = loc; }
 
 protected:
 	friend class Zone;
@@ -108,6 +109,7 @@ private:
 	bool m_resumed_from_zone_suspend = false;
 	uint32 m_resumed_npc_id = 0;
 	std::map<std::string, std::string> m_entity_variables = {};
+	glm::vec4 m_stored_location = {0, 0, -1000, 0}; // use -1000 to indicate unset/zero-state
 };
 
 class SpawnCondition {

--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -450,7 +450,7 @@ bool Zone::LoadZoneState(
 	}
 
 	std::vector<Spawn2Repository::Spawn2> spawn2s = Spawn2Repository::GetWhere(
-		database,
+		content_db,
 		fmt::format(
 			"zone = '{}' AND (version = {} OR version = -1)",
 			zone->GetShortName(),

--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -441,14 +441,6 @@ bool Zone::LoadZoneState(
 	zone->initgrids_timer.Trigger();
 	zone->Process();
 
-	// load zone variables first
-	for (auto &s: spawn_states) {
-		if (s.is_zone) {
-			LoadZoneVariables(zone, s.entity_variables);
-			break;
-		}
-	}
-
 	// load base spawn2 data for spawn locations
 	std::vector<std::string> spawn2_ids;
 	for (auto &s: spawn_states) {

--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -481,25 +481,25 @@ bool Zone::LoadZoneState(
 		}
 
 		// find spawn 2 by id
-		auto spawn2 = std::find_if(
-			spawn2s.begin(),
-			spawn2s.end(),
-			[&](const auto &e) {
-				return e.id == s.spawn2_id;
+		Spawn2Repository::Spawn2 spawn2;
+		for (auto &sp: spawn2s) {
+			if (sp.id == s.spawn2_id) {
+				spawn2 = sp;
+				break;
 			}
-		);
+		}
 
-		if (spawn2 == spawn2s.end()) {
+		if (!spawn2.id) {
 			LogZoneState("Failed to load spawn2 data for spawn2_id [{}]", s.spawn2_id);
 		}
 
 		auto new_spawn = new Spawn2(
 			s.spawn2_id,
 			s.spawngroup_id,
-			spawn2->id > 0 ? spawn2->x : s.x,
-			spawn2->id > 0 ? spawn2->y : s.y,
-			spawn2->id > 0 ? spawn2->z : s.z,
-			spawn2->id > 0 ? spawn2->heading : s.heading,
+			spawn2.id > 0 ? spawn2.x : s.x,
+			spawn2.id > 0 ? spawn2.y : s.y,
+			spawn2.id > 0 ? spawn2.z : s.z,
+			spawn2.id > 0 ? spawn2.heading : s.heading,
 			s.respawn_time,
 			s.variance,
 			spawn_time_left,

--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -449,14 +449,26 @@ bool Zone::LoadZoneState(
 		}
 	}
 
-	std::vector<Spawn2Repository::Spawn2> spawn2s = Spawn2Repository::GetWhere(
-		content_db,
-		fmt::format(
-			"zone = '{}' AND (version = {} OR version = -1)",
-			zone->GetShortName(),
-			zone->GetInstanceVersion()
-		)
-	);
+	// load base spawn2 data for spawn locations
+	std::vector<std::string> spawn2_ids;
+	for (auto &s: spawn_states) {
+		if (s.spawn2_id > 0) {
+			spawn2_ids.push_back(std::to_string(s.spawn2_id));
+		}
+	}
+
+	std::vector<Spawn2Repository::Spawn2> spawn2s;
+	if (!spawn2_ids.empty()) {
+		spawn2s = Spawn2Repository::GetWhere(
+			content_db,
+			fmt::format(
+				"id IN ({})",
+				Strings::Join(spawn2_ids, ",")
+			)
+		);
+
+		LogZoneState("Loaded [{}] spawn2s", spawn2s.size());
+	}
 
 	// spawn2
 	for (auto &s: spawn_states) {


### PR DESCRIPTION
# Description

This fixes an issue where a spawn2 NPC is saved in its current location, but on restore it will not only restore to that same position, it will respawn in that new position it was restored in.

This still retains spawn2 NPC's restoring to their saved location but restores original spawn location data as well.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

In Blackburrow, 1 second respawn timers.

![image](https://github.com/user-attachments/assets/d8ad76a1-e26b-41af-b057-2d69a2ae3227)

Summon gnoll to me

![image](https://github.com/user-attachments/assets/a3cd3510-992a-45fd-8c6c-8426a176b4fd)

On restore, gnoll is still in expected position, kill gnoll and it respawns in its expected origin spawn location.

![image](https://github.com/user-attachments/assets/fb7f4681-d4f1-44ec-acb5-c9259e315c45)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

