### PR TITLE
[Code] WorldContentService Global to Singleton Cleanup

### DIFF
--- a/client_files/export/main.cpp
+++ b/client_files/export/main.cpp
@@ -38,7 +38,6 @@
 #include "../../common/skill_caps.h"
 #include "../../common/evolving_items.h"
 
-WorldContentService  content_service;
 PlayerEventLogs      player_event_logs;
 
 void ExportSpells(SharedDatabase *db);

--- a/client_files/import/main.cpp
+++ b/client_files/import/main.cpp
@@ -32,7 +32,6 @@
 #include "../../common/events/player_event_logs.h"
 #include "../../common/evolving_items.h"
 
-WorldContentService  content_service;
 PlayerEventLogs      player_event_logs;
 
 void ImportSpells(SharedDatabase *db);

--- a/common/content/world_content_service.cpp
+++ b/common/content/world_content_service.cpp
@@ -27,7 +27,7 @@ WorldContentService *WorldContentService::SetExpansionContext()
 	// pull expansion from rules
 	int expansion = RuleI(Expansion, CurrentExpansion);
 	if (expansion >= Expansion::Classic && expansion <= Expansion::MaxId) {
-		content_service.SetCurrentExpansion(expansion);
+		WorldContentService::Instance()->SetCurrentExpansion(expansion);
 	}
 
 	LogInfo(
@@ -41,12 +41,12 @@ WorldContentService *WorldContentService::SetExpansionContext()
 
 std::string WorldContentService::GetCurrentExpansionName()
 {
-	if (content_service.GetCurrentExpansion() == Expansion::EXPANSION_ALL) {
+	if (WorldContentService::Instance()->GetCurrentExpansion() == Expansion::EXPANSION_ALL) {
 		return "All Expansions";
 	}
 
 	if (current_expansion >= Expansion::Classic && current_expansion <= Expansion::MaxId) {
-		return Expansion::ExpansionName[content_service.GetCurrentExpansion()];
+		return Expansion::ExpansionName[WorldContentService::Instance()->GetCurrentExpansion()];
 	}
 
 	return "Unknown Expansion";

--- a/common/content/world_content_service.h
+++ b/common/content/world_content_service.h
@@ -181,6 +181,12 @@ public:
 	FindZoneResult FindZone(uint32 zone_id, uint32 instance_id);
 	bool IsInPublicStaticInstance(uint32 instance_id);
 
+	static WorldContentService* Instance()
+	{
+		static WorldContentService instance;
+		return &instance;
+	}
+
 private:
 	int current_expansion{};
 	std::vector<ContentFlagsRepository::ContentFlags> content_flags;
@@ -193,7 +199,5 @@ private:
 	WorldContentService *LoadStaticGlobalZoneInstances();
 	std::vector<InstanceListRepository::InstanceList> m_zone_static_instances;
 };
-
-extern WorldContentService content_service;
 
 #endif //EQEMU_WORLD_CONTENT_SERVICE_H

--- a/common/repositories/criteria/content_filter_criteria.h
+++ b/common/repositories/criteria/content_filter_criteria.h
@@ -14,7 +14,7 @@ namespace ContentFilterCriteria {
 			table_prefix = table_prefix + ".";
 		}
 
-		int current_expansion_filter_criteria = content_service.GetCurrentExpansion();
+		int current_expansion_filter_criteria = WorldContentService::Instance()->GetCurrentExpansion();
 		if (current_expansion_filter_criteria == Expansion::EXPANSION_ALL) {
 			current_expansion_filter_criteria = Expansion::EXPANSION_FILTER_MAX;
 		}
@@ -33,8 +33,8 @@ namespace ContentFilterCriteria {
 			table_prefix
 		);
 
-		std::vector<std::string> flags_disabled = content_service.GetContentFlagsDisabled();
-		std::vector<std::string> flags_enabled  = content_service.GetContentFlagsEnabled();
+		std::vector<std::string> flags_disabled = WorldContentService::Instance()->GetContentFlagsDisabled();
+		std::vector<std::string> flags_enabled  = WorldContentService::Instance()->GetContentFlagsEnabled();
 		std::string              flags_in_filter_enabled;
 		std::string              flags_in_filter_disabled;
 		if (!flags_enabled.empty()) {

--- a/shared_memory/main.cpp
+++ b/shared_memory/main.cpp
@@ -35,7 +35,6 @@
 #include "../common/events/player_event_logs.h"
 #include "../common/evolving_items.h"
 
-WorldContentService  content_service;
 PlayerEventLogs      player_event_logs;
 
 #ifdef _WINDOWS
@@ -165,16 +164,16 @@ int main(int argc, char **argv)
 	}
 
 
-	content_service.SetCurrentExpansion(RuleI(Expansion, CurrentExpansion));
-	content_service.SetDatabase(&database)
+	WorldContentService::Instance()->SetCurrentExpansion(RuleI(Expansion, CurrentExpansion));
+	WorldContentService::Instance()->SetDatabase(&database)
 		->SetContentDatabase(&content_db)
 		->SetExpansionContext()
 		->ReloadContentFlags();
 
 	LogInfo(
 		"Current expansion is [{}] ({})",
-		content_service.GetCurrentExpansion(),
-		content_service.GetCurrentExpansionName()
+		WorldContentService::Instance()->GetCurrentExpansion(),
+		WorldContentService::Instance()->GetCurrentExpansionName()
 	);
 
 	std::string hotfix_name = "";

--- a/world/cli/test_expansion.cpp
+++ b/world/cli/test_expansion.cpp
@@ -16,7 +16,7 @@ void WorldserverCLI::ExpansionTestCommand(int argc, char **argv, argh::parser &c
 		LogInfo("No rule set configured, using default rules");
 	}
 
-	content_service.SetCurrentExpansion(RuleI(Expansion, CurrentExpansion));
+	WorldContentService::Instance()->SetCurrentExpansion(RuleI(Expansion, CurrentExpansion));
 
 	std::vector<ContentFlagsRepository::ContentFlags> flags = {};
 	auto                                              f     = ContentFlagsRepository::NewEntity();
@@ -32,13 +32,13 @@ void WorldserverCLI::ExpansionTestCommand(int argc, char **argv, argh::parser &c
 		flags.push_back(f);
 	}
 
-	content_service.SetContentFlags(flags);
+	WorldContentService::Instance()->SetContentFlags(flags);
 
 	LogInfo(
 		"Current expansion is [{}] ({}) is Velious Enabled [{}] Criteria [{}]",
-		content_service.GetCurrentExpansion(),
-		content_service.GetCurrentExpansionName(),
-		content_service.IsTheScarsOfVeliousEnabled() ? "true" : "false",
+		WorldContentService::Instance()->GetCurrentExpansion(),
+		WorldContentService::Instance()->GetCurrentExpansionName(),
+		WorldContentService::Instance()->IsTheScarsOfVeliousEnabled() ? "true" : "false",
 		ContentFilterCriteria::apply()
 	);
 }

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -820,7 +820,7 @@ bool Client::HandleEnterWorldPacket(const EQApplicationPacket *app) {
 		return true;
 	}
 
-	auto r = content_service.FindZone(zone_id, instance_id);
+	auto r = WorldContentService::Instance()->FindZone(zone_id, instance_id);
 	if (r.zone_id && r.instance.id != instance_id) {
 		LogInfo(
 			"Zone [{}] has been remapped to instance_id [{}] from instance_id [{}] for client [{}]",

--- a/world/main.cpp
+++ b/world/main.cpp
@@ -99,7 +99,6 @@ volatile bool       RunLoops   = true;
 uint32              numclients = 0;
 uint32              numzones   = 0;
 const WorldConfig   *Config;
-WorldContentService content_service;
 PlayerEventLogs     player_event_logs;
 
 void CatchSignal(int sig_num);
@@ -189,7 +188,7 @@ int main(int argc, char **argv)
 		RegisterConsoleFunctions(console);
 	}
 
-	content_service.SetDatabase(&database)
+	WorldContentService::Instance()->SetDatabase(&database)
 		->SetContentDatabase(&content_db)
 		->SetExpansionContext()
 		->ReloadContentFlags();

--- a/world/world_boot.cpp
+++ b/world/world_boot.cpp
@@ -390,7 +390,7 @@ bool WorldBoot::DatabaseLoadRoutines(int argc, char **argv)
 	WorldEventScheduler::Instance()->SetDatabase(&database)->LoadScheduledEvents();
 
 	LogInfo("Initializing [WorldContentService]");
-	content_service.SetDatabase(&database)
+	WorldContentService::Instance()->SetDatabase(&database)
 		->SetContentDatabase(&content_db)
 		->SetExpansionContext()
 		->ReloadContentFlags();

--- a/world/zonelist.cpp
+++ b/world/zonelist.cpp
@@ -978,7 +978,7 @@ void ZSList::SendServerReload(ServerReload::Type type, uchar *packet)
 	} else if (type == ServerReload::Type::SkillCaps) {
 		SkillCaps::Instance()->ReloadSkillCaps();
 	} else if (type == ServerReload::Type::ContentFlags) {
-		content_service.SetExpansionContext()->ReloadContentFlags();
+		WorldContentService::Instance()->SetExpansionContext()->ReloadContentFlags();
 	} else if (type == ServerReload::Type::Logs) {
 		EQEmuLogSys::Instance()->LoadLogDatabaseSettings();
 		player_event_logs.ReloadSettings();

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10005,8 +10005,8 @@ void Client::ShowDevToolsMenu()
 		Chat::White,
 		fmt::format(
 			"Current Expansion | {} ({})",
-			content_service.GetCurrentExpansionName(),
-			content_service.GetCurrentExpansion()
+			WorldContentService::Instance()->GetCurrentExpansionName(),
+			WorldContentService::Instance()->GetCurrentExpansion()
 		).c_str()
 	);
 

--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -2510,282 +2510,282 @@ bool Perl__delete_data(std::string bucket_key)
 
 bool Perl__IsClassicEnabled()
 {
-	return content_service.IsClassicEnabled();
+	return WorldContentService::Instance()->IsClassicEnabled();
 }
 
 bool Perl__IsTheRuinsOfKunarkEnabled()
 {
-	return content_service.IsTheRuinsOfKunarkEnabled();
+	return WorldContentService::Instance()->IsTheRuinsOfKunarkEnabled();
 }
 
 bool Perl__IsTheScarsOfVeliousEnabled()
 {
-	return content_service.IsTheScarsOfVeliousEnabled();
+	return WorldContentService::Instance()->IsTheScarsOfVeliousEnabled();
 }
 
 bool Perl__IsTheShadowsOfLuclinEnabled()
 {
-	return content_service.IsTheShadowsOfLuclinEnabled();
+	return WorldContentService::Instance()->IsTheShadowsOfLuclinEnabled();
 }
 
 bool Perl__IsThePlanesOfPowerEnabled()
 {
-	return content_service.IsThePlanesOfPowerEnabled();
+	return WorldContentService::Instance()->IsThePlanesOfPowerEnabled();
 }
 
 bool Perl__IsTheLegacyOfYkeshaEnabled()
 {
-	return content_service.IsTheLegacyOfYkeshaEnabled();
+	return WorldContentService::Instance()->IsTheLegacyOfYkeshaEnabled();
 }
 
 bool Perl__IsLostDungeonsOfNorrathEnabled()
 {
-	return content_service.IsLostDungeonsOfNorrathEnabled();
+	return WorldContentService::Instance()->IsLostDungeonsOfNorrathEnabled();
 }
 
 bool Perl__IsGatesOfDiscordEnabled()
 {
-	return content_service.IsGatesOfDiscordEnabled();
+	return WorldContentService::Instance()->IsGatesOfDiscordEnabled();
 }
 
 bool Perl__IsOmensOfWarEnabled()
 {
-	return content_service.IsOmensOfWarEnabled();
+	return WorldContentService::Instance()->IsOmensOfWarEnabled();
 }
 
 bool Perl__IsDragonsOfNorrathEnabled()
 {
-	return content_service.IsDragonsOfNorrathEnabled();
+	return WorldContentService::Instance()->IsDragonsOfNorrathEnabled();
 }
 
 bool Perl__IsDepthsOfDarkhollowEnabled()
 {
-	return content_service.IsDepthsOfDarkhollowEnabled();
+	return WorldContentService::Instance()->IsDepthsOfDarkhollowEnabled();
 }
 
 bool Perl__IsProphecyOfRoEnabled()
 {
-	return content_service.IsProphecyOfRoEnabled();
+	return WorldContentService::Instance()->IsProphecyOfRoEnabled();
 }
 
 bool Perl__IsTheSerpentsSpineEnabled()
 {
-	return content_service.IsTheSerpentsSpineEnabled();
+	return WorldContentService::Instance()->IsTheSerpentsSpineEnabled();
 }
 
 bool Perl__IsTheBuriedSeaEnabled()
 {
-	return content_service.IsTheBuriedSeaEnabled();
+	return WorldContentService::Instance()->IsTheBuriedSeaEnabled();
 }
 
 bool Perl__IsSecretsOfFaydwerEnabled()
 {
-	return content_service.IsSecretsOfFaydwerEnabled();
+	return WorldContentService::Instance()->IsSecretsOfFaydwerEnabled();
 }
 
 bool Perl__IsSeedsOfDestructionEnabled()
 {
-	return content_service.IsSeedsOfDestructionEnabled();
+	return WorldContentService::Instance()->IsSeedsOfDestructionEnabled();
 }
 
 bool Perl__IsUnderfootEnabled()
 {
-	return content_service.IsUnderfootEnabled();
+	return WorldContentService::Instance()->IsUnderfootEnabled();
 }
 
 bool Perl__IsHouseOfThuleEnabled()
 {
-	return content_service.IsHouseOfThuleEnabled();
+	return WorldContentService::Instance()->IsHouseOfThuleEnabled();
 }
 
 bool Perl__IsVeilOfAlarisEnabled()
 {
-	return content_service.IsVeilOfAlarisEnabled();
+	return WorldContentService::Instance()->IsVeilOfAlarisEnabled();
 }
 
 bool Perl__IsRainOfFearEnabled()
 {
-	return content_service.IsRainOfFearEnabled();
+	return WorldContentService::Instance()->IsRainOfFearEnabled();
 }
 
 bool Perl__IsCallOfTheForsakenEnabled()
 {
-	return content_service.IsCallOfTheForsakenEnabled();
+	return WorldContentService::Instance()->IsCallOfTheForsakenEnabled();
 }
 
 bool Perl__IsTheDarkenedSeaEnabled()
 {
-	return content_service.IsTheDarkenedSeaEnabled();
+	return WorldContentService::Instance()->IsTheDarkenedSeaEnabled();
 }
 
 bool Perl__IsTheBrokenMirrorEnabled()
 {
-	return content_service.IsTheBrokenMirrorEnabled();
+	return WorldContentService::Instance()->IsTheBrokenMirrorEnabled();
 }
 
 bool Perl__IsEmpiresOfKunarkEnabled()
 {
-	return content_service.IsEmpiresOfKunarkEnabled();
+	return WorldContentService::Instance()->IsEmpiresOfKunarkEnabled();
 }
 
 bool Perl__IsRingOfScaleEnabled()
 {
-	return content_service.IsRingOfScaleEnabled();
+	return WorldContentService::Instance()->IsRingOfScaleEnabled();
 }
 
 bool Perl__IsTheBurningLandsEnabled()
 {
-	return content_service.IsTheBurningLandsEnabled();
+	return WorldContentService::Instance()->IsTheBurningLandsEnabled();
 }
 
 bool Perl__IsTormentOfVeliousEnabled()
 {
-	return content_service.IsTormentOfVeliousEnabled();
+	return WorldContentService::Instance()->IsTormentOfVeliousEnabled();
 }
 
 bool Perl__IsCurrentExpansionClassic()
 {
-	return content_service.IsCurrentExpansionClassic();
+	return WorldContentService::Instance()->IsCurrentExpansionClassic();
 }
 
 bool Perl__IsCurrentExpansionTheRuinsOfKunark()
 {
-	return content_service.IsCurrentExpansionTheRuinsOfKunark();
+	return WorldContentService::Instance()->IsCurrentExpansionTheRuinsOfKunark();
 }
 
 bool Perl__IsCurrentExpansionTheScarsOfVelious()
 {
-	return content_service.IsCurrentExpansionTheScarsOfVelious();
+	return WorldContentService::Instance()->IsCurrentExpansionTheScarsOfVelious();
 }
 
 bool Perl__IsCurrentExpansionTheShadowsOfLuclin()
 {
-	return content_service.IsCurrentExpansionTheShadowsOfLuclin();
+	return WorldContentService::Instance()->IsCurrentExpansionTheShadowsOfLuclin();
 }
 
 bool Perl__IsCurrentExpansionThePlanesOfPower()
 {
-	return content_service.IsCurrentExpansionThePlanesOfPower();
+	return WorldContentService::Instance()->IsCurrentExpansionThePlanesOfPower();
 }
 
 bool Perl__IsCurrentExpansionTheLegacyOfYkesha()
 {
-	return content_service.IsCurrentExpansionTheLegacyOfYkesha();
+	return WorldContentService::Instance()->IsCurrentExpansionTheLegacyOfYkesha();
 }
 
 bool Perl__IsCurrentExpansionLostDungeonsOfNorrath()
 {
-	return content_service.IsCurrentExpansionLostDungeonsOfNorrath();
+	return WorldContentService::Instance()->IsCurrentExpansionLostDungeonsOfNorrath();
 }
 
 bool Perl__IsCurrentExpansionGatesOfDiscord()
 {
-	return content_service.IsCurrentExpansionGatesOfDiscord();
+	return WorldContentService::Instance()->IsCurrentExpansionGatesOfDiscord();
 }
 
 bool Perl__IsCurrentExpansionOmensOfWar()
 {
-	return content_service.IsCurrentExpansionOmensOfWar();
+	return WorldContentService::Instance()->IsCurrentExpansionOmensOfWar();
 }
 
 bool Perl__IsCurrentExpansionDragonsOfNorrath()
 {
-	return content_service.IsCurrentExpansionDragonsOfNorrath();
+	return WorldContentService::Instance()->IsCurrentExpansionDragonsOfNorrath();
 }
 
 bool Perl__IsCurrentExpansionDepthsOfDarkhollow()
 {
-	return content_service.IsCurrentExpansionDepthsOfDarkhollow();
+	return WorldContentService::Instance()->IsCurrentExpansionDepthsOfDarkhollow();
 }
 
 bool Perl__IsCurrentExpansionProphecyOfRo()
 {
-	return content_service.IsCurrentExpansionProphecyOfRo();
+	return WorldContentService::Instance()->IsCurrentExpansionProphecyOfRo();
 }
 
 bool Perl__IsCurrentExpansionTheSerpentsSpine()
 {
-	return content_service.IsCurrentExpansionTheSerpentsSpine();
+	return WorldContentService::Instance()->IsCurrentExpansionTheSerpentsSpine();
 }
 
 bool Perl__IsCurrentExpansionTheBuriedSea()
 {
-	return content_service.IsCurrentExpansionTheBuriedSea();
+	return WorldContentService::Instance()->IsCurrentExpansionTheBuriedSea();
 }
 
 bool Perl__IsCurrentExpansionSecretsOfFaydwer()
 {
-	return content_service.IsCurrentExpansionSecretsOfFaydwer();
+	return WorldContentService::Instance()->IsCurrentExpansionSecretsOfFaydwer();
 }
 
 bool Perl__IsCurrentExpansionSeedsOfDestruction()
 {
-	return content_service.IsCurrentExpansionSeedsOfDestruction();
+	return WorldContentService::Instance()->IsCurrentExpansionSeedsOfDestruction();
 }
 
 bool Perl__IsCurrentExpansionUnderfoot()
 {
-	return content_service.IsCurrentExpansionUnderfoot();
+	return WorldContentService::Instance()->IsCurrentExpansionUnderfoot();
 }
 
 bool Perl__IsCurrentExpansionHouseOfThule()
 {
-	return content_service.IsCurrentExpansionHouseOfThule();
+	return WorldContentService::Instance()->IsCurrentExpansionHouseOfThule();
 }
 
 bool Perl__IsCurrentExpansionVeilOfAlaris()
 {
-	return content_service.IsCurrentExpansionVeilOfAlaris();
+	return WorldContentService::Instance()->IsCurrentExpansionVeilOfAlaris();
 }
 
 bool Perl__IsCurrentExpansionRainOfFear()
 {
-	return content_service.IsCurrentExpansionRainOfFear();
+	return WorldContentService::Instance()->IsCurrentExpansionRainOfFear();
 }
 
 bool Perl__IsCurrentExpansionCallOfTheForsaken()
 {
-	return content_service.IsCurrentExpansionCallOfTheForsaken();
+	return WorldContentService::Instance()->IsCurrentExpansionCallOfTheForsaken();
 }
 
 bool Perl__IsCurrentExpansionTheDarkenedSea()
 {
-	return content_service.IsCurrentExpansionTheDarkenedSea();
+	return WorldContentService::Instance()->IsCurrentExpansionTheDarkenedSea();
 }
 
 bool Perl__IsCurrentExpansionTheBrokenMirror()
 {
-	return content_service.IsCurrentExpansionTheBrokenMirror();
+	return WorldContentService::Instance()->IsCurrentExpansionTheBrokenMirror();
 }
 
 bool Perl__IsCurrentExpansionEmpiresOfKunark()
 {
-	return content_service.IsCurrentExpansionEmpiresOfKunark();
+	return WorldContentService::Instance()->IsCurrentExpansionEmpiresOfKunark();
 }
 
 bool Perl__IsCurrentExpansionRingOfScale()
 {
-	return content_service.IsCurrentExpansionRingOfScale();
+	return WorldContentService::Instance()->IsCurrentExpansionRingOfScale();
 }
 
 bool Perl__IsCurrentExpansionTheBurningLands()
 {
-	return content_service.IsCurrentExpansionTheBurningLands();
+	return WorldContentService::Instance()->IsCurrentExpansionTheBurningLands();
 }
 
 bool Perl__IsCurrentExpansionTormentOfVelious()
 {
-	return content_service.IsCurrentExpansionTormentOfVelious();
+	return WorldContentService::Instance()->IsCurrentExpansionTormentOfVelious();
 }
 
 bool Perl__IsContentFlagEnabled(std::string flag_name)
 {
-	return content_service.IsContentFlagEnabled(flag_name);
+	return WorldContentService::Instance()->IsContentFlagEnabled(flag_name);
 }
 
 void Perl__SetContentFlag(std::string flag_name, bool enabled)
 {
-	content_service.SetContentFlag(flag_name, enabled);
+	WorldContentService::Instance()->SetContentFlag(flag_name, enabled);
 	zone->ReloadContentFlags();
 }
 

--- a/zone/loot.cpp
+++ b/zone/loot.cpp
@@ -57,7 +57,7 @@ void NPC::AddLootTable(uint32 loottable_id, bool is_global)
 		.content_flags_disabled = l->content_flags_disabled
 	};
 
-	if (!content_service.DoesPassContentFiltering(content_flags)) {
+	if (!WorldContentService::Instance()->DoesPassContentFiltering(content_flags)) {
 		return;
 	}
 

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -1609,227 +1609,227 @@ void lua_update_zone_header(std::string type, std::string value) {
  */
 
 bool lua_is_classic_enabled() {
-	return content_service.IsClassicEnabled();
+	return WorldContentService::Instance()->IsClassicEnabled();
 }
 
 bool lua_is_the_ruins_of_kunark_enabled() {
-	return content_service.IsTheRuinsOfKunarkEnabled();
+	return WorldContentService::Instance()->IsTheRuinsOfKunarkEnabled();
 }
 
 bool lua_is_the_scars_of_velious_enabled() {
-	return content_service.IsTheScarsOfVeliousEnabled();
+	return WorldContentService::Instance()->IsTheScarsOfVeliousEnabled();
 }
 
 bool lua_is_the_shadows_of_luclin_enabled() {
-	return content_service.IsTheShadowsOfLuclinEnabled();
+	return WorldContentService::Instance()->IsTheShadowsOfLuclinEnabled();
 }
 
 bool lua_is_the_planes_of_power_enabled() {
-	return content_service.IsThePlanesOfPowerEnabled();
+	return WorldContentService::Instance()->IsThePlanesOfPowerEnabled();
 }
 
 bool lua_is_the_legacy_of_ykesha_enabled() {
-	return content_service.IsTheLegacyOfYkeshaEnabled();
+	return WorldContentService::Instance()->IsTheLegacyOfYkeshaEnabled();
 }
 
 bool lua_is_lost_dungeons_of_norrath_enabled() {
-	return content_service.IsLostDungeonsOfNorrathEnabled();
+	return WorldContentService::Instance()->IsLostDungeonsOfNorrathEnabled();
 }
 
 bool lua_is_gates_of_discord_enabled() {
-	return content_service.IsGatesOfDiscordEnabled();
+	return WorldContentService::Instance()->IsGatesOfDiscordEnabled();
 }
 
 bool lua_is_omens_of_war_enabled() {
-	return content_service.IsOmensOfWarEnabled();
+	return WorldContentService::Instance()->IsOmensOfWarEnabled();
 }
 
 bool lua_is_dragons_of_norrath_enabled() {
-	return content_service.IsDragonsOfNorrathEnabled();
+	return WorldContentService::Instance()->IsDragonsOfNorrathEnabled();
 }
 
 bool lua_is_depths_of_darkhollow_enabled() {
-	return content_service.IsDepthsOfDarkhollowEnabled();
+	return WorldContentService::Instance()->IsDepthsOfDarkhollowEnabled();
 }
 
 bool lua_is_prophecy_of_ro_enabled() {
-	return content_service.IsProphecyOfRoEnabled();
+	return WorldContentService::Instance()->IsProphecyOfRoEnabled();
 }
 
 bool lua_is_the_serpents_spine_enabled() {
-	return content_service.IsTheSerpentsSpineEnabled();
+	return WorldContentService::Instance()->IsTheSerpentsSpineEnabled();
 }
 
 bool lua_is_the_buried_sea_enabled() {
-	return content_service.IsTheBuriedSeaEnabled();
+	return WorldContentService::Instance()->IsTheBuriedSeaEnabled();
 }
 
 bool lua_is_secrets_of_faydwer_enabled() {
-	return content_service.IsSecretsOfFaydwerEnabled();
+	return WorldContentService::Instance()->IsSecretsOfFaydwerEnabled();
 }
 
 bool lua_is_seeds_of_destruction_enabled() {
-	return content_service.IsSeedsOfDestructionEnabled();
+	return WorldContentService::Instance()->IsSeedsOfDestructionEnabled();
 }
 
 bool lua_is_underfoot_enabled() {
-	return content_service.IsUnderfootEnabled();
+	return WorldContentService::Instance()->IsUnderfootEnabled();
 }
 
 bool lua_is_house_of_thule_enabled() {
-	return content_service.IsHouseOfThuleEnabled();
+	return WorldContentService::Instance()->IsHouseOfThuleEnabled();
 }
 
 bool lua_is_veil_of_alaris_enabled() {
-	return content_service.IsVeilOfAlarisEnabled();
+	return WorldContentService::Instance()->IsVeilOfAlarisEnabled();
 }
 
 bool lua_is_rain_of_fear_enabled() {
-	return content_service.IsRainOfFearEnabled();
+	return WorldContentService::Instance()->IsRainOfFearEnabled();
 }
 
 bool lua_is_call_of_the_forsaken_enabled() {
-	return content_service.IsCallOfTheForsakenEnabled();
+	return WorldContentService::Instance()->IsCallOfTheForsakenEnabled();
 }
 
 bool lua_is_the_darkened_sea_enabled() {
-	return content_service.IsTheDarkenedSeaEnabled();
+	return WorldContentService::Instance()->IsTheDarkenedSeaEnabled();
 }
 
 bool lua_is_the_broken_mirror_enabled() {
-	return content_service.IsTheBrokenMirrorEnabled();
+	return WorldContentService::Instance()->IsTheBrokenMirrorEnabled();
 }
 
 bool lua_is_empires_of_kunark_enabled() {
-	return content_service.IsEmpiresOfKunarkEnabled();
+	return WorldContentService::Instance()->IsEmpiresOfKunarkEnabled();
 }
 
 bool lua_is_ring_of_scale_enabled() {
-	return content_service.IsRingOfScaleEnabled();
+	return WorldContentService::Instance()->IsRingOfScaleEnabled();
 }
 
 bool lua_is_the_burning_lands_enabled() {
-	return content_service.IsTheBurningLandsEnabled();
+	return WorldContentService::Instance()->IsTheBurningLandsEnabled();
 }
 
 bool lua_is_torment_of_velious_enabled() {
-	return content_service.IsTormentOfVeliousEnabled();
+	return WorldContentService::Instance()->IsTormentOfVeliousEnabled();
 }
 
 bool lua_is_current_expansion_classic() {
-	return content_service.IsCurrentExpansionClassic();
+	return WorldContentService::Instance()->IsCurrentExpansionClassic();
 }
 
 bool lua_is_current_expansion_the_ruins_of_kunark() {
-	return content_service.IsCurrentExpansionTheRuinsOfKunark();
+	return WorldContentService::Instance()->IsCurrentExpansionTheRuinsOfKunark();
 }
 
 bool lua_is_current_expansion_the_scars_of_velious() {
-	return content_service.IsCurrentExpansionTheScarsOfVelious();
+	return WorldContentService::Instance()->IsCurrentExpansionTheScarsOfVelious();
 }
 
 bool lua_is_current_expansion_the_shadows_of_luclin() {
-	return content_service.IsCurrentExpansionTheShadowsOfLuclin();
+	return WorldContentService::Instance()->IsCurrentExpansionTheShadowsOfLuclin();
 }
 
 bool lua_is_current_expansion_the_planes_of_power() {
-	return content_service.IsCurrentExpansionThePlanesOfPower();
+	return WorldContentService::Instance()->IsCurrentExpansionThePlanesOfPower();
 }
 
 bool lua_is_current_expansion_the_legacy_of_ykesha() {
-	return content_service.IsCurrentExpansionTheLegacyOfYkesha();
+	return WorldContentService::Instance()->IsCurrentExpansionTheLegacyOfYkesha();
 }
 
 bool lua_is_current_expansion_lost_dungeons_of_norrath() {
-	return content_service.IsCurrentExpansionLostDungeonsOfNorrath();
+	return WorldContentService::Instance()->IsCurrentExpansionLostDungeonsOfNorrath();
 }
 
 bool lua_is_current_expansion_gates_of_discord() {
-	return content_service.IsCurrentExpansionGatesOfDiscord();
+	return WorldContentService::Instance()->IsCurrentExpansionGatesOfDiscord();
 }
 
 bool lua_is_current_expansion_omens_of_war() {
-	return content_service.IsCurrentExpansionOmensOfWar();
+	return WorldContentService::Instance()->IsCurrentExpansionOmensOfWar();
 }
 
 bool lua_is_current_expansion_dragons_of_norrath() {
-	return content_service.IsCurrentExpansionDragonsOfNorrath();
+	return WorldContentService::Instance()->IsCurrentExpansionDragonsOfNorrath();
 }
 
 bool lua_is_current_expansion_depths_of_darkhollow() {
-	return content_service.IsCurrentExpansionDepthsOfDarkhollow();
+	return WorldContentService::Instance()->IsCurrentExpansionDepthsOfDarkhollow();
 }
 
 bool lua_is_current_expansion_prophecy_of_ro() {
-	return content_service.IsCurrentExpansionProphecyOfRo();
+	return WorldContentService::Instance()->IsCurrentExpansionProphecyOfRo();
 }
 
 bool lua_is_current_expansion_the_serpents_spine() {
-	return content_service.IsCurrentExpansionTheSerpentsSpine();
+	return WorldContentService::Instance()->IsCurrentExpansionTheSerpentsSpine();
 }
 
 bool lua_is_current_expansion_the_buried_sea() {
-	return content_service.IsCurrentExpansionTheBuriedSea();
+	return WorldContentService::Instance()->IsCurrentExpansionTheBuriedSea();
 }
 
 bool lua_is_current_expansion_secrets_of_faydwer() {
-	return content_service.IsCurrentExpansionSecretsOfFaydwer();
+	return WorldContentService::Instance()->IsCurrentExpansionSecretsOfFaydwer();
 }
 
 bool lua_is_current_expansion_seeds_of_destruction() {
-	return content_service.IsCurrentExpansionSeedsOfDestruction();
+	return WorldContentService::Instance()->IsCurrentExpansionSeedsOfDestruction();
 }
 
 bool lua_is_current_expansion_underfoot() {
-	return content_service.IsCurrentExpansionUnderfoot();
+	return WorldContentService::Instance()->IsCurrentExpansionUnderfoot();
 }
 
 bool lua_is_current_expansion_house_of_thule() {
-	return content_service.IsCurrentExpansionHouseOfThule();
+	return WorldContentService::Instance()->IsCurrentExpansionHouseOfThule();
 }
 
 bool lua_is_current_expansion_veil_of_alaris() {
-	return content_service.IsCurrentExpansionVeilOfAlaris();
+	return WorldContentService::Instance()->IsCurrentExpansionVeilOfAlaris();
 }
 
 bool lua_is_current_expansion_rain_of_fear() {
-	return content_service.IsCurrentExpansionRainOfFear();
+	return WorldContentService::Instance()->IsCurrentExpansionRainOfFear();
 }
 
 bool lua_is_current_expansion_call_of_the_forsaken() {
-	return content_service.IsCurrentExpansionCallOfTheForsaken();
+	return WorldContentService::Instance()->IsCurrentExpansionCallOfTheForsaken();
 }
 
 bool lua_is_current_expansion_the_darkened_sea() {
-	return content_service.IsCurrentExpansionTheDarkenedSea();
+	return WorldContentService::Instance()->IsCurrentExpansionTheDarkenedSea();
 }
 
 bool lua_is_current_expansion_the_broken_mirror() {
-	return content_service.IsCurrentExpansionTheBrokenMirror();
+	return WorldContentService::Instance()->IsCurrentExpansionTheBrokenMirror();
 }
 
 bool lua_is_current_expansion_empires_of_kunark() {
-	return content_service.IsCurrentExpansionEmpiresOfKunark();
+	return WorldContentService::Instance()->IsCurrentExpansionEmpiresOfKunark();
 }
 
 bool lua_is_current_expansion_ring_of_scale() {
-	return content_service.IsCurrentExpansionRingOfScale();
+	return WorldContentService::Instance()->IsCurrentExpansionRingOfScale();
 }
 
 bool lua_is_current_expansion_the_burning_lands() {
-	return content_service.IsCurrentExpansionTheBurningLands();
+	return WorldContentService::Instance()->IsCurrentExpansionTheBurningLands();
 }
 
 bool lua_is_current_expansion_torment_of_velious() {
-	return content_service.IsCurrentExpansionTormentOfVelious();
+	return WorldContentService::Instance()->IsCurrentExpansionTormentOfVelious();
 }
 
 bool lua_is_content_flag_enabled(std::string content_flag){
-	return content_service.IsContentFlagEnabled(content_flag);
+	return WorldContentService::Instance()->IsContentFlagEnabled(content_flag);
 }
 
 void lua_set_content_flag(std::string flag_name, bool enabled){
-	content_service.SetContentFlag(flag_name, enabled);
+	WorldContentService::Instance()->SetContentFlag(flag_name, enabled);
 	zone->ReloadContentFlags();
 }
 

--- a/zone/main.cpp
+++ b/zone/main.cpp
@@ -101,7 +101,6 @@ TitleManager          title_manager;
 QueryServ             *QServ        = 0;
 NpcScaleManager       *npc_scale_manager;
 QuestParserCollection *parse        = 0;
-WorldContentService   content_service;
 PlayerEventLogs       player_event_logs;
 
 const SPDat_Spell_Struct* spells;
@@ -409,7 +408,7 @@ int main(int argc, char **argv)
 		LogInfo("Loaded [{}] commands loaded", Strings::Commify(std::to_string(retval)));
 	}
 
-	content_service.SetDatabase(&database)
+	WorldContentService::Instance()->SetDatabase(&database)
 		->SetContentDatabase(&content_db)
 		->SetExpansionContext()
 		->ReloadContentFlags();
@@ -624,7 +623,8 @@ int main(int argc, char **argv)
 				entity_list.MobProcess();
 				entity_list.BeaconProcess();
 				entity_list.EncounterProcess();
-				ZoneEventScheduler::Instance()->Process(zone, &content_service);
+
+				ZoneEventScheduler::Instance()->Process(zone, WorldContentService::Instance());
 
 				if (zone) {
 					if (!zone->Process()) {

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -4571,7 +4571,7 @@ void WorldServer::ProcessReload(const ServerReload::Request& request)
 			break;
 
 		case ServerReload::Type::ContentFlags:
-			content_service.SetExpansionContext()->ReloadContentFlags();
+			WorldContentService::Instance()->SetExpansionContext()->ReloadContentFlags();
 			break;
 
 		case ServerReload::Type::DzTemplates:

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -1291,7 +1291,7 @@ void Zone::ReloadStaticData() {
 		);
 	} // if that fails, try the file name, then load defaults
 
-	content_service.SetExpansionContext()->ReloadContentFlags();
+	WorldContentService::Instance()->SetExpansionContext()->ReloadContentFlags();
 
 
 	LogInfo("Zone Static Data Reloaded");

--- a/zone/zone_loot.cpp
+++ b/zone/zone_loot.cpp
@@ -211,7 +211,7 @@ LoottableRepository::Loottable *Zone::GetLootTable(const uint32 loottable_id)
 {
 	for (auto &e: m_loottables) {
 		if (e.id == loottable_id) {
-			if (!content_service.DoesPassContentFiltering(
+			if (!WorldContentService::Instance()->DoesPassContentFiltering(
 				ContentFlags{
 					.min_expansion = e.min_expansion,
 					.max_expansion = e.max_expansion,
@@ -249,7 +249,7 @@ LootdropRepository::Lootdrop Zone::GetLootdrop(const uint32 lootdrop_id) const
 {
 	for (const auto &e: m_lootdrops) {
 		if (e.id == lootdrop_id) {
-			if (!content_service.DoesPassContentFiltering(
+			if (!WorldContentService::Instance()->DoesPassContentFiltering(
 				ContentFlags{
 					.min_expansion = e.min_expansion,
 					.max_expansion = e.max_expansion,
@@ -276,7 +276,7 @@ std::vector<LootdropEntriesRepository::LootdropEntries> Zone::GetLootdropEntries
 	std::vector<LootdropEntriesRepository::LootdropEntries> entries = {};
 	for (const auto &e: m_lootdrop_entries) {
 		if (e.lootdrop_id == lootdrop_id) {
-			if (!content_service.DoesPassContentFiltering(
+			if (!WorldContentService::Instance()->DoesPassContentFiltering(
 				ContentFlags{
 					.min_expansion = e.min_expansion,
 					.max_expansion = e.max_expansion,

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -72,7 +72,7 @@ void Client::Handle_OP_ZoneChange(const EQApplicationPacket *app) {
 		int(zone_mode)
 	);
 
-	content_service.HandleZoneRoutingMiddleware(zc);
+	WorldContentService::Instance()->HandleZoneRoutingMiddleware(zc);
 
 	uint16 target_zone_id = 0;
 	auto target_instance_id = zc->instanceID;
@@ -349,19 +349,19 @@ void Client::Handle_OP_ZoneChange(const EQApplicationPacket *app) {
 	//TODO: ADVENTURE ENTRANCE CHECK
 
 	// Expansion checks and routing
-	if (content_service.GetCurrentExpansion() >= Expansion::Classic && !GetGM()) {
+	if (WorldContentService::Instance()->GetCurrentExpansion() >= Expansion::Classic && !GetGM()) {
 		bool meets_zone_expansion_check = false;
 
 		auto z = ZoneStore::Instance()->GetZoneWithFallback(ZoneID(target_zone_name), 0);
-		if (z->expansion <= content_service.GetCurrentExpansion() || z->bypass_expansion_check) {
+		if (z->expansion <= WorldContentService::Instance()->GetCurrentExpansion() || z->bypass_expansion_check) {
 			meets_zone_expansion_check = true;
 		}
 
 		LogZoning(
 			"Checking zone request [{}] for expansion [{}] ({}) success [{}]",
 			target_zone_name,
-			(content_service.GetCurrentExpansion()),
-			content_service.GetCurrentExpansionName(),
+			(WorldContentService::Instance()->GetCurrentExpansion()),
+			WorldContentService::Instance()->GetCurrentExpansionName(),
 			meets_zone_expansion_check ? "true" : "false"
 		);
 
@@ -370,7 +370,7 @@ void Client::Handle_OP_ZoneChange(const EQApplicationPacket *app) {
 		}
 	}
 
-	if (content_service.GetCurrentExpansion() >= Expansion::Classic && GetGM()) {
+	if (WorldContentService::Instance()->GetCurrentExpansion() >= Expansion::Classic && GetGM()) {
 		LogInfo("[{}] Bypassing zone expansion checks because GM flag is set", GetCleanName());
 		Message(Chat::White, "Your GM flag allows you to bypass zone expansion checks.");
 	}
@@ -763,7 +763,7 @@ void Client::ZonePC(uint32 zoneID, uint32 instance_id, float x, float y, float z
 		pZoneName = strcpy(new char[zd->long_name.length() + 1], zd->long_name.c_str());
 	}
 
-	auto r = content_service.FindZone(zoneID, instance_id);
+	auto r = WorldContentService::Instance()->FindZone(zoneID, instance_id);
 	if (r.zone_id) {
 		zoneID      = r.zone_id;
 		instance_id = r.instance.id;
@@ -781,7 +781,7 @@ void Client::ZonePC(uint32 zoneID, uint32 instance_id, float x, float y, float z
 		);
 
 		// If we are zoning to the same zone, we need to use the current instance ID if it is not specified.
-		if (content_service.IsInPublicStaticInstance(instance_id) && zoneID == zone->GetZoneID() && instance_id == 0) {
+		if (WorldContentService::Instance()->IsInPublicStaticInstance(instance_id) && zoneID == zone->GetZoneID() && instance_id == 0) {
 			instance_id = zone->GetInstanceID();
 		}
 	}


### PR DESCRIPTION
# Description

This is part of a larger effort to remove global variables from the codebase. Eventually singletons can be cleaned up to be passed explicitly through dependency injection.

For now this encapsulates dependencies far better.

## Type of change

- [x] Code Cleanup

# Testing

TBD

# Checklist

- [] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur