### PR TITLE
[Code] Cleanup Strings Header

### DIFF
--- a/common/database.cpp
+++ b/common/database.cpp
@@ -708,6 +708,20 @@ const std::string Database::GetNPCNameByID(uint32 npc_id)
 	return e.id ? e.name : std::string();
 }
 
+template<typename InputIterator, typename OutputIterator>
+inline auto CleanMobName(InputIterator first, InputIterator last, OutputIterator result)
+{
+	for (; first != last; ++first) {
+		if (*first == '_') {
+			*result = ' ';
+		}
+		else if (isalpha(*first) || *first == '`') {
+			*result = *first;
+		}
+	}
+	return result;
+}
+
 const std::string Database::GetCleanNPCNameByID(uint32 npc_id)
 {
 	const auto& e = NpcTypesRepository::FindOne(*this, npc_id);

--- a/common/process/process.cpp
+++ b/common/process/process.cpp
@@ -1,6 +1,7 @@
 #include <string>
 #include <memory>
 #include "process.h"
+#include <fmt/format.h>
 
 std::string Process::execute(const std::string &cmd)
 {

--- a/common/repositories/rule_values_repository.h
+++ b/common/repositories/rule_values_repository.h
@@ -43,6 +43,47 @@ public:
      * method and encapsulate filters there
      */
 
+	template<typename T1, typename T2, typename T3, typename T4>
+	static std::vector<std::string> join_tuple(
+		const std::string &glue,
+		const std::pair<char, char> &encapsulation,
+		const std::vector<std::tuple<T1, T2, T3, T4>> &src
+	)
+	{
+		if (src.empty()) {
+			return {};
+		}
+
+		std::vector<std::string> output;
+
+		for (const std::tuple<T1, T2, T3, T4> &src_iter: src) {
+
+			output.emplace_back(
+
+				fmt::format(
+					"{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
+					encapsulation.first,
+					std::get<0>(src_iter),
+					encapsulation.second,
+					glue,
+					encapsulation.first,
+					std::get<1>(src_iter),
+					encapsulation.second,
+					glue,
+					encapsulation.first,
+					std::get<2>(src_iter),
+					encapsulation.second,
+					glue,
+					encapsulation.first,
+					std::get<3>(src_iter),
+					encapsulation.second
+				)
+			);
+		}
+
+		return output;
+	}
+
 	// Custom extended repository methods here
 	static std::vector<std::string> GetRuleNames(Database &db, int rule_set_id)
 	{
@@ -87,12 +128,28 @@ public:
 		return v;
 	}
 
+	template<typename T>
+	static std::string
+	ImplodePair(const std::string &glue, const std::pair<char, char> &encapsulation, const std::vector<T> &src)
+	{
+		if (src.empty()) {
+			return {};
+		}
+		std::ostringstream oss;
+		for (const T &src_iter: src) {
+			oss << encapsulation.first << src_iter << encapsulation.second << glue;
+		}
+		std::string output(oss.str());
+		output.resize(output.size() - glue.size());
+		return output;
+	}
+
 	static bool DeleteOrphanedRules(Database& db, std::vector<std::string>& v)
 	{
 		const auto query = fmt::format(
 			"DELETE FROM {} WHERE rule_name IN ({})",
 			TableName(),
-			Strings::ImplodePair(",", std::pair<char, char>('\'', '\''), v)
+			ImplodePair(",", std::pair<char, char>('\'', '\''), v)
 		);
 
 		return db.QueryDatabase(query).Success();
@@ -103,7 +160,7 @@ public:
 		const auto query = fmt::format(
 			"REPLACE INTO {} (`ruleset_id`, `rule_name`, `rule_value`, `notes`) VALUES {}",
 			TableName(),
-			Strings::ImplodePair(
+			ImplodePair(
 				",",
 				std::pair<char, char>('(', ')'),
 				join_tuple(",", std::pair<char, char>('\'', '\''), v)

--- a/common/strings.cpp
+++ b/common/strings.cpp
@@ -42,6 +42,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <iostream>
+#include <sstream>
 
 #include <random>
 #include <string>
@@ -49,6 +50,12 @@
 //Const char based
 #include "strings_legacy.cpp" // legacy c functions
 #include "strings_misc.cpp" // anything non "Strings" scoped
+
+#ifdef _WINDOWS
+#include <ctype.h>
+#include <functional>
+#include <algorithm>
+#endif
 
 std::string Strings::Random(size_t length)
 {

--- a/common/strings.cpp
+++ b/common/strings.cpp
@@ -34,6 +34,7 @@
 */
 
 #include "strings.h"
+#include <cereal/external/rapidjson/document.h>
 #include <fmt/format.h>
 #include <algorithm>
 #include <cctype>
@@ -700,6 +701,18 @@ std::string &Strings::Trim(std::string &str, const std::string &chars)
 {
 	return LTrim(RTrim(str, chars), chars);
 }
+
+const std::string NUM_TO_ENGLISH_X[] = {
+	"", "One ", "Two ", "Three ", "Four ",
+	"Five ", "Six ", "Seven ", "Eight ", "Nine ", "Ten ", "Eleven ",
+	"Twelve ", "Thirteen ", "Fourteen ", "Fifteen ",
+	"Sixteen ", "Seventeen ", "Eighteen ", "Nineteen "
+};
+
+const std::string NUM_TO_ENGLISH_Y[] = {
+	"", "", "Twenty ", "Thirty ", "Forty ",
+	"Fifty ", "Sixty ", "Seventy ", "Eighty ", "Ninety "
+};
 
 // Function to convert single digit or two digit number into words
 std::string Strings::ConvertToDigit(int n, const std::string& suffix)

--- a/common/strings.h
+++ b/common/strings.h
@@ -37,15 +37,11 @@
 
 #include <charconv>
 #include <sstream>
-#include <string.h>
+#include <cstring>
 #include <string_view>
 #include <vector>
 #include <cstdarg>
-#include <tuple>
 #include <type_traits>
-
-#include <fmt/format.h>
-#include <cereal/external/rapidjson/document.h>
 
 #ifndef _WIN32
 // this doesn't appear to affect linux-based systems..need feedback for _WIN64
@@ -59,29 +55,6 @@
 #endif
 
 #include "types.h"
-
-namespace detail {
-	// template magic to check if std::from_chars floating point functions exist
-	template <typename T, typename = void>
-	struct has_from_chars_float : std::false_type { };
-
-	// basically it "uses" this template if they do exist because reasons
-	template <typename T>
-	struct has_from_chars_float < T,
-	std::void_t<decltype(std::from_chars(std::declval<const char *>(), std::declval<const char *>(),
-						 std::declval<T &>()))>> : std::true_type { };
-}; // namespace detail
-
-namespace EQ {
-// lame -- older GCC's didn't define this, clang's libc++ however does, even though they lack FP support
-#if defined(__GNUC__) && (__GNUC__ < 11) && !defined(__clang__)
-	enum class chars_format {
-		scientific = 1, fixed = 2, hex = 4, general = fixed | scientific
-	};
-#else
-	using chars_format = std::chars_format;
-#endif
-}; // namespace EQ
 
 class Strings {
 public:
@@ -133,61 +106,6 @@ public:
 	static bool BeginsWith(const std::string& subject, const std::string& search);
 	static bool EndsWith(const std::string& subject, const std::string& search);
 	static std::string ZoneTime(const uint8 hours, const uint8 minutes);
-
-	template<typename T>
-	static std::string
-	ImplodePair(const std::string &glue, const std::pair<char, char> &encapsulation, const std::vector<T> &src)
-	{
-		if (src.empty()) {
-			return {};
-		}
-		std::ostringstream oss;
-		for (const T &src_iter: src) {
-			oss << encapsulation.first << src_iter << encapsulation.second << glue;
-		}
-		std::string output(oss.str());
-		output.resize(output.size() - glue.size());
-		return output;
-	}
-
-	// basic string_view overloads that just use std stuff since they work!
-	template <typename T>
-	std::enable_if_t<std::is_floating_point_v<T> && detail::has_from_chars_float<T>::value, std::from_chars_result>
-	static from_chars(std::string_view str, T& value, EQ::chars_format fmt = EQ::chars_format::general)
-	{
-		return std::from_chars(str.data(), str.data() + str.size(), value, fmt);
-	}
-
-	template <typename T>
-	std::enable_if_t<std::is_integral_v<T>, std::from_chars_result>
-	static from_chars(std::string_view str, T& value, int base = 10)
-	{
-		return std::from_chars(str.data(), str.data() + str.size(), value, base);
-	}
-
-	// fallback versions of floating point in case they're not implemented
-	// TODO: add error handling ...
-	// This does have to allocate since from_chars doesn't need a null terminated string and neither does string_view
-	template <typename T>
-	std::enable_if_t<std::is_floating_point_v<T> && !detail::has_from_chars_float<T>::value && std::is_same_v<T, float>, std::from_chars_result>
-	static from_chars(std::string_view str, T& value, EQ::chars_format fmt = EQ::chars_format::general)
-	{
-		std::from_chars_result res{};
-		std::string tmp_str(str.data(), str.size());
-		value = strtof(tmp_str.data(), nullptr);
-		return res;
-	}
-
-	template <typename T>
-	std::enable_if_t<std::is_floating_point_v<T> && !detail::has_from_chars_float<T>::value && std::is_same_v<T, double>, std::from_chars_result>
-	static from_chars(std::string_view str, T& value, EQ::chars_format fmt = EQ::chars_format::general)
-	{
-		std::from_chars_result res{};
-		std::string tmp_str(str.data(), str.size());
-		value = strtod(tmp_str.data(), nullptr);
-		return res;
-	}
-
 	static std::string Slugify(const std::string &input, const std::string &separator = "-");
 	static bool IsValidJson(const std::string& json);
 };
@@ -198,93 +116,6 @@ const std::string vStringFormat(const char *format, va_list args);
 // For converstion of numerics into English
 // Used for grid nodes, as NPC names remove numerals.
 // But general purpose
-
-const std::string NUM_TO_ENGLISH_X[] = {
-	"", "One ", "Two ", "Three ", "Four ",
-	"Five ", "Six ", "Seven ", "Eight ", "Nine ", "Ten ", "Eleven ",
-	"Twelve ", "Thirteen ", "Fourteen ", "Fifteen ",
-	"Sixteen ", "Seventeen ", "Eighteen ", "Nineteen "
-};
-
-const std::string NUM_TO_ENGLISH_Y[] = {
-	"", "", "Twenty ", "Thirty ", "Forty ",
-	"Fifty ", "Sixty ", "Seventy ", "Eighty ", "Ninety "
-};
-
-// _WIN32 builds require that #include<fmt/format.h> be included in whatever code file the invocation is made from (no header files)
-template<typename T1, typename T2>
-std::vector<std::string> join_pair(
-	const std::string &glue,
-	const std::pair<char, char> &encapsulation,
-	const std::vector<std::pair<T1, T2>> &src
-)
-{
-	if (src.empty()) {
-		return {};
-	}
-
-	std::vector<std::string> output;
-
-	for (const std::pair<T1, T2> &src_iter: src) {
-		output.emplace_back(
-
-			fmt::format(
-				"{}{}{}{}{}{}{}",
-				encapsulation.first,
-				src_iter.first,
-				encapsulation.second,
-				glue,
-				encapsulation.first,
-				src_iter.second,
-				encapsulation.second
-			)
-		);
-	}
-
-	return output;
-}
-
-// _WIN32 builds require that #include<fmt/format.h> be included in whatever code file the invocation is made from (no header files)
-template<typename T1, typename T2, typename T3, typename T4>
-std::vector<std::string> join_tuple(
-	const std::string &glue,
-	const std::pair<char, char> &encapsulation,
-	const std::vector<std::tuple<T1, T2, T3, T4>> &src
-)
-{
-	if (src.empty()) {
-		return {};
-	}
-
-	std::vector<std::string> output;
-
-	for (const std::tuple<T1, T2, T3, T4> &src_iter: src) {
-
-		output.emplace_back(
-
-			fmt::format(
-				"{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
-				encapsulation.first,
-				std::get<0>(src_iter),
-				encapsulation.second,
-				glue,
-				encapsulation.first,
-				std::get<1>(src_iter),
-				encapsulation.second,
-				glue,
-				encapsulation.first,
-				std::get<2>(src_iter),
-				encapsulation.second,
-				glue,
-				encapsulation.first,
-				std::get<3>(src_iter),
-				encapsulation.second
-			)
-		);
-	}
-
-	return output;
-}
 
 // misc functions
 std::string SanitizeWorldServerName(std::string server_long_name);
@@ -309,19 +140,5 @@ void RemoveApostrophes(std::string &s);
 std::string FormatName(const std::string &char_name);
 bool IsAllowedWorldServerCharacterList(char c);
 void SanitizeWorldServerName(char *name);
-
-template<typename InputIterator, typename OutputIterator>
-auto CleanMobName(InputIterator first, InputIterator last, OutputIterator result)
-{
-	for (; first != last; ++first) {
-		if (*first == '_') {
-			*result = ' ';
-		}
-		else if (isalpha(*first) || *first == '`') {
-			*result = *first;
-		}
-	}
-	return result;
-}
 
 #endif

--- a/common/strings.h
+++ b/common/strings.h
@@ -36,22 +36,15 @@
 #define _STRINGUTIL_H_
 
 #include <charconv>
-#include <sstream>
 #include <cstring>
 #include <string_view>
+#include <string>
 #include <vector>
 #include <cstdarg>
 #include <type_traits>
 
-#ifndef _WIN32
-// this doesn't appear to affect linux-based systems..need feedback for _WIN64
-
-#endif
-
-#ifdef _WINDOWS
+#ifdef _WIN32
 #include <ctype.h>
-#include <functional>
-#include <algorithm>
 #endif
 
 #include "types.h"

--- a/tests/string_util_test.h
+++ b/tests/string_util_test.h
@@ -30,7 +30,6 @@ public:
 		TEST_ADD(StringUtilTest::EscapeStringTest);
 		TEST_ADD(StringUtilTest::SearchDeliminatedStringTest);
 		TEST_ADD(StringUtilTest::SplitStringTest);
-		TEST_ADD(StringUtilTest::FromCharsTest);
 		TEST_ADD(StringUtilTest::TestIsFloat);
 		TEST_ADD(StringUtilTest::TestIsNumber);
 	}
@@ -106,21 +105,6 @@ public:
 		TEST_ASSERT(v[0] == "123");
 		TEST_ASSERT(v[1] == "456");
 		TEST_ASSERT(v[2] == "789");
-	}
-
-	void FromCharsTest() {
-		char int_chars[] = "123";
-		int int_value = 0;
-
-		char float_chars[] = "3.14";
-		float float_value = 0.0f;
-
-		Strings::from_chars(int_chars, int_value);
-		TEST_ASSERT(int_value == 123);
-
-		Strings::from_chars(float_chars, float_value);
-		TEST_ASSERT(float_value == 3.14f);
-
 	}
 
 	void TestIsFloat() {

--- a/zone/position.cpp
+++ b/zone/position.cpp
@@ -6,6 +6,7 @@
 #include "../common/data_verification.h"
 #include <numbers>
 #include "../common/types.h"
+#include <fmt/format.h>
 
 constexpr float position_eps = 0.0001f;
 


### PR DESCRIPTION
# Description

This is based off of efforts to cleanup the codebase, modernize and make it more efficient.

I have a branch called `build-analyze` that runs a trace of what takes up all of the build time (example here http://drone.akkadius.com/EQEmu/Server/18259/1/2)

We find that why strings.h is so expensive is because of all of the templates included in the header. Since it's included hundreds of times, everything is also having instantiate templates, pull in additional headers that may not be needed. 

This PR cleans all of that up by removing templates and transitive includes.

**Before**

```
232055 ms: /drone/src/common/strings.h (included 214 times, avg 1084 ms), included via:
  80x: <direct include>
  16x: client.h linked_list.h extprofile.h inventory_profile.h item_instance.h evolving_items.h say_link.h saylink_repository.h 
  9x: bot.h bot_structs.h mob.h data_bucket.h data_buckets_repository.h 
  5x: shareddb.h say_link.h saylink_repository.h 
  5x: worlddb.h shareddb.h say_link.h saylink_repository.h 
  4x: zone.h 
  ...
```

**After**

Doesn't even show up on the report anymore

## Type of change

- [x] Code Cleanup / Build Optimize

# Testing

Automated CI tests

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

