### PR TITLE
[Databuckets] Implement Cache in World

### DIFF
--- a/common/repositories/character_data_repository.h
+++ b/common/repositories/character_data_repository.h
@@ -167,6 +167,30 @@ public:
 
 		return zone_player_counts;
 	}
+
+	static std::vector<uint32_t> GetCharacterIDsByAccountID(
+		Database& db,
+		uint32_t  account_id
+	)
+	{
+		std::vector<uint32_t> character_ids;
+
+		auto query = fmt::format(
+			"SELECT id FROM character_data WHERE account_id = {} AND deleted_at IS NULL",
+			account_id
+		);
+
+		auto results = db.QueryDatabase(query);
+		if (results.Success()) {
+			for (auto row : results) {
+				if (row[0]) {
+					character_ids.push_back(static_cast<uint32_t>(std::stoul(row[0])));
+				}
+			}
+		}
+
+		return character_ids;
+	}
 };
 
 #endif //EQEMU_CHARACTER_DATA_REPOSITORY_H

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -36,6 +36,7 @@
 #include "../common/shareddb.h"
 #include "../common/opcodemgr.h"
 #include "../common/data_verification.h"
+#include "../common/data_bucket.h"
 
 #include "client.h"
 #include "worlddb.h"
@@ -135,6 +136,8 @@ Client::Client(EQStreamInterface* ieqs)
 }
 
 Client::~Client() {
+	ClearDataBucketsCache();
+
 	if (RunLoops && cle && zone_id == 0)
 		cle->SetOnline(CLE_Status::Offline);
 
@@ -477,6 +480,8 @@ bool Client::HandleSendLoginInfoPacket(const EQApplicationPacket *app)
 	LogClientLogin("Checking authentication id [{}]", id);
 
 	if ((cle = client_list.CheckAuth(id, password))) {
+		LoadDataBucketsCache();
+
 		LogClientLogin("Checking authentication id [{}] passed", id);
 		if (!is_player_zoning) {
 			// Track who is in and who is out of the game
@@ -2517,4 +2522,20 @@ void Client::SendUnsupportedClientPacket(const std::string& message)
 	e->Enabled     = 0;
 
 	QueuePacket(&packet);
+}
+
+void Client::LoadDataBucketsCache()
+{
+	DataBucket::BulkLoadEntitiesToCache(DataBucketLoadType::Account, {GetAccountID()});
+	const auto ids = CharacterDataRepository::GetCharacterIDsByAccountID(database, GetAccountID());
+	DataBucket::BulkLoadEntitiesToCache(DataBucketLoadType::Client, ids);
+}
+
+void Client::ClearDataBucketsCache()
+{
+	DataBucket::DeleteFromCache(GetAccountID(), DataBucketLoadType::Account);
+	auto ids = CharacterDataRepository::GetCharacterIDsByAccountID(database, GetAccountID());
+	for (const auto& id : ids) {
+		DataBucket::DeleteFromCache(id, DataBucketLoadType::Client);
+	}
 }

--- a/world/client.h
+++ b/world/client.h
@@ -121,6 +121,9 @@ private:
 	bool CanTradeFVNoDropItem();
 	void RecordPossibleHack(const std::string& message);
 	void SendUnsupportedClientPacket(const std::string& message);
+
+	void LoadDataBucketsCache();
+	void ClearDataBucketsCache();
 };
 
 bool CheckCharCreateInfoSoF(CharCreate_Struct *cc);


### PR DESCRIPTION
# Description

As a follow up to https://github.com/EQEmu/Server/pull/4918 - loads cache into world and unloads on client deconstructor

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing

**Loading**

```
 World | Client Log | HandleSendLoginInfoPacket Checking authentication id [137381]
 World | MySQL Quer | QueryDatabase SELECT id FROM character_data WHERE account_id = 1 AND deleted_at IS NULL -- (1 row returned) (0.000153s)
 World | MySQL Quer | QueryDatabase SELECT id, `key`, value, expires, account_id, character_id, npc_id, bot_id, zone_id, instance_id FROM data_buckets WHERE character_id IN (1) AND (`expires` > 1750113726 OR `expires` = 0) -- (17 rows returned) (0.000374s)
```

**Unloading**

```
 World |    Info    | Process Removing client from [192.168.97.1:41284]
 World | MySQL Quer | QueryDatabase SELECT id FROM character_data WHERE account_id = 1 AND deleted_at IS NULL -- (1 row returned) (0.000574s)
 World | Client Log | SetOnline Online status [schecterx] (1) status [Offline] (1)
```

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

