### PR TITLE
[Code] ZoneStore Global to Singleton Cleanup

### DIFF
--- a/client_files/export/main.cpp
+++ b/client_files/export/main.cpp
@@ -40,7 +40,6 @@
 
 EQEmuLogSys          LogSys;
 WorldContentService  content_service;
-ZoneStore            zone_store;
 PathManager          path;
 PlayerEventLogs      player_event_logs;
 EvolvingItemsManager evolving_items_manager;

--- a/client_files/import/main.cpp
+++ b/client_files/import/main.cpp
@@ -34,7 +34,6 @@
 
 EQEmuLogSys          LogSys;
 WorldContentService  content_service;
-ZoneStore            zone_store;
 PathManager          path;
 PlayerEventLogs      player_event_logs;
 EvolvingItemsManager evolving_items_manager;

--- a/common/content/world_content_service.cpp
+++ b/common/content/world_content_service.cpp
@@ -185,7 +185,7 @@ void WorldContentService::ReloadContentFlags()
 
 	SetContentFlags(set_content_flags);
 	LoadStaticGlobalZoneInstances();
-	zone_store.LoadZones(*m_content_database);
+	ZoneStore::Instance()->LoadZones(*m_content_database);
 }
 
 Database *WorldContentService::GetDatabase() const
@@ -291,7 +291,7 @@ WorldContentService *WorldContentService::LoadStaticGlobalZoneInstances()
 //   instance_list table entry for lavastorm has version = 1, is_global = 1, never_expires = 1
 WorldContentService::FindZoneResult WorldContentService::FindZone(uint32 zone_id, uint32 instance_id)
 {
-	for (const auto &z: zone_store.GetZones()) {
+	for (const auto &z: ZoneStore::Instance()->GetZones()) {
 		for (auto &i: m_zone_static_instances) {
 			if (
 				z.zoneidnumber == zone_id &&

--- a/common/zone_store.h
+++ b/common/zone_store.h
@@ -104,36 +104,39 @@ public:
 	uint8 GetZoneIdleWhenEmpty(uint32 zone_id, int version = 0);
 	uint32 GetZoneSecondsBeforeIdle(uint32 zone_id, int version = 0);
 
+	static ZoneStore* Instance()
+	{
+		static ZoneStore instance;
+		return &instance;
+	}
 private:
 	std::vector<ZoneRepository::Zone> m_zones;
 };
 
-extern ZoneStore zone_store;
-
 /**
  * Global helpers
  */
-inline uint32 ZoneID(const char *in_zone_name) { return zone_store.GetZoneID(in_zone_name); }
-inline uint32 ZoneID(const std::string& zone_name) { return zone_store.GetZoneID(zone_name); }
+inline uint32 ZoneID(const char *in_zone_name) { return ZoneStore::Instance()->GetZoneID(in_zone_name); }
+inline uint32 ZoneID(const std::string& zone_name) { return ZoneStore::Instance()->GetZoneID(zone_name); }
 inline const char *ZoneName(uint32 zone_id, bool error_unknown = false)
 {
-	return zone_store.GetZoneName(
+	return ZoneStore::Instance()->GetZoneName(
 		zone_id,
 		error_unknown
 	);
 }
 inline const char *ZoneLongName(uint32 zone_id, bool error_unknown = false)
 {
-	return zone_store.GetZoneLongName(
+	return ZoneStore::Instance()->GetZoneLongName(
 		zone_id,
 		error_unknown
 	);
 }
-inline ZoneRepository::Zone *GetZone(uint32 zone_id, int version = 0) { return zone_store.GetZone(zone_id, version); };
-inline ZoneRepository::Zone *GetZone(const char *in_zone_name) { return zone_store.GetZone(in_zone_name); };
+inline ZoneRepository::Zone *GetZone(uint32 zone_id, int version = 0) { return ZoneStore::Instance()->GetZone(zone_id, version); };
+inline ZoneRepository::Zone *GetZone(const char *in_zone_name) { return ZoneStore::Instance()->GetZone(in_zone_name); };
 inline ZoneRepository::Zone *GetZone(const char *in_zone_name, int version = 0)
 {
-	return zone_store.GetZone(
+	return ZoneStore::Instance()->GetZone(
 		ZoneID(
 			in_zone_name
 		), version
@@ -141,7 +144,7 @@ inline ZoneRepository::Zone *GetZone(const char *in_zone_name, int version = 0)
 };
 inline ZoneRepository::Zone *GetZoneVersionWithFallback(uint32 zone_id, int version = 0)
 {
-	return zone_store.GetZoneWithFallback(
+	return ZoneStore::Instance()->GetZoneWithFallback(
 		zone_id,
 		version
 	);

--- a/loginserver/main.cpp
+++ b/loginserver/main.cpp
@@ -27,7 +27,6 @@ bool            run_server = true;
 PathManager     path;
 Database        database;
 PlayerEventLogs player_event_logs;
-ZoneStore       zone_store;
 
 void CatchSignal(int sig_num)
 {

--- a/queryserv/queryserv.cpp
+++ b/queryserv/queryserv.cpp
@@ -32,7 +32,6 @@ const queryservconfig *Config;
 WorldServer           *worldserver = 0;
 EQEmuLogSys           LogSys;
 PathManager           path;
-ZoneStore             zone_store;
 PlayerEventLogs       player_event_logs;
 ZSList                zs_list;
 uint32                numzones     = 0;

--- a/shared_memory/main.cpp
+++ b/shared_memory/main.cpp
@@ -37,7 +37,6 @@
 
 EQEmuLogSys          LogSys;
 WorldContentService  content_service;
-ZoneStore            zone_store;
 PathManager          path;
 PlayerEventLogs      player_event_logs;
 EvolvingItemsManager evolving_items_manager;

--- a/ucs/ucs.cpp
+++ b/ucs/ucs.cpp
@@ -49,7 +49,6 @@ UCSDatabase database;
 WorldServer *worldserver = nullptr;
 DiscordManager discord_manager;
 PathManager path;
-ZoneStore zone_store;
 PlayerEventLogs player_event_logs;
 
 const ucsconfig *Config;

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -2369,7 +2369,7 @@ bool Client::StoreCharacter(
 		return false;
 	}
 
-	const std::string& zone_name = zone_store.GetZoneName(p_player_profile_struct->zone_id, true);
+	const std::string& zone_name = ZoneStore::Instance()->GetZoneName(p_player_profile_struct->zone_id, true);
 	if (Strings::EqualFold(zone_name, "UNKNOWN")) {
 		p_player_profile_struct->zone_id = Zones::QEYNOS;
 	}

--- a/world/console.cpp
+++ b/world/console.cpp
@@ -1219,7 +1219,7 @@ void ConsoleCrossZoneMove(
 	const auto&  zone_short_name = !Strings::IsNumber(args[2]) ? args[2] : "";
 	const uint16 instance_id     = Strings::IsNumber(args[2]) ? static_cast<uint16>(Strings::ToUnsignedInt(args[2])) : 0;
 
-	const auto& z = !zone_short_name.empty() ? zone_store.GetZone(zone_short_name) : nullptr;
+	const auto& z = !zone_short_name.empty() ? ZoneStore::Instance()->GetZone(zone_short_name) : nullptr;
 
 	if (z && !z->id) {
 		connection->SendLine(fmt::format("No zone with the short name '{}' exists.", zone_short_name));
@@ -1289,7 +1289,7 @@ void ConsoleWorldWideMove(
 	const auto&  zone_short_name = !Strings::IsNumber(args[2]) ? args[2] : "";
 	const uint16 instance_id     = Strings::IsNumber(args[2]) ? static_cast<uint16>(Strings::ToUnsignedInt(args[2])) : 0;
 
-	const auto& z = !zone_short_name.empty() ? zone_store.GetZone(zone_short_name) : nullptr;
+	const auto& z = !zone_short_name.empty() ? ZoneStore::Instance()->GetZone(zone_short_name) : nullptr;
 
 	if (z && !z->id) {
 		connection->SendLine(fmt::format("No zone with the short name '{}' exists.", zone_short_name));

--- a/world/main.cpp
+++ b/world/main.cpp
@@ -92,7 +92,6 @@
 #include "../common/ip_util.h"
 
 SkillCaps           skill_caps;
-ZoneStore           zone_store;
 ClientList          client_list;
 GroupLFPList        LFPGroupList;
 ZSList              zoneserver_list;

--- a/world/world_boot.cpp
+++ b/world/world_boot.cpp
@@ -279,9 +279,9 @@ bool WorldBoot::DatabaseLoadRoutines(int argc, char **argv)
 
 	LogInfo("Loading zones");
 
-	zone_store.LoadZones(content_db);
+	ZoneStore::Instance()->LoadZones(content_db);
 
-	if (zone_store.GetZones().empty()) {
+	if (ZoneStore::Instance()->GetZones().empty()) {
 		LogError("Failed to load zones data, check your schema for possible errors");
 		return 1;
 	}

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -6963,7 +6963,7 @@ void Client::Handle_OP_GMSearchCorpse(const EQApplicationPacket *app)
 			DialogueWindow::TableCell(
 				fmt::format(
 					"{} ({})",
-					zone_store.GetZoneLongName(e.zone_id, true),
+					ZoneStore::Instance()->GetZoneLongName(e.zone_id, true),
 					e.zone_id
 				)
 			) +

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -5115,627 +5115,627 @@ void Perl__send_player_handin_event()
 
 float Perl__GetZoneSafeX(uint32 zone_id)
 {
-	return zone_store.GetZoneSafeCoordinates(zone_id).x;
+	return ZoneStore::Instance()->GetZoneSafeCoordinates(zone_id).x;
 }
 
 float Perl__GetZoneSafeX(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneSafeCoordinates(zone_id, version).x;
+	return ZoneStore::Instance()->GetZoneSafeCoordinates(zone_id, version).x;
 }
 
 float Perl__GetZoneSafeY(uint32 zone_id)
 {
-	return zone_store.GetZoneSafeCoordinates(zone_id).y;
+	return ZoneStore::Instance()->GetZoneSafeCoordinates(zone_id).y;
 }
 
 float Perl__GetZoneSafeY(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneSafeCoordinates(zone_id, version).y;
+	return ZoneStore::Instance()->GetZoneSafeCoordinates(zone_id, version).y;
 }
 
 float Perl__GetZoneSafeZ(uint32 zone_id)
 {
-	return zone_store.GetZoneSafeCoordinates(zone_id).z;
+	return ZoneStore::Instance()->GetZoneSafeCoordinates(zone_id).z;
 }
 
 float Perl__GetZoneSafeZ(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneSafeCoordinates(zone_id, version).z;
+	return ZoneStore::Instance()->GetZoneSafeCoordinates(zone_id, version).z;
 }
 
 float Perl__GetZoneSafeHeading(uint32 zone_id)
 {
-	return zone_store.GetZoneSafeCoordinates(zone_id).w;
+	return ZoneStore::Instance()->GetZoneSafeCoordinates(zone_id).w;
 }
 
 float Perl__GetZoneSafeHeading(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneSafeCoordinates(zone_id, version).w;
+	return ZoneStore::Instance()->GetZoneSafeCoordinates(zone_id, version).w;
 }
 
 float Perl__GetZoneGraveyardID(uint32 zone_id)
 {
-	return zone_store.GetZoneGraveyardID(zone_id);
+	return ZoneStore::Instance()->GetZoneGraveyardID(zone_id);
 }
 
 float Perl__GetZoneGraveyardID(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneGraveyardID(zone_id, version);
+	return ZoneStore::Instance()->GetZoneGraveyardID(zone_id, version);
 }
 
 uint8 Perl__GetZoneMinimumLevel(uint32 zone_id)
 {
-	return zone_store.GetZoneMinimumLevel(zone_id);
+	return ZoneStore::Instance()->GetZoneMinimumLevel(zone_id);
 }
 
 uint8 Perl__GetZoneMinimumLevel(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneMinimumLevel(zone_id, version);
+	return ZoneStore::Instance()->GetZoneMinimumLevel(zone_id, version);
 }
 
 uint8 Perl__GetZoneMaximumLevel(uint32 zone_id)
 {
-	return zone_store.GetZoneMaximumLevel(zone_id);
+	return ZoneStore::Instance()->GetZoneMaximumLevel(zone_id);
 }
 
 uint8 Perl__GetZoneMaximumLevel(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneMaximumLevel(zone_id, version);
+	return ZoneStore::Instance()->GetZoneMaximumLevel(zone_id, version);
 }
 
 uint8 Perl__GetZoneMinimumStatus(uint32 zone_id)
 {
-	return zone_store.GetZoneMinimumStatus(zone_id);
+	return ZoneStore::Instance()->GetZoneMinimumStatus(zone_id);
 }
 
 uint8 Perl__GetZoneMinimumStatus(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneMinimumStatus(zone_id, version);
+	return ZoneStore::Instance()->GetZoneMinimumStatus(zone_id, version);
 }
 
 int Perl__GetZoneTimeZone(uint32 zone_id)
 {
-	return zone_store.GetZoneTimeZone(zone_id);
+	return ZoneStore::Instance()->GetZoneTimeZone(zone_id);
 }
 
 int Perl__GetZoneTimeZone(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneTimeZone(zone_id, version);
+	return ZoneStore::Instance()->GetZoneTimeZone(zone_id, version);
 }
 
 int Perl__GetZoneMaximumPlayers(uint32 zone_id)
 {
-	return zone_store.GetZoneMaximumPlayers(zone_id);
+	return ZoneStore::Instance()->GetZoneMaximumPlayers(zone_id);
 }
 
 int Perl__GetZoneMaximumPlayers(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneMaximumPlayers(zone_id, version);
+	return ZoneStore::Instance()->GetZoneMaximumPlayers(zone_id, version);
 }
 
 uint32 Perl__GetZoneRuleSet(uint32 zone_id)
 {
-	return zone_store.GetZoneRuleSet(zone_id);
+	return ZoneStore::Instance()->GetZoneRuleSet(zone_id);
 }
 
 uint32 Perl__GetZoneRuleSet(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneRuleSet(zone_id, version);
+	return ZoneStore::Instance()->GetZoneRuleSet(zone_id, version);
 }
 
 std::string Perl__GetZoneNote(uint32 zone_id)
 {
-	return zone_store.GetZoneNote(zone_id);
+	return ZoneStore::Instance()->GetZoneNote(zone_id);
 }
 
 std::string Perl__GetZoneNote(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneNote(zone_id, version);
+	return ZoneStore::Instance()->GetZoneNote(zone_id, version);
 }
 
 float Perl__GetZoneUnderworld(uint32 zone_id)
 {
-	return zone_store.GetZoneUnderworld(zone_id);
+	return ZoneStore::Instance()->GetZoneUnderworld(zone_id);
 }
 
 float Perl__GetZoneUnderworld(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneUnderworld(zone_id, version);
+	return ZoneStore::Instance()->GetZoneUnderworld(zone_id, version);
 }
 
 float Perl__GetZoneMinimumClip(uint32 zone_id)
 {
-	return zone_store.GetZoneMinimumClip(zone_id);
+	return ZoneStore::Instance()->GetZoneMinimumClip(zone_id);
 }
 
 float Perl__GetZoneMinimumClip(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneMinimumClip(zone_id, version);
+	return ZoneStore::Instance()->GetZoneMinimumClip(zone_id, version);
 }
 
 float Perl__GetZoneMaximumClip(uint32 zone_id)
 {
-	return zone_store.GetZoneMaximumClip(zone_id);
+	return ZoneStore::Instance()->GetZoneMaximumClip(zone_id);
 }
 
 float Perl__GetZoneMaximumClip(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneMaximumClip(zone_id, version);
+	return ZoneStore::Instance()->GetZoneMaximumClip(zone_id, version);
 }
 
 float Perl__GetZoneFogMinimumClip(uint32 zone_id)
 {
-	return zone_store.GetZoneFogMinimumClip(zone_id);
+	return ZoneStore::Instance()->GetZoneFogMinimumClip(zone_id);
 }
 
 float Perl__GetZoneFogMinimumClip(uint32 zone_id, uint8 slot)
 {
-	return zone_store.GetZoneFogMinimumClip(zone_id, slot);
+	return ZoneStore::Instance()->GetZoneFogMinimumClip(zone_id, slot);
 }
 
 float Perl__GetZoneFogMinimumClip(uint32 zone_id, uint8 slot, int version)
 {
-	return zone_store.GetZoneFogMinimumClip(zone_id, slot, version);
+	return ZoneStore::Instance()->GetZoneFogMinimumClip(zone_id, slot, version);
 }
 
 float Perl__GetZoneFogMaximumClip(uint32 zone_id)
 {
-	return zone_store.GetZoneFogMaximumClip(zone_id);
+	return ZoneStore::Instance()->GetZoneFogMaximumClip(zone_id);
 }
 
 float Perl__GetZoneFogMaximumClip(uint32 zone_id, uint8 slot)
 {
-	return zone_store.GetZoneFogMaximumClip(zone_id, slot);
+	return ZoneStore::Instance()->GetZoneFogMaximumClip(zone_id, slot);
 }
 
 float Perl__GetZoneFogMaximumClip(uint32 zone_id, uint8 slot, int version)
 {
-	return zone_store.GetZoneFogMaximumClip(zone_id, slot, version);
+	return ZoneStore::Instance()->GetZoneFogMaximumClip(zone_id, slot, version);
 }
 
 uint8 Perl__GetZoneFogRed(uint32 zone_id)
 {
-	return zone_store.GetZoneFogRed(zone_id);
+	return ZoneStore::Instance()->GetZoneFogRed(zone_id);
 }
 
 uint8 Perl__GetZoneFogRed(uint32 zone_id, uint8 slot)
 {
-	return zone_store.GetZoneFogRed(zone_id, slot);
+	return ZoneStore::Instance()->GetZoneFogRed(zone_id, slot);
 }
 
 uint8 Perl__GetZoneFogRed(uint32 zone_id, uint8 slot, int version)
 {
-	return zone_store.GetZoneFogRed(zone_id, slot, version);
+	return ZoneStore::Instance()->GetZoneFogRed(zone_id, slot, version);
 }
 
 uint8 Perl__GetZoneFogGreen(uint32 zone_id)
 {
-	return zone_store.GetZoneFogGreen(zone_id);
+	return ZoneStore::Instance()->GetZoneFogGreen(zone_id);
 }
 
 uint8 Perl__GetZoneFogGreen(uint32 zone_id, uint8 slot)
 {
-	return zone_store.GetZoneFogGreen(zone_id, slot);
+	return ZoneStore::Instance()->GetZoneFogGreen(zone_id, slot);
 }
 
 uint8 Perl__GetZoneFogGreen(uint32 zone_id, uint8 slot, int version)
 {
-	return zone_store.GetZoneFogGreen(zone_id, slot, version);
+	return ZoneStore::Instance()->GetZoneFogGreen(zone_id, slot, version);
 }
 
 uint8 Perl__GetZoneFogBlue(uint32 zone_id)
 {
-	return zone_store.GetZoneFogBlue(zone_id);
+	return ZoneStore::Instance()->GetZoneFogBlue(zone_id);
 }
 
 uint8 Perl__GetZoneFogBlue(uint32 zone_id, uint8 slot)
 {
-	return zone_store.GetZoneFogBlue(zone_id, slot);
+	return ZoneStore::Instance()->GetZoneFogBlue(zone_id, slot);
 }
 
 uint8 Perl__GetZoneFogBlue(uint32 zone_id, uint8 slot, int version)
 {
-	return zone_store.GetZoneFogBlue(zone_id, slot, version);
+	return ZoneStore::Instance()->GetZoneFogBlue(zone_id, slot, version);
 }
 
 uint8 Perl__GetZoneSky(uint32 zone_id)
 {
-	return zone_store.GetZoneSky(zone_id);
+	return ZoneStore::Instance()->GetZoneSky(zone_id);
 }
 
 uint8 Perl__GetZoneSky(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneSky(zone_id, version);
+	return ZoneStore::Instance()->GetZoneSky(zone_id, version);
 }
 
 uint8 Perl__GetZoneZType(uint32 zone_id)
 {
-	return zone_store.GetZoneZType(zone_id);
+	return ZoneStore::Instance()->GetZoneZType(zone_id);
 }
 
 uint8 Perl__GetZoneZType(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneZType(zone_id, version);
+	return ZoneStore::Instance()->GetZoneZType(zone_id, version);
 }
 
 float Perl__GetZoneExperienceMultiplier(uint32 zone_id)
 {
-	return zone_store.GetZoneExperienceMultiplier(zone_id);
+	return ZoneStore::Instance()->GetZoneExperienceMultiplier(zone_id);
 }
 
 float Perl__GetZoneExperienceMultiplier(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneExperienceMultiplier(zone_id, version);
+	return ZoneStore::Instance()->GetZoneExperienceMultiplier(zone_id, version);
 }
 
 float Perl__GetZoneWalkSpeed(uint32 zone_id)
 {
-	return zone_store.GetZoneWalkSpeed(zone_id);
+	return ZoneStore::Instance()->GetZoneWalkSpeed(zone_id);
 }
 
 float Perl__GetZoneWalkSpeed(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneWalkSpeed(zone_id, version);
+	return ZoneStore::Instance()->GetZoneWalkSpeed(zone_id, version);
 }
 
 uint8 Perl__GetZoneTimeType(uint32 zone_id)
 {
-	return zone_store.GetZoneTimeType(zone_id);
+	return ZoneStore::Instance()->GetZoneTimeType(zone_id);
 }
 
 uint8 Perl__GetZoneTimeType(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneTimeType(zone_id, version);
+	return ZoneStore::Instance()->GetZoneTimeType(zone_id, version);
 }
 
 float Perl__GetZoneFogDensity(uint32 zone_id)
 {
-	return zone_store.GetZoneFogDensity(zone_id);
+	return ZoneStore::Instance()->GetZoneFogDensity(zone_id);
 }
 
 float Perl__GetZoneFogDensity(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneFogDensity(zone_id, version);
+	return ZoneStore::Instance()->GetZoneFogDensity(zone_id, version);
 }
 
 std::string Perl__GetZoneFlagNeeded(uint32 zone_id)
 {
-	return zone_store.GetZoneFlagNeeded(zone_id);
+	return ZoneStore::Instance()->GetZoneFlagNeeded(zone_id);
 }
 
 std::string Perl__GetZoneFlagNeeded(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneFlagNeeded(zone_id, version);
+	return ZoneStore::Instance()->GetZoneFlagNeeded(zone_id, version);
 }
 
 int8 Perl__GetZoneCanBind(uint32 zone_id)
 {
-	return zone_store.GetZoneCanBind(zone_id);
+	return ZoneStore::Instance()->GetZoneCanBind(zone_id);
 }
 
 int8 Perl__GetZoneCanBind(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneCanBind(zone_id, version);
+	return ZoneStore::Instance()->GetZoneCanBind(zone_id, version);
 }
 
 int8 Perl__GetZoneCanCombat(uint32 zone_id)
 {
-	return zone_store.GetZoneCanCombat(zone_id);
+	return ZoneStore::Instance()->GetZoneCanCombat(zone_id);
 }
 
 int8 Perl__GetZoneCanCombat(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneCanCombat(zone_id, version);
+	return ZoneStore::Instance()->GetZoneCanCombat(zone_id, version);
 }
 
 int8 Perl__GetZoneCanLevitate(uint32 zone_id)
 {
-	return zone_store.GetZoneCanLevitate(zone_id);
+	return ZoneStore::Instance()->GetZoneCanLevitate(zone_id);
 }
 
 int8 Perl__GetZoneCanLevitate(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneCanLevitate(zone_id, version);
+	return ZoneStore::Instance()->GetZoneCanLevitate(zone_id, version);
 }
 
 int8 Perl__GetZoneCastOutdoor(uint32 zone_id)
 {
-	return zone_store.GetZoneCastOutdoor(zone_id);
+	return ZoneStore::Instance()->GetZoneCastOutdoor(zone_id);
 }
 
 int8 Perl__GetZoneCastOutdoor(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneCastOutdoor(zone_id, version);
+	return ZoneStore::Instance()->GetZoneCastOutdoor(zone_id, version);
 }
 
 uint8 Perl__GetZoneHotzone(uint32 zone_id)
 {
-	return zone_store.GetZoneHotzone(zone_id);
+	return ZoneStore::Instance()->GetZoneHotzone(zone_id);
 }
 
 uint8 Perl__GetZoneHotzone(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneHotzone(zone_id, version);
+	return ZoneStore::Instance()->GetZoneHotzone(zone_id, version);
 }
 
 uint8 Perl__GetZoneInstanceType(uint32 zone_id)
 {
-	return zone_store.GetZoneInstanceType(zone_id);
+	return ZoneStore::Instance()->GetZoneInstanceType(zone_id);
 }
 
 uint8 Perl__GetZoneInstanceType(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneInstanceType(zone_id, version);
+	return ZoneStore::Instance()->GetZoneInstanceType(zone_id, version);
 }
 
 uint64 Perl__GetZoneShutdownDelay(uint32 zone_id)
 {
-	return zone_store.GetZoneShutdownDelay(zone_id);
+	return ZoneStore::Instance()->GetZoneShutdownDelay(zone_id);
 }
 
 uint64 Perl__GetZoneShutdownDelay(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneShutdownDelay(zone_id, version);
+	return ZoneStore::Instance()->GetZoneShutdownDelay(zone_id, version);
 }
 
 int8 Perl__GetZonePEQZone(uint32 zone_id)
 {
-	return zone_store.GetZonePEQZone(zone_id);
+	return ZoneStore::Instance()->GetZonePEQZone(zone_id);
 }
 
 int8 Perl__GetZonePEQZone(uint32 zone_id, int version)
 {
-	return zone_store.GetZonePEQZone(zone_id, version);
+	return ZoneStore::Instance()->GetZonePEQZone(zone_id, version);
 }
 
 int8 Perl__GetZoneExpansion(uint32 zone_id)
 {
-	return zone_store.GetZoneExpansion(zone_id);
+	return ZoneStore::Instance()->GetZoneExpansion(zone_id);
 }
 
 int8 Perl__GetZoneExpansion(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneExpansion(zone_id, version);
+	return ZoneStore::Instance()->GetZoneExpansion(zone_id, version);
 }
 
 int8 Perl__GetZoneBypassExpansionCheck(uint32 zone_id)
 {
-	return zone_store.GetZoneBypassExpansionCheck(zone_id);
+	return ZoneStore::Instance()->GetZoneBypassExpansionCheck(zone_id);
 }
 
 int8 Perl__GetZoneBypassExpansionCheck(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneBypassExpansionCheck(zone_id, version);
+	return ZoneStore::Instance()->GetZoneBypassExpansionCheck(zone_id, version);
 }
 
 uint8 Perl__GetZoneSuspendBuffs(uint32 zone_id)
 {
-	return zone_store.GetZoneSuspendBuffs(zone_id);
+	return ZoneStore::Instance()->GetZoneSuspendBuffs(zone_id);
 }
 
 uint8 Perl__GetZoneSuspendBuffs(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneSuspendBuffs(zone_id, version);
+	return ZoneStore::Instance()->GetZoneSuspendBuffs(zone_id, version);
 }
 
 int Perl__GetZoneRainChance(uint32 zone_id)
 {
-	return zone_store.GetZoneRainChance(zone_id);
+	return ZoneStore::Instance()->GetZoneRainChance(zone_id);
 }
 
 int Perl__GetZoneRainChance(uint32 zone_id, uint8 slot)
 {
-	return zone_store.GetZoneRainChance(zone_id, slot);
+	return ZoneStore::Instance()->GetZoneRainChance(zone_id, slot);
 }
 
 int Perl__GetZoneRainChance(uint32 zone_id, uint8 slot, int version)
 {
-	return zone_store.GetZoneRainChance(zone_id, slot, version);
+	return ZoneStore::Instance()->GetZoneRainChance(zone_id, slot, version);
 }
 
 int Perl__GetZoneRainDuration(uint32 zone_id)
 {
-	return zone_store.GetZoneRainDuration(zone_id);
+	return ZoneStore::Instance()->GetZoneRainDuration(zone_id);
 }
 
 int Perl__GetZoneRainDuration(uint32 zone_id, uint8 slot)
 {
-	return zone_store.GetZoneRainDuration(zone_id, slot);
+	return ZoneStore::Instance()->GetZoneRainDuration(zone_id, slot);
 }
 
 int Perl__GetZoneRainDuration(uint32 zone_id, uint8 slot, int version)
 {
-	return zone_store.GetZoneRainDuration(zone_id, slot, version);
+	return ZoneStore::Instance()->GetZoneRainDuration(zone_id, slot, version);
 }
 
 int Perl__GetZoneSnowChance(uint32 zone_id)
 {
-	return zone_store.GetZoneSnowChance(zone_id);
+	return ZoneStore::Instance()->GetZoneSnowChance(zone_id);
 }
 
 int Perl__GetZoneSnowChance(uint32 zone_id, uint8 slot)
 {
-	return zone_store.GetZoneSnowChance(zone_id, slot);
+	return ZoneStore::Instance()->GetZoneSnowChance(zone_id, slot);
 }
 
 int Perl__GetZoneSnowChance(uint32 zone_id, uint8 slot, int version)
 {
-	return zone_store.GetZoneSnowChance(zone_id, slot, version);
+	return ZoneStore::Instance()->GetZoneSnowChance(zone_id, slot, version);
 }
 
 int Perl__GetZoneSnowDuration(uint32 zone_id)
 {
-	return zone_store.GetZoneSnowDuration(zone_id);
+	return ZoneStore::Instance()->GetZoneSnowDuration(zone_id);
 }
 
 int Perl__GetZoneSnowDuration(uint32 zone_id, uint8 slot)
 {
-	return zone_store.GetZoneSnowDuration(zone_id, slot);
+	return ZoneStore::Instance()->GetZoneSnowDuration(zone_id, slot);
 }
 
 int Perl__GetZoneSnowDuration(uint32 zone_id, uint8 slot, int version)
 {
-	return zone_store.GetZoneSnowDuration(zone_id, slot, version);
+	return ZoneStore::Instance()->GetZoneSnowDuration(zone_id, slot, version);
 }
 
 float Perl__GetZoneGravity(uint32 zone_id)
 {
-	return zone_store.GetZoneGravity(zone_id);
+	return ZoneStore::Instance()->GetZoneGravity(zone_id);
 }
 
 float Perl__GetZoneGravity(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneGravity(zone_id, version);
+	return ZoneStore::Instance()->GetZoneGravity(zone_id, version);
 }
 
 int Perl__GetZoneType(uint32 zone_id)
 {
-	return zone_store.GetZoneType(zone_id);
+	return ZoneStore::Instance()->GetZoneType(zone_id);
 }
 
 int Perl__GetZoneType(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneType(zone_id, version);
+	return ZoneStore::Instance()->GetZoneType(zone_id, version);
 }
 
 int8 Perl__GetZoneSkyLock(uint32 zone_id)
 {
-	return zone_store.GetZoneSkyLock(zone_id);
+	return ZoneStore::Instance()->GetZoneSkyLock(zone_id);
 }
 
 int8 Perl__GetZoneSkyLock(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneSkyLock(zone_id, version);
+	return ZoneStore::Instance()->GetZoneSkyLock(zone_id, version);
 }
 
 int Perl__GetZoneFastRegenHP(uint32 zone_id)
 {
-	return zone_store.GetZoneFastRegenHP(zone_id);
+	return ZoneStore::Instance()->GetZoneFastRegenHP(zone_id);
 }
 
 int Perl__GetZoneFastRegenHP(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneFastRegenHP(zone_id, version);
+	return ZoneStore::Instance()->GetZoneFastRegenHP(zone_id, version);
 }
 
 int Perl__GetZoneFastRegenMana(uint32 zone_id)
 {
-	return zone_store.GetZoneFastRegenMana(zone_id);
+	return ZoneStore::Instance()->GetZoneFastRegenMana(zone_id);
 }
 
 int Perl__GetZoneFastRegenMana(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneFastRegenMana(zone_id, version);
+	return ZoneStore::Instance()->GetZoneFastRegenMana(zone_id, version);
 }
 
 int Perl__GetZoneFastRegenEndurance(uint32 zone_id)
 {
-	return zone_store.GetZoneFastRegenEndurance(zone_id);
+	return ZoneStore::Instance()->GetZoneFastRegenEndurance(zone_id);
 }
 
 int Perl__GetZoneFastRegenEndurance(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneFastRegenEndurance(zone_id, version);
+	return ZoneStore::Instance()->GetZoneFastRegenEndurance(zone_id, version);
 }
 
 int Perl__GetZoneNPCMaximumAggroDistance(uint32 zone_id)
 {
-	return zone_store.GetZoneNPCMaximumAggroDistance(zone_id);
+	return ZoneStore::Instance()->GetZoneNPCMaximumAggroDistance(zone_id);
 }
 
 int Perl__GetZoneNPCMaximumAggroDistance(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneNPCMaximumAggroDistance(zone_id, version);
+	return ZoneStore::Instance()->GetZoneNPCMaximumAggroDistance(zone_id, version);
 }
 
 int8 Perl__GetZoneMinimumExpansion(uint32 zone_id)
 {
-	return zone_store.GetZoneMinimumExpansion(zone_id);
+	return ZoneStore::Instance()->GetZoneMinimumExpansion(zone_id);
 }
 
 int8 Perl__GetZoneMinimumExpansion(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneMinimumExpansion(zone_id, version);
+	return ZoneStore::Instance()->GetZoneMinimumExpansion(zone_id, version);
 }
 
 int8 Perl__GetZoneMaximumExpansion(uint32 zone_id)
 {
-	return zone_store.GetZoneMaximumExpansion(zone_id);
+	return ZoneStore::Instance()->GetZoneMaximumExpansion(zone_id);
 }
 
 int8 Perl__GetZoneMaximumExpansion(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneMaximumExpansion(zone_id, version);
+	return ZoneStore::Instance()->GetZoneMaximumExpansion(zone_id, version);
 }
 
 std::string Perl__GetZoneContentFlags(uint32 zone_id)
 {
-	return zone_store.GetZoneContentFlags(zone_id);
+	return ZoneStore::Instance()->GetZoneContentFlags(zone_id);
 }
 
 std::string Perl__GetZoneContentFlags(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneContentFlags(zone_id, version);
+	return ZoneStore::Instance()->GetZoneContentFlags(zone_id, version);
 }
 
 std::string Perl__GetZoneContentFlagsDisabled(uint32 zone_id)
 {
-	return zone_store.GetZoneContentFlagsDisabled(zone_id);
+	return ZoneStore::Instance()->GetZoneContentFlagsDisabled(zone_id);
 }
 
 std::string Perl__GetZoneContentFlagsDisabled(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneContentFlagsDisabled(zone_id, version);
+	return ZoneStore::Instance()->GetZoneContentFlagsDisabled(zone_id, version);
 }
 
 int Perl__GetZoneUnderworldTeleportIndex(uint32 zone_id)
 {
-	return zone_store.GetZoneUnderworldTeleportIndex(zone_id);
+	return ZoneStore::Instance()->GetZoneUnderworldTeleportIndex(zone_id);
 }
 
 int Perl__GetZoneUnderworldTeleportIndex(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneUnderworldTeleportIndex(zone_id, version);
+	return ZoneStore::Instance()->GetZoneUnderworldTeleportIndex(zone_id, version);
 }
 
 int Perl__GetZoneLavaDamage(uint32 zone_id)
 {
-	return zone_store.GetZoneLavaDamage(zone_id);
+	return ZoneStore::Instance()->GetZoneLavaDamage(zone_id);
 }
 
 int Perl__GetZoneLavaDamage(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneLavaDamage(zone_id, version);
+	return ZoneStore::Instance()->GetZoneLavaDamage(zone_id, version);
 }
 
 int Perl__GetZoneMinimumLavaDamage(uint32 zone_id)
 {
-	return zone_store.GetZoneMinimumLavaDamage(zone_id);
+	return ZoneStore::Instance()->GetZoneMinimumLavaDamage(zone_id);
 }
 
 int Perl__GetZoneMinimumLavaDamage(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneMinimumLavaDamage(zone_id, version);
+	return ZoneStore::Instance()->GetZoneMinimumLavaDamage(zone_id, version);
 }
 
 uint8 Perl__GetZoneIdleWhenEmpty(uint32 zone_id)
 {
-	return zone_store.GetZoneIdleWhenEmpty(zone_id);
+	return ZoneStore::Instance()->GetZoneIdleWhenEmpty(zone_id);
 }
 
 uint8 Perl__GetZoneIdleWhenEmpty(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneIdleWhenEmpty(zone_id, version);
+	return ZoneStore::Instance()->GetZoneIdleWhenEmpty(zone_id, version);
 }
 
 uint32 Perl__GetZoneSecondsBeforeIdle(uint32 zone_id)
 {
-	return zone_store.GetZoneSecondsBeforeIdle(zone_id);
+	return ZoneStore::Instance()->GetZoneSecondsBeforeIdle(zone_id);
 }
 
 uint32 Perl__GetZoneSecondsBeforeIdle(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneSecondsBeforeIdle(zone_id, version);
+	return ZoneStore::Instance()->GetZoneSecondsBeforeIdle(zone_id, version);
 }
 
 void Perl__send_channel_message(uint8 channel_number, uint32 guild_id, uint8 language_id, uint8 language_skill, const char* message)
@@ -5860,12 +5860,12 @@ bool Perl__SetAutoLoginCharacterNameByAccountID(uint32 account_id, std::string c
 
 uint32 Perl__GetZoneIDByLongName(std::string zone_long_name)
 {
-	return zone_store.GetZoneIDByLongName(zone_long_name);
+	return ZoneStore::Instance()->GetZoneIDByLongName(zone_long_name);
 }
 
 std::string Perl__GetZoneShortNameByLongName(std::string zone_long_name)
 {
-	return zone_store.GetZoneShortNameByLongName(zone_long_name);
+	return ZoneStore::Instance()->GetZoneShortNameByLongName(zone_long_name);
 }
 
 bool Perl__send_parcel(perl::reference table_ref)

--- a/zone/gm_commands/set/zone.cpp
+++ b/zone/gm_commands/set/zone.cpp
@@ -273,7 +273,7 @@ void SetZoneData(Client *c, const Seperator *sep)
 		entity_list.QueueClients(c, outapp);
 		safe_delete(outapp);
 
-		zone_store.LoadZones(content_db);
+		ZoneStore::Instance()->LoadZones(content_db);
 
 		c->Message(
 			Chat::White,

--- a/zone/gm_commands/zone.cpp
+++ b/zone/gm_commands/zone.cpp
@@ -25,7 +25,7 @@ void command_zone(Client *c, const Seperator *sep)
 	}
 	else {
 		// validate
-		if (!zone_store.GetZone(zone_input)) {
+		if (!ZoneStore::Instance()->GetZone(zone_input)) {
 			c->Message(Chat::White, fmt::format("Could not find zone by short_name [{}]", zone_input).c_str());
 			return;
 		}

--- a/zone/gm_commands/zone_shard.cpp
+++ b/zone/gm_commands/zone_shard.cpp
@@ -31,7 +31,7 @@ void command_zone_shard(Client *c, const Seperator *sep)
 	}
 	else {
 		// validate
-		if (!zone_store.GetZone(zone_input)) {
+		if (!ZoneStore::Instance()->GetZone(zone_input)) {
 			c->Message(Chat::White, fmt::format("Could not find zone by short_name [{}]", zone_input).c_str());
 			return;
 		}

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -4157,607 +4157,607 @@ void lua_send_player_handin_event()
 
 float lua_get_zone_safe_x(uint32 zone_id)
 {
-	return zone_store.GetZoneSafeCoordinates(zone_id).x;
+	return ZoneStore::Instance()->GetZoneSafeCoordinates(zone_id).x;
 }
 
 float lua_get_zone_safe_x(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneSafeCoordinates(zone_id, version).x;
+	return ZoneStore::Instance()->GetZoneSafeCoordinates(zone_id, version).x;
 }
 
 float lua_get_zone_safe_y(uint32 zone_id)
 {
-	return zone_store.GetZoneSafeCoordinates(zone_id).y;
+	return ZoneStore::Instance()->GetZoneSafeCoordinates(zone_id).y;
 }
 
 float lua_get_zone_safe_y(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneSafeCoordinates(zone_id, version).y;
+	return ZoneStore::Instance()->GetZoneSafeCoordinates(zone_id, version).y;
 }
 
 float lua_get_zone_safe_z(uint32 zone_id)
 {
-	return zone_store.GetZoneSafeCoordinates(zone_id).z;
+	return ZoneStore::Instance()->GetZoneSafeCoordinates(zone_id).z;
 }
 
 float lua_get_zone_safe_z(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneSafeCoordinates(zone_id, version).z;
+	return ZoneStore::Instance()->GetZoneSafeCoordinates(zone_id, version).z;
 }
 
 float lua_get_zone_safe_heading(uint32 zone_id)
 {
-	return zone_store.GetZoneSafeCoordinates(zone_id).w;
+	return ZoneStore::Instance()->GetZoneSafeCoordinates(zone_id).w;
 }
 
 float lua_get_zone_safe_heading(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneSafeCoordinates(zone_id, version).w;
+	return ZoneStore::Instance()->GetZoneSafeCoordinates(zone_id, version).w;
 }
 
 float lua_get_zone_graveyard_id(uint32 zone_id)
 {
-	return zone_store.GetZoneGraveyardID(zone_id);
+	return ZoneStore::Instance()->GetZoneGraveyardID(zone_id);
 }
 
 float lua_get_zone_graveyard_id(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneGraveyardID(zone_id, version);
+	return ZoneStore::Instance()->GetZoneGraveyardID(zone_id, version);
 }
 
 uint8 lua_get_zone_minimum_level(uint32 zone_id)
 {
-	return zone_store.GetZoneMinimumLevel(zone_id);
+	return ZoneStore::Instance()->GetZoneMinimumLevel(zone_id);
 }
 
 uint8 lua_get_zone_minimum_level(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneMinimumLevel(zone_id, version);
+	return ZoneStore::Instance()->GetZoneMinimumLevel(zone_id, version);
 }
 
 uint8 lua_get_zone_maximum_level(uint32 zone_id)
 {
-	return zone_store.GetZoneMaximumLevel(zone_id);
+	return ZoneStore::Instance()->GetZoneMaximumLevel(zone_id);
 }
 
 uint8 lua_get_zone_maximum_level(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneMaximumLevel(zone_id, version);
+	return ZoneStore::Instance()->GetZoneMaximumLevel(zone_id, version);
 }
 
 uint8 lua_get_zone_minimum_status(uint32 zone_id)
 {
-	return zone_store.GetZoneMinimumStatus(zone_id);
+	return ZoneStore::Instance()->GetZoneMinimumStatus(zone_id);
 }
 
 uint8 lua_get_zone_minimum_status(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneMinimumStatus(zone_id, version);
+	return ZoneStore::Instance()->GetZoneMinimumStatus(zone_id, version);
 }
 
 int lua_get_zone_time_zone(uint32 zone_id)
 {
-	return zone_store.GetZoneTimeZone(zone_id);
+	return ZoneStore::Instance()->GetZoneTimeZone(zone_id);
 }
 
 int lua_get_zone_time_zone(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneTimeZone(zone_id, version);
+	return ZoneStore::Instance()->GetZoneTimeZone(zone_id, version);
 }
 
 int lua_get_zone_maximum_players(uint32 zone_id)
 {
-	return zone_store.GetZoneMaximumPlayers(zone_id);
+	return ZoneStore::Instance()->GetZoneMaximumPlayers(zone_id);
 }
 
 int lua_get_zone_maximum_players(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneMaximumPlayers(zone_id, version);
+	return ZoneStore::Instance()->GetZoneMaximumPlayers(zone_id, version);
 }
 
 uint32 lua_get_zone_rule_set(uint32 zone_id)
 {
-	return zone_store.GetZoneRuleSet(zone_id);
+	return ZoneStore::Instance()->GetZoneRuleSet(zone_id);
 }
 
 uint32 lua_get_zone_rule_set(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneRuleSet(zone_id, version);
+	return ZoneStore::Instance()->GetZoneRuleSet(zone_id, version);
 }
 
 std::string lua_get_zone_note(uint32 zone_id)
 {
-	return zone_store.GetZoneNote(zone_id);
+	return ZoneStore::Instance()->GetZoneNote(zone_id);
 }
 
 std::string lua_get_zone_note(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneNote(zone_id, version);
+	return ZoneStore::Instance()->GetZoneNote(zone_id, version);
 }
 
 float lua_get_zone_underworld(uint32 zone_id)
 {
-	return zone_store.GetZoneUnderworld(zone_id);
+	return ZoneStore::Instance()->GetZoneUnderworld(zone_id);
 }
 
 float lua_get_zone_underworld(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneUnderworld(zone_id, version);
+	return ZoneStore::Instance()->GetZoneUnderworld(zone_id, version);
 }
 
 float lua_get_zone_minimum_clip(uint32 zone_id)
 {
-	return zone_store.GetZoneMinimumClip(zone_id);
+	return ZoneStore::Instance()->GetZoneMinimumClip(zone_id);
 }
 
 float lua_get_zone_minimum_clip(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneMinimumClip(zone_id, version);
+	return ZoneStore::Instance()->GetZoneMinimumClip(zone_id, version);
 }
 
 float lua_get_zone_maximum_clip(uint32 zone_id)
 {
-	return zone_store.GetZoneMaximumClip(zone_id);
+	return ZoneStore::Instance()->GetZoneMaximumClip(zone_id);
 }
 
 float lua_get_zone_maximum_clip(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneMaximumClip(zone_id, version);
+	return ZoneStore::Instance()->GetZoneMaximumClip(zone_id, version);
 }
 
 float lua_get_zone_fog_minimum_clip(uint32 zone_id)
 {
-	return zone_store.GetZoneFogMinimumClip(zone_id);
+	return ZoneStore::Instance()->GetZoneFogMinimumClip(zone_id);
 }
 
 float lua_get_zone_fog_minimum_clip(uint32 zone_id, uint8 slot)
 {
-	return zone_store.GetZoneFogMinimumClip(zone_id, slot);
+	return ZoneStore::Instance()->GetZoneFogMinimumClip(zone_id, slot);
 }
 
 float lua_get_zone_fog_minimum_clip(uint32 zone_id, uint8 slot, int version)
 {
-	return zone_store.GetZoneFogMinimumClip(zone_id, slot);
+	return ZoneStore::Instance()->GetZoneFogMinimumClip(zone_id, slot);
 }
 
 float lua_get_zone_fog_maximum_clip(uint32 zone_id)
 {
-	return zone_store.GetZoneFogMaximumClip(zone_id);
+	return ZoneStore::Instance()->GetZoneFogMaximumClip(zone_id);
 }
 
 float lua_get_zone_fog_maximum_clip(uint32 zone_id, uint8 slot)
 {
-	return zone_store.GetZoneFogMaximumClip(zone_id, slot);
+	return ZoneStore::Instance()->GetZoneFogMaximumClip(zone_id, slot);
 }
 
 float lua_get_zone_fog_maximum_clip(uint32 zone_id, uint8 slot, int version)
 {
-	return zone_store.GetZoneFogMaximumClip(zone_id, slot, version);
+	return ZoneStore::Instance()->GetZoneFogMaximumClip(zone_id, slot, version);
 }
 
 uint8 lua_get_zone_fog_red(uint32 zone_id)
 {
-	return zone_store.GetZoneFogRed(zone_id);
+	return ZoneStore::Instance()->GetZoneFogRed(zone_id);
 }
 
 uint8 lua_get_zone_fog_red(uint32 zone_id, uint8 slot)
 {
-	return zone_store.GetZoneFogRed(zone_id, slot);
+	return ZoneStore::Instance()->GetZoneFogRed(zone_id, slot);
 }
 
 uint8 lua_get_zone_fog_red(uint32 zone_id, uint8 slot, int version)
 {
-	return zone_store.GetZoneFogRed(zone_id, slot, version);
+	return ZoneStore::Instance()->GetZoneFogRed(zone_id, slot, version);
 }
 
 uint8 lua_get_zone_fog_green(uint32 zone_id)
 {
-	return zone_store.GetZoneFogGreen(zone_id);
+	return ZoneStore::Instance()->GetZoneFogGreen(zone_id);
 }
 
 uint8 lua_get_zone_fog_green(uint32 zone_id, uint8 slot)
 {
-	return zone_store.GetZoneFogGreen(zone_id, slot);
+	return ZoneStore::Instance()->GetZoneFogGreen(zone_id, slot);
 }
 
 uint8 lua_get_zone_fog_green(uint32 zone_id, uint8 slot, int version)
 {
-	return zone_store.GetZoneFogGreen(zone_id, slot, version);
+	return ZoneStore::Instance()->GetZoneFogGreen(zone_id, slot, version);
 }
 
 uint8 lua_get_zone_fog_blue(uint32 zone_id)
 {
-	return zone_store.GetZoneFogBlue(zone_id);
+	return ZoneStore::Instance()->GetZoneFogBlue(zone_id);
 }
 
 uint8 lua_get_zone_fog_blue(uint32 zone_id, uint8 slot)
 {
-	return zone_store.GetZoneFogBlue(zone_id, slot);
+	return ZoneStore::Instance()->GetZoneFogBlue(zone_id, slot);
 }
 
 uint8 lua_get_zone_fog_blue(uint32 zone_id, uint8 slot, int version)
 {
-	return zone_store.GetZoneFogBlue(zone_id, slot, version);
+	return ZoneStore::Instance()->GetZoneFogBlue(zone_id, slot, version);
 }
 
 uint8 lua_get_zone_sky(uint32 zone_id)
 {
-	return zone_store.GetZoneSky(zone_id);
+	return ZoneStore::Instance()->GetZoneSky(zone_id);
 }
 
 uint8 lua_get_zone_sky(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneSky(zone_id, version);
+	return ZoneStore::Instance()->GetZoneSky(zone_id, version);
 }
 
 uint8 lua_get_zone_ztype(uint32 zone_id)
 {
-	return zone_store.GetZoneZType(zone_id);
+	return ZoneStore::Instance()->GetZoneZType(zone_id);
 }
 
 uint8 lua_get_zone_ztype(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneZType(zone_id, version);
+	return ZoneStore::Instance()->GetZoneZType(zone_id, version);
 }
 
 float lua_get_zone_experience_multiplier(uint32 zone_id)
 {
-	return zone_store.GetZoneExperienceMultiplier(zone_id);
+	return ZoneStore::Instance()->GetZoneExperienceMultiplier(zone_id);
 }
 
 float lua_get_zone_experience_multiplier(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneExperienceMultiplier(zone_id, version);
+	return ZoneStore::Instance()->GetZoneExperienceMultiplier(zone_id, version);
 }
 
 float lua_get_zone_walk_speed(uint32 zone_id)
 {
-	return zone_store.GetZoneWalkSpeed(zone_id);
+	return ZoneStore::Instance()->GetZoneWalkSpeed(zone_id);
 }
 
 float lua_get_zone_walk_speed(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneWalkSpeed(zone_id, version);
+	return ZoneStore::Instance()->GetZoneWalkSpeed(zone_id, version);
 }
 
 uint8 lua_get_zone_time_type(uint32 zone_id)
 {
-	return zone_store.GetZoneTimeType(zone_id);
+	return ZoneStore::Instance()->GetZoneTimeType(zone_id);
 }
 
 uint8 lua_get_zone_time_type(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneTimeType(zone_id, version);
+	return ZoneStore::Instance()->GetZoneTimeType(zone_id, version);
 }
 
 float lua_get_zone_fog_density(uint32 zone_id)
 {
-	return zone_store.GetZoneFogDensity(zone_id);
+	return ZoneStore::Instance()->GetZoneFogDensity(zone_id);
 }
 
 float lua_get_zone_fog_density(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneFogDensity(zone_id, version);
+	return ZoneStore::Instance()->GetZoneFogDensity(zone_id, version);
 }
 
 std::string lua_get_zone_flag_needed(uint32 zone_id)
 {
-	return zone_store.GetZoneFlagNeeded(zone_id);
+	return ZoneStore::Instance()->GetZoneFlagNeeded(zone_id);
 }
 
 std::string lua_get_zone_flag_needed(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneFlagNeeded(zone_id, version);
+	return ZoneStore::Instance()->GetZoneFlagNeeded(zone_id, version);
 }
 
 int8 lua_get_zone_can_bind(uint32 zone_id)
 {
-	return zone_store.GetZoneCanBind(zone_id);
+	return ZoneStore::Instance()->GetZoneCanBind(zone_id);
 }
 
 int8 lua_get_zone_can_bind(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneCanBind(zone_id, version);
+	return ZoneStore::Instance()->GetZoneCanBind(zone_id, version);
 }
 
 int8 lua_get_zone_can_combat(uint32 zone_id)
 {
-	return zone_store.GetZoneCanCombat(zone_id);
+	return ZoneStore::Instance()->GetZoneCanCombat(zone_id);
 }
 
 int8 lua_get_zone_can_combat(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneCanCombat(zone_id, version);
+	return ZoneStore::Instance()->GetZoneCanCombat(zone_id, version);
 }
 
 int8 lua_get_zone_can_levitate(uint32 zone_id)
 {
-	return zone_store.GetZoneCanLevitate(zone_id);
+	return ZoneStore::Instance()->GetZoneCanLevitate(zone_id);
 }
 
 int8 lua_get_zone_can_levitate(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneCanLevitate(zone_id, version);
+	return ZoneStore::Instance()->GetZoneCanLevitate(zone_id, version);
 }
 
 int8 lua_get_zone_cast_outdoor(uint32 zone_id)
 {
-	return zone_store.GetZoneCastOutdoor(zone_id);
+	return ZoneStore::Instance()->GetZoneCastOutdoor(zone_id);
 }
 
 int8 lua_get_zone_cast_outdoor(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneCastOutdoor(zone_id, version);
+	return ZoneStore::Instance()->GetZoneCastOutdoor(zone_id, version);
 }
 
 uint8 lua_get_zone_hotzone(uint32 zone_id)
 {
-	return zone_store.GetZoneHotzone(zone_id);
+	return ZoneStore::Instance()->GetZoneHotzone(zone_id);
 }
 
 uint8 lua_get_zone_hotzone(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneHotzone(zone_id, version);
+	return ZoneStore::Instance()->GetZoneHotzone(zone_id, version);
 }
 
 uint8 lua_get_zone_instance_type(uint32 zone_id)
 {
-	return zone_store.GetZoneInstanceType(zone_id);
+	return ZoneStore::Instance()->GetZoneInstanceType(zone_id);
 }
 
 uint8 lua_get_zone_instance_type(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneInstanceType(zone_id, version);
+	return ZoneStore::Instance()->GetZoneInstanceType(zone_id, version);
 }
 
 uint64 lua_get_zone_shutdown_delay(uint32 zone_id)
 {
-	return zone_store.GetZoneShutdownDelay(zone_id);
+	return ZoneStore::Instance()->GetZoneShutdownDelay(zone_id);
 }
 
 uint64 lua_get_zone_shutdown_delay(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneShutdownDelay(zone_id, version);
+	return ZoneStore::Instance()->GetZoneShutdownDelay(zone_id, version);
 }
 
 int8 lua_get_zone_peqzone(uint32 zone_id)
 {
-	return zone_store.GetZonePEQZone(zone_id);
+	return ZoneStore::Instance()->GetZonePEQZone(zone_id);
 }
 
 int8 lua_get_zone_peqzone(uint32 zone_id, int version)
 {
-	return zone_store.GetZonePEQZone(zone_id, version);
+	return ZoneStore::Instance()->GetZonePEQZone(zone_id, version);
 }
 
 int8 lua_get_zone_expansion(uint32 zone_id)
 {
-	return zone_store.GetZoneExpansion(zone_id);
+	return ZoneStore::Instance()->GetZoneExpansion(zone_id);
 }
 
 int8 lua_get_zone_expansion(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneExpansion(zone_id, version);
+	return ZoneStore::Instance()->GetZoneExpansion(zone_id, version);
 }
 
 int8 lua_get_zone_bypass_expansion_check(uint32 zone_id)
 {
-	return zone_store.GetZoneBypassExpansionCheck(zone_id);
+	return ZoneStore::Instance()->GetZoneBypassExpansionCheck(zone_id);
 }
 
 int8 lua_get_zone_bypass_expansion_check(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneBypassExpansionCheck(zone_id, version);
+	return ZoneStore::Instance()->GetZoneBypassExpansionCheck(zone_id, version);
 }
 
 int8 lua_get_zone_suspend_buffs(uint32 zone_id)
 {
-	return zone_store.GetZoneSuspendBuffs(zone_id);
+	return ZoneStore::Instance()->GetZoneSuspendBuffs(zone_id);
 }
 
 int8 lua_get_zone_suspend_buffs(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneSuspendBuffs(zone_id, version);
+	return ZoneStore::Instance()->GetZoneSuspendBuffs(zone_id, version);
 }
 
 int lua_get_zone_rain_chance(uint32 zone_id)
 {
-	return zone_store.GetZoneRainChance(zone_id);
+	return ZoneStore::Instance()->GetZoneRainChance(zone_id);
 }
 
 int lua_get_zone_rain_chance(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneRainChance(zone_id, version);
+	return ZoneStore::Instance()->GetZoneRainChance(zone_id, version);
 }
 
 int lua_get_zone_rain_duration(uint32 zone_id)
 {
-	return zone_store.GetZoneRainDuration(zone_id);
+	return ZoneStore::Instance()->GetZoneRainDuration(zone_id);
 }
 
 int lua_get_zone_rain_duration(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneRainDuration(zone_id, version);
+	return ZoneStore::Instance()->GetZoneRainDuration(zone_id, version);
 }
 
 int lua_get_zone_snow_chance(uint32 zone_id)
 {
-	return zone_store.GetZoneSnowChance(zone_id);
+	return ZoneStore::Instance()->GetZoneSnowChance(zone_id);
 }
 
 int lua_get_zone_snow_chance(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneSnowChance(zone_id, version);
+	return ZoneStore::Instance()->GetZoneSnowChance(zone_id, version);
 }
 
 int lua_get_zone_snow_duration(uint32 zone_id)
 {
-	return zone_store.GetZoneSnowDuration(zone_id);
+	return ZoneStore::Instance()->GetZoneSnowDuration(zone_id);
 }
 
 int lua_get_zone_snow_duration(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneSnowDuration(zone_id, version);
+	return ZoneStore::Instance()->GetZoneSnowDuration(zone_id, version);
 }
 
 float lua_get_zone_gravity(uint32 zone_id)
 {
-	return zone_store.GetZoneGravity(zone_id);
+	return ZoneStore::Instance()->GetZoneGravity(zone_id);
 }
 
 float lua_get_zone_gravity(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneGravity(zone_id, version);
+	return ZoneStore::Instance()->GetZoneGravity(zone_id, version);
 }
 
 int lua_get_zone_type(uint32 zone_id)
 {
-	return zone_store.GetZoneType(zone_id);
+	return ZoneStore::Instance()->GetZoneType(zone_id);
 }
 
 int lua_get_zone_type(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneType(zone_id, version);
+	return ZoneStore::Instance()->GetZoneType(zone_id, version);
 }
 
 int lua_get_zone_sky_lock(uint32 zone_id)
 {
-	return zone_store.GetZoneSkyLock(zone_id);
+	return ZoneStore::Instance()->GetZoneSkyLock(zone_id);
 }
 
 int lua_get_zone_sky_lock(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneSkyLock(zone_id, version);
+	return ZoneStore::Instance()->GetZoneSkyLock(zone_id, version);
 }
 
 int lua_get_zone_fast_regen_hp(uint32 zone_id)
 {
-	return zone_store.GetZoneFastRegenHP(zone_id);
+	return ZoneStore::Instance()->GetZoneFastRegenHP(zone_id);
 }
 
 int lua_get_zone_fast_regen_hp(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneFastRegenHP(zone_id, version);
+	return ZoneStore::Instance()->GetZoneFastRegenHP(zone_id, version);
 }
 
 int lua_get_zone_fast_regen_mana(uint32 zone_id)
 {
-	return zone_store.GetZoneFastRegenMana(zone_id);
+	return ZoneStore::Instance()->GetZoneFastRegenMana(zone_id);
 }
 
 int lua_get_zone_fast_regen_mana(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneFastRegenMana(zone_id, version);
+	return ZoneStore::Instance()->GetZoneFastRegenMana(zone_id, version);
 }
 
 int lua_get_zone_fast_regen_endurance(uint32 zone_id)
 {
-	return zone_store.GetZoneFastRegenEndurance(zone_id);
+	return ZoneStore::Instance()->GetZoneFastRegenEndurance(zone_id);
 }
 
 int lua_get_zone_fast_regen_endurance(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneFastRegenEndurance(zone_id, version);
+	return ZoneStore::Instance()->GetZoneFastRegenEndurance(zone_id, version);
 }
 
 int lua_get_zone_npc_maximum_aggro_distance(uint32 zone_id)
 {
-	return zone_store.GetZoneNPCMaximumAggroDistance(zone_id);
+	return ZoneStore::Instance()->GetZoneNPCMaximumAggroDistance(zone_id);
 }
 
 int lua_get_zone_npc_maximum_aggro_distance(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneNPCMaximumAggroDistance(zone_id, version);
+	return ZoneStore::Instance()->GetZoneNPCMaximumAggroDistance(zone_id, version);
 }
 
 int8 lua_get_zone_minimum_expansion(uint32 zone_id)
 {
-	return zone_store.GetZoneMinimumExpansion(zone_id);
+	return ZoneStore::Instance()->GetZoneMinimumExpansion(zone_id);
 }
 
 int8 lua_get_zone_minimum_expansion(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneMinimumExpansion(zone_id, version);
+	return ZoneStore::Instance()->GetZoneMinimumExpansion(zone_id, version);
 }
 
 int8 lua_get_zone_maximum_expansion(uint32 zone_id)
 {
-	return zone_store.GetZoneMaximumExpansion(zone_id);
+	return ZoneStore::Instance()->GetZoneMaximumExpansion(zone_id);
 }
 
 int8 lua_get_zone_maximum_expansion(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneMaximumExpansion(zone_id, version);
+	return ZoneStore::Instance()->GetZoneMaximumExpansion(zone_id, version);
 }
 
 std::string lua_get_zone_content_flags(uint32 zone_id)
 {
-	return zone_store.GetZoneContentFlags(zone_id);
+	return ZoneStore::Instance()->GetZoneContentFlags(zone_id);
 }
 
 std::string lua_get_zone_content_flags(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneContentFlags(zone_id, version);
+	return ZoneStore::Instance()->GetZoneContentFlags(zone_id, version);
 }
 
 std::string lua_get_zone_content_flags_disabled(uint32 zone_id)
 {
-	return zone_store.GetZoneContentFlagsDisabled(zone_id);
+	return ZoneStore::Instance()->GetZoneContentFlagsDisabled(zone_id);
 }
 
 std::string lua_get_zone_content_flags_disabled(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneContentFlagsDisabled(zone_id, version);
+	return ZoneStore::Instance()->GetZoneContentFlagsDisabled(zone_id, version);
 }
 
 int lua_get_zone_underworld_teleport_index(uint32 zone_id)
 {
-	return zone_store.GetZoneUnderworldTeleportIndex(zone_id);
+	return ZoneStore::Instance()->GetZoneUnderworldTeleportIndex(zone_id);
 }
 
 int lua_get_zone_underworld_teleport_index(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneUnderworldTeleportIndex(zone_id, version);
+	return ZoneStore::Instance()->GetZoneUnderworldTeleportIndex(zone_id, version);
 }
 
 int lua_get_zone_lava_damage(uint32 zone_id)
 {
-	return zone_store.GetZoneLavaDamage(zone_id);
+	return ZoneStore::Instance()->GetZoneLavaDamage(zone_id);
 }
 
 int lua_get_zone_lava_damage(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneLavaDamage(zone_id, version);
+	return ZoneStore::Instance()->GetZoneLavaDamage(zone_id, version);
 }
 
 int lua_get_zone_minimum_lava_damage(uint32 zone_id)
 {
-	return zone_store.GetZoneMinimumLavaDamage(zone_id);
+	return ZoneStore::Instance()->GetZoneMinimumLavaDamage(zone_id);
 }
 
 int lua_get_zone_minimum_lava_damage(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneMinimumLavaDamage(zone_id, version);
+	return ZoneStore::Instance()->GetZoneMinimumLavaDamage(zone_id, version);
 }
 
 uint8 lua_get_zone_idle_when_empty(uint32 zone_id)
 {
-	return zone_store.GetZoneIdleWhenEmpty(zone_id);
+	return ZoneStore::Instance()->GetZoneIdleWhenEmpty(zone_id);
 }
 
 uint8 lua_get_zone_idle_when_empty(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneIdleWhenEmpty(zone_id, version);
+	return ZoneStore::Instance()->GetZoneIdleWhenEmpty(zone_id, version);
 }
 
 uint32 lua_get_zone_seconds_before_idle(uint32 zone_id)
 {
-	return zone_store.GetZoneSecondsBeforeIdle(zone_id);
+	return ZoneStore::Instance()->GetZoneSecondsBeforeIdle(zone_id);
 }
 
 uint32 lua_get_zone_seconds_before_idle(uint32 zone_id, int version)
 {
-	return zone_store.GetZoneSecondsBeforeIdle(zone_id, version);
+	return ZoneStore::Instance()->GetZoneSecondsBeforeIdle(zone_id, version);
 }
 
 void lua_send_channel_message(uint8 channel_number, uint32 guild_id, uint8 language_id, uint8 language_skill, const char* message)
@@ -5497,11 +5497,11 @@ bool lua_set_auto_login_character_name_by_account_id(uint32 account_id, std::str
 }
 
 uint32 lua_get_zone_id_by_long_name(std::string zone_long_name) {
-	return zone_store.GetZoneIDByLongName(zone_long_name);
+	return ZoneStore::Instance()->GetZoneIDByLongName(zone_long_name);
 }
 
 std::string lua_get_zone_short_name_by_long_name(std::string zone_long_name) {
-	return zone_store.GetZoneShortNameByLongName(zone_long_name);
+	return ZoneStore::Instance()->GetZoneShortNameByLongName(zone_long_name);
 }
 
 bool lua_send_parcel(luabind::object lua_table)

--- a/zone/lua_zone.cpp
+++ b/zone/lua_zone.cpp
@@ -16,7 +16,7 @@ bool Lua_Zone::BuffTimersSuspended()
 bool Lua_Zone::BypassesExpansionCheck()
 {
 	Lua_Safe_Call_Bool();
-	return zone_store.GetZoneBypassExpansionCheck(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneBypassExpansionCheck(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 bool Lua_Zone::CanBind()
@@ -88,25 +88,25 @@ float Lua_Zone::GetAAEXPModifierByCharacterID(uint32 character_id)
 std::string Lua_Zone::GetContentFlags()
 {
 	Lua_Safe_Call_String();
-	return zone_store.GetZoneContentFlags(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneContentFlags(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 std::string Lua_Zone::GetContentFlagsDisabled()
 {
 	Lua_Safe_Call_String();
-	return zone_store.GetZoneContentFlagsDisabled(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneContentFlagsDisabled(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 float Lua_Zone::GetExperienceMultiplier()
 {
 	Lua_Safe_Call_Real();
-	return zone_store.GetZoneExperienceMultiplier(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneExperienceMultiplier(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int8 Lua_Zone::GetExpansion()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneExpansion(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneExpansion(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 float Lua_Zone::GetEXPModifier(Lua_Client c)
@@ -124,19 +124,19 @@ float Lua_Zone::GetEXPModifierByCharacterID(uint32 character_id)
 int Lua_Zone::GetFastRegenEndurance()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneFastRegenEndurance(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneFastRegenEndurance(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int Lua_Zone::GetFastRegenHP()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneFastRegenHP(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneFastRegenHP(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int Lua_Zone::GetFastRegenMana()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneFastRegenMana(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneFastRegenMana(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 std::string Lua_Zone::GetFileName()
@@ -148,73 +148,73 @@ std::string Lua_Zone::GetFileName()
 std::string Lua_Zone::GetFlagNeeded()
 {
 	Lua_Safe_Call_String();
-	return zone_store.GetZoneFlagNeeded(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneFlagNeeded(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 uint8 Lua_Zone::GetFogBlue()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneFogBlue(self->GetZoneID(), 0, self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneFogBlue(self->GetZoneID(), 0, self->GetInstanceVersion());
 }
 
 uint8 Lua_Zone::GetFogBlue(uint8 slot)
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneFogBlue(self->GetZoneID(), slot, self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneFogBlue(self->GetZoneID(), slot, self->GetInstanceVersion());
 }
 
 float Lua_Zone::GetFogDensity()
 {
 	Lua_Safe_Call_Real();
-	return zone_store.GetZoneFogDensity(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneFogDensity(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 uint8 Lua_Zone::GetFogGreen()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneFogGreen(self->GetZoneID(), 0, self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneFogGreen(self->GetZoneID(), 0, self->GetInstanceVersion());
 }
 
 uint8 Lua_Zone::GetFogGreen(uint8 slot)
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneFogGreen(self->GetZoneID(), slot, self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneFogGreen(self->GetZoneID(), slot, self->GetInstanceVersion());
 }
 
 float Lua_Zone::GetFogMaximumClip()
 {
 	Lua_Safe_Call_Real();
-	return zone_store.GetZoneFogMaximumClip(self->GetZoneID(), 0, self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneFogMaximumClip(self->GetZoneID(), 0, self->GetInstanceVersion());
 }
 
 float Lua_Zone::GetFogMaximumClip(uint8 slot)
 {
 	Lua_Safe_Call_Real();
-	return zone_store.GetZoneFogMaximumClip(self->GetZoneID(), slot, self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneFogMaximumClip(self->GetZoneID(), slot, self->GetInstanceVersion());
 }
 
 float Lua_Zone::GetFogMinimumClip()
 {
 	Lua_Safe_Call_Real();
-	return zone_store.GetZoneFogMinimumClip(self->GetZoneID(), 0, self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneFogMinimumClip(self->GetZoneID(), 0, self->GetInstanceVersion());
 }
 
 float Lua_Zone::GetFogMinimumClip(uint8 slot)
 {
 	Lua_Safe_Call_Real();
-	return zone_store.GetZoneFogMinimumClip(self->GetZoneID(), slot, self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneFogMinimumClip(self->GetZoneID(), slot, self->GetInstanceVersion());
 }
 
 uint8 Lua_Zone::GetFogRed()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneFogRed(self->GetZoneID(), 0, self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneFogRed(self->GetZoneID(), 0, self->GetInstanceVersion());
 }
 
 uint8 Lua_Zone::GetFogRed(uint8 slot)
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneFogRed(self->GetZoneID(), slot, self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneFogRed(self->GetZoneID(), slot, self->GetInstanceVersion());
 }
 
 float Lua_Zone::GetGraveyardHeading()
@@ -256,7 +256,7 @@ uint32 Lua_Zone::GetGraveyardZoneID()
 float Lua_Zone::GetGravity()
 {
 	Lua_Safe_Call_Real();
-	return zone_store.GetZoneGravity(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneGravity(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 uint32 Lua_Zone::GetInstanceID()
@@ -268,7 +268,7 @@ uint32 Lua_Zone::GetInstanceID()
 uint8 Lua_Zone::GetInstanceType()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneInstanceType(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneInstanceType(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 uint16 Lua_Zone::GetInstanceVersion()
@@ -286,7 +286,7 @@ uint32 Lua_Zone::GetInstanceTimeRemaining()
 int Lua_Zone::GetLavaDamage()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneLavaDamage(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneLavaDamage(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 std::string Lua_Zone::GetLongName()
@@ -298,19 +298,19 @@ std::string Lua_Zone::GetLongName()
 float Lua_Zone::GetMaximumClip()
 {
 	Lua_Safe_Call_Real();
-	return zone_store.GetZoneMaximumClip(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneMaximumClip(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int8 Lua_Zone::GetMaximumExpansion()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneMaximumExpansion(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneMaximumExpansion(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 uint8 Lua_Zone::GetMaximumLevel()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneMaximumLevel(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneMaximumLevel(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 uint32 Lua_Zone::GetMaxClients()
@@ -322,79 +322,79 @@ uint32 Lua_Zone::GetMaxClients()
 float Lua_Zone::GetMinimumClip()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneMinimumClip(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneMinimumClip(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int8 Lua_Zone::GetMinimumExpansion()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneMinimumExpansion(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneMinimumExpansion(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 uint8 Lua_Zone::GetMinimumLevel()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneMinimumLevel(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneMinimumLevel(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int Lua_Zone::GetMinimumLavaDamage()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneMinimumLavaDamage(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneMinimumLavaDamage(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 uint8 Lua_Zone::GetMinimumStatus()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneMinimumStatus(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneMinimumStatus(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 std::string Lua_Zone::GetNote()
 {
 	Lua_Safe_Call_String();
-	return zone_store.GetZoneNote(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneNote(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int Lua_Zone::GetNPCMaximumAggroDistance()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneNPCMaximumAggroDistance(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneNPCMaximumAggroDistance(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int8 Lua_Zone::GetPEQZone()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZonePEQZone(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZonePEQZone(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int Lua_Zone::GetRainChance()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneRainChance(self->GetZoneID(), 0, self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneRainChance(self->GetZoneID(), 0, self->GetInstanceVersion());
 }
 
 int Lua_Zone::GetRainChance(uint8 slot)
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneRainChance(self->GetZoneID(), slot, self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneRainChance(self->GetZoneID(), slot, self->GetInstanceVersion());
 }
 
 int Lua_Zone::GetRainDuration()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneRainDuration(self->GetZoneID(), 0, self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneRainDuration(self->GetZoneID(), 0, self->GetInstanceVersion());
 }
 
 int Lua_Zone::GetRainDuration(uint8 slot)
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneRainDuration(self->GetZoneID(), slot, self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneRainDuration(self->GetZoneID(), slot, self->GetInstanceVersion());
 }
 
 uint32 Lua_Zone::GetRuleSet()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneRuleSet(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneRuleSet(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 float Lua_Zone::GetSafeHeading()
@@ -436,55 +436,55 @@ uint32 Lua_Zone::GetSecondsBeforeIdle()
 uint64 Lua_Zone::GetShutdownDelay()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneShutdownDelay(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneShutdownDelay(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 uint8 Lua_Zone::GetSky()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneSky(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneSky(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int8 Lua_Zone::GetSkyLock()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneSkyLock(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneSkyLock(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int Lua_Zone::GetSnowChance()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneSnowChance(self->GetZoneID(), 0, self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneSnowChance(self->GetZoneID(), 0, self->GetInstanceVersion());
 }
 
 int Lua_Zone::GetSnowChance(uint8 slot)
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneSnowChance(self->GetZoneID(), slot, self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneSnowChance(self->GetZoneID(), slot, self->GetInstanceVersion());
 }
 
 int Lua_Zone::GetSnowDuration()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneSnowDuration(self->GetZoneID(), 0, self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneSnowDuration(self->GetZoneID(), 0, self->GetInstanceVersion());
 }
 
 int Lua_Zone::GetSnowDuration(uint8 slot)
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneSnowDuration(self->GetZoneID(), slot, self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneSnowDuration(self->GetZoneID(), slot, self->GetInstanceVersion());
 }
 
 uint8 Lua_Zone::GetTimeType()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneTimeType(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneTimeType(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int Lua_Zone::GetTimeZone()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneTimeZone(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneTimeZone(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 std::string Lua_Zone::GetZoneDescription()
@@ -508,25 +508,25 @@ uint8 Lua_Zone::GetZoneType()
 float Lua_Zone::GetUnderworld()
 {
 	Lua_Safe_Call_Real();
-	return zone_store.GetZoneUnderworld(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneUnderworld(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int Lua_Zone::GetUnderworldTeleportIndex()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneUnderworldTeleportIndex(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneUnderworldTeleportIndex(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 float Lua_Zone::GetWalkSpeed()
 {
 	Lua_Safe_Call_Real();
-	return zone_store.GetZoneWalkSpeed(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneWalkSpeed(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 uint8 Lua_Zone::GetZoneZType()
 {
 	Lua_Safe_Call_Int();
-	return zone_store.GetZoneZType(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneZType(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int Lua_Zone::GetZoneTotalBlockedSpells()

--- a/zone/main.cpp
+++ b/zone/main.cpp
@@ -93,7 +93,6 @@ extern volatile bool is_zone_loaded;
 
 EntityList  entity_list;
 WorldServer worldserver;
-ZoneStore   zone_store;
 uint32      numclients = 0;
 char        errorname[32];
 extern Zone *zone;
@@ -367,9 +366,9 @@ int main(int argc, char **argv)
 		}
 	}
 
-	zone_store.LoadZones(content_db);
+	ZoneStore::Instance()->LoadZones(content_db);
 
-	if (zone_store.GetZones().empty()) {
+	if (ZoneStore::Instance()->GetZones().empty()) {
 		LogError("Failed to load zones data, check your schema for possible errors");
 		return 1;
 	}

--- a/zone/perl_zone.cpp
+++ b/zone/perl_zone.cpp
@@ -13,7 +13,7 @@ bool Perl_Zone_BuffTimersSuspended(Zone* self)
 
 bool Perl_Zone_BypassesExpansionCheck(Zone* self)
 {
-	return zone_store.GetZoneBypassExpansionCheck(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneBypassExpansionCheck(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 bool Perl_Zone_CanBind(Zone* self)
@@ -73,22 +73,22 @@ float Perl_Zone_GetAAEXPModifierByCharacterID(Zone* self, uint32 character_id)
 
 std::string Perl_Zone_GetContentFlags(Zone* self)
 {
-	return zone_store.GetZoneContentFlags(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneContentFlags(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 std::string Perl_Zone_GetContentFlagsDisabled(Zone* self)
 {
-	return zone_store.GetZoneContentFlagsDisabled(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneContentFlagsDisabled(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 float Perl_Zone_GetExperienceMultiplier(Zone* self)
 {
-	return zone_store.GetZoneExperienceMultiplier(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneExperienceMultiplier(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int8 Perl_Zone_GetExpansion(Zone* self)
 {
-	return zone_store.GetZoneExpansion(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneExpansion(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 float Perl_Zone_GetEXPModifier(Zone* self, Client* c)
@@ -103,17 +103,17 @@ float Perl_Zone_GetEXPModifierByCharacterID(Zone* self, uint32 character_id)
 
 int Perl_Zone_GetFastRegenEndurance(Zone* self)
 {
-	return zone_store.GetZoneFastRegenEndurance(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneFastRegenEndurance(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int Perl_Zone_GetFastRegenHP(Zone* self)
 {
-	return zone_store.GetZoneFastRegenHP(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneFastRegenHP(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int Perl_Zone_GetFastRegenMana(Zone* self)
 {
-	return zone_store.GetZoneFastRegenMana(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneFastRegenMana(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 std::string Perl_Zone_GetFileName(Zone* self)
@@ -123,37 +123,37 @@ std::string Perl_Zone_GetFileName(Zone* self)
 
 std::string Perl_Zone_GetFlagNeeded(Zone* self)
 {
-	return zone_store.GetZoneFlagNeeded(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneFlagNeeded(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 uint8 Perl_Zone_GetFogBlue(Zone* self, uint8 slot = 0)
 {
-	return zone_store.GetZoneFogBlue(self->GetZoneID(), slot, self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneFogBlue(self->GetZoneID(), slot, self->GetInstanceVersion());
 }
 
 float Perl_Zone_GetFogDensity(Zone* self)
 {
-	return zone_store.GetZoneFogDensity(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneFogDensity(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 uint8 Perl_Zone_GetFogGreen(Zone* self, uint8 slot = 0)
 {
-	return zone_store.GetZoneFogGreen(self->GetZoneID(), slot, self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneFogGreen(self->GetZoneID(), slot, self->GetInstanceVersion());
 }
 
 float Perl_Zone_GetFogMaximumClip(Zone* self, uint8 slot = 0)
 {
-	return zone_store.GetZoneFogMaximumClip(self->GetZoneID(), slot, self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneFogMaximumClip(self->GetZoneID(), slot, self->GetInstanceVersion());
 }
 
 float Perl_Zone_GetFogMinimumClip(Zone* self, uint8 slot = 0)
 {
-	return zone_store.GetZoneFogMinimumClip(self->GetZoneID(), slot, self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneFogMinimumClip(self->GetZoneID(), slot, self->GetInstanceVersion());
 }
 
 uint8 Perl_Zone_GetFogRed(Zone* self, uint8 slot = 0)
 {
-	return zone_store.GetZoneFogRed(self->GetZoneID(), slot, self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneFogRed(self->GetZoneID(), slot, self->GetInstanceVersion());
 }
 
 float Perl_Zone_GetGraveyardHeading(Zone* self)
@@ -188,7 +188,7 @@ uint32 Perl_Zone_GetGraveyardZoneID(Zone* self)
 
 float Perl_Zone_GetGravity(Zone* self)
 {
-	return zone_store.GetZoneGravity(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneGravity(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 uint32 Perl_Zone_GetInstanceID(Zone* self)
@@ -198,7 +198,7 @@ uint32 Perl_Zone_GetInstanceID(Zone* self)
 
 uint8 Perl_Zone_GetInstanceType(Zone* self)
 {
-	return zone_store.GetZoneInstanceType(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneInstanceType(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 uint16 Perl_Zone_GetInstanceVersion(Zone* self)
@@ -213,7 +213,7 @@ uint32 Perl_Zone_GetInstanceTimeRemaining(Zone* self)
 
 int Perl_Zone_GetLavaDamage(Zone* self)
 {
-	return zone_store.GetZoneLavaDamage(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneLavaDamage(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 std::string Perl_Zone_GetLongName(Zone* self)
@@ -223,17 +223,17 @@ std::string Perl_Zone_GetLongName(Zone* self)
 
 float Perl_Zone_GetMaximumClip(Zone* self)
 {
-	return zone_store.GetZoneMaximumClip(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneMaximumClip(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int8 Perl_Zone_GetMaximumExpansion(Zone* self)
 {
-	return zone_store.GetZoneMaximumExpansion(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneMaximumExpansion(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 uint8 Perl_Zone_GetMaximumLevel(Zone* self)
 {
-	return zone_store.GetZoneMaximumLevel(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneMaximumLevel(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 uint32 Perl_Zone_GetMaxClients(Zone* self)
@@ -243,57 +243,57 @@ uint32 Perl_Zone_GetMaxClients(Zone* self)
 
 float Perl_Zone_GetMinimumClip(Zone* self)
 {
-	return zone_store.GetZoneMinimumClip(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneMinimumClip(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int8 Perl_Zone_GetMinimumExpansion(Zone* self)
 {
-	return zone_store.GetZoneMinimumExpansion(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneMinimumExpansion(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 uint8 Perl_Zone_GetMinimumLevel(Zone* self)
 {
-	return zone_store.GetZoneMinimumLevel(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneMinimumLevel(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int Perl_Zone_GetMinimumLavaDamage(Zone* self)
 {
-	return zone_store.GetZoneMinimumLavaDamage(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneMinimumLavaDamage(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 uint8 Perl_Zone_GetMinimumStatus(Zone* self)
 {
-	return zone_store.GetZoneMinimumStatus(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneMinimumStatus(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 std::string Perl_Zone_GetNote(Zone* self)
 {
-	return zone_store.GetZoneNote(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneNote(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int Perl_Zone_GetNPCMaximumAggroDistance(Zone* self)
 {
-	return zone_store.GetZoneNPCMaximumAggroDistance(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneNPCMaximumAggroDistance(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int8 Perl_Zone_GetPEQZone(Zone* self)
 {
-	return zone_store.GetZonePEQZone(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZonePEQZone(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int Perl_Zone_GetRainChance(Zone* self, uint8 slot = 0)
 {
-	return zone_store.GetZoneRainChance(self->GetZoneID(), slot, self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneRainChance(self->GetZoneID(), slot, self->GetInstanceVersion());
 }
 
 int Perl_Zone_GetRainDuration(Zone* self, uint8 slot = 0)
 {
-	return zone_store.GetZoneRainDuration(self->GetZoneID(), slot, self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneRainDuration(self->GetZoneID(), slot, self->GetInstanceVersion());
 }
 
 uint32 Perl_Zone_GetRuleSet(Zone* self)
 {
-	return zone_store.GetZoneRuleSet(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneRuleSet(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 float Perl_Zone_GetSafeHeading(Zone* self)
@@ -328,37 +328,37 @@ uint32 Perl_Zone_GetSecondsBeforeIdle(Zone* self)
 
 uint64 Perl_Zone_GetShutdownDelay(Zone* self)
 {
-	return zone_store.GetZoneShutdownDelay(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneShutdownDelay(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 uint8 Perl_Zone_GetSky(Zone* self)
 {
-	return zone_store.GetZoneSky(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneSky(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int8 Perl_Zone_GetSkyLock(Zone* self)
 {
-	return zone_store.GetZoneSkyLock(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneSkyLock(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int Perl_Zone_GetSnowChance(Zone* self, uint8 slot = 0)
 {
-	return zone_store.GetZoneSnowChance(self->GetZoneID(), slot, self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneSnowChance(self->GetZoneID(), slot, self->GetInstanceVersion());
 }
 
 int Perl_Zone_GetSnowDuration(Zone* self, uint8 slot = 0)
 {
-	return zone_store.GetZoneSnowDuration(self->GetZoneID(), slot, self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneSnowDuration(self->GetZoneID(), slot, self->GetInstanceVersion());
 }
 
 uint8 Perl_Zone_GetTimeType(Zone* self)
 {
-	return zone_store.GetZoneTimeType(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneTimeType(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int Perl_Zone_GetTimeZone(Zone* self)
 {
-	return zone_store.GetZoneTimeZone(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneTimeZone(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 std::string Perl_Zone_GetZoneDescription(Zone* self)
@@ -378,22 +378,22 @@ uint8 Perl_Zone_GetZoneType(Zone* self)
 
 float Perl_Zone_GetUnderworld(Zone* self)
 {
-	return zone_store.GetZoneUnderworld(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneUnderworld(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int Perl_Zone_GetUnderworldTeleportIndex(Zone* self)
 {
-	return zone_store.GetZoneUnderworldTeleportIndex(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneUnderworldTeleportIndex(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 float Perl_Zone_GetWalkSpeed(Zone* self)
 {
-	return zone_store.GetZoneWalkSpeed(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneWalkSpeed(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 uint8 Perl_Zone_GetZoneZType(Zone* self)
 {
-	return zone_store.GetZoneZType(self->GetZoneID(), self->GetInstanceVersion());
+	return ZoneStore::Instance()->GetZoneZType(self->GetZoneID(), self->GetInstanceVersion());
 }
 
 int Perl_Zone_GetZoneTotalBlockedSpells(Zone* self)

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -2293,7 +2293,7 @@ void ClientTaskState::CreateTaskDynamicZone(Client* client, int task_id, Dynamic
 	}
 
 	// dz should be named the version-based zone name (used in choose zone window and dz window on live)
-	auto zone_info = zone_store.GetZoneWithFallback(dz_request.GetZoneID(), dz_request.GetZoneVersion());
+	auto zone_info = ZoneStore::Instance()->GetZoneWithFallback(dz_request.GetZoneID(), dz_request.GetZoneVersion());
 	dz_request.SetName(zone_info && !zone_info->long_name.empty() ? zone_info->long_name : task->title);
 	dz_request.SetMinPlayers(task->min_players);
 	dz_request.SetMaxPlayers(task->max_players);

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -4700,7 +4700,7 @@ void WorldServer::ProcessReload(const ServerReload::Request& request)
 			break;
 
 		case ServerReload::Type::ZoneData:
-			zone_store.LoadZones(content_db);
+			ZoneStore::Instance()->LoadZones(content_db);
 			zone->LoadZoneCFG(zone->GetShortName(), zone->GetInstanceVersion());
 			break;
 

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -1302,7 +1302,7 @@ void Zone::ReloadStaticData() {
 
 bool Zone::LoadZoneCFG(const char* filename, uint16 instance_version)
 {
-	auto z = zone_store.GetZoneWithFallback(ZoneID(filename), instance_version);
+	auto z = ZoneStore::Instance()->GetZoneWithFallback(ZoneID(filename), instance_version);
 
 	if (!z) {
 		LogError("Failed to load zone data for [{}] instance_version [{}]", filename, instance_version);
@@ -2253,7 +2253,7 @@ void Zone::LoadZoneBlockedSpells()
 			if (!content_db.LoadBlockedSpells(zone_total_blocked_spells, blocked_spells, GetZoneID())) {
 				LogError(
 					"Failed to load blocked spells for {} ({}).",
-					zone_store.GetZoneName(GetZoneID(), true),
+					ZoneStore::Instance()->GetZoneName(GetZoneID(), true),
 					GetZoneID()
 				);
 				ClearBlockedSpells();
@@ -2263,7 +2263,7 @@ void Zone::LoadZoneBlockedSpells()
 		LogInfo(
 			"Loaded [{}] blocked spells(s) for {} ({}).",
 			Strings::Commify(zone_total_blocked_spells),
-			zone_store.GetZoneName(GetZoneID(), true),
+			ZoneStore::Instance()->GetZoneName(GetZoneID(), true),
 			GetZoneID()
 		);
 	}

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -2639,7 +2639,7 @@ int64 ZoneDatabase::GetBlockedSpellsCount(uint32 zone_id)
 
 bool ZoneDatabase::LoadBlockedSpells(int64 blocked_spells_count, ZoneSpellsBlocked* into, uint32 zone_id)
 {
-	LogInfo("Loading Blocked Spells from database for {} ({}).", zone_store.GetZoneName(zone_id, true), zone_id);
+	LogInfo("Loading Blocked Spells from database for {} ({}).", ZoneStore::Instance()->GetZoneName(zone_id, true), zone_id);
 
 	const auto& l = BlockedSpellsRepository::GetWhere(
 		*this,
@@ -2661,7 +2661,7 @@ bool ZoneDatabase::LoadBlockedSpells(int64 blocked_spells_count, ZoneSpellsBlock
 			LogError(
 				"Blocked spells count of {} exceeded for {} ({}).",
 				blocked_spells_count,
-				zone_store.GetZoneName(zone_id, true),
+				ZoneStore::Instance()->GetZoneName(zone_id, true),
 				zone_id
 			);
 			break;

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -352,7 +352,7 @@ void Client::Handle_OP_ZoneChange(const EQApplicationPacket *app) {
 	if (content_service.GetCurrentExpansion() >= Expansion::Classic && !GetGM()) {
 		bool meets_zone_expansion_check = false;
 
-		auto z = zone_store.GetZoneWithFallback(ZoneID(target_zone_name), 0);
+		auto z = ZoneStore::Instance()->GetZoneWithFallback(ZoneID(target_zone_name), 0);
 		if (z->expansion <= content_service.GetCurrentExpansion() || z->bypass_expansion_check) {
 			meets_zone_expansion_check = true;
 		}


### PR DESCRIPTION
# Description

This is part of a larger effort to remove global variables from the codebase. Eventually singletons can be cleaned up to be passed explicitly through dependency injection.

For now this encapsulates dependencies far better.

## Type of change

- [x] Code Cleanup

# Testing

TBD

# Checklist

- [] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur