### PR TITLE
[Hotfix] Fix Quest Ownership Edge Case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [23.9.1] 8/2/2025
+
+### Hotfix
+
+* Fix Quest Ownership Edge Case ([#4977](https://github.com/EQEmu/Server/pull/4977)) @Kinglykrab 2025-08-02
+
 ## [23.9.0] 8/2/2025
 
 ### Bots

--- a/common/version.h
+++ b/common/version.h
@@ -25,7 +25,7 @@
 
 // Build variables
 // these get injected during the build pipeline
-#define CURRENT_VERSION "23.9.0-dev" // always append -dev to the current version for custom-builds
+#define CURRENT_VERSION "23.9.1-dev" // always append -dev to the current version for custom-builds
 #define LOGIN_VERSION "0.8.0"
 #define COMPILE_DATE    __DATE__
 #define COMPILE_TIME    __TIME__

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eqemu-server",
-  "version": "23.9.0",
+  "version": "23.9.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/EQEmu/Server.git"

--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -998,11 +998,13 @@ int PerlembParser::SendCommands(
 
 	int ret_value = 0;
 	RunningQuest q;
+
+	q.owner      = other;
+	q.questitem  = inst;
+	q.questspell = spell;
+
 	if (mob && mob->IsClient()) {
-		q.owner      = other;
 		q.initiator  = mob->CastToClient();
-		q.questitem  = inst;
-		q.questspell = spell;
 	}
 
 	if (zone) {


### PR DESCRIPTION
# Description
- Fixes an issue where ownership was not applied properly.

## Type of change
- [X] Bug fix

# Testing
## Before
```
[QuestErrors] Zone [sebilis] Script Error | Package [qst_npc_640] Event [EVENT_SPAWN] Error [Perl runtime error: Can't call method "GetOwnerID" on an undefined value at ./quests/global/640.pl line 2.]
[QuestErrors] Zone [shadeweaver] Script Error | Package [qst_global_npc] Event [EVENT_COMBAT] Error [Perl runtime error: Can't call method "GetID" on an undefined value at ./quests/global/global_npc.pl line 177.]
```
## After
<img width="139" height="77" alt="image" src="https://github.com/user-attachments/assets/db037bfe-f7b5-456c-af0d-d5241b9fc65d" />

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur