### PR TITLE
[Performance] Character Save Optimizations

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -995,6 +995,8 @@ bool Client::Save(uint8 iCommitNow) {
 	if(!ClientDataLoaded())
 		return false;
 
+	BenchTimer timer;
+
 	/* Wrote current basics to PP for saves */
 	if (!m_lock_save_position) {
 		m_pp.x       = m_Position.x;
@@ -1021,6 +1023,8 @@ bool Client::Save(uint8 iCommitNow) {
 		m_pp.mana      = current_mana;
 		m_pp.endurance = current_endurance;
 	}
+
+	database.TransactionBegin();
 
 	/* Save Character Currency */
 	database.SaveCharacterCurrency(CharacterID(), &m_pp);
@@ -1104,6 +1108,10 @@ bool Client::Save(uint8 iCommitNow) {
 	if (RuleB(Bots, Enabled)) {
 		database.botdb.SaveBotSettings(this);
 	}
+
+	database.TransactionCommit();
+
+	LogInfo("Save for [{}] took [{}]", GetCleanName(), timer.elapsed());
 
 	return true;
 }

--- a/zone/client.h
+++ b/zone/client.h
@@ -483,6 +483,9 @@ public:
 
 	virtual bool Save() { return Save(0); }
 	bool Save(uint8 iCommitNow); // 0 = delayed, 1=async now, 2=sync now
+	inline void SaveCharacterData() {
+		database.SaveCharacterData(this, &m_pp, &m_epp);
+	};
 
 	/* New PP Save Functions */
 	bool SaveCurrency(){ return database.SaveCharacterCurrency(this->CharacterID(), &m_pp); }

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -217,6 +217,8 @@ bool Client::Process() {
 				GetMerc()->Depop();
 			}
 			instalog = true;
+
+			camp_timer.Disable();
 		}
 
 		if (IsStunned() && stunned_timer.Check())

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -4621,8 +4621,12 @@ void Mob::SetZone(uint32 zone_id, uint32 instance_id)
 	{
 		CastToClient()->GetPP().zone_id = zone_id;
 		CastToClient()->GetPP().zoneInstance = instance_id;
+		CastToClient()->SaveCharacterData();
 	}
-	Save();
+
+	if (!IsClient()) {
+		Save(); // bots or other things might be covered here for some reason
+	}
 }
 
 void Mob::Kill() {

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -528,8 +528,12 @@ void Client::DoZoneSuccess(ZoneChange_Struct *zc, uint16 zone_id, uint32 instanc
 	m_pp.zone_id = zone_id;
 	m_pp.zoneInstance = instance_id;
 
-	//Force a save so its waiting for them when they zone
-	Save(2);
+	// save character position
+	m_pp.x       = m_Position.x;
+	m_pp.y       = m_Position.y;
+	m_pp.z       = m_Position.z;
+	m_pp.heading = m_Position.w;
+	SaveCharacterData();
 
 	m_lock_save_position = true;
 


### PR DESCRIPTION
# Description

This change does a few optimizations

* Wraps the whole Client::Save in a database transaction, shaving time down 3-5x
* Cuts down 8-10 instant camp saves down to 1
* Cuts down 5 saves during zone down to 2 (On during Handle_OP_Save and one during client deconstructor)
* In a few spots where do a full Client::Save we just do a Client::SaveCharacterData where only updating the character row is relevant

## Type of change

- [x] Optimizations

# Testing

Tested zoning, saving, camping etc.

**During Zoning (Before)**

```
  Zone |    Info    | DoZoneSuccess Here -- [qrg] (The Surefall Glade) inst_id [0]
  Zone |    Info    | Save Save for [Akka] took [0.011829743] -- [qrg] (The Surefall Glade) inst_id [0]
  Zone |    Info    | ResetShutdownTimer Reset to [8 Minutes and 20 Seconds] from original remaining time [8 Minutes and 9 Seconds] duration [8 Minutes and 20 Seconds] zone [PID (144477) The Surefall Glade (3)] -- [qrg] (The Surefall Glade) inst_id [0]
 World | Client Log | SetOnline Online status [test] (12) status [Zoning] (4) 
  Zone |    Info    | Save Save for [Akka] took [0.002534652] -- [qrg] (The Surefall Glade) inst_id [0]
  Zone |    Info    | SetZone Here -- [qrg] (The Surefall Glade) inst_id [0]
  Zone |    Info    | Save Save for [Akka] took [0.002374837] -- [qrg] (The Surefall Glade) inst_id [0]
  Zone |    Info    | SetZone Here -- [qrg] (The Surefall Glade) inst_id [0]
  Zone |    Info    | Save Save for [Akka] took [0.002776915] -- [qrg] (The Surefall Glade) inst_id [0]
  Zone |    Info    | Handle_OP_Save Here -- [qrg] (The Surefall Glade) inst_id [0]
  Zone |    Info    | ~Client Here -- [qrg] (The Surefall Glade) inst_id [0]
  Zone |    Info    | Save Save for [Akka] took [0.002541117] -- [qrg] (The Surefall Glade) inst_id [0]
```

**(After change) During zoning**

```
  Zone |    Info    | Handle_OP_ZoneChange [Akka] Bypassing zone expansion checks because GM flag is set -- [qrg] (The Surefall Glade) inst_id [0]
  Zone |    Info    | ResetShutdownTimer Reset to [8 Minutes and 20 Seconds] from original remaining time [8 Minutes and 12 Seconds] duration [8 Minutes and 20 Seconds] zone [PID (144740) The Surefall Glade (3)] -- [qrg] (The Surefall Glade) inst_id [0]
 World | Client Log | SetOnline Online status [test] (12) status [Zoning] (4) 
  Zone |    Info    | Save Save for [Akka] took [0.011667529] -- [qrg] (The Surefall Glade) inst_id [0]
  Zone |    Info    | Handle_OP_Save Here -- [qrg] (The Surefall Glade) inst_id [0]
  Zone |    Info    | ~Client Here -- [qrg] (The Surefall Glade) inst_id [0]
  Zone |    Info    | Save Save for [Akka] took [0.00261106] -- [qrg] (The Surefall Glade) inst_id [0]
```

**During Camp (Before)**

```
  Zone |    Info    | Save Save for [Akka] took [0.015700742] -- [halas] (Halas) inst_id [0]
  Zone |    Info    | Process Here camp timer -- [halas] (Halas) inst_id [0]
  Zone |    Info    | Save Save for [Akka] took [0.002658649] -- [halas] (Halas) inst_id [0]
  Zone |    Info    | Process Here camp timer -- [halas] (Halas) inst_id [0]
  Zone |    Info    | Save Save for [Akka] took [0.01285233] -- [halas] (Halas) inst_id [0]
  Zone |    Info    | Process Here camp timer -- [halas] (Halas) inst_id [0]
  Zone |    Info    | Save Save for [Akka] took [0.011525433] -- [halas] (Halas) inst_id [0]
  Zone |    Info    | Process Here camp timer -- [halas] (Halas) inst_id [0]
  Zone |    Info    | Save Save for [Akka] took [0.012132406] -- [halas] (Halas) inst_id [0]
  Zone |    Info    | Process Here camp timer -- [halas] (Halas) inst_id [0]
  Zone |    Info    | Save Save for [Akka] took [0.003330417] -- [halas] (Halas) inst_id [0]
  Zone |    Info    | Process Here camp timer -- [halas] (Halas) inst_id [0]
  Zone |    Info    | Save Save for [Akka] took [0.011929114] -- [halas] (Halas) inst_id [0]
  Zone |    Info    | Process Here camp timer -- [halas] (Halas) inst_id [0]
  Zone |    Info    | ~Client Here -- [halas] (Halas) inst_id [0]
```

After only shows 2 saves, OP_Save and ~Client deconstructor

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

