### PR TITLE
[Databuckets] Move Databuckets to Common

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -13,6 +13,7 @@ SET(common_sources
     crash.cpp
     crc16.cpp
     crc32.cpp
+    data_bucket.cpp
     database/database_dump_service.cpp
     database.cpp
     database_instances.cpp
@@ -550,6 +551,7 @@ SET(common_headers
     cli/eqemu_command_handler.h
     cli/terminal_color.hpp
     cron/croncpp.h
+    data_bucket.h
     database/database_dump_service.h
     data_verification.h
     database.h

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -13,7 +13,6 @@ SET(common_sources
     crash.cpp
     crc16.cpp
     crc32.cpp
-    data_bucket.cpp
     database/database_dump_service.cpp
     database.cpp
     database_instances.cpp
@@ -551,7 +550,6 @@ SET(common_headers
     cli/eqemu_command_handler.h
     cli/terminal_color.hpp
     cron/croncpp.h
-    data_bucket.h
     database/database_dump_service.h
     data_verification.h
     database.h

--- a/common/data_bucket.cpp
+++ b/common/data_bucket.cpp
@@ -9,7 +9,15 @@ using json = nlohmann::json;
 const std::string                               NESTED_KEY_DELIMITER = ".";
 std::vector<DataBucketsRepository::DataBuckets> g_data_bucket_cache  = {};
 
-extern Database database;
+#if defined(ZONE)
+#include "../zone/zonedb.h"
+extern ZoneDatabase database;
+#elif defined(WORLD)
+#include "../world/worlddb.h"
+extern WorldDatabase database;
+#else
+#error "You must define either ZONE or WORLD"
+#endif
 
 void DataBucket::SetData(const std::string &bucket_key, const std::string &bucket_value, std::string expires_time)
 {

--- a/common/data_bucket.cpp
+++ b/common/data_bucket.cpp
@@ -1,18 +1,15 @@
-#include "data_bucket.h"
-#include "zonedb.h"
-#include "mob.h"
-#include "client.h"
-#include "worldserver.h"
+#include "../common/data_bucket.h"
+#include "database.h"
 #include <ctime>
 #include <cctype>
 #include "../common/json/json.hpp"
 
 using json = nlohmann::json;
 
-extern WorldServer worldserver;
-const std::string  NESTED_KEY_DELIMITER = ".";
+const std::string                               NESTED_KEY_DELIMITER = ".";
+std::vector<DataBucketsRepository::DataBuckets> g_data_bucket_cache  = {};
 
-std::vector<DataBucketsRepository::DataBuckets> g_data_bucket_cache = {};
+extern Database database;
 
 void DataBucket::SetData(const std::string &bucket_key, const std::string &bucket_value, std::string expires_time)
 {
@@ -345,27 +342,6 @@ std::string DataBucket::GetDataRemaining(const std::string &bucket_key)
 bool DataBucket::DeleteData(const std::string &bucket_key)
 {
 	return DeleteData(DataBucketKey{.key = bucket_key});
-}
-
-// GetDataBuckets bulk loads all data buckets for a mob
-bool DataBucket::GetDataBuckets(Mob *mob)
-{
-	const uint32 id = mob->GetMobTypeIdentifier();
-
-	if (!id) {
-		return false;
-	}
-
-	if (mob->IsBot()) {
-		BulkLoadEntitiesToCache(DataBucketLoadType::Bot, {id});
-	}
-	else if (mob->IsClient()) {
-		uint32 account_id = mob->CastToClient()->AccountID();
-		BulkLoadEntitiesToCache(DataBucketLoadType::Account, {account_id});
-		BulkLoadEntitiesToCache(DataBucketLoadType::Client, {id});
-	}
-
-	return true;
 }
 
 bool DataBucket::DeleteData(const DataBucketKey &k)

--- a/common/data_bucket.h
+++ b/common/data_bucket.h
@@ -2,11 +2,9 @@
 #define EQEMU_DATABUCKET_H
 
 #include <string>
-#include "../common/types.h"
-#include "../common/repositories/data_buckets_repository.h"
-#include "mob.h"
-#include "../common/json/json_archive_single_line.h"
-#include "../common/servertalk.h"
+#include "types.h"
+#include "repositories/data_buckets_repository.h"
+#include "json/json_archive_single_line.h"
 
 struct DataBucketKey {
 	std::string key;
@@ -45,8 +43,6 @@ public:
 	static std::string GetData(const std::string &bucket_key);
 	static std::string GetDataExpires(const std::string &bucket_key);
 	static std::string GetDataRemaining(const std::string &bucket_key);
-
-	static bool GetDataBuckets(Mob *mob);
 
 	// scoped bucket methods
 	static void SetData(const DataBucketKey &k_);

--- a/world/CMakeLists.txt
+++ b/world/CMakeLists.txt
@@ -7,6 +7,7 @@ SET(world_sources
     cliententry.cpp
     clientlist.cpp
     console.cpp
+    ../common/data_bucket.cpp
     dynamic_zone.cpp
     dynamic_zone_manager.cpp
     eql_config.cpp
@@ -42,6 +43,7 @@ SET(world_headers
     cliententry.h
     clientlist.h
     console.h
+    ../common/data_bucket.h
     dynamic_zone.h
     dynamic_zone_manager.h
     eql_config.h

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -46,7 +46,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include "../common/repositories/player_event_logs_repository.h"
 #include "../common/events/player_event_logs.h"
 #include "../common/patches/patches.h"
-#include "../zone/data_bucket.h"
 #include "../common/repositories/guild_tributes_repository.h"
 #include "../common/skill_caps.h"
 #include "../common/server_reload_types.h"

--- a/zone/CMakeLists.txt
+++ b/zone/CMakeLists.txt
@@ -25,6 +25,7 @@ SET(zone_sources
     combat_record.cpp
     command.cpp
     corpse.cpp
+    ../common/data_bucket.cpp
     doors.cpp
     dialogue_window.cpp
     dynamic_zone.cpp
@@ -194,6 +195,7 @@ SET(zone_headers
     command.h
     common.h
     corpse.h
+    ../common/data_bucket.h
     doors.h
     dialogue_window.h
     dynamic_zone.h

--- a/zone/CMakeLists.txt
+++ b/zone/CMakeLists.txt
@@ -25,7 +25,6 @@ SET(zone_sources
     combat_record.cpp
     command.cpp
     corpse.cpp
-    data_bucket.cpp
     doors.cpp
     dialogue_window.cpp
     dynamic_zone.cpp
@@ -195,7 +194,6 @@ SET(zone_headers
     command.h
     common.h
     corpse.h
-    data_bucket.h
     doors.h
     dialogue_window.h
     dynamic_zone.h

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -3640,7 +3640,7 @@ bool Bot::Spawn(Client* botCharacterOwner) {
 		entity_list.AddBot(this, true, true);
 
 		ClearDataBucketCache();
-		DataBucket::GetDataBuckets(this);
+		LoadDataBucketsCache();
 		LoadBotSpellSettings();
 		if (!AI_AddBotSpells(GetBotSpellID())) {
 			GetBotOwner()->CastToClient()->Message(

--- a/zone/cli/benchmark_databuckets.cpp
+++ b/zone/cli/benchmark_databuckets.cpp
@@ -5,7 +5,7 @@
 #include "../../common/eqemu_logsys.h"
 #include "../sidecar_api/sidecar_api.h"
 #include "../../common/platform.h"
-#include "../data_bucket.h"
+#include "../../common/data_bucket.h"
 #include "../zonedb.h"
 #include "../../common/repositories/data_buckets_repository.h"
 

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -39,7 +39,7 @@ extern volatile bool RunLoops;
 #include "../common/strings.h"
 #include "../common/data_verification.h"
 #include "../common/profanity_manager.h"
-#include "data_bucket.h"
+#include "../common/data_bucket.h"
 #include "dynamic_zone.h"
 #include "expedition_request.h"
 #include "position.h"

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -42,7 +42,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
 #include "../common/data_verification.h"
 #include "../common/rdtsc.h"
-#include "data_bucket.h"
+#include "../common/data_bucket.h"
 #include "dynamic_zone.h"
 #include "event_codes.h"
 #include "guild_mgr.h"
@@ -1473,7 +1473,7 @@ void Client::Handle_Connect_OP_ZoneEntry(const EQApplicationPacket *app)
 
 	// Load Data Buckets
 	ClearDataBucketCache();
-	DataBucket::GetDataBuckets(this);
+	LoadDataBucketsCache();
 
 	// Max Level for Character:PerCharacterQglobalMaxLevel and Character:PerCharacterBucketMaxLevel
 	uint8 client_max_level = 0;

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -19,7 +19,7 @@
 #include "../common/file.h"
 #include "../common/repositories/dynamic_zones_repository.h"
 
-#include "data_bucket.h"
+#include "../common/data_bucket.h"
 #include "command.h"
 #include "dynamic_zone.h"
 #include "queryserv.h"

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -33,7 +33,7 @@
 #include "queryserv.h"
 #include "questmgr.h"
 #include "zone.h"
-#include "data_bucket.h"
+#include "../common/data_bucket.h"
 #include "../common/events/player_event_logs.h"
 #include "worldserver.h"
 

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -22,7 +22,7 @@
 #include "../common/strings.h"
 
 #include "client.h"
-#include "data_bucket.h"
+#include "../common/data_bucket.h"
 #include "groups.h"
 #include "mob.h"
 #include "raids.h"

--- a/zone/gm_commands/databuckets.cpp
+++ b/zone/gm_commands/databuckets.cpp
@@ -1,5 +1,5 @@
 #include "../client.h"
-#include "../data_bucket.h"
+#include "../../common/data_bucket.h"
 #include "../dialogue_window.h"
 #include "../../common/repositories/data_buckets_repository.h"
 

--- a/zone/gm_commands/devtools.cpp
+++ b/zone/gm_commands/devtools.cpp
@@ -1,5 +1,5 @@
 #include "../client.h"
-#include "../data_bucket.h"
+#include "../../common/data_bucket.h"
 
 void command_devtools(Client *c, const Seperator *sep)
 {

--- a/zone/gm_commands/gmzone.cpp
+++ b/zone/gm_commands/gmzone.cpp
@@ -1,5 +1,5 @@
 #include "../client.h"
-#include "../data_bucket.h"
+#include "../../common/data_bucket.h"
 
 void command_gmzone(Client *c, const Seperator *sep)
 {

--- a/zone/lua_bot.cpp
+++ b/zone/lua_bot.cpp
@@ -107,12 +107,12 @@ void Lua_Bot::SetExpansionBitmask(int expansion_bitmask) {
 
 bool Lua_Bot::ReloadBotDataBuckets() {
 	Lua_Safe_Call_Bool();
-	return DataBucket::GetDataBuckets(self);
+	return self->LoadDataBucketsCache();;
 }
 
 bool Lua_Bot::ReloadBotOwnerDataBuckets() {
 	Lua_Safe_Call_Bool();
-	return self->HasOwner() && DataBucket::GetDataBuckets(self->GetBotOwner());
+	return self->HasOwner() && self->LoadDataBucketsCache();
 }
 
 bool Lua_Bot::ReloadBotSpells() {

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3131,7 +3131,7 @@ bool Lua_Client::IsAutoFireEnabled()
 
 bool Lua_Client::ReloadDataBuckets() {
 	Lua_Safe_Call_Bool();
-	return DataBucket::GetDataBuckets(self);
+	return self->LoadDataBucketsCache();
 }
 
 uint32 Lua_Client::GetEXPForLevel(uint16 check_level)

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -24,7 +24,7 @@
 #include "qglobals.h"
 #include "encounter.h"
 #include "lua_encounter.h"
-#include "data_bucket.h"
+#include "../common/data_bucket.h"
 #include "dialogue_window.h"
 #include "dynamic_zone.h"
 #include "../common/events/player_event_logs.h"

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -24,7 +24,7 @@
 #include "../common/repositories/bot_data_repository.h"
 #include "../common/repositories/character_data_repository.h"
 
-#include "data_bucket.h"
+#include "../common/data_bucket.h"
 #include "quest_parser_collection.h"
 #include "string_ids.h"
 #include "worldserver.h"
@@ -8771,4 +8771,24 @@ bool Mob::IsGuildmaster() const {
 		default:
 			return false;
 	}
+}
+
+bool Mob::LoadDataBucketsCache()
+{
+	const uint32 id = GetMobTypeIdentifier();
+
+	if (!id) {
+		return false;
+	}
+
+	if (IsBot()) {
+		DataBucket::BulkLoadEntitiesToCache(DataBucketLoadType::Bot, {id});
+	}
+	else if (IsClient()) {
+		uint32 account_id = CastToClient()->AccountID();
+		DataBucket::BulkLoadEntitiesToCache(DataBucketLoadType::Account, {account_id});
+		DataBucket::BulkLoadEntitiesToCache(DataBucketLoadType::Client, {id});
+	}
+
+	return true;
 }

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -20,7 +20,7 @@
 #define MOB_H
 
 #include "common.h"
-#include "data_bucket.h"
+#include "../common/data_bucket.h"
 #include "entity.h"
 #include "hate_list.h"
 #include "pathfinder_interface.h"
@@ -1504,6 +1504,7 @@ public:
 	void CalcHeroicBonuses(StatBonuses* newbon);
 
 	DataBucketKey GetScopedBucketKeys();
+	bool LoadDataBucketsCache();
 
 	bool IsCloseToBanker();
 

--- a/zone/perl_bot.cpp
+++ b/zone/perl_bot.cpp
@@ -492,12 +492,12 @@ void Perl_Bot_SetSpellDurationRaid(Bot* self, int spell_id, int duration, int le
 
 bool Perl_Bot_ReloadBotDataBuckets(Bot* self)
 {
-	return DataBucket::GetDataBuckets(self);
+	return self->LoadDataBucketsCache();
 }
 
 bool Perl_Bot_ReloadBotOwnerDataBuckets(Bot* self)
 {
-	return self->HasOwner() && DataBucket::GetDataBuckets(self->GetBotOwner());
+	return self->HasOwner() && self->LoadDataBucketsCache();
 }
 
 bool Perl_Bot_ReloadBotSpells(Bot* self)

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -2995,7 +2995,7 @@ bool Perl_Client_IsAutoFireEnabled(Client* self)
 
 bool Perl_Client_ReloadDataBuckets(Client* self)
 {
-	return DataBucket::GetDataBuckets(self);
+	return self->LoadDataBucketsCache();
 }
 
 uint32 Perl_Client_GetEXPForLevel(Client* self, uint16 check_level)

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -80,7 +80,7 @@ Copyright (C) 2001-2002 EQEMu Development Team (http://eqemu.org)
 #include "../common/repositories/character_corpses_repository.h"
 #include "../common/repositories/spell_buckets_repository.h"
 
-#include "data_bucket.h"
+#include "../common/data_bucket.h"
 #include "quest_parser_collection.h"
 #include "string_ids.h"
 #include "worldserver.h"


### PR DESCRIPTION
# Description

This moves DataBuckets into "common" so it can be used by projects other than just "zone" such as "world" or any other project.

## Type of change

- [x] Code chore

# Testing

Basic databucket testing, works as expected

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

