### PR TITLE
[Bug Fix] Fix Task Reloading

### DIFF
--- a/zone/task_manager.cpp
+++ b/zone/task_manager.cpp
@@ -43,6 +43,8 @@ bool TaskManager::LoadTaskSets()
 
 bool TaskManager::LoadTasks(int single_task)
 {
+	m_task_data.clear();
+
 	std::string task_query_filter = fmt::format("id = {}", single_task);
 	if (single_task == 0) {
 		if (!LoadTaskSets()) {


### PR DESCRIPTION
# Description
- Fixes an issue where the change to a singleton caused `m_task_data` not to be cleared since we never actually delete our task manager instance.

## Type of change
- [X] Bug fix

# Testing
## Before Change
<img width="603" height="377" alt="image" src="https://github.com/user-attachments/assets/576cd4ab-3411-43b7-b45d-340b8824a70b" />

## After Change
<img width="1920" height="364" alt="image" src="https://github.com/user-attachments/assets/1517a68b-5584-49e1-b0ec-f10b5ed80200" />

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur