### PR TITLE
[Cleanup] Add #npcedit npc_tint_id Help Message

### DIFF
--- a/zone/gm_commands/npcedit.cpp
+++ b/zone/gm_commands/npcedit.cpp
@@ -110,6 +110,7 @@ void SendNPCEditSubCommands(Client *c)
 	c->Message(Chat::White, "Usage: #npcedit setanimation [Animation ID] - Sets an NPC's Animation on Spawn (Stored in spawn2 table)");
 	c->Message(Chat::White, "Usage: #npcedit respawntime [Respawn Time] - Sets an NPC's Respawn Timer in Seconds (Stored in spawn2 table)");
 	c->Message(Chat::White, "Usage: #npcedit set_grid [Grid ID] - Sets an NPC's Grid ID");
+	c->Message(Chat::White, "Usage: #npcedit npc_tint_id [id] - Sets an NPC's Tint ID (0 to 78 for RoF2)")
 }
 
 void command_npcedit(Client *c, const Seperator *sep)

--- a/zone/gm_commands/npcedit.cpp
+++ b/zone/gm_commands/npcedit.cpp
@@ -110,7 +110,7 @@ void SendNPCEditSubCommands(Client *c)
 	c->Message(Chat::White, "Usage: #npcedit setanimation [Animation ID] - Sets an NPC's Animation on Spawn (Stored in spawn2 table)");
 	c->Message(Chat::White, "Usage: #npcedit respawntime [Respawn Time] - Sets an NPC's Respawn Timer in Seconds (Stored in spawn2 table)");
 	c->Message(Chat::White, "Usage: #npcedit set_grid [Grid ID] - Sets an NPC's Grid ID");
-	c->Message(Chat::White, "Usage: #npcedit npc_tint_id [NPC Tint ID] - Sets an NPC's Tint ID (0 to 78 for RoF2)")
+	c->Message(Chat::White, "Usage: #npcedit npc_tint_id [NPC Tint ID] - Sets an NPC's Tint ID (0 to 78 for RoF2)");
 }
 
 void command_npcedit(Client *c, const Seperator *sep)

--- a/zone/gm_commands/npcedit.cpp
+++ b/zone/gm_commands/npcedit.cpp
@@ -110,7 +110,7 @@ void SendNPCEditSubCommands(Client *c)
 	c->Message(Chat::White, "Usage: #npcedit setanimation [Animation ID] - Sets an NPC's Animation on Spawn (Stored in spawn2 table)");
 	c->Message(Chat::White, "Usage: #npcedit respawntime [Respawn Time] - Sets an NPC's Respawn Timer in Seconds (Stored in spawn2 table)");
 	c->Message(Chat::White, "Usage: #npcedit set_grid [Grid ID] - Sets an NPC's Grid ID");
-	c->Message(Chat::White, "Usage: #npcedit npc_tint_id [id] - Sets an NPC's Tint ID (0 to 78 for RoF2)")
+	c->Message(Chat::White, "Usage: #npcedit npc_tint_id [NPC Tint ID] - Sets an NPC's Tint ID (0 to 78 for RoF2)")
 }
 
 void command_npcedit(Client *c, const Seperator *sep)


### PR DESCRIPTION
# Description
- This message was missing from `#npcedit help` subcommands list.