### PR TITLE
Suppress Buff SPA (527)

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -546,6 +546,9 @@ RULE_INT(Spells, PointBlankAOEMaxTargets, 0, "Max number of targets a Point-Blan
 RULE_INT(Spells, DefaultAOEMaxTargets, 0, "Max number of targets that an AOE spell which does not meet other descriptions can cast on. Set to 0 for no limit.")
 RULE_BOOL(Spells, AllowFocusOnSkillDamageSpells, false, "Allow focus effects 185, 459, and 482 to enhance SkillAttack spell effect 193")
 RULE_STRING(Spells, AlwaysStackSpells, "", "Comma-Seperated list of spell IDs to always stack with every other spell, except themselves.")
+RULE_BOOL(Spells, SuppressDispels, false, "Swaps 'cancel magic' SPA logic with SuppressBuff SPA (527).")
+RULE_INT(Spells, SuppressDispelsTime, 6, "Number of tics that dispelled buffs will be suppressed for")
+RULE_INT(Spells, SuppressDebuffSpellID, 21840, "Spell ID to send to client when a spell is supprssed.  21840 = 'Suppression Field'")
 RULE_CATEGORY_END()
 
 RULE_CATEGORY(Combat)

--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -966,6 +966,19 @@ bool IsValidSpell(uint32 spell_id)
 	return false;
 }
 
+bool IsValidOrSuppressedSpell(uint32 spell_id)
+{
+	if (IsValidSpell(spell_id)) {
+		return true;
+	}
+
+	if (spell_id == SPELL_SUPPRESSED) {
+		return true;
+	}
+
+	return false;
+}
+
 bool IsHarmTouchSpell(uint16 spell_id)
 {
 	return spell_id == SPELL_HARM_TOUCH ||

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -24,6 +24,7 @@
 
 #define SPELL_UNKNOWN 0xFFFF
 #define POISON_PROC 0xFFFE
+#define SPELL_SUPPRESSED 0xFFFD
 #define SPELLBOOK_UNKNOWN 0xFFFFFFFF		//player profile spells are 32 bit
 
 //some spell IDs which will prolly change, but are needed
@@ -1586,6 +1587,7 @@ typedef enum {
 #define SE_Duration_HP_Pct				524 // implemented - Decrease Current Hit Points by % of Total Hit Points per Tick, up to a MAX per tick
 #define SE_Duration_Mana_Pct			525 // implemented - Decrease Current Mana by % of Total Mana per Tick, up to a MAX per tick
 #define SE_Duration_Endurance_Pct		526 // implemented - Decrease Current Endurance by % of Total Hit Points per Tick, up to a MAX per tick
+#define SE_SuppressBuff				527 // implemented - Temporarily disable beneficial buff
 
 
 // LAST
@@ -1816,6 +1818,7 @@ bool IsEffectInSpell(uint16 spell_id, int effect_id);
 uint16 GetSpellTriggerSpellID(uint16 spell_id, int effect_id);
 bool IsBlankSpellEffect(uint16 spell_id, int effect_index);
 bool IsValidSpell(uint32 spell_id);
+bool IsValidOrSuppressedSpell(uint32 spell_id);
 bool IsSummonSpell(uint16 spell_id);
 bool IsDamageSpell(uint16 spell_id);
 bool IsAnyDamageSpell(uint16 spell_id);

--- a/zone/client.h
+++ b/zone/client.h
@@ -344,6 +344,7 @@ public:
 	bool IsClient() const override { return true; }
 	bool IsOfClientBot() const override { return true; }
 	bool IsOfClientBotMerc() const override { return true; }
+	void ReapplyBuff(uint32 index, bool from_suppress = false);
 	void CompleteConnect();
 	bool TryStacking(EQ::ItemInstance* item, uint8 type = ItemPacketTrade, bool try_worn = true, bool try_cursor = true);
 	void SendTraderPacket(Client* trader, uint32 Unknown72 = 51);

--- a/zone/common.h
+++ b/zone/common.h
@@ -274,6 +274,8 @@ struct Buffs_Struct {
 	bool	persistant_buff;
 	bool	client; //True if the caster is a client
 	bool	UpdateClient;
+	uint16  suppressedid;
+	uint32  suppressedticsremaining;
 
 	// cereal
 	template<class Archive>

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -2167,6 +2167,11 @@ void Lua_Mob::BuffFadeBySlot(int slot, bool recalc_bonuses) {
 	self->BuffFadeBySlot(slot, recalc_bonuses);
 }
 
+void Lua_Mob::BuffFadeBySlot(int slot, bool recalc_bonuses, bool suppress, int suppress_tics) {
+	Lua_Safe_Call_Void();
+	self->BuffFadeBySlot(slot, recalc_bonuses, suppress, suppress_tics);
+}
+
 int Lua_Mob::CanBuffStack(int spell_id, int caster_level) {
 	Lua_Safe_Call_Int();
 	return self->CanBuffStack(spell_id, caster_level);
@@ -3524,6 +3529,7 @@ luabind::scope lua_register_mob() {
 	.def("BuffFadeByEffect", (void(Lua_Mob::*)(int,int))&Lua_Mob::BuffFadeByEffect)
 	.def("BuffFadeBySlot", (void(Lua_Mob::*)(int))&Lua_Mob::BuffFadeBySlot)
 	.def("BuffFadeBySlot", (void(Lua_Mob::*)(int,bool))&Lua_Mob::BuffFadeBySlot)
+	.def("BuffFadeBySlot", (void(Lua_Mob::*)(int,bool,bool,int))&Lua_Mob::BuffFadeBySlot)
 	.def("BuffFadeBySpellID", (void(Lua_Mob::*)(int))&Lua_Mob::BuffFadeBySpellID)
 	.def("BuffFadeDetrimental", (void(Lua_Mob::*)(void))&Lua_Mob::BuffFadeDetrimental)
 	.def("BuffFadeDetrimentalByCaster", (void(Lua_Mob::*)(Lua_Mob))&Lua_Mob::BuffFadeDetrimentalByCaster)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -434,6 +434,7 @@ public:
 	void BuffFadeAll();
 	void BuffFadeBySlot(int slot);
 	void BuffFadeBySlot(int slot, bool recalc_bonuses);
+	void BuffFadeBySlot(int slot, bool recalc_bonuses, bool suppress, int suppress_tics);
 	int CanBuffStack(int spell_id, int caster_level);
 	int CanBuffStack(int spell_id, int caster_level, bool fail_if_overwrite);
 	void SetPseudoRoot(bool in);

--- a/zone/mob.h
+++ b/zone/mob.h
@@ -453,7 +453,7 @@ public:
 	void BuffFadeBeneficial();
 	void BuffFadeNonPersistDeath();
 	void BuffFadeDetrimental();
-	void BuffFadeBySlot(int slot, bool iRecalcBonuses = true);
+	void BuffFadeBySlot(int slot, bool iRecalcBonuses = true, bool suppress = false, uint32 suppresstics = 0);
 	void BuffFadeDetrimentalByCaster(Mob *caster);
 	void BuffFadeBySitModifier();
 	void BuffFadeSongs();
@@ -967,7 +967,9 @@ public:
 	void TrySympatheticProc(Mob *target, uint32 spell_id);
 	uint16 GetSympatheticFocusEffect(focusType type, uint16 spell_id);
 	bool TryFadeEffect(int slot);
-	void DispelMagic(Mob* casterm, uint16 spell_id, int effect_value);
+	void DispelMagic(Mob* casterm, uint16 spell_id, int effect_value, int chance = 1000, bool detrimental_only = false, bool benficial_only = false);
+	bool IsSuppressableBuff(int slot) const;
+	void SuppressBuff(Mob* caster, uint16 spell_id, int tic_count);
 	bool TrySpellEffectResist(uint16 spell_id);
 	int32 GetVulnerability(Mob *caster, uint32 spell_id, uint32 ticsremaining, bool from_buff_tic = false);
 	int64 GetFcDamageAmtIncoming(Mob *caster, int32 spell_id, bool from_buff_tic = false);

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -1044,6 +1044,11 @@ void Perl_Mob_BuffFadeBySlot(Mob* self, int slot, bool recalc_bonuses) // @categ
 	self->BuffFadeBySlot(slot, recalc_bonuses);
 }
 
+void Perl_Mob_BuffFadeBySlot(Mob* self, int slot, bool recalc_bonuses, bool suppress, int suppress_tics) // @categories Script Utility, Spells and Disciplines
+{
+	self->BuffFadeBySlot(slot, recalc_bonuses, suppress, suppress_tics);
+}
+
 bool Perl_Mob_CanBuffStack(Mob* self, uint16 spell_id, uint8 caster_level) // @categories Script Utility, Spells and Disciplines
 {
 	return self->CanBuffStack(spell_id, caster_level);
@@ -3613,6 +3618,7 @@ void perl_register_mob()
 	package.add("BuffFadeByEffect", (void(*)(Mob*, int, int))&Perl_Mob_BuffFadeByEffect);
 	package.add("BuffFadeBySlot", (void(*)(Mob*, int))&Perl_Mob_BuffFadeBySlot);
 	package.add("BuffFadeBySlot", (void(*)(Mob*, int, bool))&Perl_Mob_BuffFadeBySlot);
+	package.add("BuffFadeBySlot", (void(*)(Mob*, int, bool, bool, int))&Perl_Mob_BuffFadeBySlot);
 	package.add("BuffFadeBySpellID", &Perl_Mob_BuffFadeBySpellID);
 	package.add("BuffFadeDetrimental", &Perl_Mob_BuffFadeDetrimental);
 	package.add("BuffFadeDetrimentalByCaster", &Perl_Mob_BuffFadeDetrimentalByCaster);

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -1121,24 +1121,8 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 						caster->MessageString(Chat::SpellFailure, SPELL_NO_EFFECT, spells[spell_id].name);
 					break;
 				}
-				/*
-					TODO: Parsing shows there is no level modifier. However, a consistent -2% modifer was
-					found on spell with value 950 (95% spells would have 7% failure rates).
-					Further investigation is needed. ~ Kayen
-				*/
-				int chance = spells[spell_id].base_value[i];
-				int buff_count = GetMaxTotalSlots();
-				for(int slot = 0; slot < buff_count; slot++) {
-					if (IsValidSpell(buffs[slot].spellid) &&
-						IsDetrimentalSpell(buffs[slot].spellid) &&
-						spells[buffs[slot].spellid].dispel_flag == 0)
-					{
-						if (zone->random.Int(1, 1000) <= chance){
-							BuffFadeBySlot(slot);
-							slot = buff_count;
-						}
-					}
-				}
+
+				DispelMagic(caster, spell_id, effect_value, spells[spell_id].base_value[i], true);
 				break;
 			}
 
@@ -1153,19 +1137,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					break;
 				}
 
-				int chance = spells[spell_id].base_value[i];
-				int buff_count = GetMaxTotalSlots();
-				for(int slot = 0; slot < buff_count; slot++) {
-					if (IsValidSpell(buffs[slot].spellid) &&
-						IsBeneficialSpell(buffs[slot].spellid) &&
-						spells[buffs[slot].spellid].dispel_flag == 0)
-					{
-						if (zone->random.Int(1, 1000) <= chance) {
-							BuffFadeBySlot(slot);
-							slot = buff_count;
-						}
-					}
-				}
+				DispelMagic(caster, spell_id, effect_value, spells[spell_id].base_value[i], false, true);
 				break;
 			}
 
@@ -3121,9 +3093,19 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_PersistentEffect:
+			case SE_PersistentEffect: {
 				MakeAura(spell_id);
 				break;
+			}
+
+			case SE_SuppressBuff: {
+#ifdef SPELL_EFFECT_SPAM
+				snprintf(effect_desc, _EDLEN, "Suppress Buff");
+#endif
+				SuppressBuff(caster, spell_id, spell.base_value[i]);
+
+				break;
+			}
 
 			// Handled Elsewhere
 			case SE_ImmuneFleeing:
@@ -3844,18 +3826,20 @@ void Mob::BuffProcess()
 
 	for (int buffs_i = 0; buffs_i < buff_count; ++buffs_i)
 	{
-		if (IsValidSpell(buffs[buffs_i].spellid))
+		if (IsValidOrSuppressedSpell(buffs[buffs_i].spellid))
 		{
 			DoBuffTic(buffs[buffs_i], buffs_i, entity_list.GetMob(buffs[buffs_i].casterid));
 			// If the Mob died during DoBuffTic, then the buff we are currently processing will have been removed
-			if(!IsValidSpell(buffs[buffs_i].spellid)) {
+			if(!IsValidOrSuppressedSpell(buffs[buffs_i].spellid)) {
 				continue;
 			}
 
 			// DF_Permanent uses -1 DF_Aura uses -4 but we need to check negatives for some spells for some reason?
-			if (spells[buffs[buffs_i].spellid].buff_duration_formula != DF_Permanent &&
-			    spells[buffs[buffs_i].spellid].buff_duration_formula != DF_Aura &&
-				buffs[buffs_i].ticsremaining != PERMANENT_BUFF_DURATION) {
+			if (buffs[buffs_i].spellid == SPELL_SUPPRESSED ||
+				(spells[buffs[buffs_i].spellid].buff_duration_formula != DF_Permanent &&
+				spells[buffs[buffs_i].spellid].buff_duration_formula != DF_Aura &&
+				buffs[buffs_i].ticsremaining != PERMANENT_BUFF_DURATION)) {
+
 				if(!zone->BuffTimersSuspended() || !IsSuspendableSpell(buffs[buffs_i].spellid))
 				{
 					--buffs[buffs_i].ticsremaining;
@@ -4250,16 +4234,21 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 }
 
 // removes the buff in the buff slot 'slot'
-void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
+void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses, bool suppress, uint32 suppresstics)
 {
 	if(slot < 0 || slot > GetMaxTotalSlots())
 		return;
 
-	if(!IsValidSpell(buffs[slot].spellid))
+	if(!IsValidOrSuppressedSpell(buffs[slot].spellid))
 		return;
 
-	if (IsClient() && !CastToClient()->IsDead())
-		CastToClient()->MakeBuffFadePacket(buffs[slot].spellid, slot);
+	if (IsClient()) {
+		auto client = CastToClient();
+		if (!client->IsDead()) {
+			uint32 spell_id = (buffs[slot].spellid != SPELL_SUPPRESSED) ? buffs[slot].spellid : RuleI(Spells, SuppressDebuffSpellID);
+			client->MakeBuffFadePacket(spell_id, slot);
+		}
+	}
 
 	LogSpells("Fading buff [{}] from slot [{}]", buffs[slot].spellid, slot);
 
@@ -4320,6 +4309,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 			{
 				uint16 procid = GetProcID(buffs[slot].spellid, i);
 				RemoveDefensiveProc(procid);
+
 				break;
 			}
 
@@ -4388,20 +4378,24 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 
 			case SE_Rune:
 			{
-				buffs[slot].melee_rune = 0;
+				if (!suppress) {
+					buffs[slot].melee_rune = 0;
+				}
 				break;
 			}
 
 			case SE_AbsorbMagicAtt:
 			{
-				buffs[slot].magic_rune = 0;
+				if (!suppress) {
+					buffs[slot].magic_rune = 0;
+				}
 				break;
 			}
 
 			case SE_Familiar:
 			{
 				Mob *mypet = GetPet();
-				if (mypet){
+				if (mypet && !suppress){
 					if(mypet->IsNPC())
 						mypet->CastToNPC()->Depop();
 					SetPetID(0);
@@ -4418,6 +4412,9 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 
 			case SE_Charm:
 			{
+				//Trying to restore pet ownership after suppression is too much, so just downgrade to a normal dispel
+				suppress = false;
+
 				if(IsNPC())
 				{
 					CastToNPC()->RestoreGuardSpotCharm();
@@ -4642,7 +4639,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 		Mob *notify = p;
 		if(p->IsPet())
 			notify = p->GetOwner();
-		if(p) {
+		if(p && buffs[slot].spellid != SPELL_SUPPRESSED) {
 			notify->MessageString(Chat::SpellWornOff, SPELL_WORN_OFF_OF,
 				spells[buffs[slot].spellid].name, GetCleanName());
 		}
@@ -4665,10 +4662,53 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 			Numhits(false);
 	}
 
-	if (spells[buffs[slot].spellid].nimbus_effect > 0)
+	if (IsValidSpell(buffs[slot].spellid) && spells[buffs[slot].spellid].nimbus_effect > 0)
 		RemoveNimbusEffect(spells[buffs[slot].spellid].nimbus_effect);
 
-	buffs[slot].spellid = SPELL_UNKNOWN;
+	if (suppress && suppresstics > 0) {
+		if (buffs[slot].spellid != SPELL_SUPPRESSED) {
+			buffs[slot].suppressedid = buffs[slot].spellid;
+			buffs[slot].suppressedticsremaining = buffs[slot].ticsremaining;
+			buffs[slot].spellid = SPELL_SUPPRESSED;
+		}
+		buffs[slot].ticsremaining = suppresstics;
+	} else if (buffs[slot].spellid == SPELL_SUPPRESSED) {
+		buffs[slot].spellid = buffs[slot].suppressedid;
+		buffs[slot].ticsremaining = buffs[slot].suppressedticsremaining;
+		buffs[slot].suppressedid = 0;
+		buffs[slot].suppressedticsremaining = -1;
+
+		if (buffs[slot].hit_number > 0) {
+			Numhits(true);
+		}
+
+		if (IsClient()) {
+			//This bit of magic need to arrive before our BuffCreate.  It appears to put the client in a state
+			//where it will be more accepting of information like 'Make this player levitate' or 'This buff has num-hit counters'
+			auto client = CastToClient();
+			auto* action_packet = new EQApplicationPacket(OP_Action, sizeof(Action_Struct));
+			auto* action = reinterpret_cast<Action_Struct*>(action_packet->pBuffer);
+
+			action->source         = buffs[slot].casterid;
+			action->target         = client->GetID();
+			action->level          = client->GetLevel();
+			action->instrument_mod = buffs[slot].instrument_mod;
+			action->force          = 0;
+			action->hit_heading    = client->GetHeading();
+			action->hit_pitch      = 0;
+			action->type           = 231;	// 231 means a spell
+			action->spell          = buffs[slot].spellid;
+			action->spell_level    = buffs[slot].casterlevel;
+			action->effect_flag    = 0x04;  // Successful action
+
+			client->QueuePacket(action_packet);
+			safe_delete(action_packet);
+			client->ReapplyBuff(slot, true);
+		}
+	} else {
+		buffs[slot].spellid = SPELL_UNKNOWN;
+	}
+
 	if(IsPet() && GetOwner() && GetOwner()->IsClient()) {
 		SendPetBuffsToClient();
 	}
@@ -7449,19 +7489,82 @@ bool Mob::PassLimitClass(uint32 Classes_, uint16 Class_)
 	return false;
 }
 
-void Mob::DispelMagic(Mob* caster, uint16 spell_id, int effect_value)
+void Mob::DispelMagic(Mob* caster, uint16 spell_id, int effect_value, int chance, bool detrimental_only, bool beneficial_only)
 {
-	for (int slot = 0; slot < GetMaxTotalSlots(); slot++) {
-		if (
-			buffs[slot].spellid != SPELL_UNKNOWN &&
-			spells[buffs[slot].spellid].dispel_flag == 0 &&
-			!IsDiscipline(buffs[slot].spellid)
-		) {
-			if (caster && TryDispel(caster->GetCasterLevel(spell_id), buffs[slot].casterlevel, effect_value)) {
+	bool target_is_client = IsClient() || (GetUltimateOwner() && GetUltimateOwner()->IsClient());
+	bool caster_is_client = caster && (caster->IsClient() || (caster->GetUltimateOwner() && caster->GetUltimateOwner()->IsClient()));
+
+	for (int slot = 0; slot < GetMaxTotalSlots(); ++slot) {
+		auto s = buffs[slot].spellid;
+
+		if (s == SPELL_UNKNOWN || spells[s].dispel_flag != 0 || IsDiscipline(s)) {
+			continue;
+		}
+
+		if (!caster || !TryDispel(caster->GetCasterLevel(spell_id), buffs[slot].casterlevel, effect_value)) {
+			continue;
+		}
+
+		if (detrimental_only && !IsDetrimentalSpell(s)) {
+			continue;
+		}
+
+		if (beneficial_only && IsDetrimentalSpell(s)) {
+			continue;
+		}
+
+		bool perma_remove = caster_is_client || !target_is_client;
+		if (perma_remove || !RuleB(Spells, SuppressDispels)) {
+			if (chance >= 1000 || zone->random.Int(1, 1000) <= chance) {
 				BuffFadeBySlot(slot);
 				break;
 			}
+		} else {
+			//Additional restrictions on which buffs can be suppressed
+			if (spells[s].short_buff_box) {
+				continue;
+			}
+
+			BuffFadeBySlot(slot, true, true, RuleI(Spells, SuppressDispelsTime));
+			break;
 		}
+	}
+}
+
+bool Mob::IsSuppressableBuff(int slot) const {
+	auto sid = buffs[slot].spellid;
+
+	//Suppressed spells can be re-suppressed to refresh their timer
+	if (sid == SPELL_SUPPRESSED) {
+		return true;
+	}
+
+	return IsValidSpell(sid) &&
+		IsBeneficialSpell(sid) &&
+		!IsBardSong(sid) &&
+		spells[sid].dispel_flag == 0;
+}
+
+void Mob::SuppressBuff(Mob *caster, uint16 spell_id, int tic_count)
+{
+	//Think I'll let dispel imumunity apply to this as well
+	if(GetSpecialAbility(SpecialAbility::DispellImmunity)){
+		if (caster && caster->IsClient()) {
+			caster->MessageString(Chat::SpellFailure, SPELL_NO_EFFECT, spells[spell_id].name);
+		}
+		return;
+	}
+
+	std::vector<int> candidates;
+	for(int slot = 0, count = GetMaxBuffSlots(); slot < count; ++slot) {
+		if (IsSuppressableBuff(slot)) {
+			candidates.push_back(slot);
+		}
+	}
+
+	if(!candidates.empty()) {
+		int choice = zone->random.Int(0, candidates.size() - 1);
+		BuffFadeBySlot(candidates[choice], true, true, tic_count);
 	}
 }
 

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -2897,7 +2897,7 @@ void ZoneDatabase::SaveBuffs(Client *client)
 	uint32 character_buff_count = 0;
 
 	for (int slot_id = 0; slot_id < max_buff_slots; slot_id++) {
-		if (!IsValidSpell(buffs[slot_id].spellid)) {
+		if (!IsValidOrSuppressedSpell(buffs[slot_id].spellid)) {
 			continue;
 		}
 
@@ -2907,16 +2907,18 @@ void ZoneDatabase::SaveBuffs(Client *client)
 	v.reserve(character_buff_count);
 
 	for (int slot_id = 0; slot_id < max_buff_slots; slot_id++) {
-		if (!IsValidSpell(buffs[slot_id].spellid)) {
+		if (!IsValidOrSuppressedSpell(buffs[slot_id].spellid)) {
 			continue;
 		}
 
+		bool suppressed = buffs[slot_id].spellid == SPELL_SUPPRESSED;
+
 		e.character_id   = client->CharacterID();
 		e.slot_id        = slot_id;
-		e.spell_id       = buffs[slot_id].spellid;
+		e.spell_id       = suppressed ? buffs[slot_id].suppressedid : buffs[slot_id].spellid;
 		e.caster_level   = buffs[slot_id].casterlevel;
 		e.caster_name    = buffs[slot_id].caster_name;
-		e.ticsremaining  = buffs[slot_id].ticsremaining;
+		e.ticsremaining  = suppressed ? buffs[slot_id].suppressedticsremaining : buffs[slot_id].ticsremaining;
 		e.counters       = buffs[slot_id].counters;
 		e.numhits        = buffs[slot_id].hit_number;
 		e.melee_rune     = buffs[slot_id].melee_rune;
@@ -2999,6 +3001,8 @@ void ZoneDatabase::LoadBuffs(Client *client)
 		buffs[e.slot_id].virus_spread_time = 0;
 		buffs[e.slot_id].UpdateClient      = false;
 		buffs[e.slot_id].instrument_mod    = e.instrument_mod;
+		buffs[e.slot_id].suppressedid            = 0;
+		buffs[e.slot_id].suppressedticsremaining = -1;
 	}
 
 	// We load up to the most our client supports


### PR DESCRIPTION
# Description

This was something I was asked to send upstream.  It adds the ability to suppress a player's buff for a set amount of time, restoring it when the effect ends.  There are three ways a server can leverage this effect:

1. Enable the 'SuppressDispels' rule

![image](https://github.com/user-attachments/assets/9404f956-5667-4711-861b-683db744166c)

This will cause CancelMagic, DispelDetrimental and DispelBeneficial SPAs to automatically use the suppression effect instead when the target is a player/player's pet and the caster is an NPC.

Players will still be able to dispel themselves and enemies normally.

When this rule is disabled (default) dispels should behave the same as always.

2. New overloaded API method for 'BuffFadeBySlot'

Scripts can now pass two optional parameters to this API to force a suppression effect on a specific buff slot.  The third parameter is true/false to enable the suppression with the fourth being the number of tics the effect should last.

3. Use the new SPA 527 in a spell.

This SPA picks a random buff on the target and applies the suppression effect, refreshing the timer if its already suppressed.  The base_value represents the number of tics the effect should last.

Downstream users will likely want to customizes these behaviors somewhat depending on what they desire.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
    Spire missing support for new SPA

# Testing

https://github.com/user-attachments/assets/305a4903-2647-464b-b2c1-d91d740f565b

Tested with base RoF client and latest eqemu/master branch.

Test Cases:
- Suppressed buffs lose their effects and restore when suppression end
- Levitate effect properly restores after suppression
- Lua buff fade by slot works
- Perl buff fade by slot works
- Suppress on charm breaks charm
- Suppress on pet works
- Dispel on self clears buffs (with rule on or off)
- Dispel on npc clears buffs
- Custom spell with SPA 527 works
- DispelBeneficial works
- DispelDetrimental works

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [ ] I have made corresponding changes to the documentation (if applicable, if not delete this line)
- [x] I own the changes of my code and take responsibility for the potential issues that occur
