### PR TITLE
[Performance] Clear Wearchange Deduplication Cache

### DIFF
--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -133,6 +133,7 @@ Mob::Mob(
 	m_see_close_mobs_timer(1000),
 	m_mob_check_moving_timer(1000),
 	bot_attack_flag_timer(10000),
+	m_clear_wearchange_cache_timer(60 * 10 * 1000), // 10 minutes
 	m_destroying(false)
 {
 	mMovementManager = &MobMovementManager::Get();

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -211,6 +211,7 @@ public:
 	uint16 m_last_wearchange_race_id = 0;
 	// client_id -> slot_id -> key
 	std::unordered_map<uint32_t, std::unordered_map<uint8_t, uint64_t>> m_last_seen_wearchange;
+	Timer m_clear_wearchange_cache_timer;
 
 	// Bot attack flag
 	Timer bot_attack_flag_timer;

--- a/zone/mob_appearance.cpp
+++ b/zone/mob_appearance.cpp
@@ -395,6 +395,10 @@ void Mob::SendWearChange(uint8 material_slot, Client *one_client)
 
 	w->wear_slot_id = material_slot;
 
+	if (m_clear_wearchange_cache_timer.Check()) {
+		m_last_seen_wearchange.clear();
+	}
+
 	if (GetRace() != m_last_wearchange_race_id) {
 		m_last_seen_wearchange.clear();
 		m_last_wearchange_race_id = GetRace();


### PR DESCRIPTION
# Description

As a result of https://github.com/EQEmu/Server/pull/4916 (which has been working well) - I've noticed that it is keeping memory retention high in zones where mobs don't move. This is clears the cache bucket on a regular interval to keep the retention bloat from getting too large.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Basic in game testing

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur

