### PR TITLE
[Player Event Logs] Don't Clear Event Data on ETL Events

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -7112,6 +7112,18 @@ ADD COLUMN `first_login` int(11) UNSIGNED NOT NULL DEFAULT 0 AFTER `xtargets`;
 )",
 		.content_schema_update = false
 	},
+	ManifestEntry{
+		.version = 9324,
+		.description = "2025_06_11_player_event_logs_table.sql",
+		.check = "SHOW CREATE TABLE `player_event_logs`",
+		.condition = "missing",
+		.match = "COMPRESS",
+		.sql = R"(
+ALTER TABLE player_event_logs ROW_FORMAT=COMPRESSED;
+CREATE INDEX idx_event_type_char_id ON player_event_logs (event_type_id, character_id);
+)",
+		.content_schema_update = false
+	},
 // -- template; copy/paste this when you need to create a new entry
 //	ManifestEntry{
 //		.version = 9228,

--- a/common/events/player_event_logs.cpp
+++ b/common/events/player_event_logs.cpp
@@ -195,10 +195,12 @@ void PlayerEventLogs::ProcessBatchQueue()
 	};
 
 	// Helper to assign ETL table ID
-	auto                                                                                                          AssignEtlId      = [&](
-		PlayerEventLogsRepository::PlayerEventLogs &r,
-		PlayerEvent::EventType type
-	) {
+
+	auto AssignEtlId = [&](
+		PlayerEventLogsRepository::PlayerEventLogs& r,
+		PlayerEvent::EventType                      type
+	)
+	{
 		if (m_etl_settings.contains(type)) {
 			r.etl_table_id = m_etl_settings.at(type).next_id++;
 		}
@@ -406,7 +408,6 @@ void PlayerEventLogs::ProcessBatchQueue()
 			auto it = event_processors.find(static_cast<PlayerEvent::EventType>(r.event_type_id));
 			if (it != event_processors.end()) {
 				it->second(r);  // Call the appropriate lambda
-				r.event_data = "{}"; // Clear event data
 			}
 			else {
 				LogPlayerEventsDetail("Non-Implemented ETL routing [{}]", r.event_type_id);

--- a/common/version.h
+++ b/common/version.h
@@ -42,7 +42,7 @@
  * Manifest: https://github.com/EQEmu/Server/blob/master/utils/sql/db_update_manifest.txt
  */
 
-#define CURRENT_BINARY_DATABASE_VERSION 9323
+#define CURRENT_BINARY_DATABASE_VERSION 9324
 #define CURRENT_BINARY_BOTS_DATABASE_VERSION 9054
 #define CUSTOM_BINARY_DATABASE_VERSION 0
 


### PR DESCRIPTION
# Description

When ETL events are turned on, we empty the JSON data payload. This causes issues with viewing the data through tools like Spire. As a fundamental design decision as to how we want to use this tooling, we are re-introducing the data back into the field for simplicity of use.

When operators use ETL features, they are opting into double recording data. The data in tables can be used for different ways and it doesn't make sense to build tooling conditionally around both tables depending on if certain things are turned on/off or not.

To offset this, I'm enabling table compression on the table which will at least save 50% of the table storage size. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Optimization

# Testing

Ran the migration on a 40GB player event table, went down to 20GB. Event data no longer gets truncated.

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
- [x] If my changes make database schema changes, I have tested the changes on a local database (attach image). Updated version.h CURRENT_BINARY_DATABASE_VERSION to the new version. (Delete this if not applicable)
