### PR TITLE
[Fix] Prevent Ranged Attack from being triggered at arbitrary rate

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -6677,7 +6677,9 @@ void Client::SetAttackTimer()
 			else
 				speed = static_cast<int>(speed + ((hhe / 100.0f) * delay));
 		}
-		TimerToUse->SetAtTrigger(std::max(RuleI(Combat, MinHastedDelay), speed), true, true);
+
+		bool reinit = !TimerToUse->Enabled();
+		TimerToUse->SetAtTrigger(std::max(RuleI(Combat, MinHastedDelay), speed), reinit, reinit);
 
 		if (i == EQ::invslot::slotPrimary) {
 			primary_speed = speed;


### PR DESCRIPTION
# Description

If `OP_CombatAbility` triggers a Ranged Attack, it can bypass the ranged attack timer. This is normally rate limited by client, though client does calculate the speed incorrectly at high haste values - allowing the 'ranged attack' button to be pressed faster than the autofire timer. However, this could be more seriously exploited by a MQ2 plugin which sends the appropriate packet at any arbitrary rate.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

Deployed to THJ

Clients tested: 
ROF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
