### PR TITLE
[Corpses] Add corpse entity variables to DB

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -7112,6 +7112,18 @@ ADD COLUMN `first_login` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `xtargets`;
 )",
 		.content_schema_update = false
 	},
+	ManifestEntry{
+		.version = 9324,
+		.description = "2025_06_10_character_corpses_entity_variables.sql",
+		.check = "SHOW COLUMNS FROM `character_corpses` LIKE 'entity_variables'",
+		.condition = "empty",
+		.match = "",
+		.sql = R"(
+ALTER TABLE `character_corpses`
+ADD COLUMN `entity_variables` TEXT DEFAULT NULL AFTER `rezzable`;
+)",
+		.content_schema_update = false
+	},
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{
 //		.version = 9228,

--- a/common/repositories/base/base_character_corpses_repository.h
+++ b/common/repositories/base/base_character_corpses_repository.h
@@ -70,6 +70,7 @@ public:
 		uint32_t    gm_exp;
 		uint32_t    killed_by;
 		uint8_t     rezzable;
+		std::string entity_variables;
 	};
 
 	static std::string PrimaryKey()
@@ -131,6 +132,7 @@ public:
 			"gm_exp",
 			"killed_by",
 			"rezzable",
+			"entity_variables",
 		};
 	}
 
@@ -188,6 +190,7 @@ public:
 			"gm_exp",
 			"killed_by",
 			"rezzable",
+			"entity_variables",
 		};
 	}
 
@@ -279,6 +282,7 @@ public:
 		e.gm_exp           = 0;
 		e.killed_by        = 0;
 		e.rezzable         = 0;
+		e.entity_variables = "";
 
 		return e;
 	}
@@ -366,6 +370,7 @@ public:
 			e.gm_exp           = row[48] ? static_cast<uint32_t>(strtoul(row[48], nullptr, 10)) : 0;
 			e.killed_by        = row[49] ? static_cast<uint32_t>(strtoul(row[49], nullptr, 10)) : 0;
 			e.rezzable         = row[50] ? static_cast<uint8_t>(strtoul(row[50], nullptr, 10)) : 0;
+			e.entity_variables = row[51] ? row[51] : "";
 
 			return e;
 		}
@@ -449,6 +454,7 @@ public:
 		v.push_back(columns[48] + " = " + std::to_string(e.gm_exp));
 		v.push_back(columns[49] + " = " + std::to_string(e.killed_by));
 		v.push_back(columns[50] + " = " + std::to_string(e.rezzable));
+		v.push_back(columns[51] + " = '" + Strings::Escape(e.entity_variables) + "'");
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -521,6 +527,7 @@ public:
 		v.push_back(std::to_string(e.gm_exp));
 		v.push_back(std::to_string(e.killed_by));
 		v.push_back(std::to_string(e.rezzable));
+		v.push_back("'" + Strings::Escape(e.entity_variables) + "'");
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -601,6 +608,7 @@ public:
 			v.push_back(std::to_string(e.gm_exp));
 			v.push_back(std::to_string(e.killed_by));
 			v.push_back(std::to_string(e.rezzable));
+			v.push_back("'" + Strings::Escape(e.entity_variables) + "'");
 
 			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
 		}
@@ -685,6 +693,7 @@ public:
 			e.gm_exp           = row[48] ? static_cast<uint32_t>(strtoul(row[48], nullptr, 10)) : 0;
 			e.killed_by        = row[49] ? static_cast<uint32_t>(strtoul(row[49], nullptr, 10)) : 0;
 			e.rezzable         = row[50] ? static_cast<uint8_t>(strtoul(row[50], nullptr, 10)) : 0;
+			e.entity_variables = row[51] ? row[51] : "";
 
 			all_entries.push_back(e);
 		}
@@ -760,6 +769,7 @@ public:
 			e.gm_exp           = row[48] ? static_cast<uint32_t>(strtoul(row[48], nullptr, 10)) : 0;
 			e.killed_by        = row[49] ? static_cast<uint32_t>(strtoul(row[49], nullptr, 10)) : 0;
 			e.rezzable         = row[50] ? static_cast<uint8_t>(strtoul(row[50], nullptr, 10)) : 0;
+			e.entity_variables = row[51] ? row[51] : "";
 
 			all_entries.push_back(e);
 		}
@@ -885,6 +895,7 @@ public:
 		v.push_back(std::to_string(e.gm_exp));
 		v.push_back(std::to_string(e.killed_by));
 		v.push_back(std::to_string(e.rezzable));
+		v.push_back("'" + Strings::Escape(e.entity_variables) + "'");
 
 		auto results = db.QueryDatabase(
 			fmt::format(
@@ -958,6 +969,7 @@ public:
 			v.push_back(std::to_string(e.gm_exp));
 			v.push_back(std::to_string(e.killed_by));
 			v.push_back(std::to_string(e.rezzable));
+			v.push_back("'" + Strings::Escape(e.entity_variables) + "'");
 
 			insert_chunks.push_back("(" + Strings::Implode(",", v) + ")");
 		}

--- a/common/repositories/character_corpses_repository.h
+++ b/common/repositories/character_corpses_repository.h
@@ -231,6 +231,21 @@ public:
 
 		return UpdateOne(db, corpse);
 	}
+
+	static int UpdateEntityVariables(Database& db, uint32 corpse_id, const std::string& json_string)
+	{
+		auto results = db.QueryDatabase(
+			fmt::format(
+				"UPDATE `{}` SET `entity_variables` = '{}' WHERE `{}` = {}",
+				TableName(),
+				Strings::Escape(json_string),
+				PrimaryKey(),
+				corpse_id
+			)
+		);
+
+		return results.Success() ? results.RowsAffected() : 0;
+	}
 };
 
 #endif //EQEMU_CHARACTER_CORPSES_REPOSITORY_H

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9323
+#define CURRENT_BINARY_DATABASE_VERSION 9324
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9054
 #define CUSTOM_BINARY_DATABASE_VERSION 0
 

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -32,7 +32,9 @@
 #include "../common/repositories/character_corpse_items_repository.h"
 #include <iostream>
 #include "queryserv.h"
+#include "../common/json/json.hpp"
 
+using json = nlohmann::json;
 
 extern EntityList           entity_list;
 extern Zone                *zone;
@@ -673,6 +675,21 @@ bool Corpse::Save()
 	ce.drakkin_heritage = drakkin_heritage;
 	ce.drakkin_tattoo   = drakkin_tattoo;
 	ce.drakkin_details  = drakkin_details;
+
+	{
+		json j;
+		for (const auto& kv : m_EntityVariables) {
+			j[kv.first] = kv.second;
+		}
+
+		if (!j.empty()) {
+			ce.entity_variables = j.dump();
+		} else {
+			ce.entity_variables = "{}";
+		}
+
+		LogCorpses("Corpse entity_variables: %s", ce.entity_variables.c_str());
+	}
 
 	for (auto &item: m_item_list) {
 		CharacterCorpseItemEntry e;
@@ -2428,9 +2445,34 @@ Corpse *Corpse::LoadCharacterCorpse(
 	c->m_become_npc                = false;
 	c->m_consented_guild_id        = cc.guild_consent_id;
 
+	if (!cc.entity_variables.empty() && cc.entity_variables != "null") {
+		json j = json::parse(cc.entity_variables, nullptr, false);
+		if (!j.is_discarded()) {
+			for (auto& el : j.items()) {
+				c->SetEntityVariable(el.key(), el.value().get<std::string>());
+			}
+		}
+	}
+
 	c->IsRezzed(cc.is_rezzed);
 
 	c->UpdateEquipmentLight();
 
 	return c;
+}
+
+void Corpse::SyncEntityVariablesToCorpseDB()
+{
+	if (!m_is_player_corpse || m_corpse_db_id == 0) {
+		return;
+	}
+
+	json j;
+	for (const auto& [key, value] : m_EntityVariables) {
+		j[key] = value;
+	}
+
+	std::string serialized = j.dump();
+
+	CharacterCorpsesRepository::UpdateEntityVariables(database, m_corpse_db_id, serialized);
 }

--- a/zone/corpse.h
+++ b/zone/corpse.h
@@ -244,6 +244,8 @@ public:
 		const glm::vec4 &position
 	);
 
+	void SyncEntityVariablesToCorpseDB();
+
 protected:
 	void MoveItemToCorpse(Client *client, EQ::ItemInstance *inst, int16 equipSlot, std::list<uint32> &removedList);
 

--- a/zone/zonedb.h
+++ b/zone/zonedb.h
@@ -336,6 +336,7 @@ struct CharacterCorpseEntry
 	uint32 drakkin_tattoo;
 	uint32 drakkin_details;
 	std::vector<CharacterCorpseItemEntry> items;
+	std::string entity_variables;
 };
 
 namespace BeastlordPetData {


### PR DESCRIPTION
# Description

- When corpses have entity variables add/remove/modified it will update the database accordingly.
- Corpse loading will pull the database values if they exist.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# Testing

![image](https://github.com/user-attachments/assets/380f3781-533a-431e-8ae8-f7a28da7062e)
![image](https://github.com/user-attachments/assets/9de18721-4e3b-4b1a-a340-90bfc8285ed2)

Clients tested: RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
- [X] If my changes make database schema changes, I have tested the changes on a local database (attach image). Updated version.h CURRENT_BINARY_DATABASE_VERSION to the new version. (Delete this if not applicable)
