### PR TITLE
[Feature] Add Character:TradeskillUpMinChance rule

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -156,6 +156,7 @@ RULE_REAL(Character, TradeskillUpPottery, 4.0, "Pottery skillup rate adjustment.
 RULE_REAL(Character, TradeskillUpResearch, 1.0, "Research skillup rate adjustment. Lower is faster")
 RULE_REAL(Character, TradeskillUpTinkering, 2.0, "Tinkering skillup rate adjustment. Lower is faster")
 RULE_REAL(Character, TradeskillUpTailoring, 2.0, "Tailoring skillup rate adjustment. Lower is faster")
+RULE_REAL(Character, TradeskillUpMinChance, 2.5, "Determines the minimum percentage chance to gain a skill increase from a tradeskill.  Cannot go below 2.5")
 RULE_BOOL(Character, MarqueeHPUpdates, false, "Will show health percentage in center of screen if health lesser than 100%")
 RULE_INT(Character, IksarCommonTongue, 95, "Starting value for Common Tongue for Iksars")
 RULE_INT(Character, OgreCommonTongue, 95, "Starting value for Common Tongue for Ogres")


### PR DESCRIPTION
# Description

The existing Character:TradeskillUp* rules can be misleading.  There's two checks to see whether you increase your skill in a particular trade, and the second check does not have any sort of rule associated with it.

This PR adds Character:TradeskillUpMinChance, which is the minimum chance to gain a tradeskill, and it affects both the first and second stage checks.  This would allow servers (specifically THJ) to make it easier on players to do tradeskills.

I originally submitted this PR to THJ directly and was asked to consider upstreaming it.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing

Clients tested: akkstack/ROF2

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
