### PR TITLE
[Constants] Convert SE Defines to SpellEffect Namespace

### DIFF
--- a/common/item_data.h
+++ b/common/item_data.h
@@ -438,7 +438,7 @@ namespace EQ
 		//uint32	Unk054 {};
 		int16	MaxCharges {};		// Maximum charges items can hold: -1 if not a chargeable item
 		uint8	ItemType {};		// Item Type/Skill (itemClass* from above)
-		int32	SubType {};		// Some items have sub types that can be used for other things (unbreakable fishing poles, SE_FFItemClass)
+		int32	SubType {};		// Some items have sub types that can be used for other things (unbreakable fishing poles, SpellEffect::FFItemClass)
 		uint8	Material {};		// Item material type
 		uint32	HerosForgeModel {};// Hero's Forge Armor Model Type (2-13?)
 		float	SellRate {};		// Sell rate

--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -619,7 +619,7 @@ RULE_INT(Combat, SneakPullAssistRange, 400, "Modified range of assist for sneak 
 RULE_BOOL(Combat, Classic2HBAnimation, false, "2HB will use the 2 hand piercing animation instead of the overhead slashing animation")
 RULE_BOOL(Combat, ArcheryConsumesAmmo, true, "Set to false to disable Archery Ammo Consumption")
 RULE_BOOL(Combat, ThrowingConsumesAmmo, true, "Set to false to disable Throwing Ammo Consumption")
-RULE_BOOL(Combat, UseLiveRiposteMechanics, false, "Set to true to disable SPA 173 SE_RiposteChance from making those with the effect on them immune to enrage, can longer riposte from a riposte.")
+RULE_BOOL(Combat, UseLiveRiposteMechanics, false, "Set to true to disable SPA 173 SpellEffect::RiposteChance from making those with the effect on them immune to enrage, can longer riposte from a riposte.")
 RULE_INT(Combat, FrontalStunImmunityClasses, 0, "Bitmask for Classes than have frontal stun immunity, No Races (0) by default.")
 RULE_BOOL(Combat, NPCsUseFrontalStunImmunityClasses, false, "Enable or disable NPCs using frontal stun immunity Classes from Combat:FrontalStunImmunityClasses, false by default.")
 RULE_INT(Combat, FrontalStunImmunityRaces, 512, "Bitmask for Races than have frontal stun immunity, Ogre (512) only by default.")

--- a/common/spdat.cpp
+++ b/common/spdat.cpp
@@ -105,7 +105,7 @@ bool IsTargetableAESpell(uint16 spell_id)
 
 bool IsSacrificeSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_Sacrifice);
+	return IsEffectInSpell(spell_id, SpellEffect::Sacrifice);
 }
 
 bool IsLifetapSpell(uint16 spell_id)
@@ -129,7 +129,7 @@ bool IsLifetapSpell(uint16 spell_id)
 
 bool IsMesmerizeSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_Mez);
+	return IsEffectInSpell(spell_id, SpellEffect::Mez);
 }
 
 bool SpellBreaksMez(uint16 spell_id)
@@ -139,7 +139,7 @@ bool SpellBreaksMez(uint16 spell_id)
 
 bool IsStunSpell(uint16 spell_id)
 {
-	return (IsValidSpell(spell_id) && IsEffectInSpell(spell_id, SE_Stun) || IsEffectInSpell(spell_id, SE_SpinTarget));
+	return (IsValidSpell(spell_id) && IsEffectInSpell(spell_id, SpellEffect::Stun) || IsEffectInSpell(spell_id, SpellEffect::SpinTarget));
 }
 
 bool IsSummonSpell(uint16 spell_id)
@@ -153,9 +153,9 @@ bool IsSummonSpell(uint16 spell_id)
 	for (int i = 0; i < EFFECT_COUNT; i++) {
 		const auto effect_id = spell.effect_id[i];
 		if (
-			effect_id == SE_SummonPet ||
-			effect_id == SE_SummonItem ||
-			effect_id == SE_SummonPC
+			effect_id == SpellEffect::SummonPet ||
+			effect_id == SpellEffect::SummonItem ||
+			effect_id == SpellEffect::SummonPC
 		) {
 			return true;
 		}
@@ -180,7 +180,7 @@ bool IsDamageSpell(uint16 spell_id)
 		const auto effect_id = spell.effect_id[i];
 		if (
 			spell.base_value[i] < 0 &&
-			(effect_id == SE_CurrentHPOnce || effect_id == SE_CurrentHP)
+			(effect_id == SpellEffect::CurrentHPOnce || effect_id == SpellEffect::CurrentHP)
 		) {
 			return true;
 		}
@@ -207,9 +207,9 @@ bool IsAnyDamageSpell(uint16 spell_id)
 		if (
 			spell.base_value[i] < 0 &&
 			(
-				effect_id == SE_CurrentHPOnce ||
+				effect_id == SpellEffect::CurrentHPOnce ||
 				(
-					effect_id == SE_CurrentHP &&
+					effect_id == SpellEffect::CurrentHP &&
 					spell.buff_duration < 1
 				)
 			)
@@ -241,7 +241,7 @@ bool IsDamageOverTimeSpell(uint16 spell_id)
 		const auto effect_id = spell.effect_id[i];
 		if (
 			spell.base_value[i] < 0 &&
-			effect_id == SE_CurrentHP &&
+			effect_id == SpellEffect::CurrentHP &&
 			spell.buff_duration > 1
 		) {
 			return true;
@@ -253,7 +253,7 @@ bool IsDamageOverTimeSpell(uint16 spell_id)
 
 bool IsFearSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_Fear);
+	return IsEffectInSpell(spell_id, SpellEffect::Fear);
 }
 
 bool IsCureSpell(uint16 spell_id)
@@ -268,10 +268,10 @@ bool IsCureSpell(uint16 spell_id)
 
 	for (int i = 0; i < EFFECT_COUNT; i++) {
 		if (
-			spell.effect_id[i] == SE_DiseaseCounter ||
-			spell.effect_id[i] == SE_PoisonCounter ||
-			spell.effect_id[i] == SE_CurseCounter ||
-			spell.effect_id[i] == SE_CorruptionCounter
+			spell.effect_id[i] == SpellEffect::DiseaseCounter ||
+			spell.effect_id[i] == SpellEffect::PoisonCounter ||
+			spell.effect_id[i] == SpellEffect::CurseCounter ||
+			spell.effect_id[i] == SpellEffect::CorruptionCounter
 		) {
 			has_cure_effect = true;
 		}
@@ -298,9 +298,9 @@ bool IsSlowSpell(uint16 spell_id)
 	for (int i = 0; i < EFFECT_COUNT; i++) {
 		const auto effect_id = spell.effect_id[i];
 		if (
-			effect_id == SE_AttackSpeed4 ||
+			effect_id == SpellEffect::AttackSpeed4 ||
 			(
-				effect_id == SE_AttackSpeed &&
+				effect_id == SpellEffect::AttackSpeed &&
 				spell.base_value[i] < 100
 			)
 		) {
@@ -320,7 +320,7 @@ bool IsHasteSpell(uint16 spell_id)
 	const auto& spell = spells[spell_id];
 
 	for (int i = 0; i < EFFECT_COUNT; i++) {
-		if (spell.effect_id[i] == SE_AttackSpeed) {
+		if (spell.effect_id[i] == SpellEffect::AttackSpeed) {
 			return (spell.base_value[i] < 100);
 		}
 	}
@@ -331,15 +331,15 @@ bool IsHasteSpell(uint16 spell_id)
 bool IsHarmonySpell(uint16 spell_id)
 {
 	return (
-		IsEffectInSpell(spell_id, SE_ChangeFrenzyRad) ||
-		IsEffectInSpell(spell_id, SE_Harmony) ||
-		IsEffectInSpell(spell_id, SE_Lull)
+		IsEffectInSpell(spell_id, SpellEffect::ChangeFrenzyRad) ||
+		IsEffectInSpell(spell_id, SpellEffect::Harmony) ||
+		IsEffectInSpell(spell_id, SpellEffect::Lull)
 	);
 }
 
 bool IsPercentalHealSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_PercentalHeal);
+	return IsEffectInSpell(spell_id, SpellEffect::PercentalHeal);
 }
 
 bool IsGroupOnlySpell(uint16 spell_id)
@@ -359,13 +359,13 @@ bool IsBeneficialSpell(uint16 spell_id)
 
 	// You'd think just checking goodEffect flag would be enough?
 	if (spells[spell_id].good_effect == BENEFICIAL_EFFECT) {
-		// If the target type is ST_Self or ST_Pet and is a SE_CancleMagic spell
+		// If the target type is ST_Self or ST_Pet and is a SpellEffect::CancleMagic spell
 		// it is not Beneficial
 		const auto target_type = spells[spell_id].target_type;
 		if (
 			target_type != ST_Self &&
 			target_type != ST_Pet &&
-			IsEffectInSpell(spell_id, SE_CancelMagic)
+			IsEffectInSpell(spell_id, SpellEffect::CancelMagic)
 		) {
 			return false;
 		}
@@ -387,7 +387,7 @@ bool IsBeneficialSpell(uint16 spell_id)
 				// checking these SAI cause issues with the rng defensive proc line
 				// So I guess instead of fixing it for real, just a quick hack :P
 				if (
-					spells[spell_id].effect_id[0] != SE_DefensiveProc &&
+					spells[spell_id].effect_id[0] != SpellEffect::DefensiveProc &&
 					(
 						spell_affect_index == SAI_Calm ||
 						spell_affect_index == SAI_Dispell_Sight ||
@@ -403,16 +403,16 @@ bool IsBeneficialSpell(uint16 spell_id)
 				if (
 					(
 						spell_affect_index == SAI_Calm &&
-						IsEffectInSpell(spell_id, SE_Harmony)
+						IsEffectInSpell(spell_id, SpellEffect::Harmony)
 					) ||
 					(
 						spell_affect_index == SAI_Calm_Song &&
-						IsEffectInSpell(spell_id, SE_BindSight)
+						IsEffectInSpell(spell_id, SpellEffect::BindSight)
 					) ||
 					(
 						spell_affect_index == SAI_Dispell_Sight &&
 						spells[spell_id].skill == EQ::skills::SkillDivination &&
-						!IsEffectInSpell(spell_id, SE_VoiceGraft)
+						!IsEffectInSpell(spell_id, SpellEffect::VoiceGraft)
 					)
 				) {
 					return false;
@@ -436,52 +436,52 @@ bool IsDetrimentalSpell(uint16 spell_id)
 bool IsInvisibleSpell(uint16 spell_id)
 {
 	return (
-		IsEffectInSpell(spell_id, SE_Invisibility) ||
-		IsEffectInSpell(spell_id, SE_Invisibility2) ||
-		IsEffectInSpell(spell_id, SE_InvisVsUndead) ||
-		IsEffectInSpell(spell_id, SE_InvisVsUndead2) ||
-		IsEffectInSpell(spell_id, SE_InvisVsAnimals) ||
-		IsEffectInSpell(spell_id, SE_ImprovedInvisAnimals)
+		IsEffectInSpell(spell_id, SpellEffect::Invisibility) ||
+		IsEffectInSpell(spell_id, SpellEffect::Invisibility2) ||
+		IsEffectInSpell(spell_id, SpellEffect::InvisVsUndead) ||
+		IsEffectInSpell(spell_id, SpellEffect::InvisVsUndead2) ||
+		IsEffectInSpell(spell_id, SpellEffect::InvisVsAnimals) ||
+		IsEffectInSpell(spell_id, SpellEffect::ImprovedInvisAnimals)
 	);
 }
 
 bool IsInvulnerabilitySpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_DivineAura);
+	return IsEffectInSpell(spell_id, SpellEffect::DivineAura);
 }
 
 bool IsCompleteHealDurationSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_CompleteHeal);
+	return IsEffectInSpell(spell_id, SpellEffect::CompleteHeal);
 }
 
 bool IsPoisonCounterSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_PoisonCounter);
+	return IsEffectInSpell(spell_id, SpellEffect::PoisonCounter);
 }
 
 bool IsDiseaseCounterSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_DiseaseCounter);
+	return IsEffectInSpell(spell_id, SpellEffect::DiseaseCounter);
 }
 
 bool IsSummonItemSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_SummonItem);
+	return IsEffectInSpell(spell_id, SpellEffect::SummonItem);
 }
 
 bool IsSummonSkeletonSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_NecPet);
+	return IsEffectInSpell(spell_id, SpellEffect::NecPet);
 }
 
 bool IsSummonPetSpell(uint16 spell_id)
 {
 	return (
-		IsEffectInSpell(spell_id, SE_SummonPet) ||
-		IsEffectInSpell(spell_id, SE_SummonBSTPet) ||
-		IsEffectInSpell(spell_id, SE_Familiar) ||
-		IsEffectInSpell(spell_id, SE_NecPet)
+		IsEffectInSpell(spell_id, SpellEffect::SummonPet) ||
+		IsEffectInSpell(spell_id, SpellEffect::SummonBSTPet) ||
+		IsEffectInSpell(spell_id, SpellEffect::Familiar) ||
+		IsEffectInSpell(spell_id, SpellEffect::NecPet)
 	);
 }
 
@@ -495,12 +495,12 @@ bool IsPetSpell(uint16 spell_id)
 
 bool IsSummonPCSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_SummonPC);
+	return IsEffectInSpell(spell_id, SpellEffect::SummonPC);
 }
 
 bool IsCharmSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_Charm);
+	return IsEffectInSpell(spell_id, SpellEffect::Charm);
 }
 
 bool IsResurrectionSicknessSpell(uint16 spell_id) {
@@ -515,42 +515,42 @@ bool IsResurrectionSicknessSpell(uint16 spell_id) {
 
 bool IsBlindSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_Blind);
+	return IsEffectInSpell(spell_id, SpellEffect::Blind);
 }
 
 bool IsHealthSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_CurrentHP);
+	return IsEffectInSpell(spell_id, SpellEffect::CurrentHP);
 }
 
 bool IsCastTimeReductionSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_IncreaseSpellHaste);
+	return IsEffectInSpell(spell_id, SpellEffect::IncreaseSpellHaste);
 }
 
 bool IsIncreaseDurationSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_IncreaseSpellDuration);
+	return IsEffectInSpell(spell_id, SpellEffect::IncreaseSpellDuration);
 }
 
 bool IsManaCostReductionSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_ReduceManaCost);
+	return IsEffectInSpell(spell_id, SpellEffect::ReduceManaCost);
 }
 
 bool IsIncreaseRangeSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_IncreaseRange);
+	return IsEffectInSpell(spell_id, SpellEffect::IncreaseRange);
 }
 
 bool IsImprovedHealingSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_ImprovedHeal);
+	return IsEffectInSpell(spell_id, SpellEffect::ImprovedHeal);
 }
 
 bool IsImprovedDamageSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_ImprovedDamage);
+	return IsEffectInSpell(spell_id, SpellEffect::ImprovedDamage);
 }
 
 bool IsAEDurationSpell(uint16 spell_id)
@@ -596,7 +596,7 @@ bool IsPureNukeSpell(uint16 spell_id)
 
 	if (
 		effect_count == 1 &&
-		IsEffectInSpell(spell_id, SE_CurrentHP) &&
+		IsEffectInSpell(spell_id, SpellEffect::CurrentHP) &&
 		spells[spell_id].buff_duration == 0 &&
 		IsDamageSpell(spell_id)
 	) {
@@ -799,8 +799,8 @@ bool IsPartialResistableSpell(uint16 spell_id)
 		if (
 			spell.base_value[o] < 0 &&
 			(
-				effect_id == SE_CurrentHPOnce ||
-				effect_id == SE_CurrentHP
+				effect_id == SpellEffect::CurrentHPOnce ||
+				effect_id == SpellEffect::CurrentHP
 			)
 		) {
 			return true;
@@ -846,7 +846,7 @@ bool IsTGBCompatibleSpell(uint16 spell_id)
 		!IsDetrimentalSpell(spell_id) &&
 		spells[spell_id].buff_duration != 0 &&
 		!IsBardSong(spell_id) &&
-		!IsEffectInSpell(spell_id, SE_Illusion)
+		!IsEffectInSpell(spell_id, SpellEffect::Illusion)
 	) {
 		return true;
 	}
@@ -899,10 +899,10 @@ uint16 GetSpellTriggerSpellID(uint16 spell_id, int effect_id)
 
 	for (int i = 0; i < EFFECT_COUNT; i++) {
 		if (
-			spell.effect_id[i] == SE_TriggerOnCast ||
-			spell.effect_id[i] == SE_SpellTrigger ||
-			spell.effect_id[i] == SE_ApplyEffect ||
-			spell.effect_id[i] == SE_Trigger_Spell_Non_Item
+			spell.effect_id[i] == SpellEffect::TriggerOnCast ||
+			spell.effect_id[i] == SpellEffect::SpellTrigger ||
+			spell.effect_id[i] == SpellEffect::ApplyEffect ||
+			spell.effect_id[i] == SpellEffect::Trigger_Spell_Non_Item
 		) {
 			const auto trigger_spell_id = spell.limit_value[i];
 			if (
@@ -932,17 +932,17 @@ bool IsBlankSpellEffect(uint16 spell_id, int effect_index)
 	const auto base_value = spell.base_value[effect_index];
 	const auto formula    = spell.formula[effect_index];
 
-	// SE_CHA is "spacer"
-	// SE_Stacking* are also considered blank where this is used
+	// SpellEffect::CHA is "spacer"
+	// SpellEffect::Stacking* are also considered blank where this is used
 	if (
-		effect == SE_Blank ||
+		effect == SpellEffect::Blank ||
 		(
-			effect == SE_CHA &&
+			effect == SpellEffect::CHA &&
 			base_value == 0 &&
 			formula == 100
 		) ||
-		effect == SE_StackingCommand_Block ||
-		effect == SE_StackingCommand_Overwrite
+		effect == SpellEffect::StackingCommand_Block ||
+		effect == SpellEffect::StackingCommand_Overwrite
 	) {
 		return true;
 	}
@@ -1041,7 +1041,7 @@ int CalculatePoisonCounters(uint16 spell_id)
 
 	for (int i = 0; i < EFFECT_COUNT; i++) {
 		if (
-			spell.effect_id[i] == SE_PoisonCounter &&
+			spell.effect_id[i] == SpellEffect::PoisonCounter &&
 			spell.base_value[i] > 0
 		) {
 			counters += spell.base_value[i];
@@ -1063,7 +1063,7 @@ int CalculateDiseaseCounters(uint16 spell_id)
 
 	for (int i = 0; i < EFFECT_COUNT; i++) {
 		if (
-			spell.effect_id[i] == SE_DiseaseCounter &&
+			spell.effect_id[i] == SpellEffect::DiseaseCounter &&
 			spell.base_value[i] > 0
 		) {
 			counters += spell.base_value[i];
@@ -1085,7 +1085,7 @@ int CalculateCurseCounters(uint16 spell_id)
 
 	for (int i = 0; i < EFFECT_COUNT; i++) {
 		if (
-			spell.effect_id[i] == SE_CurseCounter &&
+			spell.effect_id[i] == SpellEffect::CurseCounter &&
 			spell.base_value[i] > 0
 		) {
 			counters += spell.base_value[i];
@@ -1107,7 +1107,7 @@ int CalculateCorruptionCounters(uint16 spell_id)
 
 	for (int i = 0; i < EFFECT_COUNT; i++) {
 		if (
-			spell.effect_id[i] == SE_CorruptionCounter &&
+			spell.effect_id[i] == SpellEffect::CorruptionCounter &&
 			spell.base_value[i] > 0) {
 
 			counters += spell.base_value[i];
@@ -1254,30 +1254,30 @@ int8 GetSpellResurrectionSicknessCheck(uint16 spell_id_one, uint16 spell_id_two)
 
 bool IsRuneSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_Rune);
+	return IsEffectInSpell(spell_id, SpellEffect::Rune);
 }
 
 bool IsMagicRuneSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_AbsorbMagicAtt);
+	return IsEffectInSpell(spell_id, SpellEffect::AbsorbMagicAtt);
 }
 
 bool IsManaTapSpell(uint16 spell_id)
 {
 	return (
-		IsEffectInSpell(spell_id, SE_CurrentMana) &&
+		IsEffectInSpell(spell_id, SpellEffect::CurrentMana) &&
 		spells[spell_id].target_type == ST_Tap
 	);
 }
 
 bool IsAllianceSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_AddFaction);
+	return IsEffectInSpell(spell_id, SpellEffect::AddFaction);
 }
 
 bool IsDeathSaveSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_DeathSave);
+	return IsEffectInSpell(spell_id, SpellEffect::DeathSave);
 }
 
 // Deathsave spells with base of 1 are partial
@@ -1291,7 +1291,7 @@ bool IsPartialDeathSaveSpell(uint16 spell_id)
 
 	for (int i = 0; i < EFFECT_COUNT; i++) {
 		if (
-			spell.effect_id[i] == SE_DeathSave &&
+			spell.effect_id[i] == SpellEffect::DeathSave &&
 			spell.base_value[i] == PARTIAL_DEATH_SAVE
 		) {
 			return true;
@@ -1312,7 +1312,7 @@ bool IsFullDeathSaveSpell(uint16 spell_id)
 
 	for (int i = 0; i < EFFECT_COUNT; i++) {
 		if (
-			spell.effect_id[i] == SE_DeathSave &&
+			spell.effect_id[i] == SpellEffect::DeathSave &&
 			spell.base_value[i] == FULL_DEATH_SAVE
 		) {
 			return true;
@@ -1324,33 +1324,33 @@ bool IsFullDeathSaveSpell(uint16 spell_id)
 
 bool IsShadowStepSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_ShadowStep);
+	return IsEffectInSpell(spell_id, SpellEffect::ShadowStep);
 }
 
 bool IsSuccorSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_Succor);
+	return IsEffectInSpell(spell_id, SpellEffect::Succor);
 }
 
 bool IsTeleportSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_Teleport);
+	return IsEffectInSpell(spell_id, SpellEffect::Teleport);
 }
 
 bool IsTranslocateSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_Translocate);
+	return IsEffectInSpell(spell_id, SpellEffect::Translocate);
 }
 
 bool IsGateSpell(uint16 spell_id)
 {
-	return IsEffectInSpell(spell_id, SE_Gate);
+	return IsEffectInSpell(spell_id, SpellEffect::Gate);
 }
 
 bool IsIllusionSpell(uint16 spell_id)
 {
 	return (
-		IsEffectInSpell(spell_id, SE_Illusion) &&
+		IsEffectInSpell(spell_id, SpellEffect::Illusion) &&
 		spells[spell_id].target_type == ST_Self
 	);
 }
@@ -1406,9 +1406,9 @@ DmgShieldType GetDamageShieldType(uint16 spell_id, int damage_shield_type)
 bool IsLDoNObjectSpell(uint16 spell_id)
 {
 	return (
-		IsEffectInSpell(spell_id, SE_AppraiseLDonChest) ||
-		IsEffectInSpell(spell_id, SE_DisarmLDoNTrap) ||
-		IsEffectInSpell(spell_id, SE_UnlockLDoNChest)
+		IsEffectInSpell(spell_id, SpellEffect::AppraiseLDonChest) ||
+		IsEffectInSpell(spell_id, SpellEffect::DisarmLDoNTrap) ||
+		IsEffectInSpell(spell_id, SpellEffect::UnlockLDoNChest)
 	);
 }
 
@@ -1426,8 +1426,8 @@ bool IsHealOverTimeSpell(uint16 spell_id)
 {
 	if (
 		(
-			IsEffectInSpell(spell_id, SE_HealOverTime) ||
-			GetSpellTriggerSpellID(spell_id, SE_HealOverTime)
+			IsEffectInSpell(spell_id, SpellEffect::HealOverTime) ||
+			GetSpellTriggerSpellID(spell_id, SpellEffect::HealOverTime)
 		) &&
 		!IsGroupSpell(spell_id)
 	) {
@@ -1442,9 +1442,9 @@ bool IsCompleteHealSpell(uint16 spell_id)
 	if (
 		(
 			spell_id == SPELL_COMPLETE_HEAL ||
-			IsEffectInSpell(spell_id, SE_CompleteHeal) ||
+			IsEffectInSpell(spell_id, SpellEffect::CompleteHeal) ||
 			IsPercentalHealSpell(spell_id) ||
-			GetSpellTriggerSpellID(spell_id, SE_CompleteHeal)
+			GetSpellTriggerSpellID(spell_id, SpellEffect::CompleteHeal)
 		) &&
 		!IsGroupSpell(spell_id)
 	) {
@@ -1457,16 +1457,16 @@ bool IsCompleteHealSpell(uint16 spell_id)
 
 bool IsFastHealSpell(uint16 spell_id) {
 	spell_id = (
-		IsEffectInSpell(spell_id, SE_CurrentHP) ?
+		IsEffectInSpell(spell_id, SpellEffect::CurrentHP) ?
 			spell_id :
-			GetSpellTriggerSpellID(spell_id, SE_CurrentHP)
+			GetSpellTriggerSpellID(spell_id, SpellEffect::CurrentHP)
 	);
 
 	if (!spell_id) {
 		spell_id = (
-			IsEffectInSpell(spell_id, SE_CurrentHPOnce) ?
+			IsEffectInSpell(spell_id, SpellEffect::CurrentHPOnce) ?
 				spell_id :
-				GetSpellTriggerSpellID(spell_id, SE_CurrentHPOnce)
+				GetSpellTriggerSpellID(spell_id, SpellEffect::CurrentHPOnce)
 		);
 	}
 
@@ -1481,8 +1481,8 @@ bool IsFastHealSpell(uint16 spell_id) {
 				if (
 					spells[spell_id].base_value[i] > 0 &&
 					(
-						spells[spell_id].effect_id[i] == SE_CurrentHP ||
-						spells[spell_id].effect_id[i] == SE_CurrentHPOnce
+						spells[spell_id].effect_id[i] == SpellEffect::CurrentHP ||
+						spells[spell_id].effect_id[i] == SpellEffect::CurrentHPOnce
 					)
 				) {
 					return true;
@@ -1497,16 +1497,16 @@ bool IsFastHealSpell(uint16 spell_id) {
 bool IsVeryFastHealSpell(uint16 spell_id)
 {
 	spell_id = (
-		IsEffectInSpell(spell_id, SE_CurrentHP) ?
+		IsEffectInSpell(spell_id, SpellEffect::CurrentHP) ?
 		spell_id :
-		GetSpellTriggerSpellID(spell_id, SE_CurrentHP)
+		GetSpellTriggerSpellID(spell_id, SpellEffect::CurrentHP)
 	);
 
 	if (!spell_id) {
 		spell_id = (
-			IsEffectInSpell(spell_id, SE_CurrentHPOnce) ?
+			IsEffectInSpell(spell_id, SpellEffect::CurrentHPOnce) ?
 			spell_id :
-			GetSpellTriggerSpellID(spell_id, SE_CurrentHPOnce)
+			GetSpellTriggerSpellID(spell_id, SpellEffect::CurrentHPOnce)
 		);
 	}
 
@@ -1521,8 +1521,8 @@ bool IsVeryFastHealSpell(uint16 spell_id)
 				if (
 					spells[spell_id].base_value[i] > 0 &&
 					(
-						spells[spell_id].effect_id[i] == SE_CurrentHP ||
-						spells[spell_id].effect_id[i] == SE_CurrentHPOnce
+						spells[spell_id].effect_id[i] == SpellEffect::CurrentHP ||
+						spells[spell_id].effect_id[i] == SpellEffect::CurrentHPOnce
 					)
 				) {
 					return true;
@@ -1537,16 +1537,16 @@ bool IsVeryFastHealSpell(uint16 spell_id)
 bool IsRegularSingleTargetHealSpell(uint16 spell_id)
 {
 	spell_id = (
-		IsEffectInSpell(spell_id, SE_CurrentHP) ?
+		IsEffectInSpell(spell_id, SpellEffect::CurrentHP) ?
 		spell_id :
-		GetSpellTriggerSpellID(spell_id, SE_CurrentHP)
+		GetSpellTriggerSpellID(spell_id, SpellEffect::CurrentHP)
 	);
 
 	if (!spell_id) {
 		spell_id = (
-			IsEffectInSpell(spell_id, SE_CurrentHPOnce) ?
+			IsEffectInSpell(spell_id, SpellEffect::CurrentHPOnce) ?
 			spell_id :
-			GetSpellTriggerSpellID(spell_id, SE_CurrentHPOnce)
+			GetSpellTriggerSpellID(spell_id, SpellEffect::CurrentHPOnce)
 		);
 	}
 
@@ -1567,8 +1567,8 @@ bool IsRegularSingleTargetHealSpell(uint16 spell_id)
 					spells[spell_id].base_value[i] > 0 &&
 					spells[spell_id].buff_duration == 0 &&
 					(
-						spells[spell_id].effect_id[i] == SE_CurrentHP ||
-						spells[spell_id].effect_id[i] == SE_CurrentHPOnce
+						spells[spell_id].effect_id[i] == SpellEffect::CurrentHP ||
+						spells[spell_id].effect_id[i] == SpellEffect::CurrentHPOnce
 					)
 				) {
 					return true;
@@ -1583,16 +1583,16 @@ bool IsRegularSingleTargetHealSpell(uint16 spell_id)
 bool IsRegularPetHealSpell(uint16 spell_id)
 {
 	spell_id = (
-		IsEffectInSpell(spell_id, SE_CurrentHP) ?
+		IsEffectInSpell(spell_id, SpellEffect::CurrentHP) ?
 		spell_id :
-		GetSpellTriggerSpellID(spell_id, SE_CurrentHP)
+		GetSpellTriggerSpellID(spell_id, SpellEffect::CurrentHP)
 	);
 
 	if (!spell_id) {
 		spell_id = (
-			IsEffectInSpell(spell_id, SE_CurrentHPOnce) ?
+			IsEffectInSpell(spell_id, SpellEffect::CurrentHPOnce) ?
 			spell_id :
-			GetSpellTriggerSpellID(spell_id, SE_CurrentHPOnce)
+			GetSpellTriggerSpellID(spell_id, SpellEffect::CurrentHPOnce)
 		);
 	}
 
@@ -1613,8 +1613,8 @@ bool IsRegularPetHealSpell(uint16 spell_id)
 					spells[spell_id].base_value[i] > 0 &&
 					spells[spell_id].buff_duration == 0 &&
 					(
-						spells[spell_id].effect_id[i] == SE_CurrentHP ||
-						spells[spell_id].effect_id[i] == SE_CurrentHPOnce
+						spells[spell_id].effect_id[i] == SpellEffect::CurrentHP ||
+						spells[spell_id].effect_id[i] == SpellEffect::CurrentHPOnce
 					)
 				) {
 					return true;
@@ -1629,16 +1629,16 @@ bool IsRegularPetHealSpell(uint16 spell_id)
 bool IsRegularGroupHealSpell(uint16 spell_id)
 {
 	spell_id = (
-		IsEffectInSpell(spell_id, SE_CurrentHP) ?
+		IsEffectInSpell(spell_id, SpellEffect::CurrentHP) ?
 		spell_id :
-		GetSpellTriggerSpellID(spell_id, SE_CurrentHP)
+		GetSpellTriggerSpellID(spell_id, SpellEffect::CurrentHP)
 	);
 
 	if (!spell_id) {
 		spell_id = (
-			IsEffectInSpell(spell_id, SE_CurrentHPOnce) ?
+			IsEffectInSpell(spell_id, SpellEffect::CurrentHPOnce) ?
 			spell_id :
-			GetSpellTriggerSpellID(spell_id, SE_CurrentHPOnce)
+			GetSpellTriggerSpellID(spell_id, SpellEffect::CurrentHPOnce)
 		);
 	}
 
@@ -1653,8 +1653,8 @@ bool IsRegularGroupHealSpell(uint16 spell_id)
 					spells[spell_id].base_value[i] > 0 &&
 					spells[spell_id].buff_duration == 0 &&
 					(
-						spells[spell_id].effect_id[i] == SE_CurrentHP ||
-						spells[spell_id].effect_id[i] == SE_CurrentHPOnce
+						spells[spell_id].effect_id[i] == SpellEffect::CurrentHP ||
+						spells[spell_id].effect_id[i] == SpellEffect::CurrentHPOnce
 					)
 				) {
 					return true;
@@ -1671,9 +1671,9 @@ bool IsGroupCompleteHealSpell(uint16 spell_id) {
         IsValidSpell(spell_id) &&
         (
             spell_id == SPELL_COMPLETE_HEAL ||
-            IsEffectInSpell(spell_id, SE_CompleteHeal) ||
+            IsEffectInSpell(spell_id, SpellEffect::CompleteHeal) ||
             IsPercentalHealSpell(spell_id) ||
-            GetSpellTriggerSpellID(spell_id, SE_CompleteHeal)
+            GetSpellTriggerSpellID(spell_id, SpellEffect::CompleteHeal)
         ) &&
         IsGroupSpell(spell_id)
     ) {
@@ -1687,8 +1687,8 @@ bool IsGroupHealOverTimeSpell(uint16 spell_id) {
     if (
         IsValidSpell(spell_id) &&
         (
-            IsEffectInSpell(spell_id, SE_HealOverTime) ||
-            GetSpellTriggerSpellID(spell_id, SE_HealOverTime)
+            IsEffectInSpell(spell_id, SpellEffect::HealOverTime) ||
+            GetSpellTriggerSpellID(spell_id, SpellEffect::HealOverTime)
         ) &&
         IsGroupSpell(spell_id)
     ) {
@@ -1738,7 +1738,7 @@ bool IsAnyBuffSpell(uint16 spell_id) {
 		IsBeneficialSpell(spell_id) &&
 		!IsBardSong(spell_id) &&
 		!IsEscapeSpell(spell_id) &&
-		(!IsSummonPetSpell(spell_id) && !IsEffectInSpell(spell_id, SE_TemporaryPets))
+		(!IsSummonPetSpell(spell_id) && !IsEffectInSpell(spell_id, SpellEffect::TemporaryPets))
 	) {
 		return true;
 	}
@@ -1751,9 +1751,9 @@ bool IsDispelSpell(uint16 spell_id) {
 	}
 
 	if (
-		IsEffectInSpell(spell_id, SE_CancelMagic) ||
-		IsEffectInSpell(spell_id, SE_DispelBeneficial) ||
-		IsEffectInSpell(spell_id, SE_DispelBeneficial)
+		IsEffectInSpell(spell_id, SpellEffect::CancelMagic) ||
+		IsEffectInSpell(spell_id, SpellEffect::DispelBeneficial) ||
+		IsEffectInSpell(spell_id, SpellEffect::DispelBeneficial)
 	) {
 		return true;
 	}
@@ -1768,12 +1768,12 @@ bool IsEscapeSpell(uint16 spell_id) {
 
 	return (
 		IsInvulnerabilitySpell(spell_id) ||
-		IsEffectInSpell(spell_id, SE_FeignDeath) ||
-		IsEffectInSpell(spell_id, SE_DeathSave) ||
-		IsEffectInSpell(spell_id, SE_Destroy) ||
+		IsEffectInSpell(spell_id, SpellEffect::FeignDeath) ||
+		IsEffectInSpell(spell_id, SpellEffect::DeathSave) ||
+		IsEffectInSpell(spell_id, SpellEffect::Destroy) ||
 		(
-			IsEffectInSpell(spell_id, SE_WipeHateList) &&
-			spells[spell_id].base_value[GetSpellEffectIndex(spell_id, SE_WipeHateList)] > 0
+			IsEffectInSpell(spell_id, SpellEffect::WipeHateList) &&
+			spells[spell_id].base_value[GetSpellEffectIndex(spell_id, SpellEffect::WipeHateList)] > 0
 		)
 	);
 }
@@ -1791,12 +1791,12 @@ bool IsDebuffSpell(uint16 spell_id)
 		IsMesmerizeSpell(spell_id) ||
 		IsCharmSpell(spell_id) ||
 		IsSlowSpell(spell_id) ||
-		IsEffectInSpell(spell_id, SE_Root) ||
-		IsEffectInSpell(spell_id, SE_CancelMagic) ||
-		IsEffectInSpell(spell_id, SE_MovementSpeed) ||
+		IsEffectInSpell(spell_id, SpellEffect::Root) ||
+		IsEffectInSpell(spell_id, SpellEffect::CancelMagic) ||
+		IsEffectInSpell(spell_id, SpellEffect::MovementSpeed) ||
 		IsFearSpell(spell_id) ||
-		IsEffectInSpell(spell_id, SE_InstantHate) ||
-		IsEffectInSpell(spell_id, SE_TossUp)
+		IsEffectInSpell(spell_id, SpellEffect::InstantHate) ||
+		IsEffectInSpell(spell_id, SpellEffect::TossUp)
 	);
 }
 
@@ -1807,16 +1807,16 @@ bool IsHateReduxSpell(uint16 spell_id) {
 
 	return (
 		(
-			IsEffectInSpell(spell_id, SE_InstantHate) &&
-			spells[spell_id].base_value[GetSpellEffectIndex(spell_id, SE_InstantHate)] < 0
+			IsEffectInSpell(spell_id, SpellEffect::InstantHate) &&
+			spells[spell_id].base_value[GetSpellEffectIndex(spell_id, SpellEffect::InstantHate)] < 0
 		) ||
 		(
-			IsEffectInSpell(spell_id, SE_Hate) &&
-			spells[spell_id].base_value[GetSpellEffectIndex(spell_id, SE_Hate)] < 0
+			IsEffectInSpell(spell_id, SpellEffect::Hate) &&
+			spells[spell_id].base_value[GetSpellEffectIndex(spell_id, SpellEffect::Hate)] < 0
 		) ||
 		(
-			IsEffectInSpell(spell_id, SE_ReduceHate) &&
-			spells[spell_id].base_value[GetSpellEffectIndex(spell_id, SE_ReduceHate)] < 0
+			IsEffectInSpell(spell_id, SpellEffect::ReduceHate) &&
+			spells[spell_id].base_value[GetSpellEffectIndex(spell_id, SpellEffect::ReduceHate)] < 0
 		)
 	);
 }
@@ -1830,13 +1830,13 @@ bool IsResistDebuffSpell(uint16 spell_id)
 	return (
 		!IsBeneficialSpell(spell_id) &&
 		(
-			IsEffectInSpell(spell_id, SE_ResistFire) ||
-			IsEffectInSpell(spell_id, SE_ResistCold) ||
-			IsEffectInSpell(spell_id, SE_ResistPoison) ||
-			IsEffectInSpell(spell_id, SE_ResistDisease) ||
-			IsEffectInSpell(spell_id, SE_ResistMagic) ||
-			IsEffectInSpell(spell_id, SE_ResistAll) ||
-			IsEffectInSpell(spell_id, SE_ResistCorruption)
+			IsEffectInSpell(spell_id, SpellEffect::ResistFire) ||
+			IsEffectInSpell(spell_id, SpellEffect::ResistCold) ||
+			IsEffectInSpell(spell_id, SpellEffect::ResistPoison) ||
+			IsEffectInSpell(spell_id, SpellEffect::ResistDisease) ||
+			IsEffectInSpell(spell_id, SpellEffect::ResistMagic) ||
+			IsEffectInSpell(spell_id, SpellEffect::ResistAll) ||
+			IsEffectInSpell(spell_id, SpellEffect::ResistCorruption)
 		)
 	);
 }
@@ -1849,10 +1849,10 @@ bool IsSelfConversionSpell(uint16 spell_id)
 
 	return (
 		GetSpellTargetType(spell_id) == ST_Self &&
-		IsEffectInSpell(spell_id, SE_CurrentMana) &&
-		IsEffectInSpell(spell_id, SE_CurrentHP) &&
-		spells[spell_id].base_value[GetSpellEffectIndex(spell_id, SE_CurrentMana)] > 0 &&
-		spells[spell_id].base_value[GetSpellEffectIndex(spell_id, SE_CurrentHP)] < 0
+		IsEffectInSpell(spell_id, SpellEffect::CurrentMana) &&
+		IsEffectInSpell(spell_id, SpellEffect::CurrentHP) &&
+		spells[spell_id].base_value[GetSpellEffectIndex(spell_id, SpellEffect::CurrentMana)] > 0 &&
+		spells[spell_id].base_value[GetSpellEffectIndex(spell_id, SpellEffect::CurrentHP)] < 0
 	);
 }
 
@@ -1896,9 +1896,9 @@ bool IsCastOnFadeDurationSpell(uint16 spell_id)
 {
 	for (int i = 0; i < EFFECT_COUNT; ++i) {
 		if (
-			spells[spell_id].effect_id[i] == SE_CastOnFadeEffect ||
-			spells[spell_id].effect_id[i] == SE_CastOnFadeEffectNPC ||
-			spells[spell_id].effect_id[i] == SE_CastOnFadeEffectAlways
+			spells[spell_id].effect_id[i] == SpellEffect::CastOnFadeEffect ||
+			spells[spell_id].effect_id[i] == SpellEffect::CastOnFadeEffectNPC ||
+			spells[spell_id].effect_id[i] == SpellEffect::CastOnFadeEffectAlways
 		) {
 			return true;
 		}
@@ -1926,7 +1926,7 @@ bool IsDistanceModifierSpell(uint16 spell_id)
 int GetSpellPartialMeleeRuneReduction(uint16 spell_id)
 {
 	for (int i = 0; i < EFFECT_COUNT; ++i) {
-		if (spells[spell_id].effect_id[i] == SE_MitigateMeleeDamage) {
+		if (spells[spell_id].effect_id[i] == SpellEffect::MitigateMeleeDamage) {
 			return spells[spell_id].base_value[i];
 		}
 	}
@@ -1937,7 +1937,7 @@ int GetSpellPartialMeleeRuneReduction(uint16 spell_id)
 int GetSpellPartialMagicRuneReduction(uint16 spell_id)
 {
 	for (int i = 0; i < EFFECT_COUNT; ++i) {
-		if (spells[spell_id].effect_id[i] == SE_MitigateSpellDamage) {
+		if (spells[spell_id].effect_id[i] == SpellEffect::MitigateSpellDamage) {
 			return spells[spell_id].base_value[i];
 		}
 	}
@@ -1948,7 +1948,7 @@ int GetSpellPartialMagicRuneReduction(uint16 spell_id)
 int GetSpellPartialMeleeRuneAmount(uint16 spell_id)
 {
 	for (int i = 0; i < EFFECT_COUNT; ++i) {
-		if (spells[spell_id].effect_id[i] == SE_MitigateMeleeDamage) {
+		if (spells[spell_id].effect_id[i] == SpellEffect::MitigateMeleeDamage) {
 			return spells[spell_id].max_value[i];
 		}
 	}
@@ -1959,7 +1959,7 @@ int GetSpellPartialMeleeRuneAmount(uint16 spell_id)
 int GetSpellPartialMagicRuneAmount(uint16 spell_id)
 {
 	for (int i = 0; i < EFFECT_COUNT; ++i) {
-		if (spells[spell_id].effect_id[i] == SE_MitigateSpellDamage) {
+		if (spells[spell_id].effect_id[i] == SpellEffect::MitigateSpellDamage) {
 			return spells[spell_id].max_value[i];
 		}
 	}
@@ -2002,15 +2002,15 @@ bool IsStackableDOT(uint16 spell_id)
 	}
 
 	return (
-		IsEffectInSpell(spell_id, SE_CurrentHP) ||
-		IsEffectInSpell(spell_id, SE_GravityEffect)
+		IsEffectInSpell(spell_id, SpellEffect::CurrentHP) ||
+		IsEffectInSpell(spell_id, SpellEffect::GravityEffect)
 	);
 }
 
 bool IsBardOnlyStackEffect(int effect_id)
 {
 	switch (effect_id) {
-		case SE_BardAEDot:
+		case SpellEffect::BardAEDot:
 			return true;
 		default:
 			return false;
@@ -2039,91 +2039,91 @@ bool IsEffectIgnoredInStacking(int effect_id)
 {
 	// this should match RoF2
 	switch (effect_id) {
-		case SE_SeeInvis:
-		case SE_DiseaseCounter:
-		case SE_PoisonCounter:
-		case SE_Levitate:
-		case SE_InfraVision:
-		case SE_UltraVision:
-		case SE_CurrentHPOnce:
-		case SE_CurseCounter:
-		case SE_ImprovedDamage:
-		case SE_ImprovedHeal:
-		case SE_SpellResistReduction:
-		case SE_IncreaseSpellHaste:
-		case SE_IncreaseSpellDuration:
-		case SE_IncreaseRange:
-		case SE_SpellHateMod:
-		case SE_ReduceReagentCost:
-		case SE_ReduceManaCost:
-		case SE_FcStunTimeMod:
-		case SE_LimitMaxLevel:
-		case SE_LimitResist:
-		case SE_LimitTarget:
-		case SE_LimitEffect:
-		case SE_LimitSpellType:
-		case SE_LimitSpell:
-		case SE_LimitMinDur:
-		case SE_LimitInstant:
-		case SE_LimitMinLevel:
-		case SE_LimitCastTimeMin:
-		case SE_LimitCastTimeMax:
-		case SE_StackingCommand_Block:
-		case SE_StackingCommand_Overwrite:
-		case SE_PetPowerIncrease:
-		case SE_SkillDamageAmount:
-		case SE_ChannelChanceSpells:
-		case SE_Blank:
-		case SE_FcDamageAmt:
-		case SE_SpellDurationIncByTic:
-		case SE_FcSpellVulnerability:
-		case SE_FcDamageAmtIncoming:
-		case SE_FcDamagePctCrit:
-		case SE_FcDamageAmtCrit:
-		case SE_ReduceReuseTimer:
-		case SE_LimitCombatSkills:
-		case SE_BlockNextSpellFocus:
-		case SE_SpellTrigger:
-		case SE_LimitManaMin:
-		case SE_CorruptionCounter:
-		case SE_ApplyEffect:
-		case SE_NegateSpellEffect:
-		case SE_LimitSpellGroup:
-		case SE_LimitManaMax:
-		case SE_FcHealAmt:
-		case SE_FcHealPctIncoming:
-		case SE_FcHealAmtIncoming:
-		case SE_FcHealPctCritIncoming:
-		case SE_FcHealAmtCrit:
-		case SE_LimitClass:
-		case SE_LimitRace:
-		case SE_FcBaseEffects:
-		case SE_FFItemClass:
-		case SE_SkillDamageAmount2:
-		case SE_FcLimitUse:
-		case SE_FcIncreaseNumHits:
-		case SE_LimitUseMin:
-		case SE_LimitUseType:
-		case SE_GravityEffect:
-		case SE_Display:
+		case SpellEffect::SeeInvis:
+		case SpellEffect::DiseaseCounter:
+		case SpellEffect::PoisonCounter:
+		case SpellEffect::Levitate:
+		case SpellEffect::InfraVision:
+		case SpellEffect::UltraVision:
+		case SpellEffect::CurrentHPOnce:
+		case SpellEffect::CurseCounter:
+		case SpellEffect::ImprovedDamage:
+		case SpellEffect::ImprovedHeal:
+		case SpellEffect::SpellResistReduction:
+		case SpellEffect::IncreaseSpellHaste:
+		case SpellEffect::IncreaseSpellDuration:
+		case SpellEffect::IncreaseRange:
+		case SpellEffect::SpellHateMod:
+		case SpellEffect::ReduceReagentCost:
+		case SpellEffect::ReduceManaCost:
+		case SpellEffect::FcStunTimeMod:
+		case SpellEffect::LimitMaxLevel:
+		case SpellEffect::LimitResist:
+		case SpellEffect::LimitTarget:
+		case SpellEffect::LimitEffect:
+		case SpellEffect::LimitSpellType:
+		case SpellEffect::LimitSpell:
+		case SpellEffect::LimitMinDur:
+		case SpellEffect::LimitInstant:
+		case SpellEffect::LimitMinLevel:
+		case SpellEffect::LimitCastTimeMin:
+		case SpellEffect::LimitCastTimeMax:
+		case SpellEffect::StackingCommand_Block:
+		case SpellEffect::StackingCommand_Overwrite:
+		case SpellEffect::PetPowerIncrease:
+		case SpellEffect::SkillDamageAmount:
+		case SpellEffect::ChannelChanceSpells:
+		case SpellEffect::Blank:
+		case SpellEffect::FcDamageAmt:
+		case SpellEffect::SpellDurationIncByTic:
+		case SpellEffect::FcSpellVulnerability:
+		case SpellEffect::FcDamageAmtIncoming:
+		case SpellEffect::FcDamagePctCrit:
+		case SpellEffect::FcDamageAmtCrit:
+		case SpellEffect::ReduceReuseTimer:
+		case SpellEffect::LimitCombatSkills:
+		case SpellEffect::BlockNextSpellFocus:
+		case SpellEffect::SpellTrigger:
+		case SpellEffect::LimitManaMin:
+		case SpellEffect::CorruptionCounter:
+		case SpellEffect::ApplyEffect:
+		case SpellEffect::NegateSpellEffect:
+		case SpellEffect::LimitSpellGroup:
+		case SpellEffect::LimitManaMax:
+		case SpellEffect::FcHealAmt:
+		case SpellEffect::FcHealPctIncoming:
+		case SpellEffect::FcHealAmtIncoming:
+		case SpellEffect::FcHealPctCritIncoming:
+		case SpellEffect::FcHealAmtCrit:
+		case SpellEffect::LimitClass:
+		case SpellEffect::LimitRace:
+		case SpellEffect::FcBaseEffects:
+		case SpellEffect::FFItemClass:
+		case SpellEffect::SkillDamageAmount2:
+		case SpellEffect::FcLimitUse:
+		case SpellEffect::FcIncreaseNumHits:
+		case SpellEffect::LimitUseMin:
+		case SpellEffect::LimitUseType:
+		case SpellEffect::GravityEffect:
+		case SpellEffect::Display:
 			//Spell effects implemented after ROF2, following same pattern, lets assume these should go here.
-		case SE_Fc_Spell_Damage_Pct_IncomingPC:
-		case SE_Fc_Spell_Damage_Amt_IncomingPC:
-		case SE_Ff_CasterClass:
-		case SE_Ff_Same_Caster:
-		case SE_Proc_Timer_Modifier:
-		case SE_Weapon_Stance:
-		case SE_TwinCastBlocker:
-		case SE_Fc_CastTimeAmt:
-		case SE_Fc_CastTimeMod2:
-		case SE_Ff_DurationMax:
-		case SE_Ff_Endurance_Max:
-		case SE_Ff_Endurance_Min:
-		case SE_Ff_ReuseTimeMin:
-		case SE_Ff_ReuseTimeMax:
-		case SE_Ff_Value_Min:
-		case SE_Ff_Value_Max:
-		case SE_Ff_FocusTimerMin:
+		case SpellEffect::Fc_Spell_Damage_Pct_IncomingPC:
+		case SpellEffect::Fc_Spell_Damage_Amt_IncomingPC:
+		case SpellEffect::Ff_CasterClass:
+		case SpellEffect::Ff_Same_Caster:
+		case SpellEffect::Proc_Timer_Modifier:
+		case SpellEffect::Weapon_Stance:
+		case SpellEffect::TwinCastBlocker:
+		case SpellEffect::Fc_CastTimeAmt:
+		case SpellEffect::Fc_CastTimeMod2:
+		case SpellEffect::Ff_DurationMax:
+		case SpellEffect::Ff_Endurance_Max:
+		case SpellEffect::Ff_Endurance_Min:
+		case SpellEffect::Ff_ReuseTimeMin:
+		case SpellEffect::Ff_ReuseTimeMax:
+		case SpellEffect::Ff_Value_Min:
+		case SpellEffect::Ff_Value_Max:
+		case SpellEffect::Ff_FocusTimerMin:
 			return true;
 		default:
 			return false;
@@ -2133,40 +2133,40 @@ bool IsEffectIgnoredInStacking(int effect_id)
 bool IsFocusLimit(int effect_id)
 {
 	switch (effect_id) {
-		case SE_LimitMaxLevel:
-		case SE_LimitResist:
-		case SE_LimitTarget:
-		case SE_LimitEffect:
-		case SE_LimitSpellType:
-		case SE_LimitSpell:
-		case SE_LimitMinDur:
-		case SE_LimitInstant:
-		case SE_LimitMinLevel:
-		case SE_LimitCastTimeMin:
-		case SE_LimitCastTimeMax:
-		case SE_LimitCombatSkills:
-		case SE_LimitManaMin:
-		case SE_LimitSpellGroup:
-		case SE_LimitManaMax:
-		case SE_LimitSpellClass:
-		case SE_LimitSpellSubclass:
-		case SE_LimitClass:
-		case SE_LimitRace:
-		case SE_LimitCastingSkill:
-		case SE_LimitUseMin:
-		case SE_LimitUseType:
-		case SE_Ff_Override_NotFocusable:
-		case SE_Ff_CasterClass:
-		case SE_Ff_Same_Caster:
-		case SE_Ff_DurationMax:
-		case SE_Ff_Endurance_Max:
-		case SE_Ff_Endurance_Min:
-		case SE_Ff_ReuseTimeMin:
-		case SE_Ff_ReuseTimeMax:
-		case SE_Ff_Value_Min:
-		case SE_Ff_Value_Max:
-		case SE_Ff_FocusTimerMin:
-		case SE_FFItemClass:
+		case SpellEffect::LimitMaxLevel:
+		case SpellEffect::LimitResist:
+		case SpellEffect::LimitTarget:
+		case SpellEffect::LimitEffect:
+		case SpellEffect::LimitSpellType:
+		case SpellEffect::LimitSpell:
+		case SpellEffect::LimitMinDur:
+		case SpellEffect::LimitInstant:
+		case SpellEffect::LimitMinLevel:
+		case SpellEffect::LimitCastTimeMin:
+		case SpellEffect::LimitCastTimeMax:
+		case SpellEffect::LimitCombatSkills:
+		case SpellEffect::LimitManaMin:
+		case SpellEffect::LimitSpellGroup:
+		case SpellEffect::LimitManaMax:
+		case SpellEffect::LimitSpellClass:
+		case SpellEffect::LimitSpellSubclass:
+		case SpellEffect::LimitClass:
+		case SpellEffect::LimitRace:
+		case SpellEffect::LimitCastingSkill:
+		case SpellEffect::LimitUseMin:
+		case SpellEffect::LimitUseType:
+		case SpellEffect::Ff_Override_NotFocusable:
+		case SpellEffect::Ff_CasterClass:
+		case SpellEffect::Ff_Same_Caster:
+		case SpellEffect::Ff_DurationMax:
+		case SpellEffect::Ff_Endurance_Max:
+		case SpellEffect::Ff_Endurance_Min:
+		case SpellEffect::Ff_ReuseTimeMin:
+		case SpellEffect::Ff_ReuseTimeMax:
+		case SpellEffect::Ff_Value_Min:
+		case SpellEffect::Ff_Value_Max:
+		case SpellEffect::Ff_FocusTimerMin:
+		case SpellEffect::FFItemClass:
 			return true;
 		default:
 			return false;
@@ -2192,10 +2192,10 @@ int GetSpellFuriousBash(uint16 spell_id)
 	auto mod                = 0;
 
 	for (int i = 0; i < EFFECT_COUNT; ++i) {
-		if (spells[spell_id].effect_id[i] == SE_SpellHateMod) {
+		if (spells[spell_id].effect_id[i] == SpellEffect::SpellHateMod) {
 			mod = spells[spell_id].base_value[i];
 		} else if (
-			spells[spell_id].effect_id[i] == SE_LimitEffect &&
+			spells[spell_id].effect_id[i] == SpellEffect::LimitEffect &&
 			spells[spell_id].base_value[i] == 999
 		) {
 			found_effect_limit = true;
@@ -2275,47 +2275,47 @@ bool IsInstrumentModifierAppliedToSpellEffect(uint16 spell_id, int effect_id)
 	//Effects that are verified modifiable by bard instrument/singing mods, or highly likely due to similiar type of effect.
 	switch (effect_id) {
 		//Only modify instant endurance or mana effects (Ie. Mana drain, Crescendo line)
-		case SE_CurrentEndurance:
-		case SE_CurrentMana: {
+		case SpellEffect::CurrentEndurance:
+		case SpellEffect::CurrentMana: {
 			return spells[spell_id].buff_duration == 0;
 		}
 
-		case SE_CurrentHP:
-		case SE_ArmorClass:
-		case SE_ACv2:
-		case SE_MovementSpeed:
-		case SE_ATK:
-		case SE_STR:
-		case SE_DEX:
-		case SE_AGI:
-		case SE_STA:
-		case SE_INT:
-		case SE_WIS:
-		case SE_CHA:
-		case SE_AllStats:
-		case SE_ResistFire:
-		case SE_ResistCold:
-		case SE_ResistPoison:
-		case SE_ResistDisease:
-		case SE_ResistMagic:
-		case SE_ResistAll:
-		case SE_ResistCorruption:
-		case SE_Rune:
-		case SE_AbsorbMagicAtt:
-		case SE_DamageShield:
-		case SE_MitigateDamageShield:
-		case SE_Amplification: //On live Amplification is modified by singing mods, including itself.
-		case SE_TripleAttackChance:
-		case SE_Flurry:
-		case SE_DamageModifier:
-		case SE_DamageModifier2:
-		case SE_MinDamageModifier:
-		case SE_ProcChance:
-		case SE_PetFlurry: // ? Need verified
-		case SE_DiseaseCounter:
-		case SE_PoisonCounter:
-		case SE_CurseCounter:
-		case SE_CorruptionCounter:
+		case SpellEffect::CurrentHP:
+		case SpellEffect::ArmorClass:
+		case SpellEffect::ACv2:
+		case SpellEffect::MovementSpeed:
+		case SpellEffect::ATK:
+		case SpellEffect::STR:
+		case SpellEffect::DEX:
+		case SpellEffect::AGI:
+		case SpellEffect::STA:
+		case SpellEffect::INT:
+		case SpellEffect::WIS:
+		case SpellEffect::CHA:
+		case SpellEffect::AllStats:
+		case SpellEffect::ResistFire:
+		case SpellEffect::ResistCold:
+		case SpellEffect::ResistPoison:
+		case SpellEffect::ResistDisease:
+		case SpellEffect::ResistMagic:
+		case SpellEffect::ResistAll:
+		case SpellEffect::ResistCorruption:
+		case SpellEffect::Rune:
+		case SpellEffect::AbsorbMagicAtt:
+		case SpellEffect::DamageShield:
+		case SpellEffect::MitigateDamageShield:
+		case SpellEffect::Amplification: //On live Amplification is modified by singing mods, including itself.
+		case SpellEffect::TripleAttackChance:
+		case SpellEffect::Flurry:
+		case SpellEffect::DamageModifier:
+		case SpellEffect::DamageModifier2:
+		case SpellEffect::MinDamageModifier:
+		case SpellEffect::ProcChance:
+		case SpellEffect::PetFlurry: // ? Need verified
+		case SpellEffect::DiseaseCounter:
+		case SpellEffect::PoisonCounter:
+		case SpellEffect::CurseCounter:
+		case SpellEffect::CorruptionCounter:
 			return true;
 
 		/*
@@ -2323,45 +2323,45 @@ bool IsInstrumentModifierAppliedToSpellEffect(uint16 spell_id, int effect_id)
 			Focus Effects, Proc Effects, Spell Triggers are not modified but handled elsewhere, not neccessary to checked here.
 		*/
 
-		case SE_AttackSpeed: //(Haste AND Slow not modifiable)
-		case SE_AttackSpeed2:
-		case SE_AttackSpeed3:
-		case SE_Lull:
-		case SE_ChangeFrenzyRad:
-		case SE_Harmony:
-		case SE_AddFaction:
-		//case SE_CurrentMana: // duration only
-		case SE_ManaRegen_v2:
-		//case SE_CurrentEndurance: // duration only
-		case SE_PersistentEffect:
-		case SE_ReduceReuseTimer:
-		case SE_Stun:
-		case SE_Mez:
-		case SE_WipeHateList: //?
-		case SE_CancelMagic:
-		case SE_ManaAbsorbPercentDamage:
-		case SE_ResistSpellChance:
-		case SE_Reflect:
-		case SE_MitigateSpellDamage:
-		case SE_MitigateMeleeDamage:
-		case SE_AllInstrumentMod:
-		case SE_AddSingingMod:
-		case SE_SongModCap:
-		case SE_BardSongRange:
-		case SE_TemporaryPets:
-		case SE_SpellOnDeath:
-		case SE_Invisibility:
-		case SE_Invisibility2:
-		case SE_InvisVsUndead:
-		case SE_InvisVsUndead2:
-		case SE_InvisVsAnimals:
-		case SE_ImprovedInvisAnimals:
-		case SE_SeeInvis:
-		case SE_Levitate:
-		case SE_WaterBreathing:
-		case SE_ModelSize:
-		case SE_ChangeHeight:
-		case SE_MakeDrunk:
+		case SpellEffect::AttackSpeed: //(Haste AND Slow not modifiable)
+		case SpellEffect::AttackSpeed2:
+		case SpellEffect::AttackSpeed3:
+		case SpellEffect::Lull:
+		case SpellEffect::ChangeFrenzyRad:
+		case SpellEffect::Harmony:
+		case SpellEffect::AddFaction:
+		//case SpellEffect::CurrentMana: // duration only
+		case SpellEffect::ManaRegen_v2:
+		//case SpellEffect::CurrentEndurance: // duration only
+		case SpellEffect::PersistentEffect:
+		case SpellEffect::ReduceReuseTimer:
+		case SpellEffect::Stun:
+		case SpellEffect::Mez:
+		case SpellEffect::WipeHateList: //?
+		case SpellEffect::CancelMagic:
+		case SpellEffect::ManaAbsorbPercentDamage:
+		case SpellEffect::ResistSpellChance:
+		case SpellEffect::Reflect:
+		case SpellEffect::MitigateSpellDamage:
+		case SpellEffect::MitigateMeleeDamage:
+		case SpellEffect::AllInstrumentMod:
+		case SpellEffect::AddSingingMod:
+		case SpellEffect::SongModCap:
+		case SpellEffect::BardSongRange:
+		case SpellEffect::TemporaryPets:
+		case SpellEffect::SpellOnDeath:
+		case SpellEffect::Invisibility:
+		case SpellEffect::Invisibility2:
+		case SpellEffect::InvisVsUndead:
+		case SpellEffect::InvisVsUndead2:
+		case SpellEffect::InvisVsAnimals:
+		case SpellEffect::ImprovedInvisAnimals:
+		case SpellEffect::SeeInvis:
+		case SpellEffect::Levitate:
+		case SpellEffect::WaterBreathing:
+		case SpellEffect::ModelSize:
+		case SpellEffect::ChangeHeight:
+		case SpellEffect::MakeDrunk:
 			return false;
 		default:
 			return true;
@@ -2379,8 +2379,8 @@ bool IsPulsingBardSong(uint16 spell_id)
 		spells[spell_id].buff_duration == 0xFFFF ||
 		spells[spell_id].recast_time > 0 ||
 		spells[spell_id].mana > 0 ||
-		IsEffectInSpell(spell_id, SE_TemporaryPets) ||
-		IsEffectInSpell(spell_id, SE_Familiar)
+		IsEffectInSpell(spell_id, SpellEffect::TemporaryPets) ||
+		IsEffectInSpell(spell_id, SpellEffect::Familiar)
 	) {
 		return false;
 	}
@@ -2555,28 +2555,28 @@ int GetSpellProcLimitTimer(uint16 spell_id, int proc_type)
 
 		if (proc_type == ProcType::MELEE_PROC) {
 			if (
-				spells[spell_id].effect_id[i] == SE_WeaponProc ||
-				spells[spell_id].effect_id[i] == SE_AddMeleeProc
+				spells[spell_id].effect_id[i] == SpellEffect::WeaponProc ||
+				spells[spell_id].effect_id[i] == SpellEffect::AddMeleeProc
 			) {
 				use_next_timer = true;
 			}
 		}
 
 		if (proc_type == ProcType::RANGED_PROC) {
-			if (spells[spell_id].effect_id[i] == SE_RangedProc) {
+			if (spells[spell_id].effect_id[i] == SpellEffect::RangedProc) {
 				use_next_timer = true;
 			}
 		}
 
 		if (proc_type == ProcType::DEFENSIVE_PROC) {
-			if (spells[spell_id].effect_id[i] == SE_DefensiveProc) {
+			if (spells[spell_id].effect_id[i] == SpellEffect::DefensiveProc) {
 				use_next_timer = true;
 			}
 		}
 
 		if (
 			use_next_timer &&
-			spells[spell_id].effect_id[i] == SE_Proc_Timer_Modifier
+			spells[spell_id].effect_id[i] == SpellEffect::Proc_Timer_Modifier
 		) {
 			return spells[spell_id].limit_value[i];
 		}
@@ -2683,23 +2683,23 @@ bool IsAegolismSpell(uint16 spell_id) {
 
 	for (int i = 0; i < EFFECT_COUNT; ++i) {
 
-		if (i == 0 && spells[spell_id].effect_id[i] != SE_StackingCommand_Block) {
+		if (i == 0 && spells[spell_id].effect_id[i] != SpellEffect::StackingCommand_Block) {
 			return 0;
 		}
 
-		if (i == 1 && spells[spell_id].effect_id[i] == SE_TotalHP) {
+		if (i == 1 && spells[spell_id].effect_id[i] == SpellEffect::TotalHP) {
 			has_max_hp = true;
 		}
 
-		if (i == 2 && spells[spell_id].effect_id[i] == SE_CurrentHPOnce) {
+		if (i == 2 && spells[spell_id].effect_id[i] == SpellEffect::CurrentHPOnce) {
 			has_current_hp = true;
 		}
 
-		if (i == 3 && spells[spell_id].effect_id[i] == SE_ArmorClass) {
+		if (i == 3 && spells[spell_id].effect_id[i] == SpellEffect::ArmorClass) {
 			has_ac = true;
 		}
 
-		if (i == 4 && spells[spell_id].effect_id[i] != SE_StackingCommand_Overwrite) {
+		if (i == 4 && spells[spell_id].effect_id[i] != SpellEffect::StackingCommand_Overwrite) {
 			return 0;
 		}
 	}
@@ -2726,16 +2726,16 @@ bool AegolismStackingIsSymbolSpell(uint16 spell_id) {
 
 	for (int i = 0; i < EFFECT_COUNT; ++i) {
 
-		if ((i < 2 && spells[spell_id].effect_id[i] != SE_CHA) ||
-			i > 3 && spells[spell_id].effect_id[i] != SE_Blank) {
+		if ((i < 2 && spells[spell_id].effect_id[i] != SpellEffect::CHA) ||
+			i > 3 && spells[spell_id].effect_id[i] != SpellEffect::Blank) {
 			return 0;
 		}
 
-		if (i == 2 && spells[spell_id].effect_id[i] == SE_TotalHP) {
+		if (i == 2 && spells[spell_id].effect_id[i] == SpellEffect::TotalHP) {
 			has_max_hp = true;
 		}
 
-		if (i == 3 && spells[spell_id].effect_id[i] == SE_CurrentHPOnce) {
+		if (i == 3 && spells[spell_id].effect_id[i] == SpellEffect::CurrentHPOnce) {
 			has_current_hp = true;
 		}
 	}
@@ -2759,12 +2759,12 @@ bool AegolismStackingIsArmorClassSpell(uint16 spell_id) {
 
 	for (int i = 0; i < EFFECT_COUNT; ++i) {
 
-		if ((i < 3 && spells[spell_id].effect_id[i] != SE_CHA) ||
-			i > 3 && spells[spell_id].effect_id[i] != SE_Blank) {
+		if ((i < 3 && spells[spell_id].effect_id[i] != SpellEffect::CHA) ||
+			i > 3 && spells[spell_id].effect_id[i] != SpellEffect::Blank) {
 			return 0;
 		}
 
-		if (i == 3 && spells[spell_id].effect_id[i] == SE_ArmorClass) {
+		if (i == 3 && spells[spell_id].effect_id[i] == SpellEffect::ArmorClass) {
 			has_ac = true;
 		}
 	}
@@ -2800,10 +2800,10 @@ bool IsLichSpell(uint16 spell_id)
 
 	return (
 		GetSpellTargetType(spell_id) == ST_Self &&
-		IsEffectInSpell(spell_id, SE_CurrentMana) &&
-		IsEffectInSpell(spell_id, SE_CurrentHP) &&
-		spells[spell_id].base_value[GetSpellEffectIndex(spell_id, SE_CurrentMana)] > 0 &&
-		spells[spell_id].base_value[GetSpellEffectIndex(spell_id, SE_CurrentHP)] < 0 &&
+		IsEffectInSpell(spell_id, SpellEffect::CurrentMana) &&
+		IsEffectInSpell(spell_id, SpellEffect::CurrentHP) &&
+		spells[spell_id].base_value[GetSpellEffectIndex(spell_id, SpellEffect::CurrentMana)] > 0 &&
+		spells[spell_id].base_value[GetSpellEffectIndex(spell_id, SpellEffect::CurrentHP)] < 0 &&
 		spells[spell_id].buff_duration > 0
 	);
 }
@@ -2828,7 +2828,7 @@ bool IsResurrectSpell(uint16 spell_id)
 		return false;
 	}
 
-	return IsEffectInSpell(spell_id, SE_Revive);
+	return IsEffectInSpell(spell_id, SpellEffect::Revive);
 }
 
 bool IsResistanceBuffSpell(uint16 spell_id) {
@@ -2844,13 +2844,13 @@ bool IsResistanceBuffSpell(uint16 spell_id) {
 		}
 
 		if (
-			spell.effect_id[i] == SE_ResistFire ||
-			spell.effect_id[i] == SE_ResistCold ||
-			spell.effect_id[i] == SE_ResistPoison ||
-			spell.effect_id[i] == SE_ResistDisease ||
-			spell.effect_id[i] == SE_ResistMagic ||
-			spell.effect_id[i] == SE_ResistCorruption ||
-			spell.effect_id[i] == SE_ResistAll
+			spell.effect_id[i] == SpellEffect::ResistFire ||
+			spell.effect_id[i] == SpellEffect::ResistCold ||
+			spell.effect_id[i] == SpellEffect::ResistPoison ||
+			spell.effect_id[i] == SpellEffect::ResistDisease ||
+			spell.effect_id[i] == SpellEffect::ResistMagic ||
+			spell.effect_id[i] == SpellEffect::ResistCorruption ||
+			spell.effect_id[i] == SpellEffect::ResistAll
 		) {
 			return true;
 		}
@@ -2872,13 +2872,13 @@ bool IsResistanceOnlySpell(uint16 spell_id) {
 		}
 
 		if (
-			spell.effect_id[i] == SE_ResistFire ||
-			spell.effect_id[i] == SE_ResistCold ||
-			spell.effect_id[i] == SE_ResistPoison ||
-			spell.effect_id[i] == SE_ResistDisease ||
-			spell.effect_id[i] == SE_ResistMagic ||
-			spell.effect_id[i] == SE_ResistCorruption ||
-			spell.effect_id[i] == SE_ResistAll
+			spell.effect_id[i] == SpellEffect::ResistFire ||
+			spell.effect_id[i] == SpellEffect::ResistCold ||
+			spell.effect_id[i] == SpellEffect::ResistPoison ||
+			spell.effect_id[i] == SpellEffect::ResistDisease ||
+			spell.effect_id[i] == SpellEffect::ResistMagic ||
+			spell.effect_id[i] == SpellEffect::ResistCorruption ||
+			spell.effect_id[i] == SpellEffect::ResistAll
 		) {
 			continue;
 		}
@@ -2902,7 +2902,7 @@ bool IsDamageShieldOnlySpell(uint16 spell_id) {
 		}
 
 		if (
-			spell.effect_id[i] != SE_DamageShield
+			spell.effect_id[i] != SpellEffect::DamageShield
 		) {
 			return false;
 		}
@@ -2924,14 +2924,14 @@ bool IsDamageShieldAndResistSpell(uint16 spell_id) {
 		}
 
 		if (
-			spell.effect_id[i] != SE_DamageShield &&
-			spell.effect_id[i] != SE_ResistFire &&
-			spell.effect_id[i] != SE_ResistCold &&
-			spell.effect_id[i] != SE_ResistPoison &&
-			spell.effect_id[i] != SE_ResistDisease &&
-			spell.effect_id[i] != SE_ResistMagic &&
-			spell.effect_id[i] != SE_ResistCorruption &&
-			spell.effect_id[i] != SE_ResistAll
+			spell.effect_id[i] != SpellEffect::DamageShield &&
+			spell.effect_id[i] != SpellEffect::ResistFire &&
+			spell.effect_id[i] != SpellEffect::ResistCold &&
+			spell.effect_id[i] != SpellEffect::ResistPoison &&
+			spell.effect_id[i] != SpellEffect::ResistDisease &&
+			spell.effect_id[i] != SpellEffect::ResistMagic &&
+			spell.effect_id[i] != SpellEffect::ResistCorruption &&
+			spell.effect_id[i] != SpellEffect::ResistAll
 		) {
 			return false;
 		}
@@ -2947,12 +2947,12 @@ bool IsHateSpell(uint16 spell_id) {
 
 	return (
 		(
-			IsEffectInSpell(spell_id, SE_Hate) &&
-			spells[spell_id].base_value[GetSpellEffectIndex(spell_id, SE_Hate)] > 0
+			IsEffectInSpell(spell_id, SpellEffect::Hate) &&
+			spells[spell_id].base_value[GetSpellEffectIndex(spell_id, SpellEffect::Hate)] > 0
 		) ||
 		(
-			IsEffectInSpell(spell_id, SE_InstantHate) &&
-			spells[spell_id].base_value[GetSpellEffectIndex(spell_id, SE_InstantHate)] > 0
+			IsEffectInSpell(spell_id, SpellEffect::InstantHate) &&
+			spells[spell_id].base_value[GetSpellEffectIndex(spell_id, SpellEffect::InstantHate)] > 0
 		)
 	);
 }

--- a/common/spdat.h
+++ b/common/spdat.h
@@ -1059,537 +1059,536 @@ typedef enum {
 //Spell Effect IDs
 // https://web.archive.org/web/20250816011656/https://forums.everquest.com/index.php?threads/enumerated-spa-list.206288/
 // mirror: http://pastebin.com/MYeQqGwe
-#define SE_CurrentHP					0	// implemented - Heals and nukes, repeates every tic if in a buff
-#define SE_ArmorClass					1	// implemented
-#define SE_ATK							2	// implemented
-#define SE_MovementSpeed				3	// implemented - SoW, SoC, etc
-#define SE_STR							4	// implemented
-#define SE_DEX							5	// implemented
-#define SE_AGI							6	// implemented
-#define SE_STA							7	// implemented
-#define SE_INT							8	// implemented
-#define SE_WIS							9	// implemented
-#define SE_CHA							10	// implemented - used as a spacer
-#define SE_AttackSpeed					11	// implemented
-#define SE_Invisibility					12	// implemented - TO DO: Implemented Invisiblity Levels
-#define SE_SeeInvis						13	// implemented - TO DO: Implemented See Invisiblity Levels
-#define SE_WaterBreathing				14	// implemented
-#define SE_CurrentMana					15	// implemented
-//#define SE_NPCFrenzy					16	// not used
-//#define SE_NPCAwareness				17	// not used
-#define SE_Lull							18	// implemented - Reaction Radius
-#define SE_AddFaction					19	// implemented - Alliance line
-#define SE_Blind						20	// implemented
-#define SE_Stun							21	// implemented
-#define SE_Charm						22	// implemented
-#define SE_Fear							23	// implemented
-#define SE_Stamina						24	// implemented - Invigor and such
-#define SE_BindAffinity					25	// implemented - TO DO: Implement 2nd and 3rd Recall (value 2,3 ect). Sets additional bind points.
-#define SE_Gate							26	// implemented - Gate to bind point
-#define SE_CancelMagic					27	// implemented
-#define SE_InvisVsUndead				28	// implemented
-#define SE_InvisVsAnimals				29	// implemented
-#define SE_ChangeFrenzyRad				30	// implemented - Pacify
-#define SE_Mez							31	// implemented
-#define SE_SummonItem					32	// implemented
-#define SE_SummonPet					33	// implemented
-//#define SE_Confuse					34	// not used (Nimbus of Temporal Rifting) ?
-#define SE_DiseaseCounter				35	// implemented
-#define SE_PoisonCounter				36	// implemented
-//#define SE_DetectHostile				37	// not used
-//#define SE_DetectMagic				38	// not used
-#define SE_TwinCastBlocker				39	// implemented - If present in spell, then the spell can not be twincast.
-#define SE_DivineAura					40	// implemented
-#define SE_Destroy						41	// implemented - Disintegrate, Banishment of Shadows
-#define SE_ShadowStep					42	// implemented
-#define SE_Berserk						43	// implemented (*not used in any known live spell) Makes client 'Berserk' giving crip blow chance.
-#define SE_Lycanthropy					44	// implemented
-#define SE_Vampirism					45	// implemented (*not used in any known live spell) Stackable lifetap from melee.
-#define SE_ResistFire					46	// implemented
-#define SE_ResistCold					47	// implemented
-#define SE_ResistPoison					48	// implemented
-#define SE_ResistDisease				49	// implemented
-#define SE_ResistMagic					50	// implemented
-//#define SE_DetectTraps				51	// not used
-#define SE_SenseDead					52	// implemented
-#define SE_SenseSummoned				53	// implemented
-#define SE_SenseAnimals					54	// implemented
-#define SE_Rune							55	// implemented
-#define SE_TrueNorth					56	// implemented
-#define SE_Levitate						57	// implemented
-#define SE_Illusion						58	// implemented
-#define SE_DamageShield					59	// implemented
-//#define SE_TransferItem				60	// not used
-#define SE_Identify						61	// implemented
-//#define SE_ItemID						62	// not used
-#define SE_WipeHateList					63	// implemented, @Memblur, chance to wipe hate list of target, base: pct chance, limit: none, max: ? (not implemented), Note: caster level and CHA add to pct chance
-#define SE_SpinTarget					64	// implemented - TO DO: Not sure stun portion is working correctly
-#define SE_InfraVision					65	// implemented
-#define SE_UltraVision					66	// implemented
-#define SE_EyeOfZomm					67	// implemented
-#define SE_ReclaimPet					68	// implemented
-#define SE_TotalHP						69	// implemented
-//#define SE_CorpseBomb					70	// not used
-#define SE_NecPet						71	// implemented
-//#define SE_PreserveCorpse				72	// not used
-#define SE_BindSight					73	// implemented, @Vision, see through the eyes of your target, click off buff to end effect, base: 1, limit: none, max: none
-#define SE_FeignDeath					74	// implemented
-#define SE_VoiceGraft					75	// implemented
-#define SE_Sentinel						76	// *not implemented?(just seems to send a message)
-#define SE_LocateCorpse					77	// implemented
-#define SE_AbsorbMagicAtt				78	// implemented - Rune for spells
-#define SE_CurrentHPOnce				79	// implemented - Heals and nukes, non-repeating if in a buff
-//#define SE_EnchantLight				80	// not used
-#define SE_Revive						81	// implemented - Resurrect
-#define SE_SummonPC						82	// implemented
-#define SE_Teleport						83	// implemented
-#define SE_TossUp						84	// implemented - Gravity Flux
-#define SE_WeaponProc					85	// implemented - i.e. Call of Fire
-#define SE_Harmony						86	// implemented
-#define SE_MagnifyVision				87	// implemented - Telescope
-#define SE_Succor						88	// implemented - Evacuate/Succor lines
-#define SE_ModelSize					89	// implemented - Shrink, Growth
-//#define SE_Cloak						90	// *not implemented - Used in only 2 spells
-#define SE_SummonCorpse					91	// implemented
-#define SE_InstantHate					92	// implemented - add hate
-#define SE_StopRain						93	// implemented - Wake of Karana
-#define SE_NegateIfCombat				94	// implemented
-#define SE_Sacrifice					95	// implemented
-#define SE_Silence						96	// implemented
-#define SE_ManaPool						97	// implemented
-#define SE_AttackSpeed2					98	// implemented - Melody of Ervaj
-#define SE_Root							99	// implemented
-#define SE_HealOverTime					100	// implemented
-#define SE_CompleteHeal					101	// implemented
-#define SE_Fearless						102	// implemented - Valiant Companion
-#define SE_CallPet						103	// implemented - Summon Companion
-#define SE_Translocate					104	// implemented
-#define SE_AntiGate						105	// implemented - Translocational Anchor
-#define SE_SummonBSTPet					106	// implemented
-#define SE_AlterNPCLevel				107	// implemented - not used on live
-#define SE_Familiar						108	// implemented
-#define SE_SummonItemIntoBag			109	// implemented - summons stuff into container
-#define SE_IncreaseArchery				110	// implemented
-#define SE_ResistAll					111	// implemented - Note: Physical Resists are not modified by this effect.
-#define SE_CastingLevel					112	// implemented
-#define	SE_SummonHorse					113	// implemented
-#define SE_ChangeAggro					114	// implemented - Hate modifing buffs(ie horrifying visage)
-#define SE_Hunger						115	// implemented - Song of Sustenance
-#define SE_CurseCounter					116	// implemented
-#define SE_MagicWeapon					117	// implemented - makes weapon magical
-#define SE_Amplification				118	// implemented, @Song, stackable singing mod, base: mod%, limit: none, max: none, Note: Can focus itself.
-#define SE_AttackSpeed3					119	// implemented
-#define SE_HealRate						120	// implemented - reduces healing by a %
-#define SE_ReverseDS					121 // implemented
-#define SE_ReduceSkill					122	// implemented - base: skill id, limit: none, max: none, formula: % skill is reduced (positive)
-#define SE_Screech						123	// implemented Spell Blocker(If have buff with value +1 will block any effect with -1)
-#define SE_ImprovedDamage				124 // implemented
-#define SE_ImprovedHeal					125 // implemented
-#define SE_SpellResistReduction			126 // implemented
-#define SE_IncreaseSpellHaste			127 // implemented, @Fc, On Caster, cast time mod pct, base: pct
-#define SE_IncreaseSpellDuration		128 // implemented, @Fc, On Caster, spell duration mod pct, base: pct
-#define SE_IncreaseRange				129 // implemented, @Fc, On Caster, spell range mod pct, base: pct
-#define SE_SpellHateMod					130 // implemented, @Fc, On Caster, spell hate mod pct, base: min pct, limit: max pct
-#define SE_ReduceReagentCost			131 // implemented, @Fc, On Caster, do not consume reagent pct chance, base: min pct, limit: max pct
-#define SE_ReduceManaCost				132 // implemented, @Fc, On Caster, reduce mana cost by pct, base: min pct, limt: max pct
-#define SE_FcStunTimeMod				133	// implemented, @Fc, On Caster, spell range mod pct, base: pct
-#define SE_LimitMaxLevel				134 // implemented, @Ff, Max level of spell that can be focused, if base2 then decrease effectiviness by base2 % per level over max, base:  lv, base2: effectiveness pct
-#define SE_LimitResist					135 // implemented, @Ff, Resist Type(s) that a spell focus can require or exclude, base1: resist type, Include: Positive Exclude: Negative
-#define SE_LimitTarget					136 // implemented, @Ff, Target Type(s) that a spell focus can require or exclude, base1: target type, Include: Positive Exclude: Negative
-#define SE_LimitEffect					137 // implemented, @Ff, Spell effect(s) that a spell focus can require or exclude, base1: SPA id, Include: Positive Exclude: Negative
-#define SE_LimitSpellType				138 // implemented, @Ff, Only allow focus spells that are Beneficial or Detrimental, base1: 0=det 1=bene
-#define SE_LimitSpell					139 // implemented, @Ff, Specific spell id(s) that a spell focus can require or exclude, base1: SPA id, Include: Positive Exclude: Negative
-#define SE_LimitMinDur					140 // implemented, @Ff, Mininum duration of spell that can be focused, base1: tics
-#define SE_LimitInstant					141 // implemented, @Ff, Include or exclude if an isntant cast spell can be focused, base1: 0=Exclude if Instant 1=Allow only if Instant
-#define SE_LimitMinLevel				142 // implemented, @Ff, Mininum level of spell that can be focused, base1: lv
-#define SE_LimitCastTimeMin				143 // implemented, @Ff, Mininum cast time of spell that can be focused, base1: milliseconds
-#define SE_LimitCastTimeMax				144	// implemented, @Ff, Max cast time of spell that can be focused, base1: milliseconds
-#define SE_Teleport2					145	// implemented - Banishment of the Pantheon
-//#define SE_ElectricityResist			146	// *not implemented TODO: Now used on live, xyz for teleport spells? also in temp pets?
-#define SE_PercentalHeal				147 // implemented
-#define SE_StackingCommand_Block		148 // implemented?
-#define SE_StackingCommand_Overwrite	149 // implemented?
-#define SE_DeathSave					150 // implemented
-#define SE_SuspendPet					151	// implemented, @Pet, allow caster to have an extra suspended pet, base: 0=no buffs/items 1=buffs+items, limit: none, max: none
-#define SE_TemporaryPets				152	// implemented
-#define SE_BalanceHP					153 // implemented
-#define SE_DispelDetrimental			154 // implemented, @Dispel, removes only detrimental effects on a target, base: pct chance (950=95%), limit: none, max: none
-#define SE_SpellCritDmgIncrease			155 // implemented - no known live spells use this currently
-#define SE_IllusionCopy					156	// implemented - Deception
-#define SE_SpellDamageShield			157	// implemented, @DS, causes non-melee damage on caster of a spell, base: Amt DS (negative), limit: none, max: unknown (same as base but +)
-#define SE_Reflect						158 // implemented, @SpellMisc, reflect casted detrimental spell back at caster, base: chance pct, limit: resist modifier (positive value reduces resists), max: pct of base dmg mod (50=50pct of base)
-#define SE_AllStats						159	// implemented
-#define SE_MakeDrunk					160 // *not implemented - Effect works entirely client side (Should check against tolerance)
-#define SE_MitigateSpellDamage			161	// implemented, @Runes, mitigate incoming spell damage by percentage until rune fades, base: percent mitigation, limit: max dmg absorbed per hit, max: rune amt, Note: If placed on item or AA, will provide stackable percent mitigation.
-#define SE_MitigateMeleeDamage			162	// implemented - rune with max value
-#define SE_NegateAttacks				163	// implemented
-#define SE_AppraiseLDonChest			164	// implemented
-#define SE_DisarmLDoNTrap				165	// implemented
-#define SE_UnlockLDoNChest				166	// implemented
-#define SE_PetPowerIncrease				167 // implemented, @Fc, On Caster, pet power mod, base: value
-#define SE_MeleeMitigation				168	// implemented
-#define SE_CriticalHitChance			169	// implemented
-#define SE_SpellCritChance				170	// implemented
-#define SE_CrippBlowChance				171	// implemented
-#define SE_AvoidMeleeChance				172	// implemented
-#define SE_RiposteChance				173	// implemented
-#define SE_DodgeChance					174	// implemented
-#define SE_ParryChance					175	// implemented
-#define SE_DualWieldChance				176	// implemented
-#define SE_DoubleAttackChance			177	// implemented
-#define SE_MeleeLifetap					178	// implemented
-#define SE_AllInstrumentMod				179	// implemented, @Song, set mod for ALL instrument/singing skills that will be used if higher then item mods, base: mod%, limit: none, max: none
-#define SE_ResistSpellChance			180	// implemented
-#define SE_ResistFearChance				181	// implemented
-#define SE_HundredHands					182	// implemented
-#define SE_MeleeSkillCheck				183	// implemented
-#define SE_HitChance					184	// implemented
-#define SE_DamageModifier				185	// implemented
-#define SE_MinDamageModifier			186	// implemented
-#define SE_BalanceMana					187	// implemented - Balances party mana
-#define SE_IncreaseBlockChance			188	// implemented
-#define SE_CurrentEndurance				189	// implemented
-#define SE_EndurancePool				190	// implemented
-#define SE_Amnesia						191	// implemented - Silence vs Melee Effect
-#define SE_Hate							192	// implemented - Instant and hate over time.
-#define SE_SkillAttack					193	// implemented,
-#define SE_FadingMemories				194	// implemented, @Aggro, Remove from hate lists and make invisible. Can set max level of NPCs that can be affected. base: success chance, limit: max level (ROF2), max: max level (modern client), Note: Support for max level requires Rule (Spells, UseFadingMemoriesMaxLevel) to be true. If used from limit field, then it set as the level, ie. max level of 75 would use limit value of 75. If set from max field, max level 75 would use max value of 1075, if you want to set it so it checks a level range above the spell target then for it to only work on mobs 5 levels or below you set max value to 5.
-#define SE_StunResist					195	// implemented
-#define SE_StrikeThrough				196	// implemented
-#define SE_SkillDamageTaken				197	// implemented
-#define SE_CurrentEnduranceOnce			198	// implemented
-#define SE_Taunt						199	// implemented - % chance to taunt the target
-#define SE_ProcChance					200	// implemented
-#define SE_RangedProc					201	// implemented
-#define SE_IllusionOther				202	// implemented - Project Illusion
-#define SE_MassGroupBuff				203	// implemented
-#define SE_GroupFearImmunity			204	// implemented - (Does not use bonus)
-#define SE_Rampage						205	// implemented, @Combat Instant, Perform a primary slot combat rounds on all creatures within a 40 foot radius, base: number of attack rounds, limit: max entities hit per round, max: none, Note: AE range is 40 by default. Custom: Set field 'aoe_range' to override default. Adding additional attacks and hit count limit.
-#define SE_AETaunt						206	// implemented
-#define SE_FleshToBone					207	// implemented
-//#define SE_PurgePoison				208	// not used
-#define SE_DispelBeneficial				209 // implemented, @Dispel, removes only beneficial effects on a target, base: pct chance (950=95%), limit: none, max: none
-#define SE_PetShield					210	// implmented, @ShieldAbility, allows pet to 'shield' owner for 50 pct of damage taken for a duration, base: Time multiplier 1=12 seconds, 2=24 ect, limit: mitigation on pet owner override (not on live), max: mitigation on pet overide (not on live)
-#define SE_AEMelee						211	// implemented TO DO: Implement to allow NPC use (client only atm).
-#define SE_FrenziedDevastation			212	// implemented - increase spell criticals + all DD spells cast 2x mana.
-#define SE_PetMaxHP						213	// implemented[AA] - increases the maximum hit points of your pet
-#define SE_MaxHPChange					214	// implemented
-#define SE_PetAvoidance					215	// implemented[AA] - increases pet ability to avoid melee damage
-#define SE_Accuracy						216	// implemented
-#define SE_HeadShot						217	// implemented - ability to head shot (base2 = damage)
-#define SE_PetCriticalHit				218 // implemented[AA] - gives pets a baseline critical hit chance
-#define SE_SlayUndead					219	// implemented - Allow extra damage against undead (base1 = rate, base2 = damage mod).
-#define SE_SkillDamageAmount			220	// implemented
-#define SE_Packrat						221 // implemented as bonus
-#define SE_BlockBehind					222	// implemented - Chance to block from behind (with our without Shield)
-#define SE_DoubleRiposte				223	// implemented - Chance to double riposte [not used on live]
-#define	SE_GiveDoubleRiposte			224 // implemented[AA]
-#define SE_GiveDoubleAttack				225	// implemented[AA] - Allow any class to double attack with set chance.
-#define SE_TwoHandBash					226 // *not implemented as bonus
-#define SE_ReduceSkillTimer				227	// implemented
-#define SE_ReduceFallDamage				228	// implented - reduce the damage that you take from falling
-#define SE_PersistantCasting			229 // implemented
-#define SE_ExtendedShielding			230	// implemented, @ShieldAbility, extends the range of your /shield ability by an amount of distance, base: distance units, limit: none, max: none
-#define SE_StunBashChance				231	// implemented - increase chance to stun from bash.
-#define SE_DivineSave					232	// implemented (base1 == % chance on death to insta-res) (base2 == spell cast on save)
-#define SE_Metabolism					233	// implemented - Modifies food/drink consumption rates.
-#define SE_ReduceApplyPoisonTime		234	// not implemented as bonus - reduces the time to apply poison
-#define	SE_ChannelChanceSpells			235 // implemented[AA] - chance to channel from SPELLS *No longer used on live.
-//#define SE_FreePet					236	// not used
-#define SE_GivePetGroupTarget			237 // implemented[AA] - (Pet Affinity)
-#define SE_IllusionPersistence			238	// implemented - lends persistence to your illusionary disguises, causing them to last until you die or the illusion is forcibly removed.
-#define SE_FeignedCastOnChance			239	// implemented - ability gives you an increasing chance for your feigned deaths to not be revealed by spells cast upon you.
-//#define SE_StringUnbreakable			240	// not used [Likely related to above - you become immune to feign breaking on a resisted spell and have a good chance of feigning through a spell that successfully lands upon you.]
-#define SE_ImprovedReclaimEnergy		241	// implemented - increase the amount of mana returned to you when reclaiming your pet.
-#define SE_IncreaseChanceMemwipe		242	// implemented - @Memblur, increases the chance to wipe hate with memory blurr, base: chance pct, limit: none, max: none, Note: Mods final blur chance after other bonuses added.
-#define SE_CharmBreakChance				243	// implemented - Total Domination
-#define	SE_RootBreakChance				244	// implemented[AA] reduce the chance that your root will break.
-#define SE_TrapCircumvention			245	// implemented, @Traps, decreases the chance that you will set off a trap when opening a chest or other similar container by percentage, base: chance modifer, limit: none, max: none
-#define SE_SetBreathLevel				246 // *not implemented as bonus
-#define SE_RaiseSkillCap				247	// implemented[AA] - adds skill over the skill cap.
-#define SE_SecondaryForte				248 // not implemented as bonus(gives you a 2nd specialize skill that can go past 50 to 100)
-#define SE_SecondaryDmgInc				249 // implemented[AA] Allows off hand weapon to recieve a damage bonus (Sinister Strikes)
-#define SE_SpellProcChance				250	// implemented - Increase chance to proc from melee proc spells (ie Spirit of Panther)
-#define SE_ConsumeProjectile			251	// implemented[AA] - chance to not consume an arrow (ConsumeProjectile = 100)
-#define SE_FrontalBackstabChance		252	// implemented[AA] - chance to perform a full damage backstab from front.
-#define SE_FrontalBackstabMinDmg		253	// implemented[AA] - allow a frontal backstab for mininum damage.
-#define SE_Blank						254 // implemented
-#define SE_ShieldDuration				255	// implemented, , @ShieldAbility, extends the duration of your /shield ability, base: seconds, limit: none, max: none
-#define SE_ShroudofStealth				256	// implemented
-#define SE_PetDiscipline				257 // not implemented as bonus - /pet hold - official name is GivePetHold
-#define SE_TripleBackstab				258 // implemented[AA] - chance to perform a triple backstab
-#define SE_CombatStability				259 // implemented[AA] - damage mitigation
-#define SE_AddSingingMod				260 // implemented, @Song, set mod for specific instrument/singing skills that will be used if higher then item mods, base: mod%, limit: ItemType ID, max: none
-#define SE_SongModCap					261	// implemented, @Song, raise max song modifier cap, base: amt, limit: none, max: none, Note: No longer used on live
-#define SE_RaiseStatCap					262 // implemented
-#define SE_TradeSkillMastery			263	// implemented - lets you raise more than one tradeskill above master.
-#define SE_HastenedAASkill			    264 // implemented
-#define SE_MasteryofPast				265 // implemented[AA] - Spells less than effect values level can not be fizzled
-#define SE_ExtraAttackChance			266 // implemented, @OffBonus, gives your double attacks a percent chance to perform an extra attack with 2-handed primary weapon, base: chance, limit: amt attacks, max: none
-#define SE_AddPetCommand				267 // implemented - sets command base2 to base1
-#define SE_ReduceTradeskillFail			268 // implemented - reduces chance to fail with given tradeskill by a percent chance
-#define SE_MaxBindWound					269	// implemented[AA] - Increase max HP you can bind wound.
-#define SE_BardSongRange				270	// implemented, @Song, increase range of beneficial bard songs, base: mod%, limit: none, max: none , Note: example Sionachie's Crescendo
-#define SE_BaseMovementSpeed			271 // implemented[AA] - mods basemove speed, doesn't stack with other move mods
-#define SE_CastingLevel2				272 // implemented
-#define SE_CriticalDoTChance			273	// implemented
-#define SE_CriticalHealChance			274	// implemented
-#define SE_CriticalMend					275	// implemented[AA] - chance to critical monk mend
-#define SE_Ambidexterity				276 // implemented[AA] - increase chance to duel weild by adding bonus 'skill'
-#define SE_UnfailingDivinity			277	// implemented[AA] - ability grants your Death Pact-type spells a second chance to successfully heal their target, also can cause said spells to do a portion of their healing value even on a complete failure.
-#define	SE_FinishingBlow				278 // implemented[AA] - chance to do massive damage under 10% HP (base1 = chance, base2 = damage)
-#define SE_Flurry						279	// implemented
-#define SE_PetFlurry					280 // implemented[AA]
-#define SE_FeignedMinion				281	// implemented, ability allows you to instruct your pet to feign death via the '/pet feign' command, base: succeed chance, limit: none, max: none, Note: Only implemented as an AA.
-#define SE_ImprovedBindWound			282	// implemented[AA] - increase bind wound amount by percent.
-#define SE_DoubleSpecialAttack			283	// implemented[AA] - Chance to perform second special attack as monk
-//#define SE_LoHSetHeal					284	// not used
-#define SE_NimbleEvasion				285	// *not implemented - base1 = 100 for max
-#define SE_FcDamageAmt					286	// implemented, @Fc, On Caster, spell damage mod flat amt, base: amt
-#define SE_SpellDurationIncByTic		287 // implemented, @Fc, SPA: 287, SE_SpellDurationIncByTic,			On Caster, spell buff duration mod, base: tics
-#define SE_SkillAttackProc				288	// implemented, @Procs, chance to cast a spell when using a skill, base: chance, limit: skill, max: spellid, note: if used in AA the spell id is set in aa_ranks spell field, chance is calculated as 100% = value 1000.
-#define SE_CastOnFadeEffect				289 // implemented - Triggers only if fades after natural duration.
-#define SE_IncreaseRunSpeedCap			290	// implemented[AA] - increases run speed over the hard cap
-#define SE_Purify						291 // implemented, @Dispel, remove up specified amount of detiremental spells, base: amt removed, limit: none, max: none, Note: excluding charm, fear, resurrection, and revival sickness
-#define SE_StrikeThrough2				292	// implemented[AA] - increasing chance of bypassing an opponent's special defenses, such as dodge, block, parry, and riposte.
-#define SE_FrontalStunResist			293	// implemented[AA] - Reduce chance to be stunned from front. -- live descriptions sounds like this isn't limited to frontal anymore
-#define SE_CriticalSpellChance			294 // implemented - increase chance to critical hit and critical damage modifier.
-//#define SE_ReduceTimerSpecial			295	// not used
-#define SE_FcSpellVulnerability			296	// implemented, @Fc, On Target, spell damage taken mod pct, base: min pct, limit: max pct
-#define SE_FcDamageAmtIncoming			297 // implemetned, @Fc, On Target, damage taken flat amt, base: amt
-#define SE_ChangeHeight					298	// implemented
-#define SE_WakeTheDead					299	// implemented, @Pets, summon one temporary pet from nearby corpses that last a set duration, base: none, limit: none, max: duration (seconds). Note: max range of corpse is 250.
-#define SE_Doppelganger					300	// implemented
-#define SE_ArcheryDamageModifier		301	// implemented[AA] - increase archery damage by percent
-#define SE_FcDamagePctCrit				302	// implemented, @Fc, On Caster, spell damage mod pct, base: min pct, limit: max pct, Note: applied after critical hits has been calculated.
-#define SE_FcDamageAmtCrit				303	// implemented, @Fc, On Caster, spell damage mod flat amt, base: amt
-#define SE_OffhandRiposteFail			304 // implemented as bonus - enemy cannot riposte offhand attacks
-#define SE_MitigateDamageShield			305 // implemented - off hand attacks only (Shielding Resistance)
-#define SE_ArmyOfTheDead				306 // implemented, @Pets, summon multiple temporary pets from nearby corpses that last a set duration, base: amount of corpses that a pet can summon from, limit: none, max: duration (seconds). Note: max range of corpse is 250.
-//#define SE_Appraisal					307 // *not implemented Rogue AA - This ability allows you to estimate the selling price of an item you are holding on your cursor.
-#define SE_ZoneSuspendMinion			308 // implemented, @Pet, allow suspended pets to be resummoned upon zoning, base: 1, limit: none, max: none, Calc: Bool
-#define SE_GateCastersBindpoint			309 // implemented - Gate to casters bind point
-#define SE_ReduceReuseTimer				310 // implemented, @Fc, On Caster, spell and disc reuse time mod by amount, base: milliseconds
-#define SE_LimitCombatSkills			311 // implemented, @Ff, Include or exclude combat skills or procs from being focused, base1: 0=Exclude if proc 1=Allow only if proc.
-#define SE_Sanctuary					312 // implemented - Places caster at bottom hate list, effect fades if cast cast spell on targets other than self.
-#define SE_ForageAdditionalItems		313	// implemented[AA] - chance to forage additional items
-#define SE_Invisibility2				314 // implemented - fixed duration invisible
-#define SE_InvisVsUndead2				315 // implemented - fixed duration ITU
-#define SE_ImprovedInvisAnimals			316	// implemented
-#define SE_ItemHPRegenCapIncrease		317	// implemented[AA] - increases amount of health regen gained via items
-#define SE_ItemManaRegenCapIncrease		318 // implemented - increases amount of mana regen you can gain via items
-#define SE_CriticalHealOverTime			319 // implemented
-#define SE_ShieldBlock					320	// implemented - Block attacks with shield
-#define SE_ReduceHate					321 // implemented
-#define SE_GateToHomeCity				322 // implemented
-#define SE_DefensiveProc				323 // implemented
-#define SE_HPToMana						324 // implemented
-#define SE_NoBreakAESneak				325	// implemented[AA] - [AA Nerves of Steel] increasing chance to remain hidden when they are an indirect target of an AoE spell.
-#define SE_SpellSlotIncrease			326 // *not implemented as bonus - increases your spell slot availability
-#define SE_MysticalAttune				327 // implemented - increases amount of buffs that a player can have
-#define SE_DelayDeath					328 // implemented - increases how far you can fall below 0 hp before you die
-#define SE_ManaAbsorbPercentDamage		329 // implemented
-#define SE_CriticalDamageMob			330	// implemented
-#define SE_Salvage						331 // implemented - chance to recover items that would be destroyed in failed tradeskill combine
-#define SE_SummonToCorpse				332 // *not implemented AA - Call of the Wild (Druid/Shaman Res spell with no exp) TOOD: implement this.
-#define SE_CastOnRuneFadeEffect			333 // implemented
-#define SE_BardAEDot					334	// implemented
-#define SE_BlockNextSpellFocus			335	// implemented, @Fc, On Caster, chance to block next spell, base: chance
-//#define SE_IllusionaryTarget			336	// not used
-#define SE_PercentXPIncrease			337	// implemented
-#define SE_SummonAndResAllCorpses		338	// implemented
-#define SE_TriggerOnCast				339	// implemented, @Fc, On Caster, cast on spell use, base: chance pct limit: spellid
-#define SE_SpellTrigger					340	// implemented - chance to trigger spell [Share rolls with 469] All base2 spells share roll chance, only 1 cast.
-#define SE_ItemAttackCapIncrease		341	// implemented[AA] - increases the maximum amount of attack you can gain from items.
-#define SE_ImmuneFleeing				342	// implemented - stop mob from fleeing
-#define SE_InterruptCasting				343	// implemented - % chance to interrupt spells being cast every tic. Cacophony (8272)
-#define SE_ChannelChanceItems			344	// implemented[AA] - chance to not have ITEM effects interrupted when you take damage.
-#define SE_AssassinateLevel				345	// implemented as bonus - AA Assisination max level to kill
-#define SE_HeadShotLevel				346	// implemented[AA] - HeadShot max level to kill
-#define SE_DoubleRangedAttack			347	// implemented - chance at an additional archery attack (consumes arrow)
-#define SE_LimitManaMin					348	// implemented, @Ff, Mininum mana of spell that can be focused, base1: mana amt
-#define SE_ShieldEquipDmgMod			349	// implemented[AA] Increase melee base damage (indirectly increasing hate) when wearing a shield.
-#define SE_ManaBurn						350	// implemented - Drains mana for damage/heal at a defined ratio up to a defined maximum amount of mana.
-#define SE_PersistentEffect				351	// *not implemented. creates a trap/totem that casts a spell (spell id + base1?) when anything comes near it. can probably make a beacon for this
-#define SE_IncreaseTrapCount			352	// *not implemented - looks to be some type of invulnerability? Test ITC (8755)
-#define SE_AdditionalAura				353	// *not implemented - allows use of more than 1 aura, aa effect
-//#define SE_DeactivateAllTraps			354	// *not implemented - looks to be some type of invulnerability? Test DAT (8757)
-//#define SE_LearnTrap					355	// *not implemented - looks to be some type of invulnerability? Test LT (8758)
-//#define SE_ChangeTriggerType			356	// not used
-#define SE_FcMute						357	// implemented, @Fc, On Caster, prevents spell casting, base: chance pct
-#define SE_CurrentManaOnce				358	// implemented
-//#define SE_PassiveSenseTrap			359	// *not implemented - Invulnerability (Brell's Blessing)
-#define SE_ProcOnKillShot				360	// implemented - a buff that has a base1 % to cast spell base2 when you kill a "challenging foe" base3 min level
-#define SE_SpellOnDeath					361	// implemented - casts spell on death of buffed
-#define SE_PotionBeltSlots				362	// *not implemented[AA] 'Quick Draw' expands the potion belt by one additional available item slot per rank.
-#define SE_BandolierSlots				363	// *not implemented[AA] 'Battle Ready' expands the bandolier by one additional save slot per rank.
-#define SE_TripleAttackChance			364	// implemented
-#define SE_ProcOnSpellKillShot			365	// implemented - chance to trigger a spell on kill when the kill is caused by a specific spell with this effect in it (10470 Venin)
-//#define SE_GroupShielding				366	// *not implemented[AA] This gives you /shieldgroup
-#define SE_SetBodyType					367	// implemented - set body type of base1 so it can be affected by spells that are limited to that type (Plant, Animal, Undead, etc)
-//#define SE_FactionMod					368	// *not implemented - increases faction with base1 (faction id, live won't match up w/ ours) by base2
-#define SE_CorruptionCounter			369	// implemented
-#define SE_ResistCorruption				370	// implemented
-#define SE_AttackSpeed4					371 // implemented - stackable slow effect 'Inhibit Melee'
-#define SE_ForageSkill					372	// implemented[AA] Will increase the skill cap for those that have the Forage skill and grant the skill and raise the cap to those that do not.
-#define SE_CastOnFadeEffectAlways		373 // implemented - Triggers if fades after natural duration OR from rune/numhits fades.
-#define SE_ApplyEffect					374 // implemented
-#define SE_DotCritDmgIncrease			375	// implemented - Increase damage of DoT critical amount
-//#define SE_Fling						376	// *not implemented - used in 2 test spells  (12945 | Movement Test Spell 1)
-#define SE_CastOnFadeEffectNPC			377	// implemented - Triggers only if fades after natural duration (On live these are usually players spells that effect an NPC).
-#define SE_SpellEffectResistChance		378	// implemented - Increase chance to resist specific spell effect (base1=value, base2=spell effect id)
-#define SE_ShadowStepDirectional		379 // implemented - handled by client
-#define SE_Knockdown					380 // implemented - small knock back(handled by client)
-//#define SE_KnockTowardCaster			381	// *not implemented (Call of Hither) knocks you back to caster (value) distance units infront
-#define SE_NegateSpellEffect			382 // implemented, @Debuff, negates specific spell effect benefits for the duration of the debuff and prevent non-duration spell effect from working, base: see NegateSpellEffecttype Enum, limit: SPA id, max: none
-#define SE_SympatheticProc				383 // implemented, @Fc, On Caster, cast on spell use, base: variable proc chance on cast time, limit: spellid
-#define SE_Leap							384	// implemented - Leap effect, ie stomping leap
-#define SE_LimitSpellGroup				385	// implemented, @Ff, Spell group(s) that a spell focus can require or exclude, base1: spellgroup id, Include: Positive Exclude: Negative
-#define SE_CastOnCurer					386 // implemented - Casts a spell on the person curing
-#define SE_CastOnCure					387 // implemented - Casts a spell on the cured person
-#define SE_SummonCorpseZone				388 // implemented - summons a corpse from any zone(nec AA)
-#define SE_FcTimerRefresh				389 // implemented, @Fc, On Caster, reset all recast timers, base: 1, Note: Applied from casted spells only
-#define SE_FcTimerLockout				390 // implemented, @Fc, On Caster, set a spell to be on recast timer, base: recast duration milliseconds, Note: Applied from casted spells only
-#define SE_LimitManaMax					391	// implemented, @Ff, Mininum mana of spell that can be focused, base1: mana amt
-#define SE_FcHealAmt					392 // implemented, @Fc, On Caster, spell healing mod flat amt, base: amt
-#define SE_FcHealPctIncoming			393 // implemented, @Fc, On Target, heal received mod pct, base: pct, limit: random max pct
-#define SE_FcHealAmtIncoming			394 // implemented, @Fc, On Target, heal received mod flat amt, base: amt
-#define SE_FcHealPctCritIncoming		395 // implemented, @Fc, On Target, heal received mod pct, base: pct, limit: random max pct
-#define SE_FcHealAmtCrit				396 // implemented, @Fc, On Caster, spell healing mod flat amt, base: amt
-#define SE_PetMeleeMitigation			397 // implemented[AA] - additional mitigation to your pets. Adds AC
-#define SE_SwarmPetDuration				398 // implemented - Affects the duration of swarm pets
-#define SE_FcTwincast					399 // implemented - cast 2 spells for every 1
-#define SE_HealGroupFromMana			400 // implemented - Drains mana and heals for each point of mana drained
-#define SE_ManaDrainWithDmg				401 // implemented - Deals damage based on the amount of mana drained
-#define SE_EndDrainWithDmg				402 // implemented - Deals damage for the amount of endurance drained
-#define SE_LimitSpellClass				403 // implemented, @Ff, 'Spell Category' using table field 'spell_class' that a spell focus can require or exclude, base1: category type, Include: Positive Exclude: Negative
-#define SE_LimitSpellSubclass			404 // implemented, @Ff, 'Spell Category Subclass' using table field 'spell_subclass' that a spell focus can require or exclude, base1: category type, Include: Positive Exclude: Negative
-#define SE_TwoHandBluntBlock			405 // implemented - chance to block attacks when using two hand blunt weapons (similiar to shield block)
-#define SE_CastonNumHitFade				406 // implemented - casts a spell when a buff fades due to its numhits being depleted
-#define SE_CastonFocusEffect			407 // implemented - casts a spell if focus limits are met (ie triggers when a focus effects is applied)
-#define SE_LimitHPPercent				408 // implemented - limited to a certain percent of your hp(ie heals up to 50%)
-#define SE_LimitManaPercent				409 // implemented - limited to a certain percent of your mana
-#define SE_LimitEndPercent				410 // implemented - limited to a certain percent of your end
-#define SE_LimitClass					411 // implemented, @Ff, Class(es) that can use the spell focus, base1: class(es), Note: The class value in dbase is +1 in relation to item class value, set as you would item for multiple classes
-#define SE_LimitRace					412 // implemented, @Ff, Race that can use the spell focus, base1: race, Note: not used in any known live spells. Use only single race at a time.
-#define SE_FcBaseEffects				413 // implemented, @Fc, On Caster, base spell effectiveness mod pct, base: pct
-#define SE_LimitCastingSkill			414 // implemented, @Ff, Spell and singing skills(s) that a spell focus can require or exclude, base1: skill id, Include: Positive Exclude: Negative
-#define SE_FFItemClass					415 // implemented, @Ff, Limits focuses to be applied only from item click. base1: item ItemType (-1 to include for all ItemTypes,-1000 to exclude clicks from getting the focus, or exclude specific SubTypes or Slots if set), limit: item SubType (-1 for all SubTypes), max: item Slots (bitmask of valid slots, -1 ALL slots), Note: not used on live. See comments in Mob::CalcFocusEffect for more details.
-#define SE_ACv2							416 // implemented - New AC spell effect
-#define SE_ManaRegen_v2					417 // implemented - New mana regen effect
-#define SE_SkillDamageAmount2			418 // implemented - adds skill damage directly to certain attacks
-#define SE_AddMeleeProc					419 // implemented - Adds a proc
-#define SE_FcLimitUse					420 // implemented, @Fc, On Caster, numhits mod pct, base: pct, Note: not used in any known live spells
-#define SE_FcIncreaseNumHits			421 // implemented, @Fc, On Caster, numhits mod flat amt, base: amt
-#define SE_LimitUseMin					422 // implemented, @Ff Minium amount of numhits for a spell to be focused, base: numhit amt
-#define SE_LimitUseType					423 // implemented,	@Ff Focus will only affect if has this numhits type, base: numhit type
-#define SE_GravityEffect				424 // implemented - Pulls/pushes you toward/away the mob at a set pace
-#define SE_Display						425 // *not implemented - Illusion: Flying Dragon(21626)
-#define SE_IncreaseExtTargetWindow		426 // *not implmented[AA] - increases the capacity of your extended target window
-#define SE_SkillProcAttempt				427 // implemented - chance to proc when using a skill(ie taunt)
-#define SE_LimitToSkill					428 // implemented, @Procs, limits what combat skills will effect a skill proc, base: skill value, limit: none, max: none
-#define SE_SkillProcSuccess				429 // implemented - chance to proc when tje skill in use successfully fires.
-//#define SE_PostEffect					430 // *not implemented - Fear of the Dark(27641) - Alters vision
-//#define SE_PostEffectData				431 // *not implemented - Fear of the Dark(27641) - Alters vision
-//#define SE_ExpandMaxActiveTrophyBen	432 // not used
-#define SE_CriticalDotDecay				433 // implemented - increase critical dot chance, effect decays based on level of spell it effects. (12266)
-#define SE_CriticalHealDecay			434 // implemented - increase critical heal chance, effect decays based on level of spell it effects.
-#define SE_CriticalRegenDecay			435 // implemented - increase critical heal over time chance, effect decays based on level of spell it effects.
-//#define SE_BeneficialCountDownHold	436 // not used ( 23491 | ABTest Buff Hold)
-//#define SE_TeleporttoAnchor			437 // *not implemented - Teleport Guild Hall Anchor(33099)
-//#define SE_TranslocatetoAnchor		438 // *not implemented - Translocate Primary Anchor (27750)
-#define SE_Assassinate					439 // implemented[AA] - Assassinate damage
-#define SE_FinishingBlowLvl				440 // implemented[AA] - Sets the level Finishing blow can be triggered on an NPC
-#define SE_DistanceRemoval				441 // implemented - Buff is removed from target when target moves X amount of distance away from where initially hit.
-#define SE_TriggerOnReqTarget			442 // implemented, @SpellTrigger, triggers a spell when Target Requirement conditions are met (see enum SpellRestriction for IDs), base: spellid, limit: SpellRestriction ID, max: none, Note: Usually cast on a target
-#define SE_TriggerOnReqCaster			443 // implemented, @SpellTrigger, triggers a spell when Caster Requirement conditions are met (see enum SpellRestriction for IDs), base: spellid, limit: SpellRestriction ID, max: none, Note: Usually self only
-#define SE_ImprovedTaunt				444 // implemented - Locks Aggro On Caster and Decrease other Players Aggro by X% on NPC targets below level Y
-//#define SE_AddMercSlot				445 // *not implemented[AA] - [Hero's Barracks] Allows you to conscript additional mercs.
-#define SE_AStacker						446 // implementet - bufff stacking blocker (26219 | Qirik's Watch)
-#define SE_BStacker						447 // implemented
-#define SE_CStacker						448 // implemented
-#define SE_DStacker						449 // implemented
-#define SE_MitigateDotDamage			450 // implemented, @Runes, mitigate incoming dot damage by percentage until rune fades, base: percent mitigation, limit: max dmg absorbed per hit, max: rune amt, Note: If placed on item or AA, will provide stackable percent mitigation.
-#define SE_MeleeThresholdGuard			451 // implemented  Partial Melee Rune that only is lowered if melee hits are over X amount of damage
-#define SE_SpellThresholdGuard			452 // implemented  Partial Spell Rune that only is lowered if spell hits are over X amount of damage
-#define SE_TriggerMeleeThreshold		453 // implemented  Trigger effect on X amount of melee damage taken in a single hit
-#define SE_TriggerSpellThreshold		454 // implemented  Trigger effect on X amount of spell damage taken in a single hit
-#define SE_AddHatePct					455 // implemented  Modify total hate by %
-#define SE_AddHateOverTimePct			456 // implemented  Modify total hate by % over time.
-#define SE_ResourceTap					457 // implemented  Coverts a percent of dmg from dmg spells(DD/DoT) to hp/mana/end.
-#define SE_FactionModPct				458 // implemented  Modifies faction gains and losses by percent.
-#define SE_DamageModifier2				459 // implemented - Modifies melee damage by skill type
-#define SE_Ff_Override_NotFocusable		460 // implemented, @Fc, Allow spell to be focused event if flagged with 'not_focusable' in spell table, base: 1
-#define SE_ImprovedDamage2				461 // implemented, @Fc, On Caster, spell damage mod pct, base: min pct, limit: max pct
-#define SE_FcDamageAmt2					462 // implemented, @Fc, On Caster, spell damage mod flat amt, base: amt
-#define SE_Shield_Target				463 // implemented, Base1 % damage shielded on target
-#define SE_PC_Pet_Rampage				464 // implemented - Base1 % chance to do rampage for base2 % of damage each melee round
-#define SE_PC_Pet_AE_Rampage			465 // implemented - Base1 % chance to do AE rampage for base2 % of damage each melee round
-#define SE_PC_Pet_Flurry_Chance			466 // implemented - Base1 % chance to do flurry from double attack hit.
-#define SE_DS_Mitigation_Amount			467 // implemented - Modify incoming damage shield damage by a flat amount
-#define SE_DS_Mitigation_Percentage		468 // implemented - Modify incoming damage shield damage by percentage
-#define SE_Chance_Best_in_Spell_Grp     469 // implemented - Chance to cast highest scribed spell within a spell group. All base2 spells share roll chance, only 1 cast.
-#define SE_Trigger_Best_in_Spell_Grp	470 // implemented - Chance to cast highest scribed spell within a spell group. Each spell has own chance.
-#define SE_Double_Melee_Round			471 // implemented, @OffBonus, percent chance to repeat primary weapon round with a percent damage modifier, base: pct chance repeat, limit: pct dmg mod, max: none
-#define SE_Buy_AA_Rank					472 // implemented,  @Special, Used in AA abilities that have Enable/Disable toggle. Spell on Disabled Rank has this effect in it, base: 1, limit: none, max: none, Note: This will not just buy an AA
-#define SE_Double_Backstab_Front		473 // implemented - Chance to double backstab from front
-#define SE_Pet_Crit_Melee_Damage_Pct_Owner	474 // implemenetd - Critical damage mod applied to pets from owner
-#define SE_Trigger_Spell_Non_Item		475 // implemented - Trigger spell on cast only if not from item click.
-#define SE_Weapon_Stance				476 // implemented, @Misc, Apply a specific spell buffs automatically depending 2Hander, Shield or Dual Wield is equipped, base: spellid, base: 0=2H 1=Shield 2=DW, max: none
-#define SE_Hatelist_To_Top_Index		477 // Implemented - Chance to be set to top of rampage list
-#define SE_Hatelist_To_Tail_Index		478 // Implemented - Chance to be set to bottom of rampage list
-#define SE_Ff_Value_Min					479 // implemented, @Ff, Minimum base value of a spell that can be focused, base: spells to be focused base1 value
-#define SE_Ff_Value_Max					480 // implemented, @Ff, Max base value of a spell that can be focused, base: spells to be focused base1 value
-#define SE_Fc_Cast_Spell_On_Land		481 // implemented, @Fc, On Target, cast spell if hit by spell, base: chance pct, limit: spellid
-#define SE_Skill_Base_Damage_Mod		482 // implemented, @OffBonus, modify base melee damage by percent, base: pct, limit: skill(-1=ALL), max: none
-#define SE_Fc_Spell_Damage_Pct_IncomingPC	483 // implemented, @Fc, On Target, spell damage taken mod pct, base: min pct, limit: max pct
-#define SE_Fc_Spell_Damage_Amt_IncomingPC	484 // implemented, @Fc, On Target, damage taken flat amt, base: amt
-#define SE_Ff_CasterClass				485 // implemented, @Ff, Caster of spell on target with a focus effect that is checked by incoming spells must be specified class(es). base1: class(es), Note: Set multiple classes same as would for items
-#define SE_Ff_Same_Caster				486 // implemented, @Ff, Caster of spell on target with a focus effect that is checked by incoming spells, base1: 0=Must be different caster 1=Must be same caster
-//#define SE_Extend_Tradeskill_Cap		487 //
-//#define SE_Defender_Melee_Force_Pct_PC	488 //
-#define SE_Worn_Endurance_Regen_Cap		489 // implemented, modify worn regen cap, base: amt, limit: none, max: none
-#define SE_Ff_ReuseTimeMin				490 // implemented, @Ff, Minimum recast time of a spell that can be focused, base: recast time
-#define SE_Ff_ReuseTimeMax				491 // implemented, @Ff, Max recast time of a spell that can be focused, base: recast time
-#define SE_Ff_Endurance_Min				492 // implemented, @Ff, Minimum endurance cost of a spell that can be focused, base: endurance cost
-#define SE_Ff_Endurance_Max				493 // implemented, @Ff, Max endurance cost of a spell that can be focused, base: endurance cost
-#define SE_Pet_Add_Atk					494 // implemented - Bonus on pet owner which gives their pet increased attack stat
-#define SE_Ff_DurationMax				495 // implemented, @Ff, Max duration of spell that can be focused, base: tics
-#define SE_Critical_Melee_Damage_Mod_Max	496 // implemented - increase or decrease by percent critical damage (not stackable)
-//#define SE_Ff_FocusCastProcNoBypass	497 //
-#define SE_AddExtraAttackPct_1h_Primary	498 // implemented, @OffBonus, gives your double attacks a percent chance to perform an extra attack with 1-handed primary weapon, base: chance, limit: amt attacks, max: none
-#define SE_AddExtraAttackPct_1h_Secondary	499 //implemented, @OffBonus, gives your double attacks a percent chance to perform an extra attack with 1-handed secondary weapon, base: chance, limit: amt attacks, max: none
-#define SE_Fc_CastTimeMod2				500 // implemented, @Fc, On Caster, cast time mod pct, base: pct, Note: Can reduce to instant cast
-#define SE_Fc_CastTimeAmt				501 // implemented, @Fc, On Caster, cast time mod flat amt, base: milliseconds, Note: Can reduce to instant cast
-#define SE_Fearstun						502 // implemented - Stun with a max level limit. Normal stun restrictions don't apply.
-#define SE_Melee_Damage_Position_Mod	503 // implemented, @OffBonus, modify melee damage by percent if done from Front or Behind opponent, base: pct, limit: 0=back 1=front, max: none
-#define SE_Melee_Damage_Position_Amt	504 // implemented, @OffBonus, modify melee damage by flat amount if done from Front or Behind opponent, base: amt, limit: 0=back 1=front, max: none
-#define SE_Damage_Taken_Position_Mod	505 // implemented, @DefBonus, modify melee damage by percent if dmg taken from Front or Behind, base: pct, limit: 0=back 1=front, max: none
-#define SE_Damage_Taken_Position_Amt	506 // implemented -@DefBonus, modify melee damage by flat amount if dmg taken from your Front or Behind, base: amt, limit: 0=back 1=front, max: none
-#define SE_Fc_Amplify_Mod				507 // implemented, @Fc, On Caster, damage-heal-dot mod pct, base: pct
-#define SE_Fc_Amplify_Amt				508 // implemented, @Fc, On Caster, damage-heal-dot mod flat amt, base: amt
-#define SE_Health_Transfer				509 // implemented - exchange health for damage or healing on a target. ie Lifeburn/Act of Valor
-#define SE_Fc_ResistIncoming			510 // implemented, @Fc, On Target, resist modifier, base: amt
-#define SE_Ff_FocusTimerMin				511 // implemented, @Ff, sets a recast time until focus can be used again, base: 1, limit: time ms, Note:  ie. limit to 1 trigger every 1.5 seconds
-#define SE_Proc_Timer_Modifier 			512 // implemented - limits procs per amount of a time based on timer value, base: 1, limit: time ms, Note:, ie limit to 1 proc every 55 seconds)
-//#define SE_Mana_Max_Percent			513 //
-//#define SE_Endurance_Max_Percent		514 //
-#define SE_AC_Avoidance_Max_Percent		515 // implemented - stackable avoidance modifier
-#define SE_AC_Mitigation_Max_Percent	516 // implemented - stackable defense modifier
-//#define SE_Attack_Offense_Max_Percent	517 //
-#define SE_Attack_Accuracy_Max_Percent	518 // implemented - stackable accurary modifer
-//#define SE_Luck_Amount				519 //
-//#define SE_Luck_Percent				520 //
-#define SE_Endurance_Absorb_Pct_Damage	521 // implemented - Reduces % of Damage using Endurance, drains endurance at a ratio (ie. 0.05 Endurance per Hit Point)
-#define SE_Instant_Mana_Pct				522 // implemented - Increase/Decrease mana by percent of max mana
-#define SE_Instant_Endurance_Pct		523 // implemented - Increase/Decrease mana by percent of max endurance
-#define SE_Duration_HP_Pct				524 // implemented - Decrease Current Hit Points by % of Total Hit Points per Tick, up to a MAX per tick
-#define SE_Duration_Mana_Pct			525 // implemented - Decrease Current Mana by % of Total Mana per Tick, up to a MAX per tick
-#define SE_Duration_Endurance_Pct		526 // implemented - Decrease Current Endurance by % of Total Hit Points per Tick, up to a MAX per tick
 
-
-// LAST
-
+namespace SpellEffect {
+	constexpr int CurrentHP                       = 0; // implemented - Heals and nukes, repeates every tic if in a buff
+	constexpr int ArmorClass                      = 1; // implemented
+	constexpr int ATK                             = 2; // implemented
+	constexpr int MovementSpeed                   = 3; // implemented - SoW, SoC, etc
+	constexpr int STR                             = 4; // implemented
+	constexpr int DEX                             = 5; // implemented
+	constexpr int AGI                             = 6; // implemented
+	constexpr int STA                             = 7; // implemented
+	constexpr int INT                             = 8; // implemented
+	constexpr int WIS                             = 9; // implemented
+	constexpr int CHA                             = 10; // implemented - used as a spacer
+	constexpr int AttackSpeed                     = 11; // implemented
+	constexpr int Invisibility                    = 12; // implemented - TO DO: Implemented Invisiblity Levels
+	constexpr int SeeInvis                        = 13; // implemented - TO DO: Implemented See Invisiblity Levels
+	constexpr int WaterBreathing                  = 14; // implemented
+	constexpr int CurrentMana                     = 15; // implemented
+	constexpr int NPCFrenzy                       = 16; // not used
+	constexpr int NPCAwareness                    = 17; // not used
+	constexpr int Lull                            = 18; // implemented - Reaction Radius
+	constexpr int AddFaction                      = 19; // implemented - Alliance line
+	constexpr int Blind                           = 20; // implemented
+	constexpr int Stun                            = 21; // implemented
+	constexpr int Charm                           = 22; // implemented
+	constexpr int Fear                            = 23; // implemented
+	constexpr int Stamina                         = 24; // implemented - Invigor and such
+	constexpr int BindAffinity                    = 25; // implemented - TO DO: Implement 2nd and 3rd Recall (value 2,3 ect). Sets additional bind points.
+	constexpr int Gate                            = 26; // implemented - Gate to bind point
+	constexpr int CancelMagic                     = 27; // implemented
+	constexpr int InvisVsUndead                   = 28; // implemented
+	constexpr int InvisVsAnimals                  = 29; // implemented
+	constexpr int ChangeFrenzyRad                 = 30; // implemented - Pacify
+	constexpr int Mez                             = 31; // implemented
+	constexpr int SummonItem                      = 32; // implemented
+	constexpr int SummonPet                       = 33; // implemented
+	constexpr int Confuse                         = 34; // not used (Nimbus of Temporal Rifting) ?
+	constexpr int DiseaseCounter                  = 35; // implemented
+	constexpr int PoisonCounter                   = 36; // implemented
+	constexpr int DetectHostile                   = 37; // not used
+	constexpr int DetectMagic                     = 38; // not used
+	constexpr int TwinCastBlocker                 = 39; // implemented - If present in spell, then the spell can not be twincast.
+	constexpr int DivineAura                      = 40; // implemented
+	constexpr int Destroy                         = 41; // implemented - Disintegrate, Banishment of Shadows
+	constexpr int ShadowStep                      = 42; // implemented
+	constexpr int Berserk                         = 43; // implemented (*not used in any known live spell) Makes client 'Berserk' giving crip blow chance.
+	constexpr int Lycanthropy                     = 44; // implemented
+	constexpr int Vampirism                       = 45; // implemented (*not used in any known live spell) Stackable lifetap from melee.
+	constexpr int ResistFire                      = 46; // implemented
+	constexpr int ResistCold                      = 47; // implemented
+	constexpr int ResistPoison                    = 48; // implemented
+	constexpr int ResistDisease                   = 49; // implemented
+	constexpr int ResistMagic                     = 50; // implemented
+	constexpr int DetectTraps                     = 51; // not used
+	constexpr int SenseDead                       = 52; // implemented
+	constexpr int SenseSummoned                   = 53; // implemented
+	constexpr int SenseAnimals                    = 54; // implemented
+	constexpr int Rune                            = 55; // implemented
+	constexpr int TrueNorth                       = 56; // implemented
+	constexpr int Levitate                        = 57; // implemented
+	constexpr int Illusion                        = 58; // implemented
+	constexpr int DamageShield                    = 59; // implemented
+	constexpr int TransferItem                    = 60; // not used
+	constexpr int Identify                        = 61; // implemented
+	constexpr int ItemID                          = 62; // not used
+	constexpr int WipeHateList                    = 63; // implemented, @Memblur, chance to wipe hate list of target, base: pct chance, limit: none, max: ? (not implemented), Note: caster level and CHA add to pct chance
+	constexpr int SpinTarget                      = 64; // implemented - TO DO: Not sure stun portion is working correctly
+	constexpr int InfraVision                     = 65; // implemented
+	constexpr int UltraVision                     = 66; // implemented
+	constexpr int EyeOfZomm                       = 67; // implemented
+	constexpr int ReclaimPet                      = 68; // implemented
+	constexpr int TotalHP                         = 69; // implemented
+	constexpr int CorpseBomb                      = 70; // not used
+	constexpr int NecPet                          = 71; // implemented
+	constexpr int PreserveCorpse                  = 72; // not used
+	constexpr int BindSight                       = 73; // implemented, @Vision, see through the eyes of your target, click off buff to end effect, base: 1, limit: none, max: none
+	constexpr int FeignDeath                      = 74; // implemented
+	constexpr int VoiceGraft                      = 75; // implemented
+	constexpr int Sentinel                        = 76; // *not implemented?(just seems to send a message)
+	constexpr int LocateCorpse                    = 77; // implemented
+	constexpr int AbsorbMagicAtt                  = 78; // implemented - Rune for spells
+	constexpr int CurrentHPOnce                   = 79; // implemented - Heals and nukes, non-repeating if in a buff
+	constexpr int EnchantLight                    = 80; // not used
+	constexpr int Revive                          = 81; // implemented - Resurrect
+	constexpr int SummonPC                        = 82; // implemented
+	constexpr int Teleport                        = 83; // implemented
+	constexpr int TossUp                          = 84; // implemented - Gravity Flux
+	constexpr int WeaponProc                      = 85; // implemented - i.e. Call of Fire
+	constexpr int Harmony                         = 86; // implemented
+	constexpr int MagnifyVision                   = 87; // implemented - Telescope
+	constexpr int Succor                          = 88; // implemented - Evacuate/Succor lines
+	constexpr int ModelSize                       = 89; // implemented - Shrink, Growth
+	constexpr int Cloak                           = 90; // *not implemented - Used in only 2 spells
+	constexpr int SummonCorpse                    = 91; // implemented
+	constexpr int InstantHate                     = 92; // implemented - add hate
+	constexpr int StopRain                        = 93; // implemented - Wake of Karana
+	constexpr int NegateIfCombat                  = 94; // implemented
+	constexpr int Sacrifice                       = 95; // implemented
+	constexpr int Silence                         = 96; // implemented
+	constexpr int ManaPool                        = 97; // implemented
+	constexpr int AttackSpeed2                    = 98; // implemented - Melody of Ervaj
+	constexpr int Root                            = 99; // implemented
+	constexpr int HealOverTime                    = 100; // implemented
+	constexpr int CompleteHeal                    = 101; // implemented
+	constexpr int Fearless                        = 102; // implemented - Valiant Companion
+	constexpr int CallPet                         = 103; // implemented - Summon Companion
+	constexpr int Translocate                     = 104; // implemented
+	constexpr int AntiGate                        = 105; // implemented - Translocational Anchor
+	constexpr int SummonBSTPet                    = 106; // implemented
+	constexpr int AlterNPCLevel                   = 107; // implemented - not used on live
+	constexpr int Familiar                        = 108; // implemented
+	constexpr int SummonItemIntoBag               = 109; // implemented - summons stuff into container
+	constexpr int IncreaseArchery                 = 110; // implemented
+	constexpr int ResistAll                       = 111; // implemented - Note: Physical Resists are not modified by this effect.
+	constexpr int CastingLevel                    = 112; // implemented
+	constexpr int SummonHorse                     = 113; // implemented
+	constexpr int ChangeAggro                     = 114; // implemented - Hate modifing buffs(ie horrifying visage)
+	constexpr int Hunger                          = 115; // implemented - Song of Sustenance
+	constexpr int CurseCounter                    = 116; // implemented
+	constexpr int MagicWeapon                     = 117; // implemented - makes weapon magical
+	constexpr int Amplification                   = 118; // implemented, @Song, stackable singing mod, base: mod%, limit: none, max: none, Note: Can focus itself.
+	constexpr int AttackSpeed3                    = 119; // implemented
+	constexpr int HealRate                        = 120; // implemented - reduces healing by a %
+	constexpr int ReverseDS                       = 121; // implemented
+	constexpr int ReduceSkill                     = 122; // implemented - base: skill id, limit: none, max: none, formula: % skill is reduced (positive)
+	constexpr int Screech                         = 123; // implemented Spell Blocker(If have buff with value +1 will block any effect with -1)
+	constexpr int ImprovedDamage                  = 124; // implemented
+	constexpr int ImprovedHeal                    = 125; // implemented
+	constexpr int SpellResistReduction            = 126; // implemented
+	constexpr int IncreaseSpellHaste              = 127; // implemented, @Fc, On Caster, cast time mod pct, base: pct
+	constexpr int IncreaseSpellDuration           = 128; // implemented, @Fc, On Caster, spell duration mod pct, base: pct
+	constexpr int IncreaseRange                   = 129; // implemented, @Fc, On Caster, spell range mod pct, base: pct
+	constexpr int SpellHateMod                    = 130; // implemented, @Fc, On Caster, spell hate mod pct, base: min pct, limit: max pct
+	constexpr int ReduceReagentCost               = 131; // implemented, @Fc, On Caster, do not consume reagent pct chance, base: min pct, limit: max pct
+	constexpr int ReduceManaCost                  = 132; // implemented, @Fc, On Caster, reduce mana cost by pct, base: min pct, limt: max pct
+	constexpr int FcStunTimeMod                   = 133; // implemented, @Fc, On Caster, spell range mod pct, base: pct
+	constexpr int LimitMaxLevel                   = 134; // implemented, @Ff, Max level of spell that can be focused, if base2 then decrease effectiviness by base2 % per level over max, base: lv, base2: effectiveness pct
+	constexpr int LimitResist                     = 135; // implemented, @Ff, Resist Type(s) that a spell focus can require or exclude, base1: resist type, Include: Positive Exclude: Negative
+	constexpr int LimitTarget                     = 136; // implemented, @Ff, Target Type(s) that a spell focus can require or exclude, base1: target type, Include: Positive Exclude: Negative
+	constexpr int LimitEffect                     = 137; // implemented, @Ff, Spell effect(s) that a spell focus can require or exclude, base1: SPA id, Include: Positive Exclude: Negative
+	constexpr int LimitSpellType                  = 138; // implemented, @Ff, Only allow focus spells that are Beneficial or Detrimental, base1: 0=det 1=bene
+	constexpr int LimitSpell                      = 139; // implemented, @Ff, Specific spell id(s) that a spell focus can require or exclude, base1: SPA id, Include: Positive Exclude: Negative
+	constexpr int LimitMinDur                     = 140; // implemented, @Ff, Mininum duration of spell that can be focused, base1: tics
+	constexpr int LimitInstant                    = 141; // implemented, @Ff, Include or exclude if an isntant cast spell can be focused, base1: 0=Exclude if Instant 1=Allow only if Instant
+	constexpr int LimitMinLevel                   = 142; // implemented, @Ff, Mininum level of spell that can be focused, base1: lv
+	constexpr int LimitCastTimeMin                = 143; // implemented, @Ff, Mininum cast time of spell that can be focused, base1: milliseconds
+	constexpr int LimitCastTimeMax                = 144; // implemented, @Ff, Max cast time of spell that can be focused, base1: milliseconds
+	constexpr int Teleport2                       = 145; // implemented - Banishment of the Pantheon
+	constexpr int ElectricityResist               = 146; // *not implemented TODO: Now used on live, xyz for teleport spells? also in temp pets?
+	constexpr int PercentalHeal                   = 147; // implemented
+	constexpr int StackingCommand_Block           = 148; // implemented?
+	constexpr int StackingCommand_Overwrite       = 149; // implemented?
+	constexpr int DeathSave                       = 150; // implemented
+	constexpr int SuspendPet                      = 151; // implemented, @Pet, allow caster to have an extra suspended pet, base: 0=no buffs/items 1=buffs+items, limit: none, max: none
+	constexpr int TemporaryPets                   = 152; // implemented
+	constexpr int BalanceHP                       = 153; // implemented
+	constexpr int DispelDetrimental               = 154; // implemented, @Dispel, removes only detrimental effects on a target, base: pct chance (950=95%), limit: none, max: none
+	constexpr int SpellCritDmgIncrease            = 155; // implemented - no known live spells use this currently
+	constexpr int IllusionCopy                    = 156; // implemented - Deception
+	constexpr int SpellDamageShield               = 157; // implemented, @DS, causes non-melee damage on caster of a spell, base: Amt DS (negative), limit: none, max: unknown (same as base but +)
+	constexpr int Reflect                         = 158; // implemented, @SpellMisc, reflect casted detrimental spell back at caster, base: chance pct, limit: resist modifier (positive value reduces resists), max: pct of base dmg mod (50=50pct of base)
+	constexpr int AllStats                        = 159; // implemented
+	constexpr int MakeDrunk                       = 160; // *not implemented - Effect works entirely client side (Should check against tolerance)
+	constexpr int MitigateSpellDamage             = 161; // implemented, @Runes, mitigate incoming spell damage by percentage until rune fades, base: percent mitigation, limit: max dmg absorbed per hit, max: rune amt, Note: If placed on item or AA, will provide stackable percent mitigation.
+	constexpr int MitigateMeleeDamage             = 162; // implemented - rune with max value
+	constexpr int NegateAttacks                   = 163; // implemented
+	constexpr int AppraiseLDonChest               = 164; // implemented
+	constexpr int DisarmLDoNTrap                  = 165; // implemented
+	constexpr int UnlockLDoNChest                 = 166; // implemented
+	constexpr int PetPowerIncrease                = 167; // implemented, @Fc, On Caster, pet power mod, base: value
+	constexpr int MeleeMitigation                 = 168; // implemented
+	constexpr int CriticalHitChance               = 169; // implemented
+	constexpr int SpellCritChance                 = 170; // implemented
+	constexpr int CrippBlowChance                 = 171; // implemented
+	constexpr int AvoidMeleeChance                = 172; // implemented
+	constexpr int RiposteChance                   = 173; // implemented
+	constexpr int DodgeChance                     = 174; // implemented
+	constexpr int ParryChance                     = 175; // implemented
+	constexpr int DualWieldChance                 = 176; // implemented
+	constexpr int DoubleAttackChance              = 177; // implemented
+	constexpr int MeleeLifetap                    = 178; // implemented
+	constexpr int AllInstrumentMod                = 179; // implemented, @Song, set mod for ALL instrument/singing skills that will be used if higher then item mods, base: mod%, limit: none, max: none
+	constexpr int ResistSpellChance               = 180; // implemented
+	constexpr int ResistFearChance                = 181; // implemented
+	constexpr int HundredHands                    = 182; // implemented
+	constexpr int MeleeSkillCheck                 = 183; // implemented
+	constexpr int HitChance                       = 184; // implemented
+	constexpr int DamageModifier                  = 185; // implemented
+	constexpr int MinDamageModifier               = 186; // implemented
+	constexpr int BalanceMana                     = 187; // implemented - Balances party mana
+	constexpr int IncreaseBlockChance             = 188; // implemented
+	constexpr int CurrentEndurance                = 189; // implemented
+	constexpr int EndurancePool                   = 190; // implemented
+	constexpr int Amnesia                         = 191; // implemented - Silence vs Melee Effect
+	constexpr int Hate                            = 192; // implemented - Instant and hate over time.
+	constexpr int SkillAttack                     = 193; // implemented,
+	constexpr int FadingMemories                  = 194; // implemented, @Aggro, Remove from hate lists and make invisible. Can set max level of NPCs that can be affected. base: success chance, limit: max level (ROF2), max: max level (modern client), Note: Support for max level requires Rule (Spells, UseFadingMemoriesMaxLevel) to be true. If used from limit field, then it set as the level, ie. max level of 75 would use limit value of 75. If set from max field, max level 75 would use max value of 1075, if you want to set it so it checks a level range above the spell target then for it to only work on mobs 5 levels or below you set max value to 5.
+	constexpr int StunResist                      = 195; // implemented
+	constexpr int StrikeThrough                   = 196; // implemented
+	constexpr int SkillDamageTaken                = 197; // implemented
+	constexpr int CurrentEnduranceOnce            = 198; // implemented
+	constexpr int Taunt                           = 199; // implemented - % chance to taunt the target
+	constexpr int ProcChance                      = 200; // implemented
+	constexpr int RangedProc                      = 201; // implemented
+	constexpr int IllusionOther                   = 202; // implemented - Project Illusion
+	constexpr int MassGroupBuff                   = 203; // implemented
+	constexpr int GroupFearImmunity               = 204; // implemented - (Does not use bonus)
+	constexpr int Rampage                         = 205; // implemented, @Combat Instant, Perform a primary slot combat rounds on all creatures within a 40 foot radius, base: number of attack rounds, limit: max entities hit per round, max: none, Note: AE range is 40 by default. Custom: Set field 'aoe_range' to override default. Adding additional attacks and hit count limit.
+	constexpr int AETaunt                         = 206; // implemented
+	constexpr int FleshToBone                     = 207; // implemented
+	constexpr int PurgePoison                     = 208; // not used
+	constexpr int DispelBeneficial                = 209; // implemented, @Dispel, removes only beneficial effects on a target, base: pct chance (950=95%), limit: none, max: none
+	constexpr int PetShield                       = 210; // implmented, @ShieldAbility, allows pet to 'shield' owner for 50 pct of damage taken for a duration, base: Time multiplier 1=12 seconds, 2=24 ect, limit: mitigation on pet owner override (not on live), max: mitigation on pet overide (not on live)
+	constexpr int AEMelee                         = 211; // implemented TO DO: Implement to allow NPC use (client only atm).
+	constexpr int FrenziedDevastation             = 212; // implemented - increase spell criticals + all DD spells cast 2x mana.
+	constexpr int PetMaxHP                        = 213; // implemented[AA] - increases the maximum hit points of your pet
+	constexpr int MaxHPChange                     = 214; // implemented
+	constexpr int PetAvoidance                    = 215; // implemented[AA] - increases pet ability to avoid melee damage
+	constexpr int Accuracy                        = 216; // implemented
+	constexpr int HeadShot                        = 217; // implemented - ability to head shot (base2 = damage)
+	constexpr int PetCriticalHit                  = 218; // implemented[AA] - gives pets a baseline critical hit chance
+	constexpr int SlayUndead                      = 219; // implemented - Allow extra damage against undead (base1 = rate, base2 = damage mod).
+	constexpr int SkillDamageAmount               = 220; // implemented
+	constexpr int Packrat                         = 221; // implemented as bonus
+	constexpr int BlockBehind                     = 222; // implemented - Chance to block from behind (with our without Shield)
+	constexpr int DoubleRiposte                   = 223; // implemented - Chance to double riposte [not used on live]
+	constexpr int GiveDoubleRiposte               = 224; // implemented[AA]
+	constexpr int GiveDoubleAttack                = 225; // implemented[AA] - Allow any class to double attack with set chance.
+	constexpr int TwoHandBash                     = 226; // *not implemented as bonus
+	constexpr int ReduceSkillTimer                = 227; // implemented
+	constexpr int ReduceFallDamage                = 228; // implented - reduce the damage that you take from falling
+	constexpr int PersistantCasting               = 229; // implemented
+	constexpr int ExtendedShielding               = 230; // implemented, @ShieldAbility, extends the range of your /shield ability by an amount of distance, base: distance units, limit: none, max: none
+	constexpr int StunBashChance                  = 231; // implemented - increase chance to stun from bash.
+	constexpr int DivineSave                      = 232; // implemented (base1 == % chance on death to insta-res) (base2 == spell cast on save)
+	constexpr int Metabolism                      = 233; // implemented - Modifies food/drink consumption rates.
+	constexpr int ReduceApplyPoisonTime           = 234; // not implemented as bonus - reduces the time to apply poison
+	constexpr int ChannelChanceSpells             = 235; // implemented[AA] - chance to channel from SPELLS *No longer used on live.
+	constexpr int FreePet                         = 236; // not used
+	constexpr int GivePetGroupTarget              = 237; // implemented[AA] - (Pet Affinity)
+	constexpr int IllusionPersistence             = 238; // implemented - lends persistence to your illusionary disguises, causing them to last until you die or the illusion is forcibly removed.
+	constexpr int FeignedCastOnChance             = 239; // implemented - ability gives you an increasing chance for your feigned deaths to not be revealed by spells cast upon you.
+	constexpr int StringUnbreakable               = 240; // not used [Likely related to above - you become immune to feign breaking on a resisted spell and have a good chance of feigning through a spell that successfully lands upon you.]
+	constexpr int ImprovedReclaimEnergy           = 241; // implemented - increase the amount of mana returned to you when reclaiming your pet.
+	constexpr int IncreaseChanceMemwipe           = 242; // implemented - @Memblur, increases the chance to wipe hate with memory blurr, base: chance pct, limit: none, max: none, Note: Mods final blur chance after other bonuses added.
+	constexpr int CharmBreakChance                = 243; // implemented - Total Domination
+	constexpr int RootBreakChance                 = 244; // implemented[AA] reduce the chance that your root will break.
+	constexpr int TrapCircumvention               = 245; // implemented, @Traps, decreases the chance that you will set off a trap when opening a chest or other similar container by percentage, base: chance modifer, limit: none, max: none
+	constexpr int SetBreathLevel                  = 246; // *not implemented as bonus
+	constexpr int RaiseSkillCap                   = 247; // implemented[AA] - adds skill over the skill cap.
+	constexpr int SecondaryForte                  = 248; // not implemented as bonus(gives you a 2nd specialize skill that can go past 50 to 100)
+	constexpr int SecondaryDmgInc                 = 249; // implemented[AA] Allows off hand weapon to recieve a damage bonus (Sinister Strikes)
+	constexpr int SpellProcChance                 = 250; // implemented - Increase chance to proc from melee proc spells (ie Spirit of Panther)
+	constexpr int ConsumeProjectile               = 251; // implemented[AA] - chance to not consume an arrow (ConsumeProjectile = 100)
+	constexpr int FrontalBackstabChance           = 252; // implemented[AA] - chance to perform a full damage backstab from front.
+	constexpr int FrontalBackstabMinDmg           = 253; // implemented[AA] - allow a frontal backstab for mininum damage.
+	constexpr int Blank                           = 254; // implemented
+	constexpr int ShieldDuration                  = 255; // implemented, , @ShieldAbility, extends the duration of your /shield ability, base: seconds, limit: none, max: none
+	constexpr int ShroudofStealth                 = 256; // implemented
+	constexpr int PetDiscipline                   = 257; // not implemented as bonus - /pet hold - official name is GivePetHold
+	constexpr int TripleBackstab                  = 258; // implemented[AA] - chance to perform a triple backstab
+	constexpr int CombatStability                 = 259; // implemented[AA] - damage mitigation
+	constexpr int AddSingingMod                   = 260; // implemented, @Song, set mod for specific instrument/singing skills that will be used if higher then item mods, base: mod%, limit: ItemType ID, max: none
+	constexpr int SongModCap                      = 261; // implemented, @Song, raise max song modifier cap, base: amt, limit: none, max: none, Note: No longer used on live
+	constexpr int RaiseStatCap                    = 262; // implemented
+	constexpr int TradeSkillMastery               = 263; // implemented - lets you raise more than one tradeskill above master.
+	constexpr int HastenedAASkill                 = 264; // implemented
+	constexpr int MasteryofPast                   = 265; // implemented[AA] - Spells less than effect values level can not be fizzled
+	constexpr int ExtraAttackChance               = 266; // implemented, @OffBonus, gives your double attacks a percent chance to perform an extra attack with 2-handed primary weapon, base: chance, limit: amt attacks, max: none
+	constexpr int AddPetCommand                   = 267; // implemented - sets command base2 to base1
+	constexpr int ReduceTradeskillFail            = 268; // implemented - reduces chance to fail with given tradeskill by a percent chance
+	constexpr int MaxBindWound                    = 269; // implemented[AA] - Increase max HP you can bind wound.
+	constexpr int BardSongRange                   = 270; // implemented, @Song, increase range of beneficial bard songs, base: mod%, limit: none, max: none , Note: example Sionachie's Crescendo
+	constexpr int BaseMovementSpeed               = 271; // implemented[AA] - mods basemove speed, doesn't stack with other move mods
+	constexpr int CastingLevel2                   = 272; // implemented
+	constexpr int CriticalDoTChance               = 273; // implemented
+	constexpr int CriticalHealChance              = 274; // implemented
+	constexpr int CriticalMend                    = 275; // implemented[AA] - chance to critical monk mend
+	constexpr int Ambidexterity                   = 276; // implemented[AA] - increase chance to duel weild by adding bonus 'skill'
+	constexpr int UnfailingDivinity               = 277; // implemented[AA] - ability grants your Death Pact-type spells a second chance to successfully heal their target, also can cause said spells to do a portion of their healing value even on a complete failure.
+	constexpr int FinishingBlow                   = 278; // implemented[AA] - chance to do massive damage under 10% HP (base1 = chance, base2 = damage)
+	constexpr int Flurry                          = 279; // implemented
+	constexpr int PetFlurry                       = 280; // implemented[AA]
+	constexpr int FeignedMinion                   = 281; // implemented, ability allows you to instruct your pet to feign death via the '/pet feign' command, base: succeed chance, limit: none, max: none, Note: Only implemented as an AA.
+	constexpr int ImprovedBindWound               = 282; // implemented[AA] - increase bind wound amount by percent.
+	constexpr int DoubleSpecialAttack             = 283; // implemented[AA] - Chance to perform second special attack as monk
+	constexpr int LoHSetHeal                      = 284; // not used
+	constexpr int NimbleEvasion                   = 285; // *not implemented - base1 = 100 for max
+	constexpr int FcDamageAmt                     = 286; // implemented, @Fc, On Caster, spell damage mod flat amt, base: amt
+	constexpr int SpellDurationIncByTic           = 287; // implemented, @Fc, SPA: 287, SpellEffect::SpellDurationIncByTic, = On Caster, spell buff duration mod, base: tics
+	constexpr int SkillAttackProc                 = 288; // implemented, @Procs, chance to cast a spell when using a skill, base: chance, limit: skill, max: spellid, note: if used in AA the spell id is set in aa_ranks spell field, chance is calculated as 100% = value 1000.
+	constexpr int CastOnFadeEffect                = 289; // implemented - Triggers only if fades after natural duration.
+	constexpr int IncreaseRunSpeedCap             = 290; // implemented[AA] - increases run speed over the hard cap
+	constexpr int Purify                          = 291; // implemented, @Dispel, remove up specified amount of detiremental spells, base: amt removed, limit: none, max: none, Note: excluding charm, fear, resurrection, and revival sickness
+	constexpr int StrikeThrough2                  = 292; // implemented[AA] - increasing chance of bypassing an opponent's special defenses, such as dodge, block, parry, and riposte.
+	constexpr int FrontalStunResist               = 293; // implemented[AA] - Reduce chance to be stunned from front. -- live descriptions sounds like this isn't limited to frontal anymore
+	constexpr int CriticalSpellChance             = 294; // implemented - increase chance to critical hit and critical damage modifier.
+	constexpr int ReduceTimerSpecial              = 295; // not used
+	constexpr int FcSpellVulnerability            = 296; // implemented, @Fc, On Target, spell damage taken mod pct, base: min pct, limit: max pct
+	constexpr int FcDamageAmtIncoming             = 297; // implemetned, @Fc, On Target, damage taken flat amt, base: amt
+	constexpr int ChangeHeight                    = 298; // implemented
+	constexpr int WakeTheDead                     = 299; // implemented, @Pets, summon one temporary pet from nearby corpses that last a set duration, base: none, limit: none, max: duration (seconds). Note: max range of corpse is 250.
+	constexpr int Doppelganger                    = 300; // implemented
+	constexpr int ArcheryDamageModifier           = 301; // implemented[AA] - increase archery damage by percent
+	constexpr int FcDamagePctCrit                 = 302; // implemented, @Fc, On Caster, spell damage mod pct, base: min pct, limit: max pct, Note: applied after critical hits has been calculated.
+	constexpr int FcDamageAmtCrit                 = 303; // implemented, @Fc, On Caster, spell damage mod flat amt, base: amt
+	constexpr int OffhandRiposteFail              = 304; // implemented as bonus - enemy cannot riposte offhand attacks
+	constexpr int MitigateDamageShield            = 305; // implemented - off hand attacks only (Shielding Resistance)
+	constexpr int ArmyOfTheDead                   = 306; // implemented, @Pets, summon multiple temporary pets from nearby corpses that last a set duration, base: amount of corpses that a pet can summon from, limit: none, max: duration (seconds). Note: max range of corpse is 250.
+	constexpr int Appraisal                       = 307; // *not implemented Rogue AA - This ability allows you to estimate the selling price of an item you are holding on your cursor.
+	constexpr int ZoneSuspendMinion               = 308; // implemented, @Pet, allow suspended pets to be resummoned upon zoning, base: 1, limit: none, max: none, Calc: Bool
+	constexpr int GateCastersBindpoint            = 309; // implemented - Gate to casters bind point
+	constexpr int ReduceReuseTimer                = 310; // implemented, @Fc, On Caster, spell and disc reuse time mod by amount, base: milliseconds
+	constexpr int LimitCombatSkills               = 311; // implemented, @Ff, Include or exclude combat skills or procs from being focused, base1: 0=Exclude if proc 1=Allow only if proc.
+	constexpr int Sanctuary                       = 312; // implemented - Places caster at bottom hate list, effect fades if cast cast spell on targets other than self.
+	constexpr int ForageAdditionalItems           = 313; // implemented[AA] - chance to forage additional items
+	constexpr int Invisibility2                   = 314; // implemented - fixed duration invisible
+	constexpr int InvisVsUndead2                  = 315; // implemented - fixed duration ITU
+	constexpr int ImprovedInvisAnimals            = 316; // implemented
+	constexpr int ItemHPRegenCapIncrease          = 317; // implemented[AA] - increases amount of health regen gained via items
+	constexpr int ItemManaRegenCapIncrease        = 318; // implemented - increases amount of mana regen you can gain via items
+	constexpr int CriticalHealOverTime            = 319; // implemented
+	constexpr int ShieldBlock                     = 320; // implemented - Block attacks with shield
+	constexpr int ReduceHate                      = 321; // implemented
+	constexpr int GateToHomeCity                  = 322; // implemented
+	constexpr int DefensiveProc                   = 323; // implemented
+	constexpr int HPToMana                        = 324; // implemented
+	constexpr int NoBreakAESneak                  = 325; // implemented[AA] - [AA Nerves of Steel] increasing chance to remain hidden when they are an indirect target of an AoE spell.
+	constexpr int SpellSlotIncrease               = 326; // *not implemented as bonus - increases your spell slot availability
+	constexpr int MysticalAttune                  = 327; // implemented - increases amount of buffs that a player can have
+	constexpr int DelayDeath                      = 328; // implemented - increases how far you can fall below 0 hp before you die
+	constexpr int ManaAbsorbPercentDamage         = 329; // implemented
+	constexpr int CriticalDamageMob               = 330; // implemented
+	constexpr int Salvage                         = 331; // implemented - chance to recover items that would be destroyed in failed tradeskill combine
+	constexpr int SummonToCorpse                  = 332; // *not implemented AA - Call of the Wild (Druid/Shaman Res spell with no exp) TOOD: implement this.
+	constexpr int CastOnRuneFadeEffect            = 333; // implemented
+	constexpr int BardAEDot                       = 334; // implemented
+	constexpr int BlockNextSpellFocus             = 335; // implemented, @Fc, On Caster, chance to block next spell, base: chance
+	constexpr int IllusionaryTarget               = 336; // not used
+	constexpr int PercentXPIncrease               = 337; // implemented
+	constexpr int SummonAndResAllCorpses          = 338; // implemented
+	constexpr int TriggerOnCast                   = 339; // implemented, @Fc, On Caster, cast on spell use, base: chance pct limit: spellid
+	constexpr int SpellTrigger                    = 340; // implemented - chance to trigger spell [Share rolls with 469] All base2 spells share roll chance, only 1 cast.
+	constexpr int ItemAttackCapIncrease           = 341; // implemented[AA] - increases the maximum amount of attack you can gain from items.
+	constexpr int ImmuneFleeing                   = 342; // implemented - stop mob from fleeing
+	constexpr int InterruptCasting                = 343; // implemented - % chance to interrupt spells being cast every tic. Cacophony (8272)
+	constexpr int ChannelChanceItems              = 344; // implemented[AA] - chance to not have ITEM effects interrupted when you take damage.
+	constexpr int AssassinateLevel                = 345; // implemented as bonus - AA Assisination max level to kill
+	constexpr int HeadShotLevel                   = 346; // implemented[AA] - HeadShot max level to kill
+	constexpr int DoubleRangedAttack              = 347; // implemented - chance at an additional archery attack (consumes arrow)
+	constexpr int LimitManaMin                    = 348; // implemented, @Ff, Mininum mana of spell that can be focused, base1: mana amt
+	constexpr int ShieldEquipDmgMod               = 349; // implemented[AA] Increase melee base damage (indirectly increasing hate) when wearing a shield.
+	constexpr int ManaBurn                        = 350; // implemented - Drains mana for damage/heal at a defined ratio up to a defined maximum amount of mana.
+	constexpr int PersistentEffect                = 351; // *not implemented. creates a trap/totem that casts a spell (spell id + base1?) when anything comes near it. can probably make a beacon for this
+	constexpr int IncreaseTrapCount               = 352; // *not implemented - looks to be some type of invulnerability? Test ITC (8755)
+	constexpr int AdditionalAura                  = 353; // *not implemented - allows use of more than 1 aura, aa effect
+	constexpr int DeactivateAllTraps              = 354; // *not implemented - looks to be some type of invulnerability? Test DAT (8757)
+	constexpr int LearnTrap                       = 355; // *not implemented - looks to be some type of invulnerability? Test LT (8758)
+	constexpr int ChangeTriggerType               = 356; // not used
+	constexpr int FcMute                          = 357; // implemented, @Fc, On Caster, prevents spell casting, base: chance pct
+	constexpr int CurrentManaOnce                 = 358; // implemented
+	constexpr int PassiveSenseTrap                = 359; // *not implemented - Invulnerability (Brell's Blessing)
+	constexpr int ProcOnKillShot                  = 360; // implemented - a buff that has a base1 % to cast spell base2 when you kill a "challenging foe" base3 min level
+	constexpr int SpellOnDeath                    = 361; // implemented - casts spell on death of buffed
+	constexpr int PotionBeltSlots                 = 362; // *not implemented[AA] 'Quick Draw' expands the potion belt by one additional available item slot per rank.
+	constexpr int BandolierSlots                  = 363; // *not implemented[AA] 'Battle Ready' expands the bandolier by one additional save slot per rank.
+	constexpr int TripleAttackChance              = 364; // implemented
+	constexpr int ProcOnSpellKillShot             = 365; // implemented - chance to trigger a spell on kill when the kill is caused by a specific spell with this effect in it (10470 Venin)
+	constexpr int GroupShielding                  = 366; // *not implemented[AA] This gives you /shieldgroup
+	constexpr int SetBodyType                     = 367; // implemented - set body type of base1 so it can be affected by spells that are limited to that type (Plant, Animal, Undead, etc)
+	constexpr int FactionMod                      = 368; // *not implemented - increases faction with base1 (faction id, live won't match up w/ ours) by base2
+	constexpr int CorruptionCounter               = 369; // implemented
+	constexpr int ResistCorruption                = 370; // implemented
+	constexpr int AttackSpeed4                    = 371; // implemented - stackable slow effect 'Inhibit Melee'
+	constexpr int ForageSkill                     = 372; // implemented[AA] Will increase the skill cap for those that have the Forage skill and grant the skill and raise the cap to those that do not.
+	constexpr int CastOnFadeEffectAlways          = 373; // implemented - Triggers if fades after natural duration OR from rune/numhits fades.
+	constexpr int ApplyEffect                     = 374; // implemented
+	constexpr int DotCritDmgIncrease              = 375; // implemented - Increase damage of DoT critical amount
+	constexpr int Fling                           = 376; // *not implemented - used in 2 test spells (12945 | Movement Test Spell 1)
+	constexpr int CastOnFadeEffectNPC             = 377; // implemented - Triggers only if fades after natural duration (On live these are usually players spells that effect an NPC).
+	constexpr int SpellEffectResistChance         = 378; // implemented - Increase chance to resist specific spell effect (base1=value, base2=spell effect id)
+	constexpr int ShadowStepDirectional           = 379; // implemented - handled by client
+	constexpr int Knockdown                       = 380; // implemented - small knock back(handled by client)
+	constexpr int KnockTowardCaster               = 381; // *not implemented (Call of Hither) knocks you back to caster (value) distance units infront
+	constexpr int NegateSpellEffect               = 382; // implemented, @Debuff, negates specific spell effect benefits for the duration of the debuff and prevent non-duration spell effect from working, base: see NegateSpellEffecttype Enum, limit: SPA id, max: none
+	constexpr int SympatheticProc                 = 383; // implemented, @Fc, On Caster, cast on spell use, base: variable proc chance on cast time, limit: spellid
+	constexpr int Leap                            = 384; // implemented - Leap effect, ie stomping leap
+	constexpr int LimitSpellGroup                 = 385; // implemented, @Ff, Spell group(s) that a spell focus can require or exclude, base1: spellgroup id, Include: Positive Exclude: Negative
+	constexpr int CastOnCurer                     = 386; // implemented - Casts a spell on the person curing
+	constexpr int CastOnCure                      = 387; // implemented - Casts a spell on the cured person
+	constexpr int SummonCorpseZone                = 388; // implemented - summons a corpse from any zone(nec AA)
+	constexpr int FcTimerRefresh                  = 389; // implemented, @Fc, On Caster, reset all recast timers, base: 1, Note: Applied from casted spells only
+	constexpr int FcTimerLockout                  = 390; // implemented, @Fc, On Caster, set a spell to be on recast timer, base: recast duration milliseconds, Note: Applied from casted spells only
+	constexpr int LimitManaMax                    = 391; // implemented, @Ff, Mininum mana of spell that can be focused, base1: mana amt
+	constexpr int FcHealAmt                       = 392; // implemented, @Fc, On Caster, spell healing mod flat amt, base: amt
+	constexpr int FcHealPctIncoming               = 393; // implemented, @Fc, On Target, heal received mod pct, base: pct, limit: random max pct
+	constexpr int FcHealAmtIncoming               = 394; // implemented, @Fc, On Target, heal received mod flat amt, base: amt
+	constexpr int FcHealPctCritIncoming           = 395; // implemented, @Fc, On Target, heal received mod pct, base: pct, limit: random max pct
+	constexpr int FcHealAmtCrit                   = 396; // implemented, @Fc, On Caster, spell healing mod flat amt, base: amt
+	constexpr int PetMeleeMitigation              = 397; // implemented[AA] - additional mitigation to your pets. Adds AC
+	constexpr int SwarmPetDuration                = 398; // implemented - Affects the duration of swarm pets
+	constexpr int FcTwincast                      = 399; // implemented - cast 2 spells for every 1
+	constexpr int HealGroupFromMana               = 400; // implemented - Drains mana and heals for each point of mana drained
+	constexpr int ManaDrainWithDmg                = 401; // implemented - Deals damage based on the amount of mana drained
+	constexpr int EndDrainWithDmg                 = 402; // implemented - Deals damage for the amount of endurance drained
+	constexpr int LimitSpellClass                 = 403; // implemented, @Ff, 'Spell Category' using table field 'spell_class' that a spell focus can require or exclude, base1: category type, Include: Positive Exclude: Negative
+	constexpr int LimitSpellSubclass              = 404; // implemented, @Ff, 'Spell Category Subclass' using table field 'spell_subclass' that a spell focus can require or exclude, base1: category type, Include: Positive Exclude: Negative
+	constexpr int TwoHandBluntBlock               = 405; // implemented - chance to block attacks when using two hand blunt weapons (similiar to shield block)
+	constexpr int CastonNumHitFade                = 406; // implemented - casts a spell when a buff fades due to its numhits being depleted
+	constexpr int CastonFocusEffect               = 407; // implemented - casts a spell if focus limits are met (ie triggers when a focus effects is applied)
+	constexpr int LimitHPPercent                  = 408; // implemented - limited to a certain percent of your hp(ie heals up to 50%)
+	constexpr int LimitManaPercent                = 409; // implemented - limited to a certain percent of your mana
+	constexpr int LimitEndPercent                 = 410; // implemented - limited to a certain percent of your end
+	constexpr int LimitClass                      = 411; // implemented, @Ff, Class(es) that can use the spell focus, base1: class(es), Note: The class value in dbase is +1 in relation to item class value, set as you would item for multiple classes
+	constexpr int LimitRace                       = 412; // implemented, @Ff, Race that can use the spell focus, base1: race, Note: not used in any known live spells. Use only single race at a time.
+	constexpr int FcBaseEffects                   = 413; // implemented, @Fc, On Caster, base spell effectiveness mod pct, base: pct
+	constexpr int LimitCastingSkill               = 414; // implemented, @Ff, Spell and singing skills(s) that a spell focus can require or exclude, base1: skill id, Include: Positive Exclude: Negative
+	constexpr int FFItemClass                     = 415; // implemented, @Ff, Limits focuses to be applied only from item click. base1: item ItemType (-1 to include for all ItemTypes,-1000 to exclude clicks from getting the focus, or exclude specific SubTypes or Slots if set), limit: item SubType (-1 for all SubTypes), max: item Slots (bitmask of valid slots, -1 ALL slots), Note: not used on live. See comments in Mob::CalcFocusEffect for more details.
+	constexpr int ACv2                            = 416; // implemented - New AC spell effect
+	constexpr int ManaRegen_v2                    = 417; // implemented - New mana regen effect
+	constexpr int SkillDamageAmount2              = 418; // implemented - adds skill damage directly to certain attacks
+	constexpr int AddMeleeProc                    = 419; // implemented - Adds a proc
+	constexpr int FcLimitUse                      = 420; // implemented, @Fc, On Caster, numhits mod pct, base: pct, Note: not used in any known live spells
+	constexpr int FcIncreaseNumHits               = 421; // implemented, @Fc, On Caster, numhits mod flat amt, base: amt
+	constexpr int LimitUseMin                     = 422; // implemented, @Ff Minium amount of numhits for a spell to be focused, base: numhit amt
+	constexpr int LimitUseType                    = 423; // implemented, = @Ff Focus will only affect if has this numhits type, base: numhit type
+	constexpr int GravityEffect                   = 424; // implemented - Pulls/pushes you toward/away the mob at a set pace
+	constexpr int Display                         = 425; // *not implemented - Illusion: Flying Dragon(21626)
+	constexpr int IncreaseExtTargetWindow         = 426; // *not implmented[AA] - increases the capacity of your extended target window
+	constexpr int SkillProcAttempt                = 427; // implemented - chance to proc when using a skill(ie taunt)
+	constexpr int LimitToSkill                    = 428; // implemented, @Procs, limits what combat skills will effect a skill proc, base: skill value, limit: none, max: none
+	constexpr int SkillProcSuccess                = 429; // implemented - chance to proc when tje skill in use successfully fires.
+	constexpr int PostEffect                      = 430; // *not implemented - Fear of the Dark(27641) - Alters vision
+	constexpr int PostEffectData                  = 431; // *not implemented - Fear of the Dark(27641) - Alters vision
+	constexpr int ExpandMaxActiveTrophyBen        = 432; // not used
+	constexpr int CriticalDotDecay                = 433; // implemented - increase critical dot chance, effect decays based on level of spell it effects. (12266)
+	constexpr int CriticalHealDecay               = 434; // implemented - increase critical heal chance, effect decays based on level of spell it effects.
+	constexpr int CriticalRegenDecay              = 435; // implemented - increase critical heal over time chance, effect decays based on level of spell it effects.
+	constexpr int BeneficialCountDownHold         = 436; // not used ( 23491 | ABTest Buff Hold)
+	constexpr int TeleporttoAnchor                = 437; // *not implemented - Teleport Guild Hall Anchor(33099)
+	constexpr int TranslocatetoAnchor             = 438; // *not implemented - Translocate Primary Anchor (27750)
+	constexpr int Assassinate                     = 439; // implemented[AA] - Assassinate damage
+	constexpr int FinishingBlowLvl                = 440; // implemented[AA] - Sets the level Finishing blow can be triggered on an NPC
+	constexpr int DistanceRemoval                 = 441; // implemented - Buff is removed from target when target moves X amount of distance away from where initially hit.
+	constexpr int TriggerOnReqTarget              = 442; // implemented, @SpellTrigger, triggers a spell when Target Requirement conditions are met (see enum SpellRestriction for IDs), base: spellid, limit: SpellRestriction ID, max: none, Note: Usually cast on a target
+	constexpr int TriggerOnReqCaster              = 443; // implemented, @SpellTrigger, triggers a spell when Caster Requirement conditions are met (see enum SpellRestriction for IDs), base: spellid, limit: SpellRestriction ID, max: none, Note: Usually self only
+	constexpr int ImprovedTaunt                   = 444; // implemented - Locks Aggro On Caster and Decrease other Players Aggro by X% on NPC targets below level Y
+	constexpr int AddMercSlot                     = 445; // *not implemented[AA] - [Hero's Barracks] Allows you to conscript additional mercs.
+	constexpr int AStacker                        = 446; // implementet - bufff stacking blocker (26219 | Qirik's Watch)
+	constexpr int BStacker                        = 447; // implemented
+	constexpr int CStacker                        = 448; // implemented
+	constexpr int DStacker                        = 449; // implemented
+	constexpr int MitigateDotDamage               = 450; // implemented, @Runes, mitigate incoming dot damage by percentage until rune fades, base: percent mitigation, limit: max dmg absorbed per hit, max: rune amt, Note: If placed on item or AA, will provide stackable percent mitigation.
+	constexpr int MeleeThresholdGuard             = 451; // implemented Partial Melee Rune that only is lowered if melee hits are over X amount of damage
+	constexpr int SpellThresholdGuard             = 452; // implemented Partial Spell Rune that only is lowered if spell hits are over X amount of damage
+	constexpr int TriggerMeleeThreshold           = 453; // implemented Trigger effect on X amount of melee damage taken in a single hit
+	constexpr int TriggerSpellThreshold           = 454; // implemented Trigger effect on X amount of spell damage taken in a single hit
+	constexpr int AddHatePct                      = 455; // implemented Modify total hate by %
+	constexpr int AddHateOverTimePct              = 456; // implemented Modify total hate by % over time.
+	constexpr int ResourceTap                     = 457; // implemented Coverts a percent of dmg from dmg spells(DD/DoT) to hp/mana/end.
+	constexpr int FactionModPct                   = 458; // implemented Modifies faction gains and losses by percent.
+	constexpr int DamageModifier2                 = 459; // implemented - Modifies melee damage by skill type
+	constexpr int Ff_Override_NotFocusable        = 460; // implemented, @Fc, Allow spell to be focused event if flagged with 'not_focusable' in spell table, base: 1
+	constexpr int ImprovedDamage2                 = 461; // implemented, @Fc, On Caster, spell damage mod pct, base: min pct, limit: max pct
+	constexpr int FcDamageAmt2                    = 462; // implemented, @Fc, On Caster, spell damage mod flat amt, base: amt
+	constexpr int Shield_Target                   = 463; // implemented, Base1 % damage shielded on target
+	constexpr int PC_Pet_Rampage                  = 464; // implemented - Base1 % chance to do rampage for base2 % of damage each melee round
+	constexpr int PC_Pet_AE_Rampage               = 465; // implemented - Base1 % chance to do AE rampage for base2 % of damage each melee round
+	constexpr int PC_Pet_Flurry_Chance            = 466; // implemented - Base1 % chance to do flurry from double attack hit.
+	constexpr int DS_Mitigation_Amount            = 467; // implemented - Modify incoming damage shield damage by a flat amount
+	constexpr int DS_Mitigation_Percentage        = 468; // implemented - Modify incoming damage shield damage by percentage
+	constexpr int Chance_Best_in_Spell_Grp        = 469; // implemented - Chance to cast highest scribed spell within a spell group. All base2 spells share roll chance, only 1 cast.
+	constexpr int Trigger_Best_in_Spell_Grp       = 470; // implemented - Chance to cast highest scribed spell within a spell group. Each spell has own chance.
+	constexpr int Double_Melee_Round              = 471; // implemented, @OffBonus, percent chance to repeat primary weapon round with a percent damage modifier, base: pct chance repeat, limit: pct dmg mod, max: none
+	constexpr int Buy_AA_Rank                     = 472; // implemented, @Special, Used in AA abilities that have Enable/Disable toggle. Spell on Disabled Rank has this effect in it, base: 1, limit: none, max: none, Note: This will not just buy an AA
+	constexpr int Double_Backstab_Front           = 473; // implemented - Chance to double backstab from front
+	constexpr int Pet_Crit_Melee_Damage_Pct_Owner = 474; // implemenetd - Critical damage mod applied to pets from owner
+	constexpr int Trigger_Spell_Non_Item          = 475; // implemented - Trigger spell on cast only if not from item click.
+	constexpr int Weapon_Stance                   = 476; // implemented, @Misc, Apply a specific spell buffs automatically depending 2Hander, Shield or Dual Wield is equipped, base: spellid, base: 0=2H 1=Shield 2=DW, max: none
+	constexpr int Hatelist_To_Top_Index           = 477; // Implemented - Chance to be set to top of rampage list
+	constexpr int Hatelist_To_Tail_Index          = 478; // Implemented - Chance to be set to bottom of rampage list
+	constexpr int Ff_Value_Min                    = 479; // implemented, @Ff, Minimum base value of a spell that can be focused, base: spells to be focused base1 value
+	constexpr int Ff_Value_Max                    = 480; // implemented, @Ff, Max base value of a spell that can be focused, base: spells to be focused base1 value
+	constexpr int Fc_Cast_Spell_On_Land           = 481; // implemented, @Fc, On Target, cast spell if hit by spell, base: chance pct, limit: spellid
+	constexpr int Skill_Base_Damage_Mod           = 482; // implemented, @OffBonus, modify base melee damage by percent, base: pct, limit: skill(-1=ALL), max: none
+	constexpr int Fc_Spell_Damage_Pct_IncomingPC  = 483; // implemented, @Fc, On Target, spell damage taken mod pct, base: min pct, limit: max pct
+	constexpr int Fc_Spell_Damage_Amt_IncomingPC  = 484; // implemented, @Fc, On Target, damage taken flat amt, base: amt
+	constexpr int Ff_CasterClass                  = 485; // implemented, @Ff, Caster of spell on target with a focus effect that is checked by incoming spells must be specified class(es). base1: class(es), Note: Set multiple classes same as would for items
+	constexpr int Ff_Same_Caster                  = 486; // implemented, @Ff, Caster of spell on target with a focus effect that is checked by incoming spells, base1: 0=Must be different caster 1=Must be same caster
+	constexpr int Extend_Tradeskill_Cap           = 487; //
+	constexpr int Defender_Melee_Force_Pct_PC     = 488; //
+	constexpr int Worn_Endurance_Regen_Cap        = 489; // implemented, modify worn regen cap, base: amt, limit: none, max: none
+	constexpr int Ff_ReuseTimeMin                 = 490; // implemented, @Ff, Minimum recast time of a spell that can be focused, base: recast time
+	constexpr int Ff_ReuseTimeMax                 = 491; // implemented, @Ff, Max recast time of a spell that can be focused, base: recast time
+	constexpr int Ff_Endurance_Min                = 492; // implemented, @Ff, Minimum endurance cost of a spell that can be focused, base: endurance cost
+	constexpr int Ff_Endurance_Max                = 493; // implemented, @Ff, Max endurance cost of a spell that can be focused, base: endurance cost
+	constexpr int Pet_Add_Atk                     = 494; // implemented - Bonus on pet owner which gives their pet increased attack stat
+	constexpr int Ff_DurationMax                  = 495; // implemented, @Ff, Max duration of spell that can be focused, base: tics
+	constexpr int Critical_Melee_Damage_Mod_Max   = 496; // implemented - increase or decrease by percent critical damage (not stackable)
+	constexpr int Ff_FocusCastProcNoBypass        = 497; //
+	constexpr int AddExtraAttackPct_1h_Primary    = 498; // implemented, @OffBonus, gives your double attacks a percent chance to perform an extra attack with 1-handed primary weapon, base: chance, limit: amt attacks, max: none
+	constexpr int AddExtraAttackPct_1h_Secondary  = 499; //implemented, @OffBonus, gives your double attacks a percent chance to perform an extra attack with 1-handed secondary weapon, base: chance, limit: amt attacks, max: none
+	constexpr int Fc_CastTimeMod2                 = 500; // implemented, @Fc, On Caster, cast time mod pct, base: pct, Note: Can reduce to instant cast
+	constexpr int Fc_CastTimeAmt                  = 501; // implemented, @Fc, On Caster, cast time mod flat amt, base: milliseconds, Note: Can reduce to instant cast
+	constexpr int Fearstun                        = 502; // implemented - Stun with a max level limit. Normal stun restrictions don't apply.
+	constexpr int Melee_Damage_Position_Mod       = 503; // implemented, @OffBonus, modify melee damage by percent if done from Front or Behind opponent, base: pct, limit: 0=back 1=front, max: none
+	constexpr int Melee_Damage_Position_Amt       = 504; // implemented, @OffBonus, modify melee damage by flat amount if done from Front or Behind opponent, base: amt, limit: 0=back 1=front, max: none
+	constexpr int Damage_Taken_Position_Mod       = 505; // implemented, @DefBonus, modify melee damage by percent if dmg taken from Front or Behind, base: pct, limit: 0=back 1=front, max: none
+	constexpr int Damage_Taken_Position_Amt       = 506; // implemented -@DefBonus, modify melee damage by flat amount if dmg taken from your Front or Behind, base: amt, limit: 0=back 1=front, max: none
+	constexpr int Fc_Amplify_Mod                  = 507; // implemented, @Fc, On Caster, damage-heal-dot mod pct, base: pct
+	constexpr int Fc_Amplify_Amt                  = 508; // implemented, @Fc, On Caster, damage-heal-dot mod flat amt, base: amt
+	constexpr int Health_Transfer                 = 509; // implemented - exchange health for damage or healing on a target. ie Lifeburn/Act of Valor
+	constexpr int Fc_ResistIncoming               = 510; // implemented, @Fc, On Target, resist modifier, base: amt
+	constexpr int Ff_FocusTimerMin                = 511; // implemented, @Ff, sets a recast time until focus can be used again, base: 1, limit: time ms, Note: ie. limit to 1 trigger every 1.5 seconds
+	constexpr int Proc_Timer_Modifier             = 512; // implemented - limits procs per amount of a time based on timer value, base: 1, limit: time ms, Note:, ie limit to 1 proc every 55 seconds)
+	constexpr int Mana_Max_Percent                = 513; //
+	constexpr int Endurance_Max_Percent           = 514; //
+	constexpr int AC_Avoidance_Max_Percent        = 515; // implemented - stackable avoidance modifier
+	constexpr int AC_Mitigation_Max_Percent       = 516; // implemented - stackable defense modifier
+	constexpr int Attack_Offense_Max_Percent      = 517; //
+	constexpr int Attack_Accuracy_Max_Percent     = 518; // implemented - stackable accurary modifer
+	constexpr int Luck_Amount                     = 519; //
+	constexpr int Luck_Percent                    = 520; //
+	constexpr int Endurance_Absorb_Pct_Damage     = 521; // implemented - Reduces % of Damage using Endurance, drains endurance at a ratio (ie. 0.05 Endurance per Hit Point)
+	constexpr int Instant_Mana_Pct                = 522; // implemented - Increase/Decrease mana by percent of max mana
+	constexpr int Instant_Endurance_Pct           = 523; // implemented - Increase/Decrease mana by percent of max endurance
+	constexpr int Duration_HP_Pct                 = 524; // implemented - Decrease Current Hit Points by % of Total Hit Points per Tick, up to a MAX per tick
+	constexpr int Duration_Mana_Pct               = 525; // implemented - Decrease Current Mana by % of Total Mana per Tick, up to a MAX per tick
+	constexpr int Duration_Endurance_Pct          = 526; // implemented - Decrease Current Endurance by % of Total Hit Points per Tick, up to a MAX per tick
+}
 
 #define DF_Permanent				50
 #define DF_Aura						51
@@ -1698,7 +1697,7 @@ struct SPDat_Spell_Struct
 /* 181 */	int pvp_duration; // buffdurationformula for PvP -- PVP_DURATION
 /* 182 */	int pvp_duration_cap; // buffduration for PvP -- PVP_DURATION_CAP
 /* 183 */	int pcnpc_only_flag; // valid values are 0, 1 = PCs (and mercs), and 2 = NPCs (and not mercs) -- PCNPC_ONLY_FLAG
-/* 184 */	bool cast_not_standing; // this is checked in the client's EQ_Spell::IsCastWhileInvisSpell, this also blocks SE_InterruptCasting from affecting this spell -- CAST_NOT_STANDING (Allows casting if DA, stun, mezed, charm? fear?, damage to invul targets)
+/* 184 */	bool cast_not_standing; // this is checked in the client's EQ_Spell::IsCastWhileInvisSpell, this also blocks SpellEffect::InterruptCasting from affecting this spell -- CAST_NOT_STANDING (Allows casting if DA, stun, mezed, charm? fear?, damage to invul targets)
 /* 185 */	bool can_mgb; // 0=no, -1 or 1 = yes -- CAN_MGB
 /* 186 */	int dispel_flag; // -- NO_DISPELL
 /* 187 */	//int npc_category; // -- NPC_MEM_CATEGORY

--- a/zone/aa.cpp
+++ b/zone/aa.cpp
@@ -82,7 +82,7 @@ void Mob::TemporaryPets(uint16 spell_id, Mob *targ, const char *name_override, u
 
 	for (int x = 0; x < MAX_SWARM_PETS; x++)
 	{
-		if (spells[spell_id].effect_id[x] == SE_TemporaryPets)
+		if (spells[spell_id].effect_id[x] == SpellEffect::TemporaryPets)
 		{
 			pet.count = spells[spell_id].base_value[x];
 			pet.duration = spells[spell_id].max_value[x];
@@ -1376,7 +1376,7 @@ int Mob::GetAlternateAdvancementCooldownReduction(AA::Rank *rank_in) {
 		}
 
 		for(auto &effect : rank->effects) {
-			if(effect.effect_id == SE_HastenedAASkill && effect.limit_value == ability_in->id) {
+			if(effect.effect_id == SpellEffect::HastenedAASkill && effect.limit_value == ability_in->id) {
 				total_reduction += effect.base_value;
 			}
 		}
@@ -1949,7 +1949,7 @@ void Client::TogglePassiveAlternativeAdvancement(const AA::Rank &rank, uint32 ab
 
 		Instructions for how to make the AA - assuming a basic level of knowledge of how AA's work.
 		- aa_abilities table : Create new ability with a hotkey, type 3, zero charges
-		- aa_ranks table :  [Disabled rank] First rank, should have a cost > 0 (this is what you buy), Set hotkeys, MUST SET A SPELL CONTAINING EFFECT SE_Buy_AA_Rank(SPA 472), set a short recast timer.
+		- aa_ranks table :  [Disabled rank] First rank, should have a cost > 0 (this is what you buy), Set hotkeys, MUST SET A SPELL CONTAINING EFFECT SpellEffect::Buy_AA_Rank(SPA 472), set a short recast timer.
 							[Enabled rank] Second rank, should have a cost = 0, Set hotkeys, Set any valid spell ID you want (it has to exist but does nothing), set a short recast timer.
 							*Recommend if doing custom, just make the hotkey titled 'Toggle <Ability Name>' and use for both.
 
@@ -1969,7 +1969,7 @@ void Client::TogglePassiveAlternativeAdvancement(const AA::Rank &rank, uint32 ab
 
 	*/
 
-	bool enable_next_rank = IsEffectInSpell(rank.spell, SE_Buy_AA_Rank);
+	bool enable_next_rank = IsEffectInSpell(rank.spell, SpellEffect::Buy_AA_Rank);
 
 	if (enable_next_rank) {
 
@@ -1980,7 +1980,7 @@ void Client::TogglePassiveAlternativeAdvancement(const AA::Rank &rank, uint32 ab
 		AA::Rank *rank_next = zone->GetAlternateAdvancementRank(rank.next_id);
 
 		//Add checks for any special cases for toggle.
-		if (rank_next && IsEffectinAlternateAdvancementRankEffects(*rank_next, SE_Weapon_Stance)) {
+		if (rank_next && IsEffectinAlternateAdvancementRankEffects(*rank_next, SpellEffect::Weapon_Stance)) {
 			weaponstance.aabonus_enabled = true;
 			ApplyWeaponsStance();
 		}
@@ -1994,7 +1994,7 @@ void Client::TogglePassiveAlternativeAdvancement(const AA::Rank &rank, uint32 ab
 		Message(Chat::Spells, "You disable an ability."); //Message live gives you. Should come from spell.
 
 		//Add checks for any special cases for toggle.
-		if (IsEffectinAlternateAdvancementRankEffects(rank, SE_Weapon_Stance)) {
+		if (IsEffectinAlternateAdvancementRankEffects(rank, SpellEffect::Weapon_Stance)) {
 			weaponstance.aabonus_enabled = false;
 			BuffFadeBySpellID(weaponstance.aabonus_buff_spell_id);
 		}
@@ -2005,8 +2005,8 @@ void Client::TogglePassiveAlternativeAdvancement(const AA::Rank &rank, uint32 ab
 bool Client::UseTogglePassiveHotkey(const AA::Rank &rank) {
 
 	/*
-		Disabled rank needs a rank spell containing the SE_Buy_AA_Rank effect to return true.
-		Enabled rank checks to see if the prior rank contains a rank spell with SE_Buy_AA_Rank, if so true.
+		Disabled rank needs a rank spell containing the SpellEffect::Buy_AA_Rank effect to return true.
+		Enabled rank checks to see if the prior rank contains a rank spell with SpellEffect::Buy_AA_Rank, if so true.
 
 		Note: On live the enabled rank is Expendable with Charge 1.
 
@@ -2014,13 +2014,13 @@ bool Client::UseTogglePassiveHotkey(const AA::Rank &rank) {
 	*/
 
 
-	if (IsEffectInSpell(rank.spell, SE_Buy_AA_Rank)) {//Checked when is Disabled.
+	if (IsEffectInSpell(rank.spell, SpellEffect::Buy_AA_Rank)) {//Checked when is Disabled.
 		return true;
 	}
 	else if (rank.prev_id != -1) {//Check when effect is Enabled.
 		AA::Rank *rank_prev = zone->GetAlternateAdvancementRank(rank.prev_id);
 
-		if (rank_prev && IsEffectInSpell(rank_prev->spell, SE_Buy_AA_Rank)) {
+		if (rank_prev && IsEffectInSpell(rank_prev->spell, SpellEffect::Buy_AA_Rank)) {
 			return true;
 		}
 	}

--- a/zone/aggro.cpp
+++ b/zone/aggro.cpp
@@ -1377,132 +1377,132 @@ int32 Mob::CheckAggroAmount(uint16 spell_id, Mob *target, bool is_proc)
 
 	for (int o = 0; o < EFFECT_COUNT; o++) {
 		switch (spells[spell_id].effect_id[o]) {
-			case SE_CurrentHPOnce:
-			case SE_CurrentHP: {
+			case SpellEffect::CurrentHPOnce:
+			case SpellEffect::CurrentHP: {
 				int64 val = CalcSpellEffectValue_formula(spells[spell_id].formula[o], spells[spell_id].base_value[o], spells[spell_id].max_value[o], mob_level, spell_id);
 				if(val < 0) {
 					aggro_amount -= val;
 				}
 				break;
 			}
-			case SE_MovementSpeed: {
+			case SpellEffect::MovementSpeed: {
 				int64 val = CalcSpellEffectValue_formula(spells[spell_id].formula[o], spells[spell_id].base_value[o], spells[spell_id].max_value[o], mob_level, spell_id);
 				if (val < 0) {
 					aggro_amount += default_aggro;
 				}
 				break;
 			}
-			case SE_AttackSpeed:
-			case SE_AttackSpeed2:
-			case SE_AttackSpeed3: {
+			case SpellEffect::AttackSpeed:
+			case SpellEffect::AttackSpeed2:
+			case SpellEffect::AttackSpeed3: {
 				int64 val = CalcSpellEffectValue_formula(spells[spell_id].formula[o], spells[spell_id].base_value[o], spells[spell_id].max_value[o], mob_level, spell_id);
 				if (val < 100) {
 					aggro_amount += default_aggro;
 				}
 				break;
 			}
-			case SE_Stun:
-			case SE_Blind:
-			case SE_Mez:
-			case SE_Charm:
-			case SE_Fear:
-			case SE_Fearstun:
+			case SpellEffect::Stun:
+			case SpellEffect::Blind:
+			case SpellEffect::Mez:
+			case SpellEffect::Charm:
+			case SpellEffect::Fear:
+			case SpellEffect::Fearstun:
 				aggro_amount += default_aggro;
 				break;
-			case SE_Root:
+			case SpellEffect::Root:
 				aggro_amount += 10;
 				break;
-			case SE_ACv2:
-			case SE_ArmorClass: {
+			case SpellEffect::ACv2:
+			case SpellEffect::ArmorClass: {
 				int64 val = CalcSpellEffectValue_formula(spells[spell_id].formula[o], spells[spell_id].base_value[o], spells[spell_id].max_value[o], mob_level, spell_id);
 				if (val < 0) {
 					aggro_amount += default_aggro;
 				}
 				break;
 			}
-			case SE_ATK:
-			case SE_ResistMagic:
-			case SE_ResistFire:
-			case SE_ResistCold:
-			case SE_ResistPoison:
-			case SE_ResistDisease:
-			case SE_STR:
-			case SE_STA:
-			case SE_DEX:
-			case SE_AGI:
-			case SE_INT:
-			case SE_WIS:
-			case SE_CHA: {
+			case SpellEffect::ATK:
+			case SpellEffect::ResistMagic:
+			case SpellEffect::ResistFire:
+			case SpellEffect::ResistCold:
+			case SpellEffect::ResistPoison:
+			case SpellEffect::ResistDisease:
+			case SpellEffect::STR:
+			case SpellEffect::STA:
+			case SpellEffect::DEX:
+			case SpellEffect::AGI:
+			case SpellEffect::INT:
+			case SpellEffect::WIS:
+			case SpellEffect::CHA: {
 				int64 val = CalcSpellEffectValue_formula(spells[spell_id].formula[o], spells[spell_id].base_value[o], spells[spell_id].max_value[o], mob_level, spell_id);
 				if (val < 0) {
 					aggro_amount += 10;
 				}
 				break;
 			}
-			case SE_ResistAll: {
+			case SpellEffect::ResistAll: {
 				int64 val = CalcSpellEffectValue_formula(spells[spell_id].formula[o], spells[spell_id].base_value[o], spells[spell_id].max_value[o], mob_level, spell_id);
 				if (val < 0) {
 					aggro_amount += 50;
 				}
 				break;
 			}
-			case SE_AllStats: {
+			case SpellEffect::AllStats: {
 				int64 val = CalcSpellEffectValue_formula(spells[spell_id].formula[o], spells[spell_id].base_value[o], spells[spell_id].max_value[o], mob_level, spell_id);
 				if (val < 0) {
 					aggro_amount += 70;
 				}
 				break;
 			}
-			case SE_BardAEDot:
+			case SpellEffect::BardAEDot:
 				aggro_amount += 10;
 				break;
-			case SE_SpinTarget:
-			case SE_Amnesia:
-			case SE_Silence:
-			case SE_Destroy:
+			case SpellEffect::SpinTarget:
+			case SpellEffect::Amnesia:
+			case SpellEffect::Silence:
+			case SpellEffect::Destroy:
 				aggro_amount += default_aggro;
 				break;
 			// unsure -- leave them this for now
-			case SE_Harmony:
-			case SE_CastingLevel:
-			case SE_MeleeMitigation:
-			case SE_CriticalHitChance:
-			case SE_AvoidMeleeChance:
-			case SE_RiposteChance:
-			case SE_DodgeChance:
-			case SE_ParryChance:
-			case SE_DualWieldChance:
-			case SE_DoubleAttackChance:
-			case SE_MeleeSkillCheck:
-			case SE_HitChance:
-			case SE_DamageModifier:
-			case SE_MinDamageModifier:
-			case SE_IncreaseBlockChance:
-			case SE_Accuracy:
-			case SE_DamageShield:
-			case SE_SpellDamageShield:
-			case SE_ReverseDS: {
+			case SpellEffect::Harmony:
+			case SpellEffect::CastingLevel:
+			case SpellEffect::MeleeMitigation:
+			case SpellEffect::CriticalHitChance:
+			case SpellEffect::AvoidMeleeChance:
+			case SpellEffect::RiposteChance:
+			case SpellEffect::DodgeChance:
+			case SpellEffect::ParryChance:
+			case SpellEffect::DualWieldChance:
+			case SpellEffect::DoubleAttackChance:
+			case SpellEffect::MeleeSkillCheck:
+			case SpellEffect::HitChance:
+			case SpellEffect::DamageModifier:
+			case SpellEffect::MinDamageModifier:
+			case SpellEffect::IncreaseBlockChance:
+			case SpellEffect::Accuracy:
+			case SpellEffect::DamageShield:
+			case SpellEffect::SpellDamageShield:
+			case SpellEffect::ReverseDS: {
 				aggro_amount += mob_level * 2;
 				break;
 			}
 			// unsure -- leave them this for now
-			case SE_CurrentMana:
-			case SE_ManaRegen_v2:
-			case SE_ManaPool:
-			case SE_CurrentEndurance: {
+			case SpellEffect::CurrentMana:
+			case SpellEffect::ManaRegen_v2:
+			case SpellEffect::ManaPool:
+			case SpellEffect::CurrentEndurance: {
 				int64 val = CalcSpellEffectValue_formula(spells[spell_id].formula[o], spells[spell_id].base_value[o], spells[spell_id].max_value[o], mob_level, spell_id);
 				if (val < 0) {
 					aggro_amount -= val * 2;
 				}
 				break;
 			}
-			case SE_CancelMagic:
-			case SE_DispelDetrimental:
-			case SE_DispelBeneficial:
+			case SpellEffect::CancelMagic:
+			case SpellEffect::DispelDetrimental:
+			case SpellEffect::DispelBeneficial:
 				dispel = true;
 				break;
-			case SE_ReduceHate:
-			case SE_InstantHate:
+			case SpellEffect::ReduceHate:
+			case SpellEffect::InstantHate:
 				non_modified_aggro = CalcSpellEffectValue_formula(spells[spell_id].formula[o], spells[spell_id].base_value[o], spells[spell_id].max_value[o], mob_level, spell_id);
 				break;
 		}
@@ -1549,8 +1549,8 @@ int32 Mob::CheckHealAggroAmount(uint16 spell_id, Mob *target, uint32 heal_possib
 
 	for (int o = 0; o < EFFECT_COUNT; o++) {
 		switch (spells[spell_id].effect_id[o]) {
-			case SE_CurrentHP:
-			case SE_PercentalHeal:
+			case SpellEffect::CurrentHP:
+			case SpellEffect::PercentalHeal:
 			{
 			if (heal_possible == 0) {
 				AggroAmount += 1;
@@ -1572,12 +1572,12 @@ int32 Mob::CheckHealAggroAmount(uint16 spell_id, Mob *target, uint32 heal_possib
 			AggroAmount += std::max(val, (int64)1);
 			break;
 		}
-		case SE_Rune:
+		case SpellEffect::Rune:
 			AggroAmount += CalcSpellEffectValue_formula(spells[spell_id].formula[o],
 							 spells[spell_id].base_value[o], spells[spell_id].max_value[o], GetLevel(), spell_id) * 2;
 			ignore_default_buff = true;
 			break;
-		case SE_HealOverTime:
+		case SpellEffect::HealOverTime:
 			AggroAmount += 10;
 			ignore_default_buff = true;
 			break;

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -179,7 +179,7 @@ int Mob::compute_tohit(EQ::skills::SkillType skillinuse)
 //SYNC WITH: tune.cpp, mob.h TuneGetTotalToHit
 int Mob::GetTotalToHit(EQ::skills::SkillType skill, int chance_mod)
 {
-	if (chance_mod >= 10000) // override for stuff like SE_SkillAttack
+	if (chance_mod >= 10000) // override for stuff like SpellEffect::SkillAttack
 		return -1;
 
 	// calculate attacker's accuracy
@@ -209,7 +209,7 @@ int Mob::GetTotalToHit(EQ::skills::SkillType skill, int chance_mod)
 	if (atkhit_bonus)
 		accuracy += round(static_cast<double>(accuracy) * static_cast<double>(atkhit_bonus) * 0.0001);
 
-	// 216 Melee Accuracy Amt aka SE_Accuracy -- flat bonus
+	// 216 Melee Accuracy Amt aka SpellEffect::Accuracy -- flat bonus
 	accuracy += itembonuses.Accuracy[EQ::skills::HIGHEST_SKILL + 1] +
 		aabonuses.Accuracy[EQ::skills::HIGHEST_SKILL + 1] +
 		spellbonuses.Accuracy[EQ::skills::HIGHEST_SKILL + 1] +
@@ -224,7 +224,7 @@ int Mob::GetTotalToHit(EQ::skills::SkillType skill, int chance_mod)
 	if (spellbonuses.HitChanceEffect[EQ::skills::HIGHEST_SKILL + 1] >= 10000)
 		return -1;
 
-	// 184 Accuracy % aka SE_HitChance -- percentage increase
+	// 184 Accuracy % aka SpellEffect::HitChance -- percentage increase
 	auto hit_bonus = itembonuses.HitChanceEffect[EQ::skills::HIGHEST_SKILL + 1] +
 		aabonuses.HitChanceEffect[EQ::skills::HIGHEST_SKILL + 1] +
 		spellbonuses.HitChanceEffect[EQ::skills::HIGHEST_SKILL + 1] +
@@ -285,7 +285,7 @@ int Mob::compute_defense()
 	}
 
 
-	//516 SE_AC_Mitigation_Max_Percent
+	//516 SpellEffect::AC_Mitigation_Max_Percent
 	auto ac_bonus = itembonuses.AC_Mitigation_Max_Percent + aabonuses.AC_Mitigation_Max_Percent + spellbonuses.AC_Mitigation_Max_Percent;
 	if (ac_bonus) {
 		defense += round(static_cast<double>(defense) * static_cast<double>(ac_bonus) * 0.0001);
@@ -315,15 +315,15 @@ int Mob::GetTotalDefense()
 	if (evasion_bonus >= 10000)
 		return -1;
 
-	// 515 SE_AC_Avoidance_Max_Percent
+	// 515 SpellEffect::AC_Avoidance_Max_Percent
 	auto ac_aviodance_bonus = itembonuses.AC_Avoidance_Max_Percent + aabonuses.AC_Avoidance_Max_Percent + spellbonuses.AC_Avoidance_Max_Percent;
 	if (ac_aviodance_bonus)
 		avoidance += round(static_cast<double>(avoidance) * static_cast<double>(ac_aviodance_bonus) * 0.0001);
 
-	// 172 Evasion aka SE_AvoidMeleeChance
+	// 172 Evasion aka SpellEffect::AvoidMeleeChance
 	evasion_bonus += itembonuses.AvoidMeleeChanceEffect + aabonuses.AvoidMeleeChanceEffect; // item bonus here isn't mod2 avoidance
 
-	// 215 Pet Avoidance % aka SE_PetAvoidance
+	// 215 Pet Avoidance % aka SpellEffect::PetAvoidance
 	evasion_bonus += GetPetAvoidanceBonusFromOwner();
 
 	// Evasion is a percentage bonus according to AA descriptions
@@ -1917,7 +1917,7 @@ bool Client::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::Skil
 	dead = true;
 
 	if (m_pet && m_pet->IsCharmed()) {
-		m_pet->BuffFadeByEffect(SE_Charm);
+		m_pet->BuffFadeByEffect(SpellEffect::Charm);
 	}
 
 	if (GetMerc()) {
@@ -3678,7 +3678,7 @@ int64 Mob::ReduceDamage(int64 damage)
 		return DMG_RUNE;
 
 	if (spellbonuses.MeleeRune[SBIndex::RUNE_AMOUNT] && spellbonuses.MeleeRune[SBIndex::RUNE_BUFFSLOT] >= 0)
-		damage = RuneAbsorb(damage, SE_Rune);
+		damage = RuneAbsorb(damage, SpellEffect::Rune);
 
 	if (damage < 1)
 		return DMG_RUNE;
@@ -3805,10 +3805,10 @@ int64 Mob::AffectMagicalDamage(int64 damage, uint16 spell_id, const bool iBuffTi
 
 		//Regular runes absorb spell damage (except dots) - Confirmed on live.
 		if (spellbonuses.MeleeRune[SBIndex::RUNE_AMOUNT] && spellbonuses.MeleeRune[SBIndex::RUNE_BUFFSLOT] >= 0)
-			damage = RuneAbsorb(damage, SE_Rune);
+			damage = RuneAbsorb(damage, SpellEffect::Rune);
 
 		if (spellbonuses.AbsorbMagicAtt[SBIndex::RUNE_AMOUNT] && spellbonuses.AbsorbMagicAtt[SBIndex::RUNE_BUFFSLOT] >= 0)
-			damage = RuneAbsorb(damage, SE_AbsorbMagicAtt);
+			damage = RuneAbsorb(damage, SpellEffect::AbsorbMagicAtt);
 
 		if (damage < 1)
 			return 0;
@@ -4174,7 +4174,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 			damage = ReduceDamage(damage);
 			LogCombat("Melee Damage reduced to [{}]", damage);
 			damage = ReduceAllDamage(damage);
-			TryTriggerThreshHold(damage, SE_TriggerMeleeThreshold, attacker);
+			TryTriggerThreshHold(damage, SpellEffect::TriggerMeleeThreshold, attacker);
 
 			CheckNumHitsRemaining(NumHit::IncomingHitSuccess);
 		}
@@ -4199,7 +4199,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 				Message(263, "%s tries to cast on YOU, but YOUR magical skin absorbs the spell.", attacker->GetCleanName());
 			}
 			damage = ReduceAllDamage(damage);
-			TryTriggerThreshHold(damage, SE_TriggerSpellThreshold, attacker);
+			TryTriggerThreshHold(damage, SpellEffect::TriggerSpellThreshold, attacker);
 		}
 
 		if (IsClient() && CastToClient()->sneaking) {
@@ -4314,7 +4314,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 				GetCleanName(), /* Message1 */
 				attacker->GetCleanName() /* Message2 */
 			);
-			BuffFadeByEffect(SE_Mez);
+			BuffFadeByEffect(SpellEffect::Mez);
 		}
 
 		// broken up for readability
@@ -4399,12 +4399,12 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 			int bashsave_roll = zone->random.Int(0, 100);
 			if (bashsave_roll > 98 || bashsave_roll > (55 - stunbash_chance)) {
 				// did stun -- roll other resists
-				// SE_FrontalStunResist description says any angle now a days
+				// SpellEffect::FrontalStunResist description says any angle now a days
 				int stun_resist2 = spellbonuses.FrontalStunResist + itembonuses.FrontalStunResist +
 					aabonuses.FrontalStunResist;
 				if (zone->random.Int(1, 100) > stun_resist2) {
 					// stun resist 2 failed
-					// time to check SE_StunResist and mod2 stun resist
+					// time to check SpellEffect::StunResist and mod2 stun resist
 					int stun_resist =
 						spellbonuses.StunResist + itembonuses.StunResist + aabonuses.StunResist;
 					if (zone->random.Int(0, 100) >= stun_resist) {
@@ -5668,7 +5668,7 @@ void Mob::DoRiposte(Mob *defender)
 		defender->itembonuses.DoubleRiposte;
 
 	if (DoubleRipChance && zone->random.Roll(DoubleRipChance)) {
-		LogCombat("Preforming a double riposted from SE_DoubleRiposte ([{}] percent chance)", DoubleRipChance);
+		LogCombat("Preforming a double riposted from SpellEffect::DoubleRiposte ([{}] percent chance)", DoubleRipChance);
 		defender->Attack(this, EQ::invslot::slotPrimary, true);
 		if (HasDied())
 			return;
@@ -5679,7 +5679,7 @@ void Mob::DoRiposte(Mob *defender)
 
 	// Live AA - Double Riposte
 	if (DoubleRipChance && zone->random.Roll(DoubleRipChance)) {
-		LogCombat("Preforming a double riposted from SE_GiveDoubleRiposte base1 == 0 ([{}] percent chance)", DoubleRipChance);
+		LogCombat("Preforming a double riposted from SpellEffect::GiveDoubleRiposte base1 == 0 ([{}] percent chance)", DoubleRipChance);
 		defender->Attack(this, EQ::invslot::slotPrimary, true);
 		if (HasDied())
 			return;
@@ -6027,12 +6027,12 @@ void Mob::TrySkillProc(Mob *on, EQ::skills::SkillType skill, uint16 ReuseTime, b
 
 				for (int i = 0; i < EFFECT_COUNT; i++) {
 
-					if (spells[base_spell_id].effect_id[i] == SE_SkillProcAttempt || spells[base_spell_id].effect_id[i] == SE_SkillProcSuccess) {
+					if (spells[base_spell_id].effect_id[i] == SpellEffect::SkillProcAttempt || spells[base_spell_id].effect_id[i] == SpellEffect::SkillProcSuccess) {
 						proc_spell_id = spells[base_spell_id].base_value[i];
 						ProcMod = static_cast<float>(spells[base_spell_id].limit_value[i]);
 					}
 
-					else if (spells[base_spell_id].effect_id[i] == SE_LimitToSkill && spells[base_spell_id].base_value[i] <= EQ::skills::HIGHEST_SKILL) {
+					else if (spells[base_spell_id].effect_id[i] == SpellEffect::LimitToSkill && spells[base_spell_id].base_value[i] <= EQ::skills::HIGHEST_SKILL) {
 						if (CanProc && spells[base_spell_id].base_value[i] == skill && IsValidSpell(proc_spell_id)) {
 							float final_chance = chance * (ProcMod / 100.0f);
 							if (zone->random.Roll(final_chance)) {
@@ -6071,12 +6071,12 @@ void Mob::TrySkillProc(Mob *on, EQ::skills::SkillType skill, uint16 ReuseTime, b
 				ProcMod = 0;
 
 				for (int i = 0; i < EFFECT_COUNT; i++) {
-					if (spells[base_spell_id].effect_id[i] == SE_SkillProcAttempt || spells[base_spell_id].effect_id[i] == SE_SkillProcSuccess) {
+					if (spells[base_spell_id].effect_id[i] == SpellEffect::SkillProcAttempt || spells[base_spell_id].effect_id[i] == SpellEffect::SkillProcSuccess) {
 						proc_spell_id = spells[base_spell_id].base_value[i];
 						ProcMod = static_cast<float>(spells[base_spell_id].limit_value[i]);
 					}
 
-					else if (spells[base_spell_id].effect_id[i] == SE_LimitToSkill && spells[base_spell_id].base_value[i] <= EQ::skills::HIGHEST_SKILL) {
+					else if (spells[base_spell_id].effect_id[i] == SpellEffect::LimitToSkill && spells[base_spell_id].base_value[i] <= EQ::skills::HIGHEST_SKILL) {
 
 						if (CanProc && spells[base_spell_id].base_value[i] == skill && IsValidSpell(proc_spell_id)) {
 							float final_chance = chance * (ProcMod / 100.0f);
@@ -6133,11 +6133,11 @@ void Mob::TrySkillProc(Mob *on, EQ::skills::SkillType skill, uint16 ReuseTime, b
 						limit_value = effect.limit_value;
 						slot = effect.slot;
 
-						if (effect_id == SE_SkillProcAttempt || effect_id == SE_SkillProcSuccess) {
+						if (effect_id == SpellEffect::SkillProcAttempt || effect_id == SpellEffect::SkillProcSuccess) {
 							proc_spell_id = base_value;
 							ProcMod = static_cast<float>(limit_value);
 						}
-						else if (effect_id == SE_LimitToSkill && base_value <= EQ::skills::HIGHEST_SKILL) {
+						else if (effect_id == SpellEffect::LimitToSkill && base_value <= EQ::skills::HIGHEST_SKILL) {
 
 							if (CanProc && base_value == skill && IsValidSpell(proc_spell_id)) {
 								float final_chance = chance * (ProcMod / 100.0f);
@@ -6300,7 +6300,7 @@ bool Mob::TryRootFadeByDamage(int buffslot, Mob* attacker) {
 int32 Mob::RuneAbsorb(int64 damage, uint16 type)
 {
 	uint32 buff_max = GetMaxTotalSlots();
-	if (type == SE_Rune) {
+	if (type == SpellEffect::Rune) {
 		for (uint32 slot = 0; slot < buff_max; slot++) {
 			if (slot == spellbonuses.MeleeRune[SBIndex::RUNE_BUFFSLOT] && spellbonuses.MeleeRune[SBIndex::RUNE_AMOUNT] && buffs[slot].melee_rune && IsValidSpell(buffs[slot].spellid)) {
 				int melee_rune_left = buffs[slot].melee_rune;
@@ -6544,7 +6544,7 @@ void Mob::DoShieldDamageOnShielderSpellEffect(Mob* shield_target, int64 hit_dama
 		return;
 	}
 	/*
-		SPA 463 SE_SHIELD_TARGET
+		SPA 463 SpellEffect::SHIELD_TARGET
 
 		Live description: "Shields your target, taking a percentage of their damage".
 		Only example spell on live is an NPC who uses it during a raid event "Laurion's Song" expansion. SPA 54492 'Guardian Stance' Described as 100% Melee Shielding
@@ -6596,7 +6596,7 @@ void Mob::CommonBreakInvisibleFromCombat()
 	CancelSneakHide();
 
 	if (spellbonuses.NegateIfCombat) {
-		BuffFadeByEffect(SE_NegateIfCombat);
+		BuffFadeByEffect(SpellEffect::NegateIfCombat);
 	}
 
 	hidden = false;

--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -52,7 +52,7 @@ void Mob::CalcBonuses()
 		We set this here because NPC's can cast spells to change walkspeed/runspeed
 	*/
 	float get_walk_speed = static_cast<float>(0.025f * GetWalkspeed());
-	rooted = FindType(SE_Root);
+	rooted = FindType(SpellEffect::Root);
 }
 
 void NPC::CalcBonuses()
@@ -108,7 +108,7 @@ void Client::CalcBonuses()
 
 	SetAttackTimer();
 
-	rooted = FindType(SE_Root);
+	rooted = FindType(SpellEffect::Root);
 
 	XPRate = 100 + spellbonuses.XPRateMod;
 
@@ -625,7 +625,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 
 	uint32 effect = 0;
 	int32 base_value = 0;
-	int32 limit_value = 0; // only really used for SE_RaiseStatCap & SE_ReduceSkillTimer in aa_effects table
+	int32 limit_value = 0; // only really used for SpellEffect::RaiseStatCap & SpellEffect::ReduceSkillTimer in aa_effects table
 	uint32 slot = 0;
 
 	for (const auto &e : rank.effects) {
@@ -634,13 +634,13 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 		limit_value = e.limit_value;
 		slot = e.slot;
 
-		// we default to 0 (SE_CurrentHP) for the effect, so if there aren't any base1/2 values, we'll just skip it
+		// we default to 0 (SpellEffect::CurrentHP) for the effect, so if there aren't any base1/2 values, we'll just skip it
 		if (effect == 0 && base_value == 0 && limit_value == 0)
 			continue;
 
 		// IsBlankSpellEffect()
-		if (effect == SE_Blank || (effect == SE_CHA && base_value == 0) || effect == SE_StackingCommand_Block ||
-		    effect == SE_StackingCommand_Overwrite)
+		if (effect == SpellEffect::Blank || (effect == SpellEffect::CHA && base_value == 0) || effect == SpellEffect::StackingCommand_Block ||
+		    effect == SpellEffect::StackingCommand_Overwrite)
 			continue;
 
 		LogAA("Applying Effect [{}] from AA [{}] in slot [{}] (base1: [{}], base2: [{}]) on [{}]",
@@ -653,12 +653,12 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 		}
 
 		switch (effect) {
-		case SE_ACv2:
-		case SE_ArmorClass:
+		case SpellEffect::ACv2:
+		case SpellEffect::ArmorClass:
 			newbon->AC += base_value;
 			break;
 		// Note: AA effects that use accuracy are skill limited, while spell effect is not.
-		case SE_Accuracy:
+		case SpellEffect::Accuracy:
 			// Bad data or unsupported new skill
 			if (limit_value > EQ::skills::HIGHEST_SKILL)
 				break;
@@ -667,83 +667,83 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			else if (newbon->Accuracy[limit_value] < base_value)
 				newbon->Accuracy[limit_value] += base_value;
 			break;
-		case SE_CurrentHP: // regens
+		case SpellEffect::CurrentHP: // regens
 			newbon->HPRegen += base_value;
 			break;
-		case SE_CurrentEndurance:
+		case SpellEffect::CurrentEndurance:
 			newbon->EnduranceRegen += base_value;
 			break;
-		case SE_MovementSpeed:
+		case SpellEffect::MovementSpeed:
 			newbon->movementspeed += base_value; // should we let these stack?
 			/*if (base1 > newbon->movementspeed)	//or should we use a total value?
 				newbon->movementspeed = base1;*/
 			break;
-		case SE_STR:
+		case SpellEffect::STR:
 			newbon->STR += base_value;
 			break;
-		case SE_DEX:
+		case SpellEffect::DEX:
 			newbon->DEX += base_value;
 			break;
-		case SE_AGI:
+		case SpellEffect::AGI:
 			newbon->AGI += base_value;
 			break;
-		case SE_STA:
+		case SpellEffect::STA:
 			newbon->STA += base_value;
 			break;
-		case SE_INT:
+		case SpellEffect::INT:
 			newbon->INT += base_value;
 			break;
-		case SE_WIS:
+		case SpellEffect::WIS:
 			newbon->WIS += base_value;
 			break;
-		case SE_CHA:
+		case SpellEffect::CHA:
 			newbon->CHA += base_value;
 			break;
-		case SE_WaterBreathing:
+		case SpellEffect::WaterBreathing:
 			// handled by client
 			break;
-		case SE_CurrentMana:
+		case SpellEffect::CurrentMana:
 			newbon->ManaRegen += base_value;
 			break;
-		case SE_ManaPool:
+		case SpellEffect::ManaPool:
 			newbon->Mana += base_value;
 			break;
-		case SE_ItemManaRegenCapIncrease:
+		case SpellEffect::ItemManaRegenCapIncrease:
 			newbon->ItemManaRegenCap += base_value;
 			break;
-		case SE_ResistFire:
+		case SpellEffect::ResistFire:
 			newbon->FR += base_value;
 			break;
-		case SE_ResistCold:
+		case SpellEffect::ResistCold:
 			newbon->CR += base_value;
 			break;
-		case SE_ResistPoison:
+		case SpellEffect::ResistPoison:
 			newbon->PR += base_value;
 			break;
-		case SE_ResistDisease:
+		case SpellEffect::ResistDisease:
 			newbon->DR += base_value;
 			break;
-		case SE_ResistMagic:
+		case SpellEffect::ResistMagic:
 			newbon->MR += base_value;
 			break;
-		case SE_ResistCorruption:
+		case SpellEffect::ResistCorruption:
 			newbon->Corrup += base_value;
 			break;
-		case SE_IncreaseSpellHaste:
+		case SpellEffect::IncreaseSpellHaste:
 			break;
-		case SE_IncreaseRange:
+		case SpellEffect::IncreaseRange:
 			break;
-		case SE_MaxHPChange:
+		case SpellEffect::MaxHPChange:
 			newbon->PercentMaxHPChange += base_value;
 			break;
-		case SE_Packrat:
+		case SpellEffect::Packrat:
 			newbon->Packrat += base_value;
 			break;
-		case SE_TwoHandBash:
+		case SpellEffect::TwoHandBash:
 			break;
-		case SE_SetBreathLevel:
+		case SpellEffect::SetBreathLevel:
 			break;
-		case SE_RaiseStatCap:
+		case SpellEffect::RaiseStatCap:
 			switch (limit_value) {
 			// are these #define'd somewhere?
 			case 0: // str
@@ -787,117 +787,117 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 				break;
 			}
 			break;
-		case SE_SpellSlotIncrease:
+		case SpellEffect::SpellSlotIncrease:
 			break;
-		case SE_MysticalAttune:
+		case SpellEffect::MysticalAttune:
 			newbon->BuffSlotIncrease += base_value;
 			break;
-		case SE_TotalHP:
+		case SpellEffect::TotalHP:
 			newbon->FlatMaxHPChange += base_value;
 			break;
-		case SE_StunResist:
+		case SpellEffect::StunResist:
 			newbon->StunResist += base_value;
 			break;
-		case SE_SpellCritChance:
+		case SpellEffect::SpellCritChance:
 			newbon->CriticalSpellChance += base_value;
 			break;
-		case SE_SpellCritDmgIncrease:
+		case SpellEffect::SpellCritDmgIncrease:
 			newbon->SpellCritDmgIncrease += base_value;
 			break;
-		case SE_DotCritDmgIncrease:
+		case SpellEffect::DotCritDmgIncrease:
 			newbon->DotCritDmgIncrease += base_value;
 			break;
-		case SE_ResistSpellChance:
+		case SpellEffect::ResistSpellChance:
 			newbon->ResistSpellChance += base_value;
 			break;
-		case SE_CriticalHealChance:
+		case SpellEffect::CriticalHealChance:
 			newbon->CriticalHealChance += base_value;
 			break;
-		case SE_CriticalHealOverTime:
+		case SpellEffect::CriticalHealOverTime:
 			newbon->CriticalHealOverTime += base_value;
 			break;
-		case SE_CriticalDoTChance:
+		case SpellEffect::CriticalDoTChance:
 			newbon->CriticalDoTChance += base_value;
 			break;
-		case SE_ReduceSkillTimer:
+		case SpellEffect::ReduceSkillTimer:
 			newbon->SkillReuseTime[limit_value] += base_value;
 			break;
-		case SE_Fearless:
+		case SpellEffect::Fearless:
 			newbon->Fearless = true;
 			break;
-		case SE_PersistantCasting:
+		case SpellEffect::PersistantCasting:
 			newbon->PersistantCasting += base_value;
 			break;
-		case SE_DelayDeath:
+		case SpellEffect::DelayDeath:
 			newbon->DelayDeath += base_value;
 			break;
-		case SE_FrontalStunResist:
+		case SpellEffect::FrontalStunResist:
 			newbon->FrontalStunResist += base_value;
 			break;
-		case SE_ImprovedBindWound:
+		case SpellEffect::ImprovedBindWound:
 			newbon->BindWound += base_value;
 			break;
-		case SE_MaxBindWound:
+		case SpellEffect::MaxBindWound:
 			newbon->MaxBindWound += base_value;
 			break;
-		case SE_SeeInvis:
+		case SpellEffect::SeeInvis:
 			base_value = std::min({ base_value, MAX_INVISIBILTY_LEVEL });
 			if (newbon->SeeInvis < base_value) {
 				newbon->SeeInvis = base_value;
 			}
 			break;
-		case SE_BaseMovementSpeed:
+		case SpellEffect::BaseMovementSpeed:
 			newbon->BaseMovementSpeed += base_value;
 			break;
-		case SE_IncreaseRunSpeedCap:
+		case SpellEffect::IncreaseRunSpeedCap:
 			newbon->IncreaseRunSpeedCap += base_value;
 			break;
-		case SE_ConsumeProjectile:
+		case SpellEffect::ConsumeProjectile:
 			newbon->ConsumeProjectile += base_value;
 			break;
-		case SE_ForageAdditionalItems:
+		case SpellEffect::ForageAdditionalItems:
 			newbon->ForageAdditionalItems += base_value;
 			break;
-		case SE_Salvage:
+		case SpellEffect::Salvage:
 			newbon->SalvageChance += base_value;
 			break;
-		case SE_ArcheryDamageModifier:
+		case SpellEffect::ArcheryDamageModifier:
 			newbon->ArcheryDamageModifier += base_value;
 			break;
-		case SE_DoubleRangedAttack:
+		case SpellEffect::DoubleRangedAttack:
 			newbon->DoubleRangedAttack += base_value;
 			break;
-		case SE_DamageShield:
+		case SpellEffect::DamageShield:
 			newbon->DamageShield += base_value;
 			break;
-		case SE_CharmBreakChance:
+		case SpellEffect::CharmBreakChance:
 			newbon->CharmBreakChance += base_value;
 			break;
-		case SE_OffhandRiposteFail:
+		case SpellEffect::OffhandRiposteFail:
 			newbon->OffhandRiposteFail += base_value;
 			break;
-		case SE_ItemAttackCapIncrease:
+		case SpellEffect::ItemAttackCapIncrease:
 			newbon->ItemATKCap += base_value;
 			break;
-		case SE_GivePetGroupTarget:
+		case SpellEffect::GivePetGroupTarget:
 			newbon->GivePetGroupTarget = true;
 			break;
-		case SE_ItemHPRegenCapIncrease:
+		case SpellEffect::ItemHPRegenCapIncrease:
 			newbon->ItemHPRegenCap += base_value;
 			break;
-		case SE_Ambidexterity:
+		case SpellEffect::Ambidexterity:
 			newbon->Ambidexterity += base_value;
 			break;
-		case SE_PetMaxHP:
+		case SpellEffect::PetMaxHP:
 			newbon->PetMaxHP += base_value;
 			break;
-		case SE_AvoidMeleeChance:
+		case SpellEffect::AvoidMeleeChance:
 			newbon->AvoidMeleeChanceEffect += base_value;
 			break;
-		case SE_CombatStability:
+		case SpellEffect::CombatStability:
 			newbon->CombatStability += base_value;
 			break;
-		case SE_AddSingingMod:
+		case SpellEffect::AddSingingMod:
 			switch (limit_value) {
 			case EQ::item::ItemTypeWindInstrument:
 				newbon->windMod += base_value;
@@ -916,99 +916,99 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 				break;
 			}
 			break;
-		case SE_SongModCap:
+		case SpellEffect::SongModCap:
 			newbon->songModCap += base_value;
 			break;
-		case SE_PetCriticalHit:
+		case SpellEffect::PetCriticalHit:
 			newbon->PetCriticalHit += base_value;
 			break;
-		case SE_PetAvoidance:
+		case SpellEffect::PetAvoidance:
 			newbon->PetAvoidance += base_value;
 			break;
-		case SE_ShieldBlock:
+		case SpellEffect::ShieldBlock:
 			newbon->ShieldBlock += base_value;
 			break;
-		case SE_ShieldEquipDmgMod:
+		case SpellEffect::ShieldEquipDmgMod:
 			newbon->ShieldEquipDmgMod += base_value;
 			break;
-		case SE_SecondaryDmgInc:
+		case SpellEffect::SecondaryDmgInc:
 			newbon->SecondaryDmgInc = true;
 			break;
-		case SE_ChangeAggro:
+		case SpellEffect::ChangeAggro:
 			newbon->hatemod += base_value;
 			break;
-		case SE_EndurancePool:
+		case SpellEffect::EndurancePool:
 			newbon->Endurance += base_value;
 			break;
-		case SE_ChannelChanceItems:
+		case SpellEffect::ChannelChanceItems:
 			newbon->ChannelChanceItems += base_value;
 			break;
-		case SE_ChannelChanceSpells:
+		case SpellEffect::ChannelChanceSpells:
 			newbon->ChannelChanceSpells += base_value;
 			break;
-		case SE_DoubleSpecialAttack:
+		case SpellEffect::DoubleSpecialAttack:
 			newbon->DoubleSpecialAttack += base_value;
 			break;
-		case SE_TripleBackstab:
+		case SpellEffect::TripleBackstab:
 			newbon->TripleBackstab += base_value;
 			break;
-		case SE_FrontalBackstabMinDmg:
+		case SpellEffect::FrontalBackstabMinDmg:
 			newbon->FrontalBackstabMinDmg = true;
 			break;
-		case SE_FrontalBackstabChance:
+		case SpellEffect::FrontalBackstabChance:
 			newbon->FrontalBackstabChance += base_value;
 			break;
-		case SE_Double_Backstab_Front:
+		case SpellEffect::Double_Backstab_Front:
 			newbon->Double_Backstab_Front += base_value;
 			break;
-		case SE_BlockBehind:
+		case SpellEffect::BlockBehind:
 			newbon->BlockBehind += base_value;
 			break;
-		case SE_StrikeThrough:
-		case SE_StrikeThrough2:
+		case SpellEffect::StrikeThrough:
+		case SpellEffect::StrikeThrough2:
 			newbon->StrikeThrough += base_value;
 			break;
-		case SE_DoubleAttackChance:
+		case SpellEffect::DoubleAttackChance:
 			newbon->DoubleAttackChance += base_value;
 			break;
-		case SE_GiveDoubleAttack:
+		case SpellEffect::GiveDoubleAttack:
 			newbon->GiveDoubleAttack += base_value;
 			break;
-		case SE_ProcChance:
+		case SpellEffect::ProcChance:
 			newbon->ProcChanceSPA += base_value;
 			break;
-		case SE_RiposteChance:
+		case SpellEffect::RiposteChance:
 			newbon->RiposteChance += base_value;
 			break;
-		case SE_DodgeChance:
+		case SpellEffect::DodgeChance:
 			newbon->DodgeChance += base_value;
 			break;
-		case SE_ParryChance:
+		case SpellEffect::ParryChance:
 			newbon->ParryChance += base_value;
 			break;
-		case SE_IncreaseBlockChance:
+		case SpellEffect::IncreaseBlockChance:
 			newbon->IncreaseBlockChance += base_value;
 			break;
-		case SE_Flurry:
+		case SpellEffect::Flurry:
 			newbon->FlurryChance += base_value;
 			break;
-		case SE_PetFlurry:
+		case SpellEffect::PetFlurry:
 			newbon->PetFlurry += base_value;
 			break;
-		case SE_BardSongRange:
+		case SpellEffect::BardSongRange:
 			newbon->SongRange += base_value;
 			break;
-		case SE_RootBreakChance:
+		case SpellEffect::RootBreakChance:
 			newbon->RootBreakChance += base_value;
 			break;
-		case SE_UnfailingDivinity:
+		case SpellEffect::UnfailingDivinity:
 			newbon->UnfailingDivinity += base_value;
 			break;
-		case SE_CrippBlowChance:
+		case SpellEffect::CrippBlowChance:
 			newbon->CrippBlowChance += base_value;
 			break;
 
-		case SE_HitChance: {
+		case SpellEffect::HitChance: {
 			// Bad data or unsupported new skill
 			if (limit_value > EQ::skills::HIGHEST_SKILL)
 				break;
@@ -1019,7 +1019,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_ProcOnKillShot:
+		case SpellEffect::ProcOnKillShot:
 			for (int i = 0; i < MAX_SPELL_TRIGGER * 3; i += 3) {
 				if (!newbon->SpellOnKill[i] ||
 				    ((newbon->SpellOnKill[i] == limit_value) && (newbon->SpellOnKill[i + 1] < base_value))) {
@@ -1038,7 +1038,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			}
 			break;
 
-		case SE_SpellOnDeath:
+		case SpellEffect::SpellOnDeath:
 			for (int i = 0; i < MAX_SPELL_TRIGGER * 2; i += 2) {
 				if (!newbon->SpellOnDeath[i]) {
 					// base1 = SpellID to be triggered, base2 = chance to fire
@@ -1049,8 +1049,8 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			}
 			break;
 
-		case SE_WeaponProc:
-		case SE_AddMeleeProc:
+		case SpellEffect::WeaponProc:
+		case SpellEffect::AddMeleeProc:
 			for (int i = 0; i < MAX_AA_PROCS; i += 4) {
 				if (!newbon->SpellProc[i + SBIndex::COMBAT_PROC_ORIGIN_ID]) {
 					newbon->SpellProc[i + SBIndex::COMBAT_PROC_ORIGIN_ID] = rank.id;   //aa rank id
@@ -1062,7 +1062,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			}
 			break;
 
-		case SE_RangedProc:
+		case SpellEffect::RangedProc:
 			for (int i = 0; i < MAX_AA_PROCS; i += 4) {
 				if (!newbon->RangedProc[i + SBIndex::COMBAT_PROC_ORIGIN_ID]) {
 					newbon->RangedProc[i + SBIndex::COMBAT_PROC_ORIGIN_ID] = rank.id;   //aa rank id
@@ -1074,7 +1074,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			}
 			break;
 
-		case SE_DefensiveProc:
+		case SpellEffect::DefensiveProc:
 			for (int i = 0; i < MAX_AA_PROCS; i += 4) {
 				if (!newbon->DefensiveProc[i + SBIndex::COMBAT_PROC_ORIGIN_ID]) {
 					newbon->DefensiveProc[i + SBIndex::COMBAT_PROC_ORIGIN_ID] = rank.id;   //aa rank id
@@ -1086,7 +1086,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			}
 			break;
 
-		case SE_Proc_Timer_Modifier: {
+		case SpellEffect::Proc_Timer_Modifier: {
 			/*
 				AA can multiples of this in a single effect, proc should use the timer
 				that comes after the respective proc spell effect, thus rank.id will be already set
@@ -1120,7 +1120,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_CriticalHitChance: {
+		case SpellEffect::CriticalHitChance: {
 			// Bad data or unsupported new skill
 			if (limit_value > EQ::skills::HIGHEST_SKILL)
 				break;
@@ -1130,7 +1130,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 				newbon->CriticalHitChance[limit_value] += base_value;
 		} break;
 
-		case SE_CriticalDamageMob: {
+		case SpellEffect::CriticalDamageMob: {
 			// Bad data or unsupported new skill
 			if (limit_value > EQ::skills::HIGHEST_SKILL)
 				break;
@@ -1142,7 +1142,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_Critical_Melee_Damage_Mod_Max:
+		case SpellEffect::Critical_Melee_Damage_Mod_Max:
 		{
 			// Bad data or unsupported new skill
 			if (limit_value > EQ::skills::HIGHEST_SKILL)
@@ -1155,7 +1155,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_CriticalSpellChance: {
+		case SpellEffect::CriticalSpellChance: {
 			newbon->CriticalSpellChance += base_value;
 
 			if (limit_value > newbon->SpellCritDmgIncNoStack)
@@ -1164,12 +1164,12 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_ResistFearChance: {
+		case SpellEffect::ResistFearChance: {
 			newbon->ResistFearChance += base_value; // these should stack
 			break;
 		}
 
-		case SE_SkillDamageAmount: {
+		case SpellEffect::SkillDamageAmount: {
 			// Bad data or unsupported new skill
 			if (limit_value > EQ::skills::HIGHEST_SKILL)
 				break;
@@ -1180,7 +1180,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_SkillAttackProc: {
+		case SpellEffect::SkillAttackProc: {
 			for (int i = 0; i < MAX_CAST_ON_SKILL_USE; i += 3) {
 				if (!newbon->SkillAttackProc[i + SBIndex::SKILLATK_PROC_SPELL_ID]) { // spell id
 					newbon->SkillAttackProc[i + SBIndex::SKILLATK_PROC_SPELL_ID] = rank.spell; // spell to proc
@@ -1196,7 +1196,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_DamageModifier: {
+		case SpellEffect::DamageModifier: {
 			// Bad data or unsupported new skill
 			if (limit_value > EQ::skills::HIGHEST_SKILL)
 				break;
@@ -1207,7 +1207,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_DamageModifier2: {
+		case SpellEffect::DamageModifier2: {
 			// Bad data or unsupported new skill
 			if (limit_value > EQ::skills::HIGHEST_SKILL)
 				break;
@@ -1218,7 +1218,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_Skill_Base_Damage_Mod: {
+		case SpellEffect::Skill_Base_Damage_Mod: {
 			// Bad data or unsupported new skill
 			if (limit_value > EQ::skills::HIGHEST_SKILL)
 				break;
@@ -1229,7 +1229,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_SlayUndead: {
+		case SpellEffect::SlayUndead: {
 			if (newbon->SlayUndead[SBIndex::SLAYUNDEAD_DMG_MOD] < base_value) {
 				newbon->SlayUndead[SBIndex::SLAYUNDEAD_DMG_MOD] = base_value; // Rate
 				newbon->SlayUndead[SBIndex::SLAYUNDEAD_RATE_MOD] = limit_value; // Damage Modifier
@@ -1237,12 +1237,12 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_DoubleRiposte: {
+		case SpellEffect::DoubleRiposte: {
 			newbon->DoubleRiposte += base_value;
 			break;
 		}
 
-		case SE_GiveDoubleRiposte: {
+		case SpellEffect::GiveDoubleRiposte: {
 			// 0=Regular Riposte 1=Skill Attack Riposte 2=Skill
 			if (limit_value == 0) {
 				if (newbon->GiveDoubleRiposte[SBIndex::DOUBLE_RIPOSTE_CHANCE] < base_value)
@@ -1258,7 +1258,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 		}
 
 		// Physically raises skill cap ie if 55/55 it will raise to 55/60
-		case SE_RaiseSkillCap: {
+		case SpellEffect::RaiseSkillCap: {
 
 			if (limit_value > EQ::skills::HIGHEST_SKILL)
 				break;
@@ -1268,23 +1268,23 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_MasteryofPast: {
+		case SpellEffect::MasteryofPast: {
 			if (newbon->MasteryofPast < base_value)
 				newbon->MasteryofPast = base_value;
 			break;
 		}
 
-		case SE_CastingLevel: {
+		case SpellEffect::CastingLevel: {
 			newbon->adjusted_casting_skill += base_value;
 			break;
 		}
 
-		case SE_CastingLevel2: {
+		case SpellEffect::CastingLevel2: {
 			newbon->effective_casting_level += base_value;
 			break;
 		}
 
-		case SE_DivineSave: {
+		case SpellEffect::DivineSave: {
 			if (newbon->DivineSaveChance[SBIndex::DIVINE_SAVE_CHANCE] < base_value) {
 				newbon->DivineSaveChance[SBIndex::DIVINE_SAVE_CHANCE]           = base_value;
 				newbon->DivineSaveChance[SBIndex::DIVINE_SAVE_SPELL_TRIGGER_ID] = limit_value;
@@ -1292,7 +1292,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_SpellEffectResistChance: {
+		case SpellEffect::SpellEffectResistChance: {
 			for (int e = 0; e < MAX_RESISTABLE_EFFECTS * 2; e += 2) {
 				if (
 					!newbon->SEResist[e + 1] ||
@@ -1310,7 +1310,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_MitigateDamageShield: {
+		case SpellEffect::MitigateDamageShield: {
 
 			//AA that increase mitigation are set to negative.
 			if (base_value < 0) {
@@ -1321,7 +1321,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_FinishingBlow: {
+		case SpellEffect::FinishingBlow: {
 			// base1 = chance, base2 = damage
 			if (newbon->FinishingBlow[SBIndex::FINISHING_EFFECT_DMG] < limit_value) {
 				newbon->FinishingBlow[SBIndex::FINISHING_EFFECT_PROC_CHANCE] = base_value;
@@ -1330,7 +1330,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_FinishingBlowLvl: {
+		case SpellEffect::FinishingBlowLvl: {
 			// base1 = level, base2 = ??? (Set to 200 in AA data, possible proc rate mod?)
 			if (newbon->FinishingBlowLvl[SBIndex::FINISHING_EFFECT_LEVEL_MAX] < base_value) {
 				newbon->FinishingBlowLvl[SBIndex::FINISHING_EFFECT_LEVEL_MAX]          = base_value;
@@ -1339,23 +1339,23 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_StunBashChance:
+		case SpellEffect::StunBashChance:
 			newbon->StunBashChance += base_value;
 			break;
 
-		case SE_IncreaseChanceMemwipe:
+		case SpellEffect::IncreaseChanceMemwipe:
 			newbon->IncreaseChanceMemwipe += base_value;
 			break;
 
-		case SE_CriticalMend:
+		case SpellEffect::CriticalMend:
 			newbon->CriticalMend += base_value;
 			break;
 
-		case SE_HealRate:
+		case SpellEffect::HealRate:
 			newbon->HealRate += base_value;
 			break;
 
-		case SE_MeleeLifetap: {
+		case SpellEffect::MeleeLifetap: {
 
 			if ((base_value < 0) && (newbon->MeleeLifetap > base_value))
 				newbon->MeleeLifetap = base_value;
@@ -1365,27 +1365,27 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_Vampirism:
+		case SpellEffect::Vampirism:
 			newbon->Vampirism += base_value;
 			break;
 
-		case SE_FrenziedDevastation:
+		case SpellEffect::FrenziedDevastation:
 			newbon->FrenziedDevastation += limit_value;
 			break;
 
-		case SE_SpellProcChance:
+		case SpellEffect::SpellProcChance:
 			newbon->SpellProcChance += base_value;
 			break;
 
-		case SE_Berserk:
+		case SpellEffect::Berserk:
 			newbon->BerserkSPA = true;
 			break;
 
-		case SE_Metabolism:
+		case SpellEffect::Metabolism:
 			newbon->Metabolism += base_value;
 			break;
 
-		case SE_ImprovedReclaimEnergy: {
+		case SpellEffect::ImprovedReclaimEnergy: {
 			if ((base_value < 0) && (newbon->ImprovedReclaimEnergy > base_value))
 				newbon->ImprovedReclaimEnergy = base_value;
 
@@ -1394,7 +1394,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_HeadShot: {
+		case SpellEffect::HeadShot: {
 			if (newbon->HeadShot[SBIndex::FINISHING_EFFECT_DMG] < limit_value) {
 				newbon->HeadShot[SBIndex::FINISHING_EFFECT_PROC_CHANCE] = base_value;
 				newbon->HeadShot[SBIndex::FINISHING_EFFECT_DMG]         = limit_value;
@@ -1402,7 +1402,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_HeadShotLevel: {
+		case SpellEffect::HeadShotLevel: {
 			if (newbon->HSLevel[SBIndex::FINISHING_EFFECT_LEVEL_MAX] < base_value) {
 				newbon->HSLevel[SBIndex::FINISHING_EFFECT_LEVEL_MAX] = base_value;
 				newbon->HSLevel[SBIndex::FINISHING_EFFECT_LEVEL_CHANCE_BONUS] = limit_value;
@@ -1410,7 +1410,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_Assassinate: {
+		case SpellEffect::Assassinate: {
 			if (newbon->Assassinate[SBIndex::FINISHING_EFFECT_DMG] < limit_value) {
 				newbon->Assassinate[SBIndex::FINISHING_EFFECT_PROC_CHANCE] = base_value;
 				newbon->Assassinate[SBIndex::FINISHING_EFFECT_DMG]         = limit_value;
@@ -1418,7 +1418,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_AssassinateLevel: {
+		case SpellEffect::AssassinateLevel: {
 			if (newbon->AssassinateLevel[SBIndex::FINISHING_EFFECT_LEVEL_MAX] < base_value) {
 				newbon->AssassinateLevel[SBIndex::FINISHING_EFFECT_LEVEL_MAX]          = base_value;
 				newbon->AssassinateLevel[SBIndex::FINISHING_EFFECT_LEVEL_CHANCE_BONUS] = limit_value;
@@ -1426,11 +1426,11 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_PetMeleeMitigation:
+		case SpellEffect::PetMeleeMitigation:
 			newbon->PetMeleeMitigation += base_value;
 			break;
 
-		case SE_FactionModPct: {
+		case SpellEffect::FactionModPct: {
 			if ((base_value < 0) && (newbon->FactionModPct > base_value))
 				newbon->FactionModPct = base_value;
 
@@ -1439,15 +1439,15 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_Illusion:
+		case SpellEffect::Illusion:
 			newbon->Illusion = rank.spell;
 			break;
 
-		case SE_IllusionPersistence:
+		case SpellEffect::IllusionPersistence:
 			newbon->IllusionPersistence = base_value;
 			break;
 
-		case SE_LimitToSkill: {
+		case SpellEffect::LimitToSkill: {
 
 			// Bad data or unsupported new skill
 			if (base_value > EQ::skills::HIGHEST_SKILL) {
@@ -1460,7 +1460,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_SkillProcAttempt: {
+		case SpellEffect::SkillProcAttempt: {
 			for (int e = 0; e < MAX_SKILL_PROCS; e++) {
 				if (newbon->SkillProc[e] && newbon->SkillProc[e] == rank.id)
 					break; // Do not use the same aa id more than once.
@@ -1473,7 +1473,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_SkillProcSuccess: {
+		case SpellEffect::SkillProcSuccess: {
 
 			for (int e = 0; e < MAX_SKILL_PROCS; e++) {
 				if (newbon->SkillProcSuccess[e] && newbon->SkillProcSuccess[e] == rank.id)
@@ -1487,44 +1487,44 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_MeleeMitigation:
+		case SpellEffect::MeleeMitigation:
 			newbon->MeleeMitigationEffect += base_value;
 			break;
 
-		case SE_ATK:
+		case SpellEffect::ATK:
 			newbon->ATK += base_value;
 			break;
-		case SE_IncreaseExtTargetWindow:
+		case SpellEffect::IncreaseExtTargetWindow:
 			newbon->extra_xtargets += base_value;
 			break;
 
-		case SE_PC_Pet_Rampage: {
+		case SpellEffect::PC_Pet_Rampage: {
 			newbon->PC_Pet_Rampage[SBIndex::PET_RAMPAGE_CHANCE] += base_value; //Chance to rampage
 			if (newbon->PC_Pet_Rampage[SBIndex::PET_RAMPAGE_DMG_MOD] < limit_value)
 				newbon->PC_Pet_Rampage[SBIndex::PET_RAMPAGE_DMG_MOD] = limit_value; //Damage modifer - take highest
 			break;
 		}
 
-		case SE_PC_Pet_AE_Rampage: {
+		case SpellEffect::PC_Pet_AE_Rampage: {
 			newbon->PC_Pet_AE_Rampage[SBIndex::PET_RAMPAGE_CHANCE] += base_value; //Chance to rampage
 			if (newbon->PC_Pet_AE_Rampage[SBIndex::PET_RAMPAGE_DMG_MOD] < limit_value)
 				newbon->PC_Pet_AE_Rampage[SBIndex::PET_RAMPAGE_DMG_MOD] = limit_value; //Damage modifer - take highest
 			break;
 		}
 
-		case SE_PC_Pet_Flurry_Chance:
+		case SpellEffect::PC_Pet_Flurry_Chance:
 			newbon->PC_Pet_Flurry += base_value; //Chance to Flurry
 			break;
 
-		case SE_ShroudofStealth:
+		case SpellEffect::ShroudofStealth:
 			newbon->ShroudofStealth = true;
 			break;
 
-		case SE_ReduceFallDamage:
+		case SpellEffect::ReduceFallDamage:
 			newbon->ReduceFallDamage += base_value;
 			break;
 
-		case SE_ReduceTradeskillFail:{
+		case SpellEffect::ReduceTradeskillFail:{
 
 			if (limit_value > EQ::skills::HIGHEST_SKILL)
 				break;
@@ -1533,42 +1533,42 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_TradeSkillMastery:
+		case SpellEffect::TradeSkillMastery:
 			if (newbon->TradeSkillMastery < base_value)
 				newbon->TradeSkillMastery = base_value;
 			break;
 
-		case SE_NoBreakAESneak:
+		case SpellEffect::NoBreakAESneak:
 			if (newbon->NoBreakAESneak < base_value)
 				newbon->NoBreakAESneak = base_value;
 			break;
 
-		case SE_FeignedCastOnChance:
+		case SpellEffect::FeignedCastOnChance:
 			if (newbon->FeignedCastOnChance < base_value)
 				newbon->FeignedCastOnChance = base_value;
 			break;
 
-		case SE_AddPetCommand:
+		case SpellEffect::AddPetCommand:
 			if (base_value && limit_value < PetCommand::Max)
 				newbon->PetCommands[limit_value] = true;
 			break;
 
-		case SE_FeignedMinion:
+		case SpellEffect::FeignedMinion:
 			if (newbon->FeignedMinionChance < base_value) {
 				newbon->FeignedMinionChance = base_value;
 			}
 			newbon->PetCommands[PetCommand::Feign] = true;
 			break;
 
-		case SE_AdditionalAura:
+		case SpellEffect::AdditionalAura:
 			newbon->aura_slots += base_value;
 			break;
 
-		case SE_IncreaseTrapCount:
+		case SpellEffect::IncreaseTrapCount:
 			newbon->trap_slots += base_value;
 			break;
 
-		case SE_ForageSkill:
+		case SpellEffect::ForageSkill:
 			newbon->GrantForage += base_value;
 			// we need to grant a skill point here
 			// I'd rather not do this here, but whatever, probably fine
@@ -1579,19 +1579,19 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			}
 			break;
 
-		case SE_Attack_Accuracy_Max_Percent:
+		case SpellEffect::Attack_Accuracy_Max_Percent:
 			newbon->Attack_Accuracy_Max_Percent += base_value;
 			break;
 
-		case SE_AC_Mitigation_Max_Percent:
+		case SpellEffect::AC_Mitigation_Max_Percent:
 			newbon->AC_Mitigation_Max_Percent += base_value;
 			break;
 
-		case SE_AC_Avoidance_Max_Percent:
+		case SpellEffect::AC_Avoidance_Max_Percent:
 			newbon->AC_Avoidance_Max_Percent += base_value;
 			break;
 
-		case SE_Damage_Taken_Position_Mod:
+		case SpellEffect::Damage_Taken_Position_Mod:
 		{
 			//Mitigate if damage taken from behind base2 = 0, from front base2 = 1
 			if (limit_value < 0 || limit_value >= 2) {
@@ -1604,7 +1604,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_Melee_Damage_Position_Mod:
+		case SpellEffect::Melee_Damage_Position_Mod:
 		{
 			if (limit_value < 0 || limit_value >= 2) {
 				break;
@@ -1616,7 +1616,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_Damage_Taken_Position_Amt:
+		case SpellEffect::Damage_Taken_Position_Amt:
 		{
 			//Mitigate if damage taken from behind base2 = 0, from front base2 = 1
 			if (limit_value < 0 || limit_value >= 2) {
@@ -1626,7 +1626,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_Melee_Damage_Position_Amt:
+		case SpellEffect::Melee_Damage_Position_Amt:
 		{
 			//Mitigate if damage taken from behind base2 = 0, from front base2 = 1
 			if (limit_value < 0 || limit_value >= 2) {
@@ -1637,23 +1637,23 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_DS_Mitigation_Amount:
+		case SpellEffect::DS_Mitigation_Amount:
 			newbon->DS_Mitigation_Amount += base_value;
 			break;
 
-		case SE_DS_Mitigation_Percentage:
+		case SpellEffect::DS_Mitigation_Percentage:
 			newbon->DS_Mitigation_Percentage += base_value;
 			break;
 
-		case SE_Pet_Crit_Melee_Damage_Pct_Owner:
+		case SpellEffect::Pet_Crit_Melee_Damage_Pct_Owner:
 			newbon->Pet_Crit_Melee_Damage_Pct_Owner += base_value;
 			break;
 
-		case SE_Pet_Add_Atk:
+		case SpellEffect::Pet_Add_Atk:
 			newbon->Pet_Add_Atk += base_value;
 			break;
 
-		case SE_Weapon_Stance:
+		case SpellEffect::Weapon_Stance:
 		{
 			if (IsValidSpell(base_value)) { //base1 is the spell_id of buff
 				if (limit_value <= WEAPON_STANCE_TYPE_MAX) { //0=2H, 1=Shield, 2=DW
@@ -1672,7 +1672,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_ExtraAttackChance:
+		case SpellEffect::ExtraAttackChance:
 		{
 			if (newbon->ExtraAttackChance[SBIndex::EXTRA_ATTACK_CHANCE] < base_value) {
 				newbon->ExtraAttackChance[SBIndex::EXTRA_ATTACK_CHANCE]   = base_value;
@@ -1681,7 +1681,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_AddExtraAttackPct_1h_Primary:
+		case SpellEffect::AddExtraAttackPct_1h_Primary:
 		{
 			if (newbon->ExtraAttackChancePrimary[SBIndex::EXTRA_ATTACK_CHANCE] < base_value) {
 				newbon->ExtraAttackChancePrimary[SBIndex::EXTRA_ATTACK_CHANCE]   = base_value;
@@ -1690,7 +1690,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_AddExtraAttackPct_1h_Secondary:
+		case SpellEffect::AddExtraAttackPct_1h_Secondary:
 		{
 
 			if (newbon->ExtraAttackChanceSecondary[SBIndex::EXTRA_ATTACK_CHANCE] < base_value) {
@@ -1700,7 +1700,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_Double_Melee_Round:
+		case SpellEffect::Double_Melee_Round:
 		{
 			if (newbon->DoubleMeleeRound[SBIndex::DOUBLE_MELEE_ROUND_CHANCE] < base_value) {
 				newbon->DoubleMeleeRound[SBIndex::DOUBLE_MELEE_ROUND_CHANCE] = base_value;
@@ -1710,7 +1710,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_ExtendedShielding:
+		case SpellEffect::ExtendedShielding:
 		{
 			if (newbon->ExtendedShielding < base_value) {
 				newbon->ExtendedShielding = base_value;
@@ -1718,7 +1718,7 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_ShieldDuration:
+		case SpellEffect::ShieldDuration:
 		{
 			if (newbon->ShieldDuration < base_value) {
 				newbon->ShieldDuration = base_value;
@@ -1726,23 +1726,23 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			break;
 		}
 
-		case SE_Worn_Endurance_Regen_Cap:
+		case SpellEffect::Worn_Endurance_Regen_Cap:
 			newbon->ItemEnduranceRegenCap += base_value;
 			break;
 
 
-		case SE_SecondaryForte:
+		case SpellEffect::SecondaryForte:
 			if (newbon->SecondaryForte < base_value) {
 				newbon->SecondaryForte = base_value;
 			}
 			break;
 
-		case SE_ZoneSuspendMinion:
+		case SpellEffect::ZoneSuspendMinion:
 			newbon->ZoneSuspendMinion = base_value;
 			break;
 
 
-		case SE_Reflect:
+		case SpellEffect::Reflect:
 
 			if (newbon->reflect[SBIndex::REFLECT_CHANCE] < base_value) {
 				newbon->reflect[SBIndex::REFLECT_CHANCE] = base_value;
@@ -1752,69 +1752,69 @@ void Mob::ApplyAABonuses(const AA::Rank &rank, StatBonuses *newbon)
 			}
 			break;
 
-		case SE_SpellDamageShield:
+		case SpellEffect::SpellDamageShield:
 			newbon->SpellDamageShield += base_value;
 			break;
 
-		case SE_Amplification:
+		case SpellEffect::Amplification:
 			newbon->Amplification += base_value;
 			break;
 
-		case SE_MitigateSpellDamage:
+		case SpellEffect::MitigateSpellDamage:
 		{
 			newbon->MitigateSpellRune[SBIndex::MITIGATION_RUNE_PERCENT] += base_value;
 			break;
 		}
 
-		case SE_MitigateDotDamage:
+		case SpellEffect::MitigateDotDamage:
 		{
 			newbon->MitigateDotRune[SBIndex::MITIGATION_RUNE_PERCENT] += base_value;
 			break;
 		}
 
-		case SE_TrapCircumvention:
+		case SpellEffect::TrapCircumvention:
 			newbon->TrapCircumvention += base_value;
 			break;
 
 		// to do
-		case SE_PetDiscipline:
+		case SpellEffect::PetDiscipline:
 			break;
-		case SE_PotionBeltSlots:
+		case SpellEffect::PotionBeltSlots:
 			break;
-		case SE_BandolierSlots:
+		case SpellEffect::BandolierSlots:
 			break;
-		case SE_ReduceApplyPoisonTime:
+		case SpellEffect::ReduceApplyPoisonTime:
 			break;
-		case SE_NimbleEvasion:
+		case SpellEffect::NimbleEvasion:
 			break;
 
 		// not handled here
-		case SE_HastenedAASkill:
+		case SpellEffect::HastenedAASkill:
 		// not handled here but don't want to clutter debug log -- these may need to be verified to ignore
-		case SE_LimitMaxLevel:
-		case SE_LimitResist:
-		case SE_LimitTarget:
-		case SE_LimitEffect:
-		case SE_LimitSpellType:
-		case SE_LimitMinDur:
-		case SE_LimitInstant:
-		case SE_LimitMinLevel:
-		case SE_LimitCastTimeMin:
-		case SE_LimitCastTimeMax:
-		case SE_LimitSpell:
-		case SE_LimitCombatSkills:
-		case SE_LimitManaMin:
-		case SE_LimitSpellGroup:
-		case SE_LimitSpellClass:
-		case SE_LimitSpellSubclass:
-		case SE_LimitHPPercent:
-		case SE_LimitManaPercent:
-		case SE_LimitEndPercent:
-		case SE_LimitClass:
-		case SE_LimitRace:
-		case SE_LimitCastingSkill:
-		case SE_LimitUseMin:
-		case SE_LimitUseType:
+		case SpellEffect::LimitMaxLevel:
+		case SpellEffect::LimitResist:
+		case SpellEffect::LimitTarget:
+		case SpellEffect::LimitEffect:
+		case SpellEffect::LimitSpellType:
+		case SpellEffect::LimitMinDur:
+		case SpellEffect::LimitInstant:
+		case SpellEffect::LimitMinLevel:
+		case SpellEffect::LimitCastTimeMin:
+		case SpellEffect::LimitCastTimeMax:
+		case SpellEffect::LimitSpell:
+		case SpellEffect::LimitCombatSkills:
+		case SpellEffect::LimitManaMin:
+		case SpellEffect::LimitSpellGroup:
+		case SpellEffect::LimitSpellClass:
+		case SpellEffect::LimitSpellSubclass:
+		case SpellEffect::LimitHPPercent:
+		case SpellEffect::LimitManaPercent:
+		case SpellEffect::LimitEndPercent:
+		case SpellEffect::LimitClass:
+		case SpellEffect::LimitRace:
+		case SpellEffect::LimitCastingSkill:
+		case SpellEffect::LimitUseMin:
+		case SpellEffect::LimitUseType:
 			break;
 
 		default:
@@ -1851,7 +1851,7 @@ void Mob::CalcSpellBonuses(StatBonuses* newbon)
 	//Disables a specific spell effect bonus completely, can also be limited to negate only item, AA or spell bonuses.
 	if (spellbonuses.NegateEffects){
 		for(i = 0; i < buff_count; i++) {
-			if(IsValidSpell(buffs[i].spellid) && (IsEffectInSpell(buffs[i].spellid, SE_NegateSpellEffect)) )
+			if(IsValidSpell(buffs[i].spellid) && (IsEffectInSpell(buffs[i].spellid, SpellEffect::NegateSpellEffect)) )
 				NegateSpellEffectBonuses(buffs[i].spellid);
 		}
 	}
@@ -1913,7 +1913,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 
 			//Special custom cases for loading effects on to NPC from 'npc_spels_effects' table
 			//Non-Focused Effect to modify incoming spell damage by resist type.
-			if (spell_effect_id ==  SE_FcSpellVulnerability) {
+			if (spell_effect_id == SpellEffect::FcSpellVulnerability) {
 				ModVulnerability(limit_value, effect_value);
 			}
 
@@ -1922,17 +1922,17 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 
 		switch (spell_effect_id)
 		{
-			case SE_CurrentHP: //regens
+			case SpellEffect::CurrentHP: //regens
 				if(effect_value > 0) {
 					new_bonus->HPRegen += effect_value;
 				}
 				break;
 
-			case SE_CurrentEndurance:
+			case SpellEffect::CurrentEndurance:
 				new_bonus->EnduranceRegen += effect_value;
 				break;
 
-			case SE_ChangeFrenzyRad:
+			case SpellEffect::ChangeFrenzyRad:
 			{
 				if (max_value != 0 && GetLevel() > max_value)
 					break;
@@ -1944,7 +1944,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_Harmony:
+			case SpellEffect::Harmony:
 			{
 				if (max_value != 0 && GetLevel() > max_value)
 					break;
@@ -1958,7 +1958,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_AttackSpeed:
+			case SpellEffect::AttackSpeed:
 			{
 				if ((effect_value - 100) > 0) { // Haste
 					if (new_bonus->haste < 0) break; // Slowed - Don't apply haste
@@ -1975,7 +1975,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_AttackSpeed2:
+			case SpellEffect::AttackSpeed2:
 			{
 				if ((effect_value - 100) > 0) { // Haste V2 - Stacks with V1 but does not Overcap
 					if (new_bonus->hastetype2 < 0) break; //Slowed - Don't apply haste2
@@ -1992,7 +1992,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_AttackSpeed3:
+			case SpellEffect::AttackSpeed3:
 			{
 				if (effect_value < 0){ //Slow
 					effect_value -= (effect_value * GetSlowMitigation()/100);
@@ -2008,7 +2008,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_AttackSpeed4:
+			case SpellEffect::AttackSpeed4:
 			{
 				// These don't generate the IMMUNE_ATKSPEED message and the icon shows up
 				// but have no effect on the mobs attack speed
@@ -2027,87 +2027,87 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_IncreaseArchery:
+			case SpellEffect::IncreaseArchery:
 			{
 				new_bonus->increase_archery += effect_value;
 				break;
 			}
 
-			case SE_TotalHP:
+			case SpellEffect::TotalHP:
 			{
 				new_bonus->FlatMaxHPChange += effect_value;
 				break;
 			}
 
-			case SE_ManaRegen_v2:
-			case SE_CurrentMana:
+			case SpellEffect::ManaRegen_v2:
+			case SpellEffect::CurrentMana:
 			{
 				new_bonus->ManaRegen += effect_value;
 				break;
 			}
 
-			case SE_ManaPool:
+			case SpellEffect::ManaPool:
 			{
 				new_bonus->Mana += effect_value;
 				break;
 			}
 
-			case SE_Stamina:
+			case SpellEffect::Stamina:
 			{
 				new_bonus->EnduranceReduction += effect_value;
 				break;
 			}
 
-			case SE_ACv2:
-			case SE_ArmorClass:
+			case SpellEffect::ACv2:
+			case SpellEffect::ArmorClass:
 			{
 				new_bonus->AC += effect_value;
 				break;
 			}
 
-			case SE_ATK:
+			case SpellEffect::ATK:
 			{
 				new_bonus->ATK += effect_value;
 				break;
 			}
 
-			case SE_STR:
+			case SpellEffect::STR:
 			{
 				new_bonus->STR += effect_value;
 				break;
 			}
 
-			case SE_DEX:
+			case SpellEffect::DEX:
 			{
 				new_bonus->DEX += effect_value;
 				break;
 			}
 
-			case SE_AGI:
+			case SpellEffect::AGI:
 			{
 				new_bonus->AGI += effect_value;
 				break;
 			}
 
-			case SE_STA:
+			case SpellEffect::STA:
 			{
 				new_bonus->STA += effect_value;
 				break;
 			}
 
-			case SE_INT:
+			case SpellEffect::INT:
 			{
 				new_bonus->INT += effect_value;
 				break;
 			}
 
-			case SE_WIS:
+			case SpellEffect::WIS:
 			{
 				new_bonus->WIS += effect_value;
 				break;
 			}
 
-			case SE_CHA:
+			case SpellEffect::CHA:
 			{
 				if (spells[spell_id].base_value[i] != 0) {
 					new_bonus->CHA += effect_value;
@@ -2115,7 +2115,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_AllStats:
+			case SpellEffect::AllStats:
 			{
 				new_bonus->STR += effect_value;
 				new_bonus->DEX += effect_value;
@@ -2127,37 +2127,37 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_ResistFire:
+			case SpellEffect::ResistFire:
 			{
 				new_bonus->FR += effect_value;
 				break;
 			}
 
-			case SE_ResistCold:
+			case SpellEffect::ResistCold:
 			{
 				new_bonus->CR += effect_value;
 				break;
 			}
 
-			case SE_ResistPoison:
+			case SpellEffect::ResistPoison:
 			{
 				new_bonus->PR += effect_value;
 				break;
 			}
 
-			case SE_ResistDisease:
+			case SpellEffect::ResistDisease:
 			{
 				new_bonus->DR += effect_value;
 				break;
 			}
 
-			case SE_ResistMagic:
+			case SpellEffect::ResistMagic:
 			{
 				new_bonus->MR += effect_value;
 				break;
 			}
 
-			case SE_ResistAll:
+			case SpellEffect::ResistAll:
 			{
 				new_bonus->MR += effect_value;
 				new_bonus->DR += effect_value;
@@ -2167,13 +2167,13 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_ResistCorruption:
+			case SpellEffect::ResistCorruption:
 			{
 				new_bonus->Corrup += effect_value;
 				break;
 			}
 
-			case SE_RaiseStatCap:
+			case SpellEffect::RaiseStatCap:
 			{
 				switch(spells[spell_id].limit_value[i])
 				{
@@ -2221,13 +2221,13 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_CastingLevel:	// Brilliance of Ro
+			case SpellEffect::CastingLevel:	// Brilliance of Ro
 			{
 				new_bonus->adjusted_casting_skill += effect_value;
 				break;
 			}
 
-			case SE_CastingLevel2:
+			case SpellEffect::CastingLevel2:
 			{
 				new_bonus->effective_casting_level += effect_value;
 
@@ -2237,15 +2237,15 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_MovementSpeed:
+			case SpellEffect::MovementSpeed:
 				new_bonus->movementspeed += effect_value;
 				break;
 
-			case SE_SpellDamageShield:
+			case SpellEffect::SpellDamageShield:
 				new_bonus->SpellDamageShield += effect_value;
 				break;
 
-			case SE_DamageShield:
+			case SpellEffect::DamageShield:
 			{
 				new_bonus->DamageShield += effect_value;
 				new_bonus->DamageShieldSpellID = spell_id;
@@ -2258,7 +2258,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_ReverseDS:
+			case SpellEffect::ReverseDS:
 			{
 				new_bonus->ReverseDamageShield += effect_value;
 				new_bonus->ReverseDamageShieldSpellID = spell_id;
@@ -2270,7 +2270,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_Reflect:
+			case SpellEffect::Reflect:
 
 				if (AdditiveWornBonus) {
 					new_bonus->reflect[SBIndex::REFLECT_CHANCE] += effect_value;
@@ -2283,20 +2283,20 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				}
 				break;
 
-			case SE_Amplification:
+			case SpellEffect::Amplification:
 				new_bonus->Amplification += effect_value;
 				break;
 
-			case SE_ChangeAggro:
+			case SpellEffect::ChangeAggro:
 				new_bonus->hatemod += effect_value;
 				break;
 
-			case SE_MeleeMitigation:
+			case SpellEffect::MeleeMitigation:
 				// This value is negative because it counteracts another SPA :P
 				new_bonus->MeleeMitigationEffect += effect_value;
 				break;
 
-			case SE_CriticalHitChance:
+			case SpellEffect::CriticalHitChance:
 			{
 				// Bad data or unsupported new skill
 				if (limit_value > EQ::skills::HIGHEST_SKILL)
@@ -2325,7 +2325,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_CrippBlowChance:
+			case SpellEffect::CrippBlowChance:
 			{
 				if (AdditiveWornBonus)
 					new_bonus->CrippBlowChance += effect_value;
@@ -2339,7 +2339,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_AvoidMeleeChance:
+			case SpellEffect::AvoidMeleeChance:
 			{
 				if (AdditiveWornBonus)
 					new_bonus->AvoidMeleeChanceEffect += effect_value;
@@ -2352,7 +2352,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_RiposteChance:
+			case SpellEffect::RiposteChance:
 			{
 				if (AdditiveWornBonus)
 					new_bonus->RiposteChance += effect_value;
@@ -2365,7 +2365,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_DodgeChance:
+			case SpellEffect::DodgeChance:
 			{
 				if (AdditiveWornBonus)
 					new_bonus->DodgeChance += effect_value;
@@ -2378,7 +2378,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_ParryChance:
+			case SpellEffect::ParryChance:
 			{
 				if (AdditiveWornBonus)
 					new_bonus->ParryChance += effect_value;
@@ -2391,7 +2391,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_DualWieldChance:
+			case SpellEffect::DualWieldChance:
 			{
 				if (AdditiveWornBonus)
 					new_bonus->DualWieldChance += effect_value;
@@ -2404,7 +2404,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_DoubleAttackChance:
+			case SpellEffect::DoubleAttackChance:
 			{
 
 				if (AdditiveWornBonus)
@@ -2418,7 +2418,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_TripleAttackChance:
+			case SpellEffect::TripleAttackChance:
 			{
 
 				if (AdditiveWornBonus)
@@ -2432,7 +2432,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_MeleeLifetap:
+			case SpellEffect::MeleeLifetap:
 			{
 				if (AdditiveWornBonus)
 					new_bonus->MeleeLifetap += spells[spell_id].base_value[i];
@@ -2445,11 +2445,11 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_Vampirism:
+			case SpellEffect::Vampirism:
 				new_bonus->Vampirism += effect_value;
 				break;
 
-			case SE_AllInstrumentMod:
+			case SpellEffect::AllInstrumentMod:
 			{
 				if(effect_value > new_bonus->singingMod)
 					new_bonus->singingMod = effect_value;
@@ -2464,21 +2464,21 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_ResistSpellChance:
+			case SpellEffect::ResistSpellChance:
 				new_bonus->ResistSpellChance += effect_value;
 				break;
 
-			case SE_ResistFearChance:
+			case SpellEffect::ResistFearChance:
 			{
 				new_bonus->ResistFearChance += effect_value; // these should stack
 				break;
 			}
 
-			case SE_Fearless:
+			case SpellEffect::Fearless:
 				new_bonus->Fearless = true;
 				break;
 
-			case SE_HundredHands:
+			case SpellEffect::HundredHands:
 			{
 				if (AdditiveWornBonus)
 					new_bonus->HundredHands += effect_value;
@@ -2490,7 +2490,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_MeleeSkillCheck:
+			case SpellEffect::MeleeSkillCheck:
 			{
 				if(new_bonus->MeleeSkillCheck < effect_value) {
 					new_bonus->MeleeSkillCheck = effect_value;
@@ -2499,7 +2499,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_HitChance:
+			case SpellEffect::HitChance:
 			{
 				// Bad data or unsupported new skill
 				if (limit_value > EQ::skills::HIGHEST_SKILL)
@@ -2536,7 +2536,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 
 			}
 
-			case SE_DamageModifier:
+			case SpellEffect::DamageModifier:
 			{
 				// Bad data or unsupported new skill
 				if (limit_value > EQ::skills::HIGHEST_SKILL)
@@ -2549,7 +2549,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_DamageModifier2:
+			case SpellEffect::DamageModifier2:
 			{
 				// Bad data or unsupported new skill
 				if (limit_value > EQ::skills::HIGHEST_SKILL)
@@ -2562,7 +2562,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_Skill_Base_Damage_Mod:
+			case SpellEffect::Skill_Base_Damage_Mod:
 			{
 				// Bad data or unsupported new skill
 				if (limit_value > EQ::skills::HIGHEST_SKILL)
@@ -2575,7 +2575,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_MinDamageModifier:
+			case SpellEffect::MinDamageModifier:
 			{
 				// Bad data or unsupported new skill
 				if (limit_value > EQ::skills::HIGHEST_SKILL)
@@ -2588,7 +2588,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_ReduceSkill: {
+			case SpellEffect::ReduceSkill: {
 				// Bad data or unsupported new skill
 				if (spells[spell_id].base_value[i] > EQ::skills::HIGHEST_SKILL) {
 					break;
@@ -2607,14 +2607,14 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_StunResist:
+			case SpellEffect::StunResist:
 			{
 				if(new_bonus->StunResist < effect_value)
 					new_bonus->StunResist = effect_value;
 				break;
 			}
 
-			case SE_ProcChance:
+			case SpellEffect::ProcChance:
 			{
 				if (AdditiveWornBonus)
 					new_bonus->ProcChanceSPA += effect_value;
@@ -2628,7 +2628,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_ExtraAttackChance:
+			case SpellEffect::ExtraAttackChance:
 			{
 				if (AdditiveWornBonus) {
 					new_bonus->ExtraAttackChance[SBIndex::EXTRA_ATTACK_CHANCE] += effect_value;
@@ -2641,7 +2641,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_AddExtraAttackPct_1h_Primary:
+			case SpellEffect::AddExtraAttackPct_1h_Primary:
 			{
 				if (AdditiveWornBonus) {
 					new_bonus->ExtraAttackChancePrimary[SBIndex::EXTRA_ATTACK_CHANCE] += effect_value;
@@ -2655,7 +2655,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_AddExtraAttackPct_1h_Secondary:
+			case SpellEffect::AddExtraAttackPct_1h_Secondary:
 			{
 				if (AdditiveWornBonus) {
 					new_bonus->ExtraAttackChanceSecondary[SBIndex::EXTRA_ATTACK_CHANCE] += effect_value;
@@ -2669,7 +2669,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_Double_Melee_Round:
+			case SpellEffect::Double_Melee_Round:
 			{
 				if (AdditiveWornBonus) {
 					new_bonus->DoubleMeleeRound[SBIndex::DOUBLE_MELEE_ROUND_CHANCE] += effect_value;
@@ -2683,14 +2683,14 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_PercentXPIncrease:
+			case SpellEffect::PercentXPIncrease:
 			{
 				if(new_bonus->XPRateMod < effect_value)
 					new_bonus->XPRateMod = effect_value;
 				break;
 			}
 
-			case SE_DeathSave:
+			case SpellEffect::DeathSave:
 			{
 				if(new_bonus->DeathSave[SBIndex::DEATH_SAVE_TYPE] < effect_value)
 				{
@@ -2703,7 +2703,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_DivineSave:
+			case SpellEffect::DivineSave:
 			{
 				if (AdditiveWornBonus) {
 					new_bonus->DivineSaveChance[SBIndex::DIVINE_SAVE_CHANCE] += effect_value;
@@ -2718,11 +2718,11 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_Flurry:
+			case SpellEffect::Flurry:
 				new_bonus->FlurryChance += effect_value;
 				break;
 
-			case SE_Accuracy:
+			case SpellEffect::Accuracy:
 			{
 				// Bad data or unsupported new skill
 				if (limit_value > EQ::skills::HIGHEST_SKILL)
@@ -2736,19 +2736,19 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_MaxHPChange:
+			case SpellEffect::MaxHPChange:
 				new_bonus->PercentMaxHPChange += effect_value;
 				break;
 
-			case SE_EndurancePool:
+			case SpellEffect::EndurancePool:
 				new_bonus->Endurance += effect_value;
 				break;
 
-			case SE_HealRate:
+			case SpellEffect::HealRate:
 				new_bonus->HealRate += effect_value;
 				break;
 
-			case SE_SkillDamageTaken:
+			case SpellEffect::SkillDamageTaken:
 			{
 				// Bad data or unsupported new skill
 				if (limit_value > EQ::skills::HIGHEST_SKILL)
@@ -2771,11 +2771,11 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_SpellCritChance:
+			case SpellEffect::SpellCritChance:
 				new_bonus->CriticalSpellChance += effect_value;
 				break;
 
-			case SE_CriticalSpellChance:
+			case SpellEffect::CriticalSpellChance:
 			{
 				new_bonus->CriticalSpellChance += effect_value;
 
@@ -2784,35 +2784,35 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_SpellCritDmgIncrease:
+			case SpellEffect::SpellCritDmgIncrease:
 				new_bonus->SpellCritDmgIncrease += effect_value;
 				break;
 
-			case SE_DotCritDmgIncrease:
+			case SpellEffect::DotCritDmgIncrease:
 				new_bonus->DotCritDmgIncrease += effect_value;
 				break;
 
-			case SE_CriticalHealChance:
+			case SpellEffect::CriticalHealChance:
 				new_bonus->CriticalHealChance += effect_value;
 				break;
 
-			case SE_CriticalHealOverTime:
+			case SpellEffect::CriticalHealOverTime:
 				new_bonus->CriticalHealOverTime += effect_value;
 				break;
 
-			case SE_CriticalHealDecay:
+			case SpellEffect::CriticalHealDecay:
 				new_bonus->CriticalHealDecay = true;
 				break;
 
-			case SE_CriticalRegenDecay:
+			case SpellEffect::CriticalRegenDecay:
 				new_bonus->CriticalRegenDecay = true;
 				break;
 
-			case SE_CriticalDotDecay:
+			case SpellEffect::CriticalDotDecay:
 				new_bonus->CriticalDotDecay = true;
 				break;
 
-			case SE_MitigateDamageShield:
+			case SpellEffect::MitigateDamageShield:
 			{
 				/*
 				Bard songs have identical negative base value and positive max
@@ -2828,11 +2828,11 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_CriticalDoTChance:
+			case SpellEffect::CriticalDoTChance:
 				new_bonus->CriticalDoTChance += effect_value;
 				break;
 
-			case SE_ProcOnKillShot:
+			case SpellEffect::ProcOnKillShot:
 			{
 				for(int e = 0; e < MAX_SPELL_TRIGGER*3; e+=3)
 				{
@@ -2848,7 +2848,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_SpellOnDeath:
+			case SpellEffect::SpellOnDeath:
 			{
 				for(int e = 0; e < MAX_SPELL_TRIGGER; e+=2)
 				{
@@ -2863,7 +2863,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_CriticalDamageMob:
+			case SpellEffect::CriticalDamageMob:
 			{
 				// Bad data or unsupported new skill
 				if (limit_value > EQ::skills::HIGHEST_SKILL)
@@ -2875,7 +2875,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_Critical_Melee_Damage_Mod_Max:
+			case SpellEffect::Critical_Melee_Damage_Mod_Max:
 			{
 				// Bad data or unsupported new skill
 				if (limit_value > EQ::skills::HIGHEST_SKILL)
@@ -2889,14 +2889,14 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_ReduceSkillTimer:
+			case SpellEffect::ReduceSkillTimer:
 			{
 				if(new_bonus->SkillReuseTime[limit_value] < effect_value)
 					new_bonus->SkillReuseTime[limit_value] = effect_value;
 				break;
 			}
 
-			case SE_SkillDamageAmount:
+			case SpellEffect::SkillDamageAmount:
 			{
 				// Bad data or unsupported new skill
 				if (limit_value > EQ::skills::HIGHEST_SKILL)
@@ -2908,23 +2908,23 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_GravityEffect:
+			case SpellEffect::GravityEffect:
 				new_bonus->GravityEffect = 1;
 				break;
 
-			case SE_AntiGate:
+			case SpellEffect::AntiGate:
 				new_bonus->AntiGate = true;
 				break;
 
-			case SE_MagicWeapon:
+			case SpellEffect::MagicWeapon:
 				new_bonus->MagicWeapon = true;
 				break;
 
-			case SE_Hunger:
+			case SpellEffect::Hunger:
 				new_bonus->hunger = true;
 				break;
 
-			case SE_IncreaseBlockChance:
+			case SpellEffect::IncreaseBlockChance:
 				if (AdditiveWornBonus)
 					new_bonus->IncreaseBlockChance += effect_value;
 				else if (effect_value < 0 && new_bonus->IncreaseBlockChance > effect_value)
@@ -2933,11 +2933,11 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 					new_bonus->IncreaseBlockChance = effect_value;
 				break;
 
-			case SE_PersistantCasting:
+			case SpellEffect::PersistantCasting:
 				new_bonus->PersistantCasting += effect_value;
 				break;
 
-			case SE_LimitHPPercent:
+			case SpellEffect::LimitHPPercent:
 			{
 				if(new_bonus->HPPercCap[SBIndex::RESOURCE_PERCENT_CAP] != 0 && new_bonus->HPPercCap[SBIndex::RESOURCE_PERCENT_CAP] > effect_value){
 					new_bonus->HPPercCap[SBIndex::RESOURCE_PERCENT_CAP] = effect_value;
@@ -2949,7 +2949,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				}
 				break;
 			}
-			case SE_LimitManaPercent:
+			case SpellEffect::LimitManaPercent:
 			{
 				if(new_bonus->ManaPercCap[SBIndex::RESOURCE_PERCENT_CAP] != 0 && new_bonus->ManaPercCap[SBIndex::RESOURCE_PERCENT_CAP] > effect_value){
 					new_bonus->ManaPercCap[SBIndex::RESOURCE_PERCENT_CAP] = effect_value;
@@ -2962,7 +2962,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 
 				break;
 			}
-			case SE_LimitEndPercent:
+			case SpellEffect::LimitEndPercent:
 			{
 				if(new_bonus->EndPercCap[SBIndex::RESOURCE_PERCENT_CAP] != 0 && new_bonus->EndPercCap[SBIndex::RESOURCE_PERCENT_CAP] > effect_value) {
 					new_bonus->EndPercCap[SBIndex::RESOURCE_PERCENT_CAP] = effect_value;
@@ -2977,33 +2977,33 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_NegateSpellEffect:
+			case SpellEffect::NegateSpellEffect:
 				new_bonus->NegateEffects = true;
 				break;
 
-			case SE_ImmuneFleeing:
+			case SpellEffect::ImmuneFleeing:
 				new_bonus->ImmuneToFlee = true;
 				if (currently_fleeing) // lets update shit now instead of next tick
 					ProcessFlee();
 				break;
 
-			case SE_DelayDeath:
+			case SpellEffect::DelayDeath:
 				new_bonus->DelayDeath += effect_value;
 				break;
 
-			case SE_SpellProcChance:
+			case SpellEffect::SpellProcChance:
 				new_bonus->SpellProcChance += effect_value;
 				break;
 
-			case SE_CharmBreakChance:
+			case SpellEffect::CharmBreakChance:
 				new_bonus->CharmBreakChance += effect_value;
 				break;
 
-			case SE_BardSongRange:
+			case SpellEffect::BardSongRange:
 				new_bonus->SongRange += effect_value;
 				break;
 
-			case SE_HPToMana:
+			case SpellEffect::HPToMana:
 			{
 				//Lower the ratio the more favorable
 				if ((!new_bonus->HPToManaConvert) || (new_bonus->HPToManaConvert >= effect_value)) {
@@ -3012,7 +3012,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_SkillDamageAmount2:
+			case SpellEffect::SkillDamageAmount2:
 			{
 				// Bad data or unsupported new skill
 				if (limit_value > EQ::skills::HIGHEST_SKILL)
@@ -3024,7 +3024,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_NegateAttacks:
+			case SpellEffect::NegateAttacks:
 			{
 				if (
 					!new_bonus->NegateAttacks[SBIndex::NEGATE_ATK_EXISTS] ||
@@ -3040,7 +3040,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_MitigateMeleeDamage:
+			case SpellEffect::MitigateMeleeDamage:
 			{
 				if (new_bonus->MitigateMeleeRune[SBIndex::MITIGATION_RUNE_PERCENT] < effect_value){
 					new_bonus->MitigateMeleeRune[SBIndex::MITIGATION_RUNE_PERCENT]                = effect_value;
@@ -3052,7 +3052,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 			}
 
 
-			case SE_MeleeThresholdGuard:
+			case SpellEffect::MeleeThresholdGuard:
 			{
 				if (new_bonus->MeleeThresholdGuard[SBIndex::THRESHOLDGUARD_MITIGATION_PERCENT] < effect_value){
 					new_bonus->MeleeThresholdGuard[SBIndex::THRESHOLDGUARD_MITIGATION_PERCENT]  = effect_value;
@@ -3062,7 +3062,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_SpellThresholdGuard:
+			case SpellEffect::SpellThresholdGuard:
 			{
 				if (new_bonus->SpellThresholdGuard[SBIndex::THRESHOLDGUARD_MITIGATION_PERCENT] < effect_value){
 					new_bonus->SpellThresholdGuard[SBIndex::THRESHOLDGUARD_MITIGATION_PERCENT]  = effect_value;
@@ -3072,7 +3072,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_MitigateSpellDamage:
+			case SpellEffect::MitigateSpellDamage:
 			{
 				if (WornType) {
 					new_bonus->MitigateSpellRune[SBIndex::MITIGATION_RUNE_PERCENT] += effect_value;
@@ -3087,7 +3087,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_MitigateDotDamage:
+			case SpellEffect::MitigateDotDamage:
 			{
 				if (WornType) {
 					new_bonus->MitigateDotRune[SBIndex::MITIGATION_RUNE_PERCENT] += effect_value;
@@ -3102,7 +3102,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_ManaAbsorbPercentDamage:
+			case SpellEffect::ManaAbsorbPercentDamage:
 			{
 				if (new_bonus->ManaAbsorbPercentDamage < effect_value){
 					new_bonus->ManaAbsorbPercentDamage = effect_value;
@@ -3110,7 +3110,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_Endurance_Absorb_Pct_Damage:
+			case SpellEffect::Endurance_Absorb_Pct_Damage:
 			{
 				if (new_bonus->EnduranceAbsorbPercentDamage[SBIndex::ENDURANCE_ABSORD_MITIGIATION] < effect_value) {
 					new_bonus->EnduranceAbsorbPercentDamage[SBIndex::ENDURANCE_ABSORD_MITIGIATION]  = effect_value;
@@ -3119,7 +3119,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_Shield_Target:
+			case SpellEffect::Shield_Target:
 			{
 				if (new_bonus->ShieldTargetSpa[SBIndex::SHIELD_TARGET_MITIGATION_PERCENT] < effect_value) {
 					new_bonus->ShieldTargetSpa[SBIndex::SHIELD_TARGET_MITIGATION_PERCENT] = effect_value;
@@ -3128,27 +3128,27 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_TriggerMeleeThreshold:
+			case SpellEffect::TriggerMeleeThreshold:
 				new_bonus->TriggerMeleeThreshold = true;
 				break;
 
-			case SE_TriggerSpellThreshold:
+			case SpellEffect::TriggerSpellThreshold:
 				new_bonus->TriggerSpellThreshold = true;
 				break;
 
-			case SE_ShieldBlock:
+			case SpellEffect::ShieldBlock:
 				new_bonus->ShieldBlock += effect_value;
 				break;
 
-			case SE_ShieldEquipDmgMod:
+			case SpellEffect::ShieldEquipDmgMod:
 				new_bonus->ShieldEquipDmgMod += effect_value;
 				break;
 
-			case SE_BlockBehind:
+			case SpellEffect::BlockBehind:
 				new_bonus->BlockBehind += effect_value;
 				break;
 
-			case SE_Blind:
+			case SpellEffect::Blind:
 				if (!RuleB(Combat, AllowRaidTargetBlind) && IsRaidTarget()) { // do not blind raid targets
 					break;
 				}
@@ -3156,93 +3156,93 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				new_bonus->IsBlind = true;
 				break;
 
-			case SE_Fear:
+			case SpellEffect::Fear:
 				new_bonus->IsFeared = true;
 				break;
 
 			//AA bonuses - implemented broadly into spell/item effects
-			case SE_FrontalStunResist:
+			case SpellEffect::FrontalStunResist:
 				new_bonus->FrontalStunResist += effect_value;
 				break;
 
-			case SE_ImprovedBindWound:
+			case SpellEffect::ImprovedBindWound:
 				new_bonus->BindWound += effect_value;
 				break;
 
-			case SE_MaxBindWound:
+			case SpellEffect::MaxBindWound:
 				new_bonus->MaxBindWound += effect_value;
 				break;
 
-			case SE_BaseMovementSpeed:
+			case SpellEffect::BaseMovementSpeed:
 				new_bonus->BaseMovementSpeed += effect_value;
 				break;
 
-			case SE_IncreaseRunSpeedCap:
+			case SpellEffect::IncreaseRunSpeedCap:
 				new_bonus->IncreaseRunSpeedCap += effect_value;
 				break;
 
-			case SE_DoubleSpecialAttack:
+			case SpellEffect::DoubleSpecialAttack:
 				new_bonus->DoubleSpecialAttack += effect_value;
 				break;
 
-			case SE_TripleBackstab:
+			case SpellEffect::TripleBackstab:
 				new_bonus->TripleBackstab += effect_value;
 				break;
 
-			case SE_FrontalBackstabMinDmg:
+			case SpellEffect::FrontalBackstabMinDmg:
 				new_bonus->FrontalBackstabMinDmg = true;
 				break;
 
-			case SE_FrontalBackstabChance:
+			case SpellEffect::FrontalBackstabChance:
 				new_bonus->FrontalBackstabChance += effect_value;
 				break;
 
-			case SE_Double_Backstab_Front:
+			case SpellEffect::Double_Backstab_Front:
 				new_bonus->Double_Backstab_Front += effect_value;
 				break;
 
-			case SE_ConsumeProjectile:
+			case SpellEffect::ConsumeProjectile:
 				new_bonus->ConsumeProjectile += effect_value;
 				break;
 
-			case SE_ForageAdditionalItems:
+			case SpellEffect::ForageAdditionalItems:
 				new_bonus->ForageAdditionalItems += effect_value;
 				break;
 
-			case SE_Salvage:
+			case SpellEffect::Salvage:
 				new_bonus->SalvageChance += effect_value;
 				break;
 
-			case SE_ArcheryDamageModifier:
+			case SpellEffect::ArcheryDamageModifier:
 				new_bonus->ArcheryDamageModifier += effect_value;
 				break;
 
-			case SE_DoubleRangedAttack:
+			case SpellEffect::DoubleRangedAttack:
 				new_bonus->DoubleRangedAttack += effect_value;
 				break;
 
-			case SE_SecondaryDmgInc:
+			case SpellEffect::SecondaryDmgInc:
 				new_bonus->SecondaryDmgInc = true;
 				break;
 
-			case SE_StrikeThrough:
-			case SE_StrikeThrough2:
+			case SpellEffect::StrikeThrough:
+			case SpellEffect::StrikeThrough2:
 				new_bonus->StrikeThrough += effect_value;
 				break;
 
-			case SE_GiveDoubleAttack:
+			case SpellEffect::GiveDoubleAttack:
 				new_bonus->GiveDoubleAttack += effect_value;
 				break;
 
-			case SE_PetCriticalHit:
+			case SpellEffect::PetCriticalHit:
 				new_bonus->PetCriticalHit += effect_value;
 				break;
 
-			case SE_CombatStability:
+			case SpellEffect::CombatStability:
 				new_bonus->CombatStability += effect_value;
 				break;
 
-			case SE_AddSingingMod:
+			case SpellEffect::AddSingingMod:
 				switch (limit_value) {
 				case EQ::item::ItemTypeWindInstrument:
 					new_bonus->windMod += effect_value;
@@ -3264,76 +3264,76 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				}
 				break;
 
-			case SE_SongModCap:
+			case SpellEffect::SongModCap:
 				new_bonus->songModCap += effect_value;
 				break;
 
-			case SE_PetAvoidance:
+			case SpellEffect::PetAvoidance:
 				new_bonus->PetAvoidance += effect_value;
 				break;
 
-			case SE_Ambidexterity:
+			case SpellEffect::Ambidexterity:
 				new_bonus->Ambidexterity += effect_value;
 				break;
 
-			case SE_PetMaxHP:
+			case SpellEffect::PetMaxHP:
 				new_bonus->PetMaxHP += effect_value;
 				break;
 
-			case SE_PetFlurry:
+			case SpellEffect::PetFlurry:
 				new_bonus->PetFlurry += effect_value;
 				break;
 
-			case SE_GivePetGroupTarget:
+			case SpellEffect::GivePetGroupTarget:
 				new_bonus->GivePetGroupTarget = true;
 				break;
 
-			case SE_RootBreakChance:
+			case SpellEffect::RootBreakChance:
 				new_bonus->RootBreakChance += effect_value;
 				break;
 
-			case SE_ChannelChanceItems:
+			case SpellEffect::ChannelChanceItems:
 				new_bonus->ChannelChanceItems += effect_value;
 				break;
 
-			case SE_ChannelChanceSpells:
+			case SpellEffect::ChannelChanceSpells:
 				new_bonus->ChannelChanceSpells += effect_value;
 				break;
 
-			case SE_UnfailingDivinity:
+			case SpellEffect::UnfailingDivinity:
 				new_bonus->UnfailingDivinity += effect_value;
 				break;
 
 
-			case SE_ItemHPRegenCapIncrease:
+			case SpellEffect::ItemHPRegenCapIncrease:
 				new_bonus->ItemHPRegenCap += effect_value;
 				break;
 
-			case SE_OffhandRiposteFail:
+			case SpellEffect::OffhandRiposteFail:
 				new_bonus->OffhandRiposteFail += effect_value;
 				break;
 
-			case SE_ItemAttackCapIncrease:
+			case SpellEffect::ItemAttackCapIncrease:
 				new_bonus->ItemATKCap += effect_value;
 				break;
 
-			case SE_TwoHandBluntBlock:
+			case SpellEffect::TwoHandBluntBlock:
 				new_bonus->TwoHandBluntBlock += effect_value;
 				break;
 
-			case SE_StunBashChance:
+			case SpellEffect::StunBashChance:
 				new_bonus->StunBashChance += effect_value;
 				break;
 
-			case SE_IncreaseChanceMemwipe:
+			case SpellEffect::IncreaseChanceMemwipe:
 				new_bonus->IncreaseChanceMemwipe += effect_value;
 				break;
 
-			case SE_CriticalMend:
+			case SpellEffect::CriticalMend:
 				new_bonus->CriticalMend += effect_value;
 				break;
 
-			case SE_SpellEffectResistChance:
+			case SpellEffect::SpellEffectResistChance:
 			{
 				for(int e = 0; e < MAX_RESISTABLE_EFFECTS*2; e+=2)
 				{
@@ -3353,20 +3353,20 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_MasteryofPast:
+			case SpellEffect::MasteryofPast:
 			{
 				if(new_bonus->MasteryofPast < effect_value)
 					new_bonus->MasteryofPast = effect_value;
 				break;
 			}
 
-			case SE_DoubleRiposte:
+			case SpellEffect::DoubleRiposte:
 			{
 				new_bonus->DoubleRiposte += effect_value;
 				break;
 			}
 
-			case SE_GiveDoubleRiposte:
+			case SpellEffect::GiveDoubleRiposte:
 			{
 				//Only allow for regular double riposte chance.
 				if(new_bonus->GiveDoubleRiposte[limit_value] == 0){
@@ -3376,7 +3376,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_SlayUndead: {
+			case SpellEffect::SlayUndead: {
 				if (new_bonus->SlayUndead[SBIndex::SLAYUNDEAD_DMG_MOD] < effect_value) {
 					new_bonus->SlayUndead[SBIndex::SLAYUNDEAD_RATE_MOD] = limit_value; // Rate
 					new_bonus->SlayUndead[SBIndex::SLAYUNDEAD_DMG_MOD] = effect_value; // Damage Modifier
@@ -3384,16 +3384,16 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_TriggerOnReqTarget:
-			case SE_TriggerOnReqCaster:
+			case SpellEffect::TriggerOnReqTarget:
+			case SpellEffect::TriggerOnReqCaster:
 				new_bonus->TriggerOnCastRequirement = true;
 				break;
 
-			case SE_DivineAura:
+			case SpellEffect::DivineAura:
 				new_bonus->DivineAura = true;
 				break;
 
-			case SE_ImprovedTaunt:
+			case SpellEffect::ImprovedTaunt:
 				if (new_bonus->ImprovedTaunt[SBIndex::IMPROVED_TAUNT_MAX_LVL] < effect_value) {
 					new_bonus->ImprovedTaunt[SBIndex::IMPROVED_TAUNT_MAX_LVL]   = effect_value;
 					new_bonus->ImprovedTaunt[SBIndex::IMPROVED_TAUNT_AGGRO_MOD] = limit_value;
@@ -3402,15 +3402,15 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 
 
-			case SE_DistanceRemoval:
+			case SpellEffect::DistanceRemoval:
 				new_bonus->DistanceRemoval = true;
 				break;
 
-			case SE_FrenziedDevastation:
+			case SpellEffect::FrenziedDevastation:
 				new_bonus->FrenziedDevastation += limit_value;
 				break;
 
-			case SE_Root:
+			case SpellEffect::Root:
 				if (new_bonus->Root[SBIndex::ROOT_EXISTS] && (new_bonus->Root[SBIndex::ROOT_BUFFSLOT] > buffslot)){
 					new_bonus->Root[SBIndex::ROOT_EXISTS]   = 1;
 					new_bonus->Root[SBIndex::ROOT_BUFFSLOT] = buffslot;
@@ -3421,7 +3421,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				}
 				break;
 
-			case SE_Rune:
+			case SpellEffect::Rune:
 
 				if (new_bonus->MeleeRune[SBIndex::RUNE_AMOUNT] && (new_bonus->MeleeRune[SBIndex::RUNE_BUFFSLOT] > buffslot)){
 
@@ -3435,7 +3435,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 
 				break;
 
-			case SE_AbsorbMagicAtt:
+			case SpellEffect::AbsorbMagicAtt:
 				if (new_bonus->AbsorbMagicAtt[SBIndex::RUNE_AMOUNT] && (new_bonus->AbsorbMagicAtt[SBIndex::RUNE_BUFFSLOT] > buffslot)){
 					new_bonus->AbsorbMagicAtt[SBIndex::RUNE_AMOUNT]   = effect_value;
 					new_bonus->AbsorbMagicAtt[SBIndex::RUNE_BUFFSLOT] = buffslot;
@@ -3446,15 +3446,15 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				}
 				break;
 
-			case SE_NegateIfCombat:
+			case SpellEffect::NegateIfCombat:
 				new_bonus->NegateIfCombat = true;
 				break;
 
-			case SE_Screech:
+			case SpellEffect::Screech:
 				new_bonus->Screech = effect_value;
 				break;
 
-			case SE_AlterNPCLevel:
+			case SpellEffect::AlterNPCLevel:
 
 				if (IsNPC()){
 					if (!new_bonus->AlterNPCLevel
@@ -3474,36 +3474,36 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				}
 				break;
 
-			case SE_AStacker:
+			case SpellEffect::AStacker:
 				new_bonus->AStacker[SBIndex::BUFFSTACKER_EXISTS] = 1;
 				new_bonus->AStacker[SBIndex::BUFFSTACKER_VALUE]  = effect_value;
 				break;
 
-			case SE_BStacker:
+			case SpellEffect::BStacker:
 				new_bonus->BStacker[SBIndex::BUFFSTACKER_EXISTS] = 1;
 				new_bonus->BStacker[SBIndex::BUFFSTACKER_VALUE]  = effect_value;
 				break;
 
-			case SE_CStacker:
+			case SpellEffect::CStacker:
 				new_bonus->CStacker[SBIndex::BUFFSTACKER_EXISTS] = 1;
 				new_bonus->CStacker[SBIndex::BUFFSTACKER_VALUE]  = effect_value;
 				break;
 
-			case SE_DStacker:
+			case SpellEffect::DStacker:
 				new_bonus->DStacker[SBIndex::BUFFSTACKER_EXISTS] = 1;
 				new_bonus->DStacker[SBIndex::BUFFSTACKER_VALUE]  = effect_value;
 				break;
 
-			case SE_Berserk:
+			case SpellEffect::Berserk:
 				new_bonus->BerserkSPA = true;
 				break;
 
 
-			case SE_Metabolism:
+			case SpellEffect::Metabolism:
 				new_bonus->Metabolism += effect_value;
 				break;
 
-			case SE_ImprovedReclaimEnergy:
+			case SpellEffect::ImprovedReclaimEnergy:
 			{
 				if((effect_value < 0) && (new_bonus->ImprovedReclaimEnergy > effect_value))
 					new_bonus->ImprovedReclaimEnergy = effect_value;
@@ -3513,7 +3513,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_HeadShot:
+			case SpellEffect::HeadShot:
 			{
 				if(new_bonus->HeadShot[SBIndex::FINISHING_EFFECT_DMG] < limit_value){
 					new_bonus->HeadShot[SBIndex::FINISHING_EFFECT_PROC_CHANCE] = effect_value;
@@ -3522,7 +3522,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_HeadShotLevel: {
+			case SpellEffect::HeadShotLevel: {
 				if (new_bonus->HSLevel[SBIndex::FINISHING_EFFECT_LEVEL_MAX] < effect_value) {
 					new_bonus->HSLevel[SBIndex::FINISHING_EFFECT_LEVEL_MAX]          = effect_value;
 					new_bonus->HSLevel[SBIndex::FINISHING_EFFECT_LEVEL_CHANCE_BONUS] = limit_value;
@@ -3530,7 +3530,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_Assassinate:
+			case SpellEffect::Assassinate:
 			{
 				if(new_bonus->Assassinate[SBIndex::FINISHING_EFFECT_DMG] < limit_value){
 					new_bonus->Assassinate[SBIndex::FINISHING_EFFECT_PROC_CHANCE] = effect_value;
@@ -3539,7 +3539,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_AssassinateLevel:
+			case SpellEffect::AssassinateLevel:
 			{
 				if(new_bonus->AssassinateLevel[SBIndex::FINISHING_EFFECT_LEVEL_MAX] < effect_value) {
 					new_bonus->AssassinateLevel[SBIndex::FINISHING_EFFECT_LEVEL_MAX]          = effect_value;
@@ -3548,7 +3548,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_FinishingBlow:
+			case SpellEffect::FinishingBlow:
 			{
 				//base1 = chance, base2 = damage
 				if (new_bonus->FinishingBlow[SBIndex::FINISHING_EFFECT_DMG] < limit_value){
@@ -3558,7 +3558,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_FinishingBlowLvl:
+			case SpellEffect::FinishingBlowLvl:
 			{
 				if (new_bonus->FinishingBlowLvl[SBIndex::FINISHING_EFFECT_LEVEL_MAX] < effect_value){
 					new_bonus->FinishingBlowLvl[SBIndex::FINISHING_EFFECT_LEVEL_MAX]    = effect_value;
@@ -3567,15 +3567,15 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_PetMeleeMitigation:
+			case SpellEffect::PetMeleeMitigation:
 				new_bonus->PetMeleeMitigation += effect_value;
 				break;
 
-			case SE_Sanctuary:
+			case SpellEffect::Sanctuary:
 				new_bonus->Sanctuary = true;
 				break;
 
-			case SE_FactionModPct:
+			case SpellEffect::FactionModPct:
 			{
 				if((effect_value < 0) && (new_bonus->FactionModPct > effect_value))
 					new_bonus->FactionModPct = effect_value;
@@ -3585,15 +3585,15 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_Illusion:
+			case SpellEffect::Illusion:
 				new_bonus->Illusion = spell_id;
 				break;
 
-			case SE_IllusionPersistence:
+			case SpellEffect::IllusionPersistence:
 				new_bonus->IllusionPersistence = effect_value;
 				break;
 
-			case SE_LimitToSkill: {
+			case SpellEffect::LimitToSkill: {
 				// Bad data or unsupported new skill
 				if (effect_value > EQ::skills::HIGHEST_SKILL) {
 					break;
@@ -3605,7 +3605,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_SkillProcAttempt:{
+			case SpellEffect::SkillProcAttempt:{
 
 				for(int e = 0; e < MAX_SKILL_PROCS; e++)
 				{
@@ -3621,7 +3621,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_SkillProcSuccess:{
+			case SpellEffect::SkillProcSuccess:{
 
 				for(int e = 0; e < MAX_SKILL_PROCS; e++)
 				{
@@ -3636,7 +3636,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_SkillAttackProc: {
+			case SpellEffect::SkillAttackProc: {
 				for (int i = 0; i < MAX_CAST_ON_SKILL_USE; i += 3) {
 					if (!new_bonus->SkillAttackProc[i + SBIndex::SKILLATK_PROC_SPELL_ID]) { // spell id
 						new_bonus->SkillAttackProc[i + SBIndex::SKILLATK_PROC_SPELL_ID] = max_value; // spell to proc
@@ -3652,33 +3652,33 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_PC_Pet_Rampage: {
+			case SpellEffect::PC_Pet_Rampage: {
 				new_bonus->PC_Pet_Rampage[SBIndex::PET_RAMPAGE_CHANCE] += effect_value; //Chance to rampage
 				if (new_bonus->PC_Pet_Rampage[SBIndex::PET_RAMPAGE_DMG_MOD] < limit_value)
 					new_bonus->PC_Pet_Rampage[SBIndex::PET_RAMPAGE_DMG_MOD] = limit_value; //Damage modifer - take highest
 				break;
 			}
 
-			case SE_PC_Pet_AE_Rampage: {
+			case SpellEffect::PC_Pet_AE_Rampage: {
 				new_bonus->PC_Pet_AE_Rampage[SBIndex::PET_RAMPAGE_CHANCE] += effect_value; //Chance to rampage
 				if (new_bonus->PC_Pet_AE_Rampage[SBIndex::PET_RAMPAGE_DMG_MOD] < limit_value)
 					new_bonus->PC_Pet_AE_Rampage[SBIndex::PET_RAMPAGE_DMG_MOD] = limit_value; //Damage modifer - take highest
 				break;
 			}
 
-			case SE_PC_Pet_Flurry_Chance:
+			case SpellEffect::PC_Pet_Flurry_Chance:
 				new_bonus->PC_Pet_Flurry += effect_value; //Chance to Flurry
 				break;
 
-			case SE_ShroudofStealth:
+			case SpellEffect::ShroudofStealth:
 				new_bonus->ShroudofStealth = true;
 				break;
 
-			case SE_ReduceFallDamage:
+			case SpellEffect::ReduceFallDamage:
 				new_bonus->ReduceFallDamage += effect_value;
 				break;
 
-			case SE_ReduceTradeskillFail:{
+			case SpellEffect::ReduceTradeskillFail:{
 
 				if (limit_value > EQ::skills::HIGHEST_SKILL)
 					break;
@@ -3687,12 +3687,12 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_TradeSkillMastery:
+			case SpellEffect::TradeSkillMastery:
 				if (new_bonus->TradeSkillMastery < effect_value)
 					new_bonus->TradeSkillMastery = effect_value;
 				break;
 
-			case SE_RaiseSkillCap: {
+			case SpellEffect::RaiseSkillCap: {
 				if (limit_value > EQ::skills::HIGHEST_SKILL)
 					break;
 
@@ -3701,40 +3701,40 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_NoBreakAESneak:
+			case SpellEffect::NoBreakAESneak:
 				if (new_bonus->NoBreakAESneak < effect_value)
 					new_bonus->NoBreakAESneak = effect_value;
 				break;
 
-			case SE_FeignedCastOnChance:
+			case SpellEffect::FeignedCastOnChance:
 				if (new_bonus->FeignedCastOnChance < effect_value)
 					new_bonus->FeignedCastOnChance = effect_value;
 				break;
 
-			case SE_AdditionalAura:
+			case SpellEffect::AdditionalAura:
 				if (new_bonus->aura_slots < effect_value)
 					new_bonus->aura_slots = effect_value;
 				break;
 
-			case SE_IncreaseTrapCount:
+			case SpellEffect::IncreaseTrapCount:
 				if (new_bonus->trap_slots < effect_value)
 					new_bonus->trap_slots = effect_value;
 				break;
 
-			case SE_Attack_Accuracy_Max_Percent:
+			case SpellEffect::Attack_Accuracy_Max_Percent:
 				new_bonus->Attack_Accuracy_Max_Percent += effect_value;
 				break;
 
 
-			case SE_AC_Mitigation_Max_Percent:
+			case SpellEffect::AC_Mitigation_Max_Percent:
 				new_bonus->AC_Mitigation_Max_Percent += effect_value;
 				break;
 
-			case SE_AC_Avoidance_Max_Percent:
+			case SpellEffect::AC_Avoidance_Max_Percent:
 				new_bonus->AC_Avoidance_Max_Percent += effect_value;
 				break;
 
-			case SE_Damage_Taken_Position_Mod:
+			case SpellEffect::Damage_Taken_Position_Mod:
 			{
 				//Mitigate if damage taken from behind base2 = 0, from front base2 = 1
 				if (limit_value < 0 || limit_value >= 2) {
@@ -3749,7 +3749,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_Melee_Damage_Position_Mod:
+			case SpellEffect::Melee_Damage_Position_Mod:
 			{
 				//Increase damage by percent from behind base2 = 0, from front base2 = 1
 				if (limit_value < 0 || limit_value >= 2) {
@@ -3764,7 +3764,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_Damage_Taken_Position_Amt:
+			case SpellEffect::Damage_Taken_Position_Amt:
 			{
 				//Mitigate if damage taken from behind base2 = 0, from front base2 = 1
 				if (limit_value < 0 || limit_value >= 2) {
@@ -3775,7 +3775,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_Melee_Damage_Position_Amt:
+			case SpellEffect::Melee_Damage_Position_Amt:
 			{
 				//Mitigate if damage taken from behind base2 = 0, from front base2 = 1
 				if (limit_value < 0 || limit_value >= 2) {
@@ -3786,23 +3786,23 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_DS_Mitigation_Amount:
+			case SpellEffect::DS_Mitigation_Amount:
 				new_bonus->DS_Mitigation_Amount += effect_value;
 				break;
 
-			case SE_DS_Mitigation_Percentage:
+			case SpellEffect::DS_Mitigation_Percentage:
 				new_bonus->DS_Mitigation_Percentage += effect_value;
 				break;
 
-			case SE_Pet_Crit_Melee_Damage_Pct_Owner:
+			case SpellEffect::Pet_Crit_Melee_Damage_Pct_Owner:
 				new_bonus->Pet_Crit_Melee_Damage_Pct_Owner += effect_value;
 				break;
 
-			case SE_Pet_Add_Atk:
+			case SpellEffect::Pet_Add_Atk:
 				new_bonus->Pet_Add_Atk += effect_value;
 				break;
 
-			case SE_ExtendedShielding:
+			case SpellEffect::ExtendedShielding:
 			{
 				if (AdditiveWornBonus) {
 					new_bonus->ExtendedShielding += effect_value;
@@ -3816,7 +3816,7 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_ShieldDuration:
+			case SpellEffect::ShieldDuration:
 			{
 				if (AdditiveWornBonus) {
 					new_bonus->ShieldDuration += effect_value;
@@ -3830,15 +3830,15 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_Worn_Endurance_Regen_Cap:
+			case SpellEffect::Worn_Endurance_Regen_Cap:
 				new_bonus->ItemEnduranceRegenCap += effect_value;
 				break;
 
-			case SE_ItemManaRegenCapIncrease:
+			case SpellEffect::ItemManaRegenCapIncrease:
 				new_bonus->ItemManaRegenCap += effect_value;
 				break;
 
-			case SE_Weapon_Stance: {
+			case SpellEffect::Weapon_Stance: {
 				if (IsValidSpell(effect_value)) { //base1 is the spell_id of buff
 					if (limit_value <= WEAPON_STANCE_TYPE_MAX) { //0=2H, 1=Shield, 2=DW
 						if (IsValidSpell(new_bonus->WeaponStance[limit_value])) { //Check if we already a spell_id saved for this effect
@@ -3870,42 +3870,42 @@ void Mob::ApplySpellsBonuses(uint16 spell_id, uint8 casterlevel, StatBonuses *ne
 				break;
 			}
 
-			case SE_Invisibility:
-			case SE_Invisibility2:
+			case SpellEffect::Invisibility:
+			case SpellEffect::Invisibility2:
 				effect_value = std::min({ effect_value, MAX_INVISIBILTY_LEVEL });
 				if (new_bonus->invisibility < effect_value)
 					new_bonus->invisibility = effect_value;
 				break;
 
-			case SE_InvisVsUndead:
-			case SE_InvisVsUndead2:
+			case SpellEffect::InvisVsUndead:
+			case SpellEffect::InvisVsUndead2:
 				if (new_bonus->invisibility_verse_undead < effect_value)
 					new_bonus->invisibility_verse_undead = effect_value;
 				break;
 
-			case SE_InvisVsAnimals:
-			case SE_ImprovedInvisAnimals:
+			case SpellEffect::InvisVsAnimals:
+			case SpellEffect::ImprovedInvisAnimals:
 				effect_value = std::min({ effect_value, MAX_INVISIBILTY_LEVEL });
 				if (new_bonus->invisibility_verse_animal < effect_value)
 					new_bonus->invisibility_verse_animal = effect_value;
 				break;
 
-			case SE_SeeInvis:
+			case SpellEffect::SeeInvis:
 				effect_value = std::min({ effect_value, MAX_INVISIBILTY_LEVEL });
 				if (new_bonus->SeeInvis < effect_value) {
 					new_bonus->SeeInvis = effect_value;
 				}
 				break;
 
-			case SE_ZoneSuspendMinion:
+			case SpellEffect::ZoneSuspendMinion:
 				new_bonus->ZoneSuspendMinion = effect_value;
 				break;
 
-			case SE_CompleteHeal:
+			case SpellEffect::CompleteHeal:
 				new_bonus->CompleteHealBuffBlocker = true;
 				break;
 
-			case SE_TrapCircumvention:
+			case SpellEffect::TrapCircumvention:
 				new_bonus->TrapCircumvention += effect_value;
 				break;
 		}
@@ -4128,93 +4128,93 @@ uint8 Mob::IsFocusEffect(uint16 spell_id,int effect_index, bool AA,uint32 aa_eff
 
 	switch (effect)
 	{
-		case SE_ImprovedDamage:
+		case SpellEffect::ImprovedDamage:
 			return focusImprovedDamage;
-		case SE_ImprovedDamage2:
+		case SpellEffect::ImprovedDamage2:
 			return focusImprovedDamage2;
-		case SE_ImprovedHeal:
+		case SpellEffect::ImprovedHeal:
 			return focusImprovedHeal;
-		case SE_ReduceManaCost:
+		case SpellEffect::ReduceManaCost:
 			return focusManaCost;
-		case SE_IncreaseSpellHaste:
+		case SpellEffect::IncreaseSpellHaste:
 			return focusSpellHaste;
-		case SE_IncreaseSpellDuration:
+		case SpellEffect::IncreaseSpellDuration:
 			return focusSpellDuration;
-		case SE_SpellDurationIncByTic:
+		case SpellEffect::SpellDurationIncByTic:
 			return focusSpellDurByTic;
-		case SE_SwarmPetDuration:
+		case SpellEffect::SwarmPetDuration:
 			return focusSwarmPetDuration;
-		case SE_IncreaseRange:
+		case SpellEffect::IncreaseRange:
 			return focusRange;
-		case SE_ReduceReagentCost:
+		case SpellEffect::ReduceReagentCost:
 			return focusReagentCost;
-		case SE_PetPowerIncrease:
+		case SpellEffect::PetPowerIncrease:
 			return focusPetPower;
-		case SE_SpellResistReduction:
+		case SpellEffect::SpellResistReduction:
 			return focusResistRate;
-		case SE_Fc_ResistIncoming:
+		case SpellEffect::Fc_ResistIncoming:
 			return focusFcResistIncoming;
-		case SE_Fc_Amplify_Mod:
+		case SpellEffect::Fc_Amplify_Mod:
 			return focusFcAmplifyMod;
-		case SE_Fc_Amplify_Amt:
+		case SpellEffect::Fc_Amplify_Amt:
 			return focusFcAmplifyAmt;
-		case SE_SpellHateMod:
+		case SpellEffect::SpellHateMod:
 			return focusSpellHateMod;
-		case SE_ReduceReuseTimer:
+		case SpellEffect::ReduceReuseTimer:
 			return focusReduceRecastTime;
-		case SE_TriggerOnCast:
+		case SpellEffect::TriggerOnCast:
 			return focusTriggerOnCast;
-		case SE_FcSpellVulnerability:
+		case SpellEffect::FcSpellVulnerability:
 			return focusSpellVulnerability;
-		case SE_Fc_Spell_Damage_Pct_IncomingPC:
+		case SpellEffect::Fc_Spell_Damage_Pct_IncomingPC:
 			return focusFcSpellDamagePctIncomingPC;
-		case SE_BlockNextSpellFocus:
+		case SpellEffect::BlockNextSpellFocus:
 			return focusBlockNextSpell;
-		case SE_FcTwincast:
+		case SpellEffect::FcTwincast:
 			return focusTwincast;
-		case SE_SympatheticProc:
+		case SpellEffect::SympatheticProc:
 			return focusSympatheticProc;
-		case SE_FcDamageAmt:
+		case SpellEffect::FcDamageAmt:
 			return focusFcDamageAmt;
-		case SE_FcDamageAmt2:
+		case SpellEffect::FcDamageAmt2:
 			return focusFcDamageAmt2;
-		case SE_FcDamageAmtCrit:
+		case SpellEffect::FcDamageAmtCrit:
 			return focusFcDamageAmtCrit;
-		case SE_FcDamagePctCrit:
+		case SpellEffect::FcDamagePctCrit:
 			return focusFcDamagePctCrit;
-		case SE_FcDamageAmtIncoming:
+		case SpellEffect::FcDamageAmtIncoming:
 			return focusFcDamageAmtIncoming;
-		case SE_Fc_Spell_Damage_Amt_IncomingPC:
+		case SpellEffect::Fc_Spell_Damage_Amt_IncomingPC:
 			return focusFcSpellDamageAmtIncomingPC;
-		case SE_FcHealAmtIncoming:
+		case SpellEffect::FcHealAmtIncoming:
 			return focusFcHealAmtIncoming;
-		case SE_FcHealPctIncoming:
+		case SpellEffect::FcHealPctIncoming:
 			return focusFcHealPctIncoming;
-		case SE_FcBaseEffects:
+		case SpellEffect::FcBaseEffects:
 			return focusFcBaseEffects;
-		case SE_FcIncreaseNumHits:
+		case SpellEffect::FcIncreaseNumHits:
 			return focusIncreaseNumHits;
-		case SE_FcLimitUse:
+		case SpellEffect::FcLimitUse:
 			return focusFcLimitUse;
-		case SE_FcMute:
+		case SpellEffect::FcMute:
 			return focusFcMute;
-		case SE_FcTimerRefresh:
+		case SpellEffect::FcTimerRefresh:
 			return focusFcTimerRefresh;
-		case SE_FcTimerLockout:
+		case SpellEffect::FcTimerLockout:
 			return focusFcTimerLockout;
-		case SE_Fc_Cast_Spell_On_Land:
+		case SpellEffect::Fc_Cast_Spell_On_Land:
 			return focusFcCastSpellOnLand;
-		case SE_FcStunTimeMod:
+		case SpellEffect::FcStunTimeMod:
 			return focusFcStunTimeMod;
-		case SE_Fc_CastTimeMod2:
+		case SpellEffect::Fc_CastTimeMod2:
 			return focusFcCastTimeMod2;
-		case SE_Fc_CastTimeAmt:
+		case SpellEffect::Fc_CastTimeAmt:
 			return focusFcCastTimeAmt;
-		case SE_FcHealPctCritIncoming:
+		case SpellEffect::FcHealPctCritIncoming:
 			return focusFcHealPctCritIncoming;
-		case  SE_FcHealAmt:
+		case SpellEffect::FcHealAmt:
 			return focusFcHealAmt;
-		case SE_FcHealAmtCrit:
+		case SpellEffect::FcHealAmtCrit:
 			return focusFcHealAmtCrit;
 
 	}
@@ -4234,7 +4234,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 		bool negate_aabonus = false;
 		bool negate_itembonus = false;
 
-		if (spells[spell_id].effect_id[i] == SE_NegateSpellEffect) {
+		if (spells[spell_id].effect_id[i] == SpellEffect::NegateSpellEffect) {
 
 			//Set negate types
 			switch (spells[spell_id].base_value[i])
@@ -4286,43 +4286,43 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 			//Negate bonuses
 			switch (spells[spell_id].limit_value[i])
 			{
-				case SE_CurrentHP:
+				case SpellEffect::CurrentHP:
 					if (negate_spellbonus) { spellbonuses.HPRegen = effect_value; }
 					if (negate_aabonus) { aabonuses.HPRegen = effect_value; }
 					if (negate_itembonus) { itembonuses.HPRegen = effect_value; }
 					break;
 
-				case SE_CurrentEndurance:
+				case SpellEffect::CurrentEndurance:
 					if (negate_spellbonus) { spellbonuses.EnduranceRegen = effect_value; }
 					if (negate_aabonus) { aabonuses.EnduranceRegen = effect_value; }
 					if (negate_itembonus) { itembonuses.EnduranceRegen = effect_value; }
 					break;
 
-				case SE_ChangeFrenzyRad:
+				case SpellEffect::ChangeFrenzyRad:
 					if (negate_spellbonus) { spellbonuses.AggroRange = static_cast<float>(effect_value); }
 					if (negate_aabonus) { aabonuses.AggroRange = static_cast<float>(effect_value); }
 					if (negate_itembonus) { itembonuses.AggroRange = static_cast<float>(effect_value); }
 					break;
 
-				case SE_Harmony:
+				case SpellEffect::Harmony:
 					if (negate_spellbonus) { spellbonuses.AssistRange = static_cast<float>(effect_value); }
 					if (negate_aabonus) { aabonuses.AssistRange = static_cast<float>(effect_value); }
 					if (negate_itembonus) { itembonuses.AssistRange = static_cast<float>(effect_value); }
 					break;
 
-				case SE_AttackSpeed:
+				case SpellEffect::AttackSpeed:
 					if (negate_spellbonus) { spellbonuses.haste = effect_value; }
 					if (negate_aabonus) { aabonuses.haste = effect_value; }
 					if (negate_itembonus) { itembonuses.haste = effect_value; }
 					break;
 
-				case SE_AttackSpeed2:
+				case SpellEffect::AttackSpeed2:
 					if (negate_spellbonus) { spellbonuses.hastetype2 = effect_value; }
 					if (negate_aabonus) { aabonuses.hastetype2 = effect_value; }
 					if (negate_itembonus) { itembonuses.hastetype2 = effect_value; }
 					break;
 
-				case SE_AttackSpeed3:
+				case SpellEffect::AttackSpeed3:
 				{
 					if (negate_spellbonus) { spellbonuses.hastetype3 = effect_value; }
 					if (negate_aabonus) { aabonuses.hastetype3 = effect_value; }
@@ -4330,99 +4330,99 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 					break;
 				}
 
-				case SE_AttackSpeed4:
+				case SpellEffect::AttackSpeed4:
 					if (negate_spellbonus) { spellbonuses.inhibitmelee = effect_value; }
 					if (negate_aabonus) { aabonuses.inhibitmelee = effect_value; }
 					if (negate_itembonus) { itembonuses.inhibitmelee = effect_value; }
 					break;
 
-				case SE_IncreaseArchery:
+				case SpellEffect::IncreaseArchery:
 					if (negate_spellbonus) { spellbonuses.increase_archery = effect_value; }
 					if (negate_aabonus) { aabonuses.increase_archery = effect_value; }
 					if (negate_itembonus) { itembonuses.increase_archery = effect_value; }
 					break;
 
-				case SE_TotalHP:
+				case SpellEffect::TotalHP:
 					if (negate_spellbonus) { spellbonuses.FlatMaxHPChange = effect_value; }
 					if (negate_aabonus) { aabonuses.FlatMaxHPChange = effect_value; }
 					if (negate_itembonus) { itembonuses.FlatMaxHPChange = effect_value; }
 					break;
 
-				case SE_ManaRegen_v2:
-				case SE_CurrentMana:
+				case SpellEffect::ManaRegen_v2:
+				case SpellEffect::CurrentMana:
 					if (negate_spellbonus) { spellbonuses.ManaRegen = effect_value; }
 					if (negate_aabonus) { aabonuses.ManaRegen = effect_value; }
 					if (negate_itembonus) { itembonuses.ManaRegen = effect_value; }
 					break;
 
-				case SE_ManaPool:
+				case SpellEffect::ManaPool:
 					if (negate_spellbonus) { spellbonuses.Mana = effect_value; }
 					if (negate_itembonus) { itembonuses.Mana = effect_value; }
 					if (negate_aabonus) { aabonuses.Mana = effect_value; }
 					break;
 
-				case SE_Stamina:
+				case SpellEffect::Stamina:
 					if (negate_spellbonus) { spellbonuses.EnduranceReduction = effect_value; }
 					if (negate_itembonus) { itembonuses.EnduranceReduction = effect_value; }
 					if (negate_aabonus) { aabonuses.EnduranceReduction = effect_value; }
 					break;
 
-				case SE_ACv2:
-				case SE_ArmorClass:
+				case SpellEffect::ACv2:
+				case SpellEffect::ArmorClass:
 					if (negate_spellbonus) { spellbonuses.AC = effect_value; }
 					if (negate_aabonus) { aabonuses.AC = effect_value; }
 					if (negate_itembonus) { itembonuses.AC = effect_value; }
 					break;
 
-				case SE_ATK:
+				case SpellEffect::ATK:
 					if (negate_spellbonus) { spellbonuses.ATK = effect_value; }
 					if (negate_aabonus) { aabonuses.ATK = effect_value; }
 					if (negate_itembonus) { itembonuses.ATK = effect_value; }
 					break;
 
-				case SE_STR:
+				case SpellEffect::STR:
 					if (negate_spellbonus) { spellbonuses.STR = effect_value; }
 					if (negate_itembonus) { itembonuses.STR = effect_value; }
 					if (negate_aabonus) { aabonuses.STR = effect_value; }
 					break;
 
-				case SE_DEX:
+				case SpellEffect::DEX:
 					if (negate_spellbonus) { spellbonuses.DEX = effect_value; }
 					if (negate_aabonus) { aabonuses.DEX = effect_value; }
 					if (negate_itembonus) { itembonuses.DEX = effect_value; }
 					break;
 
-				case SE_AGI:
+				case SpellEffect::AGI:
 					if (negate_itembonus) { itembonuses.AGI = effect_value; }
 					if (negate_aabonus) { aabonuses.AGI = effect_value; }
 					if (negate_spellbonus) { spellbonuses.AGI = effect_value; }
 					break;
 
-				case SE_STA:
+				case SpellEffect::STA:
 					if (negate_spellbonus) { spellbonuses.STA = effect_value; }
 					if (negate_itembonus) { itembonuses.STA = effect_value; }
 					if (negate_aabonus) { aabonuses.STA = effect_value; }
 					break;
 
-				case SE_INT:
+				case SpellEffect::INT:
 					if (negate_spellbonus) { spellbonuses.INT = effect_value; }
 					if (negate_aabonus) { aabonuses.INT = effect_value; }
 					if (negate_itembonus) { itembonuses.INT = effect_value; }
 					break;
 
-				case SE_WIS:
+				case SpellEffect::WIS:
 					if (negate_spellbonus) { spellbonuses.WIS = effect_value; }
 					if (negate_aabonus) { aabonuses.WIS = effect_value; }
 					if (negate_itembonus) { itembonuses.WIS = effect_value; }
 					break;
 
-				case SE_CHA:
+				case SpellEffect::CHA:
 					if (negate_itembonus) { itembonuses.CHA = effect_value; }
 					if (negate_spellbonus) { spellbonuses.CHA = effect_value; }
 					if (negate_aabonus) { aabonuses.CHA = effect_value; }
 					break;
 
-				case SE_AllStats:
+				case SpellEffect::AllStats:
 				{
 					if (negate_spellbonus) {
 						spellbonuses.STR = effect_value;
@@ -4457,37 +4457,37 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 					break;
 				}
 
-				case SE_ResistFire:
+				case SpellEffect::ResistFire:
 					if (negate_spellbonus) { spellbonuses.FR = effect_value; }
 					if (negate_itembonus) { itembonuses.FR = effect_value; }
 					if (negate_aabonus) { aabonuses.FR = effect_value; }
 					break;
 
-				case SE_ResistCold:
+				case SpellEffect::ResistCold:
 					if (negate_spellbonus) { spellbonuses.CR = effect_value; }
 					if (negate_aabonus) { aabonuses.CR = effect_value; }
 					if (negate_itembonus) { itembonuses.CR = effect_value; }
 					break;
 
-				case SE_ResistPoison:
+				case SpellEffect::ResistPoison:
 					if (negate_spellbonus) { spellbonuses.PR = effect_value; }
 					if (negate_aabonus) { aabonuses.PR = effect_value; }
 					if (negate_itembonus) { itembonuses.PR = effect_value; }
 					break;
 
-				case SE_ResistDisease:
+				case SpellEffect::ResistDisease:
 					if (negate_spellbonus) { spellbonuses.DR = effect_value; }
 					if (negate_itembonus) { itembonuses.DR = effect_value; }
 					if (negate_aabonus) { aabonuses.DR = effect_value; }
 					break;
 
-				case SE_ResistMagic:
+				case SpellEffect::ResistMagic:
 					if (negate_spellbonus) { spellbonuses.MR = effect_value; }
 					if (negate_aabonus) { aabonuses.MR = effect_value; }
 					if (negate_itembonus) { itembonuses.MR = effect_value; }
 					break;
 
-				case SE_ResistAll:
+				case SpellEffect::ResistAll:
 				{
 					if (negate_spellbonus) {
 						spellbonuses.MR = effect_value;
@@ -4516,74 +4516,74 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 					break;
 				}
 
-				case SE_ResistCorruption:
+				case SpellEffect::ResistCorruption:
 					if (negate_spellbonus) { spellbonuses.Corrup = effect_value; }
 					if (negate_itembonus) { itembonuses.Corrup = effect_value; }
 					if (negate_aabonus) { aabonuses.Corrup = effect_value; }
 					break;
 
-				case SE_CastingLevel:	// Brilliance of Ro
+				case SpellEffect::CastingLevel:	// Brilliance of Ro
 					if (negate_spellbonus) { spellbonuses.adjusted_casting_skill = effect_value; }
 					if (negate_aabonus) { aabonuses.adjusted_casting_skill = effect_value; }
 					if (negate_itembonus) { itembonuses.adjusted_casting_skill = effect_value; }
 					break;
 
-				case SE_CastingLevel2:
+				case SpellEffect::CastingLevel2:
 					if (negate_spellbonus) { spellbonuses.effective_casting_level = effect_value; }
 					if (negate_aabonus) { aabonuses.effective_casting_level = effect_value; }
 					if (negate_itembonus) { itembonuses.effective_casting_level = effect_value; }
 					break;
 
 
-				case SE_MovementSpeed:
+				case SpellEffect::MovementSpeed:
 					if (negate_spellbonus) { spellbonuses.movementspeed = effect_value; }
 					if (negate_aabonus) { aabonuses.movementspeed = effect_value; }
 					if (negate_itembonus) { itembonuses.movementspeed = effect_value; }
 					break;
 
-				case SE_SpellDamageShield:
+				case SpellEffect::SpellDamageShield:
 					if (negate_spellbonus) { spellbonuses.SpellDamageShield = effect_value; }
 					if (negate_aabonus) { aabonuses.SpellDamageShield = effect_value; }
 					if (negate_itembonus) { itembonuses.SpellDamageShield = effect_value; }
 					break;
 
-				case SE_DamageShield:
+				case SpellEffect::DamageShield:
 					if (negate_spellbonus) { spellbonuses.DamageShield = effect_value; }
 					if (negate_aabonus) { aabonuses.DamageShield = effect_value; }
 					if (negate_itembonus) { itembonuses.DamageShield = effect_value; }
 					break;
 
-				case SE_ReverseDS:
+				case SpellEffect::ReverseDS:
 					if (negate_spellbonus) { spellbonuses.ReverseDamageShield = effect_value; }
 					if (negate_aabonus) { aabonuses.ReverseDamageShield = effect_value; }
 					if (negate_itembonus) { itembonuses.ReverseDamageShield = effect_value; }
 					break;
 
-				case SE_Reflect:
+				case SpellEffect::Reflect:
 					if (negate_spellbonus) { spellbonuses.reflect[SBIndex::REFLECT_CHANCE] = effect_value; }
 					if (negate_aabonus) { aabonuses.reflect[SBIndex::REFLECT_CHANCE] = effect_value; }
 					if (negate_itembonus) { itembonuses.reflect[SBIndex::REFLECT_CHANCE] = effect_value; }
 					break;
 
-				case SE_Amplification:
+				case SpellEffect::Amplification:
 					if (negate_spellbonus) { spellbonuses.Amplification = effect_value; }
 					if (negate_itembonus) { itembonuses.Amplification = effect_value; }
 					if (negate_aabonus) { aabonuses.Amplification = effect_value; }
 					break;
 
-				case SE_ChangeAggro:
+				case SpellEffect::ChangeAggro:
 					if (negate_spellbonus) { spellbonuses.hatemod = effect_value; }
 					if (negate_itembonus) { itembonuses.hatemod = effect_value; }
 					if (negate_aabonus) { aabonuses.hatemod = effect_value; }
 					break;
 
-				case SE_MeleeMitigation:
+				case SpellEffect::MeleeMitigation:
 					if (negate_spellbonus) { spellbonuses.MeleeMitigationEffect = effect_value; }
 					if (negate_itembonus) { itembonuses.MeleeMitigationEffect = effect_value; }
 					if (negate_aabonus) { aabonuses.MeleeMitigationEffect = effect_value; }
 					break;
 
-				case SE_CriticalHitChance:
+				case SpellEffect::CriticalHitChance:
 				{
 					for (int e = 0; e < EQ::skills::HIGHEST_SKILL + 1; e++)
 					{
@@ -4593,61 +4593,61 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 					}
 				}
 
-				case SE_CrippBlowChance:
+				case SpellEffect::CrippBlowChance:
 					if (negate_spellbonus) { spellbonuses.CrippBlowChance = effect_value; }
 					if (negate_aabonus) { aabonuses.CrippBlowChance = effect_value; }
 					if (negate_itembonus) { itembonuses.CrippBlowChance = effect_value; }
 					break;
 
-				case SE_AvoidMeleeChance:
+				case SpellEffect::AvoidMeleeChance:
 					if (negate_spellbonus) { spellbonuses.AvoidMeleeChanceEffect = effect_value; }
 					if (negate_aabonus) { aabonuses.AvoidMeleeChanceEffect = effect_value; }
 					if (negate_itembonus) { itembonuses.AvoidMeleeChanceEffect = effect_value; }
 					break;
 
-				case SE_RiposteChance:
+				case SpellEffect::RiposteChance:
 					if (negate_spellbonus) { spellbonuses.RiposteChance = effect_value; }
 					if (negate_aabonus) { aabonuses.RiposteChance = effect_value; }
 					if (negate_itembonus) { itembonuses.RiposteChance = effect_value; }
 					break;
 
-				case SE_DodgeChance:
+				case SpellEffect::DodgeChance:
 					if (negate_spellbonus) { spellbonuses.DodgeChance = effect_value; }
 					if (negate_aabonus) { aabonuses.DodgeChance = effect_value; }
 					if (negate_itembonus) { itembonuses.DodgeChance = effect_value; }
 					break;
 
-				case SE_ParryChance:
+				case SpellEffect::ParryChance:
 					if (negate_spellbonus) { spellbonuses.ParryChance = effect_value; }
 					if (negate_aabonus) { aabonuses.ParryChance = effect_value; }
 					if (negate_itembonus) { itembonuses.ParryChance = effect_value; }
 					break;
 
-				case SE_DualWieldChance:
+				case SpellEffect::DualWieldChance:
 					if (negate_spellbonus) { spellbonuses.DualWieldChance = effect_value; }
 					if (negate_aabonus) { aabonuses.DualWieldChance = effect_value; }
 					if (negate_itembonus) { itembonuses.DualWieldChance = effect_value; }
 					break;
 
-				case SE_DoubleAttackChance:
+				case SpellEffect::DoubleAttackChance:
 					if (negate_spellbonus) { spellbonuses.DoubleAttackChance = effect_value; }
 					if (negate_aabonus) { aabonuses.DoubleAttackChance = effect_value; }
 					if (negate_itembonus) { itembonuses.DoubleAttackChance = effect_value; }
 					break;
 
-				case SE_TripleAttackChance:
+				case SpellEffect::TripleAttackChance:
 					if (negate_spellbonus) { spellbonuses.TripleAttackChance = effect_value; }
 					if (negate_aabonus) { aabonuses.TripleAttackChance = effect_value; }
 					if (negate_itembonus) { itembonuses.TripleAttackChance = effect_value; }
 					break;
 
-				case SE_MeleeLifetap:
+				case SpellEffect::MeleeLifetap:
 					if (negate_spellbonus) { spellbonuses.MeleeLifetap = effect_value; }
 					if (negate_aabonus) { aabonuses.MeleeLifetap = effect_value; }
 					if (negate_itembonus) { itembonuses.MeleeLifetap = effect_value; }
 					break;
 
-				case SE_AllInstrumentMod:
+				case SpellEffect::AllInstrumentMod:
 				{
 					if (negate_spellbonus) {
 						spellbonuses.singingMod    = effect_value;
@@ -4675,38 +4675,38 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 					break;
 				}
 
-				case SE_ResistSpellChance:
+				case SpellEffect::ResistSpellChance:
 					if (negate_spellbonus) { spellbonuses.ResistSpellChance = effect_value; }
 					if (negate_aabonus) { aabonuses.ResistSpellChance = effect_value; }
 					if (negate_itembonus) { itembonuses.ResistSpellChance = effect_value; }
 					break;
 
-				case SE_ResistFearChance:
+				case SpellEffect::ResistFearChance:
 					if (negate_spellbonus) {spellbonuses.ResistFearChance = effect_value;	}
 					if (negate_aabonus) { aabonuses.ResistFearChance = effect_value; }
 					if (negate_itembonus) { itembonuses.ResistFearChance = effect_value; }
 					break;
 
-				case SE_Fearless:
+				case SpellEffect::Fearless:
 					if (negate_spellbonus) { spellbonuses.Fearless = false; }
 					if (negate_aabonus) { aabonuses.Fearless = false; }
 					if (negate_itembonus) { itembonuses.Fearless = false; }
 					break;
 
-				case SE_HundredHands:
+				case SpellEffect::HundredHands:
 					if (negate_spellbonus) { spellbonuses.HundredHands = effect_value; }
 					if (negate_aabonus) { aabonuses.HundredHands = effect_value; }
 					if (negate_itembonus) { itembonuses.HundredHands = effect_value; }
 					break;
 
-				case SE_MeleeSkillCheck:
+				case SpellEffect::MeleeSkillCheck:
 				{
 					if (negate_spellbonus) { spellbonuses.MeleeSkillCheck = effect_value; }
 					if (negate_spellbonus) { spellbonuses.MeleeSkillCheckSkill = effect_value; }
 					break;
 				}
 
-				case SE_HitChance:
+				case SpellEffect::HitChance:
 				{
 					for (int e = 0; e < EQ::skills::HIGHEST_SKILL + 1; e++)
 					{
@@ -4717,7 +4717,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 					break;
 				}
 
-				case SE_DamageModifier:
+				case SpellEffect::DamageModifier:
 				{
 					for (int e = 0; e < EQ::skills::HIGHEST_SKILL + 1; e++)
 					{
@@ -4728,7 +4728,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 					break;
 				}
 
-				case SE_DamageModifier2:
+				case SpellEffect::DamageModifier2:
 				{
 					for (int e = 0; e < EQ::skills::HIGHEST_SKILL + 1; e++)
 					{
@@ -4739,7 +4739,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 					break;
 				}
 
-				case SE_Skill_Base_Damage_Mod:
+				case SpellEffect::Skill_Base_Damage_Mod:
 				{
 					for (int e = 0; e < EQ::skills::HIGHEST_SKILL + 1; e++)
 					{
@@ -4751,7 +4751,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 				}
 
 
-				case SE_MinDamageModifier:
+				case SpellEffect::MinDamageModifier:
 				{
 					for (int e = 0; e < EQ::skills::HIGHEST_SKILL + 1; e++)
 					{
@@ -4762,55 +4762,55 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 					break;
 				}
 
-				case SE_StunResist:
+				case SpellEffect::StunResist:
 					if (negate_spellbonus) { spellbonuses.StunResist = effect_value; }
 					if (negate_aabonus) { aabonuses.StunResist = effect_value; }
 					if (negate_itembonus) { itembonuses.StunResist = effect_value; }
 					break;
 
-				case SE_ProcChance:
+				case SpellEffect::ProcChance:
 					if (negate_spellbonus) { spellbonuses.ProcChanceSPA = effect_value; }
 					if (negate_aabonus) { aabonuses.ProcChanceSPA = effect_value; }
 					if (negate_itembonus) { itembonuses.ProcChanceSPA = effect_value; }
 					break;
 
-				case SE_ExtraAttackChance:
+				case SpellEffect::ExtraAttackChance:
 					if (negate_spellbonus) { spellbonuses.ExtraAttackChance[SBIndex::EXTRA_ATTACK_CHANCE] = effect_value; }
 					if (negate_aabonus) { aabonuses.ExtraAttackChance[SBIndex::EXTRA_ATTACK_CHANCE] = effect_value; }
 					if (negate_itembonus) { itembonuses.ExtraAttackChance[SBIndex::EXTRA_ATTACK_CHANCE] = effect_value; }
 					break;
 
-				case SE_AddExtraAttackPct_1h_Primary:
+				case SpellEffect::AddExtraAttackPct_1h_Primary:
 					if (negate_spellbonus) { spellbonuses.ExtraAttackChancePrimary[SBIndex::EXTRA_ATTACK_CHANCE] = effect_value; }
 					if (negate_aabonus) { aabonuses.ExtraAttackChancePrimary[SBIndex::EXTRA_ATTACK_CHANCE] = effect_value; }
 					if (negate_itembonus) { itembonuses.ExtraAttackChancePrimary[SBIndex::EXTRA_ATTACK_CHANCE] = effect_value; }
 					break;
 
-				case SE_AddExtraAttackPct_1h_Secondary:
+				case SpellEffect::AddExtraAttackPct_1h_Secondary:
 					if (negate_spellbonus) { spellbonuses.ExtraAttackChanceSecondary[SBIndex::EXTRA_ATTACK_CHANCE] = effect_value; }
 					if (negate_aabonus) { aabonuses.ExtraAttackChanceSecondary[SBIndex::EXTRA_ATTACK_CHANCE] = effect_value; }
 					if (negate_itembonus) { itembonuses.ExtraAttackChanceSecondary[SBIndex::EXTRA_ATTACK_CHANCE] = effect_value; }
 					break;
 
-				case SE_Double_Melee_Round:
+				case SpellEffect::Double_Melee_Round:
 					if (negate_spellbonus) { spellbonuses.DoubleMeleeRound[SBIndex::DOUBLE_MELEE_ROUND_CHANCE] = effect_value; }
 					if (negate_aabonus) { aabonuses.DoubleMeleeRound[SBIndex::DOUBLE_MELEE_ROUND_CHANCE] = effect_value; }
 					if (negate_itembonus) { itembonuses.DoubleMeleeRound[SBIndex::DOUBLE_MELEE_ROUND_CHANCE] = effect_value; }
 					break;
 
-				case SE_PercentXPIncrease:
+				case SpellEffect::PercentXPIncrease:
 					if (negate_spellbonus) { spellbonuses.XPRateMod = effect_value; }
 					if (negate_aabonus) { aabonuses.XPRateMod = effect_value; }
 					if (negate_itembonus) { itembonuses.XPRateMod = effect_value; }
 					break;
 
-				case SE_Flurry:
+				case SpellEffect::Flurry:
 					if (negate_spellbonus) { spellbonuses.FlurryChance = effect_value; }
 					if (negate_aabonus) { aabonuses.FlurryChance = effect_value; }
 					if (negate_itembonus) { itembonuses.FlurryChance = effect_value; }
 					break;
 
-				case SE_Accuracy:
+				case SpellEffect::Accuracy:
 				{
 					if (negate_spellbonus) { spellbonuses.Accuracy[EQ::skills::HIGHEST_SKILL + 1] = effect_value; }
 					if (negate_itembonus) { itembonuses.Accuracy[EQ::skills::HIGHEST_SKILL + 1] = effect_value; }
@@ -4822,25 +4822,25 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 					break;
 				}
 
-				case SE_MaxHPChange:
+				case SpellEffect::MaxHPChange:
 					if (negate_spellbonus) { spellbonuses.PercentMaxHPChange = effect_value; }
 					if (negate_aabonus) { aabonuses.PercentMaxHPChange = effect_value; }
 					if (negate_itembonus) { itembonuses.PercentMaxHPChange = effect_value; }
 					break;
 
-				case SE_EndurancePool:
+				case SpellEffect::EndurancePool:
 					if (negate_spellbonus) { spellbonuses.Endurance = effect_value; }
 					if (negate_aabonus) { aabonuses.Endurance = effect_value; }
 					if (negate_itembonus) { itembonuses.Endurance = effect_value; }
 					break;
 
-				case SE_HealRate:
+				case SpellEffect::HealRate:
 					if (negate_spellbonus) { spellbonuses.HealRate = effect_value; }
 					if (negate_aabonus) { aabonuses.HealRate = effect_value; }
 					if (negate_itembonus) { itembonuses.HealRate = effect_value; }
 					break;
 
-				case SE_SkillDamageTaken:
+				case SpellEffect::SkillDamageTaken:
 				{
 					for (int e = 0; e < EQ::skills::HIGHEST_SKILL + 1; e++)
 					{
@@ -4852,13 +4852,13 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 					break;
 				}
 
-				case SE_SpellCritChance:
+				case SpellEffect::SpellCritChance:
 					if (negate_spellbonus) { spellbonuses.CriticalSpellChance = effect_value; }
 					if (negate_aabonus) { aabonuses.CriticalSpellChance = effect_value; }
 					if (negate_itembonus) { itembonuses.CriticalSpellChance = effect_value; }
 					break;
 
-				case SE_CriticalSpellChance:
+				case SpellEffect::CriticalSpellChance:
 					if (negate_spellbonus) {
 						spellbonuses.CriticalSpellChance  = effect_value;
 						spellbonuses.SpellCritDmgIncrease = effect_value;
@@ -4876,43 +4876,43 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 
 					break;
 
-				case SE_SpellCritDmgIncrease:
+				case SpellEffect::SpellCritDmgIncrease:
 					if (negate_spellbonus) { spellbonuses.SpellCritDmgIncrease = effect_value; }
 					if (negate_aabonus) { aabonuses.SpellCritDmgIncrease = effect_value; }
 					if (negate_itembonus) { itembonuses.SpellCritDmgIncrease = effect_value; }
 					break;
 
-				case SE_DotCritDmgIncrease:
+				case SpellEffect::DotCritDmgIncrease:
 					if (negate_spellbonus) { spellbonuses.DotCritDmgIncrease = effect_value; }
 					if (negate_aabonus) { aabonuses.DotCritDmgIncrease = effect_value; }
 					if (negate_itembonus) { itembonuses.DotCritDmgIncrease = effect_value; }
 					break;
 
-				case SE_CriticalHealChance:
+				case SpellEffect::CriticalHealChance:
 					if (negate_spellbonus) { spellbonuses.CriticalHealChance = effect_value; }
 					if (negate_aabonus) { aabonuses.CriticalHealChance = effect_value; }
 					if (negate_itembonus) { itembonuses.CriticalHealChance = effect_value; }
 					break;
 
-				case SE_CriticalHealOverTime:
+				case SpellEffect::CriticalHealOverTime:
 					if (negate_spellbonus) { spellbonuses.CriticalHealOverTime = effect_value; }
 					if (negate_aabonus) { aabonuses.CriticalHealOverTime = effect_value; }
 					if (negate_itembonus) { itembonuses.CriticalHealOverTime = effect_value; }
 					break;
 
-				case SE_MitigateDamageShield:
+				case SpellEffect::MitigateDamageShield:
 					if (negate_spellbonus) { spellbonuses.DSMitigationOffHand = effect_value; }
 					if (negate_itembonus) { itembonuses.DSMitigationOffHand = effect_value; }
 					if (negate_aabonus) { aabonuses.DSMitigationOffHand = effect_value; }
 					break;
 
-				case SE_CriticalDoTChance:
+				case SpellEffect::CriticalDoTChance:
 					if (negate_spellbonus) { spellbonuses.CriticalDoTChance = effect_value; }
 					if (negate_aabonus) { aabonuses.CriticalDoTChance = effect_value; }
 					if (negate_itembonus) { itembonuses.CriticalDoTChance = effect_value; }
 					break;
 
-				case SE_ProcOnKillShot:
+				case SpellEffect::ProcOnKillShot:
 				{
 					for (int e = 0; e < MAX_SPELL_TRIGGER * 3; e += 3)
 					{
@@ -4939,7 +4939,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 				}
 
 				/*
-				case SE_SpellOnDeath:
+				case SpellEffect::SpellOnDeath:
 				{
 					for(int e = 0; e < MAX_SPELL_TRIGGER; e=2)
 					{
@@ -4950,7 +4950,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 				}
 				*/
 
-				case SE_CriticalDamageMob:
+				case SpellEffect::CriticalDamageMob:
 				{
 					for (int e = 0; e < EQ::skills::HIGHEST_SKILL + 1; e++)
 					{
@@ -4961,7 +4961,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 					break;
 				}
 
-				case SE_Critical_Melee_Damage_Mod_Max:
+				case SpellEffect::Critical_Melee_Damage_Mod_Max:
 				{
 					for (int e = 0; e < EQ::skills::HIGHEST_SKILL + 1; e++)
 					{
@@ -4972,7 +4972,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 					break;
 				}
 
-				case SE_SkillDamageAmount:
+				case SpellEffect::SkillDamageAmount:
 				{
 					for (int e = 0; e < EQ::skills::HIGHEST_SKILL + 1; e++)
 					{
@@ -4983,47 +4983,47 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 					break;
 				}
 
-				case SE_IncreaseBlockChance:
+				case SpellEffect::IncreaseBlockChance:
 					if (negate_spellbonus) { spellbonuses.IncreaseBlockChance = effect_value; }
 					if (negate_aabonus) { aabonuses.IncreaseBlockChance = effect_value; }
 					if (negate_itembonus) { itembonuses.IncreaseBlockChance = effect_value; }
 					break;
 
-				case SE_PersistantCasting:
+				case SpellEffect::PersistantCasting:
 					if (negate_spellbonus) { spellbonuses.PersistantCasting = effect_value; }
 					if (negate_itembonus) { itembonuses.PersistantCasting = effect_value; }
 					if (negate_aabonus) { aabonuses.PersistantCasting = effect_value; }
 					break;
 
-				case SE_ImmuneFleeing:
+				case SpellEffect::ImmuneFleeing:
 					if (negate_spellbonus) { spellbonuses.ImmuneToFlee = false; }
 					break;
 
-				case SE_DelayDeath:
+				case SpellEffect::DelayDeath:
 					if (negate_spellbonus) { spellbonuses.DelayDeath = effect_value; }
 					if (negate_aabonus) { aabonuses.DelayDeath = effect_value; }
 					if (negate_itembonus) { itembonuses.DelayDeath = effect_value; }
 					break;
 
-				case SE_SpellProcChance:
+				case SpellEffect::SpellProcChance:
 					if (negate_spellbonus) { spellbonuses.SpellProcChance = effect_value; }
 					if (negate_itembonus) { itembonuses.SpellProcChance = effect_value; }
 					if (negate_aabonus) { aabonuses.SpellProcChance = effect_value; }
 					break;
 
-				case SE_CharmBreakChance:
+				case SpellEffect::CharmBreakChance:
 					if (negate_spellbonus) { spellbonuses.CharmBreakChance = effect_value; }
 					if (negate_aabonus) { aabonuses.CharmBreakChance = effect_value; }
 					if (negate_itembonus) { itembonuses.CharmBreakChance = effect_value; }
 					break;
 
-				case SE_BardSongRange:
+				case SpellEffect::BardSongRange:
 					if (negate_spellbonus) { spellbonuses.SongRange = effect_value; }
 					if (negate_aabonus) { aabonuses.SongRange = effect_value; }
 					if (negate_itembonus) { itembonuses.SongRange = effect_value; }
 					break;
 
-				case SE_SkillDamageAmount2:
+				case SpellEffect::SkillDamageAmount2:
 				{
 					for (int e = 0; e < EQ::skills::HIGHEST_SKILL + 1; e++)
 					{
@@ -5034,7 +5034,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 					break;
 				}
 
-				case SE_NegateAttacks:
+				case SpellEffect::NegateAttacks:
 					if (negate_spellbonus) {
 						spellbonuses.NegateAttacks[SBIndex::NEGATE_ATK_EXISTS]   = effect_value;
 						spellbonuses.NegateAttacks[SBIndex::NEGATE_ATK_BUFFSLOT] = effect_value;
@@ -5042,7 +5042,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 
 					break;
 
-				case SE_MitigateMeleeDamage:
+				case SpellEffect::MitigateMeleeDamage:
 					if (negate_spellbonus) {
 						spellbonuses.MitigateMeleeRune[SBIndex::MITIGATION_RUNE_PERCENT]  = effect_value;
 						spellbonuses.MitigateMeleeRune[SBIndex::MITIGATION_RUNE_BUFFSLOT] = -1;
@@ -5050,7 +5050,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 
 					break;
 
-				case SE_MeleeThresholdGuard:
+				case SpellEffect::MeleeThresholdGuard:
 					if (negate_spellbonus) {
 						spellbonuses.MeleeThresholdGuard[SBIndex::THRESHOLDGUARD_MITIGATION_PERCENT] = effect_value;
 						spellbonuses.MeleeThresholdGuard[SBIndex::THRESHOLDGUARD_BUFFSLOT]           = -1;
@@ -5059,7 +5059,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 
 					break;
 
-				case SE_SpellThresholdGuard:
+				case SpellEffect::SpellThresholdGuard:
 					if (negate_spellbonus) {
 						spellbonuses.SpellThresholdGuard[SBIndex::THRESHOLDGUARD_MITIGATION_PERCENT] = effect_value;
 						spellbonuses.SpellThresholdGuard[SBIndex::THRESHOLDGUARD_BUFFSLOT]           = -1;
@@ -5068,7 +5068,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 
 					break;
 
-				case SE_MitigateSpellDamage:
+				case SpellEffect::MitigateSpellDamage:
 					if (negate_spellbonus) {
 						spellbonuses.MitigateSpellRune[SBIndex::MITIGATION_RUNE_PERCENT]  = effect_value;
 						spellbonuses.MitigateSpellRune[SBIndex::MITIGATION_RUNE_BUFFSLOT] = -1;
@@ -5076,7 +5076,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 
 					break;
 
-				case SE_MitigateDotDamage:
+				case SpellEffect::MitigateDotDamage:
 					if (negate_spellbonus) {
 						spellbonuses.MitigateDotRune[SBIndex::MITIGATION_RUNE_PERCENT]  = effect_value;
 						spellbonuses.MitigateDotRune[SBIndex::MITIGATION_RUNE_BUFFSLOT] = -1;
@@ -5084,11 +5084,11 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 
 					break;
 
-				case SE_ManaAbsorbPercentDamage:
+				case SpellEffect::ManaAbsorbPercentDamage:
 					if (negate_spellbonus) { spellbonuses.ManaAbsorbPercentDamage = effect_value; }
 					break;
 
-				case SE_Endurance_Absorb_Pct_Damage:
+				case SpellEffect::Endurance_Absorb_Pct_Damage:
 					if (negate_spellbonus) {
 						spellbonuses.EnduranceAbsorbPercentDamage[SBIndex::ENDURANCE_ABSORD_MITIGIATION]  = effect_value;
 						spellbonuses.EnduranceAbsorbPercentDamage[SBIndex::ENDURANCE_ABSORD_DRAIN_PER_HP] = effect_value;
@@ -5096,223 +5096,223 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 
 					break;
 
-				case SE_ShieldBlock:
+				case SpellEffect::ShieldBlock:
 					if (negate_spellbonus) { spellbonuses.ShieldBlock = effect_value; }
 					if (negate_aabonus) { aabonuses.ShieldBlock = effect_value; }
 					if (negate_itembonus) { itembonuses.ShieldBlock = effect_value; }
 
-				case SE_BlockBehind:
+				case SpellEffect::BlockBehind:
 					if (negate_spellbonus) { spellbonuses.BlockBehind = effect_value; }
 					if (negate_aabonus) { aabonuses.BlockBehind = effect_value; }
 					if (negate_itembonus) { itembonuses.BlockBehind = effect_value; }
 					break;
 
-				case SE_Blind:
+				case SpellEffect::Blind:
 					if (negate_spellbonus) { spellbonuses.IsBlind = false; }
 					break;
 
-				case SE_Fear:
+				case SpellEffect::Fear:
 					if (negate_spellbonus) { spellbonuses.IsFeared = false; }
 					break;
 
-				case SE_FrontalStunResist:
+				case SpellEffect::FrontalStunResist:
 					if (negate_spellbonus) { spellbonuses.FrontalStunResist = effect_value; }
 					if (negate_aabonus) { aabonuses.FrontalStunResist = effect_value; }
 					if (negate_itembonus) { itembonuses.FrontalStunResist = effect_value; }
 					break;
 
-				case SE_ImprovedBindWound:
+				case SpellEffect::ImprovedBindWound:
 					if (negate_aabonus) { aabonuses.BindWound = effect_value; }
 					if (negate_itembonus) { itembonuses.BindWound = effect_value; }
 					if (negate_spellbonus) { spellbonuses.BindWound = effect_value; }
 					break;
 
-				case SE_MaxBindWound:
+				case SpellEffect::MaxBindWound:
 					if (negate_spellbonus) { spellbonuses.MaxBindWound = effect_value; }
 					if (negate_aabonus) { aabonuses.MaxBindWound = effect_value; }
 					if (negate_itembonus) { itembonuses.MaxBindWound = effect_value; }
 					break;
 
-				case SE_BaseMovementSpeed:
+				case SpellEffect::BaseMovementSpeed:
 					if (negate_spellbonus) { spellbonuses.BaseMovementSpeed = effect_value; }
 					if (negate_aabonus) { aabonuses.BaseMovementSpeed = effect_value; }
 					if (negate_itembonus) { itembonuses.BaseMovementSpeed = effect_value; }
 					break;
 
-				case SE_IncreaseRunSpeedCap:
+				case SpellEffect::IncreaseRunSpeedCap:
 					if (negate_itembonus) { itembonuses.IncreaseRunSpeedCap = effect_value; }
 					if (negate_aabonus) { aabonuses.IncreaseRunSpeedCap = effect_value; }
 					if (negate_spellbonus) { spellbonuses.IncreaseRunSpeedCap = effect_value; }
 					break;
 
-				case SE_DoubleSpecialAttack:
+				case SpellEffect::DoubleSpecialAttack:
 					if (negate_spellbonus) { spellbonuses.DoubleSpecialAttack = effect_value; }
 					if (negate_aabonus) { aabonuses.DoubleSpecialAttack = effect_value; }
 					if (negate_itembonus) { itembonuses.DoubleSpecialAttack = effect_value; }
 					break;
 
-				case SE_TripleBackstab:
+				case SpellEffect::TripleBackstab:
 					if (negate_spellbonus) { spellbonuses.TripleBackstab = effect_value; }
 					if (negate_aabonus) { aabonuses.TripleBackstab = effect_value; }
 					if (negate_itembonus) { itembonuses.TripleBackstab = effect_value; }
 					break;
 
-				case SE_FrontalBackstabMinDmg:
+				case SpellEffect::FrontalBackstabMinDmg:
 					if (negate_spellbonus) { spellbonuses.FrontalBackstabMinDmg = false; }
 					break;
 
-				case SE_FrontalBackstabChance:
+				case SpellEffect::FrontalBackstabChance:
 					if (negate_spellbonus) { spellbonuses.FrontalBackstabChance = effect_value; }
 					if (negate_aabonus) { aabonuses.FrontalBackstabChance = effect_value; }
 					if (negate_itembonus) { itembonuses.FrontalBackstabChance = effect_value; }
 					break;
 
-				case SE_Double_Backstab_Front:
+				case SpellEffect::Double_Backstab_Front:
 					if (negate_spellbonus) { spellbonuses.Double_Backstab_Front = effect_value; }
 					if (negate_aabonus) { aabonuses.Double_Backstab_Front = effect_value; }
 					if (negate_itembonus) { itembonuses.Double_Backstab_Front = effect_value; }
 					break;
 
-				case SE_ConsumeProjectile:
+				case SpellEffect::ConsumeProjectile:
 					if (negate_spellbonus) { spellbonuses.ConsumeProjectile = effect_value; }
 					if (negate_aabonus) { aabonuses.ConsumeProjectile = effect_value; }
 					if (negate_itembonus) { itembonuses.ConsumeProjectile = effect_value; }
 					break;
 
-				case SE_ForageAdditionalItems:
+				case SpellEffect::ForageAdditionalItems:
 					if (negate_spellbonus) { spellbonuses.ForageAdditionalItems = effect_value; }
 					if (negate_aabonus) { aabonuses.ForageAdditionalItems = effect_value; }
 					if (negate_itembonus) { itembonuses.ForageAdditionalItems = effect_value; }
 					break;
 
-				case SE_Salvage:
+				case SpellEffect::Salvage:
 					if (negate_spellbonus) { spellbonuses.SalvageChance = effect_value; }
 					if (negate_aabonus) { aabonuses.SalvageChance = effect_value; }
 					if (negate_itembonus) { itembonuses.SalvageChance = effect_value; }
 					break;
 
-				case SE_ArcheryDamageModifier:
+				case SpellEffect::ArcheryDamageModifier:
 					if (negate_spellbonus) { spellbonuses.ArcheryDamageModifier = effect_value; }
 					if (negate_aabonus) { aabonuses.ArcheryDamageModifier = effect_value; }
 					if (negate_itembonus) { itembonuses.ArcheryDamageModifier = effect_value; }
 					break;
 
-				case SE_SecondaryDmgInc:
+				case SpellEffect::SecondaryDmgInc:
 					if (negate_spellbonus) { spellbonuses.SecondaryDmgInc = false; }
 					if (negate_aabonus) { aabonuses.SecondaryDmgInc = false; }
 					if (negate_itembonus) { itembonuses.SecondaryDmgInc = false; }
 					break;
 
-				case SE_StrikeThrough:
-				case SE_StrikeThrough2:
+				case SpellEffect::StrikeThrough:
+				case SpellEffect::StrikeThrough2:
 					if (negate_spellbonus) { spellbonuses.StrikeThrough = effect_value; }
 					if (negate_aabonus) { aabonuses.StrikeThrough = effect_value; }
 					if (negate_itembonus) { itembonuses.StrikeThrough = effect_value; }
 					break;
 
-				case SE_GiveDoubleAttack:
+				case SpellEffect::GiveDoubleAttack:
 					if (negate_spellbonus) { spellbonuses.GiveDoubleAttack = effect_value; }
 					if (negate_aabonus) { aabonuses.GiveDoubleAttack = effect_value; }
 					if (negate_itembonus) { itembonuses.GiveDoubleAttack = effect_value; }
 					break;
 
-				case SE_PetCriticalHit:
+				case SpellEffect::PetCriticalHit:
 					if (negate_spellbonus) { spellbonuses.PetCriticalHit = effect_value; }
 					if (negate_aabonus) { aabonuses.PetCriticalHit = effect_value; }
 					if (negate_itembonus) { itembonuses.PetCriticalHit = effect_value; }
 					break;
 
-				case SE_CombatStability:
+				case SpellEffect::CombatStability:
 					if (negate_spellbonus) { spellbonuses.CombatStability = effect_value; }
 					if (negate_aabonus) { aabonuses.CombatStability = effect_value; }
 					if (negate_itembonus) { itembonuses.CombatStability = effect_value; }
 					break;
 
-				case SE_PetAvoidance:
+				case SpellEffect::PetAvoidance:
 					if (negate_spellbonus) { spellbonuses.PetAvoidance = effect_value; }
 					if (negate_aabonus) { aabonuses.PetAvoidance = effect_value; }
 					if (negate_itembonus) { itembonuses.PetAvoidance = effect_value; }
 					break;
 
-				case SE_Ambidexterity:
+				case SpellEffect::Ambidexterity:
 					if (negate_spellbonus) { spellbonuses.Ambidexterity = effect_value; }
 					if (negate_aabonus) { aabonuses.Ambidexterity = effect_value; }
 					if (negate_itembonus) { itembonuses.Ambidexterity = effect_value; }
 					break;
 
-				case SE_PetMaxHP:
+				case SpellEffect::PetMaxHP:
 					if (negate_spellbonus) { spellbonuses.PetMaxHP = effect_value; }
 					if (negate_aabonus) { aabonuses.PetMaxHP = effect_value; }
 					if (negate_itembonus) { itembonuses.PetMaxHP = effect_value; }
 					break;
 
-				case SE_PetFlurry:
+				case SpellEffect::PetFlurry:
 					if (negate_spellbonus) { spellbonuses.PetFlurry = effect_value; }
 					if (negate_aabonus) { aabonuses.PetFlurry = effect_value; }
 					if (negate_itembonus) { itembonuses.PetFlurry = effect_value; }
 					break;
 
-				case SE_GivePetGroupTarget:
+				case SpellEffect::GivePetGroupTarget:
 					if (negate_spellbonus) { spellbonuses.GivePetGroupTarget = false; }
 					if (negate_aabonus) { aabonuses.GivePetGroupTarget = false; }
 					if (negate_itembonus) { itembonuses.GivePetGroupTarget = false; }
 					break;
 
-				case SE_PetMeleeMitigation:
+				case SpellEffect::PetMeleeMitigation:
 					if (negate_spellbonus) { spellbonuses.PetMeleeMitigation = effect_value; }
 					if (negate_itembonus) { itembonuses.PetMeleeMitigation = effect_value; }
 					if (negate_aabonus) { aabonuses.PetMeleeMitigation = effect_value; }
 					break;
 
-				case SE_RootBreakChance:
+				case SpellEffect::RootBreakChance:
 					if (negate_spellbonus) { spellbonuses.RootBreakChance = effect_value; }
 					if (negate_aabonus) { aabonuses.RootBreakChance = effect_value; }
 					if (negate_itembonus) { itembonuses.RootBreakChance = effect_value; }
 					break;
 
-				case SE_ChannelChanceItems:
+				case SpellEffect::ChannelChanceItems:
 					if (negate_spellbonus) { spellbonuses.ChannelChanceItems = effect_value; }
 					if (negate_aabonus) { aabonuses.ChannelChanceItems = effect_value; }
 					if (negate_itembonus) { itembonuses.ChannelChanceItems = effect_value; }
 					break;
 
-				case SE_ChannelChanceSpells:
+				case SpellEffect::ChannelChanceSpells:
 					if (negate_spellbonus) { spellbonuses.ChannelChanceSpells = effect_value; }
 					if (negate_aabonus) { aabonuses.ChannelChanceSpells = effect_value; }
 					if (negate_itembonus) { itembonuses.ChannelChanceSpells = effect_value; }
 					break;
 
-				case SE_UnfailingDivinity:
+				case SpellEffect::UnfailingDivinity:
 					if (negate_spellbonus) { spellbonuses.UnfailingDivinity = effect_value; }
 					if (negate_aabonus) { aabonuses.UnfailingDivinity = effect_value; }
 					if (negate_itembonus) { itembonuses.UnfailingDivinity = effect_value; }
 					break;
 
-				case SE_ItemHPRegenCapIncrease:
+				case SpellEffect::ItemHPRegenCapIncrease:
 					if (negate_spellbonus) { spellbonuses.ItemHPRegenCap = effect_value; }
 					if (negate_aabonus) { aabonuses.ItemHPRegenCap = effect_value; }
 					if (negate_itembonus) { itembonuses.ItemHPRegenCap = effect_value; }
 					break;
 
-				case SE_Worn_Endurance_Regen_Cap:
+				case SpellEffect::Worn_Endurance_Regen_Cap:
 					if (negate_spellbonus) { spellbonuses.ItemEnduranceRegenCap = effect_value; }
 					if (negate_aabonus) { aabonuses.ItemEnduranceRegenCap = effect_value; }
 					if (negate_itembonus) { itembonuses.ItemEnduranceRegenCap = effect_value; }
 					break;
 
-				case SE_OffhandRiposteFail:
+				case SpellEffect::OffhandRiposteFail:
 					if (negate_spellbonus) { spellbonuses.OffhandRiposteFail = effect_value; }
 					if (negate_aabonus) { aabonuses.OffhandRiposteFail = effect_value; }
 					if (negate_itembonus) { itembonuses.OffhandRiposteFail = effect_value; }
 					break;
 
-				case SE_ItemAttackCapIncrease:
+				case SpellEffect::ItemAttackCapIncrease:
 					if (negate_aabonus) { aabonuses.ItemATKCap = effect_value; }
 					if (negate_itembonus) { itembonuses.ItemATKCap = effect_value; }
 					if (negate_spellbonus) { spellbonuses.ItemATKCap = effect_value; }
 					break;
 
-				case SE_SpellEffectResistChance:
+				case SpellEffect::SpellEffectResistChance:
 				{
 					for (int e = 0; e < MAX_RESISTABLE_EFFECTS * 2; e += 2)
 					{
@@ -5332,25 +5332,25 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 					break;
 				}
 
-				case SE_MasteryofPast:
+				case SpellEffect::MasteryofPast:
 					if (negate_spellbonus) { spellbonuses.MasteryofPast = effect_value; }
 					if (negate_aabonus) { aabonuses.MasteryofPast = effect_value; }
 					if (negate_itembonus) { itembonuses.MasteryofPast = effect_value; }
 					break;
 
-				case SE_DoubleRiposte:
+				case SpellEffect::DoubleRiposte:
 					if (negate_spellbonus) { spellbonuses.DoubleRiposte = effect_value; }
 					if (negate_itembonus) { itembonuses.DoubleRiposte = effect_value; }
 					if (negate_aabonus) { aabonuses.DoubleRiposte = effect_value; }
 					break;
 
-				case SE_GiveDoubleRiposte:
+				case SpellEffect::GiveDoubleRiposte:
 					if (negate_spellbonus) { spellbonuses.GiveDoubleRiposte[SBIndex::DOUBLE_RIPOSTE_CHANCE] = effect_value; }
 					if (negate_itembonus) { itembonuses.GiveDoubleRiposte[SBIndex::DOUBLE_RIPOSTE_CHANCE] = effect_value; }
 					if (negate_aabonus) { aabonuses.GiveDoubleRiposte[SBIndex::DOUBLE_RIPOSTE_CHANCE] = effect_value; }
 					break;
 
-				case SE_SlayUndead:
+				case SpellEffect::SlayUndead:
 					if (negate_spellbonus) {
 						spellbonuses.SlayUndead[SBIndex::SLAYUNDEAD_RATE_MOD] = effect_value;
 						spellbonuses.SlayUndead[SBIndex::SLAYUNDEAD_DMG_MOD]  = effect_value;
@@ -5368,53 +5368,53 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 
 					break;
 
-				case SE_DoubleRangedAttack:
+				case SpellEffect::DoubleRangedAttack:
 					if (negate_spellbonus) { spellbonuses.DoubleRangedAttack = effect_value; }
 					if (negate_aabonus) { aabonuses.DoubleRangedAttack = effect_value; }
 					if (negate_itembonus) { itembonuses.DoubleRangedAttack = effect_value; }
 					break;
 
-				case SE_ShieldEquipDmgMod:
+				case SpellEffect::ShieldEquipDmgMod:
 					if (negate_spellbonus) { spellbonuses.ShieldEquipDmgMod = effect_value; }
 					if (negate_aabonus) { aabonuses.ShieldEquipDmgMod = effect_value; }
 					if (negate_itembonus) { itembonuses.ShieldEquipDmgMod = effect_value; }
 					break;
 
-				case SE_TriggerMeleeThreshold:
+				case SpellEffect::TriggerMeleeThreshold:
 					if (negate_spellbonus) { spellbonuses.TriggerMeleeThreshold = false; }
 					break;
 
-				case SE_TriggerSpellThreshold:
+				case SpellEffect::TriggerSpellThreshold:
 					if (negate_spellbonus) { spellbonuses.TriggerSpellThreshold = false; }
 					break;
 
-				case SE_DivineAura:
+				case SpellEffect::DivineAura:
 					if (negate_spellbonus) { spellbonuses.DivineAura = false; }
 					break;
 
-				case SE_StunBashChance:
+				case SpellEffect::StunBashChance:
 					if (negate_spellbonus) { spellbonuses.StunBashChance = effect_value; }
 					if (negate_itembonus) { itembonuses.StunBashChance = effect_value; }
 					if (negate_aabonus) { aabonuses.StunBashChance = effect_value; }
 					break;
 
-				case SE_IncreaseChanceMemwipe:
+				case SpellEffect::IncreaseChanceMemwipe:
 					if (negate_spellbonus) { spellbonuses.IncreaseChanceMemwipe = effect_value; }
 					if (negate_itembonus) { itembonuses.IncreaseChanceMemwipe = effect_value; }
 					if (negate_aabonus) { aabonuses.IncreaseChanceMemwipe = effect_value; }
 					break;
 
-				case SE_CriticalMend:
+				case SpellEffect::CriticalMend:
 					if (negate_spellbonus) { spellbonuses.CriticalMend = effect_value; }
 					if (negate_itembonus) { itembonuses.CriticalMend = effect_value; }
 					if (negate_aabonus) { aabonuses.CriticalMend = effect_value; }
 					break;
 
-				case SE_DistanceRemoval:
+				case SpellEffect::DistanceRemoval:
 					if (negate_spellbonus) { spellbonuses.DistanceRemoval = false; }
 					break;
 
-				case SE_ImprovedTaunt:
+				case SpellEffect::ImprovedTaunt:
 					if (negate_spellbonus) {
 						spellbonuses.ImprovedTaunt[SBIndex::IMPROVED_TAUNT_MAX_LVL]   = effect_value;
 						spellbonuses.ImprovedTaunt[SBIndex::IMPROVED_TAUNT_AGGRO_MOD] = effect_value;
@@ -5423,13 +5423,13 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 
 					break;
 
-				case SE_FrenziedDevastation:
+				case SpellEffect::FrenziedDevastation:
 					if (negate_spellbonus) { spellbonuses.FrenziedDevastation = effect_value; }
 					if (negate_aabonus) { aabonuses.FrenziedDevastation = effect_value; }
 					if (negate_itembonus) { itembonuses.FrenziedDevastation = effect_value; }
 					break;
 
-				case SE_Root:
+				case SpellEffect::Root:
 					if (negate_spellbonus) {
 						spellbonuses.Root[SBIndex::ROOT_EXISTS]   = effect_value;
 						spellbonuses.Root[SBIndex::ROOT_BUFFSLOT] = -1;
@@ -5437,7 +5437,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 
 					break;
 
-				case SE_Rune:
+				case SpellEffect::Rune:
 					if (negate_spellbonus) {
 						spellbonuses.MeleeRune[SBIndex::RUNE_AMOUNT]   = effect_value;
 						spellbonuses.MeleeRune[SBIndex::RUNE_BUFFSLOT] = -1;
@@ -5445,7 +5445,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 
 					break;
 
-				case SE_AbsorbMagicAtt:
+				case SpellEffect::AbsorbMagicAtt:
 					if (negate_spellbonus) {
 						spellbonuses.AbsorbMagicAtt[SBIndex::RUNE_AMOUNT]   = effect_value;
 						spellbonuses.AbsorbMagicAtt[SBIndex::RUNE_BUFFSLOT] = -1;
@@ -5453,31 +5453,31 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 
 					break;
 
-				case SE_Berserk:
+				case SpellEffect::Berserk:
 					if (negate_spellbonus) { spellbonuses.BerserkSPA = false; }
 					if (negate_aabonus) { aabonuses.BerserkSPA = false; }
 					if (negate_itembonus) { itembonuses.BerserkSPA = false; }
 					break;
 
-				case SE_Vampirism:
+				case SpellEffect::Vampirism:
 					if (negate_spellbonus) { spellbonuses.Vampirism = effect_value; }
 					if (negate_aabonus) { aabonuses.Vampirism = effect_value; }
 					if (negate_itembonus) { itembonuses.Vampirism = effect_value; }
 					break;
 
-				case SE_Metabolism:
+				case SpellEffect::Metabolism:
 					if (negate_spellbonus) { spellbonuses.Metabolism = effect_value; }
 					if (negate_aabonus) { aabonuses.Metabolism = effect_value; }
 					if (negate_itembonus) { itembonuses.Metabolism = effect_value; }
 					break;
 
-				case SE_ImprovedReclaimEnergy:
+				case SpellEffect::ImprovedReclaimEnergy:
 					if (negate_spellbonus) { spellbonuses.ImprovedReclaimEnergy = effect_value; }
 					if (negate_aabonus) { aabonuses.ImprovedReclaimEnergy = effect_value; }
 					if (negate_itembonus) { itembonuses.ImprovedReclaimEnergy = effect_value; }
 					break;
 
-				case SE_HeadShot:
+				case SpellEffect::HeadShot:
 					if (negate_spellbonus) {
 						spellbonuses.HeadShot[SBIndex::FINISHING_EFFECT_PROC_CHANCE] = effect_value;
 						spellbonuses.HeadShot[SBIndex::FINISHING_EFFECT_DMG]         = effect_value;
@@ -5495,7 +5495,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 
 					break;
 
-				case SE_HeadShotLevel:
+				case SpellEffect::HeadShotLevel:
 					if (negate_spellbonus) {
 						spellbonuses.HSLevel[SBIndex::FINISHING_EFFECT_LEVEL_MAX]          = effect_value;
 						spellbonuses.HSLevel[SBIndex::FINISHING_EFFECT_LEVEL_CHANCE_BONUS] = effect_value;
@@ -5513,7 +5513,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 
 					break;
 
-				case SE_Assassinate:
+				case SpellEffect::Assassinate:
 					if (negate_spellbonus) {
 						spellbonuses.Assassinate[SBIndex::FINISHING_EFFECT_PROC_CHANCE] = effect_value;
 						spellbonuses.Assassinate[SBIndex::FINISHING_EFFECT_DMG]         = effect_value;
@@ -5531,7 +5531,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 
 					break;
 
-				case SE_AssassinateLevel:
+				case SpellEffect::AssassinateLevel:
 					if (negate_spellbonus) {
 						spellbonuses.AssassinateLevel[SBIndex::FINISHING_EFFECT_LEVEL_MAX]          = effect_value;
 						spellbonuses.AssassinateLevel[SBIndex::FINISHING_EFFECT_LEVEL_CHANCE_BONUS] = effect_value;
@@ -5549,7 +5549,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 
 					break;
 
-				case SE_FinishingBlow:
+				case SpellEffect::FinishingBlow:
 					if (negate_spellbonus) {
 						spellbonuses.FinishingBlow[SBIndex::FINISHING_EFFECT_PROC_CHANCE] = effect_value;
 						spellbonuses.FinishingBlow[SBIndex::FINISHING_EFFECT_DMG]         = effect_value;
@@ -5567,7 +5567,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 
 					break;
 
-				case SE_FinishingBlowLvl:
+				case SpellEffect::FinishingBlowLvl:
 					if (negate_spellbonus) {
 						spellbonuses.FinishingBlowLvl[SBIndex::FINISHING_EFFECT_LEVEL_MAX]    = effect_value;
 						spellbonuses.FinishingBlowLvl[SBIndex::FINISHING_BLOW_LEVEL_HP_RATIO] = effect_value;
@@ -5585,42 +5585,42 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 
 					break;
 
-				case SE_Sanctuary:
+				case SpellEffect::Sanctuary:
 					if (negate_spellbonus) { spellbonuses.Sanctuary = false; }
 					break;
 
-				case SE_FactionModPct:
+				case SpellEffect::FactionModPct:
 					if (negate_spellbonus) { spellbonuses.FactionModPct = effect_value; }
 					if (negate_itembonus) { itembonuses.FactionModPct = effect_value; }
 					if (negate_aabonus) { aabonuses.FactionModPct = effect_value; }
 					break;
 
-				case SE_IllusionPersistence:
+				case SpellEffect::IllusionPersistence:
 					if (negate_spellbonus) { spellbonuses.IllusionPersistence = effect_value; }
 					if (negate_itembonus) { itembonuses.IllusionPersistence = effect_value; }
 					if (negate_aabonus) { aabonuses.IllusionPersistence = effect_value; }
 					break;
 
-				case SE_Attack_Accuracy_Max_Percent:
+				case SpellEffect::Attack_Accuracy_Max_Percent:
 					if (negate_spellbonus) { spellbonuses.Attack_Accuracy_Max_Percent = effect_value; }
 					if (negate_itembonus) { itembonuses.Attack_Accuracy_Max_Percent = effect_value; }
 					if (negate_aabonus) { aabonuses.Attack_Accuracy_Max_Percent = effect_value; }
 					break;
 
 
-				case SE_AC_Mitigation_Max_Percent:
+				case SpellEffect::AC_Mitigation_Max_Percent:
 					if (negate_spellbonus) { spellbonuses.AC_Mitigation_Max_Percent = effect_value; }
 					if (negate_itembonus) { itembonuses.AC_Mitigation_Max_Percent = effect_value; }
 					if (negate_aabonus) { aabonuses.AC_Mitigation_Max_Percent = effect_value; }
 					break;
 
-				case SE_AC_Avoidance_Max_Percent:
+				case SpellEffect::AC_Avoidance_Max_Percent:
 					if (negate_spellbonus) { spellbonuses.AC_Avoidance_Max_Percent = effect_value; }
 					if (negate_itembonus) { itembonuses.AC_Avoidance_Max_Percent = effect_value; }
 					if (negate_aabonus) { aabonuses.AC_Avoidance_Max_Percent = effect_value; }
 					break;
 
-				case SE_Melee_Damage_Position_Mod:
+				case SpellEffect::Melee_Damage_Position_Mod:
 					if (negate_spellbonus) {
 						spellbonuses.Melee_Damage_Position_Mod[SBIndex::POSITION_BACK]  = effect_value;
 						spellbonuses.Melee_Damage_Position_Mod[SBIndex::POSITION_FRONT] = effect_value;
@@ -5638,7 +5638,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 
 					break;
 
-				case SE_Damage_Taken_Position_Mod:
+				case SpellEffect::Damage_Taken_Position_Mod:
 					if (negate_spellbonus) {
 						spellbonuses.Damage_Taken_Position_Mod[SBIndex::POSITION_BACK]  = effect_value;
 						spellbonuses.Damage_Taken_Position_Mod[SBIndex::POSITION_FRONT] = effect_value;
@@ -5656,7 +5656,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 
 					break;
 
-				case SE_Melee_Damage_Position_Amt:
+				case SpellEffect::Melee_Damage_Position_Amt:
 					if (negate_spellbonus) {
 						spellbonuses.Melee_Damage_Position_Amt[SBIndex::POSITION_BACK]  = effect_value;
 						spellbonuses.Melee_Damage_Position_Amt[SBIndex::POSITION_FRONT] = effect_value;
@@ -5674,7 +5674,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 
 					break;
 
-				case SE_Damage_Taken_Position_Amt:
+				case SpellEffect::Damage_Taken_Position_Amt:
 					if (negate_spellbonus) {
 						spellbonuses.Damage_Taken_Position_Amt[SBIndex::POSITION_BACK]  = effect_value;
 						spellbonuses.Damage_Taken_Position_Amt[SBIndex::POSITION_FRONT] = effect_value;
@@ -5692,31 +5692,31 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 
 					break;
 
-				case SE_DS_Mitigation_Amount:
+				case SpellEffect::DS_Mitigation_Amount:
 					if (negate_spellbonus) { spellbonuses.DS_Mitigation_Amount = effect_value; }
 					if (negate_itembonus) { itembonuses.DS_Mitigation_Amount = effect_value; }
 					if (negate_aabonus) { aabonuses.DS_Mitigation_Amount = effect_value; }
 					break;
 
-				case SE_DS_Mitigation_Percentage:
+				case SpellEffect::DS_Mitigation_Percentage:
 					if (negate_spellbonus) { spellbonuses.DS_Mitigation_Percentage = effect_value; }
 					if (negate_itembonus) { itembonuses.DS_Mitigation_Percentage = effect_value; }
 					if (negate_aabonus) { aabonuses.DS_Mitigation_Percentage = effect_value; }
 					break;
 
-				case SE_Pet_Crit_Melee_Damage_Pct_Owner:
+				case SpellEffect::Pet_Crit_Melee_Damage_Pct_Owner:
 					if (negate_spellbonus) { spellbonuses.Pet_Crit_Melee_Damage_Pct_Owner = effect_value; }
 					if (negate_itembonus) { itembonuses.Pet_Crit_Melee_Damage_Pct_Owner = effect_value; }
 					if (negate_aabonus) { aabonuses.Pet_Crit_Melee_Damage_Pct_Owner = effect_value; }
 					break;
 
-				case SE_Pet_Add_Atk:
+				case SpellEffect::Pet_Add_Atk:
 					if (negate_spellbonus) { spellbonuses.Pet_Add_Atk = effect_value; }
 					if (negate_itembonus) { itembonuses.Pet_Add_Atk = effect_value; }
 					if (negate_aabonus) { aabonuses.Pet_Add_Atk = effect_value; }
 					break;
 
-				case SE_PC_Pet_Rampage:
+				case SpellEffect::PC_Pet_Rampage:
 					if (negate_spellbonus) {
 						spellbonuses.PC_Pet_Rampage[SBIndex::PET_RAMPAGE_CHANCE]  = effect_value;
 						spellbonuses.PC_Pet_Rampage[SBIndex::PET_RAMPAGE_DMG_MOD] = effect_value;
@@ -5734,7 +5734,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 
 					break;
 
-				case SE_PC_Pet_AE_Rampage:
+				case SpellEffect::PC_Pet_AE_Rampage:
 					if (negate_spellbonus) {
 						spellbonuses.PC_Pet_AE_Rampage[SBIndex::PET_RAMPAGE_CHANCE]  = effect_value;
 						spellbonuses.PC_Pet_AE_Rampage[SBIndex::PET_RAMPAGE_DMG_MOD] = effect_value;
@@ -5753,7 +5753,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 					break;
 
 
-				case SE_SkillProcSuccess: {
+				case SpellEffect::SkillProcSuccess: {
 					for (int e = 0; e < MAX_SKILL_PROCS; e++)
 					{
 						if (negate_spellbonus) { spellbonuses.SkillProcSuccess[e] = effect_value; }
@@ -5763,7 +5763,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 					break;
 				}
 
-				case SE_SkillProcAttempt: {
+				case SpellEffect::SkillProcAttempt: {
 					for (int e = 0; e < MAX_SKILL_PROCS; e++)
 					{
 						if (negate_spellbonus) { spellbonuses.SkillProc[e] = effect_value; }
@@ -5773,7 +5773,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 					break;
 				}
 
-				case SE_Shield_Target:	{
+				case SpellEffect::Shield_Target:	{
 					if (negate_spellbonus) {
 						spellbonuses.ShieldTargetSpa[SBIndex::SHIELD_TARGET_MITIGATION_PERCENT] = effect_value;
 						spellbonuses.ShieldTargetSpa[SBIndex::SHIELD_TARGET_BUFFSLOT] = effect_value;

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -296,8 +296,8 @@ Bot::Bot(
 
 			for (int x1 = 0; x1 < EFFECT_COUNT; x1++) {
 				switch (spell.effect_id[x1]) {
-					case SE_IllusionCopy:
-					case SE_Illusion: {
+					case SpellEffect::IllusionCopy:
+					case SpellEffect::Illusion: {
 						if (GetIllusionBlock()) {
 							break;
 						}
@@ -375,63 +375,63 @@ Bot::Bot(
 						}
 						break;
 					}
-					case SE_Silence:
+					case SpellEffect::Silence:
 					{
 						Silence(true);
 						break;
 					}
-					case SE_Amnesia:
+					case SpellEffect::Amnesia:
 					{
 						Amnesia(true);
 						break;
 					}
-					case SE_DivineAura:
+					case SpellEffect::DivineAura:
 					{
 						invulnerable = true;
 						break;
 					}
-					case SE_Invisibility2:
-					case SE_Invisibility:
+					case SpellEffect::Invisibility2:
+					case SpellEffect::Invisibility:
 					{
 						invisible = true;
 						SendAppearancePacket(AppearanceType::Invisibility, 1);
 						break;
 					}
-					case SE_Levitate:
+					case SpellEffect::Levitate:
 					{
 						if (!zone->CanLevitate())
 						{
 								SendAppearancePacket(AppearanceType::FlyMode, 0);
-								BuffFadeByEffect(SE_Levitate);
+								BuffFadeByEffect(SpellEffect::Levitate);
 						}
 						else {
 							SendAppearancePacket(AppearanceType::FlyMode, 2);
 						}
 						break;
 					}
-					case SE_InvisVsUndead2:
-					case SE_InvisVsUndead:
+					case SpellEffect::InvisVsUndead2:
+					case SpellEffect::InvisVsUndead:
 					{
 						invisible_undead = true;
 						break;
 					}
-					case SE_InvisVsAnimals:
+					case SpellEffect::InvisVsAnimals:
 					{
 						invisible_animals = true;
 						break;
 					}
-					case SE_AddMeleeProc:
-					case SE_WeaponProc:
+					case SpellEffect::AddMeleeProc:
+					case SpellEffect::WeaponProc:
 					{
 						AddProcToWeapon(GetProcID(buffs[j1].spellid, x1), false, 100 + spells[buffs[j1].spellid].limit_value[x1], buffs[j1].spellid, buffs[j1].casterlevel);
 						break;
 					}
-					case SE_DefensiveProc:
+					case SpellEffect::DefensiveProc:
 					{
 						AddDefensiveProc(GetProcID(buffs[j1].spellid, x1), 100 + spells[buffs[j1].spellid].limit_value[x1], buffs[j1].spellid);
 						break;
 					}
-					case SE_RangedProc:
+					case SpellEffect::RangedProc:
 					{
 						AddRangedProc(GetProcID(buffs[j1].spellid, x1), 100 + spells[buffs[j1].spellid].limit_value[x1], buffs[j1].spellid);
 						break;
@@ -1527,7 +1527,7 @@ bool Bot::LoadPet()
 		auto my_buffs = GetBuffs();
 		if (buffs_max && my_buffs) {
 			for (int index = 0; index < buffs_max; ++index) {
-				if (IsEffectInSpell(my_buffs[index].spellid, SE_Familiar)) {
+				if (IsEffectInSpell(my_buffs[index].spellid, SpellEffect::Familiar)) {
 					MakePet(my_buffs[index].spellid, spells[my_buffs[index].spellid].teleport_zone);
 					return true;
 				}
@@ -3578,7 +3578,7 @@ void Bot::Depop() {
 
 	if (bot_pet) {
 		if (bot_pet->Charmed()) {
-			bot_pet->BuffFadeByEffect(SE_Charm);
+			bot_pet->BuffFadeByEffect(SpellEffect::Charm);
 		}
 		else {
 			bot_pet->Depop();
@@ -5974,7 +5974,7 @@ bool Bot::SpellOnTarget(
 
 		if (spelltar->IsPet()) {
 			for (int i = 0; i < EFFECT_COUNT; ++i) {
-				if (spells[spell_id].effect_id[i] == SE_Illusion) {
+				if (spells[spell_id].effect_id[i] == SpellEffect::Illusion) {
 					return false;
 				}
 			}
@@ -6214,7 +6214,7 @@ bool Bot::DoFinishedSpellSingleTarget(uint16 spell_id, Mob* spellTarget, EQ::spe
 
 		if (!noGroupSpell) {
 			for (Mob* m : GetBuffTargets(spellTarget)) {
-				if (IsEffectInSpell(thespell, SE_AbsorbMagicAtt) || IsEffectInSpell(thespell, SE_Rune)) {
+				if (IsEffectInSpell(thespell, SpellEffect::AbsorbMagicAtt) || IsEffectInSpell(thespell, SpellEffect::Rune)) {
 					for (int i = 0; i < m->GetMaxTotalSlots(); i++) {
 						uint32 buff_count = m->GetMaxTotalSlots();
 
@@ -7831,7 +7831,7 @@ bool Bot::GetNeedsCured(Mob *tar) {
 	bool need_cured = false;
 
 	if (tar) {
-		if (tar->FindType(SE_PoisonCounter) || tar->FindType(SE_DiseaseCounter) || tar->FindType(SE_CurseCounter) || tar->FindType(SE_CorruptionCounter)) {
+		if (tar->FindType(SpellEffect::PoisonCounter) || tar->FindType(SpellEffect::DiseaseCounter) || tar->FindType(SpellEffect::CurseCounter) || tar->FindType(SpellEffect::CorruptionCounter)) {
 			uint32 buff_count = tar->GetMaxTotalSlots();
 
 			for (unsigned int j = 0; j < buff_count; j++) {
@@ -8616,7 +8616,7 @@ void Bot::Escape()
 }
 
 void Bot::Fling(float value, float target_x, float target_y, float target_z, bool ignore_los, bool clip_through_walls, bool calculate_speed) {
-	BuffFadeByEffect(SE_Levitate);
+	BuffFadeByEffect(SpellEffect::Levitate);
 	if (CheckLosFN(target_x, target_y, target_z, 6.0f) || ignore_los) {
 		auto p = new EQApplicationPacket(OP_Fling, sizeof(fling_struct));
 		auto* f = (fling_struct*) p->pBuffer;
@@ -9553,9 +9553,9 @@ bool Bot::CastChecks(uint16 spell_id, Mob* tar, uint16 spell_type, bool precheck
 
 		if (spells[spell_id].target_type == ST_Self && tar != this) {
 			if (
-				!IsEffectInSpell(spell_id, SE_SummonCorpse) ||
+				!IsEffectInSpell(spell_id, SpellEffect::SummonCorpse) ||
 				(
-					IsEffectInSpell(spell_id, SE_SummonCorpse) &&
+					IsEffectInSpell(spell_id, SpellEffect::SummonCorpse) &&
 					!RuleB(Bots, AllowCommandedSummonCorpse)
 				)
 			) {
@@ -9667,7 +9667,7 @@ bool Bot::CastChecks(uint16 spell_id, Mob* tar, uint16 spell_type, bool precheck
 
 	if (
 		!zone->CanLevitate() &&
-		IsEffectInSpell(spell_id, SE_Levitate)
+		IsEffectInSpell(spell_id, SpellEffect::Levitate)
 	) {
 		LogBotSpellChecksDetail("{} says, 'Cancelling cast of {} due to !CanLevitate.'", GetCleanName(), GetSpellName(spell_id));
 		return false;
@@ -9907,8 +9907,8 @@ bool Bot::CanCastSpellType(uint16 spell_type, uint16 spell_id, Mob* tar) {
 					spell_type != BotSpellTypes::Succor
 				) &&
 				(
-					IsEffectInSpell(spell_id, SE_Teleport) ||
-					IsEffectInSpell(spell_id, SE_Succor)
+					IsEffectInSpell(spell_id, SpellEffect::Teleport) ||
+					IsEffectInSpell(spell_id, SpellEffect::Succor)
 				)
 			) {
 				LogBotSpellChecksDetail("{} says, 'Cancelling cast of {} on {} due to Teleport.'", GetCleanName(), GetSpellName(spell_id), tar->GetCleanName());
@@ -9918,7 +9918,7 @@ bool Bot::CanCastSpellType(uint16 spell_type, uint16 spell_id, Mob* tar) {
 			if (
 				tar->IsPet() &&
 				!RuleB(Bots, CanCastIllusionsOnPets) &&
-				IsEffectInSpell(spell_id, SE_Illusion)
+				IsEffectInSpell(spell_id, SpellEffect::Illusion)
 			) {
 				LogBotSpellChecksDetail("{} says, 'Cancelling cast of {} on {} due to PetSE_Illusion.'", GetCleanName(), GetSpellName(spell_id), tar->GetCleanName());
 				return false;
@@ -9962,13 +9962,13 @@ bool Bot::CanCastSpellType(uint16 spell_type, uint16 spell_id, Mob* tar) {
 							tar->IsBot() &&
 							(tar->GetLevel() >= tar->CastToBot()->GetStopMeleeLevel()) &&
 							(
-								IsEffectInSpell(spell_id, SE_AttackSpeed) ||
-								IsEffectInSpell(spell_id, SE_ReverseDS)
+								IsEffectInSpell(spell_id, SpellEffect::AttackSpeed) ||
+								IsEffectInSpell(spell_id, SpellEffect::ReverseDS)
 							) ||
 							(
 								SpellEffectsCount(spell_id) == 1 &&
 								(
-									IsEffectInSpell(spell_id, SE_ATK) || IsEffectInSpell(spell_id, SE_STR)
+									IsEffectInSpell(spell_id, SpellEffect::ATK) || IsEffectInSpell(spell_id, SpellEffect::STR)
 								)
 							)
 						) {
@@ -9978,11 +9978,11 @@ bool Bot::CanCastSpellType(uint16 spell_type, uint16 spell_id, Mob* tar) {
 						break;
 					case Archetype::Melee:
 						if (
-							IsEffectInSpell(spell_id, SE_IncreaseSpellHaste) ||
-							IsEffectInSpell(spell_id, SE_ManaPool) ||
-							IsEffectInSpell(spell_id, SE_CastingLevel) ||
-							IsEffectInSpell(spell_id, SE_ManaRegen_v2) ||
-							IsEffectInSpell(spell_id, SE_CurrentMana)
+							IsEffectInSpell(spell_id, SpellEffect::IncreaseSpellHaste) ||
+							IsEffectInSpell(spell_id, SpellEffect::ManaPool) ||
+							IsEffectInSpell(spell_id, SpellEffect::CastingLevel) ||
+							IsEffectInSpell(spell_id, SpellEffect::ManaRegen_v2) ||
+							IsEffectInSpell(spell_id, SpellEffect::CurrentMana)
 						) {
 							LogBotSpellChecksDetail("{} says, 'Cancelling cast of {} on {} due to Archetype::Melee.'", GetCleanName(), GetSpellName(spell_id), tar->GetCleanName());
 							return false;
@@ -9997,8 +9997,8 @@ bool Bot::CanCastSpellType(uint16 spell_type, uint16 spell_id, Mob* tar) {
 			// Differences for each type
 			if (spell_type != BotSpellTypes::InCombatBuff) {
 				if (
-					IsEffectInSpell(spell_id, SE_AbsorbMagicAtt) ||
-					IsEffectInSpell(spell_id, SE_Rune)
+					IsEffectInSpell(spell_id, SpellEffect::AbsorbMagicAtt) ||
+					IsEffectInSpell(spell_id, SpellEffect::Rune)
 				) {
 					for (int i = 0; i < tar->GetMaxTotalSlots(); i++) {
 						uint32 buff_count = tar->GetMaxTotalSlots();
@@ -10026,14 +10026,14 @@ bool Bot::CanCastSpellType(uint16 spell_type, uint16 spell_id, Mob* tar) {
 							tar->IsBot() &&
 							(tar->GetLevel() >= tar->CastToBot()->GetStopMeleeLevel()) &&
 							(
-								IsEffectInSpell(spell_id, SE_AttackSpeed) ||
-								IsEffectInSpell(spell_id, SE_ReverseDS)
+								IsEffectInSpell(spell_id, SpellEffect::AttackSpeed) ||
+								IsEffectInSpell(spell_id, SpellEffect::ReverseDS)
 							) ||
 							(
 								SpellEffectsCount(spell_id) == 1 &&
 								(
-									IsEffectInSpell(spell_id, SE_ATK) ||
-									IsEffectInSpell(spell_id, SE_STR)
+									IsEffectInSpell(spell_id, SpellEffect::ATK) ||
+									IsEffectInSpell(spell_id, SpellEffect::STR)
 								)
 							)
 						) {
@@ -10043,11 +10043,11 @@ bool Bot::CanCastSpellType(uint16 spell_type, uint16 spell_id, Mob* tar) {
 						break;
 					case Archetype::Melee:
 						if (
-							IsEffectInSpell(spell_id, SE_IncreaseSpellHaste) ||
-							IsEffectInSpell(spell_id, SE_ManaPool) ||
-							IsEffectInSpell(spell_id, SE_CastingLevel) ||
-							IsEffectInSpell(spell_id, SE_ManaRegen_v2) ||
-							IsEffectInSpell(spell_id, SE_CurrentMana)
+							IsEffectInSpell(spell_id, SpellEffect::IncreaseSpellHaste) ||
+							IsEffectInSpell(spell_id, SpellEffect::ManaPool) ||
+							IsEffectInSpell(spell_id, SpellEffect::CastingLevel) ||
+							IsEffectInSpell(spell_id, SpellEffect::ManaRegen_v2) ||
+							IsEffectInSpell(spell_id, SpellEffect::CurrentMana)
 						) {
 							LogBotSpellChecksDetail("{} says, 'Cancelling cast of {} on {} due to Archetype::Melee.'", GetCleanName(), GetSpellName(spell_id), tar->GetCleanName());
 							return false;
@@ -10329,7 +10329,7 @@ bool Bot::IsValidMezTarget(Mob* owner, Mob* npc, uint16 spell_id) {
 	auto npc_buffs = npc->GetBuffs();
 
 	for (int i = 0; i < buff_count; i++) {
-		if (IsDetrimentalSpell(npc_buffs[i].spellid) && IsEffectInSpell(npc_buffs[i].spellid, SE_CurrentHP)) {
+		if (IsDetrimentalSpell(npc_buffs[i].spellid) && IsEffectInSpell(npc_buffs[i].spellid, SpellEffect::CurrentHP)) {
 			return false;
 		}
 	}
@@ -11684,7 +11684,7 @@ bool Bot::IsValidSpellTypeBySpellID(uint16 spell_type, uint16 spell_id) {
 			return false;
 		case BotSpellTypes::Root:
 		case BotSpellTypes::AERoot:
-			if (IsDetrimentalSpell(spell_id) && IsEffectInSpell(spell_id, SE_Root)) {
+			if (IsDetrimentalSpell(spell_id) && IsEffectInSpell(spell_id, SpellEffect::Root)) {
 				return true;
 			}
 
@@ -11718,7 +11718,7 @@ bool Bot::IsValidSpellTypeBySpellID(uint16 spell_type, uint16 spell_id) {
 
 			return false;
 		case BotSpellTypes::Pet:
-			if (IsSummonPetSpell(spell_id) || IsEffectInSpell(spell_id, SE_TemporaryPets)) {
+			if (IsSummonPetSpell(spell_id) || IsEffectInSpell(spell_id, SpellEffect::TemporaryPets)) {
 				return true;
 			}
 
@@ -11732,7 +11732,7 @@ bool Bot::IsValidSpellTypeBySpellID(uint16 spell_type, uint16 spell_id) {
 			return false;
 		case BotSpellTypes::Snare:
 		case BotSpellTypes::AESnare:
-			if (IsDetrimentalSpell(spell_id) && IsEffectInSpell(spell_id, SE_MovementSpeed)) {
+			if (IsDetrimentalSpell(spell_id) && IsEffectInSpell(spell_id, SpellEffect::MovementSpeed)) {
 				return true;
 			}
 
@@ -11806,7 +11806,7 @@ bool Bot::IsValidSpellTypeBySpellID(uint16 spell_type, uint16 spell_id) {
 
 			return false;
 		case BotSpellTypes::Resurrect:
-			if (IsEffectInSpell(spell_id, SE_Revive)) {
+			if (IsEffectInSpell(spell_id, SpellEffect::Revive)) {
 				return true;
 			}
 
@@ -11911,14 +11911,14 @@ bool Bot::IsValidSpellTypeBySpellID(uint16 spell_type, uint16 spell_id) {
 			return false;
 		case BotSpellTypes::ResistBuffs:
 		case BotSpellTypes::PetResistBuffs:
-			if (IsResistanceBuffSpell(spell_id) && !IsEffectInSpell(spell_id, SE_DamageShield)) {
+			if (IsResistanceBuffSpell(spell_id) && !IsEffectInSpell(spell_id, SpellEffect::DamageShield)) {
 				return true;
 			}
 
 			return false;
 		case BotSpellTypes::DamageShields:
 		case BotSpellTypes::PetDamageShields:
-			if (IsBeneficialSpell(spell_id) && IsEffectInSpell(spell_id, SE_DamageShield)) {
+			if (IsBeneficialSpell(spell_id) && IsEffectInSpell(spell_id, SpellEffect::DamageShield)) {
 				return true;
 			}
 
@@ -11926,7 +11926,7 @@ bool Bot::IsValidSpellTypeBySpellID(uint16 spell_type, uint16 spell_id) {
 		case BotSpellTypes::Teleport:
 			if (
 				IsBeneficialSpell(spell_id) &&
-				(IsEffectInSpell(spell_id, SE_Teleport) || IsEffectInSpell(spell_id, SE_Translocate))
+				(IsEffectInSpell(spell_id, SpellEffect::Teleport) || IsEffectInSpell(spell_id, SpellEffect::Translocate))
 			) {
 				return true;
 			}
@@ -11942,40 +11942,40 @@ bool Bot::IsValidSpellTypeBySpellID(uint16 spell_type, uint16 spell_id) {
 		case BotSpellTypes::Succor:
 			if (
 				IsBeneficialSpell(spell_id) &&
-				IsEffectInSpell(spell_id, SE_Succor)
+				IsEffectInSpell(spell_id, SpellEffect::Succor)
 			) {
 				return true;
 			}
 
 			return false;
 		case BotSpellTypes::BindAffinity:
-			if (IsEffectInSpell(spell_id, SE_BindAffinity)) {
+			if (IsEffectInSpell(spell_id, SpellEffect::BindAffinity)) {
 				return true;
 			}
 
 			return false;
 		case BotSpellTypes::Identify:
-			if (IsEffectInSpell(spell_id, SE_Identify)) {
+			if (IsEffectInSpell(spell_id, SpellEffect::Identify)) {
 				return true;
 			}
 
 			return false;
 		case BotSpellTypes::Levitate:
-			if (IsBeneficialSpell(spell_id) && IsEffectInSpell(spell_id, SE_Levitate)) {
+			if (IsBeneficialSpell(spell_id) && IsEffectInSpell(spell_id, SpellEffect::Levitate)) {
 				return true;
 			}
 
 			return false;
 		case BotSpellTypes::Rune:
 			if (IsBeneficialSpell(spell_id) &&
-				(IsEffectInSpell(spell_id, SE_AbsorbMagicAtt) || IsEffectInSpell(spell_id, SE_Rune))
+				(IsEffectInSpell(spell_id, SpellEffect::AbsorbMagicAtt) || IsEffectInSpell(spell_id, SpellEffect::Rune))
 			) {
 				return true;
 			}
 
 			return false;
 		case BotSpellTypes::WaterBreathing:
-			if (IsBeneficialSpell(spell_id) && IsEffectInSpell(spell_id, SE_WaterBreathing)) {
+			if (IsBeneficialSpell(spell_id) && IsEffectInSpell(spell_id, SpellEffect::WaterBreathing)) {
 				return true;
 			}
 
@@ -11983,7 +11983,7 @@ bool Bot::IsValidSpellTypeBySpellID(uint16 spell_type, uint16 spell_id) {
 		case BotSpellTypes::Size:
 			if (
 				IsBeneficialSpell(spell_id) &&
-				(IsEffectInSpell(spell_id, SE_ModelSize) || IsEffectInSpell(spell_id, SE_ChangeHeight))
+				(IsEffectInSpell(spell_id, SpellEffect::ModelSize) || IsEffectInSpell(spell_id, SpellEffect::ChangeHeight))
 			) {
 				return true;
 			}
@@ -11991,14 +11991,14 @@ bool Bot::IsValidSpellTypeBySpellID(uint16 spell_type, uint16 spell_id) {
 			return false;
 		case BotSpellTypes::Invisibility:
 			if (IsBeneficialSpell(spell_id) &&
-				(IsEffectInSpell(spell_id, SE_SeeInvis) ||IsInvisibleSpell(spell_id))
+				(IsEffectInSpell(spell_id, SpellEffect::SeeInvis) ||IsInvisibleSpell(spell_id))
 			) {
 				return true;
 			}
 
 			return false;
 		case BotSpellTypes::MovementSpeed:
-			if (IsBeneficialSpell(spell_id) && IsEffectInSpell(spell_id, SE_MovementSpeed)) {
+			if (IsBeneficialSpell(spell_id) && IsEffectInSpell(spell_id, SpellEffect::MovementSpeed)) {
 				return true;
 			}
 
@@ -12007,10 +12007,10 @@ bool Bot::IsValidSpellTypeBySpellID(uint16 spell_type, uint16 spell_id) {
 			if (
 				IsBeneficialSpell(spell_id) &&
 					(
-						IsEffectInSpell(spell_id, SE_GateToHomeCity) ||
+						IsEffectInSpell(spell_id, SpellEffect::GateToHomeCity) ||
 							(
 								teleport_zone.compare("") &&
-								(IsEffectInSpell(spell_id, SE_Teleport) || IsEffectInSpell(spell_id, SE_Translocate))
+								(IsEffectInSpell(spell_id, SpellEffect::Teleport) || IsEffectInSpell(spell_id, SpellEffect::Translocate))
 							)
 					)
 			) {
@@ -12019,7 +12019,7 @@ bool Bot::IsValidSpellTypeBySpellID(uint16 spell_type, uint16 spell_id) {
 
 			return false;
 		case BotSpellTypes::SummonCorpse:
-			if (IsEffectInSpell(spell_id, SE_SummonCorpse)) {
+			if (IsEffectInSpell(spell_id, SpellEffect::SummonCorpse)) {
 				return true;
 			}
 
@@ -12510,15 +12510,15 @@ bool Bot::IsValidSpellTypeSubType(uint16 spell_type, uint16 sub_type, uint16 spe
 
 			break;
 		case CommandedSubTypes::SeeInvis:
-			if (IsEffectInSpell(spell_id, SE_SeeInvis)) {
+			if (IsEffectInSpell(spell_id, SpellEffect::SeeInvis)) {
 				return true;
 			}
 
 			break;
 		case CommandedSubTypes::Invis:
 			if (
-				IsEffectInSpell(spell_id, SE_Invisibility) ||
-				IsEffectInSpell(spell_id, SE_Invisibility2)
+				IsEffectInSpell(spell_id, SpellEffect::Invisibility) ||
+				IsEffectInSpell(spell_id, SpellEffect::Invisibility2)
 			) {
 				return true;
 			}
@@ -12526,8 +12526,8 @@ bool Bot::IsValidSpellTypeSubType(uint16 spell_type, uint16 sub_type, uint16 spe
 			break;
 		case CommandedSubTypes::InvisUndead:
 			if (
-				IsEffectInSpell(spell_id, SE_InvisVsUndead) ||
-				IsEffectInSpell(spell_id, SE_InvisVsUndead2)
+				IsEffectInSpell(spell_id, SpellEffect::InvisVsUndead) ||
+				IsEffectInSpell(spell_id, SpellEffect::InvisVsUndead2)
 			) {
 				return true;
 			}
@@ -12535,8 +12535,8 @@ bool Bot::IsValidSpellTypeSubType(uint16 spell_type, uint16 sub_type, uint16 spe
 			break;
 		case CommandedSubTypes::InvisAnimals:
 			if (
-				IsEffectInSpell(spell_id, SE_InvisVsAnimals) ||
-				IsEffectInSpell(spell_id, SE_ImprovedInvisAnimals)
+				IsEffectInSpell(spell_id, SpellEffect::InvisVsAnimals) ||
+				IsEffectInSpell(spell_id, SpellEffect::ImprovedInvisAnimals)
 			) {
 				return true;
 			}
@@ -12545,13 +12545,13 @@ bool Bot::IsValidSpellTypeSubType(uint16 spell_type, uint16 sub_type, uint16 spe
 		case CommandedSubTypes::Shrink:
 			if (
 				(
-					IsEffectInSpell(spell_id, SE_ModelSize) &&
-					CalcSpellEffectValue(spell_id, GetSpellEffectIndex(spell_id, SE_ModelSize), GetLevel()) < 100
+					IsEffectInSpell(spell_id, SpellEffect::ModelSize) &&
+					CalcSpellEffectValue(spell_id, GetSpellEffectIndex(spell_id, SpellEffect::ModelSize), GetLevel()) < 100
 				)
 				||
 				(
-					IsEffectInSpell(spell_id, SE_ChangeHeight) &&
-					CalcSpellEffectValue(spell_id, GetSpellEffectIndex(spell_id, SE_ChangeHeight), GetLevel()) < 100
+					IsEffectInSpell(spell_id, SpellEffect::ChangeHeight) &&
+					CalcSpellEffectValue(spell_id, GetSpellEffectIndex(spell_id, SpellEffect::ChangeHeight), GetLevel()) < 100
 				)
 			) {
 				return true;
@@ -12561,13 +12561,13 @@ bool Bot::IsValidSpellTypeSubType(uint16 spell_type, uint16 sub_type, uint16 spe
 		case CommandedSubTypes::Grow:
 			if (
 				(
-					IsEffectInSpell(spell_id, SE_ModelSize) &&
-					CalcSpellEffectValue(spell_id, GetSpellEffectIndex(spell_id, SE_ModelSize), GetLevel()) > 100
+					IsEffectInSpell(spell_id, SpellEffect::ModelSize) &&
+					CalcSpellEffectValue(spell_id, GetSpellEffectIndex(spell_id, SpellEffect::ModelSize), GetLevel()) > 100
 				)
 				||
 				(
-					IsEffectInSpell(spell_id, SE_ChangeHeight) &&
-					CalcSpellEffectValue(spell_id, GetSpellEffectIndex(spell_id, SE_ChangeHeight), GetLevel()) > 100
+					IsEffectInSpell(spell_id, SpellEffect::ChangeHeight) &&
+					CalcSpellEffectValue(spell_id, GetSpellEffectIndex(spell_id, SpellEffect::ChangeHeight), GetLevel()) > 100
 				)
 			) {
 				return true;
@@ -12577,7 +12577,7 @@ bool Bot::IsValidSpellTypeSubType(uint16 spell_type, uint16 sub_type, uint16 spe
 		case CommandedSubTypes::Selo:
 			if (
 				IsBeneficialSpell(spell_id) &&
-				IsEffectInSpell(spell_id, SE_MovementSpeed) &&
+				IsEffectInSpell(spell_id, SpellEffect::MovementSpeed) &&
 				IsBardSong(spell_id)
 			) {
 				return true;
@@ -13347,7 +13347,7 @@ bool Bot::IsImmuneToBotSpell(uint16 spell_id, Mob* caster) {
 
 	if (!GetSpecialAbility(SpecialAbility::MesmerizeImmunity) && IsMesmerizeSpell(spell_id)) {
 		// check max level for spell
-		effect_index = GetSpellEffectIndex(spell_id, SE_Mez);
+		effect_index = GetSpellEffectIndex(spell_id, SpellEffect::Mez);
 		assert(effect_index >= 0);
 		// NPCs get to ignore the max level
 		if (
@@ -13359,13 +13359,13 @@ bool Bot::IsImmuneToBotSpell(uint16 spell_id, Mob* caster) {
 	}
 
 	// slow and haste spells
-	if (GetSpecialAbility(SpecialAbility::SlowImmunity) && IsEffectInSpell(spell_id, SE_AttackSpeed)) {
+	if (GetSpecialAbility(SpecialAbility::SlowImmunity) && IsEffectInSpell(spell_id, SpellEffect::AttackSpeed)) {
 		return true;
 	}
 
 	// client vs client fear
-	if (!GetSpecialAbility(SpecialAbility::FearImmunity) && IsEffectInSpell(spell_id, SE_Fear)) {
-		effect_index = GetSpellEffectIndex(spell_id, SE_Fear);
+	if (!GetSpecialAbility(SpecialAbility::FearImmunity) && IsEffectInSpell(spell_id, SpellEffect::Fear)) {
+		effect_index = GetSpellEffectIndex(spell_id, SpellEffect::Fear);
 
 		if (IsClient() && caster->IsClient() && (caster->CastToClient()->GetGM() == false)) {
 			LogSpells("Clients cannot fear eachother!");
@@ -13389,7 +13389,7 @@ bool Bot::IsImmuneToBotSpell(uint16 spell_id, Mob* caster) {
 		//let npcs cast whatever charm on anyone
 		if (!caster->IsNPC()) {
 			// check level limit of charm spell
-			effect_index = GetSpellEffectIndex(spell_id, SE_Charm);
+			effect_index = GetSpellEffectIndex(spell_id, SpellEffect::Charm);
 			assert(effect_index >= 0);
 			if (GetLevel() > spells[spell_id].max_value[effect_index] && spells[spell_id].max_value[effect_index] != 0) {
 				return true;
@@ -13400,8 +13400,8 @@ bool Bot::IsImmuneToBotSpell(uint16 spell_id, Mob* caster) {
 	if (
 		GetSpecialAbility(SpecialAbility::SnareImmunity) &&
 		(
-			IsEffectInSpell(spell_id, SE_Root) ||
-			IsEffectInSpell(spell_id, SE_MovementSpeed)
+			IsEffectInSpell(spell_id, SpellEffect::Root) ||
+			IsEffectInSpell(spell_id, SpellEffect::MovementSpeed)
 		)
 	) {
 		return true;

--- a/zone/bot_commands/pet.cpp
+++ b/zone/bot_commands/pet.cpp
@@ -245,7 +245,7 @@ void bot_command_pet_set_type(Client *c, const Seperator *sep)
 
 		if (pet_type == 6 && RuleI(Bots, RequiredMagicianEpicPetItemID) > 0) {
 			bool has_item = bot_iter->HasBotItem(RuleI(Bots, RequiredMagicianEpicPetItemID)) != INVALID_INDEX;
-			
+
 			if (!has_item) {
 				c->Message(
 					Chat::Say,
@@ -257,7 +257,7 @@ void bot_command_pet_set_type(Client *c, const Seperator *sep)
 				);
 
 				continue;
-			}	
+			}
 		}
 
 		if (current_check) {
@@ -313,7 +313,7 @@ void bot_command_pet_set_type(Client *c, const Seperator *sep)
 				continue;
 			}
 
-			if (!IsEffectInSpell(s.SpellId, SE_SummonPet)) {
+			if (!IsEffectInSpell(s.SpellId, SpellEffect::SummonPet)) {
 				continue;
 			}
 
@@ -401,7 +401,7 @@ void bot_command_pet_set_type(Client *c, const Seperator *sep)
 
 		return;
 	}
-	
+
 	if (success_count == 1 && first_found) {
 		c->Message(
 			Chat::Green,

--- a/zone/botspellsai.cpp
+++ b/zone/botspellsai.cpp
@@ -40,7 +40,7 @@ bool Bot::AICastSpell(Mob* tar, uint8 chance, uint16 spell_type, uint16 sub_targ
 	) {
 		return false;
 	}
-	
+
 	if (
 		!IsCommandedSpell() &&
 		zone->random.Int(0, 100) > chance
@@ -240,7 +240,7 @@ bool Bot::AICastSpell(Mob* tar, uint8 chance, uint16 spell_type, uint16 sub_targ
 					tar->GetCleanName()
 				).c_str()
 			);
-		
+
 			InterruptSpell();
 		}
 
@@ -297,7 +297,7 @@ bool Bot::BotCastMez(Mob* tar, uint8 bot_class, BotSpell& bot_spell, uint16 spel
 		if (AIDoSpellCast(s.SpellIndex, tar, s.ManaCost)) {
 			if (BotSpellTypeUsesTargetSettings(spell_type)) {
 				SetCastedSpellType(UINT16_MAX);
-				
+
 				if (!IsCommandedSpell()) {
 					SetBotSpellRecastTimer(spell_type, tar, true);
 				}
@@ -384,7 +384,7 @@ bool Bot::BotCastPet(Mob* tar, uint8 bot_class, BotSpell& bot_spell, uint16 spel
 		int familiar_buff_slot = -1;
 		if (buffs_max && my_buffs) {
 			for (int index = 0; index < buffs_max; ++index) {
-				if (IsEffectInSpell(my_buffs[index].spellid, SE_Familiar)) {
+				if (IsEffectInSpell(my_buffs[index].spellid, SpellEffect::Familiar)) {
 					MakePet(my_buffs[index].spellid, spells[my_buffs[index].spellid].teleport_zone);
 					familiar_buff_slot = index;
 					break;
@@ -445,11 +445,11 @@ bool Bot::BotCastNuke(Mob* tar, uint8 bot_class, BotSpell& bot_spell, uint16 spe
 		}
 
 		if (
-			!tar->GetSpecialAbility(SpecialAbility::StunImmunity) && 
+			!tar->GetSpecialAbility(SpecialAbility::StunImmunity) &&
 			(
-				IsCommandedSpell() || 
+				IsCommandedSpell() ||
 				(!tar->IsStunned() && (zone->random.Int(1, 100) <= stun_chance))
-			) 
+			)
 		) {
 			bot_spell = GetBestBotSpellForStunByTargetType(this, ST_TargetOptional, spell_type, IsAEBotSpellType(spell_type), tar);
 		}
@@ -1173,7 +1173,7 @@ BotSpell Bot::GetBestBotSpellForVeryFastHeal(Bot* caster, Mob* tar, uint16 spell
 	result.ManaCost = 0;
 
 	if (caster) {
-		std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffect(caster, spell_type, SE_CurrentHP);
+		std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffect(caster, spell_type, SpellEffect::CurrentHP);
 
 		for (auto bot_spell_list_itr : bot_spell_list) {
 			if (
@@ -1198,7 +1198,7 @@ BotSpell Bot::GetBestBotSpellForFastHeal(Bot* caster, Mob* tar, uint16 spell_typ
 	result.ManaCost = 0;
 
 	if (caster) {
-		std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffect(caster, spell_type, SE_CurrentHP);
+		std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffect(caster, spell_type, SpellEffect::CurrentHP);
 
 		for (auto bot_spell_list_itr : bot_spell_list) {
 			if (IsFastHealSpell(bot_spell_list_itr.SpellId) && caster->CastChecks(bot_spell_list_itr.SpellId, tar, spell_type)) {
@@ -1222,7 +1222,7 @@ BotSpell Bot::GetBestBotSpellForHealOverTime(Bot* caster, Mob* tar, uint16 spell
 	result.ManaCost = 0;
 
 	if (caster) {
-		std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffect(caster, spell_type, SE_HealOverTime);
+		std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffect(caster, spell_type, SpellEffect::HealOverTime);
 
 		for (auto bot_spell_list_itr : bot_spell_list) {
 			if (IsHealOverTimeSpell(bot_spell_list_itr.SpellId) && caster->CastChecks(bot_spell_list_itr.SpellId, tar, spell_type)) {
@@ -1278,7 +1278,7 @@ BotSpell Bot::GetBestBotSpellForRegularSingleTargetHeal(Bot* caster, Mob* tar, u
 	result.ManaCost = 0;
 
 	if (caster) {
-		std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffect(caster, spell_type, SE_CurrentHP);
+		std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffect(caster, spell_type, SpellEffect::CurrentHP);
 
 		for (std::list<BotSpell>::iterator bot_spell_list_itr = bot_spell_list.begin(); bot_spell_list_itr != bot_spell_list.end(); ++bot_spell_list_itr) {
 			if (IsRegularSingleTargetHealSpell(bot_spell_list_itr->SpellId) && caster->CastChecks(bot_spell_list_itr->SpellId, tar, spell_type)) {
@@ -1302,7 +1302,7 @@ BotSpell Bot::GetFirstBotSpellForSingleTargetHeal(Bot* caster, Mob* tar, uint16 
 	result.ManaCost = 0;
 
 	if (caster) {
-		std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffect(caster, spell_type, SE_CurrentHP);
+		std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffect(caster, spell_type, SpellEffect::CurrentHP);
 
 		for (std::list<BotSpell>::iterator bot_spell_list_itr = bot_spell_list.begin(); bot_spell_list_itr != bot_spell_list.end(); ++bot_spell_list_itr) {
 			if (IsRegularSingleTargetHealSpell(bot_spell_list_itr->SpellId) && caster->CastChecks(bot_spell_list_itr->SpellId, tar, spell_type)) {
@@ -1329,7 +1329,7 @@ BotSpell Bot::GetBestBotSpellForGroupHeal(Bot* caster, Mob* tar, uint16 spell_ty
 		return result;
 	}
 
-	std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffect(caster, spell_type, SE_CurrentHP);
+	std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffect(caster, spell_type, SpellEffect::CurrentHP);
 	int target_count = 0;
 	int required_count = caster->GetSpellTypeAEOrGroupTargetCount(spell_type);
 
@@ -1367,7 +1367,7 @@ BotSpell Bot::GetBestBotSpellForGroupHealOverTime(Bot* caster, Mob* tar, uint16 
 		return result;
 	}
 
-	std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffect(caster, spell_type, SE_HealOverTime);
+	std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffect(caster, spell_type, SpellEffect::HealOverTime);
 	int target_count = 0;
 	int required_count = caster->GetSpellTypeAEOrGroupTargetCount(spell_type);
 
@@ -1405,7 +1405,7 @@ BotSpell Bot::GetBestBotSpellForGroupCompleteHeal(Bot* caster, Mob* tar, uint16 
 		return result;
 	}
 
-	std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffect(caster, spell_type, SE_CompleteHeal);
+	std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffect(caster, spell_type, SpellEffect::CompleteHeal);
 	int target_count = 0;
 	int required_count = caster->GetSpellTypeAEOrGroupTargetCount(spell_type);
 
@@ -1440,7 +1440,7 @@ BotSpell Bot::GetBestBotSpellForMez(Bot* caster, uint16 spell_type) {
 	result.ManaCost = 0;
 
 	if (caster) {
-		std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffect(caster, spell_type, SE_Mez);
+		std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffect(caster, spell_type, SpellEffect::Mez);
 
 		for (std::list<BotSpell>::iterator bot_spell_list_itr = bot_spell_list.begin(); bot_spell_list_itr != bot_spell_list.end(); ++bot_spell_list_itr) {
 			if (
@@ -1548,7 +1548,7 @@ BotSpell Bot::GetBestBotMagicianPetSpell(Bot* caster, uint16 spell_type) {
 	result.ManaCost = 0;
 
 	if (caster) {
-		std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffect(caster, spell_type, SE_SummonPet);
+		std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffect(caster, spell_type, SpellEffect::SummonPet);
 		std::string pet_type = GetBotMagicianPetType(caster);
 
 		for(std::list<BotSpell>::iterator bot_spell_list_itr = bot_spell_list.begin(); bot_spell_list_itr != bot_spell_list.end(); ++bot_spell_list_itr) {
@@ -1638,7 +1638,7 @@ std::string Bot::GetBotMagicianPetType(Bot* caster) {
 					continue;
 				}
 
-				if (!IsEffectInSpell(s.SpellId, SE_SummonPet)) {
+				if (!IsEffectInSpell(s.SpellId, SpellEffect::SummonPet)) {
 					continue;
 				}
 
@@ -1683,7 +1683,7 @@ std::string Bot::GetBotMagicianPetType(Bot* caster) {
 							if (bot_level >= water_min_level) {
 								result = std::string("SumWater");
 							}
-							
+
 							found = true;
 							break;
 						case SumFire:
@@ -1730,7 +1730,7 @@ BotSpell Bot::GetBestBotSpellForNukeByTargetType(Bot* caster, SpellTargetType ta
 	}
 
 	if (caster) {
-		std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffectAndTargetType(caster, spell_type, SE_CurrentHP, target_type);
+		std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffectAndTargetType(caster, spell_type, SpellEffect::CurrentHP, target_type);
 
 		for(std::list<BotSpell>::iterator bot_spell_list_itr = bot_spell_list.begin(); bot_spell_list_itr != bot_spell_list.end(); ++bot_spell_list_itr) {
 			if (IsPureNukeSpell(bot_spell_list_itr->SpellId) || IsDamageSpell(bot_spell_list_itr->SpellId)) {
@@ -1777,7 +1777,7 @@ BotSpell Bot::GetBestBotSpellForStunByTargetType(Bot* caster, SpellTargetType ta
 
 	if (caster)
 	{
-		std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffectAndTargetType(caster, spell_type, SE_Stun, target_type);
+		std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffectAndTargetType(caster, spell_type, SpellEffect::Stun, target_type);
 
 		for(std::list<BotSpell>::iterator bot_spell_list_itr = bot_spell_list.begin(); bot_spell_list_itr != bot_spell_list.end(); ++bot_spell_list_itr)
 		{
@@ -1835,7 +1835,7 @@ BotSpell Bot::GetBestBotWizardNukeSpellByTargetResists(Bot* caster, Mob* target,
 		}
 
 
-		std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffectAndTargetType(caster, spell_type, SE_CurrentHP, ST_Target);
+		std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffectAndTargetType(caster, spell_type, SpellEffect::CurrentHP, ST_Target);
 
 		BotSpell first_wizard_magic_nuke_spell_found;
 		first_wizard_magic_nuke_spell_found.SpellId = 0;
@@ -1855,32 +1855,32 @@ BotSpell Bot::GetBestBotWizardNukeSpellByTargetResists(Bot* caster, Mob* target,
 			}
 			else if (!select_lure_nuke && IsPureNukeSpell(bot_spell_list_itr->SpellId)) {
 				if (
-					((target->GetMR() < target->GetCR()) || (target->GetMR() < target->GetFR())) && 
-					(GetSpellResistType(bot_spell_list_itr->SpellId) == RESIST_MAGIC) && 
+					((target->GetMR() < target->GetCR()) || (target->GetMR() < target->GetFR())) &&
+					(GetSpellResistType(bot_spell_list_itr->SpellId) == RESIST_MAGIC) &&
 					(spells[bot_spell_list_itr->SpellId].resist_difficulty > lure_resis_value) &&
 					caster->CastChecks(bot_spell_list_itr->SpellId, target, spell_type)
 				) {
 					spell_selected = true;
 				}
 				else if (
-					((target->GetCR() < target->GetMR()) || (target->GetCR() < target->GetFR())) && 
-					(GetSpellResistType(bot_spell_list_itr->SpellId) == RESIST_COLD) && 
-					(spells[bot_spell_list_itr->SpellId].resist_difficulty > lure_resis_value) && 
+					((target->GetCR() < target->GetMR()) || (target->GetCR() < target->GetFR())) &&
+					(GetSpellResistType(bot_spell_list_itr->SpellId) == RESIST_COLD) &&
+					(spells[bot_spell_list_itr->SpellId].resist_difficulty > lure_resis_value) &&
 					caster->CastChecks(bot_spell_list_itr->SpellId, target, spell_type)
 				) {
 					spell_selected = true;
 				}
 				else if (
-					((target->GetFR() < target->GetCR()) || (target->GetFR() < target->GetMR())) && 
-					(GetSpellResistType(bot_spell_list_itr->SpellId) == RESIST_FIRE) && 
-					(spells[bot_spell_list_itr->SpellId].resist_difficulty > lure_resis_value) && 
+					((target->GetFR() < target->GetCR()) || (target->GetFR() < target->GetMR())) &&
+					(GetSpellResistType(bot_spell_list_itr->SpellId) == RESIST_FIRE) &&
+					(spells[bot_spell_list_itr->SpellId].resist_difficulty > lure_resis_value) &&
 					caster->CastChecks(bot_spell_list_itr->SpellId, target, spell_type)
 				) {
 					spell_selected = true;
 				}
 				else if (
-					(GetSpellResistType(bot_spell_list_itr->SpellId) == RESIST_MAGIC) && 
-					(spells[bot_spell_list_itr->SpellId].resist_difficulty > lure_resis_value) && 
+					(GetSpellResistType(bot_spell_list_itr->SpellId) == RESIST_MAGIC) &&
+					(spells[bot_spell_list_itr->SpellId].resist_difficulty > lure_resis_value) &&
 					caster->CastChecks(bot_spell_list_itr->SpellId, target, spell_type)
 				) {
 					first_wizard_magic_nuke_spell_found.SpellId = bot_spell_list_itr->SpellId;
@@ -1998,11 +1998,11 @@ BotSpell Bot::GetBestBotSpellForResistDebuff(Bot* caster, Mob *tar, uint16 spell
 			if (
 				(bot_spell_list[i].type == BotSpellTypes::Debuff || IsResistDebuffSpell(bot_spell_list[i].spellid)) &&
 				(
-					(needs_magic_resist_debuff && (IsEffectInSpell(bot_spell_list[i].spellid, SE_ResistMagic) || IsEffectInSpell(bot_spell_list[i].spellid, SE_ResistAll))) ||
-					(needs_cold_resist_debuff && (IsEffectInSpell(bot_spell_list[i].spellid, SE_ResistCold) || IsEffectInSpell(bot_spell_list[i].spellid, SE_ResistAll))) ||
-					(needs_fire_resist_debuff && (IsEffectInSpell(bot_spell_list[i].spellid, SE_ResistFire) || IsEffectInSpell(bot_spell_list[i].spellid, SE_ResistAll))) ||
-					(needs_poison_resist_debuff && (IsEffectInSpell(bot_spell_list[i].spellid, SE_ResistPoison) || IsEffectInSpell(bot_spell_list[i].spellid, SE_ResistAll))) ||
-					(needs_disease_resist_debuff && (IsEffectInSpell(bot_spell_list[i].spellid, SE_ResistDisease) || IsEffectInSpell(bot_spell_list[i].spellid, SE_ResistAll)))
+					(needs_magic_resist_debuff && (IsEffectInSpell(bot_spell_list[i].spellid, SpellEffect::ResistMagic) || IsEffectInSpell(bot_spell_list[i].spellid, SpellEffect::ResistAll))) ||
+					(needs_cold_resist_debuff && (IsEffectInSpell(bot_spell_list[i].spellid, SpellEffect::ResistCold) || IsEffectInSpell(bot_spell_list[i].spellid, SpellEffect::ResistAll))) ||
+					(needs_fire_resist_debuff && (IsEffectInSpell(bot_spell_list[i].spellid, SpellEffect::ResistFire) || IsEffectInSpell(bot_spell_list[i].spellid, SpellEffect::ResistAll))) ||
+					(needs_poison_resist_debuff && (IsEffectInSpell(bot_spell_list[i].spellid, SpellEffect::ResistPoison) || IsEffectInSpell(bot_spell_list[i].spellid, SpellEffect::ResistAll))) ||
+					(needs_disease_resist_debuff && (IsEffectInSpell(bot_spell_list[i].spellid, SpellEffect::ResistDisease) || IsEffectInSpell(bot_spell_list[i].spellid, SpellEffect::ResistAll)))
 				) &&
 				!tar->IsImmuneToSpell(bot_spell_list[i].spellid, caster) &&
 				tar->CanBuffStack(bot_spell_list[i].spellid, caster->GetLevel(), true) >= 0 &&
@@ -2033,7 +2033,7 @@ BotSpell Bot::GetBestBotSpellForCure(Bot* caster, Mob* tar, uint16 spell_type) {
 
 	if (caster) {
 		std::vector<BotSpell_wPriority> bot_spell_list_itr = GetPrioritizedBotSpellsBySpellType(caster, spell_type, tar);
-		
+
 		if (IsGroupBotSpellType(spell_type)) {
 			int count_needs_cured = 0;
 			uint16 count_poisoned = 0;
@@ -2049,16 +2049,16 @@ BotSpell Bot::GetBestBotSpellForCure(Bot* caster, Mob* tar, uint16 spell_type) {
 				for (Mob* m : (IsGroupBotSpellType(spell_type) ? caster->GetSpellTargetList() : caster->GetSpellTargetList(true))) {
 					if (caster->GetNeedsCured(m)) {
 						if (caster->CastChecks(itr->SpellId, m, spell_type, true, IsGroupBotSpellType(spell_type))) {
-							if (m->FindType(SE_PoisonCounter)) {
+							if (m->FindType(SpellEffect::PoisonCounter)) {
 								++count_poisoned;
 							}
-							if (m->FindType(SE_DiseaseCounter)) {
+							if (m->FindType(SpellEffect::DiseaseCounter)) {
 								++count_diseased;
 							}
-							if (m->FindType(SE_CurseCounter)) {
+							if (m->FindType(SpellEffect::CurseCounter)) {
 								++count_cursed;
 							}
-							if (m->FindType(SE_CorruptionCounter)) {
+							if (m->FindType(SpellEffect::CorruptionCounter)) {
 								++count_corrupted;
 							}
 						}
@@ -2066,10 +2066,10 @@ BotSpell Bot::GetBestBotSpellForCure(Bot* caster, Mob* tar, uint16 spell_type) {
 				}
 
 				if (
-					(count_poisoned >= caster->GetSpellTypeAEOrGroupTargetCount(spell_type) && IsEffectInSpell(itr->SpellId, SE_PoisonCounter)) ||
-					(count_diseased >= caster->GetSpellTypeAEOrGroupTargetCount(spell_type) && IsEffectInSpell(itr->SpellId, SE_DiseaseCounter)) ||
-					(count_cursed >= caster->GetSpellTypeAEOrGroupTargetCount(spell_type) && IsEffectInSpell(itr->SpellId, SE_CurseCounter)) ||
-					(count_corrupted >= caster->GetSpellTypeAEOrGroupTargetCount(spell_type) && IsEffectInSpell(itr->SpellId, SE_CorruptionCounter))
+					(count_poisoned >= caster->GetSpellTypeAEOrGroupTargetCount(spell_type) && IsEffectInSpell(itr->SpellId, SpellEffect::PoisonCounter)) ||
+					(count_diseased >= caster->GetSpellTypeAEOrGroupTargetCount(spell_type) && IsEffectInSpell(itr->SpellId, SpellEffect::DiseaseCounter)) ||
+					(count_cursed >= caster->GetSpellTypeAEOrGroupTargetCount(spell_type) && IsEffectInSpell(itr->SpellId, SpellEffect::CurseCounter)) ||
+					(count_corrupted >= caster->GetSpellTypeAEOrGroupTargetCount(spell_type) && IsEffectInSpell(itr->SpellId, SpellEffect::CorruptionCounter))
 				) {
 					result.SpellId = itr->SpellId;
 					result.SpellIndex = itr->SpellIndex;
@@ -2086,10 +2086,10 @@ BotSpell Bot::GetBestBotSpellForCure(Bot* caster, Mob* tar, uint16 spell_type) {
 				}
 
 				if (
-					tar->FindType(SE_PoisonCounter) && IsEffectInSpell(itr->SpellId, SE_PoisonCounter) ||
-					tar->FindType(SE_DiseaseCounter) && IsEffectInSpell(itr->SpellId, SE_DiseaseCounter) ||
-					tar->FindType(SE_CurseCounter) && IsEffectInSpell(itr->SpellId, SE_CurseCounter) ||
-					tar->FindType(SE_CorruptionCounter) && IsEffectInSpell(itr->SpellId, SE_CorruptionCounter)
+					tar->FindType(SpellEffect::PoisonCounter) && IsEffectInSpell(itr->SpellId, SpellEffect::PoisonCounter) ||
+					tar->FindType(SpellEffect::DiseaseCounter) && IsEffectInSpell(itr->SpellId, SpellEffect::DiseaseCounter) ||
+					tar->FindType(SpellEffect::CurseCounter) && IsEffectInSpell(itr->SpellId, SpellEffect::CurseCounter) ||
+					tar->FindType(SpellEffect::CorruptionCounter) && IsEffectInSpell(itr->SpellId, SpellEffect::CorruptionCounter)
 				) {
 					result.SpellId = itr->SpellId;
 					result.SpellIndex = itr->SpellIndex;
@@ -2146,13 +2146,13 @@ uint8 Bot::GetChanceToCastBySpellType(uint16 spell_type)
 		case BotSpellTypes::Dispel:
 			return RuleI(Bots, PercentChanceToCastDispel);
 		case BotSpellTypes::InCombatBuff:
-			return RuleI(Bots, PercentChanceToCastInCombatBuff);		
+			return RuleI(Bots, PercentChanceToCastInCombatBuff);
 		case BotSpellTypes::HateLine:
 			return RuleI(Bots, PercentChanceToCastHateLine);
 		case BotSpellTypes::Mez:
-			return RuleI(Bots, PercentChanceToCastMez);		
+			return RuleI(Bots, PercentChanceToCastMez);
 		case BotSpellTypes::Slow:
-			return RuleI(Bots, PercentChanceToCastSlow);		
+			return RuleI(Bots, PercentChanceToCastSlow);
 		case BotSpellTypes::Debuff:
 			return RuleI(Bots, PercentChanceToCastDebuff);
 		case BotSpellTypes::Cure:
@@ -2161,7 +2161,7 @@ uint8 Bot::GetChanceToCastBySpellType(uint16 spell_type)
 		case BotSpellTypes::GroupCures:
 			return RuleI(Bots, PercentChanceToCastGroupCure);
 		case BotSpellTypes::HateRedux:
-			return RuleI(Bots, PercentChanceToCastHateRedux);		
+			return RuleI(Bots, PercentChanceToCastHateRedux);
 		case BotSpellTypes::Fear:
 			return RuleI(Bots, PercentChanceToCastFear);
 		case BotSpellTypes::RegularHeal:
@@ -2758,8 +2758,8 @@ bool Bot::IsValidSpellRange(uint16 spell_id, Mob* tar) {
 	) {
 		range = GetAOERange(spell_id);
 	}
-	
-	if (RuleB(Bots, EnableBotTGB) && IsTGBCompatibleSpell(spell_id) && IsGroupSpell(spell_id)) {			
+
+	if (RuleB(Bots, EnableBotTGB) && IsTGBCompatibleSpell(spell_id) && IsGroupSpell(spell_id)) {
 		range = spells[spell_id].aoe_range;
 	}
 
@@ -2838,7 +2838,7 @@ BotSpell Bot::GetBestBotSpellForRez(Bot* caster, Mob* target, uint16 spell_type)
 	result.ManaCost = 0;
 
 	if (caster) {
-		std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffect(caster, spell_type, SE_Revive);
+		std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffect(caster, spell_type, SpellEffect::Revive);
 
 		for (std::list<BotSpell>::iterator bot_spell_list_itr = bot_spell_list.begin(); bot_spell_list_itr != bot_spell_list.end(); ++bot_spell_list_itr) {
 			if (
@@ -2865,7 +2865,7 @@ BotSpell Bot::GetBestBotSpellForCharm(Bot* caster, Mob* target, uint16 spell_typ
 	result.ManaCost = 0;
 
 	if (caster) {
-		std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffect(caster, spell_type, SE_Charm);
+		std::list<BotSpell> bot_spell_list = GetBotSpellsForSpellEffect(caster, spell_type, SpellEffect::Charm);
 
 		for (std::list<BotSpell>::iterator bot_spell_list_itr = bot_spell_list.begin(); bot_spell_list_itr != bot_spell_list.end(); ++bot_spell_list_itr) {
 			if (

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -1391,7 +1391,7 @@ void Client::ChannelMessageReceived(uint8 chan_num, uint8 language, uint8 lang_s
 	}
 	case ChatChannel_Shout: { /* Shout */
 		Mob *sender = this;
-		if (GetPet() && GetTarget() == GetPet() && GetPet()->FindType(SE_VoiceGraft))
+		if (GetPet() && GetTarget() == GetPet() && GetPet()->FindType(SpellEffect::VoiceGraft))
 			sender = GetPet();
 
 		entity_list.ChannelMessage(sender, chan_num, language, lang_skill, message);
@@ -1429,7 +1429,7 @@ void Client::ChannelMessageReceived(uint8 chan_num, uint8 language, uint8 lang_s
 		else if(!RuleB(Chat, ServerWideAuction)) {
 			Mob *sender = this;
 
-			if (GetPet() && GetTarget() == GetPet() && GetPet()->FindType(SE_VoiceGraft))
+			if (GetPet() && GetTarget() == GetPet() && GetPet()->FindType(SpellEffect::VoiceGraft))
 			sender = GetPet();
 
 			entity_list.ChannelMessage(sender, chan_num, language, lang_skill, message);
@@ -1476,7 +1476,7 @@ void Client::ChannelMessageReceived(uint8 chan_num, uint8 language, uint8 lang_s
 		{
 			Mob *sender = this;
 
-			if (GetPet() && GetTarget() == GetPet() && GetPet()->FindType(SE_VoiceGraft))
+			if (GetPet() && GetTarget() == GetPet() && GetPet()->FindType(SpellEffect::VoiceGraft))
 				sender = GetPet();
 
 			entity_list.ChannelMessage(sender, chan_num, language, lang_skill, message);
@@ -1606,7 +1606,7 @@ void Client::ChannelMessageReceived(uint8 chan_num, uint8 language, uint8 lang_s
 		}
 
 		Mob* sender = this;
-		if (GetPet() && GetTarget() == GetPet() && GetPet()->FindType(SE_VoiceGraft)) {
+		if (GetPet() && GetTarget() == GetPet() && GetPet()->FindType(SpellEffect::VoiceGraft)) {
 			sender = GetPet();
 		}
 
@@ -6907,7 +6907,7 @@ void Client::CheckLDoNHail(NPC* n)
 	auto pet = GetPet();
 	if (pet) {
 		if (pet->GetPetType() == PetType::Charmed) {
-			pet->BuffFadeByEffect(SE_Charm);
+			pet->BuffFadeByEffect(SpellEffect::Charm);
 		} else if (pet->GetPetType() == PetType::Follow) {
 			pet->SetOwnerID(0);
 		} else {
@@ -10658,7 +10658,7 @@ void Client::MovePCDynamicZone(const std::string& zone_name, int zone_version, b
 }
 
 void Client::Fling(float value, float target_x, float target_y, float target_z, bool ignore_los, bool clip_through_walls, bool calculate_speed) {
-	BuffFadeByEffect(SE_Levitate);
+	BuffFadeByEffect(SpellEffect::Levitate);
 	if (CheckLosFN(target_x, target_y, target_z, 6.0f) || ignore_los) {
 		auto p = new EQApplicationPacket(OP_Fling, sizeof(fling_struct));
 		auto* f = (fling_struct*) p->pBuffer;
@@ -10723,7 +10723,7 @@ std::vector<int> Client::GetLearnableDisciplines(uint8 min_level, uint8 max_leve
 			continue;
 		}
 
-		if (RuleB(Spells, UseCHAScribeHack) && spells[spell_id].effect_id[EFFECT_COUNT - 1] == SE_CHA) {
+		if (RuleB(Spells, UseCHAScribeHack) && spells[spell_id].effect_id[EFFECT_COUNT - 1] == SpellEffect::CHA) {
 			continue;
 		}
 
@@ -10794,7 +10794,7 @@ std::vector<int> Client::GetScribeableSpells(uint8 min_level, uint8 max_level) {
 			continue;
 		}
 
-		if (RuleB(Spells, UseCHAScribeHack) && spells[spell_id].effect_id[EFFECT_COUNT - 1] == SE_CHA) {
+		if (RuleB(Spells, UseCHAScribeHack) && spells[spell_id].effect_id[EFFECT_COUNT - 1] == SpellEffect::CHA) {
 			continue;
 		}
 
@@ -11436,7 +11436,7 @@ void Client::SummonBaggedItems(uint32 bag_item_id, const std::vector<LootItem>& 
 		return;
 	}
 
-	// todo: maybe some common functions for SE_SummonItem and SE_SummonItemIntoBag
+	// todo: maybe some common functions for SpellEffect::SummonItem and SpellEffect::SummonItemIntoBag
 
 	const EQ::ItemData* bag_item = database.GetItem(bag_item_id);
 	if (!bag_item)

--- a/zone/client_mods.cpp
+++ b/zone/client_mods.cpp
@@ -693,7 +693,7 @@ int64 Client::CalcManaRegen(bool bCombat)
 	}
 
 	regen += aabonuses.ManaRegen;
-	// add in + 1 bonus for SE_CompleteHeal, but we don't do anything for it yet?
+	// add in + 1 bonus for SpellEffect::CompleteHeal, but we don't do anything for it yet?
 
 	int item_bonus = itembonuses.ManaRegen; // this is capped already
 	item_bonus += itembonuses.heroic_mana_regen;
@@ -1482,24 +1482,24 @@ uint32 Mob::GetInstrumentMod(uint16 spell_id)
 		Bard Spell Effects
 
 		Mod uses the highest bonus from either of these for each instrument
-		SPA 179 SE_AllInstrumentMod is used for instrument spellbonus.______Mod. This applies to ALL instrument mods (Puretones Discipline)
-		SPA 260 SE_AddSingingMod is used for instrument spellbonus.______Mod. This applies to indiviual instrument mods. (Instrument mastery AA)
+		SPA 179 SpellEffect::AllInstrumentMod is used for instrument spellbonus.______Mod. This applies to ALL instrument mods (Puretones Discipline)
+		SPA 260 SpellEffect::AddSingingMod is used for instrument spellbonus.______Mod. This applies to indiviual instrument mods. (Instrument mastery AA)
 			-Example usage: From AA a value of 4 = 40%
 
-		SPA 118 SE_Amplification is a stackable singing mod, on live it exists as both spell and AA bonus (stackable)
+		SPA 118 SpellEffect::Amplification is a stackable singing mod, on live it exists as both spell and AA bonus (stackable)
 			- Live Behavior: Amplifcation can be modified by singing mods and amplification itself, thus on the second cast of Amplification you will recieve
 			  the mod from the first cast, this continues until you reach the song mod cap.
 
-		SPA 261 SE_SongModCap raises song focus cap (No longer used on live)
-		SPA 270 SE_BardSongRange increase range of beneficial bard songs (Sionachie's Crescendo)
+		SPA 261 SpellEffect::SongModCap raises song focus cap (No longer used on live)
+		SPA 270 SpellEffect::BardSongRange increase range of beneficial bard songs (Sionachie's Crescendo)
 
-		SPA 413 SE_FcBaseEffects focus effect that replaced item instrument mods
+		SPA 413 SpellEffect::FcBaseEffects focus effect that replaced item instrument mods
 
 		Issues 10-15-21:
 		Bonuses are not applied, unless song is stopped and restarted due to pulse keeping it continues. -> Need to recode songs to recast when duration ends.
 
 		Formula Live Bards:
-		mod = (10 + (aabonus.____Mod [SPA 260 AA Instrument Mastery]) + (SE_FcBaseEffect[SPA 413])/10 + (spellbonus.______Mod [SPA 179 Puretone Disc]) + (Amplication [SPA 118])/10
+		mod = (10 + (aabonus.____Mod [SPA 260 AA Instrument Mastery]) + (SpellEffect::FcBaseEffect[SPA 413])/10 + (spellbonus.______Mod [SPA 179 Puretone Disc]) + (Amplication [SPA 118])/10
 
 		TODO: Spell Table Fields that need to be implemented
 		Field 225	//float base_effects_focus_slope;  // -- BASE_EFFECTS_FOCUS_SLOPE
@@ -1567,7 +1567,7 @@ uint32 Mob::GetInstrumentMod(uint16 spell_id)
 		else
 			effectmod = spellbonuses.singingMod;
 		if (IsBardSong(spell_id))
-			effectmod += aabonuses.singingMod + (spellbonuses.Amplification + itembonuses.Amplification + aabonuses.Amplification); //SPA 118 SE_Amplification
+			effectmod += aabonuses.singingMod + (spellbonuses.Amplification + itembonuses.Amplification + aabonuses.Amplification); //SPA 118 SpellEffect::Amplification
 		break;
 	default:
 		effectmod = 10;
@@ -1584,7 +1584,7 @@ uint32 Mob::GetInstrumentMod(uint16 spell_id)
 
 	if (effectmodcap) {
 
-		effectmodcap += aabonuses.songModCap + spellbonuses.songModCap + itembonuses.songModCap; //SPA 261 SE_SongModCap (not used on live)
+		effectmodcap += aabonuses.songModCap + spellbonuses.songModCap + itembonuses.songModCap; //SPA 261 SpellEffect::SongModCap (not used on live)
 
 		//Incase a negative modifier is used.
 		if (effectmodcap <= 0) {

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -671,7 +671,7 @@ void Client::CompleteConnect()
 
 		for (int x1 = 0; x1 < EFFECT_COUNT; x1++) {
 			switch (spell.effect_id[x1]) {
-			case SE_Illusion: {
+			case SpellEffect::Illusion: {
 				if (GetIllusionBlock()) {
 					break;
 				}
@@ -682,41 +682,41 @@ void Client::CompleteConnect()
 				}
 				break;
 			}
-			case SE_SummonHorse: {
+			case SpellEffect::SummonHorse: {
 				if (RuleB(Character, PreventMountsFromZoning) || !zone->CanCastOutdoor()) {
-					BuffFadeByEffect(SE_SummonHorse);
+					BuffFadeByEffect(SpellEffect::SummonHorse);
 				} else {
 					SummonHorse(buffs[j1].spellid);
 				}
 				break;
 			}
-			case SE_Silence:
+			case SpellEffect::Silence:
 			{
 				Silence(true);
 				break;
 			}
-			case SE_Amnesia:
+			case SpellEffect::Amnesia:
 			{
 				Amnesia(true);
 				break;
 			}
-			case SE_DivineAura:
+			case SpellEffect::DivineAura:
 			{
 				invulnerable = true;
 				break;
 			}
-			case SE_Invisibility2:
-			case SE_Invisibility:
+			case SpellEffect::Invisibility2:
+			case SpellEffect::Invisibility:
 			{
 				SendAppearancePacket(AppearanceType::Invisibility, Invisibility::Invisible);
 				break;
 			}
-			case SE_Levitate:
+			case SpellEffect::Levitate:
 			{
 				if (!zone->CanLevitate()) {
 					if (!GetGM()) {
 						SendAppearancePacket(AppearanceType::FlyMode, 0);
-						BuffFadeByEffect(SE_Levitate);
+						BuffFadeByEffect(SpellEffect::Levitate);
 						Message(Chat::Red, "You can't levitate in this zone.");
 						break;
 					}
@@ -737,18 +737,18 @@ void Client::CompleteConnect()
 
 				break;
 			}
-			case SE_AddMeleeProc:
-			case SE_WeaponProc:
+			case SpellEffect::AddMeleeProc:
+			case SpellEffect::WeaponProc:
 			{
 				AddProcToWeapon(GetProcID(buffs[j1].spellid, x1), false, 100 + spells[buffs[j1].spellid].limit_value[x1], buffs[j1].spellid, buffs[j1].casterlevel, GetSpellProcLimitTimer(buffs[j1].spellid, ProcType::MELEE_PROC));
 				break;
 			}
-			case SE_DefensiveProc:
+			case SpellEffect::DefensiveProc:
 			{
 				AddDefensiveProc(GetProcID(buffs[j1].spellid, x1), 100 + spells[buffs[j1].spellid].limit_value[x1], buffs[j1].spellid, GetSpellProcLimitTimer(buffs[j1].spellid, ProcType::DEFENSIVE_PROC));
 				break;
 			}
-			case SE_RangedProc:
+			case SpellEffect::RangedProc:
 			{
 				AddRangedProc(GetProcID(buffs[j1].spellid, x1), 100 + spells[buffs[j1].spellid].limit_value[x1], buffs[j1].spellid, GetSpellProcLimitTimer(buffs[j1].spellid, ProcType::RANGED_PROC));
 				break;
@@ -4259,7 +4259,7 @@ void Client::Handle_OP_BuffRemoveRequest(const EQApplicationPacket *app)
 
 	uint16 SpellID = m->GetSpellIDFromSlot(brrs->SlotID);
 
-	if (SpellID && (GetGM() || ((IsBeneficialSpell(SpellID) || IsEffectInSpell(SpellID, SE_BindSight)) && !spells[SpellID].no_remove))) {
+	if (SpellID && (GetGM() || ((IsBeneficialSpell(SpellID) || IsEffectInSpell(SpellID, SpellEffect::BindSight)) && !spells[SpellID].no_remove))) {
 		m->BuffFadeBySlot(brrs->SlotID, true);
 	}
 }
@@ -5078,7 +5078,7 @@ void Client::Handle_OP_ClientUpdate(const EQApplicationPacket *app) {
 			// Dismount horses when entering water
 			if (GetHorseId() && RuleB(Character, DismountWater)) {
 				SetHorseId(0);
-				BuffFadeByEffect(SE_SummonHorse);
+				BuffFadeByEffect(SpellEffect::SummonHorse);
 			}
 		}
 		CheckRegionTypeChanges();
@@ -11312,7 +11312,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			parse->EventMob(EVENT_PET_COMMAND, CastToMob(), pet, f, s->command);
 
 			if (pet->GetPetType() == PetType::Charmed) {
-				pet->BuffFadeByEffect(SE_Charm);
+				pet->BuffFadeByEffect(SpellEffect::Charm);
 				break;
 			} else {
 				SetPet(nullptr);
@@ -14239,7 +14239,7 @@ void Client::Handle_OP_Shielding(const EQApplicationPacket *app)
 		Recast is 3 minutes.
 
 		For custom use cases, Mob::ShieldAbility can be used in quests with all parameters being altered. This functional
-		is also used for SPA 201 SE_PetShield, which functions in a simalar manner with pet shielding owner.
+		is also used for SPA 201 SpellEffect::PetShield, which functions in a simalar manner with pet shielding owner.
 
 		Note: If either the shielder or the shield target die all variables are reset on both.
 

--- a/zone/common.h
+++ b/zone/common.h
@@ -53,50 +53,50 @@ namespace Archetype {
 #define SHIELD_ABILITY_RECAST_TIME 180
 
 typedef enum {	//focus types
-	focusSpellHaste = 1,				//@Fc, SPA: 127, SE_IncreaseSpellHaste,				On Caster, cast time mod pct, base: pct
-	focusSpellDuration,					//@Fc, SPA: 128, SE_IncreaseSpellDuration,			On Caster, spell duration mod pct, base: pct
-	focusRange,							//@Fc, SPA: 129, SE_IncreaseRange,					On Caster, spell range mod pct, base: pct
-	focusReagentCost,					//@Fc, SPA: 131, SE_ReduceReagentCost,				On Caster, do not consume reagent pct chance, base: min pct, limit: max pct
-	focusManaCost,						//@Fc, SPA: 132, SE_ReduceManaCost,					On Caster, reduce mana cost by pct, base: min pct, limt: max pct
-	focusImprovedHeal,					//@Fc, SPA: 125, SE_ImprovedHeal,					On Caster, spell healing mod pct, base: min pct, limit: max pct
-	focusImprovedDamage,				//@Fc, SPA: 124, SE_ImprovedDamage,					On Caster, spell damage mod pct, base: min pct, limit: max pct
-	focusImprovedDamage2,				//@Fc, SPA: 461, SE_ImprovedDamage2,				On Caster, spell damage mod pct, base: min pct, limit: max pct
-	focusFcDamagePctCrit,				//@Fc, SPA: 302, SE_FcDamagePctCrit,				On Caster, spell damage mod pct, base: min pct, limit: max pct
-	focusPetPower,						//@Fc, SPA: 167, SE_PetPowerIncrease,				On Caster, pet power mod, base: value
-	focusResistRate,					//@Fc, SPA: 126, SE_SpellResistReduction,			On Caster, casted spell resist mod pct, base: min pct, limit: max pct
-	focusSpellHateMod,					//@Fc, SPA: 130, SE_SpellHateMod,					On Caster, spell hate mod pct, base: min pct, limit: max pct
-	focusTriggerOnCast,					//@Fc, SPA: 339, SE_TriggerOnCast,					On Caster, cast on spell use, base: chance pct limit: spellid
-	focusSpellVulnerability,			//@Fc, SPA: 296, SE_FcSpellVulnerability,			On Target, spell damage taken mod pct, base: min pct, limit: max pct
-	focusFcSpellDamagePctIncomingPC,	//@Fc, SPA: 483, SE_Fc_Spell_Damage_Pct_IncomingPC, On Target, spell damage taken mod pct, base: min pct, limit: max pct
-	focusTwincast,						//@Fc, SPA: 399, SE_FcTwincast,						On Caster, chance cast spell twice, base: chance pct
-	focusSympatheticProc,				//@Fc, SPA: 383, SE_SympatheticProc,				On Caster, cast on spell use, base: variable proc chance on cast time, limit: spellid
-	focusFcDamageAmt,					//@Fc, SPA: 286, SE_FcDamageAmt,					On Caster, spell damage mod flat amt, base: amt
-	focusFcDamageAmt2,					//@Fc, SPA: 462, SE_FcDamageAmt2,					On Caster, spell damage mod flat amt, base: amt
-	focusFcDamageAmtCrit,				//@Fc, SPA: 303, SE_FFcDamageAmtCrit,				On Caster, spell damage mod flat amt, base: amt
-	focusSpellDurByTic,					//@Fc, SPA: 287, SE_SpellDurationIncByTic,			On Caster, spell buff duration mod, base: tics
-	focusSwarmPetDuration,				//@Fc, SPA: 398, SE_SwarmPetDuration,				On Caster, swarm pet duration mod, base: milliseconds
-	focusReduceRecastTime,				//@Fc, SPA: 310, SE_ReduceReuseTimer,				On Caster, disc reuse time mod, base: milliseconds
-	focusBlockNextSpell,				//@Fc, SPA: 335, SE_BlockNextSpellFocus,			On Caster, chance to block next spell, base: chance
-	focusFcHealPctIncoming,				//@Fc, SPA: 393, SE_FcHealPctIncoming,   			On Target, heal received mod pct, base: pct
-	focusFcDamageAmtIncoming,			//@Fc, SPA: 297, SE_FcDamageAmtIncoming,			On Target, damage taken flat amt, base: amt
-	focusFcSpellDamageAmtIncomingPC,	//@Fc, SPA: 484, SE_Fc_Spell_Damage_Amt_IncomingPC,	On Target, damage taken flat amt, base: amt
-	focusFcCastSpellOnLand,				//@Fc, SPA: 481, SE_Fc_Cast_Spell_On_Land,			On Target, cast spell if hit by spell, base: chance pct, limit: spellid
-	focusFcHealAmtIncoming,				//@Fc, SPA: 394, SE_FcHealAmtIncoming,				On Target, heal received mod flat amt, base: amt
-	focusFcBaseEffects,					//@Fc, SPA: 413, SE_FcBaseEffects,					On Caster, base spell effectiveness mod pct, base: pct
-	focusIncreaseNumHits,				//@Fc, SPA: 421, SE_FcIncreaseNumHits,				On Caster, numhits mod flat amt, base: amt
-	focusFcLimitUse,					//@Fc, SPA: 420, SE_FcLimitUse,						On Caster, numhits mod pct, base: pct
-	focusFcMute,						//@Fc, SPA: 357, SE_FcMute,							On Caster, prevents spell casting, base: chance pct
-	focusFcTimerRefresh,				//@Fc, SPA: 389, SE_FcTimerRefresh,					On Caster, reset spell recast timer, base: 1
-	focusFcTimerLockout,				//@Fc, SPA: 390, SE_FcTimerLockout,					On Caster, set a spell to be on recast timer, base: recast duration milliseconds
-	focusFcStunTimeMod,					//@Fc, SPA: 133, SE_FcStunTimeMod,					On Caster, stun time mod pct, base: chance pct
-	focusFcResistIncoming,				//@Fc, SPA: 510, SE_Fc_Resist_Incoming,				On Target, resist modifier, base: amt
-	focusFcAmplifyMod,					//@Fc, SPA: 507, SE_Fc_Amplify_Mod,					On Caster, damage-heal-dot mod pct, base: pct
-	focusFcAmplifyAmt,					//@Fc, SPA: 508, SE_Fc_Amplify_Amt,					On Caster, damage-heal-dot mod flat amt, base: amt
-	focusFcCastTimeMod2,				//@Fc, SPA: 500, SE_Fc_CastTimeMod2,				On Caster, cast time mod pct, base: pct
-	focusFcCastTimeAmt,					//@Fc, SPA: 501, SE_Fc_CastTimeAmt,					On Caster, cast time mod flat amt, base: milliseconds
-	focusFcHealPctCritIncoming,			//@Fc, SPA: 395, SE_FcHealPctCritIncoming,			On Target, spell healing mod pct, base: pct
-	focusFcHealAmt,						//@Fc, SPA: 392, SE_FcHealAmt,						On Caster, spell healing mod flat amt, base: amt
-	focusFcHealAmtCrit,					//@Fc, SPA: 396, SE_FcHealAmtCrit,					On Caster, spell healing mod flat amt, base: amt
+	focusSpellHaste = 1,				//@Fc, SPA: 127, SpellEffect::IncreaseSpellHaste,				On Caster, cast time mod pct, base: pct
+	focusSpellDuration,					//@Fc, SPA: 128, SpellEffect::IncreaseSpellDuration,			On Caster, spell duration mod pct, base: pct
+	focusRange,							//@Fc, SPA: 129, SpellEffect::IncreaseRange,					On Caster, spell range mod pct, base: pct
+	focusReagentCost,					//@Fc, SPA: 131, SpellEffect::ReduceReagentCost,				On Caster, do not consume reagent pct chance, base: min pct, limit: max pct
+	focusManaCost,						//@Fc, SPA: 132, SpellEffect::ReduceManaCost,					On Caster, reduce mana cost by pct, base: min pct, limt: max pct
+	focusImprovedHeal,					//@Fc, SPA: 125, SpellEffect::ImprovedHeal,					On Caster, spell healing mod pct, base: min pct, limit: max pct
+	focusImprovedDamage,				//@Fc, SPA: 124, SpellEffect::ImprovedDamage,					On Caster, spell damage mod pct, base: min pct, limit: max pct
+	focusImprovedDamage2,				//@Fc, SPA: 461, SpellEffect::ImprovedDamage2,				On Caster, spell damage mod pct, base: min pct, limit: max pct
+	focusFcDamagePctCrit,				//@Fc, SPA: 302, SpellEffect::FcDamagePctCrit,				On Caster, spell damage mod pct, base: min pct, limit: max pct
+	focusPetPower,						//@Fc, SPA: 167, SpellEffect::PetPowerIncrease,				On Caster, pet power mod, base: value
+	focusResistRate,					//@Fc, SPA: 126, SpellEffect::SpellResistReduction,			On Caster, casted spell resist mod pct, base: min pct, limit: max pct
+	focusSpellHateMod,					//@Fc, SPA: 130, SpellEffect::SpellHateMod,					On Caster, spell hate mod pct, base: min pct, limit: max pct
+	focusTriggerOnCast,					//@Fc, SPA: 339, SpellEffect::TriggerOnCast,					On Caster, cast on spell use, base: chance pct limit: spellid
+	focusSpellVulnerability,			//@Fc, SPA: 296, SpellEffect::FcSpellVulnerability,			On Target, spell damage taken mod pct, base: min pct, limit: max pct
+	focusFcSpellDamagePctIncomingPC,	//@Fc, SPA: 483, SpellEffect::Fc_Spell_Damage_Pct_IncomingPC, On Target, spell damage taken mod pct, base: min pct, limit: max pct
+	focusTwincast,						//@Fc, SPA: 399, SpellEffect::FcTwincast,						On Caster, chance cast spell twice, base: chance pct
+	focusSympatheticProc,				//@Fc, SPA: 383, SpellEffect::SympatheticProc,				On Caster, cast on spell use, base: variable proc chance on cast time, limit: spellid
+	focusFcDamageAmt,					//@Fc, SPA: 286, SpellEffect::FcDamageAmt,					On Caster, spell damage mod flat amt, base: amt
+	focusFcDamageAmt2,					//@Fc, SPA: 462, SpellEffect::FcDamageAmt2,					On Caster, spell damage mod flat amt, base: amt
+	focusFcDamageAmtCrit,				//@Fc, SPA: 303, SpellEffect::FFcDamageAmtCrit,				On Caster, spell damage mod flat amt, base: amt
+	focusSpellDurByTic,					//@Fc, SPA: 287, SpellEffect::SpellDurationIncByTic,			On Caster, spell buff duration mod, base: tics
+	focusSwarmPetDuration,				//@Fc, SPA: 398, SpellEffect::SwarmPetDuration,				On Caster, swarm pet duration mod, base: milliseconds
+	focusReduceRecastTime,				//@Fc, SPA: 310, SpellEffect::ReduceReuseTimer,				On Caster, disc reuse time mod, base: milliseconds
+	focusBlockNextSpell,				//@Fc, SPA: 335, SpellEffect::BlockNextSpellFocus,			On Caster, chance to block next spell, base: chance
+	focusFcHealPctIncoming,				//@Fc, SPA: 393, SpellEffect::FcHealPctIncoming,   			On Target, heal received mod pct, base: pct
+	focusFcDamageAmtIncoming,			//@Fc, SPA: 297, SpellEffect::FcDamageAmtIncoming,			On Target, damage taken flat amt, base: amt
+	focusFcSpellDamageAmtIncomingPC,	//@Fc, SPA: 484, SpellEffect::Fc_Spell_Damage_Amt_IncomingPC,	On Target, damage taken flat amt, base: amt
+	focusFcCastSpellOnLand,				//@Fc, SPA: 481, SpellEffect::Fc_Cast_Spell_On_Land,			On Target, cast spell if hit by spell, base: chance pct, limit: spellid
+	focusFcHealAmtIncoming,				//@Fc, SPA: 394, SpellEffect::FcHealAmtIncoming,				On Target, heal received mod flat amt, base: amt
+	focusFcBaseEffects,					//@Fc, SPA: 413, SpellEffect::FcBaseEffects,					On Caster, base spell effectiveness mod pct, base: pct
+	focusIncreaseNumHits,				//@Fc, SPA: 421, SpellEffect::FcIncreaseNumHits,				On Caster, numhits mod flat amt, base: amt
+	focusFcLimitUse,					//@Fc, SPA: 420, SpellEffect::FcLimitUse,						On Caster, numhits mod pct, base: pct
+	focusFcMute,						//@Fc, SPA: 357, SpellEffect::FcMute,							On Caster, prevents spell casting, base: chance pct
+	focusFcTimerRefresh,				//@Fc, SPA: 389, SpellEffect::FcTimerRefresh,					On Caster, reset spell recast timer, base: 1
+	focusFcTimerLockout,				//@Fc, SPA: 390, SpellEffect::FcTimerLockout,					On Caster, set a spell to be on recast timer, base: recast duration milliseconds
+	focusFcStunTimeMod,					//@Fc, SPA: 133, SpellEffect::FcStunTimeMod,					On Caster, stun time mod pct, base: chance pct
+	focusFcResistIncoming,				//@Fc, SPA: 510, SpellEffect::Fc_Resist_Incoming,				On Target, resist modifier, base: amt
+	focusFcAmplifyMod,					//@Fc, SPA: 507, SpellEffect::Fc_Amplify_Mod,					On Caster, damage-heal-dot mod pct, base: pct
+	focusFcAmplifyAmt,					//@Fc, SPA: 508, SpellEffect::Fc_Amplify_Amt,					On Caster, damage-heal-dot mod flat amt, base: amt
+	focusFcCastTimeMod2,				//@Fc, SPA: 500, SpellEffect::Fc_CastTimeMod2,				On Caster, cast time mod pct, base: pct
+	focusFcCastTimeAmt,					//@Fc, SPA: 501, SpellEffect::Fc_CastTimeAmt,					On Caster, cast time mod flat amt, base: milliseconds
+	focusFcHealPctCritIncoming,			//@Fc, SPA: 395, SpellEffect::FcHealPctCritIncoming,			On Target, spell healing mod pct, base: pct
+	focusFcHealAmt,						//@Fc, SPA: 392, SpellEffect::FcHealAmt,						On Caster, spell healing mod flat amt, base: amt
+	focusFcHealAmtCrit,					//@Fc, SPA: 396, SpellEffect::FcHealAmtCrit,					On Caster, spell healing mod flat amt, base: amt
 } focusType; //Any new FocusType needs to be added to the Mob::IsFocus function
 #define HIGHEST_FOCUS	focusFcHealAmtCrit //Should always be last focusType in enum
 

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -263,7 +263,7 @@ int64 Mob::GetActDoTDamage(uint16 spell_id, int64 value, Mob* target, bool from_
 	chance += itembonuses.CriticalDoTChance + spellbonuses.CriticalDoTChance + aabonuses.CriticalDoTChance;
 
 	if (spellbonuses.CriticalDotDecay)
-		chance += GetDecayEffectValue(spell_id, SE_CriticalDotDecay);
+		chance += GetDecayEffectValue(spell_id, SpellEffect::CriticalDotDecay);
 
 	if (spells[spell_id].override_crit_chance > 0 && chance > spells[spell_id].override_crit_chance)
 		chance = spells[spell_id].override_crit_chance;
@@ -429,14 +429,14 @@ int64 Mob::GetActSpellHealing(uint16 spell_id, int64 value, Mob* target, bool fr
 		critical_chance += itembonuses.CriticalHealChance + spellbonuses.CriticalHealChance + aabonuses.CriticalHealChance;
 
 		if (spellbonuses.CriticalHealDecay) {
-			critical_chance += GetDecayEffectValue(spell_id, SE_CriticalHealDecay);
+			critical_chance += GetDecayEffectValue(spell_id, SpellEffect::CriticalHealDecay);
 		}
 	}
 	else {
 		critical_chance = itembonuses.CriticalHealOverTime + spellbonuses.CriticalHealOverTime + aabonuses.CriticalHealOverTime;
 
 		if (spellbonuses.CriticalRegenDecay) {
-			critical_chance += GetDecayEffectValue(spell_id, SE_CriticalRegenDecay);
+			critical_chance += GetDecayEffectValue(spell_id, SpellEffect::CriticalRegenDecay);
 		}
 	}
 
@@ -596,7 +596,7 @@ int32 Mob::GetActSpellCost(uint16 spell_id, int32 cost)
 			if (buffs[buffSlot].spellid == 0 || buffs[buffSlot].spellid >= SPDAT_RECORDS)
 				continue;
 
-			if(IsEffectInSpell(buffs[buffSlot].spellid, SE_ReduceManaCost)) {
+			if(IsEffectInSpell(buffs[buffSlot].spellid, SpellEffect::ReduceManaCost)) {
 				if(CalcFocusEffect(focusManaCost, buffs[buffSlot].spellid, spell_id) == 100)
 					cost = 1;
 			}
@@ -1105,8 +1105,8 @@ void EntityList::AESpell(
 		IsTargetableAESpell(spell_id) &&
 		is_detrimental_spell &&
 		!is_npc &&
-		!IsEffectInSpell(spell_id, SE_Lull) &&
-		!IsEffectInSpell(spell_id, SE_Mez)
+		!IsEffectInSpell(spell_id, SpellEffect::Lull) &&
+		!IsEffectInSpell(spell_id, SpellEffect::Mez)
 	) {
 		max_targets_allowed = RuleI(Spells, TargetedAOEMaxTargets);
 	} else if (

--- a/zone/fearpath.cpp
+++ b/zone/fearpath.cpp
@@ -365,7 +365,7 @@ void Mob::CalculateNewFearpoint()
 	// fallback logic if pathing system can't be used
 	bool inliquid = zone->HasWaterMap() && zone->watermap->InLiquid(glm::vec3(GetPosition())) || zone->IsWaterZone(GetZ());
 	bool stay_inliquid = (inliquid && IsNPC() && CastToNPC()->IsUnderwaterOnly());
-	bool levitating = IsClient() && (FindType(SE_Levitate) || flymode != GravityBehavior::Ground);
+	bool levitating = IsClient() && (FindType(SpellEffect::Levitate) || flymode != GravityBehavior::Ground);
 	bool open_outdoor_zone = !zone->CanCastOutdoor() && !zone->IsCity();
 
 	int loop = 0;

--- a/zone/merc.cpp
+++ b/zone/merc.cpp
@@ -118,7 +118,7 @@ void Merc::CalcBonuses()
 	CalcMaxMana();
 	CalcMaxEndurance();
 
-	rooted = FindType(SE_Root);
+	rooted = FindType(SpellEffect::Root);
 }
 
 float Merc::GetDefaultSize() {
@@ -1730,7 +1730,7 @@ bool Merc::AICastSpell(int8 iChance, uint32 iSpellTypes) {
 									}
 									else {
 										//check for heal over time. if not present, try it first
-										if (!tar->FindType(SE_HealOverTime)) {
+										if (!tar->FindType(SpellEffect::HealOverTime)) {
 											selectedMercSpell = GetBestMercSpellForHealOverTime(this);
 
 											//get regular heal
@@ -1779,7 +1779,7 @@ bool Merc::AICastSpell(int8 iChance, uint32 iSpellTypes) {
 										if( !IsImmuneToSpell(selectedMercSpell.spellid, this)
 											&& (CanBuffStack(selectedMercSpell.spellid, mercLevel, true) >= 0)) {
 
-												if( GetArchetype() == Archetype::Melee && IsEffectInSpell(selectedMercSpell.spellid, SE_IncreaseSpellHaste)) {
+												if( GetArchetype() == Archetype::Melee && IsEffectInSpell(selectedMercSpell.spellid, SpellEffect::IncreaseSpellHaste)) {
 													continue;
 												}
 
@@ -1806,7 +1806,7 @@ bool Merc::AICastSpell(int8 iChance, uint32 iSpellTypes) {
 												if( !tar->IsImmuneToSpell(selectedMercSpell.spellid, this)
 													&& (tar->CanBuffStack(selectedMercSpell.spellid, mercLevel, true) >= 0)) {
 
-														if( tar->GetArchetype() == Archetype::Melee && IsEffectInSpell(selectedMercSpell.spellid, SE_IncreaseSpellHaste)) {
+														if( tar->GetArchetype() == Archetype::Melee && IsEffectInSpell(selectedMercSpell.spellid, SpellEffect::IncreaseSpellHaste)) {
 															continue;
 														}
 
@@ -2292,7 +2292,7 @@ int64 Merc::GetFocusEffect(focusType type, uint16 spell_id, bool from_buff_tic) 
 	if(type == focusReagentCost && IsSummonPetSpell(spell_id) && GetAA(aaElementalPact))
 		return 100;
 
-	if(type == focusReagentCost && (IsEffectInSpell(spell_id, SE_SummonItem) || IsSacrificeSpell(spell_id)))
+	if(type == focusReagentCost && (IsEffectInSpell(spell_id, SpellEffect::SummonItem) || IsSacrificeSpell(spell_id)))
 		return 0;
 	//Summon Spells that require reagents are typically imbue type spells, enchant metal, sacrifice and shouldn't be affected
 	//by reagent conservation for obvious reasons.
@@ -2620,7 +2620,7 @@ MercSpell Merc::GetBestMercSpellForVeryFastHeal(Merc* caster) {
 	result.time_cancast = 0;
 
 	if(caster) {
-		std::list<MercSpell> mercSpellList = GetMercSpellsForSpellEffect(caster, SE_CurrentHP);
+		std::list<MercSpell> mercSpellList = GetMercSpellsForSpellEffect(caster, SpellEffect::CurrentHP);
 
 		for (auto mercSpellListItr = mercSpellList.begin(); mercSpellListItr != mercSpellList.end();
 		     ++mercSpellListItr) {
@@ -2653,7 +2653,7 @@ MercSpell Merc::GetBestMercSpellForFastHeal(Merc* caster) {
 	result.time_cancast = 0;
 
 	if(caster) {
-		std::list<MercSpell> mercSpellList = GetMercSpellsForSpellEffect(caster, SE_CurrentHP);
+		std::list<MercSpell> mercSpellList = GetMercSpellsForSpellEffect(caster, SpellEffect::CurrentHP);
 
 		for (auto mercSpellListItr = mercSpellList.begin(); mercSpellListItr != mercSpellList.end();
 		     ++mercSpellListItr) {
@@ -2686,7 +2686,7 @@ MercSpell Merc::GetBestMercSpellForHealOverTime(Merc* caster) {
 	result.time_cancast = 0;
 
 	if(caster) {
-		std::list<MercSpell> mercHoTSpellList = GetMercSpellsForSpellEffect(caster, SE_HealOverTime);
+		std::list<MercSpell> mercHoTSpellList = GetMercSpellsForSpellEffect(caster, SpellEffect::HealOverTime);
 
 		for (auto mercSpellListItr = mercHoTSpellList.begin(); mercSpellListItr != mercHoTSpellList.end();
 		     ++mercSpellListItr) {
@@ -2727,7 +2727,7 @@ MercSpell Merc::GetBestMercSpellForPercentageHeal(Merc* caster) {
 	result.time_cancast = 0;
 
 	if(caster && caster->AI_HasSpells()) {
-		std::list<MercSpell> mercSpellList = GetMercSpellsForSpellEffect(caster, SE_CurrentHP);
+		std::list<MercSpell> mercSpellList = GetMercSpellsForSpellEffect(caster, SpellEffect::CurrentHP);
 
 		for (auto mercSpellListItr = mercSpellList.begin(); mercSpellListItr != mercSpellList.end();
 		     ++mercSpellListItr) {
@@ -2760,7 +2760,7 @@ MercSpell Merc::GetBestMercSpellForRegularSingleTargetHeal(Merc* caster) {
 	result.time_cancast = 0;
 
 	if(caster) {
-		std::list<MercSpell> mercSpellList = GetMercSpellsForSpellEffect(caster, SE_CurrentHP);
+		std::list<MercSpell> mercSpellList = GetMercSpellsForSpellEffect(caster, SpellEffect::CurrentHP);
 
 		for (auto mercSpellListItr = mercSpellList.begin(); mercSpellListItr != mercSpellList.end();
 		     ++mercSpellListItr) {
@@ -2793,7 +2793,7 @@ MercSpell Merc::GetFirstMercSpellForSingleTargetHeal(Merc* caster) {
 	result.time_cancast = 0;
 
 	if(caster) {
-		std::list<MercSpell> mercSpellList = GetMercSpellsForSpellEffect(caster, SE_CurrentHP);
+		std::list<MercSpell> mercSpellList = GetMercSpellsForSpellEffect(caster, SpellEffect::CurrentHP);
 
 		for (auto mercSpellListItr = mercSpellList.begin(); mercSpellListItr != mercSpellList.end();
 		     ++mercSpellListItr) {
@@ -2827,7 +2827,7 @@ MercSpell Merc::GetBestMercSpellForGroupHeal(Merc* caster) {
 	result.time_cancast = 0;
 
 	if(caster) {
-		std::list<MercSpell> mercSpellList = GetMercSpellsForSpellEffect(caster, SE_CurrentHP);
+		std::list<MercSpell> mercSpellList = GetMercSpellsForSpellEffect(caster, SpellEffect::CurrentHP);
 
 		for (auto mercSpellListItr = mercSpellList.begin(); mercSpellListItr != mercSpellList.end();
 		     ++mercSpellListItr) {
@@ -2860,7 +2860,7 @@ MercSpell Merc::GetBestMercSpellForGroupHealOverTime(Merc* caster) {
 	result.time_cancast = 0;
 
 	if(caster) {
-		std::list<MercSpell> mercHoTSpellList = GetMercSpellsForSpellEffect(caster, SE_HealOverTime);
+		std::list<MercSpell> mercHoTSpellList = GetMercSpellsForSpellEffect(caster, SpellEffect::HealOverTime);
 
 		for (auto mercSpellListItr = mercHoTSpellList.begin(); mercSpellListItr != mercHoTSpellList.end();
 		     ++mercSpellListItr) {
@@ -2901,7 +2901,7 @@ MercSpell Merc::GetBestMercSpellForGroupCompleteHeal(Merc* caster) {
 	result.time_cancast = 0;
 
 	if(caster) {
-		std::list<MercSpell> mercSpellList = GetMercSpellsForSpellEffect(caster, SE_CompleteHeal);
+		std::list<MercSpell> mercSpellList = GetMercSpellsForSpellEffect(caster, SpellEffect::CompleteHeal);
 
 		for (auto mercSpellListItr = mercSpellList.begin(); mercSpellListItr != mercSpellList.end();
 		     ++mercSpellListItr) {
@@ -2934,7 +2934,7 @@ MercSpell Merc::GetBestMercSpellForAETaunt(Merc* caster) {
 	result.time_cancast = 0;
 
 	if(caster) {
-		std::list<MercSpell> mercSpellList = GetMercSpellsForSpellEffect(caster, SE_Taunt);
+		std::list<MercSpell> mercSpellList = GetMercSpellsForSpellEffect(caster, SpellEffect::Taunt);
 
 		for (auto mercSpellListItr = mercSpellList.begin(); mercSpellListItr != mercSpellList.end();
 		     ++mercSpellListItr) {
@@ -2969,7 +2969,7 @@ MercSpell Merc::GetBestMercSpellForTaunt(Merc* caster) {
 	result.time_cancast = 0;
 
 	if(caster) {
-		std::list<MercSpell> mercSpellList = GetMercSpellsForSpellEffect(caster, SE_Taunt);
+		std::list<MercSpell> mercSpellList = GetMercSpellsForSpellEffect(caster, SpellEffect::Taunt);
 
 		for (auto mercSpellListItr = mercSpellList.begin(); mercSpellListItr != mercSpellList.end();
 		     ++mercSpellListItr) {
@@ -3002,7 +3002,7 @@ MercSpell Merc::GetBestMercSpellForHate(Merc* caster) {
 	result.time_cancast = 0;
 
 	if(caster) {
-		std::list<MercSpell> mercSpellList = GetMercSpellsForSpellEffect(caster, SE_InstantHate);
+		std::list<MercSpell> mercSpellList = GetMercSpellsForSpellEffect(caster, SpellEffect::InstantHate);
 
 		for (auto mercSpellListItr = mercSpellList.begin(); mercSpellListItr != mercSpellList.end();
 		     ++mercSpellListItr) {
@@ -3038,10 +3038,10 @@ MercSpell Merc::GetBestMercSpellForCure(Merc* caster, Mob *tar) {
 		return result;
 
 	int countNeedsCured = 0;
-	bool isPoisoned = tar->FindType(SE_PoisonCounter);
-	bool isDiseased = tar->FindType(SE_DiseaseCounter);
-	bool isCursed = tar->FindType(SE_CurseCounter);
-	bool isCorrupted = tar->FindType(SE_CorruptionCounter);
+	bool isPoisoned = tar->FindType(SpellEffect::PoisonCounter);
+	bool isDiseased = tar->FindType(SpellEffect::DiseaseCounter);
+	bool isCursed = tar->FindType(SpellEffect::CurseCounter);
+	bool isCorrupted = tar->FindType(SpellEffect::CorruptionCounter);
 
 	if(caster && caster->AI_HasSpells()) {
 		std::list<MercSpell> cureList = GetMercSpellsBySpellType(caster, SpellType_Cure);
@@ -3068,19 +3068,19 @@ MercSpell Merc::GetBestMercSpellForCure(Merc* caster, Mob *tar) {
 					if(selectedMercSpell.spellid == 0)
 						continue;
 
-					if(isPoisoned && IsEffectInSpell(itr->spellid, SE_PoisonCounter)) {
+					if(isPoisoned && IsEffectInSpell(itr->spellid, SpellEffect::PoisonCounter)) {
 						spellSelected = true;
 					}
-					else if(isDiseased && IsEffectInSpell(itr->spellid, SE_DiseaseCounter)) {
+					else if(isDiseased && IsEffectInSpell(itr->spellid, SpellEffect::DiseaseCounter)) {
 						spellSelected = true;
 					}
-					else if(isCursed && IsEffectInSpell(itr->spellid, SE_CurseCounter)) {
+					else if(isCursed && IsEffectInSpell(itr->spellid, SpellEffect::CurseCounter)) {
 						spellSelected = true;
 					}
-					else if(isCorrupted && IsEffectInSpell(itr->spellid, SE_CorruptionCounter)) {
+					else if(isCorrupted && IsEffectInSpell(itr->spellid, SpellEffect::CorruptionCounter)) {
 						spellSelected = true;
 					}
-					else if(IsEffectInSpell(itr->spellid, SE_DispelDetrimental)) {
+					else if(IsEffectInSpell(itr->spellid, SpellEffect::DispelDetrimental)) {
 						spellSelected = true;
 					}
 
@@ -3108,19 +3108,19 @@ MercSpell Merc::GetBestMercSpellForCure(Merc* caster, Mob *tar) {
 					if(selectedMercSpell.spellid == 0)
 						continue;
 
-					if(isPoisoned && IsEffectInSpell(itr->spellid, SE_PoisonCounter)) {
+					if(isPoisoned && IsEffectInSpell(itr->spellid, SpellEffect::PoisonCounter)) {
 						spellSelected = true;
 					}
-					else if(isDiseased && IsEffectInSpell(itr->spellid, SE_DiseaseCounter)) {
+					else if(isDiseased && IsEffectInSpell(itr->spellid, SpellEffect::DiseaseCounter)) {
 						spellSelected = true;
 					}
-					else if(isCursed && IsEffectInSpell(itr->spellid, SE_CurseCounter)) {
+					else if(isCursed && IsEffectInSpell(itr->spellid, SpellEffect::CurseCounter)) {
 						spellSelected = true;
 					}
-					else if(isCorrupted && IsEffectInSpell(itr->spellid, SE_CorruptionCounter)) {
+					else if(isCorrupted && IsEffectInSpell(itr->spellid, SpellEffect::CorruptionCounter)) {
 						spellSelected = true;
 					}
-					else if(IsEffectInSpell(itr->spellid, SE_DispelDetrimental)) {
+					else if(IsEffectInSpell(itr->spellid, SpellEffect::DispelDetrimental)) {
 						spellSelected = true;
 					}
 
@@ -3155,7 +3155,7 @@ MercSpell Merc::GetBestMercSpellForStun(Merc* caster) {
 	result.time_cancast = 0;
 
 	if(caster) {
-		std::list<MercSpell> mercSpellList = GetMercSpellsForSpellEffect(caster, SE_Stun);
+		std::list<MercSpell> mercSpellList = GetMercSpellsForSpellEffect(caster, SpellEffect::Stun);
 
 		for (auto mercSpellListItr = mercSpellList.begin(); mercSpellListItr != mercSpellList.end();
 		     ++mercSpellListItr) {
@@ -3492,7 +3492,7 @@ bool Merc::GetNeedsCured(Mob *tar) {
 	bool needCured = false;
 
 	if(tar) {
-		if(tar->FindType(SE_PoisonCounter) || tar->FindType(SE_DiseaseCounter) || tar->FindType(SE_CurseCounter) || tar->FindType(SE_CorruptionCounter)) {
+		if(tar->FindType(SpellEffect::PoisonCounter) || tar->FindType(SpellEffect::DiseaseCounter) || tar->FindType(SpellEffect::CurseCounter) || tar->FindType(SpellEffect::CorruptionCounter)) {
 			uint32 buff_count = tar->GetMaxTotalSlots();
 			int buffsWithCounters = 0;
 			needCured = true;

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -547,7 +547,7 @@ Mob::~Mob()
 	AI_Stop();
 	if (GetPet()) {
 		if (GetPet()->Charmed()) {
-			GetPet()->BuffFadeByEffect(SE_Charm);
+			GetPet()->BuffFadeByEffect(SpellEffect::Charm);
 		}
 		else {
 			SetPet(0);
@@ -625,7 +625,7 @@ void Mob::BreakCharmPetIfConditionsMet() {
 	auto pet = GetPet();
 	if (pet && pet->GetPetType() == PetType::Charmed && HasAnInvisibilityEffect()) {
 		if (RuleB(Pets, LivelikeBreakCharmOnInvis) || IsInvisible(pet)) {
-			pet->BuffFadeByEffect(SE_Charm);
+			pet->BuffFadeByEffect(SpellEffect::Charm);
 		}
 		LogRules(
 			"Pets:LivelikeBreakCharmOnInvis for [{}] invisible [{}] hidden [{}] improved_hidden (shroud of stealth) [{}] invisible_animals [{}] invisible_undead [{}]",
@@ -1352,7 +1352,7 @@ void Mob::FillSpawnStruct(NewSpawn_Struct* ns, Mob* ForWho)
 	// 3 - Mobs in water do not sink. A value of 3 in this field appears to be the default setting for all mobs
 	// (in water or not) according to 6.2 era packet collects.
 	if(IsClient())
-		ns->spawn.flymode = FindType(SE_Levitate) ? 2 : 0;
+		ns->spawn.flymode = FindType(SpellEffect::Levitate) ? 2 : 0;
 	else
 		ns->spawn.flymode = flymode;
 
@@ -5629,7 +5629,7 @@ int Mob::GetSnaredAmount()
 
 		for(int j = 0; j < EFFECT_COUNT; j++)
 		{
-			if (spells[buffs[i].spellid].effect_id[j] == SE_MovementSpeed)
+			if (spells[buffs[i].spellid].effect_id[j] == SpellEffect::MovementSpeed)
 			{
 				int64 val = CalcSpellEffectValue_formula(spells[buffs[i].spellid].formula[j], spells[buffs[i].spellid].base_value[j], spells[buffs[i].spellid].max_value[j], buffs[i].casterlevel, buffs[i].spellid);
 				//int effect = CalcSpellEffectValue(buffs[i].spellid, spells[buffs[i].spellid].effectid[j], buffs[i].casterlevel);
@@ -5827,7 +5827,7 @@ bool Mob::TrySpellTrigger(Mob *target, uint32 spell_id, int effect)
 	if (!target || !IsValidSpell(spell_id))
 		return false;
 
-	/*The effects SE_SpellTrigger (SPA 340) and SE_Chance_Best_in_Spell_Grp (SPA 469) work as follows, you typically will have 2-3 different spells each with their own
+	/*The effects SpellEffect::SpellTrigger (SPA 340) and SpellEffect::Chance_Best_in_Spell_Grp (SPA 469) work as follows, you typically will have 2-3 different spells each with their own
 	chance to be triggered with all chances equaling up to 100 pct, with only 1 spell out of the group being ultimately cast.
 	(ie Effect1 trigger spellA with 30% chance, Effect2 triggers spellB with 20% chance, Effect3 triggers spellC with 50% chance).
 	The following function ensures a statistically accurate chance for each spell to be cast based on their chance values. These effects are also  used in spells where there
@@ -5842,7 +5842,7 @@ bool Mob::TrySpellTrigger(Mob *target, uint32 spell_id, int effect)
 
 	for (int i = 0; i < EFFECT_COUNT; i++)
 	{
-		if (spells[spell_id].effect_id[i] == SE_SpellTrigger || spells[spell_id].effect_id[i] == SE_Chance_Best_in_Spell_Grp)
+		if (spells[spell_id].effect_id[i] == SpellEffect::SpellTrigger || spells[spell_id].effect_id[i] == SpellEffect::Chance_Best_in_Spell_Grp)
 			total_chance += spells[spell_id].base_value[i];
 	}
 
@@ -5852,7 +5852,7 @@ bool Mob::TrySpellTrigger(Mob *target, uint32 spell_id, int effect)
 
 		for (int i = 0; i < EFFECT_COUNT; i++){
 			//Find spells with SPA 340 and add the cumulative percent chances to the roll array
-			if ((spells[spell_id].effect_id[i] == SE_SpellTrigger) || (spells[spell_id].effect_id[i] == SE_Chance_Best_in_Spell_Grp)){
+			if ((spells[spell_id].effect_id[i] == SpellEffect::SpellTrigger) || (spells[spell_id].effect_id[i] == SpellEffect::Chance_Best_in_Spell_Grp)){
 				const int cumulative_chance = current_chance + spells[spell_id].base_value[i];
 				chance_array[i] = cumulative_chance;
 				current_chance = cumulative_chance;
@@ -5875,11 +5875,11 @@ bool Mob::TrySpellTrigger(Mob *target, uint32 spell_id, int effect)
 	}
 
 	if (CastSpell) {
-		if (spells[spell_id].effect_id[effect_slot] == SE_SpellTrigger && IsValidSpell(spells[spell_id].limit_value[effect_slot])) {
+		if (spells[spell_id].effect_id[effect_slot] == SpellEffect::SpellTrigger && IsValidSpell(spells[spell_id].limit_value[effect_slot])) {
 			SpellFinished(spells[spell_id].limit_value[effect_slot], target, EQ::spells::CastingSlot::Item, 0, -1, spells[spells[spell_id].limit_value[effect_slot]].resist_difficulty);
 			return true;
 		}
-		else if (IsClient() && spells[spell_id].effect_id[effect_slot] == SE_Chance_Best_in_Spell_Grp) {
+		else if (IsClient() && spells[spell_id].effect_id[effect_slot] == SpellEffect::Chance_Best_in_Spell_Grp) {
 			uint32 best_spell_id = CastToClient()->GetHighestScribedSpellinSpellGroup(spells[spell_id].limit_value[effect_slot]);
 			if (IsValidSpell(best_spell_id)) {
 				SpellFinished(best_spell_id, target, EQ::spells::CastingSlot::Item, 0, -1, spells[best_spell_id].resist_difficulty);
@@ -5899,7 +5899,7 @@ void Mob::TryTriggerOnCastRequirement()
 			int spell_id = buffs[e].spellid;
 			if (IsValidSpell(spell_id)) {
 				for (int i = 0; i < EFFECT_COUNT; i++) {
-					if ((spells[spell_id].effect_id[i] == SE_TriggerOnReqTarget) || (spells[spell_id].effect_id[i] == SE_TriggerOnReqCaster)) {
+					if ((spells[spell_id].effect_id[i] == SpellEffect::TriggerOnReqTarget) || (spells[spell_id].effect_id[i] == SpellEffect::TriggerOnReqCaster)) {
 						if (PassCastRestriction(spells[spell_id].limit_value[i])) {
 							SpellFinished(spells[spell_id].base_value[i], this, EQ::spells::CastingSlot::Item, 0, -1, spells[spell_id].resist_difficulty);
 							if (!TryFadeEffect(e)) {
@@ -5942,7 +5942,7 @@ void Mob::TryTwincast(Mob *caster, Mob *target, uint32 spell_id)
 		int buff_count = GetMaxTotalSlots();
 		for(int i = 0; i < buff_count; i++)
 		{
-			if(IsEffectInSpell(buffs[i].spellid, SE_FcTwincast))
+			if(IsEffectInSpell(buffs[i].spellid, SpellEffect::FcTwincast))
 			{
 				int32 focus = CalcFocusEffect(focusTwincast, buffs[i].spellid, spell_id);
 				if(focus > 0)
@@ -5968,10 +5968,10 @@ void Mob::ApplyHealthTransferDamage(Mob *caster, Mob *target, uint16 spell_id)
 		This allows for the AE spells to function without repeatedly killing caster
 		Damage or heal portion can be found as regular single use spell effect
 	*/
-	if (IsEffectInSpell(spell_id, SE_Health_Transfer)){
+	if (IsEffectInSpell(spell_id, SpellEffect::Health_Transfer)){
 		for (int i = 0; i < EFFECT_COUNT; i++) {
 
-			if (spells[spell_id].effect_id[i] == SE_Health_Transfer) {
+			if (spells[spell_id].effect_id[i] == SpellEffect::Health_Transfer) {
 				int64 new_hp = GetMaxHP();
 				new_hp -= GetMaxHP()  * spells[spell_id].base_value[i] / 1000;
 
@@ -6175,8 +6175,8 @@ bool Mob::TryFadeEffect(int slot)
 			if (!spells[buffs[slot].spellid].effect_id[i])
 				continue;
 
-			if (spells[buffs[slot].spellid].effect_id[i] == SE_CastOnFadeEffectAlways ||
-				spells[buffs[slot].spellid].effect_id[i] == SE_CastOnRuneFadeEffect)
+			if (spells[buffs[slot].spellid].effect_id[i] == SpellEffect::CastOnFadeEffectAlways ||
+				spells[buffs[slot].spellid].effect_id[i] == SpellEffect::CastOnRuneFadeEffect)
 			{
 				uint16 spell_id = spells[buffs[slot].spellid].base_value[i];
 				BuffFadeBySlot(slot);
@@ -6560,9 +6560,9 @@ void Mob::TrySpellOnKill(uint8 level, uint16 spell_id)
 {
 	if (IsValidSpell(spell_id))
 	{
-		if(IsEffectInSpell(spell_id, SE_ProcOnSpellKillShot)) {
+		if(IsEffectInSpell(spell_id, SpellEffect::ProcOnSpellKillShot)) {
 			for (int i = 0; i < EFFECT_COUNT; i++) {
-				if (spells[spell_id].effect_id[i] == SE_ProcOnSpellKillShot)
+				if (spells[spell_id].effect_id[i] == SpellEffect::ProcOnSpellKillShot)
 				{
 					if (IsValidSpell(spells[spell_id].limit_value[i]) && spells[spell_id].max_value[i] <= level)
 					{
@@ -6897,11 +6897,11 @@ void Mob::DoGravityEffect()
 	int buff_count = GetMaxTotalSlots();
 	for (int slot = 0; slot < buff_count; slot++)
 	{
-		if (IsValidSpell(buffs[slot].spellid) && IsEffectInSpell(buffs[slot].spellid, SE_GravityEffect))
+		if (IsValidSpell(buffs[slot].spellid) && IsEffectInSpell(buffs[slot].spellid, SpellEffect::GravityEffect))
 		{
 			for (int i = 0; i < EFFECT_COUNT; i++)
 			{
-				if(spells[buffs[slot].spellid].effect_id[i] == SE_GravityEffect) {
+				if(spells[buffs[slot].spellid].effect_id[i] == SpellEffect::GravityEffect) {
 
 					int casterId = buffs[slot].casterid;
 					if(casterId)
@@ -7108,7 +7108,7 @@ void Mob::CastOnCurer(uint32 spell_id)
 {
 	for(int i = 0; i < EFFECT_COUNT; i++)
 	{
-		if (spells[spell_id].effect_id[i] == SE_CastOnCurer)
+		if (spells[spell_id].effect_id[i] == SpellEffect::CastOnCurer)
 		{
 			if(IsValidSpell(spells[spell_id].base_value[i]))
 			{
@@ -7122,7 +7122,7 @@ void Mob::CastOnCure(uint32 spell_id)
 {
 	for(int i = 0; i < EFFECT_COUNT; i++)
 	{
-		if (spells[spell_id].effect_id[i] == SE_CastOnCure)
+		if (spells[spell_id].effect_id[i] == SpellEffect::CastOnCure)
 		{
 			if(IsValidSpell(spells[spell_id].base_value[i]))
 			{
@@ -7139,7 +7139,7 @@ void Mob::CastOnNumHitFade(uint32 spell_id)
 
 	for(int i = 0; i < EFFECT_COUNT; i++)
 	{
-		if (spells[spell_id].effect_id[i] == SE_CastonNumHitFade)
+		if (spells[spell_id].effect_id[i] == SpellEffect::CastonNumHitFade)
 		{
 			if(IsValidSpell(spells[spell_id].base_value[i]))
 			{

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -615,7 +615,7 @@ void Client::AI_SpellCast()
 			continue;
 		}
 
-		if(IsEffectInSpell(current_spell, SE_Charm))
+		if(IsEffectInSpell(current_spell, SpellEffect::Charm))
 		{
 			continue;
 		}
@@ -724,7 +724,7 @@ void Client::AI_Process()
 	{
 		if(!IsFeared() && !IsLD())
 		{
-			BuffFadeByEffect(SE_Charm);
+			BuffFadeByEffect(SpellEffect::Charm);
 			return;
 		}
 	}

--- a/zone/pets.cpp
+++ b/zone/pets.cpp
@@ -547,22 +547,22 @@ void NPC::SetPetState(SpellBuff_Struct *pet_buffs, uint32 *items) {
 		if (buffs[j1].spellid <= (uint32)SPDAT_RECORDS) {
 			for (int x1=0; x1 < EFFECT_COUNT; x1++) {
 				switch (spells[buffs[j1].spellid].effect_id[x1]) {
-					case SE_AddMeleeProc:
-					case SE_WeaponProc:
+					case SpellEffect::AddMeleeProc:
+					case SpellEffect::WeaponProc:
 						// We need to reapply buff based procs
 						// We need to do this here so suspended pets also regain their procs.
 						AddProcToWeapon(GetProcID(buffs[j1].spellid,x1), false, 100+spells[buffs[j1].spellid].limit_value[x1], buffs[j1].spellid, buffs[j1].casterlevel, GetSpellProcLimitTimer(buffs[j1].spellid, ProcType::MELEE_PROC));
 						break;
-					case SE_DefensiveProc:
+					case SpellEffect::DefensiveProc:
 						AddDefensiveProc(GetProcID(buffs[j1].spellid, x1), 100 + spells[buffs[j1].spellid].limit_value[x1], buffs[j1].spellid, GetSpellProcLimitTimer(buffs[j1].spellid, ProcType::DEFENSIVE_PROC));
 						break;
-					case SE_RangedProc:
+					case SpellEffect::RangedProc:
 						AddRangedProc(GetProcID(buffs[j1].spellid, x1), 100 + spells[buffs[j1].spellid].limit_value[x1], buffs[j1].spellid, GetSpellProcLimitTimer(buffs[j1].spellid, ProcType::RANGED_PROC));
 						break;
-					case SE_Charm:
-					case SE_Rune:
-					case SE_NegateAttacks:
-					case SE_Illusion:
+					case SpellEffect::Charm:
+					case SpellEffect::Rune:
+					case SpellEffect::NegateAttacks:
+					case SpellEffect::Illusion:
 						buffs[j1].spellid = SPELL_UNKNOWN;
 						pet_buffs[j1].spellid = SPELLBOOK_UNKNOWN;
 						pet_buffs[j1].effect_type = 0;

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -109,7 +109,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 	else
 	{
 		if(IsBuffSpell(spell_id)){
-			if(IsEffectInSpell(spell_id, SE_BindSight))
+			if(IsEffectInSpell(spell_id, SpellEffect::BindSight))
 			{
 				if(caster)
 				{
@@ -219,7 +219,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 	if (!IsDistanceModifierSpell(spell_id))
 		SetSpellPowerDistanceMod(0);
 
-	bool spell_trigger_cast_complete = false; //Used with SE_Spell_Trigger and SE_Chance_Best_in_Spell_Grp, true when spell has been triggered.
+	bool spell_trigger_cast_complete = false; //Used with SpellEffect::Spell_Trigger and SpellEffect::Chance_Best_in_Spell_Grp, true when spell has been triggered.
 
 	// if buff slot, use instrument mod there, otherwise calc it
 	uint32 instrument_mod = buffslot > -1 ? buffs[buffslot].instrument_mod : caster ? caster->GetInstrumentMod(spell_id) : 10;
@@ -241,7 +241,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 
 		//Prevents effect from being applied
 		if (spellbonuses.NegateEffects) {
-			if (effect != SE_NegateSpellEffect && NegateSpellEffect(spell_id, effect)) {
+			if (effect != SpellEffect::NegateSpellEffect && NegateSpellEffect(spell_id, effect)) {
 				if (caster) {
 					caster->Message(Chat::Red, "Part or all of this spell has lost its effectiveness."); //Placeholder msg, until live one is obtained.
 				}
@@ -254,12 +254,12 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 #endif
 		switch(effect)
 		{
-			case SE_CurrentHP:	// nukes, heals; also regen/dot if a buff
+			case SpellEffect::CurrentHP:	// nukes, heals; also regen/dot if a buff
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Current Hitpoints: %+i", effect_value);
 #endif
-				// SE_CurrentHP is calculated at first tick if its a dot/buff
+				// SpellEffect::CurrentHP is calculated at first tick if its a dot/buff
 				if (buffslot >= 0) {
 					//This is here so dots with hit counters tic down on initial cast.
 					if (caster && effect_value < 0) {
@@ -315,7 +315,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_CurrentHPOnce:	// used in buffs usually, see Courage
+			case SpellEffect::CurrentHPOnce:	// used in buffs usually, see Courage
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Current Hitpoints Once: %+i", effect_value);
@@ -390,7 +390,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					}
 					else if (dmg > 0) {
 						//do not apply focus/critical to buff spells
-						if (caster && !IsEffectInSpell(spell_id, SE_TotalHP)) {
+						if (caster && !IsEffectInSpell(spell_id, SpellEffect::TotalHP)) {
 							dmg = caster->GetActSpellHealing(spell_id, dmg, this);
 						}
 						HealDamage(dmg, caster);
@@ -399,7 +399,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_PercentalHeal:
+			case SpellEffect::PercentalHeal:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Percental Heal: %+i (%d%% max)", spell.max_value[i], effect_value);
@@ -434,7 +434,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_CompleteHeal:
+			case SpellEffect::CompleteHeal:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Complete Heal");
@@ -450,7 +450,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_CurrentMana:
+			case SpellEffect::CurrentMana:
 			{
 				// Bards don't get mana from effects, good or bad.
 				if(GetClass() == Class::Bard)
@@ -487,7 +487,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_CurrentManaOnce:
+			case SpellEffect::CurrentManaOnce:
 			{
 				// Bards don't get mana from effects, good or bad.
 				if(GetClass() == Class::Bard)
@@ -499,7 +499,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Translocate:
+			case SpellEffect::Translocate:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Translocate: %s %d %d %d heading %d",
@@ -517,7 +517,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Succor:
+			case SpellEffect::Succor:
 			{
 
 				float x, y, z, heading;
@@ -575,7 +575,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 						if (IsClient()) {
 							if (HasPet()) {
 								if (RuleB(Spells, EvacClearCharmPet) && GetPet()->IsCharmed()) {
-									GetPet()->BuffFadeByEffect(SE_Charm);
+									GetPet()->BuffFadeByEffect(SpellEffect::Charm);
 								}
 							}
 
@@ -598,9 +598,9 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 
 				break;
 			}
-			case SE_GateCastersBindpoint: // Used on Teleport Bind.
-			case SE_Teleport:	// gates, rings, circles, etc
-			case SE_Teleport2:
+			case SpellEffect::GateCastersBindpoint: // Used on Teleport Bind.
+			case SpellEffect::Teleport:	// gates, rings, circles, etc
+			case SpellEffect::Teleport2:
 			{
 				float x, y, z, heading;
 				const char *target_zone = nullptr;
@@ -630,7 +630,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					}
 				}
 
-				if (effect == SE_GateCastersBindpoint && caster && caster->IsClient())
+				if (effect == SpellEffect::GateCastersBindpoint && caster && caster->IsClient())
 				{ // Teleport Bind uses caster's bind point
 					int index = spells[spell_id].base_value[i] - 1;
 					if (index < 0 || index > 4)
@@ -646,11 +646,11 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 
 #ifdef SPELL_EFFECT_SPAM
 				const char *efstr = "Teleport";
-				if(effect == SE_Teleport)
+				if(effect == SpellEffect::Teleport)
 					efstr = "Teleport v1";
-				else if(effect == SE_Teleport2)
+				else if(effect == SpellEffect::Teleport2)
 					efstr = "Teleport v2";
-				else if(effect == SE_Succor)
+				else if(effect == SpellEffect::Succor)
 					efstr = "Succor";
 
 				snprintf(effect_desc, _EDLEN,
@@ -672,7 +672,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_FleshToBone:
+			case SpellEffect::FleshToBone:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Flesh To Bone");
@@ -701,7 +701,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_GroupFearImmunity:{
+			case SpellEffect::GroupFearImmunity:{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Group Fear Immunity");
 #endif
@@ -726,7 +726,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_AddFaction:
+			case SpellEffect::AddFaction:
 			{
 				if (caster && !IsPet() && GetPrimaryFaction() > 0) {
 					caster->AddFactionBonus(GetPrimaryFaction(),effect_value);
@@ -734,7 +734,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Stun:
+			case SpellEffect::Stun:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Stun: %d msec", effect_value);
@@ -777,7 +777,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Charm:
+			case SpellEffect::Charm:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Charm: %+i (up to lvl %d)", effect_value, spell.max_value[i]);
@@ -867,9 +867,9 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 			}
 
 
-			case SE_SenseDead:
-			case SE_SenseSummoned:
-			case SE_SenseAnimals:
+			case SpellEffect::SenseDead:
+			case SpellEffect::SenseSummoned:
+			case SpellEffect::SenseAnimals:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Sense Target: %+i", effect_value);
@@ -882,12 +882,12 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 
 						int MessageID = SENSE_UNDEAD;
 
-						if(effect == SE_SenseSummoned)
+						if(effect == SpellEffect::SenseSummoned)
 						{
 							bt = BodyType::Summoned;
 							MessageID = SENSE_SUMMONED;
 						}
-						else if(effect == SE_SenseAnimals)
+						else if(effect == SpellEffect::SenseAnimals)
 						{
 							bt = BodyType::Animal;
 							MessageID = SENSE_ANIMAL;
@@ -910,7 +910,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Fear:
+			case SpellEffect::Fear:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Fear: %+i", effect_value);
@@ -939,7 +939,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_BindAffinity: //TO DO: Add support for secondary and tertiary gate abilities
+			case SpellEffect::BindAffinity: //TO DO: Add support for secondary and tertiary gate abilities
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Bind Affinity");
@@ -1080,7 +1080,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Gate:
+			case SpellEffect::Gate:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Gate");
@@ -1095,7 +1095,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_CancelMagic:
+			case SpellEffect::CancelMagic:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Cancel Magic: %d", effect_value);
@@ -1111,7 +1111,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_DispelDetrimental:
+			case SpellEffect::DispelDetrimental:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Dispel Detrimental: %d", effect_value);
@@ -1142,7 +1142,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_DispelBeneficial:
+			case SpellEffect::DispelBeneficial:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Dispel Beneficial: %d", effect_value);
@@ -1169,7 +1169,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Purify:
+			case SpellEffect::Purify:
 			{
 				//Attempt to remove up to base amount of detrimental effects (excluding charm, fear, resurrection, and revival sickness).
 				int purify_count = spells[spell_id].base_value[i];
@@ -1180,8 +1180,8 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				for(int slot = 0; slot < purify_count; slot++) {
 					if (IsValidSpell(buffs[slot].spellid) && IsDetrimentalSpell(buffs[slot].spellid)){
 
-						if (!IsEffectInSpell(buffs[slot].spellid, SE_Charm) &&
-							!IsEffectInSpell(buffs[slot].spellid, SE_Fear) &&
+						if (!IsEffectInSpell(buffs[slot].spellid, SpellEffect::Charm) &&
+							!IsEffectInSpell(buffs[slot].spellid, SpellEffect::Fear) &&
 							buffs[slot].spellid != SPELL_RESURRECTION_SICKNESS &&
 							buffs[slot].spellid != SPELL_RESURRECTION_SICKNESS2 &&
 							buffs[slot].spellid != SPELL_RESURRECTION_SICKNESS3 &&
@@ -1195,7 +1195,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Mez:
+			case SpellEffect::Mez:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Mesmerize");
@@ -1204,7 +1204,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_SummonItem:
+			case SpellEffect::SummonItem:
 			{
 				const EQ::ItemData *item = database.GetItem(spell.base_value[i]);
 #ifdef SPELL_EFFECT_SPAM
@@ -1240,7 +1240,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 
 				break;
 			}
-			case SE_SummonItemIntoBag:
+			case SpellEffect::SummonItemIntoBag:
 			{
 				const EQ::ItemData *item = database.GetItem(spell.base_value[i]);
 				if (!item) {
@@ -1287,10 +1287,10 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_SummonBSTPet:
-			case SE_NecPet:
-			case SE_SummonPet:
-			case SE_Familiar:
+			case SpellEffect::SummonBSTPet:
+			case SpellEffect::NecPet:
+			case SpellEffect::SummonPet:
+			case SpellEffect::Familiar:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Summon %s: %s", (effect==SE_Familiar)?"Familiar":"Pet", spell.teleport_zone);
@@ -1326,7 +1326,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_DivineAura:
+			case SpellEffect::DivineAura:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Invulnerability");
@@ -1339,7 +1339,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_ShadowStep:
+			case SpellEffect::ShadowStep:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Shadow Step: %d", effect_value);
@@ -1352,7 +1352,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Blind:
+			case SpellEffect::Blind:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Blind: %+i", effect_value);
@@ -1361,7 +1361,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				if (IsBeneficialSpell(spell_id) && spells[spell_id].buff_duration == 0) {
 					int buff_count = GetMaxBuffSlots();
 					for (int slot = 0; slot < buff_count; slot++) {
-						if (IsValidSpell(buffs[slot].spellid) && IsEffectInSpell(buffs[slot].spellid, SE_Blind)) {
+						if (IsValidSpell(buffs[slot].spellid) && IsEffectInSpell(buffs[slot].spellid, SpellEffect::Blind)) {
 							if (caster && TryDispel(caster->GetCasterLevel(spell_id), buffs[slot].casterlevel, 1)) {
 								BuffFadeBySlot(slot);
 								slot = buff_count;
@@ -1375,7 +1375,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Rune:
+			case SpellEffect::Rune:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Melee Absorb Rune: %+i", effect_value);
@@ -1386,7 +1386,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_AbsorbMagicAtt:
+			case SpellEffect::AbsorbMagicAtt:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Spell Absorb Rune: %+i", effect_value);
@@ -1398,7 +1398,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_MitigateMeleeDamage:
+			case SpellEffect::MitigateMeleeDamage:
 			{
 				if (buffslot > -1) {
 					buffs[buffslot].melee_rune = spells[spell_id].max_value[i];
@@ -1406,7 +1406,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_MeleeThresholdGuard:
+			case SpellEffect::MeleeThresholdGuard:
 			{
 				if (buffslot > -1) {
 					buffs[buffslot].melee_rune = spells[spell_id].max_value[i];
@@ -1414,7 +1414,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_SpellThresholdGuard:
+			case SpellEffect::SpellThresholdGuard:
 			{
 				if (buffslot > -1) {
 					buffs[buffslot].magic_rune = spells[spell_id].max_value[i];
@@ -1422,7 +1422,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_MitigateSpellDamage:
+			case SpellEffect::MitigateSpellDamage:
 			{
 				if (buffslot > -1) {
 					buffs[buffslot].magic_rune = spells[spell_id].max_value[i];
@@ -1430,7 +1430,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_MitigateDotDamage:
+			case SpellEffect::MitigateDotDamage:
 			{
 				if (buffslot > -1) {
 					buffs[buffslot].dot_rune = spells[spell_id].max_value[i];
@@ -1438,7 +1438,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_DistanceRemoval:
+			case SpellEffect::DistanceRemoval:
 			{
 				if (buffslot > -1) {
 					buffs[buffslot].caston_x = int(GetX());
@@ -1448,7 +1448,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Levitate:
+			case SpellEffect::Levitate:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Levitate");
@@ -1464,7 +1464,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_DeathSave: {
+			case SpellEffect::DeathSave: {
 
 				int16 mod = 0;
 
@@ -1480,7 +1480,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
   				break;
  			}
 
-			case SE_Illusion:
+			case SpellEffect::Illusion:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Illusion: race %d", effect_value);
@@ -1497,7 +1497,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_IllusionCopy:
+			case SpellEffect::IllusionCopy:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Illusion Copy");
@@ -1527,13 +1527,13 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_WipeHateList:
+			case SpellEffect::WipeHateList:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Memory Blur: %d", effect_value);
 #endif
 				//Memory blur component of Mez spells is not checked again if Mez is recast on a target that is already mezed
-				if (!CanMemoryBlurFromMez && IsEffectInSpell(spell_id, SE_Mez)) {
+				if (!CanMemoryBlurFromMez && IsEffectInSpell(spell_id, SpellEffect::Mez)) {
 					break;
 				}
 
@@ -1558,7 +1558,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_SpinTarget:
+			case SpellEffect::SpinTarget:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Spin: %d", effect_value);
@@ -1589,7 +1589,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_EyeOfZomm:
+			case SpellEffect::EyeOfZomm:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Eye of Zomm");
@@ -1607,7 +1607,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_ReclaimPet:
+			case SpellEffect::ReclaimPet:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Reclaim Pet");
@@ -1642,7 +1642,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_BindSight:
+			case SpellEffect::BindSight:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Bind Sight");
@@ -1654,7 +1654,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_FeignDeath:
+			case SpellEffect::FeignDeath:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Feign Death");
@@ -1675,7 +1675,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Sentinel:
+			case SpellEffect::Sentinel:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Sentinel");
@@ -1696,7 +1696,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_LocateCorpse:
+			case SpellEffect::LocateCorpse:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Locate Corpse");
@@ -1709,8 +1709,8 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_SummonToCorpse:
-			case SE_Revive:
+			case SpellEffect::SummonToCorpse:
+			case SpellEffect::Revive:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Revive");	// heh the corpse won't see this
@@ -1726,8 +1726,8 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_ModelSize:
-			case SE_ChangeHeight:
+			case SpellEffect::ModelSize:
+			case SpellEffect::ChangeHeight:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Model Size: %d%%", effect_value);
@@ -1745,14 +1745,14 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					}
 				}
 				//Only applies to SPA 89, max value also likely does something, but unknown.
-				else if (effect == SE_ModelSize && spells[spell_id].limit_value[i]) {
+				else if (effect == SpellEffect::ModelSize && spells[spell_id].limit_value[i]) {
 					ChangeSize(spells[spell_id].limit_value[i]);
 				}
 
 				break;
 			}
 
-			case SE_Root:
+			case SpellEffect::Root:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Root: %+i", effect_value);
@@ -1768,7 +1768,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_SummonHorse:
+			case SpellEffect::SummonHorse:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Summon Mount: %s", spell.teleport_zone);
@@ -1787,7 +1787,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_SummonCorpse:
+			case SpellEffect::SummonCorpse:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Summon Corpse: %d", effect_value);
@@ -1857,13 +1857,13 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					}
 					else {
 						MessageString(Chat::LightBlue, TARGET_NOT_FOUND);
-						LogError("[{}] attempted to cast spell id [{}] with spell effect SE_SummonCorpse, but could not cast target into a Client object", GetCleanName(), spell_id);
+						LogError("[{}] attempted to cast spell id [{}] with spell effect SpellEffect::SummonCorpse, but could not cast target into a Client object", GetCleanName(), spell_id);
 					}
 				}
 
 				break;
 			}
-			case SE_SummonCorpseZone:
+			case SpellEffect::SummonCorpseZone:
 			{
 				if (IsClient()) {
 					Client* client_target = CastToClient();
@@ -1910,13 +1910,13 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 						}
 					} else {
 						MessageString(Chat::Spells, TARGET_NOT_FOUND);
-						LogError("[{}] attempted to cast spell id [{}] with spell effect SE_SummonCorpseZone, but could not cast target into a Client object", GetCleanName(), spell_id);
+						LogError("[{}] attempted to cast spell id [{}] with spell effect SpellEffect::SummonCorpseZone, but could not cast target into a Client object", GetCleanName(), spell_id);
 					}
 				}
 				break;
 			}
-			case SE_AddMeleeProc:
-			case SE_WeaponProc:
+			case SpellEffect::AddMeleeProc:
+			case SpellEffect::WeaponProc:
 			{
 				uint16 proc_id = GetProcID(spell_id, i);
 #ifdef SPELL_EFFECT_SPAM
@@ -1931,7 +1931,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_RangedProc:
+			case SpellEffect::RangedProc:
 			{
 				uint16 procid = GetProcID(spell_id, i);
 #ifdef SPELL_EFFECT_SPAM
@@ -1941,7 +1941,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_DefensiveProc:
+			case SpellEffect::DefensiveProc:
 			{
 				uint16 procid = GetProcID(spell_id, i);
 #ifdef SPELL_EFFECT_SPAM
@@ -1951,7 +1951,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_NegateAttacks:
+			case SpellEffect::NegateAttacks:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Melee Negate Attack Rune: %+i", effect_value);
@@ -1960,7 +1960,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					buffs[buffslot].hit_number = effect_value;
 				break;
 			}
-			case SE_AppraiseLDonChest:
+			case SpellEffect::AppraiseLDonChest:
 			{
 				if(IsNPC())
 				{
@@ -1984,7 +1984,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_DisarmLDoNTrap:
+			case SpellEffect::DisarmLDoNTrap:
 			{
 				if(IsNPC())
 				{
@@ -2008,7 +2008,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_UnlockLDoNChest:
+			case SpellEffect::UnlockLDoNChest:
 			{
 				if(IsNPC())
 				{
@@ -2032,7 +2032,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Lull:
+			case SpellEffect::Lull:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Lull");
@@ -2041,7 +2041,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_PoisonCounter:
+			case SpellEffect::PoisonCounter:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Poison Counter: %+i", effect_value);
@@ -2074,7 +2074,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_DiseaseCounter:
+			case SpellEffect::DiseaseCounter:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Disease Counter: %+i", effect_value);
@@ -2110,7 +2110,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_CurseCounter:
+			case SpellEffect::CurseCounter:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Curse Counter: %+i", effect_value);
@@ -2146,7 +2146,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_CorruptionCounter:
+			case SpellEffect::CorruptionCounter:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Corruption Counter: %+i", effect_value);
@@ -2179,7 +2179,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Destroy:
+			case SpellEffect::Destroy:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Destroy");
@@ -2193,7 +2193,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_TossUp:
+			case SpellEffect::TossUp:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Toss Up: %d", effect_value);
@@ -2204,7 +2204,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_StopRain:
+			case SpellEffect::StopRain:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Stop Rain");
@@ -2215,7 +2215,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Sacrifice:
+			case SpellEffect::Sacrifice:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Sacrifice");
@@ -2227,7 +2227,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_SummonPC:
+			case SpellEffect::SummonPC:
 			{
 				if (!caster) {
 					break;
@@ -2262,7 +2262,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Silence:
+			case SpellEffect::Silence:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Silence");
@@ -2271,7 +2271,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Amnesia:
+			case SpellEffect::Amnesia:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Amnesia");
@@ -2280,7 +2280,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_CallPet:
+			case SpellEffect::CallPet:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Call Pet");
@@ -2296,15 +2296,15 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_StackingCommand_Block:
-			case SE_StackingCommand_Overwrite:
+			case SpellEffect::StackingCommand_Block:
+			case SpellEffect::StackingCommand_Overwrite:
 			{
 				// these are special effects used by the buff stuff
 				break;
 			}
 
 
-			case SE_TemporaryPets: //Dook- swarms and wards:
+			case SpellEffect::TemporaryPets: //Dook- swarms and wards:
 			{
 				if (!caster)
 					break;
@@ -2320,7 +2320,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_FadingMemories:		//Dook- escape etc
+			case SpellEffect::FadingMemories:		//Dook- escape etc
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Fading Memories");
@@ -2373,7 +2373,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Rampage:
+			case SpellEffect::Rampage:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Rampage");
@@ -2391,7 +2391,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_AEMelee:
+			case SpellEffect::AEMelee:
 			{
 				//old aa
 
@@ -2402,7 +2402,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_AETaunt:
+			case SpellEffect::AETaunt:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "AE Taunt");
@@ -2418,7 +2418,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_SkillAttack:
+			case SpellEffect::SkillAttack:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Skill Attack");
@@ -2450,7 +2450,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_WakeTheDead:
+			case SpellEffect::WakeTheDead:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Wake The Dead");
@@ -2470,7 +2470,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_ArmyOfTheDead:
+			case SpellEffect::ArmyOfTheDead:
 			{
 				if (caster && caster->IsClient()) {
 					int dur = spells[spell_id].max_value[i];
@@ -2491,7 +2491,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Doppelganger:
+			case SpellEffect::Doppelganger:
 			{
 				if(caster && caster->IsClient()) {
 					char pet_name[64];
@@ -2503,12 +2503,12 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_BardAEDot:
+			case SpellEffect::BardAEDot:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Bard AE Dot: %+i", effect_value);
 #endif
-				// SE_CurrentHP is calculated at first tick if its a dot/buff
+				// SpellEffect::CurrentHP is calculated at first tick if its a dot/buff
 				if (buffslot >= 0)
 					break;
 				//This effect does no damage if target is moving.
@@ -2541,7 +2541,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_CurrentEndurance: {
+			case SpellEffect::CurrentEndurance: {
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Current Endurance: %+i", effect_value);
 #endif
@@ -2554,7 +2554,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_CurrentEnduranceOnce:
+			case SpellEffect::CurrentEnduranceOnce:
 			{
 #ifdef SPELL_EFFECT_SPAM
 				snprintf(effect_desc, _EDLEN, "Current Endurance Once: %+i", effect_value);
@@ -2569,7 +2569,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_BalanceHP: {
+			case SpellEffect::BalanceHP: {
 				if(!caster)
 					break;
 
@@ -2597,7 +2597,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_BalanceMana: {
+			case SpellEffect::BalanceMana: {
 				if(!caster)
 					break;
 
@@ -2625,7 +2625,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_SummonAndResAllCorpses:
+			case SpellEffect::SummonAndResAllCorpses:
 			{
 				if(IsClient())
 					CastToClient()->SummonAndRezzAllCorpses();
@@ -2633,14 +2633,14 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_GateToHomeCity:
+			case SpellEffect::GateToHomeCity:
 			{
 				if(IsClient())
 					CastToClient()->GoToBind(4);
 				break;
 			}
 
-			case SE_SuspendPet:
+			case SpellEffect::SuspendPet:
 			{
 				if(IsClient())
 					CastToClient()->SuspendMinion(spell.base_value[i]);
@@ -2648,7 +2648,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_FcTimerRefresh:
+			case SpellEffect::FcTimerRefresh:
 			{
 				if(IsClient()) {
 					for (unsigned int i = 0; i < EQ::spells::SPELL_GEM_COUNT; ++i) {
@@ -2667,7 +2667,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_FcTimerLockout: {
+			case SpellEffect::FcTimerLockout: {
 				if (IsClient()) {
 					for (unsigned int mem_spell : CastToClient()->m_pp.mem_spells) {
 						if (IsValidSpell(mem_spell)) {
@@ -2696,7 +2696,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_HealGroupFromMana: {
+			case SpellEffect::HealGroupFromMana: {
 				if(!caster)
 					break;
 
@@ -2740,7 +2740,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_ManaDrainWithDmg:
+			case SpellEffect::ManaDrainWithDmg:
 			{
 				int mana_damage = 0;
 				int32 mana_to_use = GetMana() - spell.base_value[i];
@@ -2759,7 +2759,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_EndDrainWithDmg:
+			case SpellEffect::EndDrainWithDmg:
 			{
 				if(IsClient()) {
 					int end_damage = 0;
@@ -2780,16 +2780,16 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_SetBodyType:
+			case SpellEffect::SetBodyType:
 			{
 				SetBodyType(spell.base_value[i], false);
 				break;
 			}
 
-			case SE_Leap:
+			case SpellEffect::Leap:
 			{
 				// These effects remove lev and only work a certain distance away.
-				BuffFadeByEffect(SE_Levitate);
+				BuffFadeByEffect(SpellEffect::Levitate);
 				if (caster && caster->GetTarget()) {
 					float my_x = caster->GetX();
 					float my_y = caster->GetY();
@@ -2825,7 +2825,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				}
 				break;
 			}
-			case SE_VoiceGraft:
+			case SpellEffect::VoiceGraft:
 			{
 				if(caster && caster->GetPet())
 					caster->spellbonuses.VoiceGraft = caster->GetPetID();
@@ -2833,7 +2833,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_ManaBurn:
+			case SpellEffect::ManaBurn:
 			{
 				int32 max_mana = spell.base_value[i];
 				int ratio = spell.limit_value[i];
@@ -2862,7 +2862,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Taunt:
+			case SpellEffect::Taunt:
 			{
 				if (caster && IsNPC()){
 					caster->Taunt(CastToNPC(), false, spell.base_value[i], true, spell.limit_value[i]);
@@ -2870,26 +2870,26 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_AttackSpeed:
+			case SpellEffect::AttackSpeed:
 				if (spell.base_value[i] < 100)
 					SlowMitigation(caster);
 				break;
 
-			case SE_AttackSpeed2:
+			case SpellEffect::AttackSpeed2:
 				if (spell.base_value[i] < 100)
 					SlowMitigation(caster);
 				break;
 
-			case SE_AttackSpeed3:
+			case SpellEffect::AttackSpeed3:
 				if (spell.base_value[i] < 0)
 					SlowMitigation(caster);
 				break;
 
-			case SE_AttackSpeed4:
+			case SpellEffect::AttackSpeed4:
 				SlowMitigation(caster);
 				break;
 
-			case SE_AddHatePct:
+			case SpellEffect::AddHatePct:
 			{
 				if (IsNPC()){
 					int64 new_hate = CastToNPC()->GetHateAmount(caster) * (100 + spell.base_value[i]) / 100;
@@ -2901,7 +2901,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Hate:{
+			case SpellEffect::Hate:{
 
 				if (buffslot >= 0)
 					break;
@@ -2925,7 +2925,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_InterruptCasting:{
+			case SpellEffect::InterruptCasting:{
 				if (buffslot >= 0)
 					break;
 
@@ -2935,20 +2935,20 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_MassGroupBuff:{
+			case SpellEffect::MassGroupBuff:{
 
 				SetMGB(true);
 				MessageString(Chat::Disciplines, MGB_STRING);
 				break;
 			}
 
-			case SE_IllusionOther: {
+			case SpellEffect::IllusionOther: {
 				SetProjectIllusion(true);
 				Message(Chat::NPCQuestSay, "The power of your next illusion spell will flow to your grouped target in your place.");
 				break;
 			}
 
-			case SE_ApplyEffect: {
+			case SpellEffect::ApplyEffect: {
 
 				if (caster && IsValidSpell(spells[spell_id].limit_value[i])){
 					if(zone->random.Roll(spells[spell_id].base_value[i]))
@@ -2957,7 +2957,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_SpellTrigger: {
+			case SpellEffect::SpellTrigger: {
 
 				if (!spell_trigger_cast_complete) {
 					if (caster && caster->TrySpellTrigger(this, spell_id, i))
@@ -2967,7 +2967,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 			}
 
 
-			case SE_Instant_Mana_Pct: {
+			case SpellEffect::Instant_Mana_Pct: {
 				effect_value = spells[spell_id].base_value[i];
 				int64 amt = std::abs(GetMaxMana() * effect_value / 10000);
 				if (spells[spell_id].max_value[i] && amt > spells[spell_id].max_value[i])
@@ -2982,7 +2982,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Instant_Endurance_Pct: {
+			case SpellEffect::Instant_Endurance_Pct: {
 				effect_value = spells[spell_id].base_value[i];
 				if (IsClient()) {
 					int32 amt = std::abs(CastToClient()->GetMaxEndurance() * effect_value / 10000);
@@ -3002,7 +3002,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				Calc for base1 is found in ApplyHealthTransferDamage() due to needing to account for AOE functionality
 				since effect can potentially kill caster.
 			*/
-			case SE_Health_Transfer: {
+			case SpellEffect::Health_Transfer: {
 				if (caster) {
 					effect_value = spells[spell_id].limit_value[i];
 					int64 amt = std::abs(caster->GetMaxHP() * effect_value / 1000);
@@ -3017,7 +3017,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Chance_Best_in_Spell_Grp: {
+			case SpellEffect::Chance_Best_in_Spell_Grp: {
 				if (!spell_trigger_cast_complete) {
 					if (caster && caster->TrySpellTrigger(this, spell_id, i))
 						spell_trigger_cast_complete = true;
@@ -3025,7 +3025,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Trigger_Best_in_Spell_Grp: {
+			case SpellEffect::Trigger_Best_in_Spell_Grp: {
 
 				if (caster && !caster->IsClient())
 					break;
@@ -3039,7 +3039,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Trigger_Spell_Non_Item: {
+			case SpellEffect::Trigger_Spell_Non_Item: {
 				//Only trigger if not from item
 				if (caster && caster->IsClient() && GetCastedSpellInvSlot() > 0)
 					break;
@@ -3050,19 +3050,19 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Hatelist_To_Tail_Index: {
+			case SpellEffect::Hatelist_To_Tail_Index: {
 				if (caster && zone->random.Roll(spells[spell_id].base_value[i]))
 					caster->SetBottomRampageList();
 				break;
 			}
 
-			case SE_Hatelist_To_Top_Index: {
+			case SpellEffect::Hatelist_To_Top_Index: {
 				if (caster && zone->random.Roll(spells[spell_id].base_value[i]))
 					caster->SetTopRampageList();
 				break;
 			}
 
-			case SE_Fearstun: {
+			case SpellEffect::Fearstun: {
 				//Normal 'stun' restrictions do not apply. base1=duration, base2=PC duration, max =lv restrict
 				if (!caster)
 					break;
@@ -3095,7 +3095,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_PetShield: {
+			case SpellEffect::PetShield: {
 				if (IsPet()) {
 					Mob* petowner = GetOwner();
 					if (petowner) {
@@ -3108,316 +3108,316 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				break;
 			}
 
-			case SE_Weapon_Stance: {
+			case SpellEffect::Weapon_Stance: {
 				if (IsClient()) {
 					CastToClient()->ApplyWeaponsStance();
 				}
 				break;
 			}
 
-			case SE_HealOverTime: {
+			case SpellEffect::HealOverTime: {
 				//This is here so buffs with hit counters tic down on initial cast.
 				caster->GetActSpellHealing(spell_id, effect_value, nullptr, false);
 				break;
 			}
 
-			case SE_PersistentEffect:
+			case SpellEffect::PersistentEffect:
 				MakeAura(spell_id);
 				break;
 
 			// Handled Elsewhere
-			case SE_ImmuneFleeing:
-			case SE_NegateSpellEffect:
-			case SE_Knockdown: // handled by client
-			case SE_ShadowStepDirectional: // handled by client
-			case SE_SpellOnDeath:
-			case SE_BlockNextSpellFocus:
-			case SE_ReduceReuseTimer:
-			case SE_SwarmPetDuration:
-			case SE_LimitHPPercent:
-			case SE_LimitManaPercent:
-			case SE_LimitEndPercent:
-			case SE_ExtraAttackChance:
-			case SE_ProcChance:
-			case SE_StunResist:
-			case SE_MinDamageModifier:
-			case SE_DamageModifier:
-			case SE_DamageModifier2:
-			case SE_HitChance:
-			case SE_MeleeSkillCheck:
-			case SE_HundredHands:
-			case SE_ResistFearChance:
-			case SE_ResistSpellChance:
-			case SE_AllInstrumentMod:
-			case SE_MeleeLifetap:
-			case SE_DoubleAttackChance:
-			case SE_TripleAttackChance:
-			case SE_DualWieldChance:
-			case SE_ParryChance:
-			case SE_DodgeChance:
-			case SE_RiposteChance:
-			case SE_AvoidMeleeChance:
-			case SE_CrippBlowChance:
-			case SE_CriticalHitChance:
-			case SE_MeleeMitigation:
-			case SE_Reflect:
-			case SE_Screech:
-			case SE_Amplification:
-			case SE_MagicWeapon:
-			case SE_Hunger:
-			case SE_MagnifyVision:
-			case SE_Lycanthropy:
-			case SE_NegateIfCombat:
-			case SE_CastingLevel:
-			case SE_CastingLevel2:
-			case SE_RaiseStatCap:
-			case SE_ResistAll:
-			case SE_ResistMagic:
-			case SE_ResistDisease:
-			case SE_ResistPoison:
-			case SE_ResistCold:
-			case SE_ResistFire:
-			case SE_AllStats:
-			case SE_MakeDrunk:
-			case SE_CHA:
-			case SE_WIS:
-			case SE_INT:
-			case SE_STA:
-			case SE_AGI:
-			case SE_DEX:
-			case SE_STR:
-			case SE_ATK:
-			case SE_ArmorClass:
-			case SE_EndurancePool:
-			case SE_Stamina:
-			case SE_UltraVision:
-			case SE_InfraVision:
-			case SE_ManaPool:
-			case SE_TotalHP:
-			case SE_ChangeFrenzyRad:
-			case SE_Harmony:
-			case SE_ChangeAggro:
-			case SE_Identify:
-			case SE_InstantHate:
-			case SE_ReduceHate:
-			case SE_SpellDamageShield:
-			case SE_ReverseDS:
-			case SE_DamageShield:
-			case SE_TrueNorth:
-			case SE_WaterBreathing:
-			case SE_MovementSpeed:
-			case SE_PercentXPIncrease:
-			case SE_DivineSave:
-			case SE_Accuracy:
-			case SE_Flurry:
-			case SE_ImprovedDamage:
-			case SE_ImprovedDamage2:
-			case SE_ImprovedHeal:
-			case SE_IncreaseSpellHaste:
-			case SE_IncreaseSpellDuration:
-			case SE_IncreaseRange:
-			case SE_SpellHateMod:
-			case SE_ReduceReagentCost:
-			case SE_ReduceManaCost:
-			case SE_LimitMaxLevel:
-			case SE_LimitResist:
-			case SE_LimitTarget:
-			case SE_LimitEffect:
-			case SE_LimitSpellType:
-			case SE_LimitSpell:
-			case SE_LimitMinDur:
-			case SE_LimitInstant:
-			case SE_LimitMinLevel:
-			case SE_LimitCastTimeMin:
-			case SE_LimitManaMin:
-			case SE_LimitCombatSkills:
-			case SE_SpellDurationIncByTic:
-			case SE_TriggerOnCast:
-			case SE_HealRate:
-			case SE_SkillDamageTaken:
-			case SE_FcSpellVulnerability:
-			case SE_Fc_Spell_Damage_Pct_IncomingPC:
-			case SE_Fc_Spell_Damage_Amt_IncomingPC:
-			case SE_FcTwincast:
-			case SE_DelayDeath:
-			case SE_CastOnFadeEffect:
-			case SE_CastOnFadeEffectNPC:
-			case SE_CastOnFadeEffectAlways:
-			case SE_CastOnRuneFadeEffect:
-			case SE_MaxHPChange:
-			case SE_SympatheticProc:
-			case SE_FcDamageAmt:
-			case SE_FcDamageAmt2:
-			case SE_CriticalSpellChance:
-			case SE_SpellCritChance:
-			case SE_SpellCritDmgIncrease:
-			case SE_DotCritDmgIncrease:
-			case SE_CriticalHealChance:
-			case SE_CriticalHealOverTime:
-			case SE_CriticalDoTChance:
-			case SE_ProcOnKillShot:
-			case SE_ProcOnSpellKillShot:
-			case SE_CriticalDamageMob:
-			case SE_LimitSpellGroup:
-			case SE_ResistCorruption:
-			case SE_ReduceSkillTimer:
-			case SE_HPToMana:
-			case SE_ManaAbsorbPercentDamage:
-			case SE_SkillDamageAmount:
-			case SE_SkillDamageAmount2:
-			case SE_GravityEffect:
-			case SE_IncreaseBlockChance:
-			case SE_AntiGate:
-			case SE_Fearless:
-			case SE_FcDamageAmtCrit:
-			case SE_FcHealAmtCrit:
-			case SE_CastOnCurer:
-			case SE_CastOnCure:
-			case SE_CastonNumHitFade:
-			case SE_LimitToSkill:
-			case SE_SpellProcChance:
-			case SE_CharmBreakChance:
-			case SE_BardSongRange:
-			case SE_ACv2:
-			case SE_ManaRegen_v2:
-			case SE_FcDamagePctCrit:
-			case SE_FcHealAmt:
-			case SE_FcHealPctIncoming:
-			case SE_CriticalHealDecay:
-			case SE_CriticalRegenDecay:
-			case SE_FcDamageAmtIncoming:
-			case SE_LimitCastingSkill:
-			case SE_MitigateDamageShield:
-			case SE_FcBaseEffects:
-			case SE_LimitClass:
-			case SE_BlockBehind:
-			case SE_ShieldBlock:
-			case SE_PetCriticalHit:
-			case SE_SlayUndead:
-			case SE_GiveDoubleAttack:
-			case SE_StrikeThrough:
-			case SE_StrikeThrough2:
-			case SE_SecondaryDmgInc:
-			case SE_ArcheryDamageModifier:
-			case SE_ConsumeProjectile:
-			case SE_ForageAdditionalItems:
-			case SE_Salvage:
-			case SE_FrontalBackstabChance:
-			case SE_FrontalBackstabMinDmg:
-			case SE_TripleBackstab:
-			case SE_DoubleSpecialAttack:
-			case SE_IncreaseRunSpeedCap:
-			case SE_BaseMovementSpeed:
-			case SE_FrontalStunResist:
-			case SE_ImprovedBindWound:
-			case SE_MaxBindWound:
-			case SE_CombatStability:
-			case SE_AddSingingMod:
-			case SE_SongModCap:
-			case SE_HeadShot:
-			case SE_HeadShotLevel:
-			case SE_PetAvoidance:
-			case SE_GiveDoubleRiposte:
-			case SE_Ambidexterity:
-			case SE_PetMaxHP:
-			case SE_PetFlurry:
-			case SE_MasteryofPast:
-			case SE_GivePetGroupTarget:
-			case SE_RootBreakChance:
-			case SE_UnfailingDivinity:
-			case SE_ChannelChanceSpells:
-			case SE_ChannelChanceItems:
-			case SE_FcHealPctCritIncoming:
-			case SE_FcIncreaseNumHits:
-			case SE_CastonFocusEffect:
-			case SE_FcHealAmtIncoming:
-			case SE_LimitManaMax:
-			case SE_DoubleRangedAttack:
-			case SE_ShieldEquipDmgMod:
-			case SE_TriggerOnReqTarget:
-			case SE_LimitRace:
-			case SE_FcLimitUse:
-			case SE_FcMute:
-			case SE_LimitUseType:
-			case SE_FcStunTimeMod:
-			case SE_StunBashChance:
-			case SE_IncreaseChanceMemwipe:
-			case SE_CriticalMend:
-			case SE_LimitCastTimeMax:
-			case SE_TriggerOnReqCaster:
-			case SE_FrenziedDevastation:
-			case SE_AStacker:
-			case SE_BStacker:
-			case SE_CStacker:
-			case SE_DStacker:
-			case SE_DoubleRiposte:
-			case SE_Berserk:
-			case SE_Vampirism:
-			case SE_Metabolism:
-			case SE_FinishingBlow:
-			case SE_FinishingBlowLvl:
-			case SE_Assassinate:
-			case SE_AssassinateLevel:
-			case SE_FactionModPct:
-			case SE_LimitSpellClass:
-			case SE_Sanctuary:
-			case SE_PetMeleeMitigation:
-			case SE_SkillProcAttempt:
-			case SE_SkillProcSuccess:
-			case SE_SpellResistReduction:
-			case SE_IncreaseArchery:
-			case SE_Duration_HP_Pct:
-			case SE_Duration_Mana_Pct:
-			case SE_Duration_Endurance_Pct:
-			case SE_Endurance_Absorb_Pct_Damage:
-			case SE_AC_Mitigation_Max_Percent:
-			case SE_AC_Avoidance_Max_Percent:
-			case SE_Attack_Accuracy_Max_Percent:
-			case SE_Critical_Melee_Damage_Mod_Max:
-			case SE_Melee_Damage_Position_Mod:
-			case SE_Damage_Taken_Position_Mod:
-			case SE_Melee_Damage_Position_Amt:
-			case SE_Damage_Taken_Position_Amt:
-			case SE_DS_Mitigation_Amount:
-			case SE_DS_Mitigation_Percentage:
-			case SE_Double_Backstab_Front:
-			case SE_Pet_Crit_Melee_Damage_Pct_Owner:
-			case SE_Pet_Add_Atk:
-			case SE_TwinCastBlocker:
-			case SE_Fc_Cast_Spell_On_Land:
-			case SE_Ff_CasterClass:
-			case SE_Ff_Same_Caster:
-			case SE_Fc_ResistIncoming:
-			case SE_Fc_Amplify_Amt:
-			case SE_Fc_Amplify_Mod:
-			case SE_Fc_CastTimeAmt:
-			case SE_Fc_CastTimeMod2:
-			case SE_Ff_DurationMax:
-			case SE_Ff_Endurance_Max:
-			case SE_Ff_Endurance_Min:
-			case SE_Ff_ReuseTimeMin:
-			case SE_Ff_ReuseTimeMax:
-			case SE_Ff_Value_Min:
-			case SE_Ff_Value_Max:
-			case SE_AddExtraAttackPct_1h_Primary:
-			case SE_AddExtraAttackPct_1h_Secondary:
-			case SE_Double_Melee_Round:
-			case SE_Skill_Base_Damage_Mod:
-			case SE_Worn_Endurance_Regen_Cap:
-			case SE_Buy_AA_Rank:
-			case SE_Ff_FocusTimerMin:
-			case SE_Proc_Timer_Modifier:
-			case SE_FFItemClass:
-			case SE_SpellEffectResistChance:
-			case SE_SeeInvis:
-			case SE_Invisibility:
-			case SE_Invisibility2:
-			case SE_InvisVsAnimals:
-			case SE_ImprovedInvisAnimals:
-			case SE_InvisVsUndead:
-			case SE_InvisVsUndead2:
-			case SE_Shield_Target:
-			case SE_ReduceSkill:
+			case SpellEffect::ImmuneFleeing:
+			case SpellEffect::NegateSpellEffect:
+			case SpellEffect::Knockdown: // handled by client
+			case SpellEffect::ShadowStepDirectional: // handled by client
+			case SpellEffect::SpellOnDeath:
+			case SpellEffect::BlockNextSpellFocus:
+			case SpellEffect::ReduceReuseTimer:
+			case SpellEffect::SwarmPetDuration:
+			case SpellEffect::LimitHPPercent:
+			case SpellEffect::LimitManaPercent:
+			case SpellEffect::LimitEndPercent:
+			case SpellEffect::ExtraAttackChance:
+			case SpellEffect::ProcChance:
+			case SpellEffect::StunResist:
+			case SpellEffect::MinDamageModifier:
+			case SpellEffect::DamageModifier:
+			case SpellEffect::DamageModifier2:
+			case SpellEffect::HitChance:
+			case SpellEffect::MeleeSkillCheck:
+			case SpellEffect::HundredHands:
+			case SpellEffect::ResistFearChance:
+			case SpellEffect::ResistSpellChance:
+			case SpellEffect::AllInstrumentMod:
+			case SpellEffect::MeleeLifetap:
+			case SpellEffect::DoubleAttackChance:
+			case SpellEffect::TripleAttackChance:
+			case SpellEffect::DualWieldChance:
+			case SpellEffect::ParryChance:
+			case SpellEffect::DodgeChance:
+			case SpellEffect::RiposteChance:
+			case SpellEffect::AvoidMeleeChance:
+			case SpellEffect::CrippBlowChance:
+			case SpellEffect::CriticalHitChance:
+			case SpellEffect::MeleeMitigation:
+			case SpellEffect::Reflect:
+			case SpellEffect::Screech:
+			case SpellEffect::Amplification:
+			case SpellEffect::MagicWeapon:
+			case SpellEffect::Hunger:
+			case SpellEffect::MagnifyVision:
+			case SpellEffect::Lycanthropy:
+			case SpellEffect::NegateIfCombat:
+			case SpellEffect::CastingLevel:
+			case SpellEffect::CastingLevel2:
+			case SpellEffect::RaiseStatCap:
+			case SpellEffect::ResistAll:
+			case SpellEffect::ResistMagic:
+			case SpellEffect::ResistDisease:
+			case SpellEffect::ResistPoison:
+			case SpellEffect::ResistCold:
+			case SpellEffect::ResistFire:
+			case SpellEffect::AllStats:
+			case SpellEffect::MakeDrunk:
+			case SpellEffect::CHA:
+			case SpellEffect::WIS:
+			case SpellEffect::INT:
+			case SpellEffect::STA:
+			case SpellEffect::AGI:
+			case SpellEffect::DEX:
+			case SpellEffect::STR:
+			case SpellEffect::ATK:
+			case SpellEffect::ArmorClass:
+			case SpellEffect::EndurancePool:
+			case SpellEffect::Stamina:
+			case SpellEffect::UltraVision:
+			case SpellEffect::InfraVision:
+			case SpellEffect::ManaPool:
+			case SpellEffect::TotalHP:
+			case SpellEffect::ChangeFrenzyRad:
+			case SpellEffect::Harmony:
+			case SpellEffect::ChangeAggro:
+			case SpellEffect::Identify:
+			case SpellEffect::InstantHate:
+			case SpellEffect::ReduceHate:
+			case SpellEffect::SpellDamageShield:
+			case SpellEffect::ReverseDS:
+			case SpellEffect::DamageShield:
+			case SpellEffect::TrueNorth:
+			case SpellEffect::WaterBreathing:
+			case SpellEffect::MovementSpeed:
+			case SpellEffect::PercentXPIncrease:
+			case SpellEffect::DivineSave:
+			case SpellEffect::Accuracy:
+			case SpellEffect::Flurry:
+			case SpellEffect::ImprovedDamage:
+			case SpellEffect::ImprovedDamage2:
+			case SpellEffect::ImprovedHeal:
+			case SpellEffect::IncreaseSpellHaste:
+			case SpellEffect::IncreaseSpellDuration:
+			case SpellEffect::IncreaseRange:
+			case SpellEffect::SpellHateMod:
+			case SpellEffect::ReduceReagentCost:
+			case SpellEffect::ReduceManaCost:
+			case SpellEffect::LimitMaxLevel:
+			case SpellEffect::LimitResist:
+			case SpellEffect::LimitTarget:
+			case SpellEffect::LimitEffect:
+			case SpellEffect::LimitSpellType:
+			case SpellEffect::LimitSpell:
+			case SpellEffect::LimitMinDur:
+			case SpellEffect::LimitInstant:
+			case SpellEffect::LimitMinLevel:
+			case SpellEffect::LimitCastTimeMin:
+			case SpellEffect::LimitManaMin:
+			case SpellEffect::LimitCombatSkills:
+			case SpellEffect::SpellDurationIncByTic:
+			case SpellEffect::TriggerOnCast:
+			case SpellEffect::HealRate:
+			case SpellEffect::SkillDamageTaken:
+			case SpellEffect::FcSpellVulnerability:
+			case SpellEffect::Fc_Spell_Damage_Pct_IncomingPC:
+			case SpellEffect::Fc_Spell_Damage_Amt_IncomingPC:
+			case SpellEffect::FcTwincast:
+			case SpellEffect::DelayDeath:
+			case SpellEffect::CastOnFadeEffect:
+			case SpellEffect::CastOnFadeEffectNPC:
+			case SpellEffect::CastOnFadeEffectAlways:
+			case SpellEffect::CastOnRuneFadeEffect:
+			case SpellEffect::MaxHPChange:
+			case SpellEffect::SympatheticProc:
+			case SpellEffect::FcDamageAmt:
+			case SpellEffect::FcDamageAmt2:
+			case SpellEffect::CriticalSpellChance:
+			case SpellEffect::SpellCritChance:
+			case SpellEffect::SpellCritDmgIncrease:
+			case SpellEffect::DotCritDmgIncrease:
+			case SpellEffect::CriticalHealChance:
+			case SpellEffect::CriticalHealOverTime:
+			case SpellEffect::CriticalDoTChance:
+			case SpellEffect::ProcOnKillShot:
+			case SpellEffect::ProcOnSpellKillShot:
+			case SpellEffect::CriticalDamageMob:
+			case SpellEffect::LimitSpellGroup:
+			case SpellEffect::ResistCorruption:
+			case SpellEffect::ReduceSkillTimer:
+			case SpellEffect::HPToMana:
+			case SpellEffect::ManaAbsorbPercentDamage:
+			case SpellEffect::SkillDamageAmount:
+			case SpellEffect::SkillDamageAmount2:
+			case SpellEffect::GravityEffect:
+			case SpellEffect::IncreaseBlockChance:
+			case SpellEffect::AntiGate:
+			case SpellEffect::Fearless:
+			case SpellEffect::FcDamageAmtCrit:
+			case SpellEffect::FcHealAmtCrit:
+			case SpellEffect::CastOnCurer:
+			case SpellEffect::CastOnCure:
+			case SpellEffect::CastonNumHitFade:
+			case SpellEffect::LimitToSkill:
+			case SpellEffect::SpellProcChance:
+			case SpellEffect::CharmBreakChance:
+			case SpellEffect::BardSongRange:
+			case SpellEffect::ACv2:
+			case SpellEffect::ManaRegen_v2:
+			case SpellEffect::FcDamagePctCrit:
+			case SpellEffect::FcHealAmt:
+			case SpellEffect::FcHealPctIncoming:
+			case SpellEffect::CriticalHealDecay:
+			case SpellEffect::CriticalRegenDecay:
+			case SpellEffect::FcDamageAmtIncoming:
+			case SpellEffect::LimitCastingSkill:
+			case SpellEffect::MitigateDamageShield:
+			case SpellEffect::FcBaseEffects:
+			case SpellEffect::LimitClass:
+			case SpellEffect::BlockBehind:
+			case SpellEffect::ShieldBlock:
+			case SpellEffect::PetCriticalHit:
+			case SpellEffect::SlayUndead:
+			case SpellEffect::GiveDoubleAttack:
+			case SpellEffect::StrikeThrough:
+			case SpellEffect::StrikeThrough2:
+			case SpellEffect::SecondaryDmgInc:
+			case SpellEffect::ArcheryDamageModifier:
+			case SpellEffect::ConsumeProjectile:
+			case SpellEffect::ForageAdditionalItems:
+			case SpellEffect::Salvage:
+			case SpellEffect::FrontalBackstabChance:
+			case SpellEffect::FrontalBackstabMinDmg:
+			case SpellEffect::TripleBackstab:
+			case SpellEffect::DoubleSpecialAttack:
+			case SpellEffect::IncreaseRunSpeedCap:
+			case SpellEffect::BaseMovementSpeed:
+			case SpellEffect::FrontalStunResist:
+			case SpellEffect::ImprovedBindWound:
+			case SpellEffect::MaxBindWound:
+			case SpellEffect::CombatStability:
+			case SpellEffect::AddSingingMod:
+			case SpellEffect::SongModCap:
+			case SpellEffect::HeadShot:
+			case SpellEffect::HeadShotLevel:
+			case SpellEffect::PetAvoidance:
+			case SpellEffect::GiveDoubleRiposte:
+			case SpellEffect::Ambidexterity:
+			case SpellEffect::PetMaxHP:
+			case SpellEffect::PetFlurry:
+			case SpellEffect::MasteryofPast:
+			case SpellEffect::GivePetGroupTarget:
+			case SpellEffect::RootBreakChance:
+			case SpellEffect::UnfailingDivinity:
+			case SpellEffect::ChannelChanceSpells:
+			case SpellEffect::ChannelChanceItems:
+			case SpellEffect::FcHealPctCritIncoming:
+			case SpellEffect::FcIncreaseNumHits:
+			case SpellEffect::CastonFocusEffect:
+			case SpellEffect::FcHealAmtIncoming:
+			case SpellEffect::LimitManaMax:
+			case SpellEffect::DoubleRangedAttack:
+			case SpellEffect::ShieldEquipDmgMod:
+			case SpellEffect::TriggerOnReqTarget:
+			case SpellEffect::LimitRace:
+			case SpellEffect::FcLimitUse:
+			case SpellEffect::FcMute:
+			case SpellEffect::LimitUseType:
+			case SpellEffect::FcStunTimeMod:
+			case SpellEffect::StunBashChance:
+			case SpellEffect::IncreaseChanceMemwipe:
+			case SpellEffect::CriticalMend:
+			case SpellEffect::LimitCastTimeMax:
+			case SpellEffect::TriggerOnReqCaster:
+			case SpellEffect::FrenziedDevastation:
+			case SpellEffect::AStacker:
+			case SpellEffect::BStacker:
+			case SpellEffect::CStacker:
+			case SpellEffect::DStacker:
+			case SpellEffect::DoubleRiposte:
+			case SpellEffect::Berserk:
+			case SpellEffect::Vampirism:
+			case SpellEffect::Metabolism:
+			case SpellEffect::FinishingBlow:
+			case SpellEffect::FinishingBlowLvl:
+			case SpellEffect::Assassinate:
+			case SpellEffect::AssassinateLevel:
+			case SpellEffect::FactionModPct:
+			case SpellEffect::LimitSpellClass:
+			case SpellEffect::Sanctuary:
+			case SpellEffect::PetMeleeMitigation:
+			case SpellEffect::SkillProcAttempt:
+			case SpellEffect::SkillProcSuccess:
+			case SpellEffect::SpellResistReduction:
+			case SpellEffect::IncreaseArchery:
+			case SpellEffect::Duration_HP_Pct:
+			case SpellEffect::Duration_Mana_Pct:
+			case SpellEffect::Duration_Endurance_Pct:
+			case SpellEffect::Endurance_Absorb_Pct_Damage:
+			case SpellEffect::AC_Mitigation_Max_Percent:
+			case SpellEffect::AC_Avoidance_Max_Percent:
+			case SpellEffect::Attack_Accuracy_Max_Percent:
+			case SpellEffect::Critical_Melee_Damage_Mod_Max:
+			case SpellEffect::Melee_Damage_Position_Mod:
+			case SpellEffect::Damage_Taken_Position_Mod:
+			case SpellEffect::Melee_Damage_Position_Amt:
+			case SpellEffect::Damage_Taken_Position_Amt:
+			case SpellEffect::DS_Mitigation_Amount:
+			case SpellEffect::DS_Mitigation_Percentage:
+			case SpellEffect::Double_Backstab_Front:
+			case SpellEffect::Pet_Crit_Melee_Damage_Pct_Owner:
+			case SpellEffect::Pet_Add_Atk:
+			case SpellEffect::TwinCastBlocker:
+			case SpellEffect::Fc_Cast_Spell_On_Land:
+			case SpellEffect::Ff_CasterClass:
+			case SpellEffect::Ff_Same_Caster:
+			case SpellEffect::Fc_ResistIncoming:
+			case SpellEffect::Fc_Amplify_Amt:
+			case SpellEffect::Fc_Amplify_Mod:
+			case SpellEffect::Fc_CastTimeAmt:
+			case SpellEffect::Fc_CastTimeMod2:
+			case SpellEffect::Ff_DurationMax:
+			case SpellEffect::Ff_Endurance_Max:
+			case SpellEffect::Ff_Endurance_Min:
+			case SpellEffect::Ff_ReuseTimeMin:
+			case SpellEffect::Ff_ReuseTimeMax:
+			case SpellEffect::Ff_Value_Min:
+			case SpellEffect::Ff_Value_Max:
+			case SpellEffect::AddExtraAttackPct_1h_Primary:
+			case SpellEffect::AddExtraAttackPct_1h_Secondary:
+			case SpellEffect::Double_Melee_Round:
+			case SpellEffect::Skill_Base_Damage_Mod:
+			case SpellEffect::Worn_Endurance_Regen_Cap:
+			case SpellEffect::Buy_AA_Rank:
+			case SpellEffect::Ff_FocusTimerMin:
+			case SpellEffect::Proc_Timer_Modifier:
+			case SpellEffect::FFItemClass:
+			case SpellEffect::SpellEffectResistChance:
+			case SpellEffect::SeeInvis:
+			case SpellEffect::Invisibility:
+			case SpellEffect::Invisibility2:
+			case SpellEffect::InvisVsAnimals:
+			case SpellEffect::ImprovedInvisAnimals:
+			case SpellEffect::InvisVsUndead:
+			case SpellEffect::InvisVsUndead2:
+			case SpellEffect::Shield_Target:
+			case SpellEffect::ReduceSkill:
 			{
 				break;
 			}
@@ -3474,7 +3474,7 @@ int64 Mob::CalcSpellEffectValue(uint16 spell_id, int effect_id, int caster_level
 				oval, instrument_mod, effect_value);
 	}
 	/*
-		SPA 413 SE_FcBaseEffects, modifies base value of a spell effect after formula calcultion, but before other focuses.
+		SPA 413 SpellEffect::FcBaseEffects, modifies base value of a spell effect after formula calcultion, but before other focuses.
 		This is applied to non-Bards in Mob::GetInstrumentMod
 		Like bard modifiers, this is sent in the action_struct using action->instrument_mod (which is a base effect modifier)
 
@@ -3936,7 +3936,7 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 		// doing it every time up here, since most buff effects dont need it
 
 		switch (effect) {
-		case SE_CurrentHP: {
+		case SpellEffect::CurrentHP: {
 			if (spells[buff.spellid].limit_value[i] && !PassCastRestriction(spells[buff.spellid].limit_value[i])) {
 				break;
 			}
@@ -3967,7 +3967,7 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 			}
 			break;
 		}
-		case SE_HealOverTime: {
+		case SpellEffect::HealOverTime: {
 			effect_value = CalcSpellEffectValue(buff.spellid, i, buff.casterlevel, buff.instrument_mod);
 			if (caster) {
 				effect_value = caster->GetActSpellHealing(buff.spellid, effect_value, nullptr, true);
@@ -3978,12 +3978,12 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 			break;
 		}
 
-		case SE_CurrentEndurance: {
+		case SpellEffect::CurrentEndurance: {
 			// Handled with bonuses
 			break;
 		}
 
-		case SE_BardAEDot: {
+		case SpellEffect::BardAEDot: {
 			effect_value =
 			    CalcSpellEffectValue(buff.spellid, i, buff.casterlevel, buff.instrument_mod, caster);
 
@@ -4008,7 +4008,7 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 			break;
 		}
 
-		case SE_Hate: {
+		case SpellEffect::Hate: {
 			effect_value = CalcSpellEffectValue(buff.spellid, i, buff.casterlevel, buff.instrument_mod);
 			if (caster) {
 				if (effect_value > 0) {
@@ -4030,7 +4030,7 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 			break;
 		}
 
-		case SE_WipeHateList: {
+		case SpellEffect::WipeHateList: {
 			if (IsMesmerizeSpell(buff.spellid)) {
 				break;
 			}
@@ -4051,9 +4051,9 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 			break;
 		}
 
-		case SE_Charm: {
+		case SpellEffect::Charm: {
 			if (!caster || !PassCharismaCheck(caster, buff.spellid)) {
-				BuffFadeByEffect(SE_Charm);
+				BuffFadeByEffect(SpellEffect::Charm);
 
 				// Remove from hate list of any NPC's hate list and remove all NPCs this hate list
 				if (IsNPC()) {
@@ -4065,7 +4065,7 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 			break;
 		}
 
-		case SE_Root: {
+		case SpellEffect::Root: {
 			/* Root formula derived from extensive personal live parses - Kayen
 			ROOT has a 70% chance to do a resist check to break.
 			*/
@@ -4083,7 +4083,7 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 			break;
 		}
 
-		case SE_Fear: {
+		case SpellEffect::Fear: {
 			if (zone->random.Roll(RuleI(Spells, FearBreakCheckChance))) {
 				float resist_check = ResistSpell(spells[buff.spellid].resist_type, buff.spellid, caster,0,0,true);
 
@@ -4096,9 +4096,9 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 			break;
 		}
 
-		case SE_Invisibility:
-		case SE_InvisVsAnimals:
-		case SE_InvisVsUndead: {
+		case SpellEffect::Invisibility:
+		case SpellEffect::InvisVsAnimals:
+		case SpellEffect::InvisVsUndead: {
 			if (buff.ticsremaining > 3) {
 				if (!IsBardSong(buff.spellid)) {
 					double break_chance = 2.0;
@@ -4119,9 +4119,9 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 				}
 			}
 		}
-		case SE_ImprovedInvisAnimals:
-		case SE_Invisibility2:
-		case SE_InvisVsUndead2: {
+		case SpellEffect::ImprovedInvisAnimals:
+		case SpellEffect::Invisibility2:
+		case SpellEffect::InvisVsUndead2: {
 			if (!IsBardSong(buff.spellid)) {
 				if (buff.ticsremaining <= 3 && buff.ticsremaining > 1) {
 					MessageString(Chat::Spells, INVIS_BEGIN_BREAK);
@@ -4129,7 +4129,7 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 			}
 			break;
 		}
-		case SE_InterruptCasting: {
+		case SpellEffect::InterruptCasting: {
 			if (IsCasting()) {
 				const auto &spell = spells[casting_spell_id];
 				if (!IsCastNotStandingSpell(spell.id) && zone->random.Roll(spells[buff.spellid].base_value[i])) {
@@ -4140,22 +4140,22 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 		}
 		// These effects always trigger when they fade.
 		// Should we have this triggered from else where?
-		case SE_CastOnFadeEffect:
-		case SE_CastOnFadeEffectNPC:
-		case SE_CastOnFadeEffectAlways: {
+		case SpellEffect::CastOnFadeEffect:
+		case SpellEffect::CastOnFadeEffectNPC:
+		case SpellEffect::CastOnFadeEffectAlways: {
 			if (buff.ticsremaining == 0) {
 				SpellFinished(spells[buff.spellid].base_value[i], this, EQ::spells::CastingSlot::Item, 0, -1, spells[spells[buff.spellid].base_value[i]].resist_difficulty);
 			}
 			break;
 		}
-		case SE_LocateCorpse: {
+		case SpellEffect::LocateCorpse: {
 			// This is handled by the client prior to SoD.
 
 			if (IsClient() && (CastToClient()->ClientVersionBit() & EQ::versions::maskSoDAndLater))
 				CastToClient()->LocateCorpse();
 		}
 
-		case SE_DistanceRemoval: {
+		case SpellEffect::DistanceRemoval: {
 			if (spellbonuses.DistanceRemoval) {
 
 				int distance =
@@ -4172,7 +4172,7 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 			}
 		}
 
-		case SE_AddHateOverTimePct: {
+		case SpellEffect::AddHateOverTimePct: {
 			if (IsNPC()) {
 				int64 new_hate = CastToNPC()->GetHateAmount(caster) * (100 + spell.base_value[i]) / 100;
 				if (new_hate <= 0)
@@ -4183,7 +4183,7 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 			break;
 		}
 
-		case SE_Duration_HP_Pct: {
+		case SpellEffect::Duration_HP_Pct: {
 			effect_value = spells[buff.spellid].base_value[i];
 			int64 amt = std::abs(GetMaxHP() * effect_value / 100);
 			if (spells[buff.spellid].max_value[i] && amt > spells[buff.spellid].max_value[i])
@@ -4198,7 +4198,7 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 			break;
 		}
 
-		case SE_Duration_Mana_Pct: {
+		case SpellEffect::Duration_Mana_Pct: {
 			effect_value = spells[buff.spellid].base_value[i];
 			int32 amt = std::abs(GetMaxMana() * effect_value / 100);
 			if (spells[buff.spellid].max_value[i] && amt > spells[buff.spellid].max_value[i])
@@ -4214,7 +4214,7 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 			break;
 		}
 
-		case SE_Duration_Endurance_Pct: {
+		case SpellEffect::Duration_Endurance_Pct: {
 			effect_value = spells[buff.spellid].base_value[i];
 
 			if (IsClient())	{
@@ -4302,8 +4302,8 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 
 		switch (spells[buffs[slot].spellid].effect_id[i])
 		{
-			case SE_AddMeleeProc:
-			case SE_WeaponProc:
+			case SpellEffect::AddMeleeProc:
+			case SpellEffect::WeaponProc:
 			{
 				uint16 proc_id = GetProcID(buffs[slot].spellid, i);
 
@@ -4316,21 +4316,21 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 				break;
 			}
 
-			case SE_DefensiveProc:
+			case SpellEffect::DefensiveProc:
 			{
 				uint16 procid = GetProcID(buffs[slot].spellid, i);
 				RemoveDefensiveProc(procid);
 				break;
 			}
 
-			case SE_RangedProc:
+			case SpellEffect::RangedProc:
 			{
 				uint16 procid = GetProcID(buffs[slot].spellid, i);
 				RemoveRangedProc(procid);
 				break;
 			}
 
-			case SE_SummonHorse:
+			case SpellEffect::SummonHorse:
 			{
 				if(IsClient())
 				{
@@ -4342,8 +4342,8 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 				break;
 			}
 
-			case SE_IllusionCopy:
-			case SE_Illusion:
+			case SpellEffect::IllusionCopy:
+			case SpellEffect::Illusion:
 			{
 				SendIllusionPacket(
 					AppearanceStruct{
@@ -4361,44 +4361,44 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 				break;
 			}
 
-			case SE_Levitate:
+			case SpellEffect::Levitate:
 			{
-				if (!AffectedBySpellExcludingSlot(slot, SE_Levitate))
+				if (!AffectedBySpellExcludingSlot(slot, SpellEffect::Levitate))
 					SendAppearancePacket(AppearanceType::FlyMode, 0);
 				break;
 			}
 
-			case SE_Silence:
+			case SpellEffect::Silence:
 			{
 				Silence(false);
 				break;
 			}
 
-			case SE_Amnesia:
+			case SpellEffect::Amnesia:
 			{
 				Amnesia(false);
 				break;
 			}
 
-			case SE_DivineAura:
+			case SpellEffect::DivineAura:
 			{
 				SetInvul(false);
 				break;
 			}
 
-			case SE_Rune:
+			case SpellEffect::Rune:
 			{
 				buffs[slot].melee_rune = 0;
 				break;
 			}
 
-			case SE_AbsorbMagicAtt:
+			case SpellEffect::AbsorbMagicAtt:
 			{
 				buffs[slot].magic_rune = 0;
 				break;
 			}
 
-			case SE_Familiar:
+			case SpellEffect::Familiar:
 			{
 				Mob *mypet = GetPet();
 				if (mypet){
@@ -4409,14 +4409,14 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 				break;
 			}
 
-			case SE_Mez:
+			case SpellEffect::Mez:
 			{
 				SendAppearancePacket(AppearanceType::Animation, Animation::Standing);	// unfreeze
 				mezzed = false;
 				break;
 			}
 
-			case SE_Charm:
+			case SpellEffect::Charm:
 			{
 				if(IsNPC())
 				{
@@ -4461,7 +4461,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 								for (unsigned int j = 0; j < buff_count; j++) {
 									if (IsValidSpell(tar->GetBuffs()[j].spellid)) {
 										auto spell = spells[tar->GetBuffs()[j].spellid];
-										if (spell.good_effect == DETRIMENTAL_EFFECT && IsEffectInSpell(spell.id, SE_CurrentHP) && tar->GetBuffs()[j].casterid == GetID()) {
+										if (spell.good_effect == DETRIMENTAL_EFFECT && IsEffectInSpell(spell.id, SpellEffect::CurrentHP) && tar->GetBuffs()[j].casterid == GetID()) {
 											tar->BuffFadeBySpellID(spell.id);
 										}
 									}
@@ -4475,7 +4475,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 						for (unsigned int j = 0; j < buff_count; j++) {
 							if (IsValidSpell(GetBuffs()[j].spellid )) {
 								auto spell = spells[GetBuffs()[j].spellid];
-								if (spell.good_effect == DETRIMENTAL_EFFECT && IsEffectInSpell(spell.id, SE_CurrentHP)) {
+								if (spell.good_effect == DETRIMENTAL_EFFECT && IsEffectInSpell(spell.id, SpellEffect::CurrentHP)) {
 									BuffFadeBySpellID(spell.id);
 								}
 							}
@@ -4530,7 +4530,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 						CastToClient()->AI_Start(CLIENT_LD_TIMEOUT);
 					else
 					{
-						bool feared = FindType(SE_Fear);
+						bool feared = FindType(SpellEffect::Fear);
 						if(!feared)
 							CastToClient()->AI_Stop();
 					}
@@ -4538,24 +4538,24 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 				break;
 			}
 
-			case SE_Root:
+			case SpellEffect::Root:
 			{
 				buffs[slot].RootBreakChance = 0;
 				rooted = false;
 				break;
 			}
 
-			case SE_Blind:
-				if (currently_fleeing && !FindType(SE_Fear))
+			case SpellEffect::Blind:
+				if (currently_fleeing && !FindType(SpellEffect::Fear))
 					currently_fleeing = false;
 				break;
 
-			case SE_Fear:
+			case SpellEffect::Fear:
 			{
 				if(RuleB(Combat, EnableFearPathing)){
 					if(IsClient())
 					{
-						bool charmed = FindType(SE_Charm);
+						bool charmed = FindType(SpellEffect::Charm);
 						if(!charmed)
 							CastToClient()->AI_Stop();
 					}
@@ -4572,7 +4572,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 				break;
 			}
 
-			case SE_ImmuneFleeing: {
+			case SpellEffect::ImmuneFleeing: {
 				if (RuleB(Combat, EnableFearPathing)) {
 					if (flee_mode) {
 						currently_fleeing = true;
@@ -4582,7 +4582,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 				break;
 			}
 
-			case SE_BindSight:
+			case SpellEffect::BindSight:
 			{
 				if(IsClient())
 				{
@@ -4591,20 +4591,20 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 				break;
 			}
 
-			case SE_SetBodyType:
+			case SpellEffect::SetBodyType:
 			{
 				SetBodyType(GetOrigBodyType(), false);
 				break;
 			}
 
-			case SE_AlterNPCLevel:
+			case SpellEffect::AlterNPCLevel:
 			{
 				if (IsNPC())
 					SetLevel(GetOrigLevel());
 				break;
 			}
 
-			case SE_EyeOfZomm:
+			case SpellEffect::EyeOfZomm:
 			{
 				if (IsClient())
 				{
@@ -4621,7 +4621,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 				break;
 			}
 
-			case SE_Weapon_Stance:
+			case SpellEffect::Weapon_Stance:
 			{
 				/*
 					If we click off the spell buff (or fades naturally) giving us
@@ -4735,15 +4735,15 @@ int64 Mob::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 	bool LimitInclude[MaxLimitInclude] = {false};
 	/* Certain limits require only one of several Include conditions to be true. Ie. Add damage to fire OR ice
 	spells.
-	0/1   SE_LimitResist
-	2/3   SE_LimitSpell
-	4/5   SE_LimitEffect
-	6/7   SE_LimitTarget
-	8/9   SE_LimitSpellGroup:
-	10/11 SE_LimitCastingSkill:
-	12/13 SE_LimitSpellClass:
-	14/15 SE_LimitSpellSubClass:
-	16/17 SE_FFItemCLass:
+	0/1 SpellEffect::_LimitResist
+	2/3 SpellEffect::_LimitSpell
+	4/5 SpellEffect::_LimitEffect
+	6/7 SpellEffect::_LimitTarget
+	8/9 SpellEffect::_LimitSpellGroup:
+	10/11 SpellEffect::LimitCastingSkill:
+	12/13 SpellEffect::LimitSpellClass:
+	14/15 SpellEffect::LimitSpellSubClass:
+	16/17 SpellEffect::FFItemCLass:
 	Remember: Update MaxLimitInclude in spdat.h if adding new limits that require Includes
 	*/
 
@@ -4789,11 +4789,11 @@ int64 Mob::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 		}
 
 		switch (effect) {
-			case SE_Blank:
+			case SpellEffect::Blank:
 				break;
 
 			// Handle Focus Limits
-			case SE_LimitResist:
+			case SpellEffect::LimitResist:
 				if (base_value < 0) {
 					if (spell.resist_type == -base_value) { // Exclude
 						LimitFailure = true;
@@ -4807,7 +4807,7 @@ int64 Mob::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 				}
 				break;
 
-			case SE_LimitInstant:
+			case SpellEffect::LimitInstant:
 				if (base_value == 1 && spell.buff_duration) { // Fail if not instant
 					LimitFailure = true;
 				}
@@ -4817,7 +4817,7 @@ int64 Mob::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 
 				break;
 
-			case SE_LimitMaxLevel:
+			case SpellEffect::LimitMaxLevel:
 				spell_level = spell.classes[(GetClass() % 17) - 1];
 				lvldiff     = spell_level - base_value;
 				// every level over cap reduces the effect by base2 percent unless from a clicky when
@@ -4835,25 +4835,25 @@ int64 Mob::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 				}
 				break;
 
-			case SE_LimitMinLevel:
+			case SpellEffect::LimitMinLevel:
 				if ((spell.classes[(GetClass() % 17) - 1]) < base_value) {
 					LimitFailure = true;
 				}
 				break;
 
-			case SE_LimitCastTimeMin:
+			case SpellEffect::LimitCastTimeMin:
 				if (static_cast<int32>(spell.cast_time) < base_value) {
 					LimitFailure = true;
 				}
 				break;
 
-			case SE_LimitCastTimeMax:
+			case SpellEffect::LimitCastTimeMax:
 				if (static_cast<int32>(spell.cast_time) > base_value) {
 					LimitFailure = true;
 				}
 				break;
 
-			case SE_LimitSpell:
+			case SpellEffect::LimitSpell:
 				if (base_value < 0) { // Exclude
 					if (spell_id == -base_value) {
 						LimitFailure = true;
@@ -4867,13 +4867,13 @@ int64 Mob::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 				}
 				break;
 
-			case SE_LimitMinDur:
+			case SpellEffect::LimitMinDur:
 				if (base_value > CalcBuffDuration_formula(GetLevel(), spell.buff_duration_formula, spell.buff_duration)) {
 					LimitFailure = true;
 				}
 				break;
 
-			case SE_LimitEffect:
+			case SpellEffect::LimitEffect:
 				if (base_value < 0) {
 					if (IsEffectInSpell(spell_id, -base_value)) { // Exclude
 						LimitFailure = true;
@@ -4882,7 +4882,7 @@ int64 Mob::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 				else {
 					LimitInclude[IncludeExistsSELimitEffect] = true;
 					// they use 33 here for all classes ... unsure if the type check is really needed
-					if (base_value == SE_SummonPet && type == focusReagentCost) {
+					if (base_value == SpellEffect::SummonPet && type == focusReagentCost) {
 						if (IsPetSpell(spell_id)) {
 							LimitInclude[IncludeFoundSELimitEffect] = true;
 						}
@@ -4895,7 +4895,7 @@ int64 Mob::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 				}
 				break;
 
-			case SE_LimitSpellType:
+			case SpellEffect::LimitSpellType:
 				switch (base_value) {
 					case 0:
 						if (!IsDetrimentalSpell(spell_id)) {
@@ -4910,19 +4910,19 @@ int64 Mob::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 				}
 				break;
 
-			case SE_LimitManaMin:
+			case SpellEffect::LimitManaMin:
 				if (spell.mana < base_value) {
 					LimitFailure = true;
 				}
 				break;
 
-			case SE_LimitManaMax:
+			case SpellEffect::LimitManaMax:
 				if (spell.mana > base_value) {
 					LimitFailure = true;
 				}
 				break;
 
-			case SE_LimitTarget:
+			case SpellEffect::LimitTarget:
 				if (base_value < 0) {
 					if (-base_value == spell.target_type) { // Exclude
 						LimitFailure = true;
@@ -4936,7 +4936,7 @@ int64 Mob::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 				}
 				break;
 
-			case SE_LimitCombatSkills:
+			case SpellEffect::LimitCombatSkills:
 				if (base_value == 0 && (IsCombatSkill(spell_id) || IsCombatProc(spell_id))) { // Exclude Discs / Procs
 					LimitFailure = true;
 				}
@@ -4946,7 +4946,7 @@ int64 Mob::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 
 				break;
 
-			case SE_LimitSpellGroup:
+			case SpellEffect::LimitSpellGroup:
 				if (base_value < 0) {
 					if (-base_value == spell.spell_group) { // Exclude
 						LimitFailure = true;
@@ -4960,7 +4960,7 @@ int64 Mob::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 				}
 				break;
 
-			case SE_LimitCastingSkill:
+			case SpellEffect::LimitCastingSkill:
 				if (base_value < 0) {
 					if (-base_value == spell.skill) {
 						LimitFailure = true;
@@ -4974,7 +4974,7 @@ int64 Mob::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 				}
 				break;
 
-			case SE_LimitSpellClass:
+			case SpellEffect::LimitSpellClass:
 				if (base_value < 0) { // Exclude
 					if (-base_value == spell.spell_class) {
 						LimitFailure = true;
@@ -4988,7 +4988,7 @@ int64 Mob::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 				}
 				break;
 
-			case SE_LimitSpellSubclass:
+			case SpellEffect::LimitSpellSubclass:
 				if (base_value < 0) { // Exclude
 					if (-base_value == spell.spell_subclass) {
 						LimitFailure = true;
@@ -5002,7 +5002,7 @@ int64 Mob::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 				}
 				break;
 
-			case SE_LimitClass:
+			case SpellEffect::LimitClass:
 				// Do not use this limit more then once per spell. If multiple class, treat value like items
 				// would.
 				if (!PassLimitClass(base_value, GetClass())) {
@@ -5010,75 +5010,75 @@ int64 Mob::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 				}
 				break;
 
-			case SE_LimitRace:
+			case SpellEffect::LimitRace:
 				if (base_value != GetRace()) {
 					LimitFailure = true;
 				}
 				break;
 
-			case SE_LimitUseMin:
+			case SpellEffect::LimitUseMin:
 				if (base_value > spell.hit_number) {
 					LimitFailure = true;
 				}
 				break;
 
-			case SE_LimitUseType:
+			case SpellEffect::LimitUseType:
 				if (base_value != spell.hit_number_type) {
 					LimitFailure = true;
 				}
 				break;
 
-			case SE_Ff_DurationMax:
+			case SpellEffect::Ff_DurationMax:
 				if (base_value > spell.buff_duration) {
 					LimitFailure = true;
 				}
 				break;
 
-			case SE_Ff_Endurance_Min:
+			case SpellEffect::Ff_Endurance_Min:
 				if (spell.endurance_cost < base_value) {
 					LimitFailure = true;
 				}
 				break;
 
-			case SE_Ff_Endurance_Max:
+			case SpellEffect::Ff_Endurance_Max:
 				if (spell.endurance_cost > base_value) {
 					LimitFailure = true;
 				}
 				break;
 
-			case SE_Ff_ReuseTimeMin:
+			case SpellEffect::Ff_ReuseTimeMin:
 				if (spell.recast_time < base_value) {
 					LimitFailure = true;
 				}
 				break;
 
-			case SE_Ff_ReuseTimeMax:
+			case SpellEffect::Ff_ReuseTimeMax:
 				if (spell.recast_time > base_value) {
 					LimitFailure = true;
 				}
 				break;
 
-			case SE_Ff_Value_Min:
+			case SpellEffect::Ff_Value_Min:
 				index_id = GetSpellEffectIndex(spell_id, limit_value);
 				if (index_id >= 0 && spell.base_value[index_id] < base_value) {
 					LimitFailure = true;
 				}
 				break;
 
-			case SE_Ff_Value_Max:
+			case SpellEffect::Ff_Value_Max:
 				index_id = GetSpellEffectIndex(spell_id, limit_value);
 				if (index_id >= 0 && spell.base_value[index_id] > base_value) {
 					LimitFailure = true;
 				}
 				break;
 
-			case SE_Ff_Override_NotFocusable:
+			case SpellEffect::Ff_Override_NotFocusable:
 				if (base_value == 1) {
 					not_focusable = false;
 				}
 				break;
 
-			case SE_Ff_FocusTimerMin:
+			case SpellEffect::Ff_FocusTimerMin:
 				if (IsFocusProcLimitTimerActive(-rank.id)) {
 					LimitFailure = true;
 				}
@@ -5087,7 +5087,7 @@ int64 Mob::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 				}
 				break;
 
-			case SE_FFItemClass:
+			case SpellEffect::FFItemClass:
 				has_item_limit_check = true;
 				if (casting_spell_inventory_slot && casting_spell_inventory_slot != -1) {
 					if (IsClient() && casting_spell_slot == EQ::spells::CastingSlot::Item && casting_spell_inventory_slot != 0xFFFFFFFF) {
@@ -5143,111 +5143,111 @@ int64 Mob::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 				break;
 
 				/* These are not applicable to AA's because there is never a 'caster' of the 'buff' with the focus effect.
-				case SE_Ff_Same_Caster:
-				case SE_Ff_CasterClass:
+				case SpellEffect::Ff_Same_Caster:
+				case SpellEffect::Ff_CasterClass:
 				*/
 
 				// Handle Focus Effects
-			case SE_ImprovedDamage:
+			case SpellEffect::ImprovedDamage:
 				if (type == focusImprovedDamage && base_value > value) {
 					value = base_value;
 				}
 				break;
 
-			case SE_ImprovedDamage2:
+			case SpellEffect::ImprovedDamage2:
 				if (type == focusImprovedDamage2 && base_value > value) {
 					value = base_value;
 				}
 				break;
 
-			case SE_Fc_Amplify_Mod:
+			case SpellEffect::Fc_Amplify_Mod:
 				if (type == focusFcAmplifyMod && base_value > value) {
 					value = base_value;
 				}
 				break;
 
-			case SE_ImprovedHeal:
+			case SpellEffect::ImprovedHeal:
 				if (type == focusImprovedHeal && base_value > value) {
 					value = base_value;
 				}
 				break;
 
-			case SE_ReduceManaCost:
+			case SpellEffect::ReduceManaCost:
 				if (type == focusManaCost) {
 					value = base_value;
 				}
 				break;
 
-			case SE_IncreaseSpellHaste:
+			case SpellEffect::IncreaseSpellHaste:
 				if (type == focusSpellHaste && base_value > value) {
 					value = base_value;
 					try_apply_to_item_click = is_from_item_click ? true : false;
 				}
 				break;
 
-			case SE_Fc_CastTimeMod2:
+			case SpellEffect::Fc_CastTimeMod2:
 				if (type == focusFcCastTimeMod2 && base_value > value) {
 					value = base_value;
 					try_apply_to_item_click = is_from_item_click ? true : false;
 				}
 				break;
 
-			case SE_Fc_CastTimeAmt:
+			case SpellEffect::Fc_CastTimeAmt:
 				if (type == focusFcCastTimeAmt && base_value > value) {
 					value = base_value;
 					try_apply_to_item_click = is_from_item_click ? true : false;
 				}
 				break;
 
-			case SE_IncreaseSpellDuration:
+			case SpellEffect::IncreaseSpellDuration:
 				if (type == focusSpellDuration && base_value > value) {
 					value = base_value;
 				}
 				break;
 
-			case SE_SpellDurationIncByTic:
+			case SpellEffect::SpellDurationIncByTic:
 				if (type == focusSpellDurByTic && base_value > value) {
 					value = base_value;
 				}
 				break;
 
-			case SE_SwarmPetDuration:
+			case SpellEffect::SwarmPetDuration:
 				if (type == focusSwarmPetDuration && base_value > value) {
 					value = base_value;
 				}
 				break;
 
-			case SE_IncreaseRange:
+			case SpellEffect::IncreaseRange:
 				if (type == focusRange && base_value > value) {
 					value = base_value;
 				}
 				break;
 
-			case SE_ReduceReagentCost:
+			case SpellEffect::ReduceReagentCost:
 				if (type == focusReagentCost && base_value > value) {
 					value = base_value;
 				}
 				break;
 
-			case SE_PetPowerIncrease:
+			case SpellEffect::PetPowerIncrease:
 				if (type == focusPetPower && base_value > value) {
 					value = base_value;
 				}
 				break;
 
-			case SE_SpellResistReduction:
+			case SpellEffect::SpellResistReduction:
 				if (type == focusResistRate && base_value > value) {
 					value = base_value;
 				}
 				break;
 
-			case SE_Fc_ResistIncoming:
+			case SpellEffect::Fc_ResistIncoming:
 				if (type == focusFcResistIncoming && base_value > value) {
 					value = base_value;
 				}
 				break;
 
-			case SE_SpellHateMod:
+			case SpellEffect::SpellHateMod:
 				if (type == focusSpellHateMod) {
 					if (value != 0) {
 						if (value > 0) {
@@ -5267,14 +5267,14 @@ int64 Mob::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 				}
 				break;
 
-			case SE_ReduceReuseTimer:
+			case SpellEffect::ReduceReuseTimer:
 				if (type == focusReduceRecastTime) {
 					value = base_value / 1000;
 					try_apply_to_item_click = is_from_item_click ? true : false;
 				}
 				break;
 
-			case SE_TriggerOnCast:
+			case SpellEffect::TriggerOnCast:
 				if (type == focusTriggerOnCast) {
 					if (zone->random.Roll(base_value)) {
 						value = limit_value;
@@ -5286,19 +5286,19 @@ int64 Mob::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 				}
 				break;
 
-			case SE_FcSpellVulnerability:
+			case SpellEffect::FcSpellVulnerability:
 				if (type == focusSpellVulnerability) {
 					value = base_value;
 				}
 				break;
 
-			case SE_Fc_Spell_Damage_Pct_IncomingPC:
+			case SpellEffect::Fc_Spell_Damage_Pct_IncomingPC:
 				if (type == focusFcSpellDamagePctIncomingPC) {
 					value = base_value;
 				}
 				break;
 
-			case SE_BlockNextSpellFocus:
+			case SpellEffect::BlockNextSpellFocus:
 				if (type == focusBlockNextSpell) {
 					if (zone->random.Roll(base_value)) {
 						value = 1;
@@ -5306,122 +5306,122 @@ int64 Mob::CalcAAFocus(focusType type, const AA::Rank &rank, uint16 spell_id)
 				}
 				break;
 
-			case SE_FcTwincast:
-				if (type == focusTwincast && !IsEffectInSpell(spell_id, SE_TwinCastBlocker)) {
+			case SpellEffect::FcTwincast:
+				if (type == focusTwincast && !IsEffectInSpell(spell_id, SpellEffect::TwinCastBlocker)) {
 					value = base_value;
 				}
 				break;
 
 				// Note if using these as AA, make sure this is first focus used.
-			case SE_SympatheticProc:
+			case SpellEffect::SympatheticProc:
 				if (type == focusSympatheticProc) {
 					value = limit_value;
 				}
 				break;
 
-			case SE_FcDamageAmt:
+			case SpellEffect::FcDamageAmt:
 				if (type == focusFcDamageAmt) {
 					value = base_value;
 				}
 				break;
 
-			case SE_FcDamageAmt2:
+			case SpellEffect::FcDamageAmt2:
 				if (type == focusFcDamageAmt2) {
 					value = base_value;
 				}
 				break;
 
-			case SE_Fc_Amplify_Amt:
+			case SpellEffect::Fc_Amplify_Amt:
 				if (type == focusFcAmplifyAmt) {
 					value = base_value;
 				}
 				break;
 
-			case SE_FcDamageAmtCrit:
+			case SpellEffect::FcDamageAmtCrit:
 				if (type == focusFcDamageAmtCrit) {
 					value = base_value;
 				}
 				break;
 
-			case SE_FcDamageAmtIncoming:
+			case SpellEffect::FcDamageAmtIncoming:
 				if (type == focusFcDamageAmtIncoming) {
 					value = base_value;
 				}
 				break;
 
-			case SE_Fc_Spell_Damage_Amt_IncomingPC:
+			case SpellEffect::Fc_Spell_Damage_Amt_IncomingPC:
 				if (type == focusFcSpellDamageAmtIncomingPC) {
 					value = base_value;
 				}
 				break;
 
-			case SE_FcHealAmtIncoming:
+			case SpellEffect::FcHealAmtIncoming:
 				if (type == focusFcHealAmtIncoming) {
 					value = base_value;
 				}
 				break;
 
-			case SE_FcHealPctCritIncoming:
+			case SpellEffect::FcHealPctCritIncoming:
 				if (type == focusFcHealPctCritIncoming) {
 					value = base_value;
 				}
 				break;
 
-			case SE_FcHealAmtCrit:
+			case SpellEffect::FcHealAmtCrit:
 				if (type == focusFcHealAmtCrit) {
 					value = base_value;
 				}
 				break;
 
-			case SE_FcHealAmt:
+			case SpellEffect::FcHealAmt:
 				if (type == focusFcHealAmt) {
 					value = base_value;
 				}
 				break;
 
-			case SE_FcHealPctIncoming:
+			case SpellEffect::FcHealPctIncoming:
 				if (type == focusFcHealPctIncoming) {
 					value = base_value;
 				}
 				break;
 
-			case SE_FcBaseEffects:
+			case SpellEffect::FcBaseEffects:
 				if (type == focusFcBaseEffects) {
 					value = base_value;
 				}
 				break;
 
-			case SE_FcDamagePctCrit:
+			case SpellEffect::FcDamagePctCrit:
 				if (type == focusFcDamagePctCrit) {
 					value = base_value;
 				}
 				break;
 
-			case SE_FcIncreaseNumHits:
+			case SpellEffect::FcIncreaseNumHits:
 				if (type == focusIncreaseNumHits) {
 					value = base_value;
 				}
 				break;
 
-			case SE_FcLimitUse:
+			case SpellEffect::FcLimitUse:
 				if (type == focusFcLimitUse) {
 					value = base_value;
 				}
 				break;
 
-			case SE_FcMute:
+			case SpellEffect::FcMute:
 				if (type == focusFcMute) {
 					value = base_value;
 				}
 				break;
 
-			case SE_FcStunTimeMod:
+			case SpellEffect::FcStunTimeMod:
 				if (type == focusFcStunTimeMod) {
 					value = base_value;
 				}
 				break;
 
-			case SE_Fc_Cast_Spell_On_Land:
+			case SpellEffect::Fc_Cast_Spell_On_Land:
 				if (type == focusFcCastSpellOnLand) {
 					if (zone->random.Roll(base_value)) {
 						value = limit_value;
@@ -5469,7 +5469,7 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 	}
 
 	// No further checks if spell_id no_focusable, unless spell focus_id contains an override limiter.
-	if (spells[spell_id].not_focusable && !IsEffectInSpell(focus_id, SE_Ff_Override_NotFocusable)) {
+	if (spells[spell_id].not_focusable && !IsEffectInSpell(focus_id, SpellEffect::Ff_Override_NotFocusable)) {
 		return 0;
 	}
 
@@ -5497,15 +5497,15 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 	/* Certain limits require only one of several Include conditions to be true. Determined by limits being negative or positive
 	Ie. Add damage to fire OR ice spells. If positive we 'Include', by checking each limit of same type to look for match until found. Opposed to
 	just 'Excluding', where if set to negative, if we find that match then focus fails, ie Add damage to all spells BUT Fire.
-	0/1   SE_LimitResist
-	2/3   SE_LimitSpell
-	4/5   SE_LimitEffect
-	6/7   SE_LimitTarget
-	8/9   SE_LimitSpellGroup:
-	10/11 SE_LimitCastingSkill:
-	12/13 SE_LimitSpellClass:
-	14/15 SE_LimitSpellSubClass:
-	16/17 SE_FFItemCLass:
+	0/1 SpellEffect::_LimitResist
+	2/3 SpellEffect::_LimitSpell
+	4/5 SpellEffect::_LimitEffect
+	6/7 SpellEffect::_LimitTarget
+	8/9 SpellEffect::_LimitSpellGroup:
+	10/11 SpellEffect::LimitCastingSkill:
+	12/13 SpellEffect::LimitSpellClass:
+	14/15 SpellEffect::LimitSpellSubClass:
+	16/17 SpellEffect::FFItemCLass:
 	Remember: Update MaxLimitInclude in spdat.h if adding new limits that require Includes
 	*/
 
@@ -5513,10 +5513,10 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 
 		switch (focus_spell.effect_id[i]) {
 
-			case SE_Blank:
+			case SpellEffect::Blank:
 				break;
 
-			case SE_LimitResist:
+			case SpellEffect::LimitResist:
 				if (focus_spell.base_value[i] < 0) {
 					if (spell.resist_type == -focus_spell.base_value[i]) { // Exclude
 						return 0;
@@ -5530,7 +5530,7 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				}
 				break;
 
-			case SE_LimitInstant:
+			case SpellEffect::LimitInstant:
 				if (focus_spell.base_value[i] == 1 && spell.buff_duration) { // Fail if not instant
 					return 0;
 				}
@@ -5540,7 +5540,7 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 
 				break;
 
-			case SE_LimitMaxLevel:
+			case SpellEffect::LimitMaxLevel:
 				if (IsNPC()) {
 					break;
 				}
@@ -5562,7 +5562,7 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				}
 				break;
 
-			case SE_LimitMinLevel:
+			case SpellEffect::LimitMinLevel:
 				if (IsNPC()) {
 					break;
 				}
@@ -5571,19 +5571,19 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				}
 				break;
 
-			case SE_LimitCastTimeMin:
+			case SpellEffect::LimitCastTimeMin:
 				if (spells[spell_id].cast_time < (uint16) focus_spell.base_value[i]) {
 					return (0);
 				}
 				break;
 
-			case SE_LimitCastTimeMax:
+			case SpellEffect::LimitCastTimeMax:
 				if (spells[spell_id].cast_time > (uint16) focus_spell.base_value[i]) {
 					return (0);
 				}
 				break;
 
-			case SE_LimitSpell:
+			case SpellEffect::LimitSpell:
 				if (focus_spell.base_value[i] < 0) { // Exclude
 					if (spell_id == -focus_spell.base_value[i]) {
 						return (0);
@@ -5597,14 +5597,14 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				}
 				break;
 
-			case SE_LimitMinDur:
+			case SpellEffect::LimitMinDur:
 				if (focus_spell.base_value[i] >
 					CalcBuffDuration_formula(GetLevel(), spell.buff_duration_formula, spell.buff_duration)) {
 					return (0);
 				}
 				break;
 
-			case SE_LimitEffect:
+			case SpellEffect::LimitEffect:
 				if (focus_spell.base_value[i] < 0) {
 					if (IsEffectInSpell(spell_id, -focus_spell.base_value[i])) { // Exclude
 						return 0;
@@ -5618,7 +5618,7 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				}
 				break;
 
-			case SE_LimitSpellType:
+			case SpellEffect::LimitSpellType:
 				switch (focus_spell.base_value[i]) {
 					case 0:
 						if (!IsDetrimentalSpell(spell_id)) {
@@ -5636,19 +5636,19 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				}
 				break;
 
-			case SE_LimitManaMin:
+			case SpellEffect::LimitManaMin:
 				if (spell.mana < focus_spell.base_value[i]) {
 					return 0;
 				}
 				break;
 
-			case SE_LimitManaMax:
+			case SpellEffect::LimitManaMax:
 				if (spell.mana > focus_spell.base_value[i]) {
 					return 0;
 				}
 				break;
 
-			case SE_LimitTarget:
+			case SpellEffect::LimitTarget:
 				if (focus_spell.base_value[i] < 0) {
 					if (-focus_spell.base_value[i] == spell.target_type) { // Exclude
 						return 0;
@@ -5662,7 +5662,7 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				}
 				break;
 
-			case SE_LimitCombatSkills:
+			case SpellEffect::LimitCombatSkills:
 				if (focus_spell.base_value[i] == 0 &&
 					(IsCombatSkill(spell_id) || IsCombatProc(spell_id))) { // Exclude Discs / Procs
 					return 0;
@@ -5673,7 +5673,7 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 
 				break;
 
-			case SE_LimitSpellGroup:
+			case SpellEffect::LimitSpellGroup:
 				if (focus_spell.base_value[i] < 0) {
 					if (-focus_spell.base_value[i] == spell.spell_group) { // Exclude
 						return 0;
@@ -5687,7 +5687,7 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				}
 				break;
 
-			case SE_LimitCastingSkill:
+			case SpellEffect::LimitCastingSkill:
 				if (focus_spell.base_value[i] < 0) {
 					if (-focus_spell.base_value[i] == spell.skill) {
 						return 0;
@@ -5701,7 +5701,7 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				}
 				break;
 
-			case SE_LimitClass:
+			case SpellEffect::LimitClass:
 				// Do not use this limit more then once per spell. If multiple class, treat value like items
 				// would.
 				if (!PassLimitClass(focus_spell.base_value[i], GetClass())) {
@@ -5709,31 +5709,31 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				}
 				break;
 
-			case SE_LimitRace:
+			case SpellEffect::LimitRace:
 				if (focus_spell.base_value[i] != GetRace()) {
 					return 0;
 				}
 				break;
 
-			case SE_LimitUseMin:
+			case SpellEffect::LimitUseMin:
 				if (focus_spell.base_value[i] > spell.hit_number) {
 					return 0;
 				}
 				break;
 
-			case SE_LimitUseType:
+			case SpellEffect::LimitUseType:
 				if (focus_spell.base_value[i] != spell.hit_number_type) {
 					return 0;
 				}
 				break;
 
-			case SE_CastonFocusEffect:
+			case SpellEffect::CastonFocusEffect:
 				if (focus_spell.base_value[i] > 0) {
 					Caston_spell_id = focus_spell.base_value[i];
 				}
 				break;
 
-			case SE_LimitSpellClass:
+			case SpellEffect::LimitSpellClass:
 				if (focus_spell.base_value[i] < 0) { // Exclude
 					if (-focus_spell.base_value[i] == spell.spell_class) {
 						return 0;
@@ -5747,7 +5747,7 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				}
 				break;
 
-			case SE_LimitSpellSubclass:
+			case SpellEffect::LimitSpellSubclass:
 				if (focus_spell.base_value[i] < 0) { // Exclude
 					if (-focus_spell.base_value[i] == spell.spell_subclass) {
 						return 0;
@@ -5761,7 +5761,7 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				}
 				break;
 
-			case SE_Ff_Same_Caster://hmm do i need to pass casterid from buff slot here
+			case SpellEffect::Ff_Same_Caster://hmm do i need to pass casterid from buff slot here
 				if (focus_spell.base_value[i] == 0) {
 					if (caster && casterid == caster->GetID()) {
 						return 0;
@@ -5774,7 +5774,7 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				}
 				break;
 
-			case SE_Ff_CasterClass: {
+			case SpellEffect::Ff_CasterClass: {
 
 				// Do not use this limit more then once per spell. If multiple class, treat value like items would.
 				if (caster && !PassLimitClass(focus_spell.base_value[i], caster->GetClass())) {
@@ -5783,51 +5783,51 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				break;
 			}
 
-			case SE_Ff_DurationMax:
+			case SpellEffect::Ff_DurationMax:
 				if (focus_spell.base_value[i] > spell.buff_duration) {
 					return 0;
 				}
 				break;
 
-			case SE_Ff_Endurance_Min:
+			case SpellEffect::Ff_Endurance_Min:
 				if (spell.endurance_cost < focus_spell.base_value[i]) {
 					return 0;
 				}
 				break;
 
-			case SE_Ff_Endurance_Max:
+			case SpellEffect::Ff_Endurance_Max:
 				if (spell.endurance_cost > focus_spell.base_value[i]) {
 					return 0;
 				}
 				break;
 
-			case SE_Ff_ReuseTimeMin:
+			case SpellEffect::Ff_ReuseTimeMin:
 				if (spell.recast_time < focus_spell.base_value[i]) {
 					return 0;
 				}
 				break;
 
-			case SE_Ff_ReuseTimeMax:
+			case SpellEffect::Ff_ReuseTimeMax:
 				if (spell.recast_time > focus_spell.base_value[i]) {
 					return 0;
 				}
 				break;
 
-			case SE_Ff_Value_Min:
+			case SpellEffect::Ff_Value_Min:
 				index_id = GetSpellEffectIndex(spell_id, focus_spell.limit_value[i]);
 				if (index_id >= 0 && spell.base_value[index_id] < focus_spell.base_value[i]) {
 					return 0;
 				}
 				break;
 
-			case SE_Ff_Value_Max:
+			case SpellEffect::Ff_Value_Max:
 				index_id = GetSpellEffectIndex(spell_id, focus_spell.limit_value[i]);
 				if (index_id >= 0 && spell.base_value[index_id] > focus_spell.base_value[i]) {
 					return 0;
 				}
 				break;
 
-			case SE_Ff_FocusTimerMin:
+			case SpellEffect::Ff_FocusTimerMin:
 				if (IsFocusProcLimitTimerActive(focus_spell.id)) {
 					return 0;
 				}
@@ -5836,7 +5836,7 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				}
 				break;
 
-			case SE_FFItemClass:
+			case SpellEffect::FFItemClass:
 
 				/*
 					Limits focuses to check if cast from item clicks. Can be used to INCLUDE or EXCLUDE items by ItemType and/or SubType and/or Slots
@@ -5927,8 +5927,8 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				break;
 
 			// handle effects
-			case SE_ImprovedDamage:
-			case SE_ImprovedDamage2:
+			case SpellEffect::ImprovedDamage:
+			case SpellEffect::ImprovedDamage2:
 				if (!RuleB(Spells, UseClassicSpellFocus)) {
 					if (type == focusImprovedDamage || type == focusImprovedDamage2) {
 						value = GetFocusRandomEffectivenessValue(focus_spell.base_value[i], focus_spell.limit_value[i], best_focus);
@@ -5942,14 +5942,14 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 					}
 				}
 
-			case SE_Fc_Amplify_Mod:
+			case SpellEffect::Fc_Amplify_Mod:
 				if (type == focusFcAmplifyMod && focus_spell.base_value[i] > value) {
 					value = focus_spell.base_value[i];
 				}
 				break;
 
-			case SE_ImprovedHeal:
-			case SE_ReduceManaCost:
+			case SpellEffect::ImprovedHeal:
+			case SpellEffect::ReduceManaCost:
 				if (!RuleB(Spells, UseClassicSpellFocus)) {
 					if (type == focusImprovedHeal || type == focusManaCost) {
 						value = GetFocusRandomEffectivenessValue(focus_spell.base_value[i], focus_spell.limit_value[i], best_focus);
@@ -5964,52 +5964,52 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				}
 				break;
 
-			case SE_IncreaseSpellHaste:
+			case SpellEffect::IncreaseSpellHaste:
 				if (type == focusSpellHaste && focus_spell.base_value[i] > value) {
 					value = focus_spell.base_value[i];
 					try_apply_to_item_click = is_from_item_click ? true : false;
 				}
 				break;
 
-			case SE_Fc_CastTimeMod2:
+			case SpellEffect::Fc_CastTimeMod2:
 				if (type == focusFcCastTimeMod2 && focus_spell.base_value[i] > value) {
 					value = focus_spell.base_value[i];
 					try_apply_to_item_click = is_from_item_click ? true : false;
 				}
 				break;
 
-			case SE_Fc_CastTimeAmt:
+			case SpellEffect::Fc_CastTimeAmt:
 				if (type == focusFcCastTimeAmt && focus_spell.base_value[i] > value) {
 					value = focus_spell.base_value[i];
 					try_apply_to_item_click = is_from_item_click ? true : false;
 				}
 				break;
 
-			case SE_IncreaseSpellDuration:
+			case SpellEffect::IncreaseSpellDuration:
 				if (type == focusSpellDuration && focus_spell.base_value[i] > value) {
 					value = focus_spell.base_value[i];
 				}
 				break;
 
-			case SE_SpellDurationIncByTic:
+			case SpellEffect::SpellDurationIncByTic:
 				if (type == focusSpellDurByTic && focus_spell.base_value[i] > value) {
 					value = focus_spell.base_value[i];
 				}
 				break;
 
-			case SE_SwarmPetDuration:
+			case SpellEffect::SwarmPetDuration:
 				if (type == focusSwarmPetDuration && focus_spell.base_value[i] > value) {
 					value = focus_spell.base_value[i];
 				}
 				break;
 
-			case SE_IncreaseRange:
+			case SpellEffect::IncreaseRange:
 				if (type == focusRange && focus_spell.base_value[i] > value) {
 					value = focus_spell.base_value[i];
 				}
 				break;
 
-			case SE_ReduceReagentCost:
+			case SpellEffect::ReduceReagentCost:
 				if (!RuleB(Spells, UseClassicSpellFocus)) {
 					if (type == focusReagentCost) {
 						value = GetFocusRandomEffectivenessValue(focus_spell.base_value[i], focus_spell.limit_value[i], best_focus);
@@ -6022,25 +6022,25 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				}
 				break;
 
-			case SE_PetPowerIncrease:
+			case SpellEffect::PetPowerIncrease:
 				if (type == focusPetPower && focus_spell.base_value[i] > value) {
 					value = focus_spell.base_value[i];
 				}
 				break;
 
-			case SE_SpellResistReduction:
+			case SpellEffect::SpellResistReduction:
 				if (type == focusResistRate) {
 					value = GetFocusRandomEffectivenessValue(focus_spell.base_value[i], focus_spell.limit_value[i], best_focus);
 				}
 				break;
 
-			case SE_Fc_ResistIncoming:
+			case SpellEffect::Fc_ResistIncoming:
 				if (type == focusFcResistIncoming && focus_spell.base_value[i] > value) {
 					value = focus_spell.base_value[i];
 				}
 				break;
 
-			case SE_SpellHateMod:
+			case SpellEffect::SpellHateMod:
 				if (!RuleB(Spells, UseClassicSpellFocus)) {
 					if (type == focusSpellHateMod) {
 						value = GetFocusRandomEffectivenessValue(focus_spell.base_value[i], focus_spell.limit_value[i], best_focus);
@@ -6057,14 +6057,14 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				}
 				break;
 
-			case SE_ReduceReuseTimer:
+			case SpellEffect::ReduceReuseTimer:
 				if (type == focusReduceRecastTime) {
 					value = focus_spell.base_value[i] / 1000;
 					try_apply_to_item_click = is_from_item_click ? true : false;
 				}
 				break;
 
-			case SE_TriggerOnCast:
+			case SpellEffect::TriggerOnCast:
 				if (type == focusTriggerOnCast) {
 					if (zone->random.Roll(focus_spell.base_value[i])) {
 						value = focus_spell.limit_value[i];
@@ -6075,7 +6075,7 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				}
 				break;
 
-			case SE_BlockNextSpellFocus:
+			case SpellEffect::BlockNextSpellFocus:
 				if (type == focusBlockNextSpell) {
 					if (zone->random.Roll(focus_spell.base_value[i])) {
 						value = 1;
@@ -6083,145 +6083,145 @@ int64 Mob::CalcFocusEffect(focusType type, uint16 focus_id, uint16 spell_id, boo
 				}
 				break;
 
-			case SE_SympatheticProc:
+			case SpellEffect::SympatheticProc:
 				if (type == focusSympatheticProc) {
 					value = focus_id;
 				}
 				break;
 
-			case SE_FcSpellVulnerability:
+			case SpellEffect::FcSpellVulnerability:
 				if (type == focusSpellVulnerability) {
 					value = GetFocusRandomEffectivenessValue(focus_spell.base_value[i], focus_spell.limit_value[i], best_focus);
 				}
 				break;
 
-			case SE_Fc_Spell_Damage_Pct_IncomingPC:
+			case SpellEffect::Fc_Spell_Damage_Pct_IncomingPC:
 				if (type == focusFcSpellDamagePctIncomingPC) {
 					value = GetFocusRandomEffectivenessValue(focus_spell.base_value[i], focus_spell.limit_value[i], best_focus);
 				}
 				break;
 
-			case SE_FcTwincast:
-				if (type == focusTwincast && !IsEffectInSpell(spell_id, SE_TwinCastBlocker)) {
+			case SpellEffect::FcTwincast:
+				if (type == focusTwincast && !IsEffectInSpell(spell_id, SpellEffect::TwinCastBlocker)) {
 					value = focus_spell.base_value[i];
 				}
 				break;
 
-			case SE_FcDamageAmt:
+			case SpellEffect::FcDamageAmt:
 				if (type == focusFcDamageAmt) {
 					value = focus_spell.base_value[i];
 				}
 				break;
 
-			case SE_FcDamageAmt2:
+			case SpellEffect::FcDamageAmt2:
 				if (type == focusFcDamageAmt2) {
 					value = focus_spell.base_value[i];
 				}
 				break;
 
-			case SE_Fc_Amplify_Amt:
+			case SpellEffect::Fc_Amplify_Amt:
 				if (type == focusFcAmplifyAmt) {
 					value = focus_spell.base_value[i];
 				}
 				break;
 
-			case SE_FcDamageAmtCrit:
+			case SpellEffect::FcDamageAmtCrit:
 				if (type == focusFcDamageAmtCrit) {
 					value = focus_spell.base_value[i];
 				}
 				break;
 
-			case SE_FcDamageAmtIncoming:
+			case SpellEffect::FcDamageAmtIncoming:
 				if (type == focusFcDamageAmtIncoming) {
 					value = focus_spell.base_value[i];
 				}
 				break;
 
-			case SE_Fc_Spell_Damage_Amt_IncomingPC:
+			case SpellEffect::Fc_Spell_Damage_Amt_IncomingPC:
 				if (type == focusFcSpellDamageAmtIncomingPC) {
 					value = focus_spell.base_value[i];
 				}
 				break;
 
-			case SE_FcHealAmtIncoming:
+			case SpellEffect::FcHealAmtIncoming:
 				if (type == focusFcHealAmtIncoming) {
 					value = focus_spell.base_value[i];
 				}
 				break;
 
-			case SE_FcDamagePctCrit:
+			case SpellEffect::FcDamagePctCrit:
 				if (type == focusFcDamagePctCrit) {
 					value = focus_spell.base_value[i];
 				}
 				break;
 
-			case SE_FcHealPctCritIncoming:
+			case SpellEffect::FcHealPctCritIncoming:
 				if (type == focusFcHealPctCritIncoming) {
 					value = GetFocusRandomEffectivenessValue(focus_spell.base_value[i], focus_spell.limit_value[i], best_focus);
 				}
 				break;
 
-			case SE_FcHealAmtCrit:
+			case SpellEffect::FcHealAmtCrit:
 				if (type == focusFcHealAmtCrit) {
 					value = focus_spell.base_value[i];
 				}
 				break;
 
-			case SE_FcHealAmt:
+			case SpellEffect::FcHealAmt:
 				if (type == focusFcHealAmt) {
 					value = focus_spell.base_value[i];
 				}
 				break;
 
-			case SE_FcHealPctIncoming:
+			case SpellEffect::FcHealPctIncoming:
 				if (type == focusFcHealPctIncoming) {
 					value = GetFocusRandomEffectivenessValue(focus_spell.base_value[i], focus_spell.limit_value[i], best_focus);
 				}
 				break;
 
-			case SE_FcBaseEffects:
+			case SpellEffect::FcBaseEffects:
 				if (type == focusFcBaseEffects) {
 					value = focus_spell.base_value[i];
 				}
 				break;
 
-			case SE_FcIncreaseNumHits:
+			case SpellEffect::FcIncreaseNumHits:
 				if (type == focusIncreaseNumHits) {
 					value = focus_spell.base_value[i];
 				}
 				break;
 
-			case SE_FcLimitUse:
+			case SpellEffect::FcLimitUse:
 				if (type == focusFcLimitUse) {
 					value = focus_spell.base_value[i];
 				}
 				break;
 
-			case SE_FcMute:
+			case SpellEffect::FcMute:
 				if (type == focusFcMute) {
 					value = focus_spell.base_value[i];
 				}
 				break;
 
-			case SE_FcStunTimeMod:
+			case SpellEffect::FcStunTimeMod:
 				if (type == focusFcStunTimeMod) {
 					value = focus_spell.base_value[i];
 				}
 				break;
 
-			case SE_FcTimerRefresh:
+			case SpellEffect::FcTimerRefresh:
 				if (type == focusFcTimerRefresh) {
 					value = focus_spell.base_value[i];
 				}
 				break;
 
-			case SE_FcTimerLockout:
+			case SpellEffect::FcTimerLockout:
 				if (type == focusFcTimerLockout) {
 					value = focus_spell.base_value[i];
 				}
 				break;
 
-			case SE_Fc_Cast_Spell_On_Land:
+			case SpellEffect::Fc_Cast_Spell_On_Land:
 				if (type == focusFcCastSpellOnLand) {
 					if (zone->random.Roll(focus_spell.base_value[i])) {
 						value = focus_spell.limit_value[i];
@@ -6300,7 +6300,7 @@ void Mob::TryTriggerOnCastFocusEffect(focusType type, uint16 spell_id)
 			temp_item = ins->GetItem();
 			if (temp_item && temp_item->Focus.Effect > 0 && IsValidSpell(temp_item->Focus.Effect)) {
 				focus_spell_id = temp_item->Focus.Effect;
-				if (!IsEffectInSpell(focus_spell_id, SE_TriggerOnCast)) {
+				if (!IsEffectInSpell(focus_spell_id, SpellEffect::TriggerOnCast)) {
 					continue;
 				}
 
@@ -6317,7 +6317,7 @@ void Mob::TryTriggerOnCastFocusEffect(focusType type, uint16 spell_id)
 					if (temp_item_aug && temp_item_aug->Focus.Effect > 0 && IsValidSpell(temp_item_aug->Focus.Effect)) {
 						focus_spell_id = temp_item_aug->Focus.Effect;
 
-						if (!IsEffectInSpell(focus_spell_id, SE_TriggerOnCast)) {
+						if (!IsEffectInSpell(focus_spell_id, SpellEffect::TriggerOnCast)) {
 							continue;
 						}
 
@@ -6340,7 +6340,7 @@ void Mob::TryTriggerOnCastFocusEffect(focusType type, uint16 spell_id)
 				continue;
 			}
 
-			if (!IsEffectInSpell(focus_spell_id, SE_TriggerOnCast)) {
+			if (!IsEffectInSpell(focus_spell_id, SpellEffect::TriggerOnCast)) {
 				continue;
 			}
 
@@ -6831,7 +6831,7 @@ int64 Mob::GetFocusEffect(focusType type, uint16 spell_id, Mob *caster, bool fro
 		}
 	}
 
-	if (type == focusReagentCost && (IsEffectInSpell(spell_id, SE_SummonItem) || IsSacrificeSpell(spell_id))) {
+	if (type == focusReagentCost && (IsEffectInSpell(spell_id, SpellEffect::SummonItem) || IsSacrificeSpell(spell_id))) {
 		return 0;
 	}
 	//Summon Spells that require reagents are typically imbue type spells, enchant metal, sacrifice and shouldn't be affected
@@ -7022,7 +7022,7 @@ void Mob::CheckNumHitsRemaining(NumHit type, int32 buff_slot, uint16 spell_id)
 	3:  [Incoming Spells]  (180=SE_ResistSpellChance, 296=SE_FcSpellVulnerability) //Note: Determinetal spells only unless proven otherwise
 	4:  [Outgoing Spells]
 	5:  [Outgoing Hit Successes] (220=SE_SkillDamageAmount, 178=SE_MeleeLifetap, 121=SE_ReverseDS, ?373=SE_CastOnFadeEffectAlways)
-	6:  [Incoming Hit Successes] (59=SE_DamageShield, 197=SE_SkillDamageTaken, 162=define SE_MitigateMeleeDamage)
+	6:  [Incoming Hit Successes] (59=SE_DamageShield, 197=SE_SkillDamageTaken, 162=define SpellEffect::MitigateMeleeDamage)
 	7:  [Matching Spells] *When focus is triggered (focus effects)
 	8:  [Incoming Hits or Spells] (329=SE_ManaAbsorbPercentDamage)
 	9:  [Reflected Spells] If successful
@@ -7164,8 +7164,8 @@ bool Mob::TryDivineSave()
 			spellbonuses.DivineSaveChance[SBIndex::DIVINE_SAVE_SPELL_TRIGGER_ID]
 		};
 		//Fade the divine save effect here after saving the old effects off.
-		//That way, if desired, the effect could apply SE_DivineSave again.
-		BuffFadeByEffect(SE_DivineSave);
+		//That way, if desired, the effect could apply SpellEffect::DivineSave again.
+		BuffFadeByEffect(SpellEffect::DivineSave);
 		for(size_t i = 0; i < ( sizeof(EffectsToTry) / sizeof(EffectsToTry[0]) ); ++i)
 		{
 			if( EffectsToTry[i] )
@@ -7193,7 +7193,7 @@ bool Mob::TryDeathSave() {
 	 the a value of a heal modifier of the base effects heal.
 	 Ie. Divine Intervention is 8000 HP Max UD1=20, therefore heal is 8000*20/100
 	-No evidence of chance rate increasing between UD1-3, numbers indicate it uses same CHA rate as first DI.
-	-In later expansions this SE_DeathSave was given a level limit and a heal value in its effect data.
+	-In later expansions this SpellEffect::DeathSave was given a level limit and a heal value in its effect data.
 	*/
 
 	if (spellbonuses.DeathSave[SBIndex::DEATH_SAVE_TYPE]){
@@ -7337,7 +7337,7 @@ float Mob::GetSympatheticProcChances(uint16 spell_id, int16 ProcRateMod, int32 I
 int16 Mob::GetSympatheticSpellProcRate(uint16 spell_id)
 {
 	for (int i = 0; i < EFFECT_COUNT; i++){
-		if (spells[spell_id].effect_id[i] == SE_SympatheticProc)
+		if (spells[spell_id].effect_id[i] == SpellEffect::SympatheticProc)
 			return spells[spell_id].base_value[i];
 	}
 
@@ -7347,7 +7347,7 @@ int16 Mob::GetSympatheticSpellProcRate(uint16 spell_id)
 uint16 Mob::GetSympatheticSpellProcID(uint16 spell_id)
 {
 	for (int i = 0; i < EFFECT_COUNT; i++){
-		if (spells[spell_id].effect_id[i] == SE_SympatheticProc)
+		if (spells[spell_id].effect_id[i] == SpellEffect::SympatheticProc)
 			return spells[spell_id].limit_value[i];
 	}
 
@@ -7372,8 +7372,8 @@ int64 Mob::GetFcDamageAmtIncoming(Mob *caster, int32 spell_id, bool from_buff_ti
 {
 	//THIS is target of spell cast
 	int64 dmg = 0;
-	dmg += GetFocusEffect(focusFcDamageAmtIncoming, spell_id, caster, from_buff_tic); //SPA 297 SE_FcDamageAmtIncoming
-	dmg += GetFocusEffect(focusFcSpellDamageAmtIncomingPC, spell_id, caster, from_buff_tic); //SPA 484 SE_Fc_Spell_Damage_Amt_IncomingPC
+	dmg += GetFocusEffect(focusFcDamageAmtIncoming, spell_id, caster, from_buff_tic); //SPA 297 SpellEffect::FcDamageAmtIncoming
+	dmg += GetFocusEffect(focusFcSpellDamageAmtIncomingPC, spell_id, caster, from_buff_tic); //SPA 484 SpellEffect::Fc_Spell_Damage_Amt_IncomingPC
 	return dmg;
 }
 
@@ -7433,8 +7433,8 @@ int64 Mob::GetFocusIncoming(focusType type, int effect, Mob *caster, uint32 spel
 
 bool Mob::PassLimitClass(uint32 Classes_, uint16 Class_)
 {
-	//The class value for SE_LimitClass is +1 to its equivelent value in item dbase
-	//Example Bard on items is '128' while Bard on SE_LimitClass is '256', keep this in mind if making custom spells.
+	//The class value for SpellEffect::LimitClass is +1 to its equivelent value in item dbase
+	//Example Bard on items is '128' while Bard on SpellEffect::LimitClass is '256', keep this in mind if making custom spells.
 	if (Class_ > 16)
 		return false;
 
@@ -7486,7 +7486,7 @@ bool Mob::TrySpellEffectResist(uint16 spell_id)
 
 	for(int i = 0; i < EFFECT_COUNT; ++i)
 	{
-		if (spells[spell_id].effect_id[i] == SE_Blank) {
+		if (spells[spell_id].effect_id[i] == SpellEffect::Blank) {
 			continue;
 		}
 
@@ -8286,7 +8286,7 @@ bool Mob::PassCastRestriction(int value)
 		case HAS_NO_MANA_BURN_BUFF: {
 			bool has_effect = false;
 			for (int i = 0; i < GetMaxTotalSlots(); i++) {
-				if (IsValidSpell(buffs[i].spellid) && IsEffectInSpell(buffs[i].spellid, SE_ManaBurn)) {
+				if (IsValidSpell(buffs[i].spellid) && IsEffectInSpell(buffs[i].spellid, SpellEffect::ManaBurn)) {
 					has_effect = true;
 				}
 			}
@@ -9737,7 +9737,7 @@ void Mob::ResourceTap(int64 damage, uint16 spellid)
 		return;
 
 	for (int i = 0; i < EFFECT_COUNT; i++) {
-		if (spells[spellid].effect_id[i] == SE_ResourceTap) {
+		if (spells[spellid].effect_id[i] == SpellEffect::ResourceTap) {
 			damage = (damage * spells[spellid].base_value[i]) / 1000;
 
 			if (damage) {
@@ -9767,9 +9767,9 @@ void Mob::TryTriggerThreshHold(int64 damage, int effect_id,  Mob* attacker){
 	if (damage <= 0)
 		return;
 
-	if ((SE_TriggerMeleeThreshold == effect_id) && !spellbonuses.TriggerMeleeThreshold )
+	if ((SpellEffect::TriggerMeleeThreshold == effect_id) && !spellbonuses.TriggerMeleeThreshold )
 		return;
-	else if ((SE_TriggerSpellThreshold == effect_id) && !spellbonuses.TriggerSpellThreshold)
+	else if ((SpellEffect::TriggerSpellThreshold == effect_id) && !spellbonuses.TriggerSpellThreshold)
 		return;
 
 	int buff_count = GetMaxTotalSlots();
@@ -9806,10 +9806,10 @@ void Mob::TryTriggerThreshHold(int64 damage, int effect_id,  Mob* attacker){
 void Mob::CastSpellOnLand(Mob* caster, int32 spell_id)
 {
 	/*
-	This function checks for incoming spells on a mob, if they meet the criteria for focus SE_Fc_Cast_Spell_on_Land then
+	This function checks for incoming spells on a mob, if they meet the criteria for focus SpellEffect::Fc_Cast_Spell_on_Land then
 	a new spell will be cast by THIS mob as specified by the focus effect. Note: Chance to cast the spell is determined in
 	the CalcFocusEffect function if not 100pct.
-	ApplyFocusProcLimiter() function checks for SE_Proc_Timer_Modifier which allows for limiting how often a spell from effect can be triggered
+	ApplyFocusProcLimiter() function checks for SpellEffect::Proc_Timer_Modifier which allows for limiting how often a spell from effect can be triggered
 	for example, if set to base=1 and base2= 1500, then for everyone 1 successful trigger, you will be unable to trigger again for 1.5 seconds.
 
 	Live only has this focus in buffs/debuffs that can be placed on a target. TODO: Will consider adding support for it as AA and Item.
@@ -9825,7 +9825,7 @@ void Mob::CastSpellOnLand(Mob* caster, int32 spell_id)
 		int buff_count = GetMaxTotalSlots();
 		for (int i = 0; i < buff_count; i++) {
 
-			if ((IsValidSpell(buffs[i].spellid) && (buffs[i].spellid != spell_id) && IsEffectInSpell(buffs[i].spellid, SE_Fc_Cast_Spell_On_Land))) {
+			if ((IsValidSpell(buffs[i].spellid) && (buffs[i].spellid != spell_id) && IsEffectInSpell(buffs[i].spellid, SpellEffect::Fc_Cast_Spell_On_Land))) {
 
 				//Step 2: Check if we pass all focus limiters and focus chance roll
 				trigger_spell_id = CalcFocusEffect(focusFcCastSpellOnLand, buffs[i].spellid, spell_id, false, buffs[i].casterid, caster);
@@ -9877,18 +9877,18 @@ void Mob::BreakInvisibleSpells()
 {
 	if(invisible) {
 		nobuff_invisible = 0;
-		BuffFadeByEffect(SE_Invisibility);
-		BuffFadeByEffect(SE_Invisibility2);
+		BuffFadeByEffect(SpellEffect::Invisibility);
+		BuffFadeByEffect(SpellEffect::Invisibility2);
 	}
 	if(invisible_undead) {
 		ZeroInvisibleVars(InvisType::T_INVISIBLE_VERSE_UNDEAD);
-		BuffFadeByEffect(SE_InvisVsUndead);
-		BuffFadeByEffect(SE_InvisVsUndead2);
+		BuffFadeByEffect(SpellEffect::InvisVsUndead);
+		BuffFadeByEffect(SpellEffect::InvisVsUndead2);
 	}
 	if(invisible_animals){
 		ZeroInvisibleVars(InvisType::T_INVISIBLE_VERSE_ANIMAL);
-		BuffFadeByEffect(SE_ImprovedInvisAnimals);
-		BuffFadeByEffect(SE_InvisVsAnimals);
+		BuffFadeByEffect(SpellEffect::ImprovedInvisAnimals);
+		BuffFadeByEffect(SpellEffect::InvisVsAnimals);
 	}
 }
 
@@ -9944,8 +9944,8 @@ bool Mob::HarmonySpellLevelCheck(int32 spell_id, Mob *target)
 	}
 
 	for (int i = 0; i < EFFECT_COUNT; i++) {
-		// not important to check limit on SE_Lull as it doesnt have one and if the other components won't land, then SE_Lull wont either
-		if (spells[spell_id].effect_id[i] == SE_ChangeFrenzyRad || spells[spell_id].effect_id[i] == SE_Harmony) {
+		// not important to check limit on SpellEffect::Lull as it doesnt have one and if the other components won't land, then SpellEffect::Lull wont either
+		if (spells[spell_id].effect_id[i] == SpellEffect::ChangeFrenzyRad || spells[spell_id].effect_id[i] == SpellEffect::Harmony) {
 			if ((spells[spell_id].max_value[i] != 0 && target->GetLevel() > spells[spell_id].max_value[i]) || target->GetSpecialAbility(SpecialAbility::PacifyImmunity)) {
 				return false;
 			}
@@ -9986,14 +9986,14 @@ bool Mob::PassCharmTargetRestriction(Mob *target) {
 bool Mob::PassLimitToSkill(EQ::skills::SkillType skill, int32 spell_id, int proc_type, int aa_id)
 {
 	/*
-		Check if SE_AddMeleProc or SE_RangedProc have a skill limiter. Passes automatically if no skill limiters present.
+		Check if SpellEffect::AddMeleProc or SpellEffect::RangedProc have a skill limiter. Passes automatically if no skill limiters present.
 	*/
 	int32 proc_type_spaid = 0;
 	if (proc_type == ProcType::MELEE_PROC) {
-		proc_type_spaid = SE_AddMeleeProc;
+		proc_type_spaid = SpellEffect::AddMeleeProc;
 	}
 	if (proc_type == ProcType::RANGED_PROC) {
-		proc_type_spaid = SE_RangedProc;
+		proc_type_spaid = SpellEffect::RangedProc;
 	}
 
 	bool match_proc_type = false;
@@ -10009,7 +10009,7 @@ bool Mob::PassLimitToSkill(EQ::skills::SkillType skill, int32 spell_id, int proc
 			if (spells[spell_id].effect_id[i] == proc_type_spaid) {
 				match_proc_type = true;
 			}
-			if (match_proc_type && spells[spell_id].effect_id[i] == SE_LimitToSkill && spells[spell_id].base_value[i] <= EQ::skills::HIGHEST_SKILL) {
+			if (match_proc_type && spells[spell_id].effect_id[i] == SpellEffect::LimitToSkill && spells[spell_id].base_value[i] <= EQ::skills::HIGHEST_SKILL) {
 
 				has_limit_check = true;
 				if (spells[spell_id].base_value[i] == skill) {
@@ -10046,7 +10046,7 @@ bool Mob::PassLimitToSkill(EQ::skills::SkillType skill, int32 spell_id, int proc
 					match_proc_type = true;
 				}
 
-				if (match_proc_type && effect.effect_id == SE_LimitToSkill && effect.base_value <= EQ::skills::HIGHEST_SKILL) {
+				if (match_proc_type && effect.effect_id == SpellEffect::LimitToSkill && effect.base_value <= EQ::skills::HIGHEST_SKILL) {
 					has_limit_check = true;
 					if (effect.base_value == skill) {
 						return true;
@@ -10114,11 +10114,11 @@ bool Mob::NegateSpellEffect(uint16 spell_id, int effect_id)
 
 	for (int i = 0; i < GetMaxTotalSlots(); i++) {
 		//Check for any buffs containing NegateEffect
-		if (IsValidSpell(buffs[i].spellid) && IsEffectInSpell(buffs[i].spellid, SE_NegateSpellEffect) && spell_id != buffs[i].spellid) {
+		if (IsValidSpell(buffs[i].spellid) && IsEffectInSpell(buffs[i].spellid, SpellEffect::NegateSpellEffect) && spell_id != buffs[i].spellid) {
 			//Match each of the negate effects with the current spell effect, if found, that effect will not be applied.
 			for (int j = 0; j < EFFECT_COUNT; j++)
 			{
-				if (spells[buffs[i].spellid].effect_id[j] == SE_NegateSpellEffect &&
+				if (spells[buffs[i].spellid].effect_id[j] == SpellEffect::NegateSpellEffect &&
 					spells[buffs[i].spellid].limit_value[j] == effect_id &&
 					(spells[buffs[i].spellid].base_value[j] == NEGATE_SPA_ALL_BONUSES ||
 					 spells[buffs[i].spellid].base_value[j] == NEGATE_SPA_SPELLBONUS ||
@@ -10144,7 +10144,7 @@ int Mob::GetMemoryBlurChance(int base_chance)
 		Memory blur is applied to mez on initial cast using same formula. However, recasting on a target that
 		is already mezed will not give a chance to memory blur. The blur is not checked on buff ticks.
 
-		SPA 242 SE_IncreaseChanceMemwipe modifies the final chance after all bonuses are applied.
+		SPA 242 SpellEffect::IncreaseChanceMemwipe modifies the final chance after all bonuses are applied.
 		This is also applied to memory blur from mez spells.
 
 		this = caster
@@ -10251,7 +10251,7 @@ void Mob::SpreadVirusEffect(int32 spell_id, uint32 caster_id, int32 buff_tics_re
 
 bool Mob::IsFocusProcLimitTimerActive(int32 focus_spell_id) {
 	/*
-		Used with SPA 511 SE_Ff_FocusTimerMin to limit how often a focus effect can be applied.
+		Used with SPA 511 SpellEffect::Ff_FocusTimerMin to limit how often a focus effect can be applied.
 		Ie. Can only have a spell trigger once every 15 seconds, or to be more creative can only
 		have the fire spells received a very high special focused once every 30 seconds.
 		Note, this stores timers for both spell, item and AA related focuses For AA the focus_spell_id
@@ -10293,7 +10293,7 @@ void Mob::SetFocusProcLimitTimer(int32 focus_spell_id, uint32 focus_reuse_time) 
 
 bool Mob::IsProcLimitTimerActive(int32 base_spell_id, uint32 proc_reuse_time, int proc_type) {
 	/*
-		Used with SPA 512 SE_Proc_Timer_Modifier to limit how often a proc can be cast.
+		Used with SPA 512 SpellEffect::Proc_Timer_Modifier to limit how often a proc can be cast.
 		If this effect exists it will prevent the next proc from firing until the timer
 		defined in SPA 512 is finished. Ie. 1 proc every 55 seconds.
 		Spell, Ranged, and Defensive procs all have their own timer array, therefore
@@ -10428,7 +10428,7 @@ void Mob::ApplyIllusionToCorpse(int32 spell_id, Corpse* new_corpse) {
 	}
 
 	for (int i = 0; i < EFFECT_COUNT; i++){
-		if (spells[spell_id].effect_id[i] == SE_Illusion) {
+		if (spells[spell_id].effect_id[i] == SpellEffect::Illusion) {
 			new_corpse->ApplySpellEffectIllusion(spell_id, nullptr, -1, spells[spell_id].base_value[i], spells[spell_id].limit_value[i], spells[spell_id].max_value[i]);
 			return;
 		}
@@ -10594,7 +10594,7 @@ bool Mob::HasPersistDeathIllusion(int32 spell_id) {
 		if (
 			spell_id != SPELL_MINOR_ILLUSION &&
 			spell_id != SPELL_ILLUSION_TREE &&
-			IsEffectInSpell(spell_id, SE_Illusion) &&
+			IsEffectInSpell(spell_id, SpellEffect::Illusion) &&
 			IsBeneficialSpell(spell_id)
 		) {
 			return true;

--- a/zone/tune.cpp
+++ b/zone/tune.cpp
@@ -466,12 +466,12 @@ void Mob::TuneGetAvoidanceByHitChance(Mob* defender, Mob *attacker, float hit_ch
 
 				if (loop_add_avoid >= 0) {
 					Message(0, "[#Tune] OPTION1: MODIFY Client Heroic AGI or Avoidance Mod2 stat by [+ %i ]", loop_add_avoid);
-					Message(0, "[#Tune] OPTION2: Give CLIENT an evasion bonus using SPA 172 Evasion SE_AvoidMeleeChance from (spells/items/aa) of [+ %i pct ]", evasion_bonus);
+					Message(0, "[#Tune] OPTION2: Give CLIENT an evasion bonus using SPA 172 Evasion SpellEffect::AvoidMeleeChance from (spells/items/aa) of [+ %i pct ]", evasion_bonus);
 
 				}
 				else {
 					Message(0, "[#Tune] OPTION1: MODIFY Client Heroic AGI or Avoidance Mod2 stat by [ %i ]", loop_add_avoid);
-					Message(0, "[#Tune] OPTION2: Give CLIENT an evasion bonus using SPA 172 Evasion SE_AvoidMeleeChance from (spells/items/aa) of [ %i pct ]", evasion_bonus);
+					Message(0, "[#Tune] OPTION2: Give CLIENT an evasion bonus using SPA 172 Evasion SpellEffect::AvoidMeleeChance from (spells/items/aa) of [ %i pct ]", evasion_bonus);
 				}
 
 				Message(0, "###################COMPLETE###################");
@@ -1283,7 +1283,7 @@ int64 Mob::Tunecompute_tohit(EQ::skills::SkillType skillinuse, int accuracy_over
 // return -1 in cases that always hit
 int64 Mob::TuneGetTotalToHit(EQ::skills::SkillType skill, int chance_mod, int accuracy_override, int add_accuracy)
 {
-	if (chance_mod >= 10000) // override for stuff like SE_SkillAttack
+	if (chance_mod >= 10000) // override for stuff like SpellEffect::SkillAttack
 		return -1;
 
 	// calculate attacker's accuracy
@@ -1313,7 +1313,7 @@ int64 Mob::TuneGetTotalToHit(EQ::skills::SkillType skill, int chance_mod, int ac
 	if (atkhit_bonus)
 		accuracy += round(static_cast<double>(accuracy) * static_cast<double>(atkhit_bonus) * 0.0001);
 
-	// 216 Melee Accuracy Amt aka SE_Accuracy -- flat bonus
+	// 216 Melee Accuracy Amt aka SpellEffect::Accuracy -- flat bonus
 	accuracy += itembonuses.Accuracy[EQ::skills::HIGHEST_SKILL + 1] +
 		aabonuses.Accuracy[EQ::skills::HIGHEST_SKILL + 1] +
 		spellbonuses.Accuracy[EQ::skills::HIGHEST_SKILL + 1] +
@@ -1335,7 +1335,7 @@ int64 Mob::TuneGetTotalToHit(EQ::skills::SkillType skill, int chance_mod, int ac
 	if (spellbonuses.HitChanceEffect[EQ::skills::HIGHEST_SKILL + 1] >= 10000)
 		return -1;
 
-	// 184 Accuracy % aka SE_HitChance -- percentage increase
+	// 184 Accuracy % aka SpellEffect::HitChance -- percentage increase
 	auto hit_bonus = itembonuses.HitChanceEffect[EQ::skills::HIGHEST_SKILL + 1] +
 		aabonuses.HitChanceEffect[EQ::skills::HIGHEST_SKILL + 1] +
 		spellbonuses.HitChanceEffect[EQ::skills::HIGHEST_SKILL + 1] +
@@ -1360,15 +1360,15 @@ int64 Mob::TuneGetTotalDefense(int avoidance_override, int add_avoidance)
 	if (evasion_bonus >= 10000)
 		return -1;
 
-	// 515 SE_AC_Avoidance_Max_Percent
+	// 515 SpellEffect::AC_Avoidance_Max_Percent
 	auto ac_aviodance_bonus = itembonuses.AC_Avoidance_Max_Percent + aabonuses.AC_Avoidance_Max_Percent + spellbonuses.AC_Avoidance_Max_Percent;
 	if (ac_aviodance_bonus)
 		avoidance += round(static_cast<double>(avoidance) * static_cast<double>(ac_aviodance_bonus) * 0.0001);
 
-	// 172 Evasion aka SE_AvoidMeleeChance
+	// 172 Evasion aka SpellEffect::AvoidMeleeChance
 	evasion_bonus += itembonuses.AvoidMeleeChanceEffect + aabonuses.AvoidMeleeChanceEffect; // item bonus here isn't mod2 avoidance
 
-	// 215 Pet Avoidance % aka SE_PetAvoidance
+	// 215 Pet Avoidance % aka SpellEffect::PetAvoidance
 	evasion_bonus += GetPetAvoidanceBonusFromOwner();
 
 	// Evasion is a percentage bonus according to AA descriptions
@@ -1410,7 +1410,7 @@ int64 Mob::Tunecompute_defense(int avoidance_override, int add_avoidance)
 	}
 
 
-	//516 SE_AC_Mitigation_Max_Percent
+	//516 SpellEffect::AC_Mitigation_Max_Percent
 	auto ac_bonus = itembonuses.AC_Mitigation_Max_Percent + aabonuses.AC_Mitigation_Max_Percent + spellbonuses.AC_Mitigation_Max_Percent;
 	if (ac_bonus) {
 		defense += round(static_cast<double>(defense) * static_cast<double>(ac_bonus) * 0.0001);

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -957,7 +957,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 
 				LogSpells("[WorldServer::HandleMessage] Found corpse. Marking corpse as rezzed if needed");
 				// I don't know why Rezzed is not set to true in CompleteRezz().
-				if (!IsEffectInSpell(srs->rez.spellid, SE_SummonToCorpse)) {
+				if (!IsEffectInSpell(srs->rez.spellid, SpellEffect::SummonToCorpse)) {
 					corpse->IsRezzed(true);
 					corpse->CompleteResurrection();
 				}

--- a/zone/zonedb.cpp
+++ b/zone/zonedb.cpp
@@ -3009,12 +3009,12 @@ void ZoneDatabase::LoadBuffs(Client *client)
 			continue;
 		}
 
-		if (IsEffectInSpell(buffs[slot_id].spellid, SE_Charm)) {
+		if (IsEffectInSpell(buffs[slot_id].spellid, SpellEffect::Charm)) {
 			buffs[slot_id].spellid = SPELL_UNKNOWN;
 			break;
 		}
 
-		if (IsEffectInSpell(buffs[slot_id].spellid, SE_Illusion)) {
+		if (IsEffectInSpell(buffs[slot_id].spellid, SpellEffect::Illusion)) {
 			if (buffs[slot_id].persistant_buff) {
 				break;
 			}


### PR DESCRIPTION
# Description
- Converts all `SE_` constants like `SE_X` to use namespace `SpellEffect` like `SpellEffect::X`.

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur