### PR TITLE
fix: only dismiss pet summoned by the fading familiar buff

### DIFF
--- a/zone/spell_effects.cpp
+++ b/zone/spell_effects.cpp
@@ -4394,9 +4394,9 @@ void Mob::BuffFadeBySlot(int slot, bool iRecalcBonuses)
 			case SpellEffect::Familiar:
 			{
 				Mob *mypet = GetPet();
-				if (mypet){
-					if(mypet->IsNPC())
-						mypet->CastToNPC()->Depop();
+				if (mypet && mypet->IsNPC() &&
+				    mypet->CastToNPC()->GetPetSpellID() == buffs[slot].spellid) {
+					mypet->CastToNPC()->Depop();
 					SetPetID(0);
 				}
 				break;


### PR DESCRIPTION
Fixes #5026

## What

When a `SpellEffect::Familiar` buff fades in `Mob::BuffFadeBySlot`, the code called `GetPet()` and unconditionally depopulated whatever pet the player currently had:

```cpp
// Before
Mob *mypet = GetPet();
if (mypet){
    if(mypet->IsNPC())
        mypet->CastToNPC()->Depop();
    SetPetID(0);
}
```

`GetPet()` returns the player's **current** pet — not the pet summoned by the specific buff that is fading. So if a player had a familiar, dismissed it, and summoned a combat pet, the combat pet would be killed when the familiar buff eventually expired.

```cpp
// After
Mob *mypet = GetPet();
if (mypet && mypet->IsNPC() &&
    mypet->CastToNPC()->GetPetSpellID() == buffs[slot].spellid) {
    mypet->CastToNPC()->Depop();
    SetPetID(0);
}
```

The fix checks that the current pet's `PetSpellID` matches the fading buff's spell ID before dismissing it. If the player has a different pet, it is left alone.

## Verified

- `NPC::GetPetSpellID()` is set during `MakePet()` / `MakePoweredPet()` via `SetPetSpellID(spell_id)` — the spell ID is reliably tracked
- `buffs[slot].spellid` is the standard way to reference the fading buff's spell ID throughout `BuffFadeBySlot`
- `Bot::BuffFadeBySlot` does not exist as a separate override — Bots use `Mob::BuffFadeBySlot` and are covered by this fix

## Note

New contributor here — happy to adjust anything that doesn't fit the project's conventions.