### PR TITLE
[Bug Fix] Fix Recipe Inspect Bug

### DIFF
--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -16001,7 +16001,7 @@ void Client::Handle_OP_TradeSkillRecipeInspect(const EQApplicationPacket* app)
 	const auto& v = TradeskillRecipeEntriesRepository::GetWhere(
 		content_db,
 		fmt::format(
-			"`recipe_id` = {} AND `componentcount` = 0 AND `successcount` > 0 LIMIT 1",
+			"`recipe_id` = {} AND `componentcount` = 0 AND `successcount` > 0 ORDER BY `id` ASC LIMIT 1",
 			s->recipe_id
 		)
 	);


### PR DESCRIPTION
# Description
- Fixes an issue where recipe inspect shows the incorrect result where recipes have two results.
- The recipes I looked at seem to have the **actual** result show up first in order of the `id` column.

## Type of change
- [X] Bug fix

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur