### PR TITLE
[Netcode] Fix Stale Client Edge Case

### DIFF
--- a/common/net/daybreak_connection.cpp
+++ b/common/net/daybreak_connection.cpp
@@ -1117,6 +1117,11 @@ void EQ::Net::DaybreakConnection::ProcessResend(int stream)
 		auto &first_packet = s->sent_packets.begin()->second;
 		auto time_since_first_sent = std::chrono::duration_cast<std::chrono::milliseconds>(now - first_packet.first_sent).count();
 
+		if (time_since_first_sent >= m_owner->m_options.resend_timeout) {
+			Close();
+			return;
+		}
+
 		// make sure that the first_packet in the list first_sent time is within the resend_delay and now
 		// if it is not, then we need to resend all packets in the list
 		if (time_since_first_sent <= first_packet.resend_delay && !m_acked_since_last_resend) {
@@ -1127,11 +1132,6 @@ void EQ::Net::DaybreakConnection::ProcessResend(int stream)
 				first_packet.resend_delay,
 				m_acked_since_last_resend
 			);
-			return;
-		}
-
-		if (time_since_first_sent >= m_owner->m_options.resend_timeout) {
-			Close();
 			return;
 		}
 	}

--- a/common/net/daybreak_connection.cpp
+++ b/common/net/daybreak_connection.cpp
@@ -342,16 +342,16 @@ EQ::Net::DaybreakConnection::~DaybreakConnection()
 
 void EQ::Net::DaybreakConnection::Close()
 {
-	if (m_status == StatusConnected) {
+	if (m_status != StatusDisconnected && m_status != StatusDisconnecting) {
 		FlushBuffer();
 		SendDisconnect();
+	}
 
+	if (m_status != StatusDisconnecting) {
 		m_close_time = Clock::now();
-		ChangeStatus(StatusDisconnecting);
 	}
-	else {
-		ChangeStatus(StatusDisconnecting);
-	}
+
+	ChangeStatus(StatusDisconnecting);
 }
 
 void EQ::Net::DaybreakConnection::QueuePacket(Packet &p)


### PR DESCRIPTION
# Description

This fixes a rare edge case introduced as a regression by this [PR](https://github.com/EQEmu/Server/pull/4629). 

This fix is brought about observing scenarios where certain clients can all of a sudden not enter certain zones meanwhile there are other clients functioning just fine in the zone. After rebooting the zone they can enter just fine. This started occurring around the time this resend fix was introduced (while massive) introduced a rare intermittent undesired case.

There is no proof that this is the smoking gun, but it seems extremely suspect. We can get in scenarios where the connection infinitely gets stuck in ProcessResend and never closes. This moves one conditional up to make sure we're checking timestamps against resend timeout so we can close the connection.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Tested basic logging in.

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

