### PR TITLE
[Spells] Update to SPA 180 SE_ResistSpellChance to not block unresistable spells. 

### DIFF
--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -5365,10 +5365,12 @@ float Mob::ResistSpell(uint8 resist_type, uint16 spell_id, Mob *caster, bool use
 		}
 
 		// Check for Chance to Resist Spell bonuses (ie Sanctification Discipline)
-		int resist_bonuses = CalcResistChanceBonus();
-		if (resist_bonuses && zone->random.Roll(resist_bonuses) && !IsResurrectionSicknessSpell(spell_id)) {
-			LogSpells("Resisted spell in sanctification, had [{}] chance to resist", resist_bonuses);
-			return 0;
+		if (!spells[spell_id].no_resist) {
+			int resist_bonuses = CalcResistChanceBonus();
+			if (resist_bonuses && zone->random.Roll(resist_bonuses) && !IsResurrectionSicknessSpell(spell_id)) {
+				LogSpells("Resisted spell in sanctification, had [{}] chance to resist", resist_bonuses);
+				return 0;
+			}
 		}
 	}
 

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -5365,7 +5365,7 @@ float Mob::ResistSpell(uint8 resist_type, uint16 spell_id, Mob *caster, bool use
 		}
 
 		// Check for Chance to Resist Spell bonuses (ie Sanctification Discipline)
-		if (!spells[spell_id].no_resist) {
+		if (!spells[spell_id].no_resist && resist_type != RESIST_NONE) {
 			int resist_bonuses = CalcResistChanceBonus();
 			if (resist_bonuses && zone->random.Roll(resist_bonuses) && !IsResurrectionSicknessSpell(spell_id)) {
 				LogSpells("Resisted spell in sanctification, had [{}] chance to resist", resist_bonuses);


### PR DESCRIPTION
Updates to SPA 180 SE_ResistSpellChance where base value is a chance to completely resist any spell. Seen with Paladin disc Sanctification with 100% chance, and live AA's and bard songs.

Problem: This SPA was allowing spells to be resisted that are unresistable spells and/or those flagged which spell field209 (no_resist) which is meant to bypass this spell effect.

Confirmed with live parsing that unresistable spells (Resist Type 0) will never be resisted. Tested vs a few different scenarios, when fighting Manaetic Prototype X in plane of innovation they cast every 30 seconds Oil Spray which is unresistable
https://spells.eqresource.com/spells.php?id=1076

Had AA Mystic Shield which gives 5% chance with SPA180. Out of hundreds of oil sprays got zero resists.

Using sanctification disc it still takes hold.
[Sat Apr 05 16:10:43 2025] You activate Sanctification Discipline.
[Sat Apr 05 16:10:43 2025] Your body is surrounded in an aura of sanctification.
[Sat Apr 05 16:10:43 2025] You are covered in oil.

Alternatively can test this by casting Malos (unresistable) repeatedly on a target with bard song Dance of Dragorn
which gives 10% chance to resist all spells. It never gives a resist message.
https://spells.eqresource.com/spells.php?id=18039

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected) - **Unresistable spells that may have resisted prior with this effect will no longer resist.**

Clients tested: 

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur