### PR TITLE
Group role api

### DIFF
--- a/zone/groups.cpp
+++ b/zone/groups.cpp
@@ -2474,15 +2474,53 @@ bool Group::AmIPuller(const char *mob_name)
 
 bool Group::HasRole(Mob *m, uint8 Role)
 {
-	if(!m)
-		return false;
+        if(!m)
+                return false;
 
-	for(uint32 i = 0; i < MAX_GROUP_MEMBERS; ++i)
-	{
-		if((m == members[i]) && (MemberRoles[i] & Role))
-			return true;
-	}
-	return false;
+        for(uint32 i = 0; i < MAX_GROUP_MEMBERS; ++i)
+        {
+                if((m == members[i]) && (MemberRoles[i] & Role))
+                        return true;
+        }
+        return false;
+}
+
+uint8 Group::GetMemberRole(Mob *m)
+{
+        if(!m)
+                return 0;
+
+        for(uint32 i = 0; i < MAX_GROUP_MEMBERS; ++i)
+        {
+                if(m == members[i])
+                {
+                        uint8 role = MemberRoles[i];
+                        if(m == leader)
+                                role |= RoleLeader;
+                        return role;
+                }
+        }
+
+        return 0;
+}
+
+uint8 Group::GetMemberRole(const char *name)
+{
+        if(!name)
+                return 0;
+
+        for(uint32 i = 0; i < MAX_GROUP_MEMBERS; ++i)
+        {
+                if(!strcasecmp(membername[i], name))
+                {
+                        uint8 role = MemberRoles[i];
+                        if(leader && !strcasecmp(leader->GetName(), name))
+                                role |= RoleLeader;
+                        return role;
+                }
+        }
+
+        return 0;
 }
 
 void Group::QueueClients(Mob *sender, const EQApplicationPacket *app, bool ack_required /*= true*/, bool ignore_sender /*= true*/, float distance /*= 0*/) {

--- a/zone/groups.h
+++ b/zone/groups.h
@@ -30,7 +30,7 @@ class Mob;
 
 #define MAX_MARKED_NPCS 3
 
-enum { RoleAssist = 1, RoleTank = 2, RolePuller = 4 };
+enum { RoleAssist = 1, RoleTank = 2, RolePuller = 4, RoleLeader = 8 };
 
 class GroupIDConsumer {
 public:
@@ -119,6 +119,8 @@ public:
 	void	SetGroupTankTarget(Mob *m);
 	void	SetGroupPullerTarget(Mob *m);
 	bool	HasRole(Mob *m, uint8 Role);
+        uint8   GetMemberRole(Mob *m);
+        uint8   GetMemberRole(const char *name);
 	void	NotifyAssistTarget(Client *c);
 	void	NotifyTankTarget(Client *c);
 	void	NotifyPullerTarget(Client *c);

--- a/zone/lua_group.cpp
+++ b/zone/lua_group.cpp
@@ -122,6 +122,16 @@ Lua_Mob Lua_Group::GetMember(int member_index) {
 	return self->members[member_index];
 }
 
+uint8 Lua_Group::GetMemberRole(Lua_Mob member) {
+	Lua_Safe_Call_Int();
+	return self->GetMemberRole(member);
+}
+
+uint8 Lua_Group::GetMemberRole(const char* name) {
+	Lua_Safe_Call_Int();
+	return self->GetMemberRole(name);
+}
+
 bool Lua_Group::DoesAnyMemberHaveExpeditionLockout(std::string expedition_name, std::string event_name)
 {
 	Lua_Safe_Call_Bool();
@@ -154,8 +164,10 @@ luabind::scope lua_register_group() {
 	.def("GetLeader", (Lua_Mob(Lua_Group::*)(void))&Lua_Group::GetLeader)
 	.def("GetLeaderName", (const char*(Lua_Group::*)(void))&Lua_Group::GetLeaderName)
 	.def("GetLowestLevel", (uint32(Lua_Group::*)(void))&Lua_Group::GetLowestLevel)
-	.def("GetMember", (Lua_Mob(Lua_Group::*)(int))&Lua_Group::GetMember)
-	.def("GetTotalGroupDamage", (uint32(Lua_Group::*)(Lua_Mob))&Lua_Group::GetTotalGroupDamage)
+       .def("GetMember", (Lua_Mob(Lua_Group::*)(int))&Lua_Group::GetMember)
+       .def("GetMemberRole", (uint8(Lua_Group::*)(Lua_Mob))&Lua_Group::GetMemberRole)
+       .def("GetMemberRole", (uint8(Lua_Group::*)(const char*))&Lua_Group::GetMemberRole)
+       .def("GetTotalGroupDamage", (uint32(Lua_Group::*)(Lua_Mob))&Lua_Group::GetTotalGroupDamage)
 	.def("GroupCount", (int(Lua_Group::*)(void))&Lua_Group::GroupCount)
 	.def("GroupMessage", (void(Lua_Group::*)(Lua_Mob,const char*))&Lua_Group::GroupMessage)
 	.def("GroupMessage", (void(Lua_Group::*)(Lua_Mob,uint8,const char*))&Lua_Group::GroupMessage)

--- a/zone/lua_group.h
+++ b/zone/lua_group.h
@@ -47,10 +47,12 @@ public:
 	uint32 GetHighestLevel();
 	uint32 GetLowestLevel();
 	void TeleportGroup(Lua_Mob sender, uint32 zone_id, uint32 instance_id, float x, float y, float z, float h);
-	int GetID();
-	Lua_Mob GetMember(int member_index);
-	bool DoesAnyMemberHaveExpeditionLockout(std::string expedition_name, std::string event_name);
-	bool DoesAnyMemberHaveExpeditionLockout(std::string expedition_name, std::string event_name, int max_check_count);
+        int GetID();
+        Lua_Mob GetMember(int member_index);
+       uint8 GetMemberRole(Lua_Mob member);
+       uint8 GetMemberRole(const char* name);
+        bool DoesAnyMemberHaveExpeditionLockout(std::string expedition_name, std::string event_name);
+        bool DoesAnyMemberHaveExpeditionLockout(std::string expedition_name, std::string event_name, int max_check_count);
 };
 
 #endif

--- a/zone/perl_groups.cpp
+++ b/zone/perl_groups.cpp
@@ -127,6 +127,16 @@ Client* Perl_Group_GetMember(Group* self, int member_index) // @categories Accou
 	return member ? member->CastToClient() : nullptr;
 }
 
+uint8_t Perl_Group_GetMemberRole(Group* self, Mob* member) // @categories Account and Character, Script Utility, Group
+{
+        return self->GetMemberRole(member);
+}
+
+uint8_t Perl_Group_GetMemberRole(Group* self, const char* name) // @categories Account and Character, Script Utility, Group
+{
+        return self->GetMemberRole(name);
+}
+
 bool Perl_Group_DoesAnyMemberHaveExpeditionLockout(Group* self, std::string expedition_name, std::string event_name)
 {
 	return self->AnyMemberHasDzLockout(expedition_name, event_name);
@@ -161,9 +171,11 @@ void perl_register_group()
 	package.add("GetID", &Perl_Group_GetID);
 	package.add("GetLeader", &Perl_Group_GetLeader);
 	package.add("GetLeaderName", &Perl_Group_GetLeaderName);
-	package.add("GetLowestLevel", &Perl_Group_GetLowestLevel);
-	package.add("GetMember", &Perl_Group_GetMember);
-	package.add("GetTotalGroupDamage", &Perl_Group_GetTotalGroupDamage);
+        package.add("GetLowestLevel", &Perl_Group_GetLowestLevel);
+        package.add("GetMember", &Perl_Group_GetMember);
+        package.add("GetMemberRole", (uint8_t(*)(Group*, Mob*))&Perl_Group_GetMemberRole);
+        package.add("GetMemberRole", (uint8_t(*)(Group*, const char*))&Perl_Group_GetMemberRole);
+        package.add("GetTotalGroupDamage", &Perl_Group_GetTotalGroupDamage);
 	package.add("GroupCount", &Perl_Group_GroupCount);
 	package.add("GroupMessage", (void(*)(Group*, Mob*, const char*))&Perl_Group_GroupMessage);
 	package.add("GroupMessage", (void(*)(Group*, Mob*, uint8_t, const char*))&Perl_Group_GroupMessage);


### PR DESCRIPTION
# Description

Adds scripting support to retrieve group member roles (Leader, Main Tank, Main Assist, Puller) using the new `GetMemberRole(member)` method in both **Perl** and **Lua**.

This exposes previously internal role bitmasks from `groups.h` to scripting languages.

Fixes # (n/a – enhancement)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Testing

Clients tested: RoF2

Tested with a group containing both player characters and bots. Verified output from both Lua and Perl via `event_say`.

All role bitmask constants verified against `groups.h`. Functions return correctly based on assignment via in-game group window.


## Perl Output:
```perl
sub EVENT_SAY {
    return unless $client;              
    return unless $text =~ /roles/i;

    my $group = $client->GetGroup();
    unless ($group) {
        quest::say("You are not in a group.");
        return;
    }

    for (my $i = 0; $i < $group->GroupCount(); $i++) {
        my $member = $group->GetMember($i);
        next unless $member;            # empty slot

        my $flags = $group->GetMemberRole($member);
        my @roles;
        push(@roles, "Leader")      if $flags & 8;  # RoleLeader
        push(@roles, "Main Assist") if $flags & 1;  # RoleAssist
        push(@roles, "Main Tank")   if $flags & 2;  # RoleTank
        push(@roles, "Puller")      if $flags & 4;  # RolePuller

        quest::say($member->GetCleanName() . ": " . join(', ', @roles)) if @roles;
    }
}
```
![image](https://github.com/user-attachments/assets/3718bec9-fef0-4575-b091-9eef4eaf953e)


=== Perl Script $group->GetMemberRole(member) output ===  
Aybekais - Role Mask 8 => Leader  
Warrbot - Role Mask 2 => Main Tank  

## Lua Output:
```lua
local ROLE_ASSIST  = 1
local ROLE_TANK    = 2
local ROLE_PULLER  = 4
local ROLE_LEADER  = 8

function event_say(e)
    if e.message:findi("roles") then
        PrintGroupRoles(e)
    end
end

function PrintGroupRoles(e)
    local cl = e.self
    local g  = cl:GetGroup()

    if not g.valid then
        cl:Message(15, "You are not in a group.")
        return
    end

    cl:Message(15, "=== LUA Script: g:GetMemberRole(member) output ===")

    for i = 0, g:GroupCount() - 1 do
        local member = g:GetMember(i)
        if member.valid then
            local mask = g:GetMemberRole(member)
            local roles = {}

            if bit.band(mask, ROLE_LEADER) ~= 0 then table.insert(roles, "Leader") end
            if bit.band(mask, ROLE_TANK)   ~= 0 then table.insert(roles, "Main Tank") end
            if bit.band(mask, ROLE_ASSIST) ~= 0 then table.insert(roles, "Main Assist") end
            if bit.band(mask, ROLE_PULLER) ~= 0 then table.insert(roles, "Puller") end

            local role_str = (#roles > 0) and table.concat(roles, ", ") or "None"
            cl:Message(15, member:GetCleanName() .. " - Role Mask: " .. mask .. " => " .. role_str)
        end
    end

    cl:Message(15, "==============================================")
end
```
![image](https://github.com/user-attachments/assets/2d9afa44-201e-4d32-b4f0-4ec685045e36)


=== LUA Script g:GetMemberRole(member) output ===  
Aybekais - Role Mask 8 => Leader  
Warrbot - Role Mask 2 => Main Tank  

# Checklist

- [x] I have tested my changes  
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.  
- [ ] I have made corresponding changes to the documentation (if applicable)  
- [x] I own the changes of my code and take responsibility for the potential issues that occur  
- [x] This change does not require any database schema changes  
