### PR TITLE
[Quest API] Add EVENT_CHARM_START and EVENT_CHARM_END to Perl/Lua

### DIFF
--- a/zone/embparser.cpp
+++ b/zone/embparser.cpp
@@ -208,6 +208,8 @@ const char* QuestEventSubroutines[_LargestEventID] = {
 	"EVENT_SPELL_BLOCKED",
 	"EVENT_READ_ITEM",
 	"EVENT_PET_COMMAND",
+	"EVENT_CHARM_START",
+	"EVENT_CHARM_END",
 
 	// Add new events before these or Lua crashes
 	"EVENT_SPELL_EFFECT_BOT",

--- a/zone/event_codes.h
+++ b/zone/event_codes.h
@@ -146,6 +146,8 @@ typedef enum {
 	EVENT_SPELL_BLOCKED,
 	EVENT_READ_ITEM,
 	EVENT_PET_COMMAND,
+	EVENT_CHARM_START,
+	EVENT_CHARM_END,
 
 	// Add new events before these or Lua crashes
 	EVENT_SPELL_EFFECT_BOT,

--- a/zone/lua_general.cpp
+++ b/zone/lua_general.cpp
@@ -6992,7 +6992,9 @@ luabind::scope lua_register_events() {
 			luabind::value("entity_variable_update", static_cast<int>(EVENT_ENTITY_VARIABLE_UPDATE)),
 			luabind::value("aa_loss", static_cast<int>(EVENT_AA_LOSS)),
 			luabind::value("read", static_cast<int>(EVENT_READ_ITEM)),
-			luabind::value("pet_command", static_cast<int>(EVENT_PET_COMMAND))
+			luabind::value("pet_command", static_cast<int>(EVENT_PET_COMMAND)),
+			luabind::value("charm_start", static_cast<int>(EVENT_CHARM_START)),
+			luabind::value("charm_end", static_cast<int>(EVENT_CHARM_END))
 		)];
 }
 

--- a/zone/lua_parser.cpp
+++ b/zone/lua_parser.cpp
@@ -189,7 +189,9 @@ const char *LuaEvents[_LargestEventID] = {
 	"event_aa_loss",
 	"event_spell_blocked",
 	"event_read_item",
-	"event_pet_command"
+	"event_pet_command",
+	"event_charm_start",
+	"event_charm_end"
 };
 
 extern Zone *zone;
@@ -266,6 +268,8 @@ LuaParser::LuaParser() {
 	NPCArgumentDispatch[EVENT_ENTITY_VARIABLE_UPDATE] = handle_npc_entity_variable;
 	NPCArgumentDispatch[EVENT_SPELL_BLOCKED]          = handle_npc_spell_blocked;
 	NPCArgumentDispatch[EVENT_PET_COMMAND]            = handle_npc_pet_command;
+	NPCArgumentDispatch[EVENT_CHARM_START]            = handle_npc_single_mob;
+	NPCArgumentDispatch[EVENT_CHARM_END]              = handle_npc_single_mob;
 
 	PlayerArgumentDispatch[EVENT_SAY]                        = handle_player_say;
 	PlayerArgumentDispatch[EVENT_ENVIRONMENTAL_DAMAGE]       = handle_player_environmental_damage;

--- a/zone/npc.cpp
+++ b/zone/npc.cpp
@@ -3387,62 +3387,55 @@ void NPC::DepopSwarmPets()
 	}
 }
 
-void NPC::ModifyStatsOnCharm(bool is_charm_removed)
+void NPC::ModifyStatsOnCharm(bool remove_charm, Mob* charmer)
 {
-	if (is_charm_removed) {
-		if (charm_ac) {
-			AC = default_ac;
-		}
-		if (charm_attack_delay) {
-			attack_delay = default_attack_delay;
-		}
-		if (charm_accuracy_rating) {
-			accuracy_rating = default_accuracy_rating;
-		}
-		if (charm_avoidance_rating) {
-			avoidance_rating = default_avoidance_rating;
-		}
-		if (charm_atk) {
-			ATK = default_atk;
-		}
-		if (charm_min_dmg || charm_max_dmg) {
-			base_damage = round((default_max_dmg - default_min_dmg) / 1.9);
-			min_damage  = default_min_dmg - round(base_damage / 10.0);
-		}
-		if (RuleB(Spells, CharmDisablesSpecialAbilities)) {
-			ProcessSpecialAbilities(default_special_abilities);
-		}
-
-		SetAttackTimer();
-		CalcAC();
-
-		return;
+	if (!remove_charm && parse->HasQuestSub(GetNPCTypeID(), EVENT_CHARM_START)) {
+		parse->EventNPC(EVENT_CHARM_START, this, charmer, "", 0);
+	} else if (remove_charm && parse->HasQuestSub(GetNPCTypeID(), EVENT_CHARM_END)) {
+		parse->EventNPC(EVENT_CHARM_END, this, charmer, "", 0);
 	}
 
-	if (charm_ac) {
-		AC = charm_ac;
+	const int new_ac               = remove_charm ? default_ac : charm_ac;
+	const int new_attack_delay     = remove_charm ? default_attack_delay : charm_attack_delay;
+	const int new_accuracy_rating  = remove_charm ? default_accuracy_rating : charm_accuracy_rating;
+	const int new_avoidance_rating = remove_charm ? default_avoidance_rating : charm_avoidance_rating;
+	const int new_atk              = remove_charm ? default_atk : charm_atk;
+	const int new_min_dmg          = remove_charm ? default_min_dmg : charm_min_dmg;
+	const int new_max_dmg          = remove_charm ? default_max_dmg : charm_max_dmg;
+
+	if (new_ac) {
+		AC = new_ac;
 	}
-	if (charm_attack_delay) {
-		attack_delay = charm_attack_delay;
+
+	if (new_attack_delay) {
+		attack_delay = new_attack_delay;
 	}
-	if (charm_accuracy_rating) {
-		accuracy_rating = charm_accuracy_rating;
+
+	if (new_accuracy_rating) {
+		accuracy_rating = new_accuracy_rating;
 	}
-	if (charm_avoidance_rating) {
-		avoidance_rating = charm_avoidance_rating;
+
+	if (new_avoidance_rating) {
+		avoidance_rating = new_avoidance_rating;
 	}
-	if (charm_atk) {
-		ATK = charm_atk;
+
+	if (new_atk) {
+		ATK = new_atk;
 	}
-	if (charm_min_dmg || charm_max_dmg) {
-		base_damage = round((charm_max_dmg - charm_min_dmg) / 1.9);
-		min_damage  = charm_min_dmg - round(base_damage / 10.0);
+
+	if (new_min_dmg || new_max_dmg) {
+		base_damage = std::round((new_max_dmg - new_min_dmg) / 1.9);
+		min_damage  = new_min_dmg - std::round(base_damage / 10.0);
 	}
+
 	if (RuleB(Spells, CharmDisablesSpecialAbilities)) {
-		ClearSpecialAbilities();
+		if (remove_charm) {
+			ProcessSpecialAbilities(default_special_abilities);
+		} else {
+			ClearSpecialAbilities();
+		}
 	}
 
-	// the rest of the stats aren't cached, so lets just do these two instead of full CalcBonuses()
 	SetAttackTimer();
 	CalcAC();
 }

--- a/zone/npc.h
+++ b/zone/npc.h
@@ -346,7 +346,7 @@ public:
 	int64 GetNPCHPRegen() const { return hp_regen + itembonuses.HPRegen + spellbonuses.HPRegen; }
 	inline const char* GetAmmoIDfile() const { return ammo_idfile; }
 
-	void ModifyStatsOnCharm(bool is_charm_removed);
+	void ModifyStatsOnCharm(bool remove_charm, Mob* charmer);
 
 	//waypoint crap
 	int					GetMaxWp() const { return max_wp; }

--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -835,12 +835,11 @@ bool Mob::SpellEffect(Mob* caster, uint16 spell_id, float partial, int level_ove
 					SendAppearancePacket(AppearanceType::Pet, caster->GetID(), true, true);
 				}
 
-				if (IsClient())
-				{
+				if (IsClient()) {
 					CastToClient()->AI_Start();
-				} else if(IsNPC()) {
-					CastToNPC()->SetPetSpellID(0);	//not a pet spell.
-					CastToNPC()->ModifyStatsOnCharm(false);
+				} else if (IsNPC()) {
+					CastToNPC()->SetPetSpellID(0);    //not a pet spell.
+					CastToNPC()->ModifyStatsOnCharm(false, caster);
 				}
 
 				bool bBreak = false;
@@ -4418,10 +4417,9 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 
 			case SpellEffect::Charm:
 			{
-				if(IsNPC())
-				{
+				if (IsNPC()) {
 					CastToNPC()->RestoreGuardSpotCharm();
-					CastToNPC()->ModifyStatsOnCharm(true);
+					CastToNPC()->ModifyStatsOnCharm(true, GetOwner());
 				}
 
 				SendAppearancePacket(AppearanceType::Pet, 0, true, true);


### PR DESCRIPTION
# Description
- Adds charm events for NPCs to Perl and Lua.

## Perl
- Add `EVENT_CHARM_START` and `EVENT_CHARM_END`, no exports.

### Example
```pl
sub EVENT_CHARM_START {
	my $owner_name = $client->GetCleanName();
	quest::shout("[Perl] I just got charmed by $owner_name.");
}

sub EVENT_CHARM_END {
	my $owner_name = $client->GetCleanName();
	quest::shout("[Perl] My charm from $owner_name wore off.");
}
```

### Image
<img width="763" height="117" alt="image" src="https://github.com/user-attachments/assets/924bd171-0eef-4960-b1cc-126487ed8978" />

## Lua
- Add `event_charm_start` and `event_charm_end`, exports `e.other`.

### Example
```lua
function event_charm_start(e)
	local owner_name = e.other:GetCleanName()
	e.self:Shout(string.format("[Lua] I just got charmed by %s.", owner_name))
end

function event_charm_end(e)
	local owner_name = e.other:GetCleanName()
	e.self:Shout(string.format("[Lua] My charm from %s wore off.", owner_name));
end
```

### Image
<img width="763" height="115" alt="image" src="https://github.com/user-attachments/assets/6858110b-56df-4b18-9e36-06c47e79c5d3" />

## Type of change
- [X] New feature

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur