### PR TITLE
[Spells] Fear resistance effects edge case fixes and support for SPA 102 as an AA

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -1165,10 +1165,6 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 		}
 
 		case SE_ResistFearChance: {
-			if (base_value == 100) // If we reach 100% in a single spell/item then we should be immune to
-					  // negative fear resist effects until our immunity is over
-				newbon->Fearless = true;
-
 			newbon->ResistFearChance += base_value; // these should stack
 			break;
 		}
@@ -2474,9 +2470,6 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 
 			case SE_ResistFearChance:
 			{
-				if(effect_value == 100) // If we reach 100% in a single spell/item then we should be immune to negative fear resist effects until our immunity is over
-					new_bonus->Fearless = true;
-
 				new_bonus->ResistFearChance += effect_value; // these should stack
 				break;
 			}
@@ -4689,11 +4682,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 					break;
 
 				case SE_ResistFearChance:
-					if (negate_spellbonus) {
-						spellbonuses.Fearless = false;
-						spellbonuses.ResistFearChance = effect_value;
-					}
-
+					if (negate_spellbonus) {spellbonuses.ResistFearChance = effect_value;	}
 					if (negate_aabonus) { aabonuses.ResistFearChance = effect_value; }
 					if (negate_itembonus) { itembonuses.ResistFearChance = effect_value; }
 					break;

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -5667,14 +5667,9 @@ int16 Mob::CalcResistChanceBonus()
 
 int16 Mob::CalcFearResistChance()
 {
-	int resistchance = spellbonuses.ResistFearChance + itembonuses.ResistFearChance;
-	if (IsOfClientBot()) {
-		resistchance += aabonuses.ResistFearChance;
-		if (aabonuses.Fearless == true) {
-			resistchance = 100;
-		}
-	}
-	if (spellbonuses.Fearless == true || itembonuses.Fearless == true) {
+	int resistchance = spellbonuses.ResistFearChance + itembonuses.ResistFearChance + aabonuses.ResistFearChance;
+
+	if (spellbonuses.Fearless == true || itembonuses.Fearless == true || aabonuses.Fearless == true) {
 		resistchance = 100;
 	}
 


### PR DESCRIPTION
Update to how we calculate fear resist chance from bonuses. This resolves a few rare edge cases that could potentially pop up.

Problem: SPA 181 FearResistChance  (% chance to outright resist fear) and SPA 102 Fearless (on live used only on pets for  full fear immunity if presents, with value of 1 = 100% immunity)
The way we were calculating the bonuses was mixing the variables we used for each together in a way that could cause conflicts when combined with a negate spell effect (SPA 382).

Solution: SPA 181 and SPA 102 each use their own variable consistently.

This update also adds support for SPA 102 to be used in AA.

While doing some live testing was able to confirm SPA102 when cast on pets will terminate the fear on the next tick which is consistent with how we have the mechanic coded.


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
