### PR TITLE
make loginserver work with legacy world when using local db

### DIFF
--- a/loginserver/world_server.cpp
+++ b/loginserver/world_server.cpp
@@ -155,7 +155,11 @@ void WorldServer::ProcessUserToWorldResponseLegacy(uint16_t opcode, const EQ::Ne
 	auto *res = (UsertoWorldResponseLegacy *) packet.Data();
 
 	LogDebug("Trying to find client with user id of [{}]", res->lsaccountid);
-	Client *c = server.client_manager->GetClient(res->lsaccountid, "eqemu");
+	std::string db_loginserver = "local";
+	if (std::getenv("LSPX")) {
+		db_loginserver = "eqemu";
+	}
+	Client *c = server.client_manager->GetClient(res->lsaccountid, db_loginserver);
 	if (c) {
 		LogDebug(
 			"Found client with user id of [{}] and account name of [{}]",


### PR DESCRIPTION
# Description

loginserver has support for legacy worlds and this seems to work well for eqemulator.net's public login but didn't work for me locally.  I think this was just an oversight in the rarely used legacy server function and this fixes it for the case when the LSPX environment variable is not being used.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

I tested it using a legacy world server connecting to the login server and was able to get to character select normally after this change.

Clients tested: Titanium

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
