### PR TITLE
[Bugfix] Load zone variables before encounter_load.

### DIFF
--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -1190,6 +1190,11 @@ bool Zone::Init(bool is_static) {
 
 	RespawnTimesRepository::ClearExpiredRespawnTimers(database);
 
+	// Loading zone variables so they're available for things like encounter_load
+	if (RuleB(Zone, StateSavingOnShutdown)) {
+		zone->LoadZoneVariablesState();
+	}
+
 	// make sure that anything that needs to be loaded prior to scripts is loaded before here
 	// this is to ensure that the scripts have access to the data they need
 	parse->ReloadQuests(true);

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -473,6 +473,7 @@ public:
 	inline uint32 GetZoneServerId() const { return m_zone_server_id; }
 
 	// zone state
+	bool LoadZoneVariablesState();
 	bool LoadZoneState(
 		std::unordered_map<uint32, uint32> spawn_times,
 		std::vector<Spawn2DisabledRepository::Spawn2Disabled> disabled_spawns


### PR DESCRIPTION
# Description

The encounter load function was unable to see zone variables.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Akk-stack with RoF2 client

Example encounter
```
function npc_spawn(e)
        local zone = eq.get_zone();
        local value = zone:GetVariable("test");
        eq.debug("Value found during spawn: "..value);
end

function event_encounter_load(e)
        eq.register_npc_event(Event.spawn, -1, npc_spawn);

        local zone = eq.get_zone();
        local value = zone:GetVariable("test");
        eq.debug("Value found: "..value);

        zone:SetVariable("test", "blah");
        eq.debug("Value set to 'blah'");
end
```

Before change:

![image](https://github.com/user-attachments/assets/e08cab84-57fe-4aa1-9fa0-8f93c5489166)

After change:

![image](https://github.com/user-attachments/assets/bf7950d0-7c2b-4e2f-92a3-3f3a15c98937)

Checking that normal spawn events on reload still see zone variables:

![image](https://github.com/user-attachments/assets/eebcb361-a572-4d39-a44d-28e96f12d83c)


# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
