### PR TITLE
[Player Events] Zone Fetch Settings from QS if Enabled

### DIFF
--- a/common/events/player_event_logs.cpp
+++ b/common/events/player_event_logs.cpp
@@ -535,6 +535,20 @@ std::string PlayerEventLogs::GetDiscordWebhookUrlFromEventType(int32_t event_typ
 	return "";
 }
 
+void PlayerEventLogs::LoadPlayerEventSettingsFromQS(
+	const std::vector<PlayerEventLogSettingsRepository::PlayerEventLogSettings> &settings
+)
+{
+	for (const auto &e : settings) {
+		if (e.id >= PlayerEvent::MAX || e.id < 0) {
+			continue;
+		}
+		m_settings[e.id] = e;
+	}
+
+	LogInfo("Applied [{}] player event log settings from QS", settings.size());
+}
+
 // GM_COMMAND           | [x] Implemented Formatter
 // ZONING               | [x] Implemented Formatter
 // AA_GAIN              | [x] Implemented Formatter

--- a/common/events/player_event_logs.h
+++ b/common/events/player_event_logs.h
@@ -73,9 +73,11 @@ public:
 		return BuildPlayerEventPacket(c);
 	}
 
-	[[nodiscard]] const PlayerEventLogSettingsRepository::PlayerEventLogSettings *GetSettings() const;
-	bool IsEventDiscordEnabled(int32_t event_type_id);
-	std::string GetDiscordWebhookUrlFromEventType(int32_t event_type_id);
+	[[nodiscard]] const PlayerEventLogSettingsRepository::PlayerEventLogSettings * GetSettings() const;
+	bool                                                                           IsEventDiscordEnabled(int32_t event_type_id);
+	std::string                                                                    GetDiscordWebhookUrlFromEventType(int32_t event_type_id);
+
+	void LoadPlayerEventSettingsFromQS(const std::vector<PlayerEventLogSettingsRepository::PlayerEventLogSettings>& settings);
 
 	static std::string GetDiscordPayloadFromEvent(const PlayerEvent::PlayerEventContainer &e);
 

--- a/common/repositories/base/base_player_event_log_settings_repository.h
+++ b/common/repositories/base/base_player_event_log_settings_repository.h
@@ -15,7 +15,7 @@
 #include "../../database.h"
 #include "../../strings.h"
 #include <ctime>
-
+#include <cereal/cereal.hpp>
 class BasePlayerEventLogSettingsRepository {
 public:
 	struct PlayerEventLogSettings {
@@ -25,6 +25,20 @@ public:
 		int32_t     retention_days;
 		int32_t     discord_webhook_id;
 		uint8_t     etl_enabled;
+
+		// cereal
+		template<class Archive>
+		void serialize(Archive &ar)
+		{
+			ar(
+				CEREAL_NVP(id),
+				CEREAL_NVP(event_name),
+				CEREAL_NVP(event_enabled),
+				CEREAL_NVP(retention_days),
+				CEREAL_NVP(discord_webhook_id),
+				CEREAL_NVP(etl_enabled)
+			);
+		}
 	};
 
 	static std::string PrimaryKey()

--- a/common/servertalk.h
+++ b/common/servertalk.h
@@ -273,8 +273,9 @@
 #define ServerOP_WWTaskUpdate 0x4758
 
 // player events
-#define ServerOP_QSSendQuery		0x5000
+#define ServerOP_QSSendQuery 0x5000
 #define ServerOP_PlayerEvent 0x5100
+#define ServerOP_SendPlayerEventSettings 0x5101
 
 enum {
 	CZUpdateType_Character,
@@ -1777,6 +1778,7 @@ struct BazaarPurchaseMessaging_Struct {
 	uint32           item_quantity_available;
 	uint32           id;
 };
+
 
 #pragma pack()
 

--- a/queryserv/worldserver.cpp
+++ b/queryserv/worldserver.cpp
@@ -21,10 +21,13 @@
 #include <string.h>
 #include <time.h>
 
+#include "zonelist.h"
+
 extern WorldServer           worldserver;
 extern const queryservconfig *Config;
 extern QSDatabase            qs_database;
 extern LFGuildManager        lfguildmanager;
+extern ZSList                zs_list;
 
 WorldServer::WorldServer()
 {
@@ -78,6 +81,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 			if (o->type == ServerReload::Type::Logs) {
 				LogSys.LoadLogDatabaseSettings();
 				player_event_logs.ReloadSettings();
+				zs_list.SendPlayerEventLogSettings();
 			}
 
 			break;

--- a/queryserv/zonelist.cpp
+++ b/queryserv/zonelist.cpp
@@ -5,6 +5,8 @@
 void ZSList::Add(ZoneServer* zoneserver) {
 	zone_server_list.emplace_back(std::unique_ptr<ZoneServer>(zoneserver));
 	zoneserver->SetIsZoneConnected(true);
+
+	zoneserver->SendPlayerEventLogSettings();
 }
 
 void ZSList::Remove(const std::string &uuid)
@@ -16,5 +18,12 @@ void ZSList::Remove(const std::string &uuid)
 			return;
 		}
 		iter++;
+	}
+}
+
+void ZSList::SendPlayerEventLogSettings()
+{
+	for (auto &zs : zone_server_list) {
+		zs->SendPlayerEventLogSettings();
 	}
 }

--- a/queryserv/zonelist.h
+++ b/queryserv/zonelist.h
@@ -12,9 +12,10 @@ class ZoneServer;
 
 class ZSList {
 public:
-	std::list<std::unique_ptr<ZoneServer>> &GetZsList() { return zone_server_list; }
-	void Add(ZoneServer *zoneserver);
-	void Remove(const std::string &uuid);
+	std::list<std::unique_ptr<ZoneServer>>& GetZsList() { return zone_server_list; }
+	void                                    Add(ZoneServer* zoneserver);
+	void                                    Remove(const std::string& uuid);
+	void                                    SendPlayerEventLogSettings();
 
 private:
 	std::list<std::unique_ptr<ZoneServer>> zone_server_list;

--- a/queryserv/zoneserver.cpp
+++ b/queryserv/zoneserver.cpp
@@ -58,8 +58,6 @@ void ZoneServer::SendPlayerEventLogSettings()
 
 	dyn_pack.PutSerialize(0, settings);
 
-	LogInfo("settings size [{}]", dyn_pack.Length());
-
 	auto packet_size = sizeof(ServerSendPlayerEvent_Struct) + dyn_pack.Length();
 
 	auto pack = std::make_unique<ServerPacket>(

--- a/queryserv/zoneserver.h
+++ b/queryserv/zoneserver.h
@@ -16,11 +16,12 @@ class ZoneServer : public WorldTCPConnection {
 public:
 	ZoneServer(std::shared_ptr<EQ::Net::ServertalkServerConnection> in_connection, EQ::Net::ConsoleServer *in_console);
 	~ZoneServer();
-	void SendPacket(ServerPacket *pack) { m_connection->SendPacket(pack); }
-	void SetIsZoneConnected(bool in) { m_is_zone_connected = in; }
-	bool GetIsZoneConnected() { return m_is_zone_connected; }
-	void HandleMessage(uint16 opcode, const EQ::Net::Packet &p);
+	void        SendPacket(ServerPacket *pack) { m_connection->SendPacket(pack); }
+	void        SetIsZoneConnected(bool in) { m_is_zone_connected = in; }
+	bool        GetIsZoneConnected() { return m_is_zone_connected; }
+	void        HandleMessage(uint16 opcode, const EQ::Net::Packet &p);
 	std::string GetUUID() const { return m_connection->GetUUID(); }
+	void        SendPlayerEventLogSettings();
 
 private:
 	std::shared_ptr<EQ::Net::ServertalkServerConnection> m_connection{};

--- a/utils/scripts/generators/repository-generator.pl
+++ b/utils/scripts/generators/repository-generator.pl
@@ -114,7 +114,8 @@ if ($requested_table_to_generate ne "all") {
 
 my @cereal_enabled_tables = (
     "data_buckets",
-    "player_event_logs"
+    "player_event_logs",
+    "player_event_log_settings"
 );
 
 my $generated_base_repository_files = "";

--- a/world/zonelist.cpp
+++ b/world/zonelist.cpp
@@ -37,6 +37,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include "dynamic_zone_manager.h"
 #include "ucs.h"
 #include "clientlist.h"
+#include "queryserv.h"
 #include "../common/repositories/trader_repository.h"
 #include "../common/repositories/buyer_repository.h"
 
@@ -45,6 +46,7 @@ extern EQ::Random emu_random;
 extern WebInterfaceList web_interface;
 extern SharedTaskManager shared_task_manager;
 extern ClientList client_list;
+extern QueryServConnection QSLink;
 volatile bool UCSServerAvailable_ = false;
 void CatchSignal(int sig_num);
 
@@ -985,6 +987,7 @@ void ZSList::SendServerReload(ServerReload::Type type, uchar *packet)
 		LogSys.LoadLogDatabaseSettings();
 		player_event_logs.ReloadSettings();
 		UCSLink.SendPacket(&pack);
+		QSLink.SendPacket(&pack);
 	} else if (type == ServerReload::Type::Tasks) {
 		shared_task_manager.LoadTaskData();
 	} else if (type == ServerReload::Type::DzTemplates) {

--- a/zone/queryserv.cpp
+++ b/zone/queryserv.cpp
@@ -1,12 +1,13 @@
 #include "../common/global_define.h"
 #include "../common/servertalk.h"
 #include "../common/strings.h"
+#include "../common/events/player_event_logs.h"
 #include "queryserv.h"
 #include "worldserver.h"
 
 
 extern WorldServer worldserver;
-extern QueryServ  *QServ;
+extern QueryServ*  QServ;
 
 QueryServ::QueryServ()
 {
@@ -20,18 +21,29 @@ void QueryServ::SendQuery(std::string Query)
 {
 	auto pack = new ServerPacket(ServerOP_QSSendQuery, Query.length() + 5);
 	pack->WriteUInt32(Query.length()); /* Pack Query String Size so it can be dynamically broken out at queryserv */
-	pack->WriteString(Query.c_str()); /* Query */
+	pack->WriteString(Query.c_str());  /* Query */
 	worldserver.SendPacket(pack);
 	safe_delete(pack);
 }
 
 void QueryServ::Connect()
 {
-	m_connection = std::make_unique<EQ::Net::ServertalkClient>(Config->QSHost, Config->QSPort, false, "Zone", Config->SharedKey);
+	m_connection = std::make_unique<EQ::Net::ServertalkClient>(
+		Config->QSHost,
+		Config->QSPort,
+		false,
+		"Zone",
+		Config->SharedKey
+	);
 	m_connection->OnMessage(std::bind(&QueryServ::HandleMessage, this, std::placeholders::_1, std::placeholders::_2));
-	m_connection->OnConnect([this](EQ::Net::ServertalkClient *client) {
+	m_connection->OnConnect([this](EQ::Net::ServertalkClient* client)
+	{
 		m_is_qs_connected = true;
-		LogInfo("Query Server connection established to [{}] [{}]", client->Handle()->RemoteIP(), client->Handle()->RemotePort());
+		LogInfo(
+			"Query Server connection established to [{}] [{}]",
+			client->Handle()->RemoteIP(),
+			client->Handle()->RemotePort()
+		);
 	});
 
 	LogInfo(
@@ -41,7 +53,7 @@ void QueryServ::Connect()
 	);
 }
 
-bool QueryServ::SendPacket(ServerPacket *pack)
+bool QueryServ::SendPacket(ServerPacket* pack)
 {
 	if (m_connection.get() == nullptr) {
 		Connect();
@@ -59,14 +71,50 @@ bool QueryServ::SendPacket(ServerPacket *pack)
 	return false;
 }
 
-void QueryServ::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
+void QueryServ::HandleMessage(uint16 opcode, const EQ::Net::Packet& p)
 {
 	ServerPacket tpack(opcode, p);
-	auto pack = &tpack;
+	auto         pack = &tpack;
 
 	switch (opcode) {
-		default: {
-			LogInfo("Unknown ServerOP Received <red>[{}]", opcode);
+	case ServerOP_SendPlayerEventSettings:
+		{
+			if (pack->size < sizeof(ServerSendPlayerEvent_Struct)) {
+				LogError("ServerOP_SendPlayerEventSettings: packet too small");
+				break;
+			}
+
+			auto*          data          = reinterpret_cast<const ServerSendPlayerEvent_Struct*>(pack->pBuffer);
+			const uint32_t expected_size = sizeof(ServerSendPlayerEvent_Struct) + data->cereal_size;
+
+			if (pack->size < expected_size) {
+				LogError(
+					"ServerOP_SendPlayerEventSettings: packet size mismatch, expected {}, got {}", expected_size,
+					pack->size
+				);
+				break;
+			}
+
+			std::vector<PlayerEventLogSettingsRepository::PlayerEventLogSettings> settings;
+
+			try {
+				EQ::Util::MemoryStreamReader ms(const_cast<char*>(data->cereal_data), data->cereal_size);
+				cereal::BinaryInputArchive   ar(ms);
+				ar(settings);
+			}
+			catch (const std::exception& ex) {
+				LogError("Failed to deserialize PlayerEventLogSettings: {}", ex.what());
+				break;
+			}
+
+			player_event_logs.LoadPlayerEventSettingsFromQS(settings);
+			LogInfo("Loaded {} PlayerEventLogSettings from queryserv", settings.size());
+			break;
+		}
+
+	default:
+		{
+			LogInfo("Unknown ServerOP Received [{}]", opcode);
 			break;
 		}
 	}

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -4592,7 +4592,10 @@ void WorldServer::ProcessReload(const ServerReload::Request& request)
 
 		case ServerReload::Type::Logs:
 			LogSys.LoadLogDatabaseSettings();
-			player_event_logs.ReloadSettings();
+			// if QS process is enabled, we get settings from QS
+			if (!RuleB(Logging, PlayerEventsQSProcess)) {
+				player_event_logs.ReloadSettings();
+			}
 			break;
 
 		case ServerReload::Type::Loot:


### PR DESCRIPTION
# Description

When large servers have high player event log volume, they can choose to offload player events to another server (QueryServ) where it has a separate logging database and server entirely.

The problem with this is that player event log settings can become split brained because the settings are authoritative on QS (log server). The zone server loads settings locally instead of pulling them from QS. This PR addresses that by having QS send settings when zone initially connects.

When #reload or Spire reload requests are issued, when the rule **Logging:PlayerEventsQSProcess** is enabled, zones will instead reload from QS instead of reloading from their local.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

When zones boot, they fetch settings from QS when **Logging:PlayerEventsQSProcess** is enabled

![image](https://github.com/user-attachments/assets/61f4d422-08f3-4c91-9f7c-e9174547cdbe)

This is when log settings are reloaded either from in game or from Spire

![image](https://github.com/user-attachments/assets/2667abc0-3e19-4a90-accb-78e78eb87a60)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

