### PR TITLE
[Quest API] Add GetTimers() and GetPausedTimers() to Perl/Lua

### DIFF
--- a/zone/embparser_api.cpp
+++ b/zone/embparser_api.cpp
@@ -6005,6 +6005,40 @@ bool Perl__handin(perl::reference handin_ref)
 	return quest_manager.handin(handin_map);
 }
 
+perl::array Perl__get_paused_timers(Mob* m)
+{
+	perl::array a;
+
+	const auto& l = quest_manager.GetPausedTimers(m);
+
+	if (!l.empty()) {
+		a.reserve(l.size());
+
+		for (const auto& v : l) {
+			a.push_back(v);
+		}
+	}
+
+	return a;
+}
+
+perl::array Perl__get_timers(Mob* m)
+{
+	perl::array a;
+
+	const auto& l = quest_manager.GetTimers(m);
+
+	if (!l.empty()) {
+		a.reserve(l.size());
+
+		for (const auto& v: l) {
+			a.push_back(v);
+		}
+	}
+
+	return a;
+}
+
 void perl_register_quest()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -6694,6 +6728,7 @@ void perl_register_quest()
 	package.add("getguildidbycharid", &Perl__getguildidbycharid);
 	package.add("getgroupidbycharid", &Perl__getgroupidbycharid);
 	package.add("getinventoryslotname", &Perl__getinventoryslotname);
+	package.add("get_paused_timers", &Perl__get_paused_timers);
 	package.add("getraididbycharid", &Perl__getraididbycharid);
 	package.add("get_race_bitmask", &Perl__get_race_bitmask);
 	package.add("get_recipe_component_item_ids", &Perl__GetRecipeComponentItemIDs);
@@ -6713,6 +6748,7 @@ void perl_register_quest()
 	package.add("getspellstat", (int(*)(uint32, std::string))&Perl__getspellstat);
 	package.add("getspellstat", (int(*)(uint32, std::string, uint8))&Perl__getspellstat);
 	package.add("getskillname", &Perl__getskillname);
+	package.add("get_timers", &Perl__get_timers);
 	package.add("getlevel", &Perl__getlevel);
 	package.add("getplayerburiedcorpsecount", &Perl__getplayerburiedcorpsecount);
 	package.add("getplayercorpsecount", &Perl__getplayercorpsecount);

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -5675,6 +5675,32 @@ bool lua_handin(luabind::adl::object handin_table)
 	return quest_manager.handin(handin_map);
 }
 
+luabind::object lua_get_paused_timers(lua_State* L, Mob* m) {
+	auto t = luabind::newtable(L);
+	auto v = quest_manager.GetPausedTimers(m);
+	int  i = 1;
+
+	for (const auto& e : v) {
+		t[i] = e;
+		i++;
+	}
+
+	return t;
+}
+
+luabind::object lua_get_timers(lua_State* L, Mob* m) {
+	auto t = luabind::newtable(L);
+	auto v = quest_manager.GetTimers(m);
+	int  i = 1;
+
+	for (const auto& e : v) {
+		t[i] = e;
+		i++;
+	}
+
+	return t;
+}
+
 #define LuaCreateNPCParse(name, c_type, default_value) do { \
 	cur = table[#name]; \
 	if(luabind::type(cur) != LUA_TNIL) { \
@@ -6486,6 +6512,8 @@ luabind::scope lua_register_general() {
 		luabind::def("spawn_grid", &lua_spawn_grid),
 		luabind::def("get_zone", &lua_get_zone),
 		luabind::def("handin", &lua_handin),
+		luabind::def("get_paused_timers", &lua_get_paused_timers),
+		luabind::def("get_timers", &lua_get_timers),
 		/*
 			Cross Zone
 		*/

--- a/zone/lua_mob.cpp
+++ b/zone/lua_mob.cpp
@@ -3482,6 +3482,36 @@ void Lua_Mob::BuffFadeSongs()
 	self->BuffFadeSongs();
 }
 
+luabind::object Lua_Mob::GetPausedTimers(lua_State* L) {
+	auto t = luabind::newtable(L);
+	if (d_) {
+		auto self = reinterpret_cast<NativeType*>(d_);
+		auto l = quest_manager.GetPausedTimers(self);
+		int i = 1;
+		for (const auto& v : l) {
+			t[i] = v;
+			i++;
+		}
+	}
+
+	return t;
+}
+
+luabind::object Lua_Mob::GetTimers(lua_State* L) {
+	auto t = luabind::newtable(L);
+	if (d_) {
+		auto self = reinterpret_cast<NativeType*>(d_);
+		auto l = quest_manager.GetTimers(self);
+		int i = 1;
+		for (const auto& v : l) {
+			t[i] = v;
+			i++;
+		}
+	}
+
+	return t;
+}
+
 luabind::scope lua_register_mob() {
 	return luabind::class_<Lua_Mob, Lua_Entity>("Mob")
 	.def(luabind::constructor<>())
@@ -3822,6 +3852,7 @@ luabind::scope lua_register_mob() {
 	.def("GetOwner", &Lua_Mob::GetOwner)
 	.def("GetOwnerID", &Lua_Mob::GetOwnerID)
 	.def("GetPR", &Lua_Mob::GetPR)
+	.def("GetPausedTimers", &Lua_Mob::GetPausedTimers)
 	.def("GetPet", &Lua_Mob::GetPet)
 	.def("GetPetOrder", (int(Lua_Mob::*)(void))&Lua_Mob::GetPetOrder)
 	.def("GetPhR", &Lua_Mob::GetPhR)
@@ -3847,6 +3878,7 @@ luabind::scope lua_register_mob() {
 	.def("GetTarget", &Lua_Mob::GetTarget)
 	.def("GetTexture", &Lua_Mob::GetTexture)
 	.def("GetTimerDurationMS", &Lua_Mob::GetTimerDurationMS)
+	.def("GetTimers", &Lua_Mob::GetTimers)
 	.def("GetUltimateOwner", &Lua_Mob::GetUltimateOwner)
 	.def("GetWIS", &Lua_Mob::GetWIS)
 	.def("GetWalkspeed", &Lua_Mob::GetWalkspeed)
@@ -3908,7 +3940,7 @@ luabind::scope lua_register_mob() {
 	.def("IsPausedTimer", &Lua_Mob::IsPausedTimer)
 	.def("IsPet", (bool(Lua_Mob::*)(void))&Lua_Mob::IsPet)
 	.def("IsPetOwnerBot", &Lua_Mob::IsPetOwnerBot)
-	.def("IsPetOwnerClient", &Lua_Mob::IsPetOwnerClient)	
+	.def("IsPetOwnerClient", &Lua_Mob::IsPetOwnerClient)
 	.def("IsPetOwnerNPC", &Lua_Mob::IsPetOwnerNPC)
 	.def("IsPetOwnerOfClientBot", &Lua_Mob::IsPetOwnerOfClientBot)
 	.def("IsPureMeleeClass", &Lua_Mob::IsPureMeleeClass)

--- a/zone/lua_mob.h
+++ b/zone/lua_mob.h
@@ -574,7 +574,7 @@ public:
 	bool IsFamiliar();
 	bool IsTargetLockPet();
 	bool IsPetOwnerBot();
-	bool IsPetOwnerClient();	
+	bool IsPetOwnerClient();
 	bool IsPetOwnerNPC();
 	bool IsPetOwnerOfClientBot();
 	bool IsDestructibleObject();
@@ -612,6 +612,8 @@ public:
 	void BuffFadeDetrimentalByCaster(Lua_Mob caster);
 	void BuffFadeNonPersistDeath();
 	void BuffFadeSongs();
+	luabind::object GetPausedTimers(lua_State* L);
+	luabind::object GetTimers(lua_State* L);
 };
 
 #endif

--- a/zone/lua_zone.cpp
+++ b/zone/lua_zone.cpp
@@ -838,6 +838,36 @@ void Lua_Zone::Signal(int signal_id)
 	self->Signal(signal_id);
 }
 
+luabind::object Lua_Zone::GetPausedTimers(lua_State* L) {
+	auto t = luabind::newtable(L);
+	if (d_) {
+		auto self = reinterpret_cast<NativeType*>(d_);
+		auto l = self->GetPausedTimers();
+		int i = 1;
+		for (const auto& v : l) {
+			t[i] = v;
+			i++;
+		}
+	}
+
+	return t;
+}
+
+luabind::object Lua_Zone::GetTimers(lua_State* L) {
+	auto t = luabind::newtable(L);
+	if (d_) {
+		auto self = reinterpret_cast<NativeType*>(d_);
+		auto l = self->GetTimers();
+		int i = 1;
+		for (const auto& v : l) {
+			t[i] = v;
+			i++;
+		}
+	}
+
+	return t;
+}
+
 luabind::scope lua_register_zone() {
 	return luabind::class_<Lua_Zone>("Zones")
 	.def(luabind::constructor<>())
@@ -906,6 +936,7 @@ luabind::scope lua_register_zone() {
 	.def("GetMinimumStatus", &Lua_Zone::GetMinimumStatus)
 	.def("GetNote", &Lua_Zone::GetNote)
 	.def("GetNPCMaximumAggroDistance", &Lua_Zone::GetNPCMaximumAggroDistance)
+	.def("GetPausedTimers", &Lua_Zone::GetPausedTimers)
 	.def("GetPEQZone", &Lua_Zone::GetPEQZone)
 	.def("GetRainChance", (int(Lua_Zone::*)(void))&Lua_Zone::GetRainChance)
 	.def("GetRainChance", (int(Lua_Zone::*)(uint8))&Lua_Zone::GetRainChance)
@@ -929,6 +960,7 @@ luabind::scope lua_register_zone() {
 	.def("GetTimeZone", &Lua_Zone::GetTimeZone)
 	.def("GetTimerDuration", &Lua_Zone::GetTimerDuration)
 	.def("GetTimerRemainingTime", &Lua_Zone::GetTimerRemainingTime)
+	.def("GetTimers", &Lua_Zone::GetTimers)
 	.def("GetZoneDescription", &Lua_Zone::GetZoneDescription)
 	.def("GetZoneID", &Lua_Zone::GetZoneID)
 	.def("GetZoneType", &Lua_Zone::GetZoneType)

--- a/zone/lua_zone.h
+++ b/zone/lua_zone.h
@@ -158,6 +158,8 @@ public:
 	void StopAllTimers();
 	void Signal(int signal_id);
 	void SendPayload(int payload_id, std::string payload_value);
+	luabind::object GetPausedTimers(lua_State* L);
+	luabind::object GetTimers(lua_State* L);
 
 	// data buckets
 	void SetBucket(const std::string& bucket_name, const std::string& bucket_value);

--- a/zone/perl_mob.cpp
+++ b/zone/perl_mob.cpp
@@ -3573,6 +3573,30 @@ void Perl_Mob_BuffFadeSongs(Mob* self)
 	self->BuffFadeSongs();
 }
 
+perl::array Perl_Mob_GetPausedTimers(Mob* self)
+{
+	perl::array a;
+
+	const auto& l = quest_manager.GetPausedTimers(self);
+	for (const auto& v : l) {
+		a.push_back(v);
+	}
+
+	return a;
+}
+
+perl::array Perl_Mob_GetTimers(Mob* self)
+{
+	perl::array a;
+
+	const auto& l = quest_manager.GetTimers(self);
+	for (const auto& v : l) {
+		a.push_back(v);
+	}
+
+	return a;
+}
+
 void perl_register_mob()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3897,6 +3921,7 @@ void perl_register_mob()
 	package.add("GetOwner", &Perl_Mob_GetOwner);
 	package.add("GetOwnerID", &Perl_Mob_GetOwnerID);
 	package.add("GetPR", &Perl_Mob_GetPR);
+	package.add("GetPausedTimers", &Perl_Mob_GetPausedTimers);
 	package.add("GetPet", &Perl_Mob_GetPet);
 	package.add("GetPetID", &Perl_Mob_GetPetID);
 	package.add("GetPetOrder", &Perl_Mob_GetPetOrder);
@@ -3927,6 +3952,7 @@ void perl_register_mob()
 	package.add("GetTarget", &Perl_Mob_GetTarget);
 	package.add("GetTexture", &Perl_Mob_GetTexture);
 	package.add("GetTimerDurationMS", &Perl_Mob_GetTimerDurationMS);
+	package.add("GetTimers", &Perl_Mob_GetTimers);
 	package.add("GetUltimateOwner", &Perl_Mob_GetUltimateOwner);
 	package.add("GetWIS", &Perl_Mob_GetWIS);
 	package.add("GetWalkspeed", &Perl_Mob_GetWalkspeed);

--- a/zone/perl_zone.cpp
+++ b/zone/perl_zone.cpp
@@ -653,6 +653,40 @@ void Perl_Zone_Signal(Zone* self, int signal_id)
 	self->Signal(signal_id);
 }
 
+perl::array Perl_Zone_GetPausedTimers(Zone* self)
+{
+	perl::array a;
+
+	const auto& l = self->GetPausedTimers();
+
+	if (!l.empty()) {
+		a.reserve(l.size());
+
+		for (const auto& v : l) {
+			a.push_back(v);
+		}
+	}
+
+	return a;
+}
+
+perl::array Perl_Zone_GetTimers(Zone* self)
+{
+	perl::array a;
+
+	const auto& l = self->GetTimers();
+
+	if (!l.empty()) {
+		a.reserve(l.size());
+
+		for (const auto& v : l) {
+			a.push_back(v);
+		}
+	}
+
+	return a;
+}
+
 void perl_register_zone()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -723,6 +757,7 @@ void perl_register_zone()
 	package.add("GetMinimumStatus", &Perl_Zone_GetMinimumStatus);
 	package.add("GetNote", &Perl_Zone_GetNote);
 	package.add("GetNPCMaximumAggroDistance", &Perl_Zone_GetNPCMaximumAggroDistance);
+	package.add("GetPausedTimers", &Perl_Zone_GetPausedTimers);
 	package.add("GetPEQZone", &Perl_Zone_GetPEQZone);
 	package.add("GetRainChance", (int(*)(Zone*))&Perl_Zone_GetRainChance);
 	package.add("GetRainChance", (int(*)(Zone*, uint8))&Perl_Zone_GetRainChance);
@@ -746,6 +781,7 @@ void perl_register_zone()
 	package.add("GetTimeZone", &Perl_Zone_GetTimeZone);
 	package.add("GetTimerDuration", &Perl_Zone_GetTimerDuration);
 	package.add("GetTimerRemainingTime", &Perl_Zone_GetTimerRemainingTime);
+	package.add("GetTimers", &Perl_Zone_GetTimers);
 	package.add("GetZoneDescription", &Perl_Zone_GetZoneDescription);
 	package.add("GetZoneID", &Perl_Zone_GetZoneID);
 	package.add("GetZoneType", &Perl_Zone_GetZoneType);

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -4673,10 +4673,8 @@ std::vector<std::string> QuestManager::GetPausedTimers(Mob* m)
 	std::vector<std::string> v;
 
 	if (m && !PTimerList.empty()) {
-		LogError("m valid | !PTimerList.empty()");
 		for (auto e = PTimerList.begin(); e != PTimerList.end(); e++) {
 			if (e->owner == m) {
-				LogError("e->owner == m | e->name [{}]", e->name);
 				v.emplace_back(e->name);
 			}
 		}
@@ -4690,10 +4688,8 @@ std::vector<std::string> QuestManager::GetTimers(Mob* m)
 	std::vector<std::string> v;
 
 	if (m && !QTimerList.empty()) {
-		LogError("m valid | !QTimerList.empty()");
 		for (auto e = QTimerList.begin(); e != QTimerList.end(); e++) {
 			if (e->mob == m) {
-				LogError("e->mob == m | e->name [{}]", e->name);
 				v.emplace_back(e->name);
 			}
 		}

--- a/zone/questmgr.cpp
+++ b/zone/questmgr.cpp
@@ -4667,3 +4667,37 @@ bool QuestManager::handin(std::map<std::string, uint32> required) {
 
 	return owner->CastToNPC()->CheckHandin(initiator, {}, required, {});
 }
+
+std::vector<std::string> QuestManager::GetPausedTimers(Mob* m)
+{
+	std::vector<std::string> v;
+
+	if (m && !PTimerList.empty()) {
+		LogError("m valid | !PTimerList.empty()");
+		for (auto e = PTimerList.begin(); e != PTimerList.end(); e++) {
+			if (e->owner == m) {
+				LogError("e->owner == m | e->name [{}]", e->name);
+				v.emplace_back(e->name);
+			}
+		}
+	}
+
+	return v;
+}
+
+std::vector<std::string> QuestManager::GetTimers(Mob* m)
+{
+	std::vector<std::string> v;
+
+	if (m && !QTimerList.empty()) {
+		LogError("m valid | !QTimerList.empty()");
+		for (auto e = QTimerList.begin(); e != QTimerList.end(); e++) {
+			if (e->mob == m) {
+				LogError("e->mob == m | e->name [{}]", e->name);
+				v.emplace_back(e->name);
+			}
+		}
+	}
+
+	return v;
+}

--- a/zone/questmgr.h
+++ b/zone/questmgr.h
@@ -364,6 +364,8 @@ public:
 	bool SetAutoLoginCharacterNameByAccountID(uint32 account_id, const std::string& character_name);
 	void SpawnCircle(uint32 npc_id, glm::vec4 position, float radius, uint32 points);
 	void SpawnGrid(uint32 npc_id, glm::vec4 position, float spacing, uint32 spawn_count);
+	std::vector<std::string> GetPausedTimers(Mob* m);
+	std::vector<std::string> GetTimers(Mob* m);
 
 	Bot *GetBot() const;
 	Client *GetInitiator() const;

--- a/zone/zone.cpp
+++ b/zone/zone.cpp
@@ -3559,4 +3559,30 @@ void Zone::SendPayload(int payload_id, std::string payload_value)
 	}
 }
 
+std::vector<std::string> Zone::GetPausedTimers()
+{
+	std::vector<std::string> v;
+
+	if (!paused_zone_timers.empty()) {
+		for (auto e = paused_zone_timers.begin(); e != paused_zone_timers.end(); e++) {
+			v.emplace_back(e->name);
+		}
+	}
+
+	return v;
+}
+
+std::vector<std::string> Zone::GetTimers()
+{
+	std::vector<std::string> v;
+
+	if (!zone_timers.empty()) {
+		for (auto e = zone_timers.begin(); e != zone_timers.end(); e++) {
+			v.emplace_back(e->name);
+		}
+	}
+
+	return v;
+}
+
 #include "zone_loot.cpp"

--- a/zone/zone.h
+++ b/zone/zone.h
@@ -503,6 +503,8 @@ public:
 	void SetTimer(std::string name, uint32 duration);
 	void StopTimer(std::string name);
 	void StopAllTimers();
+	std::vector<std::string> GetPausedTimers();
+	std::vector<std::string> GetTimers();
 
 private:
 	bool      allow_mercs;


### PR DESCRIPTION
# Description
- Adds `GetTimers()` and `GetPausedTimers()` methods to Perl and Lua.
- Returns a list of timer names.
- These methods allow you to get the active and paused timers on a mob or zone, allowing you to determine the remaining time or total duration, stop the timer, pause the timer, or more.
- Can be used in controllers to check if a mob has a current timer set for encounters or other interactions.

## Type of change
- [X] New feature

## Perl
### Example
```pl
sub EVENT_SAY {
	if ($text=~/#a/i) {
		my @timers = $client->GetTimers();
		my @zone_timers = $zone->GetTimers();

		my $timer_string = join(", ", @timers);
		quest::message(315, $timer_string);

		my $zone_timer_string = join(", ", @zone_timers);
		quest::message(315, $zone_timer_string);
	} elsif ($text=~/#b/i) {
		for (my $i = 0; $i < 10; $i++) {
			my $duration = (($i + 1) * 1);
			quest::message(315, "Setting timer $i to duration $duration.");
			$client->SetTimer($i, $duration);
			$zone->SetTimer($i, $duration);
		}
	}
}
```
### Image
<img width="166" height="184" alt="image" src="https://github.com/user-attachments/assets/e3056611-751b-4ff0-94be-92876cf120be" />

## Lua
### Example
```lua
function event_say(e)
	if e.message:findi("#a") then
		local timers = e.self:GetTimers()
		local zone_timers = eq.get_zone():GetTimers()

		local timer_string = table.concat(timers, ", ")
		eq.message(315, timer_string)

		local zone_timer_string = table.concat(zone_timers, ", ")
		eq.message(315, zone_timer_string)
	elseif e.message:findi("#b") then
		for i = 0, 9 do
			local duration = (i + 1) * 1
			e.self:SetTimer(tostring(i), duration)
			eq.get_zone():SetTimer(tostring(i), duration)
			eq.message(315, "Setting timer " .. tostring(i) .. " to duration " .. tostring(duration) .. ".");
		end
	end
end
```
### Image
<img width="165" height="191" alt="image" src="https://github.com/user-attachments/assets/ee5a0476-88c8-4218-b1ef-fe8c6806445d" />

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur