### PR TITLE
[Rules] Auto Update Rule Notes from Source

### DIFF
--- a/common/rulesys.cpp
+++ b/common/rulesys.cpp
@@ -502,6 +502,18 @@ bool RuleManager::UpdateInjectedRules(Database *db, const std::string &rule_set_
 		}
 	}
 
+	// update rules in the database where the description is different
+	for (const auto &e : RuleValuesRepository::All(*db)) {
+		auto i = rule_data.find(e.rule_name);
+		if (i != rule_data.end()) {
+			// if notes are different, update them
+			if (i->second.second != nullptr && !Strings::EqualFold(*i->second.second, e.notes)) {
+				LogInfo("Updating rule [{}] notes to [{}]", i->first, *i->second.second);
+				RuleValuesRepository::ReplaceOne(*db, e);
+			}
+		}
+	}
+
 	if (injected_rule_entries.size()) {
 		if (!RuleValuesRepository::InjectRules(*db, injected_rule_entries)) {
 			return false;

--- a/common/rulesys.cpp
+++ b/common/rulesys.cpp
@@ -503,12 +503,13 @@ bool RuleManager::UpdateInjectedRules(Database *db, const std::string &rule_set_
 	}
 
 	// update rules in the database where the description is different
-	for (const auto &e : RuleValuesRepository::All(*db)) {
+	for (auto &e : RuleValuesRepository::All(*db)) {
 		auto i = rule_data.find(e.rule_name);
 		if (i != rule_data.end()) {
 			// if notes are different, update them
-			if (i->second.second != nullptr && !Strings::EqualFold(*i->second.second, e.notes)) {
+			if (i->second.second != nullptr && *i->second.second != e.notes) {
 				LogInfo("Updating rule [{}] notes to [{}]", i->first, *i->second.second);
+				e.notes = *i->second.second;
 				RuleValuesRepository::ReplaceOne(*db, e);
 			}
 		}


### PR DESCRIPTION
# Description

This PR automatically updates database rule notes where they differ from source notes.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing

```
 World |    Info    | UpdateInjectedRules Updating rule [World:ExpansionSettings] notes to [Sets the expansion settings bitmask for the server, This is sent on login to world and affects client expansion settings. Defaults to all expansions enabled up to TSS, value is bitmask] 
 World |    Info    | UpdateInjectedRules Updating rule [Spells:UseAdditiveFocusFromWornSlot] notes to [Allows an additive focus effect to be calculated from worn slot. Does not apply limits checks. Can only have one additive focus rule be true.] 
 World |    Info    | UpdateInjectedRules Updating rule [Skills:MaxTrainTradeskills] notes to [Highest level for trade skills that can be taught by the trainer] 
 World |    Info    | UpdateInjectedRules Updating rule [Map:EnableLoSCheatExemptions] notes to [Enables exemptions for the LoS Cheat check. Must modify source to create these.] 
 World |    Info    | UpdateInjectedRules Updating rule [EvolvingItems:PercentOfRaidExperience] notes to [Percentage of raid experience allocated to evolving items that require experience.] 
```

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
