### PR TITLE
[Bug Fix] Add content scheme to PR4996

### DIFF
--- a/common/database/database_update_manifest.cpp
+++ b/common/database/database_update_manifest.cpp
@@ -7188,7 +7188,8 @@ CHANGE COLUMN `field221` `caster_requirement_id` int(11) NULL DEFAULT 0 AFTER `n
 CHANGE COLUMN `field222` `spell_class` int(11) NULL DEFAULT 0 AFTER `caster_requirement_id`,
 CHANGE COLUMN `field223` `spell_subclass` int(11) NULL DEFAULT 0 AFTER `spell_class`,
 CHANGE COLUMN `field232` `no_remove` int(11) NOT NULL DEFAULT 0 AFTER `min_range`;
-)"
+)",
+		.content_schema_update = true
 	}
 
 // -- template; copy/paste this when you need to create a new entry


### PR DESCRIPTION
# Description

When updating an installation with a content db set, the db changes for #4996 were not being applied.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

# Testing
Ran db updates against a spilt content db

Clients tested: 
N/A

# Checklist

- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur
