### PR TITLE
[Bug Fix] Show player count on the server list status.

### DIFF
--- a/loginserver/options.h
+++ b/loginserver/options.h
@@ -31,7 +31,7 @@ public:
 	inline void DefaultLoginServerName(const std::string &v) { m_default_loginserver_name = v; }
 	inline std::string GetDefaultLoginServerName() const { return m_default_loginserver_name; }
 	inline bool IsShowPlayerCountEnabled() const { return m_show_player_count; }
-	inline void SetShowPlayerCount(bool show_player_count) { show_player_count = show_player_count; }
+	inline void SetShowPlayerCount(bool show_player_count) { m_show_player_count = show_player_count; }
 	inline bool IsWorldDevTestServersListBottom() const { return m_world_dev_list_bottom; }
 	inline void SetWorldDevTestServersListBottom(bool list_bottom) { m_world_dev_list_bottom = list_bottom; }
 	inline bool IsWorldSpecialCharacterStartListBottom() const { return m_special_char_list_bottom; }


### PR DESCRIPTION
# Description

Setting the Show player count to true in the login.json does nothing.  This commit fixes the player count.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ X ] Bug fix (non-breaking change which fixes an issue)

# Testing

Setting the login.json -Show player count
![RoFloginsetting](https://github.com/user-attachments/assets/4c16ad7b-3bbc-4a5b-9f65-8c62a0cc633c)

Before the fix:
![RoFPrePoPlist](https://github.com/user-attachments/assets/1bf8782f-17b0-415d-b7a1-8f377ba04649)

After the fix:
![RoFPostPopList](https://github.com/user-attachments/assets/1009f543-7177-45f7-9361-84008ad91564)


Clients tested: 
RoF2

# Checklist

- [ X ] I have tested my changes
- [ X ] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [ X ] I own the changes of my code and take responsibility for the potential issues that occur
- [ X ] If my changes make database schema changes, I have tested the changes on a local database (attach image). Updated version.h CURRENT_BINARY_DATABASE_VERSION to the new version. (Delete this if not applicable)
