### PR TITLE
[Code] PathManager Global to Singleton Cleanup

### DIFF
--- a/client_files/export/main.cpp
+++ b/client_files/export/main.cpp
@@ -41,7 +41,6 @@
 EQEmuLogSys          LogSys;
 WorldContentService  content_service;
 ZoneStore            zone_store;
-PathManager          path;
 PlayerEventLogs      player_event_logs;
 EvolvingItemsManager evolving_items_manager;
 
@@ -56,7 +55,7 @@ int main(int argc, char **argv)
 	LogSys.LoadLogSettingsDefaults();
 	set_exception_handler();
 
-	path.LoadPaths();
+	PathManager::Instance()->Init();
 
 	LogInfo("Client Files Export Utility");
 	if (!EQEmuConfig::LoadConfig()) {
@@ -100,7 +99,7 @@ int main(int argc, char **argv)
 	}
 
 	LogSys.SetDatabase(&database)
-		->SetLogPath(path.GetLogPath())
+		->SetLogPath(PathManager::Instance()->GetLogPath())
 		->LoadLogDatabaseSettings()
 		->StartFileLogs();
 
@@ -136,7 +135,7 @@ int main(int argc, char **argv)
 
 void ExportSpells(SharedDatabase* db)
 {
-	std::ofstream file(fmt::format("{}/export/spells_us.txt", path.GetServerPath()));
+	std::ofstream file(fmt::format("{}/export/spells_us.txt", PathManager::Instance()->GetServerPath()));
 	if (!file || !file.is_open()) {
 		LogError("Unable to open export/spells_us.txt to write, skipping.");
 		return;
@@ -155,7 +154,7 @@ void ExportSpells(SharedDatabase* db)
 
 void ExportSkillCaps(SharedDatabase* db)
 {
-	std::ofstream file(fmt::format("{}/export/SkillCaps.txt", path.GetServerPath()));
+	std::ofstream file(fmt::format("{}/export/SkillCaps.txt", PathManager::Instance()->GetServerPath()));
 	if (!file || !file.is_open()) {
 		LogError("Unable to open export/SkillCaps.txt to write, skipping.");
 		return;
@@ -174,7 +173,7 @@ void ExportSkillCaps(SharedDatabase* db)
 
 void ExportBaseData(SharedDatabase *db)
 {
-	std::ofstream file(fmt::format("{}/export/BaseData.txt", path.GetServerPath()));
+	std::ofstream file(fmt::format("{}/export/BaseData.txt", PathManager::Instance()->GetServerPath()));
 	if (!file || !file.is_open()) {
 		LogError("Unable to open export/BaseData.txt to write, skipping.");
 		return;
@@ -193,7 +192,7 @@ void ExportBaseData(SharedDatabase *db)
 
 void ExportDBStrings(SharedDatabase *db)
 {
-	std::ofstream file(fmt::format("{}/export/dbstr_us.txt", path.GetServerPath()));
+	std::ofstream file(fmt::format("{}/export/dbstr_us.txt", PathManager::Instance()->GetServerPath()));
 	if (!file || !file.is_open()) {
 		LogError("Unable to open export/dbstr_us.txt to write, skipping.");
 		return;

--- a/client_files/import/main.cpp
+++ b/client_files/import/main.cpp
@@ -35,7 +35,6 @@
 EQEmuLogSys          LogSys;
 WorldContentService  content_service;
 ZoneStore            zone_store;
-PathManager          path;
 PlayerEventLogs      player_event_logs;
 EvolvingItemsManager evolving_items_manager;
 
@@ -49,7 +48,7 @@ int main(int argc, char **argv) {
 	LogSys.LoadLogSettingsDefaults();
 	set_exception_handler();
 
-	path.LoadPaths();
+	PathManager::Instance()->Init();
 
 	LogInfo("Client Files Import Utility");
 	if(!EQEmuConfig::LoadConfig()) {
@@ -93,7 +92,7 @@ int main(int argc, char **argv) {
 	}
 
 	LogSys.SetDatabase(&database)
-		->SetLogPath(path.GetLogPath())
+		->SetLogPath(PathManager::Instance()->GetLogPath())
 		->LoadLogDatabaseSettings()
 		->StartFileLogs();
 
@@ -138,7 +137,7 @@ bool IsStringField(int i) {
 
 void ImportSpells(SharedDatabase *db) {
 	LogInfo("Importing Spells");
-	std::string file = fmt::format("{}/import/spells_us.txt", path.GetServerPath());
+	std::string file = fmt::format("{}/import/spells_us.txt", PathManager::Instance()->GetServerPath());
 	FILE *f = fopen(file.c_str(), "r");
 	if(!f) {
 		LogError("Unable to open {} to read, skipping.", file);
@@ -228,7 +227,7 @@ void ImportSpells(SharedDatabase *db) {
 void ImportSkillCaps(SharedDatabase *db) {
 	LogInfo("Importing Skill Caps");
 
-	std::string file = fmt::format("{}/import/SkillCaps.txt", path.GetServerPath());
+	std::string file = fmt::format("{}/import/SkillCaps.txt", PathManager::Instance()->GetServerPath());
 	FILE *f = fopen(file.c_str(), "r");
 	if(!f) {
 		LogError("Unable to open {} to read, skipping.", file);
@@ -265,7 +264,7 @@ void ImportBaseData(SharedDatabase *db)
 {
 	LogInfo("Importing Base Data");
 
-	const std::string& file_name = fmt::format("{}/import/BaseData.txt", path.GetServerPath());
+	const std::string& file_name = fmt::format("{}/import/BaseData.txt", PathManager::Instance()->GetServerPath());
 
 	const auto& file_contents = File::GetContents(file_name);
 	if (!file_contents.error.empty()) {
@@ -305,7 +304,7 @@ void ImportBaseData(SharedDatabase *db)
 void ImportDBStrings(SharedDatabase *db) {
 	LogInfo("Importing DB Strings");
 
-	std::string file = fmt::format("{}/import/dbstr_us.txt", path.GetServerPath());
+	std::string file = fmt::format("{}/import/dbstr_us.txt", PathManager::Instance()->GetServerPath());
 	FILE *f = fopen(file.c_str(), "r");
 	if(!f) {
 		LogError("Unable to open {} to read, skipping.", file);

--- a/common/eqemu_config.cpp
+++ b/common/eqemu_config.cpp
@@ -436,11 +436,11 @@ void EQEmuConfig::CheckUcsConfigConversion()
 		LogInfo("Migrating old [eqemu_config] UCS configuration to new configuration");
 
 		std::string config_file_path = std::filesystem::path{
-			path.GetServerPath() + "/eqemu_config.json"
+			PathManager::Instance()->GetServerPath() + "/eqemu_config.json"
 		}.string();
 
 		std::string config_file_bak_path = std::filesystem::path{
-			path.GetServerPath() + "/eqemu_config.ucs-migrate-json.bak"
+			PathManager::Instance()->GetServerPath() + "/eqemu_config.ucs-migrate-json.bak"
 		}.string();
 
 		// copy eqemu_config.json to eqemu_config.json.bak

--- a/common/eqemu_config.h
+++ b/common/eqemu_config.h
@@ -191,7 +191,7 @@ class EQEmuConfig
 
 			std::string file = fmt::format(
 				"{}/{}",
-				(file_path.empty() ? path.GetServerPath() : file_path),
+				(file_path.empty() ? PathManager::Instance()->GetServerPath() : file_path),
 				EQEmuConfig::ConfigFile
 			);
 

--- a/common/eqemu_logsys.cpp
+++ b/common/eqemu_logsys.cpp
@@ -537,9 +537,9 @@ void EQEmuLogSys::StartFileLogs(const std::string &log_name)
 {
 	EQEmuLogSys::CloseFileLogs();
 
-	if (!File::Exists(path.GetLogPath())) {
-		LogInfo("Logs directory not found, creating [{}]", path.GetLogPath());
-		File::Makedir(path.GetLogPath());
+	if (!File::Exists(PathManager::Instance()->GetLogPath())) {
+		LogInfo("Logs directory not found, creating [{}]", PathManager::Instance()->GetLogPath());
+		File::Makedir(PathManager::Instance()->GetLogPath());
 	}
 
 	/**

--- a/common/ipc_mutex.cpp
+++ b/common/ipc_mutex.cpp
@@ -55,7 +55,7 @@ namespace EQ {
 			EQ_EXCEPT("IPC Mutex", "Could not create mutex.");
 		}
 #else
-		std::string final_name = fmt::format("{}/{}.lock", path.GetSharedMemoryPath(), name);
+		std::string final_name = fmt::format("{}/{}.lock", PathManager::Instance()->GetSharedMemoryPath(), name);
 
 #ifdef __DARWIN
 #if __DARWIN_C_LEVEL < 200809L

--- a/common/patches/rof.cpp
+++ b/common/patches/rof.cpp
@@ -78,7 +78,7 @@ namespace RoF
 	{
 		//create our opcode manager if we havent already
 		if (opcodes == nullptr) {
-			std::string opfile = fmt::format("{}/patch_{}.conf", path.GetPatchPath(), name);
+			std::string opfile = fmt::format("{}/patch_{}.conf", PathManager::Instance()->GetPatchPath(), name);
 
 			//load up the opcode manager.
 			//TODO: figure out how to support shared memory with multiple patches...
@@ -117,7 +117,7 @@ namespace RoF
 		//we need to go to every stream and replace it's manager.
 
 		if (opcodes != nullptr) {
-			std::string opfile = fmt::format("{}/patch_{}.conf", path.GetPatchPath(), name);
+			std::string opfile = fmt::format("{}/patch_{}.conf", PathManager::Instance()->GetPatchPath(), name);
 			if (!opcodes->ReloadOpcodes(opfile.c_str())) {
 				LogNetcode("[OPCODES] Error reloading opcodes file [{}] for patch [{}]", opfile.c_str(), name);
 				return;

--- a/common/patches/rof2.cpp
+++ b/common/patches/rof2.cpp
@@ -81,7 +81,7 @@ namespace RoF2
 		//create our opcode manager if we havent already
 		if (opcodes == nullptr) {
 
-			std::string opfile = fmt::format("{}/patch_{}.conf", path.GetPatchPath(), name);
+			std::string opfile = fmt::format("{}/patch_{}.conf", PathManager::Instance()->GetPatchPath(), name);
 
 			//load up the opcode manager.
 			//TODO: figure out how to support shared memory with multiple patches...
@@ -123,7 +123,7 @@ namespace RoF2
 		//we need to go to every stream and replace it's manager.
 
 		if (opcodes != nullptr) {
-			std::string opfile = fmt::format("{}/patch_{}.conf", path.GetPatchPath(), name);
+			std::string opfile = fmt::format("{}/patch_{}.conf", PathManager::Instance()->GetPatchPath(), name);
 			if (!opcodes->ReloadOpcodes(opfile.c_str())) {
 				LogNetcode("[OPCODES] Error reloading opcodes file [{}] for patch [{}]", opfile.c_str(), name);
 				return;

--- a/common/patches/sod.cpp
+++ b/common/patches/sod.cpp
@@ -72,7 +72,7 @@ namespace SoD
 	{
 		//create our opcode manager if we havent already
 		if (opcodes == nullptr) {
-			std::string opfile = fmt::format("{}/patch_{}.conf", path.GetPatchPath(), name);
+			std::string opfile = fmt::format("{}/patch_{}.conf", PathManager::Instance()->GetPatchPath(), name);
 			//load up the opcode manager.
 			//TODO: figure out how to support shared memory with multiple patches...
 			opcodes = new RegularOpcodeManager();
@@ -113,7 +113,7 @@ namespace SoD
 		//we need to go to every stream and replace it's manager.
 
 		if (opcodes != nullptr) {
-			std::string opfile = fmt::format("{}/patch_{}.conf", path.GetPatchPath(), name);
+			std::string opfile = fmt::format("{}/patch_{}.conf", PathManager::Instance()->GetPatchPath(), name);
 			if (!opcodes->ReloadOpcodes(opfile.c_str())) {
 				LogNetcode("[OPCODES] Error reloading opcodes file [{}] for patch [{}]", opfile.c_str(), name);
 				return;

--- a/common/patches/sof.cpp
+++ b/common/patches/sof.cpp
@@ -71,7 +71,7 @@ namespace SoF
 	{
 		//create our opcode manager if we havent already
 		if (opcodes == nullptr) {
-			std::string opfile = fmt::format("{}/patch_{}.conf", path.GetPatchPath(), name);
+			std::string opfile = fmt::format("{}/patch_{}.conf", PathManager::Instance()->GetPatchPath(), name);
 			//load up the opcode manager.
 			//TODO: figure out how to support shared memory with multiple patches...
 			opcodes = new RegularOpcodeManager();
@@ -110,7 +110,7 @@ namespace SoF
 		//we need to go to every stream and replace it's manager.
 
 		if (opcodes != nullptr) {
-			std::string opfile = fmt::format("{}/patch_{}.conf", path.GetPatchPath(), name);
+			std::string opfile = fmt::format("{}/patch_{}.conf", PathManager::Instance()->GetPatchPath(), name);
 			if (!opcodes->ReloadOpcodes(opfile.c_str())) {
 				LogNetcode("[OPCODES] Error reloading opcodes file [{}] for patch [{}]", opfile.c_str(), name);
 				return;

--- a/common/patches/titanium.cpp
+++ b/common/patches/titanium.cpp
@@ -73,7 +73,7 @@ namespace Titanium
 		auto Config = EQEmuConfig::get();
 		//create our opcode manager if we havent already
 		if (opcodes == nullptr) {
-			std::string opfile = fmt::format("{}/patch_{}.conf", path.GetPatchPath(), name);
+			std::string opfile = fmt::format("{}/patch_{}.conf", PathManager::Instance()->GetPatchPath(), name);
 			//load up the opcode manager.
 			//TODO: figure out how to support shared memory with multiple patches...
 			opcodes = new RegularOpcodeManager();
@@ -114,7 +114,7 @@ namespace Titanium
 		//we need to go to every stream and replace it's manager.
 
 		if (opcodes != nullptr) {
-			std::string opfile = fmt::format("{}/patch_{}.conf", path.GetPatchPath(), name);
+			std::string opfile = fmt::format("{}/patch_{}.conf", PathManager::Instance()->GetPatchPath(), name);
 			if (!opcodes->ReloadOpcodes(opfile.c_str())) {
 				LogNetcode("[OPCODES] Error reloading opcodes file [{}] for patch [{}]", opfile.c_str(), name);
 				return;

--- a/common/patches/uf.cpp
+++ b/common/patches/uf.cpp
@@ -76,7 +76,7 @@ namespace UF
 	{
 		//create our opcode manager if we havent already
 		if (opcodes == nullptr) {
-			std::string opfile = fmt::format("{}/patch_{}.conf", path.GetPatchPath(), name);
+			std::string opfile = fmt::format("{}/patch_{}.conf", PathManager::Instance()->GetPatchPath(), name);
 			//load up the opcode manager.
 			//TODO: figure out how to support shared memory with multiple patches...
 			opcodes = new RegularOpcodeManager();
@@ -117,7 +117,7 @@ namespace UF
 		//we need to go to every stream and replace it's manager.
 
 		if (opcodes != nullptr) {
-			std::string opfile = fmt::format("{}/patch_{}.conf", path.GetPatchPath(), name);
+			std::string opfile = fmt::format("{}/patch_{}.conf", PathManager::Instance()->GetPatchPath(), name);
 			if (!opcodes->ReloadOpcodes(opfile.c_str())) {
 				LogNetcode("[OPCODES] Error reloading opcodes file [{}] for patch [{}]", opfile.c_str(), name);
 				return;

--- a/common/path_manager.cpp
+++ b/common/path_manager.cpp
@@ -8,7 +8,7 @@
 
 namespace fs = std::filesystem;
 
-void PathManager::LoadPaths()
+void PathManager::Init()
 {
 	m_server_path = File::FindEqemuConfigPath();
 

--- a/common/path_manager.h
+++ b/common/path_manager.h
@@ -7,7 +7,13 @@
 
 class PathManager {
 public:
-	void LoadPaths();
+	void Init();
+
+	static PathManager *Instance()
+	{
+		static PathManager instance;
+		return &instance;
+	}
 
 	[[nodiscard]] const std::string &GetLogPath() const;
 	[[nodiscard]] const std::string &GetLuaModsPath() const;
@@ -37,7 +43,5 @@ private:
 	std::string              m_server_path;
 	std::string              m_shared_memory_path;
 };
-
-extern PathManager path;
 
 #endif //EQEMU_PATH_MANAGER_H

--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -974,7 +974,7 @@ bool SharedDatabase::LoadItems(const std::string &prefix) {
 		const auto Config = EQEmuConfig::get();
 		EQ::IPCMutex mutex("items");
 		mutex.Lock();
-		std::string file_name = fmt::format("{}/{}{}", path.GetSharedMemoryPath(), prefix, std::string("items"));
+		std::string file_name = fmt::format("{}/{}{}", PathManager::Instance()->GetSharedMemoryPath(), prefix, std::string("items"));
 		items_mmf = std::make_unique<EQ::MemoryMappedFile>(file_name);
 		items_hash = std::make_unique<EQ::FixedMemoryHashSet<EQ::ItemData>>(static_cast<uint8*>(items_mmf->Get()), items_mmf->Size());
 		mutex.Unlock();
@@ -1665,7 +1665,7 @@ bool SharedDatabase::LoadSpells(const std::string &prefix, int32 *records, const
 		EQ::IPCMutex mutex("spells");
 		mutex.Lock();
 
-		std::string file_name = fmt::format("{}/{}{}", path.GetSharedMemoryPath(), prefix, std::string("spells"));
+		std::string file_name = fmt::format("{}/{}{}", PathManager::Instance()->GetSharedMemoryPath(), prefix, std::string("spells"));
 		spells_mmf = std::make_unique<EQ::MemoryMappedFile>(file_name);
 		LogInfo("Loading [{}]", file_name);
 		*records = *static_cast<uint32*>(spells_mmf->Get());

--- a/eqlaunch/eqlaunch.cpp
+++ b/eqlaunch/eqlaunch.cpp
@@ -34,7 +34,6 @@
 #include <time.h>
 
 EQEmuLogSys LogSys;
-PathManager path;
 
 bool RunLoops = false;
 
@@ -45,7 +44,7 @@ int main(int argc, char *argv[]) {
 	LogSys.LoadLogSettingsDefaults();
 	set_exception_handler();
 
-	path.LoadPaths();
+	PathManager::Instance()->Init();
 
 	std::string launcher_name;
 	if(argc == 2) {

--- a/loginserver/client_manager.cpp
+++ b/loginserver/client_manager.cpp
@@ -94,7 +94,7 @@ ClientManager::ClientManager()
 
 	std::string opcodes_path = fmt::format(
 		"{}/{}",
-		path.GetOpcodePath(),
+		PathManager::Instance()->GetOpcodePath(),
 		"login_opcodes.conf"
 	);
 
@@ -131,7 +131,7 @@ ClientManager::ClientManager()
 
 	opcodes_path = fmt::format(
 		"{}/{}",
-		path.GetOpcodePath(),
+		PathManager::Instance()->GetOpcodePath(),
 		"login_opcodes_sod.conf"
 	);
 
@@ -169,7 +169,7 @@ ClientManager::ClientManager()
 
 	opcodes_path = fmt::format(
 		"{}/{}",
-		path.GetOpcodePath(),
+		PathManager::Instance()->GetOpcodePath(),
 		"login_opcodes_larion.conf"
 	);
 

--- a/loginserver/main.cpp
+++ b/loginserver/main.cpp
@@ -24,7 +24,6 @@
 LoginServer     server;
 EQEmuLogSys     LogSys;
 bool            run_server = true;
-PathManager     path;
 Database        database;
 PlayerEventLogs player_event_logs;
 ZoneStore       zone_store;
@@ -52,7 +51,7 @@ void LoadDatabaseConnection()
 void LoadServerConfig()
 {
 	server.config = EQ::JsonConfigFile::Load(
-		fmt::format("{}/login.json", path.GetServerPath())
+		fmt::format("{}/login.json", PathManager::Instance()->GetServerPath())
 	);
 	LogInfo("Config System Init");
 
@@ -162,7 +161,7 @@ int main(int argc, char **argv)
 		LogSys.LoadLogSettingsDefaults();
 	}
 
-	path.LoadPaths();
+	PathManager::Instance()->Init();
 
 	// command handler
 	if (argc > 1) {

--- a/queryserv/queryserv.cpp
+++ b/queryserv/queryserv.cpp
@@ -31,7 +31,6 @@ std::string           WorldShortName;
 const queryservconfig *Config;
 WorldServer           *worldserver = 0;
 EQEmuLogSys           LogSys;
-PathManager           path;
 ZoneStore             zone_store;
 PlayerEventLogs       player_event_logs;
 ZSList                zs_list;
@@ -50,7 +49,7 @@ int main()
 	set_exception_handler();
 	Timer LFGuildExpireTimer(60000);
 
-	path.LoadPaths();
+	PathManager::Instance()->Init();
 
 	LogInfo("Starting EQEmu QueryServ");
 	if (!queryservconfig::LoadConfig()) {
@@ -86,7 +85,7 @@ int main()
 	}
 
 	LogSys.SetDatabase(&database)
-		->SetLogPath(path.GetLogPath())
+		->SetLogPath(PathManager::Instance()->GetLogPath())
 		->LoadLogDatabaseSettings()
 		->StartFileLogs();
 

--- a/shared_memory/main.cpp
+++ b/shared_memory/main.cpp
@@ -38,7 +38,6 @@
 EQEmuLogSys          LogSys;
 WorldContentService  content_service;
 ZoneStore            zone_store;
-PathManager          path;
 PlayerEventLogs      player_event_logs;
 EvolvingItemsManager evolving_items_manager;
 
@@ -84,7 +83,7 @@ int main(int argc, char **argv)
 	LogSys.LoadLogSettingsDefaults();
 	set_exception_handler();
 
-	path.LoadPaths();
+	PathManager::Instance()->Init();
 
 	LogInfo("Shared Memory Loader Program");
 	if (!EQEmuConfig::LoadConfig()) {
@@ -127,7 +126,7 @@ int main(int argc, char **argv)
 	}
 
 	LogSys.SetDatabase(&database)
-		->SetLogPath(path.GetLogPath())
+		->SetLogPath(PathManager::Instance()->GetLogPath())
 		->LoadLogDatabaseSettings()
 		->StartFileLogs();
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -35,13 +35,12 @@
 
 const EQEmuConfig *Config;
 EQEmuLogSys       LogSys;
-PathManager       path;
 
 int main()
 {
 	RegisterExecutablePlatform(ExePlatformClientImport);
 	LogSys.LoadLogSettingsDefaults();
-	path.LoadPaths();
+	PathManager::Instance()->Init();
 
 	auto ConfigLoadResult = EQEmuConfig::LoadConfig();
 	Config = EQEmuConfig::get();

--- a/ucs/clientlist.cpp
+++ b/ucs/clientlist.cpp
@@ -482,7 +482,7 @@ Clientlist::Clientlist(int ChatPort) {
 	const ucsconfig *Config = ucsconfig::get();
 
 
-	std::string opcodes_file = fmt::format("{}/{}", path.GetServerPath(), Config->MailOpCodesFile);
+	std::string opcodes_file = fmt::format("{}/{}", PathManager::Instance()->GetServerPath(), Config->MailOpCodesFile);
 
 	LogInfo("Loading [{}]", opcodes_file);
 	if (!ChatOpMgr->LoadOpcodes(opcodes_file.c_str()))

--- a/ucs/ucs.cpp
+++ b/ucs/ucs.cpp
@@ -48,7 +48,6 @@ EQEmuLogSys LogSys;
 UCSDatabase database;
 WorldServer *worldserver = nullptr;
 DiscordManager discord_manager;
-PathManager path;
 ZoneStore zone_store;
 PlayerEventLogs player_event_logs;
 
@@ -107,7 +106,7 @@ int main() {
 	LogSys.LoadLogSettingsDefaults();
 	set_exception_handler();
 
-	path.LoadPaths();
+	PathManager::Instance()->Init();
 
 	// Check every minute for unused channels we can delete
 	//
@@ -140,7 +139,7 @@ int main() {
 	}
 
 	LogSys.SetDatabase(&database)
-		->SetLogPath(path.GetLogPath())
+		->SetLogPath(PathManager::Instance()->GetLogPath())
 		->LoadLogDatabaseSettings()
 		->StartFileLogs();
 

--- a/world/main.cpp
+++ b/world/main.cpp
@@ -111,7 +111,6 @@ const WorldConfig   *Config;
 EQEmuLogSys         LogSys;
 WorldContentService content_service;
 WebInterfaceList    web_interface;
-PathManager         path;
 PlayerEventLogs     player_event_logs;
 EvolvingItemsManager evolving_items_manager;
 
@@ -142,7 +141,7 @@ int main(int argc, char **argv)
 		return 0;
 	}
 
-	path.LoadPaths();
+	PathManager::Instance()->Init();
 
 	if (!WorldBoot::LoadServerConfig()) {
 		return 0;

--- a/world/world_boot.cpp
+++ b/world/world_boot.cpp
@@ -84,7 +84,7 @@ bool WorldBoot::HandleCommandInput(int argc, char **argv)
 	// command handler
 	if (argc > 1) {
 		LogSys.SilenceConsoleLogging();
-		path.LoadPaths();
+		PathManager::Instance()->Init();
 		WorldConfig::LoadConfig();
 		LoadDatabaseConnections();
 		RuleManager::Instance()->LoadRules(&database, "default", false);
@@ -234,7 +234,7 @@ bool WorldBoot::DatabaseLoadRoutines(int argc, char **argv)
 {
 	// logging system init
 	auto logging = LogSys.SetDatabase(&database)
-		->SetLogPath(path.GetLogPath())
+		->SetLogPath(PathManager::Instance()->GetLogPath())
 		->LoadLogDatabaseSettings();
 
 	LogSys.SetDiscordHandler(&WorldBoot::DiscordWebhookMessageHandler);

--- a/zone/embperl.cpp
+++ b/zone/embperl.cpp
@@ -138,7 +138,7 @@ void Embperl::DoInit()
 		LogQuests("Warning [{}]: [{}]", Config->PluginPlFile, e);
 	}
 
-	for (auto & dir : path.GetPluginPaths()) {
+	for (auto & dir : PathManager::Instance()->GetPluginPaths()) {
 		try {
 			//should probably read the directory in c, instead, so that
 			//I can echo filenames as I do it, but c'mon... I'm lazy and this 1 line reads in all the plugins

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -1070,7 +1070,7 @@ void LuaParser::ReloadQuests() {
 	std::string module_path = lua_tostring(L, -1);
 	lua_pop(L, 1);
 
-	for (const auto& dir : path.GetLuaModulePaths()) {
+	for (const auto& dir : PathManager::Instance()->GetLuaModulePaths()) {
 		module_path += fmt::format(";{}/?.lua", dir);
 		module_path += fmt::format(";{}/?/init.lua", dir);
 		module_path += fmt::format(";{}/share/lua/{}/?.lua", dir, lua_version);
@@ -1086,7 +1086,7 @@ void LuaParser::ReloadQuests() {
 	module_path = lua_tostring(L, -1);
 	lua_pop(L, 1);
 
-	for (const auto& dir : path.GetLuaModulePaths()) {
+	for (const auto& dir : PathManager::Instance()->GetLuaModulePaths()) {
 		module_path += fmt::format(";{}/?{}", dir, libext);
 		module_path += fmt::format(";{}/lib/lua/{}/?{}", dir, lua_version, libext);
 	}
@@ -1098,7 +1098,7 @@ void LuaParser::ReloadQuests() {
 	MapFunctions(L);
 
 	// load init
-	for (auto& dir : path.GetQuestPaths()) {
+	for (auto& dir : PathManager::Instance()->GetQuestPaths()) {
 		std::string filename = fmt::format("{}/{}/script_init.lua", dir, QUEST_GLOBAL_DIRECTORY);
 
 		FILE* f = fopen(filename.c_str(), "r");
@@ -1114,7 +1114,7 @@ void LuaParser::ReloadQuests() {
 
 	//zone init - always loads after global
 	if (zone) {
-		for (auto& dir : path.GetQuestPaths()) {
+		for (auto& dir : PathManager::Instance()->GetQuestPaths()) {
 			std::string zone_script = fmt::format(
 				"{}/{}/script_init_v{}.lua",
 				dir,
@@ -1147,7 +1147,7 @@ void LuaParser::ReloadQuests() {
 		}
 	}
 
-	FILE *load_order = fopen(fmt::format("{}/load_order.txt", path.GetLuaModsPath()).c_str(), "r");
+	FILE *load_order = fopen(fmt::format("{}/load_order.txt", PathManager::Instance()->GetLuaModsPath()).c_str(), "r");
 	if (load_order) {
 		char file_name[256] = { 0 };
 		while (fgets(file_name, 256, load_order) != nullptr) {
@@ -1159,7 +1159,7 @@ void LuaParser::ReloadQuests() {
 				}
 			}
 
-			LoadScript(fmt::format("{}/{}", path.GetLuaModsPath(), std::string(file_name)), file_name);
+			LoadScript(fmt::format("{}/{}", PathManager::Instance()->GetLuaModsPath(), std::string(file_name)), file_name);
 			mods_.emplace_back(L, this, file_name);
 		}
 

--- a/zone/main.cpp
+++ b/zone/main.cpp
@@ -107,7 +107,6 @@ QuestParserCollection *parse        = 0;
 EQEmuLogSys           LogSys;
 ZoneEventScheduler    event_scheduler;
 WorldContentService   content_service;
-PathManager           path;
 PlayerEventLogs       player_event_logs;
 DatabaseUpdate        database_update;
 SkillCaps             skill_caps;
@@ -137,7 +136,7 @@ int main(int argc, char **argv)
 		LogSys.SilenceConsoleLogging();
 	}
 
-	path.LoadPaths();
+	PathManager::Instance()->Init();
 
 #ifdef USE_MAP_MMFS
 	if (argc == 3 && strcasecmp(argv[1], "convert_map") == 0) {
@@ -305,7 +304,7 @@ int main(int argc, char **argv)
 	}
 
 	LogSys.SetDatabase(&database)
-		->SetLogPath(path.GetLogPath())
+		->SetLogPath(PathManager::Instance()->GetLogPath())
 		->LoadLogDatabaseSettings(ZoneCLI::RanTestCommand(argc, argv))
 		->SetGMSayHandler(&Zone::GMSayHookCallBackProcess)
 		->StartFileLogs();
@@ -752,7 +751,7 @@ bool CheckForCompatibleQuestPlugins()
 
 	try {
 		for (const auto &[directory, flag]: directories) {
-			std::string dir_path = path.GetServerPath() + "/" + directory;
+			std::string dir_path = PathManager::Instance()->GetServerPath() + "/" + directory;
 			if (!File::Exists(dir_path)) { continue; }
 
 			for (const auto &file: fs::directory_iterator(dir_path)) {

--- a/zone/map.cpp
+++ b/zone/map.cpp
@@ -271,7 +271,7 @@ bool Map::DoCollisionCheck(glm::vec3 myloc, glm::vec3 oloc, glm::vec3 &outnorm, 
 
 Map *Map::LoadMapFile(std::string file) {
 	std::transform(file.begin(), file.end(), file.begin(), ::tolower);
-	std::string filename = fmt::format("{}/base/{}.map", path.GetMapsPath(), file);
+	std::string filename = fmt::format("{}/base/{}.map", PathManager::Instance()->GetMapsPath(), file);
 
 	LogInfo("Attempting to load Map File [{}]", filename.c_str());
 

--- a/zone/pathfinder_interface.cpp
+++ b/zone/pathfinder_interface.cpp
@@ -7,7 +7,7 @@
 
 IPathfinder *IPathfinder::Load(const std::string &zone) {
 	struct stat statbuffer;
-	std::string navmesh_path = fmt::format("{}/maps/nav/{}.nav", path.GetServerPath(), zone);
+	std::string navmesh_path = fmt::format("{}/maps/nav/{}.nav", PathManager::Instance()->GetServerPath(), zone);
 	if (stat(navmesh_path.c_str(), &statbuffer) == 0) {
 		return new PathfinderNavmesh(navmesh_path);
 	}

--- a/zone/quest_parser_collection.cpp
+++ b/zone/quest_parser_collection.cpp
@@ -939,7 +939,7 @@ QuestInterface* QuestParserCollection::GetQIByNPCQuest(uint32 npc_id, std::strin
 
 	Strings::FindReplace(npc_name, "`", "-");
 
-	for (auto & dir : path.GetQuestPaths()) {
+	for (auto & dir : PathManager::Instance()->GetQuestPaths()) {
 		const std::string& npc_id_and_name = fmt::format(
 			"{}_{}",
 			npc_name,
@@ -1007,7 +1007,7 @@ QuestInterface* QuestParserCollection::GetQIByPlayerQuest(std::string& filename)
 		return nullptr;
 	}
 
-	for (auto & dir : path.GetQuestPaths()) {
+	for (auto & dir : PathManager::Instance()->GetQuestPaths()) {
 		const std::string& global_path = fmt::format(
 			"{}/{}",
 			dir,
@@ -1062,7 +1062,7 @@ QuestInterface* QuestParserCollection::GetQIByGlobalNPCQuest(std::string& filena
 
 	std::string file_name;
 
-	for (auto & dir : path.GetQuestPaths()) {
+	for (auto & dir : PathManager::Instance()->GetQuestPaths()) {
 		for (auto* e: _load_precedence) {
 			file_name = fmt::format(
 				"{}/{}/global_npc.{}",
@@ -1088,7 +1088,7 @@ QuestInterface* QuestParserCollection::GetQIByGlobalPlayerQuest(std::string& fil
 	}
 
 	std::string file_name;
-	for (auto & dir : path.GetQuestPaths()) {
+	for (auto & dir : PathManager::Instance()->GetQuestPaths()) {
 		for (auto* e: _load_precedence) {
 			file_name = fmt::format(
 				"{}/{}/global_player.{}",
@@ -1113,7 +1113,7 @@ QuestInterface* QuestParserCollection::GetQIBySpellQuest(uint32 spell_id, std::s
 		return nullptr;
 	}
 
-	for (auto & dir : path.GetQuestPaths()) {
+	for (auto & dir : PathManager::Instance()->GetQuestPaths()) {
 		const std::string& global_path = fmt::format(
 			"{}/{}/spells",
 			dir,
@@ -1167,7 +1167,7 @@ QuestInterface* QuestParserCollection::GetQIByItemQuest(std::string item_script,
 		return nullptr;
 	}
 
-	for (auto & dir : path.GetQuestPaths()) {
+	for (auto & dir : PathManager::Instance()->GetQuestPaths()) {
 		const std::string& global_path = fmt::format(
 			"{}/{}/items",
 			dir,
@@ -1221,7 +1221,7 @@ QuestInterface* QuestParserCollection::GetQIByEncounterQuest(std::string encount
 		return nullptr;
 	}
 
-	for (auto & dir : path.GetQuestPaths()) {
+	for (auto & dir : PathManager::Instance()->GetQuestPaths()) {
 		const std::string& global_path = fmt::format(
 			"{}/{}/encounters",
 			dir,
@@ -1273,7 +1273,7 @@ QuestInterface* QuestParserCollection::GetQIByBotQuest(std::string& filename)
 		return nullptr;
 	}
 
-	for (auto & dir : path.GetQuestPaths()) {
+	for (auto & dir : PathManager::Instance()->GetQuestPaths()) {
 		const std::string& global_path = fmt::format(
 			"{}/{}",
 			dir,
@@ -1327,7 +1327,7 @@ QuestInterface* QuestParserCollection::GetQIByGlobalBotQuest(std::string& filena
 	}
 
 	std::string file_name;
-	for (auto & dir : path.GetQuestPaths()) {
+	for (auto & dir : PathManager::Instance()->GetQuestPaths()) {
 		for (auto* e: _load_precedence) {
 			file_name = fmt::format(
 				"{}/{}/global_bot.{}",
@@ -1352,7 +1352,7 @@ QuestInterface* QuestParserCollection::GetQIByMercQuest(std::string& filename)
 		return nullptr;
 	}
 
-	for (auto & dir : path.GetQuestPaths()) {
+	for (auto & dir : PathManager::Instance()->GetQuestPaths()) {
 		const std::string& global_path = fmt::format(
 			"{}/{}",
 			dir,
@@ -1406,7 +1406,7 @@ QuestInterface* QuestParserCollection::GetQIByGlobalMercQuest(std::string& filen
 	}
 
 	std::string file_name;
-	for (auto & dir : path.GetQuestPaths()) {
+	for (auto & dir : PathManager::Instance()->GetQuestPaths()) {
 		for (auto* e: _load_precedence) {
 			file_name = fmt::format(
 				"{}/{}/global_merc.{}",

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -200,7 +200,7 @@ void QuestManager::summonitem(uint32 itemid, int16 charges) {
 
 void QuestManager::write(const char *file, const char *str) {
 	FILE * pFile;
-	pFile = fopen (fmt::format("{}/{}", path.GetServerPath(), file).c_str(), "a");
+	pFile = fopen (fmt::format("{}/{}", PathManager::Instance()->GetServerPath(), file).c_str(), "a");
 	if(!pFile)
 		return;
 	fprintf(pFile, "%s\n", str);

--- a/zone/water_map.cpp
+++ b/zone/water_map.cpp
@@ -17,7 +17,7 @@
 WaterMap* WaterMap::LoadWaterMapfile(std::string zone_name) {
 	std::transform(zone_name.begin(), zone_name.end(), zone_name.begin(), ::tolower);
 
-	std::string file_path = fmt::format("{}/water/{}.wtr", path.GetMapsPath(), zone_name);
+	std::string file_path = fmt::format("{}/water/{}.wtr", PathManager::Instance()->GetMapsPath(), zone_name);
 	LogDebug("Attempting to load water map with path [{}]", file_path.c_str());
 	FILE *f = fopen(file_path.c_str(), "rb");
 	if(f) {


### PR DESCRIPTION
# Description

This is part of a larger effort to remove global variables from the codebase. Eventually singletons can be cleaned up to be passed explicitly through dependency injection.

For now this encapsulates dependencies far better.

## Type of change

- [x] Code Cleanup

# Testing

Path manager work all the same, booted processes etc.

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

