### PR TITLE
[Netcode] Resend Logic Adjustments

### DIFF
--- a/common/net/daybreak_connection.cpp
+++ b/common/net/daybreak_connection.cpp
@@ -1184,20 +1184,20 @@ void EQ::Net::DaybreakConnection::ProcessResend(int stream)
 	}
 
 	for (auto &e: s->sent_packets) {
-		// if (m_resend_packets_sent >= MAX_CLIENT_RECV_PACKETS_PER_WINDOW ||
-		// 	m_resend_bytes_sent >= MAX_CLIENT_RECV_BYTES_PER_WINDOW) {
-		// 	LogNetClient(
-		// 		"Stopping resend because we hit thresholds for m_endpoint [{}] m_port [{}]  m_resend_packets_sent [{}] max [{}] in_queue [{}] m_resend_bytes_sent [{}] max [{}]",
-		// 		m_endpoint,
-		// 		m_port,
-		// 		m_resend_packets_sent,
-		// 		MAX_CLIENT_RECV_PACKETS_PER_WINDOW,
-		// 		s->sent_packets.size(),
-		// 		m_resend_bytes_sent,
-		// 		MAX_CLIENT_RECV_BYTES_PER_WINDOW
-		// 	);
-		// 	break;
-		// }
+		if (m_resend_packets_sent >= MAX_CLIENT_RECV_PACKETS_PER_WINDOW ||
+			m_resend_bytes_sent >= MAX_CLIENT_RECV_BYTES_PER_WINDOW) {
+			LogNetClient(
+				"Stopping resend because we hit thresholds for m_endpoint [{}] m_port [{}]  m_resend_packets_sent [{}] max [{}] in_queue [{}] m_resend_bytes_sent [{}] max [{}]",
+				m_endpoint,
+				m_port,
+				m_resend_packets_sent,
+				MAX_CLIENT_RECV_PACKETS_PER_WINDOW,
+				s->sent_packets.size(),
+				m_resend_bytes_sent,
+				MAX_CLIENT_RECV_BYTES_PER_WINDOW
+			);
+			break;
+		}
 
 		auto &sp = e.second;
 		auto &p  = sp.packet;

--- a/common/net/daybreak_connection.cpp
+++ b/common/net/daybreak_connection.cpp
@@ -1155,6 +1155,12 @@ void EQ::Net::DaybreakConnection::ProcessResend(int stream)
 		);
 	}
 
+	LogNetClient("Resending packets for stream [{}] packet count [{}] total packet size [{}]",
+		stream,
+		s->sent_packets.size(),
+		m_resend_bytes_sent
+	);
+
 	for (auto &e: s->sent_packets) {
 		// if (m_resend_packets_sent >= MAX_CLIENT_RECV_PACKETS_PER_WINDOW ||
 		// 	m_resend_bytes_sent >= MAX_CLIENT_RECV_BYTES_PER_WINDOW) {

--- a/common/net/daybreak_connection.cpp
+++ b/common/net/daybreak_connection.cpp
@@ -1156,18 +1156,18 @@ void EQ::Net::DaybreakConnection::ProcessResend(int stream)
 	}
 
 	for (auto &e: s->sent_packets) {
-		if (m_resend_packets_sent >= MAX_CLIENT_RECV_PACKETS_PER_WINDOW ||
-			m_resend_bytes_sent >= MAX_CLIENT_RECV_BYTES_PER_WINDOW) {
-			LogNetClient(
-				"Stopping resend because we hit thresholds m_resend_packets_sent [{}] max [{}] in_queue [{}] m_resend_bytes_sent [{}] max [{}]",
-				m_resend_packets_sent,
-				MAX_CLIENT_RECV_PACKETS_PER_WINDOW,
-				s->sent_packets.size(),
-				m_resend_bytes_sent,
-				MAX_CLIENT_RECV_BYTES_PER_WINDOW
-			);
-			break;
-		}
+		// if (m_resend_packets_sent >= MAX_CLIENT_RECV_PACKETS_PER_WINDOW ||
+		// 	m_resend_bytes_sent >= MAX_CLIENT_RECV_BYTES_PER_WINDOW) {
+		// 	LogNetClient(
+		// 		"Stopping resend because we hit thresholds m_resend_packets_sent [{}] max [{}] in_queue [{}] m_resend_bytes_sent [{}] max [{}]",
+		// 		m_resend_packets_sent,
+		// 		MAX_CLIENT_RECV_PACKETS_PER_WINDOW,
+		// 		s->sent_packets.size(),
+		// 		m_resend_bytes_sent,
+		// 		MAX_CLIENT_RECV_BYTES_PER_WINDOW
+		// 	);
+		// 	break;
+		// }
 
 		auto &sp = e.second;
 		auto &p  = sp.packet;

--- a/common/net/daybreak_connection.cpp
+++ b/common/net/daybreak_connection.cpp
@@ -1184,20 +1184,20 @@ void EQ::Net::DaybreakConnection::ProcessResend(int stream)
 	}
 
 	for (auto &e: s->sent_packets) {
-		if (m_resend_packets_sent >= MAX_CLIENT_RECV_PACKETS_PER_WINDOW ||
-			m_resend_bytes_sent >= MAX_CLIENT_RECV_BYTES_PER_WINDOW) {
-			LogNetClient(
-				"Stopping resend because we hit thresholds for m_endpoint [{}] m_port [{}]  m_resend_packets_sent [{}] max [{}] in_queue [{}] m_resend_bytes_sent [{}] max [{}]",
-				m_endpoint,
-				m_port,
-				m_resend_packets_sent,
-				MAX_CLIENT_RECV_PACKETS_PER_WINDOW,
-				s->sent_packets.size(),
-				m_resend_bytes_sent,
-				MAX_CLIENT_RECV_BYTES_PER_WINDOW
-			);
-			break;
-		}
+		// if (m_resend_packets_sent >= MAX_CLIENT_RECV_PACKETS_PER_WINDOW ||
+		// 	m_resend_bytes_sent >= MAX_CLIENT_RECV_BYTES_PER_WINDOW) {
+		// 	LogNetClient(
+		// 		"Stopping resend because we hit thresholds for m_endpoint [{}] m_port [{}]  m_resend_packets_sent [{}] max [{}] in_queue [{}] m_resend_bytes_sent [{}] max [{}]",
+		// 		m_endpoint,
+		// 		m_port,
+		// 		m_resend_packets_sent,
+		// 		MAX_CLIENT_RECV_PACKETS_PER_WINDOW,
+		// 		s->sent_packets.size(),
+		// 		m_resend_bytes_sent,
+		// 		MAX_CLIENT_RECV_BYTES_PER_WINDOW
+		// 	);
+		// 	break;
+		// }
 
 		auto &sp = e.second;
 		auto &p  = sp.packet;

--- a/common/net/daybreak_connection.cpp
+++ b/common/net/daybreak_connection.cpp
@@ -1127,12 +1127,14 @@ void EQ::Net::DaybreakConnection::ProcessResend(int stream)
 		auto time_since_first_sent = std::chrono::duration_cast<std::chrono::milliseconds>(now - first_packet.first_sent).count();
 
 		if (time_since_first_sent >= m_owner->m_options.resend_timeout) {
+			auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
+			auto first_sent_ms = std::chrono::duration_cast<std::chrono::milliseconds>(first_packet.first_sent.time_since_epoch()).count();
 			LogNetClient(
 				"Closing connection time_since_first_sent [{}] >= m_owner->m_options.resend_timeout [{}] now [{}] first_packet.first_sent [{}]",
 				time_since_first_sent,
 				m_owner->m_options.resend_timeout,
-				now,
-				first_packet.first_sent
+				now_ms,
+				first_sent_ms
 			);
 			Close();
 			return;

--- a/common/net/daybreak_connection.cpp
+++ b/common/net/daybreak_connection.cpp
@@ -1159,9 +1159,10 @@ void EQ::Net::DaybreakConnection::ProcessResend(int stream)
 		if (m_resend_packets_sent >= MAX_CLIENT_RECV_PACKETS_PER_WINDOW ||
 			m_resend_bytes_sent >= MAX_CLIENT_RECV_BYTES_PER_WINDOW) {
 			LogNetClient(
-				"Stopping resend because we hit thresholds m_resend_packets_sent [{}] max [{}] m_resend_bytes_sent [{}] max [{}]",
+				"Stopping resend because we hit thresholds m_resend_packets_sent [{}] max [{}] in_queue [{}] m_resend_bytes_sent [{}] max [{}]",
 				m_resend_packets_sent,
 				MAX_CLIENT_RECV_PACKETS_PER_WINDOW,
+				s->sent_packets,
 				m_resend_bytes_sent,
 				MAX_CLIENT_RECV_BYTES_PER_WINDOW
 			);

--- a/common/net/daybreak_connection.cpp
+++ b/common/net/daybreak_connection.cpp
@@ -1162,7 +1162,7 @@ void EQ::Net::DaybreakConnection::ProcessResend(int stream)
 				"Stopping resend because we hit thresholds m_resend_packets_sent [{}] max [{}] in_queue [{}] m_resend_bytes_sent [{}] max [{}]",
 				m_resend_packets_sent,
 				MAX_CLIENT_RECV_PACKETS_PER_WINDOW,
-				s->sent_packets,
+				s->sent_packets.size(),
 				m_resend_bytes_sent,
 				MAX_CLIENT_RECV_BYTES_PER_WINDOW
 			);

--- a/common/net/daybreak_connection.cpp
+++ b/common/net/daybreak_connection.cpp
@@ -1154,7 +1154,7 @@ void EQ::Net::DaybreakConnection::ProcessResend(int stream)
 		// make sure that the first_packet in the list first_sent time is within the resend_delay and now
 		// if it is not, then we need to resend all packets in the list
 		if (time_since_first_sent <= first_packet.resend_delay && !m_acked_since_last_resend) {
-			LogNetClient(
+			LogNetClientDetail(
 				"Not resending packets for m_endpoint [{}] m_port [{}] packets [{}] time_first_sent [{}] resend_delay [{}] m_acked_since_last_resend [{}]",
 				m_endpoint,
 				m_port,
@@ -1173,7 +1173,7 @@ void EQ::Net::DaybreakConnection::ProcessResend(int stream)
 			total_size += e.second.packet.Length();
 		}
 
-		LogNetClient(
+		LogNetClientDetail(
 			"Resending packets for m_endpoint [{}] m_port [{}] packet count [{}] total packet size [{}] m_acked_since_last_resend [{}]",
 			m_endpoint,
 			m_port,

--- a/common/net/daybreak_connection.cpp
+++ b/common/net/daybreak_connection.cpp
@@ -1127,6 +1127,13 @@ void EQ::Net::DaybreakConnection::ProcessResend(int stream)
 		auto time_since_first_sent = std::chrono::duration_cast<std::chrono::milliseconds>(now - first_packet.first_sent).count();
 
 		if (time_since_first_sent >= m_owner->m_options.resend_timeout) {
+			LogNetClient(
+				"Closing connection time_since_first_sent [{}] >= m_owner->m_options.resend_timeout [{}] now [{}] first_packet.first_sent [{}]",
+				time_since_first_sent,
+				m_owner->m_options.resend_timeout,
+				now,
+				first_packet.first_sent
+			);
 			Close();
 			return;
 		}

--- a/common/net/daybreak_connection.cpp
+++ b/common/net/daybreak_connection.cpp
@@ -1187,7 +1187,9 @@ void EQ::Net::DaybreakConnection::ProcessResend(int stream)
 		if (m_resend_packets_sent >= MAX_CLIENT_RECV_PACKETS_PER_WINDOW ||
 			m_resend_bytes_sent >= MAX_CLIENT_RECV_BYTES_PER_WINDOW) {
 			LogNetClient(
-				"Stopping resend because we hit thresholds m_resend_packets_sent [{}] max [{}] in_queue [{}] m_resend_bytes_sent [{}] max [{}]",
+				"Stopping resend because we hit thresholds for m_endpoint [{}] m_port [{}]  m_resend_packets_sent [{}] max [{}] in_queue [{}] m_resend_bytes_sent [{}] max [{}]",
+				m_endpoint,
+				m_port,
 				m_resend_packets_sent,
 				MAX_CLIENT_RECV_PACKETS_PER_WINDOW,
 				s->sent_packets.size(),

--- a/common/net/daybreak_connection.h
+++ b/common/net/daybreak_connection.h
@@ -185,6 +185,8 @@ namespace EQ
 			// resend tracking
 			size_t m_resend_packets_sent = 0;
 			size_t m_resend_bytes_sent = 0;
+			bool m_acked_since_last_resend = false;
+			Timestamp m_last_ack;
 
 			struct DaybreakSentPacket
 			{

--- a/common/net/daybreak_connection.h
+++ b/common/net/daybreak_connection.h
@@ -276,7 +276,7 @@ namespace EQ
 				simulated_in_packet_loss = 0;
 				simulated_out_packet_loss = 0;
 				tic_rate_hertz = 60.0;
-				resend_timeout = 60000;
+				resend_timeout = 30000;
 				connection_close_time = 2000;
 				outgoing_data_rate = 0.0;
 			}

--- a/common/net/daybreak_connection.h
+++ b/common/net/daybreak_connection.h
@@ -274,7 +274,7 @@ namespace EQ
 				simulated_in_packet_loss = 0;
 				simulated_out_packet_loss = 0;
 				tic_rate_hertz = 60.0;
-				resend_timeout = 30000;
+				resend_timeout = 60000;
 				connection_close_time = 2000;
 				outgoing_data_rate = 0.0;
 			}


### PR DESCRIPTION
# Description

This PR reverts https://github.com/EQEmu/Server/pull/4895 and fixes a few things by re-introducing the ack flag but also making sure the ack flag gets reset under unordered acks as well as resetting the ack flag when a second has passed. This prevents the flag from somehow putting clients in an infinite state.

This has dramatically fixed unnecessary resends and fixed issues observed on PEQ.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Extensive testing and hours with a 100 boxer on PEQ.

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

