### PR TITLE
[Cleanup] Fix #set race 0 Message

### DIFF
--- a/zone/gm_commands/set/race.cpp
+++ b/zone/gm_commands/set/race.cpp
@@ -44,6 +44,19 @@ void SetRace(Client *c, const Seperator *sep)
 		}
 	);
 
+	if (race_id == Race::Doug) {
+		c->Message(
+			Chat::White,
+			fmt::format(
+				"{} {} been returned to {} base race.",
+				c->GetTargetDescription(t, TargetDescriptionType::UCYou),
+				c == t ? "have" : "has",
+				c == t ? "your" : "their"
+			).c_str()
+		);
+		return;
+	}
+
 	c->Message(
 		Chat::White,
 		fmt::format(


### PR DESCRIPTION
# Description
- `#set race 0` was saying it was setting you/your target to an "UNKNOWN RACE", so I simply bypassed the logic by checking if race was `0` and sending a unique message.

## Type of change
- [X] Bug fix

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur