### PR TITLE
[Build] Fix Linking with GCC

### DIFF
--- a/zone/CMakeLists.txt
+++ b/zone/CMakeLists.txt
@@ -502,7 +502,7 @@ if (EQEMU_BUILD_STATIC AND PERL_LIBRARY)
 endif()
 
 # link zone against common libraries
-target_link_libraries(zone PRIVATE ${ZONE_LIBS} lua_zone perl_zone gm_commands_zone)
+target_link_libraries(zone PRIVATE lua_zone perl_zone gm_commands_zone ${ZONE_LIBS})
 
 SET(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
 


### PR DESCRIPTION
# Description

When building with gcc instead of clang, the order of items passed for final linking matters and it was failing with undefined symbols since the unity build for lua was added.  I rearranged the items in the cmake file and tested rebuilding with both clang and gcc.

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

I tested on debian with the following versions:
Debian clang version 14.0.6
gcc version 12.2.0 (Debian 12.2.0-14+deb12u1)

Clients tested: N/A

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
