### PR TITLE
[Code] Remove Lua Rule Constants

### DIFF
--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -7963,33 +7963,6 @@ luabind::scope lua_register_languages() {
 	)];
 }
 
-luabind::scope lua_register_rules_const() {
-	return luabind::class_<Rule>("Rule")
-		.enum_("constants")
-	[(
-#define RULE_INT(cat, rule, default_value, notes) \
-		luabind::value(#rule, RuleManager::Int__##rule),
-#include "../common/ruletypes.h"
-		luabind::value("_IntRuleCount", RuleManager::_IntRuleCount),
-#undef RULE_INT
-#define RULE_REAL(cat, rule, default_value, notes) \
-		luabind::value(#rule, RuleManager::Real__##rule),
-#include "../common/ruletypes.h"
-		luabind::value("_RealRuleCount", RuleManager::_RealRuleCount),
-#undef RULE_REAL
-#define RULE_BOOL(cat, rule, default_value, notes) \
-		luabind::value(#rule, RuleManager::Bool__##rule),
-#include "../common/ruletypes.h"
-		luabind::value("_BoolRuleCount", RuleManager::_BoolRuleCount),
-#undef RULE_BOOL
-#define RULE_STRING(cat, rule, default_value, notes) \
-		luabind::value(#rule, RuleManager::String__##rule),
-#include "../common/ruletypes.h"
-		luabind::value("_StringRuleCount", RuleManager::_StringRuleCount)
-#undef RULE_STRING
-	)];
-}
-
 luabind::scope lua_register_rulei() {
 	return luabind::namespace_("RuleI")
 		[

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -1320,7 +1320,6 @@ void LuaParser::MapFunctions(lua_State *L) {
 			lua_register_packet(),
 			lua_register_packet_opcodes(),
 			lua_register_stat_bonuses(),
-			lua_register_rules_const(),
 			lua_register_rulei(),
 			lua_register_ruler(),
 			lua_register_ruleb(),


### PR DESCRIPTION
# Description

This is based off of efforts to cleanup the codebase, modernize and make it more efficient.

I have a branch called `build-analyze` that runs a trace of what takes up all of the build time (example here http://drone.akkadius.com/EQEmu/Server/18259/1/2)

This shows that `lua_register_rules_const` takes 49 seconds to compile and does a lot of expensive things to provide rule constants that I've not found used in any quest codebase. The cost is not worth the benefit considering it's been in the codebase for 8 years and no utilization.

```
**** Functions that took longest to compile:
 48183 ms: lua_register_rules_const() (/drone/src/build/zone/CMakeFiles/lua_zone.dir/Unity/unity_1_cxx.cxx)
  9943 ms: __cxx_global_var_init.273 (/drone/src/common/rulesys.cpp)
  9600 ms: lua_register_packet_opcodes() (/drone/src/build/zone/CMakeFiles/lua_zone.dir/Unity/unity_2_cxx.cxx)
  6036 ms: __cxx_global_var_init.230 (/drone/src/common/database/database_update.cpp)
  5716 ms: __cxx_global_var_init.198 (/drone/src/common/database/database_update_manifest.cpp)
  5555 ms: BaseCharacterDataRepository::UpdateOne(Database&, BaseCharacterDataR... (/drone/src/zone/client_packet.cpp)
  4800 ms: BaseCharacterDataRepository::UpdateOne(Database&, BaseCharacterDataR... (/drone/src/zone/client.cpp)
  4699 ms: BaseNpcTypesRepository::UpdateOne(Database&, BaseNpcTypesRepository:... (/drone/src/zone/npc.cpp)
  4683 ms: _GLOBAL__sub_I_bot_raid.cpp (/drone/src/zone/bot_raid.cpp)
```

## Type of change

- [x] Build optimization

# Testing

Basic processes still work

# Checklist

-  [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

