### PR TITLE
[Cleanup] Cleanup #show ip_lookup Message

### DIFF
--- a/world/clientlist.h
+++ b/world/clientlist.h
@@ -45,7 +45,7 @@ public:
 	void	SendClientVersionSummary(const char *Name);
 	void	SendLFGMatches(ServerLFGMatchesRequest_Struct *LFGMatchesRequest);
 	void	ConsoleSendWhoAll(const char* to, int16 admin, Who_All_Struct* whom, WorldTCPConnection* connection);
-	void	SendCLEList(const int16& admin, const char* to, WorldTCPConnection* connection, const char* iName = 0);
+	void	SendCLEList(const int16& admin, const char* to, WorldTCPConnection* connection, const char* search_criteria = 0);
 
 	bool	SendPacket(const char* to, ServerPacket* pack);
 

--- a/zone/gm_commands/show/ip_lookup.cpp
+++ b/zone/gm_commands/show/ip_lookup.cpp
@@ -9,7 +9,7 @@ void ShowIPLookup(Client *c, const Seperator *sep)
 
 	auto pack = new ServerPacket(
 		ServerOP_IPLookup,
-		sizeof(ServerGenericWorldQuery_Struct) + ip_length + 1
+		sizeof(ServerGenericWorldQuery_Struct) + ip_length
 	);
 
 	auto s = (ServerGenericWorldQuery_Struct *) pack->pBuffer;


### PR DESCRIPTION
# Description
- Cleans up the `#show ip_lookup` message and adds `#goto`, `#show ip_lookup`, and `#zone` saylinks for easily going to a player, the zone they're in, or searching for all characters active on that IP.

# Testing
<img width="613" height="73" alt="image" src="https://github.com/user-attachments/assets/14f3ed4a-4382-4a6c-aad5-e5d558eadcae" />

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur