### PR TITLE
[API] Add wwmarquee <type> <message>

### DIFF
--- a/world/console.cpp
+++ b/world/console.cpp
@@ -1337,46 +1337,35 @@ void ConsoleWWMarquee(
 )
 {
 	if (args.size() < 2) {
-		connection->SendLine("Usage: marquee <type> <message>");
+		connection->SendLine("Usage: wwmarquee <type> <message>");
 		return;
 	}
 
-	const uint32 type = Strings::IsNumber(args[0]) ? Strings::ToUnsignedInt(args[0]) : 0;
-	const uint32 priority = 1;
-	const uint32 fade_in  = 500;
-	const uint32 fade_out = 500;
-	const uint32 duration = 5000;
-
-	// Join message from args[1..]
-	std::string message = Strings::Join(std::vector<std::string>(args.begin() + 1, args.end()), " ");
+	const uint32 type    = Strings::IsNumber(args[0]) ? Strings::ToUnsignedInt(args[0]) : 0;
+	std::string  message = Strings::Join(std::vector<std::string>(args.begin() + 1, args.end()), " ");
 	if (message.empty()) {
 		connection->SendLine("Message cannot be empty.");
 		return;
 	}
 
-	// Build the CZMarquee_Struct for world broadcast (update_type = character, identifier = 0)
-	auto pack = new ServerPacket(ServerOP_CZMarquee, sizeof(CZMarquee_Struct));
-	auto* czm = (CZMarquee_Struct*)pack->pBuffer;
+	auto pack = new ServerPacket(ServerOP_WWMarquee, sizeof(WWMarquee_Struct));
+	auto* wwm = (WWMarquee_Struct*)pack->pBuffer;
 
-	czm->update_type       = CZUpdateType_Character;  // world-wide
-	czm->update_identifier = 0;
-	czm->type              = type;
-	czm->priority          = priority;
-	czm->fade_in           = fade_in;
-	czm->fade_out          = fade_out;
-	czm->duration          = duration;
+	wwm->type       = type;
+	wwm->priority   = 510;
+	wwm->fade_in    = 0;
+	wwm->fade_out   = 0;
+	wwm->duration   = 5000;
+	wwm->min_status = AccountStatus::Player;
+	wwm->max_status = AccountStatus::Player;
 
-	strn0cpy(czm->message, message.c_str(), sizeof(czm->message));
-	czm->client_name[0] = '\0'; // unused
+	strn0cpy(wwm->message, message.c_str(), sizeof(wwm->message));
 
 	zoneserver_list.SendPacket(pack);
 	safe_delete(pack);
 
 	connection->SendLine(fmt::format("Sent world marquee type {}: {}", type, message));
 }
-
-
-
 
 /**
  * @param console

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -3140,7 +3140,6 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 	case ServerOP_WWMarquee:
 	{
 		auto s = (WWMarquee_Struct*) pack->pBuffer;
-
 		for (const auto& c : entity_list.GetClientList()) {
 			if (
 				c.second->Admin() >= s->min_status &&


### PR DESCRIPTION
# Description

This adds a Telnet API hook to send world wide marquee messages.

Use case is when Spire issues timed server restarts or shutdowns that players sometimes miss chat messages and this brings an additional mechanism to make notifications harder to miss.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing

![image](https://github.com/user-attachments/assets/7e9ccb5b-0541-4706-9005-1ee71138c7b7)

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

