### PR TITLE
[Fix] Bulk Send Corpses after Idle State

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -12796,6 +12796,16 @@ void Client::CheckSendBulkNpcPositions(bool force)
 			updated_count++;
 		}
 
+		if (force) {
+			static EQApplicationPacket p(OP_ClientUpdate, sizeof(PlayerPositionUpdateServer_Struct));
+			auto      *s = (PlayerPositionUpdateServer_Struct *) p.pBuffer;
+			for (auto &e: entity_list.GetCorpseList()) {
+				Corpse *c = e.second;
+				MakeSpawnUpdate(s);
+				QueuePacket(&p, false);
+			}
+		}
+
 		LogPositionUpdate(
 			"[{}] Sent [{}] bulk updated NPC positions, skipped [{}] distance_moved [{}] update_range [{}]",
 			GetCleanName(),


### PR DESCRIPTION
# Description

This PR addresses a minor edge case around https://github.com/EQEmu/Server/pull/4903 where an idle player can come back and corpse positions do not get synced to the player.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Untested, but should work

![image](https://github.com/user-attachments/assets/3a98d146-7368-4062-9ca0-e248a9aa178b)

# Checklist

- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
