### PR TITLE
[Fix] Fix crash from lingering spawn2 reference in NPCs.

### DIFF
--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -2611,8 +2611,11 @@ bool NPC::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillTy
 
 	safe_delete(app);
 
-	if (respawn2) {
-		respawn2->DeathReset(1);
+	if (respawn2_id) {
+		auto respawn2 = GetSpawn();
+		if (respawn2) {
+			respawn2->DeathReset(1);
+		}
 	}
 
 	if (killer_mob && GetClass() != Class::LDoNTreasure) {

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -520,7 +520,7 @@ void EntityList::MobProcess()
 
 			old_client_count = numclients;
 
-			Spawn2* s2 = mob->CastToNPC()->respawn2;
+			Spawn2* s2 = mob->CastToNPC()->GetSpawn();
 
 			// Perform normal mob processing if any of these are true:
 			//	-- zone is not empty

--- a/zone/gm_commands/advnpcspawn.cpp
+++ b/zone/gm_commands/advnpcspawn.cpp
@@ -188,7 +188,7 @@ void command_advnpcspawn(Client *c, const Seperator *sep)
 		}
 
 		auto target = c->GetTarget()->CastToNPC();
-		auto spawn2 = target->respawn2;
+		auto spawn2 = target->GetSpawn();
 		if (!spawn2) {
 			c->Message(Chat::White, "Failed to delete spawn because NPC has no Spawn2.");
 			return;
@@ -297,7 +297,7 @@ void command_advnpcspawn(Client *c, const Seperator *sep)
 		}
 
 		auto target = c->GetTarget()->CastToNPC();
-		auto spawn2 = target->respawn2;
+		auto spawn2 = target->GetSpawn();
 		if (!spawn2) {
 			c->Message(Chat::White, "Failed to edit respawn because NPC has no Spawn2.");
 			return;
@@ -434,7 +434,7 @@ void command_advnpcspawn(Client *c, const Seperator *sep)
 		}
 
 		auto target = c->GetTarget()->CastToNPC();
-		auto spawn2 = target->respawn2;
+		auto spawn2 = target->GetSpawn();
 		if (!spawn2) {
 			c->Message(Chat::White, "Failed to move spawn because NPC has no Spawn2.");
 			return;

--- a/zone/gm_commands/spawnfix.cpp
+++ b/zone/gm_commands/spawnfix.cpp
@@ -8,7 +8,7 @@ void command_spawnfix(Client* c, const Seperator* sep)
 	}
 
 	auto target = c->GetTarget()->CastToNPC();
-	auto spawn2 = target->respawn2;
+	auto spawn2 = target->GetSpawn();
 
 	if (!spawn2) {
 		c->Message(Chat::White, "Failed to fix spawn, the spawn must not exist in the database.");

--- a/zone/gm_commands/wpadd.cpp
+++ b/zone/gm_commands/wpadd.cpp
@@ -5,7 +5,7 @@ void command_wpadd(Client *c, const Seperator *sep)
 	int type1   = 0, type2 = 0, pause = 0; // Defaults for a new grid
 	Mob *target = c->GetTarget();
 	if (target && target->IsNPC()) {
-		Spawn2 *s2info = target->CastToNPC()->respawn2;
+		Spawn2 *s2info = target->CastToNPC()->GetSpawn();
 		if (s2info == nullptr) {
 			c->Message(
 				Chat::White,

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -248,7 +248,7 @@ public:
 
 	uint16 GetWaypointMax() const { return wp_m; }
 	int32 GetGrid() const { return grid; }
-	Spawn2* GetSpawn() { return respawn2 ? respawn2 : nullptr; }
+	Spawn2* GetSpawn() { return respawn2_id ? entity_list.GetSpawnByID(respawn2_id) : nullptr; }
 	uint32 GetSpawnGroupId() const { return spawn_group_id; }
 	uint32 GetSpawnPointID() const;
 
@@ -417,7 +417,7 @@ public:
 	bool  IsProximitySet();
 
 	NPCProximity* proximity;
-	Spawn2*	respawn2;
+	uint32 respawn2_id;
 	QGlobalCache *GetQGlobals() { return qGlobals; }
 	QGlobalCache *CreateQGlobals() { qGlobals = new QGlobalCache(); return qGlobals; }
 


### PR DESCRIPTION
# Description

In the case of a Zone::Repop() the spawn2 linked list would be cleared, destroying the spawn2 object. However a charmed NPC would survive the repop and continue to hold onto their reference to the spawn2 object, resulting in a variety of crashes.

I waffled around different ways to solve this and ultimately decided to remove the reference and replace it with a real-time lookup of the current spawn2 object in spawn2_list.  I do have reservations about the performance cost of this, especially in the case of line 523 in entity.cpp.  Might be a point for additional discussion.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Testing

Original Reproduction Steps:

1. Charm enemy (#cast 2932)
2. #repop
3. Kill charmed enemy or click off charm
4. #repop

Second repop usually crashes/locks up zone.

Test Cases:

1. Verify repro steps stop working (multiple attempts) - Pass
2. Verify npc respawn timers are correctly set still on death - Pass
3. Verify gm commands still function - Pass

# Checklist

- [x] I have tested my changes
- [x] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [x] I own the changes of my code and take responsibility for the potential issues that occur
