### PR TITLE
[Performance] Network Ring Buffers

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -671,6 +671,7 @@ SET(common_headers
     net/console_server_connection.h
     net/crc32.h
     net/daybreak_connection.h
+    net/daybreak_pooling.h
     net/daybreak_structs.h
     net/dns.h
     net/endian.h
@@ -682,6 +683,7 @@ SET(common_headers
     net/servertalk_server.h
     net/servertalk_server_connection.h
     net/tcp_connection.h
+    net/tcp_connection_pooling.h
     net/tcp_server.h
     net/websocket_server.h
     net/websocket_server_connection.h
@@ -742,6 +744,7 @@ SOURCE_GROUP(Net FILES
     net/crc32.h
     net/daybreak_connection.cpp
     net/daybreak_connection.h
+    net/daybreak_pooling.h
     net/daybreak_structs.h
     net/dns.h
     net/endian.h
@@ -762,6 +765,7 @@ SOURCE_GROUP(Net FILES
     net/servertalk_server_connection.h
     net/tcp_connection.cpp
     net/tcp_connection.h
+    net/tcp_connection_pooling.h
     net/tcp_server.cpp
     net/tcp_server.h
     net/websocket_server.cpp

--- a/common/eqemu_logsys.h
+++ b/common/eqemu_logsys.h
@@ -74,7 +74,7 @@ namespace Logs {
 		Spawns,
 		Spells,
 		Status, // deprecated
-		TCPConnection,
+		TCPConnection, // deprecated
 		Tasks,
 		Tradeskills,
 		Trading,
@@ -150,6 +150,8 @@ namespace Logs {
 		BotSpellTypeChecks,
 		NpcHandin,
 		ZoneState,
+		NetClient,
+		NetTCP,
 		MaxCategoryID /* Don't Remove this */
 	};
 
@@ -183,7 +185,7 @@ namespace Logs {
 		"Spawns",
 		"Spells",
 		"Status (Deprecated)",
-		"TCP Connection",
+		"TCP Connection (Deprecated)",
 		"Tasks",
 		"Tradeskills",
 		"Trading",
@@ -258,7 +260,9 @@ namespace Logs {
 		"Bot Spell Checks",
 		"Bot Spell Type Checks",
 		"NpcHandin",
-		"ZoneState"
+		"ZoneState",
+		"Net Server <-> Client",
+		"Net TCP"
 	};
 }
 

--- a/common/eqemu_logsys_log_aliases.h
+++ b/common/eqemu_logsys_log_aliases.h
@@ -261,26 +261,6 @@
         OutF(LogSys, Logs::Detail, Logs::Spells, __FILE__, __func__, __LINE__, message, ##__VA_ARGS__);\
 } while (0)
 
-#define LogStatus(message, ...) do {\
-    if (LogSys.IsLogEnabled(Logs::General, Logs::Status))\
-        OutF(LogSys, Logs::General, Logs::Status, __FILE__, __func__, __LINE__, message, ##__VA_ARGS__);\
-} while (0)
-
-#define LogStatusDetail(message, ...) do {\
-    if (LogSys.IsLogEnabled(Logs::Detail, Logs::Status))\
-        OutF(LogSys, Logs::Detail, Logs::Status, __FILE__, __func__, __LINE__, message, ##__VA_ARGS__);\
-} while (0)
-
-#define LogTCPConnection(message, ...) do {\
-    if (LogSys.IsLogEnabled(Logs::General, Logs::TCPConnection))\
-        OutF(LogSys, Logs::General, Logs::TCPConnection, __FILE__, __func__, __LINE__, message, ##__VA_ARGS__);\
-} while (0)
-
-#define LogTCPConnectionDetail(message, ...) do {\
-    if (LogSys.IsLogEnabled(Logs::Detail, Logs::TCPConnection))\
-        OutF(LogSys, Logs::Detail, Logs::TCPConnection, __FILE__, __func__, __LINE__, message, ##__VA_ARGS__);\
-} while (0)
-
 #define LogTasks(message, ...) do {\
     if (LogSys.IsLogEnabled(Logs::General, Logs::Tasks))\
         OutF(LogSys, Logs::General, Logs::Tasks, __FILE__, __func__, __LINE__, message, ##__VA_ARGS__);\
@@ -922,6 +902,26 @@
 #define LogZoneStateDetail(message, ...) do {\
     if (LogSys.IsLogEnabled(Logs::Detail, Logs::ZoneState))\
         OutF(LogSys, Logs::Detail, Logs::ZoneState, __FILE__, __func__, __LINE__, message, ##__VA_ARGS__);\
+} while (0)
+
+#define LogNetClient(message, ...) do {\
+    if (LogSys.IsLogEnabled(Logs::General, Logs::NetClient))\
+        OutF(LogSys, Logs::General, Logs::NetClient, __FILE__, __func__, __LINE__, message, ##__VA_ARGS__);\
+} while (0)
+
+#define LogNetClientDetail(message, ...) do {\
+    if (LogSys.IsLogEnabled(Logs::Detail, Logs::NetClient))\
+        OutF(LogSys, Logs::Detail, Logs::NetClient, __FILE__, __func__, __LINE__, message, ##__VA_ARGS__);\
+} while (0)
+
+#define LogNetTCP(message, ...) do {\
+    if (LogSys.IsLogEnabled(Logs::General, Logs::NetTCP))\
+        OutF(LogSys, Logs::General, Logs::NetTCP, __FILE__, __func__, __LINE__, message, ##__VA_ARGS__);\
+} while (0)
+
+#define LogNetTCPDetail(message, ...) do {\
+    if (LogSys.IsLogEnabled(Logs::Detail, Logs::NetTCP))\
+        OutF(LogSys, Logs::Detail, Logs::NetTCP, __FILE__, __func__, __LINE__, message, ##__VA_ARGS__);\
 } while (0)
 
 #define Log(debug_level, log_category, message, ...) do {\

--- a/common/net/daybreak_connection.h
+++ b/common/net/daybreak_connection.h
@@ -3,6 +3,7 @@
 #include "../random.h"
 #include "packet.h"
 #include "daybreak_structs.h"
+#include "daybreak_pooling.h"
 #include <uv.h>
 #include <chrono>
 #include <functional>

--- a/common/net/daybreak_pooling.h
+++ b/common/net/daybreak_pooling.h
@@ -1,0 +1,123 @@
+#pragma once
+
+#include <optional>
+#include <atomic>
+#include <memory>
+#include <array>
+#include <vector>
+#include <mutex>
+#include <iostream>
+#include "../eqemu_logsys.h"
+#include <uv.h>
+
+constexpr size_t UDP_BUFFER_SIZE = 512;
+
+struct EmbeddedContext {
+	size_t pool_index;
+	class SendBufferPool* pool;
+};
+
+class SendBufferPool {
+public:
+	explicit SendBufferPool(size_t initial_capacity = 64)
+		: m_capacity(initial_capacity), m_head(0)
+	{
+		LogNetClient("[SendBufferPool] Initializing with capacity [{}]", (int)m_capacity);
+
+		m_pool.reserve(m_capacity);
+		m_locks = std::make_unique<std::atomic_bool[]>(m_capacity);
+
+		for (size_t i = 0; i < m_capacity; ++i) {
+			auto* req = new PooledUdpSend();
+			req->context.pool_index = i;
+			req->context.pool = this;
+			req->uv_req.data = &req->context;
+
+			m_pool.emplace_back(std::unique_ptr<PooledUdpSend>(req));
+			m_locks[i].store(false, std::memory_order_relaxed);
+		}
+	}
+
+	std::optional<std::tuple<uv_udp_send_t*, char*, EmbeddedContext*>> acquire() {
+		size_t cap = m_capacity.load(std::memory_order_acquire);
+		for (size_t i = 0; i < cap; ++i) {
+			size_t index = m_head.fetch_add(1, std::memory_order_relaxed) % cap;
+			bool expected = false;
+			if (m_locks[index].compare_exchange_strong(expected, true)) {
+				auto* req = m_pool[index].get();
+				LogNetClientDetail("[SendBufferPool] Acquired [{}]", index);
+				return std::make_tuple(&req->uv_req, req->buffer.data(), &req->context);
+			}
+		}
+
+		LogNetClient("[SendBufferPool] Growing from [{}] to [{}]", cap, cap * 2);
+		grow();
+		return acquireAfterGrowth();
+	}
+
+	void release(EmbeddedContext* ctx) {
+		if (!ctx || ctx->pool != this || ctx->pool_index >= m_capacity.load(std::memory_order_acquire)) {
+			LogNetClient("[SendBufferPool] Invalid context release [{}]", ctx ? ctx->pool_index : -1);
+			return;
+		}
+		m_locks[ctx->pool_index].store(false, std::memory_order_release);
+		LogNetClientDetail("[SendBufferPool] Released [{}]", ctx->pool_index);
+	}
+
+private:
+	struct PooledUdpSend {
+		uv_udp_send_t                     uv_req;
+		std::array<char, UDP_BUFFER_SIZE> buffer;
+		EmbeddedContext                   context;
+	};
+
+	std::vector<std::unique_ptr<PooledUdpSend>> m_pool;
+	std::unique_ptr<std::atomic_bool[]> m_locks;
+	std::atomic<size_t> m_capacity;
+	std::atomic<size_t> m_head;
+	std::mutex m_grow_mutex;
+
+	void grow() {
+		std::lock_guard<std::mutex> lock(m_grow_mutex);
+
+		size_t old_cap = m_capacity.load(std::memory_order_acquire);
+		size_t new_cap = old_cap * 2;
+
+		m_pool.reserve(new_cap);
+		for (size_t i = old_cap; i < new_cap; ++i) {
+			auto* req = new PooledUdpSend();
+			req->context.pool_index = i;
+			req->context.pool = this;
+			req->uv_req.data = &req->context;
+
+			m_pool.emplace_back(std::unique_ptr<PooledUdpSend>(req));
+		}
+
+		auto new_locks = std::make_unique<std::atomic_bool[]>(new_cap);
+		for (size_t i = 0; i < old_cap; ++i) {
+			new_locks[i].store(m_locks[i].load(std::memory_order_acquire));
+		}
+		for (size_t i = old_cap; i < new_cap; ++i) {
+			new_locks[i].store(false, std::memory_order_relaxed);
+		}
+
+		m_locks = std::move(new_locks);
+		m_capacity.store(new_cap, std::memory_order_release);
+
+		LogNetClient("[SendBufferPool] Grew to [{}] from [{}]", new_cap, old_cap);
+	}
+
+	std::optional<std::tuple<uv_udp_send_t*, char*, EmbeddedContext*>> acquireAfterGrowth() {
+		size_t cap = m_capacity.load(std::memory_order_acquire);
+		for (size_t i = 0; i < cap; ++i) {
+			size_t index = m_head.fetch_add(1, std::memory_order_relaxed) % cap;
+			bool expected = false;
+			if (m_locks[index].compare_exchange_strong(expected, true)) {
+				auto* req = m_pool[index].get();
+				LogNetClient("[SendBufferPool] Acquired after grow [{}]", index);
+				return std::make_tuple(&req->uv_req, req->buffer.data(), &req->context);
+			}
+		}
+		return std::nullopt;
+	}
+};

--- a/common/net/daybreak_structs.h
+++ b/common/net/daybreak_structs.h
@@ -171,3 +171,4 @@ namespace EQ
 		};
 	}
 }
+

--- a/common/net/servertalk_client_connection.cpp
+++ b/common/net/servertalk_client_connection.cpp
@@ -62,15 +62,15 @@ void EQ::Net::ServertalkClient::Connect()
 	m_connecting = true;
 	EQ::Net::TCPConnection::Connect(m_addr, m_port, false, [this](std::shared_ptr<EQ::Net::TCPConnection> connection) {
 		if (connection == nullptr) {
-			LogF(Logs::General, Logs::TCPConnection, "Error connecting to {0}:{1}, attempting to reconnect...", m_addr, m_port);
+			LogNetTCP("Error connecting to {0}:{1}, attempting to reconnect...", m_addr, m_port);
 			m_connecting = false;
 			return;
 		}
 
-		LogF(Logs::General, Logs::TCPConnection, "Connected to {0}:{1}", m_addr, m_port);
+		LogNetTCP("Connected to {0}:{1}", m_addr, m_port);
 		m_connection = connection;
 		m_connection->OnDisconnect([this](EQ::Net::TCPConnection *c) {
-			LogF(Logs::General, Logs::TCPConnection, "Connection lost to {0}:{1}, attempting to reconnect...", m_addr, m_port);
+			LogNetTCP("Connection lost to {0}:{1}, attempting to reconnect...", m_addr, m_port);
 			m_connection.reset();
 		});
 

--- a/common/net/servertalk_legacy_client_connection.cpp
+++ b/common/net/servertalk_legacy_client_connection.cpp
@@ -58,15 +58,15 @@ void EQ::Net::ServertalkLegacyClient::Connect()
 	m_connecting = true;
 	EQ::Net::TCPConnection::Connect(m_addr, m_port, false, [this](std::shared_ptr<EQ::Net::TCPConnection> connection) {
 		if (connection == nullptr) {
-			LogF(Logs::General, Logs::TCPConnection, "Error connecting to {0}:{1}, attempting to reconnect...", m_addr, m_port);
+			LogNetTCP("Error connecting to {0}:{1}, attempting to reconnect...", m_addr, m_port);
 			m_connecting = false;
 			return;
 		}
 
-		LogF(Logs::General, Logs::TCPConnection, "Connected to {0}:{1}", m_addr, m_port);
+		LogNetTCP("Connected to {0}:{1}", m_addr, m_port);
 		m_connection = connection;
 		m_connection->OnDisconnect([this](EQ::Net::TCPConnection *c) {
-			LogF(Logs::General, Logs::TCPConnection, "Connection lost to {0}:{1}, attempting to reconnect...", m_addr, m_port);
+			LogNetTCP("Connection lost to {0}:{1}, attempting to reconnect...", m_addr, m_port);
 			m_connection.reset();
 		});
 
@@ -131,7 +131,7 @@ void EQ::Net::ServertalkLegacyClient::ProcessReadBuffer()
 		}
 		else {
 			EQ::Net::StaticPacket p(&m_buffer[current + 4], length);
-			
+
 			auto cb = m_message_callbacks.find(opcode);
 			if (cb != m_message_callbacks.end()) {
 				cb->second(opcode, p);

--- a/common/net/tcp_connection.cpp
+++ b/common/net/tcp_connection.cpp
@@ -1,5 +1,8 @@
 #include "tcp_connection.h"
 #include "../event/event_loop.h"
+#include <iostream>
+
+WriteReqPool tcp_write_pool;
 
 void on_close_handle(uv_handle_t* handle) {
 	delete (uv_tcp_t *)handle;
@@ -64,36 +67,37 @@ void EQ::Net::TCPConnection::Connect(const std::string &addr, int port, bool ipv
 	});
 }
 
-void EQ::Net::TCPConnection::Start() {
-	uv_read_start((uv_stream_t*)m_socket, [](uv_handle_t* handle, size_t suggested_size, uv_buf_t* buf) {
-		buf->base = new char[suggested_size];
-		buf->len = suggested_size;
-	}, [](uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf) {
+void EQ::Net::TCPConnection::Start()
+{
+	uv_read_start(
+		(uv_stream_t *) m_socket, [](uv_handle_t *handle, size_t suggested_size, uv_buf_t *buf) {
+			if (suggested_size > 65536) {
+				buf->base = new char[suggested_size];
+				buf->len  = suggested_size;
+				return;
+			}
 
-		TCPConnection *connection = (TCPConnection*)stream->data;
+			static thread_local char temp_buf[65536];
+			buf->base = temp_buf;
+			buf->len  = 65536;
+		}, [](uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf) {
+			auto *connection = (TCPConnection *) stream->data;
 
-		if (nread > 0) {
-			connection->Read(buf->base, nread);
+			if (nread > 0) {
+				connection->Read(buf->base, nread);
+			}
+			else if (nread == UV_EOF) {
+				connection->Disconnect();
+			}
+			else if (nread < 0) {
+				connection->Disconnect();
+			}
 
-			if (buf->base) {
-				delete[] buf->base;
+			if (buf->len > 65536) {
+				delete [] buf->base;
 			}
 		}
-		else if (nread == UV_EOF) {
-			connection->Disconnect();
-
-			if (buf->base) {
-				delete[] buf->base;
-			}
-		}
-		else if (nread < 0) {
-			connection->Disconnect();
-
-			if (buf->base) {
-				delete[] buf->base;
-			}
-		}
-	});
+	);
 }
 
 void EQ::Net::TCPConnection::OnRead(std::function<void(TCPConnection*, const unsigned char*, size_t)> cb)
@@ -130,42 +134,91 @@ void EQ::Net::TCPConnection::Read(const char *data, size_t count)
 	}
 }
 
-void EQ::Net::TCPConnection::Write(const char *data, size_t count)
-{
-	if (!m_socket) {
+void EQ::Net::TCPConnection::Write(const char* data, size_t count) {
+	if (!m_socket || !data || count == 0) {
+		std::cerr << "TCPConnection::Write - Invalid socket or data\n";
 		return;
 	}
 
-	struct WriteBaton
-	{
-		TCPConnection *connection;
-		char *buffer;
-	};
-
-	WriteBaton *baton = new WriteBaton;
-	baton->connection = this;
-	baton->buffer = new char[count];
-
-	uv_write_t *write_req = new uv_write_t;
-	memset(write_req, 0, sizeof(uv_write_t));
-	write_req->data = baton;
-	uv_buf_t send_buffers[1];
-
-	memcpy(baton->buffer, data, count);
-	send_buffers[0] = uv_buf_init(baton->buffer, count);
-
-	uv_write(write_req, (uv_stream_t*)m_socket, send_buffers, 1, [](uv_write_t* req, int status) {
-		WriteBaton *baton = (WriteBaton*)req->data;
-		delete[] baton->buffer;
-		delete req;
-
-		if (status < 0) {
-			baton->connection->Disconnect();
+	if (count <= TCP_BUFFER_SIZE) {
+		// Fast path: use pooled request with embedded buffer
+		auto req_opt = tcp_write_pool.acquire();
+		if (!req_opt) {
+			std::cerr << "TCPConnection::Write - Out of write requests\n";
+			return;
 		}
 
-		delete baton;
-	});
+		TCPWriteReq* write_req = *req_opt;
+
+		// Fill buffer and set context
+		memcpy(write_req->buffer.data(), data, count);
+		write_req->connection = this;
+		write_req->magic = 0xC0FFEE;
+
+		uv_buf_t buf = uv_buf_init(write_req->buffer.data(), static_cast<unsigned int>(count));
+
+		int result = uv_write(
+			&write_req->req,
+			reinterpret_cast<uv_stream_t*>(m_socket),
+			&buf,
+			1,
+			[](uv_write_t* req, int status) {
+				auto* full_req = reinterpret_cast<TCPWriteReq*>(req);
+				if (full_req->magic != 0xC0FFEE) {
+					std::cerr << "uv_write callback - invalid magic, skipping release\n";
+					return;
+				}
+
+				tcp_write_pool.release(full_req);
+
+				if (status < 0 && full_req->connection) {
+					std::cerr << "uv_write failed: " << uv_strerror(status) << std::endl;
+					full_req->connection->Disconnect();
+				}
+			}
+		);
+
+		if (result < 0) {
+			std::cerr << "uv_write() failed immediately: " << uv_strerror(result) << std::endl;
+			tcp_write_pool.release(write_req);
+		}
+
+	} else {
+		// Slow path: allocate heap buffer for large write
+		LogNetTCP("[TCPConnection] Large write of [{}] bytes, using heap buffer", count);
+
+		char* heap_buffer = new char[count];
+		memcpy(heap_buffer, data, count);
+
+		uv_write_t* write_req = new uv_write_t;
+		write_req->data = heap_buffer;
+
+		uv_buf_t buf = uv_buf_init(heap_buffer, static_cast<unsigned int>(count));
+
+		int result = uv_write(
+			write_req,
+			reinterpret_cast<uv_stream_t*>(m_socket),
+			&buf,
+			1,
+			[](uv_write_t* req, int status) {
+				char* data = static_cast<char*>(req->data);
+				delete[] data;
+				delete req;
+
+				if (status < 0) {
+					std::cerr << "uv_write (large) failed: " << uv_strerror(status) << std::endl;
+				}
+			}
+		);
+
+		if (result < 0) {
+			std::cerr << "uv_write() (large) failed immediately: " << uv_strerror(result) << std::endl;
+			delete[] heap_buffer;
+			delete write_req;
+		}
+	}
 }
+
 
 std::string EQ::Net::TCPConnection::LocalIP() const
 {

--- a/common/net/tcp_connection.h
+++ b/common/net/tcp_connection.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "tcp_connection_pooling.h"
 #include <functional>
 #include <string>
 #include <memory>
@@ -16,7 +17,7 @@ namespace EQ
 			~TCPConnection();
 
 			static void Connect(const std::string &addr, int port, bool ipv6, std::function<void(std::shared_ptr<TCPConnection>)> cb);
-			
+
 			void Start();
 			void OnRead(std::function<void(TCPConnection*, const unsigned char *, size_t)> cb);
 			void OnDisconnect(std::function<void(TCPConnection*)> cb);

--- a/common/net/tcp_connection_pooling.h
+++ b/common/net/tcp_connection_pooling.h
@@ -10,10 +10,8 @@
 #include <uv.h>
 #include <iostream>
 
-// forward declaration
 namespace EQ { namespace Net { class TCPConnection; } }
 
-//constexpr size_t TCP_BUFFER_SIZE = 1024;
 constexpr size_t TCP_BUFFER_SIZE = 8192;
 
 struct TCPWriteReq {
@@ -28,20 +26,14 @@ class WriteReqPool {
 public:
 	explicit WriteReqPool(size_t initial_capacity = 512)
 		: m_capacity(initial_capacity), m_head(0) {
-		m_reqs.reserve(m_capacity);
-		m_locks = std::make_unique<std::atomic_bool[]>(m_capacity);
-
-		for (size_t i = 0; i < m_capacity; ++i) {
-			m_reqs.emplace_back(std::make_unique<TCPWriteReq>());
-			m_locks[i].store(false, std::memory_order_relaxed);
-		}
+		initialize_pool(m_capacity);
 	}
 
 	std::optional<TCPWriteReq*> acquire() {
-		size_t start = m_head.fetch_add(1, std::memory_order_relaxed) % m_capacity;
+		size_t cap = m_capacity.load(std::memory_order_acquire);
 
-		for (size_t i = 0; i < m_capacity; ++i) {
-			size_t index = (start + i) % m_capacity;
+		for (size_t i = 0; i < cap; ++i) {
+			size_t index = m_head.fetch_add(1, std::memory_order_relaxed) % cap;
 
 			bool expected = false;
 			if (m_locks[index].compare_exchange_strong(expected, true, std::memory_order_acquire)) {
@@ -50,56 +42,78 @@ public:
 			}
 		}
 
+		LogNetTCP("[WriteReqPool] Growing from [{}] to [{}]", cap, cap * 2);
 		grow();
 		return acquireAfterGrow();
 	}
 
 	void release(TCPWriteReq* req) {
-		for (size_t i = 0; i < m_capacity; ++i) {
-			if (m_reqs[i].get() == req) {
-				m_locks[i].store(false, std::memory_order_release);
-				LogNetTCPDetail("[WriteReqPool] Released buffer index [{}]", i);
-				return;
-			}
+		if (!req) return;
+
+		const size_t index = req->buffer_index;
+		const size_t cap = m_capacity.load(std::memory_order_acquire);
+
+		if (index >= cap || m_reqs[index].get() != req) {
+			std::cerr << "WriteReqPool::release - Invalid or stale pointer (index=" << index << ")\n";
+			return;
 		}
-		std::cerr << "WriteReqPool::release - Invalid or stale pointer\n";
+
+		m_locks[index].store(false, std::memory_order_release);
+		LogNetTCPDetail("[WriteReqPool] Released buffer index [{}]", index);
 	}
 
 private:
 	std::vector<std::unique_ptr<TCPWriteReq>> m_reqs;
 	std::unique_ptr<std::atomic_bool[]> m_locks;
+	std::atomic<size_t> m_capacity;
 	std::atomic<size_t> m_head;
-	size_t m_capacity;
 	std::mutex m_grow_mutex;
+
+	void initialize_pool(size_t count) {
+		m_reqs.reserve(count);
+		m_locks = std::make_unique<std::atomic_bool[]>(count);
+
+		for (size_t i = 0; i < count; ++i) {
+			auto req = std::make_unique<TCPWriteReq>();
+			req->buffer_index = i;
+			req->req.data = req.get(); // optional: for use in libuv callbacks
+			m_locks[i].store(false, std::memory_order_relaxed);
+			m_reqs.emplace_back(std::move(req));
+		}
+
+		m_capacity.store(count, std::memory_order_release);
+	}
 
 	void grow() {
 		std::lock_guard<std::mutex> lock(m_grow_mutex);
 
-		size_t old_capacity = m_capacity;
-		size_t new_capacity = old_capacity * 2;
+		const size_t old_cap = m_capacity.load(std::memory_order_acquire);
+		const size_t new_cap = old_cap * 2;
 
-		m_reqs.reserve(new_capacity);
-		for (size_t i = old_capacity; i < new_capacity; ++i) {
-			m_reqs.emplace_back(std::make_unique<TCPWriteReq>());
+		m_reqs.reserve(new_cap);
+		for (size_t i = old_cap; i < new_cap; ++i) {
+			auto req = std::make_unique<TCPWriteReq>();
+			req->buffer_index = i;
+			req->req.data = req.get(); // optional
+			m_reqs.emplace_back(std::move(req));
 		}
 
-		auto new_locks = std::make_unique<std::atomic_bool[]>(new_capacity);
-		for (size_t i = 0; i < old_capacity; ++i) {
+		auto new_locks = std::make_unique<std::atomic_bool[]>(new_cap);
+		for (size_t i = 0; i < old_cap; ++i) {
 			new_locks[i].store(m_locks[i].load(std::memory_order_acquire));
 		}
-		for (size_t i = old_capacity; i < new_capacity; ++i) {
+		for (size_t i = old_cap; i < new_cap; ++i) {
 			new_locks[i].store(false, std::memory_order_relaxed);
 		}
 
 		m_locks = std::move(new_locks);
-		m_capacity = new_capacity;
-
-		LogNetTCP("[WriteReqPool] Grew pool to capacity [{}] from [{}]", m_capacity, old_capacity);
+		m_capacity.store(new_cap, std::memory_order_release);
 	}
 
 	std::optional<TCPWriteReq*> acquireAfterGrow() {
-		// Try every slot once again after growth
-		for (size_t i = 0; i < m_capacity; ++i) {
+		const size_t cap = m_capacity.load(std::memory_order_acquire);
+
+		for (size_t i = 0; i < cap; ++i) {
 			bool expected = false;
 			if (m_locks[i].compare_exchange_strong(expected, true, std::memory_order_acquire)) {
 				LogNetTCP("[WriteReqPool] Acquired buffer index [{}] after grow", i);

--- a/common/net/tcp_connection_pooling.h
+++ b/common/net/tcp_connection_pooling.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include "../eqemu_logsys.h"
+#include <vector>
+#include <array>
+#include <atomic>
+#include <memory>
+#include <optional>
+#include <mutex>
+#include <uv.h>
+#include <iostream>
+
+// forward declaration
+namespace EQ { namespace Net { class TCPConnection; } }
+
+//constexpr size_t TCP_BUFFER_SIZE = 1024;
+constexpr size_t TCP_BUFFER_SIZE = 8192;
+
+struct TCPWriteReq {
+	uv_write_t req{};
+	std::array<char, TCP_BUFFER_SIZE> buffer{};
+	size_t buffer_index{};
+	EQ::Net::TCPConnection* connection{};
+	uint32_t magic = 0xC0FFEE;
+};
+
+class WriteReqPool {
+public:
+	explicit WriteReqPool(size_t initial_capacity = 512)
+		: m_capacity(initial_capacity), m_head(0) {
+		m_reqs.reserve(m_capacity);
+		m_locks = std::make_unique<std::atomic_bool[]>(m_capacity);
+
+		for (size_t i = 0; i < m_capacity; ++i) {
+			m_reqs.emplace_back(std::make_unique<TCPWriteReq>());
+			m_locks[i].store(false, std::memory_order_relaxed);
+		}
+	}
+
+	std::optional<TCPWriteReq*> acquire() {
+		size_t start = m_head.fetch_add(1, std::memory_order_relaxed) % m_capacity;
+
+		for (size_t i = 0; i < m_capacity; ++i) {
+			size_t index = (start + i) % m_capacity;
+
+			bool expected = false;
+			if (m_locks[index].compare_exchange_strong(expected, true, std::memory_order_acquire)) {
+				LogNetTCPDetail("[WriteReqPool] Acquired buffer index [{}]", index);
+				return m_reqs[index].get();
+			}
+		}
+
+		grow();
+		return acquireAfterGrow();
+	}
+
+	void release(TCPWriteReq* req) {
+		for (size_t i = 0; i < m_capacity; ++i) {
+			if (m_reqs[i].get() == req) {
+				m_locks[i].store(false, std::memory_order_release);
+				LogNetTCPDetail("[WriteReqPool] Released buffer index [{}]", i);
+				return;
+			}
+		}
+		std::cerr << "WriteReqPool::release - Invalid or stale pointer\n";
+	}
+
+private:
+	std::vector<std::unique_ptr<TCPWriteReq>> m_reqs;
+	std::unique_ptr<std::atomic_bool[]> m_locks;
+	std::atomic<size_t> m_head;
+	size_t m_capacity;
+	std::mutex m_grow_mutex;
+
+	void grow() {
+		std::lock_guard<std::mutex> lock(m_grow_mutex);
+
+		size_t old_capacity = m_capacity;
+		size_t new_capacity = old_capacity * 2;
+
+		m_reqs.reserve(new_capacity);
+		for (size_t i = old_capacity; i < new_capacity; ++i) {
+			m_reqs.emplace_back(std::make_unique<TCPWriteReq>());
+		}
+
+		auto new_locks = std::make_unique<std::atomic_bool[]>(new_capacity);
+		for (size_t i = 0; i < old_capacity; ++i) {
+			new_locks[i].store(m_locks[i].load(std::memory_order_acquire));
+		}
+		for (size_t i = old_capacity; i < new_capacity; ++i) {
+			new_locks[i].store(false, std::memory_order_relaxed);
+		}
+
+		m_locks = std::move(new_locks);
+		m_capacity = new_capacity;
+
+		LogNetTCP("[WriteReqPool] Grew pool to capacity [{}] from [{}]", m_capacity, old_capacity);
+	}
+
+	std::optional<TCPWriteReq*> acquireAfterGrow() {
+		// Try every slot once again after growth
+		for (size_t i = 0; i < m_capacity; ++i) {
+			bool expected = false;
+			if (m_locks[i].compare_exchange_strong(expected, true, std::memory_order_acquire)) {
+				LogNetTCP("[WriteReqPool] Acquired buffer index [{}] after grow", i);
+				return m_reqs[i].get();
+			}
+		}
+		return std::nullopt;
+	}
+};


### PR DESCRIPTION
# Description

This PR implements network ring buffers in both our TCP server to server code and UDP client facing sending code.

**This results in lower overhead network code, higher throughput, less CPU utilization etc.**

**High Level Changes**

* Use static memory during TCP packet receive (up to 65536, anything bigger is allocated/deallocated)
* Use static ring buffer pool during TCP packet send (up to TCP_BUFFER_SIZE 8192, anything bigger is allocated/deallocated)
* Use static memory during UDP packet receive (up to 512 bytes)
* Use static ring buffer pool during UDP packet send (512 bytes)
* Use static memory during packet compression
* Add LogNetClient for (UDP / Daybreak Client logging)
* Add LogNetTCP for TCP (Server to Server, Console server etc.)

### :repeat: Ring Buffers

Instead of allocating and freeing memory for **every single packet**, we now use **pre-allocated, reusable memory pools**. That means dramatically lower CPU overhead and tighter control over memory churn.

- **Client (UDP) traffic is now ring-buffered**—zero-allocation for sends.
- **Server-to-server (TCP) traffic is ring-buffered**—covers world ↔ zone, zone ↔ queryserv, etc.
- Buffers **grow on demand** without dropping in-flight traffic.
### :electric_plug: Server-to-Server Netcode

We’ve ring-buffered the entire TCP backbone—**world ↔ zone**, **zone ↔ queryserv**, etc. This makes inter-server communication faster, leaner, and scalable. 
### :package: Compression Buffers

We used to allocate **2KB per packet** just to compress data sent to clients. That’s now **statically allocated**. Same goes for decompression on inbound packets.
### :firecracker: Receive Buffer Disaster

We were allocating **65KB per packet** on both TCP (server-to-server) and UDP (client). That’s fixed. Buffers are now **nailed up statically**, eliminating the worst case of per-packet new/delete.
### :earth_africa: Smarter Packet Routing through World

World acts as a router between all of the zones. It gets a lot of strain naturally and we do a lot of poor things like broadcasting things to all zones for things that only need 1 zone or 1 client. World no longer floods **2,000 zones** with updates meant for just a few. We started this in [PoP](https://github.com/EQEmu/Server/pull/4796), and [this patch](https://github.com/EQEmu/Server/pull/4818) pushes it further for zone-bound messages.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

# Testing

* Been running on PEQ for about a week
* Been running on THJ for a few weeks

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

