### PR TITLE
[Commands] Add #task complete Saylink to #task show

### DIFF
--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -1414,11 +1414,19 @@ void ClientTaskState::ShowClientTaskInfoMessage(ClientTaskInformation *task, Cli
 	c->Message(
 		Chat::White,
 		fmt::format(
-			"Task {} | Title: {} ID: {} Type: {}",
+			"Task {} | Title: {} ID: {} Type: {} | {}",
 			task->slot,
 			task_data->title,
 			task->task_id,
-			Tasks::GetTaskTypeDescription(task_data->type)
+			Tasks::GetTaskTypeDescription(task_data->type),
+			Saylink::Create(
+				fmt::format(
+					"#task complete {}",
+					task->task_id
+				),
+				false,
+				"Complete"
+			)
 		).c_str()
 	);
 	c->Message(Chat::White, "------------------------------------------------");


### PR DESCRIPTION
# Description
- Adds a `#task complete` link to the listing from `#task show` so tasks can be easily completed.

## Type of change
- [X] New feature

# Testing
<img width="428" height="194" alt="image" src="https://github.com/user-attachments/assets/333a81c1-56e9-40d7-a669-46478022117d" />

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur