### PR TITLE
[Cleanup] Fix Issues with Strings::Commify and Mob::SendStatsWindow

### DIFF
--- a/common/strings.cpp
+++ b/common/strings.cpp
@@ -313,6 +313,12 @@ std::string Strings::Commify(const std::string &number)
 
 	auto string_length = static_cast<int>(number.length());
 
+	if (string_length == 3) {
+		return number;
+	} else if (string_length == 4 && number.starts_with("-")) {
+		return number;
+	}
+
 	int i = 0;
 	for (i = string_length - 3; i >= 0; i -= 3) {
 		if (i > 0) {

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -1317,7 +1317,7 @@ void Mob::FillSpawnStruct(NewSpawn_Struct* ns, Mob* ForWho)
 	ns->spawn.IsMercenary = IsMerc() ? 1 : 0;
 	ns->spawn.targetable_with_hotkey = no_target_hotkey ? 0 : 1; // opposite logic!
 	ns->spawn.untargetable = IsTargetable();
-	
+
 	ns->spawn.petOwnerId	= ownerid;
 
 	ns->spawn.haircolor = haircolor;
@@ -2361,7 +2361,7 @@ void Mob::SendStatsWindow(Client* c, bool use_window)
 
 	// Attack 2
 	final_string += fmt::format(
-		"Offense: {}{} | {}{}",
+		"Offense: {}{}{}{}",
 		Strings::Commify(offense(skill)),
 		(
 			itembonuses.ATK ?


### PR DESCRIPTION
# Description
- Fixes an issue where a number like `-100` results in a string of `-,100` due to `Strings::Commify` using string length.
- If the number has a length of `4` and begins with `-`, we return the string.
- If the string has a length of `3`, we return the string.
- Removes an extra ` | ` spacing in `Mob::SendStatsWindow()`.

## Type of change
- [X] Bug fix

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur