### PR TITLE
[Feature] Load contents of script_constants table into global lua state.

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -7112,6 +7112,24 @@ ADD COLUMN `first_login` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `xtargets`;
 )",
 		.content_schema_update = false
 	},
+	ManifestEntry{
+		.version     = 9324,
+		.description = "2025_06_01_script_constants.sql",
+		.check       = "SHOW TABLES LIKE 'script_constants'",
+		.condition   = "empty",
+		.match       = "",
+		.sql         = R"(
+CREATE TABLE `script_constants` (
+	`zone` VARCHAR(32) DEFAULT '',
+	`version` SMALLINT(5) DEFAULT -1,
+	`lua_namespace` VARCHAR(100),
+	`name` VARCHAR(100),
+	`value` TEXT,
+	`valuetype` SMALLINT(5),
+	PRIMARY KEY (`zone`, `version`, `lua_namespace`, `name`)
+);
+)",
+	},
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{
 //		.version = 9228,

--- a/common/database_schema.h
+++ b/common/database_schema.h
@@ -239,6 +239,7 @@ namespace DatabaseSchema {
 			"pets_beastlord_data",
 			"pets_equipmentset",
 			"pets_equipmentset_entries",
+			"script_constants",
 			"skill_caps",
 			"spawn2",
 			"spawn_conditions",

--- a/common/repositories/base/base_script_constants_repository.h
+++ b/common/repositories/base/base_script_constants_repository.h
@@ -1,0 +1,440 @@
+/**
+ * DO NOT MODIFY THIS FILE
+ *
+ * This repository was automatically generated and is NOT to be modified directly.
+ * Any repository modifications are meant to be made to the repository extending the base.
+ * Any modifications to base repositories are to be made by the generator only
+ *
+ * @generator ./utils/scripts/generators/repository-generator.pl
+ * @docs https://docs.eqemu.io/developer/repositories
+ */
+
+#ifndef EQEMU_BASE_SCRIPT_CONSTANTS_REPOSITORY_H
+#define EQEMU_BASE_SCRIPT_CONSTANTS_REPOSITORY_H
+
+#include "../../database.h"
+#include "../../strings.h"
+#include <ctime>
+
+class BaseScriptConstantsRepository {
+public:
+	struct ScriptConstants {
+		std::string zone;
+		int16_t     version;
+		std::string lua_namespace;
+		std::string name;
+		std::string value;
+		int16_t     valuetype;
+	};
+
+	static std::string PrimaryKey()
+	{
+		return std::string("version");
+	}
+
+	static std::vector<std::string> Columns()
+	{
+		return {
+			"zone",
+			"version",
+			"lua_namespace",
+			"name",
+			"value",
+			"valuetype",
+		};
+	}
+
+	static std::vector<std::string> SelectColumns()
+	{
+		return {
+			"zone",
+			"version",
+			"lua_namespace",
+			"name",
+			"value",
+			"valuetype",
+		};
+	}
+
+	static std::string ColumnsRaw()
+	{
+		return std::string(Strings::Implode(", ", Columns()));
+	}
+
+	static std::string SelectColumnsRaw()
+	{
+		return std::string(Strings::Implode(", ", SelectColumns()));
+	}
+
+	static std::string TableName()
+	{
+		return std::string("script_constants");
+	}
+
+	static std::string BaseSelect()
+	{
+		return fmt::format(
+			"SELECT {} FROM {}",
+			SelectColumnsRaw(),
+			TableName()
+		);
+	}
+
+	static std::string BaseInsert()
+	{
+		return fmt::format(
+			"INSERT INTO {} ({}) ",
+			TableName(),
+			ColumnsRaw()
+		);
+	}
+
+	static ScriptConstants NewEntity()
+	{
+		ScriptConstants e{};
+
+		e.zone          = "";
+		e.version       = -1;
+		e.lua_namespace = "";
+		e.name          = "";
+		e.value         = "";
+		e.valuetype     = 0;
+
+		return e;
+	}
+
+	static ScriptConstants GetScriptConstants(
+		const std::vector<ScriptConstants> &script_constantss,
+		int script_constants_id
+	)
+	{
+		for (auto &script_constants : script_constantss) {
+			if (script_constants.version == script_constants_id) {
+				return script_constants;
+			}
+		}
+
+		return NewEntity();
+	}
+
+	static ScriptConstants FindOne(
+		Database& db,
+		int script_constants_id
+	)
+	{
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} WHERE {} = {} LIMIT 1",
+				BaseSelect(),
+				PrimaryKey(),
+				script_constants_id
+			)
+		);
+
+		auto row = results.begin();
+		if (results.RowCount() == 1) {
+			ScriptConstants e{};
+
+			e.zone          = row[0] ? row[0] : "";
+			e.version       = row[1] ? static_cast<int16_t>(atoi(row[1])) : -1;
+			e.lua_namespace = row[2] ? row[2] : "";
+			e.name          = row[3] ? row[3] : "";
+			e.value         = row[4] ? row[4] : "";
+			e.valuetype     = row[5] ? static_cast<int16_t>(atoi(row[5])) : 0;
+
+			return e;
+		}
+
+		return NewEntity();
+	}
+
+	static int DeleteOne(
+		Database& db,
+		int script_constants_id
+	)
+	{
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"DELETE FROM {} WHERE {} = {}",
+				TableName(),
+				PrimaryKey(),
+				script_constants_id
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
+
+	static int UpdateOne(
+		Database& db,
+		const ScriptConstants &e
+	)
+	{
+		std::vector<std::string> v;
+
+		auto columns = Columns();
+
+		v.push_back(columns[0] + " = '" + Strings::Escape(e.zone) + "'");
+		v.push_back(columns[1] + " = " + std::to_string(e.version));
+		v.push_back(columns[2] + " = '" + Strings::Escape(e.lua_namespace) + "'");
+		v.push_back(columns[3] + " = '" + Strings::Escape(e.name) + "'");
+		v.push_back(columns[4] + " = '" + Strings::Escape(e.value) + "'");
+		v.push_back(columns[5] + " = " + std::to_string(e.valuetype));
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"UPDATE {} SET {} WHERE {} = {}",
+				TableName(),
+				Strings::Implode(", ", v),
+				PrimaryKey(),
+				e.version
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
+
+	static ScriptConstants InsertOne(
+		Database& db,
+		ScriptConstants e
+	)
+	{
+		std::vector<std::string> v;
+
+		v.push_back("'" + Strings::Escape(e.zone) + "'");
+		v.push_back(std::to_string(e.version));
+		v.push_back("'" + Strings::Escape(e.lua_namespace) + "'");
+		v.push_back("'" + Strings::Escape(e.name) + "'");
+		v.push_back("'" + Strings::Escape(e.value) + "'");
+		v.push_back(std::to_string(e.valuetype));
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} VALUES ({})",
+				BaseInsert(),
+				Strings::Implode(",", v)
+			)
+		);
+
+		if (results.Success()) {
+			e.version = results.LastInsertedID();
+			return e;
+		}
+
+		e = NewEntity();
+
+		return e;
+	}
+
+	static int InsertMany(
+		Database& db,
+		const std::vector<ScriptConstants> &entries
+	)
+	{
+		std::vector<std::string> insert_chunks;
+
+		for (auto &e: entries) {
+			std::vector<std::string> v;
+
+			v.push_back("'" + Strings::Escape(e.zone) + "'");
+			v.push_back(std::to_string(e.version));
+			v.push_back("'" + Strings::Escape(e.lua_namespace) + "'");
+			v.push_back("'" + Strings::Escape(e.name) + "'");
+			v.push_back("'" + Strings::Escape(e.value) + "'");
+			v.push_back(std::to_string(e.valuetype));
+
+			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
+		}
+
+		std::vector<std::string> v;
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} VALUES {}",
+				BaseInsert(),
+				Strings::Implode(",", insert_chunks)
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
+
+	static std::vector<ScriptConstants> All(Database& db)
+	{
+		std::vector<ScriptConstants> all_entries;
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{}",
+				BaseSelect()
+			)
+		);
+
+		all_entries.reserve(results.RowCount());
+
+		for (auto row = results.begin(); row != results.end(); ++row) {
+			ScriptConstants e{};
+
+			e.zone          = row[0] ? row[0] : "";
+			e.version       = row[1] ? static_cast<int16_t>(atoi(row[1])) : -1;
+			e.lua_namespace = row[2] ? row[2] : "";
+			e.name          = row[3] ? row[3] : "";
+			e.value         = row[4] ? row[4] : "";
+			e.valuetype     = row[5] ? static_cast<int16_t>(atoi(row[5])) : 0;
+
+			all_entries.push_back(e);
+		}
+
+		return all_entries;
+	}
+
+	static std::vector<ScriptConstants> GetWhere(Database& db, const std::string &where_filter)
+	{
+		std::vector<ScriptConstants> all_entries;
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} WHERE {}",
+				BaseSelect(),
+				where_filter
+			)
+		);
+
+		all_entries.reserve(results.RowCount());
+
+		for (auto row = results.begin(); row != results.end(); ++row) {
+			ScriptConstants e{};
+
+			e.zone          = row[0] ? row[0] : "";
+			e.version       = row[1] ? static_cast<int16_t>(atoi(row[1])) : -1;
+			e.lua_namespace = row[2] ? row[2] : "";
+			e.name          = row[3] ? row[3] : "";
+			e.value         = row[4] ? row[4] : "";
+			e.valuetype     = row[5] ? static_cast<int16_t>(atoi(row[5])) : 0;
+
+			all_entries.push_back(e);
+		}
+
+		return all_entries;
+	}
+
+	static int DeleteWhere(Database& db, const std::string &where_filter)
+	{
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"DELETE FROM {} WHERE {}",
+				TableName(),
+				where_filter
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
+
+	static int Truncate(Database& db)
+	{
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"TRUNCATE TABLE {}",
+				TableName()
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
+
+	static int64 GetMaxId(Database& db)
+	{
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"SELECT COALESCE(MAX({}), 0) FROM {}",
+				PrimaryKey(),
+				TableName()
+			)
+		);
+
+		return (results.Success() && results.begin()[0] ? strtoll(results.begin()[0], nullptr, 10) : 0);
+	}
+
+	static int64 Count(Database& db, const std::string &where_filter = "")
+	{
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"SELECT COUNT(*) FROM {} {}",
+				TableName(),
+				(where_filter.empty() ? "" : "WHERE " + where_filter)
+			)
+		);
+
+		return (results.Success() && results.begin()[0] ? strtoll(results.begin()[0], nullptr, 10) : 0);
+	}
+
+	static std::string BaseReplace()
+	{
+		return fmt::format(
+			"REPLACE INTO {} ({}) ",
+			TableName(),
+			ColumnsRaw()
+		);
+	}
+
+	static int ReplaceOne(
+		Database& db,
+		const ScriptConstants &e
+	)
+	{
+		std::vector<std::string> v;
+
+		v.push_back("'" + Strings::Escape(e.zone) + "'");
+		v.push_back(std::to_string(e.version));
+		v.push_back("'" + Strings::Escape(e.lua_namespace) + "'");
+		v.push_back("'" + Strings::Escape(e.name) + "'");
+		v.push_back("'" + Strings::Escape(e.value) + "'");
+		v.push_back(std::to_string(e.valuetype));
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} VALUES ({})",
+				BaseReplace(),
+				Strings::Implode(",", v)
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
+
+	static int ReplaceMany(
+		Database& db,
+		const std::vector<ScriptConstants> &entries
+	)
+	{
+		std::vector<std::string> insert_chunks;
+
+		for (auto &e: entries) {
+			std::vector<std::string> v;
+
+			v.push_back("'" + Strings::Escape(e.zone) + "'");
+			v.push_back(std::to_string(e.version));
+			v.push_back("'" + Strings::Escape(e.lua_namespace) + "'");
+			v.push_back("'" + Strings::Escape(e.name) + "'");
+			v.push_back("'" + Strings::Escape(e.value) + "'");
+			v.push_back(std::to_string(e.valuetype));
+
+			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
+		}
+
+		std::vector<std::string> v;
+
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"{} VALUES {}",
+				BaseReplace(),
+				Strings::Implode(",", insert_chunks)
+			)
+		);
+
+		return (results.Success() ? results.RowsAffected() : 0);
+	}
+};
+
+#endif //EQEMU_BASE_SCRIPT_CONSTANTS_REPOSITORY_H

--- a/common/repositories/script_constants_repository.h
+++ b/common/repositories/script_constants_repository.h
@@ -1,0 +1,52 @@
+#ifndef EQEMU_SCRIPT_CONSTANTS_REPOSITORY_H
+#define EQEMU_SCRIPT_CONSTANTS_REPOSITORY_H
+
+#include "../database.h"
+#include "../strings.h"
+#include "base/base_script_constants_repository.h"
+
+class ScriptConstantsRepository: public BaseScriptConstantsRepository {
+public:
+
+	/**
+	 * This file was auto generated and can be modified and extended upon
+	 *
+	 * Base repository methods are automatically
+	 * generated in the "base" version of this repository. The base repository
+	 * is immutable and to be left untouched, while methods in this class
+	 * are used as extension methods for more specific persistence-layer
+	 * accessors or mutators.
+	 *
+	 * Base Methods (Subject to be expanded upon in time)
+	 *
+	 * Note: Not all tables are designed appropriately to fit functionality with all base methods
+	 *
+	 * InsertOne
+	 * UpdateOne
+	 * DeleteOne
+	 * FindOne
+	 * GetWhere(std::string where_filter)
+	 * DeleteWhere(std::string where_filter)
+	 * InsertMany
+	 * All
+	 *
+	 * Example custom methods in a repository
+	 *
+	 * ScriptConstantsRepository::GetByZoneAndVersion(int zone_id, int zone_version)
+	 * ScriptConstantsRepository::GetWhereNeverExpires()
+	 * ScriptConstantsRepository::GetWhereXAndY()
+	 * ScriptConstantsRepository::DeleteWhereXAndY()
+	 *
+	 * Most of the above could be covered by base methods, but if you as a developer
+	 * find yourself re-using logic for other parts of the code, its best to just make a
+	 * method that can be re-used easily elsewhere especially if it can use a base repository
+	 * method and encapsulate filters there
+	 */
+
+	enum ValueTypes {
+		Number = 1,
+		String = 2
+	};
+};
+
+#endif //EQEMU_SCRIPT_CONSTANTS_REPOSITORY_H

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9323
+#define CURRENT_BINARY_DATABASE_VERSION 9324
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9054
 #define CUSTOM_BINARY_DATABASE_VERSION 0
 

--- a/zone/lua_general.h
+++ b/zone/lua_general.h
@@ -25,6 +25,7 @@ luabind::scope lua_register_rules();
 luabind::scope lua_register_journal_speakmode();
 luabind::scope lua_register_journal_mode();
 luabind::scope lua_register_exp_source();
+void lua_register_db_consts(lua_State *L);
 
 #endif
 #endif

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -1326,6 +1326,8 @@ void LuaParser::MapFunctions(lua_State *L) {
 			lua_register_zone()
 		)];
 
+		lua_register_db_consts(L);
+
 	} catch(std::exception &ex) {
 		std::string error = ex.what();
 		AddError(error);


### PR DESCRIPTION
# Description

New content often relies on constant values that may change from initial development to deployment.  Things such as npc type ids, spell ids, etc.  This feature introduces a 'script_constants' table that will have its contents exposed into the Lua global namespace as a 'DBConstants' table.

At a minimum this helps makes the content more portable but the end-goal here is to allow ambitious content writers to create setup routines that can utilize the scripting DB interface to seed the database with new data and then store the resulting constant values in this table to get their content working with no manual effort.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing

![image](https://github.com/user-attachments/assets/e1260ccf-ec14-4700-868f-98d1aaf81985)

Based on the table contents above the following constants should be present in 'Blackburrow' version 0
DBConstants.test.value1 = 'hello world'
DBConstants.test2.value1 = 'hello world 2'
DBConstants.test4.value1 = 'hello world 4'

Actual:
![image](https://github.com/user-attachments/assets/b9799724-a389-4bef-8a71-32f51222fa49)

'Blackburrow' version 255 expected:
DBConstants.test.value1 = 'hello world'
DBConstants.test2.value1 = 'hello world 2'
DBConstants.test3.value1 = 'hello world 3'

Actual:
![image](https://github.com/user-attachments/assets/752853e4-7ac6-4c38-8ca6-53b127c71313)

'Crushbone' version 0 expected:
DBConstants.test.value1 = 'hello world'
DBConstants.test.value1 = 12345

Actual:
![image](https://github.com/user-attachments/assets/61fa7e73-78d3-4306-a981-200b159966c5)


# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
- [x] If my changes make database schema changes, I have tested the changes on a local database (attach image). Updated version.h CURRENT_BINARY_DATABASE_VERSION to the new version. (Delete this if not applicable)
