### PR TITLE
[Build] More Build Speed Improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,6 +363,8 @@ MESSAGE(STATUS "**************************************************")
 #setup server libs and headers
 SET(SERVER_LIBS common ${DATABASE_LIBRARY_LIBS} ${ZLIB_LIBRARY_LIBS} ${Boost_LIBRARIES} uv_a fmt RecastNavigation::Detour)
 
+set(FMT_HEADER_ONLY OFF)
+
 INCLUDE_DIRECTORIES(SYSTEM "${DATABASE_LIBRARY_INCLUDE}")
 INCLUDE_DIRECTORIES(SYSTEM "${ZLIB_LIBRARY_INCLUDE}")
 INCLUDE_DIRECTORIES(SYSTEM "${Boost_INCLUDE_DIRS}")

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -841,7 +841,7 @@ IF (UNIX)
     SET_SOURCE_FILES_PROPERTIES("patches/sod.cpp" "patches/sof.cpp" "patches/rof.cpp" "patches/rof2.cpp" "patches/uf.cpp" PROPERTIES COMPILE_FLAGS -O0)
 ENDIF (UNIX)
 
-IF (WIN32 AND EQEMU_BUILD_PCH)
+IF (EQEMU_BUILD_PCH)
     TARGET_PRECOMPILE_HEADERS(common PRIVATE pch/std-pch.h)
 ENDIF ()
 

--- a/common/pch/std-pch.h
+++ b/common/pch/std-pch.h
@@ -1,34 +1,14 @@
-// types
-#include <limits>
-#include <string>
-#include <cctype>
-#include <sstream>
+#pragma once
 
-// containers
-#include <iterator>
-#include <set>
-#include <unordered_set>
+// Lightweight, widely used
+#include <string>
+#include <vector>
 #include <map>
 #include <unordered_map>
-#include <list>
-#include <vector>
-
-// utilities
-#include <iostream>
-#include <cassert>
-#include <cmath>
 #include <memory>
-#include <functional>
-#include <algorithm>
-#include <utility>
-#include <tuple>
-#include <fstream>
-#include <cstdio>
+#include <limits>
+#include <cstdint>
+#include <cassert>
 
 // fmt
 #include <fmt/format.h>
-
-// lua
-#include "lua.hpp"
-#include <luabind/luabind.hpp>
-#include <luabind/object.hpp>

--- a/utils/scripts/build/linux-build.sh
+++ b/utils/scripts/build/linux-build.sh
@@ -14,15 +14,15 @@ perl utils/scripts/build/tag-version.pl
 
 mkdir -p build && cd build && \
   cmake -DEQEMU_BUILD_TESTS=ON \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo \
       -DEQEMU_BUILD_STATIC=ON \
       -DEQEMU_BUILD_LOGIN=ON \
       -DEQEMU_BUILD_LUA=ON \
       -DEQEMU_BUILD_PERL=ON \
-      -DCMAKE_CXX_FLAGS:STRING="-O1 -g -Wno-everything" \
-      -DCMAKE_CXX_FLAGS_RELWITHDEBINFO:STRING="-O1 -g -Wno-everything" \
+      -DCMAKE_CXX_FLAGS_RELWITHDEBINFO:STRING="-g -Wno-everything" \
       -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
       -G 'Unix Makefiles' \
-      .. && make -j$((`nproc`-12))
+      .. && make -j$((`nproc`-2))
 
 curl https://raw.githubusercontent.com/Akkadius/eqemu-install-v2/master/eqemu_config.json --output eqemu_config.json
 ./bin/tests

--- a/zone/CMakeLists.txt
+++ b/zone/CMakeLists.txt
@@ -483,6 +483,7 @@ INSTALL(TARGETS zone RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 # precompiled headers
 IF (EQEMU_BUILD_PCH)
     TARGET_PRECOMPILE_HEADERS(zone PRIVATE ../common/pch/app-pch.h)
+    TARGET_PRECOMPILE_HEADERS(zone PRIVATE ../common/pch/std-pch.h)
     TARGET_PRECOMPILE_HEADERS(zone PRIVATE ./pch/pch.h)
 ENDIF()
 


### PR DESCRIPTION
# Description

This continues the work of using [Clang's Build Analyzer](https://github.com/aras-p/ClangBuildAnalyzer) to trace down why the build is slow.

This change further drops the compile time down like a rock. It requires that your cmake build flags are consistent and aren't mixing optimization settings.

Related akk-stack change - https://github.com/Akkadius/akk-stack/commit/c9ce6abc332e44d8b00124f16ce694861d19fdf3

## Type of change

- [x] Build / Compilation Speed Improvement

# Testing

**16c/32t Intel Linux**

Full build

```
eqemu@ct-eqemu-server:~/code/build$ time ninja -j$(expr $(nproc) - 2)
[540/540] Linking CXX executable bin/zone

real    0m42.737s
```

Incremental build (edited eqemu_logsys.h)

```
eqemu@ct-eqemu-server:~/code/build$ time ninja -j$(expr $(nproc) - 2)
[262/262] Linking CXX executable bin/zone

real    0m21.583s
```

**Macbook Air (M4)**

Before I started any of this build work, an Macbook Air (M4) used to take roughly 8+ minutes to build

Now it takes

```
eqemu@ct-eqemu-server:~/code/build$ time ninja -j10
[530/530] Linking CXX executable bin/export_client_files

real	1m33.001s
```

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

