### PR TITLE
[Crash] Fix crash bug with pbae and quest scripts spawning mobs

### DIFF
--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -1125,8 +1125,8 @@ void EntityList::AESpell(
 		RuleI(Range, MobCloseScanDistance),
 		distance
 	);
-
-	for (auto& it: caster_mob->GetCloseMobList(distance)) {
+	auto list = caster_mob->GetCloseMobList(distance);
+	for (auto& it: list) {
 		current_mob = it.second;
 		if (!current_mob) {
 			continue;


### PR DESCRIPTION


# Description

If a PBAE is in progress while a mob pops it can cause a crash. Forcing a copy before the ae has a chance to pop a mob fixed the weirdness in my testing.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

