### PR TITLE
[Code] Remove Unused MZoneShutdown Mutex

### DIFF
--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -88,8 +88,6 @@ extern WorldServer worldserver;
 extern Zone* zone;
 extern NpcScaleManager* npc_scale_manager;
 
-Mutex MZoneShutdown;
-
 volatile bool is_zone_loaded = false;
 Zone* zone = 0;
 


### PR DESCRIPTION
# Description
Removes an unused Mutex.

## Type of change
- [X] Code cleanup

# Checklist
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur