### PR TITLE
[Quest API] Add GetNPCTintIndex() to Perl/Lua

### DIFF
--- a/zone/lua_npc.cpp
+++ b/zone/lua_npc.cpp
@@ -945,10 +945,16 @@ bool Lua_NPC::IsResumedFromZoneSuspend()
 	return self->IsResumedFromZoneSuspend();
 }
 
-void Lua_NPC::SetNPCTintIndex(uint32 id)
+void Lua_NPC::SetNPCTintIndex(uint32 index)
 {
 	Lua_Safe_Call_Void();
-	self->SendAppearancePacket(AppearanceType::NPCTintIndex, id);
+	self->SetNPCTintIndex(index);
+}
+
+uint32 Lua_NPC::GetNPCTintIndex()
+{
+	Lua_Safe_Call_Int();
+	return self->GetNPCTintIndex();
 }
 
 luabind::scope lua_register_npc() {
@@ -1018,6 +1024,7 @@ luabind::scope lua_register_npc() {
 	.def("GetNPCSpellsEffectsID", (uint32(Lua_NPC::*)(void))&Lua_NPC::GetNPCSpellsEffectsID)
 	.def("GetNPCSpellsID", (uint32(Lua_NPC::*)(void))&Lua_NPC::GetNPCSpellsID)
 	.def("GetNPCStat", (float(Lua_NPC::*)(std::string))&Lua_NPC::GetNPCStat)
+	.def("GetNPCTintIndex", (uint32(Lua_NPC::*)(void))&Lua_NPC::GetNPCTintIndex)
 	.def("GetPetSpellID", (int(Lua_NPC::*)(void))&Lua_NPC::GetPetSpellID)
 	.def("GetPlatinum", (uint32(Lua_NPC::*)(void))&Lua_NPC::GetPlatinum)
 	.def("GetPrimSkill", (int(Lua_NPC::*)(void))&Lua_NPC::GetPrimSkill)

--- a/zone/lua_npc.h
+++ b/zone/lua_npc.h
@@ -200,6 +200,7 @@ public:
 	Lua_Spawn GetSpawn(lua_State* L);
 	bool IsResumedFromZoneSuspend();
 	void SetNPCTintIndex(uint32 id);
+	uint32 GetNPCTintIndex();
 
 };
 

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -4940,3 +4940,16 @@ void NPC::ResetMultiQuest() {
 
 	m_hand_in = {};
 }
+
+void NPC::SetNPCTintIndex(uint32 index)
+{
+	auto outapp = new EQApplicationPacket(OP_SpawnAppearance, sizeof(SpawnAppearance_Struct));
+	auto* s = (SpawnAppearance_Struct*) outapp->pBuffer;
+
+	s->spawn_id  = GetID();
+	s->type      = AppearanceType::NPCTintIndex;
+	s->parameter = index;
+
+	entity_list.QueueClients(this, outapp);
+	safe_delete(outapp);
+}

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -552,6 +552,9 @@ public:
 
 	void ScaleNPC(uint8 npc_level, bool always_scale = false, bool override_special_abilities = false);
 
+	uint32 GetNPCTintIndex() { return m_npc_tint_id; }
+	void SetNPCTintIndex(uint32 index);
+
 	void RecalculateSkills();
 	void ReloadSpells();
 

--- a/zone/perl_npc.cpp
+++ b/zone/perl_npc.cpp
@@ -885,9 +885,14 @@ Spawn2* Perl_NPC_GetSpawn(NPC* self)
 	return self->GetSpawn();
 }
 
-void Perl_NPC_SetNPCTintIndex(NPC* self, uint32 id)
+void Perl_NPC_SetNPCTintIndex(NPC* self, uint32 index)
 {
-	return self->SendAppearancePacket(AppearanceType::NPCTintIndex, id);
+	self->SetNPCTintIndex(index);
+}
+
+uint32 Perl_NPC_GetNPCTintIndex(NPC* self)
+{
+	return self->GetNPCTintIndex();
 }
 
 void perl_register_npc()
@@ -959,6 +964,7 @@ void perl_register_npc()
 	package.add("GetNPCSpellsEffectsID", &Perl_NPC_GetNPCSpellsEffectsID);
 	package.add("GetNPCSpellsID", &Perl_NPC_GetNPCSpellsID);
 	package.add("GetNPCStat", &Perl_NPC_GetNPCStat);
+	package.add("GetNPCTintIndex", &Perl_NPC_GetNPCTintIndex);
 	package.add("GetPetSpellID", &Perl_NPC_GetPetSpellID);
 	package.add("GetPlatinum", &Perl_NPC_GetPlatinum);
 	package.add("GetPrimSkill", &Perl_NPC_GetPrimSkill);


### PR DESCRIPTION
# Description
- Adds `GetNPCTintIndex()` to Perl/Lua.
- Cleans up `SetNPCTintIndex()` code slightly.

## Type of change
- [X] New feature

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur