### PR TITLE
[Fix] Fix breaking change to UF patches caused by Big Bags update

### DIFF
--- a/common/patches/uf.cpp
+++ b/common/patches/uf.cpp
@@ -4908,7 +4908,6 @@ namespace UF
 			UFSlot = serverSlot - 2;
 		}
 
-		//else if (serverSlot <= EQ::invbag::GENERAL_BAGS_8_END && serverSlot >= EQ::invbag::GENERAL_BAGS_BEGIN) {
 		else if (serverSlot <= EQ::invbag::GENERAL_BAGS_END && serverSlot >= EQ::invbag::GENERAL_BAGS_BEGIN) {
 			UFSlot = serverSlot - (EQ::invbag::GENERAL_BAGS_BEGIN - invbag::GENERAL_BAGS_BEGIN)/*3748*/ - ((EQ::invbag::SLOT_COUNT - invbag::SLOT_COUNT) * ((serverSlot - EQ::invbag::GENERAL_BAGS_BEGIN) / EQ::invbag::SLOT_COUNT)); // + 11;
 		}


### PR DESCRIPTION
# Description

Fixed breaking changes in UF patches caused by the Big Bags update. I'm using UF opcode set for Adventure MMO.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Tested GENERAL_BAGS, CURSOR_BAG, BANK_BAGS, BANK_SHARED_BAGS, and TRADE_BAGS.

Clients tested: 

Tested with custom client / Adventure MMO.

# Checklist

- [x] I have tested my changes
- [ ] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
