### PR TITLE
[Fix] Fix Object Name Init, User Refs, and Client Sync on Close

### DIFF
--- a/zone/object.cpp
+++ b/zone/object.cpp
@@ -75,6 +75,8 @@ decay_timer(300000)
 		decay_timer.Disable();
 	}
 
+	memset(m_display_name, 0, sizeof(m_display_name));
+
 	respawn_timer.Disable();
 
 	// Set drop_id to zero - it will be set when added to zone with SetID()
@@ -122,6 +124,8 @@ decay_timer(300000)
 	// Set as much struct data as we can
 	memset(&m_data, 0, sizeof(Object_Struct));
 
+	memset(m_display_name, 0, sizeof(m_display_name));
+
 	m_data.heading = heading;
 	m_data.z       = z;
 	m_data.zone_id = zone->GetZoneID();
@@ -163,6 +167,8 @@ decay_timer(300000)
 
 	// Set as much struct data as we can
 	memset(&m_data, 0, sizeof(Object_Struct));
+
+	memset(m_display_name, 0, sizeof(m_display_name));
 
 	m_data.heading = client->GetHeading();
 	m_data.x       = client->GetX();
@@ -235,6 +241,8 @@ decay_timer(decay_time)
 
 	// Set as much struct data as we can
 	memset(&m_data, 0, sizeof(Object_Struct));
+
+	memset(m_display_name, 0, sizeof(m_display_name));
 
 	m_data.heading = heading;
 	m_data.x       = x;
@@ -311,6 +319,8 @@ decay_timer(decay_time)
 	m_data.y       = y;
 	m_data.z       = z;
 	m_data.zone_id = zone->GetZoneID();
+
+	memset(m_display_name, 0, sizeof(m_display_name));
 
 	if (!IsFixZEnabled()) {
 		FixZ();

--- a/zone/object.cpp
+++ b/zone/object.cpp
@@ -452,6 +452,12 @@ void Object::Close() {
 			}
 		}
 
+		auto outapp = new EQApplicationPacket(OP_ClearObject, sizeof(ClearObject_Struct));
+		ClearObject_Struct *cos = (ClearObject_Struct *)outapp->pBuffer;
+		cos->Clear = 1;
+		user->QueuePacket(outapp);
+		safe_delete(outapp);
+
 		user->SetTradeskillObject(nullptr);
 	}
 

--- a/zone/object.cpp
+++ b/zone/object.cpp
@@ -363,6 +363,8 @@ void Object::SetID(uint16 set_id)
 // Reset state of object back to zero
 void Object::ResetState()
 {
+	Close();
+
 	safe_delete(m_inst);
 
 	m_id   = 0;


### PR DESCRIPTION
# Description

Couple minor fixes to object behaviors I found when working with the object API.

### Issue 1:  Fix uninitialized char* in object.cpp

Objects created via the API would show trash data in their name.  This change memsets the char array to zero in the constructors.

### Issue 2: Clear object user and user tradeskill object on reset.

A call to Object:Delete(true) would uninitialize a lot of fields in the object but leave lingering references to the user who was using it as well as a reference back to that object from the user.  This would cause a zone crash if the user continued to interact with the object.  I've added a 'Close' call to the top of ResetState to clear these references.

### Issue 3: Send clear object packet on Object::Close()

Calling Object:Close() would move any items in the object's inventory back into the user's inventory but not actually update the client that the object's inventory was now empty, creating the appearance that there were two items.

This change sends a ClearObject packet to the active user when close is called.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Akk-stack with rof2 client.

Test script
```
function player_say(e)
        if e.message:findi("object") then
                local id = eq.create_ground_object_from_model("IT70_ACTORDEF", e.self:GetX() + 10, e.self:GetY() + 10, e.self:GetZ(), e.self:GetHeading(), 19);
                eq.debug("Object id: "..id);
        end

        if e.message:findi("objreset") then
                local id_str = string.gsub(e.message, "objreset ", "");
                local id = tonumber(id_str) or -1;
                eq.debug("Resetting obj "..id);
                if id > 0 then
                        local obj = eq.get_entity_list():GetObjectByID(id);
                        obj:Delete(true);
                end
        end

        if e.message:findi("objclose") then
                local id_str = string.gsub(e.message, "objclose ", "");
                local id = tonumber(id_str) or -1;
                eq.debug("Close obj "..id);
                if id > 0 then
                        local obj = eq.get_entity_list():GetObjectByID(id);
                        obj:Close();
                end
        end
end
```

Issue 1:

Before
![image](https://github.com/user-attachments/assets/9d36a13e-5cef-4184-84bf-9afcfaba1e41)

After
![image](https://github.com/user-attachments/assets/ced3c938-22d0-474c-81d9-97f0d89aa1cc)


Issue 2:

Before
![image](https://github.com/user-attachments/assets/6d0d8882-568c-4022-945b-3a08d8220a70)

After
![image](https://github.com/user-attachments/assets/48fd93b8-da3e-478e-bc0b-e1739f979478)

Issue 3:

Original stack trace
![image](https://github.com/user-attachments/assets/4b45d8c0-71ff-4d5e-a611-b64af2452004)

Crash did not reproduce after fix applied.

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
