### PR TITLE
[Zone State] Fix spawn lock on zone restore

### DIFF
--- a/zone/zone_save_state.cpp
+++ b/zone/zone_save_state.cpp
@@ -517,7 +517,7 @@ bool Zone::LoadZoneState(
 
 		new_spawn->SetStoredLocation(glm::vec4(s.x, s.y, s.z, s.heading));
 
-		if (spawn_time_left == 0) {
+		if (spawn_time_left == 0 && s.npc_id > 0) {
 			new_spawn->SetResumedNPCID(s.npc_id);
 			new_spawn->SetResumedFromZoneSuspend(true);
 			new_spawn->SetEntityVariables(GetVariablesDeserialized(s.entity_variables));


### PR DESCRIPTION
# Description

Certain spawns, specifically spawn controllers, were getting locked into not spawning. This is an interim fix for an update to the zone state system.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Test case was the LMM  trigger in hohonorb. One zone state save, its spawn2 id (258526 ) was saving with an npc id of 0.
![image](https://github.com/user-attachments/assets/76464365-fce4-42a4-a633-d7d2af96c3c3)

The zone will once again need to shut down after the normal timers have expired to save the NPC ID. While not a perfect/permanent fix, it will at least unlock the spawns on the following zone boot.

Clients tested:  N/A

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur