### PR TITLE
[Quest API] Add GetKeyRing() to Perl/Lua

### DIFF
--- a/zone/client.h
+++ b/zone/client.h
@@ -326,6 +326,7 @@ public:
 	void TraderStartTrader(const EQApplicationPacket *app);
 //	void TraderPriceUpdate(const EQApplicationPacket *app);
 	uint8 WithCustomer(uint16 NewCustomer);
+	std::vector<uint32> GetKeyRing() { return keyring; }
 	void KeyRingLoad();
 	bool KeyRingAdd(uint32 item_id);
 	bool KeyRingCheck(uint32 item_id);

--- a/zone/lua_client.cpp
+++ b/zone/lua_client.cpp
@@ -3608,6 +3608,22 @@ void Lua_Client::EnableTitleSet(uint32 title_set) {
 	self->EnableTitle(title_set);
 }
 
+luabind::object Lua_Client::GetKeyRing(lua_State* L)
+{
+	auto lua_table = luabind::newtable(L);
+
+	if (d_) {
+		auto self  = reinterpret_cast<NativeType *>(d_);
+		int  index = 1;
+		for (const uint32& item_id: self->GetKeyRing()) {
+			lua_table[index] = item_id;
+			index++;
+		}
+	}
+
+	return lua_table;
+}
+
 luabind::scope lua_register_client() {
 	return luabind::class_<Lua_Client, Lua_Mob>("Client")
 	.def(luabind::constructor<>())
@@ -3838,6 +3854,7 @@ luabind::scope lua_register_client() {
 	.def("GetInvulnerableEnvironmentDamage", (bool(Lua_Client::*)(void))&Lua_Client::GetInvulnerableEnvironmentDamage)
 	.def("GetItemIDAt", (int(Lua_Client::*)(int))&Lua_Client::GetItemIDAt)
 	.def("GetItemCooldown", (uint32(Lua_Client::*)(uint32))&Lua_Client::GetItemCooldown)
+	.def("GetKeyRing", (luabind::object(Lua_Client::*)(lua_State* L))&Lua_Client::GetKeyRing)
 	.def("GetLDoNLosses", (int(Lua_Client::*)(void))&Lua_Client::GetLDoNLosses)
 	.def("GetLDoNLossesTheme", (int(Lua_Client::*)(int))&Lua_Client::GetLDoNLossesTheme)
 	.def("GetLDoNPointsTheme", (int(Lua_Client::*)(int))&Lua_Client::GetLDoNPointsTheme)

--- a/zone/lua_client.h
+++ b/zone/lua_client.h
@@ -525,6 +525,7 @@ public:
 	bool KeyRingRemove(uint32 item_id);
 	bool CompleteTask(int task_id);
 	bool UncompleteTask(int task_id);
+	luabind::object GetKeyRing(lua_State* L);
 
 	// account data buckets
 	void SetAccountBucket(std::string bucket_name, std::string bucket_value);

--- a/zone/perl_client.cpp
+++ b/zone/perl_client.cpp
@@ -3351,6 +3351,18 @@ bool Perl_Client_UncompleteTask(Client* self, int task_id)
 	return self->UncompleteTask(task_id);
 }
 
+perl::array Perl_Client_GetKeyRing(Client* self)
+{
+	perl::array result;
+	const auto& v = self->GetKeyRing();
+
+	for (int i = 0; i < v.size(); ++i) {
+		result.push_back(v[i]);
+	}
+
+	return result;
+}
+
 void perl_register_client()
 {
 	perl::interpreter perl(PERL_GET_THX);
@@ -3582,6 +3594,7 @@ void perl_register_client()
 	package.add("GetItemCooldown", &Perl_Client_GetItemCooldown);
 	package.add("GetItemIDAt", &Perl_Client_GetItemIDAt);
 	package.add("GetItemInInventory", &Perl_Client_GetItemInInventory);
+	package.add("GetKeyRing", &Perl_Client_GetKeyRing);
 	package.add("GetLDoNLosses", &Perl_Client_GetLDoNLosses);
 	package.add("GetLDoNLossesTheme", &Perl_Client_GetLDoNLossesTheme);
 	package.add("GetLDoNPointsTheme", &Perl_Client_GetLDoNPointsTheme);


### PR DESCRIPTION
# Description
- Adds a method to get a list of items on a client's keyring.

## Perl
- Add `$client->GetKeyRing()`

### Example
```pl
sub EVENT_SAY {
	if ($text=~/#a/i) {
		my @key_ring = $client->GetKeyRing();

		foreach my $item_id (@key_ring) {
			my $item_link = quest::varlink($item_id);
			quest::message(315, "[Perl] $item_link ($item_id)");
		}
	}
}
```

### Image
<img width="189" height="105" alt="image" src="https://github.com/user-attachments/assets/e731b4c2-ab6a-4e27-a441-7e66860ee7b5" />

## Lua
- Add `client:GetKeyRing()`

### Example
```lua
function event_say(e)
	if e.message:findi("#a") then
		local key_ring = e.self:GetKeyRing()

		for k, v in ipairs(key_ring) do
			local item_link = eq.item_link(v)
			eq.message(315, "[Lua] " .. item_link .. " (" .. tostring(v) .. ")")
		end
	end
end
```

### Image
<img width="189" height="105" alt="image" src="https://github.com/user-attachments/assets/5221ede6-0f54-4a70-8360-d7c6290ecd5f" />

## Type of change
- [x] New feature

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur