### PR TITLE
[Commands] Add #show keyring Subcommand

### DIFF
--- a/common/repositories/command_subsettings_repository.h
+++ b/common/repositories/command_subsettings_repository.h
@@ -142,6 +142,7 @@ public:
 			{.parent_command = "show", .sub_command = "hatelist", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "hatelist"},
 			{.parent_command = "show", .sub_command = "inventory", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "peekinv"},
 			{.parent_command = "show", .sub_command = "ip_lookup", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "iplookup"},
+			{.parent_command = "show", .sub_command = "keyring", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "showkeyring"},
 			{.parent_command = "show", .sub_command = "line_of_sight", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "checklos"},
 			{.parent_command = "show", .sub_command = "network", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "network"},
 			{.parent_command = "show", .sub_command = "network_stats", .access_level = AccountStatus::QuestTroupe, .top_level_aliases = "netstats"},

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -4780,9 +4780,21 @@ bool Client::KeyRingClear()
 	);
 }
 
-void Client::KeyRingList()
+void Client::KeyRingList(Client* c)
 {
-	Message(Chat::LightBlue, "Keys on Keyring:");
+	if (!c) {
+		return;
+	}
+
+	std::string message = "Keys on Keyring:";
+	if (c != this) {
+		message = fmt::format(
+			"Keys on Keyring for {}:",
+			GetCleanName()
+		);
+	}
+
+	c->Message(Chat::LightBlue, message.c_str());
 
 	const EQ::ItemData *item = nullptr;
 
@@ -4795,7 +4807,7 @@ void Client::KeyRingList()
 				item->Name
 			);
 
-			Message(Chat::LightBlue, item_string.c_str());
+			c->Message(Chat::LightBlue, item_string.c_str());
 		}
 	}
 }

--- a/zone/client.h
+++ b/zone/client.h
@@ -331,7 +331,7 @@ public:
 	bool KeyRingCheck(uint32 item_id);
 	bool KeyRingClear();
 	bool KeyRingRemove(uint32 item_id);
-	void KeyRingList();
+	void KeyRingList(Client* c = nullptr);
 	bool IsNameChangeAllowed();
 	void InvokeChangeNameWindow(bool immediate = true);
 	bool ClearNameChange();

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -9789,7 +9789,7 @@ void Client::Handle_OP_Jump(const EQApplicationPacket *app)
 
 void Client::Handle_OP_KeyRing(const EQApplicationPacket *app)
 {
-	KeyRingList();
+	KeyRingList(this);
 }
 
 void Client::Handle_OP_KickPlayers(const EQApplicationPacket *app)

--- a/zone/gm_commands/show.cpp
+++ b/zone/gm_commands/show.cpp
@@ -15,6 +15,7 @@
 #include "show/group_info.cpp"
 #include "show/hatelist.cpp"
 #include "show/inventory.cpp"
+#include "show/keyring.cpp"
 #include "show/ip_lookup.cpp"
 #include "show/line_of_sight.cpp"
 #include "show/network.cpp"
@@ -78,6 +79,7 @@ void command_show(Client *c, const Seperator *sep)
 		Cmd{.cmd = "hatelist", .u = "hatelist", .fn = ShowHateList, .a = {"#hatelist"}},
 		Cmd{.cmd = "inventory", .u = "inventory", .fn = ShowInventory, .a = {"#peekinv"}},
 		Cmd{.cmd = "ip_lookup", .u = "ip_lookup", .fn = ShowIPLookup, .a = {"#iplookup"}},
+		Cmd{.cmd = "keyring", .u = "keyring", .fn = ShowKeyring, .a = {"#showkeyring"}},
 		Cmd{.cmd = "line_of_sight", .u = "line_of_sight", .fn = ShowLineOfSight, .a = {"#checklos"}},
 		Cmd{.cmd = "network", .u = "network", .fn = ShowNetwork, .a = {"#network"}},
 		Cmd{.cmd = "network_stats", .u = "network_stats", .fn = ShowNetworkStats, .a = {"#netstats"}},

--- a/zone/gm_commands/show/keyring.cpp
+++ b/zone/gm_commands/show/keyring.cpp
@@ -1,0 +1,12 @@
+#include "../../client.h"
+#include "../../dialogue_window.h"
+
+void ShowKeyring(Client *c, const Seperator *sep)
+{
+	Client* t = c;
+	if (c->GetTarget() && c->GetTarget()->IsClient()) {
+		t = c->GetTarget()->CastToClient();
+	}
+
+	t->KeyRingList(c);
+}

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3575,7 +3575,13 @@ bool Lua_Client::KeyRingClear()
 void Lua_Client::KeyRingList()
 {
 	Lua_Safe_Call_Void();
-	self->KeyRingList();
+	self->KeyRingList(self);
+}
+
+void Lua_Client::KeyRingList(Lua_Client c)
+{
+	Lua_Safe_Call_Void();
+	self->KeyRingList(self);
 }
 
 bool Lua_Client::KeyRingRemove(uint32 item_id)
@@ -3932,6 +3938,7 @@ luabind::scope lua_register_client() {
 	.def("KeyRingCheck", (bool(Lua_Client::*)(uint32))&Lua_Client::KeyRingCheck)
 	.def("KeyRingClear", (bool(Lua_Client::*)(void))&Lua_Client::KeyRingClear)
 	.def("KeyRingList", (void(Lua_Client::*)(void))&Lua_Client::KeyRingList)
+	.def("KeyRingList", (void(Lua_Client::*)(Lua_Client))&Lua_Client::KeyRingList)
 	.def("KeyRingRemove", (bool(Lua_Client::*)(uint32))&Lua_Client::KeyRingRemove)
 	.def("Kick", (void(Lua_Client::*)(void))&Lua_Client::Kick)
 	.def("LearnDisciplines", (uint16(Lua_Client::*)(uint8,uint8))&Lua_Client::LearnDisciplines)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -521,6 +521,7 @@ public:
 	bool KeyRingCheck(uint32 item_id);
 	bool KeyRingClear();
 	void KeyRingList();
+	void KeyRingList(Lua_Client c);
 	bool KeyRingRemove(uint32 item_id);
 	bool CompleteTask(int task_id);
 	bool UncompleteTask(int task_id);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -3328,7 +3328,12 @@ bool Perl_Client_KeyRingClear(Client* self)
 
 void Perl_Client_KeyRingList(Client* self)
 {
-	self->KeyRingList();
+	self->KeyRingList(self);
+}
+
+void Perl_Client_KeyRingList(Client* self, Client* c)
+{
+	self->KeyRingList(c);
 }
 
 bool Perl_Client_KeyRingRemove(Client* self, uint32 item_id)
@@ -3675,7 +3680,8 @@ void perl_register_client()
 	package.add("KeyRingAdd", &Perl_Client_KeyRingAdd);
 	package.add("KeyRingCheck", &Perl_Client_KeyRingCheck);
 	package.add("KeyRingClear", &Perl_Client_KeyRingClear);
-	package.add("KeyRingList", &Perl_Client_KeyRingList);
+	package.add("KeyRingList", (void(*)(Client*))&Perl_Client_KeyRingList);
+	package.add("KeyRingList", (void(*)(Client*, Client*))&Perl_Client_KeyRingList);
 	package.add("KeyRingRemove", &Perl_Client_KeyRingRemove);
 	package.add("Kick", &Perl_Client_Kick);
 	package.add("LearnDisciplines", &Perl_Client_LearnDisciplines);


### PR DESCRIPTION
# Description
- Adds a `#show keyring` subcommand to show your target's keyring.

## Perl
- Add `$client->KeyRingList(client)`.

## Lua
- Add `client:KeyRingList(client)`.

## Type of change
- [X] New feature

# Testing
<img width="609" height="59" alt="image" src="https://github.com/user-attachments/assets/4e303170-9db7-4237-bb43-f5f9ae706359" />

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur