### PR TITLE
[Fix] Update mutex in `zonelist` for Windows 11

### DIFF
--- a/world/zonelist.h
+++ b/world/zonelist.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <memory>
 #include <deque>
+#include <mutex>
 
 class WorldTCPConnection;
 class ServerPacket;


### PR DESCRIPTION
# Description

Include mutex for Win11 compile from https://github.com/EQEmu/Server/pull/4893 as reported at https://github.com/EQEmu/Server/pull/4893#discussion_r2093712248

![image](https://github.com/user-attachments/assets/69039d86-b74f-4db6-a736-bdaac7b8c915)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

![image](https://github.com/user-attachments/assets/3b3822bf-1ebb-49b7-ac34-8337d64f5965)

Clients tested: N/A

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur