### PR TITLE
[Bug Fix] fixed ground spawns that are picked up would automagically reappear just by zoning or relogging.

### DIFF
--- a/common/ruletypes.h
+++ b/common/ruletypes.h
@@ -1178,6 +1178,12 @@ RULE_INT(EvolvingItems, DelayUponEquipping, 30000, "Delay in ms before an evolvi
 RULE_BOOL(EvolvingItems, DestroyAugmentsOnEvolve, false, "If this is enabled, any augments in an item will be destroyed when the item evolves. Otherwise, send augments to the player via the parcel system (requires that the Parcel System be enabled).")
 RULE_CATEGORY_END()
 
+RULE_CATEGORY(Groundspawns)
+RULE_INT(Groundspawns, DecayTime, 300000, "Decay time of player dropped items.")
+RULE_INT(Groundspawns, DisarmDecayTime, 300000, "Decay time of weapons dropped due to disarm")
+RULE_BOOL(Groundspawns, RandomSpawn, true, "Determines if groundspawns with random spawn locs will periodically despawn and respawn elsewhere.")
+RULE_CATEGORY_END()
+
 #undef RULE_CATEGORY
 #undef RULE_INT
 #undef RULE_REAL

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -1483,9 +1483,11 @@ void EntityList::SendZoneObjects(Client *client)
 {
 	auto it = object_list.begin();
 	while (it != object_list.end()) {
-		auto app = new EQApplicationPacket;
-		it->second->CreateSpawnPacket(app);
-		client->FastQueuePacket(&app);
+		if (!it->second->IsGroundSpawn() || !it->second->RespawnTimerEnabled()) {
+			auto app = new EQApplicationPacket;
+			it->second->CreateSpawnPacket(app);
+			client->FastQueuePacket(&app);
+		}
 		++it;
 	}
 }

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -1838,7 +1838,7 @@ void NPC::Disarm(Client* client, int chance) {
 					CalcBonuses();
 					if (inst) {
 						// create a ground item
-						Object* object = new Object(inst, GetX(), GetY(), GetZ(), 0.0f, 300000);
+						Object* object = new Object(inst, GetX(), GetY(), GetZ(), 0.0f, RuleI(Groundspawns, DisarmDecayTime));
 						entity_list.AddObject(object, true);
 						object->StartDecay();
 						safe_delete(inst);

--- a/zone/object.h
+++ b/zone/object.h
@@ -221,6 +221,7 @@ public:
 	std::vector<std::string> GetEntityVariables();
 	void SetEntityVariable(std::string variable_name, std::string variable_value);
 	bool EntityVariableExists(std::string variable_name);
+	bool RespawnTimerEnabled() { return respawn_timer.Enabled(); };
 
 protected:
 	void	ResetState();	// Set state back to original
@@ -245,6 +246,7 @@ protected:
 	Client *user;
 	Client *last_user;
 
+	Timer random_timer;
 	Timer respawn_timer;
 	Timer decay_timer;
 	void FixZ();


### PR DESCRIPTION
# Description
Imports from TAKP source.

* After picking up a ground spawn that is on a respawn timer,  ground spawn respawn timer would not persist if you rezone or relog.
* Added 3 ground spawn rules for decay timer,  disarm decay timer, and Random spawn.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)


# Testing
before picking up the ground spawn in Shadeweaver.
![groundspawn](https://github.com/user-attachments/assets/4ee280b2-f955-4fe0-b4da-66bc0b2fbfbb)

after relogging after picking up the ground spawn.
![groundspawnrezone](https://github.com/user-attachments/assets/5a55255a-267c-4c81-bfb1-cdbe08da249d)

Clients tested: 
RoF2

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur

