### PR TITLE
[Bug Fix] Fix #show recipe uint16 Cap

### DIFF
--- a/zone/gm_commands/show/recipe.cpp
+++ b/zone/gm_commands/show/recipe.cpp
@@ -10,7 +10,7 @@ void ShowRecipe(Client *c, const Seperator *sep)
 		return;
 	}
 
-	const uint16 recipe_id = static_cast<uint16>(Strings::ToUnsignedInt(sep->arg[2]));
+	const uint32 recipe_id = Strings::ToUnsignedInt(sep->arg[2]);
 
 	const auto& re = TradeskillRecipeEntriesRepository::GetWhere(
 		content_db,


### PR DESCRIPTION
# Description
- Fixes an issue where `#show recipe` would not allow any recipe IDs over `65535` due to it being a `uint16`.

## Type of change
- [X] Bug fix

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur