### PR TITLE
[CLI] ETL Settings Output

### DIFF
--- a/world/cli/etl_get_settings.cpp
+++ b/world/cli/etl_get_settings.cpp
@@ -16,7 +16,7 @@ void WorldserverCLI::EtlGetSettings(int argc, char **argv, argh::parser &cmd, st
 	auto event_settings = player_event_logs.GetSettings();
 	auto etl_details    = player_event_logs.GetEtlSettings();
 
-	for (auto i = 0; i < PlayerEvent::EventType::MAX; i++) {
+	for (auto i = 1; i < PlayerEvent::EventType::MAX; i++) {
 		player_events["event_id"]    = event_settings[i].id;
 		player_events["enabled"]     = event_settings[i].event_enabled ? true : false;
 		player_events["retention"]   = event_settings[i].retention_days;

--- a/world/cli/etl_get_settings.cpp
+++ b/world/cli/etl_get_settings.cpp
@@ -16,7 +16,7 @@ void WorldserverCLI::EtlGetSettings(int argc, char **argv, argh::parser &cmd, st
 	auto event_settings = player_event_logs.GetSettings();
 	auto etl_details    = player_event_logs.GetEtlSettings();
 
-	for (auto i = 1; i < PlayerEvent::EventType::MAX; i++) {
+	for (auto i = PlayerEvent::GM_COMMAND; i < PlayerEvent::EventType::MAX; i++) {
 		player_events["event_id"]    = event_settings[i].id;
 		player_events["enabled"]     = event_settings[i].event_enabled ? true : false;
 		player_events["retention"]   = event_settings[i].retention_days;

--- a/world/cli/etl_get_settings.cpp
+++ b/world/cli/etl_get_settings.cpp
@@ -16,7 +16,7 @@ void WorldserverCLI::EtlGetSettings(int argc, char **argv, argh::parser &cmd, st
 	auto event_settings = player_event_logs.GetSettings();
 	auto etl_details    = player_event_logs.GetEtlSettings();
 
-	for (auto i = PlayerEvent::GM_COMMAND; i < PlayerEvent::EventType::MAX; i++) {
+	for (int i = PlayerEvent::GM_COMMAND; i < PlayerEvent::EventType::MAX; i++) {
 		player_events["event_id"]    = event_settings[i].id;
 		player_events["enabled"]     = event_settings[i].event_enabled ? true : false;
 		player_events["retention"]   = event_settings[i].retention_days;


### PR DESCRIPTION
# Description

The output from `bin/world etl:settings` dumps an event id of 0. Player Event Types start at 1.

![image](https://github.com/user-attachments/assets/f193a34f-15ff-4b82-9d99-37fb014e18b2)
![image](https://github.com/user-attachments/assets/c436bfe6-99ea-4859-9648-876b75b23296)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing
![image](https://github.com/user-attachments/assets/784a4450-8fa1-4ce4-9c4d-0ed07fa73789)

Clients tested: N/A

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur