### PR TITLE
Update client.cpp HandleEnterWorldPacket for UCS Local Address

### DIFF
--- a/world/client.cpp
+++ b/world/client.cpp
@@ -1019,8 +1019,16 @@ bool Client::HandleEnterWorldPacket(const EQApplicationPacket *app) {
 				break;
 		}
 
+		std::string ucs_addr = config->GetUCSHost();
+		if (cle && cle->IsLocalClient()) {
+			const char* local_addr = config->LocalAddress.c_str();
+			if (local_addr[0]) {
+				ucs_addr = local_addr;
+			}
+		}
+
 		buffer = fmt::format("{},{},{}.{},{}{:08X}",
-			config->GetUCSHost(),
+			ucs_addr,
 			config->GetUCSPort(),
 			config->ShortName,
 			GetCharName(),
@@ -1046,7 +1054,7 @@ bool Client::HandleEnterWorldPacket(const EQApplicationPacket *app) {
 		}
 
 		buffer = fmt::format("{},{},{}.{},{}{:08X}",
-			config->GetUCSHost(),
+			ucs_addr,
 			config->GetUCSPort(),
 			config->ShortName,
 			GetCharName(),


### PR DESCRIPTION
# Description

Please don't dismiss this as eqemu docs and general confusion around eqemu_config.json values have caused a lot of misinformation.

The value in `eqemu_config.json` `ucs.host` should never be 0.0.0.0 yet the eqemu docs have conflicting information. `host*    Hostname - just use (0.0.0.0)` The docs indicates to use hostname yet also says that 0.0.0.0 is a valid value here, but this is not a bind socket value like "telnet" or "tcp" inside eqemu_config.json. This value represents what `world/client.cpp` will send to the client upon `HandleEnterWorldPacket`. As in this value is directly used by the client to make an independent connection to UCS, this does not proxy through world.

This happens in 2 spots (1 for chat server 1 for mail server) but same exact function.
```
buffer = fmt::format("{},{},{}.{},{}{:08X}",
			config->GetUCSHost(),
			config->GetUCSPort(),
			config->ShortName,
			GetCharName(),
			static_cast<char>(connection_type),
			mail_key
		);

		outapp = new EQApplicationPacket(OP_SetChatServer, (buffer.length() + 1));
```

Once people see the purpose of `ucs.host` it becomes obvious that 0.0.0.0 will never work, so I will also adjust docs.

Anyways, the issue I'm trying to resolve is related to the same reason `world.localaddress` was introduced and how it is used to variably send the client the correct world address (when someone is LAN or external). Within `world/client.cpp` `EnterWorld` you can see how world utilizes `world.address` vs `world.localaddress`.

```
if(cle && cle->IsLocalClient()) {
		const char *local_addr = zs->GetCLocalAddress();
                ...
                ...
		} else {
			zs_addr = WorldConfig::get()->WorldAddress;
		}
	}
```

This fix applies the same logic used by world to send the correct zone server address, but for UCS.


The original issue...
 - Create a server on a LAN box (akk-stack or windows install, doesnt matter)
 - Set `world.address` to external ip
 - Set `world.localaddress` to internal lan ip
 - Set `ucs.host` to external ip

The outcome: LAN and external clients can connect (because of address and localaddress), however only external clients will get UCS access. I'd imagine 99% of real/public servers are set this way.

- Same setup, but this time set `ucs.host` to internal lan ip

The outcome: Internal clients get UCS, external do not

- Same setup, but this time set `ucs.host` to 0.0.0.0

The outcome: No clients get UCS access



Why this is brushed off a lot... Setting `ucs.host` to external IP can work for LAN clients if you loopback or NAT on router, also via /etc/hosts tricks. However, I believe those options can be harder for beginners.

I've also elected to piggyback off `world.localaddress` instead of adding a `ucs.localaddress` because eqemu_config.json doesnt need any more options lol, but mainly because anyone running a UCS on a different server than world would most likely not have a LAN client.



Fixes # (issue) - A few others have posted this same issue in discord -> server-issues -> UCS

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Testing

I have confirmed a default akk-stack running on a LAN box can have a different local/LAN client and an external client connected to it with UCS available on both ends, with each client seeing chat messages. I test external by using cell phone hotspot. 

Here are UCS logs showing the local and external clients communicating over a UCS channel.

```
[10-07-2025 22:02:30] [UCS] [Info] New Client UDP connection from [295990123] [61834]
[10-07-2025 22:02:30] [UCS] [Info] Connection type is Combined (RoF2)
[10-07-2025 22:02:30] [UCS] [Info] Received login for user [SOE.EQ.DASRPG.Comptwo] with key [4DFF45DB]
[10-07-2025 22:02:30] [UCS] [Info] DB key is [[11A4736B4DFF45DB]], Client key is [[11A4736B4DFF45DB]]
[10-07-2025 22:02:30] [UCS] [Info] FindAccount for character [Comptwo]
[10-07-2025 22:02:30] [UCS] [Info] Account ID for [Comptwo] is [2]
[10-07-2025 22:02:33] [UCS] [Info] Client: [Comptwo] joining channels [NewPlayers, General, Ranger, Antonica]
[10-07-2025 22:05:07] [UCS] [Info] New Client UDP connection from [184592576] [50494]
[10-07-2025 22:05:08] [UCS] [Info] Connection type is Combined (RoF2)
[10-07-2025 22:05:08] [UCS] [Info] Received login for user [SOE.EQ.DASRPG.Geom] with key [1A59F944]
[10-07-2025 22:05:08] [UCS] [Info] DB key is [[0B00A8C01A59F944]], Client key is [[0B00A8C01A59F944]]
[10-07-2025 22:05:08] [UCS] [Info] FindAccount for character [Geom]
[10-07-2025 22:05:08] [UCS] [Info] Account ID for [Geom] is [1]
[10-07-2025 22:05:25] [UCS] [Info] Player: [Geom], Sent Message: [[join test]
[10-07-2025 22:05:25] [UCS] [Info] Client: [Geom] joining channels [test]
[10-07-2025 22:05:29] [UCS] [Info] Player: [Comptwo], Sent Message: [[join test]
[10-07-2025 22:05:29] [UCS] [Info] Client: [Comptwo] joining channels [test]
[10-07-2025 22:05:32] [UCS] [Info] Player: [Comptwo], Sent Message: [;5 yo]
[10-07-2025 22:05:32] [UCS] [Info] [Comptwo] tells [Test], [[yo]]
[10-07-2025 22:36:47] [UCS] [Info] Client connection from [107.115.XXX.XX]:[35569] closed
[10-07-2025 22:51:06] [UCS] [Info] Client connection from [192.168.0.11]:[16069] closed
```

Here's my relevant eqemu_config.json

```
"ucs": {
   "host": "67.8.XXX.XX",
   "port": "7778"
  },
  "world": {
   "api": {
    "enabled": false
   },
   "address": "67.8.XXX.X",
   "localaddress": "192.168.0.25",
```

(For my server and hotspot external client I slightly obfuscated external IP value in above logs.)


Clients tested: Only RoF2, but uses same function as existing similar processes 

# Checklist

- [ ] I have tested my changes
- [ ] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [ ] I have made corresponding changes to the documentation (if applicable, if not delete this line)
- [ ] I own the changes of my code and take responsibility for the potential issues that occur
- [ ] If my changes make database schema changes, I have tested the changes on a local database (attach image). Updated version.h CURRENT_BINARY_DATABASE_VERSION to the new version. (Delete this if not applicable)
