### PR TITLE
[Hotfix] Fixed Mail Key Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [23.10.1] 9/16/2025
+
+### Hotfix
+* Fixed Mail Key Bug ([#5015](https://github.com/EQEmu/Server/pull/5015)) @Kinglykrab 2025-09-16
+
 ## [23.10.0] 9/15/2025
 
 ### Build

--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -142,10 +142,7 @@ void SharedDatabase::SetMailKey(uint32 character_id, uint32 ip_address, uint32 m
 
 	if (!CharacterDataRepository::UpdateOne(*this, e)) {
 		LogError("Failed to set mailkey to [{}] for character_id [{}]", full_mail_key, character_id);
-		return;
 	}
-
-	LogError("Set mailkey to [{}] for character_id [{}]", full_mail_key, character_id);
 }
 
 SharedDatabase::MailKeys SharedDatabase::GetMailKey(uint32 character_id)

--- a/common/shareddb.cpp
+++ b/common/shareddb.cpp
@@ -122,7 +122,7 @@ bool SharedDatabase::SetGMFlymode(uint32 account_id, uint8 flymode)
 	return a.id > 0;
 }
 
-void SharedDatabase::SetMailKey(uint32 character_id, int ip_address, int mail_key)
+void SharedDatabase::SetMailKey(uint32 character_id, uint32 ip_address, uint32 mail_key)
 {
 	std::string full_mail_key;
 
@@ -133,12 +133,19 @@ void SharedDatabase::SetMailKey(uint32 character_id, int ip_address, int mail_ke
 	}
 
 	auto e = CharacterDataRepository::FindOne(*this, character_id);
+	if (!e.id) {
+		LogError("Failed to find character_id [{}] when setting mailkey", character_id);
+		return;
+	}
 
 	e.mailkey = full_mail_key;
 
 	if (!CharacterDataRepository::UpdateOne(*this, e)) {
 		LogError("Failed to set mailkey to [{}] for character_id [{}]", full_mail_key, character_id);
+		return;
 	}
+
+	LogError("Set mailkey to [{}] for character_id [{}]", full_mail_key, character_id);
 }
 
 SharedDatabase::MailKeys SharedDatabase::GetMailKey(uint32 character_id)
@@ -422,7 +429,7 @@ bool SharedDatabase::DeleteSharedBankSlot(uint32 char_id, int16 slot_id)
 int32 SharedDatabase::GetSharedPlatinum(uint32 account_id)
 {
 	const auto& e = AccountRepository::FindOne(*this, account_id);
-	
+
 	return e.sharedplat;
 }
 

--- a/common/shareddb.h
+++ b/common/shareddb.h
@@ -84,7 +84,7 @@ public:
 	bool GetCommandSubSettings(std::vector<CommandSubsettingsRepository::CommandSubsettings> &command_subsettings);
 	bool SetGMInvul(uint32 account_id, bool gminvul);
 	bool SetGMFlymode(uint32 account_id, uint8 flymode);
-	void SetMailKey(uint32 character_id, int ip_address, int mail_key);
+	void SetMailKey(uint32 character_id, uint32 ip_address, uint32 mail_key);
 	struct MailKeys {
 		std::string mail_key;
 		std::string mail_key_full;

--- a/common/version.h
+++ b/common/version.h
@@ -25,7 +25,7 @@
 
 // Build variables
 // these get injected during the build pipeline
-#define CURRENT_VERSION "23.10.0-dev" // always append -dev to the current version for custom-builds
+#define CURRENT_VERSION "23.10.1-dev" // always append -dev to the current version for custom-builds
 #define LOGIN_VERSION "0.8.0"
 #define COMPILE_DATE    __DATE__
 #define COMPILE_TIME    __TIME__

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eqemu-server",
-  "version": "23.10.0",
+  "version": "23.10.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/EQEmu/Server.git"

--- a/world/client.cpp
+++ b/world/client.cpp
@@ -985,7 +985,7 @@ bool Client::HandleEnterWorldPacket(const EQApplicationPacket *app) {
 	safe_delete(outapp);
 
 	// set mailkey - used for duration of character session
-	int mail_key = EQ::Random::Instance()->Int(1, INT_MAX);
+	uint32 mail_key = EQ::Random::Instance()->Int(1, INT_MAX);
 
 	database.SetMailKey(charid, GetIP(), mail_key);
 	if (UCSServerAvailable_) {


### PR DESCRIPTION
# Description
- Fixes an issue where mailkey was using signed integers, causing `{:08X}` interpreting to break.

## Type of change
- [X] Bug fix

# Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur