### PR TITLE
[Repositories] Convert Damage Shield Types to Repositories

### DIFF
--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -1676,7 +1676,7 @@ bool SharedDatabase::GetCommandSubSettings(std::vector<CommandSubsettingsReposit
 	return true;
 }
 
-void SharedDatabase::LoadDamageShieldTypes(SPDat_Spell_Struct* s, int32 max_spell_id)
+void SharedDatabase::LoadDamageShieldTypes(SPDat_Spell_Struct* s)
 {
 	const auto& l = DamageshieldtypesRepository::All(*this);
 
@@ -1970,7 +1970,7 @@ void SharedDatabase::LoadSpells(void *data, int max_spells) {
 		sp[e.id].damage_shield_type      = 0;
 	}
 
-	LoadDamageShieldTypes(sp, max_spells);
+	LoadDamageShieldTypes(sp);
 }
 
 void SharedDatabase::LoadCharacterInspectMessage(uint32 character_id, InspectMessage_Struct* s)

--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -53,6 +53,7 @@
 #include "repositories/sharedbank_repository.h"
 #include "repositories/character_inspect_messages_repository.h"
 #include "repositories/spells_new_repository.h"
+#include "repositories/damageshieldtypes_repository.h"
 
 namespace ItemField
 {
@@ -1675,20 +1676,17 @@ bool SharedDatabase::GetCommandSubSettings(std::vector<CommandSubsettingsReposit
 	return true;
 }
 
-void SharedDatabase::LoadDamageShieldTypes(SPDat_Spell_Struct* sp, int32 iMaxSpellID) {
-	const std::string query = StringFormat("SELECT `spellid`, `type` FROM `damageshieldtypes` WHERE `spellid` > 0 "
-	                                       "AND `spellid` <= %i", iMaxSpellID);
-    auto results = QueryDatabase(query);
-    if (!results.Success()) {
-        return;
-    }
+void SharedDatabase::LoadDamageShieldTypes(SPDat_Spell_Struct* s, int32 max_spell_id)
+{
+	const auto& l = DamageshieldtypesRepository::All(*this);
 
-    for(auto& row = results.begin(); row != results.end(); ++row) {
-	    const int spellID = Strings::ToInt(row[0]);
-        if((spellID > 0) && (spellID <= iMaxSpellID))
-            sp[spellID].damage_shield_type = Strings::ToUnsignedInt(row[1]);
-    }
+	if (l.empty()) {
+		return;
+	}
 
+	for (const auto& e : l) {
+		s[e.spellid].damage_shield_type = e.type;
+	}
 }
 
 const EvolveInfo* SharedDatabase::GetEvolveInfo(uint32 loregroup) {

--- a/common/shareddb.h
+++ b/common/shareddb.h
@@ -173,7 +173,7 @@ public:
 	int GetMaxSpellID();
 	bool LoadSpells(const std::string &prefix, int32 *records, const SPDat_Spell_Struct **sp);
 	void LoadSpells(void *data, int max_spells);
-	void LoadDamageShieldTypes(SPDat_Spell_Struct *sp, int32 iMaxSpellID);
+	void LoadDamageShieldTypes(SPDat_Spell_Struct *s, int32 max_spell_id);
 	uint32 GetSharedSpellsCount() { return m_shared_spells_count; }
 	uint32 GetSpellsCount();
 

--- a/common/shareddb.h
+++ b/common/shareddb.h
@@ -173,7 +173,7 @@ public:
 	int GetMaxSpellID();
 	bool LoadSpells(const std::string &prefix, int32 *records, const SPDat_Spell_Struct **sp);
 	void LoadSpells(void *data, int max_spells);
-	void LoadDamageShieldTypes(SPDat_Spell_Struct *s, int32 max_spell_id);
+	void LoadDamageShieldTypes(SPDat_Spell_Struct* s);
 	uint32 GetSharedSpellsCount() { return m_shared_spells_count; }
 	uint32 GetSpellsCount();
 


### PR DESCRIPTION
# Description
- Converts the loading of the `damageshieldtypes` table to repositories instead of a raw query.

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur