### PR TITLE
[Bugfix] Prevent final shutdown from persisting incomplete state.

### DIFF
--- a/zone/cli/tests/zone_state.cpp
+++ b/zone/cli/tests/zone_state.cpp
@@ -38,7 +38,11 @@ inline void SetupStateZone()
 	SetupZone("soldungb");
 	zone->Process();
 	// depop the zone controller
-	entity_list.GetNPCByNPCTypeID(ZONE_CONTROLLER_NPC_ID)->Depop();
+	auto controller = entity_list.GetNPCByNPCTypeID(ZONE_CONTROLLER_NPC_ID);
+	if (controller != nullptr) {
+		controller->Depop();
+	}
+
 	entity_list.MobProcess(); // process the depop
 }
 
@@ -280,7 +284,7 @@ inline bool MatchCorpseState(Corpse *c, const ZoneStateSpawnsRepository::ZoneSta
 
 inline void TestSpawns()
 {
-	zone->Shutdown();
+	zone->Shutdown(true, false);
 	ClearState();
 	SetupStateZone();
 	zone->Repop(true);
@@ -290,7 +294,7 @@ inline void TestSpawns()
 
 	RunTest("Spawns > Ensure no state spawns exist before shutdown", 0, (int) GetStateSpawns().size());
 
-	zone->Shutdown();
+	zone->Shutdown(true, false);
 
 	auto entries = GetStateSpawns().size();
 	RunTest(fmt::format("Spawns > State exists after shutdown, entries ({})", entries), true, entries > 0);
@@ -300,7 +304,7 @@ inline void TestSpawns()
 	entries = GetStateSpawns().size();
 	RunTest(fmt::format("Spawns > State exists after bootup, entries ({})", entries), true, entries > 0);
 
-	zone->Shutdown();
+	zone->Shutdown(true, false);
 	SetupStateZone();
 
 	entries = GetStateSpawns().size();
@@ -374,7 +378,7 @@ inline void TestSpawns()
 	}
 	RespawnTimesRepository::ReplaceMany(database, times);
 
-	zone->Shutdown();
+	zone->Shutdown(true, false);
 	SetupStateZone();
 
 	condition = (int) entity_list.GetNPCList().size() == 0 && (int) entity_list.GetCorpseList().size() == 115;
@@ -436,7 +440,7 @@ inline void TestSpawns()
 
 	RespawnTimesRepository::DeleteWhere(database, fmt::format("id IN ({})", Strings::Join(spawn2_ids, ",")));
 
-	zone->Shutdown();
+	zone->Shutdown(true, false);
 	SetupStateZone();
 
 	npcs_to_kill = {};
@@ -468,7 +472,7 @@ inline void TestSpawns()
 	}
 	RunTest("Spawns > Kill 10 NPC's before save/restore (105 NPCs) (10 Corpses)", true, condition);
 
-	zone->Shutdown();
+	zone->Shutdown(true, false);
 	SetupStateZone();
 
 	condition = (int) entity_list.GetNPCList().size() == 105 && (int) entity_list.GetCorpseList().size() == 10;
@@ -655,7 +659,7 @@ inline void TestZoneVariables()
 
 	// Simulate shutdown and restart twice
 	for (int i = 1; i <= 2; ++i) {
-		zone->Shutdown();
+		zone->Shutdown(true, false);
 		SetupStateZone();
 
 		for (const auto &[key, value]: test_variables) {
@@ -678,7 +682,7 @@ inline void TestZoneVariables()
 	);
 
 	// Final shutdown and restart check
-	zone->Shutdown();
+	zone->Shutdown(true, false);
 	SetupStateZone();
 
 	for (const auto &[key, value]: test_variables) {
@@ -739,7 +743,7 @@ inline void TestHpManaEnd()
 		npc->SetMana(1);
 	}
 
-	zone->Shutdown();
+	zone->Shutdown(true, false);
 	SetupStateZone();
 
 	hp_mismatch.clear();
@@ -786,7 +790,7 @@ inline void TestBuffs()
 		npc->CastSpell(6824, npc->GetID(), (EQ::spells::CastingSlot) 0, 0, 0);
 	}
 
-	zone->Shutdown();
+	zone->Shutdown(true, false);
 	SetupStateZone();
 
 	// Check buffs
@@ -809,14 +813,14 @@ inline void TestBuffs()
 
 inline void TestZLocationDrift()
 {
-	zone->Shutdown();
+	zone->Shutdown(true, false);
 	ClearState();
 	SetupStateZone();
 
 	auto b = GetStateSpawns();
 
 	for (int i = 0; i < 10; ++i) {
-		zone->Shutdown();
+		zone->Shutdown(true, false);
 		SetupStateZone();
 	}
 
@@ -858,7 +862,7 @@ inline void TestLocationChange()
 		npc->SetPosition(-870, -1394, 106);
 	}
 
-	zone->Shutdown();
+	zone->Shutdown(true, false);
 	SetupStateZone();
 
 	bool all_moved = true;
@@ -907,7 +911,7 @@ inline void TestEntityVariables()
 		}
 	}
 
-	zone->Shutdown();
+	zone->Shutdown(true, false);
 	SetupStateZone();
 
 	// Check entity variables
@@ -952,7 +956,7 @@ inline void TestLoot()
 
 	RunTest("Loot > Cloak of Flames added to all NPC's via Loottable before shutdown", false, missing_loot);
 
-	zone->Shutdown();
+	zone->Shutdown(true, false);
 	SetupStateZone();
 
 	missing_loot = false;
@@ -1025,7 +1029,7 @@ inline void TestLoot()
 		missing_loot_corpse
 	);
 
-	zone->Shutdown();
+	zone->Shutdown(true, false);
 	SetupStateZone();
 
 	missing_loot_corpse = false;

--- a/zone/main.cpp
+++ b/zone/main.cpp
@@ -638,7 +638,7 @@ int main(int argc, char **argv)
 
 				if (zone) {
 					if (!zone->Process()) {
-						zone->Shutdown();
+						zone->Shutdown(true, false);
 					}
 				}
 
@@ -678,7 +678,7 @@ int main(int argc, char **argv)
 	safe_delete(Config);
 
 	if (zone != 0) {
-		zone->Shutdown(true);
+		zone->Shutdown(false, true);
 	}
 	//Fix for Linux world server problem.
 	safe_delete(task_manager);
@@ -697,7 +697,7 @@ int main(int argc, char **argv)
 
 void Shutdown()
 {
-	zone->Shutdown(true);
+	zone->Shutdown(true, true);
 	LogInfo("Shutting down...");
 	LogSys.CloseFileLogs();
 	EQ::EventLoop::Get().Shutdown();

--- a/zone/main.cpp
+++ b/zone/main.cpp
@@ -638,7 +638,7 @@ int main(int argc, char **argv)
 
 				if (zone) {
 					if (!zone->Process()) {
-						zone->Shutdown(true, false);
+						zone->Shutdown();
 					}
 				}
 
@@ -678,7 +678,8 @@ int main(int argc, char **argv)
 	safe_delete(Config);
 
 	if (zone != 0) {
-		zone->Shutdown(false, true);
+		zone->SetSaveZoneState(false);
+		zone->Shutdown(true);
 	}
 	//Fix for Linux world server problem.
 	safe_delete(task_manager);
@@ -697,7 +698,7 @@ int main(int argc, char **argv)
 
 void Shutdown()
 {
-	zone->Shutdown(true, true);
+	zone->Shutdown(true);
 	LogInfo("Shutting down...");
 	LogSys.CloseFileLogs();
 	EQ::EventLoop::Get().Shutdown();

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -591,7 +591,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 
 			auto *s = (ServerZoneStateChange_Struct *) pack->pBuffer;
 			LogInfo("Zone shutdown by {}.", s->admin_name);
-			zone->Shutdown();
+			zone->Shutdown(true, false);
 		}
 		break;
 	}

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -591,7 +591,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 
 			auto *s = (ServerZoneStateChange_Struct *) pack->pBuffer;
 			LogInfo("Zone shutdown by {}.", s->admin_name);
-			zone->Shutdown(true, false);
+			zone->Shutdown();
 		}
 		break;
 	}

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -874,7 +874,7 @@ bool Zone::IsLoaded() {
 	return is_zone_loaded;
 }
 
-void Zone::Shutdown(bool quiet)
+void Zone::Shutdown(bool save_state, bool quiet)
 {
 	if (!is_zone_loaded) {
 		return;
@@ -887,7 +887,7 @@ void Zone::Shutdown(bool quiet)
 		c.second->WorldKick();
 	}
 
-	if (RuleB(Zone, StateSavingOnShutdown) && zone && zone->IsLoaded()) {
+	if (save_state && RuleB(Zone, StateSavingOnShutdown) && zone && zone->IsLoaded()) {
 		SaveZoneState();
 	}
 

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -874,7 +874,7 @@ bool Zone::IsLoaded() {
 	return is_zone_loaded;
 }
 
-void Zone::Shutdown(bool save_state, bool quiet)
+void Zone::Shutdown(bool quiet)
 {
 	if (!is_zone_loaded) {
 		return;
@@ -887,7 +887,7 @@ void Zone::Shutdown(bool save_state, bool quiet)
 		c.second->WorldKick();
 	}
 
-	if (save_state && RuleB(Zone, StateSavingOnShutdown) && zone && zone->IsLoaded()) {
+	if (m_save_zone_state && RuleB(Zone, StateSavingOnShutdown) && zone && zone->IsLoaded()) {
 		SaveZoneState();
 	}
 
@@ -1010,6 +1010,7 @@ Zone::Zone(uint32 in_zoneid, uint32 in_instanceid, const char* in_short_name)
 
 	SetIdleWhenEmpty(true);
 	SetSecondsBeforeIdle(60);
+	SetSaveZoneState(false);
 
 	if (database.GetServerType() == 1) {
 		pvpzone = true;
@@ -1204,6 +1205,8 @@ bool Zone::Init(bool is_static) {
 	}
 
 	content_db.PopulateZoneSpawnList(zoneid, spawn2_list, GetInstanceVersion());
+	SetSaveZoneState(true);
+
 	database.LoadCharacterCorpses(zoneid, instanceid);
 
 	content_db.LoadTraps(short_name, GetInstanceVersion());

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -106,7 +106,7 @@ class MobMovementManager;
 class Zone {
 public:
 	static bool Bootup(uint32 iZoneID, uint32 iInstanceID, bool is_static = false);
-	void Shutdown(bool quiet = false);
+	void Shutdown(bool save_state, bool quiet);
 
 	Zone(uint32 in_zoneid, uint32 in_instanceid, const char *in_short_name);
 	~Zone();

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -106,7 +106,7 @@ class MobMovementManager;
 class Zone {
 public:
 	static bool Bootup(uint32 iZoneID, uint32 iInstanceID, bool is_static = false);
-	void Shutdown(bool save_state, bool quiet);
+	void Shutdown(bool quiet = false);
 
 	Zone(uint32 in_zoneid, uint32 in_instanceid, const char *in_short_name);
 	~Zone();
@@ -353,6 +353,9 @@ public:
 	uint32 GetInstanceTimeRemaining() const;
 	void SetInstanceTimeRemaining(uint32 instance_time_remaining);
 
+	inline bool GetSaveZoneState() const { return m_save_zone_state; }
+	inline void SetSaveZoneState(bool save_state) { m_save_zone_state = save_state; }
+
 	/**
 	 * GMSay Callback for LogSys
 	 *
@@ -516,6 +519,7 @@ private:
 	uint32    m_last_ucss_update;
 	bool      m_idle_when_empty;
 	uint32    m_seconds_before_idle;
+	bool      m_save_zone_state;
 
 	GlobalLootManager                   m_global_loot;
 	LinkedList<ZoneClientAuth_Struct *> client_auth_list;


### PR DESCRIPTION
# Description

Results of the issue Akk & Pippz found last night.

The final call to zone->Shutdown() in main() happens after the entity list has just been cleared.  Normally this call will do nothing because it checks 'is_zone_loaded' at the start and the zone will have already been Shutdown in the main event loop.

In the scenario Akk and Pippz tested last night the main event loop does destroy the zone process and successfully persists the data.  Then after the loop has terminated but before the rest of the logic for main() completes we get a 'incoming client' message to the server which reconstructs a brand new zone object and sets 'is_zone_loaded' back to true.

And since we cleared the entity_list just a few lines above (but not the spawn list) we end up with a partially saved zone.

My attempt to fix this adds a parameter to shutdown to specify if a save is requested.  I ended up making the existing 'quiet' parameter required as well mostly to ensure I didn't miss any calls to Shutdown.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Akk-stack and rof2 client.

Repro steps found and verified by Akk and Pippz:

Basically go to any instanced zone, despawn everything and then manually spawn a few npcs with #npctypespawn.

Log out and kill the zone process in spire.  Check the zone_state_spawns table to see that your data is present, you should see the number of spawns + 1 extra row for the zone variables.

Edit the following:

zone.cpp:1844
```
//autoshutdown_timer.SetTimer(set_time);
autoshutdown_timer.SetTimer(100);
```

Rebuild and launch the new zone process, then attempt to connect with the client.

Client will hang and the logs for the zone process will show two sequences of loading zone data and destroying zone data, with the second one showing a lower number than the first upon saving.  The first represents the shutdown from inside the event loop while the second is the final shutdown in the main subroutine.

```
  Zone |    Info    | LoadZoneState Loading zone state spawns for zone [potimeb] spawns [4]
<SNIP>
  Zone |    Info    | Init Zone booted successfully zone_id [223] time_offset [0]
  Zone |    Info    | Bootup Zone server [potimeb] listening on port [7009] -- [potimeb] (The Plane of Time) inst_id [101]
  Zone |    Info    | Bootup Zone bootup type [Dynamic] short_name [potimeb] zone_id [223] instance_id [101] -- [potimeb] (The Plane of Time) inst_id [101] 
  Zone |    Info    | GetTimeSync Requesting world time -- [potimeb] (The Plane of Time) inst_id [101]
  Zone |    Info    | StartShutdownTimer Reset to [1 Hour] (Loaded from [zone table]) from original remaining time [5 Seconds] duration [5 Seconds] zone [PID (2061955) The Plane of Time (223) (Instance ID 101) (Version 255)] -- [potimeb] (The Plane of Time) inst_id [101]
  Zone |    Info    | StartFileLogs Starting File Log [logs/zone/potimeb_version_255_inst_id_101_port_7009_2061955.log] -- [potimeb] (The Plane of Time) inst_id [101] 
  Zone |    Info    | ResetShutdownTimer Reset to [100 Milliseconds] from original remaining time [100 Milliseconds] duration [100 Milliseconds] zone [PID (2061955) The Plane of Time (223) (Instance ID 101) (Version 255)] -- [potimeb] (The Plane of Time) inst_id [101]
  Zone |    Info    | SaveZoneState Saved [0] spawn2_list entries -- [potimeb] (The Plane of Time) inst_id [101]
  Zone |    Info    | SaveZoneState Saved [3] entity_list.GetNPCList() entries -- [potimeb] (The Plane of Time) inst_id [101]
  Zone |    Info    | SaveZoneState Saved [0] corpses -- [potimeb] (The Plane of Time) inst_id [101]
  Zone |    Info    | SaveZoneState Saved [4] zone state spawns -- [potimeb] (The Plane of Time) inst_id [101]
<SNIP>
  Zone |    Info    | LoadZoneState Loading zone state spawns for zone [potimeb] spawns [4] -- [potimeb] (The Plane of Time) inst_id [101]
<SNIP>
  Zone |    Info    | SaveZoneState Saved [0] spawn2_list entries -- [potimeb] (The Plane of Time) inst_id [101]
  Zone |    Info    | SaveZoneState Saved [0] entity_list.GetNPCList() entries -- [potimeb] (The Plane of Time) inst_id [101]
  Zone |    Info    | SaveZoneState Saved [0] corpses -- [potimeb] (The Plane of Time) inst_id [101]
  Zone |    Info    | SaveZoneState Saved [1] zone state spawns -- [potimeb] (The Plane of Time) inst_id [101]
```

With this fix the second round of 'SaveZoneState' disappears and the zone restores properly the next time we successfully enter the zone.

```
  Zone |    Info    | ResetShutdownTimer Reset to [100 Milliseconds] from original remaining time [100 Milliseconds] duration [100 Milliseconds] zone [PID (2067571) The Plane of Time (223) (Instance ID 101) (Version 255)] -- [potimeb] (The Plane of Time) inst_id [101] 
  Zone |    Info    | SaveZoneState Saved [4] zone state spawns -- [potimeb] (The Plane of Time) inst_id [101]
  Zone |    Info    | Shutdown Zone [potimeb] zone_id [223] version [255] instance_id [101] -- [potimeb] (The Plane of Time) inst_id [101]
  Zone |    Info    | Shutdown Zone [potimeb] zone_id [223] version [255] instance_id [101] Going to sleep -- [potimeb] (The Plane of Time) inst_id [101] 
<SNIP>
  Zone |    Info    | Init Zone booted successfully zone_id [223] time_offset [0] -- [potimeb] (The Plane of Time) inst_id [101]
  Zone |    Info    | Bootup Zone server [potimeb] listening on port [7029] -- [potimeb] (The Plane of Time) inst_id [101]
  Zone |    Info    | Bootup Zone bootup type [Dynamic] short_name [potimeb] zone_id [223] instance_id [101] -- [potimeb] (The Plane of Time) inst_id [101]
  Zone |    Info    | GetTimeSync Requesting world time -- [potimeb] (The Plane of Time) inst_id [101]
  Zone |    Info    | StartShutdownTimer Reset to [1 Hour] (Loaded from [zone table]) from original remaining time [5 Seconds] duration [5 Seconds] zone [PID (2067571) The Plane of Time (223) (Instance ID 101) (Version 255)] -- [potimeb] (The Plane of Time) inst_id [101] 
  Zone |    Info    | StartFileLogs Starting File Log [logs/zone/potimeb_version_255_inst_id_101_port_7029_2067571.log] -- [potimeb] (The Plane of Time) inst_id [101] 
  Zone |    Info    | HandleMessage [HandleMessage] Received Message SyncWorldTime -- [potimeb] (The Plane of Time) inst_id [101]
  Zone |    Info    | HandleMessage Time Broadcast Packet: EQTime [07:35 am] -- [potimeb] (The Plane of Time) inst_id [101]
  Zone |    Info    | HandleMessage UCS Server is now [online] -- [potimeb] (The Plane of Time) inst_id [101]
  Zone |    Info    | Shutdown Zone [potimeb] zone_id [223] version [255] instance_id [101] -- [potimeb] (The Plane of Time) inst_id [101]
  Zone |    Info    | ~Zone Zone destructor called for zone [potimeb] -- [potimeb] (The Plane of Time) inst_id [101]
  Zone |    Info    | MapOpcodes Mapped [640] client opcode handlers -- [potimeb] (The Plane of Time) inst_id [101]
  Zone |    Info    | MapOpcodes Mapped [640] client opcode handlers -- [potimeb] (The Plane of Time) inst_id [101]
  Zone |    Info    | Shutdown Shutting down -- [potimeb] (The Plane of Time) inst_id [101]
  Zone |    Info    | main Proper zone shutdown complete. -- [potimeb] (The Plane of Time) inst_id [101]
```

Unit Tests:

![image](https://github.com/user-attachments/assets/82cb123f-9c65-4f04-b909-78fa26066246)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
