### PR TITLE
 [Code] QueryServConnection Global to Singleton Cleanup

### DIFF
--- a/world/eqemu_api_world_data_service.cpp
+++ b/world/eqemu_api_world_data_service.cpp
@@ -16,7 +16,6 @@
 extern ZSList            zoneserver_list;
 extern ClientList        client_list;
 extern WorldGuildManager guild_mgr;
-extern QueryServConnection QSLink;
 
 void callGetZoneList(Json::Value &response)
 {

--- a/world/main.cpp
+++ b/world/main.cpp
@@ -94,7 +94,6 @@
 ClientList          client_list;
 GroupLFPList        LFPGroupList;
 ZSList              zoneserver_list;
-QueryServConnection QSLink;
 LauncherList        launcher_list;
 WorldEventScheduler event_scheduler;
 volatile bool       RunLoops   = true;
@@ -269,7 +268,7 @@ int main(int argc, char **argv)
 				connection->Handle()->RemotePort(),
 				connection->GetUUID());
 
-			QSLink.AddConnection(connection);
+			QueryServConnection::Instance()->AddConnection(connection);
 		}
 	);
 
@@ -280,7 +279,7 @@ int main(int argc, char **argv)
 				connection->GetUUID()
 			);
 
-			QSLink.RemoveConnection(connection);
+			QueryServConnection::Instance()->RemoveConnection(connection);
 		}
 	);
 

--- a/world/queryserv.h
+++ b/world/queryserv.h
@@ -15,6 +15,13 @@ public:
 	void HandleGenericMessage(uint16_t opcode, EQ::Net::Packet &p);
 	void HandleLFGuildUpdateMessage(uint16_t opcode, EQ::Net::Packet &p);
 	bool SendPacket(ServerPacket* pack);
+
+	static QueryServConnection* Instance()
+	{
+		static QueryServConnection instance;
+		return &instance;
+	}
+
 private:
 	std::map<std::string, std::shared_ptr<EQ::Net::ServertalkServerConnection>> m_streams;
 	std::unique_ptr<EQ::Timer> m_keepalive;

--- a/world/zonelist.cpp
+++ b/world/zonelist.cpp
@@ -44,7 +44,6 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 extern uint32 numzones;
 extern WebInterfaceList web_interface;
 extern ClientList client_list;
-extern QueryServConnection QSLink;
 volatile bool UCSServerAvailable_ = false;
 void CatchSignal(int sig_num);
 
@@ -985,7 +984,7 @@ void ZSList::SendServerReload(ServerReload::Type type, uchar *packet)
 		EQEmuLogSys::Instance()->LoadLogDatabaseSettings();
 		player_event_logs.ReloadSettings();
 		UCSConnection::Instance()->SendPacket(&pack);
-		QSLink.SendPacket(&pack);
+		QueryServConnection::Instance()->SendPacket(&pack);
 	} else if (type == ServerReload::Type::Tasks) {
 		SharedTaskManager::Instance()->LoadTaskData();
 	} else if (type == ServerReload::Type::DzTemplates) {

--- a/world/zoneserver.cpp
+++ b/world/zoneserver.cpp
@@ -57,7 +57,6 @@ extern GroupLFPList LFPGroupList;
 extern ZSList zoneserver_list;
 extern volatile bool RunLoops;
 extern volatile bool UCSServerAvailable_;
-extern QueryServConnection QSLink;
 
 void CatchSignal(int sig_num);
 
@@ -372,7 +371,7 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 				player_event_logs.AddToQueue(n.player_event_log);
 			}
 			else {
-				QSLink.SendPacket(pack);
+				QueryServConnection::Instance()->SendPacket(pack);
 			}
 
 			// if discord enabled for event, ship to UCS to process
@@ -1359,7 +1358,7 @@ void ZoneServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p) {
 			break;
 		}
 		case ServerOP_QueryServGeneric: {
-			QSLink.SendPacket(pack);
+			QueryServConnection::Instance()->SendPacket(pack);
 			break;
 		}
 		case ServerOP_CZDialogueWindow:


### PR DESCRIPTION
# Description

This is part of a larger effort to remove global variables from the codebase. Eventually singletons can be cleaned up to be passed explicitly through dependency injection.

For now this encapsulates dependencies far better.

## Type of change

- [x] Code Cleanup

# Testing

TBD

# Checklist

- [] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur