### PR TITLE
[Code] WorldEventScheduler and ZoneEventScheduler Global to Singleton Cleanup

### DIFF
--- a/world/main.cpp
+++ b/world/main.cpp
@@ -101,7 +101,6 @@ UCSConnection       UCSLink;
 QueryServConnection QSLink;
 LauncherList        launcher_list;
 AdventureManager    adventure_manager;
-WorldEventScheduler event_scheduler;
 SharedTaskManager   shared_task_manager;
 EQ::Random          emu_random;
 volatile bool       RunLoops   = true;
@@ -429,7 +428,7 @@ int main(int argc, char **argv)
 			}
 		}
 
-		event_scheduler.Process(&zoneserver_list);
+		WorldEventScheduler::Instance()->Process(&zoneserver_list);
 
 		client_list.Process();
 		guild_mgr.Process();

--- a/world/world_boot.cpp
+++ b/world/world_boot.cpp
@@ -228,7 +228,6 @@ void WorldBoot::RegisterLoginservers()
 
 extern SharedTaskManager   shared_task_manager;
 extern AdventureManager    adventure_manager;
-extern WorldEventScheduler event_scheduler;
 
 bool WorldBoot::DatabaseLoadRoutines(int argc, char **argv)
 {
@@ -393,7 +392,7 @@ bool WorldBoot::DatabaseLoadRoutines(int argc, char **argv)
 	content_db.LoadCharacterCreateCombos();
 
 	LogInfo("Initializing [EventScheduler]");
-	event_scheduler.SetDatabase(&database)->LoadScheduledEvents();
+	WorldEventScheduler::Instance()->SetDatabase(&database)->LoadScheduledEvents();
 
 	LogInfo("Initializing [WorldContentService]");
 	content_service.SetDatabase(&database)

--- a/world/world_event_scheduler.h
+++ b/world/world_event_scheduler.h
@@ -7,6 +7,12 @@
 class WorldEventScheduler : public ServerEventScheduler {
 public:
 	void Process(ZSList *zs_list);
+
+	static WorldEventScheduler* Instance()
+	{
+		static WorldEventScheduler instance;
+		return &instance;
+	}
 };
 
 #endif //EQEMU_EVENT_SCHEDULER_H

--- a/zone/main.cpp
+++ b/zone/main.cpp
@@ -88,7 +88,6 @@ extern volatile bool is_zone_loaded;
 #include "../common/path_manager.h"
 #include "../common/database/database_update.h"
 #include "../common/skill_caps.h"
-#include "zone_event_scheduler.h"
 #include "zone_cli.h"
 
 EntityList  entity_list;
@@ -105,7 +104,6 @@ TaskManager           *task_manager = 0;
 NpcScaleManager       *npc_scale_manager;
 QuestParserCollection *parse        = 0;
 EQEmuLogSys           LogSys;
-ZoneEventScheduler    event_scheduler;
 WorldContentService   content_service;
 PathManager           path;
 PlayerEventLogs       player_event_logs;
@@ -423,7 +421,7 @@ int main(int argc, char **argv)
 		->SetExpansionContext()
 		->ReloadContentFlags();
 
-	event_scheduler.SetDatabase(&database)->LoadScheduledEvents();
+	ZoneEventScheduler::Instance()->SetDatabase(&database)->LoadScheduledEvents();
 
 	EQ::SayLinkEngine::LoadCachedSaylinks();
 
@@ -490,7 +488,7 @@ int main(int argc, char **argv)
 	QServ->CheckForConnectState();
 
 	worldserver.Connect();
-	worldserver.SetScheduler(&event_scheduler);
+	worldserver.SetScheduler(ZoneEventScheduler::Instance());
 
 	// sidecar command handler
 	if (ZoneCLI::RanConsoleCommand(argc, argv)
@@ -634,7 +632,7 @@ int main(int argc, char **argv)
 				entity_list.MobProcess();
 				entity_list.BeaconProcess();
 				entity_list.EncounterProcess();
-				event_scheduler.Process(zone, &content_service);
+				ZoneEventScheduler::Instance()->Process(zone, &content_service);
 
 				if (zone) {
 					if (!zone->Process()) {

--- a/zone/zone_event_scheduler.h
+++ b/zone/zone_event_scheduler.h
@@ -9,6 +9,12 @@ class ZoneEventScheduler : public ServerEventScheduler {
 public:
 	void Process(Zone *zone, WorldContentService *content_service);
 	void SyncEventDataWithActiveEvents();
+
+	static ZoneEventScheduler* Instance()
+	{
+		static ZoneEventScheduler instance;
+		return &instance;
+	}
 };
 
 #endif //EQEMU_ZONE_EVENT_SCHEDULER_H


### PR DESCRIPTION
# Description

This is part of a larger effort to remove global variables from the codebase. Eventually singletons can be cleaned up to be passed explicitly through dependency injection.

For now this encapsulates dependencies far better.

## Type of change

- [x] Code Cleanup

# Testing

TBD

# Checklist

- [] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur