### PR TITLE
[Code] AdventureManager Global to Singleton Cleanup

### DIFF
--- a/world/adventure.cpp
+++ b/world/adventure.cpp
@@ -17,7 +17,6 @@
 
 extern ZSList zoneserver_list;
 extern ClientList client_list;
-extern AdventureManager adventure_manager;
 extern EQ::Random emu_random;
 
 Adventure::Adventure(AdventureTemplate *t)
@@ -216,7 +215,7 @@ void Adventure::SetStatus(AdventureStatus new_status)
 	auto iter = players.begin();
 	while(iter != players.end())
 	{
-		adventure_manager.GetAdventureData((*iter).c_str());
+		AdventureManager::Instance()->GetAdventureData((*iter).c_str());
 		++iter;
 	}
 }
@@ -331,7 +330,7 @@ void Adventure::Finished(AdventureWinStatus ws)
 					afe.win = false;
 					afe.points = 0;
 				}
-				adventure_manager.AddFinishedEvent(afe);
+				AdventureManager::Instance()->AddFinishedEvent(afe);
 				database.UpdateAdventureStatsEntry(character_id, GetTemplate()->theme, (ws != AWS_Lose) ? true : false);
 			}
 		}
@@ -352,12 +351,12 @@ void Adventure::Finished(AdventureWinStatus ws)
 				afe.win = false;
 				afe.points = 0;
 			}
-			adventure_manager.AddFinishedEvent(afe);
+			AdventureManager::Instance()->AddFinishedEvent(afe);
 			database.UpdateAdventureStatsEntry(character_id, GetTemplate()->theme, (ws != AWS_Lose) ? true : false);
 		}
 		++iter;
 	}
-	adventure_manager.GetAdventureData(this);
+	AdventureManager::Instance()->GetAdventureData(this);
 }
 
 void Adventure::MoveCorpsesToGraveyard()

--- a/world/adventure_manager.h
+++ b/world/adventure_manager.h
@@ -40,6 +40,12 @@ public:
 	AdventureTemplate *GetAdventureTemplate(int theme, int id);
 	AdventureTemplate *GetAdventureTemplate(int id);
 	void GetZoneData(uint16 instance_id);
+
+	static AdventureManager* Instance()
+	{
+		static AdventureManager instance;
+		return &instance;
+	}
 protected:
 	bool IsInExcludedZoneList(std::list<AdventureZones> excluded_zones, std::string zone_name, int version);
 	bool IsInExcludedZoneInList(std::list<AdventureZoneIn> excluded_zone_ins, int zone_id, int door_object);

--- a/world/main.cpp
+++ b/world/main.cpp
@@ -100,7 +100,6 @@ LoginServerList     loginserverlist;
 UCSConnection       UCSLink;
 QueryServConnection QSLink;
 LauncherList        launcher_list;
-AdventureManager    adventure_manager;
 WorldEventScheduler event_scheduler;
 SharedTaskManager   shared_task_manager;
 EQ::Random          emu_random;
@@ -475,7 +474,7 @@ int main(int argc, char **argv)
 		zoneserver_list.Process();
 		launcher_list.Process();
 		LFPGroupList.Process();
-		adventure_manager.Process();
+		AdventureManager::Instance()->Process();
 		shared_task_manager.Process();
 		dynamic_zone_manager.Process();
 

--- a/world/world_boot.cpp
+++ b/world/world_boot.cpp
@@ -227,7 +227,6 @@ void WorldBoot::RegisterLoginservers()
 }
 
 extern SharedTaskManager   shared_task_manager;
-extern AdventureManager    adventure_manager;
 extern WorldEventScheduler event_scheduler;
 
 bool WorldBoot::DatabaseLoadRoutines(int argc, char **argv)
@@ -362,15 +361,15 @@ bool WorldBoot::DatabaseLoadRoutines(int argc, char **argv)
 	LogInfo("Deleted [{}] stale player corpses from database", database.DeleteStalePlayerCorpses());
 
 	LogInfo("Loading adventures");
-	if (!adventure_manager.LoadAdventureTemplates()) {
+	if (!AdventureManager::Instance()->LoadAdventureTemplates()) {
 		LogInfo("Unable to load adventure templates");
 	}
 
-	if (!adventure_manager.LoadAdventureEntries()) {
+	if (!AdventureManager::Instance()->LoadAdventureEntries()) {
 		LogInfo("Unable to load adventure templates");
 	}
 
-	adventure_manager.LoadLeaderboardInfo();
+	AdventureManager::Instance()->LoadLeaderboardInfo();
 
 	LogInfo("Purging expired dynamic zones and members");
 	dynamic_zone_manager.PurgeExpiredDynamicZones();

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -58,7 +58,6 @@ extern ZSList zoneserver_list;
 extern LoginServerList loginserverlist;
 extern volatile bool RunLoops;
 extern volatile bool UCSServerAvailable_;
-extern AdventureManager adventure_manager;
 extern UCSConnection UCSLink;
 extern QueryServConnection QSLink;
 extern SharedTaskManager shared_task_manager;
@@ -1295,46 +1294,46 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 			break;
 		}
 		case ServerOP_AdventureRequest: {
-			adventure_manager.CalculateAdventureRequestReply((const char*) pack->pBuffer);
+			AdventureManager::Instance()->CalculateAdventureRequestReply((const char*) pack->pBuffer);
 			break;
 		}
 		case ServerOP_AdventureRequestCreate: {
-			adventure_manager.TryAdventureCreate((const char*) pack->pBuffer);
+			AdventureManager::Instance()->TryAdventureCreate((const char*) pack->pBuffer);
 			break;
 		}
 		case ServerOP_AdventureDataRequest: {
 			AdventureFinishEvent fe;
-			while (adventure_manager.PopFinishedEvent((const char*) pack->pBuffer, fe)) {
-				adventure_manager.SendAdventureFinish(fe);
+			while (AdventureManager::Instance()->PopFinishedEvent((const char*) pack->pBuffer, fe)) {
+				AdventureManager::Instance()->SendAdventureFinish(fe);
 			}
-			adventure_manager.GetAdventureData((const char*) pack->pBuffer);
+			AdventureManager::Instance()->GetAdventureData((const char*) pack->pBuffer);
 			break;
 		}
 		case ServerOP_AdventureClickDoor: {
 			auto pcad = (ServerPlayerClickedAdventureDoor_Struct*) pack->pBuffer;
-			adventure_manager.PlayerClickedDoor(pcad->player, pcad->zone_id, pcad->id);
+			AdventureManager::Instance()->PlayerClickedDoor(pcad->player, pcad->zone_id, pcad->id);
 			break;
 		}
 		case ServerOP_AdventureLeave: {
-			adventure_manager.LeaveAdventure((const char*) pack->pBuffer);
+			AdventureManager::Instance()->LeaveAdventure((const char*) pack->pBuffer);
 			break;
 		}
 		case ServerOP_AdventureCountUpdate: {
 			auto sc = (ServerAdventureCount_Struct*) pack->pBuffer;
-			adventure_manager.IncrementCount(sc->instance_id);
+			AdventureManager::Instance()->IncrementCount(sc->instance_id);
 			break;
 		}
 		case ServerOP_AdventureAssaCountUpdate: {
-			adventure_manager.IncrementAssassinationCount(*((uint16*) pack->pBuffer));
+			AdventureManager::Instance()->IncrementAssassinationCount(*((uint16*) pack->pBuffer));
 			break;
 		}
 		case ServerOP_AdventureZoneData: {
-			adventure_manager.GetZoneData(*((uint16*) pack->pBuffer));
+			AdventureManager::Instance()->GetZoneData(*((uint16*) pack->pBuffer));
 			break;
 		}
 		case ServerOP_AdventureLeaderboard: {
 			auto lr = (ServerLeaderboardRequest_Struct*) pack->pBuffer;
-			adventure_manager.DoLeaderboardRequest(lr->player, lr->type);
+			AdventureManager::Instance()->DoLeaderboardRequest(lr->player, lr->type);
 			break;
 		}
 		case ServerOP_LSAccountUpdate: {


### PR DESCRIPTION
# Description

This is part of a larger effort to remove global variables from the codebase. Eventually singletons can be cleaned up to be passed explicitly through dependency injection.

For now this encapsulates dependencies far better.

## Type of change

- [x] Code Cleanup

# Testing

TBD

# Checklist

- [] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur