### PR TITLE
[Spells] Update to SPA 378 SE_SpellEffectResistChance

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -5331,6 +5331,14 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 							spellbonuses.SEResist[e]     = effect_value;
 							spellbonuses.SEResist[e + 1] = effect_value;
 						}
+						if (negate_itembonus) {
+							itembonuses.SEResist[e] = effect_value;
+							itembonuses.SEResist[e + 1] = effect_value;
+						}
+						if (negate_aabonus) {
+							aabonuses.SEResist[e] = effect_value;
+							aabonuses.SEResist[e + 1] = effect_value;
+						}
 					}
 					break;
 				}

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -962,7 +962,7 @@ public:
 	uint16 GetSympatheticFocusEffect(focusType type, uint16 spell_id);
 	bool TryFadeEffect(int slot);
 	void DispelMagic(Mob* casterm, uint16 spell_id, int effect_value);
-	uint16 GetSpellEffectResistChance(uint16 spell_id);
+	bool TrySpellEffectResist(uint16 spell_id);
 	int32 GetVulnerability(Mob *caster, uint32 spell_id, uint32 ticsremaining, bool from_buff_tic = false);
 	int64 GetFcDamageAmtIncoming(Mob *caster, int32 spell_id, bool from_buff_tic = false);
 	int64 GetFocusIncoming(focusType type, int effect, Mob *caster, uint32 spell_id); //**** This can be removed when bot healing focus code is updated ****

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -5359,7 +5359,7 @@ float Mob::ResistSpell(uint8 resist_type, uint16 spell_id, Mob *caster, bool use
 
 	if (!CharmTick) {
 		//Check for Spell Effect specific resistance chances (ie AA Mental Fortitude)
-		if (TrySpellEffectResist(spell_id)) {
+		if (resist_type != RESIST_NONE && TrySpellEffectResist(spell_id)) {
 			return 0;
 		}
 

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -5359,8 +5359,7 @@ float Mob::ResistSpell(uint8 resist_type, uint16 spell_id, Mob *caster, bool use
 
 	if (!CharmTick) {
 		//Check for Spell Effect specific resistance chances (ie AA Mental Fortitude)
-		int se_resist_bonuses = GetSpellEffectResistChance(spell_id);
-		if (se_resist_bonuses && zone->random.Roll(se_resist_bonuses)) {
+		if (TrySpellEffectResist(spell_id)) {
 			return 0;
 		}
 


### PR DESCRIPTION
# Description
Updates to SPA SE_SpellEffectResistChance 378 increase chance to resist specific spell effect (base1=value, base2=spell effect id)

Problem 1: This SPA was allowing spells to be resisted that are unresistable spells.

Confirmed with live parsing that unresistable spells (Resist Type 0) will never be resisted. Tested vs a few different scenarios, when fighting Manaetic Prototype X in plane of innovation they cast every 30 seconds Oil Spray which is an unresistable SNARE
https://spells.eqresource.com/spells.php?id=1076

Had Adamant Will AA which gave a 9% chance to resist snare effects. Out of hundreds of oil sprays got zero
resists.

Fixes # Unresistable spells (Resist Type 0) will no longer be resisted

Problem 2: This SPA was not allowing for proper resist checks if you had multiple different spell effects in the same spell. 

Example would be if you had an AA that gave you 5% chance to resist silence spells and 3% chance to resist snare spells. If a spell was cast on you that had both a silence and snare component you would only ever check against one.

Fixes # Allow for multiple resist checks from the same spell. Example above after fix, if a spell cast on you has both snare and silence, it will first roll for the snare if it fails to resist it, it will then roll for the silence resist check.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue) - A**dd support for multiple resist checks**
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected) - **Unresistable spells
that may have resisted prior with this effect will no longer resist.**


# Testing
![EQ1](https://github.com/user-attachments/assets/2c9718ba-6f5c-401e-9e5e-96154a105a17)

![eq2](https://github.com/user-attachments/assets/5e14ca27-45a4-4ebc-9096-f4db9178321e)

Tested using the "Snare" spell with a stun added to it. Client has a buff that gives 50% chance to resist snare
and 50% chance to resist stun.
Image one, it resists the on snare component
Image two it resist on the stun component

Attach images and describe testing done to validate functionality.

Clients tested: 

# Checklist

- [ X] I have tested my changes
- [ X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X ] I own the changes of my code and take responsibility for the potential issues that occur

