### PR TITLE
[Bug Fix] fixed Race 474 for Titanium.

### DIFF
--- a/common/patches/titanium.cpp
+++ b/common/patches/titanium.cpp
@@ -1059,7 +1059,7 @@ namespace Titanium
 		OUT(spawnid);
 		OUT_str(charname);
 
-		if (emu->race > 473)
+		if (emu->race > 474)
 			eq->race = 1;
 		else
 			OUT(race);
@@ -1840,7 +1840,7 @@ namespace Titanium
 			emu_cse = (CharacterSelectEntry_Struct *)emu_ptr;
 
 			eq->Race[char_index] = emu_cse->Race;
-			if (eq->Race[char_index] > 473)
+			if (eq->Race[char_index] > 474)
 				eq->Race[char_index] = 1;
 
 			for (int index = 0; index < EQ::textures::materialCount; ++index) {
@@ -2421,7 +2421,7 @@ namespace Titanium
 			strcpy(eq->title, emu->title);
 			//		eq->unknown0274 = emu->unknown0274;
 			eq->helm = emu->helm;
-			if (emu->race > 473)
+			if (emu->race > 474)
 				eq->race = 1;
 			else
 				eq->race = emu->race;


### PR DESCRIPTION
# Description

Titanium Max Race id goes up to 474 as shown in RaceData.txt in the client folder.   Currently it is only encoded to max at 473.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Testing

Before fix:  
![race474pre](https://github.com/user-attachments/assets/afca0687-f5fc-407e-b3b2-01ab4817df22)

After:
![race474post](https://github.com/user-attachments/assets/bb827adc-6175-4d88-8b70-e2eff2ab5a1d)


Clients tested:  Titanium

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
