### PR TITLE
[Database] Fix manifest for `helmtexture` in `horses` table

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -6943,7 +6943,7 @@ CREATE TABLE `character_pet_name` (
 		.description = "2025_03_7_expand_horse_def.sql",
 		.check = "SHOW COLUMNS FROM `horses` LIKE 'helmtexture'",
 		.condition = "missing",
-		.match = "TINYINT(2)",
+		.match = "tinyint(2)",
 		.sql = R"(
 ALTER TABLE `horses`
 	ADD COLUMN `helmtexture` TINYINT(2) NOT NULL DEFAULT -1 AFTER `texture`;

--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -6942,8 +6942,8 @@ CREATE TABLE `character_pet_name` (
 		.version = 9310,
 		.description = "2025_03_7_expand_horse_def.sql",
 		.check = "SHOW COLUMNS FROM `horses` LIKE 'helmtexture'",
-		.condition = "missing",
-		.match = "tinyint(2)",
+		.condition = "empty",
+		.match = "",
 		.sql = R"(
 ALTER TABLE `horses`
 	ADD COLUMN `helmtexture` TINYINT(2) NOT NULL DEFAULT -1 AFTER `texture`;


### PR DESCRIPTION
# Description

Database check fails for 9310 due to wrong check if column already exists.

```bash
 World |  QueryErr  | QueryDatabaseMulti [Duplicate column name 'helmtexture'] (1060) query [ALTER TABLE `horses`	ADD COLUMN `helmtexture` TINYINT(2) NOT NULL DEFAULT -1 AFTER `texture`;] 
 World |   Error    | UpdateManifest (#1060) [Duplicate column name 'helmtexture'] 
 World |    Info    | UpdateManifest Required database update failed. This could be a problem 
 World |    Info    | UpdateManifest Skipping update [9310] [2025_03_7_expand_horse_def.sql] 
 World |    Info    | UpdateManifest [9310] [2025_03_7_expand_horse_def.sql] [error] 
 World |   Error    | UpdateManifest Fatal | Database migration [2025_03_7_expand_horse_def.sql] failed to run
```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

Column exists:
```bash
 World |    Info    | UpdateManifest [9310]       [ok] | [2025_03_7_expand_horse_def.sql] 
```

Column missing:
```bash
 World |    Info    | UpdateManifest [9310]  [missing] | [2025_03_7_expand_horse_def.sql] 
...
 World |    Info    | UpdateManifest ---------------------------------------------------------------------- 
 World |    Info    | UpdateManifest Running database migrations. Please wait... 
 World |    Info    | UpdateManifest ---------------------------------------------------------------------- 
 World |    Info    | UpdateManifest [9310] [2025_03_7_expand_horse_def.sql] [ok] 
 World |    Info    | UpdateManifest [9314] [2025_03_12_zone_state_spawns_one_time_truncate.sql] [ok] 
 World |    Info    | UpdateManifest ---------------------------------------------------------------------- 
 World |    Info    | CheckDbUpdates Updates ran successfully, setting database version to [9321] from [9309] 
```

Clients tested: N/A

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
- [X] If my changes make database schema changes, I have tested the changes on a local database (attach image). Updated version.h CURRENT_BINARY_DATABASE_VERSION to the new version. (Delete this if not applicable)
