### PR TITLE
[Fix] Deadlock on failed #copycharacter commands

### DIFF
--- a/common/dbcore.cpp
+++ b/common/dbcore.cpp
@@ -189,9 +189,9 @@ void DBcore::TransactionBegin()
 	QueryDatabase("START TRANSACTION");
 }
 
-void DBcore::TransactionCommit()
+MySQLRequestResult DBcore::TransactionCommit()
 {
-	QueryDatabase("COMMIT");
+	return QueryDatabase("COMMIT");
 }
 
 void DBcore::TransactionRollback()

--- a/common/dbcore.h
+++ b/common/dbcore.h
@@ -32,7 +32,7 @@ public:
 	MySQLRequestResult QueryDatabase(const std::string& query, bool retryOnFailureOnce = true);
 	MySQLRequestResult QueryDatabaseMulti(const std::string &query);
 	void TransactionBegin();
-	void TransactionCommit();
+	MySQLRequestResult TransactionCommit();
 	void TransactionRollback();
 	std::string Escape(const std::string& s);
 	uint32 DoEscapeString(char *tobuf, const char *frombuf, uint32 fromlen);


### PR DESCRIPTION
# Description

This fixes an issue where when a query fails during the selection of source data to copy, we don't bail out of the active transaction which can keep tables in lock and deadlock processes.

We rollback transaction during failed insertion but we weren't doing it in two other places. This PR fixes this scenario.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

**Before (Problem)**

Below a select failed, copycharacter thought it was successful, transaction was never rolledback and locks were left on tables, causing a server outage.

![image](https://github.com/user-attachments/assets/60a2f332-20e5-41bd-9bde-8532082248c1)

```
cat  ./world_1231666.log | grep "Lock wait"
[04-30-2025 19:45:51] [World] [QueryErr] MySQL Error (1205) [Lock wait timeout exceeded; try restarting transaction] Query [DELETE FROM instance_list_player WHERE id IN (5108,12009,12033,2610,3112,1551,5685,951,5319,7669,9810,3484,2921,11528,10534,11049,9346,5787,11458,7923,4650,7034,3649,7799,5431,2423,4824,8217,7225,7488,8917,9712,8858,6708,5524,11945,9309,11562,12341,1790,3602,10980,6499,3692,6541,7146,2910,4659,6400,8401,1475,11162,9160,5107,11344,6330,1587,5114,1117,11215,9821,4446,492,10565,10894,7043,9596,3478,9935,12217,852,3154,6667,378,5964,6414,8007,12491,12359,10964,3413,9126,7031,7256,1281,5160,5385,1209,221,11394,1567,12040,798,3014,5217,10983,10349,10704,3240)]
```

**After**

![image](https://github.com/user-attachments/assets/99e7076f-b6a6-4a21-b9ac-53e386a8962b)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
