### PR TITLE
[Code] SkillCaps Global to Singleton Cleanup

### DIFF
--- a/common/skill_caps.h
+++ b/common/skill_caps.h
@@ -16,12 +16,16 @@ public:
 	static int32_t GetSkillCapMaxLevel(uint8 class_id, EQ::skills::SkillType skill_id);
 
 	SkillCaps *SetContentDatabase(Database *db);
+
+	static SkillCaps* Instance()
+	{
+		static SkillCaps instance;
+		return &instance;
+	}
 private:
 	Database                                    *m_content_database{};
 	std::map<uint64, SkillCapsRepository::SkillCaps> m_skill_caps = {};
 };
-
-extern SkillCaps skill_caps;
 
 
 #endif //CODE_SKILL_CAPS_H

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -2171,7 +2171,7 @@ void Client::SetClassStartingSkills(PlayerProfile_Struct *pp)
 				i == EQ::skills::SkillAlcoholTolerance || i == EQ::skills::SkillBindWound)
 				continue;
 
-			pp->skills[i] = skill_caps.GetSkillCap(pp->class_, (EQ::skills::SkillType)i, 1).cap;
+			pp->skills[i] = SkillCaps::Instance()->GetSkillCap(pp->class_, (EQ::skills::SkillType)i, 1).cap;
 		}
 	}
 

--- a/world/main.cpp
+++ b/world/main.cpp
@@ -91,7 +91,6 @@
 #include "../common/repositories/character_parcels_repository.h"
 #include "../common/ip_util.h"
 
-SkillCaps           skill_caps;
 ZoneStore           zone_store;
 ClientList          client_list;
 GroupLFPList        LFPGroupList;
@@ -207,7 +206,7 @@ int main(int argc, char **argv)
 		->SetExpansionContext()
 		->ReloadContentFlags();
 
-	skill_caps.SetContentDatabase(&content_db)->LoadSkillCaps();
+	SkillCaps::Instance()->SetContentDatabase(&content_db)->LoadSkillCaps();
 
 	std::unique_ptr<EQ::Net::ServertalkServer> server_connection;
 	server_connection = std::make_unique<EQ::Net::ServertalkServer>();

--- a/world/zonelist.cpp
+++ b/world/zonelist.cpp
@@ -978,7 +978,7 @@ void ZSList::SendServerReload(ServerReload::Type type, uchar *packet)
 	} else if (type == ServerReload::Type::Rules) {
 		RuleManager::Instance()->LoadRules(&database, RuleManager::Instance()->GetActiveRuleset(), true);
 	} else if (type == ServerReload::Type::SkillCaps) {
-		skill_caps.ReloadSkillCaps();
+		SkillCaps::Instance()->ReloadSkillCaps();
 	} else if (type == ServerReload::Type::ContentFlags) {
 		content_service.SetExpansionContext()->ReloadContentFlags();
 	} else if (type == ServerReload::Type::Logs) {

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -1242,7 +1242,7 @@ uint16 Bot::GetPrimarySkillValue() {
 }
 
 uint16 Bot::MaxSkill(EQ::skills::SkillType skillid, uint16 class_, uint16 level) const {
-	return skill_caps.GetSkillCap(class_, skillid, level).cap;
+	return SkillCaps::Instance()->GetSkillCap(class_, skillid, level).cap;
 }
 
 uint32 Bot::GetTotalATK() {
@@ -3575,7 +3575,7 @@ void Bot::Depop() {
 	RemoveAllAuras();
 
 	Mob* bot_pet = GetPet();
-	
+
 	if (bot_pet) {
 		if (bot_pet->Charmed()) {
 			bot_pet->BuffFadeByEffect(SE_Charm);
@@ -7342,7 +7342,7 @@ void Bot::CalcBotStats(bool showtext) {
 		SetLevel(GetBotOwner()->GetLevel());
 
 	for (int sindex = 0; sindex <= EQ::skills::HIGHEST_SKILL; ++sindex) {
-		skills[sindex] = skill_caps.GetSkillCap(GetClass(), (EQ::skills::SkillType)sindex, GetLevel()).cap;
+		skills[sindex] = SkillCaps::Instance()->GetSkillCap(GetClass(), (EQ::skills::SkillType)sindex, GetLevel()).cap;
 	}
 
 	taunt_timer.Start(1000);
@@ -11274,7 +11274,7 @@ void Bot::SetSpellTypePriority(uint16 spell_type, uint8 priority_type, uint16 pr
 
 std::list<BotSpellTypeOrder> Bot::GetSpellTypesPrioritized(uint8 priority_type) {
 	std::list<BotSpellTypeOrder> cast_order;
-	
+
 	for (uint16 i = BotSpellTypes::START; i <= BotSpellTypes::END; i++) {
 		BotSpellTypeOrder typeSettings = {
 			.spellType = i,

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -3196,7 +3196,7 @@ bool Client::CanHaveSkill(EQ::skills::SkillType skill_id) const
 		skill_id = EQ::skills::Skill2HPiercing;
 	}
 
-	return skill_caps.GetSkillCap(GetClass(), skill_id, RuleI(Character, MaxLevel)).cap > 0;
+	return SkillCaps::Instance()->GetSkillCap(GetClass(), skill_id, RuleI(Character, MaxLevel)).cap > 0;
 }
 
 uint16 Client::MaxSkill(EQ::skills::SkillType skill_id, uint8 class_id, uint8 level) const
@@ -3209,7 +3209,7 @@ uint16 Client::MaxSkill(EQ::skills::SkillType skill_id, uint8 class_id, uint8 le
 		skill_id = EQ::skills::Skill2HPiercing;
 	}
 
-	return skill_caps.GetSkillCap(class_id, skill_id, level).cap;
+	return SkillCaps::Instance()->GetSkillCap(class_id, skill_id, level).cap;
 }
 
 uint8 Client::GetSkillTrainLevel(EQ::skills::SkillType skill_id, uint8 class_id)
@@ -3222,7 +3222,7 @@ uint8 Client::GetSkillTrainLevel(EQ::skills::SkillType skill_id, uint8 class_id)
 		skill_id = EQ::skills::Skill2HPiercing;
 	}
 
-	return skill_caps.GetSkillTrainLevel(class_id, skill_id, RuleI(Character, MaxLevel));
+	return SkillCaps::Instance()->GetSkillTrainLevel(class_id, skill_id, RuleI(Character, MaxLevel));
 }
 
 uint16 Client::GetMaxSkillAfterSpecializationRules(EQ::skills::SkillType skillid, uint16 maxSkill)
@@ -12099,7 +12099,7 @@ void Client::MaxSkills()
 		auto current_skill_value = (
 			EQ::skills::IsSpecializedSkill(s.first) ?
 			MAX_SPECIALIZED_SKILL :
-			skill_caps.GetSkillCap(GetClass(), s.first, GetLevel()).cap
+			SkillCaps::Instance()->GetSkillCap(GetClass(), s.first, GetLevel()).cap
 		);
 
 		if (GetSkill(s.first) < current_skill_value) {

--- a/zone/main.cpp
+++ b/zone/main.cpp
@@ -110,7 +110,6 @@ WorldContentService   content_service;
 PathManager           path;
 PlayerEventLogs       player_event_logs;
 DatabaseUpdate        database_update;
-SkillCaps             skill_caps;
 EvolvingItemsManager  evolving_items_manager;
 
 const SPDat_Spell_Struct* spells;
@@ -316,7 +315,7 @@ int main(int argc, char **argv)
 
 	player_event_logs.SetDatabase(&database)->Init();
 
-	skill_caps.SetContentDatabase(&content_db)->LoadSkillCaps();
+	SkillCaps::Instance()->SetContentDatabase(&content_db)->LoadSkillCaps();
 
 	const auto c = EQEmuConfig::get();
 	if (c->auto_database_updates) {

--- a/zone/merc.cpp
+++ b/zone/merc.cpp
@@ -67,7 +67,7 @@ Merc::Merc(const NPCType* d, float x, float y, float z, float heading)
 
 	int r;
 	for (r = 0; r <= EQ::skills::HIGHEST_SKILL; r++) {
-		skills[r] = skill_caps.GetSkillCap(GetClass(), (EQ::skills::SkillType)r, GetLevel()).cap;
+		skills[r] = SkillCaps::Instance()->GetSkillCap(GetClass(), (EQ::skills::SkillType)r, GetLevel()).cap;
 	}
 
 	size = d->size;
@@ -774,12 +774,12 @@ bool Merc::HasSkill(EQ::skills::SkillType skill_id) const {
 }
 
 bool Merc::CanHaveSkill(EQ::skills::SkillType skill_id) const {
-	return skill_caps.GetSkillCap(GetClass(), skill_id, RuleI(Character, MaxLevel)).cap > 0;
+	return SkillCaps::Instance()->GetSkillCap(GetClass(), skill_id, RuleI(Character, MaxLevel)).cap > 0;
 	//if you don't have it by max level, then odds are you never will?
 }
 
 uint16 Merc::MaxSkill(EQ::skills::SkillType skillid, uint16 class_, uint16 level) const {
-	return skill_caps.GetSkillCap(class_, skillid, level).cap;
+	return SkillCaps::Instance()->GetSkillCap(class_, skillid, level).cap;
 }
 
 void Merc::FillSpawnStruct(NewSpawn_Struct* ns, Mob* ForWho) {

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -370,7 +370,7 @@ NPC::NPC(const NPCType *npc_type_data, Spawn2 *in_respawn, const glm::vec4 &posi
 	//give NPCs skill values...
 	int r;
 	for (r = 0; r <= EQ::skills::HIGHEST_SKILL; r++) {
-		skills[r] = skill_caps.GetSkillCap(GetClass(), (EQ::skills::SkillType)r, moblevel).cap;
+		skills[r] = SkillCaps::Instance()->GetSkillCap(GetClass(), (EQ::skills::SkillType)r, moblevel).cap;
 	}
 	// some overrides -- really we need to be able to set skills for mobs in the DB
 	// There are some known low level SHM/BST pets that do not follow this, which supports
@@ -3726,7 +3726,7 @@ void NPC::RecalculateSkills()
 {
   	int r;
 	for (r = 0; r <= EQ::skills::HIGHEST_SKILL; r++) {
-		skills[r] = skill_caps.GetSkillCap(GetClass(), (EQ::skills::SkillType)r, level).cap;
+		skills[r] = SkillCaps::Instance()->GetSkillCap(GetClass(), (EQ::skills::SkillType)r, level).cap;
 	}
 
 	// some overrides -- really we need to be able to set skills for mobs in the DB

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -4627,7 +4627,7 @@ void WorldServer::ProcessReload(const ServerReload::Request& request)
 			break;
 
 		case ServerReload::Type::SkillCaps:
-			skill_caps.ReloadSkillCaps();
+			SkillCaps::Instance()->ReloadSkillCaps();
 			break;
 
 		case ServerReload::Type::DataBucketsCache:


### PR DESCRIPTION
# Description

This is part of a larger effort to remove global variables from the codebase. Eventually singletons can be cleaned up to be passed explicitly through dependency injection.

For now this encapsulates dependencies far better.

## Type of change

- [x] Code Cleanup

# Testing

TBD

# Checklist

- [] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur