### PR TITLE
[Netcode] Resend Logic Adjustments

### DIFF
--- a/common/net/daybreak_connection.cpp
+++ b/common/net/daybreak_connection.cpp
@@ -1130,20 +1130,6 @@ void EQ::Net::DaybreakConnection::ProcessResend(int stream)
 			Close();
 			return;
 		}
-
-		// make sure that the first_packet in the list first_sent time is within the resend_delay and now
-		// if it is not, then we need to resend all packets in the list
-		if (time_since_first_sent <= first_packet.resend_delay && !m_acked_since_last_resend) {
-			LogNetClient(
-				"Not resending packets for stream [{}] packets [{}] time_first_sent [{}] resend_delay [{}] m_acked_since_last_resend [{}]",
-				stream,
-				s->sent_packets.size(),
-				time_since_first_sent,
-				first_packet.resend_delay,
-				m_acked_since_last_resend
-			);
-			return;
-		}
 	}
 
 	if (LogSys.IsLogEnabled(Logs::Detail, Logs::Netcode)) {
@@ -1153,11 +1139,10 @@ void EQ::Net::DaybreakConnection::ProcessResend(int stream)
 		}
 
 		LogNetClient(
-			"Resending packets for stream [{}] packet count [{}] total packet size [{}] m_acked_since_last_resend [{}]",
+			"Resending packets for stream [{}] packet count [{}] total packet size [{}]",
 			stream,
 			s->sent_packets.size(),
-			total_size,
-			m_acked_since_last_resend
+			total_size
 		);
 	}
 
@@ -1202,8 +1187,6 @@ void EQ::Net::DaybreakConnection::ProcessResend(int stream)
 			m_owner->m_options.resend_delay_max
 		);
 	}
-
-	m_acked_since_last_resend = false;
 }
 
 void EQ::Net::DaybreakConnection::Ack(int stream, uint16_t seq)
@@ -1224,7 +1207,6 @@ void EQ::Net::DaybreakConnection::Ack(int stream, uint16_t seq)
 			m_rolling_ping = (m_rolling_ping * 2 + round_time) / 3;
 
 			iter = s->sent_packets.erase(iter);
-			m_acked_since_last_resend = true;
 		}
 		else {
 			++iter;

--- a/common/net/daybreak_connection.h
+++ b/common/net/daybreak_connection.h
@@ -185,7 +185,6 @@ namespace EQ
 			// resend tracking
 			size_t m_resend_packets_sent = 0;
 			size_t m_resend_bytes_sent = 0;
-			Timestamp m_last_resend;
 
 			struct DaybreakSentPacket
 			{

--- a/common/net/daybreak_connection.h
+++ b/common/net/daybreak_connection.h
@@ -185,7 +185,7 @@ namespace EQ
 			// resend tracking
 			size_t m_resend_packets_sent = 0;
 			size_t m_resend_bytes_sent = 0;
-			bool m_acked_since_last_resend = false;
+			Timestamp m_last_resend;
 
 			struct DaybreakSentPacket
 			{


### PR DESCRIPTION
# Description

This PR aims to address a rarer report where clients can sometimes "randomly" disconnect. The working theory is that in rarer circumstances client connections end in a state where their acked flag is not getting reset. This PR removes the reliance on the ack flag entirely and simplifies the resend logic because we now have windowing logic which achieves the same thing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Tested stress flooding my client with 100's of NPC's. No issue. Repopped with instant responsiveness.

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
