### PR TITLE
[CLI] Add custom database version output

### DIFF
--- a/world/cli/database_version.cpp
+++ b/world/cli/database_version.cpp
@@ -12,8 +12,8 @@ void WorldserverCLI::DatabaseVersion(int argc, char **argv, argh::parser &cmd, s
 
 	Json::Value v;
 
-	v["database_version"]      = CURRENT_BINARY_DATABASE_VERSION;
-	v["bots_database_version"] = RuleB(Bots, Enabled) ? CURRENT_BINARY_BOTS_DATABASE_VERSION : 0;
+	v["database_version"]        = CURRENT_BINARY_DATABASE_VERSION;
+	v["bots_database_version"]   = RuleB(Bots, Enabled) ? CURRENT_BINARY_BOTS_DATABASE_VERSION : 0;
 	v["custom_database_version"] = CUSTOM_BINARY_DATABASE_VERSION;
 
 	std::stringstream payload;

--- a/world/cli/database_version.cpp
+++ b/world/cli/database_version.cpp
@@ -14,6 +14,7 @@ void WorldserverCLI::DatabaseVersion(int argc, char **argv, argh::parser &cmd, s
 
 	v["database_version"]      = CURRENT_BINARY_DATABASE_VERSION;
 	v["bots_database_version"] = RuleB(Bots, Enabled) ? CURRENT_BINARY_BOTS_DATABASE_VERSION : 0;
+	v["custom_database_version"] = CUSTOM_BINARY_DATABASE_VERSION;
 
 	std::stringstream payload;
 	payload << v;

--- a/world/cli/version.cpp
+++ b/world/cli/version.cpp
@@ -11,11 +11,12 @@ void WorldserverCLI::Version(int argc, char **argv, argh::parser &cmd, std::stri
 
 	Json::Value j;
 
-	j["bots_database_version"] = CURRENT_BINARY_BOTS_DATABASE_VERSION;
-	j["compile_date"]          = COMPILE_DATE;
-	j["compile_time"]          = COMPILE_TIME;
-	j["database_version"]      = CURRENT_BINARY_DATABASE_VERSION;
-	j["server_version"]        = CURRENT_VERSION;
+	j["bots_database_version"]   = CURRENT_BINARY_BOTS_DATABASE_VERSION;
+	j["compile_date"]            = COMPILE_DATE;
+	j["compile_time"]            = COMPILE_TIME;
+	j["custom_database_version"] = CUSTOM_BINARY_DATABASE_VERSION;
+	j["database_version"]        = CURRENT_BINARY_DATABASE_VERSION;
+	j["server_version"]          = CURRENT_VERSION;
 
 	std::stringstream payload;
 	payload << j;


### PR DESCRIPTION
# Description

From #4892, add custom database version output to `world:version` and `database:version`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

`world:version`:
![image](https://github.com/user-attachments/assets/607036f6-e0a8-45fe-a41b-a93eedea13b3)


`database:version`:
![image](https://github.com/user-attachments/assets/d9ab7485-6952-44f2-a5ed-c2b4780e1083)

Clients tested: CLI

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur