### PR TITLE
[Code] TaskManager Global to Singleton Cleanup

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2683,7 +2683,7 @@ bool NPC::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillTy
 				give_exp_client->GetCleanName(),
 				GetNPCTypeID()
 			);
-			task_manager->HandleUpdateTasksOnKill(give_exp_client, this);
+			TaskManager::Instance()->HandleUpdateTasksOnKill(give_exp_client, this);
 		}
 
 		if (killer_raid) {

--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -63,7 +63,6 @@
 
 extern QueryServ* QServ;
 extern WorldServer worldserver;
-extern TaskManager *task_manager;
 
 int bot_command_count;
 
@@ -165,7 +164,7 @@ int bot_command_init(void)
 		bot_command_add("inventoryremove", "Removes an item from a bot's inventory", AccountStatus::Player, bot_command_inventory_remove) ||
 		bot_command_add("inventorywindow", "Displays all items in a bot's inventory in a pop-up window", AccountStatus::Player, bot_command_inventory_window) ||
 		bot_command_add("itemuse", "Elicits a report from spawned bots that can use the item on your cursor (option 'empty' yields only empty slots)", AccountStatus::Player, bot_command_item_use) ||
-		bot_command_add("maxmeleerange", "Toggles whether your bot is at max melee range or not. This will disable all special abilities, including taunt.", AccountStatus::Player, bot_command_max_melee_range) ||		
+		bot_command_add("maxmeleerange", "Toggles whether your bot is at max melee range or not. This will disable all special abilities, including taunt.", AccountStatus::Player, bot_command_max_melee_range) ||
 		bot_command_add("owneroption", "Sets options available to bot owners", AccountStatus::Player, bot_command_owner_option) ||
 		bot_command_add("pet", "Lists the available bot pet [subcommands]", AccountStatus::Player, bot_command_pet) ||
 		bot_command_add("petgetlost", "Orders a bot to remove its summoned pet", AccountStatus::Player, bot_command_pet_get_lost) ||
@@ -189,11 +188,11 @@ int bot_command_init(void)
 		bot_command_add("spellmaxhppct", "Controls at what HP percent a bot will stop casting different spell types", AccountStatus::Player, bot_command_spell_max_hp_pct) ||
 		bot_command_add("spellmaxmanapct", "Controls at what mana percent a bot will stop casting different spell types", AccountStatus::Player, bot_command_spell_max_mana_pct) ||
 		bot_command_add("spellmaxthresholds", "Controls the minimum target HP threshold for a spell to be cast for a specific type", AccountStatus::Player, bot_command_spell_max_thresholds) ||
-		bot_command_add("spellminhppct", "Controls at what HP percent a bot will start casting different spell types", AccountStatus::Player, bot_command_spell_min_hp_pct) ||		
+		bot_command_add("spellminhppct", "Controls at what HP percent a bot will start casting different spell types", AccountStatus::Player, bot_command_spell_min_hp_pct) ||
 		bot_command_add("spellminmanapct", "Controls at what mana percent a bot will start casting different spell types", AccountStatus::Player, bot_command_spell_min_mana_pct) ||
-		bot_command_add("spellminthresholds", "Controls the maximum target HP threshold for a spell to be cast for a specific type", AccountStatus::Player, bot_command_spell_min_thresholds) ||		
+		bot_command_add("spellminthresholds", "Controls the maximum target HP threshold for a spell to be cast for a specific type", AccountStatus::Player, bot_command_spell_min_thresholds) ||
 		bot_command_add("spellresistlimits", "Controls the resist limits for bots to cast spells on their target", AccountStatus::Player, bot_command_spell_resist_limits) ||
-		bot_command_add("spellpursuepriority", "Controls the order of casts by spell type when pursuing in combat", AccountStatus::Player, bot_command_spell_pursue_priority) ||				
+		bot_command_add("spellpursuepriority", "Controls the order of casts by spell type when pursuing in combat", AccountStatus::Player, bot_command_spell_pursue_priority) ||
 		bot_command_add("spelltargetcount", "Sets the required target amount for group/AE spells by spell type", AccountStatus::Player, bot_command_spell_target_count) ||
 		bot_command_add("spellinfo", "Opens a dialogue window with spell info", AccountStatus::Player, bot_spell_info_dialogue_window) ||
 		bot_command_add("spells", "Lists all Spells learned by the Bot.", AccountStatus::Player, bot_command_spell_list) ||

--- a/zone/client.h
+++ b/zone/client.h
@@ -98,7 +98,6 @@ namespace EQ
 #define MAX_SPECIALIZED_SKILL 50
 
 extern Zone* zone;
-extern TaskManager *task_manager;
 
 class CLIENTPACKET
 {
@@ -1359,7 +1358,7 @@ public:
 	}
 	inline bool SaveTaskState()
 	{
-		return task_manager != nullptr && task_manager->SaveClientState(this, task_state);
+		return TaskManager::Instance() != nullptr && TaskManager::Instance()->SaveClientState(this, task_state);
 	}
 	inline bool IsTaskStateLoaded() { return task_state != nullptr; }
 	inline bool IsTaskActive(int task_id) { return task_state != nullptr && task_state->IsTaskActive(task_id); }
@@ -1433,14 +1432,14 @@ public:
 	}
 	inline void TaskSetSelector(Mob* mob, int task_set_id, bool ignore_cooldown)
 	{
-		if (task_manager && task_state) {
-			task_manager->TaskSetSelector(this, mob, task_set_id, ignore_cooldown);
+		if (TaskManager::Instance() && task_state) {
+			TaskManager::Instance()->TaskSetSelector(this, mob, task_set_id, ignore_cooldown);
 		}
 	}
 	inline void TaskQuestSetSelector(Mob* mob, const std::vector<int>& tasks, bool ignore_cooldown)
 	{
-		if (task_manager && task_state) {
-			task_manager->TaskQuestSetSelector(this, mob, tasks, ignore_cooldown);
+		if (TaskManager::Instance() && task_state) {
+			TaskManager::Instance()->TaskQuestSetSelector(this, mob, tasks, ignore_cooldown);
 		}
 	}
 	inline void EnableTask(int task_count, int *task_list)

--- a/zone/client.h
+++ b/zone/client.h
@@ -1358,7 +1358,7 @@ public:
 	}
 	inline bool SaveTaskState()
 	{
-		return TaskManager::Instance() != nullptr && TaskManager::Instance()->SaveClientState(this, task_state);
+		return TaskManager::Instance()->SaveClientState(this, task_state);
 	}
 	inline bool IsTaskStateLoaded() { return task_state != nullptr; }
 	inline bool IsTaskActive(int task_id) { return task_state != nullptr && task_state->IsTaskActive(task_id); }
@@ -1432,13 +1432,13 @@ public:
 	}
 	inline void TaskSetSelector(Mob* mob, int task_set_id, bool ignore_cooldown)
 	{
-		if (TaskManager::Instance() && task_state) {
+		if (task_state) {
 			TaskManager::Instance()->TaskSetSelector(this, mob, task_set_id, ignore_cooldown);
 		}
 	}
 	inline void TaskQuestSetSelector(Mob* mob, const std::vector<int>& tasks, bool ignore_cooldown)
 	{
-		if (TaskManager::Instance() && task_state) {
+		if (task_state) {
 			TaskManager::Instance()->TaskQuestSetSelector(this, mob, tasks, ignore_cooldown);
 		}
 	}

--- a/zone/command.cpp
+++ b/zone/command.cpp
@@ -34,7 +34,6 @@
 
 extern QueryServ* QServ;
 extern WorldServer worldserver;
-extern TaskManager *task_manager;
 extern FastMath g_Math;
 void CatchSignal(int sig_num);
 

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -4175,10 +4175,6 @@ void EntityList::ProcessProximitySay(const char *message, Client *c, uint8 langu
 
 void EntityList::SaveAllClientsTaskState()
 {
-	if (!TaskManager::Instance()) {
-		return;
-	}
-
 	auto it = client_list.begin();
 	while (it != client_list.end()) {
 		Client *client = it->second;
@@ -4192,9 +4188,6 @@ void EntityList::SaveAllClientsTaskState()
 
 void EntityList::ReloadAllClientsTaskState(int task_id)
 {
-	if (!TaskManager::Instance())
-		return;
-
 	auto it = client_list.begin();
 	while (it != client_list.end()) {
 		Client *client = it->second;

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -4175,7 +4175,7 @@ void EntityList::ProcessProximitySay(const char *message, Client *c, uint8 langu
 
 void EntityList::SaveAllClientsTaskState()
 {
-	if (!task_manager) {
+	if (!TaskManager::Instance()) {
 		return;
 	}
 
@@ -4192,7 +4192,7 @@ void EntityList::SaveAllClientsTaskState()
 
 void EntityList::ReloadAllClientsTaskState(int task_id)
 {
-	if (!task_manager)
+	if (!TaskManager::Instance())
 		return;
 
 	auto it = client_list.begin();
@@ -4205,7 +4205,7 @@ void EntityList::ReloadAllClientsTaskState(int task_id)
 				Log(Logs::General, Logs::Tasks, "[CLIENTLOAD] Reloading Task State For Client %s", client->GetName());
 				client->RemoveClientTaskState();
 				client->LoadClientTaskState();
-				task_manager->SendActiveTasksToClient(client);
+				TaskManager::Instance()->SendActiveTasksToClient(client);
 			}
 		}
 		++it;

--- a/zone/gm_commands/find/task.cpp
+++ b/zone/gm_commands/find/task.cpp
@@ -11,7 +11,7 @@ void FindTask(Client *c, const Seperator *sep)
 
 	if (sep->IsNumber(2)) {
 		const auto  task_id   = Strings::ToUnsignedInt(sep->arg[2]);
-		const auto& task_name = task_manager->GetTaskName(task_id);
+		const auto& task_name = TaskManager::Instance()->GetTaskName(task_id);
 
 		if (task_name.empty()) {
 			c->Message(
@@ -41,7 +41,7 @@ void FindTask(Client *c, const Seperator *sep)
 
 	auto found_count = 0;
 
-	for (const auto& t : task_manager->GetTaskData()) {
+	for (const auto& t : TaskManager::Instance()->GetTaskData()) {
 		const auto& task_name       = t.second.title;
 		const auto& task_name_lower = Strings::ToLower(task_name);
 		if (!Strings::Contains(task_name_lower, search_criteria)) {

--- a/zone/gm_commands/task.cpp
+++ b/zone/gm_commands/task.cpp
@@ -176,7 +176,7 @@ void command_task(Client *c, const Seperator *sep)
 				Chat::White,
 				fmt::format(
 					"Assigned {} (ID {}) to {}.",
-					task_manager->GetTaskName(task_id),
+					TaskManager::Instance()->GetTaskName(task_id),
 					task_id,
 					c->GetTargetDescription(t)
 				).c_str()
@@ -197,7 +197,7 @@ void command_task(Client *c, const Seperator *sep)
 						Chat::White,
 						fmt::format(
 							"Successfully completed {} (ID {}) for {}.",
-							task_manager->GetTaskName(task_id),
+							TaskManager::Instance()->GetTaskName(task_id),
 							task_id,
 							c->GetTargetDescription(t)
 						).c_str()
@@ -207,7 +207,7 @@ void command_task(Client *c, const Seperator *sep)
 						Chat::White,
 						fmt::format(
 							"Failed to complete {} (ID {}) for {}.",
-							task_manager->GetTaskName(task_id),
+							TaskManager::Instance()->GetTaskName(task_id),
 							task_id,
 							c->GetTargetDescription(t)
 						).c_str()
@@ -220,7 +220,7 @@ void command_task(Client *c, const Seperator *sep)
 						"{} {} not have not {} (ID {}) assigned to them.",
 						c->GetTargetDescription(t, TargetDescriptionType::UCYou),
 						c == t ? "do" : "does",
-						task_manager->GetTaskName(task_id),
+						TaskManager::Instance()->GetTaskName(task_id),
 						task_id
 					).c_str()
 				);
@@ -256,7 +256,7 @@ void command_task(Client *c, const Seperator *sep)
 						Chat::White,
 						fmt::format(
 							"Attempting to reload {} (ID {}).",
-							task_manager->GetTaskName(task_id),
+							TaskManager::Instance()->GetTaskName(task_id),
 							task_id
 						).c_str()
 					);
@@ -265,7 +265,7 @@ void command_task(Client *c, const Seperator *sep)
 						Chat::White,
 						fmt::format(
 							"Successfully reloaded {} (ID {}).",
-							task_manager->GetTaskName(task_id),
+							TaskManager::Instance()->GetTaskName(task_id),
 							task_id
 						).c_str()
 					);
@@ -318,7 +318,7 @@ void command_task(Client *c, const Seperator *sep)
 					Chat::White,
 					fmt::format(
 						"Successfully uncompleted {} (ID {}) for {}.",
-						task_manager->GetTaskName(task_id),
+						TaskManager::Instance()->GetTaskName(task_id),
 						task_id,
 						c->GetTargetDescription(t)
 					).c_str()
@@ -330,7 +330,7 @@ void command_task(Client *c, const Seperator *sep)
 						"{} {} not completed {} (ID {}).",
 						c->GetTargetDescription(t, TargetDescriptionType::UCYou),
 						c == t ? "have" : "has",
-						task_manager->GetTaskName(task_id),
+						TaskManager::Instance()->GetTaskName(task_id),
 						task_id
 					).c_str()
 				);
@@ -353,7 +353,7 @@ void command_task(Client *c, const Seperator *sep)
 				Chat::White,
 				fmt::format(
 					"Updating {} (ID {}), activity {} with a count of {} for {}.",
-					task_manager->GetTaskName(task_id),
+					TaskManager::Instance()->GetTaskName(task_id),
 					task_id,
 					activity_id,
 					count,

--- a/zone/main.cpp
+++ b/zone/main.cpp
@@ -101,7 +101,6 @@ extern Zone *zone;
 npcDecayTimes_Struct  npcCorpseDecayTimes[100];
 TitleManager          title_manager;
 QueryServ             *QServ        = 0;
-TaskManager           *task_manager = 0;
 NpcScaleManager       *npc_scale_manager;
 QuestParserCollection *parse        = 0;
 EQEmuLogSys           LogSys;
@@ -450,8 +449,7 @@ int main(int argc, char **argv)
 	npc_scale_manager->LoadScaleData();
 
 	if (RuleB(TaskSystem, EnableTaskSystem)) {
-		task_manager = new TaskManager;
-		task_manager->LoadTasks();
+		TaskManager::Instance()->LoadTasks();
 	}
 
 	parse = new QuestParserCollection();
@@ -682,7 +680,6 @@ int main(int argc, char **argv)
 		zone->Shutdown(true);
 	}
 	//Fix for Linux world server problem.
-	safe_delete(task_manager);
 	safe_delete(npc_scale_manager);
 	command_deinit();
 	bot_command_deinit();

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -2868,27 +2868,27 @@ bool QuestManager::createBot(const char *name, const char *lastname, uint8 level
 
 void QuestManager::taskselector(const std::vector<int>& tasks, bool ignore_cooldown) {
 	QuestManagerCurrentQuestVars();
-	if(RuleB(TaskSystem, EnableTaskSystem) && initiator && owner && task_manager)
+	if(RuleB(TaskSystem, EnableTaskSystem) && initiator && owner && TaskManager::Instance())
 		initiator->TaskQuestSetSelector(owner, tasks, ignore_cooldown);
 }
 void QuestManager::enabletask(int taskcount, int *tasks) {
 	QuestManagerCurrentQuestVars();
 
-	if(RuleB(TaskSystem, EnableTaskSystem) && initiator && task_manager)
+	if(RuleB(TaskSystem, EnableTaskSystem) && initiator && TaskManager::Instance())
 		initiator->EnableTask(taskcount, tasks);
 }
 
 void QuestManager::disabletask(int taskcount, int *tasks) {
 	QuestManagerCurrentQuestVars();
 
-	if(RuleB(TaskSystem, EnableTaskSystem) && initiator && task_manager)
+	if(RuleB(TaskSystem, EnableTaskSystem) && initiator && TaskManager::Instance())
 		initiator->DisableTask(taskcount, tasks);
 }
 
 bool QuestManager::istaskenabled(int taskid) {
 	QuestManagerCurrentQuestVars();
 
-	if(RuleB(TaskSystem, EnableTaskSystem) && initiator && task_manager)
+	if(RuleB(TaskSystem, EnableTaskSystem) && initiator && TaskManager::Instance())
 		return initiator->IsTaskEnabled(taskid);
 
 	return false;
@@ -2897,7 +2897,7 @@ bool QuestManager::istaskenabled(int taskid) {
 void QuestManager::tasksetselector(int tasksetid, bool ignore_cooldown) {
 	QuestManagerCurrentQuestVars();
 	Log(Logs::General, Logs::Tasks, "[UPDATE] TaskSetSelector called for task set %i", tasksetid);
-	if(RuleB(TaskSystem, EnableTaskSystem) && initiator && owner && task_manager)
+	if(RuleB(TaskSystem, EnableTaskSystem) && initiator && owner && TaskManager::Instance())
 		initiator->TaskSetSelector(owner, tasksetid, ignore_cooldown);
 }
 
@@ -2979,8 +2979,8 @@ int QuestManager::enabledtaskcount(int taskset) {
 int QuestManager::firsttaskinset(int taskset) {
 	QuestManagerCurrentQuestVars();
 
-	if(RuleB(TaskSystem, EnableTaskSystem) && task_manager)
-		return task_manager->FirstTaskInSet(taskset);
+	if(RuleB(TaskSystem, EnableTaskSystem) && TaskManager::Instance())
+		return TaskManager::Instance()->FirstTaskInSet(taskset);
 
 	return -1;
 }
@@ -2988,8 +2988,8 @@ int QuestManager::firsttaskinset(int taskset) {
 int QuestManager::lasttaskinset(int taskset) {
 	QuestManagerCurrentQuestVars();
 
-	if(RuleB(TaskSystem, EnableTaskSystem) && task_manager)
-		return task_manager->LastTaskInSet(taskset);
+	if(RuleB(TaskSystem, EnableTaskSystem) && TaskManager::Instance())
+		return TaskManager::Instance()->LastTaskInSet(taskset);
 
 	return -1;
 }
@@ -2997,8 +2997,8 @@ int QuestManager::lasttaskinset(int taskset) {
 int QuestManager::nexttaskinset(int taskset, int taskid) {
 	QuestManagerCurrentQuestVars();
 
-	if(RuleB(TaskSystem, EnableTaskSystem) && task_manager)
-		return task_manager->NextTaskInSet(taskset, taskid);
+	if(RuleB(TaskSystem, EnableTaskSystem) && TaskManager::Instance())
+		return TaskManager::Instance()->NextTaskInSet(taskset, taskid);
 
 	return -1;
 }
@@ -3063,8 +3063,8 @@ int QuestManager::completedtasksinset(int taskset) {
 bool QuestManager::istaskappropriate(int task) {
 	QuestManagerCurrentQuestVars();
 
-	if(RuleB(TaskSystem, EnableTaskSystem) && initiator && task_manager)
-		return task_manager->ValidateLevel(task, initiator->GetLevel());
+	if(RuleB(TaskSystem, EnableTaskSystem) && initiator && TaskManager::Instance())
+		return TaskManager::Instance()->ValidateLevel(task, initiator->GetLevel());
 
 	return false;
 }
@@ -3073,7 +3073,7 @@ std::string QuestManager::gettaskname(uint32 task_id) {
 	QuestManagerCurrentQuestVars();
 
 	if (RuleB(TaskSystem, EnableTaskSystem)) {
-		return task_manager->GetTaskName(task_id);
+		return TaskManager::Instance()->GetTaskName(task_id);
 	}
 
 	return std::string();
@@ -3082,8 +3082,8 @@ std::string QuestManager::gettaskname(uint32 task_id) {
 int QuestManager::GetCurrentDzTaskID() {
 	QuestManagerCurrentQuestVars();
 
-	if (RuleB(TaskSystem, EnableTaskSystem) && zone && task_manager) {
-		return task_manager->GetCurrentDzTaskID();
+	if (RuleB(TaskSystem, EnableTaskSystem) && zone && TaskManager::Instance()) {
+		return TaskManager::Instance()->GetCurrentDzTaskID();
 	}
 
 	return 0;
@@ -3092,8 +3092,8 @@ int QuestManager::GetCurrentDzTaskID() {
 void QuestManager::EndCurrentDzTask(bool send_fail) {
 	QuestManagerCurrentQuestVars();
 
-	if (RuleB(TaskSystem, EnableTaskSystem) && zone && task_manager) {
-		task_manager->EndCurrentDzTask(send_fail);
+	if (RuleB(TaskSystem, EnableTaskSystem) && zone && TaskManager::Instance()) {
+		TaskManager::Instance()->EndCurrentDzTask(send_fail);
 	}
 }
 

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -2868,27 +2868,27 @@ bool QuestManager::createBot(const char *name, const char *lastname, uint8 level
 
 void QuestManager::taskselector(const std::vector<int>& tasks, bool ignore_cooldown) {
 	QuestManagerCurrentQuestVars();
-	if(RuleB(TaskSystem, EnableTaskSystem) && initiator && owner && TaskManager::Instance())
+	if(RuleB(TaskSystem, EnableTaskSystem) && initiator && owner)
 		initiator->TaskQuestSetSelector(owner, tasks, ignore_cooldown);
 }
 void QuestManager::enabletask(int taskcount, int *tasks) {
 	QuestManagerCurrentQuestVars();
 
-	if(RuleB(TaskSystem, EnableTaskSystem) && initiator && TaskManager::Instance())
+	if(RuleB(TaskSystem, EnableTaskSystem) && initiator)
 		initiator->EnableTask(taskcount, tasks);
 }
 
 void QuestManager::disabletask(int taskcount, int *tasks) {
 	QuestManagerCurrentQuestVars();
 
-	if(RuleB(TaskSystem, EnableTaskSystem) && initiator && TaskManager::Instance())
+	if(RuleB(TaskSystem, EnableTaskSystem) && initiator)
 		initiator->DisableTask(taskcount, tasks);
 }
 
 bool QuestManager::istaskenabled(int taskid) {
 	QuestManagerCurrentQuestVars();
 
-	if(RuleB(TaskSystem, EnableTaskSystem) && initiator && TaskManager::Instance())
+	if(RuleB(TaskSystem, EnableTaskSystem) && initiator)
 		return initiator->IsTaskEnabled(taskid);
 
 	return false;
@@ -2897,7 +2897,7 @@ bool QuestManager::istaskenabled(int taskid) {
 void QuestManager::tasksetselector(int tasksetid, bool ignore_cooldown) {
 	QuestManagerCurrentQuestVars();
 	Log(Logs::General, Logs::Tasks, "[UPDATE] TaskSetSelector called for task set %i", tasksetid);
-	if(RuleB(TaskSystem, EnableTaskSystem) && initiator && owner && TaskManager::Instance())
+	if(RuleB(TaskSystem, EnableTaskSystem) && initiator && owner)
 		initiator->TaskSetSelector(owner, tasksetid, ignore_cooldown);
 }
 
@@ -2979,7 +2979,7 @@ int QuestManager::enabledtaskcount(int taskset) {
 int QuestManager::firsttaskinset(int taskset) {
 	QuestManagerCurrentQuestVars();
 
-	if(RuleB(TaskSystem, EnableTaskSystem) && TaskManager::Instance())
+	if(RuleB(TaskSystem, EnableTaskSystem))
 		return TaskManager::Instance()->FirstTaskInSet(taskset);
 
 	return -1;
@@ -2988,7 +2988,7 @@ int QuestManager::firsttaskinset(int taskset) {
 int QuestManager::lasttaskinset(int taskset) {
 	QuestManagerCurrentQuestVars();
 
-	if(RuleB(TaskSystem, EnableTaskSystem) && TaskManager::Instance())
+	if(RuleB(TaskSystem, EnableTaskSystem))
 		return TaskManager::Instance()->LastTaskInSet(taskset);
 
 	return -1;
@@ -2997,7 +2997,7 @@ int QuestManager::lasttaskinset(int taskset) {
 int QuestManager::nexttaskinset(int taskset, int taskid) {
 	QuestManagerCurrentQuestVars();
 
-	if(RuleB(TaskSystem, EnableTaskSystem) && TaskManager::Instance())
+	if(RuleB(TaskSystem, EnableTaskSystem))
 		return TaskManager::Instance()->NextTaskInSet(taskset, taskid);
 
 	return -1;
@@ -3063,7 +3063,7 @@ int QuestManager::completedtasksinset(int taskset) {
 bool QuestManager::istaskappropriate(int task) {
 	QuestManagerCurrentQuestVars();
 
-	if(RuleB(TaskSystem, EnableTaskSystem) && initiator && TaskManager::Instance())
+	if(RuleB(TaskSystem, EnableTaskSystem) && initiator)
 		return TaskManager::Instance()->ValidateLevel(task, initiator->GetLevel());
 
 	return false;
@@ -3082,7 +3082,7 @@ std::string QuestManager::gettaskname(uint32 task_id) {
 int QuestManager::GetCurrentDzTaskID() {
 	QuestManagerCurrentQuestVars();
 
-	if (RuleB(TaskSystem, EnableTaskSystem) && zone && TaskManager::Instance()) {
+	if (RuleB(TaskSystem, EnableTaskSystem) && zone) {
 		return TaskManager::Instance()->GetCurrentDzTaskID();
 	}
 
@@ -3092,7 +3092,7 @@ int QuestManager::GetCurrentDzTaskID() {
 void QuestManager::EndCurrentDzTask(bool send_fail) {
 	QuestManagerCurrentQuestVars();
 
-	if (RuleB(TaskSystem, EnableTaskSystem) && zone && TaskManager::Instance()) {
+	if (RuleB(TaskSystem, EnableTaskSystem) && zone) {
 		TaskManager::Instance()->EndCurrentDzTask(send_fail);
 	}
 }

--- a/zone/shared_task_zone_messaging.cpp
+++ b/zone/shared_task_zone_messaging.cpp
@@ -157,7 +157,7 @@ void SharedTaskZoneMessaging::HandleWorldMessage(ServerPacket *pack)
 
 			for (auto &client: entity_list.GetClientList()) {
 				Client *c = client.second;
-				task_manager->SyncClientSharedTaskState(c, c->GetTaskState());
+				TaskManager::Instance()->SyncClientSharedTaskState(c, c->GetTaskState());
 				c->RemoveClientTaskState();
 				c->LoadClientTaskState();
 			}

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -521,11 +521,6 @@ bool ClientTaskState::CanUpdate(Client* client, const TaskUpdateFilter& filter, 
 
 int ClientTaskState::UpdateTasks(Client* client, const TaskUpdateFilter& filter, int count)
 {
-	if (!TaskManager::Instance())
-	{
-		return 0;
-	}
-
 	int max_updated = 0;
 
 	for (const auto& client_task : m_active_tasks)
@@ -593,11 +588,6 @@ int ClientTaskState::UpdateTasks(Client* client, const TaskUpdateFilter& filter,
 
 std::pair<int, int> ClientTaskState::FindTask(Client* client, const TaskUpdateFilter& filter) const
 {
-	if (!TaskManager::Instance())
-	{
-		return std::make_pair(0, 0);
-	}
-
 	for (const auto& client_task : m_active_tasks)
 	{
 		const auto task = GetTaskData(client_task);
@@ -1973,7 +1963,7 @@ void ClientTaskState::AcceptNewTask(
 	bool enforce_level_requirement
 )
 {
-	if (!TaskManager::Instance() || task_id < 0) {
+	if (task_id < 0) {
 		client->Message(Chat::Red, "Task system not functioning, or task_id %i out of range.", task_id);
 		return;
 	}
@@ -2455,10 +2445,6 @@ void ClientTaskState::SyncSharedTaskZoneClientDoneCountState(
 
 bool ClientTaskState::HasActiveTasks()
 {
-	if (!TaskManager::Instance()) {
-		return false;
-	}
-
 	if (m_active_task.task_id != TASKSLOTEMPTY) {
 		return true;
 	}
@@ -2495,7 +2481,7 @@ void ClientTaskState::LockSharedTask(Client* client, bool lock)
 
 void ClientTaskState::EndSharedTask(Client* client, bool send_fail)
 {
-	if (TaskManager::Instance() && m_active_shared_task.task_id != TASKSLOTEMPTY)
+	if (m_active_shared_task.task_id != TASKSLOTEMPTY)
 	{
 		TaskManager::Instance()->EndSharedTask(*client, m_active_shared_task.task_id, send_fail);
 	}

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -66,7 +66,7 @@ void ClientTaskState::SendTaskHistory(Client *client, int task_index)
 		return;
 	}
 
-	const auto task_data = task_manager->GetTaskData(task_id);
+	const auto task_data = TaskManager::Instance()->GetTaskData(task_id);
 	if (!task_data) {
 		return;
 	}
@@ -252,16 +252,16 @@ int ClientTaskState::EnabledTaskCount(int task_set_id)
 	if ((task_set_id <= 0) || (task_set_id >= MAXTASKSETS)) { return -1; }
 
 	while ((enabled_task_index < m_enabled_tasks.size()) &&
-		   (task_set_index < task_manager->m_task_sets[task_set_id].size())) {
+		   (task_set_index < TaskManager::Instance()->m_task_sets[task_set_id].size())) {
 
-		if (m_enabled_tasks[enabled_task_index] == task_manager->m_task_sets[task_set_id][task_set_index]) {
+		if (m_enabled_tasks[enabled_task_index] == TaskManager::Instance()->m_task_sets[task_set_id][task_set_index]) {
 			enabled_task_count++;
 			enabled_task_index++;
 			task_set_index++;
 			continue;
 		}
 
-		if (m_enabled_tasks[enabled_task_index] < task_manager->m_task_sets[task_set_id][task_set_index]) {
+		if (m_enabled_tasks[enabled_task_index] < TaskManager::Instance()->m_task_sets[task_set_id][task_set_index]) {
 			enabled_task_index++;
 		}
 		else {
@@ -281,7 +281,7 @@ int ClientTaskState::ActiveTasksInSet(int task_set_id)
 
 	int active_task_in_set_count = 0;
 
-	for (int task_id : task_manager->m_task_sets[task_set_id]) {
+	for (int task_id : TaskManager::Instance()->m_task_sets[task_set_id]) {
 		if (IsTaskActive(task_id)) {
 			active_task_in_set_count++;
 		}
@@ -298,7 +298,7 @@ int ClientTaskState::CompletedTasksInSet(int task_set_id)
 
 	int completed_tasks_count = 0;
 
-	for (int i : task_manager->m_task_sets[task_set_id]) {
+	for (int i : TaskManager::Instance()->m_task_sets[task_set_id]) {
 		if (IsTaskCompleted(i)) {
 			completed_tasks_count++;
 		}
@@ -362,7 +362,7 @@ bool ClientTaskState::UnlockActivities(Client* client, ClientTaskInformation& ta
 		task_info.updated
 	);
 
-	const auto task = task_manager->GetTaskData(task_info.task_id);
+	const auto task = TaskManager::Instance()->GetTaskData(task_info.task_id);
 	if (!task)
 	{
 		return true;
@@ -453,7 +453,7 @@ const TaskInformation* ClientTaskState::GetTaskData(const ClientTaskInformation&
 		return nullptr;
 	}
 
-	return task_manager->GetTaskData(client_task.task_id);
+	return TaskManager::Instance()->GetTaskData(client_task.task_id);
 }
 
 bool ClientTaskState::CanUpdate(Client* client, const TaskUpdateFilter& filter, int task_id,
@@ -521,7 +521,7 @@ bool ClientTaskState::CanUpdate(Client* client, const TaskUpdateFilter& filter, 
 
 int ClientTaskState::UpdateTasks(Client* client, const TaskUpdateFilter& filter, int count)
 {
-	if (!task_manager)
+	if (!TaskManager::Instance())
 	{
 		return 0;
 	}
@@ -593,7 +593,7 @@ int ClientTaskState::UpdateTasks(Client* client, const TaskUpdateFilter& filter,
 
 std::pair<int, int> ClientTaskState::FindTask(Client* client, const TaskUpdateFilter& filter) const
 {
-	if (!task_manager)
+	if (!TaskManager::Instance())
 	{
 		return std::make_pair(0, 0);
 	}
@@ -901,7 +901,7 @@ int ClientTaskState::IncrementDoneCount(
 		// and by the 'Task Stage Completed' message
 		client->SendTaskActivityComplete(info->task_id, activity_id, task_index, task_data->type);
 		// Send the updated task/activity_information list to the client
-		task_manager->SendSingleActiveTaskToClient(client, *info, task_complete, false);
+		TaskManager::Instance()->SendSingleActiveTaskToClient(client, *info, task_complete, false);
 
 		if (!ignore_quest_update) {
 			if (parse->PlayerHasQuestSub(EVENT_TASK_STAGE_COMPLETE)) {
@@ -929,7 +929,7 @@ int ClientTaskState::IncrementDoneCount(
 			if (player_event_logs.IsEventEnabled(PlayerEvent::TASK_COMPLETE)) {
 				auto e = PlayerEvent::TaskCompleteEvent{
 					.task_id = static_cast<uint32>(info->task_id),
-					.task_name = task_manager->GetTaskName(static_cast<uint32>(info->task_id)),
+					.task_name = TaskManager::Instance()->GetTaskName(static_cast<uint32>(info->task_id)),
 					.activity_id = static_cast<uint32>(info->activity[activity_id].activity_id),
 					.done_count = static_cast<uint32>(info->activity[activity_id].done_count)
 				};
@@ -948,7 +948,7 @@ int ClientTaskState::IncrementDoneCount(
 
 			// shared tasks linger at the completion step and do not get removed from the task window unlike quests/task
 			if (task_data->type != TaskType::Shared) {
-				task_manager->SendCompletedTasksToClient(client, this);
+				TaskManager::Instance()->SendCompletedTasksToClient(client, this);
 
 				client->CancelTask(task_index, task_data->type);
 			}
@@ -958,7 +958,7 @@ int ClientTaskState::IncrementDoneCount(
 	}
 	else {
 		// Send an updated packet for this single activity_information
-		task_manager->SendTaskActivityLong(
+		TaskManager::Instance()->SendTaskActivityLong(
 			client,
 			info->task_id,
 			activity_id,
@@ -968,7 +968,7 @@ int ClientTaskState::IncrementDoneCount(
 		if (player_event_logs.IsEventEnabled(PlayerEvent::TASK_UPDATE)) {
 			auto e = PlayerEvent::TaskUpdateEvent{
 				.task_id = static_cast<uint32>(info->task_id),
-				.task_name = task_manager->GetTaskName(static_cast<uint32>(info->task_id)),
+				.task_name = TaskManager::Instance()->GetTaskName(static_cast<uint32>(info->task_id)),
 				.activity_id = static_cast<uint32>(info->activity[activity_id].activity_id),
 				.done_count = static_cast<uint32>(info->activity[activity_id].done_count)
 			};
@@ -976,7 +976,7 @@ int ClientTaskState::IncrementDoneCount(
 		}
 	}
 
-	task_manager->SaveClientState(client, this);
+	TaskManager::Instance()->SaveClientState(client, this);
 
 	return count;
 }
@@ -1149,7 +1149,7 @@ void ClientTaskState::FailTask(Client *client, int task_id)
 
 	// type: Shared Task (failed via world for all members)
 	if (m_active_shared_task.task_id == task_id) {
-		task_manager->EndSharedTask(*client, task_id, true);
+		TaskManager::Instance()->EndSharedTask(*client, task_id, true);
 		return;
 	}
 
@@ -1211,7 +1211,7 @@ bool ClientTaskState::IsTaskActivityActive(int task_id, int activity_id)
 		return false;
 	}
 
-	const auto task_data = task_manager->GetTaskData(info->task_id);
+	const auto task_data = TaskManager::Instance()->GetTaskData(info->task_id);
 	if (!task_data) {
 		return false;
 	}
@@ -1282,7 +1282,7 @@ void ClientTaskState::UpdateTaskActivity(
 		return;
 	}
 
-	const auto task_data = task_manager->GetTaskData(info->task_id);
+	const auto task_data = TaskManager::Instance()->GetTaskData(info->task_id);
 	if (!task_data) {
 		return;
 	}
@@ -1352,7 +1352,7 @@ void ClientTaskState::ResetTaskActivity(Client *client, int task_id, int activit
 		return;
 	}
 
-	const auto task_data = task_manager->GetTaskData(info->task_id);
+	const auto task_data = TaskManager::Instance()->GetTaskData(info->task_id);
 	if (!task_data) {
 		return;
 	}
@@ -1386,14 +1386,14 @@ void ClientTaskState::ResetTaskActivity(Client *client, int task_id, int activit
 
 bool ClientTaskState::CompleteTask(Client *c, uint32 task_id)
 {
-	const auto task_data = task_manager->GetTaskData(task_id);
+	const auto task_data = TaskManager::Instance()->GetTaskData(task_id);
 	if (!task_data) {
 		return false;
 	}
 
 	for (
 		int activity_id = 0;
-		activity_id < task_manager->GetActivityCount(task_id);
+		activity_id < TaskManager::Instance()->GetActivityCount(task_id);
 		activity_id++
 	) {
 		c->UpdateTaskActivity(
@@ -1408,7 +1408,7 @@ bool ClientTaskState::CompleteTask(Client *c, uint32 task_id)
 
 void ClientTaskState::ShowClientTaskInfoMessage(ClientTaskInformation *task, Client *c)
 {
-	const auto task_data = task_manager->GetTaskData(task->task_id);
+	const auto task_data = TaskManager::Instance()->GetTaskData(task->task_id);
 
 	c->Message(Chat::White, "------------------------------------------------");
 	c->Message(
@@ -1430,7 +1430,7 @@ void ClientTaskState::ShowClientTaskInfoMessage(ClientTaskInformation *task, Cli
 		).c_str()
 	);
 
-	for (int activity_id = 0; activity_id < task_manager->GetActivityCount(task->task_id); activity_id++) {
+	for (int activity_id = 0; activity_id < TaskManager::Instance()->GetActivityCount(task->task_id); activity_id++) {
 		std::vector<std::string> update_increments = { "1", "5", "10", "20", "50" };
 		std::vector<std::string> update_saylinks;
 
@@ -1501,7 +1501,7 @@ int ClientTaskState::TaskTimeLeft(int task_id)
 	if (m_active_task.task_id == task_id) {
 		int time_now = time(nullptr);
 
-		const auto task_data = task_manager->GetTaskData(task_id);
+		const auto task_data = TaskManager::Instance()->GetTaskData(task_id);
 		if (!task_data) {
 			return -1;
 		}
@@ -1519,7 +1519,7 @@ int ClientTaskState::TaskTimeLeft(int task_id)
 	if (m_active_shared_task.task_id == task_id) {
 		int time_now = time(nullptr);
 
-		const auto task_data = task_manager->GetTaskData(task_id);
+		const auto task_data = TaskManager::Instance()->GetTaskData(task_id);
 		if (!task_data) {
 			return -1;
 		}
@@ -1544,7 +1544,7 @@ int ClientTaskState::TaskTimeLeft(int task_id)
 
 		int time_now = time(nullptr);
 
-		const auto task_data = task_manager->GetTaskData(active_quest.task_id);
+		const auto task_data = TaskManager::Instance()->GetTaskData(active_quest.task_id);
 		if (!task_data) {
 			return -1;
 		}
@@ -1616,7 +1616,7 @@ bool ClientTaskState::TaskOutOfTime(TaskType task_type, int index)
 	}
 
 	int time_now = time(nullptr);
-	const auto task_data = task_manager->GetTaskData(info->task_id);
+	const auto task_data = TaskManager::Instance()->GetTaskData(info->task_id);
 	if (!task_data) {
 		return false;
 	}
@@ -1936,7 +1936,7 @@ void ClientTaskState::RemoveTask(Client *client, int sequence_number, TaskType t
 
 void ClientTaskState::RemoveTaskByTaskID(Client *client, uint32 task_id)
 {
-	switch (task_manager->GetTaskType(task_id)) {
+	switch (TaskManager::Instance()->GetTaskType(task_id)) {
 		case TaskType::Task: {
 			if (m_active_task.task_id == task_id) {
 				LogTasks("RemoveTaskByTaskID found Task [{}]", task_id);
@@ -1973,12 +1973,12 @@ void ClientTaskState::AcceptNewTask(
 	bool enforce_level_requirement
 )
 {
-	if (!task_manager || task_id < 0) {
+	if (!TaskManager::Instance() || task_id < 0) {
 		client->Message(Chat::Red, "Task system not functioning, or task_id %i out of range.", task_id);
 		return;
 	}
 
-	const auto task = task_manager->GetTaskData(task_id);
+	const auto task = TaskManager::Instance()->GetTaskData(task_id);
 	if (!task) {
 		client->Message(Chat::Red, "Invalid task_id %i", task_id);
 		return;
@@ -2048,12 +2048,12 @@ void ClientTaskState::AcceptNewTask(
 		}
 	}
 
-	if (enforce_level_requirement && !task_manager->ValidateLevel(task_id, client->GetLevel())) {
+	if (enforce_level_requirement && !TaskManager::Instance()->ValidateLevel(task_id, client->GetLevel())) {
 		client->MessageString(Chat::Yellow, TASK_NOT_RIGHT_LEVEL);
 		return;
 	}
 
-	if (!task_manager->IsTaskRepeatable(task_id) && IsTaskCompleted(task_id)) {
+	if (!TaskManager::Instance()->IsTaskRepeatable(task_id) && IsTaskCompleted(task_id)) {
 		return;
 	}
 
@@ -2184,11 +2184,11 @@ void ClientTaskState::AcceptNewTask(
 		}
 	}
 
-	task_manager->SendSingleActiveTaskToClient(client, *active_slot, false, true);
+	TaskManager::Instance()->SendSingleActiveTaskToClient(client, *active_slot, false, true);
 	client->StartTaskRequestCooldownTimer();
 	client->MessageString(Chat::DefaultText, YOU_ASSIGNED_TASK, task->title.c_str());
 
-	task_manager->SaveClientState(client, this);
+	TaskManager::Instance()->SaveClientState(client, this);
 
 	NPC *npc = entity_list.GetNPCByID(npc_entity_id);
 	if (npc) {
@@ -2197,7 +2197,7 @@ void ClientTaskState::AcceptNewTask(
 				.npc_id = npc->GetNPCTypeID(),
 				.npc_name = npc->GetCleanName(),
 				.task_id = static_cast<uint32>(task_id),
-				.task_name = task_manager->GetTaskName(static_cast<uint32>(task_id)),
+				.task_name = TaskManager::Instance()->GetTaskName(static_cast<uint32>(task_id)),
 			};
 			RecordPlayerEventLogWithClient(client, PlayerEvent::TASK_ACCEPT, e);
 		}
@@ -2211,7 +2211,7 @@ void ClientTaskState::AcceptNewTask(
 				.npc_id = 0,
 				.npc_name = "No NPC",
 				.task_id = static_cast<uint32>(task_id),
-				.task_name = task_manager->GetTaskName(static_cast<uint32>(task_id)),
+				.task_name = TaskManager::Instance()->GetTaskName(static_cast<uint32>(task_id)),
 			};
 			RecordPlayerEventLogWithClient(client, PlayerEvent::TASK_ACCEPT, e);
 		}
@@ -2247,7 +2247,7 @@ void ClientTaskState::SharedTaskIncrementDoneCount(
 	bool ignore_quest_update
 )
 {
-	const auto t = task_manager->GetTaskData(task_id);
+	const auto t = TaskManager::Instance()->GetTaskData(task_id);
 
 	auto info = GetClientTaskInfo(t->type, TASKSLOTSHAREDTASK);
 	if (info == nullptr) {
@@ -2286,7 +2286,7 @@ bool ClientTaskState::HasActiveSharedTask()
 
 void ClientTaskState::CreateTaskDynamicZone(Client* client, int task_id, DynamicZone& dz_request)
 {
-	const auto task = task_manager->GetTaskData(task_id);
+	const auto task = TaskManager::Instance()->GetTaskData(task_id);
 	if (!task)
 	{
 		return;
@@ -2349,7 +2349,7 @@ void ClientTaskState::ListTaskTimers(Client* client)
 
 	for (const auto& task_timer : character_task_timers)
 	{
-		const auto task = task_manager->GetTaskData(task_timer.task_id);
+		const auto task = TaskManager::Instance()->GetTaskData(task_timer.task_id);
 		if (task)
 		{
 			auto timer_type = static_cast<TaskTimerType>(task_timer.timer_type);
@@ -2455,7 +2455,7 @@ void ClientTaskState::SyncSharedTaskZoneClientDoneCountState(
 
 bool ClientTaskState::HasActiveTasks()
 {
-	if (!task_manager) {
+	if (!TaskManager::Instance()) {
 		return false;
 	}
 
@@ -2495,9 +2495,9 @@ void ClientTaskState::LockSharedTask(Client* client, bool lock)
 
 void ClientTaskState::EndSharedTask(Client* client, bool send_fail)
 {
-	if (task_manager && m_active_shared_task.task_id != TASKSLOTEMPTY)
+	if (TaskManager::Instance() && m_active_shared_task.task_id != TASKSLOTEMPTY)
 	{
-		task_manager->EndSharedTask(*client, m_active_shared_task.task_id, send_fail);
+		TaskManager::Instance()->EndSharedTask(*client, m_active_shared_task.task_id, send_fail);
 	}
 }
 bool ClientTaskState::CanAcceptNewTask(Client* client, int task_id, int npc_entity_id) const

--- a/zone/task_manager.h
+++ b/zone/task_manager.h
@@ -70,6 +70,12 @@ public:
 		return it != m_task_data.end() ? &it->second : nullptr;
 	}
 
+	static TaskManager* Instance()
+	{
+		static TaskManager instance;
+		return &instance;
+	}
+
 private:
 	std::vector<int>                              m_task_sets[MAXTASKSETS];
 	std::unordered_map<uint32_t, TaskInformation> m_task_data;

--- a/zone/tasks.cpp
+++ b/zone/tasks.cpp
@@ -14,7 +14,7 @@ extern QueryServ *QServ;
 
 void Client::LoadClientTaskState()
 {
-	if (RuleB(TaskSystem, EnableTaskSystem) && TaskManager::Instance()) {
+	if (RuleB(TaskSystem, EnableTaskSystem)) {
 		LoadClientSharedCompletedTasks();
 
 		safe_delete(task_state);

--- a/zone/tasks.cpp
+++ b/zone/tasks.cpp
@@ -14,17 +14,17 @@ extern QueryServ *QServ;
 
 void Client::LoadClientTaskState()
 {
-	if (RuleB(TaskSystem, EnableTaskSystem) && task_manager) {
+	if (RuleB(TaskSystem, EnableTaskSystem) && TaskManager::Instance()) {
 		LoadClientSharedCompletedTasks();
 
 		safe_delete(task_state);
 		task_state = new ClientTaskState();
-		if (!task_manager->LoadClientState(this, task_state)) {
+		if (!TaskManager::Instance()->LoadClientState(this, task_state)) {
 			safe_delete(task_state);
 		}
 		else {
-			task_manager->SendActiveTasksToClient(this);
-			task_manager->SendCompletedTasksToClient(this, task_state);
+			TaskManager::Instance()->SendActiveTasksToClient(this);
+			TaskManager::Instance()->SendCompletedTasksToClient(this, task_state);
 		}
 	}
 }

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -4644,11 +4644,9 @@ void WorldServer::ProcessReload(const ServerReload::Request& request)
 		case ServerReload::Type::Tasks:
 			if (RuleB(Tasks, EnableTaskSystem)) {
 				entity_list.SaveAllClientsTaskState();
-				safe_delete(task_manager);
-				task_manager = new TaskManager;
-				task_manager->LoadTasks();
+				TaskManager::Instance()->LoadTasks();
 				entity_list.ReloadAllClientsTaskState();
-				task_manager->LoadTaskSets();
+				TaskManager::Instance()->LoadTaskSets();
 			}
 			break;
 


### PR DESCRIPTION
# Description

This is part of a larger effort to remove global variables from the codebase. Eventually singletons can be cleaned up to be passed explicitly through dependency injection.

For now this encapsulates dependencies far better.

## Type of change

- [x] Code Cleanup

# Testing
![image](https://github.com/user-attachments/assets/27ec64c7-5658-4cc0-9891-371c976ed060)
![image](https://github.com/user-attachments/assets/0224bb55-32e2-4550-979d-52e630b2d9d7)


# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur