### PR TITLE
[Code] WebInterfaceList Global to Singleton Cleanup

### DIFF
--- a/world/clientlist.cpp
+++ b/world/clientlist.cpp
@@ -36,8 +36,6 @@
 #include "../common/zone_store.h"
 #include <set>
 
-extern WebInterfaceList web_interface;
-
 extern ZSList			zoneserver_list;
 uint32 numplayers = 0;	//this really wants to be a member variable of ClientList...
 
@@ -1613,7 +1611,7 @@ void ClientList::OnTick(EQ::Timer *t)
 		Iterator.Advance();
 	}
 
-	web_interface.SendEvent(out);
+	WebInterfaceList::Instance()->SendEvent(out);
 }
 
 /**

--- a/world/main.cpp
+++ b/world/main.cpp
@@ -100,7 +100,6 @@ uint32              numclients = 0;
 uint32              numzones   = 0;
 const WorldConfig   *Config;
 WorldContentService content_service;
-WebInterfaceList    web_interface;
 PlayerEventLogs     player_event_logs;
 
 void CatchSignal(int sig_num);
@@ -320,7 +319,7 @@ int main(int argc, char **argv)
 				connection->GetUUID()
 			);
 
-			web_interface.AddConnection(connection);
+			WebInterfaceList::Instance()->AddConnection(connection);
 		}
 	);
 
@@ -331,7 +330,7 @@ int main(int argc, char **argv)
 				connection->GetUUID()
 			);
 
-			web_interface.RemoveConnection(connection);
+			WebInterfaceList::Instance()->RemoveConnection(connection);
 		}
 	);
 

--- a/world/web_interface.h
+++ b/world/web_interface.h
@@ -42,6 +42,11 @@ public:
 	void SendError(const std::string &uuid, const std::string &message);
 	void SendError(const std::string &uuid, const std::string &message, const std::string &id);
 
+	static WebInterfaceList* Instance()
+	{
+		static WebInterfaceList instance;
+		return &instance;
+	}
 private:
 	std::map<std::string, std::unique_ptr<WebInterface>> m_interfaces;
 };

--- a/world/zonelist.cpp
+++ b/world/zonelist.cpp
@@ -42,7 +42,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include "../common/repositories/buyer_repository.h"
 
 extern uint32 numzones;
-extern WebInterfaceList web_interface;
 extern ClientList client_list;
 volatile bool UCSServerAvailable_ = false;
 void CatchSignal(int sig_num);
@@ -889,7 +888,7 @@ void ZSList::OnTick(EQ::Timer *t)
 		out["data"].append(outzone);
 	}
 
-	web_interface.SendEvent(out);
+	WebInterfaceList::Instance()->SendEvent(out);
 }
 
 const std::list<std::unique_ptr<ZoneServer>> &ZSList::getZoneServerList() const


### PR DESCRIPTION
# Description

This is part of a larger effort to remove global variables from the codebase. Eventually singletons can be cleaned up to be passed explicitly through dependency injection.

For now this encapsulates dependencies far better.

## Type of change

- [x] Code Cleanup

# Testing

TBD

# Checklist

- [] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur