### PR TITLE
[Bug Fix] Fix Hero's Forge Ingame and Character Select

### DIFF
--- a/world/worlddb.cpp
+++ b/world/worlddb.cpp
@@ -901,9 +901,13 @@ bool WorldDatabase::GetCharSelInventory(
 			inst->SetCustomDataString(e.custom_data);
 		}
 
-		inst->SetOrnamentIcon(e.ornament_icon);
-		inst->SetOrnamentationIDFile(e.ornament_idfile);
-		inst->SetOrnamentHeroModel(e.ornament_hero_model);
+		if (e.ornament_icon != 0 || e.ornament_idfile != 0 || e.ornament_hero_model != 0) {
+			inst->SetOrnamentIcon(e.ornament_icon);
+			inst->SetOrnamentationIDFile(e.ornament_idfile);
+			inst->SetOrnamentHeroModel(e.ornament_hero_model);
+		} else {
+			inst->SetOrnamentHeroModel(item->HerosForgeModel);
+		}
 
 		inv->PutItem(e.slot_id, *inst);
 

--- a/world/worlddb.cpp
+++ b/world/worlddb.cpp
@@ -905,7 +905,7 @@ bool WorldDatabase::GetCharSelInventory(
 			inst->SetOrnamentIcon(e.ornament_icon);
 			inst->SetOrnamentationIDFile(e.ornament_idfile);
 			inst->SetOrnamentHeroModel(e.ornament_hero_model);
-		} else {
+		} else if (item->HerosForgeModel > 0) {
 			inst->SetOrnamentHeroModel(item->HerosForgeModel);
 		}
 

--- a/zone/mob_appearance.cpp
+++ b/zone/mob_appearance.cpp
@@ -286,8 +286,8 @@ uint32 Mob::GetHerosForgeModel(uint8 material_slot) const
 					if (augment) {
 						item              = augment->GetItem();
 						heros_forge_model = item->HerosForgeModel;
-					} else if (inst->GetOrnamentHeroModel()) {
-						heros_forge_model = inst->GetOrnamentHeroModel();
+					} else if (inst->GetOrnamentHeroModel(material_slot)) {
+						heros_forge_model = inst->GetOrnamentHeroModel(material_slot);
 					}
 				}
 			}
@@ -421,7 +421,7 @@ void Mob::SendWearChange(uint8 material_slot, Client *one_client)
 		return key;
 	};
 
-	
+
 	auto dedupe_key = build_key(*w);
 	auto send_if_changed = [&](Client* client) {
 		auto& last_key = m_last_seen_wearchange[client->GetID()][material_slot];


### PR DESCRIPTION
# Description
- Fixes an issue where Hero's Forge doesn't work on the item if the item itself has the Hero's Forge model and is not using an augment to get the texture.
- Fixes an issue where Hero's Forge doesn't show on character select if the item itself has the Hero's Forge model and is not using an augment to get the texture.

## Type of change
- [X] Bug fix

# Testing
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a68698a4-cce1-4191-a1d9-d790e36efc8f" />
<img width="231" height="357" alt="image" src="https://github.com/user-attachments/assets/02492772-09a0-41bc-9284-7ca44ed70474" />

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
