### PR TITLE
updated crash report url to new hosted spire location

### DIFF
--- a/common/crash.cpp
+++ b/common/crash.cpp
@@ -23,7 +23,7 @@ void SendCrashReport(const std::string &crash_report)
 {
 	// can configure multiple endpoints if need be
 	std::vector<std::string> endpoints = {
-		"https://spire.akkadius.com/api/v1/analytics/server-crash-report",
+		"https://spire.eqemu.dev/api/v1/analytics/server-crash-report",
 //		"http://localhost:3010/api/v1/analytics/server-crash-report", // development
 	};
 


### PR DESCRIPTION
# Description

This updates the URL used for sending crash reports to the new public Spire location.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Testing

<img width="1075" height="699" alt="image" src="https://github.com/user-attachments/assets/eed22bc7-3e7e-4253-b73b-6aa3495671bf" />
