### PR TITLE
[CLI] Fix MySQL check in database dumper

### DIFF
--- a/common/database/database_dump_service.cpp
+++ b/common/database/database_dump_service.cpp
@@ -50,7 +50,7 @@ bool DatabaseDumpService::IsMySQLInstalled()
 {
 	std::string version_output = GetMySQLVersion();
 
-	return version_output.find("mysql") != std::string::npos && version_output.find("Ver") != std::string::npos;
+	return version_output.find("mysql") != std::string::npos && (version_output.find("Ver") != std::string::npos || version_output.find("from") != std::string::npos);
 }
 
 /**


### PR DESCRIPTION
# Description

On Ubuntu 25.04 (or maybe the MariaDB install with that version), the string "Ver" is no longer present causing the check for the MySQL executable to fail.

![image](https://github.com/user-attachments/assets/351dac63-654f-496f-abaf-a9df6c8731e5)
![image](https://github.com/user-attachments/assets/3afb185a-1378-407c-8c93-43dc2e542629)
![image](https://github.com/user-attachments/assets/3e815a39-6e7d-42da-989c-234011c7db92)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

![image](https://github.com/user-attachments/assets/aae2ccb7-d373-4fca-b1d8-1b77dbad1398)

Clients tested: CLI

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur