### PR TITLE
[Repositories] Convert Character Inspect Messages to Repositories

### DIFF
--- a/common/shareddb.h
+++ b/common/shareddb.h
@@ -76,8 +76,8 @@ public:
 	uint8 GetGMSpeed(uint32 account_id);
 	bool SetHideMe(uint32 account_id, uint8 hideme);
 	int DeleteStalePlayerCorpses();
-	void LoadCharacterInspectMessage(uint32 character_id, InspectMessage_Struct *message);
-	void SaveCharacterInspectMessage(uint32 character_id, const InspectMessage_Struct *message);
+	void LoadCharacterInspectMessage(uint32 character_id, InspectMessage_Struct* s);
+	void SaveCharacterInspectMessage(uint32 character_id, const InspectMessage_Struct* s);
 	bool GetCommandSettings(std::map<std::string, std::pair<uint8, std::vector<std::string>>> &command_settings);
 	bool UpdateInjectedCommandSettings(const std::vector<std::pair<std::string, uint8>> &injected);
 	bool UpdateOrphanedCommandSettings(const std::vector<std::string> &orphaned);


### PR DESCRIPTION
# Description
- Converts `character_inspect_messages` uses to repositories.

# Testing
## Loading
<img width="247" height="393" alt="image" src="https://github.com/user-attachments/assets/01c920ad-26c6-4bb2-a3f7-27df46cd06c2" />

## Saving
<img width="247" height="393" alt="image" src="https://github.com/user-attachments/assets/4a9fce82-f53e-40c2-a8f5-331851d71d5f" />

## Loading Again
<img width="247" height="393" alt="image" src="https://github.com/user-attachments/assets/919f4c2d-9315-458e-87da-b854c02ffcfe" />

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur