### PR TITLE
[Code] EQ::Random Global to Singleton Cleanup

### DIFF
--- a/common/random.h
+++ b/common/random.h
@@ -116,6 +116,12 @@ namespace EQ {
 			Reseed();
 		}
 
+		static Random* Instance()
+		{
+			static Random instance;
+			return &instance;
+		}
+
 	private:
 #ifndef BIASED_INT_DIST
 		typedef std::uniform_int_distribution<int>::param_type int_param_t;

--- a/world/adventure.cpp
+++ b/world/adventure.cpp
@@ -18,7 +18,6 @@
 extern ZSList zoneserver_list;
 extern ClientList client_list;
 extern AdventureManager adventure_manager;
-extern EQ::Random emu_random;
 
 Adventure::Adventure(AdventureTemplate *t)
 {
@@ -368,8 +367,8 @@ void Adventure::MoveCorpsesToGraveyard()
 
 	glm::vec4 position;
 
-	float x = GetTemplate()->graveyard_x + emu_random.Real(-GetTemplate()->graveyard_radius, GetTemplate()->graveyard_radius);
-	float y = GetTemplate()->graveyard_y + emu_random.Real(-GetTemplate()->graveyard_radius, GetTemplate()->graveyard_radius);
+	float x = GetTemplate()->graveyard_x + EQ::Random::Instance()->Real(-GetTemplate()->graveyard_radius, GetTemplate()->graveyard_radius);
+	float y = GetTemplate()->graveyard_y + EQ::Random::Instance()->Real(-GetTemplate()->graveyard_radius, GetTemplate()->graveyard_radius);
 	float z = GetTemplate()->graveyard_z;
 
 	position.x = x;

--- a/world/adventure_manager.cpp
+++ b/world/adventure_manager.cpp
@@ -16,7 +16,6 @@
 
 extern ZSList zoneserver_list;
 extern ClientList client_list;
-extern EQ::Random emu_random;
 
 AdventureManager::AdventureManager()
 {
@@ -324,7 +323,7 @@ void AdventureManager::CalculateAdventureRequestReply(const char *data)
 	if(eligible_adventures.size() > 0)
 	{
 		ea_iter = eligible_adventures.begin();
-		int c_index = emu_random.Int(0, (eligible_adventures.size()-1));
+		int c_index = EQ::Random::Instance()->Int(0, (eligible_adventures.size()-1));
 		for(int i = 0; i < c_index; ++i)
 		{
 			++ea_iter;

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -91,7 +91,6 @@ std::vector<RaceClassCombos> character_create_race_class_combos;
 extern ZSList zoneserver_list;
 extern LoginServerList loginserverlist;
 extern ClientList client_list;
-extern EQ::Random emu_random;
 extern uint32 numclients;
 extern volatile bool RunLoops;
 extern volatile bool UCSServerAvailable_;
@@ -984,7 +983,7 @@ bool Client::HandleEnterWorldPacket(const EQApplicationPacket *app) {
 	safe_delete(outapp);
 
 	// set mailkey - used for duration of character session
-	int mail_key = emu_random.Int(1, INT_MAX);
+	int mail_key = EQ::Random::Instance()->Int(1, INT_MAX);
 
 	database.SetMailKey(charid, GetIP(), mail_key);
 	if (UCSServerAvailable_) {

--- a/world/main.cpp
+++ b/world/main.cpp
@@ -103,7 +103,6 @@ LauncherList        launcher_list;
 AdventureManager    adventure_manager;
 WorldEventScheduler event_scheduler;
 SharedTaskManager   shared_task_manager;
-EQ::Random          emu_random;
 volatile bool       RunLoops   = true;
 uint32              numclients = 0;
 uint32              numzones   = 0;

--- a/world/zonelist.cpp
+++ b/world/zonelist.cpp
@@ -41,7 +41,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include "../common/repositories/buyer_repository.h"
 
 extern uint32 numzones;
-extern EQ::Random emu_random;
 extern WebInterfaceList web_interface;
 extern SharedTaskManager shared_task_manager;
 extern ClientList client_list;
@@ -694,7 +693,7 @@ void ZSList::RebootZone(const char* ip1, uint16 port, const char* ip2, uint32 sk
 		safe_delete_array(tmp);
 		return;
 	}
-	uint32 z = emu_random.Int(0, y - 1);
+	uint32 z = EQ::Random::Instance()->Int(0, y - 1);
 
 	auto pack = new ServerPacket(ServerOP_ZoneReboot, sizeof(ServerZoneReboot_Struct));
 	ServerZoneReboot_Struct* s = (ServerZoneReboot_Struct*)pack->pBuffer;


### PR DESCRIPTION
# Description

This is part of a larger effort to remove global variables from the codebase. Eventually singletons can be cleaned up to be passed explicitly through dependency injection.

For now this encapsulates dependencies far better.

## Type of change

- [x] Code Cleanup

# Testing

TBD

# Checklist

- [] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur