### PR TITLE
[Constants] Convert string_id Defines to ClientString Namespace

### DIFF
--- a/zone/aa.cpp
+++ b/zone/aa.cpp
@@ -1195,21 +1195,21 @@ void Client::FinishAlternateAdvancementPurchase(AA::Rank *rank, bool ignore_cost
 		if (send_message_and_save) {
 			MessageString(
 				Chat::Yellow,
-				AA_IMPROVE,
+				ClientString::AA_IMPROVE,
 				std::to_string(rank->title_sid).c_str(),
 				std::to_string(rank->prev->current_value).c_str(),
 				std::to_string(cost).c_str(),
-				cost == 1 ? std::to_string(AA_POINT).c_str() : std::to_string(AA_POINTS).c_str()
+				cost == 1 ? std::to_string(ClientString::AA_POINT).c_str() : std::to_string(ClientString::AA_POINTS).c_str()
 			);
 		}
 	} else {
 		if (send_message_and_save) {
 			MessageString(
 				Chat::Yellow,
-				AA_GAIN_ABILITY,
+				ClientString::AA_GAIN_ABILITY,
 				std::to_string(rank->title_sid).c_str(),
 				std::to_string(cost).c_str(),
-				cost == 1 ? std::to_string(AA_POINT).c_str() : std::to_string(AA_POINTS).c_str()
+				cost == 1 ? std::to_string(ClientString::AA_POINT).c_str() : std::to_string(ClientString::AA_POINTS).c_str()
 			);
 		}
 	}
@@ -1313,7 +1313,7 @@ void Client::ActivateAlternateAdvancementAbility(int rank_id, int target_id) {
 		CommonBreakInvisible();
 
 	if (spells[rank->spell].sneak && (!hidden || (hidden && (Timer::GetCurrentTime() - tmHidden) < 4000))) {
-		MessageString(Chat::SpellFailure, SNEAK_RESTRICT);
+		MessageString(Chat::SpellFailure, ClientString::SNEAK_RESTRICT);
 		return;
 	}
 	//
@@ -1327,7 +1327,7 @@ void Client::ActivateAlternateAdvancementAbility(int rank_id, int target_id) {
 			SetAppearance(eaStanding, false);
 
 		if (GetAppearance() != eaStanding) {
-			MessageString(Chat::SpellFailure, STAND_TO_CAST);
+			MessageString(Chat::SpellFailure, ClientString::STAND_TO_CAST);
 			return;
 		}
 	}
@@ -2125,20 +2125,20 @@ void Client::AutoGrantAAPoints() {
 					if (rank->prev) {
 						MessageString(
 							Chat::Yellow,
-							AA_IMPROVE,
+							ClientString::AA_IMPROVE,
 							std::to_string(rank->title_sid).c_str(),
 							std::to_string(rank->prev->current_value).c_str(),
 							"0",
-							std::to_string(AA_POINTS).c_str()
+							std::to_string(ClientString::AA_POINTS).c_str()
 						);
 					}
 					else {
 						MessageString(
 							Chat::Yellow,
-							AA_GAIN_ABILITY,
+							ClientString::AA_GAIN_ABILITY,
 							std::to_string(rank->title_sid).c_str(),
 							"0",
-							std::to_string(AA_POINTS).c_str()
+							std::to_string(ClientString::AA_POINTS).c_str()
 						);
 					}
 				}

--- a/zone/attack.cpp
+++ b/zone/attack.cpp
@@ -1503,7 +1503,7 @@ void Mob::DoAttack(Mob *other, DamageHitInfo &hit, ExtraAttackOptions *opts, boo
 				this, /* Sender */
 				Chat::StrikeThrough, /* Type: 339 */
 				FilterStrikethrough, /* FilterType: 12 */
-				STRIKETHROUGH_STRING /* You strike through your opponent's defenses! */
+				ClientString::STRIKETHROUGH_STRING /* You strike through your opponent's defenses! */
 			);
 
 			hit.damage_done = 1;			// set to one, we will check this to continue
@@ -1529,14 +1529,14 @@ void Mob::DoAttack(Mob *other, DamageHitInfo &hit, ExtraAttackOptions *opts, boo
 							this,
 							Chat::Stun,
 							FilterStuns,
-							AVOID_STUNNING_BLOW
+							ClientString::AVOID_STUNNING_BLOW
 						);
 					} else if (zone->random.Roll(stun_resist)) {
 						other->FilteredMessageString(
 							this,
 							Chat::Stun,
 							FilterStuns,
-							SHAKE_OFF_STUN
+							ClientString::SHAKE_OFF_STUN
 						);
 					} else {
 						other->Stun(3000); // yuck -- 3 seconds
@@ -1598,7 +1598,7 @@ bool Mob::Attack(Mob* other, int Hand, bool bRiposte, bool IsStrikethrough, bool
 
 	if (DivineAura() && !CastToClient()->GetGM()) { //cant attack while invulnerable unless your a gm
 		LogCombat("Attack cancelled, Divine Aura is in effect");
-		MessageString(Chat::DefaultText, DIVINE_AURA_NO_ATK);
+		MessageString(Chat::DefaultText, ClientString::DIVINE_AURA_NO_ATK);
 		return false;
 	}
 
@@ -1856,7 +1856,7 @@ bool Client::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::Skil
 			false, /* Skip Sender */
 			RuleI(Range, DamageMessages),
 			Chat::NonMelee, /* 283 */
-			HIT_NON_MELEE, /* %1 hit %2 for %3 points of non-melee damage. */
+			ClientString::HIT_NON_MELEE, /* %1 hit %2 for %3 points of non-melee damage. */
 			killer_mob->GetCleanName(), /* Message1 */
 			GetCleanName(), /* Message2 */
 			ConvertArray(damage, val1)/* Message3 */
@@ -2224,7 +2224,7 @@ bool NPC::Attack(Mob* other, int Hand, bool bRiposte, bool IsStrikethrough, bool
 	//Check that we can attack before we calc heading and face our target
 	if (!IsAttackAllowed(other)) {
 		if (GetOwnerID()) {
-			SayString(NOT_LEGAL_TARGET);
+			SayString(ClientString::NOT_LEGAL_TARGET);
 		}
 
 		if (other->IsClient()) {
@@ -2464,7 +2464,7 @@ void NPC::Damage(Mob* other, int64 damage, uint16 spell_id, EQ::skills::SkillTyp
 		{
 			if (IsLDoNTrapped())
 			{
-				MessageString(Chat::Red, LDON_ACCIDENT_SETOFF2);
+				MessageString(Chat::Red, ClientString::LDON_ACCIDENT_SETOFF2);
 				SpellFinished(GetLDoNTrapSpellID(), other, EQ::spells::CastingSlot::Item, 0, -1, spells[GetLDoNTrapSpellID()].resist_difficulty, false);
 				SetLDoNTrapSpellID(0);
 				SetLDoNTrapped(false);
@@ -2532,7 +2532,7 @@ bool NPC::Death(Mob* killer_mob, int64 damage, uint16 spell, EQ::skills::SkillTy
 			false, /* Skip Sender */
 			RuleI(Range, DamageMessages),
 			Chat::NonMelee, /* 283 */
-			HIT_NON_MELEE, /* %1 hit %2 for %3 points of non-melee damage. */
+			ClientString::HIT_NON_MELEE, /* %1 hit %2 for %3 points of non-melee damage. */
 			killer_mob->GetCleanName(), /* Message1 */
 			GetCleanName(), /* Message2 */
 			ConvertArray(damage, val1) /* Message3 */
@@ -4158,7 +4158,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 
 			pet->AddToHateList(attacker, 1, 0, true, false, false, spell_id);
 			pet->SetTarget(attacker);
-			MessageString(Chat::NPCQuestSay, PET_ATTACKING, pet->GetCleanName(), attacker->GetCleanName());
+			MessageString(Chat::NPCQuestSay, ClientString::PET_ATTACKING, pet->GetCleanName(), attacker->GetCleanName());
 		}
 
 		if (GetTempPetCount()) {
@@ -4310,7 +4310,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 				true,  /* Skip Sender */
 				RuleI(Range, SpellMessages),
 				Chat::SpellWornOff, /* 284 */
-				HAS_BEEN_AWAKENED, // %1 has been awakened by %2.
+				ClientString::HAS_BEEN_AWAKENED, // %1 has been awakened by %2.
 				GetCleanName(), /* Message1 */
 				attacker->GetCleanName() /* Message2 */
 			);
@@ -4442,7 +4442,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 								this,
 								Chat::Stun,
 								FilterStuns,
-								SHAKE_OFF_STUN
+								ClientString::SHAKE_OFF_STUN
 							);
 						}
 					}
@@ -4453,7 +4453,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 							this,
 							Chat::Stun,
 							FilterStuns,
-							AVOID_STUNNING_BLOW
+							ClientString::AVOID_STUNNING_BLOW
 						);
 					}
 				}
@@ -4568,7 +4568,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 				if (FromDamageShield && damage > 0) {
 					//special crap for spell damage, looks hackish to me
 					char val1[20] = { 0 };
-					owner->MessageString(Chat::NonMelee, OTHER_HIT_NONMELEE, GetCleanName(), ConvertArray(damage, val1));
+					owner->MessageString(Chat::NonMelee, ClientString::OTHER_HIT_NONMELEE, GetCleanName(), ConvertArray(damage, val1));
 				}
 				else {
 					if (damage > 0) {
@@ -4613,7 +4613,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 							if (owner && owner->CastToClient()->GetFilter(FilterDamageShields) != FilterHide) {
 								owner->MessageString(
 									Chat::DamageShield,
-									OTHER_HIT_NONMELEE,
+									ClientString::OTHER_HIT_NONMELEE,
 									GetCleanName(),
 									ConvertArray(damage, val1)
 								);
@@ -4622,7 +4622,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 							if (attacker->CastToClient()->GetFilter(FilterDamageShields) != FilterHide) {
 								attacker->MessageString(
 									Chat::DamageShield,
-									OTHER_HIT_NONMELEE,
+									ClientString::OTHER_HIT_NONMELEE,
 									GetCleanName(),
 									ConvertArray(damage, val1)
 								);
@@ -4636,7 +4636,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 							RuleI(Range, SpellMessages),
 							Chat::NonMelee, /* 283 */
 							FilterSpellDamage, /* FilterType: 13 */
-							HIT_NON_MELEE, /* %1 hit %2 for %3 points of non-melee damage. */
+							ClientString::HIT_NON_MELEE, /* %1 hit %2 for %3 points of non-melee damage. */
 							0,
 							attacker->GetCleanName(), /* Message1 */
 							GetCleanName(), /* Message2 */
@@ -4758,13 +4758,13 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 			//might filter on (attack_skill>200 && attack_skill<250), but I dont think we need it
 			if (!attacker->IsCorpse() && attacker->IsClient()) {
 				attacker->FilteredMessageString(attacker, Chat::DotDamage,
-					FilterDOT, YOUR_HIT_DOT, GetCleanName(), itoa(damage),
+					FilterDOT, ClientString::YOUR_HIT_DOT, GetCleanName(), itoa(damage),
 					spells[spell_id].name);
 			}
 
 			if (IsClient()) {
 				FilteredMessageString(this, Chat::DotDamage, FilterDOT,
-					YOU_TAKE_DOT, itoa(damage), attacker->GetCleanName(),
+					ClientString::YOU_TAKE_DOT, itoa(damage), attacker->GetCleanName(),
 					spells[spell_id].name);
 			}
 
@@ -4775,7 +4775,7 @@ void Mob::CommonDamage(Mob* attacker, int64 &damage, const uint16 spell_id, cons
 				RuleI(Range, SpellMessages),
 				Chat::DotDamage, /* Type: 325 */
 				FilterDOT, /* FilterType: 19 */
-				OTHER_HIT_DOT,  /* MessageFormat: %1 has taken %2 damage from %3 by %4. */
+				ClientString::OTHER_HIT_DOT,  /* MessageFormat: %1 has taken %2 damage from %3 by %4. */
 				attacker,		/* sent above */
 				GetCleanName(), /* Message1 */
 				itoa(damage), /* Message2 */
@@ -4813,45 +4813,45 @@ void Mob::HealDamage(uint64 amount, Mob* caster, uint16 spell_id)
 				if ((caster->IsClient() && caster == this)) {
 					if (caster->CastToClient()->ClientVersionBit() & EQ::versions::maskSoFAndLater) {
 						FilteredMessageString(caster, Chat::NonMelee, FilterHealOverTime,
-							HOT_HEAL_SELF, itoa(acthealed), spells[spell_id].name);
+							ClientString::HOT_HEAL_SELF, itoa(acthealed), spells[spell_id].name);
 					}
 					else
 						FilteredMessageString(caster, Chat::NonMelee, FilterHealOverTime,
-							YOU_HEALED, GetCleanName(), itoa(acthealed));
+							ClientString::YOU_HEALED, GetCleanName(), itoa(acthealed));
 				}
 				else if ((caster->IsClient() && caster != this)) {
 					if (caster->CastToClient()->ClientVersionBit() & EQ::versions::maskSoFAndLater)
 						caster->FilteredMessageString(caster, Chat::NonMelee, FilterHealOverTime,
-							HOT_HEAL_OTHER, GetCleanName(), itoa(acthealed),
+							ClientString::HOT_HEAL_OTHER, GetCleanName(), itoa(acthealed),
 							spells[spell_id].name);
 					else
 						caster->FilteredMessageString(caster, Chat::NonMelee, FilterHealOverTime,
-							YOU_HEAL, GetCleanName(), itoa(acthealed));
+							ClientString::YOU_HEAL, GetCleanName(), itoa(acthealed));
 				}
 
 				// message to target
 				if (IsClient() && caster != this) {
 					if (CastToClient()->ClientVersionBit() & EQ::versions::maskSoFAndLater)
 						FilteredMessageString(caster, Chat::NonMelee, FilterHealOverTime,
-							HOT_HEALED_OTHER, caster->GetCleanName(),
+							ClientString::HOT_HEALED_OTHER, caster->GetCleanName(),
 							itoa(acthealed), spells[spell_id].name);
 					else
 						FilteredMessageString(this, Chat::NonMelee, FilterHealOverTime,
-							YOU_HEALED, caster->GetCleanName(), itoa(acthealed));
+							ClientString::YOU_HEALED, caster->GetCleanName(), itoa(acthealed));
 				}
 			}
 			else { // normal heals
 				// Message to caster
 				if (caster->IsClient()) {
 					caster->FilteredMessageString(caster, Chat::NonMelee,
-						FilterSpellDamage, YOU_HEAL, GetCleanName(),
+						FilterSpellDamage, ClientString::YOU_HEAL, GetCleanName(),
 						itoa(acthealed));
 					}
 
 				// Message to target
 				if (IsClient() && caster != this) {
 					FilteredMessageString(caster, Chat::NonMelee,
-					FilterSpellDamage, YOU_HEALED, caster->GetCleanName(),
+					FilterSpellDamage, ClientString::YOU_HEALED, caster->GetCleanName(),
 					itoa(acthealed));
 				}
 			}
@@ -5067,10 +5067,10 @@ void Mob::TryWeaponProc(const EQ::ItemInstance *inst, const EQ::ItemData *weapon
 				if (IsPet()) {
 					Mob *own = GetOwner();
 					if (own)
-						own->MessageString(Chat::Red, PROC_PETTOOLOW);
+						own->MessageString(Chat::Red, ClientString::PROC_PETTOOLOW);
 				}
 				else {
-					MessageString(Chat::Red, PROC_TOOLOW);
+					MessageString(Chat::Red, ClientString::PROC_TOOLOW);
 				}
 			}
 			else {
@@ -5102,10 +5102,10 @@ void Mob::TryWeaponProc(const EQ::ItemInstance *inst, const EQ::ItemData *weapon
 						if (IsPet()) {
 							Mob *own = GetOwner();
 							if (own)
-								own->MessageString(Chat::Red, PROC_PETTOOLOW);
+								own->MessageString(Chat::Red, ClientString::PROC_PETTOOLOW);
 						}
 						else {
-							MessageString(Chat::Red, PROC_TOOLOW);
+							MessageString(Chat::Red, ClientString::PROC_TOOLOW);
 						}
 					}
 					else {
@@ -5344,7 +5344,7 @@ void Mob::TryPetCriticalHit(Mob *defender, DamageHitInfo &hit)
 				RuleI(Range, CriticalDamage),
 				Chat::MeleeCrit, /* Type: 301 */
 				FilterMeleeCrits, /* FilterType: 12 */
-				CRITICAL_HIT, /* MessageFormat: %1 scores a critical hit! (%2) */
+				ClientString::CRITICAL_HIT, /* MessageFormat: %1 scores a critical hit! (%2) */
 				0,
 				GetCleanName(), /* Message1 */
 				itoa(hit.damage_done + hit.min_damage) /* Message2 */
@@ -5414,7 +5414,7 @@ void Mob::TryCriticalHit(Mob *defender, DamageHitInfo &hit, ExtraAttackOptions *
 
 				LogCombatDetail("Final Slayundead damage [{}]", hit.damage_done);
 
-				int slay_sex = GetGender() == Gender::Female ? FEMALE_SLAYUNDEAD : MALE_SLAYUNDEAD;
+				int slay_sex = GetGender() == Gender::Female ? ClientString::FEMALE_SLAYUNDEAD : ClientString::MALE_SLAYUNDEAD;
 
 				entity_list.FilteredMessageCloseString(
 					this, /* Sender */
@@ -5514,7 +5514,7 @@ void Mob::TryCriticalHit(Mob *defender, DamageHitInfo &hit, ExtraAttackOptions *
 							RuleI(Range, CriticalDamage),
 							Chat::MeleeCrit, /* Type: 301 */
 							FilterMeleeCrits, /* FilterType: 12 */
-							DEADLY_STRIKE, /* MessageFormat: %1 scores a Deadly Strike!(%2) */
+							ClientString::DEADLY_STRIKE, /* MessageFormat: %1 scores a Deadly Strike!(%2) */
 							0,
 							GetCleanName(), /* Message1 */
 							itoa(hit.damage_done + hit.min_damage) /* Message2 */
@@ -5543,7 +5543,7 @@ void Mob::TryCriticalHit(Mob *defender, DamageHitInfo &hit, ExtraAttackOptions *
 					RuleI(Range, CriticalDamage),
 					Chat::MeleeCrit, /* Type: 301 */
 					FilterMeleeCrits, /* FilterType: 12 */
-					CRIPPLING_BLOW, /* MessageFormat: %1 lands a Crippling Blow!(%2) */
+					ClientString::CRIPPLING_BLOW, /* MessageFormat: %1 lands a Crippling Blow!(%2) */
 					0,
 					GetCleanName(), /* Message1 */
 					itoa(hit.damage_done + hit.min_damage) /* Message2 */
@@ -5558,7 +5558,7 @@ void Mob::TryCriticalHit(Mob *defender, DamageHitInfo &hit, ExtraAttackOptions *
 						true,
 						RuleI(Range, Emote),
 						Chat::Emote,
-						STAGGERS,
+						ClientString::STAGGERS,
 						GetName()
 					);
 					defender->Stun(RuleI(Combat, StunDuration));
@@ -5573,7 +5573,7 @@ void Mob::TryCriticalHit(Mob *defender, DamageHitInfo &hit, ExtraAttackOptions *
 				RuleI(Range, CriticalDamage),
 				Chat::MeleeCrit, /* Type: 301 */
 				FilterMeleeCrits, /* FilterType: 12 */
-				CRITICAL_HIT, /* MessageFormat: %1 scores a critical hit! (%2) */
+				ClientString::CRITICAL_HIT, /* MessageFormat: %1 scores a critical hit! (%2) */
 				0,
 				GetCleanName(), /* Message1 */
 				itoa(hit.damage_done + hit.min_damage) /* Message2 */
@@ -5633,7 +5633,7 @@ bool Mob::TryFinishingBlow(Mob *defender, int64 &damage)
 				RuleI(Range, CriticalDamage),
 				Chat::MeleeCrit, /* Type: 301 */
 				FilterMeleeCrits, /* FilterType: 12 */
-				FINISHING_BLOW, /* MessageFormat: %1 scores a Finishing Blow!!) */
+				ClientString::FINISHING_BLOW, /* MessageFormat: %1 scores a Finishing Blow!!) */
 				0,
 				GetCleanName() /* Message1 */
 			);
@@ -5654,7 +5654,7 @@ void Mob::DoRiposte(Mob *defender)
 
 	// so ahhh the angle you can riposte is larger than the angle you can hit :P
 	if (!defender->IsFacingMob(this)) {
-		defender->MessageString(Chat::TooFarAway, CANT_SEE_TARGET);
+		defender->MessageString(Chat::TooFarAway, ClientString::CANT_SEE_TARGET);
 		return;
 	}
 
@@ -6382,7 +6382,7 @@ void Mob::CommonOutgoingHitSuccess(Mob* defender, DamageHitInfo &hit, ExtraAttac
 		else if (GetClass() == Class::Ranger && GetLevel() >= RuleI(Combat, ArcheryBonusLevelRequirement)) { // no double dmg on headshot
 			if ((defender->IsNPC() && !defender->IsMoving() && !defender->IsRooted()) || !RuleB(Combat, ArcheryBonusRequiresStationary)) {
 				hit.damage_done *= 2;
-				MessageString(Chat::MeleeCrit, BOW_DOUBLE_DAMAGE);
+				MessageString(Chat::MeleeCrit, ClientString::BOW_DOUBLE_DAMAGE);
 			}
 		}
 
@@ -6848,7 +6848,7 @@ void Client::DoAttackRounds(Mob *target, int hand, bool IsFromSpell)
 						if (zone->random.Roll(flurry_chance)) {
 							Attack(target, hand, false, false, IsFromSpell);
 						}
-						MessageString(Chat::NPCFlurry, YOU_FLURRY);
+						MessageString(Chat::NPCFlurry, ClientString::YOU_FLURRY);
 					}
 				}
 			}

--- a/zone/aura.cpp
+++ b/zone/aura.cpp
@@ -1027,11 +1027,11 @@ void Mob::AddTrap(Aura *aura, AuraRecord &record)
 bool Mob::CanSpawnAura(bool trap)
 {
 	if (trap && !HasFreeTrapSlots()) {
-		MessageString(Chat::SpellFailure, NO_MORE_TRAPS);
+		MessageString(Chat::SpellFailure, ClientString::NO_MORE_TRAPS);
 		return false;
 	}
 	else if (!trap && !HasFreeAuraSlots()) {
-		MessageString(Chat::SpellFailure, NO_MORE_AURAS);
+		MessageString(Chat::SpellFailure, ClientString::NO_MORE_AURAS);
 		return false;
 	}
 

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -2932,7 +2932,7 @@ void Bot::DoAttackRounds(Mob* target, int hand) {
 						if (GetOwner()) {
 							GetOwner()->MessageString(
 								Chat::NPCFlurry,
-								NPC_FLURRY,
+								ClientString::NPC_FLURRY,
 								GetCleanName(),
 								target->GetCleanName()
 							);
@@ -3454,11 +3454,11 @@ bool Bot::CheckIfIncapacitated() {
 void Bot::SetBerserkState() {// Berserk updates should occur if primary AI criteria are met
 	if (GetClass() == Class::Warrior || GetClass() == Class::Berserker) {
 		if (!berserk && GetHPRatio() < RuleI(Combat, BerserkerFrenzyStart)) {
-			entity_list.MessageCloseString(this, false, 200, 0, BERSERK_START, GetName());
+			entity_list.MessageCloseString(this, false, 200, 0, ClientString::BERSERK_START, GetName());
 			berserk = true;
 		}
 		if (berserk && GetHPRatio() > RuleI(Combat, BerserkerFrenzyEnd)) {
-			entity_list.MessageCloseString(this, false, 200, 0, BERSERK_END, GetName());
+			entity_list.MessageCloseString(this, false, 200, 0, ClientString::BERSERK_END, GetName());
 			berserk = false;
 		}
 	}
@@ -5101,7 +5101,7 @@ bool Bot::TryFinishingBlow(Mob *defender, int64 &damage)
 		if (defender->GetLevel() <= levelreq && (chance >= zone->random.Int(1, 1000))) {
 			LogCombat("Landed a finishing blow: levelreq at [{}] other level [{}]",
 				levelreq, defender->GetLevel());
-			entity_list.MessageCloseString(this, false, 200, Chat::MeleeCrit, FINISHING_BLOW, GetName());
+			entity_list.MessageCloseString(this, false, 200, Chat::MeleeCrit, ClientString::FINISHING_BLOW, GetName());
 			damage = fb_damage;
 			return true;
 		} else {
@@ -5362,7 +5362,7 @@ void Bot::DoClassAttacks(Mob *target, bool IsRiposte) {
 					if (bo && bo->IsClient() && bo->CastToClient()->GetBotOption(Client::booMonkWuMessage)) {
 
 						bo->Message(
-							GENERIC_EMOTE,
+							ClientString::GENERIC_EMOTE,
 							"The spirit of Master Wu fills %s!  %s gains %d additional attack(s).",
 							GetCleanName(),
 							GetCleanName(),
@@ -5563,7 +5563,7 @@ void Bot::DoClassAttacks(Mob *target, bool IsRiposte) {
 			if (bo && bo->IsClient() && bo->CastToClient()->GetBotOption(Client::booMonkWuMessage)) {
 
 				bo->Message(
-					GENERIC_EMOTE,
+					ClientString::GENERIC_EMOTE,
 					"The spirit of Master Wu fills %s!  %s gains %d additional attack(s).",
 					GetCleanName(),
 					GetCleanName(),
@@ -5920,12 +5920,12 @@ bool Bot::CastSpell(
 
 		if (DivineAura()) {
 			LogSpellsDetail("Spell casting canceled: cannot cast while Divine Aura is in effect");
-			InterruptSpell(SPELL_FIZZLE, 0x121, false);
+			InterruptSpell(ClientString::SPELL_FIZZLE, 0x121, false);
 			return false;
 		}
 
 		if (slot < EQ::spells::CastingSlot::MaxGems && !CheckFizzle(spell_id)) {
-			int fizzle_msg = IsBardSong(spell_id) ? MISS_NOTE : SPELL_FIZZLE;
+			int fizzle_msg = IsBardSong(spell_id) ? ClientString::MISS_NOTE : ClientString::SPELL_FIZZLE;
 			InterruptSpell(fizzle_msg, 0x121, spell_id);
 
 			uint32 use_mana = ((spells[spell_id].mana) / 4);
@@ -7191,7 +7191,7 @@ void Bot::ProcessBotGroupInvite(Client* c, std::string const& botName) {
 				}
 			}
 		} else if (invitedBot->HasGroup()) {
-			c->MessageString(Chat::LightGray, TARGET_ALREADY_IN_GROUP, invitedBot->GetCleanName());
+			c->MessageString(Chat::LightGray, ClientString::TARGET_ALREADY_IN_GROUP, invitedBot->GetCleanName());
 		}
 	}
 }
@@ -7931,7 +7931,7 @@ void Bot::RaidGroupSay(const char* msg, ...) {
 		if (r) {
 			for (const auto& m : r->members) {
 				if (m.member && m.member->IsClient()) {
-					m.member->FilteredMessageString(this,Chat::PetResponse,FilterSocials,GENERIC_SAY,GetCleanName(),buf);
+					m.member->FilteredMessageString(this,Chat::PetResponse,FilterSocials, ClientString::GENERIC_SAY,GetCleanName(),buf);
 				}
 			}
 		}
@@ -7939,12 +7939,12 @@ void Bot::RaidGroupSay(const char* msg, ...) {
 	else if (HasGroup()) {
 			for (auto& m : GetGroup()->members) {
 				if (m && m->IsClient()) {
-					m->FilteredMessageString(this,Chat::PetResponse,FilterSocials,GENERIC_SAY,GetCleanName(),buf);
+					m->FilteredMessageString(this,Chat::PetResponse,FilterSocials, ClientString::GENERIC_SAY,GetCleanName(),buf);
 				}
 			}
 	}
 	else if (GetOwner()) {
-		GetOwner()->FilteredMessageString(this,Chat::PetResponse,FilterSocials,GENERIC_SAY,GetCleanName(),buf);
+		GetOwner()->FilteredMessageString(this,Chat::PetResponse,FilterSocials, ClientString::GENERIC_SAY,GetCleanName(),buf);
 	}
 }
 
@@ -13369,7 +13369,7 @@ bool Bot::IsImmuneToBotSpell(uint16 spell_id, Mob* caster) {
 
 		if (IsClient() && caster->IsClient() && (caster->CastToClient()->GetGM() == false)) {
 			LogSpells("Clients cannot fear eachother!");
-			caster->MessageString(Chat::Red, IMMUNE_FEAR);	// need to verify message type, not in MQ2Cast for easy look up
+			caster->MessageString(Chat::Red, ClientString::IMMUNE_FEAR);	// need to verify message type, not in MQ2Cast for easy look up
 			return true;
 		}
 		else if (GetLevel() > spells[spell_id].max_value[effect_index] && spells[spell_id].max_value[effect_index] != 0) {

--- a/zone/bot_commands/inventory.cpp
+++ b/zone/bot_commands/inventory.cpp
@@ -190,7 +190,7 @@ void bot_command_inventory_remove(Client* c, const Seperator* sep)
 	int ab_mask = (ActionableBots::ABM_Target | ActionableBots::ABM_ByName);
 
 	if (c->GetTradeskillObject() || (c->trade->state == Trading)) {
-		c->MessageString(Chat::Tell, MERCHANT_BUSY);
+		c->MessageString(Chat::Tell, ClientString::MERCHANT_BUSY);
 		return;
 	}
 

--- a/zone/bot_commands/pet.cpp
+++ b/zone/bot_commands/pet.cpp
@@ -34,7 +34,7 @@ void bot_command_pet_get_lost(Client *c, const Seperator *sep)
 		if (!bot_iter->GetPet() || bot_iter->GetPet()->IsCharmed())
 			continue;
 
-		bot_iter->GetPet()->SayString(PET_GETLOST_STRING);
+		bot_iter->GetPet()->SayString(ClientString::PET_GETLOST_STRING);
 		bot_iter->GetPet()->Depop(false);
 		bot_iter->SetPetID(0);
 		database.botdb.DeletePetItems(bot_iter->GetBotID());
@@ -80,7 +80,7 @@ void bot_command_pet_remove(Client *c, const Seperator *sep)
 		}
 
 		if (bot_iter->GetPet()) {
-			bot_iter->GetPet()->SayString(PET_GETLOST_STRING);
+			bot_iter->GetPet()->SayString(ClientString::PET_GETLOST_STRING);
 			bot_iter->GetPet()->Depop(false);
 			bot_iter->SetPetID(0);
 		}

--- a/zone/bot_raid.cpp
+++ b/zone/bot_raid.cpp
@@ -154,7 +154,7 @@ void Bot::ProcessRaidInvite(Mob* invitee, Client* invitor, bool group_invite) {
 	Raid* raid = entity_list.GetRaidByClient(invitor);
 
 	if (raid && raid->RaidCount() >= MAX_RAID_MEMBERS) {
-		invitor->MessageString(Chat::Red, RAID_IS_FULL);
+		invitor->MessageString(Chat::Red, ClientString::RAID_IS_FULL);
 		return;
 	}
 	Bot::CreateBotRaid(invitee, invitor, group_invite, raid);

--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -1361,9 +1361,9 @@ void Client::ChannelMessageReceived(uint8 chan_num, uint8 language, uint8 lang_s
 	{
 	case ChatChannel_Guild: { /* Guild Chat */
 		if (!IsInAGuild()) {
-			MessageString(Chat::DefaultText, GUILD_NOT_MEMBER2);	//You are not a member of any guild.
+			MessageString(Chat::DefaultText, ClientString::GUILD_NOT_MEMBER2);	//You are not a member of any guild.
 		} else if (!guild_mgr.CheckPermission(GuildID(), GuildRank(), GUILD_ACTION_GUILD_CHAT_SPEAK_IN)) {
-			MessageString(Chat::EchoGuild, NO_PROPER_ACCESS);
+			MessageString(Chat::EchoGuild, ClientString::NO_PROPER_ACCESS);
 		} else if (!worldserver.SendChannelMessage(this, targetname, chan_num, GuildID(), language, lang_skill, message)) {
 			Message(Chat::White, "Error: World server disconnected");
 		}
@@ -2090,7 +2090,7 @@ void Client::IncreaseLanguageSkill(uint8 language_id, uint8 increase)
 	QueuePacket(outapp);
 	safe_delete(outapp);
 
-	MessageString(Chat::Skills, LANG_SKILL_IMPROVED);
+	MessageString(Chat::Skills, ClientString::LANG_SKILL_IMPROVED);
 }
 
 void Client::AddSkill(EQ::skills::SkillType skillid, uint16 value) {
@@ -3323,7 +3323,7 @@ void Client::SetPVP(bool toggle, bool message) {
 
 	if (message) {
 		if(GetPVP()) {
-			MessageString(Chat::Shout, PVP_ON);
+			MessageString(Chat::Shout, ClientString::PVP_ON);
 		} else {
 			Message(Chat::Shout, "You now follow the ways of Order.");
 		}
@@ -3454,22 +3454,22 @@ void Client::Disarm(Client* disarmer, int chance) {
 					if (matslot != EQ::textures::materialInvalid)
 						SendWearChange(matslot);
 				}
-				MessageString(Chat::Skills, DISARMED);
+				MessageString(Chat::Skills, ClientString::DISARMED);
 				if (disarmer != this)
-					disarmer->MessageString(Chat::Skills, DISARM_SUCCESS, GetCleanName());
+					disarmer->MessageString(Chat::Skills, ClientString::DISARM_SUCCESS, GetCleanName());
 				if (chance != 1000)
 					disarmer->CheckIncreaseSkill(EQ::skills::SkillDisarm, nullptr, 4);
 				CalcBonuses();
 				// CalcEnduranceWeightFactor();
 				return;
 			}
-			disarmer->MessageString(Chat::Skills, DISARM_FAILED);
+			disarmer->MessageString(Chat::Skills, ClientString::DISARM_FAILED);
 			if (chance != 1000)
 				disarmer->CheckIncreaseSkill(EQ::skills::SkillDisarm, nullptr, 2);
 			return;
 		}
 	}
-	disarmer->MessageString(Chat::Skills, DISARM_FAILED);
+	disarmer->MessageString(Chat::Skills, ClientString::DISARM_FAILED);
 }
 
 bool Client::BindWound(Mob *bindmob, bool start, bool fail)
@@ -3512,7 +3512,7 @@ bool Client::BindWound(Mob *bindmob, bool start, bool fail)
 				// send bindmob "stand still"
 				if (!bindmob->IsAIControlled() && bindmob != this) {
 					bindmob->CastToClient()->MessageString(Chat::Yellow,
-										  YOU_ARE_BEING_BANDAGED);
+						ClientString::YOU_ARE_BEING_BANDAGED);
 				} else if (bindmob->IsAIControlled() && bindmob != this) {
 					; // Tell IPC to stand still?
 				} else {
@@ -4010,7 +4010,7 @@ void Client::Tell_StringID(uint32 string_id, const char *who, const char *messag
 	char string_id_str[10];
 	snprintf(string_id_str, 10, "%d", string_id);
 
-	MessageString(Chat::EchoTell, TELL_QUEUED_MESSAGE, who, string_id_str, message);
+	MessageString(Chat::EchoTell, ClientString::TELL_QUEUED_MESSAGE, who, string_id_str, message);
 }
 
 void Client::SetTint(int16 in_slot, uint32 color) {
@@ -4080,7 +4080,7 @@ void Client::SetLanguageSkill(uint8 language_id, uint8 language_skill)
 	QueuePacket(outapp);
 	safe_delete(outapp);
 
-	MessageString(Chat::Skills, LANG_SKILL_IMPROVED);
+	MessageString(Chat::Skills, ClientString::LANG_SKILL_IMPROVED);
 }
 
 void Client::LinkDead()
@@ -4170,7 +4170,7 @@ void Client::Escape()
 {
 	entity_list.RemoveFromTargets(this, true);
 	SetInvisible(Invisibility::Invisible);
-	MessageString(Chat::Skills, ESCAPE);
+	MessageString(Chat::Skills, ClientString::ESCAPE);
 }
 
 float Client::CalcClassicPriceMod(Mob* other, bool reverse) {
@@ -4383,13 +4383,13 @@ void Client::SacrificeConfirm(Mob *caster)
 	}
 
 	if (GetLevel() < RuleI(Spells, SacrificeMinLevel)) {
-		caster->MessageString(Chat::Red, SAC_TOO_LOW); // This being is not a worthy sacrifice.
+		caster->MessageString(Chat::Red, ClientString::SAC_TOO_LOW); // This being is not a worthy sacrifice.
 		safe_delete(outapp);
 		return;
 	}
 
 	if (GetLevel() > RuleI(Spells, SacrificeMaxLevel)) {
-		caster->MessageString(Chat::Red, SAC_TOO_HIGH);
+		caster->MessageString(Chat::Red, ClientString::SAC_TOO_HIGH);
 		safe_delete(outapp);
 		return;
 	}
@@ -4461,7 +4461,7 @@ void Client::Sacrifice(Mob *caster)
 			}
 		}
 	} else {
-		caster->MessageString(Chat::Red, SAC_TOO_LOW); // This being is not a worthy sacrifice.
+		caster->MessageString(Chat::Red, ClientString::SAC_TOO_LOW); // This being is not a worthy sacrifice.
 	}
 }
 
@@ -5679,7 +5679,7 @@ void Client::HandleLDoNOpen(NPC *target)
 		{
 			if(target->GetLDoNTrapSpellID() != 0)
 			{
-				MessageString(Chat::Red, LDON_ACCIDENT_SETOFF2);
+				MessageString(Chat::Red, ClientString::LDON_ACCIDENT_SETOFF2);
 				target->SpellFinished(target->GetLDoNTrapSpellID(), this, EQ::spells::CastingSlot::Item, 0, -1, spells[target->GetLDoNTrapSpellID()].resist_difficulty);
 				target->SetLDoNTrapSpellID(0);
 				target->SetLDoNTrapped(false);
@@ -5695,7 +5695,7 @@ void Client::HandleLDoNOpen(NPC *target)
 
 		if(target->IsLDoNLocked())
 		{
-			MessageString(Chat::Skills, LDON_STILL_LOCKED, target->GetCleanName());
+			MessageString(Chat::Skills, ClientString::LDON_STILL_LOCKED, target->GetCleanName());
 			return;
 		}
 		else
@@ -5729,13 +5729,13 @@ void Client::HandleLDoNSenseTraps(NPC *target, uint16 skill, uint8 type)
 		{
 			if((target->GetLDoNTrapType() == LDoNTypeCursed || target->GetLDoNTrapType() == LDoNTypeMagical) && type != target->GetLDoNTrapType())
 			{
-				MessageString(Chat::Skills, LDON_CANT_DETERMINE_TRAP, target->GetCleanName());
+				MessageString(Chat::Skills, ClientString::LDON_CANT_DETERMINE_TRAP, target->GetCleanName());
 				return;
 			}
 
 			if(target->IsLDoNTrapDetected())
 			{
-				MessageString(Chat::Skills, LDON_CERTAIN_TRAP, target->GetCleanName());
+				MessageString(Chat::Skills, ClientString::LDON_CERTAIN_TRAP, target->GetCleanName());
 			}
 			else
 			{
@@ -5744,10 +5744,10 @@ void Client::HandleLDoNSenseTraps(NPC *target, uint16 skill, uint8 type)
 				{
 				case -1:
 				case 0:
-					MessageString(Chat::Skills, LDON_DONT_KNOW_TRAPPED, target->GetCleanName());
+					MessageString(Chat::Skills, ClientString::LDON_DONT_KNOW_TRAPPED, target->GetCleanName());
 					break;
 				case 1:
-					MessageString(Chat::Skills, LDON_CERTAIN_TRAP, target->GetCleanName());
+					MessageString(Chat::Skills, ClientString::LDON_CERTAIN_TRAP, target->GetCleanName());
 					target->SetLDoNTrapDetected(true);
 					break;
 				default:
@@ -5757,7 +5757,7 @@ void Client::HandleLDoNSenseTraps(NPC *target, uint16 skill, uint8 type)
 		}
 		else
 		{
-			MessageString(Chat::Skills, LDON_CERTAIN_NOT_TRAP, target->GetCleanName());
+			MessageString(Chat::Skills, ClientString::LDON_CERTAIN_NOT_TRAP, target->GetCleanName());
 		}
 	}
 }
@@ -5770,13 +5770,13 @@ void Client::HandleLDoNDisarm(NPC *target, uint16 skill, uint8 type)
 		{
 			if(!target->IsLDoNTrapped())
 			{
-				MessageString(Chat::Skills, LDON_WAS_NOT_TRAPPED, target->GetCleanName());
+				MessageString(Chat::Skills, ClientString::LDON_WAS_NOT_TRAPPED, target->GetCleanName());
 				return;
 			}
 
 			if((target->GetLDoNTrapType() == LDoNTypeCursed || target->GetLDoNTrapType() == LDoNTypeMagical) && type != target->GetLDoNTrapType())
 			{
-				MessageString(Chat::Skills, LDON_HAVE_NOT_DISARMED, target->GetCleanName());
+				MessageString(Chat::Skills, ClientString::LDON_HAVE_NOT_DISARMED, target->GetCleanName());
 				return;
 			}
 
@@ -5795,13 +5795,13 @@ void Client::HandleLDoNDisarm(NPC *target, uint16 skill, uint8 type)
 				target->SetLDoNTrapDetected(false);
 				target->SetLDoNTrapped(false);
 				target->SetLDoNTrapSpellID(0);
-				MessageString(Chat::Skills, LDON_HAVE_DISARMED, target->GetCleanName());
+				MessageString(Chat::Skills, ClientString::LDON_HAVE_DISARMED, target->GetCleanName());
 				break;
 			case 0:
-				MessageString(Chat::Skills, LDON_HAVE_NOT_DISARMED, target->GetCleanName());
+				MessageString(Chat::Skills, ClientString::LDON_HAVE_NOT_DISARMED, target->GetCleanName());
 				break;
 			case -1:
-				MessageString(Chat::Red, LDON_ACCIDENT_SETOFF2);
+				MessageString(Chat::Red, ClientString::LDON_ACCIDENT_SETOFF2);
 				target->SpellFinished(target->GetLDoNTrapSpellID(), this, EQ::spells::CastingSlot::Item, 0, -1, spells[target->GetLDoNTrapSpellID()].resist_difficulty);
 				target->SetLDoNTrapSpellID(0);
 				target->SetLDoNTrapped(false);
@@ -5820,7 +5820,7 @@ void Client::HandleLDoNPickLock(NPC *target, uint16 skill, uint8 type)
 		{
 			if(target->IsLDoNTrapped())
 			{
-				MessageString(Chat::Red, LDON_ACCIDENT_SETOFF2);
+				MessageString(Chat::Red, ClientString::LDON_ACCIDENT_SETOFF2);
 				target->SpellFinished(target->GetLDoNTrapSpellID(), this, EQ::spells::CastingSlot::Item, 0, -1, spells[target->GetLDoNTrapSpellID()].resist_difficulty);
 				target->SetLDoNTrapSpellID(0);
 				target->SetLDoNTrapped(false);
@@ -5829,7 +5829,7 @@ void Client::HandleLDoNPickLock(NPC *target, uint16 skill, uint8 type)
 
 			if(!target->IsLDoNLocked())
 			{
-				MessageString(Chat::Skills, LDON_WAS_NOT_LOCKED, target->GetCleanName());
+				MessageString(Chat::Skills, ClientString::LDON_WAS_NOT_LOCKED, target->GetCleanName());
 				return;
 			}
 
@@ -5845,11 +5845,11 @@ void Client::HandleLDoNPickLock(NPC *target, uint16 skill, uint8 type)
 			{
 			case 0:
 			case -1:
-				MessageString(Chat::Skills, LDON_PICKLOCK_FAILURE, target->GetCleanName());
+				MessageString(Chat::Skills, ClientString::LDON_PICKLOCK_FAILURE, target->GetCleanName());
 				break;
 			case 1:
 				target->SetLDoNLocked(false);
-				MessageString(Chat::Skills, LDON_PICKLOCK_SUCCESS, target->GetCleanName());
+				MessageString(Chat::Skills, ClientString::LDON_PICKLOCK_SUCCESS, target->GetCleanName());
 				break;
 			}
 		}
@@ -6409,7 +6409,7 @@ void Client::SuspendMinion(int value)
 
 			CurrentPet->SetTaunting(m_suspendedminion.taunting);
 
-			MessageString(Chat::Magenta, SUSPEND_MINION_UNSUSPEND, CurrentPet->GetCleanName());
+			MessageString(Chat::Magenta, ClientString::SUSPEND_MINION_UNSUSPEND, CurrentPet->GetCleanName());
 
 			memset(&m_suspendedminion, 0, sizeof(struct PetInfo));
 			// TODO: These pet command states need to be synced ...
@@ -6440,19 +6440,19 @@ void Client::SuspendMinion(int value)
 		{
 			if(m_suspendedminion.SpellID > 0)
 			{
-				MessageString(Chat::Red,ONLY_ONE_PET);
+				MessageString(Chat::Red, ClientString::ONLY_ONE_PET);
 
 				return;
 			}
 			else if(CurrentPet->IsEngaged())
 			{
-				MessageString(Chat::Red,SUSPEND_MINION_FIGHTING);
+				MessageString(Chat::Red, ClientString::SUSPEND_MINION_FIGHTING);
 
 				return;
 			}
 			else if(entity_list.Fighting(CurrentPet))
 			{
-				MessageString(Chat::Blue,SUSPEND_MINION_HAS_AGGRO);
+				MessageString(Chat::Blue, ClientString::SUSPEND_MINION_HAS_AGGRO);
 			}
 			else
 			{
@@ -6469,7 +6469,7 @@ void Client::SuspendMinion(int value)
 				else
 					strn0cpy(m_suspendedminion.Name, CurrentPet->GetName(), 64); // Name stays even at rank 1
 
-				MessageString(Chat::Magenta, SUSPEND_MINION_SUSPEND, CurrentPet->GetCleanName());
+				MessageString(Chat::Magenta, ClientString::SUSPEND_MINION_SUSPEND, CurrentPet->GetCleanName());
 
 				CurrentPet->Depop(false);
 
@@ -6478,7 +6478,7 @@ void Client::SuspendMinion(int value)
 		}
 		else
 		{
-			MessageString(Chat::Red, ONLY_SUMMONED_PETS);
+			MessageString(Chat::Red, ClientString::ONLY_SUMMONED_PETS);
 
 			return;
 		}
@@ -6504,7 +6504,7 @@ void Client::AddEbonCrystals(uint32 amount, bool is_reclaim) {
 
 	MessageString(
 		Chat::Yellow,
-		YOU_RECEIVE,
+		ClientString::YOU_RECEIVE,
 		fmt::format(
 			"{} {}",
 			amount,
@@ -6531,7 +6531,7 @@ void Client::AddRadiantCrystals(uint32 amount, bool is_reclaim) {
 
 	MessageString(
 		Chat::Yellow,
-		YOU_RECEIVE,
+		ClientString::YOU_RECEIVE,
 		fmt::format(
 			"{} {}",
 			amount,
@@ -7034,16 +7034,16 @@ void Client::LocateCorpse()
 
 	if(ClosestCorpse)
 	{
-		MessageString(Chat::Spells, SENSE_CORPSE_DIRECTION);
+		MessageString(Chat::Spells, ClientString::SENSE_CORPSE_DIRECTION);
 		SetHeading(CalculateHeadingToTarget(ClosestCorpse->GetX(), ClosestCorpse->GetY()));
 		SetTarget(ClosestCorpse);
 		SendTargetCommand(ClosestCorpse->GetID());
 		SentPositionPacket(0.0f, 0.0f, 0.0f, 0.0f, 0, true);
 	}
 	else if(!GetTarget())
-		MessageString(Chat::Red, SENSE_CORPSE_NONE);
+		MessageString(Chat::Red, ClientString::SENSE_CORPSE_NONE);
 	else
-		MessageString(Chat::Red, SENSE_CORPSE_NOT_NAME);
+		MessageString(Chat::Red, ClientString::SENSE_CORPSE_NOT_NAME);
 }
 
 void Client::NPCSpawn(NPC *target_npc, const char *identifier, uint32 extra)
@@ -7121,7 +7121,7 @@ void Client::DragCorpses()
 		if (!corpse || !corpse->IsPlayerCorpse() ||
 				corpse->CastToCorpse()->IsBeingLooted() ||
 				!corpse->CastToCorpse()->Summon(this, false, false)) {
-			MessageString(Chat::DefaultText, CORPSEDRAG_STOP);
+			MessageString(Chat::DefaultText, ClientString::CORPSEDRAG_STOP);
 			It = DraggedCorpses.erase(It);
 			if (It == DraggedCorpses.end())
 				break;
@@ -7132,10 +7132,10 @@ void Client::DragCorpses()
 void Client::ConsentCorpses(std::string consent_name, bool deny)
 {
 	if (strcasecmp(consent_name.c_str(), GetName()) == 0) {
-		MessageString(Chat::Red, CONSENT_YOURSELF);
+		MessageString(Chat::Red, ClientString::CONSENT_YOURSELF);
 	}
 	else if (!consent_throttle_timer.Check()) {
-		MessageString(Chat::Red, CONSENT_WAIT);
+		MessageString(Chat::Red, ClientString::CONSENT_WAIT);
 	}
 	else {
 		auto pack = new ServerPacket(ServerOP_Consent, sizeof(ServerOP_Consent_Struct));
@@ -8076,7 +8076,7 @@ void Client::DuplicateLoreMessage(uint32 ItemID)
 {
 	if (!(m_ClientVersionBit & EQ::versions::maskRoFAndLater))
 	{
-		MessageString(Chat::White, PICK_LORE);
+		MessageString(Chat::White, ClientString::PICK_LORE);
 		return;
 	}
 
@@ -8085,7 +8085,7 @@ void Client::DuplicateLoreMessage(uint32 ItemID)
 	if(!item)
 		return;
 
-	MessageString(Chat::White, PICK_LORE, item->Name);
+	MessageString(Chat::White, ClientString::PICK_LORE, item->Name);
 }
 
 void Client::GarbleMessage(char *message, uint8 variance)
@@ -8442,23 +8442,23 @@ void Client::MerchantRejectMessage(Mob *merchant, int primaryfaction)
 	}
 	// If no primary faction or biggest influence is your faction hit
 	if (primaryfaction <= 0 || lowestvalue == tmpFactionValue) {
-		merchant->SayString(zone->random.Int(WONT_SELL_DEEDS1, WONT_SELL_DEEDS6));
+		merchant->SayString(zone->random.Int(ClientString::WONT_SELL_DEEDS1, ClientString::WONT_SELL_DEEDS6));
 	} else if (lowestvalue == fmod.race_mod) { // race biggest
 		// Non-standard race (ex. illusioned to wolf)
 		if (!IsPlayerRace(GetRace())) {
 			messageid = zone->random.Int(1, 3); // these aren't sequential StringIDs :(
 			switch (messageid) {
 			case 1:
-				messageid = WONT_SELL_NONSTDRACE1;
+				messageid = ClientString::WONT_SELL_NONSTDRACE1;
 				break;
 			case 2:
-				messageid = WONT_SELL_NONSTDRACE2;
+				messageid = ClientString::WONT_SELL_NONSTDRACE2;
 				break;
 			case 3:
-				messageid = WONT_SELL_NONSTDRACE3;
+				messageid = ClientString::WONT_SELL_NONSTDRACE3;
 				break;
 			default: // w/e should never happen
-				messageid = WONT_SELL_NONSTDRACE1;
+				messageid = ClientString::WONT_SELL_NONSTDRACE1;
 				break;
 			}
 			merchant->SayString(messageid);
@@ -8466,30 +8466,30 @@ void Client::MerchantRejectMessage(Mob *merchant, int primaryfaction)
 			messageid = zone->random.Int(1, 4);
 			switch (messageid) {
 			case 1:
-				messageid = WONT_SELL_RACE1;
+				messageid = ClientString::WONT_SELL_RACE1;
 				break;
 			case 2:
-				messageid = WONT_SELL_RACE2;
+				messageid = ClientString::WONT_SELL_RACE2;
 				break;
 			case 3:
-				messageid = WONT_SELL_RACE3;
+				messageid = ClientString::WONT_SELL_RACE3;
 				break;
 			case 4:
-				messageid = WONT_SELL_RACE4;
+				messageid = ClientString::WONT_SELL_RACE4;
 				break;
 			default: // w/e should never happen
-				messageid = WONT_SELL_RACE1;
+				messageid = ClientString::WONT_SELL_RACE1;
 				break;
 			}
 			merchant->SayString(messageid, itoa(GetRace()));
 		}
 	} else if (lowestvalue == fmod.class_mod) {
-		merchant->SayString(zone->random.Int(WONT_SELL_CLASS1, WONT_SELL_CLASS5), itoa(GetClass()));
+		merchant->SayString(zone->random.Int(ClientString::WONT_SELL_CLASS1, ClientString::WONT_SELL_CLASS5), itoa(GetClass()));
 	} else {
 		// Must be deity - these two sound the best for that.
 		// Can't use a message with a field, GUI wants class/race names.
 		// for those message IDs.  These are straight text.
-		merchant->SayString(zone->random.Int(WONT_SELL_DEEDS1, WONT_SELL_DEEDS2));
+		merchant->SayString(zone->random.Int(ClientString::WONT_SELL_DEEDS1, ClientString::WONT_SELL_DEEDS2));
 	}
 	return;
 }
@@ -8526,13 +8526,13 @@ void Client::SendFactionMessage(int32 tmpvalue, int32 faction_id, int32 faction_
 	if (tmpvalue == 0 || temp == 1 || temp == 2) {
 		return;
 	} else if (faction_value >= this_faction_max) {
-		MessageString(Chat::Yellow, FACTION_BEST, name);
+		MessageString(Chat::Yellow, ClientString::FACTION_BEST, name);
 	} else if (faction_value <= this_faction_min) {
-		MessageString(Chat::Yellow, FACTION_WORST, name);
+		MessageString(Chat::Yellow, ClientString::FACTION_WORST, name);
 	} else if (tmpvalue > 0 && !RuleB(Client, UseLiveFactionMessage)) {
-		MessageString(Chat::Yellow, FACTION_BETTER, name);
+		MessageString(Chat::Yellow, ClientString::FACTION_BETTER, name);
 	} else if (tmpvalue < 0 && !RuleB(Client, UseLiveFactionMessage)) {
-		MessageString(Chat::Yellow, FACTION_WORSE, name);
+		MessageString(Chat::Yellow, ClientString::FACTION_WORSE, name);
 	} else if (RuleB(Client, UseLiveFactionMessage)) {
 		Message(
 			Chat::Yellow,
@@ -8834,7 +8834,7 @@ void Client::Consume(const EQ::ItemData *item, uint8 type, int16 slot, bool auto
 		DeleteItemInInventory(slot, 1);
 
 		if (!auto_consume) // no message if the client consumed for us
-			entity_list.MessageCloseString(this, true, 50, 0, EATING_MESSAGE, GetName(), item->Name);
+			entity_list.MessageCloseString(this, true, 50, 0, ClientString::EATING_MESSAGE, GetName(), item->Name);
 
 		LogFood("Eating from slot: [{}]", (int)slot);
 
@@ -8846,7 +8846,7 @@ void Client::Consume(const EQ::ItemData *item, uint8 type, int16 slot, bool auto
 		LogFood("Consuming drink, points added to thirst_level: [{}] current_thirst: [{}]", increase, m_pp.thirst_level);
 
 		if (!auto_consume) // no message if the client consumed for us
-			entity_list.MessageCloseString(this, true, 50, 0, DRINKING_MESSAGE, GetName(), item->Name);
+			entity_list.MessageCloseString(this, true, 50, 0, ClientString::DRINKING_MESSAGE, GetName(), item->Name);
 
 		LogFood("Drinking from slot: [{}]", (int)slot);
 	}
@@ -10388,13 +10388,13 @@ void Client::DzListTimers()
 		{
 			found = true;
 			auto time = lockout.GetTimeRemainingStrs();
-			MessageString(Chat::Yellow, DZ_TIMER, time.days.c_str(), time.hours.c_str(), time.mins.c_str(), lockout.DzName().c_str());
+			MessageString(Chat::Yellow, ClientString::DZ_TIMER, time.days.c_str(), time.hours.c_str(), time.mins.c_str(), lockout.DzName().c_str());
 		}
 	}
 
 	if (!found)
 	{
-		MessageString(Chat::Yellow, DZ_NO_TIMERS);
+		MessageString(Chat::Yellow, ClientString::DZ_NO_TIMERS);
 	}
 }
 
@@ -10590,7 +10590,7 @@ void Client::MovePCDynamicZone(uint32 zone_id, int zone_version, bool msg_if_inv
 	{
 		if (msg_if_invalid)
 		{
-			MessageString(Chat::Red, DZ_WAY_IS_BLOCKED); // unconfirmed message
+			MessageString(Chat::Red, ClientString::DZ_WAY_IS_BLOCKED); // unconfirmed message
 		}
 	}
 	else if (client_dzs.size() == 1)
@@ -11909,11 +11909,11 @@ void Client::AddAAPoints(uint32 points)
 	}
 
 	if (points == 1 && m_pp.aapoints == 1) {
-		MessageString(Chat::Yellow, GAIN_SINGLE_AA_SINGLE_AA, fmt::format_int(m_pp.aapoints).c_str());
+		MessageString(Chat::Yellow, ClientString::GAIN_SINGLE_AA_SINGLE_AA, fmt::format_int(m_pp.aapoints).c_str());
 	} else if (points == 1 && m_pp.aapoints > 1) {
-		MessageString(Chat::Yellow, GAIN_SINGLE_AA_MULTI_AA, fmt::format_int(m_pp.aapoints).c_str());
+		MessageString(Chat::Yellow, ClientString::GAIN_SINGLE_AA_MULTI_AA, fmt::format_int(m_pp.aapoints).c_str());
 	} else {
-		MessageString(Chat::Yellow, GAIN_MULTI_AA_MULTI_AA, fmt::format_int(points).c_str(), fmt::format_int(m_pp.aapoints).c_str());
+		MessageString(Chat::Yellow, ClientString::GAIN_MULTI_AA_MULTI_AA, fmt::format_int(points).c_str(), fmt::format_int(m_pp.aapoints).c_str());
 	}
 
 	SendAlternateAdvancementStats();
@@ -13102,10 +13102,10 @@ void Client::SetAAEXPPercentage(uint8 percentage)
 	const uint32 before_percentage = m_epp.perAA;
 
 	if (before_percentage > 0 && percentage == 0) {
-		MessageString(Chat::White, AA_OFF);
+		MessageString(Chat::White, ClientString::AA_OFF);
 	}
 	else if (before_percentage == 0 && percentage > 0) {
-		MessageString(Chat::White, AA_ON);
+		MessageString(Chat::White, ClientString::AA_ON);
 	}
 
 	m_epp.perAA = EQ::Clamp(static_cast<int>(percentage), 0, 100);

--- a/zone/client_evolving_items.cpp
+++ b/zone/client_evolving_items.cpp
@@ -396,7 +396,7 @@ bool Client::DoEvolveCheckProgression(EQ::ItemInstance &inst)
 	e.status = "Evolved Item due to obtaining progression - New Evolve Item placed in inventory.";
 	RecordPlayerEventLog(PlayerEvent::EVOLVE_ITEM, e);
 
-	MessageString(Chat::Yellow, EVOLVE_ITEM_EVOLVED, inst.GetItem()->Name);
+	MessageString(Chat::Yellow, ClientString::EVOLVE_ITEM_EVOLVED, inst.GetItem()->Name);
 
 	LogEvolveItem(
 		"Evolved item id <red>[{}] into item id <green>[{}] for Character ID <green>[{}]",

--- a/zone/client_packet.cpp
+++ b/zone/client_packet.cpp
@@ -1924,7 +1924,7 @@ void Client::Handle_OP_AAAction(const EQApplicationPacket *app)
 	}
 	else if (action->action == aaActionDisableEXP) { //Turn Off AA Exp
 		if (m_epp.perAA > 0) {
-			MessageString(Chat::White, AA_OFF);
+			MessageString(Chat::White, ClientString::AA_OFF);
 		}
 
 		m_epp.perAA = 0;
@@ -1932,7 +1932,7 @@ void Client::Handle_OP_AAAction(const EQApplicationPacket *app)
 	}
 	else if (action->action == aaActionSetEXP) {
 		if (m_epp.perAA == 0)
-			MessageString(Chat::White, AA_ON);
+			MessageString(Chat::White, ClientString::AA_ON);
 		m_epp.perAA = action->exp_value;
 		if (m_epp.perAA < 0 || m_epp.perAA > 100)
 			m_epp.perAA = 0;	// stop exploit with sanity check
@@ -2221,7 +2221,7 @@ void Client::Handle_OP_AdventureMerchantRequest(const EQApplicationPacket *app)
 		return;
 
 	if (!tmp->CastToNPC()->IsMerchantOpen()) {
-		tmp->SayString(zone->random.Int(MERCHANT_CLOSED_ONE, MERCHANT_CLOSED_THREE));
+		tmp->SayString(zone->random.Int(ClientString::MERCHANT_CLOSED_ONE, ClientString::MERCHANT_CLOSED_THREE));
 		return;
 	}
 
@@ -3052,7 +3052,7 @@ void Client::Handle_OP_ApplyPoison(const EQApplicationPacket *app)
 
 		if (poison->Proc.Level2 > GetLevel()) {
 			// Poison is too high to apply.
-			MessageString(Chat::LightBlue, POISON_TOO_HIGH);
+			MessageString(Chat::LightBlue, ClientString::POISON_TOO_HIGH);
 		}
 		else {
 
@@ -3586,7 +3586,7 @@ void Client::Handle_OP_AutoFire(const EQApplicationPacket *app)
 	}
 
 	if (GetTarget() == this) {
-		MessageString(Chat::TooFarAway, TRY_ATTACKING_SOMEONE);
+		MessageString(Chat::TooFarAway, ClientString::TRY_ATTACKING_SOMEONE);
 		auto_fire = false;
 		return;
 	}
@@ -4033,7 +4033,7 @@ void Client::Handle_OP_Bind_Wound(const EQApplicationPacket *app)
 
 	// Not allowed to forage while mounted
 	if (RuleB(Character, NoSkillsOnHorse) && GetHorseId()) {
-		MessageString(Chat::Skills, NO_SKILL_WHILE_MOUNTED);
+		MessageString(Chat::Skills, ClientString::NO_SKILL_WHILE_MOUNTED);
 		return;
 	}
 
@@ -4284,7 +4284,7 @@ void Client::Handle_OP_Camp(const EQApplicationPacket *app)
 {
 	if (ClientVersion() == EQ::versions::ClientVersion::RoF2 && RuleB(Parcel, EnableParcelMerchants) && GetEngagedWithParcelMerchant()) {
 		Stand();
-		MessageString(Chat::Yellow, TRADER_BUSY_TWO);
+		MessageString(Chat::Yellow, ClientString::TRADER_BUSY_TWO);
 		return;
 	}
 
@@ -4376,7 +4376,7 @@ void Client::Handle_OP_CastSpell(const EQApplicationPacket *app)
 		return;
 	}
 	if (IsAIControlled()) {
-		MessageString(Chat::Red, NOT_IN_CONTROL);
+		MessageString(Chat::Red, ClientString::NOT_IN_CONTROL);
 		//Message(Chat::Red, "You cant cast right now, You aren't in control of yourself!");
 		return;
 	}
@@ -5246,9 +5246,9 @@ void Client::Handle_OP_Consider(const EQApplicationPacket *app)
 	// this could be done better, but this is only called when you con so w/e
 	// Shroud of Stealth has a special message
 	if (improved_hidden && (!t->see_improved_hide && (t->SeeInvisible() || t->see_hide))) {
-		MessageString(Chat::NPCQuestSay, SOS_KEEPS_HIDDEN); // we are trying to hide but they can see us
+		MessageString(Chat::NPCQuestSay, ClientString::SOS_KEEPS_HIDDEN); // we are trying to hide but they can see us
 	} else if ((invisible || invisible_undead || hidden || invisible_animals) && !IsInvisible(t)) {
-		MessageString(Chat::NPCQuestSay, SUSPECT_SEES_YOU);
+		MessageString(Chat::NPCQuestSay, ClientString::SUSPECT_SEES_YOU);
 	}
 
 	safe_delete(outapp);
@@ -5285,12 +5285,12 @@ void Client::Handle_OP_ConsiderCorpse(const EQApplicationPacket *app)
 			minutes = (remaining_time / 60000) % 60;
 			MessageString(
 				Chat::NPCQuestSay,
-				CORPSE_DECAY_TIME_MINUTE,
+				ClientString::CORPSE_DECAY_TIME_MINUTE,
 				std::to_string(minutes).c_str(),
 				std::to_string(seconds).c_str()
 			);
 		} else {
-			MessageString(Chat::NPCQuestSay, CORPSE_DECAY_NOW);
+			MessageString(Chat::NPCQuestSay, ClientString::CORPSE_DECAY_NOW);
 		}
 	} else if (t && t->IsPlayerCorpse()) {
 		remaining_time = t->GetRemainingRezTime();
@@ -5302,7 +5302,7 @@ void Client::Handle_OP_ConsiderCorpse(const EQApplicationPacket *app)
 				if (hours) {
 					MessageString(
 						Chat::White,
-						CORPSE_REZ_TIME_HOUR,
+						ClientString::CORPSE_REZ_TIME_HOUR,
 						std::to_string(hours).c_str(),
 						std::to_string(minutes).c_str(),
 						std::to_string(seconds).c_str()
@@ -5310,14 +5310,14 @@ void Client::Handle_OP_ConsiderCorpse(const EQApplicationPacket *app)
 				} else {
 					MessageString(
 						Chat::White,
-						CORPSE_REZ_TIME_MINUTE,
+						ClientString::CORPSE_REZ_TIME_MINUTE,
 						std::to_string(minutes).c_str(),
 						std::to_string(seconds).c_str()
 					);
 				}
 				hours = 0;
 			} else {
-				MessageString(Chat::White, CORPSE_TOO_OLD);
+				MessageString(Chat::White, ClientString::CORPSE_TOO_OLD);
 			}
 		} else {
 			Message(Chat::White, "This corpse has already accepted a resurrection.");
@@ -5333,7 +5333,7 @@ void Client::Handle_OP_ConsiderCorpse(const EQApplicationPacket *app)
 			if (days) {
 				MessageString(
 					Chat::White,
-					CORPSE_DECAY_TIME_DAY,
+					ClientString::CORPSE_DECAY_TIME_DAY,
 					std::to_string(days).c_str(),
 					std::to_string(hours).c_str(),
 					std::to_string(minutes).c_str(),
@@ -5342,7 +5342,7 @@ void Client::Handle_OP_ConsiderCorpse(const EQApplicationPacket *app)
 			} else if (hours) {
 				MessageString(
 					Chat::White,
-					CORPSE_DECAY_TIME_HOUR,
+					ClientString::CORPSE_DECAY_TIME_HOUR,
 					std::to_string(hours).c_str(),
 					std::to_string(minutes).c_str(),
 					std::to_string(seconds).c_str()
@@ -5350,13 +5350,13 @@ void Client::Handle_OP_ConsiderCorpse(const EQApplicationPacket *app)
 			} else {
 				MessageString(
 					Chat::White,
-					CORPSE_DECAY_TIME_MINUTE,
+					ClientString::CORPSE_DECAY_TIME_MINUTE,
 					std::to_string(minutes).c_str(),
 					std::to_string(seconds).c_str()
 				);
 			}
 		} else {
-			MessageString(Chat::White, CORPSE_DECAY_NOW);
+			MessageString(Chat::White, ClientString::CORPSE_DECAY_NOW);
 		}
 	}
 }
@@ -5461,7 +5461,7 @@ void Client::Handle_OP_ControlBoat(const EQApplicationPacket *app)
 		}
 		else {
 
-			MessageString(Chat::Red, IN_USE);
+			MessageString(Chat::Red, ClientString::IN_USE);
 			return;
 		}
 	}
@@ -5482,7 +5482,7 @@ void Client::Handle_OP_CorpseDrag(const EQApplicationPacket *app)
 {
 	if (DraggedCorpses.size() >= (unsigned int)RuleI(Character, MaxDraggedCorpses))
 	{
-		MessageString(Chat::Red, CORPSEDRAG_LIMIT);
+		MessageString(Chat::Red, ClientString::CORPSEDRAG_LIMIT);
 		return;
 	}
 
@@ -5500,9 +5500,9 @@ void Client::Handle_OP_CorpseDrag(const EQApplicationPacket *app)
 	if (c)
 	{
 		if (c == this)
-			MessageString(Chat::DefaultText, CORPSEDRAG_ALREADY, corpse->GetCleanName());
+			MessageString(Chat::DefaultText, ClientString::CORPSEDRAG_ALREADY, corpse->GetCleanName());
 		else
-			MessageString(Chat::DefaultText, CORPSEDRAG_SOMEONE_ELSE, corpse->GetCleanName());
+			MessageString(Chat::DefaultText, ClientString::CORPSEDRAG_SOMEONE_ELSE, corpse->GetCleanName());
 
 		return;
 	}
@@ -5512,14 +5512,14 @@ void Client::Handle_OP_CorpseDrag(const EQApplicationPacket *app)
 
 	DraggedCorpses.emplace_back(std::pair<std::string, uint16>(cds->CorpseName, corpse->GetID()));
 
-	MessageString(Chat::DefaultText, CORPSEDRAG_BEGIN, cds->CorpseName);
+	MessageString(Chat::DefaultText, ClientString::CORPSEDRAG_BEGIN, cds->CorpseName);
 }
 
 void Client::Handle_OP_CorpseDrop(const EQApplicationPacket *app)
 {
 	if (app->size == 1)
 	{
-		MessageString(Chat::DefaultText, CORPSEDRAG_STOPALL);
+		MessageString(Chat::DefaultText, ClientString::CORPSEDRAG_STOPALL);
 		ClearDraggedCorpses();
 		return;
 	}
@@ -5528,7 +5528,7 @@ void Client::Handle_OP_CorpseDrop(const EQApplicationPacket *app)
 	{
 		if (!strcasecmp(Iterator->first.c_str(), (const char *)app->pBuffer))
 		{
-			MessageString(Chat::DefaultText, CORPSEDRAG_STOP);
+			MessageString(Chat::DefaultText, ClientString::CORPSEDRAG_STOP);
 			Iterator = DraggedCorpses.erase(Iterator);
 			return;
 		}
@@ -5700,7 +5700,7 @@ void Client::Handle_OP_DeleteItem(const EQApplicationPacket *app)
 	DeleteItem_Struct* alc = (DeleteItem_Struct*)app->pBuffer;
 	const EQ::ItemInstance *inst = GetInv().GetItem(alc->from_slot);
 	if (inst && inst->GetItem()->ItemType == EQ::item::ItemTypeAlcohol) {
-		entity_list.MessageCloseString(this, true, 50, 0, DRINKING_MESSAGE, GetName(), inst->GetItem()->Name);
+		entity_list.MessageCloseString(this, true, 50, 0, ClientString::DRINKING_MESSAGE, GetName(), inst->GetItem()->Name);
 		CheckIncreaseSkill(EQ::skills::SkillAlcoholTolerance, nullptr, 25);
 
 		int16 AlcoholTolerance = GetSkill(EQ::skills::SkillAlcoholTolerance);
@@ -5845,7 +5845,7 @@ void Client::Handle_OP_Disarm(const EQApplicationPacket *app) {
 		return;
 	}
 	// Trying to disarm something we can't disarm
-	MessageString(Chat::Skills, DISARM_NO_TARGET);
+	MessageString(Chat::Skills, ClientString::DISARM_NO_TARGET);
 
 	return;
 }
@@ -5903,7 +5903,7 @@ void Client::Handle_OP_DisarmTraps(const EQApplicationPacket *app)
 			if ((zone->random.Int(0, 49) + uskill) >= (zone->random.Int(0, 49) + trap->skill))
 			{
 				success = SKILLUP_SUCCESS;
-				MessageString(Chat::Skills, DISARMED_TRAP);
+				MessageString(Chat::Skills, ClientString::DISARMED_TRAP);
 				trap->disarmed = true;
 				Log(Logs::General, Logs::Traps, "Trap %d is disarmed.", trap->trap_id);
 				trap->UpdateTrap();
@@ -5913,7 +5913,7 @@ void Client::Handle_OP_DisarmTraps(const EQApplicationPacket *app)
 				int fail_rate = 25;
 				int trap_circumvention = spellbonuses.TrapCircumvention + itembonuses.TrapCircumvention + aabonuses.TrapCircumvention;
 				fail_rate -= fail_rate * trap_circumvention / 100;
-				MessageString(Chat::Skills, FAIL_DISARM_DETECTED_TRAP);
+				MessageString(Chat::Skills, ClientString::FAIL_DISARM_DETECTED_TRAP);
 				if (zone->random.Int(0, 99) < fail_rate) {
 					trap->Trigger(this);
 				}
@@ -5923,12 +5923,12 @@ void Client::Handle_OP_DisarmTraps(const EQApplicationPacket *app)
 		}
 		else
 		{
-			MessageString(Chat::Skills, TRAP_TOO_FAR);
+			MessageString(Chat::Skills, ClientString::TRAP_TOO_FAR);
 		}
 	}
 	else
 	{
-		MessageString(Chat::Skills, LDON_SENSE_TRAP2);
+		MessageString(Chat::Skills, ClientString::LDON_SENSE_TRAP2);
 	}
 
 	return;
@@ -6042,9 +6042,9 @@ void Client::Handle_OP_DuelDecline(const EQApplicationPacket *app)
 	initiator->CastToClient()->SetDuelTarget(0);
 	initiator->CastToClient()->SetDueling(false);
 	if (GetID() == initiator->GetID()) {
-		entity->CastToClient()->MessageString(Chat::NPCQuestSay, DUEL_DECLINE, initiator->GetName());
+		entity->CastToClient()->MessageString(Chat::NPCQuestSay, ClientString::DUEL_DECLINE, initiator->GetName());
 	} else {
-		initiator->CastToClient()->MessageString(Chat::NPCQuestSay, DUEL_DECLINE, entity->GetName());
+		initiator->CastToClient()->MessageString(Chat::NPCQuestSay, ClientString::DUEL_DECLINE, entity->GetName());
 	}
 	return;
 }
@@ -6422,7 +6422,7 @@ void Client::Handle_OP_FaceChange(const EQApplicationPacket *app)
 	m_pp.drakkin_tattoo = fc->drakkin_tattoo;
 	m_pp.drakkin_details = fc->drakkin_details;
 	Save();
-	MessageString(Chat::Red, FACE_ACCEPTED);
+	MessageString(Chat::Red, ClientString::FACE_ACCEPTED);
 	return;
 }
 
@@ -6460,7 +6460,7 @@ void Client::Handle_OP_FeignDeath(const EQApplicationPacket *app)
 	uint16 totalfeign = primfeign + secfeign;
 	if (zone->random.Real(0, 160) > totalfeign) {
 		SetFeigned(false);
-		entity_list.MessageCloseString(this, false, 200, 10, STRING_FEIGNFAILED, GetName());
+		entity_list.MessageCloseString(this, false, 200, 10, ClientString::STRING_FEIGNFAILED, GetName());
 	}
 	else {
 		SetFeigned(true);
@@ -6514,7 +6514,7 @@ void Client::Handle_OP_Forage(const EQApplicationPacket *app)
 
 	// Not allowed to forage while mounted
 	if (RuleB(Character, NoSkillsOnHorse) && GetHorseId()) {
-		MessageString(Chat::Skills, NO_SKILL_WHILE_MOUNTED);
+		MessageString(Chat::Skills, ClientString::NO_SKILL_WHILE_MOUNTED);
 		return;
 	}
 
@@ -6584,7 +6584,7 @@ void Client::Handle_OP_GMBecomeNPC(const EQApplicationPacket *app)
 		m->SendAppearancePacket(AppearanceType::NPCName, 1, true);
 		t->SetBecomeNPC(true);
 		t->SetBecomeNPCLevel(b->maxlevel);
-		m->MessageString(Chat::White, TOGGLE_OFF);
+		m->MessageString(Chat::White, ClientString::TOGGLE_OFF);
 		t->tellsoff = true;
 		t->UpdateWho();
 	}
@@ -7041,10 +7041,10 @@ void Client::Handle_OP_GMToggle(const EQApplicationPacket *app)
 
 	auto *ts = (GMToggle_Struct *)app->pBuffer;
 	if (ts->toggle == 0) {
-		MessageString(Chat::White, TOGGLE_OFF);
+		MessageString(Chat::White, ClientString::TOGGLE_OFF);
 		tellsoff = true;
 	} else if (ts->toggle == 1) {
-		MessageString(Chat::White, TOGGLE_ON);
+		MessageString(Chat::White, ClientString::TOGGLE_ON);
 		tellsoff = false;
 	} else {
 		Message(Chat::White, "Unknown value in /toggle packet.");
@@ -7461,7 +7461,7 @@ void Client::Handle_OP_GroupInvite2(const EQApplicationPacket *app)
 	}
 
 	if (invitee == this) {
-		MessageString(Chat::LightGray, GROUP_INVITEE_SELF);
+		MessageString(Chat::LightGray, ClientString::GROUP_INVITEE_SELF);
 		return;
 	}
 
@@ -7492,9 +7492,9 @@ void Client::Handle_OP_GroupInvite2(const EQApplicationPacket *app)
 				}
 
 				if (inviter_raid != invitee_raid || leader) {
-					MessageString(Chat::Default, ALREADY_IN_GRP_RAID, invitee->GetCleanName());
+					MessageString(Chat::Default, ClientString::ALREADY_IN_GRP_RAID, invitee->GetCleanName());
 				} else {
-					MessageString(Chat::Default, TARGET_ALREADY_IN_GROUP, invitee->GetCleanName());
+					MessageString(Chat::Default, ClientString::TARGET_ALREADY_IN_GROUP, invitee->GetCleanName());
 				}
 
 				return;
@@ -7502,7 +7502,7 @@ void Client::Handle_OP_GroupInvite2(const EQApplicationPacket *app)
 			} else {
 				if (RuleB(Character, OnInviteReceiveAlreadyinGroupMessage)) {
 					if (!invitee->CastToClient()->MercOnlyOrNoGroup()) {
-						MessageString(Chat::Default, TARGET_ALREADY_IN_GROUP, invitee->GetCleanName());
+						MessageString(Chat::Default, ClientString::TARGET_ALREADY_IN_GROUP, invitee->GetCleanName());
 					}
 				}
 			}
@@ -7513,7 +7513,7 @@ void Client::Handle_OP_GroupInvite2(const EQApplicationPacket *app)
 			} else if (!invitee->HasRaid()) {
 				Bot::ProcessBotGroupInvite(this, std::string(invitee->GetName()));
 			} else {
-				MessageString(Chat::LightGray, ALREADY_IN_RAID, invitee->GetCleanName());
+				MessageString(Chat::LightGray, ClientString::ALREADY_IN_RAID, invitee->GetCleanName());
 			}
 		}
 	} else {
@@ -7718,7 +7718,7 @@ void Client::Handle_OP_GuildBank(const EQApplicationPacket *app)
 	switch (Action) {
 		case GuildBankPromote: {
 			if (GuildBanks->IsAreaFull(GuildID(), GuildBankMainArea)) {
-				MessageString(Chat::Red, GUILD_BANK_FULL);
+				MessageString(Chat::Red, ClientString::GUILD_BANK_FULL);
 				GuildBankAck();
 				return;
 			}
@@ -7752,7 +7752,7 @@ void Client::Handle_OP_GuildBank(const EQApplicationPacket *app)
 						RecordPlayerEventLog(PlayerEvent::GUILD_BANK_MOVE_TO_BANK_AREA, log);
 					}
 
-					MessageString(Chat::LightGray, GUILD_BANK_TRANSFERRED, inst->GetItem()->Name);
+					MessageString(Chat::LightGray, ClientString::GUILD_BANK_TRANSFERRED, inst->GetItem()->Name);
 				}
 			}
 			else {
@@ -7788,7 +7788,7 @@ void Client::Handle_OP_GuildBank(const EQApplicationPacket *app)
 
 			const auto cursor_item = cursor_item_inst->GetItem();
 			if (GuildBanks->IsAreaFull(GuildID(), GuildBankDepositArea)) {
-				MessageString(Chat::Red, GUILD_BANK_FULL);
+				MessageString(Chat::Red, ClientString::GUILD_BANK_FULL);
 				GuildBankDepositAck(true, sentAction);
 				if (ClientVersion() >= EQ::versions::ClientVersion::RoF) {
 					GetInv().PopItem(EQ::invslot::slotCursor);
@@ -7808,7 +7808,7 @@ void Client::Handle_OP_GuildBank(const EQApplicationPacket *app)
 			}
 
 			if (!allowed) {
-				MessageString(Chat::Red, GUILD_BANK_CANNOT_DEPOSIT);
+				MessageString(Chat::Red, ClientString::GUILD_BANK_CANNOT_DEPOSIT);
 				GuildBankDepositAck(true, sentAction);
 
 				if (ClientVersion() >= EQ::versions::ClientVersion::RoF) {
@@ -7879,7 +7879,7 @@ void Client::Handle_OP_GuildBank(const EQApplicationPacket *app)
 
 		case GuildBankWithdraw: {
 			if (GetInv()[EQ::invslot::slotCursor]) {
-				MessageString(Chat::Red, GUILD_BANK_EMPTY_HANDS);
+				MessageString(Chat::Red, ClientString::GUILD_BANK_EMPTY_HANDS);
 				GuildBankAck();
 				break;
 			}
@@ -7905,7 +7905,7 @@ void Client::Handle_OP_GuildBank(const EQApplicationPacket *app)
 			}
 
 			if (CheckLoreConflict(inst->GetItem())) {
-				MessageString(Chat::Red, DUP_LORE);
+				MessageString(Chat::Red, ClientString::DUP_LORE);
 				GuildBankAck();
 				break;
 			}
@@ -7947,7 +7947,7 @@ void Client::Handle_OP_GuildBank(const EQApplicationPacket *app)
 		}
 		case GuildBankSplitStacks: {
 			if (GuildBanks->IsAreaFull(GuildID(), GuildBankMainArea)) {
-				MessageString(Chat::Red, GUILD_BANK_FULL);
+				MessageString(Chat::Red, ClientString::GUILD_BANK_FULL);
 			}
 			else {
 				auto gbwis = (GuildBankWithdrawItem_Struct *) app->pBuffer;
@@ -8031,7 +8031,7 @@ void Client::Handle_OP_GuildCreate(const EQApplicationPacket *app)
 	}
 
 	if (guild_mgr.GetGuildIDByName(GuildName) != GUILD_NONE) {
-		MessageString(Chat::Red, GUILD_NAME_IN_USE);
+		MessageString(Chat::Red, ClientString::GUILD_NAME_IN_USE);
 		return;
 	}
 
@@ -8754,7 +8754,7 @@ void Client::Handle_OP_GuildStatus(const EQApplicationPacket *app)
 	Client *c = entity_list.GetClientByName(gss->Name);
 
 	if (!c) {
-		MessageString(Chat::LightGray, TARGET_PLAYER_FOR_GUILD_STATUS);
+		MessageString(Chat::LightGray, ClientString::TARGET_PLAYER_FOR_GUILD_STATUS);
 		return;
 	}
 
@@ -8762,7 +8762,7 @@ void Client::Handle_OP_GuildStatus(const EQApplicationPacket *app)
 
 	if (TargetGuildID == GUILD_NONE)
 	{
-		MessageString(Chat::LightGray, NOT_IN_A_GUILD, c->GetName());
+		MessageString(Chat::LightGray, ClientString::NOT_IN_A_GUILD, c->GetName());
 		return;
 	}
 
@@ -8774,12 +8774,12 @@ void Client::Handle_OP_GuildStatus(const EQApplicationPacket *app)
 	auto rank = c->GuildRank();
 	switch (rank) {
 		case GUILD_LEADER: {
-			MessageString(Chat::LightGray, LEADER_OF_X_GUILD, c->GetName(), GuildName);
+			MessageString(Chat::LightGray, ClientString::LEADER_OF_X_GUILD, c->GetName(), GuildName);
 			break;
 		}
 		case GUILD_SENIOR_OFFICER:
 		case GUILD_OFFICER: {
-			MessageString(Chat::LightGray, OFFICER_OF_X_GUILD, c->GetName(), GuildName);
+			MessageString(Chat::LightGray, ClientString::OFFICER_OF_X_GUILD, c->GetName(), GuildName);
 			break;
 		}
 		case GUILD_SENIOR_MEMBER:
@@ -8787,7 +8787,7 @@ void Client::Handle_OP_GuildStatus(const EQApplicationPacket *app)
 		case GUILD_JUNIOR_MEMBER:
 		case GUILD_INITIATE:
 		case GUILD_RECRUIT: {
-			MessageString(Chat::LightGray, MEMBER_OF_X_GUILD, c->GetName(), GuildName);
+			MessageString(Chat::LightGray, ClientString::MEMBER_OF_X_GUILD, c->GetName(), GuildName);
 			break;
 		}
 	}
@@ -8831,7 +8831,7 @@ void Client::Handle_OP_GuildUpdate(const EQApplicationPacket *app)
 		}
 		case GuildUpdateRanks: {
 			if (!guild_mgr.CheckPermission(guild_id, guildrank, GUILD_ACTION_RANKS_CHANGE_RANK_NAMES)) {
-				MessageString(Chat::Yellow, GUILD_PERMISSION_FAILED);
+				MessageString(Chat::Yellow, ClientString::GUILD_PERMISSION_FAILED);
 				return;
 			}
 			auto        rank = gup->payload.rank_name.rank;
@@ -8850,7 +8850,7 @@ void Client::Handle_OP_GuildUpdate(const EQApplicationPacket *app)
 		}
 		case GuildUpdatePermissions: {
 			if (!guild_mgr.CheckPermission(guild_id, guildrank, GUILD_ACTION_RANKS_CHANGE_PERMISSIONS)) {
-				MessageString(Chat::Yellow, GUILD_PERMISSION_FAILED);
+				MessageString(Chat::Yellow, ClientString::GUILD_PERMISSION_FAILED);
 				return;
 			}
 			guild_mgr.UpdateRankPermission(
@@ -8939,19 +8939,19 @@ void Client::Handle_OP_Hide(const EQApplicationPacket *app)
 		if (!auto_attack && (evadetar && evadetar->CheckAggro(this)
 			&& evadetar->IsNPC())) {
 			if (zone->random.Int(0, 260) < (int)GetSkill(EQ::skills::SkillHide)) {
-				msg->string_id = EVADE_SUCCESS;
+				msg->string_id = ClientString::EVADE_SUCCESS;
 				RogueEvade(evadetar);
 			}
 			else {
-				msg->string_id = EVADE_FAIL;
+				msg->string_id = ClientString::EVADE_FAIL;
 			}
 		}
 		else {
 			if (hidden) {
-				msg->string_id = HIDE_SUCCESS;
+				msg->string_id = ClientString::HIDE_SUCCESS;
 			}
 			else {
-				msg->string_id = HIDE_FAIL;
+				msg->string_id = ClientString::HIDE_FAIL;
 			}
 		}
 		FastQueuePacket(&outapp);
@@ -9453,7 +9453,7 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 
 
 	if (IsAIControlled()) {
-		MessageString(Chat::Red, NOT_IN_CONTROL);
+		MessageString(Chat::Red, ClientString::NOT_IN_CONTROL);
 		return;
 	}
 
@@ -9599,7 +9599,7 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 						}
 						else if (spells[spell_id].rank < spells[highest_spell_id].rank)
 						{
-							MessageString(Chat::Red, LESSER_SPELL_VERSION, spells[spell_id].name, spells[highest_spell_id].name);
+							MessageString(Chat::Red, ClientString::LESSER_SPELL_VERSION, spells[spell_id].name, spells[highest_spell_id].name);
 							return;
 						}
 					}
@@ -9622,7 +9622,7 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 				if (inst->GetCharges() == 0)
 				{
 					//Message(Chat::White, "This item is out of charges.");
-					MessageString(Chat::Red, ITEM_OUT_OF_CHARGES);
+					MessageString(Chat::Red, ClientString::ITEM_OUT_OF_CHARGES);
 					return;
 				}
 				if (GetLevel() >= item->Click.Level2)
@@ -9677,7 +9677,7 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 				}
 				else
 				{
-					MessageString(Chat::Red, ITEMS_INSUFFICIENT_LEVEL);
+					MessageString(Chat::Red, ClientString::ITEMS_INSUFFICIENT_LEVEL);
 					return;
 				}
 			}
@@ -9686,7 +9686,7 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 				if (clickaug->GetCharges() == 0)
 				{
 					//Message(Chat::White, "This item is out of charges.");
-					MessageString(Chat::Red, ITEM_OUT_OF_CHARGES);
+					MessageString(Chat::Red, ClientString::ITEM_OUT_OF_CHARGES);
 					return;
 				}
 				if (GetLevel() >= augitem->Click.Level2)
@@ -9695,11 +9695,11 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 					{
 						if (augitem->RecastType != RECAST_TYPE_UNLINKED_ITEM && !GetPTimers().Expired(&database, (pTimerItemStart + augitem->RecastType), false)) {
 							LogSpells("Casting of [{}] canceled: item spell reuse timer from augment not expired", spell_id);
-							MessageString(Chat::Red, SPELL_RECAST);
+							MessageString(Chat::Red, ClientString::SPELL_RECAST);
 							SendSpellBarEnable(augitem->Click.Effect);
 							return;
 						} else if (augitem->RecastType == RECAST_TYPE_UNLINKED_ITEM  && !GetPTimers().Expired(&database, (pTimerNegativeItemReuse * augitem->ID), false)) {
-							MessageString(Chat::Red, SPELL_RECAST);
+							MessageString(Chat::Red, ClientString::SPELL_RECAST);
 							SendSpellBarEnable(augitem->Click.Effect);
 							LogSpells("Casting of [{}] canceled: item spell reuse timer not expired", spell_id);
 							return;
@@ -9742,7 +9742,7 @@ void Client::Handle_OP_ItemVerifyRequest(const EQApplicationPacket *app)
 				}
 				else
 				{
-					MessageString(Chat::Red, ITEMS_INSUFFICIENT_LEVEL);
+					MessageString(Chat::Red, ClientString::ITEMS_INSUFFICIENT_LEVEL);
 					return;
 				}
 			}
@@ -9931,12 +9931,12 @@ void Client::Handle_OP_LeadershipExpToggle(const EQApplicationPacket *app)
 	if (*mode) {
 		m_pp.leadAAActive = 1;
 		Save();
-		MessageString(Chat::Yellow, LEADERSHIP_EXP_ON);
+		MessageString(Chat::Yellow, ClientString::LEADERSHIP_EXP_ON);
 	}
 	else {
 		m_pp.leadAAActive = 0;
 		Save();
-		MessageString(Chat::Yellow, LEADERSHIP_EXP_OFF);
+		MessageString(Chat::Yellow, ClientString::LEADERSHIP_EXP_OFF);
 	}
 }
 
@@ -10345,10 +10345,10 @@ void Client::Handle_OP_ManaChange(const EQApplicationPacket *app)
 	if (app->size == 0) {
 		// i think thats the sign to stop the songs
 		if (IsBardSong(casting_spell_id) || HasActiveSong()) {
-			InterruptSpell(SONG_ENDS, 0x121); //Live doesn't send song end message anymore (~Kayen 1/26/22)
+			InterruptSpell(ClientString::SONG_ENDS, 0x121); //Live doesn't send song end message anymore (~Kayen 1/26/22)
 		}
 		else {
-			InterruptSpell(INTERRUPT_SPELL, 0x121);
+			InterruptSpell(ClientString::INTERRUPT_SPELL, 0x121);
 		}
 		return;
 	}
@@ -10404,10 +10404,10 @@ void Client::Handle_OP_Mend(const EQApplicationPacket *app)
 
 		if (zone->random.Int(0, 99) < criticalchance) {
 			mendhp *= 2;
-			MessageString(Chat::LightBlue, MEND_CRITICAL);
+			MessageString(Chat::LightBlue, ClientString::MEND_CRITICAL);
 		}
 		else {
-			MessageString(Chat::LightBlue, MEND_SUCCESS);
+			MessageString(Chat::LightBlue, ClientString::MEND_SUCCESS);
 		}
 		SetHP(GetHP() + mendhp);
 		SendHPUpdate();
@@ -10423,10 +10423,10 @@ void Client::Handle_OP_Mend(const EQApplicationPacket *app)
 		{
 			SetHP(currenthp > mendhp ? (GetHP() - mendhp) : 1);
 			SendHPUpdate();
-			MessageString(Chat::LightBlue, MEND_WORSEN);
+			MessageString(Chat::LightBlue, ClientString::MEND_WORSEN);
 		}
 		else
-			MessageString(Chat::LightBlue, MEND_FAIL);
+			MessageString(Chat::LightBlue, ClientString::MEND_FAIL);
 	}
 
 	CheckIncreaseSkill(EQ::skills::SkillMend, nullptr, 10);
@@ -11067,9 +11067,9 @@ void Client::Handle_OP_PDeletePetition(const EQApplicationPacket *app)
 		return;
 	}
 	if (PetitionList::Instance()->DeletePetitionByCharName((char*)app->pBuffer))
-		MessageString(Chat::White, PETITION_DELETED);
+		MessageString(Chat::White, ClientString::PETITION_DELETED);
 	else
-		MessageString(Chat::White, PETITION_NO_DELETE);
+		MessageString(Chat::White, ClientString::PETITION_NO_DELETE);
 	return;
 }
 
@@ -11094,12 +11094,12 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			if (t) {
 				Mob* owner = t->GetOwner();
 				if (owner) {
-					t->SayString(PET_LEADERIS, owner->GetCleanName());
+					t->SayString(ClientString::PET_LEADERIS, owner->GetCleanName());
 				} else {
-					t->SayString(I_FOLLOW_NOONE);
+					t->SayString(ClientString::I_FOLLOW_NOONE);
 				}
 			} else if (pet) {
-				pet->SayString(PET_LEADERIS, GetName());
+				pet->SayString(ClientString::PET_LEADERIS, GetName());
 			}
 		}
 
@@ -11145,17 +11145,17 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			}
 
 			if (RuleB(Pets, PetsRequireLoS) && !DoLosChecks(t)) {
-				pet->SayString(this, NOT_LEGAL_TARGET);
+				pet->SayString(this, ClientString::NOT_LEGAL_TARGET);
 				break;
 			}
 
 			if (t->IsMezzed()) {
-				MessageString(Chat::NPCQuestSay, CANNOT_WAKE, pet->GetCleanName(), t->GetCleanName());
+				MessageString(Chat::NPCQuestSay, ClientString::CANNOT_WAKE, pet->GetCleanName(), t->GetCleanName());
 				break;
 			}
 
 			if (!pet->IsAttackAllowed(t)) {
-				pet->SayString(this, NOT_LEGAL_TARGET);
+				pet->SayString(this, ClientString::NOT_LEGAL_TARGET);
 				break;
 			}
 
@@ -11196,7 +11196,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			}
 
 			pet->AddToHateList(t, hate, 0, true, false, false, SPELL_UNKNOWN, true);
-			MessageString(Chat::PetResponse, PET_ATTACKING, pet->GetCleanName(), t->GetCleanName());
+			MessageString(Chat::PetResponse, ClientString::PET_ATTACKING, pet->GetCleanName(), t->GetCleanName());
 			SetTarget(t);
 			break;
 		}
@@ -11215,17 +11215,17 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			}
 
 			if (RuleB(Pets, PetsRequireLoS) && !DoLosChecks(GetTarget())) {
-				pet->SayString(this, NOT_LEGAL_TARGET);
+				pet->SayString(this, ClientString::NOT_LEGAL_TARGET);
 				break;
 			}
 
 			if (GetTarget()->IsMezzed()) {
-				MessageString(Chat::NPCQuestSay, CANNOT_WAKE, pet->GetCleanName(), GetTarget()->GetCleanName());
+				MessageString(Chat::NPCQuestSay, ClientString::CANNOT_WAKE, pet->GetCleanName(), GetTarget()->GetCleanName());
 				break;
 			}
 
 			if (!pet->IsAttackAllowed(GetTarget())) {
-				pet->SayString(this, NOT_LEGAL_TARGET);
+				pet->SayString(this, ClientString::NOT_LEGAL_TARGET);
 				break;
 			}
 
@@ -11257,7 +11257,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 
 			zone->AddAggroMob();
 			pet->AddToHateList(GetTarget(), 1, 0, true, false, false, SPELL_UNKNOWN, true);
-			MessageString(Chat::PetResponse, PET_ATTACKING, pet->GetCleanName(), GetTarget()->GetCleanName());
+			MessageString(Chat::PetResponse, ClientString::PET_ATTACKING, pet->GetCleanName(), GetTarget()->GetCleanName());
 			break;
 		}
 		case PetCommand::BackOff: {
@@ -11272,7 +11272,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			parse->EventMob(EVENT_PET_COMMAND, pet, CastToMob(), f, s->command);
 			parse->EventMob(EVENT_PET_COMMAND, CastToMob(), pet, f, s->command);
 
-			pet->SayString(this, Chat::PetResponse, PET_CALMING);
+			pet->SayString(this, Chat::PetResponse, ClientString::PET_CALMING);
 			pet->WipeHateList();
 			pet->SetTarget(nullptr);
 
@@ -11295,7 +11295,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			parse->EventMob(EVENT_PET_COMMAND, pet, CastToMob(), f, s->command);
 			parse->EventMob(EVENT_PET_COMMAND, CastToMob(), pet, f, s->command);
 
-			MessageString(Chat::PetResponse, PET_REPORT_HP, ConvertArrayF(pet->GetHPRatio(), val1));
+			MessageString(Chat::PetResponse, ClientString::PET_REPORT_HP, ConvertArrayF(pet->GetHPRatio(), val1));
 			pet->ShowBuffs(this);
 			break;
 		}
@@ -11318,7 +11318,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 				SetPet(nullptr);
 			}
 
-			pet->SayString(this, Chat::PetResponse, PET_GETLOST_STRING);
+			pet->SayString(this, Chat::PetResponse, ClientString::PET_GETLOST_STRING);
 			pet->CastToNPC()->Depop();
 			break;
 		}
@@ -11337,7 +11337,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			pet->SetFeigned(false);
 			SetPetCommandState(PetButton::Sit, PetButtonState::Off);
 			pet->SetAppearance(eaStanding);
-			pet->SayString(this, Chat::PetResponse, PET_GUARDINGLIFE);
+			pet->SayString(this, Chat::PetResponse, ClientString::PET_GUARDINGLIFE);
 			pet->SetPetOrder(PetOrder::Guard);
 			pet->CastToNPC()->SaveGuardSpot(pet->GetPosition());
 
@@ -11365,7 +11365,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			parse->EventMob(EVENT_PET_COMMAND, CastToMob(), pet, f, s->command);
 
 			pet->SetFeigned(false);
-			pet->SayString(this, Chat::PetResponse, PET_FOLLOWING);
+			pet->SayString(this, Chat::PetResponse, ClientString::PET_FOLLOWING);
 			pet->SetPetOrder(PetOrder::Follow);
 			SetPetCommandState(PetButton::Sit, PetButtonState::Off);
 			pet->SetAppearance(eaStanding);
@@ -11389,7 +11389,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			parse->EventMob(EVENT_PET_COMMAND, pet, CastToMob(), f, s->command);
 			parse->EventMob(EVENT_PET_COMMAND, CastToMob(), pet, f, s->command);
 
-			MessageString(Chat::PetResponse, pet->CastToNPC()->IsTaunting() ? PET_NO_TAUNT : PET_DO_TAUNT);
+			MessageString(Chat::PetResponse, pet->CastToNPC()->IsTaunting() ? ClientString::PET_NO_TAUNT : ClientString::PET_DO_TAUNT);
 			pet->CastToNPC()->SetTaunting(!pet->CastToNPC()->IsTaunting());
 			break;
 		}
@@ -11405,7 +11405,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			parse->EventMob(EVENT_PET_COMMAND, pet, CastToMob(), f, s->command);
 			parse->EventMob(EVENT_PET_COMMAND, CastToMob(), pet, f, s->command);
 
-			MessageString(Chat::PetResponse, PET_DO_TAUNT);
+			MessageString(Chat::PetResponse, ClientString::PET_DO_TAUNT);
 			pet->CastToNPC()->SetTaunting(true);
 			break;
 		}
@@ -11421,7 +11421,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			parse->EventMob(EVENT_PET_COMMAND, pet, CastToMob(), f, s->command);
 			parse->EventMob(EVENT_PET_COMMAND, CastToMob(), pet, f, s->command);
 
-			MessageString(Chat::PetResponse, PET_NO_TAUNT);
+			MessageString(Chat::PetResponse, ClientString::PET_NO_TAUNT);
 			pet->CastToNPC()->SetTaunting(false);
 			break;
 		}
@@ -11438,7 +11438,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			parse->EventMob(EVENT_PET_COMMAND, CastToMob(), pet, f, s->command);
 
 			pet->SetFeigned(false);
-			pet->SayString(this, Chat::PetResponse, PET_GUARDME_STRING);
+			pet->SayString(this, Chat::PetResponse, ClientString::PET_GUARDME_STRING);
 			pet->SetPetOrder(PetOrder::Follow);
 			SetPetCommandState(PetButton::Sit, PetButtonState::Off);
 			pet->SetAppearance(eaStanding);
@@ -11463,7 +11463,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			parse->EventMob(EVENT_PET_COMMAND, CastToMob(), pet, f, s->command);
 
 			pet->SetFeigned(false);
-			pet->SayString(this, Chat::PetResponse, PET_SIT_STRING);
+			pet->SayString(this, Chat::PetResponse, ClientString::PET_SIT_STRING);
 			pet->SetPetOrder(pet->GetPetOrder() == PetOrder::Sit ? pet->GetPreviousPetOrder() : PetOrder::Sit);
 			pet->SetAppearance(pet->GetPetOrder() == PetOrder::Sit ? eaStanding : eaSitting);
 
@@ -11490,7 +11490,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			parse->EventMob(EVENT_PET_COMMAND, CastToMob(), pet, f, s->command);
 
 			pet->SetFeigned(false);
-			pet->SayString(this, Chat::PetResponse, PET_SIT_STRING);
+			pet->SayString(this, Chat::PetResponse, ClientString::PET_SIT_STRING);
 			SetPetCommandState(PetButton::Sit, PetButtonState::Off);
 			pet->SetPetOrder(pet->GetPreviousPetOrder());
 			pet->SetAppearance(eaStanding);
@@ -11509,7 +11509,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			parse->EventMob(EVENT_PET_COMMAND, CastToMob(), pet, f, s->command);
 
 			pet->SetFeigned(false);
-			pet->SayString(this, Chat::PetResponse, PET_SIT_STRING);
+			pet->SayString(this, Chat::PetResponse, ClientString::PET_SIT_STRING);
 			SetPetCommandState(PetButton::Sit, PetButtonState::On);
 			pet->SetPetOrder(PetOrder::Sit);
 			pet->SetRunAnimSpeed(0);
@@ -11535,19 +11535,19 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 
 			if (pet->IsHeld()) {
 				if (m_ClientVersionBit & EQ::versions::maskSoDAndLater) {
-					MessageString(Chat::PetResponse, PET_HOLD_SET_OFF);
+					MessageString(Chat::PetResponse, ClientString::PET_HOLD_SET_OFF);
 				}
 
 				pet->SetHeld(false);
 			} else {
 				if (m_ClientVersionBit & EQ::versions::maskSoDAndLater) {
-					MessageString(Chat::PetResponse, PET_HOLD_SET_ON);
+					MessageString(Chat::PetResponse, ClientString::PET_HOLD_SET_ON);
 				}
 
 				if (m_ClientVersionBit & EQ::versions::maskUFAndLater) {
-					pet->SayString(this, Chat::PetResponse, PET_NOW_HOLDING);
+					pet->SayString(this, Chat::PetResponse, ClientString::PET_NOW_HOLDING);
 				} else {
-					pet->SayString(this, Chat::PetResponse, PET_ON_HOLD);
+					pet->SayString(this, Chat::PetResponse, ClientString::PET_ON_HOLD);
 				}
 
 				pet->SetHeld(true);
@@ -11570,13 +11570,13 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			parse->EventMob(EVENT_PET_COMMAND, CastToMob(), pet, f, s->command);
 
 			if (m_ClientVersionBit & EQ::versions::maskSoDAndLater) {
-				MessageString(Chat::PetResponse, PET_HOLD_SET_ON);
+				MessageString(Chat::PetResponse, ClientString::PET_HOLD_SET_ON);
 			}
 
 			if (m_ClientVersionBit & EQ::versions::maskUFAndLater) {
-				pet->SayString(this, Chat::PetResponse, PET_NOW_HOLDING);
+				pet->SayString(this, Chat::PetResponse, ClientString::PET_NOW_HOLDING);
 			} else {
-				pet->SayString(this, Chat::PetResponse, PET_ON_HOLD);
+				pet->SayString(this, Chat::PetResponse, ClientString::PET_ON_HOLD);
 			}
 
 			pet->SetHeld(true);
@@ -11597,7 +11597,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			parse->EventMob(EVENT_PET_COMMAND, CastToMob(), pet, f, s->command);
 
 			if (m_ClientVersionBit & EQ::versions::maskSoDAndLater) {
-				MessageString(Chat::PetResponse, PET_HOLD_SET_OFF);
+				MessageString(Chat::PetResponse, ClientString::PET_HOLD_SET_OFF);
 			}
 
 			pet->SetHeld(false);
@@ -11617,16 +11617,16 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 
 			if (pet->IsGHeld()) {
 				if (m_ClientVersionBit & EQ::versions::maskUFAndLater) {
-					MessageString(Chat::PetResponse, PET_OFF_GHOLD);
+					MessageString(Chat::PetResponse, ClientString::PET_OFF_GHOLD);
 				}
 
 				pet->SetGHeld(false);
 			} else {
 				if (m_ClientVersionBit & EQ::versions::maskUFAndLater) {
-					MessageString(Chat::PetResponse, PET_ON_GHOLD);
-					pet->SayString(this, Chat::PetResponse, PET_GHOLD_ON_MSG);
+					MessageString(Chat::PetResponse, ClientString::PET_ON_GHOLD);
+					pet->SayString(this, Chat::PetResponse, ClientString::PET_GHOLD_ON_MSG);
 				} else {
-					pet->SayString(this, Chat::PetResponse, PET_ON_HOLD);
+					pet->SayString(this, Chat::PetResponse, ClientString::PET_ON_HOLD);
 				}
 
 				pet->SetGHeld(true);
@@ -11649,10 +11649,10 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			parse->EventMob(EVENT_PET_COMMAND, CastToMob(), pet, f, s->command);
 
 			if (m_ClientVersionBit & EQ::versions::maskUFAndLater) {
-				MessageString(Chat::PetResponse, PET_ON_GHOLD);
-				pet->SayString(this, Chat::PetResponse, PET_GHOLD_ON_MSG);
+				MessageString(Chat::PetResponse, ClientString::PET_ON_GHOLD);
+				pet->SayString(this, Chat::PetResponse, ClientString::PET_GHOLD_ON_MSG);
 			} else {
-				pet->SayString(this, Chat::PetResponse, PET_ON_HOLD);
+				pet->SayString(this, Chat::PetResponse, ClientString::PET_ON_HOLD);
 			}
 
 			pet->SetGHeld(true);
@@ -11673,7 +11673,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			parse->EventMob(EVENT_PET_COMMAND, CastToMob(), pet, f, s->command);
 
 			if (m_ClientVersionBit & EQ::versions::maskUFAndLater) {
-				MessageString(Chat::PetResponse, PET_OFF_GHOLD);
+				MessageString(Chat::PetResponse, ClientString::PET_OFF_GHOLD);
 			}
 
 			pet->SetGHeld(false);
@@ -11691,10 +11691,10 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			parse->EventMob(EVENT_PET_COMMAND, pet, CastToMob(), f, s->command);
 			parse->EventMob(EVENT_PET_COMMAND, CastToMob(), pet, f, s->command);
 
-			MessageString(Chat::PetResponse, pet->IsNoCast() ? PET_CASTING : PET_NOT_CASTING);
+			MessageString(Chat::PetResponse, pet->IsNoCast() ? ClientString::PET_CASTING : ClientString::PET_NOT_CASTING);
 
 			if (m_ClientVersionBit & EQ::versions::maskSoDAndLater) {
-				MessageString(Chat::PetResponse, pet->IsNoCast() ? PET_SPELLHOLD_SET_OFF : PET_SPELLHOLD_SET_ON);
+				MessageString(Chat::PetResponse, pet->IsNoCast() ? ClientString::PET_SPELLHOLD_SET_OFF : ClientString::PET_SPELLHOLD_SET_ON);
 			}
 
 			pet->SetNoCast(!pet->IsNoCast());
@@ -11712,10 +11712,10 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			parse->EventMob(EVENT_PET_COMMAND, pet, CastToMob(), f, s->command);
 			parse->EventMob(EVENT_PET_COMMAND, CastToMob(), pet, f, s->command);
 
-			MessageString(Chat::PetResponse, PET_NOT_CASTING);
+			MessageString(Chat::PetResponse, ClientString::PET_NOT_CASTING);
 
 			if (m_ClientVersionBit & EQ::versions::maskSoDAndLater) {
-				MessageString(Chat::PetResponse, PET_SPELLHOLD_SET_ON);
+				MessageString(Chat::PetResponse, ClientString::PET_SPELLHOLD_SET_ON);
 			}
 
 			pet->SetNoCast(true);
@@ -11733,10 +11733,10 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			parse->EventMob(EVENT_PET_COMMAND, pet, CastToMob(), f, s->command);
 			parse->EventMob(EVENT_PET_COMMAND, CastToMob(), pet, f, s->command);
 
-			MessageString(Chat::PetResponse, PET_CASTING);
+			MessageString(Chat::PetResponse, ClientString::PET_CASTING);
 
 			if (m_ClientVersionBit & EQ::versions::maskSoDAndLater) {
-				MessageString(Chat::PetResponse, PET_SPELLHOLD_SET_OFF);
+				MessageString(Chat::PetResponse, ClientString::PET_SPELLHOLD_SET_OFF);
 			}
 
 			pet->SetNoCast(false);
@@ -11754,10 +11754,10 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			parse->EventMob(EVENT_PET_COMMAND, pet, CastToMob(), f, s->command);
 			parse->EventMob(EVENT_PET_COMMAND, CastToMob(), pet, f, s->command);
 
-			MessageString(Chat::PetResponse, pet->IsFocused() ? PET_NOT_FOCUSING : PET_NOW_FOCUSING);
+			MessageString(Chat::PetResponse, pet->IsFocused() ? ClientString::PET_NOT_FOCUSING : ClientString::PET_NOW_FOCUSING);
 
 			if (m_ClientVersionBit & EQ::versions::maskSoDAndLater) {
-				MessageString(Chat::PetResponse, pet->IsFocused() ? PET_FOCUS_SET_OFF : PET_FOCUS_SET_ON);
+				MessageString(Chat::PetResponse, pet->IsFocused() ? ClientString::PET_FOCUS_SET_OFF : ClientString::PET_FOCUS_SET_ON);
 			}
 
 			pet->SetFocused(!pet->IsFocused());
@@ -11775,10 +11775,10 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			parse->EventMob(EVENT_PET_COMMAND, pet, CastToMob(), f, s->command);
 			parse->EventMob(EVENT_PET_COMMAND, CastToMob(), pet, f, s->command);
 
-			MessageString(Chat::PetResponse, PET_NOW_FOCUSING);
+			MessageString(Chat::PetResponse, ClientString::PET_NOW_FOCUSING);
 
 			if (m_ClientVersionBit & EQ::versions::maskSoDAndLater) {
-				MessageString(Chat::PetResponse, PET_FOCUS_SET_ON);
+				MessageString(Chat::PetResponse, ClientString::PET_FOCUS_SET_ON);
 			}
 
 			pet->SetFocused(true);
@@ -11796,10 +11796,10 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			parse->EventMob(EVENT_PET_COMMAND, pet, CastToMob(), f, s->command);
 			parse->EventMob(EVENT_PET_COMMAND, CastToMob(), pet, f, s->command);
 
-			MessageString(Chat::PetResponse, PET_NOT_FOCUSING);
+			MessageString(Chat::PetResponse, ClientString::PET_NOT_FOCUSING);
 
 			if (m_ClientVersionBit & EQ::versions::maskSoDAndLater) {
-				MessageString(Chat::PetResponse, PET_FOCUS_SET_OFF);
+				MessageString(Chat::PetResponse, ClientString::PET_FOCUS_SET_OFF);
 			}
 
 			pet->SetFocused(false);
@@ -11819,7 +11819,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 
 			if (zone->random.Int(0, 99) > aabonuses.FeignedMinionChance) {
 				pet->SetFeigned(false);
-				entity_list.MessageCloseString(this, false, 200, 10, STRING_FEIGNFAILED, pet->GetCleanName());
+				entity_list.MessageCloseString(this, false, 200, 10, ClientString::STRING_FEIGNFAILED, pet->GetCleanName());
 			} else {
 				pet->SetSpecialAbility(SpecialAbility::AggroImmunity, 1);
 				pet->WipeHateList();
@@ -11866,7 +11866,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 				}
 			}
 
-			pet->SayString(this, Chat::PetResponse, PET_GETLOST_STRING);
+			pet->SayString(this, Chat::PetResponse, ClientString::PET_GETLOST_STRING);
 			break;
 		}
 		case PetCommand::StopOn: {
@@ -11884,7 +11884,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			pet->SetPetStop(true);
 			pet->StopNavigation();
 			pet->SetTarget(nullptr);
-			pet->SayString(this, Chat::PetResponse, PET_GETLOST_STRING);
+			pet->SayString(this, Chat::PetResponse, ClientString::PET_GETLOST_STRING);
 
 			if (pet->IsPetRegroup()) {
 				pet->SetPetRegroup(false);
@@ -11906,7 +11906,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			parse->EventMob(EVENT_PET_COMMAND, CastToMob(), pet, f, s->command);
 
 			pet->SetPetStop(false);
-			pet->SayString(this, Chat::PetResponse, PET_GETLOST_STRING);
+			pet->SayString(this, Chat::PetResponse, ClientString::PET_GETLOST_STRING);
 			break;
 		}
 		case PetCommand::Regroup: {
@@ -11923,11 +11923,11 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 
 			if (pet->IsPetRegroup()) {
 				pet->SetPetRegroup(false);
-				pet->SayString(this, Chat::PetResponse, PET_OFF_REGROUPING);
+				pet->SayString(this, Chat::PetResponse, ClientString::PET_OFF_REGROUPING);
 			} else {
 				pet->SetPetRegroup(true);
 				pet->SetTarget(nullptr);
-				pet->SayString(this, Chat::PetResponse, PET_ON_REGROUPING);
+				pet->SayString(this, Chat::PetResponse, ClientString::PET_ON_REGROUPING);
 
 				if (pet->IsPetStop()) {
 					pet->SetPetStop(false);
@@ -11951,7 +11951,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 
 			pet->SetPetRegroup(true);
 			pet->SetTarget(nullptr);
-			pet->SayString(this, Chat::PetResponse, PET_ON_REGROUPING);
+			pet->SayString(this, Chat::PetResponse, ClientString::PET_ON_REGROUPING);
 
 			if (pet->IsPetStop()) {
 				pet->SetPetStop(false);
@@ -11973,7 +11973,7 @@ void Client::Handle_OP_PetCommands(const EQApplicationPacket *app)
 			parse->EventMob(EVENT_PET_COMMAND, CastToMob(), pet, f, s->command);
 
 			pet->SetPetRegroup(false);
-			pet->SayString(this, Chat::PetResponse, PET_OFF_REGROUPING);
+			pet->SayString(this, Chat::PetResponse, ClientString::PET_OFF_REGROUPING);
 			break;
 		}
 		default: {
@@ -12583,12 +12583,12 @@ void Client::Handle_OP_RaidCommand(const EQApplicationPacket* app)
 
 			auto player_to_invite_group = player_to_invite->GetGroup();
 			if (player_to_invite_group && player_to_invite_group->IsGroupMember(this)) {
-				MessageString(Chat::Red, ALREADY_IN_PARTY);
+				MessageString(Chat::Red, ClientString::ALREADY_IN_PARTY);
 				break;
 			}
 
 			if (player_to_invite->IsRaidGrouped()) {
-				MessageString(Chat::White, ALREADY_IN_RAID, player_to_invite->GetCleanName()); //must invite members not in raid...
+				MessageString(Chat::White, ClientString::ALREADY_IN_RAID, player_to_invite->GetCleanName()); //must invite members not in raid...
 				return;
 			}
 
@@ -12609,7 +12609,7 @@ void Client::Handle_OP_RaidCommand(const EQApplicationPacket* app)
 			}
 
 			if (player_to_invite_group && player_to_invite_group->IsGroupMember(this)) {
-				MessageString(Chat::Red, ALREADY_IN_PARTY);
+				MessageString(Chat::Red, ClientString::ALREADY_IN_PARTY);
 				break;
 			}
 			// Not allowed: Invite a client that is in a group but not the groupleader
@@ -12653,7 +12653,7 @@ void Client::Handle_OP_RaidCommand(const EQApplicationPacket* app)
 		Group* g_invitor = invitor->GetGroup();
 
 		if (invitee && invitee->IsRaidGrouped()) {
-			invitor->MessageString(Chat::White, ALREADY_IN_RAID, GetName()); //group failed, must invite members not in raid...
+			invitor->MessageString(Chat::White, ClientString::ALREADY_IN_RAID, GetName()); //group failed, must invite members not in raid...
 			return;
 		}
 
@@ -12684,7 +12684,7 @@ void Client::Handle_OP_RaidCommand(const EQApplicationPacket* app)
 
 		if (player_sending_invite) {
 			if (IsRaidGrouped()) {
-				player_sending_invite->MessageString(Chat::White, ALREADY_IN_RAID, GetName()); //group failed, must invite members not in raid...
+				player_sending_invite->MessageString(Chat::White, ClientString::ALREADY_IN_RAID, GetName()); //group failed, must invite members not in raid...
 				return;
 			}
 			Raid* raid = entity_list.GetRaidByClient(player_sending_invite);
@@ -12757,7 +12757,7 @@ void Client::Handle_OP_RaidCommand(const EQApplicationPacket* app)
 
 				/* Prevent scenario where player had joined group with Raid invitor before accepting Raid invite */
 				if (group && group == player_sending_invite_group) {
-					player_sending_invite->MessageString(Chat::Red, INVITE_GROUP_LEADER);
+					player_sending_invite->MessageString(Chat::Red, ClientString::INVITE_GROUP_LEADER);
 					return;
 				}
 
@@ -13702,14 +13702,14 @@ void Client::Handle_OP_RemoveTrap(const EQApplicationPacket *app)
 	if (good)
 		RemoveAura(id);
 	else
-		MessageString(Chat::SpellFailure, NOT_YOUR_TRAP); // pretty sure this was red
+		MessageString(Chat::SpellFailure, ClientString::NOT_YOUR_TRAP); // pretty sure this was red
 }
 
 void Client::Handle_OP_Report(const EQApplicationPacket *app)
 {
 	if (!CanUseReport)
 	{
-		MessageString(Chat::System, REPORT_ONCE);
+		MessageString(Chat::System, ClientString::REPORT_ONCE);
 		return;
 	}
 
@@ -13787,12 +13787,12 @@ void Client::Handle_OP_RequestDuel(const EQApplicationPacket *app)
 		entity->CastToClient()->IsDueling() &&
 		entity->CastToClient()->GetDuelTarget()
 	) {
-		MessageString(Chat::NPCQuestSay, DUEL_CONSIDERING, entity->GetName());
+		MessageString(Chat::NPCQuestSay, ClientString::DUEL_CONSIDERING, entity->GetName());
 		return;
 	}
 
 	if (IsDueling()) {
-		MessageString(Chat::NPCQuestSay, DUEL_INPROGRESS);
+		MessageString(Chat::NPCQuestSay, ClientString::DUEL_INPROGRESS);
 		return;
 	}
 
@@ -13847,7 +13847,7 @@ void Client::Handle_OP_RespawnWindow(const EQApplicationPacket *app)
 void Client::Handle_OP_Rewind(const EQApplicationPacket *app)
 {
 	if ((rewind_timer.GetRemainingTime() > 1 && rewind_timer.Enabled())) {
-		MessageString(Chat::System, REWIND_WAIT);
+		MessageString(Chat::System, ClientString::REWIND_WAIT);
 	}
 	else {
 		CastToClient()->MovePC(zone->GetZoneID(), zone->GetInstanceID(), m_RewindLocation.x, m_RewindLocation.y, m_RewindLocation.z, 0, 2, Rewind);
@@ -14355,14 +14355,14 @@ void Client::Handle_OP_ShopPlayerBuy(const EQApplicationPacket *app)
 
 	if (!item) {
 		//error finding item, client didnt get the update packet for whatever reason, roleplay a tad
-		MessageString(Chat::White, ALREADY_SOLD);
+		MessageString(Chat::White, ClientString::ALREADY_SOLD);
 		entity_list.SendMerchantInventory(tmp, mp->itemslot, true);
 		SendMerchantEnd();
 		return;
 	}
 
 	if (CheckLoreConflict(item)) {
-		MessageString(Chat::White, DUPE_LORE_MERCHANT,tmp->GetCleanName(),item->Name);
+		MessageString(Chat::White, ClientString::DUPE_LORE_MERCHANT,tmp->GetCleanName(),item->Name);
 		return;
 	}
 
@@ -14414,7 +14414,7 @@ void Client::Handle_OP_ShopPlayerBuy(const EQApplicationPacket *app)
 	}
 
 	if (mpo->price < 0)	{
-		MessageString(Chat::White, ALREADY_SOLD);
+		MessageString(Chat::White, ClientString::ALREADY_SOLD);
 		safe_delete(outapp);
 		safe_delete(inst);
 		SendMerchantEnd();
@@ -14784,7 +14784,7 @@ void Client::Handle_OP_ShopRequest(const EQApplicationPacket *app)
 	}
 
 	if (tmp->IsEngaged()) {
-		MessageString(Chat::White, MERCHANT_BUSY);
+		MessageString(Chat::White, ClientString::MERCHANT_BUSY);
 		action = MerchantActions::Close;
 	}
 
@@ -14808,7 +14808,7 @@ void Client::Handle_OP_ShopRequest(const EQApplicationPacket *app)
 	}
 
 	if (!tmp->CastToNPC()->IsMerchantOpen()) {
-		tmp->SayString(zone->random.Int(MERCHANT_CLOSED_ONE, MERCHANT_CLOSED_THREE));
+		tmp->SayString(zone->random.Int(ClientString::MERCHANT_CLOSED_ONE, ClientString::MERCHANT_CLOSED_THREE));
 		action = MerchantActions::Close;
 	}
 
@@ -15109,7 +15109,7 @@ void Client::Handle_OP_Split(const EQApplicationPacket *app)
 
 	// is there an actual error message for this?
 	if (raid == nullptr && group == nullptr) {
-		MessageString(Chat::Red, SPLIT_NO_GROUP);
+		MessageString(Chat::Red, ClientString::SPLIT_NO_GROUP);
 		return;
 	}
 
@@ -15117,7 +15117,7 @@ void Client::Handle_OP_Split(const EQApplicationPacket *app)
 		10 * static_cast<uint64>(split->silver) +
 		100 * static_cast<uint64>(split->gold) +
 		1000 * static_cast<uint64>(split->platinum))) {
-		MessageString(Chat::Red, SPLIT_FAIL);
+		MessageString(Chat::Red, ClientString::SPLIT_FAIL);
 		return;
 	}
 
@@ -15147,7 +15147,7 @@ void Client::Handle_OP_Surname(const EQApplicationPacket *app)
 
 	if (GetLevel() < 20)
 	{
-		MessageString(Chat::Yellow, SURNAME_LEVEL);
+		MessageString(Chat::Yellow, ClientString::SURNAME_LEVEL);
 		return;
 	}
 
@@ -15169,13 +15169,13 @@ void Client::Handle_OP_Surname(const EQApplicationPacket *app)
 	}
 
 	if (strlen(surname->lastname) >= 20) {
-		MessageString(Chat::Yellow, SURNAME_TOO_LONG);
+		MessageString(Chat::Yellow, ClientString::SURNAME_TOO_LONG);
 		return;
 	}
 
 	if (!database.CheckNameFilter(surname->lastname, true))
 	{
-		MessageString(Chat::Yellow, SURNAME_REJECTED);
+		MessageString(Chat::Yellow, ClientString::SURNAME_REJECTED);
 		return;
 	}
 
@@ -15255,7 +15255,7 @@ void Client::Handle_OP_TargetCommand(const EQApplicationPacket *app)
 		QueuePacket(app);
 	}
 	else {
-		MessageString(Chat::Red, DONT_SEE_TARGET);
+		MessageString(Chat::Red, ClientString::DONT_SEE_TARGET);
 		auto outapp = new EQApplicationPacket(OP_TargetReject, sizeof(TargetReject_Struct));
 		outapp->pBuffer[0] = 0x2f;
 		outapp->pBuffer[1] = 0x01;
@@ -15504,7 +15504,7 @@ void Client::Handle_OP_Taunt(const EQApplicationPacket *app)
 	}
 
 	if (DistanceSquared(GetPosition(), GetTarget()->GetPosition()) > (RuleI(Skills, MaximumTauntDistance) * (RuleI(Skills, MaximumTauntDistance)))) {
-		MessageString(Chat::TooFarAway, TAUNT_TOO_FAR);
+		MessageString(Chat::TooFarAway, ClientString::TAUNT_TOO_FAR);
 		return;
 	}
 
@@ -15584,16 +15584,16 @@ void Client::Handle_OP_TradeAcceptClick(const EQApplicationPacket *app)
 			trade->state = TradeCompleting;
 
 			if (CheckTradeLoreConflict(other) || other->CheckTradeLoreConflict(this)) {
-				MessageString(Chat::Red, TRADE_CANCEL_LORE);
-				other->MessageString(Chat::Red, TRADE_CANCEL_LORE);
+				MessageString(Chat::Red, ClientString::TRADE_CANCEL_LORE);
+				other->MessageString(Chat::Red, ClientString::TRADE_CANCEL_LORE);
 				FinishTrade(this);
 				other->FinishTrade(other);
 				other->trade->Reset();
 				trade->Reset();
 			}
 			else if (CheckTradeNonDroppable()) {
-				MessageString(Chat::Red, TRADE_HAS_BEEN_CANCELLED);
-				other->MessageString(Chat::Red, TRADE_HAS_BEEN_CANCELLED);
+				MessageString(Chat::Red, ClientString::TRADE_HAS_BEEN_CANCELLED);
+				other->MessageString(Chat::Red, ClientString::TRADE_HAS_BEEN_CANCELLED);
 				FinishTrade(this);
 				other->FinishTrade(other);
 				other->trade->Reset();
@@ -15602,8 +15602,8 @@ void Client::Handle_OP_TradeAcceptClick(const EQApplicationPacket *app)
 				// TODO: query (this) as a hacker
 			}
 			else if (other->CheckTradeNonDroppable()) {
-				MessageString(Chat::Red, TRADE_HAS_BEEN_CANCELLED);
-				other->MessageString(Chat::Red, TRADE_HAS_BEEN_CANCELLED);
+				MessageString(Chat::Red, ClientString::TRADE_HAS_BEEN_CANCELLED);
+				other->MessageString(Chat::Red, ClientString::TRADE_HAS_BEEN_CANCELLED);
 				FinishTrade(this);
 				other->FinishTrade(other);
 				other->trade->Reset();
@@ -15938,7 +15938,7 @@ void Client::Handle_OP_TraderShop(const EQApplicationPacket *app)
 				);
 			}
 			else {
-				MessageString(Chat::Yellow, TRADER_BUSY);
+				MessageString(Chat::Yellow, ClientString::TRADER_BUSY);
 				LogTrading("Client::Handle_OP_TraderShop: Trader Busy");
 			}
 

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -237,11 +237,11 @@ bool Client::Process() {
 			}
 
 			if (song_target == nullptr) {
-				InterruptSpell(SONG_ENDS_ABRUPTLY, 0x121, bardsong);
+				InterruptSpell(ClientString::SONG_ENDS_ABRUPTLY, 0x121, bardsong);
 			}
 			else {
 				if (!ApplyBardPulse(bardsong, song_target, bardsong_slot)) {
-					InterruptSpell(SONG_ENDS_ABRUPTLY, 0x121, bardsong);
+					InterruptSpell(ClientString::SONG_ENDS_ABRUPTLY, 0x121, bardsong);
 				}
 			}
 		}
@@ -357,7 +357,7 @@ bool Client::Process() {
 
 		if (AutoFireEnabled()) {
 			if (GetTarget() == this) {
-				MessageString(Chat::TooFarAway, TRY_ATTACKING_SOMEONE);
+				MessageString(Chat::TooFarAway, ClientString::TRY_ATTACKING_SOMEONE);
 				auto_fire = false;
 			}
 			EQ::ItemInstance *ranged = GetInv().GetItem(EQ::invslot::slotRange);
@@ -436,10 +436,10 @@ bool Client::Process() {
 			}
 
 			if (!CombatRange(auto_attack_target)) {
-				MessageString(Chat::TooFarAway, TARGET_TOO_FAR);
+				MessageString(Chat::TooFarAway, ClientString::TARGET_TOO_FAR);
 			}
 			else if (auto_attack_target == this) {
-				MessageString(Chat::TooFarAway, TRY_ATTACKING_SOMEONE);
+				MessageString(Chat::TooFarAway, ClientString::TRY_ATTACKING_SOMEONE);
 			}
 			else if (!los_status || !los_status_facing) {
 				//you can't see your target
@@ -464,11 +464,11 @@ bool Client::Process() {
 
 		if (GetClass() == Class::Warrior || GetClass() == Class::Berserker) {
 			if (!dead && !IsBerserk() && GetHPRatio() < RuleI(Combat, BerserkerFrenzyStart)) {
-				entity_list.MessageCloseString(this, false, 200, 0, BERSERK_START, GetName());
+				entity_list.MessageCloseString(this, false, 200, 0, ClientString::BERSERK_START, GetName());
 				berserk = true;
 			}
 			if (IsBerserk() && GetHPRatio() > RuleI(Combat, BerserkerFrenzyEnd)) {
-				entity_list.MessageCloseString(this, false, 200, 0, BERSERK_END, GetName());
+				entity_list.MessageCloseString(this, false, 200, 0, ClientString::BERSERK_END, GetName());
 				berserk = false;
 			}
 		}
@@ -1004,12 +1004,12 @@ void Client::BulkSendMerchantInventory(int merchant_id, int npcid) {
 	//this resets the slot
 	zone->tmpmerchanttable[npcid] = temporary_merchant_list;
 	if (npc && handy_item) {
-		int greet_id = zone->random.Int(MERCHANT_GREETING, MERCHANT_HANDY_ITEM4);
+		int greet_id = zone->random.Int(ClientString::MERCHANT_GREETING, ClientString::MERCHANT_HANDY_ITEM4);
 		auto handy_id = std::to_string(greet_id);
-		if (greet_id != MERCHANT_GREETING) {
-			MessageString(Chat::NPCQuestSay, GENERIC_STRINGID_SAY, npc->GetCleanName(), handy_id.c_str(), GetName(), handy_item->Name);
+		if (greet_id != ClientString::MERCHANT_GREETING) {
+			MessageString(Chat::NPCQuestSay, ClientString::GENERIC_STRINGID_SAY, npc->GetCleanName(), handy_id.c_str(), GetName(), handy_item->Name);
 		} else {
-			MessageString(Chat::NPCQuestSay, GENERIC_STRINGID_SAY, npc->GetCleanName(), handy_id.c_str(), GetName());
+			MessageString(Chat::NPCQuestSay, ClientString::GENERIC_STRINGID_SAY, npc->GetCleanName(), handy_id.c_str(), GetName());
 		}
 	}
 }
@@ -1145,7 +1145,7 @@ void Client::OPTGB(const EQApplicationPacket *app)
 
 	uint32 tgb_flag = *(uint32 *)app->pBuffer;
 	if(tgb_flag == 2)
-		MessageString(Chat::White, TGB() ? TGB_ON : TGB_OFF);
+		MessageString(Chat::White, TGB() ? ClientString::TGB_ON : ClientString::TGB_OFF);
 	else
 		tgb = tgb_flag;
 }
@@ -1184,7 +1184,7 @@ void Client::OPMemorizeSpell(const EQApplicationPacket* app)
 	) {
 		MessageString(
 			Chat::Red,
-			SPELL_LEVEL_TO_LOW,
+			ClientString::SPELL_LEVEL_TO_LOW,
 			std::to_string(spells[m->spell_id].classes[GetClass() - 1]).c_str(),
 			spells[m->spell_id].name
 		);
@@ -1203,7 +1203,7 @@ void Client::OPMemorizeSpell(const EQApplicationPacket* app)
 					RuleB(Character, RestrictSpellScribing) &&
 					!item->IsEquipable(GetRace(), GetClass())
 				) {
-					MessageString(Chat::Red, CANNOT_USE_ITEM);
+					MessageString(Chat::Red, ClientString::CANNOT_USE_ITEM);
 					break;
 				}
 
@@ -1792,14 +1792,14 @@ void Client::OPGMTrainSkill(const EQApplicationPacket *app)
 			case EQ::skills::SkillJewelryMaking:
 			case EQ::skills::SkillPottery:
 				if(skilllevel >= RuleI(Skills, MaxTrainTradeskills)) {
-					MessageString(Chat::Red, MORE_SKILLED_THAN_I, pTrainer->GetCleanName());
+					MessageString(Chat::Red, ClientString::MORE_SKILLED_THAN_I, pTrainer->GetCleanName());
 					SetSkill(skill, skilllevel);
 					return;
 				}
 				break;
 			case EQ::skills::SkillResearch:
 				if(skilllevel >= RuleI(Skills, MaxTrainResearch)) {
-					MessageString(Chat::Red, MORE_SKILLED_THAN_I, pTrainer->GetCleanName());
+					MessageString(Chat::Red, ClientString::MORE_SKILLED_THAN_I, pTrainer->GetCleanName());
 					SetSkill(skill, skilllevel);
 					return;
 				}
@@ -1810,7 +1810,7 @@ void Client::OPGMTrainSkill(const EQApplicationPacket *app)
 			case EQ::skills::SkillSpecializeDivination:
 			case EQ::skills::SkillSpecializeEvocation:
 				if(skilllevel >= RuleI(Skills, MaxTrainSpecializations)) {
-					MessageString(Chat::Red, MORE_SKILLED_THAN_I, pTrainer->GetCleanName());
+					MessageString(Chat::Red, ClientString::MORE_SKILLED_THAN_I, pTrainer->GetCleanName());
 					SetSkill(skill, skilllevel);
 					return;
 				}
@@ -1822,7 +1822,7 @@ void Client::OPGMTrainSkill(const EQApplicationPacket *app)
 			if (skilllevel >= MaxSkillValue)
 			{
 				// Don't allow training over max skill level
-				MessageString(Chat::Red, MORE_SKILLED_THAN_I, pTrainer->GetCleanName());
+				MessageString(Chat::Red, ClientString::MORE_SKILLED_THAN_I, pTrainer->GetCleanName());
 				SetSkill(skill, skilllevel);
 				return;
 			}
@@ -1833,7 +1833,7 @@ void Client::OPGMTrainSkill(const EQApplicationPacket *app)
 				if (skilllevel >= MaxSpecSkill)
 				{
 					// Restrict specialization training to follow the rules
-					MessageString(Chat::Red, MORE_SKILLED_THAN_I, pTrainer->GetCleanName());
+					MessageString(Chat::Red, ClientString::MORE_SKILLED_THAN_I, pTrainer->GetCleanName());
 					SetSkill(skill, skilllevel);
 					return;
 				}
@@ -2087,7 +2087,7 @@ void Client::DoTracking()
 	auto *m = entity_list.GetMob(TrackingID);
 
 	if (!m || m->IsCorpse()) {
-		MessageString(Chat::Skills, TRACK_LOST_TARGET);
+		MessageString(Chat::Skills, ClientString::TRACK_LOST_TARGET);
 		TrackingID = 0;
 		return;
 	}
@@ -2111,23 +2111,23 @@ void Client::DoTracking()
 	}
 
 	if (relative_heading > 480) {
-		MessageString(Chat::Skills, TRACK_STRAIGHT_AHEAD, m->GetCleanName());
+		MessageString(Chat::Skills, ClientString::TRACK_STRAIGHT_AHEAD, m->GetCleanName());
 	} else if (relative_heading > 416) {
-		MessageString(Chat::Skills, TRACK_AHEAD_AND_TO, m->GetCleanName(), "left");
+		MessageString(Chat::Skills, ClientString::TRACK_AHEAD_AND_TO, m->GetCleanName(), "left");
 	} else if (relative_heading > 352) {
-		MessageString(Chat::Skills, TRACK_TO_THE, m->GetCleanName(), "left");
+		MessageString(Chat::Skills, ClientString::TRACK_TO_THE, m->GetCleanName(), "left");
 	} else if (relative_heading > 288) {
-		MessageString(Chat::Skills, TRACK_BEHIND_AND_TO, m->GetCleanName(), "left");
+		MessageString(Chat::Skills, ClientString::TRACK_BEHIND_AND_TO, m->GetCleanName(), "left");
 	} else if (relative_heading > 224) {
-		MessageString(Chat::Skills, TRACK_BEHIND_YOU, m->GetCleanName());
+		MessageString(Chat::Skills, ClientString::TRACK_BEHIND_YOU, m->GetCleanName());
 	} else if (relative_heading > 160) {
-		MessageString(Chat::Skills, TRACK_BEHIND_AND_TO, m->GetCleanName(), "right");
+		MessageString(Chat::Skills, ClientString::TRACK_BEHIND_AND_TO, m->GetCleanName(), "right");
 	} else if (relative_heading > 96) {
-		MessageString(Chat::Skills, TRACK_TO_THE, m->GetCleanName(), "right");
+		MessageString(Chat::Skills, ClientString::TRACK_TO_THE, m->GetCleanName(), "right");
 	} else if (relative_heading > 32) {
-		MessageString(Chat::Skills, TRACK_AHEAD_AND_TO, m->GetCleanName(), "right");
+		MessageString(Chat::Skills, ClientString::TRACK_AHEAD_AND_TO, m->GetCleanName(), "right");
 	} else if (relative_heading >= 0) {
-		MessageString(Chat::Skills, TRACK_STRAIGHT_AHEAD, m->GetCleanName());
+		MessageString(Chat::Skills, ClientString::TRACK_STRAIGHT_AHEAD, m->GetCleanName());
 	}
 }
 

--- a/zone/corpse.cpp
+++ b/zone/corpse.cpp
@@ -1525,7 +1525,7 @@ void Corpse::LootCorpseItem(Client *c, const EQApplicationPacket *app)
 
 	if (c && inst) {
 		if (c->CheckLoreConflict(item)) {
-			c->MessageString(Chat::White, LOOT_LORE_ERROR);
+			c->MessageString(Chat::White, ClientString::LOOT_LORE_ERROR);
 			c->QueuePacket(app);
 			SendEndLootErrorPacket(c);
 			ResetLooter();
@@ -1538,7 +1538,7 @@ void Corpse::LootCorpseItem(Client *c, const EQApplicationPacket *app)
 				EQ::ItemInstance *itm = inst->GetAugment(i);
 				if (itm) {
 					if (c->CheckLoreConflict(itm->GetItem())) {
-						c->MessageString(Chat::White, LOOT_LORE_ERROR);
+						c->MessageString(Chat::White, ClientString::LOOT_LORE_ERROR);
 						c->QueuePacket(app);
 						SendEndLootErrorPacket(c);
 						ResetLooter();
@@ -1625,7 +1625,7 @@ void Corpse::LootCorpseItem(Client *c, const EQApplicationPacket *app)
 			if (dz && !dz->CanClientLootCorpse(c, GetNPCTypeID(), GetID())) {
 				prevent_loot = true;
 				// note on live this message is only sent once on the first loot attempt of an open corpse
-				c->MessageString(Chat::Loot, LOOT_NOT_ALLOWED, inst->GetItem()->Name);
+				c->MessageString(Chat::Loot, ClientString::LOOT_NOT_ALLOWED, inst->GetItem()->Name);
 			}
 		}
 
@@ -1737,14 +1737,14 @@ void Corpse::LootCorpseItem(Client *c, const EQApplicationPacket *app)
 
 		linker.GenerateLink();
 
-		c->MessageString(Chat::Loot, LOOTED_MESSAGE, linker.Link().c_str());
+		c->MessageString(Chat::Loot, ClientString::LOOTED_MESSAGE, linker.Link().c_str());
 
 		if (!IsPlayerCorpse()) {
 			Group *g = c->GetGroup();
 			if (g != nullptr) {
 				g->GroupMessageString(
 					c, Chat::Loot,
-					OTHER_LOOTED_MESSAGE,
+					ClientString::OTHER_LOOTED_MESSAGE,
 					c->GetName(),
 					linker.Link().c_str()
 				);
@@ -1755,7 +1755,7 @@ void Corpse::LootCorpseItem(Client *c, const EQApplicationPacket *app)
 					r->RaidMessageString(
 						c,
 						Chat::Loot,
-						OTHER_LOOTED_MESSAGE,
+						ClientString::OTHER_LOOTED_MESSAGE,
 						c->GetName(),
 						linker.Link().c_str()
 					);
@@ -1961,7 +1961,7 @@ bool Corpse::Summon(Client *c, bool spell, bool CheckDistance)
 				m_is_corpse_changed = true;
 			}
 			else {
-				c->MessageString(Chat::Red, CORPSE_TOO_FAR);
+				c->MessageString(Chat::Red, ClientString::CORPSE_TOO_FAR);
 				return false;
 			}
 		}
@@ -1998,12 +1998,12 @@ bool Corpse::Summon(Client *c, bool spell, bool CheckDistance)
 					m_is_corpse_changed = true;
 				}
 				else {
-					c->MessageString(Chat::Red, CORPSE_TOO_FAR);
+					c->MessageString(Chat::Red, ClientString::CORPSE_TOO_FAR);
 					return false;
 				}
 			}
 			else {
-				c->MessageString(Chat::Red, CONSENT_DENIED);
+				c->MessageString(Chat::Red, ClientString::CONSENT_DENIED);
 				return false;
 			}
 		}
@@ -2312,7 +2312,7 @@ void Corpse::CastRezz(uint16 spell_id, Mob *caster)
 	// refresh rezzed state from database
 	const auto &e = CharacterCorpsesRepository::FindOne(database, m_corpse_db_id);
 	if (!e.id) {
-		caster->MessageString(Chat::White, REZZ_ALREADY_PENDING);
+		caster->MessageString(Chat::White, ClientString::REZZ_ALREADY_PENDING);
 		return;
 	}
 
@@ -2325,8 +2325,8 @@ void Corpse::CastRezz(uint16 spell_id, Mob *caster)
 	if (!IsRezzable()) {
 		if (caster && caster->IsClient()) {
 			if (!caster->CastToClient()->GetGM()) {
-				caster->MessageString(Chat::White, REZZ_ALREADY_PENDING);
-				caster->MessageString(Chat::White, CORPSE_TOO_OLD);
+				caster->MessageString(Chat::White, ClientString::REZZ_ALREADY_PENDING);
+				caster->MessageString(Chat::White, ClientString::CORPSE_TOO_OLD);
 				return;
 			}
 

--- a/zone/doors.cpp
+++ b/zone/doors.cpp
@@ -200,7 +200,7 @@ void Doors::HandleClick(Client *sender, uint8 trigger)
 			if (RuleI(Adventure, ItemIDToEnablePorts) != 0) {
 				if (!sender->KeyRingCheck(RuleI(Adventure, ItemIDToEnablePorts))) {
 					if (sender->GetInv().HasItem(RuleI(Adventure, ItemIDToEnablePorts)) == INVALID_INDEX) {
-						sender->MessageString(Chat::Red, DUNGEON_SEALED);
+						sender->MessageString(Chat::Red, ClientString::DUNGEON_SEALED);
 						safe_delete(outapp);
 						return;
 					}
@@ -297,7 +297,7 @@ void Doors::HandleClick(Client *sender, uint8 trigger)
 					sender->GetCleanName(),
 					z->flag_needed
 				);
-				sender->MessageString(Chat::LightBlue, DOORS_LOCKED);
+				sender->MessageString(Chat::LightBlue, ClientString::DOORS_LOCKED);
 			} else {
 				sender->Message(Chat::White, "Your GM flag allows you to use this door.");
 			}
@@ -374,7 +374,7 @@ void Doors::HandleClick(Client *sender, uint8 trigger)
 		 * GM can always open locks
 		 */
 		if (sender->GetGM()) {
-			sender->MessageString(Chat::LightBlue, DOORS_GM);
+			sender->MessageString(Chat::LightBlue, ClientString::DOORS_GM);
 
 			if (!IsDoorOpen() || (m_open_type == 58)) {
 				move_door_packet->action = static_cast<uint8>(m_invert_state == 0 ? OPEN_DOOR : OPEN_INVDOOR);
@@ -437,7 +437,7 @@ void Doors::HandleClick(Client *sender, uint8 trigger)
 							sender->CheckIncreaseSkill(EQ::skills::SkillPickLock, nullptr, 1);
 							move_door_packet->action = static_cast<uint8>(m_invert_state == 0 ? OPEN_DOOR
 								: OPEN_INVDOOR);
-							sender->MessageString(Chat::LightBlue, DOORS_SUCCESSFUL_PICK);
+							sender->MessageString(Chat::LightBlue, ClientString::DOORS_SUCCESSFUL_PICK);
 						}
 						else {
 							move_door_packet->action = static_cast<uint8>(m_invert_state == 0 ? CLOSE_DOOR
@@ -445,19 +445,19 @@ void Doors::HandleClick(Client *sender, uint8 trigger)
 						}
 					}
 					else {
-						sender->MessageString(Chat::LightBlue, DOORS_INSUFFICIENT_SKILL);
+						sender->MessageString(Chat::LightBlue, ClientString::DOORS_INSUFFICIENT_SKILL);
 						safe_delete(outapp);
 						return;
 					}
 				}
 				else {
-					sender->MessageString(Chat::LightBlue, DOORS_NO_PICK);
+					sender->MessageString(Chat::LightBlue, ClientString::DOORS_NO_PICK);
 					safe_delete(outapp);
 					return;
 				}
 			}
 			else {
-				sender->MessageString(Chat::LightBlue, DOORS_CANT_PICK);
+				sender->MessageString(Chat::LightBlue, ClientString::DOORS_CANT_PICK);
 				safe_delete(outapp);
 				return;
 			}
@@ -482,7 +482,7 @@ void Doors::HandleClick(Client *sender, uint8 trigger)
 				}
 			}
 			else {
-				sender->MessageString(Chat::LightBlue, DOORS_LOCKED);
+				sender->MessageString(Chat::LightBlue, ClientString::DOORS_LOCKED);
 				safe_delete(outapp);
 				return;
 			}

--- a/zone/effects.cpp
+++ b/zone/effects.cpp
@@ -151,10 +151,10 @@ int64 Mob::GetActSpellDamage(uint16 spell_id, int64 value, Mob* target) {
 
 			entity_list.FilteredMessageCloseString(
 				this, true, 100, Chat::SpellCrit, FilterSpellCrits,
-				OTHER_CRIT_BLAST, nullptr, GetName(), itoa(-value));
+				ClientString::OTHER_CRIT_BLAST, nullptr, GetName(), itoa(-value));
 
 			if (IsClient()) {
-				MessageString(Chat::SpellCrit, YOU_CRIT_BLAST, itoa(-value));
+				MessageString(Chat::SpellCrit, ClientString::YOU_CRIT_BLAST, itoa(-value));
 			}
 
 			return value;
@@ -506,10 +506,10 @@ int64 Mob::GetActSpellHealing(uint16 spell_id, int64 value, Mob* target, bool fr
 		if (critical_modifier > 1) {
 			entity_list.MessageCloseString(
 				this, true, 100, Chat::SpellCrit,
-				OTHER_CRIT_HEAL, GetName(), itoa(value));
+				ClientString::OTHER_CRIT_HEAL, GetName(), itoa(value));
 
 			if (IsClient()) {
-				MessageString(Chat::SpellCrit, YOU_CRIT_HEAL, itoa(value));
+				MessageString(Chat::SpellCrit, ClientString::YOU_CRIT_HEAL, itoa(value));
 			}
 		}
 
@@ -861,7 +861,7 @@ bool Client::UseDiscipline(uint32 spell_id, uint32 target) {
 		IsPet())
 	{
 		if (IsAmnesiad()) {
-			MessageString(Chat::Red, MELEE_SILENCE);
+			MessageString(Chat::Red, ClientString::MELEE_SILENCE);
 		}
 		return false;
 	}
@@ -895,7 +895,7 @@ bool Client::UseDiscipline(uint32 spell_id, uint32 target) {
 	}
 
 	if(level_to_use > GetLevel()) {
-		MessageString(Chat::Red, DISC_LEVEL_USE_ERROR);
+		MessageString(Chat::Red, ClientString::DISC_LEVEL_USE_ERROR);
 		//should summon them a new one...
 		return false;
 	}
@@ -907,7 +907,7 @@ bool Client::UseDiscipline(uint32 spell_id, uint32 target) {
 
 	// sneak attack discs require you to be hidden for 4 seconds before use
 	if (spell.sneak && (!hidden || (hidden && (Timer::GetCurrentTime() - tmHidden) < 4000))) {
-		MessageString(Chat::SpellFailure, SNEAK_RESTRICT);
+		MessageString(Chat::SpellFailure, ClientString::SNEAK_RESTRICT);
 		return false;
 	}
 

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -1829,9 +1829,9 @@ void EntityList::DuelMessage(Mob *winner, Mob *loser, bool flee)
 		//might want some sort of distance check in here?
 		if (cur != winner && cur != loser) {
 			if (flee)
-				cur->MessageString(Chat::Yellow, DUEL_FLED, winner->GetName(),loser->GetName(),loser->GetName());
+				cur->MessageString(Chat::Yellow, ClientString::DUEL_FLED, winner->GetName(),loser->GetName(),loser->GetName());
 			else
-				cur->MessageString(Chat::Yellow, DUEL_FINISHED, winner->GetName(),loser->GetName());
+				cur->MessageString(Chat::Yellow, ClientString::DUEL_FINISHED, winner->GetName(),loser->GetName());
 		}
 		++it;
 	}
@@ -5514,7 +5514,7 @@ void EntityList::ExpeditionWarning(uint32 minutes_left)
 
 	auto it = client_list.begin();
 	while (it != client_list.end()) {
-		it->second->MessageString(Chat::Yellow, DZ_MINUTES_REMAIN, itoa((int)minutes_left));
+		it->second->MessageString(Chat::Yellow, ClientString::DZ_MINUTES_REMAIN, itoa((int)minutes_left));
 		it->second->QueuePacket(outapp);
 		++it;
 	}

--- a/zone/exp.cpp
+++ b/zone/exp.cpp
@@ -342,18 +342,18 @@ void Client::CalculateLeadershipExp(uint64 &add_exp, uint8 conlevel)
 					uint64 mentor_exp = exp * (GetGroup()->GetMentorPercent() / 100.0f);
 					exp -= mentor_exp;
 					mentoree->AddLeadershipEXP(mentor_exp, 0); // ends up rounded down
-					mentoree->MessageString(Chat::LeaderShip, GAIN_GROUP_LEADERSHIP_EXP);
+					mentoree->MessageString(Chat::LeaderShip, ClientString::GAIN_GROUP_LEADERSHIP_EXP);
 				}
 				if (exp > 0)
 				{
 					// possible if you mentor 100% to the other client
 					AddLeadershipEXP(exp, 0); // ends up rounded up if mentored, no idea how live actually does it
-					MessageString(Chat::LeaderShip, GAIN_GROUP_LEADERSHIP_EXP);
+					MessageString(Chat::LeaderShip, ClientString::GAIN_GROUP_LEADERSHIP_EXP);
 				}
 			}
 			else
 			{
-				MessageString(Chat::LeaderShip, MAX_GROUP_LEADERSHIP_POINTS);
+				MessageString(Chat::LeaderShip, ClientString::MAX_GROUP_LEADERSHIP_POINTS);
 			}
 		}
 		else
@@ -366,11 +366,11 @@ void Client::CalculateLeadershipExp(uint64 &add_exp, uint8 conlevel)
 					&& RuleI(Character, KillsPerRaidLeadershipAA) > 0)
 				{
 					AddLeadershipEXP(0, RAID_EXP_PER_POINT / RuleI(Character, KillsPerRaidLeadershipAA));
-					MessageString(Chat::LeaderShip, GAIN_RAID_LEADERSHIP_EXP);
+					MessageString(Chat::LeaderShip, ClientString::GAIN_RAID_LEADERSHIP_EXP);
 				}
 				else
 				{
-					MessageString(Chat::LeaderShip, MAX_RAID_LEADERSHIP_POINTS);
+					MessageString(Chat::LeaderShip, ClientString::MAX_RAID_LEADERSHIP_POINTS);
 				}
 			}
 			else
@@ -387,17 +387,17 @@ void Client::CalculateLeadershipExp(uint64 &add_exp, uint8 conlevel)
 						uint64 mentor_exp = exp * (raid->GetMentorPercent(group_id) / 100.0f);
 						exp -= mentor_exp;
 						mentoree->AddLeadershipEXP(mentor_exp, 0);
-						mentoree->MessageString(Chat::LeaderShip, GAIN_GROUP_LEADERSHIP_EXP);
+						mentoree->MessageString(Chat::LeaderShip, ClientString::GAIN_GROUP_LEADERSHIP_EXP);
 					}
 					if (exp > 0)
 					{
 						AddLeadershipEXP(exp, 0);
-						MessageString(Chat::LeaderShip, GAIN_GROUP_LEADERSHIP_EXP);
+						MessageString(Chat::LeaderShip, ClientString::GAIN_GROUP_LEADERSHIP_EXP);
 					}
 				}
 				else
 				{
-					MessageString(Chat::LeaderShip, MAX_GROUP_LEADERSHIP_POINTS);
+					MessageString(Chat::LeaderShip, ClientString::MAX_GROUP_LEADERSHIP_POINTS);
 				}
 			}
 		}
@@ -552,11 +552,11 @@ void Client::AddEXP(ExpSource exp_source, uint64 in_add_exp, uint8 conlevel, boo
 
 	if (aa_cap >= 0 && aaexp > 0) {
 		if (m_pp.aapoints == aa_cap) {
-			MessageString(Chat::Red, AA_CAP);
+			MessageString(Chat::Red, ClientString::AA_CAP);
 			aaexp = 0;
 			m_epp.perAA = 0;
 		} else if (m_pp.aapoints > aa_cap) {
-			MessageString(Chat::Red, OVER_AA_CAP, fmt::format_int(aa_cap).c_str(), fmt::format_int(aa_cap).c_str());
+			MessageString(Chat::Red, ClientString::OVER_AA_CAP, fmt::format_int(aa_cap).c_str(), fmt::format_int(aa_cap).c_str());
 			m_pp.aapoints = aa_cap;
 			aaexp = 0;
 			m_epp.perAA = 0;
@@ -645,7 +645,7 @@ void Client::SetEXP(ExpSource exp_source, uint64 set_exp, uint64 set_aaxp, bool 
 			if (RuleI(Character, ShowExpValues) > 0) {
 				Message(Chat::Experience, "You regain %s experience from resurrection. %s", exp_amount_message.c_str(), exp_percent_message.c_str());
 			} else {
-				MessageString(Chat::Experience, REZ_REGAIN);
+				MessageString(Chat::Experience, ClientString::REZ_REGAIN);
 			}
 		} else {
 			if (membercount > 1) {
@@ -654,7 +654,7 @@ void Client::SetEXP(ExpSource exp_source, uint64 set_exp, uint64 set_aaxp, bool 
 				} else if (zone->IsHotzone()) {
 					Message(Chat::Experience, "You gain party experience (with a bonus)!");
 				} else {
-					MessageString(Chat::Experience, GAIN_GROUPXP);
+					MessageString(Chat::Experience, ClientString::GAIN_GROUPXP);
 				}
 			} else if (IsRaidGrouped()) {
 				if (RuleI(Character, ShowExpValues) > 0) {
@@ -662,7 +662,7 @@ void Client::SetEXP(ExpSource exp_source, uint64 set_exp, uint64 set_aaxp, bool 
 				} else if (zone->IsHotzone()) {
 					Message(Chat::Experience, "You gained raid experience (with a bonus)!");
 				} else {
-					MessageString(Chat::Experience, GAIN_RAIDEXP);
+					MessageString(Chat::Experience, ClientString::GAIN_RAIDEXP);
 				}
 			} else {
 				if (RuleI(Character, ShowExpValues) > 0) {
@@ -670,7 +670,7 @@ void Client::SetEXP(ExpSource exp_source, uint64 set_exp, uint64 set_aaxp, bool 
 				} else if (zone->IsHotzone()) {
 					Message(Chat::Experience, "You gain experience (with a bonus)!");
 				} else {
-					MessageString(Chat::Experience, GAIN_XP);
+					MessageString(Chat::Experience, ClientString::GAIN_XP);
 				}
 			}
 		}
@@ -756,11 +756,11 @@ void Client::SetEXP(ExpSource exp_source, uint64 set_exp, uint64 set_aaxp, bool 
 		char val2[20] = { 0 };
 
 		if (gained == 1 && m_pp.aapoints == 1) {
-			MessageString(Chat::Experience, GAIN_SINGLE_AA_SINGLE_AA, ConvertArray(m_pp.aapoints, val1)); //You have gained an ability point!  You now have %1 ability point.
+			MessageString(Chat::Experience, ClientString::GAIN_SINGLE_AA_SINGLE_AA, ConvertArray(m_pp.aapoints, val1)); //You have gained an ability point!  You now have %1 ability point.
 		} else if (gained == 1 && m_pp.aapoints > 1) {
-			MessageString(Chat::Experience, GAIN_SINGLE_AA_MULTI_AA, ConvertArray(m_pp.aapoints, val1)); //You have gained an ability point!  You now have %1 ability points.
+			MessageString(Chat::Experience, ClientString::GAIN_SINGLE_AA_MULTI_AA, ConvertArray(m_pp.aapoints, val1)); //You have gained an ability point!  You now have %1 ability points.
 		} else {
-			MessageString(Chat::Experience, GAIN_MULTI_AA_MULTI_AA, ConvertArray(gained, val1), ConvertArray(m_pp.aapoints, val2)); //You have gained %1 ability point(s)!  You now have %2 ability point(s).
+			MessageString(Chat::Experience, ClientString::GAIN_MULTI_AA_MULTI_AA, ConvertArray(gained, val1), ConvertArray(m_pp.aapoints, val2)); //You have gained %1 ability point(s)!  You now have %2 ability point(s).
 		}
 
 		if (RuleB(AA, SoundForAAEarned)) {
@@ -808,18 +808,18 @@ void Client::SetEXP(ExpSource exp_source, uint64 set_exp, uint64 set_aaxp, bool 
 		char val1[20]={0};
 		if (level_increase) {
 			if (level_count == 1) {
-				MessageString(Chat::Experience, GAIN_LEVEL, ConvertArray(check_level, val1));
+				MessageString(Chat::Experience, ClientString::GAIN_LEVEL, ConvertArray(check_level, val1));
 			} else {
 				Message(Chat::Yellow, "Welcome to level %i!", check_level);
 			}
 
 			if (check_level == RuleI(Character, DeathItemLossLevel) &&
 			    m_ClientVersionBit & EQ::versions::maskUFAndEarlier) {
-				MessageString(Chat::Yellow, CORPSE_ITEM_LOST);
+				MessageString(Chat::Yellow, ClientString::CORPSE_ITEM_LOST);
 				}
 
 			if (check_level == RuleI(Character, DeathExpLossLevel)) {
-				MessageString(Chat::Yellow, CORPSE_EXP_LOST);
+				MessageString(Chat::Yellow, ClientString::CORPSE_EXP_LOST);
 			}
 		}
 
@@ -875,7 +875,7 @@ void Client::SetEXP(ExpSource exp_source, uint64 set_exp, uint64 set_aaxp, bool 
 		char val1[20]={0};
 		char val2[20]={0};
 		char val3[20]={0};
-		MessageString(Chat::Experience, GM_GAINXP, ConvertArray(set_aaxp,val1),ConvertArray(set_exp,val2),ConvertArray(GetEXPForLevel(GetLevel()+1),val3));	//[GM] You have gained %1 AXP and %2 EXP (%3).
+		MessageString(Chat::Experience, ClientString::GM_GAINXP, ConvertArray(set_aaxp,val1),ConvertArray(set_exp,val2),ConvertArray(GetEXPForLevel(GetLevel()+1),val3));	//[GM] You have gained %1 AXP and %2 EXP (%3).
 	}
 }
 
@@ -1242,12 +1242,12 @@ void Client::SetLeadershipEXP(uint64 group_exp, uint64 raid_exp) {
 	while(group_exp >= GROUP_EXP_PER_POINT) {
 		group_exp -= GROUP_EXP_PER_POINT;
 		m_pp.group_leadership_points++;
-		MessageString(Chat::LeaderShip, GAIN_GROUP_LEADERSHIP_POINT);
+		MessageString(Chat::LeaderShip, ClientString::GAIN_GROUP_LEADERSHIP_POINT);
 	}
 	while(raid_exp >= RAID_EXP_PER_POINT) {
 		raid_exp -= RAID_EXP_PER_POINT;
 		m_pp.raid_leadership_points++;
-		MessageString(Chat::LeaderShip, GAIN_RAID_LEADERSHIP_POINT);
+		MessageString(Chat::LeaderShip, ClientString::GAIN_RAID_LEADERSHIP_POINT);
 	}
 
 	m_pp.group_leadership_exp = group_exp;

--- a/zone/expedition_request.cpp
+++ b/zone/expedition_request.cpp
@@ -254,7 +254,7 @@ void ExpeditionRequest::SendLeaderMemberInExpedition(const std::string& name, bo
 
 	if (is_solo)
 	{
-		SendLeaderMessage(Chat::Red, DZ_YOU_BELONG);
+		SendLeaderMessage(Chat::Red, ClientString::DZ_YOU_BELONG);
 	}
 	else if (m_requester)
 	{
@@ -274,11 +274,11 @@ void ExpeditionRequest::SendLeaderMemberReplayLockout(const std::string& name, c
 	auto time = lockout.GetTimeRemainingStrs();
 	if (is_solo)
 	{
-		SendLeaderMessage(Chat::Red, DZ_REPLAY_YOU, { time.days, time.hours, time.mins });
+		SendLeaderMessage(Chat::Red, ClientString::DZ_REPLAY_YOU, { time.days, time.hours, time.mins });
 	}
 	else
 	{
-		SendLeaderMessage(Chat::Red, DZ_REPLAY_OTHER, { name, time.days, time.hours, time.mins });
+		SendLeaderMessage(Chat::Red, ClientString::DZ_REPLAY_OTHER, { name, time.days, time.hours, time.mins });
 	}
 }
 
@@ -290,7 +290,7 @@ void ExpeditionRequest::SendLeaderMemberEventLockout(const std::string& name, co
 	}
 
 	auto time = lockout.GetTimeRemainingStrs();
-	SendLeaderMessage(Chat::Red, DZ_EVENT_TIMER, { name, lockout.Event(), time.days, time.hours, time.mins });
+	SendLeaderMessage(Chat::Red, ClientString::DZ_EVENT_TIMER, { name, lockout.Event(), time.days, time.hours, time.mins });
 }
 
 bool ExpeditionRequest::IsPlayerCountValidated()
@@ -305,7 +305,7 @@ bool ExpeditionRequest::IsPlayerCountValidated()
 	{
 		requirements_met = false;
 
-		SendLeaderMessage(Chat::System, DZ_PLAYER_COUNT, {
+		SendLeaderMessage(Chat::System, ClientString::DZ_PLAYER_COUNT, {
 			fmt::format_int(m_members.size()).str(),
 			fmt::format_int(m_dz->GetMinPlayers()).str(),
 			fmt::format_int(m_dz->GetMaxPlayers()).str()

--- a/zone/forage.cpp
+++ b/zone/forage.cpp
@@ -196,14 +196,14 @@ bool Client::CanFish() {
 
 	if (!Pole || !Pole->IsClassCommon() || Pole->GetItem()->ItemType != EQ::item::ItemTypeFishingPole) {
 		if (m_inv.HasItemByUse(EQ::item::ItemTypeFishingPole, 1, invWhereWorn | invWherePersonal | invWhereBank | invWhereSharedBank | invWhereTrading | invWhereCursor))	//We have a fishing pole somewhere, just not equipped
-			MessageString(Chat::Skills, FISHING_EQUIP_POLE);	//You need to put your fishing pole in your primary hand.
+			MessageString(Chat::Skills, ClientString::FISHING_EQUIP_POLE);	//You need to put your fishing pole in your primary hand.
 		else	//We don't have a fishing pole anywhere
-			MessageString(Chat::Skills, FISHING_NO_POLE);	//You can't fish without a fishing pole, go buy one.
+			MessageString(Chat::Skills, ClientString::FISHING_NO_POLE);	//You can't fish without a fishing pole, go buy one.
 		return false;
 	}
 
 	if (!Bait || !Bait->IsClassCommon() || Bait->GetItem()->ItemType != EQ::item::ItemTypeFishingBait) {
-		MessageString(Chat::Skills, FISHING_NO_BAIT);	//You can't fish without fishing bait, go buy some.
+		MessageString(Chat::Skills, ClientString::FISHING_NO_BAIT);	//You can't fish without fishing bait, go buy some.
 		return false;
 	}
 
@@ -225,7 +225,7 @@ bool Client::CanFish() {
 		float bestz = zone->zonemap->FindBestZ(rodPosition, nullptr);
 		float len = m_Position.z - bestz;
 		if(len > LineLength || len < 0.0f) {
-			MessageString(Chat::Skills, FISHING_LAND);
+			MessageString(Chat::Skills, ClientString::FISHING_LAND);
 			return false;
 		}
 
@@ -238,7 +238,7 @@ bool Client::CanFish() {
 			bool in_water = zone->watermap->InWater(dest) || zone->watermap->InVWater(dest);
 
 			if (in_lava) {
-				MessageString(Chat::Skills, FISHING_LAVA);	//Trying to catch a fire elemental or something?
+				MessageString(Chat::Skills, ClientString::FISHING_LAVA);	//Trying to catch a fire elemental or something?
 				return false;
 			}
 
@@ -247,7 +247,7 @@ bool Client::CanFish() {
 			}
 		}
 
-		MessageString(Chat::Skills, FISHING_LAND);
+		MessageString(Chat::Skills, ClientString::FISHING_LAND);
 		return false;
 	}
 	return true;
@@ -354,17 +354,17 @@ void Client::GoFish(bool guarantee, bool use_bait)
 		if (food_item) {
 
 			if (food_item->ItemType != EQ::item::ItemTypeFood) {
-				MessageString(Chat::Skills, FISHING_SUCCESS);
+				MessageString(Chat::Skills, ClientString::FISHING_SUCCESS);
 			}
 			else {
-				MessageString(Chat::Skills, FISHING_SUCCESS_FISH_NAME, food_item->Name);
+				MessageString(Chat::Skills, ClientString::FISHING_SUCCESS_FISH_NAME, food_item->Name);
 			}
 
 			EQ::ItemInstance* inst = database.CreateItem(food_item, 1);
 			if (inst != nullptr) {
 				if (CheckLoreConflict(inst->GetItem()))
 				{
-					MessageString(Chat::White, DUP_LORE);
+					MessageString(Chat::White, ClientString::DUP_LORE);
 					safe_delete(inst);
 				}
 				else
@@ -408,13 +408,13 @@ void Client::GoFish(bool guarantee, bool use_bait)
 		//chance to use bait when you dont catch anything...
 		if (zone->random.Int(0, 4) == 1) {
 			DeleteItemInInventory(bslot, 1, true);	//do we need client update?
-			MessageString(Chat::Skills, FISHING_LOST_BAIT);	//You lost your bait!
+			MessageString(Chat::Skills, ClientString::FISHING_LOST_BAIT);	//You lost your bait!
 		} else {
 			if (zone->random.Int(0, 15) == 1)	//give about a 1 in 15 chance to spill your beer. we could make this a rule, but it doesn't really seem worth it
 				//TODO: check for & consume an alcoholic beverage from inventory when this triggers, and set it as a rule that's disabled by default
-				MessageString(Chat::Skills, FISHING_SPILL_BEER);	//You spill your beer while bringing in your line.
+				MessageString(Chat::Skills, ClientString::FISHING_SPILL_BEER);	//You spill your beer while bringing in your line.
 			else
-				MessageString(Chat::Skills, FISHING_FAILED);	//You didn't catch anything.
+				MessageString(Chat::Skills, ClientString::FISHING_FAILED);	//You didn't catch anything.
 		}
 
 		RecordPlayerEventLog(PlayerEvent::FISH_FAILURE, PlayerEvent::EmptyEvent{});
@@ -431,7 +431,7 @@ void Client::GoFish(bool guarantee, bool use_bait)
 	if (Pole) {
 		const EQ::ItemData* fishing_item = Pole->GetItem();
 		if (fishing_item && fishing_item->SubType == 0 && zone->random.Int(0, 49) == 1) {
-			MessageString(Chat::Skills, FISHING_POLE_BROKE);	//Your fishing pole broke!
+			MessageString(Chat::Skills, ClientString::FISHING_POLE_BROKE);	//Your fishing pole broke!
 			DeleteItemInInventory(EQ::invslot::slotPrimary, 0, true);
 		}
 	}
@@ -461,7 +461,7 @@ void Client::ForageItem(bool guarantee) {
 	// these may need to be fine tuned, I am just guessing here
 	if (guarantee || zone->random.Int(0,199) < skill_level) {
 		uint32 foragedfood = 0;
-		uint32 stringid = FORAGE_NOEAT;
+		uint32 stringid = ClientString::FORAGE_NOEAT;
 
 		if (zone->random.Roll(RuleI(Zone, ForageChance))) {
 			foragedfood = content_db.LoadForage(m_pp.zone_id, skill_level);
@@ -482,17 +482,17 @@ void Client::ForageItem(bool guarantee) {
 		}
 
 		if (foragedfood == 13106) {
-			stringid = FORAGE_GRUBS;
+			stringid = ClientString::FORAGE_GRUBS;
 		} else {
 			switch(food_item->ItemType) {
 			case EQ::item::ItemTypeFood:
-				stringid = FORAGE_FOOD;
+				stringid = ClientString::FORAGE_FOOD;
 				break;
 			case EQ::item::ItemTypeDrink:
 				if (strstr(food_item->Name, "ater")) {
-					stringid = FORAGE_WATER;
+					stringid = ClientString::FORAGE_WATER;
 				} else {
-					stringid = FORAGE_DRINK;
+					stringid = ClientString::FORAGE_DRINK;
 				}
 				break;
 			default:
@@ -505,7 +505,7 @@ void Client::ForageItem(bool guarantee) {
 		if (inst != nullptr) {
 			// check to make sure it isn't a foraged lore item
 			if (CheckLoreConflict(inst->GetItem())) {
-				MessageString(Chat::White, DUP_LORE);
+				MessageString(Chat::White, ClientString::DUP_LORE);
 				safe_delete(inst);
 			} else {
 				PushItemOnCursor(*inst);
@@ -544,11 +544,11 @@ void Client::ForageItem(bool guarantee) {
 
 		int ChanceSecondForage = aabonuses.ForageAdditionalItems + itembonuses.ForageAdditionalItems + spellbonuses.ForageAdditionalItems;
 		if (!guarantee && zone->random.Roll(ChanceSecondForage)) {
-			MessageString(Chat::Skills, FORAGE_MASTERY);
+			MessageString(Chat::Skills, ClientString::FORAGE_MASTERY);
 			ForageItem(true);
 		}
 	} else {
-		MessageString(Chat::Skills, FORAGE_FAILED);
+		MessageString(Chat::Skills, ClientString::FORAGE_FAILED);
 		RecordPlayerEventLog(PlayerEvent::FORAGE_FAILURE, PlayerEvent::EmptyEvent{});
 
 		if (parse->PlayerHasQuestSub(EVENT_FORAGE_FAILURE)) {

--- a/zone/gm_commands/parcels.cpp
+++ b/zone/gm_commands/parcels.cpp
@@ -51,7 +51,7 @@ void command_parcels(Client *c, const Seperator *sep)
 
 		auto player_id = CharacterParcelsRepository::GetParcelCountAndCharacterName(database, player_name);
 		if (!player_id.at(0).char_id) {
-			c->MessageString(Chat::Yellow, CANT_FIND_PLAYER, player_name.c_str());
+			c->MessageString(Chat::Yellow, ClientString::CANT_FIND_PLAYER, player_name.c_str());
 			return;
 		}
 
@@ -138,7 +138,7 @@ void command_parcels(Client *c, const Seperator *sep)
 			to_name
 		);
 		if (send_to_client.at(0).character_name.empty()) {
-			c->MessageString(Chat::Yellow, CANT_FIND_PLAYER, to_name.c_str());
+			c->MessageString(Chat::Yellow, ClientString::CANT_FIND_PLAYER, to_name.c_str());
 			return;
 		}
 
@@ -205,7 +205,7 @@ void command_parcels(Client *c, const Seperator *sep)
 
 			c->MessageString(
 				Chat::Yellow,
-				PARCEL_DELIVERY,
+				ClientString::PARCEL_DELIVERY,
 				c->GetCleanName(),
 				"Money",
 				send_to_client.at(0).character_name.c_str()
@@ -289,7 +289,7 @@ void command_parcels(Client *c, const Seperator *sep)
 
 			c->MessageString(
 				Chat::Yellow,
-				PARCEL_DELIVERY,
+				ClientString::PARCEL_DELIVERY,
 				c->GetCleanName(),
 				inst->GetItem()->Name,
 				send_to_client.at(0).character_name.c_str()

--- a/zone/groups.cpp
+++ b/zone/groups.cpp
@@ -189,8 +189,8 @@ void Group::SplitMoney(uint32 copper, uint32 silver, uint32 gold, uint32 platinu
 			// the group member other than the character doing the /split only gets this message "(splitter) shares the money with the group"
 			if (share && member_client != splitter) {
 				member_client->MessageString(
-					YOU_RECEIVE_AS_SPLIT,
-					SHARE_MONEY,
+					ClientString::YOU_RECEIVE_AS_SPLIT,
+					ClientString::SHARE_MONEY,
 					splitter->GetCleanName()
 				);
 			}
@@ -200,7 +200,7 @@ void Group::SplitMoney(uint32 copper, uint32 silver, uint32 gold, uint32 platinu
 				member_client->AddMoneyToPP(receive_copper, receive_silver, receive_gold, receive_platinum, true);
 				member_client->MessageString(
 					Chat::MoneySplit,
-					YOU_RECEIVE_AS_SPLIT,
+					ClientString::YOU_RECEIVE_AS_SPLIT,
 					Strings::Money(receive_platinum, receive_gold, receive_silver, receive_copper).c_str()
 				);
 			}

--- a/zone/guild_mgr.cpp
+++ b/zone/guild_mgr.cpp
@@ -405,7 +405,7 @@ void ZoneGuildManager::ProcessWorldPacket(ServerPacket *pack)
 						c.second->SendGuildActiveTributes(c.second->GuildID());
 						c.second->SendGuildDeletePacket(s->guild_id);
 						c.second->RefreshGuildInfo();
-						c.second->MessageString(Chat::Guild, GUILD_DISBANDED);
+						c.second->MessageString(Chat::Guild, ClientString::GUILD_DISBANDED);
 						c.second->SendGuildList();
 					}
 				}

--- a/zone/horse.cpp
+++ b/zone/horse.cpp
@@ -125,7 +125,7 @@ const NPCType *Horse::BuildHorseType(uint16 spell_id)
 void Client::SummonHorse(uint16 spell_id)
 {
 	if (GetHorseId()) {
-		MessageString(Chat::Red, ALREADY_ON_A_MOUNT);
+		MessageString(Chat::Red, ClientString::ALREADY_ON_A_MOUNT);
 		return;
 	}
 

--- a/zone/merc.cpp
+++ b/zone/merc.cpp
@@ -1210,7 +1210,7 @@ void Merc::AI_Process() {
 					{
 						if(zone->random.Roll(flurrychance))
 						{
-							MessageString(Chat::NPCFlurry, YOU_FLURRY);
+							MessageString(Chat::NPCFlurry, ClientString::YOU_FLURRY);
 							Attack(GetTarget(), EQ::invslot::slotPrimary, false);
 							Attack(GetTarget(), EQ::invslot::slotPrimary, false);
 						}
@@ -2208,7 +2208,7 @@ int64 Merc::GetFocusEffect(focusType type, uint16 spell_id, bool from_buff_tic) 
 			realTotal = CalcFocusEffect(type, UsedFocusID, spell_id);
 
 		if (realTotal != 0 && UsedItem)
-			MessageString(Chat::FocusEffect, BEGINS_TO_GLOW, UsedItem->Name);
+			MessageString(Chat::FocusEffect, ClientString::BEGINS_TO_GLOW, UsedItem->Name);
 	}
 
 	//Check if spell focus effect exists for the client.

--- a/zone/mob.cpp
+++ b/zone/mob.cpp
@@ -5050,13 +5050,13 @@ void Mob::Say(const char *format, ...)
 		std::string new_message = EQ::SayLinkEngine::InjectSaylinksIfNotExist(buf);
 		entity_list.MessageCloseString(
 			talker, false, distance, Chat::NPCQuestSay,
-			GENERIC_SAY, GetCleanName(), new_message.c_str()
+			ClientString::GENERIC_SAY, GetCleanName(), new_message.c_str()
 		);
 	}
 	else {
 		entity_list.MessageCloseString(
 			talker, false, distance, Chat::NPCQuestSay,
-			GENERIC_SAY, GetCleanName(), buf
+			ClientString::GENERIC_SAY, GetCleanName(), buf
 		);
 	}
 }
@@ -5072,7 +5072,7 @@ void Mob::SayString(uint32 string_id, const char *message3, const char *message4
 
 	entity_list.MessageCloseString(
 		this, false, 200, 10,
-		GENERIC_STRINGID_SAY, GetCleanName(), string_id_str, message3, message4, message5,
+		ClientString::GENERIC_STRINGID_SAY, GetCleanName(), string_id_str, message3, message4, message5,
 		message6, message7, message8, message9
 	);
 }
@@ -5085,7 +5085,7 @@ void Mob::SayString(uint32 type, uint32 string_id, const char *message3, const c
 
 	entity_list.MessageCloseString(
 		this, false, 200, type,
-		GENERIC_STRINGID_SAY, GetCleanName(), string_id_str, message3, message4, message5,
+		ClientString::GENERIC_STRINGID_SAY, GetCleanName(), string_id_str, message3, message4, message5,
 		message6, message7, message8, message9
 	);
 }
@@ -5097,7 +5097,7 @@ void Mob::SayString(Client *to, uint32 string_id, const char *message3, const ch
 
 	auto string_id_str = std::to_string(string_id);
 
-	to->MessageString(Chat::NPCQuestSay, GENERIC_STRINGID_SAY, GetCleanName(), string_id_str.c_str(), message3, message4, message5, message6, message7, message8, message9);
+	to->MessageString(Chat::NPCQuestSay, ClientString::GENERIC_STRINGID_SAY, GetCleanName(), string_id_str.c_str(), message3, message4, message5, message6, message7, message8, message9);
 }
 
 void Mob::SayString(Client *to, uint32 type, uint32 string_id, const char *message3, const char *message4, const char *message5, const char *message6, const char *message7, const char *message8, const char *message9)
@@ -5107,7 +5107,7 @@ void Mob::SayString(Client *to, uint32 type, uint32 string_id, const char *messa
 
 	auto string_id_str = std::to_string(string_id);
 
-	to->MessageString(type, GENERIC_STRINGID_SAY, GetCleanName(), string_id_str.c_str(), message3, message4, message5, message6, message7, message8, message9);
+	to->MessageString(type, ClientString::GENERIC_STRINGID_SAY, GetCleanName(), string_id_str.c_str(), message3, message4, message5, message6, message7, message8, message9);
 }
 
 void Mob::Shout(const char *format, ...)
@@ -5120,7 +5120,7 @@ void Mob::Shout(const char *format, ...)
 	va_end(ap);
 
 	entity_list.MessageString(this, false, Chat::Shout,
-		GENERIC_SHOUT, GetCleanName(), buf);
+		ClientString::GENERIC_SHOUT, GetCleanName(), buf);
 }
 
 void Mob::Emote(const char *format, ...)
@@ -5134,7 +5134,7 @@ void Mob::Emote(const char *format, ...)
 
 	entity_list.MessageCloseString(
 		this, false, 200, 10,
-		GENERIC_EMOTE, GetCleanName(), buf
+		ClientString::GENERIC_EMOTE, GetCleanName(), buf
 	);
 }
 
@@ -5322,12 +5322,12 @@ void Mob::ExecWeaponProc(const EQ::ItemInstance* inst, uint16 spell_id, Mob* on,
 	}
 
 	if (IsSilenced() && !IsDiscipline(spell_id)) {
-		MessageString(Chat::Red, SILENCED_STRING);
+		MessageString(Chat::Red, ClientString::SILENCED_STRING);
 		return;
 	}
 
 	if (IsAmnesiad() && IsDiscipline(spell_id)) {
-		MessageString(Chat::Red, MELEE_SILENCE);
+		MessageString(Chat::Red, ClientString::MELEE_SILENCE);
 		return;
 	}
 
@@ -7154,16 +7154,16 @@ void Mob::SlowMitigation(Mob* caster)
 	if (GetSlowMitigation() && caster && caster->IsClient())
 	{
 		if ((GetSlowMitigation() > 0) && (GetSlowMitigation() < 26))
-			caster->MessageString(Chat::SpellFailure, SLOW_MOSTLY_SUCCESSFUL);
+			caster->MessageString(Chat::SpellFailure, ClientString::SLOW_MOSTLY_SUCCESSFUL);
 
 		else if ((GetSlowMitigation() >= 26) && (GetSlowMitigation() < 74))
-			caster->MessageString(Chat::SpellFailure, SLOW_PARTIALLY_SUCCESSFUL);
+			caster->MessageString(Chat::SpellFailure, ClientString::SLOW_PARTIALLY_SUCCESSFUL);
 
 		else if ((GetSlowMitigation() >= 74) && (GetSlowMitigation() < 101))
-			caster->MessageString(Chat::SpellFailure, SLOW_SLIGHTLY_SUCCESSFUL);
+			caster->MessageString(Chat::SpellFailure, ClientString::SLOW_SLIGHTLY_SUCCESSFUL);
 
 		else if (GetSlowMitigation() > 100)
-			caster->MessageString(Chat::SpellFailure, SPELL_OPPOSITE_EFFECT);
+			caster->MessageString(Chat::SpellFailure, ClientString::SPELL_OPPOSITE_EFFECT);
 	}
 }
 
@@ -7956,7 +7956,7 @@ bool Mob::ShieldAbility(uint32 target_id, int shielder_max_distance, int shield_
 
 	if (!can_shield_npc && shield_target->IsNPC()) {
 		if (IsClient()) {
-			MessageString(Chat::White, SHIELD_TARGET_NPC);
+			MessageString(Chat::White, ClientString::SHIELD_TARGET_NPC);
 		}
 		return false;
 	}
@@ -7977,7 +7977,7 @@ bool Mob::ShieldAbility(uint32 target_id, int shielder_max_distance, int shield_
 	//You have a shielder, or your 'Shield Target' already has a 'Shielder'
 	if (GetShielderID() || shield_target->GetShielderID()) {
 		if (IsClient()) {
-			MessageString(Chat::White, ALREADY_SHIELDED);
+			MessageString(Chat::White, ClientString::ALREADY_SHIELDED);
 		}
 		return false;
 	}
@@ -7985,7 +7985,7 @@ bool Mob::ShieldAbility(uint32 target_id, int shielder_max_distance, int shield_
 	//You are being shielded or already have a 'Shield Target'
 	if (GetShieldTargetID() || shield_target->GetShieldTargetID()) {
 		if (IsClient()) {
-			MessageString(Chat::White, ALREADY_SHIELDING);
+			MessageString(Chat::White, ClientString::ALREADY_SHIELDING);
 		}
 		return false;
 	}
@@ -7997,11 +7997,11 @@ bool Mob::ShieldAbility(uint32 target_id, int shielder_max_distance, int shield_
 	}
 
 	if (shield_target->CalculateDistance(GetX(), GetY(), GetZ()) > static_cast<float>(shielder_max_distance)) {
-		MessageString(Chat::Blue, TARGET_TOO_FAR);
+		MessageString(Chat::Blue, ClientString::TARGET_TOO_FAR);
 		return false;
 	}
 
-	entity_list.MessageCloseString(this, false, 100, 0, START_SHIELDING, GetCleanName(), shield_target->GetCleanName());
+	entity_list.MessageCloseString(this, false, 100, 0, ClientString::START_SHIELDING, GetCleanName(), shield_target->GetCleanName());
 
 	SetShieldTargetID(shield_target->GetID());
 	SetShielderMitigation(shielder_mitigation);
@@ -8025,7 +8025,7 @@ void Mob::ShieldAbilityFinish()
 	Mob* shield_target = entity_list.GetMob(GetShieldTargetID());
 
 	if (shield_target) {
-		entity_list.MessageCloseString(this, false, 100, 0, END_SHIELDING, GetCleanName(), shield_target->GetCleanName());
+		entity_list.MessageCloseString(this, false, 100, 0, ClientString::END_SHIELDING, GetCleanName(), shield_target->GetCleanName());
 		shield_target->SetShielderID(0);
 		shield_target->SetShieldTargetMitigation(0);
 	}

--- a/zone/mob_ai.cpp
+++ b/zone/mob_ai.cpp
@@ -529,7 +529,7 @@ void NPC::AI_Stop() {
 
 void Client::AI_Stop() {
 	Mob::AI_Stop();
-	MessageString(Chat::Red,PLAYER_REGAIN);
+	MessageString(Chat::Red, ClientString::PLAYER_REGAIN);
 
 	auto app = new EQApplicationPacket(OP_Charm, sizeof(Charm_Struct));
 	Charm_Struct *ps = (Charm_Struct*)app->pBuffer;
@@ -1101,7 +1101,7 @@ void Mob::AI_Process() {
 
 			auto pet_owner = GetOwner();
 			if (pet_owner && pet_owner->IsClient()) {
-				pet_owner->MessageString(Chat::NPCQuestSay, CANNOT_WAKE, GetCleanName(), target->GetCleanName());
+				pet_owner->MessageString(Chat::NPCQuestSay, ClientString::CANNOT_WAKE, GetCleanName(), target->GetCleanName());
 			}
 
 			RemoveFromHateList(target);
@@ -1960,14 +1960,14 @@ void Mob::StartEnrage()
 
 	// start the timer. need to call IsEnraged frequently since we dont have callback timers :-/
 	bEnraged = true;
-	entity_list.MessageCloseString(this, true, 200, Chat::NPCEnrage, NPC_ENRAGE_START, GetCleanName());
+	entity_list.MessageCloseString(this, true, 200, Chat::NPCEnrage, ClientString::NPC_ENRAGE_START, GetCleanName());
 }
 
 void Mob::ProcessEnrage(){
 	if(IsEnraged()){
 		Timer *timer = GetSpecialAbilityTimer(SpecialAbility::Enrage);
 		if(timer && timer->Check()){
-			entity_list.MessageCloseString(this, true, 200, Chat::NPCEnrage, NPC_ENRAGE_END, GetCleanName());
+			entity_list.MessageCloseString(this, true, 200, Chat::NPCEnrage, ClientString::NPC_ENRAGE_END, GetCleanName());
 
 			int enraged_cooldown = GetSpecialAbilityParam(SpecialAbility::Enrage, 2);
 			enraged_cooldown = enraged_cooldown > 0 ? enraged_cooldown : EnragedTimer;
@@ -1993,7 +1993,7 @@ bool Mob::Flurry(ExtraAttackOptions *opts)
 				true,
 				200,
 				Chat::PetFlurry,
-				NPC_FLURRY,
+				ClientString::NPC_FLURRY,
 				GetCleanName(),
 				target->GetCleanName());
 		} else {
@@ -2002,7 +2002,7 @@ bool Mob::Flurry(ExtraAttackOptions *opts)
 				true,
 				200,
 				Chat::NPCFlurry,
-				NPC_FLURRY,
+				ClientString::NPC_FLURRY,
 				GetCleanName(),
 				target->GetCleanName());
 		}
@@ -2070,9 +2070,9 @@ bool Mob::Rampage(ExtraAttackOptions *opts)
 {
 	int index_hit = 0;
 	if (IsPet() || IsTempPet() || IsCharmed() || IsAnimation()){
-		entity_list.MessageCloseString(this, true, 200, Chat::PetFlurry, NPC_RAMPAGE, GetCleanName());
+		entity_list.MessageCloseString(this, true, 200, Chat::PetFlurry, ClientString::NPC_RAMPAGE, GetCleanName());
 	} else {
-		entity_list.MessageCloseString(this, true, 200, Chat::NPCRampage, NPC_RAMPAGE, GetCleanName());
+		entity_list.MessageCloseString(this, true, 200, Chat::NPCRampage, ClientString::NPC_RAMPAGE, GetCleanName());
 	}
 
 	int rampage_targets = GetSpecialAbilityParam(SpecialAbility::Rampage, 1);
@@ -2143,9 +2143,9 @@ void Mob::AreaRampage(ExtraAttackOptions *opts)
 {
 	int index_hit = 0;
 	if (IsPet() || IsTempPet() || IsCharmed() || IsAnimation()) { // do not know every pet AA so thought it safer to add this
-		entity_list.MessageCloseString(this, true, 200, Chat::PetFlurry, AE_RAMPAGE, GetCleanName());
+		entity_list.MessageCloseString(this, true, 200, Chat::PetFlurry, ClientString::AE_RAMPAGE, GetCleanName());
 	} else {
-		entity_list.MessageCloseString(this, true, 200, Chat::NPCRampage, AE_RAMPAGE, GetCleanName());
+		entity_list.MessageCloseString(this, true, 200, Chat::NPCRampage, ClientString::AE_RAMPAGE, GetCleanName());
 	}
 
 	int rampage_targets = GetSpecialAbilityParam(SpecialAbility::AreaRampage, 1);

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -1852,17 +1852,17 @@ void NPC::Disarm(Client* client, int chance) {
 				SendWearChange(matslot);
 			if ((CastToMob()->GetBodyType() == BodyType::Humanoid || CastToMob()->GetBodyType() == BodyType::Summoned) && eslot == EQ::invslot::slotPrimary)
 				Say("Ahh! My weapon!");
-			client->MessageString(Chat::Skills, DISARM_SUCCESS, GetCleanName());
+			client->MessageString(Chat::Skills, ClientString::DISARM_SUCCESS, GetCleanName());
 			if (chance != 1000)
 				client->CheckIncreaseSkill(EQ::skills::SkillDisarm, nullptr, 4);
 			return;
 		}
-		client->MessageString(Chat::Skills, DISARM_FAILED);
+		client->MessageString(Chat::Skills, ClientString::DISARM_FAILED);
 		if (chance != 1000)
 			client->CheckIncreaseSkill(EQ::skills::SkillDisarm, nullptr, 2);
 		return;
 	}
-	client->MessageString(Chat::Skills, DISARM_FAILED);
+	client->MessageString(Chat::Skills, ClientString::DISARM_FAILED);
 }
 
 void Mob::NPCSpecialAttacks(const char* parse, int permtag, bool reset, bool remove) {
@@ -2929,7 +2929,7 @@ void NPC::DoNPCEmote(uint8 event_, uint32 emote_id, Mob* t)
 				true,
 				200,
 				Chat::NPCQuestSay,
-				GENERIC_STRING,
+				ClientString::GENERIC_STRING,
 				processed.c_str()
 			);
 		}

--- a/zone/parcels.cpp
+++ b/zone/parcels.cpp
@@ -242,7 +242,7 @@ void Client::SendParcelStatus()
 		else if (num_over_limit == 1) {
 			MessageString(
 				Chat::Red,
-				PARCEL_STATUS_1,
+				ClientString::PARCEL_STATUS_1,
 				std::to_string(num_of_parcels).c_str(),
 				std::to_string(RuleI(Parcel, ParcelMaxItems)).c_str()
 			);
@@ -250,7 +250,7 @@ void Client::SendParcelStatus()
 		else if (num_over_limit > 1) {
 			MessageString(
 				Chat::Red,
-				PARCEL_STATUS_2,
+				ClientString::PARCEL_STATUS_2,
 				std::to_string(num_of_parcels).c_str(),
 				std::to_string(num_over_limit).c_str(),
 				std::to_string(RuleI(Parcel, ParcelMaxItems)).c_str()
@@ -331,7 +331,7 @@ void Client::DoParcelSend(const Parcel_Struct *parcel_in)
 	}
 
 	if (!GetParcelEnabled()) {
-		MessageString(Chat::Yellow, PARCEL_DELAY, merchant->GetCleanName());
+		MessageString(Chat::Yellow, ClientString::PARCEL_DELAY, merchant->GetCleanName());
 		DoParcelCancel();
 		SendParcelAck();
 		return;
@@ -371,7 +371,7 @@ void Client::DoParcelSend(const Parcel_Struct *parcel_in)
 			if (send_to_client.at(0).character_name.empty()) {
 				MessageString(
 					Chat::Yellow,
-					PARCEL_UNKNOWN_NAME,
+					ClientString::PARCEL_UNKNOWN_NAME,
 					merchant->GetCleanName(),
 					parcel_in->send_to,
 					inst->GetItem()->Name
@@ -462,7 +462,7 @@ void Client::DoParcelSend(const Parcel_Struct *parcel_in)
 
 			MessageString(
 				Chat::Yellow,
-				PARCEL_DELIVERY,
+				ClientString::PARCEL_DELIVERY,
 				merchant->GetCleanName(),
 				inst->GetItem()->Name,
 				send_to_client.at(0).character_name.c_str()
@@ -528,7 +528,7 @@ void Client::DoParcelSend(const Parcel_Struct *parcel_in)
 			if (send_to_client.at(0).character_name.empty()) {
 				MessageString(
 					Chat::Yellow,
-					PARCEL_UNKNOWN_NAME,
+					ClientString::PARCEL_UNKNOWN_NAME,
 					merchant->GetCleanName(),
 					parcel_in->send_to,
 					"Money"
@@ -566,7 +566,7 @@ void Client::DoParcelSend(const Parcel_Struct *parcel_in)
 
 			MessageString(
 				Chat::Yellow,
-				PARCEL_DELIVERY,
+				ClientString::PARCEL_DELIVERY,
 				merchant->GetCleanName(),
 				"Money",
 				send_to_client.at(0).character_name.c_str()
@@ -687,7 +687,7 @@ void Client::DoParcelRetrieve(const ParcelRetrieve_Struct &parcel_in)
 			case PARCEL_MONEY_ITEM_ID: {
 				AddMoneyToPP(p->second.quantity, true);
 				MessageString(
-					Chat::Yellow, PARCEL_DELIVERED, merchant->GetCleanName(), "Money", p->second.from_name.c_str()
+					Chat::Yellow, ClientString::PARCEL_DELIVERED, merchant->GetCleanName(), "Money", p->second.from_name.c_str()
 				);
 				break;
 			}
@@ -717,11 +717,11 @@ void Client::DoParcelRetrieve(const ParcelRetrieve_Struct &parcel_in)
 
 						if (CheckLoreConflict(item->GetItem())) {
 							if (RuleB(Parcel, DeleteOnDuplicate)) {
-								MessageString(Chat::Yellow, PARCEL_DUPLICATE_DELETE, inst->GetItem()->Name);
+								MessageString(Chat::Yellow, ClientString::PARCEL_DUPLICATE_DELETE, inst->GetItem()->Name);
 								continue;
 							}
 
-							MessageString(Chat::Yellow, DUP_LORE);
+							MessageString(Chat::Yellow, ClientString::DUP_LORE);
 							SendParcelRetrieveAck();
 							return;
 						}
@@ -733,16 +733,16 @@ void Client::DoParcelRetrieve(const ParcelRetrieve_Struct &parcel_in)
 				auto const free_id = GetInv().FindFirstFreeSlotThatFitsItemWithStacking(inst.get());
 				if (free_id == INVALID_INDEX) {
 					SendParcelRetrieveAck();
-					MessageString(Chat::White, PARCEL_INV_FULL, merchant->GetCleanName());
+					MessageString(Chat::White, ClientString::PARCEL_INV_FULL, merchant->GetCleanName());
 					return;
 				}
 
 				if (CheckLoreConflict(inst->GetItem())) {
 					if (RuleB(Parcel, DeleteOnDuplicate)) {
-						MessageString(Chat::Yellow, PARCEL_DUPLICATE_DELETE, inst->GetItem()->Name);
+						MessageString(Chat::Yellow, ClientString::PARCEL_DUPLICATE_DELETE, inst->GetItem()->Name);
 					}
 					else {
-						MessageString(Chat::Yellow, DUP_LORE);
+						MessageString(Chat::Yellow, ClientString::DUP_LORE);
 						SendParcelRetrieveAck();
 						return;
 					}
@@ -751,7 +751,7 @@ void Client::DoParcelRetrieve(const ParcelRetrieve_Struct &parcel_in)
 				if (AutoPutLootInInventory(*inst.get(), false, true)) {
 					MessageString(
 						Chat::Yellow,
-						PARCEL_DELIVERED_2,
+						ClientString::PARCEL_DELIVERED_2,
 						merchant->GetCleanName(),
 						std::to_string(item_quantity).c_str(),
 						inst->GetItem()->Name,

--- a/zone/raids.cpp
+++ b/zone/raids.cpp
@@ -979,7 +979,7 @@ void Raid::SplitMoney(uint32 gid, uint32 copper, uint32 silver, uint32 gold, uin
 
 			m.member->MessageString(
 				Chat::MoneySplit,
-				YOU_RECEIVE_AS_SPLIT,
+				ClientString::YOU_RECEIVE_AS_SPLIT,
 				Strings::Money(
 					platinum_split,
 					gold_split,
@@ -2317,13 +2317,13 @@ void Raid::DelegateAbilityAssist(Mob* delegator, const char* delegatee)
 {
 	auto raid_delegatee = entity_list.GetRaidByName(delegatee);
 	if (!raid_delegatee) {
-		delegator->CastToClient()->MessageString(Chat::Cyan, NOT_IN_YOUR_RAID, delegatee);
+		delegator->CastToClient()->MessageString(Chat::Cyan, ClientString::NOT_IN_YOUR_RAID, delegatee);
 		return;
 	}
 	uint32 raid_delegatee_id = raid_delegatee->GetID();
 	uint32 raid_delegator_id = GetID();
 	if (raid_delegatee_id != raid_delegator_id) {
-		delegator->CastToClient()->MessageString(Chat::Cyan, NOT_IN_YOUR_RAID, delegatee);
+		delegator->CastToClient()->MessageString(Chat::Cyan, ClientString::NOT_IN_YOUR_RAID, delegatee);
 		return;
 	}
 
@@ -2339,7 +2339,7 @@ void Raid::DelegateAbilityAssist(Mob* delegator, const char* delegatee)
 	auto slot = FindNextRaidDelegateSlot(FindNextAssisterSlot);
 	auto ma = rm->main_assister;
 	if (slot == -1 && !ma) {
-		delegator->CastToClient()->MessageString(Chat::Cyan, MAX_MAIN_RAID_ASSISTERS);
+		delegator->CastToClient()->MessageString(Chat::Cyan, ClientString::MAX_MAIN_RAID_ASSISTERS);
 		return;
 	}
 
@@ -2454,13 +2454,13 @@ void Raid::DelegateAbilityMark(Mob* delegator, const char* delegatee)
 {
 	auto raid_delegatee = entity_list.GetRaidByName(delegatee);
 	if (!raid_delegatee) {
-		delegator->CastToClient()->MessageString(Chat::Cyan, NOT_IN_YOUR_RAID, delegatee);
+		delegator->CastToClient()->MessageString(Chat::Cyan, ClientString::NOT_IN_YOUR_RAID, delegatee);
 		return;
 	}
 	uint32 raid_delegatee_id = raid_delegatee->GetID();
 	uint32 raid_delegator_id = GetID();
 	if (raid_delegatee_id != raid_delegator_id) {
-		delegator->CastToClient()->MessageString(Chat::Cyan, NOT_IN_YOUR_RAID, delegatee);
+		delegator->CastToClient()->MessageString(Chat::Cyan, ClientString::NOT_IN_YOUR_RAID, delegatee);
 		return;
 	}
 
@@ -2477,7 +2477,7 @@ void Raid::DelegateAbilityMark(Mob* delegator, const char* delegatee)
 	auto mm = rm->main_marker;
 
 	if (slot == -1 && !mm) {
-		delegator->CastToClient()->MessageString(Chat::Cyan, MAX_MAIN_RAID_MARKERS);
+		delegator->CastToClient()->MessageString(Chat::Cyan, ClientString::MAX_MAIN_RAID_MARKERS);
 		return;
 	}
 
@@ -2609,7 +2609,7 @@ void Raid::RaidMarkNPC(Mob* mob, uint32 parameter)
 		}
 	}
 		//client is not delegated the mark ability
-		c->MessageString(Chat::Cyan, NOT_DELEGATED_MARKER);
+		c->MessageString(Chat::Cyan, ClientString::NOT_DELEGATED_MARKER);
 		return;
 }
 
@@ -2638,7 +2638,7 @@ void Raid::RaidClearNPCMarks(Client* c)
 				&& marked_npcs[i].instance_id == c->GetInstanceID())
 			{
 				auto npc_name = entity_list.GetNPCByID(marked_npcs[i].entity_id)->GetCleanName();
-				RaidMessageString(nullptr, Chat::Cyan, RAID_NO_LONGER_MARKED, npc_name);
+				RaidMessageString(nullptr, Chat::Cyan, ClientString::RAID_NO_LONGER_MARKED, npc_name);
 				marked_npcs[i].entity_id = 0;
 				marked_npcs[i].zone_id = 0;
 				marked_npcs[i].instance_id = 0;
@@ -2665,7 +2665,7 @@ void Raid::RaidClearNPCMarks(Client* c)
 		UpdateXtargetMarkedNPC();
 	}
 	else {
-		c->MessageString(Chat::Cyan, NOT_DELEGATED_MARKER);
+		c->MessageString(Chat::Cyan, ClientString::NOT_DELEGATED_MARKER);
 	}
 }
 

--- a/zone/special_attacks.cpp
+++ b/zone/special_attacks.cpp
@@ -254,7 +254,7 @@ void Mob::DoSpecialAttackDamage(Mob *who, EQ::skills::SkillType skill, int32 bas
 				auto fbash = GetSpellFuriousBash(itm->Focus.Effect);
 				hate = hate * (100 + fbash) / 100;
 				if (fbash)
-					MessageString(Chat::FocusEffect, GLOWS_RED, itm->Name);
+					MessageString(Chat::FocusEffect, ClientString::GLOWS_RED, itm->Name);
 			}
 		}
 	}
@@ -722,7 +722,7 @@ void Mob::TryBackstab(Mob *other, int ReuseTime) {
 		const EQ::ItemInstance *wpn = CastToClient()->GetInv().GetItem(EQ::invslot::slotPrimary);
 
 		if (!wpn || (wpn->GetItem()->ItemType != EQ::item::ItemType1HPiercing)){
-			MessageString(Chat::Red, BACKSTAB_WEAPON);
+			MessageString(Chat::Red, ClientString::BACKSTAB_WEAPON);
 			return;
 		}
 	}
@@ -965,10 +965,10 @@ bool Client::RangedAttack(Mob* other, bool CanDoubleAttack) {
 
 	if (float dist = DistanceSquared(m_Position, other->GetPosition()); dist > range) {
 		LogCombat("Ranged attack out of range client should catch this. ([{}] > [{}]).\n", dist, range);
-		MessageString(Chat::Red,TARGET_OUT_OF_RANGE);//Client enforces range and sends the message, this is a backup just incase.
+		MessageString(Chat::Red, ClientString::TARGET_OUT_OF_RANGE);//Client enforces range and sends the message, this is a backup just incase.
 		return false;
 	} else if (dist < (RuleI(Combat, MinRangedAttackDist)*RuleI(Combat, MinRangedAttackDist))){
-		MessageString(Chat::Yellow,RANGED_TOO_CLOSE);//Client enforces range and sends the message, this is a backup just incase.
+		MessageString(Chat::Yellow, ClientString::RANGED_TOO_CLOSE);//Client enforces range and sends the message, this is a backup just incase.
 		return false;
 	}
 
@@ -1585,11 +1585,11 @@ void Client::ThrowingAttack(Mob* other, bool CanDoubleAttack) { //old was 51
 	float dist = DistanceSquared(m_Position, other->GetPosition());
 	if(dist > range) {
 		LogCombat("Throwing attack out of range client should catch this. ([{}] > [{}]).\n", dist, range);
-		MessageString(Chat::Red,TARGET_OUT_OF_RANGE);//Client enforces range and sends the message, this is a backup just incase.
+		MessageString(Chat::Red, ClientString::TARGET_OUT_OF_RANGE);//Client enforces range and sends the message, this is a backup just incase.
 		return;
 	}
 	else if(dist < (RuleI(Combat, MinRangedAttackDist)*RuleI(Combat, MinRangedAttackDist))){
-		MessageString(Chat::Yellow,RANGED_TOO_CLOSE);//Client enforces range and sends the message, this is a backup just incase.
+		MessageString(Chat::Yellow, ClientString::RANGED_TOO_CLOSE);//Client enforces range and sends the message, this is a backup just incase.
 		return;
 	}
 
@@ -1910,7 +1910,7 @@ void NPC::DoClassAttacks(Mob *target) {
 		type_of_pet != PetType::TargetLock &&
 		DistanceSquared(GetPosition(), target->GetPosition()) <= (RuleI(Pets, PetTauntRange) * RuleI(Pets, PetTauntRange))
 	) {
-		GetOwner()->MessageString(Chat::PetResponse, PET_TAUNTING);
+		GetOwner()->MessageString(Chat::PetResponse, ClientString::PET_TAUNTING);
 		Taunt(target->CastToNPC(), false);
 	}
 
@@ -2256,7 +2256,7 @@ void Mob::Taunt(NPC *who, bool always_succeed, int chance_bonus, bool from_spell
 		level_difference < 0 ||
 		who->GetSpecialAbility(SpecialAbility::TauntImmunity)
 	) {
-		MessageString(Chat::SpellFailure, FAILED_TAUNT);
+		MessageString(Chat::SpellFailure, ClientString::FAILED_TAUNT);
 		return;
 	}
 
@@ -2368,10 +2368,10 @@ void Mob::Taunt(NPC *who, bool always_succeed, int chance_bonus, bool from_spell
 		}
 
 		if (who->CanTalk()) {
-			who->SayString(SUCCESSFUL_TAUNT, GetCleanName());
+			who->SayString(ClientString::SUCCESSFUL_TAUNT, GetCleanName());
 		}
 	} else {
-		MessageString(Chat::Skills, FAILED_TAUNT);
+		MessageString(Chat::Skills, ClientString::FAILED_TAUNT);
 	}
 
 	// Modern Abilities
@@ -2425,7 +2425,7 @@ void Mob::InstillDoubt(Mob *who) {
 		success = true;
 		//is there a success message?
 	} else {
-		MessageString(Chat::LightBlue,NOT_SCARING);
+		MessageString(Chat::LightBlue, ClientString::NOT_SCARING);
 		//Idea from WR:
 		/* if (target->IsNPC() && zone->random.Int(0,99) < 10 ) {
 			entity_list.MessageClose(target, false, 50, Chat::NPCRampage, "%s lashes out in anger!",target->GetName());
@@ -2473,7 +2473,7 @@ int Mob::TryHeadShot(Mob *defender, EQ::skills::SkillType skillInUse)
 			chance += aabonuses.HeadShot[SBIndex::FINISHING_EFFECT_PROC_CHANCE] + spellbonuses.HeadShot[SBIndex::FINISHING_EFFECT_PROC_CHANCE] + itembonuses.HeadShot[SBIndex::FINISHING_EFFECT_PROC_CHANCE];
 			if (zone->random.Int(1, 1000) <= chance) {
 				entity_list.MessageCloseString(
-					this, false, 200, Chat::MeleeCrit, FATAL_BOW_SHOT,
+					this, false, 200, Chat::MeleeCrit, ClientString::FATAL_BOW_SHOT,
 					GetName());
 				return HeadShot_Dmg;
 			}
@@ -2526,7 +2526,7 @@ int Mob::TryAssassinate(Mob *defender, EQ::skills::SkillType skillInUse)
 		if (Assassinate_Dmg && Assassinate_Level && (defender->GetLevel() <= Assassinate_Level)) {
 			if (zone->random.Int(1, 1000) <= chance) {
 				entity_list.MessageCloseString(
-					this, false, 200, Chat::MeleeCrit, ASSASSINATES,
+					this, false, 200, Chat::MeleeCrit, ClientString::ASSASSINATES,
 					GetName());
 				return Assassinate_Dmg;
 			}

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -552,7 +552,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					if(zone->random.Roll(RuleI(Spells, SuccorFailChance))) { //2% Fail chance by default
 
 						if(IsClient()) {
-							CastToClient()->MessageString(Chat::SpellFailure,SUCCOR_FAIL);
+							CastToClient()->MessageString(Chat::SpellFailure, ClientString::SUCCOR_FAIL);
 						}
 						break;
 					}
@@ -752,7 +752,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 						(caster->IsNPC() && !RuleB(Spells, NPCIgnoreBaseImmunity))))))
 				{
 					if (caster)
-						caster->MessageString(Chat::SpellFailure, IMMUNE_STUN);
+						caster->MessageString(Chat::SpellFailure, ClientString::IMMUNE_STUN);
 				} else {
 					int stun_resist = itembonuses.StunResist+spellbonuses.StunResist;
 					if (IsClient() || IsBot()) {
@@ -769,7 +769,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 						Stun(effect_value);
 					} else {
 						if (IsClient())
-							MessageString(Chat::Stun, SHAKE_OFF_STUN);
+							MessageString(Chat::Stun, ClientString::SHAKE_OFF_STUN);
 
 						LogCombat("Stun Resisted. We had [{}] percent resist chance", stun_resist);
 					}
@@ -880,17 +880,17 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					{
 						uint8 bt = BodyType::Undead;
 
-						int MessageID = SENSE_UNDEAD;
+						int MessageID = ClientString::SENSE_UNDEAD;
 
 						if(effect == SpellEffect::SenseSummoned)
 						{
 							bt = BodyType::Summoned;
-							MessageID = SENSE_SUMMONED;
+							MessageID = ClientString::SENSE_SUMMONED;
 						}
 						else if(effect == SpellEffect::SenseAnimals)
 						{
 							bt = BodyType::Animal;
-							MessageID = SENSE_ANIMAL;
+							MessageID = ClientString::SENSE_ANIMAL;
 						}
 
 						Mob *ClosestMob = entity_list.GetClosestMobByBodyType(this, bt, true);
@@ -904,7 +904,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 							SentPositionPacket(0.0f, 0.0f, 0.0f, 0.0f, 0, true);
 						}
 						else
-							MessageString(Chat::Red, SENSE_NOTHING);
+							MessageString(Chat::Red, ClientString::SENSE_NOTHING);
 					}
 				}
 				break;
@@ -989,13 +989,13 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 						safe_delete(action_packet);
 					} else {
 						if (!zone->CanBind()) {
-							MessageString(Chat::SpellFailure, CANNOT_BIND);
+							MessageString(Chat::SpellFailure, ClientString::CANNOT_BIND);
 							break;
 						}
 
 						if (!zone->IsCity()) {
 							if (caster != this && !zone->IsSpecialBindLocation(GetPosition())) {
-								MessageString(Chat::SpellFailure, CANNOT_BIND);
+								MessageString(Chat::SpellFailure, ClientString::CANNOT_BIND);
 								break;
 							} else {
 								auto action_packet = new EQApplicationPacket(
@@ -1090,7 +1090,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					if(zone->random.Roll(effect_value))
 						Gate(spells[spell_id].limit_value[i] - 1);
 					else if (caster)
-						caster->MessageString(Chat::SpellFailure,GATE_FAIL);
+						caster->MessageString(Chat::SpellFailure, ClientString::GATE_FAIL);
 				}
 				break;
 			}
@@ -1102,7 +1102,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 #endif
 				if(GetSpecialAbility(SpecialAbility::DispellImmunity)){
 					if (caster) {
-						caster->MessageString(Chat::SpellFailure, SPELL_NO_EFFECT, spells[spell_id].name);
+						caster->MessageString(Chat::SpellFailure, ClientString::SPELL_NO_EFFECT, spells[spell_id].name);
 					}
 					break;
 				}
@@ -1118,7 +1118,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 #endif
 				if(GetSpecialAbility(SpecialAbility::DispellImmunity)){
 					if (caster)
-						caster->MessageString(Chat::SpellFailure, SPELL_NO_EFFECT, spells[spell_id].name);
+						caster->MessageString(Chat::SpellFailure, ClientString::SPELL_NO_EFFECT, spells[spell_id].name);
 					break;
 				}
 				/*
@@ -1149,7 +1149,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 #endif
 				if(GetSpecialAbility(SpecialAbility::DispellImmunity)){
 					if (caster)
-						caster->MessageString(Chat::SpellFailure, SPELL_NO_EFFECT, spells[spell_id].name);
+						caster->MessageString(Chat::SpellFailure, ClientString::SPELL_NO_EFFECT, spells[spell_id].name);
 					break;
 				}
 
@@ -1297,7 +1297,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 #endif
 				if(GetPet())
 				{
-					MessageString(Chat::Shout, ONLY_ONE_PET);
+					MessageString(Chat::Shout, ClientString::ONLY_ONE_PET);
 				}
 				else
 				{
@@ -1574,7 +1574,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					&& caster && (!caster->IsNPC() || (caster->IsNPC() && !RuleB(Spells, NPCIgnoreBaseImmunity)))))
 				{
 					if (caster)
-						caster->MessageString(Chat::Shout, IMMUNE_STUN);
+						caster->MessageString(Chat::Shout, ClientString::IMMUNE_STUN);
 				}
 				else
 				{
@@ -1667,7 +1667,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 
 					if (zone->random.Int(0, 99) > spells[spell_id].base_value[i]) {
 						SetFeigned(false);
-						entity_list.MessageCloseString(this, false, 200, 10, STRING_FEIGNFAILED, GetName());
+						entity_list.MessageCloseString(this, false, 200, 10, ClientString::STRING_FEIGNFAILED, GetName());
 					} else {
 						SetFeigned(true);
 					}
@@ -1685,12 +1685,12 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					if(caster == this)
 					{
 						MessageString(Chat::Spells,
-							SENTINEL_TRIG_YOU);
+							ClientString::SENTINEL_TRIG_YOU);
 					}
 					else
 					{
 						caster->MessageString(Chat::Spells,
-							SENTINEL_TRIG_OTHER, GetCleanName());
+							ClientString::SENTINEL_TRIG_OTHER, GetCleanName());
 					}
 				}
 				break;
@@ -1837,26 +1837,26 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 							Corpse *corpse = entity_list.GetCorpseByOwner(TargetClient);
 							if(corpse) {
 								if(TargetClient == CastToClient())
-									MessageString(Chat::LightBlue, SUMMONING_CORPSE, TargetClient->CastToMob()->GetCleanName());
+									MessageString(Chat::LightBlue, ClientString::SUMMONING_CORPSE, TargetClient->CastToMob()->GetCleanName());
 								else
-									MessageString(Chat::LightBlue, SUMMONING_CORPSE_OTHER, TargetClient->CastToMob()->GetCleanName());
+									MessageString(Chat::LightBlue, ClientString::SUMMONING_CORPSE_OTHER, TargetClient->CastToMob()->GetCleanName());
 
 								corpse->Summon(CastToClient(), true, true);
 							}
 							else {
 								// No corpse found in the zone
-								MessageString(Chat::LightBlue, CORPSE_CANT_SENSE);
+								MessageString(Chat::LightBlue, ClientString::CORPSE_CANT_SENSE);
 							}
 						}
 						else if (caster) {
 							char level[4];
 							ConvertArray(effect_value, level);
 							caster->MessageString(Chat::SpellFailure,
-								SPELL_LEVEL_REQ, level);
+								ClientString::SPELL_LEVEL_REQ, level);
 						}
 					}
 					else {
-						MessageString(Chat::LightBlue, TARGET_NOT_FOUND);
+						MessageString(Chat::LightBlue, ClientString::TARGET_NOT_FOUND);
 						LogError("[{}] attempted to cast spell id [{}] with spell effect SpellEffect::SummonCorpse, but could not cast target into a Client object", GetCleanName(), spell_id);
 					}
 				}
@@ -1871,7 +1871,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 						Group* group = client_target->GetGroup();
 						if (!group->IsGroupMember(caster)) {
 							if (caster != this) {
-								caster->MessageString(Chat::Red, SUMMON_ONLY_GROUP_CORPSE);
+								caster->MessageString(Chat::Red, ClientString::SUMMON_ONLY_GROUP_CORPSE);
 								break;
 							}
 						}
@@ -1881,13 +1881,13 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 							uint32 group_id = raid->GetGroup(caster->GetName());
 							if (group_id > 0 && group_id < MAX_RAID_GROUPS) {
 								if (client_target && raid->GetGroup(client_target->GetName()) != group_id) {
-									caster->MessageString(Chat::Red, SUMMON_ONLY_GROUP_CORPSE);
+									caster->MessageString(Chat::Red, ClientString::SUMMON_ONLY_GROUP_CORPSE);
 									break;
 								}
 							}
 						} else {
 							if (caster != this) {
-								caster->MessageString(Chat::Red, SUMMON_ONLY_GROUP_CORPSE);
+								caster->MessageString(Chat::Red, ClientString::SUMMON_ONLY_GROUP_CORPSE);
 								break;
 							}
 						}
@@ -1904,12 +1904,12 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 							if (caster == this) {
 								Message(Chat::Spells, "Summoning your corpses.");
 							} else {
-								caster->MessageString(Chat::Spells, SUMMONING_CORPSE_ZONE, client_target->GetCleanName());
+								caster->MessageString(Chat::Spells, ClientString::SUMMONING_CORPSE_ZONE, client_target->GetCleanName());
 							}
 							client_target->SummonAllCorpses(client_target->GetPosition());
 						}
 					} else {
-						MessageString(Chat::Spells, TARGET_NOT_FOUND);
+						MessageString(Chat::Spells, ClientString::TARGET_NOT_FOUND);
 						LogError("[{}] attempted to cast spell id [{}] with spell effect SpellEffect::SummonCorpseZone, but could not cast target into a Client object", GetCleanName(), spell_id);
 					}
 				}
@@ -2236,7 +2236,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 				if (IsClient()) {
 					if (caster->IsClient()) {
 						if (!entity_list.IsInSameGroupOrRaidGroup(caster->CastToClient(), CastToClient())) {
-							caster->MessageString(Chat::SpellFailure, TARGET_GROUP_MEMBER);
+							caster->MessageString(Chat::SpellFailure, ClientString::TARGET_GROUP_MEMBER);
 							break;
 						}
 
@@ -2255,7 +2255,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					CastToClient()->MovePC(zone->GetZoneID(), zone->GetInstanceID(), caster->GetX(),
 							       caster->GetY(), caster->GetZ(), caster->GetHeading(), 2,
 							       SummonPC);
-					MessageString(Chat::Spells, PLAYER_SUMMONED);
+					MessageString(Chat::Spells, ClientString::PLAYER_SUMMONED);
 				} else {
 					caster->Message(Chat::Red, "This spell can only be cast on players.");
 				}
@@ -2364,7 +2364,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 								break;
 							}
 						}
-						MessageString(Chat::Skills, ESCAPE);
+						MessageString(Chat::Skills, ClientString::ESCAPE);
 					} else{
 						entity_list.RemoveFromTargets(caster);
 						SetInvisible(Invisibility::Invisible);
@@ -2938,7 +2938,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 			case SpellEffect::MassGroupBuff:{
 
 				SetMGB(true);
-				MessageString(Chat::Disciplines, MGB_STRING);
+				MessageString(Chat::Disciplines, ClientString::MGB_STRING);
 				break;
 			}
 
@@ -3068,12 +3068,12 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					break;
 
 				if (IsNPC() && GetSpecialAbility(SpecialAbility::StunImmunity)) {
-					caster->MessageString(Chat::SpellFailure, IMMUNE_STUN);
+					caster->MessageString(Chat::SpellFailure, ClientString::IMMUNE_STUN);
 					break;
 				}
 
 				if (IsNPC() && GetSpecialAbility(SpecialAbility::FearImmunity)) {
-					caster->MessageString(Chat::SpellFailure, IMMUNE_FEAR);
+					caster->MessageString(Chat::SpellFailure, ClientString::IMMUNE_FEAR);
 					break;
 				}
 				int max_level = 0;
@@ -3091,7 +3091,7 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 						Stun(spells[spell_id].base_value[i]);
 				}
 				else
-					caster->MessageString(Chat::SpellFailure, FEAR_TOO_HIGH);
+					caster->MessageString(Chat::SpellFailure, ClientString::FEAR_TOO_HIGH);
 				break;
 			}
 
@@ -4124,7 +4124,7 @@ void Mob::DoBuffTic(const Buffs_Struct &buff, int slot, Mob *caster)
 		case SpellEffect::InvisVsUndead2: {
 			if (!IsBardSong(buff.spellid)) {
 				if (buff.ticsremaining <= 3 && buff.ticsremaining > 1) {
-					MessageString(Chat::Spells, INVIS_BEGIN_BREAK);
+					MessageString(Chat::Spells, ClientString::INVIS_BEGIN_BREAK);
 				}
 			}
 			break;
@@ -4643,7 +4643,7 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 		if(p->IsPet())
 			notify = p->GetOwner();
 		if(p) {
-			notify->MessageString(Chat::SpellWornOff, SPELL_WORN_OFF_OF,
+			notify->MessageString(Chat::SpellWornOff, ClientString::SPELL_WORN_OFF_OF,
 				spells[buffs[slot].spellid].name, GetCleanName());
 		}
 	}
@@ -6704,38 +6704,38 @@ int64 Mob::GetFocusEffect(focusType type, uint16 spell_id, Mob *caster, bool fro
 		if ((rand_effectiveness && UsedItem) || (realTotal != 0 && UsedItem)) {
 			// there are a crap ton more of these, I was able to verify these ones though
 			// the RNG effective ones appear to have a different message for failing to focus
-			uint32 string_id = BEGINS_TO_GLOW; // this is really just clicky message ...
+			uint32 string_id = ClientString::BEGINS_TO_GLOW; // this is really just clicky message ...
 			switch (type) {
 			case focusSpellHaste:
-				string_id = SHIMMERS_BRIEFLY;
+				string_id = ClientString::SHIMMERS_BRIEFLY;
 				break;
 			case focusManaCost: // this might be GROWS_DIM for fail
-				string_id = FLICKERS_PALE_LIGHT;
+				string_id = ClientString::FLICKERS_PALE_LIGHT;
 				break;
 			case focusSpellDuration:
-				string_id = SPARKLES;
+				string_id = ClientString::SPARKLES;
 				break;
 			case focusImprovedDamage:
 			case focusImprovedDamage2:
 				if (realTotal)
-					string_id = ALIVE_WITH_POWER;
+					string_id = ClientString::ALIVE_WITH_POWER;
 				else
-					string_id = SEEMS_DRAINED;
+					string_id = ClientString::SEEMS_DRAINED;
 				break;
 			case focusRange:
-				string_id = PULSES_WITH_LIGHT;
+				string_id = ClientString::PULSES_WITH_LIGHT;
 				break;
 			case focusSpellHateMod: // GLOWS_RED for increasing hate
-				string_id = GLOWS_BLUE;
+				string_id = ClientString::GLOWS_BLUE;
 				break;
 			case focusImprovedHeal:
 				if (realTotal)
-					string_id = FEEDS_WITH_POWER;
+					string_id = ClientString::FEEDS_WITH_POWER;
 				else
-					string_id = POWER_DRAIN_INTO;
+					string_id = ClientString::POWER_DRAIN_INTO;
 				break;
 			case focusReagentCost: // this might be GROWS_DIM for fail as well ...
-				string_id = BEGINS_TO_SHINE;
+				string_id = ClientString::BEGINS_TO_SHINE;
 				break;
 			default:
 				break;
@@ -7234,10 +7234,10 @@ bool Mob::TryDeathSave() {
 						false,
 						200,
 						Chat::MeleeCrit,
-						DIVINE_INTERVENTION,
+						ClientString::DIVINE_INTERVENTION,
 						GetCleanName());
 				} else {
-					entity_list.MessageCloseString(this, false, 200, Chat::MeleeCrit, DEATH_PACT, GetCleanName());
+					entity_list.MessageCloseString(this, false, 200, Chat::MeleeCrit, ClientString::DEATH_PACT, GetCleanName());
 				}
 
 				SendHPUpdate();
@@ -7276,10 +7276,10 @@ bool Mob::TryDeathSave() {
 							false,
 							200,
 							Chat::MeleeCrit,
-							DIVINE_INTERVENTION,
+							ClientString::DIVINE_INTERVENTION,
 							GetCleanName());
 					} else {
-						entity_list.MessageCloseString(this, false, 200, Chat::MeleeCrit, DEATH_PACT, GetCleanName());
+						entity_list.MessageCloseString(this, false, 200, Chat::MeleeCrit, ClientString::DEATH_PACT, GetCleanName());
 					}
 
 					SendHPUpdate();
@@ -9927,12 +9927,12 @@ void Client::BreakFeignDeathWhenCastOn(bool IsResisted)
 		}
 
 		if(chance && (zone->random.Roll(chance))){
-			MessageString(Chat::SpellFailure,FD_CAST_ON_NO_BREAK);
+			MessageString(Chat::SpellFailure, ClientString::FD_CAST_ON_NO_BREAK);
 			return;
 		}
 
 		SetFeigned(false);
-		MessageString(Chat::SpellFailure,FD_CAST_ON);
+		MessageString(Chat::SpellFailure, ClientString::FD_CAST_ON);
 	}
 }
 
@@ -9962,7 +9962,7 @@ bool Mob::PassCharmTargetRestriction(Mob *target) {
 	}
 
 	if (target->IsClient() && IsClient()) {
-		MessageString(Chat::Red, CANNOT_AFFECT_PC);
+		MessageString(Chat::Red, ClientString::CANNOT_AFFECT_PC);
 		LogSpells("Spell casting canceled: Can not cast charm on a client.");
 		return false;
 	}
@@ -9971,12 +9971,12 @@ bool Mob::PassCharmTargetRestriction(Mob *target) {
 		return false;
 	}
 	else if (GetPet() && IsClient()) {
-		MessageString(Chat::Red, ONLY_ONE_PET);
+		MessageString(Chat::Red, ClientString::ONLY_ONE_PET);
 		LogSpells("Spell casting canceled: Can not cast charm if you have a pet.");
 		return false;
 	}
 	else if (target->GetOwner()) {
-		MessageString(Chat::Red, CANNOT_CHARM);
+		MessageString(Chat::Red, ClientString::CANNOT_CHARM);
 		LogSpells("Spell casting canceled: Can not cast charm on a pet.");
 		return false;
 	}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -235,7 +235,7 @@ bool Mob::CastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 			GetTarget()->GetMana() == 0
 		);
 		if (melee_block || caster_block) {
-			InterruptSpell(TARGET_NO_MANA, 0x121, spell_id);
+			InterruptSpell(ClientString::TARGET_NO_MANA, 0x121, spell_id);
 			return false;
 		}
 	}
@@ -332,7 +332,7 @@ bool Mob::DoCastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 	// note that CheckFizzle itself doesn't let NPCs fizzle,
 	// but this code allows for it.
 	if (slot < CastingSlot::MaxGems && !CheckFizzle(spell_id)) {
-		int fizzle_msg = IsBardSong(spell_id) ? MISS_NOTE : SPELL_FIZZLE;
+		int fizzle_msg = IsBardSong(spell_id) ? ClientString::MISS_NOTE : ClientString::SPELL_FIZZLE;
 
 		uint32 use_mana = ((spells[spell_id].mana) / 4);
 		LogSpells("Spell casting canceled: fizzled. [{}] mana has been consumed", use_mana);
@@ -352,7 +352,7 @@ bool Mob::DoCastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 			RuleI(Range, SpellMessages),
 			Chat::SpellFailure,
 			(IsClient() ? FilterPCSpells : FilterNPCSpells),
-			(fizzle_msg == MISS_NOTE ? MISSED_NOTE_OTHER : SPELL_FIZZLE_OTHER),
+			(fizzle_msg == ClientString::MISS_NOTE ? ClientString::MISSED_NOTE_OTHER : ClientString::SPELL_FIZZLE_OTHER),
 			0,
 			/*
 				MessageFormat: You miss a note, bringing your song to a close! (if missed note)
@@ -409,7 +409,7 @@ bool Mob::DoCastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 		LogSpells("Spell Error: no target. spell=[{}]", spell_id);
 		if(IsClient()) {
 			//clients produce messages... npcs should not for this case
-			MessageString(Chat::Red, SPELL_NEED_TAR);
+			MessageString(Chat::Red, ClientString::SPELL_NEED_TAR);
 			InterruptSpell();
 		} else {
 			InterruptSpell(0, 0, 0);	//the 0 args should cause no messages
@@ -487,7 +487,7 @@ bool Mob::DoCastSpell(uint16 spell_id, uint16 target_id, CastingSlot slot,
 	if (RuleB(Spells, UseItemCastMessage) && IsClient() && slot == CastingSlot::Item && item_slot != 0xFFFFFFFF) {
 		auto item = CastToClient()->GetInv().GetItem(item_slot);
 		if (item && item->GetItem()) {
-			MessageString(Chat::FocusEffect, BEGINS_TO_GLOW, item->GetItem()->Name);
+			MessageString(Chat::FocusEffect, ClientString::BEGINS_TO_GLOW, item->GetItem()->Name);
 		}
 	}
 
@@ -499,7 +499,7 @@ void Mob::DoSpellInterrupt(uint16 spell_id, int32 mana_cost, int my_curmana) {
 	LogSpells("Not enough mana spell [{}] curmana [{}] cost [{}]\n", spell_id, my_curmana, mana_cost);
 	if (IsClient()) {
 		//clients produce messages... npcs should not for this case
-		MessageString(Chat::Red, INSUFFICIENT_MANA);
+		MessageString(Chat::Red, ClientString::INSUFFICIENT_MANA);
 		InterruptSpell();
 	} else {
 		InterruptSpell(0, 0, 0);	//the 0 args should cause no messages
@@ -561,7 +561,7 @@ bool Mob::DoCastingChecksOnCaster(int32 spell_id, CastingSlot slot) {
 		Can not cast if spell
 	*/
 	if ((IsSilenced() && !IsDiscipline(spell_id))) {
-		MessageString(Chat::Red, SILENCED_STRING);
+		MessageString(Chat::Red, ClientString::SILENCED_STRING);
 		LogSpells("Spell casting canceled [{}] : can not cast spell when silenced.", spell_id);
 		return false;
 	}
@@ -569,7 +569,7 @@ bool Mob::DoCastingChecksOnCaster(int32 spell_id, CastingSlot slot) {
 		Can not cast if discipline.
 	*/
 	if (IsAmnesiad() && IsDiscipline(spell_id)) {
-		MessageString(Chat::Red, MELEE_SILENCE);
+		MessageString(Chat::Red, ClientString::MELEE_SILENCE);
 		LogSpells("Spell casting canceled [{}] : can not use discipline with amnesia.", spell_id);
 		return false;
 	}
@@ -607,10 +607,10 @@ bool Mob::DoCastingChecksOnCaster(int32 spell_id, CastingSlot slot) {
 		if (IsBeneficialSpell(spell_id)) {
 			if ((IsNPC() && IsEngaged()) || (IsClient() && CastToClient()->GetAggroCount())) {
 				if (IsDiscipline(spell_id)) {
-					MessageString(Chat::Red, NO_ABILITY_IN_COMBAT);
+					MessageString(Chat::Red, ClientString::NO_ABILITY_IN_COMBAT);
 				}
 				else {
-					MessageString(Chat::Red, NO_CAST_IN_COMBAT);
+					MessageString(Chat::Red, ClientString::NO_CAST_IN_COMBAT);
 				}
 				LogSpells("Spell casting canceled [{}] : can not use spell while in combat.", spell_id);
 				return false;
@@ -621,10 +621,10 @@ bool Mob::DoCastingChecksOnCaster(int32 spell_id, CastingSlot slot) {
 		if (IsBeneficialSpell(spell_id)) {
 			if ((IsNPC() && !IsEngaged()) || (IsClient() && !CastToClient()->GetAggroCount())) {
 				if (IsDiscipline(spell_id)) {
-					MessageString(Chat::Red, NO_ABILITY_OUT_OF_COMBAT);
+					MessageString(Chat::Red, ClientString::NO_ABILITY_OUT_OF_COMBAT);
 				}
 				else {
-					MessageString(Chat::Red, NO_CAST_OUT_OF_COMBAT);
+					MessageString(Chat::Red, ClientString::NO_CAST_OUT_OF_COMBAT);
 				}
 				LogSpells("Spell casting canceled [{}] : can not use spell while out of combat.", spell_id);
 				return false;
@@ -637,7 +637,7 @@ bool Mob::DoCastingChecksOnCaster(int32 spell_id, CastingSlot slot) {
 	if (IsClient() && !IsDiscipline(spell_id)) {
 		int chance = CastToClient()->GetFocusEffect(focusFcMute, spell_id);//client only
 		if (chance && zone->random.Roll(chance)) {
-			MessageString(Chat::Red, SILENCED_STRING);
+			MessageString(Chat::Red, ClientString::SILENCED_STRING);
 			LogSpells("Spell casting canceled: can not cast spell when silenced from SPA 357 FcMute.");
 			return(false);
 		}
@@ -717,7 +717,7 @@ bool Mob::DoCastingChecksZoneRestrictions(bool check_on_casting, int32 spell_id)
 			[&]() { return !bypass_casting_restrictions && spells[spell_id].time_of_day == SpellTimeRestrictions::Day && !zone->zone_time.IsDayTime(); },
 			[&]() {
 				if (gm_bypass_message("spell daytime restrictions")) { return true; }
-				MessageString(Chat::Red, CAST_DAYTIME);
+				MessageString(Chat::Red, ClientString::CAST_DAYTIME);
 				return false;
 			}
 		},
@@ -726,7 +726,7 @@ bool Mob::DoCastingChecksZoneRestrictions(bool check_on_casting, int32 spell_id)
 			[&]() { return !bypass_casting_restrictions && spells[spell_id].time_of_day == SpellTimeRestrictions::Night && !zone->zone_time.IsNightTime(); },
 			[&]() {
 				if (gm_bypass_message("spell nighttime restrictions")) return true;
-				MessageString(Chat::Red, CAST_NIGHTTIME);
+				MessageString(Chat::Red, ClientString::CAST_NIGHTTIME);
 				return false;
 			}
 		},
@@ -735,7 +735,7 @@ bool Mob::DoCastingChecksZoneRestrictions(bool check_on_casting, int32 spell_id)
 			[&]() { return check_on_casting && !bypass_casting_restrictions && spells[spell_id].zone_type == 1 && !zone->CanCastOutdoor(); },
 			[&]() {
 				if (gm_bypass_message("zone outdoor restrictions")) return true;
-				MessageString(Chat::Red, CAST_OUTDOORS);
+				MessageString(Chat::Red, ClientString::CAST_OUTDOORS);
 				return false;
 			}
 		}
@@ -812,7 +812,7 @@ bool Mob::DoCastingChecksOnTarget(bool check_on_casting, int32 spell_id, Mob *sp
 		if (IsDetrimentalSpell(spell_id)) {
 			if (((spell_target->IsNPC() && spell_target->IsEngaged()) ||
 				(spell_target->IsClient() && spell_target->CastToClient()->GetAggroCount()))) {
-				MessageString(Chat::Red, SPELL_NO_EFFECT); // Unsure correct string
+				MessageString(Chat::Red, ClientString::SPELL_NO_EFFECT); // Unsure correct string
 				LogSpells("Spell casting canceled [{}] : can not use spell while your target is in combat.", spell_id);
 				return false;
 			}
@@ -822,7 +822,7 @@ bool Mob::DoCastingChecksOnTarget(bool check_on_casting, int32 spell_id, Mob *sp
 		if (IsDetrimentalSpell(spell_id)) {
 			if (((spell_target->IsNPC() && !spell_target->IsEngaged()) ||
 				(spell_target->IsClient() && !spell_target->CastToClient()->GetAggroCount()))) {
-				MessageString(Chat::Red, SPELL_NO_EFFECT); // Unsure correct string
+				MessageString(Chat::Red, ClientString::SPELL_NO_EFFECT); // Unsure correct string
 				LogSpells("Spell casting canceled [{}] : can not use spell while your target is out of combat.", spell_id);
 				return false;
 			}
@@ -868,7 +868,7 @@ bool Mob::DoCastingChecksOnTarget(bool check_on_casting, int32 spell_id, Mob *sp
 	*/
 	if (this == spell_target && IsLifetapSpell(spell_id)) {
 		LogSpells("You cannot lifetap yourself");
-		MessageString(Chat::SpellFailure, CANT_DRAIN_SELF);
+		MessageString(Chat::SpellFailure, ClientString::CANT_DRAIN_SELF);
 		return false;
 	}
 	/*
@@ -876,14 +876,14 @@ bool Mob::DoCastingChecksOnTarget(bool check_on_casting, int32 spell_id, Mob *sp
 	*/
 	if (this == spell_target && IsSacrificeSpell(spell_id)) {
 		LogSpells("You cannot sacrifice yourself");
-		MessageString(Chat::SpellFailure, CANNOT_SAC_SELF);
+		MessageString(Chat::SpellFailure, ClientString::CANNOT_SAC_SELF);
 		return false;
 	}
 	/*
 		Max level of target for harmony to take hold
 	*/
 	if (IsClient() && IsHarmonySpell(spell_id) && !HarmonySpellLevelCheck(spell_id, spell_target)) {
-		MessageString(Chat::SpellFailure, SPELL_NO_EFFECT);
+		MessageString(Chat::SpellFailure, ClientString::SPELL_NO_EFFECT);
 		LogSpells("Spell casting canceled [{}] : can not use harmony on this target.", spell_id);
 		return false;
 	}
@@ -926,7 +926,7 @@ bool Mob::DoCastingChecksOnTarget(bool check_on_casting, int32 spell_id, Mob *sp
 				}
 
 				if (cast_failed) {
-					MessageString(Chat::Red, TARGET_GROUP_MEMBER);
+					MessageString(Chat::Red, ClientString::TARGET_GROUP_MEMBER);
 					return false;
 				}
 			}
@@ -1007,7 +1007,7 @@ void Client::CheckSongSkillIncrease(uint16 spell_id){
 			if (GetRawSkill(EQ::skills::SkillPercussionInstruments) > 0)	// no skill increases if not trained in the instrument
 				CheckIncreaseSkill(EQ::skills::SkillPercussionInstruments, nullptr, -15);
 			else
-				MessageString(Chat::Red,NO_INSTRUMENT_SKILL);	// tell the client that they need instrument training
+				MessageString(Chat::Red, ClientString::NO_INSTRUMENT_SKILL);	// tell the client that they need instrument training
 		}
 		else
 			CheckIncreaseSkill(EQ::skills::SkillSinging, nullptr, -15);
@@ -1017,7 +1017,7 @@ void Client::CheckSongSkillIncrease(uint16 spell_id){
 			if (GetRawSkill(EQ::skills::SkillStringedInstruments) > 0)
 				CheckIncreaseSkill(EQ::skills::SkillStringedInstruments, nullptr, -15);
 			else
-				MessageString(Chat::Red,NO_INSTRUMENT_SKILL);
+				MessageString(Chat::Red, ClientString::NO_INSTRUMENT_SKILL);
 		}
 		else
 			CheckIncreaseSkill(EQ::skills::SkillSinging, nullptr, -15);
@@ -1027,7 +1027,7 @@ void Client::CheckSongSkillIncrease(uint16 spell_id){
 			if (GetRawSkill(EQ::skills::SkillWindInstruments) > 0)
 				CheckIncreaseSkill(EQ::skills::SkillWindInstruments, nullptr, -15);
 			else
-				MessageString(Chat::Red,NO_INSTRUMENT_SKILL);
+				MessageString(Chat::Red, ClientString::NO_INSTRUMENT_SKILL);
 		}
 		else
 			CheckIncreaseSkill(EQ::skills::SkillSinging, nullptr, -15);
@@ -1037,7 +1037,7 @@ void Client::CheckSongSkillIncrease(uint16 spell_id){
 			if (GetRawSkill(EQ::skills::SkillBrassInstruments) > 0)
 				CheckIncreaseSkill(EQ::skills::SkillBrassInstruments, nullptr, -15);
 			else
-				MessageString(Chat::Red,NO_INSTRUMENT_SKILL);
+				MessageString(Chat::Red, ClientString::NO_INSTRUMENT_SKILL);
 		}
 		else
 			CheckIncreaseSkill(EQ::skills::SkillSinging, nullptr, -15);
@@ -1290,7 +1290,7 @@ void Mob::InterruptSpell(uint16 message, uint16 color, uint16 spellid)
 	}
 
 	if(casting_spell_aa_id && IsClient()) { //Rest AA Timer on failed cast
-		CastToClient()->MessageString(Chat::SpellFailure, ABILITY_FAILED);
+		CastToClient()->MessageString(Chat::SpellFailure, ClientString::ABILITY_FAILED);
 		CastToClient()->ResetAlternateAdvancementTimer(casting_spell_aa_id);
 	}
 
@@ -1310,10 +1310,10 @@ void Mob::InterruptSpell(uint16 message, uint16 color, uint16 spellid)
 	}
 
 	if(!message)
-		message = IsBardSong(spellid) ? SONG_ENDS_ABRUPTLY : INTERRUPT_SPELL;
+		message = IsBardSong(spellid) ? ClientString::SONG_ENDS_ABRUPTLY : ClientString::INTERRUPT_SPELL;
 
 	// clients need some packets
-	if (IsClient() && message != SONG_ENDS)
+	if (IsClient() && message != ClientString::SONG_ENDS)
 	{
 		// the interrupt message
 		outapp = new EQApplicationPacket(OP_InterruptCast, sizeof(InterruptCast_Struct));
@@ -1332,20 +1332,20 @@ void Mob::InterruptSpell(uint16 message, uint16 color, uint16 spellid)
 	// first figure out what message others should get
 	switch(message)
 	{
-		case SONG_ENDS:
-			message_other = SONG_ENDS_OTHER;
+		case ClientString::SONG_ENDS:
+			message_other = ClientString::SONG_ENDS_OTHER;
 			break;
-		case SONG_ENDS_ABRUPTLY:
-			message_other = SONG_ENDS_ABRUPTLY_OTHER;
+		case ClientString::SONG_ENDS_ABRUPTLY:
+			message_other = ClientString::SONG_ENDS_ABRUPTLY_OTHER;
 			break;
-		case MISS_NOTE:
-			message_other = MISSED_NOTE_OTHER;
+		case ClientString::MISS_NOTE:
+			message_other = ClientString::MISSED_NOTE_OTHER;
 			break;
-		case SPELL_FIZZLE:
-			message_other = SPELL_FIZZLE_OTHER;
+		case ClientString::SPELL_FIZZLE:
+			message_other = ClientString::SPELL_FIZZLE_OTHER;
 			break;
 		default:
-			message_other = INTERRUPT_SPELL_OTHER;
+			message_other = ClientString::INTERRUPT_SPELL_OTHER;
 	}
 
 	// this is the actual message, it works the same as a formatted message
@@ -1370,7 +1370,7 @@ void Mob::StopCasting()
 	if (IsClient()) {
 		auto c = CastToClient();
 		if (casting_spell_aa_id) { //Rest AA Timer on failed cast
-			c->MessageString(Chat::SpellFailure, ABILITY_FAILED);
+			c->MessageString(Chat::SpellFailure, ClientString::ABILITY_FAILED);
 			c->ResetAlternateAdvancementTimer(casting_spell_aa_id);
 		}
 
@@ -1431,7 +1431,7 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 	if(IsClient() && slot != CastingSlot::Item && slot != CastingSlot::PotionBelt && spells[spell_id].recast_time > 1000) { // 10 is item
 		if(!CastToClient()->GetPTimers().Expired(&database, pTimerSpellStart + spell_id, false)) {
 			//should we issue a message or send them a spell gem packet?
-			MessageString(Chat::Red, SPELL_RECAST);
+			MessageString(Chat::Red, ClientString::SPELL_RECAST);
 			LogSpells("Casting of [{}] canceled: spell reuse timer not expired", spell_id);
 			StopCasting();
 			return;
@@ -1447,7 +1447,7 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 		IsFromItem = true;
 		item  = CastToClient()->GetInv().GetItem(inventory_slot); //checked for in reagents and charges.
 		if (CastToClient()->HasItemRecastTimer(spell_id, inventory_slot)) {
-			MessageString(Chat::Red, SPELL_RECAST);
+			MessageString(Chat::Red, ClientString::SPELL_RECAST);
 			LogSpells("Casting of [{}] canceled: item or augment spell reuse timer not expired", spell_id);
 			StopCasting();
 			return;
@@ -1471,7 +1471,7 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 	if (casting_spell_id != spell_id)
 	{
 		LogSpells("Casting of [{}] canceled: already casting", spell_id);
-		MessageString(Chat::Red,ALREADY_CASTING);
+		MessageString(Chat::Red, ClientString::ALREADY_CASTING);
 		InterruptSpell();
 		return;
 	}
@@ -1572,13 +1572,13 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 			}
 			// if we got here, we regained concentration
 			regain_conc = true;
-			MessageString(Chat::Spells, REGAIN_AND_CONTINUE);
+			MessageString(Chat::Spells, ClientString::REGAIN_AND_CONTINUE);
 			entity_list.MessageCloseString(
 				this,
 				true,
 				RuleI(Range, SpellMessages),
 				Chat::Spells,
-				OTHER_REGAIN_CAST,
+				ClientString::OTHER_REGAIN_CAST,
 				GetCleanName());
 		}
 	}
@@ -1621,7 +1621,7 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 						case INSTRUMENT_HAND_DRUM:
 							if(itembonuses.percussionMod == 0) {			// check for the appropriate instrument type
 								HasInstrument = false;
-								c->MessageString(Chat::Red, SONG_NEEDS_DRUM);	// send an error message if missing
+								c->MessageString(Chat::Red, ClientString::SONG_NEEDS_DRUM);	// send an error message if missing
 							}
 							break;
 
@@ -1629,7 +1629,7 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 						case INSTRUMENT_WOODEN_FLUTE:
 							if(itembonuses.windMod == 0) {
 								HasInstrument = false;
-								c->MessageString(Chat::Red, SONG_NEEDS_WIND);
+								c->MessageString(Chat::Red, ClientString::SONG_NEEDS_WIND);
 							}
 							break;
 
@@ -1637,7 +1637,7 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 						case INSTRUMENT_LUTE:
 							if(itembonuses.stringedMod == 0) {
 								HasInstrument = false;
-								c->MessageString(Chat::Red, SONG_NEEDS_STRINGS);
+								c->MessageString(Chat::Red, ClientString::SONG_NEEDS_STRINGS);
 							}
 							break;
 
@@ -1645,7 +1645,7 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 						case INSTRUMENT_HORN:
 							if(itembonuses.brassMod == 0) {
 								HasInstrument = false;
-								c->MessageString(Chat::Red, SONG_NEEDS_BRASS);
+								c->MessageString(Chat::Red, ClientString::SONG_NEEDS_BRASS);
 							}
 							break;
 
@@ -1677,13 +1677,13 @@ void Mob::CastedSpellFinished(uint16 spell_id, uint32 target_id, CastingSlot slo
 					{
 						if (!missingreags)
 						{
-							c->MessageString(Chat::Red, MISSING_SPELL_COMP);
+							c->MessageString(Chat::Red, ClientString::MISSING_SPELL_COMP);
 							missingreags=true;
 						}
 
 						const EQ::ItemData *item = database.GetItem(component);
 						if(item) {
-							c->MessageString(Chat::Red, MISSING_SPELL_COMP_ITEM, item->Name);
+							c->MessageString(Chat::Red, ClientString::MISSING_SPELL_COMP_ITEM, item->Name);
 							LogSpells("Spell [{}]: Canceled. Missing required reagent [{}] ([{}])", spell_id, item->Name, component);
 						}
 						else {
@@ -1938,7 +1938,7 @@ bool Mob::DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_ce
 			if (!spell_target)
 			{
 				LogSpells("Spell [{}] canceled: invalid target (normal)", spell_id);
-				MessageString(Chat::Red, SPELL_NEED_TAR);
+				MessageString(Chat::Red, ClientString::SPELL_NEED_TAR);
 				return false;	// can't cast these unless we have a target
 			}
 			CastAction = SingleTarget;
@@ -1957,9 +1957,9 @@ bool Mob::DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_ce
 				//invalid target
 				LogSpells("Spell [{}] canceled: invalid target of body type [{}] (undead)", spell_id, mob_body);
 				if(!spell_target)
-					MessageString(Chat::Red,SPELL_NEED_TAR);
+					MessageString(Chat::Red, ClientString::SPELL_NEED_TAR);
 				else
-					MessageString(Chat::Red,CANNOT_AFFECT_NPC);
+					MessageString(Chat::Red, ClientString::CANNOT_AFFECT_NPC);
 				return false;
 			}
 			CastAction = SingleTarget;
@@ -1971,7 +1971,7 @@ bool Mob::DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_ce
 			{
 				//invalid target
 				LogSpells("Spell [{}] canceled: invalid target of body type [{}] (summoned)", spell_id, mob_body);
-				MessageString(Chat::Red,SPELL_NEED_TAR);
+				MessageString(Chat::Red, ClientString::SPELL_NEED_TAR);
 				return false;
 			}
 			CastAction = SingleTarget;
@@ -1986,7 +1986,7 @@ bool Mob::DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_ce
 				LogSpells("Spell [{}] canceled: invalid target of body type [{}] (summoned pet)",
 							spell_id, mob_body);
 
-				MessageString(Chat::Red, SPELL_NEED_TAR);
+				MessageString(Chat::Red, ClientString::SPELL_NEED_TAR);
 
 				return false;
 			}
@@ -2010,9 +2010,9 @@ bool Mob::DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_ce
 				//invalid target
 				LogSpells("Spell [{}] canceled: invalid target of body type [{}] (want body Type [{}])", spell_id, mob_body, target_bt);
 				if(!spell_target)
-					MessageString(Chat::Red,SPELL_NEED_TAR);
+					MessageString(Chat::Red, ClientString::SPELL_NEED_TAR);
 				else
-					MessageString(Chat::Red,CANNOT_AFFECT_NPC);
+					MessageString(Chat::Red, ClientString::CANNOT_AFFECT_NPC);
 				return false;
 			}
 			CastAction = SingleTarget;
@@ -2027,7 +2027,7 @@ bool Mob::DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_ce
 				if(!spell_target)
 				{
 					LogSpells("Spell [{}] canceled: invalid target (ldon object)", spell_id);
-					MessageString(Chat::Red,SPELL_NEED_TAR);
+					MessageString(Chat::Red, ClientString::SPELL_NEED_TAR);
 					return false;
 				}
 				else
@@ -2035,14 +2035,14 @@ bool Mob::DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_ce
 					if(!spell_target->IsNPC())
 					{
 						LogSpells("Spell [{}] canceled: invalid target (normal)", spell_id);
-						MessageString(Chat::Red,SPELL_NEED_TAR);
+						MessageString(Chat::Red, ClientString::SPELL_NEED_TAR);
 						return false;
 					}
 
 					if(spell_target->GetClass() != Class::LDoNTreasure)
 					{
 						LogSpells("Spell [{}] canceled: invalid target (normal)", spell_id);
-						MessageString(Chat::Red,SPELL_NEED_TAR);
+						MessageString(Chat::Red, ClientString::SPELL_NEED_TAR);
 						return false;
 					}
 				}
@@ -2051,7 +2051,7 @@ bool Mob::DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_ce
 			if(!spell_target)
 			{
 				LogSpells("Spell [{}] canceled: invalid target (normal)", spell_id);
-				MessageString(Chat::Red,SPELL_NEED_TAR);
+				MessageString(Chat::Red, ClientString::SPELL_NEED_TAR);
 				return false;	// can't cast these unless we have a target
 			}
 			CastAction = SingleTarget;
@@ -2063,10 +2063,10 @@ bool Mob::DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_ce
 			if(!spell_target || !spell_target->IsPlayerCorpse())
 			{
 				LogSpells("Spell [{}] canceled: invalid target (corpse)", spell_id);
-				uint32 message = ONLY_ON_CORPSES;
-				if(!spell_target) message = SPELL_NEED_TAR;
-				else if(!spell_target->IsCorpse()) message = ONLY_ON_CORPSES;
-				else if(!spell_target->IsPlayerCorpse()) message = CORPSE_NOT_VALID;
+				uint32 message = ClientString::ONLY_ON_CORPSES;
+				if(!spell_target) message = ClientString::SPELL_NEED_TAR;
+				else if(!spell_target->IsCorpse()) message = ClientString::ONLY_ON_CORPSES;
+				else if(!spell_target->IsPlayerCorpse()) message = ClientString::CORPSE_NOT_VALID;
 				MessageString(Chat::Red, message);
 				return false;
 			}
@@ -2086,7 +2086,7 @@ bool Mob::DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_ce
 
 			if (!spell_target) {
 				LogSpells("Spell [{}] canceled: invalid target (no pet)", spell_id);
-				MessageString(Chat::Red, NO_PET);
+				MessageString(Chat::Red, ClientString::NO_PET);
 				return false; // Can't cast these unless we have a target
 			}
 
@@ -2158,7 +2158,7 @@ bool Mob::DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_ce
 			if(!spell_target)
 			{
 				LogSpells("Spell [{}] canceled: invalid target (AOE)", spell_id);
-				MessageString(Chat::Red,SPELL_NEED_TAR);
+				MessageString(Chat::Red, ClientString::SPELL_NEED_TAR);
 				return false;
 			}
 			ae_center = spell_target;
@@ -2190,7 +2190,7 @@ bool Mob::DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_ce
 			}
 
 			if (spell_target && spell_target->IsPet() && spells[spell_id].target_type == ST_GroupNoPets) {
-				MessageString(Chat::Red, NO_CAST_ON_PET);
+				MessageString(Chat::Red, ClientString::NO_CAST_ON_PET);
 				return false;
 			}
 
@@ -2202,7 +2202,7 @@ bool Mob::DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_ce
 			if(!spell_target)
 			{
 				LogSpells("Spell [{}] canceled: invalid target (Group Required: Single Target)", spell_id);
-				MessageString(Chat::Red,SPELL_NEED_TAR);
+				MessageString(Chat::Red, ClientString::SPELL_NEED_TAR);
 				return false;
 			}
 
@@ -2316,14 +2316,14 @@ bool Mob::DetermineSpellTargets(uint16 spell_id, Mob *&spell_target, Mob *&ae_ce
 					if(group_id_caster == 0 || group_id_target == 0)
 					{
 						LogSpells("Spell [{}] canceled: Attempted to cast a Single Target Group spell on a ungrouped member", spell_id);
-						MessageString(Chat::Red, TARGET_GROUP_MEMBER);
+						MessageString(Chat::Red, ClientString::TARGET_GROUP_MEMBER);
 						return false;
 					}
 
 					if(group_id_caster != group_id_target)
 					{
 						LogSpells("Spell [{}] canceled: Attempted to cast a Single Target Group spell on a ungrouped member", spell_id);
-						MessageString(Chat::Red, TARGET_GROUP_MEMBER);
+						MessageString(Chat::Red, ClientString::TARGET_GROUP_MEMBER);
 						return false;
 					}
 
@@ -2508,7 +2508,7 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, CastingSlot slot, in
 	if (!spells[spell_id].npc_no_los && spell_target && IsDetrimentalSpell(spell_id) && (!CheckLosFN(spell_target) || !CheckWaterLoS(spell_target)) && !IsHarmonySpell(spell_id) && spells[spell_id].target_type != ST_TargetOptional)
 	{
 		LogSpells("Spell [{}]: cannot see target [{}]", spell_id, spell_target->GetName());
-		MessageString(Chat::Red,CANT_SEE_TARGET);
+		MessageString(Chat::Red, ClientString::CANT_SEE_TARGET);
 		return false;
 	}
 
@@ -2535,13 +2535,13 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, CastingSlot slot, in
 		if(dist2 > range2) {
 			//target is out of range.
 			LogSpells("Spell [{}]: Spell target is out of range (squared: [{}] > [{}])", spell_id, dist2, range2);
-			MessageString(Chat::Red, TARGET_OUT_OF_RANGE);
+			MessageString(Chat::Red, ClientString::TARGET_OUT_OF_RANGE);
 			return(false);
 		}
 		else if (dist2 < min_range2){
 			//target is too close range.
 			LogSpells("Spell [{}]: Spell target is too close (squared: [{}] < [{}])", spell_id, dist2, min_range2);
-			MessageString(Chat::Red, TARGET_TOO_CLOSE);
+			MessageString(Chat::Red, ClientString::TARGET_TOO_CLOSE);
 			return(false);
 		}
 
@@ -2556,13 +2556,13 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, CastingSlot slot, in
 		if(dist2 > range2) {
 			//target is out of range.
 			LogSpells("Spell [{}]: Spell target is out of range (squared: [{}] > [{}])", spell_id, dist2, range2);
-			MessageString(Chat::Red, TARGET_OUT_OF_RANGE);
+			MessageString(Chat::Red, ClientString::TARGET_OUT_OF_RANGE);
 			return(false);
 		}
 		else if (dist2 < min_range2){
 			//target is too close range.
 			LogSpells("Spell [{}]: Spell target is too close (squared: [{}] < [{}])", spell_id, dist2, min_range2);
-			MessageString(Chat::Red, TARGET_TOO_CLOSE);
+			MessageString(Chat::Red, ClientString::TARGET_TOO_CLOSE);
 			return(false);
 		}
 
@@ -3112,7 +3112,7 @@ int Mob::CheckStackConflict(uint16 spellid1, int caster_level1, uint16 spellid2,
 	if (spellid1 == spellid2 ) {
 
 		if (spellid1 == SPELL_EYE_OF_ZOMM && spellid2 == SPELL_EYE_OF_ZOMM) {//only the original Eye of Zomm spell will not take hold if affect is already on you, other versions client fades the buff as soon as cast.
-			MessageString(Chat::Red, SPELL_NO_HOLD);
+			MessageString(Chat::Red, ClientString::SPELL_NO_HOLD);
 			return -1;
 		}
 
@@ -3182,7 +3182,7 @@ int Mob::CheckStackConflict(uint16 spellid1, int caster_level1, uint16 spellid2,
 
 			if (spellbonuses.Screech == 1) {
 				if (effect2 == SpellEffect::Screech && sp2.base_value[i] == -1) {
-					MessageString(Chat::SpellFailure, SCREECH_BUFF_BLOCK, sp2.name);
+					MessageString(Chat::SpellFailure, ClientString::SCREECH_BUFF_BLOCK, sp2.name);
 					return -1;
 				}
 			}
@@ -3497,7 +3497,7 @@ bool Mob::CheckSpellLevelRestriction(Mob *caster, uint16 spell_id)
 	if (!can_cast) {
 		LogSpells("Spell [{}] failed: recipient did not meet the level restrictions", spell_id);
 		if (!IsBardSong(spell_id)) {
-			caster->MessageString(Chat::SpellFailure, SPELL_TOO_POWERFUL);
+			caster->MessageString(Chat::SpellFailure, ClientString::SPELL_TOO_POWERFUL);
 		}
 	}
 
@@ -3932,7 +3932,7 @@ bool Mob::SpellOnTarget(
 		!IsEffectInSpell(spell_id, SpellEffect::BindSight)
 	) {
 		if (!IsClient() || !CastToClient()->GetGM()) {
-			MessageString(Chat::SpellFailure, SPELL_NO_HOLD);
+			MessageString(Chat::SpellFailure, ClientString::SPELL_NO_HOLD);
 			return false;
 		}
 	}
@@ -4153,7 +4153,7 @@ bool Mob::SpellOnTarget(
 	if (!RuleB(Spells, AllowDoubleInvis) && !IsActiveBardSong(spell_id)) {
 		if (IsEffectInSpell(spell_id, SpellEffect::Invisibility)) {
 			if (spelltar->invisible) {
-				spelltar->MessageString(Chat::SpellFailure, ALREADY_INVIS, GetCleanName());
+				spelltar->MessageString(Chat::SpellFailure, ClientString::ALREADY_INVIS, GetCleanName());
 				safe_delete(action_packet);
 				return false;
 			}
@@ -4161,7 +4161,7 @@ bool Mob::SpellOnTarget(
 
 		if (IsEffectInSpell(spell_id, SpellEffect::InvisVsUndead)) {
 			if (spelltar->invisible_undead) {
-				spelltar->MessageString(Chat::SpellFailure, ALREADY_INVIS, GetCleanName());
+				spelltar->MessageString(Chat::SpellFailure, ClientString::ALREADY_INVIS, GetCleanName());
 				safe_delete(action_packet);
 				return false;
 			}
@@ -4169,7 +4169,7 @@ bool Mob::SpellOnTarget(
 
 		if (IsEffectInSpell(spell_id, SpellEffect::InvisVsAnimals)) {
 			if (spelltar->invisible_animals) {
-				spelltar->MessageString(Chat::SpellFailure, ALREADY_INVIS, GetCleanName());
+				spelltar->MessageString(Chat::SpellFailure, ClientString::ALREADY_INVIS, GetCleanName());
 				safe_delete(action_packet);
 				return false;
 			}
@@ -4267,7 +4267,7 @@ bool Mob::SpellOnTarget(
 							spelltar->GetName(),
 							IsBeneficialAllowed(spelltar)
 						);
-						MessageString(Chat::SpellFailure, SPELL_NO_HOLD);
+						MessageString(Chat::SpellFailure, ClientString::SPELL_NO_HOLD);
 					}
 					safe_delete(action_packet);
 					return false;
@@ -4284,7 +4284,7 @@ bool Mob::SpellOnTarget(
 				GetName(),
 				spelltar->GetName()
 			);
-			spelltar->MessageString(Chat::SpellFailure, YOU_ARE_PROTECTED, GetCleanName());
+			spelltar->MessageString(Chat::SpellFailure, ClientString::YOU_ARE_PROTECTED, GetCleanName());
 			safe_delete(action_packet);
 			return false;
 		}
@@ -4324,7 +4324,7 @@ bool Mob::SpellOnTarget(
 		IsHarmonySpell(spell_id) &&
 		!HarmonySpellLevelCheck(spell_id, spelltar)
 	) {
-		MessageString(Chat::SpellFailure, SPELL_NO_EFFECT);
+		MessageString(Chat::SpellFailure, ClientString::SPELL_NO_EFFECT);
 		safe_delete(action_packet);
 		return false;
 	}
@@ -4338,7 +4338,7 @@ bool Mob::SpellOnTarget(
 				focus = CalcFocusEffect(focusBlockNextSpell, buffs[b].spellid, spell_id);
 				if (focus) {
 					CheckNumHitsRemaining(NumHit::MatchingSpells, b);
-					MessageString(Chat::SpellFailure, SPELL_WOULDNT_HOLD);
+					MessageString(Chat::SpellFailure, ClientString::SPELL_WOULDNT_HOLD);
 					safe_delete(action_packet);
 					return false;
 				}
@@ -4441,12 +4441,12 @@ bool Mob::SpellOnTarget(
 						false, /* Skip Sender */
 						RuleI(Range, SpellMessages), /* Range */
 						Chat::Spells, /* Type */
-						SPELL_REFLECT, /* String ID */
+						ClientString::SPELL_REFLECT, /* String ID */
 						GetCleanName(), /* Message 1 */
 						spelltar->GetCleanName() /* Message 2 */
 					);
 				} else {
-					MessageString(Chat::Spells, SPELL_REFLECT, GetCleanName(), spelltar->GetCleanName());
+					MessageString(Chat::Spells, ClientString::SPELL_REFLECT, GetCleanName(), spelltar->GetCleanName());
 				}
 
 				CheckNumHitsRemaining(NumHit::ReflectSpell);
@@ -4499,11 +4499,11 @@ bool Mob::SpellOnTarget(
 				LogSpells("Spell [{}] was completely resisted by [{}]", spell_id, spelltar->GetName());
 
 				if (spells[spell_id].resist_type == RESIST_PHYSICAL){
-					MessageString(Chat::SpellFailure, PHYSICAL_RESIST_FAIL,spells[spell_id].name);
-					spelltar->MessageString(Chat::SpellFailure, YOU_RESIST, spells[spell_id].name);
+					MessageString(Chat::SpellFailure, ClientString::PHYSICAL_RESIST_FAIL,spells[spell_id].name);
+					spelltar->MessageString(Chat::SpellFailure, ClientString::YOU_RESIST, spells[spell_id].name);
 				} else {
-					MessageString(Chat::SpellFailure, TARGET_RESISTED, spells[spell_id].name);
-					spelltar->MessageString(Chat::SpellFailure, YOU_RESIST, spells[spell_id].name);
+					MessageString(Chat::SpellFailure, ClientString::TARGET_RESISTED, spells[spell_id].name);
+					spelltar->MessageString(Chat::SpellFailure, ClientString::YOU_RESIST, spells[spell_id].name);
 
 					if (IsBot() && RuleB(Bots, ShowResistMessagesToOwner)) {
 						CastToBot()->GetBotOwner()->Message
@@ -4620,7 +4620,7 @@ bool Mob::SpellOnTarget(
 		// spell. It's most likely a buff that can't stack.
 		LogSpells("Spell [{}] could not apply its effects [{}] -> [{}]\n", spell_id, GetName(), spelltar->GetName());
 		if (casting_spell_aa_id) {
-			MessageString(Chat::SpellFailure, SPELL_NO_HOLD);
+			MessageString(Chat::SpellFailure, ClientString::SPELL_NO_HOLD);
 			if (RuleB(Spells, LegacyManaburn) && IsClient() && casting_spell_aa_id == aaManaBurn) {
 				StopCasting();
 			}
@@ -5085,7 +5085,7 @@ bool Mob::IsImmuneToSpell(uint16 spell_id, Mob *caster)
 	{
 		if(GetSpecialAbility(SpecialAbility::MesmerizeImmunity)) {
 			LogSpells("We are immune to Mez spells");
-			caster->MessageString(Chat::SpellFailure, CANNOT_MEZ);
+			caster->MessageString(Chat::SpellFailure, ClientString::CANNOT_MEZ);
 			int32 aggro = caster->CheckAggroAmount(spell_id, this);
 			if(aggro > 0) {
 				AddToHateList(caster, aggro);
@@ -5103,7 +5103,7 @@ bool Mob::IsImmuneToSpell(uint16 spell_id, Mob *caster)
 			(!caster->IsNPC() || (caster->IsNPC() && !RuleB(Spells, NPCIgnoreBaseImmunity))))
 		{
 			LogSpells("Our level ([{}]) is higher than the limit of this Mez spell ([{}])", GetLevel(), spells[spell_id].max_value[effect_index]);
-			caster->MessageString(Chat::SpellFailure, CANNOT_MEZ_WITH_SPELL);
+			caster->MessageString(Chat::SpellFailure, ClientString::CANNOT_MEZ_WITH_SPELL);
 			AddToHateList(caster, 1,0,true,false,false,spell_id);
 			return true;
 		}
@@ -5113,7 +5113,7 @@ bool Mob::IsImmuneToSpell(uint16 spell_id, Mob *caster)
 	if(GetSpecialAbility(SpecialAbility::SlowImmunity) && IsEffectInSpell(spell_id, SpellEffect::AttackSpeed))
 	{
 		LogSpells("We are immune to Slow spells");
-		caster->MessageString(Chat::Red, IMMUNE_ATKSPEED);
+		caster->MessageString(Chat::Red, ClientString::IMMUNE_ATKSPEED);
 		int32 aggro = caster->CheckAggroAmount(spell_id, this);
 		if(aggro > 0) {
 			AddToHateList(caster, aggro);
@@ -5129,7 +5129,7 @@ bool Mob::IsImmuneToSpell(uint16 spell_id, Mob *caster)
 		effect_index = GetSpellEffectIndex(spell_id, SpellEffect::Fear);
 		if(GetSpecialAbility(SpecialAbility::FearImmunity)) {
 			LogSpells("We are immune to Fear spells");
-			caster->MessageString(Chat::Red, IMMUNE_FEAR);	// need to verify message type, not in MQ2Cast for easy look up
+			caster->MessageString(Chat::Red, ClientString::IMMUNE_FEAR);	// need to verify message type, not in MQ2Cast for easy look up
 			int32 aggro = caster->CheckAggroAmount(spell_id, this);
 			if(aggro > 0) {
 				AddToHateList(caster, aggro);
@@ -5140,13 +5140,13 @@ bool Mob::IsImmuneToSpell(uint16 spell_id, Mob *caster)
 		} else if(IsClient() && caster->IsClient() && (caster->CastToClient()->GetGM() == false))
 		{
 			LogSpells("Clients cannot fear eachother!");
-			caster->MessageString(Chat::Red, IMMUNE_FEAR);	// need to verify message type, not in MQ2Cast for easy look up
+			caster->MessageString(Chat::Red, ClientString::IMMUNE_FEAR);	// need to verify message type, not in MQ2Cast for easy look up
 			return true;
 		}
 		else if(GetLevel() > spells[spell_id].max_value[effect_index] && spells[spell_id].max_value[effect_index] != 0)
 		{
 			LogSpells("Level is [{}], cannot be feared by this spell", GetLevel());
-			caster->MessageString(Chat::Shout, FEAR_TOO_HIGH);
+			caster->MessageString(Chat::Shout, ClientString::FEAR_TOO_HIGH);
 			int32 aggro = caster->CheckAggroAmount(spell_id, this);
 			if (aggro > 0) {
 				AddToHateList(caster, aggro);
@@ -5159,7 +5159,7 @@ bool Mob::IsImmuneToSpell(uint16 spell_id, Mob *caster)
 		{
 			Message(Chat::Red, "Your are immune to fear.");
 			LogSpells("Clients has WarCry effect, immune to fear!");
-			caster->MessageString(Chat::Red, IMMUNE_FEAR);	// need to verify message type, not in MQ2Cast for easy look up
+			caster->MessageString(Chat::Red, ClientString::IMMUNE_FEAR);	// need to verify message type, not in MQ2Cast for easy look up
 			return true;
 		}
 	}
@@ -5169,7 +5169,7 @@ bool Mob::IsImmuneToSpell(uint16 spell_id, Mob *caster)
 		if(GetSpecialAbility(SpecialAbility::CharmImmunity))
 		{
 			LogSpells("We are immune to Charm spells");
-			caster->MessageString(Chat::Red, CANNOT_CHARM);	// need to verify message type, not in MQ2Cast for easy look up
+			caster->MessageString(Chat::Red, ClientString::CANNOT_CHARM);	// need to verify message type, not in MQ2Cast for easy look up
 			int32 aggro = caster->CheckAggroAmount(spell_id, this);
 			if(aggro > 0) {
 				AddToHateList(caster, aggro);
@@ -5198,11 +5198,11 @@ bool Mob::IsImmuneToSpell(uint16 spell_id, Mob *caster)
 				if (RuleB(Spells, CharmAggroOverLevel)) {
 					int64 aggro = caster->CheckAggroAmount(spell_id, this);
 					aggro > 0 ? AddToHateList(caster, aggro) : AddToHateList(caster, 1, 0, true, false, false, spell_id);
-					caster->MessageString(Chat::SpellFailure, TARGET_RESISTED, spells[spell_id].name);
+					caster->MessageString(Chat::SpellFailure, ClientString::TARGET_RESISTED, spells[spell_id].name);
 					return true;
 				}
 
-				caster->MessageString(Chat::Red, CANNOT_CHARM_YET);	// need to verify message type, not in MQ2Cast for easy look up<Paste>
+				caster->MessageString(Chat::Red, ClientString::CANNOT_CHARM_YET);	// need to verify message type, not in MQ2Cast for easy look up<Paste>
 				AddToHateList(caster, 1,0,true,false,false,spell_id);
 				return true;
 			}
@@ -5217,7 +5217,7 @@ bool Mob::IsImmuneToSpell(uint16 spell_id, Mob *caster)
 	{
 		if(GetSpecialAbility(SpecialAbility::SnareImmunity)) {
 			LogSpells("We are immune to Snare spells");
-			caster->MessageString(Chat::Red, IMMUNE_MOVEMENT);
+			caster->MessageString(Chat::Red, ClientString::IMMUNE_MOVEMENT);
 			int32 aggro = caster->CheckAggroAmount(spell_id, this);
 			if(aggro > 0) {
 				AddToHateList(caster, aggro);
@@ -5233,7 +5233,7 @@ bool Mob::IsImmuneToSpell(uint16 spell_id, Mob *caster)
 		if(this == caster)
 		{
 			LogSpells("You cannot lifetap yourself");
-			caster->MessageString(Chat::SpellFailure, CANT_DRAIN_SELF);
+			caster->MessageString(Chat::SpellFailure, ClientString::CANT_DRAIN_SELF);
 			return true;
 		}
 	}
@@ -5243,7 +5243,7 @@ bool Mob::IsImmuneToSpell(uint16 spell_id, Mob *caster)
 		if(this == caster)
 		{
 			LogSpells("You cannot sacrifice yourself");
-			caster->MessageString(Chat::SpellFailure, CANNOT_SAC_SELF);
+			caster->MessageString(Chat::SpellFailure, ClientString::CANNOT_SAC_SELF);
 			return true;
 		}
 	}
@@ -7297,7 +7297,7 @@ void Mob::DoBardCastingFromItemClick(bool is_casting_bard_song, uint32 cast_time
 			EQApplicationPacket *outapp = nullptr;
 			outapp = new EQApplicationPacket(OP_InterruptCast, sizeof(InterruptCast_Struct));
 			InterruptCast_Struct* ic = (InterruptCast_Struct*)outapp->pBuffer;
-			ic->messageid = SONG_ENDS;
+			ic->messageid = ClientString::SONG_ENDS;
 			ic->spawnid = GetID();
 			outapp->priority = 5;
 			CastToClient()->QueuePacket(outapp);
@@ -7436,7 +7436,7 @@ bool Mob::CheckItemRaceClassDietyRestrictionsOnCast(uint32 inventory_slot) {
 				RecordPlayerEventLogWithClient(CastToClient(), PlayerEvent::POSSIBLE_HACK, PlayerEvent::PossibleHackEvent{.message = message});
 			}
 			else {
-				MessageString(Chat::Red, MUST_EQUIP_ITEM);
+				MessageString(Chat::Red, ClientString::MUST_EQUIP_ITEM);
 			}
 			return(false);
 		}
@@ -7458,7 +7458,7 @@ bool Mob::CheckItemRaceClassDietyRestrictionsOnCast(uint32 inventory_slot) {
 				}
 				else
 				{
-					MessageString(Chat::Red, CANNOT_USE_ITEM);
+					MessageString(Chat::Red, ClientString::CANNOT_USE_ITEM);
 				}
 			}
 			return(false);
@@ -7475,7 +7475,7 @@ bool Mob::CheckItemRaceClassDietyRestrictionsOnCast(uint32 inventory_slot) {
 			RecordPlayerEventLogWithClient(CastToClient(), PlayerEvent::POSSIBLE_HACK, PlayerEvent::PossibleHackEvent{.message = message});
 		}
 		else {
-			MessageString(Chat::Red, MUST_EQUIP_ITEM);
+			MessageString(Chat::Red, ClientString::MUST_EQUIP_ITEM);
 		}
 		return(false);
 	}

--- a/zone/string_ids.h
+++ b/zone/string_ids.h
@@ -2,604 +2,610 @@
 #define STRING_IDS
 
 //These strings are loaded from eqstr_us.txt, but may vary between client versions. Maybe we could make this an enum that's dependent on the client version?
-#define GENERIC_9_STRINGS			1		//%1 %2 %3 %4 %5 %6 %7 %8 %9
-#define TARGET_OUT_OF_RANGE			100		//Your target is out of range, get closer!
-#define TARGET_NOT_FOUND			101		//Target player not found.
-#define TRADE_CANCEL_LORE			104		//Trade cancelled, duplicated Lore Items would result.
-#define CANNOT_BIND					105		//You cannot form an affinity with this area. Try a city.
-#define SPELL_DOES_NOT_WORK_HERE	106		//This spell does not work here.
-#define SPELL_DOES_NOT_WORK_PLANE	107		//This spell does not work on this plane.
-#define CANT_SEE_TARGET				108		//You cannot see your target.
-#define MGB_STRING					113		//The next group buff you cast will hit all targets in range.
-#define ABILITY_FAILED				116		//Your ability failed. Timer has been reset.
-#define ESCAPE						114		//You escape from combat, hiding yourself from view.
-#define AA_OFF						119		//Alternate Experience is *OFF*.
-#define AA_ON						121		//Alternate Experience is *ON*.
-#define TARGET_TOO_FAR				124		//Your target is too far away, get closer!
-#define PROC_TOOLOW					126		//Your will is not sufficient to command this weapon.
-#define PROC_PETTOOLOW				127		//Your pet's will is not sufficient to command its weapon.
-#define YOU_FLURRY					128		//You unleash a flurry of attacks.
-#define FAILED_DISARM_TRAP			129		//You failed to disarm the trap.
-#define DOORS_LOCKED				130		//It's locked and you're not holding the key.
-#define DOORS_CANT_PICK				131		//This lock cannot be picked.
-#define DOORS_INSUFFICIENT_SKILL	132		//You are not sufficiently skilled to pick this lock.
-#define DOORS_GM					133		//You opened the locked door with your magic GM key.
-#define ITEMS_INSUFFICIENT_LEVEL	136		//You are not sufficient level to use this item.
-#define GAIN_XP						138		//You gain experience!!
-#define GAIN_GROUPXP				139		//You gain party experience!!
-#define BOW_DOUBLE_DAMAGE			143		//Your bow shot did double dmg.
-#define YOU_ARE_BEING_BANDAGED		147		//Someone is bandaging you.
-#define FORAGE_GRUBS				150		//You have scrounged up some fishing grubs.
-#define FORAGE_WATER				151		//You have scrounged up some water.
-#define FORAGE_FOOD					152		//You have scrounged up some food.
-#define FORAGE_DRINK				153		//You have scrounged up some drink.
-#define FORAGE_NOEAT				154		//You have scrounged up something that doesn't look edible.
-#define FORAGE_FAILED				155		//You fail to locate any food nearby.
-#define ALREADY_FISHING				156		//You are already fishing!
-#define FISHING_NO_POLE				160		//You can't fish without a fishing pole, go buy one.
-#define FISHING_EQUIP_POLE			161		//You need to put your fishing pole in your primary hand.
-#define FISHING_NO_BAIT				162		//You can't fish without fishing bait, go buy some.
-#define FISHING_CAST				163		//You cast your line.
-#define NOT_SCARING					164		//You're not scaring anyone.
-#define FISHING_STOP				165		//You stop fishing and go on your way.
-#define FISHING_LAND				166		//Trying to catch land sharks perhaps?
-#define FISHING_LAVA				167		//Trying to catch a fire elemental or something?
-#define FISHING_FAILED				168		//You didn't catch anything.
-#define FISHING_POLE_BROKE			169		//Your fishing pole broke!
-#define FISHING_SUCCESS				170		//You caught, something...
-#define FISHING_SUCCESS_FISH_NAME	421		//You caught %1!
-#define FISHING_SPILL_BEER			171		//You spill your beer while bringing in your line.
-#define FISHING_LOST_BAIT			172		//You lost your bait!
-#define SPELL_FIZZLE				173		//Your spell fizzles!
-#define MUST_EQUIP_ITEM				179		//You cannot use this item unless it is equipped.
-#define MISS_NOTE					180		//You miss a note, bringing your song to a close!
-#define CANNOT_USE_ITEM				181		//Your race, class, or deity cannot use this item.
-#define ITEM_OUT_OF_CHARGES			182		//Item is out of charges.
-#define ALREADY_ON_A_MOUNT			189		//You are already on a mount.
-#define TARGET_NO_MANA				191		//Your target has no mana to affect
-#define TARGET_GROUP_MEMBER			196		//You must first target a group member.
-#define SPELL_TOO_POWERFUL			197		//Your spell is too powerful for your intended target.
-#define INSUFFICIENT_MANA			199		//Insufficient Mana to cast this spell!
-#define SAC_TOO_LOW					203		//This being is not a worthy sacrifice.
-#define SAC_TOO_HIGH				204		//This being is too powerful to be a sacrifice.
-#define CANNOT_SAC_SELF				205		//You cannot sacrifice yourself.
-#define SILENCED_STRING				207		//You *CANNOT* cast spells, you have been silenced!
-#define CAST_DAYTIME                208		//Spell can only be cast during the day.
-#define CAST_NIGHTTIME              209		//Spell can only be cast during the night.
-#define CANNOT_AFFECT_PC			210		//That spell can not affect this target PC.
-#define SPELL_NEED_TAR				214		//You must first select a target for this spell!
-#define SUMMON_ONLY_GROUP_CORPSE	215		//You must first target a living group member whose corpse you wish to summon.
-#define ONLY_ON_CORPSES				221		//This spell only works on corpses.
-#define CANT_DRAIN_SELF				224		//You can't drain yourself!
-#define CORPSE_NOT_VALID			230		//This corpse is not valid.
-#define CORPSE_TOO_OLD				231		//This player cannot be resurrected. The corpse is too old.
-#define CAST_OUTDOORS				234		//You can only cast this spell in the outdoors.
-#define SPELL_RECAST				236		//Spell recast time not yet met.
-#define SPELL_RECOVERY				237		//Spell recovery time not yet met.
-#define CANNOT_MEZ					239		//Your target cannot be mesmerized.
-#define CANNOT_MEZ_WITH_SPELL		240		//Your target cannot be mesmerized (with this spell).
-#define IMMUNE_STUN					241		//Your target is immune to the stun portion of this effect.
-#define IMMUNE_ATKSPEED				242		//Your target is immune to changes in its attack speed.
-#define IMMUNE_FEAR					243		//Your target is immune to fear spells.
-#define IMMUNE_MOVEMENT				244		//Your target is immune to changes in its run speed.
-#define ONLY_ONE_PET				246		//You cannot have more than one pet at a time.
-#define CANNOT_CHARM_YET			248		//Your target is too high of a level for your charm spell.
-#define CANNOT_AFFECT_NPC			251		//That spell can not affect this target NPC.
-#define FD_CAST_ON					254		//You are no longer feigning death, because a spell hit you.
-#define SUSPEND_MINION_HAS_AGGRO	256		//Your pet is the focus of something's attention.
-#define NO_PET						255		//You do not have a pet.
-#define GATE_FAIL					260		//Your gate is too unstable, and collapses.
-#define CORPSE_CANT_SENSE			262		//You cannot sense any corpses for this PC in this zone.
-#define SPELL_NO_HOLD				263		//Your spell did not take hold.
-#define CANNOT_CHARM				267		//This NPC cannot be charmed.
-#define SPELL_NO_EFFECT				268		//Your target looks unaffected.
-#define NO_INSTRUMENT_SKILL			269		//Stick to singing until you learn to play this instrument.
-#define REGAIN_AND_CONTINUE			270		//You regain your concentration and continue your casting.
-#define SPELL_WOULDNT_HOLD			271		//Your spell would not have taken hold on your target.
-#define MISSING_SPELL_COMP			272		//You are missing some required spell components.
-#define INVIS_BEGIN_BREAK			275		//You feel yourself starting to appear.
-#define DISCIPLINE_CONLOST			278		//You lose the concentration to remain in your fighting discipline.
-#define REZ_REGAIN					289		//You regain some experience from resurrection.
-#define DUP_LORE					290		//Duplicate lore items are not allowed.
-#define TGB_ON						293		//Target other group buff is *ON*.
-#define TGB_OFF						294		//Target other group buff is *OFF*.
-#define DONT_SEE_TARGET				303		//I don't see anyone by that name around here...
-#define DISARMED_TRAP				305		//You have disarmed the trap.
-#define LDON_SENSE_TRAP1			306		//You do not Sense any traps.
-#define TRADESKILL_NOCOMBINE		334		//You cannot combine these items in this container type!
-#define TRADESKILL_FAILED			336		//You lacked the skills to fashion the items together.
-#define TRADESKILL_TRIVIAL			338		//You can no longer advance your skill from making this item.
-#define TRADESKILL_SUCCEED			339		//You have fashioned the items together to create something new!
-#define EVADE_SUCCESS				343		//You have momentarily ducked away from the main combat.
-#define EVADE_FAIL					344		//Your attempts at ducking clear of combat fail.
-#define HIDE_FAIL					345		//You failed to hide yourself.
-#define HIDE_SUCCESS				346		//You have hidden yourself from view.
-#define SNEAK_SUCCESS				347		//You are as quiet as a cat stalking its prey.
-#define SNEAK_FAIL					348		//You are as quiet as a herd of running elephants.
-#define MEND_CRITICAL				349		//You magically mend your wounds and heal considerable damage.
-#define MEND_SUCCESS				350		//You mend your wounds and heal some damage.
-#define MEND_WORSEN					351		//You have worsened your wounds!
-#define MEND_FAIL					352		//You have failed to mend your wounds.
-#define LDON_SENSE_TRAP2			367		//You have not detected any traps.
-#define TRAP_TOO_FAR				368		//You are too far away from that trap to affect it.
-#define FAIL_DISARM_DETECTED_TRAP	370		//You fail to disarm the detected trap.
-#define LOOT_LORE_ERROR				371		//You cannot loot this Lore Item. You already have one.
-#define PICK_LORE					379		//You cannot pick up a lore item you already possess.
-#define POISON_TOO_HIGH				382		//This poison is too high level for you to apply.
-#define TAUNT_TOO_FAR				386		//You are too far away from your target to taunt.
-#define CORPSE_TOO_FAR				389		//The corpse is too far away to summon.
-#define CONSENT_DENIED				390		//You do not have consent to summon that corpse.
-#define DISCIPLINE_RDY				393		//You are ready to use a new discipline now.
-#define CONSENT_INVALID_NAME		397		//Not a valid consent name.
-#define CONSENT_NPC					398		//You cannot consent NPC\'s.
-#define CONSENT_YOURSELF			399		//You cannot consent yourself.
-#define CONSENT_WAIT				400		//You must wait 2 seconds between consents.
-#define SONG_NEEDS_DRUM				405		//You need to play a percussion instrument for this song
-#define SONG_NEEDS_WIND				406		//You need to play a wind instrument for this song
-#define SONG_NEEDS_STRINGS			407		//You need to play a stringed instrument for this song
-#define SONG_NEEDS_BRASS			408		//You need to play a brass instrument for this song
-#define AA_GAIN_ABILITY				410		//You have gained the ability "%T1" at a cost of %2 ability %T3.
-#define AA_IMPROVE					411		//You have improved %T1 %2 at a cost of %3 ability %T4.
-#define TAUNT_SUCCESS				412		//You taunt %1 to ignore others and attack you!
-#define AA_REUSE_MSG				413		//You can use the ability %B1(1) again in %2 hour(s) %3 minute(s) %4 seconds.
-#define AA_REUSE_MSG2				414		//You can use the ability %B1(1) again in %2 minute(s) %3 seconds.
-#define YOU_HEALED					419		//%1 has healed you for %2 points of damage.
-#define BEGINS_TO_GLOW				422		//Your %1 begins to glow.
-#define ALREADY_INVIS				423		//%1 tries to cast an invisibility spell on you, but you are already invisible.
-#define YOU_ARE_PROTECTED			424		//%1 tries to cast a spell on you, but you are protected.
-#define TARGET_RESISTED				425		//Your target resisted the %1 spell.
-#define YOU_RESIST					426		//You resist the %1 spell!
-#define YOU_CRIT_HEAL				427		//You perform an exceptional heal! (%1)
-#define YOU_CRIT_BLAST				428		//You deliver a critical blast! (%1)
-#define SUMMONING_CORPSE			429		//Summoning your corpse.
-#define SUMMONING_CORPSE_OTHER		430		//Summoning %1's corpse.
-#define MISSING_SPELL_COMP_ITEM		433		//You are missing %1.
-#define OTHER_HIT_NONMELEE			434		//%1 was hit by non-melee for %2 points of damage.
-#define SPELL_WORN_OFF_OF			436		//Your %1 spell has worn off of %2.
-#define SPELL_WORN_OFF				437		//Your %1 spell has worn off.
-#define PET_TAUNTING				438		//Taunting attacker, Master.
-#define INTERRUPT_SPELL				439		//Your spell is interrupted.
-#define LOSE_LEVEL					442		//You LOST a level! You are now level %1!
-#define GAIN_ABILITY_POINT			446		//You have gained an ability point! You now have %1 ability point%2.
-#define GAIN_LEVEL					447		//You have gained a level! Welcome to level %1!
-#define LANG_SKILL_IMPROVED			449		//Your language skills have improved.
-#define OTHER_LOOTED_MESSAGE		466		//--%1 has looted a %2--
-#define LOOTED_MESSAGE				467		//--You have looted a %1--
-#define FACTION_WORST				469		//Your faction standing with %1 could not possibly get any worse.
-#define FACTION_WORSE				470		//Your faction standing with %1 got worse.
-#define FACTION_BEST				471		//Your faction standing with %1 could not possibly get any better.
-#define FACTION_BETTER				472		//Your faction standing with %1 got better.
-#define PET_REPORT_HP				488		//I have %1 percent of my hit points left.
-#define PET_NO_TAUNT				489		//No longer taunting attackers, Master.
-#define PET_DO_TAUNT				490		//Taunting attackers as normal, Master.
-#define CORPSE_REZ_TIME_HOUR        491     //This corpse's resurrection time will expire in %1 hour(s) %2 minute(s) %3 seconds.
-#define CORPSE_REZ_TIME_MINUTE      492     //This corpse's resurrection time will expire in %1 minute(s) %2 seconds.
-#define CORPSE_DECAY_TIME_DAY       493     //This corpse will decay in %1 day(s) %2 hour(s) %3 minute(s) %4 seconds.
-#define CORPSE_DECAY_TIME_HOUR      494     //This corpse will decay in %1 hour(s) %2 minute(s) %3 seconds.
-#define CORPSE_DECAY_TIME_MINUTE    495		//This corpse will decay in %1 minute(s) %2 seconds.
-#define DISC_LEVEL_ERROR			503		//You must be a level %1 ... to use this discipline.
-#define DISCIPLINE_CANUSEIN			504		//You can use a new discipline in %1 minutes %2 seconds.
-#define SHARE_MONEY					511		//%1 shares money with the group.
-#define PVP_ON						552		//You are now player kill and follow the ways of Discord.
-#define GENERIC_STRINGID_SAY		554		//%1 says '%T2'
-#define CANNOT_WAKE					555		//%1 tells you, 'I am unable to wake %2, master.'
-#define SUMMONING_CORPSE_ZONE		596		//Summoning %1's corpse(s).
-#define TASK_NOT_RIGHT_LEVEL        615     //You are not at the right level for this task.
-#define INVITE_GROUP_LEADER			679		//To invite another group into yours, please invite the leader of the other group.
-#define PET_HOLD_SET_ON				698		//The pet hold mode has been set to on.
-#define PET_HOLD_SET_OFF			699		//The pet hold mode has been set to off.
-#define PET_FOCUS_SET_ON			700		//The pet focus mode has been set to on.
-#define PET_FOCUS_SET_OFF			701		//The pet focus mode has been set to off.
-#define PET_SPELLHOLD_SET_ON		702		//The pet spellhold mode has been set to on.
-#define PET_SPELLHOLD_SET_OFF		703		//The pet spellhold mode has been set to off.
-#define GUILD_NAME_IN_USE			711		//You cannot create a guild with that name, that guild already exists on this server.
-#define PARCEL_DELAY                734     //%1 tells you, 'You must give me a chance to send the last parcel before I can send another!'
-#define PARCEL_DUPLICATE_DELETE     737     //Duplicate lore items are not allowed! Your duplicate %1 has been deleted!
-#define PARCEL_DELIVER_3            741     //%1 told you, 'I will deliver the stack of %2 %3 to %4 as soon as possible!'
-#define TRADER_MODE_FAILED_ROF2	    785     //Your attempt to become a trader has failed.
-#define PARCEL_INV_FULL             790     //%1 tells you, 'Your inventory appears full!  Unable to retrieve parceled item.'
-#define AA_CAP						1000	//You have reached the AA point cap, and cannot gain any further experience until some of your stored AA point pool is used.
-#define GM_GAINXP					1002	//[GM] You have gained %1 AXP and %2 EXP (%3).
-#define MALE_SLAYUNDEAD				1007	//%1's holy blade cleanses his target!(%2)
-#define FEMALE_SLAYUNDEAD			1008	//%1's holy blade cleanses her target!(%2)
-#define FINISHING_BLOW				1009	//%1 scores a Finishing Blow!!
-#define ASSASSINATES				1016	//%1 ASSASSINATES their victim!!
-#define CRIPPLING_BLOW				1021	//%1 lands a Crippling Blow!(%2)
-#define STAGGERS					1022	//%1 staggers.
-#define CRITICAL_HIT				1023	//%1 scores a critical hit! (%2)
-#define DEADLY_STRIKE				1024	//%1 scores a Deadly Strike!(%2)
-#define RESISTS_URGE				1025	//%1 resists their urge to flee.
-#define BERSERK_START				1027	//%1 goes into a berserker frenzy!
-#define DEATH_PACT					1028	//%1's death pact has been benevolently fulfilled!
-#define DIVINE_INTERVENTION			1029	//%1 has been rescued by divine intervention!
-#define BERSERK_END					1030	//%1 is no longer berserk.
-#define GATES						1031	//%1 Gates.
-#define GENERIC_SAY					1032	//%1 says '%2'
-#define OTHER_REGAIN_CAST			1033	//%1 regains concentration and continues casting.
-#define GENERIC_SHOUT				1034	//%1 shouts '%2'
-#define GENERIC_EMOTE				1036	//%1 %2
-#define OTHER_CRIT_HEAL				1039	//%1 performs an exceptional heal! (%2)
-#define OTHER_CRIT_BLAST			1040	//%1 delivers a critical blast! (%2)
-#define NPC_ENRAGE_START			1042	//%1 has become ENRAGED.
-#define NPC_ENRAGE_END				1043	//%1 is no longer enraged.
-#define NPC_RAMPAGE					1044	//%1 goes on a RAMPAGE!
-#define NPC_FLURRY					1045	//%1 executes a FLURRY of attacks on %2!
-#define DISCIPLINE_FEARLESS			1076	//%1 becomes fearless.
-#define DUEL_FINISHED				1088	//dont know text
-#define EATING_MESSAGE				1091	//Chomp, chomp, chomp... %1 takes a bite from a %2.
-#define DRINKING_MESSAGE			1093	//Glug, glug, glug... %1 takes a drink from a %2.
-#define SUCCESSFUL_TAUNT			1095	//I'll teach you to interfere with me %3.
-#define TRADE_BACK                  1105    //I have no need for this %3, you can have it back.
-#define PET_SIT_STRING				1130	//Changing position, Master.
-#define PET_CALMING					1131	//Sorry, Master..calming down.
-#define PET_FOLLOWING				1132	//Following you, Master.
-#define PET_GUARDME_STRING			1133	//Guarding you, Master.
-#define PET_GUARDINGLIFE			1134	//Guarding with my life..oh splendid one.
-#define PET_GETLOST_STRING			1135	//As you wish, oh great one.
-#define PET_LEADERIS				1136	//My leader is %3.
-#define I_FOLLOW_NOONE				1137	//I follow no one.
-#define PET_ON_HOLD					1138	//Waiting for your order to attack, Master.
-#define NOT_LEGAL_TARGET			1139	//I beg forgiveness, Master. That is not a legal target.
-#define MERCHANT_BUSY				1143	//I'm sorry, I am busy right now.
-#define MERCHANT_GREETING			1144	//Welcome to my shop, %3.
-#define MERCHANT_HANDY_ITEM1		1145	//Hello there, %3. How about a nice %4?
-#define MERCHANT_HANDY_ITEM2		1146	//Greetings, %3. You look like you could use a %4.
-#define MERCHANT_HANDY_ITEM3		1147	//Hi there %3, just browsing? Have you seen the %4 I just got in?
-#define MERCHANT_HANDY_ITEM4		1148	//Welcome to my shop, %3. You would probably find a %4 handy.
-#define WONT_SELL_RACE1				1154 	//I don't like to speak to %B3(12) much less sell to them!
-#define WONT_SELL_CLASS1			1155 	//It's %B3(13) like you that are ruining the continent...get OUT!
-#define WONT_SELL_CLASS2			1156 	//Isn't there some kind of ordinance against %B3(13) crawling out from under their rocks?
-#define WONT_SELL_CLASS3			1157 	//%B3(13) like you don't have any place in my shop..now make way for welcome customers.
-#define WONT_SELL_CLASS4			1158 	//I thought scumbag %B3(13) like you just stole whatever they need.  Now GET OUT!
-#define WONT_SELL_CLASS5			1159 	//I don't have anything to do with %B3(13)..move along.
-#define WONT_SELL_NONSTDRACE1		1160 	//I don't have anything to do with your little gang..move along.
-#define WONT_SELL_RACE2				1161 	//It's not enough that you %B3(12) have ruined your own land. Now get lost!
-#define WONT_SELL_RACE3				1162 	//I have something here that %B3(12) use..let me see...it's the EXIT, now get LOST!
-#define WONT_SELL_RACE4				1163 	//Don't you %B3(12) have your own merchants?  Whatever, I'm not selling anything to you!
-#define WONT_SELL_NONSTDRACE2		1164 	//Members of your little "club" have ruined things around here..get lost!
-#define WONT_SELL_NONSTDRACE3		1165 	//I don't have anything to do with your damned club..move along.
-#define WONT_SELL_DEEDS1			1166 	//Creatures like you make me sick..the things you do..get out of here Pagan!
-#define WONT_SELL_DEEDS2			1167 	//After all the things you've done..the things you believe in..leave my shop!
-#define WONT_SELL_DEEDS3			1168 	//Actions speak louder than beliefs, and I despise both your actions and all you believe in.
-#define WONT_SELL_DEEDS4			1169 	//Get out of here now!
-#define WONT_SELL_DEEDS5			1170 	//I am tolerant by nature..but infidels like you push me past my limit..get out!
-#define WONT_SELL_DEEDS6			1171 	//I cannot abide you or your actions against all that is right..BE GONE!
-#define AA_POINT					1197	//point
-#define MERCHANT_CLOSED_ONE			1199	//I don't have time for that now.
-#define MERCHANT_CLOSED_TWO			1200	//Can't you see I'm doing something here?
-#define MERCHANT_CLOSED_THREE		1201	//I am not open for business right now.
-#define AA_POINTS					1215	//points
-#define SPELL_FIZZLE_OTHER			1218	//%1's spell fizzles!
-#define MISSED_NOTE_OTHER			1219	//A missed note brings %1's song to a close!
-#define SPELL_LEVEL_REQ				1226	//This spell only works on people who are level %1 and under.
-#define CORPSE_DECAY_NOW			1227	//This corpse is waiting to expire.
-#define CORPSE_ITEM_LOST			1228	//Your items will no longer stay with you when you respawn on death. You will now need to return to your corpse for your items.
-#define CORPSE_EXP_LOST				1229	//You will now lose experience when you die.
-#define FLICKERS_PALE_LIGHT			1230	//Your %1 flickers with a pale light.
-#define PULSES_WITH_LIGHT			1231	//Your %1 pulses with light as your vision sharpens.
-#define FEEDS_WITH_POWER			1232	//Your %1 feeds you with power.
-#define POWER_DRAIN_INTO			1233	//You feel your power drain into your %1.
-#define SEEMS_DRAINED				1234	//Your %1 seems drained of power.
-#define ALIVE_WITH_POWER			1235	//Your %1 feels alive with power.
-#define SPARKLES					1236	//Your %1 sparkles.
-#define GROWS_DIM					1237	//Your %1 grows dim.
-#define BEGINS_TO_SHINE				1238	//Your %1 begins to shine.
-#define CANT_FIND_PLAYER			1276 	//I can't find a player named %1!
-#define SURNAME_REJECTED			1374	//Your new surname was rejected. Please try a different name.
-#define ALREADY_SOLD				1376	//The item you were interested in has already been sold.
-#define GUILD_DISBANDED				1377    //Your guild has been disbanded!  You are no longer a member of any guild.
-#define DUEL_DECLINE				1383	//%1 has declined your challenge to duel to the death.
-#define DUEL_ACCEPTED				1384	//%1 has already accepted a duel with someone else.
-#define DUEL_CONSIDERING			1385	//%1 is considering a duel with someone else.
-#define PLAYER_SUMMONED				1393	//You have been summoned!
-#define PLAYER_REGAIN				1394	//You have control of yourself again.
-#define REZZ_ALREADY_PENDING		1379	//You were unable to restore the corpse to life, but you may have success with a later attempt.
-#define IN_USE						1406	//Someone else is using that. Try again later.
-#define DUEL_FLED					1408	//%1 has defeated %2 in a duel to the death! %3 has fled like a cowardly dog!
-#define MEMBER_OF_YOUR_GUILD		1429
-#define OFFICER_OF_YOUR_GUILD		1430
-#define LEADER_OF_YOUR_GUILD		1431
-#define TRADE_HAS_BEEN_CANCELLED	1449
-#define RECEIVED_PLATINUM			1452	//You receive %1 Platinum from %2.
-#define RECEIVED_GOLD				1453	//You receive %1 Gold from %2.
-#define RECEIVED_SILVER				1454	//You receive %1 Silver from %2.
-#define RECEIVED_COPPER				1455	//You receive %1 Copper from %2.
-#define STRING_FEIGNFAILED			1456	//%1 has fallen to the ground.
-#define DOORS_SUCCESSFUL_PICK		1457	//You successfully picked the lock.
-#define PLAYER_CHARMED				1461	//You lose control of yourself!
-#define TRADER_BUSY					1468	//That Trader is currently with a customer. Please wait until their transaction is finished.
-#define SENSE_CORPSE_DIRECTION		1563	//You sense a corpse in this direction.
-#define DUPE_LORE_MERCHANT			1573	//%1 tells you, 'You already have the lore item, %2, on your person, on your shroud, in the bank, in a real estate, or as an augment in another item.  You cannot have more than one of a particular lore item at a time.'
-#define QUEUED_TELL					2458	//[queued]
-#define QUEUE_TELL_FULL				2459	//[zoing and queue is full]
-#define TRADER_BUSY_TWO             3192    //Sorry, that action cannot be performed while trading.
-#define SUSPEND_MINION_UNSUSPEND	3267	//%1 tells you, 'I live again...'
-#define SUSPEND_MINION_SUSPEND		3268	//%1 tells you, 'By your command, master.'
-#define ONLY_SUMMONED_PETS			3269	//3269 This effect only works with summoned pets.
-#define SUSPEND_MINION_FIGHTING		3270	//Your pet must be at peace, first.
-#define SHIELD_TARGET_NPC			3278	//You must first target a living Player Character.
-#define ALREADY_SHIELDED			3279	//Either you or your target is already being shielded.
-#define ALREADY_SHIELDING			3280	//Either you or your target is already shielding another.
-#define START_SHIELDING				3281	//%1 begins to use %2 as a living shield!
-#define END_SHIELDING				3282	//%1 ceases protecting %2.
-#define OVER_AA_CAP					3374	//Warning: You are currently over the earned Advancement point limit of %1. Please spend some of your stored AA points. The NEXT time you zone all of your AA points over %2 will be deleted. You MUST spend the extra points now.
-#define TRADESKILL_MISSING_ITEM		3455	//You are missing a %1.
-#define TRADESKILL_MISSING_COMPONENTS	3456	//Sorry, but you don't have everything you need for this recipe in your general inventory.
-#define TRADESKILL_LEARN_RECIPE		3457	//You have learned the recipe %1!
-#define TASK_UPDATED                3471    //Your task '%1' has been updated.
-#define YOU_ASSIGNED_TASK           3472    //You have been assigned the task '%1'.
-#define DZ_YOU_BELONG               3500    //You cannot create this expedition since you already belong to another.
-#define DZ_REPLAY_YOU               3501    //You cannot create this expedition for another %1d:%2h:%3m since you have recently played here.
-#define DZ_PLAYER_COUNT             3503    //You do not meet the player count requirement.  You have %1 players.  You must have at least %2 and no more than %3.
-#define DZ_REPLAY_OTHER             3504    //%1 cannot be added to this expedition for another %2D:%3H:%4M since they have recently played in this area.
-#define DZ_AVAILABLE                3507    //%1 is now available to you.
-#define DZADD_INVITE                3508    //Sending an invitation to: %1.
-#define DZ_PREVENT_ENTERING         3510    //A strange magical presence prevents you from entering.  It's too dangerous to enter at the moment.
-#define DZADD_INVITE_FAIL           3511    //%1 could not be invited to join you.
-#define DZ_NO_LEADER_INFO           3512    //Unable to retrieve information on the leader to check permissions.
-#define DZ_NOT_LEADER               3513    //You are not the expedition leader, only %1 can issue this command.
-#define DZ_NOT_MEMBER               3514    //%1 is not a member of this expedition.
-#define DZ_REMOVED                  3516    //%1 has been removed from %2.
-#define DZSWAP_INVITE               3517    //Sending an invitation to: %1.  They must accept in order to swap party members.
-#define DZ_LEADER_OFFLINE           3518    //%1 is not currently online.  You can only transfer leadership to an online member of the expedition you are in.
-#define DZ_TIMER                    3519    //You have %1d:%2h:%3m remaining until you may enter %4.
-#define DZ_LEADER_NAME              3520    //%1 has been made the leader for this expedition.
-#define DZ_LEADER_YOU               3521    //You have been made the leader of this expedition.
-#define DZ_INVITE_ACCEPTED          3522    //%1 has accepted your offer to join your expedition.
-#define DZ_ADDED                    3523    //%1 has been added to %2.
-#define DZ_INVITE_ERROR             3524    //%1 accepted your offer to join your expedition but could not due to error(s).
-#define DZ_INVITE_DECLINED          3525    //%1 has declined your offer to join your expedition.
-#define DZ_INVITED                  3527    //%1 has asked you to join the expedition:  %2.        Would you like to join?
-#define DZ_WAY_IS_BLOCKED           3528    //The way is blocked to you.  Perhaps you would be able to enter if there was a reason to come here.
-#define DZ_NO_TIMERS                3529    //You have no outstanding timers.
-#define DZ_MINUTES_REMAIN           3551    //You only have %1 minutes remaining before this expedition comes to an end.
-#define DZ_LEADER                   3552    //Expedition Leader: %1
-#define DZ_MEMBERS                  3553    //Expedition Members: %1
-#define DZ_EVENT_TIMER              3561    //%1 cannot be added to this expedition since they have recently experienced %2.  They must wait another %3D:%4H:%5M until they can experience it again.  They may be added to the expedition later, once %2 has been completed.
-#define LOOT_NOT_ALLOWED			3562	//You are not allowed to loot the item: %1.
-#define DZ_UNABLE_RETRIEVE_LEADER   3583    //Unable to retrieve dynamic zone leader to check permissions.
-#define DZADD_NOT_ALLOWING          3585    //The expedition is not allowing players to be added.
-#define DZADD_NOT_ONLINE            3586    //%1 is not currently online.  A player needs to be online to be added to a Dynamic Zone
-#define DZADD_EXCEED_MAX            3587    //You can not add another player since you currently have the maximum number of players allowed (%1) in this zone.
-#define DZADD_ALREADY_PART          3588    //You can not add %1 since they are already part of this zone.
-#define DZADD_LEAVE_ZONE            3589    //You can not add %1 since they first need to leave the zone before being allowed back in.
-#define DZADD_ALREADY_OTHER         3590    //%1 can not be added to this dynamic zone since they are already assigned to another dynamic zone.
-#define DZADD_REPLAY_TIMER          3591    //%1 can not be added to this dynamic zone for another %2D:%3H:%4M since they have recently played this zone.
-#define DZADD_EVENT_TIMER           3592    //%1 can not be added to this dynamic zone since they have recently experienced %2.  They must wait for another %3D:%4H:%5M, or until event %2 has occurred.
-#define DZADD_PENDING               3593    //%1 currently has an outstanding invitation to join this Dynamic Zone.
-#define DZADD_PENDING_OTHER         3594    //%1 currently has an outstanding invitation to join another Dynamic Zone.  Players may only have one invitation outstanding.
-#define DZSWAP_CANNOT_REMOVE        3595    //%1 can not be removed from this dynamic zone since they are not assigned to it.
-#define NOT_YOUR_TRAP				3671	//You cannot remove this, you are only allowed to remove traps you have set.
-#define NO_CAST_ON_PET				4045	//You cannot cast this spell on your pet.
-#define REWIND_WAIT					4059	//You must wait a bit longer before using the rewind command again.
-#define CORPSEDRAG_LIMIT			4061	//You are already dragging as much as you can!
-#define CORPSEDRAG_ALREADY			4062	//You are already dragging %1.
-#define CORPSEDRAG_SOMEONE_ELSE		4063	//Someone else is dragging %1.
-#define CORPSEDRAG_BEGIN			4064	//You begin to drag %1.
-#define CORPSEDRAG_STOPALL			4065	//You stop dragging the corpses.
-#define CORPSEDRAG_STOP				4066	//You stop dragging the corpse.
-#define SOS_KEEPS_HIDDEN			4086	//Your Shroud of Stealth keeps you hidden from watchful eyes.␣␣
-#define DISARM_NO_TARGET            4583    //You can't use disarm on that.
-#define	TARGET_TOO_CLOSE			4602	//You are too close to your target. Get farther away.
-#define WHOALL_NO_RESULTS			5029	//There are no players in EverQuest that match those who filters.
-#define TELL_QUEUED_MESSAGE			5045	//You told %1 '%T2. %3'
-#define TOLD_NOT_ONLINE				5046	//%1 is not online at this time.
-#define RAID_IS_FULL				5048	//The raid is full.
-#define ZONING_NO_EXPANSION         5052	//The zone that you are attempting to enter is part of an expansion that you do not yet own.  You may need to return to the Login screen and enter an account key for that expansion.  If you have received this message in error, please /petition or send an email to EQAccounts@soe.sony.com
-#define PETITION_NO_DELETE			5053	//You do not have a petition in the queue.
-#define PETITION_DELETED			5054	//Your petition was successfully deleted.
-#define ALREADY_IN_RAID				5060	//%1 is already in a raid.
-#define ALREADY_IN_YOUR_RAID		5077	//%1 is already in your raid.
-#define NOT_IN_YOUR_RAID            5082	//%1 is not in your raid.
-#define GAIN_RAIDEXP				5085	//You gained raid experience!
-#define ALREADY_IN_GRP_RAID			5088	//% 1 rejects your invite because they are in a raid and you are not in theirs, or they are a raid group leader
-#define DUNGEON_SEALED				5141	//The gateway to the dungeon is sealed off to you.  Perhaps you would be able to enter if you needed to adventure there.
-#define ADVENTURE_COMPLETE			5147	//You received %1 points for successfully completing the adventure.
-#define PARCEL_STATUS_2				5433	//You currently have % 1 parcels in your mail and are % 2 parcels over the limit of % 3!If you do not retrieve at least % 2 parcels before you logout, they will be lost!
-#define PARCEL_STATUS_1				5434	//You currently have % 1 parcels in your mail and are 1 parcel over the limit of % 2!If you do not retrieve at least 1 parcel before you logout, it will be lost!
-#define SUCCOR_FAIL					5169	//The portal collapes before you can escape!
-#define NO_PROPER_ACCESS			5410    //You don't have the proper access rights.
-#define AUGMENT_RESTRICTED			5480	//The item does not satisfy the augment's restrictions.
-#define PET_ATTACKING				5501	//%1 tells you, 'Attacking %2 Master.'
-#define AVOID_STUNNING_BLOW			5753	//You avoid the stunning blow.
-#define FATAL_BOW_SHOT				5745	//%1 performs a FATAL BOW SHOT!!
-#define SUSPECT_SEES_YOU			5746	//You suspect that this being can see you.
-#define MELEE_SILENCE				5806	//You *CANNOT* use this melee ability, you are suffering from amnesia!
-#define DISCIPLINE_REUSE_MSG		5807	//You can use the ability %1 again in %2 hour(s) %3 minute(s) %4 seconds.
-#define DISCIPLINE_REUSE_MSG2		5808	//You can use the ability %1 again in %2 minute(s) %3 seconds.
-#define FAILED_TAUNT				5811	//You have failed to taunt your target.
-#define PHYSICAL_RESIST_FAIL		5817	//Your target avoided your %1 ability.
-#define AA_NO_TARGET				5825	//You must first select a target for this ability!
-#define YOU_RECEIVE                 5941    //You receive %1.
-#define NO_TASK_OFFERS              6009    //Sorry %3, I don't have anything for someone with your abilities.
-#define MAX_ACTIVE_TASKS			6010	//Sorry %3, you already have the maximum number of active tasks.
-#define TASK_REQUEST_COOLDOWN_TIMER 6011    //Sorry, %3, but you can't request another task for %4 minutes and %5 seconds.
-#define FORAGE_MASTERY				6012	//Your forage mastery has enabled you to find something else!
-#define BUYER_WELCOME               6065    //There are %1 Buyers waiting to purchase your loot.  Type /barter to search for them, or use /buyer to set up your own Buy Lines.
-#define BUYER_GREETING              6070    //%1 greets you, '%2'
-#define GUILD_BANK_CANNOT_DEPOSIT	6097	// Cannot deposit this item. Containers must be empty, and only one of each LORE and no NO TRADE or TEMPORARY items may be deposited.
-#define GUILD_BANK_FULL				6098	// There is no more room in the Guild Bank.
-#define GUILD_BANK_TRANSFERRED  	6100	// '%1' transferred to Guild Bank from Deposits.
-#define GUILD_BANK_EMPTY_HANDS  	6108	// You must empty your hands to withdraw from the Guild Bank.
-#define EVOLVE_ITEM_EVOLVED         6145    //Your %1 has evolved!
-#define EVOLVE_DETAILS              6146    //Evolving: Level %1/%2 %3%% %4
-#define EVOLVE_LEVEL_LIMIT          6147    //Your %1 can not evolve until you reach level %2.
-#define EVOLVE_XP_TXFR_CONFIRM      6148    //Are you sure you want to transfer experience between these two items?
-#define EVOLVE_XP_TXFRD             6149    //Your item's experience has been transferred!
-#define TRADESKILL_COMBINE_LORE 	6199	// Combine would result in a LORE item (%1) you already possess.
-#define TRANSFORM_FAILED			6326	//This mold cannot be applied to your %1.
-#define TRANSFORM_COMPLETE			6327	//You have successfully transformed your %1.
-#define DETRANSFORM_FAILED			6341 	//%1 has no transformation that can be removed.
-#define GUILD_PERMISSION_FAILED		6418	//You do not have permission to change access options.
-#define PARCEL_DELIVERY_ARRIVED		6465	//You have received a new parcel delivery!
-#define PARCEL_DELIVERY				6466	//%1 tells you, 'I will deliver the %2 to %3 as soon as possible!'
-#define PARCEL_UNKNOWN_NAME			6467	//%1 tells you, 'Unfortunately, I don't know anyone by the name of %2. Here is your %3 back.''
-#define PARCEL_DELIVERED			6471	//%1 hands you the %2 that was sent from %3.
-#define PARCEL_DELIVERED_2			6472	//%1 hands you the stack of %2 %3 that was sent from %4.
-#define GENERIC_STRING				6688	//%1 (used to any basic message)
-#define SENTINEL_TRIG_YOU			6724	//You have triggered your sentinel.
-#define SENTINEL_TRIG_OTHER			6725	//%1 has triggered your sentinel.
-#define TRADER_MODE_OFF				6741 	//Bazaar Trader Mode *OFF*
-#define TRADER_MODE_ON				6742 	//Bazaar Trader Mode *ON*
-#define TRADER_SET_PRICE			6754 	//To become a merchant you must assign a price to an item in your list. Do this by selecting an item, then selecting a money amount, and then clicking set price.
-#define IDENTIFY_SPELL				6765	//Item Lore: %1.
-#define PET_NOW_HOLDING				6834	//Now holding, Master.  I will not start attacks until ordered.
-#define PET_ON_GHOLD				6843	//Pet greater hold has been set to on.
-#define PET_OFF_GHOLD				6846	//Pet greater hold has been set to off.
-#define PET_GHOLD_ON_MSG			6847	//Now greater holding master.  I will only attack something new if ordered.
-#define PET_ON_REGROUPING			6854	//Now regrouping, master.
-#define PET_OFF_REGROUPING			6855	//No longer regrouping, master.
-#define BUFF_NOT_BLOCKABLE			7608	//You cannot block this effect.
-#define LDON_DONT_KNOW_TRAPPED		7552	//You do not know if this object is trapped.
-#define LDON_HAVE_DISARMED			7553	//You have disarmed %1!
-#define LDON_ACCIDENT_SETOFF		7554	//You accidentally set off the trap!
-#define LDON_HAVE_NOT_DISARMED		7555	//You have not disarmed %1.
-#define LDON_ACCIDENT_SETOFF2		7556	//You accidentally set off the trap!
-#define LDON_CERTAIN_TRAP			7557	//You are certain that %1 is trapped.
-#define LDON_CERTAIN_NOT_TRAP		7558	//You are certain that %1 is not trapped.
-#define LDON_CANT_DETERMINE_TRAP	7559	//You are unable to determine if %1 is trapped.
-#define LDON_PICKLOCK_SUCCESS		7560	//You have successfully picked %1!
-#define LDON_PICKLOCK_FAILURE		7561	//You have failed to pick %1.
-#define LDON_STILL_LOCKED			7562	//You cannot open %1, it is locked.
-#define LDON_BASH_CHEST				7563	//%1 try to %2 %3, but do no damage.
-#define DOORS_NO_PICK				7564	//You must have a lock pick in your inventory to do this.
-#define LDON_NO_LOCKPICK			7564	//You must have a lock pick in your inventory to do this.
-#define LDON_WAS_NOT_LOCKED			7565	//%1 was not locked.
-#define LDON_WAS_NOT_TRAPPED		7566	//%1 was not trapped
-#define GAIN_SINGLE_AA_SINGLE_AA	8019	//You have gained an ability point!  You now have %1 ability point.
-#define GAIN_SINGLE_AA_MULTI_AA		8020	//You have gained an ability point!  You now have %1 ability points.
-#define GAIN_MULTI_AA_MULTI_AA		8021	//You have gained %1 ability point(s)!  You now have %2 ability point(s).
-#define GAIN_GROUP_LEADERSHIP_POINT	8585	//
-#define GAIN_RAID_LEADERSHIP_POINT	8589	//
-#define MAX_GROUP_LEADERSHIP_POINTS	8584	//
-#define MAX_RAID_LEADERSHIP_POINTS	8591	//
-#define LEADERSHIP_EXP_ON			8653	//
-#define LEADERSHIP_EXP_OFF			8654	//
-#define CURRENT_SPELL_EFFECTS		8757	//%1's current spell effects:
-#define MAX_MAIN_RAID_ASSISTERS		8782	//Max number of main assists reached (3)
-#define MAX_MAIN_RAID_MARKERS		8783	//Max number of main markers reached (3)
-#define NOT_DELEGATED_MARKER		8794	//You have not been delegated Raid Mark
-#define GAIN_GROUP_LEADERSHIP_EXP	8788	//
-#define GAIN_RAID_LEADERSHIP_EXP	8789	//
-#define BUFF_MINUTES_REMAINING		8799	//%1 (%2 minutes remaining)
-#define RAID_NO_LONGER_MARKED       8801	//%1 is no longer marked
-#define YOU_HAVE_BEEN_GIVEN         8994    //You have been given: %1
-#define NO_MORE_TRAPS				9002	//You have already placed your maximum number of traps.
-#define FEAR_TOO_HIGH				9035	//Your target is too high of a level for your fear spell.
-#define SLOW_MOSTLY_SUCCESSFUL		9029	//Your spell was mostly successful.
-#define SLOW_PARTIALLY_SUCCESSFUL	9030	// Your spell was partially successful.
-#define SLOW_SLIGHTLY_SUCCESSFUL	9031	//Your spell was slightly successful.
-#define SPELL_OPPOSITE_EFFECT		9032	//Your spell may have had the opposite effect of what you desired.
-#define HAS_BEEN_AWAKENED			9037	//%1 has been awakened by %2.
-#define YOU_HEAL					9068	//You have healed %1 for %2 points of damage.
-#define YOUR_HIT_DOT				9072	//%1 has taken %2 damage from your %3.
-#define HIT_NON_MELEE				9073	//%1 hit %2 for %3 points of non-melee damage.
-#define GLOWS_BLUE					9074	//Your %1 glows blue.
-#define GLOWS_RED					9075	//Your %1 glows red.
-#define SHAKE_OFF_STUN				9077	//You shake off the stun effect!
-#define STRIKETHROUGH_STRING		9078	//You strike through your opponent's defenses!
-#define SPELL_REFLECT				9082	//%1's spell has been reflected by %2.
-#define NO_MORE_AURAS				9160	//You do not have sufficient focus to maintain that ability.
-#define NEW_SPELLS_AVAIL			9149	//You have new spells available to you. Check the merchants near your guild master.
-#define FD_CAST_ON_NO_BREAK			9174	//The strength of your will allows you to resume feigning death.
-#define SNEAK_RESTRICT				9240	//You can not use this ability because you have not been hidden for long enough.
-#define PET_NOW_FOCUSING			9254	//Focusing on one target, Master.
-#define PET_NOT_FOCUSING			9263	//No longer focusing on one target, Master.
-#define PET_NOT_CASTING				9264	//Not casting spells, Master.
-#define PET_CASTING					9291	//Casting spells normally, Master.
-#define NO_CAST_IN_COMBAT			9190	//You can not cast this spell while in combat.
-#define NO_CAST_OUT_OF_COMBAT		9191	//You can not cast this spell while out of combat.
-#define NO_ABILITY_IN_COMBAT		9192	//You can not use this ability while in combat.
-#define NO_ABILITY_OUT_OF_COMBAT	9194	//You can not use this ability while out of combat.
-#define GAIN_GROUPXP_BONUS			9298	//You gain party experience (with a bonus)!
-#define GAIN_GROUPXP_PENALTY		9301	//You gain party experience (with a penalty)!
-#define GAIN_RAIDXP_BONUS			9302	//You gained raid experience (with a bonus)!
-#define GAIN_RAIDXP_PENALTY			9303	//You gained raid experience (with a penalty)!
-#define LESSER_SPELL_VERSION        11004   //%1 is a lesser version of %2 and cannot be scribed
-#define AE_RAMPAGE					11015	//%1 goes on a WILD RAMPAGE!
-#define GROUP_IS_FULL				12000	//You cannot join that group, it is full.
-#define FACE_ACCEPTED				12028	//Facial features accepted.
-#define TRACKING_BEGIN				12040   //You begin tracking %1.
-#define SPELL_LEVEL_TO_LOW			12048	//You will have to achieve level %1 before you can scribe the %2.
-#define YOU_RECEIVE_AS_SPLIT		12071   //You receive %1 as your split.
-#define ATTACKFAILED				12158	//%1 try to %2 %3, but %4!
-#define HIT_STRING					12183	//hit
-#define CRUSH_STRING				12191	//crush
-#define PIERCE_STRING				12193	//pierce
-#define KICK_STRING					12195	//kick
-#define STRIKE_STRING				12197	//strike
-#define BACKSTAB_STRING				12199	//backstab
-#define BASH_STRING					12201	//bash
-#define GUILD_NOT_MEMBER			12242	//You are not a member of any guild.
-#define MEMBER_OF_X_GUILD			12256
-#define OFFICER_OF_X_GUILD			12257
-#define LEADER_OF_X_GUILD			12258
-#define NOT_IN_A_GUILD				12259
-#define TARGET_PLAYER_FOR_GUILD_STATUS		12260
-#define TARGET_ALREADY_IN_GROUP		12265	//% 1 is already in another group.
-#define GROUP_INVITEE_NOT_FOUND		12268	//You must target a player or use /invite <name> to invite someone to your group.
-#define GROUP_INVITEE_SELF			12270	//12270 You cannot invite yourself.
-#define ALREADY_IN_PARTY			12272	//That person is already in your party.
-#define TALKING_TO_SELF				12323	//Talking to yourself again?
-#define SPLIT_NO_GROUP				12328	//You are not in a group! Keep it all.
-#define NO_LONGER_HIDDEN			12337   //You are no longer hidden.
-#define STOP_SNEAKING				12338	//You stop sneaking
-#define NOT_IN_CONTROL				12368	//You do not have control of yourself right now.
-#define NO_SKILL_WHILE_MOUNTED		12393	//You can not use this skill while on a mount.
-#define STAND_TO_CAST				12441	//You must be standing to cast a spell.
-#define ALREADY_CASTING				12442	//You are already casting a spell!
-#define SHIMMERS_BRIEFLY			12444	//Your %1 shimmers briefly.
-#define SENSE_CORPSE_NOT_NAME		12446	//You don't sense any corpses of that name.
-#define SENSE_CORPSE_NONE			12447	//You don't sense any corpses.
-#define SCREECH_BUFF_BLOCK			12448	//Your immunity buff protected you from the spell %1!
-#define NOT_HOLDING_ITEM			12452	//You are not holding an item!
-#define SENSE_UNDEAD				12471	//You sense undead in this direction.
-#define SENSE_ANIMAL				12472	//You sense an animal in this direction.
-#define SENSE_SUMMONED				12473	//You sense a summoned being in this direction.
-#define SENSE_NOTHING				12474	//You don't sense anything.
-#define SENSE_TRAP					12475	//You sense a trap in this direction.
-#define LDON_SENSE_TRAP3			12476	//You don't sense any traps.
-#define INTERRUPT_SPELL_OTHER		12478	//%1's casting is interrupted!
-#define YOU_HIT_NONMELEE			12481	//You were hit by non-melee for %1 damage.
-#define TRACK_LOST_TARGET			12681	//You have lost your tracking target.
-#define TRACK_STRAIGHT_AHEAD		12676
-#define TRACK_AHEAD_AND_TO			12677
-#define TRACK_TO_THE				12678
-#define TRACK_BEHIND_AND_TO			12679
-#define TRACK_BEHIND_YOU			12680
-#define BEAM_SMILE					12501	//%1 beams a smile at %2
-#define SONG_ENDS_ABRUPTLY			12686	//Your song ends abruptly.
-#define SONG_ENDS					12687	//Your song ends.
-#define SONG_ENDS_OTHER				12688	//%1's song ends.
-#define SONG_ENDS_ABRUPTLY_OTHER	12689	//%1's song ends abruptly.
-#define DIVINE_AURA_NO_ATK			12695	//You can't attack while invulnerable!
-#define TRY_ATTACKING_SOMEONE		12696	//Try attacking someone other than yourself, it's more productive
-#define RANGED_TOO_CLOSE			12698	//Your target is too close to use a ranged weapon!
-#define BACKSTAB_WEAPON				12874	//You need a piercing weapon as your primary weapon in order to backstab
-#define DISARMED                    12889   //You have been disarmed!
-#define DISARM_SUCCESS              12890   //You disarmed %1!
-#define DISARM_FAILED               12891   //Your attempt to disarm failed.
-#define MORE_SKILLED_THAN_I			12931	//%1 tells you, 'You are more skilled than I! What could I possibly teach you?'
-#define SURNAME_EXISTS				12939	//You already have a surname. Operation failed.
-#define SURNAME_LEVEL				12940	//You can only submit a surname upon reaching the 20th level. Operation failed.
-#define SURNAME_TOO_LONG			12942	//Surname must be less than 20 characters in length.
-#define REPORT_ONCE					12945	//You may only submit a report once per time that you zone. Thank you.
-#define NOW_INVISIBLE				12950	//%1 is now Invisible.
-#define NOW_VISIBLE					12951	//%1 is now Visible.
-#define YOU_TAKE_DOT				12954	//You have taken %1 damage from %2 by %3
-#define GUILD_NOT_MEMBER2			12966	//You are not in a guild.
-#define HOT_HEAL_SELF				12976 	//You have been healed for %1 hit points by your %2.
-#define HOT_HEAL_OTHER				12997	//You have healed %1 for %2 hit points with your %3.
-#define HOT_HEALED_OTHER			12998	//%1 healed you for %2 hit points by %3.
-#define DISC_LEVEL_USE_ERROR		13004	//You are not sufficient level to use this discipline.
-#define SPLIT_FAIL					13112	//There is not enough to split, keep it.
-#define TOGGLE_ON					13172	//Asking server to turn ON your incoming tells.
-#define TOGGLE_OFF					13173	//Asking server to turn OFF all incoming tells for you.
-#define DUEL_INPROGRESS				13251	//You have already accepted a duel with someone else cowardly dog.
-#define OTHER_HIT_DOT				13327	//%1 has taken %2 damage from %3 by %4.
-#define GAIN_XP_BONUS				14541	//You gain experience (with a bonus)!
-#define GAIN_XP_PENALTY				14542	//You gain experience (with a penalty)!
-#define GENERIC_MISS				15041	//%1 missed %2
+namespace ClientString {
+	constexpr int GENERIC_9_STRINGS              = 1; //%1 %2 %3 %4 %5 %6 %7 %8 %9
+	constexpr int TARGET_OUT_OF_RANGE            = 100; //Your target is out of range, get closer!
+	constexpr int TARGET_NOT_FOUND               = 10; //Target player not found.
+	constexpr int TRADE_CANCEL_LORE              = 104; //Trade cancelled, duplicated Lore Items would result.
+	constexpr int CANNOT_BIND                    = 105; //You cannot form an affinity with this area. Try a city.
+	constexpr int SPELL_DOES_NOT_WORK_HERE       = 106; //This spell does not work here.
+	constexpr int SPELL_DOES_NOT_WORK_PLANE      = 107; //This spell does not work on this plane.
+	constexpr int CANT_SEE_TARGET                = 108; //You cannot see your target.
+	constexpr int MGB_STRING                     = 113; //The next group buff you cast will hit all targets in range.
+	constexpr int ABILITY_FAILED                 = 116; //Your ability failed. Timer has been reset.
+	constexpr int ESCAPE                         = 114; //You escape from combat, hiding yourself from view.
+	constexpr int AA_OFF                         = 119; //Alternate Experience is *OFF*.
+	constexpr int AA_ON                          = 121; //Alternate Experience is *ON*.
+	constexpr int TARGET_TOO_FAR                 = 124; //Your target is too far away, get closer!
+	constexpr int PROC_TOOLOW                    = 126; //Your will is not sufficient to command this weapon.
+	constexpr int PROC_PETTOOLOW                 = 127; //Your pet's will is not sufficient to command its weapon.
+	constexpr int YOU_FLURRY                     = 128; //You unleash a flurry of attacks.
+	constexpr int FAILED_DISARM_TRAP             = 129; //You failed to disarm the trap.
+	constexpr int DOORS_LOCKED                   = 130; //It's locked and you're not holding the key.
+	constexpr int DOORS_CANT_PICK                = 131; //This lock cannot be picked.
+	constexpr int DOORS_INSUFFICIENT_SKILL       = 132; //You are not sufficiently skilled to pick this lock.
+	constexpr int DOORS_GM                       = 133; //You opened the locked door with your magic GM key.
+	constexpr int ITEMS_INSUFFICIENT_LEVEL       = 136; //You are not sufficient level to use this item.
+	constexpr int GAIN_XP                        = 138; //You gain experience!!
+	constexpr int GAIN_GROUPXP                   = 139; //You gain party experience!!
+	constexpr int BOW_DOUBLE_DAMAGE              = 143; //Your bow shot did double dmg.
+	constexpr int YOU_ARE_BEING_BANDAGED         = 147; //Someone is bandaging you.
+	constexpr int FORAGE_GRUBS                   = 150; //You have scrounged up some fishing grubs.
+	constexpr int FORAGE_WATER                   = 151; //You have scrounged up some water.
+	constexpr int FORAGE_FOOD                    = 152; //You have scrounged up some food.
+	constexpr int FORAGE_DRINK                   = 153; //You have scrounged up some drink.
+	constexpr int FORAGE_NOEAT                   = 154; //You have scrounged up something that doesn't look edible.
+	constexpr int FORAGE_FAILED                  = 155; //You fail to locate any food nearby.
+	constexpr int ALREADY_FISHING                = 156; //You are already fishing!
+	constexpr int FISHING_NO_POLE                = 160; //You can't fish without a fishing pole, go buy one.
+	constexpr int FISHING_EQUIP_POLE             = 161; //You need to put your fishing pole in your primary hand.
+	constexpr int FISHING_NO_BAIT                = 162; //You can't fish without fishing bait, go buy some.
+	constexpr int FISHING_CAST                   = 163; //You cast your line.
+	constexpr int NOT_SCARING                    = 164; //You're not scaring anyone.
+	constexpr int FISHING_STOP                   = 165; //You stop fishing and go on your way.
+	constexpr int FISHING_LAND                   = 166; //Trying to catch land sharks perhaps?
+	constexpr int FISHING_LAVA                   = 167; //Trying to catch a fire elemental or something?
+	constexpr int FISHING_FAILED                 = 168; //You didn't catch anything.
+	constexpr int FISHING_POLE_BROKE             = 169; //Your fishing pole broke!
+	constexpr int FISHING_SUCCESS                = 170; //You caught, something...
+	constexpr int FISHING_SPILL_BEER             = 171; //You spill your beer while bringing in your line.
+	constexpr int FISHING_LOST_BAIT              = 172; //You lost your bait!
+	constexpr int SPELL_FIZZLE                   = 173; //Your spell fizzles!
+	constexpr int MUST_EQUIP_ITEM                = 179; //You cannot use this item unless it is equipped.
+	constexpr int MISS_NOTE                      = 180; //You miss a note, bringing your song to a close!
+	constexpr int CANNOT_USE_ITEM                = 181; //Your race, class, or deity cannot use this item.
+	constexpr int ITEM_OUT_OF_CHARGES            = 182; //Item is out of charges.
+	constexpr int ALREADY_ON_A_MOUNT             = 189; //You are already on a mount.
+	constexpr int TARGET_NO_MANA                 = 191; //Your target has no mana to affect
+	constexpr int TARGET_GROUP_MEMBER            = 196; //You must first target a group member.
+	constexpr int SPELL_TOO_POWERFUL             = 197; //Your spell is too powerful for your intended target.
+	constexpr int INSUFFICIENT_MANA              = 199; //Insufficient Mana to cast this spell!
+	constexpr int SAC_TOO_LOW                    = 203; //This being is not a worthy sacrifice.
+	constexpr int SAC_TOO_HIGH                   = 204; //This being is too powerful to be a sacrifice.
+	constexpr int CANNOT_SAC_SELF                = 205; //You cannot sacrifice yourself.
+	constexpr int SILENCED_STRING                = 207; //You *CANNOT* cast spells, you have been silenced!
+	constexpr int CAST_DAYTIME                   = 208; //Spell can only be cast during the day.
+	constexpr int CAST_NIGHTTIME                 = 209; //Spell can only be cast during the night.
+	constexpr int CANNOT_AFFECT_PC               = 210; //That spell can not affect this target PC.
+	constexpr int SPELL_NEED_TAR                 = 214; //You must first select a target for this spell!
+	constexpr int SUMMON_ONLY_GROUP_CORPSE       = 215; //You must first target a living group member whose corpse you wish to summon.
+	constexpr int ONLY_ON_CORPSES                = 221; //This spell only works on corpses.
+	constexpr int CANT_DRAIN_SELF                = 224; //You can't drain yourself!
+	constexpr int CORPSE_NOT_VALID               = 230; //This corpse is not valid.
+	constexpr int CORPSE_TOO_OLD                 = 231; //This player cannot be resurrected. The corpse is too old.
+	constexpr int CAST_OUTDOORS                  = 234; //You can only cast this spell in the outdoors.
+	constexpr int SPELL_RECAST                   = 236; //Spell recast time not yet met.
+	constexpr int SPELL_RECOVERY                 = 237; //Spell recovery time not yet met.
+	constexpr int CANNOT_MEZ                     = 239; //Your target cannot be mesmerized.
+	constexpr int CANNOT_MEZ_WITH_SPELL          = 240; //Your target cannot be mesmerized (with this spell).
+	constexpr int IMMUNE_STUN                    = 241; //Your target is immune to the stun portion of this effect.
+	constexpr int IMMUNE_ATKSPEED                = 242; //Your target is immune to changes in its attack speed.
+	constexpr int IMMUNE_FEAR                    = 243; //Your target is immune to fear spells.
+	constexpr int IMMUNE_MOVEMENT                = 244; //Your target is immune to changes in its run speed.
+	constexpr int ONLY_ONE_PET                   = 246; //You cannot have more than one pet at a time.
+	constexpr int CANNOT_CHARM_YET               = 248; //Your target is too high of a level for your charm spell.
+	constexpr int CANNOT_AFFECT_NPC              = 251; //That spell can not affect this target NPC.
+	constexpr int FD_CAST_ON                     = 254; //You are no longer feigning death, because a spell hit you.
+	constexpr int SUSPEND_MINION_HAS_AGGRO       = 256; //Your pet is the focus of something's attention.
+	constexpr int NO_PET                         = 255; //You do not have a pet.
+	constexpr int GATE_FAIL                      = 260; //Your gate is too unstable, and collapses.
+	constexpr int CORPSE_CANT_SENSE              = 262; //You cannot sense any corpses for this PC in this zone.
+	constexpr int SPELL_NO_HOLD                  = 263; //Your spell did not take hold.
+	constexpr int CANNOT_CHARM                   = 267; //This NPC cannot be charmed.
+	constexpr int SPELL_NO_EFFECT                = 268; //Your target looks unaffected.
+	constexpr int NO_INSTRUMENT_SKILL            = 269; //Stick to singing until you learn to play this instrument.
+	constexpr int REGAIN_AND_CONTINUE            = 270; //You regain your concentration and continue your casting.
+	constexpr int SPELL_WOULDNT_HOLD             = 271; //Your spell would not have taken hold on your target.
+	constexpr int MISSING_SPELL_COMP             = 272; //You are missing some required spell components.
+	constexpr int INVIS_BEGIN_BREAK              = 275; //You feel yourself starting to appear.
+	constexpr int DISCIPLINE_CONLOST             = 278; //You lose the concentration to remain in your fighting discipline.
+	constexpr int REZ_REGAIN                     = 289; //You regain some experience from resurrection.
+	constexpr int DUP_LORE                       = 290; //Duplicate lore items are not allowed.
+	constexpr int TGB_ON                         = 293; //Target other group buff is *ON*.
+	constexpr int TGB_OFF                        = 294; //Target other group buff is *OFF*.
+	constexpr int DONT_SEE_TARGET                = 303; //I don't see anyone by that name around here...
+	constexpr int DISARMED_TRAP                  = 305; //You have disarmed the trap.
+	constexpr int LDON_SENSE_TRAP1               = 306; //You do not Sense any traps.
+	constexpr int TRADESKILL_NOCOMBINE           = 334; //You cannot combine these items in this container type!
+	constexpr int TRADESKILL_FAILED              = 336; //You lacked the skills to fashion the items together.
+	constexpr int TRADESKILL_TRIVIAL             = 338; //You can no longer advance your skill from making this item.
+	constexpr int TRADESKILL_SUCCEED             = 339; //You have fashioned the items together to create something new!
+	constexpr int EVADE_SUCCESS                  = 343; //You have momentarily ducked away from the main combat.
+	constexpr int EVADE_FAIL                     = 344; //Your attempts at ducking clear of combat fail.
+	constexpr int HIDE_FAIL                      = 345; //You failed to hide yourself.
+	constexpr int HIDE_SUCCESS                   = 346; //You have hidden yourself from view.
+	constexpr int SNEAK_SUCCESS                  = 347; //You are as quiet as a cat stalking its prey.
+	constexpr int SNEAK_FAIL                     = 348; //You are as quiet as a herd of running elephants.
+	constexpr int MEND_CRITICAL                  = 349; //You magically mend your wounds and heal considerable damage.
+	constexpr int MEND_SUCCESS                   = 350; //You mend your wounds and heal some damage.
+	constexpr int MEND_WORSEN                    = 351; //You have worsened your wounds!
+	constexpr int MEND_FAIL                      = 352; //You have failed to mend your wounds.
+	constexpr int LDON_SENSE_TRAP2               = 367; //You have not detected any traps.
+	constexpr int TRAP_TOO_FAR                   = 368; //You are too far away from that trap to affect it.
+	constexpr int FAIL_DISARM_DETECTED_TRAP      = 370; //You fail to disarm the detected trap.
+	constexpr int LOOT_LORE_ERROR                = 371; //You cannot loot this Lore Item. You already have one.
+	constexpr int PICK_LORE                      = 379; //You cannot pick up a lore item you already possess.
+	constexpr int POISON_TOO_HIGH                = 382; //This poison is too high level for you to apply.
+	constexpr int TAUNT_TOO_FAR                  = 386; //You are too far away from your target to taunt.
+	constexpr int CORPSE_TOO_FAR                 = 389; //The corpse is too far away to summon.
+	constexpr int CONSENT_DENIED                 = 390; //You do not have consent to summon that corpse.
+	constexpr int DISCIPLINE_RDY                 = 393; //You are ready to use a new discipline now.
+	constexpr int CONSENT_INVALID_NAME           = 397; //Not a valid consent name.
+	constexpr int CONSENT_NPC                    = 398; //You cannot consent NPC\'s.
+	constexpr int CONSENT_YOURSELF               = 399; //You cannot consent yourself.
+	constexpr int CONSENT_WAIT                   = 400; //You must wait 2 seconds between consents.
+	constexpr int SONG_NEEDS_DRUM                = 405; //You need to play a percussion instrument for this song
+	constexpr int SONG_NEEDS_WIND                = 406; //You need to play a wind instrument for this song
+	constexpr int SONG_NEEDS_STRINGS             = 407; //You need to play a stringed instrument for this song
+	constexpr int SONG_NEEDS_BRASS               = 408; //You need to play a brass instrument for this song
+	constexpr int AA_GAIN_ABILITY                = 410; //You have gained the ability "%T1" at a cost of %2 ability %T3.
+	constexpr int AA_IMPROVE                     = 411; //You have improved %T1 %2 at a cost of %3 ability %T4.
+	constexpr int TAUNT_SUCCESS                  = 412; //You taunt %1 to ignore others and attack you!
+	constexpr int AA_REUSE_MSG                   = 413; //You can use the ability %B1(1) again in %2 hour(s) %3 minute(s) %4 seconds.
+	constexpr int AA_REUSE_MSG2                  = 414; //You can use the ability %B1(1) again in %2 minute(s) %3 seconds.
+	constexpr int YOU_HEALED                     = 419; //%1 has healed you for %2 points of damage.
+	constexpr int FISHING_SUCCESS_FISH_NAME      = 421; //You caught %1!
+	constexpr int BEGINS_TO_GLOW                 = 422; //Your %1 begins to glow.
+	constexpr int ALREADY_INVIS                  = 423; //%1 tries to cast an invisibility spell on you, but you are already invisible.
+	constexpr int YOU_ARE_PROTECTED              = 424; //%1 tries to cast a spell on you, but you are protected.
+	constexpr int TARGET_RESISTED                = 425; //Your target resisted the %1 spell.
+	constexpr int YOU_RESIST                     = 426; //You resist the %1 spell!
+	constexpr int YOU_CRIT_HEAL                  = 427; //You perform an exceptional heal! (%1)
+	constexpr int YOU_CRIT_BLAST                 = 428; //You deliver a critical blast! (%1)
+	constexpr int SUMMONING_CORPSE               = 429; //Summoning your corpse.
+	constexpr int SUMMONING_CORPSE_OTHER         = 430; //Summoning %1's corpse.
+	constexpr int MISSING_SPELL_COMP_ITEM        = 433; //You are missing %1.
+	constexpr int OTHER_HIT_NONMELEE             = 434; //%1 was hit by non-melee for %2 points of damage.
+	constexpr int SPELL_WORN_OFF_OF              = 436; //Your %1 spell has worn off of %2.
+	constexpr int SPELL_WORN_OFF                 = 437; //Your %1 spell has worn off.
+	constexpr int PET_TAUNTING                   = 438; //Taunting attacker, Master.
+	constexpr int INTERRUPT_SPELL                = 439; //Your spell is interrupted.
+	constexpr int LOSE_LEVEL                     = 442; //You LOST a level! You are now level %1!
+	constexpr int GAIN_ABILITY_POINT             = 446; //You have gained an ability point! You now have %1 ability point%2.
+	constexpr int GAIN_LEVEL                     = 447; //You have gained a level! Welcome to level %1!
+	constexpr int LANG_SKILL_IMPROVED            = 449; //Your language skills have improved.
+	constexpr int OTHER_LOOTED_MESSAGE           = 466; //--%1 has looted a %2--
+	constexpr int LOOTED_MESSAGE                 = 467; //--You have looted a %1--
+	constexpr int FACTION_WORST                  = 469; //Your faction standing with %1 could not possibly get any worse.
+	constexpr int FACTION_WORSE                  = 470; //Your faction standing with %1 got worse.
+	constexpr int FACTION_BEST                   = 471; //Your faction standing with %1 could not possibly get any better.
+	constexpr int FACTION_BETTER                 = 472; //Your faction standing with %1 got better.
+	constexpr int PET_REPORT_HP                  = 488; //I have %1 percent of my hit points left.
+	constexpr int PET_NO_TAUNT                   = 489; //No longer taunting attackers, Master.
+	constexpr int PET_DO_TAUNT                   = 490; //Taunting attackers as normal, Master.
+	constexpr int CORPSE_REZ_TIME_HOUR           = 491; //This corpse's resurrection time will expire in %1 hour(s) %2 minute(s) %3 seconds.
+	constexpr int CORPSE_REZ_TIME_MINUTE         = 492; //This corpse's resurrection time will expire in %1 minute(s) %2 seconds.
+	constexpr int CORPSE_DECAY_TIME_DAY          = 493; //This corpse will decay in %1 day(s) %2 hour(s) %3 minute(s) %4 seconds.
+	constexpr int CORPSE_DECAY_TIME_HOUR         = 494; //This corpse will decay in %1 hour(s) %2 minute(s) %3 seconds.
+	constexpr int CORPSE_DECAY_TIME_MINUTE       = 495; //This corpse will decay in %1 minute(s) %2 seconds.
+	constexpr int DISC_LEVEL_ERROR               = 503; //You must be a level %1 ... to use this discipline.
+	constexpr int DISCIPLINE_CANUSEIN            = 504; //You can use a new discipline in %1 minutes %2 seconds.
+	constexpr int SHARE_MONEY                    = 511; //%1 shares money with the group.
+	constexpr int PVP_ON                         = 552; //You are now player kill and follow the ways of Discord.
+	constexpr int GENERIC_STRINGID_SAY           = 554; //%1 says '%T2'
+	constexpr int CANNOT_WAKE                    = 555; //%1 tells you, 'I am unable to wake %2, master.'
+	constexpr int SUMMONING_CORPSE_ZONE          = 596; //Summoning %1's corpse(s).
+	constexpr int TASK_NOT_RIGHT_LEVEL           = 615; //You are not at the right level for this task.
+	constexpr int INVITE_GROUP_LEADER            = 679; //To invite another group into yours, please invite the leader of the other group.
+	constexpr int PET_HOLD_SET_ON                = 698; //The pet hold mode has been set to on.
+	constexpr int PET_HOLD_SET_OFF               = 699; //The pet hold mode has been set to off.
+	constexpr int PET_FOCUS_SET_ON               = 700; //The pet focus mode has been set to on.
+	constexpr int PET_FOCUS_SET_OFF              = 701; //The pet focus mode has been set to off.
+	constexpr int PET_SPELLHOLD_SET_ON           = 702; //The pet spellhold mode has been set to on.
+	constexpr int PET_SPELLHOLD_SET_OFF          = 703; //The pet spellhold mode has been set to off.
+	constexpr int GUILD_NAME_IN_USE              = 711; //You cannot create a guild with that name, that guild already exists on this server.
+	constexpr int PARCEL_DELAY                   = 734; //%1 tells you, 'You must give me a chance to send the last parcel before I can send another!'
+	constexpr int PARCEL_DUPLICATE_DELETE        = 737; //Duplicate lore items are not allowed! Your duplicate %1 has been deleted!
+	constexpr int PARCEL_DELIVER_3               = 741; //%1 told you, 'I will deliver the stack of %2 %3 to %4 as soon as possible!'
+	constexpr int TRADER_MODE_FAILED_ROF2        = 785; //Your attempt to become a trader has failed.
+	constexpr int PARCEL_INV_FULL                = 790; //%1 tells you, 'Your inventory appears full!  Unable to retrieve parceled item.'
+	constexpr int AA_CAP                         = 1000; //You have reached the AA point cap, and cannot gain any further experience until some of your stored AA point pool is used.
+	constexpr int GM_GAINXP	                     = 1002; //[GM] You have gained %1 AXP and %2 EXP (%3).
+	constexpr int MALE_SLAYUNDEAD                = 1007; //%1's holy blade cleanses his target!(%2)
+	constexpr int FEMALE_SLAYUNDEAD              = 1008; //%1's holy blade cleanses her target!(%2)
+	constexpr int FINISHING_BLOW                 = 1009; //%1 scores a Finishing Blow!!
+	constexpr int ASSASSINATES                   = 1016; //%1 ASSASSINATES their victim!!
+	constexpr int CRIPPLING_BLOW                 = 1021; //%1 lands a Crippling Blow!(%2)
+	constexpr int STAGGERS                       = 1022; //%1 staggers.
+	constexpr int CRITICAL_HIT                   = 1023; //%1 scores a critical hit! (%2)
+	constexpr int DEADLY_STRIKE                  = 1024; //%1 scores a Deadly Strike!(%2)
+	constexpr int RESISTS_URGE                   = 1025; //%1 resists their urge to flee.
+	constexpr int BERSERK_START                  = 1027; //%1 goes into a berserker frenzy!
+	constexpr int DEATH_PACT                     = 1028; //%1's death pact has been benevolently fulfilled!
+	constexpr int DIVINE_INTERVENTION            = 1029; //%1 has been rescued by divine intervention!
+	constexpr int BERSERK_END                    = 1030; //%1 is no longer berserk.
+	constexpr int GATES                          = 1031; //%1 Gates.
+	constexpr int GENERIC_SAY                    = 1032; //%1 says '%2'
+	constexpr int OTHER_REGAIN_CAST              = 1033; //%1 regains concentration and continues casting.
+	constexpr int GENERIC_SHOUT                  = 1034; //%1 shouts '%2'
+	constexpr int GENERIC_EMOTE                  = 1036; //%1 %2
+	constexpr int OTHER_CRIT_HEAL                = 1039; //%1 performs an exceptional heal! (%2)
+	constexpr int OTHER_CRIT_BLAST               = 1040; //%1 delivers a critical blast! (%2)
+	constexpr int NPC_ENRAGE_START               = 1042; //%1 has become ENRAGED.
+	constexpr int NPC_ENRAGE_END                 = 1043; //%1 is no longer enraged.
+	constexpr int NPC_RAMPAGE                    = 1044; //%1 goes on a RAMPAGE!
+	constexpr int NPC_FLURRY                     = 1045; //%1 executes a FLURRY of attacks on %2!
+	constexpr int DISCIPLINE_FEARLESS            = 1076; //%1 becomes fearless.
+	constexpr int DUEL_FINISHED                  = 1088; //dont know text
+	constexpr int EATING_MESSAGE                 = 1091; //Chomp, chomp, chomp... %1 takes a bite from a %2.
+	constexpr int DRINKING_MESSAGE               = 1093; //Glug, glug, glug... %1 takes a drink from a %2.
+	constexpr int SUCCESSFUL_TAUNT               = 1095; //I'll teach you to interfere with me %3.
+	constexpr int TRADE_BACK                     = 1105; //I have no need for this %3, you can have it back.
+	constexpr int TRADE_BAD_FACTION1             = 1110; //Oh look..a talking lump of refuse..how novel!
+	constexpr int TRADE_BAD_FACTION2             = 1111; //Is that your BREATH.. or did something die in here..now go away!
+	constexpr int TRADE_BAD_FACTION3             = 1112; //I didn't know Slime could speak common..go back to the sewer before I lose my temper.
+	constexpr int TRADE_BAD_FACTION4             = 1113; //I wonder how much I could get for the tongue of a blithering fool..leave before I decide to find out for myself.
+	constexpr int PET_SIT_STRING                 = 1130; //Changing position, Master.
+	constexpr int PET_CALMING                    = 1131; //Sorry, Master..calming down.
+	constexpr int PET_FOLLOWING                  = 1132; //Following you, Master.
+	constexpr int PET_GUARDME_STRING             = 1133; //Guarding you, Master.
+	constexpr int PET_GUARDINGLIFE               = 1134; //Guarding with my life..oh splendid one.
+	constexpr int PET_GETLOST_STRING             = 1135; //As you wish, oh great one.
+	constexpr int PET_LEADERIS                   = 1136; //My leader is %3.
+	constexpr int I_FOLLOW_NOONE                 = 1137; //I follow no one.
+	constexpr int PET_ON_HOLD                    = 1138; //Waiting for your order to attack, Master.
+	constexpr int NOT_LEGAL_TARGET               = 1139; //I beg forgiveness, Master. That is not a legal target.
+	constexpr int MERCHANT_BUSY                  = 1143; //I'm sorry, I am busy right now.
+	constexpr int MERCHANT_GREETING              = 1144; //Welcome to my shop, %3.
+	constexpr int MERCHANT_HANDY_ITEM1           = 1145; //Hello there, %3. How about a nice %4?
+	constexpr int MERCHANT_HANDY_ITEM2           = 1146; //Greetings, %3. You look like you could use a %4.
+	constexpr int MERCHANT_HANDY_ITEM3           = 1147; //Hi there %3, just browsing? Have you seen the %4 I just got in?
+	constexpr int MERCHANT_HANDY_ITEM4           = 1148; //Welcome to my shop, %3. You would probably find a %4 handy.
+	constexpr int WONT_SELL_RACE1                = 1154; //I don't like to speak to %B3(12) much less sell to them!
+	constexpr int WONT_SELL_CLASS1               = 1155; //It's %B3(13) like you that are ruining the continent...get OUT!
+	constexpr int WONT_SELL_CLASS2               = 1156; //Isn't there some kind of ordinance against %B3(13) crawling out from under their rocks?
+	constexpr int WONT_SELL_CLASS3               = 1157; //%B3(13) like you don't have any place in my shop..now make way for welcome customers.
+	constexpr int WONT_SELL_CLASS4               = 1158; //I thought scumbag %B3(13) like you just stole whatever they need.  Now GET OUT!
+	constexpr int WONT_SELL_CLASS5               = 1159; //I don't have anything to do with %B3(13)..move along.
+	constexpr int WONT_SELL_NONSTDRACE1          = 1160; //I don't have anything to do with your little gang..move along.
+	constexpr int WONT_SELL_RACE2                = 1161; //It's not enough that you %B3(12) have ruined your own land. Now get lost!
+	constexpr int WONT_SELL_RACE3                = 1162; //I have something here that %B3(12) use..let me see...it's the EXIT, now get LOST!
+	constexpr int WONT_SELL_RACE4                = 1163; //Don't you %B3(12) have your own merchants?  Whatever, I'm not selling anything to you!
+	constexpr int WONT_SELL_NONSTDRACE2          = 1164; //Members of your little "club" have ruined things around here..get lost!
+	constexpr int WONT_SELL_NONSTDRACE3          = 1165; //I don't have anything to do with your damned club..move along.
+	constexpr int WONT_SELL_DEEDS1               = 1166; //Creatures like you make me sick..the things you do..get out of here Pagan!
+	constexpr int WONT_SELL_DEEDS2               = 1167; //After all the things you've done..the things you believe in..leave my shop!
+	constexpr int WONT_SELL_DEEDS3               = 1168; //Actions speak louder than beliefs, and I despise both your actions and all you believe in.
+	constexpr int WONT_SELL_DEEDS4               = 1169; //Get out of here now!
+	constexpr int WONT_SELL_DEEDS5               = 1170; //I am tolerant by nature..but infidels like you push me past my limit..get out!
+	constexpr int WONT_SELL_DEEDS6               = 1171; //I cannot abide you or your actions against all that is right..BE GONE!
+	constexpr int AA_POINT                       = 1197; //point
+	constexpr int MERCHANT_CLOSED_ONE            = 1199; //I don't have time for that now.
+	constexpr int MERCHANT_CLOSED_TWO            = 1200; //Can't you see I'm doing something here?
+	constexpr int MERCHANT_CLOSED_THREE          = 1201; //I am not open for business right now.
+	constexpr int AA_POINTS                      = 1215; //points
+	constexpr int SPELL_FIZZLE_OTHER             = 1218; //%1's spell fizzles!
+	constexpr int MISSED_NOTE_OTHER              = 1219; //A missed note brings %1's song to a close!
+	constexpr int SPELL_LEVEL_REQ                = 1226; //This spell only works on people who are level %1 and under.
+	constexpr int CORPSE_DECAY_NOW               = 1227; //This corpse is waiting to expire.
+	constexpr int CORPSE_ITEM_LOST               = 1228; //Your items will no longer stay with you when you respawn on death. You will now need to return to your corpse for your items.
+	constexpr int CORPSE_EXP_LOST                = 1229; //You will now lose experience when you die.
+	constexpr int FLICKERS_PALE_LIGHT            = 1230; //Your %1 flickers with a pale light.
+	constexpr int PULSES_WITH_LIGHT              = 1231; //Your %1 pulses with light as your vision sharpens.
+	constexpr int FEEDS_WITH_POWER               = 1232; //Your %1 feeds you with power.
+	constexpr int POWER_DRAIN_INTO               = 1233; //You feel your power drain into your %1.
+	constexpr int SEEMS_DRAINED                  = 1234; //Your %1 seems drained of power.
+	constexpr int ALIVE_WITH_POWER               = 1235; //Your %1 feels alive with power.
+	constexpr int SPARKLES                       = 1236; //Your %1 sparkles.
+	constexpr int GROWS_DIM                      = 1237; //Your %1 grows dim.
+	constexpr int BEGINS_TO_SHINE                = 1238; //Your %1 begins to shine.
+	constexpr int CANT_FIND_PLAYER               = 1276; //I can't find a player named %1!
+	constexpr int SURNAME_REJECTED               = 1374; //Your new surname was rejected. Please try a different name.
+	constexpr int ALREADY_SOLD                   = 1376; //The item you were interested in has already been sold.
+	constexpr int GUILD_DISBANDED                = 1377; //Your guild has been disbanded!  You are no longer a member of any guild.
+	constexpr int DUEL_DECLINE                   = 1383; //%1 has declined your challenge to duel to the death.
+	constexpr int DUEL_ACCEPTED                  = 1384; //%1 has already accepted a duel with someone else.
+	constexpr int DUEL_CONSIDERING               = 1385; //%1 is considering a duel with someone else.
+	constexpr int PLAYER_SUMMONED                = 1393; //You have been summoned!
+	constexpr int PLAYER_REGAIN                  = 1394; //You have control of yourself again.
+	constexpr int REZZ_ALREADY_PENDING           = 1379; //You were unable to restore the corpse to life, but you may have success with a later attempt.
+	constexpr int IN_USE                         = 1406; //Someone else is using that. Try again later.
+	constexpr int DUEL_FLED                      = 1408; //%1 has defeated %2 in a duel to the death! %3 has fled like a cowardly dog!
+	constexpr int MEMBER_OF_YOUR_GUILD           = 1429;
+	constexpr int OFFICER_OF_YOUR_GUILD          = 1430;
+	constexpr int LEADER_OF_YOUR_GUILD           = 1431;
+	constexpr int TRADE_HAS_BEEN_CANCELLED       = 1449;
+	constexpr int RECEIVED_PLATINUM              = 1452; //You receive %1 Platinum from %2.
+	constexpr int RECEIVED_GOLD                  = 1453; //You receive %1 Gold from %2.
+	constexpr int RECEIVED_SILVER                = 1454; //You receive %1 Silver from %2.
+	constexpr int RECEIVED_COPPER                = 1455; //You receive %1 Copper from %2.
+	constexpr int STRING_FEIGNFAILED             = 1456; //%1 has fallen to the ground.
+	constexpr int DOORS_SUCCESSFUL_PICK          = 1457; //You successfully picked the lock.
+	constexpr int PLAYER_CHARMED                 = 1461; //You lose control of yourself!
+	constexpr int TRADER_BUSY                    = 1468; //That Trader is currently with a customer. Please wait until their transaction is finished.
+	constexpr int SENSE_CORPSE_DIRECTION         = 1563; //You sense a corpse in this direction.
+	constexpr int DUPE_LORE_MERCHANT             = 1573; //%1 tells you, 'You already have the lore item, %2, on your person, on your shroud, in the bank, in a real estate, or as an augment in another item.  You cannot have more than one of a particular lore item at a time.'
+	constexpr int QUEUED_TELL                    = 2458; //[queued]
+	constexpr int QUEUE_TELL_FULL                = 2459; //[zoing and queue is full]
+	constexpr int TRADER_BUSY_TWO                = 3192; //Sorry, that action cannot be performed while trading.
+	constexpr int SUSPEND_MINION_UNSUSPEND       = 3267; //%1 tells you, 'I live again...'
+	constexpr int SUSPEND_MINION_SUSPEND         = 3268; //%1 tells you, 'By your command, master.'
+	constexpr int ONLY_SUMMONED_PETS             = 3269; //3269 This effect only works with summoned pets.
+	constexpr int SUSPEND_MINION_FIGHTING        = 3270; //Your pet must be at peace, first.
+	constexpr int SHIELD_TARGET_NPC              = 3278; //You must first target a living Player Character.
+	constexpr int ALREADY_SHIELDED               = 3279; //Either you or your target is already being shielded.
+	constexpr int ALREADY_SHIELDING              = 3280; //Either you or your target is already shielding another.
+	constexpr int START_SHIELDING                = 3281; //%1 begins to use %2 as a living shield!
+	constexpr int END_SHIELDING                  = 3282; //%1 ceases protecting %2.
+	constexpr int OVER_AA_CAP                    = 3374; //Warning: You are currently over the earned Advancement point limit of %1. Please spend some of your stored AA points. The NEXT time you zone all of your AA points over %2 will be deleted. You MUST spend the extra points now.
+	constexpr int TRADESKILL_MISSING_ITEM        = 3455; //You are missing a %1.
+	constexpr int TRADESKILL_MISSING_COMPONENTS  = 3456; //Sorry, but you don't have everything you need for this recipe in your general inventory.
+	constexpr int TRADESKILL_LEARN_RECIPE        = 3457; //You have learned the recipe %1!
+	constexpr int TASK_UPDATED                   = 3471; //Your task '%1' has been updated.
+	constexpr int YOU_ASSIGNED_TASK              = 3472; //You have been assigned the task '%1'.
+	constexpr int DZ_YOU_BELONG                  = 3500; //You cannot create this expedition since you already belong to another.
+	constexpr int DZ_REPLAY_YOU                  = 3501; //You cannot create this expedition for another %1d:%2h:%3m since you have recently played here.
+	constexpr int DZ_PLAYER_COUNT                = 3503; //You do not meet the player count requirement.  You have %1 players.  You must have at least %2 and no more than %3.
+	constexpr int DZ_REPLAY_OTHER                = 3504; //%1 cannot be added to this expedition for another %2D:%3H:%4M since they have recently played in this area.
+	constexpr int DZ_AVAILABLE                   = 3507; //%1 is now available to you.
+	constexpr int DZADD_INVITE                   = 3508; //Sending an invitation to: %1.
+	constexpr int DZ_PREVENT_ENTERING            = 3510; //A strange magical presence prevents you from entering.  It's too dangerous to enter at the moment.
+	constexpr int DZADD_INVITE_FAIL              = 3511; //%1 could not be invited to join you.
+	constexpr int DZ_NO_LEADER_INFO              = 3512; //Unable to retrieve information on the leader to check permissions.
+	constexpr int DZ_NOT_LEADER                  = 3513; //You are not the expedition leader, only %1 can issue this command.
+	constexpr int DZ_NOT_MEMBER                  = 3514; //%1 is not a member of this expedition.
+	constexpr int DZ_REMOVED                     = 3516; //%1 has been removed from %2.
+	constexpr int DZSWAP_INVITE                  = 3517; //Sending an invitation to: %1.  They must accept in order to swap party members.
+	constexpr int DZ_LEADER_OFFLINE              = 3518; //%1 is not currently online.  You can only transfer leadership to an online member of the expedition you are in.
+	constexpr int DZ_TIMER                       = 3519; //You have %1d:%2h:%3m remaining until you may enter %4.
+	constexpr int DZ_LEADER_NAME                 = 3520; //%1 has been made the leader for this expedition.
+	constexpr int DZ_LEADER_YOU                  = 3521; //You have been made the leader of this expedition.
+	constexpr int DZ_INVITE_ACCEPTED             = 3522; //%1 has accepted your offer to join your expedition.
+	constexpr int DZ_ADDED                       = 3523; //%1 has been added to %2.
+	constexpr int DZ_INVITE_ERROR                = 3524; //%1 accepted your offer to join your expedition but could not due to error(s).
+	constexpr int DZ_INVITE_DECLINED             = 3525; //%1 has declined your offer to join your expedition.
+	constexpr int DZ_INVITED                     = 3527; //%1 has asked you to join the expedition:  %2.        Would you like to join?
+	constexpr int DZ_WAY_IS_BLOCKED              = 3528; //The way is blocked to you.  Perhaps you would be able to enter if there was a reason to come here.
+	constexpr int DZ_NO_TIMERS                   = 3529; //You have no outstanding timers.
+	constexpr int DZ_MINUTES_REMAIN              = 3551; //You only have %1 minutes remaining before this expedition comes to an end.
+	constexpr int DZ_LEADER                      = 3552; //Expedition Leader: %1
+	constexpr int DZ_MEMBERS                     = 3553; //Expedition Members: %1
+	constexpr int DZ_EVENT_TIMER                 = 3561; //%1 cannot be added to this expedition since they have recently experienced %2.  They must wait another %3D:%4H:%5M until they can experience it again.  They may be added to the expedition later, once %2 has been completed.
+	constexpr int LOOT_NOT_ALLOWED               = 3562; //You are not allowed to loot the item: %1.
+	constexpr int DZ_UNABLE_RETRIEVE_LEADER      = 3583; //Unable to retrieve dynamic zone leader to check permissions.
+	constexpr int DZADD_NOT_ALLOWING             = 3585; //The expedition is not allowing players to be added.
+	constexpr int DZADD_NOT_ONLINE               = 3586; //%1 is not currently online.  A player needs to be online to be added to a Dynamic Zone
+	constexpr int DZADD_EXCEED_MAX               = 3587; //You can not add another player since you currently have the maximum number of players allowed (%1) in this zone.
+	constexpr int DZADD_ALREADY_PART             = 3588; //You can not add %1 since they are already part of this zone.
+	constexpr int DZADD_LEAVE_ZONE               = 3589; //You can not add %1 since they first need to leave the zone before being allowed back in.
+	constexpr int DZADD_ALREADY_OTHER            = 3590; //%1 can not be added to this dynamic zone since they are already assigned to another dynamic zone.
+	constexpr int DZADD_REPLAY_TIMER             = 3591; //%1 can not be added to this dynamic zone for another %2D:%3H:%4M since they have recently played this zone.
+	constexpr int DZADD_EVENT_TIMER              = 3592; //%1 can not be added to this dynamic zone since they have recently experienced %2.  They must wait for another %3D:%4H:%5M, or until event %2 has occurred.
+	constexpr int DZADD_PENDING                  = 3593; //%1 currently has an outstanding invitation to join this Dynamic Zone.
+	constexpr int DZADD_PENDING_OTHER            = 3594; //%1 currently has an outstanding invitation to join another Dynamic Zone.  Players may only have one invitation outstanding.
+	constexpr int DZSWAP_CANNOT_REMOVE           = 3595; //%1 can not be removed from this dynamic zone since they are not assigned to it.
+	constexpr int NOT_YOUR_TRAP                  = 3671; //You cannot remove this, you are only allowed to remove traps you have set.
+	constexpr int NO_CAST_ON_PET                 = 4045; //You cannot cast this spell on your pet.
+	constexpr int REWIND_WAIT                    = 4059; //You must wait a bit longer before using the rewind command again.
+	constexpr int CORPSEDRAG_LIMIT               = 4061; //You are already dragging as much as you can!
+	constexpr int CORPSEDRAG_ALREADY             = 4062; //You are already dragging %1.
+	constexpr int CORPSEDRAG_SOMEONE_ELSE        = 4063; //Someone else is dragging %1.
+	constexpr int CORPSEDRAG_BEGIN               = 4064; //You begin to drag %1.
+	constexpr int CORPSEDRAG_STOPALL             = 4065; //You stop dragging the corpses.
+	constexpr int CORPSEDRAG_STOP                = 4066; //You stop dragging the corpse.
+	constexpr int SOS_KEEPS_HIDDEN               = 4086; //Your Shroud of Stealth keeps you hidden from watchful eyes.␣␣
+	constexpr int DISARM_NO_TARGET               = 4583; //You can't use disarm on that.
+	constexpr int TARGET_TOO_CLOSE               = 4602; //You are too close to your target. Get farther away.
+	constexpr int WHOALL_NO_RESULTS              = 5029; //There are no players in EverQuest that match those who filters.
+	constexpr int TELL_QUEUED_MESSAGE            = 5045; //You told %1 '%T2. %3'
+	constexpr int TOLD_NOT_ONLINE                = 5046; //%1 is not online at this time.
+	constexpr int RAID_IS_FULL                   = 5048; //The raid is full.
+	constexpr int ZONING_NO_EXPANSION            = 5052; //The zone that you are attempting to enter is part of an expansion that you do not yet own.  You may need to return to the Login screen and enter an account key for that expansion.  If you have received this message in error, please /petition or send an email to EQAccounts@soe.sony.com
+	constexpr int PETITION_NO_DELETE             = 5053; //You do not have a petition in the queue.
+	constexpr int PETITION_DELETED               = 5054; //Your petition was successfully deleted.
+	constexpr int ALREADY_IN_RAID                = 5060; //%1 is already in a raid.
+	constexpr int ALREADY_IN_YOUR_RAID           = 5077; //%1 is already in your raid.
+	constexpr int NOT_IN_YOUR_RAID               = 5082; //%1 is not in your raid.
+	constexpr int GAIN_RAIDEXP                   = 5085; //You gained raid experience!
+	constexpr int ALREADY_IN_GRP_RAID            = 5088; //% 1 rejects your invite because they are in a raid and you are not in theirs, or they are a raid group leader
+	constexpr int DUNGEON_SEALED                 = 5141; //The gateway to the dungeon is sealed off to you.  Perhaps you would be able to enter if you needed to adventure there.
+	constexpr int ADVENTURE_COMPLETE             = 5147; //You received %1 points for successfully completing the adventure.
+	constexpr int SUCCOR_FAIL                    = 5169; //The portal collapes before you can escape!
+	constexpr int PARCEL_STATUS_2                = 5433; //You currently have % 1 parcels in your mail and are % 2 parcels over the limit of % 3!If you do not retrieve at least % 2 parcels before you logout, they will be lost!
+	constexpr int PARCEL_STATUS_1                = 5434; //You currently have % 1 parcels in your mail and are 1 parcel over the limit of % 2!If you do not retrieve at least 1 parcel before you logout, it will be lost!
+	constexpr int NO_PROPER_ACCESS               = 5410; //You don't have the proper access rights.
+	constexpr int AUGMENT_RESTRICTED             = 5480; //The item does not satisfy the augment's restrictions.
+	constexpr int PET_ATTACKING                  = 5501; //%1 tells you, 'Attacking %2 Master.'
+	constexpr int AVOID_STUNNING_BLOW            = 5753; //You avoid the stunning blow.
+	constexpr int FATAL_BOW_SHOT                 = 5745; //%1 performs a FATAL BOW SHOT!!
+	constexpr int SUSPECT_SEES_YOU               = 5746; //You suspect that this being can see you.
+	constexpr int MELEE_SILENCE                  = 5806; //You *CANNOT* use this melee ability, you are suffering from amnesia!
+	constexpr int DISCIPLINE_REUSE_MSG           = 5807; //You can use the ability %1 again in %2 hour(s) %3 minute(s) %4 seconds.
+	constexpr int DISCIPLINE_REUSE_MSG2          = 5808; //You can use the ability %1 again in %2 minute(s) %3 seconds.
+	constexpr int FAILED_TAUNT                   = 5811; //You have failed to taunt your target.
+	constexpr int PHYSICAL_RESIST_FAIL           = 5817; //Your target avoided your %1 ability.
+	constexpr int AA_NO_TARGET                   = 5825; //You must first select a target for this ability!
+	constexpr int YOU_RECEIVE                    = 5941; //You receive %1.
+	constexpr int NO_TASK_OFFERS                 = 6009; //Sorry %3, I don't have anything for someone with your abilities.
+	constexpr int MAX_ACTIVE_TASKS               = 6010; //Sorry %3, you already have the maximum number of active tasks.
+	constexpr int TASK_REQUEST_COOLDOWN_TIMER    = 6011; //Sorry, %3, but you can't request another task for %4 minutes and %5 seconds.
+	constexpr int FORAGE_MASTERY                 = 6012; //Your forage mastery has enabled you to find something else!
+	constexpr int BUYER_WELCOME                  = 6065; //There are %1 Buyers waiting to purchase your loot.  Type /barter to search for them, or use /buyer to set up your own Buy Lines.
+	constexpr int BUYER_GREETING                 = 6070; //%1 greets you, '%2'
+	constexpr int GUILD_BANK_CANNOT_DEPOSIT      = 6097; // Cannot deposit this item. Containers must be empty, and only one of each LORE and no NO TRADE or TEMPORARY items may be deposited.
+	constexpr int GUILD_BANK_FULL                = 6098; // There is no more room in the Guild Bank.
+	constexpr int GUILD_BANK_TRANSFERRED         = 6100; // '%1' transferred to Guild Bank from Deposits.
+	constexpr int GUILD_BANK_EMPTY_HANDS         = 6108; // You must empty your hands to withdraw from the Guild Bank.
+	constexpr int EVOLVE_ITEM_EVOLVED            = 6145; //Your %1 has evolved!
+	constexpr int EVOLVE_DETAILS                 = 6146; //Evolving: Level %1/%2 %3%% %4
+	constexpr int EVOLVE_LEVEL_LIMIT             = 6147; //Your %1 can not evolve until you reach level %2.
+	constexpr int EVOLVE_XP_TXFR_CONFIRM         = 6148; //Are you sure you want to transfer experience between these two items?
+	constexpr int EVOLVE_XP_TXFRD                = 6149; //Your item's experience has been transferred!
+	constexpr int TRADESKILL_COMBINE_LORE        = 6199; // Combine would result in a LORE item (%1) you already possess.
+	constexpr int TRANSFORM_FAILED               = 6326; //This mold cannot be applied to your %1.
+	constexpr int TRANSFORM_COMPLETE             = 6327; //You have successfully transformed your %1.
+	constexpr int DETRANSFORM_FAILED             = 6341; //%1 has no transformation that can be removed.
+	constexpr int GUILD_PERMISSION_FAILED        = 6418; //You do not have permission to change access options.
+	constexpr int PARCEL_DELIVERY_ARRIVED        = 6465; //You have received a new parcel delivery!
+	constexpr int PARCEL_DELIVERY                = 6466; //%1 tells you, 'I will deliver the %2 to %3 as soon as possible!'
+	constexpr int PARCEL_UNKNOWN_NAME            = 6467; //%1 tells you, 'Unfortunately, I don't know anyone by the name of %2. Here is your %3 back.''
+	constexpr int PARCEL_DELIVERED               = 6471; //%1 hands you the %2 that was sent from %3.
+	constexpr int PARCEL_DELIVERED_2             = 6472; //%1 hands you the stack of %2 %3 that was sent from %4.
+	constexpr int GENERIC_STRING                 = 6688; //%1 (used to any basic message)
+	constexpr int SENTINEL_TRIG_YOU              = 6724; //You have triggered your sentinel.
+	constexpr int SENTINEL_TRIG_OTHER            = 6725; //%1 has triggered your sentinel.
+	constexpr int TRADER_MODE_OFF                = 6741; //Bazaar Trader Mode *OFF*
+	constexpr int TRADER_MODE_ON                 = 6742; //Bazaar Trader Mode *ON*
+	constexpr int TRADER_SET_PRICE               = 6754; //To become a merchant you must assign a price to an item in your list. Do this by selecting an item, then selecting a money amount, and then clicking set price.
+	constexpr int IDENTIFY_SPELL                 = 6765; //Item Lore: %1.
+	constexpr int PET_NOW_HOLDING                = 6834; //Now holding, Master.  I will not start attacks until ordered.
+	constexpr int PET_ON_GHOLD                   = 6843; //Pet greater hold has been set to on.
+	constexpr int PET_OFF_GHOLD                  = 6846; //Pet greater hold has been set to off.
+	constexpr int PET_GHOLD_ON_MSG               = 6847; //Now greater holding master.  I will only attack something new if ordered.
+	constexpr int PET_ON_REGROUPING              = 6854; //Now regrouping, master.
+	constexpr int PET_OFF_REGROUPING             = 6855; //No longer regrouping, master.
+	constexpr int BUFF_NOT_BLOCKABLE             = 7608; //You cannot block this effect.
+	constexpr int LDON_DONT_KNOW_TRAPPED         = 7552; //You do not know if this object is trapped.
+	constexpr int LDON_HAVE_DISARMED             = 7553; //You have disarmed %1!
+	constexpr int LDON_ACCIDENT_SETOFF           = 7554; //You accidentally set off the trap!
+	constexpr int LDON_HAVE_NOT_DISARMED         = 7555; //You have not disarmed %1.
+	constexpr int LDON_ACCIDENT_SETOFF2          = 7556; //You accidentally set off the trap!
+	constexpr int LDON_CERTAIN_TRAP              = 7557; //You are certain that %1 is trapped.
+	constexpr int LDON_CERTAIN_NOT_TRAP          = 7558; //You are certain that %1 is not trapped.
+	constexpr int LDON_CANT_DETERMINE_TRAP       = 7559; //You are unable to determine if %1 is trapped.
+	constexpr int LDON_PICKLOCK_SUCCESS          = 7560; //You have successfully picked %1!
+	constexpr int LDON_PICKLOCK_FAILURE          = 7561; //You have failed to pick %1.
+	constexpr int LDON_STILL_LOCKED              = 7562; //You cannot open %1, it is locked.
+	constexpr int LDON_BASH_CHEST                = 7563; //%1 try to %2 %3, but do no damage.
+	constexpr int DOORS_NO_PICK                  = 7564; //You must have a lock pick in your inventory to do this.
+	constexpr int LDON_NO_LOCKPICK               = 7564; //You must have a lock pick in your inventory to do this.
+	constexpr int LDON_WAS_NOT_LOCKED            = 7565; //%1 was not locked.
+	constexpr int LDON_WAS_NOT_TRAPPED           = 7566; //%1 was not trapped
+	constexpr int GAIN_SINGLE_AA_SINGLE_AA       = 8019; //You have gained an ability point!  You now have %1 ability point.
+	constexpr int GAIN_SINGLE_AA_MULTI_AA        = 8020; //You have gained an ability point!  You now have %1 ability points.
+	constexpr int GAIN_MULTI_AA_MULTI_AA         = 8021; //You have gained %1 ability point(s)!  You now have %2 ability point(s).
+	constexpr int GAIN_GROUP_LEADERSHIP_POINT    = 8585; //
+	constexpr int GAIN_RAID_LEADERSHIP_POINT     = 8589; //
+	constexpr int MAX_GROUP_LEADERSHIP_POINTS    = 8584; //
+	constexpr int MAX_RAID_LEADERSHIP_POINTS     = 8591; //
+	constexpr int LEADERSHIP_EXP_ON	             = 8653; //
+	constexpr int LEADERSHIP_EXP_OFF             = 8654; //
+	constexpr int CURRENT_SPELL_EFFECTS          = 8757; //%1's current spell effects:
+	constexpr int MAX_MAIN_RAID_ASSISTERS        = 8782; //Max number of main assists reached (3)
+	constexpr int MAX_MAIN_RAID_MARKERS          = 8783; //Max number of main markers reached (3)
+	constexpr int NOT_DELEGATED_MARKER           = 8794; //You have not been delegated Raid Mark
+	constexpr int GAIN_GROUP_LEADERSHIP_EXP      = 8788; //
+	constexpr int GAIN_RAID_LEADERSHIP_EXP       = 8789; //
+	constexpr int BUFF_MINUTES_REMAINING         = 8799; //%1 (%2 minutes remaining)
+	constexpr int RAID_NO_LONGER_MARKED          = 8801; //%1 is no longer marked
+	constexpr int YOU_HAVE_BEEN_GIVEN            = 8994; //You have been given: %1
+	constexpr int NO_MORE_TRAPS                  = 9002; //You have already placed your maximum number of traps.
+	constexpr int FEAR_TOO_HIGH                  = 9035; //Your target is too high of a level for your fear spell.
+	constexpr int SLOW_MOSTLY_SUCCESSFUL         = 9029; //Your spell was mostly successful.
+	constexpr int SLOW_PARTIALLY_SUCCESSFUL      = 9030; // Your spell was partially successful.
+	constexpr int SLOW_SLIGHTLY_SUCCESSFUL       = 9031; //Your spell was slightly successful.
+	constexpr int SPELL_OPPOSITE_EFFECT          = 9032; //Your spell may have had the opposite effect of what you desired.
+	constexpr int HAS_BEEN_AWAKENED              = 9037; //%1 has been awakened by %2.
+	constexpr int YOU_HEAL                       = 9068; //You have healed %1 for %2 points of damage.
+	constexpr int YOUR_HIT_DOT                   = 9072; //%1 has taken %2 damage from your %3.
+	constexpr int HIT_NON_MELEE                  = 9073; //%1 hit %2 for %3 points of non-melee damage.
+	constexpr int GLOWS_BLUE                     = 9074; //Your %1 glows blue.
+	constexpr int GLOWS_RED                      = 9075; //Your %1 glows red.
+	constexpr int SHAKE_OFF_STUN                 = 9077; //You shake off the stun effect!
+	constexpr int STRIKETHROUGH_STRING           = 9078; //You strike through your opponent's defenses!
+	constexpr int SPELL_REFLECT                  = 9082; //%1's spell has been reflected by %2.
+	constexpr int NO_MORE_AURAS                  = 9160; //You do not have sufficient focus to maintain that ability.
+	constexpr int NEW_SPELLS_AVAIL               = 9149; //You have new spells available to you. Check the merchants near your guild master.
+	constexpr int FD_CAST_ON_NO_BREAK            = 9174; //The strength of your will allows you to resume feigning death.
+	constexpr int SNEAK_RESTRICT                 = 9240; //You can not use this ability because you have not been hidden for long enough.
+	constexpr int PET_NOW_FOCUSING               = 9254; //Focusing on one target, Master.
+	constexpr int PET_NOT_FOCUSING               = 9263; //No longer focusing on one target, Master.
+	constexpr int PET_NOT_CASTING                = 9264; //Not casting spells, Master.
+	constexpr int PET_CASTING                    = 9291; //Casting spells normally, Master.
+	constexpr int NO_CAST_IN_COMBAT              = 9190; //You can not cast this spell while in combat.
+	constexpr int NO_CAST_OUT_OF_COMBAT          = 9191; //You can not cast this spell while out of combat.
+	constexpr int NO_ABILITY_IN_COMBAT           = 9192; //You can not use this ability while in combat.
+	constexpr int NO_ABILITY_OUT_OF_COMBAT       = 9194; //You can not use this ability while out of combat.
+	constexpr int GAIN_GROUPXP_BONUS             = 9298; //You gain party experience (with a bonus)!
+	constexpr int GAIN_GROUPXP_PENALTY           = 9301; //You gain party experience (with a penalty)!
+	constexpr int GAIN_RAIDXP_BONUS              = 9302; //You gained raid experience (with a bonus)!
+	constexpr int GAIN_RAIDXP_PENALTY            = 9303; //You gained raid experience (with a penalty)!
+	constexpr int LESSER_SPELL_VERSION           = 11004; //%1 is a lesser version of %2 and cannot be scribed
+	constexpr int AE_RAMPAGE                     = 11015; //%1 goes on a WILD RAMPAGE!
+	constexpr int GROUP_IS_FULL                  = 12000; //You cannot join that group, it is full.
+	constexpr int FACE_ACCEPTED                  = 12028; //Facial features accepted.
+	constexpr int TRACKING_BEGIN                 = 12040; //You begin tracking %1.
+	constexpr int SPELL_LEVEL_TO_LOW             = 12048; //You will have to achieve level %1 before you can scribe the %2.
+	constexpr int YOU_RECEIVE_AS_SPLIT           = 12071; //You receive %1 as your split.
+	constexpr int ATTACKFAILED                   = 12158; //%1 try to %2 %3, but %4!
+	constexpr int HIT_STRING                     = 12183; //hit
+	constexpr int CRUSH_STRING                   = 12191; //crush
+	constexpr int PIERCE_STRING                  = 12193; //pierce
+	constexpr int KICK_STRING                    = 12195; //kick
+	constexpr int STRIKE_STRING                  = 12197; //strike
+	constexpr int BACKSTAB_STRING                = 12199; //backstab
+	constexpr int BASH_STRING                    = 12201; //bash
+	constexpr int GUILD_NOT_MEMBER               = 12242; //You are not a member of any guild.
+	constexpr int MEMBER_OF_X_GUILD              = 12256;
+	constexpr int OFFICER_OF_X_GUILD             = 12257;
+	constexpr int LEADER_OF_X_GUILD              = 12258;
+	constexpr int NOT_IN_A_GUILD                 = 12259;
+	constexpr int TARGET_PLAYER_FOR_GUILD_STATUS = 12260;
+	constexpr int TARGET_ALREADY_IN_GROUP        = 12265; //% 1 is already in another group.
+	constexpr int GROUP_INVITEE_NOT_FOUND        = 12268; //You must target a player or use /invite <name> to invite someone to your group.
+	constexpr int GROUP_INVITEE_SELF             = 12270; //12270 You cannot invite yourself.
+	constexpr int ALREADY_IN_PARTY               = 12272; //That person is already in your party.
+	constexpr int TALKING_TO_SELF                = 12323; //Talking to yourself again?
+	constexpr int SPLIT_NO_GROUP                 = 12328; //You are not in a group! Keep it all.
+	constexpr int NO_LONGER_HIDDEN               = 12337; //You are no longer hidden.
+	constexpr int STOP_SNEAKING                  = 12338; //You stop sneaking
+	constexpr int NOT_IN_CONTROL                 = 12368; //You do not have control of yourself right now.
+	constexpr int NO_SKILL_WHILE_MOUNTED         = 12393; //You can not use this skill while on a mount.
+	constexpr int STAND_TO_CAST                  = 12441; //You must be standing to cast a spell.
+	constexpr int ALREADY_CASTING                = 12442; //You are already casting a spell!
+	constexpr int SHIMMERS_BRIEFLY               = 12444; //Your %1 shimmers briefly.
+	constexpr int SENSE_CORPSE_NOT_NAME          = 12446; //You don't sense any corpses of that name.
+	constexpr int SENSE_CORPSE_NONE              = 12447; //You don't sense any corpses.
+	constexpr int SCREECH_BUFF_BLOCK             = 12448; //Your immunity buff protected you from the spell %1!
+	constexpr int NOT_HOLDING_ITEM               = 12452; //You are not holding an item!
+	constexpr int SENSE_UNDEAD                   = 12471; //You sense undead in this direction.
+	constexpr int SENSE_ANIMAL                   = 12472; //You sense an animal in this direction.
+	constexpr int SENSE_SUMMONED                 = 12473; //You sense a summoned being in this direction.
+	constexpr int SENSE_NOTHING                  = 12474; //You don't sense anything.
+	constexpr int SENSE_TRAP                     = 12475; //You sense a trap in this direction.
+	constexpr int LDON_SENSE_TRAP3               = 12476; //You don't sense any traps.
+	constexpr int INTERRUPT_SPELL_OTHER          = 12478; //%1's casting is interrupted!
+	constexpr int YOU_HIT_NONMELEE               = 12481; //You were hit by non-melee for %1 damage.
+	constexpr int TRACK_LOST_TARGET              = 12681; //You have lost your tracking target.
+	constexpr int TRACK_STRAIGHT_AHEAD           = 12676;
+	constexpr int TRACK_AHEAD_AND_TO             = 12677;
+	constexpr int TRACK_TO_THE                   = 12678;
+	constexpr int TRACK_BEHIND_AND_TO            = 12679;
+	constexpr int TRACK_BEHIND_YOU               = 12680;
+	constexpr int BEAM_SMILE                     = 12501; //%1 beams a smile at %2
+	constexpr int SONG_ENDS_ABRUPTLY             = 12686; //Your song ends abruptly.
+	constexpr int SONG_ENDS                      = 12687; //Your song ends.
+	constexpr int SONG_ENDS_OTHER                = 12688; //%1's song ends.
+	constexpr int SONG_ENDS_ABRUPTLY_OTHER       = 12689; //%1's song ends abruptly.
+	constexpr int DIVINE_AURA_NO_ATK             = 12695; //You can't attack while invulnerable!
+	constexpr int TRY_ATTACKING_SOMEONE          = 12696; //Try attacking someone other than yourself, it's more productive
+	constexpr int RANGED_TOO_CLOSE               = 12698; //Your target is too close to use a ranged weapon!
+	constexpr int BACKSTAB_WEAPON                = 12874; //You need a piercing weapon as your primary weapon in order to backstab
+	constexpr int DISARMED                       = 12889; //You have been disarmed!
+	constexpr int DISARM_SUCCESS                 = 12890; //You disarmed %1!
+	constexpr int DISARM_FAILED                  = 12891; //Your attempt to disarm failed.
+	constexpr int MORE_SKILLED_THAN_I            = 12931; //%1 tells you, 'You are more skilled than I! What could I possibly teach you?'
+	constexpr int SURNAME_EXISTS                 = 12939; //You already have a surname. Operation failed.
+	constexpr int SURNAME_LEVEL                  = 12940; //You can only submit a surname upon reaching the 20th level. Operation failed.
+	constexpr int SURNAME_TOO_LONG               = 12942; //Surname must be less than 20 characters in length.
+	constexpr int REPORT_ONCE                    = 12945; //You may only submit a report once per time that you zone. Thank you.
+	constexpr int NOW_INVISIBLE                  = 12950; //%1 is now Invisible.
+	constexpr int NOW_VISIBLE                    = 12951; //%1 is now Visible.
+	constexpr int YOU_TAKE_DOT                   = 12954; //You have taken %1 damage from %2 by %3
+	constexpr int GUILD_NOT_MEMBER2              = 12966; //You are not in a guild.
+	constexpr int HOT_HEAL_SELF                  = 12976; //You have been healed for %1 hit points by your %2.
+	constexpr int HOT_HEAL_OTHER                 = 12997; //You have healed %1 for %2 hit points with your %3.
+	constexpr int HOT_HEALED_OTHER               = 12998; //%1 healed you for %2 hit points by %3.
+	constexpr int DISC_LEVEL_USE_ERROR           = 13004; //You are not sufficient level to use this discipline.
+	constexpr int SPLIT_FAIL                     = 13112; //There is not enough to split, keep it.
+	constexpr int TOGGLE_ON                      = 13172; //Asking server to turn ON your incoming tells.
+	constexpr int TOGGLE_OFF                     = 13173; //Asking server to turn OFF all incoming tells for you.
+	constexpr int DUEL_INPROGRESS                = 13251; //You have already accepted a duel with someone else cowardly dog.
+	constexpr int OTHER_HIT_DOT                  = 13327; //%1 has taken %2 damage from %3 by %4.
+	constexpr int GAIN_XP_BONUS                  = 14541; //You gain experience (with a bonus)!
+	constexpr int GAIN_XP_PENALTY                = 14542; //You gain experience (with a penalty)!
+	constexpr int GENERIC_MISS                   = 15041; //%1 missed %2
+}
 
 #endif
 

--- a/zone/task_client_state.cpp
+++ b/zone/task_client_state.cpp
@@ -866,7 +866,7 @@ int ClientTaskState::IncrementDoneCount(
 		}
 
 		for (int i = 0; i < msg_count; ++i) {
-			client->MessageString(Chat::DefaultText, TASK_UPDATED, task_data->title.c_str());
+			client->MessageString(Chat::DefaultText, ClientString::TASK_UPDATED, task_data->title.c_str());
 		}
 	}
 
@@ -886,7 +886,7 @@ int ClientTaskState::IncrementDoneCount(
 		LogTasks("task_complete is [{}]", task_complete);
 		// shared tasks only send update messages on activity completion
 		if (task_data->type == TaskType::Shared) {
-			client->MessageString(Chat::DefaultText, TASK_UPDATED, task_data->title.c_str());
+			client->MessageString(Chat::DefaultText, ClientString::TASK_UPDATED, task_data->title.c_str());
 		}
 		// and by the 'Task Stage Completed' message
 		client->SendTaskActivityComplete(info->task_id, activity_id, task_index, task_data->type);
@@ -1024,7 +1024,7 @@ void ClientTaskState::RewardTask(Client *c, const TaskInformation *ti, ClientTas
 						int16_t slot = c->GetInv().FindFreeSlot(inst->IsClassBag(), true, inst->GetItem()->Size);
 						c->SummonItem(item_id, charges, 0, 0, 0, 0, 0, 0, false, slot);
 					}
-					c->MessageString(Chat::Yellow, YOU_HAVE_BEEN_GIVEN, inst->GetItem()->Name);
+					c->MessageString(Chat::Yellow, ClientString::YOU_HAVE_BEEN_GIVEN, inst->GetItem()->Name);
 				}
 			}
 		}
@@ -2041,7 +2041,7 @@ void ClientTaskState::AcceptNewTask(
 	}
 
 	if (max_tasks) {
-		client->MessageString(Chat::Yellow, MAX_ACTIVE_TASKS, ".", ".", client->GetName());
+		client->MessageString(Chat::Yellow, ClientString::MAX_ACTIVE_TASKS, ".", ".", client->GetName());
 		return;
 	}
 
@@ -2057,7 +2057,7 @@ void ClientTaskState::AcceptNewTask(
 	}
 
 	if (enforce_level_requirement && !TaskManager::Instance()->ValidateLevel(task_id, client->GetLevel())) {
-		client->MessageString(Chat::Yellow, TASK_NOT_RIGHT_LEVEL);
+		client->MessageString(Chat::Yellow, ClientString::TASK_NOT_RIGHT_LEVEL);
 		return;
 	}
 
@@ -2140,7 +2140,7 @@ void ClientTaskState::AcceptNewTask(
 
 	// This shouldn't happen unless there is a bug in the handling of ActiveTaskCount somewhere
 	if (active_slot == nullptr) {
-		client->MessageString(Chat::Yellow, MAX_ACTIVE_TASKS, ".", ".", client->GetName());
+		client->MessageString(Chat::Yellow, ClientString::MAX_ACTIVE_TASKS, ".", ".", client->GetName());
 		return;
 	}
 
@@ -2194,7 +2194,7 @@ void ClientTaskState::AcceptNewTask(
 
 	TaskManager::Instance()->SendSingleActiveTaskToClient(client, *active_slot, false, true);
 	client->StartTaskRequestCooldownTimer();
-	client->MessageString(Chat::DefaultText, YOU_ASSIGNED_TASK, task->title.c_str());
+	client->MessageString(Chat::DefaultText, ClientString::YOU_ASSIGNED_TASK, task->title.c_str());
 
 	TaskManager::Instance()->SaveClientState(client, this);
 

--- a/zone/task_manager.cpp
+++ b/zone/task_manager.cpp
@@ -594,7 +594,7 @@ void TaskManager::TaskSetSelector(Client* client, Mob* mob, int task_set_id, boo
 	}
 
 	if (m_task_sets[task_set_id].empty()) {
-		client->MessageString(Chat::Yellow, NO_TASK_OFFERS, ".", ".", client->GetName());
+		client->MessageString(Chat::Yellow, ClientString::NO_TASK_OFFERS, ".", ".", client->GetName());
 		return;
 	}
 
@@ -632,7 +632,7 @@ void TaskManager::TaskSetSelector(Client* client, Mob* mob, int task_set_id, boo
 		SendTaskSelector(client, mob, task_list);
 	}
 	else {
-		client->MessageString(Chat::Yellow, NO_TASK_OFFERS, ".", ".", client->GetName());
+		client->MessageString(Chat::Yellow, ClientString::NO_TASK_OFFERS, ".", ".", client->GetName());
 	}
 }
 
@@ -684,7 +684,7 @@ void TaskManager::TaskQuestSetSelector(Client* client, Mob* mob, const std::vect
 		SendTaskSelector(client, mob, task_list);
 	}
 	else {
-		client->MessageString(Chat::Yellow, NO_TASK_OFFERS, ".", ".", client->GetName());
+		client->MessageString(Chat::Yellow, ClientString::NO_TASK_OFFERS, ".", ".", client->GetName());
 	}
 }
 

--- a/zone/tasks.cpp
+++ b/zone/tasks.cpp
@@ -136,7 +136,7 @@ void Client::SendTaskRequestCooldownTimerMessage()
 	if (HasTaskRequestCooldownTimer())
 	{
 		uint32_t seconds = task_request_timer.GetRemainingTime() / 1000;
-		MessageString(Chat::Yellow, TASK_REQUEST_COOLDOWN_TIMER,
+		MessageString(Chat::Yellow, ClientString::TASK_REQUEST_COOLDOWN_TIMER,
 			".", ".", // args start at %3 for this eqstr
 			GetName(),
 			fmt::format_int(seconds / 60).c_str(), // minutes

--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -123,7 +123,7 @@ void Object::HandleAugmentation(Client* user, const AugmentItem_Struct* in_augme
 		RuleB(Inventory, EnforceAugmentRestriction) &&
 		user->IsAugmentRestricted(tobe_auged->GetItemType(), auged_with->GetAugmentRestriction())
 	) {
-		user->MessageString(Chat::Red, AUGMENT_RESTRICTED);
+		user->MessageString(Chat::Red, ClientString::AUGMENT_RESTRICTED);
 		return;
 	}
 
@@ -349,13 +349,13 @@ void Object::HandleCombine(Client* user, const NewCombine_Struct* in_combine, Ob
 				Strings::ToInt(container->GetItem()->IDFile + 2)
 			);
 
-			user->MessageString(Chat::LightBlue, TRANSFORM_COMPLETE, inst->GetItem()->Name);
+			user->MessageString(Chat::LightBlue, ClientString::TRANSFORM_COMPLETE, inst->GetItem()->Name);
 			if (RuleB(Inventory, DeleteTransformationMold)) {
 				user->DeleteItemInInventory(in_combine->container_slot, 0, true);
 			}
 		}
 		else if (inst) {
-			user->MessageString(Chat::LightBlue, TRANSFORM_FAILED, inst->GetItem()->Name);
+			user->MessageString(Chat::LightBlue, ClientString::TRANSFORM_FAILED, inst->GetItem()->Name);
 		}
 		auto outapp = new EQApplicationPacket(OP_TradeSkillCombine, 0);
 		user->QueuePacket(outapp);
@@ -379,10 +379,10 @@ void Object::HandleCombine(Client* user, const NewCombine_Struct* in_combine, Ob
 			user->DeleteItemInInventory(EQ::InventoryProfile::CalcSlotId(in_combine->container_slot, 0), 0, true);
 			container->Clear();
 			user->SummonItem(new_weapon->ID, inst->GetCharges(), inst->GetAugmentItemID(0), inst->GetAugmentItemID(1), inst->GetAugmentItemID(2), inst->GetAugmentItemID(3), inst->GetAugmentItemID(4), inst->GetAugmentItemID(5), inst->IsAttuned(), EQ::invslot::slotCursor, 0, 0);
-			user->MessageString(Chat::LightBlue, TRANSFORM_COMPLETE, inst->GetItem()->Name);
+			user->MessageString(Chat::LightBlue, ClientString::TRANSFORM_COMPLETE, inst->GetItem()->Name);
 		}
 		else if (inst) {
-			user->MessageString(Chat::LightBlue, DETRANSFORM_FAILED, inst->GetItem()->Name);
+			user->MessageString(Chat::LightBlue, ClientString::DETRANSFORM_FAILED, inst->GetItem()->Name);
 		}
 		auto outapp = new EQApplicationPacket(OP_TradeSkillCombine, 0);
 		user->QueuePacket(outapp);
@@ -407,7 +407,7 @@ void Object::HandleCombine(Client* user, const NewCombine_Struct* in_combine, Ob
 		LogTradeskillsDetail("Check 2");
 
 		if (!is_augmented) {
-			user->MessageString(Chat::Emote, TRADESKILL_NOCOMBINE);
+			user->MessageString(Chat::Emote, ClientString::TRADESKILL_NOCOMBINE);
 		} else {
 			user->Message(Chat::Emote, "You must remove augments from all component items before you can attempt this combine.");
 		}
@@ -536,7 +536,7 @@ void Object::HandleCombine(Client* user, const NewCombine_Struct* in_combine, Ob
 	// Update Made count
 	if (success) {
 		if (!spec.has_learnt && ((spec.must_learn&0x10) != 0x10)) {
-			user->MessageString(Chat::LightBlue, TRADESKILL_LEARN_RECIPE, spec.name.c_str());
+			user->MessageString(Chat::LightBlue, ClientString::TRADESKILL_LEARN_RECIPE, spec.name.c_str());
 		}
 		database.UpdateRecipeMadecount(spec.recipe_id, user->CharacterID(), spec.madecount+1);
 	}
@@ -726,13 +726,13 @@ void Object::HandleAutoCombine(Client* user, const RecipeAutoCombine_Struct* rac
 
 		safe_delete(outapp);
 
-		user->MessageString(Chat::Skills, TRADESKILL_MISSING_COMPONENTS);
+		user->MessageString(Chat::Skills, ClientString::TRADESKILL_MISSING_COMPONENTS);
 
 		for (auto it = MissingItems.begin(); it != MissingItems.end(); ++it) {
 			const EQ::ItemData* item = database.GetItem(*it);
 
 			if(item)
-				user->MessageString(Chat::Skills, TRADESKILL_MISSING_ITEM, item->Name);
+				user->MessageString(Chat::Skills, ClientString::TRADESKILL_MISSING_ITEM, item->Name);
 		}
 
 		return;
@@ -786,7 +786,7 @@ void Object::HandleAutoCombine(Client* user, const RecipeAutoCombine_Struct* rac
 
 	if (success) {
 		if (!spec.has_learnt && ((spec.must_learn & 0x10) != 0x10)) {
-			user->MessageString(Chat::LightBlue, TRADESKILL_LEARN_RECIPE, spec.name.c_str());
+			user->MessageString(Chat::LightBlue, ClientString::TRADESKILL_LEARN_RECIPE, spec.name.c_str());
 		}
 		database.UpdateRecipeMadecount(spec.recipe_id, user->CharacterID(), spec.madecount+1);
 	}
@@ -1104,7 +1104,7 @@ bool Client::TradeskillExecute(DBTradeskillRecipe_Struct *spec) {
 			chance = 100;
 		}
 
-		MessageString(Chat::Emote, TRADESKILL_TRIVIAL);
+		MessageString(Chat::Emote, ClientString::TRADESKILL_TRIVIAL);
 	} else if(chance < 5) {
 		// Minimum chance is always 5
 		chance = 5;
@@ -1141,7 +1141,7 @@ bool Client::TradeskillExecute(DBTradeskillRecipe_Struct *spec) {
 			CheckIncreaseTradeskill(bonusstat, stat_modifier, skillup_modifier, success_modifier, spec->tradeskill);
 		}
 
-		MessageString(Chat::LightBlue, TRADESKILL_SUCCEED, spec->name.c_str());
+		MessageString(Chat::LightBlue, ClientString::TRADESKILL_SUCCEED, spec->name.c_str());
 
 		LogTradeskills("Tradeskill success");
 
@@ -1189,7 +1189,7 @@ bool Client::TradeskillExecute(DBTradeskillRecipe_Struct *spec) {
 		if(over_trivial < 0)
 			CheckIncreaseTradeskill(bonusstat, stat_modifier, skillup_modifier, success_modifier, spec->tradeskill);
 
-		MessageString(Chat::Emote,TRADESKILL_FAILED);
+		MessageString(Chat::Emote, ClientString::TRADESKILL_FAILED);
 
 		LogTradeskills("Tradeskill failed");
 			if (GetGroup())
@@ -1714,7 +1714,7 @@ void Client::LearnRecipe(uint32 recipe_id)
 		return;
 	}
 
-	MessageString(Chat::LightBlue, TRADESKILL_LEARN_RECIPE, tradeskill_recipe.name.c_str());
+	MessageString(Chat::LightBlue, ClientString::TRADESKILL_LEARN_RECIPE, tradeskill_recipe.name.c_str());
 
 	database.QueryDatabase(
 		fmt::format(
@@ -1921,7 +1921,7 @@ bool Client::CheckTradeskillLoreConflict(int32 recipe_id)
 					linker.SetLinkType(EQ::saylink::SayLinkItemData);
 					linker.SetItemData(tre_inst);
 					auto item_link = linker.GenerateLink();
-					MessageString(Chat::Red, TRADESKILL_COMBINE_LORE, item_link.c_str());
+					MessageString(Chat::Red, ClientString::TRADESKILL_COMBINE_LORE, item_link.c_str());
 					return true;
 				}
 			}

--- a/zone/trading.cpp
+++ b/zone/trading.cpp
@@ -914,7 +914,7 @@ void Client::TraderStartTrader(const EQApplicationPacket *app)
 		safe_delete(outapp);
 	}
 
-	MessageString(Chat::Yellow, TRADER_MODE_ON);
+	MessageString(Chat::Yellow, ClientString::TRADER_MODE_ON);
 	SetTrader(true);
 	SendTraderMode(TraderOn);
 	SendBecomeTraderToWorld(this, TraderOn);
@@ -1571,7 +1571,7 @@ void Client::SendBazaarWelcome()
 void Client::SendBarterWelcome()
 {
 	const auto results = BuyerBuyLinesRepository::GetWelcomeData(database);
-	MessageString(Chat::White, BUYER_WELCOME, std::to_string(results.count_of_buyers).c_str());
+	MessageString(Chat::White, ClientString::BUYER_WELCOME, std::to_string(results.count_of_buyers).c_str());
 }
 
 void Client::DoBazaarSearch(BazaarSearchCriteria_Struct search_criteria)
@@ -1823,7 +1823,7 @@ void Client::ShowBuyLines(const EQApplicationPacket *app)
 	if (!buyer || buyer->GetCustomerID()) {
 		bir->approval = 0; // Tell the client that the Buyer is unavailable
 		QueuePacket(app);
-		MessageString(Chat::Yellow, TRADER_BUSY);
+		MessageString(Chat::Yellow, ClientString::TRADER_BUSY);
 		return;
 	}
 
@@ -1839,7 +1839,7 @@ void Client::ShowBuyLines(const EQApplicationPacket *app)
 			greeting = "Welcome!";
 		}
 
-		MessageString(Chat::NPCQuestSay, BUYER_GREETING, buyer->GetName(), greeting.c_str());
+		MessageString(Chat::NPCQuestSay, ClientString::BUYER_GREETING, buyer->GetName(), greeting.c_str());
 		const std::string name(GetName());
 		buyer->SendSellerBrowsing(name);
 

--- a/zone/tune.cpp
+++ b/zone/tune.cpp
@@ -971,7 +971,7 @@ void Mob::TuneDoAttack(Mob *other, DamageHitInfo &hit, ExtraAttackOptions *opts,
 		int strike_through = itembonuses.StrikeThrough + spellbonuses.StrikeThrough + aabonuses.StrikeThrough;
 		if (strike_through && zone->random.Roll(strike_through)) {
 			MessageString(Chat::StrikeThrough,
-				STRIKETHROUGH_STRING); // You strike through your opponents defenses!
+				ClientString::STRIKETHROUGH_STRING); // You strike through your opponents defenses!
 			hit.damage_done = 1;			// set to one, we will check this to continue
 		}
 		// I'm pretty sure you can riposte a riposte
@@ -1494,7 +1494,7 @@ void Mob::TuneCommonOutgoingHitSuccess(Mob* defender, DamageHitInfo &hit, ExtraA
 		else if (GetClass() == Class::Ranger && GetLevel() > 50) { // no double dmg on headshot
 			if ((defender->IsNPC() && !defender->IsMoving() && !defender->IsRooted()) || !RuleB(Combat, ArcheryBonusRequiresStationary)) {
 				hit.damage_done *= 2;
-				MessageString(Chat::MeleeCrit, BOW_DOUBLE_DAMAGE);
+				MessageString(Chat::MeleeCrit, ClientString::BOW_DOUBLE_DAMAGE);
 			}
 		}
 	}

--- a/zone/worldserver.cpp
+++ b/zone/worldserver.cpp
@@ -245,11 +245,11 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 			if (client && client->Connected()) {
 				if (scm->chan_num == ChatChannel_TellEcho) {
 					if (scm->queued == 1) // tell was queued
-						client->Tell_StringID(QUEUED_TELL, scm->to, scm->message);
+						client->Tell_StringID(ClientString::QUEUED_TELL, scm->to, scm->message);
 					else if (scm->queued == 2) // tell queue was full
-						client->Tell_StringID(QUEUE_TELL_FULL, scm->to, scm->message);
+						client->Tell_StringID(ClientString::QUEUE_TELL_FULL, scm->to, scm->message);
 					else if (scm->queued == 3) // person was offline
-						client->MessageString(Chat::EchoTell, TOLD_NOT_ONLINE, scm->to);
+						client->MessageString(Chat::EchoTell, ClientString::TOLD_NOT_ONLINE, scm->to);
 					else // normal tell echo "You told Soanso, 'something'"
 							// tell echo doesn't use language, so it looks normal to you even if nobody can understand your tells
 						client->ChannelMessageSend(scm->from, scm->to, scm->chan_num, Language::CommonTongue, Language::MaxValue, scm->message);
@@ -487,7 +487,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 			Client* client = entity_list.GetClientByID(wars->id);
 			if (client) {
 				if (pack->size == 64)//no results
-					client->MessageString(Chat::White, WHOALL_NO_RESULTS);
+					client->MessageString(Chat::White, ClientString::WHOALL_NO_RESULTS);
 				else {
 					auto outapp = new EQApplicationPacket(OP_WhoAllResponse, pack->size);
 					memcpy(outapp->pBuffer, pack->pBuffer, pack->size);
@@ -973,7 +973,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 		Client* c = entity_list.GetClientByName(Rezzer);
 
 		if (c)
-			c->MessageString(Chat::SpellWornOff, REZZ_ALREADY_PENDING);
+			c->MessageString(Chat::SpellWornOff, ClientString::REZZ_ALREADY_PENDING);
 
 		break;
 	}
@@ -3674,7 +3674,7 @@ void WorldServer::HandleMessage(uint16 opcode, const EQ::Net::Packet &p)
 				if (strcasecmp(c.second->GetCleanName(), in->send_to) == 0) {
 					c.second->MessageString(
 						Chat::Yellow,
-						PARCEL_DELIVERY_ARRIVED
+						ClientString::PARCEL_DELIVERY_ARRIVED
 					);
 					c.second->SendParcelStatus();
 					if (c.second->GetEngagedWithParcelMerchant()) {

--- a/zone/zoning.cpp
+++ b/zone/zoning.cpp
@@ -737,7 +737,7 @@ void Client::ProcessMovePC(uint32 zoneID, uint32 instance_id, float x, float y, 
 			ZonePC(zoneID, instance_id, x, y, z, heading, ignorerestrictions, zm);
 			break;
 		case SummonPC:
-			MessageString(Chat::Yellow, PLAYER_SUMMONED);
+			MessageString(Chat::Yellow, ClientString::PLAYER_SUMMONED);
 			ZonePC(zoneID, instance_id, x, y, z, heading, ignorerestrictions, zm);
 			break;
 		case Rewind:
@@ -1098,7 +1098,7 @@ void Client::Gate(uint8 bind_number) {
 }
 
 void NPC::Gate(uint8 bind_number) {
-	entity_list.MessageCloseString(this, true, RuleI(Range, SpellMessages), Chat::Spells, GATES, GetCleanName());
+	entity_list.MessageCloseString(this, true, RuleI(Range, SpellMessages), Chat::Spells, ClientString::GATES, GetCleanName());
 
 	Mob::Gate(bind_number);
 }


### PR DESCRIPTION
# Description

Convert all constant defines client strings id x to namespace ClientString like ClientString::x

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
