### PR TITLE
Add a missing Froglok starting area for Titanium Startzone.

### DIFF
--- a/common/eq_constants.h
+++ b/common/eq_constants.h
@@ -988,7 +988,8 @@ enum StartZoneIndex {
     Felwithe,
     Akanon,
     Cabilis,
-    SharVahl
+    SharVahl,
+	RatheMtn
 };
 
 enum FVNoDropFlagRule

--- a/world/worlddb.cpp
+++ b/world/worlddb.cpp
@@ -732,6 +732,11 @@ void WorldDatabase::SetTitaniumDefaultStartZone(PlayerProfile_Struct* in_pp, Cha
 				in_pp->binds[0].zone_id = Zones::SHARVAHL;	// sharvahl
 				break;
 			}
+			case StartZoneIndex::RatheMtn:
+			{
+				in_pp->zone_id = Zones::RATHEMTN;	// rathemtn
+				in_pp->binds[0].zone_id = Zones::RATHEMTN;	// rathemtn
+			}
 		}
 	}
 }


### PR DESCRIPTION
# Description

It was missing a froglok start area with is player's choice 14 for Titanium Startzone.  Otherwise without a database entry for froglok startzone.  they will get sent to Qeynos.

Fixes # (issue)

## Type of change
Add an missing entry in StartZoneIndex Enum and SetTitaniumDefaultStartZone function.

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Test this while fixing up Froglok Starting area. 

Clients tested: 
Titanium

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur

